### PR TITLE
fix(desktop): 取消订阅后购买弹窗显示到期时间而非误导提示

### DIFF
--- a/apps/desktop/src/renderer/features/billing/BillingPage.tsx
+++ b/apps/desktop/src/renderer/features/billing/BillingPage.tsx
@@ -1815,6 +1815,10 @@ function BillingOfferDialog({
 }) {
   const { t, i18n } = useTranslation();
   const billingLocale = i18n.resolvedLanguage ?? i18n.language;
+  const formattedSubscriptionPeriodEndAt = formatBillingDate(
+    subscriptionPeriodEndAt,
+    billingLocale,
+  );
   const title =
     kind === 'SUBSCRIPTION'
       ? t('billing.dialogs.subscription.title')
@@ -2065,9 +2069,9 @@ function BillingOfferDialog({
 
                   {kind === 'SUBSCRIPTION' && selected && subscriptionPurchaseBlocked && (
                     <p className="mt-4 text-12 leading-5 text-[var(--text-secondary)]">
-                      {subscriptionCancelAtPeriodEnd && subscriptionPeriodEndAt
+                      {subscriptionCancelAtPeriodEnd && formattedSubscriptionPeriodEndAt
                         ? t('billing.currentSubscription.purchaseBlockedUntilPeriodEnd', {
-                            date: formatBillingDate(subscriptionPeriodEndAt, billingLocale),
+                            date: formattedSubscriptionPeriodEndAt,
                           })
                         : t('billing.currentSubscription.purchaseBlocked')}
                     </p>

--- a/apps/desktop/src/renderer/features/billing/BillingPage.tsx
+++ b/apps/desktop/src/renderer/features/billing/BillingPage.tsx
@@ -1089,6 +1089,8 @@ export function BillingSettingsSection({ accountId }: { accountId: string | null
         amountError={amountError}
         subscriptionPurchaseBlocked={subscriptionPurchaseBlocked}
         currentSubscriptionOfferCode={currentSubscriptionOfferCode}
+        subscriptionCancelAtPeriodEnd={currentSubscription?.cancelAtPeriodEnd ?? false}
+        subscriptionPeriodEndAt={currentSubscription?.currentPeriodEndAt ?? null}
         canCheckout={canCheckout}
         onClose={closeSubscriptionDialog}
         onRetry={() => void loadBillingState()}
@@ -1113,6 +1115,8 @@ export function BillingSettingsSection({ accountId }: { accountId: string | null
         amountError={amountError}
         subscriptionPurchaseBlocked={false}
         currentSubscriptionOfferCode={null}
+        subscriptionCancelAtPeriodEnd={false}
+        subscriptionPeriodEndAt={null}
         canCheckout={canCheckout}
         onClose={closeTopupDialog}
         onRetry={() => void loadBillingState()}
@@ -1774,6 +1778,8 @@ function BillingOfferDialog({
   amountError,
   subscriptionPurchaseBlocked,
   currentSubscriptionOfferCode,
+  subscriptionCancelAtPeriodEnd,
+  subscriptionPeriodEndAt,
   canCheckout,
   onClose,
   onRetry,
@@ -1796,6 +1802,8 @@ function BillingOfferDialog({
   amountError: string | null;
   subscriptionPurchaseBlocked: boolean;
   currentSubscriptionOfferCode: string | null;
+  subscriptionCancelAtPeriodEnd: boolean;
+  subscriptionPeriodEndAt: string | null;
   canCheckout: boolean;
   onClose: () => void;
   onRetry: () => void;
@@ -2057,7 +2065,11 @@ function BillingOfferDialog({
 
                   {kind === 'SUBSCRIPTION' && selected && subscriptionPurchaseBlocked && (
                     <p className="mt-4 text-12 leading-5 text-[var(--text-secondary)]">
-                      {t('billing.currentSubscription.purchaseBlocked')}
+                      {subscriptionCancelAtPeriodEnd && subscriptionPeriodEndAt
+                        ? t('billing.currentSubscription.purchaseBlockedUntilPeriodEnd', {
+                            date: formatBillingDate(subscriptionPeriodEndAt, billingLocale),
+                          })
+                        : t('billing.currentSubscription.purchaseBlocked')}
                     </p>
                   )}
                 </div>

--- a/apps/desktop/src/renderer/features/billing/__tests__/BillingPage.test.tsx
+++ b/apps/desktop/src/renderer/features/billing/__tests__/BillingPage.test.tsx
@@ -2487,6 +2487,28 @@ describe('BillingPage plan change', () => {
     expect(screen.getByText('billing.currentSubscription.purchaseBlocked')).toBeTruthy();
   });
 
+  it('shows the period-end copy in the purchase dialog when the live subscription is scheduled to cancel', async () => {
+    const billing = billingMocks();
+    billing.getCurrentSubscription = vi.fn(async () => ({
+      subscription: { ...activeSubscription(null, 'MONTH', 'ACTIVE', true), effectivePlan: null },
+    }));
+    install(billing);
+
+    render(<BillingPage />);
+
+    await selectSubscriptionManagementAction('billing.settings.subscriptionCard.action');
+    fireEvent.click((await screen.findAllByText('Plus plan'))[0].closest('button')!);
+    fireEvent.click(screen.getByText('stripe').closest('button')!);
+    expect(screen.getByText('billing.actions.pay').closest('button')).toHaveProperty(
+      'disabled',
+      true,
+    );
+    expect(
+      screen.getByText(/billing\.currentSubscription\.purchaseBlockedUntilPeriodEnd/),
+    ).toBeTruthy();
+    expect(screen.queryByText('billing.currentSubscription.purchaseBlocked')).toBeNull();
+  });
+
   it('explains a rejected quote and returns to the candidate list', async () => {
     const billing = install(billingMocks());
     billing.quotePlanChange.mockRejectedValue(

--- a/apps/desktop/src/renderer/features/billing/__tests__/BillingPage.test.tsx
+++ b/apps/desktop/src/renderer/features/billing/__tests__/BillingPage.test.tsx
@@ -2509,6 +2509,26 @@ describe('BillingPage plan change', () => {
     expect(screen.queryByText('billing.currentSubscription.purchaseBlocked')).toBeNull();
   });
 
+  it('falls back to the generic copy when the scheduled-cancel subscription has an unparseable period end', async () => {
+    const billing = billingMocks();
+    billing.getCurrentSubscription = vi.fn(async () => ({
+      subscription: {
+        ...activeSubscription(null, 'MONTH', 'ACTIVE', true),
+        effectivePlan: null,
+        currentPeriodEndAt: 'not-a-valid-date',
+      },
+    }));
+    install(billing);
+
+    render(<BillingPage />);
+
+    await selectSubscriptionManagementAction('billing.settings.subscriptionCard.action');
+    fireEvent.click((await screen.findAllByText('Plus plan'))[0].closest('button')!);
+    fireEvent.click(screen.getByText('stripe').closest('button')!);
+    expect(screen.getByText('billing.currentSubscription.purchaseBlocked')).toBeTruthy();
+    expect(screen.queryByText(/purchaseBlockedUntilPeriodEnd/)).toBeNull();
+  });
+
   it('explains a rejected quote and returns to the candidate list', async () => {
     const billing = install(billingMocks());
     billing.quotePlanChange.mockRejectedValue(

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -9393,7 +9393,8 @@
     },
     "currentSubscription": {
       "title": "Current subscription",
-      "purchaseBlocked": "You already have an unfinished subscription. Manage it before purchasing another plan."
+      "purchaseBlocked": "You already have an unfinished subscription. Manage it before purchasing another plan.",
+      "purchaseBlockedUntilPeriodEnd": "Your current plan ends {{date}}. You can purchase a new plan after it ends."
     },
     "subscriptionStatus": {
       "INCOMPLETE": "Awaiting payment",

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -9379,7 +9379,8 @@
     },
     "currentSubscription": {
       "title": "現在のサブスクリプション",
-      "purchaseBlocked": "未終了のサブスクリプションがあります。既存のサブスクリプションを処理してから新しいプランを購入してください。"
+      "purchaseBlocked": "未終了のサブスクリプションがあります。既存のサブスクリプションを処理してから新しいプランを購入してください。",
+      "purchaseBlockedUntilPeriodEnd": "現在のプランは {{date}} に終了します。終了後に新しいプランを購入できます。"
     },
     "subscriptionStatus": {
       "INCOMPLETE": "支払い待ち",

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -9379,7 +9379,8 @@
     },
     "currentSubscription": {
       "title": "현재 구독",
-      "purchaseBlocked": "종료되지 않은 구독이 있습니다. 기존 구독을 처리한 후 새 요금제를 구매하세요."
+      "purchaseBlocked": "종료되지 않은 구독이 있습니다. 기존 구독을 처리한 후 새 요금제를 구매하세요.",
+      "purchaseBlockedUntilPeriodEnd": "현재 요금제는 {{date}}에 종료됩니다. 종료 후 새 요금제를 구매할 수 있습니다."
     },
     "subscriptionStatus": {
       "INCOMPLETE": "결제 대기",

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -9375,7 +9375,8 @@
     },
     "currentSubscription": {
       "title": "当前订阅",
-      "purchaseBlocked": "当前已有未结束的订阅，请先处理现有订阅后再购买新套餐。"
+      "purchaseBlocked": "当前已有未结束的订阅，请先处理现有订阅后再购买新套餐。",
+      "purchaseBlockedUntilPeriodEnd": "当前套餐将于 {{date}} 结束，届时可购买新套餐。"
     },
     "subscriptionStatus": {
       "INCOMPLETE": "等待完成支付",

--- a/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
@@ -9378,7 +9378,8 @@
     },
     "currentSubscription": {
       "title": "當前訂閱",
-      "purchaseBlocked": "當前已有未結束的訂閱，請先處理現有訂閱後再購買新套餐。"
+      "purchaseBlocked": "當前已有未結束的訂閱，請先處理現有訂閱後再購買新套餐。",
+      "purchaseBlockedUntilPeriodEnd": "當前套餐將於 {{date}} 結束，屆時可購買新套餐。"
     },
     "subscriptionStatus": {
       "INCOMPLETE": "等待完成支付",


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 #457 描述的购买弹窗误导提示：订阅取消（`cancelAtPeriodEnd=true`）后，用户打开购买弹窗仍会看到"当前已有未结束的订阅，请先处理现有订阅后再购买新套餐"——但此时既不能恢复订阅、不能改套餐、也不能购买新套餐，提示指向不存在的操作。

改为按取消状态分支：
- `cancelAtPeriodEnd=true` 且有到期时间 → 显示"当前套餐将于 {date} 结束，届时可购买新套餐"（带真实到期日，与订阅卡片区 `endsAt` 同一字段、同一格式化）
- 否则 → 保留原文案

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue：makecindy/cindy#457（第 2 件事：文案分支）
- 本 PR 包含：`BillingOfferDialog` 新增 `subscriptionCancelAtPeriodEnd` / `subscriptionPeriodEndAt` 两个 prop（仅订阅弹窗传值，充值弹窗传 false/null）；购买弹窗 `purchaseBlocked` 文案按取消状态分支；五语言（en/zh-CN/zh-TW/ja/ko）新增 `billing.currentSubscription.purchaseBlockedUntilPeriodEnd` key；新增 1 个测试用例
- 明确不包含：#457 第 1 件事"恢复订阅入口"（需服务端能力，另开 PR）
- 用户可见变化：仅"已取消待到期"的订阅在购买弹窗中的提示文案变化
- 是否存在 breaking change：无

### UI 变化

文案分支为纯文本替换，沿用 `--text-secondary` 语义 token，无布局改动。引用的设计规范：`docs/design-rules/DESIGN.md`（语义 token）。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop run typecheck：billing 相关 0 错误
pnpm check:i18n：✅ 五语言 key 全部一致
pnpm check:i18n-glossary：✅ 无新增违规
pnpm --filter desktop exec vitest run src/renderer/features/billing/__tests__/BillingPage.test.tsx：69/69 通过（含新增用例）
```

### 未执行的验证

- 全量 `pnpm test:unit` 在本地有 6 个测试文件因既有环境问题（`@cindy/wechat-ilink` 包缺失，device-link/goal-host/wechat-im 模块）收集失败，与本次改动无关（已用 stash 验证改动前同样失败）；14722 个断言全过
- Light/Dark 实机目检未做（纯文本替换，无新配色）

## 风险

- [x] 无已知风险

### 影响与回滚

- 影响范围：`BillingOfferDialog` 一个组件 + 5 个 locale key
- 回滚 / 降级方式：revert 本 PR 即可，无数据/迁移依赖

### 提交前检查

- [x] 每个 commit 带 DCO 签名
- [x] UI 改动已注明引用设计规范章节
- [x] 已确认测试结果及未执行项说明