### PR TITLE
fix(desktop): drop search tools for Chat bridge

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
@@ -2489,6 +2489,61 @@ describe('codex proxy host', () => {
     setCustomProviders([]);
   });
 
+  it('resets a removed search tool choice for Gemini Chat bridge turns', async () => {
+    const host = await freshCodexProxyHost();
+    const { buildUserProvider } = await import('@cindy/model-providers');
+    const { setCustomProviders } = await import('../active-catalog.js');
+    const { setCustomProviderKeyReader } = await import('../provider-route.js');
+    const { setSessionProvider, clearSessionProvider } = await import('../session-provider-store.js');
+    setCustomProviders([
+      buildUserProvider({
+        id: 'gemini-chat-provider',
+        name: 'Gemini Chat Provider',
+        runtimes: {
+          codex: {
+            baseUrl: 'https://generativelanguage.googleapis.com/v1beta/openai',
+            wireProtocol: 'openai-chat',
+            models: [{ id: 'gemini-2.5-pro', name: 'Gemini 2.5 Pro' }],
+          },
+        },
+      }),
+    ]);
+    setCustomProviderKeyReader(() => 'gemini-chat-key');
+    host.registerComposed('session-gemini-chat', 'thread-gemini-chat', 'PRODUCT_PROMPT');
+    setSessionProvider('session-gemini-chat', 'gemini-chat-provider');
+
+    const parsedBody = {
+      model: 'gemini-2.5-pro',
+      tools: [{ type: 'function', name: 'shell' }, { type: 'web_search' }],
+      tool_choice: { type: 'web_search' },
+      parallel_tool_calls: true,
+      input: [{ role: 'user', content: 'hello' }],
+    };
+    const ctx = { reqId: 1, method: 'POST', url: '/responses', headers: { 'thread-id': 'thread-gemini-chat' } };
+    const decision = await Promise.resolve(host.createModelRoutingTransform()(parsedBody, ctx));
+    expect(decision).toEqual(expect.objectContaining({ localHandler: expect.any(Function) }));
+    if (!decision?.localHandler) throw new Error('expected Gemini Chat bridge local handler');
+
+    const res = {} as never;
+    await decision.localHandler({ rawBody: Buffer.from(JSON.stringify(parsedBody)), parsedBody, ctx, res });
+    const bridge = mockState.createResponsesChatHandler.mock.results.at(-1)?.value as
+      | { handle: ReturnType<typeof vi.fn> }
+      | undefined;
+    expect(bridge?.handle).toHaveBeenCalledWith({
+      parsedBody: {
+        ...parsedBody,
+        instructions: 'PRODUCT_PROMPT',
+        tools: [{ type: 'function', name: 'shell' }],
+        tool_choice: 'auto',
+      },
+      res,
+    });
+
+    clearSessionProvider('session-gemini-chat');
+    setCustomProviderKeyReader(() => null);
+    setCustomProviders([]);
+  });
+
   it('passes the parent session model into a Guardian request handled by the Anthropic bridge', async () => {
     const host = await freshCodexProxyHost();
     const { buildUserProvider } = await import('@cindy/model-providers');

--- a/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
@@ -2437,6 +2437,58 @@ describe('codex proxy host', () => {
     setCustomProviders([]);
   });
 
+  it('drops Responses-native search tools before forwarding an ordinary Chat bridge turn', async () => {
+    const host = await freshCodexProxyHost();
+    const { buildUserProvider } = await import('@cindy/model-providers');
+    const { setCustomProviders } = await import('../active-catalog.js');
+    const { setCustomProviderKeyReader } = await import('../provider-route.js');
+    const { setSessionProvider, clearSessionProvider } = await import('../session-provider-store.js');
+    setCustomProviders([
+      buildUserProvider({
+        id: 'qwen-chat-provider',
+        name: 'Qwen Chat Provider',
+        runtimes: {
+          codex: {
+            baseUrl: 'https://chat-provider.example/v1',
+            wireProtocol: 'openai-chat',
+            models: [{ id: 'qwen3.8-max', name: 'Qwen 3.8 Max' }],
+          },
+        },
+      }),
+    ]);
+    setCustomProviderKeyReader(() => 'chat-provider-key');
+    host.registerComposed('session-qwen-chat', 'thread-qwen-chat', 'PRODUCT_PROMPT');
+    setSessionProvider('session-qwen-chat', 'qwen-chat-provider');
+
+    const parsedBody = {
+      model: 'qwen3.8-max',
+      tools: [{ type: 'function', name: 'shell' }, { type: 'web_search' }],
+      input: [{ role: 'user', content: 'hello' }],
+    };
+    const ctx = { reqId: 1, method: 'POST', url: '/responses', headers: { 'thread-id': 'thread-qwen-chat' } };
+    const decision = await Promise.resolve(host.createModelRoutingTransform()(parsedBody, ctx));
+    expect(decision).toEqual(expect.objectContaining({ localHandler: expect.any(Function) }));
+    if (!decision?.localHandler) throw new Error('expected Chat bridge local handler');
+
+    const res = {} as never;
+    await decision.localHandler({ rawBody: Buffer.from(JSON.stringify(parsedBody)), parsedBody, ctx, res });
+    const bridge = mockState.createResponsesChatHandler.mock.results.at(-1)?.value as
+      | { handle: ReturnType<typeof vi.fn> }
+      | undefined;
+    expect(bridge?.handle).toHaveBeenCalledWith({
+      parsedBody: {
+        ...parsedBody,
+        instructions: 'PRODUCT_PROMPT',
+        tools: [{ type: 'function', name: 'shell' }],
+      },
+      res,
+    });
+
+    clearSessionProvider('session-qwen-chat');
+    setCustomProviderKeyReader(() => null);
+    setCustomProviders([]);
+  });
+
   it('passes the parent session model into a Guardian request handled by the Anthropic bridge', async () => {
     const host = await freshCodexProxyHost();
     const { buildUserProvider } = await import('@cindy/model-providers');

--- a/apps/desktop/src/main/maker-host/codex-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/codex-proxy-host.ts
@@ -383,6 +383,15 @@ function providerAwareGuardianReviewerModel(
 
 const GUARDIAN_PROVIDER_SEARCH_TOOL_TYPES = new Set(['web_search', 'x_search']);
 
+function providerSearchToolChoiceReferencesRemovedTool(
+  toolChoice: unknown,
+  tools: readonly unknown[],
+): boolean {
+  if (!isPlainObject(toolChoice) || typeof toolChoice.type !== 'string') return false;
+  if (!GUARDIAN_PROVIDER_SEARCH_TOOL_TYPES.has(toolChoice.type)) return false;
+  return !tools.some((tool) => isPlainObject(tool) && tool.type === toolChoice.type);
+}
+
 /**
  * Guardian decides whether another action may run. Provider-hosted search
  * tools must not let that reviewer initiate an unrelated upstream network
@@ -401,8 +410,16 @@ function stripProviderSearchTools(
   if (tools.length === body.tools.length) return body;
 
   const next = { ...body };
-  if (tools.length > 0) next.tools = tools;
-  else delete next.tools;
+  if (tools.length > 0) {
+    next.tools = tools;
+    if (providerSearchToolChoiceReferencesRemovedTool(next.tool_choice, tools)) {
+      next.tool_choice = 'auto';
+    }
+  } else {
+    delete next.tools;
+    delete next.tool_choice;
+    delete next.parallel_tool_calls;
+  }
   return next;
 }
 

--- a/apps/desktop/src/main/maker-host/codex-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/codex-proxy-host.ts
@@ -388,7 +388,7 @@ const GUARDIAN_PROVIDER_SEARCH_TOOL_TYPES = new Set(['web_search', 'x_search']);
  * tools must not let that reviewer initiate an unrelated upstream network
  * action with the approval context.
  */
-function stripGuardianProviderSearchTools(
+function stripProviderSearchTools(
   body: Record<string, unknown>,
 ): Record<string, unknown> {
   if (!Array.isArray(body.tools)) return body;
@@ -427,7 +427,7 @@ function createProviderAwareGuardianReviewerTransform(
       toModel: mainModel,
       providerId: getSessionProvider(sessionId),
     });
-    return stripGuardianProviderSearchTools({ ...body, model: mainModel });
+    return stripProviderSearchTools({ ...body, model: mainModel });
   };
 }
 
@@ -700,10 +700,13 @@ function prepareLocalBridgeBody(opts: PrepareLocalBridgeBodyOptions): unknown {
       // Keep the already parsed body if the defensive strip result cannot be parsed.
     }
   }
-  if (opts.requestModelOverride && isPlainObject(body)) {
-    body = stripGuardianProviderSearchTools({
+  // Chat Completions has no Responses-native search tool. Codex can attach it
+  // automatically even for an ordinary turn, so remove it before translating
+  // a provider-routed chat request instead of failing the entire request.
+  if (isPlainObject(body) && (opts.requestModelOverride || opts.bridge === 'chat')) {
+    body = stripProviderSearchTools({
       ...body,
-      model: opts.requestModelOverride,
+      ...(opts.requestModelOverride ? { model: opts.requestModelOverride } : {}),
     });
   }
   if (opts.instructions && isPlainObject(body)) {


### PR DESCRIPTION
## 这次改了什么

### 摘要

将 `stripGuardianProviderSearchTools` 重命名为更通用的 `stripProviderSearchTools`，并在 `prepareLocalBridgeBody` 中把清理范围从「仅 Guardian 的 `requestModelOverride`」扩展到「任何 Chat Completions 桥接（`bridge === 'chat'`）」。Chat Completions 协议没有 Responses 原生的 `web_search` / `x_search` 工具，而 Codex 会自动附带，转发到 chat provider 会导致整请求失败；现在在翻译前剥离这些 Responses-native search tool。

删除搜索工具声明时，如果 `tool_choice` 仍明确引用已删除的搜索工具，会将其重置为 `auto`；如果工具列表被清空，则同时移除 `tool_choice` 和 `parallel_tool_calls`，避免下游再次收到自相矛盾的请求。

### 变更类型

- [ ] feat 新功能
- [x] fix 缺陷修复
- [ ] refactor / perf 重构或性能优化
- [ ] docs / test / chore 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：普通 Chat bridge 的 Responses-native search tool 清理；清理已删除搜索工具对应的 `tool_choice`；工具清空时清理 `tool_choice` / `parallel_tool_calls`；新增混合 function + search tool choice 回归测试。
- 明确不包含：Anthropic bridge 路径。
- 用户可见变化：使用 Chat Completions 桥接的普通 provider 路由不再因附带 web search 或失效 tool choice 而整请求 400。
- 是否存在 breaking change：无

### UI 变化

不涉及：仅改主进程桥接翻译逻辑，无 renderer / 视觉 / 交互 / 文案变化。

## 怎么验证的

### 自动验证

- `pnpm --filter desktop exec vitest run src/main/maker-host/__tests__/codexProxyHost.test.ts` — 143/143 passed
- `pnpm --filter desktop run --if-present typecheck` — passed
- `pnpm test:unit` — passed
- `pnpm check:dco` — passed

### 手工验证

不涉及：桥接翻译行为由单测覆盖。

### 未执行的验证

无。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：只剥离 `web_search` / `x_search` 这类 Responses-native search tool 类型，并同步规范化失效工具选择字段；不影响 function tool，不影响 Anthropic bridge 路径。
- 回滚 / 降级方式：恢复清理条件为仅 `opts.requestModelOverride` 并还原 `tool_choice` 清理逻辑。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] UI 改动已在「UI 变化」注明（不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因