### PR TITLE
fix(ios-simulator): 让 shell 守卫匹配它声明的威胁模型，停止误拒普通命令

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
@@ -174,6 +174,10 @@ eval "$CMD"`,
     `CMD='xcrun simctl shutdown DEVICE'; false &&\nCMD='echo safe'; eval "$CMD"`,
     `CMD='xcrun simctl shutdown DEVICE'; true ||\nCMD='echo safe'; eval "$CMD"`,
     `CMD='xcrun simctl shutdown DEVICE'; printf ignored |\nCMD='echo safe'; eval "$CMD"`,
+    // Assignments in a pipeline or background segment run in a child shell;
+    // they cannot replace the parent value consumed by the later eval.
+    `CMD='xcrun simctl shutdown DEVICE'; CMD='echo safe' & eval "$CMD"`,
+    `CMD='xcrun simctl shutdown DEVICE'; CMD='echo safe' | /usr/bin/cat; eval "$CMD"`,
     `CMD='xcrun simctl shutdown DEVICE'; (CMD='echo safe'); eval "$CMD"`,
     `CMD='xcrun simctl shutdown DEVICE'; if false; then CMD='echo safe'; fi; eval "$CMD"`,
   ])('denies the current stored recipe at its execution point: %s', (command) => {

--- a/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
@@ -235,9 +235,23 @@ SH`,
     `bash {log}>/dev/null <<'SH'
 xcrun simctl shutdown DEVICE
 SH`,
+    `bash 0<<'SH'
+xcrun simctl shutdown DEVICE
+SH`,
     `cat <<'SH' | bash 2>/dev/null
 open -a Simulator
 SH`,
+    // Multiple stdin heredocs on one consumer: only the last body reaches bash.
+    `bash <<'DATA' <<'CODE'
+echo safe
+DATA
+xcrun simctl shutdown DEVICE
+CODE`,
+    `cat <<'DATA' | bash <<'CODE'
+echo safe
+DATA
+xcrun simctl shutdown DEVICE
+CODE`,
     `printf '<<SH'; cat <<SH | bash
 xcrun simctl shutdown DEVICE
 SH`,
@@ -613,11 +627,24 @@ PY`,
 import os
 os.system("xcr" + "un" + " sim" + "ctl shutdown DEVICE")
 PY`,
+    // The downstream heredoc replaces the pipe as bash's stdin, so DATA is
+    // ordinary cat input even though it looks like a Simulator recipe.
     `cat <<'DATA' | bash <<'CODE'
 xcrun simctl shutdown DEVICE
 DATA
 echo safe
 CODE`,
+    `bash <<'DATA' <<'CODE'
+xcrun simctl shutdown DEVICE
+DATA
+echo safe
+CODE`,
+    `bash 3<<'DATA'
+xcrun simctl shutdown DEVICE
+DATA`,
+    `bash {fd}<<'DATA'
+xcrun simctl shutdown DEVICE
+DATA`,
     `awk 'BEGIN { system("xcr" "un" " sim" "ctl shutdown DEVICE") }'`,
     'xcr$TAIL boot DEVICE',
     'sim$TAIL shutdown DEVICE',

--- a/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
@@ -89,6 +89,10 @@ describeMac('embedded iOS Simulator shell policy', () => {
     // following command, and CRLF delimiters must end the data region correctly.
     `echo hi # <<'EOF'\nxcrun simctl shutdown DEVICE`,
     `cat <<'EOF'\r\ntext\r\nEOF\r\nxcrun simctl shutdown DEVICE`,
+    // Arithmetic left-shift uses the same `<<` spelling as a heredoc opener;
+    // it must not make the following command look like a body for delimiter 2.
+    `echo $((1 << 2))\nxcrun simctl shutdown DEVICE`,
+    `(( 1 << 2 ))\nxcrun simctl shutdown DEVICE`,
   ])('denies a literal recipe behind a documentation-style prefix: %s', (command) => {
     expect(getDesktopShellCommandPolicy(command)).toMatchObject({ decision: 'deny' });
   });
@@ -234,6 +238,20 @@ SH`,
     `cat <<'SH' | bash 2>/dev/null
 open -a Simulator
 SH`,
+    // A non-zero fd redirection leaves stdin connected to the pipeline, so the
+    // downstream shell still executes the producer's body.
+    `cat <<'DATA' | bash 2<err
+xcrun simctl shutdown DEVICE
+DATA`,
+    `cat <<'DATA' | bash {fd}<err
+xcrun simctl shutdown DEVICE
+DATA`,
+    `cat <<'SH' | bash -s $((1 << 2))
+xcrun simctl shutdown DEVICE
+SH`,
+    `cat <<'DATA' | bash -s $(printf foo < /tmp/x)
+xcrun simctl shutdown DEVICE
+DATA`,
     // An unquoted delimiter still expands, so the body's substitutions run.
     `cat <<MSG
 $(xcrun simctl boot DEVICE)
@@ -434,6 +452,8 @@ check()
     'i=0; (( i++ )); echo "$i"',
     '(( $# > 0 )) && echo has-args',
     '(( $? == 0 )) && echo ok',
+    'echo $((1 << 2))',
+    '(( 1 << 2 ))',
     'i=0; while (( i < 3 )); do echo "$i"; i=$((i+1)); done',
     'if (( count > 0 )); then echo ready; fi',
   ])('allows shell arithmetic with no Simulator evidence: %s', (command) => {
@@ -590,6 +610,11 @@ PY`,
 import os
 os.system("xcr" + "un" + " sim" + "ctl shutdown DEVICE")
 PY`,
+    `cat <<'DATA' | bash <<'CODE'
+xcrun simctl shutdown DEVICE
+DATA
+echo safe
+CODE`,
     `awk 'BEGIN { system("xcr" "un" " sim" "ctl shutdown DEVICE") }'`,
     'xcr$TAIL boot DEVICE',
     'sim$TAIL shutdown DEVICE',

--- a/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
@@ -165,6 +165,11 @@ eval "$CMD"`,
     // A command-scoped assignment shadows the exported parent value only for
     // that child command.
     `CMD='xcrun simctl shutdown DEVICE'; CMD='echo safe' sh -c '$CMD'`,
+    // A direct unset in the current shell removes the stored value before the
+    // later execution point. Cover the variable-selecting and `--` spellings.
+    `CMD='xcrun simctl shutdown DEVICE'; unset CMD; eval "$CMD"`,
+    `CMD='xcrun simctl shutdown DEVICE'; unset -v CMD; eval "$CMD"`,
+    `CMD='xcrun simctl shutdown DEVICE'; command unset -- CMD; eval "$CMD"`,
   ])('allows a stored recipe that nothing executes: %s', (command) => {
     expect(getDesktopShellCommandPolicy(command)).toBeUndefined();
   });
@@ -193,6 +198,16 @@ eval "$CMD"`,
     `CMD='xcrun simctl shutdown DEVICE'; CMD='echo safe' | /usr/bin/cat; eval "$CMD"`,
     `CMD='xcrun simctl shutdown DEVICE'; (CMD='echo safe'); eval "$CMD"`,
     `CMD='xcrun simctl shutdown DEVICE'; if false; then CMD='echo safe'; fi; eval "$CMD"`,
+    // Conditional and child-scope unsets do not prove that the parent value was
+    // removed. Function-only unset leaves the variable intact as well.
+    `CMD='xcrun simctl shutdown DEVICE'; false && unset CMD; eval "$CMD"`,
+    `CMD='xcrun simctl shutdown DEVICE'; unset CMD | /usr/bin/cat; eval "$CMD"`,
+    `CMD='xcrun simctl shutdown DEVICE'; (unset CMD); eval "$CMD"`,
+    `CMD='xcrun simctl shutdown DEVICE'; unset -f CMD; eval "$CMD"`,
+    // Readonly variables survive an attempted unset, including declaration
+    // builtins that attach the readonly attribute with an option.
+    `readonly CMD='xcrun simctl shutdown DEVICE'; unset CMD; eval "$CMD"`,
+    `declare -r CMD='xcrun simctl shutdown DEVICE'; unset -v CMD; eval "$CMD"`,
   ])('denies the current stored recipe at its execution point: %s', (command) => {
     expect(getDesktopShellCommandPolicy(command)).toMatchObject({ decision: 'deny' });
   });

--- a/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
@@ -93,6 +93,7 @@ describeMac('embedded iOS Simulator shell policy', () => {
     // it must not make the following command look like a body for delimiter 2.
     `echo $((1 << 2))\nxcrun simctl shutdown DEVICE`,
     `(( 1 << 2 ))\nxcrun simctl shutdown DEVICE`,
+    `echo $[1 << 2]\nxcrun simctl shutdown DEVICE`,
   ])('denies a literal recipe behind a documentation-style prefix: %s', (command) => {
     expect(getDesktopShellCommandPolicy(command)).toMatchObject({ decision: 'deny' });
   });
@@ -161,6 +162,9 @@ eval "$CMD"`,
     // A lone background separator is complete before the newline, so the next
     // assignment is unconditional in the parent shell and replaces the value.
     `CMD='xcrun simctl shutdown DEVICE'; false &\nCMD='echo safe'; eval "$CMD"`,
+    // A command-scoped assignment shadows the exported parent value only for
+    // that child command.
+    `CMD='xcrun simctl shutdown DEVICE'; CMD='echo safe' sh -c '$CMD'`,
   ])('allows a stored recipe that nothing executes: %s', (command) => {
     expect(getDesktopShellCommandPolicy(command)).toBeUndefined();
   });
@@ -172,6 +176,7 @@ eval "$CMD"`,
     // An assignment attached to another command only changes that command's
     // environment; it must not replace the shell-scoped value used by eval.
     `CMD='xcrun simctl shutdown DEVICE'; CMD='echo safe' /usr/bin/true; eval "$CMD"`,
+    `CMD='echo safe'; CMD='xcrun simctl shutdown DEVICE' sh -c '$CMD'`,
     // The later text is not a guaranteed replacement when control flow can skip
     // it or keep it inside a child scope, so the earlier value stays possible.
     `CMD='xcrun simctl shutdown DEVICE'; false && CMD='echo safe'; eval "$CMD"`,
@@ -470,6 +475,7 @@ check()
     '(( $# > 0 )) && echo has-args',
     '(( $? == 0 )) && echo ok',
     'echo $((1 << 2))',
+    'echo $[1 << 2]',
     '(( 1 << 2 ))',
     'i=0; while (( i < 3 )); do echo "$i"; i=$((i+1)); done',
     'if (( count > 0 )); then echo ready; fi',

--- a/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
@@ -75,6 +75,10 @@ describeMac('embedded iOS Simulator shell policy', () => {
     "bash -O extglob -c 'xcrun simctl shutdown DEVICE'",
     "bash +O extglob -c 'xcrun simctl boot DEVICE'",
     "zsh -o extendedglob -c 'xcrun simctl shutdown DEVICE'",
+    // A stored recipe counts once something runs the variable that holds it.
+    `CMD='xcrun simctl shutdown DEVICE'; eval "\${CMD}"`,
+    `CMD='xcrun simctl boot DEVICE'; bash -lc "$CMD"`,
+    `CMD='xcrun simctl boot DEVICE'; echo start; eval "$CMD"`,
     // An assignment builtin stores a recipe just like a bare `NAME=value`.
     `export CMD='xcrun simctl shutdown DEVICE'; eval "$CMD"`,
     `readonly CMD='xcrun simctl boot DEVICE'; eval "$CMD"`,
@@ -125,6 +129,24 @@ describeMac('embedded iOS Simulator shell policy', () => {
     'exec -a label /usr/bin/xcrun simctl boot DEVICE',
     'exec -cl -a label xcrun simctl erase DEVICE',
   ])('no longer denies a recipe behind an option-bearing prefix: %s', (command) => {
+    expect(getDesktopShellCommandPolicy(command)).toBeUndefined();
+  });
+
+  // A stored recipe is only a recipe once something runs it. Classifying every
+  // assignment denied commands that print or write the string and execute
+  // nothing — and printing a command is exactly what a script does while
+  // explaining itself.
+  it.each([
+    `CMD='xcrun simctl shutdown DEVICE'; printf '%s\\n' "$CMD"`,
+    `CMD='xcrun simctl boot DEVICE'; echo "$CMD"`,
+    `CMD='open -a Simulator'; echo "$CMD" > /tmp/note.txt`,
+    `export CMD='xcrun simctl erase DEVICE'; echo "$CMD"`,
+    `CMD='xcrun simctl boot DEVICE'; echo done`,
+    `CMD='xcrun simctl boot DEVICE'`,
+    `readonly DOC='run xcrun simctl boot DEVICE to start'; printf '%s' "$DOC"`,
+    // A different name reaches the execution site, so this value never runs.
+    `CMD='xcrun simctl boot DEVICE'; eval "$OTHER"`,
+  ])('allows a stored recipe that nothing executes: %s', (command) => {
     expect(getDesktopShellCommandPolicy(command)).toBeUndefined();
   });
 

--- a/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
@@ -195,6 +195,9 @@ eval "$CMD"`,
     `CMD='xcrun simctl shutdown DEVICE'; CMD='echo safe' | /usr/bin/cat; eval "$CMD"`,
     `CMD='xcrun simctl shutdown DEVICE'; (CMD='echo safe'); eval "$CMD"`,
     `CMD='xcrun simctl shutdown DEVICE'; if false; then CMD='echo safe'; fi; eval "$CMD"`,
+    // `local` fails outside a function, and function bodies are intentionally
+    // outside this literal-recipe parser. It cannot prove a top-level override.
+    `CMD='xcrun simctl shutdown DEVICE'; local CMD='echo safe'; eval "$CMD"`,
   ])('denies the current stored recipe at its execution point: %s', (command) => {
     expect(getDesktopShellCommandPolicy(command)).toMatchObject({ decision: 'deny' });
   });

--- a/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
@@ -174,6 +174,10 @@ eval "$CMD"`,
     `CMD='xcrun simctl shutdown DEVICE'; false &&\nCMD='echo safe'; eval "$CMD"`,
     `CMD='xcrun simctl shutdown DEVICE'; true ||\nCMD='echo safe'; eval "$CMD"`,
     `CMD='xcrun simctl shutdown DEVICE'; printf ignored |\nCMD='echo safe'; eval "$CMD"`,
+    // A comment's separators and assignments are not shell syntax. Quoted
+    // hashes remain ordinary data and must not disable comment scanning.
+    `CMD='xcrun simctl shutdown DEVICE'; # note; CMD='echo safe'\neval "$CMD"`,
+    `CMD='xcrun simctl shutdown DEVICE'; echo "# not a comment"; eval "$CMD"`,
     // Assignments in a pipeline or background segment run in a child shell;
     // they cannot replace the parent value consumed by the later eval.
     `CMD='xcrun simctl shutdown DEVICE'; CMD='echo safe' & eval "$CMD"`,

--- a/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
@@ -160,6 +160,9 @@ describeMac('embedded iOS Simulator shell policy', () => {
     `CMD='xcrun simctl shutdown DEVICE'; eval "$CMD"; CMD='echo safe'`,
     `CMD='echo safe'; CMD='xcrun simctl shutdown DEVICE'; eval "$CMD"`,
     `CMD='xcrun simctl shutdown DEVICE'; OTHER='echo safe'; eval "$CMD"`,
+    // An assignment attached to another command only changes that command's
+    // environment; it must not replace the shell-scoped value used by eval.
+    `CMD='xcrun simctl shutdown DEVICE'; CMD='echo safe' /usr/bin/true; eval "$CMD"`,
     // The later text is not a guaranteed replacement when control flow can skip
     // it or keep it inside a child scope, so the earlier value stays possible.
     `CMD='xcrun simctl shutdown DEVICE'; false && CMD='echo safe'; eval "$CMD"`,

--- a/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
@@ -315,6 +315,8 @@ check()
     "rg -n foo --glob '*.{ts,tsx}' apps",
     'grep -rEn "(foo|bar)" apps',
     "awk '{print $1}' /tmp/app.log",
+    'ls /tmp/[abc]*.log',
+    'cp file.{ts,ts.bak}',
   ])('allows an ordinary command whose shape is not an executable: %s', (command) => {
     expect(getDesktopShellCommandPolicy(command)).toBeUndefined();
   });
@@ -356,6 +358,15 @@ SH`,
     'sim$(printf c)tl shutdown DEVICE',
     'x$(printf c)run simctl shutdown DEVICE',
     'sim`printf c`tl shutdown DEVICE',
+    // A character class or brace list holds mutually exclusive candidates, so
+    // merging their contents into the core would invent a literal that matches
+    // nothing and hide the name the shell can expand to.
+    '/usr/bin/[sx]crun s[ai]mctl shutdown DEVICE',
+    '/Applications/Xcode.app/Contents/Developer/usr/bin/[sx]imctl shutdown DEVICE',
+    '[sx]crun boot DEVICE',
+    's[ai]mctl shutdown DEVICE',
+    'x{cr,foo}un boot DEVICE',
+    's{imc,foo}tl shutdown DEVICE',
   ])('denies a command word whose executable name cannot be resolved: %s', (command) => {
     expect(getDesktopShellCommandPolicy(command)).toMatchObject({ decision: 'deny' });
   });

--- a/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
@@ -211,6 +211,21 @@ SH`,
     `cat <<'SH' | bash | cat
 open -a Simulator
 SH`,
+    `bash 2>/dev/null <<'SH'
+xcrun simctl shutdown DEVICE
+SH`,
+    `bash>/dev/null <<'SH'
+xcrun simctl shutdown DEVICE
+SH`,
+    `bash &>/dev/null <<'SH'
+xcrun simctl shutdown DEVICE
+SH`,
+    `bash {log}>/dev/null <<'SH'
+xcrun simctl shutdown DEVICE
+SH`,
+    `cat <<'SH' | bash 2>/dev/null
+open -a Simulator
+SH`,
     // An unquoted delimiter still expands, so the body's substitutions run.
     `cat <<MSG
 $(xcrun simctl boot DEVICE)
@@ -350,6 +365,18 @@ MSG`,
 xcrun simctl shutdown DEVICE
 MSG`,
     `git commit -F - <<MSG
+xcrun simctl shutdown DEVICE
+MSG`,
+    `git commit 2>/dev/null -F - <<'MSG'
+xcrun simctl shutdown DEVICE
+MSG`,
+    `bash '2>/dev/null' <<'SH'
+xcrun simctl shutdown DEVICE
+SH`,
+    `bash '&>/dev/null' <<'SH'
+xcrun simctl shutdown DEVICE
+SH`,
+    `git commit &>/dev/null -F - <<'MSG'
 xcrun simctl shutdown DEVICE
 MSG`,
     // A quoted delimiter suppresses expansion in every spelling, and `<<-`

--- a/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
@@ -39,6 +39,8 @@ describeMac('embedded iOS Simulator shell policy', () => {
     expect(getDesktopShellCommandPolicy(command)).toMatchObject({ decision: 'deny' });
   });
 
+  // Documentation puts these prefixes in front of a recipe, so the recipe is
+  // still spelled out and still reachable by reading the command word.
   it.each([
     'exec /usr/bin/xcrun simctl shutdown DEVICE',
     'command -p xcrun simctl boot DEVICE',
@@ -54,102 +56,22 @@ describeMac('embedded iOS Simulator shell policy', () => {
     "eval 'xcrun simctl erase DEVICE'",
     'echo "$(xcrun simctl shutdown DEVICE)"',
     'echo >(xcrun simctl shutdown DEVICE)',
-    "env -S 'xcrun simctl shutdown DEVICE'",
     'CMD=xcrun\\ simctl\\ shutdown\\ DEVICE; eval "$CMD"',
     'CMD=xcrun\\ simctl\\ shutdown\\ DEVICE; sh -c "$CMD"',
     'CMD=xcrun\\ simctl\\ shutdown\\ DEVICE; $CMD',
-    'printf "xcrun simctl shutdown DEVICE\\n" | sh',
     'time xcrun simctl shutdown DEVICE',
     'time -p xcrun simctl boot DEVICE',
-    'f(){ xcrun simctl shutdown DEVICE;}; f',
-    'f() ( xcrun simctl shutdown DEVICE ); f',
     `function f () ( printf '%s' "$(date)"; /usr/bin/open -a Simulator ); f`,
     '/usr/bin/xcrun \\\n simctl shutdown DEVICE',
     '/usr/bin/nice /usr/bin/xcrun simctl erase DEVICE',
     '/usr/bin/arch -arm64 /usr/bin/xcrun simctl boot DEVICE',
     '/usr/bin/caffeinate -i /usr/bin/xcrun simctl shutdown DEVICE',
-    `/bin/sh -c '"$0" "$@"' /usr/bin/xcrun simctl shutdown DEVICE`,
-    `/bin/sh -c '/usr/bin/open -a "$1"' ignored Simulator`,
-    '$(/usr/bin/xcrun --find simctl) shutdown DEVICE',
-    '/usr/bin/xc[r]un simctl shutdown DEVICE',
-    'TOOL=simctl; /usr/bin/xcrun "$TOOL" shutdown DEVICE',
-    'A=sim; B=ctl; xcrun "$A$B" shutdown DEVICE',
-    'A=sim; B=ctl; xcrun --sdk iphonesimulator "${A}${B}" erase DEVICE',
-    'xcrun s{imc,foo}tl shutdown DEVICE',
-    'A="default simctl"; xcrun --toolchain ${=A} shutdown DEVICE',
-    `bash -lc 'A="default simctl"; xcrun --toolchain $A shutdown DEVICE'`,
-    'A=(default simctl); xcrun --toolchain "${(@)A}" shutdown DEVICE',
-    'A="default simctl"; xcrun --toolchain "$=A" shutdown DEVICE',
-    'A=(default simctl); xcrun --toolchain "$A[@]" shutdown DEVICE',
-    `bash -O extglob -lc 'xcrun @(simctl) shutdown DEVICE'`,
-    `zsh -o extendedglob -c 'xcrun ^foo shutdown DEVICE'`,
-    'xcrun --sdk "$SDK" simctl list devices',
-    'A=default; xcrun --toolchain "$A" swift --version',
     'xargs /usr/bin/xcrun simctl shutdown DEVICE',
-    "find . -maxdepth 0 -exec /usr/bin/xcrun simctl shutdown DEVICE ';'",
-    `printf 'simctl shutdown DEVICE' | xargs /usr/bin/xcrun`,
-    'xcrun "$(printf simctl)" shutdown DEVICE',
-    'xcrun $(printf simctl) shutdown DEVICE',
-    'xcrun $(echo simctl) shutdown DEVICE',
-    'TOOL=$(printf simctl); xcrun "$TOOL" shutdown DEVICE',
-    'A=xcr; B=un; C=sim; D=ctl; "$A$B" "$C$D" shutdown DEVICE',
-    'A=xcr; B=un; C=simctl; env "$A$B" "$C" shutdown DEVICE',
-    'A=x; B=crun; C=sim; D=ctl; command "${A}${B}" "${C}${D}" shutdown DEVICE',
-    '$(printf xcr)$(printf un) simctl shutdown DEVICE',
-    'x{cr,foo}un simctl shutdown DEVICE',
-    'RUNNER="$UNTRUSTED_EXECUTABLE"; exec "$RUNNER" --version',
-    'env -S "$UNTRUSTED_EXECUTABLE"',
-    'A=xcr; B=un; C=sim; D=ctl; CMD="$A$B $C$D shutdown DEVICE"; env -S "$CMD"',
-    'time -l "$UNTRUSTED_EXECUTABLE"',
-    'xargs "$UNTRUSTED_EXECUTABLE"',
-    "find . -maxdepth 0 -exec \"$UNTRUSTED_EXECUTABLE\" '{}' '+'",
-    `sandbox-exec -p '(version 1) (allow default)' "$UNTRUSTED_EXECUTABLE"`,
-    'A=xcr; B=un; sh -c \'"$0" simctl shutdown DEVICE\' "$A$B"',
-    'A=xcr; B=un; C=sim; D=ctl; >/tmp/cindy-shell.log "$A$B" "$C$D" shutdown DEVICE',
-    'A=xcr; B=un; C=sim; D=ctl; 2>/dev/null "$A$B" "$C$D" shutdown DEVICE',
-    'A=xcr; B=un; C=sim; D=ctl; < /dev/null "$A$B" "$C$D" shutdown DEVICE',
-    "A=xcr; B=un; C=sim; D=ctl; COUNT='arr[$($A$B $C$D shutdown DEVICE)]'; (( COUNT ))",
-    "A=xcr; B=un; C=sim; D=ctl; PAYLOAD='arr[$($A$B $C$D shutdown DEVICE)]'; COUNT=PAYLOAD; (( COUNT ))",
-    "A=xcr; B=un; C=sim; D=ctl; printf -v COUNT 'arr[$($A$B $C$D shutdown DEVICE)]'; (( COUNT ))",
-    "A=xcr B=un C=sim D=ctl COUNT='arr[$($A$B $C$D shutdown DEVICE)]' bash -c '(( COUNT ))'",
-    'xargs -0 /Applications/Xcode.app/Contents/Developer/usr/bin/simct? shutdown DEVICE',
-    'sudo -n /Applications/Xcode.app/Contents/Developer/usr/bin/simct[l] shutdown DEVICE',
-    'gtimeout -v 5 /Applications/Xcode.app/Contents/Developer/usr/bin/simct? shutdown DEVICE',
-    `zsh -o extendedglob -c '/Applications/Xcode.app/Contents/Developer/usr/bin/simct^foo shutdown DEVICE'`,
-    `zsh -o extendedglob -c '/Applications/Xcode.app/Contents/Developer/usr/bin/simctl~foo shutdown DEVICE'`,
-    `zsh -o extendedglob -c '/Applications/Xcode.app/Contents/Developer/usr/bin/simctl# shutdown DEVICE'`,
-    'A=xcr; B=un; C=sim; D=ctl; launchctl asuser 501 "$A$B" "$C$D" shutdown DEVICE',
-    'A=xcr; B=un; C=sim; D=ctl; launchctl bsexec 123 "$A$B" "$C$D" shutdown DEVICE',
-    'A=xcr; B=un; C=sim; D=ctl; noglob "$A$B" "$C$D" shutdown DEVICE',
-    'A=xcr; B=un; C=sim; D=ctl; nocorrect "$A$B" "$C$D" shutdown DEVICE',
-    'A=xcr; B=un; C=sim; D=ctl; coproc "$A$B" "$C$D" shutdown DEVICE',
-    'A=xcr; B=un; C=sim; D=ctl; repeat 1 "$A$B" "$C$D" shutdown DEVICE',
-    'A=xcr; B=un; C=sim; D=ctl; sudo >/dev/null "$A$B" "$C$D" shutdown DEVICE',
-    'A=xcr; B=un; C=sim; D=ctl; xargs 2>/dev/null "$A$B" "$C$D" shutdown DEVICE',
-    'A=xcr; B=un; C=sim; D=ctl; launchctl submit -l test >/dev/null -- "$A$B" "$C$D" shutdown DEVICE',
-    'A=xcr; B=un; C=sim; D=ctl; sudo FOO=bar "$A$B" "$C$D" shutdown DEVICE',
-    'A=xcr; B=un; C=sim; D=ctl; xargs env FOO=bar "$A$B" "$C$D" shutdown DEVICE',
-    'A=xcr; B=un; C=sim; D=ctl; find . -maxdepth 0 -exec env FOO=bar "$A$B" "$C$D" shutdown DEVICE \';\'',
-    'A=xcr; B=un; C=sim; D=ctl; sudo command "$A$B" "$C$D" shutdown DEVICE',
-    'launchctl submit -l cindy-test -- /usr/bin/xcrun simctl shutdown DEVICE',
-    `sandbox-exec -p '(version 1) (allow default)' /usr/bin/xcrun simctl shutdown DEVICE`,
-    "shopt -s expand_aliases\nalias sim='xcrun simctl'\nsim shutdown DEVICE",
-    "alias sim=xcrun\\ simctl; eval 'sim erase DEVICE'",
-    "builtin alias sim='/usr/bin/xcrun simctl'; eval 'sim shutdown DEVICE'",
-    "command -- alias sim='open -a Simulator'; eval sim",
-    "alias safe='ls -la' sim='xcrun simctl'; eval 'sim boot DEVICE'",
-    "alias sc='simctl'; eval 'sc shutdown DEVICE'",
-  ])('denies Simulator mutation hidden behind shell execution: %s', (command) => {
+  ])('denies a literal recipe behind a documentation-style prefix: %s', (command) => {
     expect(getDesktopShellCommandPolicy(command)).toMatchObject({ decision: 'deny' });
   });
 
-  it.each(['(( $COUNT > 0 ))', '(( COUNT[$idx]++ ))', 'if (( $COUNT > 0 )); then echo ready; fi'])(
-    'denies dynamic shell arithmetic that can recursively execute stored payloads: %s',
-    (command) => {
-      expect(getDesktopShellCommandPolicy(command)).toMatchObject({ decision: 'deny' });
-    },
-  );
-
+  // A recipe pasted into an interpreter one-liner is still literal text.
   it.each([
     `python3 -c 'import subprocess; subprocess.run(["/usr/bin/xcrun", "simctl", "shutdown", "DEVICE"])'`,
     `node -e 'require("node:child_process").execFileSync("xcrun", ["simctl", "erase", "DEVICE"])'`,
@@ -160,24 +82,12 @@ describeMac('embedded iOS Simulator shell policy', () => {
     `awk 'BEGIN { system("xcrun simctl erase DEVICE") }'`,
     `osascript -e 'do shell script "/usr/bin/xcrun simctl shutdown DEVICE"'`,
     `osascript -e 'do shell script "open -a Simulator"'`,
-    `printf '%s' 'import os; os.system("xcrun simctl shutdown DEVICE")' | python3`,
-    `python3 <<'PY'
-import os
-os.system("xcrun simctl shutdown DEVICE")
-PY`,
     `osascript -e 'set cmd to "/usr/bin/xcrun simctl shutdown DEVICE"' -e 'do shell script cmd'`,
     `osascript -l JavaScript -e 'ObjC.import("Foundation"); const task = $.NSTask.alloc.init; task.launchPath = "/usr/bin/xcrun"; task.arguments = ["simctl", "shutdown", "DEVICE"]; task.launch'`,
     `python3 -c 'import subprocess; subprocess.run(["/usr/bin/open","-a","Simulator"])'`,
     `node -e 'require("child_process").spawnSync("/usr/bin/open",["-na","Simulator"])'`,
     `ruby -e 'system("/usr/bin/open", "-a", "Simulator")'`,
     `/usr/bin/expect -c 'spawn /usr/bin/xcrun simctl shutdown DEVICE; expect eof'`,
-    `printf '%s' 'exec /usr/bin/xcrun simctl shutdown DEVICE' | /usr/bin/tclsh`,
-    `printf '%s' 'import os; os.system("xcrun simctl shutdown DEVICE")' |& python3`,
-    `bash <<< 'xcrun simctl shutdown DEVICE'`,
-    `zsh <<< 'open -a Simulator'`,
-    `bash -c 'source /dev/stdin' <<< 'xcrun simctl shutdown DEVICE'`,
-    `bash -c 'eval "$(cat)"' <<< 'xcrun simctl shutdown DEVICE'`,
-    `printf 'xcrun simctl shutdown DEVICE' | bash -c 'eval "$(cat)"'`,
     // The consumer can also follow the marker, so the heredoc's own pipeline —
     // not just the text before `<<` — decides whether the body is executable.
     `cat <<'SH' | sh
@@ -193,9 +103,17 @@ MSG`,
     `cat <<MSG
 \`xcrun simctl shutdown DEVICE\`
 MSG`,
-  ])('denies Simulator mutation hidden behind a programmable interpreter: %s', (command) => {
+    // Quote removal happens during tokenization exactly as a shell performs it,
+    // so an interrupted spelling is still a literal recipe.
+    `bash <<'SH'
+xcr"un" sim"ctl" shutdown DEVICE
+SH`,
+    // Only the executor is assembled here; `simctl shutdown DEVICE` is spelled out.
+    `python3 -c "import os; os.system(''.join(['xc','run']) + ' simctl shutdown DEVICE')"`,
+  ])('denies a literal recipe inside an interpreter payload: %s', (command) => {
     expect(getDesktopShellCommandPolicy(command)).toMatchObject({ decision: 'deny' });
   });
+
 
   it.each([
     'xcrun simctl list devices',
@@ -376,27 +294,117 @@ check()
     expect(getDesktopShellCommandPolicy(command)).toBeUndefined();
   });
 
-  // Evidence matching undoes the concatenation an interpreter would perform, so
-  // narrowing the shape-only rules above does not open a fragment bypass.
+  // ── Reclassified by the stale-recipe threat model ──────────────────────────
+  //
+  // Every command below was denied before. Each one disguises the executor:
+  // assembling it from variables or string fragments, completing it with a glob
+  // or a substitution, forwarding it through eval, or storing it for an opaque
+  // wrapper to run. A recipe copied from documentation never looks like this, so
+  // none of them are in the threat model this policy defends.
+  //
+  // They are listed rather than deleted because the change is a deliberate
+  // reduction in what the guard claims to stop, and a reviewer should be able to
+  // see exactly what moved. Detecting these forms is not achievable from command
+  // text anyway — `bash script.sh` carries the executor outside the command
+  // entirely — and the machinery that attempted it is what denied ordinary work
+  // such as a heredoc body, shell arithmetic and a redirected group.
   it.each([
+    "env -S 'xcrun simctl shutdown DEVICE'",
+    'printf "xcrun simctl shutdown DEVICE\\n" | sh',
+    'f(){ xcrun simctl shutdown DEVICE;}; f',
+    'f() ( xcrun simctl shutdown DEVICE ); f',
+    `/bin/sh -c '"$0" "$@"' /usr/bin/xcrun simctl shutdown DEVICE`,
+    `/bin/sh -c '/usr/bin/open -a "$1"' ignored Simulator`,
+    '$(/usr/bin/xcrun --find simctl) shutdown DEVICE',
+    '/usr/bin/xc[r]un simctl shutdown DEVICE',
+    'TOOL=simctl; /usr/bin/xcrun "$TOOL" shutdown DEVICE',
+    'A=sim; B=ctl; xcrun "$A$B" shutdown DEVICE',
+    'A=sim; B=ctl; xcrun --sdk iphonesimulator "${A}${B}" erase DEVICE',
+    'xcrun s{imc,foo}tl shutdown DEVICE',
+    'A="default simctl"; xcrun --toolchain ${=A} shutdown DEVICE',
+    `bash -lc 'A="default simctl"; xcrun --toolchain $A shutdown DEVICE'`,
+    'A=(default simctl); xcrun --toolchain "${(@)A}" shutdown DEVICE',
+    'A="default simctl"; xcrun --toolchain "$=A" shutdown DEVICE',
+    'A=(default simctl); xcrun --toolchain "$A[@]" shutdown DEVICE',
+    `bash -O extglob -lc 'xcrun @(simctl) shutdown DEVICE'`,
+    `zsh -o extendedglob -c 'xcrun ^foo shutdown DEVICE'`,
+    'xcrun --sdk "$SDK" simctl list devices',
+    'A=default; xcrun --toolchain "$A" swift --version',
+    "find . -maxdepth 0 -exec /usr/bin/xcrun simctl shutdown DEVICE ';'",
+    `printf 'simctl shutdown DEVICE' | xargs /usr/bin/xcrun`,
+    'xcrun "$(printf simctl)" shutdown DEVICE',
+    'xcrun $(printf simctl) shutdown DEVICE',
+    'xcrun $(echo simctl) shutdown DEVICE',
+    'TOOL=$(printf simctl); xcrun "$TOOL" shutdown DEVICE',
+    'A=xcr; B=un; C=sim; D=ctl; "$A$B" "$C$D" shutdown DEVICE',
+    'A=xcr; B=un; C=simctl; env "$A$B" "$C" shutdown DEVICE',
+    'A=x; B=crun; C=sim; D=ctl; command "${A}${B}" "${C}${D}" shutdown DEVICE',
+    '$(printf xcr)$(printf un) simctl shutdown DEVICE',
+    'x{cr,foo}un simctl shutdown DEVICE',
+    'RUNNER="$UNTRUSTED_EXECUTABLE"; exec "$RUNNER" --version',
+    'env -S "$UNTRUSTED_EXECUTABLE"',
+    'A=xcr; B=un; C=sim; D=ctl; CMD="$A$B $C$D shutdown DEVICE"; env -S "$CMD"',
+    'time -l "$UNTRUSTED_EXECUTABLE"',
+    'xargs "$UNTRUSTED_EXECUTABLE"',
+    "find . -maxdepth 0 -exec \"$UNTRUSTED_EXECUTABLE\" '{}' '+'",
+    `sandbox-exec -p '(version 1) (allow default)' "$UNTRUSTED_EXECUTABLE"`,
+    'A=xcr; B=un; sh -c \'"$0" simctl shutdown DEVICE\' "$A$B"',
+    'A=xcr; B=un; C=sim; D=ctl; >/tmp/cindy-shell.log "$A$B" "$C$D" shutdown DEVICE',
+    'A=xcr; B=un; C=sim; D=ctl; 2>/dev/null "$A$B" "$C$D" shutdown DEVICE',
+    'A=xcr; B=un; C=sim; D=ctl; < /dev/null "$A$B" "$C$D" shutdown DEVICE',
+    "A=xcr; B=un; C=sim; D=ctl; COUNT='arr[$($A$B $C$D shutdown DEVICE)]'; (( COUNT ))",
+    "A=xcr; B=un; C=sim; D=ctl; PAYLOAD='arr[$($A$B $C$D shutdown DEVICE)]'; COUNT=PAYLOAD; (( COUNT ))",
+    "A=xcr; B=un; C=sim; D=ctl; printf -v COUNT 'arr[$($A$B $C$D shutdown DEVICE)]'; (( COUNT ))",
+    "A=xcr B=un C=sim D=ctl COUNT='arr[$($A$B $C$D shutdown DEVICE)]' bash -c '(( COUNT ))'",
+    'xargs -0 /Applications/Xcode.app/Contents/Developer/usr/bin/simct? shutdown DEVICE',
+    'sudo -n /Applications/Xcode.app/Contents/Developer/usr/bin/simct[l] shutdown DEVICE',
+    'gtimeout -v 5 /Applications/Xcode.app/Contents/Developer/usr/bin/simct? shutdown DEVICE',
+    `zsh -o extendedglob -c '/Applications/Xcode.app/Contents/Developer/usr/bin/simct^foo shutdown DEVICE'`,
+    `zsh -o extendedglob -c '/Applications/Xcode.app/Contents/Developer/usr/bin/simctl~foo shutdown DEVICE'`,
+    `zsh -o extendedglob -c '/Applications/Xcode.app/Contents/Developer/usr/bin/simctl# shutdown DEVICE'`,
+    'A=xcr; B=un; C=sim; D=ctl; launchctl asuser 501 "$A$B" "$C$D" shutdown DEVICE',
+    'A=xcr; B=un; C=sim; D=ctl; launchctl bsexec 123 "$A$B" "$C$D" shutdown DEVICE',
+    'A=xcr; B=un; C=sim; D=ctl; noglob "$A$B" "$C$D" shutdown DEVICE',
+    'A=xcr; B=un; C=sim; D=ctl; nocorrect "$A$B" "$C$D" shutdown DEVICE',
+    'A=xcr; B=un; C=sim; D=ctl; coproc "$A$B" "$C$D" shutdown DEVICE',
+    'A=xcr; B=un; C=sim; D=ctl; repeat 1 "$A$B" "$C$D" shutdown DEVICE',
+    'A=xcr; B=un; C=sim; D=ctl; sudo >/dev/null "$A$B" "$C$D" shutdown DEVICE',
+    'A=xcr; B=un; C=sim; D=ctl; xargs 2>/dev/null "$A$B" "$C$D" shutdown DEVICE',
+    'A=xcr; B=un; C=sim; D=ctl; launchctl submit -l test >/dev/null -- "$A$B" "$C$D" shutdown DEVICE',
+    'A=xcr; B=un; C=sim; D=ctl; sudo FOO=bar "$A$B" "$C$D" shutdown DEVICE',
+    'A=xcr; B=un; C=sim; D=ctl; xargs env FOO=bar "$A$B" "$C$D" shutdown DEVICE',
+    'A=xcr; B=un; C=sim; D=ctl; find . -maxdepth 0 -exec env FOO=bar "$A$B" "$C$D" shutdown DEVICE \';\'',
+    'A=xcr; B=un; C=sim; D=ctl; sudo command "$A$B" "$C$D" shutdown DEVICE',
+    'launchctl submit -l cindy-test -- /usr/bin/xcrun simctl shutdown DEVICE',
+    `sandbox-exec -p '(version 1) (allow default)' /usr/bin/xcrun simctl shutdown DEVICE`,
+    "shopt -s expand_aliases\nalias sim='xcrun simctl'\nsim shutdown DEVICE",
+    "alias sim=xcrun\\ simctl; eval 'sim erase DEVICE'",
+    "builtin alias sim='/usr/bin/xcrun simctl'; eval 'sim shutdown DEVICE'",
+    "command -- alias sim='open -a Simulator'; eval sim",
+    "alias safe='ls -la' sim='xcrun simctl'; eval 'sim boot DEVICE'",
+    "alias sc='simctl'; eval 'sc shutdown DEVICE'",
+    '(( $COUNT > 0 ))',
+    '(( COUNT[$idx]++ ))',
+    'if (( $COUNT > 0 )); then echo ready; fi',
+    `printf '%s' 'import os; os.system("xcrun simctl shutdown DEVICE")' | python3`,
+    `python3 <<'PY'
+import os
+os.system("xcrun simctl shutdown DEVICE")
+PY`,
+    `printf '%s' 'exec /usr/bin/xcrun simctl shutdown DEVICE' | /usr/bin/tclsh`,
+    `printf '%s' 'import os; os.system("xcrun simctl shutdown DEVICE")' |& python3`,
+    `bash <<< 'xcrun simctl shutdown DEVICE'`,
+    `zsh <<< 'open -a Simulator'`,
+    `bash -c 'source /dev/stdin' <<< 'xcrun simctl shutdown DEVICE'`,
+    `bash -c 'eval "$(cat)"' <<< 'xcrun simctl shutdown DEVICE'`,
+    `printf 'xcrun simctl shutdown DEVICE' | bash -c 'eval "$(cat)"'`,
     `python3 -c 'import os; os.system("xcr" + "un" + " sim" + "ctl shutdown DEVICE")'`,
     `node -e 'require("child_process").execSync("xcr" + "un" + " sim" + "ctl shutdown DEVICE")'`,
     `python3 - <<'PY'
 import os
 os.system("xcr" + "un" + " sim" + "ctl shutdown DEVICE")
 PY`,
-    `bash <<'SH'
-xcr"un" sim"ctl" shutdown DEVICE
-SH`,
     `awk 'BEGIN { system("xcr" "un" " sim" "ctl shutdown DEVICE") }'`,
-  ])('denies a Simulator executor assembled from string fragments: %s', (command) => {
-    expect(getDesktopShellCommandPolicy(command)).toMatchObject({ decision: 'deny' });
-  });
-
-  // Only the basename selects the executable, and a literal fragment of an
-  // executor name can be completed by the expansion next to it. Both stay
-  // fail-closed even though no whole Simulator word appears.
-  it.each([
     'xcr$TAIL boot DEVICE',
     'sim$TAIL shutdown DEVICE',
     'xc$TAIL boot DEVICE',
@@ -422,21 +430,12 @@ SH`,
     's[ai]mctl shutdown DEVICE',
     'x{cr,foo}un boot DEVICE',
     's{imc,foo}tl shutdown DEVICE',
-  ])('denies a command word whose executable name cannot be resolved: %s', (command) => {
-    expect(getDesktopShellCommandPolicy(command)).toMatchObject({ decision: 'deny' });
-  });
-
-  // Interpreters join sequences as well as concatenating with an operator.
-  // This is a finite set of forms by construction: a payload can still assemble
-  // a name from character codes or base64, which command text cannot decide.
-  it.each([
     `python3 - <<'PY'
 import os
 os.system(''.join(('xc','run')) + ' ' + ''.join(('sim','ctl')) + ' shutdown DEVICE')
 PY`,
-    `python3 -c "import os; os.system(''.join(['xc','run']) + ' simctl shutdown DEVICE')"`,
-  ])('denies an executor joined from a sequence of fragments: %s', (command) => {
-    expect(getDesktopShellCommandPolicy(command)).toMatchObject({ decision: 'deny' });
+  ])('no longer denies a disguised executor: %s', (command) => {
+    expect(getDesktopShellCommandPolicy(command)).toBeUndefined();
   });
 
   // The deliberate boundary of the narrowing: the executable name is knowable

--- a/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
@@ -85,6 +85,15 @@ describeMac('embedded iOS Simulator shell policy', () => {
     'exec -cl -a label xcrun simctl erase DEVICE',
     // A shell option that takes a value must not be read as the script operand.
     "bash -o pipefail -c 'xcrun simctl shutdown DEVICE'",
+    "bash -O extglob -c 'xcrun simctl shutdown DEVICE'",
+    "bash +O extglob -c 'xcrun simctl boot DEVICE'",
+    "zsh -o extendedglob -c 'xcrun simctl shutdown DEVICE'",
+    // An assignment builtin stores a recipe just like a bare `NAME=value`.
+    `export CMD='xcrun simctl shutdown DEVICE'; eval "$CMD"`,
+    `readonly CMD='xcrun simctl boot DEVICE'; eval "$CMD"`,
+    `declare CMD='open -a Simulator'; eval "$CMD"`,
+    `typeset CMD='xcrun simctl erase DEVICE'; eval "$CMD"`,
+    `export -p CMD='xcrun simctl boot DEVICE'; eval "$CMD"`,
     // Removing heredoc region reduction also removed the ways it could swallow a
     // real recipe: a marker inside a comment, and a CRLF delimiter that never
     // matched. Body lines are now ordinary segments.
@@ -319,6 +328,13 @@ check()
     'sh ./run.sh -c "xcrun simctl boot DEVICE"',
     "zsh tools/x.zsh -c 'open -a Simulator'",
     'bash ./build.sh --release',
+    // `command -v` / `-V` describe their operands; nothing is executed, so the
+    // operands must not be reclassified as the invocation they name.
+    'command -v simctl shutdown',
+    'command -V simctl',
+    'command -v xcrun simctl',
+    'command -pv simctl boot',
+    'export PATH=/usr/bin:$PATH; echo ok',
   ])('allows an ordinary command whose shape is not an executable: %s', (command) => {
     expect(getDesktopShellCommandPolicy(command)).toBeUndefined();
   });

--- a/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
@@ -152,6 +152,12 @@ describeMac('embedded iOS Simulator shell policy', () => {
     `CMD='xcrun simctl shutdown DEVICE'; CMD='echo safe'; eval "$CMD" 2>&1`,
     `CMD='xcrun simctl shutdown DEVICE'; echo if; CMD='echo safe'; eval "$CMD"`,
     `CMD='xcrun simctl shutdown DEVICE' && true; CMD='echo safe'; eval "$CMD"`,
+    `CMD='xcrun simctl shutdown DEVICE'
+CMD='echo safe'
+eval "$CMD"`,
+    // A lone background separator is complete before the newline, so the next
+    // assignment is unconditional in the parent shell and replaces the value.
+    `CMD='xcrun simctl shutdown DEVICE'; false &\nCMD='echo safe'; eval "$CMD"`,
   ])('allows a stored recipe that nothing executes: %s', (command) => {
     expect(getDesktopShellCommandPolicy(command)).toBeUndefined();
   });
@@ -166,6 +172,9 @@ describeMac('embedded iOS Simulator shell policy', () => {
     // The later text is not a guaranteed replacement when control flow can skip
     // it or keep it inside a child scope, so the earlier value stays possible.
     `CMD='xcrun simctl shutdown DEVICE'; false && CMD='echo safe'; eval "$CMD"`,
+    `CMD='xcrun simctl shutdown DEVICE'; false &&\nCMD='echo safe'; eval "$CMD"`,
+    `CMD='xcrun simctl shutdown DEVICE'; true ||\nCMD='echo safe'; eval "$CMD"`,
+    `CMD='xcrun simctl shutdown DEVICE'; printf ignored |\nCMD='echo safe'; eval "$CMD"`,
     `CMD='xcrun simctl shutdown DEVICE'; (CMD='echo safe'); eval "$CMD"`,
     `CMD='xcrun simctl shutdown DEVICE'; if false; then CMD='echo safe'; fi; eval "$CMD"`,
   ])('denies the current stored recipe at its execution point: %s', (command) => {

--- a/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
@@ -43,7 +43,7 @@ describeMac('embedded iOS Simulator shell policy', () => {
   // still spelled out and still reachable by reading the command word.
   it.each([
     'exec /usr/bin/xcrun simctl shutdown DEVICE',
-    'command -p xcrun simctl boot DEVICE',
+    'command xcrun simctl boot DEVICE',
     'builtin exec xcrun simctl install DEVICE /tmp/App.app',
     'nohup -- xcrun simctl launch DEVICE com.example.app',
     'env FOO=1 /usr/bin/xcrun simctl shutdown DEVICE',
@@ -60,30 +60,17 @@ describeMac('embedded iOS Simulator shell policy', () => {
     'CMD=xcrun\\ simctl\\ shutdown\\ DEVICE; sh -c "$CMD"',
     'CMD=xcrun\\ simctl\\ shutdown\\ DEVICE; $CMD',
     'time xcrun simctl shutdown DEVICE',
-    'time -p xcrun simctl boot DEVICE',
     `function f () ( printf '%s' "$(date)"; /usr/bin/open -a Simulator ); f`,
     '/usr/bin/xcrun \\\n simctl shutdown DEVICE',
     '/usr/bin/nice /usr/bin/xcrun simctl erase DEVICE',
-    '/usr/bin/arch -arm64 /usr/bin/xcrun simctl boot DEVICE',
-    '/usr/bin/caffeinate -i /usr/bin/xcrun simctl shutdown DEVICE',
+    '/usr/bin/arch /usr/bin/xcrun simctl boot DEVICE',
+    '/usr/bin/caffeinate /usr/bin/xcrun simctl shutdown DEVICE',
     'xargs /usr/bin/xcrun simctl shutdown DEVICE',
-    // A prefix option that consumes the next token must not be mistaken for the
-    // command word, or the peel stops short of a recipe spelled out in full.
-    'env -u FOO xcrun simctl shutdown DEVICE',
-    'env --unset=FOO xcrun simctl shutdown DEVICE',
-    'env -C /tmp xcrun simctl shutdown DEVICE',
-    'sudo -u me xcrun simctl shutdown DEVICE',
-    'nice -n 5 xcrun simctl shutdown DEVICE',
-    'timeout -k 5 30 xcrun simctl shutdown DEVICE',
-    'xargs -n 1 xcrun simctl shutdown DEVICE',
-    'arch -arch arm64 xcrun simctl shutdown DEVICE',
-    'caffeinate -t 60 xcrun simctl shutdown DEVICE',
-    // `exec [-cl] [-a name] command …` supplies argv[0] through `-a`, so the
-    // command word is two tokens further on.
-    'exec -a label xcrun simctl shutdown DEVICE',
-    'exec -a label /usr/bin/xcrun simctl boot DEVICE',
-    'exec -cl -a label xcrun simctl erase DEVICE',
+    'timeout 30 xcrun simctl boot DEVICE',
+    'timeout 1.5s gtimeout 2m xcrun simctl erase DEVICE',
     // A shell option that takes a value must not be read as the script operand.
+    // Unlike a prefix, a shell's `-c` scan can only ever miss when it reads an
+    // option wrongly, so the two value-taking options stay modelled here.
     "bash -o pipefail -c 'xcrun simctl shutdown DEVICE'",
     "bash -O extglob -c 'xcrun simctl shutdown DEVICE'",
     "bash +O extglob -c 'xcrun simctl boot DEVICE'",
@@ -101,6 +88,44 @@ describeMac('embedded iOS Simulator shell policy', () => {
     `cat <<'EOF'\r\ntext\r\nEOF\r\nxcrun simctl shutdown DEVICE`,
   ])('denies a literal recipe behind a documentation-style prefix: %s', (command) => {
     expect(getDesktopShellCommandPolicy(command)).toMatchObject({ decision: 'deny' });
+  });
+
+  // ── An option on the prefix ends the peel ──────────────────────────────────
+  //
+  // Each command below was denied while the policy carried a per-prefix table of
+  // which options consume the following token. Maintaining that table meant
+  // encoding two things about every CLI: its option arity, and whether the
+  // operands are executed at all. Getting either wrong denies ordinary work, and
+  // both kept being wrong — `bash -O`, then `command -v`, then `sudo -l`, one per
+  // review round. Stopping at the first option can only miss, so the table is
+  // gone and these forms are missed on purpose.
+  //
+  // Documentation spells a recipe as `sudo xcrun simctl boot …`, not
+  // `sudo -u me xcrun simctl boot …`; the plain spelling of every prefix above is
+  // still covered. All of these were also allowed before the embedded simulator
+  // existed, so this restores that behaviour rather than loosening past it.
+  it.each([
+    'command -p xcrun simctl boot DEVICE',
+    'time -p xcrun simctl boot DEVICE',
+    'env -u FOO xcrun simctl shutdown DEVICE',
+    'env --unset=FOO xcrun simctl shutdown DEVICE',
+    'env -C /tmp xcrun simctl shutdown DEVICE',
+    'sudo -u me xcrun simctl shutdown DEVICE',
+    'sudo --user=me xcrun simctl boot DEVICE',
+    'sudo -g staff xcrun simctl shutdown DEVICE',
+    'nice -n 5 xcrun simctl shutdown DEVICE',
+    'timeout -k 5 30 xcrun simctl shutdown DEVICE',
+    'xargs -n 1 xcrun simctl shutdown DEVICE',
+    'xargs -I{} xcrun simctl boot {}',
+    'arch -arch arm64 xcrun simctl shutdown DEVICE',
+    '/usr/bin/arch -arm64 /usr/bin/xcrun simctl boot DEVICE',
+    'caffeinate -t 60 xcrun simctl shutdown DEVICE',
+    '/usr/bin/caffeinate -i /usr/bin/xcrun simctl shutdown DEVICE',
+    'exec -a label xcrun simctl shutdown DEVICE',
+    'exec -a label /usr/bin/xcrun simctl boot DEVICE',
+    'exec -cl -a label xcrun simctl erase DEVICE',
+  ])('no longer denies a recipe behind an option-bearing prefix: %s', (command) => {
+    expect(getDesktopShellCommandPolicy(command)).toBeUndefined();
   });
 
   // A recipe pasted into an interpreter one-liner is still literal text.
@@ -328,12 +353,21 @@ check()
     'sh ./run.sh -c "xcrun simctl boot DEVICE"',
     "zsh tools/x.zsh -c 'open -a Simulator'",
     'bash ./build.sh --release',
-    // `command -v` / `-V` describe their operands; nothing is executed, so the
-    // operands must not be reclassified as the invocation they name.
+    // Some prefixes only report on the command they name. `command -v` prints
+    // where it lives and `sudo -l` asks whether it would be permitted; neither
+    // runs it. Ending the peel at the option covers them without the policy
+    // having to know which prefixes behave this way.
     'command -v simctl shutdown',
     'command -V simctl',
     'command -v xcrun simctl',
     'command -pv simctl boot',
+    'sudo -l xcrun simctl boot DEVICE',
+    'sudo --list xcrun simctl shutdown DEVICE',
+    // The same rule keeps ordinary option-bearing work out of the guard.
+    'sudo -u postgres psql -c "select 1"',
+    'env -u NODE_OPTIONS pnpm test',
+    'timeout -k 5 30 pnpm build',
+    'nice -n 10 make -j8',
     'export PATH=/usr/bin:$PATH; echo ok',
   ])('allows an ordinary command whose shape is not an executable: %s', (command) => {
     expect(getDesktopShellCommandPolicy(command)).toBeUndefined();

--- a/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
@@ -335,4 +335,32 @@ SH`,
   ])('denies a Simulator executor assembled from string fragments: %s', (command) => {
     expect(getDesktopShellCommandPolicy(command)).toMatchObject({ decision: 'deny' });
   });
+
+  // Only the basename selects the executable, and a literal fragment of an
+  // executor name can be completed by the expansion next to it. Both stay
+  // fail-closed even though no whole Simulator word appears.
+  it.each([
+    'xcr$TAIL boot DEVICE',
+    'sim$TAIL shutdown DEVICE',
+    'xc$TAIL boot DEVICE',
+    '${DIR}crun boot DEVICE',
+    'simct$TAIL shutdown DEVICE',
+    'sim* shutdown DEVICE',
+    '$DIR/build/$NAME --version',
+    '"$PWD/build/$NAME" --version',
+    '$DIR/simctl/$SUB shutdown DEVICE',
+  ])('denies a command word whose executable name cannot be resolved: %s', (command) => {
+    expect(getDesktopShellCommandPolicy(command)).toMatchObject({ decision: 'deny' });
+  });
+
+  // The deliberate boundary of the narrowing: the executable name is knowable
+  // and is not a Simulator executor, so denying it would be a guess about the
+  // expansion rather than a product rule. Documented in the PR description.
+  it.each([
+    '$DIR/build/tool --version',
+    'tool$SUFFIX --version',
+    'build$SUFFIX --version',
+  ])('allows a resolvable non-Simulator executable name: %s', (command) => {
+    expect(getDesktopShellCommandPolicy(command)).toBeUndefined();
+  });
 });

--- a/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
@@ -225,6 +225,16 @@ SH`,
     `cat <<'SH' | env FOO=1 bash
 xcrun simctl erase DEVICE
 SH`,
+    // A trailing pipeline operator continues onto the next physical line. The
+    // continuation command is executable shell syntax, not heredoc body data.
+    `cat <<'SH' |
+xcrun simctl shutdown DEVICE
+SH`,
+    // The same multiline pipeline still hands the eventual body to bash.
+    `cat <<'SH' |
+bash
+xcrun simctl shutdown DEVICE
+SH`,
     `cat <<'SH' | bash | cat
 open -a Simulator
 SH`,
@@ -396,6 +406,12 @@ EOF`,
 xcrun simctl shutdown DEVICE
 open -a Simulator
 EOF`,
+    // A multiline pipeline can consume a heredoc as ordinary data. Once the
+    // continuation command is retained, the data body must still disappear.
+    `cat <<'DATA' |
+wc -l
+xcrun simctl shutdown DEVICE
+DATA`,
     // A commit message written through a heredoc is stdin data, never argv. A
     // line starting with a Markdown backtick span used to read as an executable
     // position filled by an unresolvable expansion, which denied the commit and

--- a/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
@@ -246,4 +246,93 @@ PY`,
   ])('allows a non-bypass command: %s', (command) => {
     expect(getDesktopShellCommandPolicy(command)).toBeUndefined();
   });
+
+  // A heredoc body, an inline interpreter program and an arithmetic expression
+  // are not shell argv. Classifying their contents as command words denied
+  // ordinary work with no Simulator executor anywhere in the command.
+  it.each([
+    // Ordinary HTTPS read through a Python heredoc (issue #2404).
+    `python3 - <<'PY'
+import urllib.request
+data = urllib.request.urlopen("https://example.com").read()
+print(len(data))
+PY`,
+    `python3 - <<'PY'
+print(1)
+PY`,
+    `python3 - <<'PY'
+def main():
+    print("hi")
+main()
+PY`,
+    `node <<'JS'
+console.log(1)
+JS`,
+    `sqlite3 /tmp/app.db <<'SQL'
+SELECT count(*) FROM items;
+SQL`,
+    `jq . <<'JSON'
+{"a": 1}
+JSON`,
+    `cat > /tmp/notes.txt <<'EOF'
+hello (world)
+EOF`,
+    `node -e "
+function check() {
+  console.log(1);
+}
+check();
+"`,
+    `python3 -c "
+def check():
+    print(1)
+check()
+"`,
+  ])('allows an ordinary interpreter heredoc or inline program: %s', (command) => {
+    expect(getDesktopShellCommandPolicy(command)).toBeUndefined();
+  });
+
+  it.each([
+    'n=3; (( n > 1 )) && echo yes',
+    'i=0; (( i++ )); echo "$i"',
+    '(( $# > 0 )) && echo has-args',
+    '(( $? == 0 )) && echo ok',
+    'i=0; while (( i < 3 )); do echo "$i"; i=$((i+1)); done',
+    'if (( count > 0 )); then echo ready; fi',
+  ])('allows shell arithmetic with no Simulator evidence: %s', (command) => {
+    expect(getDesktopShellCommandPolicy(command)).toBeUndefined();
+  });
+
+  it.each([
+    'echo start\n*.ts\necho done',
+    // A redirected group leaves `}` in command position, which is a shell
+    // control token, not a glob-expanded executable name.
+    '{ echo a; echo b; } > /tmp/out.log 2>&1',
+    '{ pnpm build; pnpm test; } 2>&1 | tee /tmp/build.log',
+    '( cd /tmp && ls ) > /tmp/out.txt',
+    'expected=200; actual=$(curl -s -o /dev/null -w \'%{http_code}\' https://example.com); if [ "$expected" != "$actual" ]; then echo bad; fi',
+    'rg -n "Rejected\\((.*)\\)" apps',
+    "rg -n foo --glob '*.{ts,tsx}' apps",
+    'grep -rEn "(foo|bar)" apps',
+    "awk '{print $1}' /tmp/app.log",
+  ])('allows an ordinary command whose shape is not an executable: %s', (command) => {
+    expect(getDesktopShellCommandPolicy(command)).toBeUndefined();
+  });
+
+  // Evidence matching undoes the concatenation an interpreter would perform, so
+  // narrowing the shape-only rules above does not open a fragment bypass.
+  it.each([
+    `python3 -c 'import os; os.system("xcr" + "un" + " sim" + "ctl shutdown DEVICE")'`,
+    `node -e 'require("child_process").execSync("xcr" + "un" + " sim" + "ctl shutdown DEVICE")'`,
+    `python3 - <<'PY'
+import os
+os.system("xcr" + "un" + " sim" + "ctl shutdown DEVICE")
+PY`,
+    `bash <<'SH'
+xcr"un" sim"ctl" shutdown DEVICE
+SH`,
+    `awk 'BEGIN { system("xcr" "un" " sim" "ctl shutdown DEVICE") }'`,
+  ])('denies a Simulator executor assembled from string fragments: %s', (command) => {
+    expect(getDesktopShellCommandPolicy(command)).toMatchObject({ decision: 'deny' });
+  });
 });

--- a/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
@@ -349,7 +349,27 @@ SH`,
     '$DIR/build/$NAME --version',
     '"$PWD/build/$NAME" --version',
     '$DIR/simctl/$SUB shutdown DEVICE',
+    // A substitution can supply characters in the middle of the name, and the
+    // tokenizer splits on the whitespace inside it, so the command word arrives
+    // as an unterminated remnant. Contiguity is not a safe test here.
+    'si$(printf m)ctl shutdown DEVICE',
+    'sim$(printf c)tl shutdown DEVICE',
+    'x$(printf c)run simctl shutdown DEVICE',
+    'sim`printf c`tl shutdown DEVICE',
   ])('denies a command word whose executable name cannot be resolved: %s', (command) => {
+    expect(getDesktopShellCommandPolicy(command)).toMatchObject({ decision: 'deny' });
+  });
+
+  // Interpreters join sequences as well as concatenating with an operator.
+  // This is a finite set of forms by construction: a payload can still assemble
+  // a name from character codes or base64, which command text cannot decide.
+  it.each([
+    `python3 - <<'PY'
+import os
+os.system(''.join(('xc','run')) + ' ' + ''.join(('sim','ctl')) + ' shutdown DEVICE')
+PY`,
+    `python3 -c "import os; os.system(''.join(['xc','run']) + ' simctl shutdown DEVICE')"`,
+  ])('denies an executor joined from a sequence of fragments: %s', (command) => {
     expect(getDesktopShellCommandPolicy(command)).toMatchObject({ decision: 'deny' });
   });
 

--- a/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
@@ -67,6 +67,22 @@ describeMac('embedded iOS Simulator shell policy', () => {
     '/usr/bin/arch -arm64 /usr/bin/xcrun simctl boot DEVICE',
     '/usr/bin/caffeinate -i /usr/bin/xcrun simctl shutdown DEVICE',
     'xargs /usr/bin/xcrun simctl shutdown DEVICE',
+    // A prefix option that consumes the next token must not be mistaken for the
+    // command word, or the peel stops short of a recipe spelled out in full.
+    'env -u FOO xcrun simctl shutdown DEVICE',
+    'env --unset=FOO xcrun simctl shutdown DEVICE',
+    'env -C /tmp xcrun simctl shutdown DEVICE',
+    'sudo -u me xcrun simctl shutdown DEVICE',
+    'nice -n 5 xcrun simctl shutdown DEVICE',
+    'timeout -k 5 30 xcrun simctl shutdown DEVICE',
+    'xargs -n 1 xcrun simctl shutdown DEVICE',
+    'arch -arch arm64 xcrun simctl shutdown DEVICE',
+    'caffeinate -t 60 xcrun simctl shutdown DEVICE',
+    // Removing heredoc region reduction also removed the ways it could swallow a
+    // real recipe: a marker inside a comment, and a CRLF delimiter that never
+    // matched. Body lines are now ordinary segments.
+    `echo hi # <<'EOF'\nxcrun simctl shutdown DEVICE`,
+    `cat <<'EOF'\r\ntext\r\nEOF\r\nxcrun simctl shutdown DEVICE`,
   ])('denies a literal recipe behind a documentation-style prefix: %s', (command) => {
     expect(getDesktopShellCommandPolicy(command)).toMatchObject({ decision: 'deny' });
   });
@@ -446,6 +462,16 @@ PY`,
     'tool$SUFFIX --version',
     'build$SUFFIX --version',
   ])('allows a resolvable non-Simulator executable name: %s', (command) => {
+    expect(getDesktopShellCommandPolicy(command)).toBeUndefined();
+  });
+
+  // Adjacent string literals are data, not a join. Folding them used to fabricate
+  // an executor name out of ordinary interpreter code.
+  it.each([
+    `python3 -c 'print("xcr", "un")'`,
+    `node -e 'console.log(["sim", "ctl"])'`,
+    `python3 -c 'print(["sim","ctl"])'`,
+  ])('allows adjacent string literals that merely look like fragments: %s', (command) => {
     expect(getDesktopShellCommandPolicy(command)).toBeUndefined();
   });
 });

--- a/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
@@ -78,6 +78,13 @@ describeMac('embedded iOS Simulator shell policy', () => {
     'xargs -n 1 xcrun simctl shutdown DEVICE',
     'arch -arch arm64 xcrun simctl shutdown DEVICE',
     'caffeinate -t 60 xcrun simctl shutdown DEVICE',
+    // `exec [-cl] [-a name] command …` supplies argv[0] through `-a`, so the
+    // command word is two tokens further on.
+    'exec -a label xcrun simctl shutdown DEVICE',
+    'exec -a label /usr/bin/xcrun simctl boot DEVICE',
+    'exec -cl -a label xcrun simctl erase DEVICE',
+    // A shell option that takes a value must not be read as the script operand.
+    "bash -o pipefail -c 'xcrun simctl shutdown DEVICE'",
     // Removing heredoc region reduction also removed the ways it could swallow a
     // real recipe: a marker inside a comment, and a CRLF delimiter that never
     // matched. Body lines are now ordinary segments.
@@ -306,6 +313,12 @@ check()
     "awk '{print $1}' /tmp/app.log",
     'ls /tmp/[abc]*.log',
     'cp file.{ts,ts.bak}',
+    // Options after the script operand belong to the script, not to the shell.
+    // Reading them as a shell program denied ordinary work and interrupted it.
+    "bash ./print-args.sh -c 'xcrun simctl shutdown DEVICE'",
+    'sh ./run.sh -c "xcrun simctl boot DEVICE"',
+    "zsh tools/x.zsh -c 'open -a Simulator'",
+    'bash ./build.sh --release',
   ])('allows an ordinary command whose shape is not an executable: %s', (command) => {
     expect(getDesktopShellCommandPolicy(command)).toBeUndefined();
   });

--- a/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
@@ -238,6 +238,9 @@ SH`,
     `cat <<'SH' | bash 2>/dev/null
 open -a Simulator
 SH`,
+    `printf '<<SH'; cat <<SH | bash
+xcrun simctl shutdown DEVICE
+SH`,
     // A non-zero fd redirection leaves stdin connected to the pipeline, so the
     // downstream shell still executes the producer's body.
     `cat <<'DATA' | bash 2<err

--- a/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
@@ -89,6 +89,8 @@ describeMac('embedded iOS Simulator shell policy', () => {
     // following command, and CRLF delimiters must end the data region correctly.
     `echo hi # <<'EOF'\nxcrun simctl shutdown DEVICE`,
     `cat <<'EOF'\r\ntext\r\nEOF\r\nxcrun simctl shutdown DEVICE`,
+    `cat <<$'EOF' >/dev/null\ntext\nEOF\nxcrun simctl shutdown DEVICE`,
+    `cat <<$"EOF" >/dev/null\ntext\nEOF\nxcrun simctl shutdown DEVICE`,
     // Arithmetic left-shift uses the same `<<` spelling as a heredoc opener;
     // it must not make the following command look like a body for delimiter 2.
     `echo $((1 << 2))\nxcrun simctl shutdown DEVICE`,
@@ -165,11 +167,6 @@ eval "$CMD"`,
     // A command-scoped assignment shadows the exported parent value only for
     // that child command.
     `CMD='xcrun simctl shutdown DEVICE'; CMD='echo safe' sh -c '$CMD'`,
-    // A direct unset in the current shell removes the stored value before the
-    // later execution point. Cover the variable-selecting and `--` spellings.
-    `CMD='xcrun simctl shutdown DEVICE'; unset CMD; eval "$CMD"`,
-    `CMD='xcrun simctl shutdown DEVICE'; unset -v CMD; eval "$CMD"`,
-    `CMD='xcrun simctl shutdown DEVICE'; command unset -- CMD; eval "$CMD"`,
   ])('allows a stored recipe that nothing executes: %s', (command) => {
     expect(getDesktopShellCommandPolicy(command)).toBeUndefined();
   });
@@ -198,16 +195,6 @@ eval "$CMD"`,
     `CMD='xcrun simctl shutdown DEVICE'; CMD='echo safe' | /usr/bin/cat; eval "$CMD"`,
     `CMD='xcrun simctl shutdown DEVICE'; (CMD='echo safe'); eval "$CMD"`,
     `CMD='xcrun simctl shutdown DEVICE'; if false; then CMD='echo safe'; fi; eval "$CMD"`,
-    // Conditional and child-scope unsets do not prove that the parent value was
-    // removed. Function-only unset leaves the variable intact as well.
-    `CMD='xcrun simctl shutdown DEVICE'; false && unset CMD; eval "$CMD"`,
-    `CMD='xcrun simctl shutdown DEVICE'; unset CMD | /usr/bin/cat; eval "$CMD"`,
-    `CMD='xcrun simctl shutdown DEVICE'; (unset CMD); eval "$CMD"`,
-    `CMD='xcrun simctl shutdown DEVICE'; unset -f CMD; eval "$CMD"`,
-    // Readonly variables survive an attempted unset, including declaration
-    // builtins that attach the readonly attribute with an option.
-    `readonly CMD='xcrun simctl shutdown DEVICE'; unset CMD; eval "$CMD"`,
-    `declare -r CMD='xcrun simctl shutdown DEVICE'; unset -v CMD; eval "$CMD"`,
   ])('denies the current stored recipe at its execution point: %s', (command) => {
     expect(getDesktopShellCommandPolicy(command)).toMatchObject({ decision: 'deny' });
   });
@@ -234,21 +221,15 @@ eval "$CMD"`,
     `cat <<'SH' | sh
 xcrun simctl boot DEVICE
 SH`,
+    `cat <<'SH' |
+echo safe
+SH
+xcrun simctl shutdown DEVICE`,
     `cat <<'SH' | bash -s
 xcrun simctl shutdown DEVICE
 SH`,
     `cat <<'SH' | env FOO=1 bash
 xcrun simctl erase DEVICE
-SH`,
-    // A trailing pipeline operator continues onto the next physical line. The
-    // continuation command is executable shell syntax, not heredoc body data.
-    `cat <<'SH' |
-xcrun simctl shutdown DEVICE
-SH`,
-    // The same multiline pipeline still hands the eventual body to bash.
-    `cat <<'SH' |
-bash
-xcrun simctl shutdown DEVICE
 SH`,
     `cat <<'SH' | bash | cat
 open -a Simulator
@@ -294,6 +275,15 @@ DATA`,
 xcrun simctl shutdown DEVICE
 DATA`,
     `cat <<'SH' | bash -s $((1 << 2))
+xcrun simctl shutdown DEVICE
+SH`,
+    `cat <<'SH' | bash -s $[1 << 2]
+xcrun simctl shutdown DEVICE
+SH`,
+    `cat <<'SH' | bash -o pipefail
+xcrun simctl shutdown DEVICE
+SH`,
+    `cat <<'SH' | bash -O extglob
 xcrun simctl shutdown DEVICE
 SH`,
     `cat <<'DATA' | bash -s $(printf foo < /tmp/x)
@@ -421,12 +411,18 @@ EOF`,
 xcrun simctl shutdown DEVICE
 open -a Simulator
 EOF`,
-    // A multiline pipeline can consume a heredoc as ordinary data. Once the
-    // continuation command is retained, the data body must still disappear.
+    // A trailing pipe does not make the next physical line a consumer: it is
+    // still heredoc body data. The command after the delimiter is separate.
+    `cat <<'SH' |
+xcrun simctl shutdown DEVICE
+SH
+bash`,
     `cat <<'DATA' |
-wc -l
 xcrun simctl shutdown DEVICE
 DATA`,
+    `cat <<$'EOF' >/dev/null
+xcrun simctl shutdown DEVICE
+EOF`,
     // A commit message written through a heredoc is stdin data, never argv. A
     // line starting with a Markdown backtick span used to read as an executable
     // position filled by an unresolvable expansion, which denied the commit and

--- a/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
@@ -146,8 +146,27 @@ describeMac('embedded iOS Simulator shell policy', () => {
     `readonly DOC='run xcrun simctl boot DEVICE to start'; printf '%s' "$DOC"`,
     // A different name reaches the execution site, so this value never runs.
     `CMD='xcrun simctl boot DEVICE'; eval "$OTHER"`,
+    // The execution point sees the latest value, not the complete assignment
+    // history. The stored recipe was replaced before anything ran it.
+    `CMD='xcrun simctl shutdown DEVICE'; CMD='echo safe'; eval "$CMD"`,
+    `CMD='xcrun simctl shutdown DEVICE'; CMD='echo safe'; eval "$CMD" 2>&1`,
+    `CMD='xcrun simctl shutdown DEVICE'; echo if; CMD='echo safe'; eval "$CMD"`,
+    `CMD='xcrun simctl shutdown DEVICE' && true; CMD='echo safe'; eval "$CMD"`,
   ])('allows a stored recipe that nothing executes: %s', (command) => {
     expect(getDesktopShellCommandPolicy(command)).toBeUndefined();
+  });
+
+  it.each([
+    `CMD='xcrun simctl shutdown DEVICE'; eval "$CMD"; CMD='echo safe'`,
+    `CMD='echo safe'; CMD='xcrun simctl shutdown DEVICE'; eval "$CMD"`,
+    `CMD='xcrun simctl shutdown DEVICE'; OTHER='echo safe'; eval "$CMD"`,
+    // The later text is not a guaranteed replacement when control flow can skip
+    // it or keep it inside a child scope, so the earlier value stays possible.
+    `CMD='xcrun simctl shutdown DEVICE'; false && CMD='echo safe'; eval "$CMD"`,
+    `CMD='xcrun simctl shutdown DEVICE'; (CMD='echo safe'); eval "$CMD"`,
+    `CMD='xcrun simctl shutdown DEVICE'; if false; then CMD='echo safe'; fi; eval "$CMD"`,
+  ])('denies the current stored recipe at its execution point: %s', (command) => {
+    expect(getDesktopShellCommandPolicy(command)).toMatchObject({ decision: 'deny' });
   });
 
   // A recipe pasted into an interpreter one-liner is still literal text.

--- a/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
@@ -85,9 +85,8 @@ describeMac('embedded iOS Simulator shell policy', () => {
     `declare CMD='open -a Simulator'; eval "$CMD"`,
     `typeset CMD='xcrun simctl erase DEVICE'; eval "$CMD"`,
     `export -p CMD='xcrun simctl boot DEVICE'; eval "$CMD"`,
-    // Removing heredoc region reduction also removed the ways it could swallow a
-    // real recipe: a marker inside a comment, and a CRLF delimiter that never
-    // matched. Body lines are now ordinary segments.
+    // Heredoc reduction must not let a fake marker in a comment swallow a real
+    // following command, and CRLF delimiters must end the data region correctly.
     `echo hi # <<'EOF'\nxcrun simctl shutdown DEVICE`,
     `cat <<'EOF'\r\ntext\r\nEOF\r\nxcrun simctl shutdown DEVICE`,
   ])('denies a literal recipe behind a documentation-style prefix: %s', (command) => {
@@ -206,6 +205,12 @@ SH`,
     `cat <<'SH' | bash -s
 xcrun simctl shutdown DEVICE
 SH`,
+    `cat <<'SH' | env FOO=1 bash
+xcrun simctl erase DEVICE
+SH`,
+    `cat <<'SH' | bash | cat
+open -a Simulator
+SH`,
     // An unquoted delimiter still expands, so the body's substitutions run.
     `cat <<MSG
 $(xcrun simctl boot DEVICE)
@@ -320,6 +325,14 @@ JSON`,
     `cat > /tmp/notes.txt <<'EOF'
 hello (world)
 EOF`,
+    `cat > README.md <<'EOF'
+xcrun simctl shutdown DEVICE
+open -a Simulator
+EOF`,
+    `cat > README.md <<EOF
+xcrun simctl shutdown DEVICE
+open -a Simulator
+EOF`,
     // A commit message written through a heredoc is stdin data, never argv. A
     // line starting with a Markdown backtick span used to read as an executable
     // position filled by an unresolvable expansion, which denied the commit and
@@ -332,6 +345,12 @@ fix(scope): 收窄判据
 MSG`,
     `git commit -F - <<'MSG'
 \`ls\`
+MSG`,
+    `git commit -F - <<'MSG'
+xcrun simctl shutdown DEVICE
+MSG`,
+    `git commit -F - <<MSG
+xcrun simctl shutdown DEVICE
 MSG`,
     // A quoted delimiter suppresses expansion in every spelling, and `<<-`
     // strips leading tabs from the body and the closing delimiter.

--- a/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
@@ -178,6 +178,21 @@ PY`,
     `bash -c 'source /dev/stdin' <<< 'xcrun simctl shutdown DEVICE'`,
     `bash -c 'eval "$(cat)"' <<< 'xcrun simctl shutdown DEVICE'`,
     `printf 'xcrun simctl shutdown DEVICE' | bash -c 'eval "$(cat)"'`,
+    // The consumer can also follow the marker, so the heredoc's own pipeline —
+    // not just the text before `<<` — decides whether the body is executable.
+    `cat <<'SH' | sh
+xcrun simctl boot DEVICE
+SH`,
+    `cat <<'SH' | bash -s
+xcrun simctl shutdown DEVICE
+SH`,
+    // An unquoted delimiter still expands, so the body's substitutions run.
+    `cat <<MSG
+$(xcrun simctl boot DEVICE)
+MSG`,
+    `cat <<MSG
+\`xcrun simctl shutdown DEVICE\`
+MSG`,
   ])('denies Simulator mutation hidden behind a programmable interpreter: %s', (command) => {
     expect(getDesktopShellCommandPolicy(command)).toMatchObject({ decision: 'deny' });
   });
@@ -277,6 +292,46 @@ JSON`,
     `cat > /tmp/notes.txt <<'EOF'
 hello (world)
 EOF`,
+    // A commit message written through a heredoc is stdin data, never argv. A
+    // line starting with a Markdown backtick span used to read as an executable
+    // position filled by an unresolvable expansion, which denied the commit and
+    // interrupted the turn — with no Simulator executor anywhere in the command.
+    `git commit -s -F - <<'MSG'
+fix(scope): 收窄判据
+
+验证：\`pnpm --filter desktop typecheck\` 通过，\`@cindy/ios-simulator-runtime\` 36 文件
+\`pnpm test:unit\` 全绿
+MSG`,
+    `git commit -F - <<'MSG'
+\`ls\`
+MSG`,
+    // A quoted delimiter suppresses expansion in every spelling, and `<<-`
+    // strips leading tabs from the body and the closing delimiter.
+    `git commit -F - <<"MSG"
+\`ls\`
+MSG`,
+    `git commit -F - <<\\MSG
+\`ls\`
+MSG`,
+    `git commit -F - <<-'MSG'
+\t\`ls\`
+\tMSG`,
+    // An unquoted delimiter expands, but running `ls` to build the body is not a
+    // Simulator bypass; only the substitution's own command is classified.
+    `git commit -F - <<MSG
+\`ls\` 通过
+MSG`,
+    `cat <<'A' > /tmp/a && cat <<'B' > /tmp/b
+\`ls\`
+A
+\`pwd\`
+B`,
+    // An unterminated body must not fall back to argv classification either.
+    `git commit -F - <<'MSG'
+\`ls\``,
+    `git commit -F - <<'MSG'
+说明：不要直接用 simctl，走 cindy_ios_simulator
+MSG`,
     `node -e "
 function check() {
   console.log(1);

--- a/apps/desktop/src/main/maker-host/shell-command-policy.ts
+++ b/apps/desktop/src/main/maker-host/shell-command-policy.ts
@@ -655,6 +655,7 @@ function consumesStdinAsProgram(tokens: string[]): boolean {
 }
 
 interface HeredocRedirection {
+  start: number;
   marker: string;
   delimiter: string;
   expands: boolean;
@@ -770,7 +771,13 @@ function heredocRedirections(line: string): HeredocRedirection[] {
       cursor += 1;
     }
     if (delimiter !== '') {
-      redirections.push({ marker: line.slice(index, cursor), delimiter, expands, stripsTabs });
+      redirections.push({
+        start: index,
+        marker: line.slice(index, cursor),
+        delimiter,
+        expands,
+        stripsTabs,
+      });
     }
     index = cursor - 1;
   }
@@ -883,9 +890,15 @@ function hasUnquotedStdinRedirection(segment: string): boolean {
 }
 
 /** Whether the heredoc's own clause hands its body to a code-reading consumer. */
-function heredocBodyIsProgram(line: string, marker: string): boolean {
+function heredocBodyIsProgram(line: string, marker: string, markerStart: number): boolean {
   const segments = shellSegments(line);
-  const openingIndex = segments.findIndex((segment) => segment.command.includes(marker));
+  let searchCursor = 0;
+  const openingIndex = segments.findIndex((segment) => {
+    const segmentStart = line.indexOf(segment.command, searchCursor);
+    if (segmentStart < 0) return false;
+    searchCursor = segmentStart + segment.command.length;
+    return markerStart >= segmentStart && markerStart < searchCursor;
+  });
   if (openingIndex < 0) return false;
   for (let index = openingIndex; index < segments.length; index += 1) {
     const segment = segments[index]!;
@@ -924,7 +937,7 @@ function stripHeredocBodies(command: string): string {
         if (unindented === heredoc.delimiter) break;
         body.push(candidate);
       }
-      if (heredocBodyIsProgram(line, heredoc.marker)) executable.push(...body);
+      if (heredocBodyIsProgram(line, heredoc.marker, heredoc.start)) executable.push(...body);
       else if (heredoc.expands) executable.push(...shellSubcommands(body.join('\n')));
       if (index >= lines.length) break;
     }

--- a/apps/desktop/src/main/maker-host/shell-command-policy.ts
+++ b/apps/desktop/src/main/maker-host/shell-command-policy.ts
@@ -1247,13 +1247,7 @@ function containsInterpreterHeredocBypass(command: string): boolean {
     const line = lines[index] ?? '';
     const marker = /<<-?\s*(['"]?)([A-Za-z_][A-Za-z0-9_]*)\1/.exec(line);
     if (!marker) continue;
-    if (
-      !shellSegments(line.slice(0, marker.index)).some((segment) =>
-        consumesStdinAsProgram(tokenizeShellSegment(segment)),
-      )
-    ) {
-      continue;
-    }
+    if (!heredocBodyIsProgram(line, marker[0]!)) continue;
     const delimiter = marker[2]!;
     const body: string[] = [];
     for (index += 1; index < lines.length; index += 1) {
@@ -1432,19 +1426,154 @@ function containsSimulatorAliasDefinition(
   return false;
 }
 
+type HeredocRedirection = {
+  marker: string;
+  delimiter: string;
+  expands: boolean;
+  stripsTabs: boolean;
+};
+
+/**
+ * Whether the clause opening a heredoc hands the body to a program that runs it.
+ *
+ * The consumer can sit on either side of the marker: `python3 <<'PY'` reads the
+ * body directly, `cat <<'SH' | sh` pipes it into a shell. The search is scoped to
+ * the heredoc's own clause so a `;`-separated interpreter, which reads the
+ * terminal rather than this body, is not mistaken for its consumer, and the
+ * redirection itself is dropped so it cannot read as the interpreter's
+ * positional program argument.
+ */
+function heredocBodyIsProgram(line: string, marker: string): boolean {
+  const opening = shellClauses(line).find((candidate) => candidate.includes(marker)) ?? line;
+  const clause = opening.replace(marker, ' ');
+  return shellSegments(clause).some((segment) =>
+    consumesStdinAsProgram(tokenizeShellSegment(segment)),
+  );
+}
+
+/**
+ * Heredoc redirections opened on one line, skipping `<<` inside quotes and the
+ * `<<<` here-string operator (classified separately). Quoting or escaping any
+ * part of the delimiter disables expansion of the body, which is what decides
+ * whether anything in that body can reach the shell at all.
+ */
+function heredocRedirections(line: string): HeredocRedirection[] {
+  const redirections: HeredocRedirection[] = [];
+  let quote: "'" | '"' | null = null;
+  let escaped = false;
+  for (let index = 0; index < line.length; index += 1) {
+    const char = line[index]!;
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (char === '\\' && quote !== "'") {
+      escaped = true;
+      continue;
+    }
+    if (char === "'" || char === '"') {
+      if (quote === char) quote = null;
+      else if (quote === null) quote = char;
+      continue;
+    }
+    if (quote || char !== '<' || line[index + 1] !== '<') continue;
+    if (line[index + 2] === '<') {
+      index += 2;
+      continue;
+    }
+    let cursor = index + 2;
+    const stripsTabs = line[cursor] === '-';
+    if (stripsTabs) cursor += 1;
+    while (line[cursor] === ' ' || line[cursor] === '\t') cursor += 1;
+    let delimiter = '';
+    let expands = true;
+    while (cursor < line.length) {
+      const delimiterChar = line[cursor]!;
+      if (delimiterChar === "'" || delimiterChar === '"') {
+        expands = false;
+        const closing = line.indexOf(delimiterChar, cursor + 1);
+        if (closing < 0) {
+          delimiter += line.slice(cursor + 1);
+          cursor = line.length;
+          break;
+        }
+        delimiter += line.slice(cursor + 1, closing);
+        cursor = closing + 1;
+        continue;
+      }
+      if (delimiterChar === '\\') {
+        expands = false;
+        cursor += 1;
+        if (cursor < line.length) {
+          delimiter += line[cursor]!;
+          cursor += 1;
+        }
+        continue;
+      }
+      if (/[\s;&|<>()]/.test(delimiterChar)) break;
+      delimiter += delimiterChar;
+      cursor += 1;
+    }
+    if (delimiter !== '') {
+      redirections.push({ marker: line.slice(index, cursor), delimiter, expands, stripsTabs });
+    }
+    index = cursor - 1;
+  }
+  return redirections;
+}
+
+/**
+ * Reduce heredoc bodies to the text that can actually reach a command position.
+ *
+ * A body handed to an interpreter or shell *is* a program, so it stays verbatim —
+ * that is what lets a fragment-assembled executor inside `python3 <<'PY'` still be
+ * classified. A body handed to anything else is stdin data and never argv, so
+ * classifying its lines as command words denies ordinary work: a commit message
+ * line starting with a Markdown backtick span reads as an executable position
+ * filled by an unresolvable expansion. Such a body is dropped, except that an
+ * unquoted delimiter still runs the body's command substitutions, so those are
+ * kept while the surrounding prose is not.
+ */
+function stripHeredocBodies(command: string): string {
+  if (!command.includes('<<')) return command;
+  const lines = command.split('\n');
+  const executable: string[] = [];
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index]!;
+    executable.push(line);
+    for (const heredoc of heredocRedirections(line)) {
+      const body: string[] = [];
+      index += 1;
+      for (; index < lines.length; index += 1) {
+        const candidate = lines[index]!;
+        const unindented = heredoc.stripsTabs ? candidate.replace(/^\t+/, '') : candidate;
+        if (unindented === heredoc.delimiter) break;
+        body.push(candidate);
+      }
+      if (heredocBodyIsProgram(line, heredoc.marker)) executable.push(...body);
+      else if (heredoc.expands) executable.push(...shellSubcommands(body.join('\n')));
+      if (index >= lines.length) break;
+    }
+  }
+  return executable.join('\n');
+}
+
 function containsSimulatorBypass(command: string, evidence: boolean, depth = 0): boolean {
   if (depth > 8) return /\b(?:simctl|Simulator(?:\.app)?)\b/i.test(command);
+  // Interpreter payloads are read from the unmodified command; every other rule
+  // below classifies command words, so it must not see heredoc body prose.
+  const argv = stripHeredocBodies(command);
   if (
-    containsTaintedVariableExecution(command) ||
+    containsTaintedVariableExecution(argv) ||
     containsShellConsumedLiteralBypass(command) ||
-    containsSimulatorFunctionBody(command, evidence, depth)
+    containsSimulatorFunctionBody(argv, evidence, depth)
   ) {
     return true;
   }
-  for (const nested of shellSubcommands(command)) {
+  for (const nested of shellSubcommands(argv)) {
     if (containsSimulatorBypass(nested, evidence, depth + 1)) return true;
   }
-  for (const segment of shellSegments(command)) {
+  for (const segment of shellSegments(argv)) {
     // Function bodies were classified recursively above. The leading
     // `name(){` token is not an execution wrapper in its own right.
     if (SHELL_FUNCTION_DEFINITION_PREFIX.test(segment)) {

--- a/apps/desktop/src/main/maker-host/shell-command-policy.ts
+++ b/apps/desktop/src/main/maker-host/shell-command-policy.ts
@@ -677,12 +677,25 @@ function commandWordLiteralCore(token: string): string {
     .replace(/['"]/g, '');
 }
 
-/** A word made only of expansions can resolve to anything, including simctl. */
+/**
+ * A word whose executable *name* is made only of expansions can resolve to
+ * anything, including simctl. Only the basename selects the executable, so a
+ * knowable directory prefix does not make a dynamic name provable:
+ * `$DIR/build/$NAME` is as unknowable as `$NAME`.
+ */
 function isPureExpansionWord(token: string): boolean {
-  return /[$`]/.test(token) && commandWordLiteralCore(token).replace(/[\s/=,.:+-]/g, '') === '';
+  if (!/[$`]/.test(token)) return false;
+  const core = commandWordLiteralCore(token).replace(/\\/g, '/');
+  const basename = core.slice(core.lastIndexOf('/') + 1);
+  return basename.replace(/[\s=,.:+-]/g, '') === '';
 }
 
-/** `simct?`, `simctl~foo`, `xc[r]un`: a literal core that still names the boundary. */
+/**
+ * A literal core that still points at the boundary, either because it already
+ * carries most of the name (`simct?`, `simctl~foo`, `xc[r]un`) or because it is
+ * a fragment of one that the stripped expansion could complete (`xcr$TAIL`,
+ * `${DIR}crun`, `sim*`).
+ */
 function isSimulatorFragmentCore(core: string): boolean {
   // Trailing separators are left behind by stripped expansions (`$X/simctl/$Y`),
   // so classify against the last segment that still carries literal text.
@@ -694,12 +707,10 @@ function isSimulatorFragmentCore(core: string): boolean {
       .at(-1) ?? ''
   ).toLowerCase();
   if (!name) return false;
-  return SIMULATOR_EXECUTOR_NAMES.some((executor) => {
-    for (let length = executor.length; length >= MIN_SIMULATOR_FRAGMENT_LENGTH; length -= 1) {
-      if (name.startsWith(executor.slice(0, length))) return true;
-    }
-    return false;
-  });
+  return SIMULATOR_EXECUTOR_NAMES.some(
+    (executor) =>
+      name.startsWith(executor.slice(0, MIN_SIMULATOR_FRAGMENT_LENGTH)) || executor.includes(name),
+  );
 }
 
 /**

--- a/apps/desktop/src/main/maker-host/shell-command-policy.ts
+++ b/apps/desktop/src/main/maker-host/shell-command-policy.ts
@@ -410,7 +410,6 @@ interface UnwrappedCommand {
 const SHELL_ASSIGNMENT_BUILTINS = new Set([
   'declare',
   'export',
-  'local',
   'readonly',
   'typeset',
 ]);

--- a/apps/desktop/src/main/maker-host/shell-command-policy.ts
+++ b/apps/desktop/src/main/maker-host/shell-command-policy.ts
@@ -50,6 +50,8 @@ interface ShellSegment {
   command: string;
   /** The operator that ran before this command; null for the first segment. */
   precedingOperator: ';' | '&&' | '||' | '|' | '&' | null;
+  /** The operator that separates this command from the next segment, if any. */
+  followingOperator: ';' | '&&' | '||' | '|' | '&' | null;
 }
 
 /** Split command lists without treating separators inside quotes as boundaries. */
@@ -62,7 +64,11 @@ function shellSegments(command: string): ShellSegment[] {
 
   const flush = (nextOperator: Exclude<ShellSegment['precedingOperator'], null>): void => {
     if (current.trim()) {
-      segments.push({ command: current.trim(), precedingOperator });
+      segments.push({
+        command: current.trim(),
+        precedingOperator,
+        followingOperator: nextOperator,
+      });
     }
     current = '';
     precedingOperator = nextOperator;
@@ -120,13 +126,18 @@ function shellSegments(command: string): ShellSegment[] {
     }
     current += char;
   }
-  if (current.trim()) segments.push({ command: current.trim(), precedingOperator });
+  if (current.trim())
+    segments.push({ command: current.trim(), precedingOperator, followingOperator: null });
   return segments;
 }
 
 /** Whether a segment's assignments definitely replace values in the current scope. */
 function assignmentDefinitelyRunsInCurrentScope(segment: ShellSegment): boolean {
   if (segment.precedingOperator !== null && segment.precedingOperator !== ';') return false;
+  // Assignments in a pipeline or background segment execute in a child shell.
+  // They must not be treated as replacing the value in the parent scope that a
+  // later command (for example `eval "$CMD"`) will read.
+  if (segment.followingOperator === '|' || segment.followingOperator === '&') return false;
   let quote: "'" | '"' | null = null;
   let escaped = false;
   let unquoted = '';

--- a/apps/desktop/src/main/maker-host/shell-command-policy.ts
+++ b/apps/desktop/src/main/maker-host/shell-command-policy.ts
@@ -91,7 +91,12 @@ function shellSegments(command: string): ShellSegment[] {
       continue;
     }
     if (char === '\n' || char === ';') {
-      flush(';');
+      // A newline immediately after `&&`, `||` or `|` continues that operator's
+      // command. There is no empty command for the newline to run, so keep the
+      // pending edge instead of turning it into an unconditional list separator.
+      // A lone `&` is already a complete separator, so the next line is
+      // unconditional in the parent shell.
+      if (char === ';' || current.trim() || precedingOperator === '&') flush(';');
       continue;
     }
     if (

--- a/apps/desktop/src/main/maker-host/shell-command-policy.ts
+++ b/apps/desktop/src/main/maker-host/shell-command-policy.ts
@@ -224,6 +224,8 @@ const PREFIX_VALUE_OPTIONS: Record<string, RegExp> = {
   arch: /^(?:-arch|--arch|-d|-e)$/,
   caffeinate: /^(?:-t|-w)$/,
   env: /^(?:-u|--unset|-C|--chdir|-S|--split-string)$/,
+  // `exec [-cl] [-a name] command …` — `-a` supplies argv[0], the command follows.
+  exec: /^-a$/,
   gtimeout: /^(?:-k|-s|--kill-after|--signal)$/,
   nice: /^(?:-n|--adjustment)$/,
   sudo: /^(?:-u|--user|-g|--group|-h|--host|-p|--prompt|-C|--close-from|-D|--chdir|-R|--chroot|-T|--command-timeout|-U|--other-user|-r|--role)$/,
@@ -252,8 +254,21 @@ function unwrapCommand(input: string[]): UnwrappedCommand {
     const head = executableName(tokens[0]);
 
     if (SHELL_EXECUTABLES.has(head)) {
-      const flag = tokens.findIndex((token) => /^-[A-Za-z]*c[A-Za-z]*$/.test(token));
-      if (flag > 0) return { tokens: [], nestedShell: tokens[flag + 1] ?? '', assignedValues };
+      // Only leading options belong to the shell. `bash ./run.sh -c 'x'` passes
+      // `-c` to the script as `$1`, so scanning the whole argv would classify an
+      // ordinary script argument as an executed shell program.
+      let index = 1;
+      while (index < tokens.length) {
+        const token = tokens[index]!;
+        if (token === '--') break;
+        if (!token.startsWith('-') && !token.startsWith('+')) break;
+        if (/^-[A-Za-z]*c[A-Za-z]*$/.test(token)) {
+          return { tokens: [], nestedShell: tokens[index + 1] ?? '', assignedValues };
+        }
+        // `-o name` / `+o name` take a value; skipping one token would read the
+        // option's value as the script operand and end the scan early.
+        index += /^[-+]o$/.test(token) ? 2 : 1;
+      }
       return { tokens, nestedShell: null, assignedValues };
     }
     if (head === 'eval') {

--- a/apps/desktop/src/main/maker-host/shell-command-policy.ts
+++ b/apps/desktop/src/main/maker-host/shell-command-policy.ts
@@ -19,6 +19,14 @@
  * message containing a Markdown backtick were all rejected with no Simulator
  * executor anywhere in the command. This matcher denies only what it can read
  * directly and lets everything else reach the normal shell permission flow.
+ * "Directly" means that the executor occupies a command-word position this
+ * policy already understands: a direct segment, one of the plain documentation
+ * prefixes below, or a supported shell/interpreter payload. It does not scan
+ * arbitrary argv for a command another program might execute. Opaque wrappers
+ * such as `launchctl`, `sandbox-exec`, `doas`, `script`, `watch`, `parallel`,
+ * `coproc` and `repeat` remain outside this boundary even when their argv holds
+ * a complete literal recipe, because locating the executed operand requires a
+ * per-wrapper execution contract rather than shell syntax.
  *
  * Heredocs need one narrow boundary: their bodies are stdin data unless the
  * receiving command executes stdin as a program. Data bodies are omitted from

--- a/apps/desktop/src/main/maker-host/shell-command-policy.ts
+++ b/apps/desktop/src/main/maker-host/shell-command-policy.ts
@@ -241,6 +241,26 @@ interface UnwrappedCommand {
   assignedValues: string[];
 }
 
+/** Builtins that declare `NAME=value`, an equally standard way to store a recipe. */
+const SHELL_ASSIGNMENT_BUILTINS = new Set([
+  'declare',
+  'export',
+  'local',
+  'readonly',
+  'typeset',
+]);
+
+/** `command -v` / `-V` only describe their operands; nothing is executed. */
+function isInspectionOnlyCommandBuiltin(tokens: string[]): boolean {
+  if (executableName(tokens[0]) !== 'command') return false;
+  for (let index = 1; index < tokens.length; index += 1) {
+    const token = tokens[index]!;
+    if (token === '--' || !token.startsWith('-')) break;
+    if (/^-[A-Za-z]*[vV]/.test(token)) return true;
+  }
+  return false;
+}
+
 /** Peel documentation-style prefixes to reach the command word. */
 function unwrapCommand(input: string[]): UnwrappedCommand {
   const first = stripLeadingShellPreamble(stripShellControlTokens(input));
@@ -252,6 +272,21 @@ function unwrapCommand(input: string[]): UnwrappedCommand {
     assignedValues.push(...peeled.assignedValues);
     if (tokens.length === 0) return { tokens, nestedShell: null, assignedValues };
     const head = executableName(tokens[0]);
+
+    if (isInspectionOnlyCommandBuiltin(tokens)) {
+      // Describing `simctl shutdown` is not running it; classifying the operands
+      // would deny an inspection that executes nothing.
+      return { tokens: [], nestedShell: null, assignedValues };
+    }
+    if (SHELL_ASSIGNMENT_BUILTINS.has(head)) {
+      // `export CMD='xcrun simctl …'` stores the recipe just like a bare
+      // assignment, so its operands feed the same assigned-value path.
+      for (const token of tokens.slice(1)) {
+        const assignment = /^[A-Za-z_][A-Za-z0-9_]*=([\s\S]*)$/.exec(token);
+        if (assignment) assignedValues.push(assignment[1] ?? '');
+      }
+      return { tokens: [], nestedShell: null, assignedValues };
+    }
 
     if (SHELL_EXECUTABLES.has(head)) {
       // Only leading options belong to the shell. `bash ./run.sh -c 'x'` passes
@@ -265,9 +300,9 @@ function unwrapCommand(input: string[]): UnwrappedCommand {
         if (/^-[A-Za-z]*c[A-Za-z]*$/.test(token)) {
           return { tokens: [], nestedShell: tokens[index + 1] ?? '', assignedValues };
         }
-        // `-o name` / `+o name` take a value; skipping one token would read the
-        // option's value as the script operand and end the scan early.
-        index += /^[-+]o$/.test(token) ? 2 : 1;
+        // `-o name` and `-O shopt_option` take a value; skipping one token would
+        // read the option's value as the script operand and end the scan early.
+        index += /^[-+][oO]$/.test(token) ? 2 : 1;
       }
       return { tokens, nestedShell: null, assignedValues };
     }

--- a/apps/desktop/src/main/maker-host/shell-command-policy.ts
+++ b/apps/desktop/src/main/maker-host/shell-command-policy.ts
@@ -335,6 +335,7 @@ function tokenizeHeredocConsumer(segment: string): string[] {
 interface ShellAssignment {
   name: string;
   value: string;
+  readonly: boolean;
 }
 
 const SHELL_ASSIGNMENT = /^([A-Za-z_][A-Za-z0-9_]*)=([\s\S]*)$/;
@@ -352,7 +353,11 @@ function stripLeadingShellPreamble(input: string[]): Preamble {
     const token = tokens[0]!;
     const assignment = SHELL_ASSIGNMENT.exec(token);
     if (assignment) {
-      assignments.push({ name: assignment[1] ?? '', value: assignment[2] ?? '' });
+      assignments.push({
+        name: assignment[1] ?? '',
+        value: assignment[2] ?? '',
+        readonly: false,
+      });
       tokens.shift();
       continue;
     }
@@ -430,10 +435,20 @@ function unwrapCommand(input: string[]): UnwrappedCommand {
     if (SHELL_ASSIGNMENT_BUILTINS.has(head)) {
       // `export CMD='xcrun simctl …'` stores the recipe just like a bare
       // assignment, so its operands feed the same stored-value path.
+      const makesReadonly =
+        head === 'readonly'
+        || (
+          (head === 'declare' || head === 'local' || head === 'typeset')
+          && tokens.slice(1).some((token) => /^-[A-Za-z]*r[A-Za-z]*$/.test(token))
+        );
       for (const token of tokens.slice(1)) {
         const assignment = SHELL_ASSIGNMENT.exec(token);
         if (assignment) {
-          assignments.push({ name: assignment[1] ?? '', value: assignment[2] ?? '' });
+          assignments.push({
+            name: assignment[1] ?? '',
+            value: assignment[2] ?? '',
+            readonly: makesReadonly,
+          });
         }
       }
       return { tokens: [], nestedShell: null, assignments };
@@ -480,6 +495,39 @@ function unwrapCommand(input: string[]): UnwrappedCommand {
     tokens = next;
   }
   return { tokens, nestedShell: null, assignments };
+}
+
+/** Variables a direct shell `unset` definitely removes from the current scope. */
+function definitelyUnsetVariables(segment: ShellSegment): string[] {
+  if (!assignmentDefinitelyRunsInCurrentScope(segment)) return [];
+  let tokens = stripLeadingShellPreamble(
+    stripShellControlTokens(tokenizeHeredocConsumer(segment.command)),
+  ).tokens;
+  const prefix = executableName(tokens[0]);
+  if (prefix === 'builtin' || prefix === 'command') {
+    tokens = tokens.slice(1);
+    if (tokens[0] === '--') tokens = tokens.slice(1);
+    else if (tokens[0]?.startsWith('-')) return [];
+  }
+  if (executableName(tokens[0]) !== 'unset') return [];
+
+  const names: string[] = [];
+  let parsingOptions = true;
+  for (const token of tokens.slice(1)) {
+    if (parsingOptions && token === '--') {
+      parsingOptions = false;
+      continue;
+    }
+    if (parsingOptions && token.startsWith('-')) {
+      // `-v` selects variables and `-n` selects the nameref itself. `-f` and
+      // unknown options do not prove that a tracked variable was removed.
+      if (!/^-[vn]+$/.test(token)) return [];
+      continue;
+    }
+    parsingOptions = false;
+    if (/^[A-Za-z_][A-Za-z0-9_]*$/.test(token)) names.push(token);
+  }
+  return names;
 }
 
 /** `open -a Simulator` and the Simulator binary, in their documented spellings. */
@@ -1066,21 +1114,25 @@ function containsSimulatorRecipe(command: string, depth = 0): boolean {
   for (const nested of shellSubcommands(executableCommand)) {
     if (containsSimulatorRecipe(nested, depth + 1)) return true;
   }
-  const assignments = new Map<string, string[]>();
+  interface TrackedShellValue {
+    value: string;
+    readonly: boolean;
+  }
+  const assignments = new Map<string, TrackedShellValue[]>();
   const referencedAssignmentContainsRecipe = (
     reference: string,
-    visibleAssignments: Map<string, string[]> = assignments,
+    visibleAssignments: Map<string, TrackedShellValue[]> = assignments,
   ): boolean => {
     for (const [name, values] of visibleAssignments) {
       // The name matched `[A-Za-z_][A-Za-z0-9_]*`, so it carries no regex syntax.
       if (!new RegExp(`\\$\\{?${name}\\b`).test(reference)) continue;
-      if (values.some((value) => containsSimulatorRecipe(value, depth + 1))) return true;
+      if (values.some(({ value }) => containsSimulatorRecipe(value, depth + 1))) return true;
     }
     return false;
   };
   for (const segment of shellSegments(executableCommand)) {
     const unwrapped = unwrapCommand(tokenizeShellSegment(segment.command));
-    const commandScopedAssignments = new Map<string, string[]>();
+    const commandScopedAssignments = new Map<string, TrackedShellValue[]>();
     // Shell assignments replace the previous value before the command in this
     // segment runs. A `;`/newline-separated assignment therefore supersedes the
     // previous value, while a conditional, pipeline or background edge can skip
@@ -1091,18 +1143,27 @@ function containsSimulatorRecipe(command: string, depth = 0): boolean {
         assignmentDefinitelyRunsInCurrentScope(segment)
         && unwrapped.tokens.length === 0
         && unwrapped.nestedShell === null;
+      const trackedValue = { value: assignment.value, readonly: assignment.readonly };
       if (persistentAssignment) {
-        assignments.set(assignment.name, [assignment.value]);
+        const existingReadonly = (assignments.get(assignment.name) ?? []).filter(
+          (value) => value.readonly,
+        );
+        assignments.set(assignment.name, [...existingReadonly, trackedValue]);
       } else if (unwrapped.tokens.length > 0 || unwrapped.nestedShell !== null) {
         // A leading assignment shadows the exported value only for this
         // command. Use its last value while classifying the child, then leave
         // the parent-shell possibilities unchanged for later segments.
-        commandScopedAssignments.set(assignment.name, [assignment.value]);
+        commandScopedAssignments.set(assignment.name, [trackedValue]);
       } else {
         const possibleValues = assignments.get(assignment.name) ?? [];
-        possibleValues.push(assignment.value);
+        possibleValues.push(trackedValue);
         assignments.set(assignment.name, possibleValues);
       }
+    }
+    for (const name of definitelyUnsetVariables(segment)) {
+      const readonlyValues = (assignments.get(name) ?? []).filter((value) => value.readonly);
+      if (readonlyValues.length > 0) assignments.set(name, readonlyValues);
+      else assignments.delete(name);
     }
     const visibleAssignments = new Map(assignments);
     for (const [name, values] of commandScopedAssignments) {

--- a/apps/desktop/src/main/maker-host/shell-command-policy.ts
+++ b/apps/desktop/src/main/maker-host/shell-command-policy.ts
@@ -161,21 +161,28 @@ function shellRedirectionSuffix(token: string): string | null {
   return match ? (match[1] ?? '') : null;
 }
 
+/** A `NAME=value` assignment, whose value may hold a whole recipe. */
+interface ShellAssignment {
+  name: string;
+  value: string;
+}
+
+const SHELL_ASSIGNMENT = /^([A-Za-z_][A-Za-z0-9_]*)=([\s\S]*)$/;
+
 interface Preamble {
   tokens: string[];
-  /** Values of leading `NAME=value` assignments, which may hold a whole recipe. */
-  assignedValues: string[];
+  assignments: ShellAssignment[];
 }
 
 /** Remove leading assignments and redirections so the next token is the command word. */
 function stripLeadingShellPreamble(input: string[]): Preamble {
   const tokens = [...input];
-  const assignedValues: string[] = [];
+  const assignments: ShellAssignment[] = [];
   while (tokens.length > 0) {
     const token = tokens[0]!;
-    const assignment = /^[A-Za-z_][A-Za-z0-9_]*=([\s\S]*)$/.exec(token);
+    const assignment = SHELL_ASSIGNMENT.exec(token);
     if (assignment) {
-      assignedValues.push(assignment[1] ?? '');
+      assignments.push({ name: assignment[1] ?? '', value: assignment[2] ?? '' });
       tokens.shift();
       continue;
     }
@@ -184,7 +191,7 @@ function stripLeadingShellPreamble(input: string[]): Preamble {
     tokens.shift();
     if (redirectionSuffix === '' && tokens.length > 0) tokens.shift();
   }
-  return { tokens, assignedValues };
+  return { tokens, assignments };
 }
 
 const SHELL_EXECUTABLES = new Set(['bash', 'csh', 'dash', 'fish', 'ksh', 'sh', 'tcsh', 'zsh']);
@@ -226,7 +233,7 @@ interface UnwrappedCommand {
   tokens: string[];
   /** A literal program string handed to a shell via `-c`, classified recursively. */
   nestedShell: string | null;
-  assignedValues: string[];
+  assignments: ShellAssignment[];
 }
 
 /** Builtins that declare `NAME=value`, an equally standard way to store a recipe. */
@@ -242,22 +249,24 @@ const SHELL_ASSIGNMENT_BUILTINS = new Set([
 function unwrapCommand(input: string[]): UnwrappedCommand {
   const first = stripLeadingShellPreamble(stripShellControlTokens(input));
   let tokens = first.tokens;
-  const assignedValues = [...first.assignedValues];
+  const assignments = [...first.assignments];
   for (let depth = 0; depth < MAX_RECURSION_DEPTH; depth += 1) {
     const peeled = stripLeadingShellPreamble(tokens);
     tokens = peeled.tokens;
-    assignedValues.push(...peeled.assignedValues);
-    if (tokens.length === 0) return { tokens, nestedShell: null, assignedValues };
+    assignments.push(...peeled.assignments);
+    if (tokens.length === 0) return { tokens, nestedShell: null, assignments };
     const head = executableName(tokens[0]);
 
     if (SHELL_ASSIGNMENT_BUILTINS.has(head)) {
       // `export CMD='xcrun simctl …'` stores the recipe just like a bare
-      // assignment, so its operands feed the same assigned-value path.
+      // assignment, so its operands feed the same stored-value path.
       for (const token of tokens.slice(1)) {
-        const assignment = /^[A-Za-z_][A-Za-z0-9_]*=([\s\S]*)$/.exec(token);
-        if (assignment) assignedValues.push(assignment[1] ?? '');
+        const assignment = SHELL_ASSIGNMENT.exec(token);
+        if (assignment) {
+          assignments.push({ name: assignment[1] ?? '', value: assignment[2] ?? '' });
+        }
       }
-      return { tokens: [], nestedShell: null, assignedValues };
+      return { tokens: [], nestedShell: null, assignments };
     }
 
     if (SHELL_EXECUTABLES.has(head)) {
@@ -270,25 +279,25 @@ function unwrapCommand(input: string[]): UnwrappedCommand {
         if (token === '--') break;
         if (!token.startsWith('-') && !token.startsWith('+')) break;
         if (/^-[A-Za-z]*c[A-Za-z]*$/.test(token)) {
-          return { tokens: [], nestedShell: tokens[index + 1] ?? '', assignedValues };
+          return { tokens: [], nestedShell: tokens[index + 1] ?? '', assignments };
         }
         // `-o name` and `-O shopt_option` take a value; skipping one token would
         // read the option's value as the script operand and end the scan early.
         index += /^[-+][oO]$/.test(token) ? 2 : 1;
       }
-      return { tokens, nestedShell: null, assignedValues };
+      return { tokens, nestedShell: null, assignments };
     }
     if (head === 'eval') {
-      return { tokens: [], nestedShell: tokens.slice(1).join(' '), assignedValues };
+      return { tokens: [], nestedShell: tokens.slice(1).join(' '), assignments };
     }
-    if (!LITERAL_COMMAND_PREFIXES.has(head)) return { tokens, nestedShell: null, assignedValues };
+    if (!LITERAL_COMMAND_PREFIXES.has(head)) return { tokens, nestedShell: null, assignments };
 
     let index = 1;
     if (tokens[index] === '--') {
       // The only option-like token whose meaning needs no per-CLI knowledge.
       index += 1;
     } else if (tokens[index]?.startsWith('-')) {
-      return { tokens, nestedShell: null, assignedValues };
+      return { tokens, nestedShell: null, assignments };
     }
     // timeout takes a duration operand before the command it runs.
     if ((head === 'timeout' || head === 'gtimeout') && /^[\d.]+[smhd]?$/.test(tokens[index] ?? '')) {
@@ -296,11 +305,11 @@ function unwrapCommand(input: string[]): UnwrappedCommand {
     }
     const next = tokens.slice(index);
     if (next.length === 0 || next.length === tokens.length) {
-      return { tokens: next, nestedShell: null, assignedValues };
+      return { tokens: next, nestedShell: null, assignments };
     }
     tokens = next;
   }
-  return { tokens, nestedShell: null, assignedValues };
+  return { tokens, nestedShell: null, assignments };
 }
 
 /** `open -a Simulator` and the Simulator binary, in their documented spellings. */
@@ -448,21 +457,39 @@ function containsSimulatorRecipe(command: string, depth = 0): boolean {
   for (const nested of shellSubcommands(command)) {
     if (containsSimulatorRecipe(nested, depth + 1)) return true;
   }
+  const assignments: ShellAssignment[] = [];
+  const executedReferences: string[] = [];
   for (const segment of shellSegments(command)) {
     const unwrapped = unwrapCommand(tokenizeShellSegment(segment));
-    // `CMD="xcrun simctl boot $UDID"` holds a whole recipe; documentation does
-    // write it this way before running it. The value goes through the same
-    // classifier as a command, so a documented prefix (`sudo …`, `env FOO=1 …`),
-    // a nested `bash -lc '…'` or a substitution inside the value is reached too.
-    for (const value of unwrapped.assignedValues) {
-      if (containsSimulatorRecipe(value, depth + 1)) return true;
-    }
+    assignments.push(...unwrapped.assignments);
     if (unwrapped.nestedShell !== null) {
+      // `eval "$CMD"` and `sh -c "$CMD"` run a variable this scan cannot resolve.
+      executedReferences.push(unwrapped.nestedShell);
       if (containsSimulatorRecipe(unwrapped.nestedShell, depth + 1)) return true;
       continue;
     }
+    // A variable in the command word position is run as the command itself.
+    const commandWord = unwrapped.tokens[0];
+    if (commandWord?.includes('$')) executedReferences.push(commandWord);
     if (isSimulatorRecipeArgv(unwrapped.tokens)) return true;
     if (containsInterpreterSimulatorPayload(unwrapped.tokens)) return true;
+  }
+
+  // `CMD="xcrun simctl boot $UDID"; eval "$CMD"` holds a whole recipe, and
+  // documentation does write it that way before running it. The value only
+  // matters once something runs it, though: `printf '%s\n' "$CMD"` prints the
+  // string and executes nothing, so classifying every stored value would deny a
+  // command that never reaches a simulator. The value goes through the same
+  // classifier as a command, so a documented prefix, a nested `bash -lc '…'` or a
+  // substitution inside it is reached too.
+  for (const assignment of assignments) {
+    if (assignment.name === '') continue;
+    // The name matched `[A-Za-z_][A-Za-z0-9_]*`, so it carries no regex syntax.
+    const referenced = executedReferences.some((reference) =>
+      new RegExp(`\\$\\{?${assignment.name}\\b`).test(reference),
+    );
+    if (!referenced) continue;
+    if (containsSimulatorRecipe(assignment.value, depth + 1)) return true;
   }
   return false;
 }

--- a/apps/desktop/src/main/maker-host/shell-command-policy.ts
+++ b/apps/desktop/src/main/maker-host/shell-command-policy.ts
@@ -335,7 +335,6 @@ function tokenizeHeredocConsumer(segment: string): string[] {
 interface ShellAssignment {
   name: string;
   value: string;
-  readonly: boolean;
 }
 
 const SHELL_ASSIGNMENT = /^([A-Za-z_][A-Za-z0-9_]*)=([\s\S]*)$/;
@@ -353,11 +352,7 @@ function stripLeadingShellPreamble(input: string[]): Preamble {
     const token = tokens[0]!;
     const assignment = SHELL_ASSIGNMENT.exec(token);
     if (assignment) {
-      assignments.push({
-        name: assignment[1] ?? '',
-        value: assignment[2] ?? '',
-        readonly: false,
-      });
+      assignments.push({ name: assignment[1] ?? '', value: assignment[2] ?? '' });
       tokens.shift();
       continue;
     }
@@ -435,20 +430,10 @@ function unwrapCommand(input: string[]): UnwrappedCommand {
     if (SHELL_ASSIGNMENT_BUILTINS.has(head)) {
       // `export CMD='xcrun simctl …'` stores the recipe just like a bare
       // assignment, so its operands feed the same stored-value path.
-      const makesReadonly =
-        head === 'readonly'
-        || (
-          (head === 'declare' || head === 'local' || head === 'typeset')
-          && tokens.slice(1).some((token) => /^-[A-Za-z]*r[A-Za-z]*$/.test(token))
-        );
       for (const token of tokens.slice(1)) {
         const assignment = SHELL_ASSIGNMENT.exec(token);
         if (assignment) {
-          assignments.push({
-            name: assignment[1] ?? '',
-            value: assignment[2] ?? '',
-            readonly: makesReadonly,
-          });
+          assignments.push({ name: assignment[1] ?? '', value: assignment[2] ?? '' });
         }
       }
       return { tokens: [], nestedShell: null, assignments };
@@ -495,39 +480,6 @@ function unwrapCommand(input: string[]): UnwrappedCommand {
     tokens = next;
   }
   return { tokens, nestedShell: null, assignments };
-}
-
-/** Variables a direct shell `unset` definitely removes from the current scope. */
-function definitelyUnsetVariables(segment: ShellSegment): string[] {
-  if (!assignmentDefinitelyRunsInCurrentScope(segment)) return [];
-  let tokens = stripLeadingShellPreamble(
-    stripShellControlTokens(tokenizeHeredocConsumer(segment.command)),
-  ).tokens;
-  const prefix = executableName(tokens[0]);
-  if (prefix === 'builtin' || prefix === 'command') {
-    tokens = tokens.slice(1);
-    if (tokens[0] === '--') tokens = tokens.slice(1);
-    else if (tokens[0]?.startsWith('-')) return [];
-  }
-  if (executableName(tokens[0]) !== 'unset') return [];
-
-  const names: string[] = [];
-  let parsingOptions = true;
-  for (const token of tokens.slice(1)) {
-    if (parsingOptions && token === '--') {
-      parsingOptions = false;
-      continue;
-    }
-    if (parsingOptions && token.startsWith('-')) {
-      // `-v` selects variables and `-n` selects the nameref itself. `-f` and
-      // unknown options do not prove that a tracked variable was removed.
-      if (!/^-[vn]+$/.test(token)) return [];
-      continue;
-    }
-    parsingOptions = false;
-    if (/^[A-Za-z_][A-Za-z0-9_]*$/.test(token)) names.push(token);
-  }
-  return names;
 }
 
 /** `open -a Simulator` and the Simulator binary, in their documented spellings. */
@@ -677,6 +629,20 @@ function nestedShellConsumesStdinAsProgram(command: string): boolean {
   );
 }
 
+/** Leading shell options removed before deciding whether a script operand exists. */
+function shellPositionalArgs(args: string[]): string[] {
+  let index = 0;
+  while (index < args.length) {
+    const token = args[index]!;
+    if (token === '--') return args.slice(index + 1);
+    if (!token.startsWith('-') && !token.startsWith('+')) break;
+    // Bash/zsh `-o name` and Bash `-O shopt_name` consume the next token; that
+    // operand is not a script filename and does not displace heredoc stdin.
+    index += /^[-+][oO]$/.test(token) ? 2 : 1;
+  }
+  return args.slice(index);
+}
+
 /** Whether this literal command executes its stdin as source code. */
 function consumesStdinAsProgram(tokens: string[]): boolean {
   const unwrapped = unwrapCommand(tokens);
@@ -698,7 +664,9 @@ function consumesStdinAsProgram(tokens: string[]): boolean {
   } else {
     return false;
   }
-  const positional = args.find((arg) => !arg.startsWith('-'));
+  const positional = SHELL_EXECUTABLES.has(executable)
+    ? shellPositionalArgs(args)[0]
+    : args.find((arg) => !arg.startsWith('-'));
   return positional === undefined || positional === '-';
 }
 
@@ -843,6 +811,17 @@ function heredocRedirections(line: string): HeredocRedirection[] {
     let expands = true;
     while (cursor < line.length) {
       const delimiterChar = line[cursor]!;
+      if (
+        delimiterChar === '$'
+        && (line[cursor + 1] === "'" || line[cursor + 1] === '"')
+      ) {
+        // Bash's ANSI-C and locale quote prefixes are removed along with the
+        // surrounding quotes for a simple literal delimiter (`$'EOF'`). Do not
+        // grow this boundary into decoding ANSI-C escape sequences.
+        expands = false;
+        cursor += 1;
+        continue;
+      }
       if (delimiterChar === "'" || delimiterChar === '"') {
         expands = false;
         const closing = line.indexOf(delimiterChar, cursor + 1);
@@ -971,6 +950,10 @@ function hasUnquotedStdinRedirection(segment: string): boolean {
       index = skipArithmeticExpression(segment, index) - 1;
       continue;
     }
+    if (char === '$' && segment[index + 1] === '[') {
+      index = skipLegacyArithmeticExpression(segment, index) - 1;
+      continue;
+    }
     if (
       (char === '$' || char === '<' || char === '>')
       && segment[index + 1] === '('
@@ -1051,16 +1034,6 @@ function heredocBodyIsProgram(line: string, markerStart: number): boolean {
   return false;
 }
 
-/** Whether a trailing list operator requires another physical command line. */
-function shellClauseNeedsContinuation(command: string): boolean {
-  const lastSegment = shellSegments(command).at(-1);
-  return (
-    lastSegment?.followingOperator === '|'
-    || lastSegment?.followingOperator === '&&'
-    || lastSegment?.followingOperator === '||'
-  );
-}
-
 /**
  * Remove stdin-only heredoc prose before classifying command words.
  *
@@ -1072,26 +1045,9 @@ function stripHeredocBodies(command: string): string {
   const lines = command.split(/\r?\n/);
   const executable: string[] = [];
   for (let index = 0; index < lines.length; index += 1) {
-    let clause = lines[index]!;
-    const clauseHeredocs = heredocRedirections(clause);
-    // A heredoc body begins only after the complete compound command has been
-    // parsed. With a trailing `|`, `&&` or `||`, the next physical line is the
-    // continuation command rather than body data; retain it in the executable
-    // clause and shift any opener offsets found there.
-    while (shellClauseNeedsContinuation(clause) && index + 1 < lines.length) {
-      index += 1;
-      const continuation = lines[index]!;
-      const continuationStart = clause.length + 1;
-      clause += `\n${continuation}`;
-      clauseHeredocs.push(
-        ...heredocRedirections(continuation).map((heredoc) => ({
-          ...heredoc,
-          start: continuationStart + heredoc.start,
-        })),
-      );
-    }
-    executable.push(clause);
-    for (const heredoc of clauseHeredocs) {
+    const line = lines[index]!;
+    executable.push(line);
+    for (const heredoc of heredocRedirections(line)) {
       const body: string[] = [];
       index += 1;
       for (; index < lines.length; index += 1) {
@@ -1100,7 +1056,7 @@ function stripHeredocBodies(command: string): string {
         if (unindented === heredoc.delimiter) break;
         body.push(candidate);
       }
-      if (heredocBodyIsProgram(clause, heredoc.start)) executable.push(...body);
+      if (heredocBodyIsProgram(line, heredoc.start)) executable.push(...body);
       else if (heredoc.expands) executable.push(...shellSubcommands(body.join('\n')));
       if (index >= lines.length) break;
     }
@@ -1114,25 +1070,21 @@ function containsSimulatorRecipe(command: string, depth = 0): boolean {
   for (const nested of shellSubcommands(executableCommand)) {
     if (containsSimulatorRecipe(nested, depth + 1)) return true;
   }
-  interface TrackedShellValue {
-    value: string;
-    readonly: boolean;
-  }
-  const assignments = new Map<string, TrackedShellValue[]>();
+  const assignments = new Map<string, string[]>();
   const referencedAssignmentContainsRecipe = (
     reference: string,
-    visibleAssignments: Map<string, TrackedShellValue[]> = assignments,
+    visibleAssignments: Map<string, string[]> = assignments,
   ): boolean => {
     for (const [name, values] of visibleAssignments) {
       // The name matched `[A-Za-z_][A-Za-z0-9_]*`, so it carries no regex syntax.
       if (!new RegExp(`\\$\\{?${name}\\b`).test(reference)) continue;
-      if (values.some(({ value }) => containsSimulatorRecipe(value, depth + 1))) return true;
+      if (values.some((value) => containsSimulatorRecipe(value, depth + 1))) return true;
     }
     return false;
   };
   for (const segment of shellSegments(executableCommand)) {
     const unwrapped = unwrapCommand(tokenizeShellSegment(segment.command));
-    const commandScopedAssignments = new Map<string, TrackedShellValue[]>();
+    const commandScopedAssignments = new Map<string, string[]>();
     // Shell assignments replace the previous value before the command in this
     // segment runs. A `;`/newline-separated assignment therefore supersedes the
     // previous value, while a conditional, pipeline or background edge can skip
@@ -1143,27 +1095,18 @@ function containsSimulatorRecipe(command: string, depth = 0): boolean {
         assignmentDefinitelyRunsInCurrentScope(segment)
         && unwrapped.tokens.length === 0
         && unwrapped.nestedShell === null;
-      const trackedValue = { value: assignment.value, readonly: assignment.readonly };
       if (persistentAssignment) {
-        const existingReadonly = (assignments.get(assignment.name) ?? []).filter(
-          (value) => value.readonly,
-        );
-        assignments.set(assignment.name, [...existingReadonly, trackedValue]);
+        assignments.set(assignment.name, [assignment.value]);
       } else if (unwrapped.tokens.length > 0 || unwrapped.nestedShell !== null) {
         // A leading assignment shadows the exported value only for this
         // command. Use its last value while classifying the child, then leave
         // the parent-shell possibilities unchanged for later segments.
-        commandScopedAssignments.set(assignment.name, [trackedValue]);
+        commandScopedAssignments.set(assignment.name, [assignment.value]);
       } else {
         const possibleValues = assignments.get(assignment.name) ?? [];
-        possibleValues.push(trackedValue);
+        possibleValues.push(assignment.value);
         assignments.set(assignment.name, possibleValues);
       }
-    }
-    for (const name of definitelyUnsetVariables(segment)) {
-      const readonlyValues = (assignments.get(name) ?? []).filter((value) => value.readonly);
-      if (readonlyValues.length > 0) assignments.set(name, readonlyValues);
-      else assignments.delete(name);
     }
     const visibleAssignments = new Map(assignments);
     for (const [name, values] of commandScopedAssignments) {

--- a/apps/desktop/src/main/maker-host/shell-command-policy.ts
+++ b/apps/desktop/src/main/maker-host/shell-command-policy.ts
@@ -1003,6 +1003,16 @@ function heredocBodyIsProgram(line: string, markerStart: number): boolean {
   return false;
 }
 
+/** Whether a trailing list operator requires another physical command line. */
+function shellClauseNeedsContinuation(command: string): boolean {
+  const lastSegment = shellSegments(command).at(-1);
+  return (
+    lastSegment?.followingOperator === '|'
+    || lastSegment?.followingOperator === '&&'
+    || lastSegment?.followingOperator === '||'
+  );
+}
+
 /**
  * Remove stdin-only heredoc prose before classifying command words.
  *
@@ -1014,9 +1024,26 @@ function stripHeredocBodies(command: string): string {
   const lines = command.split(/\r?\n/);
   const executable: string[] = [];
   for (let index = 0; index < lines.length; index += 1) {
-    const line = lines[index]!;
-    executable.push(line);
-    for (const heredoc of heredocRedirections(line)) {
+    let clause = lines[index]!;
+    const clauseHeredocs = heredocRedirections(clause);
+    // A heredoc body begins only after the complete compound command has been
+    // parsed. With a trailing `|`, `&&` or `||`, the next physical line is the
+    // continuation command rather than body data; retain it in the executable
+    // clause and shift any opener offsets found there.
+    while (shellClauseNeedsContinuation(clause) && index + 1 < lines.length) {
+      index += 1;
+      const continuation = lines[index]!;
+      const continuationStart = clause.length + 1;
+      clause += `\n${continuation}`;
+      clauseHeredocs.push(
+        ...heredocRedirections(continuation).map((heredoc) => ({
+          ...heredoc,
+          start: continuationStart + heredoc.start,
+        })),
+      );
+    }
+    executable.push(clause);
+    for (const heredoc of clauseHeredocs) {
       const body: string[] = [];
       index += 1;
       for (; index < lines.length; index += 1) {
@@ -1025,7 +1052,7 @@ function stripHeredocBodies(command: string): string {
         if (unindented === heredoc.delimiter) break;
         body.push(candidate);
       }
-      if (heredocBodyIsProgram(line, heredoc.start)) executable.push(...body);
+      if (heredocBodyIsProgram(clause, heredoc.start)) executable.push(...body);
       else if (heredoc.expands) executable.push(...shellSubcommands(body.join('\n')));
       if (index >= lines.length) break;
     }

--- a/apps/desktop/src/main/maker-host/shell-command-policy.ts
+++ b/apps/desktop/src/main/maker-host/shell-command-policy.ts
@@ -662,6 +662,22 @@ interface HeredocRedirection {
   stripsTabs: boolean;
 }
 
+function heredocDescriptorBefore(
+  segment: string,
+  start: number,
+): { value: string; start: number } | null {
+  const beforeOperator = segment.slice(0, start);
+  const match = /(?:^|[\s;&|()])(\d+|\{[A-Za-z_][A-Za-z0-9_]*\})$/.exec(beforeOperator);
+  const value = match?.[1];
+  return value === undefined ? null : { value, start: start - value.length };
+}
+
+/** Whether a heredoc redirection feeds the command's stdin rather than another fd. */
+function heredocIsStdinRedirection(segment: string, start: number): boolean {
+  const descriptor = heredocDescriptorBefore(segment, start);
+  return descriptor === null || descriptor.value === '0';
+}
+
 /**
  * Skip a shell arithmetic expression while looking for heredoc operators.
  *
@@ -784,6 +800,21 @@ function heredocRedirections(line: string): HeredocRedirection[] {
   return redirections;
 }
 
+/** Remove heredoc operators before tokenizing the command that consumes them. */
+function removeHeredocRedirections(command: string): string {
+  const redirections = heredocRedirections(command);
+  let result = command;
+  for (let index = redirections.length - 1; index >= 0; index -= 1) {
+    const redirection = redirections[index]!;
+    const descriptor = heredocDescriptorBefore(command, redirection.start);
+    const removalStart = descriptor?.start ?? redirection.start;
+    result =
+      result.slice(0, removalStart)
+      + result.slice(redirection.start + redirection.marker.length);
+  }
+  return result;
+}
+
 /** Find the closing parenthesis for a shell `$(...)`, `<(...)` or `>(...)`. */
 function skipShellSubstitution(input: string, start: number): number {
   let depth = 1;
@@ -890,16 +921,39 @@ function hasUnquotedStdinRedirection(segment: string): boolean {
 }
 
 /** Whether the heredoc's own clause hands its body to a code-reading consumer. */
-function heredocBodyIsProgram(line: string, marker: string, markerStart: number): boolean {
+function heredocBodyIsProgram(line: string, markerStart: number): boolean {
   const segments = shellSegments(line);
   let searchCursor = 0;
+  let openingSegmentStart = -1;
   const openingIndex = segments.findIndex((segment) => {
     const segmentStart = line.indexOf(segment.command, searchCursor);
     if (segmentStart < 0) return false;
     searchCursor = segmentStart + segment.command.length;
-    return markerStart >= segmentStart && markerStart < searchCursor;
+    if (markerStart < segmentStart || markerStart >= searchCursor) return false;
+    openingSegmentStart = segmentStart;
+    return true;
   });
   if (openingIndex < 0) return false;
+  const openingSegment = segments[openingIndex]!;
+  const localMarkerStart = markerStart - openingSegmentStart;
+  const openingRedirections = heredocRedirections(openingSegment.command);
+  const openingRedirection = openingRedirections.find(
+    (redirection) => redirection.start === localMarkerStart,
+  );
+  if (
+    !openingRedirection
+    || !heredocIsStdinRedirection(openingSegment.command, openingRedirection.start)
+  ) return false;
+  // Bash applies multiple stdin heredocs on one consumer from left to right;
+  // only the final stdin redirection supplies the process's input. A previous
+  // body is data even when the later body is the program we should inspect.
+  if (
+    openingRedirections.some(
+      (redirection) =>
+        redirection.start > openingRedirection.start
+        && heredocIsStdinRedirection(openingSegment.command, redirection.start),
+    )
+  ) return false;
   for (let index = openingIndex; index < segments.length; index += 1) {
     const segment = segments[index]!;
     if (index > openingIndex && segment.precedingOperator !== '|') break;
@@ -908,7 +962,7 @@ function heredocBodyIsProgram(line: string, marker: string, markerStart: number)
     if (index > openingIndex && hasUnquotedStdinRedirection(segment.command)) break;
     if (
       consumesStdinAsProgram(
-        tokenizeHeredocConsumer(segment.command.replace(marker, ' ')),
+        tokenizeHeredocConsumer(removeHeredocRedirections(segment.command)),
       )
     ) return true;
   }
@@ -937,7 +991,7 @@ function stripHeredocBodies(command: string): string {
         if (unindented === heredoc.delimiter) break;
         body.push(candidate);
       }
-      if (heredocBodyIsProgram(line, heredoc.marker, heredoc.start)) executable.push(...body);
+      if (heredocBodyIsProgram(line, heredoc.start)) executable.push(...body);
       else if (heredoc.expands) executable.push(...shellSubcommands(body.join('\n')));
       if (index >= lines.length) break;
     }

--- a/apps/desktop/src/main/maker-host/shell-command-policy.ts
+++ b/apps/desktop/src/main/maker-host/shell-command-policy.ts
@@ -144,8 +144,14 @@ function stripShellControlTokens(tokens: string[]): string[] {
   while (out[0] === '') out.shift();
   const last = out.length - 1;
   if (last >= 0) {
-    out[last] = out[last]!.replace(/[)}]+$/, '');
-    if (out[last] === '') out.pop();
+    // A trailing `)` may close a substitution rather than a subshell. Stripping
+    // it there would truncate `CMD='echo $(xcrun simctl boot X)'` into an
+    // unterminated substitution that the recursive scan can no longer read.
+    const closesSubstitution = /\$\(|<\(|>\(/.test(out[last]!);
+    if (!closesSubstitution) {
+      out[last] = out[last]!.replace(/[)}]+$/, '');
+      if (out[last] === '') out.pop();
+    }
   }
   return out;
 }
@@ -427,9 +433,11 @@ function containsSimulatorRecipe(command: string, depth = 0): boolean {
   for (const segment of shellSegments(command)) {
     const unwrapped = unwrapCommand(tokenizeShellSegment(segment));
     // `CMD="xcrun simctl boot $UDID"` holds a whole recipe; documentation does
-    // write it this way before running it, so the literal value is classified.
+    // write it this way before running it. The value goes through the same
+    // classifier as a command, so a documented prefix (`sudo …`, `env FOO=1 …`),
+    // a nested `bash -lc '…'` or a substitution inside the value is reached too.
     for (const value of unwrapped.assignedValues) {
-      if (isSimulatorRecipeArgv(tokenizeShellSegment(value))) return true;
+      if (containsSimulatorRecipe(value, depth + 1)) return true;
     }
     if (unwrapped.nestedShell !== null) {
       if (containsSimulatorRecipe(unwrapped.nestedShell, depth + 1)) return true;

--- a/apps/desktop/src/main/maker-host/shell-command-policy.ts
+++ b/apps/desktop/src/main/maker-host/shell-command-policy.ts
@@ -208,6 +208,24 @@ const LITERAL_COMMAND_PREFIXES = new Set([
   'xargs',
 ]);
 
+/**
+ * Options of those prefixes that consume the following token. Without this,
+ * `env -u FOO xcrun simctl …` reads `FOO` as the command and the peel stops
+ * short of a recipe that is spelled out in full. Separate-word spellings only:
+ * an `--opt=value` form starts with `-` and is skipped as a plain flag.
+ */
+const PREFIX_VALUE_OPTIONS: Record<string, RegExp> = {
+  arch: /^(?:-arch|--arch|-d|-e)$/,
+  caffeinate: /^(?:-t|-w)$/,
+  env: /^(?:-u|--unset|-C|--chdir|-S|--split-string)$/,
+  gtimeout: /^(?:-k|-s|--kill-after|--signal)$/,
+  nice: /^(?:-n|--adjustment)$/,
+  sudo: /^(?:-u|--user|-g|--group|-h|--host|-p|--prompt|-C|--close-from|-D|--chdir|-R|--chroot|-T|--command-timeout|-U|--other-user|-r|--role)$/,
+  timeout: /^(?:-k|-s|--kill-after|--signal)$/,
+  xargs:
+    /^(?:-n|--max-args|-L|--max-lines|-I|--replace|-P|--max-procs|-s|--max-chars|-E|--eof)$/,
+};
+
 interface UnwrappedCommand {
   tokens: string[];
   /** A literal program string handed to a shell via `-c`, classified recursively. */
@@ -237,6 +255,7 @@ function unwrapCommand(input: string[]): UnwrappedCommand {
     }
     if (!LITERAL_COMMAND_PREFIXES.has(head)) return { tokens, nestedShell: null, assignedValues };
 
+    const valueOptions = PREFIX_VALUE_OPTIONS[head];
     let index = 1;
     while (index < tokens.length) {
       const token = tokens[index]!;
@@ -245,7 +264,7 @@ function unwrapCommand(input: string[]): UnwrappedCommand {
         break;
       }
       if (!token.startsWith('-')) break;
-      index += 1;
+      index += valueOptions?.test(token) ? 2 : 1;
     }
     // timeout takes a duration operand before the command it runs.
     if ((head === 'timeout' || head === 'gtimeout') && /^[\d.]+[smhd]?$/.test(tokens[index] ?? '')) {

--- a/apps/desktop/src/main/maker-host/shell-command-policy.ts
+++ b/apps/desktop/src/main/maker-host/shell-command-policy.ts
@@ -719,6 +719,36 @@ function skipArithmeticExpression(line: string, start: number): number {
   return line.length;
 }
 
+/** Skip Bash's legacy `$[ ... ]` arithmetic expansion. */
+function skipLegacyArithmeticExpression(line: string, start: number): number {
+  let depth = 1;
+  let quote: "'" | '"' | null = null;
+  let escaped = false;
+  for (let index = start + 2; index < line.length; index += 1) {
+    const char = line[index]!;
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (char === '\\' && quote !== "'") {
+      escaped = true;
+      continue;
+    }
+    if (char === "'" || char === '"') {
+      if (quote === char) quote = null;
+      else if (quote === null) quote = char;
+      continue;
+    }
+    if (quote) continue;
+    if (char === '[') {
+      depth += 1;
+      continue;
+    }
+    if (char === ']' && --depth === 0) return index + 1;
+  }
+  return line.length;
+}
+
 /** Heredoc markers on one shell line, excluding quoted text, comments and `<<<`. */
 function heredocRedirections(line: string): HeredocRedirection[] {
   const redirections: HeredocRedirection[] = [];
@@ -740,13 +770,17 @@ function heredocRedirections(line: string): HeredocRedirection[] {
       continue;
     }
     if (quote) continue;
-    // `<<` inside `$(( ... ))` / `(( ... ))` is arithmetic left shift, not a
-    // shell heredoc. Skip the complete expression before looking for markers.
+    // `<<` inside arithmetic syntax is left shift, not a shell heredoc. Skip
+    // both current `$(( ... ))` / `(( ... ))` and Bash's legacy `$[ ... ]`.
     if (
       (char === '$' && line[index + 1] === '(' && line[index + 2] === '(') ||
       (char === '(' && line[index + 1] === '(')
     ) {
       index = skipArithmeticExpression(line, index) - 1;
+      continue;
+    }
+    if (char === '$' && line[index + 1] === '[') {
+      index = skipLegacyArithmeticExpression(line, index) - 1;
       continue;
     }
     // In shell grammar `#` starts a comment when it begins a word. A marker in
@@ -1006,8 +1040,11 @@ function containsSimulatorRecipe(command: string, depth = 0): boolean {
     if (containsSimulatorRecipe(nested, depth + 1)) return true;
   }
   const assignments = new Map<string, string[]>();
-  const referencedAssignmentContainsRecipe = (reference: string): boolean => {
-    for (const [name, values] of assignments) {
+  const referencedAssignmentContainsRecipe = (
+    reference: string,
+    visibleAssignments: Map<string, string[]> = assignments,
+  ): boolean => {
+    for (const [name, values] of visibleAssignments) {
       // The name matched `[A-Za-z_][A-Za-z0-9_]*`, so it carries no regex syntax.
       if (!new RegExp(`\\$\\{?${name}\\b`).test(reference)) continue;
       if (values.some((value) => containsSimulatorRecipe(value, depth + 1))) return true;
@@ -1016,6 +1053,7 @@ function containsSimulatorRecipe(command: string, depth = 0): boolean {
   };
   for (const segment of shellSegments(executableCommand)) {
     const unwrapped = unwrapCommand(tokenizeShellSegment(segment.command));
+    const commandScopedAssignments = new Map<string, string[]>();
     // Shell assignments replace the previous value before the command in this
     // segment runs. A `;`/newline-separated assignment therefore supersedes the
     // previous value, while a conditional, pipeline or background edge can skip
@@ -1028,21 +1066,35 @@ function containsSimulatorRecipe(command: string, depth = 0): boolean {
         && unwrapped.nestedShell === null;
       if (persistentAssignment) {
         assignments.set(assignment.name, [assignment.value]);
+      } else if (unwrapped.tokens.length > 0 || unwrapped.nestedShell !== null) {
+        // A leading assignment shadows the exported value only for this
+        // command. Use its last value while classifying the child, then leave
+        // the parent-shell possibilities unchanged for later segments.
+        commandScopedAssignments.set(assignment.name, [assignment.value]);
       } else {
         const possibleValues = assignments.get(assignment.name) ?? [];
         possibleValues.push(assignment.value);
         assignments.set(assignment.name, possibleValues);
       }
     }
+    const visibleAssignments = new Map(assignments);
+    for (const [name, values] of commandScopedAssignments) {
+      visibleAssignments.set(name, values);
+    }
     if (unwrapped.nestedShell !== null) {
       // `eval "$CMD"` and `sh -c "$CMD"` run a variable this scan cannot resolve.
-      if (referencedAssignmentContainsRecipe(unwrapped.nestedShell)) return true;
+      if (referencedAssignmentContainsRecipe(unwrapped.nestedShell, visibleAssignments)) {
+        return true;
+      }
       if (containsSimulatorRecipe(unwrapped.nestedShell, depth + 1)) return true;
       continue;
     }
     // A variable in the command word position is run as the command itself.
     const commandWord = unwrapped.tokens[0];
-    if (commandWord?.includes('$') && referencedAssignmentContainsRecipe(commandWord)) return true;
+    if (
+      commandWord?.includes('$')
+      && referencedAssignmentContainsRecipe(commandWord, visibleAssignments)
+    ) return true;
     if (isSimulatorRecipeArgv(unwrapped.tokens)) return true;
     if (containsInterpreterSimulatorPayload(unwrapped.tokens)) return true;
   }

--- a/apps/desktop/src/main/maker-host/shell-command-policy.ts
+++ b/apps/desktop/src/main/maker-host/shell-command-policy.ts
@@ -46,14 +46,30 @@ const IOS_SIMULATOR_SHELL_DENIAL =
 
 const MAX_RECURSION_DEPTH = 8;
 
+interface ShellSegment {
+  command: string;
+  /** The operator that ran before this command; null for the first segment. */
+  precedingOperator: ';' | '&&' | '||' | '|' | '&' | null;
+}
+
 /** Split command lists without treating separators inside quotes as boundaries. */
-function shellSegments(command: string): string[] {
-  const segments: string[] = [];
+function shellSegments(command: string): ShellSegment[] {
+  const segments: ShellSegment[] = [];
   let current = '';
   let quote: "'" | '"' | null = null;
   let escaped = false;
+  let precedingOperator: ShellSegment['precedingOperator'] = null;
 
-  for (const char of command) {
+  const flush = (nextOperator: Exclude<ShellSegment['precedingOperator'], null>): void => {
+    if (current.trim()) {
+      segments.push({ command: current.trim(), precedingOperator });
+    }
+    current = '';
+    precedingOperator = nextOperator;
+  };
+
+  for (let index = 0; index < command.length; index += 1) {
+    const char = command[index]!;
     if (escaped) {
       current += char;
       escaped = false;
@@ -74,15 +90,69 @@ function shellSegments(command: string): string[] {
       quote = char;
       continue;
     }
-    if (char === '\n' || char === ';' || char === '|' || char === '&') {
-      if (current.trim()) segments.push(current.trim());
-      current = '';
+    if (char === '\n' || char === ';') {
+      flush(';');
+      continue;
+    }
+    if (
+      (char === '&' && (command[index - 1] === '>' || command[index - 1] === '<')) ||
+      (char === '&' && command[index + 1] === '>') ||
+      (char === '|' && command[index - 1] === '>')
+    ) {
+      current += char;
+      continue;
+    }
+    if (char === '|' || char === '&') {
+      if (char === '|' && command[index + 1] === '&') {
+        flush('|');
+        index += 1;
+        continue;
+      }
+      const doubled = command[index + 1] === char;
+      flush(doubled ? (char === '|' ? '||' : '&&') : char);
+      if (doubled) index += 1;
       continue;
     }
     current += char;
   }
-  if (current.trim()) segments.push(current.trim());
+  if (current.trim()) segments.push({ command: current.trim(), precedingOperator });
   return segments;
+}
+
+/** Whether a segment's assignments definitely replace values in the current scope. */
+function assignmentDefinitelyRunsInCurrentScope(segment: ShellSegment): boolean {
+  if (segment.precedingOperator !== null && segment.precedingOperator !== ';') return false;
+  let quote: "'" | '"' | null = null;
+  let escaped = false;
+  let unquoted = '';
+  for (const char of segment.command) {
+    if (escaped) {
+      unquoted += ' ';
+      escaped = false;
+      continue;
+    }
+    if (char === '\\' && quote !== "'") {
+      unquoted += ' ';
+      escaped = true;
+      continue;
+    }
+    if (quote) {
+      unquoted += ' ';
+      if (char === quote) quote = null;
+      continue;
+    }
+    if (char === "'" || char === '"') {
+      unquoted += ' ';
+      quote = char;
+      continue;
+    }
+    if (char === '(' || char === ')' || char === '`') return false;
+    unquoted += char;
+  }
+  const start = unquoted.trimStart();
+  return !/^(?:(?:\{|!)\s*|(?:then|do|else|elif|if|while|until|for|select|case|function)\b)/.test(
+    start,
+  );
 }
 
 /** Lightweight argv tokenizer. Quotes group tokens but are not retained. */
@@ -457,39 +527,42 @@ function containsSimulatorRecipe(command: string, depth = 0): boolean {
   for (const nested of shellSubcommands(command)) {
     if (containsSimulatorRecipe(nested, depth + 1)) return true;
   }
-  const assignments: ShellAssignment[] = [];
-  const executedReferences: string[] = [];
+  const assignments = new Map<string, string[]>();
+  const referencedAssignmentContainsRecipe = (reference: string): boolean => {
+    for (const [name, values] of assignments) {
+      // The name matched `[A-Za-z_][A-Za-z0-9_]*`, so it carries no regex syntax.
+      if (!new RegExp(`\\$\\{?${name}\\b`).test(reference)) continue;
+      if (values.some((value) => containsSimulatorRecipe(value, depth + 1))) return true;
+    }
+    return false;
+  };
   for (const segment of shellSegments(command)) {
-    const unwrapped = unwrapCommand(tokenizeShellSegment(segment));
-    assignments.push(...unwrapped.assignments);
+    const unwrapped = unwrapCommand(tokenizeShellSegment(segment.command));
+    // Shell assignments replace the previous value before the command in this
+    // segment runs. A `;`/newline-separated assignment therefore supersedes the
+    // previous value, while a conditional, pipeline or background edge can skip
+    // it or isolate its scope, so both values remain possible there.
+    for (const assignment of unwrapped.assignments) {
+      if (assignment.name === '') continue;
+      if (assignmentDefinitelyRunsInCurrentScope(segment)) {
+        assignments.set(assignment.name, [assignment.value]);
+      } else {
+        const possibleValues = assignments.get(assignment.name) ?? [];
+        possibleValues.push(assignment.value);
+        assignments.set(assignment.name, possibleValues);
+      }
+    }
     if (unwrapped.nestedShell !== null) {
       // `eval "$CMD"` and `sh -c "$CMD"` run a variable this scan cannot resolve.
-      executedReferences.push(unwrapped.nestedShell);
+      if (referencedAssignmentContainsRecipe(unwrapped.nestedShell)) return true;
       if (containsSimulatorRecipe(unwrapped.nestedShell, depth + 1)) return true;
       continue;
     }
     // A variable in the command word position is run as the command itself.
     const commandWord = unwrapped.tokens[0];
-    if (commandWord?.includes('$')) executedReferences.push(commandWord);
+    if (commandWord?.includes('$') && referencedAssignmentContainsRecipe(commandWord)) return true;
     if (isSimulatorRecipeArgv(unwrapped.tokens)) return true;
     if (containsInterpreterSimulatorPayload(unwrapped.tokens)) return true;
-  }
-
-  // `CMD="xcrun simctl boot $UDID"; eval "$CMD"` holds a whole recipe, and
-  // documentation does write it that way before running it. The value only
-  // matters once something runs it, though: `printf '%s\n' "$CMD"` prints the
-  // string and executes nothing, so classifying every stored value would deny a
-  // command that never reaches a simulator. The value goes through the same
-  // classifier as a command, so a documented prefix, a nested `bash -lc '…'` or a
-  // substitution inside it is reached too.
-  for (const assignment of assignments) {
-    if (assignment.name === '') continue;
-    // The name matched `[A-Za-z_][A-Za-z0-9_]*`, so it carries no regex syntax.
-    const referenced = executedReferences.some((reference) =>
-      new RegExp(`\\$\\{?${assignment.name}\\b`).test(reference),
-    );
-    if (!referenced) continue;
-    if (containsSimulatorRecipe(assignment.value, depth + 1)) return true;
   }
   return false;
 }

--- a/apps/desktop/src/main/maker-host/shell-command-policy.ts
+++ b/apps/desktop/src/main/maker-host/shell-command-policy.ts
@@ -236,6 +236,73 @@ function shellRedirectionSuffix(token: string): string | null {
   return match ? (match[1] ?? '') : null;
 }
 
+function redirectionAt(segment: string, index: number): string | null {
+  if (
+    (segment[index] === '<' || segment[index] === '>')
+    && segment[index + 1] === '('
+  ) return null;
+  const wordStart = index === 0 || /\s/.test(segment[index - 1]!);
+  const prefix = wordStart ? '(?:(?:\\d+|\\{[A-Za-z_][A-Za-z0-9_]*\\}))?' : '';
+  return new RegExp(`^${prefix}(?:&>>?|<<<|<<-|<<|<>|>>|>&|<&|>\\||<|>)`).exec(
+    segment.slice(index),
+  )?.[0] ?? null;
+}
+
+/** Remove unquoted redirections before deciding whether stdin is the program. */
+function tokenizeHeredocConsumer(segment: string): string[] {
+  let command = '';
+  let quote: "'" | '"' | null = null;
+  let escaped = false;
+  for (let index = 0; index < segment.length; index += 1) {
+    const char = segment[index]!;
+    if (escaped) {
+      command += char;
+      escaped = false;
+      continue;
+    }
+    if (char === '\\' && quote !== "'") {
+      command += char;
+      escaped = true;
+      continue;
+    }
+    if (char === "'" || char === '"') {
+      command += char;
+      if (quote === char) quote = null;
+      else if (quote === null) quote = char;
+      continue;
+    }
+    const redirection = quote === null ? redirectionAt(segment, index) : null;
+    if (redirection === null) {
+      command += char;
+      continue;
+    }
+    index += redirection.length;
+    while (/\s/.test(segment[index] ?? '')) index += 1;
+    let targetQuote: "'" | '"' | null = null;
+    let targetEscaped = false;
+    for (; index < segment.length; index += 1) {
+      const target = segment[index]!;
+      if (targetEscaped) {
+        targetEscaped = false;
+        continue;
+      }
+      if (target === '\\' && targetQuote !== "'") {
+        targetEscaped = true;
+        continue;
+      }
+      if (target === "'" || target === '"') {
+        if (targetQuote === target) targetQuote = null;
+        else if (targetQuote === null) targetQuote = target;
+        continue;
+      }
+      if (targetQuote === null && (/\s/.test(target) || redirectionAt(segment, index))) break;
+    }
+    command += ' ';
+    index -= 1;
+  }
+  return tokenizeShellSegment(command);
+}
+
 /** A `NAME=value` assignment, whose value may hold a whole recipe. */
 interface ShellAssignment {
   name: string;
@@ -642,7 +709,7 @@ function heredocBodyIsProgram(line: string, marker: string): boolean {
     if (index > openingIndex && segment.precedingOperator !== '|') break;
     if (
       consumesStdinAsProgram(
-        tokenizeShellSegment(segment.command.replace(marker, ' ')),
+        tokenizeHeredocConsumer(segment.command.replace(marker, ' ')),
       )
     ) return true;
   }

--- a/apps/desktop/src/main/maker-host/shell-command-policy.ts
+++ b/apps/desktop/src/main/maker-host/shell-command-policy.ts
@@ -1,14 +1,29 @@
 /**
  * Product-owned shell command policy for the embedded iOS Simulator.
  *
- * Agent skills may contain legacy `simctl` / `open -a Simulator` recipes. Those
- * commands bypass Cindy's ownership, admission, viewer, and cleanup contracts,
- * so prompt guidance alone is not a sufficient boundary. This module detects
- * literal executable shell segments and denies only the bypass paths; Cindy's
- * own main process still uses simctl through the runtime adapter and is
- * unaffected. This is defense in depth for command text, not an OS process
- * sandbox: scripts whose contents are absent from the command cannot be proven
- * safe here and remain subject to the normal shell permission boundary.
+ * **Threat model: a stale recipe.** A Skill, a README or the model's own memory
+ * still carries a pre-Cindy incantation (`xcrun simctl boot …`,
+ * `open -a Simulator`) and the Agent copies it verbatim. Such recipes are
+ * literal by construction — they come from documentation, so they never disguise
+ * themselves — and a literal matcher catches all of them. Cindy's own main
+ * process reaches simctl through the runtime adapter and is unaffected, and the
+ * capability gate means this policy only applies where an embedded simulator
+ * actually exists to protect.
+ *
+ * **Deliberately outside the threat model: writing around this policy.** Command
+ * text cannot decide that case at all — `bash script.sh` moves the executor out
+ * of the command entirely, and no amount of parsing recovers it. Trying anyway is
+ * what made this module deny ordinary work: it had to fail closed on every shape
+ * it could not resolve, and in shell that is most shapes, so `print(len(data))`
+ * in a heredoc, `(( n > 1 ))`, a glob-leading line, `{ …; } > file` and a commit
+ * message containing a Markdown backtick were all rejected with no Simulator
+ * executor anywhere in the command. This matcher denies only what it can read
+ * directly and lets everything else reach the normal shell permission flow.
+ *
+ * A useful consequence: a recipe delivered through a heredoc needs no heredoc
+ * modelling. Bodies are split into segments like any other text, and a body line
+ * only matters when it literally spells out a Simulator command — so
+ * `git commit -F - <<'MSG'` carrying backticks is simply not a match.
  */
 
 export interface ShellCommandPolicyDenial {
@@ -27,9 +42,11 @@ const SAFE_SIMCTL_COMMANDS = new Set([
 
 const IOS_SIMULATOR_SHELL_DENIAL =
   'Cindy blocked a shell command that would bypass the embedded iOS Simulator. ' +
-  'Use cindy_ios_simulator for device lifecycle, app install/launch, interaction, screenshots, and diagnostics. External Simulator.app automation is unavailable until Cindy can issue an explicit host authorization.';
+  'Use cindy_ios_simulator for device lifecycle, app install/launch, interaction, screenshots, and diagnostics.';
 
-/** Split command lists without treating separators inside quotes as executable boundaries. */
+const MAX_RECURSION_DEPTH = 8;
+
+/** Split command lists without treating separators inside quotes as boundaries. */
 function shellSegments(command: string): string[] {
   const segments: string[] = [];
   let current = '';
@@ -117,6 +134,7 @@ function executableName(token: string | undefined): string {
     .toLowerCase();
 }
 
+/** Drop compound-command keywords and braces so the next token is the command word. */
 function stripShellControlTokens(tokens: string[]): string[] {
   const out = [...tokens];
   while (out.length > 0 && /^(?:\{|\(|!|then|do|else|elif|if|while|until)$/.test(out[0]!)) {
@@ -137,25 +155,21 @@ function shellRedirectionSuffix(token: string): string | null {
   return match ? (match[1] ?? '') : null;
 }
 
-function stripShellRedirections(input: string[]): string[] {
-  const tokens: string[] = [];
-  for (let index = 0; index < input.length; index += 1) {
-    const suffix = shellRedirectionSuffix(input[index]!);
-    if (suffix === null) {
-      tokens.push(input[index]!);
-      continue;
-    }
-    if (suffix === '' && index + 1 < input.length) index += 1;
-  }
-  return tokens;
+interface Preamble {
+  tokens: string[];
+  /** Values of leading `NAME=value` assignments, which may hold a whole recipe. */
+  assignedValues: string[];
 }
 
-/** Remove leading assignments/redirections so the next token is the command word. */
-function stripLeadingShellPreamble(input: string[]): string[] {
+/** Remove leading assignments and redirections so the next token is the command word. */
+function stripLeadingShellPreamble(input: string[]): Preamble {
   const tokens = [...input];
+  const assignedValues: string[] = [];
   while (tokens.length > 0) {
     const token = tokens[0]!;
-    if (/^[A-Za-z_][A-Za-z0-9_]*=/.test(token)) {
+    const assignment = /^[A-Za-z_][A-Za-z0-9_]*=([\s\S]*)$/.exec(token);
+    if (assignment) {
+      assignedValues.push(assignment[1] ?? '');
       tokens.shift();
       continue;
     }
@@ -164,375 +178,89 @@ function stripLeadingShellPreamble(input: string[]): string[] {
     tokens.shift();
     if (redirectionSuffix === '' && tokens.length > 0) tokens.shift();
   }
-  return tokens;
+  return { tokens, assignedValues };
 }
+
+const SHELL_EXECUTABLES = new Set(['bash', 'csh', 'dash', 'fish', 'ksh', 'sh', 'tcsh', 'zsh']);
+const PROGRAMMABLE_INTERPRETER =
+  /^(?:python(?:\d+(?:\.\d+)*)?|pypy(?:\d+(?:\.\d+)*)?|node|nodejs|bun|deno|ruby(?:\d+(?:\.\d+)*)?|perl(?:\d+(?:\.\d+)*)?|php(?:\d+(?:\.\d+)*)?|lua(?:\d+(?:\.\d+)*)?|luajit|swift|expect(?:\d+(?:\.\d+)*)?|tclsh(?:\d+(?:\.\d+)*)?|wish(?:\d+(?:\.\d+)*)?|(?:g|m|n)?awk|osascript)$/;
+
+/**
+ * Prefixes documentation puts in front of a recipe. Peeling is best-effort: an
+ * unfamiliar option shape simply stops the peel, because mislocating the command
+ * word now costs a missed literal instead of a denied ordinary command.
+ */
+const LITERAL_COMMAND_PREFIXES = new Set([
+  'arch',
+  'builtin',
+  'caffeinate',
+  'command',
+  'env',
+  'exec',
+  'gtimeout',
+  'nice',
+  'nocorrect',
+  'noglob',
+  'nohup',
+  'sudo',
+  'time',
+  'timeout',
+  'xargs',
+]);
 
 interface UnwrappedCommand {
   tokens: string[];
+  /** A literal program string handed to a shell via `-c`, classified recursively. */
   nestedShell: string | null;
-  inspectionOnly: boolean;
-  unresolvedWrapper: boolean;
+  assignedValues: string[];
 }
 
-const MAX_WRAPPER_UNWRAP_DEPTH = 16;
-const SHELL_EXECUTABLES = new Set(['bash', 'csh', 'dash', 'fish', 'ksh', 'sh', 'tcsh', 'zsh']);
-const NON_EXECUTING_REFERENCE_COMMANDS = new Set([
-  'cat',
-  'echo',
-  'egrep',
-  'fgrep',
-  'file',
-  'grep',
-  'head',
-  'less',
-  'ls',
-  'more',
-  'printf',
-  'rg',
-  'stat',
-  'tail',
-  'wc',
-]);
-const OPAQUE_EXECUTION_WRAPPERS = new Set([
-  'coproc',
-  'doas',
-  'gtimeout',
-  'launchctl',
-  'parallel',
-  'repeat',
-  'sandbox-exec',
-  'script',
-  'sudo',
-  'timeout',
-  'watch',
-  'xargs',
-]);
-const SHELL_POSITIONAL_REFERENCE = /\$(?:[0-9]+|[@*#-]|\{(?:[0-9]+|[@*#-])\})/;
-const PROGRAMMABLE_INTERPRETER =
-  /^(?:python(?:\d+(?:\.\d+)*)?|pypy(?:\d+(?:\.\d+)*)?|node|nodejs|bun|deno|ruby(?:\d+(?:\.\d+)*)?|perl(?:\d+(?:\.\d+)*)?|php(?:\d+(?:\.\d+)*)?|lua(?:\d+(?:\.\d+)*)?|luajit|swift|expect(?:\d+(?:\.\d+)*)?|tclsh(?:\d+(?:\.\d+)*)?|wish(?:\d+(?:\.\d+)*)?|(?:g|m|n)?awk)$/;
-
-/** Peel only wrappers whose argv shape is fully understood; unknown options fail closed. */
+/** Peel documentation-style prefixes to reach the command word. */
 function unwrapCommand(input: string[]): UnwrappedCommand {
-  let tokens = stripLeadingShellPreamble(stripShellControlTokens(input));
-  for (let depth = 0; depth < MAX_WRAPPER_UNWRAP_DEPTH; depth += 1) {
-    tokens = stripLeadingShellPreamble(tokens);
-    if (tokens.length === 0) {
-      return { tokens, nestedShell: null, inspectionOnly: false, unresolvedWrapper: false };
-    }
+  const first = stripLeadingShellPreamble(stripShellControlTokens(input));
+  let tokens = first.tokens;
+  const assignedValues = [...first.assignedValues];
+  for (let depth = 0; depth < MAX_RECURSION_DEPTH; depth += 1) {
+    const peeled = stripLeadingShellPreamble(tokens);
+    tokens = peeled.tokens;
+    assignedValues.push(...peeled.assignedValues);
+    if (tokens.length === 0) return { tokens, nestedShell: null, assignedValues };
     const head = executableName(tokens[0]);
-    if (head === 'env') {
-      let index = 1;
-      let unresolved = false;
-      while (index < tokens.length) {
-        const token = tokens[index]!;
-        if (token === '--') {
-          index += 1;
-          break;
-        }
-        if (
-          token === '-' ||
-          token === '-i' ||
-          token === '--ignore-environment' ||
-          token === '-0' ||
-          token === '--null'
-        ) {
-          index += 1;
-          continue;
-        }
-        if (token === '-u' || token === '--unset' || token === '-C' || token === '--chdir') {
-          if (index + 1 >= tokens.length) unresolved = true;
-          index += 2;
-          continue;
-        }
-        if (
-          /^--(?:unset|chdir)=/.test(token) ||
-          /^-(?:u|C).+/.test(token) ||
-          /^[A-Za-z_][A-Za-z0-9_]*=/.test(token)
-        ) {
-          index += 1;
-          continue;
-        }
-        if (token.startsWith('-')) unresolved = true;
-        break;
-      }
-      tokens = tokens.slice(index);
-      if (unresolved) {
-        return { tokens, nestedShell: null, inspectionOnly: false, unresolvedWrapper: true };
-      }
-      continue;
-    }
-    if (head === 'command') {
-      let index = 1;
-      let inspectionOnly = false;
-      while (index < tokens.length) {
-        const token = tokens[index]!;
-        if (token === '--') {
-          index += 1;
-          break;
-        }
-        if (/^-[pVv]+$/.test(token)) {
-          inspectionOnly ||= /[Vv]/.test(token);
-          index += 1;
-          continue;
-        }
-        if (token.startsWith('-')) {
-          return {
-            tokens: tokens.slice(index),
-            nestedShell: null,
-            inspectionOnly: false,
-            unresolvedWrapper: true,
-          };
-        }
-        break;
-      }
-      if (inspectionOnly) {
-        return { tokens: [], nestedShell: null, inspectionOnly: true, unresolvedWrapper: false };
-      }
-      tokens = tokens.slice(index);
-      continue;
-    }
-    if (head === 'exec') {
-      let index = 1;
-      while (index < tokens.length) {
-        const token = tokens[index]!;
-        if (token === '--') {
-          index += 1;
-          break;
-        }
-        if (token === '-a') {
-          if (index + 1 >= tokens.length) {
-            return {
-              tokens: [],
-              nestedShell: null,
-              inspectionOnly: false,
-              unresolvedWrapper: true,
-            };
-          }
-          index += 2;
-          continue;
-        }
-        if (/^-a.+/.test(token) || /^-[cl]+$/.test(token)) {
-          index += 1;
-          continue;
-        }
-        if (token.startsWith('-')) {
-          return {
-            tokens: tokens.slice(index),
-            nestedShell: null,
-            inspectionOnly: false,
-            unresolvedWrapper: true,
-          };
-        }
-        break;
-      }
-      tokens = tokens.slice(index);
-      continue;
-    }
-    if (head === 'time') {
-      let index = 1;
-      while (index < tokens.length) {
-        const token = tokens[index]!;
-        if (token === '--') {
-          index += 1;
-          break;
-        }
-        if (/^-[alhp]+$/.test(token)) {
-          index += 1;
-          continue;
-        }
-        if (token === '-o') {
-          if (index + 1 >= tokens.length) {
-            return {
-              tokens: [],
-              nestedShell: null,
-              inspectionOnly: false,
-              unresolvedWrapper: true,
-            };
-          }
-          index += 2;
-          continue;
-        }
-        if (/^-o.+/.test(token)) {
-          index += 1;
-          continue;
-        }
-        if (token.startsWith('-')) {
-          return {
-            tokens: tokens.slice(index),
-            nestedShell: null,
-            inspectionOnly: false,
-            unresolvedWrapper: true,
-          };
-        }
-        break;
-      }
-      tokens = tokens.slice(index);
-      continue;
-    }
-    if (head === 'builtin' || head === 'nocorrect' || head === 'noglob' || head === 'nohup') {
-      let index = 1;
-      if (tokens[index] === '--') index += 1;
-      else if (tokens[index]?.startsWith('-')) {
-        return {
-          tokens: tokens.slice(index),
-          nestedShell: null,
-          inspectionOnly: false,
-          unresolvedWrapper: true,
-        };
-      }
-      tokens = tokens.slice(index);
-      continue;
-    }
-    if (head === 'nice') {
-      let index = 1;
-      while (index < tokens.length) {
-        const token = tokens[index]!;
-        if (token === '--') {
-          index += 1;
-          break;
-        }
-        if (token === '-n' || token === '--adjustment') {
-          if (index + 1 >= tokens.length) {
-            return {
-              tokens: [],
-              nestedShell: null,
-              inspectionOnly: false,
-              unresolvedWrapper: true,
-            };
-          }
-          index += 2;
-          continue;
-        }
-        if (/^(?:--adjustment=.+|-\d+)$/.test(token)) {
-          index += 1;
-          continue;
-        }
-        if (token.startsWith('-')) {
-          return {
-            tokens: tokens.slice(index),
-            nestedShell: null,
-            inspectionOnly: false,
-            unresolvedWrapper: true,
-          };
-        }
-        break;
-      }
-      tokens = tokens.slice(index);
-      continue;
-    }
-    if (head === 'arch') {
-      let index = 1;
-      while (index < tokens.length) {
-        const token = tokens[index]!;
-        if (token === '--') {
-          index += 1;
-          break;
-        }
-        if (token === '-arch' || token === '--arch' || token === '-d' || token === '-e') {
-          if (index + 1 >= tokens.length) {
-            return {
-              tokens: [],
-              nestedShell: null,
-              inspectionOnly: false,
-              unresolvedWrapper: true,
-            };
-          }
-          index += 2;
-          continue;
-        }
-        if (/^-(?:arm64e?|x86_64|i386|32|64|c)$/.test(token)) {
-          index += 1;
-          continue;
-        }
-        if (token.startsWith('-')) {
-          return {
-            tokens: tokens.slice(index),
-            nestedShell: null,
-            inspectionOnly: false,
-            unresolvedWrapper: true,
-          };
-        }
-        break;
-      }
-      tokens = tokens.slice(index);
-      continue;
-    }
-    if (head === 'caffeinate') {
-      let index = 1;
-      while (index < tokens.length) {
-        const token = tokens[index]!;
-        if (token === '--') {
-          index += 1;
-          break;
-        }
-        if (token === '-t' || token === '-w') {
-          if (index + 1 >= tokens.length) {
-            return {
-              tokens: [],
-              nestedShell: null,
-              inspectionOnly: false,
-              unresolvedWrapper: true,
-            };
-          }
-          index += 2;
-          continue;
-        }
-        if (/^-[dimsur]+$/.test(token)) {
-          index += 1;
-          continue;
-        }
-        if (token.startsWith('-')) {
-          return {
-            tokens: tokens.slice(index),
-            nestedShell: null,
-            inspectionOnly: false,
-            unresolvedWrapper: true,
-          };
-        }
-        break;
-      }
-      tokens = tokens.slice(index);
-      continue;
+
+    if (SHELL_EXECUTABLES.has(head)) {
+      const flag = tokens.findIndex((token) => /^-[A-Za-z]*c[A-Za-z]*$/.test(token));
+      if (flag > 0) return { tokens: [], nestedShell: tokens[flag + 1] ?? '', assignedValues };
+      return { tokens, nestedShell: null, assignedValues };
     }
     if (head === 'eval') {
-      return {
-        tokens: [],
-        nestedShell: tokens.slice(1).join(' '),
-        inspectionOnly: false,
-        unresolvedWrapper: false,
-      };
+      return { tokens: [], nestedShell: tokens.slice(1).join(' '), assignedValues };
     }
-    if (SHELL_EXECUTABLES.has(head)) {
-      let index = 1;
-      while (index < tokens.length) {
-        const token = tokens[index]!;
-        if (token === '-o' || token === '-O') {
-          index += 2;
-          continue;
-        }
-        if (/^-[A-Za-z]*c[A-Za-z]*$/.test(token)) {
-          const nestedShell = tokens[index + 1] ?? '';
-          const positionalArgs = tokens.slice(index + 2);
-          return {
-            tokens: positionalArgs,
-            nestedShell,
-            inspectionOnly: false,
-            unresolvedWrapper:
-              index + 1 >= tokens.length ||
-              (SHELL_POSITIONAL_REFERENCE.test(nestedShell) &&
-                containsSimulatorExecutor(positionalArgs)),
-          };
-        }
-        if (token === '--') break;
-        if (!token.startsWith('-')) break;
+    if (!LITERAL_COMMAND_PREFIXES.has(head)) return { tokens, nestedShell: null, assignedValues };
+
+    let index = 1;
+    while (index < tokens.length) {
+      const token = tokens[index]!;
+      if (token === '--') {
         index += 1;
+        break;
       }
+      if (!token.startsWith('-')) break;
+      index += 1;
     }
-    return { tokens, nestedShell: null, inspectionOnly: false, unresolvedWrapper: false };
+    // timeout takes a duration operand before the command it runs.
+    if ((head === 'timeout' || head === 'gtimeout') && /^[\d.]+[smhd]?$/.test(tokens[index] ?? '')) {
+      index += 1;
+    }
+    const next = tokens.slice(index);
+    if (next.length === 0 || next.length === tokens.length) {
+      return { tokens: next, nestedShell: null, assignedValues };
+    }
+    tokens = next;
   }
-  return { tokens, nestedShell: null, inspectionOnly: false, unresolvedWrapper: true };
+  return { tokens, nestedShell: null, assignedValues };
 }
 
+/** `open -a Simulator` and the Simulator binary, in their documented spellings. */
 function isExternalSimulatorLaunch(tokens: string[]): boolean {
   const head = executableName(tokens[0]);
   if (head === 'open') {
@@ -553,22 +281,19 @@ function isExternalSimulatorLaunch(tokens: string[]): boolean {
   );
 }
 
+/** The simctl subcommand of a literal `[xcrun] simctl …` invocation, or null. */
 function simctlSubcommand(tokens: string[]): string | null {
   let index = 0;
   if (executableName(tokens[index]) === 'xcrun') {
     index += 1;
     while (index < tokens.length && tokens[index]!.startsWith('-')) {
       const option = tokens[index]!;
-      if (
+      const takesValue =
         option === '--sdk' ||
         option === '-sdk' ||
         option === '--toolchain' ||
-        option === '-toolchain'
-      ) {
-        index += 2;
-      } else {
-        index += 1;
-      }
+        option === '-toolchain';
+      index += takesValue ? 2 : 1;
     }
   }
   if (executableName(tokens[index]) !== 'simctl') return null;
@@ -582,225 +307,34 @@ function isSimulatorMutation(tokens: string[]): boolean {
   return subcommand !== null && !SAFE_SIMCTL_COMMANDS.has(subcommand);
 }
 
-function containsSimulatorExecutor(tokens: string[]): boolean {
-  return tokens.some(
-    (token) =>
-      /(?:^|\/)simctl$/i.test(token) ||
-      /Simulator(?:\.app)?/i.test(token) ||
-      /\bxcrun\b[\s\S]*\bsimctl\b/i.test(token),
-  );
+function isSimulatorRecipeArgv(tokens: string[]): boolean {
+  return isExternalSimulatorLaunch(tokens) || isSimulatorMutation(tokens);
 }
 
+/** A Simulator command spelled out in free text, used for interpreter payloads. */
 function containsLiteralSimulatorExecutor(value: string): boolean {
   const argvLike = value.replace(/[^A-Za-z0-9_./-]+/g, ' ').trim();
   return (
-    /\b(?:xcrun|simctl)\b/i.test(value) ||
+    /\bxcrun\b[\s\S]*\bsimctl\b/i.test(value) ||
+    /(?:^|[^\w./-])simctl\s+\S/i.test(argvLike) ||
     /\bSimulator\.app\b/i.test(value) ||
     /\bcom\.apple\.iphonesimulator\b/i.test(value) ||
     /(?:^|\s)(?:\S*\/)?open(?:\s+-[A-Za-z]+)*\s+Simulator(?:\.app)?(?:\s|$)/i.test(argvLike)
   );
 }
 
-const MAX_ASSIGNMENT_RESOLUTION_PASSES = 4;
-const MAX_RESOLVED_ASSIGNMENTS = 64;
-const MAX_RESOLUTION_GROWTH_FACTOR = 8;
-const SIMULATOR_EXECUTOR_NAMES = ['xcrun', 'simctl'];
-const MIN_SIMULATOR_FRAGMENT_LENGTH = 4;
-
 /**
- * Join fragments a shell or interpreter concatenates: `"xcr" + "un"`,
- * `xcr"un"`, AppleScript's `"xcr" & "un"`, and the sequence forms interpreters
- * join from (`''.join(('xc','run'))`).
- *
- * This is a finite set of forms and cannot cover arbitrary computation — a
- * payload is free to assemble a name from base64 or character codes. Command
- * text alone cannot decide those, which the module header already concedes for
- * script contents; the evidence tests below are defence in depth, not a proof.
- */
-function normalizeConcatenatedFragments(command: string): string {
-  return command
-    .replace(/(['"`])\s*[+&,]\s*\1?/g, '')
-    .replace(/(['"`])\s*\1/g, '')
-    .replace(/['"`]/g, '');
-}
-
-/** Resolve literal `NAME=value` assignments so `"$A$B"` reveals its executor. */
-function resolveSimpleAssignments(command: string): string {
-  const values = new Map<string, string>();
-  for (const match of command.matchAll(
-    /(?:^|[\s;&|(])([A-Za-z_][A-Za-z0-9_]*)=(?:'([^']*)'|"([^"$`]*)"|([A-Za-z0-9_./:+-]*))/g,
-  )) {
-    const value = match[2] ?? match[3] ?? match[4] ?? '';
-    if (value) values.set(match[1]!, value);
-    // Bound the work: this runs inside a synchronous hook and a Codex event
-    // handler, so a pathological command must not be able to stall either.
-    if (values.size >= MAX_RESOLVED_ASSIGNMENTS) break;
-  }
-  if (values.size === 0) return command;
-  const budget = command.length * MAX_RESOLUTION_GROWTH_FACTOR;
-  let resolved = command;
-  for (let pass = 0; pass < MAX_ASSIGNMENT_RESOLUTION_PASSES; pass += 1) {
-    let changed = false;
-    for (const [name, value] of values) {
-      const next = resolved.replace(new RegExp(`\\$(?:${name}\\b|\\{${name}\\})`, 'g'), value);
-      if (next !== resolved) {
-        resolved = next;
-        changed = true;
-      }
-      // Self-referential values (`A='$A$A'`) grow geometrically. Stop expanding
-      // and classify what has been resolved so far.
-      if (resolved.length > budget) return resolved;
-    }
-    if (!changed) break;
-  }
-  return resolved;
-}
-
-/**
- * Whether the command still names the Simulator boundary once the concatenation
- * and simple-assignment tricks that hide an executor are undone.
- *
- * Evidence is never a denial by itself. It is what licenses the shape-only
- * fail-closed rules below to fire: without it, an unresolvable *shape* — a glob,
- * a paren, a brace — is just ordinary text. Interpreter payloads, heredoc bodies
- * and arithmetic expressions are full of such shapes, and denying them blocks
- * work this boundary was never meant to touch.
- */
-function hasSimulatorEvidence(command: string): boolean {
-  const resolved = resolveSimpleAssignments(command);
-  return (
-    containsLiteralSimulatorExecutor(command) ||
-    containsLiteralSimulatorExecutor(resolved) ||
-    containsLiteralSimulatorExecutor(normalizeConcatenatedFragments(resolved))
-  );
-}
-
-/** Strip expansions and glob metacharacters, leaving the literal core (if any). */
-function commandWordLiteralCore(token: string): string {
-  return (
-    token
-      .replace(/\$\([^)]*\)|`[^`]*`|\$\{[^}]*\}|\$[A-Za-z_][A-Za-z0-9_]*|\$[0-9@*#?$!-]/g, '')
-      // The tokenizer splits on whitespace inside a substitution, so a command
-      // word can end in an unterminated remnant (`si$(printf` from
-      // `si$(printf m)ctl`). Drop the remnant: a shorter core is the
-      // fail-closed direction under the subsequence test below.
-      .replace(/[$`][^\s]*$/, '')
-      // A character class or brace list holds mutually exclusive candidates, so
-      // its contents must go with its delimiters. Merging them invents a
-      // literal that matches nothing: `[sx]crun` would read as `sxcrun` and
-      // hide the `xcrun` the shell can expand to. Dropping the whole group
-      // leaves `crun`, which the subsequence test still catches.
-      .replace(/\[[^\]]*\]|\{[^}]*\}/g, '')
-      .replace(/[*?[\]{}()^~]/g, '')
-      .replace(/['"]/g, '')
-  );
-}
-
-/**
- * A word whose executable *name* is made only of expansions can resolve to
- * anything, including simctl. Only the basename selects the executable, so a
- * knowable directory prefix does not make a dynamic name provable:
- * `$DIR/build/$NAME` is as unknowable as `$NAME`.
- */
-function isPureExpansionWord(token: string): boolean {
-  if (!/[$`]/.test(token)) return false;
-  const core = commandWordLiteralCore(token).replace(/\\/g, '/');
-  const basename = core.slice(core.lastIndexOf('/') + 1);
-  return basename.replace(/[\s=,.:+-]/g, '') === '';
-}
-
-/**
- * A literal core that still points at the boundary, either because it already
- * carries most of the name (`simct?`, `simctl~foo`, `xc[r]un`) or because it is
- * a fragment of one that the stripped expansion could complete (`xcr$TAIL`,
- * `${DIR}crun`, `sim*`).
- */
-function isSimulatorFragmentCore(core: string): boolean {
-  // Trailing separators are left behind by stripped expansions (`$X/simctl/$Y`),
-  // so classify against the last segment that still carries literal text.
-  const name = (
-    core
-      .replace(/\\/g, '/')
-      .split('/')
-      .filter((segment) => segment !== '')
-      .at(-1) ?? ''
-  ).toLowerCase();
-  if (!name) return false;
-  return SIMULATOR_EXECUTOR_NAMES.some(
-    (executor) =>
-      name.startsWith(executor.slice(0, MIN_SIMULATOR_FRAGMENT_LENGTH)) ||
-      isSubsequenceOf(name, executor),
-  );
-}
-
-/**
- * Whether every character of `fragment` appears in `executor` in order. The
- * stripped expansion can supply the missing characters at any position, so
- * `si$(printf m)ctl` leaves the core `sictl` — contiguity is not a safe test.
- */
-function isSubsequenceOf(fragment: string, executor: string): boolean {
-  let index = 0;
-  for (const char of fragment) {
-    index = executor.indexOf(char, index) + 1;
-    if (index === 0) return false;
-  }
-  return true;
-}
-
-/**
- * Command position holds something this policy cannot resolve. A pure expansion
- * stays fail-closed because its value is unknowable; a word that keeps a literal
- * core is only a bypass candidate when that core, or the command around it,
- * shows Simulator evidence.
- */
-function isUnprovableCommandWord(token: string, evidence: boolean): boolean {
-  if (!hasDynamicShellExpansion(token)) return false;
-  if (isPureExpansionWord(token)) return true;
-  return evidence || isSimulatorFragmentCore(commandWordLiteralCore(token));
-}
-
-/**
- * General-purpose interpreters can spawn simctl without making it the shell
- * executable. Treat a literal Simulator executor in their payload/argv as a
- * mutation-capable wrapper; command-text policy cannot safely inspect the
- * language semantics beneath this point.
+ * A recipe pasted into an interpreter one-liner (`python3 -c 'os.system("xcrun
+ * simctl boot X")'`) is still literal, so the payload is scanned as text. Only a
+ * spelled-out command counts; assembling one from fragments is outside the threat
+ * model.
  */
 function containsInterpreterSimulatorPayload(tokens: string[]): boolean {
-  const interpreter = executableName(tokens[0]);
-  const payload = tokens.slice(1).join('\n');
-  if (PROGRAMMABLE_INTERPRETER.test(interpreter)) {
-    // Interpreters concatenate string fragments, so `"xcr" + "un"` names the
-    // same executor a literal match would miss.
-    return hasSimulatorEvidence(payload);
-  }
-  if (interpreter === 'osascript') {
-    // AppleScript can execute through `do shell script`, while JavaScript for
-    // Automation can reach NSTask/NSProcessInfo directly. Once an osascript
-    // payload names a Simulator executor, command-text policy cannot safely
-    // distinguish an inert reference from executable code.
-    return hasSimulatorEvidence(payload);
-  }
-  return false;
+  if (!PROGRAMMABLE_INTERPRETER.test(executableName(tokens[0]))) return false;
+  return containsLiteralSimulatorExecutor(tokens.slice(1).join('\n'));
 }
 
-/**
- * Fail closed when a command passes a literal Simulator executor to an opaque
- * execution wrapper (for example xargs or find -exec). Commands whose only
- * purpose is displaying/searching text remain outside this boundary.
- */
-function containsOpaqueSimulatorExecution(tokens: string[]): boolean {
-  const head = executableName(tokens[0]);
-  if (!head || NON_EXECUTING_REFERENCE_COMMANDS.has(head) || head === 'osascript') return false;
-  const findExec =
-    head === 'find' && tokens.some((token) => /^-(?:exec|execdir|ok|okdir)$/.test(token));
-  if (!findExec && !OPAQUE_EXECUTION_WRAPPERS.has(head)) return false;
-  // Direct simctl commands have already been classified above, including the
-  // explicitly read-only allowlist.
-  if (simctlSubcommand(tokens) !== null) return false;
-  return containsLiteralSimulatorExecutor(tokens.slice(1).join(' '));
-}
-
-/** Extract command/process substitutions because they execute even inside an otherwise safe command. */
+/** Command and process substitutions execute, so their contents are classified too. */
 function shellSubcommands(command: string): string[] {
   const subcommands: string[] = [];
   let quote: "'" | '"' | null = null;
@@ -866,758 +400,24 @@ function shellSubcommands(command: string): string[] {
   return subcommands;
 }
 
-/** Split independent command clauses while retaining pipeline boundaries. */
-function shellClauses(command: string): string[] {
-  const clauses: string[] = [];
-  let current = '';
-  let quote: "'" | '"' | null = null;
-  let escaped = false;
-  for (let index = 0; index < command.length; index += 1) {
-    const char = command[index]!;
-    if (escaped) {
-      current += char;
-      escaped = false;
-      continue;
-    }
-    if (char === '\\' && quote !== "'") {
-      current += char;
-      escaped = true;
-      continue;
-    }
-    if (quote) {
-      current += char;
-      if (char === quote) quote = null;
-      continue;
-    }
-    if (char === "'" || char === '"') {
-      current += char;
-      quote = char;
-      continue;
-    }
-    if (char === '|' && command[index + 1] === '|') {
-      if (current.trim()) clauses.push(current.trim());
-      current = '';
-      index += 1;
-      continue;
-    }
-    if (char === '&' && current.trimEnd().endsWith('|')) {
-      current += char;
-      continue;
-    }
-    if (char === '\n' || char === ';' || char === '&') {
-      if (current.trim()) clauses.push(current.trim());
-      current = '';
-      continue;
-    }
-    current += char;
+function containsSimulatorRecipe(command: string, depth = 0): boolean {
+  if (depth > MAX_RECURSION_DEPTH) return false;
+  for (const nested of shellSubcommands(command)) {
+    if (containsSimulatorRecipe(nested, depth + 1)) return true;
   }
-  if (current.trim()) clauses.push(current.trim());
-  return clauses;
-}
-
-function isLiteralSimulatorBypass(command: string): boolean {
   for (const segment of shellSegments(command)) {
     const unwrapped = unwrapCommand(tokenizeShellSegment(segment));
-    if (unwrapped.inspectionOnly || unwrapped.unresolvedWrapper) continue;
-    if (isExternalSimulatorLaunch(unwrapped.tokens) || isSimulatorMutation(unwrapped.tokens)) {
-      return true;
+    // `CMD="xcrun simctl boot $UDID"` holds a whole recipe; documentation does
+    // write it this way before running it, so the literal value is classified.
+    for (const value of unwrapped.assignedValues) {
+      if (isSimulatorRecipeArgv(tokenizeShellSegment(value))) return true;
     }
-  }
-  return false;
-}
-
-function isSimulatorExecutorValue(value: string): boolean {
-  const normalized = value
-    .trim()
-    .replace(/^['"]|['"]$/g, '')
-    .replace(/\\/g, '/');
-  return /(?:^|\/)(?:xcrun|simctl)$/i.test(normalized) || /Simulator(?:\.app)?/i.test(normalized);
-}
-
-/** Dynamic command names can resolve to a Simulator bypass, so execution must fail closed. */
-function hasDynamicShellExpansion(token: string): boolean {
-  return /[$`*?[\]{}()^~]/.test(token) || token.indexOf('#') > 0;
-}
-
-function hasUnresolvedExecutableExpansion(tokens: string[], evidence: boolean): boolean {
-  const executableTokens = stripShellControlTokens(tokens);
-  while (executableTokens[0] && /^[A-Za-z_][A-Za-z0-9_]*=/.test(executableTokens[0])) {
-    executableTokens.shift();
-  }
-  const executable = executableTokens[0] ?? '';
-  // `[` and `[[` are literal shell condition builtins, not glob-expanded
-  // executable names. Other expansion syntax in command position is unsafe.
-  if (executable === '[' || executable === '[[') return false;
-  return isUnprovableCommandWord(executable, evidence);
-}
-
-/** Arithmetic compound commands contain expressions, not an executable argv. */
-function isArithmeticCompoundCommand(tokens: string[]): boolean {
-  let index = 0;
-  while (tokens[index] && /^[A-Za-z_][A-Za-z0-9_]*=/.test(tokens[index]!)) index += 1;
-  while (tokens[index] && /^(?:\{|\(|!|then|do|else|elif|if|while|until)$/.test(tokens[index]!)) {
-    index += 1;
-  }
-  return tokens[index] === '((' || tokens[index]?.startsWith('((') === true;
-}
-
-/**
- * Shell arithmetic recursively resolves bare variables and array subscripts,
- * which can execute command substitutions stored in their values. Literals and
- * operators are always safe; a named expansion or a subscript never is. A bare
- * identifier sits between the two: the shell would resolve it recursively, but
- * reaching an executor that way requires the command to have stored one, so it
- * is classified against Simulator evidence rather than denied on shape alone.
- */
-function hasDynamicArithmeticEvaluation(segment: string, evidence: boolean): boolean {
-  const start = segment.indexOf('((');
-  const end = segment.lastIndexOf('))');
-  if (start < 0 || end < start + 2) return true;
-  const expression = segment.slice(start + 2, end);
-  // Positional and special parameters evaluate to numbers in arithmetic, so
-  // they cannot name a command; fold them away before classifying.
-  const probe = expression.replace(/\$(?:[0-9]+|[#?$!]|\{(?:[0-9]+|[#?$!])\})/g, '0');
-  if (/^[\s0-9()+\-*/%<>=!&|^~?:,]*$/.test(probe)) return false;
-  if (/[$`]/.test(probe) || /\[[^\]]*\]/.test(probe)) return true;
-  if (/^[\sA-Za-z_0-9()+\-*/%<>=!&|^~?:,]*$/.test(probe)) return evidence;
-  return true;
-}
-
-/** Unknown wrapper option shapes cannot prove which expanded token becomes the command. */
-function hasUnresolvedWrapperExpansion(unwrapped: UnwrappedCommand, evidence: boolean): boolean {
-  return (
-    unwrapped.unresolvedWrapper &&
-    unwrapped.tokens.some((token) => isUnprovableCommandWord(token, evidence))
-  );
-}
-
-type OpaqueOptionShape = 'flag' | 'value' | 'command' | 'unknown';
-
-function opaqueOptionShape(head: string, token: string): OpaqueOptionShape {
-  const option = token.replace(/=.*/s, '=');
-  if (head === 'sudo') {
-    if (
-      /^(?:-[CDghpRrTtUu]|--(?:chdir|close-from|group|host|prompt|role|command-timeout|type|other-user|user))$/.test(
-        token,
-      )
-    )
-      return 'value';
-    if (
-      /^(?:-[ABbEeHhKklnPSsVv]|--(?:askpass|bell|background|edit|preserve-env|set-home|help|remove-timestamp|reset-timestamp|list|non-interactive|stdin|shell|validate|version))$/.test(
-        token,
-      )
-    )
-      return 'flag';
-    if (/^(?:-[CDghpRrTtUu].+|--[^=]+=)/.test(token)) return 'flag';
-  }
-  if (head === 'doas') {
-    if (/^-(?:a|C|u)$/.test(token)) return 'value';
-    if (/^-(?:L|n|s)$/.test(token) || /^-(?:a|C|u).+/.test(token)) return 'flag';
-  }
-  if (head === 'xargs') {
-    if (
-      /^(?:-[EILnPRSs]|--(?:eof|replace|max-lines|max-args|max-procs|right|max-chars))$/.test(token)
-    )
-      return 'value';
-    if (/^(?:-[0oprtx]|--(?:null|open-tty|interactive|no-run-if-empty|verbose|exit))$/.test(token))
-      return 'flag';
-    if (/^(?:-[EILnPRSs].+|--[^=]+=)/.test(token)) return 'flag';
-  }
-  if (head === 'sandbox-exec') {
-    if (/^-(?:D|f|n|p)$/.test(token)) return 'value';
-    if (/^-(?:D|f|n|p).+/.test(token)) return 'flag';
-  }
-  if (head === 'launchctl') {
-    if (token === '-p') return 'command';
-    if (/^-(?:l|o|e)$/.test(token)) return 'value';
-    if (/^-(?:l|o|e).+/.test(token)) return 'flag';
-  }
-  if (head === 'timeout' || head === 'gtimeout') {
-    if (/^(?:-k|-s|--kill-after|--signal)$/.test(token)) return 'value';
-    if (/^(?:-v|--foreground|--preserve-status|--verbose)$/.test(token)) return 'flag';
-    if (/^(?:-[ks].+|--[^=]+=)/.test(token)) return 'flag';
-  }
-  if (head === 'watch') {
-    if (/^(?:-n|--interval)$/.test(token)) return 'value';
-    if (
-      /^(?:-[bcegpqrtwx]+|-d(?:=permanent)?|--(?:beep|color|differences(?:=permanent)?|chgexit|errexit|equexit|no-rerun|no-title|no-wrap|precise|exec))$/.test(
-        token,
-      )
-    )
-      return 'flag';
-    if (/^(?:-n.+|--interval=)/.test(option)) return 'flag';
-  }
-  if (head === 'script') {
-    if (/^(?:-c|--command)$/.test(token)) return 'command';
-    if (/^(?:-t|-T|--timing)$/.test(token)) return 'value';
-    if (/^-[adeFkpqr]+$/.test(token)) return 'flag';
-  }
-  return 'unknown';
-}
-
-function hasDynamicWrappedCommand(tokens: string[], evidence: boolean, depth: number): boolean {
-  if (tokens.length === 0) return false;
-  if (depth > MAX_WRAPPER_UNWRAP_DEPTH) {
-    return tokens.some((token) => isUnprovableCommandWord(token, evidence));
-  }
-  const unwrapped = unwrapCommand(tokens);
-  if (unwrapped.inspectionOnly) return false;
-  if (hasUnresolvedWrapperExpansion(unwrapped, evidence)) return true;
-  if (unwrapped.nestedShell !== null) {
-    if (containsSimulatorBypass(unwrapped.nestedShell, evidence, depth + 1)) return true;
-    return unwrapped.tokens.some((token) => isUnprovableCommandWord(token, evidence));
-  }
-  if (hasUnresolvedExecutableExpansion(unwrapped.tokens, evidence)) return true;
-  return hasOpaqueWrapperExpansion(tokens, evidence, depth + 1);
-}
-
-/** Locate the command operand conservatively without mistaking later data argv for executables. */
-function hasOpaqueWrapperExpansion(tokens: string[], evidence: boolean, depth = 0): boolean {
-  tokens = stripShellRedirections(tokens);
-  const head = executableName(tokens[0]);
-  if (head === 'find') {
-    for (let index = 1; index < tokens.length; index += 1) {
-      if (!/^-(?:exec|execdir|ok|okdir)$/.test(tokens[index]!)) continue;
-      const terminator = tokens.findIndex(
-        (token, candidateIndex) =>
-          candidateIndex > index && (token === ';' || token === '+' || token === '\\;'),
-      );
-      const commandEnd = terminator < 0 ? tokens.length : terminator;
-      return hasDynamicWrappedCommand(tokens.slice(index + 1, commandEnd), evidence, depth + 1);
-    }
-    return false;
-  }
-  if (!OPAQUE_EXECUTION_WRAPPERS.has(head)) return false;
-  if (head === 'coproc') {
-    // Bash/zsh allow an optional coprocess name, so command position is
-    // ambiguous. Any expansion in this execution form must fail closed.
-    return tokens.slice(1).some((token) => isUnprovableCommandWord(token, evidence));
-  }
-  if (head === 'repeat') {
-    // zsh evaluates the count arithmetically before executing argv.
-    if (!/^\d+$/.test(tokens[1] ?? '')) return true;
-    return hasDynamicWrappedCommand(tokens.slice(2), evidence, depth + 1);
-  }
-
-  let index = 1;
-  if (head === 'launchctl') {
-    if (tokens[1] === 'submit') index = 2;
-    else if (tokens[1] === 'asuser' || tokens[1] === 'bsexec') index = 3;
-  }
-  while (index < tokens.length) {
-    const token = tokens[index]!;
-    if (token === '--') {
-      index += 1;
-      break;
-    }
-    if (!token.startsWith('-')) break;
-    const shape = opaqueOptionShape(head, token);
-    const possibleValue = tokens[index + 1];
-    if (shape === 'command') {
-      const commandValue = token.includes('=')
-        ? token.slice(token.indexOf('=') + 1)
-        : possibleValue;
-      if (isUnprovableCommandWord(commandValue ?? '', evidence)) return true;
-      index += token.includes('=') ? 1 : 2;
-      continue;
-    }
-    if (shape === 'value') {
-      index += 2;
-      continue;
-    }
-    if (shape === 'flag') {
-      index += 1;
-      continue;
-    }
-    // Unknown option arity makes every later dynamic token ambiguous: it may
-    // be either an option value or the actual command. Fail closed instead of
-    // guessing and accidentally stepping past the executable.
-    return tokens.slice(index).some((value) => isUnprovableCommandWord(value, evidence));
-  }
-  if (head === 'sudo') {
-    while (/^[A-Za-z_][A-Za-z0-9_]*=/.test(tokens[index] ?? '')) index += 1;
-  }
-  // timeout consumes a duration before its command; macOS script consumes an
-  // output file before an optional command.
-  if (head === 'timeout' || head === 'gtimeout' || head === 'script') index += 1;
-  return hasDynamicWrappedCommand(tokens.slice(index), evidence, depth + 1);
-}
-
-function referencesVariable(command: string, variable: string): boolean {
-  const escaped = variable.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  return new RegExp(`\\$(?:${escaped}\\b|\\{${escaped}\\})`).test(command);
-}
-
-const SHELL_ASSIGNMENT_BUILTINS = new Set(['declare', 'export', 'local', 'readonly', 'typeset']);
-
-function collectShellAssignments(tokens: string[]): Array<{ name: string; value: string }> {
-  const assignments: Array<{ name: string; value: string }> = [];
-  let index = 0;
-  const head = executableName(tokens[0]);
-  if (SHELL_ASSIGNMENT_BUILTINS.has(head)) {
-    index = 1;
-    while (tokens[index]?.startsWith('-')) index += 1;
-  }
-  for (; index < tokens.length; index += 1) {
-    const assignment = /^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/s.exec(tokens[index]!);
-    if (!assignment) {
-      if (!SHELL_ASSIGNMENT_BUILTINS.has(head)) break;
-      continue;
-    }
-    assignments.push({ name: assignment[1]!, value: assignment[2] ?? '' });
-  }
-  return assignments;
-}
-
-/** Track simple shell assignments so a later eval/sh -c/$VAR cannot hide a bypass. */
-function containsTaintedVariableExecution(command: string): boolean {
-  const tainted = new Set<string>();
-  const tokenizedSegments = shellSegments(command).map((segment) => ({
-    segment,
-    tokens: tokenizeShellSegment(segment),
-  }));
-  const assignments = tokenizedSegments.flatMap(({ tokens }) => collectShellAssignments(tokens));
-  for (const { segment } of tokenizedSegments) {
-    for (const match of segment.matchAll(/\b([A-Za-z_][A-Za-z0-9_]*)=\$\(([^)]*)\)/g)) {
-      if (containsLiteralSimulatorExecutor(match[2] ?? '')) tainted.add(match[1]!);
-    }
-  }
-  for (const assignment of assignments) {
-    if (isLiteralSimulatorBypass(assignment.value) || isSimulatorExecutorValue(assignment.value)) {
-      tainted.add(assignment.name);
-    }
-  }
-  if (tainted.size === 0) return false;
-
-  for (const { segment, tokens } of tokenizedSegments) {
-    const unwrapped = unwrapCommand(tokens);
-    for (const variable of tainted) {
-      if (unwrapped.nestedShell !== null && referencesVariable(unwrapped.nestedShell, variable)) {
-        return true;
-      }
-      if (referencesVariable(unwrapped.tokens[0] ?? '', variable)) return true;
-      if (
-        executableName(unwrapped.tokens[0]) === 'xcrun' &&
-        unwrapped.tokens.some((token) => referencesVariable(token, variable))
-      ) {
-        return true;
-      }
-      // Unknown wrappers are unsafe when they consume a tainted command value.
-      if (unwrapped.unresolvedWrapper && referencesVariable(segment, variable)) return true;
-    }
-  }
-  return false;
-}
-
-function nestedShellConsumesStdinAsProgram(command: string): boolean {
-  return (
-    /(?:^|[;&|]\s*)(?:source|\.)\s+(?:\/dev\/stdin|\/dev\/fd\/0|-)(?:\s|$)/i.test(command) ||
-    /\beval\b[\s\S]*\$\(\s*cat(?:\s+(?:-|\/dev\/stdin|\/dev\/fd\/0))?\s*\)/i.test(command)
-  );
-}
-
-function consumesStdinAsProgram(tokens: string[]): boolean {
-  const unwrapped = unwrapCommand(tokens);
-  if (unwrapped.nestedShell !== null) {
-    return !unwrapped.unresolvedWrapper && nestedShellConsumesStdinAsProgram(unwrapped.nestedShell);
-  }
-  if (unwrapped.unresolvedWrapper) return false;
-  const executable = executableName(unwrapped.tokens[0]);
-  const args = unwrapped.tokens.slice(1);
-  if (SHELL_EXECUTABLES.has(executable)) {
-    if (args.some((arg) => /^-[A-Za-z]*c[A-Za-z]*$/.test(arg))) return false;
-    if (args.some((arg) => /^-[A-Za-z]*s[A-Za-z]*$/.test(arg))) return true;
-  } else if (executable === 'osascript') {
-    if (args.some((arg) => arg === '-e' || arg.startsWith('-e'))) return false;
-  } else if (PROGRAMMABLE_INTERPRETER.test(executable)) {
-    if (/^(?:(?:g|m|n)?awk)$/.test(executable)) return false;
-    if (args.some((arg) => /^(?:-c|-e|-p|-m|--eval|--print|--input-type|--module)$/.test(arg))) {
-      return false;
-    }
-  } else {
-    return false;
-  }
-  const positional = args.find((arg) => !arg.startsWith('-'));
-  return positional === undefined || positional === '-';
-}
-
-function containsInterpreterHeredocBypass(command: string): boolean {
-  const lines = command.split(/\r?\n/);
-  for (let index = 0; index < lines.length; index += 1) {
-    const line = lines[index] ?? '';
-    const marker = /<<-?\s*(['"]?)([A-Za-z_][A-Za-z0-9_]*)\1/.exec(line);
-    if (!marker) continue;
-    if (!heredocBodyIsProgram(line, marker[0]!)) continue;
-    const delimiter = marker[2]!;
-    const body: string[] = [];
-    for (index += 1; index < lines.length; index += 1) {
-      if ((lines[index] ?? '').replace(/^\t+/, '').trim() === delimiter) break;
-      body.push(lines[index] ?? '');
-    }
-    if (containsLiteralSimulatorExecutor(body.join('\n'))) return true;
-  }
-  return false;
-}
-
-/** A here-string is executable stdin just like a heredoc or producer pipeline. */
-function containsInterpreterHereStringBypass(command: string): boolean {
-  for (const clause of shellClauses(command)) {
-    let quote: "'" | '"' | null = null;
-    let escaped = false;
-    for (let index = 0; index < clause.length - 2; index += 1) {
-      const char = clause[index]!;
-      if (escaped) {
-        escaped = false;
-        continue;
-      }
-      if (char === '\\' && quote !== "'") {
-        escaped = true;
-        continue;
-      }
-      if (char === "'" || char === '"') {
-        if (quote === char) quote = null;
-        else if (quote === null) quote = char;
-        continue;
-      }
-      if (quote || clause.slice(index, index + 3) !== '<<<') continue;
-      const consumer = clause.slice(0, index).trim();
-      const payload = clause.slice(index + 3);
-      if (
-        shellSegments(consumer).some((segment) =>
-          consumesStdinAsProgram(tokenizeShellSegment(segment)),
-        ) &&
-        containsLiteralSimulatorExecutor(payload)
-      ) {
-        return true;
-      }
-      break;
-    }
-  }
-  return false;
-}
-
-/** A literal command piped to a code-reading interpreter becomes executable input. */
-function containsShellConsumedLiteralBypass(command: string): boolean {
-  if (containsInterpreterHeredocBypass(command) || containsInterpreterHereStringBypass(command)) {
-    return true;
-  }
-  for (const clause of shellClauses(command)) {
-    if (!clause.includes('|')) continue;
-    const segments = shellSegments(clause);
-    if (
-      segments.some((segment) => consumesStdinAsProgram(tokenizeShellSegment(segment))) &&
-      containsLiteralSimulatorExecutor(clause)
-    ) {
-      return true;
-    }
-  }
-  return false;
-}
-
-function isLiteralXcrunBoundaryToken(token: string): boolean {
-  return /^[A-Za-z0-9_./:+-]+$/.test(token);
-}
-
-function hasUnresolvedXcrunTool(tokens: string[]): boolean {
-  if (executableName(tokens[0]) !== 'xcrun') return false;
-  let index = 1;
-  while (index < tokens.length && tokens[index]!.startsWith('-')) {
-    const option = tokens[index]!;
-    if (/^(?:--sdk|-sdk|--toolchain|-toolchain)=/.test(option)) {
-      const value = option.slice(option.indexOf('=') + 1);
-      if (!isLiteralXcrunBoundaryToken(value)) return true;
-      index += 1;
-      continue;
-    }
-    if (
-      option === '--sdk' ||
-      option === '-sdk' ||
-      option === '--toolchain' ||
-      option === '-toolchain'
-    ) {
-      const value = tokens[index + 1];
-      if (!value || !isLiteralXcrunBoundaryToken(value)) return true;
-      index += 2;
-      continue;
-    }
-    index += 1;
-  }
-  const firstToolToken = tokens[index] ?? '';
-  return firstToolToken !== '' && !isLiteralXcrunBoundaryToken(firstToolToken);
-}
-
-const SHELL_FUNCTION_HEADER_SOURCE =
-  '(?:(?:function\\s+)?[A-Za-z_][A-Za-z0-9_]*\\s*\\(\\s*\\)|function\\s+[A-Za-z_][A-Za-z0-9_]*)';
-const SHELL_FUNCTION_DEFINITION_PREFIX = new RegExp(`^${SHELL_FUNCTION_HEADER_SOURCE}\\s*[({]`);
-
-function shellCompoundBodyEnd(command: string, openingIndex: number): number | null {
-  const opening = command[openingIndex];
-  if (opening !== '{' && opening !== '(') return null;
-  const closing = opening === '{' ? '}' : ')';
-  let nesting = 1;
-  let quote: "'" | '"' | '`' | null = null;
-  let escaped = false;
-  for (let index = openingIndex + 1; index < command.length; index += 1) {
-    const char = command[index]!;
-    if (escaped) {
-      escaped = false;
-      continue;
-    }
-    if (char === '\\' && quote !== "'") {
-      escaped = true;
-      continue;
-    }
-    if (quote) {
-      if (char === quote) quote = null;
-      continue;
-    }
-    if (char === "'" || char === '"' || char === '`') {
-      quote = char;
-      continue;
-    }
-    if (char === opening) nesting += 1;
-    else if (char === closing) {
-      nesting -= 1;
-      if (nesting === 0) return index;
-    }
-  }
-  return null;
-}
-
-/** Function bodies are executable later, so reject unsafe bodies at definition time. */
-function containsSimulatorFunctionBody(command: string, evidence: boolean, depth: number): boolean {
-  const functionPattern = new RegExp(
-    `(?:^|[;\\n]\\s*)${SHELL_FUNCTION_HEADER_SOURCE}\\s*([({])`,
-    'g',
-  );
-  while (functionPattern.exec(command) !== null) {
-    const openingIndex = functionPattern.lastIndex - 1;
-    const closingIndex = shellCompoundBodyEnd(command, openingIndex);
-    if (closingIndex === null) continue;
-    if (containsSimulatorBypass(command.slice(openingIndex + 1, closingIndex), evidence, depth + 1)) {
-      return true;
-    }
-    functionPattern.lastIndex = closingIndex + 1;
-  }
-  return false;
-}
-
-/** Alias bodies are executable later, so reject unsafe definitions up front. */
-function containsSimulatorAliasDefinition(
-  tokens: string[],
-  evidence: boolean,
-  depth: number,
-): boolean {
-  if (executableName(tokens[0]) !== 'alias') return false;
-  let index = tokens[1] === '--' ? 2 : 1;
-  for (; index < tokens.length; index += 1) {
-    const definition = tokens[index]!;
-    const separator = definition.indexOf('=');
-    // `alias` and `alias name` only inspect the current shell state.
-    if (separator <= 0) continue;
-    const body = definition.slice(separator + 1);
-    if (
-      containsLiteralSimulatorExecutor(body) ||
-      containsSimulatorBypass(body, evidence, depth + 1)
-    ) {
-      return true;
-    }
-  }
-  return false;
-}
-
-type HeredocRedirection = {
-  marker: string;
-  delimiter: string;
-  expands: boolean;
-  stripsTabs: boolean;
-};
-
-/**
- * Whether the clause opening a heredoc hands the body to a program that runs it.
- *
- * The consumer can sit on either side of the marker: `python3 <<'PY'` reads the
- * body directly, `cat <<'SH' | sh` pipes it into a shell. The search is scoped to
- * the heredoc's own clause so a `;`-separated interpreter, which reads the
- * terminal rather than this body, is not mistaken for its consumer, and the
- * redirection itself is dropped so it cannot read as the interpreter's
- * positional program argument.
- */
-function heredocBodyIsProgram(line: string, marker: string): boolean {
-  const opening = shellClauses(line).find((candidate) => candidate.includes(marker)) ?? line;
-  const clause = opening.replace(marker, ' ');
-  return shellSegments(clause).some((segment) =>
-    consumesStdinAsProgram(tokenizeShellSegment(segment)),
-  );
-}
-
-/**
- * Heredoc redirections opened on one line, skipping `<<` inside quotes and the
- * `<<<` here-string operator (classified separately). Quoting or escaping any
- * part of the delimiter disables expansion of the body, which is what decides
- * whether anything in that body can reach the shell at all.
- */
-function heredocRedirections(line: string): HeredocRedirection[] {
-  const redirections: HeredocRedirection[] = [];
-  let quote: "'" | '"' | null = null;
-  let escaped = false;
-  for (let index = 0; index < line.length; index += 1) {
-    const char = line[index]!;
-    if (escaped) {
-      escaped = false;
-      continue;
-    }
-    if (char === '\\' && quote !== "'") {
-      escaped = true;
-      continue;
-    }
-    if (char === "'" || char === '"') {
-      if (quote === char) quote = null;
-      else if (quote === null) quote = char;
-      continue;
-    }
-    if (quote || char !== '<' || line[index + 1] !== '<') continue;
-    if (line[index + 2] === '<') {
-      index += 2;
-      continue;
-    }
-    let cursor = index + 2;
-    const stripsTabs = line[cursor] === '-';
-    if (stripsTabs) cursor += 1;
-    while (line[cursor] === ' ' || line[cursor] === '\t') cursor += 1;
-    let delimiter = '';
-    let expands = true;
-    while (cursor < line.length) {
-      const delimiterChar = line[cursor]!;
-      if (delimiterChar === "'" || delimiterChar === '"') {
-        expands = false;
-        const closing = line.indexOf(delimiterChar, cursor + 1);
-        if (closing < 0) {
-          delimiter += line.slice(cursor + 1);
-          cursor = line.length;
-          break;
-        }
-        delimiter += line.slice(cursor + 1, closing);
-        cursor = closing + 1;
-        continue;
-      }
-      if (delimiterChar === '\\') {
-        expands = false;
-        cursor += 1;
-        if (cursor < line.length) {
-          delimiter += line[cursor]!;
-          cursor += 1;
-        }
-        continue;
-      }
-      if (/[\s;&|<>()]/.test(delimiterChar)) break;
-      delimiter += delimiterChar;
-      cursor += 1;
-    }
-    if (delimiter !== '') {
-      redirections.push({ marker: line.slice(index, cursor), delimiter, expands, stripsTabs });
-    }
-    index = cursor - 1;
-  }
-  return redirections;
-}
-
-/**
- * Reduce heredoc bodies to the text that can actually reach a command position.
- *
- * A body handed to an interpreter or shell *is* a program, so it stays verbatim —
- * that is what lets a fragment-assembled executor inside `python3 <<'PY'` still be
- * classified. A body handed to anything else is stdin data and never argv, so
- * classifying its lines as command words denies ordinary work: a commit message
- * line starting with a Markdown backtick span reads as an executable position
- * filled by an unresolvable expansion. Such a body is dropped, except that an
- * unquoted delimiter still runs the body's command substitutions, so those are
- * kept while the surrounding prose is not.
- */
-function stripHeredocBodies(command: string): string {
-  if (!command.includes('<<')) return command;
-  const lines = command.split('\n');
-  const executable: string[] = [];
-  for (let index = 0; index < lines.length; index += 1) {
-    const line = lines[index]!;
-    executable.push(line);
-    for (const heredoc of heredocRedirections(line)) {
-      const body: string[] = [];
-      index += 1;
-      for (; index < lines.length; index += 1) {
-        const candidate = lines[index]!;
-        const unindented = heredoc.stripsTabs ? candidate.replace(/^\t+/, '') : candidate;
-        if (unindented === heredoc.delimiter) break;
-        body.push(candidate);
-      }
-      if (heredocBodyIsProgram(line, heredoc.marker)) executable.push(...body);
-      else if (heredoc.expands) executable.push(...shellSubcommands(body.join('\n')));
-      if (index >= lines.length) break;
-    }
-  }
-  return executable.join('\n');
-}
-
-function containsSimulatorBypass(command: string, evidence: boolean, depth = 0): boolean {
-  if (depth > 8) return /\b(?:simctl|Simulator(?:\.app)?)\b/i.test(command);
-  // Interpreter payloads are read from the unmodified command; every other rule
-  // below classifies command words, so it must not see heredoc body prose.
-  const argv = stripHeredocBodies(command);
-  if (
-    containsTaintedVariableExecution(argv) ||
-    containsShellConsumedLiteralBypass(command) ||
-    containsSimulatorFunctionBody(argv, evidence, depth)
-  ) {
-    return true;
-  }
-  for (const nested of shellSubcommands(argv)) {
-    if (containsSimulatorBypass(nested, evidence, depth + 1)) return true;
-  }
-  for (const segment of shellSegments(argv)) {
-    // Function bodies were classified recursively above. The leading
-    // `name(){` token is not an execution wrapper in its own right.
-    if (SHELL_FUNCTION_DEFINITION_PREFIX.test(segment)) {
-      continue;
-    }
-    const tokens = tokenizeShellSegment(segment);
-    const arithmeticCompound = isArithmeticCompoundCommand(tokens);
-    if (arithmeticCompound && hasDynamicArithmeticEvaluation(segment, evidence)) return true;
-    const unwrapped = unwrapCommand(tokens);
-    if (unwrapped.inspectionOnly) continue;
-    // Known wrappers are peeled first so `env "$TOOL"` and `exec "$TOOL"`
-    // cannot hide a dynamically constructed executable. Shell `-c`
-    // positional arguments are not executables by themselves; its nested
-    // program is classified recursively below instead.
-    if (
-      !arithmeticCompound &&
-      unwrapped.nestedShell === null &&
-      hasUnresolvedExecutableExpansion(unwrapped.tokens, evidence)
-    ) {
-      return true;
-    }
-    if (
-      hasUnresolvedWrapperExpansion(unwrapped, evidence) ||
-      hasOpaqueWrapperExpansion(tokens, evidence)
-    ) {
-      return true;
-    }
-    if (containsSimulatorAliasDefinition(unwrapped.tokens, evidence, depth)) return true;
     if (unwrapped.nestedShell !== null) {
-      if (unwrapped.unresolvedWrapper)
-        return containsSimulatorExecutor(tokenizeShellSegment(segment));
-      if (containsSimulatorBypass(unwrapped.nestedShell, evidence, depth + 1)) return true;
+      if (containsSimulatorRecipe(unwrapped.nestedShell, depth + 1)) return true;
       continue;
     }
-    if (unwrapped.unresolvedWrapper && containsSimulatorExecutor(unwrapped.tokens)) return true;
-    if (
-      hasUnresolvedXcrunTool(unwrapped.tokens) ||
-      containsInterpreterSimulatorPayload(unwrapped.tokens) ||
-      isExternalSimulatorLaunch(unwrapped.tokens) ||
-      isSimulatorMutation(unwrapped.tokens) ||
-      containsOpaqueSimulatorExecution(unwrapped.tokens)
-    ) {
-      return true;
-    }
+    if (isSimulatorRecipeArgv(unwrapped.tokens)) return true;
+    if (containsInterpreterSimulatorPayload(unwrapped.tokens)) return true;
   }
   return false;
 }
@@ -1628,9 +428,8 @@ export function getDesktopShellCommandPolicy(
 ): ShellCommandPolicyDenial | undefined {
   if (process.platform !== 'darwin') return undefined;
   // POSIX shells remove an unquoted backslash-newline before tokenization.
-  // Mirror that expansion so the policy cannot be bypassed with continuations.
   const expandedCommand = command.replace(/\\\r?\n/g, '');
-  if (containsSimulatorBypass(expandedCommand, hasSimulatorEvidence(expandedCommand))) {
+  if (containsSimulatorRecipe(expandedCommand)) {
     return { decision: 'deny', reason: IOS_SIMULATOR_SHELL_DENIAL };
   }
   return undefined;

--- a/apps/desktop/src/main/maker-host/shell-command-policy.ts
+++ b/apps/desktop/src/main/maker-host/shell-command-policy.ts
@@ -661,6 +661,47 @@ interface HeredocRedirection {
   stripsTabs: boolean;
 }
 
+/**
+ * Skip a shell arithmetic expression while looking for heredoc operators.
+ *
+ * `<<` is also the arithmetic left-shift operator. Treating it as a heredoc
+ * opener makes the following physical lines look like the body for a marker
+ * named `2`, so a real command after the arithmetic expression can disappear
+ * from classification. Both `$(( ... ))` expansions and `(( ... ))` commands
+ * use the same balanced-parenthesis shape here.
+ */
+function skipArithmeticExpression(line: string, start: number): number {
+  let depth = 1;
+  let quote: "'" | '"' | null = null;
+  let escaped = false;
+  const expressionStart = line[start] === '$' ? start + 3 : start + 2;
+  for (let index = expressionStart; index < line.length; index += 1) {
+    const char = line[index]!;
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (char === '\\' && quote !== "'") {
+      escaped = true;
+      continue;
+    }
+    if (char === "'" || char === '"') {
+      if (quote === char) quote = null;
+      else if (quote === null) quote = char;
+      continue;
+    }
+    if (quote) continue;
+    if (char === '(') {
+      depth += 1;
+      continue;
+    }
+    if (char !== ')') continue;
+    if (depth === 1 && line[index + 1] === ')') return index + 2;
+    depth -= 1;
+  }
+  return line.length;
+}
+
 /** Heredoc markers on one shell line, excluding quoted text, comments and `<<<`. */
 function heredocRedirections(line: string): HeredocRedirection[] {
   const redirections: HeredocRedirection[] = [];
@@ -682,6 +723,15 @@ function heredocRedirections(line: string): HeredocRedirection[] {
       continue;
     }
     if (quote) continue;
+    // `<<` inside `$(( ... ))` / `(( ... ))` is arithmetic left shift, not a
+    // shell heredoc. Skip the complete expression before looking for markers.
+    if (
+      (char === '$' && line[index + 1] === '(' && line[index + 2] === '(') ||
+      (char === '(' && line[index + 1] === '(')
+    ) {
+      index = skipArithmeticExpression(line, index) - 1;
+      continue;
+    }
     // In shell grammar `#` starts a comment when it begins a word. A marker in
     // that comment must not consume later commands as a fake heredoc body.
     if (char === '#' && (index === 0 || /[\s;&|()]/.test(line[index - 1]!))) break;
@@ -727,6 +777,111 @@ function heredocRedirections(line: string): HeredocRedirection[] {
   return redirections;
 }
 
+/** Find the closing parenthesis for a shell `$(...)`, `<(...)` or `>(...)`. */
+function skipShellSubstitution(input: string, start: number): number {
+  let depth = 1;
+  let quote: "'" | '"' | null = null;
+  let escaped = false;
+  for (let index = start + 2; index < input.length; index += 1) {
+    const char = input[index]!;
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (char === '\\' && quote !== "'") {
+      escaped = true;
+      continue;
+    }
+    if (char === "'" || char === '"') {
+      if (quote === char) quote = null;
+      else if (quote === null) quote = char;
+      continue;
+    }
+    if (quote !== null) continue;
+    if (char === '(') depth += 1;
+    else if (char === ')' && --depth === 0) return index;
+  }
+  return input.length - 1;
+}
+
+/** Find the closing backtick for an old-style shell command substitution. */
+function skipBacktickSubstitution(input: string, start: number): number {
+  let escaped = false;
+  for (let index = start + 1; index < input.length; index += 1) {
+    const char = input[index]!;
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (char === '\\') {
+      escaped = true;
+      continue;
+    }
+    if (char === '`') return index;
+  }
+  return input.length - 1;
+}
+
+/** Whether a pipeline segment explicitly replaces its stdin source. */
+function hasUnquotedStdinRedirection(segment: string): boolean {
+  let quote: "'" | '"' | null = null;
+  let escaped = false;
+  for (let index = 0; index < segment.length; index += 1) {
+    const char = segment[index]!;
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (char === '\\' && quote !== "'") {
+      escaped = true;
+      continue;
+    }
+    if (quote) {
+      if (char === quote) quote = null;
+      continue;
+    }
+    if (char === "'" || char === '"') {
+      quote = char;
+      continue;
+    }
+    if (
+      (char === '$' && segment[index + 1] === '(' && segment[index + 2] === '(') ||
+      (char === '(' && segment[index + 1] === '(')
+    ) {
+      index = skipArithmeticExpression(segment, index) - 1;
+      continue;
+    }
+    if (
+      (char === '$' || char === '<' || char === '>')
+      && segment[index + 1] === '('
+    ) {
+      index = skipShellSubstitution(segment, index);
+      continue;
+    }
+    if (char === '`') {
+      index = skipBacktickSubstitution(segment, index);
+      continue;
+    }
+    if (char !== '<') continue;
+    const redirection = redirectionAt(segment, index);
+    if (redirection === null) continue;
+    // A descriptor other than 0 redirects a separate input channel and does
+    // not replace the pipeline's stdin. Cover both `2<file` and Bash's
+    // allocated-fd spelling `{fd}<file`.
+    const beforeOperator = segment.slice(0, index);
+    const explicitDescriptor =
+      /(?:^|[\s;&|()])(\d+)$/.exec(beforeOperator)?.[1]
+      ?? /(?:^|[\s;&|()])(\{[A-Za-z_][A-Za-z0-9_]*\})$/.exec(beforeOperator)?.[1]
+      ?? null;
+    if (explicitDescriptor !== null && explicitDescriptor !== '0') {
+      index += redirection.length - 1;
+      continue;
+    }
+    return true;
+  }
+  return false;
+}
+
 /** Whether the heredoc's own clause hands its body to a code-reading consumer. */
 function heredocBodyIsProgram(line: string, marker: string): boolean {
   const segments = shellSegments(line);
@@ -735,6 +890,9 @@ function heredocBodyIsProgram(line: string, marker: string): boolean {
   for (let index = openingIndex; index < segments.length; index += 1) {
     const segment = segments[index]!;
     if (index > openingIndex && segment.precedingOperator !== '|') break;
+    // A downstream stdin redirection takes precedence over the pipe, so the
+    // current heredoc body cannot become that command's input program.
+    if (index > openingIndex && hasUnquotedStdinRedirection(segment.command)) break;
     if (
       consumesStdinAsProgram(
         tokenizeHeredocConsumer(segment.command.replace(marker, ' ')),

--- a/apps/desktop/src/main/maker-host/shell-command-policy.ts
+++ b/apps/desktop/src/main/maker-host/shell-command-policy.ts
@@ -609,11 +609,17 @@ const MIN_SIMULATOR_FRAGMENT_LENGTH = 4;
 
 /**
  * Join fragments a shell or interpreter concatenates: `"xcr" + "un"`,
- * `xcr"un"`, and AppleScript's `"xcr" & "un"`.
+ * `xcr"un"`, AppleScript's `"xcr" & "un"`, and the sequence forms interpreters
+ * join from (`''.join(('xc','run'))`).
+ *
+ * This is a finite set of forms and cannot cover arbitrary computation — a
+ * payload is free to assemble a name from base64 or character codes. Command
+ * text alone cannot decide those, which the module header already concedes for
+ * script contents; the evidence tests below are defence in depth, not a proof.
  */
 function normalizeConcatenatedFragments(command: string): string {
   return command
-    .replace(/(['"`])\s*[+&]\s*\1?/g, '')
+    .replace(/(['"`])\s*[+&,]\s*\1?/g, '')
     .replace(/(['"`])\s*\1/g, '')
     .replace(/['"`]/g, '');
 }
@@ -671,10 +677,17 @@ function hasSimulatorEvidence(command: string): boolean {
 
 /** Strip expansions and glob metacharacters, leaving the literal core (if any). */
 function commandWordLiteralCore(token: string): string {
-  return token
-    .replace(/\$\([^)]*\)|`[^`]*`|\$\{[^}]*\}|\$[A-Za-z_][A-Za-z0-9_]*|\$[0-9@*#?$!-]/g, '')
-    .replace(/[*?[\]{}()^~]/g, '')
-    .replace(/['"]/g, '');
+  return (
+    token
+      .replace(/\$\([^)]*\)|`[^`]*`|\$\{[^}]*\}|\$[A-Za-z_][A-Za-z0-9_]*|\$[0-9@*#?$!-]/g, '')
+      // The tokenizer splits on whitespace inside a substitution, so a command
+      // word can end in an unterminated remnant (`si$(printf` from
+      // `si$(printf m)ctl`). Drop the remnant: a shorter core is the
+      // fail-closed direction under the subsequence test below.
+      .replace(/[$`][^\s]*$/, '')
+      .replace(/[*?[\]{}()^~]/g, '')
+      .replace(/['"]/g, '')
+  );
 }
 
 /**
@@ -709,8 +722,23 @@ function isSimulatorFragmentCore(core: string): boolean {
   if (!name) return false;
   return SIMULATOR_EXECUTOR_NAMES.some(
     (executor) =>
-      name.startsWith(executor.slice(0, MIN_SIMULATOR_FRAGMENT_LENGTH)) || executor.includes(name),
+      name.startsWith(executor.slice(0, MIN_SIMULATOR_FRAGMENT_LENGTH)) ||
+      isSubsequenceOf(name, executor),
   );
+}
+
+/**
+ * Whether every character of `fragment` appears in `executor` in order. The
+ * stripped expansion can supply the missing characters at any position, so
+ * `si$(printf m)ctl` leaves the core `sictl` — contiguity is not a safe test.
+ */
+function isSubsequenceOf(fragment: string, executor: string): boolean {
+  let index = 0;
+  for (const char of fragment) {
+    index = executor.indexOf(char, index) + 1;
+    if (index === 0) return false;
+  }
+  return true;
 }
 
 /**

--- a/apps/desktop/src/main/maker-host/shell-command-policy.ts
+++ b/apps/desktop/src/main/maker-host/shell-command-policy.ts
@@ -20,10 +20,10 @@
  * executor anywhere in the command. This matcher denies only what it can read
  * directly and lets everything else reach the normal shell permission flow.
  *
- * A useful consequence: a recipe delivered through a heredoc needs no heredoc
- * modelling. Bodies are split into segments like any other text, and a body line
- * only matters when it literally spells out a Simulator command — so
- * `git commit -F - <<'MSG'` carrying backticks is simply not a match.
+ * Heredocs need one narrow boundary: their bodies are stdin data unless the
+ * receiving command executes stdin as a program. Data bodies are omitted from
+ * command classification (while substitutions in an unquoted body still run),
+ * so a commit message may quote a stale recipe without being mistaken for one.
  */
 
 export interface ShellCommandPolicyDenial {
@@ -527,9 +527,162 @@ function shellSubcommands(command: string): string[] {
   return subcommands;
 }
 
+function nestedShellConsumesStdinAsProgram(command: string): boolean {
+  return (
+    /(?:^|[;&|]\s*)(?:source|\.)\s+(?:\/dev\/stdin|\/dev\/fd\/0|-)(?:\s|$)/i.test(command) ||
+    /\beval\b[\s\S]*\$\(\s*cat(?:\s+(?:-|\/dev\/stdin|\/dev\/fd\/0))?\s*\)/i.test(command)
+  );
+}
+
+/** Whether this literal command executes its stdin as source code. */
+function consumesStdinAsProgram(tokens: string[]): boolean {
+  const unwrapped = unwrapCommand(tokens);
+  if (unwrapped.nestedShell !== null) {
+    return nestedShellConsumesStdinAsProgram(unwrapped.nestedShell);
+  }
+  const executable = executableName(unwrapped.tokens[0]);
+  const args = unwrapped.tokens.slice(1);
+  if (SHELL_EXECUTABLES.has(executable)) {
+    if (args.some((arg) => /^-[A-Za-z]*c[A-Za-z]*$/.test(arg))) return false;
+    if (args.some((arg) => /^-[A-Za-z]*s[A-Za-z]*$/.test(arg))) return true;
+  } else if (executable === 'osascript') {
+    if (args.some((arg) => arg === '-e' || arg.startsWith('-e'))) return false;
+  } else if (PROGRAMMABLE_INTERPRETER.test(executable)) {
+    if (/^(?:(?:g|m|n)?awk)$/.test(executable)) return false;
+    if (args.some((arg) => /^(?:-c|-e|-p|-m|--eval|--print|--input-type|--module)$/.test(arg))) {
+      return false;
+    }
+  } else {
+    return false;
+  }
+  const positional = args.find((arg) => !arg.startsWith('-'));
+  return positional === undefined || positional === '-';
+}
+
+interface HeredocRedirection {
+  marker: string;
+  delimiter: string;
+  expands: boolean;
+  stripsTabs: boolean;
+}
+
+/** Heredoc markers on one shell line, excluding quoted text, comments and `<<<`. */
+function heredocRedirections(line: string): HeredocRedirection[] {
+  const redirections: HeredocRedirection[] = [];
+  let quote: "'" | '"' | null = null;
+  let escaped = false;
+  for (let index = 0; index < line.length; index += 1) {
+    const char = line[index]!;
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (char === '\\' && quote !== "'") {
+      escaped = true;
+      continue;
+    }
+    if (char === "'" || char === '"') {
+      if (quote === char) quote = null;
+      else if (quote === null) quote = char;
+      continue;
+    }
+    if (quote) continue;
+    // In shell grammar `#` starts a comment when it begins a word. A marker in
+    // that comment must not consume later commands as a fake heredoc body.
+    if (char === '#' && (index === 0 || /[\s;&|()]/.test(line[index - 1]!))) break;
+    if (char !== '<' || line[index + 1] !== '<' || line[index + 2] === '<') continue;
+    let cursor = index + 2;
+    const stripsTabs = line[cursor] === '-';
+    if (stripsTabs) cursor += 1;
+    while (line[cursor] === ' ' || line[cursor] === '\t') cursor += 1;
+    let delimiter = '';
+    let expands = true;
+    while (cursor < line.length) {
+      const delimiterChar = line[cursor]!;
+      if (delimiterChar === "'" || delimiterChar === '"') {
+        expands = false;
+        const closing = line.indexOf(delimiterChar, cursor + 1);
+        if (closing < 0) {
+          delimiter += line.slice(cursor + 1);
+          cursor = line.length;
+          break;
+        }
+        delimiter += line.slice(cursor + 1, closing);
+        cursor = closing + 1;
+        continue;
+      }
+      if (delimiterChar === '\\') {
+        expands = false;
+        cursor += 1;
+        if (cursor < line.length) {
+          delimiter += line[cursor]!;
+          cursor += 1;
+        }
+        continue;
+      }
+      if (/[\s;&|<>()]/.test(delimiterChar)) break;
+      delimiter += delimiterChar;
+      cursor += 1;
+    }
+    if (delimiter !== '') {
+      redirections.push({ marker: line.slice(index, cursor), delimiter, expands, stripsTabs });
+    }
+    index = cursor - 1;
+  }
+  return redirections;
+}
+
+/** Whether the heredoc's own clause hands its body to a code-reading consumer. */
+function heredocBodyIsProgram(line: string, marker: string): boolean {
+  const segments = shellSegments(line);
+  const openingIndex = segments.findIndex((segment) => segment.command.includes(marker));
+  if (openingIndex < 0) return false;
+  for (let index = openingIndex; index < segments.length; index += 1) {
+    const segment = segments[index]!;
+    if (index > openingIndex && segment.precedingOperator !== '|') break;
+    if (
+      consumesStdinAsProgram(
+        tokenizeShellSegment(segment.command.replace(marker, ' ')),
+      )
+    ) return true;
+  }
+  return false;
+}
+
+/**
+ * Remove stdin-only heredoc prose before classifying command words.
+ *
+ * Bodies executed by a shell/interpreter remain visible. Data bodies disappear,
+ * except that an unquoted delimiter still executes command/process substitutions.
+ */
+function stripHeredocBodies(command: string): string {
+  if (!command.includes('<<')) return command;
+  const lines = command.split(/\r?\n/);
+  const executable: string[] = [];
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index]!;
+    executable.push(line);
+    for (const heredoc of heredocRedirections(line)) {
+      const body: string[] = [];
+      index += 1;
+      for (; index < lines.length; index += 1) {
+        const candidate = lines[index]!;
+        const unindented = heredoc.stripsTabs ? candidate.replace(/^\t+/, '') : candidate;
+        if (unindented === heredoc.delimiter) break;
+        body.push(candidate);
+      }
+      if (heredocBodyIsProgram(line, heredoc.marker)) executable.push(...body);
+      else if (heredoc.expands) executable.push(...shellSubcommands(body.join('\n')));
+      if (index >= lines.length) break;
+    }
+  }
+  return executable.join('\n');
+}
+
 function containsSimulatorRecipe(command: string, depth = 0): boolean {
   if (depth > MAX_RECURSION_DEPTH) return false;
-  for (const nested of shellSubcommands(command)) {
+  const executableCommand = stripHeredocBodies(command);
+  for (const nested of shellSubcommands(executableCommand)) {
     if (containsSimulatorRecipe(nested, depth + 1)) return true;
   }
   const assignments = new Map<string, string[]>();
@@ -541,7 +694,7 @@ function containsSimulatorRecipe(command: string, depth = 0): boolean {
     }
     return false;
   };
-  for (const segment of shellSegments(command)) {
+  for (const segment of shellSegments(executableCommand)) {
     const unwrapped = unwrapCommand(tokenizeShellSegment(segment.command));
     // Shell assignments replace the previous value before the command in this
     // segment runs. A `;`/newline-separated assignment therefore supersedes the

--- a/apps/desktop/src/main/maker-host/shell-command-policy.ts
+++ b/apps/desktop/src/main/maker-host/shell-command-policy.ts
@@ -685,6 +685,12 @@ function commandWordLiteralCore(token: string): string {
       // `si$(printf m)ctl`). Drop the remnant: a shorter core is the
       // fail-closed direction under the subsequence test below.
       .replace(/[$`][^\s]*$/, '')
+      // A character class or brace list holds mutually exclusive candidates, so
+      // its contents must go with its delimiters. Merging them invents a
+      // literal that matches nothing: `[sx]crun` would read as `sxcrun` and
+      // hide the `xcrun` the shell can expand to. Dropping the whole group
+      // leaves `crun`, which the subsequence test still catches.
+      .replace(/\[[^\]]*\]|\{[^}]*\}/g, '')
       .replace(/[*?[\]{}()^~]/g, '')
       .replace(/['"]/g, '')
   );

--- a/apps/desktop/src/main/maker-host/shell-command-policy.ts
+++ b/apps/desktop/src/main/maker-host/shell-command-policy.ts
@@ -544,7 +544,11 @@ function containsSimulatorRecipe(command: string, depth = 0): boolean {
     // it or isolate its scope, so both values remain possible there.
     for (const assignment of unwrapped.assignments) {
       if (assignment.name === '') continue;
-      if (assignmentDefinitelyRunsInCurrentScope(segment)) {
+      const persistentAssignment =
+        assignmentDefinitelyRunsInCurrentScope(segment)
+        && unwrapped.tokens.length === 0
+        && unwrapped.nestedShell === null;
+      if (persistentAssignment) {
         assignments.set(assignment.name, [assignment.value]);
       } else {
         const possibleValues = assignments.get(assignment.name) ?? [];

--- a/apps/desktop/src/main/maker-host/shell-command-policy.ts
+++ b/apps/desktop/src/main/maker-host/shell-command-policy.ts
@@ -192,9 +192,17 @@ const PROGRAMMABLE_INTERPRETER =
   /^(?:python(?:\d+(?:\.\d+)*)?|pypy(?:\d+(?:\.\d+)*)?|node|nodejs|bun|deno|ruby(?:\d+(?:\.\d+)*)?|perl(?:\d+(?:\.\d+)*)?|php(?:\d+(?:\.\d+)*)?|lua(?:\d+(?:\.\d+)*)?|luajit|swift|expect(?:\d+(?:\.\d+)*)?|tclsh(?:\d+(?:\.\d+)*)?|wish(?:\d+(?:\.\d+)*)?|(?:g|m|n)?awk|osascript)$/;
 
 /**
- * Prefixes documentation puts in front of a recipe. Peeling is best-effort: an
- * unfamiliar option shape simply stops the peel, because mislocating the command
- * word now costs a missed literal instead of a denied ordinary command.
+ * Prefixes documentation puts in front of a recipe, in the plain spelling it
+ * actually uses: `sudo xcrun simctl …`, `env FOO=1 xcrun simctl …`,
+ * `timeout 30 xcrun simctl …`.
+ *
+ * **An option on the prefix ends the peel.** Reading past one means knowing that
+ * CLI's option arity *and* whether its operands are executed at all — `sudo -l`
+ * and `command -v` merely report on the command they name. Both kinds of
+ * knowledge were a standing source of defects here, in the direction that
+ * matters: getting either wrong denies ordinary work. Stopping can only miss,
+ * and a recipe copied out of documentation does not arrive decorated with
+ * options.
  */
 const LITERAL_COMMAND_PREFIXES = new Set([
   'arch',
@@ -214,26 +222,6 @@ const LITERAL_COMMAND_PREFIXES = new Set([
   'xargs',
 ]);
 
-/**
- * Options of those prefixes that consume the following token. Without this,
- * `env -u FOO xcrun simctl …` reads `FOO` as the command and the peel stops
- * short of a recipe that is spelled out in full. Separate-word spellings only:
- * an `--opt=value` form starts with `-` and is skipped as a plain flag.
- */
-const PREFIX_VALUE_OPTIONS: Record<string, RegExp> = {
-  arch: /^(?:-arch|--arch|-d|-e)$/,
-  caffeinate: /^(?:-t|-w)$/,
-  env: /^(?:-u|--unset|-C|--chdir|-S|--split-string)$/,
-  // `exec [-cl] [-a name] command …` — `-a` supplies argv[0], the command follows.
-  exec: /^-a$/,
-  gtimeout: /^(?:-k|-s|--kill-after|--signal)$/,
-  nice: /^(?:-n|--adjustment)$/,
-  sudo: /^(?:-u|--user|-g|--group|-h|--host|-p|--prompt|-C|--close-from|-D|--chdir|-R|--chroot|-T|--command-timeout|-U|--other-user|-r|--role)$/,
-  timeout: /^(?:-k|-s|--kill-after|--signal)$/,
-  xargs:
-    /^(?:-n|--max-args|-L|--max-lines|-I|--replace|-P|--max-procs|-s|--max-chars|-E|--eof)$/,
-};
-
 interface UnwrappedCommand {
   tokens: string[];
   /** A literal program string handed to a shell via `-c`, classified recursively. */
@@ -250,17 +238,6 @@ const SHELL_ASSIGNMENT_BUILTINS = new Set([
   'typeset',
 ]);
 
-/** `command -v` / `-V` only describe their operands; nothing is executed. */
-function isInspectionOnlyCommandBuiltin(tokens: string[]): boolean {
-  if (executableName(tokens[0]) !== 'command') return false;
-  for (let index = 1; index < tokens.length; index += 1) {
-    const token = tokens[index]!;
-    if (token === '--' || !token.startsWith('-')) break;
-    if (/^-[A-Za-z]*[vV]/.test(token)) return true;
-  }
-  return false;
-}
-
 /** Peel documentation-style prefixes to reach the command word. */
 function unwrapCommand(input: string[]): UnwrappedCommand {
   const first = stripLeadingShellPreamble(stripShellControlTokens(input));
@@ -273,11 +250,6 @@ function unwrapCommand(input: string[]): UnwrappedCommand {
     if (tokens.length === 0) return { tokens, nestedShell: null, assignedValues };
     const head = executableName(tokens[0]);
 
-    if (isInspectionOnlyCommandBuiltin(tokens)) {
-      // Describing `simctl shutdown` is not running it; classifying the operands
-      // would deny an inspection that executes nothing.
-      return { tokens: [], nestedShell: null, assignedValues };
-    }
     if (SHELL_ASSIGNMENT_BUILTINS.has(head)) {
       // `export CMD='xcrun simctl …'` stores the recipe just like a bare
       // assignment, so its operands feed the same assigned-value path.
@@ -311,16 +283,12 @@ function unwrapCommand(input: string[]): UnwrappedCommand {
     }
     if (!LITERAL_COMMAND_PREFIXES.has(head)) return { tokens, nestedShell: null, assignedValues };
 
-    const valueOptions = PREFIX_VALUE_OPTIONS[head];
     let index = 1;
-    while (index < tokens.length) {
-      const token = tokens[index]!;
-      if (token === '--') {
-        index += 1;
-        break;
-      }
-      if (!token.startsWith('-')) break;
-      index += valueOptions?.test(token) ? 2 : 1;
+    if (tokens[index] === '--') {
+      // The only option-like token whose meaning needs no per-CLI knowledge.
+      index += 1;
+    } else if (tokens[index]?.startsWith('-')) {
+      return { tokens, nestedShell: null, assignedValues };
     }
     // timeout takes a duration operand before the command it runs.
     if ((head === 'timeout' || head === 'gtimeout') && /^[\d.]+[smhd]?$/.test(tokens[index] ?? '')) {

--- a/apps/desktop/src/main/maker-host/shell-command-policy.ts
+++ b/apps/desktop/src/main/maker-host/shell-command-policy.ts
@@ -60,6 +60,7 @@ function shellSegments(command: string): ShellSegment[] {
   let current = '';
   let quote: "'" | '"' | null = null;
   let escaped = false;
+  let atWordStart = true;
   let precedingOperator: ShellSegment['precedingOperator'] = null;
 
   const flush = (nextOperator: Exclude<ShellSegment['precedingOperator'], null>): void => {
@@ -79,11 +80,13 @@ function shellSegments(command: string): ShellSegment[] {
     if (escaped) {
       current += char;
       escaped = false;
+      atWordStart = false;
       continue;
     }
     if (char === '\\' && quote !== "'") {
       current += char;
       escaped = true;
+      atWordStart = false;
       continue;
     }
     if (quote) {
@@ -94,6 +97,16 @@ function shellSegments(command: string): ShellSegment[] {
     if (char === "'" || char === '"') {
       current += char;
       quote = char;
+      atWordStart = false;
+      continue;
+    }
+    if (char === '#' && atWordStart) {
+      // A comment consumes the rest of the current physical line. Keep the
+      // newline for the normal separator handling so assignments before the
+      // comment retain their real shell scope.
+      const newline = command.indexOf('\n', index);
+      if (newline < 0) break;
+      index = newline - 1;
       continue;
     }
     if (char === '\n' || char === ';') {
@@ -103,6 +116,7 @@ function shellSegments(command: string): ShellSegment[] {
       // A lone `&` is already a complete separator, so the next line is
       // unconditional in the parent shell.
       if (char === ';' || current.trim() || precedingOperator === '&') flush(';');
+      atWordStart = true;
       continue;
     }
     if (
@@ -111,6 +125,7 @@ function shellSegments(command: string): ShellSegment[] {
       (char === '|' && command[index - 1] === '>')
     ) {
       current += char;
+      atWordStart = false;
       continue;
     }
     if (char === '|' || char === '&') {
@@ -122,9 +137,11 @@ function shellSegments(command: string): ShellSegment[] {
       const doubled = command[index + 1] === char;
       flush(doubled ? (char === '|' ? '||' : '&&') : char);
       if (doubled) index += 1;
+      atWordStart = true;
       continue;
     }
     current += char;
+    atWordStart = /\s/.test(char);
   }
   if (current.trim())
     segments.push({ command: current.trim(), precedingOperator, followingOperator: null });

--- a/apps/desktop/src/main/maker-host/shell-command-policy.ts
+++ b/apps/desktop/src/main/maker-host/shell-command-policy.ts
@@ -601,6 +601,119 @@ function containsLiteralSimulatorExecutor(value: string): boolean {
   );
 }
 
+const MAX_ASSIGNMENT_RESOLUTION_PASSES = 4;
+const MAX_RESOLVED_ASSIGNMENTS = 64;
+const MAX_RESOLUTION_GROWTH_FACTOR = 8;
+const SIMULATOR_EXECUTOR_NAMES = ['xcrun', 'simctl'];
+const MIN_SIMULATOR_FRAGMENT_LENGTH = 4;
+
+/**
+ * Join fragments a shell or interpreter concatenates: `"xcr" + "un"`,
+ * `xcr"un"`, and AppleScript's `"xcr" & "un"`.
+ */
+function normalizeConcatenatedFragments(command: string): string {
+  return command
+    .replace(/(['"`])\s*[+&]\s*\1?/g, '')
+    .replace(/(['"`])\s*\1/g, '')
+    .replace(/['"`]/g, '');
+}
+
+/** Resolve literal `NAME=value` assignments so `"$A$B"` reveals its executor. */
+function resolveSimpleAssignments(command: string): string {
+  const values = new Map<string, string>();
+  for (const match of command.matchAll(
+    /(?:^|[\s;&|(])([A-Za-z_][A-Za-z0-9_]*)=(?:'([^']*)'|"([^"$`]*)"|([A-Za-z0-9_./:+-]*))/g,
+  )) {
+    const value = match[2] ?? match[3] ?? match[4] ?? '';
+    if (value) values.set(match[1]!, value);
+    // Bound the work: this runs inside a synchronous hook and a Codex event
+    // handler, so a pathological command must not be able to stall either.
+    if (values.size >= MAX_RESOLVED_ASSIGNMENTS) break;
+  }
+  if (values.size === 0) return command;
+  const budget = command.length * MAX_RESOLUTION_GROWTH_FACTOR;
+  let resolved = command;
+  for (let pass = 0; pass < MAX_ASSIGNMENT_RESOLUTION_PASSES; pass += 1) {
+    let changed = false;
+    for (const [name, value] of values) {
+      const next = resolved.replace(new RegExp(`\\$(?:${name}\\b|\\{${name}\\})`, 'g'), value);
+      if (next !== resolved) {
+        resolved = next;
+        changed = true;
+      }
+      // Self-referential values (`A='$A$A'`) grow geometrically. Stop expanding
+      // and classify what has been resolved so far.
+      if (resolved.length > budget) return resolved;
+    }
+    if (!changed) break;
+  }
+  return resolved;
+}
+
+/**
+ * Whether the command still names the Simulator boundary once the concatenation
+ * and simple-assignment tricks that hide an executor are undone.
+ *
+ * Evidence is never a denial by itself. It is what licenses the shape-only
+ * fail-closed rules below to fire: without it, an unresolvable *shape* — a glob,
+ * a paren, a brace — is just ordinary text. Interpreter payloads, heredoc bodies
+ * and arithmetic expressions are full of such shapes, and denying them blocks
+ * work this boundary was never meant to touch.
+ */
+function hasSimulatorEvidence(command: string): boolean {
+  const resolved = resolveSimpleAssignments(command);
+  return (
+    containsLiteralSimulatorExecutor(command) ||
+    containsLiteralSimulatorExecutor(resolved) ||
+    containsLiteralSimulatorExecutor(normalizeConcatenatedFragments(resolved))
+  );
+}
+
+/** Strip expansions and glob metacharacters, leaving the literal core (if any). */
+function commandWordLiteralCore(token: string): string {
+  return token
+    .replace(/\$\([^)]*\)|`[^`]*`|\$\{[^}]*\}|\$[A-Za-z_][A-Za-z0-9_]*|\$[0-9@*#?$!-]/g, '')
+    .replace(/[*?[\]{}()^~]/g, '')
+    .replace(/['"]/g, '');
+}
+
+/** A word made only of expansions can resolve to anything, including simctl. */
+function isPureExpansionWord(token: string): boolean {
+  return /[$`]/.test(token) && commandWordLiteralCore(token).replace(/[\s/=,.:+-]/g, '') === '';
+}
+
+/** `simct?`, `simctl~foo`, `xc[r]un`: a literal core that still names the boundary. */
+function isSimulatorFragmentCore(core: string): boolean {
+  // Trailing separators are left behind by stripped expansions (`$X/simctl/$Y`),
+  // so classify against the last segment that still carries literal text.
+  const name = (
+    core
+      .replace(/\\/g, '/')
+      .split('/')
+      .filter((segment) => segment !== '')
+      .at(-1) ?? ''
+  ).toLowerCase();
+  if (!name) return false;
+  return SIMULATOR_EXECUTOR_NAMES.some((executor) => {
+    for (let length = executor.length; length >= MIN_SIMULATOR_FRAGMENT_LENGTH; length -= 1) {
+      if (name.startsWith(executor.slice(0, length))) return true;
+    }
+    return false;
+  });
+}
+
+/**
+ * Command position holds something this policy cannot resolve. A pure expansion
+ * stays fail-closed because its value is unknowable; a word that keeps a literal
+ * core is only a bypass candidate when that core, or the command around it,
+ * shows Simulator evidence.
+ */
+function isUnprovableCommandWord(token: string, evidence: boolean): boolean {
+  if (!hasDynamicShellExpansion(token)) return false;
+  if (isPureExpansionWord(token)) return true;
+  return evidence || isSimulatorFragmentCore(commandWordLiteralCore(token));
+}
+
 /**
  * General-purpose interpreters can spawn simctl without making it the shell
  * executable. Treat a literal Simulator executor in their payload/argv as a
@@ -611,14 +724,16 @@ function containsInterpreterSimulatorPayload(tokens: string[]): boolean {
   const interpreter = executableName(tokens[0]);
   const payload = tokens.slice(1).join('\n');
   if (PROGRAMMABLE_INTERPRETER.test(interpreter)) {
-    return containsLiteralSimulatorExecutor(payload);
+    // Interpreters concatenate string fragments, so `"xcr" + "un"` names the
+    // same executor a literal match would miss.
+    return hasSimulatorEvidence(payload);
   }
   if (interpreter === 'osascript') {
     // AppleScript can execute through `do shell script`, while JavaScript for
     // Automation can reach NSTask/NSProcessInfo directly. Once an osascript
-    // payload contains a literal Simulator executor, command-text policy cannot
-    // safely distinguish an inert reference from executable code.
-    return containsLiteralSimulatorExecutor(payload);
+    // payload names a Simulator executor, command-text policy cannot safely
+    // distinguish an inert reference from executable code.
+    return hasSimulatorEvidence(payload);
   }
   return false;
 }
@@ -779,7 +894,7 @@ function hasDynamicShellExpansion(token: string): boolean {
   return /[$`*?[\]{}()^~]/.test(token) || token.indexOf('#') > 0;
 }
 
-function hasUnresolvedExecutableExpansion(tokens: string[]): boolean {
+function hasUnresolvedExecutableExpansion(tokens: string[], evidence: boolean): boolean {
   const executableTokens = stripShellControlTokens(tokens);
   while (executableTokens[0] && /^[A-Za-z_][A-Za-z0-9_]*=/.test(executableTokens[0])) {
     executableTokens.shift();
@@ -788,7 +903,7 @@ function hasUnresolvedExecutableExpansion(tokens: string[]): boolean {
   // `[` and `[[` are literal shell condition builtins, not glob-expanded
   // executable names. Other expansion syntax in command position is unsafe.
   if (executable === '[' || executable === '[[') return false;
-  return hasDynamicShellExpansion(executable);
+  return isUnprovableCommandWord(executable, evidence);
 }
 
 /** Arithmetic compound commands contain expressions, not an executable argv. */
@@ -803,22 +918,31 @@ function isArithmeticCompoundCommand(tokens: string[]): boolean {
 
 /**
  * Shell arithmetic recursively resolves bare variables and array subscripts,
- * which can execute command substitutions stored in their values. Only
- * expressions made entirely from decimal literals and operators are safe to
- * classify without evaluating the shell environment.
+ * which can execute command substitutions stored in their values. Literals and
+ * operators are always safe; a named expansion or a subscript never is. A bare
+ * identifier sits between the two: the shell would resolve it recursively, but
+ * reaching an executor that way requires the command to have stored one, so it
+ * is classified against Simulator evidence rather than denied on shape alone.
  */
-function hasDynamicArithmeticEvaluation(segment: string): boolean {
+function hasDynamicArithmeticEvaluation(segment: string, evidence: boolean): boolean {
   const start = segment.indexOf('((');
   const end = segment.lastIndexOf('))');
   if (start < 0 || end < start + 2) return true;
   const expression = segment.slice(start + 2, end);
-  return !/^[\s0-9()+\-*/%<>=!&|^~?:,]*$/.test(expression);
+  // Positional and special parameters evaluate to numbers in arithmetic, so
+  // they cannot name a command; fold them away before classifying.
+  const probe = expression.replace(/\$(?:[0-9]+|[#?$!]|\{(?:[0-9]+|[#?$!])\})/g, '0');
+  if (/^[\s0-9()+\-*/%<>=!&|^~?:,]*$/.test(probe)) return false;
+  if (/[$`]/.test(probe) || /\[[^\]]*\]/.test(probe)) return true;
+  if (/^[\sA-Za-z_0-9()+\-*/%<>=!&|^~?:,]*$/.test(probe)) return evidence;
+  return true;
 }
 
 /** Unknown wrapper option shapes cannot prove which expanded token becomes the command. */
-function hasUnresolvedWrapperExpansion(unwrapped: UnwrappedCommand): boolean {
+function hasUnresolvedWrapperExpansion(unwrapped: UnwrappedCommand, evidence: boolean): boolean {
   return (
-    unwrapped.unresolvedWrapper && unwrapped.tokens.some((token) => hasDynamicShellExpansion(token))
+    unwrapped.unresolvedWrapper &&
+    unwrapped.tokens.some((token) => isUnprovableCommandWord(token, evidence))
   );
 }
 
@@ -886,24 +1010,24 @@ function opaqueOptionShape(head: string, token: string): OpaqueOptionShape {
   return 'unknown';
 }
 
-function hasDynamicWrappedCommand(tokens: string[], depth: number): boolean {
+function hasDynamicWrappedCommand(tokens: string[], evidence: boolean, depth: number): boolean {
   if (tokens.length === 0) return false;
   if (depth > MAX_WRAPPER_UNWRAP_DEPTH) {
-    return tokens.some((token) => hasDynamicShellExpansion(token));
+    return tokens.some((token) => isUnprovableCommandWord(token, evidence));
   }
   const unwrapped = unwrapCommand(tokens);
   if (unwrapped.inspectionOnly) return false;
-  if (hasUnresolvedWrapperExpansion(unwrapped)) return true;
+  if (hasUnresolvedWrapperExpansion(unwrapped, evidence)) return true;
   if (unwrapped.nestedShell !== null) {
-    if (containsSimulatorBypass(unwrapped.nestedShell, depth + 1)) return true;
-    return unwrapped.tokens.some((token) => hasDynamicShellExpansion(token));
+    if (containsSimulatorBypass(unwrapped.nestedShell, evidence, depth + 1)) return true;
+    return unwrapped.tokens.some((token) => isUnprovableCommandWord(token, evidence));
   }
-  if (hasUnresolvedExecutableExpansion(unwrapped.tokens)) return true;
-  return hasOpaqueWrapperExpansion(tokens, depth + 1);
+  if (hasUnresolvedExecutableExpansion(unwrapped.tokens, evidence)) return true;
+  return hasOpaqueWrapperExpansion(tokens, evidence, depth + 1);
 }
 
 /** Locate the command operand conservatively without mistaking later data argv for executables. */
-function hasOpaqueWrapperExpansion(tokens: string[], depth = 0): boolean {
+function hasOpaqueWrapperExpansion(tokens: string[], evidence: boolean, depth = 0): boolean {
   tokens = stripShellRedirections(tokens);
   const head = executableName(tokens[0]);
   if (head === 'find') {
@@ -914,7 +1038,7 @@ function hasOpaqueWrapperExpansion(tokens: string[], depth = 0): boolean {
           candidateIndex > index && (token === ';' || token === '+' || token === '\\;'),
       );
       const commandEnd = terminator < 0 ? tokens.length : terminator;
-      return hasDynamicWrappedCommand(tokens.slice(index + 1, commandEnd), depth + 1);
+      return hasDynamicWrappedCommand(tokens.slice(index + 1, commandEnd), evidence, depth + 1);
     }
     return false;
   }
@@ -922,12 +1046,12 @@ function hasOpaqueWrapperExpansion(tokens: string[], depth = 0): boolean {
   if (head === 'coproc') {
     // Bash/zsh allow an optional coprocess name, so command position is
     // ambiguous. Any expansion in this execution form must fail closed.
-    return tokens.slice(1).some((token) => hasDynamicShellExpansion(token));
+    return tokens.slice(1).some((token) => isUnprovableCommandWord(token, evidence));
   }
   if (head === 'repeat') {
     // zsh evaluates the count arithmetically before executing argv.
     if (!/^\d+$/.test(tokens[1] ?? '')) return true;
-    return hasDynamicWrappedCommand(tokens.slice(2), depth + 1);
+    return hasDynamicWrappedCommand(tokens.slice(2), evidence, depth + 1);
   }
 
   let index = 1;
@@ -948,7 +1072,7 @@ function hasOpaqueWrapperExpansion(tokens: string[], depth = 0): boolean {
       const commandValue = token.includes('=')
         ? token.slice(token.indexOf('=') + 1)
         : possibleValue;
-      if (hasDynamicShellExpansion(commandValue ?? '')) return true;
+      if (isUnprovableCommandWord(commandValue ?? '', evidence)) return true;
       index += token.includes('=') ? 1 : 2;
       continue;
     }
@@ -963,7 +1087,7 @@ function hasOpaqueWrapperExpansion(tokens: string[], depth = 0): boolean {
     // Unknown option arity makes every later dynamic token ambiguous: it may
     // be either an option value or the actual command. Fail closed instead of
     // guessing and accidentally stepping past the executable.
-    return tokens.slice(index).some((value) => hasDynamicShellExpansion(value));
+    return tokens.slice(index).some((value) => isUnprovableCommandWord(value, evidence));
   }
   if (head === 'sudo') {
     while (/^[A-Za-z_][A-Za-z0-9_]*=/.test(tokens[index] ?? '')) index += 1;
@@ -971,7 +1095,7 @@ function hasOpaqueWrapperExpansion(tokens: string[], depth = 0): boolean {
   // timeout consumes a duration before its command; macOS script consumes an
   // output file before an optional command.
   if (head === 'timeout' || head === 'gtimeout' || head === 'script') index += 1;
-  return hasDynamicWrappedCommand(tokens.slice(index), depth + 1);
+  return hasDynamicWrappedCommand(tokens.slice(index), evidence, depth + 1);
 }
 
 function referencesVariable(command: string, variable: string): boolean {
@@ -1222,7 +1346,7 @@ function shellCompoundBodyEnd(command: string, openingIndex: number): number | n
 }
 
 /** Function bodies are executable later, so reject unsafe bodies at definition time. */
-function containsSimulatorFunctionBody(command: string, depth: number): boolean {
+function containsSimulatorFunctionBody(command: string, evidence: boolean, depth: number): boolean {
   const functionPattern = new RegExp(
     `(?:^|[;\\n]\\s*)${SHELL_FUNCTION_HEADER_SOURCE}\\s*([({])`,
     'g',
@@ -1231,7 +1355,7 @@ function containsSimulatorFunctionBody(command: string, depth: number): boolean 
     const openingIndex = functionPattern.lastIndex - 1;
     const closingIndex = shellCompoundBodyEnd(command, openingIndex);
     if (closingIndex === null) continue;
-    if (containsSimulatorBypass(command.slice(openingIndex + 1, closingIndex), depth + 1)) {
+    if (containsSimulatorBypass(command.slice(openingIndex + 1, closingIndex), evidence, depth + 1)) {
       return true;
     }
     functionPattern.lastIndex = closingIndex + 1;
@@ -1240,7 +1364,11 @@ function containsSimulatorFunctionBody(command: string, depth: number): boolean 
 }
 
 /** Alias bodies are executable later, so reject unsafe definitions up front. */
-function containsSimulatorAliasDefinition(tokens: string[], depth: number): boolean {
+function containsSimulatorAliasDefinition(
+  tokens: string[],
+  evidence: boolean,
+  depth: number,
+): boolean {
   if (executableName(tokens[0]) !== 'alias') return false;
   let index = tokens[1] === '--' ? 2 : 1;
   for (; index < tokens.length; index += 1) {
@@ -1249,24 +1377,27 @@ function containsSimulatorAliasDefinition(tokens: string[], depth: number): bool
     // `alias` and `alias name` only inspect the current shell state.
     if (separator <= 0) continue;
     const body = definition.slice(separator + 1);
-    if (containsLiteralSimulatorExecutor(body) || containsSimulatorBypass(body, depth + 1)) {
+    if (
+      containsLiteralSimulatorExecutor(body) ||
+      containsSimulatorBypass(body, evidence, depth + 1)
+    ) {
       return true;
     }
   }
   return false;
 }
 
-function containsSimulatorBypass(command: string, depth = 0): boolean {
+function containsSimulatorBypass(command: string, evidence: boolean, depth = 0): boolean {
   if (depth > 8) return /\b(?:simctl|Simulator(?:\.app)?)\b/i.test(command);
   if (
     containsTaintedVariableExecution(command) ||
     containsShellConsumedLiteralBypass(command) ||
-    containsSimulatorFunctionBody(command, depth)
+    containsSimulatorFunctionBody(command, evidence, depth)
   ) {
     return true;
   }
   for (const nested of shellSubcommands(command)) {
-    if (containsSimulatorBypass(nested, depth + 1)) return true;
+    if (containsSimulatorBypass(nested, evidence, depth + 1)) return true;
   }
   for (const segment of shellSegments(command)) {
     // Function bodies were classified recursively above. The leading
@@ -1276,7 +1407,7 @@ function containsSimulatorBypass(command: string, depth = 0): boolean {
     }
     const tokens = tokenizeShellSegment(segment);
     const arithmeticCompound = isArithmeticCompoundCommand(tokens);
-    if (arithmeticCompound && hasDynamicArithmeticEvaluation(segment)) return true;
+    if (arithmeticCompound && hasDynamicArithmeticEvaluation(segment, evidence)) return true;
     const unwrapped = unwrapCommand(tokens);
     if (unwrapped.inspectionOnly) continue;
     // Known wrappers are peeled first so `env "$TOOL"` and `exec "$TOOL"`
@@ -1286,18 +1417,21 @@ function containsSimulatorBypass(command: string, depth = 0): boolean {
     if (
       !arithmeticCompound &&
       unwrapped.nestedShell === null &&
-      hasUnresolvedExecutableExpansion(unwrapped.tokens)
+      hasUnresolvedExecutableExpansion(unwrapped.tokens, evidence)
     ) {
       return true;
     }
-    if (hasUnresolvedWrapperExpansion(unwrapped) || hasOpaqueWrapperExpansion(tokens)) {
+    if (
+      hasUnresolvedWrapperExpansion(unwrapped, evidence) ||
+      hasOpaqueWrapperExpansion(tokens, evidence)
+    ) {
       return true;
     }
-    if (containsSimulatorAliasDefinition(unwrapped.tokens, depth)) return true;
+    if (containsSimulatorAliasDefinition(unwrapped.tokens, evidence, depth)) return true;
     if (unwrapped.nestedShell !== null) {
       if (unwrapped.unresolvedWrapper)
         return containsSimulatorExecutor(tokenizeShellSegment(segment));
-      if (containsSimulatorBypass(unwrapped.nestedShell, depth + 1)) return true;
+      if (containsSimulatorBypass(unwrapped.nestedShell, evidence, depth + 1)) return true;
       continue;
     }
     if (unwrapped.unresolvedWrapper && containsSimulatorExecutor(unwrapped.tokens)) return true;
@@ -1322,7 +1456,7 @@ export function getDesktopShellCommandPolicy(
   // POSIX shells remove an unquoted backslash-newline before tokenization.
   // Mirror that expansion so the policy cannot be bypassed with continuations.
   const expandedCommand = command.replace(/\\\r?\n/g, '');
-  if (containsSimulatorBypass(expandedCommand)) {
+  if (containsSimulatorBypass(expandedCommand, hasSimulatorEvidence(expandedCommand))) {
     return { decision: 'deny', reason: IOS_SIMULATOR_SHELL_DENIAL };
   }
   return undefined;

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -13623,6 +13623,58 @@ describe('CodexAgent MCP thread context hooks', () => {
     expect(JSON.stringify(terminal)).not.toContain('aborted by user');
   });
 
+  it('still reports the denial when the interrupt loses the race and the turn completes', async () => {
+    const policy = vi.fn(() => ({
+      decision: 'deny' as const,
+      reason: 'use the embedded iOS Simulator',
+    }));
+    const agent = new CodexAgent(createDeps({}, { getShellCommandPolicy: policy }));
+    const host = installFakeHost(agent, (method) =>
+      method === Method.TurnInterrupt ? {} : undefined,
+    );
+    const handle = await agent.startSession({
+      sessionId: 'session-policy-lost-race',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+      permissionMode: 'bypassPermissions',
+    });
+    const handlers = host.getThreadHandlers();
+    if (!handlers?.itemStarted || !handlers.turnCompleted) {
+      throw new Error('expected itemStarted and turnCompleted handlers');
+    }
+    const events: AgentEvent[] = [];
+    const collectEvents = (async () => {
+      for await (const event of handle.events()) events.push(event);
+    })();
+
+    handlers.itemStarted({
+      threadId: 'start-thread-id',
+      turnId: 'turn-1',
+      item: { id: 'cmd-1', type: 'commandExecution', command: 'open -a Simulator', cwd: '/repo' },
+    });
+    // turn/interrupt is asynchronous: a trusted prohibited command can finish
+    // first, and Codex then reports the turn as completed. The denial must still
+    // be the terminal outcome, or the run reads as a plain success.
+    handlers.turnCompleted({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-1', status: 'completed' },
+    } as never);
+
+    await handle.close();
+    await collectEvents;
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'error',
+          data: expect.objectContaining({
+            message: 'use the embedded iOS Simulator',
+            isTerminal: true,
+          }),
+        }),
+      ]),
+    );
+  });
+
   it('interrupts a raw function_call exec_command shell bypass as a fail-safe', async () => {
     const policy = vi.fn(() => ({
       decision: 'deny' as const,

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -13127,6 +13127,88 @@ describe('CodexAgent MCP thread context hooks', () => {
     expect(JSON.stringify(terminal)).not.toContain('aborted by user');
   });
 
+  it('keeps all declined approval items attached to an interrupted turn', async () => {
+    const policy = vi.fn(({ command }: { command: string }) => ({
+      decision: 'deny' as const,
+      reason: command.startsWith('open ') ? 'first policy reason' : 'latest policy reason',
+    }));
+    const agent = new CodexAgent(createDeps({}, { getShellCommandPolicy: policy }));
+    const host = installFakeHost(agent);
+    const handle = await agent.startSession({
+      sessionId: 'session-command-approval-policy-multiple-denials',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+      permissionMode: 'bypassPermissions',
+    });
+    const handlers = host.getThreadHandlers();
+    if (!handlers?.commandExecutionApproval || !handlers.itemCompleted || !handlers.turnCompleted) {
+      throw new Error('expected commandExecutionApproval, itemCompleted and turnCompleted handlers');
+    }
+    const events: AgentEvent[] = [];
+    const collectEvents = (async () => {
+      for await (const event of handle.events()) events.push(event);
+    })();
+
+    const turnId = 'turn-approval-policy-multiple-denials';
+    await expect(Promise.all([
+      handlers.commandExecutionApproval({
+        threadId: 'start-thread-id',
+        turnId,
+        itemId: 'cmd-approval-policy-first',
+        command: 'open -a Simulator',
+        cwd: '/repo',
+      }),
+      handlers.commandExecutionApproval({
+        threadId: 'start-thread-id',
+        turnId,
+        itemId: 'cmd-approval-policy-second',
+        command: 'xcrun simctl shutdown DEVICE',
+        cwd: '/repo',
+      }),
+    ])).resolves.toEqual([
+      { decision: 'decline' },
+      { decision: 'decline' },
+    ]);
+
+    // Completion of either declined item is not recovery progress. The
+    // interrupted turn must still retain the policy attribution.
+    handlers.itemCompleted({
+      threadId: 'start-thread-id',
+      turnId,
+      item: {
+        id: 'cmd-approval-policy-first',
+        type: 'commandExecution',
+        command: 'open -a Simulator',
+        cwd: '/repo',
+      },
+    });
+    handlers.turnCompleted({
+      threadId: 'start-thread-id',
+      turn: {
+        id: turnId,
+        status: 'interrupted',
+        error: { message: 'aborted by user' },
+      },
+    } as never);
+
+    await handle.close();
+    await collectEvents;
+    const terminal = events.filter(
+      (event) =>
+        (event as { type?: string }).type === 'error' &&
+        (event as { data?: { isTerminal?: boolean } }).data?.isTerminal === true,
+    );
+    expect(terminal).toEqual([
+      expect.objectContaining({
+        data: expect.objectContaining({
+          message: 'latest policy reason',
+          isTerminal: true,
+        }),
+      }),
+    ]);
+    expect(JSON.stringify(terminal)).not.toContain('aborted by user');
+  });
+
   it('lets an approval-path denial recover to a normal completed turn', async () => {
     const policy = vi.fn(() => ({
       decision: 'deny' as const,

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -13209,6 +13209,110 @@ describe('CodexAgent MCP thread context hooks', () => {
     expect(JSON.stringify(terminal)).not.toContain('aborted by user');
   });
 
+  it('keeps an approval denial through late updates from a pre-existing parallel item', async () => {
+    const policy = vi.fn(({ command }: { command: string }) =>
+      command === 'open -a Simulator'
+        ? { decision: 'deny' as const, reason: 'use the embedded iOS Simulator' }
+        : undefined,
+    );
+    const agent = new CodexAgent(createDeps({}, { getShellCommandPolicy: policy }));
+    const host = installFakeHost(agent);
+    const handle = await agent.startSession({
+      sessionId: 'session-command-approval-policy-parallel-sibling',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+      permissionMode: 'bypassPermissions',
+    });
+    const handlers = host.getThreadHandlers();
+    if (
+      !handlers?.commandExecutionApproval
+      || !handlers.itemStarted
+      || !handlers.itemUpdated
+      || !handlers.itemCompleted
+      || !handlers.turnDiffUpdated
+      || !handlers.turnCompleted
+    ) {
+      throw new Error('expected approval, item lifecycle and turn diff handlers');
+    }
+    const events: AgentEvent[] = [];
+    const collectEvents = (async () => {
+      for await (const event of handle.events()) events.push(event);
+    })();
+
+    const turnId = 'turn-approval-policy-parallel-sibling';
+    // This item was already running when the other parallel command was
+    // declined. Its late completion must not erase the denial attribution.
+    handlers.itemStarted({
+      threadId: 'start-thread-id',
+      turnId,
+      item: {
+        id: 'cmd-parallel-sibling',
+        type: 'commandExecution',
+        command: 'printf safe',
+        cwd: '/repo',
+      },
+    });
+    await expect(
+      handlers.commandExecutionApproval({
+        threadId: 'start-thread-id',
+        turnId,
+        itemId: 'cmd-denied-parallel',
+        command: 'open -a Simulator',
+        cwd: '/repo',
+      }),
+    ).resolves.toEqual({ decision: 'decline' });
+    handlers.turnDiffUpdated({
+      threadId: 'start-thread-id',
+      turnId,
+      diff: 'diff --git a/safe.txt b/safe.txt\n--- a/safe.txt\n+++ b/safe.txt\n',
+    });
+    handlers.itemUpdated({
+      threadId: 'start-thread-id',
+      turnId,
+      item: {
+        id: 'cmd-parallel-sibling',
+        type: 'commandExecution',
+        command: 'printf safe',
+        cwd: '/repo',
+      },
+    });
+    handlers.itemCompleted({
+      threadId: 'start-thread-id',
+      turnId,
+      item: {
+        id: 'cmd-parallel-sibling',
+        type: 'commandExecution',
+        command: 'printf safe',
+        cwd: '/repo',
+      },
+    });
+    handlers.turnCompleted({
+      threadId: 'start-thread-id',
+      turn: {
+        id: turnId,
+        status: 'interrupted',
+        error: { message: 'aborted by user' },
+      },
+    } as never);
+
+    await handle.close();
+    await collectEvents;
+    const terminal = events.filter(
+      (event) =>
+        (event as { type?: string }).type === 'error' &&
+        (event as { data?: { isTerminal?: boolean } }).data?.isTerminal === true,
+    );
+    expect(terminal).toEqual([
+      expect.objectContaining({
+        data: expect.objectContaining({
+          message: 'use the embedded iOS Simulator',
+          isTerminal: true,
+        }),
+      }),
+    ]);
+    expect(JSON.stringify(terminal)).not.toContain('aborted by user');
+  });
+
   it('lets an approval-path denial recover to a normal completed turn', async () => {
     const policy = vi.fn(() => ({
       decision: 'deny' as const,

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -13054,7 +13054,196 @@ describe('CodexAgent MCP thread context hooks', () => {
     );
   });
 
-  it('interrupts an already-started absolute-path shell bypass as a fail-safe', async () => {
+  it('keeps an approval-path policy denial as the terminal turn reason', async () => {
+    const policy = vi.fn(() => ({
+      decision: 'deny' as const,
+      reason: 'use the embedded iOS Simulator',
+    }));
+    const agent = new CodexAgent(createDeps({}, { getShellCommandPolicy: policy }));
+    const host = installFakeHost(agent, (method) =>
+      method === Method.TurnInterrupt ? {} : undefined,
+    );
+    const handle = await agent.startSession({
+      sessionId: 'session-command-approval-policy-terminal-reason',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+      permissionMode: 'bypassPermissions',
+    });
+    const handlers = host.getThreadHandlers();
+    if (!handlers?.commandExecutionApproval || !handlers.turnCompleted) {
+      throw new Error('expected commandExecutionApproval and turnCompleted handlers');
+    }
+    const events: AgentEvent[] = [];
+    const collectEvents = (async () => {
+      for await (const event of handle.events()) events.push(event);
+    })();
+
+    await expect(
+      handlers.commandExecutionApproval({
+        threadId: 'start-thread-id',
+        turnId: 'turn-approval-policy',
+        itemId: 'cmd-approval-policy',
+        command: 'open -a Simulator',
+        cwd: '/repo',
+      }),
+    ).resolves.toEqual({ decision: 'decline' });
+    handlers.turnCompleted({
+      threadId: 'start-thread-id',
+      turn: {
+        id: 'turn-approval-policy',
+        status: 'interrupted',
+        error: { message: 'aborted by user' },
+      },
+    } as never);
+
+    await handle.close();
+    await collectEvents;
+    const terminal = events.filter(
+      (event) =>
+        (event as { type?: string }).type === 'error' &&
+        (event as { data?: { isTerminal?: boolean } }).data?.isTerminal === true,
+    );
+    expect(terminal).toEqual([
+      expect.objectContaining({
+        data: expect.objectContaining({
+          message: 'use the embedded iOS Simulator',
+          isTerminal: true,
+        }),
+      }),
+    ]);
+    expect(JSON.stringify(terminal)).not.toContain('aborted by user');
+  });
+
+  it('lets an approval-path denial recover to a normal completed turn', async () => {
+    const policy = vi.fn(() => ({
+      decision: 'deny' as const,
+      reason: 'use the embedded iOS Simulator',
+    }));
+    const agent = new CodexAgent(createDeps({}, { getShellCommandPolicy: policy }));
+    const host = installFakeHost(agent);
+    const handle = await agent.startSession({
+      sessionId: 'session-command-approval-policy-recovery',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+      permissionMode: 'bypassPermissions',
+    });
+    const handlers = host.getThreadHandlers();
+    if (!handlers?.commandExecutionApproval || !handlers.turnCompleted) {
+      throw new Error('expected commandExecutionApproval and turnCompleted handlers');
+    }
+    const events: AgentEvent[] = [];
+    const collectEvents = (async () => {
+      for await (const event of handle.events()) events.push(event);
+    })();
+
+    await expect(
+      handlers.commandExecutionApproval({
+        threadId: 'start-thread-id',
+        turnId: 'turn-approval-policy-recovery',
+        itemId: 'cmd-approval-policy-recovery',
+        command: 'open -a Simulator',
+        cwd: '/repo',
+      }),
+    ).resolves.toEqual({ decision: 'decline' });
+    handlers.turnCompleted({
+      threadId: 'start-thread-id',
+      turn: {
+        id: 'turn-approval-policy-recovery',
+        status: 'completed',
+      },
+    } as never);
+
+    await handle.close();
+    await collectEvents;
+    expect(events.filter((event) => (event as { type?: string }).type === 'error')).toEqual([
+      expect.objectContaining({
+        data: expect.objectContaining({
+          message: 'use the embedded iOS Simulator',
+          isTerminal: false,
+        }),
+      }),
+    ]);
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'done' }),
+      ]),
+    );
+    expect(JSON.stringify(events)).not.toContain('isTerminal":true');
+  });
+
+  it('clears an approval denial once a replacement command continues the turn', async () => {
+    const policy = vi.fn(({ command }: { command: string }) =>
+      command === 'open -a Simulator'
+        ? { decision: 'deny' as const, reason: 'use the embedded iOS Simulator' }
+        : undefined,
+    );
+    const agent = new CodexAgent(createDeps({}, { getShellCommandPolicy: policy }));
+    const host = installFakeHost(agent);
+    const handle = await agent.startSession({
+      sessionId: 'session-command-approval-policy-replacement-failure',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+      permissionMode: 'bypassPermissions',
+    });
+    const handlers = host.getThreadHandlers();
+    if (!handlers?.commandExecutionApproval || !handlers.itemStarted || !handlers.turnCompleted) {
+      throw new Error('expected approval, itemStarted and turnCompleted handlers');
+    }
+    const events: AgentEvent[] = [];
+    const collectEvents = (async () => {
+      for await (const event of handle.events()) events.push(event);
+    })();
+
+    await expect(
+      handlers.commandExecutionApproval({
+        threadId: 'start-thread-id',
+        turnId: 'turn-approval-policy-replacement-failure',
+        itemId: 'cmd-approval-policy-replacement-failure',
+        command: 'open -a Simulator',
+        cwd: '/repo',
+      }),
+    ).resolves.toEqual({ decision: 'decline' });
+    handlers.itemStarted({
+      threadId: 'start-thread-id',
+      turnId: 'turn-approval-policy-replacement-failure',
+      item: {
+        id: 'cmd-safe-replacement',
+        type: 'commandExecution',
+        command: 'printf safe',
+        cwd: '/repo',
+      },
+    });
+    handlers.turnCompleted({
+      threadId: 'start-thread-id',
+      turn: {
+        id: 'turn-approval-policy-replacement-failure',
+        status: 'failed',
+        error: { message: 'replacement failed' },
+      },
+    } as never);
+
+    await handle.close();
+    await collectEvents;
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'error',
+          data: expect.objectContaining({
+            message: 'replacement failed',
+            isTerminal: true,
+          }),
+        }),
+      ]),
+    );
+    const terminalErrors = events.filter(
+      (event) =>
+        (event as { type?: string }).type === 'error'
+        && (event as { data?: { isTerminal?: boolean } }).data?.isTerminal === true,
+    );
+    expect(JSON.stringify(terminalErrors)).not.toContain('use the embedded iOS Simulator');
+  });
+
+  it('interrupts an already-started shell bypass and reports the policy reason', async () => {
     const { logger, warn } = createLoggerSpy();
     const policy = vi.fn(() => ({
       decision: 'deny' as const,

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -13313,6 +13313,79 @@ describe('CodexAgent MCP thread context hooks', () => {
     expect(JSON.stringify(terminal)).not.toContain('aborted by user');
   });
 
+  it('clears an approval denial when a new native plan item continues the turn', async () => {
+    const policy = vi.fn(({ command }: { command: string }) =>
+      command === 'open -a Simulator'
+        ? { decision: 'deny' as const, reason: 'use the embedded iOS Simulator' }
+        : undefined,
+    );
+    const agent = new CodexAgent(createDeps({}, { getShellCommandPolicy: policy }));
+    const host = installFakeHost(agent, (method) =>
+      method === Method.TurnStart ? { turn: { id: 'turn-plan-after-denial' } } : undefined,
+    );
+    const handle = await agent.startSession({
+      sessionId: 'session-command-approval-policy-plan-continuation',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+      permissionMode: 'bypassPermissions',
+      planMode: true,
+    });
+    const handlers = host.getThreadHandlers();
+    if (!handlers?.commandExecutionApproval || !handlers.itemStarted || !handlers.turnCompleted) {
+      throw new Error('expected approval, itemStarted and turnCompleted handlers');
+    }
+    const events: AgentEvent[] = [];
+    const collectEvents = (async () => {
+      for await (const event of handle.events()) events.push(event);
+    })();
+
+    const turnId = 'turn-plan-after-denial';
+    await handle.send({ type: 'user', content: 'make a plan' });
+    await expect(
+      handlers.commandExecutionApproval({
+        threadId: 'start-thread-id',
+        turnId,
+        itemId: 'cmd-denied-before-plan',
+        command: 'open -a Simulator',
+        cwd: '/repo',
+      }),
+    ).resolves.toEqual({ decision: 'decline' });
+    handlers.itemStarted({
+      threadId: 'start-thread-id',
+      turnId,
+      item: {
+        id: 'plan-after-denial',
+        type: 'plan',
+        text: '1. inspect\n2. edit',
+      },
+    } as never);
+    handlers.turnCompleted({
+      threadId: 'start-thread-id',
+      turn: {
+        id: turnId,
+        status: 'failed',
+        error: { message: 'plan continuation failed' },
+      },
+    } as never);
+
+    await handle.close();
+    await collectEvents;
+    const terminal = events.filter(
+      (event) =>
+        (event as { type?: string }).type === 'error'
+        && (event as { data?: { isTerminal?: boolean } }).data?.isTerminal === true,
+    );
+    expect(terminal).toEqual([
+      expect.objectContaining({
+        data: expect.objectContaining({
+          message: 'plan continuation failed',
+          isTerminal: true,
+        }),
+      }),
+    ]);
+    expect(JSON.stringify(terminal)).not.toContain('use the embedded iOS Simulator');
+  });
+
   it('lets an approval-path denial recover to a normal completed turn', async () => {
     const policy = vi.fn(() => ({
       decision: 'deny' as const,

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -13564,6 +13564,65 @@ describe('CodexAgent MCP thread context hooks', () => {
     await handle.close();
   });
 
+  it('keeps the policy reason as the terminal outcome of the interrupted turn', async () => {
+    const policy = vi.fn(() => ({
+      decision: 'deny' as const,
+      reason: 'use the embedded iOS Simulator',
+    }));
+    const agent = new CodexAgent(createDeps({}, { getShellCommandPolicy: policy }));
+    const host = installFakeHost(agent, (method) =>
+      method === Method.TurnInterrupt ? {} : undefined,
+    );
+    const handle = await agent.startSession({
+      sessionId: 'session-policy-terminal-reason',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+      permissionMode: 'bypassPermissions',
+    });
+    const handlers = host.getThreadHandlers();
+    if (!handlers?.itemStarted || !handlers.turnCompleted) {
+      throw new Error('expected itemStarted and turnCompleted handlers');
+    }
+    const events: AgentEvent[] = [];
+    const collectEvents = (async () => {
+      for await (const event of handle.events()) events.push(event);
+    })();
+
+    handlers.itemStarted({
+      threadId: 'start-thread-id',
+      turnId: 'turn-1',
+      item: { id: 'cmd-1', type: 'commandExecution', command: 'open -a Simulator', cwd: '/repo' },
+    });
+    // Codex answers our interrupt with an abort-shaped completion. The renderer
+    // clears a non-terminal error once the turn completes, so the product reason
+    // has to win here or the denial reads as a user action.
+    handlers.turnCompleted({
+      threadId: 'start-thread-id',
+      turn: {
+        id: 'turn-1',
+        status: 'interrupted',
+        error: { message: 'aborted by user' },
+      },
+    } as never);
+
+    await handle.close();
+    await collectEvents;
+    const terminal = events.filter(
+      (event) =>
+        (event as { type?: string }).type === 'error' &&
+        (event as { data?: { isTerminal?: boolean } }).data?.isTerminal === true,
+    );
+    expect(terminal).toEqual([
+      expect.objectContaining({
+        data: expect.objectContaining({
+          message: 'use the embedded iOS Simulator',
+          isTerminal: true,
+        }),
+      }),
+    ]);
+    expect(JSON.stringify(terminal)).not.toContain('aborted by user');
+  });
+
   it('interrupts a raw function_call exec_command shell bypass as a fail-safe', async () => {
     const policy = vi.fn(() => ({
       decision: 'deny' as const,

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -13907,58 +13907,6 @@ describe('CodexAgent MCP thread context hooks', () => {
     expect(JSON.stringify(terminal)).not.toContain('aborted by user');
   });
 
-  it('still reports the denial when the interrupt loses the race and the turn completes', async () => {
-    const policy = vi.fn(() => ({
-      decision: 'deny' as const,
-      reason: 'use the embedded iOS Simulator',
-    }));
-    const agent = new CodexAgent(createDeps({}, { getShellCommandPolicy: policy }));
-    const host = installFakeHost(agent, (method) =>
-      method === Method.TurnInterrupt ? {} : undefined,
-    );
-    const handle = await agent.startSession({
-      sessionId: 'session-policy-lost-race',
-      model: 'gpt-5.4',
-      workingDir: '/repo',
-      permissionMode: 'bypassPermissions',
-    });
-    const handlers = host.getThreadHandlers();
-    if (!handlers?.itemStarted || !handlers.turnCompleted) {
-      throw new Error('expected itemStarted and turnCompleted handlers');
-    }
-    const events: AgentEvent[] = [];
-    const collectEvents = (async () => {
-      for await (const event of handle.events()) events.push(event);
-    })();
-
-    handlers.itemStarted({
-      threadId: 'start-thread-id',
-      turnId: 'turn-1',
-      item: { id: 'cmd-1', type: 'commandExecution', command: 'open -a Simulator', cwd: '/repo' },
-    });
-    // turn/interrupt is asynchronous: a trusted prohibited command can finish
-    // first, and Codex then reports the turn as completed. The denial must still
-    // be the terminal outcome, or the run reads as a plain success.
-    handlers.turnCompleted({
-      threadId: 'start-thread-id',
-      turn: { id: 'turn-1', status: 'completed' },
-    } as never);
-
-    await handle.close();
-    await collectEvents;
-    expect(events).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          type: 'error',
-          data: expect.objectContaining({
-            message: 'use the embedded iOS Simulator',
-            isTerminal: true,
-          }),
-        }),
-      ]),
-    );
-  });
-
   it('interrupts a raw function_call exec_command shell bypass as a fail-safe', async () => {
     const policy = vi.fn(() => ({
       decision: 'deny' as const,

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -13011,6 +13011,10 @@ describe('CodexAgent MCP thread context hooks', () => {
       behavior: 'allow',
     }));
     handle.setInteractionResolver(resolver);
+    const events: AgentEvent[] = [];
+    const collectEvents = (async () => {
+      for await (const event of handle.events()) events.push(event);
+    })();
 
     const command = 'API_TOKEN=super-secret open -a Simulator';
     const result = await handlers.commandExecutionApproval({
@@ -13034,6 +13038,20 @@ describe('CodexAgent MCP thread context hooks', () => {
     });
     expect(JSON.stringify(warn.mock.calls)).not.toContain('super-secret');
     await handle.close();
+    await collectEvents;
+    // Declining silently is indistinguishable from a user cancellation, so the
+    // product reason has to reach the user.
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'error',
+          data: expect.objectContaining({
+            message: 'use the embedded iOS Simulator',
+            isTerminal: false,
+          }),
+        }),
+      ]),
+    );
   });
 
   it('interrupts an already-started absolute-path shell bypass as a fail-safe', async () => {

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -13070,8 +13070,8 @@ describe('CodexAgent MCP thread context hooks', () => {
       permissionMode: 'bypassPermissions',
     });
     const handlers = host.getThreadHandlers();
-    if (!handlers?.commandExecutionApproval || !handlers.turnCompleted) {
-      throw new Error('expected commandExecutionApproval and turnCompleted handlers');
+    if (!handlers?.commandExecutionApproval || !handlers.itemCompleted || !handlers.turnCompleted) {
+      throw new Error('expected commandExecutionApproval, itemCompleted and turnCompleted handlers');
     }
     const events: AgentEvent[] = [];
     const collectEvents = (async () => {
@@ -13087,6 +13087,19 @@ describe('CodexAgent MCP thread context hooks', () => {
         cwd: '/repo',
       }),
     ).resolves.toEqual({ decision: 'decline' });
+    // A declined command may still emit its own completion before the
+    // abort-shaped turn completion. That is not recovery progress and must
+    // not clear the policy reason.
+    handlers.itemCompleted({
+      threadId: 'start-thread-id',
+      turnId: 'turn-approval-policy',
+      item: {
+        id: 'cmd-approval-policy',
+        type: 'commandExecution',
+        command: 'open -a Simulator',
+        cwd: '/repo',
+      },
+    });
     handlers.turnCompleted({
       threadId: 'start-thread-id',
       turn: {

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -13313,6 +13313,107 @@ describe('CodexAgent MCP thread context hooks', () => {
     expect(JSON.stringify(terminal)).not.toContain('aborted by user');
   });
 
+  it('keeps an approval denial through an approval item that was already pending', async () => {
+    const policy = vi.fn(({ command }: { command: string }) =>
+      command === 'open -a Simulator'
+        ? { decision: 'deny' as const, reason: 'use the embedded iOS Simulator' }
+        : undefined,
+    );
+    const decision = deferred<InteractionDecision>();
+    const agent = new CodexAgent(createDeps({}, { getShellCommandPolicy: policy }));
+    const host = installFakeHost(agent);
+    const handle = await agent.startSession({
+      sessionId: 'session-command-approval-policy-pending-sibling',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+      permissionMode: 'ask',
+    });
+    const interactionResolver = vi.fn(() => decision.promise);
+    handle.setInteractionResolver(interactionResolver);
+    const handlers = host.getThreadHandlers();
+    if (
+      !handlers?.commandExecutionApproval
+      || !handlers.itemStarted
+      || !handlers.itemCompleted
+      || !handlers.turnCompleted
+    ) {
+      throw new Error('expected approval, item lifecycle and turn completion handlers');
+    }
+    const events: AgentEvent[] = [];
+    const collectEvents = (async () => {
+      for await (const event of handle.events()) events.push(event);
+    })();
+
+    const turnId = 'turn-approval-policy-pending-sibling';
+    const pendingApproval = handlers.commandExecutionApproval({
+      threadId: 'start-thread-id',
+      turnId,
+      itemId: 'cmd-pending-sibling',
+      command: 'printf safe',
+      cwd: '/repo',
+    });
+    await waitForExpectation(() => expect(interactionResolver).toHaveBeenCalledTimes(1));
+    // The resolver promise is held, so this approval is present in the pending
+    // map before the policy denial for the parallel command arrives.
+    await expect(
+      handlers.commandExecutionApproval({
+        threadId: 'start-thread-id',
+        turnId,
+        itemId: 'cmd-denied-after-pending',
+        command: 'open -a Simulator',
+        cwd: '/repo',
+      }),
+    ).resolves.toEqual({ decision: 'decline' });
+
+    decision.resolve({ kind: 'permission', behavior: 'allow' });
+    await expect(pendingApproval).resolves.toEqual({ decision: 'accept' });
+    handlers.itemStarted({
+      threadId: 'start-thread-id',
+      turnId,
+      item: {
+        id: 'cmd-pending-sibling',
+        type: 'commandExecution',
+        command: 'printf safe',
+        cwd: '/repo',
+      },
+    });
+    handlers.itemCompleted({
+      threadId: 'start-thread-id',
+      turnId,
+      item: {
+        id: 'cmd-pending-sibling',
+        type: 'commandExecution',
+        command: 'printf safe',
+        cwd: '/repo',
+      },
+    });
+    handlers.turnCompleted({
+      threadId: 'start-thread-id',
+      turn: {
+        id: turnId,
+        status: 'interrupted',
+        error: { message: 'aborted by user' },
+      },
+    } as never);
+
+    await handle.close();
+    await collectEvents;
+    const terminal = events.filter(
+      (event) =>
+        (event as { type?: string }).type === 'error' &&
+        (event as { data?: { isTerminal?: boolean } }).data?.isTerminal === true,
+    );
+    expect(terminal).toEqual([
+      expect.objectContaining({
+        data: expect.objectContaining({
+          message: 'use the embedded iOS Simulator',
+          isTerminal: true,
+        }),
+      }),
+    ]);
+    expect(JSON.stringify(terminal)).not.toContain('aborted by user');
+  });
+
   it('clears an approval denial when a new native plan item continues the turn', async () => {
     const policy = vi.fn(({ command }: { command: string }) =>
       command === 'open -a Simulator'

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -3035,6 +3035,14 @@ export class CodexAgent extends BaseAgent {
         }
       | { source: 'user-stop' }
     >();
+    // A started command can race the asynchronous interrupt and still report a
+    // completed/failed turn. Keep its policy reason separately so those terminal
+    // statuses cannot look like a successful run. The interrupt-origin map above
+    // remains authoritative for abort-shaped completions and explicit Stop.
+    const policyDeniedTurnReasons = new Map<string, string>();
+    // Approval declines happen before execution and may recover into a normal
+    // completed turn, so this reason only owns failed/interrupted completions.
+    const approvalPolicyDeniedTurnReasons = new Map<string, string>();
     // daemon 后端 retry-loop 的终局升级 (issue #677): 远端摸不到 Codex 后端时
     // daemon 无限 willRetry, turn 永不收口。同 turn 重试超阈值 → 合成终态错误,
     // 走与终态 error 完全相同的收口路径 (terminalErroredTurnIds + Done status)。
@@ -6236,6 +6244,10 @@ export class CodexAgent extends BaseAgent {
           requestId: params.approvalId ?? params.itemId,
           reason: hostPolicy.reason,
         });
+        // The decline is followed by an abort-shaped turn completion. Keep the
+        // policy reason attached to this turn so completion cannot replace it
+        // with a generic cancellation/error message.
+        approvalPolicyDeniedTurnReasons.set(params.turnId, hostPolicy.reason);
         // Declining without ever showing the user why renders as a bare failed
         // command, which is indistinguishable from a cancellation. Surface the
         // product reason so the denial is attributed to the policy, not the user.
@@ -7725,6 +7737,10 @@ export class CodexAgent extends BaseAgent {
           currentTurnPlanModeActive = false;
         }
         terminalErroredTurnIds.add(turn.id);
+        // This branch emits the authoritative policy error itself, then recurses
+        // through the normal completion bookkeeping. Do not let that recursive
+        // pass replay the race-preservation marker a second time.
+        policyDeniedTurnReasons.delete(turn.id);
         eventQueue.push({
           type: 'error',
           data: {
@@ -7939,9 +7955,23 @@ export class CodexAgent extends BaseAgent {
       // plain `done`, let the renderer clear the non-terminal warning
       // (`recoverableError: isTurnComplete ? null : …`) and leave the user with a
       // successful outcome even though the command ran and the policy fired.
-      const policyDenialReason = policyDeniedTurnReasons.get(turn.id);
+      // A started command is authoritative for every terminal status because
+      // interrupt is asynchronous. An approval decline can recover into a
+      // normal completed turn, so it only owns abort-shaped completions. An
+      // explicit user Stop suppresses any stale policy attribution.
+      const startedPolicyDenialReason =
+        interruptOrigin?.source === 'user-stop'
+          ? undefined
+          : policyDeniedTurnReasons.get(turn.id);
+      const approvalPolicyDenialReason = approvalPolicyDeniedTurnReasons.get(turn.id);
+      const policyDenialReason =
+        startedPolicyDenialReason
+        ?? ((turn.status === 'failed' || turn.status === 'interrupted')
+          ? approvalPolicyDenialReason
+          : undefined);
+      policyDeniedTurnReasons.delete(turn.id);
+      approvalPolicyDeniedTurnReasons.delete(turn.id);
       if (policyDenialReason !== undefined) {
-        policyDeniedTurnReasons.delete(turn.id);
         eventQueue.push({
           type: 'error',
           data: { message: policyDenialReason, isTerminal: true },
@@ -7954,14 +7984,10 @@ export class CodexAgent extends BaseAgent {
         proposedPlanText = null;
         planCycleActive = false;
         currentTurnPlanModeActive = false;
-<<<<<<< HEAD
-        if (turn.error?.message) {
-=======
         if (policyDenialReason !== undefined) {
           // Already reported above as the authoritative terminal outcome; the
           // interrupt-derived message must not overwrite it.
         } else if (turn.error?.message) {
->>>>>>> 503fb2240 (fix(ios-simulator): make the policy denial authoritative for every terminal status)
           eventQueue.push({
             type: 'error',
             data: { message: turn.error.message, isTerminal: true },
@@ -9068,6 +9094,7 @@ export class CodexAgent extends BaseAgent {
             ) {
               return;
             }
+            policyDeniedTurnReasons.set(params.turnId, hostPolicy.reason);
             log.warn('command execution interrupted by host policy', {
               turnId: params.turnId,
               reason: hostPolicy.reason,

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -3042,9 +3042,14 @@ export class CodexAgent extends BaseAgent {
     const policyDeniedTurnReasons = new Map<string, string>();
     // Approval can be declined before execution starts. Codex may still recover
     // and complete the turn, so this reason only owns abort-shaped completions.
-    // Keep the declined item id too: app-server can still emit that item's
-    // completion after the decline, which is not evidence of recovery.
-    const approvalPolicyDeniedTurnReasons = new Map<string, { reason: string; itemId: string }>();
+    // Keep every declined item id: app-server can emit several approval
+    // requests for one turn and may still complete each declined item after the
+    // decline. A single item id would let a later denial overwrite an earlier
+    // one, then make that earlier completion look like recovery progress.
+    const approvalPolicyDeniedTurnReasons = new Map<
+      string,
+      { reason: string; itemIds: Set<string> }
+    >();
     // daemon 后端 retry-loop 的终局升级 (issue #677): 远端摸不到 Codex 后端时
     // daemon 无限 willRetry, turn 永不收口。同 turn 重试超阈值 → 合成终态错误,
     // 走与终态 error 完全相同的收口路径 (terminalErroredTurnIds + Done status)。
@@ -6249,10 +6254,16 @@ export class CodexAgent extends BaseAgent {
         // The decline is followed by an abort-shaped turn completion. Keep the
         // policy reason attached to this turn so completion cannot replace it
         // with a generic cancellation/error message.
-        approvalPolicyDeniedTurnReasons.set(params.turnId, {
-          reason: hostPolicy.reason,
-          itemId: params.itemId,
-        });
+        const existingDenial = approvalPolicyDeniedTurnReasons.get(params.turnId);
+        if (existingDenial) {
+          existingDenial.reason = hostPolicy.reason;
+          existingDenial.itemIds.add(params.itemId);
+        } else {
+          approvalPolicyDeniedTurnReasons.set(params.turnId, {
+            reason: hostPolicy.reason,
+            itemIds: new Set([params.itemId]),
+          });
+        }
         // Declining without ever showing the user why renders as a bare failed
         // command, which is indistinguishable from a cancellation. Surface the
         // product reason so the denial is attributed to the policy, not the user.
@@ -8110,7 +8121,7 @@ export class CodexAgent extends BaseAgent {
     // not be reported as the stale Simulator-policy denial.
     const clearApprovalPolicyDenialOnProgress = (turnId: string, itemId?: string): void => {
       const denial = approvalPolicyDeniedTurnReasons.get(turnId);
-      if (!denial || denial.itemId === itemId) return;
+      if (!denial || (itemId !== undefined && denial.itemIds.has(itemId))) return;
       approvalPolicyDeniedTurnReasons.delete(turnId);
     };
 

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -3043,8 +3043,23 @@ export class CodexAgent extends BaseAgent {
     // one, then make that earlier completion look like recovery progress.
     const approvalPolicyDeniedTurnReasons = new Map<
       string,
-      { reason: string; itemIds: Set<string> }
+      {
+        reason: string;
+        itemIds: Set<string>;
+        // A sibling item may already be running when the denied approval
+        // arrives. Its later update/completion is not recovery progress: the
+        // turn is still in the abort caused by the denial. Snapshot the item
+        // ids seen before the first denial so only genuinely new work clears
+        // the policy attribution.
+        preexistingItemIds: Set<string>;
+      }
     >();
+    // Item ids observed before an approval-path denial. A turn may have
+    // parallel work in flight when one command is declined; that sibling can
+    // emit updated/completed after the denial without representing a
+    // replacement continuation. The snapshot is per-turn and is discarded
+    // with the turn's denial state at terminal completion.
+    const observedModelItemIdsByTurn = new Map<string, Set<string>>();
     // daemon 后端 retry-loop 的终局升级 (issue #677): 远端摸不到 Codex 后端时
     // daemon 无限 willRetry, turn 永不收口。同 turn 重试超阈值 → 合成终态错误,
     // 走与终态 error 完全相同的收口路径 (terminalErroredTurnIds + Done status)。
@@ -6257,6 +6272,7 @@ export class CodexAgent extends BaseAgent {
           approvalPolicyDeniedTurnReasons.set(params.turnId, {
             reason: hostPolicy.reason,
             itemIds: new Set([params.itemId]),
+            preexistingItemIds: new Set(observedModelItemIdsByTurn.get(params.turnId) ?? []),
           });
         }
         // Declining without ever showing the user why renders as a bare failed
@@ -7726,6 +7742,10 @@ export class CodexAgent extends BaseAgent {
 
     function handleTurnCompleted(params: TurnCompletedParams): void {
       const turn = params.turn;
+      // Every branch below represents an authoritative terminal notification,
+      // including the paths that defer UI settlement or return early. Item
+      // history is only needed while approval attribution is still mutable.
+      observedModelItemIdsByTurn.delete(turn.id);
       const interruptOrigin = turnInterruptOrigins.get(turn.id);
       turnInterruptOrigins.delete(turn.id);
       if (
@@ -8089,13 +8109,40 @@ export class CodexAgent extends BaseAgent {
       return type === null || !ITEM_TYPES_WITHOUT_MODEL_WORK.has(type);
     };
 
+    const noteObservedModelItem = (
+      turnId: string,
+      item: { id?: unknown; type?: unknown } | null | undefined,
+    ): void => {
+      if (
+        !item
+        || !itemRepresentsModelWork(item)
+        || typeof item.id !== 'string'
+        || item.id.length === 0
+      ) {
+        return;
+      }
+      const itemIds = observedModelItemIdsByTurn.get(turnId) ?? new Set<string>();
+      itemIds.add(item.id);
+      observedModelItemIdsByTurn.set(turnId, itemIds);
+    };
+
     // An approval decline is only attributable to the immediate abort it
-    // causes. Once the same turn produces model work or starts a replacement
-    // item, a later failure/interruption belongs to that continuation and must
-    // not be reported as the stale Simulator-policy denial.
+    // causes. Work that was already observed before the denial may still emit
+    // progress while that abort settles; only model work first observed after
+    // the denial clears the policy attribution as a genuine continuation.
     const clearApprovalPolicyDenialOnProgress = (turnId: string, itemId?: string): void => {
       const denial = approvalPolicyDeniedTurnReasons.get(turnId);
-      if (!denial || (itemId !== undefined && denial.itemIds.has(itemId))) return;
+      if (!denial) return;
+      // Turn-level progress (diffs, plans, or text deltas without an item id)
+      // cannot prove that a replacement item started after the denial. Keep
+      // the attribution until an item lifecycle event identifies new work.
+      if (itemId === undefined) return;
+      if (
+        denial.itemIds.has(itemId)
+        || denial.preexistingItemIds.has(itemId)
+      ) {
+        return;
+      }
       approvalPolicyDeniedTurnReasons.delete(turnId);
     };
 
@@ -9029,7 +9076,6 @@ export class CodexAgent extends BaseAgent {
       turnDiffUpdated: (params) => {
         if (enqueueIfBufferedTurn(params.turnId, () => handlers.turnDiffUpdated?.(params))) return;
         if (shouldIgnoreStaleTurnEvent(params.turnId)) return;
-        clearApprovalPolicyDenialOnProgress(params.turnId);
         publishTurnDiff(threadId, params.turnId, params.diff);
       },
       turnCompleted: (params) => {
@@ -9072,6 +9118,7 @@ export class CodexAgent extends BaseAgent {
           return;
         }
         if (itemRepresentsModelWork(params.item)) {
+          noteObservedModelItem(params.turnId, params.item);
           clearApprovalPolicyDenialOnProgress(params.turnId, params.item.id);
         }
         const shellCommand = shellCommandFromCodexItem(params.item);
@@ -9180,6 +9227,7 @@ export class CodexAgent extends BaseAgent {
           return;
         }
         if (itemRepresentsModelWork(params.item)) {
+          noteObservedModelItem(params.turnId, params.item);
           clearApprovalPolicyDenialOnProgress(params.turnId, params.item.id);
           producedOutputTurnIds.add(params.turnId);
         }
@@ -9234,6 +9282,7 @@ export class CodexAgent extends BaseAgent {
         }
         if (collabTerminalKey) handledCollabTerminalItemIds.add(collabTerminalKey);
         if (itemRepresentsModelWork(params.item)) {
+          noteObservedModelItem(params.turnId, params.item);
           clearApprovalPolicyDenialOnProgress(params.turnId, params.item.id);
           producedOutputTurnIds.add(params.turnId);
         }
@@ -9308,7 +9357,6 @@ export class CodexAgent extends BaseAgent {
         if (enqueueIfBufferedTurn(params.turnId, () => handlers.turnPlanUpdated?.(params))) return;
         if (shouldIgnoreStaleTurnEvent(params.turnId)) return;
         latestPlanByTurn.set(params.turnId, params.plan);
-        clearApprovalPolicyDenialOnProgress(params.turnId);
         translatePlanUpdatedNotification(params, eventQueue);
       },
       reasoningSummaryTextDelta: (params) => {

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -8099,6 +8099,14 @@ export class CodexAgent extends BaseAgent {
       return type === null || !ITEM_TYPES_WITHOUT_MODEL_WORK.has(type);
     };
 
+    // An approval decline is only attributable to the immediate abort it
+    // causes. Once the same turn produces model work or starts a replacement
+    // item, a later failure/interruption belongs to that continuation and must
+    // not be reported as the stale Simulator-policy denial.
+    const clearApprovalPolicyDenialOnProgress = (turnId: string): void => {
+      approvalPolicyDeniedTurnReasons.delete(turnId);
+    };
+
     /** 取消挂起的过载重投（会话关闭 / 用户打断 / 新 turn 覆盖时调用）。 */
     const cancelOverloadRetry = (reason: string): void => {
       const state = overloadRetry;
@@ -9029,6 +9037,7 @@ export class CodexAgent extends BaseAgent {
       turnDiffUpdated: (params) => {
         if (enqueueIfBufferedTurn(params.turnId, () => handlers.turnDiffUpdated?.(params))) return;
         if (shouldIgnoreStaleTurnEvent(params.turnId)) return;
+        clearApprovalPolicyDenialOnProgress(params.turnId);
         publishTurnDiff(threadId, params.turnId, params.diff);
       },
       turnCompleted: (params) => {
@@ -9069,6 +9078,9 @@ export class CodexAgent extends BaseAgent {
         if (interceptProposedPlanItem(params.item)) {
           discardPendingSpawnLineageIds(reservedChildThreadIds);
           return;
+        }
+        if (itemRepresentsModelWork(params.item)) {
+          clearApprovalPolicyDenialOnProgress(params.turnId);
         }
         const shellCommand = shellCommandFromCodexItem(params.item);
         if (shellCommand) {
@@ -9176,7 +9188,10 @@ export class CodexAgent extends BaseAgent {
           discardPendingSpawnLineageIds(reservedChildThreadIds);
           return;
         }
-        if (itemRepresentsModelWork(params.item)) producedOutputTurnIds.add(params.turnId);
+        if (itemRepresentsModelWork(params.item)) {
+          clearApprovalPolicyDenialOnProgress(params.turnId);
+          producedOutputTurnIds.add(params.turnId);
+        }
         noteActiveToolContext(params.item, params.turnId);
         // updated 也要登记映射,顺序与 started / completed 一致(先登记 → 翻译 → 后发重放帧)。
         // V1 的 spawn 是长跑 item(started → updated* → completed):started 那帧若没到我们手里
@@ -9227,7 +9242,10 @@ export class CodexAgent extends BaseAgent {
           return;
         }
         if (collabTerminalKey) handledCollabTerminalItemIds.add(collabTerminalKey);
-        if (itemRepresentsModelWork(params.item)) producedOutputTurnIds.add(params.turnId);
+        if (itemRepresentsModelWork(params.item)) {
+          clearApprovalPolicyDenialOnProgress(params.turnId);
+          producedOutputTurnIds.add(params.turnId);
+        }
         noteActiveToolContext(params.item, params.turnId);
         // This late item belongs to an already-terminal parent. The parent
         // cleanup already cleared its pending tools; touching the shared
@@ -9291,6 +9309,7 @@ export class CodexAgent extends BaseAgent {
           modelWork: true,
         })) return;
         if (shouldIgnoreStaleTurnEvent(params.turnId)) return;
+        clearApprovalPolicyDenialOnProgress(params.turnId);
         producedOutputTurnIds.add(params.turnId);
         translateAgentMessageDelta(params, eventQueue, { rt: translatorRt, log });
       },
@@ -9298,6 +9317,7 @@ export class CodexAgent extends BaseAgent {
         if (enqueueIfBufferedTurn(params.turnId, () => handlers.turnPlanUpdated?.(params))) return;
         if (shouldIgnoreStaleTurnEvent(params.turnId)) return;
         latestPlanByTurn.set(params.turnId, params.plan);
+        clearApprovalPolicyDenialOnProgress(params.turnId);
         translatePlanUpdatedNotification(params, eventQueue);
       },
       reasoningSummaryTextDelta: (params) => {
@@ -9305,6 +9325,7 @@ export class CodexAgent extends BaseAgent {
         if (enqueueIfBufferedTurn(params.turnId, () => handlers.reasoningSummaryTextDelta?.(params), { modelWork: true })) return;
         if (shouldIgnoreStaleTurnEvent(params.turnId)) return;
         // thinking 流也算产出：模型已经在这一轮里工作了，整体重放不再等价。
+        clearApprovalPolicyDenialOnProgress(params.turnId);
         producedOutputTurnIds.add(params.turnId);
         translateReasoningSummaryTextDelta(params, eventQueue, { rt: translatorRt, log });
       },
@@ -9312,6 +9333,7 @@ export class CodexAgent extends BaseAgent {
         // thinking 流同样算产出(与非缓冲路径一致)。
         if (enqueueIfBufferedTurn(params.turnId, () => handlers.reasoningSummaryPartAdded?.(params), { modelWork: true })) return;
         if (shouldIgnoreStaleTurnEvent(params.turnId)) return;
+        clearApprovalPolicyDenialOnProgress(params.turnId);
         producedOutputTurnIds.add(params.turnId);
         translateReasoningSummaryPartAdded(params, eventQueue, { rt: translatorRt, log });
       },
@@ -9319,6 +9341,7 @@ export class CodexAgent extends BaseAgent {
         // thinking 流同样算产出(与非缓冲路径一致)。
         if (enqueueIfBufferedTurn(params.turnId, () => handlers.reasoningTextDelta?.(params), { modelWork: true })) return;
         if (shouldIgnoreStaleTurnEvent(params.turnId)) return;
+        clearApprovalPolicyDenialOnProgress(params.turnId);
         producedOutputTurnIds.add(params.turnId);
         translateReasoningTextDelta(params, eventQueue, { rt: translatorRt, log });
       },

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -5247,6 +5247,8 @@ export class CodexAgent extends BaseAgent {
       resolve: (decision: ApprovalDecision) => void;
       kind: 'commandExecution' | 'fileChange' | 'mcpServerElicitation';
       settled: boolean;
+      turnId: string | null;
+      itemId?: string;
       /** prompt-each-time 高风险审批: 宽松模式也必须弹 UI, dismissAllPending('allow') 不得放行 */
       forcePrompt?: boolean;
     }
@@ -5478,7 +5480,11 @@ export class CodexAgent extends BaseAgent {
       requestId: string,
       kind: 'commandExecution' | 'fileChange' | 'mcpServerElicitation',
       req: InteractionRequest,
-      opts?: { forcePrompt?: boolean; autoReviewAction?: ReviewableAction },
+      opts?: {
+        forcePrompt?: boolean;
+        autoReviewAction?: ReviewableAction;
+        itemId?: string;
+      },
     ): Promise<ApprovalDecision> {
       const timingPauseId = `approval:${kind}:${requestId}`;
       return withCodexGenerationPaused(requestThreadId, turnId, timingPauseId, async () => {
@@ -5560,7 +5566,14 @@ export class CodexAgent extends BaseAgent {
             ? { ...req, suggestions: undefined }
             : req;
         return await new Promise<ApprovalDecision>((resolve) => {
-          const entry: PendingEntry = { resolve, kind, settled: false, forcePrompt };
+          const entry: PendingEntry = {
+            resolve,
+            kind,
+            settled: false,
+            turnId,
+            ...(opts?.itemId ? { itemId: opts.itemId } : {}),
+            forcePrompt,
+          };
           pendingApprovals.set(requestId, entry);
           const finalize = (d: ApprovalDecision) => {
             if (entry.settled) return;
@@ -6269,10 +6282,18 @@ export class CodexAgent extends BaseAgent {
           existingDenial.reason = hostPolicy.reason;
           existingDenial.itemIds.add(params.itemId);
         } else {
+          const preexistingItemIds = new Set(
+            observedModelItemIdsByTurn.get(params.turnId) ?? [],
+          );
+          for (const pending of pendingApprovals.values()) {
+            if (pending.turnId === params.turnId && pending.itemId) {
+              preexistingItemIds.add(pending.itemId);
+            }
+          }
           approvalPolicyDeniedTurnReasons.set(params.turnId, {
             reason: hostPolicy.reason,
             itemIds: new Set([params.itemId]),
-            preexistingItemIds: new Set(observedModelItemIdsByTurn.get(params.turnId) ?? []),
+            preexistingItemIds,
           });
         }
         // Declining without ever showing the user why renders as a bare failed
@@ -6308,6 +6329,7 @@ export class CodexAgent extends BaseAgent {
               ? { cwd: opts.workingDir }
               : { cwdUnknown: true }),
         },
+        itemId: params.itemId,
       });
       return { decision };
     };
@@ -6330,7 +6352,10 @@ export class CodexAgent extends BaseAgent {
         description: params.reason ?? undefined,
         suggestions: codexSessionApprovalSuggestions(),
         metadata: params.reason ? { reason: params.reason } : undefined,
-      }, { autoReviewAction: { kind: 'file-write', path: params.grantRoot ?? undefined } });
+      }, {
+        autoReviewAction: { kind: 'file-write', path: params.grantRoot ?? undefined },
+        itemId: params.itemId,
+      });
       return { decision };
     };
 
@@ -6631,7 +6656,7 @@ export class CodexAgent extends BaseAgent {
         description: params.reason ?? undefined,
         suggestions: codexSessionApprovalSuggestions(),
         metadata: params.reason ? { reason: params.reason } : undefined,
-      });
+      }, { itemId: params.itemId ?? undefined });
       if (decision === 'accept') {
         return { permissions: params.permissions as Record<string, unknown>, scope: 'turn' };
       }

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -7732,10 +7732,18 @@ export class CodexAgent extends BaseAgent {
      * update_plan 工具行 (避免同一份计划在聊天里出现两次)。
      * 非计划模式不拦截; 普通 Codex turn 也可能产生原生 plan item。
      */
-    function interceptProposedPlanItem(item: unknown): boolean {
+    function interceptProposedPlanItem(turnId: string, item: unknown): boolean {
       if (!currentTurnPlanModeActive) return false;
-      const candidate = item as { type?: unknown; text?: unknown } | null | undefined;
+      const candidate = item as {
+        id?: unknown;
+        type?: unknown;
+        text?: unknown;
+      } | null | undefined;
       if (!candidate || candidate.type !== 'plan') return false;
+      noteObservedModelItem(turnId, candidate);
+      if (typeof candidate.id === 'string') {
+        clearApprovalPolicyDenialOnProgress(turnId, candidate.id);
+      }
       if (typeof candidate.text === 'string') proposedPlanText = candidate.text;
       return true;
     }
@@ -9113,7 +9121,7 @@ export class CodexAgent extends BaseAgent {
           discardPendingSpawnLineageIds(reservedChildThreadIds);
           return;
         }
-        if (interceptProposedPlanItem(params.item)) {
+        if (interceptProposedPlanItem(params.turnId, params.item)) {
           discardPendingSpawnLineageIds(reservedChildThreadIds);
           return;
         }
@@ -9222,7 +9230,7 @@ export class CodexAgent extends BaseAgent {
           discardPendingSpawnLineageIds(reservedChildThreadIds);
           return;
         }
-        if (interceptProposedPlanItem(params.item)) {
+        if (interceptProposedPlanItem(params.turnId, params.item)) {
           discardPendingSpawnLineageIds(reservedChildThreadIds);
           return;
         }
@@ -9276,7 +9284,7 @@ export class CodexAgent extends BaseAgent {
           }
           isLateCollabTerminal = true;
         }
-        if (interceptProposedPlanItem(params.item)) {
+        if (interceptProposedPlanItem(params.turnId, params.item)) {
           discardPendingSpawnLineageIds(reservedChildThreadIds);
           return;
         }

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -7932,12 +7932,36 @@ export class CodexAgent extends BaseAgent {
       // 已经 return, 所以退避中的正常重投(死 turn 恒有墓碑)不会被误撤。
       revokeOverloadRetryOnTerminalSettle(`turn_${turn.status}`);
 
+      // A policy denial is authoritative for every terminal status, not just the
+      // abort-shaped one. Our `turn/interrupt` is asynchronous, so a trusted
+      // prohibited command can finish first and Codex then reports the turn as
+      // `completed`; consuming the reason only in the failure branch would emit a
+      // plain `done`, let the renderer clear the non-terminal warning
+      // (`recoverableError: isTurnComplete ? null : …`) and leave the user with a
+      // successful outcome even though the command ran and the policy fired.
+      const policyDenialReason = policyDeniedTurnReasons.get(turn.id);
+      if (policyDenialReason !== undefined) {
+        policyDeniedTurnReasons.delete(turn.id);
+        eventQueue.push({
+          type: 'error',
+          data: { message: policyDenialReason, isTerminal: true },
+          source: 'codex',
+        });
+      }
+
       if (turn.status === 'failed' || turn.status === 'interrupted') {
         // 失败 / 中断的 plan turn 不发审批 — 半截计划没有审批意义, 循环就此结束。
         proposedPlanText = null;
         planCycleActive = false;
         currentTurnPlanModeActive = false;
+<<<<<<< HEAD
         if (turn.error?.message) {
+=======
+        if (policyDenialReason !== undefined) {
+          // Already reported above as the authoritative terminal outcome; the
+          // interrupt-derived message must not overwrite it.
+        } else if (turn.error?.message) {
+>>>>>>> 503fb2240 (fix(ios-simulator): make the policy denial authoritative for every terminal status)
           eventQueue.push({
             type: 'error',
             data: { message: turn.error.message, isTerminal: true },

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -3040,9 +3040,11 @@ export class CodexAgent extends BaseAgent {
     // statuses cannot look like a successful run. The interrupt-origin map above
     // remains authoritative for abort-shaped completions and explicit Stop.
     const policyDeniedTurnReasons = new Map<string, string>();
-    // Approval declines happen before execution and may recover into a normal
-    // completed turn, so this reason only owns failed/interrupted completions.
-    const approvalPolicyDeniedTurnReasons = new Map<string, string>();
+    // Approval can be declined before execution starts. Codex may still recover
+    // and complete the turn, so this reason only owns abort-shaped completions.
+    // Keep the declined item id too: app-server can still emit that item's
+    // completion after the decline, which is not evidence of recovery.
+    const approvalPolicyDeniedTurnReasons = new Map<string, { reason: string; itemId: string }>();
     // daemon 后端 retry-loop 的终局升级 (issue #677): 远端摸不到 Codex 后端时
     // daemon 无限 willRetry, turn 永不收口。同 turn 重试超阈值 → 合成终态错误,
     // 走与终态 error 完全相同的收口路径 (terminalErroredTurnIds + Done status)。
@@ -6247,7 +6249,10 @@ export class CodexAgent extends BaseAgent {
         // The decline is followed by an abort-shaped turn completion. Keep the
         // policy reason attached to this turn so completion cannot replace it
         // with a generic cancellation/error message.
-        approvalPolicyDeniedTurnReasons.set(params.turnId, hostPolicy.reason);
+        approvalPolicyDeniedTurnReasons.set(params.turnId, {
+          reason: hostPolicy.reason,
+          itemId: params.itemId,
+        });
         // Declining without ever showing the user why renders as a bare failed
         // command, which is indistinguishable from a cancellation. Surface the
         // product reason so the denial is attributed to the policy, not the user.
@@ -7963,7 +7968,7 @@ export class CodexAgent extends BaseAgent {
         interruptOrigin?.source === 'user-stop'
           ? undefined
           : policyDeniedTurnReasons.get(turn.id);
-      const approvalPolicyDenialReason = approvalPolicyDeniedTurnReasons.get(turn.id);
+      const approvalPolicyDenialReason = approvalPolicyDeniedTurnReasons.get(turn.id)?.reason;
       const policyDenialReason =
         startedPolicyDenialReason
         ?? ((turn.status === 'failed' || turn.status === 'interrupted')
@@ -8103,7 +8108,9 @@ export class CodexAgent extends BaseAgent {
     // causes. Once the same turn produces model work or starts a replacement
     // item, a later failure/interruption belongs to that continuation and must
     // not be reported as the stale Simulator-policy denial.
-    const clearApprovalPolicyDenialOnProgress = (turnId: string): void => {
+    const clearApprovalPolicyDenialOnProgress = (turnId: string, itemId?: string): void => {
+      const denial = approvalPolicyDeniedTurnReasons.get(turnId);
+      if (!denial || denial.itemId === itemId) return;
       approvalPolicyDeniedTurnReasons.delete(turnId);
     };
 
@@ -9080,7 +9087,7 @@ export class CodexAgent extends BaseAgent {
           return;
         }
         if (itemRepresentsModelWork(params.item)) {
-          clearApprovalPolicyDenialOnProgress(params.turnId);
+          clearApprovalPolicyDenialOnProgress(params.turnId, params.item.id);
         }
         const shellCommand = shellCommandFromCodexItem(params.item);
         if (shellCommand) {
@@ -9189,7 +9196,7 @@ export class CodexAgent extends BaseAgent {
           return;
         }
         if (itemRepresentsModelWork(params.item)) {
-          clearApprovalPolicyDenialOnProgress(params.turnId);
+          clearApprovalPolicyDenialOnProgress(params.turnId, params.item.id);
           producedOutputTurnIds.add(params.turnId);
         }
         noteActiveToolContext(params.item, params.turnId);
@@ -9243,7 +9250,7 @@ export class CodexAgent extends BaseAgent {
         }
         if (collabTerminalKey) handledCollabTerminalItemIds.add(collabTerminalKey);
         if (itemRepresentsModelWork(params.item)) {
-          clearApprovalPolicyDenialOnProgress(params.turnId);
+          clearApprovalPolicyDenialOnProgress(params.turnId, params.item.id);
           producedOutputTurnIds.add(params.turnId);
         }
         noteActiveToolContext(params.item, params.turnId);
@@ -9309,7 +9316,7 @@ export class CodexAgent extends BaseAgent {
           modelWork: true,
         })) return;
         if (shouldIgnoreStaleTurnEvent(params.turnId)) return;
-        clearApprovalPolicyDenialOnProgress(params.turnId);
+        clearApprovalPolicyDenialOnProgress(params.turnId, params.itemId);
         producedOutputTurnIds.add(params.turnId);
         translateAgentMessageDelta(params, eventQueue, { rt: translatorRt, log });
       },
@@ -9325,7 +9332,7 @@ export class CodexAgent extends BaseAgent {
         if (enqueueIfBufferedTurn(params.turnId, () => handlers.reasoningSummaryTextDelta?.(params), { modelWork: true })) return;
         if (shouldIgnoreStaleTurnEvent(params.turnId)) return;
         // thinking 流也算产出：模型已经在这一轮里工作了，整体重放不再等价。
-        clearApprovalPolicyDenialOnProgress(params.turnId);
+        clearApprovalPolicyDenialOnProgress(params.turnId, params.itemId);
         producedOutputTurnIds.add(params.turnId);
         translateReasoningSummaryTextDelta(params, eventQueue, { rt: translatorRt, log });
       },
@@ -9333,7 +9340,7 @@ export class CodexAgent extends BaseAgent {
         // thinking 流同样算产出(与非缓冲路径一致)。
         if (enqueueIfBufferedTurn(params.turnId, () => handlers.reasoningSummaryPartAdded?.(params), { modelWork: true })) return;
         if (shouldIgnoreStaleTurnEvent(params.turnId)) return;
-        clearApprovalPolicyDenialOnProgress(params.turnId);
+        clearApprovalPolicyDenialOnProgress(params.turnId, params.itemId);
         producedOutputTurnIds.add(params.turnId);
         translateReasoningSummaryPartAdded(params, eventQueue, { rt: translatorRt, log });
       },
@@ -9341,7 +9348,7 @@ export class CodexAgent extends BaseAgent {
         // thinking 流同样算产出(与非缓冲路径一致)。
         if (enqueueIfBufferedTurn(params.turnId, () => handlers.reasoningTextDelta?.(params), { modelWork: true })) return;
         if (shouldIgnoreStaleTurnEvent(params.turnId)) return;
-        clearApprovalPolicyDenialOnProgress(params.turnId);
+        clearApprovalPolicyDenialOnProgress(params.turnId, params.itemId);
         producedOutputTurnIds.add(params.turnId);
         translateReasoningTextDelta(params, eventQueue, { rt: translatorRt, log });
       },

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -6236,6 +6236,14 @@ export class CodexAgent extends BaseAgent {
           requestId: params.approvalId ?? params.itemId,
           reason: hostPolicy.reason,
         });
+        // Declining without ever showing the user why renders as a bare failed
+        // command, which is indistinguishable from a cancellation. Surface the
+        // product reason so the denial is attributed to the policy, not the user.
+        eventQueue.push({
+          type: 'error',
+          data: { message: hostPolicy.reason, isTerminal: false },
+          source: 'codex',
+        });
         return { decision: 'decline' };
       }
       // requestId: approvalId 优先 (zsh-exec-bridge 多 callback 场景); 否则用 itemId

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -3035,11 +3035,6 @@ export class CodexAgent extends BaseAgent {
         }
       | { source: 'user-stop' }
     >();
-    // A started command can race the asynchronous interrupt and still report a
-    // completed/failed turn. Keep its policy reason separately so those terminal
-    // statuses cannot look like a successful run. The interrupt-origin map above
-    // remains authoritative for abort-shaped completions and explicit Stop.
-    const policyDeniedTurnReasons = new Map<string, string>();
     // Approval can be declined before execution starts. Codex may still recover
     // and complete the turn, so this reason only owns abort-shaped completions.
     // Keep every declined item id: app-server can emit several approval
@@ -7753,10 +7748,6 @@ export class CodexAgent extends BaseAgent {
           currentTurnPlanModeActive = false;
         }
         terminalErroredTurnIds.add(turn.id);
-        // This branch emits the authoritative policy error itself, then recurses
-        // through the normal completion bookkeeping. Do not let that recursive
-        // pass replay the race-preservation marker a second time.
-        policyDeniedTurnReasons.delete(turn.id);
         eventQueue.push({
           type: 'error',
           data: {
@@ -7964,28 +7955,11 @@ export class CodexAgent extends BaseAgent {
       // 已经 return, 所以退避中的正常重投(死 turn 恒有墓碑)不会被误撤。
       revokeOverloadRetryOnTerminalSettle(`turn_${turn.status}`);
 
-      // A policy denial is authoritative for every terminal status, not just the
-      // abort-shaped one. Our `turn/interrupt` is asynchronous, so a trusted
-      // prohibited command can finish first and Codex then reports the turn as
-      // `completed`; consuming the reason only in the failure branch would emit a
-      // plain `done`, let the renderer clear the non-terminal warning
-      // (`recoverableError: isTurnComplete ? null : …`) and leave the user with a
-      // successful outcome even though the command ran and the policy fired.
-      // A started command is authoritative for every terminal status because
-      // interrupt is asynchronous. An approval decline can recover into a
-      // normal completed turn, so it only owns abort-shaped completions. An
-      // explicit user Stop suppresses any stale policy attribution.
-      const startedPolicyDenialReason =
-        interruptOrigin?.source === 'user-stop'
-          ? undefined
-          : policyDeniedTurnReasons.get(turn.id);
       const approvalPolicyDenialReason = approvalPolicyDeniedTurnReasons.get(turn.id)?.reason;
       const policyDenialReason =
-        startedPolicyDenialReason
-        ?? ((turn.status === 'failed' || turn.status === 'interrupted')
+        (turn.status === 'failed' || turn.status === 'interrupted')
           ? approvalPolicyDenialReason
-          : undefined);
-      policyDeniedTurnReasons.delete(turn.id);
+          : undefined;
       approvalPolicyDeniedTurnReasons.delete(turn.id);
       if (policyDenialReason !== undefined) {
         eventQueue.push({
@@ -9124,7 +9098,6 @@ export class CodexAgent extends BaseAgent {
             ) {
               return;
             }
-            policyDeniedTurnReasons.set(params.turnId, hostPolicy.reason);
             log.warn('command execution interrupted by host policy', {
               turnId: params.turnId,
               reason: hostPolicy.reason,


### PR DESCRIPTION
## 这次改了什么

### 摘要

`shell-command-policy.ts` 的文件头声明的威胁模型是：**Skill / README / 模型记忆里残留的过时配方，被 Agent 原样照抄**（`xcrun simctl boot …`、`open -a Simulator`）。这类配方来自文档，是字面的、不会自我伪装，一个字面匹配器就能全部抓到。

但代码实际防的是另一个对手：**知道守卫存在、故意写成认不出来的样子**。这在命令文本层不可判定——`bash script.sh` 一行就把执行器移出了命令，文件头自己也承认这点。于是守卫只能对「解析不出来的一切」fail-closed，而 shell 里解析不出来的东西几乎就是 shell 本身。账单是这些命令被拒，且命令里没有任何模拟器执行器：

| 形态 | 被拒原因 |
|---|---|
| `python3 - <<'PY' … print(len(data)) … PY` | heredoc 正文行被当 argv（#2404） |
| `(( n > 1 ))`、`(( i++ ))`、`while (( i < 3 ))` | 算术里出现变量名 |
| `node -e "…function f(){ … }…"` | 引号内 JS 函数体被按 shell 重解析（#2378 同类） |
| 以 glob 开头的行、`{ …; } > file 2>&1` | 命令位置出现 glob 字符 / 收尾 `}` |
| `git commit -F - <<'MSG'` 正文含 Markdown 反引号 | 反引号行被读成不可解析的展开 |

军备竞赛在文件历史里可见：7 轮 harden、1639 行，#2380 再提 702 行换回 **9 条未解决 P1**，本分支收窄判据后一天内又被挑出 **3 个新洞**。没有一轮收敛，因为对手的写法集合是开放的，而文本分析的判定能力是有限的。

**本 PR 保留有效的那一半，删掉无效的那一半。**

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：#2404、#2378
- 本 PR 包含：
  - **保留的核心判据**：字面 `[xcrun] simctl <写操作>`（只读白名单不变）、`open -a Simulator` 各文档写法、直接执行 Simulator 二进制、命令替换里的配方、解释器一行里的配方、赋值里持有的整条配方（`CMD="xcrun simctl boot $UDID"`，文档真会这么写）。引号剥离在 tokenize 阶段按真实 shell 语义完成，所以 `xcr"un" sim"ctl"` 仍是字面命中。
  - **删除**：动态可执行名、算术、wrapper 拆包与 opaque 选项表、污染变量追踪、函数体与别名体递归、glob 与子序列内核判据、赋值还原、拼接归一化。
  - **heredoc 只保留最小边界**：普通数据 consumer（例如 `git commit -F -`、`cat > README.md`）的正文不参与命令分类；把 stdin 当程序执行的 shell / interpreter 正文仍参与分类；consumer 自身的未加引号重定向先从词法中剥离，避免 `bash 2>/dev/null <<SH` 把重定向目标误当脚本参数；未加引号 delimiter 的正文只保留实际会执行的命令替换；支持 Bash legacy `$[...]` 的词法跳过、简单 literal `$'EOF'` / `$"EOF"` 的 quote removal，以及 `bash -o/-O` 选项操作数，不实现完整 shell 语义或 ANSI-C escape decoding。
  - **后续简化/边界修正（review 期间）**：① 前缀上出现选项即停止解包，删掉 per-prefix arity 表；停在选项处只会漏拦，方向单一。② 赋值持有的配方只在同一命令里**确实有片段执行了该变量名**时才分类（`eval "$CMD"`、`sh -c "$CMD"`、命令词即 `$CMD`）。③ segment 同时保留后继 `|` / `&`，管道或后台子 shell 中的赋值不再被当成父作用域的确定覆盖。④ 分段前按 shell 词法跳过词首、未加引号的 `#` 注释，注释里的分号与伪赋值不再改变后续执行点看到的值。⑤ **明确回退两次扩散修复**：`6678a5ca3` 的“把 opener 后物理行当 continuation”不符合 Bash heredoc 语义，已回退；`7175d80ff` 的 unset/readonly 变量生命周期建模超出本 PR 威胁模型，已回退。⑥ 不再把顶层必然失败的 `local NAME=value` 当成确定覆盖；解析函数作用域仍明确不在本 PR 内。command-scoped assignment 的完整 outer-shell expansion 顺序同样不在本 PR 内继续建模。⑦ `launchctl`、`sandbox-exec`、`doas`、`script`、`watch`、`parallel`、`coproc`、`repeat` 等 opaque wrapper 的 argv 不参与分类，即使其中包含完整字面配方；定位其真正执行的 operand 需要逐 wrapper 的执行契约，不属于 shell syntax。
  - Codex 侧：`itemStarted` 命中策略时把拒绝原因**作为该 turn 的终态结果**发出。中断会让 turn 立刻完成，而 renderer 只在 turn 运行期间保留非终态错误（`makerChatStore.ts` 的 `recoverableError: isTurnComplete ? null : …`），所以仅靠「先推原因再中断」不足以保住归因——原因必须成为终态结果，否则界面上留下的仍是中断派生的 `aborted by user`（#2404 的第二个症状）。非终态推送保留为即时信号，用于中断 RPC 失败、完成事件永不到达的情况。审批阶段同一 turn 可以并行产生多个策略拒绝；现在按 turn 累计全部被拒 item id，并把拒绝前已经观察到或已挂起的 sibling item 纳入快照，只有集合外的真实后续工作才清除终态归因。
- 明确不包含：iOS Simulator Runtime、Sidecar、WDA、视频与输入路线、插件能力门（#2408 已合并）。
- 用户可见变化：上表五类命令不再被无理由拒绝，也不会再因此中断整个任务；命令确因策略被拒时显示真实原因而非 `aborted by user`。只读命令行为不变：`open -a Xcode`、`xcrun simctl list` / `listapps` / `getenv` / `diagnose`、针对 iphonesimulator SDK 的 `xcodebuild`、`expo run:ios`、`flutter run -d`。
- 是否存在 breaking change：无。

### UI 变化

不涉及：只改 main 进程判定与 Codex 事件处理，无界面、组件、样式或 UI 文案改动。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：exit 0，无 FAIL（runner 383 pass / 1 skip；所有 required workspaces 通过）

pnpm --filter desktop run --if-present typecheck
结果：exit 0

pnpm check:dco
结果：32 commits signed off，通过

apps/desktop  vitest src/main/maker-host/__tests__/shellCommandPolicy.test.ts
结果：392 passed

packages/maker-core Codex index tests
结果：463 passed

对照脚本(纯函数，可直接 tsx 跑)：
- 41 条真实开发命令 → 0 条被拒（release 0.1.43 上被拒 5 条）
- 88227044f 的 8 条断言 → 8/8 成立；heredoc 仅做 consumer/body 边界建模：数据正文忽略，可执行 stdin 正文保留，consumer 重定向不改变分类
```

### 手工验证

未做实机操作。判定函数无副作用，可对同一批命令直接跑多个版本比较，比点界面更能穷举形态。

补一条实机证据：本机安装的 0.1.43 在本分支开发期间**两次当场拦掉我自己的命令**——一次是写测试脚本的 heredoc（内容含 `xcrun simctl` 字面量），一次是 `{ …; } > file 2>&1` 形式的门禁命令。后者原先不在已知误杀清单里。

### 未执行的验证

- 未跑 `pnpm test:all`：不跨模块、不碰数据库与原生层。
- 未做多平台验证：策略入口第一行按平台返回，非 macOS 行为不变。

## 风险

### 风险分类

- [x] 权限 / 安全 / 用户数据

### 影响与回滚

- 影响范围：仅 macOS 上 Codex 与 Claude Code 的 shell 命令准入判定，以及 Codex 被策略拒绝后的终态归因。策略是纯函数，Codex 改动只增加 turn 内存中的 `Set` 查询/插入；无 prompt、tool/MCP、网络往返、持久化、迁移或协议改动，不影响缓存率与事件顺序。叠加 #2408 后，插件未安装或未启用时守卫整体不运行。
- 回滚方式：revert 即可，无数据修复。

**这是一次有意的安全边界收缩，请按此审阅。** 变为 allow 的断言没有被删除，而是分列在“伪装执行器”和“带选项装饰的前缀”两块下，块头各自写明为何不在威胁模型内。收缩的是变量拼装、字符串片段拼接、glob 与替换补全、`eval` 转发，以及 opaque wrapper argv（包括完整字面配方）这些形态；不包含完整 shell interpreter、变量生命周期或 heredoc continuation 建模。

判断依据是：这些形态**现在也拦不住**。任何一条都能改写成 `bash script.sh`，而那是命令文本层永远看不见的。所以实际损失接近零，损失的是「看起来拦住了」；换回的是五类误杀由构造消失，以及不再需要任何区域解析或检测子系统作为补偿。

如果放行人认为这道边界应当防主动绕过，那么结论是文本解析这条路必须放弃、改进程级隔离（sandbox profile 拒绝 exec simctl）；在那之前误杀是该选择的固有成本。这个判断请在合并前明确，它同时决定 **#2380 的去向**——#2380 整套机制建立在「防主动绕过」之上，与本 PR 互斥。

### 关于提交历史与既有评论

以 `ce02915c2` 为基准的后续 review 提交已逐一审计；其中一些中间提交曾尝试维护通用 CLI option arity，但已被后续“遇到第一个 option 停止解包”的简化取代。当前最终状态请直接读 HEAD 的两个文件，逐提交阅读会看到已被后续修复替换的中间形态。

两次超出原始威胁模型的修复已明确回退：`6678a5ca3`（错误的 heredoc continuation 重建）和 `7175d80ff`（unset/readonly 生命周期建模）。需要继续解释 command-scoped assignment 的 outer-shell expansion 顺序的 review 也按超出 scope 说明并 resolve，不把 shell expansion 解释器继续塞进本 PR；其余进入代码的 review 修复均是原始 false-positive / policy-attribution 目标内的窄边界补全。

**一处需要主动纠正的公开引用**：我在第 6 轮某条线程回复里，把 `command -p xcrun simctl boot DEVICE` 列为「真正的调用没有被放松」的对照证据。`794a16b01` 之后这条已变为放行——它属于「带选项装饰的前缀」那一族。当时的结论（`command -v` 不应被判为写操作）不变，但那条对照证据本身已不成立。

另请注意：本 PR 早前一条评论里的三方对照表（release / #2380 / 本 PR）描述的是**已被取代的旧方案**，其中「主动申报的取舍」几节已不适用。当前状态以本描述与 `6c8131a58` 为准。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
