### PR TITLE
test(lizi-mcps): cover helper call_tool transport

### DIFF
--- a/packages/lizi-mcps/src/__tests__/lizi_xdtHelperMcpServer.test.ts
+++ b/packages/lizi-mcps/src/__tests__/lizi_xdtHelperMcpServer.test.ts
@@ -91,6 +91,8 @@ describe("cindy_helper MCP server", () => {
         message: "Continue the existing task",
         dispatcherSessionId: "dispatcher-session",
         title: undefined,
+        useWorktree: undefined,
+        workingDir: undefined,
       });
     } finally {
       await client.close();

--- a/packages/lizi-mcps/src/__tests__/lizi_xdtHelperMcpServer.test.ts
+++ b/packages/lizi-mcps/src/__tests__/lizi_xdtHelperMcpServer.test.ts
@@ -1,0 +1,100 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { describe, expect, it, vi } from "vitest";
+
+import { createXdtHelperMcpServer } from "../lizi_xdtHelperMcpServer.js";
+
+const TARGET_SESSION_ID = "11111111-1111-4111-8111-111111111111";
+
+function parsePayload(result: unknown): Record<string, unknown> {
+  const content = (
+    result as { content?: Array<{ type: string; text?: string }> }
+  ).content;
+  const first = content?.[0];
+  if (!first || first.type !== "text" || !first.text) {
+    throw new Error("tool result has no text content");
+  }
+  return JSON.parse(first.text) as Record<string, unknown>;
+}
+
+describe("cindy_helper MCP server", () => {
+  it("dispatches a discovered send_to_session call without dropping nested arguments", async () => {
+    const sendToSession = vi.fn(async () => ({
+      ok: true as const,
+      targetSessionId: TARGET_SESSION_ID,
+      agentKind: "codex" as const,
+      wakeKind: "resumed" as const,
+      targetTitle: "Issue follow-up",
+      targetLastUserSendAt: null,
+    }));
+    const server = createXdtHelperMcpServer(
+      { sendToSession },
+      {
+        agentKind: "codex",
+        workingDir: "/repo",
+        sessionId: "dispatcher-session",
+      },
+    );
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+    const client = new Client({
+      name: "cindy-helper-transport-test",
+      version: "0.0.0",
+    });
+
+    await Promise.all([
+      server.connect(serverTransport),
+      client.connect(clientTransport),
+    ]);
+    try {
+      const topLevelTools = await client.listTools();
+      expect(topLevelTools.tools.map((tool) => tool.name).sort()).toEqual([
+        "call_tool",
+        "list_tools",
+      ]);
+
+      const discovered = parsePayload(
+        await client.callTool({
+          name: "list_tools",
+          arguments: { category: "handoff" },
+        }),
+      );
+      expect(discovered).toMatchObject({
+        ok: true,
+        category: "handoff",
+      });
+      const discoveredTools = discovered.tools as Array<{ name: string }>;
+      expect(discoveredTools.map((tool) => tool.name)).toContain(
+        "send_to_session",
+      );
+
+      const result = await client.callTool({
+        name: "call_tool",
+        arguments: {
+          name: "send_to_session",
+          args: {
+            target_session_id: TARGET_SESSION_ID,
+            message: "Continue the existing task",
+          },
+        },
+      });
+
+      expect(result.isError).not.toBe(true);
+      expect(parsePayload(result)).toMatchObject({
+        ok: true,
+        target_session_id: TARGET_SESSION_ID,
+        wake_kind: "resumed",
+      });
+      expect(sendToSession).toHaveBeenCalledOnce();
+      expect(sendToSession).toHaveBeenCalledWith({
+        targetSessionId: TARGET_SESSION_ID,
+        message: "Continue the existing task",
+        dispatcherSessionId: "dispatcher-session",
+        title: undefined,
+      });
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+});


### PR DESCRIPTION
## 这次改了什么

### 摘要

Add an end-to-end MCP transport regression for cindy_helper nested tool dispatch.

### 变更类型

- [ ] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [x] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- Related issue: Related to #1765
- Included: The test discovers send_to_session through list_tools, invokes it through call_tool, and verifies that nested arguments reach the host callback unchanged.
- Not included: Work outside the listed files.
- User-visible change: None. This pull request changes tests only.
- Breaking change: No.

### Remote and mobile adaptation

- SSH remote workspaces: Not affected.
- Device link: No channel or protocol change.
- Mobile: Not affected.

### UI 变化

Not applicable. No visual, interaction, or copy change.

- 引用的设计规范：Not applicable.

## 怎么验证的

### 自动验证

```text
pnpm --filter @cindy/mcps exec vitest run src/__tests__/lizi_xdtHelperMcpServer.test.ts
Result: passed.

pnpm --filter @cindy/mcps run --if-present typecheck
Result: passed.

pnpm test:unit
Result: passed.

pnpm check:dco
Result: passed.
```

### 手工验证

Not run.

### 未执行的验证

No additional manual flow was run.

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- Impact: lizi-mcps transport tests only; runtime behavior is unchanged.
- Risk: No known risks.
- Rollback: Revert this commit. No data migration or cleanup is required.

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因