### PR TITLE
chore(repo): 移除个人 CODEOWNERS 指派

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,27 +1,7 @@
-# 默认所有路径由维护者 review。
+# 默认所有路径由维护者团队 review。
 #
 # 生效前提（缺一条 GitHub 就静默跳过该 owner，不报错）：
 #   - team 必须真实存在于 makecindy 组织下，slug 与此处一致；
 #   - 该 team 必须对本仓库有 write 及以上权限；
-#   - 个人账号同样需要对本仓库有 write 及以上权限。
 # 组织级设置见 https://github.com/orgs/makecindy/teams
-#
-# 这里同时列出 team 与个人:即使 team 尚未建好或未授权,自动指派仍然生效。
-# team 确认可用后可以删掉个人账号那一项。
 * @makecindy/maintainers
-
-# 统一模型 registry 的协议、内置快照、远程加载与运行时投影是同一权威面。
-# 最后匹配规则覆盖上面的通用 owner；任何改动都会显式请求 registry owner。
-/.github/CODEOWNERS @zqchris
-/packages/device-link-protocol/ @zqchris
-/packages/plugin-protocol/ @zqchris
-/packages/slack-hook-protocol/ @zqchris
-/packages/model-providers/catalog/model-registry.json @zqchris
-/packages/model-providers/src/catalog.ts @zqchris
-/packages/model-providers/src/modelRegistry.ts @zqchris
-/packages/model-providers/src/source.ts @zqchris
-/packages/model-providers/src/types.ts @zqchris
-/apps/desktop/src/main/maker-host/active-catalog.ts @zqchris
-/apps/desktop/src/main/model-access/devMetaOverlay.ts @zqchris
-/apps/desktop/src/main/usage/modelPriceOverrideStore.ts @zqchris
-/apps/desktop/src/main/usage/modelPricing.ts @zqchris


### PR DESCRIPTION
## 这次改了什么

### 摘要

移除 `.github/CODEOWNERS` 中所有指向个人账号 `@zqchris` 的路径规则，让所有文件统一回落到现有的 `@makecindy/maintainers` 通配规则。原配置会给命中特定协议、模型目录和定价文件的 PR 自动追加个人审核请求，制造不必要的待审核状态；同时清理只适用于个人 owner 的过时注释。

### 变更类型

- [ ] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [x] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：维护者要求撤销误设的个人 Code Owner。
- 本 PR 包含：删除 13 条个人 CODEOWNERS 路径规则，清理对应的过时注释。
- 明确不包含：修改 branch ruleset、维护者团队成员或权限、其它 review 流程。
- 用户可见变化：后续 PR 不再因这些路径自动请求 `@zqchris` 审核；现有误生成的个人审核请求已通过 GitHub API 单独清理，不属于本 PR diff。
- 是否存在 breaking change：无。

### UI 变化

不涉及。

- 引用的设计规范：不涉及。

## 怎么验证的

### 自动验证

```text
pnpm test:unit -- --workspace-concurrency=1
结果：通过；所有 required unit workspaces 均为 PASS。

pnpm check:dco
结果：通过；1 个 commit 已签署 DCO。

git diff --check
结果：通过。

CODEOWNERS 内容检查
结果：文件中不再包含 @zqchris，仅保留 @makecindy/maintainers 通配规则。
```

### 手工验证

不涉及运行时或 UI。通过 GitHub API 核对现有 open PR：由这些路径产生的 8 条个人待审核请求已移除，维护者团队审核请求保持不变。

### 未执行的验证

未执行 package typecheck：本 PR 未修改任何 package 源码或类型定义。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅影响 GitHub 自动请求 reviewer 的 CODEOWNERS 匹配结果。
- 回滚 / 降级方式：恢复被删除的个人路径规则即可；不涉及运行时数据或客户端行为。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
