### PR TITLE
fix(desktop): mark images unavailable for text-only models

### DIFF
--- a/apps/desktop/src/main/__tests__/agentInputQueue.test.ts
+++ b/apps/desktop/src/main/__tests__/agentInputQueue.test.ts
@@ -92,6 +92,51 @@ describe('agentInputQueue', () => {
     });
   });
 
+  it('does not append an unavailable marker when the original image is delivered', () => {
+    const entry = queuedMessage([
+      {
+        id: 'image-1',
+        name: 'shot.png',
+        path: '/repo/shot.png',
+        ext: '.png',
+        size: 128,
+        category: 'image',
+        mimeType: 'image/png',
+      },
+    ]);
+    const message = buildMakerUserMessage(entry);
+    expect(message).toMatchObject({
+      type: 'user',
+      content: [
+        { type: 'text', text: 'inspect attachment' },
+        { type: 'image', path: '/repo/shot.png', mimeType: 'image/png' },
+      ],
+    });
+    expect(JSON.stringify(message)).not.toContain('IMAGE_ATTACHMENT_UNAVAILABLE_V1');
+  });
+
+  it('projects an unavailable marker without deleting the stored image attachment', () => {
+    const entry = queuedMessage([
+      {
+        id: 'image-1',
+        name: 'shot.png',
+        path: '/repo/shot.png',
+        ext: '.png',
+        size: 128,
+        category: 'image',
+        mimeType: 'image/png',
+      },
+    ]);
+    const message = buildMakerUserMessage(entry, [], { imageMode: 'omit' });
+    const serialized = JSON.stringify(message);
+    expect(serialized).not.toContain('"type":"image"');
+    expect(serialized).toContain('IMAGE_ATTACHMENT_UNAVAILABLE_V1');
+    expect(serialized).toContain('user_uploaded_image');
+    expect(serialized).toContain('shot.png');
+    expect(serialized).toContain('did not receive the image');
+    expect(entry.files).toHaveLength(1);
+  });
+
   it('appends the hidden annotation note once after all blocks for annotated images', () => {
     expect(
       buildMakerUserMessage(

--- a/apps/desktop/src/main/maker-host/__tests__/codexHistoryImageMarker.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codexHistoryImageMarker.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest';
+
+import { createCodexHistoryImageMarkerTransform } from '../codex-history-image-marker.js';
+
+const ctx = {
+  reqId: 1,
+  method: 'POST',
+  url: '/v1/responses',
+  headers: { 'thread-id': 'thread-1' },
+  upstreamBase: 'https://text.example/v1',
+};
+
+function transformFor(strip = true) {
+  return createCodexHistoryImageMarkerTransform({
+    shouldStripImages: () => strip,
+    sessionIdFromHeaders: () => 'session-1',
+  });
+}
+
+describe('createCodexHistoryImageMarkerTransform', () => {
+  it('replaces Responses images with an explicit unavailable marker', () => {
+    const result = transformFor()(
+      {
+        model: 'deepseek-chat',
+        input: [
+          {
+            type: 'message',
+            role: 'user',
+            content: [
+              { type: 'input_text', text: 'old question' },
+              { type: 'input_image', image_url: 'data:image/png;base64,bGVnYWN5' },
+            ],
+          },
+        ],
+      },
+      ctx,
+    );
+
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain('input_image');
+    expect(serialized).not.toContain('bGVnYWN5');
+    expect(serialized).toContain('IMAGE_ATTACHMENT_UNAVAILABLE_V1');
+    expect(serialized).toContain('user_uploaded_image');
+    expect(serialized).toContain('did not receive the image');
+  });
+
+  it('handles Chat Completions image_url objects without fetching them', () => {
+    const result = transformFor()(
+      {
+        model: 'deepseek-chat',
+        messages: [
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text: 'describe' },
+              { type: 'image_url', image_url: { url: 'https://example.test/legacy.png' } },
+            ],
+          },
+        ],
+      },
+      { ...ctx, url: '/v1/chat/completions' },
+    );
+
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain('image_url');
+    expect(serialized).not.toContain('https://example.test/legacy.png');
+    expect(serialized).toContain('Do not claim to have seen');
+  });
+
+  it('replaces direct Responses image items in their original history position', () => {
+    const result = transformFor()(
+      {
+        model: 'deepseek-chat',
+        input: [
+          { type: 'input_image', image_url: 'data:image/png;base64,cm9vdA==' },
+          { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'question' }] },
+        ],
+      },
+      ctx,
+    ) as { input: unknown[] };
+
+    expect(JSON.stringify(result)).not.toContain('input_image');
+    expect(JSON.stringify(result)).toContain('user_uploaded_image');
+    expect(result.input).toHaveLength(2);
+    expect(result.input[0]).toMatchObject({ type: 'message', role: 'user' });
+  });
+
+  it('handles Anthropic image source blocks without retaining base64 data', () => {
+    const result = transformFor()(
+      {
+        model: 'deepseek-chat',
+        messages: [
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text: 'old question' },
+              {
+                type: 'image',
+                source: { type: 'base64', media_type: 'image/png', data: 'c2Vuc2l0aXZl' },
+              },
+            ],
+          },
+        ],
+      },
+      { ...ctx, url: '/v1/messages' },
+    );
+
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain('"type":"image"');
+    expect(serialized).not.toContain('c2Vuc2l0aXZl');
+    expect(serialized).toContain('IMAGE_ATTACHMENT_UNAVAILABLE_V1');
+  });
+
+  it('is a no-op for capable or unknown routes', () => {
+    const body = {
+      model: 'vision',
+      input: [
+        { type: 'message', role: 'user', content: [{ type: 'input_image', image_url: 'x' }] },
+      ],
+    };
+    expect(transformFor(false)(body, ctx)).toBeNull();
+  });
+});

--- a/apps/desktop/src/main/maker-host/__tests__/codexImageCapability.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codexImageCapability.test.ts
@@ -1,0 +1,119 @@
+import type { Catalog, CatalogModel, Provider } from '@cindy/model-providers';
+import { describe, expect, it } from 'vitest';
+
+import type { AgentInputQueuedMessage } from '../../../shared/agentInputQueue.js';
+import { CodexImageCapabilityResolver } from '../codex-image-capability.js';
+
+function model(id: string, capability?: boolean): CatalogModel {
+  return {
+    id,
+    name: id,
+    contextWindow: 128_000,
+    efforts: [],
+    defaultEffort: null,
+    ...(capability === undefined ? {} : { supportsImageInput: capability }),
+  };
+}
+
+function provider(id: string, models: CatalogModel[], stripPrefix?: string): Provider {
+  return {
+    id,
+    name: id,
+    source: 'builtin',
+    agents: ['codex'],
+    auth: { method: 'apiKey' },
+    models: { codex: models },
+    routing: {
+      codex: {
+        upstream: 'https://example.test/v1',
+        authStrategy: 'api-key-header',
+        ...(stripPrefix ? { modelIdRewrite: { stripPrefix } } : {}),
+      },
+    },
+  };
+}
+
+function item(modelId: string, providerId?: string): AgentInputQueuedMessage {
+  return {
+    clientId: 'message-1',
+    text: 'inspect',
+    persistedContent: 'inspect',
+    model: modelId,
+    effort: 'medium',
+    permissionMode: 'default',
+    workingDir: '/repo',
+    chatMessage: { clientId: 'message-1', role: 'user', content: 'inspect' },
+    createOpts: {
+      agentKind: 'codex',
+      workingDir: '/repo',
+      model: modelId,
+      ...(providerId ? { providerId } : {}),
+    },
+  };
+}
+
+function harness(catalog: Catalog, sessionProvider: string | null = null) {
+  return new CodexImageCapabilityResolver({
+    getCatalog: () => catalog,
+    getSessionProvider: () => sessionProvider,
+  });
+}
+
+describe('CodexImageCapabilityResolver', () => {
+  it('uses the live session provider and explicit catalog capability', () => {
+    const resolver = harness(
+      {
+        version: 'test',
+        providers: [
+          provider('vision', [model('same', true)]),
+          provider('text', [model('same', false)]),
+        ],
+      },
+      'text',
+    );
+    expect(resolver.resolve('session-1', item('same', 'vision'))).toBe(false);
+  });
+
+  it('matches provider stripPrefix and one-million display suffixes', () => {
+    const resolver = harness(
+      {
+        version: 'test',
+        providers: [provider('prefixed', [model('deepseek-chat', false)], 'custom/')],
+      },
+      'prefixed',
+    );
+    expect(resolver.resolve('session-1', item('custom/deepseek-chat[1m]'))).toBe(false);
+  });
+
+  it('learns only the exact undeclared provider/model route', () => {
+    const catalog = {
+      version: 'test',
+      providers: [provider('one', [model('unknown')]), provider('two', [model('unknown')])],
+    };
+    const one = harness(catalog, 'one');
+    expect(one.resolve('session-1', item('unknown'))).toBeUndefined();
+    one.markRejected('session-1', item('unknown'));
+    expect(one.resolve('session-1', item('unknown'))).toBe(false);
+    expect(one.resolve('session-1', item('another'))).toBeUndefined();
+  });
+
+  it('lets an explicit positive catalog refresh override a learned rejection', () => {
+    let catalog: Catalog = { version: 'test', providers: [provider('one', [model('unknown')])] };
+    const resolver = new CodexImageCapabilityResolver({
+      getCatalog: () => catalog,
+      getSessionProvider: () => 'one',
+    });
+    resolver.markRejected('session-1', item('unknown'));
+    expect(resolver.resolve('session-1', item('unknown'))).toBe(false);
+
+    catalog = { version: 'test', providers: [provider('one', [model('unknown', true)])] };
+    expect(resolver.resolve('session-1', item('unknown'))).toBe(true);
+  });
+
+  it('keeps non-Codex routes outside this resolver', () => {
+    const resolver = harness({ version: 'test', providers: [] });
+    const other = item('model');
+    other.createOpts.agentKind = 'claude-code';
+    expect(resolver.resolve('session-1', other)).toBe(true);
+  });
+});

