### PR TITLE
fix(desktop): 标题 one-shot 关闭网关思考模型

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/titleOneShot.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/titleOneShot.test.ts
@@ -731,7 +731,11 @@ describe('generateTitleViaProvider — xd(网关 chat-completions)', () => {
       ];
       expect(url).toBe(`${XD_GATEWAY_BASE_URL}/v1/chat/completions`);
       expect(init.headers.authorization).toBe('Bearer gk-1');
-      expect(JSON.parse(init.body).model).toBe('deepseek/deepseek-v4-flash');
+      expect(JSON.parse(init.body)).toMatchObject({
+        model: 'deepseek/deepseek-v4-flash',
+        max_tokens: 32,
+        thinking: { type: 'disabled' },
+      });
     } finally {
       setXdGatewayModels([]);
     }

--- a/apps/desktop/src/main/maker-host/title-one-shot.ts
+++ b/apps/desktop/src/main/maker-host/title-one-shot.ts
@@ -59,6 +59,12 @@ const log = createLogger('maker-host:title-one-shot');
 const TITLE_TIMEOUT_MS = 12_000;
 /** 标题 ≤ 20 字,32 token 足够;codex Responses 协议层不暴露 max_tokens,仅对 messages/chat 生效。 */
 const TITLE_MAX_TOKENS = 32;
+/**
+ * XD 网关思考模型(Hy3 / DeepSeek 等)默认会先写 reasoning_content。
+ * 标题只要短正文;不关思考时 32 token 会全部烧掉,content 仍是空串。
+ * 网关认 OpenAI 兼容的 thinking.type=disabled;官方 no_think / enable_thinking=false 无效。
+ */
+const TITLE_GATEWAY_THINKING = { type: 'disabled' } as const;
 /** 异常响应保护:完整模型输出超过此 Unicode 长度就拒绝,再按历史契约截到 40 字。 */
 const TITLE_OUTPUT_MAX_CHARS = 256;
 /**
@@ -346,6 +352,7 @@ async function fetchGatewayTitle(
     body: JSON.stringify({
       model: modelId,
       max_tokens: TITLE_MAX_TOKENS,
+      thinking: TITLE_GATEWAY_THINKING,
       messages: [{ role: 'user', content: prompt }],
     }),
   });


### PR DESCRIPTION
## 这次改了什么

### 摘要

XD 网关最便宜的 chat 模型（`tencent/hy3`、`deepseek/deepseek-v4-flash`）默认先写 `reasoning_content`。标题 one-shot 只认 `message.content`，`max_tokens=32` 会被思维链吃光，自动起名和手动 AI 重命名一起失败。

网关请求现在带 `thinking: { type: "disabled" }`，让标题直接出短正文。官方 `no_think` / `enable_thinking=false` 在这条网关上无效；加大 `max_tokens` 也救不了（1024 仍全进思维链）。`max_tokens` 保持 32。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：标题 gateway-chat 请求关闭思考；单测锁定请求体
- 明确不包含：换标题模型、加大 `max_tokens`、改自动起名占位逻辑
- 用户可见变化：走 XD 网关时，新建任务的智能标题和侧栏 AI 重命名应能再次成功，不再停在原话截断或报「AI 起名失败」
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
cd /Users/dash/Code/Cindy/cindy-title-disable-thinking
pnpm --filter desktop exec vitest run \
  src/main/maker-host/__tests__/titleOneShot.test.ts \
  src/main/maker-ipc/__tests__/autoTitleIpcBoundary.test.ts \
  src/main/maker-ipc/__tests__/regenerateSessionTitle.test.ts
结果：3 files / 103 tests passed

pnpm --filter desktop run --if-present typecheck
结果：通过

bash /Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh \
  /Users/dash/Code/Cindy/cindy-title-disable-thinking
结果：packages/maker-core 的 pi-rpc-resource-discovery.integration.test.ts 失败 3 条
      （显式 project skill 的 scope 期望 project，实际 temporary）
      干净 origin/main（4e5a34e21）同样 3 条失败，与本 diff 无关，交给 CI 兜底
```

### 手工验证

对 XD 网关 `tencent/hy3` 用同一条起名 prompt 实测：

- 现网请求：`content=""`，32 token 全是 `reasoning_tokens`，`finish_reason=length`
- 加 `thinking: { type: "disabled" }`：`content="查询AI重命名失败原因"`，7 token，约 2 秒
- `deepseek/deepseek-v4-flash` 同样：默认空正文；关思考后得到 `AI重命名失败原因排查`

未在安装版 Cindy 里点侧栏 Magic 重命名做端到端回归。

### 未执行的验证

安装版 Cindy 的侧栏 AI 重命名 / 新建任务智能标题端到端未在本分支构建后点过。mobile 不涉及。

## 风险

### 风险分类

- [x] 其他：网关若拒收未知 `thinking` 字段，标题 one-shot 会回落启发式（新建任务停在原话截断；手动 AI 重命名仍会失败）。实测当前 XD 网关接受该字段。

### 影响与回滚

- 影响范围：仅 desktop 标题 one-shot 的 XD 网关 chat-completions 请求体
- 回滚 / 降级方式：revert 本 commit

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
