### PR TITLE
fix(ios-simulator): 让模拟器工具面自证作用域，并停止为误路由调用抬设备授权卡

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/iosSimulatorCodexDynamicTools.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/iosSimulatorCodexDynamicTools.test.ts
@@ -58,6 +58,11 @@ describe('iOS Simulator Codex dynamic tools', () => {
         type: 'inputText',
         text: expect.stringContaining('"check_environment"'),
       });
+      // The workflow hint is model guidance: naming a superseded tool would send
+      // the model straight back to the ambiguous name this rename hides.
+      const listed = JSON.stringify(result?.contentItems ?? []);
+      expect(listed).toContain('list_simulator_devices');
+      expect(listed).not.toContain('list_devices');
       expect(callTool).not.toHaveBeenCalled();
     }
   });

--- a/apps/desktop/src/main/maker-host/__tests__/mcpToolApprovalPolicy.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/mcpToolApprovalPolicy.test.ts
@@ -191,6 +191,48 @@ describe('desktop MCP approval policy', () => {
     ).toBe('auto-approve');
   });
 
+  it('judges a stringified simulator payload the way the Host will receive it', () => {
+    const route = { instanceId: 'instance-a', generation: 2, leaseId: 'lease-a' };
+    // Claude Code's in-process bridge stringifies nested payloads (issue #350) and
+    // jsonObjectArg parses them back before dispatch, so a policy that judged the
+    // raw string would let a routed device action run unapproved.
+    expect(
+      getDesktopMcpToolApprovalPolicy({
+        serverName: 'cindy_ios_simulator',
+        toolName: 'call_tool',
+        toolParams: { name: 'build_app', args: JSON.stringify(route) },
+      }),
+    ).toBe('prompt-each-time');
+    expect(
+      getDesktopMcpToolApprovalPolicy({
+        serverName: 'cindy_ios_simulator',
+        toolName: 'call_tool',
+        toolParams: JSON.stringify({ name: 'build_app', args: route }),
+      }),
+    ).toBe('prompt-each-time');
+    // The noise case still resolves through the same representation.
+    expect(
+      getDesktopMcpToolApprovalPolicy({
+        serverName: 'cindy_ios_simulator',
+        toolName: 'call_tool',
+        toolParams: {
+          name: 'open_simulator_url',
+          args: JSON.stringify({ url: 'https://example.com' }),
+        },
+      }),
+    ).toBe('auto-approve');
+    // Anything whose arguments cannot be read fails closed and keeps asking.
+    for (const args of [undefined, 'not json', 42, [route]]) {
+      expect(
+        getDesktopMcpToolApprovalPolicy({
+          serverName: 'cindy_ios_simulator',
+          toolName: 'call_tool',
+          toolParams: { name: 'open_simulator_url', args },
+        }),
+      ).toBe('prompt-each-time');
+    }
+  });
+
   it('discloses host file access before an agent starts an Xcode build', () => {
     setMainLocale('en');
     expect(

--- a/apps/desktop/src/main/maker-host/__tests__/mcpToolApprovalPolicy.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/mcpToolApprovalPolicy.test.ts
@@ -138,7 +138,8 @@ describe('desktop MCP approval policy', () => {
         toolName: 'list_tools',
       }),
     ).toBe('auto-approve');
-    for (const name of ['attach_device', 'build_app', 'create_instance', 'open_url']) {
+    // Taking control of a device is itself the authorization step.
+    for (const name of ['attach_device', 'create_instance']) {
       expect(
         getDesktopMcpToolApprovalPolicy({
           serverName: 'cindy_ios_simulator',
@@ -147,10 +148,38 @@ describe('desktop MCP approval policy', () => {
         }),
       ).toBe('prompt-each-time');
     }
+    const route = { instanceId: 'instance-a', generation: 2, leaseId: 'lease-a' };
+    for (const name of ['build_app', 'open_simulator_url']) {
+      expect(
+        getDesktopMcpToolApprovalPolicy({
+          serverName: 'cindy_ios_simulator',
+          toolName: 'call_tool',
+          toolParams: { name, args: { ...route } },
+        }),
+      ).toBe('prompt-each-time');
+      // No owned route means the Host rejects it on route validation, so asking
+      // the user to authorize a device this task never attached is pure noise —
+      // the shape a mis-routed "open a web URL" call takes.
+      expect(
+        getDesktopMcpToolApprovalPolicy({
+          serverName: 'cindy_ios_simulator',
+          toolName: 'call_tool',
+          toolParams: { name, args: { url: 'https://example.com' } },
+        }),
+      ).toBe('auto-approve');
+    }
+    // A superseded name must not become a way around the same gate.
     expect(
       getDesktopMcpToolApprovalPolicy({
         serverName: 'cindy_ios_simulator',
-        toolParams: { name: 'build_app', args: {} },
+        toolName: 'call_tool',
+        toolParams: { name: 'open_url', args: { ...route, url: 'https://example.com' } },
+      }),
+    ).toBe('prompt-each-time');
+    expect(
+      getDesktopMcpToolApprovalPolicy({
+        serverName: 'cindy_ios_simulator',
+        toolParams: { name: 'build_app', args: { ...route } },
       }),
     ).toBe('prompt-each-time');
     expect(

--- a/apps/desktop/src/main/maker-host/ios-simulator-codex-dynamic-tools.ts
+++ b/apps/desktop/src/main/maker-host/ios-simulator-codex-dynamic-tools.ts
@@ -18,7 +18,7 @@ const TOOLS = [
     type: 'function',
     name: LIST_TOOLS_NAME,
     description:
-      "Discover Cindy's embedded iOS Simulator tools. Use this deterministic Host gateway for iOS app work instead of probing MCP resources or opening macOS Simulator.app. Start with check_environment.",
+      "Discover Cindy's embedded iOS Simulator tools. Use this deterministic Host gateway for iOS app work instead of probing MCP resources or opening macOS Simulator.app. Every tool behind it acts on a simulated Apple device: never use it to browse the web, fetch HTTP data, or automate this Mac. Start with check_environment.",
     inputSchema: {
       type: 'object',
       additionalProperties: false,
@@ -32,7 +32,7 @@ const TOOLS = [
     type: 'function',
     name: CALL_TOOL_NAME,
     description:
-      "Invoke a validated embedded iOS Simulator tool for the current Cindy session. Call list_tools first, then pass the selected inner tool name and arguments.",
+      "Invoke a validated embedded iOS Simulator tool for the current Cindy session. Call list_tools first, then pass the selected inner tool name and arguments. Every tool here targets a simulated Apple device, so do not route web browsing, HTTP fetching, or host automation through it.",
     inputSchema: {
       type: 'object',
       additionalProperties: false,

--- a/apps/desktop/src/main/maker-host/ios-simulator-codex-dynamic-tools.ts
+++ b/apps/desktop/src/main/maker-host/ios-simulator-codex-dynamic-tools.ts
@@ -146,7 +146,7 @@ export function createIOSSimulatorCodexDynamicToolProvider(options: {
           tools: registry.list(availability?.tools),
           ...(availability ? { availability } : {}),
           workflow:
-            'Use this embedded viewer workflow: check_environment, then list_devices and either create_instance or attach_device, then start_instance. Build, install, and launch the app through this gateway. Route mutations with instanceId, generation, and leaseId.',
+            'Use this embedded viewer workflow: check_environment, then list_simulator_devices and either create_instance or attach_device, then start_instance. Build, install, and launch the app through this gateway. Route mutations with instanceId, generation, and leaseId.',
         });
       }
 

--- a/apps/desktop/src/main/maker-host/mcp-tool-approval-policy.ts
+++ b/apps/desktop/src/main/maker-host/mcp-tool-approval-policy.ts
@@ -89,6 +89,30 @@ const TRUSTED_MCP_SERVERS: ReadonlySet<string> = new Set([
 ]);
 
 /**
+ * 按「Host 最终会拿到的那个值」读取 payload。
+ *
+ * `call_tool` 的 `args` 走 `jsonObjectArg`（见 lizi-mcps/json-object-arg.ts）：Claude Code
+ * 的 in-process bridge 会把嵌套 payload 先 `JSON.stringify`（issue #350），入参校验前
+ * 会再 parse 回对象。审批若只看原始字符串，判定的就不是 Host 实际执行的那个值。
+ */
+function readJsonObject(value: unknown): Record<string, unknown> | undefined {
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  if (typeof value === 'string') {
+    try {
+      const parsed = JSON.parse(value) as unknown;
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        return parsed as Record<string, unknown>;
+      }
+    } catch {
+      return undefined;
+    }
+  }
+  return undefined;
+}
+
+/**
  * 取 iOS Simulator progressive 调用的内层动作。
  *
  * 内层名一律过 canonical 化：改名后旧名仍是可调用的隐藏别名，别名必须命中与新名
@@ -104,10 +128,7 @@ function readIOSSimulatorInnerCall(
   if (context.toolName !== 'call_tool' && context.toolName !== undefined) {
     return undefined;
   }
-  const params =
-    context.toolParams && typeof context.toolParams === 'object'
-      ? (context.toolParams as { name?: unknown; args?: unknown })
-      : undefined;
+  const params = readJsonObject(context.toolParams);
   const rawName = typeof params?.name === 'string' ? params.name.trim() : '';
   return {
     name: rawName ? canonicalIOSSimulatorToolName(rawName) : undefined,
@@ -116,17 +137,10 @@ function readIOSSimulatorInnerCall(
 }
 
 /**
- * 设备级动作必须自带它要操作的那条 owned instance 路由。没有路由的调用到不了任何
- * 设备（Host 在路由校验就拒），此时弹「授权这台设备」纯属噪音 —— 无关任务把
- * 「打开一个网址」误路由到模拟器时正是这个形状。
+ * 设备级动作必须自带它要操作的那条 owned instance 路由。
  */
-function hasIOSSimulatorInstanceRoute(args: unknown): boolean {
-  if (!args || typeof args !== 'object') return false;
-  const { instanceId, generation, leaseId } = args as {
-    instanceId?: unknown;
-    generation?: unknown;
-    leaseId?: unknown;
-  };
+function hasIOSSimulatorInstanceRoute(args: Record<string, unknown>): boolean {
+  const { instanceId, generation, leaseId } = args;
   return (
     typeof instanceId === 'string' &&
     instanceId.trim() !== '' &&
@@ -136,6 +150,20 @@ function hasIOSSimulatorInstanceRoute(args: unknown): boolean {
     typeof leaseId === 'string' &&
     leaseId.trim() !== ''
   );
+}
+
+/**
+ * 只有「能确凿读出、且确实没有 owned 路由」的调用才免掉设备授权卡：那种调用到不了
+ * 任何设备（registry 的严格参数校验先拒，Host 收不到），弹窗纯属噪音 —— 无关任务把
+ * 「打开一个网址」误路由到模拟器时正是这个形状。
+ *
+ * 读不出形状时一律 fail closed 照旧弹窗：判定不能依赖「传输层此刻恰好也会拒」这种
+ * 外部前提，否则哪天入口多加一层 coercion，读不懂就会变成静默放行。
+ */
+function skipsRoutelessDeviceApproval(args: unknown): boolean {
+  const parsed = readJsonObject(args);
+  if (!parsed) return false;
+  return !hasIOSSimulatorInstanceRoute(parsed);
 }
 
 /** Claude SDK 工具名格式固定为 `mcp__<server>__<tool>`。 */
@@ -177,9 +205,9 @@ export function getDesktopMcpToolApprovalPolicy(
       return 'prompt-each-time';
     }
     if (innerName === 'build_app' || innerName === 'open_simulator_url') {
-      return hasIOSSimulatorInstanceRoute(iosSimulatorCall.args)
-        ? 'prompt-each-time'
-        : 'auto-approve';
+      return skipsRoutelessDeviceApproval(iosSimulatorCall.args)
+        ? 'auto-approve'
+        : 'prompt-each-time';
     }
     return 'auto-approve';
   }

--- a/apps/desktop/src/main/maker-host/mcp-tool-approval-policy.ts
+++ b/apps/desktop/src/main/maker-host/mcp-tool-approval-policy.ts
@@ -22,7 +22,7 @@ import type {
   McpToolApprovalPolicy,
   McpToolApprovalPresentation,
 } from '@cindy/maker-core';
-import { canAutoApproveContactsMcpTool } from '@cindy/mcps';
+import { canAutoApproveContactsMcpTool, canonicalIOSSimulatorToolName } from '@cindy/mcps';
 
 import { t } from '../i18n.js';
 
@@ -88,6 +88,56 @@ const TRUSTED_MCP_SERVERS: ReadonlySet<string> = new Set([
   'cindy_lsp',
 ]);
 
+/**
+ * 取 iOS Simulator progressive 调用的内层动作。
+ *
+ * 内层名一律过 canonical 化：改名后旧名仍是可调用的隐藏别名，别名必须命中与新名
+ * 完全相同的审批判定，否则旧名就成了绕过设备授权的口子。
+ */
+function readIOSSimulatorInnerCall(
+  context: McpToolApprovalContext,
+): { name: string | undefined; args: unknown } | undefined {
+  if (context.serverName !== 'cindy_ios_simulator') return undefined;
+  // Some Codex app-server versions omit the outer tool name but retain the
+  // validated progressive payload. Preserve the inner action's stricter policy
+  // instead of falling back to a persistable generic server prompt.
+  if (context.toolName !== 'call_tool' && context.toolName !== undefined) {
+    return undefined;
+  }
+  const params =
+    context.toolParams && typeof context.toolParams === 'object'
+      ? (context.toolParams as { name?: unknown; args?: unknown })
+      : undefined;
+  const rawName = typeof params?.name === 'string' ? params.name.trim() : '';
+  return {
+    name: rawName ? canonicalIOSSimulatorToolName(rawName) : undefined,
+    args: params?.args,
+  };
+}
+
+/**
+ * 设备级动作必须自带它要操作的那条 owned instance 路由。没有路由的调用到不了任何
+ * 设备（Host 在路由校验就拒），此时弹「授权这台设备」纯属噪音 —— 无关任务把
+ * 「打开一个网址」误路由到模拟器时正是这个形状。
+ */
+function hasIOSSimulatorInstanceRoute(args: unknown): boolean {
+  if (!args || typeof args !== 'object') return false;
+  const { instanceId, generation, leaseId } = args as {
+    instanceId?: unknown;
+    generation?: unknown;
+    leaseId?: unknown;
+  };
+  return (
+    typeof instanceId === 'string' &&
+    instanceId.trim() !== '' &&
+    typeof generation === 'number' &&
+    Number.isInteger(generation) &&
+    generation > 0 &&
+    typeof leaseId === 'string' &&
+    leaseId.trim() !== ''
+  );
+}
+
 /** Claude SDK 工具名格式固定为 `mcp__<server>__<tool>`。 */
 function toClaudeToolName(key: string): string {
   const [serverName, toolName] = key.split('::');
@@ -118,22 +168,20 @@ export function getDesktopMcpToolApprovalPolicy(
       ? 'auto-approve'
       : 'prompt-each-time';
   }
-  if (serverName === 'cindy_ios_simulator') {
-    // Some Codex app-server versions omit the outer tool name but retain the
-    // validated progressive payload. Preserve the inner action's stricter
-    // policy instead of falling back to a persistable generic server prompt.
-    if (toolName === 'call_tool' || toolName === undefined) {
-      const innerName =
-        toolParams && typeof toolParams === 'object'
-          ? (toolParams as { name?: unknown }).name
-          : undefined;
-      return innerName === 'build_app' ||
-        innerName === 'open_url' ||
-        innerName === 'create_instance' ||
-        innerName === 'attach_device'
+  const iosSimulatorCall = readIOSSimulatorInnerCall(context);
+  if (iosSimulatorCall) {
+    const innerName = iosSimulatorCall.name;
+    // Taking control of a device is itself the authorization step, so it asks
+    // even before any route exists.
+    if (innerName === 'create_instance' || innerName === 'attach_device') {
+      return 'prompt-each-time';
+    }
+    if (innerName === 'build_app' || innerName === 'open_simulator_url') {
+      return hasIOSSimulatorInstanceRoute(iosSimulatorCall.args)
         ? 'prompt-each-time'
         : 'auto-approve';
     }
+    return 'auto-approve';
   }
   if (TRUSTED_MCP_SERVERS.has(serverName)) {
     return 'auto-approve';
@@ -148,13 +196,7 @@ export function getDesktopMcpToolApprovalPolicy(
 export function getDesktopMcpToolApprovalPresentation(
   context: McpToolApprovalContext,
 ): McpToolApprovalPresentation | undefined {
-  const innerName =
-    context.serverName === 'cindy_ios_simulator' &&
-    (context.toolName === 'call_tool' || context.toolName === undefined) &&
-    context.toolParams &&
-    typeof context.toolParams === 'object'
-      ? (context.toolParams as { name?: unknown }).name
-      : undefined;
+  const innerName = readIOSSimulatorInnerCall(context)?.name;
   if (innerName === 'build_app') {
     return {
       title: t('rightSidebar.iosSimulator.buildApproval.title'),

--- a/apps/desktop/src/main/maker-host/plugins/builtin-plugins.ts
+++ b/apps/desktop/src/main/maker-host/plugins/builtin-plugins.ts
@@ -30,7 +30,7 @@ interface BuiltinPluginMeta {
  */
 const BUILTIN_META: BuiltinPluginMeta[] = [
   { id: 'android',     name: 'Android Automation', description: 'Android adb automation — screenshots, UI dump, taps, swipes, text input, and app launch on connected devices' },
-  { id: 'ios-simulator', name: 'iOS Simulator', description: 'Cindy embedded iOS Simulator — create or attach a session-owned device, boot it in the embedded viewer, build/install/launch apps, inspect screens, and debug interactions. Prefer this for requests to open, run, test, or debug an iOS app; do not launch macOS Simulator.app unless the user explicitly asks for an external system window.' },
+  { id: 'ios-simulator', name: 'iOS Simulator', description: 'Cindy embedded iOS Simulator — create or attach a session-owned device, boot it in the embedded viewer, build/install/launch apps, inspect screens, and debug interactions. Prefer this for requests to open, run, test, or debug an iOS app; do not launch macOS Simulator.app unless the user explicitly asks for an external system window. It only acts on a simulated Apple device, so it is never the way to browse the web, fetch HTTP data, or automate this Mac.' },
   { id: 'browser',     name: 'Browser',      description: 'Browser automation — isolated browsing, snapshots, screenshots, and page actions' },
   { id: 'computer',    name: 'Computer Use', description: 'Local desktop automation — apps, windows, UI inspection, clicks, and typing via an installed driver' },
   { id: 'feishu_bot',   name: 'Feishu Bot',   description: 'Send files and notifications to Feishu users via bot messages' },

--- a/apps/desktop/src/main/maker-host/plugins/builtin-plugins.ts
+++ b/apps/desktop/src/main/maker-host/plugins/builtin-plugins.ts
@@ -30,7 +30,7 @@ interface BuiltinPluginMeta {
  */
 const BUILTIN_META: BuiltinPluginMeta[] = [
   { id: 'android',     name: 'Android Automation', description: 'Android adb automation — screenshots, UI dump, taps, swipes, text input, and app launch on connected devices' },
-  { id: 'ios-simulator', name: 'iOS Simulator', description: 'Cindy embedded iOS Simulator — create or attach a session-owned device, boot it in the embedded viewer, build/install/launch apps, inspect screens, and debug interactions. Prefer this for requests to open, run, test, or debug an iOS app; do not launch macOS Simulator.app unless the user explicitly asks for an external system window. It only acts on a simulated Apple device, so it is never the way to browse the web, fetch HTTP data, or automate this Mac.' },
+  { id: 'ios-simulator', name: 'iOS Simulator', description: 'Cindy embedded iOS Simulator — create or attach a session-owned device, boot it in the embedded viewer, build/install/launch apps, inspect screens, and debug interactions. Prefer this for requests to open, run, test, or debug an iOS app; do not launch macOS Simulator.app unless the user explicitly asks for an external system window.' },
   { id: 'browser',     name: 'Browser',      description: 'Browser automation — isolated browsing, snapshots, screenshots, and page actions' },
   { id: 'computer',    name: 'Computer Use', description: 'Local desktop automation — apps, windows, UI inspection, clicks, and typing via an installed driver' },
   { id: 'feishu_bot',   name: 'Feishu Bot',   description: 'Send files and notifications to Feishu users via bot messages' },

--- a/apps/desktop/src/main/mcp-integrations/__tests__/ios-simulator.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/__tests__/ios-simulator.test.ts
@@ -766,11 +766,30 @@ describe('iOS Simulator host', () => {
     });
     const registry = new IOSSimulatorToolRegistry();
     registerIOSSimulatorTools(registry, { callTool: vi.fn() });
+    const advertised = new Set(registry.list().map((tool) => tool.name));
 
     // The registry merges this map by advertised name, so a renamed tool that
     // kept its old availability key would silently report TOOL_NOT_REPORTED.
     const reported = Object.keys((await host.describeTools('session-a')).tools).sort();
-    expect(reported).toEqual(registry.list().map((tool) => tool.name).sort());
+    expect(reported).toEqual([...advertised].sort());
+
+    // The rejected-session branch reports its own reduced map and must use the
+    // same names, or the real rejection reason never reaches discovery.
+    const rejectedHost = createIOSSimulatorHost({
+      runtime: { inspect: vi.fn(async () => READY_REPORT) },
+      getSession: vi.fn(async () => null),
+    });
+    const rejected = await rejectedHost.describeTools('missing-session');
+    expect(rejected.ready).toBe(false);
+    expect(Object.keys(rejected.tools).length).toBeGreaterThan(0);
+    for (const [name, availability] of Object.entries(rejected.tools)) {
+      expect(advertised.has(name)).toBe(true);
+      expect(availability).toBeDefined();
+    }
+    expect(rejected.tools.list_simulator_devices).toMatchObject({
+      state: 'unavailable',
+      reasonCode: 'SESSION_NOT_FOUND',
+    });
   });
 
   it('removes stale orphaned xcresult bundles during ownership reconciliation', async () => {

--- a/apps/desktop/src/main/mcp-integrations/__tests__/ios-simulator.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/__tests__/ios-simulator.test.ts
@@ -27,6 +27,7 @@ import {
   type IOSSimulatorTouchPoint,
   type WdaRunningInstance,
 } from '@cindy/ios-simulator-runtime';
+import { IOSSimulatorToolRegistry, registerIOSSimulatorTools } from '@cindy/mcps';
 import type { IOSSimulatorPublicRouteStatus } from '../../../shared/iosSimulatorIpc';
 import {
   cancelIOSSimulatorSessionOperations,
@@ -756,6 +757,20 @@ describe('iOS Simulator host', () => {
         read_build_diagnostics: { state: 'available', backend: 'host' },
       },
     });
+  });
+
+  it('reports availability under exactly the advertised simulator tool names', async () => {
+    const host = createIOSSimulatorHost({
+      runtime: { inspect: vi.fn(async () => READY_REPORT) },
+      getSession: vi.fn(async (id) => localSession(id)),
+    });
+    const registry = new IOSSimulatorToolRegistry();
+    registerIOSSimulatorTools(registry, { callTool: vi.fn() });
+
+    // The registry merges this map by advertised name, so a renamed tool that
+    // kept its old availability key would silently report TOOL_NOT_REPORTED.
+    const reported = Object.keys((await host.describeTools('session-a')).tools).sort();
+    expect(reported).toEqual(registry.list().map((tool) => tool.name).sort());
   });
 
   it('removes stale orphaned xcresult bundles during ownership reconciliation', async () => {
@@ -6803,7 +6818,7 @@ describe('iOS Simulator host', () => {
           instanceCount: 1,
           runningInstanceCount: 1,
           tools: {
-            drag: { state: 'available', backend: 'wda' },
+            drag_on_simulator: { state: 'available', backend: 'wda' },
             touch_path: { state: 'unavailable', reasonCode: 'NATIVE_HID_NOT_ADMITTED' },
           },
         },

--- a/apps/desktop/src/main/mcp-integrations/__tests__/ios-simulator.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/__tests__/ios-simulator.test.ts
@@ -790,6 +790,18 @@ describe('iOS Simulator host', () => {
       state: 'unavailable',
       reasonCode: 'SESSION_NOT_FOUND',
     });
+
+    // Recommendations are model guidance too: naming a superseded tool sends the
+    // model back to the ambiguous name this rename hides.
+    const doctor = await host.callTool('doctor', {}, { sessionId: 'session-a' });
+    const recommended = (doctor as { data: { recommendedActions: string[] } }).data
+      .recommendedActions;
+    expect(recommended).toContain('list_simulator_devices');
+    for (const action of recommended) {
+      expect(advertised.has(action) || action === 'create_instance_or_attach_device').toBe(
+        true,
+      );
+    }
   });
 
   it('removes stale orphaned xcresult bundles during ownership reconciliation', async () => {

--- a/apps/desktop/src/main/mcp-integrations/ios-simulator.ts
+++ b/apps/desktop/src/main/mcp-integrations/ios-simulator.ts
@@ -2733,10 +2733,12 @@ export function createIOSSimulatorHost(options: IOSSimulatorHostOptions = {}): I
       state: hasInstance ? (hasRunning ? 'available' : 'instance-dependent') : 'requires-instance',
       ...(hasInstance ? {} : { reasonCode: 'INSTANCE_REQUIRED' }),
     };
+    // Keyed by the advertised (model-facing) tool names, because the registry
+    // merges this map into its own listing. Host dispatch names stay unchanged.
     const tools: Record<string, IOSSimulatorToolAvailability> = {
       check_environment: { state: 'available', backend: 'host' },
       doctor: { state: 'available', backend: 'host' },
-      list_devices: inspected.ready
+      list_simulator_devices: inspected.ready
         ? { state: 'available', backend: 'simctl' }
         : { state: 'unavailable', reasonCode: inspected.issue ?? 'ENVIRONMENT_NOT_READY' },
       list_instances: { state: 'available', backend: 'host' },
@@ -2756,9 +2758,12 @@ export function createIOSSimulatorHost(options: IOSSimulatorHostOptions = {}): I
       wait_for_ui: { ...requiresInstance, backend: 'wda' },
       tap: { ...requiresInstance, backend: hasNativeInput ? 'native-hid' : 'wda' },
       swipe: { ...requiresInstance, backend: hasNativeInput ? 'native-hid' : 'wda' },
-      drag: { ...requiresInstance, backend: hasNativeInput ? 'native-hid' : 'wda' },
+      drag_on_simulator: {
+        ...requiresInstance,
+        backend: hasNativeInput ? 'native-hid' : 'wda',
+      },
       long_press: { ...requiresInstance, backend: hasNativeInput ? 'native-hid' : 'wda' },
-      key_press: { ...requiresInstance, backend: 'wda' },
+      press_simulator_key: { ...requiresInstance, backend: 'wda' },
       batch: { ...requiresInstance, backend: hasNativeInput ? 'native-hid' : 'wda' },
       touch_path: hasNativeInput
         ? { state: 'available', backend: 'native-hid' }
@@ -2774,7 +2779,7 @@ export function createIOSSimulatorHost(options: IOSSimulatorHostOptions = {}): I
           },
     };
     for (const name of [
-      'type_text',
+      'type_simulator_text',
       'press_home',
       'set_orientation',
       'set_appearance',
@@ -2793,8 +2798,8 @@ export function createIOSSimulatorHost(options: IOSSimulatorHostOptions = {}): I
       'install_app',
       'launch_app',
       'terminate_app',
-      'open_url',
-      'take_screenshot',
+      'open_simulator_url',
+      'take_simulator_screenshot',
       'capture_visual_baseline',
       'visual_diff',
       'capture_state',

--- a/apps/desktop/src/main/mcp-integrations/ios-simulator.ts
+++ b/apps/desktop/src/main/mcp-integrations/ios-simulator.ts
@@ -3681,7 +3681,13 @@ export function createIOSSimulatorHost(options: IOSSimulatorHostOptions = {}): I
           tools: {
             doctor: { state: 'available', backend: 'host' },
             check_environment: { state: 'available', backend: 'host' },
-            list_devices: { state: 'unavailable', reasonCode: resolved.errorCode },
+            // Advertised name: the registry merges availability by the name it
+            // lists, so a stale key would report TOOL_NOT_REPORTED instead of the
+            // real session rejection reason.
+            list_simulator_devices: {
+              state: 'unavailable',
+              reasonCode: resolved.errorCode,
+            },
           },
         };
       }

--- a/apps/desktop/src/main/mcp-integrations/ios-simulator.ts
+++ b/apps/desktop/src/main/mcp-integrations/ios-simulator.ts
@@ -5939,7 +5939,12 @@ export function createIOSSimulatorHost(options: IOSSimulatorHostOptions = {}): I
           const recommendedActions: string[] = [];
           if (!environment.ready) recommendedActions.push('check_environment');
           if (environment.ready && instances.length === 0) {
-            recommendedActions.push('list_devices', 'create_instance_or_attach_device');
+            // Advertised names only: a recommendation the model cannot find in
+            // list_tools sends it back to the ambiguous superseded name.
+            recommendedActions.push(
+              'list_simulator_devices',
+              'create_instance_or_attach_device',
+            );
           }
           if (instances.some((entry) => !entry.running)) recommendedActions.push('start_instance');
           if (

--- a/docs/ios-simulator-integration-plan.md
+++ b/docs/ios-simulator-integration-plan.md
@@ -982,7 +982,7 @@ MVP 规则：
 | 工具                      | 作用                                                 |
 | ------------------------- | ---------------------------------------------------- |
 | `check_environment`       | 检查 Xcode/runtime/WDA/project adapter               |
-| `list_devices`            | 列出名称、UDID、OS、boot/attachment 状态             |
+| `list_simulator_devices`  | 列出名称、UDID、OS、boot/attachment 状态             |
 | `list_instances`          | 只列 caller Session 拥有的实例                       |
 | `create_instance`         | 创建并绑定 Session/worktree                          |
 | `attach_device`           | 将已有设备绑定当前 Session，歧义或占用时拒绝         |
@@ -993,11 +993,11 @@ MVP 规则：
 | `install_app`             | 安装已验证来源的 `.app`                              |
 | `launch_app`              | 启动 bundle，支持受控 args/env                       |
 | `terminate_app`           | 停止当前 bundle                                      |
-| `open_url`                | 经 Session permission mode 打开 deep link/URL        |
+| `open_simulator_url`      | 经 Session permission mode 在模拟设备内打开 deep link/URL |
 | `get_screen_map`          | 返回精简可访问性元素                                 |
 | `tap`                     | selector 优先、坐标兜底                              |
 | `swipe`                   | 方向或明确起止点                                     |
-| `type_text`               | 向当前焦点输入文本                                   |
+| `type_simulator_text`     | 向模拟设备内当前焦点输入文本                         |
 | `press_button`            | Home/lock 等受支持按钮                               |
 | `set_appearance`          | 设置浅色/深色系统外观                                |
 | `set_increase_contrast`   | 开关 Increase Contrast 辅助功能                      |
@@ -1013,7 +1013,7 @@ MVP 规则：
 | `visual_diff`             | 返回当前截图与基线的像素差异指标                     |
 | `capture_state`           | 原子诊断快照                                         |
 | `set_stream_profile`      | 调整 FPS、resolution、encoding、FPS overlay          |
-| `take_screenshot`         | 显式持久化截图到 `cindy-media`                       |
+| `take_simulator_screenshot` | 显式持久化模拟设备截图到 `cindy-media`             |
 | `start_recording`         | 开始显式录屏                                         |
 | `stop_recording`          | 停止并摄入 `cindy-media`                             |
 
@@ -1029,7 +1029,7 @@ MVP 规则：
 
 `list_tools` 在 MCP 和 Codex dynamic gateway 两条入口都带 Host 计算出的 capability availability（`available`、`requires-instance`、`instance-dependent`、`unavailable` 以及 backend/reasonCode）。availability 只用于发现和解释，最终执行仍由 Host 的 ownership、lease、generation 和 admission policy 再次校验。
 
-Agent 对设备的控制、install/launch、tap/type 和模型截图在首次使用设备时必须先经过 UI 的 per-device consent；授权操作本身不暴露给 Agent 工具。用户拒绝后，pane 的查看和手动输入仍可用，Agent mutation 返回 `DEVICE_CONTROL_NOT_GRANTED`。`build_app` 与 `open_url` 还要分别经过现有 Session permission mode，设备授权不能替代它们。
+Agent 对设备的控制、install/launch、tap/type 和模型截图在首次使用设备时必须先经过 UI 的 per-device consent；授权操作本身不暴露给 Agent 工具。用户拒绝后，pane 的查看和手动输入仍可用，Agent mutation 返回 `DEVICE_CONTROL_NOT_GRANTED`。`build_app` 与 `open_simulator_url` 还要分别经过现有 Session permission mode，设备授权不能替代它们；两者在调用未携带 owned instance 路由时不再抬起设备授权卡（Host 会在路由校验直接拒绝），避免无关任务被误路由时弹出无意义的授权请求。
 
 ### 13.2 后续工具
 

--- a/packages/lizi-mcps/src/ios-simulator/index.ts
+++ b/packages/lizi-mcps/src/ios-simulator/index.ts
@@ -1,3 +1,4 @@
 export * from "./server.js";
+export * from "./tool-names.js";
 export * from "./tool-registry.js";
 export * from "./tools.js";

--- a/packages/lizi-mcps/src/ios-simulator/iosSimulatorMcpServer.test.ts
+++ b/packages/lizi-mcps/src/ios-simulator/iosSimulatorMcpServer.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import type { IOSSimulatorMcpDeps } from "../types.js";
 import { createIOSSimulatorMcpServer } from "./server.js";
+import { IOS_SIMULATOR_DEPRECATED_TOOL_ALIASES } from "./tool-names.js";
 
 async function connect(
   deps: IOSSimulatorMcpDeps,
@@ -71,7 +72,7 @@ describe("createIOSSimulatorMcpServer", () => {
     expect(payload.tools.map((tool: { name: string }) => tool.name)).toEqual([
       "check_environment",
       "doctor",
-      "list_devices",
+      "list_simulator_devices",
       "list_instances",
       "create_instance",
       "attach_device",
@@ -84,13 +85,13 @@ describe("createIOSSimulatorMcpServer", () => {
       "wait_for_ui",
       "tap",
       "swipe",
-      "drag",
+      "drag_on_simulator",
       "long_press",
-      "key_press",
+      "press_simulator_key",
       "batch",
       "touch_path",
       "touch2_path",
-      "type_text",
+      "type_simulator_text",
       "press_home",
       "set_orientation",
       "set_appearance",
@@ -110,8 +111,8 @@ describe("createIOSSimulatorMcpServer", () => {
       "install_app",
       "launch_app",
       "terminate_app",
-      "open_url",
-      "take_screenshot",
+      "open_simulator_url",
+      "take_simulator_screenshot",
       "capture_visual_baseline",
       "visual_diff",
       "capture_state",
@@ -138,7 +139,10 @@ describe("createIOSSimulatorMcpServer", () => {
       tools: {
         doctor: { state: "available" as const, backend: "host" as const },
         wait_for_ui: { state: "available" as const, backend: "wda" as const },
-        drag: { state: "available" as const, backend: "native-hid" as const },
+        drag_on_simulator: {
+          state: "available" as const,
+          backend: "native-hid" as const,
+        },
       },
     }));
     const { client, server } = await connect(
@@ -159,7 +163,9 @@ describe("createIOSSimulatorMcpServer", () => {
       runningInstanceCount: 1,
     });
     expect(
-      payload.tools.find((tool: { name: string }) => tool.name === "drag"),
+      payload.tools.find(
+        (tool: { name: string }) => tool.name === "drag_on_simulator",
+      ),
     ).toMatchObject({
       availability: { state: "available", backend: "native-hid" },
     });
@@ -188,7 +194,7 @@ describe("createIOSSimulatorMcpServer", () => {
         name: "long_press",
         args: { ...route, elementId: "element-a", durationMs: 299 },
       },
-      { name: "key_press", args: { ...route, key: "space" } },
+      { name: "press_simulator_key", args: { ...route, key: "space" } },
       {
         name: "batch",
         args: {
@@ -297,6 +303,87 @@ describe("createIOSSimulatorMcpServer", () => {
     const payload = JSON.parse(readResultText(result));
     expect(result.isError).toBe(true);
     expect(payload.errorCode).toBe("UNSUPPORTED_SESSION_KIND");
+    await Promise.all([client.close(), server.close()]);
+  });
+
+  it("scopes every advertised description to the simulator domain", async () => {
+    const { client, server } = await connect(
+      { callTool: vi.fn() },
+      "session-a",
+    );
+    const result = await client.callTool({ name: "list_tools", arguments: {} });
+    const payload = JSON.parse(readResultText(result));
+
+    // The model sees the inner name next to generic host and browser tools, so
+    // the domain must be on every description, not only the renamed ones.
+    for (const tool of payload.tools as { name: string; description: string }[]) {
+      expect(tool.description.startsWith("[iOS Simulator] ")).toBe(true);
+    }
+    const openUrl = (payload.tools as { name: string; description: string }[]).find(
+      (tool) => tool.name === "open_simulator_url",
+    );
+    expect(openUrl?.description).toContain("browser and fetch tools instead");
+    await Promise.all([client.close(), server.close()]);
+  });
+
+  it("keeps superseded tool names callable without advertising them", async () => {
+    const callTool = vi.fn(async () => ({ ok: true, data: {} }));
+    const { client, server } = await connect({ callTool }, "session-a");
+
+    const listed = JSON.parse(
+      readResultText(await client.callTool({ name: "list_tools", arguments: {} })),
+    );
+    const advertised = new Set(
+      (listed.tools as { name: string }[]).map((tool) => tool.name),
+    );
+    for (const deprecated of Object.keys(
+      IOS_SIMULATOR_DEPRECATED_TOOL_ALIASES,
+    )) {
+      expect(advertised.has(deprecated)).toBe(false);
+      expect(
+        advertised.has(IOS_SIMULATOR_DEPRECATED_TOOL_ALIASES[deprecated]!),
+      ).toBe(true);
+    }
+
+    // A plugin or saved prompt written against the old name must keep working.
+    const route = { instanceId: "instance-a", generation: 1, leaseId: "lease-a" };
+    const result = await client.callTool({
+      name: "call_tool",
+      arguments: { name: "open_url", args: { ...route, url: "https://example.com" } },
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(callTool).toHaveBeenCalledWith(
+      "open_url",
+      { ...route, url: "https://example.com" },
+      { sessionId: "session-a", origin: "agent" },
+    );
+    await Promise.all([client.close(), server.close()]);
+  });
+
+  it("rejects a routeless simulator URL open before reaching the Host", async () => {
+    const callTool = vi.fn();
+    const { client, server } = await connect({ callTool }, "session-a");
+
+    // This is what a mis-routed "open a web page" call looks like. It must fail
+    // on argument validation, which is why Desktop can skip the device
+    // authorization prompt for it instead of asking about a device that this
+    // task never attached.
+    const result = await client.callTool({
+      name: "call_tool",
+      arguments: {
+        name: "open_simulator_url",
+        args: { url: "https://example.com" },
+      },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(readResultText(result))).toMatchObject({
+      ok: false,
+      errorCode: "INVALID_ARGS",
+      data: { tool: "open_simulator_url" },
+    });
+    expect(callTool).not.toHaveBeenCalled();
     await Promise.all([client.close(), server.close()]);
   });
 });

--- a/packages/lizi-mcps/src/ios-simulator/server.ts
+++ b/packages/lizi-mcps/src/ios-simulator/server.ts
@@ -56,7 +56,7 @@ export function createIOSSimulatorMcpServer(
 
   server.tool(
     "list_tools",
-    "Discover Cindy's embedded iOS Simulator tools. This is the preferred entry point for opening, running, testing, or debugging an iOS app in Cindy. Do not use cindy_computer to launch macOS Simulator.app unless the user explicitly requests an external system window. Start with check_environment before selecting a device.",
+    "Discover Cindy's embedded iOS Simulator tools. This is the preferred entry point for opening, running, testing, or debugging an iOS app in Cindy. Everything behind it acts on a simulated Apple device: never use it to browse the web, fetch HTTP data, or automate this Mac — use the browser, fetch, or computer tools for those. Do not use cindy_computer to launch macOS Simulator.app unless the user explicitly requests an external system window. Start with check_environment before selecting a device.",
     { category: z.enum(["ios_simulator"]).optional() },
     async () => {
       const availability = await deps.describeTools?.(readContext(options));
@@ -70,7 +70,7 @@ export function createIOSSimulatorMcpServer(
               tools: registry.list(availability?.tools),
               ...(availability ? { availability } : {}),
               workflow:
-                "Use this embedded viewer workflow: check_environment, then list_devices and either create_instance or attach_device, then start_instance. Build, install, and launch the app through this server. Route mutations with instanceId, generation, and leaseId.",
+                "Use this embedded viewer workflow: check_environment, then list_simulator_devices and either create_instance or attach_device, then start_instance. Build, install, and launch the app through this server. Route mutations with instanceId, generation, and leaseId.",
             }),
           },
         ],
@@ -79,7 +79,7 @@ export function createIOSSimulatorMcpServer(
   );
   server.tool(
     "call_tool",
-    "Invoke a validated iOS Simulator tool for the current Cindy session.",
+    "Invoke a validated iOS Simulator tool for the current Cindy session. Every tool here targets a simulated Apple device, so do not route web browsing, HTTP fetching, or host automation through it.",
     {
       name: z.string(),
       args: jsonObjectArg("Arguments object for the selected tool"),

--- a/packages/lizi-mcps/src/ios-simulator/tool-names.ts
+++ b/packages/lizi-mcps/src/ios-simulator/tool-names.ts
@@ -1,0 +1,42 @@
+/**
+ * Model-facing names for the embedded iOS Simulator tools.
+ *
+ * Bare names like `open_url` or `type_text` read as generic host/browser
+ * actions, and agents have mis-routed unrelated work (opening a web page) into
+ * the simulator gateway because of it. The advertised names now say what device
+ * they act on.
+ *
+ * Only what a model sees is renamed. The Host contract keeps its original
+ * names — `IOSSimulatorMcpToolName`, the Desktop IPC allowlist and the viewer
+ * panel are unaffected — and every old model-facing name stays callable as a
+ * hidden alias so an installed plugin or a saved prompt written against it
+ * keeps working.
+ */
+export const IOS_SIMULATOR_DEPRECATED_TOOL_ALIASES: Readonly<
+  Record<string, string>
+> = {
+  open_url: "open_simulator_url",
+  take_screenshot: "take_simulator_screenshot",
+  type_text: "type_simulator_text",
+  key_press: "press_simulator_key",
+  drag: "drag_on_simulator",
+  list_devices: "list_simulator_devices",
+};
+
+/**
+ * Resolve a possibly-deprecated model-facing name to the advertised one. Every
+ * name-keyed decision (approval policy, availability, dispatch) must go through
+ * this, or an alias could silently bypass a gate that the new name enforces.
+ */
+export function canonicalIOSSimulatorToolName(name: string): string {
+  return IOS_SIMULATOR_DEPRECATED_TOOL_ALIASES[name] ?? name;
+}
+
+/** Hidden aliases that still resolve to `name`, derived from one table. */
+export function deprecatedIOSSimulatorToolAliasesFor(
+  name: string,
+): readonly string[] {
+  return Object.entries(IOS_SIMULATOR_DEPRECATED_TOOL_ALIASES)
+    .filter(([, current]) => current === name)
+    .map(([deprecated]) => deprecated);
+}

--- a/packages/lizi-mcps/src/ios-simulator/tool-registry.ts
+++ b/packages/lizi-mcps/src/ios-simulator/tool-registry.ts
@@ -53,6 +53,8 @@ export function iosSimulatorBusinessError(
 /** Progressive tool registry shared by Claude and Codex transports. */
 export class IOSSimulatorToolRegistry {
   private readonly tools = new Map<string, IOSSimulatorToolDefinition>();
+  /** Deprecated name → advertised name. Callable, never advertised. */
+  private readonly deprecatedAliases = new Map<string, string>();
 
   register<T extends z.ZodRawShape>(definition: {
     name: string;
@@ -60,16 +62,35 @@ export class IOSSimulatorToolRegistry {
     readOnly?: boolean;
     inputShape: T;
     handler: IOSSimulatorToolHandler<{ [K in keyof T]: z.infer<T[K]> }>;
+    /**
+     * Superseded names that still resolve here. They keep a plugin or saved
+     * prompt written against the old name working after a rename.
+     */
+    deprecatedAliases?: readonly string[];
   }): void {
     if (this.tools.has(definition.name)) {
       throw new Error(
         `[iosSimulatorToolRegistry] duplicate tool name: ${definition.name}`,
       );
     }
+    for (const alias of definition.deprecatedAliases ?? []) {
+      if (this.tools.has(alias) || this.deprecatedAliases.has(alias)) {
+        throw new Error(
+          `[iosSimulatorToolRegistry] duplicate tool alias: ${alias}`,
+        );
+      }
+      this.deprecatedAliases.set(alias, definition.name);
+    }
     this.tools.set(definition.name, {
       ...definition,
       readOnly: definition.readOnly === true,
     } as unknown as IOSSimulatorToolDefinition);
+  }
+
+  /** Advertised name for a requested name, resolving a deprecated alias. */
+  resolveName(name: string): string {
+    if (this.tools.has(name)) return name;
+    return this.deprecatedAliases.get(name) ?? name;
   }
 
   list(
@@ -101,7 +122,8 @@ export class IOSSimulatorToolRegistry {
   }
 
   async call(name: string, rawArgs: unknown): Promise<IOSSimulatorToolResult> {
-    const definition = this.tools.get(name);
+    const resolved = this.resolveName(name);
+    const definition = this.tools.get(resolved);
     if (!definition) {
       return iosSimulatorTextResult(
         {
@@ -120,7 +142,7 @@ export class IOSSimulatorToolRegistry {
         {
           ok: false,
           errorCode: "INVALID_ARGS",
-          data: { tool: name, validation_errors: parsed.error.issues },
+          data: { tool: resolved, validation_errors: parsed.error.issues },
         },
         true,
       );

--- a/packages/lizi-mcps/src/ios-simulator/tools.ts
+++ b/packages/lizi-mcps/src/ios-simulator/tools.ts
@@ -4,12 +4,21 @@ import type {
   IOSSimulatorMcpErrorCode,
   IOSSimulatorMcpToolName,
 } from "../types.js";
+import { deprecatedIOSSimulatorToolAliasesFor } from "./tool-names.js";
 import {
   IOSSimulatorToolRegistry,
   iosSimulatorBusinessError,
   iosSimulatorTextResult,
+  type IOSSimulatorToolHandler,
 } from "./tool-registry.js";
 import { z } from "zod";
+
+/**
+ * Every advertised description carries the domain, because the model only sees
+ * the inner name (`tap`, `type_simulator_text`, …) next to generic host and
+ * browser tools that have similar names.
+ */
+const TOOL_DESCRIPTION_PREFIX = "[iOS Simulator] ";
 
 function isBusinessError(result: unknown): result is {
   ok: false;
@@ -133,7 +142,25 @@ export function registerIOSSimulatorTools(
   deps: IOSSimulatorMcpDeps,
   getContext?: () => IOSSimulatorMcpCallContext | undefined,
 ): void {
-  registry.register({
+  /**
+   * One place applies the domain prefix and derives the hidden aliases from the
+   * rename table, so a renamed tool cannot forget either half.
+   */
+  const register = <T extends z.ZodRawShape>(definition: {
+    name: string;
+    description: string;
+    readOnly?: boolean;
+    inputShape: T;
+    handler: IOSSimulatorToolHandler<{ [K in keyof T]: z.infer<T[K]> }>;
+  }): void => {
+    registry.register({
+      ...definition,
+      description: `${TOOL_DESCRIPTION_PREFIX}${definition.description}`,
+      deprecatedAliases: deprecatedIOSSimulatorToolAliasesFor(definition.name),
+    });
+  };
+
+  register({
     name: "check_environment",
     description:
       "Check whether the current local macOS session can use Cindy's embedded iOS Simulator runtime, Xcode, and the viewer bridge. This does not open macOS Simulator.app.",
@@ -142,7 +169,7 @@ export function registerIOSSimulatorTools(
     handler: async () =>
       callHost(deps, "check_environment", {}, getContext?.()),
   });
-  registry.register({
+  register({
     name: "doctor",
     description:
       "Run one bounded Host diagnosis for the current Cindy session, including environment, ownership, drivers, admitted capabilities, tool availability, and recommended next actions.",
@@ -150,15 +177,15 @@ export function registerIOSSimulatorTools(
     inputShape: {},
     handler: async () => callHost(deps, "doctor", {}, getContext?.()),
   });
-  registry.register({
-    name: "list_devices",
+  register({
+    name: "list_simulator_devices",
     description:
-      "List available simulated iPhone and iPad devices with exact UDIDs and boot states.",
+      "List available simulated iPhone and iPad devices with exact UDIDs and boot states. Apple simulators only: not Android devices, not physical hardware, not this Mac.",
     readOnly: true,
     inputShape: {},
     handler: async () => callHost(deps, "list_devices", {}, getContext?.()),
   });
-  registry.register({
+  register({
     name: "list_instances",
     description:
       "List only the iOS Simulator instances owned by the current Cindy session.",
@@ -166,7 +193,7 @@ export function registerIOSSimulatorTools(
     inputShape: {},
     handler: async () => callHost(deps, "list_instances", {}, getContext?.()),
   });
-  registry.register({
+  register({
     name: "create_instance",
     description:
       "Create a Cindy-owned embedded simulator from an installed template device, then attach it to this session for display in Cindy's viewer.",
@@ -177,7 +204,7 @@ export function registerIOSSimulatorTools(
     handler: async (args) =>
       callHost(deps, "create_instance", args, getContext?.()),
   });
-  registry.register({
+  register({
     name: "attach_device",
     description:
       "Attach one exact simulator UDID to the current Cindy embedded-simulator session. Resource admission is enforced by the host; do not open Simulator.app.",
@@ -217,7 +244,7 @@ export function registerIOSSimulatorTools(
     batteryState: z.enum(["charging", "charged", "discharging"]).optional(),
     batteryLevel: z.number().int().min(0).max(100).optional(),
   };
-  registry.register({
+  register({
     name: "start_instance",
     description:
       "Boot the exact simulator attached to this Cindy embedded-simulator session and invalidate stale generations. Keep the device in Cindy's viewer rather than opening Simulator.app.",
@@ -225,14 +252,14 @@ export function registerIOSSimulatorTools(
     handler: async (args) =>
       callHost(deps, "start_instance", args, getContext?.()),
   });
-  registry.register({
+  register({
     name: "stop_instance",
     description: "Shut down the exact attached simulator without deleting it.",
     inputShape: routeShape,
     handler: async (args) =>
       callHost(deps, "stop_instance", args, getContext?.()),
   });
-  registry.register({
+  register({
     name: "detach_device",
     description:
       "Detach the viewer. Cindy-booted devices get a ten-minute grace period; preexisting devices remain running.",
@@ -244,7 +271,7 @@ export function registerIOSSimulatorTools(
     ...routeShape,
     snapshotId: z.string().uuid(),
   };
-  registry.register({
+  register({
     name: "get_screen_map",
     description:
       "Read a bounded accessibility-first screen map. Use its snapshotId and elementIds for the next action.",
@@ -253,7 +280,7 @@ export function registerIOSSimulatorTools(
     handler: async (args) =>
       callHost(deps, "get_screen_map", args, getContext?.()),
   });
-  registry.register({
+  register({
     name: "audit_accessibility",
     description:
       "Run a bounded accessibility audit over the current simulator screen map without changing device state.",
@@ -281,7 +308,7 @@ export function registerIOSSimulatorTools(
       })
       .nullable(),
   });
-  registry.register({
+  register({
     name: "compare_screen_maps",
     description:
       "Compare a previously observed accessibility screen map with the current screen without changing device state.",
@@ -302,7 +329,7 @@ export function registerIOSSimulatorTools(
     handler: async (args) =>
       callHost(deps, "compare_screen_maps", args, getContext?.()),
   });
-  registry.register({
+  register({
     name: "wait_for_ui",
     description:
       "Wait for one bounded accessibility condition without fixed sleeps, then return a fresh screen map.",
@@ -316,7 +343,7 @@ export function registerIOSSimulatorTools(
     },
     handler: async (args) => callHost(deps, "wait_for_ui", args, getContext?.()),
   });
-  registry.register({
+  register({
     name: "tap",
     description:
       "Tap an element from the current screen map, or explicit device coordinates as a fallback.",
@@ -329,7 +356,7 @@ export function registerIOSSimulatorTools(
     },
     handler: async (args) => callHost(deps, "tap", args, getContext?.()),
   });
-  registry.register({
+  register({
     name: "swipe",
     description:
       "Swipe between explicit device points after observing the current screen map.",
@@ -344,10 +371,10 @@ export function registerIOSSimulatorTools(
     },
     handler: async (args) => callHost(deps, "swipe", args, getContext?.()),
   });
-  registry.register({
-    name: "drag",
+  register({
+    name: "drag_on_simulator",
     description:
-      "Drag from one element in the current screen map to another using native HID when admitted and WDA otherwise.",
+      "Drag from one element in the simulated device's current screen map to another, using native HID when admitted and WDA otherwise. Not a host mouse drag.",
     inputShape: {
       ...snapshotRouteShape,
       fromElementId: z.string().min(1).max(128),
@@ -357,7 +384,7 @@ export function registerIOSSimulatorTools(
     },
     handler: async (args) => callHost(deps, "drag", args, getContext?.()),
   });
-  registry.register({
+  register({
     name: "long_press",
     description:
       "Long-press an element from the current screen map for a bounded duration.",
@@ -369,10 +396,10 @@ export function registerIOSSimulatorTools(
     },
     handler: async (args) => callHost(deps, "long_press", args, getContext?.()),
   });
-  registry.register({
-    name: "key_press",
+  register({
+    name: "press_simulator_key",
     description:
-      "Send one bounded WebDriver keyboard key to the currently focused control.",
+      "Send one bounded WebDriver keyboard key to the control focused inside the simulated device. Not a host key press.",
     inputShape: {
       ...snapshotRouteShape,
       key: keyName,
@@ -380,7 +407,7 @@ export function registerIOSSimulatorTools(
     },
     handler: async (args) => callHost(deps, "key_press", args, getContext?.()),
   });
-  registry.register({
+  register({
     name: "batch",
     description:
       "Run up to 16 low-risk UI actions against one instance route, stopping on the first failure and returning a final observation.",
@@ -399,7 +426,7 @@ export function registerIOSSimulatorTools(
     y: z.number().finite().nonnegative().max(1_000_000),
     dtMs: z.number().int().min(0).max(60_000).optional(),
   });
-  registry.register({
+  register({
     name: "touch_path",
     description:
       "Perform one bounded continuous native touch path in device coordinates after observing the current screen map. Use edge only for an intentional system-edge gesture.",
@@ -411,7 +438,7 @@ export function registerIOSSimulatorTools(
     },
     handler: async (args) => callHost(deps, "touch_path", args, getContext?.()),
   });
-  registry.register({
+  register({
     name: "touch2_path",
     description:
       "Perform two synchronized bounded native touch paths in device coordinates after observing the current screen map. Both paths must use matching phases and timing.",
@@ -424,9 +451,10 @@ export function registerIOSSimulatorTools(
     handler: async (args) =>
       callHost(deps, "touch2_path", args, getContext?.()),
   });
-  registry.register({
-    name: "type_text",
-    description: "Type bounded text into the currently focused control.",
+  register({
+    name: "type_simulator_text",
+    description:
+      "Type bounded text into the control focused inside the simulated device. Not host keyboard input and not browser input.",
     inputShape: {
       ...snapshotRouteShape,
       text: z.string().max(10_000),
@@ -434,14 +462,14 @@ export function registerIOSSimulatorTools(
     },
     handler: async (args) => callHost(deps, "type_text", args, getContext?.()),
   });
-  registry.register({
+  register({
     name: "press_home",
     description:
       "Press the simulated Home button after observing the current screen map.",
     inputShape: { ...snapshotRouteShape, ...observeAfterShape },
     handler: async (args) => callHost(deps, "press_home", args, getContext?.()),
   });
-  registry.register({
+  register({
     name: "set_orientation",
     description: "Rotate the simulator after observing the current screen map.",
     inputShape: {
@@ -451,7 +479,7 @@ export function registerIOSSimulatorTools(
     handler: async (args) =>
       callHost(deps, "set_orientation", args, getContext?.()),
   });
-  registry.register({
+  register({
     name: "set_appearance",
     description: "Set the simulated system appearance to light or dark.",
     inputShape: {
@@ -461,7 +489,7 @@ export function registerIOSSimulatorTools(
     handler: async (args) =>
       callHost(deps, "set_appearance", args, getContext?.()),
   });
-  registry.register({
+  register({
     name: "set_increase_contrast",
     description:
       "Enable or disable the simulated Increase Contrast accessibility setting.",
@@ -472,7 +500,7 @@ export function registerIOSSimulatorTools(
     handler: async (args) =>
       callHost(deps, "set_increase_contrast", args, getContext?.()),
   });
-  registry.register({
+  register({
     name: "set_content_size",
     description: "Set the simulated Dynamic Type content-size category.",
     inputShape: {
@@ -495,7 +523,7 @@ export function registerIOSSimulatorTools(
     handler: async (args) =>
       callHost(deps, "set_content_size", args, getContext?.()),
   });
-  registry.register({
+  register({
     name: "set_location",
     description: "Set a simulated latitude and longitude on the exact device.",
     inputShape: {
@@ -506,7 +534,7 @@ export function registerIOSSimulatorTools(
     handler: async (args) =>
       callHost(deps, "set_location", args, getContext?.()),
   });
-  registry.register({
+  register({
     name: "start_location_route",
     description:
       "Start a bounded simulated route through explicit latitude and longitude waypoints.",
@@ -533,14 +561,14 @@ export function registerIOSSimulatorTools(
     handler: async (args) =>
       callHost(deps, "start_location_route", args, getContext?.()),
   });
-  registry.register({
+  register({
     name: "clear_location",
     description: "Clear any simulated location from the exact device.",
     inputShape: routeShape,
     handler: async (args) =>
       callHost(deps, "clear_location", args, getContext?.()),
   });
-  registry.register({
+  register({
     name: "set_privacy",
     description:
       "Grant, revoke, or reset one simulated privacy permission for an app.",
@@ -556,7 +584,7 @@ export function registerIOSSimulatorTools(
     handler: async (args) =>
       callHost(deps, "set_privacy", args, getContext?.()),
   });
-  registry.register({
+  register({
     name: "push_notification",
     description:
       "Send one bounded APNs payload to an installed app on the exact simulator.",
@@ -568,7 +596,7 @@ export function registerIOSSimulatorTools(
     handler: async (args) =>
       callHost(deps, "push_notification", args, getContext?.()),
   });
-  registry.register({
+  register({
     name: "set_status_bar",
     description:
       "Apply deterministic status-bar overrides to the exact simulator.",
@@ -576,7 +604,7 @@ export function registerIOSSimulatorTools(
     handler: async (args) =>
       callHost(deps, "set_status_bar", args, getContext?.()),
   });
-  registry.register({
+  register({
     name: "clear_status_bar",
     description:
       "Clear all simulated status-bar overrides on the exact simulator.",
@@ -584,7 +612,7 @@ export function registerIOSSimulatorTools(
     handler: async (args) =>
       callHost(deps, "clear_status_bar", args, getContext?.()),
   });
-  registry.register({
+  register({
     name: "lock_screen",
     description:
       "Lock the exact simulator after observing the current screen map.",
@@ -592,7 +620,7 @@ export function registerIOSSimulatorTools(
     handler: async (args) =>
       callHost(deps, "lock_screen", args, getContext?.()),
   });
-  registry.register({
+  register({
     name: "unlock_screen",
     description:
       "Unlock the exact simulator after observing the current screen map.",
@@ -600,7 +628,7 @@ export function registerIOSSimulatorTools(
     handler: async (args) =>
       callHost(deps, "unlock_screen", args, getContext?.()),
   });
-  registry.register({
+  register({
     name: "build_app",
     description:
       "Build one iOS app for the embedded simulator instance. Xcode runs the project's build scripts as the current macOS user, so scripts may read or modify files outside the project and build output is returned to the Agent. Approve only for a trusted project. For repositories with multiple or nested Xcode containers, pass containerPath as a worktree-relative path (or an absolute path that still resolves inside the worktree), then select a shared scheme when needed. Continue with install_app and launch_app on this same Cindy session.",
@@ -611,7 +639,7 @@ export function registerIOSSimulatorTools(
     },
     handler: async (args) => callHost(deps, "build_app", args, getContext?.()),
   });
-  registry.register({
+  register({
     name: "read_build_diagnostics",
     description:
       "Read a bounded chunk of build output or xcresult diagnostics returned by a successful or failed build_app call.",
@@ -630,7 +658,7 @@ export function registerIOSSimulatorTools(
     handler: async (args) =>
       callHost(deps, "read_build_diagnostics", args, getContext?.()),
   });
-  registry.register({
+  register({
     name: "install_app",
     description:
       "Install a build artifact produced for this Cindy session onto the exact simulator.",
@@ -638,7 +666,7 @@ export function registerIOSSimulatorTools(
     handler: async (args) =>
       callHost(deps, "install_app", args, getContext?.()),
   });
-  registry.register({
+  register({
     name: "launch_app",
     description:
       "Launch an installed build artifact on the exact Cindy embedded simulator with bounded arguments; this does not open macOS Simulator.app.",
@@ -649,7 +677,7 @@ export function registerIOSSimulatorTools(
     },
     handler: async (args) => callHost(deps, "launch_app", args, getContext?.()),
   });
-  registry.register({
+  register({
     name: "terminate_app",
     description:
       "Terminate the app represented by a current build artifact on the exact simulator.",
@@ -657,22 +685,22 @@ export function registerIOSSimulatorTools(
     handler: async (args) =>
       callHost(deps, "terminate_app", args, getContext?.()),
   });
-  registry.register({
-    name: "open_url",
+  register({
+    name: "open_simulator_url",
     description:
-      "Open a validated non-file URL on the exact simulator. This may require URL approval.",
+      "Hand a validated non-file URL to iOS inside the simulated device, so the simulator's own browser or a deep-link handler opens it. This never fetches the URL for you and never opens it on this Mac: read web pages or web data with the browser and fetch tools instead. Requires an owned simulator instance route and may require URL approval.",
     inputShape: { ...routeShape, url: z.string().min(1).max(8_192) },
     handler: async (args) => callHost(deps, "open_url", args, getContext?.()),
   });
-  registry.register({
-    name: "take_screenshot",
+  register({
+    name: "take_simulator_screenshot",
     description:
-      "Capture the exact simulator and persist the explicit result in Cindy media. The image may be sent to the model.",
+      "Capture the simulated device's own screen and persist the explicit result in Cindy media. Not a screenshot of this Mac or of a browser page. The image may be sent to the model.",
     inputShape: routeShape,
     handler: async (args) =>
       callHost(deps, "take_screenshot", args, getContext?.()),
   });
-  registry.register({
+  register({
     name: "capture_visual_baseline",
     description:
       "Capture a bounded in-memory screenshot baseline for a later pixel diff. The baseline is not persisted as media.",
@@ -680,7 +708,7 @@ export function registerIOSSimulatorTools(
     handler: async (args) =>
       callHost(deps, "capture_visual_baseline", args, getContext?.()),
   });
-  registry.register({
+  register({
     name: "visual_diff",
     description:
       "Compare the current simulator screenshot with an in-memory baseline and return bounded pixel metrics.",
@@ -693,7 +721,7 @@ export function registerIOSSimulatorTools(
     handler: async (args) =>
       callHost(deps, "visual_diff", args, getContext?.()),
   });
-  registry.register({
+  register({
     name: "capture_state",
     description:
       "Capture one bounded diagnostic state with driver health, orientation, screen map, and stream metadata.",
@@ -702,7 +730,7 @@ export function registerIOSSimulatorTools(
     handler: async (args) =>
       callHost(deps, "capture_state", args, getContext?.()),
   });
-  registry.register({
+  register({
     name: "get_diagnostics",
     description: "Read one session-scoped bounded diagnostics entry by ID.",
     readOnly: true,
@@ -710,7 +738,7 @@ export function registerIOSSimulatorTools(
     handler: async (args) =>
       callHost(deps, "get_diagnostics", args, getContext?.()),
   });
-  registry.register({
+  register({
     name: "start_recording",
     description:
       "Start one explicit H.264 simulator recording in a unique temporary file.",
@@ -718,7 +746,7 @@ export function registerIOSSimulatorTools(
     handler: async (args) =>
       callHost(deps, "start_recording", args, getContext?.()),
   });
-  registry.register({
+  register({
     name: "stop_recording",
     description:
       "Stop a current recording and ingest the finalized MOV into Cindy media.",


### PR DESCRIPTION
## 这次改了什么

### 摘要

用户在一个**纯查资料**的任务里被弹了 iOS 模拟器的设备授权卡（`Allow Codex to use open_url?` /
`Allow the cindy_ios_simulator MCP server to run tool "call_tool"?`）。弹窗本身没错乱：Codex
真的调了 `cindy_ios_simulator` 的 `open_url` —— 那个工具的语义是「在模拟设备内打开 URL」，
而模型把「打开一个网址」路由到了它。

两个诱因叠加：

1. 模拟器网关对每个「工作区启用了该插件」的会话都是 eager 暴露
   （`ios-simulator-codex-dynamic-tools.ts`，判据只有 `platform === 'darwin' && isEnabled(workingDir)`），
   跟这个任务是否与 iOS 有关无关；
2. 内层名 `open_url` / `type_text` / `take_screenshot` / `drag` / `key_press` / `list_devices`
   与浏览器、本机自动化里的同名工具从名字上无从区分。

此外，那次弹窗其实是**纯噪音**：调用没有带 owned instance 路由，参数校验就会拒，用户点
「允许」也不会发生任何设备操作。

本 PR 从三个层面收敛（不改变任何设备授权的强度）：

- **描述自证作用域**：49 个内层工具描述统一带 `[iOS Simulator]` 前缀；两个网关入口
  （Claude MCP server 与 Codex 动态工具的 `list_tools` / `call_tool`）补上「只作用于模拟 Apple
  设备，不用于网页浏览、HTTP 抓取或本机自动化」。
- **6 个易撞名工具改名，旧名保留为隐藏别名**：`open_url → open_simulator_url`、
  `take_screenshot → take_simulator_screenshot`、`type_text → type_simulator_text`、
  `key_press → press_simulator_key`、`drag → drag_on_simulator`、
  `list_devices → list_simulator_devices`。
- **无路由不再抬授权卡**：`build_app` / `open_simulator_url` 在调用未携带 owned instance 路由时
  走 `auto-approve`，让它照常在参数校验处失败并把结构化错误交回模型，而不是先让用户授权一台
  这个任务从未挂载的设备。`create_instance` / `attach_device` 仍一律逐次弹窗——它们本身就是
  授权动作。

改名刻意只动**模型可见的那一层**：Host 契约（`IOSSimulatorMcpToolName`、Desktop IPC allowlist、
viewer 面板直调）、诊断/遥测标签、`batch` 的内层 action 类型一概不变；`tool-names.ts` 是唯一的
改名表，registry 的别名与描述前缀都从它派生。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无独立 issue；来自用户反馈（模拟器权限卡出现在完全无关的任务里）。
  与 #2404（iOS Simulator host policy 误拦普通 HTTPS 抓取）同源不同层：#2404 掐掉了正常取网页的
  路，模型才会去找别的「打开 URL」的手段，本 PR 收敛的是工具面与审批噪音。
- 本 PR 包含：工具描述域前缀、两个网关入口的负向约束文案、6 个工具改名 + 隐藏别名 +
  审批/availability 的 canonical 化（含被拒会话分支）、无路由调用不再弹设备授权卡、对应单测、
  设计文档工具表更新
- 明确不包含（第二轮 review 后从本 PR 撤回）：设置页可见的内置插件描述不再改动；`ios-simulator`
  在各 locale bundle 缺 name/description 是既有缺口，属用户可见文案新增，留作单独改动
- 明确不包含：**不收窄 eager 暴露**（是否按 `.xcodeproj` / 会话已有实例等判据 gate 掉网关，判据宽窄
  需要产品定调，留作后续）；不改 #2404 的 shell 守卫；不改模拟器功能本身
- 用户可见变化：无关任务里不再因误路由弹出「授权这台设备」；模型看到的工具名带上了设备语义
- 是否存在 breaking change：无。旧名仍可调用（只是不再出现在 `list_tools`）

### UI 变化

不涉及（未改动任何 renderer / 组件 / 样式 / 界面文案；改动的是模型可见的工具描述与 main 侧策略）。

- 引用的设计规范：不涉及：无视觉、交互或界面文案变化。

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：通过（52 workspace PASS / 0 FAIL），在最终代码状态上重跑过一次

pnpm --filter desktop run typecheck
结果：通过

pnpm --filter @cindy/mcps run build   # tsc --noEmit
结果：通过

pnpm check:dco
结果：通过（1 commit signed off，range b247c2d3..528e4455）
```

新增／调整的定向用例：

- `packages/lizi-mcps/src/ios-simulator/iosSimulatorMcpServer.test.ts`
  - 每条对外描述都以 `[iOS Simulator] ` 开头，且 `open_simulator_url` 明确指向浏览器/抓取工具
  - 旧名不出现在 `list_tools`、新名出现；用旧名 `open_url` 调用仍然成功，并以 **Host 旧名 + 原样参数**
    落到 Host（存量插件/prompt 不受影响的证据）
  - 无路由的 `open_simulator_url` 在到 Host 之前就 `INVALID_ARGS`，Host 未被调用（这是第 3 条改动
    可以安全 `auto-approve` 的前提）
- `apps/desktop/src/main/maker-host/__tests__/mcpToolApprovalPolicy.test.ts`
  - 带路由的 `build_app` / `open_simulator_url` → `prompt-each-time`；无路由 → `auto-approve`
  - **旧名 `open_url` 带路由同样 `prompt-each-time`**（别名不能成为绕过设备授权的口子）
  - `create_instance` / `attach_device` 无论有无路由都 `prompt-each-time`
- `apps/desktop/src/main/maker-host/__tests__/mcpToolApprovalPolicy.test.ts`（第二轮 review 后追加）
  - stringified `args` / stringified 外层 `toolParams` 带路由时仍 `prompt-each-time`
    （`jsonObjectArg` 会把字符串 parse 回对象，审批必须判定 Host 最终收到的那个值）
  - stringified 无路由仍 `auto-approve`；`undefined` / 非 JSON 字符串 / 数组 / 数字一律 fail closed
- `apps/desktop/src/main/mcp-integrations/__tests__/ios-simulator.test.ts`
  - `describeTools` 上报的键必须与 registry 对外播的名**完全一致**（防止改名后 availability 表漏改
    而静默退化成 `TOOL_NOT_REPORTED`），**两条返回路径都覆盖**：就绪路径与「会话被拒」路径，后者还
    断言真实的 `SESSION_NOT_FOUND` 仍能带出

### 手工验证

不涉及。

### 未执行的验证

- 未跑起 Desktop 在真实 Codex / Claude 会话里目视工具面与弹窗时机；本 PR 的保证由上述单测覆盖
  （描述前缀、别名可调用、无路由不弹窗、availability 键一致）。
- 未验证「改名后模型是否真的不再误选」这类行为效果，这取决于模型，只能靠后续实际使用观察。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [x] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [x] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- **system prompt**：改动的是两个网关工具描述与 49 条内层工具描述（都在模型上下文里）。只增加域
  前缀与负向约束句，不改变任何行为判据；回滚即恢复原文案。设置页可见的内置插件描述**未改动**
  （第二轮 review 后撤回：那条只经 `listPlugins()` 进设置页，不进模型上下文）。
- **权限 / 安全**：审批策略是本 PR 的敏感面，两条不变量都有测试锁住：
  1. 内层名判定前统一 canonical 化，**旧名与新名命中完全相同的策略**，别名不构成绕过；
  2. 放宽只发生在「调用不可能触达设备」的形状上——没有 owned instance 路由时，registry 的
     `z.strictObject` 校验会先返回 `INVALID_ARGS`，Host 收不到该调用；`create_instance` /
     `attach_device` 未放宽。设备级授权强度不变。
- **存量插件兼容：无影响。** 用户升级后什么都不做：已装、已批准、已启用的插件照旧可用，不需要重装、
  不需要重新确认权限、不需要重新配置。按旧名写死的插件 Skill、保存的 prompt 与工作流仍能调用
  （旧名是隐藏别名），只是 `list_tools` 只播新名。批准状态 schema、指纹、manifest 校验、安装布局与
  包格式**均未触碰**。本 PR 也未改动插件运行时／沙箱、能力 slot 契约或装入 UI。
- 回滚 / 降级方式：整体 revert 即可，无数据迁移。别名表与描述都是纯代码，回滚后旧名重新成为对外名。
- 后续项（不在本 PR）：eager 暴露的收窄判据；#2404 的 shell 守卫误拦是这次误路由的上游诱因。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（`docs/ios-simulator-integration-plan.md` 的工具表与授权段已同步改名与新语义）
- [x] 已确认测试结果或说明未执行原因