--- a/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
@@ -1969,8 +1969,8 @@ describe('codex proxy host', () => {
         // upstream 是函数形态(每请求现取,model-access 下发可运行期换 endpoint);
         // 断言其当前求值 = 网关 base + /v1
         upstream: expect.any(Function),
-        // [encrypted activeStrip, image generation activeStrip, instructions 注入, provider-aware Guardian reviewer, Gateway 原生 web_search, 跨来源压缩块兼容, strict gateway history 兼容, xAI Responses 兼容, ByteDance Seed tool 兼容, MiniMax effort 兼容, provider model rewrite, stripNonAnthropicFields]
-        transformRequest: [expect.any(Function), expect.any(Function), expect.any(Function), expect.any(Function), expect.any(Function), expect.any(Function), expect.any(Function), expect.any(Function), expect.any(Function), expect.any(Function), expect.any(Function), mockState.stripNonAnthropicFields],
+        // [encrypted activeStrip, image generation activeStrip, instructions 注入, provider-aware Guardian reviewer, text-route history image marker, Gateway 原生 web_search, 跨来源压缩块兼容, strict gateway history 兼容, xAI Responses 兼容, ByteDance Seed tool 兼容, MiniMax effort 兼容, provider model rewrite, stripNonAnthropicFields]
+        transformRequest: [expect.any(Function), expect.any(Function), expect.any(Function), expect.any(Function), expect.any(Function), expect.any(Function), expect.any(Function), expect.any(Function), expect.any(Function), expect.any(Function), expect.any(Function), expect.any(Function), mockState.stripNonAnthropicFields],
         routingTransform: expect.any(Function),
         recoveryRules: expect.arrayContaining([
           expect.objectContaining({ id: 'encrypted_content' }),
@@ -4023,7 +4023,7 @@ describe('codex proxy host', () => {
     await host.ensureCodexProxyReady();
 
     const transforms = mockState.createAnthropicCompatProxy.mock.calls[0]?.[0]?.transformRequest ?? [];
-    expect(transforms).toHaveLength(13); // encrypted activeStrip, image generation activeStrip, instructions 注入, provider-aware Guardian reviewer, Gateway 原生 web_search, 跨来源压缩块兼容, strict gateway history 兼容, xAI Responses 兼容, ByteDance Seed tool 兼容, MiniMax effort 兼容, provider model rewrite, stripNonAnthropicFields, dump
+    expect(transforms).toHaveLength(14); // encrypted activeStrip, image generation activeStrip, instructions 注入, provider-aware Guardian reviewer, text-route history image marker, Gateway 原生 web_search, 跨来源压缩块兼容, strict gateway history 兼容, xAI Responses 兼容, ByteDance Seed tool 兼容, MiniMax effort 兼容, provider model rewrite, stripNonAnthropicFields, dump
     const ctx = {
       method: 'POST',
       url: '/v1/responses',

--- a/apps/desktop/src/main/maker-host/__tests__/custom-provider-store.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/custom-provider-store.test.ts
@@ -336,7 +336,7 @@ describe('custom-provider-store CRUD (per-runtime)', () => {
     expect(got?.runtimes.codex?.headers).toBeUndefined();
   });
 
-  it('round-trips only an explicitly enabled Pi image-input capability', async () => {
+  it('round-trips explicit positive and negative image-input capabilities', async () => {
     mountDb();
     await createCustomProvider({
       id: 'visual-pi',
@@ -356,7 +356,7 @@ describe('custom-provider-store CRUD (per-runtime)', () => {
     expect((await getCustomProvider('visual-pi'))?.runtimes.pi?.models).toEqual([
       { id: 'vision', name: 'Vision', supportsImageInput: true },
       { id: 'legacy', name: 'Legacy' },
-      { id: 'explicit-text', name: 'Explicit text' },
+      { id: 'explicit-text', name: 'Explicit text', supportsImageInput: false },
     ]);
   });
 

--- a/apps/desktop/src/main/maker-host/codex-history-image-marker.ts
+++ b/apps/desktop/src/main/maker-host/codex-history-image-marker.ts
@@ -1,0 +1,112 @@
+import type { RequestTransform } from '@cindy/anthropic-compat-proxy';
+
+import { buildUnavailableImageDataBlock } from '../../shared/agentInputQueue.js';
+
+const IMAGE_PART_TYPES = new Set(['input_image', 'image_url', 'image']);
+
+type RecordValue = Record<string, unknown>;
+type TextPartType = 'input_text' | 'text';
+
+export interface CodexHistoryImageMarkerDeps {
+  shouldStripImages: (body: RecordValue, sessionId: string | undefined) => boolean;
+  sessionIdFromHeaders: (headers: Readonly<Record<string, string>>) => string | undefined;
+}
+
+function isRecord(value: unknown): value is RecordValue {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isImagePart(value: unknown): value is RecordValue {
+  return isRecord(value) && typeof value.type === 'string' && IMAGE_PART_TYPES.has(value.type);
+}
+
+function imageFileName(part: RecordValue, fallback: string): string {
+  if (typeof part.filename === 'string' && part.filename.trim()) return part.filename;
+  if (typeof part.name === 'string' && part.name.trim()) return part.name;
+  if (isRecord(part.source) && typeof part.source.filename === 'string' && part.source.filename.trim()) {
+    return part.source.filename;
+  }
+  return fallback;
+}
+
+function markerPart(part: RecordValue, id: string, textPartType: TextPartType): RecordValue {
+  return {
+    type: textPartType,
+    text: buildUnavailableImageDataBlock({
+      id,
+      name: imageFileName(part, `${id}.image`),
+    }),
+  };
+}
+
+function stripMessageImages(
+  items: unknown[],
+  textPartType: TextPartType,
+  prefix: string,
+): { items: unknown[]; changed: boolean } {
+  const nextItems: unknown[] = [];
+  let imageIndex = 0;
+  let changed = false;
+
+  for (const item of items) {
+    if (isImagePart(item)) {
+      const id = `${prefix}-root-${imageIndex++}`;
+      const marker = markerPart(item, id, textPartType);
+      nextItems.push(
+        textPartType === 'input_text'
+          ? { type: 'message', role: 'user', content: [marker] }
+          : { role: 'user', content: [marker] },
+      );
+      changed = true;
+      continue;
+    }
+    if (!isRecord(item) || !Array.isArray(item.content)) {
+      nextItems.push(item);
+      continue;
+    }
+    const content: unknown[] = [];
+    let itemChanged = false;
+    for (const part of item.content) {
+      if (!isImagePart(part)) {
+        content.push(part);
+        continue;
+      }
+      const id = `${prefix}-${imageIndex++}`;
+      content.push(markerPart(part, id, textPartType));
+      itemChanged = true;
+      changed = true;
+    }
+    nextItems.push(itemChanged ? { ...item, content } : item);
+  }
+
+  return { items: nextItems, changed };
+}
+
+/** Text-only Codex route projection for current and historical image parts. */
+export function createCodexHistoryImageMarkerTransform(
+  deps: CodexHistoryImageMarkerDeps,
+): RequestTransform {
+  return (body, ctx) => {
+    if (!isRecord(body) || ctx.method !== 'POST') return null;
+    const sessionId = deps.sessionIdFromHeaders(ctx.headers);
+    if (!deps.shouldStripImages(body, sessionId)) return null;
+
+    let nextBody: RecordValue = body;
+    let changed = false;
+    if (Array.isArray(body.input)) {
+      const result = stripMessageImages(body.input, 'input_text', 'responses-image');
+      if (result.changed) {
+        nextBody = { ...nextBody, input: result.items };
+        changed = true;
+      }
+    }
+    if (Array.isArray(body.messages)) {
+      const result = stripMessageImages(body.messages, 'text', 'message-image');
+      if (result.changed) {
+        nextBody = { ...nextBody, messages: result.items };
+        changed = true;
+      }
+    }
+    return changed ? nextBody : null;
+  };
+}

--- a/apps/desktop/src/main/maker-host/codex-image-capability.ts
+++ b/apps/desktop/src/main/maker-host/codex-image-capability.ts
@@ -1,0 +1,126 @@
+import type { Catalog, CatalogModel, Provider } from '@cindy/model-providers';
+
+import type { AgentInputQueuedMessage } from '../../shared/agentInputQueue.js';
+
+export type ImageInputCapability = true | false | undefined;
+
+export interface CodexImageCapabilityDeps {
+  getCatalog: () => Catalog;
+  getSessionProvider: (sessionId: string) => string | null;
+}
+
+function modelCapability(model: CatalogModel | undefined): ImageInputCapability {
+  if (!model) return undefined;
+  if (model.supportsImageInput !== undefined) return model.supportsImageInput;
+  if (model.modalities !== undefined) return model.modalities.input.includes('image');
+  return undefined;
+}
+
+function candidateModelIds(provider: Provider, modelId: string): Set<string> {
+  const ids = new Set([modelId, modelId.replace(/\[1m\]$/, '')]);
+  const stripPrefix = provider.routing.codex?.modelIdRewrite?.stripPrefix;
+  if (stripPrefix && modelId.startsWith(stripPrefix)) {
+    const stripped = modelId.slice(stripPrefix.length);
+    ids.add(stripped);
+    ids.add(stripped.replace(/\[1m\]$/, ''));
+  }
+  return ids;
+}
+
+function providerModel(provider: Provider, modelId: string): CatalogModel | undefined {
+  const ids = candidateModelIds(provider, modelId);
+  return provider.models.codex?.find((model) => ids.has(model.id));
+}
+
+/**
+ * Resolves image support for the exact live Codex provider/model route.
+ * Explicit catalog declarations always beat learned failures, so catalog refreshes can recover
+ * a route without restarting Desktop. Undeclared routes remain optimistic until their first
+ * schema rejection, after which only that exact route becomes marker-only.
+ */
+export class CodexImageCapabilityResolver {
+  private readonly rejectedRoutes = new Set<string>();
+
+  constructor(private readonly deps: CodexImageCapabilityDeps) {}
+
+  resolve(sessionId: string, item: AgentInputQueuedMessage): ImageInputCapability {
+    if (item.createOpts.agentKind !== 'codex') return true;
+    return this.resolveCodexRoute(
+      sessionId,
+      item.createOpts.model || item.model,
+      item.createOpts.providerId,
+    );
+  }
+
+  resolveCodexRoute(
+    sessionId: string,
+    modelId: string,
+    queuedProviderId?: string | null,
+  ): ImageInputCapability {
+    const providerId = this.deps.getSessionProvider(sessionId) ?? queuedProviderId ?? null;
+    const catalog = this.deps.getCatalog();
+    const provider = providerId
+      ? catalog.providers.find((candidate) => candidate.id === providerId)
+      : undefined;
+    const explicit = modelCapability(provider ? providerModel(provider, modelId) : undefined);
+    if (explicit !== undefined) return explicit;
+
+    if (!providerId) {
+      const matches = catalog.providers
+        .map((candidate) => providerModel(candidate, modelId))
+        .filter((model): model is CatalogModel => model !== undefined);
+      const declared = new Set(
+        matches
+          .map(modelCapability)
+          .filter((capability): capability is boolean => capability !== undefined),
+      );
+      if (declared.size === 1) return [...declared][0];
+    }
+
+    return this.rejectedRoutes.has(this.routeKey(providerId, modelId)) ? false : undefined;
+  }
+
+  markRejected(sessionId: string, item: AgentInputQueuedMessage): void {
+    if (item.createOpts.agentKind !== 'codex') return;
+    this.markCodexRouteRejected(
+      sessionId,
+      item.createOpts.model || item.model,
+      item.createOpts.providerId,
+    );
+  }
+
+  markCodexRouteRejected(
+    sessionId: string,
+    modelId: string,
+    queuedProviderId?: string | null,
+  ): void {
+    const providerId = this.deps.getSessionProvider(sessionId) ?? queuedProviderId ?? null;
+    const catalogProvider = providerId
+      ? this.deps.getCatalog().providers.find((candidate) => candidate.id === providerId)
+      : undefined;
+    if (
+      modelCapability(catalogProvider ? providerModel(catalogProvider, modelId) : undefined) ===
+      true
+    ) {
+      return;
+    }
+    this.rejectedRoutes.add(this.routeKey(providerId, modelId));
+  }
+
+  clear(): void {
+    this.rejectedRoutes.clear();
+  }
+
+  private routeKey(providerId: string | null, modelId: string): string {
+    return `${providerId ?? '<default>'}\u0000${modelId}`;
+  }
+}
+
+let defaultResolver: CodexImageCapabilityResolver | null = null;
+
+export function getDefaultCodexImageCapabilityResolver(
+  deps: CodexImageCapabilityDeps,
+): CodexImageCapabilityResolver {
+  defaultResolver ??= new CodexImageCapabilityResolver(deps);
+  return defaultResolver;
+}

--- a/apps/desktop/src/main/maker-host/codex-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/codex-proxy-host.ts
@@ -74,9 +74,25 @@ import { desktopAnthropicImageCodec } from './anthropic-image-codec.js';
 import { readSilentEncryptedRetrySettings } from './silent-encrypted-retry-store.js';
 import { getLogDir } from '../logger.js';
 import { recordXaiRateLimitSnapshot } from '../usageBroadcaster.js';
+import { getDefaultCodexImageCapabilityResolver } from './codex-image-capability.js';
+import { createCodexHistoryImageMarkerTransform } from './codex-history-image-marker.js';
 
 // scope = 'codex-proxy'。保持独立 scope,方便后续 E2E 日志脚本按 codex proxy 过滤。
 const log = createMakerLogger('codex-proxy');
+
+const codexImageCapability = getDefaultCodexImageCapabilityResolver({
+  getCatalog: getActiveCatalog,
+  getSessionProvider,
+});
+const codexHistoryImageMarkerTransform = createCodexHistoryImageMarkerTransform({
+  sessionIdFromHeaders,
+  shouldStripImages: (body, sessionId) =>
+    Boolean(
+      sessionId &&
+      typeof body.model === 'string' &&
+      codexImageCapability.resolveCodexRoute(sessionId, body.model) === false,
+    ),
+});
 
 const registry = createInstructionsRegistry();
 const sessionToThread = new Map<string, string>();
@@ -655,8 +671,8 @@ function createChatBridgeDecision(
     // 出站代理;显式注入代理感知 fetch(见 outbound-fetch.ts)。
   }, { logger: log, fetchImpl: outboundFetch });
   return {
-    localHandler: ({ rawBody, parsedBody, res }) => {
-      const body = prepareLocalBridgeBody({
+    localHandler: ({ rawBody, parsedBody, ctx, res }) => {
+      let body = prepareLocalBridgeBody({
         rawBody,
         parsedBody,
         instructions,
@@ -665,6 +681,8 @@ function createChatBridgeDecision(
         providerId,
         upstreamBase: route.routing.upstream,
       });
+      const historySafe = ctx ? codexHistoryImageMarkerTransform(body, ctx) : null;
+      if (historySafe !== null && historySafe !== undefined) body = historySafe;
       return handler.handle({ parsedBody: body, res });
     },
   };
@@ -972,7 +990,7 @@ function createAnthropicBridgeDecision(
   });
   return {
     localHandler: ({ rawBody, parsedBody, ctx, res }) => {
-      const body = prepareLocalBridgeBody({
+      let body = prepareLocalBridgeBody({
         rawBody,
         parsedBody,
         instructions,
@@ -981,6 +999,8 @@ function createAnthropicBridgeDecision(
         providerId,
         upstreamBase,
       });
+      const historySafe = ctx ? codexHistoryImageMarkerTransform(body, ctx) : null;
+      if (historySafe !== null && historySafe !== undefined) body = historySafe;
       return handler.handle({ parsedBody: body, ctx, res });
     },
   };
@@ -2287,6 +2307,7 @@ function createTransformRequestChain(
     // session and select that session's real provider model before provider
     // compatibility transforms inspect the request.
     createProviderAwareGuardianReviewerTransform(frozenAuthInjection),
+    codexHistoryImageMarkerTransform,
     createGatewayNativeWebSearchTransform(),
     // 必须先于 xAI/MiniMax 兼容改写:先把供应商绑定的历史项降级成标准 message，
     // 后续针对具体供应商的 input 归一化才能稳定处理。

--- a/apps/desktop/src/main/maker-host/custom-provider-store.ts
+++ b/apps/desktop/src/main/maker-host/custom-provider-store.ts
@@ -378,7 +378,9 @@ function normalizeRuntime(
       name: m.name.trim(),
       ...(m.contextWindow !== undefined ? { contextWindow: m.contextWindow } : {}),
       ...(m.defaultEnabled === false ? { defaultEnabled: false } : {}),
-      ...(m.supportsImageInput === true ? { supportsImageInput: true } : {}),
+      ...(m.supportsImageInput !== undefined
+        ? { supportsImageInput: m.supportsImageInput }
+        : {}),
       ...(agent === 'pi' && m.reasoning === true && m.reasoningEfforts?.length
         ? { reasoning: true, reasoningEfforts: [...m.reasoningEfforts] }
         : {}),
@@ -523,7 +525,9 @@ function parseRuntimes(raw: string): Partial<Record<AgentKind, CustomProviderRun
               ? { contextWindow: m.contextWindow }
               : {}),
             ...(m.defaultEnabled === false ? { defaultEnabled: false } : {}),
-            ...(m.supportsImageInput === true ? { supportsImageInput: true } : {}),
+            ...(typeof m.supportsImageInput === 'boolean'
+              ? { supportsImageInput: m.supportsImageInput }
+              : {}),
             ...parseStoredPiReasoningCapability(agent, m),
           }))
       : [];

--- a/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
@@ -167,6 +167,7 @@ function unsupportedChatBridgeImageError(feature = "input content part 'input_im
 
 function createHarness(opts?: {
   getRecoveryContextSnapshot?: (sessionId: string, userClientId: string) => Promise<RecoveryContextSnapshot>;
+  resolveImageInputMode?: NonNullable<AgentInputCoordinatorDeps['resolveImageInputMode']>;
 }) {
   let running = false;
   let turnGeneration = 0;
@@ -186,6 +187,15 @@ function createHarness(opts?: {
   const getSdkSessionId = vi.fn<AgentInputCoordinatorDeps['getSdkSessionId']>(
     async () => 'sdk-session',
   );
+  let imageInputRejected = false;
+  const resolveImageInputMode = vi.fn<
+    NonNullable<AgentInputCoordinatorDeps['resolveImageInputMode']>
+  >(opts?.resolveImageInputMode ?? (() => (imageInputRejected ? 'omit' : 'include')));
+  const onImageInputRejected = vi.fn<
+    NonNullable<AgentInputCoordinatorDeps['onImageInputRejected']>
+  >(() => {
+    imageInputRejected = true;
+  });
   const reconcileTurnIdle = vi.fn<NonNullable<AgentInputCoordinatorDeps['reconcileTurnIdle']>>(
     () => false,
   );
@@ -285,6 +295,8 @@ function createHarness(opts?: {
     hasPendingInteraction: () => pendingInteraction,
     getAgentKind: () => agentKind,
     getSdkSessionId,
+    resolveImageInputMode,
+    onImageInputRejected,
     hasAssistantProgressAfter: (sessionId, userClientId) =>
       hasAssistantProgressAfter
         ? hasAssistantProgressAfter(sessionId, userClientId)
@@ -327,6 +339,8 @@ function createHarness(opts?: {
     steerToAgent,
     abortSession,
     getSdkSessionId,
+    resolveImageInputMode,
+    onImageInputRejected,
     reconcileTurnIdle,
     beforeDispatchUserTurn,
     onUndispatchedUserTurn,
@@ -422,6 +436,143 @@ beforeEach(() => {
 afterEach(() => {
   vi.useRealTimers();
   vi.restoreAllMocks();
+});
+
+describe('AgentInputCoordinator image capability projection', () => {
+  function withImage(item: AgentInputQueuedMessage): AgentInputQueuedMessage {
+    return {
+      ...item,
+      files: [
+        {
+          id: 'image-1',
+          name: 'screen.png',
+          path: '/repo/screen.png',
+          ext: '.png',
+          size: 128,
+          category: 'image',
+          mimeType: 'image/png',
+        },
+      ],
+    };
+  }
+
+  it('projects an unavailable marker for a normal send to a text route', async () => {
+    const h = createHarness({
+      resolveImageInputMode: () => 'omit',
+    });
+    h.coordinator.enqueue('image-send', withImage(makeItem('image-1', 'explain this')));
+    await flush();
+
+    expect(h.resolveImageInputMode).toHaveBeenCalledTimes(1);
+    const wire = JSON.stringify(h.sendToAgent.mock.calls[0]?.[1]);
+    expect(wire).not.toContain('"type":"image"');
+    expect(wire).toContain('IMAGE_ATTACHMENT_UNAVAILABLE_V1');
+    expect(wire).toContain('user_uploaded_image');
+    expect(wire).toContain('did not receive the image');
+  });
+
+  it('applies the same route projection to steer', async () => {
+    const h = createHarness({
+      resolveImageInputMode: () => 'omit',
+    });
+    h.setRunning(true);
+
+    await h.coordinator.steer('image-steer', withImage(makeItem('image-2', 'check this')));
+
+    const wire = JSON.stringify(h.steerToAgent.mock.calls[0]?.[1]);
+    expect(wire).not.toContain('"type":"image"');
+    expect(wire).toContain('IMAGE_ATTACHMENT_UNAVAILABLE_V1');
+  });
+
+  it('sends an unavailable marker for a pure image on a text route', async () => {
+    const h = createHarness({
+      resolveImageInputMode: () => 'omit',
+    });
+    h.coordinator.enqueue('image-only-text', withImage(makeItem('image-3', '')));
+    await flush();
+
+    expect(h.sendToAgent).toHaveBeenCalledTimes(1);
+    const wire = JSON.stringify(h.sendToAgent.mock.calls[0]?.[1]);
+    expect(wire).not.toContain('"type":"image"');
+    expect(wire).toContain('IMAGE_ATTACHMENT_UNAVAILABLE_V1');
+  });
+
+  it('retries an unknown Codex route once with a marker after schema rejection', async () => {
+    let rejected = false;
+    const h = createHarness({
+      resolveImageInputMode: () => (rejected ? 'omit' : 'include'),
+    });
+    h.onImageInputRejected.mockImplementation(() => {
+      rejected = true;
+    });
+    const item = withImage(
+      makeItem('image-auto', 'explain this', {
+        model: 'deepseek-chat',
+        createOpts: {
+          agentKind: 'codex',
+          workingDir: '/repo',
+          model: 'deepseek-chat',
+          providerId: 'deepseek',
+        },
+      }),
+    );
+    h.coordinator.enqueue('image-auto-session', item);
+    await flush();
+    expect(JSON.stringify(h.sendToAgent.mock.calls[0]?.[1])).toContain('"type":"image"');
+
+    h.setRunning(false);
+    h.coordinator.onTurnEvent(
+      'image-auto-session',
+      'error',
+      'Failed to deserialize messages[5]: unknown variant `image_url`, expected `text`',
+    );
+    await flush();
+
+    expect(h.onImageInputRejected).toHaveBeenCalledWith(
+      'image-auto-session',
+      expect.objectContaining({ clientId: 'image-auto', model: 'deepseek-chat' }),
+    );
+    expect(h.sendToAgent).toHaveBeenCalledTimes(2);
+    const fallbackWire = JSON.stringify(h.sendToAgent.mock.calls[1]?.[1]);
+    expect(fallbackWire).not.toContain('"type":"image"');
+    expect(fallbackWire).toContain('IMAGE_ATTACHMENT_UNAVAILABLE_V1');
+    expect(fallbackWire).toContain('user_uploaded_image');
+    expect(h.sendToAgent.mock.calls[1]?.[3].persistUserMessage?.autoResume).toBe(true);
+
+    h.setRunning(false);
+    h.coordinator.onTurnEvent(
+      'image-auto-session',
+      'error',
+      'unknown variant `image_url`, expected `text`',
+    );
+    await flush();
+    expect(h.sendToAgent).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries a pure-image schema failure with an unavailable marker', async () => {
+    let rejected = false;
+    const h = createHarness({
+      resolveImageInputMode: () => (rejected ? 'omit' : 'include'),
+    });
+    h.onImageInputRejected.mockImplementation(() => {
+      rejected = true;
+    });
+    h.coordinator.enqueue('image-no-fallback', withImage(makeItem('image-empty-auto', '')));
+    await flush();
+    h.setRunning(false);
+    h.coordinator.onTurnEvent(
+      'image-no-fallback',
+      'error',
+      'unknown variant `image_url`, expected `text`',
+    );
+    await flush();
+
+    expect(h.sendToAgent).toHaveBeenCalledTimes(2);
+    expect(h.onImageInputRejected).toHaveBeenCalledTimes(1);
+    const fallbackWire = JSON.stringify(h.sendToAgent.mock.calls[1]?.[1]);
+    expect(fallbackWire).not.toContain('"type":"image"');
+    expect(fallbackWire).toContain('IMAGE_ATTACHMENT_UNAVAILABLE_V1');
+  });
 });
 
 describe('AgentInputCoordinator trusted session reference snapshots', () => {
@@ -2351,7 +2502,7 @@ describe('AgentInputCoordinator send transaction', () => {
     expect(h.onUiRetry).toHaveBeenCalledWith(sid, expect.any(String), 'manual', undefined);
   });
 
-  it('removes unsupported image blocks but preserves GIF and PDF files on retry', async () => {
+  it('projects an image marker while preserving source image, GIF and PDF metadata on retry', async () => {
     const h = createHarness();
     const sid = 'retry-unsupported-image-with-text';
     h.setHasAssistantProgressAfter(async () => false);
@@ -2436,20 +2587,23 @@ describe('AgentInputCoordinator send transaction', () => {
     await flush();
 
     expect(h.sendToAgent).toHaveBeenCalledTimes(2);
-    expect(h.sendToAgent.mock.calls[1]?.[1]).toEqual({
-      type: 'user',
-      content: [
-        { type: 'text', text: 'describe this' },
-        { type: 'file', path: 'xdt-image://session/clip.gif', mimeType: 'image/gif' },
-        { type: 'file', path: '/repo/notes.pdf', mimeType: 'application/pdf' },
-      ],
-    });
+    const retryWire = JSON.stringify(h.sendToAgent.mock.calls[1]?.[1]);
+    expect(retryWire).not.toContain('"type":"image"');
+    expect(retryWire).toContain('IMAGE_ATTACHMENT_UNAVAILABLE_V1');
+    expect(retryWire).toContain('xdt-image://session/clip.gif');
+    expect(retryWire).toContain('/repo/notes.pdf');
     const retried = h.onDispatchedUserTurn.mock.calls[1]?.[1];
     expect(retried?.files).toEqual([
+      expect.objectContaining({ id: 'image-1', ext: '.png', category: 'image' }),
       expect.objectContaining({ id: 'gif-1', ext: '.gif', category: 'image' }),
       expect.objectContaining({ id: 'file-1', category: 'pdf' }),
     ]);
     expect(retried?.chatMessage.images).toEqual([
+      {
+        url: 'data:image/png;base64,aW1hZ2U=',
+        mimeType: 'image/png',
+        originalName: 'image.png',
+      },
       {
         url: 'xdt-image://session/clip.gif',
         mimeType: 'image/gif',
@@ -2464,12 +2618,18 @@ describe('AgentInputCoordinator send transaction', () => {
         }
       ).retryFiles,
     ).toEqual([
+      expect.objectContaining({ id: 'image-1', ext: '.png', category: 'image' }),
       expect.objectContaining({ id: 'gif-1', ext: '.gif', category: 'image' }),
       expect.objectContaining({ id: 'file-1', category: 'pdf' }),
     ]);
     expect(JSON.parse(retried?.persistedContent ?? '{}')).toEqual({
       text: 'describe this',
       images: [
+        {
+          url: 'data:image/png;base64,aW1hZ2U=',
+          mimeType: 'image/png',
+          originalName: 'image.png',
+        },
         {
           url: 'xdt-image://session/clip.gif',
           mimeType: 'image/gif',
@@ -2480,7 +2640,7 @@ describe('AgentInputCoordinator send transaction', () => {
     });
   });
 
-  it('keeps an unsupported image-only retry recoverable without fabricating text', async () => {
+  it('retries an unsupported image-only turn with a marker instead of fabricated content', async () => {
     const h = createHarness();
     const sid = 'retry-unsupported-image-only';
     h.setHasAssistantProgressAfter(async () => false);
@@ -2529,14 +2689,11 @@ describe('AgentInputCoordinator send transaction', () => {
     await h.coordinator.retryLastError(sid);
     await flush();
 
-    expect(h.sendToAgent).toHaveBeenCalledTimes(1);
-    expect(latestProjection(h.projections).error).toBe(error);
-    expect(latestProjection(h.projections).recovery?.kind).toBe('active-turn');
-
-    h.coordinator.enqueue(sid, makeItem('q-next', 'continue in text'));
-    await flush();
     expect(h.sendToAgent).toHaveBeenCalledTimes(2);
-    expect(h.sendToAgent.mock.calls[1]?.[1]).toEqual({ type: 'user', content: 'continue in text' });
+    const retryWire = JSON.stringify(h.sendToAgent.mock.calls[1]?.[1]);
+    expect(retryWire).not.toContain('"type":"image"');
+    expect(retryWire).toContain('IMAGE_ATTACHMENT_UNAVAILABLE_V1');
+    expect(retryWire).not.toContain(error);
   });
 
   it('keeps retry recovery compatible with the legacy bridge image error', async () => {
@@ -2567,7 +2724,10 @@ describe('AgentInputCoordinator send transaction', () => {
     await flush();
 
     expect(h.sendToAgent).toHaveBeenCalledTimes(2);
-    expect(h.sendToAgent.mock.calls[1]?.[1]).toEqual({ type: 'user', content: 'describe this' });
+    const retryWire = JSON.stringify(h.sendToAgent.mock.calls[1]?.[1]);
+    expect(retryWire).not.toContain('"type":"image"');
+    expect(retryWire).toContain('describe this');
+    expect(retryWire).toContain('IMAGE_ATTACHMENT_UNAVAILABLE_V1');
   });
 
   it('zero-progress retry supersedes the failed user row once the clone is dispatched', async () => {

--- a/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
+++ b/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
@@ -89,77 +89,6 @@ function isMakerImageAttachment(file: Pick<QueuedAttachment, 'category' | 'ext'>
   return getAgentInputAttachmentBlockType(file.category, file.ext) === 'image';
 }
 
-function attachmentSourceKey(value: unknown): string | null {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
-  const record = value as Record<string, unknown>;
-  if (typeof record.url === 'string') return `url:${record.url}`;
-  if (typeof record.base64 === 'string') return `base64:${record.base64}`;
-  return null;
-}
-
-function stripQueuedMessageImages(item: AgentInputQueuedMessage): AgentInputQueuedMessage {
-  const remainingFiles = item.files?.filter((file) => !isMakerImageAttachment(file));
-  const remainingImageSources = new Set(
-    (remainingFiles ?? [])
-      .filter((file) => file.category === 'image')
-      .map(attachmentSourceKey)
-      .filter((source): source is string => source !== null),
-  );
-  const chatMessage = { ...item.chatMessage };
-  const remainingChatImages = chatMessage.images?.filter((image) => {
-    const source = attachmentSourceKey(image);
-    return source !== null && remainingImageSources.has(source);
-  });
-  if (remainingChatImages && remainingChatImages.length > 0) {
-    chatMessage.images = remainingChatImages;
-  } else {
-    delete chatMessage.images;
-  }
-
-  // Renderer queue objects historically carry retryFiles as an extra presentation field even
-  // though it is not part of the main-process wire contract. Strip only attachments that become
-  // maker image blocks: GIF keeps category=image for preview, but is sent as a file block.
-  const compatibleChatMessage = chatMessage as typeof chatMessage & {
-    retryFiles?: QueuedAttachment[];
-  };
-  if (Array.isArray(compatibleChatMessage.retryFiles)) {
-    const retryFiles = compatibleChatMessage.retryFiles.filter(
-      (file) => !isMakerImageAttachment(file),
-    );
-    if (retryFiles.length > 0) compatibleChatMessage.retryFiles = retryFiles;
-    else delete compatibleChatMessage.retryFiles;
-  }
-
-  let persistedContent = item.persistedContent;
-  try {
-    const parsed = JSON.parse(persistedContent) as unknown;
-    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
-      const record = parsed as Record<string, unknown>;
-      const remainingPersistedImages = Array.isArray(record.images)
-        ? record.images.filter((image) => {
-            const source = attachmentSourceKey(image);
-            return source !== null && remainingImageSources.has(source);
-          })
-        : [];
-      persistedContent = JSON.stringify({
-        ...record,
-        images: remainingPersistedImages,
-      });
-    }
-  } catch {
-    // Historical plain-text queue payloads contain no persisted image references.
-  }
-
-  const stripped: AgentInputQueuedMessage = {
-    ...item,
-    persistedContent,
-    chatMessage,
-  };
-  if (remainingFiles && remainingFiles.length > 0) stripped.files = remainingFiles;
-  else delete stripped.files;
-  return stripped;
-}
-
 function hasRetryableQueuedContent(item: AgentInputQueuedMessage): boolean {
   return (
     getAgentFacingText(item).trim().length > 0 ||
@@ -167,6 +96,17 @@ function hasRetryableQueuedContent(item: AgentInputQueuedMessage): boolean {
     (item.mentions?.length ?? 0) > 0 ||
     (item.sessionRefs?.length ?? 0) > 0
   );
+}
+
+function isUnsupportedImageSchemaPayload(value: unknown): boolean {
+  if (
+    (typeof value === 'string' || value === null) &&
+    isUnsupportedResponsesImageErrorPayload(value)
+  ) {
+    return true;
+  }
+  const text = typeof value === 'string' ? value : (JSON.stringify(value) ?? '');
+  return /unknown variant\s+[`'"]?image_url[`'"]?\s*,?\s*expected\s+[`'"]?text/i.test(text);
 }
 
 export interface AgentInputSendOpts {
@@ -268,6 +208,10 @@ export interface AgentInputCoordinatorDeps {
   hasPendingInteraction: (sessionId: string) => boolean;
   getAgentKind: (sessionId: string) => AgentInputCreateOpts['agentKind'] | null;
   getSdkSessionId: (sessionId: string) => Promise<string | undefined>;
+  /** Route-aware image projection. Unknown/capable routes include the original image. */
+  resolveImageInputMode?: (sessionId: string, item: AgentInputQueuedMessage) => 'include' | 'omit';
+  /** Records a schema rejection against the exact live route (negative capability cache). */
+  onImageInputRejected?: (sessionId: string, item: AgentInputQueuedMessage) => void;
   /** Read a bounded, durable progress snapshot before a retry is re-enqueued. */
   getRecoveryContextSnapshot?: (
     sessionId: string,
@@ -863,6 +807,15 @@ export class AgentInputCoordinator {
   private readonly autoResumeDispatchAttempts = new Map<string, number>();
 
   constructor(private readonly deps: AgentInputCoordinatorDeps) {}
+
+  private buildUserMessageForRoute(
+    sessionId: string,
+    item: AgentInputQueuedMessage,
+    referenceContexts: AgentInputSessionReferenceContext[],
+  ): AgentInputMakerMessage {
+    const imageMode = this.deps.resolveImageInputMode?.(sessionId, item) ?? 'include';
+    return buildMakerUserMessage(item, referenceContexts, { imageMode });
+  }
 
   /**
    * 媒体回收器活引用取证(recycler.ts 的内存队列暂存区):序列化所有会话在
@@ -1776,15 +1729,16 @@ export class AgentInputCoordinator {
     }
 
     try {
+      const dispatchSignal = AbortSignal.any([inputBoundarySignal, steerAbort.signal]);
       const referenceContexts = await this.resolveReferenceContexts(item);
       item.persistedContent = attachSessionReferenceMetadata(
         item.persistedContent,
         referenceContexts,
       );
-      await this.deps.steerToAgent(sessionId, buildMakerUserMessage(item, referenceContexts), {
+      await this.deps.steerToAgent(sessionId, this.buildUserMessageForRoute(sessionId, item, referenceContexts), {
         messageUuid,
         userName: item.userName,
-        signal: AbortSignal.any([inputBoundarySignal, steerAbort.signal]),
+        signal: dispatchSignal,
         expectedClearBoundaryMs: steerClearBoundaryMs,
         expectedInputGeneration: steerGeneration,
         // 同 drain:steer 投递也在入队时的 async context 之外。
@@ -2300,14 +2254,16 @@ export class AgentInputCoordinator {
     if (
       !continueItem &&
       retryItem &&
-      isUnsupportedResponsesImageErrorPayload(state.error ?? state.stickyError)
+      isUnsupportedImageSchemaPayload(state.error ?? state.stickyError)
     ) {
-      retryItem = stripQueuedMessageImages(retryItem);
-      if (!hasRetryableQueuedContent(retryItem)) {
-        // An image-only turn has no truthful fallback. Keep the error/recovery intact so a later
-        // text message or model switch can take over instead of inventing replacement text.
-        log.debug('image-only retry skipped for unsupported Chat bridge input', { sessionId });
-        return { projection: this.getProjection(sessionId), outcome: 'no-progress' };
+      retryItem = { ...retryItem, imageFallbackAttempted: true };
+      try {
+        this.deps.onImageInputRejected?.(sessionId, retryItem);
+      } catch (error) {
+        log.warn('image capability rejection callback failed during retry', {
+          sessionId,
+          error: errorMessage(error),
+        });
       }
     }
     state.error = null;
@@ -2678,6 +2634,7 @@ export class AgentInputCoordinator {
         return;
       }
       if (active?.persisted) {
+        if (this.tryAutomaticImageFallback(sessionId, state, active, message)) return;
         state.activeTurn = null;
         state.stickyError = null;
         const schedulerItem = active.item && isSchedulerOriginItem(active.item);
@@ -2843,6 +2800,57 @@ export class AgentInputCoordinator {
     state.recovery = null;
     this.emit(sessionId);
     this.scheduleDrain(sessionId, 'turn-done');
+  }
+
+  private tryAutomaticImageFallback(
+    sessionId: string,
+    state: SessionInputState,
+    active: ActiveTurn,
+    message: string | undefined,
+  ): boolean {
+    const original = active.item;
+    if (
+      !original ||
+      original.imageFallbackAttempted === true ||
+      !isUnsupportedImageSchemaPayload(message) ||
+      !(original.files?.some(isMakerImageAttachment) ?? false)
+    ) {
+      return false;
+    }
+    const clientId = crypto.randomUUID();
+    const retry: AgentInputQueuedMessage = {
+      ...original,
+      clientId,
+      imageFallbackAttempted: true,
+      // Reuse the durable hidden-user-row contract so this internal retry does not create a
+      // duplicate user bubble. Unlike interrupted-turn recovery it intentionally has no info.
+      autoResume: true,
+      autoResumeInfo: undefined,
+      supersedesUserClientId: undefined,
+      chatMessage: {
+        ...original.chatMessage,
+        clientId,
+        createdAt: new Date().toISOString(),
+      },
+    };
+    state.activeTurn = null;
+    state.error = null;
+    state.stickyError = null;
+    state.recovery = null;
+    state.pendingQueue.unshift(retry);
+    this.prependPendingCompactWaitClientId(state, clientId);
+    try {
+      this.deps.onImageInputRejected?.(sessionId, original);
+    } catch (error) {
+      log.warn('image capability rejection callback failed', {
+        sessionId,
+        error: errorMessage(error),
+      });
+    }
+    this.deps.onUiRetry?.(sessionId, clientId, 'auto');
+    this.emit(sessionId);
+    this.scheduleDrain(sessionId, 'automatic-image-capability-fallback');
+    return true;
   }
 
   /**
@@ -3211,6 +3219,7 @@ export class AgentInputCoordinator {
       // may synchronously emit the new turn's started marker before it returns;
       // post-dispatch acknowledgements must remain older than that marker.
       const preVendorDispatchAt = Math.max(0, Date.now() - 1);
+      const inputSignal = this.getInputAbortSignal(sessionId, active.generation);
       const referenceContexts = await this.resolveReferenceContexts(head);
       head.persistedContent = attachSessionReferenceMetadata(
         head.persistedContent,
@@ -3218,7 +3227,7 @@ export class AgentInputCoordinator {
       );
       const result = await this.deps.sendToAgent(
         sessionId,
-        buildMakerUserMessage(head, referenceContexts),
+        this.buildUserMessageForRoute(sessionId, head, referenceContexts),
         head.createOpts,
         {
           messageUuid: active.messageUuid,
@@ -3227,7 +3236,7 @@ export class AgentInputCoordinator {
           ...(head.autoResume && typeof head.autoResumeInfo?.sessionTotal === 'number'
             ? { turnAttemptToken: head.autoResumeInfo.sessionTotal }
             : {}),
-          signal: this.getInputAbortSignal(sessionId, active.generation),
+          signal: inputSignal,
           expectedClearBoundaryMs: active.clearBoundaryMs,
           expectedInputGeneration: active.generation,
           ...(head.origin?.kind === 'scheduler' ? { origin: head.origin } : {}),

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -676,6 +676,7 @@ import {
   setSessionProvider,
 } from '../maker-host/session-provider-store.js';
 import { getActiveCatalog, setDiscoveredProviderModels } from '../maker-host/active-catalog.js';
+import { getDefaultCodexImageCapabilityResolver } from '../maker-host/codex-image-capability.js';
 import { testProviderConnection } from '../maker-host/provider-diagnostics.js';
 import { fetchProviderModels } from '../maker-host/provider-model-fetch.js';
 import { beginProviderRouteMutation, isUserProviderSession } from '../maker-host/provider-route.js';
@@ -8680,6 +8681,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
       agentKind: createOpts.agentKind,
       workingDir: createOpts.workingDir,
       model: createOpts.model,
+      providerId: row.providerId,
       effort: createOpts.effort,
       fastMode: createOpts.fastMode,
       permissionMode: createOpts.permissionMode,
@@ -10516,6 +10518,11 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
     });
   };
 
+  const codexImageCapability = getDefaultCodexImageCapabilityResolver({
+    getCatalog: getActiveCatalog,
+    getSessionProvider,
+  });
+
   const inputCoordinator: AgentInputCoordinator = new AgentInputCoordinator({
     sendToAgent: async (sessionId, message, createOpts, sendOpts) => {
       try {
@@ -10534,6 +10541,9 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
         throw err;
       }
     },
+    resolveImageInputMode: (sessionId, item) =>
+      codexImageCapability.resolve(sessionId, item) === false ? 'omit' : 'include',
+    onImageInputRejected: (sessionId, item) => codexImageCapability.markRejected(sessionId, item),
     // turn 被上游打断(且已有产出)→ 自动替用户点一次「继续」。判据、额度、退避都在
     // interruptedTurnAutoResume;这里只做编排:决策 → 退避 → 复核 → 补发 → 失败回滚。
     // 纯判定,无副作用:coordinator 用它在「决策还做不了」的时序里先把红横幅与 error 行
@@ -11284,6 +11294,8 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
       throwIpcError('INVALID_PARAMS', 'queued.createOpts.agentKind invalid');
     }
     const normalized: AgentInputQueuedMessage = { ...msg };
+    // Learned fallback state is main-owned. Never trust renderer/device-link copies.
+    delete normalized.imageFallbackAttempted;
     const refs = requireSessionRefs(normalized.sessionRefs);
     if (!isDeviceLinkInvoke()) {
       // preload/renderer 不属于可信边界，不能直接注入历史正文。

--- a/apps/desktop/src/renderer/lib/__tests__/customProviders.test.ts
+++ b/apps/desktop/src/renderer/lib/__tests__/customProviders.test.ts
@@ -141,7 +141,7 @@ describe('customProviderModelConfigFromCatalogModel', () => {
     });
   });
 
-  it('preserves an explicit Pi image-input capability through the edit round trip', () => {
+  it('preserves explicit image-input capabilities through the edit round trip', () => {
     expect(customProviderModelConfigFromCatalogModel({
       id: 'vision-model',
       name: 'Vision Model',
@@ -151,6 +151,16 @@ describe('customProviderModelConfigFromCatalogModel', () => {
       id: 'vision-model',
       name: 'Vision Model',
       supportsImageInput: true,
+    });
+    expect(customProviderModelConfigFromCatalogModel({
+      id: 'text-model',
+      name: 'Text Model',
+      contextWindow: 200_000,
+      supportsImageInput: false,
+    })).toEqual({
+      id: 'text-model',
+      name: 'Text Model',
+      supportsImageInput: false,
     });
   });
 

--- a/apps/desktop/src/renderer/lib/customProviders.ts
+++ b/apps/desktop/src/renderer/lib/customProviders.ts
@@ -130,7 +130,9 @@ export function customProviderModelConfigFromCatalogModel(
       ? { contextWindow: model.contextWindow }
       : {}),
     ...(model.defaultEnabled === false ? { defaultEnabled: false } : {}),
-    ...(model.supportsImageInput === true ? { supportsImageInput: true } : {}),
+    ...(model.supportsImageInput !== undefined
+      ? { supportsImageInput: model.supportsImageInput }
+      : {}),
     ...(reasoningEfforts.length > 0 ? { reasoning: true, reasoningEfforts } : {}),
   };
 }

--- a/apps/desktop/src/shared/agentInputQueue.ts
+++ b/apps/desktop/src/shared/agentInputQueue.ts
@@ -42,6 +42,25 @@ export interface AgentInputSerializedFile {
   annotated?: boolean;
 }
 
+export function buildUnavailableImageDataBlock(
+  file: Pick<AgentInputSerializedFile, 'id' | 'name'>,
+): string {
+  const payload = JSON.stringify({
+    event: 'user_uploaded_image',
+    fileId: file.id,
+    fileName: file.name,
+    delivery: 'not_delivered',
+    reason: 'model_route_does_not_support_images',
+  });
+  return (
+    'IMAGE_ATTACHMENT_UNAVAILABLE_V1\n' +
+    payload +
+    '\nEND_IMAGE_ATTACHMENT_UNAVAILABLE_V1\n' +
+    'The user uploaded an image, but this model route did not receive the image. ' +
+    'Do not claim to have seen or analyzed its visual content. State this limitation when needed.'
+  );
+}
+
 export interface AgentInputMention {
   type: 'file' | 'dir' | 'agent';
   name: string;
@@ -208,6 +227,8 @@ export interface AgentInputQueuedMessage {
   workingDir: string;
   vendorOptions?: Record<string, unknown>;
   files?: AgentInputSerializedFile[];
+  /** One-shot guard for the automatic image-schema fallback retry. */
+  imageFallbackAttempted?: boolean;
   mentions?: AgentInputMention[];
   sessionRefs?: AgentInputSessionRef[];
   trustedSessionReferenceContexts?: AgentInputSessionReferenceContext[];
@@ -921,6 +942,7 @@ export function deriveAutoTitleSeed(
 export function buildMakerUserMessage(
   queued: AgentInputQueuedMessage,
   sessionReferenceContexts: AgentInputSessionReferenceContext[] = [],
+  options: { imageMode?: 'include' | 'omit' } = {},
 ): AgentInputMakerMessage {
   const blocks: Array<{ type: string; [k: string]: unknown }> = [];
   const agentFacingText = getAgentFacingText(queued);
@@ -933,6 +955,7 @@ export function buildMakerUserMessage(
   let hasAnnotatedImage = false;
   for (const f of queued.files ?? []) {
     const type = getAgentInputAttachmentBlockType(f.category, f.ext);
+    if (type === 'image' && options.imageMode === 'omit') continue;
     if (f.url) {
       blocks.push({ type, path: f.url, mimeType: f.mimeType });
     } else if (f.path && !f.path.startsWith('clipboard://')) {
@@ -948,6 +971,12 @@ export function buildMakerUserMessage(
   // 文本紧随图片;claude 侧所有 text 会合并进文本前缀,红色笔迹自身即区分符。
   if (hasAnnotatedImage) {
     blocks.push({ type: 'text', text: ANNOTATED_IMAGE_NOTE });
+  }
+  if (options.imageMode === 'omit') {
+    for (const file of queued.files ?? []) {
+      if (getAgentInputAttachmentBlockType(file.category, file.ext) !== 'image') continue;
+      blocks.push({ type: 'text', text: buildUnavailableImageDataBlock(file) });
+    }
   }
   if (sessionReferenceContexts.length > 0) {
     const payload = serializeSessionReferencePayload(sessionReferenceContexts);

--- a/packages/model-providers/catalog/providers.json
+++ b/packages/model-providers/catalog/providers.json
@@ -286,12 +286,14 @@
             {
               "id": "deepseek-v4-flash",
               "name": "DeepSeek V4 Flash",
-              "contextWindow": 1000000
+              "contextWindow": 1000000,
+              "supportsImageInput": false
             },
             {
               "id": "deepseek-v4-pro",
               "name": "DeepSeek V4 Pro",
-              "contextWindow": 1000000
+              "contextWindow": 1000000,
+              "supportsImageInput": false
             }
           ],
           "modelsUrl": "https://api.deepseek.com/models"
@@ -303,12 +305,14 @@
             {
               "id": "deepseek-v4-flash",
               "name": "DeepSeek V4 Flash",
-              "contextWindow": 1000000
+              "contextWindow": 1000000,
+              "supportsImageInput": false
             },
             {
               "id": "deepseek-v4-pro",
               "name": "DeepSeek V4 Pro",
-              "contextWindow": 1000000
+              "contextWindow": 1000000,
+              "supportsImageInput": false
             }
           ],
           "modelsUrl": "https://api.deepseek.com/models"

--- a/packages/model-providers/src/__tests__/catalog.test.ts
+++ b/packages/model-providers/src/__tests__/catalog.test.ts
@@ -187,6 +187,7 @@ describe('bundled catalog validity (dynamic-first contract)', () => {
       for (const id of ['deepseek-v4-flash', 'deepseek-v4-pro']) {
         const m = rt!.models.find((x) => x.id === id);
         expect(m?.contextWindow, `${agent}/${id}`).toBe(1_000_000);
+        expect(m?.supportsImageInput, `${agent}/${id}`).toBe(false);
       }
     }
     // OpenRouter 托管的同款模型页面同样标注 1,048,576,取与仓库口径一致的 1M。
@@ -195,6 +196,10 @@ describe('bundled catalog validity (dynamic-first contract)', () => {
       openrouter?.runtimes['claude-code']?.models.find((m) => m.id === 'deepseek/deepseek-v4-pro')
         ?.contextWindow,
     ).toBe(1_000_000);
+    expect(
+      openrouter?.runtimes['claude-code']?.models.find((m) => m.id === 'deepseek/deepseek-v4-pro')
+        ?.supportsImageInput,
+    ).toBeUndefined();
   });
 
   it('Kimi Code(编程计划)预设的每个模型都带 contextWindow(k3 缺失曾回落 200K)', () => {

--- a/packages/model-providers/src/__tests__/user-provider.test.ts
+++ b/packages/model-providers/src/__tests__/user-provider.test.ts
@@ -293,6 +293,24 @@ describe('buildUserProvider (per-runtime)', () => {
     expect((p.models.pi ?? [])[0]?.supportsImageInput).toBe(true);
   });
 
+  it('preserves explicit false image capability while leaving undeclared models unknown', () => {
+    const p = buildUserProvider({
+      id: 'text-route',
+      name: 'Text route',
+      runtimes: {
+        codex: {
+          baseUrl: 'https://example.test/v1',
+          models: [
+            { id: 'text', name: 'Text', supportsImageInput: false },
+            { id: 'unknown', name: 'Unknown' },
+          ],
+        },
+      },
+    });
+    expect((p.models.codex ?? [])[0]?.supportsImageInput).toBe(false);
+    expect((p.models.codex ?? [])[1]).not.toHaveProperty('supportsImageInput');
+  });
+
   it('exports only the explicitly supported effort levels for a Pi reasoning model', () => {
     const p = buildUserProvider({
       id: 'reasoning-pi',

--- a/packages/model-providers/src/types.ts
+++ b/packages/model-providers/src/types.ts
@@ -362,9 +362,8 @@ export interface CatalogModel {
    */
   newSessionDefault?: ('claude-code' | 'codex')[];
   /**
-   * 该来源下的模型是否已由用户确认支持图片输入。目前只供 Pi 自定义 provider 使用；
-   * 缺省按 false 处理，避免把纯文本端点误报成视觉模型。它是 per-provider 能力，不参与
-   * `modelSignature` 的同 id 跨供应商一致性校验。
+   * 该来源下的模型是否支持图片输入；true/false 为显式声明，缺省表示能力未知。
+   * 它是 per-provider 能力，不参与 `modelSignature` 的同 id 跨供应商一致性校验。
    */
   supportsImageInput?: boolean;
   /**
@@ -476,7 +475,7 @@ export interface ProviderRuntimeModelConfig {
   contextWindow?: number;
   /** 模型未被用户显式开关时的可见性；缺省保持历史行为（默认可见）。 */
   defaultEnabled?: boolean;
-  /** Pi 自定义模型是否支持原生图片输入；缺省保守视为不支持。 */
+  /** 是否支持原生图片输入；true/false 为显式声明，缺省表示能力未知。 */
   supportsImageInput?: boolean;
   /** Pi 自定义模型是否支持 reasoning；缺省 / false 均按不支持处理。 */
   reasoning?: boolean;

--- a/packages/model-providers/src/user-provider.ts
+++ b/packages/model-providers/src/user-provider.ts
@@ -78,7 +78,9 @@ function toCatalogModel(
     // 手填模型保持历史默认可见；刷新发现的模型可显式声明默认隐藏。
     defaultEnabled: m.defaultEnabled ?? true,
     // 图片能力必须由用户/预设明确确认；缺省不猜，防止 Pi 静默把截图降级成占位文本。
-    ...(m.supportsImageInput === true ? { supportsImageInput: true } : {}),
+    ...(m.supportsImageInput !== undefined
+      ? { supportsImageInput: m.supportsImageInput }
+      : {}),
   };
 }
 


### PR DESCRIPTION
## What changed

- Remove the OCR fallback path and send a structured `IMAGE_ATTACHMENT_UNAVAILABLE_V1` marker to text-only model routes.
- Keep original images for routes that explicitly support image input.
- Mark the direct DeepSeek preset as text-only before dispatch, while unknown custom routes remain optimistic and learn from one precise image-schema rejection.
- Strip current and historical image parts for learned/text-only routes across Responses, Chat Completions, and Anthropic message shapes without deleting persisted attachment metadata.
- Preserve explicit `supportsImageInput: false` through provider configuration and catalog projection.

## Why

Text-only DeepSeek-compatible routes reject `image_url` parts during JSON deserialization. The previous OCR proposal added quality and packaging costs, and it still did not provide reliable visual understanding. This version tells the model only the truthful fact that the user uploaded an image which the current route did not receive.

## Impact

Known text-only routes avoid the initial 400 entirely. Unknown custom routes may fail once, then retry invisibly with the marker and cache the exact provider/model route for the current process. Multimodal routes continue receiving the original image.

## Validation

- Desktop current-message, coordinator, capability and history tests: 306/306 passed.
- Desktop proxy, provider store and renderer provider tests: 196/196 passed.
- Model provider catalog, preset and user-provider tests: 110/110 passed.
- Staged diff check passed.

## Remaining work

- Run final Desktop/model-provider type checks and lint.
- Restart the isolated Desktop instance and manually verify direct DeepSeek, an unknown custom route, a multimodal route, and model switching with historical images.

This is intentionally a draft so work can continue from another device.