### PR TITLE
fix(desktop): keep malformed math text in normal color

### DIFF
--- a/apps/desktop/src/renderer/__tests__/markdownMathRendering.test.ts
+++ b/apps/desktop/src/renderer/__tests__/markdownMathRendering.test.ts
@@ -32,7 +32,7 @@ function renderMath(markdown: string): string {
   return renderToStaticMarkup(
     createElement(ReactMarkdown, {
       remarkPlugins: [remarkGfm, remarkMath, remarkStrictInlineMath],
-      rehypePlugins: [[rehypeKatex, { strict: 'ignore' }]],
+      rehypePlugins: [[rehypeKatex, { strict: 'ignore', errorColor: 'inherit' }]],
       children: normalizeMathDelimiters(markdown),
     }),
   );
@@ -86,10 +86,33 @@ describe('math rendering pipeline (remark-math + rehype-katex)', () => {
     expect(html).not.toContain('class="katex"');
   });
 
-  it('非法 LaTeX 不抛异常,渲染为错误标记', () => {
+  it('跨行 inline math 降级为正文,不触发 KaTeX', () => {
+    const html = renderMath('说明 $第一行\n第二行$ 结束');
+    expect(html).not.toContain('class="katex"');
+    expect(html).not.toContain('katex-error');
+    expect(html).toContain('第一行');
+    expect(html).toContain('第二行');
+  });
+
+  it('截图同形的非法 display LaTeX 保持正文色', () => {
+    const html = renderMath(String.raw`$$
+\boxed{\begin{array}{l}
+(\psi^{(0)},x_0) \xrightarrow{\text{流出}} \text{背景} \\
+\underset{\displaystyle \rotatebox[origin=c]{-90}{$\rightsquigarrow$}}{R_1}
+\end{array}}
+$$`);
+
+    expect(html).toContain('katex-error');
+    expect(html).toContain('\\rotatebox');
+    expect(html).toContain('style="color:inherit"');
+    expect(html).not.toContain('var(--error-fg)');
+  });
+
+  it('非法单行 LaTeX 保持正文色,不使用错误红 token', () => {
     const html = renderMath('$\\frac{$');
-    // rehype-katex 捕获解析错误,输出 katex-error 或原文,组件不崩
-    expect(typeof html).toBe('string');
+    expect(html).toContain('katex-error');
+    expect(html).toContain('style="color:inherit"');
+    expect(html).not.toContain('var(--error-fg)');
   });
 });
 

--- a/apps/desktop/src/renderer/components/chat/MarkdownRenderer.tsx
+++ b/apps/desktop/src/renderer/components/chat/MarkdownRenderer.tsx
@@ -228,7 +228,7 @@ const REMARK_PLUGINS_PRIVILEGED: PluggableList = [
 // rehypeKatex 必须排在 rehypeHighlight 之前:remark-math 产出的 hast 是
 // `<code class="language-math ...">`,先让 katex 消费掉,否则 highlight 会往
 // 里面塞 hljs span 破坏纯文本结构。strict:'ignore' 静默非致命 LaTeX 告警;
-// errorColor 走语义豁免 error token,解析失败的公式以错误色显示原文。
+// 解析失败的公式回落为正文色原文,避免模型格式错误把普通聊天染成错误红。
 // rehypeMathBlockMarker 紧随 rehypeKatex:把裸 `<span class="katex-display">`
 // 包进 `<div data-math-block>`,让下方 div 渲染器能挂「复制为图片」工具栏
 // (components 映射只认 tagName,认不了 class)。
@@ -237,7 +237,7 @@ const REMARK_PLUGINS_PRIVILEGED: PluggableList = [
 // 打 data-fenced-code 供下方 code 渲染器按结构(而非语言标注)分派。
 const REHYPE_PLUGINS: PluggableList = [
   rehypeSlug,
-  [rehypeKatex, { strict: 'ignore', errorColor: 'var(--error-fg)' }],
+  [rehypeKatex, { strict: 'ignore', errorColor: 'inherit' }],
   rehypeMathBlockMarker,
   rehypeHighlight,
   rehypeFencedCodeMarker,

--- a/apps/desktop/src/renderer/components/chat/remarkStrictInlineMath.ts
+++ b/apps/desktop/src/renderer/components/chat/remarkStrictInlineMath.ts
@@ -9,6 +9,8 @@
  * matcher 保持一致**(apps/mobile messageMarkdown.ts),两端语义对齐:
  *
  * - 内容首/尾是空白 → 降级(「$5 和 $」这类货币配对)。
+ * - 内容含换行 → 降级。mobile 的 inline matcher 只接受单行公式,跨行内容
+ *   是正文边界误配,不能交给 KaTeX 变成跨行排版或错误色文本。
  * - 内容含反引号 → 降级(合法 LaTeX 无 backtick,必是跨 code span 误判)。
  * - 闭合 $ 后紧跟数字 → 降级(「$5和$10」CJK 无空格形态)。
  *
@@ -42,7 +44,7 @@ const remarkStrictInlineMath: Plugin<[], Root> = () => {
       const inner = raw.replace(/^\$+/, '').replace(/\$+$/, '');
       const nextChar = source[end] ?? '';
       const loose =
-        /^\s|\s$/.test(inner) || inner.includes('`') || /^\d/.test(nextChar);
+        /^\s|\s$/.test(inner) || inner.includes('\n') || inner.includes('`') || /^\d/.test(nextChar);
       if (!loose) return;
       const text: Text = { type: 'text', value: raw };
       parent.children[index] = text;


### PR DESCRIPTION
## 这次改了什么

### 摘要

- 让 Desktop 中格式错误或 KaTeX 不支持的数学文本继承消息正文颜色，不再显示为语义错误红色。
- 将包含换行的 inline math 降级为普通文本，使 Desktop 行为与 Mobile 的单行匹配规则一致。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Desktop malformed math fallback color。
- 本 PR 包含：KaTeX fallback 颜色继承、跨行 inline math 降级、对应渲染测试。
- 明确不包含：服务端、Mobile、协议、凭证、数据库、插件或其他 Markdown 行为。
- 用户可见变化：格式错误、KaTeX 不支持或跨行的数学文本以周围消息的正文颜色显示。
- 是否存在 breaking change：无。

### UI 变化

- 效果证据：`markdownMathRendering.test.ts` 的定向 DOM 断言覆盖跨行 inline math 纯文本降级，以及非法 inline/display math 使用 `errorColor: inherit`；本 PR 不改变布局、尺寸或交互。
- 引用的设计规范：`docs/design-rules/DESIGN.md` §2 Color Palette & Roles、§10 Theme System & Token Reference（含 Light / Dark 双模式交付门槛）。KaTeX 失败回退继承周围正文颜色，不新增硬编码颜色或单模式分支。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/renderer/__tests__/markdownMathRendering.test.ts
结果：通过，1 个测试文件、16 个测试全部通过。

pnpm --filter desktop run --if-present typecheck
结果：通过。

pnpm test:unit
结果：未通过。当前本机 Node 为 24.18.0，仓库 .nvmrc 要求 22.22.3；Desktop Vitest runner 在执行中被 SIGSEGV 杀死，其余适用 workspace 通过。未将该结果描述为测试通过。

git diff --check
结果：通过。

pnpm check:dco
结果：通过，PR 范围内 1 个 commit 已签名。
```

### 手工验证

不涉及：本轮没有启动独立 Desktop 实例做 Light / Dark 实机目检；颜色行为由继承式 CSS 配置与定向 DOM 测试覆盖。

### 未执行的验证

- 未在 Node 22.22.3 下重跑 `pnpm test:unit`：当前机器未发现该版本的可用安装。
- 未附截图或录屏：本改动仅改变解析失败文本的颜色继承和跨行降级，不改变界面结构；定向测试作为效果证据。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Desktop Markdown 数学渲染失败回退与跨行 inline math 解析。
- 回滚 / 降级方式：回退本 PR 的单个提交即可恢复原行为；不涉及数据迁移或持久化状态。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 `DCO`）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档或确认不需要额外文档
- [x] 已确认测试结果或说明未执行 / 未通过原因