### PR TITLE
fix(desktop): 右栏 deferred 队列按会话保序多条,不再互相覆盖

### DIFF
--- a/apps/desktop/src/main/right-sidebar-window/__tests__/controller.test.ts
+++ b/apps/desktop/src/main/right-sidebar-window/__tests__/controller.test.ts
@@ -626,4 +626,86 @@ describe('setContext / routeCommand', () => {
     h.controller.markReady();
     expect(h.sends.at(-1)).toEqual({ channel: 'cmd-channel', payload: explicit });
   });
+
+  it('同会话多条不同 passive 命令保序全量下发,不再互相覆盖(#2409)', async () => {
+    const h = makeHarness({ detached: true });
+    h.controller.setContext(ctx);
+    const register = {
+      type: 'ensure-orca-workers-tab' as const,
+      sessionId: 's1',
+      focusWorkerSessionId: 'worker-s1',
+      focusTab: false,
+    };
+    const close = { type: 'close-orca-workers-tab' as const, sessionId: 's1' };
+    await expect(h.controller.routeCommand({ command: register, allowOpen: false })).resolves.toBe('queued');
+    await expect(h.controller.routeCommand({ command: close, allowOpen: false })).resolves.toBe('queued');
+
+    h.controller.open();
+    h.controller.markReady();
+    const delivered = h.sends.filter((entry) => entry.channel === 'cmd-channel').map((entry) => entry.payload);
+    expect(delivered).toEqual([register, close]);
+  });
+
+  it('切 attached 时同会话多条 deferred 命令按序转交主 renderer(#2409)', async () => {
+    const h = makeHarness({ detached: true });
+    h.controller.setContext(ctx);
+    const register = {
+      type: 'ensure-orca-workers-tab' as const,
+      sessionId: 's1',
+      focusWorkerSessionId: 'worker-s1',
+      focusTab: false,
+    };
+    const close = { type: 'close-orca-workers-tab' as const, sessionId: 's1' };
+    await h.controller.routeCommand({ command: register, allowOpen: false });
+    await h.controller.routeCommand({ command: close, allowOpen: false });
+
+    h.controller.setDetached(false);
+    const delivered = h.sends.filter((entry) => entry.channel === 'cmd-channel').map((entry) => entry.payload);
+    expect(delivered).toEqual([register, close]);
+    expect(h.sendTargets.slice(-2)).toEqual([
+      h.mainWin.webContents.id,
+      h.mainWin.webContents.id,
+    ]);
+  });
+
+  it('完全等价的重复 passive 帧只登记一次(#2409)', async () => {
+    const h = makeHarness({ detached: true });
+    h.controller.setContext(ctx);
+    const register = {
+      type: 'ensure-orca-workers-tab' as const,
+      sessionId: 's1',
+      focusWorkerSessionId: 'worker-s1',
+      focusTab: false,
+    };
+    await h.controller.routeCommand({ command: register, allowOpen: false });
+    await h.controller.routeCommand({ command: { ...register }, allowOpen: false });
+
+    h.controller.open();
+    h.controller.markReady();
+    expect(h.sends.filter((entry) => entry.channel === 'cmd-channel')).toHaveLength(1);
+  });
+
+  it('generic ensure 被合并后,显式 intent 与其他登记命令仍全量下发(#2409)', async () => {
+    const h = makeHarness({ detached: true });
+    h.controller.setContext(ctx);
+    const explicit = {
+      type: 'ensure-orca-workers-tab' as const,
+      sessionId: 's1',
+      focusWorkerSessionId: 'worker-s1',
+      focusTab: false,
+    };
+    const close = { type: 'close-orca-workers-tab' as const, sessionId: 's1' };
+    await h.controller.routeCommand({ command: explicit, allowOpen: false });
+    await h.controller.routeCommand({
+      command: { type: 'ensure-orca-workers-tab', sessionId: 's1', focusTab: false },
+      allowOpen: false,
+    });
+    await h.controller.routeCommand({ command: close, allowOpen: false });
+
+    h.controller.open();
+    h.controller.markReady();
+    const delivered = h.sends.filter((entry) => entry.channel === 'cmd-channel').map((entry) => entry.payload);
+    expect(delivered).toEqual([explicit, close]);
+  });
+
 });

--- a/apps/desktop/src/main/right-sidebar-window/__tests__/controller.test.ts
+++ b/apps/desktop/src/main/right-sidebar-window/__tests__/controller.test.ts
@@ -708,4 +708,74 @@ describe('setContext / routeCommand', () => {
     expect(delivered).toEqual([explicit, close]);
   });
 
