### PR TITLE
fix(desktop): 子代理内部消息不再铺进主聊天流

### DIFF
--- a/apps/desktop/src/renderer/__tests__/emptyThinkingPlaceholder.test.ts
+++ b/apps/desktop/src/renderer/__tests__/emptyThinkingPlaceholder.test.ts
@@ -91,6 +91,43 @@ describe('isNonAnchorHistoryRow — 历史初始页 backfill 判定', () => {
     expect(isNonAnchor(synthetic('帮我查一下'))).toBe(false);
     expect(isNonAnchor(synthetic({ text: '帮我查一下' }))).toBe(false);
   });
+
+  it('子代理内部行算无锚点(buildRenderItems 整体剔除,漏登记会渲染 0 项)', () => {
+    // 子代理密集的会话最新一页可能全部是这类行(实测本机库单会话上万条)。
+    const subagentRow = (parentUuid: string, role = 'assistant'): Message =>
+      ({
+        id: 'r',
+        clientId: 'c',
+        sessionId: SESSION_ID,
+        role,
+        content: '子代理正文',
+        agentMeta: { parentUuid },
+        createdAt: '2026-07-02T00:00:00.000Z',
+      } as unknown as Message);
+
+    expect(isNonAnchor(subagentRow('toolu_01KzTJBHuSyQfTXT74MKLjgp'))).toBe(true);
+    expect(isNonAnchor(subagentRow('call_abc123'))).toBe(true);
+    expect(isNonAnchor(subagentRow('Task_1'))).toBe(true);
+    expect(isNonAnchor(subagentRow('toolu_ABC', 'thinking'))).toBe(true);
+  });
+
+  it('legacy transcript 链边不算子代理,仍是可见锚点', () => {
+    // 旧 Claude 导入把普通 transcript 链边存在同一个 agentMeta.parentUuid 上。
+    // 误判会让父会话自己的正文被当成无锚点行,触发无谓的整页回填。
+    const legacyRow = (parentUuid: string): Message =>
+      ({
+        id: 'r',
+        clientId: 'c',
+        sessionId: SESSION_ID,
+        role: 'assistant',
+        content: '父会话正文',
+        agentMeta: { parentUuid },
+        createdAt: '2026-07-02T00:00:00.000Z',
+      } as unknown as Message);
+
+    expect(isNonAnchor(legacyRow('preceding-user-uuid'))).toBe(false);
+    expect(isNonAnchor(legacyRow('3d2ac20f-509c-4aff-ac12-842c75f56c6f'))).toBe(false);
+  });
 });
 
 describe('handleStreamEvent — omitted thinking placeholder (live)', () => {

--- a/apps/desktop/src/renderer/__tests__/subagentInternalMessageFilter.test.ts
+++ b/apps/desktop/src/renderer/__tests__/subagentInternalMessageFilter.test.ts
@@ -17,7 +17,12 @@
 
 import { describe, it, expect } from 'vitest';
 
-import { buildRenderItems } from '../components/chat/MessageStream';
+import {
+  buildRenderItems,
+  findLastUserMessageClientId,
+  findLastUserInputClientId,
+  selectVisibleMessages,
+} from '../components/chat/MessageStream';
 import type { ChatMessage } from '@/lib/makerChatStore';
 
 const asst = (clientId: string, content: string, extra: Partial<ChatMessage> = {}): ChatMessage => ({
@@ -116,6 +121,41 @@ describe('buildRenderItems — subagent internal messages', () => {
     expect(messageIds(items)).toEqual(['u1', 'a1', 'u2']);
   });
 
+  it('still surfaces media produced by filtered subagent tool results', () => {
+    // 子代理调出图 / 出片工具时,tool_use 与 tool_result 都被隐藏,段级媒体收集拿不到;
+    // AgentTaskUpdate 也没有承载媒体的字段。不单独补这一路,产物卡会随内部工具行一起
+    // 消失(review: codex P2)。实测本机库里子代理 tool_result 确有图片/视频/音频。
+    const msgs: ChatMessage[] = [
+      { clientId: 'u1', role: 'user', content: '画一张图' },
+      {
+        clientId: 'sub-img-call',
+        role: 'tool_use',
+        content: '',
+        toolName: 'mcp__cindy__ghost_call',
+        toolUseId: 'toolu_img',
+        parentToolUseId: 'toolu_AGENT',
+      },
+      {
+        clientId: 'sub-img-result',
+        role: 'tool_result',
+        content: JSON.stringify({ xdt_image_url: 'cindy-media://blobs/abc.png' }),
+        toolUseId: 'toolu_img',
+        parentToolUseId: 'toolu_AGENT',
+      },
+      { clientId: 'a1', role: 'assistant', content: '画好了' },
+      { clientId: 'u2', role: 'user', content: '谢谢' },
+    ];
+
+    const items = buildRenderItems(msgs).items;
+    const media = items.filter((it) => it.type === 'tool_media');
+    expect(media).toHaveLength(1);
+    expect(media[0].type === 'tool_media' ? media[0].items.map((m) => m.url) : []).toEqual([
+      'cindy-media://blobs/abc.png',
+    ]);
+    // 承载媒体的子代理工具行本身仍然不渲染。
+    expect(messageIds(items)).toEqual(['u1', 'a1', 'u2']);
+  });
+
   it('keeps the parent Agent tool call itself (only its children are internal)', () => {
     const msgs: ChatMessage[] = [
       {
@@ -132,5 +172,44 @@ describe('buildRenderItems — subagent internal messages', () => {
     // Agent 调用渲染成 agent_task 卡,子代理正文不出现在任何 message 条目里。
     expect(items.some((it) => it.type === 'agent_task')).toBe(true);
     expect(messageIds(items)).toEqual([]);
+  });
+});
+
+describe('selectVisibleMessages — 可见 UI 派生共用的序列', () => {
+  it('剔除子代理内部行,保留主线程与 legacy 链边', () => {
+    const msgs: ChatMessage[] = [
+      asst('main', '父会话正文'),
+      asst('sub', '子代理正文', { parentToolUseId: 'toolu_ABC' }),
+      asst('legacy', '老导入正文', { parentToolUseId: 'preceding-user-uuid' }),
+    ];
+
+    expect(selectVisibleMessages(msgs).map((m) => m.clientId)).toEqual(['main', 'legacy']);
+  });
+
+  it('没有子代理消息时返回同一个引用(useMemo 下游不重算)', () => {
+    const msgs: ChatMessage[] = [asst('a', '正文')];
+    expect(selectVisibleMessages(msgs)).toBe(msgs);
+  });
+});
+
+describe('可见 UI 派生不把隐藏的子代理 user 行当成最后一条', () => {
+  // 同族先例:isSyntheticTrigger 行渲染成 null,却曾把「最后一条 user」抢走,
+  // 让真实的最后一条可见气泡丢掉编辑入口(见 findLastUserMessageClientId 注释)。
+  // 子代理内部的 user 行是第二类不可见 user 行(review: codex P2)。
+  const msgs: ChatMessage[] = [
+    { clientId: 'real-user', role: 'user', content: '帮我查一下' },
+    { clientId: 'a1', role: 'assistant', content: '好的' },
+    { clientId: 'sub-user', role: 'user', content: '子任务输入', parentToolUseId: 'toolu_AGENT' },
+  ];
+
+  it('findLastUserMessageClientId:编辑入口留在真实的最后一条可见 user 上', () => {
+    // 直接喂原始数组会命中隐藏行 —— 这正是缺陷本身。
+    expect(findLastUserMessageClientId(msgs)).toBe('sub-user');
+    // 组件侧统一喂 selectVisibleMessages 的结果后恢复正确。
+    expect(findLastUserMessageClientId(selectVisibleMessages(msgs))).toBe('real-user');
+  });
+
+  it('findLastUserInputClientId:在飞的自愈重连行不被子代理行夺走归属', () => {
+    expect(findLastUserInputClientId(selectVisibleMessages(msgs))).toBe('real-user');
   });
 });

--- a/apps/desktop/src/renderer/__tests__/subagentInternalMessageFilter.test.ts
+++ b/apps/desktop/src/renderer/__tests__/subagentInternalMessageFilter.test.ts
@@ -88,6 +88,34 @@ describe('buildRenderItems — subagent internal messages', () => {
     expect(messageIds(buildRenderItems(msgs).items)).toEqual(['legacy-1', 'legacy-2']);
   });
 
+  it('still derives generated-file chips from filtered subagent Write calls', () => {
+    // 子代理用 Write 建的文件是**真实产物**,只是它的 tool_use 行不该渲染。产物收集
+    // 必须回到原始序列取 turn 切片,否则文件 chip 静默消失(review: codex P2)。
+    const msgs: ChatMessage[] = [
+      { clientId: 'u1', role: 'user', content: '帮我生成报告' },
+      {
+        clientId: 'sub-write',
+        role: 'tool_use',
+        content: '',
+        toolName: 'Write',
+        toolUseId: 'toolu_write',
+        toolInput: { file_path: '/repo/report.md', content: '…' },
+        parentToolUseId: 'toolu_AGENT',
+      },
+      { clientId: 'a1', role: 'assistant', content: '写好了' },
+      { clientId: 'u2', role: 'user', content: '谢谢' },
+    ];
+
+    const items = buildRenderItems(msgs, undefined, undefined, { workingDir: '/repo' }).items;
+    const genfiles = items.filter((it) => it.type === 'generated_files');
+    expect(genfiles).toHaveLength(1);
+    expect(
+      genfiles[0].type === 'generated_files' ? genfiles[0].files.map((f) => f.path) : [],
+    ).toEqual(['/repo/report.md']);
+    // 子代理的 Write 行本身仍然不渲染。
+    expect(messageIds(items)).toEqual(['u1', 'a1', 'u2']);
+  });
+
   it('keeps the parent Agent tool call itself (only its children are internal)', () => {
     const msgs: ChatMessage[] = [
       {

--- a/apps/desktop/src/renderer/__tests__/subagentInternalMessageFilter.test.ts
+++ b/apps/desktop/src/renderer/__tests__/subagentInternalMessageFilter.test.ts
@@ -1,0 +1,108 @@
+/**
+ * subagentInternalMessageFilter.test.ts
+ * ---------------------------------------------------------------------------
+ * 锁住 buildRenderItems 对**子代理内部消息**的剔除。
+ *
+ * 背景:后台 Agent/Task 跑起来后,SDK 会把子代理自己的 thinking / 正文 / 工具调用
+ * 一并 echo 回主流(每条带 parent_tool_use_id,经 makerChatStore 投影成顶层
+ * parentToolUseId)。官方 CLI 不显示它们;Cindy 逐条渲染就等于把整篇子代理报告原样
+ * 铺进聊天窗口。它们的去处是自己那张 AgentTaskCard,不是主流。
+ *
+ * 三条不变量:
+ *  - SDK tool-parent 形态(toolu_ / call_ / 兼容模型的 Name_序号)的子消息被剔除;
+ *  - 主线程消息(无 parentToolUseId)逐字节保留;
+ *  - legacy Claude 导入的 transcript 链边(非 tool-use id 形态)不被误判成子代理 ——
+ *    否则父会话自己的正文会被一起吞掉。
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { buildRenderItems } from '../components/chat/MessageStream';
+import type { ChatMessage } from '@/lib/makerChatStore';
+
+const asst = (clientId: string, content: string, extra: Partial<ChatMessage> = {}): ChatMessage => ({
+  clientId,
+  role: 'assistant',
+  content,
+  ...extra,
+});
+
+/** 取渲染结果里所有 message 条目的 clientId(顺序保持)。 */
+const messageIds = (items: ReturnType<typeof buildRenderItems>['items']): string[] =>
+  items.flatMap((it) => (it.type === 'message' ? [it.message.clientId] : []));
+
+describe('buildRenderItems — subagent internal messages', () => {
+  it('drops subagent assistant prose from the main stream', () => {
+    const msgs: ChatMessage[] = [
+      asst('parent-intro', '我先派一个后台调研。'),
+      asst('subagent-report', '调研完成,以下是完整报告……', {
+        parentToolUseId: 'toolu_01KzTJBHuSyQfTXT74MKLjgp',
+        model: 'claude-opus-5',
+      }),
+      asst('parent-summary', '调研回来了,结论如下。'),
+    ];
+
+    expect(messageIds(buildRenderItems(msgs).items)).toEqual([
+      'parent-intro',
+      'parent-summary',
+    ]);
+  });
+
+  it('drops subagent thinking blocks too', () => {
+    const msgs: ChatMessage[] = [
+      { clientId: 'think-sub', role: 'thinking', content: '子代理在想…', parentToolUseId: 'toolu_ABC' },
+      asst('parent', '父会话正文'),
+    ];
+
+    expect(messageIds(buildRenderItems(msgs).items)).toEqual(['parent']);
+  });
+
+  it('recognises the compat tool-use id shape (kimi-style Name_序号)', () => {
+    const msgs: ChatMessage[] = [
+      asst('sub', '子代理正文', { parentToolUseId: 'Task_1' }),
+      asst('parent', '父会话正文'),
+    ];
+
+    expect(messageIds(buildRenderItems(msgs).items)).toEqual(['parent']);
+  });
+
+  it('keeps main-thread messages untouched when nothing is a subagent child', () => {
+    const msgs: ChatMessage[] = [
+      asst('a', '第一段'),
+      asst('b', '第二段'),
+    ];
+
+    expect(messageIds(buildRenderItems(msgs).items)).toEqual(['a', 'b']);
+  });
+
+  it('does NOT drop legacy transcript-chain parents (non tool-use id shape)', () => {
+    // 旧 Claude 导入把普通 transcript 链边存在同一个字段上。把它当子代理归属会
+    // 让父会话自己的正文整段消失 —— 这里锁住不能误判。
+    const msgs: ChatMessage[] = [
+      asst('legacy-1', '父会话正文', { parentToolUseId: 'preceding-user-uuid' }),
+      asst('legacy-2', '父会话正文二', {
+        parentToolUseId: '3d2ac20f-509c-4aff-ac12-842c75f56c6f',
+      }),
+    ];
+
+    expect(messageIds(buildRenderItems(msgs).items)).toEqual(['legacy-1', 'legacy-2']);
+  });
+
+  it('keeps the parent Agent tool call itself (only its children are internal)', () => {
+    const msgs: ChatMessage[] = [
+      {
+        clientId: 'agent-call',
+        role: 'tool_use',
+        content: '',
+        toolName: 'Agent',
+        toolUseId: 'toolu_AGENT',
+      },
+      asst('sub-child', '子代理正文', { parentToolUseId: 'toolu_AGENT' }),
+    ];
+
+    const items = buildRenderItems(msgs).items;
+    // Agent 调用渲染成 agent_task 卡,子代理正文不出现在任何 message 条目里。
+    expect(items.some((it) => it.type === 'agent_task')).toBe(true);
+    expect(messageIds(items)).toEqual([]);
+  });
+});

--- a/apps/desktop/src/renderer/components/chat/MessageStream.tsx
+++ b/apps/desktop/src/renderer/components/chat/MessageStream.tsx
@@ -1015,9 +1015,29 @@ export function buildSubagentModelMap(messages: ChatMessage[]): Map<string, stri
  * 这类非 tool-use id)也存进同一个字段,无条件当子代理会把父会话自己的正文一起
  * 吞掉。只认 SDK tool-parent 形态,与 maker-shared 的投影判据共用同一个函数。
  */
-function isSubagentInternalMessage(message: ChatMessage): boolean {
+export function isSubagentInternalMessage(message: ChatMessage): boolean {
   const parent = message.parentToolUseId;
   return typeof parent === 'string' && parent.length > 0 && isSubagentParentToolUseId(parent);
+}
+
+/**
+ * 「用户实际看得见的那份消息序列」——剔除子代理内部行后的视图。
+ *
+ * 所有**面向可见 UI 的派生**都必须吃这一份,不能各自去扫原始数组:turn 边界、
+ * 「最后一条 user 消息」这类判断一旦把不可见行算进去,可见气泡就会丢掉编辑入口、
+ * 运行态标记与 action bar —— 同一类坑此前已被 `isSyntheticTrigger` 行踩过一次
+ * (见 `findLastUserMessageClientId` 的注释),子代理内部行是第二类不可见行
+ * (review: codex P2)。
+ *
+ * 反面:`buildSubagentModelMap` 之类**按子代理归属反查**的派生必须继续吃原始序列,
+ * 它要的恰恰是这些被隐藏的行。
+ *
+ * 没有子代理消息时返回同一个引用,useMemo 下游不产生额外重算。
+ */
+export function selectVisibleMessages(messages: ChatMessage[]): ChatMessage[] {
+  return messages.some(isSubagentInternalMessage)
+    ? messages.filter((m) => !isSubagentInternalMessage(m))
+    : messages;
 }
 
 export function buildRenderItems(
@@ -1049,9 +1069,9 @@ export function buildRenderItems(
   // 过滤放在最前面:后续所有 pass(tool_result lookup、段落配对、turn 边界、work-group)
   // 看到的都是同一份"用户可见"的消息序列,不会出现"查得到但不渲染"的半吊子状态。
   const hasSubagentInternalMessages = allMessages.some(isSubagentInternalMessage);
-  // 过滤后下标 → 原始下标。产物文件卡(collectGeneratedFiles)必须回到**原始**序列
-  // 取 turn 切片:子代理用 Write / Bash 建的文件是真实产物,只是它的 tool_use 行不该
-  // 渲染;只喂过滤后的切片会让这些文件 chip 静默消失(review: codex P2)。
+  // 过滤后下标 → 原始下标。**产物**类派生(生成文件 chip、媒体卡)必须回到原始序列取
+  // turn 切片:子代理用 Write / Bash 建的文件、出图出片工具返回的媒体都是真实产物,
+  // 只是承载它们的工具行不该渲染;只喂过滤后的切片会让这些卡静默消失(review: codex P2)。
   const originalIndexByVisible: number[] = [];
   const messages = hasSubagentInternalMessages
     ? allMessages.filter((m, idx) => {
@@ -1245,6 +1265,33 @@ export function buildRenderItems(
         changeSet,
       });
     }
+    // 子代理工具结果里的媒体产物(出图 / 视频 / 音频 / 模型)。这些工具行本身被隐藏,
+    // 不进 tool_segment,所以段级的 pendingSegmentMedia 收不到它们;而 AgentTaskUpdate
+    // 没有承载媒体的字段,不补这一路产物卡就会随内部工具行一起消失(review: codex P2)。
+    // 归属到 turn 一级,与产物文件卡同一处理方式。
+    //
+    // 只收**被隐藏的**那部分:可见工具行的媒体照旧走 tool_segment,不能在这里重复渲染。
+    // ghost_call 的锚卡逻辑不在这条路径上——子代理不参与意识卡片的开卡/锚定。
+    if (hasSubagentInternalMessages) {
+      const hiddenMedia: ToolMediaItem[] = [];
+      const seenMediaUrls = new Set<string>();
+      for (const message of originalTurnSlice(lo, hi)) {
+        if (message.role !== 'tool_result' || !isSubagentInternalMessage(message)) continue;
+        for (const item of extractToolResultMedia(message.content)) {
+          if (seenMediaUrls.has(item.url)) continue;
+          seenMediaUrls.add(item.url);
+          hiddenMedia.push(item);
+        }
+      }
+      if (hiddenMedia.length > 0) {
+        items.push({
+          type: 'tool_media',
+          key: `subagent-media-${anchorClientId}`,
+          items: hiddenMedia,
+        });
+      }
+    }
+
     const workingDir = opts?.workingDir ?? '';
     if (!workingDir || hi <= lo) return;
     const slice = originalTurnSlice(lo, hi);
@@ -2666,6 +2713,13 @@ export function MessageStream({
     };
   }, [remoteHostId, sessionId]);
 
+  // 「用户实际看得见的那份序列」。turn 边界与 last-user 这类**可见 UI 派生**统一吃它,
+  // 否则被隐藏的子代理行会被当成 turn 边界或「最后一条 user 消息」,让可见气泡丢掉编辑
+  // 入口与运行态标记(review: codex P2;同族的 isSyntheticTrigger 坑见
+  // findLastUserMessageClientId 注释)。按子代理归属反查的派生(buildSubagentModelMap)
+  // 仍吃原始 messages —— 它要的正是这些被隐藏的行。
+  const visibleMessages = useMemo(() => selectVisibleMessages(messages), [messages]);
+
   // 全量 build:折叠 / 丢弃 / 反向膨胀的所有规则一次性吸收 — 窗口看到的就是
   // 用户看到的。流式中每 token messages 引用变 → 这里跑一次 O(n) 单线性扫描,
   // 实测 N=1000 < 2ms (Windows),如果未来发现瓶颈再走增量化(out of scope)。
@@ -2679,13 +2733,13 @@ export function MessageStream({
     [messages, taskUpdates, ghostCardSnapshot, hasMoreMessages, turnChangeSets, workingDir],
   );
   const assistantsWithFollowingUserBoundary = useMemo(
-    () => collectAssistantsWithFollowingUserBoundary(messages),
-    [messages],
+    () => collectAssistantsWithFollowingUserBoundary(visibleMessages),
+    [visibleMessages],
   );
   // action bar 只挂每个 turn 的收尾 assistant 正文(见 collectTurnFinalAssistantClientIds)。
   const turnFinalAssistantClientIds = useMemo(
-    () => collectTurnFinalAssistantClientIds(messages),
-    [messages],
+    () => collectTurnFinalAssistantClientIds(visibleMessages),
+    [visibleMessages],
   );
   // subagent-model-chip: parentToolUseId(Agent/Task 行 id)→ 子代理模型,
   // 供 AgentActionsBlock 给 Agent/Task 行反查并渲染模型 chip。
@@ -3973,7 +4027,7 @@ export function MessageStream({
   // 不挂载组件(卸载时组件自会把 navRailCoversNav 报回 false,chip 兜底回归),
   // 也不做下面的空闲补页。
   const { enabled: navRailEnabled } = useMessageNavRailPreference();
-  const navRailEntries = useMemo(() => deriveNavRailEntries(messages), [messages]);
+  const navRailEntries = useMemo(() => deriveNavRailEntries(visibleMessages), [visibleMessages]);
 
   // 入口去重:导航条**完整覆盖导航**(出场且刻度未截断)时抑制"跳到上一条
   // 提问"chip —— 同一个导航任务只保留一套入口。导航条缺席(短对话 / 窄窗 /
@@ -4106,18 +4160,35 @@ export function MessageStream({
   // edit-last-message: 最后一条 user 消息才显示编辑入口(编辑 = rewind 到该条
   // + 重发,更早的消息会连带丢弃后续轮次,v1 不开放)。与 first 同理用全量
   // messages 判定,不受窗口分页影响。
-  const lastUserMessageClientId = useMemo(() => findLastUserMessageClientId(messages), [messages]);
+  // 走 visibleMessages:子代理内部的 user 行渲染不出来,让它成为"最后一条 user"
+  // 会把编辑入口从真实的最后一条可见气泡上抢走 —— 与该 helper 里 isSyntheticTrigger
+  // 那条同源(review: codex P2)。
+  const lastUserMessageClientId = useMemo(
+    () => findLastUserMessageClientId(visibleMessages),
+    [visibleMessages],
+  );
   // 含合成行的"最后一条用户侧输入":自愈重连行据此判断自己是不是仍在飞(见 helper 注释)。
-  const lastUserInputClientId = useMemo(() => findLastUserInputClientId(messages), [messages]);
+  // 同样走可见序列:子代理内部的 user 行不是父会话某个 turn 的发起者,算进来会让
+  // 在飞的重连行被"夺走归属"、提前停转。
+  const lastUserInputClientId = useMemo(
+    () => findLastUserInputClientId(visibleMessages),
+    [visibleMessages],
+  );
 
+  // 刻意吃**原始** messages,不走 visibleMessages:子代理消耗的 token 是这个 turn 的
+  // 真实花费,过滤掉等于把子代理的账从用量里抹掉(成本失真,比显示问题更糟)。
+  // 归属键 turnFinalAssistantClientIds 已按可见序列算出,聚合区间仍落在正确的 turn 内。
   const userTurnUsageDetailsByAssistantId = useMemo(() => {
     return collectAssistantTurnUsageDetails(messages, turnFinalAssistantClientIds);
   }, [messages, turnFinalAssistantClientIds]);
 
   // error-tail-banner:尾部未忽略的 error 行由输入框上方红条独家承载,流内需要
-  // 知道"是不是最后一条"来跳过重复渲染。
+  // 知道"是不是最后一条"来跳过重复渲染。走可见序列:尾部挂着子代理内部行时,
+  // 真实的最后一条可见 error 会因为"不是最后一条"而在流内重复渲染一遍。
   const lastMessageClientId =
-    messages.length > 0 ? messages[messages.length - 1].clientId : undefined;
+    visibleMessages.length > 0
+      ? visibleMessages[visibleMessages.length - 1].clientId
+      : undefined;
   const previousLocalFileRefsRef = useRef<readonly KnownLocalFileRef[]>([]);
   const localFileRefs = useMemo<readonly KnownLocalFileRef[]>(() => {
     return collectStableLocalFileRefs(messages, previousLocalFileRefsRef.current);
@@ -4138,7 +4209,12 @@ export function MessageStream({
   // 引用缓存:内容不变时复用上一个 Map 引用——UserMessage 顶层订阅该
   // context,流式期间 messages 每批 delta 都换引用,不缓存会让全部历史
   // 消息每批 token 重渲一遍(ghostCallMapsEqual 注释有完整推导)。
-  const ghostCallsByUserTurnRaw = useMemo(() => collectGhostCallsByUserTurn(messages), [messages]);
+  // 走可见序列:归属键是**可见的**那条 user 消息(软提示卡挂在它上面),被隐藏的
+  // 子代理 user 行不该成为归属键,否则该 turn 的召唤卡升级不到任何可见气泡上。
+  const ghostCallsByUserTurnRaw = useMemo(
+    () => collectGhostCallsByUserTurn(visibleMessages),
+    [visibleMessages],
+  );
   const ghostCallsCacheRef = useRef(ghostCallsByUserTurnRaw);
   if (!ghostCallMapsEqual(ghostCallsCacheRef.current, ghostCallsByUserTurnRaw)) {
     ghostCallsCacheRef.current = ghostCallsByUserTurnRaw;

--- a/apps/desktop/src/renderer/components/chat/MessageStream.tsx
+++ b/apps/desktop/src/renderer/components/chat/MessageStream.tsx
@@ -1048,9 +1048,33 @@ export function buildRenderItems(
   // 它们的去处是自己那张 AgentTaskCard(仍由 taskUpdates 正常渲染),不是主流。
   // 过滤放在最前面:后续所有 pass(tool_result lookup、段落配对、turn 边界、work-group)
   // 看到的都是同一份"用户可见"的消息序列,不会出现"查得到但不渲染"的半吊子状态。
-  const messages = allMessages.some(isSubagentInternalMessage)
-    ? allMessages.filter((m) => !isSubagentInternalMessage(m))
+  const hasSubagentInternalMessages = allMessages.some(isSubagentInternalMessage);
+  // 过滤后下标 → 原始下标。产物文件卡(collectGeneratedFiles)必须回到**原始**序列
+  // 取 turn 切片:子代理用 Write / Bash 建的文件是真实产物,只是它的 tool_use 行不该
+  // 渲染;只喂过滤后的切片会让这些文件 chip 静默消失(review: codex P2)。
+  const originalIndexByVisible: number[] = [];
+  const messages = hasSubagentInternalMessages
+    ? allMessages.filter((m, idx) => {
+        if (isSubagentInternalMessage(m)) return false;
+        originalIndexByVisible.push(idx);
+        return true;
+      })
     : allMessages;
+
+  /**
+   * 把过滤后的 turn 区间 `[lo, hi)` 映射回原始序列的区间,使产物收集能看到被隐藏的
+   * 子代理工具调用。`hi` 落在末尾时右端取 `allMessages.length`,保证最后一个 turn
+   * 也覆盖到它后面的子代理尾巴。
+   */
+  const originalTurnSlice = (lo: number, hi: number): readonly ChatMessage[] => {
+    if (!hasSubagentInternalMessages) return messages.slice(lo, hi);
+    const start = originalIndexByVisible[lo];
+    if (start === undefined) return messages.slice(lo, hi);
+    const end = hi < originalIndexByVisible.length
+      ? originalIndexByVisible[hi]
+      : allMessages.length;
+    return allMessages.slice(start, end);
+  };
 
   // ── Pass 0: build toolUseId → tool_result.content lookup ──
   // Plan/task rendering and regular tool result pairing both need a stable
@@ -1223,7 +1247,7 @@ export function buildRenderItems(
     }
     const workingDir = opts?.workingDir ?? '';
     if (!workingDir || hi <= lo) return;
-    const slice = messages.slice(lo, hi);
+    const slice = originalTurnSlice(lo, hi);
     const generatedFiles = collectGeneratedFiles(slice, workingDir).filter((file) => {
       const normalized = pathKey(file.path);
       return !exactPaths.has(normalized) || changeSets.length === 0;

--- a/apps/desktop/src/renderer/components/chat/MessageStream.tsx
+++ b/apps/desktop/src/renderer/components/chat/MessageStream.tsx
@@ -39,6 +39,7 @@ import {
 import {
   isAgentPlanToolName,
   isDeliveryProseText,
+  isSubagentParentToolUseId,
 } from '@cindy/maker-shared/message-render';
 // 子代理卡判据只能有一份:此前桌面自带一份只认 Agent/Task/collab:* 的副本,新增 harness
 // (PI 的 subagent)加进共享判据也到不了 AgentTaskCard,会静默落进普通工具组(codex review)。
@@ -1002,8 +1003,25 @@ export function buildSubagentModelMap(messages: ChatMessage[]): Map<string, stri
   return out;
 }
 
+/**
+ * 子代理内部消息判据:这条消息是不是某个 Agent/Task 调用**内部**产生的,而不是
+ * 父会话自己说的话。
+ *
+ * 数据来源与 buildSubagentModelMap 同一份:SDK 给子代理的每条消息都带
+ * `parent_tool_use_id`(= 派生它的 Agent 工具调用 id),经 makerChatStore 投影成
+ * 顶层 `parentToolUseId`(实时事件与历史重载两条路径都投影)。
+ *
+ * 形态判据不能省:legacy Claude 导入把普通 transcript 链边(`preceding-user-uuid`
+ * 这类非 tool-use id)也存进同一个字段,无条件当子代理会把父会话自己的正文一起
+ * 吞掉。只认 SDK tool-parent 形态,与 maker-shared 的投影判据共用同一个函数。
+ */
+function isSubagentInternalMessage(message: ChatMessage): boolean {
+  const parent = message.parentToolUseId;
+  return typeof parent === 'string' && parent.length > 0 && isSubagentParentToolUseId(parent);
+}
+
 export function buildRenderItems(
-  messages: ChatMessage[],
+  allMessages: ChatMessage[],
   taskUpdates?: ReadonlyMap<string, AgentTaskUpdate>,
   ghostCards?: GhostCardSnapshot,
   opts?: {
@@ -1021,6 +1039,19 @@ export function buildRenderItems(
   items: RenderItem[];
   singleResultMap: Map<string, string>;
 } {
+  // ── Pass -1: 剔除子代理内部消息 ──
+  // 后台 Agent/Task 跑起来后,SDK 会把子代理自己的 thinking / 正文 / 工具调用一并
+  // echo 回主流(每条都带 parent_tool_use_id)。这些是**子任务内部的经过**,不是父
+  // 会话对用户说的话 —— 官方 CLI 界面从不显示它们,Cindy 逐条渲染就等于把整篇子代理
+  // 报告原样铺进聊天窗口(实测一条子代理正文 5.5k 字符直接刷屏)。
+  //
+  // 它们的去处是自己那张 AgentTaskCard(仍由 taskUpdates 正常渲染),不是主流。
+  // 过滤放在最前面:后续所有 pass(tool_result lookup、段落配对、turn 边界、work-group)
+  // 看到的都是同一份"用户可见"的消息序列,不会出现"查得到但不渲染"的半吊子状态。
+  const messages = allMessages.some(isSubagentInternalMessage)
+    ? allMessages.filter((m) => !isSubagentInternalMessage(m))
+    : allMessages;
+
   // ── Pass 0: build toolUseId → tool_result.content lookup ──
   // Plan/task rendering and regular tool result pairing both need a stable
   // lookup by vendor toolUseId. Adjacency remains a fallback in Pass 2.

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -14300,14 +14300,17 @@ function isHiddenThinkingRow(m: Message): boolean {
 /**
  * 该服务端行**渲染后不会留下可见锚点**(初始页全是这类行时必须继续往前翻页)。
  *
- * 四类:
+ * 五类:
  *   - `tool_result`:配对的 tool_use 父消息可能在更老的页里,MessageStream 会丢弃 orphan;
  *   - 被 `isHiddenThinkingRow` 过滤掉的行:直接不进渲染列表;
  *   - 计划工具调用:MessageStream 会吞掉,只更新 composer 上方的计划胶囊;
  *   - 合成指令行(`isSyntheticTriggerRow`):MessageStream 渲染 null、content 置空,
  *     与 `loadOlderMessages` 的可见锚点判定同口径(见该处「合成指令行渲染 null,不算可见
  *     锚点」)。少了这一类,一页里只要混进一条合成 user 行就会被当成锚点提前停止回填,
- *     而它映射后同样不产生可见内容 —— 症状与完全不回填一样。
+ *     而它映射后同样不产生可见内容 —— 症状与完全不回填一样;
+ *   - 子代理内部行(`isSubagentInternalHistoryRow`):`buildRenderItems` 在入口整体剔除,
+ *     一条都不进渲染列表。子代理密集的会话最新一页可能**全部**是这类行(实测本机库里
+ *     单会话可达上万条),漏登记就会重现上面那种「DB 里有几千条、重开渲染 0 项」的症状。
  *
  * 任何组合占满整页,都会让映射结果为空,而 MessageStream 在 `visibleRenderItems.length === 0`
  * 时不触发自动翻页 —— 结果是 DB 里有几千条消息、重开会话却渲染 0 项,更老的用户/助手消息
@@ -14318,8 +14321,20 @@ function isNonAnchorHistoryRow(m: Message): boolean {
     m.role === 'tool_result' ||
     isHiddenThinkingRow(m) ||
     isAgentPlanHistoryToolUseRow(m) ||
-    isSyntheticTriggerRow(m)
+    isSyntheticTriggerRow(m) ||
+    isSubagentInternalHistoryRow(m)
   );
+}
+
+/**
+ * 服务端行是子代理内部消息(`buildRenderItems` 会整体剔除,见该处 Pass -1)。
+ *
+ * 判据与渲染侧共用同一个形态函数:只认 SDK tool-parent 形态,legacy Claude 导入存在
+ * 同一字段上的普通 transcript 链边不算 —— 否则父会话自己的正文会被当成无锚点行。
+ */
+function isSubagentInternalHistoryRow(m: Message): boolean {
+  const parent = m.agentMeta?.parentUuid;
+  return typeof parent === 'string' && parent.length > 0 && isSubagentParentToolUseId(parent);
 }
 
 function isAgentPlanHistoryToolUseRow(m: Message): boolean {

--- a/docs/design-previews/subagent-internal-message-filter/index.html
+++ b/docs/design-previews/subagent-internal-message-filter/index.html
@@ -1,0 +1,222 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Cindy Desktop · 子代理内部消息不再铺进主聊天流(修复前后对比)</title>
+<style>
+  /* ── 色值 1:1 取自 apps/desktop/src/renderer/themes/colors.ts(代码为真相源) ── */
+  :root {
+    --surface:#f8f8f6; --surface-elevated:#ffffff; --surface-chip:#e5e5e5;
+    --border-default:#e5e5e5;
+    --text-primary:#262626; --text-secondary:#737373; --text-tertiary:#a3a3a3;
+    --agent-actions-rail:#DDD6CB;
+  }
+  .dark {
+    --surface:#1f1f1e; --surface-elevated:#2c2c2a; --surface-chip:#3c3c3a;
+    --border-default:#404040;
+    --text-primary:#d4d4d4; --text-secondary:#a3a3a3; --text-tertiary:#737373;
+    --agent-actions-rail:#404040;
+  }
+  * { box-sizing:border-box; margin:0; padding:0; -webkit-font-smoothing:antialiased; }
+  body {
+    font-family:-apple-system,BlinkMacSystemFont,"PingFang SC","Helvetica Neue",sans-serif;
+    background:#111; padding:24px; color:#ddd; line-height:1.5;
+  }
+  h1 { font-size:18px; font-weight:600; margin-bottom:6px; color:#f0f0f0; }
+  .lede { font-size:13px; color:#999; margin-bottom:20px; max-width:1180px; }
+  .lede code { background:#222; padding:1px 5px; border-radius:3px; font-size:12px; }
+
+  .modes { display:flex; flex-direction:column; gap:24px; }
+  .mode-label {
+    font-size:12px; font-weight:600; letter-spacing:.06em; text-transform:uppercase;
+    color:#888; margin-bottom:8px;
+  }
+  .pair { display:grid; grid-template-columns:1fr 1fr; gap:16px; }
+  @media (max-width:900px) { .pair { grid-template-columns:1fr; } }
+
+  .pane { border-radius:10px; overflow:hidden; border:1px solid #333; }
+  .pane-head {
+    font-size:12px; font-weight:600; padding:8px 12px;
+    display:flex; align-items:center; gap:8px;
+  }
+  .pane-head.before { background:#3a2222; color:#ffb4a8; }
+  .pane-head.after  { background:#1f3326; color:#9fe0b4; }
+  .badge {
+    font-size:10px; font-weight:700; padding:1px 6px; border-radius:99px;
+    background:rgba(255,255,255,.12);
+  }
+
+  /* ── 聊天流(结构与 MessageStream 一致:assistant 正文 / thinking 折叠行 / AgentTaskCard) ── */
+  .stream {
+    background:var(--surface); padding:16px; min-height:430px;
+    display:flex; flex-direction:column; gap:12px;
+  }
+  .msg { font-size:14px; color:var(--text-primary); max-width:100%; }
+  .thinking-row {
+    font-size:13px; color:var(--text-secondary);
+    display:flex; align-items:center; gap:6px;
+  }
+  .thinking-row::before { content:"✦"; color:var(--text-tertiary); font-size:11px; }
+
+  /* AgentTaskCard:圆角卡 + 标题行 + 展开区左侧 rail(对齐 AgentTaskCard.tsx) */
+  .task-card {
+    background:var(--surface-elevated); border:1px solid var(--border-default);
+    border-radius:8px; padding:10px 12px;
+  }
+  .task-head {
+    display:flex; align-items:center; gap:8px;
+    font-size:13px; font-weight:500; color:var(--text-primary);
+  }
+  .chev { color:var(--text-tertiary); font-size:10px; }
+  .dot { width:6px; height:6px; border-radius:50%; background:#2AAE5B; flex:none; }
+  .model-chip {
+    margin-left:auto; font-size:11px; color:var(--text-secondary);
+    background:var(--surface-chip); padding:1px 7px; border-radius:99px;
+  }
+  .task-body {
+    margin-top:8px; border-left:2px solid var(--agent-actions-rail); padding-left:12px;
+    font-size:13px; line-height:1.45; color:var(--text-secondary);
+  }
+  .task-body .meta { font-size:12px; color:var(--text-tertiary); margin-top:4px; }
+
+  /* 泄漏出来的子代理正文(修复前) */
+  .leak {
+    font-size:13px; color:var(--text-primary);
+    border:1px dashed #d9534f; border-radius:6px; padding:10px 12px;
+    background:rgba(217,83,79,.06);
+  }
+  .leak h4 { font-size:13px; font-weight:600; margin:8px 0 4px; }
+  .leak p { margin-bottom:6px; }
+  .leak .cut {
+    color:var(--text-tertiary); font-size:12px; font-style:italic;
+    border-top:1px dashed var(--border-default); margin-top:8px; padding-top:6px;
+  }
+  .leak-tag {
+    display:inline-block; font-size:10px; font-weight:700; color:#d9534f;
+    border:1px solid #d9534f; border-radius:3px; padding:0 4px; margin-bottom:6px;
+  }
+  .note {
+    font-size:12px; color:var(--text-tertiary); font-style:italic;
+    padding:8px 0 0; border-top:1px solid var(--border-default); margin-top:auto;
+  }
+</style>
+</head>
+<body>
+
+<h1>子代理内部消息不再铺进主聊天流</h1>
+<p class="lede">
+  左：修复前 —— 后台 Subagent 的思考、正文与工具调用逐条铺进聊天流（实测单条正文 5559 字符）。
+  右：修复后 —— 同一批消息在 <code>buildRenderItems</code> 入口被剔除，Subagent 的工作仍以
+  AgentTaskCard 呈现在原位置。<strong>本次改动不新增任何视觉元素</strong>，两侧的卡片、间距、
+  颜色 token 完全一致，差异只是「多出来的条目消失了」。
+</p>
+
+<div class="modes">
+
+  <!-- ─────────── Light ─────────── -->
+  <div>
+    <div class="mode-label">Light</div>
+    <div class="pair">
+
+      <div class="pane">
+        <div class="pane-head before">修复前 <span class="badge">main</span></div>
+        <div class="stream">
+          <div class="msg">我先派一个后台调研，同时继续看本地代码。</div>
+          <div class="task-card">
+            <div class="task-head"><span class="chev">▸</span><span class="dot"></span>调研 oh-my-pi 现状
+              <span class="model-chip">claude-opus-5</span></div>
+          </div>
+          <div class="thinking-row">思考 4 秒</div>
+          <div class="leak">
+            <span class="leak-tag">子代理内部消息 · 不该出现在这里</span>
+            <p>调研完成。以下为结构化事实清单，全部来自一手来源（GitHub API + repo 内文件），未编造。</p>
+            <h4># oh-my-pi (omp) 调研报告</h4>
+            <p><strong>Repo 确认：https://github.com/can1357/oh-my-pi</strong> —— 就是猜测中的
+              can1357/oh-my-pi。官网 https://omp.sh，npm 包 <code>@oh-my-pi/pi-coding-agent</code>。
+              README 明确声明是 Mario Zechner (badlogic) 的 pi-mono 的 fork，MIT 协议。</p>
+            <h4>## 1. 相对原版 pi 增加/改造的功能</h4>
+            <p>定位："A coding agent with the IDE wired in"，TypeScript + Bun 运行时 + 约 8 万行
+              Rust 原生核心。README 列了 21 项……</p>
+            <p class="cut">…此处还有约 5000 字符继续铺开（原文 5559 字符）…</p>
+          </div>
+          <div class="msg">调研回来了，结论如下。</div>
+          <div class="note">用户要往上滚很久才能回到自己的对话。</div>
+        </div>
+      </div>
+
+      <div class="pane">
+        <div class="pane-head after">修复后 <span class="badge">本 PR</span></div>
+        <div class="stream">
+          <div class="msg">我先派一个后台调研，同时继续看本地代码。</div>
+          <div class="task-card">
+            <div class="task-head"><span class="chev">▾</span><span class="dot"></span>调研 oh-my-pi 现状
+              <span class="model-chip">claude-opus-5</span></div>
+            <div class="task-body">
+              调研 oh-my-pi 的当前状态、相对原版 pi 的差异，以及对 Cindy 的参考价值。
+              <div class="meta">Agent "调研 oh-my-pi 现状" finished</div>
+            </div>
+          </div>
+          <div class="msg">调研回来了，结论如下。</div>
+          <div class="note">Subagent 的工作收在自己的卡片里，父会话的对话保持连续。</div>
+        </div>
+      </div>
+
+    </div>
+  </div>
+
+  <!-- ─────────── Dark ─────────── -->
+  <div class="dark">
+    <div class="mode-label">Dark</div>
+    <div class="pair">
+
+      <div class="pane">
+        <div class="pane-head before">修复前 <span class="badge">main</span></div>
+        <div class="stream">
+          <div class="msg">我先派一个后台调研，同时继续看本地代码。</div>
+          <div class="task-card">
+            <div class="task-head"><span class="chev">▸</span><span class="dot"></span>调研 oh-my-pi 现状
+              <span class="model-chip">claude-opus-5</span></div>
+          </div>
+          <div class="thinking-row">思考 4 秒</div>
+          <div class="leak">
+            <span class="leak-tag">子代理内部消息 · 不该出现在这里</span>
+            <p>调研完成。以下为结构化事实清单，全部来自一手来源（GitHub API + repo 内文件），未编造。</p>
+            <h4># oh-my-pi (omp) 调研报告</h4>
+            <p><strong>Repo 确认：https://github.com/can1357/oh-my-pi</strong> —— 就是猜测中的
+              can1357/oh-my-pi。官网 https://omp.sh，npm 包 <code>@oh-my-pi/pi-coding-agent</code>。
+              README 明确声明是 Mario Zechner (badlogic) 的 pi-mono 的 fork，MIT 协议。</p>
+            <h4>## 1. 相对原版 pi 增加/改造的功能</h4>
+            <p>定位："A coding agent with the IDE wired in"，TypeScript + Bun 运行时 + 约 8 万行
+              Rust 原生核心。README 列了 21 项……</p>
+            <p class="cut">…此处还有约 5000 字符继续铺开（原文 5559 字符）…</p>
+          </div>
+          <div class="msg">调研回来了，结论如下。</div>
+          <div class="note">用户要往上滚很久才能回到自己的对话。</div>
+        </div>
+      </div>
+
+      <div class="pane">
+        <div class="pane-head after">修复后 <span class="badge">本 PR</span></div>
+        <div class="stream">
+          <div class="msg">我先派一个后台调研，同时继续看本地代码。</div>
+          <div class="task-card">
+            <div class="task-head"><span class="chev">▾</span><span class="dot"></span>调研 oh-my-pi 现状
+              <span class="model-chip">claude-opus-5</span></div>
+            <div class="task-body">
+              调研 oh-my-pi 的当前状态、相对原版 pi 的差异，以及对 Cindy 的参考价值。
+              <div class="meta">Agent "调研 oh-my-pi 现状" finished</div>
+            </div>
+          </div>
+          <div class="msg">调研回来了，结论如下。</div>
+          <div class="note">Subagent 的工作收在自己的卡片里，父会话的对话保持连续。</div>
+        </div>
+      </div>
+
+    </div>
+  </div>
+
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
## 这次改了什么

### 摘要

后台 Subagent（Agent / Task 工具）跑起来后，Claude Code SDK 会把子代理**自己**的
thinking、正文与工具调用一并 echo 回主消息流，每条都带 `parent_tool_use_id`。官方
CLI 界面从不显示这些消息；Cindy 要把整个对话渲染出来，于是逐条铺进聊天窗口——实测
一条子代理调研正文 5559 字符直接刷屏。

数据侧一直是齐的：`makerChatStore` 的**实时事件**与**历史重载**两条路径都把 SDK 的
`parent_tool_use_id` 投影成顶层 `parentToolUseId`。但 `MessageStream` 只拿这个字段建
subagent-model-chip 映射（`buildSubagentModelMap`），从未据此判断「这条不属于主流」。

修法是在 `buildRenderItems` 入口按共享判据 `isSubagentParentToolUseId` 剔除这些行，
后续所有 pass（tool_result lookup、段落配对、turn 边界、work-group）看到同一份「用户
可见」序列，不会出现「查得到但不渲染」的半吊子状态。子代理内容仍由 `taskUpdates`
渲染成 AgentTaskCard，模型 chip 不受影响（`buildSubagentModelMap` 走原始 `messages`）。

形态判据不能省：legacy Claude 导入把普通 transcript 链边（`preceding-user-uuid`、裸
RFC UUID 这类非 tool-use id）也存在同一个字段上，无条件当子代理会把**父会话自己的正文**
一起吞掉。只认 SDK tool-parent 形态，与 maker-shared 的投影判据共用同一个函数，测试
锁住了这条。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无（用户实测反馈：后台 Subagent 结果不折叠，整篇铺在聊天流里）
- 本 PR 包含：`buildRenderItems` 入口剔除带 SDK tool-parent 形态 `parentToolUseId`
  的消息，以及该过滤自身需要的四处配套边界，加单元测试锁住判据。它们是同一个改动的
  完整闭环，拆开任一部分都会留下可见回归：
  1. 历史无锚点判定登记这一新类型（否则子代理密集的会话冷启动会渲染 0 项且翻不动）；
  2. 产物文件 chip 回原始序列取 turn 切片（否则子代理建的文件 chip 静默消失）；
  3. 子代理工具结果里的媒体产物在 turn 边界另行派生（否则出图/出片/音频卡随内部
     工具行一起消失）；
  4. 可见 UI 派生统一走 `selectVisibleMessages`（否则隐藏的子代理 user 行会被当成
     「最后一条 user」或 turn 边界，让真实的最后一条可见气泡丢掉编辑入口与运行态标记）。
- 明确不包含：
  - `<task-notification>` 通知本身的处理（它在 translator 里被丢弃是**正确行为**，
    不是 bug——最初的判断认为是它在泄漏，实测证伪，见下方「根因核实」）；
  - Codex / PI 的 Subagent 采集与呈现；
  - 任何新的 Subagent 正文查看入口、侧栏页签、成本呈现——这些由
    `docs/product-rules/subagent-product-direction.md` §4.2 / §4.3 的 PI 重新设计回答，
    本 PR 不预设也不抢跑；
  - `MessageStream` 分组管线重构、`claude-local-sessions.ts` 历史导入路径。
- 用户可见变化：Claude Code 后台 Subagent 运行期间，聊天流不再出现子代理自己的思考、
  正文与工具调用；这些工作仍以 AgentTaskCard 呈现在原位置。
- 是否存在 breaking change：无。

### 根因核实（与最初判断不同，记录在此避免后人重走）

最初的判断是「`<task-notification>` 纯文本通知没被 translator 认出，顺着普通消息通道
流进聊天窗口」。实测证伪：

- `translator.ts` 的 `case 'user'` 对**字符串** content 走 `extractToolResultFullText`
  直接返回空数组，**什么事件都不 push**——通知本身没有任何渲染通道，丢弃是正确的；
- 真正铺进聊天窗口的是子代理自己的 sidechain 消息。以本机一次实测为例：
  `~/.claude/projects/.../subagents/agent-a9a0f191f7d0fd9ee.jsonl` 第 25 行是一条
  `isSidechain: true` 的 assistant 消息（5559 字符），它以 `role=assistant` +
  `agent_meta.parentUuid = toolu_01KzTJBHuSyQfTXT74MKLjgp` 落库，正是聊天流里刷屏的那篇。

### UI 变化

**改动后效果预览（自包含单文件，含 Light / Dark 两态的修复前后对比）：**
`docs/design-previews/subagent-internal-message-filter/index.html`

在线预览：https://htmlpreview.github.io/?https://github.com/zqchris/cindy/blob/fix-claude-task-notification-collapse/docs/design-previews/subagent-internal-message-filter/index.html

预览页的色值 1:1 取自 `apps/desktop/src/renderer/themes/colors.ts`（`surface`、
`surface-elevated`、`surface-chip`、`text-primary/secondary/tertiary`、
`agent-actions-rail`、`border-default`），结构对齐 `AgentTaskCard.tsx`（标题行 +
`Collapse` 展开区 + 左侧 2px rail + 模型 chip）。

对比要点：修复前，Subagent 的思考行与整篇正文逐条铺在聊天流里（实测单条 5559 字符，
预览页截断展示）；修复后，同一批消息不再出现，Subagent 的工作收在它自己的
AgentTaskCard 里，父会话的对话保持连续。

- 引用的设计规范：本次改动**不新增也不修改**任何组件、布局、样式、动效或 UI 文案，
  纯粹是从渲染序列中**剔除**本不该出现的条目。被剔除内容原有的 AgentTaskCard 呈现
  逐字节不变（`DESIGN.md` 的间距、圆角、语义色 token 均沿用既有组件，未引入任何新的
  视觉元素或硬编码颜色）。双模式因此天然一致：没有任何一种模式下需要新增的样式分支。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run \
  src/renderer/__tests__/subagentInternalMessageFilter.test.ts \
  src/renderer/__tests__/emptyThinkingPlaceholder.test.ts
结果：Test Files 2 passed (2) / Tests 29 passed (29)

pnpm --filter desktop run typecheck
结果：通过（无输出）

pnpm test:unit
结果：EXIT=0，零 FAIL；PASS apps/desktop unit (72.4s)、PASS apps/mobile unit (10.2s)，
      packages 全部 PASS 或 SKIP(notApplicable)
```

测试覆盖 17 条边界：

*过滤本身* —— 子代理 assistant 正文被剔除、子代理 thinking 被剔除、兼容模型的
`Name_序号` tool-use id 形态被识别、无 parentToolUseId 的主线程消息原样保留、legacy
transcript 链边（`preceding-user-uuid` 与裸 RFC UUID）**不被**误判、父 Agent 调用本身
仍渲染成 agent_task 卡。

*回归防护（第二轮 review 补）* —— 子代理 Write 建的文件仍派生出产物文件 chip、子代理行
算历史无锚点行（`toolu_` / `call_` / `Task_1` / thinking 四态）、legacy 链边不算无锚点行。

*回归防护（第三轮 review 补）* —— 子代理工具结果里的媒体仍渲染成 `tool_media` 卡、
`selectVisibleMessages` 的剔除与引用稳定性、`findLastUserMessageClientId` 与
`findLastUserInputClientId` 在存在隐藏 user 行时仍归属到真实的最后一条可见气泡
（其中一条直接断言「喂原始数组会命中隐藏行」，把缺陷本身钉住）。

### 手工验证

用本机真实 Cindy 数据库（18 万余条消息）离线核验判据分界，确认过滤范围与保留范围：

```text
=== 会被过滤（判定为 subagent 内部消息）===
  tool_use 7288 / tool_result 7259 / thinking 2568 / assistant 1293
  合计 18408 行 / 30.3 MB 正文
  样本 parentUuid: toolu_bdrk_013GVsS6x2HrgCfUvCkRaTxJ …

=== 会保留（legacy transcript 链边，不是 subagent）===
  thinking 97 / tool_use 89 / tool_result 89 / assistant 53 / user 10
  合计 338 行 / 0.3 MB 正文
  样本 parentUuid: 285c97c9-7bbc-4fec-b296-2a14e78ca83b …
```

两类在真实数据上分得干净：SDK tool-parent 形态全部落入过滤侧，裸 UUID 的 legacy
链边全部落入保留侧，没有交叉。

另核实 `loadOlderMessages` 的追页锚点判定是否受影响：它只认真实 user 行作锚点，而本机
库里带 `toolu_` / `call_` parentUuid 的 user 行为 **0 条**，故该路径无需改动。

第三轮 review 后补验两项（同一份真实库）：

- 子代理 `tool_result` 中的媒体标记确实存在 —— `xdt-image://` 26 条、`cindy-media://`
  39 条、`xdt_image_url` 6 条、`xdt_video_url` 1 条、`xdt_audio_url` 1 条。媒体产物卡
  丢失是**可观测**的真实回归，已修。
- 带 SDK tool-parent 形态 `parentUuid` 的 `user` 行为 **0 条**（1172 条带 `parentUuid`
  的 user 行全是 legacy 形态）。「隐藏 user 行抢走编辑入口」当前**不可观测但路径可达**，
  且同类坑此前已被 `isSyntheticTrigger` 行踩过一次，按回归一并修掉。

### 未执行的验证

- **实机 dev 目检未做**（Light / Dark 均未在真实 Electron 窗口里目检）。原因：复现需要
  在桌面 dev 实例里真实跑一个后台 Subagent 并等它产出长正文，而本次工作在手机端远程
  进行，看不到桌面窗口。已提供的替代证据是上面那份自包含对比预览页（色值取自
  `colors.ts`、结构对齐 `AgentTaskCard.tsx`、含 Light / Dark 两态）；它是**按代码值
  还原的设计稿，不是实机截图**，这一点如实说明。改动本身不新增任何视觉元素，风险集中
  在「该不该过滤」而非「长什么样」，后者已由单元测试与真实数据核验覆盖。
- 用户可执行的验证步骤：起 dev 实例 → 在 Claude Code 会话里让它派一个后台 Subagent
  做一件会产出长文的活（如 `Agent` 工具跑一次调研）→ 观察 Subagent 运行期间聊天流是否
  只出现一张 Task 卡、不再铺出子代理自己的思考与正文 → 展开 Task 卡确认原有
  description / summary 显示不变 → 切 Light / Dark 各看一次。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 desktop renderer 的聊天流渲染。纯渲染层过滤，不改采集、不改落库、不改
  协议、不改 wire format；被过滤的消息仍完整存在于数据库中，随时可以恢复显示。
- 回滚 / 降级方式：revert 本 commit 即可，无数据面残留。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
