### PR TITLE
fix(usage): 从 Codex 的 Anthropic 桥补记 Claude 订阅额度

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/claudeRateLimitHeadersObserver.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/claudeRateLimitHeadersObserver.test.ts
@@ -15,6 +15,7 @@ import type { ResponseObserverCtx } from '@cindy/anthropic-compat-proxy';
 import {
   composeResponseObservers,
   createClaudeRateLimitHeadersObserver,
+  recordClaudeRateLimitHeaders,
   resetClaudeRateLimitHeadersDedup,
   setClaudeRateLimitHeadersListener,
 } from '../claude-rate-limit-headers-observer';
@@ -179,5 +180,135 @@ describe('composeResponseObservers', () => {
     const sinkA = { onData: vi.fn() };
     expect(composeResponseObservers(() => sinkA)(makeCtx())).toBe(sinkA);
     expect(composeResponseObservers(() => undefined, () => null)(makeCtx())).toBeUndefined();
+  });
+});
+
+/**
+ * recordClaudeRateLimitHeaders —— 透明代理与 codex Anthropic 本地桥的共用入口(#2626)。
+ * 桥的 localHandler 绕开 compat-proxy 的转发层, 拿不到 responseObserver, 只能从这里
+ * 回喂; 两条链路必须共用同一份去抖与账号归属状态。
+ */
+describe('recordClaudeRateLimitHeaders (bridge entry)', () => {
+  beforeEach(() => {
+    resetClaudeRateLimitHeadersDedup();
+  });
+
+  /** 桥侧拿到的是 Fetch `Headers`, 按约定先 Object.fromEntries 再传入。 */
+  function fromFetchHeaders(init: Record<string, string>): Record<string, string> {
+    return Object.fromEntries(new Headers(init));
+  }
+
+  it('parses headers that arrived as a Fetch Headers object, whatever case upstream used', () => {
+    // 实测: 上游按 HTTP 语义可能用任意大小写下发; Headers 迭代出的 key 一律小写,
+    // 正是 parseClaudeUnifiedRateLimitHeaders 要求的形态。
+    const listener = vi.fn();
+    setClaudeRateLimitHeadersListener(listener);
+
+    recordClaudeRateLimitHeaders({
+      upstreamBase: 'https://api.anthropic.com',
+      responseHeaders: fromFetchHeaders({
+        'Anthropic-RateLimit-Unified-5h-Utilization': '0.34',
+        'ANTHROPIC-RATELIMIT-UNIFIED-5H-RESET': '1786447200',
+        'anthropic-ratelimit-unified-7d-utilization': '0.09',
+        'Anthropic-RateLimit-Unified-Status': 'allowed',
+      }),
+      requestHeaders: { authorization: 'Bearer sk-ant-oat01-live' },
+    });
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    const snapshot = listener.mock.calls[0][0];
+    expect(snapshot.fiveHour.utilization).toBeCloseTo(34, 5);
+    expect(snapshot.fiveHour.resetsAt).toBe(1786447200);
+    expect(snapshot.sevenDay.utilization).toBeCloseTo(9, 5);
+    expect(snapshot.rateLimitStatus).toBe('allowed');
+    expect(snapshot.source).toBe('unified-headers');
+    expect(listener.mock.calls[0][1]).toBe('sk-ant-oat01-live');
+  });
+
+  it('extracts the bearer regardless of request header casing', () => {
+    // 桥路径的请求头由 provider 自己拼, 大小写不受本模块控制; 取错等于账号归属
+    // 丢失, 而这类失败是静默的。
+    const listener = vi.fn();
+    setClaudeRateLimitHeadersListener(listener);
+
+    recordClaudeRateLimitHeaders({
+      upstreamBase: 'https://api.anthropic.com',
+      responseHeaders: fromFetchHeaders({ 'anthropic-ratelimit-unified-5h-utilization': '0.5' }),
+      requestHeaders: { Authorization: 'Bearer sk-ant-oat01-mixed' },
+    });
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener.mock.calls[0][1]).toBe('sk-ant-oat01-mixed');
+  });
+
+  it('clamps a utilization above 1.0 instead of overflowing', () => {
+    // 实测边界: 超额时上游会下发 5h-utilization = 1.06 (配 status=rejected,
+    // overage-in-use=true)。现有语义是 clamp 到 100。
+    const listener = vi.fn();
+    setClaudeRateLimitHeadersListener(listener);
+
+    recordClaudeRateLimitHeaders({
+      upstreamBase: 'https://api.anthropic.com',
+      responseHeaders: fromFetchHeaders({
+        'anthropic-ratelimit-unified-5h-utilization': '1.06',
+        'anthropic-ratelimit-unified-status': 'rejected',
+      }),
+      requestHeaders: { authorization: 'Bearer sk-ant-oat01-live' },
+    });
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener.mock.calls[0][0].fiveHour.utilization).toBe(100);
+    expect(listener.mock.calls[0][0].rateLimitStatus).toBe('rejected');
+  });
+
+  it('skips non-anthropic upstreams and header-less responses', () => {
+    const listener = vi.fn();
+    setClaudeRateLimitHeadersListener(listener);
+
+    recordClaudeRateLimitHeaders({
+      upstreamBase: XD_GATEWAY_BASE_URL,
+      responseHeaders: fromFetchHeaders({ 'anthropic-ratelimit-unified-5h-utilization': '0.5' }),
+      requestHeaders: { authorization: 'Bearer sk-ant-oat01-live' },
+    });
+    recordClaudeRateLimitHeaders({
+      upstreamBase: 'https://api.anthropic.com',
+      responseHeaders: fromFetchHeaders({ 'content-type': 'text/event-stream' }),
+      requestHeaders: { authorization: 'Bearer sk-ant-oat01-live' },
+    });
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('shares one dedupe state with the transparent-proxy observer', () => {
+    // 同一账号、同一组数值, 先后经两条链路到达 —— 第二次必须被去抖掉,
+    // 否则同一笔观测会落库 / 广播两次。
+    const listener = vi.fn();
+    setClaudeRateLimitHeadersListener(listener);
+    const observer = createClaudeRateLimitHeadersObserver();
+
+    observer(makeCtx());
+    recordClaudeRateLimitHeaders({
+      upstreamBase: 'https://api.anthropic.com',
+      responseHeaders: fromFetchHeaders(makeCtx().responseHeaders as Record<string, string>),
+      requestHeaders: makeCtx().requestHeaders as Record<string, string>,
+    });
+
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('still reports across links when the account changed', () => {
+    const listener = vi.fn();
+    setClaudeRateLimitHeadersListener(listener);
+    const observer = createClaudeRateLimitHeadersObserver();
+
+    observer(makeCtx({ requestHeaders: { authorization: 'Bearer sk-ant-oat01-old' } }));
+    recordClaudeRateLimitHeaders({
+      upstreamBase: 'https://api.anthropic.com',
+      responseHeaders: fromFetchHeaders(makeCtx().responseHeaders as Record<string, string>),
+      requestHeaders: { authorization: 'Bearer sk-ant-oat01-new' },
+    });
+
+    expect(listener).toHaveBeenCalledTimes(2);
+    expect(listener.mock.calls[1][1]).toBe('sk-ant-oat01-new');
   });
 });

--- a/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
@@ -4129,3 +4129,150 @@ describe('codex proxy host', () => {
     expect(host.getCodexProxyEndpoint()).toBe('http://127.0.0.1:43210');
   });
 });
