### PR TITLE
feat(desktop): releaseNotes CDN 请求加重试逻辑

### DIFF
--- a/apps/desktop/src/main/__tests__/releaseNotesService.test.ts
+++ b/apps/desktop/src/main/__tests__/releaseNotesService.test.ts
@@ -184,6 +184,122 @@ describe('releaseNotesService', () => {
     expect(requestMock).toHaveBeenCalledTimes(2);
   });
 
+  describe('重试逻辑', () => {
+    it('网络错误后重试成功', async () => {
+      vi.useFakeTimers();
+      const { fetchReleaseNotes } = await import('../releaseNotesService');
+
+      const req1 = new MockRequest();
+      const req2 = new MockRequest();
+      const resp2 = new MockResponse();
+      requestMock.mockReturnValueOnce(req1).mockReturnValueOnce(req2);
+
+      const promise = fetchReleaseNotes('0.2.1');
+      // 第一次：网络错误（retryable）
+      req1.emit('error', new Error('ECONNRESET'));
+
+      // 推进重试延迟 1s + 让微任务执行
+      await vi.advanceTimersByTimeAsync(1_000);
+      // 再多推进一帧确保 fetchCdnJsonOnce 的 Promise 链已执行到 requestMock()
+      await vi.advanceTimersByTimeAsync(0);
+
+      // 第二次：成功
+      req2.emit('response', resp2);
+      resp2.emit('data', Buffer.from(JSON.stringify({
+        version: '0.2.1',
+        date: '2026-08-10',
+        topics: [{ title: '重试成功', text: '第二次请求返回了数据。' }],
+      }), 'utf8'));
+      resp2.emit('end');
+
+      const notes = await promise;
+      expect(notes).not.toBeNull();
+      expect(notes?.version).toBe('0.2.1');
+      expect(requestMock).toHaveBeenCalledTimes(2);
+
+      vi.useRealTimers();
+    });
+
+    it('HTTP 404 不重试，直接返回 null', async () => {
+      const { fetchReleaseNotes } = await import('../releaseNotesService');
+
+      const req = new MockRequest();
+      const resp = new MockResponse();
+      resp.statusCode = 404;
+      requestMock.mockReturnValueOnce(req);
+
+      const promise = fetchReleaseNotes('0.2.2');
+      req.emit('response', resp);
+
+      const notes = await promise;
+      expect(notes).toBeNull();
+      expect(requestMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('全部重试耗尽后返回 null', async () => {
+      vi.useFakeTimers();
+      const { fetchReleaseNotes } = await import('../releaseNotesService');
+
+      // 4 次全部网络错误（首次 + 3 次重试 = 4 次）
+      const reqs = Array.from({ length: 4 }, () => new MockRequest());
+      reqs.forEach((r) => requestMock.mockReturnValueOnce(r));
+
+      const promise = fetchReleaseNotes('0.2.3');
+
+      for (let i = 0; i < 4; i++) {
+        reqs[i].emit('error', new Error('ETIMEDOUT'));
+        // 推进重试延迟（最后一次不需要，但无害）
+        if (i < 3) {
+          // 指数退避：1s, 2s, 4s
+          const delay = 1000 * 2 ** i;
+          await vi.advanceTimersByTimeAsync(delay);
+          await vi.advanceTimersByTimeAsync(0);
+        }
+      }
+
+      const notes = await promise;
+      expect(notes).toBeNull();
+      expect(requestMock).toHaveBeenCalledTimes(4);
+
+      vi.useRealTimers();
+    });
+
+    it('超时视为可重试，第二次成功', async () => {
+      vi.useFakeTimers();
+      const { fetchReleaseNotes } = await import('../releaseNotesService');
+
+      const req1 = new MockRequest();
+      const req2 = new MockRequest();
+      const resp2 = new MockResponse();
+      requestMock.mockReturnValueOnce(req1).mockReturnValueOnce(req2);
+
+      const promise = fetchReleaseNotes('0.2.4');
+
+      // 快进到 15s 超时
+      await vi.advanceTimersByTimeAsync(15_000);
+      // 推进重试延迟 1s
+      await vi.advanceTimersByTimeAsync(1_000);
+      await vi.advanceTimersByTimeAsync(0);
+
+      // 第二次成功
+      req2.emit('response', resp2);
+      resp2.emit('data', Buffer.from(JSON.stringify({
+        version: '0.2.4',
+        date: '2026-08-10',
+        topics: [{ title: '超时重试', text: '第二次成功。' }],
+      }), 'utf8'));
+      resp2.emit('end');
+
+      const notes = await promise;
+      expect(notes).not.toBeNull();
+      expect(notes?.version).toBe('0.2.4');
+      expect(requestMock).toHaveBeenCalledTimes(2);
+      expect(req1.abort).toHaveBeenCalled();
+
+      vi.useRealTimers();
+    });
+  });
+
   it('sections 非空但全部畸形(无任何有效 bullet)同样按失败处理不缓存', async () => {
     const { fetchReleaseNotes } = await import('../releaseNotesService');
 

--- a/apps/desktop/src/main/releaseNotesService.ts
+++ b/apps/desktop/src/main/releaseNotesService.ts
@@ -45,6 +45,8 @@ const log = createLogger('releaseNotesService');
 // ── Constants ──────────────────────────────────────────────────────────────
 
 const REQUEST_TIMEOUT_MS = 15_000;
+const MAX_RETRIES = 3;
+const RETRY_BASE_DELAY_MS = 1_000;
 
 // ── State ──────────────────────────────────────────────────────────────────
 
@@ -59,13 +61,21 @@ let indexCache: string[] | null = null;
 // ── Core ───────────────────────────────────────────────────────────────────
 
 /**
- * Fetch a JSON document from the CDN. Returns the parsed value on 200, null on
- * any failure (404 / network / parse / timeout). Silent — caller decides UX.
- * Extracted so both the per-version notice fetcher and the version-index
- * fetcher share the same net.request boilerplate + timeout handling.
+ * Result of a single CDN fetch attempt.
+ * - `ok` + `data`: HTTP 200 + valid JSON.
+ * - `null`: non-retryable failure (HTTP non-200, JSON parse error).
+ * - `retryable` error: network error / timeout — caller can retry.
  */
-function fetchCdnJson<T>(url: string): Promise<T | null> {
-  log.info('Fetching: %s', url);
+type FetchAttempt<T> =
+  | { ok: true; data: T }
+  | { ok: false; retryable: boolean };
+
+/**
+ * Single attempt at fetching a JSON document from the CDN.
+ * Resolves with structured result so the retry wrapper can decide whether to
+ * back off and retry or give up immediately.
+ */
+function fetchCdnJsonOnce<T>(url: string): Promise<FetchAttempt<T>> {
   return new Promise((resolve) => {
     try {
       const request = net.request(url);
@@ -78,7 +88,7 @@ function fetchCdnJson<T>(url: string): Promise<T | null> {
           settled = true;
           request.abort();
           log.info('Timeout: %s', url);
-          resolve(null);
+          resolve({ ok: false, retryable: true });
         }
       }, REQUEST_TIMEOUT_MS);
 
@@ -87,7 +97,7 @@ function fetchCdnJson<T>(url: string): Promise<T | null> {
           log.info('HTTP %d for %s', response.statusCode, url);
           clearTimeout(timeout);
           settled = true;
-          resolve(null);
+          resolve({ ok: false, retryable: false });
           return;
         }
 
@@ -100,10 +110,10 @@ function fetchCdnJson<T>(url: string): Promise<T | null> {
           settled = true;
           try {
             body += decoder.end();
-            resolve(JSON.parse(body) as T);
+            resolve({ ok: true, data: JSON.parse(body) as T });
           } catch (err) {
             log.error('JSON parse failed for %s:', url, err);
-            resolve(null);
+            resolve({ ok: false, retryable: false });
           }
         });
         response.on('error', (err) => {
@@ -111,7 +121,7 @@ function fetchCdnJson<T>(url: string): Promise<T | null> {
           clearTimeout(timeout);
           if (!settled) {
             settled = true;
-            resolve(null);
+            resolve({ ok: false, retryable: true });
           }
         });
       });
@@ -121,16 +131,43 @@ function fetchCdnJson<T>(url: string): Promise<T | null> {
         clearTimeout(timeout);
         if (!settled) {
           settled = true;
-          resolve(null);
+          resolve({ ok: false, retryable: true });
         }
       });
 
       request.end();
     } catch (err) {
       log.error('Unexpected error for %s:', url, err);
-      resolve(null);
+      resolve({ ok: false, retryable: true });
     }
   });
+}
+
+/**
+ * Fetch a JSON document from the CDN with retries for transient failures.
+ *
+ * Retryable (network error / timeout): up to MAX_RETRIES attempts with
+ * exponential backoff (1s → 2s → 4s). Non-retryable (HTTP non-200, JSON parse
+ * error): returns null immediately — no point re-fetching a definitive answer.
+ *
+ * Returns the parsed value on 200, null on any failure. Silent — caller decides
+ * UX.
+ */
+async function fetchCdnJson<T>(url: string): Promise<T | null> {
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    if (attempt > 0) {
+      const delayMs = RETRY_BASE_DELAY_MS * 2 ** (attempt - 1);
+      log.info('Retry %d/%d for %s in %dms', attempt, MAX_RETRIES, url, delayMs);
+      await new Promise((r) => setTimeout(r, delayMs));
+    }
+
+    const result = await fetchCdnJsonOnce<T>(url);
+    if (result.ok) return result.data;
+    if (!result.retryable) return null;
+  }
+
+  log.info('All retries exhausted for %s', url);
+  return null;
 }
 
 /**


### PR DESCRIPTION
## 这次改了什么

### 摘要

给  的 CDN 请求加自动重试：网络错误或超时时最多重试 3 次，指数退避 1s → 2s → 4s。HTTP 非 200（如 404）和 JSON 解析错误不重试（属于确定性失败，重试无意义）。

海外用户从国内 CDN 拉取公告容易因跨境网络抖动导致瞬时丢包/超时，目前一次失败即彻底放弃（auto 路径甚至是静默失败），加重试后大幅提升弱网环境下的成功率。

### 变更类型

- [x] `feat` 新功能

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：
  - `releaseNotesService.ts`：`fetchCdnJson` 拆为单次尝试 `fetchCdnJsonOnce` + 带重试的 `fetchCdnJson`
  - 4 条新增单测：网络错误重试成功、HTTP 404 不重试、全部重试耗尽、超时重试
- 明确不包含：renderer 侧改动（IPC 接口、缓存策略、UI 交互均不变）
- 用户可见变化：弱网环境下公告弹窗更不容易静默丢失
- 是否存在 breaking change：无

### UI 变化

不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/__tests__/releaseNotesService.test.ts
结果：10 tests passed（含 4 条新增重试测试）

pnpm --filter desktop run typecheck
结果：零错误

pnpm test:unit
结果：全部 PASS，无 FAIL
```

### 手工验证

不涉及（逻辑变更仅影响 main 进程 CDN 请求行为，IPC 接口与 renderer 交互不变）

### 未执行的验证

无

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围：仅 `releaseNotesService` 的 CDN 请求路径（公告/更新通知拉取）
- 回滚 / 降级方式：revert 此 commit 即可恢复无重试行为

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)