### PR TITLE
fix(claude-code): 统一图片附件为原生输入

### DIFF
--- a/apps/desktop/src/main/__tests__/agentInputQueue.test.ts
+++ b/apps/desktop/src/main/__tests__/agentInputQueue.test.ts
@@ -79,6 +79,7 @@ describe('agentInputQueue', () => {
             size: 128,
             category: 'image',
             mimeType: 'image/png',
+            pathOrigin: 'desktop-host',
             url: 'xdt-image://session/shot.png',
           },
         ]),
@@ -87,7 +88,12 @@ describe('agentInputQueue', () => {
       type: 'user',
       content: [
         { type: 'text', text: 'inspect attachment' },
-        { type: 'image', path: 'xdt-image://session/shot.png', mimeType: 'image/png' },
+        {
+          type: 'image',
+          path: 'xdt-image://session/shot.png',
+          mimeType: 'image/png',
+          pathOrigin: 'desktop-host',
+        },
       ],
     });
   });

--- a/apps/desktop/src/main/__tests__/claudeInput.test.ts
+++ b/apps/desktop/src/main/__tests__/claudeInput.test.ts
@@ -113,7 +113,9 @@ describe('Claude Code SDK input', () => {
   it('falls back to a quoted path when the final image is too large to embed', async () => {
     const tempDir = await createTempDir();
     const imagePath = path.join(tempDir, 'too-large.png');
-    await fs.writeFile(imagePath, Buffer.alloc(5 * 1024 * 1024 + 1));
+    const imageBytes = Buffer.alloc(Math.floor((5 * 1024 * 1024) / 4) * 3 + 1);
+    Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]).copy(imageBytes);
+    await fs.writeFile(imagePath, imageBytes);
     const imageResizer = { process: vi.fn(async () => imagePath) };
     const content: UserMessage['content'] = [
       { type: 'image', path: imagePath, mimeType: 'image/png' },
@@ -123,6 +125,50 @@ describe('Claude Code SDK input', () => {
     expect(await toClaudeSdkContent(content, imageResizer)).toBe(
       `@"${imagePath}" Inspect this`,
     );
+  });
+
+  it('allows image data exactly at the encoded inline limit', async () => {
+    const tempDir = await createTempDir();
+    const imagePath = path.join(tempDir, 'inline-limit.png');
+    const imageBytes = Buffer.alloc(Math.floor((5 * 1024 * 1024) / 4) * 3);
+    Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]).copy(imageBytes);
+    await fs.writeFile(imagePath, imageBytes);
+    const imageResizer = { process: vi.fn(async () => imagePath) };
+    const content: UserMessage['content'] = [
+      { type: 'image', path: imagePath, mimeType: 'image/png' },
+    ];
+
+    const result = await toClaudeSdkContent(content, imageResizer);
+
+    expect(result).toEqual([
+      {
+        type: 'image',
+        source: {
+          type: 'base64',
+          media_type: 'image/png',
+          data: imageBytes.toString('base64'),
+        },
+      },
+    ]);
+  });
+
+  it('keeps SSH image paths remote even when the same path exists on the desktop', async () => {
+    const tempDir = await createTempDir();
+    const imagePath = path.join(tempDir, 'remote.png');
+    await fs.writeFile(
+      imagePath,
+      Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    );
+    const imageResizer = { process: vi.fn(async () => imagePath) };
+    const content: UserMessage['content'] = [
+      { type: 'image', path: imagePath, mimeType: 'image/png' },
+      { type: 'text', text: 'Inspect this' },
+    ];
+
+    expect(await toClaudeSdkContent(content, imageResizer, false)).toBe(
+      `@"${imagePath}" Inspect this`,
+    );
+    expect(imageResizer.process).not.toHaveBeenCalled();
   });
 
   it('does not duplicate mention chips already serialized in text', async () => {

--- a/apps/desktop/src/main/__tests__/claudeInput.test.ts
+++ b/apps/desktop/src/main/__tests__/claudeInput.test.ts
@@ -1,21 +1,103 @@
-import { describe, expect, it } from 'vitest';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { toClaudeSdkContent } from '../../../../../packages/maker-core/src/agents/claude-code/index';
 import type { UserMessage } from '../../../../../packages/maker-core/src/types/common';
 
-// 注意: toClaudeSdkContent 自 image-resizer 接通后改为 async。image block 的 path
-// 会先经 resizer.process() 透明替换 — 但测试里用的虚拟 path (C:\tmp\shot.png) 在
-// 磁盘上不存在, fs.stat 失败后 resizer 直接返回原 path, 期望值不变。
 describe('Claude Code SDK input', () => {
-  it('keeps file and image attachments as @path refs instead of inline blocks', async () => {
+  const tempDirs: string[] = [];
+
+  async function createTempDir(): Promise<string> {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'cindy-claude-input-'));
+    tempDirs.push(tempDir);
+    return tempDir;
+  }
+
+  afterEach(async () => {
+    await Promise.all(tempDirs.splice(0).map((tempDir) => fs.rm(tempDir, { recursive: true })));
+  });
+
+  it('inlines an original image while keeping file attachments as path refs', async () => {
+    const tempDir = await createTempDir();
+    const imagePath = path.join(tempDir, 'small.png');
+    const imageBytes = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+    await fs.writeFile(imagePath, imageBytes);
+    const imageResizer = { process: vi.fn(async (inputPath: string) => inputPath) };
     const content: UserMessage['content'] = [
       { type: 'text', text: 'Inspect these' },
       { type: 'file', path: 'E:\\repo\\large.txt', mimeType: 'text/plain' },
-      { type: 'image', path: 'C:\\tmp\\shot.png', mimeType: 'image/png' },
+      { type: 'image', path: imagePath, mimeType: 'image/png' },
     ];
 
-    expect(await toClaudeSdkContent(content)).toBe(
-      '@"E:\\repo\\large.txt" @"C:\\tmp\\shot.png" Inspect these',
+    expect(await toClaudeSdkContent(content, imageResizer)).toEqual([
+      {
+        type: 'image',
+        source: {
+          type: 'base64',
+          media_type: 'image/png',
+          data: imageBytes.toString('base64'),
+        },
+      },
+      { type: 'text', text: '@"E:\\repo\\large.txt" Inspect these' },
+    ]);
+    expect(imageResizer.process).toHaveBeenCalledWith(imagePath);
+  });
+
+  it('uses the resized file format and bytes for the native image block', async () => {
+    const tempDir = await createTempDir();
+    const sourcePath = path.join(tempDir, 'large.png');
+    const resizedPath = path.join(tempDir, 'large.webp');
+    const resizedBytes = Buffer.from([0x52, 0x49, 0x46, 0x46]);
+    await fs.writeFile(resizedPath, resizedBytes);
+    const imageResizer = { process: vi.fn(async () => resizedPath) };
+    const content: UserMessage['content'] = [
+      { type: 'image', path: sourcePath, mimeType: 'image/png' },
+      { type: 'text', text: 'Read the image' },
+    ];
+
+    expect(await toClaudeSdkContent(content, imageResizer)).toEqual([
+      {
+        type: 'image',
+        source: {
+          type: 'base64',
+          media_type: 'image/webp',
+          data: resizedBytes.toString('base64'),
+        },
+      },
+      { type: 'text', text: 'Read the image' },
+    ]);
+    expect(imageResizer.process).toHaveBeenCalledWith(sourcePath);
+  });
+
+  it('falls back to a quoted path when the final image cannot be read', async () => {
+    const tempDir = await createTempDir();
+    const missingPath = path.join(tempDir, 'missing.png');
+    const imageResizer = { process: vi.fn(async () => missingPath) };
+    const content: UserMessage['content'] = [
+      { type: 'image', path: missingPath, mimeType: 'image/png' },
+      { type: 'text', text: 'Inspect this' },
+    ];
+
+    expect(await toClaudeSdkContent(content, imageResizer)).toBe(
+      `@"${missingPath}" Inspect this`,
+    );
+  });
+
+  it('falls back to a quoted path when the final image is too large to embed', async () => {
+    const tempDir = await createTempDir();
+    const imagePath = path.join(tempDir, 'too-large.png');
+    await fs.writeFile(imagePath, Buffer.alloc(5 * 1024 * 1024 + 1));
+    const imageResizer = { process: vi.fn(async () => imagePath) };
+    const content: UserMessage['content'] = [
+      { type: 'image', path: imagePath, mimeType: 'image/png' },
+      { type: 'text', text: 'Inspect this' },
+    ];
+
+    expect(await toClaudeSdkContent(content, imageResizer)).toBe(
+      `@"${imagePath}" Inspect this`,
     );
   });
 

--- a/apps/desktop/src/main/__tests__/claudeInput.test.ts
+++ b/apps/desktop/src/main/__tests__/claudeInput.test.ts
@@ -27,7 +27,7 @@ describe('Claude Code SDK input', () => {
     await fs.writeFile(imagePath, imageBytes);
     const imageResizer = {
       process: vi.fn(async (inputPath: string) => inputPath),
-      validate: vi.fn(async () => true),
+      validateBuffer: vi.fn(async () => true),
     };
     const content: UserMessage['content'] = [
       { type: 'text', text: 'Inspect these' },
@@ -57,7 +57,7 @@ describe('Claude Code SDK input', () => {
     await fs.writeFile(resizedPath, resizedBytes);
     const imageResizer = {
       process: vi.fn(async () => resizedPath),
-      validate: vi.fn(async () => true),
+      validateBuffer: vi.fn(async () => true),
     };
     const content: UserMessage['content'] = [
       { type: 'image', path: sourcePath, mimeType: 'image/png' },
@@ -85,7 +85,7 @@ describe('Claude Code SDK input', () => {
     await fs.writeFile(imagePath, imageBytes);
     const imageResizer = {
       process: vi.fn(async () => imagePath),
-      validate: vi.fn(async () => true),
+      validateBuffer: vi.fn(async () => true),
     };
     const content: UserMessage['content'] = [
       { type: 'image', path: imagePath, mimeType: 'image/webp' },
@@ -110,7 +110,7 @@ describe('Claude Code SDK input', () => {
     const missingPath = path.join(tempDir, 'missing.png');
     const imageResizer = {
       process: vi.fn(async () => missingPath),
-      validate: vi.fn(async () => true),
+      validateBuffer: vi.fn(async () => true),
     };
     const content: UserMessage['content'] = [
       { type: 'image', path: missingPath, mimeType: 'image/png' },
@@ -130,7 +130,7 @@ describe('Claude Code SDK input', () => {
     await fs.writeFile(imagePath, imageBytes);
     const imageResizer = {
       process: vi.fn(async () => imagePath),
-      validate: vi.fn(async () => true),
+      validateBuffer: vi.fn(async () => true),
     };
     const content: UserMessage['content'] = [
       { type: 'image', path: imagePath, mimeType: 'image/png' },
@@ -150,7 +150,7 @@ describe('Claude Code SDK input', () => {
     await fs.writeFile(imagePath, imageBytes);
     const imageResizer = {
       process: vi.fn(async () => imagePath),
-      validate: vi.fn(async () => true),
+      validateBuffer: vi.fn(async () => true),
     };
     const content: UserMessage['content'] = [
       { type: 'image', path: imagePath, mimeType: 'image/png' },
@@ -179,7 +179,7 @@ describe('Claude Code SDK input', () => {
     );
     const imageResizer = {
       process: vi.fn(async () => imagePath),
-      validate: vi.fn(async () => true),
+      validateBuffer: vi.fn(async () => true),
     };
     const content: UserMessage['content'] = [
       { type: 'image', path: imagePath, mimeType: 'image/png' },

--- a/apps/desktop/src/main/__tests__/claudeInput.test.ts
+++ b/apps/desktop/src/main/__tests__/claudeInput.test.ts
@@ -23,7 +23,7 @@ describe('Claude Code SDK input', () => {
   it('inlines an original image while keeping file attachments as path refs', async () => {
     const tempDir = await createTempDir();
     const imagePath = path.join(tempDir, 'small.png');
-    const imageBytes = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+    const imageBytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
     await fs.writeFile(imagePath, imageBytes);
     const imageResizer = { process: vi.fn(async (inputPath: string) => inputPath) };
     const content: UserMessage['content'] = [
@@ -50,7 +50,7 @@ describe('Claude Code SDK input', () => {
     const tempDir = await createTempDir();
     const sourcePath = path.join(tempDir, 'large.png');
     const resizedPath = path.join(tempDir, 'large.webp');
-    const resizedBytes = Buffer.from([0x52, 0x49, 0x46, 0x46]);
+    const resizedBytes = Buffer.from('RIFF0000WEBP', 'ascii');
     await fs.writeFile(resizedPath, resizedBytes);
     const imageResizer = { process: vi.fn(async () => resizedPath) };
     const content: UserMessage['content'] = [
@@ -70,6 +70,30 @@ describe('Claude Code SDK input', () => {
       { type: 'text', text: 'Read the image' },
     ]);
     expect(imageResizer.process).toHaveBeenCalledWith(sourcePath);
+  });
+
+  it('uses image bytes instead of a misleading extension or declared MIME type', async () => {
+    const tempDir = await createTempDir();
+    const imagePath = path.join(tempDir, 'misleading.png');
+    const imageBytes = Buffer.from([0xff, 0xd8, 0xff, 0xe0]);
+    await fs.writeFile(imagePath, imageBytes);
+    const imageResizer = { process: vi.fn(async () => imagePath) };
+    const content: UserMessage['content'] = [
+      { type: 'image', path: imagePath, mimeType: 'image/webp' },
+      { type: 'text', text: 'Inspect this' },
+    ];
+
+    expect(await toClaudeSdkContent(content, imageResizer)).toEqual([
+      {
+        type: 'image',
+        source: {
+          type: 'base64',
+          media_type: 'image/jpeg',
+          data: imageBytes.toString('base64'),
+        },
+      },
+      { type: 'text', text: 'Inspect this' },
+    ]);
   });
 
   it('falls back to a quoted path when the final image cannot be read', async () => {

--- a/apps/desktop/src/main/__tests__/claudeInput.test.ts
+++ b/apps/desktop/src/main/__tests__/claudeInput.test.ts
@@ -25,7 +25,10 @@ describe('Claude Code SDK input', () => {
     const imagePath = path.join(tempDir, 'small.png');
     const imageBytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
     await fs.writeFile(imagePath, imageBytes);
-    const imageResizer = { process: vi.fn(async (inputPath: string) => inputPath) };
+    const imageResizer = {
+      process: vi.fn(async (inputPath: string) => inputPath),
+      validate: vi.fn(async () => true),
+    };
     const content: UserMessage['content'] = [
       { type: 'text', text: 'Inspect these' },
       { type: 'file', path: 'E:\\repo\\large.txt', mimeType: 'text/plain' },
@@ -52,7 +55,10 @@ describe('Claude Code SDK input', () => {
     const resizedPath = path.join(tempDir, 'large.webp');
     const resizedBytes = Buffer.from('RIFF0000WEBP', 'ascii');
     await fs.writeFile(resizedPath, resizedBytes);
-    const imageResizer = { process: vi.fn(async () => resizedPath) };
+    const imageResizer = {
+      process: vi.fn(async () => resizedPath),
+      validate: vi.fn(async () => true),
+    };
     const content: UserMessage['content'] = [
       { type: 'image', path: sourcePath, mimeType: 'image/png' },
       { type: 'text', text: 'Read the image' },
@@ -77,7 +83,10 @@ describe('Claude Code SDK input', () => {
     const imagePath = path.join(tempDir, 'misleading.png');
     const imageBytes = Buffer.from([0xff, 0xd8, 0xff, 0xe0]);
     await fs.writeFile(imagePath, imageBytes);
-    const imageResizer = { process: vi.fn(async () => imagePath) };
+    const imageResizer = {
+      process: vi.fn(async () => imagePath),
+      validate: vi.fn(async () => true),
+    };
     const content: UserMessage['content'] = [
       { type: 'image', path: imagePath, mimeType: 'image/webp' },
       { type: 'text', text: 'Inspect this' },
@@ -99,7 +108,10 @@ describe('Claude Code SDK input', () => {
   it('falls back to a quoted path when the final image cannot be read', async () => {
     const tempDir = await createTempDir();
     const missingPath = path.join(tempDir, 'missing.png');
-    const imageResizer = { process: vi.fn(async () => missingPath) };
+    const imageResizer = {
+      process: vi.fn(async () => missingPath),
+      validate: vi.fn(async () => true),
+    };
     const content: UserMessage['content'] = [
       { type: 'image', path: missingPath, mimeType: 'image/png' },
       { type: 'text', text: 'Inspect this' },
@@ -116,7 +128,10 @@ describe('Claude Code SDK input', () => {
     const imageBytes = Buffer.alloc(Math.floor((5 * 1024 * 1024) / 4) * 3 + 1);
     Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]).copy(imageBytes);
     await fs.writeFile(imagePath, imageBytes);
-    const imageResizer = { process: vi.fn(async () => imagePath) };
+    const imageResizer = {
+      process: vi.fn(async () => imagePath),
+      validate: vi.fn(async () => true),
+    };
     const content: UserMessage['content'] = [
       { type: 'image', path: imagePath, mimeType: 'image/png' },
       { type: 'text', text: 'Inspect this' },
@@ -133,7 +148,10 @@ describe('Claude Code SDK input', () => {
     const imageBytes = Buffer.alloc(Math.floor((5 * 1024 * 1024) / 4) * 3);
     Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]).copy(imageBytes);
     await fs.writeFile(imagePath, imageBytes);
-    const imageResizer = { process: vi.fn(async () => imagePath) };
+    const imageResizer = {
+      process: vi.fn(async () => imagePath),
+      validate: vi.fn(async () => true),
+    };
     const content: UserMessage['content'] = [
       { type: 'image', path: imagePath, mimeType: 'image/png' },
     ];
@@ -159,7 +177,10 @@ describe('Claude Code SDK input', () => {
       imagePath,
       Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
     );
-    const imageResizer = { process: vi.fn(async () => imagePath) };
+    const imageResizer = {
+      process: vi.fn(async () => imagePath),
+      validate: vi.fn(async () => true),
+    };
     const content: UserMessage['content'] = [
       { type: 'image', path: imagePath, mimeType: 'image/png' },
       { type: 'text', text: 'Inspect this' },

--- a/apps/desktop/src/main/__tests__/normalizeAttachmentsOss.test.ts
+++ b/apps/desktop/src/main/__tests__/normalizeAttachmentsOss.test.ts
@@ -148,10 +148,13 @@ describe('normalizeUserMessage — device-link 出方向 OSS 引用物化', () =
     const [ossKeyArg, destArg] = downloadToFile.mock.calls[0] as unknown as [string, string];
     expect(ossKeyArg).toBe('cindy/device-link/u/x.png');
     expect(destArg).toMatch(/cindy-attachments[\\/]v2-[^\\/]+[\\/]sess-1[\\/].+\.png$/);
-    const block = (out as { content: Array<{ type: string; path?: string; mimeType?: string }> })
+    const block = (out as {
+      content: Array<{ type: string; path?: string; mimeType?: string; pathOrigin?: string }>;
+    })
       .content[1];
     expect(block.path).toBe(destArg); // path 指向下载目标
     expect(block.mimeType).toBe('image/png');
+    expect(block.pathOrigin).toBe('desktop-host');
     expect(removeRemote).toHaveBeenCalledWith('cindy/device-link/u/x.png');
   });
 

--- a/apps/desktop/src/main/maker-ipc/__tests__/normalizeAttachmentsTemp.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/normalizeAttachmentsTemp.test.ts
@@ -220,6 +220,32 @@ describe('inline attachment temporary files', () => {
     expect(downloadToFile).not.toHaveBeenCalled();
   });
 
+  it('keeps queued annotated images on their burned image URL', async () => {
+    const burnedUrl = 'xdt-image://queued-annotated/annotated.png';
+    const originalPath = path.join(tempRoot.value, 'original.png');
+    await fs.writeFile(originalPath, Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+    const item = {
+      clientId: 'queued-annotated-image',
+      files: [{
+        category: 'image',
+        ext: '.png',
+        path: originalPath,
+        url: burnedUrl,
+        mimeType: 'image/png',
+        annotated: true,
+      }],
+    };
+
+    const materialized = await materializeQueuedOssAttachmentsDeferred(
+      'queued-annotated-image',
+      item,
+    );
+
+    expect(materialized.item).toBe(item);
+    expect(ingestMedia).not.toHaveBeenCalled();
+    expect(downloadToFile).not.toHaveBeenCalled();
+  });
+
   it('writes private bytes and removes them even before Maker owns the session', async () => {
     const sessionId = 'reviewer-session';
     const normalized = await normalizeUserMessage(sessionId, {

--- a/apps/desktop/src/main/maker-ipc/__tests__/normalizeAttachmentsTemp.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/normalizeAttachmentsTemp.test.ts
@@ -220,20 +220,38 @@ describe('inline attachment temporary files', () => {
     expect(downloadToFile).not.toHaveBeenCalled();
   });
 
-  it('keeps queued annotated images on their burned image URL', async () => {
+  it('keeps queued images on managed URLs instead of rematerializing their source paths', async () => {
     const burnedUrl = 'xdt-image://queued-annotated/annotated.png';
+    const selectedUrl = 'xdt-image://queued-selected/selected.png';
+    const mediaUrl = `cindy-media://blobs/${'d'.repeat(64)}.png`;
     const originalPath = path.join(tempRoot.value, 'original.png');
     await fs.writeFile(originalPath, Buffer.from([0x89, 0x50, 0x4e, 0x47]));
     const item = {
       clientId: 'queued-annotated-image',
-      files: [{
-        category: 'image',
-        ext: '.png',
-        path: originalPath,
-        url: burnedUrl,
-        mimeType: 'image/png',
-        annotated: true,
-      }],
+      files: [
+        {
+          category: 'image',
+          ext: '.png',
+          path: originalPath,
+          url: selectedUrl,
+          mimeType: 'image/png',
+        },
+        {
+          category: 'image',
+          ext: '.png',
+          path: originalPath,
+          url: mediaUrl,
+          mimeType: 'image/png',
+        },
+        {
+          category: 'image',
+          ext: '.png',
+          path: originalPath,
+          url: burnedUrl,
+          mimeType: 'image/png',
+          annotated: true,
+        },
+      ],
     };
 
     const materialized = await materializeQueuedOssAttachmentsDeferred(

--- a/apps/desktop/src/main/maker-ipc/__tests__/normalizeAttachmentsTemp.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/normalizeAttachmentsTemp.test.ts
@@ -66,7 +66,10 @@ describe('inline attachment temporary files', () => {
     }
     const imageBlock = normalized.content.find((block) => block.type === 'image');
     const imagePath = imageBlock?.path;
-    if (typeof imagePath !== 'string') throw new Error('expected materialized image path');
+    if (!imageBlock || typeof imagePath !== 'string') {
+      throw new Error('expected materialized image path');
+    }
+    expect(imageBlock.pathOrigin).toBe('desktop-host');
     const sessionTempDir = path.dirname(imagePath);
     const ownerRoot = path.dirname(sessionTempDir);
     const ownerRecord = JSON.parse(

--- a/apps/desktop/src/main/maker-ipc/__tests__/normalizeAttachmentsTemp.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/normalizeAttachmentsTemp.test.ts
@@ -35,6 +35,7 @@ import {
   cleanupSessionTempAttachments,
   configureTempAttachmentOwner,
   materializeDirectSendOssAttachments,
+  materializeQueuedOssAttachmentsDeferred,
   normalizeUserMessage,
 } from '../normalizeAttachments.js';
 import * as cindyMediaBlobStore from '../../cindy-media/blobStore.js';
@@ -108,6 +109,115 @@ describe('inline attachment temporary files', () => {
     });
     materialized.cleanupAfterAcceptance?.();
     expect(removeRemote).toHaveBeenCalledWith('cindy/device-link/user/image.png');
+  });
+
+  it('marks queued OSS images as desktop-host attachments after materialization', async () => {
+    const hash = 'b'.repeat(64);
+    const mediaUrl = `cindy-media://blobs/${hash}.png`;
+    const absPath = path.join(tempRoot.value, 'queued-materialized.png');
+    vi.mocked(downloadToFile).mockImplementationOnce(async (_ossKey, destination) => {
+      await fs.writeFile(destination, Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+    });
+    vi.mocked(cindyMediaBlobStore.supportedMime).mockReturnValue(true);
+    vi.mocked(cindyMediaBlobStore.resolveSafe).mockReturnValue({
+      absPath,
+      mimeType: 'image/png',
+      hash,
+    });
+    vi.mocked(ingestMedia).mockResolvedValueOnce({
+      hash,
+      ext: '.png',
+      mimeType: 'image/png',
+      bytes: 4,
+      url: mediaUrl,
+      deduplicated: false,
+      refIds: ['ref-2'],
+    });
+    const ossRef = buildAttachmentOssRef({
+      ossKey: 'cindy/device-link/user/queued-image.png',
+      mimeType: 'image/png',
+      originalName: 'queued-image.png',
+    });
+
+    const materialized = await materializeQueuedOssAttachmentsDeferred(
+      'queued-oss-image',
+      {
+        clientId: 'queued-image-1',
+        files: [{
+          category: 'image',
+          ext: '.png',
+          path: ossRef,
+          mimeType: 'image/png',
+        }],
+      },
+    );
+
+    expect(materialized.item).toEqual({
+      clientId: 'queued-image-1',
+      files: [{
+        category: 'image',
+        ext: '.png',
+        path: absPath,
+        url: mediaUrl,
+        mimeType: 'image/png',
+        pathOrigin: 'desktop-host',
+        base64: undefined,
+      }],
+      persistedContent: undefined,
+    });
+    materialized.cleanupAfterAcceptance?.();
+    expect(removeRemote).toHaveBeenCalledWith('cindy/device-link/user/queued-image.png');
+  });
+
+  it('marks queued local images as desktop-host attachments after materialization', async () => {
+    const sourcePath = path.join(tempRoot.value, 'device-link-local.png');
+    await fs.writeFile(sourcePath, Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+    const hash = 'c'.repeat(64);
+    const mediaUrl = `cindy-media://blobs/${hash}.png`;
+    const absPath = path.join(tempRoot.value, 'queued-local-materialized.png');
+    vi.mocked(cindyMediaBlobStore.mimeForExt).mockReturnValue('image/png');
+    vi.mocked(cindyMediaBlobStore.resolveSafe).mockReturnValue({
+      absPath,
+      mimeType: 'image/png',
+      hash,
+    });
+    vi.mocked(ingestMedia).mockResolvedValueOnce({
+      hash,
+      ext: '.png',
+      mimeType: 'image/png',
+      bytes: 4,
+      url: mediaUrl,
+      deduplicated: false,
+      refIds: ['ref-3'],
+    });
+
+    const materialized = await materializeQueuedOssAttachmentsDeferred(
+      'queued-local-image',
+      {
+        clientId: 'queued-image-2',
+        files: [{
+          category: 'image',
+          ext: '.png',
+          path: sourcePath,
+          mimeType: 'image/png',
+        }],
+      },
+    );
+
+    expect(materialized.item).toEqual({
+      clientId: 'queued-image-2',
+      files: [{
+        category: 'image',
+        ext: '.png',
+        path: absPath,
+        url: mediaUrl,
+        mimeType: 'image/png',
+        pathOrigin: 'desktop-host',
+        base64: undefined,
+      }],
+      persistedContent: undefined,
+    });
+    expect(downloadToFile).not.toHaveBeenCalled();
   });
 
   it('writes private bytes and removes them even before Maker owns the session', async () => {

--- a/apps/desktop/src/main/maker-ipc/__tests__/normalizeAttachmentsTemp.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/normalizeAttachmentsTemp.test.ts
@@ -14,8 +14,13 @@ vi.mock('../../imageCacheStore.js', () => ({
 }));
 vi.mock('../../cindy-media/blobStore.js', () => ({
   resolveSafe: vi.fn(),
+  supportedMime: vi.fn(),
+  mimeForExt: vi.fn(),
 }));
-vi.mock('../../cindy-media/ledger.js', () => ({}));
+vi.mock('../../cindy-media/ledger.js', () => ({
+  removeRefById: vi.fn(),
+  deleteZeroRefBlobRecord: vi.fn(),
+}));
 vi.mock('../../cindy-media/ingest.js', () => ({ ingestMedia: vi.fn() }));
 vi.mock('../../device-link/mediaTransfer.js', () => ({
   downloadToFile: vi.fn(),
@@ -29,12 +34,18 @@ import {
   cleanupOrphanedTempAttachments,
   cleanupSessionTempAttachments,
   configureTempAttachmentOwner,
+  materializeDirectSendOssAttachments,
   normalizeUserMessage,
 } from '../normalizeAttachments.js';
+import * as cindyMediaBlobStore from '../../cindy-media/blobStore.js';
+import { ingestMedia } from '../../cindy-media/ingest.js';
+import { downloadToFile, removeRemote } from '../../device-link/mediaTransfer.js';
+import { buildAttachmentOssRef } from '../../../shared/attachmentOssRef.js';
 
 const tempDirs: string[] = [];
 
 beforeEach(async () => {
+  vi.clearAllMocks();
   tempRoot.value = await fs.mkdtemp(path.join(os.tmpdir(), 'cindy-review-inline-test-'));
   tempDirs.push(tempRoot.value);
   configureTempAttachmentOwner({
@@ -48,6 +59,57 @@ afterEach(async () => {
 });
 
 describe('inline attachment temporary files', () => {
+  it('marks directly materialized OSS images as desktop-host attachments', async () => {
+    const hash = 'a'.repeat(64);
+    const mediaUrl = `cindy-media://blobs/${hash}.png`;
+    const absPath = path.join(tempRoot.value, 'materialized.png');
+    vi.mocked(downloadToFile).mockImplementationOnce(async (_ossKey, destination) => {
+      await fs.writeFile(destination, Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+    });
+    vi.mocked(cindyMediaBlobStore.supportedMime).mockReturnValue(true);
+    vi.mocked(cindyMediaBlobStore.resolveSafe).mockReturnValue({
+      absPath,
+      mimeType: 'image/png',
+      hash,
+    });
+    vi.mocked(ingestMedia).mockResolvedValueOnce({
+      hash,
+      ext: '.png',
+      mimeType: 'image/png',
+      bytes: 4,
+      url: mediaUrl,
+      deduplicated: false,
+      refIds: ['ref-1'],
+    });
+    const ossRef = buildAttachmentOssRef({
+      ossKey: 'cindy/device-link/user/image.png',
+      mimeType: 'image/png',
+      originalName: 'image.png',
+    });
+
+    const materialized = await materializeDirectSendOssAttachments(
+      'direct-oss-image',
+      {
+        type: 'user',
+        content: [{ type: 'image', path: ossRef, mimeType: 'image/png' }],
+      },
+      undefined,
+    );
+
+    expect(materialized.message).toEqual({
+      type: 'user',
+      content: [{
+        type: 'image',
+        path: absPath,
+        mimeType: 'image/png',
+        pathOrigin: 'desktop-host',
+        base64: undefined,
+      }],
+    });
+    materialized.cleanupAfterAcceptance?.();
+    expect(removeRemote).toHaveBeenCalledWith('cindy/device-link/user/image.png');
+  });
+
   it('writes private bytes and removes them even before Maker owns the session', async () => {
     const sessionId = 'reviewer-session';
     const normalized = await normalizeUserMessage(sessionId, {

--- a/apps/desktop/src/main/maker-ipc/normalizeAttachments.ts
+++ b/apps/desktop/src/main/maker-ipc/normalizeAttachments.ts
@@ -863,9 +863,11 @@ export async function materializeDirectSendOssAttachments(
       typeof pathValue === 'string' &&
       pathValue !== originalPath
     ) {
+      const isImage = (original as { type?: unknown }).type === 'image';
       nextContent[attachmentIndexes[index]] = {
         ...(original as object),
         path: pathValue,
+        ...(isImage ? { pathOrigin: 'desktop-host' as const } : {}),
         base64: undefined,
       };
     }

--- a/apps/desktop/src/main/maker-ipc/normalizeAttachments.ts
+++ b/apps/desktop/src/main/maker-ipc/normalizeAttachments.ts
@@ -418,7 +418,6 @@ type SerializedFileLike = {
   type?: unknown;
   category?: unknown;
   ext?: unknown;
-  annotated?: unknown;
 };
 
 function isQueuedImageFile(file: SerializedFileLike): boolean {
@@ -459,12 +458,17 @@ function needsImageMaterialize(v: unknown): v is string {
   return isOssRefField(v) || isLocalImagePathField(v);
 }
 
+function isManagedImageUrl(v: unknown): v is string {
+  return (
+    typeof v === 'string'
+    && (v.startsWith('xdt-image://') || v.startsWith('cindy-media://'))
+  );
+}
+
 function queuedFileMaterializeRef(file: SerializedFileLike): string | null {
   if (isOssRefField(file.url)) return file.url;
-  // 标注图的 url 是烧录位图，path 仍是原始磁盘图；本地队列必须继续使用 url。
-  if (file.annotated === true && typeof file.url === 'string' && file.url.length > 0) {
-    return null;
-  }
+  // url 是队列实际消费的图片；path 只是文件选择器保留的原始磁盘来源。
+  if (isQueuedImageFile(file) && isManagedImageUrl(file.url)) return null;
   if (isOssRefField(file.path)) return file.path;
   if (!isQueuedImageFile(file)) return null;
   if (isLocalImagePathField(file.url)) return file.url;

--- a/apps/desktop/src/main/maker-ipc/normalizeAttachments.ts
+++ b/apps/desktop/src/main/maker-ipc/normalizeAttachments.ts
@@ -410,7 +410,24 @@ export async function normalizeUserMessage(
 // device-link 出方向:被控端入队消息的 OSS 引用一次性物化(files[] + persistedContent 共用下载)
 // ───────────────────────────────────────────────────────────────────────────
 
-type SerializedFileLike = { url?: unknown; path?: unknown; base64?: unknown; mimeType?: unknown };
+type SerializedFileLike = {
+  url?: unknown;
+  path?: unknown;
+  base64?: unknown;
+  mimeType?: unknown;
+  type?: unknown;
+  category?: unknown;
+  ext?: unknown;
+};
+
+function isQueuedImageFile(file: SerializedFileLike): boolean {
+  if (file.type === 'image') return true;
+  return (
+    file.category === 'image'
+    && typeof file.ext === 'string'
+    && file.ext.toLowerCase() !== '.gif'
+  );
+}
 
 /** 该字段是 device-link 出方向附件 OSS 引用串。 */
 function isOssRefField(v: unknown): v is string {
@@ -439,6 +456,15 @@ function isLocalImagePathField(v: unknown): v is string {
 /** persistedContent images[].url 需要物化:OSS 引用,或被控端本机绝对路径图片。 */
 function needsImageMaterialize(v: unknown): v is string {
   return isOssRefField(v) || isLocalImagePathField(v);
+}
+
+function queuedFileMaterializeRef(file: SerializedFileLike): string | null {
+  if (isOssRefField(file.url)) return file.url;
+  if (isOssRefField(file.path)) return file.path;
+  if (!isQueuedImageFile(file)) return null;
+  if (isLocalImagePathField(file.url)) return file.url;
+  if (isLocalImagePathField(file.path)) return file.path;
+  return null;
 }
 
 /** persistedContent JSON 串里是否含需物化引用(images[].url / files[].path)。解析失败 → 视作无。 */
@@ -543,15 +569,14 @@ async function materializeQueuedOssAttachmentsInternal(
   const files = Array.isArray(it.files) ? it.files : null;
   const pcStr = typeof it.persistedContent === 'string' ? it.persistedContent : null;
 
-  const filesHaveOss =
+  const filesNeedMaterialize =
     files?.some(
       (f) =>
         !!f &&
         typeof f === 'object' &&
-        (isOssRefField((f as SerializedFileLike).url) ||
-          isOssRefField((f as SerializedFileLike).path)),
+        queuedFileMaterializeRef(f as SerializedFileLike) !== null,
     ) ?? false;
-  if (!filesHaveOss && !(pcStr && persistedContentNeedsMaterialize(pcStr))) return { item }; // 无需物化 → 原样
+  if (!filesNeedMaterialize && !(pcStr && persistedContentNeedsMaterialize(pcStr))) return { item }; // 无需物化 → 原样
 
   const byRef = new Map<string, MaterializedRef>(); // 引用串 → 物化结果(同串只下载/拷贝+入库一次)
   const ossKeys = new Set<string>();
@@ -697,7 +722,7 @@ async function materializeQueuedOssAttachmentsInternal(
           continue;
         }
         const sf = f as SerializedFileLike;
-        const refStr = isOssRefField(sf.url) ? sf.url : isOssRefField(sf.path) ? sf.path : null;
+        const refStr = queuedFileMaterializeRef(sf);
         if (!refStr) {
           out.push(f);
           continue;
@@ -706,7 +731,15 @@ async function materializeQueuedOssAttachmentsInternal(
           refStr,
           typeof sf.mimeType === 'string' ? sf.mimeType : undefined,
         );
-        out.push(m ? { ...(f as object), url: m.url, path: m.absPath, base64: undefined } : f);
+        out.push(m
+          ? {
+              ...(f as object),
+              url: m.url,
+              path: m.absPath,
+              ...(isQueuedImageFile(sf) ? { pathOrigin: 'desktop-host' as const } : {}),
+              base64: undefined,
+            }
+          : f);
       }
       nextFiles = out;
     }

--- a/apps/desktop/src/main/maker-ipc/normalizeAttachments.ts
+++ b/apps/desktop/src/main/maker-ipc/normalizeAttachments.ts
@@ -418,6 +418,7 @@ type SerializedFileLike = {
   type?: unknown;
   category?: unknown;
   ext?: unknown;
+  annotated?: unknown;
 };
 
 function isQueuedImageFile(file: SerializedFileLike): boolean {
@@ -460,6 +461,10 @@ function needsImageMaterialize(v: unknown): v is string {
 
 function queuedFileMaterializeRef(file: SerializedFileLike): string | null {
   if (isOssRefField(file.url)) return file.url;
+  // 标注图的 url 是烧录位图，path 仍是原始磁盘图；本地队列必须继续使用 url。
+  if (file.annotated === true && typeof file.url === 'string' && file.url.length > 0) {
+    return null;
+  }
   if (isOssRefField(file.path)) return file.path;
   if (!isQueuedImageFile(file)) return null;
   if (isLocalImagePathField(file.url)) return file.url;

--- a/apps/desktop/src/main/maker-ipc/normalizeAttachments.ts
+++ b/apps/desktop/src/main/maker-ipc/normalizeAttachments.ts
@@ -272,6 +272,7 @@ type AttachmentBlock = {
   path?: string;
   base64?: string;
   mimeType?: string;
+  pathOrigin?: 'desktop-host';
 };
 type UserMessageShape = string | { type: 'user'; content: string | RawBlock[] };
 
@@ -299,6 +300,16 @@ export async function normalizeUserMessage(
     }
 
     const block = { ...raw } as AttachmentBlock & { type: 'image' | 'file' };
+    const isDesktopHostImage = block.type === 'image' && (
+      block.pathOrigin === 'desktop-host'
+      || Boolean(block.base64)
+      || (typeof block.path === 'string' && (
+        block.path.startsWith('xdt-image://')
+        || block.path.startsWith('cindy-media://')
+        || isAttachmentOssRef(block.path)
+      ))
+    );
+    if (isDesktopHostImage) block.pathOrigin = 'desktop-host';
 
     // 0) device-link 出方向 OSS 引用(控制端发来的附件)→ presign-get 下载物化到临时文件,
     //    用后删 OSS。新引用下载/校验失败 → 整条不发；旧引用保留历史的单附件降级语义。

--- a/apps/desktop/src/renderer/__tests__/messageAttachmentPayload.test.ts
+++ b/apps/desktop/src/renderer/__tests__/messageAttachmentPayload.test.ts
@@ -65,6 +65,7 @@ describe('messageAttachmentPayload', () => {
         type: 'image',
         path: 'xdt-image://session/shot.png',
         mimeType: 'image/png',
+        pathOrigin: 'desktop-host',
         originalName: 'original.png',
       },
     ]);
@@ -95,7 +96,29 @@ describe('messageAttachmentPayload', () => {
         type: 'image',
         base64: 'inline-image',
         mimeType: 'image/png',
+        pathOrigin: 'desktop-host',
         originalName: 'fallback.png',
+      },
+    ]);
+  });
+
+  it('marks a desktop image path so remote sessions can keep the local-file warning', () => {
+    const imagePath = join('desktop', 'photo.jpg');
+    const image = attachment({
+      name: 'photo.jpg',
+      path: imagePath,
+      ext: '.jpg',
+      category: 'image',
+      mimeType: 'image/jpeg',
+    });
+
+    expect(buildMakerUserContentBlocks('', undefined, [image])).toEqual([
+      {
+        type: 'image',
+        path: imagePath,
+        mimeType: 'image/jpeg',
+        pathOrigin: 'desktop-host',
+        originalName: 'photo.jpg',
       },
     ]);
   });

--- a/apps/desktop/src/renderer/__tests__/messageAttachmentPayload.test.ts
+++ b/apps/desktop/src/renderer/__tests__/messageAttachmentPayload.test.ts
@@ -49,6 +49,7 @@ describe('messageAttachmentPayload', () => {
         path: 'clipboard://paste-1',
         url: 'xdt-image://session/shot.png',
         originalName: 'original.png',
+        pathOrigin: 'desktop-host',
       }),
     ]);
     expect(payload.imageAttachments).toEqual([

--- a/apps/desktop/src/renderer/lib/fileTypes.ts
+++ b/apps/desktop/src/renderer/lib/fileTypes.ts
@@ -142,6 +142,8 @@ export interface SerializedAttachedFile {
   size: number;
   category: FileCategory;
   mimeType: string;
+  /** Image source was selected or pasted on the Desktop host. */
+  pathOrigin?: 'desktop-host';
   url?: string;
   originalName?: string;
   /**

--- a/apps/desktop/src/renderer/lib/messageAttachmentPayload.ts
+++ b/apps/desktop/src/renderer/lib/messageAttachmentPayload.ts
@@ -123,7 +123,11 @@ function buildImageAttachment(file: AttachedFile): RenderImageAttachment | null 
 export function buildUserMessageAttachmentPayload(
   files?: readonly AttachedFile[],
 ): UserMessageAttachmentPayload {
-  const serializedFiles = serializeAttachedFiles(files);
+  const serializedFiles = serializeAttachedFiles(files)?.map((file) => (
+    getAgentInputAttachmentBlockType(file.category, file.ext) === 'image'
+      ? { ...file, pathOrigin: 'desktop-host' as const }
+      : file
+  ));
   const imageAttachments = files
     ?.map(buildImageAttachment)
     .filter((image): image is RenderImageAttachment => image !== null);

--- a/apps/desktop/src/renderer/lib/messageAttachmentPayload.ts
+++ b/apps/desktop/src/renderer/lib/messageAttachmentPayload.ts
@@ -30,6 +30,7 @@ export type SdkAttachmentBlock = {
   path?: string;
   base64?: string;
   mimeType?: string;
+  pathOrigin?: 'desktop-host';
   originalName?: string;
   /**
    * 显式文件附件的原始磁盘路径(path 为 xdt-image:// 缓存 URL 时携带):
@@ -143,6 +144,7 @@ export function buildUserMessageAttachmentPayload(
 
 function buildAttachmentBlock(file: SerializedAttachedFile): SdkAttachmentBlock | null {
   const type = getAgentInputAttachmentBlockType(file.category, file.ext);
+  const pathOrigin = type === 'image' ? { pathOrigin: 'desktop-host' as const } : {};
   if (file.url) {
     // 显式文件(选择器/拖拽)拷入缓存后 url 与原始磁盘 path 并存:把原始路径一并
     // 带上,message 形态的远程发送才能识别「字节精确」语义不压缩(队列形态的
@@ -154,6 +156,7 @@ function buildAttachmentBlock(file: SerializedAttachedFile): SdkAttachmentBlock 
       type,
       path: file.url,
       mimeType: file.mimeType,
+      ...pathOrigin,
       originalName: file.originalName ?? file.name,
       ...(originalPath ? { originalPath } : {}),
     };
@@ -163,6 +166,7 @@ function buildAttachmentBlock(file: SerializedAttachedFile): SdkAttachmentBlock 
       type,
       path: file.path,
       mimeType: file.mimeType,
+      ...pathOrigin,
       originalName: file.originalName ?? file.name,
     };
   }
@@ -173,6 +177,7 @@ function buildAttachmentBlock(file: SerializedAttachedFile): SdkAttachmentBlock 
       type,
       base64: legacyBase64,
       mimeType: file.mimeType,
+      ...pathOrigin,
       originalName: file.originalName ?? file.name,
     };
   }

--- a/apps/desktop/src/shared/agentInputQueue.ts
+++ b/apps/desktop/src/shared/agentInputQueue.ts
@@ -30,6 +30,8 @@ export interface AgentInputSerializedFile {
   size: number;
   category: AgentInputFileCategory;
   mimeType: string;
+  /** Renderer-owned image path that originated on this Desktop host. */
+  pathOrigin?: 'desktop-host';
   url?: string;
   originalName?: string;
   base64?: string;
@@ -933,12 +935,15 @@ export function buildMakerUserMessage(
   let hasAnnotatedImage = false;
   for (const f of queued.files ?? []) {
     const type = getAgentInputAttachmentBlockType(f.category, f.ext);
+    const pathOrigin = type === 'image' && f.pathOrigin === 'desktop-host'
+      ? { pathOrigin: f.pathOrigin }
+      : {};
     if (f.url) {
-      blocks.push({ type, path: f.url, mimeType: f.mimeType });
+      blocks.push({ type, path: f.url, mimeType: f.mimeType, ...pathOrigin });
     } else if (f.path && !f.path.startsWith('clipboard://')) {
-      blocks.push({ type, path: f.path, mimeType: f.mimeType });
+      blocks.push({ type, path: f.path, mimeType: f.mimeType, ...pathOrigin });
     } else if (f.base64) {
-      blocks.push({ type, base64: f.base64, mimeType: f.mimeType });
+      blocks.push({ type, base64: f.base64, mimeType: f.mimeType, ...pathOrigin });
     } else {
       continue;
     }

--- a/packages/maker-core/src/agents/claude-code/__tests__/abort-stops-background-tasks.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/abort-stops-background-tasks.test.ts
@@ -36,7 +36,7 @@ const asyncQueueMock = vi.hoisted(() => ({
 }));
 const imageResizerMock = vi.hoisted(() => ({
   process: vi.fn(async (p: string) => p),
-  validate: vi.fn(async () => true),
+  validateBuffer: vi.fn(async () => true),
 }));
 
 vi.mock('@anthropic-ai/claude-agent-sdk', () => ({

--- a/packages/maker-core/src/agents/claude-code/__tests__/abort-stops-background-tasks.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/abort-stops-background-tasks.test.ts
@@ -36,6 +36,7 @@ const asyncQueueMock = vi.hoisted(() => ({
 }));
 const imageResizerMock = vi.hoisted(() => ({
   process: vi.fn(async (p: string) => p),
+  validate: vi.fn(async () => true),
 }));
 
 vi.mock('@anthropic-ai/claude-agent-sdk', () => ({

--- a/packages/maker-core/src/agents/claude-code/__tests__/invalid-resume-recovery.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/invalid-resume-recovery.test.ts
@@ -15,6 +15,7 @@ const sdkMock = vi.hoisted(() => ({ query: vi.fn(), forkSession: vi.fn() }));
 
 const imageResizerMock = vi.hoisted(() => ({
   process: vi.fn(async (p: string) => p),
+  validate: vi.fn(async () => true),
 }));
 
 vi.mock('@anthropic-ai/claude-agent-sdk', () => ({

--- a/packages/maker-core/src/agents/claude-code/__tests__/invalid-resume-recovery.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/invalid-resume-recovery.test.ts
@@ -15,7 +15,7 @@ const sdkMock = vi.hoisted(() => ({ query: vi.fn(), forkSession: vi.fn() }));
 
 const imageResizerMock = vi.hoisted(() => ({
   process: vi.fn(async (p: string) => p),
-  validate: vi.fn(async () => true),
+  validateBuffer: vi.fn(async () => true),
 }));
 
 vi.mock('@anthropic-ai/claude-agent-sdk', () => ({

--- a/packages/maker-core/src/agents/claude-code/__tests__/plan-mode.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/plan-mode.test.ts
@@ -187,7 +187,7 @@ afterEach(async () => {
 });
 
 describe('ClaudeCodeAgent plan mode', () => {
-  it('keeps review text, Markdown, PDF, and image references in one real SDK turn', async () => {
+  it('keeps review text, file references, and a native image in one real SDK turn', async () => {
     const { handle, queryPrompt, workingDir } = await startPlanSession(
       false,
       {},
@@ -199,16 +199,14 @@ describe('ClaudeCodeAgent plan mode', () => {
     const imagePath = path.join(workingDir, 'poster.png');
     await fs.writeFile(markdownPath, '# Launch\nBudget: 100 vs 80 + 50');
     await fs.writeFile(pdfPath, '%PDF-1.4\n% review transport fixture');
+    const imageBase64 =
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M8AAAMBAQDJ/pLvAAAAAElFTkSuQmCC';
     await fs.writeFile(
       imagePath,
-      Buffer.from(
-        'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M8AAAMBAQDJ/pLvAAAAAElFTkSuQmCC',
-        'base64',
-      ),
+      Buffer.from(imageBase64, 'base64'),
     );
     const realMarkdownPath = await fs.realpath(markdownPath);
     const realPdfPath = await fs.realpath(pdfPath);
-    const realImagePath = await fs.realpath(imagePath);
     const nextInput = queryPrompt[Symbol.asyncIterator]().next();
 
     await handle.send({
@@ -222,9 +220,20 @@ describe('ClaudeCodeAgent plan mode', () => {
     });
 
     const sdkInput = (await nextInput).value;
-    expect(sdkInput?.message?.content).toBe(
-      `@"${realMarkdownPath}" @"${realPdfPath}" @"${realImagePath}" Review the Markdown, PDF, and image evidence.`,
-    );
+    expect(sdkInput?.message?.content).toEqual([
+      {
+        type: 'image',
+        source: {
+          type: 'base64',
+          media_type: 'image/png',
+          data: imageBase64,
+        },
+      },
+      {
+        type: 'text',
+        text: `@"${realMarkdownPath}" @"${realPdfPath}" Review the Markdown, PDF, and image evidence.`,
+      },
+    ]);
     await handle.close();
   });
 

--- a/packages/maker-core/src/agents/claude-code/__tests__/plan-mode.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/plan-mode.test.ts
@@ -625,6 +625,61 @@ describe('ClaudeCodeAgent plan mode', () => {
     await handle.close();
   });
 
+  it('warns when an active SSH session is steered with a desktop-local image', async () => {
+    const configDir = await makeTempDir();
+    process.env.CLAUDE_CONFIG_DIR = configDir;
+    const workingDir = await makeTempDir();
+    const imagePath = path.join(workingDir, 'desktop-steer.png');
+    const remoteSend = vi.fn(async () => {});
+    const fakeQuery = { ...createFakeQuery(), send: remoteSend };
+    const remoteCcQueryFactory: NonNullable<AgentDeps['remoteCcQueryFactory']> = async () =>
+      fakeQuery as never;
+    const logger = createNoopLogger();
+    const warn = vi.spyOn(logger, 'warn');
+    const agent = new ClaudeCodeAgent(createDeps({ logger, remoteCcQueryFactory }));
+    const handle = await agent.startSession({
+      sessionId: 'session-remote-desktop-steer-image',
+      model: 'claude-opus-4-6',
+      workingDir,
+      remoteHostId: 'remote-1',
+      permissionMode: 'auto',
+    });
+    const iterator = handle.events()[Symbol.asyncIterator]();
+
+    await handle.send({ type: 'user', content: 'Start the remote turn' });
+    await vi.waitFor(() => expect(remoteSend).toHaveBeenCalledTimes(1));
+    await handle.steer({
+      type: 'user',
+      content: [
+        {
+          type: 'image',
+          path: imagePath,
+          mimeType: 'image/png',
+          pathOrigin: 'desktop-host',
+        },
+        { type: 'text', text: 'Inspect this too' },
+      ],
+    });
+    await vi.waitFor(() => expect(remoteSend).toHaveBeenCalledTimes(2));
+
+    expect(warn).toHaveBeenCalledWith(
+      'cc remote: local attachment not accessible on remote session',
+      expect.objectContaining({
+        sessionId: 'session-remote-desktop-steer-image',
+        hostId: 'remote-1',
+      }),
+    );
+    const events = [await nextEvent(iterator), await nextEvent(iterator)];
+    expect(events).toContainEqual(expect.objectContaining({
+      type: 'error',
+      data: expect.objectContaining({
+        message: expect.stringContaining('[REMOTE_LOCAL_ATTACHMENT_UNSUPPORTED]'),
+        isTerminal: false,
+      }),
+    }));
+    await handle.close();
+  });
+
   it('overrides remote cc-manager env with a host-materialized Claude route', async () => {
     const configDir = await makeTempDir();
     process.env.CLAUDE_CONFIG_DIR = configDir;

--- a/packages/maker-core/src/agents/claude-code/__tests__/plan-mode.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/plan-mode.test.ts
@@ -507,6 +507,43 @@ describe('ClaudeCodeAgent plan mode', () => {
     await handle.close();
   });
 
+  it('forwards SSH image paths without reading a same-named desktop file', async () => {
+    const configDir = await makeTempDir();
+    process.env.CLAUDE_CONFIG_DIR = configDir;
+    const workingDir = await makeTempDir();
+    const imagePath = path.join(workingDir, 'remote.png');
+    await fs.writeFile(
+      imagePath,
+      Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    );
+    const remoteSend = vi.fn(async () => {});
+    const fakeQuery = { ...createFakeQuery(), send: remoteSend };
+    const remoteCcQueryFactory: NonNullable<AgentDeps['remoteCcQueryFactory']> = async () =>
+      fakeQuery as never;
+    const agent = new ClaudeCodeAgent(createDeps({ remoteCcQueryFactory }));
+    const handle = await agent.startSession({
+      sessionId: 'session-remote-image-path',
+      model: 'claude-opus-4-6',
+      workingDir,
+      remoteHostId: 'remote-1',
+      permissionMode: 'auto',
+    });
+
+    await handle.send({
+      type: 'user',
+      content: [
+        { type: 'image', path: imagePath, mimeType: 'image/png' },
+        { type: 'text', text: 'Inspect this' },
+      ],
+    });
+    await vi.waitFor(() => expect(remoteSend).toHaveBeenCalledTimes(1));
+
+    expect(remoteSend.mock.calls[0]?.[0]).toMatchObject({
+      message: { content: `@"${imagePath}" Inspect this` },
+    });
+    await handle.close();
+  });
+
   it('overrides remote cc-manager env with a host-materialized Claude route', async () => {
     const configDir = await makeTempDir();
     process.env.CLAUDE_CONFIG_DIR = configDir;

--- a/packages/maker-core/src/agents/claude-code/__tests__/plan-mode.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/plan-mode.test.ts
@@ -30,7 +30,7 @@ vi.mock('@anthropic-ai/claude-agent-sdk', () => ({
   query: sdkMock.query,
 }));
 
-import { ClaudeCodeAgent } from '../index.js';
+import { ClaudeCodeAgent, toClaudeSdkContent } from '../index.js';
 
 const tempDirs: string[] = [];
 const originalClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR;
@@ -187,6 +187,36 @@ afterEach(async () => {
 });
 
 describe('ClaudeCodeAgent plan mode', () => {
+  it('encodes the same image bytes that passed validation', async () => {
+    const workingDir = await makeTempDir();
+    const imagePath = path.join(workingDir, 'race.png');
+    const originalBase64 =
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=';
+    const original = Buffer.from(originalBase64, 'base64');
+    const replacement = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    await fs.writeFile(imagePath, original);
+    const validateBuffer = vi.fn(async (data: Buffer) => {
+      expect(data).toEqual(original);
+      await fs.writeFile(imagePath, replacement);
+      return true;
+    });
+
+    const content = await toClaudeSdkContent(
+      [{ type: 'image', path: imagePath, mimeType: 'image/png' }],
+      { process: async (input) => input, validateBuffer },
+    );
+
+    expect(content).toEqual([{
+      type: 'image',
+      source: {
+        type: 'base64',
+        media_type: 'image/png',
+        data: originalBase64,
+      },
+    }]);
+    expect(validateBuffer).toHaveBeenCalledOnce();
+  });
+
   it('keeps review text, file references, and a native image in one real SDK turn', async () => {
     const { handle, queryPrompt, workingDir } = await startPlanSession(
       false,

--- a/packages/maker-core/src/agents/claude-code/__tests__/plan-mode.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/plan-mode.test.ts
@@ -550,6 +550,59 @@ describe('ClaudeCodeAgent plan mode', () => {
     await handle.close();
   });
 
+  it('warns when an SSH session receives a desktop-local image', async () => {
+    const configDir = await makeTempDir();
+    process.env.CLAUDE_CONFIG_DIR = configDir;
+    const workingDir = await makeTempDir();
+    const imagePath = path.join(workingDir, 'desktop.png');
+    const remoteSend = vi.fn(async () => {});
+    const fakeQuery = { ...createFakeQuery(), send: remoteSend };
+    const remoteCcQueryFactory: NonNullable<AgentDeps['remoteCcQueryFactory']> = async () =>
+      fakeQuery as never;
+    const logger = createNoopLogger();
+    const warn = vi.spyOn(logger, 'warn');
+    const agent = new ClaudeCodeAgent(createDeps({ logger, remoteCcQueryFactory }));
+    const handle = await agent.startSession({
+      sessionId: 'session-remote-desktop-image',
+      model: 'claude-opus-4-6',
+      workingDir,
+      remoteHostId: 'remote-1',
+      permissionMode: 'auto',
+    });
+    const iterator = handle.events()[Symbol.asyncIterator]();
+
+    await handle.send({
+      type: 'user',
+      content: [
+        {
+          type: 'image',
+          path: imagePath,
+          mimeType: 'image/png',
+          pathOrigin: 'desktop-host',
+        },
+        { type: 'text', text: 'Inspect this' },
+      ],
+    });
+    await vi.waitFor(() => expect(remoteSend).toHaveBeenCalledTimes(1));
+
+    expect(warn).toHaveBeenCalledWith(
+      'cc remote: local attachment not accessible on remote session',
+      expect.objectContaining({
+        sessionId: 'session-remote-desktop-image',
+        hostId: 'remote-1',
+      }),
+    );
+    const events = [await nextEvent(iterator), await nextEvent(iterator)];
+    expect(events).toContainEqual(expect.objectContaining({
+      type: 'error',
+      data: expect.objectContaining({
+        message: expect.stringContaining('[REMOTE_LOCAL_ATTACHMENT_UNSUPPORTED]'),
+        isTerminal: false,
+      }),
+    }));
+    await handle.close();
+  });
+
   it('overrides remote cc-manager env with a host-materialized Claude route', async () => {
     const configDir = await makeTempDir();
     process.env.CLAUDE_CONFIG_DIR = configDir;

--- a/packages/maker-core/src/agents/claude-code/__tests__/plan-mode.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/plan-mode.test.ts
@@ -520,7 +520,9 @@ describe('ClaudeCodeAgent plan mode', () => {
     const fakeQuery = { ...createFakeQuery(), send: remoteSend };
     const remoteCcQueryFactory: NonNullable<AgentDeps['remoteCcQueryFactory']> = async () =>
       fakeQuery as never;
-    const agent = new ClaudeCodeAgent(createDeps({ remoteCcQueryFactory }));
+    const logger = createNoopLogger();
+    const warn = vi.spyOn(logger, 'warn');
+    const agent = new ClaudeCodeAgent(createDeps({ logger, remoteCcQueryFactory }));
     const handle = await agent.startSession({
       sessionId: 'session-remote-image-path',
       model: 'claude-opus-4-6',
@@ -541,6 +543,10 @@ describe('ClaudeCodeAgent plan mode', () => {
     expect(remoteSend.mock.calls[0]?.[0]).toMatchObject({
       message: { content: `@"${imagePath}" Inspect this` },
     });
+    expect(warn).not.toHaveBeenCalledWith(
+      'cc remote: local attachment not accessible on remote session',
+      expect.anything(),
+    );
     await handle.close();
   });
 

--- a/packages/maker-core/src/agents/claude-code/__tests__/plan-mode.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/plan-mode.test.ts
@@ -200,7 +200,7 @@ describe('ClaudeCodeAgent plan mode', () => {
     await fs.writeFile(markdownPath, '# Launch\nBudget: 100 vs 80 + 50');
     await fs.writeFile(pdfPath, '%PDF-1.4\n% review transport fixture');
     const imageBase64 =
-      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M8AAAMBAQDJ/pLvAAAAAElFTkSuQmCC';
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=';
     await fs.writeFile(
       imagePath,
       Buffer.from(imageBase64, 'base64'),
@@ -504,6 +504,28 @@ describe('ClaudeCodeAgent plan mode', () => {
     ]);
     expect(starts[0]?.allowedTools).not.toBe(source);
     expect(sdkMock.query).not.toHaveBeenCalled();
+    await handle.close();
+  });
+
+  it('keeps a truncated image as a path reference instead of native inline data', async () => {
+    const { handle, queryPrompt, workingDir } = await startPlanSession(false);
+    const imagePath = path.join(workingDir, 'truncated.png');
+    await fs.writeFile(
+      imagePath,
+      Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    );
+    const nextInput = queryPrompt[Symbol.asyncIterator]().next();
+
+    await handle.send({
+      type: 'user',
+      content: [
+        { type: 'text', text: 'Inspect this image.' },
+        { type: 'image', path: imagePath, mimeType: 'image/png' },
+      ],
+    });
+
+    const sdkInput = (await nextInput).value;
+    expect(sdkInput?.message?.content).toBe(`@"${imagePath}" Inspect this image.`);
     await handle.close();
   });
 

--- a/packages/maker-core/src/agents/claude-code/__tests__/rewind-runtime-settings.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/rewind-runtime-settings.test.ts
@@ -32,6 +32,7 @@ const sdkMock = vi.hoisted(() => ({
 
 const imageResizerMock = vi.hoisted(() => ({
   process: vi.fn(async (p: string) => p),
+  validate: vi.fn(async () => true),
 }));
 
 vi.mock('@anthropic-ai/claude-agent-sdk', () => ({

--- a/packages/maker-core/src/agents/claude-code/__tests__/rewind-runtime-settings.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/rewind-runtime-settings.test.ts
@@ -32,7 +32,7 @@ const sdkMock = vi.hoisted(() => ({
 
 const imageResizerMock = vi.hoisted(() => ({
   process: vi.fn(async (p: string) => p),
-  validate: vi.fn(async () => true),
+  validateBuffer: vi.fn(async () => true),
 }));
 
 vi.mock('@anthropic-ai/claude-agent-sdk', () => ({

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -5163,12 +5163,7 @@ export class ClaudeCodeAgent extends BaseAgent {
             const hasFileAttachment = message.content.some(
               (b) => b.type === 'file' || b.type === 'mention',
             );
-            const sourceImageCount = message.content.filter((b) => b.type === 'image').length;
-            const inlineImageCount = Array.isArray(content)
-              ? content.filter((b) => b.type === 'image').length
-              : 0;
-            const hasPathBackedImage = sourceImageCount > inlineImageCount;
-            if (hasFileAttachment || hasPathBackedImage) {
+            if (hasFileAttachment) {
               log.warn('cc remote: local attachment not accessible on remote session', {
                 sessionId: opts.sessionId,
                 hostId: opts.remoteHostId,
@@ -5176,7 +5171,7 @@ export class ClaudeCodeAgent extends BaseAgent {
               eventQueue.push({
                 type: 'error',
                 data: {
-                  message: '[REMOTE_LOCAL_ATTACHMENT_UNSUPPORTED] Local file attachments and images that cannot be embedded are not accessible on remote sessions. Paste content directly instead.',
+                  message: '[REMOTE_LOCAL_ATTACHMENT_UNSUPPORTED] Local file attachments are not accessible on remote sessions. Paste content directly instead.',
                   isTerminal: false,
                 },
                 source: 'claude-code',

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -403,19 +403,92 @@ function hasMentionText(existingText: string, block: { path: string; kind?: 'fil
   return existingText.includes(rawMentionText(block)) || existingText.includes(quotedMentionText(block));
 }
 
+type ClaudeImageMediaType = 'image/jpeg' | 'image/png' | 'image/gif' | 'image/webp';
+
+type ClaudeSdkContentBlock =
+  | {
+      type: 'image';
+      source: {
+        type: 'base64';
+        media_type: ClaudeImageMediaType;
+        data: string;
+      };
+    }
+  | { type: 'text'; text: string };
+
+interface ClaudeInputImageResizer {
+  process(absPath: string): Promise<string>;
+}
+
+const CLAUDE_INLINE_IMAGE_MAX_BYTES = 5 * 1024 * 1024;
+
+function resolveClaudeImageMediaType(
+  imagePath: string,
+  mimeType?: string,
+): ClaudeImageMediaType | null {
+  const extensionMediaType: Record<string, ClaudeImageMediaType> = {
+    '.gif': 'image/gif',
+    '.jfif': 'image/jpeg',
+    '.jpeg': 'image/jpeg',
+    '.jpg': 'image/jpeg',
+    '.png': 'image/png',
+    '.webp': 'image/webp',
+  };
+  const fromExtension = extensionMediaType[path.extname(imagePath).toLowerCase()];
+  if (fromExtension) return fromExtension;
+
+  switch (mimeType?.toLowerCase()) {
+    case 'image/gif':
+    case 'image/jpeg':
+    case 'image/png':
+    case 'image/webp':
+      return mimeType.toLowerCase() as ClaudeImageMediaType;
+    case 'image/jpg':
+      return 'image/jpeg';
+    default:
+      return null;
+  }
+}
+
+async function toClaudeImageBlock(
+  imagePath: string,
+  mimeType?: string,
+): Promise<ClaudeSdkContentBlock | null> {
+  const mediaType = resolveClaudeImageMediaType(imagePath, mimeType);
+  if (!mediaType) return null;
+
+  let handle: Awaited<ReturnType<typeof fs.open>> | undefined;
+  try {
+    handle = await fs.open(imagePath, 'r');
+    const stat = await handle.stat();
+    if (!stat.isFile() || stat.size <= 0 || stat.size > CLAUDE_INLINE_IMAGE_MAX_BYTES) {
+      return null;
+    }
+    const data = await handle.readFile();
+    if (data.length === 0 || data.length > CLAUDE_INLINE_IMAGE_MAX_BYTES) return null;
+    return {
+      type: 'image',
+      source: {
+        type: 'base64',
+        media_type: mediaType,
+        data: data.toString('base64'),
+      },
+    };
+  } catch {
+    return null;
+  } finally {
+    await handle?.close().catch(() => undefined);
+  }
+}
+
 /**
  * 把 maker-core 的 UserMessage content 装配成 Claude SDK 接受的形式。
- *
- * Async 而非 sync —— image block 的 absPath 会先经过 image-resizer 透明替换为
- * 缩好的缓存副本路径(命中走缓存近乎 0ms, miss 后台 sharp 处理 ~200-500ms),
- * 再以 @"resizedAbsPath" 形态注入到 prefix。Claude SDK 后续读 mention 引用的
- * 就是缩好的文件, 显著节省 vision token。
- *
- * 失败 (sharp 不可用 / 文件不存在 / GIF / 超时) 安全降级回原 path, 不阻塞 send。
+ * 图片按需压缩后统一发送为原生 image block；无法安全内联时回退为原有路径引用。
  */
 export async function toClaudeSdkContent(
   content: UserMessage['content'],
-): Promise<string | Array<{ type: string; [k: string]: unknown }>> {
+  imageResizer: ClaudeInputImageResizer = getDefaultImageResizer(),
+): Promise<string | ClaudeSdkContentBlock[]> {
   if (typeof content === 'string') return content;
 
   const textParts = content
@@ -424,18 +497,27 @@ export async function toClaudeSdkContent(
   const existingText = textParts.join('\n');
   const refs: string[] = [];
 
-  // 先把所有 image block 的 path 收集出来批量 resize (并发由 resizer 内部 semaphore 控)。
-  // 同 turn 多张图能并发处理, 不需要在这里串行 await。
-  const resizer = getDefaultImageResizer();
-  const imagePathPromises = new Map<number, Promise<string>>();
+  const imageBlockPromises = new Map<
+    number,
+    Promise<{ block: ClaudeSdkContentBlock | null; finalPath: string }>
+  >();
   content.forEach((block, idx) => {
     if (block.type === 'image') {
-      imagePathPromises.set(idx, resizer.process(block.path));
+      imageBlockPromises.set(
+        idx,
+        imageResizer.process(block.path).then(async (finalPath) => ({
+          block: await toClaudeImageBlock(finalPath, block.mimeType),
+          finalPath,
+        })),
+      );
     }
   });
-  const resizedPaths = new Map<number, string>();
-  for (const [idx, p] of imagePathPromises) {
-    resizedPaths.set(idx, await p);
+  const resolvedImages = new Map<
+    number,
+    { block: ClaudeSdkContentBlock | null; finalPath: string }
+  >();
+  for (const [idx, promise] of imageBlockPromises) {
+    resolvedImages.set(idx, await promise);
   }
 
   content.forEach((block, idx) => {
@@ -444,7 +526,9 @@ export async function toClaudeSdkContent(
     if (block.type === 'mention') {
       mentionBlock = { path: block.path, kind: block.kind };
     } else if (block.type === 'image') {
-      mentionBlock = { path: resizedPaths.get(idx) ?? block.path, kind: 'file' as const };
+      const resolvedImage = resolvedImages.get(idx);
+      if (resolvedImage?.block) return;
+      mentionBlock = { path: resolvedImage?.finalPath ?? block.path, kind: 'file' as const };
     } else {
       mentionBlock = { path: block.path, kind: 'file' as const };
     }
@@ -455,7 +539,9 @@ export async function toClaudeSdkContent(
 
   const prefix = refs.length > 0 ? `${refs.join(' ')} ` : '';
   const text = `${prefix}${textParts.join('\n')}`.trim();
-  return text || prefix.trim();
+  const imageBlocks = [...resolvedImages.values()].flatMap(({ block }) => (block ? [block] : []));
+  if (imageBlocks.length === 0) return text || prefix.trim();
+  return text ? [...imageBlocks, { type: 'text', text }] : imageBlocks;
 }
 
 function userMessageTextForCapabilityRouting(content: UserMessage['content']): string {
@@ -1303,7 +1389,7 @@ export class ClaudeCodeAgent extends BaseAgent {
     // checkpoint snapshot 的 messageId (cli.js:7086382), rewind preview 反查同款 uuid。
     type SdkUserInput = {
       type: 'user';
-      message: { role: 'user'; content: string | Array<{ type: string; [k: string]: unknown }> };
+      message: { role: 'user'; content: string | ClaudeSdkContentBlock[] };
       parent_tool_use_id: null;
       uuid?: string;
     };
@@ -5059,23 +5145,28 @@ export class ClaudeCodeAgent extends BaseAgent {
             throw new Error('Claude send cancelled before acceptance');
           }
           // **Remote attachment guard (MVP)**: 远端 session 走 cc 进程在 SSH host 上跑,
-          // 本地图片/文件附件转出来的 `@"<desktop-local-path>"` 引用在远端找不到文件,
+          // 本地文件附件转出来的 `@"<desktop-local-path>"` 引用在远端找不到文件,
           // 模型看不见 → silent context loss。完整修法是 upload 文件到远端 (follow-up),
           // 这里 MVP 检测到附件就 emit warn event 让用户知道,实际请求里把附件 ref 留着
           // (daemon 端 SDK 读不到就跳过, 不会 crash)。
           if (opts.remoteHostId && Array.isArray(message.content)) {
-            const hasAttachment = message.content.some(
-              (b) => b.type === 'image' || b.type === 'file' || b.type === 'mention',
+            const hasFileAttachment = message.content.some(
+              (b) => b.type === 'file' || b.type === 'mention',
             );
-            if (hasAttachment) {
-              log.warn('cc remote: local file/image attachment not accessible on remote session', {
+            const sourceImageCount = message.content.filter((b) => b.type === 'image').length;
+            const inlineImageCount = Array.isArray(content)
+              ? content.filter((b) => b.type === 'image').length
+              : 0;
+            const hasPathBackedImage = sourceImageCount > inlineImageCount;
+            if (hasFileAttachment || hasPathBackedImage) {
+              log.warn('cc remote: local attachment not accessible on remote session', {
                 sessionId: opts.sessionId,
                 hostId: opts.remoteHostId,
               });
               eventQueue.push({
                 type: 'error',
                 data: {
-                  message: '[REMOTE_LOCAL_ATTACHMENT_UNSUPPORTED] Local file/image attachments are not accessible on remote sessions. Paste content directly instead.',
+                  message: '[REMOTE_LOCAL_ATTACHMENT_UNSUPPORTED] Local file attachments and images that cannot be embedded are not accessible on remote sessions. Paste content directly instead.',
                   isTerminal: false,
                 },
                 source: 'claude-code',

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -418,6 +418,7 @@ type ClaudeSdkContentBlock =
 
 interface ClaudeInputImageResizer {
   process(absPath: string): Promise<string>;
+  validate(absPath: string): Promise<boolean>;
 }
 
 const CLAUDE_INLINE_IMAGE_MAX_ENCODED_BYTES = 5 * 1024 * 1024;
@@ -510,10 +511,13 @@ export async function toClaudeSdkContent(
     if (block.type === 'image' && readImagePathsLocally) {
       imageBlockPromises.set(
         idx,
-        imageResizer.process(block.path).then(async (finalPath) => ({
-          block: await toClaudeImageBlock(finalPath),
-          finalPath,
-        })),
+        imageResizer.process(block.path).then(async (finalPath) => {
+          const isValidImage = await imageResizer.validate(finalPath);
+          return {
+            block: isValidImage ? await toClaudeImageBlock(finalPath) : null,
+            finalPath,
+          };
+        }),
       );
     }
   });

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -420,7 +420,11 @@ interface ClaudeInputImageResizer {
   process(absPath: string): Promise<string>;
 }
 
-const CLAUDE_INLINE_IMAGE_MAX_BYTES = 5 * 1024 * 1024;
+const CLAUDE_INLINE_IMAGE_MAX_ENCODED_BYTES = 5 * 1024 * 1024;
+
+function base64EncodedByteLength(rawByteLength: number): number {
+  return Math.ceil(rawByteLength / 3) * 4;
+}
 
 function detectClaudeImageMediaType(data: Buffer): ClaudeImageMediaType | null {
   if (
@@ -451,19 +455,27 @@ async function toClaudeImageBlock(imagePath: string): Promise<ClaudeSdkContentBl
   try {
     handle = await fs.open(imagePath, 'r');
     const stat = await handle.stat();
-    if (!stat.isFile() || stat.size <= 0 || stat.size > CLAUDE_INLINE_IMAGE_MAX_BYTES) {
+    if (
+      !stat.isFile()
+      || stat.size <= 0
+      || base64EncodedByteLength(stat.size) > CLAUDE_INLINE_IMAGE_MAX_ENCODED_BYTES
+    ) {
       return null;
     }
     const data = await handle.readFile();
-    if (data.length === 0 || data.length > CLAUDE_INLINE_IMAGE_MAX_BYTES) return null;
+    if (
+      data.length === 0
+      || base64EncodedByteLength(data.length) > CLAUDE_INLINE_IMAGE_MAX_ENCODED_BYTES
+    ) return null;
     const mediaType = detectClaudeImageMediaType(data);
     if (!mediaType) return null;
+    const encodedData = data.toString('base64');
     return {
       type: 'image',
       source: {
         type: 'base64',
         media_type: mediaType,
-        data: data.toString('base64'),
+        data: encodedData,
       },
     };
   } catch {
@@ -480,6 +492,7 @@ async function toClaudeImageBlock(imagePath: string): Promise<ClaudeSdkContentBl
 export async function toClaudeSdkContent(
   content: UserMessage['content'],
   imageResizer: ClaudeInputImageResizer = getDefaultImageResizer(),
+  readImagePathsLocally = true,
 ): Promise<string | ClaudeSdkContentBlock[]> {
   if (typeof content === 'string') return content;
 
@@ -494,7 +507,7 @@ export async function toClaudeSdkContent(
     Promise<{ block: ClaudeSdkContentBlock | null; finalPath: string }>
   >();
   content.forEach((block, idx) => {
-    if (block.type === 'image') {
+    if (block.type === 'image' && readImagePathsLocally) {
       imageBlockPromises.set(
         idx,
         imageResizer.process(block.path).then(async (finalPath) => ({
@@ -5132,7 +5145,12 @@ export class ClaudeCodeAgent extends BaseAgent {
               reviewReadGrants,
             );
           }
-          const content = await toClaudeSdkContent(message.content);
+          // SSH 图片路径属于远端主机，不能在桌面端压缩或读取；保留路径引用交给远端 SDK。
+          const content = await toClaudeSdkContent(
+            message.content,
+            undefined,
+            !opts.remoteHostId,
+          );
           if (sendOpts?.signal?.aborted) {
             throw new Error('Claude send cancelled before acceptance');
           }
@@ -5234,7 +5252,12 @@ export class ClaudeCodeAgent extends BaseAgent {
             reviewReadGrants,
           );
         }
-        const content = await toClaudeSdkContent(message.content);
+        // steer 与 send 保持同一来源边界：SSH 图片路径只由远端 SDK 读取。
+        const content = await toClaudeSdkContent(
+          message.content,
+          undefined,
+          !opts.remoteHostId,
+        );
         if (sendOpts?.signal?.aborted) {
           throw new Error('Claude steer cancelled before acceptance');
         }

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -4842,6 +4842,27 @@ export class ClaudeCodeAgent extends BaseAgent {
         releaseCancellationRebuildGate?.();
       }
     }
+    const warnIfRemoteDesktopAttachment = (content: UserMessage['content']): void => {
+      if (!opts.remoteHostId || !Array.isArray(content)) return;
+      const hasDesktopLocalAttachment = content.some(
+        (block) => block.type === 'file'
+          || block.type === 'mention'
+          || (block.type === 'image' && block.pathOrigin === 'desktop-host'),
+      );
+      if (!hasDesktopLocalAttachment) return;
+      log.warn('cc remote: local attachment not accessible on remote session', {
+        sessionId: opts.sessionId,
+        hostId: opts.remoteHostId,
+      });
+      eventQueue.push({
+        type: 'error',
+        data: {
+          message: '[REMOTE_LOCAL_ATTACHMENT_UNSUPPORTED] Local file attachments are not accessible on remote sessions. Paste content directly instead.',
+          isTerminal: false,
+        },
+        source: 'claude-code',
+      });
+    };
     const handle: AgentSessionHandle = {
       get id() { return sdkSessionId ?? '<pending>'; },
       agentKind: 'claude-code',
@@ -5163,27 +5184,7 @@ export class ClaudeCodeAgent extends BaseAgent {
           // 模型看不见 → silent context loss。完整修法是 upload 文件到远端 (follow-up),
           // 这里 MVP 检测到附件就 emit warn event 让用户知道,实际请求里把附件 ref 留着
           // (daemon 端 SDK 读不到就跳过, 不会 crash)。
-          if (opts.remoteHostId && Array.isArray(message.content)) {
-            const hasDesktopLocalAttachment = message.content.some(
-              (b) => b.type === 'file'
-                || b.type === 'mention'
-                || (b.type === 'image' && b.pathOrigin === 'desktop-host'),
-            );
-            if (hasDesktopLocalAttachment) {
-              log.warn('cc remote: local attachment not accessible on remote session', {
-                sessionId: opts.sessionId,
-                hostId: opts.remoteHostId,
-              });
-              eventQueue.push({
-                type: 'error',
-                data: {
-                  message: '[REMOTE_LOCAL_ATTACHMENT_UNSUPPORTED] Local file attachments are not accessible on remote sessions. Paste content directly instead.',
-                  isTerminal: false,
-                },
-                source: 'claude-code',
-              });
-            }
-          }
+          warnIfRemoteDesktopAttachment(message.content);
           // Claude Code streaming-input 协议要求 message 包装层,漏掉会 exit code 1。
           // sendOpts.messageUuid 注入到 SDK input.uuid — SDK 透传当作 file checkpoint
           // snapshot 的 messageId, rewind preview 拿同款 uuid 调 rewindFiles dryRun。
@@ -5268,6 +5269,7 @@ export class ClaudeCodeAgent extends BaseAgent {
           // keeps the original queue/composer content and lets the user retry.
           throw new Error('No active Claude turn to steer');
         }
+        warnIfRemoteDesktopAttachment(message.content);
         // Same-turn steering deliberately does NOT call beginTurn(), reset the
         // tool-loop guard, or emit a new running status. Those are turn-start
         // side effects; doing them here would corrupt usage attribution and make

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -422,41 +422,31 @@ interface ClaudeInputImageResizer {
 
 const CLAUDE_INLINE_IMAGE_MAX_BYTES = 5 * 1024 * 1024;
 
-function resolveClaudeImageMediaType(
-  imagePath: string,
-  mimeType?: string,
-): ClaudeImageMediaType | null {
-  const extensionMediaType: Record<string, ClaudeImageMediaType> = {
-    '.gif': 'image/gif',
-    '.jfif': 'image/jpeg',
-    '.jpeg': 'image/jpeg',
-    '.jpg': 'image/jpeg',
-    '.png': 'image/png',
-    '.webp': 'image/webp',
-  };
-  const fromExtension = extensionMediaType[path.extname(imagePath).toLowerCase()];
-  if (fromExtension) return fromExtension;
-
-  switch (mimeType?.toLowerCase()) {
-    case 'image/gif':
-    case 'image/jpeg':
-    case 'image/png':
-    case 'image/webp':
-      return mimeType.toLowerCase() as ClaudeImageMediaType;
-    case 'image/jpg':
-      return 'image/jpeg';
-    default:
-      return null;
+function detectClaudeImageMediaType(data: Buffer): ClaudeImageMediaType | null {
+  if (
+    data.length >= 8
+    && data.subarray(0, 8).equals(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]))
+  ) {
+    return 'image/png';
   }
+  if (data.length >= 3 && data[0] === 0xff && data[1] === 0xd8 && data[2] === 0xff) {
+    return 'image/jpeg';
+  }
+  if (data.length >= 6) {
+    const signature = data.toString('ascii', 0, 6);
+    if (signature === 'GIF87a' || signature === 'GIF89a') return 'image/gif';
+  }
+  if (
+    data.length >= 12
+    && data.toString('ascii', 0, 4) === 'RIFF'
+    && data.toString('ascii', 8, 12) === 'WEBP'
+  ) {
+    return 'image/webp';
+  }
+  return null;
 }
 
-async function toClaudeImageBlock(
-  imagePath: string,
-  mimeType?: string,
-): Promise<ClaudeSdkContentBlock | null> {
-  const mediaType = resolveClaudeImageMediaType(imagePath, mimeType);
-  if (!mediaType) return null;
-
+async function toClaudeImageBlock(imagePath: string): Promise<ClaudeSdkContentBlock | null> {
   let handle: Awaited<ReturnType<typeof fs.open>> | undefined;
   try {
     handle = await fs.open(imagePath, 'r');
@@ -466,6 +456,8 @@ async function toClaudeImageBlock(
     }
     const data = await handle.readFile();
     if (data.length === 0 || data.length > CLAUDE_INLINE_IMAGE_MAX_BYTES) return null;
+    const mediaType = detectClaudeImageMediaType(data);
+    if (!mediaType) return null;
     return {
       type: 'image',
       source: {
@@ -506,7 +498,7 @@ export async function toClaudeSdkContent(
       imageBlockPromises.set(
         idx,
         imageResizer.process(block.path).then(async (finalPath) => ({
-          block: await toClaudeImageBlock(finalPath, block.mimeType),
+          block: await toClaudeImageBlock(finalPath),
           finalPath,
         })),
       );

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -418,7 +418,7 @@ type ClaudeSdkContentBlock =
 
 interface ClaudeInputImageResizer {
   process(absPath: string): Promise<string>;
-  validate(absPath: string): Promise<boolean>;
+  validateBuffer(data: Buffer): Promise<boolean>;
 }
 
 const CLAUDE_INLINE_IMAGE_MAX_ENCODED_BYTES = 5 * 1024 * 1024;
@@ -451,7 +451,10 @@ function detectClaudeImageMediaType(data: Buffer): ClaudeImageMediaType | null {
   return null;
 }
 
-async function toClaudeImageBlock(imagePath: string): Promise<ClaudeSdkContentBlock | null> {
+async function toClaudeImageBlock(
+  imagePath: string,
+  validateBuffer: (data: Buffer) => Promise<boolean>,
+): Promise<ClaudeSdkContentBlock | null> {
   let handle: Awaited<ReturnType<typeof fs.open>> | undefined;
   try {
     handle = await fs.open(imagePath, 'r');
@@ -470,6 +473,7 @@ async function toClaudeImageBlock(imagePath: string): Promise<ClaudeSdkContentBl
     ) return null;
     const mediaType = detectClaudeImageMediaType(data);
     if (!mediaType) return null;
+    if (!(await validateBuffer(data))) return null;
     const encodedData = data.toString('base64');
     return {
       type: 'image',
@@ -512,9 +516,11 @@ export async function toClaudeSdkContent(
       imageBlockPromises.set(
         idx,
         imageResizer.process(block.path).then(async (finalPath) => {
-          const isValidImage = await imageResizer.validate(finalPath);
           return {
-            block: isValidImage ? await toClaudeImageBlock(finalPath) : null,
+            block: await toClaudeImageBlock(
+              finalPath,
+              (data) => imageResizer.validateBuffer(data),
+            ),
             finalPath,
           };
         }),

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -5160,10 +5160,12 @@ export class ClaudeCodeAgent extends BaseAgent {
           // 这里 MVP 检测到附件就 emit warn event 让用户知道,实际请求里把附件 ref 留着
           // (daemon 端 SDK 读不到就跳过, 不会 crash)。
           if (opts.remoteHostId && Array.isArray(message.content)) {
-            const hasFileAttachment = message.content.some(
-              (b) => b.type === 'file' || b.type === 'mention',
+            const hasDesktopLocalAttachment = message.content.some(
+              (b) => b.type === 'file'
+                || b.type === 'mention'
+                || (b.type === 'image' && b.pathOrigin === 'desktop-host'),
             );
-            if (hasFileAttachment) {
+            if (hasDesktopLocalAttachment) {
               log.warn('cc remote: local attachment not accessible on remote session', {
                 sessionId: opts.sessionId,
                 hostId: opts.remoteHostId,

--- a/packages/maker-core/src/agents/shared/image-resizer.ts
+++ b/packages/maker-core/src/agents/shared/image-resizer.ts
@@ -83,6 +83,8 @@ const DEFAULTS = {
   cacheVersion: 'v1',
 };
 
+const VALIDATION_MAX_INPUT_PIXELS = 100_000_000;
+
 interface QueueTask {
   run: () => Promise<void>;
 }
@@ -178,6 +180,54 @@ export class ImageResizer {
     });
     this.inflight.set(key, task);
     return task;
+  }
+
+  /**
+   * Fully decode an image before it is embedded as model-native base64 input.
+   * Magic bytes identify a container but cannot prove that the payload is complete.
+   * Missing sharp, decode errors, and timeouts all fail closed so callers can keep
+   * the existing path-reference fallback.
+   */
+  async validate(absPath: string): Promise<boolean> {
+    if (!absPath || typeof absPath !== 'string') return false;
+    const sharp = loadSharp();
+    if (!sharp) return false;
+
+    return this.acquireSlot(async () => {
+      const work = sharp(absPath, {
+        failOn: 'error',
+        limitInputPixels: VALIDATION_MAX_INPUT_PIXELS,
+        sequentialRead: true,
+      })
+        .rotate()
+        .resize({
+          width: this.cfg.maxEdgePx,
+          height: this.cfg.maxEdgePx,
+          fit: 'inside',
+          withoutEnlargement: true,
+        })
+        .toBuffer()
+        .then(() => true)
+        .catch((error) => {
+          this.cfg.logger?.warn('image-resizer: image validation failed', {
+            absPath,
+            error: String(error),
+          });
+          return false;
+        });
+      const timeout = new Promise<'timeout'>((resolve) => {
+        setTimeout(() => resolve('timeout'), this.cfg.timeoutMs).unref?.();
+      });
+      const result = await Promise.race([work, timeout]);
+      if (result === 'timeout') {
+        this.cfg.logger?.warn('image-resizer: image validation timeout', {
+          absPath,
+          timeoutMs: this.cfg.timeoutMs,
+        });
+        return false;
+      }
+      return result;
+    });
   }
 
   /** 内部: 跑实际的 resize, 含并发闸门 + 超时 + 错误降级。 */

--- a/packages/maker-core/src/agents/shared/image-resizer.ts
+++ b/packages/maker-core/src/agents/shared/image-resizer.ts
@@ -190,11 +190,24 @@ export class ImageResizer {
    */
   async validate(absPath: string): Promise<boolean> {
     if (!absPath || typeof absPath !== 'string') return false;
+    return this.validateInput(absPath, { absPath });
+  }
+
+  /** Validate the exact bytes a caller is about to embed. */
+  async validateBuffer(data: Buffer): Promise<boolean> {
+    if (!Buffer.isBuffer(data) || data.length === 0) return false;
+    return this.validateInput(data, { bytes: data.length });
+  }
+
+  private async validateInput(
+    input: string | Buffer,
+    logMeta: Record<string, unknown>,
+  ): Promise<boolean> {
     const sharp = loadSharp();
     if (!sharp) return false;
 
     return this.acquireSlot(async () => {
-      const work = sharp(absPath, {
+      const work = sharp(input, {
         failOn: 'error',
         limitInputPixels: VALIDATION_MAX_INPUT_PIXELS,
         sequentialRead: true,
@@ -210,7 +223,7 @@ export class ImageResizer {
         .then(() => true)
         .catch((error) => {
           this.cfg.logger?.warn('image-resizer: image validation failed', {
-            absPath,
+            ...logMeta,
             error: String(error),
           });
           return false;
@@ -221,7 +234,7 @@ export class ImageResizer {
       const result = await Promise.race([work, timeout]);
       if (result === 'timeout') {
         this.cfg.logger?.warn('image-resizer: image validation timeout', {
-          absPath,
+          ...logMeta,
           timeoutMs: this.cfg.timeoutMs,
         });
         return false;

--- a/packages/maker-core/src/agents/shared/image-resizer.ts
+++ b/packages/maker-core/src/agents/shared/image-resizer.ts
@@ -3,8 +3,8 @@
  * ---------------------------------------------------------------------------
  * Last-mile shrink for images that go INTO the LLM context. UI / IM 仍然显示
  * 原图,只在 toClaudeSdkContent / toAppServerInput 这一步把 image-block 的
- * absPath 透明替换为缩好的副本路径,Claude SDK / codex app-server 读到的就是
- * resized 文件,显著节省 vision token。
+ * absPath 透明替换为缩好的副本路径,再由下游转换为模型原生图片输入,
+ * 显著节省 vision token。
  *
  * 设计要点:
  *  - 用 sharp (libvips Node binding)。所有 decode/resize/encode 都在 libuv

--- a/packages/maker-core/src/types/common.ts
+++ b/packages/maker-core/src/types/common.ts
@@ -45,7 +45,7 @@ export type ReasoningDisplay = 'off' | 'summarized' | 'full';
  */
 export type UserContentBlock =
   | { type: 'text'; text: string }
-  | { type: 'image'; path: string; mimeType?: string }
+  | { type: 'image'; path: string; mimeType?: string; pathOrigin?: 'desktop-host' }
   | { type: 'file'; path: string; mimeType?: string }
   | { type: 'mention'; name: string; path: string; kind?: 'file' | 'dir' | 'agent' };
 


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Claude Code Agent 在部分订阅模型下无法稳定读取小图片附件的问题。图片在按需压缩后统一转换为模型原生 image block，不再根据文件大小混用路径引用；普通文件仍保留原有路径引用。

无法读取、格式不支持或压缩后仍超过 5 MiB 的图片会回退为路径引用；远程机器场景会继续提示这类本地路径不可访问，避免静默丢失附件。

### 变更类型

- [ ] feat 新功能
- [x] fix 缺陷修复
- [ ] refactor / perf 重构或性能优化
- [ ] docs / test / chore 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#2535
- 本 PR 包含：Claude Code 图片输入转换、内联大小上限与安全回退、远程附件警告修正、相关回归测试
- 明确不包含：Codex Agent 输入链路、真实 SSH 远程机器文件上传、UI 改动
- 用户可见变化：Claude Code Agent 可稳定读取不同文件大小的受支持图片附件
- 是否存在 breaking change：无

### UI 变化

不涉及：本次仅调整附件发送前的内部来源标记与远程告警判定，无视觉、交互或 UI 文案变化。

- 引用的设计规范：不涉及：纯逻辑修复，无视觉、交互或 UI 文案变化

## 怎么验证的

### 自动验证

    pnpm test:unit
    结果：通过，所有要求运行的 workspace 均为 PASS

    pnpm --filter @cindy/maker-core run --if-present typecheck
    结果：通过

    pnpm --filter desktop run --if-present typecheck
    结果：通过

    pnpm check:dco
    结果：通过，提交 69c15cb7f 已签名

### 手工验证

- Windows dev remote 隔离沙盒 image2535，使用企业 SSO（企业 ID：xd）登录。
- Claude Code + GPT-5.6-Sol（ChatGPT 订阅）分别发送 500,000 B 与 500,001 B PNG；两个独立任务均正确识别图片标题和第二行文字。
- 刷新 500,001 B 图片所在任务后继续追问，图片上下文恢复正常。
- 检查运行日志，未发现图片解析、base64、请求过大或桥接错误。

### 未执行的验证

- 未在真实 SSH 远程机器会话中发送图片；本次仅验证 remote 服务端点模式下的本机设备会话。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：会话体积

### 影响与回滚

- 影响范围：仅 Claude Code Agent 的图片附件输入。图片以 base64 随 SDK 消息落盘，可能增加会话文件体积；现有图片压缩链路与 5 MiB 内联上限限制了最坏情况。
- 回滚 / 降级方式：回退提交 69c15cb7f 即恢复图片路径引用；无法内联时当前实现也会自动降级为路径引用。
- 移动端冷更：不涉及 apps/mobile 原生配置、原生依赖或 runtime fingerprint 输入，不触发冷更。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（git commit -s）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次无需文档改动）
- [x] 已确认测试结果或说明未执行原因