### PR TITLE
fix(desktop): 远程任务运行时刷新左侧图标颜色

### DIFF
--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionCard.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionCard.tsx
@@ -81,10 +81,7 @@ import { isRemoteSessionWriteBlocked } from '../lib/remoteSessionWriteGuard';
 import { prefetchDirtyWorktreeForRemoval } from '@/lib/worktreeRemovalWarning';
 import { useSessionAttentionKind } from '@/lib/sessionAttentionStore';
 import { useSessionAttentionUrgency } from '../contexts/SessionAttentionUrgencyContext';
-import {
-  isRemoteSessionActivityActive,
-  useRemoteSessionActivity,
-} from '@/features/device-link/remoteSessionActivityStore';
+import { useRemoteSessionActivity } from '@/features/device-link/remoteSessionActivityStore';
 import {
   useSessionBoundSchedules,
   scheduleFocusPath,
@@ -179,14 +176,15 @@ export function SessionCard({
             ? ('running' as const)
             : ('done' as const);
   // 左侧 vendor mark 呼吸原先只看本地 running 集;远程会话的运行态只进了右侧
-  // 状态槽。并入活动镜像,与 SessionItem / 折叠 rail 同一口径。
-  const leftIconRunning = isRunning || isRemoteSessionActivityActive(remoteActivity);
+  // 状态槽。只并入 phase=running,与 SessionItem / 折叠 rail 同一口径;
+  // needs-interaction 继续由右侧 awaiting 表达。
+  const leftIconRunning = isRunning || remoteActivity?.phase === 'running';
   const rightStatusKind =
     remoteRightStatus ??
     resolveSidebarRightStatus({
       attentionKind,
       isUrgentFromContext,
-      isRunning: leftIconRunning,
+      isRunning,
       hasAttentionNotification,
     });
   const isPinned = session.pinnedAt != null;
@@ -239,13 +237,7 @@ export function SessionCard({
       : null;
   const listPreview = awaitingText ?? runningDetail ?? summaryPreview;
   const cardPreview = awaitingText ?? summaryPreview;
-  const cardPreviewLineClamp = session.summary
-    ? 3
-    : leftIconRunning
-      ? 2
-      : isAutomationGenerated
-        ? 1
-        : 2;
+  const cardPreviewLineClamp = session.summary ? 3 : isRunning ? 2 : isAutomationGenerated ? 1 : 2;
   // 任务信息复选(C / C' 期):卡片右下角信息槽内容,与整理菜单同源共享状态。
   const { fields: taskInfoFields } = useTaskInfoFields();
   const cardPrRefs = usePrRefsForSession(session.id);
@@ -292,12 +284,12 @@ export function SessionCard({
 
   // 运行结束:仅做一次卡片底色 settle 闪动作为完成提示。运行中的活动感由标题左侧
   // SessionStatusIcon 呼吸 + 底部短扫动进度条表达;完成提醒继续走 SessionStatusIcon 状态点(绿/蓝/红)。
-  const prevRunningRef = useRef(leftIconRunning);
+  const prevRunningRef = useRef(isRunning);
   const [isSettling, setIsSettling] = useState(false);
   useEffect(() => {
     const wasRunning = prevRunningRef.current;
-    prevRunningRef.current = leftIconRunning;
-    if (leftIconRunning) {
+    prevRunningRef.current = isRunning;
+    if (isRunning) {
       setIsSettling(false);
       return;
     }
@@ -305,7 +297,7 @@ export function SessionCard({
     setIsSettling(true);
     const timer = setTimeout(() => setIsSettling(false), 900);
     return () => clearTimeout(timer);
-  }, [leftIconRunning]);
+  }, [isRunning]);
   // ── rename（与 SessionItem 同款防重复提交 ref） ──
   const [isEditing, setIsEditing] = useState(false);
   const [editValue, setEditValue] = useState(displayTitle);

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionCard.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionCard.tsx
@@ -81,7 +81,10 @@ import { isRemoteSessionWriteBlocked } from '../lib/remoteSessionWriteGuard';
 import { prefetchDirtyWorktreeForRemoval } from '@/lib/worktreeRemovalWarning';
 import { useSessionAttentionKind } from '@/lib/sessionAttentionStore';
 import { useSessionAttentionUrgency } from '../contexts/SessionAttentionUrgencyContext';
-import { useRemoteSessionActivity } from '@/features/device-link/remoteSessionActivityStore';
+import {
+  isRemoteSessionActivityActive,
+  useRemoteSessionActivity,
+} from '@/features/device-link/remoteSessionActivityStore';
 import {
   useSessionBoundSchedules,
   scheduleFocusPath,
@@ -175,12 +178,15 @@ export function SessionCard({
           : remoteActivity.phase === 'running'
             ? ('running' as const)
             : ('done' as const);
+  // 左侧 vendor mark 呼吸原先只看本地 running 集;远程会话的运行态只进了右侧
+  // 状态槽。并入活动镜像,与 SessionItem / 折叠 rail 同一口径。
+  const leftIconRunning = isRunning || isRemoteSessionActivityActive(remoteActivity);
   const rightStatusKind =
     remoteRightStatus ??
     resolveSidebarRightStatus({
       attentionKind,
       isUrgentFromContext,
-      isRunning,
+      isRunning: leftIconRunning,
       hasAttentionNotification,
     });
   const isPinned = session.pinnedAt != null;
@@ -233,7 +239,13 @@ export function SessionCard({
       : null;
   const listPreview = awaitingText ?? runningDetail ?? summaryPreview;
   const cardPreview = awaitingText ?? summaryPreview;
-  const cardPreviewLineClamp = session.summary ? 3 : isRunning ? 2 : isAutomationGenerated ? 1 : 2;
+  const cardPreviewLineClamp = session.summary
+    ? 3
+    : leftIconRunning
+      ? 2
+      : isAutomationGenerated
+        ? 1
+        : 2;
   // 任务信息复选(C / C' 期):卡片右下角信息槽内容,与整理菜单同源共享状态。
   const { fields: taskInfoFields } = useTaskInfoFields();
   const cardPrRefs = usePrRefsForSession(session.id);
@@ -280,12 +292,12 @@ export function SessionCard({
 
   // 运行结束:仅做一次卡片底色 settle 闪动作为完成提示。运行中的活动感由标题左侧
   // SessionStatusIcon 呼吸 + 底部短扫动进度条表达;完成提醒继续走 SessionStatusIcon 状态点(绿/蓝/红)。
-  const prevRunningRef = useRef(isRunning);
+  const prevRunningRef = useRef(leftIconRunning);
   const [isSettling, setIsSettling] = useState(false);
   useEffect(() => {
     const wasRunning = prevRunningRef.current;
-    prevRunningRef.current = isRunning;
-    if (isRunning) {
+    prevRunningRef.current = leftIconRunning;
+    if (leftIconRunning) {
       setIsSettling(false);
       return;
     }
@@ -293,7 +305,7 @@ export function SessionCard({
     setIsSettling(true);
     const timer = setTimeout(() => setIsSettling(false), 900);
     return () => clearTimeout(timer);
-  }, [isRunning]);
+  }, [leftIconRunning]);
   // ── rename（与 SessionItem 同款防重复提交 ref） ──
   const [isEditing, setIsEditing] = useState(false);
   const [editValue, setEditValue] = useState(displayTitle);
@@ -557,7 +569,7 @@ export function SessionCard({
     <span className={CARD_TITLE_STATUS_SLOT_CLASS} aria-hidden>
       <SessionStatusIcon
         session={session}
-        isRunning={isRunning}
+        isRunning={leftIconRunning}
         isAttached={isAttached}
         hasAttentionNotification={hasAttentionNotification}
         isActive={isActive}
@@ -992,7 +1004,7 @@ export function SessionCard({
           >
             <SessionStatusIcon
               session={session}
-              isRunning={isRunning}
+              isRunning={leftIconRunning}
               isAttached={isAttached}
               hasAttentionNotification={hasAttentionNotification}
               isActive={isActive}

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionItem.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionItem.tsx
@@ -91,7 +91,10 @@ import { isRemoteSessionWriteBlocked } from '../lib/remoteSessionWriteGuard';
 import { prefetchDirtyWorktreeForRemoval } from '@/lib/worktreeRemovalWarning';
 import { useSessionAttentionKind } from '@/lib/sessionAttentionStore';
 import { useSessionAttentionUrgency } from '../contexts/SessionAttentionUrgencyContext';
-import { useRemoteSessionActivity } from '@/features/device-link/remoteSessionActivityStore';
+import {
+  isRemoteSessionActivityActive,
+  useRemoteSessionActivity,
+} from '@/features/device-link/remoteSessionActivityStore';
 import { resolveSidebarRightStatus } from './sidebarRightStatus';
 import { AutomationTimerIcon } from './AutomationTimerIcon';
 import { SidebarRightStatusIndicator } from './SidebarRightStatusIndicator';
@@ -381,12 +384,15 @@ export const SessionItem = memo(function SessionItem({
           : remoteActivity.phase === 'running'
             ? ('running' as const)
             : ('done' as const);
+  // 左侧 vendor mark 呼吸原先只看本地 running 集;远程会话的运行态只进了右侧
+  // 状态槽,图标颜色不会刷新。并入活动镜像,与折叠 rail / 活动 store 同一口径。
+  const leftIconRunning = isRunning || isRemoteSessionActivityActive(remoteActivity);
   const rightStatusKind =
     remoteRightStatus ??
     resolveSidebarRightStatus({
       attentionKind,
       isUrgentFromContext,
-      isRunning,
+      isRunning: leftIconRunning,
       hasAttentionNotification,
     });
   const showRightStatus = rightStatusKind !== 'time';
@@ -890,7 +896,7 @@ export const SessionItem = memo(function SessionItem({
       <span className="flex w-[15px] shrink-0 items-center justify-center">
         <SessionStatusIcon
           session={session}
-          isRunning={isRunning}
+          isRunning={leftIconRunning}
           isAttached={isAttached}
           hasAttentionNotification={hasAttentionNotification}
           isActive={isActive}

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionItem.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionItem.tsx
@@ -91,10 +91,7 @@ import { isRemoteSessionWriteBlocked } from '../lib/remoteSessionWriteGuard';
 import { prefetchDirtyWorktreeForRemoval } from '@/lib/worktreeRemovalWarning';
 import { useSessionAttentionKind } from '@/lib/sessionAttentionStore';
 import { useSessionAttentionUrgency } from '../contexts/SessionAttentionUrgencyContext';
-import {
-  isRemoteSessionActivityActive,
-  useRemoteSessionActivity,
-} from '@/features/device-link/remoteSessionActivityStore';
+import { useRemoteSessionActivity } from '@/features/device-link/remoteSessionActivityStore';
 import { resolveSidebarRightStatus } from './sidebarRightStatus';
 import { AutomationTimerIcon } from './AutomationTimerIcon';
 import { SidebarRightStatusIndicator } from './SidebarRightStatusIndicator';
@@ -385,14 +382,15 @@ export const SessionItem = memo(function SessionItem({
             ? ('running' as const)
             : ('done' as const);
   // 左侧 vendor mark 呼吸原先只看本地 running 集;远程会话的运行态只进了右侧
-  // 状态槽,图标颜色不会刷新。并入活动镜像,与折叠 rail / 活动 store 同一口径。
-  const leftIconRunning = isRunning || isRemoteSessionActivityActive(remoteActivity);
+  // 状态槽,图标颜色不会刷新。只并入 phase=running,与折叠 rail 的 remoteLampOf
+  // 以及本地 pending-prompt 口径一致:needs-interaction 继续由右侧 awaiting 表达。
+  const leftIconRunning = isRunning || remoteActivity?.phase === 'running';
   const rightStatusKind =
     remoteRightStatus ??
     resolveSidebarRightStatus({
       attentionKind,
       isUrgentFromContext,
-      isRunning: leftIconRunning,
+      isRunning,
       hasAttentionNotification,
     });
   const showRightStatus = rightStatusKind !== 'time';

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/sessionCardReviewRegressions.test.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/sessionCardReviewRegressions.test.ts
@@ -121,23 +121,24 @@ describe('SessionCard review regressions', () => {
 
   it('merges remote activity into the left vendor-mark running state', () => {
     // 远程会话的运行态原先只进右侧状态槽,左侧图标仍只看本地 running 集。
-    // 按行精准订阅活动镜像,与折叠 rail / remoteLampOf 同一口径。
-    expect(sessionItemSource).toContain('isRemoteSessionActivityActive');
+    // 只并入 phase=running,与折叠 rail / remoteLampOf 同一口径;
+    // needs-interaction 继续由右侧 awaiting 表达。
     expect(sessionItemSource).toContain(
-      'const leftIconRunning = isRunning || isRemoteSessionActivityActive(remoteActivity)',
+      'const leftIconRunning = isRunning || remoteActivity?.phase === \'running\'',
     );
     expect(sessionItemSource).toContain('isRunning={leftIconRunning}');
-    expect(sessionCardSource).toContain('isRemoteSessionActivityActive');
     expect(sessionCardSource).toContain(
-      'const leftIconRunning = isRunning || isRemoteSessionActivityActive(remoteActivity)',
+      'const leftIconRunning = isRunning || remoteActivity?.phase === \'running\'',
     );
     expect(sessionCardSource).toContain('isRunning={leftIconRunning}');
+    expect(sessionCardSource).not.toContain('isRemoteSessionActivityActive');
+    expect(sessionItemSource).not.toContain('isRemoteSessionActivityActive');
   });
 
   it('keeps card preview line budgets stable across content sources', () => {
-    expect(sessionCardSource).toContain('const cardPreviewLineClamp = session.summary');
-    expect(sessionCardSource).toContain('leftIconRunning');
-    expect(sessionCardSource).toContain('isAutomationGenerated');
+    expect(sessionCardSource).toContain(
+      'const cardPreviewLineClamp = session.summary ? 3 : isRunning ? 2 : isAutomationGenerated ? 1 : 2',
+    );
     expect(sessionCardSource).toContain('style={{ WebkitLineClamp: cardPreviewLineClamp }}');
   });
 

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/sessionCardReviewRegressions.test.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/sessionCardReviewRegressions.test.ts
@@ -119,10 +119,25 @@ describe('SessionCard review regressions', () => {
     expect(sessionCardSource).not.toContain('titlePrefixWidth');
   });
 
-  it('keeps card preview line budgets stable across content sources', () => {
-    expect(sessionCardSource).toContain(
-      'const cardPreviewLineClamp = session.summary ? 3 : isRunning ? 2 : isAutomationGenerated ? 1 : 2',
+  it('merges remote activity into the left vendor-mark running state', () => {
+    // 远程会话的运行态原先只进右侧状态槽,左侧图标仍只看本地 running 集。
+    // 按行精准订阅活动镜像,与折叠 rail / remoteLampOf 同一口径。
+    expect(sessionItemSource).toContain('isRemoteSessionActivityActive');
+    expect(sessionItemSource).toContain(
+      'const leftIconRunning = isRunning || isRemoteSessionActivityActive(remoteActivity)',
     );
+    expect(sessionItemSource).toContain('isRunning={leftIconRunning}');
+    expect(sessionCardSource).toContain('isRemoteSessionActivityActive');
+    expect(sessionCardSource).toContain(
+      'const leftIconRunning = isRunning || isRemoteSessionActivityActive(remoteActivity)',
+    );
+    expect(sessionCardSource).toContain('isRunning={leftIconRunning}');
+  });
+
+  it('keeps card preview line budgets stable across content sources', () => {
+    expect(sessionCardSource).toContain('const cardPreviewLineClamp = session.summary');
+    expect(sessionCardSource).toContain('leftIconRunning');
+    expect(sessionCardSource).toContain('isAutomationGenerated');
     expect(sessionCardSource).toContain('style={{ WebkitLineClamp: cardPreviewLineClamp }}');
   });
 


### PR DESCRIPTION
## 这次改了什么

### 摘要

远程任务已经在跑时，侧栏右侧状态会更新，左侧 vendor 图标却一直是灰色。原因是左右两套状态源没对齐：右侧看被控端活动镜像，左侧只看本机 `runningSessionIds`。远程任务不在本机进程里，这个集合永远是空的。

本 PR 只修这件事：文字行和卡片行都按折叠 rail 的同一口径，把远程 `phase === 'running'` 并进左侧图标颜色。`needs-interaction` 继续只走右侧 awaiting，不把等待交互画成橙色呼吸。卡片预览行数和完成闪动仍看本机 `isRunning`。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：`SessionItem` / `SessionCard` 左侧 running 状态并入远程活动镜像的 `phase === 'running'`
- 明确不包含：侧边栏重设计、范围标题、显示设置菜单、组件级 store 注入测试基建
- 用户可见变化：正在运行的远程任务，左侧图标会变成橙色并呼吸；等待交互时左侧不呼吸
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：DESIGN.md §2 Semantic & Accent，Thinking / Warning Orange（`--warning-accent` / `--status-bar-accent`）只用于侧栏 running-state 呼吸图标。本次只让远程真正 running 的任务走与本地任务同一条已登记消费路径，不新增颜色、不改图标形态。等待交互继续由右侧 awaiting 表达，不新增界面元素。
- 界面效果：复用既有左侧 vendor mark 的橙色呼吸，没有新布局、新控件或新文案；因此不另附截图。合入前建议在有远程设备的桌面端确认：远程 running 变橙，needs-interaction 左侧保持灰、右侧走 awaiting。

## 怎么验证的

### 自动验证

```text
pnpm --dir /Users/dash/Code/Cindy/cindy-fix-remote-sidebar-icon-running --filter desktop run --if-present typecheck
结果：通过

bash /Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh /Users/dash/Code/Cindy/cindy-fix-remote-sidebar-icon-running
结果：GATE_EXIT=0
```

已 rebase 到最新 `origin/main`（`eaec7e40a`）并 force-push，解除与 `main` 的合并冲突。

### 手工验证

在侧边栏重设计沙箱里看到复现：远程任务已运行，右侧状态更新，左侧图标仍灰。本 PR 基于最新 `main` 拆出后，未再单独开一份远程控制沙箱复验；合入前建议在有远程设备的桌面端确认左侧图标会随远程 running 变橙。

### 未执行的验证

- 未在本 PR worktree 再跑一份隔离桌面沙箱做远程实机回归
- Dark 模式实机目检未做；颜色走既有 `--status-bar-accent` token

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围：Desktop 侧栏文字行 / 卡片行的左侧 running 颜色；本地会话路径不变
- 回滚 / 降级方式：回退本 PR 即可

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
