### PR TITLE
fix(desktop): 恢复延期重启后的排队输入

### DIFF
--- a/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
@@ -6068,6 +6068,201 @@ describe('AgentInputCoordinator crash-recovery queue snapshots (issue #761)', ()
     expect(latestSnapshotClientIds(h.persistQueueSnapshot)).toEqual([]);
   });
 
+  it('replays a wake that races an empty queue restore without duplicate dispatch', async () => {
+    const h = createHarness();
+    const sid = 'snapshot-empty-restore-wake-race';
+    const restoreGate = deferred<AgentInputQueuedMessage[]>();
+    let restartPending = true;
+    h.setLoadQueueSnapshot(() => restoreGate.promise);
+    h.setHasPendingCredentialSwitch(() => restartPending);
+
+    const restoring = h.coordinator.ensureQueueRestored(sid);
+    h.coordinator.enqueue(sid, makeItem('q-1', 'queued during deferred restart'));
+    await flush();
+    expect(latestProjection(h.projections).pendingQueue.map((item) => item.clientId)).toEqual([
+      'q-1',
+    ]);
+    expect(h.sendToAgent).not.toHaveBeenCalled();
+
+    restartPending = false;
+    h.coordinator.wakeSession(sid, 'deferred-codex-restart-applied');
+    await flush();
+    expect(h.sendToAgent).not.toHaveBeenCalled();
+
+    restoreGate.resolve([]);
+    await restoring;
+    await flush();
+
+    expect(h.sendToAgent).toHaveBeenCalledTimes(1);
+    expect(h.sendToAgent.mock.calls[0]?.[1]).toEqual({
+      type: 'user',
+      content: 'queued during deferred restart',
+    });
+    await flush();
+    expect(h.sendToAgent).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not dispatch an in-memory queue item removed before an empty restore finishes', async () => {
+    const h = createHarness();
+    const sid = 'snapshot-empty-restore-remove-race';
+    const restoreGate = deferred<AgentInputQueuedMessage[]>();
+    h.setLoadQueueSnapshot(() => restoreGate.promise);
+
+    const restoring = h.coordinator.ensureQueueRestored(sid);
+    const item = makeItem('q-1', 'cancel before restore');
+    h.coordinator.enqueue(sid, item);
+    await flush();
+    h.coordinator.remove(sid, item.clientId);
+    await flush();
+
+    restoreGate.resolve([]);
+    await restoring;
+    await flush();
+
+    expect(h.sendToAgent).not.toHaveBeenCalled();
+    expect(latestProjection(h.projections).pendingQueue).toEqual([]);
+    expect(h.onDiscardedQueuedMessage).toHaveBeenCalledWith(
+      sid,
+      expect.objectContaining({ clientId: item.clientId, text: item.text }),
+    );
+  });
+
+  it('drains only the post-clear generation after clearSession wins an in-flight restore', async () => {
+    const h = createHarness();
+    const sid = 'snapshot-empty-restore-clear-race';
+    const restoreGate = deferred<AgentInputQueuedMessage[]>();
+    h.setLoadQueueSnapshot(() => restoreGate.promise);
+
+    const generation = h.coordinator.getGeneration(sid);
+    const restoring = h.coordinator.ensureQueueRestored(sid);
+    h.coordinator.enqueue(sid, makeItem('q-old', 'stale generation'));
+    await flush();
+    h.coordinator.clearSession(sid);
+    expect(h.coordinator.getGeneration(sid)).toBe(generation + 1);
+    h.coordinator.enqueue(sid, makeItem('q-new', 'post-clear generation'));
+    await flush();
+    expect(h.sendToAgent).not.toHaveBeenCalled();
+
+    restoreGate.resolve([]);
+    await restoring;
+    await flush();
+
+    expect(h.sendToAgent).toHaveBeenCalledTimes(1);
+    expect(h.sendToAgent.mock.calls[0]?.[1]).toEqual({
+      type: 'user',
+      content: 'post-clear generation',
+    });
+    expect(latestProjection(h.projections).pendingQueue).toEqual([]);
+    await flush();
+    expect(h.sendToAgent).toHaveBeenCalledTimes(1);
+  });
+
+  it('drains only the post-clear generation when durable restore de-duplication is in flight', async () => {
+    const h = createHarness();
+    const sid = 'snapshot-dedup-restore-clear-race';
+    const dedupStarted = deferred<void>();
+    const dedupGate = deferred<Set<string>>();
+    h.setLoadQueueSnapshot(async () => [makeItem('r-old', 'restored stale generation')]);
+    h.setGetPersistedClientIds(() => {
+      dedupStarted.resolve();
+      return dedupGate.promise;
+    });
+
+    const generation = h.coordinator.getGeneration(sid);
+    const restoring = h.coordinator.ensureQueueRestored(sid);
+    await dedupStarted.promise;
+    h.coordinator.enqueue(sid, makeItem('q-old', 'queued stale generation'));
+    await flush();
+    h.coordinator.clearSession(sid);
+    expect(h.coordinator.getGeneration(sid)).toBe(generation + 1);
+    h.coordinator.enqueue(sid, makeItem('q-new', 'post-clear after de-dup'));
+    await flush();
+    expect(h.sendToAgent).not.toHaveBeenCalled();
+
+    dedupGate.resolve(new Set());
+    await restoring;
+    await flush();
+
+    expect(h.sendToAgent).toHaveBeenCalledTimes(1);
+    expect(h.sendToAgent.mock.calls[0]?.[1]).toEqual({
+      type: 'user',
+      content: 'post-clear after de-dup',
+    });
+    expect(latestProjection(h.projections).pendingQueue).toEqual([]);
+    expect(h.onDiscardedQueuedMessage).toHaveBeenCalledWith(
+      sid,
+      expect.objectContaining({ clientId: 'r-old' }),
+    );
+    await flush();
+    expect(h.sendToAgent).toHaveBeenCalledTimes(1);
+  });
+
+  it('drains only the post-clear generation when snapshot loading rejects after clearSession', async () => {
+    const h = createHarness();
+    const sid = 'snapshot-load-reject-clear-race';
+    const restoreGate = deferred<AgentInputQueuedMessage[]>();
+    h.setLoadQueueSnapshot(() => restoreGate.promise);
+
+    const generation = h.coordinator.getGeneration(sid);
+    const restoring = h.coordinator.ensureQueueRestored(sid);
+    h.coordinator.enqueue(sid, makeItem('q-old', 'queued stale generation'));
+    await flush();
+    h.coordinator.clearSession(sid);
+    expect(h.coordinator.getGeneration(sid)).toBe(generation + 1);
+    h.coordinator.enqueue(sid, makeItem('q-new', 'post-clear after load failure'));
+    await flush();
+    expect(h.sendToAgent).not.toHaveBeenCalled();
+
+    restoreGate.reject(new Error('snapshot load failed'));
+    await expect(restoring).rejects.toThrow('snapshot load failed');
+    await flush();
+
+    expect(h.sendToAgent).toHaveBeenCalledTimes(1);
+    expect(h.sendToAgent.mock.calls[0]?.[1]).toEqual({
+      type: 'user',
+      content: 'post-clear after load failure',
+    });
+    expect(latestProjection(h.projections).pendingQueue).toEqual([]);
+    await flush();
+    expect(h.sendToAgent).toHaveBeenCalledTimes(1);
+  });
+
+  it('drains only the post-clear generation when durable de-duplication rejects after clearSession', async () => {
+    const h = createHarness();
+    const sid = 'snapshot-dedup-reject-clear-race';
+    const dedupStarted = deferred<void>();
+    const dedupGate = deferred<Set<string>>();
+    h.setLoadQueueSnapshot(async () => [makeItem('r-old', 'restored stale generation')]);
+    h.setGetPersistedClientIds(() => {
+      dedupStarted.resolve();
+      return dedupGate.promise;
+    });
+
+    const generation = h.coordinator.getGeneration(sid);
+    const restoring = h.coordinator.ensureQueueRestored(sid);
+    await dedupStarted.promise;
+    h.coordinator.enqueue(sid, makeItem('q-old', 'queued stale generation'));
+    await flush();
+    h.coordinator.clearSession(sid);
+    expect(h.coordinator.getGeneration(sid)).toBe(generation + 1);
+    h.coordinator.enqueue(sid, makeItem('q-new', 'post-clear after de-dup failure'));
+    await flush();
+    expect(h.sendToAgent).not.toHaveBeenCalled();
+
+    dedupGate.reject(new Error('durable de-duplication failed'));
+    await expect(restoring).rejects.toThrow('durable de-duplication failed');
+    await flush();
+
+    expect(h.sendToAgent).toHaveBeenCalledTimes(1);
+    expect(h.sendToAgent.mock.calls[0]?.[1]).toEqual({
+      type: 'user',
+      content: 'post-clear after de-dup failure',
+    });
+    expect(latestProjection(h.projections).pendingQueue).toEqual([]);
+    await flush();
+    expect(h.sendToAgent).toHaveBeenCalledTimes(1);
+  });
+
   it('restores a quiet session as a paused queue and only drains after explicit resume', async () => {
     const h = createHarness();
     const sid = 'snapshot-restore-paused';
@@ -6454,13 +6649,15 @@ describe('AgentInputCoordinator crash-recovery queue snapshots (issue #761)', ()
     });
 
     await h.coordinator.ensureQueueRestored(sid).catch(() => undefined);
-    // 读失败:不标记已恢复,收口点保持关闭。
-    h.setRunning(true);
+    // 读失败:不标记已恢复,既不打开持久化闸门,也不唤醒本可立即派发的内存队列。
     h.coordinator.enqueue(sid, makeItem('q-1', 'first'));
     await flush();
+    expect(h.sendToAgent).not.toHaveBeenCalled();
+    expect(latestProjection(h.projections).pendingQueue.map((q) => q.clientId)).toEqual(['q-1']);
     expect(h.persistQueueSnapshot).not.toHaveBeenCalled();
 
     // 下一个入口重试成功:恢复项 prepend 并开闸。
+    h.setRunning(true);
     await h.coordinator.ensureQueueRestored(sid);
     await flush();
     expect(attempts).toBe(2);
@@ -6469,6 +6666,23 @@ describe('AgentInputCoordinator crash-recovery queue snapshots (issue #761)', ()
       'q-1',
     ]);
     expect(latestSnapshotClientIds(h.persistQueueSnapshot)).toEqual(['r-1', 'q-1']);