+  it('close 之后的 generic ensure 不与屏障前的 ensure 合并,重开意图保留(#2511 review)', async () => {
+    const h = makeHarness({ detached: true });
+    h.controller.setContext(ctx);
+    const explicit = {
+      type: 'ensure-orca-workers-tab' as const,
+      sessionId: 's1',
+      focusWorkerSessionId: 'worker-s1',
+      focusTab: false,
+    };
+    const close = { type: 'close-orca-workers-tab' as const, sessionId: 's1' };
+    const reopen = { type: 'ensure-orca-workers-tab' as const, sessionId: 's1', focusTab: false };
+    await h.controller.routeCommand({ command: explicit, allowOpen: false });
+    await h.controller.routeCommand({ command: close, allowOpen: false });
+    await h.controller.routeCommand({ command: reopen, allowOpen: false });
+
+    h.controller.open();
+    h.controller.markReady();
+    const delivered = h.sends.filter((entry) => entry.channel === 'cmd-channel').map((entry) => entry.payload);
+    expect(delivered).toEqual([explicit, close, reopen]);
+  });
+
+  it('隔着 close 的等价 ensure 帧不做跨屏障合并(#2511 review)', async () => {
+    const h = makeHarness({ detached: true });
+    h.controller.setContext(ctx);
+    const ensure = { type: 'ensure-orca-workers-tab' as const, sessionId: 's1', focusTab: false };
+    const close = { type: 'close-orca-workers-tab' as const, sessionId: 's1' };
+    await h.controller.routeCommand({ command: ensure, allowOpen: false });
+    await h.controller.routeCommand({ command: close, allowOpen: false });
+    await h.controller.routeCommand({ command: { ...ensure }, allowOpen: false });
+
+    h.controller.open();
+    h.controller.markReady();
+    const delivered = h.sends.filter((entry) => entry.channel === 'cmd-channel').map((entry) => entry.payload);
+    expect(delivered).toEqual([ensure, close, ensure]);
+  });
+
+  it('同目标 open-turn-review 后帧取代前帧,不同 session 的并存(#2511 review)', async () => {
+    const h = makeHarness({ detached: true });
+    h.controller.setContext(ctx);
+    const stale = {
+      type: 'open-turn-review' as const,
+      sessionId: 'worker-a',
+      changeSetIds: ['cs-old'],
+      requestNonce: 1,
+      hostSessionId: 's1',
+    };
+    const fresh = {
+      type: 'open-turn-review' as const,
+      sessionId: 'worker-a',
+      changeSetIds: ['cs-new'],
+      requestNonce: 2,
+      hostSessionId: 's1',
+    };
+    const other = {
+      type: 'open-turn-review' as const,
+      sessionId: 'worker-b',
+      changeSetIds: ['cs-b'],
+      requestNonce: 3,
+      hostSessionId: 's1',
+    };
+    await h.controller.routeCommand({ command: stale, allowOpen: false });
+    await h.controller.routeCommand({ command: other, allowOpen: false });
+    await h.controller.routeCommand({ command: fresh, allowOpen: false });
+
+    h.controller.open();
+    h.controller.markReady();
+    const delivered = h.sends.filter((entry) => entry.channel === 'cmd-channel').map((entry) => entry.payload);
+    expect(delivered).toEqual([other, fresh]);
+  });
+
 });

--- a/apps/desktop/src/main/right-sidebar-window/controller.ts
+++ b/apps/desktop/src/main/right-sidebar-window/controller.ts
@@ -76,6 +76,19 @@ function commandHostSessionId(cmd: RsbWindowCommand): string {
   return cmd.type === 'open-turn-review' ? (cmd.hostSessionId ?? cmd.sessionId) : cmd.sessionId;
 }
 
