### PR TITLE
feat(desktop): 默认开启提问导航条并区分自动化消息

### DIFF
--- a/apps/desktop/src/renderer/__tests__/messageNavRailModel.test.ts
+++ b/apps/desktop/src/renderer/__tests__/messageNavRailModel.test.ts
@@ -50,6 +50,20 @@ describe('deriveNavRailEntries', () => {
     expect(deriveNavRailEntries([])).toEqual([]);
   });
 
+  it('保留自动化来源标记,供导航条用短刻度区分', () => {
+    const entries = deriveNavRailEntries([
+      msg({ clientId: 'u1', role: 'user', content: '手动提问' }),
+      msg({
+        clientId: 'u2',
+        role: 'user',
+        content: '自动提问',
+        automationOrigin: { kind: 'scheduler', scheduleId: 'schedule-1' },
+      }),
+      msg({ clientId: 'u3', role: 'user', content: '普通提问', automationOrigin: undefined }),
+    ]);
+    expect(entries.map((entry) => entry.isAutomation)).toEqual([false, true, false]);
+  });
+
   it('运行中插话(delivery=steer)不算新一轮,不产生刻度', () => {
     const messages = [
       msg({ clientId: 'u1', role: 'user', content: '第一问' }),

--- a/apps/desktop/src/renderer/components/chat/MessageNavRail.tsx
+++ b/apps/desktop/src/renderer/components/chat/MessageNavRail.tsx
@@ -438,6 +438,21 @@ export function MessageNavRail({
           // 该轮次的内容当前正显示在视口里 → 提亮(Codex 同款"屏上内容高亮");
           // 当前项在提亮之上再加长,两个信号分工:范围 = 在看什么,长刻度 = 读到哪。
           const inView = rangeStartIdx >= 0 && fullIdx >= rangeStartIdx && fullIdx <= rangeEndIdx;
+          // 自动化提问是系统注入的重复性消息,用更短的刻度保留其导航入口,
+          // 同时让手动提问成为更容易扫到的主节奏。当前项仍比普通自动刻度更长,
+          // 保持点击跳转后的定位反馈。
+          const tickWidthClass = isActive
+            ? entry.isAutomation
+              ? 'w-3'
+              : 'w-4'
+            : inView
+              ? entry.isAutomation
+                ? 'w-2.5'
+                : 'w-3'
+              : entry.isAutomation
+                ? 'w-2'
+                : 'w-3';
+          const tickHoverWidthClass = entry.isAutomation ? 'group-hover:w-3' : 'group-hover:w-3.5';
           return (
             <Tooltip.Root key={entry.id}>
               <Tooltip.Trigger asChild>
@@ -448,6 +463,7 @@ export function MessageNavRail({
                     preview,
                   })}
                   aria-current={isActive ? 'true' : undefined}
+                  data-message-nav-automation={entry.isAutomation ? 'true' : undefined}
                   onClick={() => handleTickClick(entry.id)}
                   onMouseEnter={handleTickMouseEnter}
                   onMouseLeave={handleTickMouseLeave}
@@ -468,11 +484,11 @@ export function MessageNavRail({
                       'h-[2px] rounded-full',
                       'transition-[width,background-color] duration-[var(--motion-base)]',
                       'ease-[var(--motion-ease-move)]',
-                      isActive
-                        ? 'w-4 bg-[var(--text-primary)]'
-                        : inView
-                          ? 'w-3 bg-[var(--text-primary)] group-hover:w-3.5'
-                          : 'w-3 bg-[var(--border-default)] group-hover:w-3.5 group-hover:bg-[var(--text-secondary)]',
+                      tickWidthClass,
+                      inView || isActive
+                        ? 'bg-[var(--text-primary)]'
+                        : 'bg-[var(--border-default)] group-hover:bg-[var(--text-secondary)]',
+                      tickHoverWidthClass,
                     )}
                   />
                 </button>

--- a/apps/desktop/src/renderer/components/chat/__tests__/MessageNavRail.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/__tests__/MessageNavRail.test.tsx
@@ -81,6 +81,14 @@ const ENTRIES: NavRailEntry[] = [
   { id: 'u5', preview: '第五问' },
 ];
 
+const MIXED_ENTRIES: NavRailEntry[] = [
+  { id: 'u1', preview: '第一问' },
+  { id: 'u2', preview: '自动任务提问', isAutomation: true },
+  { id: 'u3', preview: '第三问' },
+  { id: 'u4', preview: '第四问' },
+  { id: 'u5', preview: '第五问' },
+];
+
 describe('MessageNavRail', () => {
   beforeEach(() => {
     document.body.innerHTML = '';
@@ -170,6 +178,33 @@ describe('MessageNavRail', () => {
     fireEvent.click(screen.getAllByRole('button')[4]);
     expect(onJump).toHaveBeenCalledWith('u5');
     expect(screen.getAllByRole('button')[4].getAttribute('aria-current')).toBe('true');
+  });
+
+  it('自动化提问使用更短的刻度,但保留相同点击定位入口', async () => {
+    const root = buildScrollContainer(1000, [
+      { id: 'u1', top: -400 },
+      { id: 'u2', top: 50 },
+      { id: 'u3', top: 400 },
+      { id: 'u4', top: 600 },
+      { id: 'u5', top: 900 },
+    ]);
+    render(
+      <MessageNavRail
+        entries={MIXED_ENTRIES}
+        scrollRef={{ current: root }}
+        contentMaxWidth={880}
+        bottomOffset={200}
+        onJump={vi.fn()}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getAllByRole('button')).toHaveLength(5);
+    });
+    const buttons = screen.getAllByRole('button');
+    expect(buttons[1].getAttribute('data-message-nav-automation')).toBe('true');
+    expect(buttons[0].getAttribute('data-message-nav-automation')).toBeNull();
+    expect(buttons[1].querySelector('span')?.className).toContain('w-2');
+    expect(buttons[0].querySelector('span')?.className).toContain('w-3');
   });
 
   it('渲染窗口外的锚点(DOM 缺失)视作已越过阈值', async () => {

--- a/apps/desktop/src/renderer/components/chat/messageNavRailModel.ts
+++ b/apps/desktop/src/renderer/components/chat/messageNavRailModel.ts
@@ -15,6 +15,8 @@ import { resolveUserDisplayText } from './userMessageDisplayText';
 export interface NavRailEntry {
   /** user 消息的 clientId,同时是 data-message-client-id 锚点值。 */
   id: string;
+  /** scheduler 注入的自动化提问;导航条用更短的刻度与手动提问区分。 */
+  isAutomation?: boolean;
   /**
    * 提问的单行预览。不是原文首行:user 消息可能带 composer 引用标记行
    * (`> <!-- cindy-composer-quote -->`),直接截原文会把内部标记裸奔进
@@ -154,11 +156,16 @@ export function deriveNavRailEntries(messages: readonly ChatMessage[]): NavRailE
       if (!preview) preview = attachmentNames.join(' · ');
       const attachmentCount = (m.images?.length ?? 0) + (m.files?.length ?? 0);
       if (preview) {
-        entries.push({ id: m.clientId, preview });
+        entries.push({ id: m.clientId, preview, isAutomation: Boolean(m.automationOrigin) });
       } else if (attachmentCount > 0) {
         // 有附件但一个名字都取不到(粘贴截图):仍是真实提问,保留刻度,
         // 预览文案由组件按 attachmentsOnly 用 i18n 兜底。
-        entries.push({ id: m.clientId, preview: '', attachmentsOnly: attachmentCount });
+        entries.push({
+          id: m.clientId,
+          preview: '',
+          attachmentsOnly: attachmentCount,
+          isAutomation: Boolean(m.automationOrigin),
+        });
       }
       // 无文本、无附件 → 无法识别的空刻度,不当成提问(PR #830 review)。
       continue;

--- a/apps/desktop/src/renderer/components/settings/MessageNavRailCell.tsx
+++ b/apps/desktop/src/renderer/components/settings/MessageNavRailCell.tsx
@@ -1,6 +1,6 @@
 /**
  * MessageNavRailCell — TipsSection 内的 "显示提问导航条" cell row。
- * 纯 Renderer 本地偏好(localStorage,默认关闭),切换立即生效,无 IPC。
+ * 纯 Renderer 本地偏好(localStorage,默认开启),切换立即生效,无 IPC。
  * 行内形态与 SilentEncryptedRetryCell 对齐;恢复默认走 DefaultOverrideControls
  * (语义 = 清 override 跟随版本默认,见 useMessageNavRailPreference)。
  */
@@ -38,7 +38,7 @@ export function MessageNavRailCell() {
         </div>
       </div>
       <div className="flex items-center gap-2">
-        <DefaultOverrideControls isCustomized={isCustomized} onReset={() => setEnabled(false)} />
+        <DefaultOverrideControls isCustomized={isCustomized} onReset={() => setEnabled(true)} />
         <Switch
           checked={enabled}
           onCheckedChange={setEnabled}

--- a/apps/desktop/src/renderer/hooks/__tests__/useMessageNavRailPreference.test.ts
+++ b/apps/desktop/src/renderer/hooks/__tests__/useMessageNavRailPreference.test.ts
@@ -2,8 +2,8 @@
 
 /**
  * useMessageNavRailPreference — 覆盖 override 语义(规则 20):
- *  - 默认关闭;localStorage 只存 override
- *  - 开启 → 写入;关回默认 → 删除 key(清 override)
+ *  - 默认开启;localStorage 只存 override
+ *  - 关闭 → 写入;开回默认 → 删除 key(清 override)
  *  - 非法存储值回落默认
  */
 
@@ -24,34 +24,43 @@ describe('useMessageNavRailPreference', () => {
     _resetMessageNavRailPreferenceForTests();
   });
 
-  it('defaults to disabled with no stored override', () => {
-    expect(getMessageNavRailEnabled()).toBe(false);
+  it('defaults to enabled with no stored override', () => {
+    expect(getMessageNavRailEnabled()).toBe(true);
     const { result } = renderHook(() => useMessageNavRailPreference());
-    expect(result.current.enabled).toBe(false);
+    expect(result.current.enabled).toBe(true);
     expect(result.current.isCustomized).toBe(false);
   });
 
-  it('reads a stored enabled override', () => {
+  it('reads a stored disabled override', () => {
+    localStorage.setItem(KEY, 'false');
+    expect(getMessageNavRailEnabled()).toBe(false);
+    const { result } = renderHook(() => useMessageNavRailPreference());
+    expect(result.current.enabled).toBe(false);
+    expect(result.current.isCustomized).toBe(true);
+  });
+
+  it('keeps an older stored enabled value as a user override', () => {
     localStorage.setItem(KEY, 'true');
     expect(getMessageNavRailEnabled()).toBe(true);
     const { result } = renderHook(() => useMessageNavRailPreference());
+    expect(result.current.enabled).toBe(true);
     expect(result.current.isCustomized).toBe(true);
   });
 
   it('falls back to default on garbage stored value', () => {
     localStorage.setItem(KEY, 'whatever');
-    expect(getMessageNavRailEnabled()).toBe(false);
+    expect(getMessageNavRailEnabled()).toBe(true);
   });
 
-  it('enabling persists override; disabling removes the key', () => {
+  it('disabling persists override; enabling removes the key', () => {
     const { result } = renderHook(() => useMessageNavRailPreference());
-    act(() => result.current.setEnabled(true));
-    expect(localStorage.getItem(KEY)).toBe('true');
-    expect(getMessageNavRailEnabled()).toBe(true);
-
     act(() => result.current.setEnabled(false));
-    expect(localStorage.getItem(KEY)).toBeNull();
+    expect(localStorage.getItem(KEY)).toBe('false');
     expect(getMessageNavRailEnabled()).toBe(false);
+
+    act(() => result.current.setEnabled(true));
+    expect(localStorage.getItem(KEY)).toBeNull();
+    expect(getMessageNavRailEnabled()).toBe(true);
     expect(result.current.isCustomized).toBe(false);
   });
 });

--- a/apps/desktop/src/renderer/hooks/useMessageNavRailPreference.ts
+++ b/apps/desktop/src/renderer/hooks/useMessageNavRailPreference.ts
@@ -2,11 +2,12 @@
  * useMessageNavRailPreference — 聊天区左缘"提问导航条"的显隐偏好。
  * ---------------------------------------------------------------------------
  * 两态:
- *   - false  不显示导航条(系统默认值)。
- *   - true   在符合出场条件的对话里显示(提问 ≥4、留白/高度达标,见 MessageNavRail)。
+ *   - true   在符合出场条件的对话里显示(系统默认值)。
+ *   - false  用户可通过设置关闭导航条。
+ *   - 出场仍受 MessageNavRail 的提问数量、留白与高度条件限制。
  *
  * 规则 20(配置默认值 vs override)落法:localStorage 只存 override——
- * 用户关回 false(= 当前系统默认)时**删除** key 而不是写入,这样未自定义
+ * 用户开回 true(= 当前系统默认)时**删除** key 而不是写入,这样未自定义
  * 的用户未来能自动跟随新版本默认值;isCustomized 即 "存在 override"。
  *
  * 模块级内存值做跨实例 SoT + `storage` 事件跨窗口同步,模式与
@@ -16,27 +17,38 @@
 import { useCallback, useEffect, useState } from 'react';
 
 const STORAGE_KEY = 'chat.messageNavRail.enabled';
-const DEFAULT_ENABLED = false;
+const DEFAULT_ENABLED = true;
 /** override 的持久化形态;只有非默认值会落盘。 */
-const STORED_ENABLED = 'true';
+const STORED_DISABLED = 'false';
 
-function parseStored(raw: string | null): boolean | null {
-  return raw === STORED_ENABLED ? true : null;
+function parseStored(raw: string | null): { value: boolean; customized: boolean } {
+  if (raw === 'true') return { value: true, customized: true };
+  if (raw === STORED_DISABLED) return { value: false, customized: true };
+  return { value: DEFAULT_ENABLED, customized: false };
 }
 
 /** 模块级内存 SoT;null = 尚未被本窗口读定/写定。 */
 let memoryValue: boolean | null = null;
+let memoryCustomized: boolean | null = null;
+
+function readPreference(): { value: boolean; customized: boolean } {
+  if (memoryValue !== null && memoryCustomized !== null) {
+    return { value: memoryValue, customized: memoryCustomized };
+  }
+  try {
+    const parsed = parseStored(localStorage.getItem(STORAGE_KEY));
+    memoryValue = parsed.value;
+    memoryCustomized = parsed.customized;
+    return parsed;
+  } catch {
+    // localStorage 不可用——退回默认(不落定内存,留待后续写入)。
+    return { value: DEFAULT_ENABLED, customized: false };
+  }
+}
 
 /** 同步读——给非 hook 路径用。 */
 export function getMessageNavRailEnabled(): boolean {
-  if (memoryValue !== null) return memoryValue;
-  try {
-    const parsed = parseStored(localStorage.getItem(STORAGE_KEY));
-    if (parsed !== null) return (memoryValue = parsed);
-  } catch {
-    // localStorage 不可用——退回默认(不落定内存,留待后续写入)。
-  }
-  return DEFAULT_ENABLED;
+  return readPreference().value;
 }
 
 const listeners = new Set<() => void>();
@@ -47,17 +59,18 @@ export function useMessageNavRailPreference(): {
   isCustomized: boolean;
   setEnabled: (next: boolean) => void;
 } {
-  const [enabled, setState] = useState<boolean>(getMessageNavRailEnabled);
+  const [preference, setPreference] = useState(readPreference);
 
   const setEnabled = useCallback((next: boolean) => {
     memoryValue = next;
-    setState(next);
+    memoryCustomized = next !== DEFAULT_ENABLED;
+    setPreference({ value: next, customized: memoryCustomized });
     try {
       if (next === DEFAULT_ENABLED) {
-        // 关回默认 = 清除 override(而非写入默认值快照)。
+        // 开回默认 = 清除 override(而非写入默认值快照)。
         localStorage.removeItem(STORAGE_KEY);
       } else {
-        localStorage.setItem(STORAGE_KEY, STORED_ENABLED);
+        localStorage.setItem(STORAGE_KEY, STORED_DISABLED);
       }
     } catch {
       // localStorage 不可用——内存 SoT 已生效;仅跨窗口同步缺失。
@@ -66,11 +79,13 @@ export function useMessageNavRailPreference(): {
   }, []);
 
   useEffect(() => {
-    const sync = () => setState(getMessageNavRailEnabled());
+    const sync = () => setPreference(readPreference());
     listeners.add(sync);
     const onStorage = (e: StorageEvent) => {
       if (e.key !== STORAGE_KEY) return;
-      memoryValue = parseStored(e.newValue) ?? DEFAULT_ENABLED;
+      const next = parseStored(e.newValue);
+      memoryValue = next.value;
+      memoryCustomized = next.customized;
       sync();
     };
     window.addEventListener('storage', onStorage);
@@ -80,11 +95,16 @@ export function useMessageNavRailPreference(): {
     };
   }, []);
 
-  return { enabled, isCustomized: enabled !== DEFAULT_ENABLED, setEnabled };
+  return {
+    enabled: preference.value,
+    isCustomized: preference.customized,
+    setEnabled,
+  };
 }
 
 /** 测试专用:清空内存 SoT,让下一次读回落 localStorage / 默认值。 */
 export function _resetMessageNavRailPreferenceForTests(): void {
   memoryValue = null;
+  memoryCustomized = null;
   listeners.clear();
 }


### PR DESCRIPTION
## 这次改了什么

### 摘要

默认开启聊天正文左侧的提问导航条，并用更短的刻度区分自动化发送的消息，让用户在长任务中能快速定位自己发出的消息与自动化消息。

导航条仍只在提问数、窗口留白和可用高度达到现有条件时出现；用户可在设置中关闭。偏好继续采用“系统默认 + 用户 override”：新用户和未自定义用户跟随新的开启默认值，旧版已存的 true / false 均保留为显式自定义，恢复默认会删除 override 并回到开启。

旧版以关闭为默认值，用户切回关闭时会删除存储键；因此升级前的缺失键无法区分“从未自定义”和“曾显式关闭后回到旧默认”。本次默认值演进将缺失键按未自定义处理并跟随新的开启默认值，不新增无法追溯既有历史意图的迁移标记。

### 变更类型

- [x] feat 新功能
- [ ] fix 缺陷修复
- [ ] refactor / perf 重构或性能优化
- [ ] docs / test / chore 文档、测试或工程维护

### 范围

- 关联 Issue / 需求：用户反馈——提问导航条应区分手动消息与自动化消息，并默认开启
- 本 PR 包含：自动化来源投影到导航条条目；自动化短刻度；导航条默认开启；旧偏好 override 兼容；回归测试
- 明确不包含：导航条出场门槛、滚动定位算法、预览卡内容与移动端 UI
- 用户可见变化：符合出场条件的长任务默认显示导航条；自动化消息刻度更短；设置中可关闭或恢复默认
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：docs/design-rules/DESIGN.md §2 Color Palette & Roles、§10 Theme System & Token Reference、§14 Interaction Conventions、Light / Dark Dual-Mode Delivery Gate。刻度仍使用既有语义 token 与动效 token，不新增颜色；仅通过长度建立信息层级，点击区域、键盘焦点、悬停和当前项反馈保持不变；Light / Dark 共用同一 token 路径。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/renderer/hooks/__tests__/useMessageNavRailPreference.test.ts src/renderer/__tests__/messageNavRailModel.test.ts src/renderer/components/chat/__tests__/MessageNavRail.test.tsx
结果：3 个测试文件、63 个测试全部通过

pnpm --filter desktop typecheck
结果：通过

bash /Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh /Users/dash/Code/Cindy/cindy-question-nav-auto-label
结果：GATE_EXIT=0，仓库根 pnpm test:unit 全部通过

pnpm check:dco
结果：1 个提交 DCO 签名通过
```

### 手工验证

- macOS：从本 worktree 启动 Global Desktop 开发版，并用 pnpm desktop:whoami --all 确认运行实例来源与 worktree 一致。
- 未逐项目检自动化短刻度在真实长任务中的最终视觉效果。

### 未执行的验证

- 未单独实机目检 Light / Dark 两种模式；实现复用导航条现有语义 token，自动测试覆盖结构与宽度差异。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异

### 影响与回滚

- 已知兼容性取舍：旧版缺失存储键无法区分未自定义用户与曾显式关闭后回到旧默认的用户；两类用户都会跟随新的开启默认值。现存 true / false override 均保持不变。
- 影响范围：Desktop Renderer 的提问导航条与本地显隐偏好；不涉及数据库、协议、服务端或插件。
- 回滚 / 降级方式：用户可在设置中关闭导航条；代码回滚后旧版 true override 仍可继续读取。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] UI 改动已在 UI 变化注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已确认测试结果或说明未执行原因
