### PR TITLE
fix(utility-model): 直连 Anthropic Messages 用真实 API model id，剥离 SDK [1m] 后缀

### DIFF
--- a/apps/desktop/src/main/utility-model/__tests__/oneShotCandidates.test.ts
+++ b/apps/desktop/src/main/utility-model/__tests__/oneShotCandidates.test.ts
@@ -1443,7 +1443,9 @@ describe('utility one-shot candidates', () => {
     expect(fetchMock).toHaveBeenCalledWith('https://anthropic.example/api/v1/messages', expect.anything());
     const init = fetchMock.mock.calls[0]?.[1] as { headers: Record<string, string>; body: string };
     expect(init.headers.Authorization).toBe('Bearer anthropic-token');
-    expect(JSON.parse(init.body).model).toBe('claude-sonnet-4-6[1m]');
+    // 直连 /v1/messages 必须用真实 API model id:SDK 的 `[1m]` beta 通道后缀
+    // 会命中 Anthropic API 404(见 #2429)。目录 contextWindow ≥1M 也不能带。
+    expect(JSON.parse(init.body).model).toBe('claude-sonnet-4-6');
   });
 
   it('uses OpenAI Codex OAuth and strips the bridge model prefix on the selected route', async () => {
@@ -1549,4 +1551,51 @@ describe('utility one-shot candidates', () => {
       expect(body).not.toHaveProperty('reasoning');
     },
   );
+});
+
+describe('utility Anthropic messages direct model id (#2429)', () => {
+  const anthropicProvider = (models: Array<{ id: string; contextWindow: number }>) => ({
+    providers: [{
+      id: 'anthropic',
+      name: 'Anthropic',
+      source: 'builtin',
+      agents: ['claude-code'],
+      auth: { method: 'oauth' },
+      routing: {
+        'claude-code': { upstream: 'https://anthropic.example/api/v1', authStrategy: 'oauth-passthrough' },
+      },
+      models: { 'claude-code': models },
+    }],
+  });
+
+  async function runAnthropicOneShot(model: string) {
+    readClaudeOAuth.mockResolvedValue({ accessToken: 'anthropic-token' });
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      text: async () => JSON.stringify({ content: [{ type: 'text', text: 'script' }] }),
+    } as never);
+    await requestUtilityText(makerMock(false), 'generate', {
+      providerId: 'anthropic',
+      agentKind: 'claude-code',
+      model,
+    });
+    const lastCall = fetchMock.mock.calls.at(-1);
+    return JSON.parse(String(lastCall?.[1]?.body)).model as string;
+  }
+
+  it('sends a bare API model id for 1M-context models (no SDK [1m] wire suffix)', async () => {
+    activeCatalog.mockReturnValue(anthropicProvider([
+      { id: 'claude-fable-5', contextWindow: 1_000_000 },
+      { id: 'claude-opus-5', contextWindow: 1_000_000 },
+    ]) as never);
+    expect(await runAnthropicOneShot('claude-fable-5')).toBe('claude-fable-5');
+    expect(await runAnthropicOneShot('claude-opus-5')).toBe('claude-opus-5');
+  });
+
+  it('keeps the bare model id for non-1M Claude models (e.g. Haiku)', async () => {
+    activeCatalog.mockReturnValue(anthropicProvider([
+      { id: 'claude-haiku-4-5', contextWindow: 200_000 },
+    ]) as never);
+    expect(await runAnthropicOneShot('claude-haiku-4-5')).toBe('claude-haiku-4-5');
+  });
 });

--- a/apps/desktop/src/main/utility-model/oneShotCandidates.ts
+++ b/apps/desktop/src/main/utility-model/oneShotCandidates.ts
@@ -624,7 +624,7 @@ async function requestBuiltinProviderText(
           'anthropic-version': '2023-06-01',
           'anthropic-beta': 'oauth-2025-04-20',
         },
-        model: toSdkModelString(input.model, findProviderModel(input.provider, input.agentKind, input.model)?.contextWindow),
+        model: toAnthropicMessagesModelId(input.model, findProviderModel(input.provider, input.agentKind, input.model)?.contextWindow),
         prompt: text,
         // Anthropic API 协议必填 max_tokens:缺省时以模型目录声明的 maxOutput
         // (模型自身输出能力)兜底,没有目录条目才回退 81920——宿主不设政策上限。
@@ -903,6 +903,19 @@ function appendProviderPath(baseUrl: string, suffix: string): string {
   // Fragments are client-side only and must not be sent as part of an API URL.
   url.hash = '';
   return url.toString();
+}
+
+/**
+ * Anthropic Messages API 直连请求的 model 转换。
+ *
+ * 主链 Claude Code 走 SDK/本地代理，`[1m]` 是 SDK 识别 1M beta 通道的 wire
+ * 后缀（见 maker-core toSdkModelString 契约：SDK 细节不外泄给调用方）。
+ * 本路径直连 /v1/messages，Anthropic API 不认 `[1m]` 后缀（返回 404），
+ * 因此发往 API 的 model 必须剥离该后缀、保留目录真实 model id。
+ * 只作用于内置 anthropic 分支；自定义/兼容供应商走各自 model 透传，不做全局剥离。
+ */
+function toAnthropicMessagesModelId(model: string, contextWindow?: number | null): string {
+  return toSdkModelString(model, contextWindow).replace(/\[1m\]$/, '');
 }
 
 /** Claude providers may configure either the host root or an existing `/v1` base. */


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 #2429：Auto-review / 任务摘要等 utility one-shot 路径在内置 anthropic 分支**直连** `/v1/messages` 时，把 Claude Code SDK 的 wire 字符串（如 `claude-fable-5[1m]`）原样发进请求体。

`[1m]` 是 maker-core `toSdkModelString` 为 SDK 识别 1M beta 通道追加的内部后缀（契约明确「SDK 细节不外泄给调用方」）。Anthropic Messages API 不认它，对 1M 上下文模型（fable/opus/sonnet）恒返回 **404** → reviewer 拿不到结果 → Auto 模式 fail-closed 成 `[AUTO_REVIEW_UNAVAILABLE]`。主对话链正常是因为它走 Claude Code SDK + 本地代理，SDK 内部翻译了 `[1m]`。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：#2429
- 本 PR 包含：新增 `toAnthropicMessagesModelId()`（复用 `toSdkModelString` 的窗口口径，剥离 `[1m]` 后缀，产出 provider-native API model id）；内置 anthropic 分支改用该转换。
- 明确不包含：自定义/兼容供应商的 model 透传（不做全局剥离）；fail-closed 语义变更。
- 用户可见变化：Auto 模式下需审核操作不再因 404 而 fail-closed 成 `[AUTO_REVIEW_UNAVAILABLE]`。
- 是否存在 breaking change：无

### UI 变化

不涉及：本改动只调整 utility 请求体 model 字段，无视觉、布局、动效或文案变化。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop run --if-present typecheck
结果：PASS

pnpm --filter desktop vitest run src/main/utility-model/__tests__/oneShotCandidates.test.ts
结果：PASS（46 条，含新增 2 条）
```

全量 `test:unit` 由 fork client-ci（同 SHA `15c9de259`）验证：https://github.com/gardenZzz/cindy/actions/runs/31506118835 （8/8 job success）。

### 手工验证

不涉及（主仓 CI 需维护者放行，fork CI 等价验证已全绿）。

### 未执行的验证

无。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅内置 anthropic 的 Messages 直连路径（utility one-shot）。
- 回滚方式：revert 本 PR 即可。

Closes #2429
