### PR TITLE
fix(desktop): explain XD tool-result image loss

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/xdToolResultImageNotice.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/xdToolResultImageNotice.test.ts
@@ -42,17 +42,23 @@ describe('XD tool-result image notice', () => {
     () => 'https://gateway.example.com/anthropic/',
   );
 
-  it('replaces XD-routed tool-result images without exposing image bytes', () => {
-    const output = transform(request(), context('https://gateway.example.com:443/anthropic'));
-    const json = JSON.stringify(output);
+  it.each(['codex/gpt-5.6-sol', 'gpt-5.6-sol'])(
+    'replaces XD-routed %s tool-result images without exposing image bytes',
+    (model) => {
+      const output = transform(
+        request(model),
+        context('https://gateway.example.com:443/anthropic'),
+      );
+      const json = JSON.stringify(output);
 
-    expect(output).not.toBeNull();
-    expect(json).toContain('image metadata');
-    expect(json).toContain('current route cannot deliver images inside tool results');
-    expect(json).toContain('attach it directly to the conversation');
-    expect(json).not.toContain('SECRET_IMAGE_BYTES');
-    expect(json).not.toContain('text-only');
-  });
+      expect(output).not.toBeNull();
+      expect(json).toContain('image metadata');
+      expect(json).toContain('current route cannot deliver images inside tool results');
+      expect(json).toContain('attach it directly to the conversation');
+      expect(json).not.toContain('SECRET_IMAGE_BYTES');
+      expect(json).not.toContain('text-only');
+    },
+  );
 
   it('does not change the same model on a custom provider route', () => {
     expect(transform(request(), context('https://custom.example.com/v1'))).toBeNull();

--- a/apps/desktop/src/main/maker-host/__tests__/xdToolResultImageNotice.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/xdToolResultImageNotice.test.ts
@@ -42,7 +42,7 @@ describe('XD tool-result image notice', () => {
     () => 'https://gateway.example.com/anthropic/',
   );
 
-  it.each(['codex/gpt-5.6-sol', 'gpt-5.6-sol'])(
+  it.each(['codex/gpt-5.6-sol', 'gpt-5.6-sol', 'gpt-5.6-sol[1m]'])(
     'replaces XD-routed %s tool-result images without exposing image bytes',
     (model) => {
       const output = transform(

--- a/apps/desktop/src/main/maker-host/__tests__/xdToolResultImageNotice.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/xdToolResultImageNotice.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+
+import type { RequestTransformCtx } from '@cindy/anthropic-compat-proxy';
+
+import { createXdToolResultImageNoticeTransform } from '../xd-tool-result-image-notice.js';
+
+const imageBlock = {
+  type: 'image',
+  source: { type: 'base64', media_type: 'image/png', data: 'SECRET_IMAGE_BYTES' },
+};
+
+function context(upstreamBase: string): RequestTransformCtx {
+  return {
+    reqId: 1,
+    method: 'POST',
+    url: '/v1/messages',
+    headers: {},
+    upstreamBase,
+  };
+}
+
+function request(model = 'codex/gpt-5.6-sol'): Record<string, unknown> {
+  return {
+    model,
+    messages: [
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'read-1',
+            content: [{ type: 'text', text: 'image metadata' }, imageBlock],
+          },
+        ],
+      },
+    ],
+  };
+}
+
+describe('XD tool-result image notice', () => {
+  const transform = createXdToolResultImageNoticeTransform(
+    () => 'https://gateway.example.com/anthropic/',
+  );
+
+  it('replaces XD-routed tool-result images without exposing image bytes', () => {
+    const output = transform(request(), context('https://gateway.example.com:443/anthropic'));
+    const json = JSON.stringify(output);
+
+    expect(output).not.toBeNull();
+    expect(json).toContain('image metadata');
+    expect(json).toContain('current route cannot deliver images inside tool results');
+    expect(json).toContain('attach it directly to the conversation');
+    expect(json).not.toContain('SECRET_IMAGE_BYTES');
+    expect(json).not.toContain('text-only');
+  });
+
+  it('does not change the same model on a custom provider route', () => {
+    expect(transform(request(), context('https://custom.example.com/v1'))).toBeNull();
+  });
+
+  it('does not change other models or ordinary user images', () => {
+    expect(
+      transform(request('claude-opus-5'), context('https://gateway.example.com/anthropic')),
+    ).toBeNull();
+    expect(
+      transform(
+        {
+          model: 'codex/gpt-5.6-sol',
+          messages: [{ role: 'user', content: [imageBlock] }],
+        },
+        context('https://gateway.example.com/anthropic'),
+      ),
+    ).toBeNull();
+  });
+});

--- a/apps/desktop/src/main/maker-host/anthropic-compat-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/anthropic-compat-proxy-host.ts
@@ -103,6 +103,7 @@ import {
   authenticatePiProxySession,
   getPiProxySessionProvider,
 } from './pi-proxy-session-auth.js';
+import { createXdToolResultImageNoticeTransform } from './xd-tool-result-image-notice.js';
 
 // scope = 'cc-proxy' → logger.ts 的 emit() 路由把这条流量并入统一 agent 流
 // (agent-*.ndjson, source=proxy)。child(sub) 会继续保持 'cc-proxy/sub' 前缀, routing 一致。
@@ -596,6 +597,7 @@ export async function ensureAnthropicCompatProxyReady(): Promise<void> {
         // image block、不碰 tool_use 结构，位于 repair/dedupe 之后安全；未命中时返回 null，
         // 旧 #794 strip 继续兜底。
         buildVisionBridgeProxyTransform(log),
+        createXdToolResultImageNoticeTransform(claudeUpstreamEndpoint),
         // PI / Claude 走本 proxy 的 /responses 时（Gateway grok、自定义 LiteLLM）
         // 不会经过 Codex 的 xAI 订阅 transform，必须在这里洗 ModelInput。
         createActiveStripTransform({

--- a/apps/desktop/src/main/maker-host/xd-tool-result-image-notice.ts
+++ b/apps/desktop/src/main/maker-host/xd-tool-result-image-notice.ts
@@ -33,13 +33,9 @@ export function createXdToolResultImageNoticeTransform(
   readXdUpstream: () => string,
 ): RequestTransform {
   return (body, ctx) => {
-    if (
-      !isPlainObject(body) ||
-      typeof body.model !== 'string' ||
-      !XD_TOOL_RESULT_IMAGE_MODELS.has(body.model)
-    ) {
-      return null;
-    }
+    if (!isPlainObject(body) || typeof body.model !== 'string') return null;
+    const model = body.model.endsWith('[1m]') ? body.model.slice(0, -4) : body.model;
+    if (!XD_TOOL_RESULT_IMAGE_MODELS.has(model)) return null;
     const actualUpstream = ctx.upstreamBase ? normalizeUpstreamBase(ctx.upstreamBase) : null;
     const xdUpstream = normalizeUpstreamBase(readXdUpstream());
     if (!actualUpstream || actualUpstream !== xdUpstream) return null;

--- a/apps/desktop/src/main/maker-host/xd-tool-result-image-notice.ts
+++ b/apps/desktop/src/main/maker-host/xd-tool-result-image-notice.ts
@@ -3,7 +3,7 @@ import {
   type RequestTransform,
 } from '@cindy/anthropic-compat-proxy';
 
-const XD_TOOL_RESULT_IMAGE_MODEL = 'codex/gpt-5.6-sol';
+const XD_TOOL_RESULT_IMAGE_MODELS = new Set(['codex/gpt-5.6-sol', 'gpt-5.6-sol']);
 const XD_TOOL_RESULT_IMAGE_NOTICE =
   '[image omitted: this tool returned an image, but the current route cannot deliver ' +
   'images inside tool results. Do NOT guess or fabricate what the image contains. ' +
@@ -33,7 +33,13 @@ export function createXdToolResultImageNoticeTransform(
   readXdUpstream: () => string,
 ): RequestTransform {
   return (body, ctx) => {
-    if (!isPlainObject(body) || body.model !== XD_TOOL_RESULT_IMAGE_MODEL) return null;
+    if (
+      !isPlainObject(body) ||
+      typeof body.model !== 'string' ||
+      !XD_TOOL_RESULT_IMAGE_MODELS.has(body.model)
+    ) {
+      return null;
+    }
     const actualUpstream = ctx.upstreamBase ? normalizeUpstreamBase(ctx.upstreamBase) : null;
     const xdUpstream = normalizeUpstreamBase(readXdUpstream());
     if (!actualUpstream || actualUpstream !== xdUpstream) return null;

--- a/apps/desktop/src/main/maker-host/xd-tool-result-image-notice.ts
+++ b/apps/desktop/src/main/maker-host/xd-tool-result-image-notice.ts
@@ -1,0 +1,42 @@
+import {
+  replaceToolResultImagesWithNotice,
+  type RequestTransform,
+} from '@cindy/anthropic-compat-proxy';
+
+const XD_TOOL_RESULT_IMAGE_MODEL = 'codex/gpt-5.6-sol';
+const XD_TOOL_RESULT_IMAGE_NOTICE =
+  '[image omitted: this tool returned an image, but the current route cannot deliver ' +
+  'images inside tool results. Do NOT guess or fabricate what the image contains. ' +
+  'Tell the user the image could not be delivered through the current route, and ask ' +
+  'them to attach it directly to the conversation.]';
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function normalizeUpstreamBase(value: string): string | null {
+  try {
+    const url = new URL(value.trim());
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') return null;
+    const port = url.port || (url.protocol === 'https:' ? '443' : '80');
+    return `${url.protocol}//${url.hostname}:${port}${url.pathname.replace(/\/+$/, '')}${url.search}`;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Keep XD's known tool-result image limitation non-silent without changing other
+ * providers or the subscription bridge, which have different transport semantics.
+ */
+export function createXdToolResultImageNoticeTransform(
+  readXdUpstream: () => string,
+): RequestTransform {
+  return (body, ctx) => {
+    if (!isPlainObject(body) || body.model !== XD_TOOL_RESULT_IMAGE_MODEL) return null;
+    const actualUpstream = ctx.upstreamBase ? normalizeUpstreamBase(ctx.upstreamBase) : null;
+    const xdUpstream = normalizeUpstreamBase(readXdUpstream());
+    if (!actualUpstream || actualUpstream !== xdUpstream) return null;
+    return replaceToolResultImagesWithNotice(body, XD_TOOL_RESULT_IMAGE_NOTICE);
+  };
+}

--- a/packages/anthropic-compat-proxy/src/index.ts
+++ b/packages/anthropic-compat-proxy/src/index.ts
@@ -48,6 +48,7 @@ export {
   repairToolExchangeAdjacency,
   repairToolExchangeAdjacencyFromBody,
   repairToolExchangeStructureFromBody,
+  replaceToolResultImagesWithNotice,
   stripEmptyAssistantMessagesFromBody,
   stripEmptyTextFromBody,
   stripEmptyThinkingFromBody,

--- a/packages/anthropic-compat-proxy/src/transform.ts
+++ b/packages/anthropic-compat-proxy/src/transform.ts
@@ -1122,8 +1122,9 @@ const TOOL_RESULT_IMAGE_OMITTED_TEXT =
   + 'and ask them to paste the relevant content as text or switch to a vision-capable '
   + 'model.]';
 
-function replaceToolResultImagesWithNotice(
+export function replaceToolResultImagesWithNotice(
   body: Record<string, unknown>,
+  noticeText = TOOL_RESULT_IMAGE_OMITTED_TEXT,
 ): Record<string, unknown> | null {
   const messages = body.messages;
   if (!Array.isArray(messages)) return null;
@@ -1141,7 +1142,7 @@ function replaceToolResultImagesWithNotice(
         if (!isPlainObject(inner) || inner.type !== 'image') return inner;
         replaced += 1;
         blockChanged = true;
-        return { type: 'text', text: TOOL_RESULT_IMAGE_OMITTED_TEXT };
+        return { type: 'text', text: noticeText };
       });
       if (!blockChanged) return block;
       msgChanged = true;


### PR DESCRIPTION
## 这次改了什么

### Summary

Keep XD Sol tool-result image failures explicit when the existing Vision Bridge cannot deliver the image.

### Change type

- [ ] `feat`
- [x] `fix`
- [ ] `refactor` / `perf`
- [ ] `docs` / `test` / `chore`
- [ ] Other

### Scope

- Related to #2416.
- Included: a post-Vision-Bridge fallback for XD-routed `codex/gpt-5.6-sol`, `gpt-5.6-sol`, and `[1m]` wire variants; sibling-text preservation; and route-scope tests.
- Not included: image transport changes, direct subscription routes, custom providers, other models, or ordinary user images.
- User-visible change: the model receives a clear notice and asks the user to attach the image directly.
- Breaking change: No.

### Remote and mobile adaptation

- SSH remote workspaces: Not affected.
- Device link: No channel or protocol change.
- Mobile: Not affected.

### UI changes

Not applicable. No UI files or user-interface copy changed.

- Design basis: Not applicable.

## 怎么验证的

### Automated

```text
pnpm --filter desktop exec vitest run src/main/maker-host/__tests__/xdToolResultImageNotice.test.ts --pool=threads --maxWorkers=1
Result: 5 tests passed.

NODE_OPTIONS=--max-old-space-size=6144 pnpm --filter desktop run --if-present typecheck
Result: passed.

pnpm test:unit
Result: passed for all applicable workspaces.

pnpm check:dco -- --base origin/main
Result: passed.
```

### Manual

Not run.

### Not run

Real XD Gateway validation was not run because upstream credentials are unavailable in the isolated verifier.

## 风险

### Risk classification

- [ ] No known risk
- [ ] SQLite / migration
- [ ] System prompt
- [x] Protocol compatibility
- [ ] Permissions / security / user data
- [ ] Existing plugin compatibility
- [ ] Native layer / fingerprint / OTA
- [ ] Cross-platform differences
- [ ] Other

### Impact and rollback

- Impact: only tool-result image blocks that remain after Vision Bridge handling for the exact model on the configured XD upstream.
- Risk: an incorrect route match could degrade an image-capable tool result to text. Tests cover model, upstream, and message-role boundaries.
- Rollback: revert the commit. No migration or cleanup is required.

### Pre-submit checks

- [x] Reviewed the complete diff
- [x] Every commit has a DCO sign-off
- [x] UI design reference is not applicable
- [x] No credentials, tokens, or authorization files are included
- [x] No documentation change is required
- [x] Test results and untested paths are documented
