### PR TITLE
fix(chat): 删除靠前 message 后保持滚动锚点稳定 (#2289)

### DIFF
--- a/apps/desktop/src/renderer/__tests__/agentActionRowRendering.test.ts
+++ b/apps/desktop/src/renderer/__tests__/agentActionRowRendering.test.ts
@@ -354,6 +354,15 @@ describe('AgentActionRow — 行主文案', () => {
     expect(screen.getAllByText('查看工作区状态')).toHaveLength(1);
     expect(screen.queryByText(/^# /)).toBeNull();
   });
+
+  it('exposes the tool clientId as a viewport child anchor', () => {
+    const { container } = render(
+      createElement(AgentActionRow, {
+        message: mkTool('t1', 'Bash', { command: 'ls' }),
+      }),
+    );
+    expect(container.querySelector('[data-message-client-id="t1"]')).toBeTruthy();
+  });
 });
 
 describe('AgentActionsBlock — 状态判定与块头', () => {

--- a/apps/desktop/src/renderer/__tests__/buildRenderItemsKeyStability.test.ts
+++ b/apps/desktop/src/renderer/__tests__/buildRenderItemsKeyStability.test.ts
@@ -21,14 +21,18 @@ import { join } from 'node:path';
 import {
   assistantHasFollowingUserBoundary,
   buildRenderItems,
+  collectDeleteAnchorClientIds,
   collectStableLocalFileRefs,
   collectTurnFinalAssistantClientIds,
   findRestorableViewportItemIdx,
   groupWorkRuns,
   insertForkOriginItem,
+  isScrollNavigationKey,
+  pickDeleteCompensationAnchorKey,
   shouldBlockAssistantFork,
   type RenderItem,
 } from '../components/chat/MessageStream';
+import { shouldHandleNavigationKey } from '../components/chat/useNavigationKeyListener';
 import type { ChatMessage } from '@/lib/makerChatStore';
 import type { TurnChangeSetSummary } from '../../shared/turnChangeSet';
 
@@ -1338,5 +1342,130 @@ describe('collectStableLocalFileRefs — reference stability', () => {
       mkFileRef('foo.ts'),
       mkFileRef('bar.ts'),
     ]);
+  });
+});
+
+// ── pickDeleteCompensationAnchorKey ──────────────────────────────────────────
+
+describe('pickDeleteCompensationAnchorKey', () => {
+  it('picks the first surviving neighbor after the deleted range', () => {
+    // 旧全量: 窗口 [w1,w2,v,w3] 被整段清掉, 邻居 after 是 next, 会话尾是 tail
+    const prevAll = ['head', 'w1', 'w2', 'v', 'w3', 'next', 'mid', 'tail'];
+    const curAll = ['head', 'next', 'mid', 'tail'];
+    expect(pickDeleteCompensationAnchorKey(prevAll, curAll, 'v')).toBe('next');
+  });
+
+  it('falls back to the nearest surviving predecessor when no successor remains', () => {
+    const prevAll = ['head', 'keep', 'v', 'gone1', 'gone2'];
+    const curAll = ['head', 'keep'];
+    expect(pickDeleteCompensationAnchorKey(prevAll, curAll, 'v')).toBe('keep');
+  });
+
+  it('does not rebuild at conversation tail when prev is the full old sequence', () => {
+    // 回归: 窗口整段被清时旧可见窗与 cur 全量无交集, helper 会落到 cur 末项(会话尾);
+    // 调用方必须传旧全量序列才能保住删除区间后的邻居。
+    const prevVisibleOnly = ['w1', 'w2', 'v', 'w3']; // 整窗被清, 无存活邻接
+    const prevAll = ['head', 'w1', 'w2', 'v', 'w3', 'next', 'mid', 'tail'];
+    const curAll = ['head', 'next', 'mid', 'tail'];
+    expect(pickDeleteCompensationAnchorKey(prevVisibleOnly, curAll, 'v')).toBe('tail');
+    expect(pickDeleteCompensationAnchorKey(prevAll, curAll, 'v')).toBe('next');
+  });
+
+  it('returns null when deleted key is absent from prevKeys', () => {
+    expect(pickDeleteCompensationAnchorKey(['a', 'b'], ['a', 'b', 'c'], 'missing')).toBeNull();
+  });
+
+  it('picks the intervening tool row when a focused child is deleted from a surviving work group', () => {
+    const before = groupWorkRuns(
+      buildRenderItems([
+        mkUser('u1'),
+        mkAssistant('a-intro', 'Starting.'),
+        mkTool('t1', 'Read'),
+        mkAssistant('a-draft', 'Progress update.'),
+        mkTool('t2', 'Bash'),
+        mkAssistant('a-final', 'done'),
+      ]).items,
+      false,
+    );
+    const after = groupWorkRuns(
+      buildRenderItems([
+        mkUser('u1'),
+        mkAssistant('a-intro', 'Starting.'),
+        mkTool('t1', 'Read'),
+        mkTool('t2', 'Bash'),
+        mkAssistant('a-final', 'done'),
+      ]).items,
+      false,
+    );
+    const previousAnchorIds = collectDeleteAnchorClientIds(before);
+    const currentAnchorIds = collectDeleteAnchorClientIds(after);
+    const previousGroup = before.find((item) => item.type === 'work_group');
+    const currentGroup = after.find((item) => item.type === 'work_group');
+
+    expect(previousGroup).toBeDefined();
+    expect(currentGroup).toBeDefined();
+    expect(previousGroup?.key).toBe(currentGroup?.key);
+    expect(previousAnchorIds).toEqual(['u1', 'a-intro', 't1', 'a-draft', 't2', 'a-final']);
+    expect(currentAnchorIds).toEqual(['u1', 'a-intro', 't1', 't2', 'a-final']);
+    expect(pickDeleteCompensationAnchorKey(previousAnchorIds, currentAnchorIds, 'a-draft')).toBe(
+      't2',
+    );
+  });
+
+  it('picks the next message when an anchored task card is deleted from a surviving work group', () => {
+    const messagesBefore = [
+      mkUser('u1'),
+      mkTool('t1', 'Read'),
+      mkResult('r-t1', 'tu-t1'),
+      mkTool('task1', 'Agent', { description: 'Review auth flow', prompt: 'Check auth' }),
+      mkResult('r-task1', 'tu-task1', 'done'),
+      mkAssistant('a-final', 'done'),
+    ];
+    const before = groupWorkRuns(buildRenderItems(messagesBefore).items, false);
+    const after = groupWorkRuns(
+      buildRenderItems(
+        messagesBefore.filter((message) => !['task1', 'r-task1'].includes(message.clientId)),
+      ).items,
+      false,
+    );
+    const previousAnchorIds = collectDeleteAnchorClientIds(before);
+    const currentAnchorIds = collectDeleteAnchorClientIds(after);
+    const previousGroup = before.find((item) => item.type === 'work_group');
+    const currentGroup = after.find((item) => item.type === 'work_group');
+
+    expect(previousGroup?.key).toBe('work-t1');
+    expect(currentGroup?.key).toBe(previousGroup?.key);
+    expect(previousAnchorIds).toEqual(['u1', 't1', 'task1', 'a-final']);
+    expect(currentAnchorIds).toEqual(['u1', 't1', 'a-final']);
+    expect(
+      pickDeleteCompensationAnchorKey(previousAnchorIds, currentAnchorIds, 'task1'),
+    ).toBe('a-final');
+  });
+
+  it('keeps an intervening non-message render item after a top-level message is deleted', () => {
+    const previousItemKeys = ['msg-user', 'work-tool', 'msg-assistant'];
+    const currentItemKeys = ['work-tool', 'msg-assistant'];
+    const previousMessageIds = ['user', 'assistant'];
+    const currentMessageIds = ['assistant'];
+
+    expect(
+      pickDeleteCompensationAnchorKey(previousMessageIds, currentMessageIds, 'user'),
+    ).toBe('assistant');
+    expect(
+      pickDeleteCompensationAnchorKey(previousItemKeys, currentItemKeys, 'msg-user'),
+    ).toBe('work-tool');
+  });
+});
+
+describe('focus scroll takeover keys', () => {
+  it('treats Space as user-controlled scrolling', () => {
+    expect(isScrollNavigationKey(' ')).toBe(true);
+    expect(isScrollNavigationKey('Enter')).toBe(false);
+  });
+
+  it('does not treat Space in an editable target as scroll takeover', () => {
+    expect(shouldHandleNavigationKey(' ', null)).toBe(true);
+    expect(shouldHandleNavigationKey('PageUp', null)).toBe(true);
+    expect(shouldHandleNavigationKey('Enter', null)).toBe(false);
   });
 });

