### PR TITLE
fix(codex): prefer real PowerShell executable on Windows

### DIFF
--- a/packages/maker-core/src/agents/codex/env-builder.test.ts
+++ b/packages/maker-core/src/agents/codex/env-builder.test.ts
@@ -1,3 +1,7 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { AuthAdapter } from '../../interfaces/auth-adapter.js';
@@ -19,6 +23,9 @@ function createAuthAdapter(env: Record<string, string> = {}): AuthAdapter {
 }
 
 describe('buildCodexEnv', () => {
+  const originalPathEntries = Object.entries(process.env).filter(
+    ([key]) => key.toLowerCase() === 'path',
+  );
   const originalNoColor = process.env.NO_COLOR;
   const originalCliColor = process.env.CLICOLOR;
   const originalForceColor = process.env.FORCE_COLOR;
@@ -35,7 +42,71 @@ describe('buildCodexEnv', () => {
     restore('FORCE_COLOR', originalForceColor);
     restore('TERM', originalTerm);
     restore('PSStyle__OutputRendering', originalPsOutputRendering);
+    for (const key of Object.keys(process.env)) {
+      if (key.toLowerCase() === 'path') delete process.env[key];
+    }
+    for (const [key, value] of originalPathEntries) {
+      if (value !== undefined) process.env[key] = value;
+    }
   });
+
+  it.runIf(process.platform === 'win32')(
+    'prioritizes a real pwsh.exe over an earlier pwsh.cmd shim',
+    async () => {
+      const root = await mkdtemp(path.join(tmpdir(), 'cindy-codex-pwsh-'));
+      const shimDir = path.join(root, 'shim');
+      const executableDir = path.join(root, 'PowerShell', '7');
+
+      try {
+        await mkdir(shimDir, { recursive: true });
+        await mkdir(executableDir, { recursive: true });
+        await writeFile(path.join(shimDir, 'pwsh.cmd'), '@echo off\r\n');
+        await writeFile(path.join(executableDir, 'pwsh.exe'), 'test executable placeholder');
+
+        for (const key of Object.keys(process.env)) {
+          if (key.toLowerCase() === 'path') delete process.env[key];
+        }
+        process.env.Path = [shimDir, executableDir].join(path.delimiter);
+
+        const env = await buildCodexEnv(createAuthAdapter(), {});
+        const pathKey = Object.keys(env).find((key) => key.toLowerCase() === 'path');
+
+        expect(pathKey).toBeDefined();
+        expect(env[pathKey!]?.split(path.delimiter)).toEqual([executableDir, shimDir]);
+      } finally {
+        await rm(root, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it.runIf(process.platform === 'win32')(
+    'skips a WindowsApps pwsh.exe alias when a real executable follows it',
+    async () => {
+      const root = await mkdtemp(path.join(tmpdir(), 'cindy-codex-pwsh-alias-'));
+      const aliasDir = path.join(root, 'Microsoft', 'WindowsApps');
+      const executableDir = path.join(root, 'PowerShell', '7');
+
+      try {
+        await mkdir(aliasDir, { recursive: true });
+        await mkdir(executableDir, { recursive: true });
+        await writeFile(path.join(aliasDir, 'pwsh.exe'), 'test app execution alias placeholder');
+        await writeFile(path.join(executableDir, 'pwsh.exe'), 'test executable placeholder');
+
+        for (const key of Object.keys(process.env)) {
+          if (key.toLowerCase() === 'path') delete process.env[key];
+        }
+        process.env.Path = [aliasDir, executableDir].join(path.delimiter);
+
+        const env = await buildCodexEnv(createAuthAdapter(), {});
+        const pathKey = Object.keys(env).find((key) => key.toLowerCase() === 'path');
+
+        expect(pathKey).toBeDefined();
+        expect(env[pathKey!]?.split(path.delimiter)).toEqual([executableDir, aliasDir]);
+      } finally {
+        await rm(root, { recursive: true, force: true });
+      }
+    },
+  );
 
   it('defaults command output to plain text across common CLI color controls', async () => {
     delete process.env.NO_COLOR;

--- a/packages/maker-core/src/agents/codex/env-builder.test.ts
+++ b/packages/maker-core/src/agents/codex/env-builder.test.ts
@@ -141,6 +141,72 @@ describe('buildCodexEnv', () => {
     },
   );
 
+  it.runIf(process.platform === 'win32')(
+    'keeps host-managed PATH prepends ahead of the prioritized PowerShell directory',
+    async () => {
+      const root = await mkdtemp(path.join(tmpdir(), 'cindy-codex-host-path-'));
+      const hostToolsDir = path.join(root, 'host-tools');
+      const shimDir = path.join(root, 'shim');
+      const executableDir = path.join(root, 'PowerShell', '7');
+
+      try {
+        await mkdir(hostToolsDir, { recursive: true });
+        await mkdir(shimDir, { recursive: true });
+        await mkdir(executableDir, { recursive: true });
+        await writeFile(path.join(hostToolsDir, 'rg.exe'), 'host-managed tool');
+        await writeFile(path.join(shimDir, 'pwsh.cmd'), '@echo off\r\n');
+        await writeFile(path.join(executableDir, 'pwsh.exe'), 'test executable placeholder');
+
+        for (const key of Object.keys(process.env)) {
+          if (key.toLowerCase() === 'path') delete process.env[key];
+        }
+        process.env.Path = [shimDir, executableDir].join(path.delimiter);
+
+        const env = await buildCodexEnv(createAuthAdapter(), {
+          pathPrepends: [hostToolsDir],
+        });
+        const pathKey = Object.keys(env).find((key) => key.toLowerCase() === 'path');
+
+        expect(pathKey).toBeDefined();
+        expect(env[pathKey!]?.split(path.delimiter)).toEqual([
+          hostToolsDir,
+          executableDir,
+          shimDir,
+        ]);
+      } finally {
+        await rm(root, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it.runIf(process.platform === 'win32')(
+    'skips arbitrary UNC PATH entries while locating pwsh.exe',
+    async () => {
+      const root = await mkdtemp(path.join(tmpdir(), 'cindy-codex-unc-pwsh-'));
+      const executableDir = path.join(root, 'PowerShell', '7');
+
+      try {
+        await mkdir(executableDir, { recursive: true });
+        await writeFile(path.join(executableDir, 'pwsh.exe'), 'test executable placeholder');
+        for (const key of Object.keys(process.env)) {
+          if (key.toLowerCase() === 'path') delete process.env[key];
+        }
+        process.env.Path = [String.raw`\\offline.example\share`, executableDir].join(
+          path.delimiter,
+        );
+
+        const env = await buildCodexEnv(createAuthAdapter(), {});
+        const pathKey = Object.keys(env).find((key) => key.toLowerCase() === 'path');
+        expect(env[pathKey!]?.split(path.delimiter)).toEqual([
+          executableDir,
+          String.raw`\\offline.example\share`,
+        ]);
+      } finally {
+        await rm(root, { recursive: true, force: true });
+      }
+    },
+  );
+
   it('defaults command output to plain text across common CLI color controls', async () => {
     delete process.env.NO_COLOR;
     delete process.env.CLICOLOR;

--- a/packages/maker-core/src/agents/codex/env-builder.test.ts
+++ b/packages/maker-core/src/agents/codex/env-builder.test.ts
@@ -5,7 +5,7 @@ import path from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { AuthAdapter } from '../../interfaces/auth-adapter.js';
-import { buildCodexEnv } from './env-builder.js';
+import { buildCodexEnv, findFirstWindowsPwshExecutableIndex } from './env-builder.js';
 
 function createAuthAdapter(env: Record<string, string> = {}): AuthAdapter {
   return {
@@ -252,5 +252,23 @@ describe('buildCodexEnv', () => {
     expect(env.FORCE_COLOR).toBe('1');
     expect(env.TERM).toBe('xterm-256color');
     expect(env.PSStyle__OutputRendering).toBe('Ansi');
+  });
+});
+
+describe('findFirstWindowsPwshExecutableIndex', () => {
+  it('stops probing after the first accessible pwsh.exe entry', async () => {
+    const probed: string[] = [];
+
+    const index = await findFirstWindowsPwshExecutableIndex(
+      ['C:\\PowerShell', 'Z:\\slow-mapped-drive'],
+      async (directory) => {
+        probed.push(directory);
+        if (directory === 'C:\\PowerShell') return true;
+        throw new Error('later PATH entries must not be probed');
+      },
+    );
+
+    expect(index).toBe(0);
+    expect(probed).toEqual(['C:\\PowerShell']);
   });
 });

--- a/packages/maker-core/src/agents/codex/env-builder.test.ts
+++ b/packages/maker-core/src/agents/codex/env-builder.test.ts
@@ -108,6 +108,39 @@ describe('buildCodexEnv', () => {
     },
   );
 
+  it.runIf(process.platform === 'win32')(
+    'prioritizes pwsh.exe from a quoted PATH entry',
+    async () => {
+      const root = await mkdtemp(path.join(tmpdir(), 'cindy-codex-pwsh-quoted-'));
+      const shimDir = path.join(root, 'shim');
+      const executableDir = path.join(root, 'PowerShell', '7');
+      const quotedExecutableDir = `"${executableDir}"`;
+
+      try {
+        await mkdir(shimDir, { recursive: true });
+        await mkdir(executableDir, { recursive: true });
+        await writeFile(path.join(shimDir, 'pwsh.cmd'), '@echo off\r\n');
+        await writeFile(path.join(executableDir, 'pwsh.exe'), 'test executable placeholder');
+
+        for (const key of Object.keys(process.env)) {
+          if (key.toLowerCase() === 'path') delete process.env[key];
+        }
+        process.env.Path = [shimDir, quotedExecutableDir].join(path.delimiter);
+
+        const env = await buildCodexEnv(createAuthAdapter(), {});
+        const pathKey = Object.keys(env).find((key) => key.toLowerCase() === 'path');
+
+        expect(pathKey).toBeDefined();
+        expect(env[pathKey!]?.split(path.delimiter)).toEqual([
+          quotedExecutableDir,
+          shimDir,
+        ]);
+      } finally {
+        await rm(root, { recursive: true, force: true });
+      }
+    },
+  );
+
   it('defaults command output to plain text across common CLI color controls', async () => {
     delete process.env.NO_COLOR;
     delete process.env.CLICOLOR;

--- a/packages/maker-core/src/agents/codex/env-builder.ts
+++ b/packages/maker-core/src/agents/codex/env-builder.ts
@@ -62,6 +62,34 @@ async function hasAccessiblePwshExecutable(directory: string): Promise<boolean> 
   }
 }
 
+type PwshExecutableProbe = (directory: string) => Promise<boolean>;
+
+/**
+ * Walk PATH in resolution order and stop as soon as an exact executable is
+ * usable. Besides preserving PATH precedence, the short circuit avoids
+ * starting probes for later mapped drives after the answer is already known.
+ */
+export async function findFirstWindowsPwshExecutableIndex(
+  entries: string[],
+  probe: PwshExecutableProbe = hasAccessiblePwshExecutable,
+): Promise<number> {
+  for (const [index, entry] of entries.entries()) {
+    const trimmed = entry.trim();
+    const directory =
+      trimmed.length >= 2 && trimmed.startsWith('"') && trimmed.endsWith('"')
+        ? trimmed.slice(1, -1).trim()
+        : trimmed;
+    if (directory.length === 0 || isUncPathEntry(directory)) continue;
+
+    const normalized = path.win32.normalize(directory).replace(/[\\/]+$/, '').toLowerCase();
+    if (normalized.endsWith('\\microsoft\\windowsapps')) continue;
+
+    if (await probe(directory)) return index;
+  }
+
+  return -1;
+}
+
 async function prioritizeWindowsPwshExecutable(env: Record<string, string>): Promise<void> {
   if (process.platform !== 'win32') return;
 
@@ -69,20 +97,7 @@ async function prioritizeWindowsPwshExecutable(env: Record<string, string>): Pro
   if (!pathKey || !env[pathKey]) return;
 
   const entries = env[pathKey].split(path.delimiter);
-  const executableChecks = entries.map(async (entry) => {
-    const trimmed = entry.trim();
-    const directory =
-      trimmed.length >= 2 && trimmed.startsWith('"') && trimmed.endsWith('"')
-        ? trimmed.slice(1, -1).trim()
-        : trimmed;
-    if (directory.length === 0 || isUncPathEntry(directory)) return false;
-
-    const normalized = path.win32.normalize(directory).replace(/[\\/]+$/, '').toLowerCase();
-    if (normalized.endsWith('\\microsoft\\windowsapps')) return false;
-
-    return hasAccessiblePwshExecutable(directory);
-  });
-  const executableIndex = (await Promise.all(executableChecks)).findIndex(Boolean);
+  const executableIndex = await findFirstWindowsPwshExecutableIndex(entries);
   if (executableIndex <= 0) return;
 
   const [executableDir] = entries.splice(executableIndex, 1);

--- a/packages/maker-core/src/agents/codex/env-builder.ts
+++ b/packages/maker-core/src/agents/codex/env-builder.ts
@@ -48,12 +48,16 @@ function prioritizeWindowsPwshExecutable(env: Record<string, string>): void {
   const entries = env[pathKey].split(path.delimiter);
   const executableIndex = entries.findIndex((entry) => {
     const trimmed = entry.trim();
-    if (trimmed.length === 0) return false;
+    const directory =
+      trimmed.length >= 2 && trimmed.startsWith('"') && trimmed.endsWith('"')
+        ? trimmed.slice(1, -1).trim()
+        : trimmed;
+    if (directory.length === 0) return false;
 
-    const normalized = path.win32.normalize(trimmed).replace(/[\\/]+$/, '').toLowerCase();
+    const normalized = path.win32.normalize(directory).replace(/[\\/]+$/, '').toLowerCase();
     if (normalized.endsWith('\\microsoft\\windowsapps')) return false;
 
-    return existsSync(path.join(trimmed, 'pwsh.exe'));
+    return existsSync(path.join(directory, 'pwsh.exe'));
   });
   if (executableIndex <= 0) return;
 

--- a/packages/maker-core/src/agents/codex/env-builder.ts
+++ b/packages/maker-core/src/agents/codex/env-builder.ts
@@ -11,6 +11,7 @@
  * 由调用方原样传给 new Codex({ env })。
  */
 
+import { existsSync } from 'node:fs';
 import path from 'node:path';
 
 import type { AgentCredentialMode, AuthAdapter } from '../../interfaces/auth-adapter.js';
@@ -30,6 +31,35 @@ function prependPath(env: Record<string, string>, prepends: string[]): void {
   }
 
   env[key] = [...cleaned, current].filter(Boolean).join(path.delimiter);
+}
+
+/**
+ * Codex resolves `pwsh` from PATH before its absolute Windows fallback. A batch
+ * shim found first is accepted as the shell path, but Rust cannot launch it
+ * with the generated arguments. Prefer the first exact pwsh.exe already on the
+ * user's PATH while preserving every other entry and its relative order.
+ */
+function prioritizeWindowsPwshExecutable(env: Record<string, string>): void {
+  if (process.platform !== 'win32') return;
+
+  const pathKey = Object.keys(env).find((key) => key.toLowerCase() === 'path');
+  if (!pathKey || !env[pathKey]) return;
+
+  const entries = env[pathKey].split(path.delimiter);
+  const executableIndex = entries.findIndex((entry) => {
+    const trimmed = entry.trim();
+    if (trimmed.length === 0) return false;
+
+    const normalized = path.win32.normalize(trimmed).replace(/[\\/]+$/, '').toLowerCase();
+    if (normalized.endsWith('\\microsoft\\windowsapps')) return false;
+
+    return existsSync(path.join(trimmed, 'pwsh.exe'));
+  });
+  if (executableIndex <= 0) return;
+
+  const [executableDir] = entries.splice(executableIndex, 1);
+  entries.unshift(executableDir);
+  env[pathKey] = entries.join(path.delimiter);
 }
 
 export async function buildCodexEnv(
@@ -61,6 +91,7 @@ export async function buildCodexEnv(
     : undefined;
   Object.assign(env, await auth.getAuthEnv(authOptions));
   prependPath(env, runtimeConfig.pathPrepends ?? []);
+  prioritizeWindowsPwshExecutable(env);
 
   // Windows 下 Python piped stdout 默认走 locale encoding(cp936/GBK), 不看 chcp 65001。
   // 强制 UTF-8 避免 Bash 工具执行 python 命令时中文乱码。跨平台设置无副作用。

--- a/packages/maker-core/src/agents/codex/env-builder.ts
+++ b/packages/maker-core/src/agents/codex/env-builder.ts
@@ -11,7 +11,7 @@
  * 由调用方原样传给 new Codex({ env })。
  */
 
-import { existsSync } from 'node:fs';
+import { access } from 'node:fs/promises';
 import path from 'node:path';
 
 import type { AgentCredentialMode, AuthAdapter } from '../../interfaces/auth-adapter.js';
@@ -39,26 +39,50 @@ function prependPath(env: Record<string, string>, prepends: string[]): void {
  * with the generated arguments. Prefer the first exact pwsh.exe already on the
  * user's PATH while preserving every other entry and its relative order.
  */
-function prioritizeWindowsPwshExecutable(env: Record<string, string>): void {
+function isUncPathEntry(directory: string): boolean {
+  return directory.startsWith('\\\\') || directory.startsWith('//');
+}
+
+const PWSH_PATH_PROBE_TIMEOUT_MS = 1_000;
+
+async function hasAccessiblePwshExecutable(directory: string): Promise<boolean> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      access(path.join(directory, 'pwsh.exe')).then(
+        () => true,
+        () => false,
+      ),
+      new Promise<boolean>((resolve) => {
+        timeout = setTimeout(() => resolve(false), PWSH_PATH_PROBE_TIMEOUT_MS);
+      }),
+    ]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
+
+async function prioritizeWindowsPwshExecutable(env: Record<string, string>): Promise<void> {
   if (process.platform !== 'win32') return;
 
   const pathKey = Object.keys(env).find((key) => key.toLowerCase() === 'path');
   if (!pathKey || !env[pathKey]) return;
 
   const entries = env[pathKey].split(path.delimiter);
-  const executableIndex = entries.findIndex((entry) => {
+  const executableChecks = entries.map(async (entry) => {
     const trimmed = entry.trim();
     const directory =
       trimmed.length >= 2 && trimmed.startsWith('"') && trimmed.endsWith('"')
         ? trimmed.slice(1, -1).trim()
         : trimmed;
-    if (directory.length === 0) return false;
+    if (directory.length === 0 || isUncPathEntry(directory)) return false;
 
     const normalized = path.win32.normalize(directory).replace(/[\\/]+$/, '').toLowerCase();
     if (normalized.endsWith('\\microsoft\\windowsapps')) return false;
 
-    return existsSync(path.join(directory, 'pwsh.exe'));
+    return hasAccessiblePwshExecutable(directory);
   });
+  const executableIndex = (await Promise.all(executableChecks)).findIndex(Boolean);
   if (executableIndex <= 0) return;
 
   const [executableDir] = entries.splice(executableIndex, 1);
@@ -94,8 +118,8 @@ export async function buildCodexEnv(
     ? { credentialMode: options.credentialMode }
     : undefined;
   Object.assign(env, await auth.getAuthEnv(authOptions));
+  await prioritizeWindowsPwshExecutable(env);
   prependPath(env, runtimeConfig.pathPrepends ?? []);
-  prioritizeWindowsPwshExecutable(env);
 
   // Windows 下 Python piped stdout 默认走 locale encoding(cp936/GBK), 不看 chcp 65001。
   // 强制 UTF-8 避免 Bash 工具执行 python 命令时中文乱码。跨平台设置无副作用。

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -3152,12 +3152,15 @@ describe('CodexAgent.refreshLocalModels', () => {
     vi.useFakeTimers();
     try {
       MockCodexTransport.dropModelList = true;
+      const transportCreated = new Promise<void>((resolve) => {
+        MockCodexTransport.onCreate = () => resolve();
+      });
       const agent = new CodexAgent(createDeps());
       const refresh = agent.refreshLocalModels({ credentialMode: 'oauth-bearer' });
       const refreshExpectation = expect(refresh).rejects.toThrow(
         'codex app-server model refresh timed out after 20000ms',
       );
-      await vi.advanceTimersByTimeAsync(0);
+      await transportCreated;
       await vi.advanceTimersByTimeAsync(20_000);
 
       await refreshExpectation;
@@ -3176,6 +3179,9 @@ describe('CodexAgent.refreshLocalModels', () => {
     vi.useFakeTimers();
     try {
       MockCodexTransport.dropInitialize = true;
+      const transportCreated = new Promise<void>((resolve) => {
+        MockCodexTransport.onCreate = () => resolve();
+      });
       const agent = new CodexAgent(createDeps({}, {
         onCodexLocalModelsListed: vi.fn().mockResolvedValue(undefined),
       }));
@@ -3183,7 +3189,7 @@ describe('CodexAgent.refreshLocalModels', () => {
       const refreshExpectation = expect(refresh).rejects.toThrow(
         'codex app-server model refresh timed out after 20000ms',
       );
-      await vi.advanceTimersByTimeAsync(0);
+      await transportCreated;
       await vi.advanceTimersByTimeAsync(20_000);
 
       await refreshExpectation;


### PR DESCRIPTION
## 这次改了什么

Fixes #2446

- 在 Windows 上构建 Codex 子进程环境时，优先把包含真实 `pwsh.exe` 的目录放到 `PATH` 首位。
- 跳过 Microsoft Store 的 `WindowsApps` alias，避免 Codex 选中 `pwsh.cmd` shim 或无效 alias 后让所有 shell 命令报 `batch file arguments are invalid`。
- 正确识别被双引号包裹的 PATH 目录：探测时移除一对外围引号，重排时保留原始 PATH 条目。
- 按 PATH 顺序探测；找到第一个真实 `pwsh.exe` 后立即停止，不再访问后续（包括慢速或不可达 mapped drive）条目。
- 非 Windows 平台行为保持不变。
- 增加针对 `.cmd` shim、`WindowsApps` alias、带引号真实 PowerShell 目录和首命中短路的回归测试。

## 怎么验证的

最终冻结 tree：`b7bf0a23ffefe2aaf6298dcda832ce49ce248b58`（Windows D 盘干净门禁 checkout）

- env-builder 定向测试：9/9 通过
- Codex control-plane deadline 回归：2/2 通过
- 变更文件 ESLint：通过
- maker-core typecheck：exit 0
- `pnpm test:unit -- --workspace-concurrency=1`：exit 0；Desktop、Mobile、maker-core 及全部 required workspaces PASS
- 门禁使用 Python 3.10.11，完整日志保存在本机 D 盘门禁日志目录
- `pnpm check:dco`：4 个 PR commits 均通过

## 风险与回滚

- 影响范围仅为 Windows 上启动的 Codex 子进程环境；不会修改用户持久化环境变量。
- 短路策略保持 PATH 的优先级语义，并避免对首个可用解释器之后的路径做无必要 I/O。
- macOS/Linux 不进入该逻辑。
- 如需回滚，可直接 revert 本 PR 的提交。

## UI

- 不涉及 UI、文案或视觉改动。
