### PR TITLE
fix(desktop): guard pending provider switch routes

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/claudeProxyScopeGate.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/claudeProxyScopeGate.test.ts
@@ -53,7 +53,7 @@ import {
   readClaudeSessionRoute,
   resetClaudeSessionRouteRegistryForTest,
 } from '../claude-session-route-registry';
-import { setProviderOAuthTokenReader } from '../provider-route';
+import { setPendingCredentialSwitchReader, setProviderOAuthTokenReader } from '../provider-route';
 import {
   registerPiProxySession,
   resetPiProxySessionsForTest,
@@ -74,10 +74,33 @@ describe('cc routingTransform — xAI 会话的辅助请求回落默认路由 (i
     setClaudeProxyGatewayKeyReader(() => gatewayKey);
     setClaudeProxySessionIdResolver((sdkId) => (sdkId === 'sdk-grok' ? 'sess-grok' : null));
     setSessionProvider('sess-grok', 'xai');
+    setPendingCredentialSwitchReader(() => undefined);
   });
 
   afterEach(() => {
     clearSessionProvider('sess-grok');
+    setPendingCredentialSwitchReader(() => undefined);
+  });
+
+  it('订阅直连目标也在进入 bridge 前拦截 pending switch', async () => {
+    setPendingCredentialSwitchReader(() => ({
+      model: 'chatgpt/gpt-5.5',
+      providerId: 'openai',
+      previousModel: 'claude-opus-4-8',
+    }));
+    const decision = await Promise.resolve(
+      createModelRoutingTransform()(
+        { model: 'chatgpt/gpt-5.5' },
+        ctxWith({ ...SESSION_HEADER, authorization: 'Bearer sk-ant-oat01' }),
+      ),
+    );
+    const writeHead = vi.fn();
+    const end = vi.fn();
+    await decision?.localHandler?.({ res: { writeHead, end } } as never);
+    expect(writeHead).toHaveBeenCalledWith(503, expect.any(Object));
+    expect(JSON.parse(end.mock.calls[0][0])).toMatchObject({
+      error: { code: 'provider_switch_pending' },
+    });
   });
 
   it('claude-haiku 分类器请求(oauth-spawn)→ 换网关 key,不去 api.x.ai', () => {

--- a/apps/desktop/src/main/maker-host/__tests__/claudeSessionRouteObservation.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/claudeSessionRouteObservation.test.ts
@@ -39,6 +39,7 @@ vi.mock('../claude-fast-mode-log', () => ({
 }));
 vi.mock('../provider-route', () => ({
   // 默认路由会话: 显式供应商解析恒 null; 网关默认决策 = 有 key 才换。
+  resolvePendingSessionRouteDecision: vi.fn(() => null),
   resolveSessionRouteDecision: routeMocks.resolveSessionRouteDecision,
   gatewayDefaultRouteDecision: vi.fn((_agent: string, gatewayKey: string | null) =>
     gatewayKey ? { headerOverride: { 'x-api-key': gatewayKey } } : null),

--- a/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
@@ -212,7 +212,8 @@ describe('withCodexUpstreamRecording', () => {
     const { buildUserProvider } = await import('@cindy/model-providers');
     const { setCustomProviders } = await import('../active-catalog.js');
     const { setCustomProviderKeyReader } = await import('../provider-route.js');
-    const { setSessionProvider, clearSessionProvider } = await import('../session-provider-store.js');
+    const { setSessionProvider, clearSessionProvider } =
+      await import('../session-provider-store.js');
     setCustomProviders([
       buildUserProvider({
         id: 'kimi-moonshot',
@@ -525,6 +526,75 @@ describe('decideCodexRoute', () => {
 });
 
 describe('chatBridgeCapabilitiesForRoute', () => {
+  it('fails closed before a pending target reaches the old custom local bridge', async () => {
+    const host = await freshCodexProxyHost();
+    const { buildUserProvider } = await import('@cindy/model-providers');
+    const { setCustomProviders } = await import('../active-catalog.js');
+    const {
+      setCustomProviderKeyReader,
+      setPendingCredentialSwitchReader,
+    } = await import('../provider-route.js');
+    const { setSessionProvider, clearSessionProvider } = await import('../session-provider-store.js');
+    setCustomProviders([
+      buildUserProvider({
+        id: 'provider-a',
+        name: 'Provider A',
+        runtimes: {
+          codex: {
+            baseUrl: 'https://provider-a.example/v1',
+            wireProtocol: 'openai-chat',
+            models: [{ id: 'shared-model', name: 'Shared Model' }],
+          },
+        },
+      }),
+    ]);
+    const readKey = vi.fn(() => 'provider-a-key');
+    setCustomProviderKeyReader(readKey);
+    setPendingCredentialSwitchReader(() => ({
+      model: 'shared-model',
+      providerId: 'provider-b',
+    }));
+    host.registerComposed('session-pending-bridge', 'thread-pending-bridge', 'PRODUCT_PROMPT');
+    setSessionProvider('session-pending-bridge', 'provider-a');
+    host.setCodexProxyAuthInjection('env-key');
+
+    try {
+      const body = { model: 'shared-model', input: [{ role: 'user', content: 'hello' }] };
+      const ctx = {
+        reqId: 1,
+        method: 'POST',
+        url: '/responses',
+        headers: { 'thread-id': 'thread-pending-bridge' },
+      };
+      const decision = await Promise.resolve(host.createModelRoutingTransform()(body, ctx));
+      expect(decision).toEqual({ localHandler: expect.any(Function) });
+      expect(readKey).not.toHaveBeenCalled();
+      expect(mockState.createResponsesChatHandler).not.toHaveBeenCalled();
+
+      const writeHead = vi.fn();
+      const end = vi.fn();
+      await decision!.localHandler!({
+        rawBody: Buffer.from(JSON.stringify(body)),
+        parsedBody: body,
+        ctx,
+        res: { writeHead, end } as never,
+      });
+      expect(writeHead).toHaveBeenCalledWith(
+        503,
+        expect.objectContaining({ 'retry-after': '1' }),
+      );
+      expect(JSON.parse(end.mock.calls[0][0])).toMatchObject({
+        error: { code: 'provider_switch_pending' },
+      });
+    } finally {
+      host.unregister('session-pending-bridge');
+      clearSessionProvider('session-pending-bridge');
+      setPendingCredentialSwitchReader(() => undefined);
+      setCustomProviderKeyReader(() => null);
+      setCustomProviders([]);
+    }
+  });
+
   it('does not forward unsupported passthrough fields into the translator', async () => {
     const { chatBridgeCapabilitiesForRoute } = await freshCodexProxyHost();
     const capabilities = chatBridgeCapabilitiesForRoute(

--- a/apps/desktop/src/main/maker-host/__tests__/providerRoute.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/providerRoute.test.ts
@@ -840,6 +840,25 @@ describe('resolveSessionRouteDecision — 自定义供应商(resolve 时注入 k
     });
   });
 
+  it('implicit 旧路由也拦截 pending 目标，但允许同模型旧 turn 收尾', () => {
+    clearSessionProvider('s-user');
+    setPendingCredentialSwitchReader(() => ({
+      model: 'new-model',
+      providerId: 'provider-b',
+      previousModel: 'old-model',
+    }));
+    expect(resolveSessionRouteDecision('s-user', 'codex', KEY, 'new-model')).toEqual({
+      localHandler: expect.any(Function),
+    });
+
+    setPendingCredentialSwitchReader(() => ({
+      model: 'shared-model',
+      providerId: 'provider-b',
+      previousModel: 'shared-model',
+    }));
+    expect(resolveSessionRouteDecision('s-user', 'codex', KEY, 'shared-model')).toBeNull();
+  });
+
   it('同供应商 pending 与无 model 的控制面请求不受影响', () => {
     setCustomProviders([
       buildUserProvider({

--- a/apps/desktop/src/main/maker-host/__tests__/providerRoute.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/providerRoute.test.ts
@@ -826,6 +826,14 @@ describe('resolveSessionRouteDecision — 自定义供应商(resolve 时注入 k
     expect(resolveSessionRouteDecision('s-user', 'claude-code', KEY, 'old-model')).toMatchObject({
       upstreamOverride: 'https://provider-a.example/v1',
     });
+    setPendingCredentialSwitchReader(() => ({
+      model: 'old-model',
+      providerId: 'provider-b',
+      previousModel: 'old-model',
+    }));
+    expect(resolveSessionRouteDecision('s-user', 'claude-code', KEY, 'old-model')).toMatchObject({
+      upstreamOverride: 'https://provider-a.example/v1',
+    });
     setPendingCredentialSwitchReader(() => undefined);
     expect(resolveSessionRouteDecision('s-user', 'claude-code', KEY, 'unknown-model')).toMatchObject({
       upstreamOverride: 'https://provider-a.example/v1',

--- a/apps/desktop/src/main/maker-host/__tests__/providerRoute.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/providerRoute.test.ts
@@ -859,7 +859,7 @@ describe('resolveSessionRouteDecision — 自定义供应商(resolve 时注入 k
     expect(resolveSessionRouteDecision('s-user', 'codex', KEY, 'shared-model')).toBeNull();
   });
 
-  it('同供应商 pending 与无 model 的控制面请求不受影响', () => {
+  it('同供应商 pending 也拦目标模型，但无 model 的控制面请求不受影响', () => {
     setCustomProviders([
       buildUserProvider({
         id: 'provider-a',
@@ -876,13 +876,24 @@ describe('resolveSessionRouteDecision — 自定义供应商(resolve 时注入 k
     setSessionProvider('s-user', 'provider-a');
     setPendingCredentialSwitchReader(() => ({ model: 'new-model', providerId: 'provider-a' }));
 
-    expect(resolveSessionRouteDecision('s-user', 'claude-code', KEY, 'new-model')).toMatchObject({
-      upstreamOverride: 'https://provider-a.example/v1',
+    expect(resolveSessionRouteDecision('s-user', 'claude-code', KEY, 'new-model')).toEqual({
+      localHandler: expect.any(Function),
     });
     setPendingCredentialSwitchReader(() => ({ model: 'new-model', providerId: 'provider-b' }));
     expect(resolveSessionRouteDecision('s-user', 'claude-code', KEY)).toMatchObject({
       upstreamOverride: 'https://provider-a.example/v1',
     });
+
+    clearSessionProvider('s-user');
+    setPendingCredentialSwitchReader(() => ({
+      model: 'codex/gpt-5.5',
+      providerId: null,
+      previousModel: 'gpt-5.5',
+    }));
+    expect(resolveSessionRouteDecision('s-user', 'codex', KEY, 'codex/gpt-5.5')).toEqual({
+      localHandler: expect.any(Function),
+    });
+    expect(resolveSessionRouteDecision('s-user', 'codex', KEY, 'gpt-5.5')).toBeNull();
   });
 
   it('blocks new routes while endpoint and key switch as one logical mutation', async () => {

--- a/apps/desktop/src/main/maker-host/__tests__/providerRoute.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/providerRoute.test.ts
@@ -27,6 +27,7 @@ import {
   inferProviderIdForModel,
   isUserProviderSession,
   setCustomProviderKeyReader,
+  setPendingCredentialSwitchReader,
   setProviderOAuthTokenReader,
   setProviderViewsReader,
   resolveImplicitProviderOAuthRouteDecision,
@@ -71,6 +72,7 @@ const CODEX_ACCOUNT_HEADER_DELETE = [
 afterEach(() => {
   mockGetAppCapabilities.mockReturnValue({ canUseCindyGateway: true });
   setProviderOAuthTokenReader(() => null);
+  setPendingCredentialSwitchReader(() => undefined);
   clearSessionProvider('s-xai');
   clearSessionProvider('s-xai-rewrite');
   clearSessionProvider('s-anthropic-codex');
@@ -423,6 +425,18 @@ describe('resolveSessionRouteDecision — modelPrefixes 服务范围门(issue #8
     )).resolves.toEqual(expect.objectContaining({ upstreamOverride: 'https://api.x.ai/v1' }));
   });
 
+  it('pending 目标在旧 Provider scope 外时仍先 fail closed', () => {
+    setSessionProvider('s-scope', 'xai');
+    setPendingCredentialSwitchReader(() => ({
+      model: 'gpt-5.6-sol',
+      providerId: 'openai',
+    }));
+
+    expect(resolveSessionRouteDecision('s-scope', 'codex', KEY, 'gpt-5.6-sol')).toEqual({
+      localHandler: expect.any(Function),
+    });
+  });
+
   it('未声明 modelPrefixes 的供应商(XD/Anthropic/自定义)不受门限制 —— no-break', () => {
     setSessionProvider('s-scope', 'xd');
     expect(resolveSessionRouteDecision('s-scope', 'claude-code', KEY, 'claude-haiku-4-5-20251001')).toEqual({
@@ -718,6 +732,129 @@ describe('resolveSessionRouteDecision — 自定义供应商(resolve 时注入 k
       headerOverride: { authorization: 'Bearer sk-or-123' },
       upstreamOverride: 'https://openrouter.ai/api/v1',
       headerDelete: CODEX_ACCOUNT_HEADER_DELETE,
+    });
+  });
+
+  it('跨供应商切换 pending 时不把目标模型发给旧供应商', async () => {
+    setCustomProviders([
+      buildUserProvider({
+        id: 'provider-a',
+        name: 'Provider A',
+        runtimes: {
+          'claude-code': {
+            baseUrl: 'https://provider-a.example/v1',
+            models: [{ id: 'deepseek-v4-flash', name: 'DeepSeek V4 Flash' }],
+          },
+        },
+      }),
+      buildUserProvider({
+        id: 'provider-b',
+        name: 'Provider B',
+        runtimes: {
+          'claude-code': {
+            baseUrl: 'https://provider-b.example/v1',
+            models: [{ id: 'anthropic/gpt-5.6-sol', name: 'GPT 5.6 Sol' }],
+          },
+        },
+      }),
+    ]);
+    const readKey = vi.fn(() => 'custom-key');
+    setCustomProviderKeyReader(readKey);
+    setSessionProvider('s-user', 'provider-a');
+    setPendingCredentialSwitchReader((sessionId) =>
+      sessionId === 's-user'
+        ? { model: 'anthropic/gpt-5.6-sol', providerId: 'provider-b' }
+        : undefined,
+    );
+
+    const decision = await Promise.resolve(
+      resolveSessionRouteDecision('s-user', 'claude-code', KEY, 'anthropic/gpt-5.6-sol'),
+    );
+    expect(decision).toEqual({ localHandler: expect.any(Function) });
+    expect(
+      resolveSessionRouteDecision('s-user', 'claude-code', KEY, 'anthropic/gpt-5.6-sol[1m]'),
+    ).toEqual({ localHandler: expect.any(Function) });
+    expect(readKey).not.toHaveBeenCalled();
+
+    const writeHead = vi.fn();
+    const end = vi.fn();
+    await decision!.localHandler!({
+      rawBody: Buffer.from('{}'),
+      parsedBody: { model: 'anthropic/gpt-5.6-sol' },
+      ctx: { reqId: 1, method: 'POST', url: '/v1/messages', headers: {} },
+      res: { writeHead, end } as never,
+    });
+    expect(writeHead).toHaveBeenCalledWith(503, {
+      'content-type': 'application/json; charset=utf-8',
+      'cache-control': 'no-store',
+      'retry-after': '1',
+    });
+    expect(JSON.parse(end.mock.calls[0][0])).toMatchObject({
+      error: {
+        type: 'provider_switch_pending',
+        code: 'provider_switch_pending',
+      },
+    });
+
+    setPendingCredentialSwitchReader(() => ({
+      model: 'deepseek-v4-flash',
+      providerId: 'provider-b',
+    }));
+    expect(
+      resolveSessionRouteDecision('s-user', 'claude-code', KEY, 'deepseek-v4-flash'),
+    ).toEqual({ localHandler: expect.any(Function) });
+    expect(readKey).not.toHaveBeenCalled();
+  });
+
+  it('pending 只拦目标模型，保留旧 turn 与自定义供应商 universal 路由', () => {
+    setCustomProviders([
+      buildUserProvider({
+        id: 'provider-a',
+        name: 'Provider A',
+        runtimes: {
+          'claude-code': {
+            baseUrl: 'https://provider-a.example/v1',
+            models: [{ id: 'old-model', name: 'Old Model' }],
+          },
+        },
+      }),
+    ]);
+    setCustomProviderKeyReader(() => 'custom-key');
+    setSessionProvider('s-user', 'provider-a');
+    setPendingCredentialSwitchReader(() => ({ model: 'new-model', providerId: 'provider-b' }));
+
+    expect(resolveSessionRouteDecision('s-user', 'claude-code', KEY, 'old-model')).toMatchObject({
+      upstreamOverride: 'https://provider-a.example/v1',
+    });
+    setPendingCredentialSwitchReader(() => undefined);
+    expect(resolveSessionRouteDecision('s-user', 'claude-code', KEY, 'unknown-model')).toMatchObject({
+      upstreamOverride: 'https://provider-a.example/v1',
+    });
+  });
+
+  it('同供应商 pending 与无 model 的控制面请求不受影响', () => {
+    setCustomProviders([
+      buildUserProvider({
+        id: 'provider-a',
+        name: 'Provider A',
+        runtimes: {
+          'claude-code': {
+            baseUrl: 'https://provider-a.example/v1',
+            models: [{ id: 'new-model', name: 'New Model' }],
+          },
+        },
+      }),
+    ]);
+    setCustomProviderKeyReader(() => 'custom-key');
+    setSessionProvider('s-user', 'provider-a');
+    setPendingCredentialSwitchReader(() => ({ model: 'new-model', providerId: 'provider-a' }));
+
+    expect(resolveSessionRouteDecision('s-user', 'claude-code', KEY, 'new-model')).toMatchObject({
+      upstreamOverride: 'https://provider-a.example/v1',
+    });
+    setPendingCredentialSwitchReader(() => ({ model: 'new-model', providerId: 'provider-b' }));
+    expect(resolveSessionRouteDecision('s-user', 'claude-code', KEY)).toMatchObject({
+      upstreamOverride: 'https://provider-a.example/v1',
     });
   });
 

--- a/apps/desktop/src/main/maker-host/anthropic-compat-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/anthropic-compat-proxy-host.ts
@@ -59,6 +59,7 @@ import { getSessionProvider } from './session-provider-store.js';
 import {
   gatewayDefaultRouteDecision,
   getUserProviderIdForSession,
+  resolvePendingSessionRouteDecision,
   resolveSessionRouteDecision,
 } from './provider-route.js';
 import { createProviderUpstreamErrorObserver } from './provider-upstream-error-observer.js';
@@ -206,6 +207,10 @@ export function createModelRoutingTransform(): RoutingTransform {
     if (ccSessionId) noteClaudeSessionRequest(ccSessionId, ctx.reqId);
     if (!isPlainObject(body)) return null;
     const wireModel = typeof body.model === 'string' ? body.model : '';
+    const pendingRoute = sessionId
+      ? resolvePendingSessionRouteDecision(sessionId, wireModel || undefined)
+      : null;
+    if (pendingRoute) return pendingRoute;
 
     // ⓪ 订阅直连翻译:model 带 `chatgpt/` / `xai/` 前缀 → 交给本地 responses handler
     //    (localHandler 插槽,进程内直调,不多一跳;它把 Anthropic Messages ↔ OpenAI Responses

--- a/apps/desktop/src/main/maker-host/codex-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/codex-proxy-host.ts
@@ -48,6 +48,7 @@ import {
   getSessionRoutingDescriptor,
   resolveSessionRoute,
   resolveSessionRouteDecision,
+  resolvePendingSessionRouteDecision,
   buildLocalHandlerHeaders,
   inferProviderIdForModel,
   isHostInjectedAuthSession,
@@ -2165,6 +2166,10 @@ export function createModelRoutingTransform(
       return unresolvedCollabSpawnRouteDecision();
     }
     const explicitProviderId = sessionId ? getSessionProvider(sessionId) : null;
+    const pendingRoute = sessionId
+      ? resolvePendingSessionRouteDecision(sessionId, model || undefined)
+      : null;
+    if (pendingRoute) return pendingRoute;
     const selectedRouting = sessionId
       ? getSessionRoutingDescriptor(sessionId, 'codex', model || undefined)
       : null;

--- a/apps/desktop/src/main/maker-host/provider-route.ts
+++ b/apps/desktop/src/main/maker-host/provider-route.ts
@@ -245,7 +245,6 @@ export function resolvePendingSessionRouteDecision(
   const pendingSwitch = pendingCredentialSwitchReader(sessionId);
   return wireModel &&
     pendingSwitch &&
-    pendingSwitch.providerId !== providerId &&
     samePendingSwitchModel(pendingSwitch.model, wireModel) &&
     (!pendingSwitch.previousModel ||
       !samePendingSwitchModel(pendingSwitch.previousModel, wireModel))

--- a/apps/desktop/src/main/maker-host/provider-route.ts
+++ b/apps/desktop/src/main/maker-host/provider-route.ts
@@ -155,7 +155,7 @@ const PENDING_PROVIDER_SWITCH_ERROR = 'provider_switch_pending';
 
 type PendingCredentialSwitchReader = (
   sessionId: string,
-) => { model: string; providerId: string | null } | undefined;
+) => { model: string; providerId: string | null; previousModel?: string } | undefined;
 let pendingCredentialSwitchReader: PendingCredentialSwitchReader = () => undefined;
 
 /** Main wires the pending switch service into this synchronous routing boundary. */
@@ -246,7 +246,9 @@ export function resolvePendingSessionRouteDecision(
     wireModel &&
     pendingSwitch &&
     pendingSwitch.providerId !== providerId &&
-    samePendingSwitchModel(pendingSwitch.model, wireModel)
+    samePendingSwitchModel(pendingSwitch.model, wireModel) &&
+    (!pendingSwitch.previousModel ||
+      !samePendingSwitchModel(pendingSwitch.previousModel, wireModel))
     ? pendingProviderSwitchRouteDecision(providerId)
     : null;
 }

--- a/apps/desktop/src/main/maker-host/provider-route.ts
+++ b/apps/desktop/src/main/maker-host/provider-route.ts
@@ -209,15 +209,16 @@ function updatingProviderRouteDecision(providerId: string): RoutingDecision {
   };
 }
 
-function pendingProviderSwitchRouteDecision(providerId: string): RoutingDecision {
+function pendingProviderSwitchRouteDecision(providerId: string | null): RoutingDecision {
   return {
     localHandler: async ({ res }) => {
+      const source = providerId ? `Provider '${providerId}'` : 'The default Provider route';
       const payload = JSON.stringify({
         type: 'error',
         error: {
           type: PENDING_PROVIDER_SWITCH_ERROR,
           code: PENDING_PROVIDER_SWITCH_ERROR,
-          message: `Provider switch from '${providerId}' is pending; retry after the current turn completes.`,
+          message: `${source} has a pending Provider switch; retry after the current turn completes.`,
         },
       });
       res.writeHead(503, {
@@ -242,8 +243,7 @@ export function resolvePendingSessionRouteDecision(
 ): RoutingDecision | null {
   const providerId = getSessionProvider(sessionId);
   const pendingSwitch = pendingCredentialSwitchReader(sessionId);
-  return providerId &&
-    wireModel &&
+  return wireModel &&
     pendingSwitch &&
     pendingSwitch.providerId !== providerId &&
     samePendingSwitchModel(pendingSwitch.model, wireModel) &&
@@ -670,7 +670,8 @@ export function resolveSessionRouteDecision(
   wireModel?: string,
 ): RoutingDecision | null | Promise<RoutingDecision | null> {
   const providerId = getSessionProvider(sessionId);
-  if (!providerId) return null;
+  const pendingDecision = resolvePendingSessionRouteDecision(sessionId, wireModel);
+  if (!providerId) return pendingDecision;
   if (isProviderRouteMutationInProgress(providerId)) {
     return updatingProviderRouteDecision(providerId);
   }
@@ -679,7 +680,6 @@ export function resolveSessionRouteDecision(
   const routing = provider ? providerRoutingForModel(provider, agent, wireModel) : null;
   if (!routing) return null;
   if (routing.disabled) return disabledProviderRouteDecision(providerId);
-  const pendingDecision = resolvePendingSessionRouteDecision(sessionId, wireModel);
   if (pendingDecision) return pendingDecision;
   if (!routingServesWireModel(routing, wireModel)) return null;
   // 自定义供应商：resolve 时按 provider_key_<id>_<agent> 读出该 runtime 的 API key 注入鉴权头（不在 catalog）。

--- a/apps/desktop/src/main/maker-host/provider-route.ts
+++ b/apps/desktop/src/main/maker-host/provider-route.ts
@@ -151,6 +151,17 @@ const CLIENT_AUTH_HEADERS = ['authorization', 'x-api-key'];
 const MISSING_CUSTOM_PROVIDER_API_KEY = 'cindy-missing-custom-provider-api-key';
 const DISABLED_PROVIDER_ROUTE_ERROR = 'provider_route_disabled';
 const UPDATING_PROVIDER_ROUTE_ERROR = 'provider_route_updating';
+const PENDING_PROVIDER_SWITCH_ERROR = 'provider_switch_pending';
+
+type PendingCredentialSwitchReader = (
+  sessionId: string,
+) => { model: string; providerId: string | null } | undefined;
+let pendingCredentialSwitchReader: PendingCredentialSwitchReader = () => undefined;
+
+/** Main wires the pending switch service into this synchronous routing boundary. */
+export function setPendingCredentialSwitchReader(reader: PendingCredentialSwitchReader): void {
+  pendingCredentialSwitchReader = reader;
+}
 
 /**
  * 已迁移但无法安全执行的历史路由必须由 proxy 原地拒绝，不能返回 null：
@@ -196,6 +207,48 @@ function updatingProviderRouteDecision(providerId: string): RoutingDecision {
       res.end(payload);
     },
   };
+}
+
+function pendingProviderSwitchRouteDecision(providerId: string): RoutingDecision {
+  return {
+    localHandler: async ({ res }) => {
+      const payload = JSON.stringify({
+        type: 'error',
+        error: {
+          type: PENDING_PROVIDER_SWITCH_ERROR,
+          code: PENDING_PROVIDER_SWITCH_ERROR,
+          message: `Provider switch from '${providerId}' is pending; retry after the current turn completes.`,
+        },
+      });
+      res.writeHead(503, {
+        'content-type': 'application/json; charset=utf-8',
+        'cache-control': 'no-store',
+        'retry-after': '1',
+      });
+      res.end(payload);
+    },
+  };
+}
+
+function samePendingSwitchModel(left: string, right: string): boolean {
+  const leftBare = left.endsWith('[1m]') ? left.slice(0, -'[1m]'.length) : left;
+  const rightBare = right.endsWith('[1m]') ? right.slice(0, -'[1m]'.length) : right;
+  return leftBare === rightBare;
+}
+
+export function resolvePendingSessionRouteDecision(
+  sessionId: string,
+  wireModel: string | undefined,
+): RoutingDecision | null {
+  const providerId = getSessionProvider(sessionId);
+  const pendingSwitch = pendingCredentialSwitchReader(sessionId);
+  return providerId &&
+    wireModel &&
+    pendingSwitch &&
+    pendingSwitch.providerId !== providerId &&
+    samePendingSwitchModel(pendingSwitch.model, wireModel)
+    ? pendingProviderSwitchRouteDecision(providerId)
+    : null;
 }
 
 function withoutClientAuthHeaders(
@@ -624,6 +677,8 @@ export function resolveSessionRouteDecision(
   const routing = provider ? providerRoutingForModel(provider, agent, wireModel) : null;
   if (!routing) return null;
   if (routing.disabled) return disabledProviderRouteDecision(providerId);
+  const pendingDecision = resolvePendingSessionRouteDecision(sessionId, wireModel);
+  if (pendingDecision) return pendingDecision;
   if (!routingServesWireModel(routing, wireModel)) return null;
   // 自定义供应商：resolve 时按 provider_key_<id>_<agent> 读出该 runtime 的 API key 注入鉴权头（不在 catalog）。
   const apiKey = provider?.source === 'user' ? customProviderKeyReader(providerId, agent) : null;

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -680,7 +680,11 @@ import {
 import { getActiveCatalog, setDiscoveredProviderModels } from '../maker-host/active-catalog.js';
 import { testProviderConnection } from '../maker-host/provider-diagnostics.js';
 import { fetchProviderModels } from '../maker-host/provider-model-fetch.js';
-import { beginProviderRouteMutation, isUserProviderSession } from '../maker-host/provider-route.js';
+import {
+  beginProviderRouteMutation,
+  isUserProviderSession,
+  setPendingCredentialSwitchReader,
+} from '../maker-host/provider-route.js';
 import {
   getAnthropicModelDiscoveryFailure,
   refreshAnthropicModelsFromHttp,
@@ -11150,6 +11154,10 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
     logger: log,
   });
   pendingCredentialSwitchHolder = pendingCredentialSwitchService;
+  setPendingCredentialSwitchReader((sessionId) => {
+    const pending = pendingCredentialSwitchService.get(sessionId);
+    return pending ? { model: pending.model, providerId: pending.providerId } : undefined;
+  });
 
   // Memory 设置变更撞上 Codex busy 时的延迟软重启登记(见 deferredCodexRestart.ts)。
   // 与 pendingCredentialSwitchService 共用 turn 结束 / 会话关闭边界接线;pending

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -11156,7 +11156,15 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
   pendingCredentialSwitchHolder = pendingCredentialSwitchService;
   setPendingCredentialSwitchReader((sessionId) => {
     const pending = pendingCredentialSwitchService.get(sessionId);
-    return pending ? { model: pending.model, providerId: pending.providerId } : undefined;
+    return pending
+      ? {
+          model: pending.model,
+          providerId: pending.providerId,
+          ...(pending.previousRoute?.model
+            ? { previousModel: pending.previousRoute.model }
+            : {}),
+        }
+      : undefined;
   });
 
   // Memory 设置变更撞上 Codex busy 时的延迟软重启登记(见 deferredCodexRestart.ts)。


### PR DESCRIPTION
## 这次改了什么

### 摘要

Fail closed when a request targets a Provider switch that has not finished applying. The request is rejected locally before Cindy reads the old Provider key or selects its endpoint.

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Fixes #2575
- 本 PR 包含：Expose the existing pending credential-switch target to transparent and local-bridge route boundaries; return a structured 503 before model-scope fallback or old Provider credential reads.
- 明确不包含：Global custom-Provider model ownership checks or changes to the existing universal routing contract.
- 用户可见变化：A request that races a pending Provider switch fails locally with `provider_switch_pending` and can be retried after the current turn completes.
- 是否存在 breaking change：No.

### Remote and mobile adaptation

- SSH remote workspaces: Not affected.
- Device link: No channel or protocol change.
- Mobile: Not affected.

### UI 变化

Not involved. No Renderer or visual behavior changed.

- 引用的设计规范：Not involved.

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/maker-host/__tests__/providerRoute.test.ts src/main/maker-host/__tests__/codexProxyHost.test.ts src/main/maker-host/__tests__/claudeProxyScopeGate.test.ts src/main/maker-host/__tests__/claudeSessionRouteObservation.test.ts
Result: 4 files, 215 tests passed.

NODE_OPTIONS=--max-old-space-size=6144 pnpm --filter desktop run --if-present typecheck
Result: passed.

pnpm test:unit
Result: all configured workspaces passed.

pnpm check:dco
Result: passed.
```

### 手工验证

Not run.

### 未执行的验证

Live two-Provider proxy validation was not run. The route, credential-read, overlapping-model-ID, control-plane, and current-turn cases are covered deterministically.

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Session proxy requests whose model matches a pending target that differs from the in-flight model.
- 回滚 / 降级方式：Revert the commit. No migration or data cleanup is required.

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
