### PR TITLE
fix(desktop): 修复区域 userData 与共享实例登录态隔离

### DIFF
--- a/apps/desktop/src/main/__tests__/authPassiveSharedInstance.test.ts
+++ b/apps/desktop/src/main/__tests__/authPassiveSharedInstance.test.ts
@@ -11,9 +11,9 @@ import { describe, expect, it } from 'vitest';
  * 的 auth 持久状态——refresh token 文件、服务端 device token(登出会连坐作废)、
  * relogin marker(一次性,被消费掉 primary 就看不到)、canary flag、账号删除 receipt。
  *
- * 约束的是破坏性动作,不是写入本身:passive 照常续期并写回轮换后的新 token(写入的
- * 是有效凭证,primary 侧由 replacement-retry 消化);停掉续期反而会让它的 access
- * token 过期后没有任何自愈路径。
+ * 约束的是破坏性动作,不是已知 realm 会话的轮换写回:passive 照常续期并写回
+ * 有效的新 token,primary 侧由 replacement-retry 消化。但旧版裸 token 格式没有 realm,
+ * passive 无权猜测并把它迁移成本区会话。
  *
  * 2026-07-27 事故:两个 MIGRATE_FAILED 的 passive 实例(05:30 与 07:51)在 LocalDbGate
  * fatal 界面点「返回登录」,logout 删掉整机 refresh token;正在使用的 primary 分别在
