### PR TITLE
fix(desktop): 修复跳到底部按钮与输入框的动态间距

### DIFF
--- a/apps/desktop/src/renderer/components/chat/MessageStream.tsx
+++ b/apps/desktop/src/renderer/components/chat/MessageStream.tsx
@@ -207,6 +207,7 @@ import {
 } from './messageNavRailModel';
 import { resolveUserDisplayText } from './userMessageDisplayText';
 import { detectScrollAnchoringApplied } from './scrollAnchoringDetect';
+import { resolveMessageStreamIndicatorBottomOffset } from './messageStreamIndicatorPosition';
 import {
   decideAutoFillAction,
   decideUserIntentFillAction,
@@ -267,6 +268,8 @@ interface MessageStreamProps {
   hasMoreMessages?: boolean;
   /** Dynamic bottom padding (px) to reserve space for the input overlay */
   bottomPadding?: number;
+  /** Distance from the chat viewport bottom to the visible composer card top. */
+  composerTopOffset?: number;
   /** Content width — shared with the input overlay so chat stream + input
    *  box stay horizontally aligned (same width, same center, symmetric
    *  padding when the main area is compressed). */
@@ -2536,6 +2539,7 @@ export function MessageStream({
   isLoadingMore,
   hasMoreMessages,
   bottomPadding,
+  composerTopOffset,
   contentWidth,
   focusMessageClientId,
   focusMessageRequestId,
@@ -4235,13 +4239,13 @@ export function MessageStream({
     previousLocalFileRefsRef.current = localFileRefs;
   }, [localFileRefs]);
 
-  // chip 垂直位置 — 用户要求贴在"Generating..." RunningStatusBar 那一行。
-  // overlay 内部从下到上是:input box + 上方 10px gap + RunningStatusBar(约 28px)+
-  // 32px 渐变蒙层。把 chip 挪进 overlay 内、center 大致对齐 status bar center,
-  // 经验值 overlayHeight - 56(原 -60,2026-05-13 用户反馈再往上 4px)。
-  // Math.max 兜底防极小 overlay 时 chip 跑出容器。
+  // chip 垂直位置：优先使用父层实测的输入框卡片顶边，避免 RunningStatusBar
+  // 出现 / 收起改变 overlay 总高度后，把按钮带进输入框。旧调用方保留历史兜底。
   const resolvedBottomPadding = bottomPadding ?? 200;
-  const indicatorBottomOffset = Math.max(resolvedBottomPadding - 56, 12);
+  const indicatorBottomOffset = resolveMessageStreamIndicatorBottomOffset({
+    bottomPadding,
+    composerTopOffset,
+  });
 
   // 「提及 → 兑现」关联(方案 2):从会话历史现算,软提示卡据此升级为召唤卡。
   // 引用缓存:内容不变时复用上一个 Map 引用——UserMessage 顶层订阅该
@@ -4587,7 +4591,7 @@ export function MessageStream({
 
             {/* F1 / F3: 新消息悬浮提示——挂在 scrollRef 的 relative wrapper 内部，
            与滚动容器平级。visible 由 `!isNearBottom && unreadCount > 0` 双重
-           守护；bottomOffset 直接复用 bottomPadding（overlayHeight）+ 12。 */}
+           守护；bottomOffset 让按钮位于输入框上边缘上方约 6px。 */}
             <NewMessageIndicator
               visible={!isNearBottom && unreadCount > 0}
               count={unreadCount}

--- a/apps/desktop/src/renderer/components/chat/MessageStream.tsx
+++ b/apps/desktop/src/renderer/components/chat/MessageStream.tsx
@@ -268,8 +268,8 @@ interface MessageStreamProps {
   hasMoreMessages?: boolean;
   /** Dynamic bottom padding (px) to reserve space for the input overlay */
   bottomPadding?: number;
-  /** Distance from the chat viewport bottom to the visible composer card top. */
-  composerTopOffset?: number;
+  /** Distance from the chat viewport bottom to the visible composer stack top. */
+  composerStackTopOffset?: number;
   /** Content width — shared with the input overlay so chat stream + input
    *  box stay horizontally aligned (same width, same center, symmetric
    *  padding when the main area is compressed). */
@@ -2539,7 +2539,7 @@ export function MessageStream({
   isLoadingMore,
   hasMoreMessages,
   bottomPadding,
-  composerTopOffset,
+  composerStackTopOffset,
   contentWidth,
   focusMessageClientId,
   focusMessageRequestId,
@@ -4244,7 +4244,7 @@ export function MessageStream({
   const resolvedBottomPadding = bottomPadding ?? 200;
   const indicatorBottomOffset = resolveMessageStreamIndicatorBottomOffset({
     bottomPadding,
-    composerTopOffset,
+    composerStackTopOffset,
   });
 
   // 「提及 → 兑现」关联(方案 2):从会话历史现算,软提示卡据此升级为召唤卡。

--- a/apps/desktop/src/renderer/components/chat/__tests__/messageStreamIndicatorPosition.test.ts
+++ b/apps/desktop/src/renderer/components/chat/__tests__/messageStreamIndicatorPosition.test.ts
@@ -26,12 +26,12 @@ describe('resolveMessageStreamIndicatorBottomOffset', () => {
     expect(resolveMessageStreamIndicatorBottomOffset({ bottomPadding: 40 })).toBe(12);
   });
 
-  it('measures from the whole composer stack so plan mode stays above the indicator', () => {
+  it('measures from the outer composer stack so goal and plan indicators stay above the button', () => {
     const composerStack = {
       getBoundingClientRect: () => ({ top: 620 }),
     } as HTMLElement;
     const querySelector = vi.fn((selector: string) =>
-      selector === '[data-chat-input-root]' ? composerStack : null,
+      selector === '[data-chat-composer-stack]' ? composerStack : null,
     );
     const overlay = {
       querySelector,
@@ -39,6 +39,6 @@ describe('resolveMessageStreamIndicatorBottomOffset', () => {
     } as unknown as HTMLElement;
 
     expect(measureComposerStackTopOffset(overlay)).toBe(180);
-    expect(querySelector).toHaveBeenCalledWith('[data-chat-input-root]');
+    expect(querySelector).toHaveBeenCalledWith('[data-chat-composer-stack]');
   });
 });

--- a/apps/desktop/src/renderer/components/chat/__tests__/messageStreamIndicatorPosition.test.ts
+++ b/apps/desktop/src/renderer/components/chat/__tests__/messageStreamIndicatorPosition.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveMessageStreamIndicatorBottomOffset } from '../messageStreamIndicatorPosition';
+
+describe('resolveMessageStreamIndicatorBottomOffset', () => {
+  it('keeps the indicator anchored to the composer when the status row changes overlay height', () => {
+    expect(
+      resolveMessageStreamIndicatorBottomOffset({
+        bottomPadding: 174,
+        composerTopOffset: 142,
+      }),
+    ).toBe(148);
+    expect(
+      resolveMessageStreamIndicatorBottomOffset({
+        bottomPadding: 206,
+        composerTopOffset: 142,
+      }),
+    ).toBe(148);
+  });
+
+  it('preserves the legacy offset when the composer card cannot be measured', () => {
+    expect(resolveMessageStreamIndicatorBottomOffset({ bottomPadding: 174 })).toBe(118);
+    expect(resolveMessageStreamIndicatorBottomOffset({ bottomPadding: 40 })).toBe(12);
+  });
+});

--- a/apps/desktop/src/renderer/components/chat/__tests__/messageStreamIndicatorPosition.test.ts
+++ b/apps/desktop/src/renderer/components/chat/__tests__/messageStreamIndicatorPosition.test.ts
@@ -1,25 +1,44 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
-import { resolveMessageStreamIndicatorBottomOffset } from '../messageStreamIndicatorPosition';
+import {
+  measureComposerStackTopOffset,
+  resolveMessageStreamIndicatorBottomOffset,
+} from '../messageStreamIndicatorPosition';
 
 describe('resolveMessageStreamIndicatorBottomOffset', () => {
   it('keeps the indicator anchored to the composer when the status row changes overlay height', () => {
     expect(
       resolveMessageStreamIndicatorBottomOffset({
         bottomPadding: 174,
-        composerTopOffset: 142,
+        composerStackTopOffset: 142,
       }),
     ).toBe(148);
     expect(
       resolveMessageStreamIndicatorBottomOffset({
         bottomPadding: 206,
-        composerTopOffset: 142,
+        composerStackTopOffset: 142,
       }),
     ).toBe(148);
   });
 
-  it('preserves the legacy offset when the composer card cannot be measured', () => {
+  it('preserves the legacy offset when the composer stack cannot be measured', () => {
     expect(resolveMessageStreamIndicatorBottomOffset({ bottomPadding: 174 })).toBe(118);
     expect(resolveMessageStreamIndicatorBottomOffset({ bottomPadding: 40 })).toBe(12);
+  });
+
+  it('measures from the whole composer stack so plan mode stays above the indicator', () => {
+    const composerStack = {
+      getBoundingClientRect: () => ({ top: 620 }),
+    } as HTMLElement;
+    const querySelector = vi.fn((selector: string) =>
+      selector === '[data-chat-input-root]' ? composerStack : null,
+    );
+    const overlay = {
+      querySelector,
+      getBoundingClientRect: () => ({ bottom: 800 }),
+    } as unknown as HTMLElement;
+
+    expect(measureComposerStackTopOffset(overlay)).toBe(180);
+    expect(querySelector).toHaveBeenCalledWith('[data-chat-input-root]');
   });
 });

--- a/apps/desktop/src/renderer/components/chat/messageStreamIndicatorPosition.ts
+++ b/apps/desktop/src/renderer/components/chat/messageStreamIndicatorPosition.ts
@@ -1,0 +1,17 @@
+const DEFAULT_BOTTOM_PADDING_PX = 200;
+const LEGACY_STATUS_ROW_OFFSET_PX = 56;
+const MIN_BOTTOM_OFFSET_PX = 12;
+const COMPOSER_GAP_PX = 6;
+
+export function resolveMessageStreamIndicatorBottomOffset({
+  bottomPadding,
+  composerTopOffset,
+}: {
+  bottomPadding?: number;
+  composerTopOffset?: number;
+}): number {
+  if (composerTopOffset != null) return composerTopOffset + COMPOSER_GAP_PX;
+
+  const resolvedBottomPadding = bottomPadding ?? DEFAULT_BOTTOM_PADDING_PX;
+  return Math.max(resolvedBottomPadding - LEGACY_STATUS_ROW_OFFSET_PX, MIN_BOTTOM_OFFSET_PX);
+}

--- a/apps/desktop/src/renderer/components/chat/messageStreamIndicatorPosition.ts
+++ b/apps/desktop/src/renderer/components/chat/messageStreamIndicatorPosition.ts
@@ -5,13 +5,20 @@ const COMPOSER_GAP_PX = 6;
 
 export function resolveMessageStreamIndicatorBottomOffset({
   bottomPadding,
-  composerTopOffset,
+  composerStackTopOffset,
 }: {
   bottomPadding?: number;
-  composerTopOffset?: number;
+  composerStackTopOffset?: number;
 }): number {
-  if (composerTopOffset != null) return composerTopOffset + COMPOSER_GAP_PX;
+  if (composerStackTopOffset != null) return composerStackTopOffset + COMPOSER_GAP_PX;
 
   const resolvedBottomPadding = bottomPadding ?? DEFAULT_BOTTOM_PADDING_PX;
   return Math.max(resolvedBottomPadding - LEGACY_STATUS_ROW_OFFSET_PX, MIN_BOTTOM_OFFSET_PX);
+}
+
+export function measureComposerStackTopOffset(overlayEl: HTMLElement): number | undefined {
+  const composerStack = overlayEl.querySelector<HTMLElement>('[data-chat-input-root]');
+  if (!composerStack) return undefined;
+
+  return overlayEl.getBoundingClientRect().bottom - composerStack.getBoundingClientRect().top;
 }

--- a/apps/desktop/src/renderer/components/chat/messageStreamIndicatorPosition.ts
+++ b/apps/desktop/src/renderer/components/chat/messageStreamIndicatorPosition.ts
@@ -17,7 +17,7 @@ export function resolveMessageStreamIndicatorBottomOffset({
 }
 
 export function measureComposerStackTopOffset(overlayEl: HTMLElement): number | undefined {
-  const composerStack = overlayEl.querySelector<HTMLElement>('[data-chat-input-root]');
+  const composerStack = overlayEl.querySelector<HTMLElement>('[data-chat-composer-stack]');
   if (!composerStack) return undefined;
 
   return overlayEl.getBoundingClientRect().bottom - composerStack.getBoundingClientRect().top;

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -6503,7 +6503,7 @@ export function ChatInput({
           Hence this extra `relative` layer around the wrapper. It also serves
           as the outside-click boundary for collapsing the expanded queue tail
           (see paletteAnchorRef) — palette clicks are "inside". */}
-      <div ref={paletteAnchorRef} className="relative w-full">
+      <div ref={paletteAnchorRef} className="relative w-full" data-chat-input-card>
         <div
           ref={mergedCardRef}
           className={cn(

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -6503,7 +6503,7 @@ export function ChatInput({
           Hence this extra `relative` layer around the wrapper. It also serves
           as the outside-click boundary for collapsing the expanded queue tail
           (see paletteAnchorRef) — palette clicks are "inside". */}
-      <div ref={paletteAnchorRef} className="relative w-full" data-chat-input-card>
+      <div ref={paletteAnchorRef} className="relative w-full">
         <div
           ref={mergedCardRef}
           className={cn(

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
@@ -71,6 +71,7 @@ import { PlanViewerCard } from '@/components/new-chat/PlanViewerCard';
 import { PlanActionCard } from '@/components/new-chat/PlanActionCard';
 import { InteractionPromptHost } from '@/components/interaction-portal';
 import { MessageStream } from '@/components/chat/MessageStream';
+import { measureComposerStackTopOffset } from '@/components/chat/messageStreamIndicatorPosition';
 import { ShareSelectionBar } from '@/components/chat/ShareSelectionBar';
 import {
   shareSelectionStore,
@@ -1155,18 +1156,18 @@ export function CCAgentSessionView({
     setOverlayEl(node);
   }, []);
   const [overlayHeight, setOverlayHeight] = useState(200);
-  const [composerTopOffset, setComposerTopOffset] = useState<number | undefined>(undefined);
+  const [composerStackTopOffset, setComposerStackTopOffset] = useState<number | undefined>(
+    undefined,
+  );
 
   useEffect(() => {
     if (!overlayEl) return;
     const measureOverlay = () => {
-      // 状态行会动态出现 / 收起，overlay 总高度不等于输入框卡片顶边。
-      // 直接量卡片到 overlay 底边的距离，让消息流悬浮按钮不受状态行高度影响。
+      // 状态行会动态出现 / 收起，overlay 总高度不等于 composer 栈顶边。
+      // 直接量完整 composer 栈（含计划模式提示）到 overlay 底边的距离，
+      // 让消息流悬浮按钮不受状态行或输入框内部状态高度影响。
       setOverlayHeight(overlayEl.offsetHeight);
-      const composerCard = overlayEl.querySelector<HTMLElement>('[data-chat-input-card]');
-      setComposerTopOffset(
-        composerCard ? overlayEl.getBoundingClientRect().bottom - composerCard.getBoundingClientRect().top : undefined,
-      );
+      setComposerStackTopOffset(measureComposerStackTopOffset(overlayEl));
     };
     // Seed with the current height so the first paint after remount uses the
     // real value (not the stale state from the previous mount).
@@ -3701,7 +3702,7 @@ export function CCAgentSessionView({
       isLoadingMore={isLoadingMore}
       hasMoreMessages={hasMoreMessages}
       bottomPadding={overlayHeight}
-      composerTopOffset={composerTopOffset}
+      composerStackTopOffset={composerStackTopOffset}
       contentWidth={messageWidth}
       focusMessageClientId={focusedMessageTarget?.clientId ?? null}
       focusMessageRequestId={focusedMessageTarget?.requestId ?? 0}

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
@@ -4154,6 +4154,7 @@ export function CCAgentSessionView({
             <div
               className="mx-auto flex flex-col items-center gap-[10px]"
               style={{ width: inputWidth }}
+              data-chat-composer-stack
             >
               {/* FP-7 / F-PERM-2 / F7.4: mutually exclusive prompts.
                  Plan review takes precedence — the SDK won't interleave it with

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
@@ -1155,17 +1155,23 @@ export function CCAgentSessionView({
     setOverlayEl(node);
   }, []);
   const [overlayHeight, setOverlayHeight] = useState(200);
+  const [composerTopOffset, setComposerTopOffset] = useState<number | undefined>(undefined);
 
   useEffect(() => {
     if (!overlayEl) return;
+    const measureOverlay = () => {
+      // 状态行会动态出现 / 收起，overlay 总高度不等于输入框卡片顶边。
+      // 直接量卡片到 overlay 底边的距离，让消息流悬浮按钮不受状态行高度影响。
+      setOverlayHeight(overlayEl.offsetHeight);
+      const composerCard = overlayEl.querySelector<HTMLElement>('[data-chat-input-card]');
+      setComposerTopOffset(
+        composerCard ? overlayEl.getBoundingClientRect().bottom - composerCard.getBoundingClientRect().top : undefined,
+      );
+    };
     // Seed with the current height so the first paint after remount uses the
     // real value (not the stale state from the previous mount).
-    setOverlayHeight(overlayEl.offsetHeight);
-    const ro = new ResizeObserver(() => {
-      // offsetHeight (includes padding) instead of contentRect.height so the
-      // bottom padding fully covers the overlay.
-      setOverlayHeight(overlayEl.offsetHeight);
-    });
+    measureOverlay();
+    const ro = new ResizeObserver(measureOverlay);
     ro.observe(overlayEl);
     return () => ro.disconnect();
   }, [overlayEl]);
@@ -3695,6 +3701,7 @@ export function CCAgentSessionView({
       isLoadingMore={isLoadingMore}
       hasMoreMessages={hasMoreMessages}
       bottomPadding={overlayHeight}
+      composerTopOffset={composerTopOffset}
       contentWidth={messageWidth}
       focusMessageClientId={focusedMessageTarget?.clientId ?? null}
       focusMessageRequestId={focusedMessageTarget?.requestId ?? 0}


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复聊天流底部悬浮按钮在“正在生成”状态行出现或收起时与输入框重叠的问题。现在直接测量输入框卡片顶边，按钮始终与输入框上边缘保持 6px 间距；无法取得测量值时继续使用原有定位逻辑兜底。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：底部跳转按钮与输入框保持稳定间距
- 本 PR 包含：输入框卡片顶边测量、消息流悬浮按钮动态定位、定位函数回归测试
- 明确不包含：输入框样式、正在生成状态行样式、Mobile 端改动
- 用户可见变化：无论“正在生成”状态是否显示，跳到底部按钮都不会进入输入框区域
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：`docs/design-rules/DESIGN.md` §5「Spacing System」允许 6px 间距；§10「Light / Dark Dual-Mode Delivery Gate」要求双模式共用完整状态实现。本次仅调整共享几何定位，不新增颜色或主题分支，Light / Dark 使用同一逻辑。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/renderer/components/chat/__tests__/messageStreamIndicatorPosition.test.ts
结果：通过，2 个测试全部通过

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm test:unit
结果：通过，所有必跑 workspace 均通过

pnpm check:dco
结果：通过，当前 PR 的 1 个 commit 已签名
```

### 手工验证

不涉及：最终提交未在隔离 worktree 中重新启动 Desktop 实例；问题定位来自此前 remote dev 验收反馈。

### 未执行的验证

- 未在 Light / Dark 两种模式下进行最终实机目检；本次不改颜色、主题 token 或组件样式，两种模式共享同一几何定位逻辑。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Desktop 聊天消息流中“新消息”和“跳到底部”悬浮按钮的垂直定位。
- 回滚 / 降级方式：撤销本 PR 的提交即可恢复原有经验值定位。
- 移动端冷更判断：仅修改 Desktop Renderer 的 TypeScript / TSX 文件，不涉及 `apps/mobile` 原生配置、依赖、config plugin 或原生模块，不会改变 mobile runtime fingerprint，不触发冷更。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因