### PR TITLE
fix(worktree): avoid redundant safe.directory writes

### DIFF
--- a/apps/desktop/src/main/__tests__/worktreeManagerCreate.test.ts
+++ b/apps/desktop/src/main/__tests__/worktreeManagerCreate.test.ts
@@ -106,6 +106,13 @@ describe('createWorktree naming authority', () => {
       },
     });
     expect(storeMap.get('session-1')).toEqual(result.ok ? result.meta : undefined);
+    expect(gitExecMock).not.toHaveBeenCalledWith([
+      'config',
+      '--global',
+      '--add',
+      'safe.directory',
+      path.join(baseRepo, '.cindy-worktrees', 'auto-abc123'),
+    ]);
   });
 
   it('preserves an explicit legal name and still rejects an explicit illegal name', async () => {

--- a/apps/desktop/src/main/worktree/WorktreeManager.ts
+++ b/apps/desktop/src/main/worktree/WorktreeManager.ts
@@ -659,8 +659,7 @@ export async function copyClaudeSiviDirs(
  *   6. configureHooksPath
  *   7. copyClaudeSiviDirs(跳过 .claude/worktrees 这类历史工作区状态)
  *   8. applyWorktreeIncludeFile
- *   9. git config --global --add safe.directory <path>
- *  10. worktreeStore.set(sessionId, meta) → 同步写 sessions.worktree_path
+ *   9. worktreeStore.set(sessionId, meta) → 同步写 sessions.worktree_path
  */
 export async function createWorktree(req: CreateWorktreeReq): Promise<CreateWorktreeResp> {
   const create = () => withCreateWorktreeQueue(req.baseRepo, () => createWorktreeInner(req));
@@ -856,20 +855,7 @@ async function createWorktreeInner(req: CreateWorktreeReq): Promise<CreateWorktr
       );
     }
 
-    // 9. safe.directory
-    try {
-      await timed('add safe.directory', () =>
-        gitExec(['config', '--global', '--add', 'safe.directory', worktreePath]),
-      );
-    } catch (err) {
-      // 非致命 — 仅日志
-      log.warn(
-        `[worktree] add safe.directory failed:`,
-        err instanceof Error ? err.message : String(err),
-      );
-    }
-
-    // 10. store + DB
+    // 9. store + DB
     const meta: WorktreeMeta = {
       sessionId: req.sessionId,
       name,

--- a/apps/desktop/src/main/worktree/__tests__/gitExec.test.ts
+++ b/apps/desktop/src/main/worktree/__tests__/gitExec.test.ts
@@ -540,4 +540,111 @@ describe('gitExec timeoutMs', () => {
     await expect(p).resolves.toEqual({ stdout: 'ok', stderr: '' });
     expect(vi.getTimerCount()).toBe(0);
   });
+
+  it('dubious ownership only adds an absent exact safe.directory', async () => {
+    vi.useRealTimers();
+    setPlatform('linux');
+    const calls: Array<{ args: string[]; cb: ExecCb }> = [];
+    mocks.execFile.mockImplementation((_file: string, args: string[], _opts: unknown, cb: ExecCb) => {
+      calls.push({ args, cb });
+      return Object.assign(new EventEmitter(), {
+        pid: 4242,
+        kill: vi.fn(),
+        exitCode: null,
+        signalCode: null,
+      });
+    });
+
+    const operation = gitExec(['status'], '/owned/repo');
+    await vi.waitFor(() => expect(calls).toHaveLength(1));
+    const dubious = Object.assign(new Error('dubious'), { code: 128 });
+    calls[0].cb(
+      dubious,
+      '',
+      "fatal: detected dubious ownership in repository at '/owned/repo'",
+    );
+    await vi.waitFor(() => expect(calls).toHaveLength(2));
+    const missing = Object.assign(new Error('missing'), { code: 1 });
+    calls[1].cb(missing, '', '');
+    await vi.waitFor(() => expect(calls).toHaveLength(3));
+    calls[2].cb(null, '', '');
+    await vi.waitFor(() => expect(calls).toHaveLength(4));
+    calls[3].cb(null, 'clean', '');
+
+    await expect(operation).resolves.toEqual({ stdout: 'clean', stderr: '' });
+    expect(calls.map(({ args }) => args)).toEqual([
+      ['status'],
+      ['config', '--global', '--get-all', 'safe.directory'],
+      ['config', '--global', '--add', 'safe.directory', '/owned/repo'],
+      ['status'],
+    ]);
+  });
+
+  it('dubious ownership reuses an existing exact safe.directory', async () => {
+    vi.useRealTimers();
+    setPlatform('linux');
+    const calls: Array<{ args: string[]; cb: ExecCb }> = [];
+    mocks.execFile.mockImplementation((_file: string, args: string[], _opts: unknown, cb: ExecCb) => {
+      calls.push({ args, cb });
+      return Object.assign(new EventEmitter(), {
+        pid: 4242,
+        kill: vi.fn(),
+        exitCode: null,
+        signalCode: null,
+      });
+    });
+
+    const operation = gitExec(['status'], '/manual/repo');
+    await vi.waitFor(() => expect(calls).toHaveLength(1));
+    calls[0].cb(
+      Object.assign(new Error('dubious'), { code: 128 }),
+      '',
+      "fatal: detected dubious ownership in repository at '/manual/repo'",
+    );
+    await vi.waitFor(() => expect(calls).toHaveLength(2));
+    calls[1].cb(null, '/manual/repo\n', '');
+    await vi.waitFor(() => expect(calls).toHaveLength(3));
+    calls[2].cb(null, 'clean', '');
+
+    await expect(operation).resolves.toEqual({ stdout: 'clean', stderr: '' });
+    expect(calls.some(({ args }) => args.includes('--add'))).toBe(false);
+  });
+
+  it('ignores safe.directory values that precede an empty reset', async () => {
+    vi.useRealTimers();
+    setPlatform('linux');
+    const calls: Array<{ args: string[]; cb: ExecCb }> = [];
+    mocks.execFile.mockImplementation((_file: string, args: string[], _opts: unknown, cb: ExecCb) => {
+      calls.push({ args, cb });
+      return Object.assign(new EventEmitter(), {
+        pid: 4242,
+        kill: vi.fn(),
+        exitCode: null,
+        signalCode: null,
+      });
+    });
+
+    const operation = gitExec(['status'], '/reset/repo');
+    await vi.waitFor(() => expect(calls).toHaveLength(1));
+    calls[0].cb(
+      Object.assign(new Error('dubious'), { code: 128 }),
+      '',
+      "fatal: detected dubious ownership in repository at '/reset/repo'",
+    );
+    await vi.waitFor(() => expect(calls).toHaveLength(2));
+    calls[1].cb(null, '/reset/repo\n\n', '');
+    await vi.waitFor(() => expect(calls).toHaveLength(3));
+    calls[2].cb(null, '', '');
+    await vi.waitFor(() => expect(calls).toHaveLength(4));
+    calls[3].cb(null, 'clean', '');
+
+    await expect(operation).resolves.toEqual({ stdout: 'clean', stderr: '' });
+    expect(calls[2].args).toEqual([
+      'config',
+      '--global',
+      '--add',
+      'safe.directory',
+      '/reset/repo',
+    ]);
+  });
 });

--- a/apps/desktop/src/main/worktree/gitExec.ts
+++ b/apps/desktop/src/main/worktree/gitExec.ts
@@ -4,7 +4,7 @@
  * 职责:
  *   - 用 child_process.execFile 调用 git, 保留 stderr/stdout/exitCode
  *   - 自动处理 dubious-ownership: 若 stderr 含 "dubious ownership", 提取路径,
- *     `git config --global --add safe.directory <path>`, 重试**一次**原命令
+ *     精确值尚不存在时添加 `safe.directory`, 重试**一次**原命令
  *   - 抛出 GitExecError 让上层 errorClassifier 解析为 WorktreeError
  *
  * 不在这里做 errorClassifier — 那是上层 createWorktree/removeWorktree 的职责,
@@ -69,6 +69,8 @@ export interface GitExecOpts {
    */
   timeoutMs?: number;
 }
+
+const safeDirectoryQueues = new Map<string, Promise<void>>();
 
 /** POSIX 超时后 SIGTERM → SIGKILL 的宽限期:给 git 留出清理 .lock 的时间窗。 */
 const POSIX_KILL_GRACE_MS = 1_500;
@@ -446,6 +448,34 @@ function extractDubiousPath(stderr: string): string | null {
   return null;
 }
 
+async function listSafeDirectories(): Promise<string[]> {
+  try {
+    const { stdout } = await execFileOnce(['config', '--global', '--get-all', 'safe.directory']);
+    const values = stdout.split(/\r?\n/);
+    if (values.at(-1) === '') values.pop();
+    const resetIndex = values.lastIndexOf('');
+    return resetIndex < 0 ? values : values.slice(resetIndex + 1);
+  } catch (err) {
+    if (err instanceof GitExecError && err.exitCode === 1) return [];
+    throw err;
+  }
+}
+
+/** Add an exact value only when the user's global config does not already contain it. */
+async function ensureSafeDirectory(directory: string): Promise<void> {
+  const previous = safeDirectoryQueues.get(directory) ?? Promise.resolve();
+  const run = previous.catch(() => undefined).then(async () => {
+    if ((await listSafeDirectories()).includes(directory)) return;
+    await execFileOnce(['config', '--global', '--add', 'safe.directory', directory]);
+  });
+  safeDirectoryQueues.set(directory, run);
+  try {
+    await run;
+  } finally {
+    if (safeDirectoryQueues.get(directory) === run) safeDirectoryQueues.delete(directory);
+  }
+}
+
 /**
  * 主 API: 执行 git 命令, 自动处理 dubious-ownership。
  *
@@ -471,9 +501,7 @@ export async function gitExec(
       const dubiousPath = extractDubiousPath(err.stderr) ?? cwd;
       if (dubiousPath) {
         try {
-          await execFileOnce(
-            ['config', '--global', '--add', 'safe.directory', dubiousPath],
-          );
+          await ensureSafeDirectory(dubiousPath);
           // 配完 safe.directory 后重试原命令
           return await execFileOnce(args, cwd, opts);
         } catch {


### PR DESCRIPTION
## 这次改了什么

### 摘要

Stop managed worktree creation from unconditionally modifying the user's global `safe.directory` configuration. The existing dubious-ownership recovery now adds an exact path only when it is absent from the effective values after the last empty reset.

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Related to #2627
- 本 PR 包含：Remove the unconditional global config write; honor ordered empty-reset semantics while deduplicating the existing on-error repair; retain the single retry.
- 明确不包含：Removing historical entries or automatic cleanup on worktree deletion. Existing entries have no ownership provenance.
- 用户可见变化：Normal worktree creation no longer changes global Git configuration.
- 是否存在 breaking change：No.

### UI 变化

Not involved.

- 引用的设计规范：不涉及：Desktop main-process Git configuration only; no visual, layout, copy, or interaction change.

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/worktree/__tests__/gitExec.test.ts src/main/__tests__/worktreeManagerCreate.test.ts
Result: 2 files, 25 tests passed.

NODE_OPTIONS=--max-old-space-size=6144 pnpm --filter desktop run --if-present typecheck
Result: passed.

pnpm test:unit
Result: all configured workspaces passed.

pnpm check:dco
Result: passed.
```

### 手工验证

Not run.

### 未执行的验证

A real dubious-ownership repository was not created. Exact command sequencing is covered with isolated child-process tests.

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Managed worktree creation and the existing dubious-ownership retry path.
- 回滚 / 降级方式：Revert the commit. No migration or data cleanup is required.

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
