### PR TITLE
fix(mobile): 协同任务图标对齐桌面 UsersRound

### DIFF
--- a/apps/mobile/app/devices/index.tsx
+++ b/apps/mobile/app/devices/index.tsx
@@ -32,10 +32,10 @@ import {
   Lock,
   Pencil,
   Pin,
-  Puzzle,
   RefreshCw,
   RadioTower,
   SquarePen,
+  UsersRound,
   X,
 } from 'lucide-react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -2624,8 +2624,9 @@ function SessionStatusMark({
       {archived ? (
         <Archive color={cindyList ? colors.textSecondary : colors.textTertiary} size={cindyList ? iconSize.sm : iconSize.lg} strokeWidth={iconStroke.thin} />
       ) : orcaLead ? (
+        // 与桌面 SessionStatusIcon /「+」菜单协同项同款 UsersRound，不再用旧 Puzzle。
         <SessionStatusPulse running={running}>
-          <Puzzle color={glyphColor} size={cindyList ? iconSize.sm : iconSize.action} strokeWidth={iconStroke.thin} />
+          <UsersRound color={glyphColor} size={cindyList ? iconSize.sm : iconSize.action} strokeWidth={iconStroke.thin} />
         </SessionStatusPulse>
       ) : attached ? (
         <SessionStatusPulse running={running}>

--- a/apps/mobile/src/__tests__/homeDesktopFirst.test.ts
+++ b/apps/mobile/src/__tests__/homeDesktopFirst.test.ts
@@ -193,6 +193,8 @@ describe('mobile home desktop-first surface', () => {
     expect((homeSource.match(/^  useRemoteSessionStoreVersion\(\);$/gm) ?? []).length).toBeGreaterThanOrEqual(2);
     expect(homeSource).toContain('useMinuteNow();');
     expect(homeSource).toContain('<RadioTower');
+    expect(homeSource).toContain('<UsersRound');
+    expect(homeSource).not.toContain('<Puzzle');
     expect(homeSource).toContain('width: 24');
     expect(homeSource).toContain('width: iconSize.md');
     expect(homeSource).toContain('size={cindyList ? iconSize.sm : isClaudeCodeAgentKind(item.session.agentKind) ? 19 : iconSize.lg}');


### PR DESCRIPTION
## 这次改了什么

### 摘要

手机任务列表里，协同 Lead 任务仍显示旧的拼图图标，和桌面侧栏 /「+」菜单已经统一的圆形双人图标不一致。这次只把手机列表里的这个图标换成同一款 `UsersRound`。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：手机首页任务行协同 Lead 状态图标从 `Puzzle` 换成 `UsersRound`，并补源码断言防止再退回旧图标
- 明确不包含：桌面图标、手机「+」菜单（手机端尚未做完整协同编排入口）、协同功能本身
- 用户可见变化：手机任务列表里，处于协同模式的 Lead 任务图标与桌面一致
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：`docs/design-rules/DESIGN.md` §1 极简与身份标识克制；桌面已裁决协同入口统一用 `UsersRound`（侧栏 `SessionStatusIcon`、「+」菜单、右侧协同 tab）。手机列表沿用同一 glyph，颜色仍走语义 token（`statusAccent` / `activeGlyph` / `textSecondary` / `textTertiary`），Light / Dark 不另写硬编码色。尺寸与描边保持原档，只换图标。
- 界面效果：CINDY List 行首图标从拼图换成桌面同款圆形双人标；闲置走 `textSecondary`，运行走 `statusAccent #EA6B17`。下面是按现网 token 还原的 Light/Dark 对照页（未改尺寸/描边/行高）。

```html
<!DOCTYPE html>
<html lang="zh-CN">
<head>
  <meta charset="utf-8" />
  <meta name="viewport" content="width=device-width, initial-scale=1" />
  <title>#2669 手机协同图标对照</title>
  <style>
    :root {
      --surface: #EDEDED;
      --surface-row: #F6F6F6;
      --border: #C6C9CE;
      --text-primary: #3C3F43;
      --text-secondary: #8C8E94;
      --text-tertiary: #686B72;
      --status-accent: #EA6B17;
      --page: #F8F8F8;
    }
    html[data-theme="dark"] {
      --surface: #2A2828;
      --surface-row: #312F2F;
      --border: #434343;
      --text-primary: #D4D4D4;
      --text-secondary: #6F6F6F;
      --text-tertiary: #BFC1C4;
      --status-accent: #EA6B17;
      --page: #2A2828;
    }
    * { box-sizing: border-box; }
    body {
      margin: 0;
      background: var(--page);
      color: var(--text-primary);
      font: 14px/20px Inter, "PingFang SC", "Noto Sans SC", sans-serif;
    }
    main { max-width: 860px; margin: 0 auto; padding: 24px 16px 48px; }
    h1 { font-size: 20px; line-height: 28px; font-weight: 600; margin: 0 0 8px; }
    .lede, .note { color: var(--text-secondary); margin: 0 0 16px; }
    .note { font-size: 13px; line-height: 18px; }
    .bar { display: flex; gap: 8px; margin: 0 0 20px; }
    button {
      border: 1px solid var(--border);
      background: var(--surface-row);
      color: var(--text-primary);
      border-radius: 9999px;
      padding: 6px 12px;
      font: inherit;
    }
    button[aria-pressed="true"] { background: var(--text-primary); color: var(--page); }
    .grid { display: grid; gap: 16px; }
    @media (min-width: 720px) { .grid { grid-template-columns: 1fr 1fr; } }
    section {
      background: var(--surface);
      border: 1px solid var(--border);
      border-radius: 12px;
      overflow: hidden;
    }
    .label {
      padding: 10px 16px;
      font-size: 12px;
      color: var(--text-secondary);
      border-bottom: 1px solid var(--border);
    }
    .row {
      display: flex;
      align-items: stretch;
      height: 60px;
      padding-left: 18px;
      background: var(--surface-row);
      gap: 8px;
    }
    .row + .row { border-top: 1px solid var(--border); }
    .icon {
      width: 16px;
      display: flex;
      align-items: center;
      justify-content: center;
      flex: 0 0 16px;
    }
    .icon svg {
      width: 14px;
      height: 14px;
      stroke: currentColor;
      fill: none;
      stroke-width: 1.75;
      stroke-linecap: round;
      stroke-linejoin: round;
    }
    .idle { color: var(--text-secondary); }
    .running { color: var(--status-accent); }
    .copy { flex: 1; min-width: 0; display: flex; flex-direction: column; justify-content: center; padding: 8px 18px 8px 0; }
    .title { font-size: 14px; line-height: 20px; font-weight: 600; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
    .preview { font-size: 11px; line-height: 16px; color: var(--text-secondary); }
    .time { font-size: 11px; line-height: 16px; color: var(--text-secondary); flex: 0 0 auto; padding-top: 14px; padding-right: 18px; }
  </style>
</head>
<body>
  <main>
    <h1>手机任务列表：协同图标对照</h1>
    <p class="lede">#2669 只换 Lead 协同行的 glyph：旧 <code>Puzzle</code> → 桌面同款 <code>UsersRound</code>。颜色、尺寸、描边不变。</p>
    <p class="note">CINDY List 行：高 60、图标 14、描边 1.75。闲置走 <code>textSecondary</code>，运行走 <code>statusAccent #EA6B17</code>。Light / Dark 都按 <code>apps/mobile/src/theme/tokens.ts</code>。</p>
    <div class="bar">
      <button type="button" data-theme="light" aria-pressed="true">Light</button>
      <button type="button" data-theme="dark" aria-pressed="false">Dark</button>
    </div>
    <div class="grid">
      <section>
        <div class="label">改前 · Puzzle</div>
        <div class="row">
          <div class="icon idle" aria-hidden="true">
            <svg viewBox="0 0 24 24"><path d="M15.39 4.39a1 1 0 0 0 1.68-.474 2.5 2.5 0 1 1 3.014 3.015 1 1 0 0 0-.474 1.68l1.683 1.682a2.414 2.414 0 0 1 0 3.414L19.61 15.39a1 1 0 0 1-1.68-.474 2.5 2.5 0 1 0-3.014 3.015 1 1 0 0 1 .474 1.68l-1.683 1.682a2.414 2.414 0 0 1-3.414 0L8.61 19.61a1 1 0 0 0-1.68.474 2.5 2.5 0 1 1-3.014-3.015 1 1 0 0 0 .474-1.68l-1.683-1.682a2.414 2.414 0 0 1 0-3.414L4.39 8.61a1 1 0 0 1 1.68.474 2.5 2.5 0 1 0 3.014-3.015 1 1 0 0 1-.474-1.68l1.683-1.682a2.414 2.414 0 0 1 3.414 0z"/></svg>
          </div>
          <div class="copy">
            <div class="title">协同 Lead · 闲置</div>
            <div class="preview">旧拼图图标</div>
          </div>
          <div class="time">刚刚</div>
        </div>
        <div class="row">
          <div class="icon running" aria-hidden="true">
            <svg viewBox="0 0 24 24"><path d="M15.39 4.39a1 1 0 0 0 1.68-.474 2.5 2.5 0 1 1 3.014 3.015 1 1 0 0 0-.474 1.68l1.683 1.682a2.414 2.414 0 0 1 0 3.414L19.61 15.39a1 1 0 0 1-1.68-.474 2.5 2.5 0 1 0-3.014 3.015 1 1 0 0 1 .474 1.68l-1.683 1.682a2.414 2.414 0 0 1-3.414 0L8.61 19.61a1 1 0 0 0-1.68.474 2.5 2.5 0 1 1-3.014-3.015 1 1 0 0 0 .474-1.68l-1.683-1.682a2.414 2.414 0 0 1 0-3.414L4.39 8.61a1 1 0 0 1 1.68.474 2.5 2.5 0 1 0 3.014-3.015 1 1 0 0 1-.474-1.68l1.683-1.682a2.414 2.414 0 0 1 3.414 0z"/></svg>
          </div>
          <div class="copy">
            <div class="title">协同 Lead · 运行中</div>
            <div class="preview">警告橙不变</div>
          </div>
          <div class="time">1 分钟前</div>
        </div>
      </section>
      <section>
        <div class="label">改后 · UsersRound（与桌面一致）</div>
        <div class="row">
          <div class="icon idle" aria-hidden="true">
            <svg viewBox="0 0 24 24"><path d="M18 21a8 8 0 0 0-16 0"/><circle cx="10" cy="8" r="5"/><path d="M22 20c0-3.37-2-6.5-4-8a5 5 0 0 0-.45-8.3"/></svg>
          </div>
          <div class="copy">
            <div class="title">协同 Lead · 闲置</div>
            <div class="preview">桌面同款双人标</div>
          </div>
          <div class="time">刚刚</div>
        </div>
        <div class="row">
          <div class="icon running" aria-hidden="true">
            <svg viewBox="0 0 24 24"><path d="M18 21a8 8 0 0 0-16 0"/><circle cx="10" cy="8" r="5"/><path d="M22 20c0-3.37-2-6.5-4-8a5 5 0 0 0-.45-8.3"/></svg>
          </div>
          <div class="copy">
            <div class="title">协同 Lead · 运行中</div>
            <div class="preview">警告橙不变</div>
          </div>
          <div class="time">1 分钟前</div>
        </div>
      </section>
    </div>
  </main>
  <script>
    const root = document.documentElement;
    document.querySelectorAll("button[data-theme]").forEach((button) => {
      button.addEventListener("click", () => {
        root.dataset.theme = button.dataset.theme;
        document.querySelectorAll("button[data-theme]").forEach((item) => {
          item.setAttribute("aria-pressed", String(item === button));
        });
      });
    });
  </script>
</body>
</html>

```

## 怎么验证的

### 自动验证

```text
pnpm --filter mobile exec vitest run src/__tests__/homeDesktopFirst.test.ts
结果：15 passed

pnpm --filter mobile run --if-present typecheck
结果：通过
```

根 `pnpm test:unit` 经 `run-unit-gate.sh` 跑完，`mobile` 通过。失败项均不在本 PR diff 内，且在干净 `origin/main`（`274a4948d`）上同样复现：

- `apps/desktop` `builtinGhostProvisioner.test.ts` / `forge.test.ts`：19 failed
- `packages/maker-core` `pi-rpc-resource-discovery.integration.test.ts`：3 failed（显式 project skill 的 `scope` 期望 `project`，实际 `temporary`）

不把基线失败混进本 PR。

### 手工验证

未在模拟器/真机目检。改动是同一 lucide glyph 替换，颜色与尺寸未改。

### 未执行的验证

- 手机模拟器目检（Light / Dark）：当前会话从手机客户端发起，未启动 `pnpm mobile:sim:start`。
- 完整 `pnpm test:all`：本次只换图标，不涉及协议 / 原生 / 跨模块行为。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅手机任务列表协同 Lead 行首图标
- 回滚 / 降级方式：回退本 commit
- 存量插件影响：无
- runtime fingerprint：不涉及（只改 JS / TSX，未动 `app.json` / 原生依赖 / config plugin）

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因

