### PR TITLE
fix(plugin): 将协同任务切换事件归一到主任务

### DIFF
--- a/apps/desktop/src/main/cindy-brain/__tests__/sessionFocusRetryContract.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/sessionFocusRetryContract.test.ts
@@ -32,4 +32,16 @@ describe('session focus retry wiring', () => {
     expect(body).toContain('lastRawSessionId = null;');
     expect(body).toContain('primarySessionId === lastPrimarySessionId');
   });
+
+  it('releases raw focus when session-switch eligibility is temporarily unavailable', () => {
+    const start = mainSource.indexOf('export function notifyGhostSessionEvent(');
+    const end = mainSource.indexOf('\n}\n\n/**\n * 会话切换上报入口', start);
+    const body = mainSource.slice(start, end);
+
+    expect(body).toContain('onRetry: () => void = () => {}');
+    expect(body).toContain("if (info.outcome === 'retry') onRetry();");
+    expect(mainSource).toContain(
+      "notifyGhostSessionEvent('switched', { sessionId }, claim, releaseRaw)",
+    );
+  });
 });

--- a/apps/desktop/src/main/cindy-brain/__tests__/sessionFocusRetryContract.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/sessionFocusRetryContract.test.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+describe('session focus retry wiring', () => {
+  const mainSource = readFileSync(
+    resolve(process.cwd(), 'src/main/cindy-brain/index.ts'),
+    'utf8',
+  ).replace(/\r\n/g, '\n');
+  const gatewaySource = readFileSync(
+    resolve(process.cwd(), 'src/main/cindy-brain/subscriptionGateway.ts'),
+    'utf8',
+  ).replace(/\r\n/g, '\n');
+
+  it('forwards same-id IPC focus reports to the primary tracker for retries', () => {
+    const start = mainSource.indexOf('function noteGhostWindowSessionFocused(');
+    const end = mainSource.indexOf('\n}\n\nfunction mainShellWindows', start);
+    const body = mainSource.slice(start, end);
+
+    expect(body).toContain('if (previous !== sessionId)');
+    expect(body).toContain('noteGhostSessionFocused(sessionId);');
+    expect(body).not.toContain('if (previous === sessionId) return;');
+  });
+
+  it('releases raw focus after a failed publication recheck', () => {
+    const start = gatewaySource.indexOf('export function createGhostPrimarySessionFocusTracker(');
+    const end = gatewaySource.indexOf('\n}\n\n/* ──', start);
+    const body = gatewaySource.slice(start, end);
+
+    expect(body).toContain('recheckedPrimarySessionId = await resolve(sessionId);');
+    expect(body).toContain('lastRawSessionId = null;');
+    expect(body).toContain('primarySessionId === lastPrimarySessionId');
+  });
+});

--- a/apps/desktop/src/main/cindy-brain/__tests__/subscriptionGateway.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/subscriptionGateway.test.ts
@@ -184,7 +184,31 @@ describe('createGhostPrimarySessionFocusTracker', () => {
     expect(attempts).toBe(3);
   });
 