+
+/**
+ * 额度回调的安装门(#2626)。桥的 localHandler 绕开 compat-proxy 的转发层, 转发层上的
+ * rate-limit observer 看不到这些响应, 只能由 host 在这里回喂 —— 但必须只对
+ * 「内置 Anthropic + 订阅 OAuth + 官方 hostname」这一种路由安装, 其余形态误装会把
+ * 别的账号 / 别的上游的数据写进 Claude 订阅快照。
+ */
+describe('createModelRoutingTransform —— Anthropic 桥的额度回调安装门', () => {
+  it('installs the quota callback for builtin Anthropic subscription OAuth and feeds the shared recorder', async () => {
+    const host = await freshCodexProxyHost();
+    const {
+      getActiveCatalog,
+      setAnthropicDiscoveredModels,
+      setXdGatewayModels,
+    } = await import('../active-catalog.js');
+    const {
+      setProviderOAuthTokenReader,
+      setProviderViewsReader,
+    } = await import('../provider-route.js');
+    const { clearSessionProvider } = await import('../session-provider-store.js');
+    const {
+      resetClaudeRateLimitHeadersDedup,
+      setClaudeRateLimitHeadersListener,
+    } = await import('../claude-rate-limit-headers-observer.js');
+
+    const model: import('@cindy/model-providers').CatalogModel = {
+      id: 'claude-quota-callback',
+      name: 'Quota Callback',
+      group: 'anthropic',
+      contextWindow: 200_000,
+      efforts: ['low', 'medium', 'high'],
+      defaultEffort: 'high',
+      status: 'active',
+    };
+    setAnthropicDiscoveredModels([model]);
+    setXdGatewayModels([{ id: model.id, agents: ['claude-code'] }]);
+    setProviderViewsReader(async () => getActiveCatalog().providers.map((provider) => ({
+      ...provider,
+      connected: provider.id === 'anthropic',
+    })));
+    setProviderOAuthTokenReader((providerId, agent) => (
+      providerId === 'anthropic' && agent === 'codex' ? 'claude-subscription-token' : null
+    ));
+    host.registerComposed('session-quota-callback', 'thread-quota-callback', 'PRODUCT_PROMPT');
+    clearSessionProvider('session-quota-callback');
+    host.setCodexProxyGatewayKeyReader(() => null);
+    host.setCodexProxyAuthInjection('oauth-bearer');
+    resetClaudeRateLimitHeadersDedup();
+    const listener = vi.fn();
+    setClaudeRateLimitHeadersListener(listener);
+
+    try {
+      await Promise.resolve(host.createModelRoutingTransform()(
+        { model: model.id, input: [{ role: 'user', content: 'hello' }] },
+        {
+          reqId: 1,
+          method: 'POST',
+          url: '/responses',
+          headers: { 'thread-id': 'thread-quota-callback' },
+        },
+      ));
+
+      const config = (mockState.createResponsesAnthropicHandler.mock.calls as unknown as Array<[
+        {
+          onUpstreamResponse?: (info: {
+            status: number;
+            responseHeaders: Headers;
+            requestHeaders: Readonly<Record<string, string>>;
+          }) => void;
+        },
+      ]>).at(-1)?.[0];
+      expect(config?.onUpstreamResponse).toBeTypeOf('function');
+
+      // 回调真的把 headers 喂到了共用入口 —— 只断言「装上了」会漏掉接错线的情形。
+      config?.onUpstreamResponse?.({
+        status: 200,
+        responseHeaders: new Headers({
+          'anthropic-ratelimit-unified-5h-utilization': '0.34',
+          'anthropic-ratelimit-unified-status': 'allowed',
+        }),
+        requestHeaders: { authorization: 'Bearer claude-subscription-token' },
+      });
+      expect(listener).toHaveBeenCalledTimes(1);
+      expect(listener.mock.calls[0][0].fiveHour.utilization).toBeCloseTo(34, 5);
+      expect(listener.mock.calls[0][0].source).toBe('unified-headers');
+      expect(listener.mock.calls[0][1]).toBe('claude-subscription-token');
+    } finally {
+      host.unregister('session-quota-callback');
+      clearSessionProvider('session-quota-callback');
+      setProviderOAuthTokenReader(() => null);
+      setProviderViewsReader(async () => []);
+      setAnthropicDiscoveredModels([]);
+      setXdGatewayModels([]);
+      host.setCodexProxyGatewayKeyReader(() => null);
+      setClaudeRateLimitHeadersListener(() => undefined);
+    }
+  });
+
+  it('does not install it for a custom anthropic-compatible provider on an API key', async () => {
+    const host = await freshCodexProxyHost();
+    const { buildUserProvider } = await import('@cindy/model-providers');
+    const { setCustomProviders } = await import('../active-catalog.js');
+    const { setCustomProviderKeyReader } = await import('../provider-route.js');
+    const { setSessionProvider, clearSessionProvider } = await import('../session-provider-store.js');
+    setCustomProviders([
+      buildUserProvider({
+        id: 'anthropic-compatible',
+        name: 'Anthropic Compatible',
+        runtimes: {
+          codex: {
+            baseUrl: 'https://messages.provider.example/v1',
+            wireProtocol: 'anthropic-messages',
+            models: [{ id: 'claude-compatible', name: 'Claude Compatible' }],
+          },
+        },
+      }),
+    ]);
+    setCustomProviderKeyReader(() => 'provider-key');
+    host.registerComposed('session-quota-gate-custom', 'thread-quota-gate-custom', 'PRODUCT_PROMPT');
+    setSessionProvider('session-quota-gate-custom', 'anthropic-compatible');
+    host.setCodexProxyAuthInjection('env-key');
+
+    try {
+      await Promise.resolve(host.createModelRoutingTransform()(
+        { model: 'claude-compatible' },
+        {
+          reqId: 1,
+          method: 'POST',
+          url: '/responses',
+          headers: { 'thread-id': 'thread-quota-gate-custom' },
+        },
+      ));
+
+      const config = (mockState.createResponsesAnthropicHandler.mock.calls as unknown as Array<[
+        { upstreamBase: string; onUpstreamResponse?: unknown },
+      ]>).at(-1)?.[0];
+      expect(config?.upstreamBase).toBe('https://messages.provider.example/v1');
+      // 非官方 hostname + 非订阅 OAuth:两道门任一不满足都不装
+      expect(config?.onUpstreamResponse).toBeUndefined();
+    } finally {
+      host.unregister('session-quota-gate-custom');
+      clearSessionProvider('session-quota-gate-custom');
+      setCustomProviders([]);
+      setCustomProviderKeyReader(() => null);
+    }
+  });
+});

