### PR TITLE
fix(desktop): 展示模型的全部隐藏 Agent

### DIFF
--- a/apps/desktop/src/renderer/__tests__/unifiedModelList.test.ts
+++ b/apps/desktop/src/renderer/__tests__/unifiedModelList.test.ts
@@ -10,6 +10,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import {
   buildUnionRows,
   countModelsByAgent,
+  getHiddenAgents,
   isCapabilityRow,
   isRowDisabled,
   isRowDiverged,
@@ -121,6 +122,24 @@ describe('isRowDiverged', () => {
     const ccOnly = rows[1];
     setModelVisibility('claude-code', 'p1', 'cc-only', false);
     expect(isRowDiverged('p1', ccOnly)).toBe(false);
+  });
+
+  it('三 Agent 中两端隐藏时保留全部隐藏 Agent', () => {
+    const threeAgent = {
+      ...provider,
+      agents: ['claude-code', 'codex', 'pi'],
+      models: {
+        ...provider.models,
+        pi: [model('shared', 500_000)],
+      },
+    } as ProviderView;
+    const shared = buildUnionRows(threeAgent)[0];
+
+    setModelVisibility('claude-code', 'p1', 'shared', false);
+    setModelVisibility('codex', 'p1', 'shared', false);
+
+    expect(isRowDiverged('p1', shared)).toBe(true);
+    expect(getHiddenAgents('p1', shared)).toEqual(['claude-code', 'codex']);
   });
 });
 

