### PR TITLE
fix(desktop): 自动补救 PID 复用导致的迁移阻塞

### DIFF
--- a/apps/desktop/src/main/__tests__/ownerNamespaceMigration.test.ts
+++ b/apps/desktop/src/main/__tests__/ownerNamespaceMigration.test.ts
@@ -221,6 +221,42 @@ describe('claimLegacyOwnerNamespace', () => {
     expect(hasExclusiveSharedLegacyUserDataAccess(root, (pid) => pid === 4242)).toBe(true);
   });
 
+  it('warms stale-pid provenance for local startup before synchronous guards inspect it', async () => {
+    const root = await tempRoot();
+    const startedAtMs = 1_000_000;
+    await writeDevInstanceRecord(root, 4242, root, { startedAtMs });
+
+    await __testing.warmStaleProcessProvenance(
+      root,
+      realFsDeps(root, {
+        isPidAlive: (pid) => pid === 4242,
+        readProcessIdentity: () => ({
+          startedAtMs: startedAtMs + 120_000,
+          command: '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+        }),
+      }),
+    );
+
+    expect(hasExclusiveSharedLegacyUserDataAccess(root, (pid) => pid === 4242)).toBe(true);
+  });
+
+  it('keeps local startup fail-closed when provenance warmup cannot read identity', async () => {
+    const root = await tempRoot();
+    await writeDevInstanceRecord(root, 4242, root, { startedAtMs: 1_000_000 });
+
+    await __testing.warmStaleProcessProvenance(
+      root,
+      realFsDeps(root, {
+        isPidAlive: (pid) => pid === 4242,
+        readProcessIdentity: () => {
+          throw new Error('process inspection denied');
+        },
+      }),
+    );
+
+    expect(hasExclusiveSharedLegacyUserDataAccess(root, (pid) => pid === 4242)).toBe(false);
+  });
+
   it('keeps deferring when a reused pid now belongs to another Cindy process', async () => {
     const root = await tempRoot();
     const startedAtMs = 1_000_000;

--- a/apps/desktop/src/main/__tests__/ownerNamespaceMigration.test.ts
+++ b/apps/desktop/src/main/__tests__/ownerNamespaceMigration.test.ts
@@ -195,6 +195,32 @@ describe('claimLegacyOwnerNamespace', () => {
     expect(result).toMatchObject({ status: 'migrated' });
   });
 
+  it('warms stale-pid provenance before side-channel importers inspect a completed claim', async () => {
+    const root = await tempRoot();
+    const startedAtMs = 1_000_000;
+    await fs.writeFile(
+      path.join(root, __testing.CLAIM_MARKER),
+      JSON.stringify({ version: 1, ownerKey: dataOwnerStorageKey('cloud-a'), complete: true }),
+    );
+    await writeDevInstanceRecord(root, 4242, root, { startedAtMs });
+
+    const result = await claimLegacyOwnerNamespace(
+      { mode: 'cloud', dataOwnerId: 'cloud-a', user: { id: 'cloud-a' } },
+      realFsDeps(root, {
+        isPidAlive: (pid) => pid === 4242,
+        readProcessIdentity: () => ({
+          startedAtMs: startedAtMs + 120_000,
+          command: '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+        }),
+      }),
+    );
+
+    expect(result).toEqual({ status: 'migrated', moved: 0, conflicts: 0 });
+    // Omit the synchronous identity reader: this assertion must consume the
+    // proof produced by claimLegacyOwnerNamespace's async warm-up.
+    expect(hasLegacyOwnerNamespaceClaim('cloud-a', root, (pid) => pid === 4242)).toBe(true);
+  });
+
   it('keeps deferring when a reused pid now belongs to another Cindy process', async () => {
     const root = await tempRoot();
     const startedAtMs = 1_000_000;

--- a/apps/desktop/src/main/__tests__/ownerNamespaceMigration.test.ts
+++ b/apps/desktop/src/main/__tests__/ownerNamespaceMigration.test.ts
@@ -146,6 +146,81 @@ describe('claimLegacyOwnerNamespace', () => {
     await expect(fs.access(path.join(root, __testing.CLAIM_MARKER))).rejects.toThrow();
   });
 
+  it('ignores a live pid that OS provenance proves was reused by another app', async () => {
+    const root = await tempRoot();
+    const startedAtMs = 1_000_000;
+    await fs.writeFile(path.join(root, 'slack-hook.json'), 'legacy-hook');
+    await writeDevInstanceRecord(root, 4242, root, {
+      startedAtMs,
+      rootDir: '/Applications/Old Cindy.app/Contents/Resources/app.asar',
+    });
+
+    const result = await claimLegacyOwnerNamespace(
+      { mode: 'cloud', dataOwnerId: 'cloud-a', user: { id: 'cloud-a' } },
+      realFsDeps(root, {
+        isPidAlive: (pid) => pid === 4242,
+        readProcessIdentity: () => ({
+          startedAtMs: startedAtMs + 120_000,
+          command: '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+        }),
+      }),
+    );
+
+    expect(result).toMatchObject({ status: 'migrated' });
+    await expect(
+      fs.readFile(
+        path.join(root, 'owners', dataOwnerStorageKey('cloud-a'), 'slack-hook.json'),
+        'utf-8',
+      ),
+    ).resolves.toBe('legacy-hook');
+  });
+
+  it('keeps deferring when a reused pid now belongs to another Cindy process', async () => {
+    const root = await tempRoot();
+    const startedAtMs = 1_000_000;
+    await fs.writeFile(path.join(root, 'slack-hook.json'), 'legacy-hook');
+    await writeDevInstanceRecord(root, 4242, root, { startedAtMs });
+
+    const result = await claimLegacyOwnerNamespace(
+      { mode: 'cloud', dataOwnerId: 'cloud-a', user: { id: 'cloud-a' } },
+      realFsDeps(root, {
+        isPidAlive: (pid) => pid === 4242,
+        readProcessIdentity: () => ({
+          startedAtMs: startedAtMs + 120_000,
+          command: '/Applications/Cindy.app/Contents/MacOS/Cindy',
+        }),
+      }),
+    );
+
+    expect(result).toMatchObject({
+      status: 'deferred',
+      deferredReason: 'concurrent-live-instances',
+    });
+    await expect(fs.readFile(path.join(root, 'slack-hook.json'), 'utf-8')).resolves.toBe('legacy-hook');
+  });
+
+  it('fails closed when process identity cannot be read', async () => {
+    const root = await tempRoot();
+    await fs.writeFile(path.join(root, 'slack-hook.json'), 'legacy-hook');
+    await writeDevInstanceRecord(root, 4242, root, { startedAtMs: 1_000_000 });
+
+    const result = await claimLegacyOwnerNamespace(
+      { mode: 'cloud', dataOwnerId: 'cloud-a', user: { id: 'cloud-a' } },
+      realFsDeps(root, {
+        isPidAlive: (pid) => pid === 4242,
+        readProcessIdentity: () => {
+          throw new Error('process inspection denied');
+        },
+      }),
+    );
+
+    expect(result).toMatchObject({
+      status: 'deferred',
+      deferredReason: 'concurrent-live-instances',
+    });
+    await expect(fs.readFile(path.join(root, 'slack-hook.json'), 'utf-8')).resolves.toBe('legacy-hook');
+  });
+
   it('fails closed (defers) when a registry record exists but cannot be read', async () => {
     const root = await tempRoot();
     await fs.writeFile(path.join(root, 'slack-hook.json'), 'legacy-hook');
@@ -281,6 +356,30 @@ describe('claimLegacyOwnerNamespace', () => {
     expect(result).toMatchObject({ status: 'migrated' });
     const targetRoot = path.join(root, 'owners', dataOwnerStorageKey('cloud-a'));
     await expect(fs.readFile(path.join(targetRoot, 'slack-hook.json'), 'utf-8')).resolves.toBe('legacy-hook');
+  });
+
+  it('ignores a stale SingletonLock whose live pid has been reused by another app', async () => {
+    const root = await tempRoot();
+    await fs.writeFile(path.join(root, 'slack-hook.json'), 'legacy-hook');
+    await writeSingletonLock(root, 4242);
+    const lockMtimeMs = (await fs.lstat(path.join(root, 'SingletonLock'))).mtimeMs;
+
+    const result = await claimLegacyOwnerNamespace(
+      { mode: 'cloud', dataOwnerId: 'cloud-a', user: { id: 'cloud-a' } },
+      realFsDeps(
+        root,
+        {
+          isPidAlive: (pid) => pid === 4242,
+          readProcessIdentity: () => ({
+            startedAtMs: lockMtimeMs + 120_000,
+            command: '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+          }),
+        },
+        { readlink: () => Promise.resolve('myhost-4242') },
+      ),
+    );
+
+    expect(result).toMatchObject({ status: 'migrated' });
   });
 
   it('interrupts a long directory merge when an instance registers mid-recursion', async () => {
@@ -1281,6 +1380,34 @@ describe('legacy Ghost plugin recovery', () => {
     ).resolves.toContain('"id":"valid-plugin"');
   });
 
+  it('recovers plugins when a live registry pid was reused by another app', async () => {
+    const root = await tempRoot();
+    const ownerId = 'cloud-a';
+    const ownerKey = dataOwnerStorageKey(ownerId);
+    const startedAtMs = 1_000_000;
+    await writeGhostDir(root, 'cindy-brain', 'valid-plugin');
+    await writeDevInstanceRecord(root, 4242, root, { startedAtMs });
+
+    const result = await recoverLegacyGhostPlugins(
+      { mode: 'cloud', dataOwnerId: ownerId, user: { id: ownerId } },
+      realFsDeps(root, {
+        isPidAlive: (pid) => pid === 4242,
+        readProcessIdentity: () => ({
+          startedAtMs: startedAtMs + 120_000,
+          command: '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+        }),
+      }),
+    );
+
+    expect(result).toMatchObject({ status: 'migrated', moved: 1 });
+    await expect(
+      fs.readFile(
+        path.join(root, 'owners', ownerKey, 'cindy-brain', 'valid-plugin', 'ghost.json'),
+        'utf-8',
+      ),
+    ).resolves.toContain('"id":"valid-plugin"');
+  });
+
   it('interrupts plugin recovery when an instance registers before the next plugin move', async () => {
     const root = await tempRoot();
     await writeGhostDir(root, 'cindy-brain', 'first-plugin');
@@ -1538,6 +1665,23 @@ describe('hasExclusiveSharedLegacyUserDataAccess', () => {
     expect(hasExclusiveSharedLegacyUserDataAccess(root, (pid) => pid === 4242)).toBe(false);
     expect(hasExclusiveSharedLegacyUserDataAccess(root, () => false)).toBe(true);
   });
+
+  it('ignores a registry pid that was reused by another app', async () => {
+    const root = await tempRoot();
+    const startedAtMs = 1_000_000;
+    await writeDevInstanceRecord(root, 4242, root, { startedAtMs });
+
+    expect(
+      hasExclusiveSharedLegacyUserDataAccess(
+        root,
+        (pid) => pid === 4242,
+        () => ({
+          startedAtMs: startedAtMs + 120_000,
+          command: '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+        }),
+      ),
+    ).toBe(true);
+  });
 });
 
 describe('isSameUserDataDir', () => {
@@ -1594,6 +1738,7 @@ function realFsDeps(
     passiveSharedUserData: () => false,
     selfPid: () => process.pid,
     isPidAlive: () => false,
+    readProcessIdentity: () => null,
     ...guardOverrides,
     ...fsOverrides,
   };
@@ -1603,18 +1748,20 @@ interface GuardDeps {
   passiveSharedUserData: () => boolean;
   selfPid: () => number;
   isPidAlive: (pid: number) => boolean;
+  readProcessIdentity: (pid: number) => { startedAtMs: number; command: string } | null;
 }
 
 async function writeDevInstanceRecord(
   root: string,
   pid: number,
   userDataDir: string = root,
+  options: { startedAtMs?: number; rootDir?: string } = {},
 ): Promise<void> {
   const registryDir = path.join(root, '.dev-instances');
   await fs.mkdir(registryDir, { recursive: true });
   await fs.writeFile(
     path.join(registryDir, `${pid}.json`),
-    JSON.stringify({ schemaVersion: 1, pid, userDataDir, passive: false }),
+    JSON.stringify({ schemaVersion: 1, pid, userDataDir, passive: false, ...options }),
     'utf-8',
   );
 }

--- a/apps/desktop/src/main/__tests__/ownerNamespaceMigration.test.ts
+++ b/apps/desktop/src/main/__tests__/ownerNamespaceMigration.test.ts
@@ -218,7 +218,7 @@ describe('claimLegacyOwnerNamespace', () => {
     expect(result).toEqual({ status: 'migrated', moved: 0, conflicts: 0 });
     // Omit the synchronous identity reader: this assertion must consume the
     // proof produced by claimLegacyOwnerNamespace's async warm-up.
-    expect(hasLegacyOwnerNamespaceClaim('cloud-a', root, (pid) => pid === 4242)).toBe(true);
+    expect(hasExclusiveSharedLegacyUserDataAccess(root, (pid) => pid === 4242)).toBe(true);
   });
 
   it('keeps deferring when a reused pid now belongs to another Cindy process', async () => {

--- a/apps/desktop/src/main/__tests__/ownerNamespaceMigration.test.ts
+++ b/apps/desktop/src/main/__tests__/ownerNamespaceMigration.test.ts
@@ -175,6 +175,26 @@ describe('claimLegacyOwnerNamespace', () => {
     ).resolves.toBe('legacy-hook');
   });
 
+  it('does not permanently defer when a pid is reused by another app shortly after exit', async () => {
+    const root = await tempRoot();
+    const startedAtMs = 1_000_000;
+    await fs.writeFile(path.join(root, 'slack-hook.json'), 'legacy-hook');
+    await writeDevInstanceRecord(root, 4242, root, { startedAtMs });
+
+    const result = await claimLegacyOwnerNamespace(
+      { mode: 'cloud', dataOwnerId: 'cloud-a', user: { id: 'cloud-a' } },
+      realFsDeps(root, {
+        isPidAlive: (pid) => pid === 4242,
+        readProcessIdentity: () => ({
+          startedAtMs: startedAtMs + 2_500,
+          command: '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+        }),
+      }),
+    );
+
+    expect(result).toMatchObject({ status: 'migrated' });
+  });
+
   it('keeps deferring when a reused pid now belongs to another Cindy process', async () => {
     const root = await tempRoot();
     const startedAtMs = 1_000_000;

--- a/apps/desktop/src/main/__tests__/ownerNamespaceMigration.test.ts
+++ b/apps/desktop/src/main/__tests__/ownerNamespaceMigration.test.ts
@@ -1702,6 +1702,30 @@ describe('hasExclusiveSharedLegacyUserDataAccess', () => {
       ),
     ).toBe(true);
   });
+
+  it('reuses async stale-pid proof in sync guards and invalidates it when the record changes', async () => {
+    const root = await tempRoot();
+    const startedAtMs = 1_000_000;
+    await writeDevInstanceRecord(root, 4242, root, { startedAtMs });
+
+    await claimLegacyOwnerNamespace(
+      { mode: 'cloud', dataOwnerId: 'cloud-a', user: { id: 'cloud-a' } },
+      realFsDeps(root, {
+        isPidAlive: (pid) => pid === 4242,
+        readProcessIdentity: () => ({
+          startedAtMs: startedAtMs + 120_000,
+          command: '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+        }),
+      }),
+    );
+
+    expect(hasExclusiveSharedLegacyUserDataAccess(root, (pid) => pid === 4242)).toBe(true);
+
+    await writeDevInstanceRecord(root, 4242, root, {
+      startedAtMs: startedAtMs + 1,
+    });
+    expect(hasExclusiveSharedLegacyUserDataAccess(root, (pid) => pid === 4242)).toBe(false);
+  });
 });
 
 describe('isSameUserDataDir', () => {

--- a/apps/desktop/src/main/bootstrap-electron.ts
+++ b/apps/desktop/src/main/bootstrap-electron.ts
@@ -185,6 +185,7 @@ import {
 import { setTelegramRemoteSource } from './device-link/telegramRemoteControl';
 import * as authManager from './authManager';
 import { hasPersistedSessionHint } from './authSessionHint';
+import { warmStaleProcessProvenance } from './ownerNamespaceMigration.js';
 import { createAccountDeletionIpcHandlers } from './accountDeletionIpc';
 import * as profileEdit from './profileEdit';
 import { uploadPublicAsset } from './ossPublicUpload';
@@ -6987,6 +6988,12 @@ app.on('ready', async () => {
   // log-upload:settings-get 决定入口可用性;更重要的是崩溃即时路径要在
   // onFatalShutdown 上就位,否则 createWindow 之后立刻崩的那一次拿不到标记。
   initLogUploadService();
+  // Local profiles bypass authManager's cloud claim path. Await the same
+  // asynchronous PID provenance scan before the first BrowserWindow exists so
+  // sidebar's synchronous legacy migration reads can consume an exact proof.
+  if (getActiveAppSession().mode === 'local') {
+    await warmStaleProcessProvenance();
+  }
   startupWindowCreationAllowed = true;
   createWindow();
   // The macOS release watcher stays disarmed until a task drag begins. Start

--- a/apps/desktop/src/main/ownerNamespaceMigration.ts
+++ b/apps/desktop/src/main/ownerNamespaceMigration.ts
@@ -1,5 +1,5 @@
 import { app } from 'electron';
-import { execFileSync } from 'node:child_process';
+import { execFile } from 'node:child_process';
 import fsSync from 'node:fs';
 import fs from 'node:fs/promises';
 import path from 'node:path';
@@ -107,10 +107,13 @@ const log = createLogger('ownerNamespaceMigration');
 // shortly after the record was written as the old Cindy process.
 const PID_REUSE_TOLERANCE_MS = 2_000;
 const PROCESS_IDENTITY_QUERY_TIMEOUT_MS = 1_500;
+const STALE_PROCESS_PROOF_TTL_MS = 10_000;
 const legacyGhostMigrationResults = new Map<
   string,
   OwnerNamespaceMigrationResult['status']
 >();
+const staleProcessProofs = new Map<string, number>();
+const staleProcessProofRefreshes = new Map<string, Promise<void>>();
 
 const productionDeps: MigrationDeps = {
   userDataDir: () => app.getPath('userData'),
@@ -136,7 +139,7 @@ const productionDeps: MigrationDeps = {
       return (error as NodeJS.ErrnoException).code === 'EPERM';
     }
   },
-  readProcessIdentity: readProcessIdentityDefault,
+  readProcessIdentity: undefined,
 };
 
 function verifiedCloudOwner(state: MigrationSessionState): string | null {
@@ -187,64 +190,43 @@ function parseProcessIdentityOutput(raw: string): ProcessIdentitySnapshot | null
   return { startedAtMs, command };
 }
 
-/**
- * Read enough OS provenance to distinguish a live registration from a stale
- * file whose PID has since been reused. Failure is represented as null so the
- * migration guard can keep its fail-closed posture.
- */
-function readProcessIdentityDefault(pid: number): ProcessIdentitySnapshot | null {
-  if (!Number.isInteger(pid) || pid <= 0) return null;
-  try {
-    if (process.platform === 'win32') {
-      const powershell = `${process.env.SystemRoot ?? 'C:\\Windows'}\\System32\\WindowsPowerShell\\v1.0\\powershell.exe`;
-      const output = execFileSync(
-        powershell,
-        [
-          '-NoProfile',
-          '-NonInteractive',
-          '-Command',
-          `$p = Get-Process -Id ${pid} -ErrorAction Stop; ` +
-            '$command = if ($p.Path) { $p.Path } else { $p.ProcessName }; ' +
-            '[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false); ' +
-            "[Console]::WriteLine($p.StartTime.ToUniversalTime().ToString('O')); " +
-            '[Console]::Write($command)',
-        ],
-        {
-          encoding: 'utf-8',
-          timeout: PROCESS_IDENTITY_QUERY_TIMEOUT_MS,
-          maxBuffer: 4_096,
-          windowsHide: true,
-          stdio: ['ignore', 'pipe', 'ignore'],
-        },
-      );
-      return parseProcessIdentityOutput(output);
-    }
-
-    const output = execFileSync('ps', ['-p', String(pid), '-o', 'lstart=', '-o', 'command='], {
-      encoding: 'utf-8',
-      timeout: PROCESS_IDENTITY_QUERY_TIMEOUT_MS,
-      maxBuffer: 16_384,
-      env: { ...process.env, LC_ALL: 'C' },
-      stdio: ['ignore', 'pipe', 'ignore'],
-    });
-    const match = /^(.{24})\s+([\s\S]+)$/.exec(output.trim());
-    return match ? parseProcessIdentityOutput(`${match[1]}\n${match[2]}`) : null;
-  } catch {
-    return null;
-  }
+function execFileUtf8(
+  file: string,
+  args: readonly string[],
+  options: {
+    maxBuffer: number;
+    env?: NodeJS.ProcessEnv;
+    windowsHide?: boolean;
+  },
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      file,
+      [...args],
+      {
+        ...options,
+        encoding: 'utf-8',
+        timeout: PROCESS_IDENTITY_QUERY_TIMEOUT_MS,
+      },
+      (error, stdout) => {
+        if (error) reject(error);
+        else resolve(stdout);
+      },
+    );
+  });
 }
 
-/** Read all candidate process identities with one OS query per scan. */
-function readProcessIdentitiesDefault(
+/** Read all candidate process identities asynchronously with one OS query per scan. */
+async function readProcessIdentitiesDefault(
   pids: readonly number[],
-): ReadonlyMap<number, ProcessIdentitySnapshot | null> {
+): Promise<ReadonlyMap<number, ProcessIdentitySnapshot | null>> {
   const uniquePids = [...new Set(pids)].filter((pid) => Number.isInteger(pid) && pid > 0);
   const result = new Map<number, ProcessIdentitySnapshot | null>();
   if (uniquePids.length === 0) return result;
   try {
     if (process.platform === 'win32') {
       const powershell = `${process.env.SystemRoot ?? 'C:\\Windows'}\\System32\\WindowsPowerShell\\v1.0\\powershell.exe`;
-      const output = execFileSync(
+      const output = await execFileUtf8(
         powershell,
         [
           '-NoProfile',
@@ -258,11 +240,8 @@ function readProcessIdentitiesDefault(
             '$rows | ConvertTo-Json -Compress',
         ],
         {
-          encoding: 'utf-8',
-          timeout: PROCESS_IDENTITY_QUERY_TIMEOUT_MS,
           maxBuffer: 16_384,
           windowsHide: true,
-          stdio: ['ignore', 'pipe', 'ignore'],
         },
       );
       const parsed = JSON.parse(output) as unknown;
@@ -287,15 +266,12 @@ function readProcessIdentitiesDefault(
       return result;
     }
 
-    const output = execFileSync(
+    const output = await execFileUtf8(
       'ps',
       ['-p', uniquePids.join(','), '-o', 'pid=', '-o', 'lstart=', '-o', 'command='],
       {
-        encoding: 'utf-8',
-        timeout: PROCESS_IDENTITY_QUERY_TIMEOUT_MS,
         maxBuffer: 16_384,
         env: { ...process.env, LC_ALL: 'C' },
-        stdio: ['ignore', 'pipe', 'ignore'],
       },
     );
     for (const line of output.split('\n')) {
@@ -345,12 +321,50 @@ function readProcessIdentitySafely(
   }
 }
 
-function readProcessIdentitiesForPids(
+async function readProcessIdentitiesForPids(
   pids: readonly number[],
-  reader: ProcessIdentityReader,
-): ReadonlyMap<number, ProcessIdentitySnapshot | null> {
-  if (reader === readProcessIdentityDefault) return readProcessIdentitiesDefault(pids);
+  reader?: ProcessIdentityReader,
+): Promise<ReadonlyMap<number, ProcessIdentitySnapshot | null>> {
+  if (!reader) return readProcessIdentitiesDefault(pids);
   return new Map(pids.map((pid) => [pid, readProcessIdentitySafely(reader, pid)] as const));
+}
+
+function processProofKey(
+  userDataDir: string,
+  kind: 'registry' | 'singleton-lock',
+  fingerprint: string,
+): string {
+  return `${path.resolve(userDataDir)}\u0000${kind}\u0000${fingerprint}`;
+}
+
+function rememberStaleProcessProof(key: string): void {
+  staleProcessProofs.set(key, Date.now() + STALE_PROCESS_PROOF_TTL_MS);
+}
+
+function hasFreshStaleProcessProof(key: string): boolean {
+  const expiresAt = staleProcessProofs.get(key);
+  if (expiresAt === undefined) return false;
+  if (expiresAt <= Date.now()) {
+    staleProcessProofs.delete(key);
+    return false;
+  }
+  return true;
+}
+
+function refreshStaleProcessProofs(userDataDir: string): void {
+  const key = path.resolve(userDataDir);
+  if (staleProcessProofRefreshes.has(key)) return;
+  const refresh: Promise<void> = findConcurrentLiveInstancePids(productionDeps, userDataDir)
+    .then(() => undefined)
+    .catch((error) => {
+      log.debug('stale process provenance refresh failed closed', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
+  staleProcessProofRefreshes.set(key, refresh);
+  void refresh.then(() => {
+    if (staleProcessProofRefreshes.get(key) === refresh) staleProcessProofRefreshes.delete(key);
+  });
 }
 
 /**
@@ -377,16 +391,16 @@ function recordedPidMayStillBeLive(
 }
 
 /**
- * Synchronous twin of findConcurrentLiveInstancePids for the importer gate
- * (hasLegacyOwnerNamespaceClaim runs in sync call sites). Fail-closed: any
- * unreadable registry state counts as "a peer may be live". Same signals —
- * `.dev-instances/<pid>.json` records plus the packaged SingletonLock
- * symlink (retroactive signal for pre-registry packaged builds).
+ * Synchronous twin of findConcurrentLiveInstancePids for importer and sidebar
+ * guards. It never launches an OS inspection command from these reusable main
+ * thread paths. A live PID is ignored only when a recent asynchronous scan
+ * proved this exact immutable registry/lock fingerprint stale; changes and
+ * unreadable state keep the fail-closed behavior.
  */
 function hasConcurrentLiveInstanceSync(
   userDataDir: string,
   isPidAlive: (pid: number) => boolean,
-  readProcessIdentity: ProcessIdentityReader,
+  readProcessIdentity?: ProcessIdentityReader,
 ): boolean {
   const selfPid = process.pid;
   const registryDir = path.join(userDataDir, '.dev-instances');
@@ -397,6 +411,8 @@ function hasConcurrentLiveInstanceSync(
     if (!isMissing(error)) return true;
   }
   const candidates: Array<{
+    raw: string;
+    fileName: string;
     pid: number;
     recordedAtMs: number | undefined;
     rootDir: string | undefined;
@@ -427,13 +443,32 @@ function hasConcurrentLiveInstanceSync(
       continue;
     }
     if (!isPidAlive(pid)) continue;
-    candidates.push({ pid, recordedAtMs: record.startedAtMs, rootDir: record.rootDir });
+    candidates.push({
+      raw,
+      fileName: name,
+      pid,
+      recordedAtMs: record.startedAtMs,
+      rootDir: record.rootDir,
+    });
   }
-  const identities = readProcessIdentitiesForPids(candidates.map(({ pid }) => pid), readProcessIdentity);
-  for (const candidate of candidates) {
-    const identity = identities.get(candidate.pid) ?? null;
-    if (recordedPidMayStillBeLive(candidate.recordedAtMs, candidate.rootDir, identity)) return true;
-    log.info('ignoring stale instance registry record after PID reuse', { pid: candidate.pid });
+  if (readProcessIdentity) {
+    for (const candidate of candidates) {
+      const identity = readProcessIdentitySafely(readProcessIdentity, candidate.pid);
+      if (recordedPidMayStillBeLive(candidate.recordedAtMs, candidate.rootDir, identity)) {
+        return true;
+      }
+    }
+  } else {
+    for (const candidate of candidates) {
+      if (
+        !hasFreshStaleProcessProof(
+          processProofKey(userDataDir, 'registry', `${candidate.fileName}\u0000${candidate.raw}`),
+        )
+      ) {
+        if (isPidAlive === isPidAliveDefault) refreshStaleProcessProofs(userDataDir);
+        return true;
+      }
+    }
   }
   try {
     const lockPath = path.join(userDataDir, 'SingletonLock');
@@ -447,16 +482,22 @@ function hasConcurrentLiveInstanceSync(
       lockPid !== selfPid &&
       isPidAlive(lockPid)
     ) {
-      let lockMtimeMs: number | undefined;
+      let lockMtimeMs: number;
       try {
         lockMtimeMs = fsSync.lstatSync(lockPath).mtimeMs;
       } catch {
-        // Missing provenance keeps the old fail-closed live-PID behavior.
+        return true;
       }
-      const identity =
-        readProcessIdentitiesForPids([lockPid], readProcessIdentity).get(lockPid) ?? null;
-      if (recordedPidMayStillBeLive(lockMtimeMs, undefined, identity)) return true;
-      log.info('ignoring stale SingletonLock after PID reuse', { pid: lockPid });
+      if (readProcessIdentity) {
+        const identity = readProcessIdentitySafely(readProcessIdentity, lockPid);
+        if (recordedPidMayStillBeLive(lockMtimeMs, undefined, identity)) return true;
+      } else {
+        const fingerprint = `${lockTarget}\u0000${lockMtimeMs}`;
+        if (!hasFreshStaleProcessProof(processProofKey(userDataDir, 'singleton-lock', fingerprint))) {
+          if (isPidAlive === isPidAliveDefault) refreshStaleProcessProofs(userDataDir);
+          return true;
+        }
+      }
     }
   } catch {
     // ENOENT(无 packaged 实例)/EINVAL(非 symlink)——无信号。
@@ -473,7 +514,7 @@ function hasConcurrentLiveInstanceSync(
 export function hasExclusiveSharedLegacyUserDataAccess(
   userDataDir = app.getPath('userData'),
   isPidAlive: (pid: number) => boolean = isPidAliveDefault,
-  readProcessIdentity: ProcessIdentityReader = readProcessIdentityDefault,
+  readProcessIdentity?: ProcessIdentityReader,
 ): boolean {
   return (
     process.env.XDT_PASSIVE_SHARED_USER_DATA !== '1' &&
@@ -502,7 +543,7 @@ export function hasLegacyOwnerNamespaceClaim(
   ownerId: string,
   userDataDir = app.getPath('userData'),
   isPidAlive: (pid: number) => boolean = isPidAliveDefault,
-  readProcessIdentity: ProcessIdentityReader = readProcessIdentityDefault,
+  readProcessIdentity?: ProcessIdentityReader,
 ): boolean {
   if (!hasExclusiveSharedLegacyUserDataAccess(userDataDir, isPidAlive, readProcessIdentity)) {
     return false;
@@ -793,7 +834,7 @@ export function getLegacyGhostRecoveryStatus(
     rejectReservedIds?: boolean;
   } = {},
   isPidAlive: (pid: number) => boolean = isPidAliveDefault,
-  readProcessIdentity: ProcessIdentityReader = readProcessIdentityDefault,
+  readProcessIdentity?: ProcessIdentityReader,
 ): LegacyGhostRecoveryStatus {
   if (boundaryPending || session.mode !== 'cloud' || !session.dataOwnerId || !session.user) {
     return NO_LEGACY_GHOST_RECOVERY;
@@ -1442,6 +1483,8 @@ async function findConcurrentLiveInstancePids(
   }
   const selfPid = deps.selfPid();
   const candidates: Array<{
+    raw: string;
+    fileName: string;
     pid: number;
     recordedAtMs: number | undefined;
     rootDir: string | undefined;
@@ -1473,11 +1516,17 @@ async function findConcurrentLiveInstancePids(
       continue;
     }
     if (!deps.isPidAlive(pid)) continue;
-    candidates.push({ pid, recordedAtMs: record.startedAtMs, rootDir: record.rootDir });
+    candidates.push({
+      raw,
+      fileName: name,
+      pid,
+      recordedAtMs: record.startedAtMs,
+      rootDir: record.rootDir,
+    });
   }
 
-  const readProcessIdentity = deps.readProcessIdentity ?? readProcessIdentityDefault;
-  const identities = readProcessIdentitiesForPids(
+  const readProcessIdentity = deps.readProcessIdentity;
+  const identities = await readProcessIdentitiesForPids(
     candidates.map(({ pid }) => pid),
     readProcessIdentity,
   );
@@ -1487,6 +1536,9 @@ async function findConcurrentLiveInstancePids(
     if (recordedPidMayStillBeLive(candidate.recordedAtMs, candidate.rootDir, identity)) {
       pids.push(candidate.pid);
     } else {
+      rememberStaleProcessProof(
+        processProofKey(userDataDir, 'registry', `${candidate.fileName}\u0000${candidate.raw}`),
+      );
       log.info('ignoring stale instance registry record after PID reuse', { pid: candidate.pid });
     }
   }
@@ -1518,10 +1570,13 @@ async function findConcurrentLiveInstancePids(
         // Missing provenance keeps the old fail-closed live-PID behavior.
       }
       const identity =
-        readProcessIdentitiesForPids([lockPid], readProcessIdentity).get(lockPid) ?? null;
+        (await readProcessIdentitiesForPids([lockPid], readProcessIdentity)).get(lockPid) ?? null;
       if (recordedPidMayStillBeLive(lockMtimeMs, undefined, identity)) {
         pids.push(lockPid);
       } else {
+        rememberStaleProcessProof(
+          processProofKey(userDataDir, 'singleton-lock', `${lockTarget}\u0000${lockMtimeMs}`),
+        );
         log.info('ignoring stale SingletonLock after PID reuse', { pid: lockPid });
       }
     }

--- a/apps/desktop/src/main/ownerNamespaceMigration.ts
+++ b/apps/desktop/src/main/ownerNamespaceMigration.ts
@@ -101,7 +101,12 @@ export interface OwnerNamespaceMigrationResult {
 }
 
 const log = createLogger('ownerNamespaceMigration');
-const PID_REUSE_TOLERANCE_MS = 60_000;
+// Process start timestamps are reported at one-second precision by `ps` on
+// Unix. Keep only enough tolerance for that rounding (plus modest clock
+// sampling skew): a large window would permanently classify a PID reused
+// shortly after the record was written as the old Cindy process.
+const PID_REUSE_TOLERANCE_MS = 2_000;
+const PROCESS_IDENTITY_QUERY_TIMEOUT_MS = 1_500;
 const legacyGhostMigrationResults = new Map<
   string,
   OwnerNamespaceMigrationResult['status']
@@ -206,7 +211,7 @@ function readProcessIdentityDefault(pid: number): ProcessIdentitySnapshot | null
         ],
         {
           encoding: 'utf-8',
-          timeout: 1_500,
+          timeout: PROCESS_IDENTITY_QUERY_TIMEOUT_MS,
           maxBuffer: 4_096,
           windowsHide: true,
           stdio: ['ignore', 'pipe', 'ignore'],
@@ -217,7 +222,7 @@ function readProcessIdentityDefault(pid: number): ProcessIdentitySnapshot | null
 
     const output = execFileSync('ps', ['-p', String(pid), '-o', 'lstart=', '-o', 'command='], {
       encoding: 'utf-8',
-      timeout: 1_500,
+      timeout: PROCESS_IDENTITY_QUERY_TIMEOUT_MS,
       maxBuffer: 16_384,
       env: { ...process.env, LC_ALL: 'C' },
       stdio: ['ignore', 'pipe', 'ignore'],
@@ -227,6 +232,83 @@ function readProcessIdentityDefault(pid: number): ProcessIdentitySnapshot | null
   } catch {
     return null;
   }
+}
+
+/** Read all candidate process identities with one OS query per scan. */
+function readProcessIdentitiesDefault(
+  pids: readonly number[],
+): ReadonlyMap<number, ProcessIdentitySnapshot | null> {
+  const uniquePids = [...new Set(pids)].filter((pid) => Number.isInteger(pid) && pid > 0);
+  const result = new Map<number, ProcessIdentitySnapshot | null>();
+  if (uniquePids.length === 0) return result;
+  try {
+    if (process.platform === 'win32') {
+      const powershell = `${process.env.SystemRoot ?? 'C:\\Windows'}\\System32\\WindowsPowerShell\\v1.0\\powershell.exe`;
+      const output = execFileSync(
+        powershell,
+        [
+          '-NoProfile',
+          '-NonInteractive',
+          '-Command',
+          `$ids = @(${uniquePids.join(',')}); ` +
+            '$rows = Get-Process -Id $ids -ErrorAction Stop | ForEach-Object { ' +
+            '$command = if ($_.Path) { $_.Path } else { $_.ProcessName }; ' +
+            "[PSCustomObject]@{ pid = $_.Id; startedAt = $_.StartTime.ToUniversalTime().ToString('O'); command = $command } }; " +
+            '[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false); ' +
+            '$rows | ConvertTo-Json -Compress',
+        ],
+        {
+          encoding: 'utf-8',
+          timeout: PROCESS_IDENTITY_QUERY_TIMEOUT_MS,
+          maxBuffer: 16_384,
+          windowsHide: true,
+          stdio: ['ignore', 'pipe', 'ignore'],
+        },
+      );
+      const parsed = JSON.parse(output) as unknown;
+      const rows = Array.isArray(parsed) ? parsed : [parsed];
+      for (const row of rows) {
+        if (!row || typeof row !== 'object') continue;
+        const value = row as Record<string, unknown>;
+        const pid = value.pid;
+        const startedAtMs = typeof value.startedAt === 'string' ? Date.parse(value.startedAt) : NaN;
+        const command = value.command;
+        if (
+          typeof pid === 'number' &&
+          Number.isInteger(pid) &&
+          Number.isFinite(startedAtMs) &&
+          startedAtMs > 0 &&
+          typeof command === 'string' &&
+          command.length > 0
+        ) {
+          result.set(pid, { startedAtMs, command });
+        }
+      }
+      return result;
+    }
+
+    const output = execFileSync(
+      'ps',
+      ['-p', uniquePids.join(','), '-o', 'pid=', '-o', 'lstart=', '-o', 'command='],
+      {
+        encoding: 'utf-8',
+        timeout: PROCESS_IDENTITY_QUERY_TIMEOUT_MS,
+        maxBuffer: 16_384,
+        env: { ...process.env, LC_ALL: 'C' },
+        stdio: ['ignore', 'pipe', 'ignore'],
+      },
+    );
+    for (const line of output.split('\n')) {
+      const match = /^\s*(\d+)\s+(.{24})\s+([\s\S]+)$/.exec(line.trimEnd());
+      if (!match) continue;
+      const pid = Number(match[1]);
+      const identity = parseProcessIdentityOutput(`${match[2]}\n${match[3]}`);
+      if (identity) result.set(pid, identity);
+    }
+  } catch {
+    // Missing entries keep the caller fail-closed when provenance is ambiguous.
+  }
+  return result;
 }
 
 function looksLikeCindyRuntime(command: string, rootDir?: string): boolean {
@@ -261,6 +343,14 @@ function readProcessIdentitySafely(
   } catch {
     return null;
   }
+}
+
+function readProcessIdentitiesForPids(
+  pids: readonly number[],
+  reader: ProcessIdentityReader,
+): ReadonlyMap<number, ProcessIdentitySnapshot | null> {
+  if (reader === readProcessIdentityDefault) return readProcessIdentitiesDefault(pids);
+  return new Map(pids.map((pid) => [pid, readProcessIdentitySafely(reader, pid)] as const));
 }
 
 /**
@@ -306,6 +396,11 @@ function hasConcurrentLiveInstanceSync(
   } catch (error) {
     if (!isMissing(error)) return true;
   }
+  const candidates: Array<{
+    pid: number;
+    recordedAtMs: number | undefined;
+    rootDir: string | undefined;
+  }> = [];
   for (const name of names) {
     if (!name.endsWith('.json')) continue;
     let raw: string;
@@ -332,9 +427,13 @@ function hasConcurrentLiveInstanceSync(
       continue;
     }
     if (!isPidAlive(pid)) continue;
-    const identity = readProcessIdentitySafely(readProcessIdentity, pid);
-    if (recordedPidMayStillBeLive(record.startedAtMs, record.rootDir, identity)) return true;
-    log.info('ignoring stale instance registry record after PID reuse', { pid });
+    candidates.push({ pid, recordedAtMs: record.startedAtMs, rootDir: record.rootDir });
+  }
+  const identities = readProcessIdentitiesForPids(candidates.map(({ pid }) => pid), readProcessIdentity);
+  for (const candidate of candidates) {
+    const identity = identities.get(candidate.pid) ?? null;
+    if (recordedPidMayStillBeLive(candidate.recordedAtMs, candidate.rootDir, identity)) return true;
+    log.info('ignoring stale instance registry record after PID reuse', { pid: candidate.pid });
   }
   try {
     const lockPath = path.join(userDataDir, 'SingletonLock');
@@ -354,7 +453,8 @@ function hasConcurrentLiveInstanceSync(
       } catch {
         // Missing provenance keeps the old fail-closed live-PID behavior.
       }
-      const identity = readProcessIdentitySafely(readProcessIdentity, lockPid);
+      const identity =
+        readProcessIdentitiesForPids([lockPid], readProcessIdentity).get(lockPid) ?? null;
       if (recordedPidMayStillBeLive(lockMtimeMs, undefined, identity)) return true;
       log.info('ignoring stale SingletonLock after PID reuse', { pid: lockPid });
     }
@@ -1341,7 +1441,11 @@ async function findConcurrentLiveInstancePids(
     names = []; // 注册表目录不存在 ≠ 无并发:下方 SingletonLock 探测仍要跑。
   }
   const selfPid = deps.selfPid();
-  const pids: number[] = [];
+  const candidates: Array<{
+    pid: number;
+    recordedAtMs: number | undefined;
+    rootDir: string | undefined;
+  }> = [];
   for (const name of names) {
     if (!name.endsWith('.json')) continue;
     let raw: string;
@@ -1369,14 +1473,21 @@ async function findConcurrentLiveInstancePids(
       continue;
     }
     if (!deps.isPidAlive(pid)) continue;
-    const identity = readProcessIdentitySafely(
-      deps.readProcessIdentity ?? readProcessIdentityDefault,
-      pid,
-    );
-    if (recordedPidMayStillBeLive(record.startedAtMs, record.rootDir, identity)) {
-      pids.push(pid);
+    candidates.push({ pid, recordedAtMs: record.startedAtMs, rootDir: record.rootDir });
+  }
+
+  const readProcessIdentity = deps.readProcessIdentity ?? readProcessIdentityDefault;
+  const identities = readProcessIdentitiesForPids(
+    candidates.map(({ pid }) => pid),
+    readProcessIdentity,
+  );
+  const pids: number[] = [];
+  for (const candidate of candidates) {
+    const identity = identities.get(candidate.pid) ?? null;
+    if (recordedPidMayStillBeLive(candidate.recordedAtMs, candidate.rootDir, identity)) {
+      pids.push(candidate.pid);
     } else {
-      log.info('ignoring stale instance registry record after PID reuse', { pid });
+      log.info('ignoring stale instance registry record after PID reuse', { pid: candidate.pid });
     }
   }
 
@@ -1406,10 +1517,8 @@ async function findConcurrentLiveInstancePids(
       } catch {
         // Missing provenance keeps the old fail-closed live-PID behavior.
       }
-      const identity = readProcessIdentitySafely(
-        deps.readProcessIdentity ?? readProcessIdentityDefault,
-        lockPid,
-      );
+      const identity =
+        readProcessIdentitiesForPids([lockPid], readProcessIdentity).get(lockPid) ?? null;
       if (recordedPidMayStillBeLive(lockMtimeMs, undefined, identity)) {
         pids.push(lockPid);
       } else {

--- a/apps/desktop/src/main/ownerNamespaceMigration.ts
+++ b/apps/desktop/src/main/ownerNamespaceMigration.ts
@@ -1618,6 +1618,22 @@ export async function claimLegacyOwnerNamespace(
     return { status: 'claimed-by-other-owner', moved: 0, conflicts: 0 };
   }
   if (existingMarker?.complete) {
+    // The claim marker only covers the main owner-tree move. Provider secrets,
+    // IM files, and retired integration accounts still pass through the
+    // synchronous legacy-import gate immediately after this async call. Warm
+    // the exact PID-reuse provenance proof here so those consumers can make a
+    // safe decision on their first check; otherwise their one async refresh
+    // would finish after the check and the import would wait until a later
+    // login or restart.
+    try {
+      await findConcurrentLiveInstancePids(deps, userDataDir);
+    } catch (error) {
+      // Provenance errors remain fail-closed in the synchronous guards. The
+      // completed claim itself is still a valid idempotent result.
+      log.debug('completed owner namespace claim provenance warmup failed closed', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
     return { status: 'migrated', moved: 0, conflicts: 0 };
   }
 

--- a/apps/desktop/src/main/ownerNamespaceMigration.ts
+++ b/apps/desktop/src/main/ownerNamespaceMigration.ts
@@ -368,6 +368,24 @@ function refreshStaleProcessProofs(userDataDir: string): void {
 }
 
 /**
+ * Warm the short-lived PID-reuse proofs before synchronous legacy consumers
+ * inspect a stable local profile during first-window startup. Provenance
+ * failures are deliberately swallowed here; the synchronous guards remain
+ * fail-closed until a complete, exact proof is available.
+ */
+export async function warmStaleProcessProvenance(
+  userDataDir = app.getPath('userData'),
+): Promise<void> {
+  try {
+    await findConcurrentLiveInstancePids(productionDeps, userDataDir);
+  } catch (error) {
+    log.debug('startup stale process provenance warmup failed closed', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+/**
  * PID liveness alone is insufficient: macOS and Windows routinely reuse old
  * PIDs. Ignore a registration only when OS provenance proves that the current
  * process started well after the record and is not another Cindy/Electron
@@ -1808,5 +1826,10 @@ export const __testing = {
   LEGACY_PATHS,
   isSameUserDataDir,
   pathExistsNoFollowSync,
+  warmStaleProcessProvenance: (
+    userDataDir: string,
+    deps: MigrationDeps,
+  ): Promise<void> =>
+    findConcurrentLiveInstancePids(deps, userDataDir).then(() => undefined).catch(() => undefined),
   resetLegacyGhostRecoveryState: () => legacyGhostMigrationResults.clear(),
 };

--- a/apps/desktop/src/main/ownerNamespaceMigration.ts
+++ b/apps/desktop/src/main/ownerNamespaceMigration.ts
@@ -1,4 +1,5 @@
 import { app } from 'electron';
+import { execFileSync } from 'node:child_process';
 import fsSync from 'node:fs';
 import fs from 'node:fs/promises';
 import path from 'node:path';
@@ -59,7 +60,7 @@ interface MigrationDeps {
   readFile(file: string): Promise<string>;
   writeFileExclusive(file: string, text: string): Promise<void>;
   writeFile(file: string, text: string): Promise<void>;
-  lstat(file: string): Promise<{ isDirectory(): boolean }>;
+  lstat(file: string): Promise<{ isDirectory(): boolean; mtimeMs?: number }>;
   readdir(dir: string): Promise<string[]>;
   mkdir(dir: string): Promise<void>;
   rename(source: string, target: string): Promise<void>;
@@ -69,7 +70,22 @@ interface MigrationDeps {
   passiveSharedUserData(): boolean;
   selfPid(): number;
   isPidAlive(pid: number): boolean;
+  readProcessIdentity?(pid: number): ProcessIdentitySnapshot | null;
 }
+
+interface RegisteredInstanceRecord {
+  pid?: number;
+  userDataDir?: string;
+  startedAtMs?: number;
+  rootDir?: string;
+}
+
+interface ProcessIdentitySnapshot {
+  startedAtMs: number;
+  command: string;
+}
+
+type ProcessIdentityReader = (pid: number) => ProcessIdentitySnapshot | null;
 
 /** claim 被推迟(而非放弃)的原因;下次独占启动时自然重试完成。 */
 export type OwnerNamespaceClaimDeferredReason =
@@ -85,6 +101,7 @@ export interface OwnerNamespaceMigrationResult {
 }
 
 const log = createLogger('ownerNamespaceMigration');
+const PID_REUSE_TOLERANCE_MS = 60_000;
 const legacyGhostMigrationResults = new Map<
   string,
   OwnerNamespaceMigrationResult['status']
@@ -114,6 +131,7 @@ const productionDeps: MigrationDeps = {
       return (error as NodeJS.ErrnoException).code === 'EPERM';
     }
   },
+  readProcessIdentity: readProcessIdentityDefault,
 };
 
 function verifiedCloudOwner(state: MigrationSessionState): string | null {
@@ -155,6 +173,119 @@ function isPidAliveDefault(pid: number): boolean {
   }
 }
 
+function parseProcessIdentityOutput(raw: string): ProcessIdentitySnapshot | null {
+  const newline = raw.indexOf('\n');
+  if (newline < 0) return null;
+  const startedAtMs = Date.parse(raw.slice(0, newline).trim());
+  const command = raw.slice(newline + 1).trim();
+  if (!Number.isFinite(startedAtMs) || startedAtMs <= 0 || command.length === 0) return null;
+  return { startedAtMs, command };
+}
+
+/**
+ * Read enough OS provenance to distinguish a live registration from a stale
+ * file whose PID has since been reused. Failure is represented as null so the
+ * migration guard can keep its fail-closed posture.
+ */
+function readProcessIdentityDefault(pid: number): ProcessIdentitySnapshot | null {
+  if (!Number.isInteger(pid) || pid <= 0) return null;
+  try {
+    if (process.platform === 'win32') {
+      const powershell = `${process.env.SystemRoot ?? 'C:\\Windows'}\\System32\\WindowsPowerShell\\v1.0\\powershell.exe`;
+      const output = execFileSync(
+        powershell,
+        [
+          '-NoProfile',
+          '-NonInteractive',
+          '-Command',
+          `$p = Get-Process -Id ${pid} -ErrorAction Stop; ` +
+            '$command = if ($p.Path) { $p.Path } else { $p.ProcessName }; ' +
+            '[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false); ' +
+            "[Console]::WriteLine($p.StartTime.ToUniversalTime().ToString('O')); " +
+            '[Console]::Write($command)',
+        ],
+        {
+          encoding: 'utf-8',
+          timeout: 1_500,
+          maxBuffer: 4_096,
+          windowsHide: true,
+          stdio: ['ignore', 'pipe', 'ignore'],
+        },
+      );
+      return parseProcessIdentityOutput(output);
+    }
+
+    const output = execFileSync('ps', ['-p', String(pid), '-o', 'lstart=', '-o', 'command='], {
+      encoding: 'utf-8',
+      timeout: 1_500,
+      maxBuffer: 16_384,
+      env: { ...process.env, LC_ALL: 'C' },
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    const match = /^(.{24})\s+([\s\S]+)$/.exec(output.trim());
+    return match ? parseProcessIdentityOutput(`${match[1]}\n${match[2]}`) : null;
+  } catch {
+    return null;
+  }
+}
+
+function looksLikeCindyRuntime(command: string, rootDir?: string): boolean {
+  const normalizedCommand = command.replaceAll('\\', '/').toLowerCase();
+  const normalizedRoot = rootDir?.replaceAll('\\', '/').toLowerCase();
+  if (normalizedRoot && normalizedCommand.includes(normalizedRoot)) return true;
+
+  const resourcesMarker = '/contents/resources/';
+  const resourcesIndex = normalizedRoot?.indexOf(resourcesMarker) ?? -1;
+  if (
+    normalizedRoot &&
+    resourcesIndex > 0 &&
+    normalizedCommand.includes(normalizedRoot.slice(0, resourcesIndex))
+  ) {
+    return true;
+  }
+
+  return (
+    normalizedCommand.includes('/cindy.app/') ||
+    normalizedCommand.includes('/electron.app/') ||
+    /(^|[\s/])cindy(?:\.exe)?(?:\s|$)/.test(normalizedCommand) ||
+    /(^|[\s/])electron(?:\.exe)?(?:\s|$)/.test(normalizedCommand)
+  );
+}
+
+function readProcessIdentitySafely(
+  reader: ProcessIdentityReader,
+  pid: number,
+): ProcessIdentitySnapshot | null {
+  try {
+    return reader(pid);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * PID liveness alone is insufficient: macOS and Windows routinely reuse old
+ * PIDs. Ignore a registration only when OS provenance proves that the current
+ * process started well after the record and is not another Cindy/Electron
+ * runtime. Missing or ambiguous provenance remains live (fail closed).
+ */
+function recordedPidMayStillBeLive(
+  recordedAtMs: number | undefined,
+  rootDir: string | undefined,
+  identity: ProcessIdentitySnapshot | null,
+): boolean {
+  if (
+    typeof recordedAtMs !== 'number' ||
+    !Number.isFinite(recordedAtMs) ||
+    recordedAtMs <= 0 ||
+    identity === null
+  ) {
+    return true;
+  }
+  if (identity.startedAtMs <= recordedAtMs + PID_REUSE_TOLERANCE_MS) return true;
+  return looksLikeCindyRuntime(identity.command, rootDir);
+}
+
 /**
  * Synchronous twin of findConcurrentLiveInstancePids for the importer gate
  * (hasLegacyOwnerNamespaceClaim runs in sync call sites). Fail-closed: any
@@ -165,6 +296,7 @@ function isPidAliveDefault(pid: number): boolean {
 function hasConcurrentLiveInstanceSync(
   userDataDir: string,
   isPidAlive: (pid: number) => boolean,
+  readProcessIdentity: ProcessIdentityReader,
 ): boolean {
   const selfPid = process.pid;
   const registryDir = path.join(userDataDir, '.dev-instances');
@@ -183,33 +315,48 @@ function hasConcurrentLiveInstanceSync(
       if (isMissing(error)) continue;
       return true;
     }
-    let record: Partial<{ pid: number; userDataDir: string }>;
+    let record: RegisteredInstanceRecord;
     try {
-      record = JSON.parse(raw) as Partial<{ pid: number; userDataDir: string }>;
+      record = JSON.parse(raw) as RegisteredInstanceRecord;
     } catch {
       continue; // torn leftover
     }
     const pid = record.pid;
-    if (typeof pid !== 'number' || !Number.isInteger(pid) || pid === selfPid) continue;
+    if (typeof pid !== 'number' || !Number.isInteger(pid) || pid <= 0 || pid === selfPid) {
+      continue;
+    }
     if (
       typeof record.userDataDir === 'string' &&
       !isSameUserDataDir(record.userDataDir, userDataDir, process.platform)
     ) {
       continue;
     }
-    if (isPidAlive(pid)) return true;
+    if (!isPidAlive(pid)) continue;
+    const identity = readProcessIdentitySafely(readProcessIdentity, pid);
+    if (recordedPidMayStillBeLive(record.startedAtMs, record.rootDir, identity)) return true;
+    log.info('ignoring stale instance registry record after PID reuse', { pid });
   }
   try {
-    const lockTarget = fsSync.readlinkSync(path.join(userDataDir, 'SingletonLock'));
+    const lockPath = path.join(userDataDir, 'SingletonLock');
+    const lockTarget = fsSync.readlinkSync(lockPath);
     const match = /-(\d+)$/.exec(lockTarget);
     const lockPid = match ? Number(match[1]) : null;
     if (
       lockPid !== null &&
       Number.isInteger(lockPid) &&
+      lockPid > 0 &&
       lockPid !== selfPid &&
       isPidAlive(lockPid)
     ) {
-      return true;
+      let lockMtimeMs: number | undefined;
+      try {
+        lockMtimeMs = fsSync.lstatSync(lockPath).mtimeMs;
+      } catch {
+        // Missing provenance keeps the old fail-closed live-PID behavior.
+      }
+      const identity = readProcessIdentitySafely(readProcessIdentity, lockPid);
+      if (recordedPidMayStillBeLive(lockMtimeMs, undefined, identity)) return true;
+      log.info('ignoring stale SingletonLock after PID reuse', { pid: lockPid });
     }
   } catch {
     // ENOENT(无 packaged 实例)/EINVAL(非 symlink)——无信号。
@@ -226,10 +373,11 @@ function hasConcurrentLiveInstanceSync(
 export function hasExclusiveSharedLegacyUserDataAccess(
   userDataDir = app.getPath('userData'),
   isPidAlive: (pid: number) => boolean = isPidAliveDefault,
+  readProcessIdentity: ProcessIdentityReader = readProcessIdentityDefault,
 ): boolean {
   return (
     process.env.XDT_PASSIVE_SHARED_USER_DATA !== '1' &&
-    !hasConcurrentLiveInstanceSync(userDataDir, isPidAlive)
+    !hasConcurrentLiveInstanceSync(userDataDir, isPidAlive, readProcessIdentity)
   );
 }
 
@@ -254,8 +402,11 @@ export function hasLegacyOwnerNamespaceClaim(
   ownerId: string,
   userDataDir = app.getPath('userData'),
   isPidAlive: (pid: number) => boolean = isPidAliveDefault,
+  readProcessIdentity: ProcessIdentityReader = readProcessIdentityDefault,
 ): boolean {
-  if (!hasExclusiveSharedLegacyUserDataAccess(userDataDir, isPidAlive)) return false;
+  if (!hasExclusiveSharedLegacyUserDataAccess(userDataDir, isPidAlive, readProcessIdentity)) {
+    return false;
+  }
   try {
     const parsed = JSON.parse(
       fsSync.readFileSync(path.join(userDataDir, CLAIM_MARKER), 'utf-8'),
@@ -542,6 +693,7 @@ export function getLegacyGhostRecoveryStatus(
     rejectReservedIds?: boolean;
   } = {},
   isPidAlive: (pid: number) => boolean = isPidAliveDefault,
+  readProcessIdentity: ProcessIdentityReader = readProcessIdentityDefault,
 ): LegacyGhostRecoveryStatus {
   if (boundaryPending || session.mode !== 'cloud' || !session.dataOwnerId || !session.user) {
     return NO_LEGACY_GHOST_RECOVERY;
@@ -584,7 +736,7 @@ export function getLegacyGhostRecoveryStatus(
   if (process.env.XDT_PASSIVE_SHARED_USER_DATA === '1') {
     return { state: 'deferred', legacyPluginCount, canRetry: false };
   }
-  if (hasConcurrentLiveInstanceSync(root, isPidAlive)) {
+  if (hasConcurrentLiveInstanceSync(root, isPidAlive, readProcessIdentity)) {
     return { state: 'deferred', legacyPluginCount, canRetry: false };
   }
 
@@ -1199,14 +1351,16 @@ async function findConcurrentLiveInstancePids(
       if (isMissing(error)) continue;
       throw error;
     }
-    let record: Partial<{ pid: number; userDataDir: string }>;
+    let record: RegisteredInstanceRecord;
     try {
-      record = JSON.parse(raw) as Partial<{ pid: number; userDataDir: string }>;
+      record = JSON.parse(raw) as RegisteredInstanceRecord;
     } catch {
       continue; // torn leftover, never a live registration
     }
     const pid = record.pid;
-    if (typeof pid !== 'number' || !Number.isInteger(pid) || pid === selfPid) continue;
+    if (typeof pid !== 'number' || !Number.isInteger(pid) || pid <= 0 || pid === selfPid) {
+      continue;
+    }
     // 只认同一 userData 的记录;userDataDir 不一致说明是异常拷贝进来的残留。
     if (
       typeof record.userDataDir === 'string' &&
@@ -1214,7 +1368,16 @@ async function findConcurrentLiveInstancePids(
     ) {
       continue;
     }
-    if (deps.isPidAlive(pid)) pids.push(pid);
+    if (!deps.isPidAlive(pid)) continue;
+    const identity = readProcessIdentitySafely(
+      deps.readProcessIdentity ?? readProcessIdentityDefault,
+      pid,
+    );
+    if (recordedPidMayStillBeLive(record.startedAtMs, record.rootDir, identity)) {
+      pids.push(pid);
+    } else {
+      log.info('ignoring stale instance registry record after PID reuse', { pid });
+    }
   }
 
   // 追溯 fallback:本补丁之前的 packaged build 不写注册表,但 Chromium 单例锁是
@@ -1225,17 +1388,33 @@ async function findConcurrentLiveInstancePids(
   // win32 的 Chromium 用命名 mutex 无文件可查,该平台的历史盲区随 release 升级
   // 消失。best-effort:读不出/解析不出不阻塞(Chromium 自身会清理重建锁)。
   try {
-    const lockTarget = await deps.readlink(path.join(userDataDir, 'SingletonLock'));
+    const lockPath = path.join(userDataDir, 'SingletonLock');
+    const lockTarget = await deps.readlink(lockPath);
     const match = /-(\d+)$/.exec(lockTarget);
     const lockPid = match ? Number(match[1]) : null;
     if (
       lockPid !== null &&
       Number.isInteger(lockPid) &&
+      lockPid > 0 &&
       lockPid !== selfPid &&
       !pids.includes(lockPid) &&
       deps.isPidAlive(lockPid)
     ) {
-      pids.push(lockPid);
+      let lockMtimeMs: number | undefined;
+      try {
+        lockMtimeMs = (await deps.lstat(lockPath)).mtimeMs;
+      } catch {
+        // Missing provenance keeps the old fail-closed live-PID behavior.
+      }
+      const identity = readProcessIdentitySafely(
+        deps.readProcessIdentity ?? readProcessIdentityDefault,
+        lockPid,
+      );
+      if (recordedPidMayStillBeLive(lockMtimeMs, undefined, identity)) {
+        pids.push(lockPid);
+      } else {
+        log.info('ignoring stale SingletonLock after PID reuse', { pid: lockPid });
+      }
     }
   } catch {
     // ENOENT(无 packaged 实例)/EINVAL(非 symlink,如 win32 lockfile)——无信号。


### PR DESCRIPTION
## 这次改了什么

### 摘要

v0.1.44 引入 owner namespace 迁移并发保护后，旧 `.dev-instances` 记录只按 PID 是否存活判断。macOS 等系统复用 PID 时，已经退出的 Cindy 记录可能碰巧指向 Chrome 或系统进程，迁移便会永久误判为“另一个 Cindy 实例仍在运行”，导致旧侧栏置顶、凭证、IM、旧插件等数据一直无法进入账号命名空间。

本 PR 为共享迁移并发门补充进程身份校验：同时比较记录时间、当前 OS 进程启动时间和命令。只有能明确证明 PID 已被非 Cindy/Electron 进程复用时才忽略旧记录；身份缺失、查询失败或仍像 Cindy/Electron 时继续 fail-closed。旧 `SingletonLock` 的 PID fallback 使用同一判据。

受影响用户升级后无需手工修复：现有 owner claim 会在下次独占启动自动重试，缺失的账号侧栏文件也会从仍保留的旧 `sidebar-settings.json` 自动初始化。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：近期更新后置顶项目缺失；补救已被迁移并发门误阻塞的存量用户
- 本 PR 包含：同步/异步共享迁移门、`.dev-instances` 与 `SingletonLock` 的 PID 复用识别；对应回归测试
- 明确不包含：新增覆盖式 migration、删除历史记录、手工修复按钮、UI 改动
- 用户可见变化：此前迁移被错误阻塞的用户，下次正常独占启动后会自动恢复旧置顶及其他待迁移数据
- 是否存在 breaking change：无

### UI 变化

不涉及。

- 引用的设计规范：不涉及：仅修改 Desktop main 进程迁移并发判定与单元测试

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/__tests__/ownerNamespaceMigration.test.ts
结果：62/62 通过

pnpm --filter desktop run --if-present typecheck
结果：通过

bash /Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh /Users/dash/Code/Cindy/cindy-fix-sidebar-migration-self-heal
结果：完整 test:unit 通过；Desktop、Mobile 与全部适用 workspace 均 PASS

pnpm check:dco
结果：1 个提交签名通过

git diff --check origin/main...HEAD
结果：通过
```

### 手工验证

不涉及 UI。使用本机历史备份确认旧 Cindy PID 记录当前已分别被 Chrome/系统进程复用；本 PR 的判据会识别这些记录为陈旧并允许现有迁移重试。

### 未执行的验证

- 未在 Windows 实机执行 PowerShell 进程身份查询；使用依赖注入覆盖了成功、身份不可读与 fail-closed 行为，Windows 路径由 CI typecheck/单测继续兜底
- 未对两个历史文件执行整文件 Prettier 重写：它们在本 PR 基线即不符合当前 Prettier 3.9 输出，整文件重写会制造大量无关格式 diff；当前改动已通过 `git diff --check`

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅在共享 legacy userData 迁移门检测到“记录 PID 存活”时额外读取该 PID 的 OS 启动时间和命令；查询超时或不确定时仍按旧行为推迟
- 安全边界：只有“当前进程明显晚于记录且明确不是 Cindy/Electron”时放行；保留 60 秒容差，不自动删除旧记录，避免竞态
- 存量插件影响：无。未修改插件批准状态、指纹、manifest、安装布局或包格式；只是恢复此前被共享迁移门误阻塞的旧插件恢复流程
- 回滚 / 降级方式：回滚本提交即可恢复为纯 PID 存活判定；不会删除或覆盖旧数据文件

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因

