### PR TITLE
fix(codex): 修复非 GPT 模型无法使用 Cindy 插件

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
@@ -310,6 +310,15 @@ describe('withCodexUpstreamRecording', () => {
 });
 
 describe('codex gateway config', () => {
+  it('所有认证模式都让缺少 model metadata 的 Codex 模型使用 CodeModeOnly', async () => {
+    const { buildCodexProxySpawnArgs } = await import('../codex-gateway-config.js');
+
+    for (const mode of ['oauth-bearer', 'env-key', 'provider-oauth'] as const) {
+      const args = buildCodexProxySpawnArgs('http://127.0.0.1:12345', mode);
+      expect(args).toContain('features.code_mode_only=true');
+    }
+  });
+
   it('oauth-bearer 模式: requires_openai_auth, 不带 env_key', async () => {
     const { buildCodexProxySpawnArgs } = await import('../codex-gateway-config.js');
 

--- a/apps/desktop/src/main/maker-host/codex-gateway-config.ts
+++ b/apps/desktop/src/main/maker-host/codex-gateway-config.ts
@@ -80,6 +80,8 @@ export function buildCodexProxySpawnArgs(baseUrl: string, authMode: CodexProxySp
     ? `model_providers.${p}.requires_openai_auth=true`
     : `model_providers.${p}.env_key="${CODEX_GATEWAY_ENV_KEY}"`;
   const args = [
+    // 统一使用 CodeModeOnly，解决 Codex namespace tools 发现不及时的问题。
+    '-c', 'features.code_mode_only=true',
     '-c', `model_provider="${p}"`,
     '-c', `model_providers.${p}.name="Cindy Gateway"`,
     '-c', `model_providers.${p}.base_url="${baseUrl}"`,


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复非 GPT 模型在 Cindy Codex 下无法使用 Cindy 插件的问题。

具体表现：在 Codex 中选择非 GPT 模型时，Cindy 插件工具可能无法被及时发现，进而无法完成插件调用；GPT 模型路径不在本 PR 的问题范围内。

国产或其他非 GPT 模型经过 Cindy Gateway 时，Codex 可能未获得 Code Mode 的模型元数据，退回传统工具面，导致 `ghost_list` / `ghost_call` 等 namespace tools 不能及时被模型发现，插件指令无法执行。

本 PR 在 Codex app-server 的 Gateway spawn 配置中统一开启：

```text
features.code_mode_only=true
```

Codex fallback metadata 本身已经使用 `use_responses_lite=false`，因此不需要接管或替换 Codex 的模型 catalog，也不需要修改 LiteLLM 或 Responses → Chat bridge。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [x] `docs` / `test` / `chore` 文档、测试或工程维护

### 范围

- 关联 Issue / 需求：
  - Fixes #1890
  - Related to #1432
  - Related context: #2328, #771
- 本 PR 包含：对三种 Codex Gateway 认证模式统一注入 `features.code_mode_only=true`，以及对应回归测试。
- 明确不包含：LiteLLM、Responses → Chat bridge、上游 provider 请求格式转换、模型 catalog 替换。
- 用户可见变化：非 GPT 模型在 Codex 下可以更及时发现并使用 Cindy 插件工具。
- 是否存在 breaking change：无。

## UI 变化

- 引用的设计规范：不涉及：仅修改 Desktop main 侧 Codex spawn 配置和测试，没有 UI 变化。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/maker-host/__tests__/codexProxyHost.test.ts
结果：142/142 通过

pnpm --filter desktop typecheck
结果：通过

pnpm --filter desktop exec eslint src/main/maker-host/codex-gateway-config.ts src/main/maker-host/__tests__/codexProxyHost.test.ts
结果：通过

git diff --check
结果：通过

pnpm check:dco
结果：通过，1 个 commit 带 DCO 签名
```

### 手工验证

CN Desktop dev 实例已通过官方 wrapper 启动并达到 ready，使用当前修复分支，未添加 LiteLLM、API key 或 model catalog 额外注入。

### 未执行的验证

根级 `pnpm test:unit` 已尝试。当前 Node 26 的 Desktop renderer 测试出现既有环境问题：`localStorage` 为不可用的 webstorage stub，导致多组 renderer 测试失败；非 Desktop workspace 已通过。该失败与本 PR 修改的 Codex Gateway spawn 配置无关。

## 风险

### 风险分类

- [x] 协议兼容
- [x] 跨平台差异
- [ ] 无已知风险
- [ ] system prompt
- [ ] 权限 / 安全 / 用户数据

### 影响与回滚

- 影响范围：所有本地 Codex Gateway app-server spawn，覆盖 `oauth-bearer`、`env-key`、`provider-oauth` 三种认证模式；不改变上游 URL、鉴权、模型路由或请求转换。
- 回滚 / 降级方式：移除该 `-c features.code_mode_only=true` spawn override 即可回滚；不会修改用户全局 Codex 配置或持久化数据。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要回归测试
- [x] 已确认测试结果或说明未执行原因