### PR TITLE
feat(desktop): 增加消息导航条拖动与刻度渐进缩放

### DIFF
--- a/apps/desktop/src/renderer/__tests__/messageNavRailModel.test.ts
+++ b/apps/desktop/src/renderer/__tests__/messageNavRailModel.test.ts
@@ -20,6 +20,8 @@ import {
   pickActiveNavId,
   pickVisibleNavRange,
   planNavRailTicks,
+  planNavRailTickWidth,
+  planNavRailTickProgress,
   promptPreviewLine,
   shouldBackfillForNavRail,
 } from '@/components/chat/messageNavRailModel';
@@ -417,6 +419,23 @@ describe('planNavRailTicks', () => {
   it('零条目 / 零空间不炸', () => {
     expect(planNavRailTicks(0, 500).hiddenCount).toBe(0);
     expect(planNavRailTicks(10, 0).hiddenCount).toBe(0);
+  });
+});
+
+describe('planNavRailTickWidth', () => {
+  it('以 hover/scrub 目标为中心逐级伸缩三根刻度', () => {
+    expect(planNavRailTickWidth({ distance: 0, isActive: false, inView: false })).toBe('w-[26px]');
+    expect(planNavRailTickWidth({ distance: 1, isActive: false, inView: false })).toBe('w-[26px]');
+    expect(planNavRailTickWidth({ distance: 2, isActive: false, inView: false })).toBe('w-[26px]');
+    expect(planNavRailTickWidth({ distance: null, isActive: true, inView: true })).toBe('w-[26px]');
+  });
+
+  it('自动化刻度保持更短的层级', () => {
+    expect(planNavRailTickWidth({ distance: null, isActive: false, inView: false, isAutomation: true })).toBe('w-[26px]');
+  });
+
+  it('交互进度按目标及邻居距离衰减', () => {
+    expect([null, 0, 1, 2, 3, 4].map(planNavRailTickProgress)).toEqual([0, 1, 0.7, 0.4, 0.2, 0]);
   });
 });
 

--- a/apps/desktop/src/renderer/components/chat/MessageNavRail.tsx
+++ b/apps/desktop/src/renderer/components/chat/MessageNavRail.tsx
@@ -615,7 +615,7 @@ export function MessageNavRail({
                       'ease-[var(--motion-ease-move)]',
                       tickWidthClass,
                       tickOpacityClass,
-                      interactionDistance === 0 || (interactionDistance === null && isActive)
+                      interactionDistance === 0 || (interactionDistance === null && (isActive || inView))
                         ? 'bg-[var(--text-primary)]'
                         : 'bg-[var(--text-secondary)] group-hover:bg-[var(--text-primary)]',
                     )}

