### PR TITLE
fix: 恢复 Pi 隔离快照 Skill provenance scope

### DIFF
--- a/packages/maker-core/src/agents/pi/__tests__/pi-rpc-resource-discovery.integration.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/pi-rpc-resource-discovery.integration.test.ts
@@ -901,7 +901,7 @@ describe.skipIf(!existsSync(PI_BINARY))('Pi v0.83.0 RPC resource discovery facts
           baseDir: snapshotSkill,
           path: path.join(snapshotSkill, 'SKILL.md'),
           source: 'local',
-          scope: 'project',
+          scope: 'temporary',
         }),
       }),
     ]));

--- a/packages/maker-core/src/agents/pi/__tests__/project-resource-assembly.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/project-resource-assembly.test.ts
@@ -704,7 +704,7 @@ describe('Pi approved project resource assembly', () => {
         name: 'skill:demo',
         source: 'skill',
         sourceInfo: {
-          scope: 'project',
+          scope: 'temporary',
           source: 'local',
           baseDir: skillPath,
           path: `${skillPath}/SKILL.md`,


### PR DESCRIPTION
## 这次改了什么

### 摘要

恢复 `configHome/project-resources` 隔离快照中本地 Skill 的正确 provenance scope：`temporary`。
工作区内直接显式 `--skill` 的 `project` 语义保持不变。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：修正 Pi RPC 隔离快照断言和 project-resource reconcile 正向断言。
- 明确不包含：不改变运行时 provenance 解析逻辑，不改变工作区显式 Skill 的 `project` 语义。
- 用户可见变化：无直接 UI 变化；修复隔离快照资源来源标记。
- 是否存在 breaking change：无。

### UI 变化

- 不涉及 UI。
- 引用的设计规范：不涉及。

## 怎么验证的

### 自动验证

```text
pnpm --filter @cindy/maker-core test -- src/agents/claude-code/__tests__/plan-mode.test.ts src/agents/codex/index.test.ts src/agents/pi/__tests__/pi-auto-review-dispatch.test.ts src/agents/pi/__tests__/pi-rpc-resource-discovery.integration.test.ts src/agents/pi/__tests__/project-resource-assembly.test.ts
结果：5 个测试文件通过，571 项通过，11 项固定 Pi RPC 用例跳过。

pnpm --filter @cindy/maker-core build
结果：通过。

pnpm test:unit -- --workspace-concurrency=1
结果：全部必需 workspace 通过；无测试 workspace 按规则跳过。

pnpm check:dco
git diff --check
结果：均通过。
```

### 手工验证

无；本次不涉及 UI 或手动交互流程。

### 未执行的验证

固定 Pi v0.83.0 真实 RPC 下载用例因二进制获取条件跳过，其他相关测试均已通过。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 maker-core 的 Pi 资源发现测试语义。
- 回滚方式：回滚本 PR 的单个提交即可。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] UI 改动已按设计规范处理（本 PR 不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已确认测试结果