### PR TITLE
fix(desktop): 继续暂停队列时解锁队首恢复

### DIFF
--- a/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
@@ -4410,6 +4410,61 @@ describe('AgentInputCoordinator stop and drain boundaries', () => {
     expect(h.abortSession).not.toHaveBeenCalled();
   });
 
+  it('resumes a paused queue-head recovery from the original head without reordering the tail', async () => {
+    const h = createHarness();
+    const sid = 'resume-paused-queue-head-recovery';
+    const first = makeItem('q-1', 'first');
+    const second = makeItem('q-2', 'second', {
+      origin: { kind: 'orca', senderLabel: 'worker-1' },
+    });
+
+    h.sendToAgent.mockResolvedValueOnce(hostSendFailure('SEND_FAILED', 'boom'));
+    h.coordinator.enqueue(sid, first);
+    await flush();
+
+    h.coordinator.enqueue(sid, second);
+    await flush();
+
+    // A mechanical duplicate resume must not retry an unpaused recovery. Only
+    // the visible paused-queue Continue action owns the recovery transition.
+    h.coordinator.resume(sid);
+    await flush();
+    let projection = latestProjection(h.projections);
+    expect(h.sendToAgent).toHaveBeenCalledTimes(1);
+    expect(projection.recovery).toEqual({ kind: 'queue-head', clientId: 'q-1' });
+
+    projection = h.coordinator.pausePendingQueueForRewind(sid);
+    expect(projection).toMatchObject({
+      queuePaused: true,
+      recovery: { kind: 'queue-head', clientId: 'q-1' },
+    });
+    expect(projection.pendingQueue.map((item) => item.clientId)).toEqual(['q-1', 'q-2']);
+
+    // A stale recovery must never retry through a different queue head.
+    h.coordinator.move(sid, 'q-2', 0);
+    h.coordinator.resume(sid);
+    await flush();
+    projection = latestProjection(h.projections);
+    expect(h.sendToAgent).toHaveBeenCalledTimes(1);
+    expect(projection.recovery).toEqual({ kind: 'queue-head', clientId: 'q-1' });
+    expect(projection.pendingQueue.map((item) => item.clientId)).toEqual(['q-2', 'q-1']);
+
+    h.coordinator.move(sid, 'q-1', 0);
+    projection = h.coordinator.pausePendingQueueForRewind(sid);
+    expect(projection.pendingQueue.map((item) => item.clientId)).toEqual(['q-1', 'q-2']);
+
+    h.sendToAgent.mockResolvedValueOnce(sendSuccess());
+    h.coordinator.resume(sid);
+    await flush();
+
+    projection = latestProjection(h.projections);
+    expect(h.sendToAgent).toHaveBeenCalledTimes(2);
+    expect(h.sendToAgent.mock.calls[1]?.[1]).toEqual({ type: 'user', content: 'first' });
+    expect(projection.recovery).toBeNull();
+    expect(projection.error).toBeNull();
+    expect(projection.pendingQueue.map((item) => item.clientId)).toEqual(['q-2']);
+  });
+
   it('keeps the queue paused after Stop and drains after Continue plus Claude abort boundary', async () => {
     const h = createHarness();
     const sid = 'stop-claude';

--- a/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
@@ -4424,6 +4424,7 @@ describe('AgentInputCoordinator stop and drain boundaries', () => {
 
     h.coordinator.enqueue(sid, second);
     await flush();
+    mocks.touchUserSendInDb.mockClear();
 
     // A mechanical duplicate resume must not retry an unpaused recovery. Only
     // the visible paused-queue Continue action owns the recovery transition.
@@ -4431,6 +4432,7 @@ describe('AgentInputCoordinator stop and drain boundaries', () => {
     await flush();
     let projection = latestProjection(h.projections);
     expect(h.sendToAgent).toHaveBeenCalledTimes(1);
+    expect(mocks.touchUserSendInDb).not.toHaveBeenCalled();
     expect(projection.recovery).toEqual({ kind: 'queue-head', clientId: 'q-1' });
 
     projection = h.coordinator.pausePendingQueueForRewind(sid);
@@ -4446,6 +4448,7 @@ describe('AgentInputCoordinator stop and drain boundaries', () => {
     await flush();
     projection = latestProjection(h.projections);
     expect(h.sendToAgent).toHaveBeenCalledTimes(1);
+    expect(mocks.touchUserSendInDb).not.toHaveBeenCalled();
     expect(projection.recovery).toEqual({ kind: 'queue-head', clientId: 'q-1' });
     expect(projection.pendingQueue.map((item) => item.clientId)).toEqual(['q-2', 'q-1']);
 
@@ -4460,6 +4463,8 @@ describe('AgentInputCoordinator stop and drain boundaries', () => {
     projection = latestProjection(h.projections);
     expect(h.sendToAgent).toHaveBeenCalledTimes(2);
     expect(h.sendToAgent.mock.calls[1]?.[1]).toEqual({ type: 'user', content: 'first' });
+    expect(mocks.touchUserSendInDb).toHaveBeenCalledOnce();
+    expect(mocks.touchUserSendInDb).toHaveBeenCalledWith(sid, undefined);
     expect(projection.recovery).toBeNull();
     expect(projection.error).toBeNull();
     expect(projection.pendingQueue.map((item) => item.clientId)).toEqual(['q-2']);

--- a/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
+++ b/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
@@ -1373,8 +1373,8 @@ export class AgentInputCoordinator {
     //  - UI 续跑(「继续」按钮,sendUiTrigger):等价 retryLastError——清 recovery
     //    重发队首 A(原样重发是既有 retryLastError 对 queue-head 的语义),合成
     //    continue 项不入队,避免 A 与 continue 双发。
-    // 自动来源(scheduler / orca)与 resume(继续队列)维持既有「不清」语义:
-    // 自动化项不代表用户表态,resume 是机械放行,显式点重试/删除仍是唯一出路。
+    // 自动来源(scheduler / orca)不代表用户表态,维持「不清」语义。暂停队列的
+    // Continue 则由 resume 原子清除与当前队首匹配的 recovery 后重发原消息。
     if (state.recovery?.kind === 'queue-head' && !automaticOrigin) {
       const abandonedClientId = state.recovery.clientId;
       if (isUiContinuationItem(item)) {
@@ -2099,9 +2099,26 @@ export class AgentInputCoordinator {
 
   resume(sessionId: string): AgentInputProjection {
     const state = this.getState(sessionId);
+    const recovery = state.recovery;
+    const pausedQueueHeadRecoveryClientId =
+      state.queuePaused &&
+      recovery?.kind === 'queue-head' &&
+      state.pendingQueue[0]?.clientId === recovery.clientId
+        ? recovery.clientId
+        : null;
     state.queuePaused = false;
     state.queuePausedByRestore = false;
-    this.clearErrorUnlessQueueHeadBlocked(state);
+    if (pausedQueueHeadRecoveryClientId !== null) {
+      state.error = null;
+      state.stickyError = null;
+      state.recovery = null;
+      log.info('paused queue resume resets queue-head recovery', {
+        sessionId,
+        clientId: pausedQueueHeadRecoveryClientId,
+      });
+    } else {
+      this.clearErrorUnlessQueueHeadBlocked(state);
+    }
     this.emit(sessionId);
     this.scheduleDrain(sessionId, 'resume');
     this.scheduleExternalTurnRetryIfNeeded(sessionId, state, 'resume');

--- a/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
+++ b/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
@@ -2116,6 +2116,7 @@ export class AgentInputCoordinator {
         sessionId,
         clientId: pausedQueueHeadRecoveryClientId,
       });
+      this.touchUserSend(sessionId);
     } else {
       this.clearErrorUnlessQueueHeadBlocked(state);
     }


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复暂停队列同时存在 `queue-head recovery` 时，用户点击“继续发送”后队列仍永久停滞的问题。

`resume()` 现在会原子检查调用前的权威状态：只有队列确实处于暂停态、recovery 类型为 `queue-head`，且 recovery 的 `clientId` 精确匹配当前队首时，才清除这条 pre-accept recovery 和错误，并沿用现有 drain 从原队首继续派发。

未暂停的重复 resume、active-turn recovery 和 recovery/队首不匹配的状态保持原语义，不会转换成隐式 Retry。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Closes #2587；关联 #2041、#2042
- 本 PR 包含：`AgentInputCoordinator.resume()` 的 paused queue-head recovery 原子解锁，以及 coordinator 回归测试
- 明确不包含：IPC、preload、renderer、Mobile、Device Link 协议、UI 文案或 recovery 数据模型变更
- 用户可见变化：暂停队列的 recovery 队首可通过现有“继续发送”恢复执行
- 是否存在 breaking change：无

### UI 变化

不涉及：复用现有“继续发送”入口，不修改视觉、交互结构或文案。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
# TDD RED
vitest agent-input-coordinator.test.ts -t "resumes a paused queue-head recovery..."
结果：按预期失败，expected sendToAgent 2 calls, received 1

# Coordinator 全量
vitest agent-input-coordinator.test.ts
结果：269 passed

# maker-ipc 全量（最新 origin/main）
vitest src/main/maker-ipc
结果：86 files passed，1571 tests passed

# 文件级 lint
eslint src/main/maker-ipc/agent-input-coordinator.ts src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
结果：通过

# Desktop typecheck
NODE_OPTIONS=--max-old-space-size=8192 tsc --noEmit -p apps/desktop/tsconfig.json
结果：通过
```

### 手工验证

不涉及：使用 coordinator 的公开操作构造确定性状态并自动验证。

### 未执行的验证

无。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Desktop main 进程中暂停队列的 resume 状态转换；队列未暂停或 recovery 不匹配时行为不变
- 回滚 / 降级方式：回滚本提交即可恢复原语义；无数据迁移或持久化格式变化

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在“UI 变化”注明（不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（无需新增文档）
- [x] 已确认测试结果或说明未执行原因