### PR TITLE
fix(desktop): 账号切换不再把在飞任务伪装成正常收尾

### DIFF
--- a/apps/desktop/src/main/bootstrap-electron.ts
+++ b/apps/desktop/src/main/bootstrap-electron.ts
@@ -289,7 +289,10 @@ import {
   resolveBetterSqliteModuleEntry,
   resolveBetterSqliteNativeBinding,
 } from './localDb/betterSqliteFactory';
-import { freezeSessionActiveTurnMarkers } from './localDb/sessionActiveTurn';
+import {
+  beginSessionTurnEndedSuppression,
+  freezeSessionActiveTurnMarkers,
+} from './localDb/sessionActiveTurn';
 import { getDrizzleDir } from './localDb/migrate';
 import { resolveSqliteVecExtPath } from './localDb/sqliteVecLoader';
 import {
@@ -1196,26 +1199,38 @@ async function teardownAuthAccountBoundary(reason: string): Promise<void> {
   // 的 Maker 上兑现旧 owner 的记忆设置重启(shutdown 触发的会话关闭事件也会
   // 撞上它,先清再关)。
   clearDeferredCodexRestartForOwnerBoundary();
+  // interrupted-turn-resume:shutdown 批量 close 会话会触发 close teardown 的
+  // markSessionTurnEnded,把"边界时还在飞的 turn"伪装成正常收尾 —— 被切换打断的
+  // 任务从此既无中断横幅也无红点,呈现为"卡住且无报错"(与 ⌘Q 的 quit freeze 同款
+  // 问题,quit freeze 只保护退出编排,不覆盖这里)。shutdown 到 DB dispose 期间抑制
+  // ended 写,保住 startedAt > endedAt 的中断痕迹;不覆盖 teardown 前段,边界早段
+  // 自然完成的 turn 照常收尾。释放放 finally:抑制器是进程级计数,泄漏一次就把
+  // 后续 owner 的正常收尾写全部吞掉,中断横幅会在每个正常完成的任务上误弹。
+  const releaseEndedSuppression = beginSessionTurnEndedSuppression();
   try {
-    const maker = getMakerIfReady();
-    if (maker) await maker.shutdown();
-    resetMaker();
-  } catch (err) {
-    authBoundaryLog.error(`maker shutdown on ${reason} failed (non-fatal):`, err);
-    resetMaker();
+    try {
+      const maker = getMakerIfReady();
+      if (maker) await maker.shutdown();
+      resetMaker();
+    } catch (err) {
+      authBoundaryLog.error(`maker shutdown on ${reason} failed (non-fatal):`, err);
+      resetMaker();
+    }
+    // device-link 单持有者仲裁:必须在 dispose DbClient **之前**释放持有权行
+    // (dispose 同步 clearCurrentDbClient,之后 store 不可用,只能等 15s+ 心跳
+    // 过期,同机幸存实例接管变慢)。内部带 1.5s 超时,不会卡住登出。
+    try {
+      await releaseDeviceLinkOwnershipBeforeLogout();
+    } catch (err) {
+      authBoundaryLog.error(
+        `[bootstrap-electron] release device-link ownership on ${reason} failed (non-fatal):`,
+        err,
+      );
+    }
+    await lifecycleDbClientManager.dispose(reason);
+  } finally {
+    releaseEndedSuppression();
   }
-  // device-link 单持有者仲裁:必须在 dispose DbClient **之前**释放持有权行
-  // (dispose 同步 clearCurrentDbClient,之后 store 不可用,只能等 15s+ 心跳
-  // 过期,同机幸存实例接管变慢)。内部带 1.5s 超时,不会卡住登出。
-  try {
-    await releaseDeviceLinkOwnershipBeforeLogout();
-  } catch (err) {
-    authBoundaryLog.error(
-      `[bootstrap-electron] release device-link ownership on ${reason} failed (non-fatal):`,
-      err,
-    );
-  }
-  await lifecycleDbClientManager.dispose(reason);
   agentIslandService?.resetRuntimeState();
 }
 

--- a/apps/desktop/src/main/localDb/__tests__/sessionActiveTurn.test.ts
+++ b/apps/desktop/src/main/localDb/__tests__/sessionActiveTurn.test.ts
@@ -1,6 +1,7 @@
 /**
  * interrupted-turn-resume(简化版)单测。
- * 覆盖:started/ended 时间戳写入与保序、quit freeze、「疑似中断」pending 判定
+ * 覆盖:started/ended 时间戳写入与保序、quit freeze、owner 边界 ended 写抑制
+ * (有作用域、可释放、重入安全)、「疑似中断」pending 判定
  * (ended / cleared 边界、deleted / 不可见来源排除)、ended 落库后的注入回调通知
  * (广播假阳性修复:生效值读回 / 异常不断链 / ack resolve 前发出),以及 retry
  * 续跑判定 hasAssistantProgressAfterMessage 的正负路径。
@@ -271,6 +272,83 @@ describe('sessionActiveTurn', () => {
     const row = await readMarks(client, 's-quit');
     expect(row?.last_turn_ended_at).toBeNull();
     expect(row!.active_turn_started_at!).toBeGreaterThan(0);
+  });
+
+  it('owner-boundary suppression blocks ended writes while held and restores them after release', async () => {
+    const { markSessionTurnStarted, markSessionTurnEnded, beginSessionTurnEndedSuppression } =
+      await import('../sessionActiveTurn.js');
+    const client = createTestDbClient();
+    await seedSession(client, 's-owner-boundary');
+
+    markSessionTurnStarted('s-owner-boundary');
+    await vi.waitFor(async () => {
+      expect((await readMarks(client, 's-owner-boundary'))?.active_turn_started_at).toBeTypeOf(
+        'number',
+      );
+    });
+
+    // 模拟切账号:owner 边界 teardown 抑制期间,maker.shutdown 关 session 触发的
+    // ended 写必须 no-op —— 否则被切换打断的在飞 turn 被伪装成正常收尾,重新打开
+    // 会话时既无中断横幅也无红点(2026-08-11 实报:跨区凭证误判触发账号切换,
+    // busy Codex 会话静默孤儿化)。
+    const release = beginSessionTurnEndedSuppression();
+    markSessionTurnEnded('s-owner-boundary');
+    await new Promise((r) => setTimeout(r, 20));
+    expect((await readMarks(client, 's-owner-boundary'))?.last_turn_ended_at).toBeNull();
+
+    // 释放后(新 owner 的运行期)正常收尾写恢复 —— 抑制必须有作用域,不能像
+    // quit freeze 一样永久生效,否则新 owner 每个正常完成的任务都会误报中断。
+    release();
+    markSessionTurnEnded('s-owner-boundary');
+    await vi.waitFor(async () => {
+      const row = await readMarks(client, 's-owner-boundary');
+      expect(row?.last_turn_ended_at).toBeTypeOf('number');
+      expect(row!.last_turn_ended_at!).toBeGreaterThanOrEqual(row!.active_turn_started_at!);
+    });
+  });
+
+  it('owner-boundary suppression release is idempotent and reentrant holds stack', async () => {
+    const { markSessionTurnEnded, beginSessionTurnEndedSuppression } =
+      await import('../sessionActiveTurn.js');
+    const client = createTestDbClient();
+    const startedAt = Date.now() - 1_000;
+    await seedSession(client, 's-owner-reentrant', { startedAt });
+
+    // 重入:两个边界流程重叠持有(极端但登出+切号竞态可达),任一释放不解除另一个。
+    const releaseA = beginSessionTurnEndedSuppression();
+    const releaseB = beginSessionTurnEndedSuppression();
+    releaseA();
+    releaseA(); // 幂等:重复释放不把 B 的持有也计销。
+    markSessionTurnEnded('s-owner-reentrant');
+    await new Promise((r) => setTimeout(r, 20));
+    expect((await readMarks(client, 's-owner-reentrant'))?.last_turn_ended_at).toBeNull();
+
+    releaseB();
+    markSessionTurnEnded('s-owner-reentrant');
+    await vi.waitFor(async () => {
+      expect((await readMarks(client, 's-owner-reentrant'))?.last_turn_ended_at).toBeTypeOf('number');
+    });
+  });
+
+  it('owner-boundary suppression also blocks barrier ended writes at call time', async () => {
+    const {
+      markSessionTurnStarted,
+      markSessionTurnEndedAfterBarrier,
+      beginSessionTurnEndedSuppression,
+    } = await import('../sessionActiveTurn.js');
+    const client = createTestDbClient();
+    await seedSession(client, 's-owner-barrier');
+    markSessionTurnStarted('s-owner-barrier');
+    await vi.waitFor(async () => {
+      expect((await readMarks(client, 's-owner-barrier'))?.active_turn_started_at).toBeTypeOf('number');
+    });
+
+    // shutdown close 经 barrier 版收尾同样要被挡(与 quit freeze 的对应用例同构)。
+    const release = beginSessionTurnEndedSuppression();
+    markSessionTurnEndedAfterBarrier('s-owner-barrier', Promise.resolve());
+    await new Promise((r) => setTimeout(r, 20));
+    expect((await readMarks(client, 's-owner-barrier'))?.last_turn_ended_at).toBeNull();
+    release();
   });
 
   it('ended write notifies the injected listener with the effective DB value', async () => {

--- a/apps/desktop/src/main/localDb/sessionActiveTurn.ts
+++ b/apps/desktop/src/main/localDb/sessionActiveTurn.ts
@@ -73,6 +73,36 @@ export function freezeSessionActiveTurnMarkers(): void {
 }
 
 /**
+ * 数据 owner 边界(切账号 / 登出)的**有作用域** ended 写抑制 —— 与 _quitFrozen
+ * 同一语义:边界 teardown 的 maker.shutdown 会批量 close 所有本地会话,close
+ * teardown 触发的 ended 写会把"边界时还在飞的 turn"伪装成正常收尾,被切换打断
+ * 的任务既无中断横幅也无红点,呈现为"卡住且无报错"(2026-08-11 实报:凭证跨区
+ * 误判触发账号切换,busy Codex 会话被静默孤儿化)。与 quit freeze 的差别只有一个:
+ * 边界后进程继续服务新 owner,必须可释放。计数器支持重入;返回的释放函数幂等。
+ *
+ * 残余竞态说明:close 触发的 ended 写来自 session status listener 的 async handler,
+ * 不被 maker.shutdown 的 await 覆盖,理论上可能晚于释放时刻。调用方靠「持有到
+ * teardown 尾部(DB dispose 之后)」把窗口压到极小;真漏网的迟到写会撞上已
+ * dispose 的 DbClient,由写链吞错落日志,不会污染时间戳。
+ */
+let _endedWriteSuppressions = 0;
+
+export function beginSessionTurnEndedSuppression(): () => void {
+  _endedWriteSuppressions += 1;
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    _endedWriteSuppressions -= 1;
+  };
+}
+
+/** ended 写抑制判定:quit freeze 或任一在持有的 owner 边界抑制。 */
+function isEndedWriteSuppressed(): boolean {
+  return _quitFrozen || _endedWriteSuppressions > 0;
+}
+
+/**
  * ended 落库后的通知回调(见文件头「ended 落库后广播」)。由 localDb/ipc/sessions.ts
  * 在 registerSessionIpc 时注入 broadcastSessionPatched —— 本模块不直接 import 它,
  * 因为 ipc/sessions.ts 已 import 本模块(ack 路径),反向依赖会成环;注入也让单测
@@ -159,7 +189,7 @@ export function markSessionTurnStarted(sessionId: string): void {
  * 在重启后误判为中断。只允许时间戳前进。
  */
 export function markSessionTurnEnded(sessionId: string, endedAtOverride?: number): void {
-  if (_quitFrozen) return;
+  if (isEndedWriteSuppressed()) return;
   const notifyContext = captureTurnEndedPersistedContext();
   enqueueEndedWrite(
     sessionId,
@@ -178,7 +208,7 @@ export function markSessionTurnEnded(sessionId: string, endedAtOverride?: number
  * 入队时刻判定」的语义一致(barrier 版的"入队时刻"= 本函数调用时刻)。
  */
 export function markSessionTurnEndedAfterBarrier(sessionId: string, barrier: Promise<unknown>): void {
-  if (_quitFrozen) return;
+  if (isEndedWriteSuppressed()) return;
   const endedAt = Date.now();
   const notifyContext = captureTurnEndedPersistedContext();
   void barrier.then(
@@ -577,5 +607,10 @@ function summarizeRecoveryContent(raw: string): string {
 export function _resetSessionActiveTurnStateForTests(): void {
   _writeChains.clear();
   _quitFrozen = false;
+  _endedWriteSuppressions = 0;
   _onTurnEndedPersisted = null;
+  // bootAt 一并重置:它在模块 import 时定格,而用例常以「相对 now 的 startedAt」
+  // 造数据 —— 文件内前置用例的累计耗时一旦超过该相对差,后续用例的中断判定就会
+  // 因 startedAt >= bootAt 静默翻转(时钟脆弱)。每个用例重新定基消除顺序耦合。
+  _bootAtMs = Date.now();
 }


### PR DESCRIPTION
## 这次改了什么

### 摘要

账号切换 / 登出(数据 owner 边界)时,`teardownAuthAccountBoundary` 的 `maker.shutdown()` 会批量 close 所有本地会话;close teardown 会给每个被关会话写 `markSessionTurnEnded`,把「边界时还在飞的 turn」伪装成正常收尾。被切换打断的任务从此既无中断横幅、无红点、也无错误行 —— 用户看到的是「任务永远没有进度,但也没有报错」。

2026-08-11 实机复现:凭证跨区误判(`runtime refresh rejected cross-realm personal session realm=global buildRegion=cn`)触发运行时账号切换,3 个正在跑 turn 的本地 Codex 会话被静默孤儿化,UI 永久停留在运行中。

⌘Q 场景已有 `freezeSessionActiveTurnMarkers()`(quit freeze)保护同款问题,但它只挂在退出编排上且不可释放,不覆盖 owner 边界。本次:

- `sessionActiveTurn.ts` 新增**有作用域**的 ended 写抑制 `beginSessionTurnEndedSuppression()`(计数器重入安全、释放函数幂等),与 quit freeze 共用同一判定入口;
- `teardownAuthAccountBoundary` 在 `maker.shutdown()` 到 DB dispose 期间持有抑制、`finally` 释放 —— 被打断会话保住 `startedAt > endedAt` 的中断痕迹,复用**现有**的「继续任务 / 忽略」横幅与重启后中断红点,不新增任何 UI 或持久化结构;
- 顺带修一处测试脆弱性:`_resetSessionActiveTurnStateForTests` 同步重置 `_bootAtMs`,消除同文件用例因累计耗时超过相对时间差导致的顺序耦合(本次加用例时实际踩到)。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无(实机故障排查直接转修复)
- 本 PR 包含：owner 边界 teardown 期间抑制 `lastTurnEndedAt` 写入;对应单测
- 明确不包含：凭证跨区误判本身的修复(另有 `dash/fix-region-userdata-auth-isolation` 线);账号切换前对 busy 会话的主动确认/挽留交互
- 用户可见变化：账号切换打断正在运行的任务后,重新打开该任务会显示既有的「任务被中断 → 继续任务 / 忽略」横幅(此前完全无提示)
- 是否存在 breaking change：无

### UI 变化

不涉及:复用既有 `InterruptedTurnBanner` 与中断红点,无新增或修改的视觉/交互/文案。

- 引用的设计规范：不涉及(未触碰 UI 代码路径)

## 怎么验证的

### 自动验证

- `bash run-unit-gate.sh <worktree>`(仓库根 `pnpm test:unit` 全量)→ GATE_EXIT=0 全绿
- `pnpm --filter desktop exec vitest run src/main/localDb/__tests__/sessionActiveTurn.test.ts` → 24 passed(含新增 3 个用例:抑制期间 ended 写 no-op 且释放后恢复、重入/幂等释放、barrier 版收尾同样被挡)
- `pnpm --filter desktop run typecheck` → 通过

### 手动验证

- 未做实机切账号验证(需要双账号环境);故障现场由 2026-08-11 本机日志确认:`main-2026-08-11.log` 18:04:02 的 `runtime-replacement-account-switch` teardown 与其后 3 个 busy Codex 会话零事件、无错误写回。

## 风险与回滚

- 风险:抑制窗口内(shutdown → DB dispose)如有 turn 恰好**正常完成**,其 ended 写会被一并抑制,该会话下次打开会多弹一次「继续任务/忽略」横幅 —— 点忽略即消,无数据损失;与既有 quit freeze 的取舍方向一致(宁多提示,不吞中断)。
- 抑制器为进程级计数,若泄漏会导致后续正常收尾全部误判中断;已用 `finally` 释放 + 幂等释放函数 + 单测覆盖守住。
- close 触发的 ended 写理论上可迟于释放时刻(async listener 不被 shutdown await 覆盖);持有到 DB dispose 之后把窗口压到极小,真漏网的迟到写撞已 dispose 的 DbClient,由写链吞错落日志,不污染时间戳(代码注释已说明)。
- 回滚:revert 单 commit 即可,无 schema / 协议 / 持久化格式变更。

## Self-review Checklist

- [x] 改动聚焦单一目标,无无关 diff
- [x] 已读相关规则文档(credentials-and-local-storage、database-and-migrations 不涉及 schema 变更;engineering-conventions)
- [x] 单测门禁全绿,typecheck 通过
- [x] 新增逻辑有单测覆盖
- [x] 注释说明了残余竞态与取舍
- [x] 无凭证/敏感信息入库
- [ ] 实机双模式目检(不涉及 UI)
