### PR TITLE
fix(desktop): 避免重开 Worker 时重复加载历史

### DIFF
--- a/apps/desktop/src/renderer/__tests__/makerChatStoreActiveView.test.ts
+++ b/apps/desktop/src/renderer/__tests__/makerChatStoreActiveView.test.ts
@@ -47,6 +47,10 @@ vi.mock('@/lib/composerDraftStore', () => ({
 
 import { makerChatStore } from '@/lib/makerChatStore';
 import * as messageService from '@/lib/messageService';
+import {
+  markSessionAutomaticHistoryLoadCompleted,
+  restoreSessionAutomaticHistoryLoadAttempts,
+} from '@/lib/sessionScrollStore';
 
 const BASE_TIME = new Date('2026-05-20T00:00:00.000Z');
 
@@ -970,10 +974,11 @@ describe('makerChatStore active view tracking', () => {
         .mockResolvedValueOnce(fullPage(sessionId, 999))
         .mockRejectedValueOnce(new Error('tunnel dropped'));
 
-      makerChatStore.loadOlderMessages(sessionId);
-      await flushPagingLoop();
+      const didAdvanceWindow = await makerChatStore.loadOlderMessages(sessionId, true);
 
       const snapshot = makerChatStore.getSnapshot(sessionId);
+      expect(didAdvanceWindow).toBe(true);
+      expect(restoreSessionAutomaticHistoryLoadAttempts(sessionId, 5)).toBe(5);
       expect(snapshot.isLoadingMore).toBe(false);
       // 第 1 页已进 UI(游标推进、内容不丢),失败只终止追页,保持可重试。
       expect(snapshot.hasMoreMessages).toBe(true);
@@ -988,13 +993,27 @@ describe('makerChatStore active view tracking', () => {
 
       vi.mocked(messageService.list).mockRejectedValueOnce(new Error('tunnel dropped'));
 
-      makerChatStore.loadOlderMessages(sessionId);
-      await flushPagingLoop();
+      const didAdvanceWindow = await makerChatStore.loadOlderMessages(sessionId, true);
 
       const snapshot = makerChatStore.getSnapshot(sessionId);
+      expect(didAdvanceWindow).toBe(false);
+      expect(restoreSessionAutomaticHistoryLoadAttempts(sessionId, 5)).toBe(0);
       expect(snapshot.isLoadingMore).toBe(false);
       expect(snapshot.hasMoreMessages).toBe(true);
       expect(snapshot.oldestMessageId).toBe('current');
+    });
+
+    it('reports an empty authoritative page as no cached-window advance', async () => {
+      const sessionId = sid('older-backfill-empty');
+      await seedSession(sessionId);
+
+      vi.mocked(messageService.list).mockResolvedValueOnce([]);
+
+      const didAdvanceWindow = await makerChatStore.loadOlderMessages(sessionId, true);
+
+      expect(didAdvanceWindow).toBe(false);
+      expect(makerChatStore.getSnapshot(sessionId).hasMoreMessages).toBe(false);
+      expect(restoreSessionAutomaticHistoryLoadAttempts(sessionId, 5)).toBe(0);
     });
 
     // rewind 竞态守卫:追页 in-flight 期间 reloadMessages(rewind commit 后的强制
@@ -1035,17 +1054,20 @@ describe('makerChatStore active view tracking', () => {
         .mockReturnValueOnce(olderPagePromise) // loadOlderMessages 第 1 页(挂起中)
         .mockResolvedValueOnce([]); // reloadMessages → ensureInitialMessages(重载后空历史)
 
-      makerChatStore.loadOlderMessages(sessionId);
+      markSessionAutomaticHistoryLoadCompleted(sessionId);
+      const loadResult = makerChatStore.loadOlderMessages(sessionId, true);
       expect(makerChatStore.getSnapshot(sessionId).isLoadingMore).toBe(true);
 
       makerChatStore.reloadMessages(sessionId);
       await Promise.resolve();
+      expect(restoreSessionAutomaticHistoryLoadAttempts(sessionId, 5)).toBe(0);
 
       // 翻页此刻才返回(短页 → 循环立即收口进入提交),但代际已变 → 作废。
       resolveOlderPage(fullPage(sessionId, 999).slice(0, 10));
       await flushPagingLoop();
 
       const snapshot = makerChatStore.getSnapshot(sessionId);
+      await expect(loadResult).resolves.toBe(false);
       expect(snapshot.isLoadingMore).toBe(false);
       expect(snapshot.messages).toHaveLength(0); // 旧窗口没有被 merge 回清空后的切片
       expect(snapshot.oldestMessageId).toBeNull();
@@ -1102,7 +1124,9 @@ describe('makerChatStore active view tracking', () => {
     const sessionId = sid('demote');
     const dispose = enter(sessionId);
     addMessage(sessionId);
+    markSessionAutomaticHistoryLoadCompleted(sessionId);
     expect(makerChatStore.getSnapshot(sessionId).messages).toHaveLength(1);
+    expect(restoreSessionAutomaticHistoryLoadAttempts(sessionId, 5)).toBe(5);
 
     dispose(); // 写 lastViewedAt = BASE_TIME
     // 4:59 仍保留，5:00 的 demote timer 才清空（检查间隔 30s）。
@@ -1113,6 +1137,7 @@ describe('makerChatStore active view tracking', () => {
 
     expect(makerChatStore.getSnapshot(sessionId).messages).toHaveLength(0);
     expect(makerChatStore.getSnapshot(sessionId).historyLoaded).toBe(false);
+    expect(restoreSessionAutomaticHistoryLoadAttempts(sessionId, 5)).toBe(0);
   });
 
   it('demotes a prefetched session that never enters a mounted view', async () => {

--- a/apps/desktop/src/renderer/__tests__/makerChatStoreActiveView.test.ts
+++ b/apps/desktop/src/renderer/__tests__/makerChatStoreActiveView.test.ts
@@ -1077,6 +1077,7 @@ describe('makerChatStore active view tracking', () => {
     it('keeps legacy single-row removal compatible with an in-flight paging window', async () => {
       const sessionId = sid('older-backfill-single-delete-compat');
       await seedSession(sessionId);
+      markSessionAutomaticHistoryLoadCompleted(sessionId);
 
       let resolveOlderPage!: (rows: Message[]) => void;
       vi.mocked(messageService.list).mockReturnValueOnce(
@@ -1094,11 +1095,13 @@ describe('makerChatStore active view tracking', () => {
       expect(snapshot.messages).toHaveLength(10);
       expect(snapshot.messages.some((message) => message.clientId === 'client-current')).toBe(false);
       expect(snapshot.isLoadingMore).toBe(false);
+      expect(restoreSessionAutomaticHistoryLoadAttempts(sessionId, 5)).toBe(5);
     });
 
     it('discards an in-flight paging window after grouped deletion', async () => {
       const sessionId = sid('older-backfill-group-delete-race');
       await seedSession(sessionId);
+      markSessionAutomaticHistoryLoadCompleted(sessionId);
 
       let resolveOlderPage!: (rows: Message[]) => void;
       vi.mocked(messageService.list).mockReturnValueOnce(
@@ -1115,6 +1118,7 @@ describe('makerChatStore active view tracking', () => {
       const snapshot = makerChatStore.getSnapshot(sessionId);
       expect(snapshot.messages).toHaveLength(0);
       expect(snapshot.isLoadingMore).toBe(false);
+      expect(restoreSessionAutomaticHistoryLoadAttempts(sessionId, 5)).toBe(0);
     });
   });
 

--- a/apps/desktop/src/renderer/__tests__/makerChatStoreJumpBackfill.test.ts
+++ b/apps/desktop/src/renderer/__tests__/makerChatStoreJumpBackfill.test.ts
@@ -72,6 +72,10 @@ vi.mock('@/lib/composerDraftStore', () => ({
 
 import { makerChatStore } from '@/lib/makerChatStore';
 import { aroundMessagesByClientIdFor, listMessagesFor } from '@/lib/makerTransport';
+import {
+  markSessionAutomaticHistoryLoadCompleted,
+  restoreSessionAutomaticHistoryLoadAttempts,
+} from '@/lib/sessionScrollStore';
 import type { Message } from '@/lib/ccAgent.types';
 
 const SID = 'sess-jump-backfill';
@@ -1331,6 +1335,7 @@ describe('跳转补齐 — 窗口连续,不留历史空洞', () => {
     await makerChatStore.loadAroundMessageClientId(SID, 'island-trim', { radius: 60 });
     expect(makerChatStore.getSnapshot(SID).historyWindowHasIsland).toBe(true);
     expect(makerChatStore.getSnapshot(SID).messages.length).toBeGreaterThan(300);
+    markSessionAutomaticHistoryLoadCompleted(SID);
 
     // 离开视图 → 触发 _trimMessagesIfNeeded。
     const leave = makerChatStore.enterView(SID);
@@ -1339,6 +1344,8 @@ describe('跳转补齐 — 窗口连续,不留历史空洞', () => {
     expect(makerChatStore.getSnapshot(SID).messages).toHaveLength(200);
     // 关键:裁剪不清标记 —— 保留的 200 行未必连续。
     expect(makerChatStore.getSnapshot(SID).historyWindowHasIsland).toBe(true);
+    // 普通裁剪正是原问题的重挂载场景:消息窗口仍属同一代,自动补载预算必须保持耗尽。
+    expect(restoreSessionAutomaticHistoryLoadAttempts(SID, 5)).toBe(5);
   });
 
   it('Y2. 超长裁剪丢掉当前计划边界时,允许重入重新首拉补回计划', async () => {

--- a/apps/desktop/src/renderer/__tests__/makerChatStoreJumpBackfill.test.ts
+++ b/apps/desktop/src/renderer/__tests__/makerChatStoreJumpBackfill.test.ts
@@ -355,6 +355,7 @@ describe('跳转补齐 — 窗口连续,不留历史空洞', () => {
       createdAt: '2026-07-20T00:00:00.000Z',
     });
     vi.mocked(aroundMessagesByClientIdFor).mockResolvedValueOnce([target]);
+    markSessionAutomaticHistoryLoadCompleted(SID);
     vi.mocked(listMessagesFor).mockImplementationOnce(async () => {
       const page = fullPageNewestFirst();
       // 补齐 await 期间发生 edit-last 截断。
@@ -367,6 +368,7 @@ describe('跳转补齐 — 窗口连续,不留历史空洞', () => {
     // 跳转整体作废：不返回目标，也不把 around 行 merge 回窗口。
     expect(result).toBeNull();
     expect(makerChatStore.getSnapshot(SID).messages.map((m) => m.clientId)).not.toContain('rewound');
+    expect(restoreSessionAutomaticHistoryLoadAttempts(SID, 5)).toBe(0);
   });
 
   it('J. 纯文本会话在预算内停手,不会无限翻到几千行', async () => {

--- a/apps/desktop/src/renderer/__tests__/reconcileRemoteMessages.test.ts
+++ b/apps/desktop/src/renderer/__tests__/reconcileRemoteMessages.test.ts
@@ -30,6 +30,10 @@ vi.mock('@/lib/sessionService', () => ({
 
 import { makerChatStore } from '@/lib/makerChatStore';
 import { remoteProjectsStore } from '@/features/device-link/remoteProjectsStore';
+import {
+  markSessionAutomaticHistoryLoadCompleted,
+  restoreSessionAutomaticHistoryLoadAttempts,
+} from '@/lib/sessionScrollStore';
 
 const DEVICE_ID = 'dev-A';
 const DEVICE_B_ID = 'dev-B';
@@ -509,6 +513,7 @@ describe('makerChatStore.reconcileRemoteMessages', () => {
       dbMessage(s, 'old-cache', 'old cached text', '2026-06-15T00:00:00.000Z'),
       dbMessage(s, 'cached-future', 'controller clock ahead text', '2026-06-16T00:00:00.000Z'),
     ]);
+    markSessionAutomaticHistoryLoadCompleted(s);
 
     const remoteHistory = Array.from({ length: 550 }, (_, index) =>
       dbMessage(
@@ -531,6 +536,7 @@ describe('makerChatStore.reconcileRemoteMessages', () => {
     expect(snapshot.messages.at(-1)?.clientId).toBe('client-new-549');
     expect(snapshot.oldestMessageId).toBe('new-50');
     expect(snapshot.hasMoreMessages).toBe(true);
+    expect(restoreSessionAutomaticHistoryLoadAttempts(s, 5)).toBe(0);
   });
 
   it('远程会话:无重叠对账保留分页期间新到的 remote push', async () => {

--- a/apps/desktop/src/renderer/__tests__/reconcileRemoteMessages.test.ts
+++ b/apps/desktop/src/renderer/__tests__/reconcileRemoteMessages.test.ts
@@ -514,6 +514,14 @@ describe('makerChatStore.reconcileRemoteMessages', () => {
       dbMessage(s, 'cached-future', 'controller clock ahead text', '2026-06-16T00:00:00.000Z'),
     ]);
     markSessionAutomaticHistoryLoadCompleted(s);
+    const completionAttemptsAtRebuildNotification: number[] = [];
+    const unsubscribe = makerChatStore.subscribe(s, () => {
+      if (makerChatStore.getSnapshot(s).messages[0]?.clientId === 'client-new-50') {
+        completionAttemptsAtRebuildNotification.push(
+          restoreSessionAutomaticHistoryLoadAttempts(s, 5),
+        );
+      }
+    });
 
     const remoteHistory = Array.from({ length: 550 }, (_, index) =>
       dbMessage(
@@ -527,6 +535,7 @@ describe('makerChatStore.reconcileRemoteMessages', () => {
 
     makerChatStore.reconcileRemoteMessages(s);
     await flushMany(REMOTE_RECONCILE_FLUSH_TICKS);
+    unsubscribe();
 
     const snapshot = makerChatStore.getSnapshot(s);
     expect(snapshot.messages).toHaveLength(500);
@@ -537,6 +546,7 @@ describe('makerChatStore.reconcileRemoteMessages', () => {
     expect(snapshot.oldestMessageId).toBe('new-50');
     expect(snapshot.hasMoreMessages).toBe(true);
     expect(restoreSessionAutomaticHistoryLoadAttempts(s, 5)).toBe(0);
+    expect(completionAttemptsAtRebuildNotification).toContain(0);
   });
 
   it('远程会话:无重叠对账保留分页期间新到的 remote push', async () => {

--- a/apps/desktop/src/renderer/__tests__/sessionScrollStore.test.ts
+++ b/apps/desktop/src/renderer/__tests__/sessionScrollStore.test.ts
@@ -2,8 +2,9 @@ import { afterEach, describe, expect, it } from 'vitest';
 
 import {
   clearSessionScroll,
-  markSessionAutomaticHistoryLoadStarted,
+  markSessionAutomaticHistoryLoadCompleted,
   readSessionScroll,
+  resetSessionAutomaticHistoryLoadCompletion,
   restoreSessionAutomaticHistoryLoadAttempts,
   saveSessionScroll,
   type SessionScrollSnapshot,
@@ -34,7 +35,7 @@ afterEach(() => {
 });
 
 describe('session automatic history load memory', () => {
-  it('keeps a started auto-fill run exhausted across an A → B → A remount', () => {
+  it('keeps a completed auto-fill run exhausted across an A → B → A remount', () => {
     saveSessionScroll(SESSION_A, bottomSnapshot);
 
     const firstMountAttempts = restoreSessionAutomaticHistoryLoadAttempts(
@@ -53,10 +54,10 @@ describe('session automatic history load memory', () => {
       }),
     ).toBe('load-from-db');
 
-    markSessionAutomaticHistoryLoadStarted(SESSION_A);
+    markSessionAutomaticHistoryLoadCompleted(SESSION_A);
 
-    // 真实卸载顺序是先 mark 自动加载,再由 layout cleanup 保存滚动快照。
-    // 保存快照不能把已启动标记覆盖掉。
+    // 真实卸载顺序是先完成自动加载,再由 layout cleanup 保存滚动快照。
+    // 保存快照不能把已完成标记覆盖掉。
     saveSessionScroll(SESSION_A, bottomSnapshot);
 
     // 切到另一个 Worker 不会继承 A 的预算。
@@ -109,8 +110,18 @@ describe('session automatic history load memory', () => {
     expect(readSessionScroll(SESSION_A)).toEqual(bottomSnapshot);
   });
 
+  it('restores the automatic budget when the cached message window is discarded', () => {
+    saveSessionScroll(SESSION_A, bottomSnapshot);
+    markSessionAutomaticHistoryLoadCompleted(SESSION_A);
+
+    resetSessionAutomaticHistoryLoadCompletion(SESSION_A);
+
+    expect(readSessionScroll(SESSION_A)).toEqual(bottomSnapshot);
+    expect(restoreSessionAutomaticHistoryLoadAttempts(SESSION_A, MAX_AUTO_LOAD_ATTEMPTS)).toBe(0);
+  });
+
   it('clears the automatic load marker together with the session view memory', () => {
-    markSessionAutomaticHistoryLoadStarted(SESSION_A);
+    markSessionAutomaticHistoryLoadCompleted(SESSION_A);
     clearSessionScroll(SESSION_A);
 
     expect(readSessionScroll(SESSION_A)).toBeUndefined();

--- a/apps/desktop/src/renderer/__tests__/sessionScrollStore.test.ts
+++ b/apps/desktop/src/renderer/__tests__/sessionScrollStore.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  clearSessionScroll,
+  markSessionAutomaticHistoryLoadStarted,
+  readSessionScroll,
+  restoreSessionAutomaticHistoryLoadAttempts,
+  saveSessionScroll,
+  type SessionScrollSnapshot,
+} from '../lib/sessionScrollStore';
+import {
+  decideAutoFillAction,
+  decideUserIntentFillAction,
+  MAX_AUTO_LOAD_ATTEMPTS,
+} from '../components/chat/viewportFillDetect';
+import {
+  NAV_RAIL_BACKFILL_MAX_ROUNDS,
+  shouldBackfillForNavRail,
+} from '../components/chat/messageNavRailModel';
+
+const SESSION_A = 'worker-a';
+const SESSION_B = 'worker-b';
+
+const bottomSnapshot: SessionScrollSnapshot = {
+  windowAnchorKey: null,
+  viewportTopKey: 'message-tail',
+  offset: 0,
+  isNearBottom: true,
+};
+
+afterEach(() => {
+  clearSessionScroll(SESSION_A);
+  clearSessionScroll(SESSION_B);
+});
+
+describe('session automatic history load memory', () => {
+  it('keeps a started auto-fill run exhausted across an A → B → A remount', () => {
+    saveSessionScroll(SESSION_A, bottomSnapshot);
+
+    const firstMountAttempts = restoreSessionAutomaticHistoryLoadAttempts(
+      SESSION_A,
+      MAX_AUTO_LOAD_ATTEMPTS,
+    );
+    expect(firstMountAttempts).toBe(0);
+    expect(
+      decideAutoFillAction({
+        scrollHeight: 600,
+        clientHeight: 600,
+        windowAtTop: true,
+        hasMoreMessages: true,
+        isLoadingMore: false,
+        attemptCount: firstMountAttempts,
+      }),
+    ).toBe('load-from-db');
+
+    markSessionAutomaticHistoryLoadStarted(SESSION_A);
+
+    // 真实卸载顺序是先 mark 自动加载,再由 layout cleanup 保存滚动快照。
+    // 保存快照不能把已启动标记覆盖掉。
+    saveSessionScroll(SESSION_A, bottomSnapshot);
+
+    // 切到另一个 Worker 不会继承 A 的预算。
+    expect(restoreSessionAutomaticHistoryLoadAttempts(SESSION_B, MAX_AUTO_LOAD_ATTEMPTS)).toBe(0);
+
+    // 再切回 A 时,即使仍是“视口未撑满 + DB 有更早历史”,也不重拉同一页。
+    const remountAttempts = restoreSessionAutomaticHistoryLoadAttempts(
+      SESSION_A,
+      MAX_AUTO_LOAD_ATTEMPTS,
+    );
+    expect(remountAttempts).toBe(MAX_AUTO_LOAD_ATTEMPTS);
+    expect(
+      decideAutoFillAction({
+        scrollHeight: 600,
+        clientHeight: 600,
+        windowAtTop: true,
+        hasMoreMessages: true,
+        isLoadingMore: false,
+        attemptCount: remountAttempts,
+      }),
+    ).toBe('none');
+
+    const remountNavRailRounds = restoreSessionAutomaticHistoryLoadAttempts(
+      SESSION_A,
+      NAV_RAIL_BACKFILL_MAX_ROUNDS,
+    );
+    expect(remountNavRailRounds).toBe(NAV_RAIL_BACKFILL_MAX_ROUNDS);
+    expect(
+      shouldBackfillForNavRail({
+        entryCount: 1,
+        hasMoreMessages: true,
+        isLoadingMore: false,
+        rounds: remountNavRailRounds,
+      }),
+    ).toBe(false);
+
+    // 自动预算耗尽不参与用户意图判定;用户继续向上翻仍然可以加载。
+    expect(
+      decideUserIntentFillAction({
+        scrollHeight: 600,
+        clientHeight: 600,
+        scrollTop: 0,
+        windowAtTop: true,
+        hasMoreMessages: true,
+        isLoadingMore: false,
+      }),
+    ).toBe('load-from-db');
+
+    // 自动补载标记与滚动快照共存在同一份 session view memory 中。
+    expect(readSessionScroll(SESSION_A)).toEqual(bottomSnapshot);
+  });
+
+  it('clears the automatic load marker together with the session view memory', () => {
+    markSessionAutomaticHistoryLoadStarted(SESSION_A);
+    clearSessionScroll(SESSION_A);
+
+    expect(readSessionScroll(SESSION_A)).toBeUndefined();
+    expect(restoreSessionAutomaticHistoryLoadAttempts(SESSION_A, MAX_AUTO_LOAD_ATTEMPTS)).toBe(0);
+  });
+});

--- a/apps/desktop/src/renderer/components/chat/MessageStream.tsx
+++ b/apps/desktop/src/renderer/components/chat/MessageStream.tsx
@@ -65,7 +65,9 @@ import { createLogger } from '@/lib/logger';
 import { stopAllMedia } from '@/lib/mediaPlaybackBus';
 import { cn } from '@/lib/utils';
 import {
+  markSessionAutomaticHistoryLoadStarted,
   readSessionScroll,
+  restoreSessionAutomaticHistoryLoadAttempts,
   saveSessionScroll,
   type SessionScrollSnapshot,
 } from '@/lib/sessionScrollStore';
@@ -200,6 +202,7 @@ import { usePrevUserMessageInView } from './usePrevUserMessageInView';
 import { JumpToBottomChip } from './JumpToBottomChip';
 import { MessageNavRail } from './MessageNavRail';
 import {
+  NAV_RAIL_BACKFILL_MAX_ROUNDS,
   NAV_RAIL_JUMP_TOP_OFFSET_PX,
   deriveNavRailEntries,
   shouldBackfillForNavRail,
@@ -209,6 +212,7 @@ import { detectScrollAnchoringApplied } from './scrollAnchoringDetect';
 import {
   decideAutoFillAction,
   decideUserIntentFillAction,
+  MAX_AUTO_LOAD_ATTEMPTS,
   TOP_HISTORY_TRIGGER_PX,
   NO_SCROLL_TOLERANCE_PX,
 } from './viewportFillDetect';
@@ -3253,8 +3257,10 @@ export function MessageStream({
   //   2. windowAtTop=y AND hasMoreMessages=false  → DB 真的没历史了
   //   3. attemptCount >= MAX_AUTO_LOAD_ATTEMPTS  → 退化保护 (只数 IPC, 不数 expand)
   //
-  // attemptCount 用 ref 持有, 跟着 mount 生命周期走; sessionId 切换时父组件用
-  // key={sessionId} 重挂载本组件, ref 自动归零 (单 session 内独立计数, 无需手动 reset).
+  // attemptCount 用 ref 持有,让同一次 mount 内仍可按原预算连续补页。第一次真的
+  // 发起自动补载时同时在 sessionScrollStore 记 started;切走再切回的新 mount
+  // 直接从耗尽态开始,避免 leaveView 裁掉已补前缀后把同一页重新拉一遍。
+  // 用户明确向上滚动 / 翻页走 decideUserIntentFillAction,不读取这份自动预算。
   // useLayoutEffect 而不是 useEffect — 在 commit 同步阶段读 scrollH/clientH,
   // 避免 useEffect 滞后一帧导致跟 ResizeObserver/pinToBottom 的副作用错序.
   //
@@ -3263,7 +3269,9 @@ export function MessageStream({
   // 当前触发条件下 (scrollH===clientH) scrollTop 必为 0, 视觉收敛主要靠 line 716
   // 的 pinToBottom effect, 这两个 ref 在这是防御层 (避免 IPC race window 里
   // handleScroll 误覆盖 ref 用错快照 → F-SYNC-2 算错 delta).
-  const autoLoadAttemptCountRef = useRef<number>(0);
+  const autoLoadAttemptCountRef = useRef<number>(
+    restoreSessionAutomaticHistoryLoadAttempts(sessionId, MAX_AUTO_LOAD_ATTEMPTS),
+  );
   useLayoutEffect(() => {
     const el = scrollRef.current;
     if (!el) return;
@@ -3293,6 +3301,7 @@ export function MessageStream({
         autoLoadAttemptCountRef.current += 1;
         prevScrollHeightRef.current = el.scrollHeight;
         prevScrollTopAtLoadRef.current = el.scrollTop;
+        if (sessionId) markSessionAutomaticHistoryLoadStarted(sessionId);
         onLoadMore();
         return;
       }
@@ -3316,6 +3325,7 @@ export function MessageStream({
     hasMoreMessages,
     isLoadingMore,
     onLoadMore,
+    sessionId,
     windowAtTop,
     expandWindow,
     windowCoversEnd,
@@ -4061,12 +4071,12 @@ export function MessageStream({
   // 打开后本 effect 依赖变化会重新评估补页。
   // 调度 effect 的依赖含 sessionId(与 MessageNavRail 的 resetKey 同款惯例):
   // 两个会话的条目数 / hasMore 恰好相同且 onLoadMore 身份未变时,切会话也要
-  // 取消旧会话待发的空闲回调、并按归零后的轮数预算为新会话重新评估
-  // (Copilot review)。
-  const navRailBackfillRoundsRef = useRef(0);
-  useEffect(() => {
-    navRailBackfillRoundsRef.current = 0;
-  }, [sessionId]);
+  // 取消旧会话待发的空闲回调。轮数预算只在 mount 时按会话记忆恢复一次;
+  // 不能在 passive effect 再读,否则同一 mount 的 viewport-fill 先 mark 后会
+  // 提前封死导航条自己的本轮预算。
+  const navRailBackfillRoundsRef = useRef(
+    restoreSessionAutomaticHistoryLoadAttempts(sessionId, NAV_RAIL_BACKFILL_MAX_ROUNDS),
+  );
   useEffect(() => {
     if (!navRailEnabled) return;
     if (!onLoadMore) return;
@@ -4086,6 +4096,7 @@ export function MessageStream({
       navRailBackfillRoundsRef.current += 1;
       prevScrollHeightRef.current = el.scrollHeight;
       prevScrollTopAtLoadRef.current = el.scrollTop;
+      if (sessionId) markSessionAutomaticHistoryLoadStarted(sessionId);
       onLoadMore();
     };
     // 空闲期执行,别跟首屏渲染 / 两段式扩窗抢主线程;测试等无 ric 环境退化。

--- a/apps/desktop/src/renderer/components/chat/MessageStream.tsx
+++ b/apps/desktop/src/renderer/components/chat/MessageStream.tsx
@@ -66,7 +66,6 @@ import { stopAllMedia } from '@/lib/mediaPlaybackBus';
 import { cn } from '@/lib/utils';
 import {
   readSessionScroll,
-  restoreSessionAutomaticHistoryLoadAttempts,
   saveSessionScroll,
   type SessionScrollSnapshot,
 } from '@/lib/sessionScrollStore';
@@ -226,6 +225,7 @@ import {
 import { countUnreadAdded } from './unreadCount';
 import { useNavigationKeyListener } from './useNavigationKeyListener';
 import { suppressScrollbarActivation } from '@/lib/scrollbarAutoHide';
+import { useAutomaticHistoryLoadBudget } from './useAutomaticHistoryLoadBudget';
 import { collectAssistantTurnUsageDetails } from '@/lib/userTurnUsage';
 import type { TurnUsageDetails } from '../../../shared/turnUsageDetails';
 import { hasReviewableTurnChanges, type TurnChangeSetSummary } from '../../../shared/turnChangeSet';
@@ -250,6 +250,7 @@ interface MessageStreamProps {
    *  triggers extra re-renders mid-session. */
   workingDir: string;
   messages: ChatMessage[];
+  historyLoaded: boolean;
   taskUpdates?: ReadonlyMap<string, AgentTaskUpdate>;
   /** Kept for API compatibility. v2 — no longer threaded into render items
    *  (AgentActionsBlock + ThinkingCard manage their own per-block expand
@@ -2526,6 +2527,7 @@ export function MessageStream({
   remoteHostId,
   workingDir,
   messages,
+  historyLoaded,
   taskUpdates,
   isSessionStreaming = false,
   continuationTurnClientId = null,
@@ -3268,9 +3270,23 @@ export function MessageStream({
   // 当前触发条件下 (scrollH===clientH) scrollTop 必为 0, 视觉收敛主要靠 line 716
   // 的 pinToBottom effect, 这两个 ref 在这是防御层 (避免 IPC race window 里
   // handleScroll 误覆盖 ref 用错快照 → F-SYNC-2 算错 delta).
-  const autoLoadAttemptCountRef = useRef<number>(
-    restoreSessionAutomaticHistoryLoadAttempts(sessionId, MAX_AUTO_LOAD_ATTEMPTS),
+  const {
+    viewportAttemptsRef: autoLoadAttemptCountRef,
+    navRailRoundsRef: navRailBackfillRoundsRef,
+    runAutomaticLoad,
+  } = useAutomaticHistoryLoadBudget(
+    sessionId,
+    MAX_AUTO_LOAD_ATTEMPTS,
+    NAV_RAIL_BACKFILL_MAX_ROUNDS,
+    {
+      historyLoaded,
+      messageCount: messages.length,
+      firstMessageClientId: messages[0]?.clientId ?? null,
+    },
   );
+  // MessageStream 只按 sessionId remount。逻辑窗口在同一 mount 内被 reload / reconcile /
+  // truncate 时,hook 会同步归零两套本地预算；不能只用 messages identity,正常
+  // push/prepend 同样会换引用。
   useLayoutEffect(() => {
     const el = scrollRef.current;
     if (!el) return;
@@ -3300,7 +3316,7 @@ export function MessageStream({
         autoLoadAttemptCountRef.current += 1;
         prevScrollHeightRef.current = el.scrollHeight;
         prevScrollTopAtLoadRef.current = el.scrollTop;
-        void onLoadMore(true);
+        void runAutomaticLoad(onLoadMore);
         return;
       }
       case 'none':
@@ -3323,6 +3339,7 @@ export function MessageStream({
     hasMoreMessages,
     isLoadingMore,
     onLoadMore,
+    runAutomaticLoad,
     sessionId,
     windowAtTop,
     expandWindow,
@@ -4072,9 +4089,6 @@ export function MessageStream({
   // 取消旧会话待发的空闲回调。轮数预算只在 mount 时按会话记忆恢复一次;
   // 不能在 passive effect 再读,否则同一 mount 的 viewport-fill 先 mark 后会
   // 提前封死导航条自己的本轮预算。
-  const navRailBackfillRoundsRef = useRef(
-    restoreSessionAutomaticHistoryLoadAttempts(sessionId, NAV_RAIL_BACKFILL_MAX_ROUNDS),
-  );
   useEffect(() => {
     if (!navRailEnabled) return;
     if (!onLoadMore) return;
@@ -4094,7 +4108,7 @@ export function MessageStream({
       navRailBackfillRoundsRef.current += 1;
       prevScrollHeightRef.current = el.scrollHeight;
       prevScrollTopAtLoadRef.current = el.scrollTop;
-      void onLoadMore(true);
+      void runAutomaticLoad(onLoadMore);
     };
     // 空闲期执行,别跟首屏渲染 / 两段式扩窗抢主线程;测试等无 ric 环境退化。
     if (typeof window.requestIdleCallback === 'function') {
@@ -4110,6 +4124,7 @@ export function MessageStream({
     hasMoreMessages,
     isLoadingMore,
     onLoadMore,
+    runAutomaticLoad,
   ]);
 
   const railJumpSeqRef = useRef(0);

--- a/apps/desktop/src/renderer/components/chat/MessageStream.tsx
+++ b/apps/desktop/src/renderer/components/chat/MessageStream.tsx
@@ -65,7 +65,6 @@ import { createLogger } from '@/lib/logger';
 import { stopAllMedia } from '@/lib/mediaPlaybackBus';
 import { cn } from '@/lib/utils';
 import {
-  markSessionAutomaticHistoryLoadStarted,
   readSessionScroll,
   restoreSessionAutomaticHistoryLoadAttempts,
   saveSessionScroll,
@@ -261,8 +260,8 @@ interface MessageStreamProps {
   continuationTurnClientId?: string | null;
   /** 旧被控端缺省该字段时才启用兼容兜底；unknown 在首个投影前 fail closed。 */
   continuationInFlightProjectionCapability?: ContinuationInFlightProjectionCapability;
-  /** F-SYNC-2: callback to load older messages */
-  onLoadMore?: () => void;
+  /** F-SYNC-2: callback to load older messages; true marks this as an automatic fill. */
+  onLoadMore?: (automatic?: boolean) => Promise<boolean>;
   isLoadingMore?: boolean;
   hasMoreMessages?: boolean;
   /** Dynamic bottom padding (px) to reserve space for the input overlay */
@@ -3258,7 +3257,7 @@ export function MessageStream({
   //   3. attemptCount >= MAX_AUTO_LOAD_ATTEMPTS  → 退化保护 (只数 IPC, 不数 expand)
   //
   // attemptCount 用 ref 持有,让同一次 mount 内仍可按原预算连续补页。第一次真的
-  // 发起自动补载时同时在 sessionScrollStore 记 started;切走再切回的新 mount
+  // 成功推进缓存窗口后同时在 sessionScrollStore 记 completed;切走再切回的新 mount
   // 直接从耗尽态开始,避免 leaveView 裁掉已补前缀后把同一页重新拉一遍。
   // 用户明确向上滚动 / 翻页走 decideUserIntentFillAction,不读取这份自动预算。
   // useLayoutEffect 而不是 useEffect — 在 commit 同步阶段读 scrollH/clientH,
@@ -3301,8 +3300,7 @@ export function MessageStream({
         autoLoadAttemptCountRef.current += 1;
         prevScrollHeightRef.current = el.scrollHeight;
         prevScrollTopAtLoadRef.current = el.scrollTop;
-        if (sessionId) markSessionAutomaticHistoryLoadStarted(sessionId);
-        onLoadMore();
+        void onLoadMore(true);
         return;
       }
       case 'none':
@@ -4096,8 +4094,7 @@ export function MessageStream({
       navRailBackfillRoundsRef.current += 1;
       prevScrollHeightRef.current = el.scrollHeight;
       prevScrollTopAtLoadRef.current = el.scrollTop;
-      if (sessionId) markSessionAutomaticHistoryLoadStarted(sessionId);
-      onLoadMore();
+      void onLoadMore(true);
     };
     // 空闲期执行,别跟首屏渲染 / 两段式扩窗抢主线程;测试等无 ric 环境退化。
     if (typeof window.requestIdleCallback === 'function') {

--- a/apps/desktop/src/renderer/components/chat/__tests__/useAutomaticHistoryLoadBudget.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/__tests__/useAutomaticHistoryLoadBudget.test.tsx
@@ -1,0 +1,139 @@
+// @vitest-environment jsdom
+
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  clearSessionScroll,
+  markSessionAutomaticHistoryLoadCompleted,
+  resetSessionAutomaticHistoryLoadCompletion,
+} from '@/lib/sessionScrollStore';
+import { useAutomaticHistoryLoadBudget } from '../useAutomaticHistoryLoadBudget';
+
+const SESSION_ID = 'worker-mounted-budget';
+const LOADED_WINDOW = {
+  historyLoaded: true,
+  messageCount: 10,
+  firstMessageClientId: 'oldest-a',
+};
+
+afterEach(() => clearSessionScroll(SESSION_ID));
+
+describe('useAutomaticHistoryLoadBudget', () => {
+  it('resets both mounted budgets when the completed window is invalidated', () => {
+    markSessionAutomaticHistoryLoadCompleted(SESSION_ID);
+    const view = renderHook(() => useAutomaticHistoryLoadBudget(SESSION_ID, 5, 3, LOADED_WINDOW));
+
+    expect(view.result.current.viewportAttemptsRef.current).toBe(5);
+    expect(view.result.current.navRailRoundsRef.current).toBe(3);
+
+    act(() => {
+      resetSessionAutomaticHistoryLoadCompletion(SESSION_ID);
+      view.rerender();
+    });
+
+    expect(view.result.current.viewportAttemptsRef.current).toBe(0);
+    expect(view.result.current.navRailRoundsRef.current).toBe(0);
+  });
+
+  it('does not reset failed-load budgets while completion remains false', () => {
+    const view = renderHook(() => useAutomaticHistoryLoadBudget(SESSION_ID, 5, 3, LOADED_WINDOW));
+    view.result.current.viewportAttemptsRef.current = 5;
+    view.result.current.navRailRoundsRef.current = 3;
+
+    act(() => view.rerender());
+
+    expect(view.result.current.viewportAttemptsRef.current).toBe(5);
+    expect(view.result.current.navRailRoundsRef.current).toBe(3);
+  });
+
+  it('resets exhausted failed-load budgets when the mounted window reloads', () => {
+    const view = renderHook(
+      ({ historyLoaded }) =>
+        useAutomaticHistoryLoadBudget(SESSION_ID, 5, 3, {
+          ...LOADED_WINDOW,
+          historyLoaded,
+        }),
+      { initialProps: { historyLoaded: true } },
+    );
+    view.result.current.viewportAttemptsRef.current = 5;
+    view.result.current.navRailRoundsRef.current = 3;
+
+    act(() => view.rerender({ historyLoaded: false }));
+
+    expect(view.result.current.viewportAttemptsRef.current).toBe(0);
+    expect(view.result.current.navRailRoundsRef.current).toBe(0);
+  });
+
+  it('resets exhausted budgets when reconciliation replaces the mounted window head', () => {
+    const view = renderHook(
+      ({ firstMessageClientId }) =>
+        useAutomaticHistoryLoadBudget(SESSION_ID, 5, 3, {
+          ...LOADED_WINDOW,
+          firstMessageClientId,
+        }),
+      { initialProps: { firstMessageClientId: 'oldest-a' } },
+    );
+    view.result.current.viewportAttemptsRef.current = 5;
+    view.result.current.navRailRoundsRef.current = 3;
+
+    act(() => view.rerender({ firstMessageClientId: 'oldest-rebuilt' }));
+
+    expect(view.result.current.viewportAttemptsRef.current).toBe(0);
+    expect(view.result.current.navRailRoundsRef.current).toBe(0);
+  });
+
+  it('does not mistake an in-flight automatic prepend for a window rebuild', async () => {
+    const view = renderHook(
+      ({ firstMessageClientId }) =>
+        useAutomaticHistoryLoadBudget(SESSION_ID, 5, 3, {
+          ...LOADED_WINDOW,
+          firstMessageClientId,
+        }),
+      { initialProps: { firstMessageClientId: 'oldest-a' } },
+    );
+    view.result.current.viewportAttemptsRef.current = 4;
+    view.result.current.navRailRoundsRef.current = 2;
+    let finishLoad!: (advanced: boolean) => void;
+    const load = () =>
+      new Promise<boolean>((resolve) => {
+        finishLoad = resolve;
+      });
+
+    const pending = view.result.current.runAutomaticLoad(load);
+    act(() => view.rerender({ firstMessageClientId: 'older-page' }));
+
+    expect(view.result.current.viewportAttemptsRef.current).toBe(4);
+    expect(view.result.current.navRailRoundsRef.current).toBe(2);
+
+    finishLoad(true);
+    await pending;
+  });
+
+  it('resets budgets after an in-flight automatic load is invalidated by a replacement', async () => {
+    const view = renderHook(
+      ({ firstMessageClientId }) =>
+        useAutomaticHistoryLoadBudget(SESSION_ID, 5, 3, {
+          ...LOADED_WINDOW,
+          firstMessageClientId,
+        }),
+      { initialProps: { firstMessageClientId: 'oldest-a' } },
+    );
+    view.result.current.viewportAttemptsRef.current = 5;
+    view.result.current.navRailRoundsRef.current = 3;
+    let finishLoad!: (advanced: boolean) => void;
+    const load = () =>
+      new Promise<boolean>((resolve) => {
+        finishLoad = resolve;
+      });
+
+    const pending = view.result.current.runAutomaticLoad(load);
+    act(() => view.rerender({ firstMessageClientId: 'authoritative-head' }));
+
+    finishLoad(false);
+    await pending;
+
+    expect(view.result.current.viewportAttemptsRef.current).toBe(0);
+    expect(view.result.current.navRailRoundsRef.current).toBe(0);
+  });
+});

--- a/apps/desktop/src/renderer/components/chat/useAutomaticHistoryLoadBudget.ts
+++ b/apps/desktop/src/renderer/components/chat/useAutomaticHistoryLoadBudget.ts
@@ -1,0 +1,85 @@
+import { useCallback, useLayoutEffect, useRef } from 'react';
+
+import { restoreSessionAutomaticHistoryLoadAttempts } from '@/lib/sessionScrollStore';
+
+export function useAutomaticHistoryLoadBudget(
+  sessionId: string | undefined,
+  viewportMaxAttempts: number,
+  navRailMaxRounds: number,
+  windowSnapshot: {
+    historyLoaded: boolean;
+    messageCount: number;
+    firstMessageClientId: string | null;
+  },
+) {
+  const viewportAttemptsRef = useRef(
+    restoreSessionAutomaticHistoryLoadAttempts(sessionId, viewportMaxAttempts),
+  );
+  const navRailRoundsRef = useRef(
+    restoreSessionAutomaticHistoryLoadAttempts(sessionId, navRailMaxRounds),
+  );
+  const completionSeenRef = useRef(restoreSessionAutomaticHistoryLoadAttempts(sessionId, 1) > 0);
+  const previousWindowSnapshotRef = useRef(windowSnapshot);
+  const automaticLoadInFlightCountRef = useRef(0);
+  const windowInvalidatedDuringAutomaticLoadRef = useRef(false);
+
+  const resetMountedBudgets = useCallback(() => {
+    viewportAttemptsRef.current = 0;
+    navRailRoundsRef.current = 0;
+  }, []);
+
+  // 消费当前窗口失效的既有响应式事实。只看 completed 的 true → false 不够：预算也可能
+  // 因连续失败耗尽,那时 marker 始终是 false。反过来,不能在普通 false → false rerender
+  // 上归零,否则会绕过两套退化上限。
+  useLayoutEffect(() => {
+    const completedNow = restoreSessionAutomaticHistoryLoadAttempts(sessionId, 1) > 0;
+    const previous = previousWindowSnapshotRef.current;
+    const reloadStarted = previous.historyLoaded && !windowSnapshot.historyLoaded;
+    const visibleWindowWasTruncated = windowSnapshot.messageCount < previous.messageCount;
+    const windowHeadChanged =
+      previous.firstMessageClientId !== null &&
+      windowSnapshot.firstMessageClientId !== previous.firstMessageClientId;
+    const invalidatedWindowShape =
+      !completedNow && (visibleWindowWasTruncated || windowHeadChanged);
+
+    if ((completionSeenRef.current && !completedNow) || reloadStarted) {
+      resetMountedBudgets();
+    } else if (invalidatedWindowShape) {
+      if (visibleWindowWasTruncated || automaticLoadInFlightCountRef.current === 0) {
+        resetMountedBudgets();
+      } else {
+        // 正常自动 prepend 与同大小的权威换窗都表现成“首行变化”。请求返回前无法区分，
+        // 先记下边沿；成功推进说明是 prepend，false 则说明请求被 epoch 作废，届时复位。
+        windowInvalidatedDuringAutomaticLoadRef.current = true;
+      }
+    }
+    completionSeenRef.current = completedNow;
+    previousWindowSnapshotRef.current = windowSnapshot;
+  });
+
+  const runAutomaticLoad = useCallback(
+    async (loadMore: (automatic?: boolean) => Promise<boolean>): Promise<boolean> => {
+      automaticLoadInFlightCountRef.current += 1;
+      try {
+        const advanced = await loadMore(true);
+        if (advanced) {
+          completionSeenRef.current = true;
+          windowInvalidatedDuringAutomaticLoadRef.current = false;
+        }
+        return advanced;
+      } finally {
+        automaticLoadInFlightCountRef.current -= 1;
+        if (
+          automaticLoadInFlightCountRef.current === 0 &&
+          windowInvalidatedDuringAutomaticLoadRef.current
+        ) {
+          windowInvalidatedDuringAutomaticLoadRef.current = false;
+          resetMountedBudgets();
+        }
+      }
+    },
+    [resetMountedBudgets],
+  );
+
+  return { viewportAttemptsRef, navRailRoundsRef, runAutomaticLoad };
+}

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
@@ -3686,6 +3686,7 @@ export function CCAgentSessionView({
       // a TS-narrowing fallback, never expected to fire at runtime.
       workingDir={session?.workingDir ?? ''}
       messages={messages}
+      historyLoaded={historyLoaded}
       taskUpdates={taskUpdates}
       isSessionStreaming={isStreaming}
       continuationTurnClientId={continuationTurnClientId}

--- a/apps/desktop/src/renderer/hooks/useCCAgentChat.ts
+++ b/apps/desktop/src/renderer/hooks/useCCAgentChat.ts
@@ -194,8 +194,8 @@ interface UseCCAgentChatReturn {
   continuationTurnClientId: string | null;
   /** 续跑边界投影能力；legacy 时保留旧被控端的兼容兜底。 */
   continuationInFlightProjectionCapability: ContinuationInFlightProjectionCapability;
-  /** F-SYNC-2: Load older messages (prepend to top) */
-  loadOlderMessages: () => void;
+  /** F-SYNC-2: Load older messages; automatic=true remembers a successful auto-fill. */
+  loadOlderMessages: (automatic?: boolean) => Promise<boolean>;
   isLoadingMore: boolean;
   hasMoreMessages: boolean;
   historyWindowHasIsland: boolean;
@@ -549,9 +549,9 @@ export function useCCAgentChat(
     [sessionId],
   );
 
-  const loadOlderMessages = useCallback(() => {
-    if (!sessionId) return;
-    makerChatStore.loadOlderMessages(sessionId);
+  const loadOlderMessages = useCallback((automatic = false): Promise<boolean> => {
+    if (!sessionId) return Promise.resolve(false);
+    return makerChatStore.loadOlderMessages(sessionId, automatic);
   }, [sessionId]);
 
   const respondToPermission = useCallback(

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -120,6 +120,10 @@ import type { AgentKind } from '@/hooks/useAgentCapabilities';
 import type { Effort } from '@/lib/userPreferences.types';
 import { emitAutoTitlePreview, emitAutoTitlePreviewCleared, emitPatch } from '@/lib/sessionsBus';
 import { createLogger } from '@/lib/logger';
+import {
+  markSessionAutomaticHistoryLoadCompleted,
+  resetSessionAutomaticHistoryLoadCompletion,
+} from '@/lib/sessionScrollStore';
 import { extractIpcError } from '@/utils/ipcError';
 import { tryBeginAgentSendDispatch } from '@/lib/agentSwitchCoordinator';
 import { getUserPrompt } from '@/lib/userPromptStore';
@@ -3174,6 +3178,7 @@ function _purgeSession(sessionId: string): void {
   // 交接中的迟到 continuation，且不写入 /clear 的历史时间边界。
   bumpRendererClearGeneration(sessionId);
   cancelRemoteOptimisticSendsForSessionPurge(sessionId);
+  resetSessionAutomaticHistoryLoadCompletion(sessionId);
   sessions.delete(sessionId);
   localSentUserMessageIds.delete(sessionId);
   pendingLocalRetryIntents.delete(sessionId);
@@ -3387,6 +3392,7 @@ function _demoteIdleSessions(): void {
     // 分页锁。漏 bump 的后果是 in-flight 那一页按 demote 前的游标提交,把一段脱离上下文
     // 的旧历史 merge 进空切片(或重开后的新切片),最近的消息反而缺席(#676 review)。
     bumpMessagesEpoch(sessionId);
+    resetSessionAutomaticHistoryLoadCompletion(sessionId);
     setState(sessionId, (s) => ({
       ...s,
       messages: [],
@@ -9602,6 +9608,7 @@ function ensureInitialMessages(sessionId: string): void {
  */
 function reloadMessages(sessionId: string, opts?: { allowCacheHydrate?: boolean }): void {
   discardPendingTextDelta(sessionId);
+  resetSessionAutomaticHistoryLoadCompletion(sessionId);
   // 代际递增:作废 in-flight 的 loadOlderMessages 追页窗口(见 _messagesEpoch 注释)。
   bumpMessagesEpoch(sessionId);
   invalidateHistoryFetch(sessionId);
@@ -10094,7 +10101,10 @@ function runRemoteReconcile(sessionId: string, opts?: { force?: boolean }): Prom
           historyWindowHasIsland: hasDetachedArrival,
         };
       });
-      if (didRebuild) bumpMessagesEpoch(sessionId);
+      if (didRebuild) {
+        resetSessionAutomaticHistoryLoadCompletion(sessionId);
+        bumpMessagesEpoch(sessionId);
+      }
     } finally {
       // 消息路径的早返 / 异常都要等交互重建落定;交互失败会让 run reject(替换原结果),
       // 语义正确:本代不完成。
@@ -10147,21 +10157,26 @@ function finalizeStuckRemoteTurn(sessionId: string): void {
  */
 const MAX_LOAD_OLDER_PAGES = 10;
 
-function loadOlderMessages(sessionId: string): void {
+/**
+ * 加载并提交更早的历史。返回 true 仅表示当前缓存窗口确实向前推进;
+ * 行首守卫、空页、全程失败、代际作废和提交异常都返回 false。
+ * automatic=true 时只在推进成功后耗尽该缓存窗口的跨 mount 自动补载预算。
+ */
+function loadOlderMessages(sessionId: string, automatic = false): Promise<boolean> {
   const state = getOrCreateState(sessionId);
-  if (state.isLoadingMore || !state.hasMoreMessages) return;
+  if (state.isLoadingMore || !state.hasMoreMessages) return Promise.resolve(false);
 
   let firstPageOpts: { limit: number; before?: string; beforeTs?: number };
   if (state.oldestMessageId) {
     firstPageOpts = { limit: 50, before: state.oldestMessageId };
   } else if (state.messages.length > 0) {
     const oldest = state.messages[0];
-    if (!oldest.createdAt) return;
+    if (!oldest.createdAt) return Promise.resolve(false);
     const ts = new Date(oldest.createdAt).getTime();
-    if (!Number.isFinite(ts)) return;
+    if (!Number.isFinite(ts)) return Promise.resolve(false);
     firstPageOpts = { limit: 50, beforeTs: ts };
   } else {
-    return;
+    return Promise.resolve(false);
   }
 
   setState(sessionId, (s) => ({ ...s, isLoadingMore: true }));
@@ -10173,7 +10188,7 @@ function loadOlderMessages(sessionId: string): void {
   // 远程会话(device-link)往上翻页加载更多历史:会话与消息只在被控端,必须走 origin-aware
   // 的 listMessagesFor(本地会话回落 messageService.list),否则查控制端空库 → 旧历史加载为空。
   // 与初始加载 / backfill(本文件其余处)保持一致。
-  void (async () => {
+  return (async () => {
     try {
       const collected: Message[] = [];
       // 跨页按 clientId 去重:mergeMessages 只对"新批 vs 已有"去重,不去重批内
@@ -10220,7 +10235,7 @@ function loadOlderMessages(sessionId: string): void {
       // 重置之后,新代际很可能已经开始自己的分页并重新置了锁 —— 这里再无条件清一次,
       // 就是把别人的锁放掉,让后续滚动 / 跳转并发去抢同一个游标,重新制造游标回退与
       // 重复分页(#676 review)。谁重置谁释放,被作废的请求一律不碰。
-      if ((_messagesEpoch.get(sessionId) ?? 0) !== epochAtStart) return;
+      if ((_messagesEpoch.get(sessionId) ?? 0) !== epochAtStart) return false;
 
       if (collected.length === 0) {
         setState(sessionId, (s) => ({
@@ -10229,17 +10244,28 @@ function loadOlderMessages(sessionId: string): void {
           hasMoreMessages: hasMore ? s.hasMoreMessages : false,
           isLoadingMore: false,
         }));
-        return;
+        return false;
       }
 
       const mapped = mapServerMessages(collected);
-      setState(sessionId, (s) => ({
-        ...s,
-        messages: mergeMessages(mapped, s.messages, {}, 'newest-first'),
-        oldestMessageId: oldestId ?? s.oldestMessageId,
-        hasMoreMessages: hasMore,
-        isLoadingMore: false,
-      }));
+      let didAdvanceWindow = false;
+      setState(sessionId, (s) => {
+        const messages = mergeMessages(mapped, s.messages, {}, 'newest-first');
+        const nextOldestMessageId = oldestId ?? s.oldestMessageId;
+        didAdvanceWindow =
+          messages.length > s.messages.length || nextOldestMessageId !== s.oldestMessageId;
+        return {
+          ...s,
+          messages,
+          oldestMessageId: nextOldestMessageId,
+          hasMoreMessages: hasMore,
+          isLoadingMore: false,
+        };
+      });
+      if (didAdvanceWindow && automatic) {
+        markSessionAutomaticHistoryLoadCompleted(sessionId);
+      }
+      return didAdvanceWindow;
     } catch (err) {
       // map/merge/commit 阶段兜底(subagent review P1):任何异常都必须复位
       // isLoadingMore,否则行首守卫会让该会话永久无法再翻页(spinner 卡死)。
@@ -10252,6 +10278,7 @@ function loadOlderMessages(sessionId: string): void {
       if ((_messagesEpoch.get(sessionId) ?? 0) === epochAtStart) {
         setState(sessionId, (s) => ({ ...s, isLoadingMore: false }));
       }
+      return false;
     }
   })();
 }
@@ -12551,6 +12578,7 @@ async function clearSessionAfterGuardImpl(sessionId: string, clearedAt: string):
   // The clear guard itself must be the new authority generation, otherwise an
   // older projection can win the race and reinsert pre-clear queue state.
   bumpMessagesEpoch(sessionId);
+  resetSessionAutomaticHistoryLoadCompletion(sessionId);
   bumpInteractionReconcileEpoch(sessionId);
   supersedeInputProjectionRequests(sessionId, { supersedeOperations: true });
   if (remoteDeviceId) {

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -2064,6 +2064,8 @@ function cancelRemoteOptimisticSendsForRemoteClear(
   clearBoundaryMs: number,
   opts: { historicalHydration?: boolean } = {},
 ): void {
+  // 历史 hydration 也会走到这里,但它只清理旧 optimistic 状态,并没有替换当前消息窗口;
+  // 因此只作废在途请求,不能把已经完成的自动补载误判成新窗口。
   bumpMessagesEpoch(sessionId);
   bumpInteractionReconcileEpoch(sessionId);
   invalidateInputProjectionRequests(sessionId);
@@ -3172,13 +3174,12 @@ function _purgeSession(sessionId: string): void {
   clearIssueConfirmDraftsForSession(sessionId);
   // 代际递增(bump 而非 delete,原因见 _messagesEpoch 注释):作废 in-flight 翻页,
   // 避免其提交把旧窗口 merge 进 purge 后重建的空 slice。
-  bumpMessagesEpoch(sessionId);
+  invalidateMessageHistoryWindow(sessionId);
   invalidateInputProjectionRequests(sessionId);
   // 删除 / 归档 / LRU 都是 renderer owner 边界。作废仍在附件物化或 composer
   // 交接中的迟到 continuation，且不写入 /clear 的历史时间边界。
   bumpRendererClearGeneration(sessionId);
   cancelRemoteOptimisticSendsForSessionPurge(sessionId);
-  resetSessionAutomaticHistoryLoadCompletion(sessionId);
   sessions.delete(sessionId);
   localSentUserMessageIds.delete(sessionId);
   pendingLocalRetryIntents.delete(sessionId);
@@ -3391,8 +3392,7 @@ function _demoteIdleSessions(): void {
     // 等于代际重置,必须 bump epoch 作废 in-flight 的翻页 / 跳转补齐,并由本次重置释放
     // 分页锁。漏 bump 的后果是 in-flight 那一页按 demote 前的游标提交,把一段脱离上下文
     // 的旧历史 merge 进空切片(或重开后的新切片),最近的消息反而缺席(#676 review)。
-    bumpMessagesEpoch(sessionId);
-    resetSessionAutomaticHistoryLoadCompletion(sessionId);
+    invalidateMessageHistoryWindow(sessionId);
     setState(sessionId, (s) => ({
       ...s,
       messages: [],
@@ -8997,6 +8997,17 @@ function bumpMessagesEpoch(sessionId: string): void {
   _messagesEpoch.set(sessionId, (_messagesEpoch.get(sessionId) ?? 0) + 1);
 }
 
+/**
+ * 作废当前逻辑历史窗口:既让在途分页不能提交回旧窗口,也让下一次挂载重新获得自动
+ * 补载预算。在真正替换当前窗口的路径中,纯内存 trim 是唯一例外——它正是要保留
+ * “这个窗口已经自动补过”的事实,避免切回会话后重复拉同一段历史,所以仍只调用
+ * bumpMessagesEpoch。
+ */
+function invalidateMessageHistoryWindow(sessionId: string): void {
+  bumpMessagesEpoch(sessionId);
+  resetSessionAutomaticHistoryLoadCompletion(sessionId);
+}
+
 function isCurrentHistoryFetch(
   sessionId: string,
   token: number,
@@ -9608,9 +9619,8 @@ function ensureInitialMessages(sessionId: string): void {
  */
 function reloadMessages(sessionId: string, opts?: { allowCacheHydrate?: boolean }): void {
   discardPendingTextDelta(sessionId);
-  resetSessionAutomaticHistoryLoadCompletion(sessionId);
   // 代际递增:作废 in-flight 的 loadOlderMessages 追页窗口(见 _messagesEpoch 注释)。
-  bumpMessagesEpoch(sessionId);
+  invalidateMessageHistoryWindow(sessionId);
   invalidateHistoryFetch(sessionId);
   // Drop the in-flight guard so ensureInitialMessages can run again.
   _historyFetchInFlight.delete(sessionId);
@@ -9681,7 +9691,7 @@ function removeMessagesByClientIds(
   invalidateRemoteMessageCache(sessionId);
   discardPendingTextDelta(sessionId);
   // 作废删除提交前发起的历史分页，避免旧页响应把已经清除的行重新 merge 回来。
-  if (options.invalidateHistory !== false) bumpMessagesEpoch(sessionId);
+  if (options.invalidateHistory !== false) invalidateMessageHistoryWindow(sessionId);
   setState(sessionId, (s) => {
     const removedMessages = s.messages.filter((message) => deletedClientIds.has(message.clientId));
     const messages = s.messages.filter((message) => !deletedClientIds.has(message.clientId));
@@ -9751,7 +9761,7 @@ function dropMessagesFromClientId(sessionId: string, clientId: string): void {
   // 路径,同样必须作废 in-flight 的分页 / 跳转补齐。漏 bump 的后果是它们把 rewind
   // 刚软删掉的行当作有效响应 merge 回渲染层(#676 review)。clientId 不在列表时
   // 也照 bump:代价只是让 in-flight 分页重新取一次,比漏作废安全。
-  bumpMessagesEpoch(sessionId);
+  invalidateMessageHistoryWindow(sessionId);
   setState(sessionId, (s) => {
     const idx = s.messages.findIndex((m) => m.clientId === clientId);
     // 目标已经不在切片里(reload / 重开把它清掉了)也必须放锁:上面 bump 过 epoch,
@@ -10004,12 +10014,10 @@ function runRemoteReconcile(sessionId: string, opts?: { force?: boolean }): Prom
       //
       // historyWindowHasIsland 按"是否保留了晚到的本地行"决定清不清,见下方 lateArrivals。
       const isContiguous = reachedKnownWindow;
-      // 代际 bump 与分页锁释放都**只在重建真正提交后**才做。原先在 setState 之前先 bump:
-      // 一旦更新器里的 isStreaming 守卫(分页期间开始了新 turn)否掉这次重建,窗口没换、
-      // 却已经作废掉一个无关的 in-flight 跳转 / 翻页、还替它放了锁;更晚启动的对账也会
-      // 因为这个白 bump 被当成陈旧丢掉(#676 review codex P1)。setState 是同步的,
-      // 把 bump 挪到它之后不引入任何可观察的中间态。
-      let didRebuild = false;
+      // 代际 bump 与分页锁释放都**只在重建确定提交时**做。不能放在 setState 外面提前 bump:
+      // 更新器里的 isStreaming 守卫可能否掉重建。也不能等 setState 通知完成后才 bump:
+      // MessageStream 要在同一次通知里观察到窗口已失效、重置已挂载的自动补载预算。
+      // updater 同步执行且下面所有早退都已经结束,在 return 新 state 前失效正好满足两边。
       setState(sessionId, (s) => {
         // promise 期间可能已开始新 turn(streaming)→ 放弃本次合并,turn 结束会再触发。
         // force 时(stall 看门狗已确认被控端 not-running)放行:此处 isStreaming 是卡死残留。
@@ -10043,7 +10051,7 @@ function runRemoteReconcile(sessionId: string, opts?: { force?: boolean }): Prom
         // 无缺失且无权威字段变化 → 不换引用(视同已应用)。
         if (messages === s.messages) return s;
         if (isContiguous) return { ...s, messages };
-        didRebuild = true;
+        invalidateMessageHistoryWindow(sessionId);
         const oldestRow = oldestMessageRow(collected, 'newest-first');
         // 保留下来的晚到行是否**可证明**与新窗口连续:
         //  - 比权威窗口最新一行还新 → 就是分页期间的 live push,接在尾部,连续;
@@ -10101,10 +10109,6 @@ function runRemoteReconcile(sessionId: string, opts?: { force?: boolean }): Prom
           historyWindowHasIsland: hasDetachedArrival,
         };
       });
-      if (didRebuild) {
-        resetSessionAutomaticHistoryLoadCompletion(sessionId);
-        bumpMessagesEpoch(sessionId);
-      }
     } finally {
       // 消息路径的早返 / 异常都要等交互重建落定;交互失败会让 run reject(替换原结果),
       // 语义正确:本代不完成。
@@ -12577,8 +12581,7 @@ async function clearSessionAfterGuardImpl(sessionId: string, clearedAt: string):
   // Invalidate old history/projection operations before the first network await.
   // The clear guard itself must be the new authority generation, otherwise an
   // older projection can win the race and reinsert pre-clear queue state.
-  bumpMessagesEpoch(sessionId);
-  resetSessionAutomaticHistoryLoadCompletion(sessionId);
+  invalidateMessageHistoryWindow(sessionId);
   bumpInteractionReconcileEpoch(sessionId);
   supersedeInputProjectionRequests(sessionId, { supersedeOperations: true });
   if (remoteDeviceId) {

--- a/apps/desktop/src/renderer/lib/sessionScrollStore.ts
+++ b/apps/desktop/src/renderer/lib/sessionScrollStore.ts
@@ -36,14 +36,15 @@ export interface SessionScrollSnapshot {
 interface SessionViewMemory {
   scroll?: SessionScrollSnapshot;
   /**
-   * 本次 app 运行期内,该会话是否已经启动过一轮自动历史补载。
+   * 当前缓存消息窗口是否已经成功完成过一轮自动历史补载。
    *
-   * 这里只记 started,不记精确轮数:一次 mount 可能只拉 1 页就撑满视口,
+   * 这里只记 completed,不记精确轮数:一次 mount 可能只拉 1 页就撑满视口,
    * 离开时消息缓存又会裁掉刚补进来的前缀。若下次 mount 从 1/5 继续算,
    * 仍会把同一页历史重新拉一遍。重挂载时应把自动预算整体视作已用完;
-   * 用户明确上滑 / 翻页的加载路径不读取这个标记,仍可继续加载。
+   * 用户明确上滑 / 翻页的加载路径不读取这个标记,仍可继续加载。缓存窗口被
+   * 整体丢弃时清除此标记,让新窗口重新获得一次自动补载预算。
    */
-  automaticHistoryLoadStarted?: true;
+  automaticHistoryLoadCompleted?: true;
 }
 
 const store = new Map<string, SessionViewMemory>();
@@ -57,22 +58,32 @@ export function readSessionScroll(sessionId: string): SessionScrollSnapshot | un
   return store.get(sessionId)?.scroll;
 }
 
-/** 记录该会话在当前 app 运行期已经启动过自动历史补载。 */
-export function markSessionAutomaticHistoryLoadStarted(sessionId: string): void {
+/** 记录当前缓存消息窗口已经成功推进过一次自动历史补载。 */
+export function markSessionAutomaticHistoryLoadCompleted(sessionId: string): void {
   const previous = store.get(sessionId);
-  store.set(sessionId, { ...previous, automaticHistoryLoadStarted: true });
+  store.set(sessionId, { ...previous, automaticHistoryLoadCompleted: true });
+}
+
+/** 缓存消息窗口被整体重建时,恢复该会话的自动补载预算并保留滚动快照。 */
+export function resetSessionAutomaticHistoryLoadCompletion(sessionId: string): void {
+  const previous = store.get(sessionId);
+  if (!previous?.automaticHistoryLoadCompleted) return;
+  const next = { ...previous };
+  delete next.automaticHistoryLoadCompleted;
+  if (next.scroll) store.set(sessionId, next);
+  else store.delete(sessionId);
 }
 
 /**
  * 为一次新的 MessageStream mount 恢复自动补载计数。
- * 旧 mount 已经启动过补载时直接返回上限,避免切走再切回后重启同一轮补载。
+ * 当前缓存窗口已经完成过补载时直接返回上限,避免切走再切回后重启同一轮补载。
  */
 export function restoreSessionAutomaticHistoryLoadAttempts(
   sessionId: string | null | undefined,
   maxAttempts: number,
 ): number {
   if (!sessionId) return 0;
-  return store.get(sessionId)?.automaticHistoryLoadStarted ? maxAttempts : 0;
+  return store.get(sessionId)?.automaticHistoryLoadCompleted ? maxAttempts : 0;
 }
 
 export function clearSessionScroll(sessionId: string): void {

--- a/apps/desktop/src/renderer/lib/sessionScrollStore.ts
+++ b/apps/desktop/src/renderer/lib/sessionScrollStore.ts
@@ -33,14 +33,46 @@ export interface SessionScrollSnapshot {
   anchoredForwardCount?: number;
 }
 
-const store = new Map<string, SessionScrollSnapshot>();
+interface SessionViewMemory {
+  scroll?: SessionScrollSnapshot;
+  /**
+   * 本次 app 运行期内,该会话是否已经启动过一轮自动历史补载。
+   *
+   * 这里只记 started,不记精确轮数:一次 mount 可能只拉 1 页就撑满视口,
+   * 离开时消息缓存又会裁掉刚补进来的前缀。若下次 mount 从 1/5 继续算,
+   * 仍会把同一页历史重新拉一遍。重挂载时应把自动预算整体视作已用完;
+   * 用户明确上滑 / 翻页的加载路径不读取这个标记,仍可继续加载。
+   */
+  automaticHistoryLoadStarted?: true;
+}
+
+const store = new Map<string, SessionViewMemory>();
 
 export function saveSessionScroll(sessionId: string, snapshot: SessionScrollSnapshot): void {
-  store.set(sessionId, snapshot);
+  const previous = store.get(sessionId);
+  store.set(sessionId, { ...previous, scroll: snapshot });
 }
 
 export function readSessionScroll(sessionId: string): SessionScrollSnapshot | undefined {
-  return store.get(sessionId);
+  return store.get(sessionId)?.scroll;
+}
+
+/** 记录该会话在当前 app 运行期已经启动过自动历史补载。 */
+export function markSessionAutomaticHistoryLoadStarted(sessionId: string): void {
+  const previous = store.get(sessionId);
+  store.set(sessionId, { ...previous, automaticHistoryLoadStarted: true });
+}
+
+/**
+ * 为一次新的 MessageStream mount 恢复自动补载计数。
+ * 旧 mount 已经启动过补载时直接返回上限,避免切走再切回后重启同一轮补载。
+ */
+export function restoreSessionAutomaticHistoryLoadAttempts(
+  sessionId: string | null | undefined,
+  maxAttempts: number,
+): number {
+  if (!sessionId) return 0;
+  return store.get(sessionId)?.automaticHistoryLoadStarted ? maxAttempts : 0;
 }
 
 export function clearSessionScroll(sessionId: string): void {


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复协同任务中切走再切回 Worker 后重复自动加载同一批历史消息的问题。

`MessageStream` 现在会在现有的会话级视图内存中记录“该会话已经启动过自动历史补载”。同一次挂载仍保留原有的视口填充预算和提问导航条补页预算；重新挂载时只耗尽自动数据库补载预算，用户主动上滑或翻页仍可继续加载更早历史。

同时新增 A → B → A 切换回归测试，覆盖 Worker 隔离、滚动快照保存、两条自动补载入口和用户主动加载路径。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：用户反馈的协同 Worker 历史重复加载问题
- 本 PR 包含：Desktop `MessageStream` 自动历史补载预算的会话级记忆，以及对应回归测试
- 明确不包含：数据库分页协议、消息缓存裁剪策略、Worker 持久化或视觉样式调整
- 用户可见变化：切走再切回已经自动补过历史的 Worker 时，不再重复自动加载同一批历史；主动上滑加载保持不变
- 是否存在 breaking change：无

### UI 变化

无截图变化：本 PR 不修改布局、样式、动效或文案，只修正重复自动补载行为。

- 引用的设计规范：`docs/design-rules/DESIGN.md` §14.4「Session-loading wordmark sheen」；保留既有会话切换加载视觉及其适用范围，本 PR 只抑制重挂载后的重复历史分页请求。

## 怎么验证的

### 自动验证

```text
bash /Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh /Users/dash/Code/Cindy/cindy-fix-worker-history-reload
结果：GATE_EXIT=0，全仓 pnpm test:unit 通过

pnpm --filter desktop test sessionScrollStore.test.ts viewportFillDetect.test.ts messageNavRailModel.test.ts messageStreamRenderWindowIntegration.test.ts
结果：135 passed，1 个默认关闭的 50k 压测 skipped

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --filter desktop exec eslint src/renderer/components/chat/MessageStream.tsx src/renderer/lib/sessionScrollStore.ts src/renderer/__tests__/sessionScrollStore.test.ts
结果：通过

pnpm check:dco
结果：1 个提交签名检查通过
```

### 手工验证

未执行。

### 未执行的验证

未启动 Desktop 实机执行协同 Worker A → B → A 切换；该路径由新增的会话级回归测试覆盖。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop 中复用 `MessageStream` 的会话视图，主要修复协同 Worker 面板重挂载场景
- 回滚 / 降级方式：回滚本提交即可恢复原有每次挂载重新计算自动补载预算的行为；不涉及数据库、协议或持久数据迁移

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
