### PR TITLE
fix(desktop): clarify Pi project Skill loading state

### DIFF
--- a/apps/desktop/src/renderer/components/new-chat/SlashCommandPalette.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/SlashCommandPalette.tsx
@@ -237,8 +237,8 @@ export function SlashCommandPalette({
                 ref={focused ? focusedRef : undefined}
                 type="button"
                 aria-disabled={unavailable}
-                aria-label={unavailable ? `${cmd.name}: ${t('commandPalette.projectTrustRequired')}` : cmd.name}
-                title={unavailable ? t('commandPalette.projectTrustRequired') : undefined}
+                aria-label={unavailable ? `${cmd.name}: ${t('commandPalette.projectSkillNotLoaded')}` : cmd.name}
+                title={unavailable ? t('commandPalette.projectSkillNotLoaded') : undefined}
                 // `onMouseDown` instead of `onClick` so the textarea
                 // keeps focus — click would fire after blur.
                 onMouseDown={(e) => {
@@ -295,7 +295,7 @@ export function SlashCommandPalette({
           </div>
           <div className="mt-[8px] text-13 leading-[1.5] text-[var(--cmd-palette-tooltip-body)]">
             {isSlashCommandUnavailable(focusedCmd)
-              ? t('commandPalette.projectTrustRequired')
+              ? t('commandPalette.projectSkillNotLoaded')
               : focusedCmd.description}
           </div>
         </div>,

--- a/apps/desktop/src/renderer/components/new-chat/__tests__/SlashCommandPalette.test.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/__tests__/SlashCommandPalette.test.tsx
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import zhCNCommon from '@/i18n/locales/zh-CN/common.json';
+import type { UnifiedCommand } from '@/lib/slashCommands';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+import { SlashCommandPalette } from '../SlashCommandPalette';
+
+beforeAll(() => {
+  vi.stubGlobal(
+    'ResizeObserver',
+    class {
+      observe() {}
+      disconnect() {}
+    },
+  );
+  Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+    configurable: true,
+    value: vi.fn(),
+  });
+});
+
+afterEach(cleanup);
+
+const discoveredProjectSkill: UnifiedCommand = {
+  kind: 'agent-skill',
+  name: 'demo',
+  source: 'skill',
+  scope: 'repo',
+  runtimeStatus: 'discovered',
+};
+
+describe('SlashCommandPalette project Skill rows', () => {
+  it('keeps a discovered Skill disabled and non-actionable', () => {
+    const onSelect = vi.fn();
+
+    render(
+      <SlashCommandPalette
+        query=""
+        commands={[discoveredProjectSkill]}
+        focusedIndex={0}
+        onFocusedIndexChange={vi.fn()}
+        onSelect={onSelect}
+        onClose={vi.fn()}
+      />,
+    );
+
+    const row = screen.getByRole('button', {
+      name: 'demo: commandPalette.projectSkillNotLoaded',
+    });
+    expect(row.getAttribute('aria-disabled')).toBe('true');
+    expect(row.className).toContain('opacity-50');
+    expect(row.className).toContain('cursor-not-allowed');
+
+    fireEvent.mouseDown(row);
+    fireEvent.click(row);
+
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it('uses the automatic loading copy without a trust or admission action', () => {
+    expect(zhCNCommon.commandPalette.projectSkillNotLoaded).toBe(
+      '当前 Pi 任务尚未加载此项目 Skill，新任务会自动尝试加载',
+    );
+    expect(zhCNCommon.commandPalette).not.toHaveProperty('projectTrustRequired');
+    expect(zhCNCommon.commandPalette).not.toHaveProperty('projectSkillConfirmAction');
+  });
+
+  it('continues to select a loaded Skill normally', () => {
+    const loaded: UnifiedCommand = {
+      ...discoveredProjectSkill,
+      runtimeStatus: 'loaded',
+    };
+    const onSelect = vi.fn();
+
+    render(
+      <SlashCommandPalette
+        query=""
+        commands={[loaded]}
+        focusedIndex={0}
+        onFocusedIndexChange={vi.fn()}
+        onSelect={onSelect}
+        onClose={vi.fn()}
+      />,
+    );
+
+    fireEvent.mouseDown(screen.getByRole('button', { name: 'demo' }));
+
+    expect(onSelect).toHaveBeenCalledWith(loaded);
+  });
+});

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -8257,7 +8257,7 @@
     }
   },
   "commandPalette": {
-    "projectTrustRequired": "Available after you trust this project"
+    "projectSkillNotLoaded": "This Pi task hasn't loaded this project Skill. New tasks will automatically try to load it."
   },
   "skillhub": {
     "home": {

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -8244,7 +8244,7 @@
     }
   },
   "commandPalette": {
-    "projectTrustRequired": "このプロジェクトを信頼すると使用できます"
+    "projectSkillNotLoaded": "現在の Pi タスクでは、このプロジェクト Skill はまだ読み込まれていません。新しいタスクでは自動的に読み込みを試みます。"
   },
   "skillhub": {
     "home": {

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -8244,7 +8244,7 @@
     }
   },
   "commandPalette": {
-    "projectTrustRequired": "이 프로젝트를 신뢰하면 사용할 수 있습니다"
+    "projectSkillNotLoaded": "현재 Pi 작업에는 이 프로젝트 Skill이 아직 로드되지 않았습니다. 새 작업에서는 자동으로 로드를 시도합니다."
   },
   "skillhub": {
     "home": {

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -8240,7 +8240,7 @@
     }
   },
   "commandPalette": {
-    "projectTrustRequired": "需要信任此项目后可用"
+    "projectSkillNotLoaded": "当前 Pi 任务尚未加载此项目 Skill，新任务会自动尝试加载"
   },
   "skillhub": {
     "home": {

--- a/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
@@ -8243,7 +8243,7 @@
     }
   },
   "commandPalette": {
-    "projectTrustRequired": "信任此專案後即可使用"
+    "projectSkillNotLoaded": "目前的 Pi 任務尚未載入此專案 Skill，新任務會自動嘗試載入"
   },
   "skillhub": {
     "home": {


### PR DESCRIPTION
## 这次改了什么

### 摘要

修正 Pi 项目 Skill 在命令面板尚未由当前 runtime 加载时的错误提示：不再显示“需要信任此项目后可用”，改为说明当前 Pi 任务尚未加载、新任务会自动尝试加载。`loaded` 后继续沿用 #2134 的正常可用状态。

产品决策已取消 PR5b 的确认弹窗与授权动作；本 PR 只修正文案和回归测试。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：Refs #1991；Fixes #2403；Depends on #2465 PR5a
- 本 PR 包含：命令面板不可用提示的五语言文案；discovered 禁用与 loaded 可用的 renderer 回归测试
- 明确不包含：确认弹窗、approval adapter、授权 IPC、permission UI、权限选择器、Pi 设置页、packages/extensions 行为或整体 UI 重设计
- 用户可见变化：置灰的 Pi 项目 Skill 显示准确的自动加载状态，不再暗示用户需要执行信任操作
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：`docs/design-rules/DESIGN.md` §11 Voice & Content（微文案应准确表达当前状态与可行动性）。本次不改布局、样式、token 或交互，Light / Dark 视觉保持既有实现。
- 截图：未附；仅替换状态文案，无视觉结构变化

## 怎么验证的

### 自动验证

```text
Node.js v22.23.2
pnpm --filter desktop exec vitest run src/renderer/lib/__tests__/slashCommands.test.ts src/renderer/components/new-chat/__tests__/SlashCommandPalette.test.tsx
结果：28/28 通过

pnpm check:i18n
结果：通过，五语言 key 一致

pnpm check:i18n-glossary
结果：通过，无新增术语违规

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm test:unit
结果：完整通过（Desktop、Mobile、maker-core 及全部必跑 workspaces）

pnpm check:dco
结果：通过，1 个 commit 已签名
```

### 手工验证

不涉及：当前 worktree 不属于运行中 Desktop 实例，未把静态测试误报为实机目检。

### 未执行的验证

- Desktop 实机 Light / Dark 目检未执行；本次不改任何视觉样式，组件测试覆盖 aria/title 文案、禁用不可操作与 loaded 正常选择。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围：仅 Desktop `/` 命令面板中 discovered Pi 项目 Skill 的状态文案
- 回滚 / 降级方式：回退本提交即可恢复旧文案；无数据、协议、权限或持久化影响
- permission UI 影响：无，本 PR 不修改权限选择器或任何授权 UI

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] UI 改动已注明设计规范依据
- [x] 未提交凭证、令牌或授权文件
- [x] 已确认测试结果