--- a/apps/desktop/src/main/maker-host/claude-rate-limit-headers-observer.ts
+++ b/apps/desktop/src/main/maker-host/claude-rate-limit-headers-observer.ts
@@ -6,6 +6,10 @@
  * anthropic-compat-proxy 的 responseObserver 上,在响应开始时同步读一次 headers、
  * 组装快照后 fire-and-forget 交给注入的 listener(→ usageBroadcaster 落库 + 广播)。
  *
+ * 两条链路共用同一份状态: 透明代理(anthropic-compat-proxy 的 responseObserver)与
+ * codex 的 Anthropic 本地桥(localHandler 绕开转发层, 见 codex-proxy-host)都调用
+ * recordClaudeRateLimitHeaders —— 去抖签名与账号归属只有一份, 不复制第二份状态。
+ *
  * 热路径纪律(规则 10):
  *   - 只在 'response' 事件同步读 header 对象,不返回 sink(不 tee 响应 body,SSE
  *     字节流零感知);
@@ -82,34 +86,66 @@ export function resetClaudeRateLimitHeadersDedup(): void {
 }
 
 /**
+ * bearer 提取 —— 大小写不敏感。转发层的 header 已由 proxy 小写化, 但桥路径传进来的
+ * 是 provider 自己拼的请求头, 大小写不受本模块控制; 取错等于账号归属丢失(快照会被
+ * 当成"无归属"), 而这类失败是静默的, 所以这里不假设 key 形态。
+ */
+function extractBearerToken(requestHeaders: Readonly<Record<string, string>>): string | null {
+  for (const [name, value] of Object.entries(requestHeaders)) {
+    if (name.toLowerCase() !== 'authorization') continue;
+    return typeof value === 'string' && value.startsWith('Bearer ')
+      ? value.slice('Bearer '.length)
+      : null;
+  }
+  return null;
+}
+
+/**
+ * 解析一次订阅直连响应的 unified headers 并交给 listener —— 透明代理与 codex 桥的
+ * 共用入口(见顶部说明)。同步返回, 内部 fire-and-forget, 任何失败都不抛出。
+ *
+ * headers 的 key 必须已小写化: `parseClaudeUnifiedRateLimitHeaders` 是按精确
+ * key 索引取值的, 传 Fetch `Headers` 对象或未归一化的记录会静默解析成 null。
+ * 桥路径请用 `Object.fromEntries(response.headers)`(Fetch 迭代出的 key 一律小写)。
+ */
+export function recordClaudeRateLimitHeaders(input: {
+  upstreamBase: string;
+  responseHeaders: Readonly<Record<string, string>>;
+  requestHeaders: Readonly<Record<string, string>>;
+}): void {
+  // 订阅直连才有 unified headers;网关 / 其它上游一次 hostname 比较短路。
+  if (!isAnthropicDirectUpstream(input.upstreamBase)) return;
+  const listener = _listener;
+  if (!listener) return;
+
+  const snapshot = parseClaudeUnifiedRateLimitHeaders(input.responseHeaders, Date.now());
+  if (!snapshot) return;
+
+  const requestBearerToken = extractBearerToken(input.requestHeaders);
+
+  // 去抖签名包含请求身份 —— 换号场景旧账号的尾巴响应写过签名后, 新账号首个
+  // 响应即使 5h/7d/status 数值恰好相同也必须到达 listener(归属不同, 不是重复)。
+  const signature = `${requestBearerToken ?? ''}|${snapshotSignature(snapshot)}`;
+  if (signature === _lastSignature) return;
+
+  try {
+    const accepted = listener(snapshot, requestBearerToken) !== false;
+    if (accepted) _lastSignature = signature;
+  } catch {
+    // listener 是 fire-and-forget,失败不影响响应转发(proxy 侧还有一层 try 兜底)。
+  }
+}
+
+/**
  * 创建旁路 observer。永远返回 undefined(不注册 body sink)。
  */
 export function createClaudeRateLimitHeadersObserver(): ResponseObserver {
   return (ctx) => {
-    // 订阅直连才有 unified headers;网关 / 其它上游一次 hostname 比较短路。
-    if (!isAnthropicDirectUpstream(ctx.upstreamBase)) return undefined;
-    const listener = _listener;
-    if (!listener) return undefined;
-
-    const snapshot = parseClaudeUnifiedRateLimitHeaders(ctx.responseHeaders, Date.now());
-    if (!snapshot) return undefined;
-
-    const auth = ctx.requestHeaders['authorization'];
-    const requestBearerToken = typeof auth === 'string' && auth.startsWith('Bearer ')
-      ? auth.slice('Bearer '.length)
-      : null;
-
-    // 去抖签名包含请求身份 —— 换号场景旧账号的尾巴响应写过签名后, 新账号首个
-    // 响应即使 5h/7d/status 数值恰好相同也必须到达 listener(归属不同, 不是重复)。
-    const signature = `${requestBearerToken ?? ''}|${snapshotSignature(snapshot)}`;
-    if (signature === _lastSignature) return undefined;
-
-    try {
-      const accepted = listener(snapshot, requestBearerToken) !== false;
-      if (accepted) _lastSignature = signature;
-    } catch {
-      // listener 是 fire-and-forget,失败不影响响应转发(proxy 侧还有一层 try 兜底)。
-    }
+    recordClaudeRateLimitHeaders({
+      upstreamBase: ctx.upstreamBase,
+      responseHeaders: ctx.responseHeaders,
+      requestHeaders: ctx.requestHeaders,
+    });
     return undefined;
   };
 }

