### PR TITLE
fix(desktop): IM 初始流式输出面创建失败时收口降级为纯文本

### DIFF
--- a/apps/desktop/src/main/im/shared/__tests__/turnRunnerSendOutcome.test.ts
+++ b/apps/desktop/src/main/im/shared/__tests__/turnRunnerSendOutcome.test.ts
@@ -2793,4 +2793,119 @@ describe('turnRunner send outcome policy (feishu adapter characterization)', () 
       expect(mocks.persistUserMessage).toHaveBeenCalled();
     });
   });
+
+describe('初始流式输出面创建失败的收口降级(#2164)', () => {
+  it('startStreamingText 拒绝 + 短文本:正文经 sendText 一次性送达,turn 正常完成', async () => {
+    mocks.feishuIm.startStreamingText.mockRejectedValue(new Error('card create denied'));
+    const h = setupSession(async () => ({ accepted: true }));
+    const onTurnComplete = vi.fn();
+    await runDefaultTurn(onTurnComplete);
+    h.emit({ type: 'text', data: { text: 'recovered answer', isFinal: true }, source: 'claude-code' });
+    await flushMicrotasks();
+    h.emit({ type: 'done', data: {}, source: 'claude-code' });
+    await waitForAssertion(() => {
+      expect(onTurnComplete).toHaveBeenCalledTimes(1);
+      expect(mocks.feishuIm.sendText).toHaveBeenCalledWith(
+        'ou_user',
+        'recovered answer',
+        expect.anything(),
+      );
+    });
+    const fallbackSends = mocks.feishuIm.sendText.mock.calls.filter(
+      (call) => call[1] === 'recovered answer',
+    );
+    expect(fallbackSends).toHaveLength(1);
+  });
+
+  it('拒绝后多个连续 text delta:不重复调用 startStreamingText,降级仍只发一次', async () => {
+    mocks.feishuIm.startStreamingText.mockRejectedValue(new Error('card create denied'));
+    const h = setupSession(async () => ({ accepted: true }));
+    const onTurnComplete = vi.fn();
+    await runDefaultTurn(onTurnComplete);
+    h.emit({ type: 'text', data: { text: 'part-1 ' }, source: 'claude-code' });
+    await flushMicrotasks();
+    h.emit({ type: 'text', data: { text: 'part-2 ' }, source: 'claude-code' });
+    await flushMicrotasks();
+    h.emit({ type: 'text', data: { text: 'part-3' }, source: 'claude-code' });
+    await flushMicrotasks();
+    h.emit({ type: 'done', data: {}, source: 'claude-code' });
+    await waitForAssertion(() => {
+      expect(onTurnComplete).toHaveBeenCalledTimes(1);
+      // onTurnComplete 在收口开头触发,降级发送在其后 —— 断言必须一起等。
+      expect(mocks.feishuIm.sendText).toHaveBeenCalledWith(
+        'ou_user',
+        'part-1 part-2 part-3',
+        expect.anything(),
+      );
+    });
+    // 失败标记抑制重试:密集 delta 不造成 API 风暴 / 孤儿卡。
+    expect(mocks.feishuIm.startStreamingText).toHaveBeenCalledTimes(1);
+    const fallbackSends = mocks.feishuIm.sendText.mock.calls.filter(
+      (call) => call[1] === 'part-1 part-2 part-3',
+    );
+    expect(fallbackSends).toHaveLength(1);
+  });
+
+  it('拒绝 + 降级发送也失败:completion / 收口仍各执行一次,不阻塞', async () => {
+    mocks.feishuIm.startStreamingText.mockRejectedValue(new Error('card create denied'));
+    mocks.feishuIm.sendText.mockRejectedValue(new Error('plain send down'));
+    const h = setupSession(async () => ({ accepted: true }));
+    const onTurnComplete = vi.fn();
+    await runDefaultTurn(onTurnComplete);
+    h.emit({ type: 'text', data: { text: 'never delivered', isFinal: true }, source: 'claude-code' });
+    await flushMicrotasks();
+    h.emit({ type: 'done', data: {}, source: 'claude-code' });
+    await waitForAssertion(() => {
+      expect(onTurnComplete).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('正常建卡成功:finalize 收口,不触发纯文本降级', async () => {
+    const streamingHandle = {
+      messageId: 'stream-ok',
+      append: vi.fn(),
+      replace: vi.fn(),
+      finalize: vi.fn(),
+      close: vi.fn(),
+    };
+    mocks.feishuIm.startStreamingText.mockResolvedValue(streamingHandle);
+    const h = setupSession(async () => ({ accepted: true }));
+    const onTurnComplete = vi.fn();
+    await runDefaultTurn(onTurnComplete);
+    h.emit({ type: 'text', data: { text: 'streamed fine', isFinal: true }, source: 'claude-code' });
+    await flushMicrotasks();
+    h.emit({ type: 'done', data: {}, source: 'claude-code' });
+    await waitForAssertion(() => {
+      expect(streamingHandle.finalize).toHaveBeenCalledTimes(1);
+    });
+    expect(mocks.feishuIm.sendText).not.toHaveBeenCalledWith(
+      'ou_user',
+      'streamed fine',
+      expect.anything(),
+    );
+  });
+
+  it('空正文 + 建卡失败:保留「本轮无文本输出」提示', async () => {
+    mocks.feishuIm.startStreamingText.mockRejectedValue(new Error('card create denied'));
+    const h = setupSession(async () => ({ accepted: true }));
+    const onTurnComplete = vi.fn();
+    await runDefaultTurn(onTurnComplete);
+    // 只有 tool_use 会惰性触发建卡,不产生正文。
+    h.emit({
+      type: 'tool_use',
+      data: { name: 'Bash', input: { command: 'ls' } },
+      source: 'claude-code',
+    });
+    await flushMicrotasks();
+    h.emit({ type: 'done', data: {}, source: 'claude-code' });
+    await waitForAssertion(() => {
+      expect(onTurnComplete).toHaveBeenCalledTimes(1);
+      expect(mocks.feishuIm.sendText).toHaveBeenCalledWith(
+        'ou_user',
+        expect.stringContaining('本轮无文本输出'),
+        expect.anything(),
+      );
+    });
+  });
+});
 });

--- a/apps/desktop/src/main/im/shared/turnRunner.ts
+++ b/apps/desktop/src/main/im/shared/turnRunner.ts
@@ -164,7 +164,13 @@ interface TurnState {
    * all callers await this same promise instead of each minting a new card.
    * Without it we get one card per delta — a flood of orphan cards.
    */
-  streamingHandlePromise: Promise<StreamingTextHandle> | null;
+  streamingHandlePromise: Promise<StreamingTextHandle | null> | null;
+  /**
+   * 初始流式输出面创建失败(#2164)。置位后本轮不再重试 startStreamingText
+   * (密集 delta 会造成 API 风暴 / 多张孤儿卡),已生成正文由 turn 收口一次性
+   * 降级为普通文本发送,不再静默丢失。
+   */
+  streamingStartFailed: boolean;
   /**
    * 呈现大脑(正文累积 / 过程区合成), 与官方 bot 共用 im/shared/turnPresenter。
    * buffer-replace 策略: 保留个人 IM 渠道现有行为 —— isFinal 用该条全文整体替换
@@ -673,6 +679,7 @@ export function createTurnRunner(
       initialMessageText: text,
       streamingHandle: null,
       streamingHandlePromise: null,
+      streamingStartFailed: false,
       presenter: createTurnPresenter({ mode: 'buffer-replace' }),
       mediaAbsPaths: [],
       workingDir: row.workingDir,
@@ -1861,7 +1868,7 @@ export function createTurnRunner(
     // 一下 ensureStreamingHandle 让 card 先建出来, 再投递。投递接口本身是
     // O(1) 同步 push, 不阻塞事件循环。
     void ensureStreamingHandle(turn).then((handle) => {
-      if (!handle.addExtraImageAbsPath) return; // patchedCardHandle 不实现这个能力
+      if (!handle?.addExtraImageAbsPath) return; // patchedCardHandle 不实现这个能力 / 创建失败(null)
       for (const url of urls) {
         try {
           const { absPath } = url.startsWith('cindy-media://')
@@ -1900,7 +1907,7 @@ export function createTurnRunner(
   function handleToolUseEvent(turn: TurnState, event: AgentEvent): void {
     if (!turn.presenter.applyToolUse(event)) return;
     ensureActivityTicker(turn);
-    void ensureStreamingHandle(turn).then((h) => h.replace(composeStreamingView(turn)));
+    void ensureStreamingHandle(turn).then((h) => h?.replace(composeStreamingView(turn)));
   }
 
   /**
@@ -1918,7 +1925,7 @@ export function createTurnRunner(
   function handleRetryNoticeEvent(turn: TurnState, event: AgentEvent): void {
     if (!turn.presenter.applyRetryNotice(event)) return;
     ensureActivityTicker(turn);
-    void ensureStreamingHandle(turn).then((h) => h.replace(composeStreamingView(turn)));
+    void ensureStreamingHandle(turn).then((h) => h?.replace(composeStreamingView(turn)));
   }
 
   function ensureActivityTicker(turn: TurnState): void {
@@ -2370,26 +2377,43 @@ export function createTurnRunner(
     // deltas, 这时卡片会一直停在 "灵感正在路上..." placeholder 直到 done; done 之间
     // 几秒延迟里用户看着像 stuck。replace 一次保证用户即时看到回复内容。
     if (!turn.presenter.applyText(event)) return;
-    void ensureStreamingHandle(turn).then((h) => h.replace(composeStreamingView(turn)));
+    void ensureStreamingHandle(turn).then((h) => h?.replace(composeStreamingView(turn)));
   }
 
-  function ensureStreamingHandle(turn: TurnState): Promise<StreamingTextHandle> {
+  function ensureStreamingHandle(turn: TurnState): Promise<StreamingTextHandle | null> {
     if (turn.streamingHandle) return Promise.resolve(turn.streamingHandle);
+    // 初始创建已失败:resolve null(#2164)。不复用 rejected promise 也不再重试 ——
+    // 密集 delta 下重试会造成 API 风暴 / 多张孤儿卡;正文由 turn 收口统一降级。
+    if (turn.streamingStartFailed) return Promise.resolve(null);
     if (turn.streamingHandlePromise) return turn.streamingHandlePromise;
     // Singleton: subsequent concurrent callers await the same promise rather
     // than each calling startStreamingText (which would mint a new card per
     // call and produce a flood of orphan messages).
+    // 创建失败集中在此捕获并 resolve null(#2164):调用点全部是 fire-and-forget
+    // 的 .then(...),各自补 rejection handler 必然遗漏;失败留下脱敏日志与
+    // streamingStartFailed 标记,已生成正文由收口分支一次性降级发送。
     turn.streamingHandlePromise = (async () => {
-      const handle =
-        output.kind === 'chunked-text'
-          ? chunkedTextHandle(turn)
-          : turn.outputCardMessageId
-            ? patchedCardHandle(turn.outputCardMessageId)
-            : await output.im.startStreamingText(turn.userId, undefined, {
-                threadTs: turn.scopeKey,
-              });
-      turn.streamingHandle = handle;
-      return handle;
+      try {
+        const handle =
+          output.kind === 'chunked-text'
+            ? chunkedTextHandle(turn)
+            : turn.outputCardMessageId
+              ? patchedCardHandle(turn.outputCardMessageId)
+              : await output.im.startStreamingText(turn.userId, undefined, {
+                  threadTs: turn.scopeKey,
+                });
+        turn.streamingHandle = handle;
+        return handle;
+      } catch (err) {
+        turn.streamingStartFailed = true;
+        // 只记渠道 / 阶段 / 错误摘要,不记 token、消息正文与完整用户标识。
+        log.warn(
+          `[${channel}/turn] initial streaming output start failed (phase=initial_stream_start): ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+        return null;
+      }
     })();
     return turn.streamingHandlePromise;
   }
@@ -2520,6 +2544,32 @@ export function createTurnRunner(
         }
       } catch {
         /* swallow */
+      }
+    } else {
+      // 初始流式输出面创建失败但正文已生成(#2164):此前两条分支都不命中,
+      // 已持久化的助手回复在渠道侧静默消失。收口时一次性降级为普通文本发送
+      // (turn.done 已置,composeStreamingView 只含干净正文;长度限制由渠道发送
+      // 实现兑现)。发送失败只记脱敏日志,不阻塞 settle / 队列放行。
+      try {
+        const fallbackText = composeStreamingView(turn);
+        if (output.kind === 'chunked-text') {
+          await output.commitFinal({
+            userId,
+            text: fallbackText,
+            terminal: turn.terminalKind,
+            threadTs: state.scopeKey,
+            ...(turn.mediaAbsPaths.length > 0 ? { mediaAbsPaths: turn.mediaAbsPaths } : {}),
+          });
+        } else {
+          await output.im.sendText(userId, fallbackText, { threadTs: state.scopeKey });
+        }
+        log.info(`[${channel}/turn] streaming surface unavailable — final text delivered via plain send`);
+      } catch (err) {
+        log.warn(
+          `[${channel}/turn] plain-text fallback send failed (non-fatal): ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
       }
     }
     settleTurnTerminal(turn);


### PR DESCRIPTION
## 这次改了什么

### 摘要

fix #2164。飞书等 rich-card IM 渠道的初始 `startStreamingText` 失败后,助手正文虽已生成并落库,但在渠道侧静默消失——`handleTurnDoneAsync` 只有「有 handle → finalize」与「正文为空 → 无输出提示」两条分支,正文非空且 handle 缺席时两条都不命中,用户什么都收不到。

按维护者分析的方案修复:

- `ensureStreamingHandle` 集中捕获创建失败(现有调用点全部是 fire-and-forget 的 `.then`,逐个补 rejection handler 必然遗漏):失败时置 `streamingStartFailed`、记脱敏日志(渠道/阶段/错误摘要,不含 token、正文与完整用户标识),promise resolve `null`;返回类型收敛为 `Promise<StreamingTextHandle | null>`,由 typecheck 强制所有调用点判空。
- `streamingStartFailed` 抑制本轮后续重试:密集 delta 不再造成对 IM API 的重试风暴或多张孤儿卡。
- 收口新增第三分支:正文非空且无输出面 → 一次性经渠道普通文本发送(`chunked-text` 渠道走 `commitFinal`,长度限制由渠道发送实现兑现);降级发送自身失败只记日志,不阻塞 settle 与队列放行。
- 错误收口路径不变(原本已发送错误消息,非静默);transpond 变体不变(其 finalize 已有失败日志)。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他:

### 范围

- 关联 Issue / 需求:#2164
- 本 PR 包含:`apps/desktop/src/main/im/shared/turnRunner.ts`(集中失败捕获 + 重试抑制 + 收口降级分支)与 `turnRunnerSendOutcome.test.ts` 新增 5 条回归
- 明确不包含:渠道各自 `startStreamingText` 内部的失败原因治理;transpond 流式变体
- 用户可见变化:此前静默丢失的回复,现在会以普通文本消息送达(仅失去流式卡片形态)
- 是否存在 breaking change:无

### UI 变化

不涉及(main 进程 IM 收口逻辑,无界面改动)。

- 引用的设计规范:不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/im/shared/__tests__/turnRunnerSendOutcome.test.ts --pool=forks
结果:72/72 通过(含新增 5 条:拒绝+短文本降级送达一次 / 拒绝+密集 delta 时 startStreamingText 只调一次且降级只发一次 / 降级发送也失败不阻塞收口 / 正常建卡不触发降级 / 空正文保留既有「本轮无文本输出」提示)

pnpm --filter desktop run --if-present typecheck
结果:通过(0 错误)

desktop 全量单测(--pool=forks 规避 threads 池已知 SIGSEGV flake)
结果:23201/23203 通过(2 skip),无失败

根 pnpm test:unit
结果:除 desktop threads 池 SIGSEGV flake 与 apps/mobile i18nCatalogParity(净 origin/main 上同样失败的基线破损)外全部通过
```

### 手工验证

不涉及(收口路径由回归测试全分支覆盖;真实飞书建卡失败依赖服务端故障注入,不可稳定手工复现)。

### 未执行的验证

未在真实飞书渠道注入建卡失败做端到端验证,原因如上;降级分支行为以 mock IM 渠道断言。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] 其他:

### 影响与回滚

- 影响范围:仅「初始流式输出面创建失败且正文非空」这一此前静默丢消息的路径;正常建卡路径行为与字节不变。
- 回滚 / 降级方式:revert 本 commit 即回到原有(静默丢失)行为,无状态、无数据迁移。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`,见 [DCO](../DCO))
- [ ] UI 改动已在「UI 变化」注明引用的设计规范章节(不涉及 UI 则跳过)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
