### PR TITLE
fix(desktop): utility 直连 Anthropic 时剥掉 SDK 专用的 [1m] 模型后缀

### DIFF
--- a/apps/desktop/src/main/utility-model/__tests__/oneShotCandidates.test.ts
+++ b/apps/desktop/src/main/utility-model/__tests__/oneShotCandidates.test.ts
@@ -80,7 +80,7 @@ import { readModelDisableOverrides } from '../../maker-host/model-disable-store.
 import { isProviderRouteMutationInProgress } from '../../maker-host/provider-route.js';
 import { readCustomProviderKey } from '../../secrets/providerSecretStore.js';
 import { getUtilityModelChainProfiles } from '../UtilityModelSelection.js';
-import { getUtilityTextCandidates, requestUtilityText } from '../oneShotCandidates.js';
+import { getUtilityTextCandidates, requestUtilityText, toAnthropicApiModelId } from '../oneShotCandidates.js';
 
 const getProfiles = vi.mocked(getUtilityModelChainProfiles);
 const readKey = vi.mocked(readClaudeApiKey);
@@ -1033,6 +1033,77 @@ describe('utility one-shot candidates', () => {
     expect(body.max_tokens).toBe(64_000);
   });
 
+  it('内置 Anthropic 直连:1M 目录模型的 body.model 用裸目录 id,不带 SDK 专用 [1m] 后缀(#2429)', async () => {
+    activeCatalog.mockReturnValue({
+      providers: [{
+        id: 'anthropic',
+        name: 'Anthropic',
+        source: 'builtin',
+        agents: ['claude-code'],
+        auth: { method: 'oauth' },
+        routing: {
+          'claude-code': { upstream: 'https://anthropic.example/api/v1', authStrategy: 'oauth-passthrough' },
+        },
+        models: {
+          'claude-code': [{ id: 'claude-fable-5', name: 'Fable', contextWindow: 1_000_000, maxOutput: 64_000 }],
+        },
+      }],
+    } as never);
+    readClaudeOAuth.mockResolvedValue({ accessToken: 'anthropic-token' });
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      text: async () => JSON.stringify({ content: [{ type: 'text', text: 'verdict' }] }),
+    } as never);
+
+    const result = await requestUtilityText(makerMock(false), 'review this', {
+      providerId: 'anthropic',
+      agentKind: 'claude-code',
+      model: 'claude-fable-5',
+    });
+
+    expect(result).toMatchObject({ ok: true, providerId: 'anthropic' });
+    const body = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body));
+    expect(body.model).toBe('claude-fable-5');
+  });
+
+  it('toAnthropicApiModelId:剥掉尾部 [1m],其余 id 原样返回(防御显示 id 泄入)', () => {
+    expect(toAnthropicApiModelId('claude-opus-5[1m]')).toBe('claude-opus-5');
+    expect(toAnthropicApiModelId('claude-fable-5')).toBe('claude-fable-5');
+    expect(toAnthropicApiModelId('claude-haiku-4-5-20251001')).toBe('claude-haiku-4-5-20251001');
+  });
+
+  it('内置 Anthropic 直连:非 1M 模型的 body.model 保持目录 id 不变(不回归)', async () => {
+    activeCatalog.mockReturnValue({
+      providers: [{
+        id: 'anthropic',
+        name: 'Anthropic',
+        source: 'builtin',
+        agents: ['claude-code'],
+        auth: { method: 'oauth' },
+        routing: {
+          'claude-code': { upstream: 'https://anthropic.example/api/v1', authStrategy: 'oauth-passthrough' },
+        },
+        models: {
+          'claude-code': [{ id: 'claude-haiku-4-5-20251001', name: 'Haiku', contextWindow: 200_000, maxOutput: 64_000 }],
+        },
+      }],
+    } as never);
+    readClaudeOAuth.mockResolvedValue({ accessToken: 'anthropic-token' });
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      text: async () => JSON.stringify({ content: [{ type: 'text', text: 'verdict' }] }),
+    } as never);
+
+    await requestUtilityText(makerMock(false), 'review this', {
+      providerId: 'anthropic',
+      agentKind: 'claude-code',
+      model: 'claude-haiku-4-5-20251001',
+    });
+
+    const body = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body));
+    expect(body.model).toBe('claude-haiku-4-5-20251001');
+  });
+
   it('缺省不传 maxTokens 时,xd wire 不发送输出上限(模型自然输出)', async () => {
     activeCatalog.mockReturnValue({
       providers: [{
@@ -1443,7 +1514,9 @@ describe('utility one-shot candidates', () => {
     expect(fetchMock).toHaveBeenCalledWith('https://anthropic.example/api/v1/messages', expect.anything());
     const init = fetchMock.mock.calls[0]?.[1] as { headers: Record<string, string>; body: string };
     expect(init.headers.Authorization).toBe('Bearer anthropic-token');
-    expect(JSON.parse(init.body).model).toBe('claude-sonnet-4-6[1m]');
+    // [1m] 是 Claude Code SDK 的 beta 通道后缀,直连 /v1/messages 会 404(#2429):
+    // 直连请求体必须用目录裸 id。
+    expect(JSON.parse(init.body).model).toBe('claude-sonnet-4-6');
   });
 
   it('uses OpenAI Codex OAuth and strips the bridge model prefix on the selected route', async () => {

--- a/apps/desktop/src/main/utility-model/oneShotCandidates.ts
+++ b/apps/desktop/src/main/utility-model/oneShotCandidates.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto';
 
-import { toSdkModelString, type AgentKind, type Maker } from '@cindy/maker-core';
+import { type AgentKind, type Maker } from '@cindy/maker-core';
 import { appendProviderRequestPath } from '@cindy/model-providers';
 
 import { createLogger } from '../logger.js';
@@ -624,7 +624,9 @@ async function requestBuiltinProviderText(
           'anthropic-version': '2023-06-01',
           'anthropic-beta': 'oauth-2025-04-20',
         },
-        model: toSdkModelString(input.model, findProviderModel(input.provider, input.agentKind, input.model)?.contextWindow),
+        // 直连 Anthropic API 用目录裸 id;不要复用 toSdkModelString——它会给 1M
+        // 目录模型追加 SDK 专用的 [1m] 后缀,/v1/messages 对该串返回 404(#2429)。
+        model: toAnthropicApiModelId(input.model),
         prompt: text,
         // Anthropic API 协议必填 max_tokens:缺省时以模型目录声明的 maxOutput
         // (模型自身输出能力)兜底,没有目录条目才回退 81920——宿主不设政策上限。
@@ -903,6 +905,19 @@ function appendProviderPath(baseUrl: string, suffix: string): string {
   // Fragments are client-side only and must not be sent as part of an API URL.
   url.hash = '';
   return url.toString();
+}
+
+/**
+ * catalog model id → 内置 Anthropic `/v1/messages` 直连请求体的 API model id。
+ *
+ * `[1m]` 是 Claude Code SDK 的 beta 通道后缀(由 toSdkModelString 按目录
+ * contextWindow 追加),不是 Anthropic API 模型名;直连 Messages API 时携带它
+ * 会被上游以 404 not_found 拒绝,进而让 Auto-review 持续 fail-closed(#2429)。
+ * 该转换仅用于内置 anthropic 直连分支——不对自定义供应商做全局字符串剥离,
+ * 部分兼容网关可能把 `[1m]` 作为自己的路由 id。
+ */
+export function toAnthropicApiModelId(model: string): string {
+  return model.endsWith('[1m]') ? model.slice(0, -'[1m]'.length) : model;
 }
 
 /** Claude providers may configure either the host root or an existing `/v1` base. */


### PR DESCRIPTION
## 这次改了什么

### 摘要

fix #2429。Auto-review 的 utility/one-shot 显式 Anthropic 直连分支把 `toSdkModelString` 产出的 Claude Code SDK wire 串(如 `claude-fable-5[1m]`)直接放进 `/v1/messages` 请求体。`[1m]` 是 SDK 的 beta 通道细节,不是 Anthropic API 模型名,上游对 1M 目录模型一律 404 `not_found`,Auto 模式按安全策略 fail-closed,用户只能看到 `[AUTO_REVIEW_UNAVAILABLE]`。

- 新增显式可测的 `toAnthropicApiModelId()`:目录 id 原样透传,仅剥尾部 `[1m]`;**只用于内置 anthropic 直连分支**,不对自定义供应商做全局字符串剥离(兼容网关可能把 `[1m]` 当自己的路由 id)。
- 直连请求体改用该转换;既有断言直连 body 含 `[1m]` 的用例按修复后的契约更新。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他:

### 范围

- 关联 Issue / 需求:#2429
- 本 PR 包含:`apps/desktop/src/main/utility-model/oneShotCandidates.ts` 新增转换函数并在 anthropic 直连分支使用 + 对应测试
- 明确不包含:自定义供应商与网关路径的模型 id 处理(维持原样);SDK 侧 wire 串生成
- 用户可见变化:选用 1M 目录模型时 Auto-review / 一次性 utility 调用不再恒 404 失败
- 是否存在 breaking change:无

### UI 变化

不涉及。

- 引用的设计规范:不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/utility-model/__tests__/oneShotCandidates.test.ts --pool=forks
结果:全部通过(新增回归:1M 模型 claude-fable-5 直连 body.model 不含 [1m] / 非 1M 模型 claude-haiku-4-5-20251001 不回归 / 转换函数三态单测)

pnpm --filter desktop run --if-present typecheck
结果:通过(0 错误)

desktop 全量单测(--pool=forks 规避 threads 池已知 SIGSEGV flake)
结果:约 2.44 万用例全部通过

根 pnpm test:unit
结果:通过(期间出现的失败均逐一隔离复跑核实为负载 flake,与本改动无关)
```

### 手工验证

不涉及(直连请求体由测试断言到字段级)。

### 未执行的验证

未对真实 Anthropic API 发起付费直连请求验证 404 消失;以 issue 内上游返回的 `not_found` 错误与 API 文档模型命名规则为依据。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] 其他:

### 影响与回滚

- 影响范围:仅内置 anthropic 显式直连分支的 utility/one-shot 请求体 `model` 字段;其余路径字节不变。
- 回滚 / 降级方式:revert 本 commit,回到直连 404 的原状,无状态、无数据迁移。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`,见 [DCO](../DCO))
- [ ] UI 改动已在「UI 变化」注明引用的设计规范章节(不涉及 UI 则跳过)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
