### PR TITLE
feat(mobile): 登录后自动上报用户 ID 至 THEMIS 安全 SDK

### DIFF
--- a/apps/mobile/src/auth/AuthContext.tsx
+++ b/apps/mobile/src/auth/AuthContext.tsx
@@ -828,6 +828,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       }
     } else {
       void clearTapdbUser();
+      // 登出时清除 THEMIS 用户绑定,避免崩溃/强杀上报误归于上一个账号。
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-member-access
+        requireNativeModule('XdtThemis').addCustomField('playerinfo', '');
+      } catch {
+        // xdt-themis is build-time injected; absent in dev / unconfigured regions.
+      }
     }
   }, [initialized, user?.id]);
 

--- a/apps/mobile/src/auth/AuthContext.tsx
+++ b/apps/mobile/src/auth/AuthContext.tsx
@@ -1,4 +1,5 @@
 import * as WebBrowser from 'expo-web-browser';
+import { requireNativeModule } from 'expo-modules-core';
 import {
   createContext,
   useCallback,
@@ -814,8 +815,20 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   // 账号标识 —— initialized 变 true 时迁移必然已经落盘。
   useEffect(() => {
     if (!initialized) return;
-    if (user?.id) void setTapdbUser(user.id);
-    else void clearTapdbUser();
+    if (user?.id) {
+      void setTapdbUser(user.id);
+      // THEMIS 安全 SDK 上报绑定用户 ID(构建期注入原生模块,缺模块时静默降级)。
+      // 用 requireNativeModule 而非 require('xdt-themis'):前者是 expo-modules-core
+      // 的运行时查找(不受 Metro 静态解析影响),模块缺失时抛出可捕获的错误。
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-member-access
+        requireNativeModule('XdtThemis').addCustomField('playerinfo', String(user.id));
+      } catch {
+        // xdt-themis is build-time injected; absent in dev / unconfigured regions.
+      }
+    } else {
+      void clearTapdbUser();
+    }
   }, [initialized, user?.id]);
 
   // 词典缓存的落盘键按账号分区。登出清理是尽力而为的(索引可能读不出来),分区让


### PR DESCRIPTION
## 改动

在 AuthContext 的 user.id 变更 effect 中，通过 `expo-modules-core` 的 `requireNativeModule` 调用 `addCustomField("playerinfo", userId)`，将登录用户 ID 绑定到 THEMIS 安全 SDK 的上报中。登出时清除 binding 避免误归。

该模块为构建期注入（只存在于 cindy-build-scripts），缺模块时 try-catch 静默降级，dev / 未配置 region 的构建不受影响。

## 为什么这样写

- `requireNativeModule` 而非 `require("xdt-themis")`：前者走 expo-modules-core 的运行时原生模块查找，不受 Metro 静态依赖解析影响，模块缺失时抛出可捕获的错误。
- 与 `setTapdbUser` 同位置、同守卫条件（`initialized && user?.id`）——覆盖登录成功、token 刷新恢复会话、冷启动恢复登录态。

## 验证

- `pnpm --filter mobile run typecheck` — 通过
- `pnpm test:unit` — mobile/auth 相关测试通过（desktop 有预存 SIGSEGV 不相关）
- iOS 冷更已验证 subscriber 全链路生效（崩溃后 THEMIS 后台有日志）

## 风险

低。单文件一行调用，try-catch 保护；模块不存在时静默降级。不涉及 UI。

## UI 变化

引用的设计规范：不涉及——纯后台数据绑定（app 无视觉/交互/文案变化）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)