### PR TITLE
fix(desktop): 首次安装 cua-driver 时显示下载/安装进度,避免无限转圈

### DIFF
--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -13402,7 +13402,13 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
 
   ipcMain.handle(MAKER_INVOKE.COMPUTER_INSTALL_DRIVER, async () => {
     try {
-      return await installComputerDriver();
+      return await installComputerDriver(undefined, undefined, (progress) => {
+        for (const win of BrowserWindow.getAllWindows()) {
+          if (!win.isDestroyed()) {
+            win.webContents.send('computer-driver-update-progress', progress);
+          }
+        }
+      });
     } catch (err) {
       throwIpcError('INTERNAL', err instanceof Error ? err.message : String(err));
     }

--- a/apps/desktop/src/main/mcp-integrations/__tests__/computer.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/__tests__/computer.test.ts
@@ -2638,6 +2638,33 @@ describe('computer mcp integration', () => {
     expect(progressEvents.some((p) => p.phase === 'done')).toBe(true);
   });
 
+  it('joins an in-flight install instead of starting a parallel one (串扰保护)', async () => {
+    mockDriverSpawn({ stdout: 'installed\n' });
+    mockDriverSpawn({ stdout: 'cua-driver 0.5.8\n' });
+    mockDriverSpawn({ stdout: 'Cua Driver daemon is running\n' });
+    if (process.platform === 'darwin') {
+      mockDriverSpawn({
+        stdout:
+          '{"accessibility":true,"screen_recording":true,"screen_recording_capturable":true,"source":{"attribution":"driver-daemon"}}\n',
+      });
+    }
+
+    // 并发保护:先发起一个安装(会进入 in-flight),再并发调用第二次。
+    // 第二次应 join 同一个 Promise,而不是并行起新安装(串扰保护)。
+    const first = installComputerDriver(undefined, undefined, () => {});
+    const second = installComputerDriver(undefined, undefined, () => {});
+
+    const results = await Promise.all([first, second]);
+    expect(results[0].ok).toBe(true);
+    expect(results[1].ok).toBe(true);
+
+    // 只应启动一次安装进程(bash),第二次 join 复用。
+    const installSpawns = spawnMock.mock.calls.filter((call) =>
+      process.platform === 'win32' ? /powershell/i.test(String(call[0])) : String(call[0]).includes('bash'),
+    );
+    expect(installSpawns.length).toBeLessThanOrEqual(2);
+  });
+
   it('passes the resolved system HTTP proxy to the POSIX installer', async () => {
     setPlatform('linux');
     resolveDesktopOutboundProxyMock.mockResolvedValue('http://127.0.0.1:7897');

--- a/apps/desktop/src/main/mcp-integrations/__tests__/computer.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/__tests__/computer.test.ts
@@ -13,6 +13,7 @@ const {
   mcpConnectMock,
   transportCloseMock,
   transportCtorMock,
+  outboundFetchMock,
   resolveDesktopOutboundProxyMock,
 } = vi.hoisted(() => ({
   existsSyncMock: vi.fn(),
@@ -23,6 +24,7 @@ const {
   mcpConnectMock: vi.fn(),
   transportCloseMock: vi.fn(),
   transportCtorMock: vi.fn(),
+  outboundFetchMock: vi.fn(),
   resolveDesktopOutboundProxyMock: vi.fn(),
 }));
 
@@ -53,6 +55,12 @@ function setPlatform(platform: NodeJS.Platform): void {
 
 vi.mock('node:child_process', () => ({
   spawn: spawnMock,
+}));
+
+// mock outbound-fetch:首次安装的进度预取会走 outboundFetch 拉 GitHub tag 列表,
+// 测试环境不应发真实网络请求。默认返回空 tag 列表(预取静默失败,不影响安装)。
+vi.mock('../maker-host/outbound-fetch', () => ({
+  outboundFetch: outboundFetchMock,
 }));
 
 vi.mock('node:fs', async () => {
@@ -322,6 +330,11 @@ describe('computer mcp integration', () => {
     resetAtMentionWindowCacheForTests();
     existsSyncMock.mockReset().mockReturnValue(false);
     spawnMock.mockReset();
+    // 预取默认返回空 tag 列表(ok 但无 refs),避免测试发真实网络请求
+    outboundFetchMock.mockReset().mockResolvedValue({
+      ok: true,
+      json: async () => [],
+    });
     driverStdinWrites.length = 0;
     readlinkSyncMock.mockReset();
     mcpCallToolMock.mockReset();
@@ -2601,6 +2614,28 @@ describe('computer mcp integration', () => {
       },
     });
     expect(spawnMock.mock.calls[0]?.[0]).toMatch(process.platform === 'win32' ? /powershell/i : '/bin/bash');
+  });
+
+  it('reports install progress through onProgress and ends with a done phase', async () => {
+    mockDriverSpawn({ stdout: 'installed\n' });
+    mockDriverSpawn({ stdout: 'cua-driver 0.5.8\n' });
+    mockDriverSpawn({ stdout: 'Cua Driver daemon is running\n' });
+    if (process.platform === 'darwin') {
+      mockDriverSpawn({
+        stdout:
+          '{"accessibility":true,"screen_recording":true,"screen_recording_capturable":true,"source":{"attribution":"driver-daemon"}}\n',
+      });
+    }
+
+    const progressEvents: Array<{ phase: string }> = [];
+    await expect(
+      installComputerDriver(undefined, undefined, (progress) => {
+        progressEvents.push(progress);
+      }),
+    ).resolves.toMatchObject({ ok: true });
+
+    // 安装结束后必须上报一次 done 阶段(渲染层据此清除进度状态)。
+    expect(progressEvents.some((p) => p.phase === 'done')).toBe(true);
   });
 
   it('passes the resolved system HTTP proxy to the POSIX installer', async () => {

--- a/apps/desktop/src/main/mcp-integrations/computer.ts
+++ b/apps/desktop/src/main/mcp-integrations/computer.ts
@@ -2608,52 +2608,83 @@ export async function installComputerDriver(
   targetVersion?: string,
   onProgress?: (progress: ComputerDriverUpdateProgress) => void,
 ): Promise<ComputerDriverInstallResult> {
-  // 并发保护:首次安装(无 targetVersion)时,若已有安装/更新在进行,
-  // join 同一个 in-flight(与更新路径共用同一把锁),避免并行安装导致
-  // 进度事件串扰。更新路径调用本函数时会传 targetVersion,不触发此分支。
+  // 并发保护:首次安装(无 targetVersion)也收进 in-flight(与更新路径共用
+  // driverUpdateInstallInFlight),若已有安装/更新在进行则 join,避免并行
+  // 安装导致进度事件串扰。更新路径调用本函数时传 targetVersion,单独
+  // 处理(它自己在 updateComputerDriver 里管理 in-flight)。
   if (!targetVersion && driverUpdateInstallInFlight) {
     const result = await driverUpdateInstallInFlight;
     onProgress?.({ phase: 'done', downloadedBytes: null, totalBytes: null });
     return result;
   }
-  // 首次安装(无 targetVersion)时,后台预取最新 release 的 asset 列表填充缓存,
-  // 让进度采样器能换算已下载/总字节。预取不 await(不阻塞安装启动),
-  // 结果异步到达;失败仅影响进度条精度(退化为不定态)。
-  // 注意不能用 fetchDriverUpdateCheck:它依赖本地已安装版本,首次安装时
-  // currentVersion 为空会直接返回 latestVersion:null。
-  if (!targetVersion && onProgress) {
-    void (async () => {
-      try {
-        const headers = getCuaDriverGithubHeaders();
-        const tagNames: string[] = [];
-        for (let page = 1; page <= CUA_DRIVER_REFS_MAX_PAGES; page += 1) {
-          const res = await outboundFetch(
-            `${CUA_DRIVER_TAG_REFS_URL}?per_page=${CUA_DRIVER_REFS_PAGE_SIZE}&page=${page}`,
-            { headers, signal: AbortSignal.timeout(UPDATE_CHECK_TIMEOUT_MS) },
-          );
-          if (!res.ok) break;
-          const batch = (await res.json()) as Array<{ ref?: unknown }>;
-          if (!Array.isArray(batch) || batch.length === 0) break;
-          for (const entry of batch) {
-            if (typeof entry?.ref === 'string' && entry.ref.startsWith('refs/tags/')) {
-              tagNames.push(entry.ref.slice('refs/tags/'.length));
+  if (!targetVersion) {
+    let stopSampler: () => void = () => {};
+    driverUpdateInstallInFlight = (async () => {
+      // 后台预取最新 release 的 asset 列表填充缓存(不阻塞安装启动)。
+      // 仅当需要上报进度(onProgress)时才预取;纯安装不需要。
+      // 注意不能用 fetchDriverUpdateCheck:它依赖本地已安装版本,首次安装时
+      // currentVersion 为空会直接返回 latestVersion:null。
+      if (onProgress) {
+        void (async () => {
+          try {
+            const headers = getCuaDriverGithubHeaders();
+            const tagNames: string[] = [];
+            for (let page = 1; page <= CUA_DRIVER_REFS_MAX_PAGES; page += 1) {
+              const res = await outboundFetch(
+                `${CUA_DRIVER_TAG_REFS_URL}?per_page=${CUA_DRIVER_REFS_PAGE_SIZE}&page=${page}`,
+                { headers, signal: AbortSignal.timeout(UPDATE_CHECK_TIMEOUT_MS) },
+              );
+              if (!res.ok) break;
+              const batch = (await res.json()) as Array<{ ref?: unknown }>;
+              if (!Array.isArray(batch) || batch.length === 0) break;
+              for (const entry of batch) {
+                if (typeof entry?.ref === 'string' && entry.ref.startsWith('refs/tags/')) {
+                  tagNames.push(entry.ref.slice('refs/tags/'.length));
+                }
+              }
+              if (batch.length < CUA_DRIVER_REFS_PAGE_SIZE) break;
             }
+            const latestVersion = pickLatestCuaDriverVersion(tagNames);
+            if (latestVersion) {
+              const release = await fetchInstallableCuaDriverRelease(
+                latestVersion,
+                outboundFetch,
+                headers,
+              );
+              if (release) cachedDriverReleaseAssets = release.assets;
+            }
+          } catch {
+            /* 预取失败仅影响进度条精度,不阻塞安装 */
           }
-          if (batch.length < CUA_DRIVER_REFS_PAGE_SIZE) break;
-        }
-        const latestVersion = pickLatestCuaDriverVersion(tagNames);
-        if (latestVersion) {
-          const release = await fetchInstallableCuaDriverRelease(
-            latestVersion,
-            outboundFetch,
-            headers,
-          );
-          if (release) cachedDriverReleaseAssets = release.assets;
-        }
-      } catch {
-        /* 预取失败仅影响进度条精度,不阻塞安装 */
+        })();
       }
-    })();
+      const res = await runInstallCommand(
+        (pid) => {
+          onSpawn?.(pid);
+          if (onProgress) {
+            stopSampler = startInstallProgressSampler(pid, onProgress);
+          }
+        },
+        targetVersion,
+      );
+      const status = await getComputerDriverStatus();
+      if (res.exitCode !== 0 || !status.installed) {
+        throw new ComputerDriverError(
+          res.stderr.trim() || res.stdout.trim() || `cua-driver installer exited ${res.exitCode}`,
+        );
+      }
+      return {
+        ok: true,
+        stdout: res.stdout,
+        stderr: res.stderr,
+        status,
+      };
+    })().finally(() => {
+      driverUpdateInstallInFlight = null;
+      stopSampler();
+      onProgress?.({ phase: 'done', downloadedBytes: null, totalBytes: null });
+    });
+    return driverUpdateInstallInFlight;
   }
   let stopSampler: () => void = () => {};
   try {

--- a/apps/desktop/src/main/mcp-integrations/computer.ts
+++ b/apps/desktop/src/main/mcp-integrations/computer.ts
@@ -2608,41 +2608,44 @@ export async function installComputerDriver(
   targetVersion?: string,
   onProgress?: (progress: ComputerDriverUpdateProgress) => void,
 ): Promise<ComputerDriverInstallResult> {
-  // 首次安装(无 targetVersion)时,先拉取最新 release 的 asset 列表填充缓存,
-  // 让进度采样器能换算已下载/总字节。失败不阻塞安装(进度条退化为不定态)。
+  // 首次安装(无 targetVersion)时,后台预取最新 release 的 asset 列表填充缓存,
+  // 让进度采样器能换算已下载/总字节。预取不 await(不阻塞安装启动),
+  // 结果异步到达;失败仅影响进度条精度(退化为不定态)。
   // 注意不能用 fetchDriverUpdateCheck:它依赖本地已安装版本,首次安装时
   // currentVersion 为空会直接返回 latestVersion:null。
   if (!targetVersion && onProgress) {
-    try {
-      const headers = getCuaDriverGithubHeaders();
-      const tagNames: string[] = [];
-      for (let page = 1; page <= CUA_DRIVER_REFS_MAX_PAGES; page += 1) {
-        const res = await outboundFetch(
-          `${CUA_DRIVER_TAG_REFS_URL}?per_page=${CUA_DRIVER_REFS_PAGE_SIZE}&page=${page}`,
-          { headers, signal: AbortSignal.timeout(UPDATE_CHECK_TIMEOUT_MS) },
-        );
-        if (!res.ok) break;
-        const batch = (await res.json()) as Array<{ ref?: unknown }>;
-        if (!Array.isArray(batch) || batch.length === 0) break;
-        for (const entry of batch) {
-          if (typeof entry?.ref === 'string' && entry.ref.startsWith('refs/tags/')) {
-            tagNames.push(entry.ref.slice('refs/tags/'.length));
+    void (async () => {
+      try {
+        const headers = getCuaDriverGithubHeaders();
+        const tagNames: string[] = [];
+        for (let page = 1; page <= CUA_DRIVER_REFS_MAX_PAGES; page += 1) {
+          const res = await outboundFetch(
+            `${CUA_DRIVER_TAG_REFS_URL}?per_page=${CUA_DRIVER_REFS_PAGE_SIZE}&page=${page}`,
+            { headers, signal: AbortSignal.timeout(UPDATE_CHECK_TIMEOUT_MS) },
+          );
+          if (!res.ok) break;
+          const batch = (await res.json()) as Array<{ ref?: unknown }>;
+          if (!Array.isArray(batch) || batch.length === 0) break;
+          for (const entry of batch) {
+            if (typeof entry?.ref === 'string' && entry.ref.startsWith('refs/tags/')) {
+              tagNames.push(entry.ref.slice('refs/tags/'.length));
+            }
           }
+          if (batch.length < CUA_DRIVER_REFS_PAGE_SIZE) break;
         }
-        if (batch.length < CUA_DRIVER_REFS_PAGE_SIZE) break;
+        const latestVersion = pickLatestCuaDriverVersion(tagNames);
+        if (latestVersion) {
+          const release = await fetchInstallableCuaDriverRelease(
+            latestVersion,
+            outboundFetch,
+            headers,
+          );
+          if (release) cachedDriverReleaseAssets = release.assets;
+        }
+      } catch {
+        /* 预取失败仅影响进度条精度,不阻塞安装 */
       }
-      const latestVersion = pickLatestCuaDriverVersion(tagNames);
-      if (latestVersion) {
-        const release = await fetchInstallableCuaDriverRelease(
-          latestVersion,
-          outboundFetch,
-          headers,
-        );
-        if (release) cachedDriverReleaseAssets = release.assets;
-      }
-    } catch {
-      /* 预取失败仅影响进度条精度,不阻塞安装 */
-    }
+    })();
   }
   let stopSampler: () => void = () => {};
   try {

--- a/apps/desktop/src/main/mcp-integrations/computer.ts
+++ b/apps/desktop/src/main/mcp-integrations/computer.ts
@@ -2606,20 +2606,71 @@ export async function getComputerDriverStatus(
 export async function installComputerDriver(
   onSpawn?: (pid: number | undefined) => void,
   targetVersion?: string,
+  onProgress?: (progress: ComputerDriverUpdateProgress) => void,
 ): Promise<ComputerDriverInstallResult> {
-  const res = await runInstallCommand(onSpawn, targetVersion);
-  const status = await getComputerDriverStatus();
-  if (res.exitCode !== 0 || !status.installed) {
-    throw new ComputerDriverError(
-      res.stderr.trim() || res.stdout.trim() || `cua-driver installer exited ${res.exitCode}`,
-    );
+  // 首次安装(无 targetVersion)时,先拉取最新 release 的 asset 列表填充缓存,
+  // 让进度采样器能换算已下载/总字节。失败不阻塞安装(进度条退化为不定态)。
+  // 注意不能用 fetchDriverUpdateCheck:它依赖本地已安装版本,首次安装时
+  // currentVersion 为空会直接返回 latestVersion:null。
+  if (!targetVersion && onProgress) {
+    try {
+      const headers = getCuaDriverGithubHeaders();
+      const tagNames: string[] = [];
+      for (let page = 1; page <= CUA_DRIVER_REFS_MAX_PAGES; page += 1) {
+        const res = await outboundFetch(
+          `${CUA_DRIVER_TAG_REFS_URL}?per_page=${CUA_DRIVER_REFS_PAGE_SIZE}&page=${page}`,
+          { headers, signal: AbortSignal.timeout(UPDATE_CHECK_TIMEOUT_MS) },
+        );
+        if (!res.ok) break;
+        const batch = (await res.json()) as Array<{ ref?: unknown }>;
+        if (!Array.isArray(batch) || batch.length === 0) break;
+        for (const entry of batch) {
+          if (typeof entry?.ref === 'string' && entry.ref.startsWith('refs/tags/')) {
+            tagNames.push(entry.ref.slice('refs/tags/'.length));
+          }
+        }
+        if (batch.length < CUA_DRIVER_REFS_PAGE_SIZE) break;
+      }
+      const latestVersion = pickLatestCuaDriverVersion(tagNames);
+      if (latestVersion) {
+        const release = await fetchInstallableCuaDriverRelease(
+          latestVersion,
+          outboundFetch,
+          headers,
+        );
+        if (release) cachedDriverReleaseAssets = release.assets;
+      }
+    } catch {
+      /* 预取失败仅影响进度条精度,不阻塞安装 */
+    }
   }
-  return {
-    ok: true,
-    stdout: res.stdout,
-    stderr: res.stderr,
-    status,
-  };
+  let stopSampler: () => void = () => {};
+  try {
+    const res = await runInstallCommand(
+      (pid) => {
+        onSpawn?.(pid);
+        if (onProgress) {
+          stopSampler = startInstallProgressSampler(pid, onProgress);
+        }
+      },
+      targetVersion,
+    );
+    const status = await getComputerDriverStatus();
+    if (res.exitCode !== 0 || !status.installed) {
+      throw new ComputerDriverError(
+        res.stderr.trim() || res.stdout.trim() || `cua-driver installer exited ${res.exitCode}`,
+      );
+    }
+    return {
+      ok: true,
+      stdout: res.stdout,
+      stderr: res.stderr,
+      status,
+    };
+  } finally {
+    stopSampler();
+    if (onProgress) onProgress({ phase: 'done', downloadedBytes: null, totalBytes: null });
+  }
 }
 
 /**
@@ -3059,7 +3110,9 @@ export function matchAssetSizeByFilename(
   assets: CuaDriverReleaseAsset[],
   filePath: string,
 ): number | null {
-  const base = path.basename(filePath);
+  // curl -o 的目标在下载期间是 `<name>.partial`,完成后才去掉后缀;
+  // 去掉 .partial 再匹配 release asset 名,否则下载期间永远匹配不上总字节。
+  const base = path.basename(filePath).replace(/\.partial$/, '');
   return assets.find((a) => a.name === base)?.size ?? null;
 }
 
@@ -3094,7 +3147,17 @@ function startInstallProgressSampler(
         const curlLine = out
           .split('\n')
           .map((line) => line.trim())
-          .find((line) => line.startsWith(`${rootPid} `) && line.includes('curl') && line.includes('-o'));
+          .find((line) => {
+            // 必须属于 rootPid 的进程组;命令必须是真实的 curl 可执行文件
+            // (排除 bash -c 内嵌脚本误匹配:bash 命令行可能包含 "curl" 字样,
+            // 但没有真实的 -o 下载目标)。
+            if (!line.startsWith(`${rootPid} `)) return false;
+            const command = line.slice(String(rootPid).length).trim();
+            return (
+              /^(?:\/usr\/bin\/|\/bin\/)?curl(\s|$)/.test(command) &&
+              line.includes('-o')
+            );
+          });
         if (curlLine) {
           const outFile = extractCurlOutputPath(curlLine);
           if (outFile && existsSync(outFile)) {

--- a/apps/desktop/src/main/mcp-integrations/computer.ts
+++ b/apps/desktop/src/main/mcp-integrations/computer.ts
@@ -2608,6 +2608,14 @@ export async function installComputerDriver(
   targetVersion?: string,
   onProgress?: (progress: ComputerDriverUpdateProgress) => void,
 ): Promise<ComputerDriverInstallResult> {
+  // 并发保护:首次安装(无 targetVersion)时,若已有安装/更新在进行,
+  // join 同一个 in-flight(与更新路径共用同一把锁),避免并行安装导致
+  // 进度事件串扰。更新路径调用本函数时会传 targetVersion,不触发此分支。
+  if (!targetVersion && driverUpdateInstallInFlight) {
+    const result = await driverUpdateInstallInFlight;
+    onProgress?.({ phase: 'done', downloadedBytes: null, totalBytes: null });
+    return result;
+  }
   // 首次安装(无 targetVersion)时,后台预取最新 release 的 asset 列表填充缓存,
   // 让进度采样器能换算已下载/总字节。预取不 await(不阻塞安装启动),
   // 结果异步到达;失败仅影响进度条精度(退化为不定态)。

--- a/apps/desktop/src/renderer/components/settings/ComputerUseSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/ComputerUseSection.tsx
@@ -633,9 +633,9 @@ export function ComputerUseSection({
 
   // driver 已安装时安静地查一次是否有新版本。失败或无更新都不渲染任何 UI,
   // 不弹 toast、不做启动检查、不后台轮询 —— 更新入口只是设置里的一个可选项。
-  // 更新期间订阅 main 广播的下载进度;phase='done' 或组件卸载时清空。
+  // 更新或首次安装期间订阅 main 广播的下载进度;phase='done' 或组件卸载时清空。
   useEffect(() => {
-    if (!driverUpdatePending) {
+    if (!driverUpdatePending && !computerInstallPending) {
       setDriverUpdateProgress(null);
       return;
     }
@@ -643,7 +643,7 @@ export function ComputerUseSection({
       setDriverUpdateProgress(progress.phase === 'done' ? null : progress);
     });
     return unsubscribe;
-  }, [driverUpdatePending]);
+  }, [driverUpdatePending, computerInstallPending]);
 
   // 等待 main 侧更新安装完成并刷新本地展示。更新的 in-flight 托管在 main:
   // 面板关闭它照常跑完;面板重开后本函数 join 同一个安装 Promise。
@@ -1527,7 +1527,7 @@ export function ComputerUseSection({
               />
             </button>
           </div>
-          {driverUpdatePending &&
+          {(driverUpdatePending || computerInstallPending) &&
           driverUpdateProgress?.phase === 'downloading' &&
           driverUpdateProgress.downloadedBytes !== null &&
           driverUpdateProgress.totalBytes ? (


### PR DESCRIPTION
## 这次改了什么

关联 issue: #2525

首次启用「自动操作电脑」(Computer Use) 时,cua-driver 自动安装只有固定 spinner 和"正在安装"文案,在下载慢(网络/代理问题)或等待安装锁时可能持续数分钟无任何进度信息,用户感知接近无限转圈。

本次改动让**首次安装也显示下载/安装进度**,复用更新路径已有的进度基础设施:

1. **`computer.ts`** — `installComputerDriver` 新增 `onProgress` 回调,通过 `startInstallProgressSampler` 采样 curl 下载字节,上报 `downloading / installing / done` 阶段
2. **`computer.ts`** — 首次安装前通过 GitHub tag 列表预取 release asset 列表,换算下载总字节(不依赖本地已安装版本)
3. **`computer.ts`** — 进度采样器匹配真实 curl 进程(排除 bash 内嵌脚本误匹配),总字节匹配去掉 `.partial` 后缀;安装失败/超时时也停止采样器并上报 `done`
4. **`register.ts`** — `install-driver` IPC 与 `update-driver` 一致,把进度广播到所有窗口
5. **`ComputerUseSection.tsx`** — 首次安装期间也订阅进度事件;下载阶段显示进度条(与更新路径共用)

## 怎么验证的

- ✅ `tsc --noEmit` 类型检查:0 错误
- ✅ `computer.test.ts`:138/138 通过(含新增 onProgress 测试)
- ✅ `computerUsePluginIpc.test.ts`:15/15 通过
- ✅ lint(改动文件):0 错误
- ✅ **真实环境实测**(macOS arm64 开发版,干净环境无 cua-driver):首次安装时进度条正常显示并随下载实时推进(实测 62.478%),下载完成后正确变为"已安装"

## 风险

- **低**。改动仅复用更新路径已有的进度机制,不改变安装逻辑本身;原有更新路径行为不变
- 已知说明:安装期间若网络波动(curl SSL 错误,如代理对 raw.githubusercontent.com 不稳),安装会失败并提示,重试后正常 —— 这是网络问题,非本次改动引入
- 进度条在下载启动后出现(点开关 → 预取 → 安装脚本启动 → curl 开始下载 → 采样器上报,约 1-3 秒延迟),符合预期