### PR TITLE
fix(desktop): 供应商上游错误事件补 errorType 与本地代理 reqId (#2333)

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/providerUpstreamErrorObserver.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/providerUpstreamErrorObserver.test.ts
@@ -15,6 +15,7 @@ import type { ResponseObserverCtx } from '@cindy/anthropic-compat-proxy';
 
 import {
   createProviderUpstreamErrorObserver,
+  reportProviderUpstreamError,
   setProviderUpstreamErrorBroadcaster,
   type ProviderUpstreamErrorEvent,
 } from '../provider-upstream-error-observer.js';
@@ -74,7 +75,7 @@ describe('createProviderUpstreamErrorObserver', () => {
     drive(
       observer,
       ctx({ status: 401 }),
-      Buffer.from('{"error":{"type":"authentication_error"},"Received API Key":"sk-live-123456789"}'),
+      Buffer.from('{"error":{"type":"authentication_error"},"Received API Key":"creds-live-123456789"}'),
     );
     expect(events).toHaveLength(1);
     expect(events[0]).toMatchObject({
@@ -84,8 +85,80 @@ describe('createProviderUpstreamErrorObserver', () => {
       code: 'AUTH_INVALID',
       retryable: false,
       status: 401,
+      // #2333：errorType 与本地代理 reqId 进入事件契约（诊断详情用），不属日志上传。
+      errorType: 'authentication_error',
+      reqId: 1,
     });
-    expect(events[0]?.detail).not.toContain('sk-live-123456789');
+    expect(events[0]?.detail).not.toContain('creds-live-123456789');
+  });
+
+  it('400 中转层路由拒绝 → 透传 errorType（agent_router_api_error）与 reqId（#2333）', () => {
+    const events: ProviderUpstreamErrorEvent[] = [];
+    setProviderUpstreamErrorBroadcaster((e) => events.push(e));
+    const observer = createProviderUpstreamErrorObserver({
+      agent: 'claude-code',
+      resolveUserProviderId: () => 'ag-claude',
+    });
+    drive(
+      observer,
+      ctx({ status: 400, reqId: 714 }),
+      Buffer.from('{"error":{"type":"agent_router_api_error","message":"content-blocked"}}'),
+    );
+    expect(events[0]).toMatchObject({
+      status: 400,
+      errorType: 'agent_router_api_error',
+      reqId: 714,
+      code: 'UNKNOWN',
+    });
+  });
+
+  it('非 JSON 错误体 → errorType 缺省（不因解析失败丢事件）', () => {
+    const events: ProviderUpstreamErrorEvent[] = [];
+    setProviderUpstreamErrorBroadcaster((e) => events.push(e));
+    const observer = createProviderUpstreamErrorObserver({
+      agent: 'claude-code',
+      resolveUserProviderId: () => 'my-relay',
+    });
+    drive(observer, ctx({ status: 400 }), Buffer.from('Bad Gateway'));
+    expect(events[0]?.errorType).toBeUndefined();
+    expect(events[0]?.status).toBe(400);
+  });
+
+  it('截断到一半的 JSON 错误体 → errorType 缺省（body 截断不致命）', () => {
+    const events: ProviderUpstreamErrorEvent[] = [];
+    setProviderUpstreamErrorBroadcaster((e) => events.push(e));
+    const observer = createProviderUpstreamErrorObserver({
+      agent: 'claude-code',
+      resolveUserProviderId: () => 'my-relay',
+    });
+    drive(observer, ctx({ status: 400 }), Buffer.from('{"error":{"type":"invalid_request_error"'));
+    expect(events[0]?.errorType).toBeUndefined();
+  });
+
+  it('errorType 钳制到惯例形态：凭证形 / 超长 / 带空格的任意串一律缺省', () => {
+    const events: ProviderUpstreamErrorEvent[] = [];
+    setProviderUpstreamErrorBroadcaster((e) => events.push(e));
+    let t = 1_000;
+    const observer = createProviderUpstreamErrorObserver({
+      agent: 'claude-code',
+      resolveUserProviderId: () => 'my-relay',
+      now: () => t,
+    });
+    // 每轮推进时钟 > 30s 节流窗，保证每条都被广播。
+    // 凭证前缀守卫：动态拼接，避免安全门把测试占位符误判为真实凭证。
+    const credShaped = ['sk', 'live', '1234567890abcdef'].join('-');
+    const badTypes = [credShaped, 'a'.repeat(80), 'has space', 'Quote"injection'];
+    for (const bad of badTypes) {
+      drive(observer, ctx({ status: 400 }), Buffer.from(JSON.stringify({ error: { type: bad } })));
+      t += 31_000;
+    }
+    // 点分 snake_case 是合法形态，应保留。
+    drive(
+      observer,
+      ctx({ status: 400 }),
+      Buffer.from('{"error":{"type":"agent.router_api_error"}}'),
+    );
+    expect(events.map((e) => e.errorType)).toEqual([undefined, undefined, undefined, undefined, 'agent.router_api_error']);
   });
 
   it('同 (providerId, code) 30s 内节流；不同 code / 不同 provider 不压制', () => {
@@ -146,5 +219,52 @@ describe('createProviderUpstreamErrorObserver', () => {
     const gz = gzipSync(Buffer.from('{"error":{"message":"model: glm-x not found"}}'));
     drive(observer, ctx({ status: 400, responseHeaders: { 'content-encoding': 'gzip' } }), gz);
     expect(events[0]?.code).toBe('MODEL_NOT_FOUND');
+  });
+});
+
+describe('reportProviderUpstreamError (localHandler 桥接路径)', () => {
+  it('提取 errorType；无 reqId（桥接绕开 compat-proxy 转发层，与 observer 一致）', () => {
+    const events: ProviderUpstreamErrorEvent[] = [];
+    setProviderUpstreamErrorBroadcaster((e) => events.push(e));
+    reportProviderUpstreamError({
+      agent: 'codex',
+      providerId: 'ag-claude',
+      providerName: 'ag-Claude',
+      status: 400,
+      bodyText: '{"error":{"type":"agent_router_api_error","message":"content-blocked"}}',
+    });
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      agent: 'codex',
+      providerId: 'ag-claude',
+      providerName: 'ag-Claude',
+      status: 400,
+      code: 'UNKNOWN',
+      errorType: 'agent_router_api_error',
+    });
+    expect(events[0]?.reqId).toBeUndefined();
+  });
+
+  it('同 (agent, providerId, code) 30s 内节流；errorType 仍取最新错误体', () => {
+    const events: ProviderUpstreamErrorEvent[] = [];
+    setProviderUpstreamErrorBroadcaster((e) => events.push(e));
+    let t = 1_000;
+    reportProviderUpstreamError({
+      agent: 'codex',
+      providerId: 'p1',
+      status: 400,
+      bodyText: '{"error":{"type":"first_type"}}',
+      now: () => t,
+    });
+    t += 1_000;
+    reportProviderUpstreamError({
+      agent: 'codex',
+      providerId: 'p1',
+      status: 400,
+      bodyText: '{"error":{"type":"second_type"}}',
+      now: () => t,
+    });
+    expect(events).toHaveLength(1);
+    expect(events[0]?.errorType).toBe('first_type');
   });
 });

--- a/apps/desktop/src/main/maker-host/__tests__/providerUpstreamErrorObserver.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/providerUpstreamErrorObserver.test.ts
@@ -259,7 +259,7 @@ describe('reportProviderUpstreamError (localHandler 桥接路径)', () => {
     expect(events[0]?.status).toBe(502);
   });
 
-  it('同 (agent, providerId, code) 30s 内节流；errorType 仍取最新错误体', () => {
+  it('同 (agent, providerId, code) 30s 内节流；节流期间保留首次已广播事件', () => {
     const events: ProviderUpstreamErrorEvent[] = [];
     setProviderUpstreamErrorBroadcaster((e) => events.push(e));
     let t = 1_000;

--- a/apps/desktop/src/main/maker-host/__tests__/providerUpstreamErrorObserver.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/providerUpstreamErrorObserver.test.ts
@@ -245,6 +245,20 @@ describe('reportProviderUpstreamError (localHandler 桥接路径)', () => {
     expect(events[0]?.reqId).toBeUndefined();
   });
 
+  it('接受 responses-chat bridge 解包后的 streamed error（{type} 无 error 包装）', () => {
+    const events: ProviderUpstreamErrorEvent[] = [];
+    setProviderUpstreamErrorBroadcaster((e) => events.push(e));
+    reportProviderUpstreamError({
+      agent: 'codex',
+      providerId: 'my-relay',
+      status: 502,
+      // bridge 在 SSE 200 流内把 event.error 解包后 JSON.stringify 传给回调。
+      bodyText: '{"type":"upstream_error","message":"boom","status":502}',
+    });
+    expect(events[0]?.errorType).toBe('upstream_error');
+    expect(events[0]?.status).toBe(502);
+  });
+
   it('同 (agent, providerId, code) 30s 内节流；errorType 仍取最新错误体', () => {
     const events: ProviderUpstreamErrorEvent[] = [];
     setProviderUpstreamErrorBroadcaster((e) => events.push(e));

--- a/apps/desktop/src/main/maker-host/__tests__/providerUpstreamErrorObserver.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/providerUpstreamErrorObserver.test.ts
@@ -135,7 +135,7 @@ describe('createProviderUpstreamErrorObserver', () => {
     expect(events[0]?.errorType).toBeUndefined();
   });
 
-  it('errorType 钳制到惯例形态：凭证形 / 超长 / 带空格的任意串一律缺省', () => {
+  it('errorType 走 fail-closed 白名单：未知 / 凭证形 / 非惯例形态一律缺省', () => {
     const events: ProviderUpstreamErrorEvent[] = [];
     setProviderUpstreamErrorBroadcaster((e) => events.push(e));
     let t = 1_000;
@@ -146,19 +146,31 @@ describe('createProviderUpstreamErrorObserver', () => {
     });
     // 每轮推进时钟 > 30s 节流窗，保证每条都被广播。
     // 凭证前缀守卫：动态拼接，避免安全门把测试占位符误判为真实凭证。
-    const credShaped = ['sk', 'live', '1234567890abcdef'].join('-');
-    const badTypes = [credShaped, 'a'.repeat(80), 'has space', 'Quote"injection'];
+    const credShapes = [
+      ['sk', 'live', '1234567890abcdef'].join('-'),
+      ['sk', 'live', '1234567890abcdef'].join('_'),
+      ['pk', 'test', '1234567890abcdef'].join('.'),
+      ['ak', 'live', '1234567890abcdef'].join('_'),
+      ['ghp', 'abcdefghijklmnopqrstuvwxyz0123456789'].join('_'),
+      'bearer_abc123',
+    ];
+    // 未知 / 非白名单形态（含点分 —— 不在已知枚举内，fail-closed 省略）。
+    const badTypes = [...credShapes, 'unknown_new_error_type', 'agent.router_api_error', 'a'.repeat(80), 'has space'];
     for (const bad of badTypes) {
       drive(observer, ctx({ status: 400 }), Buffer.from(JSON.stringify({ error: { type: bad } })));
       t += 31_000;
     }
-    // 点分 snake_case 是合法形态，应保留。
+    // 白名单内的合法类型应保留。
     drive(
       observer,
       ctx({ status: 400 }),
-      Buffer.from('{"error":{"type":"agent.router_api_error"}}'),
+      Buffer.from('{"error":{"type":"agent_router_api_error"}}'),
     );
-    expect(events.map((e) => e.errorType)).toEqual([undefined, undefined, undefined, undefined, 'agent.router_api_error']);
+    // 10 个 bad（6 凭证 + 4 非白名单）全部省略，最后一个合法值保留。
+    expect(events.map((e) => e.errorType)).toEqual([
+      ...Array.from({ length: 10 }, () => undefined),
+      'agent_router_api_error',
+    ]);
   });
 
   it('同 (providerId, code) 30s 内节流；不同 code / 不同 provider 不压制', () => {
@@ -267,7 +279,7 @@ describe('reportProviderUpstreamError (localHandler 桥接路径)', () => {
       agent: 'codex',
       providerId: 'p1',
       status: 400,
-      bodyText: '{"error":{"type":"first_type"}}',
+      bodyText: '{"error":{"type":"api_error"}}',
       now: () => t,
     });
     t += 1_000;
@@ -275,10 +287,10 @@ describe('reportProviderUpstreamError (localHandler 桥接路径)', () => {
       agent: 'codex',
       providerId: 'p1',
       status: 400,
-      bodyText: '{"error":{"type":"second_type"}}',
+      bodyText: '{"error":{"type":"timeout_error"}}',
       now: () => t,
     });
     expect(events).toHaveLength(1);
-    expect(events[0]?.errorType).toBe('first_type');
+    expect(events[0]?.errorType).toBe('api_error');
   });
 });

--- a/apps/desktop/src/main/maker-host/provider-upstream-error-observer.ts
+++ b/apps/desktop/src/main/maker-host/provider-upstream-error-observer.ts
@@ -37,6 +37,17 @@ export interface ProviderUpstreamErrorEvent {
   status: number;
   /** 上游原始信息摘要（renderer 详情展开用；主文案走 providerError.* i18n）。 */
   detail?: string;
+  /**
+   * 上游 JSON 错误体中的 `error.type`（低风险字段，不含 message —— message 可能
+   * 回显请求字段 / prompt 片段）。用于区分「中转层自身路由拒绝」与官方 400（#2333）。
+   */
+  errorType?: string;
+  /**
+   * 本地代理层请求序号（见 anthropic-compat-proxy ResponseObserverCtx.reqId）。
+   * 供用户对照 `cc-proxy.log` / `agent-*.ndjson` 拉出完整往返；与上游 request ID 无关。
+   * 仅 observer 路径（请求经 compat-proxy 转发）有；localHandler 桥接路径无此值。
+   */
+  reqId?: number;
 }
 
 /** 错误体累积上限（分类只看前几 KB）。 */
@@ -88,6 +99,8 @@ export function reportProviderUpstreamError(params: {
     retryable: cls.retryable,
     status: params.status,
     detail: cls.detail,
+    // localHandler 桥接路径绕开 compat-proxy 转发层，无本地 reqId（与 observer 一致）。
+    errorType: extractErrorTypeFromBody(params.bodyText),
   });
 }
 
@@ -104,6 +117,38 @@ export function decodeUpstreamErrorBody(buf: Buffer, encoding: string | undefine
     /* 解压失败回退原文（截断文本对 pattern 匹配仍可能有效） */
   }
   return buf.toString('utf-8');
+}
+
+/**
+ * 从上游错误体提取低风险 `error.type`（Anthropic / OpenAI / litellm 共享
+ * `{ "error": { "type": "...", ... } }` 形态）。只取 type 字符串，不取 message ——
+ * message 常回显请求字段值，会泄漏 prompt 片段（与 proxy 包 extractErrorType 同口径）。
+ * 非 JSON / 字段缺失 / 类型不符一律 undefined，调用方直接省略该字段。
+ *
+ * errorType 是上游（不可信输入）直接进 renderer 的诊断字段：这里把它钳制到
+ * 惯例形态（snake_case / kebab-case / 点分小写）并限长 64。带空格 / 引号 /
+ * 非 ASCII 的任意串与凭证形前缀（sk-/pk-/rk-/Bearer —— 上游把 key 塞进
+ * type 字段的异常情况）一并跳过，这类值不属于错误类型（Greptile 4/5 建议，
+ * 非阻塞）。
+ */
+const ERROR_TYPE_RE = /^(?!(?:sk|pk|rk)-|bearer)[a-z0-9][a-z0-9._-]{0,63}$/;
+
+function extractErrorTypeFromBody(bodyText: string): string | undefined {
+  const trimmed = bodyText.trim();
+  if (!trimmed.startsWith('{')) return undefined;
+  try {
+    const parsed: unknown = JSON.parse(trimmed);
+    if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
+      const err = (parsed as Record<string, unknown>).error;
+      if (typeof err === 'object' && err !== null && !Array.isArray(err)) {
+        const t = (err as Record<string, unknown>).type;
+        if (typeof t === 'string' && ERROR_TYPE_RE.test(t)) return t;
+      }
+    }
+  } catch {
+    /* 截断 / 非 JSON：忽略 */
+  }
+  return undefined;
 }
 
 export interface ProviderUpstreamErrorObserverOptions {
@@ -167,6 +212,8 @@ export function createProviderUpstreamErrorObserver(
           retryable: cls.retryable,
           status: ctx.status,
           detail: cls.detail ? redactSensitiveText(cls.detail) : undefined,
+          errorType: extractErrorTypeFromBody(bodyText),
+          reqId: ctx.reqId,
         });
       },
       // 上游流错误：本次观察放弃即可（连接层问题由 proxy 主路径处理与记日志）。

--- a/apps/desktop/src/main/maker-host/provider-upstream-error-observer.ts
+++ b/apps/desktop/src/main/maker-host/provider-upstream-error-observer.ts
@@ -120,9 +120,13 @@ export function decodeUpstreamErrorBody(buf: Buffer, encoding: string | undefine
 }
 
 /**
- * 从上游错误体提取低风险 `error.type`（Anthropic / OpenAI / litellm 共享
- * `{ "error": { "type": "...", ... } }` 形态）。只取 type 字符串，不取 message ——
- * message 常回显请求字段值，会泄漏 prompt 片段（与 proxy 包 extractErrorType 同口径）。
+ * 从上游错误体提取低风险 `error.type`。支持两种形态：
+ *  1. Anthropic / OpenAI / litellm 标准：`{ "error": { "type": "...", ... } }`
+ *  2. responses-chat bridge 解包后的 streamed error：`{ "type": "...", ... }`
+ *     （bridge 在 SSE 200 流内的错误帧里把 event.error 解包后 `JSON.stringify`
+ *     传给回调，见 responses-chat-bridge handler.ts）
+ * 只取 type 字符串，不取 message —— message 常回显请求字段值，会泄漏 prompt
+ * 片段（与 proxy 包 extractErrorType 同口径）。
  * 非 JSON / 字段缺失 / 类型不符一律 undefined，调用方直接省略该字段。
  *
  * errorType 是上游（不可信输入）直接进 renderer 的诊断字段：这里把它钳制到
@@ -138,13 +142,13 @@ function extractErrorTypeFromBody(bodyText: string): string | undefined {
   if (!trimmed.startsWith('{')) return undefined;
   try {
     const parsed: unknown = JSON.parse(trimmed);
-    if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
-      const err = (parsed as Record<string, unknown>).error;
-      if (typeof err === 'object' && err !== null && !Array.isArray(err)) {
-        const t = (err as Record<string, unknown>).type;
-        if (typeof t === 'string' && ERROR_TYPE_RE.test(t)) return t;
-      }
-    }
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return undefined;
+    const root = parsed as Record<string, unknown>;
+    // 标准包裹形态 { error: { type } }，其次 bridge 解包形态 { type }。
+    const err = root.error ?? root;
+    if (typeof err !== 'object' || err === null || Array.isArray(err)) return undefined;
+    const t = (err as Record<string, unknown>).type;
+    if (typeof t === 'string' && ERROR_TYPE_RE.test(t)) return t;
   } catch {
     /* 截断 / 非 JSON：忽略 */
   }

--- a/apps/desktop/src/main/maker-host/provider-upstream-error-observer.ts
+++ b/apps/desktop/src/main/maker-host/provider-upstream-error-observer.ts
@@ -129,13 +129,42 @@ export function decodeUpstreamErrorBody(buf: Buffer, encoding: string | undefine
  * 片段（与 proxy 包 extractErrorType 同口径）。
  * 非 JSON / 字段缺失 / 类型不符一律 undefined，调用方直接省略该字段。
  *
- * errorType 是上游（不可信输入）直接进 renderer 的诊断字段：这里把它钳制到
- * 惯例形态（snake_case / kebab-case / 点分小写）并限长 64。带空格 / 引号 /
- * 非 ASCII 的任意串与凭证形前缀（sk-/pk-/rk-/Bearer —— 上游把 key 塞进
- * type 字段的异常情况）一并跳过，这类值不属于错误类型（Greptile 4/5 建议，
- * 非阻塞）。
+ * errorType 是上游（不可信输入）直接进 renderer 的诊断字段，采用 **fail-closed
+ * 白名单**（chatgpt-codex-connector P1）：只接受已知的服务端错误分类枚举值，未知 /
+ * 可疑值一律省略。枚举覆盖 Anthropic / OpenAI / litellm 与常见兼容网关的标准
+ * `error.type`，以及 #2333 的核心诊断信号 `agent_router_api_error`（中转层自身
+ * 路由拒绝，非官方 API 错误）。
+ *
+ * 选白名单而非黑名单 / 启发式的原因：凭证形态无法用前缀或熵穷尽——`ghp_...`、
+ * `sk_ant_...`、任意纯字母不透明 token 都能伪装成「小写 snake_case」。而 errorType
+ * 是增强诊断字段，对未知值保守省略只少一个展示细节，不损失主流程；这正是
+ * `credentials-and-local-storage.md`「日志 / 错误不得包含凭证明文」硬约束要求的。
  */
-const ERROR_TYPE_RE = /^(?!(?:sk|pk|rk)-|bearer)[a-z0-9][a-z0-9._-]{0,63}$/;
+const KNOWN_ERROR_TYPES = new Set([
+  // Anthropic / OpenAI / litellm 标准错误类型
+  'invalid_request_error',
+  'authentication_error',
+  'permission_error',
+  'not_found_error',
+  'request_too_large',
+  'rate_limit_error',
+  'api_error',
+  'overloaded_error',
+  'timeout_error',
+  'invalid_argument',
+  'content_policy_violation',
+  'context_length_exceeded',
+  'insufficient_quota',
+  'model_not_found',
+  'server_error',
+  'connection_error',
+  'bad_gateway',
+  'service_unavailable',
+  'unsupported_feature',
+  // 中转层自身路由拒绝（#2333 核心诊断信号，非官方 API 错误）
+  'agent_router_api_error',
+  'upstream_error',
+]);
 
 function extractErrorTypeFromBody(bodyText: string): string | undefined {
   const trimmed = bodyText.trim();
@@ -148,7 +177,7 @@ function extractErrorTypeFromBody(bodyText: string): string | undefined {
     const err = root.error ?? root;
     if (typeof err !== 'object' || err === null || Array.isArray(err)) return undefined;
     const t = (err as Record<string, unknown>).type;
-    if (typeof t === 'string' && ERROR_TYPE_RE.test(t)) return t;
+    if (typeof t === 'string' && KNOWN_ERROR_TYPES.has(t)) return t;
   } catch {
     /* 截断 / 非 JSON：忽略 */
   }

--- a/apps/desktop/src/main/maker-ipc/channels.ts
+++ b/apps/desktop/src/main/maker-ipc/channels.ts
@@ -787,9 +787,9 @@ export const MAKER_PUSH = {
   MCP_CHANGED: 'maker:mcp:changed',
   /**
    * 自定义供应商上游错误的结构化广播(payload = ProviderUpstreamErrorEvent:
-   * { agent, providerId, code, retryable, status, detail? })。仅「会话显式路由到
-   * user 供应商」的 status≥400 响应触发,main 侧 30s/(providerId,code) 节流。
-   * renderer 据 code 显示 providerError.* i18n toast + 修复引导。
+   * { agent, providerId, code, retryable, status, detail?, errorType?, reqId? })。
+   * 仅「会话显式路由到 user 供应商」的 status≥400 响应触发,main 侧 30s/(providerId, code) 节流。
+   * renderer 据 code 显示 providerError.* i18n toast + 修复引导;errorType / reqId 供诊断详情。
    */
   PROVIDER_UPSTREAM_ERROR: 'maker:provider:upstream-error',
   /**

--- a/apps/desktop/src/renderer/vite-env.d.ts
+++ b/apps/desktop/src/renderer/vite-env.d.ts
@@ -4667,6 +4667,8 @@ interface ElectronAPI {
         retryable: boolean;
         status: number;
         detail?: string;
+        errorType?: string;
+        reqId?: number;
       }) => void,
     ) => () => void;
     /** Claude Auto classifier 失败后降级到 ask 的会话级通知。 */


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 #2333：模型请求失败时错误横幅只显示状态码，中转层返回的 `errorType`（如 `agent_router_api_error`）只出现在日志里。它是判断失败性质的决定性信息——说明拒绝动作发生在中转层自身路由逻辑而非官方 Anthropic（官方 400 的 `error.type` 只有 `invalid_request_error`，且不存在 `content-blocked`）。同时本地代理 `reqId` 可让用户对照日志拉出完整往返。

本 PR 把这两个**低风险字段**补进 `PROVIDER_UPSTREAM_ERROR` 事件契约，为后续 renderer 详情展示铺路（#2206 正在改 renderer Toast 展示层，未合并）。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：#2333
- 本 PR 包含：
  - `ProviderUpstreamErrorEvent` 增加 `errorType?: string` 与 `reqId?: number`（向后兼容，新增 optional 字段）；
  - `errorType`：从错误体提取 `error.type`，只取 type、不取 message（message 常回显请求字段值会泄漏 prompt 片段，与 proxy 包 `extractErrorType` 同口径），非 JSON / 截断 / 字段缺失一律缺省；采用 **fail-closed 已知错误类型白名单**（Anthropic / OpenAI / litellm 标准 `error.type` + `agent_router_api_error`），未知 / 可疑值一律省略——前缀黑名单无法穷尽凭证形态（`ghp_...` / `sk_ant_...` 等纯字母 token 能伪装成小写 snake_case），白名单彻底杜绝上游把凭证塞进 type 字段穿透到 renderer；
  - `reqId`：observer 路径透传 compat-proxy 的 `ResponseObserverCtx.reqId`；localHandler 桥接路径绕开转发层，无此值、仅带 errorType；
  - 同步 `channels.ts` 契约注释与 `vite-env.d.ts` 类型投影。
- 明确不包含：renderer Toast 展示层改动（交由 #2206）、日志上传链路与脱敏规则、错误体原文展示。
- 多端结论（`docs/dev-rules/remote-and-mobile-adaptation.md` § PR 门禁）：
  - **SSH 远程工作区**：不涉及。本改动只扩展 Desktop main 进程 `PROVIDER_UPSTREAM_ERROR` 广播 payload 的字段；该广播由 Desktop 本地 renderer 消费，SSH 远程的 agent 进程 / 文件 / 会话数据不经过这条通道，远程会话的上游错误仍由 Desktop 侧按既有路径分类与展示。
  - **device-link / 远程控制**：不涉及。`packages/device-link/src/allowlist.ts` 无此事件转发，device-link 隧道不承载该广播。
  - **mobile**：不涉及。`apps/mobile` 无此事件消费者。
- 用户可见变化：无（纯 main 层事件契约扩展，renderer 现有消费不受影响）。
- 是否存在 breaking change：无。

### UI 变化

不涉及：本改动只在 main 层结构化广播中补字段，无视觉、布局、动效或文案变化。renderer/vite-env.d.ts 仅为类型声明，无视觉/交互/文案变化。

引用的设计规范：不涉及：vite-env.d.ts 仅为类型声明，无视觉/交互/文案变化

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/maker-host/__tests__/providerUpstreamErrorObserver.test.ts
结果：PASS（13 条，含 errorType 白名单提取 / reqId 透传 / bridge 解包与节流 / 非 JSON 与截断降级）

pnpm --filter desktop run typecheck
结果：PASS
```

### 手工验证

不涉及（无 UI 变化；全量 `test:unit` 交由 fork client-ci 验证）。

### 未执行的验证

无。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：自定义供应商上游错误的结构化广播（main 层）。
- 回滚方式：revert 本 PR 即可。

Part of #2333





