### PR TITLE
fix(anthropic-compat-proxy): 流式请求的成功响应有效性门

### DIFF
--- a/packages/anthropic-compat-proxy/src/server.test.ts
+++ b/packages/anthropic-compat-proxy/src/server.test.ts
@@ -2569,3 +2569,104 @@ describe('per-thread 已见 id 缓存(codex-connector P1:请求体缺席历史 i
     expect(r2).not.toContain('Bash_210_dup2');
   });
 });
+
+describe('streaming response validity gate (#2242)', () => {
+  const SSE_HEADERS = { 'content-type': 'text/event-stream; charset=utf-8' };
+  const SSE_BODY = 'event: message_start\ndata: {"type":"message_start"}\n\nevent: message_stop\ndata: {"type":"message_stop"}\n\n';
+
+  it('流式请求收到空 2xx → 结构化 502(empty_stream_response)', async () => {
+    const upstream = await startFakeUpstream((_idx, _body, res) => {
+      res.writeHead(200, SSE_HEADERS);
+      res.end();
+    });
+    upstreamClose = upstream.close;
+    proxy = await createAnthropicCompatProxy({ upstream: upstream.url });
+
+    const result = await post(proxy.url, { model: 'test-model', stream: true });
+    expect(result.status).toBe(502);
+    const parsed = JSON.parse(result.text) as { error: { type: string; code?: string } };
+    expect(parsed.error.type).toBe('proxy_error');
+    expect(parsed.error.code).toBe('empty_stream_response');
+  });
+
+  it('流式请求收到非 SSE 2xx → 502(non_sse_stream_response)', async () => {
+    const upstream = await startFakeUpstream((_idx, _body, res) => {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ error: { type: 'gateway_hiccup', message: 'nope' } }));
+    });
+    upstreamClose = upstream.close;
+    proxy = await createAnthropicCompatProxy({ upstream: upstream.url });
+
+    const result = await post(proxy.url, { model: 'test-model', stream: true });
+    expect(result.status).toBe(502);
+    expect((JSON.parse(result.text) as { error: { code?: string } }).error.code)
+      .toBe('non_sse_stream_response');
+  });
+
+  it('零事件 SSE(只有注释/心跳)正常结束 → 502(sse_without_events)', async () => {
+    const upstream = await startFakeUpstream((_idx, _body, res) => {
+      res.writeHead(200, SSE_HEADERS);
+      res.write(': ping\n\n');
+      res.end(': bye\n\n');
+    });
+    upstreamClose = upstream.close;
+    proxy = await createAnthropicCompatProxy({ upstream: upstream.url });
+
+    const result = await post(proxy.url, { model: 'test-model', stream: true });
+    expect(result.status).toBe(502);
+    expect((JSON.parse(result.text) as { error: { code?: string } }).error.code)
+      .toBe('sse_without_events');
+  });
+
+  it('合法 SSE 原样透传,事件前的注释心跳不丢', async () => {
+    const upstream = await startFakeUpstream((_idx, _body, res) => {
+      res.writeHead(200, SSE_HEADERS);
+      res.write(': keepalive\n\n');
+      res.end(SSE_BODY);
+    });
+    upstreamClose = upstream.close;
+    proxy = await createAnthropicCompatProxy({ upstream: upstream.url });
+
+    const result = await post(proxy.url, { model: 'test-model', stream: true });
+    expect(result.status).toBe(200);
+    expect(result.text).toBe(`: keepalive\n\n${SSE_BODY}`);
+  });
+
+  it('压缩 SSE 不按明文扫行:首字节提交并透传', async () => {
+    const gz = gzipSync(Buffer.from(SSE_BODY, 'utf8'));
+    const upstream = await startFakeUpstream((_idx, _body, res) => {
+      res.writeHead(200, { ...SSE_HEADERS, 'content-encoding': 'gzip' });
+      res.end(gz);
+    });
+    upstreamClose = upstream.close;
+    proxy = await createAnthropicCompatProxy({ upstream: upstream.url });
+
+    const result = await post(proxy.url, { model: 'test-model', stream: true });
+    expect(result.status).toBe(200);
+    expect(result.text).toBe(SSE_BODY);
+  });
+
+  it('非流式请求不受门控:空 200 照旧字节透传(行为保持)', async () => {
+    const upstream = await startFakeUpstream((_idx, _body, res) => {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end();
+    });
+    upstreamClose = upstream.close;
+    proxy = await createAnthropicCompatProxy({ upstream: upstream.url });
+
+    const result = await post(proxy.url, { model: 'test-model' });
+    expect(result).toEqual({ status: 200, text: '' });
+  });
+
+  it('已提交后的截断保持连接失败语义,不补成正常结束', async () => {
+    const upstream = await startFakeUpstream((_idx, _body, res) => {
+      res.writeHead(200, SSE_HEADERS);
+      res.write('event: message_start\ndata: {"type":"message_start"}\n\n');
+      setTimeout(() => res.destroy(), 30);
+    });
+    upstreamClose = upstream.close;
+    proxy = await createAnthropicCompatProxy({ upstream: upstream.url });
+
+    await expect(post(proxy.url, { model: 'test-model', stream: true })).rejects.toThrow();
+  });
+});

