### PR TITLE
fix(desktop): 修复切换任务后流式动效重播

### DIFF
--- a/apps/desktop/src/renderer/components/chat/AssistantMessage.tsx
+++ b/apps/desktop/src/renderer/components/chat/AssistantMessage.tsx
@@ -117,12 +117,14 @@ const StreamingBody = memo(function StreamingBody({
   localFileRefs,
   currentSessionId,
   currentSessionTitle,
+  streamFadeKey,
 }: {
   workingDir: string;
   content: string;
   localFileRefs?: readonly KnownLocalFileRef[];
   currentSessionId?: string;
   currentSessionTitle?: string | null;
+  streamFadeKey?: string;
 }) {
   const { committedText, pendingLine } = useMemo(
     () => splitAtLastNewline(content),
@@ -135,6 +137,7 @@ const StreamingBody = memo(function StreamingBody({
           workingDir={workingDir}
           content={committedText}
           isStreaming
+          streamFadeKey={streamFadeKey}
           localFileRefs={localFileRefs}
           currentSessionId={currentSessionId}
           currentSessionTitle={currentSessionTitle}
@@ -286,6 +289,9 @@ export const AssistantMessage = memo(function AssistantMessage({
   // /goal:隐藏助手输出末尾由 goal 协议要求模型吐出的裁决 JSON 块(仅显示层剥离,
   // 原文仍保留在 DB / transcript)。pattern:末尾的 ```json {...goal_status...} ``` 围栏块。
   const displayContent = stripGoalVerdictBlock(content);
+  const streamFadeKey = messageClientId
+    ? `${currentSessionId ?? ''}\u0000${messageClientId}`
+    : undefined;
 
   return (
     <div
@@ -324,6 +330,7 @@ export const AssistantMessage = memo(function AssistantMessage({
             localFileRefs={localFileRefs}
             currentSessionId={currentSessionId}
             currentSessionTitle={currentSessionTitle}
+            streamFadeKey={streamFadeKey}
           />
         ) : (
           // 默认分支 (USE_LINE_COMMIT_STREAMING=false) + 非 streaming 都走完整
@@ -333,6 +340,7 @@ export const AssistantMessage = memo(function AssistantMessage({
             workingDir={workingDir}
             content={displayContent}
             isStreaming={isStreaming}
+            streamFadeKey={streamFadeKey}
             localFileRefs={localFileRefs}
             currentSessionId={currentSessionId}
             currentSessionTitle={currentSessionTitle}

--- a/apps/desktop/src/renderer/components/chat/MarkdownRenderer.tsx
+++ b/apps/desktop/src/renderer/components/chat/MarkdownRenderer.tsx
@@ -33,8 +33,9 @@ import remarkSessionLinks from './remarkSessionLinks';
 import { rehypeMathBlockMarker } from './rehypeMathBlockMarker';
 import { FENCED_CODE_PROP, rehypeFencedCodeMarker } from './rehypeFencedCodeMarker';
 import {
-  createWordFadeState,
+  getOrCreateWordFadeState,
   markSettledFromAnimationEnd,
+  releaseWordFadeState,
   rehypeStreamWordFade,
 } from './rehypeStreamWordFade';
 import { repairStreamingMarkdown } from './repairStreamingMarkdown';
@@ -317,6 +318,11 @@ interface MarkdownRendererProps {
    *  message never misses its last token. Default false (static content
    *  paths like TextLightbox bypass the throttle entirely). */
   isStreaming?: boolean;
+  /**
+   * Stable identity of the streaming message. Keeps the word-fade timeline
+   * across task-view remounts so already-rendered text cannot replay.
+   */
+  streamFadeKey?: string;
   /** Files uploaded in the session. Used to resolve model-authored links like
    *  `[doc.docx](doc.docx)` back to the original attachment path. */
   localFileRefs?: readonly KnownLocalFileRef[];
@@ -1620,6 +1626,7 @@ export const MarkdownRenderer = memo(function MarkdownRenderer({
   workingDir,
   content,
   isStreaming = false,
+  streamFadeKey,
   localFileRefs,
   currentSessionId,
   currentSessionTitle,
@@ -1644,12 +1651,15 @@ export const MarkdownRenderer = memo(function MarkdownRenderer({
   const streamFade = isStreaming && !reducedMotion && streamFadeEnabled;
   const wordFade = useMemo(() => {
     if (!streamFade) return null;
-    const state = createWordFadeState();
+    const state = getOrCreateWordFadeState(streamFadeKey);
     return {
       state,
       plugins: [...REHYPE_PLUGINS, [rehypeStreamWordFade, state]] as PluggableList,
     };
-  }, [streamFade]);
+  }, [streamFade, streamFadeKey]);
+  useEffect(() => {
+    if (!isStreaming) releaseWordFadeState(streamFadeKey);
+  }, [isStreaming, streamFadeKey]);
   const rehypePlugins = wordFade?.plugins ?? REHYPE_PLUGINS;
   const handleWordFadeAnimationEnd = useMemo(() => {
     if (!wordFade) return undefined;

--- a/apps/desktop/src/renderer/components/chat/__tests__/rehypeStreamWordFade.test.ts
+++ b/apps/desktop/src/renderer/components/chat/__tests__/rehypeStreamWordFade.test.ts
@@ -8,16 +8,23 @@
 
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import type { Element, Root, Text } from 'hast';
 
 import {
+  _resetWordFadeStateCacheForTests,
   createWordFadeState,
+  getOrCreateWordFadeState,
   markSettledFromAnimationEnd,
+  releaseWordFadeState,
   rehypeStreamWordFade,
   splitWords,
   type WordFadeState,
 } from '../rehypeStreamWordFade';
+
+afterEach(() => {
+  _resetWordFadeStateCacheForTests();
+});
 
 function textNode(value: string): Text {
   return { type: 'text', value };
@@ -78,6 +85,31 @@ describe('splitWords', () => {
 });
 
 describe('rehypeStreamWordFade', () => {
+  it('同一条流式消息 remount 后沿用原时间线，已有词不从头重播', () => {
+    const cacheKey = 'session-1\u0000message-1';
+    const firstMount = getOrCreateWordFadeState(cacheKey);
+    const tree1 = root(el('p', [textNode('one two')]));
+    run(tree1, firstMount, 0);
+    const firstKeys = collectWords(tree1).map((word) => word.key);
+
+    const remount = getOrCreateWordFadeState(cacheKey);
+    const tree2 = root(el('p', [textNode('one two three')]));
+    run(tree2, remount, 1000);
+    const words = collectWords(tree2);
+
+    expect(remount).toBe(firstMount);
+    expect(words.slice(0, 2).map((word) => word.key)).toEqual(firstKeys);
+    expect(words.slice(0, 2).every((word) => word.delay < -150)).toBe(true);
+    expect(words[2].delay).toBe(0);
+  });
+
+  it('消息进入终态后释放 remount 状态', () => {
+    const cacheKey = 'session-1\u0000message-1';
+    const active = getOrCreateWordFadeState(cacheKey);
+    releaseWordFadeState(cacheKey);
+    expect(getOrCreateWordFadeState(cacheKey)).not.toBe(active);
+  });
+
   it('文本节点被切成带 --wf-delay 的 stream-word span,首词 0ms 起、24ms/词递进', () => {
     const state = createWordFadeState();
     const tree = root(el('p', [textNode('one two three')]));

--- a/apps/desktop/src/renderer/components/chat/rehypeStreamWordFade.ts
+++ b/apps/desktop/src/renderer/components/chat/rehypeStreamWordFade.ts
@@ -127,6 +127,43 @@ export function createWordFadeState(): WordFadeState {
 }
 
 /**
+ * 流式消息在切换任务时会随 MessageStream 一起卸载。动画状态如果只挂在
+ * MarkdownRenderer 实例上，回来后整条已有正文会被当成首次到达并重播。
+ *
+ * 这里按消息身份保留一个有界 LRU：同一条仍在流式中的消息 remount 后继续使用原来的
+ * 绝对时间线；终态渲染会主动释放。上限只兜底清理由后台结束、此后再未打开的任务。
+ */
+const WORD_FADE_STATE_CACHE_MAX = 64;
+const wordFadeStateCache = new Map<string, WordFadeState>();
+
+export function getOrCreateWordFadeState(cacheKey?: string): WordFadeState {
+  if (!cacheKey) return createWordFadeState();
+  const cached = wordFadeStateCache.get(cacheKey);
+  if (cached) {
+    wordFadeStateCache.delete(cacheKey);
+    wordFadeStateCache.set(cacheKey, cached);
+    return cached;
+  }
+
+  const state = createWordFadeState();
+  wordFadeStateCache.set(cacheKey, state);
+  if (wordFadeStateCache.size > WORD_FADE_STATE_CACHE_MAX) {
+    const oldest = wordFadeStateCache.keys().next().value;
+    if (oldest !== undefined) wordFadeStateCache.delete(oldest);
+  }
+  return state;
+}
+
+export function releaseWordFadeState(cacheKey?: string): void {
+  if (cacheKey) wordFadeStateCache.delete(cacheKey);
+}
+
+/** 测试专用：隔离模块级 remount 状态。 */
+export function _resetWordFadeStateCacheForTests(): void {
+  wordFadeStateCache.clear();
+}
+
+/**
  * animationend 落袋入口:MarkdownRenderer 根节点上监听冒泡的 animationend,
  * 把播完 stream-word-in 的词 key 记进 state.settled。按动画名过滤 —— 同一子树里
  * 其它动画(代码高亮、chip 等)的 animationend 不误伤。


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复开启流式输出动效后，在仍生成中的任务之间切换时，最后一条助手消息会从头重新播放逐词淡入的问题。消息内容仍来自真实流式增量；本次让动效时间线按任务与消息身份跨组件重挂保留，旧内容不再重播，后续新增内容继续淡入。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其它

### 范围

- 关联 Issue / 需求：用户反馈
- 本 PR 包含：按任务与消息身份缓存流式逐词淡入状态；消息终态主动释放；64 条 LRU 上限兜底；补充重挂与释放回归测试
- 明确不包含：流式传输协议、消息持久化、Mobile 行为
- 用户可见变化：切回仍在生成的任务时，已显示正文不再从头淡入；真正新增的正文仍继续淡入
- 是否存在 breaking change：无

### UI 变化

交互行为修复，不改变颜色、布局、时长或动效形态。遵循 `DESIGN.md §14.4 Stream-word fade`：已见词不得重播，动效仅用于真实新增的流式正文，并继续响应 reduced motion。

- 引用的设计规范：`docs/design-rules/DESIGN.md §14.4 Stream-word fade`

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/renderer/components/chat/__tests__/rehypeStreamWordFade.test.ts
结果：29/29 通过

pnpm test:unit
结果：通过。首次运行 Desktop workspace 有 1 个不稳定失败；同范围 Desktop 全量复跑通过，随后根级完整门禁复跑通过

pnpm --filter desktop typecheck
结果：通过

pnpm check:dco
结果：通过，1 个 commit 已签名

subagent code review
结果：未发现 P0/P1 阻断问题
```

### 手工验证

Windows Global 独立沙盒 `curious-pasteur`：开启流式输出动效，在长回复仍生成时反复切换任务。已显示正文保持稳定，离开期间新增正文继续淡入；用户验收通过。

### 未执行的验证

- 未单独实机目检 macOS：改动为跨平台 Renderer 状态逻辑，无平台分支
- 未单独目检 Light / Dark：未改变颜色、样式 token 或动效形态

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其它

### 影响与回滚

- 影响范围：仅 Desktop Renderer 中已开启的流式逐词淡入动效
- 回滚 / 降级方式：回滚本 PR 即恢复原组件实例内状态；用户也可关闭流式输出动效
- Mobile 冷更判断：不会触发。未修改 `apps/mobile`、Mobile 原生配置、依赖、config plugin、原生模块或任何 runtime fingerprint 输入
- 存量插件影响：无

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要测试
- [x] 已确认测试结果并如实说明首次波动与复跑结果