### PR TITLE
docs(pi): clarify explicit skill provenance

### DIFF
--- a/packages/maker-core/src/agents/pi/skill-runtime-provenance.ts
+++ b/packages/maker-core/src/agents/pi/skill-runtime-provenance.ts
@@ -4,10 +4,11 @@ import type { PiRuntimeCommand } from '../../types/pi-runtime-capabilities.js';
 
 /**
  * Return the exact explicit --skill directory proven by pinned Pi provenance.
- * Pi v0.83 reports explicit local skills as either `temporary` (staged launch
- * snapshots) or `project` (paths passed directly on the CLI). Both fields must
- * agree; accepting either independently lets malformed runtime data mark the
- * wrong discovered project skill loaded.
+ * Pi v0.83 reports explicit local skills as `temporary` for Cindy's staged
+ * launch snapshots; direct `--skill` paths report `project` on Windows and
+ * `temporary` on macOS. Both values are accepted because the runtime
+ * provenance is path-scoped; accepting either independently still lets
+ * malformed data mark the wrong discovered project skill as loaded.
  */
 export function piExplicitSkillRuntimePath(command: PiRuntimeCommand): string | null {
   const baseDir = command.sourceInfo.baseDir;


### PR DESCRIPTION
## 这次改了什么

### 摘要

对齐 `packages/maker-core/src/agents/pi/skill-runtime-provenance.ts` 的 provenance 文档与 main 上已合入的平台条件式契约：Pi v0.83 对显式 `--skill` 路径在 Windows 上报 `project`、macOS 上报 `temporary`，而 Cindy 的分阶段启动快照统一报 `temporary`。原文档把「直接 CLI 路径」一律描述为 `project`，与测试事实（`process.platform === 'win32' ? 'project' : 'temporary'`）相矛盾，已改为按平台说明并保留「两值均接受、path-scoped 校验」的不变量。

### 变更类型

- [x] `docs` 文档维护

### 范围

- 包含：`skill-runtime-provenance.ts` 顶部契约注释的措辞修正（仅注释，无行为变化）。
- 不包含：测试代码、运行时逻辑、UI、i18n。
- 用户可见变化：无。
- breaking change：无。

### 说明

此前本 PR 中的测试对齐（`scope: 'temporary'`）已被 main 上以平台条件式（Windows `project` / macOS `temporary`）合入的实现取代，因此测试改动不再保留；与 PR 主题无关的 provider dialog 改动也已移除，当前 PR 仅剩文档澄清。

## 怎么验证的

- `pnpm --filter @cindy/maker-core build`：除本机 node_modules 过期导致的既有测试文件类型错误外，改动文件无新增错误（注释改动不影响类型）。
- `pnpm test:unit:related`：`packages/maker-core unit` 通过（32.3s）。
- `pnpm check:dco` 通过；`git diff --check` 通过。

## 风险

- 影响范围：仅注释文档。
- 回滚方式：revert 本 PR 的单个 commit。