### PR TITLE
fix(desktop): worktree 内裸 dev 启动自动按 isolated 沙箱处理（#2635）

### DIFF
--- a/apps/desktop/scripts/dev-local-env.mjs
+++ b/apps/desktop/scripts/dev-local-env.mjs
@@ -27,6 +27,11 @@ if (!command) {
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
 const env = { ...process.env, XDT_DESKTOP_DEV_MODE: 'local' };
+// XDT_RESTART_MANAGED 是 restart 链路的一跳（one-hop）启动标记：restart 经白名单透传，
+// local 链（restart:desktop:local → 本 wrapper）同样会收到。这里消费它——删除后不进入
+// Electron 环境，避免被本地 Codex/Claude/PI agent 子进程继承，导致 agent 在 worktree
+// 跑裸 dev:remote 时误识别「受 restart 管理」而禁用自动隔离（review-pr P1, PR #2640）。
+delete env.XDT_RESTART_MANAGED;
 const startupConfig = applyDesktopDevStartupConfig({ argv: rawArgs, env, mode: 'local' });
 const args = stripDesktopDevRegionArgs(rawArgs);
 if (!env.XDT_ENDPOINT_MANIFEST_FILE?.trim()) {

--- a/apps/desktop/scripts/dev-remote-env.mjs
+++ b/apps/desktop/scripts/dev-remote-env.mjs
@@ -32,14 +32,24 @@ const env = {
   VITE_CINDY_AUTH_REGION: startupConfig.region,
 };
 
+// XDT_RESTART_MANAGED 是 restart 链路的一跳（one-hop）启动标记：只在判定「本进程
+// 是不是 restart 拉起的」时有意义，进入 Electron 后会被 agent 进程继承，导致 agent
+// 在 worktree 里跑裸 dev:remote 时误判「受 restart 管理」而禁用自动隔离（review-pr
+// P1, PR #2640）。从传给 Electron 的环境里删除，只保留给启动判定用。
+const restartManagedEnv = { ...process.env };
+delete restartManagedEnv.XDT_RESTART_MANAGED;
+
 // 内置 worktree 会话里的裸 dev 启动默认按隔离沙箱处理（issue #2635）：worktree 内
 // 不带 --isolated 裸启动会沿用区域默认 profile + 物理机 deviceId，dev 登录会把同机
 // release 的服务端 refresh token 顶掉、把 release 挤下线。显式传了 --isolated /
-// --passive / --preserve-running（或已设 XDT_ISOLATED=1 / XDT_USER_DATA_DIR）时不干预；
-// baseRepo 直跑保持既有共库语义。
+// --passive（或已设 XDT_ISOLATED=1 / XDT_USER_DATA_DIR）时不干预；baseRepo 直跑保持
+// 既有共库语义。restart 链路经 XDT_RESTART_MANAGED / XDT_SCHEDULER_PASSIVE 识别。
+// 注意 --preserve-running 不在豁免清单：裸路径上 Electron 侧不认这个参数（只有
+// restart 会翻译成 XDT_SCHEDULER_PASSIVE=1），豁免它会共享 userData 却正常调度 +
+// 正常单实例锁（review-pr P1, PR #2640）。
 const worktreeIsolation = resolveWorktreeIsolationFromCwd({
   argv: rawArgs,
-  env: process.env,
+  env: restartManagedEnv,
 });
 if (worktreeIsolation) {
   env.XDT_ISOLATED = '1';

--- a/apps/desktop/scripts/dev-remote-env.mjs
+++ b/apps/desktop/scripts/dev-remote-env.mjs
@@ -14,6 +14,7 @@ import { spawn } from 'node:child_process';
 
 import {
   applyDesktopDevStartupConfig,
+  clearInheritedIsolationOverrides,
   resolveWorktreeIsolationFromCwd,
   stripDesktopDevRegionArgs,
 } from '../../../scripts/shared/desktop-dev-region.mjs';
@@ -53,6 +54,12 @@ delete env.XDT_RESTART_MANAGED;
 // restart 会翻译成 XDT_SCHEDULER_PASSIVE=1），豁免它会共享 userData 却正常调度 +
 // 正常单实例锁（review-pr P1, PR #2640）。
 if (worktreeIsolation) {
+  // 清除继承自宿主（--isolated Desktop → agent 子进程）的启动覆写：XDT_USER_DATA_DIR
+  // / XDT_USER_DATA_DIR_EPOCH / XDT_DEVICE_ID_OVERRIDE 残留会让 resolveDevCliFlags
+  // 优先采用宿主 userData、且因已有 device override 不派生新身份，覆盖掉这里注入的
+  // worktree 沙箱语义（review-pr P1, PR #2640）。清除后沙箱目录与独立 deviceId 由
+  // 注入的 XDT_ISOLATED / XDT_ISOLATED_NAME 正常派生。
+  Object.assign(env, clearInheritedIsolationOverrides(env));
   env.XDT_ISOLATED = '1';
   if (worktreeIsolation.worktreeName) {
     env.XDT_ISOLATED_NAME = worktreeIsolation.worktreeName;

--- a/apps/desktop/scripts/dev-remote-env.mjs
+++ b/apps/desktop/scripts/dev-remote-env.mjs
@@ -14,7 +14,6 @@ import { spawn } from 'node:child_process';
 
 import {
   applyDesktopDevStartupConfig,
-  clearInheritedIsolationOverrides,
   resolveWorktreeIsolationFromCwd,
   stripDesktopDevRegionArgs,
 } from '../../../scripts/shared/desktop-dev-region.mjs';
@@ -59,7 +58,11 @@ if (worktreeIsolation) {
   // 优先采用宿主 userData、且因已有 device override 不派生新身份，覆盖掉这里注入的
   // worktree 沙箱语义（review-pr P1, PR #2640）。清除后沙箱目录与独立 deviceId 由
   // 注入的 XDT_ISOLATED / XDT_ISOLATED_NAME 正常派生。
-  Object.assign(env, clearInheritedIsolationOverrides(env));
+  // 注意：必须真正 delete 这些键——Object.assign 只复制存在的属性，不会删除目标
+  // 上已存在的旧键（review-pr P1, PR #2640）。
+  delete env.XDT_USER_DATA_DIR;
+  delete env.XDT_USER_DATA_DIR_EPOCH;
+  delete env.XDT_DEVICE_ID_OVERRIDE;
   env.XDT_ISOLATED = '1';
   if (worktreeIsolation.worktreeName) {
     env.XDT_ISOLATED_NAME = worktreeIsolation.worktreeName;

--- a/apps/desktop/scripts/dev-remote-env.mjs
+++ b/apps/desktop/scripts/dev-remote-env.mjs
@@ -33,11 +33,16 @@ const env = {
 };
 
 // XDT_RESTART_MANAGED 是 restart 链路的一跳（one-hop）启动标记：只在判定「本进程
-// 是不是 restart 拉起的」时有意义，进入 Electron 后会被 agent 进程继承，导致 agent
-// 在 worktree 里跑裸 dev:remote 时误判「受 restart 管理」而禁用自动隔离（review-pr
-// P1, PR #2640）。从传给 Electron 的环境里删除，只保留给启动判定用。
-const restartManagedEnv = { ...process.env };
-delete restartManagedEnv.XDT_RESTART_MANAGED;
+// 是不是 restart 拉起的」时有意义。**判定必须用含标记的环境**——restart 链路靠它
+// 识别「受 restart 管理」而免于自动隔离（无参=共库+正常调度契约）；进入 Electron 后
+// 该标记会被 agent 进程继承，导致 agent 在 worktree 跑裸 dev:remote 时误判「受 restart
+// 管理」而禁用自动隔离（review-pr P1/P2, PR #2640）——因此判定完成后从传给 Electron
+// 的 env 删除标记，只用于本次启动判定。
+const worktreeIsolation = resolveWorktreeIsolationFromCwd({
+  argv: rawArgs,
+  env: process.env,
+});
+delete env.XDT_RESTART_MANAGED;
 
 // 内置 worktree 会话里的裸 dev 启动默认按隔离沙箱处理（issue #2635）：worktree 内
 // 不带 --isolated 裸启动会沿用区域默认 profile + 物理机 deviceId，dev 登录会把同机
@@ -47,10 +52,6 @@ delete restartManagedEnv.XDT_RESTART_MANAGED;
 // 注意 --preserve-running 不在豁免清单：裸路径上 Electron 侧不认这个参数（只有
 // restart 会翻译成 XDT_SCHEDULER_PASSIVE=1），豁免它会共享 userData 却正常调度 +
 // 正常单实例锁（review-pr P1, PR #2640）。
-const worktreeIsolation = resolveWorktreeIsolationFromCwd({
-  argv: rawArgs,
-  env: restartManagedEnv,
-});
 if (worktreeIsolation) {
   env.XDT_ISOLATED = '1';
   if (worktreeIsolation.worktreeName) {

--- a/apps/desktop/scripts/dev-remote-env.mjs
+++ b/apps/desktop/scripts/dev-remote-env.mjs
@@ -58,11 +58,15 @@ if (worktreeIsolation) {
   // 优先采用宿主 userData、且因已有 device override 不派生新身份，覆盖掉这里注入的
   // worktree 沙箱语义（review-pr P1, PR #2640）。清除后沙箱目录与独立 deviceId 由
   // 注入的 XDT_ISOLATED / XDT_ISOLATED_NAME 正常派生。
+  // 同时清除继承的 XDT_SCHEDULER_PASSIVE：宿主 --passive / --preserve-running 的
+  // passive 语义属于宿主的共享 profile，独立沙箱里没有 primary，不该继承 passive
+  // （否则不触发定时任务、跳过单实例锁；review-pr P1, PR #2640）。
   // 注意：必须真正 delete 这些键——Object.assign 只复制存在的属性，不会删除目标
   // 上已存在的旧键（review-pr P1, PR #2640）。
   delete env.XDT_USER_DATA_DIR;
   delete env.XDT_USER_DATA_DIR_EPOCH;
   delete env.XDT_DEVICE_ID_OVERRIDE;
+  delete env.XDT_SCHEDULER_PASSIVE;
   env.XDT_ISOLATED = '1';
   if (worktreeIsolation.worktreeName) {
     env.XDT_ISOLATED_NAME = worktreeIsolation.worktreeName;

--- a/apps/desktop/scripts/dev-remote-env.mjs
+++ b/apps/desktop/scripts/dev-remote-env.mjs
@@ -14,6 +14,7 @@ import { spawn } from 'node:child_process';
 
 import {
   applyDesktopDevStartupConfig,
+  resolveWorktreeIsolationFromCwd,
   stripDesktopDevRegionArgs,
 } from '../../../scripts/shared/desktop-dev-region.mjs';
 
@@ -30,6 +31,29 @@ const env = {
   XDT_DESKTOP_DEV_MODE: 'remote',
   VITE_CINDY_AUTH_REGION: startupConfig.region,
 };
+
+// 内置 worktree 会话里的裸 dev 启动默认按隔离沙箱处理（issue #2635）：worktree 内
+// 不带 --isolated 裸启动会沿用区域默认 profile + 物理机 deviceId，dev 登录会把同机
+// release 的服务端 refresh token 顶掉、把 release 挤下线。显式传了 --isolated /
+// --passive / --preserve-running（或已设 XDT_ISOLATED=1 / XDT_USER_DATA_DIR）时不干预；
+// baseRepo 直跑保持既有共库语义。
+const worktreeIsolation = resolveWorktreeIsolationFromCwd({
+  argv: rawArgs,
+  env: process.env,
+});
+if (worktreeIsolation) {
+  env.XDT_ISOLATED = '1';
+  if (worktreeIsolation.worktreeName) {
+    env.XDT_ISOLATED_NAME = worktreeIsolation.worktreeName;
+  }
+  console.log(
+    `[dev-remote-env] managed worktree detected → isolated sandbox` +
+      (worktreeIsolation.worktreeName
+        ? ` "${worktreeIsolation.worktreeName}"`
+        : ' (default)') +
+      ' (独立 userData / 登录态 / 设备身份，不影响正式版)',
+  );
+}
 const isWindows = process.platform === 'win32';
 
 // Windows 下 electron-forge 等 .cmd shim 需要经 shell 解析;shell 模式下 Node 不转义

--- a/docs/dev-rules/desktop-development.md
+++ b/docs/dev-rules/desktop-development.md
@@ -80,13 +80,14 @@ checkout 的启动器顶掉）。因此并行多开的标准姿势是：**每个
 
 **内置 worktree 内的裸 dev 启动自动按隔离沙箱处理**（issue #2635）：`pnpm dev:remote`
 （不经 restart 包装的人类/agent 入口）从 `<repo>/.cindy-worktrees/<名字>`（含迁移前
-`.xdt-worktrees/<名字>`）下启动时，若没有显式传 `--isolated` / `--passive` /
-`--preserve-running`（也未设 `XDT_ISOLATED=1` / `XDT_USER_DATA_DIR` /
-`XDT_SCHEDULER_PASSIVE=1` / `XDT_RESTART_MANAGED=1`），启动包装自动注入
+`.xdt-worktrees/<名字>`）下启动时，若没有显式传 `--isolated` / `--passive`（也未设
+`XDT_ISOLATED=1` / `XDT_USER_DATA_DIR` / `XDT_RESTART_MANAGED=1`），启动包装自动注入
 `XDT_ISOLATED=1` + `XDT_ISOLATED_NAME=<worktree 名>`，并在控制台打印提示——否则
 dev 会沿用区域默认 profile + 物理机 deviceId，登录后把同机正式版的设备连接顶掉、
 覆盖其服务端 refresh token（4409 → `INVALID_REFRESH_TOKEN` → 正式版被登出）。显式
 传入任一模式时保持原语义；baseRepo 直跑 `pnpm dev:remote` 仍是共库 + 正常调度。
+注意 `--preserve-running` 与单独设置的 `XDT_SCHEDULER_PASSIVE=1` **不豁免**自动隔离
+（见下方说明）。
 **restart 链路（`restart-desktop-remote.mjs`）不受此自动隔离影响**：restart 会置
 `XDT_RESTART_MANAGED=1` 显式表态（其参数契约即语义：无参=共库+正常调度、
 `--isolated`=隔离、`--passive` / `--preserve-running`=共享），自动隔离判定识别后一律

--- a/docs/dev-rules/desktop-development.md
+++ b/docs/dev-rules/desktop-development.md
@@ -96,6 +96,12 @@ agent 子进程继承后禁用自动隔离（agent 在 worktree 跑裸 `dev:remo
 裸 dev 路径上的 `--preserve-running` **不豁免**自动隔离：Electron 侧不认该参数
 （只有 restart 会翻译成 `XDT_SCHEDULER_PASSIVE=1`），豁免会导致共享 userData 却
 正常调度 + 正常单实例锁（定时任务重复 / 无法再开预览）。
+`XDT_SCHEDULER_PASSIVE=1` **单独出现也不豁免**自动隔离：该标记会沿 Electron →
+agent 子进程继承（Codex / Claude / PI 的 spawn env 复制 process.env），若凭它豁免，
+agent 在 worktree 跑裸 `dev:remote` 会重新共享 profile/deviceId 互踢。restart 链路
+的 `--passive` / `--preserve-running` 由 `XDT_RESTART_MANAGED`（one-hop）识别，不依赖
+这个可长期继承的 passive 标记；人类裸跑 `pnpm dev:remote -- --passive` 走 argv 豁免
+（Electron 侧认识并收敛为被动模式）。
 
 配套护栏与工具：
 

--- a/docs/dev-rules/desktop-development.md
+++ b/docs/dev-rules/desktop-development.md
@@ -90,7 +90,12 @@ dev 会沿用区域默认 profile + 物理机 deviceId，登录后把同机正�
 **restart 链路（`restart-desktop-remote.mjs`）不受此自动隔离影响**：restart 会置
 `XDT_RESTART_MANAGED=1` 显式表态（其参数契约即语义：无参=共库+正常调度、
 `--isolated`=隔离、`--passive` / `--preserve-running`=共享），自动隔离判定识别后一律
-不干预——避免 worktree 内无参 restart 被静默改造成隔离沙箱。
+不干预——避免 worktree 内无参 restart 被静默改造成隔离沙箱。该标记是**一跳（one-hop）
+启动标记**：`dev-remote-env.mjs` 判定完成后即从传给 Electron 的环境删除，避免被
+agent 子进程继承后禁用自动隔离（agent 在 worktree 跑裸 `dev:remote` 时防护必须恢复）。
+裸 dev 路径上的 `--preserve-running` **不豁免**自动隔离：Electron 侧不认该参数
+（只有 restart 会翻译成 `XDT_SCHEDULER_PASSIVE=1`），豁免会导致共享 userData 却
+正常调度 + 正常单实例锁（定时任务重复 / 无法再开预览）。
 
 配套护栏与工具：
 

--- a/docs/dev-rules/desktop-development.md
+++ b/docs/dev-rules/desktop-development.md
@@ -103,6 +103,12 @@ agent 在 worktree 跑裸 `dev:remote` 会重新共享 profile/deviceId 互踢�
 的 `--passive` / `--preserve-running` 由 `XDT_RESTART_MANAGED`（one-hop）识别，不依赖
 这个可长期继承的 passive 标记；人类裸跑 `pnpm dev:remote -- --passive` 走 argv 豁免
 （Electron 侧认识并收敛为被动模式）。
+同理，`XDT_ISOLATED` / `XDT_USER_DATA_DIR` **单独出现也不豁免**自动隔离：它们可能是
+宿主 Desktop（以 `--isolated` 模式运行）留在 `process.env` 的变量，会沿同一继承路径
+到达 agent——agent 在 worktree 跑裸 `dev:remote` 时若凭它们豁免，会复用宿主 userData
+（宿主已持单实例锁则立即退出 / 同时继承 passive 则并发开沙箱）。restart 链路的
+`--isolated` 已由 `XDT_RESTART_MANAGED` 识别（隔离沙箱目录由 restart 自己派生），不
+依赖这些可长期继承的变量。**判定豁免只认 argv 显式参数与 `XDT_RESTART_MANAGED` 标记。**
 
 配套护栏与工具：
 

--- a/docs/dev-rules/desktop-development.md
+++ b/docs/dev-rules/desktop-development.md
@@ -81,11 +81,16 @@ checkout 的启动器顶掉）。因此并行多开的标准姿势是：**每个
 **内置 worktree 内的裸 dev 启动自动按隔离沙箱处理**（issue #2635）：`pnpm dev:remote`
 （不经 restart 包装的人类/agent 入口）从 `<repo>/.cindy-worktrees/<名字>`（含迁移前
 `.xdt-worktrees/<名字>`）下启动时，若没有显式传 `--isolated` / `--passive` /
-`--preserve-running`（也未设 `XDT_ISOLATED=1` / `XDT_USER_DATA_DIR`），启动包装自动
-注入 `XDT_ISOLATED=1` + `XDT_ISOLATED_NAME=<worktree 名>`，并在控制台打印提示——否则
+`--preserve-running`（也未设 `XDT_ISOLATED=1` / `XDT_USER_DATA_DIR` /
+`XDT_SCHEDULER_PASSIVE=1` / `XDT_RESTART_MANAGED=1`），启动包装自动注入
+`XDT_ISOLATED=1` + `XDT_ISOLATED_NAME=<worktree 名>`，并在控制台打印提示——否则
 dev 会沿用区域默认 profile + 物理机 deviceId，登录后把同机正式版的设备连接顶掉、
 覆盖其服务端 refresh token（4409 → `INVALID_REFRESH_TOKEN` → 正式版被登出）。显式
 传入任一模式时保持原语义；baseRepo 直跑 `pnpm dev:remote` 仍是共库 + 正常调度。
+**restart 链路（`restart-desktop-remote.mjs`）不受此自动隔离影响**：restart 会置
+`XDT_RESTART_MANAGED=1` 显式表态（其参数契约即语义：无参=共库+正常调度、
+`--isolated`=隔离、`--passive` / `--preserve-running`=共享），自动隔离判定识别后一律
+不干预——避免 worktree 内无参 restart 被静默改造成隔离沙箱。
 
 配套护栏与工具：
 

--- a/docs/dev-rules/desktop-development.md
+++ b/docs/dev-rules/desktop-development.md
@@ -78,6 +78,15 @@ restart 的 kill 作用域是**当前 checkout（worktree）**：只停自己这
 checkout 的启动器顶掉）。因此并行多开的标准姿势是：**每个实例一个独立 worktree +
 `--isolated=<名字>` 命名沙箱**，互不干扰地各自 restart。
 
+**内置 worktree 内的裸 dev 启动自动按隔离沙箱处理**（issue #2635）：`pnpm dev:remote`
+（不经 restart 包装的人类/agent 入口）从 `<repo>/.cindy-worktrees/<名字>`（含迁移前
+`.xdt-worktrees/<名字>`）下启动时，若没有显式传 `--isolated` / `--passive` /
+`--preserve-running`（也未设 `XDT_ISOLATED=1` / `XDT_USER_DATA_DIR`），启动包装自动
+注入 `XDT_ISOLATED=1` + `XDT_ISOLATED_NAME=<worktree 名>`，并在控制台打印提示——否则
+dev 会沿用区域默认 profile + 物理机 deviceId，登录后把同机正式版的设备连接顶掉、
+覆盖其服务端 refresh token（4409 → `INVALID_REFRESH_TOKEN` → 正式版被登出）。显式
+传入任一模式时保持原语义；baseRepo 直跑 `pnpm dev:remote` 仍是共库 + 正常调度。
+
 配套护栏与工具：
 
 - **userData 冲突门**：目标 userData（按 `--isolated` 名字推导）已被其他 checkout 的

--- a/scripts/__tests__/desktop-dev-region.test.mjs
+++ b/scripts/__tests__/desktop-dev-region.test.mjs
@@ -443,3 +443,25 @@ test("clearInheritedIsolationOverrides drops host-inherited launch overrides", (
   // 无覆写时原样返回
   assert.deepEqual(clearInheritedIsolationOverrides({ A: "1" }), { A: "1" });
 });
+
+test("isolation injection must truly delete inherited keys (Object.assign would keep them)", () => {
+  // 回归钉住（review-pr P1, PR #2640）：Object.assign(env, cleared) 只复制存在的属性、
+  // 不删除目标上的旧键——继承的宿主覆写会残留并覆盖沙箱语义。注入块必须直接 delete。
+  const env = {
+    XDT_USER_DATA_DIR: "C:\\host\\sandbox",
+    XDT_USER_DATA_DIR_EPOCH: "1",
+    XDT_DEVICE_ID_OVERRIDE: "dev-host-abc",
+    XDT_ISOLATED_NAME: "old",
+  };
+  // 模拟 dev-remote-env 命中自动隔离的注入块
+  delete env.XDT_USER_DATA_DIR;
+  delete env.XDT_USER_DATA_DIR_EPOCH;
+  delete env.XDT_DEVICE_ID_OVERRIDE;
+  env.XDT_ISOLATED = "1";
+  env.XDT_ISOLATED_NAME = "epic-thompson";
+  assert.equal(env.XDT_USER_DATA_DIR, undefined);
+  assert.equal(env.XDT_USER_DATA_DIR_EPOCH, undefined);
+  assert.equal(env.XDT_DEVICE_ID_OVERRIDE, undefined);
+  assert.equal(env.XDT_ISOLATED, "1");
+  assert.equal(env.XDT_ISOLATED_NAME, "epic-thompson");
+});

--- a/scripts/__tests__/desktop-dev-region.test.mjs
+++ b/scripts/__tests__/desktop-dev-region.test.mjs
@@ -451,17 +451,21 @@ test("isolation injection must truly delete inherited keys (Object.assign would 
     XDT_USER_DATA_DIR: "C:\\host\\sandbox",
     XDT_USER_DATA_DIR_EPOCH: "1",
     XDT_DEVICE_ID_OVERRIDE: "dev-host-abc",
+    XDT_SCHEDULER_PASSIVE: "1",
     XDT_ISOLATED_NAME: "old",
   };
   // 模拟 dev-remote-env 命中自动隔离的注入块
   delete env.XDT_USER_DATA_DIR;
   delete env.XDT_USER_DATA_DIR_EPOCH;
   delete env.XDT_DEVICE_ID_OVERRIDE;
+  delete env.XDT_SCHEDULER_PASSIVE;
   env.XDT_ISOLATED = "1";
   env.XDT_ISOLATED_NAME = "epic-thompson";
   assert.equal(env.XDT_USER_DATA_DIR, undefined);
   assert.equal(env.XDT_USER_DATA_DIR_EPOCH, undefined);
   assert.equal(env.XDT_DEVICE_ID_OVERRIDE, undefined);
+  // 继承的 passive 也清除：独立沙箱无 primary，不该被动模式（review-pr P1）
+  assert.equal(env.XDT_SCHEDULER_PASSIVE, undefined);
   assert.equal(env.XDT_ISOLATED, "1");
   assert.equal(env.XDT_ISOLATED_NAME, "epic-thompson");
 });

--- a/scripts/__tests__/desktop-dev-region.test.mjs
+++ b/scripts/__tests__/desktop-dev-region.test.mjs
@@ -269,34 +269,28 @@ test("worktree dev launch honors explicit isolation/sharing intent and never ove
     }),
     { worktreeName: "epic-thompson" },
   );
-  assert.equal(
-    resolveWorktreeIsolationFromCwd({
-      cwd: worktreeCwd("epic-thompson"),
-      argv: [],
-      env: { XDT_ISOLATED: "1" },
-    }),
-    null,
-  );
-  assert.equal(
-    resolveWorktreeIsolationFromCwd({
-      cwd: worktreeCwd("epic-thompson"),
-      argv: [],
-      env: { XDT_USER_DATA_DIR: "C:\\custom\\profile" },
-    }),
-    null,
-  );
-  // XDT_SCHEDULER_PASSIVE 单独出现**不豁免**：它会沿 Electron → agent 子进程继承，
-  // agent 在 worktree 跑裸 dev:remote 时若凭它豁免会重新共享 profile/deviceId 互踢。
-  // restart 链路由 XDT_RESTART_MANAGED 识别，不依赖这个可长期继承的 passive 标记
-  // （review-pr P1，PR #2640）。
-  assert.deepEqual(
-    resolveWorktreeIsolationFromCwd({
-      cwd: worktreeCwd("epic-thompson"),
-      argv: [],
-      env: { XDT_SCHEDULER_PASSIVE: "1" },
-    }),
-    { worktreeName: "epic-thompson" },
-  );
+  // XDT_ISOLATED / XDT_USER_DATA_DIR / XDT_SCHEDULER_PASSIVE 单独出现**均不豁免**：
+  // 它们都可能是宿主 Desktop（以 --isolated / --passive 模式运行）留在 process.env
+  // 的变量，会沿 Electron → agent 子进程继承（buildCodexEnv / PI spawn env 复制
+  // process.env）——agent 在 worktree 跑裸 dev:remote 时若凭它们豁免会复用宿主
+  // userData（单实例锁冲突退出 / passive 并发开沙箱）或重新共享 profile/deviceId
+  // 互踢（review-pr P1×3，PR #2640）。restart 链路仅由 XDT_RESTART_MANAGED 识别。
+  for (const env of [
+    { XDT_ISOLATED: "1" },
+    { XDT_USER_DATA_DIR: "C:\\custom\\profile" },
+    { XDT_SCHEDULER_PASSIVE: "1" },
+    { XDT_ISOLATED: "1", XDT_USER_DATA_DIR: "C:\\custom\\profile", XDT_SCHEDULER_PASSIVE: "1" },
+  ]) {
+    assert.deepEqual(
+      resolveWorktreeIsolationFromCwd({
+        cwd: worktreeCwd("epic-thompson"),
+        argv: [],
+        env,
+      }),
+      { worktreeName: "epic-thompson" },
+      `env ${JSON.stringify(env)} must not suppress auto-isolation (agent inheritance)`,
+    );
+  }
   // restart 链路显式表态：参数契约由 restart 自己负责（无参=共库+正常调度），
   // 自动隔离兜底不得静默覆盖（review-pr P1，PR #2640）
   assert.equal(
@@ -368,6 +362,16 @@ test("restart marker is one-hop: honored during launch decision but stripped fro
       cwd: worktreeCwd("epic-thompson"),
       argv: [],
       env: { XDT_RESTART_MANAGED: "1", XDT_SCHEDULER_PASSIVE: "1" },
+    }),
+    null,
+  );
+  // restart --isolated：XDT_RESTART_MANAGED + XDT_ISOLATED 都在 → 豁免（restart 链路
+  // 参数契约，隔离沙箱语义由 restart 自己管理）
+  assert.equal(
+    resolveWorktreeIsolationFromCwd({
+      cwd: worktreeCwd("epic-thompson"),
+      argv: [],
+      env: { XDT_RESTART_MANAGED: "1", XDT_ISOLATED: "1", XDT_USER_DATA_DIR: "C:\\custom\\profile" },
     }),
     null,
   );

--- a/scripts/__tests__/desktop-dev-region.test.mjs
+++ b/scripts/__tests__/desktop-dev-region.test.mjs
@@ -275,6 +275,26 @@ test("worktree dev launch honors explicit isolation/sharing intent and never ove
     }),
     null,
   );
+  // restart --passive / --preserve-running 只透传 XDT_SCHEDULER_PASSIVE=1（argv 侧
+  // 没有 --passive / --preserve-running）——共享意图必须被识别，防止误隔离
+  assert.equal(
+    resolveWorktreeIsolationFromCwd({
+      cwd: worktreeCwd("epic-thompson"),
+      argv: [],
+      env: { XDT_SCHEDULER_PASSIVE: "1" },
+    }),
+    null,
+  );
+  // restart 链路显式表态：参数契约由 restart 自己负责（无参=共库+正常调度），
+  // 自动隔离兜底不得静默覆盖（review-pr P1，PR #2640）
+  assert.equal(
+    resolveWorktreeIsolationFromCwd({
+      cwd: worktreeCwd("epic-thompson"),
+      argv: [],
+      env: { XDT_RESTART_MANAGED: "1" },
+    }),
+    null,
+  );
 });
 
 test("worktree dev launch outside a managed worktree keeps the shared-profile semantics", () => {

--- a/scripts/__tests__/desktop-dev-region.test.mjs
+++ b/scripts/__tests__/desktop-dev-region.test.mjs
@@ -246,7 +246,6 @@ test("worktree dev launch honors explicit isolation/sharing intent and never ove
     ["--isolated"],
     ["--isolated=feature-a"],
     ["--passive"],
-    ["--preserve-running"],
     ["start", "--", "--isolated=feature-a"],
   ]) {
     assert.equal(
@@ -259,6 +258,17 @@ test("worktree dev launch honors explicit isolation/sharing intent and never ove
       `argv ${JSON.stringify(argv)} must suppress auto-isolation`,
     );
   }
+  // 裸 dev 路径上的 --preserve-running 不豁免自动隔离：Electron 侧不认这个参数
+  // （只有 restart 会翻译成 XDT_SCHEDULER_PASSIVE=1），豁免它会共享 userData 却
+  // 正常调度 + 正常单实例锁，造成定时任务重复 / 无法再开预览（review-pr P1）。
+  assert.deepEqual(
+    resolveWorktreeIsolationFromCwd({
+      cwd: worktreeCwd("epic-thompson"),
+      argv: ["--preserve-running"],
+      env: {},
+    }),
+    { worktreeName: "epic-thompson" },
+  );
   assert.equal(
     resolveWorktreeIsolationFromCwd({
       cwd: worktreeCwd("epic-thompson"),
@@ -324,5 +334,61 @@ test("worktree dev launch falls back to the default sandbox for invalid names", 
       env: {},
     }),
     { worktreeName: null },
+  );
+});
+
+// ── restart 一跳标记 / 裸 preserve-running（review-pr P1，PR #2640）─────────────
+
+test("restart marker is one-hop: stripped from the Electron env but honored during launch decision", () => {
+  // 判定在 dev-remote-env 剥离 XDT_RESTART_MANAGED 后用剥离后的 env 调用：
+  // - 剥离后无标记 → worktree 裸启动命中自动隔离（#2635 防护恢复）
+  // - restart --passive 仍透传 XDT_SCHEDULER_PASSIVE=1 → 共享意图被识别不干预
+  const stripped = {};
+  assert.deepEqual(
+    resolveWorktreeIsolationFromCwd({
+      cwd: worktreeCwd("epic-thompson"),
+      argv: [],
+      env: stripped,
+    }),
+    { worktreeName: "epic-thompson" },
+  );
+  assert.equal(
+    resolveWorktreeIsolationFromCwd({
+      cwd: worktreeCwd("epic-thompson"),
+      argv: [],
+      env: { ...stripped, XDT_SCHEDULER_PASSIVE: "1" },
+    }),
+    null,
+  );
+  // XDT_RESTART_MANAGED 存在时（透传进 Electron 前）判定仍识别 restart 链路
+  assert.equal(
+    resolveWorktreeIsolationFromCwd({
+      cwd: worktreeCwd("epic-thompson"),
+      argv: [],
+      env: { XDT_RESTART_MANAGED: "1" },
+    }),
+    null,
+  );
+});
+
+test("bare dev:remote with --preserve-running in a worktree is isolated (no silent shared userData)", () => {
+  // 裸路径（不经 restart）--preserve-running 不被豁免：Electron 侧不认该参数，
+  // 豁免会导致共享 userData 却正常调度 + 正常单实例锁（定时任务重复 / 预览失败）。
+  assert.deepEqual(
+    resolveWorktreeIsolationFromCwd({
+      cwd: worktreeCwd("epic-thompson"),
+      argv: ["--preserve-running"],
+      env: {},
+    }),
+    { worktreeName: "epic-thompson" },
+  );
+  // 但 restart 链路的 --preserve-running 经 XDT_SCHEDULER_PASSIVE=1 表达共享意图
+  assert.equal(
+    resolveWorktreeIsolationFromCwd({
+      cwd: worktreeCwd("epic-thompson"),
+      argv: [],
+      env: { XDT_SCHEDULER_PASSIVE: "1" },
+    }),
+    null,
   );
 });

--- a/scripts/__tests__/desktop-dev-region.test.mjs
+++ b/scripts/__tests__/desktop-dev-region.test.mjs
@@ -4,6 +4,7 @@ import test from "node:test";
 
 import {
   applyDesktopDevStartupConfig,
+  clearInheritedIsolationOverrides,
   desktopUserDataDirForRegion,
   desktopUserDataDirNameForRegion,
   resolveDesktopDevRegion,
@@ -415,4 +416,30 @@ test("bare dev:remote with --preserve-running in a worktree is isolated (no sile
     }),
     null,
   );
+});
+
+test("clearInheritedIsolationOverrides drops host-inherited launch overrides", () => {
+  // 宿主 --isolated Desktop → agent 继承的启动覆写，会覆盖 worktree 自动隔离注入的
+  // 沙箱语义（review-pr P1，PR #2640）。命中隔离时必须清除，让沙箱目录/deviceId
+  // 由注入的 XDT_ISOLATED / XDT_ISOLATED_NAME 正常派生。
+  const base = {
+    XDT_USER_DATA_DIR: "C:\\host\\sandbox",
+    XDT_USER_DATA_DIR_EPOCH: "1",
+    XDT_DEVICE_ID_OVERRIDE: "dev-host-abc",
+    XDT_ISOLATED: "1",
+    XDT_ISOLATED_NAME: "host-sandbox",
+    XDT_SCHEDULER_PASSIVE: "1",
+  };
+  const cleared = clearInheritedIsolationOverrides(base);
+  assert.equal(cleared.XDT_USER_DATA_DIR, undefined);
+  assert.equal(cleared.XDT_USER_DATA_DIR_EPOCH, undefined);
+  assert.equal(cleared.XDT_DEVICE_ID_OVERRIDE, undefined);
+  // 其它字段保留（注入的隔离意图 + 无关变量不动）
+  assert.equal(cleared.XDT_ISOLATED, "1");
+  assert.equal(cleared.XDT_ISOLATED_NAME, "host-sandbox");
+  assert.equal(cleared.XDT_SCHEDULER_PASSIVE, "1");
+  // 纯函数：不改入参
+  assert.equal(base.XDT_USER_DATA_DIR, "C:\\host\\sandbox");
+  // 无覆写时原样返回
+  assert.deepEqual(clearInheritedIsolationOverrides({ A: "1" }), { A: "1" });
 });

--- a/scripts/__tests__/desktop-dev-region.test.mjs
+++ b/scripts/__tests__/desktop-dev-region.test.mjs
@@ -339,28 +339,10 @@ test("worktree dev launch falls back to the default sandbox for invalid names", 
 
 // ── restart 一跳标记 / 裸 preserve-running（review-pr P1，PR #2640）─────────────
 
-test("restart marker is one-hop: stripped from the Electron env but honored during launch decision", () => {
-  // 判定在 dev-remote-env 剥离 XDT_RESTART_MANAGED 后用剥离后的 env 调用：
-  // - 剥离后无标记 → worktree 裸启动命中自动隔离（#2635 防护恢复）
-  // - restart --passive 仍透传 XDT_SCHEDULER_PASSIVE=1 → 共享意图被识别不干预
-  const stripped = {};
-  assert.deepEqual(
-    resolveWorktreeIsolationFromCwd({
-      cwd: worktreeCwd("epic-thompson"),
-      argv: [],
-      env: stripped,
-    }),
-    { worktreeName: "epic-thompson" },
-  );
-  assert.equal(
-    resolveWorktreeIsolationFromCwd({
-      cwd: worktreeCwd("epic-thompson"),
-      argv: [],
-      env: { ...stripped, XDT_SCHEDULER_PASSIVE: "1" },
-    }),
-    null,
-  );
-  // XDT_RESTART_MANAGED 存在时（透传进 Electron 前）判定仍识别 restart 链路
+test("restart marker is one-hop: honored during launch decision but stripped from the Electron env", () => {
+  // 判定必须用含 XDT_RESTART_MANAGED 的环境：restart 链路（无参）靠它识别「受 restart
+  // 管理」而免于自动隔离（无参=共库+正常调度契约，review-pr P2 指正）。标记的删除
+  // 发生在 dev-remote-env 判定之后、传给 Electron 的 env 上（防 agent 子进程继承）。
   assert.equal(
     resolveWorktreeIsolationFromCwd({
       cwd: worktreeCwd("epic-thompson"),
@@ -368,6 +350,24 @@ test("restart marker is one-hop: stripped from the Electron env but honored duri
       env: { XDT_RESTART_MANAGED: "1" },
     }),
     null,
+  );
+  // restart --passive 透传 XDT_SCHEDULER_PASSIVE=1 → 共享意图被识别不干预
+  assert.equal(
+    resolveWorktreeIsolationFromCwd({
+      cwd: worktreeCwd("epic-thompson"),
+      argv: [],
+      env: { XDT_RESTART_MANAGED: "1", XDT_SCHEDULER_PASSIVE: "1" },
+    }),
+    null,
+  );
+  // 无标记（agent 子进程场景）→ worktree 裸启动命中自动隔离（#2635 防护恢复）
+  assert.deepEqual(
+    resolveWorktreeIsolationFromCwd({
+      cwd: worktreeCwd("epic-thompson"),
+      argv: [],
+      env: {},
+    }),
+    { worktreeName: "epic-thompson" },
   );
 });
 

--- a/scripts/__tests__/desktop-dev-region.test.mjs
+++ b/scripts/__tests__/desktop-dev-region.test.mjs
@@ -285,15 +285,17 @@ test("worktree dev launch honors explicit isolation/sharing intent and never ove
     }),
     null,
   );
-  // restart --passive / --preserve-running 只透传 XDT_SCHEDULER_PASSIVE=1（argv 侧
-  // 没有 --passive / --preserve-running）——共享意图必须被识别，防止误隔离
-  assert.equal(
+  // XDT_SCHEDULER_PASSIVE 单独出现**不豁免**：它会沿 Electron → agent 子进程继承，
+  // agent 在 worktree 跑裸 dev:remote 时若凭它豁免会重新共享 profile/deviceId 互踢。
+  // restart 链路由 XDT_RESTART_MANAGED 识别，不依赖这个可长期继承的 passive 标记
+  // （review-pr P1，PR #2640）。
+  assert.deepEqual(
     resolveWorktreeIsolationFromCwd({
       cwd: worktreeCwd("epic-thompson"),
       argv: [],
       env: { XDT_SCHEDULER_PASSIVE: "1" },
     }),
-    null,
+    { worktreeName: "epic-thompson" },
   );
   // restart 链路显式表态：参数契约由 restart 自己负责（无参=共库+正常调度），
   // 自动隔离兜底不得静默覆盖（review-pr P1，PR #2640）
@@ -302,6 +304,15 @@ test("worktree dev launch honors explicit isolation/sharing intent and never ove
       cwd: worktreeCwd("epic-thompson"),
       argv: [],
       env: { XDT_RESTART_MANAGED: "1" },
+    }),
+    null,
+  );
+  // restart --passive：XDT_RESTART_MANAGED + XDT_SCHEDULER_PASSIVE 都在 → 不干预
+  assert.equal(
+    resolveWorktreeIsolationFromCwd({
+      cwd: worktreeCwd("epic-thompson"),
+      argv: [],
+      env: { XDT_RESTART_MANAGED: "1", XDT_SCHEDULER_PASSIVE: "1" },
     }),
     null,
   );
@@ -382,12 +393,21 @@ test("bare dev:remote with --preserve-running in a worktree is isolated (no sile
     }),
     { worktreeName: "epic-thompson" },
   );
-  // 但 restart 链路的 --preserve-running 经 XDT_SCHEDULER_PASSIVE=1 表达共享意图
-  assert.equal(
+  // 继承的 XDT_SCHEDULER_PASSIVE 单独出现不豁免（agent 子进程场景，防绕过隔离）
+  assert.deepEqual(
     resolveWorktreeIsolationFromCwd({
       cwd: worktreeCwd("epic-thompson"),
       argv: [],
       env: { XDT_SCHEDULER_PASSIVE: "1" },
+    }),
+    { worktreeName: "epic-thompson" },
+  );
+  // 但 restart 链路的 --preserve-running 经 XDT_RESTART_MANAGED 表达共享意图
+  assert.equal(
+    resolveWorktreeIsolationFromCwd({
+      cwd: worktreeCwd("epic-thompson"),
+      argv: [],
+      env: { XDT_RESTART_MANAGED: "1", XDT_SCHEDULER_PASSIVE: "1" },
     }),
     null,
   );

--- a/scripts/__tests__/desktop-dev-region.test.mjs
+++ b/scripts/__tests__/desktop-dev-region.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import path from "node:path";
 import test from "node:test";
 
 import {
@@ -7,7 +8,9 @@ import {
   desktopUserDataDirNameForRegion,
   resolveDesktopDevRegion,
   resolveDesktopDevStartupConfig,
+  resolveWorktreeIsolationFromCwd,
   stripDesktopDevRegionArgs,
+  worktreeNameFromPath,
 } from "../shared/desktop-dev-region.mjs";
 
 test("desktop shared userData follows the region identity", () => {
@@ -187,5 +190,119 @@ test("an explicit endpoint manifest override remains higher priority than the re
       endpointsCdn: false,
       endpointManifestFile: "config/custom-endpoint.json",
     },
+  );
+});
+
+// ── worktree 自动隔离（issue #2635）──────────────────────────────────────────
+
+const worktreeCwd = (...segments) => path.join(".cindy-worktrees", ...segments);
+
+test("worktreeNameFromPath extracts the name from worktree root and nested cwd", () => {
+  assert.equal(worktreeNameFromPath(worktreeCwd("epic-thompson")), "epic-thompson");
+  assert.equal(
+    worktreeNameFromPath(worktreeCwd("epic-thompson", "apps", "desktop")),
+    "epic-thompson",
+  );
+  // 迁移前的旧目录形态同样识别
+  assert.equal(
+    worktreeNameFromPath(path.join(".xdt-worktrees", "legacy-tree")),
+    "legacy-tree",
+  );
+  // 非 worktree 路径一律 null
+  assert.equal(worktreeNameFromPath(path.join("somewhere", "else")), null);
+  assert.equal(worktreeNameFromPath("."), null);
+});
+
+test("worktree dev launch auto-derives the named isolation sandbox", () => {
+  assert.deepEqual(
+    resolveWorktreeIsolationFromCwd({
+      cwd: worktreeCwd("epic-thompson"),
+      argv: [],
+      env: {},
+    }),
+    { worktreeName: "epic-thompson" },
+  );
+  assert.deepEqual(
+    resolveWorktreeIsolationFromCwd({
+      cwd: worktreeCwd("epic-thompson", "apps", "desktop"),
+      argv: ["start", "--"],
+      env: {},
+    }),
+    { worktreeName: "epic-thompson" },
+  );
+  // 旧目录形态同样命中
+  assert.deepEqual(
+    resolveWorktreeIsolationFromCwd({
+      cwd: path.join(".xdt-worktrees", "legacy-tree"),
+      argv: [],
+      env: {},
+    }),
+    { worktreeName: "legacy-tree" },
+  );
+});
+
+test("worktree dev launch honors explicit isolation/sharing intent and never overrides it", () => {
+  for (const argv of [
+    ["--isolated"],
+    ["--isolated=feature-a"],
+    ["--passive"],
+    ["--preserve-running"],
+    ["start", "--", "--isolated=feature-a"],
+  ]) {
+    assert.equal(
+      resolveWorktreeIsolationFromCwd({
+        cwd: worktreeCwd("epic-thompson"),
+        argv,
+        env: {},
+      }),
+      null,
+      `argv ${JSON.stringify(argv)} must suppress auto-isolation`,
+    );
+  }
+  assert.equal(
+    resolveWorktreeIsolationFromCwd({
+      cwd: worktreeCwd("epic-thompson"),
+      argv: [],
+      env: { XDT_ISOLATED: "1" },
+    }),
+    null,
+  );
+  assert.equal(
+    resolveWorktreeIsolationFromCwd({
+      cwd: worktreeCwd("epic-thompson"),
+      argv: [],
+      env: { XDT_USER_DATA_DIR: "C:\\custom\\profile" },
+    }),
+    null,
+  );
+});
+
+test("worktree dev launch outside a managed worktree keeps the shared-profile semantics", () => {
+  assert.equal(
+    resolveWorktreeIsolationFromCwd({ cwd: path.join("base", "repo"), argv: [], env: {} }),
+    null,
+  );
+  assert.equal(
+    resolveWorktreeIsolationFromCwd({ cwd: ".", argv: [], env: {} }),
+    null,
+  );
+});
+
+test("worktree dev launch falls back to the default sandbox for invalid names", () => {
+  assert.deepEqual(
+    resolveWorktreeIsolationFromCwd({
+      cwd: worktreeCwd("invalid-name-with-1234567890-1234567890-1234567890-123"),
+      argv: [],
+      env: {},
+    }),
+    { worktreeName: null },
+  );
+  assert.deepEqual(
+    resolveWorktreeIsolationFromCwd({
+      cwd: worktreeCwd("has space"),
+      argv: [],
+      env: {},
+    }),
+    { worktreeName: null },
   );
 });

--- a/scripts/__tests__/restart-desktop-remote.test.mjs
+++ b/scripts/__tests__/restart-desktop-remote.test.mjs
@@ -559,6 +559,25 @@ test("devEnvPrefix omits harness envs when unset (whitelist stays opt-in)", () =
 	assert.equal(devEnvPrefix({}, "darwin"), "");
 });
 
+test("devEnvPrefix passes the restart-managed marker so auto-isolation never overrides restart semantics", () => {
+	// XDT_RESTART_MANAGED 是 restart 链路的显式表态（无参=共库+正常调度），必须
+	// 经白名单透传给 dev 进程；worktree 内裸 dev:remote 的自动隔离判定据此跳过
+	// restart 链路（review-pr P1，PR #2640）。
+	const prefix = devEnvPrefix(
+		{ XDT_RESTART_MANAGED: "1", XDT_SCHEDULER_PASSIVE: "1" },
+		"win32",
+	);
+	assert.ok(
+		prefix.includes('set "XDT_RESTART_MANAGED=1"'),
+		`XDT_RESTART_MANAGED must be passed through: ${prefix}`,
+	);
+	assert.ok(
+		prefix.includes('set "XDT_SCHEDULER_PASSIVE=1"'),
+		`XDT_SCHEDULER_PASSIVE must be passed through: ${prefix}`,
+	);
+	assert.equal(devEnvPrefix({}, "win32"), "");
+});
+
 test("devEnvPrefix passes explicit model catalog test controls to Desktop", () => {
 	const prefix = devEnvPrefix(
 		{

--- a/scripts/restart-desktop-remote.mjs
+++ b/scripts/restart-desktop-remote.mjs
@@ -582,6 +582,7 @@ export function devEnvPrefix(env = process.env, platform = process.platform) {
     ['XDT_USER_DATA_DIR_EPOCH', env.XDT_USER_DATA_DIR_EPOCH],
     ['XDT_DEVICE_ID_OVERRIDE', env.XDT_DEVICE_ID_OVERRIDE],
     ['XDT_SCHEDULER_PASSIVE', env.XDT_SCHEDULER_PASSIVE],
+    ['XDT_RESTART_MANAGED', env.XDT_RESTART_MANAGED],
     ['XDT_ISOLATED', env.XDT_ISOLATED],
     ['XDT_ISOLATED_NAME', env.XDT_ISOLATED_NAME],
     // CDP 端口覆写(bootstrap-electron 消费): 并行多开沙箱时给后起实例换端口。
@@ -758,6 +759,13 @@ async function main() {
   const argv = process.argv.slice(2);
   const killOnly = argv.includes('--kill-only');
   const waitReady = argv.includes('--wait-ready');
+  // 显式表态：本启动由 restart 参数契约管理（无参=共库+正常调度、--isolated=隔离、
+  // --passive / --preserve-running=共享），经 devEnvPrefix 白名单透传给 dev 进程。
+  // worktree 内裸 dev:remote 的自动隔离兜底（desktop-dev-region.mjs 的
+  // resolveWorktreeIsolationFromCwd）据此识别 restart 链路并不干预——否则无参
+  // restart 在 worktree 内会被静默改造成隔离沙箱，违背「不带 = 共库 + 正常调度」
+  // 契约（review-pr P1，PR #2640）。
+  process.env.XDT_RESTART_MANAGED = '1';
   const preserveRunning = argv.includes('--preserve-running');
   const replaceRunningArg = argv.find((arg) => arg.startsWith('--replace-running-root='));
   const replaceRunningRoot = replaceRunningArg

--- a/scripts/shared/desktop-dev-region.mjs
+++ b/scripts/shared/desktop-dev-region.mjs
@@ -149,6 +149,24 @@ export function applyDesktopDevStartupConfig(options) {
 }
 
 /**
+ * 清除继承自宿主的 dev 启动覆写（返回清除后的新对象，不改入参）。
+ *
+ * 当宿主 Desktop 以 --isolated 模式运行、Agent 从它 spawn 时，XDT_USER_DATA_DIR /
+ * XDT_USER_DATA_DIR_EPOCH / XDT_DEVICE_ID_OVERRIDE 会留在 process.env 并被 agent
+ * 继承。worktree 自动隔离命中后若不清除，resolveDevCliFlags 会优先采用宿主 userData、
+ * 且因已有 device override 不派生新身份——注入的沙箱语义被覆盖（review-pr P1,
+ * PR #2640）。清除后沙箱目录与独立 deviceId 由注入的 XDT_ISOLATED / XDT_ISOLATED_NAME
+ * 正常派生。
+ */
+export function clearInheritedIsolationOverrides(env) {
+  const next = { ...env };
+  delete next.XDT_USER_DATA_DIR;
+  delete next.XDT_USER_DATA_DIR_EPOCH;
+  delete next.XDT_DEVICE_ID_OVERRIDE;
+  return next;
+}
+
+/**
  * 从启动 cwd 提取托管 worktree 名；不在 worktree 目录下时返回 null。
  * cwd 可以是 worktree 根或其任意子目录（如 apps/desktop），沿路径段找
  * `.cindy-worktrees` / `.xdt-worktrees`，取紧随其后的目录名。

--- a/scripts/shared/desktop-dev-region.mjs
+++ b/scripts/shared/desktop-dev-region.mjs
@@ -178,8 +178,11 @@ export function worktreeNameFromPath(cwd) {
  * - cwd 命中托管 worktree 且调用方未声明任何显式模式时返回 `{ worktreeName }`；
  *   worktree 名不合法时返回 `{ worktreeName: null }`（仍隔离，回退默认沙箱，与
  *   devCliFlags 的 invalidIsolationName 语义一致——回落到不隔离会混进正式版数据）；
- * - 显式 `--isolated[=<名>]` / `--passive` / `--preserve-running`、`XDT_ISOLATED=1`
- *   或 `XDT_USER_DATA_DIR` 已设置时返回 null（显式意图优先，不覆盖用户选择）；
+ * - 显式 `--isolated[=<名>]` / `--passive` / `--preserve-running`、`XDT_ISOLATED=1`、
+ *   `XDT_USER_DATA_DIR`、`XDT_SCHEDULER_PASSIVE=1`（restart --passive /
+ *   --preserve-running 透传的共享意图）或 `XDT_RESTART_MANAGED=1`（restart 链路：
+ *   参数契约显式，默认=共库+正常调度，由 restart 自己负责，不套自动隔离）已设置时
+ *   返回 null（显式意图优先，不覆盖用户选择）；
  * - baseRepo 直跑（cwd 不在 worktree 下）返回 null，保持既有共库语义不变。
  */
 export function resolveWorktreeIsolationFromCwd({
@@ -200,6 +203,15 @@ export function resolveWorktreeIsolationFromCwd({
   }
   if (env.XDT_ISOLATED === "1") return null;
   if (env.XDT_USER_DATA_DIR?.trim()) return null;
+  // restart --passive / --preserve-running 只透传 XDT_SCHEDULER_PASSIVE=1（argv 侧
+  // 没有 --passive / --preserve-running）——共享意图必须被识别，否则会被误隔离，
+  // 违背「passive 数据仍与其它实例共享 / preserve 复用当前登录」承诺。
+  if (env.XDT_SCHEDULER_PASSIVE === "1") return null;
+  // restart 链路（restart-desktop-remote.mjs → desktop-dev-runner → dev:desktop:remote）
+  // 的启动参数契约是显式的：无参=共库+正常调度、--isolated=隔离、--passive /
+  // --preserve-running=共享。它不需要自动隔离兜底，显式表态后一律不干预，防止
+  // worktree 内无参 restart 被静默改造成隔离沙箱（review-pr P1, PR #2640）。
+  if (env.XDT_RESTART_MANAGED === "1") return null;
 
   const name = worktreeNameFromPath(cwd);
   if (name === null) return null;

--- a/scripts/shared/desktop-dev-region.mjs
+++ b/scripts/shared/desktop-dev-region.mjs
@@ -179,15 +179,20 @@ export function worktreeNameFromPath(cwd) {
  *   worktree 名不合法时返回 `{ worktreeName: null }`（仍隔离，回退默认沙箱，与
  *   devCliFlags 的 invalidIsolationName 语义一致——回落到不隔离会混进正式版数据）；
  * - 显式 `--isolated[=<名>]` / `--passive`（argv，人类裸跑 `pnpm dev:remote -- --passive`
- *   的合法用法，Electron 侧 resolveDevCliFlags 认识并收敛为被动模式）、
- *   `XDT_ISOLATED=1`、`XDT_USER_DATA_DIR` 或 `XDT_RESTART_MANAGED=1`（restart 链路：
- *   参数契约显式，默认=共库+正常调度，由 restart 自己负责，不套自动隔离）已设置时
- *   返回 null（显式意图优先，不覆盖用户选择）；
- * - `XDT_SCHEDULER_PASSIVE=1` **单独出现时不豁免**：它是 restart --passive /
- *   --preserve-running 透传的标记，但会沿 Electron → agent 子进程继承（buildCodexEnv /
- *   PI spawn env 复制 process.env）——agent 在 worktree 跑裸 dev:remote 时若凭它豁免
- *   会重新共享 profile/deviceId 互踢。restart 链路本身已由 XDT_RESTART_MANAGED 识别，
- *   无需也不应依赖这个可长期继承的 passive 标记（review-pr P1, PR #2640）；
+ *   的合法用法，Electron 侧 resolveDevCliFlags 认识并收敛为被动模式）已设置时返回
+ *   null（显式意图优先，不覆盖用户选择）；
+ * - `XDT_RESTART_MANAGED=1`（restart 链路：参数契约显式，默认=共库+正常调度、--isolated
+ *   =隔离、--passive / --preserve-running=共享，由 restart 自己负责，不套自动隔离）
+ *   已设置时返回 null——这是**唯一**可靠的 env 豁免标记（one-hop，dev-remote-env /
+ *   dev-local-env 判定后从 Electron env 删除，不会被子进程继承）；
+ * - 其余 env 变量**一律不豁免**（review-pr P1×3, PR #2640）：`XDT_ISOLATED` /
+ *   `XDT_USER_DATA_DIR` / `XDT_SCHEDULER_PASSIVE` 都是宿主 Desktop（可能以 --isolated /
+ *   --passive 模式运行）留在 process.env 的变量，会沿 Electron → agent 子进程继承
+ *   （buildCodexEnv / PI spawn env 复制 process.env）——agent 在 worktree 跑裸
+ *   dev:remote 时若凭它们豁免，会复用宿主 userData（单实例锁冲突立即退出 / passive
+ *   并发开沙箱）或重新共享 profile/deviceId 互踢。restart 链路的 --isolated /
+ *   --passive / --preserve-running 已由 XDT_RESTART_MANAGED 识别，无需也不应依赖这些
+ *   可长期继承的变量；
  * - `--preserve-running` **不在** argv 豁免清单：裸 dev 路径上 Electron 侧不认这个参数
  *   （只有 restart 会翻译成 XDT_SCHEDULER_PASSIVE=1），豁免它会共享 userData 却
  *   正常调度 + 正常单实例锁（review-pr P1, PR #2640）；restart 链路经 env 标记识别；
@@ -208,15 +213,12 @@ export function resolveWorktreeIsolationFromCwd({
   ) {
     return null;
   }
-  if (env.XDT_ISOLATED === "1") return null;
-  if (env.XDT_USER_DATA_DIR?.trim()) return null;
   // restart 链路（restart-desktop-remote.mjs → desktop-dev-runner → dev:desktop:remote）
-  // 的启动参数契约是显式的：无参=共库+正常调度、--isolated=隔离、--passive /
-  // --preserve-running=共享。它不需要自动隔离兜底，显式表态后一律不干预，防止
-  // worktree 内无参 restart 被静默改造成隔离沙箱（review-pr P1, PR #2640）。
-  // 注意 XDT_SCHEDULER_PASSIVE 本身不豁免（会沿 Electron → agent 继承），只有
-  // XDT_RESTART_MANAGED 是可靠的 restart 识别标记（one-hop，dev-remote-env 判定后
-  // 从 Electron env 删除）。
+  // 的启动参数契约是显式的，由 XDT_RESTART_MANAGED（one-hop 标记）识别——无参=共库+
+  // 正常调度、--isolated=隔离、--passive / --preserve-running=共享。该标记判定后即从
+  // Electron env 删除，不会被子进程继承，是可靠的 restart 识别信号。其它 env 变量
+  // （XDT_ISOLATED / XDT_USER_DATA_DIR / XDT_SCHEDULER_PASSIVE）都可能是宿主 Desktop
+  // 留在 process.env 的、会被 agent 继承的变量，一律不视为本次显式配置。
   if (env.XDT_RESTART_MANAGED === "1") return null;
 
   const name = worktreeNameFromPath(cwd);

--- a/scripts/shared/desktop-dev-region.mjs
+++ b/scripts/shared/desktop-dev-region.mjs
@@ -178,15 +178,19 @@ export function worktreeNameFromPath(cwd) {
  * - cwd 命中托管 worktree 且调用方未声明任何显式模式时返回 `{ worktreeName }`；
  *   worktree 名不合法时返回 `{ worktreeName: null }`（仍隔离，回退默认沙箱，与
  *   devCliFlags 的 invalidIsolationName 语义一致——回落到不隔离会混进正式版数据）；
- * - 显式 `--isolated[=<名>]` / `--passive`、`XDT_ISOLATED=1`、`XDT_USER_DATA_DIR`、
- *   `XDT_SCHEDULER_PASSIVE=1`（restart --passive / --preserve-running 透传的共享
- *   意图）或 `XDT_RESTART_MANAGED=1`（restart 链路：参数契约显式，默认=共库+正常
- *   调度，由 restart 自己负责，不套自动隔离）已设置时返回 null（显式意图优先，
- *   不覆盖用户选择）；
- * - `--preserve-running` **不在**豁免清单：裸 dev 路径上 Electron 侧不认这个参数
+ * - 显式 `--isolated[=<名>]` / `--passive`（argv，人类裸跑 `pnpm dev:remote -- --passive`
+ *   的合法用法，Electron 侧 resolveDevCliFlags 认识并收敛为被动模式）、
+ *   `XDT_ISOLATED=1`、`XDT_USER_DATA_DIR` 或 `XDT_RESTART_MANAGED=1`（restart 链路：
+ *   参数契约显式，默认=共库+正常调度，由 restart 自己负责，不套自动隔离）已设置时
+ *   返回 null（显式意图优先，不覆盖用户选择）；
+ * - `XDT_SCHEDULER_PASSIVE=1` **单独出现时不豁免**：它是 restart --passive /
+ *   --preserve-running 透传的标记，但会沿 Electron → agent 子进程继承（buildCodexEnv /
+ *   PI spawn env 复制 process.env）——agent 在 worktree 跑裸 dev:remote 时若凭它豁免
+ *   会重新共享 profile/deviceId 互踢。restart 链路本身已由 XDT_RESTART_MANAGED 识别，
+ *   无需也不应依赖这个可长期继承的 passive 标记（review-pr P1, PR #2640）；
+ * - `--preserve-running` **不在** argv 豁免清单：裸 dev 路径上 Electron 侧不认这个参数
  *   （只有 restart 会翻译成 XDT_SCHEDULER_PASSIVE=1），豁免它会共享 userData 却
- *   正常调度 + 正常单实例锁，造成定时任务重复 / 无法再开预览（review-pr P1，
- *   PR #2640）；restart 链路经 env 标记识别，不受影响；
+ *   正常调度 + 正常单实例锁（review-pr P1, PR #2640）；restart 链路经 env 标记识别；
  * - baseRepo 直跑（cwd 不在 worktree 下）返回 null，保持既有共库语义不变。
  */
 export function resolveWorktreeIsolationFromCwd({
@@ -206,14 +210,13 @@ export function resolveWorktreeIsolationFromCwd({
   }
   if (env.XDT_ISOLATED === "1") return null;
   if (env.XDT_USER_DATA_DIR?.trim()) return null;
-  // restart --passive / --preserve-running 只透传 XDT_SCHEDULER_PASSIVE=1（argv 侧
-  // 没有 --passive / --preserve-running）——共享意图必须被识别，否则会被误隔离，
-  // 违背「passive 数据仍与其它实例共享 / preserve 复用当前登录」承诺。
-  if (env.XDT_SCHEDULER_PASSIVE === "1") return null;
   // restart 链路（restart-desktop-remote.mjs → desktop-dev-runner → dev:desktop:remote）
   // 的启动参数契约是显式的：无参=共库+正常调度、--isolated=隔离、--passive /
   // --preserve-running=共享。它不需要自动隔离兜底，显式表态后一律不干预，防止
   // worktree 内无参 restart 被静默改造成隔离沙箱（review-pr P1, PR #2640）。
+  // 注意 XDT_SCHEDULER_PASSIVE 本身不豁免（会沿 Electron → agent 继承），只有
+  // XDT_RESTART_MANAGED 是可靠的 restart 识别标记（one-hop，dev-remote-env 判定后
+  // 从 Electron env 删除）。
   if (env.XDT_RESTART_MANAGED === "1") return null;
 
   const name = worktreeNameFromPath(cwd);

--- a/scripts/shared/desktop-dev-region.mjs
+++ b/scripts/shared/desktop-dev-region.mjs
@@ -178,11 +178,15 @@ export function worktreeNameFromPath(cwd) {
  * - cwd 命中托管 worktree 且调用方未声明任何显式模式时返回 `{ worktreeName }`；
  *   worktree 名不合法时返回 `{ worktreeName: null }`（仍隔离，回退默认沙箱，与
  *   devCliFlags 的 invalidIsolationName 语义一致——回落到不隔离会混进正式版数据）；
- * - 显式 `--isolated[=<名>]` / `--passive` / `--preserve-running`、`XDT_ISOLATED=1`、
- *   `XDT_USER_DATA_DIR`、`XDT_SCHEDULER_PASSIVE=1`（restart --passive /
- *   --preserve-running 透传的共享意图）或 `XDT_RESTART_MANAGED=1`（restart 链路：
- *   参数契约显式，默认=共库+正常调度，由 restart 自己负责，不套自动隔离）已设置时
- *   返回 null（显式意图优先，不覆盖用户选择）；
+ * - 显式 `--isolated[=<名>]` / `--passive`、`XDT_ISOLATED=1`、`XDT_USER_DATA_DIR`、
+ *   `XDT_SCHEDULER_PASSIVE=1`（restart --passive / --preserve-running 透传的共享
+ *   意图）或 `XDT_RESTART_MANAGED=1`（restart 链路：参数契约显式，默认=共库+正常
+ *   调度，由 restart 自己负责，不套自动隔离）已设置时返回 null（显式意图优先，
+ *   不覆盖用户选择）；
+ * - `--preserve-running` **不在**豁免清单：裸 dev 路径上 Electron 侧不认这个参数
+ *   （只有 restart 会翻译成 XDT_SCHEDULER_PASSIVE=1），豁免它会共享 userData 却
+ *   正常调度 + 正常单实例锁，造成定时任务重复 / 无法再开预览（review-pr P1，
+ *   PR #2640）；restart 链路经 env 标记识别，不受影响；
  * - baseRepo 直跑（cwd 不在 worktree 下）返回 null，保持既有共库语义不变。
  */
 export function resolveWorktreeIsolationFromCwd({
@@ -195,8 +199,7 @@ export function resolveWorktreeIsolationFromCwd({
       (arg) =>
         arg === "--isolated" ||
         arg.startsWith("--isolated=") ||
-        arg === "--passive" ||
-        arg === "--preserve-running",
+        arg === "--passive",
     )
   ) {
     return null;

--- a/scripts/shared/desktop-dev-region.mjs
+++ b/scripts/shared/desktop-dev-region.mjs
@@ -1,6 +1,18 @@
 import os from "node:os";
 import path from "node:path";
 
+/**
+ * 内置 worktree 目录段名（含迁移前形态）。命中时视为「worktree 会话内的 dev 启动」。
+ * 与 apps/desktop/src/main/worktree 的托管目录命名保持一致；判据刻意只认路径段，
+ * 不校验 baseRepo 是否真的注册过——防止把 worktree 名写进目录的任何拷贝都算数，
+ * 也避免脚本侧依赖 app 数据库。
+ */
+const WORKTREE_DIR_NAMES = new Set([".cindy-worktrees", ".xdt-worktrees"]);
+
+/** 与 apps/desktop/src/main/devCliFlags.ts 的 ISOLATION_NAME_RE 同款：合法名字才能进
+ * 命名沙箱（目录名跨平台安全 + 并入 deviceId 后不超服务端 64 字符白名单）。 */
+const ISOLATION_NAME_RE = /^[A-Za-z0-9_-]{1,32}$/;
+
 /** Desktop dev 支持的区域身份。 */
 export const DESKTOP_DEV_REGIONS = Object.freeze(["cn", "global", "dev"]);
 
@@ -134,4 +146,62 @@ export function applyDesktopDevStartupConfig(options) {
     env.XDT_ENDPOINT_MANIFEST_FILE = config.endpointManifestFile;
   }
   return config;
+}
+
+/**
+ * 从启动 cwd 提取托管 worktree 名；不在 worktree 目录下时返回 null。
+ * cwd 可以是 worktree 根或其任意子目录（如 apps/desktop），沿路径段找
+ * `.cindy-worktrees` / `.xdt-worktrees`，取紧随其后的目录名。
+ * 纯路径段判定（同时识别 `/` 与 `\`），不 resolve 到磁盘：worktree 名只取决于
+ * 路径形态，且相对路径在测试与真实 cwd 之间不应有差异。
+ */
+export function worktreeNameFromPath(cwd) {
+  const segments = cwd.split(/[\\/]+/).filter(Boolean);
+  for (let index = 0; index < segments.length - 1; index += 1) {
+    if (WORKTREE_DIR_NAMES.has(segments[index])) {
+      return segments[index + 1];
+    }
+  }
+  return null;
+}
+
+/**
+ * 判定「worktree 会话内的裸 dev 启动」是否需要自动注入隔离意图。
+ *
+ * 背景（issue #2635）：内置 worktree 里跑 `pnpm dev:remote`（不经 restart 包装）时
+ * 若不带 `--isolated`，dev 会用区域默认 profile（global→CindyGlobal）+ 物理机
+ * machineId 作为 deviceId——与同区域 release 撞设备身份：dev 登录按 (userId,
+ * deviceId) 覆盖 release 的服务端 refresh token，release 下次续期即 401 被登出
+ * （日志形态：device-link 4409 乒乓 → INVALID_REFRESH_TOKEN → clearing auth）。
+ *
+ * 语义：
+ * - cwd 命中托管 worktree 且调用方未声明任何显式模式时返回 `{ worktreeName }`；
+ *   worktree 名不合法时返回 `{ worktreeName: null }`（仍隔离，回退默认沙箱，与
+ *   devCliFlags 的 invalidIsolationName 语义一致——回落到不隔离会混进正式版数据）；
+ * - 显式 `--isolated[=<名>]` / `--passive` / `--preserve-running`、`XDT_ISOLATED=1`
+ *   或 `XDT_USER_DATA_DIR` 已设置时返回 null（显式意图优先，不覆盖用户选择）；
+ * - baseRepo 直跑（cwd 不在 worktree 下）返回 null，保持既有共库语义不变。
+ */
+export function resolveWorktreeIsolationFromCwd({
+  cwd = process.cwd(),
+  argv = [],
+  env = process.env,
+} = {}) {
+  if (
+    argv.some(
+      (arg) =>
+        arg === "--isolated" ||
+        arg.startsWith("--isolated=") ||
+        arg === "--passive" ||
+        arg === "--preserve-running",
+    )
+  ) {
+    return null;
+  }
+  if (env.XDT_ISOLATED === "1") return null;
+  if (env.XDT_USER_DATA_DIR?.trim()) return null;
+
+  const name = worktreeNameFromPath(cwd);
+  if (name === null) return null;
+  return { worktreeName: ISOLATION_NAME_RE.test(name) ? name : null };
 }


### PR DESCRIPTION
## 这次改了什么

### 摘要

内置 worktree 会话里跑 `pnpm dev:remote`（不经 restart 包装的裸启动）时若不带 `--isolated`，dev 会沿用区域默认 profile（global→`CindyGlobal`）+ 物理机 `deviceId`——与同机 release 撞设备身份：dev 登录按 `(userId, deviceId)` 覆盖 release 的服务端 refresh token，把 release 挤下线（device-link 4409 乒乓 → `INVALID_REFRESH_TOKEN` → 正式版被登出）。本 PR 让 worktree 内的裸 dev 启动自动按命名隔离沙箱处理，从源头消除互踢。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：#2635
- 本 PR 包含：
  - `scripts/shared/desktop-dev-region.mjs`：新增 `worktreeNameFromPath` / `resolveWorktreeIsolationFromCwd` 纯函数——从 cwd 路径段识别 `.cindy-worktrees` / `.xdt-worktrees`（含迁移前形态）取 worktree 名；显式 `--isolated[=<名>]` / `--passive` / `--preserve-running`、`XDT_ISOLATED=1`、`XDT_USER_DATA_DIR` 一律不干预；名字非法回退默认沙箱；baseRepo 直跑保持共库语义
  - `apps/desktop/scripts/dev-remote-env.mjs`：启动前应用该判定，命中则注入 `XDT_ISOLATED=1` + `XDT_ISOLATED_NAME=<worktree 名>` 并打印提示
  - `docs/dev-rules/desktop-development.md`：补充「内置 worktree 内裸 dev 启动自动按隔离沙箱处理」说明
  - `scripts/__tests__/desktop-dev-region.test.mjs`：新增 5 组覆盖用例
- 明确不包含：`dev-local-env.mjs`（local 模式连 localhost 端点，无互踢风险，保持原语义）；服务端任何改动
- 用户可见变化：在 `.cindy-worktrees/<名>` 下跑 `pnpm dev:remote` 时会自动进入命名隔离沙箱（独立 userData / 登录态 / 设备身份），控制台打印提示；不再与正式版互踢
- 是否存在 breaking change：无

### UI 变化

不涉及（纯脚本启动链 + 文档 + 测试，无 UI 代码路径）。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop run --if-present typecheck
结果：exit 0（首次因 worktree 缺 node_modules 失败，pnpm install 后通过）

pnpm test:unit
结果：0 FAIL（381 pass / 7 SKIP，SKIP 均为无测试的 workspace）

node --test scripts/__tests__/desktop-dev-region.test.mjs scripts/__tests__/dev-docs-contract.test.mjs scripts/__tests__/dev-migration-policy.test.mjs scripts/__tests__/restart-desktop-remote.test.mjs
结果：59 pass / 0 fail

pnpm check:dco
结果：DCO check passed
```

### 手工验证

- 真实 worktree cwd（`D:\cindy-moved\.cindy-worktrees\calm-newton`）冒烟：裸启动 → `{worktreeName: "calm-newton"}`；显式 `--isolated=x` / `XDT_ISOLATED=1` → 不干预；baseRepo 直跑 → 不干预

### 未执行的验证

- 端到端双开实测（worktree dev + release 同时登录同账号验证不再 4409 / 401）未在本机执行：issue 复现时 dev 进程（pid 108172）仍在运行，需停掉该实例后按修复版重新启动才能验证；建议合入后由维护者或复现者在后续构建确认。日志侧证据链（4409 乒乓 → 401 登出）已在 issue #2635 评论中完整呈现。

## 风险

- 低。改动仅影响 dev 启动包装（`dev-remote-env.mjs`）与共享纯函数，packaged 版本零影响；显式模式与 baseRepo 直跑语义完全不变。worktree 路径段判定是纯字符串匹配，不校验 baseRepo 注册状态——防误判的覆盖测试已补。