### PR TITLE
fix(desktop): 修复分享模式选择框被裁切

### DIFF
--- a/apps/desktop/src/renderer/__tests__/shareSelectionContainment.test.ts
+++ b/apps/desktop/src/renderer/__tests__/shareSelectionContainment.test.ts
@@ -1,0 +1,44 @@
+/**
+ * 回归:分享选择模式在长 assistant 正文末尾动态挂载选择框时,消息 item 不能继续
+ * 使用 content-visibility 的 intrinsic 占位。否则绝对定位的 20px 选择框会按缓存
+ * 盒裁切成近乎不可见的高度。jsdom 不计算这组布局,所以这里锁住 DOM/CSS 契约。
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const readRendererSource = (relativePath: string): string =>
+  readFileSync(resolve(__dirname, '..', relativePath), 'utf8').replace(/\r\n/g, '\n');
+
+const messageStreamSource = readRendererSource('components/chat/MessageStream.tsx');
+const globalsSource = readRendererSource('styles/globals.css');
+
+function cssRuleBody(selector: string): string {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return globalsSource.match(new RegExp(`${escaped}\\s*\\{([\\s\\S]*?)\\}`))?.[1] ?? '';
+}
+
+describe('分享选择模式的消息布局隔离', () => {
+  it('只在分享选择激活时给消息流容器挂状态属性', () => {
+    expect(messageStreamSource).toContain(
+      "data-share-selection-active={shareSelectionActive ? '' : undefined}",
+    );
+  });
+
+  it('常态消息仍保留 content-visibility 性能优化', () => {
+    const rule = cssRuleBody('.msg-stream-items > *');
+
+    expect(rule).toContain('content-visibility: auto;');
+    expect(rule).toContain('contain-intrinsic-size: auto 240px;');
+  });
+
+  it('分享模式下仅让可分享消息使用真实布局盒', () => {
+    const rule = cssRuleBody(
+      '.msg-stream-items[data-share-selection-active] > [data-share-message-id]',
+    );
+
+    expect(rule).toContain('content-visibility: visible;');
+    expect(rule).toContain('contain-intrinsic-size: none;');
+  });
+});

--- a/apps/desktop/src/renderer/components/chat/MessageStream.tsx
+++ b/apps/desktop/src/renderer/components/chat/MessageStream.tsx
@@ -4150,6 +4150,7 @@ export function MessageStream({
               态丢失 / 滚动锚点漂走。 */}
                 <div
                   ref={itemsRef}
+                  data-share-selection-active={shareSelectionActive ? '' : undefined}
                   className={cn(
                     // msg-stream-items:直接子元素(每条 render item 的根节点)带
                     // content-visibility:auto(globals.css)—— 视口外条目跳过布局

--- a/apps/desktop/src/renderer/styles/globals.css
+++ b/apps/desktop/src/renderer/styles/globals.css
@@ -1174,6 +1174,14 @@ body.resizing-pane [data-ghost-webview] {
   contain-intrinsic-size: none;
 }
 
+/* 分享选择模式会在消息 wrapper 左侧动态挂载绝对定位的选择框。该元素需要真实
+   消息盒参与布局与绘制；继续使用视口外 intrinsic 占位会让长消息末尾的选择框
+   被压缩或裁切。仅让可分享消息退出隔离，常态和工具类条目继续保留渲染跳过。 */
+.msg-stream-items[data-share-selection-active] > [data-share-message-id] {
+  content-visibility: visible;
+  contain-intrinsic-size: none;
+}
+
 /* 会话切换 shell-first 帧的品牌加载指示(BrandLoadingMark):
    wordmark 低亮常驻 + 亮带经同形 mask 在字标形状内扫过(Codex Desktop
    startup loader 同构表现)。两条硬约束:


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Desktop 分享选择模式中，长 Assistant 正文左侧的消息选择框被 `content-visibility` 布局隔离裁切、看起来像没有渲染的问题。

分享模式激活时，消息流容器会挂明确状态标记；仅已挂载的可分享消息退出 `content-visibility` 隔离并使用真实布局盒。普通聊天仍保留视口外消息跳过布局与绘制的性能优化。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：用户反馈分享选择模式中，底部长回复没有可见选择框
- 本 PR 包含：分享模式状态标记、可分享消息的 containment 例外、DOM/CSS 契约回归测试
- 明确不包含：WorkGroup 分享语义调整、分享内容范围调整、常态消息性能优化调整
- 用户可见变化：进入分享选择模式后，长消息左侧的选择框完整可见
- 是否存在 breaking change：无

### UI 变化

- macOS Desktop 开发版已手工验证原复现任务；未附截图，因为复现界面包含用户任务内容
- 引用的设计规范：`docs/design-rules/DESIGN.md` §5 Layout Principles（选择框继续使用既有选择列布局）与 §10 Light / Dark Dual-Mode Delivery Gate（未新增颜色或主题分支，布局修复对两种模式共用）

## 怎么验证的

### 自动验证

```text
bash /Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh /Users/dash/Code/Cindy/cindy-fix-share-selection-checkbox-pr
结果：GATE_EXIT=0，完整单元测试门禁通过

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --filter desktop test shareSelectionContainment.test.ts shareSelectionStore.test.ts workGroupDeliveryProse.test.ts
结果：3 个测试文件、29 条测试通过

pnpm --dir apps/desktop exec eslint src/renderer/components/chat/MessageStream.tsx src/renderer/__tests__/shareSelectionContainment.test.ts
结果：通过

pnpm check:dco
结果：1 个提交的 DCO 签名通过
```

### 手工验证

- macOS Desktop 开发版进入原复现任务，对底部长 Assistant 回复执行“分享为图片”
- 修复前选择框状态已选中但可见尺寸被裁成约 `20×1px`；修复后选择框正常显示
- 用户完成复测并确认“OK”
- 发布 worktree 与手工验证 worktree 的 3 个改动文件已逐字比较一致

### 未执行的验证

- 未单独在 Windows 上进行手工目检
- 未分别切换 Light / Dark 做两轮实机目检；本次没有新增颜色或主题条件，二者共用同一布局规则

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：分享选择模式下，已挂载的可分享消息会临时退出 `content-visibility` 隔离

### 影响与回滚

- 影响范围：仅分享选择模式中的可分享消息；退出分享模式后恢复原有 `content-visibility: auto` 性能路径
- 回滚 / 降级方式：移除消息流状态属性及对应 CSS override，即恢复修复前行为
- 不涉及数据库、协议、权限、用户数据、插件兼容或移动端 runtime fingerprint

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次无需额外产品文档，已补回归测试与代码注释）
- [x] 已确认测试结果或说明未执行原因
