### PR TITLE
fix(desktop): honor system proxy for cua installer

### DIFF
--- a/apps/desktop/src/main/mcp-integrations/__tests__/computer.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/__tests__/computer.test.ts
@@ -13,6 +13,7 @@ const {
   mcpConnectMock,
   transportCloseMock,
   transportCtorMock,
+  resolveDesktopOutboundProxyMock,
 } = vi.hoisted(() => ({
   existsSyncMock: vi.fn(),
   readlinkSyncMock: vi.fn(),
@@ -22,10 +23,23 @@ const {
   mcpConnectMock: vi.fn(),
   transportCloseMock: vi.fn(),
   transportCtorMock: vi.fn(),
+  resolveDesktopOutboundProxyMock: vi.fn(),
 }));
 
 const originalPlatform = process.platform;
-const driverResolutionEnvKeys = ['XDT_CUA_DRIVER_PATH', 'LOCALAPPDATA', 'LocalAppData'] as const;
+const driverResolutionEnvKeys = [
+  'XDT_CUA_DRIVER_PATH',
+  'LOCALAPPDATA',
+  'LocalAppData',
+  'HTTPS_PROXY',
+  'https_proxy',
+  'HTTP_PROXY',
+  'http_proxy',
+  'ALL_PROXY',
+  'all_proxy',
+  'NO_PROXY',
+  'no_proxy',
+] as const;
 const originalDriverResolutionEnv = new Map<string, string | undefined>(
   driverResolutionEnvKeys.map((key) => [key, process.env[key]]),
 );
@@ -68,6 +82,10 @@ vi.mock('@modelcontextprotocol/sdk/client/stdio.js', () => ({
   }),
 }));
 
