### PR TITLE
fix(ios-simulator): 把启动期的 Xcode 权限探测推迟到真正使用模拟器

### DIFF
--- a/apps/desktop/src/main/mcp-integrations/__tests__/ios-simulator.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/__tests__/ios-simulator.test.ts
@@ -295,10 +295,11 @@ describe('iOS Simulator host', () => {
       await mkdir(path.dirname(evidencePath), { recursive: true });
       await writeFile(evidencePath, '{"version":1,"armedAt":"2026-08-11T00:00:00.000Z"}');
       const competingRegistry = new IOSSimulatorOwnershipRegistryFile(registryPath);
-      let finishRecovery: (value: readonly string[]) => void = () => undefined;
+      let finishRecovery: (value: { recovered: readonly string[]; complete: boolean }) => void =
+        () => undefined;
       const recoverPendingCreatesAtStartup = vi.fn(
         (_owned: readonly { udid: string; name: string }[], _signal?: AbortSignal) =>
-          new Promise<readonly string[]>((resolve) => {
+          new Promise<{ recovered: readonly string[]; complete: boolean }>((resolve) => {
             finishRecovery = resolve;
           }),
       );
@@ -318,7 +319,7 @@ describe('iOS Simulator host', () => {
         expect(recoverPendingCreatesAtStartup).toHaveBeenCalledWith([], expect.any(AbortSignal));
         expect(competingRegistry.acquireWriterSync()).toBe(false);
 
-        finishRecovery([]);
+        finishRecovery({ recovered: [], complete: true });
         await expect(recovering).resolves.toBeUndefined();
         expect(competingRegistry.acquireWriterSync()).toBe(true);
         // A completed sweep retires the breadcrumb, so the next startup has no
@@ -392,6 +393,37 @@ describe('iOS Simulator host', () => {
     }
   });
 
+  itMac('keeps interrupted-create evidence when a startup sweep is incomplete', async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), 'cindy-ios-host-incomplete-sweep-'));
+    const getPath = vi.spyOn(app, 'getPath').mockReturnValue(root);
+    const evidencePath = path.join(root, 'ios-simulator', 'pending-create-evidence.json');
+    await mkdir(path.dirname(evidencePath), { recursive: true });
+    await writeFile(evidencePath, '{"version":1,"armedAt":"2026-08-11T00:00:00.000Z"}');
+    const lifecycle: IOSSimulatorSimctlLifecycle = {
+      findExact: vi.fn(),
+      bootExact: vi.fn(),
+      shutdownExact: vi.fn(),
+      createExact: vi.fn(),
+      recoverPendingCreatesAtStartup: vi.fn(async () => ({
+        recovered: [],
+        complete: false,
+      })),
+      deleteExact: vi.fn(),
+    };
+    try {
+      await expect(
+        reconcilePersistedIOSSimulatorOwnership({ createLifecycle: () => lifecycle }),
+      ).resolves.toBeUndefined();
+
+      // The runtime observed a marker but could not safely attribute it. Keeping
+      // the breadcrumb is what makes the next startup retry instead of leaking it.
+      await expect(stat(evidencePath)).resolves.toMatchObject({});
+    } finally {
+      getPath.mockRestore();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   itMac(
     'does not inspect or delete pending markers when the ownership registry is invalid',
     async () => {
@@ -417,10 +449,11 @@ describe('iOS Simulator host', () => {
   );
 
   it('gates an already-created Host on one startup pending-create recovery', async () => {
-    let finishRecovery: (value: readonly string[]) => void = () => undefined;
+    let finishRecovery: (value: { recovered: readonly string[]; complete: boolean }) => void =
+      () => undefined;
     const recoverPendingCreatesAtStartup = vi.fn(
       (_owned: readonly { udid: string; name: string }[], _signal?: AbortSignal) =>
-        new Promise<readonly string[]>((resolve) => {
+        new Promise<{ recovered: readonly string[]; complete: boolean }>((resolve) => {
           finishRecovery = resolve;
         }),
     );
@@ -452,7 +485,7 @@ describe('iOS Simulator host', () => {
     expect(inspect).not.toHaveBeenCalled();
     expect(pendingCreateEvidence.clearIfUnchanged).not.toHaveBeenCalled();
 
-    finishRecovery([]);
+    finishRecovery({ recovered: [], complete: true });
     await expect(firstCall).resolves.toMatchObject({ ok: true });
     await expect(
       host.callTool('list_devices', {}, { sessionId: 'session-a' }),
@@ -465,7 +498,10 @@ describe('iOS Simulator host', () => {
 
   it('retries startup pending-create recovery after the ownership gate becomes available', async () => {
     let recoveryAllowed = false;
-    const recoverPendingCreatesAtStartup = vi.fn(async () => [] as readonly string[]);
+    const recoverPendingCreatesAtStartup = vi.fn(async () => ({
+      recovered: [] as readonly string[],
+      complete: true,
+    }));
     const lifecycle: IOSSimulatorSimctlLifecycle = {
       findExact: vi.fn(),
       bootExact: vi.fn(),

--- a/apps/desktop/src/main/mcp-integrations/__tests__/ios-simulator.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/__tests__/ios-simulator.test.ts
@@ -1252,6 +1252,67 @@ describe('iOS Simulator host', () => {
     expect(driverManager.stop).not.toHaveBeenCalled();
   });
 
+  it('keeps a routable binding usable while another binding cannot be reconciled', async () => {
+    const lifecycle: IOSSimulatorSimctlLifecycle = {
+      findExact: vi.fn(),
+      bootExact: vi.fn(),
+      shutdownExact: vi.fn(),
+      createExact: vi.fn(),
+      deleteExact: vi.fn(),
+    };
+    const actor = new IOSSimulatorInstanceActor({
+      store: new IOSSimulatorOwnershipStore({ createId: () => crypto.randomUUID() }),
+      lifecycle,
+    });
+    const routable = actor.attach({
+      sessionId: 'routable-session',
+      worktreeRoot: '/tmp/routable-session',
+      sourceFingerprint: 'fingerprint-a',
+      device: READY_REPORT.devices[0]!,
+    });
+    actor.attach({
+      sessionId: 'unreadable-session',
+      worktreeRoot: '/tmp/unreadable-session',
+      sourceFingerprint: 'fingerprint-b',
+      device: { ...READY_REPORT.devices[0]!, udid: 'E4DED148-43B9-4193-9D80-399976A43E08' },
+    });
+    const inspect = vi.fn(async () => READY_REPORT);
+    const host = createIOSSimulatorHost({
+      actor,
+      lifecycle,
+      runtime: { inspect },
+      getSession: vi.fn(async (id: string) => {
+        if (id === 'unreadable-session') throw new Error('session row is unreadable');
+        return localSession(id);
+      }),
+    });
+
+    try {
+      await host.reconcileOwnership();
+      const afterFirstSweep = actor.getOwned('routable-session', routable.instanceId);
+
+      // A binding whose session row cannot be read keeps the pass incomplete, so
+      // the sweep runs again on the next dispatch. It must not invalidate the
+      // route of a binding it observed as unchanged, or no caller could ever use
+      // a generation/lease pair it just read.
+      await host.reconcileOwnership();
+      expect(inspect).toHaveBeenCalledTimes(2);
+      const afterSecondSweep = actor.getOwned('routable-session', routable.instanceId);
+      expect(afterSecondSweep.generation).toBe(afterFirstSweep.generation);
+      expect(afterSecondSweep.lease.id).toBe(afterFirstSweep.lease.id);
+      expect(() =>
+        actor.assertRoute({
+          sessionId: afterFirstSweep.sessionId,
+          instanceId: afterFirstSweep.instanceId,
+          generation: afterFirstSweep.generation,
+          leaseId: afterFirstSweep.lease.id,
+        }),
+      ).not.toThrow();
+    } finally {
+      await host.dispose();
+    }
+  });
+
   it.each(['Booted', 'Booting'] as const)(
     'restores scheduler occupancy for a persisted %s device',
     async (deviceState) => {

--- a/apps/desktop/src/main/mcp-integrations/__tests__/ios-simulator.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/__tests__/ios-simulator.test.ts
@@ -291,6 +291,9 @@ describe('iOS Simulator host', () => {
       const root = await mkdtemp(path.join(os.tmpdir(), 'cindy-ios-host-lazy-reconcile-'));
       const getPath = vi.spyOn(app, 'getPath').mockReturnValue(root);
       const registryPath = path.join(root, 'ios-simulator', 'ownership-registry.json');
+      const evidencePath = path.join(root, 'ios-simulator', 'pending-create-evidence.json');
+      await mkdir(path.dirname(evidencePath), { recursive: true });
+      await writeFile(evidencePath, '{"version":1,"armedAt":"2026-08-11T00:00:00.000Z"}');
       const competingRegistry = new IOSSimulatorOwnershipRegistryFile(registryPath);
       let finishRecovery: (value: readonly string[]) => void = () => undefined;
       const recoverPendingCreatesAtStartup = vi.fn(
@@ -318,6 +321,9 @@ describe('iOS Simulator host', () => {
         finishRecovery([]);
         await expect(recovering).resolves.toBeUndefined();
         expect(competingRegistry.acquireWriterSync()).toBe(true);
+        // A completed sweep retires the breadcrumb, so the next startup has no
+        // reason to touch CoreSimulator at all.
+        await expect(stat(evidencePath)).rejects.toMatchObject({ code: 'ENOENT' });
       } finally {
         competingRegistry.releaseWriterSync();
         getPath.mockRestore();
@@ -325,6 +331,66 @@ describe('iOS Simulator host', () => {
       }
     },
   );
+
+  itMac(
+    'performs no simulator probe at startup when the profile never created a device',
+    async () => {
+      const root = await mkdtemp(path.join(os.tmpdir(), 'cindy-ios-host-quiet-startup-'));
+      const getPath = vi.spyOn(app, 'getPath').mockReturnValue(root);
+      const registryPath = path.join(root, 'ios-simulator', 'ownership-registry.json');
+      const competingRegistry = new IOSSimulatorOwnershipRegistryFile(registryPath);
+      const createLifecycle = vi.fn();
+      try {
+        await expect(
+          reconcilePersistedIOSSimulatorOwnership({ createLifecycle }),
+        ).resolves.toBeUndefined();
+
+        // No lifecycle means no xcrun/xcodebuild child process, so macOS never
+        // raises an Xcode consent prompt detached from a user action.
+        expect(createLifecycle).not.toHaveBeenCalled();
+        expect(competingRegistry.acquireWriterSync()).toBe(true);
+      } finally {
+        competingRegistry.releaseWriterSync();
+        getPath.mockRestore();
+        await rm(root, { recursive: true, force: true });
+      }
+    },
+  );
+
+  itMac('retries an interrupted-create sweep that failed on the next startup', async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), 'cindy-ios-host-failed-sweep-'));
+    const getPath = vi.spyOn(app, 'getPath').mockReturnValue(root);
+    const evidencePath = path.join(root, 'ios-simulator', 'pending-create-evidence.json');
+    await mkdir(path.dirname(evidencePath), { recursive: true });
+    await writeFile(evidencePath, '{"version":1,"armedAt":"2026-08-11T00:00:00.000Z"}');
+    const competingRegistry = new IOSSimulatorOwnershipRegistryFile(
+      path.join(root, 'ios-simulator', 'ownership-registry.json'),
+    );
+    const lifecycle: IOSSimulatorSimctlLifecycle = {
+      findExact: vi.fn(),
+      bootExact: vi.fn(),
+      shutdownExact: vi.fn(),
+      createExact: vi.fn(),
+      recoverPendingCreatesAtStartup: vi.fn(async () => {
+        throw new Error('simctl list failed');
+      }),
+      deleteExact: vi.fn(),
+    };
+    try {
+      await expect(
+        reconcilePersistedIOSSimulatorOwnership({ createLifecycle: () => lifecycle }),
+      ).resolves.toBeUndefined();
+
+      // Keeping the breadcrumb is what makes the retry happen; dropping it here
+      // would leak the hidden marker device.
+      await expect(stat(evidencePath)).resolves.toMatchObject({});
+      expect(competingRegistry.acquireWriterSync()).toBe(true);
+    } finally {
+      competingRegistry.releaseWriterSync();
+      getPath.mockRestore();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
 
   itMac(
     'does not inspect or delete pending markers when the ownership registry is invalid',
@@ -367,16 +433,24 @@ describe('iOS Simulator host', () => {
       deleteExact: vi.fn(),
     };
     const inspect = vi.fn(async () => READY_REPORT);
+    const pendingCreateEvidence = {
+      arm: vi.fn(),
+      isArmed: vi.fn(() => true),
+      generation: vi.fn(() => 7),
+      clearIfUnchanged: vi.fn(),
+    };
     const host = createIOSSimulatorHost({
       lifecycle,
       runtime: { inspect },
       getSession: vi.fn(async (id) => localSession(id)),
+      pendingCreateEvidence,
     });
 
     const firstCall = host.callTool('list_devices', {}, { sessionId: 'session-a' });
     await vi.waitFor(() => expect(recoverPendingCreatesAtStartup).toHaveBeenCalledOnce());
     expect(recoverPendingCreatesAtStartup).toHaveBeenCalledWith([], expect.any(AbortSignal));
     expect(inspect).not.toHaveBeenCalled();
+    expect(pendingCreateEvidence.clearIfUnchanged).not.toHaveBeenCalled();
 
     finishRecovery([]);
     await expect(firstCall).resolves.toMatchObject({ ok: true });
@@ -384,6 +458,9 @@ describe('iOS Simulator host', () => {
       host.callTool('list_devices', {}, { sessionId: 'session-a' }),
     ).resolves.toMatchObject({ ok: true });
     expect(recoverPendingCreatesAtStartup).toHaveBeenCalledOnce();
+    // The in-process sweep retires the same breadcrumb the create path arms, so
+    // a profile that stops owning devices returns to quiet startups.
+    expect(pendingCreateEvidence.clearIfUnchanged).toHaveBeenCalledWith(7);
   });
 
   it('retries startup pending-create recovery after the ownership gate becomes available', async () => {

--- a/apps/desktop/src/main/mcp-integrations/__tests__/ios-simulator.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/__tests__/ios-simulator.test.ts
@@ -434,7 +434,7 @@ describe('iOS Simulator host', () => {
     };
     const inspect = vi.fn(async () => READY_REPORT);
     const pendingCreateEvidence = {
-      arm: vi.fn(),
+      arm: vi.fn(() => 7),
       isArmed: vi.fn(() => true),
       generation: vi.fn(() => 7),
       clearIfUnchanged: vi.fn(),
@@ -1309,6 +1309,77 @@ describe('iOS Simulator host', () => {
         }),
       ).not.toThrow();
     } finally {
+      await host.dispose();
+    }
+  });
+
+  it('normalizes inherited viewer state per binding, not per sweep', async () => {
+    const lifecycle: IOSSimulatorSimctlLifecycle = {
+      findExact: vi.fn(),
+      bootExact: vi.fn(),
+      shutdownExact: vi.fn(),
+      createExact: vi.fn(),
+      deleteExact: vi.fn(),
+    };
+    const actor = new IOSSimulatorInstanceActor({
+      store: new IOSSimulatorOwnershipStore({ createId: () => crypto.randomUUID() }),
+      lifecycle,
+    });
+    const reconciledFirst = actor.attach({
+      sessionId: 'readable-session',
+      worktreeRoot: '/tmp/readable-session',
+      sourceFingerprint: 'fingerprint-a',
+      device: READY_REPORT.devices[0]!,
+    });
+    const skippedFirst = actor.attach({
+      sessionId: 'late-session',
+      worktreeRoot: '/tmp/late-session',
+      sourceFingerprint: 'fingerprint-b',
+      device: { ...READY_REPORT.devices[0]!, udid: 'E4DED148-43B9-4193-9D80-399976A43E08' },
+    });
+    const normalizeRequests: { instanceId: string; normalizeViewerState: boolean }[] = [];
+    const reconcile = actor.reconcile.bind(actor);
+    vi.spyOn(actor, 'reconcile').mockImplementation((...args) => {
+      normalizeRequests.push({
+        instanceId: args[0],
+        normalizeViewerState: args[5]?.normalizeViewerState === true,
+      });
+      return reconcile(...args);
+    });
+    let lateSessionReadable = false;
+    const inspect = vi.fn(async () => READY_REPORT);
+    const host = createIOSSimulatorHost({
+      actor,
+      lifecycle,
+      runtime: { inspect },
+      getSession: vi.fn(async (id: string) => {
+        if (id === 'late-session' && !lateSessionReadable) {
+          throw new Error('session row is unreadable');
+        }
+        return localSession(id);
+      }),
+    });
+
+    try {
+      await host.reconcileOwnership();
+      // The skipped binding never reached a reconcile, so nothing corrected the
+      // viewer state it inherited from the previous process.
+      expect(normalizeRequests).toEqual([
+        { instanceId: reconciledFirst.instanceId, normalizeViewerState: true },
+      ]);
+
+      lateSessionReadable = true;
+      normalizeRequests.length = 0;
+      await host.reconcileOwnership();
+      expect(inspect).toHaveBeenCalledTimes(2);
+      // The retry must still normalize the binding it skipped, while leaving the
+      // already-reconciled one alone so a viewer that attached meanwhile survives.
+      expect(normalizeRequests).toEqual([
+        { instanceId: reconciledFirst.instanceId, normalizeViewerState: false },
+        { instanceId: skippedFirst.instanceId, normalizeViewerState: true },
+      ]);
+    } finally {
+      vi.restoreAllMocks();
       await host.dispose();
     }
   });

--- a/apps/desktop/src/main/mcp-integrations/ios-simulator.ts
+++ b/apps/desktop/src/main/mcp-integrations/ios-simulator.ts
@@ -125,6 +125,16 @@ interface IOSSimulatorSessionSnapshot {
   status?: 'active' | 'archived' | 'deleted' | null;
 }
 
+interface IOSSimulatorPersistedInstanceReconcileResult {
+  /** False when this binding still needs another reconcile pass. */
+  complete: boolean;
+  /**
+   * True once this pass either reconciled the binding or removed it, meaning a
+   * later pass must no longer treat its persisted `viewerState` as inherited.
+   */
+  viewerStateHandled: boolean;
+}
+
 interface IOSSimulatorPluginStatusReadOptions {
   /** Test seam; production uses the active Main-owned task database. */
   getSession?: (sessionId: string) => Promise<IOSSimulatorSessionSnapshot | null>;
@@ -1098,9 +1108,12 @@ export function createIOSSimulatorHost(options: IOSSimulatorHostOptions = {}): I
     options.isOwnerBoundaryPending ?? isAppSessionBoundaryPending;
   const pendingCreateEvidence = options.pendingCreateEvidence ?? null;
   let ownershipReconciledScopeKey: string | null = null;
-  // Persisted `viewerState` can only be stale on the first sweep of an owner
-  // generation; after that a detached value would be this process's own truth.
+  // Persisted `viewerState` can only be stale on the first sweep that actually
+  // reaches a binding; after that a detached value would be this process's own
+  // truth. Tracked per binding, because an incomplete sweep can skip one
+  // binding entirely while normalizing the rest.
   let viewerStateNormalizedScopeKey: string | null = null;
+  const viewerStateNormalizedInstanceIds = new Set<string>();
   let ownershipReconcilePromise: { scopeKey: string; promise: Promise<void> } | null = null;
   let pendingCreateReconcileController: AbortController | null = null;
   let pendingCreateReconcilePromise: Promise<unknown> | null = null;
@@ -2366,11 +2379,12 @@ export function createIOSSimulatorHost(options: IOSSimulatorHostOptions = {}): I
     snapshot: IOSSimulatorInstance,
     devices: ReadonlyMap<string, IOSSimulatorEnvironmentReport['devices'][number]>,
     normalizeViewerState: boolean,
-  ): Promise<boolean> {
+  ): Promise<IOSSimulatorPersistedInstanceReconcileResult> {
     const instance = actor
       .list(snapshot.sessionId)
       .find((candidate) => candidate.instanceId === snapshot.instanceId);
-    if (!instance) return true;
+    // A binding that no longer exists has no inherited viewer state to correct.
+    if (!instance) return { complete: true, viewerStateHandled: true };
 
     let complete = true;
     let driverRuntimeRecovered = await cleanupOrphanedDriverRuntime(instance);
@@ -2394,7 +2408,9 @@ export function createIOSSimulatorHost(options: IOSSimulatorHostOptions = {}): I
         instanceId: instance.instanceId,
         error: error instanceof Error ? error.message : String(error),
       });
-      return false;
+      // This binding was skipped before any reconcile, so its inherited viewer
+      // state is still unhandled and the retry must normalize it.
+      return { complete: false, viewerStateHandled: false };
     }
     if (!session || session.status === 'deleted' || session.status === 'archived') {
       const released = await actor.runOwnershipCleanup(
@@ -2402,7 +2418,7 @@ export function createIOSSimulatorHost(options: IOSSimulatorHostOptions = {}): I
         instance.sessionId,
         (owned, signal) => releaseStaleBinding(owned, device, true, signal),
       );
-      return released && complete;
+      return { complete: released && complete, viewerStateHandled: released };
     }
     if (session.remoteHostId || !device) {
       const runtimeReleased = await releaseInstanceRuntime(instance);
@@ -2418,7 +2434,7 @@ export function createIOSSimulatorHost(options: IOSSimulatorHostOptions = {}): I
         session.remoteHostId ? 'UNSUPPORTED_SESSION_KIND' : 'ORPHANED_DEVICE',
         { normalizeViewerState },
       );
-      return complete;
+      return { complete, viewerStateHandled: true };
     }
     const reconciledDeviceState = deviceState ?? 'unknown';
     if (reconciledDeviceState === 'shutdown') {
@@ -2463,7 +2479,36 @@ export function createIOSSimulatorHost(options: IOSSimulatorHostOptions = {}): I
         resourceScheduler.markStopped(reconciled.instanceId),
       );
     }
-    return complete;
+    return { complete, viewerStateHandled: true };
+  }
+
+  function isViewerStateNormalized(scopeKey: string, instanceId: string): boolean {
+    return (
+      viewerStateNormalizedScopeKey === scopeKey &&
+      viewerStateNormalizedInstanceIds.has(instanceId)
+    );
+  }
+
+  function markViewerStateNormalized(scopeKey: string, instanceId: string): void {
+    // An old in-flight pass must not suppress the new owner's normalization.
+    if (isOwnerBoundaryPending() || getOwnerScopeKey() !== scopeKey) return;
+    if (viewerStateNormalizedScopeKey !== scopeKey) {
+      viewerStateNormalizedInstanceIds.clear();
+      viewerStateNormalizedScopeKey = scopeKey;
+    }
+    viewerStateNormalizedInstanceIds.add(instanceId);
+  }
+
+  /** Keep the per-binding latch bounded by the bindings that still exist. */
+  function retainViewerStateNormalized(
+    scopeKey: string,
+    persisted: readonly IOSSimulatorInstance[],
+  ): void {
+    if (viewerStateNormalizedScopeKey !== scopeKey) return;
+    const live = new Set(persisted.map((instance) => instance.instanceId));
+    for (const instanceId of viewerStateNormalizedInstanceIds) {
+      if (!live.has(instanceId)) viewerStateNormalizedInstanceIds.delete(instanceId);
+    }
   }
 
   async function reconcilePersistedOwnership(): Promise<void> {
@@ -2567,22 +2612,28 @@ export function createIOSSimulatorHost(options: IOSSimulatorHostOptions = {}): I
       const devices = new Map(
         environment.devices.map((device) => [device.udid.toUpperCase(), device]),
       );
-      const normalizeViewerState = viewerStateNormalizedScopeKey !== scopeKey;
-      for (const snapshot of actor.listAll()) {
-        const instanceComplete = await withSessionLock(snapshot.sessionId, () =>
+      const persisted = actor.listAll();
+      retainViewerStateNormalized(scopeKey, persisted);
+      for (const snapshot of persisted) {
+        const normalizeViewerState = !isViewerStateNormalized(scopeKey, snapshot.instanceId);
+        const instanceResult = await withSessionLock(snapshot.sessionId, () =>
           reconcilePersistedInstance(snapshot, devices, normalizeViewerState),
         );
-        if (!instanceComplete) complete = false;
+        if (!instanceResult.complete) complete = false;
+        // Latch per binding, not per pass: a binding skipped before its reconcile
+        // (e.g. its session row was unreadable) still carries viewer state
+        // inherited from a dead process, and the retry has to correct it. A
+        // binding that was reconciled must not be normalized again, or the retry
+        // would kick a viewer that attached in the meantime.
+        if (instanceResult.viewerStateHandled) {
+          markViewerStateNormalized(scopeKey, snapshot.instanceId);
+        }
       }
       // Every DB/session read above belongs to the captured owner generation.
       // Never latch it across an account boundary or let an old in-flight pass
       // suppress the new owner's required cleanup and scheduler reconciliation.
       if (!isOwnerBoundaryPending() && getOwnerScopeKey() === scopeKey) {
         ownershipReconciledScopeKey = complete ? scopeKey : null;
-        // Inherited viewer state is corrected even when the pass was incomplete:
-        // this sweep already observed every binding, and a retry must not kick a
-        // viewer that attached in the meantime.
-        viewerStateNormalizedScopeKey = scopeKey;
       }
     })().finally(() => {
       if (ownershipReconcilePromise?.promise === reconciliation) {

--- a/apps/desktop/src/main/mcp-integrations/ios-simulator.ts
+++ b/apps/desktop/src/main/mcp-integrations/ios-simulator.ts
@@ -1098,6 +1098,9 @@ export function createIOSSimulatorHost(options: IOSSimulatorHostOptions = {}): I
     options.isOwnerBoundaryPending ?? isAppSessionBoundaryPending;
   const pendingCreateEvidence = options.pendingCreateEvidence ?? null;
   let ownershipReconciledScopeKey: string | null = null;
+  // Persisted `viewerState` can only be stale on the first sweep of an owner
+  // generation; after that a detached value would be this process's own truth.
+  let viewerStateNormalizedScopeKey: string | null = null;
   let ownershipReconcilePromise: { scopeKey: string; promise: Promise<void> } | null = null;
   let pendingCreateReconcileController: AbortController | null = null;
   let pendingCreateReconcilePromise: Promise<unknown> | null = null;
@@ -2362,6 +2365,7 @@ export function createIOSSimulatorHost(options: IOSSimulatorHostOptions = {}): I
   async function reconcilePersistedInstance(
     snapshot: IOSSimulatorInstance,
     devices: ReadonlyMap<string, IOSSimulatorEnvironmentReport['devices'][number]>,
+    normalizeViewerState: boolean,
   ): Promise<boolean> {
     const instance = actor
       .list(snapshot.sessionId)
@@ -2412,6 +2416,7 @@ export function createIOSSimulatorHost(options: IOSSimulatorHostOptions = {}): I
         device ? (deviceState === 'booted' ? 'ready' : 'stopped') : 'error',
         'degraded',
         session.remoteHostId ? 'UNSUPPORTED_SESSION_KIND' : 'ORPHANED_DEVICE',
+        { normalizeViewerState },
       );
       return complete;
     }
@@ -2451,7 +2456,7 @@ export function createIOSSimulatorHost(options: IOSSimulatorHostOptions = {}): I
           ? 'healthy'
           : 'recovering',
       driverRuntimeRecovered ? null : 'WDA_UNAVAILABLE',
-      { preserveDetachGrace: shouldResumeDetachGrace },
+      { preserveDetachGrace: shouldResumeDetachGrace, normalizeViewerState },
     );
     if (shouldResumeDetachGrace && driverRuntimeRecovered && complete) {
       await actor.resumeDetachGrace(reconciled.instanceId, reconciled.sessionId, () =>
@@ -2562,9 +2567,10 @@ export function createIOSSimulatorHost(options: IOSSimulatorHostOptions = {}): I
       const devices = new Map(
         environment.devices.map((device) => [device.udid.toUpperCase(), device]),
       );
+      const normalizeViewerState = viewerStateNormalizedScopeKey !== scopeKey;
       for (const snapshot of actor.listAll()) {
         const instanceComplete = await withSessionLock(snapshot.sessionId, () =>
-          reconcilePersistedInstance(snapshot, devices),
+          reconcilePersistedInstance(snapshot, devices, normalizeViewerState),
         );
         if (!instanceComplete) complete = false;
       }
@@ -2573,6 +2579,10 @@ export function createIOSSimulatorHost(options: IOSSimulatorHostOptions = {}): I
       // suppress the new owner's required cleanup and scheduler reconciliation.
       if (!isOwnerBoundaryPending() && getOwnerScopeKey() === scopeKey) {
         ownershipReconciledScopeKey = complete ? scopeKey : null;
+        // Inherited viewer state is corrected even when the pass was incomplete:
+        // this sweep already observed every binding, and a retry must not kick a
+        // viewer that attached in the meantime.
+        viewerStateNormalizedScopeKey = scopeKey;
       }
     })().finally(() => {
       if (ownershipReconcilePromise?.promise === reconciliation) {

--- a/apps/desktop/src/main/mcp-integrations/ios-simulator.ts
+++ b/apps/desktop/src/main/mcp-integrations/ios-simulator.ts
@@ -21,6 +21,7 @@ import {
   IOSSimulatorInstanceError,
   IOSSimulatorOwnershipStore,
   IOSSimulatorOwnershipRegistryFile,
+  IOSSimulatorPendingCreateEvidenceFile,
   IOSSimulatorProjectBuildError,
   IOSSimulatorProjectBuilder,
   IOSSimulatorResourceScheduler,
@@ -49,6 +50,8 @@ import {
   type IOSSimulatorMutationRoute,
   type IOSSimulatorNativeSidecarDriver,
   type IOSSimulatorLatestH264Frame,
+  type IOSSimulatorPendingCreateEvidence,
+  type IOSSimulatorPendingCreateEvidenceStore,
   type IOSSimulatorProjectBuildResult,
   type IOSSimulatorRuntime,
   type IOSSimulatorSimctlLifecycle,
@@ -200,6 +203,12 @@ export interface IOSSimulatorHostOptions {
   resourceScheduler?: IOSSimulatorResourceScheduler;
   /** Fail-closed gate supplied by the persisted registry owner. */
   canReconcilePendingCreates?: () => boolean;
+  /**
+   * Profile-scoped interrupted-create breadcrumb shared with the injected
+   * lifecycle. A completed sweep retires it so later startups can skip the
+   * CoreSimulator probe entirely.
+   */
+  pendingCreateEvidence?: IOSSimulatorPendingCreateEvidenceStore;
   /** Main-owned account generation used to scope persisted ownership reconciliation. */
   getOwnerScopeKey?: () => string;
   /** Fail closed while the active account runtime is being replaced. */
@@ -444,14 +453,34 @@ export function createRegistryBackedIOSSimulatorDeviceGrantStore(
   });
 }
 
+/**
+ * Interrupted-create evidence lives beside the ownership registry, inside the
+ * active Cindy profile. Its presence is the only reason a profile without
+ * persisted ownership still needs a CoreSimulator sweep, so keeping it accurate
+ * is what keeps Xcode consent prompts tied to real simulator use.
+ */
+function createDefaultPendingCreateEvidence(
+  registry: IOSSimulatorOwnershipRegistryFile,
+): IOSSimulatorPendingCreateEvidenceStore {
+  const filePath = path.join(path.dirname(registry.filePath), 'pending-create-evidence.json');
+  return new IOSSimulatorPendingCreateEvidenceFile(filePath, {
+    onError: (error) =>
+      logger.warn('iOS Simulator interrupted-create evidence could not be updated', {
+        filePath: redact(filePath),
+        error: error instanceof Error ? error.message : String(error),
+      }),
+  });
+}
+
 function createProfileScopedIOSSimulatorLifecycle(
   registry: IOSSimulatorOwnershipRegistryFile,
+  pendingCreateEvidence: IOSSimulatorPendingCreateEvidence,
 ): IOSSimulatorSimctlLifecycle {
   const createMarkerNamespace = createHash('sha256')
     .update(path.resolve(registry.filePath))
     .digest('hex')
     .slice(0, 16);
-  return createIOSSimulatorSimctlLifecycle({ createMarkerNamespace });
+  return createIOSSimulatorSimctlLifecycle({ createMarkerNamespace, pendingCreateEvidence });
 }
 
 const STARTUP_PENDING_CREATE_RECOVERY_TIMEOUT_MS = 6_000;
@@ -459,9 +488,15 @@ const STARTUP_PENDING_CREATE_RECOVERY_TIMEOUT_MS = 6_000;
 async function recoverProfilePendingCreatesAtStartup(
   lifecycle: IOSSimulatorSimctlLifecycle,
   persistedInstances: readonly IOSSimulatorInstance[],
-  signal?: AbortSignal,
+  options: {
+    signal?: AbortSignal;
+    /** Retired only after a completed sweep proves no marker is left. */
+    evidence?: IOSSimulatorPendingCreateEvidenceStore | null;
+  } = {},
 ): Promise<void> {
   if (!lifecycle.recoverPendingCreatesAtStartup) return;
+  const { signal, evidence } = options;
+  const evidenceGeneration = evidence?.generation() ?? 0;
   const controller = new AbortController();
   const abortFromParent = (): void => controller.abort(signal?.reason);
   if (signal?.aborted) abortFromParent();
@@ -479,6 +514,10 @@ async function recoverProfilePendingCreatesAtStartup(
       })),
       controller.signal,
     );
+    // A completed sweep proves this profile holds no leftover create marker.
+    // Retire the breadcrumb so the next startup stays off xcrun — unless
+    // another create armed it while this sweep was still running.
+    evidence?.clearIfUnchanged(evidenceGeneration);
   } catch (error) {
     // A marker remains hidden and profile-scoped, so an optional Simulator
     // cleanup failure must not block Cindy startup. Keeping it intact lets the
@@ -1057,6 +1096,7 @@ export function createIOSSimulatorHost(options: IOSSimulatorHostOptions = {}): I
   const getOwnerScopeKey = options.getOwnerScopeKey ?? activeOwnerScopeKey;
   const isOwnerBoundaryPending =
     options.isOwnerBoundaryPending ?? isAppSessionBoundaryPending;
+  const pendingCreateEvidence = options.pendingCreateEvidence ?? null;
   let ownershipReconciledScopeKey: string | null = null;
   let ownershipReconcilePromise: { scopeKey: string; promise: Promise<void> } | null = null;
   let pendingCreateReconcileController: AbortController | null = null;
@@ -2464,11 +2504,10 @@ export function createIOSSimulatorHost(options: IOSSimulatorHostOptions = {}): I
         } else {
           startupPendingCreateRecoveryAttempted = true;
           const controller = new AbortController();
-          const recovery = recoverProfilePendingCreatesAtStartup(
-            lifecycle,
-            actor.listAll(),
-            controller.signal,
-          );
+          const recovery = recoverProfilePendingCreatesAtStartup(lifecycle, actor.listAll(), {
+            signal: controller.signal,
+            evidence: pendingCreateEvidence,
+          });
           pendingCreateReconcileController = controller;
           pendingCreateReconcilePromise = recovery;
           try {
@@ -6348,6 +6387,7 @@ function installDefaultIOSSimulatorHost(
   lifecycle: IOSSimulatorSimctlLifecycle,
   persistedActor: ReturnType<typeof createDefaultActor>,
   registry: IOSSimulatorOwnershipRegistryFile,
+  pendingCreateEvidence: IOSSimulatorPendingCreateEvidenceStore,
 ): IOSSimulatorHost {
   if (defaultIOSSimulatorRuntime) {
     persistedActor.release();
@@ -6365,6 +6405,7 @@ function installDefaultIOSSimulatorHost(
       actor: persistedActor.actor,
       grantStore: createRegistryBackedIOSSimulatorDeviceGrantStore(registry),
       canReconcilePendingCreates: persistedActor.canReconcilePendingCreates,
+      pendingCreateEvidence,
       driverManager: createDefaultDriverManager(),
     });
     configureIOSSimulatorRendererAccessRevocationObserver((grants) => {
@@ -6403,9 +6444,15 @@ export function initializeIOSSimulatorHost(): IOSSimulatorHost {
   }
 
   const registry = createDefaultOwnershipRegistry();
-  const lifecycle = createProfileScopedIOSSimulatorLifecycle(registry);
+  const pendingCreateEvidence = createDefaultPendingCreateEvidence(registry);
+  const lifecycle = createProfileScopedIOSSimulatorLifecycle(registry, pendingCreateEvidence);
   const persistedActor = createDefaultActor(lifecycle, registry);
-  return installDefaultIOSSimulatorHost(lifecycle, persistedActor, registry);
+  return installDefaultIOSSimulatorHost(
+    lifecycle,
+    persistedActor,
+    registry,
+    pendingCreateEvidence,
+  );
 }
 
 function currentIOSSimulatorHost(): IOSSimulatorHost | null {
@@ -6515,9 +6562,15 @@ export function reconcileIOSSimulatorOwnership(): Promise<void> {
 
 /**
  * Startup recovery performs one bounded, profile-scoped pending-create sweep
- * even when ownership is empty, then releases the writer lease without
+ * when this profile can still hold a create marker — persisted ownership, or an
+ * armed interrupted-create breadcrumb — then releases the writer lease without
  * installing the Host. Persisted bindings still install the Host so they are
  * reconciled even if the feature is not opened again after a crash.
+ *
+ * A profile with neither is provably clean, so startup performs no `xcrun` /
+ * CoreSimulator access at all. That keeps macOS Xcode consent prompts attached
+ * to the moment the user actually opens the simulator, in the same spirit as
+ * the safeStorage probe rule in `docs/dev-rules/credentials-and-local-storage.md`.
  */
 export interface IOSSimulatorPersistedOwnershipRecoveryOptions {
   /** Test seam; production always derives a profile-scoped lifecycle. */
@@ -6542,15 +6595,32 @@ export async function reconcilePersistedIOSSimulatorOwnership(
       );
     }
     const persistedInstances = registry.loadSync();
+    const pendingCreateEvidence = createDefaultPendingCreateEvidence(registry);
+    if (persistedInstances.length === 0 && !pendingCreateEvidence.isArmed()) {
+      // Nothing owned and no interrupted create: sweeping here would spawn
+      // xcrun on a profile that never used the simulator, which is exactly the
+      // startup-time Xcode permission prompt users report.
+      logger.debug('Skipped iOS Simulator startup recovery for a profile with no simulator state');
+      registry.releaseWriterSync();
+      return;
+    }
     const lifecycle =
-      options.createLifecycle?.(registry) ?? createProfileScopedIOSSimulatorLifecycle(registry);
+      options.createLifecycle?.(registry) ??
+      createProfileScopedIOSSimulatorLifecycle(registry, pendingCreateEvidence);
     if (persistedInstances.length === 0) {
-      await recoverProfilePendingCreatesAtStartup(lifecycle, persistedInstances);
+      await recoverProfilePendingCreatesAtStartup(lifecycle, persistedInstances, {
+        evidence: pendingCreateEvidence,
+      });
       registry.releaseWriterSync();
       return;
     }
     const persistedActor = createDefaultActor(lifecycle, registry);
-    const host = installDefaultIOSSimulatorHost(lifecycle, persistedActor, registry);
+    const host = installDefaultIOSSimulatorHost(
+      lifecycle,
+      persistedActor,
+      registry,
+      pendingCreateEvidence,
+    );
     registryTransferred = true;
     await host.reconcileOwnership();
   } catch (error) {
@@ -6612,9 +6682,15 @@ export function cleanupIOSSimulatorRemovedSession(sessionId: string): Promise<vo
     // Keep the same writer lease from the authoritative read through Host
     // installation. Releasing and reacquiring here would reopen the race with
     // another Cindy process attaching this task while it is being removed.
-    const lifecycle = createProfileScopedIOSSimulatorLifecycle(registry);
+    const pendingCreateEvidence = createDefaultPendingCreateEvidence(registry);
+    const lifecycle = createProfileScopedIOSSimulatorLifecycle(registry, pendingCreateEvidence);
     const persistedActor = createDefaultActor(lifecycle, registry);
-    const host = installDefaultIOSSimulatorHost(lifecycle, persistedActor, registry);
+    const host = installDefaultIOSSimulatorHost(
+      lifecycle,
+      persistedActor,
+      registry,
+      pendingCreateEvidence,
+    );
     registryTransferred = true;
     return host.cleanupRemovedSession(normalizedSessionId);
   } catch (error) {

--- a/apps/desktop/src/main/mcp-integrations/ios-simulator.ts
+++ b/apps/desktop/src/main/mcp-integrations/ios-simulator.ts
@@ -517,7 +517,7 @@ async function recoverProfilePendingCreatesAtStartup(
   );
   timer.unref?.();
   try {
-    await lifecycle.recoverPendingCreatesAtStartup(
+    const recovery = await lifecycle.recoverPendingCreatesAtStartup(
       persistedInstances.map((instance) => ({
         udid: instance.simulatorUdid,
         name: instance.simulatorName,
@@ -527,7 +527,7 @@ async function recoverProfilePendingCreatesAtStartup(
     // A completed sweep proves this profile holds no leftover create marker.
     // Retire the breadcrumb so the next startup stays off xcrun — unless
     // another create armed it while this sweep was still running.
-    evidence?.clearIfUnchanged(evidenceGeneration);
+    if (recovery.complete) evidence?.clearIfUnchanged(evidenceGeneration);
   } catch (error) {
     // A marker remains hidden and profile-scoped, so an optional Simulator
     // cleanup failure must not block Cindy startup. Keeping it intact lets the

--- a/packages/ios-simulator-runtime/src/index.ts
+++ b/packages/ios-simulator-runtime/src/index.ts
@@ -24,6 +24,7 @@ export * from "./native-sidecar/sandbox.js";
 export * from "./native-sidecar/layout.js";
 export * from "./ownership-store.js";
 export * from "./ownership-registry-file.js";
+export * from "./pending-create-evidence-file.js";
 export * from "./project-adapter.js";
 export * from "./runtime.js";
 export * from "./resource-scheduler.js";

--- a/packages/ios-simulator-runtime/src/instance-actor.test.ts
+++ b/packages/ios-simulator-runtime/src/instance-actor.test.ts
@@ -116,6 +116,30 @@ describe("IOSSimulatorInstanceActor", () => {
     ).not.toThrow();
   });
 
+  it("renews an expired lease on an unchanged reconcile without issuing a new generation", () => {
+    const harness = createHarness();
+    const before = harness.instance;
+    // A persisted lease restored from a previous process, or idle past its TTL.
+    harness.setNow(Date.parse(before.lease.expiresAt) + 1);
+
+    const reconciled = harness.actor.reconcile(
+      before.instanceId,
+      before.sessionId,
+      before.lifecycleState,
+      before.healthState,
+      before.errorCode,
+    );
+
+    // Without this, every later sweep stays unchanged too, so the binding could
+    // never produce a usable route again.
+    expect(reconciled.generation).toBe(before.generation);
+    expect(reconciled.lease.id).not.toBe(before.lease.id);
+    expect(reconciled.viewerState).toBe(before.viewerState);
+    expect(() =>
+      harness.actor.assertRoute(harness.route(reconciled)),
+    ).not.toThrow();
+  });
+
   it("issues a new route when the observed state changed", () => {
     const harness = createHarness();
     const before = harness.instance;

--- a/packages/ios-simulator-runtime/src/instance-actor.test.ts
+++ b/packages/ios-simulator-runtime/src/instance-actor.test.ts
@@ -94,6 +94,61 @@ function createHarness(
 }
 
 describe("IOSSimulatorInstanceActor", () => {
+  it("keeps the current route when a reconcile observes no change", () => {
+    const harness = createHarness();
+    const before = harness.instance;
+
+    const reconciled = harness.actor.reconcile(
+      before.instanceId,
+      before.sessionId,
+      before.lifecycleState,
+      before.healthState,
+      before.errorCode,
+    );
+
+    expect(reconciled.generation).toBe(before.generation);
+    expect(reconciled.lease.id).toBe(before.lease.id);
+    // CoreSimulator says nothing about viewer attachment, so an unchanged
+    // binding must not have a live viewer kicked out from under it.
+    expect(reconciled.viewerState).toBe("attached");
+    expect(() =>
+      harness.actor.assertRoute(harness.route(before)),
+    ).not.toThrow();
+  });
+
+  it("issues a new route when the observed state changed", () => {
+    const harness = createHarness();
+    const before = harness.instance;
+
+    const reconciled = harness.actor.reconcile(
+      before.instanceId,
+      before.sessionId,
+      "ready",
+      before.healthState,
+      before.errorCode,
+    );
+
+    expect(reconciled.generation).toBe(before.generation + 1);
+    expect(reconciled.lease.id).not.toBe(before.lease.id);
+    expect(reconciled.viewerState).toBe("detached");
+  });
+
+  it("normalizes a viewer state inherited from a dead process", () => {
+    const harness = createHarness();
+    const before = harness.instance;
+
+    const reconciled = harness.actor.reconcile(
+      before.instanceId,
+      before.sessionId,
+      before.lifecycleState,
+      before.healthState,
+      before.errorCode,
+      { normalizeViewerState: true },
+    );
+
+    expect(reconciled.viewerState).toBe("detached");
+  });
+
   it("increments generation across exact start and stop operations", async () => {
     const harness = createHarness();
     const started = await harness.actor.start(harness.route());

--- a/packages/ios-simulator-runtime/src/instance-actor.ts
+++ b/packages/ios-simulator-runtime/src/instance-actor.ts
@@ -40,6 +40,13 @@ type IOSSimulatorCreateInput = Omit<IOSSimulatorAttachInput, "device"> & {
 
 export interface IOSSimulatorReconcileOptions {
   preserveDetachGrace?: boolean;
+  /**
+   * Correct a `viewerState` inherited from a process that is already gone. Only
+   * the first sweep of an owner generation knows the persisted value cannot
+   * describe a live viewer; later sweeps observe CoreSimulator alone and have no
+   * evidence about viewer attachment, so they must leave it untouched.
+   */
+  normalizeViewerState?: boolean;
 }
 
 export type IOSSimulatorMutationSource = "agent" | "user";
@@ -291,6 +298,24 @@ export class IOSSimulatorInstanceActor {
     options: IOSSimulatorReconcileOptions = {},
   ): IOSSimulatorInstance {
     const current = this.#store.requireOwned(instanceId, sessionId);
+    // The ownership sweep runs ahead of every tool dispatch, so a reconcile that
+    // observed no change must not issue a new route: bumping the generation and
+    // minting a new lease invalidates the (generation, leaseId) pair the caller
+    // just read, which no caller can ever win against. Viewer attachment is
+    // process-local and never observed by CoreSimulator, so an unchanged binding
+    // keeps its viewer as well — see `normalizeViewerState` for the one sweep
+    // that is allowed to correct a value inherited from a dead process. A
+    // pending detach grace is excluded: re-arming that deadline in this process
+    // is itself a transition, so it still issues a fresh route.
+    const unchanged =
+      options.preserveDetachGrace !== true &&
+      current.graceExpiresAt === null &&
+      current.lifecycleState === lifecycleState &&
+      current.healthState === healthState &&
+      current.errorCode === errorCode;
+    const staleViewerState =
+      options.normalizeViewerState === true && current.viewerState !== "detached";
+    if (unchanged && !staleViewerState) return current;
     this.#cancelActiveAgentMutation(instanceId);
     this.#abortLifecycleStartsForInstance(instanceId);
     const renewed = this.#store.renew(instanceId, sessionId, {

--- a/packages/ios-simulator-runtime/src/instance-actor.ts
+++ b/packages/ios-simulator-runtime/src/instance-actor.ts
@@ -315,7 +315,17 @@ export class IOSSimulatorInstanceActor {
       current.errorCode === errorCode;
     const staleViewerState =
       options.normalizeViewerState === true && current.viewerState !== "detached";
-    if (unchanged && !staleViewerState) return current;
+    if (unchanged && !staleViewerState) {
+      // Preserving the route must not mean preserving a lease that can no longer
+      // authorize one. A persisted lease can already be expired here — restored
+      // from a previous process, or idle past its TTL — and because every later
+      // sweep is unchanged too, nothing would ever renew it: reads that hand back
+      // a full route without heartbeating (`doctor`) would then fail
+      // LEASE_EXPIRED forever. `heartbeat` is exactly the needed shape: it leaves
+      // a healthy lease and its id untouched, extends one close to expiry under
+      // the same id, and mints a new id only when the old one is already unusable.
+      return this.#store.heartbeat(instanceId, sessionId);
+    }
     this.#cancelActiveAgentMutation(instanceId);
     this.#abortLifecycleStartsForInstance(instanceId);
     const renewed = this.#store.renew(instanceId, sessionId, {

--- a/packages/ios-simulator-runtime/src/pending-create-evidence-file.test.ts
+++ b/packages/ios-simulator-runtime/src/pending-create-evidence-file.test.ts
@@ -16,7 +16,9 @@ describe("IOSSimulatorPendingCreateEvidenceFile", () => {
       expect(evidence.isArmed()).toBe(false);
       expect(evidence.generation()).toBe(0);
 
-      evidence.arm();
+      // The armed generation goes back to the caller so it can retire exactly
+      // its own evidence later.
+      expect(evidence.arm()).toBe(1);
       expect(evidence.isArmed()).toBe(true);
       expect(evidence.generation()).toBe(1);
       if (process.platform !== "win32") {

--- a/packages/ios-simulator-runtime/src/pending-create-evidence-file.test.ts
+++ b/packages/ios-simulator-runtime/src/pending-create-evidence-file.test.ts
@@ -1,0 +1,68 @@
+import { mkdtemp, rm, stat } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { describe, expect, it, vi } from "vitest";
+
+import { IOSSimulatorPendingCreateEvidenceFile } from "./pending-create-evidence-file.js";
+
+describe("IOSSimulatorPendingCreateEvidenceFile", () => {
+  it("stays unarmed until a create arms it, then clears on a matching generation", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "cindy-ios-evidence-"));
+    try {
+      const evidence = new IOSSimulatorPendingCreateEvidenceFile(
+        path.join(root, "nested", "pending-create-evidence.json"),
+      );
+      expect(evidence.isArmed()).toBe(false);
+      expect(evidence.generation()).toBe(0);
+
+      evidence.arm();
+      expect(evidence.isArmed()).toBe(true);
+      expect(evidence.generation()).toBe(1);
+      if (process.platform !== "win32") {
+        expect((await stat(evidence.filePath)).mode & 0o777).toBe(0o600);
+      }
+
+      evidence.clearIfUnchanged(evidence.generation());
+      expect(evidence.isArmed()).toBe(false);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps evidence armed by a create that started after the sweep captured its generation", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "cindy-ios-evidence-"));
+    try {
+      const evidence = new IOSSimulatorPendingCreateEvidenceFile(
+        path.join(root, "pending-create-evidence.json"),
+      );
+      evidence.arm();
+      const sweepGeneration = evidence.generation();
+
+      // A concurrent create arms again while the sweep is still running.
+      evidence.arm();
+      evidence.clearIfUnchanged(sweepGeneration);
+
+      expect(evidence.isArmed()).toBe(true);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("reports a failed arm instead of failing the create", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "cindy-ios-evidence-"));
+    try {
+      const onError = vi.fn();
+      // A directory in place of the marker file makes every write fail.
+      const evidence = new IOSSimulatorPendingCreateEvidenceFile(root, {
+        onError,
+      });
+
+      expect(() => evidence.arm()).not.toThrow();
+      expect(onError).toHaveBeenCalledOnce();
+      expect(evidence.generation()).toBe(1);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/ios-simulator-runtime/src/pending-create-evidence-file.ts
+++ b/packages/ios-simulator-runtime/src/pending-create-evidence-file.ts
@@ -10,7 +10,13 @@ const EVIDENCE_VERSION = 1;
  * create marker.
  */
 export interface IOSSimulatorPendingCreateEvidence {
-  arm(): void;
+  /** Arms the breadcrumb and returns the generation that armed it. */
+  arm(): number;
+  /**
+   * Retires the breadcrumb, but only when no later create armed it. Callers may
+   * only invoke this from a path that proves their own marker no longer exists.
+   */
+  clearIfUnchanged(generation: number): void;
 }
 
 /**
@@ -27,7 +33,6 @@ export interface IOSSimulatorPendingCreateEvidenceStore
    * never has its evidence retired by that sweep.
    */
   generation(): number;
-  clearIfUnchanged(generation: number): void;
 }
 
 export interface IOSSimulatorPendingCreateEvidenceFileOptions {
@@ -63,7 +68,7 @@ export class IOSSimulatorPendingCreateEvidenceFile
     return this.#filePath;
   }
 
-  arm(): void {
+  arm(): number {
     this.#generation += 1;
     try {
       mkdirSync(path.dirname(this.#filePath), { recursive: true });
@@ -80,6 +85,7 @@ export class IOSSimulatorPendingCreateEvidenceFile
       // use. Failing the create the user actually asked for would be worse.
       this.#onError?.(error);
     }
+    return this.#generation;
   }
 
   isArmed(): boolean {

--- a/packages/ios-simulator-runtime/src/pending-create-evidence-file.ts
+++ b/packages/ios-simulator-runtime/src/pending-create-evidence-file.ts
@@ -1,0 +1,102 @@
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+const EVIDENCE_VERSION = 1;
+
+/**
+ * Create-side view of the interrupted-create breadcrumb. `createExact` arms it
+ * before `simctl create` can commit a device, so a crash between the create and
+ * the ownership write still leaves proof that this profile may hold a hidden
+ * create marker.
+ */
+export interface IOSSimulatorPendingCreateEvidence {
+  arm(): void;
+}
+
+/**
+ * Recovery-side view. A profile with no persisted ownership and no armed
+ * evidence provably has nothing to sweep, so the Host can skip the
+ * CoreSimulator probe entirely instead of running `simctl` on every startup.
+ */
+export interface IOSSimulatorPendingCreateEvidenceStore
+  extends IOSSimulatorPendingCreateEvidence {
+  isArmed(): boolean;
+  /**
+   * Monotonic arm counter. A sweep captures it before it starts and passes it
+   * back to `clearIfUnchanged`, so a create issued while the sweep was running
+   * never has its evidence retired by that sweep.
+   */
+  generation(): number;
+  clearIfUnchanged(generation: number): void;
+}
+
+export interface IOSSimulatorPendingCreateEvidenceFileOptions {
+  /** Best-effort persistence seam: failures are reported, never thrown. */
+  onError?: (error: unknown) => void;
+}
+
+/**
+ * Presence-only marker file kept beside the profile ownership registry. Only
+ * existence is authoritative; the JSON body is human-facing debug context and
+ * is never parsed back.
+ *
+ * Concurrency: every mutation happens under the profile ownership writer lease
+ * (creates require the persisted actor, sweeps run inside recovery), so no
+ * cross-process locking of its own is required.
+ */
+export class IOSSimulatorPendingCreateEvidenceFile
+  implements IOSSimulatorPendingCreateEvidenceStore
+{
+  readonly #filePath: string;
+  readonly #onError: ((error: unknown) => void) | null;
+  #generation = 0;
+
+  constructor(
+    filePath: string,
+    options: IOSSimulatorPendingCreateEvidenceFileOptions = {},
+  ) {
+    this.#filePath = filePath;
+    this.#onError = options.onError ?? null;
+  }
+
+  get filePath(): string {
+    return this.#filePath;
+  }
+
+  arm(): void {
+    this.#generation += 1;
+    try {
+      mkdirSync(path.dirname(this.#filePath), { recursive: true });
+      writeFileSync(
+        this.#filePath,
+        JSON.stringify({
+          version: EVIDENCE_VERSION,
+          armedAt: new Date().toISOString(),
+        }),
+        { encoding: "utf8", mode: 0o600 },
+      );
+    } catch (error) {
+      // A missing breadcrumb only defers marker cleanup to the next simulator
+      // use. Failing the create the user actually asked for would be worse.
+      this.#onError?.(error);
+    }
+  }
+
+  isArmed(): boolean {
+    return existsSync(this.#filePath);
+  }
+
+  generation(): number {
+    return this.#generation;
+  }
+
+  clearIfUnchanged(generation: number): void {
+    if (generation !== this.#generation) return;
+    try {
+      rmSync(this.#filePath, { force: true });
+    } catch (error) {
+      // Keeping stale evidence only costs one extra sweep on the next startup.
+      this.#onError?.(error);
+    }
+  }
+}

--- a/packages/ios-simulator-runtime/src/simctl-lifecycle.test.ts
+++ b/packages/ios-simulator-runtime/src/simctl-lifecycle.test.ts
@@ -636,6 +636,58 @@ describe("createIOSSimulatorSimctlLifecycle", () => {
     );
   });
 
+  it("does not let a later settled create retire older incomplete startup evidence", async () => {
+    const oldMarkerName =
+      "__CindyPending__profilealpha__11111111-2222-4333-8444-555555555555";
+    const newUdid = "2A9D41E0-E031-4AD0-A8B5-847480802E8E";
+    let listCount = 0;
+    const run = vi.fn<IOSSimulatorCommandRunner["run"]>(
+      async (_command, args) => {
+        if (args[1] === "list") {
+          listCount += 1;
+          return {
+            stdout: devicesJson([
+              {
+                udid: UDID,
+                name: oldMarkerName,
+                deviceTypeIdentifier: null,
+              },
+            ]),
+            stderr: "",
+            exitCode: 0,
+          };
+        }
+        if (args[1] === "create") {
+          return { stdout: `${newUdid}\n`, stderr: "", exitCode: 0 };
+        }
+        if (args[1] === "rename") {
+          return { stdout: "", stderr: "", exitCode: 0 };
+        }
+        throw new Error(`unexpected ${args.join(" ")}`);
+      },
+    );
+    const evidence = createEvidenceSpy();
+    const lifecycle = createIOSSimulatorSimctlLifecycle({
+      commandRunner: { run },
+      createMarkerNamespace: "profilealpha",
+      pendingCreateEvidence: evidence,
+    });
+
+    await expect(
+      lifecycle.recoverPendingCreatesAtStartup?.([]),
+    ).resolves.toEqual({ recovered: [], complete: false });
+    expect(listCount).toBe(2);
+
+    const created = await lifecycle.createExact({
+      name: "Cindy iPhone",
+      deviceTypeIdentifier: DEVICE_TYPE,
+      runtimeIdentifier: RUNTIME,
+    });
+    await lifecycle.renameExact?.(created.udid, "Cindy iPhone");
+
+    expect(evidence.cleared).toEqual([]);
+  });
+
   it("cancels create and deletes only an exact late-created UDID", async () => {
     const controller = new AbortController();
     const reason = new Error("create cancelled for exit");

--- a/packages/ios-simulator-runtime/src/simctl-lifecycle.test.ts
+++ b/packages/ios-simulator-runtime/src/simctl-lifecycle.test.ts
@@ -969,4 +969,39 @@ describe("createIOSSimulatorSimctlLifecycle", () => {
     });
     expect(run).not.toHaveBeenCalled();
   });
+
+  it("arms interrupted-create evidence before issuing simctl create", async () => {
+    const events: string[] = [];
+    const run = vi.fn<IOSSimulatorCommandRunner["run"]>(
+      async (_command, args) => {
+        events.push(`run:${args[1]}`);
+        if (args[1] === "create") {
+          return { stdout: "", stderr: "interrupted", exitCode: 1 };
+        }
+        return { stdout: devicesJson([]), stderr: "", exitCode: 0 };
+      },
+    );
+    const arm = vi.fn(() => {
+      events.push("arm");
+    });
+    const lifecycle = createIOSSimulatorSimctlLifecycle({
+      commandRunner: { run },
+      createMarkerNamespace: "testprofile",
+      pendingCreateEvidence: { arm },
+    });
+
+    // A create that fails once CoreSimulator may already have committed the
+    // device must still leave startup-recovery evidence behind.
+    await expect(
+      lifecycle.createExact({
+        name: "Cindy iPhone",
+        deviceTypeIdentifier: DEVICE_TYPE,
+        runtimeIdentifier: RUNTIME,
+      }),
+    ).rejects.toMatchObject({ code: "SIMULATOR_CREATE_FAILED" });
+
+    expect(arm).toHaveBeenCalledOnce();
+    expect(events[0]).toBe("arm");
+    expect(events).toContain("run:create");
+  });
 });

--- a/packages/ios-simulator-runtime/src/simctl-lifecycle.test.ts
+++ b/packages/ios-simulator-runtime/src/simctl-lifecycle.test.ts
@@ -16,7 +16,8 @@ function devicesJson(
     udid: string;
     name: string;
     state?: string;
-    deviceTypeIdentifier?: string;
+    /** `null` reproduces a listing that omits the device type. */
+    deviceTypeIdentifier?: string | null;
   }>,
 ): string {
   return JSON.stringify({
@@ -33,7 +34,11 @@ function devicesJson(
         ...device,
         state: device.state ?? "Shutdown",
         isAvailable: true,
-        deviceTypeIdentifier: device.deviceTypeIdentifier ?? DEVICE_TYPE,
+        ...(device.deviceTypeIdentifier === null
+          ? {}
+          : {
+              deviceTypeIdentifier: device.deviceTypeIdentifier ?? DEVICE_TYPE,
+            }),
       })),
     },
   });
@@ -1047,6 +1052,53 @@ describe("createIOSSimulatorSimctlLifecycle", () => {
 
     expect(evidence.armed).toBe(1);
     expect(evidence.cleared).toEqual([]);
+  });
+
+  it("keeps evidence when a marker device exists but cannot be attributed", async () => {
+    let markerName = "";
+    const run = vi.fn<IOSSimulatorCommandRunner["run"]>(async (_command, args) => {
+      if (args[1] === "create") {
+        markerName = args[2]!;
+        return { stdout: "", stderr: "interrupted", exitCode: 1 };
+      }
+      if (args[1] === "list") {
+        // The device really was committed under this exact random marker, but the
+        // listing omits its device type, so it cannot be uniquely recovered.
+        return {
+          stdout: devicesJson([
+            { udid: UDID, name: markerName, deviceTypeIdentifier: null },
+          ]),
+          stderr: "",
+          exitCode: 0,
+        };
+      }
+      return { stdout: "", stderr: "", exitCode: 0 };
+    });
+    const evidence = createEvidenceSpy();
+    const lifecycle = createIOSSimulatorSimctlLifecycle({
+      commandRunner: { run },
+      createMarkerNamespace: "testprofile",
+      pendingCreateEvidence: evidence,
+    });
+
+    await expect(
+      lifecycle.createExact({
+        name: "Cindy iPhone",
+        deviceTypeIdentifier: DEVICE_TYPE,
+        runtimeIdentifier: RUNTIME,
+      }),
+    ).rejects.toMatchObject({ code: "SIMULATOR_CREATE_FAILED" });
+
+    // Retiring here would strand a hidden simulator: empty registry plus no
+    // evidence means the next startup skips recovery entirely.
+    expect(evidence.armed).toBe(1);
+    expect(evidence.cleared).toEqual([]);
+    // Attribution stayed strict, so nothing was deleted on a guess.
+    expect(run).not.toHaveBeenCalledWith(
+      "/usr/bin/xcrun",
+      ["simctl", "delete", UDID],
+      expect.anything(),
+    );
   });
 
   it("retires evidence when a failed create is rolled back", async () => {

--- a/packages/ios-simulator-runtime/src/simctl-lifecycle.test.ts
+++ b/packages/ios-simulator-runtime/src/simctl-lifecycle.test.ts
@@ -43,6 +43,23 @@ function listJson(state: string): string {
   return devicesJson([{ udid: UDID, name: "iPhone 17 Pro", state }]);
 }
 
+/** Records the arm/retire calls a lifecycle makes on the create breadcrumb. */
+function createEvidenceSpy(events?: string[]) {
+  const spy = {
+    armed: 0,
+    cleared: [] as number[],
+    arm(): number {
+      spy.armed += 1;
+      events?.push("arm");
+      return spy.armed;
+    },
+    clearIfUnchanged(generation: number): void {
+      spy.cleared.push(generation);
+    },
+  };
+  return spy;
+}
+
 describe("createIOSSimulatorSimctlLifecycle", () => {
   it("boots and polls an exact UDID until bootstatus succeeds", async () => {
     let now = 0;
@@ -981,13 +998,11 @@ describe("createIOSSimulatorSimctlLifecycle", () => {
         return { stdout: devicesJson([]), stderr: "", exitCode: 0 };
       },
     );
-    const arm = vi.fn(() => {
-      events.push("arm");
-    });
+    const evidence = createEvidenceSpy(events);
     const lifecycle = createIOSSimulatorSimctlLifecycle({
       commandRunner: { run },
       createMarkerNamespace: "testprofile",
-      pendingCreateEvidence: { arm },
+      pendingCreateEvidence: evidence,
     });
 
     // A create that fails once CoreSimulator may already have committed the
@@ -1000,8 +1015,146 @@ describe("createIOSSimulatorSimctlLifecycle", () => {
       }),
     ).rejects.toMatchObject({ code: "SIMULATOR_CREATE_FAILED" });
 
-    expect(arm).toHaveBeenCalledOnce();
     expect(events[0]).toBe("arm");
     expect(events).toContain("run:create");
+    // The post-create list proved nothing was committed, so the profile must not
+    // keep paying a startup sweep that has nothing to clean.
+    expect(evidence.cleared).toEqual([1]);
+  });
+
+  it("keeps evidence when a failed create cannot be verified", async () => {
+    const run = vi.fn<IOSSimulatorCommandRunner["run"]>(async (_command, args) => {
+      if (args[1] === "create") {
+        return { stdout: "", stderr: "interrupted", exitCode: 1 };
+      }
+      // The verification list itself fails: nothing is proven either way.
+      return { stdout: "", stderr: "list failed", exitCode: 1 };
+    });
+    const evidence = createEvidenceSpy();
+    const lifecycle = createIOSSimulatorSimctlLifecycle({
+      commandRunner: { run },
+      createMarkerNamespace: "testprofile",
+      pendingCreateEvidence: evidence,
+    });
+
+    await expect(
+      lifecycle.createExact({
+        name: "Cindy iPhone",
+        deviceTypeIdentifier: DEVICE_TYPE,
+        runtimeIdentifier: RUNTIME,
+      }),
+    ).rejects.toMatchObject({ code: "SIMULATOR_CREATE_FAILED" });
+
+    expect(evidence.armed).toBe(1);
+    expect(evidence.cleared).toEqual([]);
+  });
+
+  it("retires evidence when a failed create is rolled back", async () => {
+    let markerName = "";
+    const run = vi.fn<IOSSimulatorCommandRunner["run"]>(async (_command, args) => {
+      if (args[1] === "create") {
+        markerName = args[2]!;
+        return { stdout: "", stderr: "cancelled", exitCode: 1 };
+      }
+      if (args[1] === "list") {
+        return {
+          stdout: devicesJson([{ udid: UDID, name: markerName }]),
+          stderr: "",
+          exitCode: 0,
+        };
+      }
+      return { stdout: "", stderr: "", exitCode: 0 };
+    });
+    const evidence = createEvidenceSpy();
+    const lifecycle = createIOSSimulatorSimctlLifecycle({
+      commandRunner: { run },
+      createMarkerNamespace: "testprofile",
+      pendingCreateEvidence: evidence,
+    });
+
+    await expect(
+      lifecycle.createExact({
+        name: "Cindy iPhone",
+        deviceTypeIdentifier: DEVICE_TYPE,
+        runtimeIdentifier: RUNTIME,
+      }),
+    ).rejects.toMatchObject({ code: "SIMULATOR_CREATE_FAILED" });
+
+    expect(run).toHaveBeenCalledWith(
+      "/usr/bin/xcrun",
+      ["simctl", "delete", UDID],
+      expect.objectContaining({ timeoutMs: expect.any(Number) }),
+    );
+    expect(evidence.cleared).toEqual([1]);
+  });
+
+  it("retires evidence once a created device is renamed away from its marker", async () => {
+    const run = vi.fn<IOSSimulatorCommandRunner["run"]>(async (_command, args) => {
+      if (args[1] === "create") {
+        return { stdout: `${UDID}\n`, stderr: "", exitCode: 0 };
+      }
+      return { stdout: "", stderr: "", exitCode: 0 };
+    });
+    const evidence = createEvidenceSpy();
+    const lifecycle = createIOSSimulatorSimctlLifecycle({
+      commandRunner: { run },
+      createMarkerNamespace: "testprofile",
+      pendingCreateEvidence: evidence,
+    });
+
+    const created = await lifecycle.createExact({
+      name: "Cindy iPhone",
+      deviceTypeIdentifier: DEVICE_TYPE,
+      runtimeIdentifier: RUNTIME,
+    });
+    // The caller persists ownership before finalizing the name, so evidence is
+    // still required here.
+    expect(evidence.cleared).toEqual([]);
+
+    await lifecycle.renameExact?.(created.udid, "Cindy iPhone");
+    expect(evidence.cleared).toEqual([1]);
+  });
+
+  it("keeps evidence while another create is still inside its ownership window", async () => {
+    let creates = 0;
+    const run = vi.fn<IOSSimulatorCommandRunner["run"]>(async (_command, args) => {
+      if (args[1] === "create") {
+        creates += 1;
+        return creates === 1
+          ? { stdout: `${UDID}\n`, stderr: "", exitCode: 0 }
+          : { stdout: "", stderr: "blocked", exitCode: 1 };
+      }
+      if (args[1] === "list") {
+        return { stdout: devicesJson([]), stderr: "", exitCode: 0 };
+      }
+      return { stdout: "", stderr: "", exitCode: 0 };
+    });
+    const evidence = createEvidenceSpy();
+    const lifecycle = createIOSSimulatorSimctlLifecycle({
+      commandRunner: { run },
+      createMarkerNamespace: "testprofile",
+      pendingCreateEvidence: evidence,
+    });
+
+    const first = await lifecycle.createExact({
+      name: "Cindy iPhone",
+      deviceTypeIdentifier: DEVICE_TYPE,
+      runtimeIdentifier: RUNTIME,
+    });
+
+    // A second create fails cleanly while the first is still between create and
+    // its ownership write. Retiring now would strand the first marker.
+    await expect(
+      lifecycle.createExact({
+        name: "Cindy iPhone 2",
+        deviceTypeIdentifier: DEVICE_TYPE,
+        runtimeIdentifier: RUNTIME,
+      }),
+    ).rejects.toMatchObject({ code: "SIMULATOR_CREATE_FAILED" });
+    expect(evidence.armed).toBe(2);
+    expect(evidence.cleared).toEqual([]);
+
+    await lifecycle.renameExact?.(first.udid, "Cindy iPhone");
+    expect(evidence.cleared).toEqual([2]);
   });
 });

--- a/packages/ios-simulator-runtime/src/simctl-lifecycle.test.ts
+++ b/packages/ios-simulator-runtime/src/simctl-lifecycle.test.ts
@@ -438,7 +438,7 @@ describe("createIOSSimulatorSimctlLifecycle", () => {
 
     await expect(
       lifecycle.recoverPendingCreatesAtStartup?.([]),
-    ).resolves.toEqual([UDID]);
+    ).resolves.toEqual({ recovered: [UDID], complete: true });
     expect(run.mock.calls.filter(([, args]) => args[1] === "delete")).toEqual([
       expect.arrayContaining(["/usr/bin/xcrun", ["simctl", "delete", UDID]]),
     ]);
@@ -540,7 +540,7 @@ describe("createIOSSimulatorSimctlLifecycle", () => {
       lifecycle.recoverPendingCreatesAtStartup?.([
         { udid: ownedUdid, name: "Cindy Restored iPhone" },
       ]),
-    ).resolves.toEqual([UDID, ownedUdid]);
+    ).resolves.toEqual({ recovered: [UDID, ownedUdid], complete: true });
     expect(run.mock.calls.filter(([, args]) => args[1] === "delete")).toEqual([
       expect.arrayContaining(["/usr/bin/xcrun", ["simctl", "delete", UDID]]),
     ]);
@@ -591,7 +591,43 @@ describe("createIOSSimulatorSimctlLifecycle", () => {
 
     await expect(
       lifecycle.recoverPendingCreatesAtStartup?.([]),
-    ).resolves.toEqual([]);
+    ).resolves.toEqual({ recovered: [], complete: false });
+    expect(
+      run.mock.calls.filter(([, args]) => args[1] === "list"),
+    ).toHaveLength(2);
+    expect(run.mock.calls.filter(([, args]) => args[1] === "delete")).toEqual(
+      [],
+    );
+  });
+
+  it("reports incomplete startup recovery when marker metadata is missing", async () => {
+    const markerName =
+      "__CindyPending__profilealpha__11111111-2222-4333-8444-555555555555";
+    const run = vi.fn<IOSSimulatorCommandRunner["run"]>(
+      async (_command, args) => {
+        if (args[1] === "list") {
+          return {
+            stdout: devicesJson([
+              { udid: UDID, name: markerName, deviceTypeIdentifier: null },
+            ]),
+            stderr: "",
+            exitCode: 0,
+          };
+        }
+        if (args[1] === "delete") {
+          return { stdout: "", stderr: "", exitCode: 0 };
+        }
+        throw new Error(`unexpected ${args.join(" ")}`);
+      },
+    );
+    const lifecycle = createIOSSimulatorSimctlLifecycle({
+      commandRunner: { run },
+      createMarkerNamespace: "profilealpha",
+    });
+
+    await expect(
+      lifecycle.recoverPendingCreatesAtStartup?.([]),
+    ).resolves.toEqual({ recovered: [], complete: false });
     expect(
       run.mock.calls.filter(([, args]) => args[1] === "list"),
     ).toHaveLength(2);

--- a/packages/ios-simulator-runtime/src/simctl-lifecycle.ts
+++ b/packages/ios-simulator-runtime/src/simctl-lifecycle.ts
@@ -552,6 +552,10 @@ export function createIOSSimulatorSimctlLifecycle(
    */
   const pendingCreateMarkers = new Map<string, string | null>();
   let lastArmedEvidenceGeneration = 0;
+  // Evidence may predate this lifecycle. If startup recovery could not prove
+  // that older marker is gone, a later create must not retire the shared file
+  // merely because its own marker settled successfully.
+  let startupRecoveryIncomplete = false;
 
   function armPendingCreateMarker(markerName: string): void {
     if (!pendingCreateEvidence) return;
@@ -568,7 +572,7 @@ export function createIOSSimulatorSimctlLifecycle(
   function settlePendingCreateMarker(markerName: string): void {
     if (!pendingCreateEvidence) return;
     if (!pendingCreateMarkers.delete(markerName)) return;
-    if (pendingCreateMarkers.size > 0) return;
+    if (pendingCreateMarkers.size > 0 || startupRecoveryIncomplete) return;
     // The newest arm is the generation the file now carries, so retiring against
     // it is a no-op if anything armed the breadcrumb outside this lifecycle.
     pendingCreateEvidence.clearIfUnchanged(lastArmedEvidenceGeneration);
@@ -976,9 +980,15 @@ export function createIOSSimulatorSimctlLifecycle(
           requireIdentifier(device.name, "name"),
         ]),
       );
-      const pending = (await list(signal)).filter((device) =>
-        isPendingCreateName(device.name),
-      );
+      let pending: IOSSimulatorDevice[];
+      try {
+        pending = (await list(signal)).filter((device) =>
+          isPendingCreateName(device.name),
+        );
+      } catch (error) {
+        startupRecoveryIncomplete = true;
+        throw error;
+      }
       const recovered: string[] = [];
       let complete = true;
       let firstFailure: unknown = null;
@@ -1013,11 +1023,18 @@ export function createIOSSimulatorSimctlLifecycle(
           await cleanupFailedCreate(udid, signal);
           recovered.push(udid);
         } catch (error) {
-          if (signal?.aborted) throwIfAborted(signal);
+          if (signal?.aborted) {
+            startupRecoveryIncomplete = true;
+            throwIfAborted(signal);
+          }
           firstFailure ??= error;
         }
       }
-      if (firstFailure !== null) throw firstFailure;
+      if (firstFailure !== null) {
+        startupRecoveryIncomplete = true;
+        throw firstFailure;
+      }
+      startupRecoveryIncomplete = !complete;
       return { recovered, complete };
     },
 

--- a/packages/ios-simulator-runtime/src/simctl-lifecycle.ts
+++ b/packages/ios-simulator-runtime/src/simctl-lifecycle.ts
@@ -51,6 +51,13 @@ export interface IOSSimulatorSimctlLifecycleOptions {
   pendingCreateEvidence?: IOSSimulatorPendingCreateEvidence;
 }
 
+export interface IOSSimulatorPendingCreateRecoveryResult {
+  /** Marker UUIDs that were renamed or deleted during the sweep. */
+  recovered: readonly string[];
+  /** False when a marker was observed but could not be safely attributed. */
+  complete: boolean;
+}
+
 /**
  * Carries the exact device identity when a failed or aborted `simctl create`
  * produced a device but its immediate compensating delete also failed. The
@@ -151,7 +158,7 @@ export interface IOSSimulatorSimctlLifecycle {
   recoverPendingCreatesAtStartup?(
     ownedDevices: readonly { udid: string; name: string }[],
     signal?: AbortSignal,
-  ): Promise<readonly string[]>;
+  ): Promise<IOSSimulatorPendingCreateRecoveryResult>;
   deleteExact(udid: string, signal?: AbortSignal): Promise<void>;
   /** Set the simulated system appearance without bringing Simulator.app forward. */
   setAppearance?(
@@ -962,7 +969,7 @@ export function createIOSSimulatorSimctlLifecycle(
     async recoverPendingCreatesAtStartup(
       ownedDevices,
       signal,
-    ): Promise<readonly string[]> {
+    ): Promise<IOSSimulatorPendingCreateRecoveryResult> {
       const owned = new Map(
         ownedDevices.map((device) => [
           requireUdid(device.udid),
@@ -973,6 +980,7 @@ export function createIOSSimulatorSimctlLifecycle(
         isPendingCreateName(device.name),
       );
       const recovered: string[] = [];
+      let complete = true;
       let firstFailure: unknown = null;
       for (const device of pending) {
         const udid = device.udid.toUpperCase();
@@ -993,8 +1001,13 @@ export function createIOSSimulatorSimctlLifecycle(
             current.name !== device.name ||
             !isPendingCreateName(current.name) ||
             current.runtimeIdentifier !== device.runtimeIdentifier ||
+            current.deviceTypeIdentifier === null ||
             current.deviceTypeIdentifier !== device.deviceTypeIdentifier
           ) {
+            // We deliberately avoid deleting a marker whose identity changed or
+            // whose metadata is incomplete. That is not a completed sweep: the
+            // breadcrumb must survive so a later startup can retry the cleanup.
+            complete = false;
             continue;
           }
           await cleanupFailedCreate(udid, signal);
@@ -1005,7 +1018,7 @@ export function createIOSSimulatorSimctlLifecycle(
         }
       }
       if (firstFailure !== null) throw firstFailure;
-      return recovered;
+      return { recovered, complete };
     },
 
     async deleteExact(udid, signal): Promise<void> {

--- a/packages/ios-simulator-runtime/src/simctl-lifecycle.ts
+++ b/packages/ios-simulator-runtime/src/simctl-lifecycle.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import { createNodeIOSSimulatorCommandRunner } from "./command-runner.js";
 import { IOSSimulatorInstanceError } from "./instance-errors.js";
 import type { IOSSimulatorCreatedDevice } from "./instance-types.js";
+import type { IOSSimulatorPendingCreateEvidence } from "./pending-create-evidence-file.js";
 import { parseSimctlListJson } from "./simctl-parser.js";
 import type {
   IOSSimulatorCommandResult,
@@ -42,6 +43,12 @@ export interface IOSSimulatorSimctlLifecycleOptions {
   pollIntervalMs?: number;
   /** Stable, non-secret profile identity used to recover interrupted creates. */
   createMarkerNamespace?: string;
+  /**
+   * Host-owned breadcrumb armed before every `simctl create`. It is what lets
+   * recovery stay off the CoreSimulator path until this profile has actually
+   * created a device.
+   */
+  pendingCreateEvidence?: IOSSimulatorPendingCreateEvidence;
 }
 
 /**
@@ -502,6 +509,7 @@ export function createIOSSimulatorSimctlLifecycle(
     options.createMarkerNamespace ?? randomUUID().replaceAll("-", ""),
   );
   const createMarkerPrefix = `${CREATE_MARKER_PREFIX}${createMarkerNamespace}__`;
+  const pendingCreateEvidence = options.pendingCreateEvidence ?? null;
   if (bootTimeoutMs <= 0 || pollIntervalMs <= 0) {
     throw new IOSSimulatorInstanceError(
       "INVALID_ARGUMENT",
@@ -745,6 +753,10 @@ export function createIOSSimulatorSimctlLifecycle(
       );
       const markerName = `${createMarkerPrefix}${randomUUID()}`;
       throwIfAborted(signal);
+      // Arm before CoreSimulator can commit the device: everything after this
+      // point may leave a hidden marker behind if the process dies, and the
+      // breadcrumb is the only thing that survives to prove it.
+      pendingCreateEvidence?.arm();
       let result: IOSSimulatorCommandResult | null = null;
       let commandError: unknown = null;
       try {

--- a/packages/ios-simulator-runtime/src/simctl-lifecycle.ts
+++ b/packages/ios-simulator-runtime/src/simctl-lifecycle.ts
@@ -534,6 +534,50 @@ export function createIOSSimulatorSimctlLifecycle(
     );
   }
 
+  /**
+   * Markers minted by this process that may still exist in CoreSimulator. A
+   * marker stays pending from the moment `simctl create` can commit a device
+   * until that device is proven renamed away or deleted — a span that covers the
+   * caller's ownership write, which is the window the breadcrumb exists for.
+   *
+   * The breadcrumb may only be retired while this map is empty: another create
+   * still inside that window needs the same evidence to survive a crash.
+   */
+  const pendingCreateMarkers = new Map<string, string | null>();
+  let lastArmedEvidenceGeneration = 0;
+
+  function armPendingCreateMarker(markerName: string): void {
+    if (!pendingCreateEvidence) return;
+    lastArmedEvidenceGeneration = pendingCreateEvidence.arm();
+    pendingCreateMarkers.set(markerName, null);
+  }
+
+  function bindPendingCreateMarker(markerName: string, udid: string): void {
+    if (!pendingCreateMarkers.has(markerName)) return;
+    pendingCreateMarkers.set(markerName, udid.toUpperCase());
+  }
+
+  /** Only call from a path that proves this exact marker no longer exists. */
+  function settlePendingCreateMarker(markerName: string): void {
+    if (!pendingCreateEvidence) return;
+    if (!pendingCreateMarkers.delete(markerName)) return;
+    if (pendingCreateMarkers.size > 0) return;
+    // The newest arm is the generation the file now carries, so retiring against
+    // it is a no-op if anything armed the breadcrumb outside this lifecycle.
+    pendingCreateEvidence.clearIfUnchanged(lastArmedEvidenceGeneration);
+  }
+
+  function settlePendingCreateMarkerForDevice(udid: string): void {
+    if (pendingCreateMarkers.size === 0) return;
+    const normalized = udid.toUpperCase();
+    for (const [markerName, markerUdid] of pendingCreateMarkers) {
+      if (markerUdid === normalized) {
+        settlePendingCreateMarker(markerName);
+        return;
+      }
+    }
+  }
+
   async function cleanupFailedCreate(
     udid: string,
     signal?: AbortSignal,
@@ -554,17 +598,23 @@ export function createIOSSimulatorSimctlLifecycle(
     }
   }
 
+  /**
+   * `verified` separates "this profile provably created nothing" from "the check
+   * itself could not run". Only the former may retire create evidence.
+   */
   async function recoverCreatedMarker(
     markerName: string,
     deviceTypeIdentifier: string,
     runtimeIdentifier: string,
     signal: AbortSignal,
-  ): Promise<IOSSimulatorDevice | null> {
+  ): Promise<{ device: IOSSimulatorDevice | null; verified: boolean }> {
     const result = await runner.run(XCRUN, ["simctl", "list", "-j"], {
       timeoutMs: CREATE_ABORT_CLEANUP_TIMEOUT_MS,
       signal,
     });
-    if (result.exitCode !== 0 || signal.aborted) return null;
+    if (result.exitCode !== 0 || signal.aborted) {
+      return { device: null, verified: false };
+    }
     const candidates = parseSimctlListJson(result.stdout).devices.filter(
       (device) =>
         device.name === markerName &&
@@ -572,7 +622,10 @@ export function createIOSSimulatorSimctlLifecycle(
         device.deviceTypeIdentifier === deviceTypeIdentifier &&
         UUID_PATTERN.test(device.udid.toUpperCase()),
     );
-    return candidates.length === 1 ? candidates[0]! : null;
+    if (candidates.length === 1) return { device: candidates[0]!, verified: true };
+    // Zero candidates proves nothing was committed under this exact marker.
+    // Multiple candidates cannot be attributed to this operation.
+    return { device: null, verified: candidates.length === 0 };
   }
 
   async function list(signal?: AbortSignal): Promise<IOSSimulatorDevice[]> {
@@ -620,6 +673,11 @@ export function createIOSSimulatorSimctlLifecycle(
         "The newly created iOS Simulator could not be named.",
         true,
       );
+    }
+    // The caller persists ownership before finalizing the name, so a marker that
+    // is renamed away is both recorded and no longer sweepable.
+    if (!isPendingCreateName(targetName)) {
+      settlePendingCreateMarkerForDevice(normalized);
     }
   }
 
@@ -756,7 +814,7 @@ export function createIOSSimulatorSimctlLifecycle(
       // Arm before CoreSimulator can commit the device: everything after this
       // point may leave a hidden marker behind if the process dies, and the
       // breadcrumb is the only thing that survives to prove it.
-      pendingCreateEvidence?.arm();
+      armPendingCreateMarker(markerName);
       let result: IOSSimulatorCommandResult | null = null;
       let commandError: unknown = null;
       try {
@@ -786,6 +844,7 @@ export function createIOSSimulatorSimctlLifecycle(
             deviceTypeIdentifier,
           }
         : null;
+      if (createdDevice) bindPendingCreateMarker(markerName, createdDevice.udid);
       const createFailure =
         commandError ??
         (result?.exitCode !== 0
@@ -814,13 +873,18 @@ export function createIOSSimulatorSimctlLifecycle(
             runtimeIdentifier,
             cleanupController.signal,
           );
-          if (recovered) {
+          if (recovered.device) {
             createdDevice = {
-              udid: recovered.udid.toUpperCase(),
+              udid: recovered.device.udid.toUpperCase(),
               name: markerName,
               runtimeIdentifier,
               deviceTypeIdentifier,
             };
+            bindPendingCreateMarker(markerName, createdDevice.udid);
+          } else if (recovered.verified) {
+            // This create provably left nothing behind, so it must not keep the
+            // profile paying a startup sweep it cannot clean anything with.
+            settlePendingCreateMarker(markerName);
           }
         } catch {
           // The marker is profile-scoped and remains recoverable on startup.
@@ -834,6 +898,8 @@ export function createIOSSimulatorSimctlLifecycle(
             createdDevice.udid,
             cleanupController?.signal,
           );
+          // The compensating delete succeeded, so this marker is gone.
+          settlePendingCreateMarker(markerName);
         } catch (error) {
           throw new IOSSimulatorCreateCleanupRequiredError(
             createdDevice,
@@ -950,6 +1016,8 @@ export function createIOSSimulatorSimctlLifecycle(
           "The iOS Simulator device could not be deleted.",
         );
       }
+      // A rolled-back create leaves nothing for a sweep to find either.
+      settlePendingCreateMarkerForDevice(normalized);
     },
 
     async setAppearance(udid, appearance, signal): Promise<void> {

--- a/packages/ios-simulator-runtime/src/simctl-lifecycle.ts
+++ b/packages/ios-simulator-runtime/src/simctl-lifecycle.ts
@@ -615,17 +615,24 @@ export function createIOSSimulatorSimctlLifecycle(
     if (result.exitCode !== 0 || signal.aborted) {
       return { device: null, verified: false };
     }
-    const candidates = parseSimctlListJson(result.stdout).devices.filter(
+    // The marker name is random and profile-scoped, so its presence alone proves
+    // CoreSimulator committed something for this operation. Verification must key
+    // on that name only: `deviceTypeIdentifier` is nullable in a listing, so a
+    // metadata mismatch would otherwise be read as "nothing was created" and
+    // retire the recovery evidence for a device that really exists.
+    const named = parseSimctlListJson(result.stdout).devices.filter(
+      (device) => device.name === markerName,
+    );
+    const candidates = named.filter(
       (device) =>
-        device.name === markerName &&
         device.runtimeIdentifier === runtimeIdentifier &&
         device.deviceTypeIdentifier === deviceTypeIdentifier &&
         UUID_PATTERN.test(device.udid.toUpperCase()),
     );
+    // Deletion keeps the stricter identity rule; only a listing without this
+    // exact name proves nothing needs recovering.
     if (candidates.length === 1) return { device: candidates[0]!, verified: true };
-    // Zero candidates proves nothing was committed under this exact marker.
-    // Multiple candidates cannot be attributed to this operation.
-    return { device: null, verified: candidates.length === 0 };
+    return { device: null, verified: named.length === 0 };
   }
 
   async function list(signal?: AbortSignal): Promise<IOSSimulatorDevice[]> {


### PR DESCRIPTION
## 这次改了什么

### 摘要

用户反馈：刚装好/刚启动 Cindy 就被 macOS 弹窗请求了几个 Xcode 相关权限，而他并没有要用 iOS 模拟器。

原因是启动链路上有一次无条件的模拟器清扫：账号库就绪后 `registerLocalDbIpc` 的 `onReady` 会调
`reconcilePersistedIOSSimulatorOwnership`，它在 macOS 上一律拿 writer 租约、读 ownership registry，
并且**即使一台持久化设备都没有**也会做一次 profile pending-create 清扫 → 拉起
`/usr/bin/xcrun simctl list -j` 子进程。子进程的 TCC 归因是 Cindy 自己，而它要读 Xcode 名下的
数据目录（`~/Library/Developer/CoreSimulator`、`~/Library/Developer/Xcode`），于是 macOS 在与
用户动作完全无关的启动期弹出 Xcode 数据（App Data）授权。有持久化设备时启动还会继续跑
`reconcilePendingCreates`、`xcode-select -p` / `xcodebuild -version` / 再一次设备列举，以及逐实例的
设备与 WDA 回收。

这次让启动清扫**只在这个 profile 真的可能留下东西时才发生**：

- 新增 profile 级 interrupted-create 面包屑（与 ownership registry 同目录的
  `pending-create-evidence.json`）。它在设备创建命令拉起**之前**落盘——那之后的任何崩溃都可能留下
  隐藏的 create marker，面包屑是唯一能活下来的证据。清扫成功后按 generation 比对清除，因此清扫
  期间新发起的创建不会被同一次清扫误清。
- 启动恢复只在「有持久化设备」或「面包屑已武装」时才构造 lifecycle 并清扫。两者都没有的 profile
  在启动期完全不碰 xcrun / CoreSimulator。
- Host 内那次一次性清扫沿用同一个面包屑，所以设备全部释放后，启动会重新回到安静状态，不会
  「用过一次就永久留下启动期探测」。

同一条原则在本仓已有先例：`docs/dev-rules/credentials-and-local-storage.md` 明确禁止在启动路径
主动探测 `safeStorage.isEncryptionAvailable()`，理由正是「探测本身会把弹窗时机提前到与用户动作
无关的启动期」。

### 摘要（二）：空转的归属清扫会作废 Agent 刚读到的路由

同一条启动/清扫链路上的第二个缺陷，实机排查内嵌模拟器完全无法启动时定位到。

`reconcilePersistedOwnership` 在**每次工具分派前**都会跑，而
`IOSSimulatorInstanceActor.reconcile()` 无条件做三件事：`generation + 1`、`renew()` 换新
lease id、把 `viewerState` 置回 `detached`——即使这一轮从 CoreSimulator 观测到的状态和已存状态
完全一样。

后果是调用方永远拿不到可用路由：读到 `(gen N, lease L_N)` 后，下一次调用的清扫先把它变成
`(N+1, L_{N+1})` 再校验，回传 `N` 得 `STALE_GENERATION`，补成 `N+1` 得 `LEASE_EXPIRED`，而
`L_{N+1}` 从不返回给调用方。**没有任何取值组合能同时过两道校验**，所有路由型工具 100% 失败。

放大成永久故障的是闩锁：只要 registry 里有任何一条清扫处理不掉的绑定，`complete` 就是 false，
`ownershipReconciledScopeKey` 永远合不上，于是每次调用都重跑全量清扫，上述作废每次都发生。
实测本机三条绑定：两条外来会话的 `generation` 冻在 44 / 31（`getSession` 抛错 → 提前 return），
自己会话的一路递增到 21——正是这个分支分裂的指纹。

- `reconcile()` 观测到无变化时原样返回当前快照：不涨 generation、不换 lease、不动
  `viewerState`，也不再取消进行中的 agent mutation（没变化就不该取消，这是附带修复）。
- 新增 `normalizeViewerState` 选项保留唯一合法的那次纠正：owner generation 的首轮清扫仍会修掉
  上一个进程遗留的 `viewerState`；此后的清扫只看 CoreSimulator，对 viewer 附着没有证据，不再
  踢掉活着的 viewer（这正是 viewer 每隔几秒掉线的原因）。
- 待处理的 detach grace 不走空转路径：在本进程重新武装那个 deadline 本身就是一次状态迁移，
  仍旧签发新路由。
- **重试语义一点没动**：不完整的清扫下次分派照旧重跑（`ios-simulator.test.ts` 的
  `degraded → healthy` 恢复用例依赖它），只是不再作废它没有改动的路由。

两个缺陷放在同一个 PR：都在这条清扫路径上，改的是同一个文件与同一个 package，分开提会在
`ios-simulator.ts` 相邻 hunk 上冲突。它们互不取代——摘要（一）的提前 return 条件是
「无持久化设备且面包屑未武装」，本机有三条绑定，对摘要（二）的死锁没有任何缓解作用。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无（来自用户反馈：启动时被请求 Xcode 相关权限，希望改到真正开模拟器时再请求）
- 本 PR 包含：interrupted-create 面包屑（新模块 + 创建路径接入）、启动恢复的状态门禁、清扫成功后
  retire 面包屑、对应单测；以及「空转的 reconcile 不再作废路由」+ `normalizeViewerState`
  选项 + 对应单测
- 明确不包含：不改模拟器功能本身、不改 Agent/构建审批、不改 viewer 与右侧栏；不动「首次使用时
  用户拒绝授权」的引导文案（既有缺口，见「风险」）
- 用户可见变化（二）：内嵌模拟器从「无法启动」恢复为可用——此前只要机器上存在一条清扫处理不掉的
  绑定（例如已归档会话遗留的设备），启动实例 / 构建 / 安装等全部路由型操作都会以
  `STALE_GENERATION` 或 `LEASE_EXPIRED` 失败；viewer 也不再每隔几秒自己掉线。
- 用户可见变化：从没用过内嵌模拟器的用户，启动不再出现 Xcode 相关授权弹窗；弹窗改在第一次打开
  模拟器面板或 Agent 第一次调模拟器工具时出现。已经授过权的用户升级后无感知，什么都不用重做。
- 是否存在 breaking change：无

### UI 变化

不涉及（未改动任何 renderer / 组件 / 文案路径）。

- 引用的设计规范：不涉及：本 PR 只改 main 进程的启动恢复与共享 package 逻辑，无视觉、交互或文案变化。

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：通过（54 workspace PASS / 0 FAIL，含 apps/desktop 与 packages/ios-simulator-runtime）；
      在最终代码状态上重跑过一次

pnpm --filter desktop run typecheck
结果：通过

pnpm --filter @cindy/ios-simulator-runtime run build   # tsc --noEmit
结果：通过

pnpm check:dco
结果：通过（2 commits signed off，range c7291e9c..0948c585）
```

新增／调整的定向用例：

- `apps/desktop/.../__tests__/ios-simulator.test.ts`
  - 无状态 profile 启动时**不构造 lifecycle**（即不可能拉起 xcrun 子进程）且释放 writer 租约
  - 面包屑已武装时照旧清扫，并在清扫成功后 retire 面包屑
  - 清扫失败时保留面包屑，留给下次启动重试
  - Host 内一次性清扫用同一 generation 调 `clearIfUnchanged`
- `packages/ios-simulator-runtime/src/simctl-lifecycle.test.ts`：创建失败时也已经先 arm 再拉起子进程
- `packages/ios-simulator-runtime/src/pending-create-evidence-file.test.ts`：arm / isArmed /
  generation / clearIfUnchanged 语义，含并发创建不被误清、写盘失败只上报不抛错
- `packages/ios-simulator-runtime/src/instance-actor.test.ts`（摘要二）：无变化的 reconcile 保留
  generation / lease / viewerState 且原路由仍可 `assertRoute`；状态变化仍签发新路由；
  `normalizeViewerState` 仍纠正继承来的 viewerState
- `apps/desktop/.../__tests__/ios-simulator.test.ts`（摘要二回归）：一条 session 读不出来的绑定
  令清扫不完整并在下次分派重跑时，可路由绑定的 generation 与 lease 必须存活

### 手工验证

不涉及。

### 未执行的验证

- 未做实机冷启动验证「启动期确实没有 xcrun 子进程」，也未验证 TCC 弹窗时机。要证明弹窗消失需要
  一台尚未给过 Xcode 授权的机器，或重置本机 TCC 记录——后者会改动开发机的系统授权状态，没有做。
  代码侧的等价证据是「无状态 profile 启动不构造 lifecycle」这条单测。
- 未验证首次使用时用户**拒绝**授权后 `simctl` 的确切返回码与面板文案表现。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：macOS 上的 iOS 模拟器启动恢复路径。写入一个新的 profile 内文件
  （`<userData>/ios-simulator/pending-create-evidence.json`，0o600，只存 version + armedAt，无凭证、
  无路径、无用户内容），仅在设备创建与清扫时读写，且都在既有 ownership writer 租约之下，不新增
  跨进程锁。共享 package 不依赖 Electron，路径由 Desktop 注入，模块 import 时不写盘。
  单写者、崩溃恢复、账号边界 fail-closed 等既有不变量都未改动：面包屑只是给启动清扫多加一个
  「要不要做」的判据，不改清扫本身的语义。
- 回滚 / 降级方式：整体 revert 即可回到「每次启动都清扫」。回滚不需要数据迁移——遗留的面包屑
  文件会被旧代码忽略；旧代码本来就无条件清扫，遗留 marker 照样会被清掉。
- 影响范围（二）：改的是路由契约的失效时机——`generation` / `lease` 只在观测到真实状态迁移时
  推进，不再每次清扫都推进。**收紧的是失效条件，不是校验本身**：`assertMutationRoute` 的三道
  校验一字未改，跨会话归属、owner 边界 fail-closed、单写者租约都未触碰。可以想到的行为边界是
  进程重启后、且绑定状态与重启前完全一致时，重启前的路由仍然有效；这类情形下 WDA 已经不在，
  `healthState` 会变成 `degraded` / `WDA_UNAVAILABLE`，属于状态变化，照旧作废。
- 回滚 / 降级方式（二）：两个修复各自独立，可单独 revert 对应 commit（本 PR 两个 commit
  一一对应），revert 后回到「每次清扫都换路由」，不涉及数据迁移。
- 两个如实的行为边界：
  1. 升级前就残留、且当前没有任何持久化设备的隐藏 create marker（旧版创建中途崩溃留下的），
     不再在启动时清理，改由下次真正使用模拟器时的清扫兜住。这类设备未启动、Cindy 侧列表本来
     就按名字过滤隐藏，但在 Xcode 设备列表里能看到。
  2. 用户在首次开模拟器时拒绝 Xcode 数据授权时，面板走的仍是现有「安装 Xcode / 创建设备」引导
     文案，不会明说权限被拒。这是既有文案缺口，本 PR 未扩范围处理。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（改动语义写在受影响函数的 doc comment 里；无规则文档需要更新）
- [x] 已确认测试结果或说明未执行原因