+/**
+ * 队列里最近一条 close-orca-workers-tab **之后**的段。ensure 合并判定只能在
+ * 这个段里做:close 是语义屏障,[显式 ensure, close, generic ensure] 里最后的
+ * generic ensure 是「close 之后重新打开」的最新意图,匹配屏障前的历史 ensure
+ * 会让 flush 终态停在 close、丢掉重开。
+ */
+function segmentAfterLastOrcaClose(queue: readonly RsbWindowCommand[]): readonly RsbWindowCommand[] {
+  for (let i = queue.length - 1; i >= 0; i -= 1) {
+    if (queue[i].type === 'close-orca-workers-tab') return queue.slice(i + 1);
+  }
+  return queue;
+}
+
 export class RsbWindowController {
   private winRef: BrowserWindow | null = null;
   /** BrowserWindow.close() 到 closed 事件之间仍未 destroyed，不能继续当活 host。 */
@@ -301,25 +314,41 @@ export class RsbWindowController {
     const queue = this.deferredCommands.get(hostSessionId);
     // Orca 既有优先规则:队列里已有 ensure-orca intent(带定位与否都算)时,
     // 后到的**无定位** generic ensure 忽略 —— 它既是重复帧去重,也保护更具体
-    // 的旧 intent(focusWorkerSessionId / searchJump)不被稀释。
+    // 的旧 intent(focusWorkerSessionId / searchJump)不被稀释。判定止于最近的
+    // close 屏障(segmentAfterLastOrcaClose),不匹配屏障前的历史 ensure。
     if (
       command.type === 'ensure-orca-workers-tab' &&
       command.focusWorkerSessionId === undefined &&
       command.searchJump === undefined &&
-      queue?.some((queued) => queued.type === 'ensure-orca-workers-tab')
+      queue &&
+      segmentAfterLastOrcaClose(queue).some(
+        (queued) => queued.type === 'ensure-orca-workers-tab',
+      )
     ) {
       return;
     }
-    // 完全等价的重复登记合并(幂等帧,如同一挂载路径的重复静默登记)。
+    // 完全等价的重复登记只做**相邻**合并(幂等帧,如同一挂载路径的重复静默
+    // 登记必然连续到达)。隔着其他命令的等价帧不合并 —— 中间命令(如 close)
+    // 可能已改变重放语义。
     const serialized = JSON.stringify(command);
-    if (queue?.some((queued) => JSON.stringify(queued) === serialized)) {
+    if (queue && queue.length > 0 && JSON.stringify(queue[queue.length - 1]) === serialized) {
       return;
     }
     if (!queue && this.deferredCommands.size >= MAX_DEFERRED_SESSIONS) {
       const oldest = this.deferredCommands.keys().next().value as string | undefined;
       if (oldest) this.deferredCommands.delete(oldest);
     }
-    const next = queue ?? [];
+    let next = queue ?? [];
+    // open-turn-review 是同目标 last-write-wins 的载荷帧(同 session 的 review
+    // tab 是单例):同目标旧帧被新帧**取代**而不是并存 —— flush 后 renderer 对
+    // 命令是并发处理的,两帧同时在途时完成顺序不保证,旧载荷可能覆盖新载荷;
+    // 队列里同目标只留最新一帧,竞态源头即消失。
+    if (command.type === 'open-turn-review') {
+      next = next.filter(
+        (queued) =>
+          !(queued.type === 'open-turn-review' && queued.sessionId === command.sessionId),
+      );
+    }
     if (next.length >= MAX_DEFERRED_COMMANDS_PER_SESSION) {
       const dropped = next.shift();
       this.deps.log.warn(

--- a/apps/desktop/src/main/right-sidebar-window/controller.ts
+++ b/apps/desktop/src/main/right-sidebar-window/controller.ts
@@ -60,6 +60,12 @@ export interface RsbWindowControllerDeps {
 /** ensureOpenForAutomation 等 renderer ready 握手的超时。 */
 const READY_TIMEOUT_MS = 8000;
 const MAX_DEFERRED_SESSIONS = 8;
+/**
+ * 单会话 deferred 队列上限。正常路径远达不到(passive 命令种类有限且有合并
+ * 规则);达到时丢最旧一条并记 warn —— 不能静默,登记类命令被丢意味着这次
+ * 登记在窗口打开前不再有落点(#2409 的溢出策略要求)。
+ */
+const MAX_DEFERRED_COMMANDS_PER_SESSION = 32;
 
 /**
  * command 的宿主桶 session —— 裁决可见性与 deferred 排队都以它为准。
@@ -82,8 +88,17 @@ export class RsbWindowController {
     timeout: NodeJS.Timeout;
   }> = [];
   private lastContext: RsbWindowContext | null = null;
-  /** allowOpen=false 时每个 session 只保留最终有效命令，避免 remote memory intent 丢失。 */
-  private deferredCommands = new Map<string, RsbWindowCommand>();
+  /**
+   * allowOpen=false 时按宿主 session 保序排队的 deferred 命令。
+   *
+   * 每会话保留**一组有序 intent** 而不是一条(#2409):此前同会话后到的
+   * passive 命令直接覆盖先到的,登记类命令(如历史挂载的 subagent 页签静默
+   * 登记)会被随后的 Orca ensure/close intent 顶掉,窗口再打开时这次登记
+   * 没有落点——renderer 侧按设计只在 attached 结果下写本地 store,队列是
+   * queued 命令唯一的交付路径。语义不同的命令保序全量下发;完全等价的重复
+   * 帧与「generic ensure 不得顶掉更具体的 Orca intent」在 enqueue 时合并。
+   */
+  private deferredCommands = new Map<string, RsbWindowCommand[]>();
   private closeWaiters: Array<() => void> = [];
 
   constructor(private readonly deps: RsbWindowControllerDeps) {}
@@ -283,23 +298,64 @@ export class RsbWindowController {
     // 按宿主桶排队:跨会话 open-turn-review 属于 lead 的桶,须由 lead 上下文
     // flush;按 worker sessionId 入队会在 context 保持 lead 时永远刷不出来。
     const hostSessionId = commandHostSessionId(command);
-    const previous = this.deferredCommands.get(hostSessionId);
+    const queue = this.deferredCommands.get(hostSessionId);
+    // Orca 既有优先规则:队列里已有 ensure-orca intent(带定位与否都算)时,
+    // 后到的**无定位** generic ensure 忽略 —— 它既是重复帧去重,也保护更具体
+    // 的旧 intent(focusWorkerSessionId / searchJump)不被稀释。
     if (
       command.type === 'ensure-orca-workers-tab' &&
-      previous?.type === 'ensure-orca-workers-tab' &&
       command.focusWorkerSessionId === undefined &&
-      command.searchJump === undefined
+      command.searchJump === undefined &&
+      queue?.some((queued) => queued.type === 'ensure-orca-workers-tab')
     ) {
       return;
     }
-    if (
-      !this.deferredCommands.has(hostSessionId) &&
-      this.deferredCommands.size >= MAX_DEFERRED_SESSIONS
-    ) {
+    // 完全等价的重复登记合并(幂等帧,如同一挂载路径的重复静默登记)。
+    const serialized = JSON.stringify(command);
+    if (queue?.some((queued) => JSON.stringify(queued) === serialized)) {
+      return;
+    }
+    if (!queue && this.deferredCommands.size >= MAX_DEFERRED_SESSIONS) {
       const oldest = this.deferredCommands.keys().next().value as string | undefined;
       if (oldest) this.deferredCommands.delete(oldest);
     }
-    this.deferredCommands.set(hostSessionId, command);
+    const next = queue ?? [];
+    if (next.length >= MAX_DEFERRED_COMMANDS_PER_SESSION) {
+      const dropped = next.shift();
+      this.deps.log.warn(
+        `right-sidebar deferred queue overflow, dropping oldest command type=${dropped?.type ?? 'unknown'}`,
+      );
+    }
+    next.push(command);
+    this.deferredCommands.set(hostSessionId, next);
+  }
+
+  /**
+   * 按入队顺序全量下发当前 context 会话的 deferred 队列。`isHostAlive` 逐条
+   * 复查目标存活:批量下发中途窗口可能被销毁,剩余命令放回队列头等待下一个
+   * host ready,不发往死窗口也不静默丢弃。
+   */
+  private flushDeferredCommands(
+    isHostAlive: () => boolean,
+    send: (command: RsbWindowCommand) => void,
+  ): void {
+    const sessionId = this.lastContext?.available ? this.lastContext.sessionId : null;
+    if (!sessionId) return;
+    const queue = this.deferredCommands.get(sessionId);
+    if (!queue || queue.length === 0) return;
+    this.deferredCommands.delete(sessionId);
+    for (let i = 0; i < queue.length; i += 1) {
+      if (!isHostAlive()) {
+        const remainder = queue.slice(i);
+        const requeued = this.deferredCommands.get(sessionId);
+        this.deferredCommands.set(
+          sessionId,
+          requeued ? [...remainder, ...requeued] : remainder,
+        );
+        return;
+      }
+      send(queue[i]);
+    }
   }
 
   private flushDeferredCommandsToDetachedHost(): void {
@@ -312,24 +368,20 @@ export class RsbWindowController {
     ) {
       return;
     }
-    const sessionId = this.lastContext?.available ? this.lastContext.sessionId : null;
-    if (!sessionId) return;
-    const command = this.deferredCommands.get(sessionId);
-    if (!command) return;
-    this.deferredCommands.delete(sessionId);
-    this.deps.sendToWindow(this.winRef, this.deps.commandChannel, command);
+    this.flushDeferredCommands(
+      () => Boolean(this.winRef && !this.winRef.isDestroyed() && !this.closing),
+      (command) => this.deps.sendToWindow(this.winRef!, this.deps.commandChannel, command),
+    );
   }
 
   private flushDeferredCommandsToAttachedHost(): void {
     if (this.deps.settings.read().detached) return;
-    const sessionId = this.lastContext?.available ? this.lastContext.sessionId : null;
-    if (!sessionId) return;
-    const command = this.deferredCommands.get(sessionId);
-    if (!command) return;
     const main = this.deps.getMainWindow();
     if (!main || main.isDestroyed()) return;
-    this.deferredCommands.delete(sessionId);
-    this.deps.sendToWindow(main, this.deps.commandChannel, command);
+    this.flushDeferredCommands(
+      () => !main.isDestroyed(),
+      (command) => this.deps.sendToWindow(main, this.deps.commandChannel, command),
+    );
   }
 
   private waitUntilClosed(): Promise<void> {


### PR DESCRIPTION
## 这次改了什么

### 摘要

fix #2409。detached 右栏窗口关闭/未 ready 时,`deferredCommands` 每会话只存一条命令,后到的 passive 命令直接 set 覆盖先到的——历史挂载路径的 subagent 页签静默登记会被随后的 Orca ensure/close intent 顶掉;renderer 按设计只在 attached 结果下写本地 store,队列被覆盖等于这次登记没有落点,窗口再打开时页签入口缺失。

- 存储改为 `Map<hostSessionId, RsbWindowCommand[]>`:语义不同的命令保序全量下发,detached 与 attached 两条 flush 路径共用同一实现。
- enqueue 合并规则:完全等价的重复帧只登记一次;保留既有 Orca 优先规则(队列已有 ensure-orca intent 时,后到的无定位 generic ensure 忽略,保护更具体的旧 intent)并先固化为测试。
- 每会话条数上限 32,溢出丢最旧并记 warn(不静默);跨会话 `MAX_DEFERRED_SESSIONS` 淘汰行为不变。
- flush 中途 host 销毁时,剩余命令放回队列头等下一个 host ready,不发往死窗口也不丢弃。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他:

### 范围

- 关联 Issue / 需求:#2409
- 本 PR 包含:`apps/desktop/src/main/right-sidebar-window/controller.ts` 队列结构与 flush 语义 + `controller.test.ts` 新增 4 条回归
- 明确不包含:renderer 侧 store 写入时机;右栏窗口 UI
- 用户可见变化:右栏关闭期间发生的多个登记(如 subagent 页签 + Orca 面板)在窗口重开后全部生效,不再互相顶掉
- 是否存在 breaking change:无

### UI 变化

不涉及(main 进程队列逻辑,无界面改动)。

- 引用的设计规范:不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/right-sidebar-window/__tests__/controller.test.ts --pool=forks
结果:全部通过(既有 38 条控制器用例不变;新增 4 条:同会话登记+close 保序全量下发 / 切 attached 全量转交主 renderer / 等价重复帧合并 / generic ensure 合并后显式 intent 与其他命令仍全量下发)

pnpm --filter desktop run --if-present typecheck
结果:通过(0 错误)

desktop 全量单测(--pool=forks 规避 threads 池已知 SIGSEGV flake)
结果:约 2.44 万用例全部通过

根 pnpm test:unit
结果:通过(期间出现的失败均逐一隔离复跑核实为负载 flake,与本改动无关)
```

### 手工验证

不涉及(队列行为由控制器测试全路径覆盖)。

### 未执行的验证

无。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] 其他:

### 影响与回滚

- 影响范围:仅右栏窗口 deferred 命令队列;单条命令场景行为与原实现一致,多条场景从「覆盖」变为「保序下发」。上限 32 条/会话防无界增长。
- 回滚 / 降级方式:revert 本 commit 回到单条覆盖行为,无状态、无数据迁移。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`,见 [DCO](../DCO))
- [ ] UI 改动已在「UI 变化」注明引用的设计规范章节(不涉及 UI 则跳过)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
