### PR TITLE
fix(desktop): 新建对话不再显示手机设备

### DIFF
--- a/apps/desktop/src/renderer/__tests__/controllableDevicePredicate.test.ts
+++ b/apps/desktop/src/renderer/__tests__/controllableDevicePredicate.test.ts
@@ -1,7 +1,7 @@
 /**
  * controllableDevicePredicate.test.ts —— 可控被控设备的准入判定。
  * 守住「添加远程项目」设备下拉 / 入口 gate 的准入:
- * 同账号、在线、对方已开被控、本机未关闭控制、非本机。
+ * 同账号、在线、对方已开被控、本机未关闭控制、非本机、非手机。
  */
 import { describe, it, expect } from 'vitest';
 
@@ -36,22 +36,26 @@ describe('isControllableDevice', () => {
     // busy(对方正忙)仍可作为项目目标。
     expect(isControllableDevice(dev({ busy: true }))).toBe(true);
   });
-  it('离线 / 未开被控 / 本机关闭控制 / 本机 → 不可控', () => {
+  it('离线 / 未开被控 / 本机关闭控制 / 本机 / 手机 → 不可控', () => {
     expect(isControllableDevice(dev({ online: false }))).toBe(false);
     expect(isControllableDevice(dev({ remoteControlEnabled: false }))).toBe(false);
     expect(isControllableDevice(dev({ controlEnabled: false }))).toBe(false);
     expect(isControllableDevice(dev({ isSelf: true }))).toBe(false);
+    expect(isControllableDevice(dev({ platform: 'ios' }))).toBe(false);
+    expect(isControllableDevice(dev({ platform: 'android' }))).toBe(false);
   });
 });
 
 describe('toControllableDevices', () => {
-  it('过滤可控目标 + 投影成 {deviceId,name,platform}(丢弃离线/未开被控/本机)', () => {
+  it('过滤可控目标 + 投影成 {deviceId,name,platform}(丢弃离线/未开被控/本机/手机)', () => {
     const out = toControllableDevices([
       dev({ deviceId: 'ok', name: 'OK', platform: 'darwin' }),
       dev({ deviceId: 'off', online: false }),
       dev({ deviceId: 'noctl', remoteControlEnabled: false }),
       dev({ deviceId: 'local-off', controlEnabled: false }),
       dev({ deviceId: 'self', isSelf: true }),
+      dev({ deviceId: 'iphone', platform: 'ios' }),
+      dev({ deviceId: 'android', platform: 'android' }),
     ]);
     expect(out).toEqual([{ deviceId: 'ok', name: 'OK', platform: 'darwin' }]);
   });
@@ -88,16 +92,33 @@ describe('isSelectableDevice(设备切换器,含离线)', () => {
     expect(isSelectableDevice(dev({ isSelf: true }))).toBe(false);
     expect(isSelectableDevice(dev({ isSelf: true, online: false }))).toBe(false);
   });
+
+  it('手机只能作为控制端,在线或离线都不进入设备选择', () => {
+    expect(isSelectableDevice(dev({ platform: 'ios' }))).toBe(false);
+    expect(isSelectableDevice(dev({ platform: 'android' }))).toBe(false);
+    expect(
+      isSelectableDevice(
+        dev({ platform: 'ios', online: false, remoteControlEnabled: false }),
+      ),
+    ).toBe(false);
+    expect(
+      isSelectableDevice(
+        dev({ platform: 'android', online: false, remoteControlEnabled: false }),
+      ),
+    ).toBe(false);
+  });
 });
 
 describe('toSelectableDevices', () => {
-  it('保留离线设备并带上 online 标记,过滤本机与已关控制的', () => {
+  it('保留离线电脑并带上 online 标记,过滤本机、已关控制与手机', () => {
     const out = toSelectableDevices([
       dev({ deviceId: 'on', name: 'On', platform: 'darwin' }),
       dev({ deviceId: 'off', name: 'Off', online: false, remoteControlEnabled: false }),
       dev({ deviceId: 'noctl', online: true, remoteControlEnabled: false }),
       dev({ deviceId: 'local-off', controlEnabled: false }),
       dev({ deviceId: 'self', isSelf: true }),
+      dev({ deviceId: 'iphone', platform: 'ios' }),
+      dev({ deviceId: 'android', platform: 'android', online: false }),
     ]);
     expect(out).toEqual([
       { deviceId: 'on', name: 'On', platform: 'darwin', online: true },

--- a/apps/desktop/src/renderer/hooks/useControllableDevices.ts
+++ b/apps/desktop/src/renderer/hooks/useControllableDevices.ts
@@ -3,12 +3,13 @@
  *
  * 与 useDeviceLinkSettings(被控开关 / controlledBy / 轮询 / getState 全套)不同,这里只
  * 拉设备列表 + 订阅 presence / 本地控制偏好,筛出**可控目标**:
- * `online && remoteControlEnabled && controlEnabled && !isSelf`。
+ * `online && remoteControlEnabled && controlEnabled && !isSelf && !isMobilePlatform(platform)`。
  * 供「添加远程项目」弹窗的设备下拉 + 入口 gate(useHasAnyRemoteTarget)共用,避免在首页
  * 常驻时背上整套设置页的订阅开销。device-link 不可用(未登录 / relay 断)→ 静默空列表。
  */
 
 import { useEffect, useRef, useState } from 'react';
+import { isMobilePlatform } from '@cindy/maker-shared/device-list';
 
 export interface ControllableDevice {
   deviceId: string;
@@ -17,11 +18,18 @@ export interface ControllableDevice {
 }
 
 /**
- * 可作为远程项目目标的判定:同账号、在线、对方已开「允许被控」、本机未关闭控制、且不是本机。
- * 纯函数,供 hook 过滤 + 单测复用(守住这条准入,避免误把离线 / 未开被控 / 本机列进去)。
+ * 可作为远程项目目标的判定:同账号、在线、对方已开「允许被控」、本机未关闭控制、
+ * 不是本机、且不是只能作为控制端的手机。
+ * 纯函数,供 hook 过滤 + 单测复用(守住这条准入,避免误把离线 / 未开被控 / 本机 / 手机列进去)。
  */
 export function isControllableDevice(d: DeviceLinkDeviceView): boolean {
-  return d.online && d.remoteControlEnabled && d.controlEnabled && !d.isSelf;
+  return (
+    d.online &&
+    d.remoteControlEnabled &&
+    d.controlEnabled &&
+    !d.isSelf &&
+    !isMobilePlatform(d.platform)
+  );
 }
 
 /** 把设备全量列表(含本机/离线/未开被控)收敛成可控目标视图。纯函数,便于单测整条 transform。 */
@@ -59,7 +67,8 @@ export interface SelectableDevice extends ControllableDevice {
 }
 
 /**
- * 设备切换器的准入:同账号、非本机、本机未关闭控制;对方的「允许被控」**只在它在线时才作数**。
+ * 设备切换器的准入:同账号、非本机、非手机、本机未关闭控制;对方的「允许被控」
+ * **只在它在线时才作数**。
  *
  * 与 isControllableDevice 的差别是不要求 online —— 见 SelectableDevice。
  *
@@ -70,7 +79,9 @@ export interface SelectableDevice extends ControllableDevice {
  * `controlEnabled` 是控制端本地偏好,任何时候都权威,照常要求。
  */
 export function isSelectableDevice(d: DeviceLinkDeviceView): boolean {
-  if (d.isSelf || !d.controlEnabled) return false;
+  // 手机端是控制端而非被控端。即便旧版本或异常 presence 报出 remoteControlEnabled=true，
+  // 也不能把 iOS / Android 暴露成新建对话的运行目标。
+  if (d.isSelf || !d.controlEnabled || isMobilePlatform(d.platform)) return false;
   return d.online ? d.remoteControlEnabled : true;
 }
 


### PR DESCRIPTION
## 这次改了什么

### 摘要

新建对话的设备选择现在会排除 iOS / Android 设备。手机在 Cindy 的设备模型中只能作为控制端，不能作为运行对话的被控端；此前创建页的独立设备筛选漏掉了已有的移动平台约束，导致手机（尤其离线手机）仍会显示在候选列表里。

本次在共享的可控设备准入层复用 `isMobilePlatform`，同时覆盖“添加远程项目”入口和新建对话设备切换器，避免异常或旧版本 presence 将手机暴露为被控目标。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：新建对话设备选择不应显示手机
- 本 PR 包含：过滤在线与离线的 iOS / Android 设备；补充设备准入单元测试
- 明确不包含：设备列表样式、文案、device-link 协议或服务端改动
- 用户可见变化：新建对话的设备下拉不再显示手机；可作为被控端的电脑仍按原规则显示
- 是否存在 breaking change：无

### UI 变化

不涉及：仅调整创建页设备候选数据的准入过滤，没有修改组件布局、样式、动效或文案。

- 引用的设计规范：不涉及；未修改视觉或交互表现

## 怎么验证的

### 自动验证

```text
bash /Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh /Users/dash/Code/Cindy/cindy-hide-mobile-device-targets
结果：GATE_EXIT=0（最新 origin/main 基线）

pnpm --filter desktop typecheck
结果：通过

pnpm --filter desktop exec vitest run src/renderer/__tests__/controllableDevicePredicate.test.ts
结果：14 tests passed

pnpm check:dco
结果：1 commit signed off，检查通过
```

### 手工验证

不涉及：本次为纯设备列表投影逻辑，已由在线/离线 iOS、Android 与电脑用例覆盖。

### 未执行的验证

未启动 Desktop 做人工目检；本次没有视觉、文案或布局改动。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop 新建对话与添加远程项目使用的设备候选列表
- 回滚 / 降级方式：回退本提交即可恢复旧筛选逻辑；不涉及数据迁移或持久状态

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（不需要额外文档）
- [x] 已确认测试结果或说明未执行原因
