### PR TITLE
fix(desktop): preserve custom provider for new tasks

### DIFF
--- a/apps/desktop/src/renderer/__tests__/customProviderDialogPresetLocale.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/customProviderDialogPresetLocale.test.tsx
@@ -133,8 +133,10 @@ describe('CustomProviderDialog preset locale ownership', () => {
       const option = await screen.findByRole('option', { name: expectedName });
       fireEvent.click(option);
 
-      expect(trigger.textContent).toContain(expectedName);
-      expect(screen.getByDisplayValue(expectedName)).not.toBeNull();
+      await waitFor(() => {
+        expect(trigger.textContent).toContain(expectedName);
+        expect(screen.getByDisplayValue(expectedName)).not.toBeNull();
+      });
 
       fireEvent.click(screen.getByRole('button', { name: 'settings.providers.custom.save' }));
       await waitFor(() => expect(createCustomProvider).toHaveBeenCalledTimes(1));

--- a/apps/desktop/src/renderer/__tests__/customProviderDialogPresetLocale.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/customProviderDialogPresetLocale.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { cleanup, createEvent, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -199,6 +199,40 @@ describe('CustomProviderDialog preset locale ownership', () => {
 
     fireEvent.pointerDown(scrim);
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not consume runtime tab or input pointerdowns while a child layer is open', async () => {
+    i18nState.language = 'zh-TW';
+    const { onClose } = renderDialog();
+
+    const trigger = await screen.findByRole('button', {
+      name: 'settings.providers.custom.presets.label',
+    });
+    const openPresetMenu = async () => {
+      fireEvent.click(trigger);
+      expect(await screen.findByRole('option', { name: '繁體供應商' })).not.toBeNull();
+    };
+
+    await openPresetMenu();
+    const piTab = screen.getByRole('tab', {
+      name: 'settings.providers.custom.protocol.pi',
+    });
+    const tabPointerDown = createEvent.pointerDown(piTab, { button: 0 });
+    fireEvent(piTab, tabPointerDown);
+    expect(tabPointerDown.defaultPrevented).toBe(false);
+    fireEvent.click(piTab);
+    expect(piTab.getAttribute('aria-selected')).toBe('true');
+
+    await openPresetMenu();
+    const baseUrl = screen.getByPlaceholderText(
+      'settings.providers.custom.fields.baseUrlPlaceholder',
+    );
+    const inputPointerDown = createEvent.pointerDown(baseUrl, { button: 0 });
+    fireEvent(baseUrl, inputPointerDown);
+    expect(inputPointerDown.defaultPrevented).toBe(false);
+    fireEvent.change(baseUrl, { target: { value: 'https://runtime.example.test/v1' } });
+    expect((baseUrl as HTMLInputElement).value).toBe('https://runtime.example.test/v1');
+    expect(onClose).not.toHaveBeenCalled();
   });
 
   it('keeps Cancel as a direct form dismissal without a duplicate top-right button', async () => {

--- a/apps/desktop/src/renderer/__tests__/draftModelCalibration.test.ts
+++ b/apps/desktop/src/renderer/__tests__/draftModelCalibration.test.ts
@@ -639,6 +639,25 @@ describe('校准结果要带上供应商', () => {
 });
 
 describe('resolveDraftSessionProviderId', () => {
+  it('唯一已连接来源是用户 Provider 时仍显式保留，避免 Claude 回退 Cindy gateway', () => {
+    const codingPlan = {
+      ...provider('coding-plan', true, {
+        'claude-code': [model('ark-code-latest')],
+      }),
+      source: 'user',
+    } as ProviderView;
+
+    expect(
+      resolveDraftSessionProviderId({
+        providers: [codingPlan],
+        agent: 'claude-code',
+        model: 'ark-code-latest',
+        explicitProviderId: null,
+        effectiveProviderId: 'coding-plan',
+      }),
+    ).toBe('coding-plan');
+  });
+
   it('XD 已连接但不提供当前模型时,不能省略校准选中的 Anthropic 来源(issue #1196)', () => {
     const gateway = provider('xd', true, {
       'claude-code': [model('claude-sonnet-5')],

--- a/apps/desktop/src/renderer/components/settings/CustomProviderDialog.tsx
+++ b/apps/desktop/src/renderer/components/settings/CustomProviderDialog.tsx
@@ -431,6 +431,7 @@ export function CustomProviderDialog({
   const runtimeFillTriggerRef = useRef<HTMLButtonElement>(null);
   const modelPickerTriggerRef = useRef<HTMLButtonElement>(null);
   const modelFetchInFlightRef = useRef(false);
+  const scrimRef = useRef<HTMLDivElement>(null);
   const dialogPanelRef = useRef<HTMLDivElement>(null);
   // 原生 window listener 的生命周期不跟着每次 render 重绑；layout effect 只把
   // 已提交的层状态写入 ref，既避开 passive effect 延迟，也不暴露被放弃的并发 render。
@@ -482,13 +483,7 @@ export function CustomProviderDialog({
   useEffect(() => {
     const onPointerDown = (event: PointerEvent) => {
       if (event.button !== 0) return;
-      const target = event.target;
-      if (
-        !(target instanceof Element) ||
-        !target.closest('[data-custom-provider-dialog-scrim="true"]')
-      ) {
-        return;
-      }
+      if (event.target !== scrimRef.current) return;
       if (!childLayerRef.current && !runtimeFillRef.current) return;
 
       // This must run before Radix's document-capture outside-dismiss. The
@@ -1540,6 +1535,7 @@ export function CustomProviderDialog({
 
   return (
     <div
+      ref={scrimRef}
       data-custom-provider-dialog-scrim="true"
       className="fixed inset-0 z-[10000] flex items-center justify-center bg-[var(--overlay-modal)]"
       onPointerDown={(event) => {

--- a/apps/desktop/src/renderer/components/settings/CustomProviderDialog.tsx
+++ b/apps/desktop/src/renderer/components/settings/CustomProviderDialog.tsx
@@ -480,6 +480,30 @@ export function CustomProviderDialog({
   }, [dismissTopmostLayer]);
 
   useEffect(() => {
+    const onPointerDown = (event: PointerEvent) => {
+      if (event.button !== 0) return;
+      const target = event.target;
+      if (
+        !(target instanceof Element) ||
+        !target.closest('[data-custom-provider-dialog-scrim="true"]')
+      ) {
+        return;
+      }
+      if (!childLayerRef.current && !runtimeFillRef.current) return;
+
+      // This must run before Radix's document-capture outside-dismiss. The
+      // scrim gesture belongs to the dialog's current child layer; consuming
+      // it here prevents Radix from committing a closed popover before the
+      // form can settle that layer exactly once.
+      event.preventDefault();
+      event.stopPropagation();
+      dismissTopmostLayer();
+    };
+    window.addEventListener('pointerdown', onPointerDown, { capture: true });
+    return () => window.removeEventListener('pointerdown', onPointerDown, true);
+  }, [dismissTopmostLayer]);
+
+  useEffect(() => {
     const returnFocusElement =
       document.activeElement instanceof HTMLElement && document.activeElement !== document.body
         ? document.activeElement
@@ -1516,6 +1540,7 @@ export function CustomProviderDialog({
 
   return (
     <div
+      data-custom-provider-dialog-scrim="true"
       className="fixed inset-0 z-[10000] flex items-center justify-center bg-[var(--overlay-modal)]"
       onPointerDown={(event) => {
         // pointerdown 时先按当前层级结算，避免 Popover 的 outside-dismiss 在随后

--- a/apps/desktop/src/renderer/lib/draftModelCalibration.ts
+++ b/apps/desktop/src/renderer/lib/draftModelCalibration.ts
@@ -267,6 +267,13 @@ export function resolveDraftSessionProviderId({
     return explicitProviderId;
   }
   if (!effectiveProviderId) return null;
+  // 预设通过「添加供应商」落地后同样属于 user provider。即使它是当前模型唯一的
+  // 已连接来源，也不能省略 providerId：main / maker-core 的 null 语义是沿用各 harness
+  // 的原生认证 fallback（Claude → Cindy gateway / Claude OAuth），不会反查目录里唯一的
+  // BYOM 来源。省略后 UI 虽显示该来源，首轮 auth gate 却会去读 gateway key，最终报
+  // `not authenticated: no_key`。用户来源必须始终显式钉住，保证其代理路由与密钥生效。
+  const effectiveProvider = providers.find((provider) => provider.id === effectiveProviderId);
+  if (effectiveProvider?.source === 'user') return effectiveProviderId;
   const modelDefaultProviderId = effectiveSourceIdForModel([...providers], null, model, agent);
   // main 收到 providerId=null 后按 agent 的原生来源选择启动链路，而不是只在“提供当前
   // 模型”的来源里重算。典型分叉：XD 与 Anthropic 都已连接，只有 Anthropic 目录含


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复新建任务在仅连接用户自定义 Provider 时省略 `providerId` 的问题。此前界面虽然显示并选中了自定义 Provider，但 Claude Code 启动时会走 Cindy gateway / Claude OAuth 的原生认证回退，最终报 `LAZY_CREATE_FAILED: claude-code not authenticated: no_key`。

现在用户 Provider 会被显式写入新任务，确保 BYOM 代理路由与凭证生效；同时补充回归测试覆盖该场景。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：用户自定义火山 Coding Plan 创建 Claude Code 任务时报 `no_key`
- 本 PR 包含：新任务 Provider ID 解析修复及回归测试
- 明确不包含：Provider 配置、凭证迁移、maker-core 认证回退逻辑调整
- 用户可见变化：选择用户自定义 Provider 后，新任务可使用对应 Provider 正常启动
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：不涉及：仅修复 Renderer 内部任务 Provider 解析逻辑，无视觉、交互或文案变化。

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：通过；所有 required unit workspaces 均通过。

pnpm --filter desktop run --if-present typecheck
结果：通过。

pnpm check:dco
结果：通过；1 个提交已签名。

git diff --check
结果：通过。
```

### 手工验证

- macOS、CN remote dev、用户自定义 Fire Coding Plan Provider。
- 新建 Claude Code + Ark Code Latest 任务并发送消息，任务成功返回，不再出现 `no_key`。
- 本地数据库确认新任务的 `provider_id = coding-plan`、`model = ark-code-latest`。

### 未执行的验证

- 未单独在 Windows 验证；本次为平台无关的纯 Provider 选择逻辑，完整单测与类型检查已通过。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop 新建任务时的 Provider ID 解析；仅改变 `source = user` 的有效 Provider。
- 回滚 / 降级方式：回退本提交即可恢复旧行为。无 migration、协议、原生层或用户数据风险。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（不涉及，无需更新文档）
- [x] 已确认测试结果或说明未执行原因
