### PR TITLE
refactor(maker-core): make auto-review root access explicit

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/autoPermissionReviewer.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/autoPermissionReviewer.test.ts
@@ -19,7 +19,11 @@ function request(overrides: Partial<AutoReviewRequest> = {}): AutoReviewRequest 
     model: 'current-model',
     userIntent: 'Fix the type error and run tests',
     action: { kind: 'exec', command: 'npx tsc --noEmit' },
-    workspaceRoots: ['/repo'],
+    rootAccess: {
+      primaryRoot: '/repo',
+      readRoots: ['/repo'],
+      writableRoots: ['/repo'],
+    },
     platform: 'darwin',
     ...overrides,
   };
@@ -47,10 +51,14 @@ describe('buildAutoPermissionReviewPrompt', () => {
   });
 
   it('separates the writable workspace root from read-only reference roots', () => {
-    // Extra Dirs 是只读引用目录:prompt 拍平成一个 workspaceRoots 数组会让
+    // Extra Dirs 是只读引用目录:prompt 拍平读写 root 会让
     // 「workspace edits 倾向 allow」把写入只读目录的灰区命令一并放行(codex-connector 报)。
     const prompt = buildAutoPermissionReviewPrompt(request({
-      workspaceRoots: ['/repo', '/extra-docs'],
+      rootAccess: {
+        primaryRoot: '/repo',
+        readRoots: ['/repo', '/extra-docs'],
+        writableRoots: ['/repo'],
+      },
     }));
 
     expect(prompt).toContain('"workspaceRoot":"/repo"');
@@ -60,6 +68,11 @@ describe('buildAutoPermissionReviewPrompt', () => {
     expect(prompt).toContain('READING anything inside them is routine reference work');
     expect(prompt).toContain('WRITING, deleting, or modifying anything inside them');
     expect(prompt).toContain('edits inside workspaceRoot');
+    expect(prompt).toContain([
+      '<review_input>',
+      '{"userIntent":"Fix the type error and run tests","action":{"kind":"exec","command":"npx tsc --noEmit"},"workspaceRoot":"/repo","readOnlyReferenceRoots":["/extra-docs"],"platform":"darwin"}',
+      '</review_input>',
+    ].join('\n'));
   });
 
   it('delimits the action as untrusted data so command text cannot rewrite the policy', () => {
@@ -78,10 +91,14 @@ describe('buildAutoPermissionReviewPrompt', () => {
   it('bounds oversized intent and workspace roots before sending them to the model', () => {
     const prompt = buildAutoPermissionReviewPrompt(request({
       userIntent: `intent-head-${'i'.repeat(4_000)}-intent-tail`,
-      workspaceRoots: Array.from(
-        { length: 12 },
-        (_, index) => `/root-${index}-${'r'.repeat(2_000)}`,
-      ),
+      rootAccess: {
+        primaryRoot: `/root-0-${'r'.repeat(2_000)}`,
+        readRoots: Array.from(
+          { length: 12 },
+          (_, index) => `/root-${index}-${'r'.repeat(2_000)}`,
+        ),
+        writableRoots: [`/root-0-${'r'.repeat(2_000)}`],
+      },
     }));
 
     expect(prompt).toContain('intent-head-');

--- a/apps/desktop/src/main/maker-host/auto-permission-reviewer.ts
+++ b/apps/desktop/src/main/maker-host/auto-permission-reviewer.ts
@@ -108,10 +108,11 @@ function serializeUntrustedPayload(value: unknown): string {
  */
 export function buildAutoPermissionReviewPrompt(request: AutoReviewRequest): string {
   assertReviewableActionSize(request.action);
-  // workspaceRoots 位置语义(与 maker-core reviewAction 同契约):首元素是唯一可写的
-  // 工作目录,其余是只读引用目录(additionalDirectories)。prompt 必须保留这一区分,
-  // 否则「workspace edits 倾向 allow」会把写只读引用目录的灰区命令一并放行。
-  const [workspaceRoot, ...referenceRoots] = request.workspaceRoots;
+  // P1 caller 仍只授权 primaryRoot 可写，因此 prompt 保持既有单主工作区语义；权限来源改为
+  // 显式 rootAccess，避免靠数组位置猜读写。后续若启用额外 writableRoots，必须同步扩展 prompt 契约。
+  const workspaceRoot = request.rootAccess.primaryRoot;
+  const writableRoots = new Set(request.rootAccess.writableRoots);
+  const referenceRoots = request.rootAccess.readRoots.filter((root) => !writableRoots.has(root));
   const payload = {
     userIntent: compactText(request.userIntent, MAX_USER_INTENT_CHARS),
     action: request.action,

--- a/packages/maker-core/src/agents/claude-code/__tests__/auto-review-policy.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/auto-review-policy.test.ts
@@ -12,11 +12,16 @@ import {
   classifyBuiltinToolForAutoReview,
   normalizeBuiltinToolForAutoReview,
 } from '../auto-review-policy.js';
+import type { WorkspaceRootAccess } from '../../shared/auto-review.js';
 
-const roots = ['/repo', '/extra']; // 工作区根:cwd + 一个额外目录
+const roots: WorkspaceRootAccess = {
+  primaryRoot: '/repo',
+  readRoots: ['/repo', '/extra'],
+  writableRoots: ['/repo'],
+}; // 工作区根:cwd + 一个额外只读目录
 
-function verdict(toolName: string, input: unknown, workspaceRoots = roots) {
-  return classifyBuiltinToolForAutoReview({ toolName, input, workspaceRoots });
+function verdict(toolName: string, input: unknown, rootAccess = roots) {
+  return classifyBuiltinToolForAutoReview({ toolName, input, rootAccess });
 }
 
 describe('classifyBuiltinToolForAutoReview — 只读与安全状态工具', () => {
@@ -80,28 +85,44 @@ describe('classifyBuiltinToolForAutoReview — 文件写(结构化 path 精确�
     expect(classifyBuiltinToolForAutoReview({
       toolName: 'Write',
       input: { file_path: '/private/var/folders/x/ws/a.ts' },
-      workspaceRoots: ['/var/folders/x/ws'],
+      rootAccess: {
+        primaryRoot: '/var/folders/x/ws',
+        readRoots: ['/var/folders/x/ws'],
+        writableRoots: ['/var/folders/x/ws'],
+      },
       platform: 'darwin',
     })).toBe('auto-approve');
     // 反向:root 带 /private、目标不带,也应对齐。
     expect(classifyBuiltinToolForAutoReview({
       toolName: 'Write',
       input: { file_path: '/var/folders/x/ws/a.ts' },
-      workspaceRoots: ['/private/var/folders/x/ws'],
+      rootAccess: {
+        primaryRoot: '/private/var/folders/x/ws',
+        readRoots: ['/private/var/folders/x/ws'],
+        writableRoots: ['/private/var/folders/x/ws'],
+      },
       platform: 'darwin',
     })).toBe('auto-approve');
     // /private 抹平不误伤真实越界:/private/etc 归 /etc,仍在 /var 工作区外。
     expect(classifyBuiltinToolForAutoReview({
       toolName: 'Write',
       input: { file_path: '/private/etc/passwd' },
-      workspaceRoots: ['/var/folders/x/ws'],
+      rootAccess: {
+        primaryRoot: '/var/folders/x/ws',
+        readRoots: ['/var/folders/x/ws'],
+        writableRoots: ['/var/folders/x/ws'],
+      },
       platform: 'darwin',
     })).toBe('prompt-each-time'); // 抹平后落 /etc = 系统目录 → 确定性同意
     // Linux:/private/var 不再抹平 → 区外写升级(远端 Linux 会话)。
     expect(classifyBuiltinToolForAutoReview({
       toolName: 'Write',
       input: { file_path: '/private/var/folders/x/ws/a.ts' },
-      workspaceRoots: ['/var/folders/x/ws'],
+      rootAccess: {
+        primaryRoot: '/var/folders/x/ws',
+        readRoots: ['/var/folders/x/ws'],
+        writableRoots: ['/var/folders/x/ws'],
+      },
       platform: 'linux',
     })).toBe('prompt');
   });
@@ -145,7 +166,11 @@ describe('classifyBuiltinToolForAutoReview — 内置 Read/Grep/LS 读凭证升�
 });
 
 describe('classifyBuiltinToolForAutoReview — Windows 盘符路径边界', () => {
-  const win = ['C:\\Users\\me\\project'];
+  const win: WorkspaceRootAccess = {
+    primaryRoot: 'C:\\Users\\me\\project',
+    readRoots: ['C:\\Users\\me\\project'],
+    writableRoots: ['C:\\Users\\me\\project'],
+  };
   it('Windows 工作区内写 → auto-approve(绝对与相对)', () => {
     expect(verdict('Write', { file_path: 'C:\\Users\\me\\project\\src\\a.ts' }, win)).toBe('auto-approve');
     expect(verdict('Edit', { file_path: 'src\\a.ts' }, win)).toBe('auto-approve');

--- a/packages/maker-core/src/agents/claude-code/auto-review-policy.ts
+++ b/packages/maker-core/src/agents/claude-code/auto-review-policy.ts
@@ -12,6 +12,7 @@ import {
   isSensitiveCredentialPath,
   type ReviewableAction,
   type ReviewVerdict,
+  type WorkspaceRootAccess,
 } from '../shared/auto-review.js';
 
 export type BuiltinAutoReviewVerdict = ReviewVerdict;
@@ -21,8 +22,8 @@ export interface BuiltinAutoReviewContext {
   toolName: string;
   /** 工具入参(SDK 透传的原始对象)。 */
   input: unknown;
-  /** 会话的工作区根:cwd + additionalDirectories,绝对路径。远端会话是远端路径(纯字符串判定)。 */
-  workspaceRoots: string[];
+  /** 会话的显式读写根。远端会话是远端路径(纯字符串判定)。 */
+  rootAccess: WorkspaceRootAccess;
   /** 会话所在平台(决定是否抹平 macOS firmlink /private)。缺省用本进程 process.platform;远端会话应传远端 OS。 */
   platform?: NodeJS.Platform;
 }
@@ -96,7 +97,7 @@ export function classifyBuiltinToolForAutoReview(
 ): BuiltinAutoReviewVerdict {
   const action = normalizeBuiltinToolForAutoReview(ctx.toolName, ctx.input);
   const opts = ctx.platform ? { platform: ctx.platform } : undefined;
-  return reviewAction(action, ctx.workspaceRoots, opts);
+  return reviewAction(action, ctx.rootAccess, opts);
 }
 
 /** 把 Claude 内置工具翻译成共享动作；判定与 AI fallback 都复用这一份归一化结果。 */

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -124,7 +124,7 @@ import {
   resolveAutoReviewDecision,
   type AutoReviewDecision,
 } from '../shared/auto-review-decision.js';
-import type { ReviewableAction } from '../shared/auto-review.js';
+import type { ReviewableAction, WorkspaceRootAccess } from '../shared/auto-review.js';
 import {
   resolveAgentCredentialMode,
   resolveEffectiveCredentialModeFromAuthSource,
@@ -1794,12 +1794,16 @@ export class ClaudeCodeAgent extends BaseAgent {
       const hostApprovalPresentation = mcpApprovalPresentation(toolName, input);
       let forcePrompt = turnPolicyForcePrompt;
       if (mutablePermissionMode === 'auto' && !toolName.startsWith('mcp__')) {
-        const workspaceRoots = [opts.workingDir, ...mutableExtraDirs].filter(
+        const readRoots = [opts.workingDir, ...mutableExtraDirs].filter(
           (d): d is string => typeof d === 'string' && d.length > 0,
         );
         const autoDecision = await reviewAutoAction(
           normalizeBuiltinToolForAutoReview(toolName, input),
-          workspaceRoots,
+          {
+            primaryRoot: opts.workingDir,
+            readRoots,
+            writableRoots: [opts.workingDir],
+          },
           opts.remoteHostId ? 'linux' : process.platform,
         );
         // 热切换收口:reviewAutoAction 是 async,期间 setPermissionMode 可能收紧(Auto→Ask)
@@ -1993,7 +1997,7 @@ export class ClaudeCodeAgent extends BaseAgent {
     });
     const reviewAutoAction = (
       action: ReviewableAction,
-      workspaceRoots: string[],
+      rootAccess: WorkspaceRootAccess,
       platform: NodeJS.Platform,
     ): Promise<AutoReviewDecision> => {
       const request = {
@@ -2003,7 +2007,7 @@ export class ClaudeCodeAgent extends BaseAgent {
         model: mutableModel,
         userIntent: currentAutoReviewIntent,
         action,
-        workspaceRoots,
+        rootAccess,
         platform,
       };
       const key = JSON.stringify(request);
@@ -2840,9 +2844,13 @@ export class ClaudeCodeAgent extends BaseAgent {
             ) {
               const autoDecision = await reviewAutoAction(
                 normalizeBuiltinToolForAutoReview(remoteToolName, params.input ?? {}),
-                [opts.workingDir].filter(
-                  (d): d is string => typeof d === 'string' && d.length > 0,
-                ),
+                {
+                  primaryRoot: opts.workingDir,
+                  readRoots: [opts.workingDir].filter(
+                    (d): d is string => typeof d === 'string' && d.length > 0,
+                  ),
+                  writableRoots: [opts.workingDir],
+                },
                 'linux',
               );
               if (!remoteTurnPolicyForcePrompt && autoDecision.verdict === 'allow') {

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -11496,7 +11496,11 @@ describe('CodexAgent MCP thread context hooks', () => {
       model: 'qwen/qwen3-coder',
       userIntent: 'Check this project for type errors',
       action: { kind: 'exec', command: 'npx tsc --noEmit', cwd: '/repo' },
-      workspaceRoots: ['/repo'],
+      rootAccess: {
+        primaryRoot: '/repo',
+        readRoots: ['/repo'],
+        writableRoots: ['/repo'],
+      },
       platform: process.platform,
     }));
     expect(reviewAutoPermissionAction.mock.calls[0]?.[0]).not.toHaveProperty('transcript');

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -3965,6 +3965,13 @@ export class CodexAgent extends BaseAgent {
       : [joinCodexHome('memories')];
     const runtimeWorkspaceRoots = (): string[] =>
       reviewMode ? [opts.workingDir] : [opts.workingDir, ...mutableExtraDirs];
+    const runtimeRootAccess = () => ({
+      primaryRoot: opts.workingDir,
+      readRoots: runtimeWorkspaceRoots().filter(
+        (dir): dir is string => typeof dir === 'string' && dir.length > 0,
+      ),
+      writableRoots: [opts.workingDir],
+    });
     // Auto-review 传给 core 的会话平台(决定是否抹平 macOS /private firmlink)。远端会话的 host
     // process.platform 不代表远端 OS(host 可能 macOS、远端 Linux)——远端 OS 未接入前保守传 'linux'
     // 关掉抹平 → fail-closed(不把远端 /private/tmp 误当 /tmp 区内)。本地用真实 process.platform。
@@ -3981,9 +3988,7 @@ export class CodexAgent extends BaseAgent {
         model: mutableCatalogModel ?? mutableModel,
         userIntent: currentAutoReviewIntent,
         action,
-        workspaceRoots: runtimeWorkspaceRoots().filter(
-          (dir): dir is string => typeof dir === 'string' && dir.length > 0,
-        ),
+        rootAccess: runtimeRootAccess(),
         platform: sessionReviewPlatform,
       };
       const key = JSON.stringify(request);
@@ -5516,7 +5521,7 @@ export class CodexAgent extends BaseAgent {
           if (opts?.autoReviewAction) {
             const verdict = reviewAction(
               opts.autoReviewAction,
-              runtimeWorkspaceRoots().filter((d): d is string => typeof d === 'string' && d.length > 0),
+              runtimeRootAccess(),
               { platform: sessionReviewPlatform },
             );
             // 无人值守:只接受 core 判为 auto-approve 的安全动作。prompt / prompt-each-time 都意味着

--- a/packages/maker-core/src/agents/index.ts
+++ b/packages/maker-core/src/agents/index.ts
@@ -81,7 +81,7 @@ export {
   type AutoReviewRequest,
   type AutoReviewTimeoutPolicy,
 } from './shared/auto-review-decision.js';
-export type { ReviewableAction } from './shared/auto-review.js';
+export type { ReviewableAction, WorkspaceRootAccess } from './shared/auto-review.js';
 export {
   ORCA_NESTED_REPORT_DENIAL_REASON,
   ORCA_NESTED_REPORT_ERROR_CODE,

--- a/packages/maker-core/src/agents/pi/__tests__/pi-auto-review-policy.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/pi-auto-review-policy.test.ts
@@ -8,10 +8,14 @@ import { describe, expect, it } from 'vitest';
 import { classifyPiToolForAutoReview } from '../auto-review-policy.js';
 
 const WS = '/Users/t/ws';
-const roots = [WS];
+const rootAccess = {
+  primaryRoot: WS,
+  readRoots: [WS],
+  writableRoots: [WS],
+};
 
 function verdict(toolName: string, input: Record<string, unknown>) {
-  return classifyPiToolForAutoReview({ toolName, input, workspaceRoots: roots });
+  return classifyPiToolForAutoReview({ toolName, input, rootAccess });
 }
 
 describe('classifyPiToolForAutoReview', () => {
@@ -27,10 +31,10 @@ describe('classifyPiToolForAutoReview', () => {
   it('allows reads but not writes in extra read-only roots', () => {
     const readRoots = [WS, '/Users/t/reference'];
     expect(classifyPiToolForAutoReview({
-      toolName: 'read', input: { path: '/Users/t/reference/spec.md' }, workspaceRoots: roots, readRoots,
+      toolName: 'read', input: { path: '/Users/t/reference/spec.md' }, rootAccess: { ...rootAccess, readRoots },
     })).toBe('auto-approve');
     expect(classifyPiToolForAutoReview({
-      toolName: 'write', input: { path: '/Users/t/reference/spec.md' }, workspaceRoots: roots, readRoots,
+      toolName: 'write', input: { path: '/Users/t/reference/spec.md' }, rootAccess: { ...rootAccess, readRoots },
     })).toBe('prompt');
   });
 

--- a/packages/maker-core/src/agents/pi/auto-review-policy.ts
+++ b/packages/maker-core/src/agents/pi/auto-review-policy.ts
@@ -18,6 +18,7 @@ import {
   reviewAction,
   type ReviewableAction,
   type ReviewVerdict,
+  type WorkspaceRootAccess,
 } from '../shared/auto-review.js';
 
 export type PiAutoReviewVerdict = ReviewVerdict;
@@ -27,10 +28,8 @@ export interface PiAutoReviewContext {
   toolName: string;
   /** 工具入参(bridge 透传的原始对象)。 */
   input: Record<string, unknown>;
-  /** 会话工作区根:cwd,绝对路径(pi 无 extraDirs)。 */
-  workspaceRoots: string[];
-  /** 可读根:工作区 + Pi 附加只读引用目录。写操作仍只看 workspaceRoots。 */
-  readRoots?: string[];
+  /** 会话显式读写根；附加目录只出现在 readRoots。 */
+  rootAccess: WorkspaceRootAccess;
 }
 
 /** 给当前模型 reviewer 的完整 MCP/未知工具证据；输入来自 JSON RPC，可安全序列化。 */
@@ -109,5 +108,5 @@ export function normalizePiToolForAutoReview(ctx: PiAutoReviewContext): Reviewab
 }
 
 export function classifyPiToolForAutoReview(ctx: PiAutoReviewContext): PiAutoReviewVerdict {
-  return reviewAction(normalizePiToolForAutoReview(ctx), ctx.readRoots ?? ctx.workspaceRoots);
+  return reviewAction(normalizePiToolForAutoReview(ctx), ctx.rootAccess);
 }

--- a/packages/maker-core/src/agents/pi/index.ts
+++ b/packages/maker-core/src/agents/pi/index.ts
@@ -53,7 +53,7 @@ import {
   resolveAutoReviewDecision,
   type AutoReviewDecision,
 } from '../shared/auto-review-decision.js';
-import type { ReviewableAction } from '../shared/auto-review.js';
+import type { ReviewableAction, WorkspaceRootAccess } from '../shared/auto-review.js';
 import { buildMemoryScopeKey } from '../../memory/storage.js';
 import type {
   Capabilities,
@@ -1165,7 +1165,11 @@ export class PiAgent extends BaseAgent {
         model: mutableModel,
         userIntent: currentAutoReviewIntent,
         action,
-        workspaceRoots: [opts.workingDir, ...mutableExtraDirs],
+        rootAccess: {
+          primaryRoot: opts.workingDir,
+          readRoots: [opts.workingDir, ...mutableExtraDirs],
+          writableRoots: [opts.workingDir],
+        },
         platform: opts.remoteHostId ? 'linux' as const : process.platform,
       };
       const cacheKey = JSON.stringify(request);
@@ -1311,8 +1315,11 @@ export class PiAgent extends BaseAgent {
             this.handleExtensionUiRequest(event, proc, () => ({
               resolver: interactionResolver,
               permissionMode,
-              workspaceRoots: [opts.workingDir],
-              readRoots: [opts.workingDir, ...mutableExtraDirs],
+              rootAccess: {
+                primaryRoot: opts.workingDir,
+                readRoots: [opts.workingDir, ...mutableExtraDirs],
+                writableRoots: [opts.workingDir],
+              },
               reviewAutoAction,
               notifyAutoReviewUnavailable: () => autoReviewUnavailableNotice.notify(),
               registeredMcpServerNames,
@@ -2465,8 +2472,7 @@ export class PiAgent extends BaseAgent {
     getPermissionCtx: () => {
       resolver: InteractionResolver | null;
       permissionMode: 'ask' | 'auto' | 'bypassPermissions';
-      workspaceRoots: string[];
-      readRoots: string[];
+      rootAccess: WorkspaceRootAccess;
       reviewAutoAction: (action: ReviewableAction) => Promise<AutoReviewDecision>;
       /** 审阅器不可用时的会话级一次性提示;去重与重置由会话侧持有(issue #1574)。 */
       notifyAutoReviewUnavailable: () => void;
@@ -2555,8 +2561,7 @@ export class PiAgent extends BaseAgent {
       const {
         resolver,
         permissionMode,
-        workspaceRoots,
-        readRoots,
+        rootAccess,
         reviewAutoAction,
         notifyAutoReviewUnavailable,
         registeredMcpServerNames,
@@ -2766,8 +2771,7 @@ export class PiAgent extends BaseAgent {
           const action = normalizePiToolForAutoReview({
             toolName,
             input,
-            workspaceRoots,
-            readRoots,
+            rootAccess,
           });
           const decision = await reviewAutoAction(action);
           // 权限热切换:reviewAutoAction 是 async 的,期间用户可能改档。按**最新**档位收口,

--- a/packages/maker-core/src/agents/shared/auto-review-decision.test.ts
+++ b/packages/maker-core/src/agents/shared/auto-review-decision.test.ts
@@ -18,7 +18,11 @@ import {
   type AutoReviewRequest,
 } from './auto-review-decision.js';
 
-const roots = ['/repo', '/extra'];
+const rootAccess = {
+  primaryRoot: '/repo',
+  readRoots: ['/repo', '/extra'],
+  writableRoots: ['/repo'],
+};
 
 afterEach(() => {
   vi.useRealTimers();
@@ -32,7 +36,7 @@ function request(action: AutoReviewRequest['action']): AutoReviewRequest {
     model: 'current-model',
     userIntent: 'Fix the type error',
     action,
-    workspaceRoots: roots,
+    rootAccess,
     platform: 'linux',
   };
 }

--- a/packages/maker-core/src/agents/shared/auto-review-decision.ts
+++ b/packages/maker-core/src/agents/shared/auto-review-decision.ts
@@ -4,6 +4,7 @@ import {
   reviewAction,
   type ReviewableAction,
   type ReviewVerdict,
+  type WorkspaceRootAccess,
 } from './auto-review.js';
 
 /** Auto 对用户可见行为的最终三态；只有 `ask` 才允许弹用户确认。 */
@@ -90,12 +91,8 @@ export interface AutoReviewRequest {
   model: string;
   userIntent: string;
   action: ReviewableAction;
-  /**
-   * 位置语义(reviewAction 同契约):`[0]` 是唯一可写的工作目录,其余是只读引用目录
-   * (additionalDirectories)。所有 agent 一律传 `[workingDir, ...extraDirs]`;host 侧
-   * reviewer prompt 依赖该顺序区分可写/只读,不得打乱或拍平。
-   */
-  workspaceRoots: string[];
+  /** 显式目录权限；host prompt 与确定性 core 必须消费同一份读写边界。 */
+  rootAccess: WorkspaceRootAccess;
   platform: NodeJS.Platform;
 }
 
@@ -207,7 +204,7 @@ export function classifyLocalAutoReviewTier(
 ): LocalAutoReviewTier {
   const verdict = reviewAction(
     request.action,
-    request.workspaceRoots,
+    request.rootAccess,
     { platform: request.platform },
   );
   return verdict === 'prompt' ? 'needs-review' : verdict;

--- a/packages/maker-core/src/agents/shared/auto-review.adversarial.test.ts
+++ b/packages/maker-core/src/agents/shared/auto-review.adversarial.test.ts
@@ -19,9 +19,13 @@
  */
 import { describe, expect, it } from 'vitest';
 
-import { classifyShellCommand } from './auto-review.js';
+import { classifyShellCommand, type WorkspaceRootAccess } from './auto-review.js';
 
-const roots = ['/repo', '/extra'];
+const roots: WorkspaceRootAccess = {
+  primaryRoot: '/repo',
+  readRoots: ['/repo', '/extra'],
+  writableRoots: ['/repo'],
+};
 const opts = { cwd: '/repo', platform: 'darwin' as const };
 
 /** 必须确定性必问:stdin / 占位符 / 交互模式决定了实际执行什么,或直接读凭证、提权。 */

--- a/packages/maker-core/src/agents/shared/auto-review.corpus.test.ts
+++ b/packages/maker-core/src/agents/shared/auto-review.corpus.test.ts
@@ -18,9 +18,13 @@
  */
 import { describe, expect, it } from 'vitest';
 
-import { classifyShellCommand, commandExecutableNames } from './auto-review.js';
+import { classifyShellCommand, commandExecutableNames, type WorkspaceRootAccess } from './auto-review.js';
 
-const roots = ['/repo', '/extra'];
+const roots: WorkspaceRootAccess = {
+  primaryRoot: '/repo',
+  readRoots: ['/repo', '/extra'],
+  writableRoots: ['/repo'],
+};
 const opts = { cwd: '/repo', platform: 'darwin' as const };
 
 describe('语料回归 — 修复源 1:引号内 | 是数据不是管道', () => {
@@ -45,15 +49,19 @@ describe('语料回归 — 修复源 1:引号内 | 是数据不是管道', () =>
 });
 
 describe('语料回归 — 修复源 2:cd 区内目录 && 只读命令', () => {
-  it('cd <区内> && 只读 → auto-approve(改前 cd 段落灰区)', () => {
+  it('cd <区内> && 普通只读 → auto-approve，Git 仍要询问', () => {
     for (const c of [
-      'cd /repo && git log --all --oneline --since="10 days ago" | head -50',
-      'cd /repo && git diff --check',
       'cd /repo/packages/maker-core && ls -la src',
-      'cd /repo/.cindy-worktrees/feature-x && git diff upstream/main...HEAD --stat',
       'cd /repo && grep -rn "classifyShellCommand" packages --include="*.ts" | head -20',
     ]) {
       expect(classifyShellCommand(c, roots, opts), c).toBe('auto-approve');
+    }
+    for (const c of [
+      'cd /repo && git log --all --oneline --since="10 days ago" | head -50',
+      'cd /repo && git diff --check',
+      'cd /repo/.cindy-worktrees/feature-x && git diff upstream/main...HEAD --stat',
+    ]) {
+      expect(classifyShellCommand(c, roots, opts), c).toBe('prompt');
     }
   });
   it('cd 区外 / 动态目标仍不放行', () => {
@@ -386,7 +394,8 @@ describe('review 第四轮 — 分类器入口族', () => {
     expect(classifyShellCommand('cd /repo/$(whoami) && ls', roots, opts)).toBe('prompt');
     // 安全伪设备不算副作用,不因这道检查回退。
     expect(classifyShellCommand('cd /repo 2>/dev/null && ls', roots, opts)).toBe('auto-approve');
-    expect(classifyShellCommand('cd /repo && git log --oneline | head', roots, opts)).toBe('auto-approve');
+    // shell 内切换的 cwd 不能作为 host 已验证 Git 仓库的证明。
+    expect(classifyShellCommand('cd /repo && git log --oneline | head', roots, opts)).toBe('prompt');
   });
 });
 
@@ -824,7 +833,7 @@ describe('语料回归 — 命中率下限(总量护栏)', () => {
       'sed -n 1,120p src/index.ts',
       'gh pr view 1 --json state',
       'git log --all --oneline 2>/dev/null | head',
-      'cd /repo && git log --oneline | grep -i "pi\\|harness" | head -30',
+      'git log --oneline | grep -i "pi\\|harness" | head -30',
       'wc -l src/index.ts',
       'find . -name "*.test.ts" | head',
       'which node',

--- a/packages/maker-core/src/agents/shared/auto-review.test.ts
+++ b/packages/maker-core/src/agents/shared/auto-review.test.ts
@@ -12,9 +12,18 @@ import {
   classifyShellCommand,
   isProtectedSystemPath,
   reviewAction,
+  type WorkspaceRootAccess,
 } from './auto-review.js';
 
-const roots = ['/repo', '/extra'];
+function rootAccess(primaryRoot: string, readOnlyRoots: string[] = []): WorkspaceRootAccess {
+  return {
+    primaryRoot,
+    readRoots: [primaryRoot, ...readOnlyRoots],
+    writableRoots: [primaryRoot],
+  };
+}
+
+const roots = rootAccess('/repo', ['/extra']);
 
 describe('reviewAction — 非 shell 动作', () => {
   it('read / session-state → auto-approve', () => {
@@ -35,7 +44,7 @@ describe('reviewAction — file-write 工作区边界', () => {
     expect(reviewAction({ kind: 'file-write', path: '/repo/x.ts' }, roots)).toBe('auto-approve');
   });
   it('额外只读引用目录(非首 root)写 → prompt(additionalDirectories 可读不可写)', () => {
-    // /extra 是只读引用目录,写入须升级,不能因它在 workspaceRoots 里就当可写(codex 报)。
+    // /extra 是只读引用目录,写入须升级,不能因它在 readRoots 里就当可写(codex 报)。
     expect(reviewAction({ kind: 'file-write', path: '/extra/y.ts' }, roots)).toBe('prompt');
   });
   it('区外(非系统)/ .. 逃逸 / 前缀不整段 → prompt(灰区,交 reviewer)', () => {
@@ -48,21 +57,21 @@ describe('reviewAction — file-write 工作区边界', () => {
       expect(reviewAction({ kind: 'file-write', path: p }, roots)).toBe('prompt-each-time');
     }
     expect(reviewAction({ kind: 'file-write', path: '/repo/../../../etc/hosts' }, roots)).toBe('prompt-each-time');
-    expect(reviewAction({ kind: 'file-write', path: '/private/etc/passwd' }, ['/var/f/ws'], { platform: 'darwin' })).toBe('prompt-each-time');
-    expect(reviewAction({ kind: 'file-write', path: 'C:\\Windows\\System32\\x' }, ['C:\\repo'], { platform: 'win32' })).toBe('prompt-each-time');
+    expect(reviewAction({ kind: 'file-write', path: '/private/etc/passwd' }, rootAccess('/var/f/ws'), { platform: 'darwin' })).toBe('prompt-each-time');
+    expect(reviewAction({ kind: 'file-write', path: 'C:\\Windows\\System32\\x' }, rootAccess('C:\\repo'), { platform: 'win32' })).toBe('prompt-each-time');
   });
   it('path 缺失 → prompt(无法确认在区内)', () => {
     expect(reviewAction({ kind: 'file-write', path: undefined }, roots)).toBe('prompt');
   });
   it('macOS firmlink:/private/var 与 /var 对齐(仅 darwin);Linux 不抹平', () => {
     // 显式传 platform,使断言在任何宿主(含 Linux CI)上确定。
-    expect(reviewAction({ kind: 'file-write', path: '/private/var/f/ws/a' }, ['/var/f/ws'], { platform: 'darwin' })).toBe('auto-approve');
+    expect(reviewAction({ kind: 'file-write', path: '/private/var/f/ws/a' }, rootAccess('/var/f/ws'), { platform: 'darwin' })).toBe('auto-approve');
     // /private/etc 归 /etc(系统目录)→ 高影响红线(见系统目录写用例)。
-    expect(reviewAction({ kind: 'file-write', path: '/private/etc/passwd' }, ['/var/f/ws'], { platform: 'darwin' })).toBe('prompt-each-time');
+    expect(reviewAction({ kind: 'file-write', path: '/private/etc/passwd' }, rootAccess('/var/f/ws'), { platform: 'darwin' })).toBe('prompt-each-time');
     // Linux:/private/tmp 与 /tmp 无关,写 /private/tmp/repo/x(root=/tmp/repo)不再被误判为区内 → prompt。
-    expect(reviewAction({ kind: 'file-write', path: '/private/tmp/repo/x' }, ['/tmp/repo'], { platform: 'linux' })).toBe('prompt');
+    expect(reviewAction({ kind: 'file-write', path: '/private/tmp/repo/x' }, rootAccess('/tmp/repo'), { platform: 'linux' })).toBe('prompt');
     // darwin 上同一路径仍抹平为区内。
-    expect(reviewAction({ kind: 'file-write', path: '/private/tmp/repo/x' }, ['/tmp/repo'], { platform: 'darwin' })).toBe('auto-approve');
+    expect(reviewAction({ kind: 'file-write', path: '/private/tmp/repo/x' }, rootAccess('/tmp/repo'), { platform: 'darwin' })).toBe('auto-approve');
   });
 });
 
@@ -72,6 +81,107 @@ describe('reviewAction — exec 实际 cwd 边界', () => {
     expect(reviewAction({ kind: 'exec', command: 'pwd', cwd: '/extra' }, roots)).toBe('prompt');
     expect(reviewAction({ kind: 'exec', command: 'pwd', cwd: '/Users/me' }, roots)).toBe('prompt');
     expect(reviewAction({ kind: 'exec', command: 'rm -rf build', cwd: '/Users/me' }, roots)).toBe('prompt-each-time');
+  });
+});
+
+describe('显式 root access 契约', () => {
+  const reordered: WorkspaceRootAccess = {
+    primaryRoot: '/repo',
+    readRoots: ['/extra', '/repo'],
+    writableRoots: ['/repo'],
+  };
+
+  it('相对路径按 primaryRoot 解析，写权限不依赖 readRoots 顺序', () => {
+    expect(reviewAction({ kind: 'file-write', path: 'src/a.ts' }, reordered)).toBe('auto-approve');
+    expect(reviewAction({ kind: 'file-write', path: '/extra/a.ts' }, reordered)).toBe('prompt');
+  });
+
+  it('cd 可进入只读根做只读工作，但破坏与 git -C 不会把只读根当成可写/可信 cwd', () => {
+    expect(classifyShellCommand('cd /extra && rg TODO .', reordered)).toBe('auto-approve');
+    expect(classifyShellCommand('cd /extra && rm -rf build', reordered)).toBe('prompt-each-time');
+    expect(classifyShellCommand('git -C /repo status', reordered)).toBe('auto-approve');
+    expect(classifyShellCommand('git -C /extra status', reordered)).toBe('prompt');
+  });
+
+  it('跨段 cwd 仍供普通命令解析，但 Git 不把 shell 内改出的 cwd 当 host-trusted', () => {
+    expect(classifyShellCommand('cd /extra && rg TODO .', reordered))
+      .toBe('auto-approve');
+    expect(classifyShellCommand('cd /extra && git diff', reordered))
+      .toBe('prompt');
+    expect(classifyShellCommand('pushd /extra && git status', reordered))
+      .toBe('prompt');
+    expect(classifyShellCommand('cd /extra && git -C /extra status', reordered))
+      .toBe('prompt');
+    expect(classifyShellCommand('cd /extra && git -C /repo status', reordered))
+      .toBe('prompt');
+    expect(classifyShellCommand('cd /extra && env -C /extra git status', reordered))
+      .toBe('prompt');
+    expect(classifyShellCommand('cd /extra && env -C /repo git status', reordered))
+      .toBe('prompt');
+    expect(classifyShellCommand('env -C /extra git diff', reordered))
+      .toBe('prompt');
+  });
+
+  it('env 即使重新切到同名 host cwd，也不能为 Git 重建信任锚', () => {
+    expect(classifyShellCommand('env -C /repo git status', reordered))
+      .toBe('prompt');
+    expect(classifyShellCommand('env --chdir=/repo git diff', reordered))
+      .toBe('prompt');
+    // 这个来源标记只收紧 Git；普通只读命令继续使用 wrapper 解析出的 cwd。
+    expect(classifyShellCommand('env -C /repo rg TODO .', reordered))
+      .toBe('auto-approve');
+  });
+
+  it('Windows root 同样按显式权限判定，不依赖 readRoots 位置', () => {
+    const windows: WorkspaceRootAccess = {
+      primaryRoot: 'C:\\repo',
+      readRoots: ['D:\\reference', 'C:\\repo'],
+      writableRoots: ['C:\\repo'],
+    };
+    expect(reviewAction({ kind: 'file-write', path: 'src\\a.ts' }, windows, { platform: 'win32' }))
+      .toBe('auto-approve');
+    expect(reviewAction({ kind: 'file-write', path: 'D:\\reference\\a.ts' }, windows, { platform: 'win32' }))
+      .toBe('prompt');
+    expect(classifyShellCommand('git -C C:\\repo status', windows, { platform: 'win32' }))
+      .toBe('auto-approve');
+  });
+
+  it('重叠可写根按最具体根判定整根删除，POSIX 与 Windows 同口径', () => {
+    const posix: WorkspaceRootAccess = {
+      primaryRoot: '/repo',
+      readRoots: ['/repo', '/repo/packages/core'],
+      writableRoots: ['/repo', '/repo/packages/core'],
+    };
+    expect(classifyShellCommand('rm -rf /repo/packages/core', posix))
+      .toBe('prompt-each-time');
+    expect(classifyShellCommand('rm -rf /repo/packages/core/build', posix))
+      .toBe('prompt');
+
+    const windows: WorkspaceRootAccess = {
+      primaryRoot: 'C:\\repo',
+      readRoots: ['C:\\repo', 'C:\\repo\\packages\\core'],
+      writableRoots: ['C:\\repo', 'C:\\repo\\packages\\core'],
+    };
+    expect(classifyShellCommand('rm -rf C:\\repo\\packages\\core', windows, { platform: 'win32' }))
+      .toBe('prompt-each-time');
+    expect(classifyShellCommand('rm -rf C:\\repo\\packages\\core\\build', windows, { platform: 'win32' }))
+      .toBe('prompt');
+
+    const mixedCaseWindows: WorkspaceRootAccess = {
+      primaryRoot: 'C:\\Repo',
+      readRoots: ['C:\\Repo', 'c:\\REPO\\Packages\\Core'],
+      writableRoots: ['C:\\Repo', 'c:\\REPO\\Packages\\Core'],
+    };
+    expect(classifyShellCommand(
+      'rm -rf C:\\repo\\PACKAGES\\core',
+      mixedCaseWindows,
+      { platform: 'win32' },
+    )).toBe('prompt-each-time');
+    expect(classifyShellCommand(
+      'rm -rf C:\\repo\\PACKAGES\\core\\build',
+      mixedCaseWindows,
+      { platform: 'win32' },
+    )).toBe('prompt');
   });
 });
 
@@ -289,7 +399,7 @@ describe('classifyShellCommand — 极高风险才 prompt-each-time', () => {
     expect(classifyShellCommand("xargs -a /tmp/items sh -c 'echo item'", roots)).toBe('prompt');
   });
   it('Windows 路径保留反斜杠并按首个可写根判定', () => {
-    const windowsRoots = ['C:\\repo', 'C:\\extra'];
+    const windowsRoots = rootAccess('C:\\repo', ['C:\\extra']);
     expect(classifyShellCommand('rm -rf C:\\repo\\build', windowsRoots, {
       cwd: 'C:\\repo',
       platform: 'win32',
@@ -417,7 +527,7 @@ describe('classifyShellCommand — curl/wget 带查询串的 GET(exfil 面)', ()
 });
 
 describe('reviewAction — Windows 绝对路径边界(盘符路径不再被当相对路径拼进工作区)', () => {
-  const winRoots = ['C:\\Users\\me\\project'];
+  const winRoots = rootAccess('C:\\Users\\me\\project');
   it('工作区外的 Windows 绝对写:系统目录 → prompt-each-time,非系统 → prompt', () => {
     expect(reviewAction({ kind: 'file-write', path: 'C:\\Windows\\System32\\drivers\\etc\\hosts' }, winRoots)).toBe('prompt-each-time');
     expect(reviewAction({ kind: 'file-write', path: 'D:\\secrets\\x.txt' }, winRoots)).toBe('prompt');
@@ -437,7 +547,7 @@ describe('reviewAction — Windows 绝对路径边界(盘符路径不再被当�
     expect(reviewAction({ kind: 'file-write', path: 'C:..\\Windows\\System32\\evil.exe' }, winRoots)).toBe('prompt');
     expect(reviewAction({ kind: 'file-write', path: 'C:evil.txt' }, winRoots)).toBe('prompt');
     // POSIX 工作区下盘符相对路径同样 fail-closed 升级(不拼进 /repo)。
-    expect(reviewAction({ kind: 'file-write', path: 'C:..\\..\\etc\\passwd' }, ['/repo'])).toBe('prompt');
+    expect(reviewAction({ kind: 'file-write', path: 'C:..\\..\\etc\\passwd' }, rootAccess('/repo'))).toBe('prompt');
   });
 });
 
@@ -1606,7 +1716,7 @@ describe('引号内字面括号 / -execdir 相对目标 / -files0-from 动态根
   });
 
   it('-execdir 的相对破坏目标 cwd 随匹配项变动、不可证 → 必问', () => {
-    const r = ['/repo'];
+    const r = rootAccess('/repo');
     // -execdir 在匹配项目录执行,相对 `cindy` 实际可能删掉整个 /repo → 必问。
     expect(classifyShellCommand('find /repo -maxdepth 0 -execdir rm -rf cindy \\;', r)).toBe('prompt-each-time');
     // 反例:同样相对目标但用 -exec(会话 cwd 解析)且在区内 → 灰区。

--- a/packages/maker-core/src/agents/shared/auto-review.ts
+++ b/packages/maker-core/src/agents/shared/auto-review.ts
@@ -47,6 +47,19 @@ export { isSensitiveCredentialPath } from './sensitive-credential-paths.js';
 export type ReviewVerdict = 'auto-approve' | 'prompt' | 'prompt-each-time';
 
 /**
+ * 会话目录权限的显式契约。
+ *
+ * `primaryRoot` 只定义相对路径与默认 cwd 的解析基准；真正的权限边界分别由
+ * `readRoots` / `writableRoots` 决定。调用方必须保证 primaryRoot 同时位于两组 roots 中，
+ * 且 writableRoots 是 readRoots 的子集。core 只做纯字符串判定，不访问文件系统。
+ */
+export interface WorkspaceRootAccess {
+  primaryRoot: string;
+  readRoots: readonly string[];
+  writableRoots: readonly string[];
+}
+
+/**
  * 归一化动作 —— 各 harness 的 adapter 把自己的工具调用/审批请求翻译成它,交 reviewAction 裁决。
  *   read          读文件/内省(可带 path:读凭证文件必问;scope='tree' 的目录级递归读若根在区外必升级,其余放行)
  *   session-state 会话内状态/控制,无本地写/外发(todo、后台 shell 读写、subagent 派生)
@@ -67,12 +80,12 @@ export type ReviewableAction =
 
 /**
  * 核心裁决。纯函数、确定性、无副作用(不触文件系统 —— 探文件存在性会变侧信道,且对远端
- * 路径不可行;workspaceRoots 只做字符串前缀判定)。workspaceRoots[0] 是唯一可写工作目录，
- * 后续项是 additionalDirectories 只读引用目录，均为绝对路径。
+ * 路径不可行;rootAccess 只做字符串前缀判定)。相对路径按 primaryRoot 解析，读写权限
+ * 分别由 readRoots / writableRoots 判定，所有 root 均为绝对路径。
  */
 export function reviewAction(
   action: ReviewableAction,
-  workspaceRoots: string[],
+  rootAccess: WorkspaceRootAccess,
   opts?: { platform?: NodeJS.Platform },
 ): ReviewVerdict {
   // macOS firmlink(/private/{var,tmp,etc} == /{var,tmp,etc})仅在 darwin 上成立;在 Linux(含远端 Linux)
@@ -84,9 +97,13 @@ export function reviewAction(
       if (action.path && isSensitiveCredentialPath(action.path)) return 'prompt-each-time';
       // 目录级递归读(Grep/Glob/LS,scope='tree')的**根目录**在工作区外 → 能遍历进区外的凭证子路径
       // (如 `Grep {path:'/Users/me', pattern:'AKIA'}` 读出 ~/.aws/credentials,而 path 本身不含凭证名,
-      // copilot 报)→ 升级。读取范围含额外只读引用目录(整个 workspaceRoots)。单文件读只读一个具名文件。
+      // copilot 报)→ 升级。读取范围含额外只读引用目录(整个 readRoots)。单文件读只读一个具名文件。
       if (action.scope === 'tree' && action.path
-        && !isInsideWorkspace(normalizeTarget(action.path, workspaceRoots), workspaceRoots, aliasFirmlinks)) return 'prompt';
+        && !isInsideWorkspace(
+          normalizeTarget(action.path, rootAccess.primaryRoot),
+          rootAccess.readRoots,
+          aliasFirmlinks,
+        )) return 'prompt';
       return 'auto-approve';
     case 'session-state':
       return 'auto-approve';
@@ -95,12 +112,11 @@ export function reviewAction(
       // 写凭证文件必问、不可记住 —— 即便落在工作区内(如 /repo/.aws/credentials、/repo/.codex/auth.json):
       // 把 secret 写进 git-tracked checkout 与写区外同样危险,凭证性优先于工作区边界。
       if (isSensitiveCredentialPath(action.path)) return 'prompt-each-time';
-      const normalizedWriteTarget = normalizeTarget(action.path, workspaceRoots);
-      // **只有工作目录(workspaceRoots[0])可写**;额外目录(additionalDirectories)是只读引用上下文
-      // (base-agent 契约 / index.ts extraDirs 注释:可读不可写)。相对路径挂到 workspaceRoots[0] 解析。
+      const normalizedWriteTarget = normalizeTarget(action.path, rootAccess.primaryRoot);
+      // 写权限只看显式 writableRoots；当前 caller 仅传 primaryRoot，额外目录仍是只读引用上下文
+      // (base-agent 契约 / index.ts extraDirs 注释:可读不可写)。相对路径挂到 primaryRoot 解析。
       // 区内一律放行 —— 即便工作区本身落在 /var、/root 等下,区内写也不该被系统红线误升(先判区内)。
-      const writableRoots = workspaceRoots.slice(0, 1);
-      if (isInsideWorkspace(normalizedWriteTarget, writableRoots, aliasFirmlinks)) return 'auto-approve';
+      if (isInsideWorkspace(normalizedWriteTarget, rootAccess.writableRoots, aliasFirmlinks)) return 'auto-approve';
       // 区外写系统/受保护目录(/etc、/System、C:\Windows 等)是高影响系统级写入,不能交灰区 reviewer
       // 静默 allow(copilot 报)→ 确定性必问。canonical(darwin 抹平 /private firmlink)后判,使
       // `/private/etc/passwd` 也命中 `/etc`。其它区外写 → 灰区 reviewer。
@@ -109,7 +125,7 @@ export function reviewAction(
     }
     case 'exec': {
       const cwdUnknown = action.cwdUnknown === true || (action.cwd !== undefined && action.cwd.trim() === '');
-      const shellVerdict = classifyShellCommand(action.command, workspaceRoots, {
+      const shellVerdict = classifyShellCommand(action.command, rootAccess, {
         cwd: cwdUnknown ? undefined : action.cwd,
         cwdUnknown,
         platform: opts?.platform,
@@ -118,9 +134,12 @@ export function reviewAction(
       if (cwdUnknown) return shellVerdict === 'auto-approve' ? 'prompt' : shellVerdict;
       // 额外目录是只读引用，不是可执行写入边界。先保留命令分类器识别出的确定性红线，
       // 其它命令只要 cwd 不在首个可写根内就升级到 reviewer，避免相对写落进 additionalDirectories。
-      const writableRoots = workspaceRoots.slice(0, 1);
       if (action.cwd
-        && !isInsideWorkspace(normalizeTarget(action.cwd, workspaceRoots), writableRoots, aliasFirmlinks)) {
+        && !isInsideWorkspace(
+          normalizeTarget(action.cwd, rootAccess.primaryRoot),
+          rootAccess.writableRoots,
+          aliasFirmlinks,
+        )) {
         return shellVerdict === 'prompt-each-time' ? shellVerdict : 'prompt';
       }
       return shellVerdict;
@@ -972,6 +991,8 @@ type UnwrappedCommand = {
   tokens: string[];
   cwd?: string;
   cwdUnknown: boolean;
+  /** 是否消费过会重新解析 cwd 的 wrapper 选项；即使文本路径未变，也不再是 host 信任来源。 */
+  consumedCwdChangingWrapper: boolean;
   inspectionOnly: boolean;
   /** 达到剥壳上限时首 token 仍是包装器 = 未能看到真实命令(超深嵌套 `env env … rm`)→ 消费方 fail-closed。 */
   wrapperUnresolved: boolean;
@@ -993,7 +1014,7 @@ function resolveCwdTarget(
     return { cwdUnknown: true };
   }
   return {
-    cwd: normalizeTarget(target, currentCwd ? [currentCwd] : []),
+    cwd: normalizeTarget(target, currentCwd),
     cwdUnknown: false,
   };
 }
@@ -1007,8 +1028,10 @@ function unwrapCommand(
   let toks = stripShellControlTokens(tokens);
   let cwd = initialCwd;
   let cwdUnknown = initialCwdUnknown;
+  let consumedCwdChangingWrapper = false;
   let inspectionOnly = false;
   const applyCwd = (target: string | undefined): void => {
+    consumedCwdChangingWrapper = true;
     const next = resolveCwdTarget(target, cwd, cwdUnknown);
     cwd = next.cwd;
     cwdUnknown = next.cwdUnknown;
@@ -1308,7 +1331,14 @@ function unwrapCommand(
   // env -S)在 depth<MAX 处 break,不算未解析,避免误升。
   const wrapperUnresolved = depth >= MAX_WRAPPER_UNWRAP_DEPTH
     && toks.length > 0 && COMMAND_WRAPPERS.has(executableName(toks[0]));
-  return { tokens: toks, cwd, cwdUnknown, inspectionOnly, wrapperUnresolved };
+  return {
+    tokens: toks,
+    cwd,
+    cwdUnknown,
+    consumedCwdChangingWrapper,
+    inspectionOnly,
+    wrapperUnresolved,
+  };
 }
 
 /** 无需 cwd 语义的调用点只取剥壳后的真实 argv。 */
@@ -2258,6 +2288,8 @@ function highImpactExecutionNeedsConsent(command: string, depth = 0): boolean {
 type ShellReviewOptions = {
   cwd?: string;
   cwdUnknown?: boolean;
+  /** false = cwd 来自 shell 内部 cd/pushd 等，不能作为 Git 仓库配置的 host 信任证明。 */
+  cwdHostTrusted?: boolean;
   platform?: NodeJS.Platform;
 };
 
@@ -2296,11 +2328,10 @@ function charClassCanTraverse(target: string): boolean {
 
 function destructiveTargetNeedsConsent(
   target: string,
-  workspaceRoots: string[],
+  rootAccess: WorkspaceRootAccess,
   opts: ShellReviewOptions,
 ): boolean {
-  const writableRoot = workspaceRoots[0];
-  if (!writableRoot) return true;
+  if (rootAccess.writableRoots.length === 0) return true;
   // 变量、命令/花括号展开的运行期目标不可静态求值；`~` 也不能按 cwd 解析。
   if (/[$`{}]/.test(target) || target.startsWith('~')) return true;
   // 字符类能展开出 `.`/`/` → 运行期路径可穿越出静态前缀,不可静态证明在区内 → 必问(greptile 报)。
@@ -2310,10 +2341,8 @@ function destructiveTargetNeedsConsent(
   // workspace”级别；只有明确进入子目录（如 build/*）才交 reviewer 静默裁决。
   const globIndex = target.search(/[*?[\]]/);
   const staticTarget = globIndex >= 0 ? (target.slice(0, globIndex) || '.') : target;
-  const cwd = opts.cwd ?? writableRoot;
+  const cwd = opts.cwd ?? rootAccess.primaryRoot;
   const aliasFirmlinks = (opts.platform ?? process.platform) === 'darwin';
-  const normalizedRoot = canonicalPath(writableRoot, aliasFirmlinks);
-  if (normalizedRoot === '/' || /^[A-Za-z]:\/$/.test(normalizedRoot)) return true;
   const candidates = [staticTarget];
   if (globIndex >= 0) {
     // A bracket expression may itself spell `..` (`[.].`). Check the same
@@ -2322,9 +2351,23 @@ function destructiveTargetNeedsConsent(
     candidates.push(target.replace(/[[\]{}*?]/g, '') || '.');
   }
   return candidates.some((candidate) => {
-    const normalizedTarget = normalizeTarget(candidate, [cwd]);
-    if (!isInsideWorkspace(normalizedTarget, [writableRoot], aliasFirmlinks)) return true;
-    return canonicalPath(normalizedTarget, aliasFirmlinks) === normalizedRoot;
+    const normalizedTarget = normalizeTarget(candidate, cwd);
+    const comparisonPath = (path: string): string => {
+      const canonical = canonicalPath(path, aliasFirmlinks);
+      return (opts.platform ?? process.platform) === 'win32'
+        ? canonical.toLowerCase()
+        : canonical;
+    };
+    const canonicalTarget = comparisonPath(normalizedTarget);
+    // roots 可重叠(`/repo` + `/repo/packages/core`)。目标落入多个根时必须以最具体的根为
+    // 破坏边界；否则删除完整子根会被更宽的父根当成“普通子目录清理”而降级到灰区。
+    const containingRoots = rootAccess.writableRoots
+      .map(comparisonPath)
+      .filter((root) => isInsideWorkspace(canonicalTarget, [root], false))
+      .sort((a, b) => b.length - a.length);
+    const writableRoot = containingRoots[0];
+    if (!writableRoot || writableRoot === '/' || /^[A-Za-z]:\/$/.test(writableRoot)) return true;
+    return canonicalTarget === writableRoot;
   });
 }
 
@@ -2557,13 +2600,13 @@ function shellQuoteArgvForReview(tokens: string[]): string {
 
 function matchedPathSentinel(
   root: string,
-  workspaceRoots: string[],
+  rootAccess: WorkspaceRootAccess,
   opts: ShellReviewOptions,
 ): string | null {
   if (/[$`{}*?[\]]/.test(root) || root.startsWith('~')) return null;
-  const base = opts.cwd ?? workspaceRoots[0];
+  const base = opts.cwd ?? rootAccess.primaryRoot;
   if (!isAbsolutePath(toForwardSlashes(root)) && (!base || opts.cwdUnknown)) return null;
-  const resolved = normalizeTarget(root, base ? [base] : []).replace(/\/+$/, '');
+  const resolved = normalizeTarget(root, base).replace(/\/+$/, '');
   return `${resolved}/${MATCHED_PATH_SENTINEL}`;
 }
 
@@ -2575,7 +2618,7 @@ function matchedPathSentinel(
 function systemWriteTargetsInSegment(
   segment: string,
   tokens: string[],
-  workspaceRoots: string[],
+  rootAccess: WorkspaceRootAccess,
   opts: ShellReviewOptions,
 ): boolean {
   const targets = [...redirectionTargets(segment), ...argumentWriteTargets(tokens)];
@@ -2583,25 +2626,25 @@ function systemWriteTargetsInSegment(
   // 静态不可证的写目标(tar -P 的归档成员等)一律要求同意。
   if (targets.includes(UNPROVABLE_WRITE_TARGET)) return true;
   const aliasFirmlinks = (opts.platform ?? process.platform) === 'darwin';
-  const base = opts.cwd ?? workspaceRoots[0];
+  const base = opts.cwd ?? rootAccess.primaryRoot;
   return targets.some((t) =>
     // 每个目标查两种形态:原样(保留 Windows `\` 分隔符)与去 POSIX `\` 转义(`/e\tc`→`/etc`)。
     [t, t.replace(/\\(.)/g, '$1')].some((v) => {
       const forward = toForwardSlashes(v);
       // cwd 未知 + 相对目标 → 无法证明它没落进系统目录,fail-closed。
       if (opts.cwdUnknown && !isAbsolutePath(forward)) return true;
-      return isProtectedSystemPath(canonicalPath(normalizeTarget(v, [base]), aliasFirmlinks));
+      return isProtectedSystemPath(canonicalPath(normalizeTarget(v, base), aliasFirmlinks));
     }));
 }
 
 /** 系统/区外批量破坏与受保护分支强推不能只交给模型裁决。 */
 function scopedDestructionNeedsConsent(
   command: string,
-  workspaceRoots: string[],
+  rootAccess: WorkspaceRootAccess,
   opts: ShellReviewOptions,
   depth = 0,
 ): boolean {
-  let currentCwd: string | undefined = opts.cwd ?? workspaceRoots[0];
+  let currentCwd: string | undefined = opts.cwd ?? rootAccess.primaryRoot;
   let currentCwdUnknown = opts.cwdUnknown === true;
   for (const { text: segment, separatorAfter } of splitExecutableSegments(command)) {
     const unwrapped = unwrapCommand(tokenize(segment), currentCwd, currentCwdUnknown);
@@ -2616,25 +2659,25 @@ function scopedDestructionNeedsConsent(
     const bin = executableName(tokens[0] ?? '');
     // 系统写目标(shell 重定向 + 参数写通道)按**本段有效 cwd** 解析:相对目标必须挂到 unwrapped.cwd
     // (含 `cd /etc &&` 跨段传递与 `env -C /etc` 段内改目录),否则 `cp /tmp/payload hosts` 配 cwd=/etc
-    // 实际覆盖 /etc/hosts 却因按 workspaceRoots 解析而只落灰区(codex 报)。
-    if (systemWriteTargetsInSegment(segment, tokens, workspaceRoots, segmentOpts)) return true;
+    // 实际覆盖 /etc/hosts 却因按会话根解析而只落灰区(codex 报)。
+    if (systemWriteTargetsInSegment(segment, tokens, rootAccess, segmentOpts)) return true;
     const rmTargets = destructiveRmTargets(tokens);
     if (rmTargets?.some((target) =>
-      destructiveTargetNeedsConsent(target, workspaceRoots, segmentOpts))) return true;
+      destructiveTargetNeedsConsent(target, rootAccess, segmentOpts))) return true;
     // Windows cmd.exe 广泛递归删除(`rd`/`rmdir`/`del`/`erase` 带 `/s`)按目标作用域判定(codex 报)。
     const winRmTargets = windowsDestructiveRmTargets(tokens);
     if (winRmTargets?.some((target) =>
-      destructiveTargetNeedsConsent(target, workspaceRoots, segmentOpts))) return true;
+      destructiveTargetNeedsConsent(target, rootAccess, segmentOpts))) return true;
     // shell -c（含 -lc 等组合短选项）内还有一层命令字符串；递归有限深，超过说明静态结构已不可靠。
     const shellPayload = shellCommandPayload(tokens);
     if (shellPayload && (depth >= MAX_EXEC_REVIEW_DEPTH || scopedDestructionNeedsConsent(
-      shellPayload, workspaceRoots, segmentOpts, depth + 1))) {
+      shellPayload, rootAccess, segmentOpts, depth + 1))) {
       return true;
     }
     // cmd.exe /c "rd /s /q …" 把破坏性删除藏进 cmd 载荷,递归下探(codex 报)。
     const cmdPayload = cmdCommandPayload(tokens);
     if (cmdPayload && (depth >= MAX_EXEC_REVIEW_DEPTH || scopedDestructionNeedsConsent(
-      cmdPayload, workspaceRoots, segmentOpts, depth + 1))) {
+      cmdPayload, rootAccess, segmentOpts, depth + 1))) {
       return true;
     }
     if (bin === 'find') {
@@ -2653,7 +2696,7 @@ function scopedDestructionNeedsConsent(
         const execScope = dirRelative ? { ...segmentOpts, cwdUnknown: true } : segmentOpts;
         // 忽略 {} 直接删的字面/独立目标(`rm -rf /` / `/outside` / -execdir 下的相对目标)按其作用域判定。
         if (rmTargetsInExec.some((target) => !isMatchedPathPlaceholder(target)
-          && destructiveTargetNeedsConsent(target, workspaceRoots, execScope))) return true;
+          && destructiveTargetNeedsConsent(target, rootAccess, execScope))) return true;
         if (rmTargetsInExec.some(isMatchedPathPlaceholder)) execMatchedRm = true;
         // rm 之外的危险面同样要审:受保护写通道(`-exec cp payload /etc/hosts \;`、`-exec tee /etc/x \;`、
         // `-exec install -d /etc/cron.d \;`)、载荷里的重定向与 `cd /etc &&` 跨段(codex 报只查了 rm 目标)。
@@ -2665,19 +2708,19 @@ function scopedDestructionNeedsConsent(
         for (const root of concreteRoots) {
           let innerArgv = argv;
           if (root !== null) {
-            const sentinel = matchedPathSentinel(root, workspaceRoots, segmentOpts);
+            const sentinel = matchedPathSentinel(root, rootAccess, segmentOpts);
             if (sentinel === null) return true; // 根不可静态解析 → 占位目标落哪不可证
             innerArgv = argv.map((t) => substituteMatchedPath(t, sentinel));
           }
           if (depth >= MAX_EXEC_REVIEW_DEPTH || scopedDestructionNeedsConsent(
-            shellQuoteArgvForReview(innerArgv), workspaceRoots, execScope, depth + 1)) return true;
+            shellQuoteArgvForReview(innerArgv), rootAccess, execScope, depth + 1)) return true;
         }
       }
       // 删的是被匹配到的路径(占位符 {}/$0/…),或 -delete → 删除作用域由遍历根决定;动态根一律必问。
       if (deletes || execMatchedRm) {
         if (dynamicRoots) return true;
         if (findRoots.some((target) =>
-          destructiveTargetNeedsConsent(target, workspaceRoots, segmentOpts))) return true;
+          destructiveTargetNeedsConsent(target, rootAccess, segmentOpts))) return true;
       }
     }
     // xargs / parallel 动态补入的目标无法从 argv 证明在工作区内；递归/强制 rm 必须保留用户同意
@@ -2691,7 +2734,7 @@ function scopedDestructionNeedsConsent(
         // Unmodelled options plus an apparent shell command cannot be proven safe.
         if (tokens.slice(1).some((token) => SHELL_EXECUTORS.has(executableName(token)))) return true;
       } else if (nested.length > 0 && (depth >= MAX_EXEC_REVIEW_DEPTH || scopedDestructionNeedsConsent(
-        serializeArgvForReview(nested), workspaceRoots, segmentOpts, depth + 1))) {
+        serializeArgvForReview(nested), rootAccess, segmentOpts, depth + 1))) {
         return true;
       }
     }
@@ -3037,7 +3080,7 @@ const SAFE_GIT_GLOBAL_FLAGS: ReadonlySet<string> = new Set([
 
 function isTrustedGitCwdPath(
   target: string | undefined,
-  workspaceRoots: string[],
+  rootAccess: WorkspaceRootAccess,
   cwd: string | undefined,
   cwdUnknown: boolean,
   platform: NodeJS.Platform | undefined,
@@ -3049,7 +3092,7 @@ function isTrustedGitCwdPath(
   // `chdir` 先跟随 symlink、再处理 `..`。词法 normalize 会把 `/repo/link/..` 错折成
   // `/repo`，所以只允许不含 `.`/`..`/空分量的绝对路径，且必须精确等于宿主确认 cwd。
   if (!isAbsolutePath(forward) || forward.split('/').slice(1).some((part) => part === '' || part === '.' || part === '..')) return false;
-  const base = cwd ?? workspaceRoots[0];
+  const base = cwd ?? rootAccess.primaryRoot;
   if (!base) return false;
   const aliasFirmlinks = (platform ?? process.platform) === 'darwin';
   return canonicalPath(forward, aliasFirmlinks) === canonicalPath(base, aliasFirmlinks);
@@ -3057,7 +3100,7 @@ function isTrustedGitCwdPath(
 
 function parseGitInvocation(
   tokens: string[],
-  workspaceRoots: string[],
+  rootAccess: WorkspaceRootAccess,
   opts: ShellReviewOptions,
 ): { sub?: string; args: string[] } | undefined {
   // Git 的全局选项位于子命令之前。`git -C /repo show` 中 `/repo` 不是子命令；若直接
@@ -3074,7 +3117,7 @@ function parseGitInvocation(
       return { sub: token, args: tokens.slice(index + 1) };
     }
     if (token === '-C') {
-      if (!isTrustedGitCwdPath(tokens[index + 1], workspaceRoots, opts.cwd, opts.cwdUnknown === true, opts.platform)) return undefined;
+      if (!isTrustedGitCwdPath(tokens[index + 1], rootAccess, opts.cwd, opts.cwdUnknown === true, opts.platform)) return undefined;
       index += 2;
       continue;
     }
@@ -3086,7 +3129,7 @@ function parseGitInvocation(
     }
     const attachedCwd = /^-C=?(.*)$/.exec(token);
     if (attachedCwd) {
-      if (!isTrustedGitCwdPath(attachedCwd[1], workspaceRoots, opts.cwd, opts.cwdUnknown === true, opts.platform)) return undefined;
+      if (!isTrustedGitCwdPath(attachedCwd[1], rootAccess, opts.cwd, opts.cwdUnknown === true, opts.platform)) return undefined;
       index++;
       continue;
     }
@@ -3108,7 +3151,7 @@ function parseGitInvocation(
 function classifyGit(
   tokens: string[],
   segment: string,
-  workspaceRoots: string[],
+  rootAccess: WorkspaceRootAccess,
   opts: ShellReviewOptions,
 ): ReviewVerdict {
   // 高风险 git(强推/硬重置/clean -f)已在 REVIEW_REQUIRED_PATTERNS 命中,这里分只读 vs 写。
@@ -3133,7 +3176,7 @@ function classifyGit(
   // 远程助手传输 `ext::<cmd>` / `fd::` 会把 URL 里的命令交给 shell 执行(RCE);即便 ls-remote 最终报错,
   // 命令也已跑(codex 报:`git ls-remote 'ext::sh -c …'`)。任何 git 命令带 ext::/fd:: 传输 → 升级。
   if (/(?:^|[\s'"=])(?:ext|fd)::/.test(segment)) return 'prompt';
-  const invocation = parseGitInvocation(tokens, workspaceRoots, opts);
+  const invocation = parseGitInvocation(tokens, rootAccess, opts);
   if (!invocation?.sub || !SAFE_GIT_SUBCOMMANDS.has(invocation.sub)) {
     // `git config --get/--list` 只读;其它 git(commit/checkout/merge/fetch/config 写…)升级。
     if (invocation?.sub === 'config' && /--(?:get|list|get-all)\b/.test(segment)) return 'auto-approve';
@@ -3169,21 +3212,22 @@ function classifyGit(
 
 function classifyShellSegment(
   segment: string,
-  workspaceRoots: string[],
+  rootAccess: WorkspaceRootAccess,
   opts: ShellReviewOptions,
 ): ReviewVerdict {
   const rawTokens = tokenize(segment);
   const unwrapped = unwrapCommand(
     rawTokens,
-    opts.cwd ?? workspaceRoots[0],
+    opts.cwd ?? rootAccess.primaryRoot,
     opts.cwdUnknown === true,
   );
   const tokens = unwrapped.tokens;
   // 包装器可改变内层 cwd（如 `env -C /extra git …`）。不能把该路径当作可信审批基准；
   // 只要 Git 前经过改目录或 cwd 变得未知，保守交给 prompt。
-  const initialCwd = opts.cwd ?? workspaceRoots[0];
+  const initialCwd = opts.cwd ?? rootAccess.primaryRoot;
   const aliasFirmlinks = (opts.platform ?? process.platform) === 'darwin';
-  const wrapperChangedCwd = unwrapped.cwdUnknown
+  const wrapperChangedCwd = unwrapped.consumedCwdChangingWrapper
+    || unwrapped.cwdUnknown
     || (unwrapped.cwd !== undefined && initialCwd !== undefined
       && canonicalPath(unwrapped.cwd, aliasFirmlinks) !== canonicalPath(initialCwd, aliasFirmlinks));
   // 裸 env / 未指定 VARIABLE 的 printenv 会输出整个进程环境(含 provider API key)，不能交给
@@ -3256,8 +3300,10 @@ function classifyShellSegment(
     : cmd0Raw;
   if (cmd0.includes('/') && !/^\/(?:usr\/s?bin|s?bin)\//.test(cmd0)) return 'prompt';
   if (bin === 'git') {
-    if (wrapperChangedCwd) return 'prompt';
-    return classifyGit(tokens, deQuoted, workspaceRoots, opts);
+    // 只有 host 直接提供的 cwd 能作为 Git 仓库配置的信任锚。shell 内部 cd/pushd 即使
+    // 静态落在 readRoots，也可能经过 symlink 进入恶意 checkout；env -C 等包装器同理。
+    if (opts.cwdHostTrusted === false || wrapperChangedCwd) return 'prompt';
+    return classifyGit(tokens, deQuoted, rootAccess, opts);
   }
   if (isSafeFetch(bin, deQuoted, tokens)) return 'auto-approve';
   if (isSafeReadonlyBin(bin, deQuoted, tokens)) return 'auto-approve';
@@ -3302,7 +3348,7 @@ export function commandExecutableNames(command: string): string[] {
 
 export function classifyShellCommand(
   command: string,
-  workspaceRoots: string[],
+  rootAccess: WorkspaceRootAccess,
   opts: ShellReviewOptions = {},
 ): ReviewVerdict {
   if (typeof command !== 'string' || command.trim().length === 0) return 'prompt';
@@ -3352,7 +3398,7 @@ export function classifyShellCommand(
   // `| tee /etc/hosts`、`truncate -s 0 /etc/passwd`、`tar -C /etc` 等)= 高影响系统写,复用
   // file-write 的系统红线。**判定放在 scopedDestructionNeedsConsent 的分段循环里**,因为那里已经
   // 跨段跟踪有效 cwd(`cd /etc &&`)与包装器改目录(`env -C /etc`)—— 相对写目标必须按有效 cwd 解析
-  // (codex 报:按 workspaceRoots 解析会让 `cp /tmp/payload hosts` 配 cwd=/etc 漏成灰区)。
+  // (codex 报:按会话根解析会让 `cp /tmp/payload hosts` 配 cwd=/etc 漏成灰区)。
   // 该循环的首个变体就是原始 command(保留引号),含空格的 DEST 靠引号定界不会被拆碎。
   // 删除/强推需要结合目标范围判断，不能只按关键词一刀切：可证明局限在工作区子目录或普通
   // feature ref 的操作进入 reviewer；系统级、区外、整工作区、动态目标和受保护/隐含分支必问。
@@ -3362,7 +3408,7 @@ export function classifyShellCommand(
     scopedVariants.push(deEscaped, deExpanded, deSubstituted);
   }
   if (scopedVariants.some((variant) =>
-    scopedDestructionNeedsConsent(variant, workspaceRoots, opts))) return 'prompt-each-time';
+    scopedDestructionNeedsConsent(variant, rootAccess, opts))) return 'prompt-each-time';
   for (const re of REVIEW_REQUIRED_PATTERNS) {
     if (re.test(deEscaped) || re.test(quotesOnly) || re.test(deGlobbed) || re.test(deExpanded) || re.test(deExpandedGlob) || re.test(deSubstituted)) return 'prompt';
   }
@@ -3374,8 +3420,9 @@ export function classifyShellCommand(
   // 段(相对目标按跟踪 cwd 解析);目标区外/动态(`$VAR`、`~`、`-`)/source/popd 维持灰区不变。
   // 安全性:破坏类(`cd /etc && cp payload hosts`)由前面的 scopedDestructionNeedsConsent 以
   // 自己的跨段 cwd 跟踪先行拦截;这里只影响「全段只读」时 cd 段自身的档位。
-  let trackedCwd: string | undefined = opts.cwd ?? workspaceRoots[0];
+  let trackedCwd: string | undefined = opts.cwd ?? rootAccess.primaryRoot;
   let trackedCwdUnknown = opts.cwdUnknown === true;
+  let trackedCwdHostTrusted = opts.cwdHostTrusted !== false && !trackedCwdUnknown;
   const aliasFirmlinks = (opts.platform ?? process.platform) === 'darwin';
   for (const seg of segments) {
     const segTokens = stripShellControlTokens(tokenize(seg));
@@ -3385,9 +3432,10 @@ export function classifyShellCommand(
       const next = resolveCwdTarget(dirChange.target, trackedCwd, trackedCwdUnknown);
       trackedCwd = next.cwd;
       trackedCwdUnknown = next.cwdUnknown;
+      trackedCwdHostTrusted = false;
       if ((segBin === 'cd' || segBin === 'pushd')
         && !next.cwdUnknown && next.cwd
-        && isInsideWorkspace(next.cwd, workspaceRoots, aliasFirmlinks)
+        && isInsideWorkspace(next.cwd, rootAccess.readRoots, aliasFirmlinks)
         // 快捷放行只针对「切目录」这个动作本身。同一段里仍可能挂着输出重定向或命令替换
         // (`cd /repo > /tmp/out`),那属于写文件/执行任意内容,不能被这条捷径绕过 ——
         // 复用与 classifyShellSegment 同一份判据(安全伪设备已排除),review P1。
@@ -3397,7 +3445,12 @@ export function classifyShellCommand(
       needsPrompt = true; // 区外/动态目标、source/popd:与改动前同档(灰区)。
       continue;
     }
-    const v = classifyShellSegment(seg, workspaceRoots, opts);
+    const v = classifyShellSegment(seg, rootAccess, {
+      ...opts,
+      cwd: trackedCwd,
+      cwdUnknown: trackedCwdUnknown,
+      cwdHostTrusted: trackedCwdHostTrusted,
+    });
     if (v === 'prompt-each-time') return 'prompt-each-time';
     if (v === 'prompt') needsPrompt = true;
   }
@@ -3424,12 +3477,11 @@ function isAbsolutePath(p: string): boolean {
   return p.startsWith('/') || /^[A-Za-z]:/.test(p);
 }
 
-/** 归一化路径:去包裹引号、统一分隔符,相对路径挂到第一个 workspace root(cwd)。 */
-function normalizeTarget(target: string, workspaceRoots: string[]): string {
+/** 归一化路径:去包裹引号、统一分隔符,相对路径挂到显式 base(cwd)。 */
+function normalizeTarget(target: string, base?: string): string {
   let p = toForwardSlashes(target.replace(/^['"]|['"]$/g, ''));
   if (!isAbsolutePath(p)) {
-    const cwd = workspaceRoots[0];
-    if (cwd) p = `${toForwardSlashes(cwd).replace(/\/+$/, '')}/${p.replace(/^\/+/, '')}`;
+    if (base) p = `${toForwardSlashes(base).replace(/\/+$/, '')}/${p.replace(/^\/+/, '')}`;
   }
   return normalizeSlashes(p);
 }
@@ -3480,9 +3532,9 @@ function canonicalPath(p: string, aliasFirmlinks: boolean): string {
  * 缓解:创建该 symlink 本身需要一条 `ln -s`(shell 命令,会按写/未知升级),攻击面限于**预先已存在**
  * 的恶意链接。以 fail-open 的这一窄口,换取无 fs 副作用 + 远端路径可判 + 确定性可测,是刻意取舍。
  */
-function isInsideWorkspace(target: string, workspaceRoots: string[], aliasFirmlinks: boolean): boolean {
+function isInsideWorkspace(target: string, roots: readonly string[], aliasFirmlinks: boolean): boolean {
   const t = canonicalPath(target, aliasFirmlinks);
-  for (const root of workspaceRoots) {
+  for (const root of roots) {
     if (!root) continue;
     const r = canonicalPath(root, aliasFirmlinks);
     if (t === r) return true;


### PR DESCRIPTION
## 这次改了什么

### 摘要

把 Auto Review 的工作区权限从“数组中第一个根可写、其余只读”的位置约定，重构为显式的 `primaryRoot / readRoots / writableRoots` 契约，并贯通 Codex、Claude、Pi 与 Desktop 调用链。

这是 #2398 的 P1 契约阶段：当前仍保持“主工作区可写、额外目录只读”，不在本 PR 中开放额外目录写权限。后续阶段可以基于显式契约安全实现 mixed access。

### 变更类型

- [x] `refactor` / `perf` 重构或性能优化

### 范围

- 关联 Issue / 需求：Refs #2398
- 本 PR 包含：Auto Review root-access 类型、shell/path classifier、各 agent caller 与 Desktop reviewer 投影
- 明确不包含：数据库、UI、额外目录写权限开关、Mobile/device-link/SSH 能力扩展
- 用户可见变化：无；当前权限行为保持不变
- 是否存在 breaking change：无（内部 workspace 契约同步迁移）

### UI 变化

不涉及：未修改 UI、视觉、交互或用户文案。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
相关 7-file Vitest suite
结果：420 passed，1 todo

核心 auto-review suite
结果：241/241 passed

pnpm --filter @cindy/maker-core run --if-present typecheck
结果：exit 0

pnpm --filter desktop run --if-present typecheck
结果：exit 0

pnpm test:unit -- --workspace-concurrency=1
结果：exit 0；全部 workspace PASS
```

根门禁首次运行时，机器默认 PATH 将 `python` 解析为 Python 2.7，导致与本 PR 无关的 `scriptRunnerPythonProtocol.test.ts` 4 条语法错误。诊断确认同一冻结快照在 Python 3.10 下该文件 4/4 通过；随后在同一 shell 显式前置 Python 3.10，完整根门禁取得 `exit 0`。提交前 source/gate 的 17 个规范化 Git blob manifest 均为 `809469DBFD01AAC21539E041D5014BF1B881F862CC088F4D0DF472A5308B57CA`。

### 手工验证

独立 reviewer 多轮检查权限边界，最终无 P0/P1；重点覆盖 `cd/pushd/env -C` 后 Git 信任、Windows mixed-case 重叠 writable root 和 prompt payload 不变。

### 未执行的验证

未执行实际多个 writable roots 的端到端写入验证，因为本 PR 不启用该能力。

## 风险

### 风险分类

- [x] 权限 / 安全 / 用户数据

### 影响与回滚

- 影响范围：Auto Review 的内部路径与 shell 命令权限分类
- 回滚 / 降级方式：回退本提交即可恢复旧位置约定
- 安全边界：当前 callers 仍固定 primary 可写、extras 只读；`env -C/--chdir` 与跨段 cwd 改变后的 Git 不继承 host-trusted 状态；Windows 路径按大小写不敏感 identity 判断完整根删除

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要测试
- [x] 已确认测试结果或说明未执行原因