### PR TITLE
fix(desktop): route XD Grok through Chat bridge

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/activeCatalogXdAvailability.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/activeCatalogXdAvailability.test.ts
@@ -170,6 +170,13 @@ describe('XD 网关权威模型清单重建', () => {
     expect(isXdCodexAnthropicBridgeModel('codex-native-only')).toBe(false);
   });
 
+  it('marks XD Gateway Grok models for the Codex Chat bridge', () => {
+    setActiveCatalog(BUNDLED_CATALOG);
+    setXdGatewayModels([{ id: 'x-ai/grok-4.5', agents: ['codex'] }]);
+
+    expect(xdModels('codex')[0]?.codexCompatibilityWireProtocol).toBe('openai-chat');
+  });
+
   it('perAgent 覆盖块按 tab 应用(cc 无 Fast + 1M 窗口;codex 保持基线)', () => {
     setActiveCatalog(BUNDLED_CATALOG);
     setXdGatewayModels([

--- a/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
@@ -2722,8 +2722,11 @@ describe('codex proxy host', () => {
 
     current = {
       model: 'x-ai/grok-4.5',
-      tools: [{ type: 'namespace', name: 'multi_agent_v1', tools: [] }],
-      tool_choice: { type: 'namespace', name: 'multi_agent_v1' },
+      tools: [
+        { type: 'namespace', name: 'multi_agent_v1', tools: [] },
+        { type: 'web_search', external_web_access: false },
+      ],
+      tool_choice: { type: 'web_search' },
       parallel_tool_calls: true,
       input: 'hello',
     };
@@ -2734,6 +2737,44 @@ describe('codex proxy host', () => {
     expect(current).toEqual({ model: 'x-ai/grok-4.5', input: 'hello' });
 
     clearSessionProvider('session-xd-grok');
+  });
+
+  it('sanitizes Gateway Grok tools for an implicit XD session', async () => {
+    const host = await freshCodexProxyHost();
+    mockState.createAnthropicCompatProxy.mockResolvedValueOnce({
+      url: 'http://127.0.0.1:43210',
+      dispose: vi.fn(async () => undefined),
+    });
+    await host.ensureCodexProxyReady();
+    host.registerComposed('session-implicit-xd-grok', 'thread-implicit-xd-grok', 'PRODUCT_PROMPT');
+
+    const proxyOptions = mockState.createAnthropicCompatProxy.mock.calls[0]?.[0];
+    const transforms = proxyOptions?.transformRequest ?? [];
+    const routingTransform = proxyOptions?.routingTransform;
+    let current: unknown = {
+      model: 'x-ai/grok-4.5',
+      tools: [
+        { type: 'namespace', name: 'multi_agent_v1', tools: [] },
+        { type: 'function', name: 'exec_command' },
+      ],
+      input: 'hello',
+    };
+    const ctx = {
+      method: 'POST',
+      url: '/responses',
+      headers: { 'thread-id': 'thread-implicit-xd-grok' },
+    };
+    for (const transform of transforms) {
+      const next = transform(current, ctx);
+      if (next !== null && next !== undefined) current = next;
+    }
+
+    expect(current).toEqual({
+      model: 'x-ai/grok-4.5',
+      tools: [{ type: 'function', name: 'exec_command' }],
+      input: 'hello',
+    });
+    await expect(routingTransform(current, ctx)).resolves.toBeNull();
   });
 
   it('keeps Gateway Grok tools when an OAuth session falls back to ChatGPT', async () => {

--- a/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
@@ -2671,6 +2671,144 @@ describe('codex proxy host', () => {
     clearSessionProvider('session-gateway-passthrough');
   });
 
+  it('sanitizes unsupported tools for XD Gateway Grok without applying direct xAI rewrites', async () => {
+    const host = await freshCodexProxyHost();
+    const { setSessionProvider, clearSessionProvider } = await import('../session-provider-store.js');
+    mockState.createAnthropicCompatProxy.mockResolvedValueOnce({
+      url: 'http://127.0.0.1:43210',
+      dispose: vi.fn(async () => undefined),
+    });
+    await host.ensureCodexProxyReady();
+    host.registerComposed('session-xd-grok', 'thread-xd-grok', 'PRODUCT_PROMPT');
+    setSessionProvider('session-xd-grok', 'xd');
+
+    const transforms = mockState.createAnthropicCompatProxy.mock.calls[0]?.[0]?.transformRequest ?? [];
+    let current: unknown = {
+      model: 'x-ai/grok-4.5',
+      instructions: 'keep gateway instructions',
+      reasoning: { effort: 'high', summary: 'auto' },
+      tools: [
+        { type: 'namespace', name: 'multi_agent_v1', tools: [{ type: 'function', name: 'close_agent' }] },
+        { type: 'function', name: 'exec_command' },
+        {
+          type: 'web_search',
+          filters: { allowed_domains: ['example.com'] },
+          external_web_access: true,
+          search_context_size: 'medium',
+        },
+      ],
+      tool_choice: { type: 'namespace', name: 'multi_agent_v1' },
+      parallel_tool_calls: false,
+      input: [{ type: 'custom_tool_call', call_id: 'call_1', name: 'legacy_tool', input: '{}' }],
+    };
+    const ctx = { method: 'POST', url: '/responses', headers: { 'thread-id': 'thread-xd-grok' } };
+    for (const transform of transforms) {
+      const next = transform(current, ctx);
+      if (next !== null && next !== undefined) current = next;
+    }
+
+    expect(current).toEqual({
+      model: 'x-ai/grok-4.5',
+      instructions: 'keep gateway instructions',
+      reasoning: { effort: 'high', summary: 'auto' },
+      tools: [
+        { type: 'function', name: 'exec_command' },
+        { type: 'web_search', filters: { allowed_domains: ['example.com'] } },
+      ],
+      tool_choice: 'auto',
+      parallel_tool_calls: false,
+      input: [{ type: 'custom_tool_call', call_id: 'call_1', name: 'legacy_tool', input: '{}' }],
+    });
+
+    current = {
+      model: 'x-ai/grok-4.5',
+      tools: [{ type: 'namespace', name: 'multi_agent_v1', tools: [] }],
+      tool_choice: { type: 'namespace', name: 'multi_agent_v1' },
+      parallel_tool_calls: true,
+      input: 'hello',
+    };
+    for (const transform of transforms) {
+      const next = transform(current, ctx);
+      if (next !== null && next !== undefined) current = next;
+    }
+    expect(current).toEqual({ model: 'x-ai/grok-4.5', input: 'hello' });
+
+    clearSessionProvider('session-xd-grok');
+  });
+
+  it('keeps Gateway Grok tools when an OAuth session falls back to ChatGPT', async () => {
+    const host = await freshCodexProxyHost();
+    const { setSessionProvider, clearSessionProvider } = await import('../session-provider-store.js');
+    mockState.createAnthropicCompatProxy.mockResolvedValueOnce({
+      url: 'http://127.0.0.1:43210',
+      dispose: vi.fn(async () => undefined),
+    });
+    await host.ensureCodexProxyReady();
+    host.registerComposed('session-xd-grok-fallback', 'thread-xd-grok-fallback', 'PRODUCT_PROMPT');
+    setSessionProvider('session-xd-grok-fallback', 'xd');
+    host.setCodexProxyAuthInjection('oauth-bearer');
+    host.setCodexProxyGatewayKeyReader(() => null);
+
+    const proxyOptions = mockState.createAnthropicCompatProxy.mock.calls[0]?.[0];
+    const transforms = proxyOptions?.transformRequest ?? [];
+    const routingTransform = proxyOptions?.routingTransform;
+    const original = {
+      model: 'x-ai/grok-4.5',
+      tools: [{ type: 'namespace', name: 'multi_agent_v1', tools: [] }],
+      input: 'hello',
+    };
+    const ctx = {
+      method: 'POST',
+      url: '/responses',
+      headers: { 'thread-id': 'thread-xd-grok-fallback' },
+    };
+    let current: unknown = original;
+    for (const transform of transforms) {
+      const next = transform(current, ctx);
+      if (next !== null && next !== undefined) current = next;
+    }
+
+    expect(current).toEqual(original);
+    expect(routingTransform(original, ctx)).toEqual({
+      upstreamOverride: 'https://chatgpt.com/backend-api/codex',
+    });
+
+    host.clearCodexProxyAuthInjection();
+    clearSessionProvider('session-xd-grok-fallback');
+  });
+
+  it('keeps Codex namespace tools for non-Grok XD Gateway models', async () => {
+    const host = await freshCodexProxyHost();
+    const { setSessionProvider, clearSessionProvider } = await import('../session-provider-store.js');
+    mockState.createAnthropicCompatProxy.mockResolvedValueOnce({
+      url: 'http://127.0.0.1:43210',
+      dispose: vi.fn(async () => undefined),
+    });
+    await host.ensureCodexProxyReady();
+    host.registerComposed('session-xd-deepseek', 'thread-xd-deepseek', 'PRODUCT_PROMPT');
+    setSessionProvider('session-xd-deepseek', 'xd');
+
+    const transforms = mockState.createAnthropicCompatProxy.mock.calls[0]?.[0]?.transformRequest ?? [];
+    const original = {
+      model: 'deepseek/deepseek-v4-pro',
+      tools: [
+        { type: 'function', name: 'exec_command' },
+        { type: 'namespace', name: 'multi_agent_v1', tools: [] },
+      ],
+      input: 'hello',
+    };
+    let current: unknown = original;
+    const ctx = { method: 'POST', url: '/responses', headers: { 'thread-id': 'thread-xd-deepseek' } };
+    for (const transform of transforms) {
+      const next = transform(current, ctx);
+      if (next !== null && next !== undefined) current = next;
+    }
+
+    expect(current).toEqual(original);
+
+    clearSessionProvider('session-xd-deepseek');
+  });
+
   it('normalizes xAI Codex Responses body before forwarding requests', async () => {
     const host = await freshCodexProxyHost();
     const { setSessionProvider, clearSessionProvider } = await import('../session-provider-store.js');

--- a/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
@@ -2671,183 +2671,155 @@ describe('codex proxy host', () => {
     clearSessionProvider('session-gateway-passthrough');
   });
 
-  it('sanitizes unsupported tools for XD Gateway Grok without applying direct xAI rewrites', async () => {
+  it('routes XD Gateway Grok through the Chat bridge without dropping plugin tools', async () => {
     const host = await freshCodexProxyHost();
+    const { setXdGatewayModels } = await import('../active-catalog.js');
     const { setSessionProvider, clearSessionProvider } = await import('../session-provider-store.js');
-    mockState.createAnthropicCompatProxy.mockResolvedValueOnce({
-      url: 'http://127.0.0.1:43210',
-      dispose: vi.fn(async () => undefined),
-    });
-    await host.ensureCodexProxyReady();
+    setXdGatewayModels([{ id: 'x-ai/grok-4.5', agents: ['codex'] }]);
+    host.setCodexProxyGatewayKeyReader(() => 'xd-gateway-key');
     host.registerComposed('session-xd-grok', 'thread-xd-grok', 'PRODUCT_PROMPT');
     setSessionProvider('session-xd-grok', 'xd');
 
-    const transforms = mockState.createAnthropicCompatProxy.mock.calls[0]?.[0]?.transformRequest ?? [];
-    let current: unknown = {
+    const body = {
       model: 'x-ai/grok-4.5',
-      instructions: 'keep gateway instructions',
-      reasoning: { effort: 'high', summary: 'auto' },
       tools: [
         { type: 'namespace', name: 'multi_agent_v1', tools: [{ type: 'function', name: 'close_agent' }] },
-        { type: 'function', name: 'exec_command' },
-        {
-          type: 'web_search',
-          filters: { allowed_domains: ['example.com'] },
-          external_web_access: true,
-          search_context_size: 'medium',
-        },
-      ],
-      tool_choice: { type: 'namespace', name: 'multi_agent_v1' },
-      parallel_tool_calls: false,
-      input: [{ type: 'custom_tool_call', call_id: 'call_1', name: 'legacy_tool', input: '{}' }],
-    };
-    const ctx = { method: 'POST', url: '/responses', headers: { 'thread-id': 'thread-xd-grok' } };
-    for (const transform of transforms) {
-      const next = transform(current, ctx);
-      if (next !== null && next !== undefined) current = next;
-    }
-
-    expect(current).toEqual({
-      model: 'x-ai/grok-4.5',
-      instructions: 'keep gateway instructions',
-      reasoning: { effort: 'high', summary: 'auto' },
-      tools: [
-        { type: 'function', name: 'exec_command' },
-        { type: 'web_search', filters: { allowed_domains: ['example.com'] } },
-      ],
-      tool_choice: 'auto',
-      parallel_tool_calls: false,
-      input: [{ type: 'custom_tool_call', call_id: 'call_1', name: 'legacy_tool', input: '{}' }],
-    });
-
-    current = {
-      model: 'x-ai/grok-4.5',
-      tools: [
-        { type: 'namespace', name: 'multi_agent_v1', tools: [] },
+        { type: 'custom', name: 'apply_patch' },
+        { type: 'tool_search' },
         { type: 'web_search', external_web_access: false },
       ],
       tool_choice: { type: 'web_search' },
-      parallel_tool_calls: true,
-      input: 'hello',
-    };
-    for (const transform of transforms) {
-      const next = transform(current, ctx);
-      if (next !== null && next !== undefined) current = next;
-    }
-    expect(current).toEqual({ model: 'x-ai/grok-4.5', input: 'hello' });
-
-    clearSessionProvider('session-xd-grok');
-  });
-
-  it('sanitizes Gateway Grok tools for an implicit XD session', async () => {
-    const host = await freshCodexProxyHost();
-    mockState.createAnthropicCompatProxy.mockResolvedValueOnce({
-      url: 'http://127.0.0.1:43210',
-      dispose: vi.fn(async () => undefined),
-    });
-    await host.ensureCodexProxyReady();
-    host.registerComposed('session-implicit-xd-grok', 'thread-implicit-xd-grok', 'PRODUCT_PROMPT');
-
-    const proxyOptions = mockState.createAnthropicCompatProxy.mock.calls[0]?.[0];
-    const transforms = proxyOptions?.transformRequest ?? [];
-    const routingTransform = proxyOptions?.routingTransform;
-    let current: unknown = {
-      model: 'x-ai/grok-4.5',
-      tools: [
-        { type: 'namespace', name: 'multi_agent_v1', tools: [] },
-        { type: 'function', name: 'exec_command' },
-      ],
       input: 'hello',
     };
     const ctx = {
+      reqId: 1,
+      method: 'POST',
+      url: '/responses',
+      headers: { 'thread-id': 'thread-xd-grok' },
+    };
+    const decision = await Promise.resolve(host.createModelRoutingTransform()(body, ctx));
+    expect(decision).toEqual(expect.objectContaining({ localHandler: expect.any(Function) }));
+    expect(mockState.createResponsesChatHandler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        upstreamBase: `${XD_GATEWAY_BASE_URL}/v1`,
+        buildHeaders: expect.any(Function),
+      }),
+      expect.anything(),
+    );
+    const config = (mockState.createResponsesChatHandler.mock.calls as unknown as Array<[
+      { buildHeaders: () => Promise<Record<string, string>> },
+    ]>).at(-1)?.[0];
+    expect(await config?.buildHeaders()).toEqual({ authorization: 'Bearer xd-gateway-key' });
+
+    const res = {} as never;
+    await decision?.localHandler?.({
+      rawBody: Buffer.from(JSON.stringify(body)),
+      parsedBody: body,
+      ctx,
+      res,
+    });
+    const bridge = mockState.createResponsesChatHandler.mock.results.at(-1)?.value as
+      | { handle: ReturnType<typeof vi.fn> }
+      | undefined;
+    expect(bridge?.handle).toHaveBeenCalledWith({
+      parsedBody: {
+        ...body,
+        tools: body.tools.slice(0, 3),
+        tool_choice: 'auto',
+        instructions: 'PRODUCT_PROMPT',
+      },
+      res,
+    });
+
+    clearSessionProvider('session-xd-grok');
+    setXdGatewayModels([]);
+    host.setCodexProxyGatewayKeyReader(() => null);
+  });
+
+  it('routes an implicit XD Gateway Grok session through the Chat bridge', async () => {
+    const host = await freshCodexProxyHost();
+    const { getActiveCatalog, setXdGatewayModels } = await import('../active-catalog.js');
+    const { setProviderViewsReader } = await import('../provider-route.js');
+    const { clearSessionProvider } = await import('../session-provider-store.js');
+    setXdGatewayModels([{ id: 'x-ai/grok-4.5', agents: ['codex'] }]);
+    setProviderViewsReader(async () => getActiveCatalog().providers.map((provider) => ({
+      ...provider,
+      connected: provider.id === 'xd',
+    })));
+    host.setCodexProxyGatewayKeyReader(() => 'xd-gateway-key');
+    host.registerComposed('session-implicit-xd-grok', 'thread-implicit-xd-grok', 'PRODUCT_PROMPT');
+    clearSessionProvider('session-implicit-xd-grok');
+
+    const ctx = {
+      reqId: 1,
       method: 'POST',
       url: '/responses',
       headers: { 'thread-id': 'thread-implicit-xd-grok' },
     };
-    for (const transform of transforms) {
-      const next = transform(current, ctx);
-      if (next !== null && next !== undefined) current = next;
-    }
+    const decision = await Promise.resolve(host.createModelRoutingTransform()(
+      { model: 'x-ai/grok-4.5', input: 'hello' },
+      ctx,
+    ));
+    expect(decision).toEqual(expect.objectContaining({ localHandler: expect.any(Function) }));
 
-    expect(current).toEqual({
-      model: 'x-ai/grok-4.5',
-      tools: [{ type: 'function', name: 'exec_command' }],
-      input: 'hello',
-    });
-    await expect(routingTransform(current, ctx)).resolves.toBeNull();
+    host.unregister('session-implicit-xd-grok');
+    setProviderViewsReader(async () => []);
+    setXdGatewayModels([]);
+    host.setCodexProxyGatewayKeyReader(() => null);
   });
 
-  it('keeps Gateway Grok tools when an OAuth session falls back to ChatGPT', async () => {
+  it('keeps the ChatGPT fallback when XD Gateway credentials are unavailable', async () => {
     const host = await freshCodexProxyHost();
+    const { setXdGatewayModels } = await import('../active-catalog.js');
     const { setSessionProvider, clearSessionProvider } = await import('../session-provider-store.js');
-    mockState.createAnthropicCompatProxy.mockResolvedValueOnce({
-      url: 'http://127.0.0.1:43210',
-      dispose: vi.fn(async () => undefined),
-    });
-    await host.ensureCodexProxyReady();
+    setXdGatewayModels([{ id: 'x-ai/grok-4.5', agents: ['codex'] }]);
     host.registerComposed('session-xd-grok-fallback', 'thread-xd-grok-fallback', 'PRODUCT_PROMPT');
     setSessionProvider('session-xd-grok-fallback', 'xd');
     host.setCodexProxyAuthInjection('oauth-bearer');
     host.setCodexProxyGatewayKeyReader(() => null);
 
-    const proxyOptions = mockState.createAnthropicCompatProxy.mock.calls[0]?.[0];
-    const transforms = proxyOptions?.transformRequest ?? [];
-    const routingTransform = proxyOptions?.routingTransform;
-    const original = {
+    const decision = host.createModelRoutingTransform()({
       model: 'x-ai/grok-4.5',
       tools: [{ type: 'namespace', name: 'multi_agent_v1', tools: [] }],
       input: 'hello',
-    };
-    const ctx = {
+    }, {
+      reqId: 1,
       method: 'POST',
       url: '/responses',
       headers: { 'thread-id': 'thread-xd-grok-fallback' },
-    };
-    let current: unknown = original;
-    for (const transform of transforms) {
-      const next = transform(current, ctx);
-      if (next !== null && next !== undefined) current = next;
-    }
-
-    expect(current).toEqual(original);
-    expect(routingTransform(original, ctx)).toEqual({
+    });
+    expect(decision).toEqual({
       upstreamOverride: 'https://chatgpt.com/backend-api/codex',
     });
 
     host.clearCodexProxyAuthInjection();
     clearSessionProvider('session-xd-grok-fallback');
+    setXdGatewayModels([]);
   });
 
-  it('keeps Codex namespace tools for non-Grok XD Gateway models', async () => {
+  it('keeps non-Grok XD Gateway models on native Responses', async () => {
     const host = await freshCodexProxyHost();
+    const { setXdGatewayModels } = await import('../active-catalog.js');
     const { setSessionProvider, clearSessionProvider } = await import('../session-provider-store.js');
-    mockState.createAnthropicCompatProxy.mockResolvedValueOnce({
-      url: 'http://127.0.0.1:43210',
-      dispose: vi.fn(async () => undefined),
-    });
-    await host.ensureCodexProxyReady();
+    setXdGatewayModels([{ id: 'deepseek/deepseek-v4-pro', agents: ['codex'] }]);
+    host.setCodexProxyGatewayKeyReader(() => 'xd-gateway-key');
     host.registerComposed('session-xd-deepseek', 'thread-xd-deepseek', 'PRODUCT_PROMPT');
     setSessionProvider('session-xd-deepseek', 'xd');
 
-    const transforms = mockState.createAnthropicCompatProxy.mock.calls[0]?.[0]?.transformRequest ?? [];
-    const original = {
+    const decision = host.createModelRoutingTransform()({
       model: 'deepseek/deepseek-v4-pro',
-      tools: [
-        { type: 'function', name: 'exec_command' },
-        { type: 'namespace', name: 'multi_agent_v1', tools: [] },
-      ],
       input: 'hello',
-    };
-    let current: unknown = original;
-    const ctx = { method: 'POST', url: '/responses', headers: { 'thread-id': 'thread-xd-deepseek' } };
-    for (const transform of transforms) {
-      const next = transform(current, ctx);
-      if (next !== null && next !== undefined) current = next;
-    }
-
-    expect(current).toEqual(original);
+    }, {
+      reqId: 1,
+      method: 'POST',
+      url: '/responses',
+      headers: { 'thread-id': 'thread-xd-deepseek' },
+    });
+    expect(decision).toBeNull();
 
     clearSessionProvider('session-xd-deepseek');
+    setXdGatewayModels([]);
+    host.setCodexProxyGatewayKeyReader(() => null);
   });
 
   it('normalizes xAI Codex Responses body before forwarding requests', async () => {

--- a/apps/desktop/src/main/maker-host/active-catalog.ts
+++ b/apps/desktop/src/main/maker-host/active-catalog.ts
@@ -695,6 +695,9 @@ function computeMerged(): Catalog {
           ...(gm.icon !== undefined ? { icon: gm.icon } : {}),
           ...(cost ? { cost } : {}),
           ...(gm.modalities !== undefined ? { modalities: gm.modalities } : {}),
+          ...(agent === 'codex' && gm.id.startsWith('x-ai/grok-')
+            ? { codexCompatibilityWireProtocol: 'openai-chat' as const }
+            : {}),
         };
         models[agent]!.push(merged);
       }

--- a/apps/desktop/src/main/maker-host/codex-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/codex-proxy-host.ts
@@ -401,6 +401,33 @@ function stripGuardianProviderSearchTools(
   return next;
 }
 
+// Chat Completions cannot execute xAI server-side search. Remove only Codex's explicit
+// disabled declaration; enabled search stays visible to the bridge and fails closed.
+function stripDisabledWebSearchTool(
+  body: Record<string, unknown>,
+): Record<string, unknown> {
+  if (!Array.isArray(body.tools)) return body;
+  const tools = body.tools.filter(
+    (tool) => !isPlainObject(tool)
+      || tool.type !== 'web_search'
+      || tool.external_web_access !== false,
+  );
+  if (tools.length === body.tools.length) return body;
+
+  const next = { ...body };
+  if (tools.length > 0) {
+    next.tools = tools;
+    if (isPlainObject(next.tool_choice) && next.tool_choice.type === 'web_search') {
+      next.tool_choice = 'auto';
+    }
+  } else {
+    delete next.tools;
+    delete next.tool_choice;
+    delete next.parallel_tool_calls;
+  }
+  return next;
+}
+
 function createProviderAwareGuardianReviewerTransform(
   frozenAuthInjection?: CodexProxyAuthInjection,
 ): RequestTransform {
@@ -612,7 +639,31 @@ function createChatBridgeDecision(
   requestModelOverride?: string,
 ): RoutingDecision | null {
   if (!route || route.routing.wireProtocol !== 'openai-chat') return null;
+  const isXdGatewayBridge =
+    route.providerId === 'xd' && route.routing.authStrategy === 'gateway-key';
+  const gatewayKey = isXdGatewayBridge ? _readGatewayKey() : null;
+  const upstreamBase = isXdGatewayBridge
+    ? buildCodexGatewayBaseUrl()
+    : route.routing.upstream;
+  if (isXdGatewayBridge && !gatewayKey) {
+    return {
+      localHandler: async ({ res }) => {
+        res.writeHead(503, {
+          'content-type': 'application/json; charset=utf-8',
+          'cache-control': 'no-store',
+        });
+        res.end(JSON.stringify({
+          error: {
+            type: 'authentication_error',
+            code: 'cindy_gateway_credentials_unavailable',
+            message: 'Cindy AI credentials are not ready for this bridged model.',
+          },
+        }));
+      },
+    };
+  }
   const { headers } = buildLocalHandlerHeaders(route, 'codex');
+  if (gatewayKey) headers.authorization = `Bearer ${gatewayKey}`;
   const stripPrefix = route.routing.modelIdRewrite?.stripPrefix;
   const realModel = rewriteChatBridgeModel(wireModel, stripPrefix);
   // localHandler 绕过 proxy 的 responseObserver,自定义(user)供应商的上游错误不会被
@@ -635,7 +686,7 @@ function createChatBridgeDecision(
     }
     : CHAT_BRIDGE_DEFAULT_CAPABILITIES;
   const capabilities = chatBridgeCapabilitiesForRoute(
-    route.routing.upstream,
+    upstreamBase,
     realModel,
     baseCapabilities,
   );
@@ -645,7 +696,7 @@ function createChatBridgeDecision(
       }
     : undefined;
   const handler = createResponsesChatHandler({
-    upstreamBase: route.routing.upstream,
+    upstreamBase,
     ...(route.routing.requestPath ? { chatCompletionsPath: route.routing.requestPath } : {}),
     buildHeaders: async () => headers,
     rewriteModel: (model: string) => rewriteChatBridgeModel(model, stripPrefix),
@@ -663,7 +714,7 @@ function createChatBridgeDecision(
         requestModelOverride,
         bridge: 'chat',
         providerId,
-        upstreamBase: route.routing.upstream,
+        upstreamBase,
       });
       return handler.handle({ parsedBody: body, res });
     },
@@ -726,6 +777,15 @@ function prepareLocalBridgeBody(opts: PrepareLocalBridgeBodyOptions): unknown {
           ? [...existing, { type: 'input_text', text: `\n\n${opts.instructions}` }]
           : [existingText, opts.instructions].filter(Boolean).join('\n\n'),
     };
+  }
+  if (
+    opts.bridge === 'chat'
+    && opts.providerId === 'xd'
+    && isPlainObject(body)
+    && typeof body.model === 'string'
+    && body.model.startsWith('x-ai/grok-')
+  ) {
+    body = stripDisabledWebSearchTool(body);
   }
   const historySafe = isChatGptUpstreamBase(opts.upstreamBase)
     ? null
@@ -1002,7 +1062,12 @@ function createLocalBridgeDecision(
       requestModelOverride,
     );
     if (decision) {
-      recordCodexThreadUpstreamForDiagnostics(threadId, route.routing.upstream);
+      recordCodexThreadUpstreamForDiagnostics(
+        threadId,
+        route.providerId === 'xd' && route.routing.authStrategy === 'gateway-key'
+          ? buildCodexGatewayBaseUrl()
+          : route.routing.upstream,
+      );
     }
     return decision;
   }
@@ -1369,24 +1434,17 @@ const XAI_SUPPORTED_TOOL_TYPES = new Set([
   'shell',
 ]);
 
-function sanitizeXaiTools(
-  body: Record<string, unknown>,
-  dropDisabledWebSearch = false,
-): Record<string, unknown> | null {
+function sanitizeXaiTools(body: Record<string, unknown>): Record<string, unknown> | null {
   if (!Array.isArray(body.tools)) return null;
 
   let changed = false;
-  const tools: Record<string, unknown>[] = [];
+  const tools: unknown[] = [];
   for (const tool of body.tools) {
     if (!isPlainObject(tool) || typeof tool.type !== 'string' || !XAI_SUPPORTED_TOOL_TYPES.has(tool.type)) {
       changed = true;
       continue;
     }
     if (tool.type === 'web_search') {
-      if (dropDisabledWebSearch && tool.external_web_access === false) {
-        changed = true;
-        continue;
-      }
       const nextTool: Record<string, unknown> = { type: 'web_search' };
       for (const key of ['filters', 'enable_image_understanding', 'enable_image_search']) {
         if (key in tool) nextTool[key] = tool[key];
@@ -1400,49 +1458,9 @@ function sanitizeXaiTools(
   if (!changed) return null;
 
   const next: Record<string, unknown> = { ...body };
-  if (tools.length > 0) {
-    next.tools = tools;
-    if (toolChoiceReferencesRemovedTool(next.tool_choice, tools)) next.tool_choice = 'auto';
-  } else {
-    delete next.tools;
-    delete next.tool_choice;
-    delete next.parallel_tool_calls;
-  }
+  if (tools.length > 0) next.tools = tools;
+  else delete next.tools;
   return next;
-}
-
-function isXdGatewayGrokRequest(
-  body: Record<string, unknown>,
-  ctx: RequestTransformCtx,
-  frozenAuthInjection?: CodexProxyAuthInjection,
-): boolean {
-  if (typeof body.model !== 'string' || !body.model.startsWith('x-ai/grok-')) return false;
-  const path = ctx.url.split('?', 1)[0] ?? ctx.url;
-  if (ctx.method !== 'POST' || (!path.endsWith('/responses') && path !== '/responses')) return false;
-
-  const authInjection = frozenAuthInjection ?? getCodexProxyAuthInjection();
-  const sessionId = sessionIdFromTransformCtx(ctx);
-  const canUseExplicitSessionRoute = Boolean(sessionId && (
-    authInjection === 'oauth-bearer'
-    || isUserProviderSession(sessionId)
-    || isHostInjectedAuthSession(sessionId, 'codex')
-  ));
-  const routing = canUseExplicitSessionRoute && sessionId
-    ? getSessionRoutingDescriptor(sessionId, 'codex', body.model)
-    : null;
-  const gatewayKey = _readGatewayKey();
-  const resolvedRoute = routing && sessionId
-    && (authInjection === 'oauth-bearer' || authInjection === 'provider-oauth')
-    ? resolveSessionRouteDecision(sessionId, 'codex', gatewayKey, body.model)
-    : null;
-
-  if (routing) {
-    return routing.authStrategy === 'gateway-key'
-      && (routing.wireProtocol ?? 'openai-responses') === 'openai-responses'
-      && (authInjection === 'env-key' || resolvedRoute !== null);
-  }
-  return authInjection === 'env-key'
-    || (authInjection === 'provider-oauth' && gatewayDefaultRouteDecision('codex', gatewayKey) !== null);
 }
 
 /**
@@ -1530,7 +1548,7 @@ function isByteDanceSeedRequest(
   return isByteDanceSeedModel(body.model) || isVolcengineArkResponsesRouting(ctx, body.model);
 }
 
-function toolChoiceReferencesRemovedTool(
+function seedToolChoiceReferencesRemovedTool(
   toolChoice: unknown,
   tools: Record<string, unknown>[],
 ): boolean {
@@ -1575,7 +1593,7 @@ function sanitizeByteDanceSeedTools(body: Record<string, unknown>): Record<strin
   const next: Record<string, unknown> = { ...body };
   if (tools.length > 0) {
     next.tools = tools;
-    if (toolChoiceReferencesRemovedTool(next.tool_choice, tools)) next.tool_choice = 'auto';
+    if (seedToolChoiceReferencesRemovedTool(next.tool_choice, tools)) next.tool_choice = 'auto';
   } else {
     delete next.tools;
     delete next.tool_choice;
@@ -1784,14 +1802,9 @@ function createByteDanceSeedResponsesCompatTransform(): RequestTransform {
   };
 }
 
-function createXaiResponsesCompatTransform(
-  frozenAuthInjection?: CodexProxyAuthInjection,
-): RequestTransform {
+function createXaiResponsesCompatTransform(): RequestTransform {
   return (body, ctx) => {
     if (!isPlainObject(body)) return null;
-    // XD Gateway 的 Grok 只复用已由 422 证明必要的 tools schema 清理；直连 xAI 的
-    // instructions/history/reasoning/search 改写没有网关运行证据，不能扩大到这条路由。
-    if (isXdGatewayGrokRequest(body, ctx, frozenAuthInjection)) return sanitizeXaiTools(body, true);
     const sessionId = sessionIdFromTransformCtx(ctx);
     const explicitProviderId = sessionId ? getSessionProvider(sessionId) : null;
     const inferredProviderId =
@@ -2223,6 +2236,11 @@ export function createModelRoutingTransform(
     const selectedUsesLocalBridge =
       ctx.method === 'POST'
       && Boolean(model)
+      && !(
+        selectedRouting?.wireProtocol === 'openai-chat'
+        && selectedRouting.authStrategy === 'gateway-key'
+        && !gatewayKey
+      )
       && (
         selectedRouting?.wireProtocol === 'openai-chat'
         || selectedRouting?.wireProtocol === 'anthropic-messages'
@@ -2344,7 +2362,7 @@ function createTransformRequestChain(
     // 后续针对具体供应商的 input 归一化才能稳定处理。
     createCrossProviderCompactionCompatTransform(),
     createStrictGatewayHistoryCompatTransform(),
-    createXaiResponsesCompatTransform(frozenAuthInjection),
+    createXaiResponsesCompatTransform(),
     createByteDanceSeedResponsesCompatTransform(),
     createMiniMaxResponsesCompatTransform(),
     createProviderModelRewriteTransform(),

--- a/apps/desktop/src/main/maker-host/codex-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/codex-proxy-host.ts
@@ -1369,7 +1369,10 @@ const XAI_SUPPORTED_TOOL_TYPES = new Set([
   'shell',
 ]);
 
-function sanitizeXaiTools(body: Record<string, unknown>): Record<string, unknown> | null {
+function sanitizeXaiTools(
+  body: Record<string, unknown>,
+  dropDisabledWebSearch = false,
+): Record<string, unknown> | null {
   if (!Array.isArray(body.tools)) return null;
 
   let changed = false;
@@ -1380,6 +1383,10 @@ function sanitizeXaiTools(body: Record<string, unknown>): Record<string, unknown
       continue;
     }
     if (tool.type === 'web_search') {
+      if (dropDisabledWebSearch && tool.external_web_access === false) {
+        changed = true;
+        continue;
+      }
       const nextTool: Record<string, unknown> = { type: 'web_search' };
       for (const key of ['filters', 'enable_image_understanding', 'enable_image_search']) {
         if (key in tool) nextTool[key] = tool[key];
@@ -1413,18 +1420,29 @@ function isXdGatewayGrokRequest(
   const path = ctx.url.split('?', 1)[0] ?? ctx.url;
   if (ctx.method !== 'POST' || (!path.endsWith('/responses') && path !== '/responses')) return false;
 
-  const sessionId = sessionIdFromTransformCtx(ctx);
-  if (!sessionId || getSessionProvider(sessionId) !== 'xd') return false;
-  const routing = getSessionRoutingDescriptor(sessionId, 'codex', body.model);
-  if (
-    routing?.authStrategy !== 'gateway-key'
-    || (routing.wireProtocol ?? 'openai-responses') !== 'openai-responses'
-  ) {
-    return false;
-  }
-
   const authInjection = frozenAuthInjection ?? getCodexProxyAuthInjection();
-  return authInjection !== 'oauth-bearer' || Boolean(_readGatewayKey());
+  const sessionId = sessionIdFromTransformCtx(ctx);
+  const canUseExplicitSessionRoute = Boolean(sessionId && (
+    authInjection === 'oauth-bearer'
+    || isUserProviderSession(sessionId)
+    || isHostInjectedAuthSession(sessionId, 'codex')
+  ));
+  const routing = canUseExplicitSessionRoute && sessionId
+    ? getSessionRoutingDescriptor(sessionId, 'codex', body.model)
+    : null;
+  const gatewayKey = _readGatewayKey();
+  const resolvedRoute = routing && sessionId
+    && (authInjection === 'oauth-bearer' || authInjection === 'provider-oauth')
+    ? resolveSessionRouteDecision(sessionId, 'codex', gatewayKey, body.model)
+    : null;
+
+  if (routing) {
+    return routing.authStrategy === 'gateway-key'
+      && (routing.wireProtocol ?? 'openai-responses') === 'openai-responses'
+      && (authInjection === 'env-key' || resolvedRoute !== null);
+  }
+  return authInjection === 'env-key'
+    || (authInjection === 'provider-oauth' && gatewayDefaultRouteDecision('codex', gatewayKey) !== null);
 }
 
 /**
@@ -1773,7 +1791,7 @@ function createXaiResponsesCompatTransform(
     if (!isPlainObject(body)) return null;
     // XD Gateway 的 Grok 只复用已由 422 证明必要的 tools schema 清理；直连 xAI 的
     // instructions/history/reasoning/search 改写没有网关运行证据，不能扩大到这条路由。
-    if (isXdGatewayGrokRequest(body, ctx, frozenAuthInjection)) return sanitizeXaiTools(body);
+    if (isXdGatewayGrokRequest(body, ctx, frozenAuthInjection)) return sanitizeXaiTools(body, true);
     const sessionId = sessionIdFromTransformCtx(ctx);
     const explicitProviderId = sessionId ? getSessionProvider(sessionId) : null;
     const inferredProviderId =

--- a/apps/desktop/src/main/maker-host/codex-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/codex-proxy-host.ts
@@ -1373,7 +1373,7 @@ function sanitizeXaiTools(body: Record<string, unknown>): Record<string, unknown
   if (!Array.isArray(body.tools)) return null;
 
   let changed = false;
-  const tools: unknown[] = [];
+  const tools: Record<string, unknown>[] = [];
   for (const tool of body.tools) {
     if (!isPlainObject(tool) || typeof tool.type !== 'string' || !XAI_SUPPORTED_TOOL_TYPES.has(tool.type)) {
       changed = true;
@@ -1393,9 +1393,38 @@ function sanitizeXaiTools(body: Record<string, unknown>): Record<string, unknown
   if (!changed) return null;
 
   const next: Record<string, unknown> = { ...body };
-  if (tools.length > 0) next.tools = tools;
-  else delete next.tools;
+  if (tools.length > 0) {
+    next.tools = tools;
+    if (toolChoiceReferencesRemovedTool(next.tool_choice, tools)) next.tool_choice = 'auto';
+  } else {
+    delete next.tools;
+    delete next.tool_choice;
+    delete next.parallel_tool_calls;
+  }
   return next;
+}
+
+function isXdGatewayGrokRequest(
+  body: Record<string, unknown>,
+  ctx: RequestTransformCtx,
+  frozenAuthInjection?: CodexProxyAuthInjection,
+): boolean {
+  if (typeof body.model !== 'string' || !body.model.startsWith('x-ai/grok-')) return false;
+  const path = ctx.url.split('?', 1)[0] ?? ctx.url;
+  if (ctx.method !== 'POST' || (!path.endsWith('/responses') && path !== '/responses')) return false;
+
+  const sessionId = sessionIdFromTransformCtx(ctx);
+  if (!sessionId || getSessionProvider(sessionId) !== 'xd') return false;
+  const routing = getSessionRoutingDescriptor(sessionId, 'codex', body.model);
+  if (
+    routing?.authStrategy !== 'gateway-key'
+    || (routing.wireProtocol ?? 'openai-responses') !== 'openai-responses'
+  ) {
+    return false;
+  }
+
+  const authInjection = frozenAuthInjection ?? getCodexProxyAuthInjection();
+  return authInjection !== 'oauth-bearer' || Boolean(_readGatewayKey());
 }
 
 /**
@@ -1483,7 +1512,7 @@ function isByteDanceSeedRequest(
   return isByteDanceSeedModel(body.model) || isVolcengineArkResponsesRouting(ctx, body.model);
 }
 
-function seedToolChoiceReferencesRemovedTool(
+function toolChoiceReferencesRemovedTool(
   toolChoice: unknown,
   tools: Record<string, unknown>[],
 ): boolean {
@@ -1528,7 +1557,7 @@ function sanitizeByteDanceSeedTools(body: Record<string, unknown>): Record<strin
   const next: Record<string, unknown> = { ...body };
   if (tools.length > 0) {
     next.tools = tools;
-    if (seedToolChoiceReferencesRemovedTool(next.tool_choice, tools)) next.tool_choice = 'auto';
+    if (toolChoiceReferencesRemovedTool(next.tool_choice, tools)) next.tool_choice = 'auto';
   } else {
     delete next.tools;
     delete next.tool_choice;
@@ -1737,9 +1766,14 @@ function createByteDanceSeedResponsesCompatTransform(): RequestTransform {
   };
 }
 
-function createXaiResponsesCompatTransform(): RequestTransform {
+function createXaiResponsesCompatTransform(
+  frozenAuthInjection?: CodexProxyAuthInjection,
+): RequestTransform {
   return (body, ctx) => {
     if (!isPlainObject(body)) return null;
+    // XD Gateway 的 Grok 只复用已由 422 证明必要的 tools schema 清理；直连 xAI 的
+    // instructions/history/reasoning/search 改写没有网关运行证据，不能扩大到这条路由。
+    if (isXdGatewayGrokRequest(body, ctx, frozenAuthInjection)) return sanitizeXaiTools(body);
     const sessionId = sessionIdFromTransformCtx(ctx);
     const explicitProviderId = sessionId ? getSessionProvider(sessionId) : null;
     const inferredProviderId =
@@ -2292,7 +2326,7 @@ function createTransformRequestChain(
     // 后续针对具体供应商的 input 归一化才能稳定处理。
     createCrossProviderCompactionCompatTransform(),
     createStrictGatewayHistoryCompatTransform(),
-    createXaiResponsesCompatTransform(),
+    createXaiResponsesCompatTransform(frozenAuthInjection),
     createByteDanceSeedResponsesCompatTransform(),
     createMiniMaxResponsesCompatTransform(),
     createProviderModelRewriteTransform(),

--- a/apps/desktop/src/main/maker-host/provider-route.ts
+++ b/apps/desktop/src/main/maker-host/provider-route.ts
@@ -21,6 +21,7 @@
 
 import {
   actualSourceIdForModel,
+  resolveCodexCompatibilityWireProtocol,
   type AgentKind,
   type Provider,
   type ProviderView,
@@ -28,10 +29,7 @@ import {
 } from '@cindy/model-providers';
 import type { RoutingDecision } from '@cindy/anthropic-compat-proxy';
 
-import {
-  getActiveCatalog,
-  isXdCodexAnthropicBridgeModel,
-} from './active-catalog.js';
+import { getActiveCatalog } from './active-catalog.js';
 import { getAppCapabilities } from '../appCapabilities.js';
 import { getSessionProvider } from './session-provider-store.js';
 
@@ -413,11 +411,20 @@ function providerRoutingForModel(
   agent: AgentKind,
   wireModel: string | undefined,
 ): RoutingDescriptor | null {
+  const catalogModelId = wireModel?.replace(/\[1m\]$/, '');
+  const catalogModel = catalogModelId
+    ? provider.models[agent]?.find((model) => model.id === catalogModelId)
+    : undefined;
+  const compatibilityWire = resolveCodexCompatibilityWireProtocol(
+    provider,
+    agent,
+    catalogModel,
+  );
   if (
     provider.id === 'xd'
     && agent === 'codex'
     && wireModel
-    && isXdCodexAnthropicBridgeModel(wireModel)
+    && compatibilityWire === 'anthropic-messages'
   ) {
     const claudeRouting = provider.routing['claude-code'];
     if (!claudeRouting) return null;
@@ -426,7 +433,10 @@ function providerRoutingForModel(
       wireProtocol: 'anthropic-messages',
     };
   }
-  return provider.routing[agent] ?? null;
+  const routing = provider.routing[agent];
+  return routing && compatibilityWire
+    ? { ...routing, wireProtocol: compatibilityWire }
+    : routing ?? null;
 }
 
 /**


### PR DESCRIPTION
## 这次改了什么

### 摘要

Route XD Gateway Grok models through Cindy's Responses-to-Chat bridge so Codex plugin tools remain available.

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- Related issue: Fixes #2348
- Included: Mark XD Gateway `x-ai/grok-*` models for the existing Chat bridge, preserve namespace/custom/tool-search adapters, inject Gateway credentials, and cover explicit and implicit routes.
- Not included: Direct xAI routing, retry behavior, other Gateway models, or server-side search adaptation.
- User-visible change: Codex sessions using XD Gateway Grok retain plugin tools instead of failing with the Responses `namespace` schema.
- Breaking change: No.

### Remote and mobile adaptation

- SSH remote workspaces: Not affected.
- Device link: No channel or protocol change.
- Mobile: Not affected.

### UI 变化

Not applicable. No visual, layout, copy, or interaction change.

- 引用的设计规范：不涉及：request JSON is transformed in the Desktop main process; no UI path changes.

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/maker-host/__tests__/activeCatalogXdAvailability.test.ts src/main/maker-host/__tests__/providerRoute.test.ts src/main/maker-host/__tests__/codexProxyHost.test.ts
Result: passed (214 tests).

pnpm --filter @cindy/responses-chat-bridge exec vitest run src/__tests__/translate-request.test.ts src/__tests__/chat-sse-translator.test.ts
Result: passed (90 tests).

pnpm test:unit
Result: passed.

NODE_OPTIONS=--max-old-space-size=6144 pnpm --filter desktop run --if-present typecheck
Result: passed.

pnpm check:dco
Result: passed.
```

### 手工验证

Not run.

### 未执行的验证

Real XD Gateway and Windows smoke tests were not run.

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [x] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- Impact: Only XD Gateway `x-ai/grok-*` Codex requests switch from native Responses forwarding to the existing Chat bridge.
- Risk: Chat Completions does not provide Responses server-side search tools. Disabled search is removed; enabled unsupported search fails closed.
- Rollback: Revert the three commits. No data migration or cleanup is required.

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