--- a/packages/anthropic-compat-proxy/src/server.ts
+++ b/packages/anthropic-compat-proxy/src/server.ts
@@ -771,6 +771,10 @@ function forward(
   // 同底再铸」的自激循环(codex-connector review P1)。由 createAnthropicCompatProxy
   // 注入,forward 是模块级函数取不到闭包作用域。
   threadMintedIdCache?: Map<string, Set<string>> | null,
+  // 请求体显式声明 `"stream": true`(请求处理层解析一次后传入,不二次 parse)。
+  // 为 true 时启用 2xx 成功响应的流式有效性门(#2242):空 2xx / 非 SSE 2xx /
+  // 零事件 SSE 不再原样透传给客户端,转成结构化 502。false 保持字节级透传。
+  requestDeclaredStream = false,
 ): void {
   // 客户端已断开(典型:400 缓冲期间断开后走到透明重试)——'close' 已经发过,
   // 下面挂的中断传播 listener 永远不会触发,直接不发起上游请求。
@@ -864,7 +868,11 @@ function forward(
   // response 的终态处理,保证 observer 与下游收口语义不受事件先后影响。
   let failActiveResponse: ((err: unknown) => void) | null = null;
 
-  const finishClientAfterUpstreamFailure = (err: Error, message = `upstream stream error: ${String(err)}`): boolean => {
+  const finishClientAfterUpstreamFailure = (
+    err: Error,
+    message = `upstream stream error: ${String(err)}`,
+    code?: string,
+  ): boolean => {
     if (
       clientAborted ||
       proxyDestroyedClient ||
@@ -881,7 +889,7 @@ function forward(
     if (!clientRes.headersSent) {
       clientRes.writeHead(502, { 'content-type': 'application/json' });
       clientRes.end(JSON.stringify({
-        error: { type: 'proxy_error', message },
+        error: { type: 'proxy_error', ...(code ? { code } : {}), message },
       }));
     } else {
       // 已经把上游的部分响应发给客户端时,不能 end 一个看似完整的 SSE。
@@ -1021,6 +1029,7 @@ function forward(
             pathOverride,
             responseToolUseIds,
             threadMintedIdCache,
+            requestDeclaredStream,
           );
           return;
         }
@@ -1214,7 +1223,64 @@ function forward(
       toolUseIdRewrite.on('error', (err) => failStreamingResponse('error', err));
     }
 
-    clientRes.writeHead(status, upstreamRes.statusMessage, respHeaders);
+    // ── 流式请求的成功响应有效性门(#2242)──────────────────────────────
+    // 请求显式声明 stream:true 时,2xx 响应不再「先 writeHead 再 pipe」:上游或
+    // 网关产生的**正常结束的空 2xx / 非 SSE 2xx / 零事件 SSE** 会被客户端(Claude
+    // Code)当成 "empty or malformed response (HTTP 200)" 而无法分类重试。此时把
+    // writeHead 延迟到确认合法流才提交 —— 明文 SSE 扫到首个 event:/data: 行提交,
+    // 压缩 SSE 无法扫行、收到首字节即提交(空 2xx 仍被 end 分支拦);上游干净结束
+    // 仍未提交 → 结构化 502(proxy_error + code)。已提交后的截断继续走既有连接
+    // 失败语义(finishClientAfterUpstreamFailure → destroy),不补成正常结束。
+    // 只约束显式流式请求:非流式 JSON 响应照旧字节透传,零行为变化。
+    const gateStreamValidity = requestDeclaredStream && status >= 200 && status < 300;
+    // 合法 SSE 的首个事件必然远早于此(Anthropic 首行即 event: message_start);
+    // 上限只为封顶「持续输出无事件垃圾」时的内存与延迟。
+    const STREAM_GATE_PENDING_CAP_BYTES = 64 * 1024;
+    const SSE_EVENT_MARKER_RE = /(^|\r?\n)(event|data):/;
+    let streamGateCommitted = false;
+    const pendingChunks: Buffer[] = [];
+    let pendingBytes = 0;
+    let pendingText = '';
+    const commitStreamResponse = (): void => {
+      if (streamGateCommitted) return;
+      streamGateCommitted = true;
+      clientRes.writeHead(status, upstreamRes.statusMessage, respHeaders);
+      const dest = toolUseIdRewrite ?? clientRes;
+      // 门控期间积累的待发字节(非门控路径恒为空)先写出,再切回字节级 pipe ——
+      // pipe 是 SSE 零延迟的命脉('data' 监听只做计数+错误体收集,不影响流)。
+      for (const chunk of pendingChunks) dest.write(chunk);
+      pendingChunks.length = 0;
+      pendingText = '';
+      if (toolUseIdRewrite) {
+        // 客户端断开 / 上游故障收口时把 transform 一并拆掉,避免上游继续灌进无消费者的流。
+        const rewriteStream = toolUseIdRewrite;
+        clientRes.on('close', () => rewriteStream.destroy());
+        upstreamRes.pipe(rewriteStream);
+        rewriteStream.pipe(clientRes);
+      } else {
+        upstreamRes.pipe(clientRes);
+      }
+    };
+    if (!gateStreamValidity) commitStreamResponse();
+
+    /** 未提交状态下把无效流转成结构化 502(观察器按上游真实终态另行收口)。 */
+    const rejectInvalidStreamResponse = (code: string, detail: Record<string, unknown>): void => {
+      logger.warn?.('◀ invalid success response to a streaming request → 502', {
+        reqId,
+        method,
+        path: upstreamPathname,
+        status,
+        code,
+        contentType: upstreamRes.headers['content-type'],
+        contentEncoding: upstreamRes.headers['content-encoding'],
+        ...detail,
+      });
+      finishClientAfterUpstreamFailure(
+        new Error(`invalid streaming response (${code})`),
+        `upstream returned an invalid success response to a streaming request (${code})`,
+        code,
+      );
+    };
 
     // 收 body: 总字节始终累加;status >= 400 时额外收集前 ERROR_RESPONSE_DUMP_MAX_BYTES
     // 字节做 dump 用。2xx 路径只做计数, 无内存压力。
@@ -1234,11 +1300,67 @@ function forward(
         errBuf.push(chunk.length <= remain ? chunk : chunk.subarray(0, remain));
         errBufBytes += Math.min(chunk.length, remain);
       }
+      if (!streamGateCommitted) {
+        // 门控中(未提交):积累待发字节并判定是否可提交。
+        if (pendingBytes < STREAM_GATE_PENDING_CAP_BYTES) {
+          pendingChunks.push(chunk);
+          pendingBytes += chunk.length;
+        } else {
+          pendingBytes += chunk.length;
+        }
+        if (!isSse) {
+          // 非 SSE 2xx:留在门控里等 end 统一转 502(有界缓冲做 errorType 诊断);
+          // 超上限说明上游在持续输出非流式字节,立刻转 502 并切断上游。
+          if (pendingBytes > STREAM_GATE_PENDING_CAP_BYTES) {
+            upstreamResponseTerminal = 'error';
+            observerError(new Error('invalid streaming response (non_sse_stream_response)'));
+            rejectInvalidStreamResponse('non_sse_stream_response', { bytes: totalBytes });
+            upstreamReq.destroy(new Error('invalid streaming response (non_sse_stream_response)'));
+          }
+          return;
+        }
+        if (isCompressed) {
+          // 压缩 SSE 无法按明文扫事件行:首字节即提交(与改写器同款不解压原则);
+          // 空 2xx 仍由 end 分支拦截。
+          commitStreamResponse();
+          return;
+        }
+        // 事件标记均为 ASCII,UTF-8 多字节字符被 chunk 边界截断不影响判定。
+        pendingText += chunk.toString('utf8');
+        if (SSE_EVENT_MARKER_RE.test(pendingText)) {
+          commitStreamResponse();
+        } else if (pendingBytes > STREAM_GATE_PENDING_CAP_BYTES) {
+          upstreamResponseTerminal = 'error';
+          observerError(new Error('invalid streaming response (sse_without_events)'));
+          rejectInvalidStreamResponse('sse_without_events', { bytes: totalBytes });
+          upstreamReq.destroy(new Error('invalid streaming response (sse_without_events)'));
+        }
+      }
     });
     upstreamRes.on('end', () => {
       if (upstreamResponseTerminal !== null) return;
       upstreamResponseTerminal = 'end';
       if (clientAborted || clientRes.destroyed || upstreamFailureHandled) return;
+      if (!streamGateCommitted) {
+        // 上游对流式请求「正常结束」却始终没有产生合法流:空 2xx / 非 SSE 2xx /
+        // 零事件 SSE。观察器按上游真实终态收口(end),客户端收结构化 502。
+        observerEnd();
+        const detail: Record<string, unknown> = { bytes: totalBytes };
+        let code: string;
+        if (totalBytes === 0) {
+          code = 'empty_stream_response';
+        } else if (isSse) {
+          code = 'sse_without_events';
+        } else {
+          code = 'non_sse_stream_response';
+          const merged = Buffer.concat(pendingChunks);
+          const decoded = decodeBodyForLog(merged, String(upstreamRes.headers['content-encoding'] ?? ''));
+          const errorType = extractErrorType(decoded, String(upstreamRes.headers['content-type'] ?? ''));
+          if (errorType) detail.errorType = errorType;
+        }
+        rejectInvalidStreamResponse(code, detail);
+        return;
+      }
       // 4xx/5xx 用 warn 级别冒泡, 默认只记低风险摘要 (status / content-type / bytes / errorType),
       // 完整 body 只在 debug 级别下才进日志 —— 避免 release 把上游错误体里可能回显的请求字段
       // 静默落盘到用户磁盘。debug 关时 isDebugEnabled 提前返 false, 不付 dump 字符串构造开销。
@@ -1281,15 +1403,6 @@ function forward(
       failStreamingResponse('close');
     });
 
-    if (toolUseIdRewrite) {
-      // 客户端断开 / 上游故障收口时把 transform 一并拆掉,避免上游继续灌进无消费者的流。
-      const rewriteStream = toolUseIdRewrite;
-      clientRes.on('close', () => rewriteStream.destroy());
-      upstreamRes.pipe(toolUseIdRewrite);
-      toolUseIdRewrite.pipe(clientRes);
-    } else {
-      upstreamRes.pipe(clientRes);  // ← 字节级 pipe,SSE 零延迟的命脉('data' 只是计数+错误体收集, 不影响流)
-    }
   });
 
   upstreamReq.on('error', (err) => {
@@ -1654,6 +1767,10 @@ export async function createAnthropicCompatProxy(opts: ProxyOptions): Promise<Pr
         parsedForRewrite = undefined;
       }
     }
+    // 请求是否显式声明流式(#2242 有效性门的启用判据)。复用上方解析结果,
+    // 非 JSON / 未声明 → false,响应路径保持字节级透传不变。
+    const requestDeclaredStream =
+      isRecord(parsedForRewrite) && parsedForRewrite.stream === true;
     const requestedIds = collectToolUseIdsForResponseRewrite(parsedForRewrite);
     // 全新/刚归一化的 kimi 会话,请求体可能还没有任何铸造形态 id(历史缺席),
     // 但模型仍会铸 minted id —— 用请求体 model 判定 kimi,确保首 fresh id 也
@@ -1728,6 +1845,7 @@ export async function createAnthropicCompatProxy(opts: ProxyOptions): Promise<Pr
       route.pathOverride,
       responseToolUseIds,
       threadMintedIdCache,
+      requestDeclaredStream,
     );
   });
 


