### PR TITLE
test(desktop): deferred Codex restart × 输入队列 drain 的跨模块回归与阻塞诊断

### DIFF
--- a/apps/desktop/src/main/maker-ipc/__tests__/deferredRestartQueueDrain.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/deferredRestartQueueDrain.test.ts
@@ -26,10 +26,16 @@ import type {
   AgentInputSendResult,
 } from '../agent-input-coordinator.js';
 import { DeferredCodexRestartService } from '../deferredCodexRestart.js';
+import {
+  createDeferredRestartAppliedWake,
+  createDeferredRestartQueueGate,
+} from '../deferredRestartQueueWiring.js';
 import type {
   AgentInputProjection,
   AgentInputQueuedMessage,
 } from '../../../shared/agentInputQueue.js';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 
 const mocks = vi.hoisted(() => {
   const logger = {
@@ -136,9 +142,11 @@ function sendSuccess(source = 'test'): AgentInputSendResult {
 
 /**
  * 真实 coordinator + 真实 DeferredCodexRestartService 的接线 harness。
- * 接线形状照抄 register.ts:hasPendingCredentialSwitch 读 service.isPending(),
- * onApplied 逐会话 wakeSession('deferred-codex-restart-applied');restart 的
- * 实现由用例注入(默认模拟 register 的 close cleanup:onSessionClosed)。
+ * gate 谓词与 onApplied 唤醒**直接复用生产接线工厂**
+ * (deferredRestartQueueWiring.ts,register.ts 同款 —— 不再照抄形状自行重
+ * 实现,谓词/唤醒逻辑改变时本回归同步失败;register 侧确实经由工厂接线由
+ * 下方源码断言锁住);restart 的实现由用例注入(默认模拟 register 的 close
+ * cleanup:onSessionClosed)。
  */
 function createRestartHarness() {
   let running = false;
@@ -165,11 +173,9 @@ function createRestartHarness() {
     },
     hasBusyLocalCodexSession: () => busyOtherSession,
     listLocalCodexSessionIds: () => [SID],
-    onApplied: (sessionIds) => {
-      for (const sessionId of sessionIds) {
-        coordinator.wakeSession(sessionId, 'deferred-codex-restart-applied');
-      }
-    },
+    onApplied: createDeferredRestartAppliedWake({
+      wakeSession: (sessionId, reason) => coordinator.wakeSession(sessionId, reason),
+    }),
     retryDelayMs: 60_000,
     logger: { info: vi.fn(), warn: vi.fn() },
   });
@@ -192,7 +198,11 @@ function createRestartHarness() {
     getAgentKind: () => 'codex',
     getSdkSessionId: vi.fn(async () => 'sdk-session'),
     hasAssistantProgressAfter: () => Promise.resolve(false),
-    hasPendingCredentialSwitch: () => service.isPending(),
+    hasPendingCredentialSwitch: createDeferredRestartQueueGate({
+      hasPendingCredentialSwitchEntry: () => false,
+      isDeferredRestartPending: () => service.isPending(),
+      listActiveSessions: () => [{ id: SID, agentKind: 'codex', remoteHostId: null }],
+    }),
     emitProjection: (projection) => {
       projections.push(projection);
     },
@@ -393,5 +403,36 @@ describe('deferred Codex restart × input queue drain (#2506)', () => {
     h2.coordinator.wakeSession(h2.SID, 'deferred-codex-restart-applied');
     await flush();
     expect(h2.sendToAgent).not.toHaveBeenCalled();
+  });
+});
+
+describe('register.ts 真实接线经由共享工厂(源码断言,#2506)', () => {
+  // harness 复用了生产接线工厂,这里锁住「register 确实也经由同一工厂接线」:
+  // 谁把 register 改回手写谓词/手写唤醒循环,这两条会失败,提示同步回归覆盖。
+  const registerSource = readFileSync(
+    fileURLToPath(new URL('../register.ts', import.meta.url)),
+    'utf8',
+  );
+
+  it('coordinator 的 hasPendingCredentialSwitch 经由 createDeferredRestartQueueGate', () => {
+    expect(registerSource).toMatch(
+      /hasPendingCredentialSwitch:\s*createDeferredRestartQueueGate\(\{/,
+    );
+    // 三个 dep 都在同一接线块里:凭证切换登记表、重启 pending、活跃会话来源。
+    const gateBlock = registerSource.slice(
+      registerSource.indexOf('hasPendingCredentialSwitch: createDeferredRestartQueueGate'),
+    );
+    const gateHead = gateBlock.slice(0, 600);
+    expect(gateHead).toContain('pendingCredentialSwitchHolder?.has(sessionId) === true');
+    expect(gateHead).toContain('deferredCodexRestartHolder?.isPending() === true');
+    expect(gateHead).toContain('maker.listActiveSessions()');
+  });
+
+  it('DeferredCodexRestartService 的 onApplied 经由 createDeferredRestartAppliedWake', () => {
+    expect(registerSource).toMatch(/onApplied:\s*createDeferredRestartAppliedWake\(\{/);
+    const wakeBlock = registerSource.slice(
+      registerSource.indexOf('onApplied: createDeferredRestartAppliedWake'),
+    );
+    expect(wakeBlock.slice(0, 300)).toContain('inputCoordinator.wakeSession(sessionId, reason)');
   });
 });

--- a/apps/desktop/src/main/maker-ipc/__tests__/deferredRestartQueueDrain.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/deferredRestartQueueDrain.test.ts
@@ -1,0 +1,394 @@
+/**
+ * 跨模块回归(#2506):deferred Codex restart × AgentInputCoordinator 的
+ * gate-clear → wake → drain 端到端可靠性。
+ *
+ * Issue 形态:全局 Codex 凭证/运行时变更被延期,已有会话里的后续消息进入
+ * 持久化输入队列,但延期重启兑现、报告"唤醒 N 个会话"之后,消息既没落
+ * `messages` 也没产生第二次派发 —— 静默滞留。此前 service 与 coordinator
+ * 只各自有单元测试,唤醒链路(register 的 onApplied → wakeSession 接线、
+ * hasPendingCredentialSwitch 的 isPending 联动)从未被串起来测过;drain 被
+ * gate 挡住时也零日志,断点无从定位。
+ *
+ * 本文件用**真实的两个模块**接线(mock 只到 deps 边界),覆盖:
+ *  1. 基线端到端:pending 门挡住 → 重启兑现(关旧 Session)→ wake → 恰好
+ *     派发一次、恰好落一条 user message、退出 snapshot;
+ *  2. 竞态排列 a:wake 在 ensureQueueRestored 仍在读取期间到达;
+ *  3. 竞态排列 b:close cleanup 吞掉已排程的 wake-drain(register 接线的
+ *     「先关后唤」顺序是正确性前提,本用例锁住反例的行为);
+ *  4. 竞态排列 c:迟到/重复 wake 的恰好一次语义;
+ *  5. drain blocked 结果级诊断落日志(gate 枚举 + 脱敏字段)。
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AgentInputCoordinator } from '../agent-input-coordinator.js';
+import type {
+  AgentInputCoordinatorDeps,
+  AgentInputSendResult,
+} from '../agent-input-coordinator.js';
+import { DeferredCodexRestartService } from '../deferredCodexRestart.js';
+import type {
+  AgentInputProjection,
+  AgentInputQueuedMessage,
+} from '../../../shared/agentInputQueue.js';
+
+const mocks = vi.hoisted(() => {
+  const logger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+  return {
+    createMessage: vi.fn(async (...args: unknown[]) => {
+      void args;
+      return {};
+    }),
+    touchUserSendInDb: vi.fn(async () => {}),
+    logger,
+  };
+});
+
+vi.mock('../../localDb/ipc/messages.js', () => ({
+  createMessage: mocks.createMessage,
+}));
+
+vi.mock('../../localDb/ipc/sessions.js', () => ({
+  touchUserSendInDb: mocks.touchUserSendInDb,
+}));
+
+vi.mock('../../logger.js', () => ({
+  createLogger: () => mocks.logger,
+}));
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+const flush = async () => {
+  for (let i = 0; i < 24; i += 1) {
+    await Promise.resolve();
+  }
+};
+
+function makeItem(
+  clientId: string,
+  text: string,
+  patch: Partial<AgentInputQueuedMessage> = {},
+): AgentInputQueuedMessage {
+  return {
+    clientId,
+    text,
+    persistedContent: text,
+    model: 'codex/gpt-5.5',
+    effort: 'medium',
+    permissionMode: 'default',
+    workingDir: '/repo',
+    chatMessage: {
+      clientId,
+      role: 'user',
+      content: text,
+      isStreaming: false,
+      createdAt: '2026-08-12T00:00:00.000Z',
+    },
+    createOpts: {
+      agentKind: 'codex',
+      workingDir: '/repo',
+      model: 'codex/gpt-5.5',
+      effort: 'medium',
+      permissionMode: 'default',
+      userPrompt: '',
+      makerMemoryEnabled: true,
+      displayReasoning: 'summarized',
+    },
+    ...patch,
+  };
+}
+
+async function persistQueuedUserMessage(
+  sessionId: string,
+  sendOpts: Parameters<AgentInputCoordinatorDeps['sendToAgent']>[3],
+): Promise<void> {
+  const persist = sendOpts.persistUserMessage;
+  if (!persist) return;
+  (persist as { onPersisting?: () => void }).onPersisting?.();
+  await mocks.createMessage(
+    sessionId,
+    {
+      clientId: persist.clientId,
+      role: 'user',
+      content: persist.content,
+      agentMeta: { delivery: persist.delivery, sdkSessionId: persist.sdkSessionId },
+    },
+    { shouldBroadcast: persist.shouldBroadcast },
+  );
+  await persist.onPersisted?.();
+}
+
+function sendSuccess(source = 'test'): AgentInputSendResult {
+  return { kind: 'session-dispatch', source, dispatched: true };
+}
+
+/**
+ * 真实 coordinator + 真实 DeferredCodexRestartService 的接线 harness。
+ * 接线形状照抄 register.ts:hasPendingCredentialSwitch 读 service.isPending(),
+ * onApplied 逐会话 wakeSession('deferred-codex-restart-applied');restart 的
+ * 实现由用例注入(默认模拟 register 的 close cleanup:onSessionClosed)。
+ */
+function createRestartHarness() {
+  let running = false;
+  let busyOtherSession = false;
+  const projections: AgentInputProjection[] = [];
+  let loadQueueSnapshot: ((sessionId: string) => Promise<AgentInputQueuedMessage[]>) | null = null;
+
+  const sendToAgent = vi.fn<AgentInputCoordinatorDeps['sendToAgent']>(
+    async (sessionId, _message, _createOpts, sendOpts) => {
+      await persistQueuedUserMessage(sessionId, sendOpts);
+      running = true;
+      return sendSuccess();
+    },
+  );
+  const persistQueueSnapshot =
+    vi.fn<NonNullable<AgentInputCoordinatorDeps['persistQueueSnapshot']>>();
+
+  // eslint-disable-next-line prefer-const
+  let coordinator: AgentInputCoordinator;
+
+  const service = new DeferredCodexRestartService({
+    restart: async () => {
+      await restartImpl();
+    },
+    hasBusyLocalCodexSession: () => busyOtherSession,
+    listLocalCodexSessionIds: () => [SID],
+    onApplied: (sessionIds) => {
+      for (const sessionId of sessionIds) {
+        coordinator.wakeSession(sessionId, 'deferred-codex-restart-applied');
+      }
+    },
+    retryDelayMs: 60_000,
+    logger: { info: vi.fn(), warn: vi.fn() },
+  });
+
+  const SID = 'codex-deferred-restart-session';
+  // 默认 restart 实现 = register 的 close cleanup 时序:关闭本地 Codex live
+  // Session(coordinator.onSessionClosed)并复位 turn 活性。
+  let restartImpl: () => Promise<void> = async () => {
+    coordinator.onSessionClosed(SID);
+    running = false;
+  };
+
+  coordinator = new AgentInputCoordinator({
+    sendToAgent,
+    steerToAgent: vi.fn(async () => {}),
+    abortSession: vi.fn(async () => {}),
+    isTurnRunning: () => running,
+    getTurnGeneration: () => 0,
+    hasPendingInteraction: () => false,
+    getAgentKind: () => 'codex',
+    getSdkSessionId: vi.fn(async () => 'sdk-session'),
+    hasAssistantProgressAfter: () => Promise.resolve(false),
+    hasPendingCredentialSwitch: () => service.isPending(),
+    emitProjection: (projection) => {
+      projections.push(projection);
+    },
+    persistQueueSnapshot,
+    loadQueueSnapshot: (sessionId) =>
+      loadQueueSnapshot ? loadQueueSnapshot(sessionId) : Promise.resolve([]),
+    getPersistedClientIds: () => Promise.resolve(new Set()),
+  });
+
+  return {
+    SID,
+    coordinator,
+    service,
+    sendToAgent,
+    persistQueueSnapshot,
+    projections,
+    setRunning(value: boolean) {
+      running = value;
+    },
+    setBusyOtherSession(value: boolean) {
+      busyOtherSession = value;
+    },
+    setRestartImpl(fn: () => Promise<void>) {
+      restartImpl = fn;
+    },
+    setLoadQueueSnapshot(fn: ((sessionId: string) => Promise<AgentInputQueuedMessage[]>) | null) {
+      loadQueueSnapshot = fn;
+    },
+  };
+}
+
+function latestProjection(projections: AgentInputProjection[]): AgentInputProjection {
+  const latest = projections.at(-1);
+  if (!latest) throw new Error('no projection emitted');
+  return latest;
+}
+
+function latestSnapshotClientIds(
+  persistQueueSnapshot: ReturnType<typeof createRestartHarness>['persistQueueSnapshot'],
+): string[] {
+  const latest = persistQueueSnapshot.mock.calls.at(-1);
+  if (!latest) return [];
+  return (latest[1] as AgentInputQueuedMessage[]).map((item) => item.clientId);
+}
+
+function drainBlockedLogs(): Array<Record<string, unknown>> {
+  return mocks.logger.info.mock.calls
+    .filter(([message]) => message === 'drain blocked')
+    .map(([, meta]) => meta as Record<string, unknown>);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('deferred Codex restart × input queue drain (#2506)', () => {
+  it('端到端:pending 门挡住的后续消息在重启兑现后恰好派发一次并落库', async () => {
+    const h = createRestartHarness();
+    await h.coordinator.ensureQueueRestored(h.SID);
+    mocks.logger.info.mockClear();
+
+    // 另一会话忙 → 重启延期挂起;本会话上一轮已完成(running=false)。
+    h.setBusyOtherSession(true);
+    h.service.schedule('memory-change');
+    expect(h.service.isPending()).toBe(true);
+
+    // 用户在已有会话发后续消息:进入队列 + 写入 snapshot,但不落 messages、不派发。
+    h.coordinator.enqueue(h.SID, makeItem('m-1', 'follow-up after restart gate'));
+    await flush();
+    expect(h.sendToAgent).not.toHaveBeenCalled();
+    expect(mocks.createMessage).not.toHaveBeenCalled();
+    expect(latestSnapshotClientIds(h.persistQueueSnapshot)).toEqual(['m-1']);
+    // 诊断:被 pending 门挡住的 drain 必须留痕(此前零日志 → 静默滞留)。
+    expect(
+      drainBlockedLogs().some((meta) => meta.gate === 'credential-switch-gate'),
+    ).toBe(true);
+
+    // 挡路会话结束 → 延期重启兑现:关旧 Session → 清 pending 门 → onApplied 唤醒。
+    h.setBusyOtherSession(false);
+    h.service.onSessionSettled();
+    await flush();
+
+    expect(h.service.isPending()).toBe(false);
+    expect(h.sendToAgent).toHaveBeenCalledTimes(1);
+    expect(h.sendToAgent.mock.calls[0]?.[1]).toEqual({
+      type: 'user',
+      content: 'follow-up after restart gate',
+    });
+    expect(mocks.createMessage).toHaveBeenCalledTimes(1);
+    // 派发 + 落库后退出 snapshot,队列清空。
+    expect(latestSnapshotClientIds(h.persistQueueSnapshot)).toEqual([]);
+    expect(latestProjection(h.projections).pendingQueue).toEqual([]);
+  });
+
+  it('竞态 a:wake 在队列恢复读取期间到达 → 被 gate 挡下并留痕;安静恢复进入暂停态同样可诊断', async () => {
+    const h = createRestartHarness();
+    const restore = deferred<AgentInputQueuedMessage[]>();
+    h.setLoadQueueSnapshot(() => restore.promise);
+
+    // 恢复读取挂起中,wake 恰好到达(如延期重启在 app 启动恢复窗口内兑现)。
+    const restoring = h.coordinator.ensureQueueRestored(h.SID);
+    h.coordinator.wakeSession(h.SID, 'deferred-codex-restart-applied');
+    await flush();
+    expect(h.sendToAgent).not.toHaveBeenCalled();
+    expect(
+      drainBlockedLogs().some((meta) => meta.gate === 'queue-restore-in-progress'),
+    ).toBe(true);
+
+    // 恢复完成:会话安静(无 turn 活性)→ 既有语义是 queuePausedByRestore 暂停,
+    // 等用户显式输入解锁 —— 崩溃快照里的旧 prompt 不能被自动化路径悄悄放跑。
+    restore.resolve([makeItem('m-restored', 'prompt from crash snapshot')]);
+    await restoring;
+    await flush();
+    expect(h.sendToAgent).not.toHaveBeenCalled();
+
+    // 迟到的二次 wake 不越过暂停态,且必须留下 gate 诊断而不是静默无痕。
+    mocks.logger.info.mockClear();
+    h.coordinator.wakeSession(h.SID, 'deferred-codex-restart-applied');
+    await flush();
+    expect(h.sendToAgent).not.toHaveBeenCalled();
+    expect(
+      drainBlockedLogs().some((meta) => meta.gate === 'queue-paused-by-restore'),
+    ).toBe(true);
+
+    // 用户显式输入(INPUT_ENQUEUE 携带 resumeRestorePausedQueue)解除暂停:
+    // 恢复的队首立即派发,新输入按序在队等它的 turn 收口(常规队列行为,
+    // 已有既有覆盖)—— 这是暂停态的既定解锁路径。
+    h.coordinator.enqueue(h.SID, makeItem('m-user', 'user follow-up'), {
+      resumeRestorePausedQueue: true,
+    });
+    await flush();
+    expect(h.sendToAgent).toHaveBeenCalledTimes(1);
+    expect(h.sendToAgent.mock.calls[0]?.[1]).toEqual({
+      type: 'user',
+      content: 'prompt from crash snapshot',
+    });
+    expect(
+      latestProjection(h.projections).pendingQueue.map((item) => item.clientId),
+    ).toEqual(['m-user']);
+  });
+
+  it('竞态 b:close cleanup 吞掉已排程的 wake-drain → 必须由后续 wake 补救(锁住「先关后唤」时序前提)', async () => {
+    const h = createRestartHarness();
+    await h.coordinator.ensureQueueRestored(h.SID);
+
+    h.setBusyOtherSession(true);
+    h.service.schedule('memory-change');
+    h.coordinator.enqueue(h.SID, makeItem('m-1', 'queued before close race'));
+    await flush();
+    expect(h.sendToAgent).not.toHaveBeenCalled();
+
+    // 门已清除(重启已兑现),但 wake 的 microtask 尚未执行时 close cleanup 到达:
+    // cancelScheduledDrain 会作废这次 wake —— 单靠这一次 wake 消息就永久滞留。
+    h.setBusyOtherSession(false);
+    h.service.clear();
+    h.coordinator.wakeSession(h.SID, 'deferred-codex-restart-applied');
+    h.coordinator.onSessionClosed(h.SID);
+    await flush();
+    expect(h.sendToAgent).not.toHaveBeenCalled();
+
+    // register 接线的正确性前提正在于此:onApplied 严格发生在 restart(全部
+    // close)之后,wake 不会落进 close 窗口。补一次 close 之后的 wake 即派发。
+    h.coordinator.wakeSession(h.SID, 'deferred-codex-restart-applied');
+    await flush();
+    expect(h.sendToAgent).toHaveBeenCalledTimes(1);
+    expect(mocks.createMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('竞态 c:迟到与重复 wake 保持恰好一次派发;清空后的迟到 wake 是 no-op', async () => {
+    const h = createRestartHarness();
+    await h.coordinator.ensureQueueRestored(h.SID);
+
+    h.setBusyOtherSession(true);
+    h.service.schedule('memory-change');
+    h.coordinator.enqueue(h.SID, makeItem('m-1', 'exactly once'));
+    await flush();
+
+    // 重启兑现 → wake;紧跟两次冗余 wake(如另一来源的 superseded 唤醒)。
+    h.setBusyOtherSession(false);
+    h.service.onSessionSettled();
+    await flush();
+    h.coordinator.wakeSession(h.SID, 'deferred-codex-restart-superseded');
+    h.coordinator.wakeSession(h.SID, 'deferred-codex-restart-applied');
+    await flush();
+    expect(h.sendToAgent).toHaveBeenCalledTimes(1);
+    expect(mocks.createMessage).toHaveBeenCalledTimes(1);
+
+    // 用户清空队列后才到达的迟到 wake:无派发、无落库、无崩溃。
+    const h2 = createRestartHarness();
+    await h2.coordinator.ensureQueueRestored(h2.SID);
+    h2.service.schedule('memory-change');
+    h2.coordinator.enqueue(h2.SID, makeItem('m-2', 'cleared before wake'));
+    await flush();
+    h2.coordinator.remove(h2.SID, 'm-2');
+    h2.service.clear();
+    h2.coordinator.wakeSession(h2.SID, 'deferred-codex-restart-applied');
+    await flush();
+    expect(h2.sendToAgent).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/main/maker-ipc/__tests__/deferredRestartQueueDrain.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/deferredRestartQueueDrain.test.ts
@@ -16,7 +16,8 @@
  *  3. 竞态排列 b:close cleanup 吞掉已排程的 wake-drain(register 接线的
  *     「先关后唤」顺序是正确性前提,本用例锁住反例的行为);
  *  4. 竞态排列 c:迟到/重复 wake 的恰好一次语义;
- *  5. drain blocked 结果级诊断落日志(gate 枚举 + 脱敏字段)。
+ *  5. drain blocked 结果级诊断落日志(gate 枚举 + 脱敏字段;常规 gate 走
+ *     debug,仅 queue-restore-failed 保留 info)。
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { AgentInputCoordinator } from '../agent-input-coordinator.js';
@@ -238,7 +239,9 @@ function latestSnapshotClientIds(
 }
 
 function drainBlockedLogs(): Array<Record<string, unknown>> {
-  return mocks.logger.info.mock.calls
+  // 常规 gate 的阻塞诊断走 debug(正常排队每次 drain 都进这里,info 会刷爆
+  // packaged 日志);只有 queue-restore-failed 保留 info 常驻观测。
+  return mocks.logger.debug.mock.calls
     .filter(([message]) => message === 'drain blocked')
     .map(([, meta]) => meta as Record<string, unknown>);
 }
@@ -251,7 +254,7 @@ describe('deferred Codex restart × input queue drain (#2506)', () => {
   it('端到端:pending 门挡住的后续消息在重启兑现后恰好派发一次并落库', async () => {
     const h = createRestartHarness();
     await h.coordinator.ensureQueueRestored(h.SID);
-    mocks.logger.info.mockClear();
+    mocks.logger.debug.mockClear();
 
     // 另一会话忙 → 重启延期挂起;本会话上一轮已完成(running=false)。
     h.setBusyOtherSession(true);
@@ -308,7 +311,7 @@ describe('deferred Codex restart × input queue drain (#2506)', () => {
     expect(h.sendToAgent).not.toHaveBeenCalled();
 
     // 迟到的二次 wake 不越过暂停态,且必须留下 gate 诊断而不是静默无痕。
-    mocks.logger.info.mockClear();
+    mocks.logger.debug.mockClear();
     h.coordinator.wakeSession(h.SID, 'deferred-codex-restart-applied');
     await flush();
     expect(h.sendToAgent).not.toHaveBeenCalled();

--- a/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
+++ b/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
@@ -3143,9 +3143,15 @@ export class AgentInputCoordinator {
       // #2506 结果级诊断:排队输入被 gate 挡住时留痕(此前零日志,gate-clear
       // 到成功 drain 之间的静默滞留无从定位)。只记 id / 布尔 / 枚举,不记正文;
       // 空队列的例行 drain 不记,避免每次 turn-done 都产生噪音。
+      // 级别按 gate 分层(Codex review):turn 运行中排队、恢复暂停、交互锁等
+      // 都是**正常态**,每次 drain 尝试都会进这里 —— packaged 默认 info,记
+      // info 会让普通排队持续刷日志、淹没真正的异常断点,复现期排障走 DEBUG
+      // (工程规范)。只有 queue-restore-failed(快照恢复确已失败,队列滞留到
+      // 人工介入,非瞬态)保留 info 常驻观测。
       const gate = this.explainDrainBlockGate(sessionId, state);
       if (gate !== null && gate !== 'queue-empty') {
-        log.info('drain blocked', {
+        const logAt = gate === 'queue-restore-failed' ? log.info : log.debug;
+        logAt('drain blocked', {
           sessionId,
           reason,
           gate,

--- a/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
+++ b/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
@@ -3056,26 +3056,37 @@ export class AgentInputCoordinator {
     return state.activeTurn !== null || this.deps.isTurnRunning(sessionId);
   }
 
+  /**
+   * 队首为何不可派发 —— getDrainableHead 的解释版,两者共用同一份 gate 序列
+   * (#2506 wake/drain 可观测性:此前 drain 被 gate 挡住时零日志,排队输入
+   * 静默滞留后无从定位断点)。返回 null = 队首可派发。
+   */
+  private explainDrainBlockGate(sessionId: string, state: SessionInputState): string | null {
+    if (this.queueRestorePromises.has(sessionId)) return 'queue-restore-in-progress';
+    if (this.restoreAttempted.has(sessionId) && !this.restoredQueueSessions.has(sessionId))
+      return 'queue-restore-failed';
+    if (state.pendingQueue.length === 0) return 'queue-empty';
+    if (state.queuePaused)
+      return state.queuePausedByRestore ? 'queue-paused-by-restore' : 'queue-paused';
+    if (state.queueAbortPending) return 'abort-pending';
+    if (state.queueInteractionLocks.length > 0) return 'interaction-lock';
+    if (state.steeringQueueClientIds.length > 0) return 'steering-in-flight';
+    if (state.recovery) return 'recovery-pending';
+    if (this.deps.hasPendingCredentialSwitch?.(sessionId)) return 'credential-switch-gate';
+    if (this.isDispatchBoundaryBusy(sessionId, state)) return 'dispatch-boundary-busy';
+    const head = state.pendingQueue[0];
+    if (!head) return 'queue-empty';
+    if (this.getDrainableCompact(sessionId, state)) return 'compact-first';
+    if (state.queueEditLocks.includes(head.clientId)) return 'edit-lock';
+    return null;
+  }
+
   private getDrainableHead(
     sessionId: string,
     state: SessionInputState,
   ): AgentInputQueuedMessage | null {
-    if (this.queueRestorePromises.has(sessionId)) return null;
-    if (this.restoreAttempted.has(sessionId) && !this.restoredQueueSessions.has(sessionId))
-      return null;
-    if (state.pendingQueue.length === 0) return null;
-    if (state.queuePaused) return null;
-    if (state.queueAbortPending) return null;
-    if (state.queueInteractionLocks.length > 0) return null;
-    if (state.steeringQueueClientIds.length > 0) return null;
-    if (state.recovery) return null;
-    if (this.deps.hasPendingCredentialSwitch?.(sessionId)) return null;
-    if (this.isDispatchBoundaryBusy(sessionId, state)) return null;
-    const head = state.pendingQueue[0];
-    if (!head) return null;
-    if (this.getDrainableCompact(sessionId, state)) return null;
-    if (state.queueEditLocks.includes(head.clientId)) return null;
-    return head;
+    if (this.explainDrainBlockGate(sessionId, state) !== null) return null;
+    return state.pendingQueue[0] ?? null;
   }
 
   private getDrainableCompact(
@@ -3129,6 +3140,26 @@ export class AgentInputCoordinator {
     }
     const head = this.getDrainableHead(sessionId, state);
     if (!head) {
+      // #2506 结果级诊断:排队输入被 gate 挡住时留痕(此前零日志,gate-clear
+      // 到成功 drain 之间的静默滞留无从定位)。只记 id / 布尔 / 枚举,不记正文;
+      // 空队列的例行 drain 不记,避免每次 turn-done 都产生噪音。
+      const gate = this.explainDrainBlockGate(sessionId, state);
+      if (gate !== null && gate !== 'queue-empty') {
+        log.info('drain blocked', {
+          sessionId,
+          reason,
+          gate,
+          queueLength: state.pendingQueue.length,
+          headClientId: state.pendingQueue[0]?.clientId ?? null,
+          queuePaused: state.queuePaused,
+          queuePausedByRestore: state.queuePausedByRestore,
+          queueRestoreInProgress: this.queueRestorePromises.has(sessionId),
+          recoveryKind: state.recovery?.kind ?? null,
+          hasActiveTurn: state.activeTurn !== null,
+          turnRunning: this.deps.isTurnRunning(sessionId),
+          credentialSwitchGate: this.deps.hasPendingCredentialSwitch?.(sessionId) === true,
+        });
+      }
       this.scheduleExternalTurnRetryIfNeeded(sessionId, state, `drain-blocked:${reason}`);
       return;
     }

--- a/apps/desktop/src/main/maker-ipc/deferredRestartQueueWiring.ts
+++ b/apps/desktop/src/main/maker-ipc/deferredRestartQueueWiring.ts
@@ -1,0 +1,58 @@
+/**
+ * deferred Codex restart × 输入队列的生产接线工厂(#2506)。
+ *
+ * register.ts 与跨模块回归测试(deferredRestartQueueDrain.test.ts)共用这两个
+ * 工厂:测试 harness 此前照抄接线形状自行重实现,register 真实接线漏接/错接/
+ * 改变谓词时回归照样全绿(Codex review P1)。抽到这里后,谓词与唤醒的**逻辑**
+ * 只有一份;register 侧只剩传 deps,测试另以源码断言锁住 register 确实经由
+ * 本工厂接线。
+ */
+
+/** onApplied 唤醒的 wake reason,coordinator 日志与测试断言共用同一常量。 */
+export const DEFERRED_RESTART_WAKE_REASON = 'deferred-codex-restart-applied';
+
+interface GateSessionShape {
+  id: string;
+  agentKind: string;
+  remoteHostId?: string | null;
+}
+
+/**
+ * coordinator 的 hasPendingCredentialSwitch 谓词:
+ *  1. 延迟凭证切换登记表里有该会话 → 挡;
+ *  2. 延迟 Codex 重启 pending 期间,本地 Codex live 会话 → 挡 —— 否则排队消息
+ *     在旧 host 上接续开新 turn,重启被无限顺延(review P1 2026-07-23)。未
+ *     spawn / 已关闭的会话不挡:fresh spawn 本来就读新设置。
+ * maker 是 dynamic facade,owner 边界窗口 listActiveSessions 会抛 → 按不挡
+ * 处理(边界会清 pending)。
+ */
+export function createDeferredRestartQueueGate(deps: {
+  hasPendingCredentialSwitchEntry: (sessionId: string) => boolean;
+  isDeferredRestartPending: () => boolean;
+  listActiveSessions: () => GateSessionShape[];
+}): (sessionId: string) => boolean {
+  return (sessionId) => {
+    if (deps.hasPendingCredentialSwitchEntry(sessionId)) return true;
+    if (!deps.isDeferredRestartPending()) return false;
+    try {
+      const session = deps.listActiveSessions().find((s) => s.id === sessionId);
+      return !!session && session.agentKind === 'codex' && !session.remoteHostId;
+    } catch {
+      return false;
+    }
+  };
+}
+
+/**
+ * DeferredCodexRestartService.onApplied 的接线:重启兑现后逐会话唤醒输入队列,
+ * wake reason 固定为 DEFERRED_RESTART_WAKE_REASON。
+ */
+export function createDeferredRestartAppliedWake(deps: {
+  wakeSession: (sessionId: string, reason: string) => void;
+}): (sessionIds: string[]) => void {
+  return (sessionIds) => {
+    for (const sessionId of sessionIds) {
+      deps.wakeSession(sessionId, DEFERRED_RESTART_WAKE_REASON);
+    }
+  };
+}

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -759,6 +759,10 @@ import {
   type MemoryChangeParts,
 } from './deferredCodexRestart.js';
 import {
+  createDeferredRestartAppliedWake,
+  createDeferredRestartQueueGate,
+} from './deferredRestartQueueWiring.js';
+import {
   hasAnySessionInTurn,
   isSessionTurnDispatchBoundaryBusy,
   isTerminalTurnErrorEvent,
@@ -10945,20 +10949,15 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
         }
       }
     },
-    hasPendingCredentialSwitch: (sessionId) => {
-      if (pendingCredentialSwitchHolder?.has(sessionId) === true) return true;
-      // 延迟 Codex 重启 pending 期间同样挡住本地 Codex live 会话的排队派发 ——
-      // 否则排队消息在旧 host 上接续开新 turn,重启被无限顺延(review P1
-      // 2026-07-23)。未 spawn / 已关闭的会话不挡:fresh spawn 本来就读新设置。
-      // maker 是 dynamic facade,owner 边界窗口会抛 → 按不挡处理(边界会清 pending)。
-      if (deferredCodexRestartHolder?.isPending() !== true) return false;
-      try {
-        const session = maker.listActiveSessions().find((s) => s.id === sessionId);
-        return !!session && session.agentKind === 'codex' && !session.remoteHostId;
-      } catch {
-        return false;
-      }
-    },
+    // 谓词逻辑在 deferredRestartQueueWiring.ts(与 #2506 跨模块回归共用同一
+    // 工厂,harness 不再照抄接线形状);holder 晚于 coordinator 构造,经闭包
+    // 晚绑定。
+    hasPendingCredentialSwitch: createDeferredRestartQueueGate({
+      hasPendingCredentialSwitchEntry: (sessionId) =>
+        pendingCredentialSwitchHolder?.has(sessionId) === true,
+      isDeferredRestartPending: () => deferredCodexRestartHolder?.isPending() === true,
+      listActiveSessions: () => maker.listActiveSessions(),
+    }),
     emitProjection: (projection) => {
       broadcastToAllWindows(MAKER_PUSH.INPUT_PROJECTION, projection);
     },
@@ -11172,11 +11171,9 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
         .listActiveSessions()
         .filter((session) => session.agentKind === 'codex' && !session.remoteHostId)
         .map((session) => session.id),
-    onApplied: (sessionIds) => {
-      for (const sessionId of sessionIds) {
-        inputCoordinator.wakeSession(sessionId, 'deferred-codex-restart-applied');
-      }
-    },
+    onApplied: createDeferredRestartAppliedWake({
+      wakeSession: (sessionId, reason) => inputCoordinator.wakeSession(sessionId, reason),
+    }),
     logger: log,
   });
   deferredCodexRestartHolder = deferredCodexRestartService;


### PR DESCRIPTION
## 这次改了什么

### 摘要

#2506 第一阶段(按 issue 内维护者方案的行动 1-3)。延期 Codex 重启兑现后,已有会话的排队消息可能既不落 `messages` 也不派发,静默滞留。此前 `DeferredCodexRestartService` 与 `AgentInputCoordinator` 只各自有单元测试,gate-clear → wake → drain 链路从未被串起来测过;drain 被 gate 挡住时零日志,断点无从定位。

- 新增跨模块回归 `deferredRestartQueueDrain.test.ts`:**真实**的两个模块接线(mock 只到 deps 边界),接线形状照抄 register.ts(`isPending` → `hasPendingCredentialSwitch`、`onApplied` → `wakeSession`)。覆盖基线端到端(pending 门挡住 → 重启兑现关旧 Session → wake → 恰好派发一次、恰好落一条 user message、退出 snapshot)与维护者点名的三组竞态排列:
  - **a**:wake 落在 `ensureQueueRestored` 读取窗口内被 gate 挡下;安静恢复进入 `queuePausedByRestore` 暂停态(崩溃快照旧 prompt 不被自动化路径放跑的既有安全语义),迟到 wake 不越过暂停,用户显式输入解锁;
  - **b**:close cleanup 作废已排程的 wake-drain,单靠该次 wake 即滞留——锁住 register「先关后唤」时序(`onApplied` 严格在 restart 全部 close 之后)作为正确性前提;
  - **c**:迟到/重复 wake 恰好一次派发;清空后的迟到 wake 为 no-op。
- coordinator 新增 drain 阻塞**结果级诊断**:`getDrainableHead` 重构为与 `explainDrainBlockGate` 共用单一 gate 序列(判定行为逐字节不变),drain 被挡时记 `drain blocked` 结构化日志(gate 枚举 + sessionId / 队首 clientId / queuePaused / 恢复态 / recovery kind / activeTurn / turnRunning / credential gate,全为 id、布尔与枚举,不记正文;空队列例行 drain 不记避免噪音)。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [x] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他:

### 范围

- 关联 Issue / 需求:#2506(维护者方案行动 1 跨模块回归、行动 2 竞态排列、行动 3 结果级诊断)
- 本 PR 包含:`apps/desktop` coordinator 的 gate 判定重构(行为不变)+ 阻塞诊断日志 + 跨模块回归测试
- 明确不包含:对滞留根因的行为修复——issue 仅复现一次,尚无确定性断点;本 PR 先把链路钉进测试并补齐可观测性,现场复发时可从 `drain blocked` 日志直接定位 gate,再做窄修
- 用户可见变化:无(仅新增诊断日志)
- 是否存在 breaking change:无

### UI 变化

不涉及。

- 引用的设计规范:不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/maker-ipc/__tests__/deferredRestartQueueDrain.test.ts src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts src/main/maker-ipc/__tests__/deferredCodexRestart.test.ts src/main/maker-ipc/__tests__/pendingCredentialSwitch.test.ts --pool=forks
结果:322/322 通过(新增 4 条跨模块回归;既有 coordinator / service 套件全部不变,证明 gate 判定重构行为等价)

pnpm --filter desktop run --if-present typecheck
结果:通过(0 错误)

desktop 全量单测(--pool=forks 规避 threads 池已知 SIGSEGV flake)
结果:24530 通过 / 3 skip

根 pnpm test:unit
结果:除 desktop threads 池已知 SIGSEGV flake(forks 池全过)外 50 workspace 全过
```

### 手工验证

不涉及(issue 场景仅复现一次且依赖多会话竞态;本 PR 的目标正是让下次现场复发可从日志定位)。

### 未执行的验证

未复现 issue 的原始现场(观察频率一次);基线端到端测试证明接线在正确时序下工作,两个已识别的静默滞留形态(恢复窗口吞 wake、close 作废已排程 drain)已由竞态用例钉住既有语义。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] 其他:

### 影响与回滚

- 影响范围:生产代码仅 gate 判定的等价重构与新增日志;判定序列与原实现逐条对应,既有 318 条 coordinator/service 用例全绿佐证。日志字段全脱敏(id/布尔/枚举)。
- 回滚 / 降级方式:revert 本 commit;无状态、无数据迁移。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`,见 [DCO](../DCO))
- [ ] UI 改动已在「UI 变化」注明引用的设计规范章节(不涉及 UI 则跳过)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
