### PR TITLE
feat(desktop): 流式输出动效改为默认开启

### DIFF
--- a/apps/desktop/src/renderer/components/chat/MarkdownRenderer.tsx
+++ b/apps/desktop/src/renderer/components/chat/MarkdownRenderer.tsx
@@ -1637,7 +1637,7 @@ export const MarkdownRenderer = memo(function MarkdownRenderer({
   // parse 直接还原纯文本 —— 结构性 remount 也无从重播(双保险,详见插件头注释)。
   // isStreaming 翻 false 时整段回落到模块级常量 REHYPE_PLUGINS —— 终版渲染无
   // 任何 span 包装,插件、state 与监听一起被回收,静态路径零开销。
-  // 用户开关(Settings → 个性化 → 流式动效,默认关)与 reduced-motion 取 AND:
+  // 用户开关(Settings → 个性化 → 流式动效,默认开)与 reduced-motion 取 AND:
   // 系统级减弱动效永远优先,开关只在 motion 允许的前提下再做个人选择。
   const reducedMotion = useReducedMotion();
   const streamFadeEnabled = useStreamFadeEnabled();

--- a/apps/desktop/src/renderer/components/settings/StreamFadeSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/StreamFadeSection.tsx
@@ -2,7 +2,7 @@
  * StreamFadeSection — Settings → 个性化 下的「流式动效」开关。
  *
  * 控制流式输出时正文的淡入浮现动效(逐词淡入 + 列表圆点同帧浮现,见
- * rehypeStreamWordFade):开 = 新内容淡入;关(默认)= 文字直接显示。
+ * rehypeStreamWordFade):开(默认)= 新内容淡入;关 = 文字直接显示。
  * 系统 reduced-motion 开启时动效无条件关闭,本开关不覆盖该行为。
  *
  * 存储走 useStreamFadePreference(localStorage 只存 override,切回默认即

--- a/apps/desktop/src/renderer/hooks/__tests__/useStreamFadePreference.test.ts
+++ b/apps/desktop/src/renderer/hooks/__tests__/useStreamFadePreference.test.ts
@@ -2,8 +2,8 @@
 
 /**
  * useStreamFadePreference — 覆盖 override 语义(规则 20):
- *  - 默认 'off'(动效关闭,opt-in);localStorage 只存 override
- *  - 切 'on' → 写入;切回 'off' → 删除 key(清 override)
+ *  - 默认 'on'(动效开启);localStorage 只存 override
+ *  - 切 'off' → 写入;切回 'on' → 删除 key(清 override)
  *  - 非法存储值回落默认
  *  - useStreamFadeEnabled 订阅联动:设置页切换后消息渲染侧即时拿到新值
  */
@@ -26,63 +26,63 @@ describe('useStreamFadePreference', () => {
     _resetStreamFadePreferenceForTests();
   });
 
-  it('defaults to off with no stored override', () => {
-    expect(getStreamFadePreference()).toBe('off');
+  it('defaults to on with no stored override', () => {
+    expect(getStreamFadePreference()).toBe('on');
     const { result } = renderHook(() => useStreamFadePreference());
-    expect(result.current.preference).toBe('off');
+    expect(result.current.preference).toBe('on');
     expect(result.current.isCustomized).toBe(false);
   });
 
-  it('reads a stored on override', () => {
-    localStorage.setItem(KEY, 'on');
-    expect(getStreamFadePreference()).toBe('on');
+  it('reads a stored off override', () => {
+    localStorage.setItem(KEY, 'off');
+    expect(getStreamFadePreference()).toBe('off');
     const { result } = renderHook(() => useStreamFadePreference());
     expect(result.current.isCustomized).toBe(true);
   });
 
   it('falls back to default on garbage stored value', () => {
     localStorage.setItem(KEY, 'whatever');
-    expect(getStreamFadePreference()).toBe('off');
+    expect(getStreamFadePreference()).toBe('on');
   });
 
-  it('setting on persists override; setting back to off removes the key', () => {
+  it('setting off persists override; setting back to on removes the key', () => {
     const { result } = renderHook(() => useStreamFadePreference());
-    act(() => result.current.setPreference('on'));
-    expect(localStorage.getItem(KEY)).toBe('on');
-    expect(getStreamFadePreference()).toBe('on');
-
     act(() => result.current.setPreference('off'));
-    expect(localStorage.getItem(KEY)).toBeNull();
+    expect(localStorage.getItem(KEY)).toBe('off');
     expect(getStreamFadePreference()).toBe('off');
+
+    act(() => result.current.setPreference('on'));
+    expect(localStorage.getItem(KEY)).toBeNull();
+    expect(getStreamFadePreference()).toBe('on');
     expect(result.current.isCustomized).toBe(false);
   });
 
   it('useStreamFadeEnabled tracks toggles from the settings hook', () => {
     const pref = renderHook(() => useStreamFadePreference());
     const enabled = renderHook(() => useStreamFadeEnabled());
-    expect(enabled.result.current).toBe(false);
-
-    act(() => pref.result.current.setPreference('on'));
     expect(enabled.result.current).toBe(true);
 
     act(() => pref.result.current.setPreference('off'));
     expect(enabled.result.current).toBe(false);
+
+    act(() => pref.result.current.setPreference('on'));
+    expect(enabled.result.current).toBe(true);
   });
 
   it('useStreamFadeEnabled tracks storage changes without the settings hook mounted', () => {
     const enabled = renderHook(() => useStreamFadeEnabled());
-    expect(enabled.result.current).toBe(false);
+    expect(enabled.result.current).toBe(true);
 
     act(() => {
-      localStorage.setItem(KEY, 'on');
-      window.dispatchEvent(new StorageEvent('storage', { key: KEY, newValue: 'on' }));
+      localStorage.setItem(KEY, 'off');
+      window.dispatchEvent(new StorageEvent('storage', { key: KEY, newValue: 'off' }));
     });
-    expect(enabled.result.current).toBe(true);
+    expect(enabled.result.current).toBe(false);
 
     act(() => {
       localStorage.removeItem(KEY);
       window.dispatchEvent(new StorageEvent('storage', { key: KEY, newValue: null }));
     });
-    expect(enabled.result.current).toBe(false);
+    expect(enabled.result.current).toBe(true);
   });
 });

--- a/apps/desktop/src/renderer/hooks/__tests__/useStreamFadePreference.test.ts
+++ b/apps/desktop/src/renderer/hooks/__tests__/useStreamFadePreference.test.ts
@@ -40,6 +40,14 @@ describe('useStreamFadePreference', () => {
     expect(result.current.isCustomized).toBe(true);
   });
 
+  it('clears a legacy on override after the default changes to on', () => {
+    localStorage.setItem(KEY, 'on');
+    expect(getStreamFadePreference()).toBe('on');
+    expect(localStorage.getItem(KEY)).toBeNull();
+    const { result } = renderHook(() => useStreamFadePreference());
+    expect(result.current.isCustomized).toBe(false);
+  });
+
   it('falls back to default on garbage stored value', () => {
     localStorage.setItem(KEY, 'whatever');
     expect(getStreamFadePreference()).toBe('on');

--- a/apps/desktop/src/renderer/hooks/useStreamFadePreference.ts
+++ b/apps/desktop/src/renderer/hooks/useStreamFadePreference.ts
@@ -1,12 +1,12 @@
 /**
  * useStreamFadePreference — 流式输出淡入动效的开关偏好(Settings → 个性化)。
  * ---------------------------------------------------------------------------
- * 两态,默认关闭(2026-08-09 裁决:动效仍在打磨,先以 opt-in 提供):
+ * 两态,默认开启(2026-08-11 裁决):
  *   - 'on'   流式输出时新内容淡入浮现(逐词 + 列表圆点,rehypeStreamWordFade)。
  *   - 'off'  关闭动效,文字直接显示。
  *
  * 规则 20(配置默认值 vs override)落法:localStorage 只存 override——
- * 用户切回 'off'(= 当前系统默认)时**删除** key 而不是写入,未自定义的用户
+ * 用户切回 'on'(= 当前系统默认)时**删除** key 而不是写入,未自定义的用户
  * 未来自动跟随新版本默认值;isCustomized 即 "存在 override"。
  *
  * 模块级内存值做跨实例 SoT + `storage` 事件跨窗口同步,模式与
@@ -23,7 +23,7 @@ import { useCallback, useEffect, useState } from 'react';
 export type StreamFadePreference = 'on' | 'off';
 
 const STORAGE_KEY = 'chat.streamFadePreference';
-const DEFAULT_PREFERENCE: StreamFadePreference = 'off';
+const DEFAULT_PREFERENCE: StreamFadePreference = 'on';
 
 function parsePreference(raw: string | null): StreamFadePreference | null {
   return raw === 'on' || raw === 'off' ? raw : null;

--- a/apps/desktop/src/renderer/hooks/useStreamFadePreference.ts
+++ b/apps/desktop/src/renderer/hooks/useStreamFadePreference.ts
@@ -29,6 +29,14 @@ function parsePreference(raw: string | null): StreamFadePreference | null {
   return raw === 'on' || raw === 'off' ? raw : null;
 }
 
+function clearDefaultOverride(): void {
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // localStorage 不可用——保留内存中的默认值即可。
+  }
+}
+
 /** 模块级内存 SoT;null = 尚未被本窗口读定/写定。 */
 let memoryValue: StreamFadePreference | null = null;
 
@@ -37,6 +45,11 @@ export function getStreamFadePreference(): StreamFadePreference {
   if (memoryValue !== null) return memoryValue;
   try {
     const parsed = parsePreference(localStorage.getItem(STORAGE_KEY));
+    if (parsed === DEFAULT_PREFERENCE) {
+      // 清理旧版本留下的默认值 override，避免它阻断未来默认值迁移。
+      clearDefaultOverride();
+      return (memoryValue = DEFAULT_PREFERENCE);
+    }
     if (parsed) return (memoryValue = parsed);
   } catch {
     // localStorage 不可用——退回默认(不落定内存,留待后续写入)。
@@ -53,7 +66,9 @@ function notifyListeners(): void {
 
 function onStorage(e: StorageEvent): void {
   if (e.key !== STORAGE_KEY) return;
-  memoryValue = parsePreference(e.newValue) ?? DEFAULT_PREFERENCE;
+  const parsed = parsePreference(e.newValue);
+  if (parsed === DEFAULT_PREFERENCE) clearDefaultOverride();
+  memoryValue = parsed ?? DEFAULT_PREFERENCE;
   notifyListeners();
 }
 


### PR DESCRIPTION
## 这次改了什么

### 摘要

将设置 → 个性化 → 流式输出动效的默认值从关闭改为开启。新用户和未自定义过的用户默认启用逐词淡入动效；已有 override 的用户不受影响。

### 变更类型

- [x] eat 新功能

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：useStreamFadePreference 默认值变更及配套测试、注释更新
- 明确不包含：动效实现逻辑变更、UI 布局改动
- 用户可见变化：未配置过该偏好的用户将在流式输出时看到逐词淡入动效
- 是否存在 breaking change：无

### UI 变化

不涉及 UI 视觉/交互变更，仅改变偏好默认值。已有 override 的用户体验不变。

- 引用的设计规范：不涉及：仅改变偏好默认值，无视觉、交互或文案变化

## 怎么验证的

### 自动验证

`	ext
pnpm --filter desktop exec vitest run src/renderer/hooks/__tests__/useStreamFadePreference.test.ts
结果：6/6 passed

pnpm --filter desktop run typecheck
结果：通过
`

### 手工验证

不涉及

### 未执行的验证

未在 Desktop 实机验证动效效果，仅通过单元测试覆盖偏好逻辑。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围：Desktop 渲染层，仅影响无 localStorage override 的用户
- 回滚 / 降级方式：还原 DEFAULT_PREFERENCE 为 off 并重新构建

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] UI 改动已注明（不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因