+vi.mock('../../maker-host/outbound-proxy-resolver.js', () => ({
+  resolveDesktopOutboundProxy: resolveDesktopOutboundProxyMock,
+}));
+
 vi.mock('electron', () => ({
   app: {
     getPath: vi.fn((name: string) => (name === 'temp' ? '/tmp' : '/Users/tester')),
@@ -81,6 +99,7 @@ import {
   cleanupAllComputerDriverSessions,
   cleanupComputerDriverSession,
   compareSemver,
+  buildCuaInstallerProxyEnv,
   extractDriverSemver,
   getCuaDriverReleaseAssetName,
   resolveCuaDriverHostArch,
@@ -310,6 +329,7 @@ describe('computer mcp integration', () => {
     mcpConnectMock.mockReset().mockResolvedValue(undefined);
     transportCloseMock.mockReset().mockResolvedValue(undefined);
     transportCtorMock.mockReset();
+    resolveDesktopOutboundProxyMock.mockReset().mockResolvedValue(null);
     for (const key of driverResolutionEnvKeys) {
       delete process.env[key];
     }
@@ -2581,6 +2601,63 @@ describe('computer mcp integration', () => {
       },
     });
     expect(spawnMock.mock.calls[0]?.[0]).toMatch(process.platform === 'win32' ? /powershell/i : '/bin/bash');
+  });
+
+  it('passes the resolved system HTTP proxy to the POSIX installer', async () => {
+    setPlatform('linux');
+    resolveDesktopOutboundProxyMock.mockResolvedValue('http://127.0.0.1:7897');
+    mockDriverSpawn({ stdout: 'installed\n' });
+    mockDriverSpawn({ stdout: 'cua-driver 0.5.8\n' });
+    mockDriverSpawn({ stdout: 'Cua Driver daemon is running\n' });
+
+    await installComputerDriver();
+
+    expect(resolveDesktopOutboundProxyMock).toHaveBeenCalledWith(
+      'https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/install.sh',
+    );
+    expect(spawnMock.mock.calls[0]?.[2]?.env).toMatchObject({
+      HTTPS_PROXY: 'http://127.0.0.1:7897',
+      HTTP_PROXY: 'http://127.0.0.1:7897',
+      https_proxy: 'http://127.0.0.1:7897',
+      http_proxy: 'http://127.0.0.1:7897',
+    });
+  });
+
+  it('continues the POSIX install when system proxy resolution fails', async () => {
+    setPlatform('linux');
+    resolveDesktopOutboundProxyMock.mockRejectedValue(new Error('resolver unavailable'));
+    mockDriverSpawn({ stdout: 'installed\n' });
+    mockDriverSpawn({ stdout: 'cua-driver 0.5.8\n' });
+    mockDriverSpawn({ stdout: 'Cua Driver daemon is running\n' });
+
+    await expect(installComputerDriver()).resolves.toMatchObject({ ok: true });
+
+    expect(spawnMock.mock.calls[0]?.[2]?.env).not.toHaveProperty('HTTPS_PROXY');
+    expect(spawnMock.mock.calls[0]?.[2]?.env).not.toHaveProperty('ALL_PROXY');
+  });
+
+  it('preserves explicit proxy env instead of replacing it with the system proxy', async () => {
+    setPlatform('linux');
+    process.env.HTTPS_PROXY = 'http://user:secret@127.0.0.1:6152';
+    resolveDesktopOutboundProxyMock.mockResolvedValue('http://127.0.0.1:7897');
+    mockDriverSpawn({ stdout: 'installed\n' });
+    mockDriverSpawn({ stdout: 'cua-driver 0.5.8\n' });
+    mockDriverSpawn({ stdout: 'Cua Driver daemon is running\n' });
+
+    await installComputerDriver();
+
+    expect(resolveDesktopOutboundProxyMock).not.toHaveBeenCalled();
+    expect(spawnMock.mock.calls[0]?.[2]?.env?.HTTPS_PROXY).toBe(
+      'http://user:secret@127.0.0.1:6152',
+    );
+  });
+
+  it('uses remote DNS for a resolved SOCKS5 installer proxy', () => {
+    expect(buildCuaInstallerProxyEnv('socks5://127.0.0.1:7898')).toEqual({
+      ALL_PROXY: 'socks5h://127.0.0.1:7898',
+      all_proxy: 'socks5h://127.0.0.1:7898',
+    });
+    expect(buildCuaInstallerProxyEnv('https://unsupported.example')).toBeUndefined();
   });
 
   it('keeps macOS status checks side-effect-free when the daemon is stopped', async () => {

--- a/apps/desktop/src/main/mcp-integrations/computer.ts
+++ b/apps/desktop/src/main/mcp-integrations/computer.ts
@@ -5,6 +5,7 @@ import { spawn, type ChildProcess } from 'node:child_process';
 import { existsSync, mkdirSync, readFileSync, readlinkSync, rmSync, statSync } from 'node:fs';
 import type { Stream } from 'node:stream';
 import { app } from 'electron';
+import { hasProxyEnvConfig, parseOutboundProxyUrl } from '@cindy/anthropic-compat-proxy';
 import { BRAND_NAME } from '@cindy/maker-shared/branding';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
@@ -19,6 +20,7 @@ import type {
 } from '@cindy/mcps';
 import { createLogger } from '../logger.js';
 import { outboundFetch } from '../maker-host/outbound-fetch.js';
+import { resolveDesktopOutboundProxy } from '../maker-host/outbound-proxy-resolver.js';
 
 const logger = createLogger('mcp/cindy_computer');
 const DRIVER_COMMAND = 'cua-driver';
@@ -898,11 +900,48 @@ export function installIdleTimeoutForPlatform(platform: NodeJS.Platform = proces
   return platform === 'win32' ? INSTALL_HARD_TIMEOUT_MS : INSTALL_IDLE_TIMEOUT_MS;
 }
 
-function runInstallCommand(
+/** Translate Cindy's validated system proxy decision into env understood by installer tools. */
+export function buildCuaInstallerProxyEnv(
+  proxyUrl: string | null | undefined,
+): Record<string, string> | undefined {
+  const proxy = parseOutboundProxyUrl(proxyUrl);
+  if (!proxy) return undefined;
+  if (proxy.kind === 'socks5') {
+    const proxyUrlWithRemoteDns = proxy.url.replace(/^socks5:/, 'socks5h:');
+    return { ALL_PROXY: proxyUrlWithRemoteDns, all_proxy: proxyUrlWithRemoteDns };
+  }
+  return {
+    HTTPS_PROXY: proxy.url,
+    HTTP_PROXY: proxy.url,
+    https_proxy: proxy.url,
+    http_proxy: proxy.url,
+  };
+}
+
+async function resolveCuaInstallerProxyEnv(
+  installUrl: string,
+): Promise<Record<string, string> | undefined> {
+  // Explicit env already reaches the child unchanged and keeps its per-host NO_PROXY semantics.
+  if (hasProxyEnvConfig()) return undefined;
+  try {
+    return buildCuaInstallerProxyEnv(await resolveDesktopOutboundProxy(installUrl));
+  } catch (err) {
+    logger.debug('cua-driver installer proxy resolution failed (using inherited environment)', {
+      message: err instanceof Error ? err.message : String(err),
+    });
+    return undefined;
+  }
+}
+
+async function runInstallCommand(
   onSpawn?: (pid: number | undefined) => void,
   targetVersion?: string,
 ): Promise<ExecResult> {
   clearStaleCuaInstallLock();
+  let extraEnv = process.platform === 'win32'
+    ? undefined
+    : await resolveCuaInstallerProxyEnv(UNIX_INSTALL_URL);
+  if (targetVersion) extraEnv = { ...extraEnv, CUA_DRIVER_RS_VERSION: targetVersion };
   const activityOptions: ActivityTimeoutOptions = {
     idleTimeoutMs: installIdleTimeoutForPlatform(),
     hardTimeoutMs: INSTALL_HARD_TIMEOUT_MS,
@@ -911,7 +950,7 @@ function runInstallCommand(
     // 更新场景把检测到的版本 pin 给上游脚本(env 是其最高优先级版本源)。
     // 不 pin 时上游会用脚本内 baked 默认值,该值可能滞后于真实最新版,
     // 导致「更新到 0.7.0」实际装回旧版(review P1)。
-    ...(targetVersion ? { extraEnv: { CUA_DRIVER_RS_VERSION: targetVersion } } : {}),
+    ...(extraEnv ? { extraEnv } : {}),
   };
   if (process.platform === 'win32') {
     return runProcessWithActivityTimeout(


### PR DESCRIPTION
## 这次改了什么

### Summary

- Resolve Cindy's system proxy for the official `cua-driver` installer on macOS and Linux.
- Pass validated HTTP or SOCKS5 proxy settings to the installer child process.
- Preserve explicit proxy environment variables and fail open if proxy resolution fails.

### Change type

- [ ] `feat`
- [x] `fix`
- [ ] `refactor` / `perf`
- [ ] `docs` / `test` / `chore`

### Scope

- Related to #2525.
- Included: installer proxy propagation and regression tests.
- Not included: first-install progress UI, lock-wait UX, or Windows installer changes.
- Breaking change: No.

### Remote and mobile adaptation

- SSH remote workspaces: Not affected.
- Device link: No channel or protocol change.
- Mobile: Not affected.

### UI 变化

Not involved.

- 引用的设计规范：Not involved.

## 怎么验证的

### Automated verification

- `pnpm --filter desktop exec vitest run src/main/mcp-integrations/__tests__/computer.test.ts` — 141 passed.
- `NODE_OPTIONS=--max-old-space-size=6144 pnpm --filter desktop run --if-present typecheck` — passed.
- `pnpm test:unit` — passed.
- `pnpm check:dco` — passed.

### Manual verification

Not run.

### Not run

Packaged macOS installation through a live Clash system proxy.

## 风险

### Risk classification

- [ ] No known risk
- [x] Cross-platform behavior

### Impact and rollback

- Impact: macOS and Linux `cua-driver` installer subprocesses only.
- Risk: PAC decisions are resolved for the official installer URL and applied to the installer process. Explicit proxy environment variables keep precedence. Windows is unchanged.
- Rollback: Revert this commit. No data migration or cleanup is required.

### Pre-submit checks

- [x] Reviewed the complete diff.
- [x] Every commit has a DCO sign-off.
- [x] No credentials, tokens, or authorization files are included.
- [x] Required tests passed.
