### PR TITLE
fix(model-picker): 缩短跨端模型列表次要标签

### DIFF
--- a/apps/desktop/src/renderer/__tests__/modelPickerCompactTranslations.test.ts
+++ b/apps/desktop/src/renderer/__tests__/modelPickerCompactTranslations.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+
+import en from '../i18n/locales/en/common.json';
+import ja from '../i18n/locales/ja/common.json';
+import ko from '../i18n/locales/ko/common.json';
+import zhCN from '../i18n/locales/zh-CN/common.json';
+import zhTW from '../i18n/locales/zh-TW/common.json';
+
+const nonEnglishCatalogs = { ja, ko, 'zh-CN': zhCN, 'zh-TW': zhTW } as const;
+
+describe('desktop model-picker compact translations', () => {
+  it('uses Sub for the English subscription badge', () => {
+    expect(en.newChat.modelSelector.meta.subscriptionBadgeCompact).toBe('Sub');
+  });
+
+  it.each(Object.entries(nonEnglishCatalogs))(
+    '%s keeps subscription and effort labels short enough for a narrow model row',
+    (_locale, catalog) => {
+      expect(
+        Array.from(catalog.newChat.modelSelector.meta.subscriptionBadgeCompact).length,
+      ).toBeLessThanOrEqual(4);
+      for (const label of Object.values(catalog.effortLevels)) {
+        expect(Array.from(label).length).toBeLessThanOrEqual(4);
+      }
+    },
+  );
+});

--- a/apps/desktop/src/renderer/__tests__/modelSelectorTriggerVariant.test.ts
+++ b/apps/desktop/src/renderer/__tests__/modelSelectorTriggerVariant.test.ts
@@ -6,9 +6,15 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { Effort } from '@/lib/userPreferences.types';
 
