### PR TITLE
fix(desktop): allow safe interpreter heredocs

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
@@ -202,6 +202,11 @@ PY`,
     'osascript -e \'tell application "Simulator" to quit\'',
     `python3 -c 'print("ordinary project build")'`,
     `python3 -c 'print("Simulator")'`,
+    `python3 - <<'PY'
+import json
+__import__("json")
+print(json.dumps({"ok": True}))
+PY`,
     `node -e 'console.log("ordinary project build")'`,
     'swift test --filter IOSSimulatorTests',
     'swift build --product IOSSimulatorRuntime',

--- a/apps/desktop/src/main/maker-host/shell-command-policy.ts
+++ b/apps/desktop/src/main/maker-host/shell-command-policy.ts
@@ -1096,6 +1096,30 @@ function containsInterpreterHeredocBypass(command: string): boolean {
   return false;
 }
 
+/**
+ * Heredoc bodies are program text, not shell segments. They have already been
+ * checked for literal Simulator executors above; blank them before the general
+ * shell parser runs so Python/Node syntax cannot be mistaken for a shell
+ * executable or an unresolved expansion.
+ */
+function redactHeredocBodiesForShellParsing(command: string): string {
+  const lines = command.split(/\r?\n/);
+  let delimiter: string | null = null;
+
+  return lines
+    .map((line) => {
+      if (delimiter !== null) {
+        if (line.replace(/^\t+/, '').trim() === delimiter) delimiter = null;
+        return '';
+      }
+
+      const marker = /<<-?\s*(['"]?)([A-Za-z_][A-Za-z0-9_]*)\1/.exec(line);
+      if (marker) delimiter = marker[2]!;
+      return line;
+    })
+    .join('\n');
+}
+
 /** A here-string is executable stdin just like a heredoc or producer pipeline. */
 function containsInterpreterHereStringBypass(command: string): boolean {
   for (const clause of shellClauses(command)) {
@@ -1322,7 +1346,10 @@ export function getDesktopShellCommandPolicy(
   // POSIX shells remove an unquoted backslash-newline before tokenization.
   // Mirror that expansion so the policy cannot be bypassed with continuations.
   const expandedCommand = command.replace(/\\\r?\n/g, '');
-  if (containsSimulatorBypass(expandedCommand)) {
+  if (
+    containsInterpreterHeredocBypass(expandedCommand) ||
+    containsSimulatorBypass(redactHeredocBodiesForShellParsing(expandedCommand))
+  ) {
     return { decision: 'deny', reason: IOS_SIMULATOR_SHELL_DENIAL };
   }
   return undefined;


### PR DESCRIPTION
## 这次改了什么

新增 `redactHeredocBodiesForShellParsing`：在通用 shell 解析前，把 heredoc 正文行清空（保留定界符行），避免 Python/Node 的程序文本被误判为 shell 可执行文件或未解析展开。`containsInterpreterHeredocBypass` 仍先于「真实命令」运行；`containsSimulatorBypass` 改为对「已脱敏 heredoc 正文」的命令运行，保证 Simulator 旁路检测不变的同时不再误伤合法的 interpreter heredoc。

## 怎么验证的

- 新增 `shellCommandPolicy` 用例：`python3 - <<'PY'` 形式的合法 heredoc（含 `__import__("json")`、`json.dumps` 等）不再被拒。
- `pnpm --filter desktop exec vitest run src/main/maker-host/__tests__/shellCommandPolicy.test.ts`

## 风险

- heredoc 正文仍会先经过 `containsInterpreterHeredocBypass` 真实检测；脱敏只作用于其后的 shell tokenize 阶段，不会绕过任何 Simulator 旁路检查。
- 仅处理标准 `<<` / `<<-` + 引号/裸定界符形式；其余 shell 语法与既有策略不受影响。