--- a/apps/desktop/src/renderer/components/settings/UnifiedModelList.tsx
+++ b/apps/desktop/src/renderer/components/settings/UnifiedModelList.tsx
@@ -713,6 +713,12 @@ export function UnifiedModelList({
                         .join(' · ')
                     : undefined;
                   const hiddenAgents = diverged ? getHiddenAgents(provider.id, row) : [];
+                  const divergedChipLabel =
+                    hiddenAgents.length > 0
+                      ? t('settings.providers.models.divergedChip', {
+                          agent: hiddenAgents.map((agent) => AGENT_LABEL[agent]).join(' / '),
+                        })
+                      : '';
                   return (
                     <div
                       key={row.id}
@@ -746,15 +752,14 @@ export function UnifiedModelList({
                         <button
                           type="button"
                           onClick={() => setSplitMode(true)}
-                          className="flex h-[18px] shrink-0 items-center rounded-full px-2 text-11 font-medium transition-opacity hover:opacity-80"
+                          className="flex h-[18px] min-w-0 max-w-32 items-center rounded-full px-2 text-11 font-medium transition-opacity hover:opacity-80"
                           style={{
                             backgroundColor: 'var(--surface-chip)',
                             color: 'var(--text-secondary)',
                           }}
+                          title={divergedChipLabel}
                         >
-                          {t('settings.providers.models.divergedChip', {
-                            agent: hiddenAgents.map((agent) => AGENT_LABEL[agent]).join(' / '),
-                          })}
+                          <span className="truncate">{divergedChipLabel}</span>
                         </button>
                       )}
                       {/* 固定 44px 右对齐列:上下扫读时数字齐成一条线;合成媒体行

--- a/apps/desktop/src/renderer/components/settings/UnifiedModelList.tsx
+++ b/apps/desktop/src/renderer/components/settings/UnifiedModelList.tsx
@@ -17,7 +17,7 @@
  *     选择面板(modelList.ts 硬排除),没有显示轴 ⇒ 行内**没有开关**,只有「⋯」停用;
  *     其启用状态控制媒体生成等专属链路能否使用它。
  *   - 普通模式:对话模型行恒为一个开关,一次拨动同时写该模型全部可用 agent 的可见性
- *     override;分歧(双端可用但可见性不同)以「已在 X 隐藏」chip 提示,点击进入分别调整。
+ *     override;分歧(多端可用但可见性不同)以「已在 X / Y 隐藏」chip 提示,点击进入分别调整。
  *   - 分别调整模式:对话模型行统一变为两列(列头 Claude Code / Codex),模型在某 agent
  *     不可用时该格显示「—」。停用行不在分组里,不参与分别模式(停用不分 agent,一停全停)。
  *
@@ -236,11 +236,16 @@ export function isCapabilityRow(row: UnionModelRow, userProvider: boolean): bool
   return !!rep && !isAgentSelectableModel(rep, { userProvider });
 }
 
-/** 分歧 = 双端可用且可见性不同(仅对话模型行有意义)。 */
+/** 分歧 = 多端可用且可见性不同(仅对话模型行有意义)。 */
 export function isRowDiverged(providerId: string, row: UnionModelRow): boolean {
   if (row.avail.length < 2) return false;
   const values = row.avail.map((a) => rowEnabled(providerId, row, a));
   return values.some((v) => v !== values[0]);
+}
+
+/** 该行当前隐藏的全部 agent;普通模式的分歧 chip 必须完整展示,不能只取首个。 */
+export function getHiddenAgents(providerId: string, row: UnionModelRow): AgentKind[] {
+  return row.avail.filter((agent) => rowEnabled(providerId, row, agent) === false);
 }
 
 /**
@@ -707,9 +712,7 @@ export function UnifiedModelList({
                         .map((a) => `${AGENT_LABEL[a]} ${formatContextWindow(row.byAgent[a]!.contextWindow)}`)
                         .join(' · ')
                     : undefined;
-                  const hiddenAgent = diverged
-                    ? row.avail.find((a) => rowEnabled(provider.id, row, a) === false)
-                    : undefined;
+                  const hiddenAgents = diverged ? getHiddenAgents(provider.id, row) : [];
                   return (
                     <div
                       key={row.id}
@@ -739,7 +742,7 @@ export function UnifiedModelList({
                         </span>
                       )}
                       <span className="min-w-0 flex-1" />
-                      {!splitMode && diverged && hiddenAgent && (
+                      {!splitMode && diverged && hiddenAgents.length > 0 && (
                         <button
                           type="button"
                           onClick={() => setSplitMode(true)}
@@ -749,7 +752,9 @@ export function UnifiedModelList({
                             color: 'var(--text-secondary)',
                           }}
                         >
-                          {t('settings.providers.models.divergedChip', { agent: AGENT_LABEL[hiddenAgent] })}
+                          {t('settings.providers.models.divergedChip', {
+                            agent: hiddenAgents.map((agent) => AGENT_LABEL[agent]).join(' / '),
+                          })}
                         </button>
                       )}
                       {/* 固定 44px 右对齐列:上下扫读时数字齐成一条线;合成媒体行


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复模型供应商普通模式的分歧提示：当同一模型在多个 Agent 中被隐藏时，完整显示所有隐藏 Agent，不再只显示第一个。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：多个 Agent 隐藏同一模型时，分歧提示只显示一个 Agent
- 本 PR 包含：收集并展示全部隐藏 Agent；增加三 Agent、其中两个 Agent 隐藏的回归用例
- 明确不包含：模型默认可见性、用户 visibility override、停用状态或服务端目录逻辑调整
- 用户可见变化：提示由“已在 X 隐藏”扩展为“已在 X / Y 隐藏”
- 是否存在 breaking change：无

### UI 变化

分歧 chip 会列出全部隐藏 Agent；窄侧栏下限制宽度并省略显示，悬停 `title` 可查看完整内容。未修改颜色、交互方式和主题样式。

- 引用的设计规范：`docs/design-rules/DESIGN.md` §10 Light / Dark 双模式交付门槛；继续复用现有语义 token，未新增颜色或主题分支

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：runner（383 pass / 1 skip / 0 fail）、Mobile 及其余 workspace 通过；Desktop 有 19 项目录/链接安全用例失败，packages/maker-core 有 3 项 Pi resource-discovery scope 断言失败。两组失败均已在干净 upstream/main 274a4948d 上以相同最小命令、同一依赖复现，确认属于基线环境/契约漂移，与本 PR 无关。

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --filter desktop exec eslint src/renderer/components/settings/UnifiedModelList.tsx src/renderer/__tests__/unifiedModelList.test.ts
结果：通过

pnpm check:dco
结果：通过
```

### 手工验证

未执行；当前 worktree 未启动 Desktop 实例。

### 未执行的验证

未进行 Light / Dark 实机目检；本次调整现有 chip 的文本数据与窄宽收缩行为，未修改颜色或主题 token。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：设置 → 模型供应商 → 普通模式的模型分歧提示
- 回滚 / 降级方式：回退本 PR commit 即可恢复旧行为

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