--- a/apps/desktop/src/main/maker-host/codex-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/codex-proxy-host.ts
@@ -62,7 +62,10 @@ import {
   rewriteSessionModelIdForRoute,
 } from './provider-route.js';
 import { getSessionProvider } from './session-provider-store.js';
-import { composeResponseObservers } from './claude-rate-limit-headers-observer.js';
+import {
+  composeResponseObservers,
+  recordClaudeRateLimitHeaders,
+} from './claude-rate-limit-headers-observer.js';
 import { createProviderUpstreamErrorObserver, reportProviderUpstreamError } from './provider-upstream-error-observer.js';
 import { createXaiProxyAuthInvalidationObserver } from './xai-auth-invalidation-host.js';
 import { xaiServerSideTools } from './xai-server-side-tools.js';
@@ -966,6 +969,29 @@ function createAnthropicBridgeDecision(
       : () => false,
     imageCodec: desktopAnthropicImageCodec,
     ...(onUpstreamError ? { onUpstreamError } : {}),
+    // 账号额度旁路 —— 只给「内置 Anthropic + 订阅 OAuth + 官方 hostname」这一种路由
+    // 装。桥的 localHandler 绕开了 compat-proxy 的转发层, 转发层上的
+    // createClaudeRateLimitHeadersObserver 看不到这些响应(见 #2626), 所以额度只能
+    // 从这里回喂; 解析与去抖仍走 observer 那份共用状态, 不复制第二份。
+    //
+    // 其余形态一律不装: API key / 自定义兼容供应商 / XD Gateway 的响应要么没有
+    // unified headers, 要么根本不属于这个 Claude 订阅账号, 误写会污染快照。
+    ...(isAnthropicSubscriptionOAuth && isOfficialAnthropicUpstream(upstreamBase)
+      ? {
+          onUpstreamResponse: ({ responseHeaders, requestHeaders }: {
+            responseHeaders: Headers;
+            requestHeaders: Readonly<Record<string, string>>;
+          }) => {
+            // Fetch `Headers` 不支持索引取值, 直接传下去会被静默解析成 null;
+            // 迭代出的 key 一律小写, 正是解析函数要求的形态。
+            recordClaudeRateLimitHeaders({
+              upstreamBase,
+              responseHeaders: Object.fromEntries(responseHeaders),
+              requestHeaders,
+            });
+          },
+        }
+      : {}),
   }, {
     logger: log,
     fetchImpl: outboundFetch,

--- a/packages/responses-anthropic-bridge/src/__tests__/handler.test.ts
+++ b/packages/responses-anthropic-bridge/src/__tests__/handler.test.ts
@@ -607,3 +607,154 @@ describe('createResponsesAnthropicHandler', () => {
     expect(res.chunks.join('').length).toBeLessThan(17 * 1024);
   });
 });