+  });
+
+  it('keeps the persistence gate closed when durable restore de-duplication fails', async () => {
+    const h = createHarness();
+    const sid = 'snapshot-dedup-failure';
+    h.setLoadQueueSnapshot(async () => [makeItem('r-1', 'not safely de-duplicated')]);
+    h.setGetPersistedClientIds(async () => {
+      throw new Error('db not ready');
+    });
+
+    await expect(h.coordinator.ensureQueueRestored(sid)).rejects.toThrow('db not ready');
+    h.coordinator.enqueue(sid, makeItem('q-1', 'queued while restore is unsafe'));
+    await flush();
+
+    expect(h.sendToAgent).not.toHaveBeenCalled();
+    expect(latestProjection(h.projections).pendingQueue.map((q) => q.clientId)).toEqual(['q-1']);
+    expect(h.persistQueueSnapshot).not.toHaveBeenCalled();
   });
 
   it('skips the redundant snapshot write when memory state already matches the loaded snapshot', async () => {

--- a/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
+++ b/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
@@ -957,9 +957,26 @@ export class AgentInputCoordinator {
     this.restoreAttempted.add(sessionId);
     const existing = this.queueRestorePromises.get(sessionId);
     if (existing) return existing;
-    const promise = this.restoreQueueSnapshot(sessionId).finally(() => {
-      this.queueRestorePromises.delete(sessionId);
-    });
+    const restoreState = this.getState(sessionId);
+    const restoreGeneration = restoreState.generation;
+    let restoreFailed = false;
+    const promise = this.restoreQueueSnapshot(sessionId)
+      .catch((err) => {
+        restoreFailed = true;
+        throw err;
+      })
+      .finally(() => {
+        this.queueRestorePromises.delete(sessionId);
+        if (!restoreFailed) return;
+        const currentState = this.getState(sessionId);
+        const restoreWasSuperseded =
+          currentState !== restoreState || currentState.generation !== restoreGeneration;
+        // 同代失败必须继续 fail closed;clearSession 已让新代成为 restored 权威态时,
+        // 旧 restore 只剩 drain gate。先删 gate,再让新代重新经过现有调度门禁。
+        if (restoreWasSuperseded && this.restoredQueueSessions.has(sessionId)) {
+          this.scheduleDrain(sessionId, 'queue-snapshot-restore-failed-superseded');
+        }
+      });
     this.queueRestorePromises.set(sessionId, promise);
     return promise;
   }
@@ -986,6 +1003,7 @@ export class AgentInputCoordinator {
       this.restoredQueueSessions.add(sessionId);
       this.queueRestorePromises.delete(sessionId);
       this.maybePersistQueueSnapshot(sessionId);
+      if (!state.queuePaused) this.scheduleDrain(sessionId, 'queue-snapshot-restore-superseded');
       return;
     }
     // 去重:内存态 + DB 已落库的消息。DB 查询覆盖"消息已被 agent 接受落库但删快照
@@ -1010,6 +1028,8 @@ export class AgentInputCoordinator {
             this.deps.onDiscardedQueuedMessage?.(sessionId, item);
           }
           this.maybePersistQueueSnapshot(sessionId);
+          if (!currentState.queuePaused)
+            this.scheduleDrain(sessionId, 'queue-snapshot-restore-superseded');
           return;
         }
         for (const cid of persisted) existingIds.add(cid);
@@ -1085,6 +1105,9 @@ export class AgentInputCoordinator {
       // 快照为空 / 全部与内存态重复:同步一次收口点,让内存态成为权威快照。
       this.queueRestorePromises.delete(sessionId);
       this.maybePersistQueueSnapshot(sessionId);
+      // restore gate 可能已经吞掉了门解除时的唯一一次 wakeSession;簿记完成后
+      // 重新走 generation-aware drain,让恢复窗口内已有的内存队列获得新唤醒源。
+      if (!state.queuePaused) this.scheduleDrain(sessionId, 'queue-snapshot-restored');
       return;
     }
     // 静默会话(无排队、无在飞 turn)恢复为**暂停中的队列**:重启后不自动替用户


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 deferred Codex restart 恢复期间，排队输入可能永久留在队列中、直到下一次无关 wake 才继续的问题。

根因是 enqueue / wake 在 queue restore promise 存在时会被 restore gate 吞掉，而旧 generation 的 restore 在 clearSession 后成功、返回空快照或失败退出时，没有为已经建立的新 generation 重新调度 drain。本 PR 在 restore 的 generation-aware 收口点复用现有 scheduleDrain，并保持同 generation 的 restore 失败继续 fail-closed。

Fixes #2506

### 变更类型

- [ ] feat 新功能
- [x] fix 缺陷修复
- [ ] refactor / perf 重构或性能优化
- [ ] docs / test / chore 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Fixes #2506
- 本 PR 包含：
  - restore 返回空队列后重新调度当前 session drain。
  - clearSession 建立新 generation 后，旧 generation 的 load / durable de-dup restore 成功或失败收口时，唤醒当前 generation。
  - 仅当失败的 restore 已被新 generation 取代且当前 generation 已恢复时调度；同 generation 失败保持 fail-closed。
  - 增加确定性竞态回归测试，覆盖 remove、clear、load failure、durable de-dup failure、duplicate exact-once 与旧项不派发。
- 明确不包含：
  - 不改变 credential、recovery、acceptance 或 quiet-paused 门禁。
  - 不修改 queue schema、持久化格式、IPC channel、device-link 或 Mobile 协议。
  - 不改变正常路径的发送顺序与 exact-once 语义。
- 用户可见变化：
  - deferred restart / clear 恢复竞态下，新输入能够自动继续投递，不再依赖下一次无关 wake。
- 是否存在 breaking change：无。

### UI 变化

不涉及 UI、样式或用户可见文案。

## 怎么验证的

### 自动验证

~~~text
pnpm test:unit --workspace-concurrency=1
结果：通过
- runner self-tests：376 passed / 8 skipped
- apps/desktop unit：通过（1387.8s）
- apps/mobile unit：通过（82.2s）
- 全部 required workspace unit：通过

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --filter desktop exec vitest run src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
结果：275 / 275 tests passed

pnpm check:dco
结果：1 commit signed off

git diff --check
结果：通过
~~~

完整单测在与 staged tree 完全一致的物理 J 盘验证 worktree 中运行；验证 tree 与 staged tree 均为 104f367f72d6d4e71747855c2f668ac725dcb90f。使用 Python 3.10，并将该测试进程树限制为 2 个可用 CPU，以规避本机 Python 2.7 PATH 与高并发冷启动抖动；未跳过、删除或弱化测试。

### 手工验证

未执行真实 Codex credential / restart / crash 流程；竞态时序由可控 restore promise 的单元测试覆盖。

### 未执行的验证

- 未使用真实 Codex 账号触发 deferred restart。
- 未执行 Desktop 打包应用 E2E。
- 未执行真实 device-link / Mobile 远程投递 E2E；本 PR 未修改这些协议与投影。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：异步恢复、generation 切换与队列 exact-once 时序

### 影响与回滚

- 影响范围：
  - 仅 Desktop main 进程 agent input coordinator 的 restore 收口调度。
  - 新增 drain 仍经过既有 generation、quiet-paused、credential、recovery 与 acceptance gates。
  - 不修改持久化格式、协议或已有错误处理口径。
- 回滚 / 降级方式：
  - 可直接 revert 本 PR。
  - 回滚后恢复既有行为：命中竞态的新输入可能继续等待下一次 wake，但不会改变已持久化队列内容。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（git commit -s）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本 PR 无需产品文档变更）
- [x] 已确认测试结果或说明未执行原因