-  it('clears deduplication when focus leaves the session or resolution fails', async () => {
+  it('preserves the published lead while a same-lead worker focus is unresolved', async () => {
+    let workerBAttempts = 0;
+    const published: string[] = [];
+    const notify = vi.fn(async (sessionId: string, claim: () => Promise<boolean>) => {
+      if (await claim()) published.push(sessionId);
+    });
+    const tracker = createGhostPrimarySessionFocusTracker(async (sessionId) => {
+      if (sessionId === 'worker-b') {
+        workerBAttempts += 1;
+        return workerBAttempts === 1 ? null : 'lead-a';
+      }
+      return 'lead-a';
+    }, notify);
+
+    tracker.note('worker-a');
+    await vi.waitFor(() => expect(published).toEqual(['lead-a']));
+    tracker.note('worker-b');
+    await vi.waitFor(() => expect(workerBAttempts).toBe(1));
+    tracker.note('worker-b');
+    await vi.waitFor(() => expect(workerBAttempts).toBe(3));
+
+    expect(published).toEqual(['lead-a']);
+  });
+
+  it('clears deduplication when focus explicitly leaves the session', async () => {
     const published: string[] = [];
     const notify = vi.fn(async (sessionId: string, claim: () => Promise<boolean>) => {
       if (await claim()) published.push(sessionId);
@@ -199,8 +223,7 @@ describe('createGhostPrimarySessionFocusTracker', () => {
     tracker.note(null);
     tracker.note('lead');
     await vi.waitFor(() => expect(published).toHaveLength(2));
-    tracker.note('hidden-worker');
-    await Promise.resolve();
+    tracker.note(null);
     tracker.note('lead');
     await vi.waitFor(() => expect(published).toHaveLength(3));
 

--- a/apps/desktop/src/main/cindy-brain/__tests__/subscriptionGateway.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/subscriptionGateway.test.ts
@@ -13,11 +13,14 @@ import {
   GhostTapPendingQueue,
   GhostTurnOriginTracker,
   GhostTurnTranslator,
+  createGhostPrimarySessionFocusTracker,
   createGhostSessionFocusTracker,
   ghostActivityId,
   isGhostEligibleSessionRow,
+  isGhostSessionSwitchEligibleRow,
   normalizeTurnUsage,
   readStatusIsRunning,
+  resolveGhostPrimarySessionId,
   resolveGhostUserHookModel,
   withGhostAssistantHookModel,
   withGhostUserHookModel,
@@ -30,6 +33,161 @@ import {
   type GhostPipeEventPush,
   type InstalledGhost,
 } from '../../../shared/ghost';
+
+describe('did-session-switched primary session resolution', () => {
+  it('allows ordinary sessions and Orca leads, but never workers or background sessions', () => {
+    expect(isGhostSessionSwitchEligibleRow({ source: 'desktop', orcaRole: null })).toBe(true);
+    expect(isGhostSessionSwitchEligibleRow({ source: 'shared', orcaRole: 'lead' })).toBe(true);
+    expect(isGhostSessionSwitchEligibleRow({ source: 'plugin', orcaRole: 'lead' })).toBe(true);
+    expect(isGhostSessionSwitchEligibleRow({ source: 'desktop', orcaRole: 'worker' })).toBe(false);
+    expect(isGhostSessionSwitchEligibleRow({ source: 'desktop', orcaRole: 'unknown' })).toBe(false);
+    expect(isGhostSessionSwitchEligibleRow({ source: 'scheduler', orcaRole: null })).toBe(false);
+  });
+
+  it('keeps ordinary and lead ids, and maps a worker to its lead', async () => {
+    const roles = new Map<string, string | null>([
+      ['ordinary', null],
+      ['lead', 'lead'],
+      ['worker', 'worker'],
+    ]);
+    const readSession = vi.fn(async (sessionId: string) =>
+      roles.has(sessionId) ? { orcaRole: roles.get(sessionId) } : null,
+    );
+    const resolveWorkerLead = vi.fn(async () => 'lead');
+
+    await expect(
+      resolveGhostPrimarySessionId('ordinary', readSession, resolveWorkerLead),
+    ).resolves.toBe('ordinary');
+    await expect(resolveGhostPrimarySessionId('lead', readSession, resolveWorkerLead)).resolves.toBe(
+      'lead',
+    );
+    await expect(
+      resolveGhostPrimarySessionId('worker', readSession, resolveWorkerLead),
+    ).resolves.toBe('lead');
+    expect(resolveWorkerLead).toHaveBeenCalledTimes(1);
+    expect(resolveWorkerLead).toHaveBeenCalledWith('worker');
+  });
+
+  it('fails closed for missing rows, unknown roles, missing teams, and lookup failures', async () => {
+    const noTeam = vi.fn(async () => null);
+    await expect(
+      resolveGhostPrimarySessionId('missing', async () => null, noTeam),
+    ).resolves.toBeNull();
+    await expect(
+      resolveGhostPrimarySessionId('unknown', async () => ({ orcaRole: 'unknown' }), noTeam),
+    ).resolves.toBeNull();
+    await expect(
+      resolveGhostPrimarySessionId('worker', async () => ({ orcaRole: 'worker' }), noTeam),
+    ).resolves.toBeNull();
+    await expect(
+      resolveGhostPrimarySessionId(
+        'worker',
+        async () => {
+          throw new Error('db unavailable');
+        },
+        noTeam,
+      ),
+    ).resolves.toBeNull();
+  });
+});
+
+describe('createGhostPrimarySessionFocusTracker', () => {
+  it('deduplicates different workers that resolve to the same lead', async () => {
+    const published: string[] = [];
+    const notify = vi.fn(async (sessionId: string, claim: () => Promise<boolean>) => {
+      if (await claim()) published.push(sessionId);
+    });
+    const tracker = createGhostPrimarySessionFocusTracker(async () => 'lead', notify);
+
+    tracker.note('worker-1');
+    await vi.waitFor(() => expect(published).toEqual(['lead']));
+    tracker.note('worker-2');
+    await Promise.resolve();
+
+    expect(published).toEqual(['lead']);
+  });
+
+  it('ignores a stale async resolution after focus changes', async () => {
+    let resolveFirst!: (sessionId: string | null) => void;
+    let resolveSecond!: (sessionId: string | null) => void;
+    const first = new Promise<string | null>((resolve) => {
+      resolveFirst = resolve;
+    });
+    const second = new Promise<string | null>((resolve) => {
+      resolveSecond = resolve;
+    });
+    const resolve = vi.fn((sessionId: string) => (sessionId === 'worker-1' ? first : second));
+    const published: string[] = [];
+    const notify = vi.fn(async (sessionId: string, claim: () => Promise<boolean>) => {
+      if (await claim()) published.push(sessionId);
+    });
+    const tracker = createGhostPrimarySessionFocusTracker(resolve, notify);
+
+    tracker.note('worker-1');
+    tracker.note('worker-2');
+    resolveSecond('lead-2');
+    await vi.waitFor(() => expect(published).toEqual(['lead-2']));
+    resolveFirst('lead-1');
+    await Promise.resolve();
+
+    expect(published).toEqual(['lead-2']);
+  });
+
+  it('claims publication at the final async boundary', async () => {
+    const pending: Array<{ sessionId: string; claim: () => Promise<boolean> }> = [];
+    const tracker = createGhostPrimarySessionFocusTracker(async () => 'lead', (sessionId, claim) => {
+      pending.push({ sessionId, claim });
+    });
+
+    tracker.note('worker-1');
+    await vi.waitFor(() => expect(pending).toHaveLength(1));
+    tracker.note('worker-2');
+    await vi.waitFor(() => expect(pending).toHaveLength(2));
+
+    await expect(pending[0]?.claim()).resolves.toBe(false);
+    await expect(pending[1]?.claim()).resolves.toBe(true);
+    await expect(pending[1]?.claim()).resolves.toBe(false);
+  });
+
+  it('rejects a lead mapping that changes before publication', async () => {
+    let currentLead = 'lead-1';
+    const pending: Array<{ sessionId: string; claim: () => Promise<boolean> }> = [];
+    const tracker = createGhostPrimarySessionFocusTracker(
+      async () => currentLead,
+      (sessionId, claim) => pending.push({ sessionId, claim }),
+    );
+
+    tracker.note('worker');
+    await vi.waitFor(() => expect(pending).toHaveLength(1));
+    currentLead = 'lead-2';
+
+    expect(pending[0]?.sessionId).toBe('lead-1');
+    await expect(pending[0]?.claim()).resolves.toBe(false);
+  });
+
+  it('clears deduplication when focus leaves the session or resolution fails', async () => {
+    const published: string[] = [];
+    const notify = vi.fn(async (sessionId: string, claim: () => Promise<boolean>) => {
+      if (await claim()) published.push(sessionId);
+    });
+    const tracker = createGhostPrimarySessionFocusTracker(
+      async (sessionId) => (sessionId === 'hidden-worker' ? null : 'lead'),
+      notify,
+    );
+
+    tracker.note('worker');
+    await vi.waitFor(() => expect(published).toHaveLength(1));
+    tracker.note(null);
+    tracker.note('lead');
+    await vi.waitFor(() => expect(published).toHaveLength(2));
+    tracker.note('hidden-worker');
+    await Promise.resolve();
+    tracker.note('lead');
+    await vi.waitFor(() => expect(published).toHaveLength(3));
+
+    expect(published).toEqual(['lead', 'lead', 'lead']);
+  });
+});
 
 function ghost(
   id: string,

--- a/apps/desktop/src/main/cindy-brain/__tests__/subscriptionGateway.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/subscriptionGateway.test.ts
@@ -208,6 +208,27 @@ describe('createGhostPrimarySessionFocusTracker', () => {
     expect(published).toEqual(['lead-a']);
   });
 
+  it('allows the same focus to retry when the publication recheck fails', async () => {
+    let attempts = 0;
+    const pending: Array<{ sessionId: string; claim: () => Promise<boolean> }> = [];
+    const tracker = createGhostPrimarySessionFocusTracker(
+      async () => {
+        attempts += 1;
+        return attempts === 2 ? null : 'lead';
+      },
+      (sessionId, claim) => pending.push({ sessionId, claim }),
+    );
+
+    tracker.note('worker');
+    await vi.waitFor(() => expect(pending).toHaveLength(1));
+    await expect(pending[0]?.claim()).resolves.toBe(false);
+
+    tracker.note('worker');
+    await vi.waitFor(() => expect(pending).toHaveLength(2));
+    await expect(pending[1]?.claim()).resolves.toBe(true);
+    expect(attempts).toBe(4);
+  });
+
   it('clears deduplication when focus explicitly leaves the session', async () => {
     const published: string[] = [];
     const notify = vi.fn(async (sessionId: string, claim: () => Promise<boolean>) => {

--- a/apps/desktop/src/main/cindy-brain/__tests__/subscriptionGateway.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/subscriptionGateway.test.ts
@@ -165,6 +165,25 @@ describe('createGhostPrimarySessionFocusTracker', () => {
     await expect(pending[0]?.claim()).resolves.toBe(false);
   });
 
+  it('allows the same unresolved focus to retry after the first lookup fails', async () => {
+    let attempts = 0;
+    const published: string[] = [];
+    const notify = vi.fn(async (sessionId: string, claim: () => Promise<boolean>) => {
+      if (await claim()) published.push(sessionId);
+    });
+    const tracker = createGhostPrimarySessionFocusTracker(async () => {
+      attempts += 1;
+      return attempts === 1 ? null : 'lead';
+    }, notify);
+
+    tracker.note('worker');
+    await vi.waitFor(() => expect(attempts).toBe(1));
+    tracker.note('worker');
+    await vi.waitFor(() => expect(published).toEqual(['lead']));
+
+    expect(attempts).toBe(3);
+  });
+
   it('clears deduplication when focus leaves the session or resolution fails', async () => {
     const published: string[] = [];
     const notify = vi.fn(async (sessionId: string, claim: () => Promise<boolean>) => {

--- a/apps/desktop/src/main/cindy-brain/index.ts
+++ b/apps/desktop/src/main/cindy-brain/index.ts
@@ -1929,17 +1929,20 @@ function noteGhostWindowSessionFocused(sender: WebContents, sessionId: string | 
   // Renderer route reports are not an authority to grant Simulator access. They
   // may only remove a stale Main-owned grant when this window family moves away
   // from the task for which it was explicitly authorized.
-  revokeIOSSimulatorRendererAccessForSessionChange(sender, sessionId);
   const previous = ghostSessionFocusByWebContents.get(sender.id);
-  if (previous === sessionId) return;
-  ghostSessionFocusByWebContents.set(sender.id, sessionId);
-  if (!ghostSessionFocusTrackedWebContents.has(sender.id)) {
-    ghostSessionFocusTrackedWebContents.add(sender.id);
-    sender.once('destroyed', () => {
-      ghostSessionFocusByWebContents.delete(sender.id);
-      ghostSessionFocusTrackedWebContents.delete(sender.id);
-    });
+  if (previous !== sessionId) {
+    revokeIOSSimulatorRendererAccessForSessionChange(sender, sessionId);
+    ghostSessionFocusByWebContents.set(sender.id, sessionId);
+    if (!ghostSessionFocusTrackedWebContents.has(sender.id)) {
+      ghostSessionFocusTrackedWebContents.add(sender.id);
+      sender.once('destroyed', () => {
+        ghostSessionFocusByWebContents.delete(sender.id);
+        ghostSessionFocusTrackedWebContents.delete(sender.id);
+      });
+    }
   }
+  // Keep forwarding same-id reports: the primary tracker may have cleared its
+  // raw-id dedupe marker after a transient resolution failure and needs a retry.
   noteGhostSessionFocused(sessionId);
 }
 

--- a/apps/desktop/src/main/cindy-brain/index.ts
+++ b/apps/desktop/src/main/cindy-brain/index.ts
@@ -1913,11 +1913,12 @@ const ghostPrimarySessionFocusTracker = createGhostPrimarySessionFocusTracker(
     ),
   (sessionId, claim) => notifyGhostSessionEvent('switched', { sessionId }, claim),
 );
-const ghostSessionFocusTracker = createGhostSessionFocusTracker((sessionId) =>
-  ghostPrimarySessionFocusTracker.note(sessionId),
-);
+// 原始焦点只供 preview 使用；不能用它的 raw-id 去重阻断 primary tracker 的重试。
+const ghostSessionFocusTracker = createGhostSessionFocusTracker(() => {});
 export function noteGhostSessionFocused(sessionId: string | null): void {
-  if (sessionId === null) ghostPrimarySessionFocusTracker.note(null);
+  // 两个 tracker 都必须收到每次上报：raw tracker 负责 preview，primary tracker
+  // 负责 Worker → Lead 归一、异步乱序和失败后的重试。
+  ghostPrimarySessionFocusTracker.note(sessionId);
   ghostSessionFocusTracker.note(sessionId);
 }
 

--- a/apps/desktop/src/main/cindy-brain/index.ts
+++ b/apps/desktop/src/main/cindy-brain/index.ts
@@ -240,7 +240,8 @@ import {
 import { ConnectionTokenProvider, type IssuedConnectionToken } from './connectionTokenProvider.js';
 import { GhostFsSlot } from './fsSlot.js';
 import { getGhostGrantConfirmBridge } from './ghostGrantConfirmBridge.js';
-import { getSessionFsSnapshot } from '../localDb/ipc/sessions.js';
+import { getSessionFsSnapshot, getSessionRowSnapshot } from '../localDb/ipc/sessions.js';
+import { getTeamByWorkerSession } from '../localDb/orcaTeamStore.js';
 import { getDirDepositVault, getSaveDepositVault, isPathInsideDir } from './dirDeposit.js';
 import { readInstalledGhostManifest } from '../installedGhostManifest.js';
 import {
@@ -252,10 +253,13 @@ import {
   GhostSubscriptionGateway,
   GhostActivityTracker,
   GhostTurnTranslator,
+  createGhostPrimarySessionFocusTracker,
   createGhostSessionFocusTracker,
   GhostTapPendingQueue,
   GhostTurnOriginTracker,
   isGhostEligibleSessionRow,
+  isGhostSessionSwitchEligibleRow,
+  resolveGhostPrimarySessionId,
   type GhostInteractionActivityKind,
   type GhostScreenResult,
   type MinimalAgentEvent,
@@ -1383,8 +1387,8 @@ export function getGhostSubscriptionGateway(): GhostSubscriptionGateway {
 }
 
 /**
- * 会话是否在订阅事件的投递范围(用户主会话:desktop/shared 来源、非 orca;
- * 行级判定见 subscriptionGateway.isGhostEligibleSessionRow)。
+ * 会话是否在订阅事件的投递范围。默认只允许非 Orca 用户主任务；session-switch
+ * 额外允许已归一后的 Orca Lead，行级判定见 subscriptionGateway。
  * outcome 三值:eligible / ineligible(查到行且明确不合格,可终身缓存)/
  * retry(DB 未就绪、查询抛错、行还没落库——都是暂时态,调用方稍后重试;
  * 2026-07-12 实测:启动期会话接线早于 DbClient 就绪,一次性判定会把
@@ -1392,6 +1396,7 @@ export function getGhostSubscriptionGateway(): GhostSubscriptionGateway {
  */
 async function isGhostEligibleSession(
   sessionId: string,
+  scope: 'default' | 'session-switch' = 'default',
 ): Promise<
   | { outcome: 'eligible'; agentKind?: string; workdir?: string }
   | { outcome: 'ineligible' }
@@ -1412,7 +1417,11 @@ async function isGhostEligibleSession(
       .limit(1);
     const row = rows[0];
     if (!row) return { outcome: 'retry' }; // 行未落库(极早期)→ 暂时态
-    if (isGhostEligibleSessionRow(row)) {
+    const isEligible =
+      scope === 'session-switch'
+        ? isGhostSessionSwitchEligibleRow(row)
+        : isGhostEligibleSessionRow(row);
+    if (isEligible) {
       return {
         outcome: 'eligible',
         agentKind: row.agentKind ?? undefined,
@@ -1850,6 +1859,7 @@ export function runGhostAssistantReplyHook(
 export function notifyGhostSessionEvent(
   kind: 'created' | 'archived' | 'switched',
   data: { sessionId: string; workdir?: string },
+  shouldPublish: () => boolean | Promise<boolean> = () => true,
 ): void {
   void (async () => {
     try {
@@ -1858,9 +1868,12 @@ export function notifyGhostSessionEvent(
         (g) => g.enabled && g.manifest.subscribe?.topics?.includes('session'),
       );
       if (!hasSubscriber) return;
-      // 投递范围与 turn 事件同口径:只投用户主会话(retry 视为不投,
-      // 生命周期事件不值得重试机制)。
-      const info = await isGhostEligibleSession(data.sessionId);
+      // created / archived 与 turn 事件同口径；switched 额外允许归一后的 Orca Lead。
+      // retry 视为不投，生命周期事件不值得引入重试机制。
+      const info = await isGhostEligibleSession(
+        data.sessionId,
+        kind === 'switched' ? 'session-switch' : 'default',
+      );
       if (info.outcome !== 'eligible') return;
       // switched 的调用方(renderer 路由上报)只有 sessionId,workdir 从资格
       // 查询顺手补上,与 created/archived 的载荷形状对齐。
@@ -1868,6 +1881,8 @@ export function notifyGhostSessionEvent(
         data.workdir === undefined && info.workdir !== undefined
           ? { ...data, workdir: info.workdir }
           : data;
+      // switched 在异步归一、资格查询完成后再确认一次焦点代次；确认与去重在同一步完成。
+      if (!(await shouldPublish())) return;
       getGhostSubscriptionGateway().publish(
         'session',
         kind === 'created'
@@ -1885,13 +1900,24 @@ export function notifyGhostSessionEvent(
 
 /**
  * 会话切换上报入口(renderer MainLayout 路由 effect 经 'ghosts:session-focused'
- * 调,平台无关):去重后发 did-session-switched。连续同 id / 非会话页(null)
- * 不发;切走再切回算新切换(去重语义见 createGhostSessionFocusTracker)。
+ * 调,平台无关):Worker 归一到 Lead 后发 did-session-switched。连续指向同一主任务 / 非会话页
+ * (null)不发；切走再切回算新切换。原始焦点仍单独保留给旧 preview 缺省落点。
  */
+const ghostPrimarySessionFocusTracker = createGhostPrimarySessionFocusTracker(
+  (sessionId) =>
+    resolveGhostPrimarySessionId(
+      sessionId,
+      getSessionRowSnapshot,
+      async (workerSessionId) =>
+        (await getTeamByWorkerSession(workerSessionId))?.leadSessionId ?? null,
+    ),
+  (sessionId, claim) => notifyGhostSessionEvent('switched', { sessionId }, claim),
+);
 const ghostSessionFocusTracker = createGhostSessionFocusTracker((sessionId) =>
-  notifyGhostSessionEvent('switched', { sessionId }),
+  ghostPrimarySessionFocusTracker.note(sessionId),
 );
 export function noteGhostSessionFocused(sessionId: string | null): void {
+  if (sessionId === null) ghostPrimarySessionFocusTracker.note(null);
   ghostSessionFocusTracker.note(sessionId);
 }
 

--- a/apps/desktop/src/main/cindy-brain/index.ts
+++ b/apps/desktop/src/main/cindy-brain/index.ts
@@ -1860,6 +1860,7 @@ export function notifyGhostSessionEvent(
   kind: 'created' | 'archived' | 'switched',
   data: { sessionId: string; workdir?: string },
   shouldPublish: () => boolean | Promise<boolean> = () => true,
+  onRetry: () => void = () => {},
 ): void {
   void (async () => {
     try {
@@ -1874,7 +1875,10 @@ export function notifyGhostSessionEvent(
         data.sessionId,
         kind === 'switched' ? 'session-switch' : 'default',
       );
-      if (info.outcome !== 'eligible') return;
+      if (info.outcome !== 'eligible') {
+        if (info.outcome === 'retry') onRetry();
+        return;
+      }
       // switched 的调用方(renderer 路由上报)只有 sessionId,workdir 从资格
       // 查询顺手补上,与 created/archived 的载荷形状对齐。
       const payload =
@@ -1911,7 +1915,8 @@ const ghostPrimarySessionFocusTracker = createGhostPrimarySessionFocusTracker(
       async (workerSessionId) =>
         (await getTeamByWorkerSession(workerSessionId))?.leadSessionId ?? null,
     ),
-  (sessionId, claim) => notifyGhostSessionEvent('switched', { sessionId }, claim),
+  (sessionId, claim, releaseRaw) =>
+    notifyGhostSessionEvent('switched', { sessionId }, claim, releaseRaw),
 );
 // 原始焦点只供 preview 使用；不能用它的 raw-id 去重阻断 primary tracker 的重试。
 const ghostSessionFocusTracker = createGhostSessionFocusTracker(() => {});

--- a/apps/desktop/src/main/cindy-brain/subscriptionGateway.ts
+++ b/apps/desktop/src/main/cindy-brain/subscriptionGateway.ts
@@ -564,6 +564,40 @@ export function isGhostEligibleSessionRow(row: {
   return (row.source === 'desktop' || row.source === 'shared' || row.source === 'plugin') && row.orcaRole == null;
 }
 
+/** did-session-switched 可投递 Orca Lead，但绝不暴露 Worker。 */
+export function isGhostSessionSwitchEligibleRow(row: {
+  source: string | null | undefined;
+  orcaRole: string | null | undefined;
+}): boolean {
+  return (
+    (row.source === 'desktop' || row.source === 'shared' || row.source === 'plugin') &&
+    (row.orcaRole == null || row.orcaRole === 'lead')
+  );
+}
+
+/** 将焦点任务归一为用户可见的主任务；无法可靠归一时静默丢弃。 */
+export async function resolveGhostPrimarySessionId(
+  sessionId: string,
+  readSession: (
+    sessionId: string,
+  ) => Promise<{ orcaRole?: string | null } | null>,
+  resolveWorkerLead: (workerSessionId: string) => Promise<string | null>,
+): Promise<string | null> {
+  try {
+    const row = await readSession(sessionId);
+    if (!row) return null;
+    if (row.orcaRole == null || row.orcaRole === 'lead') return sessionId;
+    if (row.orcaRole !== 'worker') return null;
+
+    const leadSessionId = await resolveWorkerLead(sessionId);
+    return typeof leadSessionId === 'string' && leadSessionId.length > 0
+      ? leadSessionId
+      : null;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * 会话切换去重器(did-session-switched 的入口滤波,抽成工厂便于单测):
  * renderer 的路由 effect 每次路由变化都上报"当前台前会话"(路由重渲/非会话
@@ -583,6 +617,53 @@ export function createGhostSessionFocusTracker(
     // 台前会话快照(preview 槽缺省落点等"当前会话"语境用;非会话页为 null)。
     current() {
       return last;
+    },
+  };
+}
+
+/**
+ * did-session-switched 的异步焦点归一器：只接受最新一次归一结果，并在
+ * Worker -> Lead 归一之后去重。
+ */
+export function createGhostPrimarySessionFocusTracker(
+  resolve: (sessionId: string) => Promise<string | null>,
+  notify: (sessionId: string, claim: () => Promise<boolean>) => void,
+): { note(sessionId: string | null): void } {
+  let lastRawSessionId: string | null = null;
+  let lastPrimarySessionId: string | null = null;
+  let generation = 0;
+
+  return {
+    note(sessionId) {
+      if (sessionId === lastRawSessionId) return;
+      lastRawSessionId = sessionId;
+      const currentGeneration = ++generation;
+
+      if (sessionId === null) {
+        lastPrimarySessionId = null;
+        return;
+      }
+
+      void resolve(sessionId)
+        .then((primarySessionId) => {
+          if (currentGeneration !== generation) return;
+          if (primarySessionId === null) {
+            lastPrimarySessionId = null;
+            return;
+          }
+          notify(primarySessionId, async () => {
+            if (currentGeneration !== generation) return false;
+            // Team 归属也可能在首次解析后变化；发布前重新解析，绝不投递过期 Lead。
+            if ((await resolve(sessionId)) !== primarySessionId) return false;
+            if (currentGeneration !== generation) return false;
+            if (primarySessionId === lastPrimarySessionId) return false;
+            lastPrimarySessionId = primarySessionId;
+            return true;
+          });
+        })
+        .catch(() => {
+          if (currentGeneration === generation) lastPrimarySessionId = null;
+        });
     },
   };
 }

--- a/apps/desktop/src/main/cindy-brain/subscriptionGateway.ts
+++ b/apps/desktop/src/main/cindy-brain/subscriptionGateway.ts
@@ -627,7 +627,11 @@ export function createGhostSessionFocusTracker(
  */
 export function createGhostPrimarySessionFocusTracker(
   resolve: (sessionId: string) => Promise<string | null>,
-  notify: (sessionId: string, claim: () => Promise<boolean>) => void,
+  notify: (
+    sessionId: string,
+    claim: () => Promise<boolean>,
+    releaseRaw: () => void,
+  ) => void,
 ): { note(sessionId: string | null): void } {
   let lastRawSessionId: string | null = null;
   let lastPrimarySessionId: string | null = null;
@@ -672,6 +676,8 @@ export function createGhostPrimarySessionFocusTracker(
             if (primarySessionId === lastPrimarySessionId) return false;
             lastPrimarySessionId = primarySessionId;
             return true;
+          }, () => {
+            if (currentGeneration === generation) lastRawSessionId = null;
           });
         })
         .catch(() => {

--- a/apps/desktop/src/main/cindy-brain/subscriptionGateway.ts
+++ b/apps/desktop/src/main/cindy-brain/subscriptionGateway.ts
@@ -655,7 +655,19 @@ export function createGhostPrimarySessionFocusTracker(
           notify(primarySessionId, async () => {
             if (currentGeneration !== generation) return false;
             // Team 归属也可能在首次解析后变化；发布前重新解析，绝不投递过期 Lead。
-            if ((await resolve(sessionId)) !== primarySessionId) return false;
+            let recheckedPrimarySessionId: string | null;
+            try {
+              recheckedPrimarySessionId = await resolve(sessionId);
+            } catch {
+              if (currentGeneration === generation) lastRawSessionId = null;
+              return false;
+            }
+            if (recheckedPrimarySessionId !== primarySessionId) {
+              // 发布前复查失败或映射已变化时，释放 raw marker；同一焦点的后续
+              // 上报必须能够重新归一，而已发布的 primary 去重状态保持不变。
+              if (currentGeneration === generation) lastRawSessionId = null;
+              return false;
+            }
             if (currentGeneration !== generation) return false;
             if (primarySessionId === lastPrimarySessionId) return false;
             lastPrimarySessionId = primarySessionId;

--- a/apps/desktop/src/main/cindy-brain/subscriptionGateway.ts
+++ b/apps/desktop/src/main/cindy-brain/subscriptionGateway.ts
@@ -648,6 +648,8 @@ export function createGhostPrimarySessionFocusTracker(
         .then((primarySessionId) => {
           if (currentGeneration !== generation) return;
           if (primarySessionId === null) {
+            // 解析失败不应占用 raw focus；同一焦点的后续上报需要能够重试。
+            lastRawSessionId = null;
             lastPrimarySessionId = null;
             return;
           }
@@ -662,7 +664,10 @@ export function createGhostPrimarySessionFocusTracker(
           });
         })
         .catch(() => {
-          if (currentGeneration === generation) lastPrimarySessionId = null;
+          if (currentGeneration === generation) {
+            lastRawSessionId = null;
+            lastPrimarySessionId = null;
+          }
         });
     },
   };

--- a/apps/desktop/src/main/cindy-brain/subscriptionGateway.ts
+++ b/apps/desktop/src/main/cindy-brain/subscriptionGateway.ts
@@ -650,7 +650,6 @@ export function createGhostPrimarySessionFocusTracker(
           if (primarySessionId === null) {
             // 解析失败不应占用 raw focus；同一焦点的后续上报需要能够重试。
             lastRawSessionId = null;
-            lastPrimarySessionId = null;
             return;
           }
           notify(primarySessionId, async () => {
@@ -666,7 +665,6 @@ export function createGhostPrimarySessionFocusTracker(
         .catch(() => {
           if (currentGeneration === generation) {
             lastRawSessionId = null;
-            lastPrimarySessionId = null;
           }
         });
     },


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复插件订阅 `did-session-switched` 时，焦点落在 Orca Worker 任务会暴露 Worker ID 或漏发事件的问题。Host 在投递切换事件前将 Worker 归一为对应 Lead，并在异步解析完成后仅发布最新且仍有效的主任务。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：插件协同任务切换通知应只暴露主任务
- 本 PR 包含：`did-session-switched` 的 Worker → Lead 归一、异步最新值校验、归一后去重与失败静默
- 明确不包含：插件任务消息发送能力、preview 缺省目标、普通 turn / hook 事件资格、manifest 变更
- 用户可见变化：订阅 session topic 的插件在焦点位于 Orca Worker 时收到对应 Lead 的任务 ID
- 是否存在 breaking change：无

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/cindy-brain/__tests__/subscriptionGateway.test.ts
结果：67 项通过

pnpm --dir packages/maker-core exec vitest run src/agents/pi/__tests__/pi-rpc-resource-discovery.integration.test.ts --pool=forks --maxWorkers=1
结果：15 项通过，1 项按平台条件跳过

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm test:unit
结果：全部 workspace 通过

pnpm check:dco
结果：通过，1 个提交已签署
```

### 手工验证

不涉及 UI；未进行手工交互验证。

### 未执行的验证

无。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [x] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：插件订阅事件路由

### 影响与回滚

- 影响范围：只影响插件 `did-session-switched` 事件在 Orca 协同任务下的任务 ID；普通任务、preview、turn / hook 事件保持原行为。存量插件影响：无需重新安装、重新授权或重新配置，仅把 Worker ID 修正为 Lead ID。
- 回滚 / 降级方式：回退本 PR 提交即可恢复原有切换事件行为。本 PR 修改插件基座订阅事件，需白名单放行人明确 Approve 后方可合并。
- 移动端冷更：不涉及 `apps/mobile` 原生配置、原生依赖或 runtime fingerprint，不触发冷更。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因