### PR TITLE
fix(desktop): 右栏 detached 队列改为每会话有序 intent 组，登记命令不被后到命令顶掉 (#2409)

### DIFF
--- a/apps/desktop/src/main/maker-ipc/channels.ts
+++ b/apps/desktop/src/main/maker-ipc/channels.ts
@@ -663,6 +663,7 @@ export const MAKER_INVOKE = {
    *  - SET_DETACHED(boolean): 落盘偏好;true 附带开窗,false 附带关窗;返回新 state
    *  - GET_CONTEXT: 子窗口 mount 时拉主窗上报的 { sessionId, workdir, remoteHostId, deviceLinkDeviceId, available }
    *  - READY: 子窗口根组件挂载握手(resolve main 侧 ensureOpen 等待)
+   *  - ACK_COMMAND: 子窗口确认当前 deferred 命令已消费(推进桶头)
    *  - SEND_COMMAND: 主窗把命令(如 open-terminal 快捷键)转发给子窗口,必要时先开窗
    */
   RSB_WINDOW_GET_STATE: 'maker:rsb-window:get-state',
@@ -671,6 +672,11 @@ export const MAKER_INVOKE = {
   RSB_WINDOW_SET_DETACHED: 'maker:rsb-window:set-detached',
   RSB_WINDOW_GET_CONTEXT: 'maker:rsb-window:get-context',
   RSB_WINDOW_READY: 'maker:rsb-window:ready',
+  /**
+   * 子窗口确认当前 deferred 命令已消费（串行 enqueue 完成）。
+   * main 仅在有在途 detached 交付时推进桶头；直播 route 命令的 ack 被忽略。
+   */
+  RSB_WINDOW_ACK_COMMAND: 'maker:rsb-window:ack-command',
   RSB_WINDOW_SEND_COMMAND: 'maker:rsb-window:send-command',
   /**
    * 插件停靠面板独立窗口(ghost panel window)——每 ghostId 一扇窗。

--- a/apps/desktop/src/main/right-sidebar-window/__tests__/controller.test.ts
+++ b/apps/desktop/src/main/right-sidebar-window/__tests__/controller.test.ts
@@ -862,6 +862,89 @@ describe('setContext / routeCommand', () => {
     ]);
   });
 
+  it('切回 attached 时 drop 已交付未 ack 桶头,不双执行(Greptile P1)', async () => {
+    const h = makeHarness({ detached: true });
+    h.controller.setContext(ctx);
+    const closeWorkers = { type: 'close-orca-workers-tab' as const, sessionId: 's1' };
+    const genericEnsure = {
+      type: 'ensure-orca-workers-tab' as const,
+      sessionId: 's1',
+      focusTab: false,
+    };
+    await h.controller.routeCommand({ command: closeWorkers, allowOpen: false });
+    await h.controller.routeCommand({ command: genericEnsure, allowOpen: false });
+
+    h.controller.open();
+    h.controller.markReady();
+    // 子窗已收到 close，尚未 ack
+    expect(h.sends.filter((e) => e.channel === 'cmd-channel').map((e) => e.payload)).toEqual([
+      closeWorkers,
+    ]);
+
+    h.controller.setDetached(false);
+    // close 已交付给子窗：只把剩余 ensure 转交主窗，不重发 close
+    expect(h.sends.filter((e) => e.channel === 'cmd-channel').map((e) => e.payload)).toEqual([
+      closeWorkers,
+      genericEnsure,
+    ]);
+    expect(h.sendTargets.filter((_, i) => h.sends[i]?.channel === 'cmd-channel')).toEqual([
+      h.windows[0].webContents.id, // close → 子窗
+      h.mainWin.webContents.id, // ensure → 主窗
+    ]);
+  });
+
+  it('deferred 在途时直播命令入同一桶,无参 ack 不误推进尾部(Codex P1)', async () => {
+    const h = makeHarness({ detached: true });
+    h.controller.setContext(ctx);
+    const deferredA = { type: 'close-orca-workers-tab' as const, sessionId: 's1' };
+    const deferredC = {
+      type: 'ensure-orca-workers-tab' as const,
+      sessionId: 's1',
+      focusTab: false,
+    };
+    const liveB = { type: 'open-subagents-tab' as const, sessionId: 's1' };
+
+    await h.controller.routeCommand({ command: deferredA, allowOpen: false });
+    await h.controller.routeCommand({ command: deferredC, allowOpen: false });
+    h.controller.open();
+    h.controller.markReady();
+    // A 在途
+    expect(h.sends.filter((e) => e.channel === 'cmd-channel').map((e) => e.payload)).toEqual([
+      deferredA,
+    ]);
+
+    // 直播 B：应入桶排队，不能直发
+    const result = await h.controller.routeCommand({ command: liveB, allowOpen: true });
+    expect(result).toBe('queued');
+    expect(h.sends.filter((e) => e.channel === 'cmd-channel').map((e) => e.payload)).toEqual([
+      deferredA,
+    ]);
+
+    // A ack → 下发仍在桶内的 C（B 在 C 后）
+    h.controller.ackDetachedDeferredCommand();
+    expect(h.sends.filter((e) => e.channel === 'cmd-channel').map((e) => e.payload)).toEqual([
+      deferredA,
+      deferredC,
+    ]);
+
+    // 模拟 renderer 串行：A 后若曾误把 B 当直发 ack，会把 C 误 shift；
+    // 正确路径：C 的 ack 后才到 B
+    h.controller.ackDetachedDeferredCommand();
+    expect(h.sends.filter((e) => e.channel === 'cmd-channel').map((e) => e.payload)).toEqual([
+      deferredA,
+      deferredC,
+      liveB,
+    ]);
+    h.controller.ackDetachedDeferredCommand();
+    // 桶空，再 ack no-op
+    h.controller.ackDetachedDeferredCommand();
+    expect(h.sends.filter((e) => e.channel === 'cmd-channel').map((e) => e.payload)).toEqual([
+      deferredA,
+      deferredC,
+      liveB,
+    ]);
+  });
+
   it('关窗销毁时未 ack 的尾部 intent 保留,重开后可继续交付(Codex P1)', async () => {
     const h = makeHarness({ detached: true }, { asyncClose: true });
     h.controller.setContext(ctx);

--- a/apps/desktop/src/main/right-sidebar-window/__tests__/controller.test.ts
+++ b/apps/desktop/src/main/right-sidebar-window/__tests__/controller.test.ts
@@ -637,6 +637,11 @@ describe('setContext / routeCommand', () => {
 
     h.controller.open();
     h.controller.markReady();
+    // detached 一次只下发桶头，ack 后才推进下一条
+    expect(h.sends.filter((entry) => entry.channel === 'cmd-channel')).toEqual([
+      { channel: 'cmd-channel', payload: subagents },
+    ]);
+    h.controller.ackDetachedDeferredCommand();
     expect(h.sends.filter((entry) => entry.channel === 'cmd-channel')).toEqual([
       { channel: 'cmd-channel', payload: subagents },
       { channel: 'cmd-channel', payload: closeWorkers },
@@ -681,7 +686,12 @@ describe('setContext / routeCommand', () => {
 
     h.controller.open();
     h.controller.markReady();
-    expect(h.sends.map((entry) => entry.payload)).toEqual([register, { type: 'close-orca-workers-tab', sessionId: 's1' }]);
+    expect(h.sends.map((entry) => entry.payload)).toEqual([register]);
+    h.controller.ackDetachedDeferredCommand();
+    expect(h.sends.map((entry) => entry.payload)).toEqual([
+      register,
+      { type: 'close-orca-workers-tab', sessionId: 's1' },
+    ]);
   });
 
   it('连续等价的 subagent 静默登记只保留一条,避免队列无限堆积(#2491 Codex P2)', async () => {
@@ -770,6 +780,10 @@ describe('setContext / routeCommand', () => {
     h.controller.markReady();
     expect(h.sends.filter((entry) => entry.channel === 'cmd-channel')).toEqual([
       { channel: 'cmd-channel', payload: focused },
+    ]);
+    h.controller.ackDetachedDeferredCommand();
+    expect(h.sends.filter((entry) => entry.channel === 'cmd-channel')).toEqual([
+      { channel: 'cmd-channel', payload: focused },
       { channel: 'cmd-channel', payload: registerOnly },
     ]);
   });
@@ -840,7 +854,83 @@ describe('setContext / routeCommand', () => {
     h.controller.markReady();
     expect(h.sends.filter((entry) => entry.channel === 'cmd-channel')).toEqual([
       { channel: 'cmd-channel', payload: { type: 'close-orca-workers-tab', sessionId: 's1' } },
+    ]);
+    h.controller.ackDetachedDeferredCommand();
+    expect(h.sends.filter((entry) => entry.channel === 'cmd-channel')).toEqual([
+      { channel: 'cmd-channel', payload: { type: 'close-orca-workers-tab', sessionId: 's1' } },
       { channel: 'cmd-channel', payload: genericEnsure },
+    ]);
+  });
+
+  it('关窗销毁时未 ack 的尾部 intent 保留,重开后可继续交付(Codex P1)', async () => {
+    const h = makeHarness({ detached: true }, { asyncClose: true });
+    h.controller.setContext(ctx);
+    const closeWorkers = { type: 'close-orca-workers-tab' as const, sessionId: 's1' };
+    const genericEnsure = {
+      type: 'ensure-orca-workers-tab' as const,
+      sessionId: 's1',
+      focusTab: false,
+    };
+    await h.controller.routeCommand({ command: closeWorkers, allowOpen: false });
+    await h.controller.routeCommand({ command: genericEnsure, allowOpen: false });
+
+    h.controller.open();
+    h.controller.markReady();
+    // 仅下发桶头 close；ensure 仍在 main 桶内
+    expect(h.sends.filter((entry) => entry.channel === 'cmd-channel')).toEqual([
+      { channel: 'cmd-channel', payload: closeWorkers },
+    ]);
+
+    // 首条尚未 ack 时关窗销毁 BrowserWindow：在途标记清除，整桶保留
+    h.controller.close();
+    h.windows[0].emitClosed();
+    expect(h.sends.filter((entry) => entry.channel === 'cmd-channel')).toEqual([
+      { channel: 'cmd-channel', payload: closeWorkers },
+    ]);
+
+    // 重开 + ready：从桶头 close 重新交付，ack 后才到 ensure
+    h.controller.open();
+    h.controller.markReady();
+    const cmds = () => h.sends.filter((entry) => entry.channel === 'cmd-channel');
+    expect(cmds().map((e) => e.payload)).toEqual([closeWorkers, closeWorkers]);
+    h.controller.ackDetachedDeferredCommand();
+    expect(cmds().map((e) => e.payload)).toEqual([closeWorkers, closeWorkers, genericEnsure]);
+    h.controller.ackDetachedDeferredCommand();
+    // 桶空后再 ack 是 no-op
+    h.controller.ackDetachedDeferredCommand();
+    expect(cmds().map((e) => e.payload)).toEqual([closeWorkers, closeWorkers, genericEnsure]);
+  });
+
+  it('ack 推进后关窗,剩余尾部 intent 仍可在重开后交付(Codex P1)', async () => {
+    const h = makeHarness({ detached: true }, { asyncClose: true });
+    h.controller.setContext(ctx);
+    const closeWorkers = { type: 'close-orca-workers-tab' as const, sessionId: 's1' };
+    const genericEnsure = {
+      type: 'ensure-orca-workers-tab' as const,
+      sessionId: 's1',
+      focusTab: false,
+    };
+    await h.controller.routeCommand({ command: closeWorkers, allowOpen: false });
+    await h.controller.routeCommand({ command: genericEnsure, allowOpen: false });
+
+    h.controller.open();
+    h.controller.markReady();
+    h.controller.ackDetachedDeferredCommand(); // close 完成，ensure 在途
+    expect(h.sends.filter((e) => e.channel === 'cmd-channel').map((e) => e.payload)).toEqual([
+      closeWorkers,
+      genericEnsure,
+    ]);
+
+    h.controller.close();
+    h.windows[0].emitClosed();
+
+    h.controller.open();
+    h.controller.markReady();
+    // ensure 未 ack，重开后应再次下发 ensure（不再重发已 ack 的 close）
+    expect(h.sends.filter((e) => e.channel === 'cmd-channel').map((e) => e.payload)).toEqual([
+      closeWorkers,
+      genericEnsure,
+      genericEnsure,
     ]);
   });
 

--- a/apps/desktop/src/main/right-sidebar-window/__tests__/controller.test.ts
+++ b/apps/desktop/src/main/right-sidebar-window/__tests__/controller.test.ts
@@ -626,4 +626,239 @@ describe('setContext / routeCommand', () => {
     h.controller.markReady();
     expect(h.sends.at(-1)).toEqual({ channel: 'cmd-channel', payload: explicit });
   });
+
+  it('同 session 两条不同 passive 命令入队后按序全部 flush(#2409)', async () => {
+    const h = makeHarness({ detached: true });
+    h.controller.setContext(ctx);
+    const subagents = { type: 'open-subagents-tab' as const, sessionId: 's1' };
+    const closeWorkers = { type: 'close-orca-workers-tab' as const, sessionId: 's1' };
+    await h.controller.routeCommand({ command: subagents, allowOpen: false });
+    await h.controller.routeCommand({ command: closeWorkers, allowOpen: false });
+
+    h.controller.open();
+    h.controller.markReady();
+    expect(h.sends.filter((entry) => entry.channel === 'cmd-channel')).toEqual([
+      { channel: 'cmd-channel', payload: subagents },
+      { channel: 'cmd-channel', payload: closeWorkers },
+    ]);
+  });
+
+  it('同 session 两条不同 passive 命令在切回 attached 时按序转交主 renderer(#2409)', async () => {
+    const h = makeHarness({ detached: true });
+    h.controller.setContext(ctx);
+    const subagents = { type: 'open-subagents-tab' as const, sessionId: 's1' };
+    const closeWorkers = { type: 'close-orca-workers-tab' as const, sessionId: 's1' };
+    await h.controller.routeCommand({ command: subagents, allowOpen: false });
+    await h.controller.routeCommand({ command: closeWorkers, allowOpen: false });
+
+    h.controller.setDetached(false);
+    expect(h.sends.filter((entry) => entry.channel === 'cmd-channel')).toEqual([
+      { channel: 'cmd-channel', payload: subagents },
+      { channel: 'cmd-channel', payload: closeWorkers },
+    ]);
+    expect(h.sendTargets.filter((_, i) => h.sends[i]?.channel === 'cmd-channel')).toEqual([
+      h.mainWin.webContents.id,
+      h.mainWin.webContents.id,
+    ]);
+  });
+
+  it('subagent 登记入队后再入队另一条 passive 命令,登记不被覆盖(#2409)', async () => {
+    const h = makeHarness({ detached: true });
+    h.controller.setContext(ctx);
+    const register = {
+      type: 'open-subagents-tab' as const,
+      sessionId: 's1',
+      focusRunId: 'run-1',
+      focusProvider: null,
+      focusTab: false,
+      revealSidebar: false,
+    };
+    await h.controller.routeCommand({ command: register, allowOpen: false });
+    await h.controller.routeCommand({
+      command: { type: 'close-orca-workers-tab', sessionId: 's1' },
+      allowOpen: false,
+    });
+
+    h.controller.open();
+    h.controller.markReady();
+    expect(h.sends.map((entry) => entry.payload)).toEqual([register, { type: 'close-orca-workers-tab', sessionId: 's1' }]);
+  });
+
+  it('连续等价的 subagent 静默登记只保留一条,避免队列无限堆积(#2491 Codex P2)', async () => {
+    const h = makeHarness({ detached: true });
+    h.controller.setContext(ctx);
+    // 生产路径 openSubagentsTab 用 `?? null` 写 focus 字段,IPC 保留 null
+    const registerBase = {
+      type: 'open-subagents-tab' as const,
+      sessionId: 's1',
+      focusRunId: null,
+      focusProvider: null,
+      focusTab: false,
+      revealSidebar: false,
+    };
+    const registerOnly = (over: Partial<typeof registerBase> = {}) => ({
+      ...registerBase,
+      sessionId: 's1',
+      ...over,
+    });
+    // 连续 5 次静默登记(模拟 detached 关窗期间多次 agent_task_update)
+    for (let i = 0; i < 5; i++) {
+      await h.controller.routeCommand({ command: registerOnly(), allowOpen: false });
+    }
+
+    h.controller.open();
+    h.controller.markReady();
+    expect(h.sends.filter((entry) => entry.channel === 'cmd-channel')).toEqual([
+      { channel: 'cmd-channel', payload: registerBase },
+    ]);
+  });
+
+  it('null 与 undefined 的静默登记互相去重(生产 null / 遗留 undefined 等价)', async () => {
+    const h = makeHarness({ detached: true });
+    h.controller.setContext(ctx);
+    const withNull = {
+      type: 'open-subagents-tab' as const,
+      sessionId: 's1',
+      focusRunId: null,
+      focusProvider: null,
+      focusTab: false,
+      revealSidebar: false,
+    };
+    const withUndefined = {
+      type: 'open-subagents-tab' as const,
+      sessionId: 's1',
+      focusRunId: undefined,
+      focusProvider: undefined,
+      focusTab: false,
+      revealSidebar: false,
+    };
+    await h.controller.routeCommand({ command: withNull, allowOpen: false });
+    await h.controller.routeCommand({ command: withUndefined, allowOpen: false });
+    await h.controller.routeCommand({ command: withNull, allowOpen: false });
+
+    h.controller.open();
+    h.controller.markReady();
+    expect(h.sends.filter((entry) => entry.channel === 'cmd-channel')).toEqual([
+      { channel: 'cmd-channel', payload: withNull },
+    ]);
+  });
+
+  it('带 focus 的 subagent 登记不与其后静默登记合并,静默登记也不覆盖带 focus 登记(#2491 Codex P2)', async () => {
+    const h = makeHarness({ detached: true });
+    h.controller.setContext(ctx);
+    const focused = {
+      type: 'open-subagents-tab' as const,
+      sessionId: 's1',
+      focusRunId: 'run-1',
+      focusProvider: null,
+      focusTab: false,
+      revealSidebar: false,
+    };
+    await h.controller.routeCommand({ command: focused, allowOpen: false });
+    // 带 focus 的登记之后又来一条静默登记:两者语义不同,都应保留
+    const registerOnly = {
+      type: 'open-subagents-tab' as const,
+      sessionId: 's1',
+      focusRunId: null,
+      focusProvider: null,
+      focusTab: false,
+      revealSidebar: false,
+    };
+    await h.controller.routeCommand({ command: registerOnly, allowOpen: false });
+
+    h.controller.open();
+    h.controller.markReady();
+    expect(h.sends.filter((entry) => entry.channel === 'cmd-channel')).toEqual([
+      { channel: 'cmd-channel', payload: focused },
+      { channel: 'cmd-channel', payload: registerOnly },
+    ]);
+  });
+
+  it('ensure 定位意图 last-write-wins:后到显式 ensure 替换尾部 ensure(#2409)', async () => {
+    const h = makeHarness({ detached: true });
+    h.controller.setContext(ctx);
+    const first = {
+      type: 'ensure-orca-workers-tab' as const,
+      sessionId: 's1',
+      focusWorkerSessionId: 'w1',
+      focusTab: false,
+    };
+    const second = {
+      type: 'ensure-orca-workers-tab' as const,
+      sessionId: 's1',
+      focusWorkerSessionId: 'w2',
+      focusTab: false,
+    };
+    await h.controller.routeCommand({ command: first, allowOpen: false });
+    await h.controller.routeCommand({ command: second, allowOpen: false });
+
+    h.controller.open();
+    h.controller.markReady();
+    // Orca 页签单例,worker focus 只能有一个落点:后到的显式 intent 胜出(与旧 set 语义一致)。
+    expect(h.sends.filter((entry) => entry.channel === 'cmd-channel')).toEqual([
+      { channel: 'cmd-channel', payload: second },
+    ]);
+  });
+
+  it('带定位的 ensure 吸收尾部 generic ensure,generic 不追加(#2409)', async () => {
+    const h = makeHarness({ detached: true });
+    h.controller.setContext(ctx);
+    await h.controller.routeCommand({
+      command: { type: 'ensure-orca-workers-tab', sessionId: 's1', focusTab: false },
+      allowOpen: false,
+    });
+    const focused = {
+      type: 'ensure-orca-workers-tab' as const,
+      sessionId: 's1',
+      focusWorkerSessionId: 'w1',
+      focusTab: false,
+    };
+    await h.controller.routeCommand({ command: focused, allowOpen: false });
+
+    h.controller.open();
+    h.controller.markReady();
+    expect(h.sends.filter((entry) => entry.channel === 'cmd-channel')).toEqual([
+      { channel: 'cmd-channel', payload: focused },
+    ]);
+  });
+
+  it('generic ensure 不吸收尾部 close(ensure 在 close 后有真实语义,#2409)', async () => {
+    const h = makeHarness({ detached: true });
+    h.controller.setContext(ctx);
+    await h.controller.routeCommand({
+      command: { type: 'close-orca-workers-tab', sessionId: 's1' },
+      allowOpen: false,
+    });
+    const genericEnsure = {
+      type: 'ensure-orca-workers-tab' as const,
+      sessionId: 's1',
+      focusTab: false,
+    };
+    await h.controller.routeCommand({ command: genericEnsure, allowOpen: false });
+
+    h.controller.open();
+    h.controller.markReady();
+    expect(h.sends.filter((entry) => entry.channel === 'cmd-channel')).toEqual([
+      { channel: 'cmd-channel', payload: { type: 'close-orca-workers-tab', sessionId: 's1' } },
+      { channel: 'cmd-channel', payload: genericEnsure },
+    ]);
+  });
+
+  it('context 切换后旧 session 的整组 intent 全部清理(#2409)', async () => {
+    const h = makeHarness({ detached: true });
+    h.controller.setContext(ctx);
+    await h.controller.routeCommand({
+      command: { type: 'open-subagents-tab', sessionId: 's1' },
+      allowOpen: false,
+    });
+    await h.controller.routeCommand({
+      command: { type: 'close-orca-workers-tab', sessionId: 's1' },
+      allowOpen: false,
+    });
+
+    h.controller.setContext({ ...ctx, sessionId: 's2' });
+    h.controller.open();
+    h.controller.markReady();
+    expect(h.sends.filter((entry) => entry.channel === 'cmd-channel')).toEqual([]);
+  });
 });

--- a/apps/desktop/src/main/right-sidebar-window/__tests__/controller.test.ts
+++ b/apps/desktop/src/main/right-sidebar-window/__tests__/controller.test.ts
@@ -862,7 +862,7 @@ describe('setContext / routeCommand', () => {
     ]);
   });
 
-  it('切回 attached 时 drop 已交付未 ack 桶头,不双执行(Greptile P1)', async () => {
+  it('切回 attached 时整桶含未 ack 桶头转交主窗,不丢 intent(Greptile P1)', async () => {
     const h = makeHarness({ detached: true });
     h.controller.setContext(ctx);
     const closeWorkers = { type: 'close-orca-workers-tab' as const, sessionId: 's1' };
@@ -876,20 +876,22 @@ describe('setContext / routeCommand', () => {
 
     h.controller.open();
     h.controller.markReady();
-    // 子窗已收到 close，尚未 ack
+    // 子窗已收到 close，尚未 ack；子窗即将销毁，其副作用不保留
     expect(h.sends.filter((e) => e.channel === 'cmd-channel').map((e) => e.payload)).toEqual([
       closeWorkers,
     ]);
 
     h.controller.setDetached(false);
-    // close 已交付给子窗：只把剩余 ensure 转交主窗，不重发 close
+    // 整桶（含未 ack 桶头 close + ensure）必须转交主 host，否则 intent 丢失
     expect(h.sends.filter((e) => e.channel === 'cmd-channel').map((e) => e.payload)).toEqual([
-      closeWorkers,
-      genericEnsure,
+      closeWorkers, // 子窗在途
+      closeWorkers, // 主窗重放
+      genericEnsure, // 主窗
     ]);
     expect(h.sendTargets.filter((_, i) => h.sends[i]?.channel === 'cmd-channel')).toEqual([
-      h.windows[0].webContents.id, // close → 子窗
-      h.mainWin.webContents.id, // ensure → 主窗
+      h.windows[0].webContents.id,
+      h.mainWin.webContents.id,
+      h.mainWin.webContents.id,
     ]);
   });
 

--- a/apps/desktop/src/main/right-sidebar-window/controller.ts
+++ b/apps/desktop/src/main/right-sidebar-window/controller.ts
@@ -157,9 +157,10 @@ export class RsbWindowController {
       this.open({ userInitiated: true });
     } else {
       // queued 调用方早已返回；attach 时必须把 ownership 显式交回主 renderer。
-      // 已交付未 ack 的桶头可能已在子窗执行：drop 它再 drain 剩余，避免双执行
-      // （Greptile P1）。无在途时整桶原样转交。
-      this.dropInFlightDetachedHead();
+      // 子窗即将销毁，其 store / 未完成 commandChain 一并作废：在途未 ack 桶头
+      // 也必须转交主窗（主 host），不能 drop——否则 close/open/focus 会永久丢失
+      // （Greptile P1）。仅清在途标记，整桶（含桶头）drain 给 main。
+      this.detachedDeliverySessionId = null;
       this.flushDeferredCommandsToAttachedHost();
       this.close();
     }
@@ -359,21 +360,6 @@ export class RsbWindowController {
     if (this.detachedDeliverySessionId === hostSessionId) return true;
     const bucket = this.deferredCommands.get(hostSessionId);
     return Boolean(bucket && bucket.length > 0);
-  }
-
-  /**
-   * 丢弃已下发未 ack 的桶头并清在途标记。
-   * attach 切换时调用：子窗可能已执行该条，不得再转交主 renderer。
-   */
-  private dropInFlightDetachedHead(): void {
-    const sessionId = this.detachedDeliverySessionId;
-    if (sessionId === null) return;
-    const bucket = this.deferredCommands.get(sessionId);
-    if (bucket && bucket.length > 0) {
-      bucket.shift();
-      if (bucket.length === 0) this.deferredCommands.delete(sessionId);
-    }
-    this.detachedDeliverySessionId = null;
   }
 
   /**

--- a/apps/desktop/src/main/right-sidebar-window/controller.ts
+++ b/apps/desktop/src/main/right-sidebar-window/controller.ts
@@ -157,8 +157,9 @@ export class RsbWindowController {
       this.open({ userInitiated: true });
     } else {
       // queued 调用方早已返回；attach 时必须把 ownership 显式交回主 renderer。
-      // 丢弃 detached 在途标记：剩余桶（含未 ack 桶头）整组转交主窗。
-      this.detachedDeliverySessionId = null;
+      // 已交付未 ack 的桶头可能已在子窗执行：drop 它再 drain 剩余，避免双执行
+      // （Greptile P1）。无在途时整桶原样转交。
+      this.dropInFlightDetachedHead();
       this.flushDeferredCommandsToAttachedHost();
       this.close();
     }
@@ -288,6 +289,15 @@ export class RsbWindowController {
       return 'stale-context';
     }
 
+    // 已有 deferred 在途或同 session 桶内仍有尾部时，直播命令也入同一桶，
+    // 避免直发 B 与无参 ack 误推进未完成的 C（Codex P1）。
+    const hostSessionId = commandHostSessionId(command);
+    if (this.hasDetachedDeferredPending(hostSessionId)) {
+      this.enqueueDeferredCommand(command);
+      this.flushDeferredCommandsToDetachedHost();
+      return 'queued';
+    }
+
     this.deps.sendToWindow(this.winRef, this.deps.commandChannel, command);
     return 'routed';
   }
@@ -344,6 +354,28 @@ export class RsbWindowController {
     bucket.push(command);
   }
 
+  /** 同 host session 是否有 detached deferred 在途或桶内尾部。 */
+  private hasDetachedDeferredPending(hostSessionId: string): boolean {
+    if (this.detachedDeliverySessionId === hostSessionId) return true;
+    const bucket = this.deferredCommands.get(hostSessionId);
+    return Boolean(bucket && bucket.length > 0);
+  }
+
+  /**
+   * 丢弃已下发未 ack 的桶头并清在途标记。
+   * attach 切换时调用：子窗可能已执行该条，不得再转交主 renderer。
+   */
+  private dropInFlightDetachedHead(): void {
+    const sessionId = this.detachedDeliverySessionId;
+    if (sessionId === null) return;
+    const bucket = this.deferredCommands.get(sessionId);
+    if (bucket && bucket.length > 0) {
+      bucket.shift();
+      if (bucket.length === 0) this.deferredCommands.delete(sessionId);
+    }
+    this.detachedDeliverySessionId = null;
+  }
+
   /**
    * attached 路径：主 renderer 常驻，整桶按序一次下发即可。
    * detached 不得走这里（见 flushDeferredCommandsToDetachedHost 的单条 + ack）。
@@ -384,7 +416,7 @@ export class RsbWindowController {
 
   /**
    * 子窗口 renderer 确认当前 deferred 命令已消费后推进桶头并继续下一条。
-   * 无在途交付时 no-op（直播 routeCommand 单条命令也会触发 ack，安全忽略）。
+   * 无在途交付时 no-op（无 deferred 时的直播 route 命令也会触发 ack，安全忽略）。
    */
   ackDetachedDeferredCommand(): void {
     const sessionId = this.detachedDeliverySessionId;

--- a/apps/desktop/src/main/right-sidebar-window/controller.ts
+++ b/apps/desktop/src/main/right-sidebar-window/controller.ts
@@ -84,6 +84,12 @@ export class RsbWindowController {
   private lastContext: RsbWindowContext | null = null;
   /** allowOpen=false 时每个 host session 保留一组有序 intent（登记类命令不被后到命令顶掉）。 */
   private deferredCommands = new Map<string, RsbWindowCommand[]>();
+  /**
+   * detached 桶头在途交付标记：只在 renderer ack 后才 shift 桶头。
+   * 关窗 / session 切换时清标记但不丢桶，未确认的 intent 可在下次 flush 重发
+   * （Codex P1：确认消费前不得删除整桶）。
+   */
+  private detachedDeliverySessionId: string | null = null;
   private closeWaiters: Array<() => void> = [];
 
   constructor(private readonly deps: RsbWindowControllerDeps) {}
@@ -151,6 +157,8 @@ export class RsbWindowController {
       this.open({ userInitiated: true });
     } else {
       // queued 调用方早已返回；attach 时必须把 ownership 显式交回主 renderer。
+      // 丢弃 detached 在途标记：剩余桶（含未 ack 桶头）整组转交主窗。
+      this.detachedDeliverySessionId = null;
       this.flushDeferredCommandsToAttachedHost();
       this.close();
     }
@@ -199,9 +207,14 @@ export class RsbWindowController {
     this.lastContext = ctx;
     if (!ctx.available || !ctx.sessionId) {
       this.deferredCommands.clear();
+      this.detachedDeliverySessionId = null;
     } else if (previousSessionId !== ctx.sessionId) {
       for (const sessionId of this.deferredCommands.keys()) {
         if (sessionId !== ctx.sessionId) this.deferredCommands.delete(sessionId);
+      }
+      // 旧 session 的在途交付作废；桶已按 session 清掉，标记也必须对齐。
+      if (this.detachedDeliverySessionId !== ctx.sessionId) {
+        this.detachedDeliverySessionId = null;
       }
     }
     if (this.winRef && !this.winRef.isDestroyed() && !this.closing) {
@@ -331,7 +344,10 @@ export class RsbWindowController {
     bucket.push(command);
   }
 
-  /** 取当前 context session 的整桶 deferred intent,按序全部交给 send。 */
+  /**
+   * attached 路径：主 renderer 常驻，整桶按序一次下发即可。
+   * detached 不得走这里（见 flushDeferredCommandsToDetachedHost 的单条 + ack）。
+   */
   private drainCurrentSessionDeferred(send: (command: RsbWindowCommand) => void): void {
     const sessionId = this.lastContext?.available ? this.lastContext.sessionId : null;
     if (!sessionId) return;
@@ -341,6 +357,11 @@ export class RsbWindowController {
     for (const command of bucket) send(command);
   }
 
+  /**
+   * detached 路径：一次只下发桶头，ack 前保留整桶（含桶头）。
+   * 关窗销毁 BrowserWindow 时未 ack 的尾部 intent 仍在 main 桶内，可再次 flush
+   * （Codex P1：串行消费者未启动的尾部不得随窗口永久丢失）。
+   */
   private flushDeferredCommandsToDetachedHost(): void {
     if (
       !this.deps.settings.read().detached ||
@@ -351,9 +372,30 @@ export class RsbWindowController {
     ) {
       return;
     }
-    this.drainCurrentSessionDeferred((command) => {
-      this.deps.sendToWindow(this.winRef!, this.deps.commandChannel, command);
-    });
+    if (this.detachedDeliverySessionId !== null) return;
+    const sessionId = this.lastContext?.available ? this.lastContext.sessionId : null;
+    if (!sessionId) return;
+    const bucket = this.deferredCommands.get(sessionId);
+    if (!bucket || bucket.length === 0) return;
+    const command = bucket[0];
+    this.detachedDeliverySessionId = sessionId;
+    this.deps.sendToWindow(this.winRef, this.deps.commandChannel, command);
+  }
+
+  /**
+   * 子窗口 renderer 确认当前 deferred 命令已消费后推进桶头并继续下一条。
+   * 无在途交付时 no-op（直播 routeCommand 单条命令也会触发 ack，安全忽略）。
+   */
+  ackDetachedDeferredCommand(): void {
+    const sessionId = this.detachedDeliverySessionId;
+    if (sessionId === null) return;
+    const bucket = this.deferredCommands.get(sessionId);
+    if (bucket && bucket.length > 0) {
+      bucket.shift();
+      if (bucket.length === 0) this.deferredCommands.delete(sessionId);
+    }
+    this.detachedDeliverySessionId = null;
+    this.flushDeferredCommandsToDetachedHost();
   }
 
   private flushDeferredCommandsToAttachedHost(): void {
@@ -402,6 +444,8 @@ export class RsbWindowController {
     this.winRef = null;
     this.ready = false;
     this.closing = false;
+    // 未 ack 的桶头/尾部仍在 deferredCommands；仅清在途标记，下次 open+ready 重发。
+    this.detachedDeliverySessionId = null;
     const closeWaiters = this.closeWaiters.splice(0);
     closeWaiters.forEach((resolve) => resolve());
     // 悬着的 ready 等待全部失败(窗口没等到挂载就没了)

--- a/apps/desktop/src/main/right-sidebar-window/controller.ts
+++ b/apps/desktop/src/main/right-sidebar-window/controller.ts
@@ -82,8 +82,8 @@ export class RsbWindowController {
     timeout: NodeJS.Timeout;
   }> = [];
   private lastContext: RsbWindowContext | null = null;
-  /** allowOpen=false 时每个 session 只保留最终有效命令，避免 remote memory intent 丢失。 */
-  private deferredCommands = new Map<string, RsbWindowCommand>();
+  /** allowOpen=false 时每个 host session 保留一组有序 intent（登记类命令不被后到命令顶掉）。 */
+  private deferredCommands = new Map<string, RsbWindowCommand[]>();
   private closeWaiters: Array<() => void> = [];
 
   constructor(private readonly deps: RsbWindowControllerDeps) {}
@@ -283,23 +283,62 @@ export class RsbWindowController {
     // 按宿主桶排队:跨会话 open-turn-review 属于 lead 的桶,须由 lead 上下文
     // flush;按 worker sessionId 入队会在 context 保持 lead 时永远刷不出来。
     const hostSessionId = commandHostSessionId(command);
-    const previous = this.deferredCommands.get(hostSessionId);
-    if (
-      command.type === 'ensure-orca-workers-tab' &&
-      previous?.type === 'ensure-orca-workers-tab' &&
-      command.focusWorkerSessionId === undefined &&
-      command.searchJump === undefined
-    ) {
+    const bucket = this.deferredCommands.get(hostSessionId);
+    if (!bucket) {
+      if (this.deferredCommands.size >= MAX_DEFERRED_SESSIONS) {
+        const oldest = this.deferredCommands.keys().next().value as string | undefined;
+        if (oldest) this.deferredCommands.delete(oldest);
+      }
+      this.deferredCommands.set(hostSessionId, [command]);
       return;
     }
-    if (
-      !this.deferredCommands.has(hostSessionId) &&
-      this.deferredCommands.size >= MAX_DEFERRED_SESSIONS
-    ) {
-      const oldest = this.deferredCommands.keys().next().value as string | undefined;
-      if (oldest) this.deferredCommands.delete(oldest);
+    // Orca 页签单例 coalescing(#2409):只与紧邻尾部同类命令合并,其余不同语义
+    // 命令保序追加、绝不互相覆盖(登记类 intent 不被后到 passive 命令顶掉)。
+    //  - 带定位的 ensure(focus/searchJump)蕴含「打开」:最新聚焦意图覆盖尾部 ensure;
+    //  - 无定位的 generic ensure:尾部已是 ensure 时被吸收(等价重复,或该 generic
+    //    不如尾部更具体的 worker/search intent,保护具体 intent 不被抹掉);
+    //    尾部是 close 等非 ensure 命令时照常追加(ensure 在 close 后有真实语义)。
+    if (command.type === 'ensure-orca-workers-tab') {
+      const last = bucket[bucket.length - 1];
+      const isGeneric = command.focusWorkerSessionId === undefined && command.searchJump === undefined;
+      if (last?.type === 'ensure-orca-workers-tab') {
+        if (isGeneric) return;
+        bucket[bucket.length - 1] = command;
+        return;
+      }
     }
-    this.deferredCommands.set(hostSessionId, command);
+    // Subagent 静默登记是固定常量(SUBAGENT_TAB_REGISTER_ONLY:revealSidebar=false、
+    // 无 focus 参数),detached 关窗期间每次 agent_task_update 都会再次入队(历史挂载 +
+    // 实时更新,见 CCAgentSessionView)。openSubagentsTab 用 `?? null` 显式写 focus
+    // 字段,IPC 也保留 null,故 null 与 undefined 都视为「无 focus」(Codex P1)。
+    // 连续等价静默登记只保留一条,避免队列无限堆积、开窗时重复执行。
+    if (command.type === 'open-subagents-tab') {
+      const last = bucket[bucket.length - 1];
+      const isRegisterOnly =
+        command.revealSidebar === false &&
+        command.focusRunId == null &&
+        command.focusProvider == null;
+      if (
+        isRegisterOnly &&
+        last?.type === 'open-subagents-tab' &&
+        last.revealSidebar === false &&
+        last.focusRunId == null &&
+        last.focusProvider == null
+      ) {
+        return;
+      }
+    }
+    bucket.push(command);
+  }
+
+  /** 取当前 context session 的整桶 deferred intent,按序全部交给 send。 */
+  private drainCurrentSessionDeferred(send: (command: RsbWindowCommand) => void): void {
+    const sessionId = this.lastContext?.available ? this.lastContext.sessionId : null;
+    if (!sessionId) return;
+    const bucket = this.deferredCommands.get(sessionId);
+    if (!bucket || bucket.length === 0) return;
+    this.deferredCommands.delete(sessionId);
+    for (const command of bucket) send(command);
   }
 
   private flushDeferredCommandsToDetachedHost(): void {
@@ -312,24 +351,18 @@ export class RsbWindowController {
     ) {
       return;
     }
-    const sessionId = this.lastContext?.available ? this.lastContext.sessionId : null;
-    if (!sessionId) return;
-    const command = this.deferredCommands.get(sessionId);
-    if (!command) return;
-    this.deferredCommands.delete(sessionId);
-    this.deps.sendToWindow(this.winRef, this.deps.commandChannel, command);
+    this.drainCurrentSessionDeferred((command) => {
+      this.deps.sendToWindow(this.winRef!, this.deps.commandChannel, command);
+    });
   }
 
   private flushDeferredCommandsToAttachedHost(): void {
     if (this.deps.settings.read().detached) return;
-    const sessionId = this.lastContext?.available ? this.lastContext.sessionId : null;
-    if (!sessionId) return;
-    const command = this.deferredCommands.get(sessionId);
-    if (!command) return;
     const main = this.deps.getMainWindow();
     if (!main || main.isDestroyed()) return;
-    this.deferredCommands.delete(sessionId);
-    this.deps.sendToWindow(main, this.deps.commandChannel, command);
+    this.drainCurrentSessionDeferred((command) => {
+      this.deps.sendToWindow(main, this.deps.commandChannel, command);
+    });
   }
 
   private waitUntilClosed(): Promise<void> {

--- a/apps/desktop/src/main/right-sidebar-window/ipc.ts
+++ b/apps/desktop/src/main/right-sidebar-window/ipc.ts
@@ -290,6 +290,16 @@ export function registerRsbWindowIpc(opts: {
     controller.markReady();
   });
 
+  ipcMain.handle(MAKER_INVOKE.RSB_WINDOW_ACK_COMMAND, (event) => {
+    // 仅子窗口可确认 detached deferred 消费；主窗误调忽略。
+    const sidebarWc = controller.getSidebarWebContents();
+    if (!sidebarWc || event.sender !== sidebarWc) {
+      log.warn('RSB_WINDOW_ACK_COMMAND from non-sidebar sender, ignored');
+      return;
+    }
+    controller.ackDetachedDeferredCommand();
+  });
+
   ipcMain.handle(MAKER_INVOKE.RSB_WINDOW_SEND_COMMAND, async (event, payload: unknown) => {
     // 参数错误无论 sender 身份都按 IPC 契约抛 INVALID_PARAMS。
     const request = parseCommandRouteRequest(payload);

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -1517,6 +1517,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
     } | null> => ipcRenderer.invoke('maker:rsb-window:get-context'),
     /** 子窗口根组件挂载握手(main 侧 ensureOpen 等它)。 */
     ready: (): Promise<void> => ipcRenderer.invoke('maker:rsb-window:ready'),
+    /** 子窗口确认当前 deferred 命令已消费(推进 main 桶头)。 */
+    ackCommand: (): Promise<void> => ipcRenderer.invoke('maker:rsb-window:ack-command'),
     /** 主窗请求 main 原子裁决命令宿主；必要时 main 开窗、排队或取消 stale intent。 */
     sendCommand: (request: RsbWindowCommandRouteRequest): Promise<RsbWindowCommandRouteResult> =>
       ipcRenderer.invoke('maker:rsb-window:send-command', request),

--- a/apps/desktop/src/renderer/__tests__/orcaRemoteRoutingInvariants.test.ts
+++ b/apps/desktop/src/renderer/__tests__/orcaRemoteRoutingInvariants.test.ts
@@ -149,7 +149,8 @@ describe('orca 远程路由接线不变式', () => {
 
   it('detached 子窗口消费 browser/file/orca intent,主窗口 helper 不直接写子窗宿主 store', () => {
     const layout = read('components/layout/SidebarWindowLayout.tsx');
-    expect(layout).toContain('executeSidebarCommand(cmd)');
+    // 串行消费入口:enqueueSidebarCommand 保证 close→ensure 等顺序 intent 不并发
+    expect(layout).toContain('enqueueSidebarCommand(cmd)');
     const executor = read('features/right-sidebar/lib/executeSidebarCommand.ts');
     expect(executor).toContain("command.type === 'open-web-browser'");
     expect(executor).toContain("command.type === 'open-file-browser'");

--- a/apps/desktop/src/renderer/__tests__/orcaRemoteRoutingInvariants.test.ts
+++ b/apps/desktop/src/renderer/__tests__/orcaRemoteRoutingInvariants.test.ts
@@ -151,6 +151,8 @@ describe('orca 远程路由接线不变式', () => {
     const layout = read('components/layout/SidebarWindowLayout.tsx');
     // 串行消费入口:enqueueSidebarCommand 保证 close→ensure 等顺序 intent 不并发
     expect(layout).toContain('enqueueSidebarCommand(cmd)');
+    // detached deferred 桶头需 ack 后才推进；关窗不丢未确认尾部 intent
+    expect(layout).toContain('ackCommand()');
     const executor = read('features/right-sidebar/lib/executeSidebarCommand.ts');
     expect(executor).toContain("command.type === 'open-web-browser'");
     expect(executor).toContain("command.type === 'open-file-browser'");

--- a/apps/desktop/src/renderer/components/layout/MainLayout.tsx
+++ b/apps/desktop/src/renderer/components/layout/MainLayout.tsx
@@ -56,7 +56,7 @@ import {
 import { didUserCloseDetachedSidebarWindow } from '@/lib/rsbWindowTransitions';
 import { routeSidebarCommand } from '@/features/right-sidebar/lib/detachedSidebarRouting';
 import { openTerminalFromShortcut } from '@/features/right-sidebar/lib/openTerminalShortcut';
-import { executeSidebarCommand } from '@/features/right-sidebar/lib/executeSidebarCommand';
+import { enqueueSidebarCommand } from '@/features/right-sidebar/lib/executeSidebarCommand';
 import { RightSidebarDetach } from '@/components/layout/RightSidebarDetach';
 import { useSidebarResize } from '@/hooks/useSidebarResize';
 import { useSidebarCardMode } from '@/hooks/useSidebarCardMode';
@@ -883,7 +883,7 @@ export function MainLayout() {
     if (isSecondaryWindow()) return;
     return window.electronAPI.rightSidebarWindow.onCommand((command) => {
       if (command.sessionId !== rightSidebarSessionIdRef.current) return;
-      void executeSidebarCommand(command).catch((err) => {
+      void enqueueSidebarCommand(command).catch((err) => {
         applicationMenuLog.warn('execute attached sidebar command failed', err);
       });
     });

--- a/apps/desktop/src/renderer/components/layout/SidebarWindowLayout.tsx
+++ b/apps/desktop/src/renderer/components/layout/SidebarWindowLayout.tsx
@@ -112,7 +112,15 @@ export function SidebarWindowLayout() {
   //   renderer 的 store 消费;远程会话走 memory-only,不能靠主窗 store/SQLite 同步。
   useEffect(() => {
     return window.electronAPI.rightSidebarWindow.onCommand((cmd) => {
-      void enqueueSidebarCommand(cmd).catch((err) => log.warn('sidebar command failed', err));
+      // 串行消费完成后 ack：main 才 shift 桶头并下发下一条 deferred intent。
+      // 直播 route 命令的 ack 在 main 侧无在途交付时 no-op。
+      void enqueueSidebarCommand(cmd)
+        .catch((err) => log.warn('sidebar command failed', err))
+        .finally(() => {
+          void window.electronAPI.rightSidebarWindow.ackCommand().catch((err) => {
+            log.warn('sidebar command ack failed', err);
+          });
+        });
     });
   }, []);
 

--- a/apps/desktop/src/renderer/components/layout/SidebarWindowLayout.tsx
+++ b/apps/desktop/src/renderer/components/layout/SidebarWindowLayout.tsx
@@ -31,7 +31,7 @@ import { PanelRight } from 'lucide-react';
 import { RightSidebarShell } from '@/features/right-sidebar/RightSidebarShell';
 import { useDeviceLinkRemoteProjects } from '@/features/device-link/useDeviceLinkRemoteProjects';
 import { onRequestRightSidebarVisibility } from '@/features/right-sidebar/lib/sidebarCommands';
-import { executeSidebarCommand } from '@/features/right-sidebar/lib/executeSidebarCommand';
+import { enqueueSidebarCommand } from '@/features/right-sidebar/lib/executeSidebarCommand';
 import {
   closeTab,
   getBucket,
@@ -112,7 +112,7 @@ export function SidebarWindowLayout() {
   //   renderer 的 store 消费;远程会话走 memory-only,不能靠主窗 store/SQLite 同步。
   useEffect(() => {
     return window.electronAPI.rightSidebarWindow.onCommand((cmd) => {
-      void executeSidebarCommand(cmd).catch((err) => log.warn('sidebar command failed', err));
+      void enqueueSidebarCommand(cmd).catch((err) => log.warn('sidebar command failed', err));
     });
   }, []);
 

--- a/apps/desktop/src/renderer/features/right-sidebar/lib/__tests__/executeSidebarCommand.test.ts
+++ b/apps/desktop/src/renderer/features/right-sidebar/lib/__tests__/executeSidebarCommand.test.ts
@@ -25,7 +25,7 @@ import {
   closeOrcaWorkersTabAfterTeamEnd,
   ensureOrcaWorkersTab,
 } from '../../plugins/orca-workers/actions';
-import { executeSidebarCommand } from '../executeSidebarCommand';
+import { enqueueSidebarCommand, executeSidebarCommand } from '../executeSidebarCommand';
 import {
   openDirInSidebarFileBrowser,
   openExternalFileInSidebarFileBrowser,
@@ -104,5 +104,30 @@ describe('executeSidebarCommand', () => {
       revealSidebar: true,
       userInitiated: false,
     });
+  });
+
+  it('enqueueSidebarCommand 串行执行:后入命令等前一条完成后再开始(Codex P2)', async () => {
+    const order: string[] = [];
+    const close = closeOrcaWorkersTabAfterTeamEnd as ReturnType<typeof vi.fn>;
+    const ensure = ensureOrcaWorkersTab as ReturnType<typeof vi.fn>;
+    close.mockImplementation(async () => {
+      order.push('close-start');
+      await new Promise((r) => setTimeout(r, 10));
+      order.push('close-end');
+    });
+    ensure.mockImplementation(async () => {
+      order.push('ensure-start');
+    });
+
+    const p1 = enqueueSidebarCommand({ type: 'close-orca-workers-tab', sessionId: 's1' });
+    const p2 = enqueueSidebarCommand({
+      type: 'ensure-orca-workers-tab',
+      sessionId: 's1',
+      focusTab: false,
+    });
+
+    await Promise.all([p1, p2]);
+    // 严格串行:ensure 必须在 close 完成后才开始,不能交错
+    expect(order).toEqual(['close-start', 'close-end', 'ensure-start']);
   });
 });

--- a/apps/desktop/src/renderer/features/right-sidebar/lib/executeSidebarCommand.ts
+++ b/apps/desktop/src/renderer/features/right-sidebar/lib/executeSidebarCommand.ts
@@ -16,6 +16,20 @@ import { openSubagentsTab } from './openSubagentsTab';
 import { openTurnReview } from './openTurnReview';
 import { openUrlInSidebarBrowser } from './openInSidebarBrowser';
 
+// 串行消费队列(Codex P2):main 批量下发的 deferred intent 带顺序语义(如
+// `close-orca-workers-tab` 后接 generic ensure),而两个 onCommand 消费点都
+// `void executeSidebarCommand(...)` 并发启动,close 在真正删除页签前让出执行权、
+// 后到的 ensure 会看到旧页签直接返回,最终状态违背最新 intent。用单条 promise
+// 链把命令排成严格串行,保证同一 renderer 内按到达顺序逐条完成。
+let commandChain: Promise<void> = Promise.resolve();
+
+/** 排入串行消费队列;返回本条命令完成的 Promise(供调用方感知失败)。 */
+export function enqueueSidebarCommand(command: RsbWindowCommand): Promise<void> {
+  const run = commandChain.then(() => executeSidebarCommand(command));
+  commandChain = run.catch(() => undefined);
+  return run;
+}
+
 /** 在 main 已选定的当前 renderer host 中执行命令，不自行选择宿主。 */
 export async function executeSidebarCommand(command: RsbWindowCommand): Promise<void> {
   if (command.type === 'open-web-browser') {

--- a/apps/desktop/src/renderer/vite-env.d.ts
+++ b/apps/desktop/src/renderer/vite-env.d.ts
@@ -1787,6 +1787,8 @@ interface ElectronAPI {
     } | null>;
     /** 子窗口根组件挂载握手。 */
     ready: () => Promise<void>;
+    /** 子窗口确认当前 deferred 命令已消费(推进 main 桶头)。 */
+    ackCommand: () => Promise<void>;
     /** 主窗把命令转发给子窗口(必要时 main 先开窗)。 */
     /** main 原子裁决 attached / routed / queued / stale-context。 */
     sendCommand: (


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 #2409：右栏处于 detached 模式且侧栏窗口关闭 / 未 ready 时，同会话的「登记类」命令（如 `open-subagents-tab` 历史静默登记）可能被随后同会话的另一条 `allowOpen: false` 的命令顶掉，导致这次登记丢失。

原因：`deferredCommands` 是 `Map<hostSessionId, RsbWindowCommand>`，每个会话只保留一条；`enqueueDeferredCommand` 直接 `set` 覆盖（仅对 `ensure-orca-workers-tab` 无参重复帧做了去重豁免）。窗口再打开时只执行后到的那条。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue：修复 #2409
- 本 PR 包含：
  - `deferredCommands` 改为 `Map<hostSessionId, RsbWindowCommand[]>`：每个 host session 保留一组有序 intent，不同语义命令保序追加、绝不互相覆盖；
  - Orca 页签单例 coalescing 保持旧语义：带定位的 `ensure-orca-workers-tab`（`focusWorkerSessionId` / `searchJump`）覆盖尾部 ensure（最新聚焦意图胜出）；无定位 generic ensure 在尾部已是 ensure 时被吸收（等价重复，或不如尾部更具体的 worker/search intent，保护具体 intent 不被抹掉）；尾部是 `close-orca-workers-tab` 等非 ensure 命令时照常追加（ensure 在 close 后有真实语义）；
  - detached / attached 两条 flush 复用同一套 `drainCurrentSessionDeferred`，按序全部下发，避免路径分叉；
  - 保留既有 `MAX_DEFERRED_SESSIONS` 跨 session 淘汰逻辑（经查证经公开 API 实际不可达——`setContext` 切换 session 时已清掉其它会话桶，属防御性兜底，不改动）。
- 明确不包含：不做每会话条数上限（维护者建议若引入需明确溢出策略，当前无溢出风险，YAGNI）；不改 renderer 侧 `openSubagentsTab` 的 attached-only 裁决语义。
- 多端结论（`docs/dev-rules/remote-and-mobile-adaptation.md` § PR 门禁）：
  - **SSH 远程工作区**：不涉及。本改动只改 Desktop main 进程右栏窗口控制器内部队列，与 agent 进程 / 文件 / 会话数据的远程通道无关。
  - **device-link / 远程控制**：不涉及。`packages/device-link` 不承载 RSB command 通道，隧道不转发该队列。
  - **mobile**：不涉及。`apps/mobile` 无右栏子窗口。
- 用户可见变化：detached 模式下同会话多个 deferred intent（如历史 Subagent 登记 + 随后的 Orca 命令）现在都会按序执行，登记不再丢失。
- 是否存在 breaking change：无（纯 main 层队列内部实现，命令契约未变）。

### UI 变化

不涉及：纯 main 层队列内部实现 + renderer 命令串行化，无视觉/交互/文案变化。

引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/right-sidebar-window/__tests__/controller.test.ts
结果：PASS（45 条，含新增 6 条 #2409 回归：同会话多命令按序 flush、切 attached 按序转交、登记不丢失、ensure 定位 last-write-wins、generic 不吸收 close、context 切换整组清理）

pnpm --filter desktop run typecheck
结果：PASS
```

### 手工验证

不涉及（无 UI 变化；全量 `test:unit` 交由 fork client-ci 验证）。

### 未执行的验证

无。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：detached 右栏窗口的 deferred 命令队列（main 层）。
- 回滚方式：revert 本 PR 即可。

Fixes #2409