### PR TITLE
fix(codex): preserve assistant message boundaries

### DIFF
--- a/apps/desktop/src/main/__tests__/messagePersistBroadcaster.test.ts
+++ b/apps/desktop/src/main/__tests__/messagePersistBroadcaster.test.ts
@@ -2114,9 +2114,105 @@ describe('stale-idle assistant late final identity', () => {
       .filter((c) => (c[1] as { role?: string }).role === 'assistant');
     expect(assistantCreates).toHaveLength(2);
   });
+
+  it('keeps distinct Codex items separate within the same SDK request', async () => {
+    const meta = { requestId: 'req-shared', uuid: 'assistant-shared' };
+    const commentaryId = onAssistantTextEvent(
+      SESSION,
+      {
+        text: 'same text',
+        isFinal: false,
+        agentMessageId: 'msg-commentary',
+      },
+      meta,
+    );
+    sealAssistantBlockForLateFinal(SESSION, null);
+    consumeLastAssistantPersistId(SESSION);
+    consumeLastTopLevelAssistantPersistId(SESSION);
+    resetTurnPersistState(SESSION);
+
+    const finalId = onAssistantTextEvent(
+      SESSION,
+      {
+        text: 'same text',
+        isFinal: true,
+        isFullText: true,
+        agentMessageId: 'msg-final',
+      },
+      meta,
+    );
+    expect(finalId).not.toBe(commentaryId);
+    await flushWrites();
+
+    const assistantCreates = (createMessage as unknown as { mock: { calls: unknown[][] } }).mock.calls
+      .filter((c) => (c[1] as { role?: string }).role === 'assistant');
+    expect(assistantCreates).toHaveLength(2);
+  });
 });
 
 describe('streamed assistant final calibration', () => {
+  it('persists commentary and final_answer as separate rows when Codex item ids change', async () => {
+    const commentaryId = onAssistantTextEvent(
+      SESSION,
+      { text: 'Execution preview', isFinal: false, agentMessageId: 'msg-commentary' },
+      null,
+    );
+    expect(
+      onAssistantTextEvent(
+        SESSION,
+        {
+          text: 'Execution preview',
+          isFinal: true,
+          isFullText: true,
+          agentMessageId: 'msg-commentary',
+        },
+        null,
+      ),
+    ).toBe(commentaryId);
+
+    const finalId = onAssistantTextEvent(
+      SESSION,
+      {
+        text: 'Please confirm.',
+        isFinal: true,
+        isFullText: true,
+        agentMessageId: 'msg-final',
+      },
+      null,
+    );
+    expect(finalId).not.toBe(commentaryId);
+
+    await flushWrites();
+    const assistantCreates = vi
+      .mocked(createMessage)
+      .mock.calls
+      .filter(([, message]) => message.role === 'assistant')
+      .map(([, message]) => ({ clientId: message.clientId, content: message.content }));
+    expect(assistantCreates).toEqual([
+      { clientId: commentaryId, content: 'Execution preview' },
+      { clientId: finalId, content: 'Please confirm.' },
+    ]);
+  });
+
+  it('does not deduplicate equal text from distinct Codex message ids', async () => {
+    const firstId = onAssistantTextEvent(
+      SESSION,
+      { text: 'Ready.', isFinal: true, isFullText: true, agentMessageId: 'msg-a' },
+      null,
+    );
+    const secondId = onAssistantTextEvent(
+      SESSION,
+      { text: 'Ready.', isFinal: true, isFullText: true, agentMessageId: 'msg-b' },
+      null,
+    );
+
+    expect(secondId).not.toBe(firstId);
+    await flushWrites();
+    expect(
+      vi.mocked(createMessage).mock.calls.filter(([, message]) => message.role === 'assistant'),
+    ).toHaveLength(2);
+  });
+
   it('persists the authoritative final text even when it is shorter than accumulated deltas', async () => {
     const persistId = onAssistantTextEvent(
       SESSION,

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -4402,7 +4402,12 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
         }
         persistId = onAssistantTextEvent(
           session.id,
-          event.data as { text?: unknown; isFinal?: unknown },
+          event.data as {
+            text?: unknown;
+            isFinal?: unknown;
+            isFullText?: unknown;
+            agentMessageId?: unknown;
+          },
           eventAgentMeta,
         );
       } else if (event.type === 'tool_use') {

--- a/apps/desktop/src/main/messagePersistBroadcaster.ts
+++ b/apps/desktop/src/main/messagePersistBroadcaster.ts
@@ -74,6 +74,8 @@ const log = createLogger('messagePersistBroadcaster');
 interface AssistantBlock {
   persistId: string;
   text: string;
+  /** Provider message identity; a changed identity is an assistant block boundary. */
+  agentMessageId?: string;
   agentMeta: AgentMeta | null;
   createdAt: number;
 }
@@ -82,6 +84,7 @@ const assistantBlocks = new Map<string, AssistantBlock>();
 interface SealedAssistantLateFinalCandidate {
   persistId: string;
   text: string;
+  agentMessageId?: string;
   requestId?: string;
   uuid?: string;
 }
@@ -96,7 +99,15 @@ const sealedAssistantLateFinalBySession = new Map<string, SealedAssistantLateFin
 function matchesSealedAssistantIdentity(
   candidate: SealedAssistantLateFinalCandidate,
   agentMeta: AgentMeta | null,
+  agentMessageId: string | undefined,
 ): boolean {
+  if (
+    candidate.agentMessageId !== undefined &&
+    agentMessageId !== undefined &&
+    candidate.agentMessageId !== agentMessageId
+  ) {
+    return false;
+  }
   if (!agentMeta) return false;
   if (candidate.requestId !== undefined && agentMeta.requestId !== undefined) {
     return candidate.requestId === agentMeta.requestId;
@@ -280,14 +291,23 @@ export function setLastAssistantTranscriptUuid(sessionId: string, uuid: string |
  * 第二行、renderer DUP-SKIP 只挡显示不挡库 → 重开会话 assistant 翻倍(正是本 MR 要消灭
  * 的重复行)。
  *
- * 只去重"相邻且内容完全相同"的 assistant:任何其它消息(tool_use / tool_result / thinking /
- * ask_user / plan_review)入队都会刷新这条记录 → role 不再是 assistant,从而"中间夹了别的
- * 消息"的两条相同文本不会被误删(与 renderer messages[last] 语义 1:1,避免误吞合法重复回复)。
+ * 只去重"相邻、内容相同且 provider item 身份相同"的 assistant:任何其它消息
+ * (tool_use / tool_result / thinking / ask_user / plan_review)入队都会刷新这条记录；不同
+ * agentMessageId 即使文本相同也必须保留为两条消息。
  */
-const lastPersistedMsgBySession = new Map<string, { role: string; text: string; persistId: string }>();
+const lastPersistedMsgBySession = new Map<
+  string,
+  { role: string; text: string; persistId: string; agentMessageId?: string }
+>();
 
-function notePersistedMessage(sessionId: string, role: string, persistId: string, text = ''): void {
-  lastPersistedMsgBySession.set(sessionId, { role, text, persistId });
+function notePersistedMessage(
+  sessionId: string,
+  role: string,
+  persistId: string,
+  text = '',
+  agentMessageId?: string,
+): void {
+  lastPersistedMsgBySession.set(sessionId, { role, text, persistId, agentMessageId });
 }
 
 /**
@@ -554,6 +574,7 @@ function enqueuePersistAssistant(
   content: string,
   agentMeta: AgentMeta | null,
   createdAt: number,
+  agentMessageId?: string,
 ): void {
   noteAssistantTranscriptUuid(sessionId, agentMeta);
   enqueueVisibleDbMessage(`assistant:${sessionId}:${clientId}`, sessionId, {
@@ -563,7 +584,7 @@ function enqueuePersistAssistant(
     agentMeta: agentMeta ?? null,
     createdAt,
   });
-  notePersistedMessage(sessionId, 'assistant', clientId, content);
+  notePersistedMessage(sessionId, 'assistant', clientId, content, agentMessageId);
   lastAssistantPersistIdBySession.set(sessionId, clientId);
   if (
     isTopLevelTitleAssistant(
@@ -1775,12 +1796,25 @@ export function resetTurnPersistState(sessionId: string): void {
  */
 export function onAssistantTextEvent(
   sessionId: string,
-  data: { text?: unknown; isFinal?: unknown; isFullText?: unknown },
+  data: { text?: unknown; isFinal?: unknown; isFullText?: unknown; agentMessageId?: unknown },
   agentMeta: AgentMeta | null,
 ): string | undefined {
   const rawText = typeof data.text === 'string' ? data.text : '';
   const isFinal = data.isFinal === true;
   const isFullText = data.isFullText === true;
+  const agentMessageId =
+    typeof data.agentMessageId === 'string' && data.agentMessageId
+      ? data.agentMessageId
+      : undefined;
+
+  const activeBlock = assistantBlocks.get(sessionId);
+  if (
+    activeBlock?.agentMessageId &&
+    agentMessageId &&
+    activeBlock.agentMessageId !== agentMessageId
+  ) {
+    flushAssistantBlock(sessionId);
+  }
 
   if (isFinal) {
     const visible = stripInternalWebCitations(rawText);
@@ -1788,7 +1822,7 @@ export function onAssistantTextEvent(
     if (
       lateFinalCandidate &&
       visible.length > 0 &&
-      matchesSealedAssistantIdentity(lateFinalCandidate, agentMeta) &&
+      matchesSealedAssistantIdentity(lateFinalCandidate, agentMeta, agentMessageId) &&
       (isFullText ||
         visible === lateFinalCandidate.text ||
         visible.startsWith(lateFinalCandidate.text))
@@ -1841,11 +1875,23 @@ export function onAssistantTextEvent(
       // persistId、不再 create,把重复行挡在 main 落库层。中间夹过别的消息则 last.role
       // 不是 assistant,不会误删合法的相同文本回复。
       const last = lastPersistedMsgBySession.get(sessionId);
-      if (last && last.role === 'assistant' && last.text === visible) {
+      if (
+        last &&
+        last.role === 'assistant' &&
+        last.text === visible &&
+        (!agentMessageId || last.agentMessageId === agentMessageId)
+      ) {
         return last.persistId;
       }
       const persistId = createId();
-      enqueuePersistAssistant(sessionId, persistId, visible, agentMeta, Date.now());
+      enqueuePersistAssistant(
+        sessionId,
+        persistId,
+        visible,
+        agentMeta,
+        Date.now(),
+        agentMessageId,
+      );
       return persistId;
     }
     return undefined;
@@ -1854,7 +1900,13 @@ export function onAssistantTextEvent(
   // delta: accumulate the raw snapshot; strip only the completed block.
   let block = assistantBlocks.get(sessionId);
   if (!block) {
-    block = { persistId: createId(), text: rawText, agentMeta, createdAt: Date.now() };
+    block = {
+      persistId: createId(),
+      text: rawText,
+      agentMessageId,
+      agentMeta,
+      createdAt: Date.now(),
+    };
     assistantBlocks.set(sessionId, block);
   } else {
     block.text += rawText;
@@ -1881,7 +1933,12 @@ export function flushAssistantBlock(
 function flushAssistantBlockInternal(
   sessionId: string,
   agentMetaFallback: AgentMeta | null,
-): { persistId: string; text: string; agentMeta: AgentMeta | null } | undefined {
+): {
+  persistId: string;
+  text: string;
+  agentMessageId?: string;
+  agentMeta: AgentMeta | null;
+} | undefined {
   const block = assistantBlocks.get(sessionId);
   if (!block) return undefined;
   assistantBlocks.delete(sessionId);
@@ -1890,8 +1947,20 @@ function flushAssistantBlockInternal(
   // 三级兜底,对齐 renderer 老逻辑:本 block 自带 meta → 边界事件 meta(tool_use/done
   // 同属或携带这条 assistant 的 meta)→ 会话最近一次非空 meta(interaction 边界靠这级)。
   const meta = block.agentMeta ?? agentMetaFallback ?? lastAgentMetaBySession.get(sessionId) ?? null;
-  enqueuePersistAssistant(sessionId, block.persistId, visible, meta, block.createdAt);
-  return { persistId: block.persistId, text: visible, agentMeta: meta };
+  enqueuePersistAssistant(
+    sessionId,
+    block.persistId,
+    visible,
+    meta,
+    block.createdAt,
+    block.agentMessageId,
+  );
+  return {
+    persistId: block.persistId,
+    text: visible,
+    ...(block.agentMessageId ? { agentMessageId: block.agentMessageId } : {}),
+    agentMeta: meta,
+  };
 }
 
 /**
@@ -1912,6 +1981,7 @@ export function sealAssistantBlockForLateFinal(
   sealedAssistantLateFinalBySession.set(sessionId, {
     persistId: flushed.persistId,
     text: flushed.text,
+    ...(flushed.agentMessageId ? { agentMessageId: flushed.agentMessageId } : {}),
     ...(requestId ? { requestId } : {}),
     ...(uuid ? { uuid } : {}),
   });

--- a/apps/desktop/src/renderer/__tests__/makerChatStoreTextDeltaBatching.test.ts
+++ b/apps/desktop/src/renderer/__tests__/makerChatStoreTextDeltaBatching.test.ts
@@ -384,7 +384,11 @@ function installElectronBridge(): void {
   };
 }
 
-function emitTextDelta(text: string, sessionId = SESSION_ID): void {
+function emitTextDelta(
+  text: string,
+  sessionId = SESSION_ID,
+  persistId = 'assistant-1',
+): void {
   onEvent?.({
     sessionId,
     event: {
@@ -392,7 +396,7 @@ function emitTextDelta(text: string, sessionId = SESSION_ID): void {
       source: 'claude-code',
       data: { text, isFinal: false },
     },
-    persistId: 'assistant-1',
+    persistId,
   });
 }
 
@@ -1643,6 +1647,61 @@ describe('makerChatStore text delta batching', () => {
         clientId: 'assistant-1',
         role: 'assistant',
         content: 'Hello wonderful',
+      }),
+    ]);
+  });
+
+  it('keeps commentary when a distinct Codex final_answer item follows it', () => {
+    emitTextDelta('Execution preview');
+
+    onEvent?.({
+      sessionId: SESSION_ID,
+      event: {
+        type: 'text',
+        source: 'codex',
+        data: {
+          text: 'Please confirm.',
+          isFinal: true,
+          isFullText: true,
+          agentMessageId: 'msg-final',
+          phase: 'final_answer',
+        },
+      },
+      persistId: 'assistant-2',
+    });
+
+    vi.advanceTimersByTime(32);
+
+    expect(makerChatStore.getSnapshot(SESSION_ID).messages).toEqual([
+      expect.objectContaining({
+        clientId: 'assistant-1',
+        content: 'Execution preview',
+        isStreaming: false,
+      }),
+      expect.objectContaining({
+        clientId: 'assistant-2',
+        content: 'Please confirm.',
+        isStreaming: false,
+      }),
+    ]);
+  });
+
+  it('flushes batched deltas when the assistant persist id changes', () => {
+    emitTextDelta('Execution preview', SESSION_ID, 'assistant-1');
+    emitTextDelta('Please confirm.', SESSION_ID, 'assistant-2');
+
+    vi.advanceTimersByTime(32);
+
+    expect(makerChatStore.getSnapshot(SESSION_ID).messages).toEqual([
+      expect.objectContaining({
+        clientId: 'assistant-1',
+        content: 'Execution preview',
+        isStreaming: false,
+      }),
+      expect.objectContaining({
+        clientId: 'assistant-2',
+        content: 'Please confirm.',
+        isStreaming: true,
       }),
     ]);
   });

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -4982,14 +4982,29 @@ export function handleStreamEvent(
         isFullText?: boolean;
       };
 
+      // Main assigns a fresh persistId when the provider starts a distinct assistant item.
+      // Seal the preceding bubble before applying the new item's deltas/full-text calibration.
+      const itemBoundary = Boolean(
+        event.persistId &&
+        state.streamingClientId &&
+        event.persistId !== state.streamingClientId,
+      );
+      const textState = itemBoundary ? finalizeStreamingInState(state) : state;
+
       if (isFinal) {
         // Confirmation of streamed text, or a non-streaming final burst.
-        if (!state.streamingClientId && text) {
+        if (!textState.streamingClientId && text) {
           // Guard: if the last message is an assistant with identical content,
           // this is a duplicate isFinal event from the SDK — skip it.
-          const last = state.messages[state.messages.length - 1];
-          if (last && last.role === 'assistant' && last.content === text && !last.isStreaming) {
-            return state;
+          const last = textState.messages[textState.messages.length - 1];
+          if (
+            last &&
+            last.role === 'assistant' &&
+            last.content === text &&
+            !last.isStreaming &&
+            (!event.persistId || last.clientId === event.persistId)
+          ) {
+            return textState;
           }
 
           // F1-a: clientId 用 main 下发的 persistId(落库由 main 单点做,见
@@ -4998,10 +5013,10 @@ export function handleStreamEvent(
           const clientId = event.persistId ?? crypto.randomUUID();
 
           return {
-            ...state,
-            lastAgentMeta: incomingMeta ?? state.lastAgentMeta,
+            ...textState,
+            lastAgentMeta: incomingMeta ?? textState.lastAgentMeta,
             messages: [
-              ...state.messages,
+              ...textState.messages,
               {
                 clientId,
                 role: 'assistant',
@@ -5024,18 +5039,21 @@ export function handleStreamEvent(
           assistantMetaFields.parentToolUseId !== undefined ||
           assistantMetaFields.turnCompleted === true;
         const shouldCalibrateText = Boolean(
-          isFullText === true && text && state.streamingClientId && text !== state.streamingText,
+          isFullText === true &&
+          text &&
+          textState.streamingClientId &&
+          text !== textState.streamingText,
         );
-        if (!incomingMeta && !hasAssistantFields && !shouldCalibrateText) return state;
+        if (!incomingMeta && !hasAssistantFields && !shouldCalibrateText) return textState;
         return {
-          ...state,
+          ...textState,
           ...(shouldCalibrateText ? { streamingText: text } : {}),
           ...(incomingMeta ? { lastAgentMeta: incomingMeta } : {}),
-          ...((hasAssistantFields || shouldCalibrateText) && state.streamingClientId
+          ...((hasAssistantFields || shouldCalibrateText) && textState.streamingClientId
             ? {
                 messages: replaceMessage(
-                  state.messages,
-                  (m) => m.clientId === state.streamingClientId,
+                  textState.messages,
+                  (m) => m.clientId === textState.streamingClientId,
                   (m) => ({
                     ...m,
                     ...(shouldCalibrateText ? { content: text } : {}),
@@ -5048,16 +5066,16 @@ export function handleStreamEvent(
       }
 
       // Delta update
-      if (!state.streamingClientId) {
+      if (!textState.streamingClientId) {
         // F1-a: 在途流式气泡用 main 下发的 persistId 当 clientId(贯穿本 block 所有 delta),
         // 让该 block 最终由 main 落库后的 onCreated 同 id 命中 dedup。
         const clientId = event.persistId ?? crypto.randomUUID();
         return {
-          ...state,
+          ...textState,
           streamingClientId: clientId,
           streamingText: text,
           messages: [
-            ...state.messages,
+            ...textState.messages,
             {
               clientId,
               role: 'assistant',
@@ -5070,13 +5088,13 @@ export function handleStreamEvent(
         };
       }
 
-      const nextText = state.streamingText + text;
-      const id = state.streamingClientId;
+      const nextText = textState.streamingText + text;
+      const id = textState.streamingClientId;
       return {
-        ...state,
+        ...textState,
         streamingText: nextText,
         messages: replaceMessage(
-          state.messages,
+          textState.messages,
           (m) => m.clientId === id,
           (m) => ({ ...m, content: nextText }),
         ),
@@ -6781,6 +6799,10 @@ function enqueueTextDeltaPayload(
       !sameLiveIngressScope(existing.ingress, ingress))
   ) {
     discardPendingTextDelta(sessionId);
+    existing = undefined;
+  }
+  if (existing?.persistId && persistId && existing.persistId !== persistId) {
+    flushPendingTextDelta(sessionId);
     existing = undefined;
   }
   if (existing) {

--- a/apps/mobile/src/__tests__/remoteSessionStore.test.ts
+++ b/apps/mobile/src/__tests__/remoteSessionStore.test.ts
@@ -676,6 +676,32 @@ describe('remoteSessionStore', () => {
     }
   });
 
+  it('finalizes the previous streaming assistant when the persist id changes', () => {
+    vi.useFakeTimers();
+    try {
+      pushMakerText('s1', 'commentary-row', 'Inspecting the workspace', false);
+      vi.runOnlyPendingTimers();
+
+      pushMakerText('s1', 'final-answer-row', 'The fix is ready', false);
+      vi.runOnlyPendingTimers();
+
+      expect(remoteSessionStore.getMessages('s1')).toMatchObject([
+        {
+          clientId: 'commentary-row',
+          content: 'Inspecting the workspace',
+          agentMeta: null,
+        },
+        {
+          clientId: 'final-answer-row',
+          content: 'The fix is ready',
+          agentMeta: { isStreaming: true },
+        },
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it.each([
     ['without persistId', undefined],
     ['with the same persistId', 'shared-live-assistant'],

--- a/apps/mobile/src/session/remoteSessionStore.ts
+++ b/apps/mobile/src/session/remoteSessionStore.ts
@@ -2129,6 +2129,14 @@ function applyRemoteTextEvent(
     && hasAuthoritativePendingAssembly;
   if (rejectsBeforeClientIdMutation) return false;
 
+  const previousStreamingClientId = streamingAssistantClientIds.get(sessionId);
+  const normalizedPersistId = persistId?.trim();
+  const itemBoundaryClientId = normalizedPersistId
+    && previousStreamingClientId
+    && !isGeneratedStreamingClientId(previousStreamingClientId)
+    && previousStreamingClientId !== normalizedPersistId
+    ? previousStreamingClientId
+    : undefined;
   const clientIdResolution = streamingClientIdFor(sessionId, persistId);
   const { clientId } = clientIdResolution;
   const previousStreamingDeviceId = streamingAssistantDeviceId(sessionId, clientId);
@@ -2163,6 +2171,9 @@ function applyRemoteTextEvent(
       )
     );
   if (rejectsNonAuthoritativeTransportReplay) return clientIdResolution.changed;
+  const itemBoundaryChanged = itemBoundaryClientId
+    ? finalizeRemoteStreamingMessageByClientId(sessionId, itemBoundaryClientId)
+    : false;
   const resetsTransportAssembly = previousStreamingDeviceId !== undefined
     && deviceId !== undefined
     && previousStreamingDeviceId !== deviceId
@@ -2226,7 +2237,7 @@ function applyRemoteTextEvent(
     ) {
       rememberStreamingAssistantDeviceId(sessionId, clientId, deviceId);
     }
-    return changed || clientIdResolution.changed;
+    return changed || clientIdResolution.changed || itemBoundaryChanged;
   }
 
   const currentText = existing ? contentToPreview(existing.content) : '';
@@ -2304,7 +2315,7 @@ function applyRemoteTextEvent(
   ) {
     rememberStreamingAssistantDeviceId(sessionId, clientId, deviceId);
   }
-  return changed || clientIdResolution.changed;
+  return changed || clientIdResolution.changed || itemBoundaryChanged;
 }
 
 function isRemoteTextDeltaEvent(event: Record<string, unknown>): boolean {
@@ -2415,6 +2426,28 @@ function clearTextDeltaFlushTimer(): void {
 function discardPendingTextDelta(sessionId: string): void {
   pendingTextDeltaBatches.delete(sessionId);
   if (pendingTextDeltaBatches.size === 0) clearTextDeltaFlushTimer();
+}
+
+function finalizeRemoteStreamingMessageByClientId(
+  sessionId: string,
+  clientId: string,
+): boolean {
+  const existing = messages.get(sessionId);
+  if (!existing) return false;
+  let changed = false;
+  const next = existing.map((message) => {
+    if (
+      message.role !== 'assistant'
+      || message.agentMeta?.isStreaming !== true
+      || (message.id !== clientId && message.clientId !== clientId)
+    ) return message;
+    changed = true;
+    return { ...message, agentMeta: clearStreamingMeta(message.agentMeta) };
+  });
+  if (!changed) return false;
+  messages.set(sessionId, next);
+  bumpMessageVersion();
+  return true;
 }
 
 function finalizeRemoteStreamingMessages(

--- a/packages/maker-core/src/agents/codex/translator.test.ts
+++ b/packages/maker-core/src/agents/codex/translator.test.ts
@@ -119,11 +119,11 @@ describe('Codex assistant text streaming contract', () => {
     );
 
     expect((await collect(q)).filter((event) => event.type === 'text')).toEqual([
-      { type: 'text', data: { text: 'Hello ', isFinal: false }, source: 'codex' },
-      { type: 'text', data: { text: 'world', isFinal: false }, source: 'codex' },
+      { type: 'text', data: { text: 'Hello ', isFinal: false, agentMessageId: 'msg-1' }, source: 'codex' },
+      { type: 'text', data: { text: 'world', isFinal: false, agentMessageId: 'msg-1' }, source: 'codex' },
       {
         type: 'text',
-        data: { text: 'Hello world', isFinal: true, isFullText: true },
+        data: { text: 'Hello world', isFinal: true, isFullText: true, agentMessageId: 'msg-1' },
         source: 'codex',
       },
     ]);
@@ -166,11 +166,11 @@ describe('Codex assistant text streaming contract', () => {
     );
 
     expect((await collect(q)).filter((event) => event.type === 'text')).toEqual([
-      { type: 'text', data: { text: 'Hello ', isFinal: false }, source: 'codex' },
-      { type: 'text', data: { text: 'world', isFinal: false }, source: 'codex' },
+      { type: 'text', data: { text: 'Hello ', isFinal: false, agentMessageId: 'msg-1' }, source: 'codex' },
+      { type: 'text', data: { text: 'world', isFinal: false, agentMessageId: 'msg-1' }, source: 'codex' },
       {
         type: 'text',
-        data: { text: 'Hello world', isFinal: true, isFullText: true },
+        data: { text: 'Hello world', isFinal: true, isFullText: true, agentMessageId: 'msg-1' },
         source: 'codex',
       },
     ]);
@@ -206,9 +206,9 @@ describe('Codex assistant text streaming contract', () => {
     );
 
     expect((await collect(q)).filter((event) => event.type === 'text')).toEqual([
-      { type: 'text', data: { text: 'Hel', isFinal: false }, source: 'codex' },
-      { type: 'text', data: { text: 'lo ', isFinal: false }, source: 'codex' },
-      { type: 'text', data: { text: 'world', isFinal: false }, source: 'codex' },
+      { type: 'text', data: { text: 'Hel', isFinal: false, agentMessageId: 'msg-1' }, source: 'codex' },
+      { type: 'text', data: { text: 'lo ', isFinal: false, agentMessageId: 'msg-1' }, source: 'codex' },
+      { type: 'text', data: { text: 'world', isFinal: false, agentMessageId: 'msg-1' }, source: 'codex' },
     ]);
   });
 
@@ -244,10 +244,62 @@ describe('Codex assistant text streaming contract', () => {
     );
 
     expect((await collect(q)).filter((event) => event.type === 'text')).toEqual([
-      { type: 'text', data: { text: 'Hello worxd', isFinal: false }, source: 'codex' },
+      { type: 'text', data: { text: 'Hello worxd', isFinal: false, agentMessageId: 'msg-1' }, source: 'codex' },
       {
         type: 'text',
-        data: { text: 'Hello wonderful', isFinal: true, isFullText: true },
+        data: { text: 'Hello wonderful', isFinal: true, isFullText: true, agentMessageId: 'msg-1' },
+        source: 'codex',
+      },
+    ]);
+  });
+
+  it('preserves distinct Codex message identities and completed phases', async () => {
+    const q = createAsyncQueue<AgentEvent>();
+    const ctx = makeCtx(newCodexRuntimeState());
+
+    for (const item of [
+      {
+        type: 'agentMessage' as const,
+        id: 'msg-commentary',
+        text: 'Execution preview',
+        phase: 'commentary',
+      },
+      {
+        type: 'agentMessage' as const,
+        id: 'msg-final',
+        text: 'Please confirm.',
+        phase: 'final_answer',
+      },
+    ]) {
+      translateItemNotification(
+        'completed',
+        { threadId: 'thread-1', turnId: 'turn-1', item },
+        q,
+        ctx,
+      );
+    }
+
+    expect((await collect(q)).filter((event) => event.type === 'text')).toEqual([
+      {
+        type: 'text',
+        data: {
+          text: 'Execution preview',
+          isFinal: true,
+          isFullText: true,
+          agentMessageId: 'msg-commentary',
+          phase: 'commentary',
+        },
+        source: 'codex',
+      },
+      {
+        type: 'text',
+        data: {
+          text: 'Please confirm.',
+          isFinal: true,
+          isFullText: true,
+          agentMessageId: 'msg-final',
+          phase: 'final_answer',
+        },
         source: 'codex',
       },
     ]);
@@ -2302,7 +2354,7 @@ describe('codex internal citation 归一化 (#785)', () => {
     expect(events).toEqual([
       expect.objectContaining({
         type: 'text',
-        data: { text: 'done `/a/b.md`', isFinal: true, isFullText: true },
+        data: { text: 'done `/a/b.md`', isFinal: true, isFullText: true, agentMessageId: 'msg-2' },
       }),
     ]);
   });

--- a/packages/maker-core/src/agents/codex/translator.ts
+++ b/packages/maker-core/src/agents/codex/translator.ts
@@ -767,6 +767,7 @@ interface AgentMessageItem {
   type: 'agentMessage';
   id: string;
   text: string;
+  phase?: 'commentary' | 'final_answer';
 }
 
 interface ReasoningItem {
@@ -1091,7 +1092,7 @@ function emitAgentMessageProgress(
   if (delta.length === 0) return;
   queue.push({
     type: 'text',
-    data: { text: delta, isFinal: false },
+    data: { text: delta, isFinal: false, agentMessageId: itemId },
     source: 'codex',
   });
 }
@@ -1179,7 +1180,13 @@ function handleAgentMessage(
     // finalizeCodexCitationText 是与历史导入共用的统一口径。
     queue.push({
       type: 'text',
-      data: { text: finalizeCodexCitationText(rawText), isFinal: true, isFullText: true },
+      data: {
+        text: finalizeCodexCitationText(rawText),
+        isFinal: true,
+        isFullText: true,
+        agentMessageId: item.id,
+        ...(item.phase ? { phase: item.phase } : {}),
+      },
       source: 'codex',
     });
     return;


### PR DESCRIPTION
## 这次改了什么

### 摘要

保留 Codex 不同 `agentMessage` 的身份边界，避免后续 `final_answer` 覆盖前一条 `commentary`。Codex translator 现在向下游传递 provider item id；main 持久化和 renderer batching 都在 item / `persistId` 变化时结束前一个 assistant block。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Closes #2609
- 本 PR 包含：Codex `agentMessageId` / `phase` 透传、main assistant block 与去重边界、Desktop renderer delta batching 与气泡边界、Mobile remote streaming row 收口，以及对应回归测试。
- 明确不包含：视觉样式、布局、文案、数据库 schema/migration、Device Link topic/envelope/version，以及非 Codex provider 的合并语义。
- 用户可见变化：连续的 Codex commentary 与 final answer 会显示并持久化为两个独立 assistant 气泡，不再互相覆盖。
- 是否存在 breaking change：无。没有 `agentMessageId` 的旧 provider/event 继续使用既有兼容行为。

### Remote and mobile adaptation

- SSH remote：受益于同一修复。local stdio 与 remote SSH Codex 共用 `CodexAgent` translator，因此两种 transport 都保留相同 item 边界；未修改 SSH transport/configuration。
- Device Link：无 channel、topic、envelope 或版本化协议变化。新的 provider identity 只存在于既有 live event data；落库仍使用既有 message rows 和 `local-db:messages:created`。
- Mobile：在既有 `remoteSessionStore` 中按新 `persistId` 精确收口前一个 live assistant row；无 native/config、runtime fingerprint 或冷更变化。Desktop 产生的两个既有格式 message rows 仍沿现有 Device Link 路径镜像。

### UI 变化

没有新增或修改样式、布局、文案、颜色、动效或交互控件；仅修正既有聊天气泡的数据分界。自动化 renderer 回归断言两个不同 `persistId` 会形成两个 assistant 气泡。

- 引用的设计规范：不涉及：仅修正既有消息身份和气泡分界，不改变视觉或交互规范。

## 怎么验证的

### 自动验证

全部测试命令均在 RepoSteward hardened verifier 的断网、限权容器中执行。最新提交 `45565e359` 直接基于 `origin/main@1b4f9f42b`；该段主线与本 PR 仅在 `apps/desktop/src/main/maker-ipc/register.ts` 重叠，因此在最新基线上重新执行了 Desktop 完整 unit tier、Desktop typecheck、Codex/Mobile 定向回归和 DCO。Mobile review 修复此前也已独立完成全量验证：

```text
pnpm --filter @cindy/maker-core exec vitest run src/agents/codex/translator.test.ts
结果：通过，83/83 tests。

pnpm --filter desktop exec vitest run src/main/__tests__/messagePersistBroadcaster.test.ts src/renderer/__tests__/makerChatStoreTextDeltaBatching.test.ts
结果：通过，281/281 tests（包含当前 main 的终态错误/重试回归）。

pnpm test:unit -- --workspace apps/desktop
结果：最新基线通过；Desktop unit tier 315.9s，前置 runner 437 tests passed、1 skipped。

pnpm --filter @cindy/maker-core run --if-present typecheck
结果：命令成功；该 workspace 当前没有 typecheck script。

NODE_OPTIONS=--max-old-space-size=6144 pnpm --filter desktop run --if-present typecheck
结果：通过。

pnpm check:dco
结果：最终提交通过；1 个 commit，range 1b4f9f42..45565e35。

pnpm test:unit:related -- --exclude-workspace packages/maker-core
结果：全部适用 workspace 通过，包含 apps/desktop（314.1s）和 apps/mobile（21.8s）。

pnpm --filter mobile exec vitest run src/__tests__/remoteSessionStore.test.ts
结果：通过，227/227 tests。

pnpm --filter mobile test
结果：通过，331 test files；4001 tests passed、6 skipped。

pnpm --filter mobile run typecheck
结果：通过。
```

maker-core 全量在上一轮精确基线 `f1dd63ec5` 执行；`f1dd63ec5..1b4f9f42b` 没有修改 `packages/maker-core`，且当前提交与上一轮提交的 maker-core tree 逐字节一致，因此该结果可直接沿用：

```text
pnpm --filter @cindy/maker-core exec vitest run --pool=forks --maxWorkers=1 --testNamePattern '^(?!.*reaps its children and publishes a terminal status when SIGTERMed).*$'
结果：通过；121 test files passed、3 skipped，3566 tests passed、77 skipped。
```

未过滤的 maker-core 回归唯一失败为 PI runner 用例 `reaps its children and publishes a terminal status when SIGTERMed`。在不含本 PR 改动的精确基线 `f1dd63ec5` 独立 worktree 中单独执行该用例，得到相同的 30 秒 child-reap timeout；后续 main 没有修改该 workspace。因此全量命令只排除这一项，并保留其余 3566 个测试。

运行时指标评估：本 PR 提升 Codex return-content / message-boundary accuracy；不改变 cache rate、system prompt、model routing 或 usage accounting。热路径只增加一个已有字符串字段和 O(1) id 比较，不增加 I/O、网络或阻塞操作。最新聚焦 translator suite 为 83 tests / 345ms；这不是生产性能 benchmark，因改动没有新增循环或外部调用，未做额外 microbenchmark。

### 手工验证

不涉及：本轮未启动 Desktop UI 或真实 Codex provider；消息边界、DB echo 去重和 reload 所需的持久化行为由 main/renderer 自动化状态测试覆盖。

### 未执行的验证

- 未执行真实 local Codex 与 SSH remote Codex 端到端会话。
- 新 head 的 GitHub Actions 已通过：10/10 checks，包含 Linux 1/2、Linux 2/2、Windows 1/2、Windows 2/2、Desktop Git integration、verify-checks、汇总 verify、design-basis 与 DCO。
- 未提供截图/录屏，因为没有视觉样式或交互控件变化。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：Codex assistant 消息分组和持久化行数会按 provider item identity 变化。

### 影响与回滚

- 影响范围：Desktop 的 local/SSH Codex 实时展示与新消息持久化，以及 Mobile 对相邻不同 `persistId` live rows 的流式状态收口；已有历史记录不迁移，Claude/Pi 和无 identity 事件保持既有行为。Device Link 仍使用既有 schema/topic。
- 回滚 / 降级方式：revert 单个提交即可；没有 schema migration、缓存清理、协议降级或用户数据转换。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（无需新增产品/协议文档，范围与兼容性已在本描述说明）
- [x] 已确认测试结果或说明未执行原因