--- a/apps/desktop/src/renderer/__tests__/focusScrollLifecycle.test.ts
+++ b/apps/desktop/src/renderer/__tests__/focusScrollLifecycle.test.ts
@@ -1,0 +1,478 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+import {
+  pickIntersectingChildAnchor,
+  readAnchorClientId,
+  readViewportChildAnchorClientId,
+  resolveChipJumpTargetScrollTop,
+  resolveDeleteCompensationLanding,
+  resolveProgrammaticScrollEndDecision,
+  shouldRefreshExpandedChildViewportAnchor,
+  shouldRefreshHiddenChildViewportAnchor,
+  shouldUseFocusedElementAsViewportAnchor,
+  toRenderItemViewportSnapshot,
+} from '../components/chat/MessageStream';
+
+const messageStreamSource = readFileSync(
+  new URL('../components/chat/MessageStream.tsx', import.meta.url),
+  'utf8',
+).replace(/\r\n/g, '\n');
+
+function sourceBetween(start: string, end: string): string {
+  const startIndex = messageStreamSource.indexOf(start);
+  const endIndex = messageStreamSource.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    throw new Error(`MessageStream source markers not found: ${start} → ${end}`);
+  }
+  return messageStreamSource.slice(startIndex, endIndex);
+}
+
+describe('focus scroll cancellation decisions', () => {
+  it('replays a deferred deletion when the user takes over the active focus scroll', () => {
+    expect(
+      resolveProgrammaticScrollEndDecision({
+        generation: 7,
+        activeGeneration: 7,
+        hasDeferredDelete: true,
+      }),
+    ).toBe('replay-deferred-delete');
+  });
+
+  it('lets an explicit replacement navigation consume the old deletion compensation', () => {
+    expect(
+      resolveProgrammaticScrollEndDecision({
+        generation: 7,
+        activeGeneration: 7,
+        hasDeferredDelete: true,
+        consumeDeferredDelete: true,
+      }),
+    ).toBe('consume-deferred-delete');
+  });
+
+  it('does not let a stale focus callback mutate a newer navigation generation', () => {
+    expect(
+      resolveProgrammaticScrollEndDecision({
+        generation: 7,
+        activeGeneration: 8,
+        hasDeferredDelete: true,
+      }),
+    ).toBe('stale');
+  });
+});
+
+describe('chip jump settlement', () => {
+  it('recomputes the landing from settled target geometry after content above it is deleted', () => {
+    expect(
+      resolveChipJumpTargetScrollTop({
+        scrollTop: 240,
+        containerTop: 100,
+        targetTop: 62,
+        topOffset: 12,
+      }),
+    ).toBe(190);
+  });
+
+  it('clamps a target shifted above the scroll range to the top', () => {
+    expect(
+      resolveChipJumpTargetScrollTop({
+        scrollTop: 20,
+        containerTop: 100,
+        targetTop: 40,
+        topOffset: 12,
+      }),
+    ).toBe(0);
+  });
+});
+
+describe('focused message viewport anchor decisions', () => {
+  it('keeps the measured viewport anchor when the focused message is centered below the top', () => {
+    expect(
+      shouldUseFocusedElementAsViewportAnchor({
+        focusClientId: 'focused',
+        elementClientId: 'focused',
+        containerTop: 100,
+        elementTop: 240,
+        elementBottom: 320,
+      }),
+    ).toBe(false);
+  });
+
+  it('uses an exact focused message that crosses the viewport top', () => {
+    expect(
+      shouldUseFocusedElementAsViewportAnchor({
+        focusClientId: 'focused',
+        elementClientId: 'focused',
+        containerTop: 100,
+        elementTop: 80,
+        elementBottom: 160,
+      }),
+    ).toBe(true);
+  });
+
+  it('does not treat a folded work-group fallback as the hidden focused message', () => {
+    expect(
+      shouldUseFocusedElementAsViewportAnchor({
+        focusClientId: 'focused',
+        containerTop: 100,
+        elementTop: 80,
+        elementBottom: 160,
+      }),
+    ).toBe(false);
+  });
+
+  it('drops a hidden child anchor when precise DOM restoration falls back to its render item', () => {
+    expect(
+      toRenderItemViewportSnapshot(
+        {
+          viewportTopKey: 'work-summary-task',
+          offset: 48,
+          messageClientId: 'hidden-child',
+          messageOffset: 12,
+        },
+        0,
+      ),
+    ).toEqual({ viewportTopKey: 'work-summary-task', offset: 0 });
+  });
+
+  it('lands delete compensation on a visible collapsed container instead of a hidden child', () => {
+    expect(
+      resolveDeleteCompensationLanding({
+        exactVisible: true,
+        fallbackContainerVisible: true,
+      }),
+    ).toBe('exact');
+    expect(
+      resolveDeleteCompensationLanding({
+        exactVisible: false,
+        fallbackContainerVisible: true,
+      }),
+    ).toBe('container');
+    expect(
+      resolveDeleteCompensationLanding({
+        exactVisible: false,
+        fallbackContainerVisible: false,
+      }),
+    ).toBe('item');
+  });
+
+  it('refreshes a child snapshot only when collapse hid it without deleting the data', () => {
+    expect(
+      shouldRefreshHiddenChildViewportAnchor({
+        snapshotMessageClientId: 'hidden-child',
+        exactChildVisible: false,
+        childStillInRenderItems: true,
+      }),
+    ).toBe(true);
+    expect(
+      shouldRefreshHiddenChildViewportAnchor({
+        snapshotMessageClientId: 'hidden-child',
+        exactChildVisible: false,
+        childStillInRenderItems: false,
+      }),
+    ).toBe(false);
+    expect(
+      shouldRefreshHiddenChildViewportAnchor({
+        snapshotMessageClientId: 'hidden-child',
+        exactChildVisible: true,
+        childStillInRenderItems: true,
+      }),
+    ).toBe(false);
+    expect(
+      shouldRefreshHiddenChildViewportAnchor({
+        snapshotMessageClientId: undefined,
+        exactChildVisible: false,
+        childStillInRenderItems: true,
+      }),
+    ).toBe(false);
+  });
+
+  it('remeasures after expand only when the viewport-top item gained a visible child', () => {
+    expect(
+      shouldRefreshExpandedChildViewportAnchor({
+        snapshotMessageClientId: undefined,
+        viewportTopItemHasVisibleExactChild: true,
+      }),
+    ).toBe(true);
+    expect(
+      shouldRefreshExpandedChildViewportAnchor({
+        snapshotMessageClientId: undefined,
+        viewportTopItemHasVisibleExactChild: false,
+      }),
+    ).toBe(false);
+    expect(
+      shouldRefreshExpandedChildViewportAnchor({
+        snapshotMessageClientId: 'already-anchored',
+        viewportTopItemHasVisibleExactChild: true,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('viewport child anchors', () => {
+  it('prefers an exact message id over a tool-block token list', () => {
+    expect(
+      readAnchorClientId({
+        dataset: { messageClientId: 'row-2', messageClientIds: 't1 t2' },
+      }),
+    ).toBe('row-2');
+    expect(readAnchorClientId({ dataset: { messageClientIds: ' t1  t2 ' } })).toBe('t1');
+    expect(readAnchorClientId({ dataset: {} })).toBeUndefined();
+  });
+
+  it('ignores aggregate token lists when snapshotting the viewport child', () => {
+    expect(
+      readViewportChildAnchorClientId({
+        dataset: { messageClientId: 'row-2', messageClientIds: 't1 t2' },
+      }),
+    ).toBe('row-2');
+    expect(
+      readViewportChildAnchorClientId({ dataset: { messageClientIds: 'hidden-1 hidden-2' } }),
+    ).toBeUndefined();
+    expect(readViewportChildAnchorClientId({ dataset: {} })).toBeUndefined();
+  });
+
+  it('keeps the innermost intersecting child when a work-group block wraps a tool row', () => {
+    expect(
+      pickIntersectingChildAnchor(
+        [
+          { clientId: 't1', top: 40, bottom: 280 },
+          { clientId: 'row-2', top: 90, bottom: 130 },
+        ],
+        100,
+      ),
+    ).toEqual({ clientId: 'row-2', offset: 10 });
+  });
+
+  it('skips children that sit entirely above or below the viewport top', () => {
+    expect(
+      pickIntersectingChildAnchor(
+        [
+          { clientId: 'above', top: 0, bottom: 80 },
+          { clientId: 'cross', top: 90, bottom: 140 },
+          { clientId: 'below', top: 160, bottom: 200 },
+        ],
+        100,
+      ),
+    ).toEqual({ clientId: 'cross', offset: 10 });
+  });
+});
+
+describe('MessageStream focus cancellation wiring', () => {
+  it('routes wheel, touch, pointer, and keyboard takeover through the replaying cancel path', () => {
+    const takeover = sourceBetween('const onUserInput = () => {', 'const onNavigationKey');
+    expect(takeover).toContain('cancelFocusJump();');
+    expect(takeover).not.toContain('deferredDeleteCompensationRef.current = false');
+  });
+
+  it('cancels the old focus before the portaled previous-message chip starts smooth scrolling', () => {
+    const previousMessageJump = sourceBetween(
+      'const handleJumpToPrevUserMsg = useCallback(() => {',
+      'const prevPreview =',
+    );
+    const cancelIndex = previousMessageJump.indexOf(
+      'cancelFocusJump({ consumeDeferredDelete: true });',
+    );
+    const beginIndex = previousMessageJump.indexOf('beginChipJump({');
+    const smoothScrollIndex = previousMessageJump.indexOf(
+      "el.scrollIntoView({ behavior: 'smooth', block: 'start' });",
+    );
+    expect(cancelIndex).toBeGreaterThanOrEqual(0);
+    expect(beginIndex).toBeGreaterThanOrEqual(0);
+    expect(smoothScrollIndex).toBeGreaterThanOrEqual(0);
+    expect(cancelIndex).toBeLessThan(beginIndex);
+    expect(beginIndex).toBeLessThan(smoothScrollIndex);
+    expect(previousMessageJump).toContain('clientId: prevUserMsgId');
+    expect(previousMessageJump).toContain("selector: 'user-message'");
+  });
+
+  it('replays a deferred deletion before the message navigation rail requests a fallible target', () => {
+    const railJump = sourceBetween(
+      'const handleNavRailJump = useCallback((clientId: string) => {',
+      'useLayoutEffect(() => {',
+    );
+    const cancelIndex = railJump.indexOf('cancelFocusJump();');
+    const requestIndex = railJump.indexOf(
+      'setRailJumpRequest({ id: clientId, seq: railJumpSeqRef.current });',
+    );
+    expect(cancelIndex).toBeGreaterThanOrEqual(0);
+    expect(railJump).not.toContain('consumeDeferredDelete: true');
+    expect(requestIndex).toBeGreaterThanOrEqual(0);
+    expect(cancelIndex).toBeLessThan(requestIndex);
+  });
+
+  it('tracks the message navigation rail smooth scroll before moving to its target', () => {
+    const railJumpEffect = sourceBetween(
+      'useLayoutEffect(() => {\n    if (!railJumpRequest) return;',
+      '// 第一条 user 消息没有',
+    );
+    const beginIndex = railJumpEffect.indexOf('beginChipJump({');
+    const smoothScrollIndex = railJumpEffect.indexOf(
+      "root.scrollTo({ top: Math.max(0, targetTop), behavior: 'smooth' });",
+    );
+    expect(beginIndex).toBeGreaterThanOrEqual(0);
+    expect(smoothScrollIndex).toBeGreaterThanOrEqual(0);
+    expect(beginIndex).toBeLessThan(smoothScrollIndex);
+    expect(railJumpEffect).toContain('clientId: railJumpRequest.id');
+    expect(railJumpEffect).toContain('topOffset: NAV_RAIL_JUMP_TOP_OFFSET_PX');
+  });
+
+  it('re-resolves the saved target before consuming an earlier deferred deletion', () => {
+    const settlement = sourceBetween(
+      'const settleChipJump = useCallback(',
+      'const beginChipJump = useCallback(',
+    );
+    const queryIndex = settlement.indexOf('root.querySelector<HTMLElement>');
+    const consumeIndex = settlement.indexOf('deferredDeleteCompensationRef.current = false');
+    const finishIndex = settlement.indexOf(
+      'requestAnimationFrame(() => finishChipJump(generation, { refreshAnchor: true }))',
+    );
+    expect(queryIndex).toBeGreaterThanOrEqual(0);
+    expect(consumeIndex).toBeGreaterThan(queryIndex);
+    expect(finishIndex).toBeGreaterThan(consumeIndex);
+    expect(settlement).not.toContain('consumeDeferredDelete: true');
+  });
+
+  it('measures rendered child ids and skips collapsed aggregate containers', () => {
+    const measure = sourceBetween(
+      'const measureViewportTop = useCallback',
+      'const refreshViewportAnchor = useCallback',
+    );
+    expect(measure).toContain("querySelectorAll<HTMLElement>('[data-message-client-id]')");
+    expect(measure).not.toContain('[data-message-client-ids]');
+    expect(measure).toContain('pickIntersectingChildAnchor(');
+    expect(measure).toContain('readViewportChildAnchorClientId(element)');
+  });
+
+  it('remeasures a hidden child snapshot when a work group collapses', () => {
+    const refreshHidden = sourceBetween(
+      'const refreshHiddenChildViewportAnchor = useCallback(() => {',
+      'const scrollKeyToViewportTop = useCallback',
+    );
+    expect(refreshHidden).toContain('queryMessageElement(root, clientId)');
+    expect(refreshHidden).toContain('shouldRefreshHiddenChildViewportAnchor(');
+    expect(refreshHidden).toContain('shouldRefreshExpandedChildViewportAnchor(');
+    expect(refreshHidden).toContain('hasVisibleExactChildAnchor(itemElement)');
+    expect(refreshHidden).toContain('toRenderItemViewportSnapshot(snapshot)');
+    expect(refreshHidden).toContain('refreshViewportAnchor()');
+    const resizeObserver = sourceBetween(
+      'const ro = new ResizeObserver(() => {',
+      'ro.observe(content);',
+    );
+    expect(resizeObserver).toContain('refreshHiddenChildViewportAnchor()');
+    expect(resizeObserver).toContain('if (isNearBottomRef.current)');
+    const collapseObserver = sourceBetween(
+      'const observer = new MutationObserver(() => {',
+      'observer.observe(items, { childList: true, subtree: true });',
+    );
+    expect(collapseObserver).toContain('refreshHiddenChildViewportAnchor()');
+  });
+
+  it('cancels chip jumps on scrollbar mousedown as well as wheel and touch', () => {
+    const takeover = sourceBetween(
+      'const onWheel = (event: WheelEvent) => {',
+      '}, [clearChipJumpSuppression, triggerUserIntentFill, unpinAutoFollowForUserUpIntent]);',
+    );
+    expect(takeover).toContain('clearChipJumpSuppression();');
+    expect(takeover).toContain("root.addEventListener('mousedown', onMouseDown)");
+  });
+
+  it('uses message-level neighbors only when the deleted child\'s render item survives', () => {
+    const compensation = sourceBetween(
+      '// ── 删除靠前 message 后的视口保位（#2289）──',
+      '// ── post-load auto-expand ──',
+    );
+    expect(compensation).toContain(
+      'if (anchor.messageClientId && snapshotMessageGone && anchorItemStillVisible)',
+    );
+    expect(compensation).toContain('if (anchorItemStillVisible) return;');
+    expect(compensation).toContain('collectDeleteAnchorClientIds(prevSeq)');
+    expect(compensation).toContain('resolveDeleteCompensationLanding(');
+    expect(compensation).toContain('queryVisibleAggregateContainer(root, survivorMessageId)');
+    expect(compensation).toContain('toRenderItemViewportSnapshot(');
+    expect(compensation).not.toContain(
+      'if (anchor.messageClientId && snapshotMessageGone) {',
+    );
+  });
+
+  it('finishes an older chip or rail navigation before starting a jump to bottom', () => {
+    const jumpToBottom = sourceBetween(
+      'const scrollToBottomSmooth = useCallback(() => {',
+      '// F2: messages diff',
+    );
+    const settleIndex = jumpToBottom.indexOf(
+      'finishChipJump(chipJumpGeneration, { consumeDeferredDelete: true });',
+    );
+    const beginIndex = jumpToBottom.indexOf('const generation = beginProgrammaticScroll();');
+    expect(settleIndex).toBeGreaterThanOrEqual(0);
+    expect(beginIndex).toBeGreaterThanOrEqual(0);
+    expect(settleIndex).toBeLessThan(beginIndex);
+    expect(jumpToBottom).toContain('const generation = beginProgrammaticScroll();');
+    expect(jumpToBottom).toContain('finishProgrammaticScroll(generation)');
+  });
+
+  it('finishes a jump-to-bottom generation on user takeover and scrollend', () => {
+    const takeover = sourceBetween(
+      'const clearChipJumpSuppression = useCallback(() => {',
+      'const settleChipJump = useCallback(',
+    );
+    expect(takeover).toContain(
+      'deferredDeleteCompensationRef.current ||\n      chipJumpGenerationRef.current !== null ||\n      focusJumpRef.current ||\n      programmaticScrollRef.current',
+    );
+    expect(takeover).toContain('unpinAutoFollowForUserUpIntent()');
+    expect(takeover).toContain('if (focusJumpRef.current)');
+    expect(takeover).toContain('cancelFocusJump()');
+    expect(takeover).toContain('if (programmaticScrollRef.current)');
+    expect(takeover).toContain('finishProgrammaticScroll(programmaticScrollGenerationRef.current)');
+    expect(takeover).toContain("root.scrollTo({ top: root.scrollTop, behavior: 'auto' })");
+    const scrollEnd = sourceBetween(
+      'const onScrollEnd = () => {\n      settleChipJump();',
+      "root.addEventListener('scrollend', onScrollEnd);",
+    );
+    expect(scrollEnd).toContain('finishProgrammaticScroll(generation)');
+  });
+
+  it('records a child viewport snapshot after restore settles', () => {
+    const restore = sourceBetween(
+      'const applyRestore = useCallback(() => {',
+      'const applyRestoreRef = useRef(applyRestore);',
+    );
+    expect(restore).toContain('refreshViewportAnchor()');
+    expect(restore).toContain(
+      'if (finishProgrammaticScroll(generation) === false) refreshViewportAnchor()',
+    );
+  });
+
+  it('scrolls restored child anchors only when the exact message DOM exists', () => {
+    const restore = sourceBetween(
+      'const scrollMessageToViewportTop = useCallback',
+      'const restoreViewportSnapshot = useCallback',
+    );
+    expect(restore).toContain('queryMessageElement(container, clientId)');
+    expect(restore).not.toContain('queryFocusElement(');
+  });
+
+  it('defers recovered grouping-key restoration while programmatic navigation is in flight', () => {
+    const compensation = sourceBetween(
+      '// ── 删除靠前 message 后的视口保位（#2289）──',
+      '// ── post-load auto-expand ──',
+    );
+    const recoveredStart = compensation.indexOf(
+      'if (snapshot && recoveredKey && !snapshotMessageGone)',
+    );
+    const recoveredEnd = compensation.indexOf('if (!sessionId) return;');
+    expect(recoveredStart).toBeGreaterThanOrEqual(0);
+    expect(recoveredEnd).toBeGreaterThan(recoveredStart);
+    const recovered = compensation.slice(recoveredStart, recoveredEnd);
+    expect(recovered).toContain('restoreViewportSnapshot(rebased, 0)');
+    expect(recovered).toContain(
+      'if (!windowAnchorLost && !programmaticScrollRef.current && !isLoadingMore)',
+    );
+    const restoreIndex = recovered.indexOf('restoreViewportSnapshot(rebased, 0)');
+    const guardIndex = recovered.indexOf(
+      'if (!windowAnchorLost && !programmaticScrollRef.current && !isLoadingMore)',
+    );
+    expect(guardIndex).toBeGreaterThanOrEqual(0);
+    expect(guardIndex).toBeLessThan(restoreIndex);
+  });
+});

--- a/apps/desktop/src/renderer/__tests__/workGroupBlockInteraction.test.ts
+++ b/apps/desktop/src/renderer/__tests__/workGroupBlockInteraction.test.ts
@@ -38,6 +38,15 @@ describe('WorkGroupBlock — 嵌套工作组接线静态扫描', () => {
     expect(source).not.toMatch(/AgentActionsBlock/);
   });
 
+  it('exposes thinking rows as viewport child anchors', () => {
+    expect(source).toMatch(
+      /function ThinkingActivityRow[\s\S]*data-message-client-id=\{activity\.key\}/,
+    );
+    expect(source).toMatch(
+      /function ExpandedThinkingRow[\s\S]*data-message-client-id=\{message\.clientId\}/,
+    );
+  });
+
   it('完成态内层工作组递归复用 WorkGroupBlock', () => {
     expect(source).toMatch(/child\.kind === 'group'[\s\S]*?<WorkGroupBlock/);
   });

--- a/apps/desktop/src/renderer/components/chat/AgentActionRow.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentActionRow.tsx
@@ -876,7 +876,7 @@ export function AgentActionRow({
   };
 
   return (
-    <div className="flex flex-col">
+    <div className="flex flex-col" data-message-client-id={message.clientId}>
       <button
         type="button"
         onClick={(e) => void onActivate(e.currentTarget)}

--- a/apps/desktop/src/renderer/components/chat/AgentActionsBlock.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentActionsBlock.tsx
@@ -103,6 +103,7 @@ export function AgentActionsBlock({
     // data-message-client-ids(空格分隔):后台任务面板「点行跳聊天」的定位锚点。
     // 聚合块内的工具行折叠时不在可视 DOM,精确 clientId 锚点(message wrapper /
     // 任务卡)查不到时,MessageStream 的 focus 用 ~= 属性选择器落到本块容器。
+    // 视口删除补偿不读这个聚合列表，避免把隐藏工具 id 当成活锚点。
     <div
       className="flex w-full justify-start"
       data-message-client-ids={toolCalls.map((c) => c.clientId).join(' ')}

--- a/apps/desktop/src/renderer/components/chat/MessageStream.tsx
+++ b/apps/desktop/src/renderer/components/chat/MessageStream.tsx
@@ -89,6 +89,70 @@ const JUMP_DOWN_IDLE_MS = 2000;
 const SCROLL_DIRECTION_DEAD_ZONE_PX = 1;
 const TOUCH_HISTORY_INTENT_THRESHOLD_PX = 8;
 const HISTORY_NAVIGATION_KEYS: ReadonlySet<string> = new Set(['PageUp', 'ArrowUp', 'Home']);
+
+type ProgrammaticScrollEndDecision =
+  'stale' | 'finished' | 'replay-deferred-delete' | 'consume-deferred-delete';
+
+type ChipJumpTarget = {
+  generation: number;
+  clientId: string;
+  selector: 'message' | 'user-message';
+  topOffset: number;
+};
+
+/**
+ * 程序化滚动结束时的删除补偿裁决。用户接管必须重放延期补偿；显式的新导航有
+ * 自己的确定落点，可以消费旧补偿；过期 generation 不能触碰后发滚动的状态。
+ */
+export function resolveProgrammaticScrollEndDecision({
+  generation,
+  activeGeneration,
+  hasDeferredDelete,
+  consumeDeferredDelete = false,
+}: {
+  generation: number;
+  activeGeneration: number;
+  hasDeferredDelete: boolean;
+  consumeDeferredDelete?: boolean;
+}): ProgrammaticScrollEndDecision {
+  if (generation !== activeGeneration) return 'stale';
+  if (!hasDeferredDelete) return 'finished';
+  return consumeDeferredDelete ? 'consume-deferred-delete' : 'replay-deferred-delete';
+}
+
+/** 以落定时的最新 DOM 几何重新计算 chip / 导航轨道目标，而不是复用 smooth 开始前的像素。 */
+export function resolveChipJumpTargetScrollTop({
+  scrollTop,
+  containerTop,
+  targetTop,
+  topOffset,
+}: {
+  scrollTop: number;
+  containerTop: number;
+  targetTop: number;
+  topOffset: number;
+}): number {
+  return Math.max(0, scrollTop + targetTop - containerTop - topOffset);
+}
+
+/** 搜索目标只有作为精确 DOM 消息锚点跨过视口顶边时，才能覆盖真实顶端量测。 */
+export function shouldUseFocusedElementAsViewportAnchor({
+  focusClientId,
+  elementClientId,
+  containerTop,
+  elementTop,
+  elementBottom,
+}: {
+  focusClientId: string;
+  elementClientId?: string;
+  containerTop: number;
+  elementTop: number;
+  elementBottom: number;
+}): boolean {
+  return (
+    elementClientId === focusClientId && elementTop <= containerTop && elementBottom > containerTop
+  );
+}
 // chip jump 抑制 expand/load 的安全兜底时长。正常解抑靠 wheel/touch/keydown,
 // 这个 timer 只防"click 后既不滚也不动键盘"的极端情况,够长能覆盖最长 smooth
 // scroll(浏览器长距离 ~1s)。
@@ -221,7 +285,10 @@ import {
   shouldUnpinOnWheel,
 } from './autoFollowIntent';
 import { countUnreadAdded } from './unreadCount';
-import { useNavigationKeyListener } from './useNavigationKeyListener';
+import { NAVIGATION_KEYS, useNavigationKeyListener } from './useNavigationKeyListener';
+export function isScrollNavigationKey(key: string): boolean {
+  return NAVIGATION_KEYS.has(key);
+}
 import { suppressScrollbarActivation } from '@/lib/scrollbarAutoHide';
 import { collectAssistantTurnUsageDetails } from '@/lib/userTurnUsage';
 import type { TurnUsageDetails } from '../../../shared/turnUsageDetails';
@@ -868,6 +935,189 @@ function recoverLostAnchorIdx(items: RenderItem[], lostKey: string): number {
 export function findRestorableViewportItemIdx(items: RenderItem[], viewportTopKey: string): number {
   const exactIdx = items.findIndex((it) => it.key === viewportTopKey);
   return exactIdx >= 0 ? exactIdx : recoverLostAnchorIdx(items, viewportTopKey);
+}
+
+/**
+ * 删除补偿的落点选择:视口顶端 item 被删后,取旧序列里它之后第一条存活 item
+ * (连带删除可能越过多条);无则回退它之前最近的存活 item,再无则落到新末条。
+ * 返回 null = 旧序列里找不到被删 key(快照过旧),无从补偿。
+ * 注意:窗口整段被清时 prevKeys 必须是旧**全量**序列——已回退的可见窗没有删除区
+ * 的邻接信息,fallback 会落到 curKeys 末项(会话尾)。
+ */
+export function pickDeleteCompensationAnchorKey(
+  prevKeys: readonly string[],
+  curKeys: readonly string[],
+  deletedKey: string,
+): string | null {
+  const deletedIdx = prevKeys.indexOf(deletedKey);
+  if (deletedIdx < 0) return null;
+  const alive = new Set(curKeys);
+  return (
+    prevKeys.slice(deletedIdx + 1).find((k) => alive.has(k)) ??
+    prevKeys.slice(0, deletedIdx).findLast((k) => alive.has(k)) ??
+    curKeys.at(-1) ??
+    null
+  );
+}
+
+/** 删除补偿落点：精确可见 child 优先；否则落到折叠摘要容器，不用隐藏后代配外层旧 offset。 */
+export function resolveDeleteCompensationLanding(input: {
+  exactVisible: boolean;
+  fallbackContainerVisible: boolean;
+}): 'exact' | 'container' | 'item' {
+  if (input.exactVisible) return 'exact';
+  if (input.fallbackContainerVisible) return 'container';
+  return 'item';
+}
+
+export function isVisibleDeleteCompensationElement(
+  element: { getBoundingClientRect(): { height: number } } | null,
+): boolean {
+  return Boolean(element && element.getBoundingClientRect().height > 0);
+}
+
+/**
+ * 渲染顺序下所有可定位 clientId：message、tool_segment、agent_task、嵌套 work_group。
+ * 删除补偿与 focus 落点都走这条序列，避免子消息删除时跳过中间的工具行。
+ */
+export function collectDeleteAnchorClientIds(items: readonly RenderItem[]): string[] {
+  const ids: string[] = [];
+  for (const item of items) {
+    if (item.type === 'message') ids.push(item.message.clientId);
+    else if (item.type === 'tool_segment') {
+      for (const toolCall of item.toolCalls) ids.push(toolCall.clientId);
+    } else if (item.type === 'agent_task' && item.toolCall) {
+      ids.push(item.toolCall.clientId);
+    } else if (item.type === 'work_group') {
+      ids.push(...collectDeleteAnchorClientIds(item.children));
+    }
+  }
+  return ids;
+}
+
+function queryMessageElement(root: ParentNode, clientId: string): HTMLElement | null {
+  return root.querySelector(
+    `[data-message-client-id="${CSS.escape(clientId)}"]`,
+  ) as HTMLElement | null;
+}
+
+/**
+ * 精确 message / 任务卡优先；否则取 data-message-client-ids 的最内层匹配。
+ * 工作组容器也会带全量子 id，必须用最内层，否则会滚到组顶而不是中间的工具行。
+ */
+function queryFocusElement(root: ParentNode, clientId: string): HTMLElement | null {
+  const exact = queryMessageElement(root, clientId);
+  if (exact) return exact;
+  const matches = root.querySelectorAll<HTMLElement>(
+    `[data-message-client-ids~="${CSS.escape(clientId)}"]`,
+  );
+  return matches[matches.length - 1] ?? null;
+}
+
+/** 折叠摘要容器：跳过高度为 0 的精确 child，取仍可见的最内层聚合节点。 */
+function queryVisibleAggregateContainer(
+  root: ParentNode,
+  clientId: string,
+): HTMLElement | null {
+  const matches = root.querySelectorAll<HTMLElement>(
+    `[data-message-client-ids~="${CSS.escape(clientId)}"]`,
+  );
+  for (let i = matches.length - 1; i >= 0; i--) {
+    const element = matches[i];
+    if (element.getBoundingClientRect().height > 0) return element;
+  }
+  return null;
+}
+
+/** 精确 id 优先；否则取 data-message-client-ids 的第一个 token（折叠工具块 focus 回退）。 */
+export function readAnchorClientId(element: {
+  dataset: { messageClientId?: string; messageClientIds?: string };
+}): string | undefined {
+  const exact = element.dataset.messageClientId?.trim();
+  if (exact) return exact;
+  return element.dataset.messageClientIds?.trim().split(/\s+/).find(Boolean);
+}
+
+/** 视口子锚点只认已渲染的精确 id；聚合 token 列表留给 queryFocusElement。 */
+export function readViewportChildAnchorClientId(element: {
+  dataset: { messageClientId?: string; messageClientIds?: string };
+}): string | undefined {
+  return element.dataset.messageClientId?.trim() || undefined;
+}
+
+type ChildAnchorRect = {
+  clientId: string;
+  top: number;
+  bottom: number;
+};
+
+/** 树序最后一个跨过容器顶边的子锚点（最内层）。 */
+export function pickIntersectingChildAnchor(
+  candidates: readonly ChildAnchorRect[],
+  containerTop: number,
+): { clientId: string; offset: number } | null {
+  let picked: { clientId: string; offset: number } | null = null;
+  for (const candidate of candidates) {
+    if (candidate.bottom - containerTop <= 0 || candidate.top > containerTop) continue;
+    picked = {
+      clientId: candidate.clientId,
+      offset: Math.max(0, containerTop - candidate.top),
+    };
+  }
+  return picked;
+}
+
+type ViewportTopSnapshot = {
+  viewportTopKey: string;
+  offset: number;
+  messageClientId?: string;
+  messageOffset?: number;
+};
+
+/** 精确子 DOM 不存在时降级到 render-item 锚点，避免隐藏 child 继续触发删除补偿。 */
+export function toRenderItemViewportSnapshot(
+  snapshot: ViewportTopSnapshot,
+  offset = snapshot.offset,
+): ViewportTopSnapshot {
+  return { viewportTopKey: snapshot.viewportTopKey, offset };
+}
+
+/**
+ * 展开工作组 / 工具块被折叠后，精确 child DOM 会消失，但 render-item 数据仍在。
+ * 这时必须重新量测；否则陈旧 messageClientId 会在隐藏 child 被删时误走补偿。
+ */
+export function shouldRefreshHiddenChildViewportAnchor(input: {
+  snapshotMessageClientId: string | undefined;
+  exactChildVisible: boolean;
+  childStillInRenderItems: boolean;
+}): boolean {
+  return (
+    input.snapshotMessageClientId !== undefined &&
+    !input.exactChildVisible &&
+    input.childStillInRenderItems
+  );
+}
+
+/**
+ * 折叠组展开后快照往往只有 render-item key。视口顶 item 里已出现可见的精确
+ * child 时必须重测，否则删这个 child 时补偿看不到 snapshotMessageGone。
+ */
+export function shouldRefreshExpandedChildViewportAnchor(input: {
+  snapshotMessageClientId: string | undefined;
+  viewportTopItemHasVisibleExactChild: boolean;
+}): boolean {
+  return (
+    input.snapshotMessageClientId === undefined &&
+    input.viewportTopItemHasVisibleExactChild
+  );
+}
+
+function hasVisibleExactChildAnchor(itemElement: HTMLElement): boolean {
+  for (const element of itemElement.querySelectorAll<HTMLElement>('[data-message-client-id]')) {
+    const rect = element.getBoundingClientRect();
+    if (rect.bottom > rect.top) return true;
+  }
+  return false;
 }
 
 /**
@@ -1816,20 +2066,9 @@ function workGroupClientId(run: WorkChildItem[]): string {
   return workChildClientId(firstActivity ?? run[0]);
 }
 
-/** 工作组内全部可定位 clientId(嵌套组递归),供组容器的回退锚点使用。 */
+/** 工作组容器回退锚点：与删除补偿同一条 clientId 序列。 */
 function collectWorkGroupClientIds(children: readonly RenderItem[]): string[] {
-  const ids: string[] = [];
-  for (const child of children) {
-    if (child.type === 'message') ids.push(child.message.clientId);
-    else if (child.type === 'tool_segment') {
-      for (const toolCall of child.toolCalls) ids.push(toolCall.clientId);
-    } else if (child.type === 'agent_task' && child.toolCall) {
-      ids.push(child.toolCall.clientId);
-    } else if (child.type === 'work_group') {
-      ids.push(...collectWorkGroupClientIds(child.children));
-    }
-  }
-  return ids;
+  return collectDeleteAnchorClientIds(children);
 }
 
 function renderItemContainsClientId(item: RenderItem, clientId: string): boolean {
@@ -2401,29 +2640,31 @@ function renderWorkGroupChild(
   }
 
   return (
-    <MessageItem
-      message={item.message}
-      toolResult={props.singleResultMap.get(item.message.clientId)}
-      workingDir={props.workingDir}
-      sessionId={props.sessionId}
-      sessionTitle={props.sessionTitle}
-      agentKind={props.agentKind}
-      remoteHostId={props.remoteHostId}
-      sessionRunning={props.isSessionStreaming}
-      assistantForkBlocked={shouldBlockAssistantFork(
-        props.isSessionStreaming,
-        item.message,
-        props.assistantsWithFollowingUserBoundary,
-      )}
-      assistantIsTurnFinal={props.turnFinalAssistantClientIds.has(item.message.clientId)}
-      userTurnUsageDetails={props.userTurnUsageDetailsByAssistantId.get(item.message.clientId)}
-      isFirstUserMessage={item.message.clientId === props.firstUserMessageClientId}
-      isLastUserMessage={item.message.clientId === props.lastUserMessageClientId}
-      isLastUserInput={item.message.clientId === props.lastUserInputClientId}
-      isContinuationTurnOwner={item.message.clientId === props.continuationTurnClientId}
-      continuationInFlightProjectionCapability={props.continuationInFlightProjectionCapability}
-      localFileRefs={props.localFileRefs}
-    />
+    <div data-message-client-id={item.message.clientId}>
+      <MessageItem
+        message={item.message}
+        toolResult={props.singleResultMap.get(item.message.clientId)}
+        workingDir={props.workingDir}
+        sessionId={props.sessionId}
+        sessionTitle={props.sessionTitle}
+        agentKind={props.agentKind}
+        remoteHostId={props.remoteHostId}
+        sessionRunning={props.isSessionStreaming}
+        assistantForkBlocked={shouldBlockAssistantFork(
+          props.isSessionStreaming,
+          item.message,
+          props.assistantsWithFollowingUserBoundary,
+        )}
+        assistantIsTurnFinal={props.turnFinalAssistantClientIds.has(item.message.clientId)}
+        userTurnUsageDetails={props.userTurnUsageDetailsByAssistantId.get(item.message.clientId)}
+        isFirstUserMessage={item.message.clientId === props.firstUserMessageClientId}
+        isLastUserMessage={item.message.clientId === props.lastUserMessageClientId}
+        isLastUserInput={item.message.clientId === props.lastUserInputClientId}
+        isContinuationTurnOwner={item.message.clientId === props.continuationTurnClientId}
+        continuationInFlightProjectionCapability={props.continuationInFlightProjectionCapability}
+        localFileRefs={props.localFileRefs}
+      />
+    </div>
   );
 }
 
@@ -2578,6 +2819,8 @@ export function MessageStream({
   /** Set while we programmatically change scrollTop, so the scroll handler
    *  doesn't misread the assignment as user-initiated up-scroll. */
   const programmaticScrollRef = useRef(false);
+  /** 让旧 rAF 不能清掉后发程序化滚动的状态或覆盖其锚点。 */
+  const programmaticScrollGenerationRef = useRef(0);
   /** F-SYNC-2: remembered scrollHeight snapshot taken at the moment we
    *  trigger `onLoadMore`, used to restore position after prepend. */
   const prevScrollHeightRef = useRef(0);
@@ -2588,6 +2831,16 @@ export function MessageStream({
   const prevScrollTopAtLoadRef = useRef(0);
   /** Track previous scrollTop to detect scroll direction. */
   const prevScrollTopRef = useRef(0);
+  /** 上一帧 render items。全量序列在窗口回退成尾窗时仍能选到删除区后的邻居。 */
+  const prevVisibleItemsRef = useRef<readonly RenderItem[]>([]);
+  const prevAllItemsRef = useRef<readonly RenderItem[]>([]);
+  /** 最近一次滚动/跳转落定的视口顶端。不读 sessionScrollStore（程序化跳转后会陈旧）。 */
+  const lastViewportTopRef = useRef<ViewportTopSnapshot | null>(null);
+  /** 窗口重建后下一提交执行的一次性视口复位。 */
+  const pendingReanchorScrollRef = useRef<ViewportTopSnapshot | null>(null);
+  /** 程序化滚动期间到达的删除，待滚动结束后重放补偿。 */
+  const deferredDeleteCompensationRef = useRef(false);
+  const [deleteCompensationReplay, setDeleteCompensationReplay] = useState(0);
   /** clientId of the last user-role message we've already observed. Used to
    *  detect a NEW user send → force pin regardless of prior scroll state. */
   const lastUserMsg = messages[messages.length - 1];
@@ -2658,6 +2911,17 @@ export function MessageStream({
   } | null>(null);
   const focusScrollTimerRef = useRef<number | null>(null);
   const focusHighlightTimerRef = useRef<number | null>(null);
+  /** 进行中的 focus 跳转。生命周期跨越流式重渲染:接管 / 落定监听在挂载级注册并读
+   *  本 ref 判定,挂在 reactive effect 里会被内容型重渲染的 cleanup 拆掉且早退分支
+   *  不再重挂。keysAtJump 供目标在跳转途中被删时选相邻存活落点。 */
+  const focusJumpRef = useRef<{
+    requestKey: string;
+    clientId: string;
+    targetKey: string;
+    keysAtJump: readonly string[];
+    messageClientIdsAtJump: readonly string[];
+    scrollGeneration: number;
+  } | null>(null);
   useEffect(
     () => () => {
       if (focusScrollTimerRef.current !== null) {
@@ -2911,6 +3175,353 @@ export function MessageStream({
     return () => window.clearTimeout(id);
   }, [defaultWindowItems, firstVisibleItemKey, visibleRenderItems.length, allRenderItems.length]);
 
+  // 镜像 ref：unmount cleanup / ResizeObserver / 落定回调里读最新值（闭包会 stale）。
+  const visibleRenderItemsRef = useRef(visibleRenderItems);
+  visibleRenderItemsRef.current = visibleRenderItems;
+  // 量出当前视口顶端 render-item；若它内部还有已渲染的子消息，再记实际跨过视口顶边
+  // 的 message clientId。折叠工作组 / 折叠工具块的聚合 data-message-client-ids 只给
+  // focus 回退用，不参与视口快照，避免把隐藏 child 当成活锚点。
+  const measureViewportTop = useCallback((): ViewportTopSnapshot | null => {
+    const container = scrollRef.current;
+    const items = itemsRef.current;
+    if (!container || !items) return null;
+    const vis = visibleRenderItemsRef.current;
+    const cTop = container.getBoundingClientRect().top;
+    const children = items.children;
+    for (let i = 0; i < children.length; i++) {
+      const rect = (children[i] as HTMLElement).getBoundingClientRect();
+      // 第一条「底边还在容器顶边下方」的 item = 正好跨过视口顶边的那条。
+      if (rect.bottom - cTop > 0) {
+        const key = vis[i]?.key;
+        if (!key) return null;
+        const snapshot: ViewportTopSnapshot = {
+          viewportTopKey: key,
+          offset: Math.max(0, cTop - rect.top),
+        };
+        const itemElement = children[i] as HTMLElement;
+        const childAnchor = pickIntersectingChildAnchor(
+          Array.from(
+            itemElement.querySelectorAll<HTMLElement>('[data-message-client-id]'),
+            (element) => {
+              const clientId = readViewportChildAnchorClientId(element);
+              if (!clientId) return null;
+              const rect = element.getBoundingClientRect();
+              if (rect.bottom <= rect.top) return null;
+              return { clientId, top: rect.top, bottom: rect.bottom };
+            },
+          ).filter((candidate): candidate is ChildAnchorRect => candidate !== null),
+          cTop,
+        );
+        if (childAnchor) {
+          snapshot.messageClientId = childAnchor.clientId;
+          snapshot.messageOffset = childAnchor.offset;
+        }
+        return snapshot;
+      }
+    }
+    return null;
+  }, []);
+  // 量测并写入「删除前快照」，返回结果供同帧复用。用户滚动、非贴底程序化跳转与
+  // focus 落定经它刷新；贴底态由 auto-follow 接管，无需快照。
+  const refreshViewportAnchor = useCallback((): ViewportTopSnapshot | null => {
+    const measured = measureViewportTop();
+    if (measured) lastViewportTopRef.current = measured;
+    return measured;
+  }, [measureViewportTop]);
+  const beginProgrammaticScroll = useCallback((): number => {
+    programmaticScrollRef.current = true;
+    programmaticScrollGenerationRef.current += 1;
+    return programmaticScrollGenerationRef.current;
+  }, []);
+  // true = 触发删除补偿重放；false = 正常结束；null = 已被后发滚动取代的旧回调。
+  const finishProgrammaticScroll = useCallback(
+    (
+      generation: number,
+      { consumeDeferredDelete = false }: { consumeDeferredDelete?: boolean } = {},
+    ): boolean | null => {
+      const decision = resolveProgrammaticScrollEndDecision({
+        generation,
+        activeGeneration: programmaticScrollGenerationRef.current,
+        hasDeferredDelete: deferredDeleteCompensationRef.current,
+        consumeDeferredDelete,
+      });
+      if (decision === 'stale') return null;
+      programmaticScrollGenerationRef.current += 1;
+      programmaticScrollRef.current = false;
+      if (decision === 'finished') return false;
+      deferredDeleteCompensationRef.current = false;
+      if (decision === 'consume-deferred-delete') return false;
+      setDeleteCompensationReplay((version) => version + 1);
+      return true;
+    },
+    [],
+  );
+  const allRenderItemsRef = useRef(allRenderItems);
+  allRenderItemsRef.current = allRenderItems;
+  // 折叠/展开不改 visibleRenderItems。精确 child 被卸掉且数据仍在时降级重测；
+  // 快照没有子锚点但视口顶 item 已露出精确 child 时也重测（折叠→展开）。
+  const refreshHiddenChildViewportAnchor = useCallback(() => {
+    const snapshot = lastViewportTopRef.current;
+    const clientId = snapshot?.messageClientId;
+    if (clientId && snapshot) {
+      const root = scrollRef.current;
+      const exact = root ? queryMessageElement(root, clientId) : null;
+      const rect = exact?.getBoundingClientRect();
+      if (
+        !shouldRefreshHiddenChildViewportAnchor({
+          snapshotMessageClientId: clientId,
+          exactChildVisible: Boolean(rect && rect.bottom > rect.top),
+          childStillInRenderItems: allRenderItemsRef.current.some((item) =>
+            renderItemContainsClientId(item, clientId),
+          ),
+        })
+      ) {
+        return;
+      }
+      lastViewportTopRef.current = toRenderItemViewportSnapshot(snapshot);
+      refreshViewportAnchor();
+      return;
+    }
+    const vis = visibleRenderItemsRef.current;
+    const idx = snapshot
+      ? vis.findIndex((item) => item.key === snapshot.viewportTopKey)
+      : -1;
+    const itemElement =
+      idx >= 0 ? (itemsRef.current?.children[idx] as HTMLElement | undefined) : undefined;
+    if (
+      !shouldRefreshExpandedChildViewportAnchor({
+        snapshotMessageClientId: clientId,
+        viewportTopItemHasVisibleExactChild: Boolean(
+          itemElement && hasVisibleExactChildAnchor(itemElement),
+        ),
+      })
+    ) {
+      return;
+    }
+    refreshViewportAnchor();
+  }, [refreshViewportAnchor]);
+  // 瞬时把 key 对应 item 的顶边摆到「容器顶边下方 offset 处」;key 不在当前窗口或
+  // DOM 未就绪则放弃。删除补偿与 focus 落定共用。
+  const scrollKeyToViewportTop = useCallback((key: string, offset: number) => {
+    const container = scrollRef.current;
+    const idx = visibleRenderItemsRef.current.findIndex((item) => item.key === key);
+    const child =
+      idx >= 0 ? (itemsRef.current?.children[idx] as HTMLElement | undefined) : undefined;
+    if (!container || !child) return;
+    const delta =
+      child.getBoundingClientRect().top - (container.getBoundingClientRect().top - offset);
+    if (Math.abs(delta) < 1) return;
+    const generation = beginProgrammaticScroll();
+    container.scrollTop += delta;
+    requestAnimationFrame(() => finishProgrammaticScroll(generation));
+  }, [beginProgrammaticScroll, finishProgrammaticScroll]);
+  const scrollMessageToViewportTop = useCallback((clientId: string, offset: number) => {
+    const container = scrollRef.current;
+    // 视口复位只认已渲染的精确 child。聚合 data-message-client-ids 命中折叠组容器
+    // 会让隐藏 child 继续当活锚点，删除后把组滚到顶。focus 跳转仍走 queryFocusElement。
+    const target = container ? queryMessageElement(container, clientId) : null;
+    if (!container || !target) return false;
+    const delta =
+      target.getBoundingClientRect().top - (container.getBoundingClientRect().top - offset);
+    if (Math.abs(delta) < 1) return true;
+    const generation = beginProgrammaticScroll();
+    container.scrollTop += delta;
+    requestAnimationFrame(() => finishProgrammaticScroll(generation));
+    return true;
+  }, [beginProgrammaticScroll, finishProgrammaticScroll]);
+  const restoreViewportSnapshot = useCallback(
+    (snapshot: ViewportTopSnapshot, itemOffset = snapshot.offset): boolean => {
+      if (
+        snapshot.messageClientId &&
+        scrollMessageToViewportTop(snapshot.messageClientId, snapshot.messageOffset ?? 0)
+      ) {
+        lastViewportTopRef.current = snapshot;
+        return true;
+      }
+      const itemSnapshot = toRenderItemViewportSnapshot(snapshot, itemOffset);
+      lastViewportTopRef.current = itemSnapshot;
+      if (visibleRenderItemsRef.current.some((item) => item.key === itemSnapshot.viewportTopKey)) {
+        scrollKeyToViewportTop(itemSnapshot.viewportTopKey, itemSnapshot.offset);
+        return true;
+      }
+      return false;
+    },
+    [scrollKeyToViewportTop, scrollMessageToViewportTop],
+  );
+  const restoreViewportSnapshotOrRebuildWindow = useCallback(
+    (snapshot: ViewportTopSnapshot, itemOffset = snapshot.offset) => {
+      if (restoreViewportSnapshot(snapshot, itemOffset)) return;
+      pendingReanchorScrollRef.current = lastViewportTopRef.current;
+      const key = lastViewportTopRef.current?.viewportTopKey;
+      if (key) setFirstVisibleItemKey(key);
+    },
+    [restoreViewportSnapshot],
+  );
+  const cancelFocusJump = useCallback(
+    ({
+      consumeDeferredDelete = false,
+      refreshAnchor = false,
+    }: {
+      consumeDeferredDelete?: boolean;
+      refreshAnchor?: boolean;
+    } = {}): boolean => {
+      const jump = focusJumpRef.current;
+      if (!jump) return false;
+      focusJumpRef.current = null;
+      if (focusScrollTimerRef.current !== null) {
+        window.clearTimeout(focusScrollTimerRef.current);
+        focusScrollTimerRef.current = null;
+      }
+      if (focusHighlightTimerRef.current !== null) {
+        window.clearTimeout(focusHighlightTimerRef.current);
+        focusHighlightTimerRef.current = null;
+      }
+      // 只终止仍由这次 focus 拥有的原生 smooth 动画；过期 focus 不得打断后发滚动。
+      if (jump.scrollGeneration === programmaticScrollGenerationRef.current) {
+        const root = scrollRef.current;
+        if (root) root.scrollTo({ top: root.scrollTop, behavior: 'auto' });
+      }
+      const replayingDelete = finishProgrammaticScroll(jump.scrollGeneration, {
+        consumeDeferredDelete,
+      });
+      if (refreshAnchor && replayingDelete === false) refreshViewportAnchor();
+      return true;
+    },
+    [finishProgrammaticScroll, refreshViewportAnchor],
+  );
+  // focus 跳转落定收尾(scrollend 主路径与兜底 timer 共用,幂等):途中布局变化
+  // (删除 / 流式)会让 smooth 落点偏离目标,先瞬时校正回目标;目标在跳转途中被删时
+  // 锚到跳转时序列中它之后第一条存活 item(与删除补偿同语义,落点在窗口外则走窗口
+  // 重建 + pending 复位);用户已接管则不校正。下一帧再清 programmatic 标记并刷新
+  // 删除前快照——半途量测会把跳变中的位置误存为锚点。
+  const settleFocusJump = useCallback(() => {
+    const jump = focusJumpRef.current;
+    if (!jump) return;
+    focusJumpRef.current = null;
+    if (focusScrollTimerRef.current !== null) {
+      window.clearTimeout(focusScrollTimerRef.current);
+      focusScrollTimerRef.current = null;
+    }
+    if (focusHighlightTimerRef.current !== null) {
+      window.clearTimeout(focusHighlightTimerRef.current);
+      focusHighlightTimerRef.current = null;
+    }
+    if (jump.scrollGeneration !== programmaticScrollGenerationRef.current) return;
+    // settle 前已观察到的删除由当前目标校正消费；同帧后续删除仍走通用重放。
+    deferredDeleteCompensationRef.current = false;
+    // 邻居锚定分支会显式写入快照(窗口重建的 DOM 下一提交才就绪),此时不得再用
+    // 旧 DOM 量测覆盖。
+    let snapshotPinned = false;
+    const root = scrollRef.current;
+    if (root) {
+      setHighlightMessageClientId(jump.clientId);
+      const all = allRenderItemsRef.current;
+      const target = queryFocusElement(root, jump.clientId);
+      if (target) {
+        target.scrollIntoView({ block: 'center' });
+        const measured = refreshViewportAnchor();
+        const rootTop = root.getBoundingClientRect().top;
+        const targetRect = target.getBoundingClientRect();
+        if (
+          jump.messageClientIdsAtJump.includes(jump.clientId) &&
+          shouldUseFocusedElementAsViewportAnchor({
+            focusClientId: jump.clientId,
+            elementClientId: target.dataset.messageClientId,
+            containerTop: rootTop,
+            elementTop: targetRect.top,
+            elementBottom: targetRect.bottom,
+          })
+        ) {
+          lastViewportTopRef.current = {
+            ...(measured ?? {
+              viewportTopKey: renderItemKeyForClientId(all, jump.clientId) ?? jump.targetKey,
+              offset: 0,
+            }),
+            messageClientId: jump.clientId,
+            messageOffset: Math.max(0, rootTop - targetRect.top),
+          };
+        }
+      } else {
+        const targetExists = all.some((item) => renderItemContainsClientId(item, jump.clientId));
+        const landMessageClientId =
+          !targetExists && jump.messageClientIdsAtJump.includes(jump.clientId)
+            ? pickDeleteCompensationAnchorKey(
+                jump.messageClientIdsAtJump,
+                collectDeleteAnchorClientIds(all),
+                jump.clientId,
+              )
+            : null;
+        let landKey = landMessageClientId
+          ? renderItemKeyForClientId(all, landMessageClientId)
+          : null;
+        if (!landKey) {
+          const recoveredIdx = findRestorableViewportItemIdx(all, jump.targetKey);
+          landKey =
+            recoveredIdx >= 0
+              ? (all[recoveredIdx]?.key ?? null)
+              : pickDeleteCompensationAnchorKey(
+                  jump.keysAtJump,
+                  all.map((item) => item.key),
+                  jump.targetKey,
+                );
+        }
+        if (landKey) {
+          snapshotPinned = true;
+          restoreViewportSnapshotOrRebuildWindow({
+            viewportTopKey: landKey,
+            offset: 0,
+            ...(landMessageClientId
+              ? { messageClientId: landMessageClientId, messageOffset: 0 }
+              : {}),
+          });
+        }
+      }
+    }
+    requestAnimationFrame(() => {
+      const activeJump = focusJumpRef.current;
+      if (activeJump && activeJump.requestKey !== jump.requestKey) return;
+      const replayingDelete = finishProgrammaticScroll(jump.scrollGeneration);
+      if (!snapshotPinned && replayingDelete === false) refreshViewportAnchor();
+    });
+  }, [
+    finishProgrammaticScroll,
+    refreshViewportAnchor,
+    restoreViewportSnapshotOrRebuildWindow,
+  ]);
+  // 接管 / 落定监听挂载级注册一次,读 focusJumpRef 判定,无活跃跳转时空转。挂在下面
+  // 的 reactive effect 里会被流式重渲染的 cleanup 拆掉且早退分支不再重挂,导致接管
+  // 失灵、兜底 timer 落定时把用户拽回目标。
+  useEffect(() => {
+    const root = scrollRef.current;
+    if (!root) return;
+    // 用户中途接管(滚轮 / 触摸 / 按住滚动条 / 键盘导航):浏览器已取消 smooth 动画,
+    // 立即恢复用户滚动语义,落定时不再校正回目标。
+    const onUserInput = () => {
+      // finish 路径会重放 focus 期间延期的删除补偿；不能直接清掉，否则用户接管后
+      // 会永久保留删除造成的错误位移。
+      cancelFocusJump();
+    };
+    const onNavigationKey = (event: KeyboardEvent) => {
+      if (event.defaultPrevented) return;
+      if (!isScrollNavigationKey(event.key)) return;
+      if (isEditableKeyboardTarget(event.target)) return;
+      onUserInput();
+    };
+    const onScrollEnd = () => settleFocusJump();
+    root.addEventListener('wheel', onUserInput, { passive: true });
+    root.addEventListener('touchstart', onUserInput, { passive: true });
+    root.addEventListener('mousedown', onUserInput);
+    window.addEventListener('keydown', onNavigationKey);
+    root.addEventListener('scrollend', onScrollEnd);
+    return () => {
+      root.removeEventListener('wheel', onUserInput);
+      root.removeEventListener('touchstart', onUserInput);
+      root.removeEventListener('mousedown', onUserInput);
+      window.removeEventListener('keydown', onNavigationKey);
+      root.removeEventListener('scrollend', onScrollEnd);
+    };
+  }, [cancelFocusJump, settleFocusJump]);
+
   useLayoutEffect(() => {
     const focusRequestKey = focusMessageClientId
       ? `${focusMessageRequestId ?? 0}:${focusMessageClientId}`
@@ -2918,7 +3529,13 @@ export function MessageStream({
     if (!focusMessageClientId || !focusRequestKey) {
       lastAppliedFocusRef.current = null;
       lastMissingFocusRef.current = null;
+      cancelFocusJump({ refreshAnchor: true });
       return;
+    }
+    // 新请求必须在任何 missing / 扩窗 / DOM 未就绪早退前废弃旧跳转，否则旧 timer
+    // 或 scrollend 会继续按上一目标落定。requestId 也纳入 key，支持同消息重复跳转。
+    if (focusJumpRef.current && focusJumpRef.current.requestKey !== focusRequestKey) {
+      cancelFocusJump({ refreshAnchor: true });
     }
     if (lastAppliedFocusRef.current === focusRequestKey) return;
     const lastItemKey = allRenderItems.at(-1)?.key ?? null;
@@ -2949,20 +3566,22 @@ export function MessageStream({
     }
     const root = scrollRef.current;
     if (!root) return;
-    // 精确锚点(message wrapper / 带 toolCall 的任务卡)优先;查不到时退回
-    // 聚合动作块的容器锚点(data-message-client-ids 空格分隔多 clientId)——
-    // 后台 Bash 等工具行渲染在折叠块内,没有独立的行级 DOM 锚点。
-    const el = (root.querySelector(
-      `[data-message-client-id="${CSS.escape(focusMessageClientId)}"]`,
-    ) ??
-      root.querySelector(
-        `[data-message-client-ids~="${CSS.escape(focusMessageClientId)}"]`,
-      )) as HTMLElement | null;
+    const el = queryFocusElement(root, focusMessageClientId);
     if (!el) return;
     restoringRef.current = false;
     isNearBottomRef.current = false;
     setIsNearBottom(false);
-    programmaticScrollRef.current = true;
+    const scrollGeneration = beginProgrammaticScroll();
+    // 新跳直接覆盖未落定的旧跳(用户快速连点两条结果):旧跳转态被替换,旧兜底
+    // timer 一并重设,浏览器的旧 smooth 动画由新 scrollIntoView 接管。
+    focusJumpRef.current = {
+      requestKey: focusRequestKey,
+      clientId: focusMessageClientId,
+      targetKey,
+      keysAtJump: allRenderItems.map((item) => item.key),
+      messageClientIdsAtJump: collectDeleteAnchorClientIds(allRenderItems),
+      scrollGeneration,
+    };
     el.scrollIntoView({ behavior: 'smooth', block: 'center' });
     lastAppliedFocusRef.current = focusRequestKey;
     if (focusScrollTimerRef.current !== null) {
@@ -2971,32 +3590,27 @@ export function MessageStream({
     if (focusHighlightTimerRef.current !== null) {
       window.clearTimeout(focusHighlightTimerRef.current);
     }
-    // 高亮时机:等平滑滚动**落定后**再点亮,避免目标还在半途就提前闪高亮(用户反馈)。
-    // 优先用 scrollend 精确对齐;拿不到(不支持 / 目标已在视口内滚动距离为 0 不触发)时用兜底延时。
-    // 点亮后**不再自动淡出**——停在搜索命中处,直到下次跳转覆盖或切会话(满足「搜索态高亮不消失」)。
-    let highlightApplied = false;
-    const applyHighlight = () => {
-      if (highlightApplied) return;
-      highlightApplied = true;
-      root.removeEventListener('scrollend', applyHighlight);
-      setHighlightMessageClientId(focusMessageClientId);
-    };
-    root.addEventListener('scrollend', applyHighlight, { once: true });
-    focusScrollTimerRef.current = window.setTimeout(() => {
-      programmaticScrollRef.current = false;
-    }, 800);
-    // 兜底:scrollend 未触发(距离为 0 / 环境不支持)时,~600ms 后强制点亮。
+    // 落定主路径是挂载级 scrollend 监听;有 scrollend 时兜底只是安全网(长距离
+    // smooth 常 >800ms,给足 2.5s),无 scrollend 的环境用 800ms 近似落定。
+    focusScrollTimerRef.current = window.setTimeout(
+      settleFocusJump,
+      'onscrollend' in window ? 2500 : 800,
+    );
+    // 高亮等落定后再点亮(落定回调里做),点亮后不再自动淡出——停在搜索命中处,直到
+    // 下次跳转覆盖或切会话。scrollend 未触发(距离为 0 / 环境不支持)时 ~600ms 兜底。
     focusHighlightTimerRef.current = window.setTimeout(() => {
-      applyHighlight();
+      setHighlightMessageClientId(focusMessageClientId);
       focusHighlightTimerRef.current = null;
     }, 600);
-    // 清理:effect 因依赖变化重跑(如用户快速连点两条结果)时,移除尚未触发的旧监听器,
-    // 避免旧 applyHighlight 在下次 scrollend 以上一条 clientId 点亮、造成高亮闪错消息。
-    // 已触发过则监听器已被 { once } 自动移除,这里为幂等空操作。
-    return () => {
-      root.removeEventListener('scrollend', applyHighlight);
-    };
-  }, [allRenderItems, focusMessageClientId, focusMessageRequestId, visibleRenderItems]);
+  }, [
+    allRenderItems,
+    focusMessageClientId,
+    focusMessageRequestId,
+    visibleRenderItems,
+    beginProgrammaticScroll,
+    cancelFocusJump,
+    settleFocusJump,
+  ]);
 
   // 会话内全部图片的有序 src(全量,来自未裁剪的 allRenderItems),下发给
   // ImageLightbox 做翻图。基于全量而非 visibleRenderItems,这样计数 / 翻页
@@ -3083,10 +3697,7 @@ export function MessageStream({
     visibleStartIdx + visibleRenderItems.length >= allRenderItems.length;
 
   // ── 滚动位置 保存 / 还原 的辅助 ──
-  // unmount cleanup 与 ResizeObserver 回调里读不到最新的 visibleRenderItems /
-  // firstVisibleItemKey(闭包会 stale),用 ref 镜像每次 render 同步一份,供它们读取。
-  const visibleRenderItemsRef = useRef(visibleRenderItems);
-  visibleRenderItemsRef.current = visibleRenderItems;
+  // 镜像 ref:unmount cleanup 与 ResizeObserver 回调里读最新值(闭包会 stale)。
   const windowCoversEndRef = useRef(windowCoversEnd);
   windowCoversEndRef.current = windowCoversEnd;
   const firstVisibleItemKeyRef = useRef(firstVisibleItemKey);
@@ -3107,28 +3718,6 @@ export function MessageStream({
     }
   }, [firstVisibleItemKey, windowCoversEnd]);
 
-  // 量出当前视口顶端那条 render-item 的 key + 它被滚到视口上方的像素数。
-  // 用 children 索引 ↔ visibleRenderItems 索引的天然对应关系反查(map 一条 item
-  // 产出一个根节点),不需要给每条 item 的 DOM 打 data 标记。stable 引用(无依赖)。
-  const measureViewportTop = useCallback((): { viewportTopKey: string; offset: number } | null => {
-    const container = scrollRef.current;
-    const items = itemsRef.current;
-    if (!container || !items) return null;
-    const vis = visibleRenderItemsRef.current;
-    const cTop = container.getBoundingClientRect().top;
-    const children = items.children;
-    for (let i = 0; i < children.length; i++) {
-      const rect = (children[i] as HTMLElement).getBoundingClientRect();
-      // 第一条「底边还在容器顶边下方」的 item = 正好跨过视口顶边的那条。
-      if (rect.bottom - cTop > 0) {
-        const key = vis[i]?.key;
-        if (!key) return null;
-        return { viewportTopKey: key, offset: Math.max(0, cTop - rect.top) };
-      }
-    }
-    return null;
-  }, []);
-
   // 把视口滚回快照记录的「锚点 item + 偏移」。按条目相对定位,所以即使上方图片 /
   // markdown 还没异步渲染完导致高度偏小,也会落在正确的 item 上;settle 期间由
   // ResizeObserver 反复调用本函数纠偏(幂等,不漂移)。stable 引用(无依赖)。
@@ -3145,36 +3734,36 @@ export function MessageStream({
     const rect = child.getBoundingClientRect();
     // 期望 child 顶端落在 (容器顶边 - offset) 处;向下滚 delta 会让 rect.top 上移 delta。
     const delta = rect.top - (cTop - snap.offset);
-    if (Math.abs(delta) < 1) return;
-    programmaticScrollRef.current = true;
+    if (Math.abs(delta) < 1) {
+      refreshViewportAnchor();
+      return;
+    }
+    const generation = beginProgrammaticScroll();
     container.scrollTop += delta;
     requestAnimationFrame(() => {
-      programmaticScrollRef.current = false;
+      if (finishProgrammaticScroll(generation) === false) refreshViewportAnchor();
     });
-  }, []);
+  }, [beginProgrammaticScroll, finishProgrammaticScroll, refreshViewportAnchor]);
   // ResizeObserver 回调用 ref 取最新 applyRestore,避免把它放进 observer 依赖导致
   // 流式每 token(visibleRenderItems 变)都 disconnect/reconnect。
   const applyRestoreRef = useRef(applyRestore);
   applyRestoreRef.current = applyRestore;
 
-  // 保存当前浏览位置到 sessionScrollStore。在用户滚动时(DOM 一定存活)持续调用,
-  // 不依赖 unmount 时机。无 sessionId / 量测失败则跳过。
+  // 保存当前浏览位置到 sessionScrollStore,并同步刷新删除前快照(单次量测)。用户
+  // 滚动时持续调用(DOM 一定存活),unmount cleanup 兜底最后一帧;量测失败则跳过。
   const saveRafRef = useRef<number | null>(null);
   const saveScrollSnapshot = useCallback(() => {
-    if (!sessionId) return;
-    const measured = measureViewportTop();
-    if (!measured) return;
+    const measured = refreshViewportAnchor();
+    if (!sessionId || !measured) return;
     saveSessionScroll(sessionId, {
       windowAnchorKey: firstVisibleItemKeyRef.current,
       viewportTopKey: measured.viewportTopKey,
       offset: measured.offset,
       isNearBottom: isNearBottomRef.current,
       anchoredForwardCount:
-        firstVisibleItemKeyRef.current !== null
-          ? anchoredForwardItemsRef.current
-          : undefined,
+        firstVisibleItemKeyRef.current !== null ? anchoredForwardItemsRef.current : undefined,
     });
-  }, [sessionId, measureViewportTop]);
+  }, [sessionId, refreshViewportAnchor]);
 
   // perf-baseline (见 perfLog 注释):
   // 父组件用 key={sessionId} 包了本组件,所以每次切 session 都是全新 mount,
@@ -3374,24 +3963,135 @@ export function MessageStream({
   // 动手就立即通行 — 不会卡住"用 chip 连点上翻"或"跳完立刻 wheel 看更老历史"。
   // 3s safety timer 兜底,应对极端 case(用户 click 后既不滚也不动键盘)。
   const chipJumpInProgressRef = useRef<boolean>(false);
+  const chipJumpGenerationRef = useRef<number | null>(null);
+  const chipJumpTargetRef = useRef<ChipJumpTarget | null>(null);
   const chipJumpClearTimerRef = useRef<number | null>(null);
   const userHistoryTouchStartYRef = useRef<number | null>(null);
   const userIntentLoadInFlightRef = useRef<boolean>(false);
-  const clearChipJumpSuppression = useCallback(() => {
-    if (chipJumpInProgressRef.current) {
+  const finishChipJump = useCallback(
+    (
+      generation: number,
+      {
+        consumeDeferredDelete = false,
+        refreshAnchor = false,
+      }: { consumeDeferredDelete?: boolean; refreshAnchor?: boolean } = {},
+    ): boolean | null => {
+      if (chipJumpGenerationRef.current !== generation) return null;
+      chipJumpGenerationRef.current = null;
+      if (chipJumpTargetRef.current?.generation === generation) {
+        chipJumpTargetRef.current = null;
+      }
       chipJumpInProgressRef.current = false;
+      if (chipJumpClearTimerRef.current !== null) {
+        window.clearTimeout(chipJumpClearTimerRef.current);
+        chipJumpClearTimerRef.current = null;
+      }
+      const replayingDelete = finishProgrammaticScroll(generation, { consumeDeferredDelete });
+      if (refreshAnchor && replayingDelete === false) refreshViewportAnchor();
+      return replayingDelete;
+    },
+    [finishProgrammaticScroll, refreshViewportAnchor],
+  );
+  // wheel/touch/键盘接管：结束当前 smooth，但让期间延期的删除补偿重放。
+  const clearChipJumpSuppression = useCallback(() => {
+    // 跳底会乐观置位贴底。接管后若仍贴底：流式 ResizeObserver 会 pinToBottom 拽回
+    // 视口，延期删除重放也会被补偿 effect 直接跳过。有进行中的 chip / focus /
+    // 跳底 generation 时一律解除，不只在已有延期删除时。
+    if (
+      deferredDeleteCompensationRef.current ||
+      chipJumpGenerationRef.current !== null ||
+      focusJumpRef.current ||
+      programmaticScrollRef.current
+    ) {
+      unpinAutoFollowForUserUpIntent();
     }
+    const generation = chipJumpGenerationRef.current;
+    if (generation !== null) {
+      finishChipJump(generation);
+      const root = scrollRef.current;
+      if (root) root.scrollTo({ top: root.scrollTop, behavior: 'auto' });
+      return;
+    }
+    chipJumpInProgressRef.current = false;
     if (chipJumpClearTimerRef.current !== null) {
       window.clearTimeout(chipJumpClearTimerRef.current);
       chipJumpClearTimerRef.current = null;
     }
-  }, []);
+    if (focusJumpRef.current) {
+      cancelFocusJump();
+      return;
+    }
+    if (programmaticScrollRef.current) {
+      finishProgrammaticScroll(programmaticScrollGenerationRef.current);
+      const root = scrollRef.current;
+      if (root) root.scrollTo({ top: root.scrollTop, behavior: 'auto' });
+    }
+  }, [cancelFocusJump, finishChipJump, finishProgrammaticScroll, unpinAutoFollowForUserUpIntent]);
+  // 正常落定：删除 / 流式更新可能让 smooth 开始时算出的像素落点失效。必须按本次
+  // generation 保存的目标标识重新查 DOM、瞬时校正后，才能让确定落点消费延期删除补偿。
+  // 目标已被删 / DOM 不可用时不消费，交给通用删除补偿重放。
+  const settleChipJump = useCallback((expectedGeneration?: number) => {
+    const generation = expectedGeneration ?? chipJumpGenerationRef.current;
+    if (generation === null || chipJumpGenerationRef.current !== generation) return;
+    const target = chipJumpTargetRef.current;
+    let targetResolved = false;
+    const root = scrollRef.current;
+    if (root && target?.generation === generation) {
+      const selectorAttribute =
+        target.selector === 'user-message' ? 'data-user-msg-id' : 'data-message-client-id';
+      const element = root.querySelector<HTMLElement>(
+        `[${selectorAttribute}="${CSS.escape(target.clientId)}"]`,
+      );
+      if (element) {
+        const correctedScrollTop = resolveChipJumpTargetScrollTop({
+          scrollTop: root.scrollTop,
+          containerTop: root.getBoundingClientRect().top,
+          targetTop: element.getBoundingClientRect().top,
+          topOffset: target.topOffset,
+        });
+        if (Math.abs(correctedScrollTop - root.scrollTop) >= 1) root.scrollTop = correctedScrollTop;
+        targetResolved = true;
+      }
+    }
+    // 只消费校正前已观察到的删除；校正后、下一帧 finish 前新到的删除会重新置位，
+    // 仍由 finish 触发重放，不能被这次导航一并吞掉。
+    if (targetResolved) deferredDeleteCompensationRef.current = false;
+    requestAnimationFrame(() => finishChipJump(generation, { refreshAnchor: true }));
+  }, [finishChipJump]);
+  const beginChipJump = useCallback((target: Omit<ChipJumpTarget, 'generation'>) => {
+    if (chipJumpClearTimerRef.current !== null) {
+      window.clearTimeout(chipJumpClearTimerRef.current);
+    }
+    chipJumpInProgressRef.current = true;
+    const generation = beginProgrammaticScroll();
+    chipJumpGenerationRef.current = generation;
+    chipJumpTargetRef.current = { ...target, generation };
+    chipJumpClearTimerRef.current = window.setTimeout(() => {
+      settleChipJump(generation);
+    }, CHIP_JUMP_SAFETY_MS);
+  }, [beginProgrammaticScroll, settleChipJump]);
+  useEffect(() => {
+    const root = scrollRef.current;
+    if (!root) return;
+    const onScrollEnd = () => {
+      settleChipJump();
+      if (chipJumpGenerationRef.current !== null) return;
+      if (!programmaticScrollRef.current) return;
+      const generation = programmaticScrollGenerationRef.current;
+      if (finishProgrammaticScroll(generation) === false) refreshViewportAnchor();
+    };
+    root.addEventListener('scrollend', onScrollEnd);
+    return () => root.removeEventListener('scrollend', onScrollEnd);
+  }, [finishProgrammaticScroll, refreshViewportAnchor, settleChipJump]);
   useEffect(() => {
     return () => {
       if (chipJumpClearTimerRef.current !== null) {
         window.clearTimeout(chipJumpClearTimerRef.current);
         chipJumpClearTimerRef.current = null;
       }
+      chipJumpGenerationRef.current = null;
+      chipJumpTargetRef.current = null;
+      chipJumpInProgressRef.current = false;
     };
   }, []);
   useEffect(() => {
@@ -3487,17 +4187,22 @@ export function MessageStream({
     const onTouchEnd = () => {
       userHistoryTouchStartYRef.current = null;
     };
+    const onMouseDown = () => {
+      clearChipJumpSuppression();
+    };
     root.addEventListener('wheel', onWheel, { passive: true });
     root.addEventListener('touchstart', onTouchStart, { passive: true });
     root.addEventListener('touchmove', onTouchMove, { passive: true });
     root.addEventListener('touchend', onTouchEnd, { passive: true });
     root.addEventListener('touchcancel', onTouchEnd, { passive: true });
+    root.addEventListener('mousedown', onMouseDown);
     return () => {
       root.removeEventListener('wheel', onWheel);
       root.removeEventListener('touchstart', onTouchStart);
       root.removeEventListener('touchmove', onTouchMove);
       root.removeEventListener('touchend', onTouchEnd);
       root.removeEventListener('touchcancel', onTouchEnd);
+      root.removeEventListener('mousedown', onMouseDown);
     };
   }, [clearChipJumpSuppression, triggerUserIntentFill, unpinAutoFollowForUserUpIntent]);
   useEffect(() => {
@@ -3525,16 +4230,18 @@ export function MessageStream({
   const pinToBottom = useCallback(() => {
     const el = scrollRef.current;
     if (!el) return;
-    programmaticScrollRef.current = true;
+    const generation = beginProgrammaticScroll();
     suppressScrollbarActivation(el);
     el.scrollTop = el.scrollHeight;
     // Clear the flag on the next frame — after the browser has dispatched
     // the resulting scroll event. We use rAF (not a microtask) because the
     // scroll event is dispatched asynchronously.
     requestAnimationFrame(() => {
-      programmaticScrollRef.current = false;
+      if (finishProgrammaticScroll(generation) === false && !isNearBottomRef.current) {
+        refreshViewportAnchor();
+      }
     });
-  }, []);
+  }, [beginProgrammaticScroll, finishProgrammaticScroll, refreshViewportAnchor]);
 
   // F3: 平滑滚到底的按钮回调。
   //   - 乐观更新 unreadCount / isNearBottom / isNearBottomRef → 按钮同一 tick fade-out
@@ -3544,14 +4251,23 @@ export function MessageStream({
   const scrollToBottomSmooth = useCallback(() => {
     const el = scrollRef.current;
     if (!el) return;
+    // 显式的新导航取代尚未落定的搜索 focus；自身的底部落点会消费此前延期的删除补偿。
+    cancelFocusJump({ consumeDeferredDelete: true });
+    const chipJumpGeneration = chipJumpGenerationRef.current;
+    if (chipJumpGeneration !== null) {
+      finishChipJump(chipJumpGeneration, { consumeDeferredDelete: true });
+    }
     setUnreadCount(0);
     setIsNearBottom(true);
     isNearBottomRef.current = true;
-    programmaticScrollRef.current = true;
+    const generation = beginProgrammaticScroll();
     // render-window-bidirectional: 清除锚点回到默认尾部窗口（chip/jump-down 语义）。
     setFirstVisibleItemKey(null);
     el.scrollTo({ top: el.scrollHeight, behavior: 'smooth' });
-  }, []);
+    window.setTimeout(() => {
+      if (finishProgrammaticScroll(generation) === false) refreshViewportAnchor();
+    }, CHIP_JUMP_SAFETY_MS);
+  }, [beginProgrammaticScroll, cancelFocusJump, finishChipJump, finishProgrammaticScroll, refreshViewportAnchor]);
 
   // F2: messages diff → 按角色累计 unreadCount
   //   - 计数规则抽成纯函数 countUnreadAdded（见 unreadCount.ts）：新 clientId 才计、
@@ -3701,14 +4417,30 @@ export function MessageStream({
         return;
       }
       if (performance.now() < suppressPinUntil) return;
-      if (isNearBottomRef.current) pinToBottom();
+      if (isNearBottomRef.current) {
+        pinToBottom();
+        return;
+      }
+      refreshHiddenChildViewportAnchor();
     });
     ro.observe(content);
     return () => {
       content.removeEventListener(CARD_EXPAND_TOGGLE_EVENT, onCardExpandToggle);
       ro.disconnect();
     };
-  }, [pinToBottom]);
+  }, [pinToBottom, refreshHiddenChildViewportAnchor]);
+
+  // 折叠动画末帧可能已是 0fr，再卸载时内容高度几乎不变，ResizeObserver 不一定
+  // 再触发。精确 child 节点从 items 子树消失时补一次（数据仍在才重测）。
+  useEffect(() => {
+    const items = itemsRef.current;
+    if (!items) return;
+    const observer = new MutationObserver(() => {
+      refreshHiddenChildViewportAnchor();
+    });
+    observer.observe(items, { childList: true, subtree: true });
+    return () => observer.disconnect();
+  }, [refreshHiddenChildViewportAnchor]);
 
   // F-SYNC-2 + render-window: Preserve scroll position after either
   //   (a) DB prepend (messages 数组前端追加,触发 isLoadingMore false → render)
@@ -3756,17 +4488,206 @@ export function MessageStream({
       if (delta > 0 && !anchoringApplied) {
         // anchoring 没生效(viewport 内没合适锚点元素时 Chromium 会跳过自动调整),
         // 由 F-SYNC-2 手动补偿,行为同原版。
-        programmaticScrollRef.current = true;
+        const generation = beginProgrammaticScroll();
         el.scrollTop += delta;
-        requestAnimationFrame(() => {
-          programmaticScrollRef.current = false;
-        });
+        requestAnimationFrame(() => finishProgrammaticScroll(generation));
       }
       // anchoringApplied=true 分支无操作 — 浏览器 anchoring 已把 viewport 摆好。
       prevScrollHeightRef.current = 0;
       prevScrollTopAtLoadRef.current = 0;
     }
-  }, [visibleRenderItems, isLoadingMore]);
+  }, [visibleRenderItems, isLoadingMore, beginProgrammaticScroll, finishProgrammaticScroll]);
+
+  // ── 删除靠前 message 后的视口保位（#2289）──
+  // 快照来自滚动/跳转落定；删除提交后再量会使 delta 恒为 0。贴底交给 pin-to-bottom。
+  useLayoutEffect(() => {
+    const prevVisibleItems = prevVisibleItemsRef.current;
+    const prevAllItems = prevAllItemsRef.current;
+    prevVisibleItemsRef.current = visibleRenderItems;
+    prevAllItemsRef.current = allRenderItems;
+    const snapshot = lastViewportTopRef.current;
+    const prevSeq = prevAllItems.length > 0 ? prevAllItems : prevVisibleItems;
+
+    const pending = pendingReanchorScrollRef.current;
+    if (pending) {
+      pendingReanchorScrollRef.current = null;
+      restoreViewportSnapshot(pending);
+      return;
+    }
+
+    const shrank = visibleRenderItems.length < prevVisibleItems.length;
+    const snapshotKeyGone =
+      snapshot !== null && !visibleRenderItems.some((it) => it.key === snapshot.viewportTopKey);
+    const snapshotMessageClientId = snapshot?.messageClientId;
+    const snapshotMessageGone =
+      snapshotMessageClientId !== undefined &&
+      !allRenderItems.some((item) => renderItemContainsClientId(item, snapshotMessageClientId));
+    if (!shrank && !snapshotKeyGone && !snapshotMessageGone) return;
+
+    const recoverableMessageClientId = snapshotMessageClientId;
+    const recoverableMessageExists =
+      recoverableMessageClientId !== undefined &&
+      allRenderItems.some((item) => renderItemContainsClientId(item, recoverableMessageClientId));
+
+    const recoveredIdx = snapshot
+      ? findRestorableViewportItemIdx(visibleRenderItems, snapshot.viewportTopKey)
+      : -1;
+    const recoveredKey = recoveredIdx >= 0 ? visibleRenderItems[recoveredIdx]?.key : undefined;
+    const windowAnchorLost =
+      firstVisibleItemKey !== null &&
+      findRestorableViewportItemIdx(allRenderItems, firstVisibleItemKey) < 0;
+    if (snapshot && recoveredKey && !snapshotMessageGone) {
+      if (recoveredKey !== snapshot.viewportTopKey) {
+        const rebased: ViewportTopSnapshot = {
+          ...snapshot,
+          viewportTopKey: recoveredKey,
+          offset: 0,
+          ...(recoverableMessageExists
+            ? {
+                messageClientId: recoverableMessageClientId,
+                messageOffset: snapshot.messageOffset ?? snapshot.offset,
+              }
+            : {}),
+        };
+        lastViewportTopRef.current = rebased;
+        if (!windowAnchorLost && !programmaticScrollRef.current && !isLoadingMore) {
+          restoreViewportSnapshot(rebased, 0);
+        }
+      }
+      if (!windowAnchorLost && !programmaticScrollRef.current && !isLoadingMore) return;
+    }
+
+    if (!sessionId) return;
+    if (programmaticScrollRef.current || isLoadingMore) {
+      prevVisibleItemsRef.current = prevVisibleItems;
+      prevAllItemsRef.current = prevAllItems;
+      if (programmaticScrollRef.current) deferredDeleteCompensationRef.current = true;
+      return;
+    }
+    if (isNearBottomRef.current) return;
+
+    let anchor = snapshot;
+    if (restoringRef.current) {
+      const snap = restoreSnapshotRef.current;
+      if (
+        !snap?.viewportTopKey ||
+        findRestorableViewportItemIdx(visibleRenderItems, snap.viewportTopKey) >= 0
+      ) {
+        return;
+      }
+      anchor = { viewportTopKey: snap.viewportTopKey, offset: snap.offset };
+      restoringRef.current = false;
+    }
+    if (!anchor) return;
+    const { viewportTopKey: anchorKey, offset: anchorOffset } = anchor;
+    const anchorItemStillVisible = visibleRenderItems.some((item) => item.key === anchorKey);
+    if (anchor.messageClientId && snapshotMessageGone && anchorItemStillVisible) {
+      const survivorMessageId = pickDeleteCompensationAnchorKey(
+        collectDeleteAnchorClientIds(prevSeq),
+        collectDeleteAnchorClientIds(allRenderItems),
+        anchor.messageClientId,
+      );
+      if (survivorMessageId) {
+        const survivorItemKey = renderItemKeyForClientId(allRenderItems, survivorMessageId);
+        const root = scrollRef.current;
+        const exact = root ? queryMessageElement(root, survivorMessageId) : null;
+        const fallback = root ? queryVisibleAggregateContainer(root, survivorMessageId) : null;
+        const landing = resolveDeleteCompensationLanding({
+          exactVisible: isVisibleDeleteCompensationElement(exact),
+          fallbackContainerVisible: isVisibleDeleteCompensationElement(fallback),
+        });
+        if (landing === 'exact') {
+          const itemOffset = survivorItemKey === anchorKey ? anchorOffset : 0;
+          restoreViewportSnapshotOrRebuildWindow(
+            {
+              viewportTopKey: survivorItemKey ?? anchorKey,
+              offset: itemOffset,
+              messageClientId: survivorMessageId,
+              messageOffset: 0,
+            },
+            itemOffset,
+          );
+          return;
+        }
+        if (landing === 'container' && root && fallback) {
+          // 折叠摘要行可见，隐藏 child 没有精确 DOM。滚摘要到视口顶，不要复用外层旧 offset。
+          const delta =
+            fallback.getBoundingClientRect().top - root.getBoundingClientRect().top;
+          if (Math.abs(delta) >= 1) {
+            const generation = beginProgrammaticScroll();
+            root.scrollTop += delta;
+            requestAnimationFrame(() => finishProgrammaticScroll(generation));
+          }
+          lastViewportTopRef.current = toRenderItemViewportSnapshot({
+            viewportTopKey: survivorItemKey ?? anchorKey,
+            offset: 0,
+          });
+          refreshViewportAnchor();
+          return;
+        }
+        restoreViewportSnapshotOrRebuildWindow(
+          { viewportTopKey: survivorItemKey ?? anchorKey, offset: 0 },
+          0,
+        );
+        return;
+      }
+    }
+    if (anchorItemStillVisible) return;
+
+    if (windowAnchorLost) {
+      const aliveIdx = findRestorableViewportItemIdx(allRenderItems, anchorKey);
+      let targetKey: string | null;
+      let targetOffset = 0;
+      if (aliveIdx >= 0) {
+        targetKey = allRenderItems[aliveIdx]?.key ?? null;
+        if (targetKey === anchorKey) targetOffset = anchorOffset;
+      } else {
+        targetKey = pickDeleteCompensationAnchorKey(
+          prevSeq.map((it) => it.key),
+          allRenderItems.map((it) => it.key),
+          anchorKey,
+        );
+      }
+      if (!targetKey) return;
+      const targetSnapshot: ViewportTopSnapshot = snapshotMessageGone
+        ? { viewportTopKey: targetKey, offset: targetOffset }
+        : {
+            ...anchor,
+            viewportTopKey: targetKey,
+            offset: targetOffset,
+            ...(recoverableMessageExists
+              ? {
+                  messageClientId: recoverableMessageClientId,
+                  messageOffset: anchor.messageOffset ?? anchor.offset,
+                }
+              : {}),
+          };
+      lastViewportTopRef.current = targetSnapshot;
+      pendingReanchorScrollRef.current = targetSnapshot;
+      setFirstVisibleItemKey(targetKey);
+      return;
+    }
+
+    const survivorKey = pickDeleteCompensationAnchorKey(
+      prevVisibleItems.map((it) => it.key),
+      visibleRenderItems.map((it) => it.key),
+      anchorKey,
+    );
+    if (!survivorKey) return;
+    restoreViewportSnapshot({ viewportTopKey: survivorKey, offset: 0 });
+  }, [
+    visibleRenderItems,
+    allRenderItems,
+    firstVisibleItemKey,
+    sessionId,
+    isLoadingMore,
+    deleteCompensationReplay,
+    restoreViewportSnapshot,
+    restoreViewportSnapshotOrRebuildWindow,
+    beginProgrammaticScroll,
+    finishProgrammaticScroll,
+    refreshViewportAnchor,
+  ]);
 
   // ── post-load auto-expand ──
   // 修一类已知 UX 缺口 (跟 render-window 轴换轴无关,老代码同病):
@@ -3833,8 +4754,8 @@ export function MessageStream({
     if (!programmaticScrollRef.current) {
       // 用户手动滚动 = 接管浏览,退出「还原中」,后续恢复正常 auto-follow 判定。
       restoringRef.current = false;
-      // 持续保存当前浏览位置(rAF 节流,DOM 必然存活)。不依赖 unmount 时机,
-      // 规避「React passive cleanup 在 DOM 移除后才跑、量测拿到 null」的坑。
+      // 持续保存浏览位置（rAF 节流，DOM 必然存活），内含删除前快照刷新——纯滚动后
+      // 快照停在陈旧 key 会让删除补偿失配。
       if (saveRafRef.current === null) {
         saveRafRef.current = requestAnimationFrame(() => {
           saveRafRef.current = null;
@@ -3915,9 +4836,16 @@ export function MessageStream({
     // F3: smooth 滚动完成后清除 programmaticScrollRef，让后续用户滚动能被正确识别。
     //   - 判据：距底 < 5px（smooth 动画收敛后的稳定值）+ 当前处于 programmatic 态
     //   - 用 rAF 推迟一帧，避免连续 smooth 滚动的尾帧事件被误判
-    if (programmaticScrollRef.current && distanceFromBottom < 5) {
+    // 同帧刷新删除前快照：程序化贴底后视口顶端已变，陈旧 key 会让删除补偿早退。
+    if (
+      programmaticScrollRef.current &&
+      focusJumpRef.current === null &&
+      chipJumpGenerationRef.current === null &&
+      distanceFromBottom < 5
+    ) {
+      const generation = programmaticScrollGenerationRef.current;
       requestAnimationFrame(() => {
-        programmaticScrollRef.current = false;
+        if (finishProgrammaticScroll(generation) === false) refreshViewportAnchor();
       });
     }
 
@@ -3956,6 +4884,8 @@ export function MessageStream({
     windowAtTop,
     expandWindow,
     saveScrollSnapshot,
+    refreshViewportAnchor,
+    finishProgrammaticScroll,
     windowCoversEnd,
     anchoredForwardItems,
     visibleStartIdx,
@@ -4009,22 +4939,22 @@ export function MessageStream({
       `[data-user-msg-id="${CSS.escape(prevUserMsgId)}"]`,
     ) as HTMLElement | null;
     if (!el) return;
+    // portal 不在 scroll root 内，mousedown 接管监听收不到；必须在新 smooth 开始前
+    // 显式废弃旧 focus，避免其 scrollend 把视口拉回搜索结果。
+    cancelFocusJump({ consumeDeferredDelete: true });
     suppressAfterClick();
     // expand/load 抑制:smooth scroll 期间路径如果穿过 scrollTop<50,handleScroll
     // 会触发 expandWindow/onLoadMore + F-SYNC-2 scrollTop+=delta,这条 race 可能
     // 把 viewport 拽飞。设 ref 让 handleScroll 跳过那分支。解抑靠 wheel/touch/
     // keydown(在上面 useEffect 里挂的监听),用户一动手就过去,不会卡"用 chip
     // 连点上翻"或"跳完立刻 wheel 看更老历史"。
-    chipJumpInProgressRef.current = true;
-    if (chipJumpClearTimerRef.current !== null) {
-      window.clearTimeout(chipJumpClearTimerRef.current);
-    }
-    chipJumpClearTimerRef.current = window.setTimeout(() => {
-      chipJumpClearTimerRef.current = null;
-      clearChipJumpSuppression();
-    }, CHIP_JUMP_SAFETY_MS);
+    beginChipJump({
+      clientId: prevUserMsgId,
+      selector: 'user-message',
+      topOffset: 0,
+    });
     el.scrollIntoView({ behavior: 'smooth', block: 'start' });
-  }, [prevUserMsgId, suppressAfterClick, clearChipJumpSuppression]);
+  }, [prevUserMsgId, suppressAfterClick, beginChipJump, cancelFocusJump]);
 
   const prevPreview = prevUserMsgId ? firstNonEmptyLine(previewById.get(prevUserMsgId) ?? '') : '';
 
@@ -4108,9 +5038,13 @@ export function MessageStream({
   const [railJumpRequest, setRailJumpRequest] = useState<{ id: string; seq: number } | null>(null);
   const lastAppliedRailJumpRef = useRef(0);
   const handleNavRailJump = useCallback((clientId: string) => {
+    // 先废弃旧搜索 focus；目标即使需要下一轮扩窗，旧 scrollend/timer 也不能抢回视口。
+    // 导航条目标要到 layout effect 才能确认仍存在且 DOM 已就绪，因此这里不能提前消费
+    // focus 期间延期的删除补偿：先重放补偿，目标有效时后续导航再覆盖最终落点。
+    cancelFocusJump();
     railJumpSeqRef.current += 1;
     setRailJumpRequest({ id: clientId, seq: railJumpSeqRef.current });
-  }, []);
+  }, [cancelFocusJump]);
 
   useLayoutEffect(() => {
     if (!railJumpRequest) return;
@@ -4142,14 +5076,11 @@ export function MessageStream({
     setIsNearBottom(false);
     // smooth scroll 途经顶部区域时抑制 expandWindow/onLoadMore(chip-jump 协议,
     // 解抑靠用户 wheel/touch/keydown + 安全兜底 timer)。
-    chipJumpInProgressRef.current = true;
-    if (chipJumpClearTimerRef.current !== null) {
-      window.clearTimeout(chipJumpClearTimerRef.current);
-    }
-    chipJumpClearTimerRef.current = window.setTimeout(() => {
-      chipJumpClearTimerRef.current = null;
-      clearChipJumpSuppression();
-    }, CHIP_JUMP_SAFETY_MS);
+    beginChipJump({
+      clientId: railJumpRequest.id,
+      selector: 'message',
+      topOffset: NAV_RAIL_JUMP_TOP_OFFSET_PX,
+    });
     // 落点手动计算,不走 scrollIntoView:轮次跳转要让视口恰好框住
     // "提问 → 回答",提问顶边停在容器顶下方 12px;消息锚点通用的
     // scroll-mt-20(80px)是搜索跳转的上文语境预留,对本任务是漏出
@@ -4159,7 +5090,7 @@ export function MessageStream({
       (el.getBoundingClientRect().top - root.getBoundingClientRect().top) -
       NAV_RAIL_JUMP_TOP_OFFSET_PX;
     root.scrollTo({ top: Math.max(0, targetTop), behavior: 'smooth' });
-  }, [railJumpRequest, allRenderItems, visibleRenderItems, clearChipJumpSuppression]);
+  }, [railJumpRequest, allRenderItems, visibleRenderItems, beginChipJump]);
 
   // 第一条 user 消息没有"上一条 assistant"作为 resumeSessionAt 锚点，
   // rewind 必然抛 NO_PRIOR_ASSISTANT。直接在 UI 层把按钮藏掉，避免无效点击。
@@ -4270,6 +5201,8 @@ export function MessageStream({
               data-scroll-container=""
               className="h-full w-full overflow-y-auto overflow-x-hidden [scrollbar-gutter:stable]"
               onScroll={handleScroll}
+              onPointerDownCapture={() => refreshViewportAnchor()}
+              onKeyDownCapture={() => refreshViewportAnchor()}
             >
               <div
                 ref={contentRef}
@@ -4424,6 +5357,7 @@ export function MessageStream({
                         // data-message-client-ids:组折叠时子卡片/聚合块整体 unmount,
                         // 精确锚点消失 —— 后台任务面板「点行跳聊天」经 ~= 回退查询
                         // 落到组容器(与 AgentActionsBlock 的容器锚点同一约定)。
+                        // 视口子锚点不读这个聚合列表，只认已渲染的 data-message-client-id。
                         <div
                           key={item.key}
                           className="scroll-mt-20"

--- a/apps/desktop/src/renderer/components/chat/WorkGroupBlock.tsx
+++ b/apps/desktop/src/renderer/components/chat/WorkGroupBlock.tsx
@@ -158,6 +158,7 @@ function ThinkingActivityRow({
     <button
       type="button"
       data-live-work-activity="thinking"
+      data-message-client-id={activity.key}
       data-work-thinking-expandable={canExpand ? 'true' : 'false'}
       disabled={!canExpand}
       aria-expanded={canExpand ? expanded : undefined}
@@ -235,11 +236,13 @@ function ExpandedThinkingRow({ message }: { message: ChatMessage }) {
   if (!activity) {
     if (!message.thinkingRedacted) return null;
     return (
-      <ThinkingCard
-        blockKey={message.clientId}
-        content={message.content}
-        isRedacted
-      />
+      <div data-message-client-id={message.clientId}>
+        <ThinkingCard
+          blockKey={message.clientId}
+          content={message.content}
+          isRedacted
+        />
+      </div>
     );
   }
 
@@ -247,6 +250,7 @@ function ExpandedThinkingRow({ message }: { message: ChatMessage }) {
     <button
       type="button"
       data-live-work-activity="thinking"
+      data-message-client-id={message.clientId}
       data-work-thinking-expandable={canExpand ? 'true' : 'false'}
       onClick={onToggle}
       disabled={!canExpand}

--- a/apps/desktop/src/renderer/components/chat/useNavigationKeyListener.ts
+++ b/apps/desktop/src/renderer/components/chat/useNavigationKeyListener.ts
@@ -11,12 +11,15 @@
  * 抽出来的原因:之前 MessageStream(chip-jump suppression 解抑)和
  * usePrevUserMessageInView(suppress 解除)各自挂一份相同 key 列表的 listener。
  * 重复不算 bug,但两处 key 集合若漂移会很微妙(比如有人给一边加了 Space
- * 忘了另一边)。统一用同一份 NAVIGATION_KEYS 是单一信息源。
+ * 忘了另一边)。统一用同一份 NAVIGATION_KEYS 是单一信息源；MessageStream 的
+ * isScrollNavigationKey 直接读这里。
  */
 
 import { useEffect, useRef } from 'react';
 
-/** 翻页/方向类按键集合 — 视为"用户主动想看历史"的信号。
+import { isEditableKeyboardTarget } from '@/lib/editableKeyboardTarget';
+
+/** 翻页/方向/空格滚动键 — 视为用户接管程序化滚动。
  *  普通文字键(字母数字、Tab、Enter 等)不在内,避免输入框打字被误当成滚动意图。 */
 export const NAVIGATION_KEYS: ReadonlySet<string> = new Set([
   'PageUp',
@@ -25,7 +28,14 @@ export const NAVIGATION_KEYS: ReadonlySet<string> = new Set([
   'ArrowDown',
   'Home',
   'End',
+  ' ',
 ]);
+
+export function shouldHandleNavigationKey(key: string, target: EventTarget | null): boolean {
+  if (!NAVIGATION_KEYS.has(key)) return false;
+  if (key === ' ' && target != null && isEditableKeyboardTarget(target)) return false;
+  return true;
+}
 
 /**
  * 监听 window keydown,任一 NAVIGATION_KEYS 触发时调用 onNavKey。
@@ -37,7 +47,7 @@ export function useNavigationKeyListener(onNavKey: () => void): void {
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
-      if (NAVIGATION_KEYS.has(e.key)) {
+      if (shouldHandleNavigationKey(e.key, e.target)) {
         cbRef.current();
       }
     };


### PR DESCRIPTION
## 这次改了什么

### 摘要

删除会话中靠前的 message 后，聊天视口可能跳到错误位置。删除路径只更新 store，原有补偿在数组收缩时不会介入；Chromium 的 `overflow-anchor` 又会在锚点元素本身被删时失效。

本 PR 将删除、分组和程序化滚动的锚点处理收敛到 `MessageStream`：

- 记录删除前的视口锚点；锚点被删时按旧序列选择相邻存活内容。
- 顶层 message 被删时按完整 render-item 序列选邻居，不跳过紧随的 work group、工具或媒体内容。
- 展开 work group 内的子 message 删除按完整 clientId 序列（含 tool / task / 嵌套组）选邻居，不再跳过中间的工具行；DOM 查询取最内层 `data-message-client-ids`。
- 视口子锚点与视口复位只认已渲染的 `data-message-client-id`；折叠工作组 / 折叠工具块的聚合 `data-message-client-ids` 只给 focus 回退。
- 展开后再折叠工作组会卸掉精确 child DOM；数据仍在时重新量测视口锚点。折叠组再展开、视口顶 item 出现可见精确 child 时同样重测，避免隐藏或新露出的 child 被删时误走或漏掉补偿。
- 流式完成后分组 key 恢复不得打断进行中的 search / chip / 导航轨道平滑滚动，改走延期补偿。
- 展开工作组内的 thinking 行（含 redacted 与 live preview）同样挂 `data-message-client-id` 子锚点。
- render window 锚点被连带删除时，从上一帧全量序列重建窗口，待 DOM 就绪后复位。
- focus / chip / 导航轨道的程序化滚动使用 generation token；用户接管（含空格与滚动条拖拽，输入框内空格除外）会重放延期删除补偿。
- 跳底 smooth 保存 generation，在 scrollend、用户接管或安全超时后收尾，避免删除补偿被卡住。
- 用户接管跳底 / chip / focus 平滑滚动时一律解除乐观贴底（不只在已有延期删除时），再停止原生 smooth，避免流式 `pinToBottom` 或删除重放把视口拽回。
- 删除补偿若下一条是折叠容器里的隐藏 child，落到可见摘要行，不复用外层组的旧 offset。
- 会话还原落定后量测子锚点，切回已展开工作组内部时也能补偿跨视口顶的 child 删除。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue：Closes #2289
- 变更文件：`MessageStream.tsx`、`AgentActionRow.tsx`、`AgentActionsBlock.tsx`、`WorkGroupBlock.tsx`、`useNavigationKeyListener.ts` 与对应 key / anchor / focus / work-group 回归测试。
- 不包含：删除 store 路径、数据库、协议、mount restore 状态机。
- 用户可见变化：删除靠前 message 后保留原阅读位置；删除当前锚点或 focus 目标时落到相邻内容（含中间工具行与 thinking 行）；新导航不再被旧 focus 拉回。
- Breaking change：无

### UI 变化

不涉及视觉、文案、颜色或布局规范变更；仅修正既有聊天列表的滚动位置与导航接管语义。

- 引用的设计规范：`docs/design-rules/DESIGN.md` §14 Interaction Conventions；保持用户直接控制，用户滚轮、触摸、空格、滚动条或键盘接管后不再被旧程序化滚动拉回。

## 怎么验证的

### 本地定向验证

```text
pnpm exec eslint src/renderer/components/chat/MessageStream.tsx \
  src/renderer/__tests__/focusScrollLifecycle.test.ts
结果：通过

pnpm exec vitest run src/renderer/__tests__/focusScrollLifecycle.test.ts
结果：1 file / 30 tests passed
```

全量与 typecheck 交 CI。

### CI 验证

- 当前 head `94c13bf50`：push 后由 fork / 主仓 client-ci 执行，终态以该 SHA 的 run 为准。
- DCO：commit 带匹配 author 的 `Signed-off-by`。

### 未在本地执行

- `pnpm test:unit` 全量：按维护者指示考虑本地机器负载，不在本机运行；交 `client-ci` 完整执行。
- desktop typecheck：交同一 `client-ci` 的 `verify-checks`。
- Desktop 长会话人工交互：未执行；不把静态检查或单测等同于实机目检。

## 风险

- 影响范围：Desktop 聊天消息列表的删除补偿、focus 跳转落定及程序化滚动收尾。
- 回滚：revert 本 commit 即恢复旧行为；不涉及用户数据或持久化格式。
- 当前未知：当前 head 的 CI 与 Desktop 长会话人工交互结果。

### 提交前检查

- [x] 已 review 完整 diff
- [x] PR 已合并为单一 commit
- [x] commit 带匹配 author 的 DCO `Signed-off-by`
- [x] UI 路径改动已注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已说明本地已验证与未验证边界