### PR DESCRIPTION
## 这次改了什么

### 摘要

fix 部分 #2242(维护者分析中的行动 3;行动 1 的 /compact 透传已由 #2280 覆盖)。长会话撞到网关损坏的空 HTTP 200 时,anthropic-compat-proxy 的普通托管路径把「正常结束的空 2xx / 非 SSE 2xx / 零事件 SSE」原样 pipe 给 Claude Code,客户端只能报无法分类重试的 "empty or malformed response (HTTP 200)"。

本 PR 在请求体显式声明 `stream: true` 时(复用请求层已有的一次 JSON 解析,不引入二次 parse),把 2xx 响应的 `writeHead` 延迟到确认合法流才提交:

- 明文 SSE:扫到首个 `event:`/`data:` 行才提交(事件前的注释心跳如 `: keepalive` 照常透传,字节级不变);
- 压缩 SSE:无法按明文扫行,首字节即提交(空 2xx 仍会在 end 时被拦下);
- 上游干净结束仍未提交合法流 → 结构化 502(`proxy_error` + `code`: `empty_stream_response` / `sse_without_events` / `non_sse_stream_response`;非 SSE 分支附有界的 errorType 诊断,不记响应正文);
- 持续输出但无事件字节超 64KB 上限 → 502 并主动切断上游(封顶内存与首字延迟);
- 已提交后的截断保持既有连接失败语义(destroy),不会被「补」成正常结束。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他:

