### PR TITLE
test(desktop): stabilize heavy contract tests

### DIFF
--- a/apps/desktop/src/renderer/__tests__/typographyDiscipline.test.ts
+++ b/apps/desktop/src/renderer/__tests__/typographyDiscipline.test.ts
@@ -1,4 +1,4 @@
-import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { readdirSync, readFileSync } from 'node:fs';
 import { join, relative, sep } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
@@ -581,18 +581,28 @@ function findFixedLeadingWithScalingToken(text: string): Hit[] {
 
 // ── 文件遍历 ────────────────────────────────────────────────────────
 
-function collectFiles(exts: RegExp): string[] {
-  const files: string[] = [];
+interface ScanFile {
+  rel: string;
+  kind: 'source' | 'css';
+}
+
+function collectScanFiles(): ScanFile[] {
+  const files: ScanFile[] = [];
   const walk = (dir: string) => {
-    for (const name of readdirSync(dir)) {
-      const p = join(dir, name);
-      if (statSync(p).isDirectory()) {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const p = join(dir, entry.name);
+      if (entry.isDirectory()) {
         walk(p);
         continue;
       }
-      if (!exts.test(name)) continue;
+      const kind = /\.(ts|tsx|html)$/.test(entry.name)
+        ? 'source'
+        : /\.css$/.test(entry.name)
+          ? 'css'
+          : undefined;
+      if (!kind) continue;
       const rel = relative(ROOT, p).split(sep).join('/');
-      if (!SKIP_FILES.some((re) => re.test(rel))) files.push(rel);
+      if (!SKIP_FILES.some((re) => re.test(rel))) files.push({ rel, kind });
     }
   };
   walk(SCAN_DIR);
@@ -628,26 +638,28 @@ function scan(): Violation[] {
       });
   };
 
-  for (const rel of collectFiles(/\.(ts|tsx|html)$/)) {
-    const text = prepareTsContent(readFileSync(join(ROOT, rel), 'utf8'));
-    push(rel, text, 'tw-weight', findTwWeightViolations(text));
-    push(rel, text, 'arb-size', findArbitrarySizes(text));
-    push(rel, text, 'token-size', findOffLadderTokenSizes(text));
-    push(rel, text, 'inline-weight', findInlineWeightViolations(text));
-    push(rel, text, 'inline-size', findInlineSizeViolations(text));
-    push(rel, text, 'string-weight', findStringWeightViolations(text));
-    push(rel, text, 'font-shorthand', findFontShorthands(text));
-    push(rel, text, 'fixed-leading', findFixedLeadingWithScalingToken(text));
-  }
-  for (const rel of collectFiles(/\.css$/)) {
-    const text = stripCssComments(readFileSync(join(ROOT, rel), 'utf8'));
-    push(
-      rel,
-      text,
-      'css-weight',
-      findStringWeightViolations(text, { includeSelectorContext: true }),
-    );
-    push(rel, text, 'font-shorthand', findFontShorthands(text));
+  for (const { rel, kind } of collectScanFiles()) {
+    const raw = readFileSync(join(ROOT, rel), 'utf8');
+    if (kind === 'source') {
+      const text = prepareTsContent(raw);
+      push(rel, text, 'tw-weight', findTwWeightViolations(text));
+      push(rel, text, 'arb-size', findArbitrarySizes(text));
+      push(rel, text, 'token-size', findOffLadderTokenSizes(text));
+      push(rel, text, 'inline-weight', findInlineWeightViolations(text));
+      push(rel, text, 'inline-size', findInlineSizeViolations(text));
+      push(rel, text, 'string-weight', findStringWeightViolations(text));
+      push(rel, text, 'font-shorthand', findFontShorthands(text));
+      push(rel, text, 'fixed-leading', findFixedLeadingWithScalingToken(text));
+    } else {
+      const text = stripCssComments(raw);
+      push(
+        rel,
+        text,
+        'css-weight',
+        findStringWeightViolations(text, { includeSelectorContext: true }),
+      );
+      push(rel, text, 'font-shorthand', findFontShorthands(text));
+    }
   }
   return violations;
 }

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/review/__tests__/plugin.test.ts
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/review/__tests__/plugin.test.ts
@@ -7,23 +7,27 @@
  * 本身的契约:registry 命中、defaultState 形状、hydrateState 对非法 raw 的容错。
  */
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+// ReviewTabBody has its own renderer tests. This suite only exercises the
+// registration/state contract, so keep the full review UI graph outside this fixture.
+vi.mock('../ReviewTabBody', () => ({ ReviewTabBody: () => null }));
 
 let registry: typeof import('../../../registry');
 let pluginMod: typeof import('../index');
+let fixtureInitializationCount = 0;
 
 describe('review plugin', () => {
-  beforeEach(async () => {
-    // 关键:vitest 模块缓存默认共享,直接 import 第二次拿到 cached export 不会再
-    // 跑顶层 registerTabKind side-effect。每个测试前先 resetModules + 全新 import
-    // registry,registry 也是模块单例,新 import 拿到的是空 registry。然后 import
-    // plugin 让它跑一遍 register。
+  beforeAll(async () => {
+    fixtureInitializationCount += 1;
+    // registry 与 plugin 共享同一个文件级 fixture：注册 side-effect 只需执行一次。
+    // 每个用例都重置模块会在满载 worker 中重复拉起依赖图并撞上 hook timeout。
     vi.resetModules();
     registry = await import('../../../registry');
     pluginMod = await import('../index');
   });
 
-  afterEach(() => {
+  afterAll(() => {
     registry._resetTabKindRegistry();
   });
 
@@ -154,7 +158,8 @@ describe('review plugin', () => {
   });
 
   // 引用 pluginMod 让 lint 满意 + 验证 module load 成功
-  it('module imports without throwing', () => {
+  it('loads the registration fixture once without throwing', () => {
     expect(pluginMod).toBeTruthy();
+    expect(fixtureInitializationCount).toBe(1);
   });
 });


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Desktop 全量单测中 review plugin 注册契约的负载型波动。原测试在 11 个用例的每个 `beforeEach` 都执行 `vi.resetModules()` 并重新加载 plugin 入口，重复拉入完整 `ReviewTabBody` 依赖图；Windows 满载 worker 下会偶发超过 Vitest 默认 10 秒 hook timeout。

本 PR 将注册 fixture 改为文件级只初始化一次，并 mock 该契约测试不负责渲染的 `ReviewTabBody`。原有 11 项 registry、菜单、default state 与 hydrate 契约全部保留。

同一轮根门禁还暴露 typography discipline 扫描在高负载下超过 20 秒：测试原先对 `apps/desktop/src` 做两遍递归，并对每个目录项额外 `statSync`。现在改为单次 `readdirSync({ withFileTypes: true })` 遍历，按 source/CSS 分桶且每个文件只读取一次；扫描规则、豁免和 timeout 均未放宽。

### 变更类型

- [x] `docs` / `test` / `chore` 文档、测试或工程维护

### 范围

- 关联 Issue / 需求：本地根门禁中反复出现的 review plugin hook 与 typography scan 超时
- 本 PR 包含：调整 `plugin.test.ts` 的 fixture 装载与清理方式；将 typography discipline 的双遍 stat 扫描改为单遍 Dirent 扫描
- 明确不包含：生产插件注册逻辑、Review UI、扫描规则/豁免、全局 Vitest timeout 或其它波动测试
- 用户可见变化：无
- 是否存在 breaking change：无

### UI 变化

不涉及：只修改测试 fixture 与契约扫描器，不修改组件、样式、交互或文案。

- 引用的设计规范：不涉及：纯测试 fixture 与契约扫描性能优化，无视觉、交互或文案变化。

## 怎么验证的

### 自动验证

```text
RED 结构契约
结果：修复前初始化次数 expected 1 / received 11，其余 10 项契约通过

相关 review plugin / registry / resource-usage Vitest
结果：11 files / 126 tests passed；目标 plugin.test.ts 11 / 11 passed

Typography RED / GREEN
结果：根门禁 RED 为 23046ms > 20000ms；单遍扫描后定向 5 / 5 passed，独立负载下首 case 1411ms；组合快照定向 plugin + typography 16 / 16 passed

pnpm --filter desktop run --if-present typecheck
结果：最终组合冻结 tree `c17f0e58dd85a52ebfa8b532b25660b75b31e5b7` 上 exit 0

pnpm test:unit -- --workspace-concurrency=1
结果：最终组合冻结 tree `c17f0e58dd85a52ebfa8b532b25660b75b31e5b7` 上 exit 0（1541.2s）；runner 376 passed / 8 skipped / 0 failed；Desktop、Mobile 与全部 required workspaces PASS

git diff --cached --check
结果：exit 0

pnpm check:dco
结果：2 commits signed off
```

### 手工验证

不涉及。独立 reviewer 检查共享 registry 状态、mock 边界、跨用例污染，以及单遍扫描的扩展分类、跳过规则和 Windows/macOS 行为，最终无 P0/P1。

### 未执行的验证

- 未执行打包或 UI 手工验证；本 PR 只改变测试装载模型，不改变产品代码。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围：仅 Desktop review plugin 单元测试的模块 fixture 生命周期与 typography discipline 契约扫描性能。
- 回滚 / 降级方式：可分别 revert 两个提交；不涉及用户数据或运行时行为。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在「UI 变化」注明不涉及
- [x] 未提交凭证、令牌或授权文件
- [x] 无额外文档需求
- [x] 已确认测试结果或说明未执行原因