### PR TITLE
fix(desktop): 已有任务换模后下次新建仍跟随这次选择

### DIFF
--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -235,7 +235,7 @@ export function App() {
           const shouldPatchActiveModel = markModelChoice !== false || effort !== undefined;
           if (shouldPatchActiveModel) {
             patch(vendor, {
-              model: modelId,
+              ...(markModelChoice === false ? {} : { model: modelId }),
               providerId: providerId || null,
               ...(effort !== undefined ? { effort: effort as Effort } : {}),
             });

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -235,7 +235,11 @@ export function App() {
           const shouldPatchActiveModel = markModelChoice !== false || effort !== undefined;
           if (shouldPatchActiveModel) {
             patch(vendor, {
-              ...(markModelChoice === false ? {} : { model: modelId }),
+              // markModelChoice=false 仍要写回当前活动模型:远程新建草稿
+              // pushActiveDraftPref、以及旧控制端换模都走这条 wire。丢掉 model
+              // 会让被控端 lastByVendor 停在旧模型。选模标记由 store 的
+              // preserving 路径单独守住,这里只负责同步当前活动值。
+              model: modelId,
               providerId: providerId || null,
               ...(effort !== undefined ? { effort: effort as Effort } : {}),
             });

--- a/apps/desktop/src/renderer/__tests__/deviceLinkInteractionScenarios.test.ts
+++ b/apps/desktop/src/renderer/__tests__/deviceLinkInteractionScenarios.test.ts
@@ -967,6 +967,7 @@ describe('远程交互接线不变式', () => {
     expect(syncBody).toContain(".invoke(remoteDeviceId, 'maker:apply-new-maker-draft-pref'");
 
     expect(chatInputSrc).toContain('markModelChoice: true');
+    expect(chatInputSrc).toContain('agentKind: targetAgentKind');
 
     const appSrc = read('App.tsx');
     expect(appSrc).toContain(

--- a/apps/desktop/src/renderer/__tests__/deviceLinkInteractionScenarios.test.ts
+++ b/apps/desktop/src/renderer/__tests__/deviceLinkInteractionScenarios.test.ts
@@ -972,6 +972,8 @@ describe('远程交互接线不变式', () => {
     expect(appSrc).toContain(
       'markModelChoice === false ? patchVendorPrefsPreservingModelChoice : patchVendorPrefs',
     );
+    expect(appSrc).toContain('model: modelId');
+    expect(appSrc).not.toContain("markModelChoice === false ? {} : { model: modelId }");
 
     const newMakerDraftRouteSrc = read('features/cc-agent/NewMakerDraftRoute.tsx');
     const pushActiveStart = newMakerDraftRouteSrc.indexOf('const pushActiveDraftPref');

--- a/apps/desktop/src/renderer/__tests__/deviceLinkInteractionScenarios.test.ts
+++ b/apps/desktop/src/renderer/__tests__/deviceLinkInteractionScenarios.test.ts
@@ -963,7 +963,7 @@ describe('远程交互接线不变式', () => {
     expect(syncBody).toContain("opts.markModelChoice === true");
     expect(syncBody).toContain('markModelChoice');
     expect(syncBody).toContain('{ model: modelId, providerId: activeProviderId ?? null }');
-    expect(syncBody).toContain(': { model: modelId }');
+    expect(syncBody).not.toContain(': { model: modelId }');
     expect(syncBody).toContain(
       'opts.remoteDeviceId ?? getSessionDeviceId(sessionId) ?? deviceLinkDeviceId',
     );

--- a/apps/desktop/src/renderer/__tests__/deviceLinkInteractionScenarios.test.ts
+++ b/apps/desktop/src/renderer/__tests__/deviceLinkInteractionScenarios.test.ts
@@ -963,6 +963,7 @@ describe('远程交互接线不变式', () => {
     expect(syncBody).toContain("opts.markModelChoice === true");
     expect(syncBody).toContain('markModelChoice');
     expect(syncBody).toContain('{ model: modelId, providerId: activeProviderId ?? null }');
+    expect(syncBody).toContain(': { model: modelId }');
     expect(syncBody).toContain(
       'opts.remoteDeviceId ?? getSessionDeviceId(sessionId) ?? deviceLinkDeviceId',
     );
@@ -982,6 +983,8 @@ describe('远程交互接线不变式', () => {
     expect(draftSrc).toContain('if (!opts.markModelChoice && modelChosen[vendor] === true)');
     expect(draftSrc).toContain('delete nextPatch.model');
     expect(draftSrc).toContain('delete nextPatch.providerId');
+    expect(draftSrc).toContain('if (incomingModel !== savedModel)');
+    expect(draftSrc).toContain('delete nextPatch.effort');
 
     const newMakerDraftRouteSrc = read('features/cc-agent/NewMakerDraftRoute.tsx');
     const pushActiveStart = newMakerDraftRouteSrc.indexOf('const pushActiveDraftPref');

--- a/apps/desktop/src/renderer/__tests__/deviceLinkInteractionScenarios.test.ts
+++ b/apps/desktop/src/renderer/__tests__/deviceLinkInteractionScenarios.test.ts
@@ -961,6 +961,8 @@ describe('远程交互接线不变式', () => {
     expect(syncBody).toContain('patchVendorPrefsPreservingModelChoice');
     expect(syncBody).toContain('markModelChoice ? patchVendorPrefs : patchVendorPrefsPreservingModelChoice');
     expect(syncBody).toContain("opts.markModelChoice === true");
+    expect(syncBody).toContain('markModelChoice');
+    expect(syncBody).toContain('{ model: modelId, providerId: activeProviderId ?? null }');
     expect(syncBody).toContain(
       'opts.remoteDeviceId ?? getSessionDeviceId(sessionId) ?? deviceLinkDeviceId',
     );
@@ -975,6 +977,11 @@ describe('远程交互接线不变式', () => {
     );
     expect(appSrc).toContain('model: modelId');
     expect(appSrc).not.toContain("markModelChoice === false ? {} : { model: modelId }");
+
+    const draftSrc = read('state/newMakerDraft.ts');
+    expect(draftSrc).toContain('if (!opts.markModelChoice && modelChosen[vendor] === true)');
+    expect(draftSrc).toContain('delete nextPatch.model');
+    expect(draftSrc).toContain('delete nextPatch.providerId');
 
     const newMakerDraftRouteSrc = read('features/cc-agent/NewMakerDraftRoute.tsx');
     const pushActiveStart = newMakerDraftRouteSrc.indexOf('const pushActiveDraftPref');

--- a/apps/desktop/src/renderer/__tests__/deviceLinkInteractionScenarios.test.ts
+++ b/apps/desktop/src/renderer/__tests__/deviceLinkInteractionScenarios.test.ts
@@ -951,7 +951,7 @@ describe('远程交互接线不变式', () => {
     expect(finalize).toBeGreaterThan(sync);
   });
 
-  it('会话同步 New Maker 草稿默认不应打 modelChosenByVendor 显式选择标记', () => {
+  it('已有任务换模会打选模标记,只改思考档 / Fast 不会', () => {
     const chatInputSrc = read('components/new-chat/ChatInput.tsx');
     const syncStart = chatInputSrc.indexOf('const syncSessionDraftModelPrefs');
     const syncEnd = chatInputSrc.indexOf('const persistFastModeChange', syncStart);
@@ -959,12 +959,14 @@ describe('远程交互接线不变式', () => {
     expect(syncEnd).toBeGreaterThan(syncStart);
     const syncBody = chatInputSrc.slice(syncStart, syncEnd);
     expect(syncBody).toContain('patchVendorPrefsPreservingModelChoice');
-    expect(syncBody).toContain('markModelChoice: false');
+    expect(syncBody).toContain('markModelChoice ? patchVendorPrefs : patchVendorPrefsPreservingModelChoice');
+    expect(syncBody).toContain("opts.markModelChoice === true");
     expect(syncBody).toContain(
       'opts.remoteDeviceId ?? getSessionDeviceId(sessionId) ?? deviceLinkDeviceId',
     );
     expect(syncBody).toContain(".invoke(remoteDeviceId, 'maker:apply-new-maker-draft-pref'");
-    expect(syncBody).not.toContain('patchVendorPrefs(vendor');
+
+    expect(chatInputSrc).toContain('markModelChoice: true');
 
     const appSrc = read('App.tsx');
     expect(appSrc).toContain(

--- a/apps/desktop/src/renderer/__tests__/newMakerDraft.test.ts
+++ b/apps/desktop/src/renderer/__tests__/newMakerDraft.test.ts
@@ -372,6 +372,7 @@ describe('newMakerDraft store', () => {
     expect(m1.getPersistedVendorModel('cc')).toBe('claude-sonnet-4-6');
 
     m1.patchVendorPrefsPreservingModelChoice('cc', {
+      model: 'claude-sonnet-4-6',
       effort: 'high',
     });
 
@@ -391,7 +392,7 @@ describe('newMakerDraft store', () => {
     expect(m1.getDraft().modelChosenByVendor).toEqual({});
     expect(m1.getPersistedVendorModel('cc')).toBe('');
 
-    m1.patchVendorPrefs('cc', { model: 'claude-sonnet-4-6' });
+    m1.patchVendorPrefs('cc', { model: 'claude-sonnet-4-6', effort: 'medium' });
     expect(m1.getDraft().modelChosenByVendor).toEqual({ cc: true });
 
     m1.patchVendorPrefsPreservingModelChoice('cc', {
@@ -401,9 +402,22 @@ describe('newMakerDraft store', () => {
     });
     expect(m1.getDraft().lastByVendor.cc.model).toBe('claude-sonnet-4-6');
     expect(m1.getDraft().lastByVendor.cc.providerId).toBeNull();
-    expect(m1.getDraft().lastByVendor.cc.effort).toBe('high');
+    expect(m1.getDraft().lastByVendor.cc.effort).toBe('medium');
     expect(m1.getDraft().modelChosenByVendor).toEqual({ cc: true });
     expect(m1.getPersistedVendorModel('cc')).toBe('claude-sonnet-4-6');
+  });
+
+  it('patchVendorPrefsPreservingModelChoice:已打标且活动模型一致时才更新思考档', async () => {
+    const m1 = await loadModule();
+    m1.patchVendorPrefs('cc', { model: 'claude-sonnet-4-6', effort: 'medium' });
+
+    m1.patchVendorPrefsPreservingModelChoice('cc', {
+      model: 'claude-sonnet-4-6',
+      effort: 'high',
+    });
+    expect(m1.getDraft().lastByVendor.cc.model).toBe('claude-sonnet-4-6');
+    expect(m1.getDraft().lastByVendor.cc.effort).toBe('high');
+    expect(m1.getDraft().modelChosenByVendor).toEqual({ cc: true });
   });
 
   it('patchVendorPrefsPreservingModelChoice:未打标时仍可写回活动模型与来源', async () => {

--- a/apps/desktop/src/renderer/__tests__/newMakerDraft.test.ts
+++ b/apps/desktop/src/renderer/__tests__/newMakerDraft.test.ts
@@ -381,6 +381,28 @@ describe('newMakerDraft store', () => {
     expect(m1.getPersistedVendorModel('cc')).toBe('claude-sonnet-4-6');
   });
 
+  it('patchVendorPrefsPreservingModelChoice:可写回活动模型但不打标也不清标', async () => {
+    const m1 = await loadModule();
+    m1.patchVendorPrefsPreservingModelChoice('cc', {
+      model: 'claude-opus-4-8',
+      effort: 'high',
+    });
+    expect(m1.getDraft().lastByVendor.cc.model).toBe('claude-opus-4-8');
+    expect(m1.getDraft().modelChosenByVendor).toEqual({});
+    expect(m1.getPersistedVendorModel('cc')).toBe('');
+
+    m1.patchVendorPrefs('cc', { model: 'claude-sonnet-4-6' });
+    expect(m1.getDraft().modelChosenByVendor).toEqual({ cc: true });
+
+    m1.patchVendorPrefsPreservingModelChoice('cc', {
+      model: 'claude-opus-4-8',
+      effort: 'high',
+    });
+    expect(m1.getDraft().lastByVendor.cc.model).toBe('claude-opus-4-8');
+    expect(m1.getDraft().modelChosenByVendor).toEqual({ cc: true });
+    expect(m1.getPersistedVendorModel('cc')).toBe('claude-opus-4-8');
+  });
+
   it('已有任务换模走 patchVendorPrefs,下次新建跟随这次选择', async () => {
     const m1 = await loadModule();
     m1.patchVendorPrefs('cc', { model: 'claude-sonnet-4-6' });

--- a/apps/desktop/src/renderer/__tests__/newMakerDraft.test.ts
+++ b/apps/desktop/src/renderer/__tests__/newMakerDraft.test.ts
@@ -420,6 +420,20 @@ describe('newMakerDraft store', () => {
     expect(m1.getDraft().modelChosenByVendor).toEqual({ cc: true });
   });
 
+  it('patchVendorPrefsPreservingModelChoice:未打标且不带 model 时不得改活动模型', async () => {
+    const m1 = await loadModule();
+    const seedModel = m1.getDraft().lastByVendor.cc.model;
+
+    m1.patchVendorPrefsPreservingModelChoice('cc', {
+      effort: 'high',
+    });
+
+    expect(m1.getDraft().lastByVendor.cc.model).toBe(seedModel);
+    expect(m1.getDraft().lastByVendor.cc.effort).toBe('high');
+    expect(m1.getDraft().modelChosenByVendor).toEqual({});
+    expect(m1.getPersistedVendorModel('cc')).toBe('');
+  });
+
   it('patchVendorPrefsPreservingModelChoice:未打标时仍可写回活动模型与来源', async () => {
     const m1 = await loadModule();
     m1.patchVendorPrefsPreservingModelChoice('cc', {

--- a/apps/desktop/src/renderer/__tests__/newMakerDraft.test.ts
+++ b/apps/desktop/src/renderer/__tests__/newMakerDraft.test.ts
@@ -396,11 +396,28 @@ describe('newMakerDraft store', () => {
 
     m1.patchVendorPrefsPreservingModelChoice('cc', {
       model: 'claude-opus-4-8',
+      providerId: 'anthropic',
+      effort: 'high',
+    });
+    expect(m1.getDraft().lastByVendor.cc.model).toBe('claude-sonnet-4-6');
+    expect(m1.getDraft().lastByVendor.cc.providerId).toBeNull();
+    expect(m1.getDraft().lastByVendor.cc.effort).toBe('high');
+    expect(m1.getDraft().modelChosenByVendor).toEqual({ cc: true });
+    expect(m1.getPersistedVendorModel('cc')).toBe('claude-sonnet-4-6');
+  });
+
+  it('patchVendorPrefsPreservingModelChoice:未打标时仍可写回活动模型与来源', async () => {
+    const m1 = await loadModule();
+    m1.patchVendorPrefsPreservingModelChoice('cc', {
+      model: 'claude-opus-4-8',
+      providerId: 'anthropic',
       effort: 'high',
     });
     expect(m1.getDraft().lastByVendor.cc.model).toBe('claude-opus-4-8');
-    expect(m1.getDraft().modelChosenByVendor).toEqual({ cc: true });
-    expect(m1.getPersistedVendorModel('cc')).toBe('claude-opus-4-8');
+    expect(m1.getDraft().lastByVendor.cc.providerId).toBe('anthropic');
+    expect(m1.getDraft().lastByVendor.cc.effort).toBe('high');
+    expect(m1.getDraft().modelChosenByVendor).toEqual({});
+    expect(m1.getPersistedVendorModel('cc')).toBe('');
   });
 
   it('已有任务换模走 patchVendorPrefs,下次新建跟随这次选择', async () => {

--- a/apps/desktop/src/renderer/__tests__/newMakerDraft.test.ts
+++ b/apps/desktop/src/renderer/__tests__/newMakerDraft.test.ts
@@ -412,7 +412,6 @@ describe('newMakerDraft store', () => {
     m1.patchVendorPrefs('cc', { model: 'claude-sonnet-4-6', effort: 'medium' });
 
     m1.patchVendorPrefsPreservingModelChoice('cc', {
-      model: 'claude-sonnet-4-6',
       effort: 'high',
     });
     expect(m1.getDraft().lastByVendor.cc.model).toBe('claude-sonnet-4-6');

--- a/apps/desktop/src/renderer/__tests__/newMakerDraft.test.ts
+++ b/apps/desktop/src/renderer/__tests__/newMakerDraft.test.ts
@@ -350,14 +350,12 @@ describe('newMakerDraft store', () => {
     expect(m2.getPersistedVendorModel('cc')).toBe('claude-opus-4-8');
   });
 
-  it('patchVendorPrefsPreservingModelChoice:会话同步草稿默认不打显式选择标记', async () => {
+  it('patchVendorPrefsPreservingModelChoice:只改思考档不打显式选择标记', async () => {
     const m1 = await loadModule();
     m1.patchVendorPrefsPreservingModelChoice('cc', {
-      model: 'claude-opus-4-8',
       effort: 'high',
     });
 
-    expect(m1.getDraft().lastByVendor.cc.model).toBe('claude-opus-4-8');
     expect(m1.getDraft().lastByVendor.cc.effort).toBe('high');
     expect(m1.getDraft().modelChosenByVendor).toEqual({});
     expect(m1.getPersistedVendorModel('cc')).toBe('');
@@ -367,31 +365,26 @@ describe('newMakerDraft store', () => {
     expect(m1.getPersistedVendorModel('cc')).toBe('claude-opus-4-8');
   });
 
-  it('patchVendorPrefsPreservingModelChoice:会话同步 model 会清掉旧显式选模标记', async () => {
+  it('patchVendorPrefsPreservingModelChoice:已有任务换模后只改思考档不得清掉选模标记', async () => {
     const m1 = await loadModule();
     m1.patchVendorPrefs('cc', { model: 'claude-sonnet-4-6' });
     expect(m1.getDraft().modelChosenByVendor).toEqual({ cc: true });
     expect(m1.getPersistedVendorModel('cc')).toBe('claude-sonnet-4-6');
 
     m1.patchVendorPrefsPreservingModelChoice('cc', {
-      model: 'claude-opus-4-8',
       effort: 'high',
     });
 
-    expect(m1.getDraft().lastByVendor.cc.model).toBe('claude-opus-4-8');
-    expect(m1.getDraft().modelChosenByVendor).toEqual({});
-    expect(m1.getPersistedVendorModel('cc')).toBe('');
+    expect(m1.getDraft().lastByVendor.cc.model).toBe('claude-sonnet-4-6');
+    expect(m1.getDraft().lastByVendor.cc.effort).toBe('high');
+    expect(m1.getDraft().modelChosenByVendor).toEqual({ cc: true });
+    expect(m1.getPersistedVendorModel('cc')).toBe('claude-sonnet-4-6');
   });
 
-  it('patchVendorPrefsPreservingModelChoice:会话同步同一 model 保留旧显式选模标记', async () => {
+  it('已有任务换模走 patchVendorPrefs,下次新建跟随这次选择', async () => {
     const m1 = await loadModule();
-    m1.patchVendorPrefs('cc', { model: 'claude-opus-4-8' });
-    expect(m1.getDraft().modelChosenByVendor).toEqual({ cc: true });
-
-    m1.patchVendorPrefsPreservingModelChoice('cc', {
-      model: 'claude-opus-4-8',
-      effort: 'high',
-    });
+    m1.patchVendorPrefs('cc', { model: 'claude-sonnet-4-6' });
+    m1.patchVendorPrefs('cc', { model: 'claude-opus-4-8', effort: 'high' });
 
     expect(m1.getDraft().lastByVendor.cc.model).toBe('claude-opus-4-8');
     expect(m1.getDraft().lastByVendor.cc.effort).toBe('high');

--- a/apps/desktop/src/renderer/__tests__/scheduleDefaultModel.test.ts
+++ b/apps/desktop/src/renderer/__tests__/scheduleDefaultModel.test.ts
@@ -114,40 +114,37 @@ describe('getScheduleDefaultModel 三级回退', () => {
     expect(getScheduleDefaultModel('claude-code')).toBe('claude-sonnet-4-6');
   });
 
-  it('三级:已有会话同步 New Maker 草稿默认不打显式选择标记 → 调度仍走 Sonnet 兜底', async () => {
+  it('三级:已有任务只改思考档不打显式选择标记 → 调度仍走 Sonnet 兜底', async () => {
     const draft = await import('@/state/newMakerDraft');
     draft.patchVendorPrefsPreservingModelChoice('cc', {
-      model: 'claude-opus-4-8',
       effort: 'high',
     });
     const { getScheduleDefaultModel } = await loadModule();
-    expect(draft.getDraft().lastByVendor.cc.model).toBe('claude-opus-4-8');
     expect(draft.getPersistedVendorModel('cc')).toBe('');
     expect(getScheduleDefaultModel('claude-code')).toBe('claude-sonnet-4-6');
   });
 
-  it('三级:旧 New Maker 显式选模被会话同步覆盖后不污染调度默认模型', async () => {
+  it('三级:已有任务换模后调度跟随这次选择', async () => {
     const draft = await import('@/state/newMakerDraft');
     draft.patchVendorPrefs('cc', { model: 'claude-opus-4-8' });
     expect(draft.getPersistedVendorModel('cc')).toBe('claude-opus-4-8');
 
-    draft.patchVendorPrefsPreservingModelChoice('cc', {
+    draft.patchVendorPrefs('cc', {
       model: 'claude-sonnet-4-7',
       effort: 'high',
     });
 
     const { getScheduleDefaultModel } = await loadModule();
     expect(draft.getDraft().lastByVendor.cc.model).toBe('claude-sonnet-4-7');
-    expect(draft.getPersistedVendorModel('cc')).toBe('');
-    expect(getScheduleDefaultModel('claude-code')).toBe('claude-sonnet-4-6');
+    expect(draft.getPersistedVendorModel('cc')).toBe('claude-sonnet-4-7');
+    expect(getScheduleDefaultModel('claude-code')).toBe('claude-sonnet-4-7');
   });
 
-  it('三级:旧 New Maker 显式选模被同 model 会话同步更新后仍作为调度默认模型', async () => {
+  it('三级:旧显式选模后只改思考档,调度仍用原来的模型', async () => {
     const draft = await import('@/state/newMakerDraft');
     draft.patchVendorPrefs('cc', { model: 'claude-opus-4-8' });
 
     draft.patchVendorPrefsPreservingModelChoice('cc', {
-      model: 'claude-opus-4-8',
       effort: 'high',
     });
 

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -5206,11 +5206,11 @@ export function ChatInput({
               : 'cc';
         const persistPrefs = markModelChoice ? patchVendorPrefs : patchVendorPrefsPreservingModelChoice;
         persistPrefs(vendor, {
-          // 换模才带配对并打标记。只改思考档时仍带当前 model,让 store
-          // 判断是否与已保存模型一致;不一致则丢掉这次 effort。
+          // 换模才带配对并打标记。本机只改思考档 / Fast 不写回活动模型,
+          // 避免未打标用户把区域默认改成当前任务模型。
           ...(markModelChoice
             ? { model: modelId, providerId: activeProviderId ?? null }
-            : { model: modelId }),
+            : {}),
           ...(patch.effort !== undefined ? { effort: patch.effort } : {}),
         });
         if (memoryProviderId) {

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -5206,10 +5206,11 @@ export function ChatInput({
               : 'cc';
         const persistPrefs = markModelChoice ? patchVendorPrefs : patchVendorPrefsPreservingModelChoice;
         persistPrefs(vendor, {
-          // 只改思考档 / Fast 不得改写下次新建用的模型或来源;换模才带配对并打标记。
+          // 换模才带配对并打标记。只改思考档时仍带当前 model,让 store
+          // 判断是否与已保存模型一致;不一致则丢掉这次 effort。
           ...(markModelChoice
             ? { model: modelId, providerId: activeProviderId ?? null }
-            : {}),
+            : { model: modelId }),
           ...(patch.effort !== undefined ? { effort: patch.effort } : {}),
         });
         if (memoryProviderId) {

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -5182,11 +5182,14 @@ export function ChatInput({
         activeProviderId?: string | null;
         memoryProviderId?: string | null;
         remoteDeviceId?: string;
+        /** 跨引擎换模时写目标 Agent 的草稿槽,缺省用当前任务引擎。 */
+        agentKind?: AgentKind;
         /** 已有任务里换模 / 换来源时为 true,下次新建跟随这次选择。只改思考档 / Fast 保持 false。 */
         markModelChoice?: boolean;
       } = {},
     ) => {
-      if (!sessionId || !currentModelAgentKind || !modelId) return;
+      const agentKind = opts.agentKind ?? currentModelAgentKind;
+      if (!sessionId || !agentKind || !modelId) return;
       const activeProviderId =
         opts.activeProviderId !== undefined ? opts.activeProviderId : selectedProviderId;
       const memoryProviderId =
@@ -5196,9 +5199,9 @@ export function ChatInput({
       const markModelChoice = opts.markModelChoice === true;
       if (!remoteDeviceId) {
         const vendor =
-          currentModelAgentKind === 'codex'
+          agentKind === 'codex'
             ? 'codex'
-            : currentModelAgentKind === 'pi'
+            : agentKind === 'pi'
               ? 'pi'
               : 'cc';
         const persistPrefs = markModelChoice ? patchVendorPrefs : patchVendorPrefsPreservingModelChoice;
@@ -5210,10 +5213,10 @@ export function ChatInput({
         });
         if (memoryProviderId) {
           if (patch.effort !== undefined) {
-            setProviderModelChoice(currentModelAgentKind, memoryProviderId, modelId, patch.effort);
+            setProviderModelChoice(agentKind, memoryProviderId, modelId, patch.effort);
           }
           if (patch.fast !== undefined) {
-            setProviderModelFast(currentModelAgentKind, memoryProviderId, modelId, patch.fast);
+            setProviderModelFast(agentKind, memoryProviderId, modelId, patch.fast);
           }
         }
         if (patch.effort !== undefined) setEffortForModel(modelId, patch.effort);
@@ -5223,7 +5226,7 @@ export function ChatInput({
       window.electronAPI.deviceLink
         .invoke(remoteDeviceId, 'maker:apply-new-maker-draft-pref', [
           {
-            agent: currentModelAgentKind,
+            agent: agentKind,
             providerId: activeProviderId ?? '',
             modelId,
             active: true,
@@ -5522,6 +5525,19 @@ export function ChatInput({
             effort: newEffort,
             fastMode: targetFast,
           });
+          // 跨引擎点选也是用户显式选模:记到目标 vendor,下次用该引擎新建跟随这次选择。
+          // 真切换可能推迟到下一条消息,但选择已经做出。
+          syncSessionDraftModelPrefs(
+            newModelId,
+            { effort: newEffort, fast: targetFast },
+            {
+              activeProviderId: providerId,
+              memoryProviderId: providerId,
+              remoteDeviceId: deviceLinkDeviceId,
+              agentKind: targetAgentKind,
+              markModelChoice: true,
+            },
+          );
           if (makerChatStore.getSnapshot(sourceSessionId).agentStatus.isRunning) {
             toast.success(
               t('newChat.chatInput.agentSwitch.deferred', {
@@ -5560,6 +5576,17 @@ export function ChatInput({
         }
         // 立即切换路径(harness / registry 缺省兜底,生产不走):维持旧收敛语义。
         makerChatStore.noteAgentSwitched(sourceSessionId, targetAgentKind);
+        syncSessionDraftModelPrefs(
+          newModelId,
+          { effort: newEffort, fast: targetFast },
+          {
+            activeProviderId: providerId,
+            memoryProviderId: providerId,
+            remoteDeviceId: deviceLinkDeviceId,
+            agentKind: targetAgentKind,
+            markModelChoice: true,
+          },
+        );
         if (!result.engineReady) {
           toast.error(t('newChat.chatInput.agentSwitch.engineNotReady'), { duration: 4000 });
         }
@@ -5585,6 +5612,8 @@ export function ChatInput({
       localProviders.providers,
       ccCaps.capabilities,
       codexCaps.capabilities,
+      piCaps.capabilities,
+      syncSessionDraftModelPrefs,
     ],
   );
   // 声明顺序在 performAgentSwitch 之前的 handler(handleFastModeChange)经此 ref

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -296,6 +296,7 @@ import {
 } from '@/state/providerModelMemory';
 import {
   getDraft,
+  patchVendorPrefs,
   patchVendorPrefsPreservingModelChoice,
   setEffortForModel,
   setFastModeForModel,
@@ -5181,6 +5182,8 @@ export function ChatInput({
         activeProviderId?: string | null;
         memoryProviderId?: string | null;
         remoteDeviceId?: string;
+        /** 已有任务里换模 / 换来源时为 true,下次新建跟随这次选择。只改思考档 / Fast 保持 false。 */
+        markModelChoice?: boolean;
       } = {},
     ) => {
       if (!sessionId || !currentModelAgentKind || !modelId) return;
@@ -5190,6 +5193,7 @@ export function ChatInput({
         opts.memoryProviderId !== undefined ? opts.memoryProviderId : effectiveSourceId;
       const remoteDeviceId =
         opts.remoteDeviceId ?? getSessionDeviceId(sessionId) ?? deviceLinkDeviceId;
+      const markModelChoice = opts.markModelChoice === true;
       if (!remoteDeviceId) {
         const vendor =
           currentModelAgentKind === 'codex'
@@ -5197,8 +5201,10 @@ export function ChatInput({
             : currentModelAgentKind === 'pi'
               ? 'pi'
               : 'cc';
-        patchVendorPrefsPreservingModelChoice(vendor, {
-          model: modelId,
+        const persistPrefs = markModelChoice ? patchVendorPrefs : patchVendorPrefsPreservingModelChoice;
+        persistPrefs(vendor, {
+          // 只改思考档 / Fast 不得改写下次新建用的模型;换模才带 model 并打标记。
+          ...(markModelChoice ? { model: modelId } : {}),
           providerId: activeProviderId ?? null,
           ...(patch.effort !== undefined ? { effort: patch.effort } : {}),
         });
@@ -5221,7 +5227,7 @@ export function ChatInput({
             providerId: activeProviderId ?? '',
             modelId,
             active: true,
-            markModelChoice: false,
+            markModelChoice,
             ...(patch.effort !== undefined ? { effort: patch.effort } : {}),
             ...(patch.fast !== undefined ? { fast: patch.fast } : {}),
           },
@@ -5700,7 +5706,7 @@ export function ChatInput({
             syncSessionDraftModelPrefs(
               newModelId,
               { effort: newEffort, fast: fastPersisted ? restoredFast : fastMode },
-              { remoteDeviceId: sourceRemoteDeviceId },
+              { remoteDeviceId: sourceRemoteDeviceId, markModelChoice: true },
             );
             if (remoteDeferred && isSourceSessionCurrent()) {
               toast.success(t('newChat.chatInput.credentialSwitchDeferred'), { duration: 4000 });
@@ -5734,7 +5740,9 @@ export function ChatInput({
               // 默认 success 1200ms 读不完这句;拉长到 4s。
               toast.success(t('newChat.chatInput.credentialSwitchDeferred'), { duration: 4000 });
             }
-            syncSessionDraftModelPrefs(newModelId, { effort: newEffort, fast: restoredFast });
+            syncSessionDraftModelPrefs(newModelId, { effort: newEffort, fast: restoredFast }, {
+              markModelChoice: true,
+            });
             if (currentModelAgentKind && effectiveSourceId) {
               modelMemory?.setFast(
                 currentModelAgentKind,
@@ -6104,6 +6112,7 @@ export function ChatInput({
             activeProviderId: newProviderId,
             memoryProviderId: newProviderId,
             remoteDeviceId: sourceRemoteDeviceId,
+            markModelChoice: true,
           },
         );
         onModelDidChange?.(targetModel);
@@ -6161,7 +6170,11 @@ export function ChatInput({
           syncSessionDraftModelPrefs(
             modelId,
             { effort: eff, fast: restoredFast },
-            { activeProviderId: newProviderId, memoryProviderId: newProviderId },
+            {
+              activeProviderId: newProviderId,
+              memoryProviderId: newProviderId,
+              markModelChoice: true,
+            },
           );
           if (currentModelAgentKind && newProviderId) {
             modelMemory?.setFast(currentModelAgentKind, newProviderId, modelId, restoredFast);

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -5206,9 +5206,10 @@ export function ChatInput({
               : 'cc';
         const persistPrefs = markModelChoice ? patchVendorPrefs : patchVendorPrefsPreservingModelChoice;
         persistPrefs(vendor, {
-          // 只改思考档 / Fast 不得改写下次新建用的模型;换模才带 model 并打标记。
-          ...(markModelChoice ? { model: modelId } : {}),
-          providerId: activeProviderId ?? null,
+          // 只改思考档 / Fast 不得改写下次新建用的模型或来源;换模才带配对并打标记。
+          ...(markModelChoice
+            ? { model: modelId, providerId: activeProviderId ?? null }
+            : {}),
           ...(patch.effort !== undefined ? { effort: patch.effort } : {}),
         });
         if (memoryProviderId) {

--- a/apps/desktop/src/renderer/state/newMakerDraft.ts
+++ b/apps/desktop/src/renderer/state/newMakerDraft.ts
@@ -754,9 +754,9 @@ function patchVendorPrefsInternal(
     const incomingModel =
       typeof nextPatch.model === 'string' && nextPatch.model.length > 0
         ? nextPatch.model
-        : undefined;
-    // 已显式选过时,只改思考档 / Fast / 远程档位同步不得替换那次选择的
-    // 模型、来源或思考档。活动任务模型与已保存模型一致时,才允许更新 effort。
+        : savedModel;
+    // 已显式选过时,不得替换那次选择的模型或来源。没带 model 视为仍在已保存
+    // 模型上改档;带了不同 model 则丢掉这次 effort,避免 A/B 错配。
     delete nextPatch.model;
     delete nextPatch.providerId;
     if (incomingModel !== savedModel) {

--- a/apps/desktop/src/renderer/state/newMakerDraft.ts
+++ b/apps/desktop/src/renderer/state/newMakerDraft.ts
@@ -151,7 +151,7 @@ export interface NewMakerDraft {
    * vendor,否则全新 / 没用过该 vendor 的用户会被对话侧 Opus 种子默认顶掉
    * 成本保守兜底。patchVendorPrefs 收到显式 model 时置 true;只改思考档 / Fast
    * 的会话回写走 patchVendorPrefsPreservingModelChoice：不得打标、不得清标，
-   * 也不得在已打标后改写 lastByVendor.model / providerId。
+   * 也不得在已打标后改写 lastByVendor.model / providerId / effort。
    */
   modelChosenByVendor: Partial<Record<MakerVendor, boolean>>;
 }
@@ -750,9 +750,18 @@ function patchVendorPrefsInternal(
     // 会带 modelId),但不得打标,也不得清掉已有标记。
   }
   if (!opts.markModelChoice && modelChosen[vendor] === true) {
-    // 已显式选过时,只改思考档 / Fast / 远程档位同步不得替换那次选择的模型或来源。
+    const savedModel = currentDraft.lastByVendor[vendor].model;
+    const incomingModel =
+      typeof nextPatch.model === 'string' && nextPatch.model.length > 0
+        ? nextPatch.model
+        : undefined;
+    // 已显式选过时,只改思考档 / Fast / 远程档位同步不得替换那次选择的
+    // 模型、来源或思考档。活动任务模型与已保存模型一致时,才允许更新 effort。
     delete nextPatch.model;
     delete nextPatch.providerId;
+    if (incomingModel !== savedModel) {
+      delete nextPatch.effort;
+    }
   }
   currentDraft = {
     ...currentDraft,
@@ -772,9 +781,10 @@ export function patchVendorPrefs(vendor: MakerVendor, patch: Partial<VendorPrefs
 
 /**
  * 已创建任务把思考档、以及 wire 上的当前活动模型同步回新建草稿时使用。
- * 未打标时可以更新 lastByVendor.model / providerId,方便远程草稿 / 旧控制端
- * 把活动值写回,但不把这次当成显式选模。已打标后只接受思考档等非选模字段,
- * 不得替换那次选择的模型或来源。本机已有任务里换模型应走 patchVendorPrefs。
+ * 未打标时可以更新 lastByVendor.model / providerId / effort,方便远程草稿 /
+ * 旧控制端把活动值写回,但不把这次当成显式选模。已打标后不得替换那次选择的
+ * 模型、来源或思考档;只有活动模型与已保存模型一致时才更新 effort。
+ * 本机已有任务里换模型应走 patchVendorPrefs。
  */
 export function patchVendorPrefsPreservingModelChoice(
   vendor: MakerVendor,

--- a/apps/desktop/src/renderer/state/newMakerDraft.ts
+++ b/apps/desktop/src/renderer/state/newMakerDraft.ts
@@ -744,9 +744,8 @@ function patchVendorPrefsInternal(
       // 新建页 picker 或已有任务换模 → 打标记,下次新建跟随这次选择,不再回落区域默认。
       modelChosen[vendor] = true;
     }
-    // markModelChoice=false 只回写思考档 / 来源等非选模字段。即便 patch 里带着
-    // 当前任务的 model id,也不得把已有标记清掉,否则已有任务里随手换模 / 改档
-    // 会让下次新建重新落到服务端区域默认。
+    // markModelChoice=false 仍可写回当前活动模型(远程草稿 / 旧控制端 wire
+    // 会带 modelId),但不得打标,也不得清掉已有标记。
   }
   currentDraft = {
     ...currentDraft,
@@ -765,10 +764,10 @@ export function patchVendorPrefs(vendor: MakerVendor, patch: Partial<VendorPrefs
 }
 
 /**
- * 已创建任务把思考档等非选模偏好同步回新建草稿时使用。
- * 更新 lastByVendor,但不把 modelChosenByVendor 打成「显式选过模型」:
- * 只改思考档不能把区域默认升级成用户选择,也不得清掉已有的选模标记。
- * 已有任务里换模型应走 patchVendorPrefs,让下次新建跟随这次选择。
+ * 已创建任务把思考档、以及 wire 上的当前活动模型同步回新建草稿时使用。
+ * 可以更新 lastByVendor.model,但不把 modelChosenByVendor 打成「显式选过」:
+ * 只改思考档 / 远程草稿回写不能把区域默认升级成用户选择,也不得清掉已有标记。
+ * 本机已有任务里换模型应走 patchVendorPrefs,让下次新建跟随这次选择。
  */
 export function patchVendorPrefsPreservingModelChoice(
   vendor: MakerVendor,

--- a/apps/desktop/src/renderer/state/newMakerDraft.ts
+++ b/apps/desktop/src/renderer/state/newMakerDraft.ts
@@ -144,13 +144,13 @@ export interface NewMakerDraft {
   /** 每个 vendor 的"上次使用配置"——切回该 vendor 时自动恢复。 */
   lastByVendor: Record<MakerVendor, VendorPrefs>;
   /**
-   * 用户是否在 New Maker 界面**显式**选过该 vendor 的模型。
+   * 用户是否**显式**选过该 vendor 的模型（新建页 picker，或已有任务里换模）。
    * lastByVendor 整个快照随任意 draft 写入落盘,model 即使从没被用户碰过也会带上
    * sanitize 的种子默认值 —— 仅凭 lastByVendor 无法区分"真选过"和"默认回填"。
    * 调度任务默认模型的三级回退(getPersistedVendorModel 消费)只认这里标记过的
    * vendor,否则全新 / 没用过该 vendor 的用户会被对话侧 Opus 种子默认顶掉
-   * 成本保守兜底。patchVendorPrefs 收到 New Maker 显式 model 时置 true;会话同步 model
-   * 覆盖 lastByVendor 时清掉,避免把会话侧模型误当成 New Maker picker 选择。
+   * 成本保守兜底。patchVendorPrefs 收到显式 model 时置 true;只改思考档 / Fast
+   * 的会话回写走 patchVendorPrefsPreservingModelChoice，不得清掉已有标记。
    */
   modelChosenByVendor: Partial<Record<MakerVendor, boolean>>;
 }
@@ -741,19 +741,12 @@ function patchVendorPrefsInternal(
   const modelChosen = { ...currentDraft.modelChosenByVendor };
   if (typeof patch.model === 'string' && patch.model.length > 0) {
     if (opts.markModelChoice) {
-      // New Maker 显式 model 选择 → 打标记(见 modelChosenByVendor 注释)。
+      // 新建页 picker 或已有任务换模 → 打标记,下次新建跟随这次选择,不再回落区域默认。
       modelChosen[vendor] = true;
-    } else if (
-      currentDraft.modelChosenByVendor[vendor] &&
-      currentDraft.lastByVendor[vendor].model === patch.model
-    ) {
-      // 会话同步的是同一个 model:保留原 New Maker picker 选择语义。
-      modelChosen[vendor] = true;
-    } else {
-      // 会话同步 model 会覆盖 lastByVendor[vendor].model。若 model 发生变化,旧标记已不能继续代表
-      // "New Maker picker 选过这个 model",否则 scheduler 会把会话侧模型误当成显式选择。
-      delete modelChosen[vendor];
     }
+    // markModelChoice=false 只回写思考档 / 来源等非选模字段。即便 patch 里带着
+    // 当前任务的 model id,也不得把已有标记清掉,否则已有任务里随手换模 / 改档
+    // 会让下次新建重新落到服务端区域默认。
   }
   currentDraft = {
     ...currentDraft,
@@ -772,9 +765,10 @@ export function patchVendorPrefs(vendor: MakerVendor, patch: Partial<VendorPrefs
 }
 
 /**
- * 已创建会话把最近一次成功应用的模型偏好同步回 New Maker 草稿默认时使用。
- * 这会更新 lastByVendor 供下一次新建聊天复用,但不把 modelChosenByVendor 打成
- * "用户在 New Maker 显式选过模型",避免影响 scheduler 的成本保守默认模型兜底。
+ * 已创建任务把思考档等非选模偏好同步回新建草稿时使用。
+ * 更新 lastByVendor,但不把 modelChosenByVendor 打成「显式选过模型」:
+ * 只改思考档不能把区域默认升级成用户选择,也不得清掉已有的选模标记。
+ * 已有任务里换模型应走 patchVendorPrefs,让下次新建跟随这次选择。
  */
 export function patchVendorPrefsPreservingModelChoice(
   vendor: MakerVendor,
@@ -859,11 +853,11 @@ export function getCurrentVendorPrefs(): VendorPrefs {
  * 与 getDraft().lastByVendor[v].model 的区别:后者永远非空 —— sanitize 会用
  * getDefaultModelForVendor 兜底填充,且 lastByVendor 整个快照随任意 draft 写入
  * 落盘,即使用户从没碰过该 vendor 的模型,持久化里也躺着种子默认值。
- * 所以这里要求 modelChosenByVendor[vendor] === true(只在 patchVendorPrefs
- * 收到显式 model 时打的标)才返回,否则一律 ''。
+ * 所以这里要求 modelChosenByVendor[vendor] === true(新建页 picker 或已有
+ * 任务换模经 patchVendorPrefs 打的标)才返回,否则一律 ''。
  * 调度任务的默认模型三级回退(useScheduleForm getScheduleDefaultModel)依赖这个
  * 区分:没显式选过的用户应落到调度自己的成本保守兜底(Sonnet),而不是被
- * 对话侧的 Opus 默认顶掉。读 raw localStorage 而非 getDraft(),解析失败 → ''。
+ * 对话侧的 Opus 种子默认顶掉。读 raw localStorage 而非 getDraft(),解析失败 → ''。
  */
 export function getPersistedVendorModel(vendor: MakerVendor): string {
   if (typeof window === 'undefined') return '';

--- a/apps/desktop/src/renderer/state/newMakerDraft.ts
+++ b/apps/desktop/src/renderer/state/newMakerDraft.ts
@@ -150,7 +150,8 @@ export interface NewMakerDraft {
    * 调度任务默认模型的三级回退(getPersistedVendorModel 消费)只认这里标记过的
    * vendor,否则全新 / 没用过该 vendor 的用户会被对话侧 Opus 种子默认顶掉
    * 成本保守兜底。patchVendorPrefs 收到显式 model 时置 true;只改思考档 / Fast
-   * 的会话回写走 patchVendorPrefsPreservingModelChoice，不得清掉已有标记。
+   * 的会话回写走 patchVendorPrefsPreservingModelChoice：不得打标、不得清标，
+   * 也不得在已打标后改写 lastByVendor.model / providerId。
    */
   modelChosenByVendor: Partial<Record<MakerVendor, boolean>>;
 }
@@ -739,7 +740,8 @@ function patchVendorPrefsInternal(
   opts: { markModelChoice: boolean },
 ): void {
   const modelChosen = { ...currentDraft.modelChosenByVendor };
-  if (typeof patch.model === 'string' && patch.model.length > 0) {
+  const nextPatch = { ...patch };
+  if (typeof nextPatch.model === 'string' && nextPatch.model.length > 0) {
     if (opts.markModelChoice) {
       // 新建页 picker 或已有任务换模 → 打标记,下次新建跟随这次选择,不再回落区域默认。
       modelChosen[vendor] = true;
@@ -747,12 +749,17 @@ function patchVendorPrefsInternal(
     // markModelChoice=false 仍可写回当前活动模型(远程草稿 / 旧控制端 wire
     // 会带 modelId),但不得打标,也不得清掉已有标记。
   }
+  if (!opts.markModelChoice && modelChosen[vendor] === true) {
+    // 已显式选过时,只改思考档 / Fast / 远程档位同步不得替换那次选择的模型或来源。
+    delete nextPatch.model;
+    delete nextPatch.providerId;
+  }
   currentDraft = {
     ...currentDraft,
     modelChosenByVendor: modelChosen,
     lastByVendor: {
       ...currentDraft.lastByVendor,
-      [vendor]: { ...currentDraft.lastByVendor[vendor], ...patch },
+      [vendor]: { ...currentDraft.lastByVendor[vendor], ...nextPatch },
     },
   };
   scheduleWrite();
@@ -765,9 +772,9 @@ export function patchVendorPrefs(vendor: MakerVendor, patch: Partial<VendorPrefs
 
 /**
  * 已创建任务把思考档、以及 wire 上的当前活动模型同步回新建草稿时使用。
- * 可以更新 lastByVendor.model,但不把 modelChosenByVendor 打成「显式选过」:
- * 只改思考档 / 远程草稿回写不能把区域默认升级成用户选择,也不得清掉已有标记。
- * 本机已有任务里换模型应走 patchVendorPrefs,让下次新建跟随这次选择。
+ * 未打标时可以更新 lastByVendor.model / providerId,方便远程草稿 / 旧控制端
+ * 把活动值写回,但不把这次当成显式选模。已打标后只接受思考档等非选模字段,
+ * 不得替换那次选择的模型或来源。本机已有任务里换模型应走 patchVendorPrefs。
  */
 export function patchVendorPrefsPreservingModelChoice(
   vendor: MakerVendor,


### PR DESCRIPTION
## 这次改了什么

### 摘要

已有任务里换模型，以前会回写新建草稿，却把「我选过模型」这个标记清掉。下次新建就会重新落到区域默认（CN 现在是 DeepSeek）。

这次改成：已有任务里换模型或换来源，记成下次新建的选择；只改思考档或 Fast，不改下次新建用的模型，也不清已有标记。从没选过模型的新用户仍走区域默认。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：
  - 已有任务换模 / 换来源时打上显式选模标记，下次新建跟随这次选择
  - 只改思考档 / Fast 不再回写模型 id，也不清已有标记
  - 已显式选过后，档位同步不得替换那次选择的模型、来源或思考档
  - 同步更新相关单测
- 明确不包含：
  - 不改服务端区域默认（CN 仍可把 DeepSeek 标成新用户默认）
  - 不改从未选过模型的新用户回落逻辑
  - 不新增 device-link 字段来区分旧控制端换模与纯档位同步
- 用户可见变化：已有任务里换过模型后，再点新建，会继续用刚才选的模型，而不是回到区域默认
- 是否存在 breaking change：无

### 多端形态

- SSH 远程工作区：有理由不涉及。这次只改本机新建草稿记忆和已有任务换模回写，不碰 workdir / agent 进程 / 远程文件通道。
- 设备互联远程控制：本 PR 已一并适配。继续使用既有 `maker:apply-new-maker-draft-pref`；换模打标，档位同步不打标。未打标时仍可写回活动模型，兼容旧控制端；已打标后不再被档位同步改掉。没有改 allowlist，也没有改重试 / 超时 / 断链恢复。
- 手机版：有理由不涉及独立 UI。手机作为控制端复用同一条 device-link 偏好通道，不需要单独入口。

### UI 变化

- 引用的设计规范：不涉及：只改新建草稿的模型记忆，没有视觉、交互或文案变化。

## 怎么验证的

### 自动验证

```text
cd /Users/dash/Code/Cindy/cindy-preserve-new-task-model-choice
pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --filter desktop exec vitest run \
  src/renderer/__tests__/newMakerDraft.test.ts \
  src/renderer/__tests__/scheduleDefaultModel.test.ts \
  src/renderer/__tests__/deviceLinkInteractionScenarios.test.ts
结果：3 files / 120 tests 通过

pnpm check:dco
结果：commits signed off
```

### 手工验证

未在运行中的 Cindy 里点选验证。改动在独立 worktree，当前宿主不会热更到这次代码。

### 未执行的验证

实机：新建页选模型 → 进已有任务换另一个模型 → 再新建，确认仍是刚才那个模型。只改思考档后再新建，确认模型不变。

## 风险

### 风险分类

- [x] 协议兼容
- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop 新建任务默认模型记忆；调度任务默认模型会跟随「已有任务里换过的模型」。device-link 继续用既有 payload，不新增字段。
- 回滚 / 降级方式：回退本 PR 即可。旧控制端换模仍走 `markModelChoice: false` 写回活动模型；已打标后的档位同步不会覆盖那次选择。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