@@ -155,7 +155,8 @@ describe('passive shared-userData instance auth isolation', () => {
     const body = authSource.slice(start, end);
 
     // dev + packaged 共库双开是受支持的场景（--preserve-running）：老构建的 primary
-    // 可能仍在消费三个 legacy 文件，passive 只能写入新原子记录，不能删除旧文件。
+    // 可能仍在消费三个 legacy 文件，passive 不能删除它们，也不能给没有
+    // realm 的裸 token 擅自分区。
     expect(body).toContain('if (!isPassiveSharedUserDataInstance()) {');
     const guardIdx = body.indexOf('if (!isPassiveSharedUserDataInstance()) {');
     expect(body.indexOf('removeSafe(LEGACY_REFRESH_TOKEN_KEY);')).toBeGreaterThan(guardIdx);
@@ -163,13 +164,24 @@ describe('passive shared-userData instance auth isolation', () => {
     const legacyTokenIdx = body.indexOf(
       'const legacyToken = readSafe(LEGACY_RESOURCE_REFRESH_TOKEN_KEY);',
     );
-    const migrationGuardIdx = body.indexOf(
-      'if (!isPassiveSharedUserDataInstance()) {',
+    const ambiguousRealmGuardIdx = body.indexOf(
+      'if (legacyToken && isPassiveSharedUserDataInstance()) {',
       legacyTokenIdx,
     );
-    expect(migrationGuardIdx).toBeGreaterThan(legacyTokenIdx);
+    expect(ambiguousRealmGuardIdx).toBeGreaterThan(legacyTokenIdx);
+    const migrationWriteIdx = body.indexOf(
+      'writePersistedAuthSession(legacyToken, AUTH_REGION)',
+      legacyTokenIdx,
+    );
+    expect(migrationWriteIdx).toBeGreaterThan(ambiguousRealmGuardIdx);
+    const passiveBranch = body.slice(ambiguousRealmGuardIdx, migrationWriteIdx);
+    expect(passiveBranch).toContain('passiveLocalSignOut = true;');
+    expect(passiveBranch).toContain("commitActiveAppSession('signed-out');");
+    expect(passiveBranch).toContain('return snapshotLoggedOutAuthState();');
+    expect(passiveBranch).not.toContain('writePersistedAuthSession');
+    expect(passiveBranch).not.toContain('removeSafe(');
     expect(body.indexOf('removeSafe(LEGACY_RESOURCE_REFRESH_TOKEN_KEY);')).toBeGreaterThan(
-      migrationGuardIdx,
+      migrationWriteIdx,
     );
   });
 

--- a/apps/desktop/src/main/__tests__/claudeOrphanReaper.test.ts
+++ b/apps/desktop/src/main/__tests__/claudeOrphanReaper.test.ts
@@ -63,7 +63,7 @@ describe('reapClaudeOrphansSync', () => {
     logger.warn.mockReset();
   });
 
-  it('kills current main-process children and historical xdt-maker orphans', async () => {
+  it('kills current main-process children and historical same-region orphans', async () => {
     const selfChildPid = 111;
     const historicalPid = 222;
     const livePeerPid = 333;
@@ -72,8 +72,8 @@ describe('reapClaudeOrphansSync', () => {
       if (file === 'taskkill') return '';
       return [
         `${selfChildPid}|${process.pid}|C:\\tools\\claude.exe`,
-        `${historicalPid}|99999|C:\\Users\\me\\AppData\\Roaming\\xdt-maker\\claude-code\\claude.exe`,
-        `${livePeerPid}|88888|C:\\Users\\me\\AppData\\Roaming\\xdt-maker\\claude-code\\claude.exe`,
+        `${historicalPid}|99999|C:\\Users\\me\\AppData\\Roaming\\CindyGlobal\\claude-code\\claude.exe`,
+        `${livePeerPid}|88888|C:\\Users\\me\\AppData\\Roaming\\CindyGlobal\\claude-code\\claude.exe`,
         `${externalPid}|77777|C:\\Users\\me\\.local\\bin\\claude.exe`,
       ].join('\n');
     });
@@ -122,8 +122,8 @@ describe('reapClaudeOrphansSync', () => {
     const execFileSync = vi.fn((file: string) => {
       if (file === 'taskkill') return '';
       return [
-        `${systemOrphanPid}|4|C:\\Users\\me\\AppData\\Roaming\\xdt-maker\\claude-code\\claude.exe`,
-        `${selfChildPid}|${process.pid}|C:\\Users\\me\\AppData\\Roaming\\xdt-maker\\claude-code\\claude.exe`,
+        `${systemOrphanPid}|4|C:\\Users\\me\\AppData\\Roaming\\CindyGlobal\\claude-code\\claude.exe`,
+        `${selfChildPid}|${process.pid}|C:\\Users\\me\\AppData\\Roaming\\CindyGlobal\\claude-code\\claude.exe`,
       ].join('\n');
     });
     const killSpy = vi.spyOn(process, 'kill').mockImplementation((() => true) as typeof process.kill);
@@ -136,14 +136,14 @@ describe('reapClaudeOrphansSync', () => {
     expect(killSpy).not.toHaveBeenCalled();
   });
 
-  it('matches all xdt-maker Claude binary path markers', async () => {
+  it('matches all current Global Claude binary path marker shapes', async () => {
     const pids = [701, 702, 703];
     const execFileSync = vi.fn((file: string) => {
       if (file === 'taskkill') return '';
       return [
-        `${pids[0]}|4|C:\\Users\\me\\AppData\\Roaming\\xdt-maker\\claude-code\\claude.exe`,
-        `${pids[1]}|4|C:/Users/me/AppData/Roaming/xdt-maker/claude-code/claude.exe`,
-        `${pids[2]}|4|/Users/me/Library/Application Support/xdt-maker/claude-code/claude`,
+        `${pids[0]}|4|C:\\Users\\me\\AppData\\Roaming\\CindyGlobal\\claude-code\\claude.exe`,
+        `${pids[1]}|4|C:/Users/me/AppData/Roaming/CindyGlobal/claude-code/claude.exe`,
+        `${pids[2]}|4|/Users/me/Library/Application Support/CindyGlobal/claude-code/claude`,
       ].join('\n');
     });
     const { reapClaudeOrphansSync } = await importReaper({ platform: 'win32', execFileSync });
@@ -158,6 +158,24 @@ describe('reapClaudeOrphansSync', () => {
         expect.objectContaining({ stdio: 'ignore' }),
       );
     }
+  });
+
+  it('does not claim historical CN xdt-maker processes from a Global build', async () => {
+    const cnHistoricalPid = 704;
+    const execFileSync = vi.fn((file: string) => {
+      if (file === 'taskkill') return '';
+      return `${cnHistoricalPid}|4|C:\\Users\\me\\AppData\\Roaming\\xdt-maker\\claude-code\\claude.exe`;
+    });
+    const { reapClaudeOrphansSync } = await importReaper({ platform: 'win32', execFileSync });
+
+    const result = reapClaudeOrphansSync();
+
+    expect(result.killedHistoricalOrphans).toBe(0);
+    expect(execFileSync).not.toHaveBeenCalledWith(
+      'taskkill',
+      expect.anything(),
+      expect.anything(),
+    );
   });
 
   it('does not throw when scanning fails', async () => {
@@ -281,7 +299,7 @@ describe('reapClaudeOrphansSync', () => {
     const lowercasePid = 801;
     const execFileSync = vi.fn((file: string) => {
       if (file === 'taskkill') return '';
-      return `${lowercasePid}|4|C:\\users\\me\\appdata\\roaming\\xdt-maker\\claude-code\\claude.exe`;
+      return `${lowercasePid}|4|C:\\users\\me\\appdata\\roaming\\cindyglobal\\claude-code\\claude.exe`;
     });
     const { reapClaudeOrphansSync } = await importReaper({ platform: 'win32', execFileSync });
 

--- a/apps/desktop/src/main/__tests__/devStartupStatus.test.ts
+++ b/apps/desktop/src/main/__tests__/devStartupStatus.test.ts
@@ -38,6 +38,7 @@ describe('devStartupStatus', () => {
       rootDir: path.join(tempDir, 'repo'),
       commit: 'abc123',
       mode: 'remote',
+      region: 'cn',
       passive: true,
       isolated: false,
       pid: 4242,
@@ -67,6 +68,7 @@ describe('devStartupStatus', () => {
       state: 'ready',
       rootDir: path.join(tempDir, 'repo'),
       mode: 'remote',
+      region: 'cn',
       passive: true,
     });
   });

--- a/apps/desktop/src/main/__tests__/regionUserData.test.ts
+++ b/apps/desktop/src/main/__tests__/regionUserData.test.ts
@@ -2,10 +2,9 @@ import { describe, expect, it } from 'vitest';
 import { resolveRegionUserDataDirName } from '../regionUserData';
 
 /**
- * 同机双装的核心不变量:cn 构建 / dev 完全不动 Electron 默认 userData
- * (线上 cn 包行为零变化),global packaged 构建切到独立目录。
- * 这个函数跑在 main 入口最早期,回归 = 两个区域的包共库串台(P0),
- * 所以把所有象限全部锁死。
+ * 同机双装的核心不变量:保持已发布的 cn=Cindy、global=CindyGlobal 映射，数据库 /
+ * 登录态 / 单实例锁 / sessionData 随 userData 目录天然隔离。此模块跑在 main 入口
+ * 最早期，回归 = 两个区域的包共库串台(P0)，所以把所有象限全部锁死。
  */
 describe('resolveRegionUserDataDirName', () => {
   const ARGV = ['Cindy.exe'] as const;
@@ -22,16 +21,19 @@ describe('resolveRegionUserDataDirName', () => {
     ).toBeNull();
   });
 
-  it('dev(非 packaged)任何区域都不覆写(隔离语义归 --isolated)', () => {
+  it('dev(非 packaged)按区域选择正式 profile，隔离沙箱再基于它派生', () => {
     expect(
       resolveRegionUserDataDirName({ isPackaged: false, region: 'cn', argv: ARGV }),
     ).toBeNull();
     expect(
       resolveRegionUserDataDirName({ isPackaged: false, region: 'global', argv: ARGV }),
-    ).toBeNull();
+    ).toBe('CindyGlobal');
+    expect(
+      resolveRegionUserDataDirName({ isPackaged: false, region: 'dev', argv: ARGV }),
+    ).toBe('CindyDev');
   });
 
-  it('显式 --user-data-dir(smoke 脚本临时目录)时不覆写,尊重调用方', () => {
+  it('显式 --user-data-dir 或 XDT_USER_DATA_DIR 时不覆写,尊重调用方', () => {
     expect(
       resolveRegionUserDataDirName({
         isPackaged: true,
@@ -39,7 +41,6 @@ describe('resolveRegionUserDataDirName', () => {
         argv: ['Cindy.exe', '--smoke-test', '--user-data-dir=C:\\tmp\\xdt-smoke-x'],
       }),
     ).toBeNull();
-    // 空格分隔形态同样尊重。
     expect(
       resolveRegionUserDataDirName({
         isPackaged: true,
@@ -47,5 +48,21 @@ describe('resolveRegionUserDataDirName', () => {
         argv: ['Cindy.exe', '--user-data-dir', 'C:\\tmp\\xdt-smoke-x'],
       }),
     ).toBeNull();
+    expect(
+      resolveRegionUserDataDirName({
+        isPackaged: false,
+        region: 'global',
+        argv: ARGV,
+        envUserDataDir: '/tmp/custom-profile',
+      }),
+    ).toBeNull();
+    expect(
+      resolveRegionUserDataDirName({
+        isPackaged: true,
+        region: 'global',
+        argv: ARGV,
+        envUserDataDir: '/tmp/ambient-dev-only-profile',
+      }),
+    ).toBe('CindyGlobal');
   });
 });

--- a/apps/desktop/src/main/__tests__/regionUserData.test.ts
+++ b/apps/desktop/src/main/__tests__/regionUserData.test.ts
@@ -33,7 +33,7 @@ describe('resolveRegionUserDataDirName', () => {
     ).toBe('CindyDev');
   });
 
-  it('显式 --user-data-dir 或 XDT_USER_DATA_DIR 时不覆写,尊重调用方', () => {
+  it('显式 Chromium --user-data-dir 时不覆写,尊重调用方', () => {
     expect(
       resolveRegionUserDataDirName({
         isPackaged: true,
@@ -48,20 +48,15 @@ describe('resolveRegionUserDataDirName', () => {
         argv: ['Cindy.exe', '--user-data-dir', 'C:\\tmp\\xdt-smoke-x'],
       }),
     ).toBeNull();
+  });
+
+  it('XDT_USER_DATA_DIR 仍保留区域默认 profile 作为隔离 epoch 基线', () => {
     expect(
       resolveRegionUserDataDirName({
         isPackaged: false,
         region: 'global',
         argv: ARGV,
         envUserDataDir: '/tmp/custom-profile',
-      }),
-    ).toBeNull();
-    expect(
-      resolveRegionUserDataDirName({
-        isPackaged: true,
-        region: 'global',
-        argv: ARGV,
-        envUserDataDir: '/tmp/ambient-dev-only-profile',
       }),
     ).toBe('CindyGlobal');
   });

--- a/apps/desktop/src/main/authManager.ts
+++ b/apps/desktop/src/main/authManager.ts
@@ -2058,14 +2058,22 @@ export async function initialize(options: AuthInitializeOptions = {}): Promise<A
   }
   let persistedSession = readPersistedAuthSession();
   if (!persistedSession) {
-    // 旧版只保存裸 refresh token；迁移时按安装包区域解释，并以单个加密 JSON
-    // 原子记录替代，确保 token 与 realm 永不分离。passive 可以写入有效的新记录，
-    // 但旧文件仍留给可能正在消费它的旧版 primary。
+    // 旧版只保存裸 refresh token，没有 realm 可供校验。只有独占 userData 的
+    // primary 才能按当前构建区域迁移它；passive 若猜 AUTH_REGION，恰好会在旧
+    // cn / global 共库时把对端 token 认领成本区会话，随后 refresh 轮换并改写
+    // primary 的凭证。这里 fail closed：保留旧文件，本进程稳定保持登出，等
+    // 同区域的独占实例完成原子迁移。
     const legacyToken = readSafe(LEGACY_RESOURCE_REFRESH_TOKEN_KEY);
+    if (legacyToken && isPassiveSharedUserDataInstance()) {
+      log.warn(
+        'passive shared-userData instance found an unscoped legacy refresh token; refusing to assign a realm or rotate it',
+      );
+      passiveLocalSignOut = true;
+      commitActiveAppSession('signed-out');
+      return snapshotLoggedOutAuthState();
+    }
     if (legacyToken && writePersistedAuthSession(legacyToken, AUTH_REGION)) {
-      if (!isPassiveSharedUserDataInstance()) {
-        removeSafe(LEGACY_RESOURCE_REFRESH_TOKEN_KEY);
-      }
+      removeSafe(LEGACY_RESOURCE_REFRESH_TOKEN_KEY);
       persistedSession = { version: 1, realm: AUTH_REGION, refreshToken: legacyToken };
     }
   }

--- a/apps/desktop/src/main/bootstrap-electron.ts
+++ b/apps/desktop/src/main/bootstrap-electron.ts
@@ -232,7 +232,7 @@ import {
 } from './file-browser/remote-file-cache';
 import { sweepStartupDraftImages } from './imageCacheOrphanSweep';
 import { sweepLegacyDialogueWorkingDirs } from './localDb/dialogueWorkdirSelfHeal';
-import { BRAND_IDENTITY } from '@cindy/maker-shared/brand-identity';
+import { legacyDialogueUserDataDirNames } from '@cindy/maker-shared/brand-identity';
 import * as videoCacheStore from './videoCacheStore';
 import { imageSchemePrivilege, registerImageProtocolHandler } from './imageProtocol';
 import { videoSchemePrivilege, registerVideoProtocolHandler } from './videoProtocol';
@@ -641,7 +641,7 @@ import {
 } from './deepLink.js';
 import { registerFolderContextMenu } from './folderContextMenu.js';
 import { healWindowsShortcuts } from './windowsShortcutSelfHeal.js';
-import { CURRENT_APP_ID } from '../shared/brandRegion.js';
+import { CURRENT_APP_ID, CURRENT_CINDY_REGION } from '../shared/brandRegion.js';
 import {
   readWindowBehaviorSettings,
   writeSwallowActivationClick,
@@ -6682,7 +6682,7 @@ app.on('ready', async () => {
         await sweepLegacyDialogueWorkingDirs({
           db: getDbClient(),
           userDataDir: app.getPath('userData'),
-          legacyUserDataDirNames: BRAND_IDENTITY.legacyUserDataDirNames,
+          legacyUserDataDirNames: legacyDialogueUserDataDirNames(CURRENT_CINDY_REGION),
           currentDialoguesRoot: ownerScopedUserDataPath('dialogues'),
           additionalLegacyDialogueRoots: [path.join(app.getPath('userData'), 'dialogues')],
           log: createLogger('dialogue-workdir-self-heal'),

--- a/apps/desktop/src/main/claude-orphan-reaper.ts
+++ b/apps/desktop/src/main/claude-orphan-reaper.ts
@@ -18,8 +18,8 @@
  * Safety guarantees:
  *   - Current-session cleanup only targets `claude` processes whose parent is
  *     the current Electron main process.
- *   - Historical cleanup requires both an xdt-maker bundled Claude binary path
- *     marker and a dead parent, so an active second xdt-maker instance is left
+ *   - Historical cleanup requires both a bundled Claude path marker owned by
+ *     this build region and a dead parent, so an active peer instance is left
  *     alone.
  *   - External Claude installs (for example `/usr/local/bin/claude`) do not
  *     contain the xdt-maker marker and are not historical-orphan candidates.
@@ -41,10 +41,9 @@ const log = createLogger('claude-orphan-reaper');
  * normalize (e.g. `appdata\roaming\...`) still match. Update the path shape if
  * the packaged Claude binary ever moves out of `userData/claude-code/`.
  *
- * Markers cover every current + historical userData dir name (brand-identity
- * `legacyUserDataDirNames`): while retaining compatibility with legacy profiles, orphans
- * spawned by the pre-rename install still carry the old dir name in their
- * command line and must keep being recognized.
+ * Markers cover the current + historical userData dir names owned by this build
+ * region. The old `xdt-maker` install belonged to the CN release lineage; a
+ * Global build must not use it to claim or kill the other edition's processes.
  */
 export function buildClaudePathMarkers(dirNames: readonly string[]): string[] {
   return dirNames.flatMap((dirName) => {
@@ -281,7 +280,7 @@ export function killProcessTree(pid: number, childrenByParent: Map<number, numbe
 
 /**
  * Synchronously reaps Claude Code process trees owned by this app instance, plus
- * historical xdt-maker bundled Claude processes whose parent has already died.
+ * historical same-region bundled Claude processes whose parent has already died.
  */
 export function reapClaudeOrphansSync(): ReaperResult {
   const start = Date.now();

--- a/apps/desktop/src/main/devStartupStatus.ts
+++ b/apps/desktop/src/main/devStartupStatus.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
+import type { CindyRegion } from '@cindy/maker-shared/brand-identity';
 
 export type DesktopDevMode = 'remote' | 'local' | 'unknown';
 export type DesktopDevInstanceState = 'starting' | 'ready' | 'failed';
@@ -24,6 +25,8 @@ export interface DesktopDevInstanceRecord {
   rootDir: string;
   commit: string | null;
   mode: DesktopDevMode;
+  /** 构建区域；共享 userData 启动器据此拒绝跨区域 passive 预览。 */
+  region: CindyRegion;
   passive: boolean;
   isolated: boolean;
   userDataDir: string;
@@ -40,6 +43,7 @@ export interface BeginDesktopDevInstanceOptions {
   rootDir: string;
   commit?: string | null;
   mode?: DesktopDevMode;
+  region?: CindyRegion;
   passive: boolean;
   isolated: boolean;
   pid?: number;
@@ -132,6 +136,7 @@ export function beginDesktopDevInstance(
     rootDir: path.resolve(options.rootDir),
     commit: options.commit ?? null,
     mode: options.mode ?? 'unknown',
+    region: options.region ?? 'global',
     passive: options.passive,
     isolated: options.isolated,
     userDataDir: path.resolve(options.userDataDir),

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -11,15 +11,15 @@ import { createLogger, initLogger } from './logger.js';
 import { beginDesktopDevInstance, type DesktopDevMode } from './devStartupStatus.js';
 import { ensureSystemBinPathForMachineId } from './deviceId.js';
 
-// 同机双装(cn/global):global 构建把 userData 切到区域目录(CindyGlobal),
-// 与 cn 版(productName 默认 'Cindy')彻底分库;数据库 / 登录态 / 单实例锁 /
-// sessionData 随 userData 目录天然隔离。必须在 initLogger()(packaged 日志
-// 目录)、crashReporter、单实例锁与一切 userData 读取之前执行。cn 构建与
-// dev 返回 null,零行为变化(dev 隔离语义由下方 devCliFlags 的 --isolated 承载)。
+// 正式目录保持历史兼容：global 构建继续使用 CindyGlobal，cn 版继续使用
+// productName 默认的 Cindy；dev 也按构建区域选择对应 profile。必须在
+// initLogger()(packaged 日志目录)、crashReporter、单实例锁与一切 userData
+// 读取之前完成区域映射。
 const regionUserDataDirName = resolveRegionUserDataDirName({
   isPackaged: app.isPackaged,
   region: CURRENT_CINDY_REGION,
   argv: process.argv,
+  envUserDataDir: process.env.XDT_USER_DATA_DIR,
 });
 if (regionUserDataDirName) {
   app.setPath('userData', path.join(app.getPath('appData'), regionUserDataDirName));
@@ -226,6 +226,7 @@ if (devFlags.needsIsolatedDeviceId) {
     rootDir,
     commit,
     mode,
+    region: CURRENT_CINDY_REGION,
     passive: devFlags.schedulerPassive,
     isolated: Boolean(devFlags.userDataDirOverride),
   });

--- a/apps/desktop/src/main/legacyUserDataMigration.ts
+++ b/apps/desktop/src/main/legacyUserDataMigration.ts
@@ -30,7 +30,10 @@
 import originalFs from 'original-fs';
 import path from 'node:path';
 import { app, BrowserWindow, ipcMain } from 'electron';
-import { BRAND_IDENTITY } from '@cindy/maker-shared/brand-identity';
+import {
+  BRAND_IDENTITY,
+  legacyBrandUserDataDirNames,
+} from '@cindy/maker-shared/brand-identity';
 import { CURRENT_CINDY_REGION } from '../shared/brandRegion.js';
 
 import { createLogger } from './logger';
@@ -617,7 +620,7 @@ export async function runLegacyUserDataMigrationForUser(userId: string): Promise
   }
   inFlight = runLegacyUserDataMigration(userId, {
     userDataDir: app.getPath('userData'),
-    legacyDirNames: BRAND_IDENTITY.legacyUserDataDirNames,
+    legacyDirNames: legacyBrandUserDataDirNames(),
     legacyDbPrefixes: BRAND_IDENTITY.legacyDbFilePrefixes,
     currentDbPrefix: BRAND_IDENTITY.dbFilePrefix,
     fs: realFsDeps,

--- a/apps/desktop/src/main/localDb/dialogueWorkdirSelfHeal.ts
+++ b/apps/desktop/src/main/localDb/dialogueWorkdirSelfHeal.ts
@@ -112,7 +112,7 @@ export interface SweepLegacyDialogueWorkingDirsDeps {
   db: DialogueSweepDb;
   /** 当前 userData 绝对路径。 */
   userDataDir: string;
-  /** legacy userData 目录名候选(BRAND_IDENTITY.legacyUserDataDirNames)。 */
+  /** 当前区域的历史 dialogue userData 目录名候选。 */
   legacyUserDataDirNames: readonly string[];
   /** Explicit current owner dialogue root; defaults to userDataDir/dialogues. */
   currentDialoguesRoot?: string;

--- a/apps/desktop/src/main/maker-host/codex-local-sessions.ts
+++ b/apps/desktop/src/main/maker-host/codex-local-sessions.ts
@@ -1376,7 +1376,7 @@ function acceptStateBackedWinnerAfterRecovery(
   return winner;
 }
 
-/** 当前区域的全部历史品牌 Codex HOME;不包含当前 Cindy/CindyGlobal HOME。 */
+/** 当前区域的全部历史品牌 Codex HOME;不包含当前区域正在使用的 HOME。 */
 function legacyBrandedCodexHomes(targetHome: string): string[] {
   const userDataParent = path.dirname(path.dirname(targetHome));
   return allUserDataDirNames(CURRENT_CINDY_REGION)
@@ -3674,7 +3674,7 @@ function getDesktopCodexHome(): string {
     /* fallback for non-Electron test runners */
   }
 
-  // 兜底路径按区域取目录名(global 构建的 userData 是 CindyGlobal,同机双装分库)。
+  // 兜底路径按现有区域目录映射取值(global=CindyGlobal,cn=Cindy，同机双装分库)。
   const dirName = brandUserDataDirName(CURRENT_CINDY_REGION);
   if (process.platform === 'darwin') {
     return path.join(os.homedir(), 'Library', 'Application Support', dirName, 'codex-home');

--- a/apps/desktop/src/main/process-monitor/__tests__/agent-scan.test.ts
+++ b/apps/desktop/src/main/process-monitor/__tests__/agent-scan.test.ts
@@ -79,7 +79,7 @@ describe('classifyMonitoredAgentCommandLine', () => {
   it('识别 pi 静态品牌 marker,不影响 claude/codex 委托', () => {
     const piMarkers = buildPiPathMarkers(['cindy']);
     expect(piMarkers).toContain('appdata\\roaming\\cindy\\pi\\');
-    // 品牌目录名随构建配置变化(如 CindyGlobal / 历史 xdt-maker),测试从真实
+    // 品牌目录名随构建配置变化(如 Cindy / CindyGlobal / 历史 xdt-maker),测试从真实
     // 品牌清单派生 probe,不写死品牌名。
     const brandDir = allUserDataDirNames(CURRENT_CINDY_REGION)[0].toLowerCase();
     expect(

--- a/apps/desktop/src/main/regionUserData.ts
+++ b/apps/desktop/src/main/regionUserData.ts
@@ -13,10 +13,9 @@
  *    保持 Electron 原生行为(线上 cn 包与历史行为完全一致)。
  *  - 非 packaged 启动同样按区域选正式 profile；`--isolated` 再由 devCliFlags
  *    基于这个区域目录派生 `<区域目录>-dev2[-<名字>]`。
- *  - 命令行显式传了 Chromium 原生 `--user-data-dir`，或环境已显式设置
- *    `XDT_USER_DATA_DIR` 时返回 null，尊重调用方
- *    (smoke-packaged.mjs 用它把假库指到 os.tmpdir 临时目录;覆写会让 global
- *    包的 smoke 数据写进真实 CindyGlobal 目录、临时目录清了个空)。
+ *  - 命令行显式传了 Chromium 原生 `--user-data-dir` 时返回 null，尊重调用方。
+ *    `XDT_USER_DATA_DIR` 是 devCliFlags 的最终覆写；这里仍先建立区域默认
+ *    profile，确保隔离 epoch comparison 以 CindyGlobal / Cindy / CindyDev 为基线。
  *  - 只决定**目录名**,拼绝对路径(appData 基址)留给调用方——本模块保持
  *    零 Electron 依赖,可直接单测。
  */
@@ -43,9 +42,6 @@ export function resolveRegionUserDataDirName(input: {
   envUserDataDir?: string;
 }): string | null {
   if (hasExplicitUserDataDir(input.argv)) return null;
-  // XDT_USER_DATA_DIR is a dev-only override. Packaged builds must keep their
-  // published region mapping even if an ambient shell variable leaks in.
-  if (!input.isPackaged && input.envUserDataDir?.trim()) return null;
   const dirName = brandUserDataDirName(input.region);
   // 与 productName 默认派生目录同名(cn)→ 不覆写,走 Electron 原生路径。
   if (dirName === BRAND_IDENTITY.userDataDirName) return null;

--- a/apps/desktop/src/main/regionUserData.ts
+++ b/apps/desktop/src/main/regionUserData.ts
@@ -1,19 +1,20 @@
 /**
- * regionUserData — packaged 构建按区域切换 Electron userData 目录(同机双装)。
+ * regionUserData — 按构建区域选择 Electron userData 目录。
  *
  * 背景:cn / global 是两个可同机并存的系统身份(appId / exe / 安装目录已按
  * 区域派生),但 Electron 默认 userData 目录由 package.json productName('Cindy')
  * 派生,两个区域的包会共用同一目录——数据库 / 登录态 / 单实例锁全部串台。
- * 因此 global 构建在 main 入口最早期(initLogger、crashReporter、单实例锁、
- * 一切 userData 读取之前)把 userData 切到区域目录(%APPDATA%\CindyGlobal /
- * ~/Library/Application Support/CindyGlobal),与 cn 版彻底分库。
+ * 因此 global 构建与 dev 启动都在 main 入口最早期(initLogger、crashReporter、
+ * 单实例锁、一切 userData 读取之前)把 userData 切到当前区域目录。正式目录保持
+ * 历史兼容：cn=`Cindy`、global=`CindyGlobal`；内部 dev 身份使用 `CindyDev`。
  *
  * 语义边界:
  *  - cn 构建的区域目录名 = productName 默认派生目录 → 返回 null,零改动,
  *    保持 Electron 原生行为(线上 cn 包与历史行为完全一致)。
- *  - dev(非 packaged)永远返回 null:dev 的隔离语义由 --isolated /
- *    XDT_USER_DATA_DIR(devCliFlags)承载,不与区域身份耦合。
- *  - 命令行显式传了 Chromium 原生 `--user-data-dir` 时返回 null,尊重调用方
+ *  - 非 packaged 启动同样按区域选正式 profile；`--isolated` 再由 devCliFlags
+ *    基于这个区域目录派生 `<区域目录>-dev2[-<名字>]`。
+ *  - 命令行显式传了 Chromium 原生 `--user-data-dir`，或环境已显式设置
+ *    `XDT_USER_DATA_DIR` 时返回 null，尊重调用方
  *    (smoke-packaged.mjs 用它把假库指到 os.tmpdir 临时目录;覆写会让 global
  *    包的 smoke 数据写进真实 CindyGlobal 目录、临时目录清了个空)。
  *  - 只决定**目录名**,拼绝对路径(appData 基址)留给调用方——本模块保持
@@ -39,9 +40,12 @@ export function resolveRegionUserDataDirName(input: {
   isPackaged: boolean;
   region: CindyRegion;
   argv: readonly string[];
+  envUserDataDir?: string;
 }): string | null {
-  if (!input.isPackaged) return null;
   if (hasExplicitUserDataDir(input.argv)) return null;
+  // XDT_USER_DATA_DIR is a dev-only override. Packaged builds must keep their
+  // published region mapping even if an ambient shell variable leaks in.
+  if (!input.isPackaged && input.envUserDataDir?.trim()) return null;
   const dirName = brandUserDataDirName(input.region);
   // 与 productName 默认派生目录同名(cn)→ 不覆写,走 Electron 原生路径。
   if (dirName === BRAND_IDENTITY.userDataDirName) return null;

--- a/apps/desktop/src/main/skillhub/usageIndexer.ts
+++ b/apps/desktop/src/main/skillhub/usageIndexer.ts
@@ -378,7 +378,7 @@ function defaultXdtUserDataDir(
   appDataDir: string,
   env: NodeJS.ProcessEnv,
 ): string {
-  // 按区域取目录名(global 构建的 userData 是 CindyGlobal,同机双装分库)。
+  // 按现有区域目录映射取值(global=CindyGlobal,cn=Cindy，同机双装分库)。
   const dirName = brandUserDataDirName(CURRENT_CINDY_REGION);
   if (platform === 'darwin') return path.join(homeDir, 'Library', 'Application Support', dirName);
   if (platform === 'win32') return path.join(appDataDir, dirName);

--- a/apps/mobile/scripts/export-realdata-visual-snapshot.mjs
+++ b/apps/mobile/scripts/export-realdata-visual-snapshot.mjs
@@ -19,10 +19,12 @@ import { createServer } from 'node:http';
 import { createRequire } from 'node:module';
 import { randomBytes, timingSafeEqual } from 'node:crypto';
 import { basename, dirname, join, resolve } from 'node:path';
-import { homedir, tmpdir } from 'node:os';
+import { tmpdir } from 'node:os';
+import {
+  desktopUserDataDirForRegion,
+  resolveDesktopDevRegion,
+} from '../../../scripts/shared/desktop-dev-region.mjs';
 
-// 新装身份是 Cindy;旧 xdt-maker 目录仅在用户显式 --db 指过去时才碰,不再默认扫描。
-const DEFAULT_APP_SUPPORT = join(homedir(), 'Library', 'Application Support', 'Cindy');
 const DEFAULT_OUT_DIR = join(tmpdir(), 'cindy-mobile-realdata');
 const DEFAULT_LIMIT = 100;
 const DEFAULT_MESSAGE_LIMIT = 80;
@@ -39,7 +41,7 @@ const repoRoot = resolve(options.repo ?? join(import.meta.dirname, '..'));
 const requireFromRepo = createRequire(join(repoRoot, 'package.json'));
 const Database = requireFromRepo('better-sqlite3');
 
-const sourceDb = resolveDbPath(options.db, Boolean(options.confirmSensitive));
+const sourceDb = resolveDbPath(options.db, Boolean(options.confirmSensitive), options.region);
 // 私有输出目录:0700,只有当前用户可进。
 const outDir = resolve(options.outDir ?? DEFAULT_OUT_DIR);
 mkdirSync(outDir, { recursive: true });
@@ -313,7 +315,7 @@ function messageRow(row) {
 
 // DB 来源解析:显式 --db 直接用;auto 扫描属"从真实库导出敏感数据",必须显式 --confirm-sensitive
 // 才允许,避免脚本被无意运行就把整库聊天导出来。
-function resolveDbPath(input, confirmSensitive) {
+function resolveDbPath(input, confirmSensitive, region) {
   if (input && input !== 'auto') {
     const explicit = resolve(input);
     if (!existsSync(explicit)) throw new Error(`--db 指定的文件不存在: ${explicit}`);
@@ -325,17 +327,18 @@ function resolveDbPath(input, confirmSensitive) {
         '或加 `--confirm-sensitive` 明确确认要从默认目录导出敏感数据。',
     );
   }
+  const appSupport = desktopUserDataDirForRegion(region);
   const entries = [];
-  for (const name of safeReaddir(DEFAULT_APP_SUPPORT)) {
+  for (const name of safeReaddir(appSupport)) {
     if (!/^(xdt-maker|cindy)-.+\.db$/i.test(name)) continue;
-    const full = join(DEFAULT_APP_SUPPORT, name);
+    const full = join(appSupport, name);
     try {
       const stat = statSync(full);
       if (stat.isFile()) entries.push({ full, mtimeMs: stat.mtimeMs, size: stat.size });
     } catch {}
   }
   entries.sort((a, b) => b.mtimeMs - a.mtimeMs || b.size - a.size);
-  if (!entries[0]) throw new Error(`no cindy/xdt-maker *.db found in ${DEFAULT_APP_SUPPORT}`);
+  if (!entries[0]) throw new Error(`no cindy/xdt-maker *.db found in ${appSupport}`);
   return entries[0].full;
 }
 
@@ -352,10 +355,19 @@ function copySqliteBundle(source, target) {
 }
 
 function parseArgs(args) {
-  const parsed = {};
+  const parsed = {
+    region: resolveDesktopDevRegion(args, {
+      ...process.env,
+      CINDY_AUTH_REGION:
+        process.env.CINDY_AUTH_REGION ??
+        process.env.EXPO_PUBLIC_CINDY_AUTH_REGION,
+    }),
+  };
   for (let i = 0; i < args.length; i += 1) {
     const arg = args[i];
     if (arg === '--db') parsed.db = args[++i];
+    else if (arg === '--region') i += 1;
+    else if (arg.startsWith('--region=')) continue;
     else if (arg === '--out') parsed.out = args[++i];
     else if (arg === '--out-dir') parsed.outDir = args[++i];
     else if (arg === '--repo') parsed.repo = args[++i];
@@ -377,7 +389,8 @@ function parseArgs(args) {
           'dev-only 工具:导出真实会话为移动端视觉预览快照(含敏感聊天数据)。',
           '',
           '  --db <path>           指定 SQLite 库路径(推荐);省略需配 --confirm-sensitive',
-          '  --confirm-sensitive   确认从默认 Cindy 目录自动扫描真实库并导出',
+          '  --region <cn|global|dev> 选择默认 userData 区域(默认读取区域环境变量，再默认 global)',
+          '  --confirm-sensitive   确认从所选区域的默认 profile 自动扫描真实库并导出',
           '  --serve               启动 token 门禁的本地 HTTP(仅回环 + Origin 白名单)',
           '  --port <n>            serve 端口(默认 3344)',
           '  --token <str>         固定 serve token(默认每次随机生成)',

--- a/docs/dev-rules/desktop-development.md
+++ b/docs/dev-rules/desktop-development.md
@@ -59,10 +59,17 @@ Cindy 内部而拒绝重启，或因目标 userData 被其他 checkout 占用而
   passive 停止续期，会使它的 access token 过期后再无替换途径（primary 的续期只更新磁盘
   token，不更新 passive 进程的内存态，而直接走 `apiFetch` 的路径没有 401 refresh/retry）。
 - `--preserve-running`：并行 dev，不停止任何已有 Cindy dev 进程，每个新实例强制 passive
-  并共享当前 userData／登录态；仅供能证明实例归属的上层编排，或用户明确「不要关当前
-  实例／不要重新登录」时用。仅支持 remote，禁止与 `--isolated` 组合。
+  并共享当前区域的 userData／登录态；启动前必须由 `.dev-instances` 存活记录证明已运行
+  实例与目标区域一致，旧记录没有 region 或跨区域都会 fail closed。仅供能证明实例归属的
+  上层编排，或用户明确「不要关当前实例／不要重新登录」时用。仅支持 remote，禁止与
+  `--isolated` 组合。共享实例若只发现没有 realm 的旧版裸 refresh token，也不得猜区域迁移
+  或轮换，保持本进程登出，交给同区域独占实例完成凭证迁移。
 
-已手动设 `XDT_USER_DATA_DIR` 时尊重用户值，不覆盖。
+已手动设 `XDT_USER_DATA_DIR` 时尊重用户值，不覆盖，也不探测或迁移正式区域目录。
+
+正式版目录保持历史兼容：CN → `Cindy`，Global → `CindyGlobal`，不在启动时改名或搬迁用户数据。
+非隔离 dev 也使用当前区域对应的正式 profile；`--isolated` 沙箱再按相同区域映射派生目录。
+跨区域共享、登录态迁移或旧版本回滚应使用显式隔离目录，避免不同构建误用同一 profile。
 
 ### 并行多开 dev
 

--- a/packages/maker-shared/src/__tests__/brandIdentity.test.ts
+++ b/packages/maker-shared/src/__tests__/brandIdentity.test.ts
@@ -9,6 +9,8 @@ import {
   brandBundleIdPrefix,
   brandExecutableName,
   brandUserDataDirName,
+  legacyBrandUserDataDirNames,
+  legacyDialogueUserDataDirNames,
   resolveCindyRegion,
 } from '../brandIdentity.js';
 
@@ -65,7 +67,9 @@ describe('BRAND_IDENTITY invariants', () => {
 
   it('cn 区域值 = 基线标量字段(dev / legacy 消费点与 cn 构建同一身份)', () => {
     expect(BRAND_IDENTITY.executableNameByRegion.cn).toBe(BRAND_IDENTITY.executableName);
-    expect(BRAND_IDENTITY.userDataDirNameByRegion.cn).toBe(BRAND_IDENTITY.userDataDirName);
+    expect(BRAND_IDENTITY.userDataDirNameByRegion.cn).toBe(
+      BRAND_IDENTITY.userDataDirName,
+    );
   });
 
   it('scheme 符合 RFC 3986(字母开头,字母/数字/+/-/. 组成)且主 scheme 不在 legacy 里', () => {
@@ -104,6 +108,14 @@ describe('BRAND_IDENTITY invariants', () => {
     expect(Object.isFrozen(BRAND_IDENTITY.appIdByRegion)).toBe(true);
     expect(Object.isFrozen(BRAND_IDENTITY.executableNameByRegion)).toBe(true);
     expect(Object.isFrozen(BRAND_IDENTITY.userDataDirNameByRegion)).toBe(true);
+    expect(Object.isFrozen(BRAND_IDENTITY.legacyUserDataDirNamesByRegion)).toBe(true);
+    for (const names of Object.values(BRAND_IDENTITY.legacyUserDataDirNamesByRegion)) {
+      expect(Object.isFrozen(names)).toBe(true);
+    }
+    expect(Object.isFrozen(BRAND_IDENTITY.legacyDialogueUserDataDirNamesByRegion)).toBe(true);
+    for (const names of Object.values(BRAND_IDENTITY.legacyDialogueUserDataDirNamesByRegion)) {
+      expect(Object.isFrozen(names)).toBe(true);
+    }
     expect(Object.isFrozen(BRAND_IDENTITY.legacySchemes)).toBe(true);
     expect(Object.isFrozen(BRAND_IDENTITY.legacyUserDataDirNames)).toBe(true);
     expect(Object.isFrozen(BRAND_IDENTITY.legacyDbFilePrefixes)).toBe(true);
@@ -137,6 +149,7 @@ describe('区域解析与派生', () => {
     expect(brandExecutableName('dev')).toBe('CindyDev');
     expect(brandUserDataDirName()).toBe('CindyGlobal');
     expect(brandUserDataDirName('global')).toBe('CindyGlobal');
+    expect(brandUserDataDirName('cn')).toBe('Cindy');
   });
 });
 
@@ -146,11 +159,22 @@ describe('派生 helper', () => {
   });
 
   it('allUserDataDirNames 本区域目录名恒为首位 + 全部历史值,且不含另一区域', () => {
-    expect(allUserDataDirNames()).toEqual(['CindyGlobal', 'xdt-maker']);
+    expect(allUserDataDirNames()).toEqual(['CindyGlobal']);
     expect(allUserDataDirNames('cn')).toEqual(['Cindy', 'xdt-maker']);
-    // global 的匹配集不含 cn 的 'Cindy':orphan-reaper 按路径认领进程,
-    // 跨区域匹配会误杀另一个安装的进程。
-    expect(allUserDataDirNames('global')).toEqual(['CindyGlobal', 'xdt-maker']);
+    // global 的匹配集不含 cn 的 Cindy / xdt-maker：orphan-reaper 按路径认领
+    // 进程，跨区域匹配会误杀另一个安装的进程。
+    expect(allUserDataDirNames('global')).toEqual(['CindyGlobal']);
+  });
+
+  it('legacyBrandUserDataDirNames 只返回品牌翻转前的共享 mToc 来源', () => {
+    expect(legacyBrandUserDataDirNames()).toEqual(['xdt-maker']);
+  });
+
+  it('dialogue cwd 迁移来源按区域保留旧品牌目录', () => {
+    expect(legacyDialogueUserDataDirNames()).toEqual([]);
+    expect(legacyDialogueUserDataDirNames('cn')).toEqual(['xdt-maker']);
+    expect(legacyDialogueUserDataDirNames('global')).toEqual([]);
+    expect(legacyDialogueUserDataDirNames('dev')).toEqual([]);
   });
 
   it('helper 接受显式档案参数(历史身份回放用)', () => {
@@ -160,6 +184,8 @@ describe('派生 helper', () => {
       legacySchemes: [],
       userDataDirNameByRegion: { cn: 'xdt-maker', global: 'xdt-maker' },
       legacyUserDataDirNames: [],
+      legacyUserDataDirNamesByRegion: { cn: [], global: [], dev: [] },
+      legacyDialogueUserDataDirNamesByRegion: { cn: [], global: [], dev: [] },
       dbFilePrefix: 'xdt-maker',
       legacyDbFilePrefixes: [],
     };

--- a/packages/maker-shared/src/brandIdentity.ts
+++ b/packages/maker-shared/src/brandIdentity.ts
@@ -17,7 +17,7 @@
  *    com.xd.cindycn / com.xd.cindy 同一套);exe 名 cn/global 同值 'Cindy'
  *    (2026-07-26 显示名统一决策,文件层双装隔离随之放弃,dev 仍独立)。
  *  - 历史兼容锚点(旧 scheme 解析、旧 userData / DB 文件识别)由
- *    `legacySchemes` / `legacyUserDataDirNames` / `legacyDbFilePrefixes`
+ *    `legacySchemes` / `legacyUserDataDirNames(ByRegion)` / `legacyDbFilePrefixes`
  *    承载,只增不减:老用户机器上的存量注册与文件可能永远带着旧值。
  *  - 永久不随本配置变化的标识符(settings 键名 `xdtMaker.*`、
  *    `xdt-image://` 等进程内 scheme、`.cshare` 扩展名、
@@ -97,16 +97,28 @@ export interface BrandIdentity {
   /** 历史 scheme,永久保持注册 + 解析兼容(存量链接不能死)。只增不减。 */
   readonly legacySchemes: readonly string[];
   /**
-   * Electron userData 目录名(cn / dev 基线值 = package.json productName,
-   * Electron 默认派生)。区域值走 `brandUserDataDirName(region)`:global 构建
-   * 在 main 入口早期 setPath 切到区域目录,与 cn 彻底分库(数据库 / 登录态 /
-   * 单实例锁随 userData 目录天然隔离)。
+   * Electron 默认派生的 userData 目录名(= package.json productName)。已发布的
+   * cn 构建沿用该目录；global 继续使用历史独立目录 `CindyGlobal`，避免启动时
+   * 改名或搬迁用户数据。
    */
   readonly userDataDirName: string;
-  /** 按区域派生的 userData 目录名(cn 保持 productName 默认,global 独立目录)。 */
+  /** 按区域派生的 userData 目录名。 */
   readonly userDataDirNameByRegion: Readonly<Record<CindyRegion, string>>;
-  /** 历史 userData 目录名(orphan-reaper 等按路径识别的消费点需匹配全量)。只增不减。 */
+  /** 品牌翻转前的共享历史 userData 目录名(首登 mToc 迁移使用)。只增不减。 */
   readonly legacyUserDataDirNames: readonly string[];
+  /**
+   * 各区域曾经使用过的 userData 目录名。按路径识别进程的消费点只能匹配本区域，
+   * 不能把另一发行版的历史目录纳入自己的 kill / 回收范围。只增不减。
+   */
+  readonly legacyUserDataDirNamesByRegion: Readonly<
+    Record<CindyRegion, readonly string[]>
+  >;
+  /**
+   * 各区域的 sessions.working_dir 迁移来源。它与进程路径归属清单故意分离。
+   */
+  readonly legacyDialogueUserDataDirNamesByRegion: Readonly<
+    Record<CindyRegion, readonly string[]>
+  >;
   /**
    * 更新分发 CDN / OSS 的一级路径前缀(渠道身份,老客户端永远只看自己的前缀)。
    * ⚠️ 两区共用(owner 决策 2026-07-18):cn / global 的发布渠道靠**不同
@@ -158,6 +170,17 @@ export const BRAND_IDENTITY: BrandIdentity = Object.freeze({
     dev: 'CindyDev',
   }),
   legacyUserDataDirNames: Object.freeze(['xdt-maker']),
+  legacyUserDataDirNamesByRegion: Object.freeze({
+    cn: Object.freeze(['xdt-maker']),
+    global: Object.freeze([]),
+    dev: Object.freeze([]),
+  }),
+  legacyDialogueUserDataDirNamesByRegion: Object.freeze({
+    cn: Object.freeze(['xdt-maker']),
+    // xdt-maker 是旧 CN 渠道的数据来源；Global 不导入或改写 CN 的历史 cwd。
+    global: Object.freeze([]),
+    dev: Object.freeze([]),
+  }),
   cdnPrefix: 'cindy',
   updaterName: 'cindy-updater',
   dbFilePrefix: 'cindy',
@@ -202,13 +225,34 @@ export function allDeepLinkSchemes(identity: BrandIdentity = BRAND_IDENTITY): re
 }
 
 /**
- * 按路径识别本产品 userData 的全部目录名(本区域当前 + 历史),本区域目录名
- * 恒为首位。⚠️ 故意**不包含另一区域**的目录:同机双装时 orphan-reaper 等
- * 按路径匹配的消费点只应认领自己区域的进程 / 文件,跨区域匹配会误杀。
+ * 按路径识别本产品 userData 的全部目录名(本区域当前 + 本区域明确拥有的历史名)，
+ * 本区域目录名恒为首位。⚠️ 故意**不包含另一区域当前或历史使用的目录**：同机双装
+ * 时 orphan-reaper 等按路径匹配的消费点只应认领自己区域的进程，跨区域匹配会误杀。
  */
 export function allUserDataDirNames(
   region: CindyRegion = DEFAULT_CINDY_REGION,
   identity: BrandIdentity = BRAND_IDENTITY,
 ): readonly string[] {
-  return [identity.userDataDirNameByRegion[region], ...identity.legacyUserDataDirNames];
+  return [
+    identity.userDataDirNameByRegion[region],
+    ...identity.legacyUserDataDirNamesByRegion[region],
+  ];
+}
+
+/**
+ * 按区域取持久化 dialogue cwd 的历史 userData 目录名。只用于数据迁移，
+ * 绝不能用于判断进程归属或清理另一实例。
+ */
+export function legacyDialogueUserDataDirNames(
+  region: CindyRegion = DEFAULT_CINDY_REGION,
+  identity: BrandIdentity = BRAND_IDENTITY,
+): readonly string[] {
+  return identity.legacyDialogueUserDataDirNamesByRegion[region];
+}
+
+/** 品牌翻转前的共享老目录候选，仅供 cn 的 mToc 首登数据导入。 */
+export function legacyBrandUserDataDirNames(
+  identity: BrandIdentity = BRAND_IDENTITY,
+): readonly string[] {
+  return identity.legacyUserDataDirNames;
 }

--- a/scripts/__tests__/brand-identity-sync.test.mjs
+++ b/scripts/__tests__/brand-identity-sync.test.mjs
@@ -48,7 +48,9 @@ function extractRegionMap(source, mapName, label) {
   const block = blockRe.exec(source);
   assert.ok(block, `pattern not found: ${label} (${blockRe})`);
   const map = {};
-  for (const [, key, value] of block[1].matchAll(/(cn|global|dev):\s*'([^']+)'/g)) {
+  for (const [, key, , value] of block[1].matchAll(
+    /(cn|global|dev):\s*(['"])([^'"]+)\2/g,
+  )) {
     map[key] = value;
   }
   assert.deepEqual(Object.keys(map).sort(), ['cn', 'dev', 'global'], `${label} 缺区域键`);
@@ -88,6 +90,21 @@ test('restart-desktop-remote.mjs BRAND_USER_DATA_DIR_NAME mirrors brandIdentity.
     'restart-desktop-remote.mjs BRAND_USER_DATA_DIR_NAME',
   );
   assert.equal(value, USER_DATA_DIR_NAME);
+});
+
+test('desktop dev userData region map mirrors brandIdentity.userDataDirNameByRegion', () => {
+  const expected = extractRegionMap(
+    brandIdentitySource,
+    'userDataDirNameByRegion',
+    'brandIdentity.ts userDataDirNameByRegion',
+  );
+  const regionSource = readSource('scripts/shared/desktop-dev-region.mjs');
+  const actual = extractRegionMap(
+    regionSource,
+    'DESKTOP_USER_DATA_DIR_NAME_BY_REGION',
+    'desktop-dev-region.mjs DESKTOP_USER_DATA_DIR_NAME_BY_REGION',
+  );
+  assert.deepEqual(actual, expected);
 });
 
 test('desktop package.json productName mirrors brandIdentity.userDataDirName', () => {

--- a/scripts/__tests__/desktop-dev-region.test.mjs
+++ b/scripts/__tests__/desktop-dev-region.test.mjs
@@ -3,10 +3,19 @@ import test from "node:test";
 
 import {
   applyDesktopDevStartupConfig,
+  desktopUserDataDirNameForRegion,
   resolveDesktopDevRegion,
   resolveDesktopDevStartupConfig,
   stripDesktopDevRegionArgs,
 } from "../shared/desktop-dev-region.mjs";
+
+test("desktop shared userData follows the region identity", () => {
+  assert.equal(desktopUserDataDirNameForRegion(), "CindyGlobal");
+  assert.equal(desktopUserDataDirNameForRegion("global"), "CindyGlobal");
+  assert.equal(desktopUserDataDirNameForRegion("cn"), "Cindy");
+  assert.equal(desktopUserDataDirNameForRegion("dev"), "CindyDev");
+  assert.throws(() => desktopUserDataDirNameForRegion("us"), /expected cn, global or dev/);
+});
 
 test("desktop dev region defaults to global and keeps the legacy env fallback", () => {
   assert.equal(resolveDesktopDevRegion([], {}), "global");

--- a/scripts/__tests__/desktop-dev-region.test.mjs
+++ b/scripts/__tests__/desktop-dev-region.test.mjs
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   applyDesktopDevStartupConfig,
+  desktopUserDataDirForRegion,
   desktopUserDataDirNameForRegion,
   resolveDesktopDevRegion,
   resolveDesktopDevStartupConfig,
@@ -15,6 +16,26 @@ test("desktop shared userData follows the region identity", () => {
   assert.equal(desktopUserDataDirNameForRegion("cn"), "Cindy");
   assert.equal(desktopUserDataDirNameForRegion("dev"), "CindyDev");
   assert.throws(() => desktopUserDataDirNameForRegion("us"), /expected cn, global or dev/);
+});
+
+test("desktop userData path follows platform appData rules and selected region", () => {
+  assert.equal(
+    desktopUserDataDirForRegion("global", "darwin", {}, "/Users/tester"),
+    "/Users/tester/Library/Application Support/CindyGlobal",
+  );
+  assert.equal(
+    desktopUserDataDirForRegion("cn", "linux", { XDG_CONFIG_HOME: "/tmp/config" }, "/home/tester"),
+    "/tmp/config/Cindy",
+  );
+  assert.equal(
+    desktopUserDataDirForRegion(
+      "dev",
+      "win32",
+      { APPDATA: "C:\\Users\\tester\\AppData\\Roaming" },
+      "C:\\Users\\tester",
+    ),
+    "C:\\Users\\tester\\AppData\\Roaming\\CindyDev",
+  );
 });
 
 test("desktop dev region defaults to global and keeps the legacy env fallback", () => {

--- a/scripts/__tests__/restart-desktop-remote.test.mjs
+++ b/scripts/__tests__/restart-desktop-remote.test.mjs
@@ -9,10 +9,13 @@ import { fileURLToPath } from "node:url";
 import {
 	applyDesktopStartupConfigForPhase,
 	commandUsesUserDataDir,
+	defaultIsolatedUserDataDir,
 	devEnvPrefix,
 	isRepositoryDesktopDevProcess,
 	formatDesktopStartupFailure,
+	inspectSharedUserDataRegion,
 	partitionDesktopDevProcesses,
+	productionUserDataDir,
 	readDesktopStartupStatus,
 	parseWorktreePaths,
 	osascriptLaunchDarwinTerminalArgs,
@@ -133,6 +136,68 @@ test("userData conflict detection matches exact sandbox dirs only", () => {
 		commandUsesUserDataDir("node scripts/dev.mjs", "/Users/dev/Library/Application Support/Cindy-dev"),
 		false,
 	);
+});
+
+test("shared production userData path is region-aware", () => {
+	assert.equal(path.basename(productionUserDataDir()), "CindyGlobal");
+	assert.equal(path.basename(productionUserDataDir("global")), "CindyGlobal");
+	assert.equal(path.basename(productionUserDataDir("cn")), "Cindy");
+	assert.equal(path.basename(productionUserDataDir("dev")), "CindyDev");
+});
+
+test("default isolated userData path is region-aware", () => {
+	assert.equal(path.basename(defaultIsolatedUserDataDir("", "global")), "CindyGlobal-dev2");
+	assert.equal(path.basename(defaultIsolatedUserDataDir("", "cn")), "Cindy-dev2");
+	assert.equal(path.basename(defaultIsolatedUserDataDir("review", "dev")), "CindyDev-dev2-review");
+});
+
+test("preserve-running only shares a target with live records from the same region", () => {
+	const userData = fs.mkdtempSync(path.join(os.tmpdir(), "cindy-shared-region-"));
+	const records = path.join(userData, ".dev-instances");
+	const knownRoot = path.resolve("/repo/cindy-global");
+	fs.mkdirSync(records);
+	try {
+		fs.writeFileSync(
+			path.join(records, `${process.pid}.json`),
+			`${JSON.stringify({ schemaVersion: 1, pid: process.pid, region: "global", rootDir: knownRoot })}\n`,
+		);
+		const processes = [{
+			pid: process.pid + 1,
+			command: `electron --type=renderer --user-data-dir=${userData} --app-path=${path.join(knownRoot, "apps", "desktop")}`,
+		}];
+		assert.deepEqual(inspectSharedUserDataRegion(userData, "global", processes), {
+			compatible: true,
+			reason: null,
+		});
+		const mismatch = inspectSharedUserDataRegion(userData, "cn", processes);
+		assert.equal(mismatch.compatible, false);
+		assert.match(mismatch.reason, /pid=.*region=global/);
+
+		fs.writeFileSync(
+			path.join(records, `${process.pid}.json`),
+			`${JSON.stringify({ schemaVersion: 1, pid: process.pid, rootDir: knownRoot })}\n`,
+		);
+		const unknown = inspectSharedUserDataRegion(userData, "global", processes);
+		assert.equal(unknown.compatible, false);
+		assert.match(unknown.reason, /region=unknown/);
+
+		fs.writeFileSync(
+			path.join(records, `${process.pid}.json`),
+			`${JSON.stringify({ schemaVersion: 1, pid: process.pid, region: "global", rootDir: knownRoot })}\n`,
+		);
+		const unrecorded = inspectSharedUserDataRegion(userData, "global", [
+			...processes,
+			{
+				pid: process.pid + 2,
+				command: `electron --type=renderer --user-data-dir=${userData} --app-path=/repo/unknown/apps/desktop`,
+			},
+		]);
+		assert.equal(unrecorded.compatible, false);
+		assert.match(unrecorded.reason, /not covered/);
+		assert.match(unrecorded.reason, new RegExp(`pid=${process.pid + 2}`));
+	} finally {
+		fs.rmSync(userData, { recursive: true, force: true });
+	}
 });
 
 test("desktop restart runner forwards user args (incl. --isolated) into the kill stage", () => {
@@ -438,6 +503,7 @@ test("desktop whoami prefers launch-time commit metadata over process inference"
 		rootDir: "/repo/cindy-preview",
 		state: "ready",
 		mode: "remote",
+		region: "global",
 		passive: true,
 		isolated: false,
 		userDataDir: "/tmp/Cindy",
@@ -448,6 +514,7 @@ test("desktop whoami prefers launch-time commit metadata over process inference"
 
 	assert.equal(merged[0].commit, "abc123");
 	assert.equal(merged[0].commitVerified, true);
+	assert.equal(merged[0].region, "global");
 	assert.equal(merged[0].source, "record");
 });
 

--- a/scripts/desktop-whoami.mjs
+++ b/scripts/desktop-whoami.mjs
@@ -4,9 +4,12 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import {
+  desktopUserDataDirNameForRegion,
+  resolveDesktopDevRegion,
+} from './shared/desktop-dev-region.mjs';
 
 const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
-const PRODUCT_USER_DATA_NAME = 'Cindy';
 
 function run(command, args, options = {}) {
   return spawnSync(command, args, {
@@ -186,15 +189,16 @@ export function identifyDesktopProcesses(processes, worktrees) {
   return result;
 }
 
-function defaultUserDataDir() {
+function defaultUserDataDir(region = 'global') {
+  const dirName = desktopUserDataDirNameForRegion(region);
   if (process.platform === 'win32') {
     const appData = process.env.APPDATA || path.join(process.env.USERPROFILE || '', 'AppData', 'Roaming');
-    return path.join(appData, PRODUCT_USER_DATA_NAME);
+    return path.join(appData, dirName);
   }
   if (process.platform === 'darwin') {
-    return path.join(os.homedir(), 'Library', 'Application Support', PRODUCT_USER_DATA_NAME);
+    return path.join(os.homedir(), 'Library', 'Application Support', dirName);
   }
-  return path.join(process.env.XDG_CONFIG_HOME || path.join(os.homedir(), '.config'), PRODUCT_USER_DATA_NAME);
+  return path.join(process.env.XDG_CONFIG_HOME || path.join(os.homedir(), '.config'), dirName);
 }
 
 function isProcessAlive(pid) {
@@ -264,6 +268,7 @@ export function mergeDesktopInstanceRecords(scanned, records, worktrees) {
       // main + renderer process scan as a second, independent signal.
       ready: record.state === 'ready' && scannedItem?.ready === true,
       mode: record.mode,
+      region: record.region ?? null,
       passive: Boolean(record.passive),
       isolated: Boolean(record.isolated),
       userDataDir: record.userDataDir,
@@ -302,7 +307,7 @@ function printText(report) {
   console.log('active dev instances:');
   for (const instance of report.instances) {
     console.log(
-      `- pid=${instance.pid} state=${instance.state} mode=${instance.mode} passive=${instance.passive}` +
+      `- pid=${instance.pid} state=${instance.state} mode=${instance.mode} region=${instance.region ?? 'unknown'} passive=${instance.passive}` +
       ` root=${instance.rootDir} commit=${instance.commit ?? 'unverified'} userData=${instance.userDataDir ?? 'unknown'}`,
     );
   }
@@ -310,11 +315,12 @@ function printText(report) {
 
 function main() {
   const options = parseArgs(process.argv.slice(2));
+  const region = resolveDesktopDevRegion([], process.env);
   const worktrees = repositoryWorktrees();
   const processes = listProcesses();
   const preliminary = identifyDesktopProcesses(processes, worktrees);
   const userDataDirs = new Set([
-    path.resolve(options.userDataDir ?? process.env.XDT_USER_DATA_DIR ?? defaultUserDataDir()),
+    path.resolve(options.userDataDir ?? process.env.XDT_USER_DATA_DIR ?? defaultUserDataDir(region)),
     ...preliminary.map((item) => item.userDataDir).filter(Boolean).map((item) => path.resolve(item)),
   ]);
   const scanned = preliminary;

--- a/scripts/dev-embed-search.mjs
+++ b/scripts/dev-embed-search.mjs
@@ -33,6 +33,10 @@ import os from 'node:os';
 import path from 'node:path';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
+import {
+  desktopUserDataDirForRegion,
+  resolveDesktopDevRegion,
+} from './shared/desktop-dev-region.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -49,6 +53,7 @@ function parseArgs(argv) {
     to: null,
     userId: process.env.XDT_USER_ID ?? null,
     dbPath: null,
+    regionArgs: [],
   };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
@@ -65,6 +70,10 @@ function parseArgs(argv) {
       out.userId = argv[++i];
     } else if (a === '--db') {
       out.dbPath = argv[++i];
+    } else if (a === '--region') {
+      out.regionArgs.push('--region', argv[++i]);
+    } else if (a.startsWith('--region=')) {
+      out.regionArgs.push(a);
     } else if (a === '-h' || a === '--help') {
       printHelp();
       process.exit(0);
@@ -80,6 +89,7 @@ function parseArgs(argv) {
     printHelp();
     process.exit(1);
   }
+  out.region = resolveDesktopDevRegion(out.regionArgs, process.env);
   return out;
 }
 
@@ -93,6 +103,8 @@ Options:
   --to <iso>         不晚于该时间
   --user-id <id>     显式指定 user_id (默认从 XDT_USER_ID 读, 或 glob 匹配)
   --db <path>        覆盖 db 路径 (绕过 user-id 解析)
+  --region <cn|global|dev>
+                     选择 userData 区域 (默认读取 CINDY_AUTH_REGION, 再默认 global)
 
 环境变量:
   ANTHROPIC_API_KEY  必填 — 与 desktop 同一个 LiteLLM bearer token
@@ -120,29 +132,16 @@ function fail(msg) {
 /**
  * Electron app.getPath('userData') 在不同平台的等价路径 — 与
  * apps/desktop/src/main/localDb/index.ts 中 dbPath() 的拼接逻辑一致。
- * userData 子目录名来自 productName(2026-07-17 身份翻转后为 'Cindy',
- * 与 @cindy/maker-shared/brand-identity 的 userDataDirName 同源;本脚本是
- * 零依赖 dev CLI,不 import TS 包,字面量与之保持一致)。
+ * userData 子目录名由 shared/desktop-dev-region.mjs 镜像区域映射；本脚本
+ * 复用该路径函数，默认 Global → CindyGlobal，避免辅助工具读错 profile。
  */
-const USER_DATA_DIR_NAME = 'Cindy';
 const DB_FILE_PREFIX = 'cindy';
 
-function userDataDir() {
-  switch (process.platform) {
-    case 'darwin':
-      return path.join(os.homedir(), 'Library', 'Application Support', USER_DATA_DIR_NAME);
-    case 'win32':
-      return path.join(
-        process.env.APPDATA ?? path.join(os.homedir(), 'AppData', 'Roaming'),
-        USER_DATA_DIR_NAME,
-      );
-    case 'linux':
-      return path.join(
-        process.env.XDG_CONFIG_HOME ?? path.join(os.homedir(), '.config'),
-        USER_DATA_DIR_NAME,
-      );
-    default:
-      fail(`unsupported platform: ${process.platform}`);
+function userDataDir(region) {
+  try {
+    return desktopUserDataDirForRegion(region);
+  } catch (error) {
+    fail(error instanceof Error ? error.message : String(error));
   }
 }
 
@@ -151,7 +150,7 @@ function resolveDbPath(args) {
     if (!fs.existsSync(args.dbPath)) fail(`db not found: ${args.dbPath}`);
     return args.dbPath;
   }
-  const dir = userDataDir();
+  const dir = userDataDir(args.region);
   if (!fs.existsSync(dir)) {
     fail(
       `userData dir not found: ${dir}\n` +

--- a/scripts/restart-desktop-remote.mjs
+++ b/scripts/restart-desktop-remote.mjs
@@ -4,7 +4,11 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { applyDesktopDevStartupConfig } from './shared/desktop-dev-region.mjs';
+import {
+  applyDesktopDevStartupConfig,
+  desktopUserDataDirNameForRegion,
+  resolveDesktopDevRegion,
+} from './shared/desktop-dev-region.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const rootDir = path.resolve(__dirname, '..');
@@ -15,12 +19,10 @@ const startupReadyTimeoutMs = 120_000;
 const forceKillLabel = process.platform === 'win32' ? 'taskkill /F /T' : 'kill -9';
 
 /**
- * 产品 userData 目录基名(--isolated 沙箱目录 `<BRAND_USER_DATA_DIR_NAME>-dev[-<名字>]`
- * 的派生基座)。⚠️ 值必须与 packages/maker-shared/src/brandIdentity.ts 的
- * BRAND_IDENTITY.userDataDirName 一致——.mjs 无法 import TS 单点,只能镜像字面量;
+ * 产品默认 userData 目录基名。⚠️ 值必须与
+ * packages/maker-shared/src/brandIdentity.ts 的 BRAND_IDENTITY.userDataDirName
+ * 一致——.mjs 无法 import TS 单点,只能镜像字面量;
  * 一致性由 scripts/__tests__/brand-identity-sync.test.mjs 断言兜底。
- * 主进程侧(devCliFlags.ts)以 app.getPath('userData') 为基座派生同名目录,两边
- * 必须落在同一路径,否则 restart 脚本创建的沙箱目录与实际生效目录分家。
  */
 export const BRAND_USER_DATA_DIR_NAME = 'Cindy';
 
@@ -429,7 +431,7 @@ function closeDarwinTerminalTtys(ttys) {
 }
 
 /**
- * --isolated 的默认独立 userData 目录:与正式版的 `Cindy` 平级、名字带 -dev 后缀,
+ * --isolated 的默认独立 userData 目录:与当前区域正式目录平级、名字带 -dev2 后缀,
  * 稳定不随 checkout 变(多个 worktree 共享同一个 dev 沙箱,想再细分用命名沙箱
  * `--isolated=<名字>` 或自己设 XDT_USER_DATA_DIR 覆盖)。命名沙箱目录再追加
  * `-<名字>` 后缀,每个名字一条完全独立的沙箱。只在 dev 生效——主进程入口只在
@@ -447,15 +449,80 @@ function userDataDirNamed(dirName) {
   return path.join(xdgConfig, dirName);
 }
 
-function defaultIsolatedUserDataDir(isolationName) {
+export function defaultIsolatedUserDataDir(isolationName, region = 'global') {
   // 目录纪元 v2(-dev2),与 devCliFlags.ts 的派生保持一字不差:#871 起隔离沙箱用
   // CindyDev 钥匙串身份,旧 -dev 目录留给旧 checkout(#912 review)。
-  return userDataDirNamed(`${BRAND_USER_DATA_DIR_NAME}-dev2${isolationName ? `-${isolationName}` : ''}`);
+  const baseName = desktopUserDataDirNameForRegion(region);
+  return userDataDirNamed(`${baseName}-dev2${isolationName ? `-${isolationName}` : ''}`);
 }
 
 /** 非隔离 dev 与正式版共用的 userData 目录。 */
-function productionUserDataDir() {
-  return userDataDirNamed(BRAND_USER_DATA_DIR_NAME);
+export function productionUserDataDir(region = 'global') {
+  return userDataDirNamed(desktopUserDataDirNameForRegion(region));
+}
+
+function isProcessAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error?.code !== 'ESRCH';
+  }
+}
+
+/**
+ * --preserve-running 只有在目标 profile 的所有存活实例都明确声明同一区域时
+ * 才能共享。旧记录没有 region，属于无法证明兼容，必须 fail closed。
+ */
+export function inspectSharedUserDataRegion(userDataDir, expectedRegion, processes = []) {
+  const recordsDir = path.join(userDataDir, '.dev-instances');
+  const liveRecords = [];
+  try {
+    for (const name of fs.readdirSync(recordsDir)) {
+      if (!name.endsWith('.json')) continue;
+      try {
+        const record = JSON.parse(fs.readFileSync(path.join(recordsDir, name), 'utf8'));
+        if (Number.isInteger(record?.pid) && isProcessAlive(record.pid)) liveRecords.push(record);
+      } catch {
+        // 损坏记录不能证明兼容；若确有 helper 占用，下面的 process guard 会拒绝。
+      }
+    }
+  } catch {
+    // 没有注册表时继续看进程扫描。
+  }
+
+  const incompatibleRecords = liveRecords.filter(
+    (record) => record.region !== expectedRegion || typeof record.rootDir !== 'string',
+  );
+  if (incompatibleRecords.length > 0) {
+    return {
+      compatible: false,
+      reason:
+        `target userData has live instance record(s) with incompatible or unknown region: ` +
+        incompatibleRecords
+          .map(
+            (record) =>
+              `pid=${record.pid},region=${record.region ?? 'unknown'},` +
+              `root=${record.rootDir ?? 'unknown'}`,
+          )
+          .join('; '),
+    };
+  }
+
+  const scannedUsers = processes.filter((proc) => commandUsesUserDataDir(proc.command, userDataDir));
+  const unprovenUsers = scannedUsers.filter(
+    (proc) => !liveRecords.some((record) => commandContainsPath(proc.command, record.rootDir)),
+  );
+  if (unprovenUsers.length > 0) {
+    return {
+      compatible: false,
+      reason:
+        `target userData has active process(es) not covered by a live ` +
+        `region=${expectedRegion} instance record: ` +
+        unprovenUsers.map((proc) => `pid=${proc.pid}`).join(', '),
+    };
+  }
+  return { compatible: true, reason: null };
 }
 
 function parseIsolationName(isolatedArg) {
@@ -699,6 +766,7 @@ async function main() {
   // --local 切换到本地模式(连 localhost:3333);缺省走 remote(连 xdt-api)。
   const mode = argv.includes('--local') ? 'local' : 'remote';
   const startupConfig = applyDesktopStartupConfigForPhase({ argv, mode });
+  const selectedRegion = startupConfig?.region ?? resolveDesktopDevRegion(argv, process.env);
   const isolatedArg = argv.find((a) => a === '--isolated' || a.startsWith('--isolated='));
   if (preserveRunning && killOnly) {
     throw new Error('--preserve-running cannot be combined with the internal --kill-only stage');
@@ -754,8 +822,8 @@ async function main() {
     console.log(`==> Endpoint manifest: ${startupConfig.endpointManifestFile}`);
   }
   // --isolated[=<名字>]: dev 使用独立的 userData 目录(数据库/登录态/会话全部与
-  // 正式版隔离,首次要重新登录 Cindy 账号)。不带名字 = 默认沙箱(Cindy-dev);
-  // 带名字 = 独立命名沙箱(Cindy-dev-<名字>),每个名字一条,可同时多开。
+  // 正式版隔离,首次要重新登录 Cindy 账号)。不带名字 = 当前区域默认沙箱;
+  // 带名字 = 在区域沙箱名后追加 `-<名字>`,每个名字一条,可同时多开。
   // 实现:置 XDT_USER_DATA_DIR(主进程入口只在非 packaged 时应用,见
   // apps/desktop/src/main/index.ts),经 devEnvPrefix 白名单透传给 dev 进程。
   // 已手动设了 XDT_USER_DATA_DIR 时尊重用户的值,不覆盖。
@@ -778,7 +846,7 @@ async function main() {
     process.env.XDT_ISOLATED = '1';
     if (isolationName) process.env.XDT_ISOLATED_NAME = isolationName;
     if (!process.env.XDT_USER_DATA_DIR) {
-      process.env.XDT_USER_DATA_DIR = defaultIsolatedUserDataDir(isolationName);
+      process.env.XDT_USER_DATA_DIR = defaultIsolatedUserDataDir(isolationName, selectedRegion);
       // 可信纪元信号:仅当目录由本脚本按 -dev2 纪元派生时携带,主进程据此允许
       // 显式 env 覆写命中纪元判定。用户手动设 XDT_USER_DATA_DIR(上面的分支不
       // 进入)或旧 checkout 启动都不带该信号 → 观察模式,防旧代码对同一显式
@@ -819,11 +887,11 @@ async function main() {
   // --isolated 名字,或用户自己停掉那个实例。preserve-running 不进此门 ——
   // 它的语义就是共享 userData 的被动预览。检测是尽力而为:靠 helper 进程命令行
   // 上的 --user-data-dir,对方实例刚启动还没起 helper 时可能漏检。
+  const targetUserDataDir = process.env.XDT_USER_DATA_DIR
+    || (isolatedArg
+      ? defaultIsolatedUserDataDir(parseIsolationName(isolatedArg), selectedRegion)
+      : productionUserDataDir(selectedRegion));
   if (!preserveRunning) {
-    const targetUserDataDir = process.env.XDT_USER_DATA_DIR
-      || (isolatedArg
-        ? defaultIsolatedUserDataDir(parseIsolationName(isolatedArg))
-        : productionUserDataDir());
     const conflicts = listDesktopDevProcesses().filter(
       (proc) => !commandContainsPath(proc.command, rootDir)
         && commandUsesUserDataDir(proc.command, targetUserDataDir),
@@ -836,6 +904,18 @@ async function main() {
       console.error('==> Refusing to stop processes outside this checkout. Pick a different sandbox');
       console.error('    name (--isolated=<name>), or stop that instance yourself and re-run.');
       process.exit(1);
+    }
+  } else {
+    const compatibility = inspectSharedUserDataRegion(
+      targetUserDataDir,
+      selectedRegion,
+      listDesktopDevProcesses(),
+    );
+    if (!compatibility.compatible) {
+      throw new Error(
+        `--preserve-running cannot safely share ${targetUserDataDir}: ${compatibility.reason}. ` +
+          'Restart the existing instance with the same region, or use an isolated sandbox.',
+      );
     }
   }
 

--- a/scripts/shared/desktop-dev-region.mjs
+++ b/scripts/shared/desktop-dev-region.mjs
@@ -1,3 +1,6 @@
+import os from "node:os";
+import path from "node:path";
+
 /** Desktop dev 支持的区域身份。 */
 export const DESKTOP_DEV_REGIONS = Object.freeze(["cn", "global", "dev"]);
 
@@ -17,6 +20,33 @@ export function desktopUserDataDirNameForRegion(region = "global") {
     throw new Error(`invalid desktop dev region: ${region}; expected cn, global or dev`);
   }
   return DESKTOP_USER_DATA_DIR_NAME_BY_REGION[region];
+}
+
+/** 计算与 Electron app.getPath('userData') 对齐的区域 profile 路径。 */
+export function desktopUserDataDirForRegion(
+  region = "global",
+  platform = process.platform,
+  env = process.env,
+  homeDir = os.homedir(),
+) {
+  const dirName = desktopUserDataDirNameForRegion(region);
+  const pathImpl = platform === "win32" ? path.win32 : path.posix;
+  switch (platform) {
+    case "darwin":
+      return pathImpl.join(homeDir, "Library", "Application Support", dirName);
+    case "win32":
+      return pathImpl.join(
+        env.APPDATA || pathImpl.join(homeDir, "AppData", "Roaming"),
+        dirName,
+      );
+    case "linux":
+      return pathImpl.join(
+        env.XDG_CONFIG_HOME || pathImpl.join(homeDir, ".config"),
+        dirName,
+      );
+    default:
+      throw new Error(`unsupported platform: ${platform}`);
+  }
 }
 
 /**

--- a/scripts/shared/desktop-dev-region.mjs
+++ b/scripts/shared/desktop-dev-region.mjs
@@ -2,6 +2,24 @@
 export const DESKTOP_DEV_REGIONS = Object.freeze(["cn", "global", "dev"]);
 
 /**
+ * 与 packages/maker-shared/src/brandIdentity.ts 的 userDataDirNameByRegion 镜像。
+ * .mjs 启动器不能直接 import TS；同步关系由 brand-identity-sync.test.mjs 锁住。
+ */
+export const DESKTOP_USER_DATA_DIR_NAME_BY_REGION = Object.freeze({
+  cn: "Cindy",
+  global: "CindyGlobal",
+  dev: "CindyDev",
+});
+
+/** 共享 Desktop profile 的区域目录名；省略区域时遵循产品规则默认 Global。 */
+export function desktopUserDataDirNameForRegion(region = "global") {
+  if (!DESKTOP_DEV_REGIONS.includes(region)) {
+    throw new Error(`invalid desktop dev region: ${region}; expected cn, global or dev`);
+  }
+  return DESKTOP_USER_DATA_DIR_NAME_BY_REGION[region];
+}
+
+/**
  * 解析 desktop dev 区域。命令行显式值优先，保留 CINDY_AUTH_REGION 作为
  * CI / 老脚本兼容入口；无配置时默认 Global。
  */

--- a/scripts/voice-input-benchmark.mjs
+++ b/scripts/voice-input-benchmark.mjs
@@ -10,6 +10,10 @@ import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
 import { gzipSync, gunzipSync } from 'node:zlib';
 import WebSocket from 'ws';
+import {
+  desktopUserDataDirForRegion,
+  resolveDesktopDevRegion,
+} from './shared/desktop-dev-region.mjs';
 
 const execFile = promisify(execFileCb);
 
@@ -134,6 +138,7 @@ Refine options:
   --dictation-text <text>           Single ad-hoc case input
   --expected-text <text>            Expected output for the single ad-hoc case
   --context <path>                  JSON context merged into every case
+  --region <cn|global|dev>          userData 区域 (默认读取 CINDY_AUTH_REGION, 再默认 global)
   --iterations <n>                  Default: 1
   --timeout-ms <n>                  Default: 15000
   --base-url <url>                  LiteLLM gateway. Default: VITE_XD_GATEWAY_BASE_URL
@@ -188,6 +193,7 @@ function parseArgs(argv) {
     dictationText: '',
     expectedText: '',
     context: '',
+    region: null,
   };
 
   for (let i = 0; i < args.length; i += 1) {
@@ -265,6 +271,9 @@ function parseArgs(argv) {
         break;
       case '--context':
         opts.context = path.resolve(next());
+        break;
+      case '--region':
+        opts.region = next();
         break;
       case '--base-url':
         opts.baseUrl = next();
@@ -604,24 +613,27 @@ async function resolveLiteLlmApiKey(opts) {
     process.env.ANTHROPIC_API_KEY,
   ].find((value) => value?.trim());
   if (explicit) return explicit.trim();
-  const stored = await readXdGatewayApiKeyFromAppStorage();
+  const region = opts.region ?? resolveDesktopDevRegion([], process.env);
+  const stored = await readXdGatewayApiKeyFromAppStorage(region);
   if (stored) return stored;
   throw new Error(
     'No LiteLLM/XD Gateway API key found. Pass --api-key, set XDT_VOICE_INPUT_BENCHMARK_API_KEY, or save an API key in Settings > API Key.',
   );
 }
 
-async function readXdGatewayApiKeyFromAppStorage() {
+async function readXdGatewayApiKeyFromAppStorage(region) {
   const electron = resolveElectronBinary();
   if (!electron) return null;
+  const userDataDir = desktopUserDataDirForRegion(region);
   const helperPath = path.join(os.tmpdir(), `xdt-read-xd-gateway-key-${process.pid}-${Date.now()}.cjs`);
   await fsp.writeFile(helperPath, `
 const fs = require('node:fs');
 const path = require('node:path');
 const { app, safeStorage } = require('electron');
-// userData 子目录随 productName(2026-07 身份翻转后 'Cindy'),要读 desktop dev
-// 同一份 safe-storage 就必须对齐这个名字。
+// safeStorage service name remains Cindy for the shared packaged CN/Global keychain;
+// the profile path is selected explicitly so Global reads CindyGlobal storage.
 app.setName('Cindy');
+app.setPath('userData', ${JSON.stringify(userDataDir)});
 app.whenReady().then(() => {
   try {
     const file = path.join(app.getPath('userData'), 'safe-storage', 'api_key.enc');


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 CN / Global 或多个 Desktop 实例共享 userData 时可能互相误认登录凭证、轮换 refresh token，导致正在使用的实例被莫名登出的风险。

本 PR 保持正式目录不变：CN 使用 `Cindy`，Global 使用 `CindyGlobal`，dev 使用 `CindyDev`；不做 `CindyCn` 改名，也不在启动时搬迁正式用户数据。

### 变更类型

- [x] `fix` 缺陷修复
- [x] `refactor` / `perf` 重构或性能优化
- [x] `docs` / `test` / `chore` 文档、测试或工程维护

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：
  - passive 共享实例遇到没有 realm 的旧裸 refresh token 时 fail closed，不猜区域、不轮换、不删除。
  - 按区域固定选择 userData profile，并让 dev 启动器、实例记录、`--preserve-running` 共享校验使用同一映射。
  - 按区域限制历史进程、Codex HOME、dialogue cwd 等路径识别，避免 Global 误认领 CN 的旧 `xdt-maker` 进程或数据。
  - 增加区域映射、凭证隔离、进程归属和启动器回归测试及开发文档。
- 明确不包含：不重命名或迁移正式 `userData` 目录；不修改服务端、不改变认证协议、不新增迁移弹窗。
- 用户可见变化：正常同区域启动和登录无感；无法确认区域的旧裸凭证不会被自动猜测，相关实例会保持未登录，等待同区域独占实例完成凭证整理。
- 是否存在 breaking change：无

### UI 变化

不涉及：仅修改 Desktop main、共享身份映射、启动脚本、测试和开发文档，无界面视觉或交互变化。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
bash /Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh /Users/dash/Code/Cindy/cindy-fix-region-userdata-auth-isolation
结果：全仓 unit gate 通过（24035 tests，3 skipped）。

pnpm --filter desktop run --if-present typecheck
结果：通过。

pnpm --filter @cindy/maker-shared run --if-present typecheck
结果：通过。

pnpm check:dco
结果：通过，1 个 commit 带 DCO 签名。
```

### 手工验证

不涉及：本 PR 未启动可见客户端做 UI 手工验证；变更集中在 main 进程、脚本和路径/凭证隔离。

### 未执行的验证

无。

## 风险

### 风险分类

- [ ] 无已知风险
- [x] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [x] 跨平台差异

### 影响与回滚

- 影响范围：Desktop 的区域 userData 选择、共享实例启动校验、登录态持久化兼容、历史进程/路径识别；正式 CN/Global 目录名和现有用户数据位置保持不变。
- 回滚 / 降级方式：回滚本 PR commit 即恢复原有启动和凭证处理逻辑；本 PR 不移动、不删除正式用户数据。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