### 范围

- 关联 Issue / 需求:#2242(部分修复,对应维护者分析的行动 3)
- 本 PR 包含:`packages/anthropic-compat-proxy/src/server.ts` 的流式成功响应有效性门 + `server.test.ts` 新增 7 条门控用例
- 明确不包含:#2242 的行动 1(/compact 指令透传,已由 #2280 修复)与行动 2(客户端侧重试语义);非流式请求与非 2xx 路径零变化
- 用户可见变化:流式请求收到损坏成功响应时,从模糊的 "empty or malformed response (HTTP 200)" 变为带明确 code 的 502 `proxy_error`,客户端可按 5xx 语义重试
- 是否存在 breaking change:无

### UI 变化

不涉及。

- 引用的设计规范:不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter @cindy/anthropic-compat-proxy test
结果:317/317 通过(含新增 7 条:空 2xx→502 empty_stream_response / 非 SSE 2xx→502 / 零事件 SSE→502 / 合法 SSE 含心跳前缀字节级透传 / gzip SSE 透传 / 非流式请求空 200 不受门控 / 提交后截断保持连接失败)

pnpm --filter @cindy/anthropic-compat-proxy run --if-present typecheck
结果:通过(0 错误)

根 pnpm test:unit
结果:除两项与本改动无关的已知失败外全部通过——desktop threads 池 SIGSEGV flake(本 PR 未触碰 desktop),以及 apps/mobile i18nCatalogParity 在净 origin/main 上同样失败(基线破损,已单独观察)
```

### 手工验证

不涉及(行为均由字节级断言的单测覆盖:fake upstream + 真实 HTTP 往返)。

### 未执行的验证

未在真实网关故障现场复现(该故障为偶发网关行为);门控逻辑以 fake upstream 精确构造的等价响应验证。

## 风险

### 风险分类

- [x] 协议兼容
- [ ] 无已知风险
- [ ] 其他:

### 影响与回滚

- 影响范围:仅 `stream: true` 请求的 2xx 响应路径。合法 SSE 流首事件前最多缓冲若干字节后原样冲刷,字节序列不变;压缩流首字节即提交。最坏情况(上游持续输出非事件内容)缓冲上限 64KB。
- 回滚 / 降级方式:revert 本 commit 即回到原样 pipe 行为,无状态、无数据迁移。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`,见 [DCO](../DCO))
- [ ] UI 改动已在「UI 变化」注明引用的设计规范章节(不涉及 UI 则跳过)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
