### PR TITLE
fix(desktop): preserve deferred sidebar commands

### DIFF
--- a/apps/desktop/src/main/right-sidebar-window/__tests__/controller.test.ts
+++ b/apps/desktop/src/main/right-sidebar-window/__tests__/controller.test.ts
@@ -607,6 +607,23 @@ describe('setContext / routeCommand', () => {
     expect(h.sendTargets.at(-1)).toBe(h.mainWin.webContents.id);
   });
 
+  it('flushes every queued passive command for the current session in order', async () => {
+    const h = makeHarness({ detached: true });
+    h.controller.setContext(ctx);
+    const first = { type: 'ensure-orca-workers-tab' as const, sessionId: 's1', focusTab: false };
+    const second = { type: 'close-orca-workers-tab' as const, sessionId: 's1' };
+    await h.controller.routeCommand({ command: first, allowOpen: false });
+    await h.controller.routeCommand({ command: second, allowOpen: false });
+
+    h.controller.open();
+    h.controller.markReady();
+
+    expect(h.sends.filter((entry) => entry.channel === 'cmd-channel')).toEqual([
+      { channel: 'cmd-channel', payload: first },
+      { channel: 'cmd-channel', payload: second },
+    ]);
+  });
+
   it('passive ensure 不覆盖已排队的显式 worker intent', async () => {
     const h = makeHarness({ detached: true });
     h.controller.setContext(ctx);

--- a/apps/desktop/src/main/right-sidebar-window/controller.ts
+++ b/apps/desktop/src/main/right-sidebar-window/controller.ts
@@ -60,6 +60,7 @@ export interface RsbWindowControllerDeps {
 /** ensureOpenForAutomation 等 renderer ready 握手的超时。 */
 const READY_TIMEOUT_MS = 8000;
 const MAX_DEFERRED_SESSIONS = 8;
+const MAX_DEFERRED_COMMANDS_PER_SESSION = 8;
 
 /**
  * command 的宿主桶 session —— 裁决可见性与 deferred 排队都以它为准。
@@ -82,8 +83,8 @@ export class RsbWindowController {
     timeout: NodeJS.Timeout;
   }> = [];
   private lastContext: RsbWindowContext | null = null;
-  /** allowOpen=false 时每个 session 只保留最终有效命令，避免 remote memory intent 丢失。 */
-  private deferredCommands = new Map<string, RsbWindowCommand>();
+  /** allowOpen=false 时按宿主 session 保留有界、有序的 deferred 命令。 */
+  private deferredCommands = new Map<string, RsbWindowCommand[]>();
   private closeWaiters: Array<() => void> = [];
 
   constructor(private readonly deps: RsbWindowControllerDeps) {}
@@ -283,10 +284,10 @@ export class RsbWindowController {
     // 按宿主桶排队:跨会话 open-turn-review 属于 lead 的桶,须由 lead 上下文
     // flush;按 worker sessionId 入队会在 context 保持 lead 时永远刷不出来。
     const hostSessionId = commandHostSessionId(command);
-    const previous = this.deferredCommands.get(hostSessionId);
+    const queued = this.deferredCommands.get(hostSessionId);
     if (
       command.type === 'ensure-orca-workers-tab' &&
-      previous?.type === 'ensure-orca-workers-tab' &&
+      queued?.some((previous) => previous.type === 'ensure-orca-workers-tab') &&
       command.focusWorkerSessionId === undefined &&
       command.searchJump === undefined
     ) {
@@ -299,7 +300,10 @@ export class RsbWindowController {
       const oldest = this.deferredCommands.keys().next().value as string | undefined;
       if (oldest) this.deferredCommands.delete(oldest);
     }
-    this.deferredCommands.set(hostSessionId, command);
+    const next = queued ?? [];
+    if (next.length >= MAX_DEFERRED_COMMANDS_PER_SESSION) next.shift();
+    next.push(command);
+    this.deferredCommands.set(hostSessionId, next);
   }
 
   private flushDeferredCommandsToDetachedHost(): void {
@@ -314,22 +318,26 @@ export class RsbWindowController {
     }
     const sessionId = this.lastContext?.available ? this.lastContext.sessionId : null;
     if (!sessionId) return;
-    const command = this.deferredCommands.get(sessionId);
-    if (!command) return;
+    const commands = this.deferredCommands.get(sessionId);
+    if (!commands) return;
     this.deferredCommands.delete(sessionId);
-    this.deps.sendToWindow(this.winRef, this.deps.commandChannel, command);
+    for (const command of commands) {
+      this.deps.sendToWindow(this.winRef, this.deps.commandChannel, command);
+    }
   }
 
   private flushDeferredCommandsToAttachedHost(): void {
     if (this.deps.settings.read().detached) return;
     const sessionId = this.lastContext?.available ? this.lastContext.sessionId : null;
     if (!sessionId) return;
-    const command = this.deferredCommands.get(sessionId);
-    if (!command) return;
+    const commands = this.deferredCommands.get(sessionId);
+    if (!commands) return;
     const main = this.deps.getMainWindow();
     if (!main || main.isDestroyed()) return;
     this.deferredCommands.delete(sessionId);
-    this.deps.sendToWindow(main, this.deps.commandChannel, command);
+    for (const command of commands) {
+      this.deps.sendToWindow(main, this.deps.commandChannel, command);
+    }
   }
 
   private waitUntilClosed(): Promise<void> {


### PR DESCRIPTION
Fixes #2409.

## 这次改了什么

### 摘要

右侧栏窗口在 detached/不可用期间，每个宿主 session 的 passive 命令从「单条覆盖（后到的覆盖先到的）」改为「有界、有序的队列（每 session 上限 8 条）」。这样 `ensure -> close -> ensure` 这样的序列不再丢失最终的 ensure。原有的 `ensure-orca-workers-tab` 去重逻辑保留。窗口 reopen/attached 时按入队顺序逐条下发到宿主。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#2409
- 本 PR 包含：`RsbWindowController.deferredCommands` 由 `Map<string, RsbWindowCommand>` 改为 `Map<string, RsbWindowCommand[]>`；入队按宿主 session 有界排队（`MAX_DEFERRED_COMMANDS_PER_SESSION = 8`，超出丢最旧）；detached/attached 两条 flush 路径改为按序逐条下发；新增单测覆盖 `ensure -> close -> ensure` 序列。
- 明确不包含：右侧栏窗口的其他生命周期、可见性、去重语义调整。
- 用户可见变化：无（detached 期间命令投递的内部可靠性提升）。
- 是否存在 breaking change：无

### UI 变化

不涉及：仅改主进程命令排队逻辑，无 renderer / 视觉 / 交互 / 文案变化。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/right-sidebar-window/__tests__/controller.test.ts
pnpm --filter desktop run --if-present typecheck
结果：PR 作者本地已通过；本次触发重审后以 CI 为准。
```

### 手工验证

不涉及：无 UI 可手工操作路径，行为由单测覆盖。

### 未执行的验证

本次未本地复跑单测与 typecheck，依赖 CI 重跑确认。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 detached/不可用期间按宿主 session 的命令排队路径；已 open 的窗口不受影响。每 session 队列上限 8，叠加 `MAX_DEFERRED_SESSIONS = 8`，内存有界。去重仅对无 `focusWorkerSessionId` / `searchJump` 的 `ensure-orca-workers-tab` 生效，语义与之前一致。
- 回滚 / 降级方式：revert 本 PR，`deferredCommands` 回到单条覆盖语义。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] UI 改动已在「UI 变化」注明（不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