+
+/**
+ * onUpstreamResponse —— 最终上游响应的元数据旁路(见 #2626)。
+ * 桥不解释这些 header, 只保证「最终响应一次、重试的中间响应不报」。
+ */
+describe('createResponsesAnthropicHandler onUpstreamResponse', () => {
+  it('reports the final headers once for a streaming success', async () => {
+    const fetchImpl = vi.fn(async () => new Response(anthropicStream().body, {
+      status: 200,
+      headers: {
+        'content-type': 'text/event-stream',
+        'anthropic-ratelimit-unified-5h-utilization': '0.34',
+      },
+    })) as typeof fetch;
+    const onUpstreamResponse = vi.fn();
+    const handler = createResponsesAnthropicHandler({
+      upstreamBase: 'https://provider.example',
+      buildHeaders: async () => ({ authorization: 'Bearer live' }),
+      onUpstreamResponse,
+    }, { fetchImpl });
+    const res = new FakeResponse();
+    await handler.handle({ parsedBody: { model: 'claude', input: 'hi' }, ctx, res: res as never });
+
+    expect(onUpstreamResponse).toHaveBeenCalledTimes(1);
+    const info = onUpstreamResponse.mock.calls[0][0];
+    expect(info.status).toBe(200);
+    expect(info.responseHeaders.get('anthropic-ratelimit-unified-5h-utilization')).toBe('0.34');
+    // 请求头按发出去的那一份传出 —— 账号归属靠它
+    expect(info.requestHeaders.authorization).toBe('Bearer live');
+    expect(res.status).toBe(200);
+  });
+
+  it('reports once for a non-streaming success', async () => {
+    const fetchImpl = vi.fn(async () => new Response(anthropicStream().body, {
+      status: 200,
+      headers: { 'content-type': 'text/event-stream', 'anthropic-ratelimit-unified-status': 'allowed' },
+    })) as typeof fetch;
+    const onUpstreamResponse = vi.fn();
+    const handler = createResponsesAnthropicHandler({
+      upstreamBase: 'https://provider.example',
+      buildHeaders: async () => ({}),
+      onUpstreamResponse,
+    }, { fetchImpl });
+    const res = new FakeResponse();
+    await handler.handle({
+      parsedBody: { model: 'claude', input: 'hi', stream: false },
+      ctx,
+      res: res as never,
+    });
+
+    expect(onUpstreamResponse).toHaveBeenCalledTimes(1);
+    expect(onUpstreamResponse.mock.calls[0][0].responseHeaders.get('anthropic-ratelimit-unified-status'))
+      .toBe('allowed');
+  });
+
+  it('reports the final non-2xx response too', async () => {
+    const fetchImpl = vi.fn(async () => new Response('nope', {
+      status: 429,
+      headers: { 'anthropic-ratelimit-unified-status': 'rejected' },
+    })) as typeof fetch;
+    const onUpstreamResponse = vi.fn();
+    const handler = createResponsesAnthropicHandler({
+      upstreamBase: 'https://provider.example',
+      buildHeaders: async () => ({}),
+      onUpstreamResponse,
+    }, { fetchImpl });
+    const res = new FakeResponse();
+    await handler.handle({ parsedBody: { model: 'claude', input: 'hi' }, ctx, res: res as never });
+
+    expect(onUpstreamResponse).toHaveBeenCalledTimes(1);
+    expect(onUpstreamResponse.mock.calls[0][0].status).toBe(429);
+    expect(res.status).toBe(429);
+  });
+
+  it('skips the intermediate 401 and reports only the refreshed response', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response('expired', {
+        status: 401,
+        headers: { 'anthropic-ratelimit-unified-status': 'stale-should-not-be-reported' },
+      }))
+      .mockResolvedValueOnce(new Response(anthropicStream().body, {
+        status: 200,
+        headers: { 'content-type': 'text/event-stream', 'anthropic-ratelimit-unified-status': 'allowed' },
+      }));
+    const onUpstreamResponse = vi.fn();
+    const handler = createResponsesAnthropicHandler({
+      upstreamBase: 'https://provider.example',
+      buildHeaders: async () => ({ authorization: 'Bearer stale' }),
+      refreshHeaders: async () => ({ authorization: 'Bearer fresh' }),
+      onUpstreamResponse,
+    }, { fetchImpl: fetchMock as unknown as typeof fetch });
+    const res = new FakeResponse();
+    await handler.handle({ parsedBody: { model: 'claude', input: 'hi' }, ctx, res: res as never });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(onUpstreamResponse).toHaveBeenCalledTimes(1);
+    const info = onUpstreamResponse.mock.calls[0][0];
+    expect(info.status).toBe(200);
+    expect(info.responseHeaders.get('anthropic-ratelimit-unified-status')).toBe('allowed');
+    // 换过凭据后的请求头才是这次响应的归属依据
+    expect(info.requestHeaders.authorization).toBe('Bearer fresh');
+  });
+
+  it('skips the intermediate 413 and reports only the downscaled retry', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response('too large', { status: 413 }))
+      .mockResolvedValueOnce(new Response(anthropicStream().body, {
+        status: 200,
+        headers: { 'content-type': 'text/event-stream', 'anthropic-ratelimit-unified-status': 'allowed' },
+      }));
+    const onUpstreamResponse = vi.fn();
+    const handler = createResponsesAnthropicHandler({
+      upstreamBase: 'https://provider.example',
+      buildHeaders: async () => ({}),
+      imageCodec: { normalize: async () => ({ data: 'abc', mediaType: 'image/png' }) },
+      onUpstreamResponse,
+    }, { fetchImpl: fetchMock as unknown as typeof fetch });
+    const res = new FakeResponse();
+    await handler.handle({
+      parsedBody: {
+        model: 'claude',
+        input: [{ role: 'user', content: [{ type: 'input_image', image_url: 'data:image/png;base64,abc' }] }],
+      },
+      ctx,
+      res: res as never,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(onUpstreamResponse).toHaveBeenCalledTimes(1);
+    expect(onUpstreamResponse.mock.calls[0][0].status).toBe(200);
+  });
+
+  it('never lets a throwing or rejecting callback affect the response', async () => {
+    const fetchImpl = vi.fn(async () => anthropicStream()) as typeof fetch;
+    for (const onUpstreamResponse of [
+      () => { throw new Error('sync boom'); },
+      async () => { throw new Error('async boom'); },
+    ]) {
+      const handler = createResponsesAnthropicHandler({
+        upstreamBase: 'https://provider.example',
+        buildHeaders: async () => ({}),
+        onUpstreamResponse,
+      }, { fetchImpl });
+      const res = new FakeResponse();
+      await handler.handle({ parsedBody: { model: 'claude', input: 'hi' }, ctx, res: res as never });
+      expect(res.status).toBe(200);
+      expect(res.chunks.join('')).toContain('event: response.completed');
+      expect(res.ended).toBe(true);
+    }
+  });
+});

