### PR TITLE
fix(desktop): group model families within each source

### DIFF
--- a/apps/desktop/src/renderer/__tests__/modelSelectorProviderGroups.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/modelSelectorProviderGroups.test.tsx
@@ -374,6 +374,70 @@ describe('ModelSelector provider groups', () => {
     expect(within(dashscopeGroup).queryByText('Opus 4.8')).toBeNull();
   });
 
+  it('keeps models of the same family together within one provider group', async () => {
+    providersRef.providers = [
+      {
+        id: 'xd',
+        name: 'Cindy AI',
+        source: 'builtin',
+        agents: ['claude-code'],
+        auth: { method: 'api-key' },
+        routing: { 'claude-code': {} },
+        connected: true,
+        models: {
+          'claude-code': [
+            {
+              id: 'codex/gpt-5.6-sol',
+              name: 'Codex GPT-5.6 Sol',
+              group: 'gpt-budget',
+              sortOrder: 10,
+              contextWindow: 200000,
+              efforts: ['low', 'medium', 'high'],
+              defaultEffort: 'high',
+            },
+            {
+              id: 'deepseek-v4-pro',
+              name: 'DeepSeek V4 Pro',
+              group: 'ungrouped',
+              sortOrder: 20,
+              contextWindow: 200000,
+              efforts: ['low', 'medium', 'high'],
+              defaultEffort: 'high',
+            },
+            {
+              id: 'codex/gpt-5.6-terra',
+              name: 'Codex GPT-5.6 Terra',
+              group: 'gpt-budget',
+              sortOrder: 11,
+              contextWindow: 200000,
+              efforts: ['low', 'medium', 'high'],
+              defaultEffort: 'medium',
+            },
+          ],
+        },
+      },
+    ] as unknown[];
+
+    try {
+      renderSelector({
+        modelId: 'codex/gpt-5.6-sol',
+        currentProviderId: 'xd',
+      });
+      await openDropdown();
+
+      const rows = within(screen.getByRole('group', { name: 'Cindy AI' }))
+        .getAllByRole('option')
+        .map((row) => row.textContent);
+      expect(rows).toEqual([
+        expect.stringContaining('Codex GPT-5.6 Sol'),
+        expect.stringContaining('Codex GPT-5.6 Terra'),
+        expect.stringContaining('DeepSeek V4 Pro'),
+      ]);
+    } finally {
+      providersRef.providers = providersRef.DEFAULT_PROVIDERS;
+    }
+  });
+
   it('keeps the create-agent secondary panel at the original left/center position with layout coordinates', async () => {
     renderSelector({ visualVariant: 'create-agent', useMorphPopover: true });
     await openDropdown();

--- a/apps/desktop/src/renderer/__tests__/modelSelectorProviderGroups.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/modelSelectorProviderGroups.test.tsx
@@ -387,7 +387,7 @@ describe('ModelSelector provider groups', () => {
         models: {
           'claude-code': [
             {
-              id: 'codex/gpt-5.6-sol',
+              id: 'xd/codex-gpt-5.6-sol',
               name: 'Codex GPT-5.6 Sol',
               group: 'gpt-budget',
               sortOrder: 10,
@@ -396,7 +396,7 @@ describe('ModelSelector provider groups', () => {
               defaultEffort: 'high',
             },
             {
-              id: 'deepseek-v4-pro',
+              id: 'deepseek/v4-pro',
               name: 'DeepSeek V4 Pro',
               group: 'ungrouped',
               sortOrder: 20,
@@ -405,7 +405,7 @@ describe('ModelSelector provider groups', () => {
               defaultEffort: 'high',
             },
             {
-              id: 'codex/gpt-5.6-terra',
+              id: 'xd/codex-gpt-5.6-terra',
               name: 'Codex GPT-5.6 Terra',
               group: 'gpt-budget',
               sortOrder: 11,
@@ -420,7 +420,7 @@ describe('ModelSelector provider groups', () => {
 
     try {
       renderSelector({
-        modelId: 'codex/gpt-5.6-sol',
+        modelId: 'xd/codex-gpt-5.6-sol',
         currentProviderId: 'xd',
       });
       await openDropdown();

--- a/apps/desktop/src/renderer/components/new-chat/ModelSelector.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ModelSelector.tsx
@@ -95,6 +95,7 @@ import {
   resolveCodexCompatibilityWireProtocol,
   sourcesForModel,
   visibleModelUnion,
+  groupModelsForDisplay,
   type ProviderView,
 } from '@cindy/model-providers';
 import { isProviderLogoKind } from '@cindy/model-providers/branding';
@@ -1314,7 +1315,12 @@ function ModelSelectorContentView({
             });
           },
       query,
-    });
+    }).map((section) => ({
+      ...section,
+      // 供应商顺序仍由 providerOrder 决定；仅整理每个来源自己的模型，使同类模型
+      // （如 Codex / GPT / DeepSeek）相邻，并遵从目录的 sortOrder。
+      models: groupModelsForDisplay(section.models).flatMap((group) => group.models),
+    }));
     // visibilityVersion 仅作刷新触发器(设置页改显示开关后强制重算);deviceId 切换需重算分段。
   }, [
     sourcesEnabled,

--- a/packages/model-providers/src/__tests__/modelList.test.ts
+++ b/packages/model-providers/src/__tests__/modelList.test.ts
@@ -204,8 +204,41 @@ describe('parity: buildProviderSections 薄壳 vs 历史实现', () => {
 
   it('全用例深等(含顺序与字段存在性)', () => {
     for (const args of cases) {
-      expect(buildProviderSections(args)).toEqual(legacyBuildProviderSections(args));
+      const current = buildProviderSections(args);
+      // 新增的展示排序元数据不属于历史实现；先剥离它们，继续锁住旧的字段/顺序语义。
+      expect(
+        current.map(({ provider, models }) => ({
+          provider,
+          models: models.map(({ group: _group, mode: _mode, sortOrder: _sortOrder, ...model }) => model),
+        })),
+      ).toEqual(legacyBuildProviderSections(args));
     }
+  });
+
+  it('透传模型分组与目录排序元数据', () => {
+    const metadataProvider = provider('metadata', ['codex'], {
+      codex: [
+        model('metadata-model', {
+          group: 'gpt-budget',
+          mode: 'chat',
+          sortOrder: 7,
+        }),
+      ],
+    });
+    const sections = buildProviderSections({
+      providers: [metadataProvider],
+      agent: 'codex',
+      isVisible: () => true,
+    });
+
+    expect(sections[0]?.models).toEqual([
+      expect.objectContaining({
+        id: 'metadata-model',
+        group: 'gpt-budget',
+        mode: 'chat',
+        sortOrder: 7,
+      }),
+    ]);
   });
 });
 

--- a/packages/model-providers/src/sections.ts
+++ b/packages/model-providers/src/sections.ts
@@ -44,6 +44,9 @@ export interface SectionModel {
   contextWindow: number;
   /** 展示图标 id(AI Gateway / 目录设定,见 CatalogModel.icon);缺省回落来源供应商标。 */
   icon?: string;
+  group?: string;
+  mode?: string;
+  sortOrder?: number;
 }
 
 export interface ProviderSection {
@@ -184,6 +187,9 @@ export function buildProviderSections(args: {
         sm.codexCompatibilityWireProtocol = m.codexCompatibilityWireProtocol;
       }
       if (m.icon !== undefined) sm.icon = m.icon;
+      if (m.group !== undefined) sm.group = m.group;
+      if (m.mode !== undefined) sm.mode = m.mode;
+      if (m.sortOrder !== undefined) sm.sortOrder = m.sortOrder;
       return sm;
     }),
   }));


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复模型选择器在同一来源内按网关原始顺序显示，导致 Codex GPT-5.6 系列被 DeepSeek 等其它模型穿插的问题。

现在保持来源分组顺序不变，但会在每个来源段内按模型类别聚合，并在类别内按目录 `sortOrder` 排列。这样同一来源的同类模型会连续显示，例如 Cindy AI 下的 Codex GPT-5.6 Sol / Terra / Luna。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：模型选择器同来源模型排序
- 本 PR 包含：Desktop `ModelSelector` 的来源段内排序，以及对应回归测试
- 明确不包含：供应商段顺序、模型路由、模型目录数据或移动端列表排序
- 用户可见变化：同一来源的同类模型连续显示，不再被其它类别模型穿插
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：不涉及：仅调整既有模型选择器中已有列表项的展示顺序，不改变布局、样式、交互或文案。

## 怎么验证的

### 自动验证

```text
Node 22.22.3
pnpm test:unit
结果：通过

pnpm --filter desktop typecheck
结果：通过

pnpm --filter desktop exec vitest run src/renderer/__tests__/modelSelectorProviderGroups.test.tsx
结果：12/12 通过
```

### 手工验证

- 不涉及：回归测试覆盖同一来源下 Codex GPT-5.6 Sol / Terra 连续显示，DeepSeek 条目随后显示的排序场景。

### 未执行的验证

- 无。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围：Desktop 模型选择器的按来源分组列表。
- 回滚 / 降级方式：回滚本提交即可恢复目录原始顺序；不影响已保存的模型选择或请求路由。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 DCO）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
