### PR TITLE
fix(desktop): honor Pi Anthropic utility routes

### DIFF
--- a/apps/desktop/src/main/utility-model/__tests__/oneShotCandidates.test.ts
+++ b/apps/desktop/src/main/utility-model/__tests__/oneShotCandidates.test.ts
@@ -498,6 +498,68 @@ describe('utility one-shot candidates', () => {
     });
   });
 
+  it('uses Anthropic Messages for an explicitly selected pi anthropic-messages provider', async () => {
+    activeCatalog.mockReturnValue({
+      providers: [
+        {
+          id: 'pi-anthropic-only',
+          name: 'Pi Anthropic Only',
+          source: 'user',
+          agents: ['pi'],
+          auth: { method: 'apiKey' },
+          routing: {
+            pi: {
+              upstream: 'https://anthropic-only.example/v1',
+              wireProtocol: 'anthropic-messages',
+              authStrategy: 'api-key-header',
+            },
+          },
+          models: {
+            pi: [{ id: 'pi-anthropic-model', name: 'Pi Anthropic Model', contextWindow: 100_000 }],
+          },
+        },
+      ],
+    } as never);
+    readCustomKey.mockReturnValue('pi-secret');
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      text: async () =>
+        JSON.stringify({
+          content: [{ type: 'text', text: 'review decision' }],
+        }),
+    } as never);
+
+    const result = await requestUtilityText(makerMock(false), 'review this action', {
+      providerId: 'pi-anthropic-only',
+      agentKind: 'pi',
+      model: 'pi-anthropic-model',
+      maxTokens: 256,
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      text: 'review decision',
+      providerId: 'pi-anthropic-only',
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://anthropic-only.example/v1/messages',
+      expect.anything(),
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const init = fetchMock.mock.calls[0]?.[1] as { body: string; headers: Record<string, string> };
+    expect(init.headers).toMatchObject({
+      Authorization: 'Bearer pi-secret',
+      'Content-Type': 'application/json',
+      'anthropic-version': '2023-06-01',
+      'x-api-key': 'pi-secret',
+    });
+    expect(JSON.parse(init.body)).toEqual({
+      model: 'pi-anthropic-model',
+      max_tokens: 256,
+      messages: [{ role: 'user', content: 'review this action' }],
+    });
+  });
+
   it.each([
     {
       wireProtocol: 'openai-chat' as const,

--- a/apps/desktop/src/main/utility-model/oneShotCandidates.ts
+++ b/apps/desktop/src/main/utility-model/oneShotCandidates.ts
@@ -1141,6 +1141,12 @@ async function requestCustomProviderText(input: {
     ...(input.headers ?? {}),
     'Content-Type': 'application/json',
   };
+  const wire: ProviderWire =
+    input.agentKind === 'claude-code' || input.wireProtocol === 'anthropic-messages'
+      ? 'anthropic-messages'
+      : input.wireProtocol === 'openai-chat'
+        ? 'chat-completions'
+        : 'responses';
   // safeStorage 有当前凭证时覆盖历史 header；没有时仅 api-key 策略允许保留旧版
   // header-only 配置，以便用户升级后继续可用。OAuth 与 none 仍必须清掉复制进来的凭证头。
   const preserveLegacyApiKeyHeaders =
@@ -1153,19 +1159,13 @@ async function requestCustomProviderText(input: {
   }
   if (input.credential) {
     headers.Authorization = `Bearer ${input.credential}`;
-    if (input.agentKind === 'claude-code' && input.authStrategy === 'api-key-header') {
+    if (wire === 'anthropic-messages' && input.authStrategy === 'api-key-header') {
       headers['x-api-key'] = input.credential;
     }
   }
-  if (input.agentKind === 'claude-code') {
+  if (wire === 'anthropic-messages') {
     headers['anthropic-version'] = headers['anthropic-version'] ?? '2023-06-01';
   }
-  const wire: ProviderWire =
-    input.agentKind === 'claude-code'
-      ? 'anthropic-messages'
-      : input.wireProtocol === 'openai-chat'
-        ? 'chat-completions'
-        : 'responses';
   return requestProviderHttpText({
     wire,
     endpoint: input.requestPath


### PR DESCRIPTION
## 这次改了什么

### 摘要

Honor an explicitly declared `anthropic-messages` wire for Pi utility requests. Auto-review now uses the provider's Messages endpoint and required protocol header instead of `/responses`.

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Fixes #2629
- 本 PR 包含：Pi utility wire selection, Anthropic version and API-key headers, and regression coverage for the request and response shapes.
- 明确不包含：Auto-review retry policy, cross-provider fallback, or the broader utility routing refactor in #2102.
- 用户可见变化：Auto-review can use a custom Pi provider that declares `anthropic-messages`.
- 是否存在 breaking change：No.

### UI 变化

不涉及：No Renderer, visual, interaction, or copy change.

- 引用的设计规范：不涉及。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/utility-model/__tests__/oneShotCandidates.test.ts
Result: 48 tests passed.

NODE_OPTIONS=--max-old-space-size=6144 pnpm --filter desktop run --if-present typecheck
Result: passed.

pnpm test:unit
Result: all configured workspaces passed.

pnpm check:dco
Result: passed.
```

### 手工验证

Not run.

### 未执行的验证

A live custom Anthropic-compatible provider was not used. Endpoint, headers, authorization, body, and response parsing are covered deterministically.

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [x] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Custom Pi runtimes that explicitly declare `anthropic-messages`; Chat Completions, Responses, and existing Claude routes are unchanged.
- 回滚 / 降级方式：Revert the commit. No migration or data cleanup is required.

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
