### PR TITLE
fix(desktop): expose slider accessible names

### DIFF
--- a/apps/desktop/src/renderer/components/ui/__tests__/slider.test.tsx
+++ b/apps/desktop/src/renderer/components/ui/__tests__/slider.test.tsx
@@ -1,0 +1,25 @@
+// @vitest-environment jsdom
+
+import { render, screen } from '@testing-library/react';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { Slider } from '../slider';
+
+beforeAll(() => {
+  vi.stubGlobal(
+    'ResizeObserver',
+    class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    },
+  );
+});
+
+describe('Slider', () => {
+  it('puts accessible names on the interactive thumb', () => {
+    render(<Slider aria-label="UI font size" defaultValue={[14]} min={12} max={24} />);
+
+    expect(screen.getByRole('slider', { name: 'UI font size' })).toBeTruthy();
+  });
+});

--- a/apps/desktop/src/renderer/components/ui/slider.tsx
+++ b/apps/desktop/src/renderer/components/ui/slider.tsx
@@ -13,30 +13,46 @@ import { cn } from '@/lib/utils';
 const Slider = React.forwardRef<
   React.ComponentRef<typeof SliderPrimitives.Root>,
   React.ComponentPropsWithoutRef<typeof SliderPrimitives.Root>
->(({ className, ...props }, ref) => (
-  <SliderPrimitives.Root
-    ref={ref}
-    className={cn(
-      'relative flex w-full touch-none select-none items-center',
-      'data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50',
+>(
+  (
+    {
       className,
-    )}
-    {...props}
-  >
-    <SliderPrimitives.Track className="relative h-1.5 w-full grow overflow-hidden rounded-full bg-[var(--surface-chip)]">
-      <SliderPrimitives.Range className="absolute h-full rounded-full bg-[var(--accent-emphasis)]" />
-    </SliderPrimitives.Track>
-    <SliderPrimitives.Thumb
+      'aria-label': ariaLabel,
+      'aria-labelledby': ariaLabelledBy,
+      'aria-describedby': ariaDescribedBy,
+      'aria-valuetext': ariaValueText,
+      ...props
+    },
+    ref,
+  ) => (
+    <SliderPrimitives.Root
+      ref={ref}
       className={cn(
-        'block h-4 w-4 rounded-full border border-[var(--border-default)]',
-        'bg-[var(--surface-elevated)]',
-        'transition-colors',
-        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--settings-theme-card-bg)]',
-        'disabled:pointer-events-none',
+        'relative flex w-full touch-none select-none items-center',
+        'data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50',
+        className,
       )}
-    />
-  </SliderPrimitives.Root>
-));
+      {...props}
+    >
+      <SliderPrimitives.Track className="relative h-1.5 w-full grow overflow-hidden rounded-full bg-[var(--surface-chip)]">
+        <SliderPrimitives.Range className="absolute h-full rounded-full bg-[var(--accent-emphasis)]" />
+      </SliderPrimitives.Track>
+      <SliderPrimitives.Thumb
+        aria-label={ariaLabel}
+        aria-labelledby={ariaLabelledBy}
+        aria-describedby={ariaDescribedBy}
+        aria-valuetext={ariaValueText}
+        className={cn(
+          'block h-4 w-4 rounded-full border border-[var(--border-default)]',
+          'bg-[var(--surface-elevated)]',
+          'transition-colors',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--settings-theme-card-bg)]',
+          'disabled:pointer-events-none',
+        )}
+      />
+    </SliderPrimitives.Root>
+  ),
+);
 Slider.displayName = SliderPrimitives.Root.displayName;
 
 export { Slider };


### PR DESCRIPTION
## 这次改了什么

### 摘要

将 `Slider` 的无障碍名称与说明传给实际可聚焦、带 `slider` 语义的 Thumb，而不是只留在外层容器。

### 变更类型

- [x] `fix` 缺陷修复
- [x] 其他：无障碍改进

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：将 `apps/desktop/src/renderer/components/ui/slider.tsx` 中 `Slider` 组件的 `aria-label` / `aria-labelledby` 透传到真正承载 `role="slider"` 的 Thumb，并补一个无障碍回归单测。
- 明确不包含：视觉样式、数值范围、键盘 / 鼠标交互语义。
- 用户可见变化：屏幕阅读器在通用设置里读得到两个字号 slider 的中文名称（修复前为空）。
- 是否存在 breaking change：无。

### UI 变化

- 引用的设计规范：不涉及：仅将 ARIA 元数据落到已承载 `role="slider"` 的元素上，未改变视觉样式、数值范围、键盘 / 鼠标交互与文案（已在 `slider.tsx` 与 `__tests__/slider.test.tsx` 单测中验证 Thumb 行为不变）。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/renderer/components/ui/__tests__/slider.test.tsx
结果：全部通过（新增的 aria 透传断言 + 原有键盘 / 鼠标交互断言）
pnpm --filter desktop typecheck
结果：通过
pnpm test:unit（在初始化 cindy-protocol 子模块后运行）
结果：通过
pnpm check:dco
结果：通过
```

### 手工验证

在 macOS 上运行现有 Cindy 开发实例（`pnpm restart:desktop:remote --region=global`），打开设置 > 通用；修复前无障碍树中两个字号 slider 的名称为空。热更新修复后，无障碍树读到：

- `调整界面字号`，值 14
- `调整代码字号`，值 14

### 未执行的验证

无（变更仅涉及单文件 + 单测，未触及 SQLite / migration、system prompt、协议、权限或原生层）。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：纯无障碍元数据透传，不引入新路径、不修改交互

### 影响与回滚

- 影响范围：`Slider` 组件被设置页两个字号 slider 复用。无障碍名称从无到有。
- 回滚 / 降级方式：revert 此 PR 即可，热更新 + 发版均生效。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）— 本次命中 UI 路径，已按 `pr-design-basis` 校验填「不涉及：<理由>」。