### PR TITLE
fix(ios-simulator): release disabled Host and settle WDA fallback

### DIFF
--- a/apps/desktop/src/main/cindy-brain/__tests__/iosSimulatorCapabilityMutation.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/iosSimulatorCapabilityMutation.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  acquireIOSSimulatorManifestMutation,
+  runIOSSimulatorCapabilityMutation,
+  runIOSSimulatorManifestMutation,
+} from '../iosSimulatorCapabilityMutation.js';
+
+describe('iOS Simulator capability mutation serialization', () => {
+  it('does not let a later enable complete before an older teardown finishes', async () => {
+    let finishTeardown!: () => void;
+    const teardownFinished = new Promise<void>((resolve) => {
+      finishTeardown = resolve;
+    });
+    const events: string[] = [];
+    const disable = runIOSSimulatorCapabilityMutation(async () => {
+      events.push('disable-start');
+      await teardownFinished;
+      events.push('disable-finish');
+    });
+    const enableMutation = vi.fn(async () => {
+      events.push('enable');
+    });
+    const enable = runIOSSimulatorCapabilityMutation(enableMutation);
+
+    await vi.waitFor(() => expect(events).toEqual(['disable-start']));
+    expect(enableMutation).not.toHaveBeenCalled();
+
+    finishTeardown();
+    await expect(Promise.all([disable, enable])).resolves.toEqual([undefined, undefined]);
+    expect(events).toEqual(['disable-start', 'disable-finish', 'enable']);
+  });
+
+  it('keeps an install-lock cardpoint reentrant inside the same capability mutation', async () => {
+    const events: string[] = [];
+
+    await expect(
+      runIOSSimulatorCapabilityMutation(async () => {
+        events.push('outer');
+        await runIOSSimulatorManifestMutation([{ slots: ['ios-simulator'] }], async () => {
+          events.push('inner');
+        });
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(events).toEqual(['outer', 'inner']);
+  });
+
+  it.each([
+    {
+      name: 'an enabled install',
+      manifests: [{ slots: ['ios-simulator'] }],
+    },
+    {
+      name: 'an update that adds the slot',
+      manifests: [{ slots: [] }, { slots: ['ios-simulator'] }],
+    },
+    {
+      name: 'an update that removes the slot',
+      manifests: [{ slots: ['ios-simulator'] }, { slots: [] }],
+    },
+  ])('queues $name behind an older teardown', async ({ manifests }) => {
+    let finishTeardown!: () => void;
+    const teardownFinished = new Promise<void>((resolve) => {
+      finishTeardown = resolve;
+    });
+    const events: string[] = [];
+    const disable = runIOSSimulatorCapabilityMutation(async () => {
+      events.push('disable-start');
+      await teardownFinished;
+      events.push('disable-finish');
+    });
+    const packageMutation = runIOSSimulatorManifestMutation(manifests, async () => {
+      events.push('package-mutation');
+    });
+
+    await vi.waitFor(() => expect(events).toEqual(['disable-start']));
+    finishTeardown();
+    await Promise.all([disable, packageMutation]);
+
+    expect(events).toEqual(['disable-start', 'disable-finish', 'package-mutation']);
+  });
+
+  it('does not serialize an update when neither manifest owns the slot', async () => {
+    let finishTeardown!: () => void;
+    const teardownFinished = new Promise<void>((resolve) => {
+      finishTeardown = resolve;
+    });
+    const events: string[] = [];
+    const disable = runIOSSimulatorCapabilityMutation(async () => {
+      events.push('disable-start');
+      await teardownFinished;
+      events.push('disable-finish');
+    });
+
+    await vi.waitFor(() => expect(events).toEqual(['disable-start']));
+    await runIOSSimulatorManifestMutation([{ slots: [] }, { slots: ['panel'] }], async () => {
+      events.push('ordinary-update');
+    });
+    expect(events).toEqual(['disable-start', 'ordinary-update']);
+
+    finishTeardown();
+    await disable;
+  });
+
+  it('lets an existing package mutation hold and release the same FIFO explicitly', async () => {
+    let finishTeardown!: () => void;
+    const teardownFinished = new Promise<void>((resolve) => {
+      finishTeardown = resolve;
+    });
+    const events: string[] = [];
+    const disable = runIOSSimulatorCapabilityMutation(async () => {
+      events.push('disable-start');
+      await teardownFinished;
+      events.push('disable-finish');
+    });
+
+    await vi.waitFor(() => expect(events).toEqual(['disable-start']));
+    const leasePromise = acquireIOSSimulatorManifestMutation([
+      { slots: [] },
+      { slots: ['ios-simulator'] },
+    ]);
+    let acquired = false;
+    void leasePromise.then(() => {
+      acquired = true;
+    });
+    await Promise.resolve();
+    expect(acquired).toBe(false);
+
+    finishTeardown();
+    const release = await leasePromise;
+    events.push('package-mutation');
+    release();
+    await disable;
+
+    expect(events).toEqual(['disable-start', 'disable-finish', 'package-mutation']);
+  });
+});

--- a/apps/desktop/src/main/cindy-brain/__tests__/iosSimulatorCapabilityTeardownWiring.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/iosSimulatorCapabilityTeardownWiring.test.ts
@@ -1,0 +1,53 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+describe('iOS Simulator capability teardown wiring', () => {
+  const brainSource = readFileSync(
+    resolve(process.cwd(), 'src/main/cindy-brain/index.ts'),
+    'utf8',
+  ).replace(/\r\n/g, '\n');
+  const makerIpcSource = readFileSync(
+    resolve(process.cwd(), 'src/main/maker-ipc/register.ts'),
+    'utf8',
+  ).replace(/\r\n/g, '\n');
+
+  it('routes the plugin-page project disable through the capability FIFO and scoped cleanup', () => {
+    const start = brainSource.indexOf("'ghosts:workdir-prefs:set'");
+    const end = brainSource.indexOf("ipcMain.handle('ghosts:cindy-prefs:set'", start);
+    const handler = brainSource.slice(start, end);
+
+    expect(handler).toContain('assertTrustedAppRendererEvent(event);');
+    expect(handler).toContain("ghost.manifest.slots.includes('ios-simulator')");
+    expect(handler).toContain('runIOSSimulatorCapabilityMutation(mutate)');
+    expect(handler).toMatch(
+      /releaseIOSSimulatorAfterCapabilityLoss\(\s*hadEnabledIOSSimulatorCapability,\s*\{ projectWorkingDirs: \[workdir\] \},\s*true,?\s*\)/,
+    );
+  });
+
+  it('lets a repeated plugin disable retry cleanup while the Host remains active', () => {
+    const start = brainSource.indexOf("ipcMain.handle('ghosts:set-enabled'");
+    const end = brainSource.indexOf("ipcMain.handle('ghosts:runtime-states'", start);
+    const handler = brainSource.slice(start, end);
+
+    expect(handler).toMatch(
+      /releaseIOSSimulatorAfterCapabilityLoss\(\s*hadEnabledIOSSimulatorCapability,\s*\{\},\s*true,?\s*\)/,
+    );
+  });
+
+  it('combines provider and built-in-tool access for each project binding', () => {
+    const start = makerIpcSource.indexOf(
+      'const isIOSSimulatorProviderEnabledForProject = (workingDir: string): boolean => {',
+    );
+    const end = makerIpcSource.indexOf('const runBuiltinToolMutation', start);
+    const providerWiring = makerIpcSource.slice(start, end);
+
+    expect(providerWiring).toContain('getIOSSimulatorPluginAccessDecision(workingDir).allowed');
+    expect(providerWiring).toContain("registry.isEnabled('ios-simulator', workingDir)");
+    expect(providerWiring).toContain('configureIOSSimulatorActiveProviderResolver({');
+    expect(providerWiring).toContain(
+      'isEnabledForProject: isIOSSimulatorProviderEnabledForProject',
+    );
+  });
+});

--- a/apps/desktop/src/main/cindy-brain/__tests__/iosSimulatorCapabilityTeardownWiring.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/iosSimulatorCapabilityTeardownWiring.test.ts
@@ -66,4 +66,32 @@ describe('iOS Simulator capability teardown wiring', () => {
     );
     expect(helper).toContain('reconcilePendingCreates,');
   });
+
+  it('guards built-in-tool cleanup mutations at the trusted Main IPC boundary', () => {
+    const setStart = makerIpcSource.indexOf('ipcMain.handle(MAKER_INVOKE.PLUGINS_SET_ENABLED');
+    const clearStart = makerIpcSource.indexOf(
+      'ipcMain.handle(MAKER_INVOKE.PLUGINS_CLEAR_ENABLED',
+      setStart,
+    );
+    const projectStart = makerIpcSource.indexOf('registerProjectPluginPolicyHandlers', clearStart);
+    const setHandler = makerIpcSource.slice(setStart, clearStart);
+    const clearHandler = makerIpcSource.slice(clearStart, projectStart);
+    const projectWiring = makerIpcSource.slice(
+      projectStart,
+      makerIpcSource.indexOf('// ── Android automation', projectStart),
+    );
+
+    for (const handler of [setHandler, clearHandler]) {
+      expect(handler).toContain(
+        "if (id === 'ios-simulator') assertTrustedAppRendererEvent(event);",
+      );
+      expect(
+        handler.indexOf("if (id === 'ios-simulator') assertTrustedAppRendererEvent(event);"),
+      ).toBeLessThan(handler.indexOf('runBuiltinToolMutation'));
+    }
+    expect(projectWiring).toContain('assertTrustedSender: (event) =>');
+    expect(projectWiring).toContain('resolveIOSSimulatorProjectWorkingDir: async');
+    expect(projectWiring).toContain('maker.listAllMeta().catch(() => [])');
+    expect(projectWiring).toContain('resolveMainOwnedIOSSimulatorProject(requestedWorkingDir');
+  });
 });

--- a/apps/desktop/src/main/cindy-brain/__tests__/iosSimulatorCapabilityTeardownWiring.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/iosSimulatorCapabilityTeardownWiring.test.ts
@@ -50,4 +50,20 @@ describe('iOS Simulator capability teardown wiring', () => {
       'isEnabledForProject: isIOSSimulatorProviderEnabledForProject',
     );
   });
+
+  it('does not sweep profile pending-create markers while another project is retained', () => {
+    const start = brainSource.indexOf(
+      'export async function deactivateIOSSimulatorForBuiltinToolDefault',
+    );
+    const end = brainSource.indexOf(
+      'export async function deactivateIOSSimulatorForBuiltinToolProject',
+      start,
+    );
+    const helper = brainSource.slice(start, end);
+
+    expect(helper).toContain(
+      'const reconcilePendingCreates = options.shouldReleaseHost?.() !== false;',
+    );
+    expect(helper).toContain('reconcilePendingCreates,');
+  });
 });

--- a/apps/desktop/src/main/cindy-brain/__tests__/iosSimulatorPluginGate.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/iosSimulatorPluginGate.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
 import type { InstalledGhost } from '../../../shared/ghost.js';
-import { resolveIOSSimulatorPluginAccess } from '../iosSimulatorPluginGate.js';
+import {
+  resolveIOSSimulatorCapabilityLossCleanupScope,
+  resolveIOSSimulatorPluginAccess,
+} from '../iosSimulatorPluginGate.js';
 
 function ghost(id: string, enabled: boolean, slots: string[] = ['ios-simulator']): InstalledGhost {
   return {
@@ -65,5 +68,69 @@ describe('iOS Simulator plugin Host gate', () => {
       allowed: false,
       errorCode: 'IOS_SIMULATOR_PLUGIN_REQUIRED',
     });
+  });
+});
+
+describe('iOS Simulator capability-loss cleanup scope', () => {
+  it('retries an active Host after an earlier disable cleanup failed', () => {
+    const scope = resolveIOSSimulatorCapabilityLossCleanupScope({
+      wasEnabled: false,
+      retryIfHostActive: true,
+      hostRuntimeActive: true,
+      hasActiveProvider: false,
+      hasEnabledProviderForProject: () => false,
+    });
+
+    expect(scope).toEqual({});
+  });
+
+  it('does not retry when the capability was already disabled and no Host remains', () => {
+    expect(
+      resolveIOSSimulatorCapabilityLossCleanupScope({
+        wasEnabled: false,
+        retryIfHostActive: true,
+        hostRuntimeActive: false,
+        hasActiveProvider: false,
+        hasEnabledProviderForProject: () => false,
+      }),
+    ).toBeNull();
+  });
+
+  it('cleans only projects that lost their last effective provider', () => {
+    expect(
+      resolveIOSSimulatorCapabilityLossCleanupScope({
+        wasEnabled: true,
+        retryIfHostActive: false,
+        hostRuntimeActive: true,
+        hasActiveProvider: true,
+        projectWorkingDirs: ['/project-a', '/project-b'],
+        hasEnabledProviderForProject: (workingDir) => workingDir === '/project-b',
+      }),
+    ).toEqual({ projectWorkingDirs: ['/project-a'] });
+  });
+
+  it('evaluates provider access per binding when the mutation has no project scope', () => {
+    const scope = resolveIOSSimulatorCapabilityLossCleanupScope({
+      wasEnabled: true,
+      retryIfHostActive: false,
+      hostRuntimeActive: true,
+      hasActiveProvider: true,
+      hasEnabledProviderForProject: (workingDir) => workingDir === '/project-b',
+    });
+
+    expect(scope?.shouldReleaseProject?.('/project-a')).toBe(true);
+    expect(scope?.shouldReleaseProject?.('/project-b')).toBe(false);
+  });
+
+  it('keeps the last-provider cleanup unscoped so pending creates are reconciled', () => {
+    expect(
+      resolveIOSSimulatorCapabilityLossCleanupScope({
+        wasEnabled: true,
+        retryIfHostActive: false,
+        hostRuntimeActive: true,
+        hasActiveProvider: false,
+        hasEnabledProviderForProject: () => false,
+      }),
+    ).toEqual({});
   });
 });

