### PR TITLE
fix(bridge): keep Chat requests working without web search

### DIFF
--- a/packages/responses-chat-bridge/src/__tests__/handler.test.ts
+++ b/packages/responses-chat-bridge/src/__tests__/handler.test.ts
@@ -115,6 +115,35 @@ describe('createResponsesChatHandler', () => {
     });
   });
 
+  it('rejects an explicit tool_choice for a dropped web_search tool', async () => {
+    const fetchImpl = vi.fn() as unknown as typeof fetch;
+    const warn = vi.fn();
+    const handler = createResponsesChatHandler({
+      upstreamBase: 'https://provider.example/v1',
+      buildHeaders: async () => ({}),
+    }, { fetchImpl, logger: { warn } });
+    const res = new FakeResponse();
+
+    await handler.handle({
+      parsedBody: {
+        model: 'custom-model',
+        input: [{ type: 'message', role: 'user', content: 'search' }],
+        tools: [{ type: 'web_search' }],
+        tool_choice: { type: 'function', name: 'web_search' },
+      },
+      res: res as never,
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.chunks.join('')).toContain('unsupported_feature');
+    expect(res.chunks.join('')).toContain('tool_choice.web_search');
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith('responses-chat bridge rejected unsupported feature', {
+      model: 'custom-model',
+      feature: 'tool_choice.web_search',
+    });
+  });
+
   it('preserves the upstream base query when applying the chat path', async () => {
     const fetchImpl = vi.fn(async () =>
       streamResponse([

--- a/packages/responses-chat-bridge/src/__tests__/handler.test.ts
+++ b/packages/responses-chat-bridge/src/__tests__/handler.test.ts
@@ -144,6 +144,43 @@ describe('createResponsesChatHandler', () => {
     });
   });
 
+  it('keeps a same-named retained function tool selectable beside web_search', async () => {
+    const fetchImpl = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body));
+      expect(body.tools).toEqual([
+        { type: 'function', function: { name: 'web_search', parameters: { type: 'object' } } },
+      ]);
+      expect(body.tool_choice).toEqual({
+        type: 'function',
+        function: { name: 'web_search' },
+      });
+      return streamResponse([
+        { id: 'chat_1', choices: [{ delta: {}, finish_reason: 'stop' }] },
+      ]);
+    }) as typeof fetch;
+    const handler = createResponsesChatHandler({
+      upstreamBase: 'https://provider.example/v1',
+      buildHeaders: async () => ({}),
+    }, { fetchImpl });
+    const res = new FakeResponse();
+
+    await handler.handle({
+      parsedBody: {
+        model: 'custom-model',
+        input: [{ type: 'message', role: 'user', content: 'call the function' }],
+        tools: [
+          { type: 'function', name: 'web_search', parameters: { type: 'object' } },
+          { type: 'web_search' },
+        ],
+        tool_choice: { type: 'function', name: 'web_search' },
+      },
+      res: res as never,
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(res.status).toBe(200);
+  });
+
   it('preserves the upstream base query when applying the chat path', async () => {
     const fetchImpl = vi.fn(async () =>
       streamResponse([

--- a/packages/responses-chat-bridge/src/__tests__/handler.test.ts
+++ b/packages/responses-chat-bridge/src/__tests__/handler.test.ts
@@ -144,6 +144,65 @@ describe('createResponsesChatHandler', () => {
     });
   });
 
+  it('rejects a required tool_choice when the only tool is a dropped web_search', async () => {
+    const fetchImpl = vi.fn() as unknown as typeof fetch;
+    const warn = vi.fn();
+    const handler = createResponsesChatHandler({
+      upstreamBase: 'https://provider.example/v1',
+      buildHeaders: async () => ({}),
+    }, { fetchImpl, logger: { warn } });
+    const res = new FakeResponse();
+
+    await handler.handle({
+      parsedBody: {
+        model: 'custom-model',
+        input: [{ type: 'message', role: 'user', content: 'search' }],
+        tools: [{ type: 'web_search' }],
+        tool_choice: 'required',
+      },
+      res: res as never,
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.chunks.join('')).toContain('unsupported_feature');
+    expect(res.chunks.join('')).toContain('tool_choice.web_search');
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('keeps a required tool_choice when another tool survives beside web_search', async () => {
+    const fetchImpl = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body));
+      expect(body.tools).toEqual([
+        { type: 'function', function: { name: 'exec', parameters: { type: 'object' } } },
+      ]);
+      expect(body.tool_choice).toBe('required');
+      return streamResponse([
+        { id: 'chat_1', choices: [{ delta: {}, finish_reason: 'stop' }] },
+      ]);
+    }) as typeof fetch;
+    const handler = createResponsesChatHandler({
+      upstreamBase: 'https://provider.example/v1',
+      buildHeaders: async () => ({}),
+    }, { fetchImpl });
+    const res = new FakeResponse();
+
+    await handler.handle({
+      parsedBody: {
+        model: 'custom-model',
+        input: [{ type: 'message', role: 'user', content: 'do it' }],
+        tools: [
+          { type: 'function', name: 'exec', parameters: { type: 'object' } },
+          { type: 'web_search' },
+        ],
+        tool_choice: 'required',
+      },
+      res: res as never,
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(res.status).toBe(200);
+  });
+
   it('keeps a same-named retained function tool selectable beside web_search', async () => {
     const fetchImpl = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
       const body = JSON.parse(String(init?.body));

--- a/packages/responses-chat-bridge/src/__tests__/handler.test.ts
+++ b/packages/responses-chat-bridge/src/__tests__/handler.test.ts
@@ -273,6 +273,42 @@ describe('createResponsesChatHandler', () => {
     expect(res.status).toBe(200);
   });
 
+  it('keeps a nested same-named function selectable beside web_search', async () => {
+    const fetchImpl = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body));
+      expect(body.tools?.map((tool: { function: { name: string } }) => tool.function.name))
+        .toContain('web_search');
+      expect(body.tool_choice).toEqual({
+        type: 'function',
+        function: { name: 'web_search' },
+      });
+      return streamResponse([
+        { id: 'chat_1', choices: [{ delta: {}, finish_reason: 'stop' }] },
+      ]);
+    }) as typeof fetch;
+    const handler = createResponsesChatHandler({
+      upstreamBase: 'https://provider.example/v1',
+      buildHeaders: async () => ({}),
+    }, { fetchImpl });
+    const res = new FakeResponse();
+
+    await handler.handle({
+      parsedBody: {
+        model: 'custom-model',
+        input: [{ type: 'message', role: 'user', content: 'call the nested function' }],
+        tools: [
+          { type: 'function', function: { name: 'web_search', parameters: { type: 'object' } } },
+          { type: 'web_search' },
+        ],
+        tool_choice: { type: 'function', name: 'web_search' },
+      },
+      res: res as never,
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(res.status).toBe(200);
+  });
+
   it('preserves the upstream base query when applying the chat path', async () => {
     const fetchImpl = vi.fn(async () =>
       streamResponse([

--- a/packages/responses-chat-bridge/src/__tests__/handler.test.ts
+++ b/packages/responses-chat-bridge/src/__tests__/handler.test.ts
@@ -73,8 +73,17 @@ describe('createResponsesChatHandler', () => {
     expect(res.ended).toBe(true);
   });
 
-  it('rejects a built-in web_search tool instead of silently dropping it', async () => {
-    const fetchImpl = vi.fn() as unknown as typeof fetch;
+  it('drops an unsupported built-in web_search tool and continues upstream', async () => {
+    const fetchImpl = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body));
+      expect(body.tools).toEqual([
+        { type: 'function', function: { name: 'exec', parameters: { type: 'object' } } },
+      ]);
+      return streamResponse([
+        { id: 'chat_1', choices: [{ delta: { content: 'ok' } }] },
+        { id: 'chat_1', choices: [{ delta: {}, finish_reason: 'stop' }] },
+      ]);
+    }) as typeof fetch;
     const warn = vi.fn();
     const handler = createResponsesChatHandler({
       upstreamBase: 'https://provider.example/v1',
@@ -86,20 +95,23 @@ describe('createResponsesChatHandler', () => {
       parsedBody: {
         model: 'custom-model',
         input: [{ type: 'message', role: 'user', content: 'search' }],
-        tools: [{ type: 'web_search' }],
+        tools: [
+          { type: 'function', name: 'exec', parameters: { type: 'object' } },
+          { type: 'web_search' },
+        ],
       },
       res: res as never,
     });
 
-    expect(res.status).toBe(400);
-    expect(res.chunks.join('')).toContain('unsupported_feature');
-    expect(res.chunks.join('')).toContain('tools[0]');
-    expect(res.chunks.join('')).toContain('web_search');
-    expect(fetchImpl).not.toHaveBeenCalled();
-    expect(warn).toHaveBeenCalledTimes(1);
-    expect(warn).toHaveBeenCalledWith('responses-chat bridge rejected unsupported feature', {
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(res.status).toBe(200);
+    expect(res.chunks.join('')).toContain('ok');
+    expect(res.ended).toBe(true);
+    expect(warn).toHaveBeenCalledWith('responses-chat bridge dropped unsupported built-in tool', {
       model: 'custom-model',
-      feature: 'tools[0].web_search',
+      tool: 'web_search',
+      index: 1,
+      action: 'continue_without_tool',
     });
   });
 

--- a/packages/responses-chat-bridge/src/__tests__/handler.test.ts
+++ b/packages/responses-chat-bridge/src/__tests__/handler.test.ts
@@ -240,6 +240,39 @@ describe('createResponsesChatHandler', () => {
     expect(res.status).toBe(200);
   });
 
+  it('keeps a same-named string custom tool selectable beside web_search', async () => {
+    const fetchImpl = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body));
+      expect(body.tools?.map((tool: { function: { name: string } }) => tool.function.name))
+        .toContain('web_search');
+      expect(body.tool_choice).toEqual({
+        type: 'function',
+        function: { name: 'web_search' },
+      });
+      return streamResponse([
+        { id: 'chat_1', choices: [{ delta: {}, finish_reason: 'stop' }] },
+      ]);
+    }) as typeof fetch;
+    const handler = createResponsesChatHandler({
+      upstreamBase: 'https://provider.example/v1',
+      buildHeaders: async () => ({}),
+    }, { fetchImpl });
+    const res = new FakeResponse();
+
+    await handler.handle({
+      parsedBody: {
+        model: 'custom-model',
+        input: [{ type: 'message', role: 'user', content: 'call the custom tool' }],
+        tools: ['web_search', { type: 'web_search' }],
+        tool_choice: { type: 'custom', name: 'web_search' },
+      },
+      res: res as never,
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(res.status).toBe(200);
+  });
+
   it('preserves the upstream base query when applying the chat path', async () => {
     const fetchImpl = vi.fn(async () =>
       streamResponse([

--- a/packages/responses-chat-bridge/src/handler.ts
+++ b/packages/responses-chat-bridge/src/handler.ts
@@ -166,7 +166,13 @@ export function createResponsesChatHandler(
           capabilities: provider.capabilities,
           onDroppedTool: (type, index) => {
             if (type === 'web_search') {
-              throw new UnsupportedResponsesFeatureError(`tools[${index}].web_search`);
+              log.warn?.('responses-chat bridge dropped unsupported built-in tool', {
+                model: request.model,
+                tool: type,
+                index,
+                action: 'continue_without_tool',
+              });
+              return;
             }
             log.warn?.('responses-chat bridge dropped non-function tool', { type, index });
           },

--- a/packages/responses-chat-bridge/src/translate-request.ts
+++ b/packages/responses-chat-bridge/src/translate-request.ts
@@ -845,11 +845,22 @@ export function translateResponsesRequestWithContext(
   const developerRole = capabilities.developerRole ?? 'system';
   const toolContext = ChatBridgeToolContext.fromRequest(input);
   reportDroppedTools(input.tools, opts.onDroppedTool);
-  if (
-    hasDroppedWebSearchTool(input.tools)
-    && explicitlySelectsDroppedWebSearch(input.tools, input.tool_choice)
-  ) {
-    throw new UnsupportedResponsesFeatureError('tool_choice.web_search');
+  if (hasDroppedWebSearchTool(input.tools)) {
+    // Ordinary/auto requests keep degrading (web_search removed, other tools preserved). Stay
+    // fail-closed only when the request can be satisfied *solely* by the dropped web_search:
+    // either it explicitly selects web_search, or it demands `required` while every convertible
+    // tool was dropped, leaving no tool the upstream could call. Otherwise `required` is silently
+    // relaxed and a search-less provider answers as though no tool were requested.
+    const requiresDroppedWebSearch =
+      explicitlySelectsDroppedWebSearch(input.tools, input.tool_choice)
+      || (
+        input.tool_choice === 'required'
+        && capabilities.forceAutoToolChoice !== true
+        && toolContext.chatTools === undefined
+      );
+    if (requiresDroppedWebSearch) {
+      throw new UnsupportedResponsesFeatureError('tool_choice.web_search');
+    }
   }
   const messages = translateInput(input.input, {
     developerRole,

--- a/packages/responses-chat-bridge/src/translate-request.ts
+++ b/packages/responses-chat-bridge/src/translate-request.ts
@@ -692,6 +692,23 @@ function reportDroppedTools(
   });
 }
 
+function hasDroppedWebSearchTool(tools: ResponsesRequest['tools']): boolean {
+  return (tools ?? []).some((tool) => (
+    isPlainObject(tool) && tool.type === 'web_search'
+  ));
+}
+
+function explicitlySelectsWebSearch(choice: unknown): boolean {
+  if (!isPlainObject(choice)) return false;
+  if (choice.type === 'web_search') return true;
+  if (
+    (choice.type === 'function' || choice.type === 'custom')
+    && choice.name === 'web_search'
+  ) return true;
+  const nestedFunction = isPlainObject(choice.function) ? choice.function : undefined;
+  return nestedFunction?.name === 'web_search';
+}
+
 function translateToolChoice(
   choice: unknown,
   forceAuto: boolean,
@@ -806,6 +823,9 @@ export function translateResponsesRequestWithContext(
   const developerRole = capabilities.developerRole ?? 'system';
   const toolContext = ChatBridgeToolContext.fromRequest(input);
   reportDroppedTools(input.tools, opts.onDroppedTool);
+  if (hasDroppedWebSearchTool(input.tools) && explicitlySelectsWebSearch(input.tool_choice)) {
+    throw new UnsupportedResponsesFeatureError('tool_choice.web_search');
+  }
   const messages = translateInput(input.input, {
     developerRole,
     mediaCapabilities: capabilities,

--- a/packages/responses-chat-bridge/src/translate-request.ts
+++ b/packages/responses-chat-bridge/src/translate-request.ts
@@ -705,6 +705,10 @@ function hasRetainedTool(
   namespace?: string,
 ): boolean {
   for (const tool of tools ?? []) {
+    if (typeof tool === 'string') {
+      if (kind === 'custom' && namespace === undefined && tool === name) return true;
+      continue;
+    }
     if (!isPlainObject(tool)) continue;
     if (tool.type === kind && tool.name === name && namespace === undefined) return true;
     if (tool.type === 'namespace' && tool.name === namespace) {

--- a/packages/responses-chat-bridge/src/translate-request.ts
+++ b/packages/responses-chat-bridge/src/translate-request.ts
@@ -698,15 +698,37 @@ function hasDroppedWebSearchTool(tools: ResponsesRequest['tools']): boolean {
   ));
 }
 
-function explicitlySelectsWebSearch(choice: unknown): boolean {
+function hasRetainedTool(
+  tools: ResponsesRequest['tools'],
+  kind: 'function' | 'custom',
+  name: string,
+  namespace?: string,
+): boolean {
+  for (const tool of tools ?? []) {
+    if (!isPlainObject(tool)) continue;
+    if (tool.type === kind && tool.name === name && namespace === undefined) return true;
+    if (tool.type === 'namespace' && tool.name === namespace) {
+      const children = Array.isArray(tool.tools) ? tool.tools : tool.children;
+      if (Array.isArray(children) && children.some((child) => (
+        isPlainObject(child) && child.type === kind && child.name === name
+      ))) return true;
+    }
+  }
+  return false;
+}
+
+function explicitlySelectsDroppedWebSearch(
+  tools: ResponsesRequest['tools'],
+  choice: unknown,
+): boolean {
   if (!isPlainObject(choice)) return false;
   if (choice.type === 'web_search') return true;
-  if (
-    (choice.type === 'function' || choice.type === 'custom')
-    && choice.name === 'web_search'
-  ) return true;
+  if (choice.type !== 'function' && choice.type !== 'custom') return false;
   const nestedFunction = isPlainObject(choice.function) ? choice.function : undefined;
-  return nestedFunction?.name === 'web_search';
+  const name = typeof choice.name === 'string' ? choice.name : nestedFunction?.name;
+  if (name !== 'web_search') return false;
+  const namespace = typeof choice.namespace === 'string' ? choice.namespace : undefined;
+  return !hasRetainedTool(tools, choice.type, name, namespace);
 }
 
 function translateToolChoice(
@@ -823,7 +845,10 @@ export function translateResponsesRequestWithContext(
   const developerRole = capabilities.developerRole ?? 'system';
   const toolContext = ChatBridgeToolContext.fromRequest(input);
   reportDroppedTools(input.tools, opts.onDroppedTool);
-  if (hasDroppedWebSearchTool(input.tools) && explicitlySelectsWebSearch(input.tool_choice)) {
+  if (
+    hasDroppedWebSearchTool(input.tools)
+    && explicitlySelectsDroppedWebSearch(input.tools, input.tool_choice)
+  ) {
     throw new UnsupportedResponsesFeatureError('tool_choice.web_search');
   }
   const messages = translateInput(input.input, {

--- a/packages/responses-chat-bridge/src/translate-request.ts
+++ b/packages/responses-chat-bridge/src/translate-request.ts
@@ -710,7 +710,13 @@ function hasRetainedTool(
       continue;
     }
     if (!isPlainObject(tool)) continue;
-    if (tool.type === kind && tool.name === name && namespace === undefined) return true;
+    const nested = isPlainObject(tool.function) ? tool.function : undefined;
+    const toolName = typeof tool.name === 'string'
+      ? tool.name
+      : typeof nested?.name === 'string'
+        ? nested.name
+        : undefined;
+    if (tool.type === kind && toolName === name && namespace === undefined) return true;
     if (tool.type === 'namespace' && tool.name === namespace) {
       const children = Array.isArray(tool.tools) ? tool.tools : tool.children;
       if (Array.isArray(children) && children.some((child) => (


### PR DESCRIPTION
## 这次改了什么

### 摘要

Chat Completions bridge 收到 Codex 常驻的内建 `web_search` 工具时，不再因为该工具没有 Chat Completions 等价表示而返回 `400 unsupported_feature`、阻断整条消息。

本 PR 将这类请求恢复为显式降级：bridge 丢弃无法转换的 `web_search`，记录包含模型、工具索引和降级动作的 warning，然后保留 `exec` 等普通 function tools 并继续请求上游。

背景：#1593 指出旧行为会静默丢弃搜索能力；#2239 因此改为 fail-closed。实际在 Codex + 自定义 Chat Completions provider（例如 GLM / DeepSeek 兼容端点）中，`web_search` 是常驻工具，即使用户只是发送普通消息也会触发 fail-closed，导致请求尚未到达上游就失败。Claude 框架不经过这条 Responses → Chat bridge，因此不受影响。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#1593、#2239、#2377
- 本 PR 包含：`web_search` 的 drop-and-continue 降级；结构化 warning；验证其他 function tools 仍发送到上游的回归测试。
- 明确不包含：新增 Cindy 托管搜索 function tool；修改 Claude 框架；UI 能力提示；provider 原生搜索能力协商。
- 用户可见变化：使用 Codex 框架连接 Chat Completions provider 时，内建搜索不可转换不再导致消息发送失败；该轮仍可使用保留下来的普通工具（包括 `exec`）作为现有的有限 fallback。
- 是否存在 breaking change：有。#2239 引入的 `web_search` fail-closed 400 改为显式降级并继续请求上游。

### UI 变化

- 不涉及：仅修改协议 bridge 与单元测试。
- 引用的设计规范：不涉及。

## 怎么验证的

### 自动验证

```text
pnpm --filter @cindy/responses-chat-bridge test -- src/__tests__/handler.test.ts src/__tests__/translate-request.test.ts
结果：133 passed

pnpm --filter @cindy/responses-chat-bridge typecheck
结果：passed

pnpm test:unit
结果：passed（首次运行遇到 1 个无关 Renderer 偶发失败；该用例单独重跑 9/9 passed，随后完整重跑全部通过）

pnpm --dir apps/desktop exec vitest run src/renderer/__tests__/customProviderDialogPresetLocale.test.tsx --pool=threads --maxWorkers=1
结果：9 passed

pnpm check:dco
结果：passed

git diff --check HEAD
结果：passed
```

补充：执行了 `pnpm --filter @cindy/responses-chat-bridge lint`，被 `src/translate-request.ts:765` 的既有 `_type` 未使用错误阻断；该文件本次未修改。

### 手工验证

未在当前运行中的 Desktop 中做端到端验证：宿主应用不运行此隔离 worktree 的代码。回归测试直接验证了以下协议行为：

- `web_search` 未进入 Chat Completions 请求；
- `exec` function tool 保留；
- 上游 `fetch` 被调用；
- Responses 事件正常返回；
- warning 明确记录 `continue_without_tool`。

### 未执行的验证

- 未对真实 GLM / DeepSeek 自定义端点做端到端请求；待包含该提交的 Desktop 构建验证。
- 未验证模型一定会主动使用 `exec` 联网；本 PR 只保证现有 fallback 工具不被 bridge 一并丢弃，不承诺搜索成功。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [x] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Responses → Chat Completions bridge 中携带内建 `web_search` 的请求。原生 Responses provider、Claude 框架和普通 function tool 转换不变。
- 行为风险：需要原生搜索的请求可能在没有原生搜索的情况下继续回答；warning 会明确记录降级，普通 function tools（含 `exec`）仍可作为当前有限 fallback。
- 核心指标评估：不修改 system prompt、工具注册顺序、事件 translator 或 usage；只删除原本的本地 400 短路。缓存率无变化；成功路径新增一次固定 warning 调用，没有新增网络往返；回归测试验证工具保留与事件返回准确性。
- 回滚 / 降级方式：回滚本提交即可恢复 #2239 的 fail-closed 行为。

### 后续建议（不阻塞本 PR）

1. 在 provider 能力层决定是否暴露原生 `web_search`，避免由 bridge 被动降级。
2. 评估把 Cindy 托管搜索作为标准 function tool 接入 Codex，但作为独立需求处理凭证、额度、权限和多轮回填。
3. 若暂不接托管搜索，可补充可观测性/UI 能力状态，区分“普通消息已发送”和“本轮没有原生搜索”。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（不涉及独立文档改动；上下文和后续方案记录在本 PR）
- [x] 已确认测试结果或说明未执行原因
