### PR TITLE
fix(desktop): 远程模型列表不再因一条坏目录整表失败

### DIFF
--- a/apps/desktop/src/renderer/__tests__/agentCapabilitiesDeviceCache.test.ts
+++ b/apps/desktop/src/renderer/__tests__/agentCapabilitiesDeviceCache.test.ts
@@ -283,9 +283,9 @@ describe('useAgentCapabilities deviceId-aware cache', () => {
     expect(mod.getCachedCapabilities('codex', 'dev-invalid')).toBeNull();
   });
 
-  it('capabilities 模型数组混入非法元素时整份进入 error，不得部分发布或落缓存', async () => {
+  it('capabilities 模型数组混入非法元素时丢掉坏项，保留合法模型', async () => {
     const invoke = vi.fn(async () => ({
-      ...caps('invalid'),
+      ...caps('valid'),
       availableModels: [...caps('valid').availableModels, null],
     }));
     const getCapabilities = vi.fn(async (k: string) => caps(`local:${k}`));
@@ -298,18 +298,22 @@ describe('useAgentCapabilities deviceId-aware cache', () => {
 
     await mod.prefetchDeviceCapabilities('dev-invalid-item');
 
-    expect(listener).toHaveBeenCalledWith({
-      status: 'error',
-      error: 'Invalid agent capabilities response',
-    });
-    expect(mod.getCachedCapabilities('codex', 'dev-invalid-item')).toBeNull();
+    expect(mod.getCachedCapabilities('codex', 'dev-invalid-item')?.availableModels).toHaveLength(1);
+    expect(listener).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'ready',
+        capabilities: expect.objectContaining({
+          availableModels: [expect.objectContaining({ displayName: 'valid' })],
+        }),
+      }),
+    );
   });
 
   it.each([
     { label: '空数组', value: [] },
     { label: '未知 agent', value: ['future-agent'] },
     { label: '重复 agent', value: ['codex', 'codex'] },
-  ])('newSessionDefault 非法（$label）时整份 capabilities fail closed', async ({ value }) => {
+  ])('newSessionDefault 非法（$label）时丢掉该模型，不整表失败', async ({ value }) => {
     const invoke = vi.fn(async () => ({
       ...caps('invalid-default'),
       availableModels: [
@@ -329,11 +333,13 @@ describe('useAgentCapabilities deviceId-aware cache', () => {
 
     await mod.prefetchDeviceCapabilities('dev-invalid-default');
 
-    expect(listener).toHaveBeenCalledWith({
-      status: 'error',
-      error: 'Invalid agent capabilities response',
-    });
-    expect(mod.getCachedCapabilities('codex', 'dev-invalid-default')).toBeNull();
+    expect(mod.getCachedCapabilities('codex', 'dev-invalid-default')?.availableModels).toEqual([]);
+    expect(listener).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'ready',
+        capabilities: expect.objectContaining({ availableModels: [] }),
+      }),
+    );
   });
 
   it('接受 v3 的 Pi 新任务默认标记', async () => {
@@ -358,7 +364,7 @@ describe('useAgentCapabilities deviceId-aware cache', () => {
     ).toEqual(['pi']);
   });
 
-  it('模型默认 effort 不在可用列表中时不得落缓存', async () => {
+  it('模型默认 effort 不在可用列表中时丢掉该行，不整表失败', async () => {
     const invoke = vi.fn(async () => ({
       ...caps('invalid-effort'),
       availableModels: [
@@ -381,11 +387,13 @@ describe('useAgentCapabilities deviceId-aware cache', () => {
 
     await mod.prefetchDeviceCapabilities('dev-invalid-effort');
 
-    expect(listener).toHaveBeenCalledWith({
-      status: 'error',
-      error: 'Invalid agent capabilities response',
-    });
-    expect(mod.getCachedCapabilities('codex', 'dev-invalid-effort')).toBeNull();
+    expect(mod.getCachedCapabilities('codex', 'dev-invalid-effort')?.availableModels).toEqual([]);
+    expect(listener).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'ready',
+        capabilities: expect.objectContaining({ availableModels: [] }),
+      }),
+    );
   });
 
   it.each(['effortLevels', 'permissionModes'] as const)(

--- a/apps/desktop/src/renderer/__tests__/deviceProvidersCache.test.ts
+++ b/apps/desktop/src/renderer/__tests__/deviceProvidersCache.test.ts
@@ -84,7 +84,7 @@ describe('useDeviceProviders deviceId-aware cache', () => {
     expect(mod.getCachedDeviceProviders('dev-invalid')).toBeNull();
   });
 
-  it('provider 数组混入非法元素时丢掉坏项，保留合法供应商', async () => {
+  it('provider 数组混入非法元素时整份进入 error，不得部分发布或落缓存', async () => {
     const invoke = vi.fn(async () => ({ providers: [provider('valid'), null] }));
     vi.stubGlobal('window', { electronAPI: { deviceLink: { invoke } } });
     const mod = await import('@/hooks/useDeviceProviders');
@@ -93,15 +93,12 @@ describe('useDeviceProviders deviceId-aware cache', () => {
 
     await mod.prefetchDeviceProviders('dev-invalid-item');
 
-    expect(mod.getCachedDeviceProviders('dev-invalid-item')?.providers.map((row) => row.id)).toEqual([
-      'valid',
-    ]);
-    expect(listener).toHaveBeenCalledWith(
-      expect.objectContaining({
-        status: 'ready',
-        providers: [expect.objectContaining({ id: 'valid' })],
-      }),
-    );
+    expect(listener).toHaveBeenCalledWith({
+      status: 'error',
+      error: 'Invalid provider list response',
+      unsupported: false,
+    });
+    expect(mod.getCachedDeviceProviders('dev-invalid-item')).toBeNull();
   });
 
   it('接受不含执行字段的安全投影 provider', async () => {

--- a/apps/desktop/src/renderer/__tests__/deviceProvidersCache.test.ts
+++ b/apps/desktop/src/renderer/__tests__/deviceProvidersCache.test.ts
@@ -84,7 +84,7 @@ describe('useDeviceProviders deviceId-aware cache', () => {
     expect(mod.getCachedDeviceProviders('dev-invalid')).toBeNull();
   });
 
-  it('provider 数组混入非法元素时整份进入 error，不得部分发布或落缓存', async () => {
+  it('provider 数组混入非法元素时丢掉坏项，保留合法供应商', async () => {
     const invoke = vi.fn(async () => ({ providers: [provider('valid'), null] }));
     vi.stubGlobal('window', { electronAPI: { deviceLink: { invoke } } });
     const mod = await import('@/hooks/useDeviceProviders');
@@ -93,12 +93,15 @@ describe('useDeviceProviders deviceId-aware cache', () => {
 
     await mod.prefetchDeviceProviders('dev-invalid-item');
 
-    expect(listener).toHaveBeenCalledWith({
-      status: 'error',
-      error: 'Invalid provider list response',
-      unsupported: false,
-    });
-    expect(mod.getCachedDeviceProviders('dev-invalid-item')).toBeNull();
+    expect(mod.getCachedDeviceProviders('dev-invalid-item')?.providers.map((row) => row.id)).toEqual([
+      'valid',
+    ]);
+    expect(listener).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'ready',
+        providers: [expect.objectContaining({ id: 'valid' })],
+      }),
+    );
   });
 
   it('接受不含执行字段的安全投影 provider', async () => {
@@ -156,25 +159,68 @@ describe('useDeviceProviders deviceId-aware cache', () => {
     expect(connectedProvidersForAgent(cached?.providers ?? [], 'codex')).toEqual([]);
   });
 
-  it('嵌套模型损坏时整份 provider 响应失败', async () => {
+  it('嵌套模型损坏时丢掉坏模型，保留供应商', async () => {
     const malformed = {
       ...provider('malformed-model'),
-      models: { 'claude-code': [null] },
+      models: {
+        'claude-code': [
+          null,
+          {
+            id: 'kept',
+            name: 'Kept',
+            contextWindow: 200_000,
+            efforts: ['medium'],
+            defaultEffort: 'medium',
+          },
+        ],
+      },
     };
     const invoke = vi.fn(async () => ({ providers: [malformed] }));
     vi.stubGlobal('window', { electronAPI: { deviceLink: { invoke } } });
     const mod = await import('@/hooks/useDeviceProviders');
-    const listener = vi.fn();
-    mod.subscribeDeviceProviders('dev-malformed-model', listener);
 
     await mod.prefetchDeviceProviders('dev-malformed-model');
 
-    expect(listener).toHaveBeenCalledWith({
-      status: 'error',
-      error: 'Invalid provider list response',
-      unsupported: false,
-    });
-    expect(mod.getCachedDeviceProviders('dev-malformed-model')).toBeNull();
+    expect(
+      mod.getCachedDeviceProviders('dev-malformed-model')?.providers[0]?.models['claude-code'],
+    ).toEqual([
+      expect.objectContaining({ id: 'kept' }),
+    ]);
+  });
+
+  it('模型有 efforts 却没有自洽 defaultEffort 时丢掉该行，不整表失败', async () => {
+    const invoke = vi.fn(async () => ({
+      providers: [
+        {
+          ...provider('openai'),
+          models: {
+            'claude-code': [
+              {
+                id: 'gpt-5.6-luna',
+                name: 'GPT-5.6-Luna',
+                contextWindow: 1_050_000,
+                efforts: ['low', 'medium', 'high', 'xhigh', 'max'],
+              },
+              {
+                id: 'claude-opus-5',
+                name: 'Claude Opus 5',
+                contextWindow: 200_000,
+                efforts: ['high'],
+                defaultEffort: 'high',
+              },
+            ],
+          },
+        },
+      ],
+    }));
+    vi.stubGlobal('window', { electronAPI: { deviceLink: { invoke } } });
+    const mod = await import('@/hooks/useDeviceProviders');
+
+    await mod.prefetchDeviceProviders('dev-luna');
+
+    expect(
+      mod.getCachedDeviceProviders('dev-luna')?.providers[0]?.models['claude-code'].map((m) => m.id),
+    ).toEqual(['claude-opus-5']);
   });
 
   it.each([
@@ -193,48 +239,6 @@ describe('useDeviceProviders deviceId-aware cache', () => {
         routing: { 'claude-code': { wireProtocol: 'future-protocol' } },
       },
     ],
-    [
-      'model.disabled',
-      {
-        ...providerWithModel('bad-model-disabled'),
-        models: {
-          'claude-code': [
-            {
-              ...providerWithModel('bad-model-disabled').models['claude-code'][0],
-              disabled: 'true',
-            },
-          ],
-        },
-      },
-    ],
-    [
-      'model.supportsFastMode',
-      {
-        ...providerWithModel('bad-fast-mode'),
-        models: {
-          'claude-code': [
-            {
-              ...providerWithModel('bad-fast-mode').models['claude-code'][0],
-              supportsFastMode: 'true',
-            },
-          ],
-        },
-      },
-    ],
-    [
-      'model.defaultEnabled',
-      {
-        ...providerWithModel('bad-default-enabled'),
-        models: {
-          'claude-code': [
-            {
-              ...providerWithModel('bad-default-enabled').models['claude-code'][0],
-              defaultEnabled: 'false',
-            },
-          ],
-        },
-      },
-    ],
   ])('%s 类型损坏时整份 provider 响应失败', async (field, malformed) => {
     const deviceId = `dev-invalid-${field}`;
     const invoke = vi.fn(async () => ({ providers: [malformed] }));
@@ -251,6 +255,46 @@ describe('useDeviceProviders deviceId-aware cache', () => {
       unsupported: false,
     });
     expect(mod.getCachedDeviceProviders(deviceId)).toBeNull();
+  });
+
+  it.each([
+    ['model.disabled', 'true'],
+    ['model.supportsFastMode', 'true'],
+    ['model.defaultEnabled', 'false'],
+  ])('%s 类型损坏时丢掉该模型，不整表失败', async (field, badValue) => {
+    const key = field.split('.')[1] as 'disabled' | 'supportsFastMode' | 'defaultEnabled';
+    const invoke = vi.fn(async () => ({
+      providers: [
+        {
+          ...providerWithModel('kept-provider'),
+          models: {
+            'claude-code': [
+              {
+                ...providerWithModel('kept-provider').models['claude-code'][0],
+                [key]: badValue,
+              },
+              {
+                id: 'good',
+                name: 'Good',
+                contextWindow: 200_000,
+                efforts: ['medium'],
+                defaultEffort: 'medium',
+              },
+            ],
+          },
+        },
+      ],
+    }));
+    vi.stubGlobal('window', { electronAPI: { deviceLink: { invoke } } });
+    const mod = await import('@/hooks/useDeviceProviders');
+
+    await mod.prefetchDeviceProviders(`dev-drop-${key}`);
+
+    expect(
+      mod
+        .getCachedDeviceProviders(`dev-drop-${key}`)
+        ?.providers[0]?.models['claude-code'].map((model) => model.id),
+    ).toEqual(['good']);
   });
 
   it('模型可见性 override 含非布尔值时不得缓存', async () => {

--- a/apps/desktop/src/renderer/__tests__/deviceProvidersCache.test.ts
+++ b/apps/desktop/src/renderer/__tests__/deviceProvidersCache.test.ts
@@ -219,7 +219,7 @@ describe('useDeviceProviders deviceId-aware cache', () => {
     await mod.prefetchDeviceProviders('dev-luna');
 
     expect(
-      mod.getCachedDeviceProviders('dev-luna')?.providers[0]?.models['claude-code'].map((m) => m.id),
+      mod.getCachedDeviceProviders('dev-luna')?.providers[0]?.models['claude-code']?.map((m) => m.id),
     ).toEqual(['claude-opus-5']);
   });
 
@@ -293,7 +293,7 @@ describe('useDeviceProviders deviceId-aware cache', () => {
     expect(
       mod
         .getCachedDeviceProviders(`dev-drop-${key}`)
-        ?.providers[0]?.models['claude-code'].map((model) => model.id),
+        ?.providers[0]?.models['claude-code']?.map((model) => model.id),
     ).toEqual(['good']);
   });
 

--- a/apps/desktop/src/renderer/hooks/useAgentCapabilities.ts
+++ b/apps/desktop/src/renderer/hooks/useAgentCapabilities.ts
@@ -250,9 +250,15 @@ function parseAgentCapabilities(value: unknown): AgentCapabilities {
   if (!isRecord(value)) {
     throw new Error('Invalid agent capabilities response');
   }
+  if (!Array.isArray(value.availableModels)) {
+    throw new Error('Invalid agent capabilities response');
+  }
+  // Same policy as the local model plane: drop a catalog row that cannot
+  // stand on its own (missing defaultEffort, extra junk) instead of
+  // rejecting the whole remote list. One stale model on the controlled
+  // machine was emptying the selector.
+  value.availableModels = value.availableModels.filter(isModelDescriptor);
   if (
-    !Array.isArray(value.availableModels) ||
-    !value.availableModels.every(isModelDescriptor) ||
     typeof value.hasFastMode !== 'boolean' ||
     !Array.isArray(value.effortLevels) ||
     !value.effortLevels.every(isNamedDescriptor) ||

--- a/apps/desktop/src/renderer/hooks/useDeviceProviders.ts
+++ b/apps/desktop/src/renderer/hooks/useDeviceProviders.ts
@@ -139,7 +139,6 @@ export function parseDeviceProvidersPayload(value: unknown): DeviceProvidersPayl
   if (providersIn.length === 0 && value.providers.length > 0) {
     throw new Error('Invalid provider list response');
   }
-  value.providers = providersIn;
   const overrides = value.modelVisibilityOverrides;
   if (
     overrides !== undefined &&
@@ -152,7 +151,7 @@ export function parseDeviceProvidersPayload(value: unknown): DeviceProvidersPayl
   // 但 model-providers 的 connectedProvidersForAgent 需要每个声明的 agent 有一个
   // routing entry 才会把供应商视为可用。只在远程解析边界补齐空 entry，不改变本机
   // registry 对缺失 route 的严格语义，也保留已有 disabled 标记。
-  const providers = value.providers.map((provider) => {
+  const providers = providersIn.map((provider) => {
     const routing = { ...(provider.routing ?? {}) } as ProviderView['routing'];
     for (const agent of provider.agents) {
       if (routing[agent as keyof ProviderView['routing']] === undefined) {

--- a/apps/desktop/src/renderer/hooks/useDeviceProviders.ts
+++ b/apps/desktop/src/renderer/hooks/useDeviceProviders.ts
@@ -97,10 +97,24 @@ function isProviderRoute(value: unknown): boolean {
   );
 }
 
+function sanitizeProviderModels(
+  models: unknown,
+): Record<string, unknown[]> | null {
+  if (!isRecord(models)) return null;
+  const sanitized: Record<string, unknown[]> = {};
+  for (const [agent, entries] of Object.entries(models)) {
+    if (!Array.isArray(entries)) return null;
+    sanitized[agent] = entries.filter(isProviderModel);
+  }
+  return sanitized;
+}
+
 function isProviderView(value: unknown): value is ProviderView {
   if (!isRecord(value)) return false;
   const routing = value.routing;
-  const models = value.models;
+  const models = sanitizeProviderModels(value.models);
+  if (!models) return false;
+  value.models = models;
   return (
     typeof value.id === 'string' &&
     value.id.length > 0 &&
@@ -109,10 +123,6 @@ function isProviderView(value: unknown): value is ProviderView {
     value.agents.every((agent) => typeof agent === 'string') &&
     (routing === undefined ||
       (isRecord(routing) && Object.values(routing).every(isProviderRoute))) &&
-    isRecord(models) &&
-    Object.values(models).every(
-      (entries) => Array.isArray(entries) && entries.every(isProviderModel),
-    ) &&
     typeof value.connected === 'boolean' &&
     isOptionalBoolean(value.suspended)
   );
@@ -122,9 +132,14 @@ export function parseDeviceProvidersPayload(value: unknown): DeviceProvidersPayl
   if (!isRecord(value)) {
     throw new Error('Invalid provider list response');
   }
-  if (!Array.isArray(value.providers) || !value.providers.every(isProviderView)) {
+  if (!Array.isArray(value.providers)) {
     throw new Error('Invalid provider list response');
   }
+  const providersIn = value.providers.filter(isProviderView);
+  if (providersIn.length === 0 && value.providers.length > 0) {
+    throw new Error('Invalid provider list response');
+  }
+  value.providers = providersIn;
   const overrides = value.modelVisibilityOverrides;
   if (
     overrides !== undefined &&

--- a/apps/desktop/src/renderer/hooks/useDeviceProviders.ts
+++ b/apps/desktop/src/renderer/hooks/useDeviceProviders.ts
@@ -132,13 +132,10 @@ export function parseDeviceProvidersPayload(value: unknown): DeviceProvidersPayl
   if (!isRecord(value)) {
     throw new Error('Invalid provider list response');
   }
-  if (!Array.isArray(value.providers)) {
+  if (!Array.isArray(value.providers) || !value.providers.every(isProviderView)) {
     throw new Error('Invalid provider list response');
   }
-  const providersIn = value.providers.filter(isProviderView);
-  if (providersIn.length === 0 && value.providers.length > 0) {
-    throw new Error('Invalid provider list response');
-  }
+  const providersIn = value.providers;
   const overrides = value.modelVisibilityOverrides;
   if (
     overrides !== undefined &&


### PR DESCRIPTION
## 这次改了什么

### 摘要

远程会话的模型选择器会整表失败，只因为被控端目录里有一条站不住的模型。本机目录本来就会丢掉这种行（这次是 `gpt-5.6-luna`：有 efforts，没有自洽的 `defaultEffort`），远程解析却把整份 `maker:provider:list` / `maker:get-capabilities` 判废。控制端改成同一条策略：丢掉坏行，保留其余合法模型。供应商骨架或 routing 非法时仍整表失败。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：远程 capabilities / provider list 解析时跳过无法自洽的模型行
- 明确不包含：修 `gpt-5.6-luna` 目录本身；Work Louder 键盘灯效
- 用户可见变化：远程会话模型列表不再因一条坏模型整表变红；该坏模型本身仍可能不出现
- 是否存在 breaking change：无

### UI 变化

不涉及：纯逻辑重构，无视觉/交互/文案变化。命中 renderer 路径只是因为解析器住在 hooks 里。

- 引用的设计规范：不涉及：纯逻辑重构，无视觉/交互/文案变化

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/renderer/__tests__/deviceProvidersCache.test.ts src/renderer/__tests__/agentCapabilitiesDeviceCache.test.ts
结果：50 passed

pnpm --filter desktop run typecheck
结果：通过
```

全量 `pnpm test:unit` 在本 PR 分支上有 1 个失败：`customProviderDialogPresetLocale.test.tsx`（IME Escape / 预设菜单）。该文件不在本 PR diff 内；干净 `origin/main` 上单独复现也失败（同文件另一条 flake）。按仓库规则交给 CI 兜底，不混入本 PR。

### 手工验证

Desktop remote / device-link 会话：打开远程任务的模型选择器，原先整表红字，修后能列出其余模型。`gpt-5.6-luna` 仍可能不出现。

### 未执行的验证

无。全量单测门禁因上述无关 flake 未整表转绿，已在干净基线核实。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [x] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：控制端解析被控端 `maker:get-capabilities` / `maker:provider:list` 的展示投影。供应商骨架或 routing 仍非法时整表失败；只有单行模型不自洽时跳过该行。
- 回滚 / 降级方式：revert 本 PR，远程选择器回到「一条坏模型整表变红」。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因