--- a/packages/responses-anthropic-bridge/src/handler.ts
+++ b/packages/responses-anthropic-bridge/src/handler.ts
@@ -353,6 +353,35 @@ export function createResponsesAnthropicHandler(
         return;
       }
 
+      // 最终上游响应的元数据旁路 —— 重试链已经结束(401/403 换凭据、413 压图的中间
+      // 响应都在上面 continue 掉了), 这里的 upstream 就是要回给调用方的那一个。
+      //
+      // 放在读 body / 翻译之前: headers 与 body 消费无关, 早取一步, 流式路径下也不
+      // 会因为 body 还没开始读就拿不到。同步发起、不 await —— 回调是 best-effort 的
+      // 观测通道, 既不能延后首字节, 也不能让它的失败影响响应本身。
+      if (provider.onUpstreamResponse) {
+        try {
+          const result = provider.onUpstreamResponse({
+            status: upstream.status,
+            responseHeaders: upstream.headers,
+            requestHeaders: providerHeaders,
+          });
+          if (result && typeof (result as Promise<void>).catch === 'function') {
+            (result as Promise<void>).catch((error: unknown) => {
+              log.warn?.('responses-anthropic bridge onUpstreamResponse failed', {
+                model: incoming.model,
+                error: error instanceof Error ? error.message : String(error),
+              });
+            });
+          }
+        } catch (error) {
+          log.warn?.('responses-anthropic bridge onUpstreamResponse failed', {
+            model: incoming.model,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }
+
       const reportUpstreamError = async (status: number, body: string): Promise<void> => {
         if (!provider.onUpstreamError) return;
         try {

--- a/packages/responses-anthropic-bridge/src/index.ts
+++ b/packages/responses-anthropic-bridge/src/index.ts
@@ -38,6 +38,7 @@ export type {
   ResponsesAnthropicHandler,
   ResponsesAnthropicLogger,
   ResponsesAnthropicProviderConfig,
+  ResponsesAnthropicResponseInfo,
   ResponsesRequest,
   ToolCallKind,
   ToolCallMapping,

--- a/packages/responses-anthropic-bridge/src/types.ts
+++ b/packages/responses-anthropic-bridge/src/types.ts
@@ -81,6 +81,24 @@ export interface ResponsesAnthropicProviderConfig {
   imageCodec?: AnthropicImageCodec;
   /** Called after a non-2xx response, before the translated error is returned. */
   onUpstreamError?: (info: ResponsesAnthropicErrorInfo) => void | Promise<void>;
+  /**
+   * Called once for the final upstream response — success or not — before the body
+   * is read or translated. Intermediate responses consumed by an internal retry
+   * (401/403 credential refresh, 413 image downscale) are not reported.
+   *
+   * Provider-agnostic response metadata only: the bridge does not interpret these
+   * headers. Best effort — the call is fire-and-forget and never blocks or fails
+   * the response, so a consumer must not rely on it for correctness.
+   */
+  onUpstreamResponse?: (info: ResponsesAnthropicResponseInfo) => void | Promise<void>;
+}
+
+export interface ResponsesAnthropicResponseInfo {
+  status: number;
+  /** Final upstream response headers. Iterating a Fetch `Headers` lowercases names. */
+  responseHeaders: Headers;
+  /** Provider-owned request headers actually sent upstream for this attempt. */
+  requestHeaders: Readonly<Record<string, string>>;
 }
 
 export interface ResponsesAnthropicHandleArgs {


### PR DESCRIPTION
## 这次改了什么

### 摘要

Codex 会话使用 Claude 订阅模型时，请求经由本地的 Responses → Anthropic Messages 桥打到 `api.anthropic.com`。这条桥是 `localHandler`，**绕开了 compat-proxy 的转发层**，因此转发层上的 `createClaudeRateLimitHeadersObserver` 永远看不到这些响应 —— 额度确实被消耗，但账号快照停在上一次 claude-code 回合观测到的值，直到用户碰巧再用一次 claude-code 才更新。

桥对「上游错误」这类信息已经遇到过同一个结构性缺口，做法是显式回喂（`onUpstreamError`）。额度响应头属于同一类响应元数据，所以本 PR 沿用这个先例，而不是把快照维度从 `agent_kind` 挪走：

- 给桥的 provider 配置加一个**与供应商语义无关**的可选回调 `onUpstreamResponse`。它对**最终**上游响应触发一次（成功与否都触发），在 body 被读取／翻译之前；被内部重试消费掉的中间响应（401/403 换凭据、413 压图）不触发。回调是 fire-and-forget，既不阻塞流式响应，也不会因自身失败影响响应本身。
- 把「解析 headers → 提取 bearer → listener/去抖」从既有 observer 里抽成共用入口 `recordClaudeRateLimitHeaders`，透明代理与桥**共用同一份状态**，不复制第二份去抖与账号归属逻辑。bearer 提取改为大小写不敏感 —— 桥路径的请求头由 provider 自己拼，大小写不受该模块控制，取错等于账号归属静默丢失。
- 回调**只**安装在「内置 Anthropic + provider OAuth + 官方 `api.anthropic.com` hostname」这一种路由上。API key、自定义 anthropic-compatible 供应商、XD Gateway 一律不装，避免把别的账号／别的上游的数据写进 Claude 订阅槽。

一个实现细节值得单独说：桥拿到的是 Fetch `Headers` 对象，而 `parseClaudeUnifiedRateLimitHeaders` 是按精确 key 索引取值的，直接传会**静默解析成 null**（不抛错、无日志）。host 侧用 `Object.fromEntries(responseHeaders)` 转换（Fetch 迭代出的 key 一律小写，正是解析函数要求的形态），并有专门的测试守住这个陷阱。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#2626（含维护者 bot 给出的实现建议与边界）
- 本 PR 包含：
  - `packages/responses-anthropic-bridge`：新增可选 `onUpstreamResponse` 回调与 `ResponsesAnthropicResponseInfo` 类型，在最终上游响应处触发一次
  - `apps/desktop/src/main/maker-host/claude-rate-limit-headers-observer.ts`：抽出 `recordClaudeRateLimitHeaders` 共用入口；bearer 提取大小写不敏感
  - `apps/desktop/src/main/maker-host/codex-proxy-host.ts`：在双重门后接线
  - 三个测试文件共 14 条新增用例
- 明确不包含：
  - **不改额度解析口径**。当前 parser 只消费 16 个 unified header 里的 6 个（每窗口的 `-status`、整套 `overage-*`、`fallback-percentage`、`upgrade-paths` 都未使用），本 PR 保持原样
  - **不动 schema**。快照仍以 `agent_kind='claude-code'` 作为 Claude 账号额度数据槽
  - **不碰展示层**。codex 会话的 chip 按 harness 选计费形态，本次不改
  - **不碰其它 harness / 其它桥**（chat bridge、xAI、Pi 均不受影响）
- 用户可见变化：codex 会话消耗 Claude 订阅额度后，账号快照随即更新；用户下次打开 claude-code 会话时，底栏 chip 与额度悬浮卡显示的是当前值，而不是上一次 claude-code 回合的陈旧值
- 是否存在 breaking change：无。`onUpstreamResponse` 是可选新增字段，未传时行为与现在完全一致

### UI 变化

不涉及：本 PR 只改 main 进程与 bridge package，未触及任何 renderer / 组件 / 文案 / 样式文件。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter @cindy/responses-anthropic-bridge run typecheck
结果：通过

pnpm --filter desktop run typecheck
结果：通过

npx vitest run packages/responses-anthropic-bridge/src/__tests__/handler.test.ts
结果：28 passed（新增 6）

npx vitest run apps/desktop/src/main/maker-host/__tests__/claudeRateLimitHeadersObserver.test.ts
结果：16 passed（新增 6）

npx vitest run apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
结果：144 passed（新增 2）

pnpm test:unit
结果：除 packages/maker-core 外全部 PASS。maker-core 的 4 条失败位于
src/agents/pi/__tests__/pi-rpc-resource-discovery.integration.test.ts，
已在干净 main（stash 全部改动后）复跑复现，与本 PR 无关；maker-core
既不依赖 @cindy/responses-anthropic-bridge，也不引用该 observer。

pnpm check:dco
结果：DCO check passed: 1 commit signed off
```

新增用例对应 #2626 中列出的测试要求：

| 要求 | 覆盖 |
|---|---|
| 成功 SSE / 成功 JSON / 最终非 2xx 各只回调一次，且携带最终 response/request headers | `handler.test.ts` 3 例 |
| 401→刷新→200、413→压图→200 只记录最后一次响应 | `handler.test.ts` 2 例 |
| 仅「内置 Anthropic + provider OAuth + 官方 hostname」安装回调；自定义 provider / API key 不安装 | `codexProxyHost.test.ts` 2 例（安装那例并断言回调确实喂到了共用入口，只断言「装上了」会漏掉接错线） |
| unified headers 能更新 5h / 7d / 状态 / reset | `claudeRateLimitHeadersObserver.test.ts` |
| 账号隔离：bearer 不一致时的归属、换号后数值相同也不去抖 | 同上，跨两条链路各一例 |
| 回调抛异常 / reject 不影响响应 | `handler.test.ts` 1 例（额外补充） |

另外补了两条来自真机观测的边界：`utilization` 会超过 1.0（实测 1.06，clamp 到 100）、上游用混合大小写下发时经 `Object.fromEntries` 仍能正常解析。

### 手工验证

macOS，dev build（`--passive`，共享正式登录态），codex harness + Claude 订阅模型（Opus 4.8）。

**① 响应头确实存在**（在本 PR 之前用临时只读探针抓的，探针未提交）：一轮对话产生 6 次桥响应，全部 `200`、上游 `https://api.anthropic.com/v1/messages`、各带 16 个 `anthropic-ratelimit-unified-*` 头；路由侧确认 `providerId=anthropic` / `providerSource=builtin` / `wireProtocol=anthropic-messages` / `authStrategy=provider-oauth-header`。

**② 修复前后的对照**（同一 dev 实例、同一 passive 模式、同样跑 codex 会话，唯一变量是本 PR）：

| | codex 对话期间 `recordClaudeSubscriptionUsageSnapshot` 被调用 |
|---|---|
| 修复前（3 轮对话） | 0 次 |
| 修复后（4 轮对话） | 每轮 1 次，共 4 次 |

判据取自 `usageBroadcaster` 的日志。修复前 codex 对话完全不会触达 Claude 订阅记录入口，修复后每轮都会 —— 这正是本 PR 要接上的那一段。

### 未执行的验证

**未能在本地验证「快照落库到 `account_usage_snapshots`」这最后一步。**

原因：dev + `--passive` 实例里 `currentAccountUsageOwner()`（`getCurrentUserId()`）取不到 owner，`ensureClaudeSubscriptionUsageLoaded` 因此直接返回、`hydrated` 保持 false，落库被 `#2467` 加的守卫拦下并打出 `skip persisting claude subscription usage snapshot: hydration unavailable`。同一实例里 **codex 槽也报同样的错**，且该现象在本 PR 之前的 dev 会话中就存在 —— 属于该环境的既有限制，与本改动无关（正式版落库正常）。

需要说明的是，`recordClaudeSubscriptionUsageSnapshot` 中广播（`broadcastClaudeSubscriptionUsage`）发生在落库守卫**之前**，所以内存快照与 renderer 广播这两步在上述验证中是走通的。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

补充说明（虽归入「无已知风险」，但值得把关人过目）：

- 本 PR 改动了 `packages/responses-anthropic-bridge` 的**公开配置类型**（新增可选字段），属于跨包 API 形状变化。字段可选、默认不传，对既有调用方无影响
- 回调携带请求头（含 OAuth bearer），但**不出进程**：仅传给同进程内的 `recordClaudeRateLimitHeaders`，用途与既有 observer 一致（账号归属与去抖），不落盘、不进日志
- 安装门是双重的（`isAnthropicSubscriptionOAuth` + 官方 hostname），共用入口内还有一次 hostname 全等校验兜底

### 影响与回滚

- 影响范围：仅「codex harness + 内置 Anthropic 订阅 OAuth + 官方 hostname」这一条路由的响应头旁路；其余路由、其它 harness、其它桥不受影响
- 回滚 / 降级方式：整个 PR revert 即可，无数据迁移、无持久化格式变更、无协议变更。若只想临时停用，移除 host 侧那段 `onUpstreamResponse` 安装即可，bridge 侧的可选字段留着也不产生任何行为

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（回调语义与两处约束写在类型注释与实现注释里）
- [x] 已确认测试结果或说明未执行原因
