### PR TITLE
fix(desktop): empty-response 纳入中断自动续跑的有界恢复

### DIFF
--- a/apps/desktop/src/main/maker-ipc/__tests__/interruptedTurnAutoResume.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/interruptedTurnAutoResume.test.ts
@@ -66,8 +66,22 @@ describe('isInterruptedTurnError', () => {
     ).toBe(true);
   });
 
+  it('accepts the classified empty-response reason (#2320)', () => {
+    // translator 只在「发起过 API 调用、零文本、零工具、零 usage 增量」的严格
+    // 形态下盖这个 key —— 上游/网关返回退化空响应,与流被切断同属连接层故障,
+    // 由既有连续失败上限与人工介入周期硬上限止损。
+    expect(
+      isInterruptedTurnError({
+        reason: 'empty-response',
+        message: 'The model returned an empty response.',
+      }),
+    ).toBe(true);
+    // reason 是权威判据:不要求 sdkError tag,也不要求文案形态。
+    expect(isInterruptedTurnError({ reason: 'empty-response' })).toBe(true);
+  });
+
   it('rejects errors that carry a stable reason (已分类,另有处置路径)', () => {
-    for (const reason of ['empty-response', 'turn-failed', 'silent-stop-exhausted']) {
+    for (const reason of ['turn-failed', 'silent-stop-exhausted']) {
       expect(
         isInterruptedTurnError({
           sdkError: 'server_error',

--- a/apps/desktop/src/main/maker-ipc/interruptedTurnAutoResume.ts
+++ b/apps/desktop/src/main/maker-ipc/interruptedTurnAutoResume.ts
@@ -78,9 +78,9 @@ function isStreamTruncationError(signals: InterruptedTurnErrorSignals): boolean 
  * ——黑名单漏一条就会对认证失效、协议错这类确定性失败反复重试、反复烧额度，而
  * 白名单漏一条只是少一次自愈。风险不对称，所以这里只认识别得了的形态。
  *
- * 先过 reason 门（带稳定 reason 的都是 translator 已归类的错误：`empty-response`
- * 零产出无可续、`turn-failed` 连错误详情都没有、`silent-stop-exhausted` 是另一套
- * 自愈的耗尽信号），然后认三类：
+ * 先过 reason 门（带稳定 reason 的都是 translator 已归类的错误：`turn-failed`
+ * 连错误详情都没有、`silent-stop-exhausted` 是另一套自愈的耗尽信号），然后认
+ * 三类：
  *
  *  1. **SSE 流被切断**（`isStreamTruncationError`）——最初的实测形态。
  *  2. **网络到不了上游**（`isNetworkishErrorMessage`：502/503/504、errno、
@@ -105,7 +105,22 @@ export function isInterruptedTurnError(signals: InterruptedTurnErrorSignals): bo
   const reason = typeof signals.reason === 'string' ? signals.reason : '';
   // 例外先行：`upstream-overload` 是**已归类为可重试**的 reason，它本身就是比文案更可靠的
   // 权威判据（结构化优先于文案，与 overload-error.ts 的论证同源），直接放行、不再看文案。
-  if (reason === UPSTREAM_OVERLOAD_REASON || reason === 'codex_reconnect_stalled') return true;
+  //
+  // `empty-response` 同理放行（#2320）：translator 的判据已经足够严格——本轮确实发起过
+  // API 调用（apiCalls > 0）、无可见文本、无 result 兜底文本、无工具调用、无 compact
+  // boundary、单轮 usage 增量全为 0——这是上游/网关返回退化空响应的形态，与「流被切断」
+  // 同属连接层故障，续跑一次通常就能过去。此前按「零产出无可续」排除，但 coordinator 的
+  // auto 路径对零产出 turn 本就走**克隆重发原文**（active-turn recovery 已落库，重发安全；
+  // 见 performRetryLastError），对已有 durable progress 的长任务则带 RecoveryCheckpoint
+  // 续跑——两种形态都有安全动作可执行。连续空响应仍由同一份连续失败上限 / 人工介入周期
+  // 硬上限 / 退避止损，预算耗尽后横幅交还用户，不会无界重试。
+  if (
+    reason === UPSTREAM_OVERLOAD_REASON ||
+    reason === 'codex_reconnect_stalled' ||
+    reason === 'empty-response'
+  ) {
+    return true;
+  }
   if (reason.length > 0) return false;
   if (isStreamTruncationError(signals)) return true;
   const message = signals.message;


### PR DESCRIPTION
## 这次改了什么

### 摘要

fix #2320。长会话/大上下文下模型返回退化空响应(无文本、无工具调用、usage=0)时,translator 已把它严格识别为 `reason: 'empty-response'` 的终态错误,但 Desktop 自动续跑分类器 `isInterruptedTurnError` 的 reason 门把它明确排除——连续空轮在恢复介入后仍停在原地等人工接手,用户只能反复手动发「继续」。

把严格命中的 `empty-response` 与 `upstream-overload` / `codex_reconnect_stalled` 同列为已归类可重试 reason 放行:

- 判据完全复用 translator 既有的完整条件(本轮发起过 API 调用、无可见文本、无 result 兜底文本、无工具调用、无 compact boundary、单轮 usage 增量全为 0),不看文案、不看 UI 显示的 0 tokens。
- 接管后复用既有恢复状态机:零产出 turn 走克隆重发原文(active-turn recovery 已落库,重发安全);已有 durable progress 的长任务带 RecoveryCheckpoint 续跑,不重放已完成工作。
- 止损不变:连续 5 次失败上限、单次人工介入周期 10 次硬上限、指数退避 + jitter、kill switch;预算耗尽后横幅交还用户,不静默结束。

原「零产出无可续」的排除理由已过时:coordinator 的 auto 路径对零产出 turn 本就实现了安全的克隆重发(`performRetryLastError`)。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他:

### 范围

- 关联 Issue / 需求:#2320
- 本 PR 包含:`apps/desktop/src/main/maker-ipc/interruptedTurnAutoResume.ts` reason 门放行 empty-response + 对应测试
- 明确不包含:translator 的 empty-response 判定本身(未动);恢复状态机与止损参数(未动)
- 用户可见变化:连续空响应轮会被有界自动恢复接管重试,不再停在原地等人工「继续」
- 是否存在 breaking change:无

### UI 变化

不涉及。

- 引用的设计规范:不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/maker-ipc/__tests__/interruptedTurnAutoResume.test.ts --pool=forks
结果:全部通过(新增 empty-response 放行用例:带文案 / 仅 reason 两态;turn-failed 与 silent-stop-exhausted 维持拒绝)

pnpm --filter desktop run --if-present typecheck
结果:通过(0 错误)

desktop 全量单测(--pool=forks 规避 threads 池已知 SIGSEGV flake)
结果:约 2.44 万用例全部通过

根 pnpm test:unit
结果:通过(期间出现的失败均逐一隔离复跑核实为负载 flake,与本改动无关)
```

### 手工验证

不涉及(空响应为偶发上游退化行为,无法稳定手工复现;分类器行为由测试断言)。

### 未执行的验证

未在真实空响应现场端到端验证,原因如上;恢复路径复用既有已验证状态机,本 PR 只放宽入口分类。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] 其他:

### 影响与回滚

- 影响范围:仅自动续跑分类器对 empty-response 终态的处置(从「不接管」变为「有界接管」);全部既有止损上限、退避与 kill switch 原样生效,最坏情况回到与现状等价的人工接手。
- 回滚 / 降级方式:revert 本 commit 回到不接管行为;运行期也可用既有 kill switch 直接停用自动续跑。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`,见 [DCO](../DCO))
- [ ] UI 改动已在「UI 变化」注明引用的设计规范章节(不涉及 UI 则跳过)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
