### PR TITLE
fix(maker-core): 热切 Claude 模型前先扩 availableModels 白名单

### DIFF
--- a/apps/desktop/src/main/maker-host/index.ts
+++ b/apps/desktop/src/main/maker-host/index.ts
@@ -896,6 +896,8 @@ export function getMaker(): Maker {
       capabilityAdditions: {
         availableModels: deriveAvailableModels(getDesktopSelectableCatalog(), 'claude-code'),
       },
+      resolveVerifiedContextWindow: (providerId, modelId) =>
+        resolveVerifiedContextWindow(getDesktopSelectableCatalog(), 'claude-code', providerId, modelId),
       // SDK PreToolUse / PostToolUse 等 in-process hook 注入点。host 自己定义 hook
       // 实现 (./claude-hooks/*.ts), maker-core 不感知具体逻辑。
       //

--- a/packages/maker-core/src/agents/claude-code/__tests__/rewind-runtime-settings.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/rewind-runtime-settings.test.ts
@@ -272,6 +272,8 @@ describe('ClaudeCodeAgent runtime settings during rewind window', () => {
       defaultEffort: 'high',
     });
 
+    expect(handle.getUsageSnapshot().contextWindow).toBe(1_000_000);
+
     await handle.setModel?.('x-ai/grok-4.6');
 
     expect(firstQuery.applyFlagSettings).toHaveBeenCalledWith({
@@ -281,6 +283,7 @@ describe('ClaudeCodeAgent runtime settings during rewind window', () => {
     expect(firstQuery.applyFlagSettings.mock.invocationCallOrder[0]).toBeLessThan(
       firstQuery.setModel.mock.invocationCallOrder[0],
     );
+    expect(handle.getUsageSnapshot().contextWindow).toBe(256_000);
 
     await handle.close();
   });

--- a/packages/maker-core/src/agents/claude-code/__tests__/rewind-runtime-settings.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/rewind-runtime-settings.test.ts
@@ -333,6 +333,49 @@ describe('ClaudeCodeAgent runtime settings during rewind window', () => {
     await handle.close();
   });
 
+  it('does not apply the flattened catalog window when the host resolver returns null', async () => {
+    const configDir = await makeTempDir();
+    process.env.CLAUDE_CONFIG_DIR = configDir;
+    process.env.XDT_CC_SSE_IDLE_TIMEOUT_MS = '0';
+    const workingDir = await makeTempDir();
+    const firstQuery = createFakeQuery();
+    sdkMock.query.mockReturnValue(firstQuery);
+
+    const resolveVerifiedContextWindow = vi.fn(() => null);
+
+    const agent = new ClaudeCodeAgent({
+      ...createDeps(),
+      capabilityAdditions: {
+        availableModels: [
+          ...TEST_MODELS,
+          {
+            id: 'shared-model',
+            displayName: 'Shared',
+            contextWindow: 256_000,
+            efforts: ['low', 'medium', 'high'],
+            defaultEffort: 'high',
+          },
+        ],
+      },
+      resolveVerifiedContextWindow,
+    });
+    const handle = await agent.startSession({
+      sessionId: 'session-unverified-window',
+      model: 'claude-opus-4-6',
+      workingDir,
+      permissionMode: 'acceptEdits',
+    });
+
+    expect(handle.getUsageSnapshot().contextWindow).toBe(0);
+
+    await handle.setModel?.('shared-model', { providerId: 'xd' });
+
+    expect(resolveVerifiedContextWindow).toHaveBeenCalledWith('xd', 'shared-model');
+    expect(handle.getUsageSnapshot().contextWindow).toBe(0);
+
+    await handle.close();
+  });
+
   it('passes max through when changing effort in a live Sonnet 5 session', async () => {
     const { handle, firstQuery } = await startRewindableSession();
 

--- a/packages/maker-core/src/agents/claude-code/__tests__/rewind-runtime-settings.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/rewind-runtime-settings.test.ts
@@ -288,6 +288,51 @@ describe('ClaudeCodeAgent runtime settings during rewind window', () => {
     await handle.close();
   });
 
+  it('uses the session provider route when the same model id has different windows', async () => {
+    const configDir = await makeTempDir();
+    process.env.CLAUDE_CONFIG_DIR = configDir;
+    process.env.XDT_CC_SSE_IDLE_TIMEOUT_MS = '0';
+    const workingDir = await makeTempDir();
+    const firstQuery = createFakeQuery();
+    sdkMock.query.mockReturnValue(firstQuery);
+
+    const resolveVerifiedContextWindow = vi.fn((providerId: string | null | undefined, modelId: string) => {
+      if (modelId !== 'shared-model') return null;
+      if (providerId === 'xd') return 256_000;
+      return 1_000_000;
+    });
+
+    const agent = new ClaudeCodeAgent({
+      ...createDeps(),
+      capabilityAdditions: {
+        availableModels: [
+          ...TEST_MODELS,
+          {
+            id: 'shared-model',
+            displayName: 'Shared',
+            contextWindow: 1_000_000,
+            efforts: ['low', 'medium', 'high'],
+            defaultEffort: 'high',
+          },
+        ],
+      },
+      resolveVerifiedContextWindow,
+    });
+    const handle = await agent.startSession({
+      sessionId: 'session-provider-window',
+      model: 'claude-opus-4-6',
+      workingDir,
+      permissionMode: 'acceptEdits',
+    });
+
+    await handle.setModel?.('shared-model', { providerId: 'xd' });
+
+    expect(resolveVerifiedContextWindow).toHaveBeenCalledWith('xd', 'shared-model');
+    expect(handle.getUsageSnapshot().contextWindow).toBe(256_000);
+
+    await handle.close();
+  });
+
   it('passes max through when changing effort in a live Sonnet 5 session', async () => {
     const { handle, firstQuery } = await startRewindableSession();
 

--- a/packages/maker-core/src/agents/claude-code/__tests__/rewind-runtime-settings.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/rewind-runtime-settings.test.ts
@@ -250,7 +250,37 @@ describe('ClaudeCodeAgent runtime settings during rewind window', () => {
     ]);
 
     await handle.setModel?.('claude-sonnet-5');
+    expect(firstQuery.applyFlagSettings).toHaveBeenCalledWith({
+      availableModels: ['claude-opus-4-6[1m]', 'claude-sonnet-5'],
+    });
     expect(firstQuery.setModel).toHaveBeenCalledWith('claude-sonnet-5');
+    expect(firstQuery.applyFlagSettings.mock.invocationCallOrder[0]).toBeLessThan(
+      firstQuery.setModel.mock.invocationCallOrder[0],
+    );
+
+    await handle.close();
+  });
+
+  it('widens the live Claude allowlist before switching to a later-loaded gateway model', async () => {
+    const { handle, firstQuery, agent } = await startRewindableSession();
+
+    agent.capabilities.availableModels.push({
+      id: 'x-ai/grok-4.6',
+      displayName: 'Grok 4.6',
+      contextWindow: 256_000,
+      efforts: ['low', 'medium', 'high'],
+      defaultEffort: 'high',
+    });
+
+    await handle.setModel?.('x-ai/grok-4.6');
+
+    expect(firstQuery.applyFlagSettings).toHaveBeenCalledWith({
+      availableModels: ['claude-opus-4-6[1m]', 'claude-sonnet-5', 'x-ai/grok-4.6'],
+    });
+    expect(firstQuery.setModel).toHaveBeenCalledWith('x-ai/grok-4.6');
+    expect(firstQuery.applyFlagSettings.mock.invocationCallOrder[0]).toBeLessThan(
+      firstQuery.setModel.mock.invocationCallOrder[0],
+    );
 
     await handle.close();
   });
@@ -268,11 +298,11 @@ describe('ClaudeCodeAgent runtime settings during rewind window', () => {
 
   it('falls back to the model-supported xhigh when an older runtime rejects max', async () => {
     const { handle, firstQuery } = await startRewindableSession();
+
+    await handle.setModel?.('claude-sonnet-5');
     firstQuery.applyFlagSettings
       .mockRejectedValueOnce(new Error('invalid effortLevel: max'))
       .mockResolvedValueOnce(undefined);
-
-    await handle.setModel?.('claude-sonnet-5');
     await expect(handle.setEffort?.('max')).resolves.toBeUndefined();
 
     expect(firstQuery.applyFlagSettings.mock.calls.slice(-2)).toEqual([
@@ -423,7 +453,13 @@ describe('ClaudeCodeAgent runtime settings during rewind window', () => {
     const rebuildArgs = sdkMock.query.mock.calls[1]?.[0] as { options: Record<string, unknown> };
     expect(rebuildArgs.options.model).toBe('claude-opus-4-6[1m]');
     // sonnet-5 fixture 窗口 500K < 1M → wire 串不带 [1m](窗口驱动规则)。
+    expect(secondQuery.applyFlagSettings).toHaveBeenCalledWith({
+      availableModels: ['claude-opus-4-6[1m]', 'claude-sonnet-5'],
+    });
     expect(secondQuery.setModel).toHaveBeenCalledWith('claude-sonnet-5');
+    expect(secondQuery.applyFlagSettings.mock.invocationCallOrder[0]).toBeLessThan(
+      secondQuery.setModel.mock.invocationCallOrder[0],
+    );
 
     await handle.close();
   });

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -1997,6 +1997,16 @@ export class ClaudeCodeAgent extends BaseAgent {
       : {};
     const showThinkingSummaries = opts.displayReasoning === 'summarized';
 
+    // Claude Code 把 availableModels 当成组织白名单。目录 + 当前/目标模型都走同一
+    // 个 catalog-id → wire-string 映射,启动与热切共用,后加载的网关模型(如
+    // x-ai/grok-4.6)也能进名单。
+    const currentAvailableSdkModels = (selectedModel: string): string[] => [
+      ...new Set([
+        ...this.capabilities.availableModels.map(({ id }) => sdkModelFor(id)),
+        sdkModelFor(selectedModel),
+      ]),
+    ];
+
     // SDK settings 对象 (优先级最高, 覆盖 user/project/local 文件层) — 本地分支
     // 和远端分支必须**保持一致** , 否则同 session setting 跨本地 / 远端表现不同
     // (eg. summarized reasoning UI 本地有 remote 没)。getter 让 memOverride /
@@ -2005,17 +2015,7 @@ export class ClaudeCodeAgent extends BaseAgent {
     const buildSettings = (): Settings => {
       const settings = buildClaudeFlagSettings({
         showThinkingSummaries,
-        // availableModels is the SDK's highest-priority allowlist. Convert the
-        // whole current catalog and the selected model through the one
-        // catalog-id → wire-string mapper so startup and live switches share
-        // the same [1m] and legacy conversion rules. Keep the selected model
-        // even when it is temporarily outside the catalog.
-        availableModels: [
-          ...new Set([
-            ...this.capabilities.availableModels.map(({ id }) => sdkModelFor(id)),
-            sdkModelFor(mutableModel),
-          ]),
-        ],
+        availableModels: currentAvailableSdkModels(mutableModel),
         // Do not carry the local manager's native-memory suppression across the
         // SSH boundary: the remote host retains its own Claude memory
         // configuration. Maker Memory on remote sessions is injected via the
@@ -4707,6 +4707,11 @@ export class ClaudeCodeAgent extends BaseAgent {
           replayed = true;
           const targetModel = mutableModel;
           try {
+            // 与 live setModel 同序:先扩白名单再切。buildQuery await 期间切到的
+            // 目录外模型,新 Query 的启动名单还是旧快照,直接 setModel 会撞组织限制。
+            await q.applyFlagSettings({
+              availableModels: currentAvailableSdkModels(targetModel),
+            });
             await q.setModel(sdkModelFor(targetModel));
             snapshot.model = targetModel;
             log.debug(`${label}: replayed setModel`, { model: targetModel });
@@ -5774,6 +5779,13 @@ export class ClaudeCodeAgent extends BaseAgent {
         const isControlBlocked = controlRequestsBlocked();
         log.debug('setModel', { from: mutableModel, to: newModel, sdk: sdkModel, controlRequestsBlocked: isControlBlocked });
         if (!isControlBlocked) {
+          // flag settings 只在 Query 创建时写入。热切若只调 setModel,Claude Code
+          // 仍按启动时的组织白名单校验,后加载的网关模型会报
+          // "restricted by your organization's settings"(2026-08-13)。applyFlagSettings
+          // 是 merge,先把当前目录 + 目标模型并进去再切。
+          await q.applyFlagSettings({
+            availableModels: currentAvailableSdkModels(newModel),
+          });
           await q.setModel(sdkModel);
         }
         const usedNativeAutoReview = usesNativeClaudeAutoReview();

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -2006,6 +2006,12 @@ export class ClaudeCodeAgent extends BaseAgent {
         sdkModelFor(selectedModel),
       ]),
     ];
+    const resolveModelContextWindow = (model: string): number | undefined => {
+      const descriptor = this.capabilities.availableModels.find((item) => item.id === model);
+      return descriptor && Number.isFinite(descriptor.contextWindow) && descriptor.contextWindow > 0
+        ? descriptor.contextWindow
+        : undefined;
+    };
 
     // SDK settings 对象 (优先级最高, 覆盖 user/project/local 文件层) — 本地分支
     // 和远端分支必须**保持一致** , 否则同 session setting 跨本地 / 远端表现不同
@@ -2167,16 +2173,13 @@ export class ClaudeCodeAgent extends BaseAgent {
     // 附加只读引用目录: 启动时取 opts.extraDirs 快照, setExtraDirs 覆盖, buildQuery
     // 每 turn 读最新值传给 SDK options.additionalDirectories — 即时生效。
     let mutableExtraDirs: string[] = Array.isArray(opts.extraDirs) ? [...opts.extraDirs] : [];
-    const modelContextWindows = new Map(
-      this.capabilities.availableModels.map((model) => [model.id, model.contextWindow] as const),
-    );
 
     // ── Usage tracker (Stage 2 B') ──────────────────────────────────────────
     // 单 session 共享的 mutable usage state. translator 通过 ctx 注入访问.
     // handle.getUsageSnapshot 也读它, 形成"SDK 原始 usage → tracker → status event / handle snapshot"
-    // 单一可信源.
+    // 单一可信源. 窗口跟白名单同一份实时目录,不冻启动快照。
     const usageTracker = new UsageTracker();
-    usageTracker.setContextWindow(modelContextWindows.get(mutableModel) ?? 0);
+    usageTracker.setContextWindow(resolveModelContextWindow(mutableModel) ?? 0);
 
     // ── 跨 turn 共享状态 ───────────────────────────────────────────────────
     let configuredResumeSessionId: string | undefined = opts.resumeSessionId;
@@ -4197,7 +4200,7 @@ export class ClaudeCodeAgent extends BaseAgent {
               turn: turnState,
               log,
               getModel: () => mutableModel,
-              getModelContextWindow: () => modelContextWindows.get(mutableModel),
+              getModelContextWindow: () => resolveModelContextWindow(mutableModel),
               getEffort: () => mutableEffort,
               getPermissionMode: () => mutablePermissionMode,
               getSdkSessionId: () => sdkSessionId,
@@ -5821,7 +5824,7 @@ export class ClaudeCodeAgent extends BaseAgent {
             });
           });
         }
-        const newContextWindow = modelContextWindows.get(mutableModel);
+        const newContextWindow = resolveModelContextWindow(mutableModel);
         if (newContextWindow === undefined) {
           // setContextWindow(0) 是 no-op —— tracker 会静默沿用旧模型窗口直到下一个
           // result 的 modelUsage 修正。UI 环 / auto-compact 期间按旧窗口算(偏乐观),

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -2007,6 +2007,11 @@ export class ClaudeCodeAgent extends BaseAgent {
       ]),
     ];
     const resolveModelContextWindow = (model: string): number | undefined => {
+      // 核实窗口按会话实际来源取,不查扁平 availableModels:同 id 多来源时首见
+      // 可能是另一条路由。host 未注入或目录有歧义时再退回扁平目录,保住无 host
+      // 路径和后加载模型的即时窗口。
+      const verified = this.deps.resolveVerifiedContextWindow?.(mutableProviderId, model);
+      if (typeof verified === 'number' && verified > 0) return verified;
       const descriptor = this.capabilities.availableModels.find((item) => item.id === model);
       return descriptor && Number.isFinite(descriptor.contextWindow) && descriptor.contextWindow > 0
         ? descriptor.contextWindow

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -2007,11 +2007,14 @@ export class ClaudeCodeAgent extends BaseAgent {
       ]),
     ];
     const resolveModelContextWindow = (model: string): number | undefined => {
-      // 核实窗口按会话实际来源取,不查扁平 availableModels:同 id 多来源时首见
-      // 可能是另一条路由。host 未注入或目录有歧义时再退回扁平目录,保住无 host
-      // 路径和后加载模型的即时窗口。
-      const verified = this.deps.resolveVerifiedContextWindow?.(mutableProviderId, model);
-      if (typeof verified === 'number' && verified > 0) return verified;
+      // 核实窗口按会话实际来源取。host 注入了 resolver 时,null = 不要收敛
+      // (同 id 多来源 / 未核实兜底),采信 SDK 上报,不能再拿扁平目录首见值覆盖。
+      // 只有未注入 resolver 的路径(测试 / 无 host)才退回扁平目录。
+      const resolveVerified = this.deps.resolveVerifiedContextWindow;
+      if (resolveVerified) {
+        const verified = resolveVerified(mutableProviderId, model);
+        return typeof verified === 'number' && verified > 0 ? verified : undefined;
+      }
       const descriptor = this.capabilities.availableModels.find((item) => item.id === model);
       return descriptor && Number.isFinite(descriptor.contextWindow) && descriptor.contextWindow > 0
         ? descriptor.contextWindow


### PR DESCRIPTION
## 这次改了什么

### 摘要

已经在跑的 Claude Code 任务，中途切到后加载的网关模型（例如 `x-ai/grok-4.6`）会失败，toast 只显示「设置切换失败，未生效」。底层报错是 Claude Code 的 `restricted by your organization's settings`。

原因不是 Anthropic / 公司后台禁了这个模型。Cindy 启动任务时会把当时的模型目录写成 Claude Code 最高优先级的 `availableModels`；热切却只调 `setModel`，不会把新模型补进这份名单。选择器已经能显示网关 Grok，底下进程还拿启动时的旧名单校验，所以直接拒。先切第一方 `xai/grok-*` 再切回来之所以能好，是因为跨凭证形态会重建进程，名单才赶上目录。

这次让 live `setModel` 和 rewind / rebuild 重放都先 `applyFlagSettings` 扩白名单，再切模型。选择器能点的后加载模型，热切不必再绕去重建进程。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：Claude Code 热切与 rewind 重放时，把当前目录 + 目标模型 merge 进 `availableModels`
- 明确不包含：toast 文案改写；跨引擎切换；Codex / Pi 热切
- 用户可见变化：已启动的 Claude Code 任务可以直接切到后加载的网关模型，不再先绕第一方 Grok
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter @cindy/maker-core exec vitest run \
  src/agents/claude-code/__tests__/rewind-runtime-settings.test.ts \
  src/agents/claude-code/__tests__/flag-settings.test.ts
结果：44 passed

/Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh \
  /Users/dash/Code/Cindy/cindy-cc-setmodel-available-models
结果：GATE_EXIT=0
```

### 手工验证

开发版 worktree `/Users/dash/Code/Cindy/cindy-cc-setmodel-available-models`（pid 26330，`desktop:whoami` MATCH）。在已运行的 Claude Code 任务里直接切到网关 `x-ai/grok-4.6`，不再先绕第一方 Grok，切换成功。

### 未执行的验证

无。`@cindy/maker-core` 没有独立 `typecheck` script；`tsc --noEmit` 的失败都在既有测试文件里，与本次 diff 无关。

## 风险

### 风险分类

- [x] 其他：Claude Code 热切多一次 `applyFlagSettings` merge

### 影响与回滚

- 影响范围：本地 / 远端 Claude Code 会话的 live `setModel`，以及 rewind / rebuild 后的模型重放
- 回滚 / 降级方式：回退本 PR。失败时仍会抛错，不会静默切到错误模型
- 存量插件影响：无

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