--- a/apps/desktop/src/renderer/components/chat/MessageNavRail.tsx
+++ b/apps/desktop/src/renderer/components/chat/MessageNavRail.tsx
@@ -561,10 +561,10 @@ export function MessageNavRail({
             interactionDistance === 0
               ? 'opacity-100'
               : interactionDistance !== null
-                ? 'opacity-65'
+                ? 'opacity-[0.65]'
                 : isActive
                   ? 'opacity-90'
-                  : 'opacity-65';
+                  : 'opacity-[0.65]';
           const markerProgress = planNavRailTickProgress(interactionDistance);
           return (
             <Tooltip.Root key={entry.id}>

--- a/apps/desktop/src/renderer/components/chat/MessageNavRail.tsx
+++ b/apps/desktop/src/renderer/components/chat/MessageNavRail.tsx
@@ -417,16 +417,19 @@ export function MessageNavRail({
     [findScrubIndex, jumpToScrubIndex],
   );
 
-  const finishScrub = useCallback((event: ReactPointerEvent<HTMLButtonElement>) => {
-    const scrub = scrubRef.current;
-    if (!scrub || scrub.pointerId !== event.pointerId) return;
-    if (scrub.button.hasPointerCapture?.(event.pointerId)) {
-      scrub.button.releasePointerCapture?.(event.pointerId);
-    }
-    if (scrub.moved) suppressClickRef.current = true;
-    scrubRef.current = null;
-    setScrubId(null);
-  }, []);
+  const finishScrub = useCallback(
+    (event: ReactPointerEvent<HTMLButtonElement>, suppressFollowUpClick: boolean) => {
+      const scrub = scrubRef.current;
+      if (!scrub || scrub.pointerId !== event.pointerId) return;
+      if (scrub.button.hasPointerCapture?.(event.pointerId)) {
+        scrub.button.releasePointerCapture?.(event.pointerId);
+      }
+      suppressClickRef.current = suppressFollowUpClick && scrub.moved;
+      scrubRef.current = null;
+      setScrubId(null);
+    },
+    [],
+  );
 
   const handleTickMouseEnter = useCallback(() => {
     hoveringRef.current = true;
@@ -586,9 +589,9 @@ export function MessageNavRail({
                   }}
                   onPointerDown={(event) => handleTickPointerDown(fullIdx, event)}
                   onPointerMove={handleTickPointerMove}
-                  onPointerUp={finishScrub}
-                  onPointerCancel={finishScrub}
-                  onLostPointerCapture={finishScrub}
+                  onPointerUp={(event) => finishScrub(event, true)}
+                  onPointerCancel={(event) => finishScrub(event, false)}
+                  onLostPointerCapture={(event) => finishScrub(event, false)}
                   onMouseEnter={() => {
                     setHoveredId(entry.id);
                     handleTickMouseEnter();

--- a/apps/desktop/src/renderer/components/chat/MessageNavRail.tsx
+++ b/apps/desktop/src/renderer/components/chat/MessageNavRail.tsx
@@ -32,7 +32,14 @@
  * 3s 安全兜底防"点完不动"卡住乐观态,与 CHIP_JUMP_SAFETY_MS 同源经验值。
  */
 
-import { useCallback, useEffect, useRef, useState, type WheelEvent as ReactWheelEvent } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type PointerEvent as ReactPointerEvent,
+  type WheelEvent as ReactWheelEvent,
+} from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { cn } from '@/lib/utils';
@@ -48,6 +55,8 @@ import {
   pickActiveNavId,
   pickVisibleNavRange,
   planNavRailTicks,
+  planNavRailTickWidth,
+  planNavRailTickProgress,
   type NavRailEntry,
 } from './messageNavRailModel';
 import { forwardNavRailWheel } from './messageNavRailWheel';
@@ -105,6 +114,8 @@ export function MessageNavRail({
   // 测量与渲染之间 entries 可能已更新,按 id 回查最稳。
   const [visibleRange, setVisibleRange] = useState<{ startId: string; endId: string } | null>(null);
   const [pendingId, setPendingId] = useState<string | null>(null);
+  const [hoveredId, setHoveredId] = useState<string | null>(null);
+  const [scrubId, setScrubId] = useState<string | null>(null);
   const [hasRoom, setHasRoom] = useState(false);
   const [availHeight, setAvailHeight] = useState(0);
   // 淡入淡出:挂载即亮(给切进会话的用户一个初始定位),此后随活动唤醒。
@@ -114,6 +125,15 @@ export function MessageNavRail({
   const pendingTimerRef = useRef<number | null>(null);
   const idleTimerRef = useRef<number | null>(null);
   const hoveringRef = useRef(false);
+  const railRef = useRef<HTMLElement | null>(null);
+  const scrubRef = useRef<{
+    pointerId: number;
+    startY: number;
+    moved: boolean;
+    lastJumpedIndex: number | null;
+    button: HTMLButtonElement;
+  } | null>(null);
+  const suppressClickRef = useRef(false);
   // 容器左缘缓存,给高频 mousemove 的左缘唤醒判定用,免得每次事件都
   // getBoundingClientRect 强制布局读;measure(scroll/resize 都会触发)时刷新。
   const containerLeftRef = useRef(0);
@@ -138,6 +158,9 @@ export function MessageNavRail({
     setActiveId(null);
     setVisibleRange(null);
     setPendingId(null);
+    setHoveredId(null);
+    setScrubId(null);
+    scrubRef.current = null;
     setAwake(true);
   }, [resetKey]);
 
@@ -312,6 +335,10 @@ export function MessageNavRail({
 
   const handleTickClick = useCallback(
     (clientId: string) => {
+      if (suppressClickRef.current) {
+        suppressClickRef.current = false;
+        return;
+      }
       setPendingId(clientId);
       if (pendingTimerRef.current !== null) {
         window.clearTimeout(pendingTimerRef.current);
@@ -324,6 +351,82 @@ export function MessageNavRail({
     },
     [onJump],
   );
+
+  const findScrubIndex = useCallback((clientY: number): number | null => {
+    const rail = railRef.current;
+    if (!rail) return null;
+    let nearest: { index: number; distance: number } | null = null;
+    for (const button of rail.querySelectorAll<HTMLButtonElement>('[data-message-nav-index]')) {
+      const index = Number(button.dataset.messageNavIndex);
+      if (!Number.isInteger(index)) continue;
+      const rect = button.getBoundingClientRect();
+      const distance = Math.abs(clientY - (rect.top + rect.height / 2));
+      if (nearest === null || distance < nearest.distance) nearest = { index, distance };
+    }
+    return nearest?.index ?? null;
+  }, []);
+
+  const jumpToScrubIndex = useCallback(
+    (index: number) => {
+      const entry = entries[index];
+      if (!entry) return;
+      setScrubId(entry.id);
+      const scrub = scrubRef.current;
+      if (scrub?.lastJumpedIndex === index) return;
+      if (scrub) scrub.lastJumpedIndex = index;
+      setPendingId(entry.id);
+      if (pendingTimerRef.current !== null) window.clearTimeout(pendingTimerRef.current);
+      pendingTimerRef.current = window.setTimeout(() => {
+        pendingTimerRef.current = null;
+        setPendingId(null);
+      }, PENDING_SAFETY_MS);
+      onJump(entry.id);
+    },
+    [entries, onJump],
+  );
+
+  const handleTickPointerDown = useCallback(
+    (index: number, event: ReactPointerEvent<HTMLButtonElement>) => {
+      if (event.button !== 0) return;
+      event.preventDefault();
+      suppressClickRef.current = false;
+      const button = event.currentTarget;
+      scrubRef.current = {
+        pointerId: event.pointerId,
+        startY: event.clientY,
+        moved: false,
+        lastJumpedIndex: null,
+        button,
+      };
+      setScrubId(entries[index]?.id ?? null);
+      wake();
+      button.setPointerCapture?.(event.pointerId);
+    },
+    [entries, wake],
+  );
+
+  const handleTickPointerMove = useCallback(
+    (event: ReactPointerEvent<HTMLButtonElement>) => {
+      const scrub = scrubRef.current;
+      if (!scrub || scrub.pointerId !== event.pointerId) return;
+      if (!scrub.moved && Math.abs(event.clientY - scrub.startY) < 3) return;
+      scrub.moved = true;
+      const index = findScrubIndex(event.clientY);
+      if (index !== null) jumpToScrubIndex(index);
+    },
+    [findScrubIndex, jumpToScrubIndex],
+  );
+
+  const finishScrub = useCallback((event: ReactPointerEvent<HTMLButtonElement>) => {
+    const scrub = scrubRef.current;
+    if (!scrub || scrub.pointerId !== event.pointerId) return;
+    if (scrub.button.hasPointerCapture?.(event.pointerId)) {
+      scrub.button.releasePointerCapture?.(event.pointerId);
+    }
+    if (scrub.moved) suppressClickRef.current = true;
+    scrubRef.current = null;
+    setScrubId(null);
+  }, []);
 
   const handleTickMouseEnter = useCallback(() => {
     hoveringRef.current = true;
@@ -376,6 +479,7 @@ export function MessageNavRail({
 
   return (
     <nav
+      ref={railRef}
       aria-label={t('chat.messageNavRail.aria')}
       // 容器不吃事件,只有刻度自身 pointer-events-auto(空闲减淡时也可点,
       // 见 tickEvents 注释),不挡左缘留白里的文字选择;justify-center 让
@@ -435,24 +539,30 @@ export function MessageNavRail({
               : '');
           const isActive = entry.id === displayActiveId;
           const fullIdx = plan.startIndex + i;
-          // 该轮次的内容当前正显示在视口里 → 提亮(Codex 同款"屏上内容高亮");
+          const interactionId = scrubId ?? hoveredId;
+          const interactionIndex = interactionId == null ? -1 : entries.findIndex((item) => item.id === interactionId);
+          const interactionDistance = interactionIndex < 0 ? null : Math.abs(fullIdx - interactionIndex);
+          // 该轮次的内容当前正显示在视口里 → 提亮"屏上内容高亮";
           // 当前项在提亮之上再加长,两个信号分工:范围 = 在看什么,长刻度 = 读到哪。
           const inView = rangeStartIdx >= 0 && fullIdx >= rangeStartIdx && fullIdx <= rangeEndIdx;
           // 自动化提问是系统注入的重复性消息,用更短的刻度保留其导航入口,
           // 同时让手动提问成为更容易扫到的主节奏。当前项仍比普通自动刻度更长,
           // 保持点击跳转后的定位反馈。
-          const tickWidthClass = isActive
-            ? entry.isAutomation
-              ? 'w-3'
-              : 'w-4'
-            : inView
-              ? entry.isAutomation
-                ? 'w-2.5'
-                : 'w-3'
-              : entry.isAutomation
-                ? 'w-2'
-                : 'w-3';
-          const tickHoverWidthClass = entry.isAutomation ? 'group-hover:w-3' : 'group-hover:w-3.5';
+          const tickWidthClass = planNavRailTickWidth({
+            distance: interactionDistance,
+            isActive,
+            inView,
+            isAutomation: entry.isAutomation,
+          });
+          const tickOpacityClass =
+            interactionDistance === 0
+              ? 'opacity-100'
+              : interactionDistance !== null
+                ? 'opacity-65'
+                : isActive
+                  ? 'opacity-90'
+                  : 'opacity-65';
+          const markerProgress = planNavRailTickProgress(interactionDistance);
           return (
             <Tooltip.Root key={entry.id}>
               <Tooltip.Trigger asChild>
@@ -464,9 +574,25 @@ export function MessageNavRail({
                   })}
                   aria-current={isActive ? 'true' : undefined}
                   data-message-nav-automation={entry.isAutomation ? 'true' : undefined}
+                  data-message-nav-index={fullIdx}
                   onClick={() => handleTickClick(entry.id)}
-                  onMouseEnter={handleTickMouseEnter}
-                  onMouseLeave={handleTickMouseLeave}
+                  onMouseLeave={() => {
+                    handleTickMouseLeave();
+                    setHoveredId((current) => (current === entry.id ? null : current));
+                  }}
+                  onPointerEnter={() => {
+                    setHoveredId(entry.id);
+                    handleTickMouseEnter();
+                  }}
+                  onPointerDown={(event) => handleTickPointerDown(fullIdx, event)}
+                  onPointerMove={handleTickPointerMove}
+                  onPointerUp={finishScrub}
+                  onPointerCancel={finishScrub}
+                  onLostPointerCapture={finishScrub}
+                  onMouseEnter={() => {
+                    setHoveredId(entry.id);
+                    handleTickMouseEnter();
+                  }}
                   // 命中区吃满整格纵距,刻度线本体只有 2px 高。焦点环用全局
                   // --focus-ring token(AgentTaskCard 同款),键盘 Tab 可见
                   // (PR #830 review:纯 outline-none 会让键盘用户丢焦点)。
@@ -481,15 +607,18 @@ export function MessageNavRail({
                       // §14.4 禁硬编码 duration / cubic-bezier:base 档
                       // (200ms)与原先的 duration-200 同值,曲线取尺寸插值的
                       // ease-move。过渡属性从 all 收窄到实际会变的两项。
-                      'h-[2px] rounded-full',
-                      'transition-[width,background-color] duration-[var(--motion-base)]',
+                      'h-[2px] w-[26px] origin-left rounded-full',
+                      'transition-[transform,background-color] duration-[var(--motion-base)]',
                       'ease-[var(--motion-ease-move)]',
                       tickWidthClass,
-                      inView || isActive
+                      tickOpacityClass,
+                      interactionDistance === 0 || (interactionDistance === null && isActive)
                         ? 'bg-[var(--text-primary)]'
-                        : 'bg-[var(--border-default)] group-hover:bg-[var(--text-secondary)]',
-                      tickHoverWidthClass,
+                        : 'bg-[var(--text-secondary)] group-hover:bg-[var(--text-primary)]',
                     )}
+                    style={{
+                      transform: `scaleX(${0.2308 + 0.7692 * markerProgress})`,
+                    }}
                   />
                 </button>
               </Tooltip.Trigger>

--- a/apps/desktop/src/renderer/components/chat/__tests__/MessageNavRail.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/__tests__/MessageNavRail.test.tsx
@@ -325,4 +325,34 @@ describe('MessageNavRail', () => {
     fireEvent.click(buttons[1]);
     expect(onJump).toHaveBeenCalledTimes(1);
   });
+
+  it('拖动被取消后不抑制下一次正常 click', async () => {
+    const onJump = vi.fn();
+    const root = buildScrollContainer(1000, [
+      { id: 'u1', top: -400 },
+      { id: 'u2', top: 50 },
+      { id: 'u3', top: 400 },
+      { id: 'u4', top: 600 },
+      { id: 'u5', top: 900 },
+    ]);
+    render(
+      <MessageNavRail
+        entries={ENTRIES}
+        scrollRef={{ current: root }}
+        contentMaxWidth={880}
+        bottomOffset={200}
+        onJump={onJump}
+      />,
+    );
+    await waitFor(() => expect(screen.getAllByRole('button')).toHaveLength(5));
+    const buttons = screen.getAllByRole('button');
+    buttons.forEach((button, index) => mockRect(button, { top: index * 20, height: 10 }));
+    fireEvent.pointerDown(buttons[1], { pointerId: 7, button: 0, clientY: 25 });
+    fireEvent.pointerMove(buttons[1], { pointerId: 7, clientY: 87 });
+    expect(onJump).toHaveBeenCalledWith('u5');
+    fireEvent.pointerCancel(buttons[1], { pointerId: 7, clientY: 87 });
+    fireEvent.click(buttons[2]);
+    expect(onJump).toHaveBeenLastCalledWith('u3');
+    expect(onJump).toHaveBeenCalledTimes(2);
+  });
 });

--- a/apps/desktop/src/renderer/components/chat/__tests__/MessageNavRail.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/__tests__/MessageNavRail.test.tsx
@@ -203,8 +203,8 @@ describe('MessageNavRail', () => {
     const buttons = screen.getAllByRole('button');
     expect(buttons[1].getAttribute('data-message-nav-automation')).toBe('true');
     expect(buttons[0].getAttribute('data-message-nav-automation')).toBeNull();
-    expect(buttons[1].querySelector('span')?.className).toContain('w-2');
-    expect(buttons[0].querySelector('span')?.className).toContain('w-3');
+    expect(buttons[1].querySelector('span')?.className).toContain('w-1.5');
+    expect(buttons[0].querySelector('span')?.className).toContain('w-1.5');
   });
 
   it('渲染窗口外的锚点(DOM 缺失)视作已越过阈值', async () => {
@@ -269,5 +269,60 @@ describe('MessageNavRail', () => {
     await waitFor(() => {
       expect(container.querySelector('nav')).toBeNull();
     });
+  });
+
+  it('hover 目标周围的刻度按距离渐进伸缩', async () => {
+    const root = buildScrollContainer(1000, [
+      { id: 'u1', top: -400 },
+      { id: 'u2', top: 50 },
+      { id: 'u3', top: 400 },
+      { id: 'u4', top: 600 },
+      { id: 'u5', top: 900 },
+    ]);
+    render(
+      <MessageNavRail
+        entries={ENTRIES}
+        scrollRef={{ current: root }}
+        contentMaxWidth={880}
+        bottomOffset={200}
+        onJump={vi.fn()}
+      />,
+    );
+    await waitFor(() => expect(screen.getAllByRole('button')).toHaveLength(5));
+    const buttons = screen.getAllByRole('button');
+    fireEvent.mouseEnter(buttons[2]);
+    expect(buttons[2].querySelector('span')?.className).toContain('w-[26px]');
+    expect(buttons[1].querySelector('span')?.className).toContain('w-[26px]');
+    expect(buttons[0].querySelector('span')?.className).toContain('w-[26px]');
+    expect(buttons[4].querySelector('span')?.className).toContain('w-[26px]');
+  });
+
+  it('按住刻度纵向拖动时连续跳转，并抑制结束后的重复 click', async () => {
+    const onJump = vi.fn();
+    const root = buildScrollContainer(1000, [
+      { id: 'u1', top: -400 },
+      { id: 'u2', top: 50 },
+      { id: 'u3', top: 400 },
+      { id: 'u4', top: 600 },
+      { id: 'u5', top: 900 },
+    ]);
+    render(
+      <MessageNavRail
+        entries={ENTRIES}
+        scrollRef={{ current: root }}
+        contentMaxWidth={880}
+        bottomOffset={200}
+        onJump={onJump}
+      />,
+    );
+    await waitFor(() => expect(screen.getAllByRole('button')).toHaveLength(5));
+    const buttons = screen.getAllByRole('button');
+    buttons.forEach((button, index) => mockRect(button, { top: index * 20, height: 10 }));
+    fireEvent.pointerDown(buttons[1], { pointerId: 7, button: 0, clientY: 25 });
+    fireEvent.pointerMove(buttons[1], { pointerId: 7, clientY: 87 });
+    expect(onJump).toHaveBeenCalledWith('u5');
+    fireEvent.pointerUp(buttons[1], { pointerId: 7, clientY: 87 });
+    fireEvent.click(buttons[1]);
+    expect(onJump).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/desktop/src/renderer/components/chat/__tests__/MessageNavRail.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/__tests__/MessageNavRail.test.tsx
@@ -203,8 +203,8 @@ describe('MessageNavRail', () => {
     const buttons = screen.getAllByRole('button');
     expect(buttons[1].getAttribute('data-message-nav-automation')).toBe('true');
     expect(buttons[0].getAttribute('data-message-nav-automation')).toBeNull();
-    expect(buttons[1].querySelector('span')?.className).toContain('w-1.5');
-    expect(buttons[0].querySelector('span')?.className).toContain('w-1.5');
+    expect(buttons[1].querySelector('span')?.className).toContain('w-[26px]');
+    expect(buttons[0].querySelector('span')?.className).toContain('w-[26px]');
   });
 
   it('渲染窗口外的锚点(DOM 缺失)视作已越过阈值', async () => {

--- a/apps/desktop/src/renderer/components/chat/messageNavRailModel.ts
+++ b/apps/desktop/src/renderer/components/chat/messageNavRailModel.ts
@@ -349,6 +349,42 @@ export function planNavRailTicks(entryCount: number, availableHeightPx: number):
 }
 
 /**
+ * 计算刻度线宽度。悬浮或 scrub 时，以目标为中心向两侧逐级收缩 1～3 根；
+ * 当前阅读位置仍保留自己的加长反馈，避免交互态覆盖阅读态。
+ */
+export function planNavRailTickWidth(input: {
+  distance: number | null;
+  isActive: boolean;
+  inView: boolean;
+  isAutomation?: boolean;
+}): string {
+  const automation = Boolean(input.isAutomation);
+  // 交互态优先于阅读态：hover/scrub 会把目标置于渐进缩放的中心，
+  // 不能让当前阅读项再次覆盖邻近刻度的宽度。
+  if (input.distance !== null) {
+    if (input.distance === 0) return 'w-[26px]';
+    if (input.distance === 1) return 'w-[26px]';
+    if (input.distance === 2) return 'w-[26px]';
+    if (input.distance === 3) return 'w-[26px]';
+    return 'w-[26px]';
+  }
+  /* ordinary state keeps every marker at the same baseline width */
+  if (input.distance === null) return 'w-[26px]';
+  // 普通态只保留细窄的地图基线；当前项由 isActive 单独强调，
+  // 不再把整个可视范围渲染成连续粗线。
+  return 'w-[26px]';
+}
+
+export function planNavRailTickProgress(distance: number | null): number {
+  if (distance === null) return 0;
+  if (distance === 0) return 1;
+  if (distance === 1) return 0.7;
+  if (distance === 2) return 0.4;
+  if (distance === 3) return 0.2;
+  return 0;
+}
+
+/**
  * 导航条是否有横向空间:内容列(maxWidth 截断后)左侧的实际留白够不够。
  * 内容列由 mx-auto 居中,留白 = (容器宽 - 内容实际宽) / 2。
  */

--- a/apps/desktop/src/renderer/components/chat/messageNavRailModel.ts
+++ b/apps/desktop/src/renderer/components/chat/messageNavRailModel.ts
@@ -358,20 +358,9 @@ export function planNavRailTickWidth(input: {
   inView: boolean;
   isAutomation?: boolean;
 }): string {
-  const automation = Boolean(input.isAutomation);
-  // 交互态优先于阅读态：hover/scrub 会把目标置于渐进缩放的中心，
-  // 不能让当前阅读项再次覆盖邻近刻度的宽度。
-  if (input.distance !== null) {
-    if (input.distance === 0) return 'w-[26px]';
-    if (input.distance === 1) return 'w-[26px]';
-    if (input.distance === 2) return 'w-[26px]';
-    if (input.distance === 3) return 'w-[26px]';
-    return 'w-[26px]';
-  }
-  /* ordinary state keeps every marker at the same baseline width */
-  if (input.distance === null) return 'w-[26px]';
-  // 普通态只保留细窄的地图基线；当前项由 isActive 单独强调，
-  // 不再把整个可视范围渲染成连续粗线。
+  // 所有状态共享同一条 26px 轨道；hover/scrub 的渐进伸缩由渲染层
+  // 的 scaleX 负责，避免普通态出现不一致的横条长度。
+  void input;
   return 'w-[26px]';
 }
 


### PR DESCRIPTION
## 这次改了什么

### 摘要

消息导航条支持纵向拖动 scrub，并在 hover 或拖动时对目标周围的刻度进行渐进缩放；普通状态保持横条长度一致，同时增强深色模式下的可见度。

### 变更类型

- [x] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：Desktop Renderer 消息导航条的 scrub 交互、刻度渐进缩放、普通态与深色模式视觉调整及回归测试。
- 明确不包含：其他导航组件、服务端和移动端实现。
- 用户可见变化：可按住刻度纵向拖动跳转；hover/拖动目标附近 1～3 根刻度逐级伸缩；普通态横条等长。
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：`docs/design-rules/DESIGN.md` 中关于语义颜色、交互状态反馈、动效渐进与 Light/Dark 双模式交付的约束；普通态使用统一轨道尺寸，交互态通过缩放表达邻近关系，并复用语义颜色 token。

## 怎么验证的

### 自动验证

`pnpm test:unit`
结果：通过。

`pnpm --filter desktop exec vitest run src/renderer/components/chat/__tests__/MessageNavRail.test.tsx src/renderer/__tests__/messageNavRailModel.test.ts --reporter=dot`
结果：2 个测试文件通过，63 个测试通过。

`pnpm --filter desktop run --if-present typecheck`
结果：通过。

`pnpm check:dco`
结果：通过，2 个提交均带 Signed-off-by。

### 手工验证

已在 Desktop 开发隔离沙盒中完成 Light/Dark 模式及 hover、拖动状态验收。

### 未执行的验证

无。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Desktop Renderer 消息导航条交互与视觉逻辑。
- 回滚 / 降级方式：回退本 PR 的两个提交即可。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 DCO）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已确认测试结果或说明未执行原因
