### PR TITLE
fix(desktop): recover model options after anchor remount

### DIFF
--- a/apps/desktop/src/renderer/components/new-chat/ModelSelector.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ModelSelector.tsx
@@ -972,6 +972,10 @@ function ModelSelectorContentView({
   // pointer-reveal;布局变化后 Chromium 补发的合成 move 坐标不变,天然被挡。
   const hoverIntentArmedRef = useRef(false);
   const hoverIntentBaseRef = useRef<{ x: number; y: number } | null>(null);
+  const detachedAnchorRecoveryRef = useRef<{
+    providerId: string | null;
+    modelId: string;
+  } | null>(null);
   useEffect(() => {
     if (!pointerRevealRequiresIntent) return;
     const onMove = (e: PointerEvent) => {
@@ -983,6 +987,7 @@ function ModelSelectorContentView({
       const dy = e.screenY - hoverIntentBaseRef.current.y;
       if (dx * dx + dy * dy >= 16) {
         hoverIntentArmedRef.current = true;
+        detachedAnchorRecoveryRef.current = null;
         document.removeEventListener('pointermove', onMove, true);
       }
     };
@@ -1547,6 +1552,12 @@ function ModelSelectorContentView({
   useEffect(() => {
     if (!optionsPanelUsesLayoutPositioning || !editing) return;
     if (!editingModel || (optionsAnchor !== null && !optionsAnchor.isConnected)) {
+      const anchorDetached = optionsAnchor !== null && !optionsAnchor.isConnected;
+      if (anchorDetached) {
+        // 只允许刚失联的同一模型行恢复一次。不要武装组件级 hover gate，否则后续
+        // 任意行都能绕过 pointer movement 门槛（见 PR#1792 关联回归）。
+        detachedAnchorRecoveryRef.current = editing;
+      }
       closeOptionsPanel();
     }
   }, [closeOptionsPanel, editing, editingModel, optionsAnchor, optionsPanelUsesLayoutPositioning]);
@@ -1896,12 +1907,19 @@ function ModelSelectorContentView({
     // untrusted 事件(jsdom 测试/程序派发)不设门:布局位移诱发的浏览器事件是
     // trusted 的,真实闪现场景仍被挡。
     const revealOptionsByPointer = (event: ReactPointerEvent<HTMLDivElement>) => {
+      const recoveryTarget = detachedAnchorRecoveryRef.current;
+      const isDetachedAnchorRecovery =
+        optionsPanelUsesLayoutPositioning &&
+        recoveryTarget?.providerId === providerId &&
+        recoveryTarget.modelId === model.id;
       if (
         pointerRevealRequiresIntent &&
         !hoverIntentArmedRef.current &&
+        !isDetachedAnchorRecovery &&
         event.nativeEvent.isTrusted
       )
         return;
+      if (isDetachedAnchorRecovery) detachedAnchorRecoveryRef.current = null;
       revealOptions(event.currentTarget);
     };
     return (


### PR DESCRIPTION
## 这次改了什么

### 摘要

从 #1792 拆出 `ModelSelector` 的独立 UI 稳定性修复。

create-agent 形态使用 layout-positioned 行级选项面板时，搜索或布局变化可能让当前 anchor DOM 脱离并重新挂载。旧面板会正确关闭，但重挂载后的同一模型行仍受 pointer-movement intent gate 阻挡，导致用户首次悬停无法重新打开选项面板。

本 PR 记录一次性的 `providerId + modelId` 恢复目标：仅刚失联的同一模型行可以在下一次可信 pointer 事件中恢复；真实指针移动或恢复成功后立即清除目标，避免其它行绕过 hover intent 门槛。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 PR：从 #1792 拆出，避免 Orca 核心生命周期修复与产品 UI 混审。
- 本 PR 包含：`ModelSelector` detached anchor 的一次性、同模型恢复门。
- 明确不包含：不改 Orca、模型路由、provider 数据、权限默认、Popover 视觉样式或移动端。
- 用户可见变化：小窗口/搜索重挂载边界下，同一模型行首次重新悬停可正常打开选项面板。
- 是否存在 breaking change：无。

### UI 变化

- 引用的设计规范：`docs/design-rules/DESIGN.md` §14.2（Composer 模型/权限控件统一行为）与 §14.4（chip/container transform 与浮层边界）。
- 视觉变化：无；未新增颜色、尺寸、动效或布局。
- 交互变化：只恢复 detached anchor 后同一模型行的一次可信 hover；其它行仍必须满足 pointer movement intent gate。

## 怎么验证的

### 自动验证

```text
# Node v22.22.0 / pnpm 10.33.2
pnpm --dir apps/desktop exec vitest run --maxWorkers=1 \
  src/renderer/__tests__/modelSelectorProviderGroups.test.tsx \
  src/renderer/__tests__/modelSelectorTriggerVariant.test.ts
结果：通过，2 files / 68 tests。

pnpm --dir apps/desktop exec eslint   src/renderer/components/new-chat/ModelSelector.tsx
结果：通过。

pnpm --dir apps/desktop typecheck
结果：通过。

pnpm test:unit -- --workspace-concurrency=1
结果：通过；根测试运行器 383 passed / 1 skipped，所有 required unit workspaces 通过，Desktop unit 通过。

pnpm check:dco
git diff --check
结果：通过；DCO 1 commit signed off。
```

### 手工验证

未执行截图对比：本 PR 没有视觉样式变化。

### 未执行的验证

未在真实 Chromium 中手动复现 trusted pointer 的重挂载时序；现有测试覆盖旧 anchor 脱离、面板关闭、新行重挂载和再次打开的结构契约，本 PR 为草稿，保留产品侧交互复核空间。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [x] 其他：产品 UI hover 边界

### 影响与回滚

- 影响范围：仅 create-agent/layout-positioned `ModelSelector` 行级选项面板的 detached-anchor 恢复路径。
- 回滚 / 降级方式：回滚本 PR 的单个提交即可；无数据或协议变更。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [ ] 已补充必要文档（无需新增；引用现有设计规范）
- [x] 已确认测试结果或说明未执行原因
