### PR TITLE
fix(desktop): seal recovered predecessor plans

### DIFF
--- a/apps/desktop/src/main/__tests__/fork.test.ts
+++ b/apps/desktop/src/main/__tests__/fork.test.ts
@@ -27,10 +27,14 @@ const UUID_V4_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9
 // (确认 fork 把对的 sourceSdkSessionId / upToMessageId / title / workingDir 传下去)
 // 和返回值 (uuidMap 决定 messages.agentMeta remap 结果)。
 const forkSdkSessionMock = vi.fn();
+const drainPersistQueueMock = vi.fn(async () => {});
 vi.mock('../maker-host/index.js', () => ({
   getMaker: () => ({
     forkSdkSession: forkSdkSessionMock,
   }),
+}));
+vi.mock('../messagePersistBroadcaster.js', () => ({
+  drainPersistQueue: drainPersistQueueMock,
 }));
 
 // fake drizzle: select 链返回 thenable。写入侧 MR2.2 后走 DbClient.tx。
@@ -93,6 +97,7 @@ beforeEach(async () => {
   queryMock.mockReset();
   queryMock.mockResolvedValue([]);
   forkSdkSessionMock.mockReset();
+  drainPersistQueueMock.mockClear();
   // 默认空 uuidMap 让 agentMeta 字段被去掉 (无映射)。具体测试按需 override。
   forkSdkSessionMock.mockResolvedValue({
     newSdkSessionId: 'sdk-new-session-uuid',
@@ -187,6 +192,25 @@ async function writeClaudeJsonlInConfigDir(
 // ── tests ──────────────────────────────────────────────────────────────────
 
 describe('forkSessionAtMessage', () => {
+  it('waits for pending main persistence before reading the fork snapshot', async () => {
+    let releaseDrain!: () => void;
+    drainPersistQueueMock.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseDrain = resolve;
+        }),
+    );
+    const selectsBeforeFork = fakeDb.select.mock.calls.length;
+
+    const pending = forkSessionAtMessage('src-session', 'target-user');
+    await vi.waitFor(() => expect(drainPersistQueueMock).toHaveBeenCalledTimes(1));
+    expect(fakeDb.select.mock.calls.length).toBe(selectsBeforeFork);
+
+    releaseDrain();
+    await expect(pending).rejects.toMatchObject({ code: 'SOURCE_NOT_FOUND' });
+    expect(fakeDb.select.mock.calls.length).toBeGreaterThan(selectsBeforeFork);
+  });
+
   it('happy path: fork copies prior messages, calls maker.forkSdkSession with assistant uuid, seeds context snapshot', async () => {
     const target = makeMessageRow({ id: 'target-user', role: 'user', createdAt: 3000 });
     const priorAssistant = makeMessageRow({
@@ -227,6 +251,7 @@ describe('forkSessionAtMessage', () => {
 
     const result = await forkSessionAtMessage('src-session', 'target-user');
 
+    expect(drainPersistQueueMock).toHaveBeenCalledTimes(1);
     // maker 入参: 用最近一条带 uuid 的 assistant
     expect(forkSdkSessionMock).toHaveBeenCalledWith('claude-code', {
       sourceSdkSessionId: 'sdk-uuid-source',

--- a/apps/desktop/src/main/__tests__/makerEventHotPathOrdering.test.ts
+++ b/apps/desktop/src/main/__tests__/makerEventHotPathOrdering.test.ts
@@ -27,10 +27,16 @@ describe('maker:event hot path ordering', () => {
     const lifecycleStart = wireSessionSource.indexOf(
       'onTerminal: ({ turnGeneration, event, isCurrentGeneration }) => {',
     );
+    const remoteReturnIndex = wireSessionSource.indexOf(
+      'if (session.remoteHostId) return;',
+      lifecycleStart,
+    );
     const recoveryDoneIndex = wireSessionSource.indexOf('recoveryPlanSettlement.settleDone(');
 
     expect(lifecycleStart).toBeGreaterThanOrEqual(0);
+    expect(remoteReturnIndex).toBeGreaterThan(lifecycleStart);
     expect(recoveryDoneIndex).toBeGreaterThan(lifecycleStart);
+    expect(recoveryDoneIndex).toBeLessThan(remoteReturnIndex);
     expect(wireSessionSource.slice(recoveryDoneIndex, recoveryDoneIndex + 700)).toContain(
       'turnGeneration',
     );
@@ -39,6 +45,7 @@ describe('maker:event hot path ordering', () => {
     );
     const recoveryErrorIndex = wireSessionSource.indexOf('recoveryPlanSettlement.settleError(');
     expect(recoveryErrorIndex).toBeGreaterThanOrEqual(0);
+    expect(recoveryErrorIndex).toBeLessThan(remoteReturnIndex);
     expect(wireSessionSource.slice(recoveryErrorIndex, recoveryErrorIndex + 700)).toContain(
       'turnGeneration',
     );
@@ -55,6 +62,38 @@ describe('maker:event hot path ordering', () => {
     expect(source).toContain('persist: persistUserMessage');
     expect(source).toContain('providerGeneration,');
     expect(source).toContain('recoveryPlanSettlement.teardown(sessionId);');
+  });
+
+  it('keeps an already-dispatched recovery settlement while follow-up input queues', () => {
+    const coordinatorSource = extractInputCoordinatorSource();
+    const userEnqueueSource = coordinatorSource.match(
+      /onUserEnqueue: \(sessionId\) => \{[\s\S]*?\n {4}\},\n {4}onAutomaticEnqueue:/,
+    )?.[0];
+    const automaticEnqueueSource = coordinatorSource.match(
+      /onAutomaticEnqueue: \(sessionId\) => \{[\s\S]*?\n {4}\},\n {4}onRejectedUserTurn:/,
+    )?.[0];
+
+    expect(userEnqueueSource).toBeTruthy();
+    expect(automaticEnqueueSource).toBeTruthy();
+    expect(userEnqueueSource).not.toContain('recoveryPlanSettlement.teardown(sessionId);');
+    expect(automaticEnqueueSource).not.toContain('recoveryPlanSettlement.teardown(sessionId);');
+    expect(coordinatorSource).toContain(
+      'recoveryPlanSettlement.cancelUndispatched(sessionId, item.clientId);',
+    );
+  });
+
+  it('drains pending message writes before reading a retry recovery snapshot', () => {
+    const coordinatorSource = extractInputCoordinatorSource();
+    const snapshotReaderSource = coordinatorSource.match(
+      /getRecoveryContextSnapshot: async \(sessionId, userClientId\) => \{[\s\S]*?\n {4}\},/,
+    )?.[0];
+
+    expect(snapshotReaderSource).toBeTruthy();
+    expectOrder(
+      snapshotReaderSource ?? '',
+      'await drainPersistQueue();',
+      'return getRecoveryContextSnapshot(sessionId, userClientId);',
+    );
   });
 
   it('rewires a replacement Session instance that retains the same business id', () => {
@@ -979,6 +1018,17 @@ function extractWireSessionSource(): string {
     throw new Error('wireSessionToIpc source block not found');
   }
   return wireSessionSource;
+}
+
+function extractInputCoordinatorSource(): string {
+  const coordinatorStart = source.indexOf('const inputCoordinator: AgentInputCoordinator =');
+  const coordinatorEnd = source.indexOf(
+    '\n  agentInputCoordinatorHolder = inputCoordinator;',
+    coordinatorStart,
+  );
+  expect(coordinatorStart).toBeGreaterThanOrEqual(0);
+  expect(coordinatorEnd).toBeGreaterThan(coordinatorStart);
+  return source.slice(coordinatorStart, coordinatorEnd);
 }
 
 function extractInstallDesktopInteractionListenerSource(): string {

--- a/apps/desktop/src/main/__tests__/makerEventHotPathOrdering.test.ts
+++ b/apps/desktop/src/main/__tests__/makerEventHotPathOrdering.test.ts
@@ -22,6 +22,41 @@ const goalStorageSourcePath = resolve(__dirname, '..', 'goal-host', 'storage.ts'
 const goalStorageSource = readFileSync(goalStorageSourcePath, 'utf8').replace(/\r\n?/g, '\n');
 
 describe('maker:event hot path ordering', () => {
+  it('settles recovery plans only from the owning current provider generation', () => {
+    const wireSessionSource = extractWireSessionSource();
+    const lifecycleStart = wireSessionSource.indexOf(
+      'onTerminal: ({ turnGeneration, event, isCurrentGeneration }) => {',
+    );
+    const recoveryDoneIndex = wireSessionSource.indexOf('recoveryPlanSettlement.settleDone(');
+
+    expect(lifecycleStart).toBeGreaterThanOrEqual(0);
+    expect(recoveryDoneIndex).toBeGreaterThan(lifecycleStart);
+    expect(wireSessionSource.slice(recoveryDoneIndex, recoveryDoneIndex + 700)).toContain(
+      'turnGeneration',
+    );
+    expect(wireSessionSource.slice(recoveryDoneIndex, recoveryDoneIndex + 700)).toContain(
+      'isCurrentGeneration',
+    );
+    const recoveryErrorIndex = wireSessionSource.indexOf('recoveryPlanSettlement.settleError(');
+    expect(recoveryErrorIndex).toBeGreaterThanOrEqual(0);
+    expect(wireSessionSource.slice(recoveryErrorIndex, recoveryErrorIndex + 700)).toContain(
+      'turnGeneration',
+    );
+    expect(wireSessionSource.slice(recoveryErrorIndex, recoveryErrorIndex + 700)).toContain(
+      'isCurrentGeneration',
+    );
+  });
+
+  it('routes recovery user persistence through the pre-await plan closure boundary', () => {
+    expect(source).toContain('recoveryPlanSettlement.persistUserBoundary({');
+    expect(source).toContain(
+      'closePlanUpdates: () => closeCodexPlanUpdatesForRecovery(sessionId, predecessorPlan)',
+    );
+    expect(source).toContain('persist: persistUserMessage');
+    expect(source).toContain('providerGeneration,');
+    expect(source).toContain('recoveryPlanSettlement.teardown(sessionId);');
+  });
+
   it('rewires a replacement Session instance that retains the same business id', () => {
     const wireSessionSource = extractWireSessionSource();
 

--- a/apps/desktop/src/main/__tests__/messagePersistBroadcaster.test.ts
+++ b/apps/desktop/src/main/__tests__/messagePersistBroadcaster.test.ts
@@ -58,6 +58,9 @@ import {
 import {
   onToolUseEvent,
   persistCodexPlanOnDone,
+  persistRecoveredCodexPlanOnDone,
+  closeCodexPlanUpdatesForRecovery,
+  isCodexPlanUpdateClosed,
   persistCodexPlanOnTerminalError,
   onToolResultEvent,
   onToolResultFullEvent,
@@ -84,6 +87,7 @@ import {
   saveTurnStartedAtForDeferred,
   preserveTurnPersistStateForBackground,
 } from '../messagePersistBroadcaster.js';
+import { RecoveryPlanSettlement } from '../maker-ipc/recoveryPlanSettlement.js';
 
 const SESSION = 'sess-tr';
 const FULL =
@@ -271,6 +275,94 @@ describe('update_plan tool_use persistence', () => {
       terminalPlanSnapshot: true,
       terminalPlanAtMs: expect.any(Number),
     });
+  });
+
+  it('seals an exact predecessor plan row after a successful recovery turn', async () => {
+    vi.mocked(updateMessageContent).mockResolvedValueOnce({
+      clientId: 'plan-row-client',
+    } as never);
+    expect(
+      persistRecoveredCodexPlanOnDone(SESSION, {
+        clientId: 'plan-row-client',
+        toolUseId: 'plan:failed-turn',
+        turnId: 'failed-turn',
+        input: { plan: [{ step: 'Finish recovery', status: 'in_progress' }] },
+      }),
+    ).toBe(true);
+    expect(isCodexPlanUpdateClosed(SESSION, 'plan:failed-turn')).toBe(true);
+
+    await flushWrites();
+    expect(updateMessageContent).toHaveBeenCalledWith(SESSION, 'plan-row-client', {
+      toolUseId: 'plan:failed-turn',
+      toolName: 'update_plan',
+      input: { plan: [{ step: 'Finish recovery', status: 'in_progress' }] },
+      terminalPlanSnapshot: true,
+      terminalPlanAtMs: expect.any(Number),
+    });
+  });
+
+  it('rejects late update_plan events once recovery owns the predecessor plan', () => {
+    closeCodexPlanUpdatesForRecovery(SESSION, {
+      clientId: 'plan-row-client',
+      toolUseId: 'plan:failed-turn',
+      turnId: 'failed-turn',
+      input: { plan: [{ step: 'Finish recovery', status: 'in_progress' }] },
+    });
+
+    expect(isCodexPlanUpdateClosed(SESSION, 'plan:failed-turn')).toBe(true);
+    expect(
+      onToolUseEvent(
+        SESSION,
+        {
+          toolUseId: 'plan:failed-turn',
+          toolName: 'update_plan',
+          input: { plan: [{ step: 'Finish recovery', status: 'pending' }] },
+        },
+        null,
+      ),
+    ).toBeUndefined();
+  });
+
+  it('closes predecessor updates while the recovery user durable write is blocked', async () => {
+    const plan = {
+      clientId: 'blocked-plan-row',
+      toolUseId: 'plan:blocked-failed-turn',
+      turnId: 'blocked-failed-turn',
+      input: { plan: [{ step: 'Preserve latest fact', status: 'in_progress' }] },
+    };
+    const settlement = new RecoveryPlanSettlement();
+    let releaseDurableWrite!: () => void;
+    const durableWrite = new Promise<void>((resolve) => {
+      releaseDurableWrite = resolve;
+    });
+
+    const pending = settlement.persistUserBoundary({
+      sessionId: SESSION,
+      recoveryUserClientId: 'blocked-recovery-user',
+      attemptToken: 7,
+      providerGeneration: 11,
+      plan,
+      closePlanUpdates: () => closeCodexPlanUpdatesForRecovery(SESSION, plan),
+      persist: () => durableWrite,
+    });
+
+    expect(isCodexPlanUpdateClosed(SESSION, plan.toolUseId)).toBe(true);
+    expect(
+      onToolUseEvent(
+        SESSION,
+        {
+          toolUseId: plan.toolUseId,
+          toolName: 'update_plan',
+          input: { plan: [{ step: 'Late stale update', status: 'pending' }] },
+        },
+        null,
+      ),
+    ).toBeUndefined();
+    expect(settlement.hasPending(SESSION)).toBe(false);
+
+    releaseDurableWrite();
+    await pending;
+    expect(settlement.hasPending(SESSION)).toBe(true);
   });
 
   it('still seals after a continuation boundary cleared the per-segment maps', async () => {

--- a/apps/desktop/src/main/localDb/__tests__/sessionActiveTurn.test.ts
+++ b/apps/desktop/src/main/localDb/__tests__/sessionActiveTurn.test.ts
@@ -44,6 +44,8 @@ describe('sessionActiveTurn', () => {
         active_turn_started_at INTEGER,
         active_turn_pid INTEGER,
         last_turn_ended_at INTEGER,
+        context_tokens INTEGER NOT NULL DEFAULT 0,
+        context_window INTEGER NOT NULL DEFAULT 0,
         created_at INTEGER NOT NULL,
         updated_at INTEGER NOT NULL
       );
@@ -56,6 +58,7 @@ describe('sessionActiveTurn', () => {
         content TEXT NOT NULL,
         tool_use_id TEXT,
         agent_meta TEXT,
+        agent_kind TEXT,
         created_at INTEGER NOT NULL,
         rewind_at INTEGER
       );
@@ -113,6 +116,42 @@ describe('sessionActiveTurn', () => {
       [id],
     );
   }
+
+  it('captures the exact latest unsealed Codex plan generation for recovery', async () => {
+    const { getRecoveryContextSnapshot } = await import('../sessionActiveTurn.js');
+    const client = createTestDbClient();
+    await seedSession(client, 's-plan');
+    await client.exec(
+      'INSERT INTO messages (id, client_id, session_id, role, content, created_at) VALUES (?, ?, ?, ?, ?, ?)',
+      ['u1', 'failed-user', 's-plan', 'user', 'do work', 100],
+    );
+    await client.exec(
+      'INSERT INTO messages (id, client_id, session_id, role, content, tool_use_id, agent_kind, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+      [
+        'p1',
+        'plan-row-client',
+        's-plan',
+        'tool_use',
+        JSON.stringify({
+          toolUseId: 'plan:failed-turn',
+          toolName: 'update_plan',
+          input: { plan: [{ step: 'Recover', status: 'in_progress' }] },
+          turnCompleted: false,
+        }),
+        'plan:failed-turn',
+        'codex',
+        110,
+      ],
+    );
+
+    const snapshot = await getRecoveryContextSnapshot('s-plan', 'failed-user');
+    expect(snapshot.predecessorPlan).toEqual({
+      clientId: 'plan-row-client',
+      toolUseId: 'plan:failed-turn',
+      turnId: 'failed-turn',
+      input: { plan: [{ step: 'Recover', status: 'in_progress' }] },
+    });
+  });
 
   it('markSessionTurnStarted / markSessionTurnEnded write the two timestamps', async () => {
     const { markSessionTurnStarted, markSessionTurnEnded } = await import('../sessionActiveTurn.js');

--- a/apps/desktop/src/main/localDb/sessionActiveTurn.ts
+++ b/apps/desktop/src/main/localDb/sessionActiveTurn.ts
@@ -49,13 +49,14 @@
  * turn 主流程。
  */
 
-import { and, desc, eq, gt, inArray, isNull, lt, sql } from 'drizzle-orm';
+import { and, desc, eq, gt, inArray, isNull, like, lt, sql } from 'drizzle-orm';
 
 import { getDbClient } from './client/current';
 import { messages, sessions } from './schema';
 import { createLogger } from '../logger';
 import { DESKTOP_VISIBLE_SESSION_SOURCES } from '../../shared/sessionSource.js';
 import { boundedSummary } from '../maker-ipc/recoveryCoordinator.js';
+import type { RecoveryPredecessorPlan } from '../../shared/agentInputQueue.js';
 
 const log = createLogger('session-active-turn');
 
@@ -511,6 +512,7 @@ export async function getRecoveryContextSnapshot(
     role: 'assistant' | 'tool_use' | 'thinking' | 'ask_user' | 'plan_review';
     summary: string;
   }>;
+  predecessorPlan: RecoveryPredecessorPlan | null;
 }> {
   const db = getDbClient().drizzle;
   const progressRoles = ['assistant', 'tool_use', 'thinking', 'ask_user', 'plan_review'] as const;
@@ -528,7 +530,7 @@ export async function getRecoveryContextSnapshot(
     isNull(messages.rewindAt),
     afterUser,
   );
-  const [session, countRow, recentRows] = await Promise.all([
+  const [session, countRow, recentRows, planRows] = await Promise.all([
     db
       .select({ contextTokens: sessions.contextTokens, contextWindow: sessions.contextWindow })
       .from(sessions)
@@ -544,6 +546,24 @@ export async function getRecoveryContextSnapshot(
       .where(visibleProgress)
       .orderBy(desc(messages.createdAt), desc(sql.raw('"messages"."rowid"')))
       .limit(6),
+    db
+      .select({
+        clientId: messages.clientId,
+        toolUseId: messages.toolUseId,
+        content: messages.content,
+      })
+      .from(messages)
+      .where(
+        and(
+          eq(messages.sessionId, sessionId),
+          eq(messages.role, 'tool_use'),
+          like(messages.toolUseId, 'plan:%'),
+          isNull(messages.rewindAt),
+          afterUser,
+        ),
+      )
+      .orderBy(desc(messages.createdAt), desc(sql.raw('"messages"."rowid"')))
+      .limit(6),
   ]);
 
   return {
@@ -554,7 +574,38 @@ export async function getRecoveryContextSnapshot(
       role: normalizeRecoveryRole(row.role),
       summary: summarizeRecoveryContent(row.content),
     })),
+    predecessorPlan: findRecoveryPredecessorPlan(planRows),
   };
+}
+
+function findRecoveryPredecessorPlan(
+  rows: Array<{ clientId: string; toolUseId: string | null; content: string }>,
+): RecoveryPredecessorPlan | null {
+  for (const row of rows) {
+    if (!row.toolUseId?.startsWith('plan:')) continue;
+    try {
+      const content = JSON.parse(row.content) as Record<string, unknown>;
+      const input = content.input;
+      if (
+        content.toolName !== 'update_plan' ||
+        !input ||
+        typeof input !== 'object' ||
+        Array.isArray(input) ||
+        !Array.isArray((input as Record<string, unknown>).plan)
+      )
+        continue;
+      if (content.terminalPlanSnapshot === true) return null;
+      return {
+        clientId: row.clientId,
+        toolUseId: row.toolUseId,
+        turnId: row.toolUseId.slice('plan:'.length),
+        input: input as Record<string, unknown>,
+      };
+    } catch {
+      // Ignore malformed legacy rows and continue to the next exact plan row.
+    }
+  }
+  return null;
 }
 
 function normalizeRecoveryRole(

--- a/apps/desktop/src/main/maker-ipc/__tests__/recoveryCoordinator.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/recoveryCoordinator.test.ts
@@ -45,6 +45,32 @@ describe('recoveryCoordinator', () => {
     expect(automatic.source).toBe('automatic');
   });
 
+  it('carries the exact predecessor plan identity across recovery attempts', () => {
+    const predecessorPlan = {
+      clientId: 'plan-row-client',
+      toolUseId: 'plan:failed-turn',
+      turnId: 'failed-turn',
+      input: { plan: [{ step: 'Recover', status: 'in_progress' }] },
+    };
+    const first = buildRecoveryCheckpoint('automatic', 'failed-user', undefined, {
+      contextTokens: 10_000,
+      contextWindow: 200_000,
+      progressCount: 1,
+      recentProgress: [],
+      predecessorPlan,
+    });
+    const repeated = buildRecoveryCheckpoint('automatic', 'recovery-user', first, {
+      contextTokens: 12_000,
+      contextWindow: 200_000,
+      progressCount: 1,
+      recentProgress: [],
+      predecessorPlan: null,
+    });
+
+    expect(first.predecessorPlan).toEqual(predecessorPlan);
+    expect(repeated.predecessorPlan).toEqual(predecessorPlan);
+  });
+
   it('adds a bounded handoff only in checkpoint mode', () => {
     const checkpoint = buildRecoveryCheckpoint('manual', 'failed-1', undefined, {
       contextTokens: 180_000,

--- a/apps/desktop/src/main/maker-ipc/__tests__/recoveryPlanSettlement.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/recoveryPlanSettlement.test.ts
@@ -1,0 +1,241 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { RecoveryPlanSettlement } from '../recoveryPlanSettlement.js';
+
+const PLAN = {
+  clientId: 'plan-row-client',
+  toolUseId: 'plan:failed-turn',
+  turnId: 'failed-turn',
+  input: { plan: [{ step: 'Recover', status: 'in_progress' }] },
+};
+const GENERATION = 11;
+
+describe('RecoveryPlanSettlement', () => {
+  it('returns the predecessor plan only at the matching successful recovery terminal', () => {
+    const book = new RecoveryPlanSettlement();
+    book.arm('s1', 'recovery-user', 7, GENERATION, PLAN);
+    expect(book.ownsPredecessorPlan('s1', 'plan:failed-turn')).toBe(true);
+
+    expect(
+      book.settleDone(
+        's1',
+        6,
+        { raw: { id: 'stale-turn', status: 'completed' } },
+        'foreground',
+        GENERATION,
+      ),
+    ).toBeNull();
+    expect(
+      book.settleDone(
+        's1',
+        7,
+        { raw: { id: 'recovery-turn', status: 'completed' } },
+        'foreground',
+        GENERATION,
+      ),
+    ).toEqual(PLAN);
+    expect(book.ownsPredecessorPlan('s1', 'plan:failed-turn')).toBe(false);
+    expect(
+      book.settleDone(
+        's1',
+        7,
+        { raw: { id: 'recovery-turn', status: 'completed' } },
+        'foreground',
+        GENERATION,
+      ),
+    ).toBeNull();
+  });
+
+  it('keeps the plan open when recovery fails or is interrupted', () => {
+    const book = new RecoveryPlanSettlement();
+    book.arm('s1', 'recovery-user', 7, GENERATION, PLAN);
+
+    expect(
+      book.settleDone(
+        's1',
+        7,
+        { raw: { id: 'recovery-turn', status: 'interrupted' } },
+        'foreground',
+        GENERATION,
+      ),
+    ).toBeNull();
+    expect(book.hasPending('s1')).toBe(false);
+
+    book.arm('s1', 'recovery-user-2', 8, GENERATION, PLAN);
+    expect(book.settleError('s1', 8, null, 'foreground', GENERATION)).toBe(true);
+    expect(book.hasPending('s1')).toBe(false);
+
+    book.arm('s1', 'recovery-user-3', 9, GENERATION, PLAN);
+    expect(
+      book.settleDone(
+        's1',
+        9,
+        {
+          cancelled: true,
+          raw: { id: 'cancelled-recovery-turn', status: 'completed' },
+        },
+        'foreground',
+        GENERATION,
+      ),
+    ).toBeNull();
+    expect(book.hasPending('s1')).toBe(false);
+  });
+
+  it('ignores a late terminal event from the predecessor turn', () => {
+    const book = new RecoveryPlanSettlement();
+    book.arm('s1', 'manual-recovery-user', null, GENERATION, PLAN);
+
+    expect(book.settleError('s1', null, null, 'foreground', GENERATION, false)).toBe(false);
+    expect(book.hasPending('s1')).toBe(true);
+    expect(
+      book.settleDone(
+        's1',
+        null,
+        { raw: { id: 'failed-turn', status: 'failed' } },
+        'foreground',
+        GENERATION - 1,
+        false,
+      ),
+    ).toBeNull();
+    expect(book.hasPending('s1')).toBe(true);
+    expect(
+      book.settleDone(
+        's1',
+        null,
+        {
+          raw: { id: 'manual-recovery-turn', status: 'failed' },
+        },
+        'foreground',
+        GENERATION,
+      ),
+    ).toBeNull();
+    expect(book.hasPending('s1')).toBe(false);
+
+    book.arm('s1', 'manual-recovery-user-2', null, GENERATION + 1, PLAN);
+    expect(
+      book.settleDone(
+        's1',
+        null,
+        {
+          raw: { id: 'manual-recovery-turn-2', status: 'interrupted' },
+        },
+        'foreground',
+        GENERATION + 1,
+      ),
+    ).toBeNull();
+    expect(book.hasPending('s1')).toBe(false);
+
+    book.arm('s1', 'manual-recovery-user-3', null, GENERATION + 2, PLAN);
+    expect(
+      book.settleDone(
+        's1',
+        null,
+        { raw: { id: 'manual-recovery-turn-3', status: 'completed' } },
+        'foreground',
+        GENERATION + 2,
+      ),
+    ).toEqual(PLAN);
+  });
+
+  it('does not let background terminals settle a foreground recovery', () => {
+    const book = new RecoveryPlanSettlement();
+    book.arm('s1', 'recovery-user', null, GENERATION, PLAN);
+
+    expect(
+      book.settleDone(
+        's1',
+        null,
+        { raw: { id: 'background-turn', status: 'completed' } },
+        'background',
+        GENERATION,
+      ),
+    ).toBeNull();
+    expect(book.hasPending('s1')).toBe(true);
+    expect(book.settleError('s1', null, 'background-turn', 'background', GENERATION)).toBe(false);
+    expect(book.hasPending('s1')).toBe(true);
+  });
+
+  it('does not let an ordinary success seal after the owned recovery ended with an id-less error', () => {
+    const book = new RecoveryPlanSettlement();
+    book.arm('s1', 'manual-recovery-user', null, GENERATION, PLAN);
+
+    expect(book.settleError('s1', null, null, 'foreground', GENERATION, true)).toBe(true);
+    expect(book.hasPending('s1')).toBe(false);
+    expect(
+      book.settleDone(
+        's1',
+        null,
+        { raw: { id: 'ordinary-later-turn', status: 'completed' } },
+        'foreground',
+        GENERATION + 1,
+        true,
+      ),
+    ).toBeNull();
+  });
+
+  it('does not settle from a late terminal whose provider generation is no longer current', () => {
+    const book = new RecoveryPlanSettlement();
+    book.arm('s1', 'manual-recovery-user', null, GENERATION, PLAN);
+
+    expect(
+      book.settleDone(
+        's1',
+        null,
+        { raw: { id: 'stale-non-predecessor-turn', status: 'completed' } },
+        'foreground',
+        GENERATION,
+        false,
+      ),
+    ).toBeNull();
+    expect(book.hasPending('s1')).toBe(true);
+  });
+
+  it('cannot arm a recovery row cancelled on either side of its durable-write race', () => {
+    const book = new RecoveryPlanSettlement();
+    book.cancelUndispatched('s1', 'cancelled-before-arm');
+    book.teardown('s1');
+    book.arm('s1', 'cancelled-before-arm', 7, GENERATION, PLAN);
+    expect(book.hasPending('s1')).toBe(false);
+
+    book.arm('s1', 'cancelled-after-arm', 8, GENERATION, PLAN);
+    book.cancelUndispatched('s1', 'cancelled-after-arm');
+    expect(book.hasPending('s1')).toBe(false);
+  });
+
+  it('closes immediately but never arms a failed or undispatched durable recovery row', async () => {
+    const failed = new RecoveryPlanSettlement();
+    const closeFailed = vi.fn();
+    await expect(
+      failed.persistUserBoundary({
+        sessionId: 's1',
+        recoveryUserClientId: 'failed-write',
+        attemptToken: 7,
+        providerGeneration: GENERATION,
+        plan: PLAN,
+        closePlanUpdates: closeFailed,
+        persist: () => Promise.reject(new Error('write failed')),
+      }),
+    ).rejects.toThrow('write failed');
+    expect(closeFailed).toHaveBeenCalledTimes(1);
+    expect(failed.hasPending('s1')).toBe(false);
+
+    const cancelled = new RecoveryPlanSettlement();
+    let releaseWrite!: () => void;
+    const write = new Promise<void>((resolve) => {
+      releaseWrite = resolve;
+    });
+    const pending = cancelled.persistUserBoundary({
+      sessionId: 's2',
+      recoveryUserClientId: 'cancelled-write',
+      attemptToken: 8,
+      providerGeneration: GENERATION,
+      plan: PLAN,
+      closePlanUpdates: () => {},
+      persist: () => write,
+    });
+    cancelled.cancelUndispatched('s2', 'cancelled-write');
+    releaseWrite();
+    await pending;
+    expect(cancelled.hasPending('s2')).toBe(false);
+  });
+});

--- a/apps/desktop/src/main/maker-ipc/recoveryCoordinator.ts
+++ b/apps/desktop/src/main/maker-ipc/recoveryCoordinator.ts
@@ -6,6 +6,7 @@ export interface RecoveryContextSnapshot {
   contextWindow: number;
   progressCount: number;
   recentProgress: RecoveryCheckpoint['recentProgress'];
+  predecessorPlan?: RecoveryCheckpoint['predecessorPlan'] | null;
 }
 
 export interface RecoveryDecisionInput {
@@ -112,6 +113,7 @@ export function buildRecoveryCheckpoint(
     contextRatio: contextRatio(snapshot.contextTokens, snapshot.contextWindow),
     progressCount: snapshot.progressCount,
     createdAt: new Date().toISOString(),
+    predecessorPlan: snapshot.predecessorPlan ?? previous?.predecessorPlan,
     recentProgress: snapshot.recentProgress.slice(0, 6).map((entry) => ({
       role: entry.role,
       summary: boundedSummary(entry.summary),

--- a/apps/desktop/src/main/maker-ipc/recoveryPlanSettlement.ts
+++ b/apps/desktop/src/main/maker-ipc/recoveryPlanSettlement.ts
@@ -1,0 +1,135 @@
+import type { RecoveryPredecessorPlan } from '../../shared/agentInputQueue.js';
+
+interface PendingRecoveryPlan {
+  recoveryUserClientId: string;
+  attemptToken: number | null;
+  providerGeneration: number;
+  plan: RecoveryPredecessorPlan;
+}
+
+/** Exact lifecycle boundary between an interrupted plan and its recovery turn. */
+export class RecoveryPlanSettlement {
+  private readonly pendingBySession = new Map<string, PendingRecoveryPlan>();
+  private readonly cancelledBeforeArmBySession = new Map<string, string>();
+
+  arm(
+    sessionId: string,
+    recoveryUserClientId: string,
+    attemptToken: number | null,
+    providerGeneration: number,
+    plan: RecoveryPredecessorPlan,
+  ): void {
+    if (this.cancelledBeforeArmBySession.get(sessionId) === recoveryUserClientId) {
+      this.cancelledBeforeArmBySession.delete(sessionId);
+      return;
+    }
+    this.cancelledBeforeArmBySession.delete(sessionId);
+    this.pendingBySession.set(sessionId, {
+      recoveryUserClientId,
+      attemptToken,
+      providerGeneration,
+      plan,
+    });
+  }
+
+  async persistUserBoundary<T>(params: {
+    sessionId: string;
+    recoveryUserClientId: string;
+    attemptToken: number | null;
+    providerGeneration: number;
+    plan: RecoveryPredecessorPlan;
+    closePlanUpdates: () => void;
+    persist: () => Promise<T>;
+  }): Promise<T> {
+    // Close synchronously before the durable await. A late predecessor event
+    // must not enter the shared write FIFO and overtake this recovery row.
+    params.closePlanUpdates();
+    const persisted = await params.persist();
+    this.arm(
+      params.sessionId,
+      params.recoveryUserClientId,
+      params.attemptToken,
+      params.providerGeneration,
+      params.plan,
+    );
+    return persisted;
+  }
+
+  cancelUndispatched(sessionId: string, recoveryUserClientId: string): void {
+    const pending = this.pendingBySession.get(sessionId);
+    if (pending?.recoveryUserClientId === recoveryUserClientId) {
+      this.pendingBySession.delete(sessionId);
+      return;
+    }
+    // Stop/remove may race the durable write. Remember that exact row so a
+    // later onAccepted continuation cannot arm a turn that never dispatched.
+    this.cancelledBeforeArmBySession.set(sessionId, recoveryUserClientId);
+  }
+
+  settleDone(
+    sessionId: string,
+    attemptToken: number | null,
+    data: { cancelled?: unknown; raw?: { id?: unknown; status?: unknown } } | null | undefined,
+    turnScope: 'foreground' | 'background' = 'foreground',
+    providerGeneration?: number,
+    isCurrentGeneration = true,
+  ): RecoveryPredecessorPlan | null {
+    const pending = this.pendingBySession.get(sessionId);
+    if (
+      turnScope === 'background' ||
+      !isCurrentGeneration ||
+      !pending ||
+      pending.attemptToken !== attemptToken ||
+      pending.providerGeneration !== providerGeneration
+    )
+      return null;
+    const eventTurnId = typeof data?.raw?.id === 'string' ? data.raw.id : null;
+    // A paired/late terminal from the failed predecessor may arrive after a
+    // manual retry was armed. It does not own the recovery lifecycle.
+    if (eventTurnId === pending.plan.turnId) return null;
+    this.pendingBySession.delete(sessionId);
+    return isSuccessfulRecoveryDone(data) ? pending.plan : null;
+  }
+
+  settleError(
+    sessionId: string,
+    attemptToken: number | null,
+    eventTurnId?: string | null,
+    turnScope: 'foreground' | 'background' = 'foreground',
+    providerGeneration?: number,
+    isCurrentGeneration = true,
+  ): boolean {
+    const pending = this.pendingBySession.get(sessionId);
+    if (
+      turnScope === 'background' ||
+      !isCurrentGeneration ||
+      !pending ||
+      pending.attemptToken !== attemptToken ||
+      pending.providerGeneration !== providerGeneration
+    )
+      return false;
+    if (eventTurnId === pending.plan.turnId) return false;
+    this.pendingBySession.delete(sessionId);
+    return true;
+  }
+
+  hasPending(sessionId: string): boolean {
+    return this.pendingBySession.has(sessionId);
+  }
+
+  ownsPredecessorPlan(sessionId: string, toolUseId: string): boolean {
+    return this.pendingBySession.get(sessionId)?.plan.toolUseId === toolUseId;
+  }
+
+  teardown(sessionId: string): void {
+    this.pendingBySession.delete(sessionId);
+    // Keep a pre-arm cancellation tombstone: Stop tears down the live session
+    // before an in-flight durable write can return and attempt to arm it.
+  }
+}
+
+function isSuccessfulRecoveryDone(
+  data: { cancelled?: unknown; raw?: { status?: unknown } } | null | undefined,
+): boolean {
+  return data?.cancelled !== true && data?.raw?.status === 'completed';
+}

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -388,6 +388,8 @@ import {
   flushOrphanToolResults,
   getLastAssistantTranscriptUuid,
   getSessionDbAgentKind,
+  closeCodexPlanUpdatesForRecovery,
+  isCodexPlanUpdateClosed,
   isSuccessfulCodexDoneEventData,
   markAssistantTurnCompleted,
   markAssistantTurnFailed,
@@ -400,6 +402,7 @@ import {
   onInteractionResolved,
   clearCodexPlanRowsForSession,
   persistCodexPlanOnDone,
+  persistRecoveredCodexPlanOnDone,
   persistCodexPlanOnTerminalError,
   onThinkingEvent,
   onToolResultEvent,
@@ -818,6 +821,7 @@ import {
   type SuppressedTurnError,
   type SuppressedTurnErrorOwner,
 } from './autoResumeBookkeeping.js';
+import { RecoveryPlanSettlement } from './recoveryPlanSettlement.js';
 import {
   InterruptedTurnAutoResumeGuard,
   isAutoResumeUserMessage,
@@ -992,6 +996,7 @@ export function cancelSchedulerAutoResume(sessionId: string, runId: string): boo
   // teardown 是既有唯一生命周期出口：撤退避、清 coordinator 接管与隐藏续跑、
   // 结算活动行并通知 runner。runId 校验防止迟到的旧 abort 误杀新 run。
   autoResumeBookkeeping.teardown(sessionId);
+  recoveryPlanSettlement.teardown(sessionId);
   return true;
 }
 
@@ -1023,6 +1028,7 @@ const autoResumeBookkeeping = new AutoResumeBookkeeping({
     failPendingSchedulerAutoResume(sessionId, attemptToken),
   log: (message, fields) => log.debug(message, fields),
 });
+const recoveryPlanSettlement = new RecoveryPlanSettlement();
 
 /**
  * A Codex reconnect-stall retry is scheduled against the current runtime
@@ -1042,6 +1048,7 @@ function resetAutomaticRecoveryForExplicitStop(sessionId: string): void {
   silentStopAutoResumeGuard.noteSessionReset(sessionId);
   interruptedTurnAutoResumeGuard.noteSessionReset(sessionId);
   autoResumeBookkeeping.teardown(sessionId);
+  recoveryPlanSettlement.teardown(sessionId);
 }
 
 function autoResumeAttemptToken(item: AgentInputQueuedMessage): number | null {
@@ -3508,6 +3515,34 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
         }
         return;
       }
+      if (event.source === 'codex' && !isSilentStop) {
+        const attemptToken =
+          typeof event.turnAttemptToken === 'number' ? event.turnAttemptToken : null;
+        if (event.type === 'done') {
+          const recoveredPlan = recoveryPlanSettlement.settleDone(
+            session.id,
+            attemptToken,
+            event.data as { cancelled?: unknown; raw?: { id?: unknown; status?: unknown } } | null,
+            'foreground',
+            turnGeneration,
+            isCurrentGeneration,
+          );
+          if (recoveredPlan) persistRecoveredCodexPlanOnDone(session.id, recoveredPlan);
+        } else if (isTerminalTurnErrorEvent(event)) {
+          const errorTurnId =
+            typeof (event.data as { raw?: { id?: unknown } } | null)?.raw?.id === 'string'
+              ? (event.data as { raw: { id: string } }).raw.id
+              : null;
+          recoveryPlanSettlement.settleError(
+            session.id,
+            attemptToken,
+            errorTurnId,
+            'foreground',
+            turnGeneration,
+            isCurrentGeneration,
+          );
+        }
+      }
       if (isCurrentGeneration) silentStopTurnLeaseGate.supersede(session.id);
       void sessionTurnLeaseTracker.markTurnEnded(session.id, turnLeaseId);
     },
@@ -3556,6 +3591,17 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
         backgroundTurnPredatesSessionClear(session.id, event.backgroundTurnStartedAt)
       ) {
         return;
+      }
+      if (event.source === 'codex' && event.type === 'tool_use') {
+        const planEvent = event.data as { toolUseId?: unknown; toolName?: unknown };
+        if (
+          planEvent.toolName === 'update_plan' &&
+          typeof planEvent.toolUseId === 'string' &&
+          (isCodexPlanUpdateClosed(session.id, planEvent.toolUseId) ||
+            recoveryPlanSettlement.ownsPredecessorPlan(session.id, planEvent.toolUseId))
+        ) {
+          return;
+        }
       }
       // 自动续跑的 pending 不能只靠 status(isRunning=true) 清理：Pi/Claude 的
       // terminal-only 路径可能首个事件就是 error。Session 已把 host-owned token
@@ -5007,6 +5053,7 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
             // 补发会把用户关掉的会话重新拉起来),后者会把结果错绑到下一个会话实例(codex P1)。
             interruptedTurnAutoResumeGuard.noteSessionReset(session.id);
             autoResumeBookkeeping.teardown(session.id);
+            recoveryPlanSettlement.teardown(session.id);
           }
           // rehydrate / 凭证切换 close-rebuild 窗口:同一逻辑会话进程内重建,
           // 协调器状态应连续。窗口内保留 input boundary(不 abort,避免取消
@@ -9824,8 +9871,9 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
         autoResumeBookkeeping.releasePendingOutcome(sessionId, attemptToken, message.clientId);
       }
     };
+    const checkpoint = message.agentMeta?.recoveryCheckpoint;
     try {
-      return await enqueueDurableWrite(`user:${sessionId}:${message.clientId}`, (ownerScope) => {
+      const persistUserMessage = () => enqueueDurableWrite(`user:${sessionId}:${message.clientId}`, (ownerScope) => {
         // Coordinator accepts can stamp transcriptParentUuid early; this late FIFO
         // fallback covers makerSendTransaction/direct createDbMessage paths.
         const transcriptParentUuid = getLastAssistantTranscriptUuid(sessionId);
@@ -9856,6 +9904,21 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
           agentKind ? { ...enrichedMessage, agentKind } : enrichedMessage,
           scopedOpts,
         );
+      });
+      const predecessorPlan = checkpoint?.predecessorPlan;
+      if (!predecessorPlan) return await persistUserMessage();
+      const providerGeneration = maker.getSession(sessionId)?.getTurnGeneration();
+      if (typeof providerGeneration !== 'number') {
+        throw new Error('Recovery provider generation unavailable before durable persistence');
+      }
+      return await recoveryPlanSettlement.persistUserBoundary({
+        sessionId,
+        recoveryUserClientId: message.clientId,
+        attemptToken: autoResumeAttemptTokenFromAgentMeta(message.agentMeta),
+        providerGeneration,
+        plan: predecessorPlan,
+        closePlanUpdates: () => closeCodexPlanUpdatesForRecovery(sessionId, predecessorPlan),
+        persist: persistUserMessage,
       });
     } catch (err) {
       releasePendingOutcomeOnFailure();
@@ -10897,6 +10960,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
     // 用 enqueue 入口而不是消息文本: 零产出重试重发的是原文, 文本上无从区分,
     // 而它走 unshift 不经这里, 于是不会把自己的回流作废掉。
     onUserEnqueue: (sessionId) => {
+      recoveryPlanSettlement.teardown(sessionId);
       autoResumeBookkeeping.supersedeUnclaimedErrorForUserIntervention(sessionId);
       // The user turn can dispatch before the backoff callback observes that its
       // recovery was superseded. Fail the scheduler waiter synchronously so it
@@ -10905,6 +10969,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
       publishUiSessionIntervention(sessionId);
     },
     onAutomaticEnqueue: (sessionId) => {
+      recoveryPlanSettlement.teardown(sessionId);
       // Orca 等自动输入会推进同一会话，必须撤销旧 retry owner，避免它消费这轮事件；
       // 但预算充值仍只发生在真人消息的持久化路径，自动输入不会重置 episode。
       autoResumeBookkeeping.supersedeUnclaimedErrorForUserIntervention(sessionId);
@@ -10921,6 +10986,9 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
     },
     // 队列项未派发即被丢弃(stop/remove/clearSession) → 释放暂存的 accepted 副作用, 防回调表泄漏。
     onDiscardedQueuedMessage: (sessionId, item) => {
+      if (item.recoveryCheckpoint?.predecessorPlan) {
+        recoveryPlanSettlement.cancelUndispatched(sessionId, item.clientId);
+      }
       discardQueuedAttachmentOwnership(sessionId, item.clientId);
       orcaInterAgentDispatcher.discardQueuedOrcaInterAgentAcceptedCallback(item.clientId);
       // Auto-resume cleanup must run before generic claimed-retry release:
@@ -10999,6 +11067,9 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
     },
     onUndispatchedUserTurn: (sessionId, item, disposition) => {
       // 目标轮落库了却没能 dispatch(取消 / 失败): 记账该立刻还回去, 而不是等超时。
+      if (item.recoveryCheckpoint?.predecessorPlan) {
+        recoveryPlanSettlement.cancelUndispatched(sessionId, item.clientId);
+      }
       publishUiTurnUndispatched(sessionId, item.clientId);
       clearPendingTurnChangeSets(sessionId);
       gitSnapshotCoordinator?.onTurnAbort(sessionId);

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -3497,24 +3497,9 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
       );
     },
     onTerminal: ({ turnGeneration, event, isCurrentGeneration }) => {
-      if (session.remoteHostId) return;
-      const turnLeaseId = providerTurnLeaseId(session.instanceId, turnGeneration);
       const isSilentStop =
         event.type === 'done' &&
         (event.data as { silentStop?: unknown } | null | undefined)?.silentStop === true;
-      if (isSilentStop && isCurrentGeneration) {
-        // The provider turn ended, but the product turn remains occupied while
-        // the bounded auto-resume decision runs. Its exact lease is either
-        // replaced by the next provider generation or released by settle.
-        const scheduled = silentStopTurnLeaseGate.schedule(session.id, event, turnLeaseId);
-        if (!scheduled) {
-          log.debug('ignored duplicate silent-stop terminal for the current turn', {
-            sessionId: session.id,
-            turnLeaseId,
-          });
-        }
-        return;
-      }
       if (event.source === 'codex' && !isSilentStop) {
         const attemptToken =
           typeof event.turnAttemptToken === 'number' ? event.turnAttemptToken : null;
@@ -3542,6 +3527,25 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
             isCurrentGeneration,
           );
         }
+      }
+      // SSH-backed sessions intentionally skip the local turn-lease bookkeeping
+      // below, but their Codex lifecycle still owns the same durable recovery
+      // plan settlement. Keep this return after the generation-scoped terminal
+      // handling so remote successes seal the exact predecessor row as well.
+      if (session.remoteHostId) return;
+      const turnLeaseId = providerTurnLeaseId(session.instanceId, turnGeneration);
+      if (isSilentStop && isCurrentGeneration) {
+        // The provider turn ended, but the product turn remains occupied while
+        // the bounded auto-resume decision runs. Its exact lease is either
+        // replaced by the next provider generation or released by settle.
+        const scheduled = silentStopTurnLeaseGate.schedule(session.id, event, turnLeaseId);
+        if (!scheduled) {
+          log.debug('ignored duplicate silent-stop terminal for the current turn', {
+            sessionId: session.id,
+            turnLeaseId,
+          });
+        }
+        return;
       }
       if (isCurrentGeneration) silentStopTurnLeaseGate.supersede(session.id);
       void sessionTurnLeaseTracker.markTurnEnded(session.id, turnLeaseId);
@@ -10956,11 +10960,11 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
       }
       publishUiContinuation(sessionId, clientId);
     },
-    // 新消息进队 → 作废该会话的待续跑记账(渠道那条旧消息已被别的内容取代)。
-    // 用 enqueue 入口而不是消息文本: 零产出重试重发的是原文, 文本上无从区分,
-    // 而它走 unshift 不经这里, 于是不会把自己的回流作废掉。
+    // 新消息进队 → 作废该会话的渠道待续跑记账(渠道那条旧消息已被别的内容取代)。
+    // 已 dispatch 的计划恢复结算必须继续归属于当前 provider generation；普通 follow-up
+    // 只会排在它后面，不能在这里拆掉。真正未派发的恢复项由下面两个精确 item/clientId
+    // 回调 cancelUndispatched，Stop/关闭则走显式 teardown。
     onUserEnqueue: (sessionId) => {
-      recoveryPlanSettlement.teardown(sessionId);
       autoResumeBookkeeping.supersedeUnclaimedErrorForUserIntervention(sessionId);
       // The user turn can dispatch before the backoff callback observes that its
       // recovery was superseded. Fail the scheduler waiter synchronously so it
@@ -10969,7 +10973,6 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
       publishUiSessionIntervention(sessionId);
     },
     onAutomaticEnqueue: (sessionId) => {
-      recoveryPlanSettlement.teardown(sessionId);
       // Orca 等自动输入会推进同一会话，必须撤销旧 retry owner，避免它消费这轮事件；
       // 但预算充值仍只发生在真人消息的持久化路径，自动输入不会重置 episode。
       autoResumeBookkeeping.supersedeUnclaimedErrorForUserIntervention(sessionId);

--- a/apps/desktop/src/main/maker-orchestration/fork.ts
+++ b/apps/desktop/src/main/maker-orchestration/fork.ts
@@ -17,6 +17,7 @@ import { getDbClient } from '../localDb/client/current';
 import { sessions, messages } from '../localDb/schema';
 import { sessionToCamel } from '../localDb/mapper';
 import { getMaker } from '../maker-host/index.js';
+import { drainPersistQueue } from '../messagePersistBroadcaster.js';
 import { createBusinessSessionId } from '../sessionIds.js';
 import { dbToMakerAgentKind, normalizeDbAgentKind } from '../../shared/agentKindConversion.js';
 import type { Session } from '../../renderer/lib/ccAgent.types';
@@ -417,6 +418,10 @@ export async function forkSessionAtMessage(
   sourceSessionId: string,
   messageClientId: string,
 ): Promise<Session> {
+  // A successful recovery seals its predecessor plan on the main persistence
+  // FIFO. Fork must snapshot after that seal; a fork started before recovery
+  // completion naturally drains without it and keeps the independent plan live.
+  await drainPersistQueue();
   const db = getDbClient().drizzle;
 
   // 1. 读 source session
@@ -655,6 +660,7 @@ export async function forkSessionAtMessage(
 }
 
 export async function forkSessionStripEncrypted(sourceSessionId: string): Promise<Session> {
+  await drainPersistQueue();
   const db = getDbClient().drizzle;
 
   const [source] = await db

--- a/apps/desktop/src/main/messagePersistBroadcaster.ts
+++ b/apps/desktop/src/main/messagePersistBroadcaster.ts
@@ -48,6 +48,7 @@ import { takeMediaToolResult } from './mcp-integrations/mediaToolResultFallback.
 import { redactSensitiveText } from '@cindy/maker-shared/error-redaction';
 import { getSessionProvider } from './maker-host/session-provider-store.js';
 import type { AgentMeta } from '../renderer/lib/ccAgent.types';
+import type { RecoveryPredecessorPlan } from '../shared/agentInputQueue.js';
 
 const log = createLogger('messagePersistBroadcaster');
 
@@ -61,6 +62,29 @@ interface AssistantBlock {
 
 const assistantBlocks = new Map<string, AssistantBlock>();
 const clearBoundaryBySession = new Map<string, number>();
+const closedCodexPlanUpdatesBySession = new Map<string, Map<string, string>>();
+
+export function isCodexPlanUpdateClosed(sessionId: string, toolUseId: string): boolean {
+  return closedCodexPlanUpdatesBySession.get(sessionId)?.has(toolUseId) === true;
+}
+
+function rememberCodexPlanTerminalSeal(
+  sessionId: string,
+  toolUseId: string,
+  persistId: string,
+): void {
+  getOrCreateSessionMap(closedCodexPlanUpdatesBySession, sessionId).set(toolUseId, persistId);
+}
+
+/** The predecessor turn is over; its late provider events can no longer mutate this generation. */
+export function closeCodexPlanUpdatesForRecovery(
+  sessionId: string,
+  plan: RecoveryPredecessorPlan,
+): void {
+  if (plan.toolUseId === `plan:${plan.turnId}`) {
+    rememberCodexPlanTerminalSeal(sessionId, plan.toolUseId, plan.clientId);
+  }
+}
 
 export function noteSessionClearBoundary(sessionId: string, clearedAt: string | number | null | undefined): void {
   if (clearedAt === null || clearedAt === undefined) {
@@ -713,6 +737,10 @@ export function onToolUseEvent(
   const toolUseId = typeof data.toolUseId === 'string' ? data.toolUseId : '';
   const toolName = typeof data.toolName === 'string' ? data.toolName : '';
 
+  if (toolName === 'update_plan' && toolUseId && isCodexPlanUpdateClosed(sessionId, toolUseId)) {
+    return undefined;
+  }
+
   if (scope === 'background') {
     if (backgroundTurnPredatesSessionClear(sessionId, backgroundTurnStartedAt)) {
       return undefined;
@@ -839,6 +867,7 @@ export function persistCodexPlanOnDone(
   // 终态已定,这份计划行不再需要跨段引用;同时保留最新 input 供同 turn 的
   // 重复 done(罕见)幂等复用。
   planRowMap?.set(toolUseId, { persistId, input: nextInput });
+  if (isSuccessfulTerminal) rememberCodexPlanTerminalSeal(sessionId, toolUseId, persistId);
   enqueueWrite(`codex_plan_done:${sessionId}:${persistId}`, async (ownerScope) => {
     const updated = await updateDbMessageContent(sessionId, persistId, {
       toolUseId,
@@ -851,6 +880,28 @@ export function persistCodexPlanOnDone(
     // Reuse the existing upsert-style row broadcast so a renderer that mounts
     // between `done` and this queued write, plus remote mirrors, receives the
     // durable terminal snapshot instead of keeping its stale local copy.
+    if (updated) broadcastMessageRow(sessionId, updated, ownerScope);
+  });
+  return true;
+}
+
+export function persistRecoveredCodexPlanOnDone(
+  sessionId: string,
+  plan: RecoveryPredecessorPlan,
+): boolean {
+  if (!plan.clientId || plan.toolUseId !== `plan:${plan.turnId}` || !Array.isArray(plan.input.plan))
+    return false;
+
+  const terminalPlanAtMs = Date.now();
+  rememberCodexPlanTerminalSeal(sessionId, plan.toolUseId, plan.clientId);
+  enqueueWrite(`codex_recovered_plan_done:${sessionId}:${plan.clientId}`, async (ownerScope) => {
+    const updated = await updateDbMessageContent(sessionId, plan.clientId, {
+      toolUseId: plan.toolUseId,
+      toolName: 'update_plan',
+      input: plan.input,
+      terminalPlanSnapshot: true,
+      terminalPlanAtMs,
+    });
     if (updated) broadcastMessageRow(sessionId, updated, ownerScope);
   });
   return true;
@@ -1671,6 +1722,7 @@ export function clearCodexPlanRowsForSession(sessionId: string): void {
 
 export function clearSessionPersistState(sessionId: string): void {
   clearCodexPlanRowsForSession(sessionId);
+  closedCodexPlanUpdatesBySession.delete(sessionId);
   assistantBlocks.delete(sessionId);
   backgroundTurnPersistStatesBySession.delete(sessionId);
   lastAgentMetaBySession.delete(sessionId);

--- a/apps/desktop/src/shared/agentInputQueue.ts
+++ b/apps/desktop/src/shared/agentInputQueue.ts
@@ -178,10 +178,24 @@ export interface RecoveryCheckpoint {
   contextRatio: number | null;
   progressCount: number;
   createdAt: string;
+  /**
+   * Exact plan generation owned by the interrupted predecessor turn. Main
+   * keeps this internal so a later successful recovery turn can seal that
+   * durable row even when the recovery itself emits no update_plan event.
+   */
+  predecessorPlan?: RecoveryPredecessorPlan;
   recentProgress: Array<{
     role: 'assistant' | 'tool_use' | 'thinking' | 'ask_user' | 'plan_review';
     summary: string;
   }>;
+}
+
+export interface RecoveryPredecessorPlan {
+  clientId: string;
+  toolUseId: string;
+  turnId: string;
+  /** Frozen update_plan input for this generation; step states remain factual. */
+  input: Record<string, unknown>;
 }
 
 export interface AgentInputQueuedMessage {


### PR DESCRIPTION
## 这次改了什么

### 摘要

恢复任务成功完成时，精确封存触发恢复的前驱 Codex 计划，避免恢复 turn 没有再次调用 `update_plan` 时，旧计划在重载或 fork 后重新出现。

实现会把前驱 turn / plan identity 写入 durable recovery checkpoint，并将结算绑定到当前 foreground provider generation。只有恢复成功才写入原计划行的 `terminalPlanSnapshot`；失败或中断继续保留未封存状态。前驱计划进入恢复后会拒绝迟到更新，fork 也会先等待相关持久化完成。

PR #2200 提供 renderer 侧兜底；本 PR 补上 durable recovery predecessor-plan seal，使数据库状态本身正确收口。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#2176
- 本 PR 包含：恢复 checkpoint 的前驱计划身份、foreground generation ownership、成功/失败/中断结算、迟到计划更新隔离、fork 持久化屏障及回归测试
- 明确不包含：PR #2200 的 renderer fallback；新的 UI、IPC channel、wire protocol 或数据库 migration
- 用户可见变化：恢复成功后，原任务计划不会在重载或 fork 后错误复活
- 是否存在 breaking change：无

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm test:unit -- --workspace-concurrency=1
结果：通过，所有 workspace PASS（fresh frozen-snapshot gate，exit 0）

pnpm --filter desktop run --if-present typecheck
结果：通过

定向回归测试（6 个文件）
结果：175 tests passed

Review follow-up (`ba00de36`)
结果：冻结 tree `70e36a1cc534678d1d6300e58c99b51a0b30d0b8`；hot-path ordering 33/33、Desktop typecheck exit 0、根 `pnpm test:unit -- --workspace-concurrency=1` exit 0；完整日志保存在本地 D 盘门禁日志目录

pnpm check:dco
结果：通过，2 commits signed off
```

### 手工验证

不涉及；本次行为由恢复生命周期、持久化排序、fork 与本地数据库单元测试覆盖。

### 未执行的验证

未运行 `pnpm test:all`；本次已完成仓库硬门禁 `pnpm test:unit`、Desktop typecheck 与定向回归，未涉及需要额外端到端验证的 UI 或跨端协议。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：Desktop main 恢复生命周期与持久化排序

### 影响与回滚

- 影响范围：Desktop main 的恢复 checkpoint、计划结算、消息持久化广播和 fork 快照；不改 schema、UI、协议或插件
- 回滚 / 降级方式：回滚本提交即可恢复原行为；失败或中断路径仍保持计划未封存，不会把未完成状态误标为成功

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [ ] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次无文档变更需要）
- [x] 已确认测试结果或说明未执行原因