--- a/apps/desktop/src/main/cindy-brain/__tests__/marketGhostSessionBoundary.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/marketGhostSessionBoundary.test.ts
@@ -59,7 +59,10 @@ describe('market Ghost session boundary', () => {
     const captureIndex = body.indexOf('const mutationOwner = captureGhostMutationOwner();');
     const ledgerBindIndex = body.indexOf('const marketLedger = getPluginMarketLedger().bind(');
     const inspectIndex = body.indexOf('await manager.inspect(lizFilePath)');
-    const leaseIndex = body.indexOf('const releaseMutation = beginGhostMutation(mutationOwner);');
+    const tryIndex = body.indexOf(
+      'try {\n        releaseMutation = beginGhostMutation(mutationOwner);',
+    );
+    const leaseIndex = body.indexOf('releaseMutation = beginGhostMutation(mutationOwner);');
     const detachDecisionIndex = body.indexOf(
       'const detachMarketRecord = Boolean(marketRecord?.installed)',
     );
@@ -75,7 +78,9 @@ describe('market Ghost session boundary', () => {
     expect(captureIndex).toBeGreaterThan(-1);
     expect(ledgerBindIndex).toBeGreaterThan(captureIndex);
     expect(ledgerBindIndex).toBeLessThan(inspectIndex);
+    expect(tryIndex).toBeGreaterThan(inspectIndex);
     expect(leaseIndex).toBeGreaterThan(inspectIndex);
+    expect(leaseIndex).toBeGreaterThan(tryIndex);
     expect(ledgerReadIndex).toBeGreaterThan(leaseIndex);
     expect(detachDecisionIndex).toBeGreaterThan(ledgerReadIndex);
     expect(runtimeStopIndex).toBeGreaterThan(leaseIndex);
@@ -90,7 +95,7 @@ describe('market Ghost session boundary', () => {
     expect(body).toContain('onPackagePlaced: () => {');
     expect(body).toContain('packagePlaced = true;');
     expect(body).toMatch(/if \(!packagePlaced\) \{\s+restoreMarketRecord\(\);/);
-    expect(body).toContain('releaseMutation();');
+    expect(body).toContain('releaseMutation?.();');
     expect(body).not.toContain('GHOST_SOURCE_CONFLICT');
   });
 
@@ -128,7 +133,9 @@ describe('market Ghost session boundary', () => {
     const waitIndex = body.indexOf(
       'await getGhostNodeRuntimeBroker().stopAndWait(inspected.manifest.id);',
     );
-    const tryIndex = body.indexOf('try {\n        runtime.stop(inspected.manifest.id);');
+    const tryIndex = body.indexOf(
+      'try {\n        releaseMutation = beginGhostMutation(mutationOwner);',
+    );
     const updateIndex = body.indexOf('result = await manager.update(lizFilePath');
     const restoreIndex = body.indexOf(
       'if (previousGhostAtMutation) spawnIfResident(previousGhostAtMutation);',
@@ -139,7 +146,7 @@ describe('market Ghost session boundary', () => {
     expect(waitIndex).toBeGreaterThan(-1);
     expect(waitIndex).toBeLessThan(updateIndex);
     expect(restoreIndex).toBeGreaterThan(waitIndex);
-    expect(body).toMatch(/finally \{\s+releaseMutation\(\);/);
+    expect(body).toMatch(/finally \{\s+releaseMutation\?\.\(\);\s+releaseIOSMutation\(\);/);
     expect(body).toContain(
       "throwIpcError('INTERNAL', 'Unable to verify the installed Plugin source');",
     );
@@ -186,17 +193,24 @@ describe('market Ghost session boundary', () => {
     const capabilityIndex = body.indexOf(
       'const releaseIOSMutation = await acquireIOSSimulatorManifestMutation(',
     );
-    const leaseIndex = body.indexOf('const releaseMutation = beginGhostMutation(mutationOwner);');
+    const tryIndex = body.indexOf(
+      'try {\n        releaseMutation = beginGhostMutation(mutationOwner);',
+    );
+    const leaseIndex = body.indexOf('releaseMutation = beginGhostMutation(mutationOwner);');
 
     expect(installLockIndex).toBeGreaterThan(-1);
     expect(capabilityIndex).toBeGreaterThan(installLockIndex);
+    expect(tryIndex).toBeGreaterThan(capabilityIndex);
     expect(leaseIndex).toBeGreaterThan(capabilityIndex);
+    expect(leaseIndex).toBeGreaterThan(tryIndex);
     expect(body).toMatch(
       /acquireIOSSimulatorManifestMutation\(\s*\[\s*previousGhost\?\.manifest,\s*inspected\.canonicalManifest,?\s*\]/,
     );
     expect(body).toContain('const previousGhostAtMutation =');
     expect(body).toContain('spawnIfResident(previousGhostAtMutation)');
     expect(body).toContain('await releaseIOSSimulatorAfterCapabilityLoss(');
-    expect(body).toMatch(/finally \{\s+releaseMutation\(\);\s+releaseIOSMutation\(\);/);
+    expect(body).toMatch(
+      /finally \{\s+releaseMutation\?\.\(\);\s+releaseIOSMutation\(\);/,
+    );
   });
 });

--- a/apps/desktop/src/main/cindy-brain/__tests__/marketGhostSessionBoundary.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/marketGhostSessionBoundary.test.ts
@@ -16,9 +16,7 @@ describe('market Ghost session boundary', () => {
   ).replace(/\r\n/g, '\n');
 
   it('requires the pre-approval session generation when acquiring the mutation lease', () => {
-    const captureStart = source.indexOf(
-      'function captureGhostMutationOwner(): ActiveAppSession {',
-    );
+    const captureStart = source.indexOf('function captureGhostMutationOwner(): ActiveAppSession {');
     const captureEnd = source.indexOf('\n}\n', captureStart);
     const captureBody = source.slice(captureStart, captureEnd);
     expect(captureBody).toContain('isAppSessionBoundaryPending()');
@@ -36,22 +34,13 @@ describe('market Ghost session boundary', () => {
   });
 
   it('captures before async inspection but leases only after Node authorization', () => {
-    const installStart = source.indexOf(
-      'export async function installOrUpdateMarketGhostPackage(',
-    );
-    const installEnd = source.indexOf(
-      '\n}\n\ntype GhostUninstallLedgerCompletion',
-      installStart,
-    );
+    const installStart = source.indexOf('export async function installOrUpdateMarketGhostPackage(');
+    const installEnd = source.indexOf('\n}\n\ntype GhostUninstallLedgerCompletion', installStart);
     const body = source.slice(installStart, installEnd);
 
-    const captureIndex = body.indexOf(
-      'const mutationOwner = captureGhostMutationOwner();',
-    );
+    const captureIndex = body.indexOf('const mutationOwner = captureGhostMutationOwner();');
     const inspectIndex = body.indexOf('await manager.inspect(cindyFilePath)');
-    const leaseIndex = body.indexOf(
-      'releaseMutation = beginGhostMutation(mutationOwner);',
-    );
+    const leaseIndex = body.indexOf('releaseMutation = beginGhostMutation(mutationOwner);');
 
     expect(captureIndex).toBeGreaterThan(-1);
     expect(captureIndex).toBeLessThan(inspectIndex);
@@ -60,13 +49,8 @@ describe('market Ghost session boundary', () => {
   });
 
   it('allows explicit local replacement and detaches market routing before landing', () => {
-    const updateStart = source.indexOf(
-      "ipcMain.handle('ghosts:update'",
-    );
-    const updateEnd = source.indexOf(
-      "ipcMain.handle('ghosts:pick-file'",
-      updateStart,
-    );
+    const updateStart = source.indexOf("ipcMain.handle('ghosts:update'");
+    const updateEnd = source.indexOf("ipcMain.handle('ghosts:pick-file'", updateStart);
     const body = source.slice(updateStart, updateEnd);
 
     const ledgerReadIndex = body.indexOf(
@@ -105,28 +89,23 @@ describe('market Ghost session boundary', () => {
     expect(body).toContain('suppressed: marketRecordWasSuppressed');
     expect(body).toContain('onPackagePlaced: () => {');
     expect(body).toContain('packagePlaced = true;');
-    expect(body).toContain('if (!packagePlaced) {\n            restoreMarketRecord();');
+    expect(body).toMatch(/if \(!packagePlaced\) \{\s+restoreMarketRecord\(\);/);
     expect(body).toContain('releaseMutation();');
     expect(body).not.toContain('GHOST_SOURCE_CONFLICT');
   });
 
   it('runs the final market callback before both initial install and update placement', () => {
-    const installStart = source.indexOf(
-      'async function installOrUpdateMarketGhostPackageLocked(',
-    );
-    const installEnd = source.indexOf(
-      '\n}\n\ntype GhostUninstallLedgerCompletion',
-      installStart,
-    );
+    const installStart = source.indexOf('async function installOrUpdateMarketGhostPackageLocked(');
+    const installEnd = source.indexOf('\n}\n\ntype GhostUninstallLedgerCompletion', installStart);
     const body = source.slice(installStart, installEnd);
     const initialBranch = body.slice(
-      body.indexOf('if (!installed) {'),
+      body.indexOf('if (!installedAtMutation) {'),
       body.indexOf('const runtime = getGhostRuntime();'),
     );
 
     expect(initialBranch.indexOf('expected.beforeCommitInLock?.();')).toBeGreaterThan(-1);
     expect(initialBranch.indexOf('expected.beforeCommitInLock?.();')).toBeLessThan(
-      initialBranch.indexOf('return installAndDock('),
+      initialBranch.indexOf('return installAndDockLocked('),
     );
     expect(body.match(/expected\.beforeCommitInLock\?\.\(\);/g)).toHaveLength(2);
 
@@ -137,7 +116,7 @@ describe('market Ghost session boundary', () => {
 
     expect(waitIndex).toBeGreaterThan(-1);
     expect(waitIndex).toBeLessThan(updateIndex);
-    const restoreIndex = body.indexOf('spawnIfResident(installed);');
+    const restoreIndex = body.indexOf('spawnIfResident(installedAtMutation);');
     expect(restoreIndex).toBeGreaterThan(updateIndex);
   });
 
@@ -152,7 +131,7 @@ describe('market Ghost session boundary', () => {
     const tryIndex = body.indexOf('try {\n        runtime.stop(inspected.manifest.id);');
     const updateIndex = body.indexOf('result = await manager.update(lizFilePath');
     const restoreIndex = body.indexOf(
-      'if (previousGhost) spawnIfResident(previousGhost);',
+      'if (previousGhostAtMutation) spawnIfResident(previousGhostAtMutation);',
     );
 
     expect(tryIndex).toBeGreaterThan(-1);
@@ -160,8 +139,64 @@ describe('market Ghost session boundary', () => {
     expect(waitIndex).toBeGreaterThan(-1);
     expect(waitIndex).toBeLessThan(updateIndex);
     expect(restoreIndex).toBeGreaterThan(waitIndex);
-    expect(body).toContain('finally {\n        releaseMutation();');
-    expect(body).toContain("throwIpcError('INTERNAL', 'Unable to verify the installed Plugin source');");
-    expect(body).toContain("throwIpcError('INTERNAL', 'Unable to detach the installed Plugin source');");
+    expect(body).toMatch(/finally \{\s+releaseMutation\(\);/);
+    expect(body).toContain(
+      "throwIpcError('INTERNAL', 'Unable to verify the installed Plugin source');",
+    );
+    expect(body).toContain(
+      "throwIpcError('INTERNAL', 'Unable to detach the installed Plugin source');",
+    );
+  });
+
+  it('orders install locking before the iOS capability queue and the owner mutation lease', () => {
+    const installStart = source.indexOf('export async function installAndDock(');
+    const installEnd = source.indexOf('\n}\n\nasync function installAndDockLocked(', installStart);
+    const installBody = source.slice(installStart, installEnd);
+    const installLockIndex = installBody.indexOf('withGhostInstallLock(opts.ghostId');
+    const installCapabilityIndex = installBody.indexOf('runIOSSimulatorManifestMutation(');
+
+    expect(installLockIndex).toBeGreaterThan(-1);
+    expect(installCapabilityIndex).toBeGreaterThan(installLockIndex);
+    expect(installBody).toContain('opts.incomingManifest');
+
+    const marketStart = source.indexOf('async function installOrUpdateMarketGhostPackageLocked(');
+    const marketEnd = source.indexOf('\n}\n\ntype GhostUninstallLedgerCompletion', marketStart);
+    const marketBody = source.slice(marketStart, marketEnd);
+    const capabilityIndex = marketBody.indexOf(
+      'releaseIOSMutation = await acquireIOSSimulatorManifestMutation(',
+    );
+    const leaseIndex = marketBody.indexOf('releaseMutation = beginGhostMutation(mutationOwner);');
+
+    expect(capabilityIndex).toBeGreaterThan(-1);
+    expect(leaseIndex).toBeGreaterThan(capabilityIndex);
+    expect(marketBody).toMatch(
+      /acquireIOSSimulatorManifestMutation\(\s*\[\s*installed\?\.manifest,\s*inspected\.canonicalManifest,?\s*\]/,
+    );
+    expect(marketBody).toContain('const installedAtMutation =');
+    expect(marketBody).toMatch(
+      /finally \{\s+releaseMutation\?\.\(\);\s+releaseIOSMutation\?\.\(\);/,
+    );
+  });
+
+  it('serializes local updates that add or remove the iOS slot and refreshes rollback state', () => {
+    const updateStart = source.indexOf("ipcMain.handle('ghosts:update'");
+    const updateEnd = source.indexOf("ipcMain.handle('ghosts:pick-file'", updateStart);
+    const body = source.slice(updateStart, updateEnd);
+    const installLockIndex = body.indexOf('withGhostInstallLock(inspected.manifest.id');
+    const capabilityIndex = body.indexOf(
+      'const releaseIOSMutation = await acquireIOSSimulatorManifestMutation(',
+    );
+    const leaseIndex = body.indexOf('const releaseMutation = beginGhostMutation(mutationOwner);');
+
+    expect(installLockIndex).toBeGreaterThan(-1);
+    expect(capabilityIndex).toBeGreaterThan(installLockIndex);
+    expect(leaseIndex).toBeGreaterThan(capabilityIndex);
+    expect(body).toMatch(
+      /acquireIOSSimulatorManifestMutation\(\s*\[\s*previousGhost\?\.manifest,\s*inspected\.canonicalManifest,?\s*\]/,
+    );
+    expect(body).toContain('const previousGhostAtMutation =');
+    expect(body).toContain('spawnIfResident(previousGhostAtMutation)');
+    expect(body).toContain('await releaseIOSSimulatorAfterCapabilityLoss(');
+    expect(body).toMatch(/finally \{\s+releaseMutation\(\);\s+releaseIOSMutation\(\);/);
   });
 });

--- a/apps/desktop/src/main/cindy-brain/index.ts
+++ b/apps/desktop/src/main/cindy-brain/index.ts
@@ -813,9 +813,15 @@ export async function deactivateIOSSimulatorForBuiltinToolDefault(options: {
   shouldReleaseHost?: () => boolean;
 } = {}): Promise<void> {
   try {
+    // Pending-create evidence is profile-scoped. Sweeping it while an explicit
+    // project override still provides the capability could delete that
+    // retained project's marker between `simctl create` and binding persist.
+    // If the last provider disappears later, the armed evidence keeps the Host
+    // fail-closed and a later teardown retry performs the full sweep.
+    const reconcilePendingCreates = options.shouldReleaseHost?.() !== false;
     await deactivateIOSSimulatorHost({
       ...options,
-      reconcilePendingCreates: true,
+      reconcilePendingCreates,
       allowHostRelease: true,
     });
   } catch (error) {

--- a/apps/desktop/src/main/cindy-brain/index.ts
+++ b/apps/desktop/src/main/cindy-brain/index.ts
@@ -218,6 +218,7 @@ import {
 import {
   deactivateIOSSimulatorHost,
   getIOSSimulatorPluginStatus,
+  isIOSSimulatorHostRuntimeActive,
 } from '../mcp-integrations/ios-simulator.js';
 import type { GhostTrustRegistry } from './ghostSignature.js';
 import { GhostNotifySlot, sanitizeGhostNoticeText } from './notifySlot.js';
@@ -729,8 +730,14 @@ function hasEnabledIOSSimulatorCapability(ghosts = getGhostManager().list()): bo
 async function releaseIOSSimulatorAfterCapabilityLoss(
   wasEnabled: boolean,
   options: { projectWorkingDirs?: readonly string[] } = {},
+  retryIfHostActive = false,
 ): Promise<void> {
-  if (!wasEnabled || hasEnabledIOSSimulatorCapability()) return;
+  if (
+    (!wasEnabled && !(retryIfHostActive && isIOSSimulatorHostRuntimeActive())) ||
+    hasEnabledIOSSimulatorCapability()
+  ) {
+    return;
+  }
   try {
     await deactivateIOSSimulatorHost(options);
   } catch (error) {
@@ -4183,7 +4190,12 @@ async function uninstallGhostAndCleanupLocked(
         ? null
         : (prepareGhostUninstallLedgerCompletion?.(id) ?? null);
     const manager = getGhostManager();
-    const hadEnabledIOSSimulatorCapability = hasEnabledIOSSimulatorCapability(manager.list());
+    const ghostsBeforeUninstall = manager.list();
+    const hadEnabledIOSSimulatorCapability = hasEnabledIOSSimulatorCapability(ghostsBeforeUninstall);
+    const removedIOSSimulatorCapability = ghostsBeforeUninstall.some(
+      (ghost) =>
+        ghost.manifest.id === id && ghost.manifest.slots.includes('ios-simulator'),
+    );
     const runtime = getGhostRuntime();
     runtime.stop(id);
     getGhostNodeRuntimeBroker().stop(id);
@@ -4248,7 +4260,11 @@ async function uninstallGhostAndCleanupLocked(
     // 卸载刚落地,manager.list() 就是当下的全部事实(哪怕是空表)——标权威,
     // 好让「卸掉最后一个插件」也能把账本里的孤儿记录一并清掉。
     broadcastGhostsChanged(manager.list(), true);
-    await releaseIOSSimulatorAfterCapabilityLoss(hadEnabledIOSSimulatorCapability);
+    await releaseIOSSimulatorAfterCapabilityLoss(
+      hadEnabledIOSSimulatorCapability,
+      {},
+      removedIOSSimulatorCapability,
+    );
     if (recentIds) broadcastGhostRecentUsageChanged(recentIds);
     try {
       await completeLedger?.();

--- a/apps/desktop/src/main/cindy-brain/index.ts
+++ b/apps/desktop/src/main/cindy-brain/index.ts
@@ -207,7 +207,10 @@ import { GhostPreviewSlot } from './previewSlot.js';
 import { GhostScheduleSlot, isMainShellWindowUrl } from './scheduleSlot.js';
 import { GhostWorkspaceSlot, type WorkspaceSessionService } from './workspaceSlot.js';
 import { GhostIOSSimulatorSlot, type IOSSimulatorSlotFocusContext } from './iosSimulatorSlot.js';
-import { resolveIOSSimulatorPluginAccess } from './iosSimulatorPluginGate.js';
+import {
+  resolveIOSSimulatorCapabilityLossCleanupScope,
+  resolveIOSSimulatorPluginAccess,
+} from './iosSimulatorPluginGate.js';
 import {
   acquireIOSSimulatorManifestMutation,
   runIOSSimulatorCapabilityMutation,
@@ -733,22 +736,63 @@ function hasEnabledIOSSimulatorCapability(ghosts = getGhostManager().list()): bo
   );
 }
 
+function hasEnabledIOSSimulatorCapabilityForProject(
+  workingDir: string,
+  ghosts = getGhostManager().list(),
+): boolean {
+  return resolveIOSSimulatorPluginAccess(ghosts, workingDir, {
+    isAvailableForActiveSession: isGhostAvailableForActiveSession,
+    isDisabledForWorkdir: isGhostDisabledForWorkdir,
+  }).allowed;
+}
+
+interface IOSSimulatorActiveProviderResolver {
+  hasActiveProvider(): boolean;
+  isEnabledForProject(workingDir: string): boolean;
+}
+
+let iosSimulatorActiveProviderResolver: IOSSimulatorActiveProviderResolver | null = null;
+
+/** Inject the Maker project-policy half without making cindy-brain import Maker. */
+export function configureIOSSimulatorActiveProviderResolver(
+  resolver: IOSSimulatorActiveProviderResolver,
+): void {
+  iosSimulatorActiveProviderResolver = resolver;
+}
+
+function isIOSSimulatorProviderEnabledForProject(workingDir: string): boolean {
+  return (
+    iosSimulatorActiveProviderResolver?.isEnabledForProject(workingDir) ??
+    hasEnabledIOSSimulatorCapabilityForProject(workingDir)
+  );
+}
+
+function hasActiveIOSSimulatorProvider(): boolean {
+  return (
+    iosSimulatorActiveProviderResolver?.hasActiveProvider() ??
+    hasEnabledIOSSimulatorCapability()
+  );
+}
+
 async function releaseIOSSimulatorAfterCapabilityLoss(
   wasEnabled: boolean,
   options: { projectWorkingDirs?: readonly string[] } = {},
   retryIfHostActive = false,
 ): Promise<void> {
-  if (
-    (!wasEnabled && !(retryIfHostActive && isIOSSimulatorHostRuntimeActive())) ||
-    hasEnabledIOSSimulatorCapability()
-  ) {
-    return;
-  }
+  const scope = resolveIOSSimulatorCapabilityLossCleanupScope({
+    wasEnabled,
+    retryIfHostActive,
+    hostRuntimeActive: isIOSSimulatorHostRuntimeActive(),
+    hasActiveProvider: hasActiveIOSSimulatorProvider(),
+    projectWorkingDirs: options.projectWorkingDirs,
+    hasEnabledProviderForProject: isIOSSimulatorProviderEnabledForProject,
+  });
+  if (!scope) return;
   try {
     await deactivateIOSSimulatorHost({
-      ...options,
+      ...scope,
       allowHostRelease: true,
-      shouldReleaseHost: () => !hasEnabledIOSSimulatorCapability(),
+      shouldReleaseHost: () => !hasActiveIOSSimulatorProvider(),
     });
   } catch (error) {
     // The durable preference has already changed. Keep the Host and shell
@@ -5309,7 +5353,8 @@ export function registerGhostIpc(): void {
   });
   ipcMain.handle(
     'ghosts:workdir-prefs:set',
-    (_event, workdir: unknown, ghostId: unknown, disabled: unknown) => {
+    async (event, workdir: unknown, ghostId: unknown, disabled: unknown) => {
+      assertTrustedAppRendererEvent(event);
       if (typeof workdir !== 'string' || workdir.trim().length === 0) {
         throwIpcError('INVALID_PARAMS', 'workdir must be a non-empty string');
       }
@@ -5319,18 +5364,38 @@ export function registerGhostIpc(): void {
       if (typeof disabled !== 'boolean') {
         throwIpcError('INVALID_PARAMS', 'disabled must be a boolean');
       }
-      const wasDisabled = isGhostDisabledForWorkdir(ghostId, workdir);
-      const next = setGhostDisabledForWorkdir(workdir, ghostId, disabled);
-      // A setup card may already be waiting for this plugin in the affected
-      // project. Wake all waiters for the plugin; each one revalidates its own
-      // captured workdir and only the matching scope is rejected.
-      if (wasDisabled !== disabled) {
-        getGhostSetupChangeBus().emit(ghostId, { source: 'workdir_policy' });
-      }
-      // 生效面变了(新会话花名册 / $ 菜单),借 ghosts:changed 通知所有窗口
-      // 重拉——载荷仍是完整已装清单,消费方按需再 sendSync 取目录级清单。
-      broadcastGhostsChanged(manager.list());
-      return { disabled: next };
+      const changesIOSSimulatorCapability = manager
+        .list()
+        .some(
+          (ghost) =>
+            ghost.manifest.id === ghostId && ghost.manifest.slots.includes('ios-simulator'),
+        );
+      const mutate = async () => {
+        const hadEnabledIOSSimulatorCapability =
+          hasEnabledIOSSimulatorCapabilityForProject(workdir);
+        const wasDisabled = isGhostDisabledForWorkdir(ghostId, workdir);
+        const next = setGhostDisabledForWorkdir(workdir, ghostId, disabled);
+        // A setup card may already be waiting for this plugin in the affected
+        // project. Wake all waiters for the plugin; each one revalidates its own
+        // captured workdir and only the matching scope is rejected.
+        if (wasDisabled !== disabled) {
+          getGhostSetupChangeBus().emit(ghostId, { source: 'workdir_policy' });
+        }
+        // 生效面变了(新会话花名册 / $ 菜单),借 ghosts:changed 通知所有窗口
+        // 重拉——载荷仍是完整已装清单,消费方按需再 sendSync 取目录级清单。
+        broadcastGhostsChanged(manager.list());
+        if (disabled && changesIOSSimulatorCapability) {
+          await releaseIOSSimulatorAfterCapabilityLoss(
+            hadEnabledIOSSimulatorCapability,
+            { projectWorkingDirs: [workdir] },
+            true,
+          );
+        }
+        return { disabled: next };
+      };
+      return changesIOSSimulatorCapability
+        ? runIOSSimulatorCapabilityMutation(mutate)
+        : mutate();
     },
   );
 
@@ -5801,7 +5866,11 @@ export function registerGhostIpc(): void {
         // (要等插件再次上报或重启)。熄灯类操作(runtime/node/订阅)放在前面是既有
         // 行为且幂等,唯独这条会留下用户可见的错状态(copilot + codex review)。
         suspendGhostUnreadProjection(id);
-        await releaseIOSSimulatorAfterCapabilityLoss(hadEnabledIOSSimulatorCapability);
+        await releaseIOSSimulatorAfterCapabilityLoss(
+          hadEnabledIOSSimulatorCapability,
+          {},
+          true,
+        );
       }
       return { ok: true };
     };

--- a/apps/desktop/src/main/cindy-brain/index.ts
+++ b/apps/desktop/src/main/cindy-brain/index.ts
@@ -215,7 +215,10 @@ import {
   requestIOSSimulatorRendererSessionAccess,
   revokeIOSSimulatorRendererAccessForSessionChange,
 } from '../mcp-integrations/ios-simulator-renderer-access.js';
-import { getIOSSimulatorPluginStatus } from '../mcp-integrations/ios-simulator.js';
+import {
+  deactivateIOSSimulatorHost,
+  getIOSSimulatorPluginStatus,
+} from '../mcp-integrations/ios-simulator.js';
 import type { GhostTrustRegistry } from './ghostSignature.js';
 import { GhostNotifySlot, sanitizeGhostNoticeText } from './notifySlot.js';
 import { GhostBadgeSlot } from './badgeSlot.js';
@@ -712,6 +715,62 @@ export function waitForGhostMutations(): Promise<void> {
 /** Account-managed built-ins are unavailable outside a verified cloud session. */
 export function isGhostAvailableForActiveSession(id: string): boolean {
   return !isCindyAccountGhostId(id) || getAppCapabilities().canUseCindyAccountServices;
+}
+
+function hasEnabledIOSSimulatorCapability(ghosts = getGhostManager().list()): boolean {
+  return ghosts.some(
+    (ghost) =>
+      ghost.enabled === true &&
+      ghost.manifest.slots.includes('ios-simulator') &&
+      isGhostAvailableForActiveSession(ghost.manifest.id),
+  );
+}
+
+async function releaseIOSSimulatorAfterCapabilityLoss(
+  wasEnabled: boolean,
+  options: { projectWorkingDirs?: readonly string[] } = {},
+): Promise<void> {
+  if (!wasEnabled || hasEnabledIOSSimulatorCapability()) return;
+  try {
+    await deactivateIOSSimulatorHost(options);
+  } catch (error) {
+    // The durable preference has already changed. Keep the Host and shell
+    // guard fail-closed until ownership cleanup can be retried safely.
+    log.warn('iOS Simulator Host cleanup remains pending after capability loss', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+/**
+ * Settings → 内置工具 user-default disable has no project scope, so it
+ * retires every current binding. This is exported to keep the settings IPC
+ * adapter independent from Ghost filesystem internals.
+ */
+export async function deactivateIOSSimulatorForBuiltinToolDefault(options: {
+  shouldReleaseProject?: (workingDir: string) => boolean;
+} = {}): Promise<void> {
+  try {
+    await deactivateIOSSimulatorHost(options);
+  } catch (error) {
+    log.warn('iOS Simulator Host cleanup remains pending after built-in tool disable', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+/** Project-scoped built-in-tool disable only retires bindings in that project. */
+export async function deactivateIOSSimulatorForBuiltinToolProject(
+  workingDir: string,
+): Promise<void> {
+  try {
+    await deactivateIOSSimulatorHost({ projectWorkingDirs: [workingDir] });
+  } catch (error) {
+    log.warn('iOS Simulator project cleanup remains pending after built-in tool disable', {
+      workingDir,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
 }
 
 /** Live Host capability gate shared by Agent transports and Renderer IPC. */
@@ -4124,6 +4183,7 @@ async function uninstallGhostAndCleanupLocked(
         ? null
         : (prepareGhostUninstallLedgerCompletion?.(id) ?? null);
     const manager = getGhostManager();
+    const hadEnabledIOSSimulatorCapability = hasEnabledIOSSimulatorCapability(manager.list());
     const runtime = getGhostRuntime();
     runtime.stop(id);
     getGhostNodeRuntimeBroker().stop(id);
@@ -4188,6 +4248,7 @@ async function uninstallGhostAndCleanupLocked(
     // 卸载刚落地,manager.list() 就是当下的全部事实(哪怕是空表)——标权威,
     // 好让「卸掉最后一个插件」也能把账本里的孤儿记录一并清掉。
     broadcastGhostsChanged(manager.list(), true);
+    await releaseIOSSimulatorAfterCapabilityLoss(hadEnabledIOSSimulatorCapability);
     if (recentIds) broadcastGhostRecentUsageChanged(recentIds);
     try {
       await completeLedger?.();
@@ -5621,6 +5682,7 @@ export function registerGhostIpc(): void {
     if (typeof enabled !== 'boolean') {
       throwIpcError('INVALID_PARAMS', 'enabled must be a boolean');
     }
+    const hadEnabledIOSSimulatorCapability = hasEnabledIOSSimulatorCapability(manager.list());
     if (!enabled) {
       runtime.stop(id); // 沉睡立即熄灯
       getGhostNodeRuntimeBroker().stop(id); // 随包 Node 也立即关闭
@@ -5642,6 +5704,7 @@ export function registerGhostIpc(): void {
       // (要等插件再次上报或重启)。熄灯类操作(runtime/node/订阅)放在前面是既有
       // 行为且幂等,唯独这条会留下用户可见的错状态(copilot + codex review)。
       suspendGhostUnreadProjection(id);
+      await releaseIOSSimulatorAfterCapabilityLoss(hadEnabledIOSSimulatorCapability);
     }
     return { ok: true };
   });

--- a/apps/desktop/src/main/cindy-brain/index.ts
+++ b/apps/desktop/src/main/cindy-brain/index.ts
@@ -795,8 +795,8 @@ async function releaseIOSSimulatorAfterCapabilityLoss(
       shouldReleaseHost: () => !hasActiveIOSSimulatorProvider(),
     });
   } catch (error) {
-    // The durable preference has already changed. Keep the Host and shell
-    // guard fail-closed until ownership cleanup can be retried safely.
+    // The durable preference has already changed. Keep the Host singleton and
+    // ownership writer lease until cleanup can be retried safely.
     log.warn('iOS Simulator Host cleanup remains pending after capability loss', {
       error: error instanceof Error ? error.message : String(error),
     });
@@ -817,7 +817,7 @@ export async function deactivateIOSSimulatorForBuiltinToolDefault(options: {
     // project override still provides the capability could delete that
     // retained project's marker between `simctl create` and binding persist.
     // If the last provider disappears later, the armed evidence keeps the Host
-    // fail-closed and a later teardown retry performs the full sweep.
+    // responsible for cleanup and a later teardown retry performs the full sweep.
     const reconcilePendingCreates = options.shouldReleaseHost?.() !== false;
     await deactivateIOSSimulatorHost({
       ...options,
@@ -4196,7 +4196,7 @@ async function installOrUpdateMarketGhostPackageLocked(
         ...(trustOverride ? { trustOverride } : {}),
         beforePackageCommit: () => {
           getGhostOauthAccountManager().expireAccountsForChangedClients(
-            withRuntimeFiloGoogleClient(installed.manifest),
+            withRuntimeFiloGoogleClient(installedAtMutation.manifest),
             withRuntimeFiloGoogleClient(inspected.canonicalManifest),
           );
         },
@@ -5533,14 +5533,16 @@ export function registerGhostIpc(): void {
       const releaseIOSMutation = await acquireIOSSimulatorManifestMutation(
         [previousGhost?.manifest, inspected.canonicalManifest],
       );
-      const releaseMutation = beginGhostMutation(mutationOwner);
-      const previousGhostAtMutation =
-        manager.list().find((ghost) => ghost.manifest.id === inspected.manifest.id) ?? previousGhost;
-      const hadEnabledIOSSimulatorCapability = hasEnabledIOSSimulatorCapability(manager.list());
-      const removedIOSSimulatorCapability =
-        previousGhostAtMutation?.manifest.slots.includes('ios-simulator') === true &&
-        !inspected.canonicalManifest.slots.includes('ios-simulator');
+      let releaseMutation: (() => void) | null = null;
       try {
+        releaseMutation = beginGhostMutation(mutationOwner);
+        const previousGhostAtMutation =
+          manager.list().find((ghost) => ghost.manifest.id === inspected.manifest.id) ??
+          previousGhost;
+        const hadEnabledIOSSimulatorCapability = hasEnabledIOSSimulatorCapability(manager.list());
+        const removedIOSSimulatorCapability =
+          previousGhostAtMutation?.manifest.slots.includes('ios-simulator') === true &&
+          !inspected.canonicalManifest.slots.includes('ios-simulator');
         runtime.stop(inspected.manifest.id);
         // 等待失败表示旧进程仍可能存活；此时不能恢复 resident，否则会产生
         // 两份后台进程。仅在确认退出后的更新阶段失败时恢复旧版本。
@@ -5673,7 +5675,7 @@ export function registerGhostIpc(): void {
         );
         return { ghost: result.ghost };
       } finally {
-        releaseMutation();
+        releaseMutation?.();
         releaseIOSMutation();
       }
     });

--- a/apps/desktop/src/main/cindy-brain/index.ts
+++ b/apps/desktop/src/main/cindy-brain/index.ts
@@ -209,6 +209,11 @@ import { GhostWorkspaceSlot, type WorkspaceSessionService } from './workspaceSlo
 import { GhostIOSSimulatorSlot, type IOSSimulatorSlotFocusContext } from './iosSimulatorSlot.js';
 import { resolveIOSSimulatorPluginAccess } from './iosSimulatorPluginGate.js';
 import {
+  acquireIOSSimulatorManifestMutation,
+  runIOSSimulatorCapabilityMutation,
+  runIOSSimulatorManifestMutation,
+} from './iosSimulatorCapabilityMutation.js';
+import {
   clearIOSSimulatorRendererAccess,
   focusIOSSimulatorRendererSession,
   getIOSSimulatorRendererSessionAccess,
@@ -467,6 +472,7 @@ function getGhostSetupManifestTracker(): GhostSetupManifestTracker {
 }
 
 const ghostMutationCoordinator = new GhostMutationCoordinator();
+export { runIOSSimulatorCapabilityMutation } from './iosSimulatorCapabilityMutation.js';
 
 /**
  * Capture the stable owner before a mutation performs any asynchronous
@@ -739,7 +745,11 @@ async function releaseIOSSimulatorAfterCapabilityLoss(
     return;
   }
   try {
-    await deactivateIOSSimulatorHost(options);
+    await deactivateIOSSimulatorHost({
+      ...options,
+      allowHostRelease: true,
+      shouldReleaseHost: () => !hasEnabledIOSSimulatorCapability(),
+    });
   } catch (error) {
     // The durable preference has already changed. Keep the Host and shell
     // guard fail-closed until ownership cleanup can be retried safely.
@@ -756,9 +766,14 @@ async function releaseIOSSimulatorAfterCapabilityLoss(
  */
 export async function deactivateIOSSimulatorForBuiltinToolDefault(options: {
   shouldReleaseProject?: (workingDir: string) => boolean;
+  shouldReleaseHost?: () => boolean;
 } = {}): Promise<void> {
   try {
-    await deactivateIOSSimulatorHost(options);
+    await deactivateIOSSimulatorHost({
+      ...options,
+      reconcilePendingCreates: true,
+      allowHostRelease: true,
+    });
   } catch (error) {
     log.warn('iOS Simulator Host cleanup remains pending after built-in tool disable', {
       error: error instanceof Error ? error.message : String(error),
@@ -769,9 +784,14 @@ export async function deactivateIOSSimulatorForBuiltinToolDefault(options: {
 /** Project-scoped built-in-tool disable only retires bindings in that project. */
 export async function deactivateIOSSimulatorForBuiltinToolProject(
   workingDir: string,
+  shouldReleaseHost?: () => boolean,
 ): Promise<void> {
   try {
-    await deactivateIOSSimulatorHost({ projectWorkingDirs: [workingDir] });
+    await deactivateIOSSimulatorHost({
+      projectWorkingDirs: [workingDir],
+      allowHostRelease: true,
+      shouldReleaseHost,
+    });
   } catch (error) {
     log.warn('iOS Simulator project cleanup remains pending after built-in tool disable', {
       workingDir,
@@ -3877,12 +3897,18 @@ export async function installAndDock(
    */
   opts: {
     ghostId: string;
+    incomingManifest: GhostManifest;
     enable?: boolean;
     expectedPackageSha256?: string;
     trustOverride?: GhostHostTrustOverride;
   },
 ): Promise<InstalledGhost> {
-  return withGhostInstallLock(opts.ghostId, () => installAndDockLocked(manager, lizFilePath, opts));
+  return withGhostInstallLock(opts.ghostId, () =>
+    runIOSSimulatorManifestMutation(
+      [opts.enable === true ? opts.incomingManifest : undefined],
+      () => installAndDockLocked(manager, lizFilePath, opts),
+    ),
+  );
 }
 
 async function installAndDockLocked(
@@ -3890,6 +3916,7 @@ async function installAndDockLocked(
   lizFilePath: string,
   opts: {
     ghostId: string;
+    incomingManifest: GhostManifest;
     enable?: boolean;
     expectedPackageSha256?: string;
     trustOverride?: GhostHostTrustOverride;
@@ -3990,6 +4017,7 @@ async function installOrUpdateMarketGhostPackageLocked(
 ): Promise<InstalledGhost> {
   const mutationOwner = captureGhostMutationOwner();
   let releaseMutation: (() => void) | null = null;
+  let releaseIOSMutation: (() => void) | null = null;
   try {
     const manager = getGhostManager();
     const inspected = await manager.inspect(cindyFilePath);
@@ -4063,13 +4091,19 @@ async function installOrUpdateMarketGhostPackageLocked(
     }
     rejectUnauthorizedTokenBroker(inspected.canonicalManifest);
 
+    releaseIOSMutation = await acquireIOSSimulatorManifestMutation([
+      installed?.manifest,
+      inspected.canonicalManifest,
+    ]);
     // Node 高风险条目由 renderer 装入确认卡权限清单如实展示;
     // 2026-07-24 Lizi 定案:不再有 Main 侧原生二次确认弹窗(PR #333,本处为其
     // 漏删的市场安装路径调用点,一并对齐)。
     // Hold the owner-stability lease only for the actual Ghost filesystem
     // mutation.
     releaseMutation = beginGhostMutation(mutationOwner);
-    if (!installed) {
+    const installedAtMutation =
+      manager.list().find((ghost) => ghost.manifest.id === expected.ghostId) ?? installed;
+    if (!installedAtMutation) {
       // 2026-07-26 定案:市场首装一律装完即开(defaultInstall 与手动安装归一),
       // 用户不必再手动点一次开关。市场包走官方分发链路(服务端校验 + sha256
       // 校验下载),且确认框如实展示权限清单,确认安装即授权运行;本地 .cindy
@@ -4080,8 +4114,9 @@ async function installOrUpdateMarketGhostPackageLocked(
       // 所有前置校验(保留前缀/审阅比对/签名/解压上限)都会作用在旧字节上。
       // 本地 .cindy 装入通道已强制此对账,市场通道同一口径。
       expected.beforeCommitInLock?.();
-      return installAndDock(manager, cindyFilePath, {
+      return installAndDockLocked(manager, cindyFilePath, {
         ghostId: expected.ghostId,
+        incomingManifest: inspected.canonicalManifest,
         enable: true,
         expectedPackageSha256: inspected.packageSha256,
         ...(trustOverride ? { trustOverride } : {}),
@@ -4089,6 +4124,10 @@ async function installOrUpdateMarketGhostPackageLocked(
     }
 
     expected.beforeCommitInLock?.();
+    const hadEnabledIOSSimulatorCapability = hasEnabledIOSSimulatorCapability(manager.list());
+    const removedIOSSimulatorCapability =
+      installedAtMutation.manifest.slots.includes('ios-simulator') &&
+      !inspected.canonicalManifest.slots.includes('ios-simulator');
     const runtime = getGhostRuntime();
     runtime.stop(expected.ghostId);
     // 无法确认旧进程已退出时保持停止态，不能启动第二份 resident。只有旧进程
@@ -4118,7 +4157,7 @@ async function installOrUpdateMarketGhostPackageLocked(
       });
     } catch (error) {
       if (!packagePlaced) {
-        spawnIfResident(installed);
+        spawnIfResident(installedAtMutation);
         throw error;
       }
       const placed = manager.list().find((ghost) => ghost.manifest.id === expected.ghostId);
@@ -4130,7 +4169,7 @@ async function installOrUpdateMarketGhostPackageLocked(
       result = { ghost: placed };
     }
     if ('rejection' in result) {
-      spawnIfResident(installed);
+      spawnIfResident(installedAtMutation);
       throwInstallError(result.rejection);
     }
     runtime.resetFuse(expected.ghostId);
@@ -4146,9 +4185,15 @@ async function installOrUpdateMarketGhostPackageLocked(
       }
     }
     spawnIfResident(result.ghost);
+    await releaseIOSSimulatorAfterCapabilityLoss(
+      hadEnabledIOSSimulatorCapability,
+      {},
+      removedIOSSimulatorCapability,
+    );
     return result.ghost;
   } finally {
     releaseMutation?.();
+    releaseIOSMutation?.();
   }
 }
 
@@ -4175,7 +4220,18 @@ export async function uninstallGhostAndCleanup(
 ): Promise<void> {
   // 按 ghostId 与装入/更新互斥:卸载与同 id 的市场/本地装入不得交错,否则
   // 市场装入的"目标是否已装"判定会被本卸载在其落位前抽走(反之亦然)。
-  return withGhostInstallLock(id, () => uninstallGhostAndCleanupLocked(id, options));
+  return withGhostInstallLock(id, () => {
+    const changesIOSSimulatorCapability = getGhostManager()
+      .list()
+      .some(
+        (ghost) =>
+          ghost.manifest.id === id && ghost.manifest.slots.includes('ios-simulator'),
+      );
+    const uninstall = () => uninstallGhostAndCleanupLocked(id, options);
+    return changesIOSSimulatorCapability
+      ? runIOSSimulatorCapabilityMutation(uninstall)
+      : uninstall();
+  });
 }
 
 async function uninstallGhostAndCleanupLocked(
@@ -5364,6 +5420,7 @@ export function registerGhostIpc(): void {
     return {
       ghost: await installAndDock(manager, lizFilePath, {
         ghostId: probe.manifest.id,
+        incomingManifest: probe.canonicalManifest,
         enable,
         expectedPackageSha256,
       }),
@@ -5401,8 +5458,17 @@ export function registerGhostIpc(): void {
     // 与市场装入/本地装入/卸载共用按 ghostId 的互斥:换目录期间同 id 的其它
     // 装入/卸载不得插入(否则并发装入会与本次 rename 竞争、留下不一致态)。
     return withGhostInstallLock(inspected.manifest.id, async () => {
-      const releaseMutation = beginGhostMutation(mutationOwner);
       const previousGhost = manager.list().find((g) => g.manifest.id === inspected.manifest.id);
+      const releaseIOSMutation = await acquireIOSSimulatorManifestMutation(
+        [previousGhost?.manifest, inspected.canonicalManifest],
+      );
+      const releaseMutation = beginGhostMutation(mutationOwner);
+      const previousGhostAtMutation =
+        manager.list().find((ghost) => ghost.manifest.id === inspected.manifest.id) ?? previousGhost;
+      const hadEnabledIOSSimulatorCapability = hasEnabledIOSSimulatorCapability(manager.list());
+      const removedIOSSimulatorCapability =
+        previousGhostAtMutation?.manifest.slots.includes('ios-simulator') === true &&
+        !inspected.canonicalManifest.slots.includes('ios-simulator');
       try {
         runtime.stop(inspected.manifest.id);
         // 等待失败表示旧进程仍可能存活；此时不能恢复 resident，否则会产生
@@ -5426,7 +5492,7 @@ export function registerGhostIpc(): void {
               : false;
           }
         } catch (error) {
-          if (previousGhost) spawnIfResident(previousGhost);
+          if (previousGhostAtMutation) spawnIfResident(previousGhostAtMutation);
           log.warn('failed to verify Plugin provenance before local update', {
             ghostId: inspected.manifest.id,
             error: error instanceof Error ? error.message : String(error),
@@ -5465,7 +5531,7 @@ export function registerGhostIpc(): void {
             marketLedger.markRemoved(inspected.manifest.id, marketInstallSubject);
           } catch (error) {
             restoreMarketRecord();
-            if (previousGhost) spawnIfResident(previousGhost);
+            if (previousGhostAtMutation) spawnIfResident(previousGhostAtMutation);
             log.warn('failed to detach Plugin market provenance before local update', {
               ghostId: inspected.manifest.id,
               error: error instanceof Error ? error.message : String(error),
@@ -5498,10 +5564,12 @@ export function registerGhostIpc(): void {
           if (!packagePlaced) {
             restoreMarketRecord();
             // 更新失败:恢复旧版本的常驻 Node 工作进程(如果是 resident 且已启用)
-            if (previousGhost) spawnIfResident(previousGhost);
+            if (previousGhostAtMutation) spawnIfResident(previousGhostAtMutation);
             throw err;
           }
-          const placed = manager.list().find((ghost) => ghost.manifest.id === inspected.manifest.id);
+          const placed = manager
+            .list()
+            .find((ghost) => ghost.manifest.id === inspected.manifest.id);
           if (!placed) throw err;
           log.warn('local ghost post-placement notification failed', {
             ghostId: inspected.manifest.id,
@@ -5511,7 +5579,7 @@ export function registerGhostIpc(): void {
         }
         if ('rejection' in result) {
           restoreMarketRecord();
-          if (previousGhost) spawnIfResident(previousGhost);
+          if (previousGhostAtMutation) spawnIfResident(previousGhostAtMutation);
           throwInstallError(result.rejection);
         }
         runtime.resetFuse(inspected.manifest.id); // 换了代码,给新版本干净的熔断记账
@@ -5527,9 +5595,15 @@ export function registerGhostIpc(): void {
           }
         }
         spawnIfResident(result.ghost); // 常驻意识:换完代码立即用新版本点火
+        await releaseIOSSimulatorAfterCapabilityLoss(
+          hadEnabledIOSSimulatorCapability,
+          {},
+          removedIOSSimulatorCapability,
+        );
         return { ghost: result.ghost };
       } finally {
         releaseMutation();
+        releaseIOSMutation();
       }
     });
   });
@@ -5698,31 +5772,42 @@ export function registerGhostIpc(): void {
     if (typeof enabled !== 'boolean') {
       throwIpcError('INVALID_PARAMS', 'enabled must be a boolean');
     }
-    const hadEnabledIOSSimulatorCapability = hasEnabledIOSSimulatorCapability(manager.list());
-    if (!enabled) {
-      runtime.stop(id); // 沉睡立即熄灯
-      getGhostNodeRuntimeBroker().stop(id); // 随包 Node 也立即关闭
-      getGhostSubscriptionGateway().dropGhost(id); // 订阅态清零(缓冲/熔断/seq)
-    }
-    const result = await manager.setEnabled(id, enabled);
-    if ('rejection' in result) throwUninstallError(result.rejection);
-    if (enabled) {
-      runtime.resetFuse(id); // 重新唤醒 = 清熔断记账,可再拉起
-      const ghost = findAvailableGhost(id);
-      if (ghost) spawnIfResident(ghost); // 常驻意识:唤醒即启动
-      resumeGhostUnreadProjection(id); // 沉睡期间保留的那颗点回来
-    } else {
-      // 未读停止投影(记录保留):沉睡的意识没法把面板里的内容给你看,留一颗点
-      // 只是噪声;但用户是"先别烦我"不是"这条我读过了",唤醒要能找回来。
-      //
-      // **必须在 setEnabled 成功之后**:写 `.disabled` 可能失败(目录只读 / IO
-      // 错误),那时插件仍是启用态,可提前熄灭的话未读点就被错误清掉、且不会自愈
-      // (要等插件再次上报或重启)。熄灯类操作(runtime/node/订阅)放在前面是既有
-      // 行为且幂等,唯独这条会留下用户可见的错状态(copilot + codex review)。
-      suspendGhostUnreadProjection(id);
-      await releaseIOSSimulatorAfterCapabilityLoss(hadEnabledIOSSimulatorCapability);
-    }
-    return { ok: true };
+    const changesIOSSimulatorCapability = manager
+      .list()
+      .some(
+        (ghost) =>
+          ghost.manifest.id === id && ghost.manifest.slots.includes('ios-simulator'),
+      );
+    const mutate = async () => {
+      const hadEnabledIOSSimulatorCapability = hasEnabledIOSSimulatorCapability(manager.list());
+      if (!enabled) {
+        runtime.stop(id); // 沉睡立即熄灯
+        getGhostNodeRuntimeBroker().stop(id); // 随包 Node 也立即关闭
+        getGhostSubscriptionGateway().dropGhost(id); // 订阅态清零(缓冲/熔断/seq)
+      }
+      const result = await manager.setEnabled(id, enabled);
+      if ('rejection' in result) throwUninstallError(result.rejection);
+      if (enabled) {
+        runtime.resetFuse(id); // 重新唤醒 = 清熔断记账,可再拉起
+        const ghost = findAvailableGhost(id);
+        if (ghost) spawnIfResident(ghost); // 常驻意识:唤醒即启动
+        resumeGhostUnreadProjection(id); // 沉睡期间保留的那颗点回来
+      } else {
+        // 未读停止投影(记录保留):沉睡的意识没法把面板里的内容给你看,留一颗点
+        // 只是噪声;但用户是"先别烦我"不是"这条我读过了",唤醒要能找回来。
+        //
+        // **必须在 setEnabled 成功之后**:写 `.disabled` 可能失败(目录只读 / IO
+        // 错误),那时插件仍是启用态,可提前熄灭的话未读点就被错误清掉、且不会自愈
+        // (要等插件再次上报或重启)。熄灯类操作(runtime/node/订阅)放在前面是既有
+        // 行为且幂等,唯独这条会留下用户可见的错状态(copilot + codex review)。
+        suspendGhostUnreadProjection(id);
+        await releaseIOSSimulatorAfterCapabilityLoss(hadEnabledIOSSimulatorCapability);
+      }
+      return { ok: true };
+    };
+    return changesIOSSimulatorCapability
+      ? runIOSSimulatorCapabilityMutation(mutate)
+      : mutate();
   });
 
   // 运行时状态快照(面板错误接管态的首帧数据源;广播只覆盖后续变化)。

--- a/apps/desktop/src/main/cindy-brain/iosSimulatorCapabilityMutation.ts
+++ b/apps/desktop/src/main/cindy-brain/iosSimulatorCapabilityMutation.ts
@@ -1,0 +1,73 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+interface IOSSimulatorCapabilityManifest {
+  slots: readonly string[];
+}
+
+let mutationTail: Promise<void> = Promise.resolve();
+const heldMutation = new AsyncLocalStorage<boolean>();
+
+async function acquireIOSSimulatorCapabilityMutation(): Promise<() => void> {
+  if (heldMutation.getStore() === true) return () => undefined;
+
+  const previous = mutationTail;
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  mutationTail = previous.then(
+    () => gate,
+    () => gate,
+  );
+  await previous.catch(() => undefined);
+
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    release();
+  };
+}
+
+/**
+ * Serialize durable iOS Simulator capability changes with Host teardown.
+ * A later enable must not report success while an older disable can still
+ * retire viewer, driver, media, device, or ownership state underneath it.
+ */
+export function runIOSSimulatorCapabilityMutation<T>(mutation: () => Promise<T>): Promise<T> {
+  // Install/update cardpoints can re-enter through a narrower shared helper
+  // after they already acquired this queue. Treat that as the same mutation;
+  // enqueueing behind our own unresolved tail would self-deadlock.
+  if (heldMutation.getStore() === true) return mutation();
+
+  return (async () => {
+    const release = await acquireIOSSimulatorCapabilityMutation();
+    try {
+      return await heldMutation.run(true, mutation);
+    } finally {
+      release();
+    }
+  })();
+}
+
+/**
+ * Serialize a package mutation only when either the installed or incoming
+ * manifest owns the Host-managed iOS Simulator slot.
+ */
+export function runIOSSimulatorManifestMutation<T>(
+  manifests: readonly (IOSSimulatorCapabilityManifest | null | undefined)[],
+  mutation: () => Promise<T>,
+): Promise<T> {
+  return manifests.some((manifest) => manifest?.slots.includes('ios-simulator'))
+    ? runIOSSimulatorCapabilityMutation(mutation)
+    : mutation();
+}
+
+/** Acquire the same FIFO around an existing mutation body without reindenting it. */
+export function acquireIOSSimulatorManifestMutation(
+  manifests: readonly (IOSSimulatorCapabilityManifest | null | undefined)[],
+): Promise<() => void> {
+  return manifests.some((manifest) => manifest?.slots.includes('ios-simulator'))
+    ? acquireIOSSimulatorCapabilityMutation()
+    : Promise.resolve(() => undefined);
+}

--- a/apps/desktop/src/main/cindy-brain/iosSimulatorPluginGate.ts
+++ b/apps/desktop/src/main/cindy-brain/iosSimulatorPluginGate.ts
@@ -23,6 +23,38 @@ function pluginActionData(
   };
 }
 
+export interface IOSSimulatorCapabilityLossCleanupScope {
+  projectWorkingDirs?: readonly string[];
+  shouldReleaseProject?: (workingDir: string) => boolean;
+}
+
+/**
+ * Select only projects that lost their last effective provider. An alternative
+ * provider may remain enabled globally while being disabled in the binding's
+ * project, so capability teardown must not use a process-wide provider check
+ * to skip every binding.
+ */
+export function resolveIOSSimulatorCapabilityLossCleanupScope(input: {
+  wasEnabled: boolean;
+  retryIfHostActive: boolean;
+  hostRuntimeActive: boolean;
+  hasActiveProvider: boolean;
+  projectWorkingDirs?: readonly string[];
+  hasEnabledProviderForProject: (workingDir: string) => boolean;
+}): IOSSimulatorCapabilityLossCleanupScope | null {
+  if (!input.wasEnabled && !(input.retryIfHostActive && input.hostRuntimeActive)) return null;
+  if (input.projectWorkingDirs) {
+    const projectWorkingDirs = input.projectWorkingDirs.filter(
+      (workingDir) => !input.hasEnabledProviderForProject(workingDir),
+    );
+    return projectWorkingDirs.length > 0 ? { projectWorkingDirs } : null;
+  }
+  if (!input.hasActiveProvider) return {};
+  return {
+    shouldReleaseProject: (workingDir) => !input.hasEnabledProviderForProject(workingDir),
+  };
+}
+
 /**
  * Resolve the live product gate for Cindy's Host-owned iOS Simulator.
  *
@@ -41,7 +73,7 @@ export function resolveIOSSimulatorPluginAccess(
       allowed: false,
       errorCode: 'IOS_SIMULATOR_PLUGIN_REQUIRED',
       message:
-        "Cindy's embedded iOS Simulator requires the iOS Simulator plugin. The embedded route is unavailable until the user installs and enables “iOS Simulator” from Plugins → Marketplace; other iOS workflows are unaffected.",
+        "Cindy's embedded iOS Simulator requires the iOS Simulator plugin. Ask the user to open Plugins → Marketplace, install “iOS Simulator”, and enable it. Do not retry until the plugin is installed.",
       data: pluginActionData('not-installed', 'install-plugin'),
     };
   }
@@ -61,7 +93,7 @@ export function resolveIOSSimulatorPluginAccess(
       allowed: false,
       errorCode: 'IOS_SIMULATOR_DISABLED',
       message:
-        'The embedded iOS Simulator plugin is disabled for the current project. Enable it for this working directory before retrying the embedded tool; other iOS workflows are unaffected.',
+        'The iOS Simulator plugin is disabled for the current project. Ask the user to enable it for this working directory before retrying.',
       data: pluginActionData('disabled-in-workdir', 'enable-plugin', workdirDisabled),
     };
   }
@@ -72,7 +104,7 @@ export function resolveIOSSimulatorPluginAccess(
       allowed: false,
       errorCode: 'IOS_SIMULATOR_PLUGIN_DISABLED',
       message:
-        'The embedded iOS Simulator plugin is installed but disabled. Enable it on the Plugins page before retrying the embedded tool; other iOS workflows are unaffected.',
+        'The iOS Simulator plugin is installed but disabled. Ask the user to enable it on the Plugins page before retrying.',
       data: pluginActionData('disabled', 'enable-plugin', disabled),
     };
   }
@@ -81,7 +113,7 @@ export function resolveIOSSimulatorPluginAccess(
     allowed: false,
     errorCode: 'IOS_SIMULATOR_PLUGIN_DISABLED',
     message:
-      'The installed embedded iOS Simulator plugin is unavailable in the current Cindy session. Make it available from the Plugins page before retrying the embedded tool; other iOS workflows are unaffected.',
+      'The installed iOS Simulator plugin is unavailable in the current Cindy session. Ask the user to open the Plugins page and make the plugin available before retrying.',
     data: pluginActionData('session-unavailable', 'enable-plugin', candidates[0]),
   };
 }

--- a/apps/desktop/src/main/maker-host/plugins/__tests__/plugin-registry.test.ts
+++ b/apps/desktop/src/main/maker-host/plugins/__tests__/plugin-registry.test.ts
@@ -140,6 +140,19 @@ describe('PluginRegistry — scoped priority', () => {
     });
   });
 
+  it('keeps an explicitly enabled iOS Simulator project enabled after the user default is disabled', async () => {
+    await registry.setEnabled('ios-simulator', false);
+    await registry.setProjectEnabled('ios-simulator', workingDir, true);
+
+    expect(registry.isEnabled('ios-simulator')).toBe(false);
+    expect(registry.isEnabled('ios-simulator', workingDir)).toBe(true);
+    await expect(registry.getEnableState('ios-simulator', workingDir)).resolves.toMatchObject({
+      effectiveEnabled: true,
+      userOverride: { enabled: false },
+      projectOverride: { enabled: true, workingDir },
+    });
+  });
+
   it('returns true by default with workingDir', () => {
     expect(registry.isEnabled('ssh', workingDir)).toBe(true);
   });

--- a/apps/desktop/src/main/maker-ipc/__tests__/projectPluginPolicyHandlers.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/projectPluginPolicyHandlers.test.ts
@@ -3,7 +3,7 @@ import { drizzle } from 'drizzle-orm/better-sqlite3';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { DbClient } from '../../localDb/client/DbClient.js';
 import { clearCurrentDbClient, setCurrentDbClient } from '../../localDb/client/current.js';
@@ -11,7 +11,10 @@ import * as schema from '../../localDb/schema.js';
 import { PluginRegistry } from '../../maker-host/plugins/plugin-registry.js';
 import { SettingsReader } from '../../maker-host/plugins/settings-reader.js';
 import { MAKER_INVOKE } from '../channels.js';
-import { registerProjectPluginPolicyHandlers } from '../projectPluginPolicyHandlers.js';
+import {
+  registerProjectPluginPolicyHandlers,
+  resolveMainOwnedIOSSimulatorProject,
+} from '../projectPluginPolicyHandlers.js';
 import { IpcHarness } from './helpers/ipcHarness.js';
 
 /** Lifecycle rows that must remain unchanged after a project policy toggle. */
@@ -39,6 +42,29 @@ describe('project plugin policy handlers', () => {
     }
   });
 
+  it('derives the Simulator project scope only from Main-owned local sessions', () => {
+    const owned = path.resolve('owned-project');
+    const remote = path.resolve('remote-project');
+
+    expect(
+      resolveMainOwnedIOSSimulatorProject(`${owned}${path.sep}`, [
+        { workDir: owned },
+        { workDir: remote, remoteHostId: 'remote-host' },
+      ]),
+    ).toBe(owned);
+    expect(
+      resolveMainOwnedIOSSimulatorProject(remote, [
+        { workDir: remote, remoteHostId: 'remote-host' },
+      ]),
+    ).toBeNull();
+    expect(
+      resolveMainOwnedIOSSimulatorProject(path.resolve('unknown'), [{ workDir: owned }]),
+    ).toBeNull();
+    expect(
+      resolveMainOwnedIOSSimulatorProject('relative-project', [{ workDir: owned }]),
+    ).toBeNull();
+  });
+
   it('disables future collab sessions without ending the active team or worker', async () => {
     workingDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cindy-collab-policy-'));
     const client = createTestDbClient();
@@ -54,6 +80,8 @@ describe('project plugin policy handlers', () => {
     const harness = new IpcHarness();
     registerProjectPluginPolicyHandlers(harness, {
       getPluginRegistry: () => pluginRegistry,
+      assertTrustedSender: () => undefined,
+      resolveIOSSimulatorProjectWorkingDir: async (candidate) => candidate,
     });
     const before = await readLifecycleSnapshot(client);
 
@@ -83,6 +111,8 @@ describe('project plugin policy handlers', () => {
     const harness = new IpcHarness();
     registerProjectPluginPolicyHandlers(harness, {
       getPluginRegistry: () => pluginRegistry,
+      assertTrustedSender: () => undefined,
+      resolveIOSSimulatorProjectWorkingDir: async () => workingDir,
       onProjectPolicyChanged: (input) => {
         changed.push(input);
       },
@@ -94,16 +124,90 @@ describe('project plugin policy handlers', () => {
       'ios-simulator',
       false,
     );
-    await harness.invoke(
-      MAKER_INVOKE.PLUGINS_CLEAR_PROJECT_ENABLED,
-      workingDir,
-      'ios-simulator',
-    );
+    await harness.invoke(MAKER_INVOKE.PLUGINS_CLEAR_PROJECT_ENABLED, workingDir, 'ios-simulator');
 
     expect(changed).toEqual([
       { workingDir, id: 'ios-simulator', effectiveEnabled: false },
       { workingDir, id: 'ios-simulator', effectiveEnabled: true },
     ]);
+  });
+
+  it('rejects an untrusted sender before persisting or notifying a project mutation', async () => {
+    const setProjectEnabled = vi.fn(async () => true);
+    const clearProjectEnabled = vi.fn(async () => true);
+    const isEnabled = vi.fn(() => false);
+    const onProjectPolicyChanged = vi.fn();
+    const harness = new IpcHarness();
+    registerProjectPluginPolicyHandlers(harness, {
+      getPluginRegistry: () => ({ setProjectEnabled, clearProjectEnabled, isEnabled }),
+      assertTrustedSender: () => {
+        throw new Error('[PERMISSION_DENIED] untrusted renderer');
+      },
+      resolveIOSSimulatorProjectWorkingDir: vi.fn(async (candidate: string) => candidate),
+      onProjectPolicyChanged,
+    });
+
+    await expect(
+      harness.invoke(
+        MAKER_INVOKE.PLUGINS_SET_PROJECT_ENABLED,
+        '/owned-project',
+        'ios-simulator',
+        false,
+      ),
+    ).rejects.toThrow('untrusted renderer');
+
+    expect(setProjectEnabled).not.toHaveBeenCalled();
+    expect(clearProjectEnabled).not.toHaveBeenCalled();
+    expect(onProjectPolicyChanged).not.toHaveBeenCalled();
+  });
+
+  it('uses the Main-owned project path and rejects an unknown Simulator project', async () => {
+    const setProjectEnabled = vi.fn(async () => true);
+    const clearProjectEnabled = vi.fn(async () => true);
+    const isEnabled = vi.fn(() => true);
+    const onProjectPolicyChanged = vi.fn();
+    const requested = '/renderer-project-alias';
+    const owned = '/main-owned-project';
+    const harness = new IpcHarness();
+    registerProjectPluginPolicyHandlers(harness, {
+      getPluginRegistry: () => ({ setProjectEnabled, clearProjectEnabled, isEnabled }),
+      assertTrustedSender: () => undefined,
+      resolveIOSSimulatorProjectWorkingDir: vi.fn(async (candidate: string) =>
+        candidate === requested ? owned : null,
+      ),
+      onProjectPolicyChanged,
+    });
+
+    await harness.invoke(
+      MAKER_INVOKE.PLUGINS_SET_PROJECT_ENABLED,
+      requested,
+      'ios-simulator',
+      false,
+    );
+    await harness.invoke(MAKER_INVOKE.PLUGINS_CLEAR_PROJECT_ENABLED, requested, 'ios-simulator');
+    await expect(
+      harness.invoke(
+        MAKER_INVOKE.PLUGINS_SET_PROJECT_ENABLED,
+        '/unknown-project',
+        'ios-simulator',
+        false,
+      ),
+    ).rejects.toThrow('Project scope is not available');
+
+    expect(setProjectEnabled).toHaveBeenCalledTimes(1);
+    expect(setProjectEnabled).toHaveBeenCalledWith('ios-simulator', owned, false);
+    expect(clearProjectEnabled).toHaveBeenCalledWith('ios-simulator', owned);
+    expect(isEnabled).toHaveBeenCalledWith('ios-simulator', owned);
+    expect(onProjectPolicyChanged).toHaveBeenNthCalledWith(1, {
+      workingDir: owned,
+      id: 'ios-simulator',
+      effectiveEnabled: false,
+    });
+    expect(onProjectPolicyChanged).toHaveBeenNthCalledWith(2, {
+      workingDir: owned,
+      id: 'ios-simulator',
+      effectiveEnabled: true,
+    });
   });
 
   function createTestDbClient(): DbClient {

--- a/apps/desktop/src/main/maker-ipc/__tests__/projectPluginPolicyHandlers.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/projectPluginPolicyHandlers.test.ts
@@ -71,6 +71,41 @@ describe('project plugin policy handlers', () => {
     });
   });
 
+  it('notifies the host lifecycle after a project override changes', async () => {
+    workingDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cindy-ios-policy-callback-'));
+    const pluginRegistry = new PluginRegistry({
+      settingsReader: new SettingsReader({
+        userDataPath: workingDir,
+        logger: { warn: () => undefined },
+      }),
+    });
+    const changed: Array<{ workingDir: string; id: string; effectiveEnabled: boolean }> = [];
+    const harness = new IpcHarness();
+    registerProjectPluginPolicyHandlers(harness, {
+      getPluginRegistry: () => pluginRegistry,
+      onProjectPolicyChanged: (input) => {
+        changed.push(input);
+      },
+    });
+
+    await harness.invoke(
+      MAKER_INVOKE.PLUGINS_SET_PROJECT_ENABLED,
+      workingDir,
+      'ios-simulator',
+      false,
+    );
+    await harness.invoke(
+      MAKER_INVOKE.PLUGINS_CLEAR_PROJECT_ENABLED,
+      workingDir,
+      'ios-simulator',
+    );
+
+    expect(changed).toEqual([
+      { workingDir, id: 'ios-simulator', effectiveEnabled: false },
+      { workingDir, id: 'ios-simulator', effectiveEnabled: true },
+    ]);
+  });
+
   function createTestDbClient(): DbClient {
     const dbHandle = new Database(':memory:');
     rawDb = dbHandle;

--- a/apps/desktop/src/main/maker-ipc/projectPluginPolicyHandlers.ts
+++ b/apps/desktop/src/main/maker-ipc/projectPluginPolicyHandlers.ts
@@ -20,6 +20,7 @@ export type ProjectPluginPolicyRegistry = Pick<
 /** Host dependencies for project-level plugin policy IPC handlers. */
 export interface ProjectPluginPolicyHandlerDeps {
   getPluginRegistry(): ProjectPluginPolicyRegistry;
+  runPolicyMutation?<T>(id: string, mutation: () => Promise<T>): Promise<T>;
   onProjectPolicyChanged?(input: {
     workingDir: string;
     id: string;
@@ -32,6 +33,8 @@ export function registerProjectPluginPolicyHandlers(
   registry: IpcHandlerRegistry,
   deps: ProjectPluginPolicyHandlerDeps,
 ): void {
+  const runMutation = <T>(id: string, mutation: () => Promise<T>): Promise<T> =>
+    deps.runPolicyMutation?.(id, mutation) ?? mutation();
   registry.handle(
     MAKER_INVOKE.PLUGINS_SET_PROJECT_ENABLED,
     async (_event, workingDir, id, enabled) => {
@@ -45,11 +48,13 @@ export function registerProjectPluginPolicyHandlers(
           'workingDir (string) + id (string) + enabled (boolean) required',
         );
       }
-      const ok = await deps.getPluginRegistry().setProjectEnabled(id, workingDir, enabled);
-      if (!ok) {
-        throwIpcError('PERMISSION_DENIED', `Cannot modify essential plugin: ${id}`);
-      }
-      await deps.onProjectPolicyChanged?.({ workingDir, id, effectiveEnabled: enabled });
+      await runMutation(id, async () => {
+        const ok = await deps.getPluginRegistry().setProjectEnabled(id, workingDir, enabled);
+        if (!ok) {
+          throwIpcError('PERMISSION_DENIED', `Cannot modify essential plugin: ${id}`);
+        }
+        await deps.onProjectPolicyChanged?.({ workingDir, id, effectiveEnabled: enabled });
+      });
     },
   );
 
@@ -57,11 +62,13 @@ export function registerProjectPluginPolicyHandlers(
     if (typeof workingDir !== 'string' || typeof id !== 'string') {
       throwIpcError('INVALID_PARAMS', 'workingDir (string) + id (string) required');
     }
-    const ok = await deps.getPluginRegistry().clearProjectEnabled(id, workingDir);
-    if (!ok) {
-      throwIpcError('PERMISSION_DENIED', `Cannot modify essential plugin: ${id}`);
-    }
-    const effectiveEnabled = deps.getPluginRegistry().isEnabled(id, workingDir);
-    await deps.onProjectPolicyChanged?.({ workingDir, id, effectiveEnabled });
+    await runMutation(id, async () => {
+      const ok = await deps.getPluginRegistry().clearProjectEnabled(id, workingDir);
+      if (!ok) {
+        throwIpcError('PERMISSION_DENIED', `Cannot modify essential plugin: ${id}`);
+      }
+      const effectiveEnabled = deps.getPluginRegistry().isEnabled(id, workingDir);
+      await deps.onProjectPolicyChanged?.({ workingDir, id, effectiveEnabled });
+    });
   });
 }

--- a/apps/desktop/src/main/maker-ipc/projectPluginPolicyHandlers.ts
+++ b/apps/desktop/src/main/maker-ipc/projectPluginPolicyHandlers.ts
@@ -14,12 +14,17 @@ import type { IpcHandlerRegistry } from './ipcHandlerRegistry.js';
 /** Minimal plugin registry surface required by project policy handlers. */
 export type ProjectPluginPolicyRegistry = Pick<
   PluginRegistry,
-  'setProjectEnabled' | 'clearProjectEnabled'
+  'setProjectEnabled' | 'clearProjectEnabled' | 'isEnabled'
 >;
 
 /** Host dependencies for project-level plugin policy IPC handlers. */
 export interface ProjectPluginPolicyHandlerDeps {
   getPluginRegistry(): ProjectPluginPolicyRegistry;
+  onProjectPolicyChanged?(input: {
+    workingDir: string;
+    id: string;
+    effectiveEnabled: boolean;
+  }): void | Promise<void>;
 }
 
 /** Register project policy writes without coupling them to active runtimes. */
@@ -44,6 +49,7 @@ export function registerProjectPluginPolicyHandlers(
       if (!ok) {
         throwIpcError('PERMISSION_DENIED', `Cannot modify essential plugin: ${id}`);
       }
+      await deps.onProjectPolicyChanged?.({ workingDir, id, effectiveEnabled: enabled });
     },
   );
 
@@ -55,5 +61,7 @@ export function registerProjectPluginPolicyHandlers(
     if (!ok) {
       throwIpcError('PERMISSION_DENIED', `Cannot modify essential plugin: ${id}`);
     }
+    const effectiveEnabled = deps.getPluginRegistry().isEnabled(id, workingDir);
+    await deps.onProjectPolicyChanged?.({ workingDir, id, effectiveEnabled });
   });
 }

--- a/apps/desktop/src/main/maker-ipc/projectPluginPolicyHandlers.ts
+++ b/apps/desktop/src/main/maker-ipc/projectPluginPolicyHandlers.ts
@@ -6,6 +6,9 @@
  * outside this boundary.
  */
 
+import path from 'node:path';
+
+import { normalizeWorkingDirForProjectSettings } from '../../shared/workingDir.js';
 import type { PluginRegistry } from '../maker-host/plugins/plugin-registry.js';
 import { throwIpcError } from '../utils/ipcValidate.js';
 import { MAKER_INVOKE } from './channels.js';
@@ -20,12 +23,35 @@ export type ProjectPluginPolicyRegistry = Pick<
 /** Host dependencies for project-level plugin policy IPC handlers. */
 export interface ProjectPluginPolicyHandlerDeps {
   getPluginRegistry(): ProjectPluginPolicyRegistry;
+  assertTrustedSender(event: unknown): void;
+  resolveIOSSimulatorProjectWorkingDir(workingDir: string): Promise<string | null>;
   runPolicyMutation?<T>(id: string, mutation: () => Promise<T>): Promise<T>;
   onProjectPolicyChanged?(input: {
     workingDir: string;
     id: string;
     effectiveEnabled: boolean;
   }): void | Promise<void>;
+}
+
+export interface MainOwnedProjectSession {
+  workDir: string;
+  remoteHostId?: string | null;
+}
+
+/** Resolve an untrusted Renderer path to the matching Main-owned local project key. */
+export function resolveMainOwnedIOSSimulatorProject(
+  requestedWorkingDir: string,
+  sessions: readonly MainOwnedProjectSession[],
+): string | null {
+  if (!path.isAbsolute(requestedWorkingDir)) return null;
+  const requestedProject = normalizeWorkingDirForProjectSettings(requestedWorkingDir);
+  if (!requestedProject) return null;
+  for (const session of sessions) {
+    if (session.remoteHostId) continue;
+    const projectWorkingDir = normalizeWorkingDirForProjectSettings(session.workDir);
+    if (projectWorkingDir === requestedProject) return projectWorkingDir;
+  }
+  return null;
 }
 
 /** Register project policy writes without coupling them to active runtimes. */
@@ -37,7 +63,7 @@ export function registerProjectPluginPolicyHandlers(
     deps.runPolicyMutation?.(id, mutation) ?? mutation();
   registry.handle(
     MAKER_INVOKE.PLUGINS_SET_PROJECT_ENABLED,
-    async (_event, workingDir, id, enabled) => {
+    async (event, workingDir, id, enabled) => {
       if (
         typeof workingDir !== 'string' ||
         typeof id !== 'string' ||
@@ -48,27 +74,53 @@ export function registerProjectPluginPolicyHandlers(
           'workingDir (string) + id (string) + enabled (boolean) required',
         );
       }
+      if (id === 'ios-simulator') deps.assertTrustedSender(event);
+      const authorizedWorkingDir =
+        id === 'ios-simulator'
+          ? await deps.resolveIOSSimulatorProjectWorkingDir(workingDir)
+          : workingDir;
+      if (!authorizedWorkingDir) {
+        throwIpcError('PERMISSION_DENIED', 'Project scope is not available for this operation');
+      }
       await runMutation(id, async () => {
-        const ok = await deps.getPluginRegistry().setProjectEnabled(id, workingDir, enabled);
+        const ok = await deps
+          .getPluginRegistry()
+          .setProjectEnabled(id, authorizedWorkingDir, enabled);
         if (!ok) {
           throwIpcError('PERMISSION_DENIED', `Cannot modify essential plugin: ${id}`);
         }
-        await deps.onProjectPolicyChanged?.({ workingDir, id, effectiveEnabled: enabled });
+        await deps.onProjectPolicyChanged?.({
+          workingDir: authorizedWorkingDir,
+          id,
+          effectiveEnabled: enabled,
+        });
       });
     },
   );
 
-  registry.handle(MAKER_INVOKE.PLUGINS_CLEAR_PROJECT_ENABLED, async (_event, workingDir, id) => {
+  registry.handle(MAKER_INVOKE.PLUGINS_CLEAR_PROJECT_ENABLED, async (event, workingDir, id) => {
     if (typeof workingDir !== 'string' || typeof id !== 'string') {
       throwIpcError('INVALID_PARAMS', 'workingDir (string) + id (string) required');
     }
+    if (id === 'ios-simulator') deps.assertTrustedSender(event);
+    const authorizedWorkingDir =
+      id === 'ios-simulator'
+        ? await deps.resolveIOSSimulatorProjectWorkingDir(workingDir)
+        : workingDir;
+    if (!authorizedWorkingDir) {
+      throwIpcError('PERMISSION_DENIED', 'Project scope is not available for this operation');
+    }
     await runMutation(id, async () => {
-      const ok = await deps.getPluginRegistry().clearProjectEnabled(id, workingDir);
+      const ok = await deps.getPluginRegistry().clearProjectEnabled(id, authorizedWorkingDir);
       if (!ok) {
         throwIpcError('PERMISSION_DENIED', `Cannot modify essential plugin: ${id}`);
       }
-      const effectiveEnabled = deps.getPluginRegistry().isEnabled(id, workingDir);
-      await deps.onProjectPolicyChanged?.({ workingDir, id, effectiveEnabled });
+      const effectiveEnabled = deps.getPluginRegistry().isEnabled(id, authorizedWorkingDir);
+      await deps.onProjectPolicyChanged?.({
+        workingDir: authorizedWorkingDir,
+        id,
+        effectiveEnabled,
+      });
     });
   });
 }

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -84,6 +84,7 @@ import { toolNotFoundMessage } from '../cindy-brain/pipeDispatcher.js';
 import { getGhostSetupChangeBus } from '../cindy-brain/ghostSetupChangeBus.js';
 import { isGhostDisabledForWorkdir } from '../cindy-brain/ghostWorkdirPrefs.js';
 import {
+  configureIOSSimulatorActiveProviderResolver,
   deactivateIOSSimulatorForBuiltinToolDefault,
   deactivateIOSSimulatorForBuiltinToolProject,
   executeGhostSetupAction,
@@ -13245,17 +13246,23 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
   });
 
   // ── Plugin system (Phase 1) ──────────────────────────────────────────────
-  const hasActiveIOSSimulatorProvider = (): boolean => {
+  const isIOSSimulatorProviderEnabledForProject = (workingDir: string): boolean => {
     const registry = getPluginRegistry();
+    return (
+      getIOSSimulatorPluginAccessDecision(workingDir).allowed &&
+      registry.isEnabled('ios-simulator', workingDir)
+    );
+  };
+  const hasActiveIOSSimulatorProvider = (): boolean => {
     return maker.listActiveSessions().some((session) => {
       if (!maker.isSessionAlive(session.id) || session.remoteHostId) return false;
-      const workingDir = session.workDir;
-      return (
-        getIOSSimulatorPluginAccessDecision(workingDir).allowed &&
-        registry.isEnabled('ios-simulator', workingDir)
-      );
+      return isIOSSimulatorProviderEnabledForProject(session.workDir);
     });
   };
+  configureIOSSimulatorActiveProviderResolver({
+    hasActiveProvider: hasActiveIOSSimulatorProvider,
+    isEnabledForProject: isIOSSimulatorProviderEnabledForProject,
+  });
   const runBuiltinToolMutation = <T>(id: string, mutation: () => Promise<T>): Promise<T> =>
     id === 'ios-simulator' ? runIOSSimulatorCapabilityMutation(mutation) : mutation();
 

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -535,7 +535,10 @@ import {
   shouldRecycleHandoffWorktreeOnFailure,
 } from './handoffWorktree.js';
 import { validateHandoffWorkingDir } from './handoffWorkingDir.js';
-import { registerProjectPluginPolicyHandlers } from './projectPluginPolicyHandlers.js';
+import {
+  registerProjectPluginPolicyHandlers,
+  resolveMainOwnedIOSSimulatorProject,
+} from './projectPluginPolicyHandlers.js';
 import {
   TURN_CHANGE_SET_DETAIL_ID_LIMIT,
   TurnChangeSetActionError,
@@ -13307,10 +13310,11 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
     },
   );
 
-  ipcMain.handle(MAKER_INVOKE.PLUGINS_SET_ENABLED, async (_e, id: unknown, enabled: unknown) => {
+  ipcMain.handle(MAKER_INVOKE.PLUGINS_SET_ENABLED, async (event, id: unknown, enabled: unknown) => {
     if (typeof id !== 'string' || typeof enabled !== 'boolean') {
       throwIpcError('INVALID_PARAMS', 'id (string) + enabled (boolean) required');
     }
+    if (id === 'ios-simulator') assertTrustedAppRendererEvent(event);
     return runBuiltinToolMutation(id, async () => {
       const ok = await getPluginRegistry().setEnabled(id, enabled);
       if (!ok) {
@@ -13345,10 +13349,11 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
     });
   });
 
-  ipcMain.handle(MAKER_INVOKE.PLUGINS_CLEAR_ENABLED, async (_e, id: unknown) => {
+  ipcMain.handle(MAKER_INVOKE.PLUGINS_CLEAR_ENABLED, async (event, id: unknown) => {
     if (typeof id !== 'string') {
       throwIpcError('INVALID_PARAMS', 'id (string) required');
     }
+    if (id === 'ios-simulator') assertTrustedAppRendererEvent(event);
     return runBuiltinToolMutation(id, async () => {
       const ok = await getPluginRegistry().clearEnabled(id);
       if (!ok) {
@@ -13376,6 +13381,16 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
 
   registerProjectPluginPolicyHandlers(createElectronIpcHandlerRegistry(), {
     getPluginRegistry,
+    assertTrustedSender: (event) =>
+      assertTrustedAppRendererEvent(event as Parameters<typeof assertTrustedAppRendererEvent>[0]),
+    resolveIOSSimulatorProjectWorkingDir: async (requestedWorkingDir) => {
+      const activeSessions = maker.listActiveSessions();
+      const persistedSessions = await maker.listAllMeta().catch(() => []);
+      return resolveMainOwnedIOSSimulatorProject(requestedWorkingDir, [
+        ...activeSessions,
+        ...persistedSessions,
+      ]);
+    },
     runPolicyMutation: (id, mutation) => runBuiltinToolMutation(id, mutation),
     onProjectPolicyChanged: async ({ workingDir, id, effectiveEnabled }) => {
       if (id === 'ios-simulator' && !effectiveEnabled) {

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -84,6 +84,8 @@ import { toolNotFoundMessage } from '../cindy-brain/pipeDispatcher.js';
 import { getGhostSetupChangeBus } from '../cindy-brain/ghostSetupChangeBus.js';
 import { isGhostDisabledForWorkdir } from '../cindy-brain/ghostWorkdirPrefs.js';
 import {
+  deactivateIOSSimulatorForBuiltinToolDefault,
+  deactivateIOSSimulatorForBuiltinToolProject,
   executeGhostSetupAction,
   executeGhostSetupInlineAction,
   getGhostManager,
@@ -13291,6 +13293,14 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
     if (!ok) {
       throwIpcError('PERMISSION_DENIED', `Cannot modify essential plugin: ${id}`);
     }
+    if (id === 'ios-simulator' && enabled === false) {
+      const registry = getPluginRegistry();
+      await deactivateIOSSimulatorForBuiltinToolDefault({
+        // A project-level explicit enable outranks the user default. Keep its
+        // active bindings while retiring projects that now resolve disabled.
+        shouldReleaseProject: (workingDir) => !registry.isEnabled(id, workingDir),
+      });
+    }
     // Ordinary plugins are user defaults: existing sessions keep their frozen
     // policy and only new sessions observe changes, so no shared environment
     // refresh is needed.
@@ -13318,6 +13328,12 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
     if (!ok) {
       throwIpcError('PERMISSION_DENIED', `Cannot modify essential plugin: ${id}`);
     }
+    if (id === 'ios-simulator' && !getPluginRegistry().isEnabled(id)) {
+      const registry = getPluginRegistry();
+      await deactivateIOSSimulatorForBuiltinToolDefault({
+        shouldReleaseProject: (workingDir) => !registry.isEnabled(id, workingDir),
+      });
+    }
     if (!GLOBAL_PLUGIN_IDS.has(id) && id !== 'browser') {
       return { codexMcpRefreshed: true };
     }
@@ -13332,6 +13348,11 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
 
   registerProjectPluginPolicyHandlers(createElectronIpcHandlerRegistry(), {
     getPluginRegistry,
+    onProjectPolicyChanged: async ({ workingDir, id, effectiveEnabled }) => {
+      if (id === 'ios-simulator' && !effectiveEnabled) {
+        await deactivateIOSSimulatorForBuiltinToolProject(workingDir);
+      }
+    },
   });
 
   // ── Android automation (Settings →「电脑使用」) ──────────────────────────

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -92,6 +92,7 @@ import {
   getGhostSetupAssessment,
   getIOSSimulatorPluginAccessDecision,
   isGhostAvailableForActiveSession,
+  runIOSSimulatorCapabilityMutation,
 } from '../cindy-brain/index.js';
 import {
   assertTrustedAppRendererEvent,
@@ -13244,6 +13245,20 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
   });
 
   // ── Plugin system (Phase 1) ──────────────────────────────────────────────
+  const hasActiveIOSSimulatorProvider = (): boolean => {
+    const registry = getPluginRegistry();
+    return maker.listActiveSessions().some((session) => {
+      if (!maker.isSessionAlive(session.id) || session.remoteHostId) return false;
+      const workingDir = session.workDir;
+      return (
+        getIOSSimulatorPluginAccessDecision(workingDir).allowed &&
+        registry.isEnabled('ios-simulator', workingDir)
+      );
+    });
+  };
+  const runBuiltinToolMutation = <T>(id: string, mutation: () => Promise<T>): Promise<T> =>
+    id === 'ios-simulator' ? runIOSSimulatorCapabilityMutation(mutation) : mutation();
+
   ipcMain.handle(MAKER_INVOKE.PLUGINS_LIST, async (_e, workingDir: unknown) => {
     const wd = typeof workingDir === 'string' ? workingDir : undefined;
     return getPluginRegistry().listPlugins(wd);
@@ -13289,34 +13304,37 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
     if (typeof id !== 'string' || typeof enabled !== 'boolean') {
       throwIpcError('INVALID_PARAMS', 'id (string) + enabled (boolean) required');
     }
-    const ok = await getPluginRegistry().setEnabled(id, enabled);
-    if (!ok) {
-      throwIpcError('PERMISSION_DENIED', `Cannot modify essential plugin: ${id}`);
-    }
-    if (id === 'ios-simulator' && enabled === false) {
-      const registry = getPluginRegistry();
-      await deactivateIOSSimulatorForBuiltinToolDefault({
-        // A project-level explicit enable outranks the user default. Keep its
-        // active bindings while retiring projects that now resolve disabled.
-        shouldReleaseProject: (workingDir) => !registry.isEnabled(id, workingDir),
+    return runBuiltinToolMutation(id, async () => {
+      const ok = await getPluginRegistry().setEnabled(id, enabled);
+      if (!ok) {
+        throwIpcError('PERMISSION_DENIED', `Cannot modify essential plugin: ${id}`);
+      }
+      if (id === 'ios-simulator' && enabled === false) {
+        const registry = getPluginRegistry();
+        await deactivateIOSSimulatorForBuiltinToolDefault({
+          // A project-level explicit enable outranks the user default. Keep its
+          // active bindings while retiring projects that now resolve disabled.
+          shouldReleaseProject: (workingDir) => !registry.isEnabled(id, workingDir),
+          shouldReleaseHost: () => !hasActiveIOSSimulatorProvider(),
+        });
+      }
+      // Ordinary plugins are user defaults: existing sessions keep their frozen
+      // policy and only new sessions observe changes, so no shared environment
+      // refresh is needed.
+      if (!GLOBAL_PLUGIN_IDS.has(id) && id !== 'browser') {
+        return { codexMcpRefreshed: true };
+      }
+      // Machine-wide tools keep their existing lifecycle. The preference is
+      // already durable at this point, so refresh best-effort; a busy turn must
+      // keep using the existing bridge and must not turn a successful save into
+      // an IPC failure. Renderer surfaces the deferred state explicitly.
+      return refreshCodexMcpEnvironment({
+        restartCodex: restartCodexAfterAuthModeChange,
+        shutdownCodexEnvironment,
+        onDeferred: () =>
+          deferredCodexRestartHolder?.schedule('Codex Browser capability routing changed'),
+        logger: log,
       });
-    }
-    // Ordinary plugins are user defaults: existing sessions keep their frozen
-    // policy and only new sessions observe changes, so no shared environment
-    // refresh is needed.
-    if (!GLOBAL_PLUGIN_IDS.has(id) && id !== 'browser') {
-      return { codexMcpRefreshed: true };
-    }
-    // Machine-wide tools keep their existing lifecycle. The preference is
-    // already durable at this point, so refresh best-effort; a busy turn must
-    // keep using the existing bridge and must not turn a successful save into
-    // an IPC failure. Renderer surfaces the deferred state explicitly.
-    return refreshCodexMcpEnvironment({
-      restartCodex: restartCodexAfterAuthModeChange,
-      shutdownCodexEnvironment,
-      onDeferred: () =>
-        deferredCodexRestartHolder?.schedule('Codex Browser capability routing changed'),
-      logger: log,
     });
   });
 
@@ -13324,33 +13342,41 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
     if (typeof id !== 'string') {
       throwIpcError('INVALID_PARAMS', 'id (string) required');
     }
-    const ok = await getPluginRegistry().clearEnabled(id);
-    if (!ok) {
-      throwIpcError('PERMISSION_DENIED', `Cannot modify essential plugin: ${id}`);
-    }
-    if (id === 'ios-simulator' && !getPluginRegistry().isEnabled(id)) {
-      const registry = getPluginRegistry();
-      await deactivateIOSSimulatorForBuiltinToolDefault({
-        shouldReleaseProject: (workingDir) => !registry.isEnabled(id, workingDir),
+    return runBuiltinToolMutation(id, async () => {
+      const ok = await getPluginRegistry().clearEnabled(id);
+      if (!ok) {
+        throwIpcError('PERMISSION_DENIED', `Cannot modify essential plugin: ${id}`);
+      }
+      if (id === 'ios-simulator' && !getPluginRegistry().isEnabled(id)) {
+        const registry = getPluginRegistry();
+        await deactivateIOSSimulatorForBuiltinToolDefault({
+          shouldReleaseProject: (workingDir) => !registry.isEnabled(id, workingDir),
+          shouldReleaseHost: () => !hasActiveIOSSimulatorProvider(),
+        });
+      }
+      if (!GLOBAL_PLUGIN_IDS.has(id) && id !== 'browser') {
+        return { codexMcpRefreshed: true };
+      }
+      return refreshCodexMcpEnvironment({
+        restartCodex: restartCodexAfterAuthModeChange,
+        shutdownCodexEnvironment,
+        onDeferred: () =>
+          deferredCodexRestartHolder?.schedule('Codex Browser capability routing changed'),
+        logger: log,
       });
-    }
-    if (!GLOBAL_PLUGIN_IDS.has(id) && id !== 'browser') {
-      return { codexMcpRefreshed: true };
-    }
-    return refreshCodexMcpEnvironment({
-      restartCodex: restartCodexAfterAuthModeChange,
-      shutdownCodexEnvironment,
-      onDeferred: () =>
-        deferredCodexRestartHolder?.schedule('Codex Browser capability routing changed'),
-      logger: log,
     });
   });
 
   registerProjectPluginPolicyHandlers(createElectronIpcHandlerRegistry(), {
     getPluginRegistry,
+    runPolicyMutation: (id, mutation) => runBuiltinToolMutation(id, mutation),
     onProjectPolicyChanged: async ({ workingDir, id, effectiveEnabled }) => {
       if (id === 'ios-simulator' && !effectiveEnabled) {
-        await deactivateIOSSimulatorForBuiltinToolProject(workingDir);
+        const registry = getPluginRegistry();
+        await deactivateIOSSimulatorForBuiltinToolProject(
+          workingDir,
+          () => !hasActiveIOSSimulatorProvider(),
+        );
       }
     },
   });
@@ -13359,19 +13385,15 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
   registerAndroidAutomationHandlers(createElectronIpcHandlerRegistry());
 
   // ── iOS Simulator pane / Agent discovery ────────────────────────────────
-  registerIOSSimulatorHandlers(
-    createElectronIpcHandlerRegistry(),
-    {
-      isPluginAvailable: (workingDir) =>
-        getIOSSimulatorPluginAccessDecision(workingDir).allowed,
-      getSessionContext: async (sessionId) => {
-        const liveSession = maker.getSession(sessionId);
-        if (liveSession) return { workingDir: liveSession.workDir };
-        const snapshot = await getSessionRowSnapshotStrict(sessionId);
-        return snapshot ? { workingDir: snapshot.workingDir } : null;
-      },
+  registerIOSSimulatorHandlers(createElectronIpcHandlerRegistry(), {
+    isPluginAvailable: (workingDir) => getIOSSimulatorPluginAccessDecision(workingDir).allowed,
+    getSessionContext: async (sessionId) => {
+      const liveSession = maker.getSession(sessionId);
+      if (liveSession) return { workingDir: liveSession.workDir };
+      const snapshot = await getSessionRowSnapshotStrict(sessionId);
+      return snapshot ? { workingDir: snapshot.workingDir } : null;
     },
-  );
+  });
 
   // ── Browser automation (Settings →「电脑使用」) ───────────────────────────
   // Probe local browser detection. Drives the detection status + download

--- a/apps/desktop/src/main/mcp-integrations/__tests__/ios-simulator.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/__tests__/ios-simulator.test.ts
@@ -2700,6 +2700,102 @@ describe('iOS Simulator host', () => {
     expect(inspect).not.toHaveBeenCalled();
   });
 
+  it('deactivates only bindings in the requested project and preserves other projects', async () => {
+    const lifecycle: IOSSimulatorSimctlLifecycle = {
+      findExact: vi.fn(async (udid) =>
+        READY_REPORT.devices.find((device) => device.udid === udid) ?? null,
+      ),
+      bootExact: vi.fn(),
+      shutdownExact: vi.fn(),
+      createExact: vi.fn(),
+      deleteExact: vi.fn(),
+    };
+    const actor = new IOSSimulatorInstanceActor({
+      store: new IOSSimulatorOwnershipStore({ createId: () => crypto.randomUUID() }),
+      lifecycle,
+    });
+    actor.attach({
+      sessionId: 'project-a-session',
+      worktreeRoot: '/repo/.cindy-worktrees/task-a',
+      sourceFingerprint: 'fingerprint-a',
+      device: READY_REPORT.devices[0]!,
+      bootProvenance: 'preexisting',
+    });
+    actor.attach({
+      sessionId: 'project-b-session',
+      worktreeRoot: '/other/project',
+      sourceFingerprint: 'fingerprint-b',
+      device: { ...READY_REPORT.devices[0]!, udid: '9A9D41E0-E031-4AD0-A8B5-847480802E8E' },
+      bootProvenance: 'preexisting',
+    });
+    const host = createIOSSimulatorHost({
+      actor,
+      lifecycle,
+      runtime: { inspect: vi.fn(async () => READY_REPORT) },
+      driverManager: {
+        get: vi.fn(() => null),
+        start: vi.fn(),
+        stop: vi.fn(async () => undefined),
+      },
+      getSession: vi.fn(async (id) => localSession(id)),
+      mediaCapture: {
+        discardInstance: vi.fn(async () => undefined),
+        discardSession: vi.fn(async () => undefined),
+      } as unknown as IOSSimulatorMediaCaptureAdapter,
+    });
+
+    await expect(
+      host.deactivate({ projectWorkingDirs: ['/repo'] }),
+    ).resolves.toEqual({ hostCanBeReleased: false, cleanedInstanceCount: 1 });
+    expect(actor.listAll().map((instance) => instance.sessionId)).toEqual([
+      'project-b-session',
+    ]);
+  });
+
+  it('keeps ownership when capability deactivation cleanup fails', async () => {
+    const lifecycle: IOSSimulatorSimctlLifecycle = {
+      findExact: vi.fn(async () => READY_REPORT.devices[0]!),
+      bootExact: vi.fn(),
+      shutdownExact: vi.fn(),
+      createExact: vi.fn(),
+      deleteExact: vi.fn(),
+    };
+    const actor = new IOSSimulatorInstanceActor({
+      store: new IOSSimulatorOwnershipStore({ createId: () => crypto.randomUUID() }),
+      lifecycle,
+    });
+    actor.attach({
+      sessionId: 'cleanup-failure-session',
+      worktreeRoot: '/tmp/cleanup-failure',
+      sourceFingerprint: 'fingerprint-a',
+      device: READY_REPORT.devices[0]!,
+      bootProvenance: 'preexisting',
+    });
+    const host = createIOSSimulatorHost({
+      actor,
+      lifecycle,
+      runtime: { inspect: vi.fn(async () => READY_REPORT) },
+      driverManager: {
+        get: vi.fn(() => null),
+        start: vi.fn(),
+        stop: vi.fn(async () => {
+          throw new Error('driver cleanup failed');
+        }),
+      },
+      getSession: vi.fn(async (id) => localSession(id)),
+      mediaCapture: {
+        discardInstance: vi.fn(async () => undefined),
+        discardSession: vi.fn(async () => undefined),
+      } as unknown as IOSSimulatorMediaCaptureAdapter,
+    });
+
+    await expect(host.deactivate()).rejects.toMatchObject({ code: 'DEVICE_BUSY' });
+    expect(actor.listAll()).toHaveLength(1);
+    await expect(
+      host.callTool('list_instances', {}, { sessionId: 'cleanup-failure-session' }),
+    ).resolves.toMatchObject({ ok: true });
+  });
+
   it('disposes WDA and recording resources on host shutdown without changing ownership', async () => {
     const lifecycle: IOSSimulatorSimctlLifecycle = {
       findExact: vi.fn(),

--- a/apps/desktop/src/main/mcp-integrations/__tests__/ios-simulator.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/__tests__/ios-simulator.test.ts
@@ -29,6 +29,7 @@ import {
 } from '@cindy/ios-simulator-runtime';
 import { IOSSimulatorToolRegistry, registerIOSSimulatorTools } from '@cindy/mcps';
 import type { IOSSimulatorPublicRouteStatus } from '../../../shared/iosSimulatorIpc';
+import { normalizeWorkingDirForProjectSettings } from '../../../shared/workingDir';
 import {
   cancelIOSSimulatorSessionOperations,
   cleanupIOSSimulatorRemovedSession,
@@ -2850,7 +2851,10 @@ describe('iOS Simulator host', () => {
       device: READY_REPORT.devices[0]!,
       bootProvenance: 'preexisting',
     });
-    const shouldReleaseProject = vi.fn((workingDir: string) => workingDir !== linkedProject);
+    const logicalProjectForPolicy = normalizeWorkingDirForProjectSettings(linkedProject)!;
+    const shouldReleaseProject = vi.fn(
+      (workingDir: string) => workingDir !== logicalProjectForPolicy,
+    );
     const host = createIOSSimulatorHost({
       actor,
       lifecycle,
@@ -2862,7 +2866,7 @@ describe('iOS Simulator host', () => {
         hostCanBeReleased: false,
         cleanedInstanceCount: 0,
       });
-      expect(shouldReleaseProject).toHaveBeenCalledWith(linkedProject);
+      expect(shouldReleaseProject).toHaveBeenCalledWith(logicalProjectForPolicy);
       expect(actor.list('symlink-policy-session')).toHaveLength(1);
     } finally {
       await host.dispose();

--- a/apps/desktop/src/main/mcp-integrations/__tests__/ios-simulator.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/__tests__/ios-simulator.test.ts
@@ -2764,6 +2764,169 @@ describe('iOS Simulator host', () => {
     ]);
   });
 
+  it('rejects a late panel status read after project deactivation has closed admission', async () => {
+    const lifecycle: IOSSimulatorSimctlLifecycle = {
+      findExact: vi.fn(async () => READY_REPORT.devices[0]!),
+      bootExact: vi.fn(),
+      shutdownExact: vi.fn(),
+      createExact: vi.fn(),
+      deleteExact: vi.fn(),
+    };
+    const actor = new IOSSimulatorInstanceActor({
+      store: new IOSSimulatorOwnershipStore({ createId: () => crypto.randomUUID() }),
+      lifecycle,
+    });
+    actor.attach({
+      sessionId: 'project-a-session',
+      worktreeRoot: '/repo/project-a',
+      sourceFingerprint: 'fingerprint-a',
+      device: READY_REPORT.devices[0]!,
+      bootProvenance: 'preexisting',
+    });
+    let signalDriverStop!: () => void;
+    const driverStopStarted = new Promise<void>((resolve) => {
+      signalDriverStop = resolve;
+    });
+    let releaseDriverStop!: () => void;
+    const driverStopReleased = new Promise<void>((resolve) => {
+      releaseDriverStop = resolve;
+    });
+    let signalInspectStarted!: () => void;
+    const inspectStarted = new Promise<void>((resolve) => {
+      signalInspectStarted = resolve;
+    });
+    let releaseInspect!: () => void;
+    const inspectReleased = new Promise<void>((resolve) => {
+      releaseInspect = resolve;
+    });
+    const inspect = vi.fn(async () => {
+      signalInspectStarted();
+      await inspectReleased;
+      return READY_REPORT;
+    });
+    const host = createIOSSimulatorHost({
+      actor,
+      lifecycle,
+      runtime: { inspect },
+      driverManager: {
+        get: vi.fn(() => null),
+        start: vi.fn(),
+        stop: vi.fn(async () => {
+          signalDriverStop();
+          await driverStopReleased;
+        }),
+      },
+      getSession: vi.fn(async (id) => ({
+        ...localSession(id),
+        workDir: '/repo/project-a',
+      })),
+      mediaCapture: {
+        discardInstance: vi.fn(async () => undefined),
+        discardSession: vi.fn(async () => undefined),
+      } as unknown as IOSSimulatorMediaCaptureAdapter,
+    });
+
+    const deactivation = host.deactivate({ projectWorkingDirs: ['/repo/project-a'] });
+    await driverStopStarted;
+
+    const status = host.getStatus('project-a-session');
+    const firstStatusEffect = await Promise.race([
+      status.then(() => 'settled' as const),
+      inspectStarted.then(() => 'inspected' as const),
+    ]);
+    releaseInspect();
+    releaseDriverStop();
+
+    expect(firstStatusEffect).toBe('settled');
+    await expect(status).resolves.toMatchObject({
+      ok: false,
+      errorCode: 'IOS_SIMULATOR_HOST_ERROR',
+    });
+    await expect(deactivation).resolves.toEqual({
+      hostCanBeReleased: true,
+      cleanedInstanceCount: 1,
+    });
+    expect(inspect).not.toHaveBeenCalled();
+    expect(actor.listAll()).toEqual([]);
+    await host.dispose();
+  });
+
+  it('does not start a late status reconciliation after project deactivation begins', async () => {
+    const lifecycle: IOSSimulatorSimctlLifecycle = {
+      findExact: vi.fn(async () => READY_REPORT.devices[0]!),
+      bootExact: vi.fn(),
+      shutdownExact: vi.fn(),
+      createExact: vi.fn(),
+      deleteExact: vi.fn(),
+    };
+    const actor = new IOSSimulatorInstanceActor({
+      store: new IOSSimulatorOwnershipStore({ createId: () => crypto.randomUUID() }),
+      lifecycle,
+    });
+    actor.attach({
+      sessionId: 'project-a-session',
+      worktreeRoot: '/repo/project-a',
+      sourceFingerprint: 'fingerprint-a',
+      device: READY_REPORT.devices[0]!,
+      bootProvenance: 'preexisting',
+    });
+    let resolveSessionLookup!: (session: ReturnType<typeof localSession>) => void;
+    const sessionLookup = new Promise<ReturnType<typeof localSession>>((resolve) => {
+      resolveSessionLookup = resolve;
+    });
+    let signalDriverStop!: () => void;
+    const driverStopStarted = new Promise<void>((resolve) => {
+      signalDriverStop = resolve;
+    });
+    let releaseDriverStop!: () => void;
+    const driverStopReleased = new Promise<void>((resolve) => {
+      releaseDriverStop = resolve;
+    });
+    const inspect = vi.fn(async () => READY_REPORT);
+    const getSession = vi.fn(async (id: string) => {
+      if (getSession.mock.calls.length === 1) return sessionLookup;
+      return { ...localSession(id), workDir: '/repo/project-a' };
+    });
+    const host = createIOSSimulatorHost({
+      actor,
+      lifecycle,
+      runtime: { inspect },
+      driverManager: {
+        get: vi.fn(() => null),
+        start: vi.fn(),
+        stop: vi.fn(async () => {
+          signalDriverStop();
+          await driverStopReleased;
+        }),
+      },
+      getSession,
+      mediaCapture: {
+        discardInstance: vi.fn(async () => undefined),
+        discardSession: vi.fn(async () => undefined),
+      } as unknown as IOSSimulatorMediaCaptureAdapter,
+    });
+
+    const status = host.getStatus('project-a-session');
+    await vi.waitFor(() => expect(getSession).toHaveBeenCalledOnce());
+    const deactivation = host.deactivate({ projectWorkingDirs: ['/repo/project-a'] });
+    await driverStopStarted;
+
+    resolveSessionLookup({ ...localSession('project-a-session'), workDir: '/repo/project-a' });
+    await expect(status).resolves.toMatchObject({
+      ok: false,
+      errorCode: 'IOS_SIMULATOR_HOST_ERROR',
+    });
+    releaseDriverStop();
+
+    await expect(deactivation).resolves.toEqual({
+      hostCanBeReleased: true,
+      cleanedInstanceCount: 1,
+    });
+    expect(inspect).not.toHaveBeenCalled();
+    expect(actor.listAll()).toEqual([]);
+    await host.dispose();
+  });
+
   it('keeps ownership when capability deactivation cleanup fails', async () => {
     const lifecycle: IOSSimulatorSimctlLifecycle = {
       findExact: vi.fn(async () => READY_REPORT.devices[0]!),

--- a/apps/desktop/src/main/mcp-integrations/__tests__/ios-simulator.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/__tests__/ios-simulator.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readFile, rm, stat, utimes, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, stat, symlink, utimes, writeFile } from 'node:fs/promises';
 import { readFileSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -35,10 +35,12 @@ import {
   createIOSSimulatorHost,
   createRegistryBackedIOSSimulatorDeviceGrantStore,
   createRegistryBackedIOSSimulatorActor,
+  deactivateIOSSimulatorHost,
   disposeIOSSimulatorHost,
   flushIOSSimulatorOwnershipRegistry,
   getIOSSimulatorPluginStatus,
   getIOSSimulatorMcpDeps,
+  initializeIOSSimulatorHost,
   reconcilePersistedIOSSimulatorOwnership,
   type IOSSimulatorAppLifecycleAdapter,
   type IOSSimulatorMediaCaptureAdapter,
@@ -296,8 +298,10 @@ describe('iOS Simulator host', () => {
       await mkdir(path.dirname(evidencePath), { recursive: true });
       await writeFile(evidencePath, '{"version":1,"armedAt":"2026-08-11T00:00:00.000Z"}');
       const competingRegistry = new IOSSimulatorOwnershipRegistryFile(registryPath);
-      let finishRecovery: (value: { recovered: readonly string[]; complete: boolean }) => void =
-        () => undefined;
+      let finishRecovery: (value: {
+        recovered: readonly string[];
+        complete: boolean;
+      }) => void = () => undefined;
       const recoverPendingCreatesAtStartup = vi.fn(
         (_owned: readonly { udid: string; name: string }[], _signal?: AbortSignal) =>
           new Promise<{ recovered: readonly string[]; complete: boolean }>((resolve) => {
@@ -450,8 +454,8 @@ describe('iOS Simulator host', () => {
   );
 
   it('gates an already-created Host on one startup pending-create recovery', async () => {
-    let finishRecovery: (value: { recovered: readonly string[]; complete: boolean }) => void =
-      () => undefined;
+    let finishRecovery: (value: { recovered: readonly string[]; complete: boolean }) => void = () =>
+      undefined;
     const recoverPendingCreatesAtStartup = vi.fn(
       (_owned: readonly { udid: string; name: string }[], _signal?: AbortSignal) =>
         new Promise<{ recovered: readonly string[]; complete: boolean }>((resolve) => {
@@ -911,9 +915,7 @@ describe('iOS Simulator host', () => {
       .recommendedActions;
     expect(recommended).toContain('list_simulator_devices');
     for (const action of recommended) {
-      expect(advertised.has(action) || action === 'create_instance_or_attach_device').toBe(
-        true,
-      );
+      expect(advertised.has(action) || action === 'create_instance_or_attach_device').toBe(true);
     }
   });
 
@@ -2714,8 +2716,8 @@ describe('iOS Simulator host', () => {
 
   it('deactivates only bindings in the requested project and preserves other projects', async () => {
     const lifecycle: IOSSimulatorSimctlLifecycle = {
-      findExact: vi.fn(async (udid) =>
-        READY_REPORT.devices.find((device) => device.udid === udid) ?? null,
+      findExact: vi.fn(
+        async (udid) => READY_REPORT.devices.find((device) => device.udid === udid) ?? null,
       ),
       bootExact: vi.fn(),
       shutdownExact: vi.fn(),
@@ -2756,15 +2758,24 @@ describe('iOS Simulator host', () => {
       } as unknown as IOSSimulatorMediaCaptureAdapter,
     });
 
-    await expect(
-      host.deactivate({ projectWorkingDirs: ['/repo'] }),
-    ).resolves.toEqual({ hostCanBeReleased: false, cleanedInstanceCount: 1 });
-    expect(actor.listAll().map((instance) => instance.sessionId)).toEqual([
-      'project-b-session',
-    ]);
+    await expect(host.deactivate({ projectWorkingDirs: ['/repo'] })).resolves.toEqual({
+      hostCanBeReleased: false,
+      cleanedInstanceCount: 1,
+    });
+    expect(actor.listAll().map((instance) => instance.sessionId)).toEqual(['project-b-session']);
   });
 
-  it('rejects a late panel status read after project deactivation has closed admission', async () => {
+  it('matches a logical project path to a binding persisted under its real path', async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), 'cindy-ios-project-symlink-'));
+    const realProject = path.join(root, 'real-project');
+    const linkedProject = path.join(root, 'linked-project');
+    await mkdir(realProject);
+    try {
+      await symlink(realProject, linkedProject, 'dir');
+    } catch {
+      await rm(root, { recursive: true, force: true });
+      return;
+    }
     const lifecycle: IOSSimulatorSimctlLifecycle = {
       findExact: vi.fn(async () => READY_REPORT.devices[0]!),
       bootExact: vi.fn(),
@@ -2777,81 +2788,127 @@ describe('iOS Simulator host', () => {
       lifecycle,
     });
     actor.attach({
-      sessionId: 'project-a-session',
-      worktreeRoot: '/repo/project-a',
+      sessionId: 'symlink-session',
+      worktreeRoot: realProject,
       sourceFingerprint: 'fingerprint-a',
       device: READY_REPORT.devices[0]!,
       bootProvenance: 'preexisting',
     });
-    let signalDriverStop!: () => void;
-    const driverStopStarted = new Promise<void>((resolve) => {
-      signalDriverStop = resolve;
-    });
-    let releaseDriverStop!: () => void;
-    const driverStopReleased = new Promise<void>((resolve) => {
-      releaseDriverStop = resolve;
-    });
-    let signalInspectStarted!: () => void;
-    const inspectStarted = new Promise<void>((resolve) => {
-      signalInspectStarted = resolve;
-    });
-    let releaseInspect!: () => void;
-    const inspectReleased = new Promise<void>((resolve) => {
-      releaseInspect = resolve;
-    });
-    const inspect = vi.fn(async () => {
-      signalInspectStarted();
-      await inspectReleased;
-      return READY_REPORT;
-    });
     const host = createIOSSimulatorHost({
       actor,
       lifecycle,
-      runtime: { inspect },
+      runtime: { inspect: vi.fn(async () => READY_REPORT) },
       driverManager: {
         get: vi.fn(() => null),
         start: vi.fn(),
-        stop: vi.fn(async () => {
-          signalDriverStop();
-          await driverStopReleased;
-        }),
+        stop: vi.fn(async () => undefined),
       },
-      getSession: vi.fn(async (id) => ({
-        ...localSession(id),
-        workDir: '/repo/project-a',
-      })),
+      getSession: vi.fn(async (id) => ({ ...localSession(id), workDir: linkedProject })),
       mediaCapture: {
         discardInstance: vi.fn(async () => undefined),
         discardSession: vi.fn(async () => undefined),
       } as unknown as IOSSimulatorMediaCaptureAdapter,
     });
+    try {
+      await expect(host.deactivate({ projectWorkingDirs: [linkedProject] })).resolves.toEqual({
+        hostCanBeReleased: true,
+        cleanedInstanceCount: 1,
+      });
+      expect(actor.listAll()).toEqual([]);
+    } finally {
+      await host.dispose();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
 
-    const deactivation = host.deactivate({ projectWorkingDirs: ['/repo/project-a'] });
-    await driverStopStarted;
-
-    const status = host.getStatus('project-a-session');
-    const firstStatusEffect = await Promise.race([
-      status.then(() => 'settled' as const),
-      inspectStarted.then(() => 'inspected' as const),
-    ]);
-    releaseInspect();
-    releaseDriverStop();
-
-    expect(firstStatusEffect).toBe('settled');
-    await expect(status).resolves.toMatchObject({
-      ok: false,
-      errorCode: 'IOS_SIMULATOR_HOST_ERROR',
+  it('checks project policy through the logical path while matching its physical binding', async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), 'cindy-ios-project-policy-symlink-'));
+    const realProject = path.join(root, 'real-project');
+    const linkedProject = path.join(root, 'linked-project');
+    await mkdir(realProject);
+    try {
+      await symlink(realProject, linkedProject, 'dir');
+    } catch {
+      await rm(root, { recursive: true, force: true });
+      return;
+    }
+    const lifecycle: IOSSimulatorSimctlLifecycle = {
+      findExact: vi.fn(async () => READY_REPORT.devices[0]!),
+      bootExact: vi.fn(),
+      shutdownExact: vi.fn(),
+      createExact: vi.fn(),
+      deleteExact: vi.fn(),
+    };
+    const actor = new IOSSimulatorInstanceActor({
+      store: new IOSSimulatorOwnershipStore({ createId: () => crypto.randomUUID() }),
+      lifecycle,
     });
-    await expect(deactivation).resolves.toEqual({
+    actor.attach({
+      sessionId: 'symlink-policy-session',
+      worktreeRoot: realProject,
+      sourceFingerprint: 'fingerprint-a',
+      device: READY_REPORT.devices[0]!,
+      bootProvenance: 'preexisting',
+    });
+    const shouldReleaseProject = vi.fn((workingDir: string) => workingDir !== linkedProject);
+    const host = createIOSSimulatorHost({
+      actor,
+      lifecycle,
+      runtime: { inspect: vi.fn(async () => READY_REPORT) },
+      getSession: vi.fn(async (id) => ({ ...localSession(id), workDir: linkedProject })),
+    });
+    try {
+      await expect(host.deactivate({ shouldReleaseProject })).resolves.toEqual({
+        hostCanBeReleased: false,
+        cleanedInstanceCount: 0,
+      });
+      expect(shouldReleaseProject).toHaveBeenCalledWith(linkedProject);
+      expect(actor.list('symlink-policy-session')).toHaveLength(1);
+    } finally {
+      await host.dispose();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('reconciles pending-create evidence during an unscoped capability shutdown', async () => {
+    let armed = true;
+    const pendingCreateEvidence = {
+      arm: vi.fn(() => 9),
+      isArmed: vi.fn(() => armed),
+      generation: vi.fn(() => 9),
+      clearIfUnchanged: vi.fn(() => {
+        armed = false;
+      }),
+    };
+    const recoverPendingCreatesAtStartup = vi.fn(async () => ({
+      recovered: [] as readonly string[],
+      complete: true,
+    }));
+    const lifecycle: IOSSimulatorSimctlLifecycle = {
+      findExact: vi.fn(),
+      bootExact: vi.fn(),
+      shutdownExact: vi.fn(),
+      createExact: vi.fn(),
+      recoverPendingCreatesAtStartup,
+      deleteExact: vi.fn(),
+    };
+    const host = createIOSSimulatorHost({
+      lifecycle,
+      pendingCreateEvidence,
+      runtime: { inspect: vi.fn(async () => READY_REPORT) },
+      getSession: vi.fn(async (id) => localSession(id)),
+    });
+
+    await expect(host.deactivate()).resolves.toEqual({
       hostCanBeReleased: true,
-      cleanedInstanceCount: 1,
+      cleanedInstanceCount: 0,
     });
-    expect(inspect).not.toHaveBeenCalled();
-    expect(actor.listAll()).toEqual([]);
+    expect(recoverPendingCreatesAtStartup).toHaveBeenCalledWith([], expect.any(AbortSignal));
+    expect(pendingCreateEvidence.clearIfUnchanged).toHaveBeenCalledWith(9);
     await host.dispose();
   });
 
-  it('does not start a late status reconciliation after project deactivation begins', async () => {
+  it('keeps another project status and tools available during scoped deactivation', async () => {
     const lifecycle: IOSSimulatorSimctlLifecycle = {
       findExact: vi.fn(async () => READY_REPORT.devices[0]!),
       bootExact: vi.fn(),
@@ -2870,9 +2927,12 @@ describe('iOS Simulator host', () => {
       device: READY_REPORT.devices[0]!,
       bootProvenance: 'preexisting',
     });
-    let resolveSessionLookup!: (session: ReturnType<typeof localSession>) => void;
-    const sessionLookup = new Promise<ReturnType<typeof localSession>>((resolve) => {
-      resolveSessionLookup = resolve;
+    actor.attach({
+      sessionId: 'project-b-session',
+      worktreeRoot: '/repo/project-b',
+      sourceFingerprint: 'fingerprint-b',
+      device: { ...READY_REPORT.devices[0]!, udid: '9A9D41E0-E031-4AD0-A8B5-847480802E8E' },
+      bootProvenance: 'preexisting',
     });
     let signalDriverStop!: () => void;
     const driverStopStarted = new Promise<void>((resolve) => {
@@ -2883,14 +2943,105 @@ describe('iOS Simulator host', () => {
       releaseDriverStop = resolve;
     });
     const inspect = vi.fn(async () => READY_REPORT);
-    const getSession = vi.fn(async (id: string) => {
-      if (getSession.mock.calls.length === 1) return sessionLookup;
-      return { ...localSession(id), workDir: '/repo/project-a' };
-    });
     const host = createIOSSimulatorHost({
       actor,
       lifecycle,
       runtime: { inspect },
+      driverManager: {
+        get: vi.fn(() => null),
+        start: vi.fn(),
+        stop: vi.fn(async (instanceId: string) => {
+          if (
+            actor.list('project-a-session').some((instance) => instance.instanceId === instanceId)
+          ) {
+            signalDriverStop();
+            await driverStopReleased;
+          }
+        }),
+      },
+      getSession: vi.fn(async (id) => ({
+        ...localSession(id),
+        workDir: id === 'project-a-session' ? '/repo/project-a' : '/repo/project-b',
+      })),
+      mediaCapture: {
+        discardInstance: vi.fn(async () => undefined),
+        discardSession: vi.fn(async () => undefined),
+      } as unknown as IOSSimulatorMediaCaptureAdapter,
+    });
+
+    const deactivation = host.deactivate({ projectWorkingDirs: ['/repo/project-a'] });
+    await driverStopStarted;
+
+    await expect(host.getStatus('project-a-session')).resolves.toMatchObject({
+      ok: false,
+      errorCode: 'MUTATION_CANCELLED',
+    });
+    await expect(host.getStatus('project-b-session')).resolves.toMatchObject({
+      ok: true,
+      sessionId: 'project-b-session',
+      instances: [{ instanceId: expect.any(String) }],
+    });
+    await expect(host.getPluginStatus('project-b-session')).resolves.toMatchObject({ ok: true });
+    await expect(
+      host.callTool('list_instances', {}, { sessionId: 'project-b-session' }),
+    ).resolves.toMatchObject({
+      ok: true,
+      data: { instances: [{ instanceId: expect.any(String) }] },
+    });
+    const projectBInstance = actor.list('project-b-session')[0]!;
+    await expect(
+      host.setViewerVisibility(
+        'project-b-session',
+        {
+          instanceId: projectBInstance.instanceId,
+          generation: projectBInstance.generation,
+          leaseId: projectBInstance.lease.id,
+        },
+        false,
+      ),
+    ).resolves.toMatchObject({ ok: true });
+    releaseDriverStop();
+
+    await expect(deactivation).resolves.toEqual({
+      hostCanBeReleased: false,
+      cleanedInstanceCount: 1,
+    });
+    expect(inspect).toHaveBeenCalled();
+    expect(actor.listAll().map((instance) => instance.sessionId)).toEqual(['project-b-session']);
+    await host.dispose();
+  });
+
+  it('completes a scoped cleanup once it has been admitted', async () => {
+    const lifecycle: IOSSimulatorSimctlLifecycle = {
+      findExact: vi.fn(async () => READY_REPORT.devices[0]!),
+      bootExact: vi.fn(),
+      shutdownExact: vi.fn(),
+      createExact: vi.fn(),
+      deleteExact: vi.fn(),
+    };
+    const actor = new IOSSimulatorInstanceActor({
+      store: new IOSSimulatorOwnershipStore({ createId: () => crypto.randomUUID() }),
+      lifecycle,
+    });
+    actor.attach({
+      sessionId: 'project-a-session',
+      worktreeRoot: '/repo/project-a',
+      sourceFingerprint: 'fingerprint-a',
+      device: READY_REPORT.devices[0]!,
+      bootProvenance: 'preexisting',
+    });
+    let releaseDriverStop!: () => void;
+    const driverStopReleased = new Promise<void>((resolve) => {
+      releaseDriverStop = resolve;
+    });
+    let signalDriverStop!: () => void;
+    const driverStopStarted = new Promise<void>((resolve) => {
+      signalDriverStop = resolve;
+    });
+    const host = createIOSSimulatorHost({
+      actor,
+      lifecycle,
+      runtime: { inspect: vi.fn(async () => READY_REPORT) },
       driverManager: {
         get: vi.fn(() => null),
         start: vi.fn(),
@@ -2899,6 +3050,194 @@ describe('iOS Simulator host', () => {
           await driverStopReleased;
         }),
       },
+      getSession: vi.fn(async (id) => ({ ...localSession(id), workDir: '/repo/project-a' })),
+      mediaCapture: {
+        discardInstance: vi.fn(async () => undefined),
+        discardSession: vi.fn(async () => undefined),
+      } as unknown as IOSSimulatorMediaCaptureAdapter,
+    });
+
+    const deactivation = host.deactivate({ projectWorkingDirs: ['/repo/project-a'] });
+    await driverStopStarted;
+    releaseDriverStop();
+
+    await expect(deactivation).resolves.toEqual({
+      hostCanBeReleased: true,
+      cleanedInstanceCount: 1,
+    });
+    expect(actor.list('project-a-session')).toEqual([]);
+    expect(lifecycle.shutdownExact).not.toHaveBeenCalled();
+    expect(lifecycle.deleteExact).not.toHaveBeenCalled();
+    await host.dispose();
+  });
+
+  it('keeps an enabled project while default disable cleans disabled projects', async () => {
+    const projectBDevice = {
+      ...READY_REPORT.devices[0]!,
+      udid: '9A9D41E0-E031-4AD0-A8B5-847480802E8E',
+    };
+    const lifecycle: IOSSimulatorSimctlLifecycle = {
+      findExact: vi.fn(
+        async (udid) =>
+          [READY_REPORT.devices[0]!, projectBDevice].find((device) => device.udid === udid) ?? null,
+      ),
+      bootExact: vi.fn(),
+      shutdownExact: vi.fn(),
+      createExact: vi.fn(),
+      deleteExact: vi.fn(),
+    };
+    const actor = new IOSSimulatorInstanceActor({
+      store: new IOSSimulatorOwnershipStore({ createId: () => crypto.randomUUID() }),
+      lifecycle,
+    });
+    actor.attach({
+      sessionId: 'project-a-session',
+      worktreeRoot: '/repo/project-a',
+      sourceFingerprint: 'fingerprint-a',
+      device: READY_REPORT.devices[0]!,
+      bootProvenance: 'preexisting',
+    });
+    actor.attach({
+      sessionId: 'project-b-session',
+      worktreeRoot: '/repo/project-b',
+      sourceFingerprint: 'fingerprint-b',
+      device: projectBDevice,
+      bootProvenance: 'preexisting',
+    });
+    const projectAInstanceId = actor.list('project-a-session')[0]!.instanceId;
+    let releaseProjectAStop!: () => void;
+    const projectAStopReleased = new Promise<void>((resolve) => {
+      releaseProjectAStop = resolve;
+    });
+    let signalProjectAStop!: () => void;
+    const projectAStopStarted = new Promise<void>((resolve) => {
+      signalProjectAStop = resolve;
+    });
+    const enabledProjects = new Set(['/repo/project-b']);
+    const host = createIOSSimulatorHost({
+      actor,
+      lifecycle,
+      runtime: { inspect: vi.fn(async () => READY_REPORT) },
+      driverManager: {
+        get: vi.fn(() => null),
+        start: vi.fn(),
+        stop: vi.fn(async (instanceId: string) => {
+          if (instanceId !== projectAInstanceId) return;
+          signalProjectAStop();
+          await projectAStopReleased;
+        }),
+      },
+      getSession: vi.fn(async (id) => ({
+        ...localSession(id),
+        workDir: id === 'project-a-session' ? '/repo/project-a' : '/repo/project-b',
+      })),
+      mediaCapture: {
+        discardInstance: vi.fn(async () => undefined),
+        discardSession: vi.fn(async () => undefined),
+      } as unknown as IOSSimulatorMediaCaptureAdapter,
+    });
+
+    const deactivation = host.deactivate({
+      shouldReleaseProject: (workingDir) => !enabledProjects.has(workingDir),
+    });
+    await projectAStopStarted;
+    releaseProjectAStop();
+
+    await expect(deactivation).resolves.toEqual({
+      hostCanBeReleased: false,
+      cleanedInstanceCount: 1,
+    });
+    expect(actor.listAll().map((instance) => instance.sessionId)).toEqual(['project-b-session']);
+    await host.dispose();
+  });
+
+  it('shares an admitted policy cleanup with a racing permanent task removal', async () => {
+    const lifecycle: IOSSimulatorSimctlLifecycle = {
+      findExact: vi.fn(async () => READY_REPORT.devices[0]!),
+      bootExact: vi.fn(),
+      shutdownExact: vi.fn(),
+      createExact: vi.fn(),
+      deleteExact: vi.fn(),
+    };
+    const actor = new IOSSimulatorInstanceActor({
+      store: new IOSSimulatorOwnershipStore({ createId: () => crypto.randomUUID() }),
+      lifecycle,
+    });
+    actor.attach({
+      sessionId: 'removed-project-session',
+      worktreeRoot: '/repo/project-a',
+      sourceFingerprint: 'fingerprint-a',
+      device: READY_REPORT.devices[0]!,
+      bootProvenance: 'preexisting',
+    });
+    let releaseDriverStop!: () => void;
+    const driverStopReleased = new Promise<void>((resolve) => {
+      releaseDriverStop = resolve;
+    });
+    let signalDriverStop!: () => void;
+    const driverStopStarted = new Promise<void>((resolve) => {
+      signalDriverStop = resolve;
+    });
+    const host = createIOSSimulatorHost({
+      actor,
+      lifecycle,
+      runtime: { inspect: vi.fn(async () => READY_REPORT) },
+      driverManager: {
+        get: vi.fn(() => null),
+        start: vi.fn(),
+        stop: vi.fn(async () => {
+          signalDriverStop();
+          await driverStopReleased;
+        }),
+      },
+      getSession: vi.fn(async (id) => ({ ...localSession(id), workDir: '/repo/project-a' })),
+      mediaCapture: {
+        discardInstance: vi.fn(async () => undefined),
+        discardSession: vi.fn(async () => undefined),
+      } as unknown as IOSSimulatorMediaCaptureAdapter,
+    });
+
+    const deactivation = host.deactivate({ projectWorkingDirs: ['/repo/project-a'] });
+    await driverStopStarted;
+    const permanentRemoval = host.cleanupRemovedSession('removed-project-session');
+    releaseDriverStop();
+
+    await expect(permanentRemoval).resolves.toBeUndefined();
+    await expect(deactivation).resolves.toEqual({
+      hostCanBeReleased: true,
+      cleanedInstanceCount: 1,
+    });
+    expect(actor.listAll()).toEqual([]);
+    await host.dispose();
+  });
+
+  it('cancels a target create before its delayed task lookup can register an actor lifecycle', async () => {
+    const lifecycle: IOSSimulatorSimctlLifecycle = {
+      findExact: vi.fn(async () => READY_REPORT.devices[0]!),
+      bootExact: vi.fn(),
+      shutdownExact: vi.fn(),
+      createExact: vi.fn(),
+      deleteExact: vi.fn(),
+    };
+    const actor = new IOSSimulatorInstanceActor({
+      store: new IOSSimulatorOwnershipStore({ createId: () => crypto.randomUUID() }),
+      lifecycle,
+    });
+    let resolveSessionLookup!: (session: ReturnType<typeof localSession>) => void;
+    const sessionLookup = new Promise<ReturnType<typeof localSession>>((resolve) => {
+      resolveSessionLookup = resolve;
+    });
+    const inspect = vi.fn(async () => READY_REPORT);
+    const getSession = vi.fn(async () => sessionLookup);
+    const host = createIOSSimulatorHost({
+      actor,
+      lifecycle,
+      runtime: { inspect },
+      driverManager: {
+        get: vi.fn(() => null),
+        start: vi.fn(),
+        stop: vi.fn(async () => undefined),
+      },
       getSession,
       mediaCapture: {
         discardInstance: vi.fn(async () => undefined),
@@ -2906,23 +3245,24 @@ describe('iOS Simulator host', () => {
       } as unknown as IOSSimulatorMediaCaptureAdapter,
     });
 
-    const status = host.getStatus('project-a-session');
+    const create = host.callTool(
+      'create_instance',
+      { templateUdid: READY_REPORT.devices[0]!.udid, name: 'Delayed create' },
+      { sessionId: 'project-a-session' },
+    );
     await vi.waitFor(() => expect(getSession).toHaveBeenCalledOnce());
     const deactivation = host.deactivate({ projectWorkingDirs: ['/repo/project-a'] });
-    await driverStopStarted;
-
     resolveSessionLookup({ ...localSession('project-a-session'), workDir: '/repo/project-a' });
-    await expect(status).resolves.toMatchObject({
-      ok: false,
-      errorCode: 'IOS_SIMULATOR_HOST_ERROR',
-    });
-    releaseDriverStop();
 
+    await expect(create).resolves.toMatchObject({
+      ok: false,
+      errorCode: 'MUTATION_CANCELLED',
+    });
     await expect(deactivation).resolves.toEqual({
       hostCanBeReleased: true,
-      cleanedInstanceCount: 1,
+      cleanedInstanceCount: 0,
     });
-    expect(inspect).not.toHaveBeenCalled();
+    expect(lifecycle.createExact).not.toHaveBeenCalled();
     expect(actor.listAll()).toEqual([]);
     await host.dispose();
   });
@@ -8559,6 +8899,63 @@ describe('iOS Simulator host', () => {
     ).resolves.toMatchObject({ ok: false, errorCode: 'INVALID_ARGUMENT' });
   });
 
+  itMac.each([
+    ['Host dispose', 'dispose'],
+    ['the final registry flush', 'final-flush'],
+  ] as const)(
+    'releases an idle default Host after %s fails and allows reinitialization',
+    async (_failure, failurePoint) => {
+      const root = await mkdtemp(path.join(os.tmpdir(), 'cindy-ios-host-idle-release-failure-'));
+      const registryPath = path.join(root, 'ios-simulator', 'ownership-registry.json');
+      const getPath = vi.spyOn(app, 'getPath').mockReturnValue(root);
+      const competingRegistry = new IOSSimulatorOwnershipRegistryFile(registryPath);
+      const host = initializeIOSSimulatorHost();
+      const dispose =
+        failurePoint === 'dispose'
+          ? vi.spyOn(host, 'dispose').mockRejectedValueOnce(new Error('dispose failed'))
+          : null;
+      const save = vi.spyOn(IOSSimulatorOwnershipRegistryFile.prototype, 'saveSync');
+      if (failurePoint === 'final-flush') {
+        save
+          .mockImplementationOnce(() => undefined)
+          .mockImplementationOnce(() => {
+            throw new Error('final flush failed');
+          });
+      }
+
+      try {
+        await expect(
+          deactivateIOSSimulatorHost({
+            projectWorkingDirs: ['/repo/disabled-project'],
+            allowHostRelease: true,
+            shouldReleaseHost: () => true,
+          }),
+        ).resolves.toEqual({ hostReleased: true, cleanedInstanceCount: 0 });
+
+        expect(competingRegistry.acquireWriterSync()).toBe(true);
+        competingRegistry.releaseWriterSync();
+        const replacementHost = initializeIOSSimulatorHost();
+        expect(replacementHost).not.toBe(host);
+
+        save.mockRestore();
+        dispose?.mockRestore();
+        await expect(
+          deactivateIOSSimulatorHost({
+            projectWorkingDirs: ['/repo/replacement-project'],
+            allowHostRelease: true,
+            shouldReleaseHost: () => true,
+          }),
+        ).resolves.toEqual({ hostReleased: true, cleanedInstanceCount: 0 });
+      } finally {
+        save.mockRestore();
+        dispose?.mockRestore();
+        competingRegistry.releaseWriterSync();
+        getPath.mockRestore();
+        await rm(root, { recursive: true, force: true });
+      }
+    },
+  );
+
   itMac(
     'retries persisted removed-task cleanup after another registry writer releases its lease',
     async () => {
@@ -8628,6 +9025,17 @@ describe('iOS Simulator host', () => {
           instances: unknown[];
         };
         expect(persisted.instances).toEqual([]);
+
+        const retainedHost = initializeIOSSimulatorHost();
+        await expect(
+          deactivateIOSSimulatorHost({
+            projectWorkingDirs: ['/repo/enabled-without-binding'],
+            allowHostRelease: true,
+            shouldReleaseHost: () => false,
+          }),
+        ).resolves.toEqual({ hostReleased: false, cleanedInstanceCount: 0 });
+        expect(initializeIOSSimulatorHost()).toBe(retainedHost);
+        expect(writerLeaseHeld).toBe(true);
       } finally {
         await disposeIOSSimulatorHost();
         expect(writerLeaseHeld).toBe(false);

--- a/apps/desktop/src/main/mcp-integrations/__tests__/ios-simulator.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/__tests__/ios-simulator.test.ts
@@ -995,6 +995,18 @@ describe('iOS Simulator host', () => {
           healthState: 'healthy',
         },
       ],
+      routeStatuses: [
+        {
+          instanceId: attached.instanceId,
+          input: {
+            adapter: null,
+            state: 'unavailable',
+            continuous: false,
+            multiTouch: false,
+            reasonCode: 'route-error',
+          },
+        },
+      ],
     });
     await expect(
       host.callTool('list_instances', {}, { sessionId: 'session-a' }),
@@ -4660,6 +4672,87 @@ describe('iOS Simulator host', () => {
     expect(driverManager.recoverNativeSidecar).toHaveBeenLastCalledWith(started.instanceId, {
       rearm: true,
     });
+  });
+
+  it('reports input detection only while Native is actually awaiting its capability probe', async () => {
+    const lifecycle: IOSSimulatorSimctlLifecycle = {
+      findExact: vi.fn(),
+      bootExact: vi.fn(),
+      shutdownExact: vi.fn(),
+      createExact: vi.fn(),
+      deleteExact: vi.fn(),
+    };
+    const actor = new IOSSimulatorInstanceActor({
+      store: new IOSSimulatorOwnershipStore(),
+      lifecycle,
+    });
+    const attached = actor.attach({
+      sessionId: 'session-a',
+      worktreeRoot: '/tmp/session-a',
+      sourceFingerprint: 'fingerprint-a',
+      device: READY_REPORT.devices[0]!,
+    });
+    const started = await actor.start({
+      sessionId: 'session-a',
+      instanceId: attached.instanceId,
+      generation: attached.generation,
+      leaseId: attached.lease.id,
+    });
+    const nativeAdmission = evaluateIOSSimulatorNativeCapabilityAdmission({
+      policy: createIOSSimulatorNativeDevelopmentAdmissionPolicy({
+        enableContinuousInput: true,
+      }),
+      processState: 'idle',
+      now: () => new Date('2026-08-12T00:00:00.000Z'),
+    });
+    const running = {
+      instanceId: started.instanceId,
+      simulatorUdid: started.simulatorUdid,
+      pid: 42,
+      driver: {},
+      driverRouter: {
+        capabilityReport: vi.fn(() => ({
+          nativeSidecar: { available: false, admission: nativeAdmission },
+          routes: {
+            continuousInput: {
+              selected: 'wda',
+              fallback: true,
+              reason: 'Native capability is awaiting the sidecar handshake.',
+            },
+            stream: {},
+          },
+        })),
+      },
+      driverSessionId: 'wda-session',
+    } as unknown as WdaRunningInstance;
+    const host = createIOSSimulatorHost({
+      actor,
+      lifecycle,
+      driverManager: {
+        get: vi.fn(() => running),
+        start: vi.fn(),
+        stop: vi.fn(async () => undefined),
+      },
+      runtime: { inspect: vi.fn(async () => READY_REPORT) },
+      getSession: vi.fn(async (id) => localSession(id)),
+    });
+
+    const status = await host.getStatus('session-a');
+    expect(status).toMatchObject({
+      ok: true,
+      routeStatuses: [
+        {
+          instanceId: started.instanceId,
+          input: {
+            adapter: 'wda',
+            state: 'detecting',
+            continuous: false,
+            reasonCode: 'native-probe-pending',
+          },
+        },
+      ],
+    });
+    await host.dispose();
   });
 
   it('stops the embedded viewer when the exact external simulator is shut down', async () => {

--- a/apps/desktop/src/main/mcp-integrations/ios-simulator.ts
+++ b/apps/desktop/src/main/mcp-integrations/ios-simulator.ts
@@ -1745,10 +1745,13 @@ export function createIOSSimulatorHost(options: IOSSimulatorHostOptions = {}): I
     } else if (!running) {
       input = {
         adapter: null,
-        state: 'detecting',
+        // A ready binding without a live WDA driver is not probing Native
+        // capability.  Treat it as unavailable so the renderer can settle on
+        // a stable state instead of showing an endless "detecting" spinner.
+        state: 'unavailable',
         continuous: false,
         multiTouch: false,
-        reasonCode: 'native-probe-pending',
+        reasonCode: 'route-error',
       };
     } else if (!report) {
       input = {

--- a/apps/desktop/src/main/mcp-integrations/ios-simulator.ts
+++ b/apps/desktop/src/main/mcp-integrations/ios-simulator.ts
@@ -1,5 +1,5 @@
 import { createHash, randomUUID } from 'node:crypto';
-import type { Dirent } from 'node:fs';
+import { realpathSync, type Dirent } from 'node:fs';
 import { readdir, realpath, rm, stat } from 'node:fs/promises';
 import { release as hostOsRelease } from 'node:os';
 import path from 'node:path';
@@ -260,7 +260,11 @@ export interface IOSSimulatorHost {
     sessionIds?: readonly string[];
     projectWorkingDirs?: readonly string[];
     shouldReleaseProject?: (workingDir: string) => boolean;
+    /** User-default shutdown must also retire profile-scoped interrupted-create evidence. */
+    reconcilePendingCreates?: boolean;
   }): Promise<{ hostCanBeReleased: boolean; cleanedInstanceCount: number }>;
+  /** Atomically close global admission only when no Host-owned work remains. */
+  tryBeginIdleRelease(): boolean;
   reconcileOwnership(): Promise<void>;
   describeTools(sessionId: string): Promise<IOSSimulatorToolAvailabilityReport>;
   getStatus(sessionId: string): Promise<IOSSimulatorSessionStatus>;
@@ -332,6 +336,28 @@ interface IOSSimulatorSessionRemovalBarrierOperation {
   admissionEpoch: number;
   settled: Promise<void>;
   finish(): void;
+}
+
+interface IOSSimulatorCapabilityDeactivationScope {
+  scoped: boolean;
+  matchesSession(
+    sessionId: string,
+    physicalWorkingDir: string | null | undefined,
+    policyWorkingDir?: string | null | undefined,
+  ): boolean;
+}
+
+function canonicalIOSSimulatorProjectWorkingDir(raw: string | null | undefined): string | null {
+  const normalized = normalizeWorkingDirForProjectSettings(raw);
+  if (normalized === null) return null;
+  try {
+    return normalizeWorkingDirForProjectSettings(realpathSync.native(normalized));
+  } catch {
+    // A retired worktree can disappear before capability cleanup reaches it.
+    // Keep the stable normalized spelling so persisted ownership can still be
+    // matched and retired without following a replacement symlink.
+    return normalized;
+  }
 }
 
 function sessionError(
@@ -1067,6 +1093,7 @@ export function createIOSSimulatorHost(options: IOSSimulatorHostOptions = {}): I
     Set<IOSSimulatorSessionRemovalBarrierOperation>
   >();
   const sessionRemovalCleanupPromises = new Map<string, Promise<void>>();
+  const pendingSessionRemovalBarrierResolutions = new Map<string, number>();
   const blockedBuildInstances = new Set<string>();
   const instanceLifecycleBarriers = new Map<string, { epoch: number; pendingTeardowns: number }>();
   const mediaCapture = options.mediaCapture ?? new IOSSimulatorMediaCapture();
@@ -1116,8 +1143,7 @@ export function createIOSSimulatorHost(options: IOSSimulatorHostOptions = {}): I
     }
   >();
   const getOwnerScopeKey = options.getOwnerScopeKey ?? activeOwnerScopeKey;
-  const isOwnerBoundaryPending =
-    options.isOwnerBoundaryPending ?? isAppSessionBoundaryPending;
+  const isOwnerBoundaryPending = options.isOwnerBoundaryPending ?? isAppSessionBoundaryPending;
   const pendingCreateEvidence = options.pendingCreateEvidence ?? null;
   let ownershipReconciledScopeKey: string | null = null;
   // Persisted `viewerState` can only be stale on the first sweep that actually
@@ -1131,7 +1157,8 @@ export function createIOSSimulatorHost(options: IOSSimulatorHostOptions = {}): I
   let pendingCreateReconcilePromise: Promise<unknown> | null = null;
   let startupPendingCreateRecoveryAttempted = false;
   let disposePromise: Promise<void> | null = null;
-  let deactivationInProgress = false;
+  let globalDeactivationInProgress = false;
+  const deactivationPromises = new Set<Promise<unknown>>();
   const inspectRuntime = (): Promise<IOSSimulatorEnvironmentReport> =>
     runtime.inspect(runtimeInspectionExitController.signal);
   const canReconcilePendingCreates = options.canReconcilePendingCreates ?? (() => true);
@@ -1631,7 +1658,7 @@ export function createIOSSimulatorHost(options: IOSSimulatorHostOptions = {}): I
     }
   }
   const assertHostActive = (): void => {
-    if (disposePromise || deactivationInProgress) throw new IOSSimulatorHostDisposedError();
+    if (disposePromise || globalDeactivationInProgress) throw new IOSSimulatorHostDisposedError();
   };
   let driverManager = options.driverManager;
   const getDriverManager = () => {
@@ -1839,33 +1866,59 @@ export function createIOSSimulatorHost(options: IOSSimulatorHostOptions = {}): I
     if (!normalizedSessionId) {
       return sessionError(null, 'SESSION_CONTEXT_REQUIRED', 'A Cindy session is required.');
     }
-    const removalAdmissionEpoch = sessionRemovalAdmissionEpochs.get(normalizedSessionId) ?? 0;
-    const session = await getSession(normalizedSessionId);
-    if (!session) {
-      return sessionError(
+    const registerRemovalBarrier = options.registerRemovalBarrier === true;
+    if (registerRemovalBarrier) {
+      pendingSessionRemovalBarrierResolutions.set(
         normalizedSessionId,
-        'SESSION_NOT_FOUND',
-        'The Cindy session no longer exists.',
+        (pendingSessionRemovalBarrierResolutions.get(normalizedSessionId) ?? 0) + 1,
       );
     }
-    if (session.status && session.status !== 'active') {
-      return sessionError(
-        normalizedSessionId,
-        'SESSION_NOT_FOUND',
-        'The Cindy session is no longer active.',
-      );
+    try {
+      const removalAdmissionEpoch = sessionRemovalAdmissionEpochs.get(normalizedSessionId) ?? 0;
+      const session = await getSession(normalizedSessionId);
+      if (sessionRemovalCleanupPromises.has(normalizedSessionId)) {
+        return sessionError(
+          normalizedSessionId,
+          'MUTATION_CANCELLED',
+          'The simulator binding is being removed because its project capability changed.',
+        );
+      }
+      if (!session) {
+        return sessionError(
+          normalizedSessionId,
+          'SESSION_NOT_FOUND',
+          'The Cindy session no longer exists.',
+        );
+      }
+      if (session.status && session.status !== 'active') {
+        return sessionError(
+          normalizedSessionId,
+          'SESSION_NOT_FOUND',
+          'The Cindy session is no longer active.',
+        );
+      }
+      if (session.remoteHostId) {
+        return sessionError(
+          normalizedSessionId,
+          'UNSUPPORTED_SESSION_KIND',
+          'SSH and remote sessions cannot access simulators on this Mac.',
+        );
+      }
+      const removalBarrierOperation = registerRemovalBarrier
+        ? beginSessionRemovalBarrierOperation(normalizedSessionId, removalAdmissionEpoch)
+        : undefined;
+      return { ok: true, sessionId: normalizedSessionId, session, removalBarrierOperation };
+    } finally {
+      if (registerRemovalBarrier) {
+        const remaining =
+          (pendingSessionRemovalBarrierResolutions.get(normalizedSessionId) ?? 1) - 1;
+        if (remaining > 0) {
+          pendingSessionRemovalBarrierResolutions.set(normalizedSessionId, remaining);
+        } else {
+          pendingSessionRemovalBarrierResolutions.delete(normalizedSessionId);
+        }
+      }
     }
-    if (session.remoteHostId) {
-      return sessionError(
-        normalizedSessionId,
-        'UNSUPPORTED_SESSION_KIND',
-        'SSH and remote sessions cannot access simulators on this Mac.',
-      );
-    }
-    const removalBarrierOperation = options.registerRemovalBarrier
-      ? beginSessionRemovalBarrierOperation(normalizedSessionId, removalAdmissionEpoch)
-      : undefined;
-    return { ok: true, sessionId: normalizedSessionId, session, removalBarrierOperation };
   }
 
   function currentOwnedInstance(instance: IOSSimulatorInstance): IOSSimulatorInstance {
@@ -2160,6 +2213,20 @@ export function createIOSSimulatorHost(options: IOSSimulatorHostOptions = {}): I
     return trackedCleanup;
   }
 
+  function canReleaseHostRuntime(): boolean {
+    return (
+      actor.listAll().length === 0 &&
+      !actor.hasPendingOperations() &&
+      activeBuilds.size === 0 &&
+      pendingSessionRemovalBarrierResolutions.size === 0 &&
+      activeSessionRemovalBarrierOperations.size === 0 &&
+      sessionRemovalCleanupPromises.size === 0 &&
+      pendingCreateReconcilePromise === null &&
+      ownershipReconcilePromise === null &&
+      pendingCreateEvidence?.isArmed() !== true
+    );
+  }
+
   async function reconcileLiveDevice(
     instance: IOSSimulatorInstance,
   ): Promise<IOSSimulatorInstance> {
@@ -2272,7 +2339,7 @@ export function createIOSSimulatorHost(options: IOSSimulatorHostOptions = {}): I
   }
 
   async function inspectForPlugin(sessionId: string): Promise<GhostIOSSimulatorStatusProbeResult> {
-    if (disposePromise || deactivationInProgress) {
+    if (disposePromise || globalDeactivationInProgress) {
       return {
         ok: false,
         errorCode: 'IOS_SIMULATOR_HOST_ERROR',
@@ -2290,7 +2357,7 @@ export function createIOSSimulatorHost(options: IOSSimulatorHostOptions = {}): I
     const resolved = await resolveSession(sessionId);
     if (
       disposePromise ||
-      deactivationInProgress ||
+      globalDeactivationInProgress ||
       isOwnerBoundaryPending() ||
       getOwnerScopeKey() !== ownerScopeKey
     ) {
@@ -2304,7 +2371,7 @@ export function createIOSSimulatorHost(options: IOSSimulatorHostOptions = {}): I
       return { ok: false, errorCode: resolved.errorCode, message: resolved.message };
     try {
       const environment = await readPluginEnvironment();
-      if (disposePromise || deactivationInProgress) {
+      if (disposePromise || globalDeactivationInProgress) {
         return {
           ok: false,
           errorCode: 'IOS_SIMULATOR_HOST_ERROR',
@@ -2365,16 +2432,20 @@ export function createIOSSimulatorHost(options: IOSSimulatorHostOptions = {}): I
   }
 
   async function inspectForSession(sessionId: string): Promise<IOSSimulatorSessionStatus> {
-    if (disposePromise || deactivationInProgress) return hostDisposedStatus(sessionId);
+    if (disposePromise || globalDeactivationInProgress) return hostDisposedStatus(sessionId);
     const resolved = await resolveSession(sessionId);
     if (!resolved.ok) return resolved;
-    if (disposePromise || deactivationInProgress) return hostDisposedStatus(resolved.sessionId);
+    if (disposePromise || globalDeactivationInProgress)
+      return hostDisposedStatus(resolved.sessionId);
     await reconcilePersistedOwnership();
-    if (disposePromise || deactivationInProgress) return hostDisposedStatus(resolved.sessionId);
+    if (disposePromise || globalDeactivationInProgress)
+      return hostDisposedStatus(resolved.sessionId);
     await reconcileLiveDevices(actor.list(resolved.sessionId));
-    if (disposePromise || deactivationInProgress) return hostDisposedStatus(resolved.sessionId);
+    if (disposePromise || globalDeactivationInProgress)
+      return hostDisposedStatus(resolved.sessionId);
     const environment = await inspectRuntime();
-    if (disposePromise || deactivationInProgress) return hostDisposedStatus(resolved.sessionId);
+    if (disposePromise || globalDeactivationInProgress)
+      return hostDisposedStatus(resolved.sessionId);
     const instances = actor
       .list(resolved.sessionId)
       .map((instance) => actor.heartbeatOwned(resolved.sessionId, instance.instanceId));
@@ -2505,8 +2576,7 @@ export function createIOSSimulatorHost(options: IOSSimulatorHostOptions = {}): I
 
   function isViewerStateNormalized(scopeKey: string, instanceId: string): boolean {
     return (
-      viewerStateNormalizedScopeKey === scopeKey &&
-      viewerStateNormalizedInstanceIds.has(instanceId)
+      viewerStateNormalizedScopeKey === scopeKey && viewerStateNormalizedInstanceIds.has(instanceId)
     );
   }
 
@@ -6062,10 +6132,7 @@ export function createIOSSimulatorHost(options: IOSSimulatorHostOptions = {}): I
           if (environment.ready && instances.length === 0) {
             // Advertised names only: a recommendation the model cannot find in
             // list_tools sends it back to the ambiguous superseded name.
-            recommendedActions.push(
-              'list_simulator_devices',
-              'create_instance_or_attach_device',
-            );
+            recommendedActions.push('list_simulator_devices', 'create_instance_or_attach_device');
           }
           if (instances.some((entry) => !entry.running)) recommendedActions.push('start_instance');
           if (
@@ -6231,7 +6298,11 @@ export function createIOSSimulatorHost(options: IOSSimulatorHostOptions = {}): I
           cleanedInstanceCount: 0,
         };
       }
-      if (deactivationInProgress) {
+      const scoped =
+        options.sessionIds !== undefined ||
+        options.projectWorkingDirs !== undefined ||
+        options.shouldReleaseProject !== undefined;
+      if (!scoped && globalDeactivationInProgress) {
         throw new IOSSimulatorInstanceError(
           'DEVICE_BUSY',
           'iOS Simulator cleanup is already in progress.',
@@ -6239,40 +6310,61 @@ export function createIOSSimulatorHost(options: IOSSimulatorHostOptions = {}): I
         );
       }
 
-      deactivationInProgress = true;
       const initialInstanceCount = actor.listAll().length;
-      try {
+      const cleanup = (async () => {
         const requestedSessionIds = new Set(
           (options.sessionIds ?? []).map((value) => value.trim()).filter(Boolean),
         );
         const requestedProjects = new Set(
           (options.projectWorkingDirs ?? [])
-            .map((value) => normalizeWorkingDirForProjectSettings(value))
+            .map((value) => canonicalIOSSimulatorProjectWorkingDir(value))
             .filter((value): value is string => value !== null),
         );
-        const scoped =
-          options.sessionIds !== undefined ||
-          options.projectWorkingDirs !== undefined ||
-          options.shouldReleaseProject !== undefined;
-        const matchesScope = (instance: IOSSimulatorInstance): boolean => {
-          if (!scoped) return true;
-          if (requestedSessionIds.has(instance.sessionId)) return true;
-          const project = normalizeWorkingDirForProjectSettings(instance.worktreeRoot);
-          return (
-            project !== null &&
-            (requestedProjects.has(project) || options.shouldReleaseProject?.(project) === true)
-          );
+        const scope: IOSSimulatorCapabilityDeactivationScope = {
+          scoped,
+          matchesSession(sessionId, physicalWorkingDir, policyWorkingDir = physicalWorkingDir) {
+            if (!scoped) return true;
+            if (requestedSessionIds.has(sessionId)) return true;
+            const project = canonicalIOSSimulatorProjectWorkingDir(physicalWorkingDir);
+            const policyProject = normalizeWorkingDirForProjectSettings(policyWorkingDir);
+            return (
+              (project !== null && requestedProjects.has(project)) ||
+              (policyProject !== null && options.shouldReleaseProject?.(policyProject) === true)
+            );
+          },
         };
+        const sessionPolicyWorkingDirs = new Map<string, string | null>();
+        const policyWorkingDirForSession = async (
+          sessionId: string,
+          fallback: string | null | undefined,
+        ): Promise<string | null> => {
+          if (sessionPolicyWorkingDirs.has(sessionId)) {
+            return sessionPolicyWorkingDirs.get(sessionId) ?? null;
+          }
+          const session = await getSession(sessionId);
+          const workingDir = normalizeWorkingDirForProjectSettings(session?.workDir ?? fallback);
+          sessionPolicyWorkingDirs.set(sessionId, workingDir);
+          return workingDir;
+        };
+        const matchesScope = async (instance: IOSSimulatorInstance): Promise<boolean> =>
+          scope.matchesSession(
+            instance.sessionId,
+            instance.worktreeRoot,
+            await policyWorkingDirForSession(instance.sessionId, instance.worktreeRoot),
+          );
 
         if (!scoped) {
+          globalDeactivationInProgress = true;
           // Close the actor queues before ownership reconciliation. This is the
           // point at which the shell guard's protection becomes stricter, so no
           // new boot/mutation can race the final sweep.
           await Promise.all([actor.cancelAllLifecycleStarts(), actor.cancelAllMutations()]);
         }
-
         const pendingCreateEvidenceArmed = pendingCreateEvidence?.isArmed() === true;
-        if (!scoped && (actor.listAll().length > 0 || pendingCreateEvidenceArmed)) {
+        if (
+          (!scoped || options.reconcilePendingCreates === true) &&
+          (actor.listAll().length > 0 || pendingCreateEvidenceArmed)
+        ) {
           // A create can cross `simctl create` before its binding is persisted.
           // Complete the pending-create sweep while admission is closed so a
           // hidden marker device cannot outlive the Host and its shell guard.
@@ -6288,9 +6380,10 @@ export function createIOSSimulatorHost(options: IOSSimulatorHostOptions = {}): I
         const failures = new Set<string>();
         const attemptedSessions = new Set<string>();
         while (true) {
-          const matchingSessions = new Set(
-            actor.listAll().filter(matchesScope).map((instance) => instance.sessionId),
-          );
+          const matchingSessions = new Set<string>();
+          for (const instance of actor.listAll()) {
+            if (await matchesScope(instance)) matchingSessions.add(instance.sessionId);
+          }
           // A create may have issued `simctl create` before its binding was
           // persisted. Include its session in the project-scoped sweep so
           // cancelling the session also settles the hidden create marker.
@@ -6300,12 +6393,22 @@ export function createIOSSimulatorHost(options: IOSSimulatorHostOptions = {}): I
               continue;
             }
             const session = await getSession(sessionId);
-            const project = normalizeWorkingDirForProjectSettings(session?.workDir);
-            if (
-              project !== null &&
-              (requestedProjects.has(project) || options.shouldReleaseProject?.(project) === true)
-            ) {
+            if (scope.matchesSession(sessionId, session?.workDir, session?.workDir)) {
               matchingSessions.add(sessionId);
+            }
+          }
+          if (scoped) {
+            for (const sessionId of pendingSessionRemovalBarrierResolutions.keys()) {
+              const session = await getSession(sessionId);
+              if (scope.matchesSession(sessionId, session?.workDir, session?.workDir)) {
+                matchingSessions.add(sessionId);
+              }
+            }
+            for (const sessionId of activeSessionRemovalBarrierOperations.keys()) {
+              const session = await getSession(sessionId);
+              if (scope.matchesSession(sessionId, session?.workDir, session?.workDir)) {
+                matchingSessions.add(sessionId);
+              }
             }
           }
           for (const sessionId of requestedSessionIds) matchingSessions.add(sessionId);
@@ -6325,13 +6428,15 @@ export function createIOSSimulatorHost(options: IOSSimulatorHostOptions = {}): I
             failures.add(pendingSessions[index]);
             logger.warn('iOS Simulator capability deactivation cleanup failed', {
               sessionId: pendingSessions[index],
-              error:
-                result.reason instanceof Error ? result.reason.message : String(result.reason),
+              error: result.reason instanceof Error ? result.reason.message : String(result.reason),
             });
           });
         }
 
-        const remainingMatchingInstances = actor.listAll().filter(matchesScope);
+        const remainingMatchingInstances: IOSSimulatorInstance[] = [];
+        for (const instance of actor.listAll()) {
+          if (await matchesScope(instance)) remainingMatchingInstances.push(instance);
+        }
         if (failures.size > 0 || remainingMatchingInstances.length > 0) {
           throw new IOSSimulatorInstanceError(
             'DEVICE_BUSY',
@@ -6343,15 +6448,7 @@ export function createIOSSimulatorHost(options: IOSSimulatorHostOptions = {}): I
           );
         }
 
-        const hostCanBeReleased =
-          actor.listAll().length === 0 &&
-          !actor.hasPendingOperations() &&
-          activeBuilds.size === 0 &&
-          activeSessionRemovalBarrierOperations.size === 0 &&
-          sessionRemovalCleanupPromises.size === 0 &&
-          pendingCreateReconcilePromise === null &&
-          ownershipReconcilePromise === null &&
-          pendingCreateEvidence?.isArmed() !== true;
+        const hostCanBeReleased = canReleaseHostRuntime();
         if (!scoped && !hostCanBeReleased) {
           throw new IOSSimulatorInstanceError(
             'DEVICE_BUSY',
@@ -6363,9 +6460,19 @@ export function createIOSSimulatorHost(options: IOSSimulatorHostOptions = {}): I
           hostCanBeReleased,
           cleanedInstanceCount: initialInstanceCount - actor.listAll().length,
         };
+      })();
+      deactivationPromises.add(cleanup);
+      try {
+        return await cleanup;
       } finally {
-        deactivationInProgress = false;
+        deactivationPromises.delete(cleanup);
+        if (!scoped) globalDeactivationInProgress = false;
       }
+    },
+    tryBeginIdleRelease() {
+      if (disposePromise || globalDeactivationInProgress || !canReleaseHostRuntime()) return false;
+      globalDeactivationInProgress = true;
+      return true;
     },
     abortOperationsForExit() {
       void abortPendingCreateReconciliation();
@@ -6405,6 +6512,7 @@ export function createIOSSimulatorHost(options: IOSSimulatorHostOptions = {}): I
     dispose() {
       if (disposePromise) return disposePromise;
       disposePromise = (async () => {
+        const pendingDeactivations = [...deactivationPromises];
         const pendingCreateReconciliation = abortPendingCreateReconciliation();
         runtimeInspectionExitController.abort();
         buildDiagnosticReadExitController.abort();
@@ -6422,6 +6530,7 @@ export function createIOSSimulatorHost(options: IOSSimulatorHostOptions = {}): I
           });
         });
         await Promise.all([
+          Promise.allSettled(pendingDeactivations).then(() => undefined),
           pendingCreateReconciliation,
           lifecycleStarts,
           mutations,
@@ -6491,7 +6600,8 @@ interface DefaultIOSSimulatorRuntime {
 let defaultIOSSimulatorRuntime: DefaultIOSSimulatorRuntime | null = null;
 let defaultIOSSimulatorRuntimeClosing = false;
 let defaultIOSSimulatorRuntimeDisposePromise: Promise<void> | null = null;
-let defaultIOSSimulatorRuntimeDeactivatePromise: Promise<IOSSimulatorDeactivateResult> | null = null;
+let defaultIOSSimulatorRuntimeDeactivatePromise: Promise<IOSSimulatorDeactivateResult> | null =
+  null;
 let passivePluginRuntime: IOSSimulatorRuntime | null = null;
 let passivePluginEnvironmentCache: {
   expiresAt: number;
@@ -6539,10 +6649,8 @@ async function readPassiveIOSSimulatorPluginStatus(
   }
   try {
     const getOwnerScopeKey = options.getOwnerScopeKey ?? activeOwnerScopeKey;
-    const isOwnerBoundaryPending =
-      options.isOwnerBoundaryPending ?? isAppSessionBoundaryPending;
-    const isHostClosing =
-      options.isHostClosing ?? (() => defaultIOSSimulatorRuntimeClosing);
+    const isOwnerBoundaryPending = options.isOwnerBoundaryPending ?? isAppSessionBoundaryPending;
+    const isHostClosing = options.isHostClosing ?? (() => defaultIOSSimulatorRuntimeClosing);
     if (isHostClosing() || isOwnerBoundaryPending()) {
       return {
         ok: false,
@@ -6562,11 +6670,7 @@ async function readPassiveIOSSimulatorPluginStatus(
         };
       });
     const session = await getSession(normalizedSessionId);
-    if (
-      isHostClosing() ||
-      isOwnerBoundaryPending() ||
-      getOwnerScopeKey() !== ownerScopeKey
-    ) {
+    if (isHostClosing() || isOwnerBoundaryPending() || getOwnerScopeKey() !== ownerScopeKey) {
       return {
         ok: false,
         errorCode: 'IOS_SIMULATOR_HOST_ERROR',
@@ -6590,11 +6694,7 @@ async function readPassiveIOSSimulatorPluginStatus(
     const environment = options.inspectEnvironment
       ? projectPluginEnvironment(await options.inspectEnvironment())
       : await readPassivePluginEnvironment();
-    if (
-      isHostClosing() ||
-      isOwnerBoundaryPending() ||
-      getOwnerScopeKey() !== ownerScopeKey
-    ) {
+    if (isHostClosing() || isOwnerBoundaryPending() || getOwnerScopeKey() !== ownerScopeKey) {
       return {
         ok: false,
         errorCode: 'IOS_SIMULATOR_HOST_ERROR',
@@ -6689,12 +6789,7 @@ export function initializeIOSSimulatorHost(): IOSSimulatorHost {
   const pendingCreateEvidence = createDefaultPendingCreateEvidence(registry);
   const lifecycle = createProfileScopedIOSSimulatorLifecycle(registry, pendingCreateEvidence);
   const persistedActor = createDefaultActor(lifecycle, registry);
-  return installDefaultIOSSimulatorHost(
-    lifecycle,
-    persistedActor,
-    registry,
-    pendingCreateEvidence,
-  );
+  return installDefaultIOSSimulatorHost(lifecycle, persistedActor, registry, pendingCreateEvidence);
 }
 
 function currentIOSSimulatorHost(): IOSSimulatorHost | null {
@@ -6717,6 +6812,12 @@ export interface IOSSimulatorDeactivateOptions {
   sessionIds?: readonly string[];
   projectWorkingDirs?: readonly string[];
   shouldReleaseProject?: (workingDir: string) => boolean;
+  /** User-default shutdown must also retire profile-scoped interrupted-create evidence. */
+  reconcilePendingCreates?: boolean;
+  /** Scoped cleanup never releases the process singleton unless the caller proves no provider remains. */
+  allowHostRelease?: boolean;
+  /** Live provider check immediately before releasing the process singleton. */
+  shouldReleaseHost?: () => boolean;
 }
 
 export interface IOSSimulatorDeactivateResult {
@@ -6728,9 +6829,11 @@ export interface IOSSimulatorDeactivateResult {
  * Release Simulator ownership when the capability is switched off while
  * keeping the Host lazy and re-initializable for a later enable.
  *
- * Cleanup failures deliberately leave the singleton and writer lease installed.
- * Releasing either before ownership is empty would abandon Cindy-owned cleanup
- * without a process that can safely retry it.
+ * Cleanup failures before the Host proves itself idle deliberately leave the
+ * singleton and writer lease installed. After idle release is reserved, the
+ * first registry flush has already persisted an empty ownership set; final
+ * teardown failures are logged but must not strand a permanently closing
+ * singleton.
  */
 export function deactivateIOSSimulatorHost(
   options: IOSSimulatorDeactivateOptions = {},
@@ -6750,29 +6853,59 @@ export function deactivateIOSSimulatorHost(
     return Promise.resolve({ hostReleased: true, cleanedInstanceCount: 0 });
   }
 
-  defaultIOSSimulatorRuntimeClosing = true;
+  const scoped =
+    options.sessionIds !== undefined ||
+    options.projectWorkingDirs !== undefined ||
+    options.shouldReleaseProject !== undefined;
+  const allowHostRelease = !scoped || options.allowHostRelease === true;
+  if (!scoped) defaultIOSSimulatorRuntimeClosing = true;
   let deactivation!: Promise<IOSSimulatorDeactivateResult>;
   deactivation = (async () => {
     try {
-      const scoped =
-        options.sessionIds !== undefined ||
-        options.projectWorkingDirs !== undefined ||
-        options.shouldReleaseProject !== undefined;
       if (!scoped) clearIOSSimulatorRendererAccess();
       const result = await runtime.host.deactivate(options);
       await runtime.flushRegistry();
-      if (!result.hostCanBeReleased || defaultIOSSimulatorRuntime !== runtime) {
+      const idleReleaseStarted =
+        allowHostRelease &&
+        result.hostCanBeReleased &&
+        options.shouldReleaseHost?.() !== false &&
+        defaultIOSSimulatorRuntime === runtime &&
+        (scoped ? runtime.host.tryBeginIdleRelease() : true);
+      if (!idleReleaseStarted) {
         return {
           hostReleased: false,
           cleanedInstanceCount: result.cleanedInstanceCount,
         };
       }
-      await runtime.host.dispose();
-      await runtime.flushRegistry();
-      configureIOSSimulatorRendererAccessRevocationObserver(null);
-      runtime.releaseExitAbortHandler();
-      runtime.releaseRegistry();
-      defaultIOSSimulatorRuntime = null;
+      try {
+        await runtime.host.dispose();
+      } catch (error) {
+        logger.warn('Idle iOS Simulator Host dispose failed after release was reserved', {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+      try {
+        await runtime.flushRegistry();
+      } catch (error) {
+        logger.warn('Final iOS Simulator ownership flush failed after idle release', {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+      try {
+        configureIOSSimulatorRendererAccessRevocationObserver(null);
+      } finally {
+        try {
+          runtime.releaseExitAbortHandler();
+        } finally {
+          try {
+            runtime.releaseRegistry();
+          } finally {
+            if (defaultIOSSimulatorRuntime === runtime) {
+              defaultIOSSimulatorRuntime = null;
+            }
+          }
+        }
+      }
       return {
         hostReleased: true,
         cleanedInstanceCount: result.cleanedInstanceCount,
@@ -6781,7 +6914,7 @@ export function deactivateIOSSimulatorHost(
       if (defaultIOSSimulatorRuntimeDeactivatePromise === deactivation) {
         defaultIOSSimulatorRuntimeDeactivatePromise = null;
       }
-      if (!defaultIOSSimulatorRuntimeDisposePromise) {
+      if (!scoped && !defaultIOSSimulatorRuntimeDisposePromise) {
         defaultIOSSimulatorRuntimeClosing = false;
       }
     }
@@ -7065,9 +7198,7 @@ export function getIOSSimulatorMcpDeps(
   options: IOSSimulatorMcpDepsOptions = {},
 ): IOSSimulatorMcpDeps {
   const getHost = (): IOSSimulatorHost => options.host ?? initializeIOSSimulatorHost();
-  const resolveAccess = (
-    context?: IOSSimulatorMcpCallContext,
-  ): IOSSimulatorMcpAccessDecision => {
+  const resolveAccess = (context?: IOSSimulatorMcpCallContext): IOSSimulatorMcpAccessDecision => {
     const decision = options.resolveAccess?.(context);
     if (decision) return decision;
     if (options.isIOSSimulatorEnabled && !options.isIOSSimulatorEnabled(context)) {

--- a/apps/desktop/src/main/mcp-integrations/ios-simulator.ts
+++ b/apps/desktop/src/main/mcp-integrations/ios-simulator.ts
@@ -93,6 +93,7 @@ import { redact } from '../log-upload/redact.js';
 import { withSessionRouteLock } from '../localDb/sessionRouteLock.js';
 import { desktopSessionStorage } from '../maker-host/session-storage.js';
 import { isTrustedAppRendererWindow } from '../security/trustedAppRenderer.js';
+import { normalizeWorkingDirForProjectSettings } from '../../shared/workingDir.js';
 import {
   IOSSimulatorPackagedSidecarArtifactResolver,
   verifyIOSSimulatorSidecarDigest,
@@ -249,6 +250,17 @@ export interface IOSSimulatorHost {
   cancelSessionOperations(sessionId: string): Promise<void>;
   /** Tear down all simulator runtime and ownership after a task is durably removed. */
   cleanupRemovedSession(sessionId: string): Promise<void>;
+  /**
+   * Stop accepting simulator work and release Host-owned bindings for a
+   * capability shutdown. When `workingDirs` is omitted every binding is
+   * targeted; an empty list is a deliberate no-op. The Host can be released
+   * only when no binding or lifecycle operation remains.
+   */
+  deactivate(options?: {
+    sessionIds?: readonly string[];
+    projectWorkingDirs?: readonly string[];
+    shouldReleaseProject?: (workingDir: string) => boolean;
+  }): Promise<{ hostCanBeReleased: boolean; cleanedInstanceCount: number }>;
   reconcileOwnership(): Promise<void>;
   describeTools(sessionId: string): Promise<IOSSimulatorToolAvailabilityReport>;
   getStatus(sessionId: string): Promise<IOSSimulatorSessionStatus>;
@@ -1119,6 +1131,7 @@ export function createIOSSimulatorHost(options: IOSSimulatorHostOptions = {}): I
   let pendingCreateReconcilePromise: Promise<unknown> | null = null;
   let startupPendingCreateRecoveryAttempted = false;
   let disposePromise: Promise<void> | null = null;
+  let deactivationInProgress = false;
   const inspectRuntime = (): Promise<IOSSimulatorEnvironmentReport> =>
     runtime.inspect(runtimeInspectionExitController.signal);
   const canReconcilePendingCreates = options.canReconcilePendingCreates ?? (() => true);
@@ -1618,7 +1631,7 @@ export function createIOSSimulatorHost(options: IOSSimulatorHostOptions = {}): I
     }
   }
   const assertHostActive = (): void => {
-    if (disposePromise) throw new IOSSimulatorHostDisposedError();
+    if (disposePromise || deactivationInProgress) throw new IOSSimulatorHostDisposedError();
   };
   let driverManager = options.driverManager;
   const getDriverManager = () => {
@@ -6203,6 +6216,149 @@ export function createIOSSimulatorHost(options: IOSSimulatorHostOptions = {}): I
     cleanupRemovedSession(sessionId) {
       return cleanupRemovedSessionRuntime(sessionId);
     },
+    async deactivate(options = {}) {
+      if (disposePromise) {
+        return {
+          hostCanBeReleased: false,
+          cleanedInstanceCount: 0,
+        };
+      }
+      if (deactivationInProgress) {
+        throw new IOSSimulatorInstanceError(
+          'DEVICE_BUSY',
+          'iOS Simulator cleanup is already in progress.',
+          true,
+        );
+      }
+
+      deactivationInProgress = true;
+      const initialInstanceCount = actor.listAll().length;
+      try {
+        const requestedSessionIds = new Set(
+          (options.sessionIds ?? []).map((value) => value.trim()).filter(Boolean),
+        );
+        const requestedProjects = new Set(
+          (options.projectWorkingDirs ?? [])
+            .map((value) => normalizeWorkingDirForProjectSettings(value))
+            .filter((value): value is string => value !== null),
+        );
+        const scoped =
+          options.sessionIds !== undefined ||
+          options.projectWorkingDirs !== undefined ||
+          options.shouldReleaseProject !== undefined;
+        const matchesScope = (instance: IOSSimulatorInstance): boolean => {
+          if (!scoped) return true;
+          if (requestedSessionIds.has(instance.sessionId)) return true;
+          const project = normalizeWorkingDirForProjectSettings(instance.worktreeRoot);
+          return (
+            project !== null &&
+            (requestedProjects.has(project) || options.shouldReleaseProject?.(project) === true)
+          );
+        };
+
+        if (!scoped) {
+          // Close the actor queues before ownership reconciliation. This is the
+          // point at which the shell guard's protection becomes stricter, so no
+          // new boot/mutation can race the final sweep.
+          await Promise.all([actor.cancelAllLifecycleStarts(), actor.cancelAllMutations()]);
+        }
+
+        const pendingCreateEvidenceArmed = pendingCreateEvidence?.isArmed() === true;
+        if (!scoped && (actor.listAll().length > 0 || pendingCreateEvidenceArmed)) {
+          // A create can cross `simctl create` before its binding is persisted.
+          // Complete the pending-create sweep while admission is closed so a
+          // hidden marker device cannot outlive the Host and its shell guard.
+          // Force a fresh ownership pass after an earlier successful reconcile:
+          // capability shutdown must also sweep a marker armed after that pass.
+          if (pendingCreateEvidenceArmed) startupPendingCreateRecoveryAttempted = false;
+          ownershipReconciledScopeKey = null;
+          await reconcilePersistedOwnership();
+        } else {
+          await ownershipReconcilePromise?.promise;
+        }
+
+        const failures = new Set<string>();
+        const attemptedSessions = new Set<string>();
+        while (true) {
+          const matchingSessions = new Set(
+            actor.listAll().filter(matchesScope).map((instance) => instance.sessionId),
+          );
+          // A create may have issued `simctl create` before its binding was
+          // persisted. Include its session in the project-scoped sweep so
+          // cancelling the session also settles the hidden create marker.
+          for (const sessionId of actor.listPendingLifecycleStartSessionIds()) {
+            if (!scoped) {
+              matchingSessions.add(sessionId);
+              continue;
+            }
+            const session = await getSession(sessionId);
+            const project = normalizeWorkingDirForProjectSettings(session?.workDir);
+            if (
+              project !== null &&
+              (requestedProjects.has(project) || options.shouldReleaseProject?.(project) === true)
+            ) {
+              matchingSessions.add(sessionId);
+            }
+          }
+          for (const sessionId of requestedSessionIds) matchingSessions.add(sessionId);
+          const pendingSessions = [...matchingSessions].filter(
+            (sessionId) => !attemptedSessions.has(sessionId),
+          );
+          if (pendingSessions.length === 0) break;
+          for (const sessionId of pendingSessions) {
+            attemptedSessions.add(sessionId);
+            revokeIOSSimulatorRendererSession(sessionId);
+          }
+          const results = await Promise.allSettled(
+            pendingSessions.map((sessionId) => cleanupRemovedSessionRuntime(sessionId)),
+          );
+          results.forEach((result, index) => {
+            if (result.status === 'fulfilled') return;
+            failures.add(pendingSessions[index]);
+            logger.warn('iOS Simulator capability deactivation cleanup failed', {
+              sessionId: pendingSessions[index],
+              error:
+                result.reason instanceof Error ? result.reason.message : String(result.reason),
+            });
+          });
+        }
+
+        const remainingMatchingInstances = actor.listAll().filter(matchesScope);
+        if (failures.size > 0 || remainingMatchingInstances.length > 0) {
+          throw new IOSSimulatorInstanceError(
+            'DEVICE_BUSY',
+            `Simulator cleanup is still pending for ${Math.max(
+              failures.size,
+              remainingMatchingInstances.length,
+            )} binding(s).`,
+            true,
+          );
+        }
+
+        const hostCanBeReleased =
+          actor.listAll().length === 0 &&
+          !actor.hasPendingOperations() &&
+          activeBuilds.size === 0 &&
+          activeSessionRemovalBarrierOperations.size === 0 &&
+          sessionRemovalCleanupPromises.size === 0 &&
+          pendingCreateReconcilePromise === null &&
+          ownershipReconcilePromise === null &&
+          pendingCreateEvidence?.isArmed() !== true;
+        if (!scoped && !hostCanBeReleased) {
+          throw new IOSSimulatorInstanceError(
+            'DEVICE_BUSY',
+            'Simulator cleanup is still pending.',
+            true,
+          );
+        }
+        return {
+          hostCanBeReleased,
+          cleanedInstanceCount: initialInstanceCount - actor.listAll().length,
+        };
+      } finally {
+        deactivationInProgress = false;
+      }
+    },
     abortOperationsForExit() {
       void abortPendingCreateReconciliation();
       runtimeInspectionExitController.abort();
@@ -6327,6 +6483,7 @@ interface DefaultIOSSimulatorRuntime {
 let defaultIOSSimulatorRuntime: DefaultIOSSimulatorRuntime | null = null;
 let defaultIOSSimulatorRuntimeClosing = false;
 let defaultIOSSimulatorRuntimeDisposePromise: Promise<void> | null = null;
+let defaultIOSSimulatorRuntimeDeactivatePromise: Promise<IOSSimulatorDeactivateResult> | null = null;
 let passivePluginRuntime: IOSSimulatorRuntime | null = null;
 let passivePluginEnvironmentCache: {
   expiresAt: number;
@@ -6515,10 +6672,10 @@ function installDefaultIOSSimulatorHost(
  * ownership.
  */
 export function initializeIOSSimulatorHost(): IOSSimulatorHost {
-  if (defaultIOSSimulatorRuntime) return defaultIOSSimulatorRuntime.host;
   if (defaultIOSSimulatorRuntimeClosing) {
     throw new Error('The iOS Simulator host is shutting down.');
   }
+  if (defaultIOSSimulatorRuntime) return defaultIOSSimulatorRuntime.host;
 
   const registry = createDefaultOwnershipRegistry();
   const pendingCreateEvidence = createDefaultPendingCreateEvidence(registry);
@@ -6536,6 +6693,95 @@ function currentIOSSimulatorHost(): IOSSimulatorHost | null {
   return defaultIOSSimulatorRuntime?.host ?? null;
 }
 
+/**
+ * Whether this process installed the Host Simulator runtime, which means Cindy
+ * may hold simulator ownership or cleanup evidence right now.
+ *
+ * Synchronous and side-effect free by contract: it must never initialize the
+ * Host. A shutting-down runtime still counts as active so a later disable can
+ * retry cleanup rather than leaving the singleton and writer lease stranded.
+ */
+export function isIOSSimulatorHostRuntimeActive(): boolean {
+  return currentIOSSimulatorHost() !== null || defaultIOSSimulatorRuntimeClosing;
+}
+
+export interface IOSSimulatorDeactivateOptions {
+  sessionIds?: readonly string[];
+  projectWorkingDirs?: readonly string[];
+  shouldReleaseProject?: (workingDir: string) => boolean;
+}
+
+export interface IOSSimulatorDeactivateResult {
+  hostReleased: boolean;
+  cleanedInstanceCount: number;
+}
+
+/**
+ * Release Simulator ownership when the capability is switched off while
+ * keeping the Host lazy and re-initializable for a later enable.
+ *
+ * Cleanup failures deliberately leave the singleton and writer lease installed.
+ * Releasing either before ownership is empty would abandon Cindy-owned cleanup
+ * without a process that can safely retry it.
+ */
+export function deactivateIOSSimulatorHost(
+  options: IOSSimulatorDeactivateOptions = {},
+): Promise<IOSSimulatorDeactivateResult> {
+  if (defaultIOSSimulatorRuntimeDisposePromise) {
+    return Promise.resolve({ hostReleased: false, cleanedInstanceCount: 0 });
+  }
+  if (defaultIOSSimulatorRuntimeDeactivatePromise) {
+    const pending = defaultIOSSimulatorRuntimeDeactivatePromise;
+    return pending.then(
+      () => deactivateIOSSimulatorHost(options),
+      () => deactivateIOSSimulatorHost(options),
+    );
+  }
+  const runtime = defaultIOSSimulatorRuntime;
+  if (!runtime) {
+    return Promise.resolve({ hostReleased: true, cleanedInstanceCount: 0 });
+  }
+
+  defaultIOSSimulatorRuntimeClosing = true;
+  let deactivation!: Promise<IOSSimulatorDeactivateResult>;
+  deactivation = (async () => {
+    try {
+      const scoped =
+        options.sessionIds !== undefined ||
+        options.projectWorkingDirs !== undefined ||
+        options.shouldReleaseProject !== undefined;
+      if (!scoped) clearIOSSimulatorRendererAccess();
+      const result = await runtime.host.deactivate(options);
+      await runtime.flushRegistry();
+      if (!result.hostCanBeReleased || defaultIOSSimulatorRuntime !== runtime) {
+        return {
+          hostReleased: false,
+          cleanedInstanceCount: result.cleanedInstanceCount,
+        };
+      }
+      await runtime.host.dispose();
+      await runtime.flushRegistry();
+      configureIOSSimulatorRendererAccessRevocationObserver(null);
+      runtime.releaseExitAbortHandler();
+      runtime.releaseRegistry();
+      defaultIOSSimulatorRuntime = null;
+      return {
+        hostReleased: true,
+        cleanedInstanceCount: result.cleanedInstanceCount,
+      };
+    } finally {
+      if (defaultIOSSimulatorRuntimeDeactivatePromise === deactivation) {
+        defaultIOSSimulatorRuntimeDeactivatePromise = null;
+      }
+      if (!defaultIOSSimulatorRuntimeDisposePromise) {
+        defaultIOSSimulatorRuntimeClosing = false;
+      }
+    }
+  })();
+  defaultIOSSimulatorRuntimeDeactivatePromise = deactivation;
+  return deactivation;
+}
+
 export function getIOSSimulatorSessionStatus(
   sessionId: string,
 ): Promise<IOSSimulatorSessionStatus> {
@@ -6546,8 +6792,6 @@ export function getIOSSimulatorPluginStatus(
   sessionId: string,
   options: IOSSimulatorPluginStatusReadOptions = {},
 ): Promise<GhostIOSSimulatorStatusProbeResult> {
-  const host = currentIOSSimulatorHost();
-  if (host) return host.getPluginStatus(sessionId);
   if (defaultIOSSimulatorRuntimeClosing) {
     return Promise.resolve({
       ok: false,
@@ -6555,6 +6799,8 @@ export function getIOSSimulatorPluginStatus(
       message: 'The iOS Simulator host is shutting down.',
     });
   }
+  const host = currentIOSSimulatorHost();
+  if (host) return host.getPluginStatus(sessionId);
   return readPassiveIOSSimulatorPluginStatus(sessionId, options);
 }
 
@@ -6696,8 +6942,9 @@ export async function reconcilePersistedIOSSimulatorOwnership(
 export async function disposeIOSSimulatorHost(): Promise<void> {
   if (defaultIOSSimulatorRuntimeDisposePromise) return defaultIOSSimulatorRuntimeDisposePromise;
   defaultIOSSimulatorRuntimeClosing = true;
-  const runtime = defaultIOSSimulatorRuntime;
   defaultIOSSimulatorRuntimeDisposePromise = (async () => {
+    await defaultIOSSimulatorRuntimeDeactivatePromise?.catch(() => undefined);
+    const runtime = defaultIOSSimulatorRuntime;
     try {
       clearIOSSimulatorRendererAccess();
       if (!runtime) return;

--- a/apps/desktop/src/main/mcp-integrations/ios-simulator.ts
+++ b/apps/desktop/src/main/mcp-integrations/ios-simulator.ts
@@ -2272,7 +2272,7 @@ export function createIOSSimulatorHost(options: IOSSimulatorHostOptions = {}): I
   }
 
   async function inspectForPlugin(sessionId: string): Promise<GhostIOSSimulatorStatusProbeResult> {
-    if (disposePromise) {
+    if (disposePromise || deactivationInProgress) {
       return {
         ok: false,
         errorCode: 'IOS_SIMULATOR_HOST_ERROR',
@@ -2288,7 +2288,12 @@ export function createIOSSimulatorHost(options: IOSSimulatorHostOptions = {}): I
     }
     const ownerScopeKey = getOwnerScopeKey();
     const resolved = await resolveSession(sessionId);
-    if (isOwnerBoundaryPending() || getOwnerScopeKey() !== ownerScopeKey) {
+    if (
+      disposePromise ||
+      deactivationInProgress ||
+      isOwnerBoundaryPending() ||
+      getOwnerScopeKey() !== ownerScopeKey
+    ) {
       return {
         ok: false,
         errorCode: 'IOS_SIMULATOR_HOST_ERROR',
@@ -2299,7 +2304,7 @@ export function createIOSSimulatorHost(options: IOSSimulatorHostOptions = {}): I
       return { ok: false, errorCode: resolved.errorCode, message: resolved.message };
     try {
       const environment = await readPluginEnvironment();
-      if (disposePromise) {
+      if (disposePromise || deactivationInProgress) {
         return {
           ok: false,
           errorCode: 'IOS_SIMULATOR_HOST_ERROR',
@@ -2360,16 +2365,16 @@ export function createIOSSimulatorHost(options: IOSSimulatorHostOptions = {}): I
   }
 
   async function inspectForSession(sessionId: string): Promise<IOSSimulatorSessionStatus> {
-    if (disposePromise) return hostDisposedStatus(sessionId);
+    if (disposePromise || deactivationInProgress) return hostDisposedStatus(sessionId);
     const resolved = await resolveSession(sessionId);
     if (!resolved.ok) return resolved;
-    if (disposePromise) return hostDisposedStatus(resolved.sessionId);
+    if (disposePromise || deactivationInProgress) return hostDisposedStatus(resolved.sessionId);
     await reconcilePersistedOwnership();
-    if (disposePromise) return hostDisposedStatus(resolved.sessionId);
+    if (disposePromise || deactivationInProgress) return hostDisposedStatus(resolved.sessionId);
     await reconcileLiveDevices(actor.list(resolved.sessionId));
-    if (disposePromise) return hostDisposedStatus(resolved.sessionId);
+    if (disposePromise || deactivationInProgress) return hostDisposedStatus(resolved.sessionId);
     const environment = await inspectRuntime();
-    if (disposePromise) return hostDisposedStatus(resolved.sessionId);
+    if (disposePromise || deactivationInProgress) return hostDisposedStatus(resolved.sessionId);
     const instances = actor
       .list(resolved.sessionId)
       .map((instance) => actor.heartbeatOwned(resolved.sessionId, instance.instanceId));

--- a/apps/desktop/src/main/mcp-integrations/ios-simulator.ts
+++ b/apps/desktop/src/main/mcp-integrations/ios-simulator.ts
@@ -6355,9 +6355,8 @@ export function createIOSSimulatorHost(options: IOSSimulatorHostOptions = {}): I
 
         if (!scoped) {
           globalDeactivationInProgress = true;
-          // Close the actor queues before ownership reconciliation. This is the
-          // point at which the shell guard's protection becomes stricter, so no
-          // new boot/mutation can race the final sweep.
+          // Close the actor queues before ownership reconciliation so no new
+          // Host boot or mutation can race the final sweep.
           await Promise.all([actor.cancelAllLifecycleStarts(), actor.cancelAllMutations()]);
         }
         const pendingCreateEvidenceArmed = pendingCreateEvidence?.isArmed() === true;
@@ -6367,7 +6366,7 @@ export function createIOSSimulatorHost(options: IOSSimulatorHostOptions = {}): I
         ) {
           // A create can cross `simctl create` before its binding is persisted.
           // Complete the pending-create sweep while admission is closed so a
-          // hidden marker device cannot outlive the Host and its shell guard.
+          // hidden marker device cannot outlive the Host and writer lease.
           // Force a fresh ownership pass after an earlier successful reconcile:
           // capability shutdown must also sweep a marker armed after that pass.
           if (pendingCreateEvidenceArmed) startupPendingCreateRecoveryAttempted = false;

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/ios-simulator/IOSSimulatorTabBody.tsx
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/ios-simulator/IOSSimulatorTabBody.tsx
@@ -527,6 +527,14 @@ export function IOSSimulatorTabBody({
   const viewerInteractive = Boolean(
     viewerVisible && streamState === 'streaming' && presentationMatchesRoute && frameFresh && !busy,
   );
+  // WDA is the stable compatibility input route.  Pointer gestures still use
+  // the same tap/swipe fallback path, but must not first send a live native
+  // touch that is guaranteed to fail with NATIVE_INPUT_UNAVAILABLE.
+  const nativeContinuousInputActive = Boolean(
+    routeStatus?.input.adapter === 'native-sidecar' &&
+    routeStatus.input.continuous &&
+    routeStatus.input.state === 'active',
+  );
   const streamRouteLabel =
     routeStatus?.stream.adapter === 'native-sidecar' && routeStatus.stream.encoding === 'h264'
       ? t('rightSidebar.iosSimulator.route.nativeH264')
@@ -541,10 +549,10 @@ export function IOSSimulatorTabBody({
         : t('rightSidebar.iosSimulator.route.hidden');
   const streamRouteStateLabel = routeStatus
     ? t(`rightSidebar.iosSimulator.route.state.${routeStatus.stream.state}`)
-    : t('rightSidebar.iosSimulator.route.state.detecting');
+    : t('rightSidebar.iosSimulator.route.state.unavailable');
   const inputRouteStateLabel = routeStatus
     ? t(`rightSidebar.iosSimulator.route.state.${routeStatus.input.state}`)
-    : t('rightSidebar.iosSimulator.route.state.detecting');
+    : t('rightSidebar.iosSimulator.route.state.unavailable');
   const formatActionError = useCallback(
     (result: Extract<IOSSimulatorToolResponse, { ok: false }>) =>
       t(actionErrorI18nKey(result.errorCode), {
@@ -1450,13 +1458,19 @@ export function IOSSimulatorTabBody({
         idleTimer: null,
         tail: Promise.resolve(),
       };
-      gesture.tail = invokeLiveTouch(gesture, 'begin', point)
-        .then(() => {
-          gesture.beginAcknowledged = true;
-        })
-        .catch(() => {
-          gesture.failed = true;
-        });
+      if (nativeContinuousInputActive) {
+        gesture.tail = invokeLiveTouch(gesture, 'begin', point)
+          .then(() => {
+            gesture.beginAcknowledged = true;
+          })
+          .catch(() => {
+            gesture.failed = true;
+          });
+      } else {
+        // Keep the gesture locally so pointer-up can classify it as tap or
+        // swipe, while routing the actual action straight through WDA.
+        gesture.failed = true;
+      }
       pointerGestureRef.current = gesture;
       beginInteractiveFrameRate();
       armPointerGestureWatchdog(gesture);
@@ -1467,6 +1481,7 @@ export function IOSSimulatorTabBody({
       attachedInstance,
       beginInteractiveFrameRate,
       invokeLiveTouch,
+      nativeContinuousInputActive,
       pointerRatio,
       viewerInteractive,
     ],

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/ios-simulator/__tests__/IOSSimulatorTabBody.test.tsx
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/ios-simulator/__tests__/IOSSimulatorTabBody.test.tsx
@@ -107,6 +107,50 @@ function readyStatus(instance = readyInstance()): IOSSimulatorSessionStatus {
   };
 }
 
+function nativeActiveRouteStatus(instance = readyInstance()): IOSSimulatorRouteStatusPush {
+  return {
+    sessionId: instance.sessionId,
+    instanceId: instance.instanceId,
+    generation: instance.generation,
+    updatedAt: '2026-08-12T00:00:00.000Z',
+    stream: {
+      adapter: 'wda',
+      encoding: 'jpeg',
+      state: 'active',
+      reasonCode: 'wda-active',
+    },
+    input: {
+      adapter: 'native-sidecar',
+      state: 'active',
+      continuous: true,
+      multiTouch: true,
+      reasonCode: 'native-active',
+    },
+  };
+}
+
+function wdaFallbackRouteStatus(instance = readyInstance()): IOSSimulatorRouteStatusPush {
+  return {
+    sessionId: instance.sessionId,
+    instanceId: instance.instanceId,
+    generation: instance.generation,
+    updatedAt: '2026-08-12T00:00:00.000Z',
+    stream: {
+      adapter: 'wda',
+      encoding: 'jpeg',
+      state: 'active',
+      reasonCode: 'wda-active',
+    },
+    input: {
+      adapter: 'wda',
+      state: 'fallback',
+      continuous: false,
+      multiTouch: false,
+      reasonCode: 'native-sidecar-unavailable',
+    },
+  };
+}
+
 function multiReadyStatus(
   mutationStates: IOSSimulatorMutationState[] = [],
 ): IOSSimulatorSessionStatus {
@@ -827,8 +871,19 @@ describe('IOSSimulatorTabBody', () => {
     fireEvent.pointerDown(image, { pointerId: 9, button: 0, clientX: 20, clientY: 40 });
     fireEvent.pointerUp(image, { pointerId: 9, clientX: 180, clientY: 360 });
     await waitFor(() => {
-      expect(api.liveTouch.mock.calls.map(([request]) => request.phase)).toEqual(['begin', 'end']);
+      expect(api.call).toHaveBeenCalledWith({
+        sessionId: 'session-a',
+        name: 'swipe',
+        args: expect.objectContaining({
+          instanceId: instance.instanceId,
+          startXRatio: 0.1,
+          startYRatio: 0.1,
+          endXRatio: 0.9,
+          endYRatio: 0.9,
+        }),
+      });
     });
+    expect(api.liveTouch).not.toHaveBeenCalled();
     await act(async () => {
       await new Promise((resolve) => window.setTimeout(resolve, 300));
     });
@@ -1458,51 +1513,10 @@ describe('IOSSimulatorTabBody', () => {
   });
 
   it('streams pointer samples through native touch and temporarily boosts frame rate', async () => {
-    const api = installStatus({
-      ok: true,
-      sessionId: 'session-a',
-      deviceGrants: [],
-      mutationStates: [],
-      instances: [
-        {
-          instanceId: 'instance-a',
-          sessionId: 'session-a',
-          sessionKind: 'local',
-          sourceFingerprint: 'fingerprint-a',
-          simulatorUdid: 'DEVICE-UDID-123',
-          simulatorName: 'iPhone 17 Pro',
-          runtimeIdentifier: 'runtime',
-          deviceTypeIdentifier: 'type',
-          creationProvenance: 'external',
-          bootProvenance: 'preexisting',
-          generation: 2,
-          lifecycleState: 'ready',
-          viewerState: 'attached',
-          healthState: 'healthy',
-          lease: {
-            id: 'lease-a',
-            issuedAt: '2026-07-23T00:00:00.000Z',
-            expiresAt: '2026-07-23T00:10:00.000Z',
-          },
-          createdAt: '2026-07-23T00:00:00.000Z',
-          lastActiveAt: '2026-07-23T00:00:00.000Z',
-          stoppedAt: null,
-          graceExpiresAt: null,
-          errorCode: null,
-        },
-      ],
-      environment: {
-        platform: 'darwin',
-        supported: true,
-        ready: true,
-        xcodeVersion: 'Xcode 26.4',
-        runtimes: [],
-        devices: [],
-        issue: null,
-        error: null,
-        setupSteps: [],
-      },
-    });
+    const statusValue = readyStatus();
+    if (!statusValue.ok) throw new Error('Expected a ready simulator status.');
+    statusValue.routeStatuses = [nativeActiveRouteStatus()];
+    const api = installStatus(statusValue);
     api.setViewerVisibility.mockResolvedValue(streamingJpegResult());
     api.latestFrame.mockResolvedValue(streamingJpegResult());
     const rendered = render(
@@ -1535,7 +1549,7 @@ describe('IOSSimulatorTabBody', () => {
       sessionId: 'session-a',
       instanceId: 'instance-a',
       generation: 2,
-      leaseId: 'lease-a',
+      leaseId: 'lease-2',
       phase: 'begin',
       xRatio: 0.1,
       yRatio: 0.1,
@@ -1566,7 +1580,10 @@ describe('IOSSimulatorTabBody', () => {
   });
 
   it('finishes a captured gesture when pointer movement reports that the button is released', async () => {
-    const api = installStatus(readyStatus());
+    const statusValue = readyStatus();
+    if (!statusValue.ok) throw new Error('Expected a ready simulator status.');
+    statusValue.routeStatuses = [nativeActiveRouteStatus()];
+    const api = installStatus(statusValue);
     api.setViewerVisibility.mockResolvedValue(streamingJpegResult());
     api.latestFrame.mockResolvedValue(streamingJpegResult());
     const rendered = render(
@@ -1606,7 +1623,10 @@ describe('IOSSimulatorTabBody', () => {
   });
 
   it('cancels native touch when pointer capture is lost', async () => {
-    const api = installStatus(readyStatus());
+    const statusValue = readyStatus();
+    if (!statusValue.ok) throw new Error('Expected a ready simulator status.');
+    statusValue.routeStatuses = [nativeActiveRouteStatus()];
+    const api = installStatus(statusValue);
     api.setViewerVisibility.mockResolvedValue(streamingJpegResult());
     api.latestFrame.mockResolvedValue(streamingJpegResult());
     const rendered = render(
@@ -1636,7 +1656,10 @@ describe('IOSSimulatorTabBody', () => {
   });
 
   it('releases a partially delivered native gesture without replaying the swipe', async () => {
-    const api = installStatus(readyStatus());
+    const statusValue = readyStatus();
+    if (!statusValue.ok) throw new Error('Expected a ready simulator status.');
+    statusValue.routeStatuses = [nativeActiveRouteStatus()];
+    const api = installStatus(statusValue);
     api.setViewerVisibility.mockResolvedValue(streamingJpegResult());
     api.latestFrame.mockResolvedValue(streamingJpegResult());
     api.liveTouch.mockImplementation(async (request): Promise<IOSSimulatorToolResponse> =>
@@ -1699,15 +1722,13 @@ describe('IOSSimulatorTabBody', () => {
     });
   });
 
-  it('uses the discrete compatibility route only when native touch never began', async () => {
-    const api = installStatus(readyStatus());
+  it('routes compatibility gestures directly through WDA without a native attempt', async () => {
+    const statusValue = readyStatus();
+    if (!statusValue.ok) throw new Error('Expected a ready simulator status.');
+    statusValue.routeStatuses = [wdaFallbackRouteStatus()];
+    const api = installStatus(statusValue);
     api.setViewerVisibility.mockResolvedValue(streamingJpegResult());
     api.latestFrame.mockResolvedValue(streamingJpegResult());
-    api.liveTouch.mockResolvedValue({
-      ok: false,
-      errorCode: 'NATIVE_INPUT_UNAVAILABLE',
-      message: 'Continuous native input is unavailable.',
-    });
     const rendered = render(
       <IOSSimulatorTabBody state={{ instanceId: 'instance-a' }} ctx={ctx} active shellVisible />,
     );
@@ -1736,7 +1757,38 @@ describe('IOSSimulatorTabBody', () => {
         }),
       });
     });
-    expect(api.liveTouch.mock.calls.map(([request]) => request.phase)).toEqual(['begin']);
+    expect(api.liveTouch).not.toHaveBeenCalled();
+
+    fireEvent.pointerDown(image, {
+      pointerId: 13,
+      button: 0,
+      buttons: 1,
+      clientX: 20,
+      clientY: 40,
+    });
+    fireEvent.pointerUp(image, { pointerId: 13, clientX: 20, clientY: 40 });
+    await waitFor(() => {
+      expect(api.call).toHaveBeenCalledWith({
+        sessionId: 'session-a',
+        name: 'tap',
+        args: expect.objectContaining({
+          instanceId: 'instance-a',
+          xRatio: 0.1,
+          yRatio: 0.1,
+        }),
+      });
+    });
+  });
+
+  it('does not show native detection while the route status is missing', async () => {
+    const api = installStatus(readyStatus());
+    render(<IOSSimulatorTabBody state={{ instanceId: 'instance-a' }} ctx={ctx} />);
+
+    await waitFor(() => expect(api.status).toHaveBeenCalledOnce());
+    expect(screen.queryByText('rightSidebar.iosSimulator.route.state.detecting')).toBeNull();
+    expect(
+      screen.getAllByText('rightSidebar.iosSimulator.route.state.unavailable').length,
+    ).toBeGreaterThan(0);
   });
 
   it('rejects a frame that belongs to an obsolete simulator generation', async () => {

--- a/packages/ios-simulator-runtime/src/instance-actor.ts
+++ b/packages/ios-simulator-runtime/src/instance-actor.ts
@@ -279,6 +279,26 @@ export class IOSSimulatorInstanceActor {
     return this.#store.listAll();
   }
 
+  /** Whether lifecycle or mutation work is still queued/in flight. */
+  hasPendingOperations(): boolean {
+    return (
+      this.#tails.size > 0 ||
+      this.#activeMutations.size > 0 ||
+      this.#activeLifecycleStarts.size > 0
+    );
+  }
+
+  /** Session ids with a lifecycle start that has not settled yet. */
+  listPendingLifecycleStartSessionIds(): string[] {
+    return [
+      ...new Set(
+        [...this.#activeLifecycleStarts.values()]
+          .flatMap((records) => [...records])
+          .map((record) => record.sessionId),
+      ),
+    ];
+  }
+
   /** Remove a persisted binding after orphan policy has decided its fate. */
   forget(instanceId: string, sessionId: string): IOSSimulatorInstance {
     this.#store.requireOwned(instanceId, sessionId);

--- a/packages/ios-simulator-runtime/src/native-sidecar/process-manager.test.ts
+++ b/packages/ios-simulator-runtime/src/native-sidecar/process-manager.test.ts
@@ -322,6 +322,8 @@ describe("IOSSimulatorNativeSidecarProcessManager", () => {
       binaryPath: "/private/fake/ios-simulator-sidecar",
       createChannel,
       verifyBinaryIntegrity,
+      enableH264Stream: true,
+      enableContinuousInput: true,
     });
 
     await expect(manager.start(input())).rejects.toMatchObject({
@@ -330,6 +332,17 @@ describe("IOSSimulatorNativeSidecarProcessManager", () => {
     });
     expect(verifyBinaryIntegrity).toHaveBeenCalledTimes(1);
     expect(createChannel).not.toHaveBeenCalled();
+    expect(manager.diagnostics("instance-a")).toMatchObject({
+      running: false,
+      state: "failed",
+      admission: {
+        processState: "failed",
+        capabilities: {
+          h264Stream: { reasonCode: "PROCESS_NOT_RUNNING" },
+          continuousInput: { reasonCode: "PROCESS_NOT_RUNNING" },
+        },
+      },
+    });
   });
 
   it("rechecks packaged artifact integrity before a channel restart", async () => {
@@ -793,6 +806,35 @@ describe("IOSSimulatorNativeSidecarProcessManager", () => {
         launch: {
           allowed: false,
           reasonCode: "ARTIFACT_UNTRUSTED",
+        },
+        fallbackRoute: "wda-mjpeg",
+      },
+    });
+  });
+
+  it("settles a missing development sidecar to fallback instead of awaiting a probe", async () => {
+    const manager = new IOSSimulatorNativeSidecarProcessManager({
+      binaryPath: "/private/fake/missing-ios-simulator-sidecar",
+      enableH264Stream: true,
+      enableContinuousInput: true,
+    });
+
+    await expect(manager.start(input())).rejects.toMatchObject({
+      code: "BINARY_UNAVAILABLE",
+    });
+    expect(manager.diagnostics("instance-a")).toMatchObject({
+      running: false,
+      state: "failed",
+      lastFailure: "Native sidecar executable is unavailable",
+      admission: {
+        processState: "failed",
+        launch: { active: false, reasonCode: "PROCESS_NOT_RUNNING" },
+        capabilities: {
+          h264Stream: { active: false, reasonCode: "PROCESS_NOT_RUNNING" },
+          continuousInput: {
+            active: false,
+            reasonCode: "PROCESS_NOT_RUNNING",
+          },
         },
         fallbackRoute: "wda-mjpeg",
       },

--- a/packages/ios-simulator-runtime/src/native-sidecar/process-manager.ts
+++ b/packages/ios-simulator-runtime/src/native-sidecar/process-manager.ts
@@ -748,18 +748,46 @@ export class IOSSimulatorNativeSidecarProcessManager {
       this.#lastFailure.set(input.instanceId, error.message);
       throw error;
     }
-    await this.#verifyBinaryIntegrity(input.instanceId);
-    if (!this.#options.createChannel) {
-      try {
-        await access(this.#options.binaryPath, constants.X_OK);
-      } catch {
-        throw new IOSSimulatorNativeSidecarProcessManagerError(
-          "BINARY_UNAVAILABLE",
-          "Native sidecar executable is unavailable",
+    // Resolve all pre-channel launch requirements inside the same failure
+    // boundary as the actual sidecar startup.  A missing artifact, failed
+    // integrity check, or unavailable sandbox must settle the admission to
+    // `failed`; otherwise the preflight `idle/AWAITING_PROBE` decision leaks
+    // to route-status consumers and the renderer can remain stuck on
+    // "detecting" even though WDA has already selected its fallback route.
+    let sandbox: IOSSimulatorNativeSidecarSandboxLaunchState;
+    try {
+      await this.#verifyBinaryIntegrity(input.instanceId);
+      if (!this.#options.createChannel) {
+        try {
+          await access(this.#options.binaryPath, constants.X_OK);
+        } catch {
+          throw new IOSSimulatorNativeSidecarProcessManagerError(
+            "BINARY_UNAVAILABLE",
+            "Native sidecar executable is unavailable",
+          );
+        }
+      }
+      sandbox = await this.#prepareSandbox(input, operation);
+    } catch (error) {
+      this.#lastAdmission.set(
+        input.instanceId,
+        evaluateIOSSimulatorNativeCapabilityAdmission({
+          policy,
+          processState: "failed",
+          now: this.#options.now,
+        }),
+      );
+      if (!this.#lastFailure.has(input.instanceId)) {
+        this.#lastFailure.set(
+          input.instanceId,
+          safeProcessManagerFailure(
+            error,
+            "Native sidecar process failed before launch.",
+          ).message,
         );
       }
+      throw error;
     }
-    const sandbox = await this.#prepareSandbox(input, operation);
     const channel =
       this.#options.createChannel?.(input) ??
       new IOSSimulatorNativeSidecarChannel(

--- a/packages/ios-simulator-runtime/src/wda/process-manager.test.ts
+++ b/packages/ios-simulator-runtime/src/wda/process-manager.test.ts
@@ -1125,4 +1125,70 @@ describe("WdaProcessManager", () => {
     await harness.manager.stop("instance-a");
     expect(nativeManager.stop).toHaveBeenCalledWith("instance-a");
   });
+
+  it("keeps WDA active and reports a settled Native fallback after sidecar startup fails", async () => {
+    const nativeAdmission = evaluateIOSSimulatorNativeCapabilityAdmission({
+      policy: createIOSSimulatorNativeDevelopmentAdmissionPolicy({
+        enableH264Stream: true,
+        enableContinuousInput: true,
+      }),
+      processState: "failed",
+    });
+    const nativeManager = {
+      providerId: "cindy.bundled-ios-simulator",
+      diagnostics: vi.fn(() => ({
+        running: false,
+        state: "failed" as const,
+        crashCount: 0,
+        probe: null,
+        lastFailure: "Native sidecar executable is unavailable",
+        lastTermination: null,
+        admission: nativeAdmission,
+      })),
+      admission: vi.fn(() => nativeAdmission),
+      get: vi.fn(() => null),
+      start: vi.fn(async () => {
+        throw new Error("Native sidecar executable is unavailable");
+      }),
+      recover: vi.fn(async () => {
+        throw new Error("Native sidecar executable is unavailable");
+      }),
+      stop: vi.fn(async () => undefined),
+    } satisfies WdaProcessManagerOptions["nativeCapabilityProvider"];
+    const harness = await createHarness(nativeManager);
+
+    const running = await harness.manager.start({
+      instanceId: "instance-a",
+      simulatorUdid: UDID,
+      generation: 9,
+      runtimeIdentifier: "runtime",
+      runtimeBuildVersion: "runtime-build",
+      xcodeBuild: "build",
+      architecture: "arm64",
+    });
+
+    expect(harness.driver.createSession).toHaveBeenCalledOnce();
+    expect(running.driverRouter?.capabilityReport()).toMatchObject({
+      nativeSidecar: {
+        available: false,
+        admission: {
+          processState: "failed",
+          capabilities: {
+            h264Stream: { reasonCode: "PROCESS_NOT_RUNNING" },
+            continuousInput: { reasonCode: "PROCESS_NOT_RUNNING" },
+          },
+        },
+      },
+      routes: {
+        continuousInput: { selected: "wda", fallback: true },
+        stream: {
+          h264: { selected: "wda", fallback: true },
+        },
+      },
+    });
+    expect(running.driverRouter?.continuousInput()).toBeNull();
+    expect(running.driverRouter?.discreteInput()).toBe(harness.driver);
+
+    await harness.manager.stop("instance-a");
+  });
 });


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 iOS Simulator capability 关闭后 Host 仍长期占用 ownership / shell guard，以及 Native Sidecar 不可用时界面和输入没有稳定降级的问题。

关闭最后一个 capability provider、卸载最后一个 provider，或在「设置 → 内置工具」按用户／项目范围关闭 iOS Simulator 时，Host 会按 scope 清理 Cindy-owned 资源。项目级清理不会进入进程级 closing，其他仍启用项目的状态查询、工具调用与既有 viewer/route 会继续可用；只有确认没有 enabled provider、project binding、pending operation/evidence 或仍需管理的 Cindy-owned 资源后，才释放 singleton、writer lease 与 shell guard。之后 Agent 可以再次启动外部 Simulator.app / `simctl`，重新启用能力时 Host 仍可懒初始化。

Codex 的 `open` / `xcrun` PATH shim 现在通过当前 Desktop profile 的鉴权 loopback 通道实时复用项目开关与 Host 状态。能力关闭且清理完成后，同一个 Codex 任务无需重建任务或重启 Desktop 即可使用外部 Simulator；重新启用后，同一个 shim 会恢复拒绝外部 Simulator 操作。插件启停／卸载、用户与项目设置、以及含 iOS slot 的安装／更新共用同一 capability mutation FIFO，避免 disable 后立即 re-enable 被旧 teardown 反向撤销。

Native Sidecar 在二进制、完整性或沙箱 preflight 阶段失败时，现在会把 admission 收敛为 `failed`，而不是一直遗留 `AWAITING_PROBE`。WDA 保持运行并成为稳定兼容路径；右侧栏只在 Native 确实处于 probe 时显示「检测中」，并且 WDA 模式的点击／滑动不再先发送一个必然失败的 Native touch。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：iOS Simulator Host 关闭后不能恢复外部模拟器使用；测试实例长期显示「检测原生能力」。
- 本 PR 包含：全局／项目范围 capability deactivation、失败可重试、Host 释放、Codex shell shim 实时状态同步、Native route status 收敛、WDA 输入降级。
- 明确不包含：关闭 viewer/tab 时清理设备；测试实例选择或多 Desktop 实例管理；跨 profile Skill 链接清理；插件 manifest、批准状态或安装布局变更。
- 用户可见变化：能力关闭且清理成功后无需重启 Desktop 或重建 Codex 任务，即可让 Agent 使用外部模拟器；重新启用后恢复内嵌能力保护；Native 不可用时状态不再无限显示「检测中」，点击／滑动继续通过 WDA 工作。
- 是否存在 breaking change：无。

### UI 变化

- 引用的设计规范：`docs/design-rules/DESIGN.md` §11 Voice & Content（进行中状态只用于真实进行中的操作）与 §10 Light / Dark 双模式交付门槛。本次只修正既有状态文案的显示条件，不新增样式、颜色、布局或文案 key；沿用现有主题 token，因此 Light / Dark 实现均未改变。
- 截图／录屏：未附。变化只在 Native capability 缺失／失败时，将错误的持续「检测中」改为既有「不可用／兼容」状态。

## 怎么验证的

### 自动验证

```text
Desktop 定向：
pnpm exec vitest run src/main/mcp-integrations/__tests__/ios-simulator.test.ts src/renderer/features/right-sidebar/plugins/ios-simulator/__tests__/IOSSimulatorTabBody.test.tsx
结果：2 files，156 tests passed

Runtime 定向：
pnpm exec vitest run src/native-sidecar/process-manager.test.ts src/wda/process-manager.test.ts
结果：2 files，52 tests passed

Codex shell shim / Host policy 定向：
pnpm exec vitest run src/main/maker-host/__tests__/agentShellPolicyServer.test.ts src/main/maker-host/__tests__/agentShellGuards.test.ts src/main/cindy-brain/__tests__/iosSimulatorPluginGate.test.ts src/main/maker-host/__tests__/iosSimulatorShellHook.test.ts src/main/maker-host/__tests__/shellCommandPolicy.test.ts src/main/mcp-integrations/__tests__/ios-simulator.test.ts --project standard
结果：6 files，531 tests passed

最终 review 回归（跨项目清理、late admission、symlink identity、pending-create evidence、mutation FIFO、dispose/flush failure injection）：
结果：4 files，147 tests passed

本轮 scoped capability teardown 回归（插件页项目停用、失败后重复停用、多 provider 按项目保留、保留项目 create marker 竞态）：
结果：3 files，147 tests passed

Codex shell policy 项目归属回归（同物理根的逻辑别名歧义、项目外 cwd）：
结果：3 files，9 tests passed

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --filter @cindy/ios-simulator-runtime run --if-present typecheck
结果：该 package 无 typecheck script，按仓库约定跳过

pnpm --filter @cindy/ios-simulator-runtime build
结果：通过（tsc --noEmit）

pnpm test:unit -- --workspace-concurrency=1
结果：全仓 required unit tier 通过（workspace 串行；并行跑中出现的 7 个无关时序失败均已单独复跑通过）

git diff --check
结果：通过

pnpm check:dco
结果：13 commits 全部通过
```

### 手工验证

- 已用隔离 Desktop 测试实例复核卡住表象；确认其中一次实例错配属于同时运行两个隔离 Desktop 的操作问题，不扩进产品代码。
- 未做 UI Light / Dark 实机目检；本次没有样式或 token 改动。

### 未执行的验证

- 未执行真实 Native Sidecar H.264 / HID smoke：当前测试实例未构建 Native Sidecar，不能把 WDA 降级验证冒充 Native 实机验证。
- 未执行 Windows 实机验证：iOS Simulator runtime 只在 macOS 生效；全仓单元测试覆盖跨平台静态回归，最终以 CI 为准。
- 新 head 的 GitHub CI 在推送后重新运行；本文只记录已完成的本地门禁，远端结果以 GitHub checks 为准。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [x] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Desktop iOS Simulator Host 生命周期、Codex 在 macOS 上的 `open` / `xcrun` PATH shim、Native Sidecar admission、WDA fallback 与右侧栏 route status / input routing。
- 回滚 / 降级方式：回滚本 PR 的十三个 commit；Native Sidecar 不可用时仍可通过 WDA MJPEG + 离散输入降级。
- 在决定 idle release 之前，清理失败会保留 ownership、Host singleton、writer lease 与 shell guard，允许后续重试；不会提前暴露仍由 Cindy 使用的设备。idle release 一旦预订，即使 `host.dispose()` 或最终 registry flush 失败，也会记录错误并完成 observer、exit handler、writer lease 与 singleton 清理，避免永久卡在 closing；后续 Host 可重新初始化。shim 只有收到当前 profile 鉴权 loopback 通道的精确 `allow` 才会转发；通道缺失、超时、鉴权失败、异常响应或 Desktop 正在退出时继续拒绝。
- 项目范围关闭只清理该项目 binding，不设置进程级 closing；项目 A 清理期间，仍启用的项目 B 可继续查询状态、调用工具并使用既有 viewer/route。多个 enabled provider 时关闭一个不会提前释放 Host；项目显式启用优先于用户默认关闭。
- capability mutation 通过 FIFO 串行；late create/attach admission、pending-create evidence、symlink/canonical identity 与尚未建立 binding 的 enabled 项目都会参与 idle-release 判定。
- 存量插件影响：无。未修改 manifest、receipt、批准状态 schema、指纹、安装布局、包格式或凭证／偏好；已安装、已批准、已启用插件无需重新安装、确认或配置。
- 插件作者契约无需同步：未修改 slot、manifest 校验、发现链、沙箱权限或 FORGE_GUIDE。
- 不涉及 Mobile runtime fingerprint 或 OTA。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次不改变公开接口或作者契约，无额外文档改动）
- [x] 已确认测试结果或说明未执行原因