+const modelSelectorI18nRef = vi.hoisted(() => ({
+  language: 'zh-CN',
+  resolvedLanguage: 'zh-CN',
+}));
+
 vi.mock('react-i18next', async (importOriginal) => ({
   ...(await importOriginal<typeof import('react-i18next')>()),
   useTranslation: () => ({
+    i18n: modelSelectorI18nRef,
     t: (
       key: string,
       options?: {
@@ -420,6 +426,7 @@ vi.mock('@/state/deviceLinkModelMirror', () => ({
 import {
   ModelSelector,
   ModelSelectorContent,
+  modelCompactEffortLabel,
   modelEffortLabel,
   modelListMaxHeightForRows,
   modelTagDensityForWidth,
@@ -431,6 +438,8 @@ import { makerChatStore } from '@/lib/makerChatStore';
 const requestProviderModelsAutoRefresh = vi.fn(async () => ({ ok: true as const }));
 
 beforeEach(() => {
+  modelSelectorI18nRef.language = 'zh-CN';
+  modelSelectorI18nRef.resolvedLanguage = 'zh-CN';
   requestProviderModelsAutoRefresh.mockClear();
   modelVisibilityRef.isEnabled = () => true;
   providersRef.providers = providersRef.DEFAULT_PROVIDERS;
@@ -1432,6 +1441,23 @@ describe('ModelSelector trigger variants', () => {
     );
   });
 
+  it('uses stable English effort ids for compact row and trigger labels', () => {
+    const t = (key: string, options?: { defaultValue?: string }) =>
+      key === 'effortLevels.xhigh' ? '超高' : (options?.defaultValue ?? key);
+
+    expect(
+      modelCompactEffortLabel(
+        'en-US',
+        t,
+        { effortDisplayNames: { xhigh: 'Extra High' } },
+        'xhigh',
+        '特高',
+      ),
+    ).toBe('XHi');
+    expect(modelCompactEffortLabel('en-US', t, null, 'medium', '中')).toBe('Mid');
+    expect(modelCompactEffortLabel('zh-CN', t, null, 'xhigh', 'Extra High')).toBe('超高');
+  });
+
   it.each([
     {
       agentKind: 'claude-code' as const,
@@ -1927,9 +1953,9 @@ describe('ModelSelector trigger variants', () => {
       const subscription = within(tags as HTMLElement).getByText(
         'settings.providers.models.subscription',
       );
-      expect(
-        hidden.compareDocumentPosition(subscription) & Node.DOCUMENT_POSITION_FOLLOWING,
-      ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+      expect(hidden.compareDocumentPosition(subscription) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(
+        Node.DOCUMENT_POSITION_FOLLOWING,
+      );
       expect(row.querySelector('[data-model-hidden-label]')).toBe(hidden);
       expect(screen.queryByRole('option', { name: /Sonnet 4\.6/ })).toBeNull();
     } finally {

--- a/apps/desktop/src/renderer/components/new-chat/ModelSelector.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ModelSelector.tsx
@@ -98,6 +98,7 @@ import {
   type ProviderView,
 } from '@cindy/model-providers';
 import { isProviderLogoKind } from '@cindy/model-providers/branding';
+import { compactEnglishEffortLabel } from '@cindy/maker-shared/agent-capabilities';
 import { getModelPriceQuote } from '../../../shared/modelPriceQuote';
 import { applyProviderOrder } from '../../../shared/providerOrder';
 import type { ModelPricingCatalog } from '../../../shared/regionalMoney';
@@ -439,6 +440,24 @@ export function modelEffortLabel(
   return t(`effortLevels.${e}`, {
     defaultValue: m?.effortDisplayNames?.[e] ?? agentDisplayName ?? e,
   });
+}
+
+export function modelCompactEffortLabel(
+  language: string,
+  t: Translate,
+  m: Pick<RowModel, 'effortDisplayNames'> | null | undefined,
+  e: Effort,
+  agentDisplayName?: string,
+): string {
+  return language.toLowerCase().startsWith('en')
+    ? compactEnglishEffortLabel(e)
+    : modelEffortLabel(t, m, e, agentDisplayName);
+}
+
+function resolvedTranslationLanguage(
+  i18n: { resolvedLanguage?: string; language?: string } | undefined,
+): string {
+  return i18n?.resolvedLanguage ?? i18n?.language ?? '';
 }
 
 function ModelPromotionBadge({ children }: { children: ReactNode }) {
@@ -839,7 +858,7 @@ function ModelSelectorContentView({
 }) {
   // 当前来源解析器:已建会话 = 实际路由口径(含停用拷贝),其余 = 准入口径。
   const resolveCurrentSourceId = actualRoute ? actualSourceIdForModel : effectiveSourceIdForModel;
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const constrainedListMaxHeight = modelListMaxHeightForRows(maxVisibleModelRows);
   const [paneElement, setPaneElement] = useState<HTMLDivElement | null>(null);
   const [paneWidth, setPaneWidth] = useState<number | null>(null);
@@ -1096,6 +1115,8 @@ function ModelSelectorContentView({
   // 档名多语言:i18n 词表(effortLevels.*) → 模型级 effortDisplayNames →
   // capabilities displayName(未知档兜底) → 原 id。
   const effortLabelFor = (m: RowModel, e: Effort) => modelEffortLabel(t, m, e, effortMeta.get(e));
+  const compactEffortLabelFor = (m: RowModel, e: Effort) =>
+    modelCompactEffortLabel(resolvedTranslationLanguage(i18n), t, m, e, effortMeta.get(e));
 
   // 当前 agent 是否支持 Fast Mode(agent 级能力,叠加 per-model supportsFastMode 才显示开关)。
   const hasFastModeCap = useMemo(() => {
@@ -1978,8 +1999,12 @@ function ModelSelectorContentView({
                     {model.displayName}
                   </span>
                   {rowEffort && (
-                    <span className="shrink-0 text-13 font-normal text-[var(--text-tertiary)]">
-                      {effortLabelFor(model, rowEffort)}
+                    <span
+                      aria-label={effortLabelFor(model, rowEffort)}
+                      title={effortLabelFor(model, rowEffort)}
+                      className="shrink-0 text-13 font-normal text-[var(--text-tertiary)]"
+                    >
+                      {compactEffortLabelFor(model, rowEffort)}
                     </span>
                   )}
                   {rowFastOn && (
@@ -2001,8 +2026,14 @@ function ModelSelectorContentView({
                       </span>
                     )}
                     {showSubscriptionTag && (
-                      <span className="inline-flex shrink-0 items-center rounded-full bg-[var(--surface-chip)] px-2 py-[1px] text-11 font-medium text-[var(--text-secondary)]">
-                        {t('settings.providers.models.subscription')}
+                      <span
+                        aria-label={t('settings.providers.models.subscription')}
+                        title={t('settings.providers.models.subscription')}
+                        className="inline-flex shrink-0 items-center rounded-full bg-[var(--surface-chip)] px-2 py-[1px] text-11 font-medium text-[var(--text-secondary)]"
+                      >
+                        {t('newChat.modelSelector.meta.subscriptionBadgeCompact', {
+                          defaultValue: t('settings.providers.models.subscription'),
+                        })}
                       </span>
                     )}
                     {showPromotionTag && rowPromotionLabel && (
@@ -2346,7 +2377,7 @@ export function ModelSelector({
   onNavigateToProviders,
   agentSwitch,
 }: ModelSelectorProps) {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const [open, setOpen] = useState(false);
   const openRef = useRef(false);
   const [keepOpenForAgentConfirmation, setKeepOpenForAgentConfirmation] = useState(false);
@@ -2570,7 +2601,16 @@ export function ModelSelector({
     !hasConnectedSource;
   // trigger 上仍展示当前模型的 effort(模型支持时)。
   const showEffort = !fallbackOption?.active && efforts.length > 0 && efforts.includes(effort);
-  const effortLabel = showEffort ? labelOf(effort) : null;
+  const fullEffortLabel = showEffort ? labelOf(effort) : null;
+  const effortLabel = showEffort
+    ? modelCompactEffortLabel(
+        resolvedTranslationLanguage(i18n),
+        t,
+        currentModel,
+        effort,
+        effortMeta.get(effort),
+      )
+    : null;
   // Fast 工具栏按钮已移除 → trigger 上用闪电标出当前是否 Fast(模型支持 + 已开启时)。
   // 支持性按「当前生效来源」现查 per-provider 条目;无法解析来源(flat / device-link 退化)时
   // 回退拍平值,避免误隐藏闪电。
@@ -2603,20 +2643,20 @@ export function ModelSelector({
     : showSourceDisconnected
       ? `${t('newChat.modelSelector.source.disconnected')}: ${displayIdentityLabel}`
       : agentIdentity?.state === 'pending' && agentName
-        ? effortLabel
+        ? fullEffortLabel
           ? t('newChat.modelSelector.trigger.pendingAriaWithEffort', {
               agent: agentName,
               model: displayLabel,
-              effort: effortLabel,
+              effort: fullEffortLabel,
             })
           : t('newChat.modelSelector.trigger.pendingAria', {
               agent: agentName,
               model: displayLabel,
             })
-        : effortLabel
+        : fullEffortLabel
           ? t('newChat.modelSelector.trigger.ariaWithEffort', {
               model: displayIdentityLabel,
-              effort: effortLabel,
+              effort: fullEffortLabel,
             })
           : t('newChat.modelSelector.trigger.aria', { model: displayIdentityLabel });
   // compact 会隐藏断连状态文字；原生 title 仍需保留同一状态，避免鼠标用户悬停
@@ -2846,6 +2886,7 @@ export function ModelSelector({
                 ·
               </span>
               <span
+                title={fullEffortLabel ?? undefined}
                 className={cn(
                   'min-w-0 font-normal',
                   isCreateAgentVariant

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -5549,6 +5549,7 @@
         "context": "{{value}} context",
         "codexCompatibilityMode": "Codex compatibility mode",
         "price": "{{input}}/{{output}} per 1M",
+        "subscriptionBadgeCompact": "Sub",
         "fastBadge": "Fast"
       },
       "source": {

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -5547,6 +5547,7 @@
         "context": "コンテキスト {{value}}",
         "codexCompatibilityMode": "Codex 互換モード",
         "price": "{{input}}/{{output}} / 100万",
+        "subscriptionBadgeCompact": "サブスク",
         "fastBadge": "高速"
       },
       "source": {

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -5547,6 +5547,7 @@
         "context": "컨텍스트 {{value}}",
         "codexCompatibilityMode": "Codex 호환 모드",
         "price": "{{input}}/{{output}} / 100만",
+        "subscriptionBadgeCompact": "구독",
         "fastBadge": "고속"
       },
       "source": {

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -5543,6 +5543,7 @@
         "context": "{{value}} 上下文",
         "codexCompatibilityMode": "Codex 兼容模式",
         "price": "{{input}}/{{output}} / 百万",
+        "subscriptionBadgeCompact": "订阅",
         "fastBadge": "快速"
       },
       "source": {

--- a/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
@@ -5546,6 +5546,7 @@
         "context": "{{value}} 上下文",
         "codexCompatibilityMode": "Codex 相容模式",
         "price": "{{input}}/{{output}} / 百萬",
+        "subscriptionBadgeCompact": "訂閱",
         "fastBadge": "快速"
       },
       "source": {

--- a/apps/mobile/src/__tests__/mobileModelPickerLayout.test.ts
+++ b/apps/mobile/src/__tests__/mobileModelPickerLayout.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Mobile model-picker row layout contract.
+ *
+ * React Native components cannot load in the Node Vitest environment, so this test locks the
+ * source structure that keeps secondary metadata from consuming the model-name line.
+ */
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const source = readFileSync(
+  resolve(process.cwd(), 'src/session/MobileModelPickerList.tsx'),
+  'utf8',
+).replace(/\s+/g, ' ');
+
+describe('MobileModelPickerList compact rows', () => {
+  it('gives provider-aware model names a dedicated primary line', () => {
+    const modelName = source.indexOf('{row.model.displayName}');
+    const metadata = source.indexOf(
+      '{isSubscription || rowEffort || fastOn ? (',
+      modelName,
+    );
+
+    expect(modelName).toBeGreaterThan(-1);
+    expect(metadata).toBeGreaterThan(modelName);
+    expect(source.slice(modelName, metadata)).toContain('</View>');
+  });
+
+  it('keeps subscription, effort and Fast in the secondary line', () => {
+    expect(source).toContain('<View style={styles.optionMetaRow}>');
+    expect(source).toMatch(
+      /\{t\(["']models\.picker\.subscriptionBadgeCompact["']\)\}/,
+    );
+    expect(source).toContain('{compactEffortLabelFor(');
+    expect(source).toContain('{fastOn ? (');
+  });
+
+  it('uses the same primary and secondary hierarchy for flat fallback rows', () => {
+    const modelName = source.indexOf('{option.label}');
+    const metadata = source.indexOf(
+      '{rowEffort || (fastEditable && selected && selectedFastMode) ? (',
+      modelName,
+    );
+
+    expect(modelName).toBeGreaterThan(-1);
+    expect(metadata).toBeGreaterThan(modelName);
+    expect(source.slice(modelName, metadata)).toContain('</View>');
+  });
+});

--- a/apps/mobile/src/__tests__/modelPickerRows.test.ts
+++ b/apps/mobile/src/__tests__/modelPickerRows.test.ts
@@ -12,6 +12,7 @@ import type { MobileModelMemoryAccessors } from '@/session/draftModelMemory';
 import {
   budgetRowDisabled,
   buildRowMetaLine,
+  compactEffortLabelFor,
   effortLabelFor,
   formatContextWindow,
   formatPriceLine,
@@ -89,20 +90,54 @@ describe('providerDisplayTitle / formatPriceLine / buildRowMetaLine', () => {
   });
 });
 
-describe('effortLabelFor —— 四级优先(模型覆盖 → capabilities → 中文词表 → 原 id)', () => {
-  it('模型 effortDisplayNames 覆盖优先', () => {
-    expect(effortLabelFor({ effortDisplayNames: { xhigh: '特高' } }, 'xhigh', capabilities)).toBe('特高');
+describe('effortLabelFor —— 五级优先(i18n → 模型覆盖 → capabilities → 兼容词表 → 原 id)', () => {
+  it('已知档位优先使用当前界面的本地化文案', () => {
+    expect(effortLabelFor({ effortDisplayNames: { xhigh: '特高' } }, 'xhigh', capabilities)).toBe('超高');
   });
-  it('无覆盖 → capabilities effortLevels label', () => {
-    expect(effortLabelFor({}, 'xhigh', capabilities)).toBe('Extra High');
+  it('未知档位回退模型覆盖与 capabilities 标签', () => {
+    expect(effortLabelFor({ effortDisplayNames: { custom: '自定义' } }, 'custom', capabilities)).toBe('自定义');
+    expect(
+      effortLabelFor({}, 'remote', {
+        ...capabilities,
+        effortLevels: [{ id: 'remote', label: '远程档' }],
+      }),
+    ).toBe('远程档');
   });
-  it('capabilities 缺该档 / 未加载 → 中文词表兜底', () => {
+  it('capabilities 缺该档 / 未加载 → 本地化词表', () => {
     expect(effortLabelFor({}, 'minimal', capabilities)).toBe('最小');
     expect(effortLabelFor({}, 'high', null)).toBe('高');
     expect(effortLabelFor({}, 'ultra', null)).toBe('极致');
   });
   it('词表也没有 → 原 id', () => {
     expect(effortLabelFor({}, 'nonexistent', null)).toBe('nonexistent');
+  });
+});
+
+describe('compactEffortLabelFor —— 英文列表短码', () => {
+  it('英文按稳定 effort id 显示 2–3 字母，非英文仍用本地化全称', async () => {
+    const previousLanguage = i18n.language;
+    try {
+      await i18n.changeLanguage('en');
+      expect(effortLabelFor({}, 'xhigh', capabilities)).toBe('Extra High');
+      expect(
+        compactEffortLabelFor({ effortDisplayNames: { xhigh: '特高' } }, 'xhigh', capabilities),
+      ).toBe('XHi');
+      expect(compactEffortLabelFor({}, 'minimal', capabilities)).toBe('Min');
+      expect(compactEffortLabelFor({}, 'low', capabilities)).toBe('Lo');
+      expect(compactEffortLabelFor({}, 'medium', capabilities)).toBe('Mid');
+      expect(compactEffortLabelFor({}, 'high', capabilities)).toBe('Hi');
+      expect(compactEffortLabelFor({}, 'ultra', capabilities)).toBe('Ult');
+      expect(compactEffortLabelFor({}, 'max', capabilities)).toBe('Max');
+
+      await i18n.changeLanguage('zh-CN');
+      expect(compactEffortLabelFor({}, 'high', null)).toBe('高');
+      await i18n.changeLanguage('ja');
+      expect(compactEffortLabelFor({}, 'ultra', null)).toBe('究極');
+      await i18n.changeLanguage('ko');
+      expect(compactEffortLabelFor({}, 'medium', null)).toBe('보통');
+    } finally {
+      await i18n.changeLanguage(previousLanguage);
+    }
   });
 });
 

--- a/apps/mobile/src/__tests__/modelPickerTranslations.test.ts
+++ b/apps/mobile/src/__tests__/modelPickerTranslations.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+
+import en from '@/i18n/locales/en/models.json';
+import ja from '@/i18n/locales/ja/models.json';
+import ko from '@/i18n/locales/ko/models.json';
+import zhCN from '@/i18n/locales/zh-CN/models.json';
+import zhTW from '@/i18n/locales/zh-TW/models.json';
+
+const nonEnglishCatalogs = { ja, ko, 'zh-CN': zhCN, 'zh-TW': zhTW } as const;
+
+describe('mobile model-picker translations', () => {
+  it('uses Sub in the English list and keeps the full English option labels', () => {
+    expect(en.picker.subscriptionBadgeCompact).toBe('Sub');
+    expect(en.options.effortLevels.xhigh).toBe('Extra High');
+  });
+
+  it.each(Object.entries(nonEnglishCatalogs))(
+    '%s keeps localized list metadata within four characters',
+    (_locale, catalog) => {
+      expect(
+        Array.from(catalog.picker.subscriptionBadgeCompact).length,
+      ).toBeLessThanOrEqual(4);
+      for (const label of Object.values(catalog.options.effortLevels)) {
+        expect(Array.from(label).length).toBeLessThanOrEqual(4);
+      }
+    },
+  );
+});

--- a/apps/mobile/src/i18n/locales/en/models.json
+++ b/apps/mobile/src/i18n/locales/en/models.json
@@ -8,6 +8,7 @@
     "emptyDefault": "No models available",
     "loadingDefault": "Loading models…",
     "subscriptionBadge": "Subscription",
+    "subscriptionBadgeCompact": "Sub",
     "backToModels": "Back to model list",
     "agentSwitchHint": "After you pick a model, the next message switches to {{agent}}",
     "crossAgentEmptyHint": "Connect a {{agent}} model source on the controlled device first",
@@ -24,7 +25,16 @@
     "fastMode": "Fast Mode",
     "fastModeAccessibility": "Fast mode {{model}}",
     "reasoningEffort": "Reasoning Effort",
-    "reasoningEffortAccessibility": "Reasoning effort {{label}}"
+    "reasoningEffortAccessibility": "Reasoning effort {{label}}",
+    "effortLevels": {
+      "minimal": "Minimal",
+      "low": "Low",
+      "medium": "Medium",
+      "high": "High",
+      "xhigh": "Extra High",
+      "max": "Max",
+      "ultra": "Ultra"
+    }
   },
   "agentSwitch": {
     "browseAccessibility": "Browse {{agent}} models",

--- a/apps/mobile/src/i18n/locales/ja/models.json
+++ b/apps/mobile/src/i18n/locales/ja/models.json
@@ -8,6 +8,7 @@
     "emptyDefault": "利用可能なモデルがありません",
     "loadingDefault": "モデルを読み込み中…",
     "subscriptionBadge": "サブスク",
+    "subscriptionBadgeCompact": "サブスク",
     "backToModels": "モデル一覧に戻る",
     "agentSwitchHint": "モデルを選択すると、次のメッセージから {{agent}} に切り替わります",
     "crossAgentEmptyHint": "先に操作対象のデバイスで {{agent}} のモデルソースを接続してください",
@@ -24,7 +25,16 @@
     "fastMode": "高速モード",
     "fastModeAccessibility": "高速モード {{model}}",
     "reasoningEffort": "推論強度",
-    "reasoningEffortAccessibility": "推論強度 {{label}}"
+    "reasoningEffortAccessibility": "推論強度 {{label}}",
+    "effortLevels": {
+      "minimal": "最小",
+      "low": "低",
+      "medium": "中",
+      "high": "高",
+      "xhigh": "超高",
+      "max": "最高",
+      "ultra": "究極"
+    }
   },
   "agentSwitch": {
     "browseAccessibility": "{{agent}} のモデルを表示",

--- a/apps/mobile/src/i18n/locales/ko/models.json
+++ b/apps/mobile/src/i18n/locales/ko/models.json
@@ -8,6 +8,7 @@
     "emptyDefault": "사용 가능한 모델이 없습니다",
     "loadingDefault": "모델을 불러오는 중…",
     "subscriptionBadge": "구독",
+    "subscriptionBadgeCompact": "구독",
     "backToModels": "모델 목록으로 돌아가기",
     "agentSwitchHint": "모델을 선택하면 다음 메시지부터 {{agent}}(으)로 전환됩니다",
     "crossAgentEmptyHint": "먼저 제어 대상 기기에서 {{agent}} 모델 소스를 연결하세요",
@@ -24,7 +25,16 @@
     "fastMode": "빠른 모드",
     "fastModeAccessibility": "빠른 모드 {{model}}",
     "reasoningEffort": "추론 강도",
-    "reasoningEffortAccessibility": "추론 강도 {{label}}"
+    "reasoningEffortAccessibility": "추론 강도 {{label}}",
+    "effortLevels": {
+      "minimal": "최소",
+      "low": "낮음",
+      "medium": "보통",
+      "high": "높음",
+      "xhigh": "초고",
+      "max": "최고",
+      "ultra": "극한"
+    }
   },
   "agentSwitch": {
     "browseAccessibility": "{{agent}} 모델 보기",

--- a/apps/mobile/src/i18n/locales/zh-CN/models.json
+++ b/apps/mobile/src/i18n/locales/zh-CN/models.json
@@ -8,6 +8,7 @@
     "emptyDefault": "暂无可用模型",
     "loadingDefault": "正在加载模型…",
     "subscriptionBadge": "订阅",
+    "subscriptionBadgeCompact": "订阅",
     "backToModels": "返回模型列表",
     "agentSwitchHint": "选择模型后，下一条消息将切换到 {{agent}}",
     "crossAgentEmptyHint": "请先在被控设备连接 {{agent}} 的模型来源",
@@ -24,7 +25,16 @@
     "fastMode": "快速模式",
     "fastModeAccessibility": "快速模式 {{model}}",
     "reasoningEffort": "推理强度",
-    "reasoningEffortAccessibility": "推理强度 {{label}}"
+    "reasoningEffortAccessibility": "推理强度 {{label}}",
+    "effortLevels": {
+      "minimal": "最小",
+      "low": "低",
+      "medium": "中",
+      "high": "高",
+      "xhigh": "超高",
+      "max": "最高",
+      "ultra": "极致"
+    }
   },
   "agentSwitch": {
     "browseAccessibility": "浏览 {{agent}} 模型",

--- a/apps/mobile/src/i18n/locales/zh-TW/models.json
+++ b/apps/mobile/src/i18n/locales/zh-TW/models.json
@@ -8,6 +8,7 @@
     "emptyDefault": "暫無可用模型",
     "loadingDefault": "正在載入模型…",
     "subscriptionBadge": "訂閱",
+    "subscriptionBadgeCompact": "訂閱",
     "backToModels": "返回模型列表",
     "agentSwitchHint": "選擇模型後，下一條訊息將切換到 {{agent}}",
     "crossAgentEmptyHint": "請先在被控裝置連線 {{agent}} 的模型來源",
@@ -24,7 +25,16 @@
     "fastMode": "快速模式",
     "fastModeAccessibility": "快速模式 {{model}}",
     "reasoningEffort": "推理強度",
-    "reasoningEffortAccessibility": "推理強度 {{label}}"
+    "reasoningEffortAccessibility": "推理強度 {{label}}",
+    "effortLevels": {
+      "minimal": "最小",
+      "low": "低",
+      "medium": "中",
+      "high": "高",
+      "xhigh": "超高",
+      "max": "最高",
+      "ultra": "極致"
+    }
   },
   "agentSwitch": {
     "browseAccessibility": "瀏覽 {{agent}} 模型",

--- a/apps/mobile/src/session/MobileModelPickerList.tsx
+++ b/apps/mobile/src/session/MobileModelPickerList.tsx
@@ -2,8 +2,8 @@
  * MobileModelPickerList —— 模型浮窗一级视图的行列表(新建会话页 + 会话内 composer 共用,
  * 由 ModelPickerSheet 装配)。
  *
- * 展现内容对齐桌面 ModelSelector 的 renderModelItem:每行 = 来源官方 mark + 模型名 +
- * `订阅`(订阅制来源)+ 当前 effort 标签 + Fast 闪电(点亮时)+
+ * 展现内容对齐桌面 ModelSelector 的 renderModelItem:每行 = 来源官方 mark + 模型名主行 +
+ * `订阅`(订阅制来源)+ 当前 effort 标签 + Fast 闪电(点亮时)的紧凑副行 +
  * 选中 Check + 行内「配置」入口。
  * 触屏适配:桌面 hover「Edit」→ 每行右侧常驻配置图标,点击经 `onOpenOptions` 通知浮窗
  * 打开二级「模型选项」SheetSurface(元信息 / 快速开关 / 推理强度,见 ModelOptionsSheetView),
@@ -30,6 +30,7 @@ import { useSessionModelMirrorVersion } from '@/session/sessionModelMirror';
 import {
   budgetDisabledHint,
   budgetRowDisabled,
+  compactEffortLabelFor,
   effortLabelFor,
   rowEffortOf,
   rowFastEditable,
@@ -104,7 +105,12 @@ const makeStyles = (c: ThemeColors) =>
     optionTitleRow: {
       alignItems: 'center',
       flexDirection: 'row',
-      gap: spacing.xs + 2,
+      minWidth: 0,
+    },
+    optionMetaRow: {
+      alignItems: 'center',
+      flexDirection: 'row',
+      gap: spacing.xs,
       minWidth: 0,
     },
     optionText: {
@@ -117,9 +123,10 @@ const makeStyles = (c: ThemeColors) =>
     },
     effortLabel: {
       color: c.textTertiary,
-      flexShrink: 0,
+      flexShrink: 1,
       fontSize: typeScale.footnote,
       fontWeight: fontWeight.regular,
+      minWidth: 0,
     },
     disabledHint: {
       color: c.textTertiary,
@@ -268,20 +275,38 @@ export function MobileModelPickerList({
               <View style={styles.optionMain}>
                 <View style={styles.optionTitleRow}>
                   <Text numberOfLines={1} style={styles.optionText}>{row.model.displayName}</Text>
-                  {isSubscription ? (
-                    <View style={styles.subscriptionBadge}>
-                      <Text style={styles.subscriptionBadgeText}>{t('models.picker.subscriptionBadge')}</Text>
-                    </View>
-                  ) : null}
-                  {rowEffort ? (
-                    <Text numberOfLines={1} style={styles.effortLabel}>
-                      {effortLabelFor(row.model, rowEffort, capabilities ?? null)}
-                    </Text>
-                  ) : null}
-                  {fastOn ? (
-                    <Zap color={colors.textTertiary} size={iconSize.sm} strokeWidth={iconStroke.regular} />
-                  ) : null}
                 </View>
+                {isSubscription || rowEffort || fastOn ? (
+                  <View style={styles.optionMetaRow}>
+                    {isSubscription ? (
+                      <View style={styles.subscriptionBadge}>
+                        <Text
+                          accessibilityLabel={t('models.picker.subscriptionBadge')}
+                          numberOfLines={1}
+                          style={styles.subscriptionBadgeText}
+                        >
+                          {t('models.picker.subscriptionBadgeCompact')}
+                        </Text>
+                      </View>
+                    ) : null}
+                    {rowEffort ? (
+                      <Text
+                        accessibilityLabel={effortLabelFor(
+                          row.model,
+                          rowEffort,
+                          capabilities ?? null,
+                        )}
+                        numberOfLines={1}
+                        style={styles.effortLabel}
+                      >
+                        {compactEffortLabelFor(row.model, rowEffort, capabilities ?? null)}
+                      </Text>
+                    ) : null}
+                    {fastOn ? (
+                      <Zap color={colors.textTertiary} size={iconSize.sm} strokeWidth={iconStroke.regular} />
+                    ) : null}
+                  </View>
+                ) : null}
                 {rowDisabled ? (
                   <Text numberOfLines={1} style={styles.disabledHint}>{budgetDisabledHint()}</Text>
                 ) : null}
@@ -354,15 +379,27 @@ export function MobileModelPickerList({
               <View style={styles.optionMain}>
                 <View style={styles.optionTitleRow}>
                   <Text numberOfLines={1} style={styles.optionText}>{option.label}</Text>
-                  {rowEffort ? (
-                    <Text numberOfLines={1} style={styles.effortLabel}>
-                      {effortLabelFor(option, rowEffort, capabilities ?? null)}
-                    </Text>
-                  ) : null}
-                  {fastEditable && selected && selectedFastMode ? (
-                    <Zap color={colors.textTertiary} size={iconSize.sm} strokeWidth={iconStroke.regular} />
-                  ) : null}
                 </View>
+                {rowEffort || (fastEditable && selected && selectedFastMode) ? (
+                  <View style={styles.optionMetaRow}>
+                    {rowEffort ? (
+                      <Text
+                        accessibilityLabel={effortLabelFor(
+                          option,
+                          rowEffort,
+                          capabilities ?? null,
+                        )}
+                        numberOfLines={1}
+                        style={styles.effortLabel}
+                      >
+                        {compactEffortLabelFor(option, rowEffort, capabilities ?? null)}
+                      </Text>
+                    ) : null}
+                    {fastEditable && selected && selectedFastMode ? (
+                      <Zap color={colors.textTertiary} size={iconSize.sm} strokeWidth={iconStroke.regular} />
+                    ) : null}
+                  </View>
+                ) : null}
               </View>
               {selected ? <Check color={colors.textPrimary} size={iconSize.lg} strokeWidth={iconStroke.medium} /> : null}
               {hasOptions ? (

--- a/apps/mobile/src/session/modelPickerRows.ts
+++ b/apps/mobile/src/session/modelPickerRows.ts
@@ -10,7 +10,10 @@ import { modelSupportsFastMode, type ProviderView } from '@cindy/model-providers
 import type { SectionModel } from '@cindy/model-providers/sections';
 import type { AgentKind } from '@cindy/model-providers/types';
 
-import { MOBILE_EFFORT_LABELS } from '@cindy/maker-shared/agent-capabilities';
+import {
+  compactEnglishEffortLabel,
+  MOBILE_EFFORT_LABELS,
+} from '@cindy/maker-shared/agent-capabilities';
 
 import { i18n } from '@/i18n';
 
@@ -94,19 +97,37 @@ export function buildRowMetaLine(args: {
 }
 
 /**
- * effort 档展示名(桌面 effortLabelFor 同序):模型级 effortDisplayNames 覆盖 →
- * agent capabilities effortLevels 的 label(normalize 已换中文词表)→ 中文词表
- * (capabilities 未加载时的兜底)→ 原 id。
+ * effort 档完整展示名(桌面 modelEffortLabel 同序):客户端 i18n → 模型级
+ * effortDisplayNames → agent capabilities effortLevels → 简中兼容词表 → 原 id。
  */
 export function effortLabelFor(
   model: Pick<PickerRowModel, 'effortDisplayNames'>,
   effort: string,
   capabilities: MobileAgentCapabilities | null,
 ): string {
+  const localized = i18n.t(`models.options.effortLevels.${effort}`, { defaultValue: '' });
+  if (localized) return localized;
   const override = model.effortDisplayNames?.[effort];
   if (override) return override;
   const level = capabilities?.effortLevels.find((l) => l.id === effort);
   return level?.label ?? MOBILE_EFFORT_LABELS[effort] ?? effort;
+}
+
+/**
+ * 一级列表使用稳定 effort id 生成英文短码，避免被控端下发的长文案或混合语言挤占模型名。
+ * 非英文界面继续使用完整本地化标签；完整英文名称仍由模型选项页展示。
+ */
+export function compactEffortLabelFor(
+  model: Pick<PickerRowModel, 'effortDisplayNames'>,
+  effort: string,
+  capabilities: MobileAgentCapabilities | null,
+): string {
+  const language = (i18n.resolvedLanguage ?? i18n.language).toLowerCase();
+  if (!language.startsWith('en')) {
+    return effortLabelFor(model, effort, capabilities);
+  }
+
+  return compactEnglishEffortLabel(effort);
 }
 
 /** 选中行判定:分段模式比 (providerId, modelId) 双键;flat(providerId null)只比模型 id。 */

--- a/packages/maker-shared/src/__tests__/agentCapabilities.test.ts
+++ b/packages/maker-shared/src/__tests__/agentCapabilities.test.ts
@@ -3,6 +3,7 @@ import {
   buildMobileModelSwitchConfirmation,
   buildSessionRuntimeOptions,
   categorizeMobileModel,
+  compactEnglishEffortLabel,
   normalizeMobileAgentCapabilities,
   reconcileRuntimeDraftWithCapabilities,
 } from '../agentCapabilities';
@@ -44,6 +45,15 @@ const desktopCapabilitiesPayload = {
 };
 
 describe('agent capabilities shared model', () => {
+  it('uses the same 2–3 letter English effort codes on desktop and mobile', () => {
+    expect(
+      ['minimal', 'low', 'medium', 'high', 'xhigh', 'ultra', 'max'].map(
+        compactEnglishEffortLabel,
+      ),
+    ).toEqual(['Min', 'Lo', 'Mid', 'Hi', 'XHi', 'Ult', 'Max']);
+    expect(compactEnglishEffortLabel('extra-high')).toBe('XHi');
+  });
+
   it('normalizes desktop capability payloads for runtime controls', () => {
     const capabilities = normalizeMobileAgentCapabilities(desktopCapabilitiesPayload);
 

--- a/packages/maker-shared/src/agentCapabilities.ts
+++ b/packages/maker-shared/src/agentCapabilities.ts
@@ -73,9 +73,8 @@ export interface MobileModelSwitchConfirmation {
 }
 
 /**
- * effort 档展示名词表(手机端简体中文,与桌面 i18n `effortLevels.*` 的 zh-CN 值对齐:
- * 低 / 中 / 高 / 超高 / 最高 / 极致)。手机无 i18n 体系,在 normalize 单点把 capabilities 的
- * 英文 displayName 换成中文,下游(列表行 / 模型选项 / trigger 药丸 / 会话设置)全部继承;
+ * 旧移动端兼容词表,与桌面 i18n `effortLevels.*` 的 zh-CN 值对齐。normalize 仍用它稳定
+ * capabilities 快照与旧消费者；模型选择器等用户可见入口再按当前语言覆盖已知档位。
  * 未知档 id 不在词表内 → 保留被控端给的 displayName 原文。
  */
 export const MOBILE_EFFORT_LABELS: Record<string, string> = {
@@ -87,6 +86,42 @@ export const MOBILE_EFFORT_LABELS: Record<string, string> = {
   max: '最高',
   ultra: '极致',
 };
+
+const ENGLISH_COMPACT_EFFORT_LABELS: Record<string, string> = {
+  auto: 'Aut',
+  balanced: 'Bal',
+  default: 'Def',
+  extrahigh: 'XHi',
+  high: 'Hi',
+  low: 'Lo',
+  max: 'Max',
+  maximum: 'Max',
+  medium: 'Mid',
+  minimal: 'Min',
+  none: 'Off',
+  off: 'Off',
+  standard: 'Std',
+  ultra: 'Ult',
+  xhigh: 'XHi',
+};
+
+/** Windows、macOS 与移动端模型选择器共用的英文 effort 短码。 */
+export function compactEnglishEffortLabel(effort: string): string {
+  const normalizedEffort = effort.toLowerCase().replace(/[^a-z0-9]/g, '');
+  const standardLabel = ENGLISH_COMPACT_EFFORT_LABELS[normalizedEffort];
+  if (standardLabel) return standardLabel;
+
+  const words = effort.match(/[a-z0-9]+/gi) ?? [];
+  if (words.length > 1) {
+    return words
+      .slice(0, 3)
+      .map((word) => word[0]?.toUpperCase() ?? '')
+      .join('');
+  }
+
+  const word = words[0] ?? effort;
+  return `${word.slice(0, 1).toUpperCase()}${word.slice(1, 3).toLowerCase()}`;
+}
 
 const FALLBACK_EFFORT_OPTIONS: MobileChoiceOption[] = [
   { id: 'low', label: MOBILE_EFFORT_LABELS.low },


### PR DESCRIPTION
## 这次改了什么

### 摘要

让 Mobile、Windows 和 macOS 的模型选择列表优先展示模型名，把容易挤占宽度的次要信息改成紧凑标签，同时保留完整文案和原有操作能力。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：移动端窄屏模型名过早截断，并统一优化桌面端同类模型列表
- 本 PR 包含：Mobile 将模型名与订阅、思考深度、Fast 拆成主副两行；桌面与 Mobile 英文订阅缩为 `Sub`，思考深度统一为 `Min / Lo / Mid / Hi / XHi / Ult / Max`；审计并补齐简中、繁中、日语、韩语对应文案
- 明确不包含：模型路由、模型能力语义、协议、原生依赖、配置页完整文案的缩写
- 用户可见变化：列表里模型名获得优先空间；配置页、悬停提示和无障碍标签仍展示完整本地化名称；选中、配置和 Fast 入口保持不变
- 是否存在 breaking change：无

### UI 变化

- Mobile：模型名独占主行，订阅、思考深度和 Fast 位于紧凑副行
- Windows / macOS：列表行和顶部模型入口使用相同英文短码，完整名称保留在 title / aria-label；中文、繁中、日语、韩语沿用短本地化词
- 截图/录屏：本轮未启动实际客户端，见「未执行的验证」
- 引用的设计规范：
  - `DESIGN.md` §3 Typography Rules / Hierarchy：模型名为主要信息，元信息降为次级层级
  - `DESIGN.md` §4 Select & Dropdown：保留原有选中反馈、配置入口和控件行为
  - `DESIGN.md` §8 Window & Adaptive Behavior / Mobile：窄宽度优先保证主要内容可读
  - `DESIGN.md` §10 Light / Dark Dual-Mode Delivery Gate：继续使用现有语义色 token，没有新增单主题颜色
  - `DESIGN.md` §11 Voice & Content：英文采用明确的 2–3 字母短码，其他语言使用各自自然且短的本地化词

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：通过；Desktop、Mobile 及全部 required unit workspace 均 PASS

pnpm --filter desktop run --if-present typecheck
pnpm --filter mobile run --if-present typecheck
pnpm --filter @cindy/maker-shared run --if-present typecheck
结果：通过；maker-shared 当前无 typecheck script，按仓库门禁自动跳过

pnpm --filter desktop exec vitest run src/renderer/__tests__/modelSelectorCustomProviderCodexGate.test.tsx src/renderer/__tests__/modelSelectorProviderGroups.test.tsx src/renderer/__tests__/modelSelectorTriggerVariant.test.ts src/renderer/__tests__/modelPickerCompactTranslations.test.ts
结果：4 files / 76 tests 通过

pnpm --filter mobile exec vitest run src/__tests__/modelPickerRows.test.ts src/__tests__/mobileModelPickerLayout.test.ts src/__tests__/modelPickerTranslations.test.ts
结果：3 files / 25 tests 通过

pnpm --filter @cindy/maker-shared exec vitest run src/__tests__/agentCapabilities.test.ts
结果：1 file / 11 tests 通过

pnpm check:i18n
pnpm check:i18n-glossary
结果：五种语言 key 一致，术语检查通过；仅有仓库既有非阻塞警告

pnpm check:dco
结果：1 个提交签名通过
```

### 手工验证

- Review 完整 diff，确认紧凑文案只进入列表和顶部触发器，配置页完整名称未被缩写
- 核对英文短码均为 2–3 个字符；简中、繁中、日语、韩语列表标签均不超过 4 个字符

### 未执行的验证

- 未在 iPhone 模拟器实机目检 Light / Dark：当前会话没有可用的 iOS Simulator 工具
- 未启动 Windows / macOS Desktop 做实际界面目检
- Mobile 验证位置：branch `mobile-model-picker-compact`，worktree `/Users/chris/Code/Github/cindy-mobile-model-picker-compact`；未启动 Metro，因此没有 Metro 独占归属与 `__DEV__` build label 证据

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Desktop 与 Mobile 的模型选择列表、Desktop 顶部模型入口及相关 i18n / 测试；不改变协议、模型能力、运行时 fingerprint 或持久数据
- 跨平台差异：Mobile 使用主副两行；Windows / macOS 保持单行但缩短标签。三端共享同一英文思考深度短码
- 回滚 / 降级方式：回滚本提交即可恢复原列表文案与布局；不存在数据迁移或兼容状态

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要测试；本次无需额外用户文档
- [x] 已确认测试结果并说明未执行的目检
