### PR TITLE
fix(codex): scope CodeModeOnly to gateway routes

### DIFF
--- a/apps/desktop/src/main/bootstrap-electron.ts
+++ b/apps/desktop/src/main/bootstrap-electron.ts
@@ -1350,7 +1350,7 @@ async function teardownAuthAccountBoundary(reason: string): Promise<void> {
   // 先丢弃旧 owner 的延迟 Codex 重启登记 —— holder 随进程存活,不清会在新 owner
   // 的 Maker 上兑现旧 owner 的记忆设置重启(shutdown 触发的会话关闭事件也会
   // 撞上它,先清再关)。
-  clearDeferredCodexRestartForOwnerBoundary();
+  await clearDeferredCodexRestartForOwnerBoundary();
   // interrupted-turn-resume:shutdown 批量 close 会话会触发 close teardown 的
   // markSessionTurnEnded,把"边界时还在飞的 turn"伪装成正常收尾 —— 被切换打断的
   // 任务从此既无中断横幅也无红点,呈现为"卡住且无报错"(与 ⌘Q 的 quit freeze 同款

--- a/apps/desktop/src/main/im/shared/__tests__/cardActionTakeoverReplace.test.ts
+++ b/apps/desktop/src/main/im/shared/__tests__/cardActionTakeoverReplace.test.ts
@@ -18,6 +18,7 @@ const mocks = vi.hoisted(() => ({
   executeDetach: vi.fn(),
   generateTakeoverSummary: vi.fn(),
   getMaker: vi.fn(),
+  getCodexProxyAuthInjectionState: vi.fn(() => 'env-key' as const),
   closeSession: vi.fn(async () => {}),
   getDesktopCcPrefs: vi.fn<() => DesktopCcPrefs | null>(() => null),
   resolveLenientSessionRoute: vi.fn(),
@@ -57,6 +58,9 @@ vi.mock('../../../logger', () => ({ createLogger: () => mocks.logger }));
 vi.mock('../../../maker-host', () => ({ getMaker: mocks.getMaker }));
 vi.mock('../../../maker-host/model-route-guard-live', () => ({
   resolveLenientSessionRoute: mocks.resolveLenientSessionRoute,
+}));
+vi.mock('../../../maker-host/codex-proxy-host', () => ({
+  getCodexProxyAuthInjectionState: mocks.getCodexProxyAuthInjectionState,
 }));
 vi.mock('../../index', () => ({ getDesktopCcPrefs: mocks.getDesktopCcPrefs }));
 vi.mock('../controlProjects', () => ({
@@ -214,6 +218,7 @@ beforeEach(() => {
   mocks.readPermissionMode.mockResolvedValue('auto');
   mocks.updatePermissionMode.mockResolvedValue(undefined);
   mocks.applyRuntimeSetModelChange.mockResolvedValue({ status: 'applied' });
+  mocks.getCodexProxyAuthInjectionState.mockReturnValue('env-key');
   mocks.getMaker.mockReturnValue({
     createSession: vi.fn(async () => ({ id: 'sess-new' })),
     closeSession: mocks.closeSession,
@@ -641,7 +646,10 @@ describe('model:pick 持久化失败', () => {
       'anthropic',
     );
     expect(mocks.applyRuntimeSetModelChange).toHaveBeenCalledWith(
-      expect.objectContaining({ providerId: 'anthropic' }),
+      expect.objectContaining({
+        providerId: 'anthropic',
+        codexAuthInjection: 'env-key',
+      }),
     );
   });
 

--- a/apps/desktop/src/main/im/shared/__tests__/cardActionTakeoverReplace.test.ts
+++ b/apps/desktop/src/main/im/shared/__tests__/cardActionTakeoverReplace.test.ts
@@ -28,6 +28,10 @@ const mocks = vi.hoisted(() => ({
   clearPendingCredentialSwitchForSession: vi.fn(),
   wakeSessionInputAfterCredentialSwitch: vi.fn(),
   getPendingCredentialSwitchTarget: vi.fn(() => undefined),
+  prepareCodexThreadRotationForSession: vi.fn(async () => ({
+    newSdkSessionId: 'thread-new',
+    rollback: vi.fn(async () => undefined),
+  })),
   readModelRouteSnapshot: vi.fn(
     async (): Promise<{ model: string; effort: string; providerId: string | null } | null> => null,
   ),
@@ -105,6 +109,7 @@ vi.mock('../../../maker-ipc/register', () => ({
   clearPendingCredentialSwitchForSession: mocks.clearPendingCredentialSwitchForSession,
   wakeSessionInputAfterCredentialSwitch: mocks.wakeSessionInputAfterCredentialSwitch,
   getPendingCredentialSwitchTarget: mocks.getPendingCredentialSwitchTarget,
+  prepareCodexThreadRotationForSession: mocks.prepareCodexThreadRotationForSession,
   withSendToSessionLock: mocks.withSendToSessionLock,
 }));
 vi.mock('../pendingInteractions', () => ({

--- a/apps/desktop/src/main/im/shared/cardActionHandler.ts
+++ b/apps/desktop/src/main/im/shared/cardActionHandler.ts
@@ -39,6 +39,7 @@ import {
   clearPendingCredentialSwitchForSession,
   getPendingCredentialSwitchTarget,
   isSessionInTurn,
+  prepareCodexThreadRotationForSession,
   registerPendingCredentialSwitchForSession,
   withSendToSessionLock,
   wakeSessionInputAfterCredentialSwitch,
@@ -386,6 +387,7 @@ export function createCardActionHandler(
           wakeSessionInputQueue: wakeSessionInputAfterCredentialSwitch,
           getPendingCredentialSwitch: getPendingCredentialSwitchTarget,
           codexAuthInjection: getCodexProxyAuthInjectionState(),
+          prepareCodexThreadRotation: prepareCodexThreadRotationForSession,
           logger: log,
         });
 

--- a/apps/desktop/src/main/im/shared/cardActionHandler.ts
+++ b/apps/desktop/src/main/im/shared/cardActionHandler.ts
@@ -27,6 +27,7 @@ import {
 
 import { createLogger } from '../../logger';
 import { getMaker } from '../../maker-host';
+import { getCodexProxyAuthInjectionState } from '../../maker-host/codex-proxy-host';
 import { resolveLenientSessionRoute } from '../../maker-host/model-route-guard-live';
 import {
   getSessionProvider,
@@ -384,6 +385,7 @@ export function createCardActionHandler(
           clearPendingCredentialSwitch: clearPendingCredentialSwitchForSession,
           wakeSessionInputQueue: wakeSessionInputAfterCredentialSwitch,
           getPendingCredentialSwitch: getPendingCredentialSwitchTarget,
+          codexAuthInjection: getCodexProxyAuthInjectionState(),
           logger: log,
         });
 

--- a/apps/desktop/src/main/localDb/ipc/__tests__/sessionsUpdate.test.ts
+++ b/apps/desktop/src/main/localDb/ipc/__tests__/sessionsUpdate.test.ts
@@ -66,7 +66,7 @@ vi.mock('../../../maker-host/claude-transcript-relocation.js', () => ({
   relocateClaudeTranscriptsForSessionMove: h.relocate,
 }));
 
-import { registerSessionIpc } from '../sessions';
+import { registerSessionIpc, replaceSessionSdkSessionIdIfCurrent } from '../sessions';
 import { setSessionRouteLockImplementation } from '../../sessionRouteLock';
 
 function createDb(): void {
@@ -167,6 +167,43 @@ afterEach(() => {
 });
 
 describe('local-db:sessions:update handler wiring', () => {
+  it('replaces sdkSessionId with a database-level compare-and-swap and broadcasts the new id', async () => {
+    h.sqlite!.prepare('UPDATE sessions SET sdk_session_id = ? WHERE id = ?').run(
+      'sdk-old',
+      'codex-local',
+    );
+
+    await expect(
+      replaceSessionSdkSessionIdIfCurrent('codex-local', 'sdk-old', 'sdk-new'),
+    ).resolves.toBe(true);
+
+    const persisted = h
+      .sqlite!.prepare('SELECT sdk_session_id AS sdkSessionId FROM sessions WHERE id = ?')
+      .get('codex-local') as { sdkSessionId: string | null };
+    expect(persisted.sdkSessionId).toBe('sdk-new');
+    expect(h.tapWindowBroadcast).toHaveBeenCalledWith('local-db:sessions:patched', {
+      sessionId: 'codex-local',
+      patch: { sdkSessionId: 'sdk-new' },
+    });
+  });
+
+  it('rejects a stale sdkSessionId replacement without overwriting the current value', async () => {
+    h.sqlite!.prepare('UPDATE sessions SET sdk_session_id = ? WHERE id = ?').run(
+      'sdk-current',
+      'codex-local',
+    );
+
+    await expect(
+      replaceSessionSdkSessionIdIfCurrent('codex-local', 'sdk-stale', 'sdk-new'),
+    ).resolves.toBe(false);
+
+    const persisted = h
+      .sqlite!.prepare('SELECT sdk_session_id AS sdkSessionId FROM sessions WHERE id = ?')
+      .get('codex-local') as { sdkSessionId: string | null };
+    expect(persisted.sdkSessionId).toBe('sdk-current');
+    expect(h.tapWindowBroadcast).not.toHaveBeenCalled();
+  });
+
   it('does not resurrect a deleted task through the generic status writer', async () => {
     h.sqlite!.prepare("UPDATE sessions SET status = 'deleted' WHERE id = ?").run('codex-local');
 

--- a/apps/desktop/src/main/localDb/ipc/sessions.ts
+++ b/apps/desktop/src/main/localDb/ipc/sessions.ts
@@ -490,6 +490,35 @@ export async function persistSessionFields(
   if (isOwnerScopeCurrent(ownerScope)) broadcastSessionPatched(sessionId, clean, ownerScope);
 }
 
+/**
+ * Replace a session's native SDK thread id only when it is still the expected
+ * value (database-level compare-and-swap).
+ *
+ * Thread rotation is deliberately an internal main-process operation rather
+ * than another remotely persistable session field.  The CAS prevents a slow
+ * fork/close sequence from overwriting a newer `/clear`, agent switch, or
+ * another route transition.  A successful replacement is broadcast so all
+ * local/device-link session mirrors converge on the id that will be resumed.
+ */
+export async function replaceSessionSdkSessionIdIfCurrent(
+  sessionId: string,
+  expectedSdkSessionId: string,
+  nextSdkSessionId: string,
+): Promise<boolean> {
+  const ownerScope = captureOwnerScope();
+  const db = getDbClient().drizzle;
+  const result = await db
+    .update(sessions)
+    .set({ sdkSessionId: nextSdkSessionId })
+    .where(and(eq(sessions.id, sessionId), eq(sessions.sdkSessionId, expectedSdkSessionId)))
+    .run();
+  const applied = result.changes === 1;
+  if (applied && isOwnerScopeCurrent(ownerScope)) {
+    broadcastSessionPatched(sessionId, { sdkSessionId: nextSdkSessionId }, ownerScope);
+  }
+  return applied;
+}
+
 const MAX_LIMIT = 1000;
 
 /**

--- a/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
@@ -313,12 +313,12 @@ describe('withCodexUpstreamRecording', () => {
 });
 
 describe('codex gateway config', () => {
-  it('所有认证模式都让缺少 model metadata 的 Codex 模型使用 CodeModeOnly', async () => {
+  it('不在 spawn 层全局注入 CodeModeOnly', async () => {
     const { buildCodexProxySpawnArgs } = await import('../codex-gateway-config.js');
 
     for (const mode of ['oauth-bearer', 'env-key', 'provider-oauth'] as const) {
       const args = buildCodexProxySpawnArgs('http://127.0.0.1:12345', mode);
-      expect(args).toContain('features.code_mode_only=true');
+      expect(args).not.toContain('features.code_mode_only=true');
     }
   });
 

--- a/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
@@ -298,6 +298,66 @@ describe('withCodexUpstreamRecording', () => {
     }
   });
 
+  it('fails closed when a selected Provider disappears during its route mutation', async () => {
+    const host = await freshCodexProxyHost();
+    const { buildUserProvider } = await import('@cindy/model-providers');
+    const { setCustomProviders } = await import('../active-catalog.js');
+    const { beginProviderRouteMutation } = await import('../provider-route.js');
+    const { setSessionProvider, clearSessionProvider } = await import('../session-provider-store.js');
+    setCustomProviders([
+      buildUserProvider({
+        id: 'provider-under-update',
+        name: 'Provider Under Update',
+        runtimes: {
+          codex: {
+            baseUrl: 'https://provider.example/v1',
+            models: [{ id: 'provider-model', name: 'Provider Model' }],
+          },
+        },
+      }),
+    ]);
+    host.registerComposed('session-provider-update', 'thread-provider-update', 'PRODUCT_PROMPT');
+    setSessionProvider('session-provider-update', 'provider-under-update');
+    host.setCodexProxyAuthInjection('env-key');
+    const finishMutation = beginProviderRouteMutation('provider-under-update');
+
+    try {
+      // Catalog refresh can temporarily remove the selected Provider while the
+      // mutation flag is still active. The request must not fall through to Gateway.
+      setCustomProviders([]);
+      const body = { model: 'provider-model', input: 'hello' };
+      const ctx = {
+        reqId: 1,
+        method: 'POST',
+        url: '/responses',
+        headers: { 'thread-id': 'thread-provider-update' },
+      };
+      const decision = await Promise.resolve(host.createModelRoutingTransform()(body, ctx));
+      expect(decision).toEqual({ localHandler: expect.any(Function) });
+
+      const writeHead = vi.fn();
+      const end = vi.fn();
+      await decision!.localHandler!({
+        rawBody: Buffer.from(JSON.stringify(body)),
+        parsedBody: body,
+        ctx,
+        res: { writeHead, end } as never,
+      });
+      expect(writeHead).toHaveBeenCalledWith(
+        503,
+        expect.objectContaining({ 'retry-after': '1' }),
+      );
+      expect(JSON.parse(end.mock.calls[0][0])).toMatchObject({
+        error: { code: 'provider_route_updating' },
+      });
+    } finally {
+      finishMutation();
+      host.unregister('session-provider-update');
+      clearSessionProvider('session-provider-update');
+      setCustomProviders([]);
+    }
+  });
+
   it('never lets a recording failure affect forwarding', async () => {
     // 诊断旁路:默认上游取值抛错也不能影响 decision。
     const host = await freshCodexProxyHost();

--- a/apps/desktop/src/main/maker-host/__tests__/providerRoute.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/providerRoute.test.ts
@@ -138,6 +138,12 @@ describe('Codex CodeModeOnly route capability', () => {
     })).resolves.toEqual({ requiresCodeModeOnly: false });
 
     await expect(resolveCodexRouteCapabilities({
+      providerId: 'openai',
+      model: 'gpt-5.5',
+      credentialMode: 'gateway-key',
+    })).resolves.toEqual({ requiresCodeModeOnly: true });
+
+    await expect(resolveCodexRouteCapabilities({
       providerId: 'xai',
       model: 'xai/grok-4.3',
       credentialMode: 'provider-oauth',

--- a/apps/desktop/src/main/maker-host/__tests__/providerRoute.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/providerRoute.test.ts
@@ -31,6 +31,7 @@ import {
   setProviderOAuthTokenReader,
   setProviderViewsReader,
   resolveImplicitProviderOAuthRouteDecision,
+  resolveCodexRouteCapabilities,
   resolveVisionBackendRoute,
   rewriteImplicitModelIdForRoute,
   rewriteSessionModelIdForRoute,
@@ -81,6 +82,7 @@ afterEach(() => {
   clearSessionProvider('s-xd-model-wire');
   setXdGatewayModels([]);
   setAnthropicDiscoveredModels([]);
+  setCustomProviders([]);
   setProviderViewsReader(async () => []);
 });
 
@@ -118,6 +120,104 @@ describe('local mode Cindy gateway gate', () => {
     expect(inferProviderIdForModel('gpt-local-gate', 'codex')).toBeNull();
 
     clearSessionProvider('s-local-xd');
+  });
+});
+
+describe('Codex CodeModeOnly route capability', () => {
+  it('follows the final catalog route and not the provider id', async () => {
+    await expect(resolveCodexRouteCapabilities({
+      providerId: 'xd',
+      model: 'codex/gpt-5.5',
+      credentialMode: 'gateway-key',
+    })).resolves.toEqual({ requiresCodeModeOnly: true });
+
+    await expect(resolveCodexRouteCapabilities({
+      providerId: 'openai',
+      model: 'gpt-5.5',
+      credentialMode: 'oauth-bearer',
+    })).resolves.toEqual({ requiresCodeModeOnly: false });
+
+    await expect(resolveCodexRouteCapabilities({
+      providerId: 'xai',
+      model: 'xai/grok-4.3',
+      credentialMode: 'provider-oauth',
+    })).resolves.toEqual({ requiresCodeModeOnly: false });
+  });
+
+  it('uses the fallback route when an explicit provider does not serve the model', async () => {
+    await expect(resolveCodexRouteCapabilities({
+      providerId: 'xai',
+      model: 'codex/gpt-5.5',
+      credentialMode: 'gateway-key',
+    })).resolves.toEqual({ requiresCodeModeOnly: true });
+  });
+
+  it.each([
+    ['deepseek', 'deepseek-v4-pro'],
+    ['zhipu-glm', 'glm-5.2'],
+  ])('uses the connected implicit %s Chat bridge instead of the spawn fallback', async (
+    providerId,
+    model,
+  ) => {
+    setCustomProviders([
+      buildUserProvider({
+        id: providerId,
+        name: providerId,
+        runtimes: {
+          codex: {
+            baseUrl: `https://${providerId}.example.com`,
+            wireProtocol: 'openai-chat',
+            models: [{ id: model, name: model }],
+          },
+        },
+      }),
+    ]);
+    setProviderViewsReader(async () =>
+      buildRegistry(getActiveCatalog(), { [providerId]: true, xd: true }, {}),
+    );
+
+    await expect(resolveCodexRouteCapabilities({
+      providerId: null,
+      model,
+      credentialMode: 'gateway-key',
+    })).resolves.toEqual({ requiresCodeModeOnly: false });
+  });
+
+  it('uses the connected implicit Anthropic Messages bridge instead of the spawn fallback', async () => {
+    setAnthropicDiscoveredModels([{
+      id: 'claude-sonnet-route-capability',
+      name: 'Claude Sonnet Route Capability',
+      contextWindow: 200_000,
+      efforts: [],
+      defaultEffort: null,
+      status: 'active',
+    }]);
+    setProviderViewsReader(async () =>
+      buildRegistry(getActiveCatalog(), { anthropic: true, xd: true }, {}),
+    );
+
+    await expect(resolveCodexRouteCapabilities({
+      providerId: null,
+      model: 'claude-sonnet-route-capability',
+      credentialMode: 'gateway-key',
+    })).resolves.toEqual({ requiresCodeModeOnly: false });
+  });
+
+  it('keeps an implicit native xAI Responses route out of CodeModeOnly', async () => {
+    await expect(resolveCodexRouteCapabilities({
+      providerId: null,
+      model: 'xai/grok-4.3',
+      credentialMode: 'provider-oauth',
+    })).resolves.toEqual({ requiresCodeModeOnly: false });
+  });
+
+  it('does not claim the gateway capability when the gateway is unavailable', async () => {
+    mockGetAppCapabilities.mockReturnValue({ canUseCindyGateway: false });
+    await expect(resolveCodexRouteCapabilities({
+      providerId: 'xd',
+      model: 'codex/gpt-5.5',
+      credentialMode: 'gateway-key',
+    })).resolves.toBeUndefined();
   });
 });
 

--- a/apps/desktop/src/main/maker-host/__tests__/providerRoute.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/providerRoute.test.ts
@@ -88,7 +88,10 @@ afterEach(() => {
   setAnthropicDiscoveredModels([]);
   setCustomProviders([]);
   setProviderViewsReader(async () => []);
+  setVisionGatewayKeyReader(() => KEY);
 });
+
+setVisionGatewayKeyReader(() => KEY);
 
 describe('implicit local bridge resume routing', () => {
   it('keeps the connected source when a running session model becomes retired', async () => {
@@ -152,6 +155,22 @@ describe('Codex CodeModeOnly route capability', () => {
       model: 'xai/grok-4.3',
       credentialMode: 'provider-oauth',
     })).resolves.toEqual({ requiresCodeModeOnly: false });
+  });
+
+  it('uses the OAuth spawn fallback when an explicit Gateway route has no key', async () => {
+    setVisionGatewayKeyReader(() => null);
+
+    await expect(resolveCodexRouteCapabilities({
+      providerId: 'xd',
+      model: 'gpt-5.5',
+      credentialMode: 'oauth-bearer',
+    })).resolves.toBeUndefined();
+
+    await expect(resolveCodexRouteCapabilities({
+      providerId: 'xd',
+      model: 'codex/gpt-5.5',
+      credentialMode: 'oauth-bearer',
+    })).resolves.toEqual({ requiresCodeModeOnly: true });
   });
 
   it('uses the fallback route when an explicit provider does not serve the model', async () => {

--- a/apps/desktop/src/main/maker-host/__tests__/providerRoute.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/providerRoute.test.ts
@@ -254,6 +254,14 @@ describe('Codex CodeModeOnly route capability', () => {
     })).resolves.toEqual({ requiresCodeModeOnly: false });
   });
 
+  it('does not infer an implicit OAuth route while an explicit Provider is selected', async () => {
+    await expect(resolveCodexRouteCapabilities({
+      providerId: 'removed-provider',
+      model: 'xai/grok-4.3',
+      credentialMode: 'gateway-key',
+    })).resolves.toEqual({ requiresCodeModeOnly: true });
+  });
+
   it('does not claim the gateway capability when the gateway is unavailable', async () => {
     mockGetAppCapabilities.mockReturnValue({ canUseCindyGateway: false });
     await expect(resolveCodexRouteCapabilities({

--- a/apps/desktop/src/main/maker-host/__tests__/providerRoute.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/providerRoute.test.ts
@@ -159,11 +159,13 @@ describe('Codex CodeModeOnly route capability', () => {
   });
 
   it.each([
-    ['deepseek', 'deepseek-v4-pro'],
-    ['zhipu-glm', 'glm-5.2'],
+    ['deepseek', 'deepseek-v4-pro', 'deepseek-v4-pro'],
+    ['zhipu-glm', 'glm-5.2', 'glm-5.2'],
+    ['zhipu-glm', 'glm-5.2', 'glm-5.2[1m]'],
   ])('uses the connected implicit %s Chat bridge instead of the spawn fallback', async (
     providerId,
-    model,
+    catalogModel,
+    wireModel,
   ) => {
     setCustomProviders([
       buildUserProvider({
@@ -173,7 +175,7 @@ describe('Codex CodeModeOnly route capability', () => {
           codex: {
             baseUrl: `https://${providerId}.example.com`,
             wireProtocol: 'openai-chat',
-            models: [{ id: model, name: model }],
+            models: [{ id: catalogModel, name: catalogModel }],
           },
         },
       }),
@@ -184,7 +186,7 @@ describe('Codex CodeModeOnly route capability', () => {
 
     await expect(resolveCodexRouteCapabilities({
       providerId: null,
-      model,
+      model: wireModel,
       credentialMode: 'gateway-key',
     })).resolves.toEqual({ requiresCodeModeOnly: false });
   });

--- a/apps/desktop/src/main/maker-host/__tests__/providerRoute.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/providerRoute.test.ts
@@ -20,7 +20,9 @@ import {
   beginProviderRouteMutation,
   buildLocalHandlerHeaders,
   buildRouteDecision,
+  getProviderRouteMutationGeneration,
   getSessionRoutingDescriptor,
+  hasAnyProviderRouteMutationInProgress,
   resolveSessionRoute,
   resolveSessionRouteDecision,
   resolveImplicitLocalBridgeRoute,
@@ -1186,6 +1188,21 @@ describe('resolveSessionRouteDecision — 自定义供应商(resolve 时注入 k
       upstreamOverride: 'https://new.example/v1',
       headerOverride: { authorization: 'Bearer new-key' },
     });
+  });
+
+  it('keeps the global mutation guard active until every provider route is released', () => {
+    const generationBefore = getProviderRouteMutationGeneration();
+    const finishOpenRouter = beginProviderRouteMutation('openrouter');
+    expect(getProviderRouteMutationGeneration()).toBe(generationBefore + 1);
+    const finishDeepSeek = beginProviderRouteMutation('deepseek');
+    expect(getProviderRouteMutationGeneration()).toBe(generationBefore + 2);
+
+    expect(hasAnyProviderRouteMutationInProgress()).toBe(true);
+    finishOpenRouter();
+    expect(hasAnyProviderRouteMutationInProgress()).toBe(true);
+    finishDeepSeek();
+    expect(hasAnyProviderRouteMutationInProgress()).toBe(false);
+    expect(getProviderRouteMutationGeneration()).toBe(generationBefore + 2);
   });
 
   it('精确请求路径只覆盖带 model 的推理请求，不改写无 body 的控制面请求', () => {

--- a/apps/desktop/src/main/maker-host/__tests__/providerRoute.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/providerRoute.test.ts
@@ -41,6 +41,7 @@ import {
 } from '../provider-route.js';
 import {
   getActiveCatalog,
+  setActiveCatalog,
   setAnthropicDiscoveredModels,
   setCustomProviders,
   setDiscoveredCodexModels,
@@ -78,6 +79,7 @@ afterEach(() => {
   mockGetAppCapabilities.mockReturnValue({ canUseCindyGateway: true });
   setProviderOAuthTokenReader(() => null);
   setPendingCredentialSwitchReader(() => undefined);
+  setActiveCatalog(BUNDLED_CATALOG);
   clearSessionProvider('s-xai');
   clearSessionProvider('s-xai-rewrite');
   clearSessionProvider('s-anthropic-codex');
@@ -158,6 +160,37 @@ describe('Codex CodeModeOnly route capability', () => {
       model: 'codex/gpt-5.5',
       credentialMode: 'gateway-key',
     })).resolves.toEqual({ requiresCodeModeOnly: true });
+  });
+
+  it('uses the Gateway capability when env-key ignores a disabled builtin provider', async () => {
+    setActiveCatalog({
+      ...BUNDLED_CATALOG,
+      providers: BUNDLED_CATALOG.providers.map((provider) =>
+        provider.id === 'openai'
+          ? {
+              ...provider,
+              routing: {
+                ...provider.routing,
+                codex: { ...provider.routing.codex!, disabled: true },
+              },
+            }
+          : provider,
+      ),
+    });
+
+    await expect(resolveCodexRouteCapabilities({
+      providerId: 'openai',
+      model: 'gpt-5.5',
+      credentialMode: 'gateway-key',
+    })).resolves.toEqual({ requiresCodeModeOnly: true });
+
+    // OAuth sessions still enter the explicit route branch and receive the
+    // disabled-provider error, so they must not be classified as Gateway.
+    await expect(resolveCodexRouteCapabilities({
+      providerId: 'openai',
+      model: 'gpt-5.5',
+      credentialMode: 'oauth-bearer',
+    })).resolves.toEqual({ requiresCodeModeOnly: false });
   });
 
   it.each([

--- a/apps/desktop/src/main/maker-host/codex-gateway-config.ts
+++ b/apps/desktop/src/main/maker-host/codex-gateway-config.ts
@@ -80,8 +80,6 @@ export function buildCodexProxySpawnArgs(baseUrl: string, authMode: CodexProxySp
     ? `model_providers.${p}.requires_openai_auth=true`
     : `model_providers.${p}.env_key="${CODEX_GATEWAY_ENV_KEY}"`;
   const args = [
-    // 统一使用 CodeModeOnly，解决 Codex namespace tools 发现不及时的问题。
-    '-c', 'features.code_mode_only=true',
     '-c', `model_provider="${p}"`,
     '-c', `model_providers.${p}.name="Cindy Gateway"`,
     '-c', `model_providers.${p}.base_url="${baseUrl}"`,

--- a/apps/desktop/src/main/maker-host/codex-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/codex-proxy-host.ts
@@ -53,6 +53,7 @@ import {
   buildLocalHandlerHeaders,
   inferProviderIdForModel,
   isHostInjectedAuthSession,
+  isProviderRouteMutationInProgress,
   isUserProviderSession,
   getUserProviderIdForSession,
   readProviderOAuthToken,
@@ -2217,6 +2218,10 @@ export function createModelRoutingTransform(
       authInjection === 'oauth-bearer' ||
       isUserProviderSession(sessionId) ||
       isHostInjectedAuthSession(sessionId, 'codex') ||
+      // The catalog entry can disappear mid-mutation, making the other
+      // explicit-route predicates false. Keep the mutation's 503 fail-closed.
+      (explicitProviderId !== null &&
+        isProviderRouteMutationInProgress(explicitProviderId)) ||
       selectedUsesLocalBridge
     )) {
       if (selectedUsesLocalBridge && model) {

--- a/apps/desktop/src/main/maker-host/index.ts
+++ b/apps/desktop/src/main/maker-host/index.ts
@@ -234,6 +234,7 @@ import {
 } from './rehydrateCloseSuppression.js';
 import { hydrateSessionProvider } from './session-provider-store.js';
 import { prepareLocalCodexCredentialModeSwitch } from './codex-credential-switch.js';
+import { resolveCodexRouteCapabilities } from './provider-route.js';
 import { createDesktopOrcaTeamStoreAdapter } from './orcaTeamStoreAdapter.js';
 import { broadcastOrcaWorkerChanged } from './orcaWorkerBroadcast.js';
 import {
@@ -1281,6 +1282,8 @@ export function getMaker(): Maker {
       // 让 agent 按 id 回查 availableModels —— 那张表去重后 provider 归属已丢。
       resolveVerifiedContextWindow: (providerId, modelId) =>
         resolveVerifiedContextWindow(getDesktopSelectableCatalog(), 'codex', providerId, modelId),
+      resolveCodexRouteCapabilities: ({ providerId, model, credentialMode }) =>
+        resolveCodexRouteCapabilities({ providerId, model, credentialMode }),
       onCodexLocalModelsListed: (models) => {
         setDiscoveredCodexModels(mapCodexAppServerModelsToCatalog(models));
       },

--- a/apps/desktop/src/main/maker-host/index.ts
+++ b/apps/desktop/src/main/maker-host/index.ts
@@ -42,6 +42,7 @@ import type { MakerSessionCreateOpts } from '../maker-ipc/sessionRequest.js';
 import {
   dispatchInterAgentMessage,
   isSessionInTurn,
+  reconcileCodexRouteRebuildsAfterProviderChange,
   wireSessionToIpc,
 } from '../maker-ipc/register.js';
 import { MAKER_PUSH } from '../maker-ipc/channels.js';
@@ -289,6 +290,7 @@ let _codexModelBackfill: CodexModelBackfillCoordinator | null = null;
 
 /** Refresh selectable model capabilities, then notify every local/remote renderer. */
 function refreshSelectableModelsAndBroadcast(payload: Record<string, unknown>): void {
+  reconcileCodexRouteRebuildsAfterProviderChange();
   if (_maker) refreshCatalogDerivedModels(_maker, getDesktopSelectableCatalog());
   try {
     providerAccessRuntimeRefreshListener?.();

--- a/apps/desktop/src/main/maker-host/provider-route.ts
+++ b/apps/desktop/src/main/maker-host/provider-route.ts
@@ -511,6 +511,72 @@ export function providerRoutingServesWireModel(
 }
 
 /**
+ * Resolve route capabilities for a Codex thread from the same final-route
+ * inputs used by the proxy.  This deliberately returns a capability rather
+ * than inferring from provider ids: an explicit provider can decline a model
+ * via modelPrefixes, in which case the request falls back to the spawn
+ * default route.
+ */
+export async function resolveCodexRouteCapabilities(args: {
+  providerId?: string | null;
+  model: string;
+  credentialMode?: 'gateway-key' | 'oauth-bearer' | 'provider-oauth';
+}): Promise<{ requiresCodeModeOnly?: boolean } | undefined> {
+  const model = args.model.trim();
+  const providerId = args.providerId?.trim() || null;
+  let explicitRouteWasOutOfScope = false;
+
+  if (providerId) {
+    const provider = getActiveCatalog().providers.find((candidate) => candidate.id === providerId);
+    if (providerId === 'xd' && !getAppCapabilities().canUseCindyGateway) return undefined;
+    const routing = provider?.routing.codex;
+    if (isProviderRouteMutationInProgress(providerId)) return undefined;
+    if (routing?.disabled) return { requiresCodeModeOnly: false };
+    if (routing && routingServesWireModel(routing, model || undefined)) {
+      return { requiresCodeModeOnly: routing.requiresCodeModeOnly === true };
+    }
+    explicitRouteWasOutOfScope = routing !== null && routing !== undefined;
+  }
+
+  // The proxy resolves implicit Chat / Anthropic Messages routes from the
+  // connected ProviderView snapshot, not from catalog membership alone. Keep
+  // the capability decision on that same source so an implicit DeepSeek, GLM,
+  // or Anthropic bridge never inherits the spawn host's Gateway capability.
+  if (!providerId && model && hasImplicitLocalBridgeCandidate(model, 'codex')) {
+    const provider = await connectedDefaultProviderForModel(model.replace(/\[1m\]$/, ''), 'codex');
+    const routing = provider
+      ? providerRoutingForModel(provider, 'codex', model)
+      : null;
+    if (
+      routing?.wireProtocol === 'openai-chat'
+      || routing?.wireProtocol === 'anthropic-messages'
+    ) {
+      return { requiresCodeModeOnly: false };
+    }
+  }
+
+  // xAI and future uniquely namespaced provider-OAuth routes are handled
+  // before the default Gateway/ChatGPT branch even without a session provider.
+  const implicitProviderOAuth = uniqueProviderForModel(model, 'codex')?.routing.codex;
+  if (implicitProviderOAuth?.authStrategy === 'provider-oauth-header') {
+    return { requiresCodeModeOnly: implicitProviderOAuth.requiresCodeModeOnly === true };
+  }
+
+  // An explicit route that does not serve this model follows the same default
+  // route as codex-proxy-host: codex/* and gateway-key requests use Cindy
+  // Gateway; an out-of-scope provider-OAuth route also falls back there.
+  const usesCindyGateway = getAppCapabilities().canUseCindyGateway && (
+    args.credentialMode === 'gateway-key'
+    || model.startsWith('codex/')
+    || (explicitRouteWasOutOfScope && args.credentialMode === 'provider-oauth')
+  );
+  if (!usesCindyGateway) return undefined;
+  const gatewayRoute = getActiveCatalog().providers.find((p) => p.id === 'xd')?.routing.codex;
+  if (!gatewayRoute || gatewayRoute.disabled) return undefined;
+  return { requiresCodeModeOnly: gatewayRoute.requiresCodeModeOnly === true };
+}
+
+/**
  * 据某会话**显式选定的供应商**解析本次请求的路由决策。
  * 返回 null = 该会话未显式选供应商(或该供应商对此 agent 无路由,或本次请求的 wire model
  * 不在该路由声明的服务范围内)→ 调用方回落 decideXxxRoute / spawn 默认(no-break)。

--- a/apps/desktop/src/main/maker-host/provider-route.ts
+++ b/apps/desktop/src/main/maker-host/provider-route.ts
@@ -604,7 +604,9 @@ export async function resolveCodexRouteCapabilities(args: {
 
   // xAI and future uniquely namespaced provider-OAuth routes are handled
   // before the default Gateway/ChatGPT branch even without a session provider.
-  const implicitProviderOAuth = uniqueProviderForModel(model, 'codex')?.routing.codex;
+  const implicitProviderOAuth = providerId
+    ? undefined
+    : uniqueProviderForModel(model, 'codex')?.routing.codex;
   if (implicitProviderOAuth?.authStrategy === 'provider-oauth-header') {
     return { requiresCodeModeOnly: implicitProviderOAuth.requiresCodeModeOnly === true };
   }

--- a/apps/desktop/src/main/maker-host/provider-route.ts
+++ b/apps/desktop/src/main/maker-host/provider-route.ts
@@ -525,6 +525,7 @@ export async function resolveCodexRouteCapabilities(args: {
   const model = args.model.trim();
   const providerId = args.providerId?.trim() || null;
   let explicitRouteWasOutOfScope = false;
+  let explicitRouteWasIgnored = false;
 
   if (providerId) {
     const provider = getActiveCatalog().providers.find((candidate) => candidate.id === providerId);
@@ -533,7 +534,25 @@ export async function resolveCodexRouteCapabilities(args: {
     if (isProviderRouteMutationInProgress(providerId)) return undefined;
     if (routing?.disabled) return { requiresCodeModeOnly: false };
     if (routing && routingServesWireModel(routing, model || undefined)) {
-      return { requiresCodeModeOnly: routing.requiresCodeModeOnly === true };
+      // The proxy applies builtin per-session routes only for the OAuth spawn,
+      // host-injected auth, user providers, or local protocol bridges. An
+      // explicit builtin provider can therefore be present while env-key has
+      // already fallen back to the default Cindy Gateway route.
+      const routeUsesLocalBridge =
+        routing.wireProtocol === 'openai-chat'
+        || routing.wireProtocol === 'anthropic-messages';
+      const routeUsesHostInjectedAuth =
+        routing.authStrategy === 'provider-oauth-header'
+        || routing.authStrategy === 'oauth-token';
+      const explicitRouteApplies =
+        args.credentialMode === 'oauth-bearer'
+        || provider?.source === 'user'
+        || routeUsesLocalBridge
+        || routeUsesHostInjectedAuth;
+      if (explicitRouteApplies) {
+        return { requiresCodeModeOnly: routing.requiresCodeModeOnly === true };
+      }
+      explicitRouteWasIgnored = true;
     }
     explicitRouteWasOutOfScope = routing !== null && routing !== undefined;
   }
@@ -568,6 +587,7 @@ export async function resolveCodexRouteCapabilities(args: {
   const usesCindyGateway = getAppCapabilities().canUseCindyGateway && (
     args.credentialMode === 'gateway-key'
     || model.startsWith('codex/')
+    || explicitRouteWasIgnored
     || (explicitRouteWasOutOfScope && args.credentialMode === 'provider-oauth')
   );
   if (!usesCindyGateway) return undefined;

--- a/apps/desktop/src/main/maker-host/provider-route.ts
+++ b/apps/desktop/src/main/maker-host/provider-route.ts
@@ -544,8 +544,7 @@ export async function resolveCodexRouteCapabilities(args: {
     if (providerId === 'xd' && !getAppCapabilities().canUseCindyGateway) return undefined;
     const routing = provider?.routing.codex;
     if (isProviderRouteMutationInProgress(providerId)) return undefined;
-    if (routing?.disabled) return { requiresCodeModeOnly: false };
-    if (routing && routingServesWireModel(routing, model || undefined)) {
+    if (routing) {
       // The proxy applies builtin per-session routes only for the OAuth spawn,
       // host-injected auth, user providers, or local protocol bridges. An
       // explicit builtin provider can therefore be present while env-key has
@@ -556,15 +555,31 @@ export async function resolveCodexRouteCapabilities(args: {
       const routeUsesHostInjectedAuth =
         routing.authStrategy === 'provider-oauth-header'
         || routing.authStrategy === 'oauth-token';
-      const explicitRouteApplies =
-        args.credentialMode === 'oauth-bearer'
-        || provider?.source === 'user'
-        || routeUsesLocalBridge
-        || routeUsesHostInjectedAuth;
-      if (explicitRouteApplies) {
-        return { requiresCodeModeOnly: routing.requiresCodeModeOnly === true };
+      if (routing.disabled) {
+        // getSessionRoutingDescriptor filters disabled routes, so a builtin
+        // env-key route is ignored and the proxy falls through to its Gateway
+        // default. OAuth, user, and host-injected-auth sessions still enter
+        // resolveSessionRouteDecision and receive the explicit disabled-route
+        // error instead of falling through.
+        const disabledRouteIsIntercepted =
+          args.credentialMode === 'oauth-bearer'
+          || provider?.source === 'user'
+          || routeUsesHostInjectedAuth;
+        if (disabledRouteIsIntercepted) {
+          return { requiresCodeModeOnly: false };
+        }
+        explicitRouteWasIgnored = true;
+      } else if (routingServesWireModel(routing, model || undefined)) {
+        const explicitRouteApplies =
+          args.credentialMode === 'oauth-bearer'
+          || provider?.source === 'user'
+          || routeUsesLocalBridge
+          || routeUsesHostInjectedAuth;
+        if (explicitRouteApplies) {
+          return { requiresCodeModeOnly: routing.requiresCodeModeOnly === true };
+        }
+        explicitRouteWasIgnored = true;
       }
-      explicitRouteWasIgnored = true;
     }
     explicitRouteWasOutOfScope = routing !== null && routing !== undefined;
   }

--- a/apps/desktop/src/main/maker-host/provider-route.ts
+++ b/apps/desktop/src/main/maker-host/provider-route.ts
@@ -561,8 +561,9 @@ export async function resolveCodexRouteCapabilities(args: {
   // connected ProviderView snapshot, not from catalog membership alone. Keep
   // the capability decision on that same source so an implicit DeepSeek, GLM,
   // or Anthropic bridge never inherits the spawn host's Gateway capability.
-  if (!providerId && model && hasImplicitLocalBridgeCandidate(model, 'codex')) {
-    const provider = await connectedDefaultProviderForModel(model.replace(/\[1m\]$/, ''), 'codex');
+  const catalogModel = model.replace(/\[1m\]$/, '');
+  if (!providerId && catalogModel && hasImplicitLocalBridgeCandidate(catalogModel, 'codex')) {
+    const provider = await connectedDefaultProviderForModel(catalogModel, 'codex');
     const routing = provider
       ? providerRoutingForModel(provider, 'codex', model)
       : null;

--- a/apps/desktop/src/main/maker-host/provider-route.ts
+++ b/apps/desktop/src/main/maker-host/provider-route.ts
@@ -576,9 +576,15 @@ export async function resolveCodexRouteCapabilities(args: {
           || routeUsesLocalBridge
           || routeUsesHostInjectedAuth;
         if (explicitRouteApplies) {
-          return { requiresCodeModeOnly: routing.requiresCodeModeOnly === true };
+          // An OAuth host can only take an explicit gateway-key route when the
+          // proxy can replace its subscription bearer with the live Gateway key.
+          // Without that key, the proxy falls through to its spawn-default route.
+          if (routing.authStrategy !== 'gateway-key' || gatewayKeyReader()) {
+            return { requiresCodeModeOnly: routing.requiresCodeModeOnly === true };
+          }
+        } else {
+          explicitRouteWasIgnored = true;
         }
-        explicitRouteWasIgnored = true;
       }
     }
     explicitRouteWasOutOfScope = routing !== null && routing !== undefined;

--- a/apps/desktop/src/main/maker-host/provider-route.ts
+++ b/apps/desktop/src/main/maker-host/provider-route.ts
@@ -49,6 +49,7 @@ import { getSessionProvider } from './session-provider-store.js';
 type CustomProviderKeyReader = (providerId: string, agent: AgentKind) => string | null;
 let customProviderKeyReader: CustomProviderKeyReader = () => null;
 const providerRouteMutationCounts = new Map<string, number>();
+let providerRouteMutationGeneration = 0;
 
 /** host 启动期接通真实 safeStorage 读取（按 `provider_key_<id>_<agent>`，per-runtime 独立密钥）。 */
 export function setCustomProviderKeyReader(reader: CustomProviderKeyReader): void {
@@ -64,6 +65,7 @@ export function setCustomProviderKeyReader(reader: CustomProviderKeyReader): voi
  */
 export function beginProviderRouteMutation(providerId: string): () => void {
   providerId = runtimeCustomProviderId(providerId);
+  providerRouteMutationGeneration += 1;
   providerRouteMutationCounts.set(
     providerId,
     (providerRouteMutationCounts.get(providerId) ?? 0) + 1,
@@ -80,6 +82,16 @@ export function beginProviderRouteMutation(providerId: string): () => void {
 
 export function isProviderRouteMutationInProgress(providerId: string): boolean {
   return providerRouteMutationCounts.has(runtimeCustomProviderId(providerId));
+}
+
+/** True while any Provider config/credential route is between its old and new snapshots. */
+export function hasAnyProviderRouteMutationInProgress(): boolean {
+  return providerRouteMutationCounts.size > 0;
+}
+
+/** Monotonic token used to discard capability reads that overlap any Provider mutation. */
+export function getProviderRouteMutationGeneration(): number {
+  return providerRouteMutationGeneration;
 }
 
 /**

--- a/apps/desktop/src/main/maker-ipc/__tests__/codexRouteRebuild.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/codexRouteRebuild.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  CodexRouteRebuildService,
+  type CodexRouteRebuildSession,
+} from '../codexRouteRebuild.js';
+
+function createHarness(initialSessions: CodexRouteRebuildSession[]) {
+  const sessions = [...initialSessions];
+  let currentRequiresCodeModeOnly = false;
+  let reconciliationBlocked = false;
+  const closeSession = vi.fn(async (sessionId: string) => {
+    const index = sessions.findIndex((session) => session.id === sessionId);
+    if (index >= 0) sessions.splice(index, 1);
+  });
+  const onApplied = vi.fn();
+  const service = new CodexRouteRebuildService({
+    maker: {
+      listActiveSessions: () => sessions,
+      closeSession,
+    },
+    isReconciliationBlocked: () => reconciliationBlocked,
+    resolveRequiresCodeModeOnly: async () => currentRequiresCodeModeOnly,
+    onApplied,
+    retryDelayMs: 60_000,
+  });
+  return {
+    service,
+    sessions,
+    closeSession,
+    onApplied,
+    setCurrentRequiresCodeModeOnly(value: boolean) {
+      currentRequiresCodeModeOnly = value;
+    },
+    setReconciliationBlocked(value: boolean) {
+      reconciliationBlocked = value;
+    },
+  };
+}
+
+function localCodex(
+  id: string,
+  frozen: boolean,
+  isTurnRunning: () => boolean = () => false,
+): CodexRouteRebuildSession {
+  return {
+    id,
+    instanceId: `${id}-instance`,
+    agentKind: 'codex',
+    remoteHostId: null,
+    model: 'codex/gpt-5.5',
+    codexRouteRequiresCodeModeOnly: frozen,
+    isTurnRunning,
+  };
+}
+
+describe('CodexRouteRebuildService', () => {
+  it('keeps an idle session when the live catalog capability is unchanged', async () => {
+    const h = createHarness([localCodex('same', false)]);
+
+    await h.service.reconcile(1);
+
+    expect(h.closeSession).not.toHaveBeenCalled();
+    expect(h.service.has('same')).toBe(false);
+  });
+
+  it.each([
+    { frozen: false, current: true },
+    { frozen: true, current: false },
+  ])('closes an idle local Codex session across $frozen -> $current', async ({ frozen, current }) => {
+    const h = createHarness([localCodex('idle', frozen)]);
+    h.setCurrentRequiresCodeModeOnly(current);
+
+    await h.service.reconcile(2);
+
+    expect(h.closeSession).toHaveBeenCalledWith('idle');
+    expect(h.service.has('idle')).toBe(false);
+    expect(h.onApplied).toHaveBeenCalledWith('idle');
+  });
+
+  it('gates a busy session and closes it after the turn settles', async () => {
+    let running = true;
+    const h = createHarness([localCodex('busy', false, () => running)]);
+    h.setCurrentRequiresCodeModeOnly(true);
+
+    await h.service.reconcile(3);
+    expect(h.service.has('busy')).toBe(true);
+    expect(h.closeSession).not.toHaveBeenCalled();
+
+    running = false;
+    await h.service.onTurnSettled('busy');
+
+    expect(h.closeSession).toHaveBeenCalledWith('busy');
+    expect(h.service.has('busy')).toBe(false);
+    expect(h.onApplied).toHaveBeenCalledWith('busy');
+  });
+
+  it('keeps a pending rebuild queue-gated while a Provider route mutation is active', async () => {
+    let running = true;
+    const h = createHarness([localCodex('mutation-pending', false, () => running)]);
+    h.setCurrentRequiresCodeModeOnly(true);
+    await h.service.reconcile(4);
+    expect(h.service.has('mutation-pending')).toBe(true);
+
+    running = false;
+    h.setReconciliationBlocked(true);
+    await h.service.onTurnSettled('mutation-pending');
+    expect(h.closeSession).not.toHaveBeenCalled();
+    expect(h.service.has('mutation-pending')).toBe(true);
+
+    h.setReconciliationBlocked(false);
+    await h.service.onTurnSettled('mutation-pending');
+    expect(h.closeSession).toHaveBeenCalledWith('mutation-pending');
+    expect(h.service.has('mutation-pending')).toBe(false);
+  });
+
+  it('discards an async capability snapshot if a Provider mutation starts while resolving', async () => {
+    const sessions = [localCodex('mutation-race', false)];
+    let blocked = false;
+    let finishResolve!: (value: boolean) => void;
+    const closeSession = vi.fn(async () => {});
+    const service = new CodexRouteRebuildService({
+      maker: {
+        listActiveSessions: () => sessions,
+        closeSession,
+      },
+      isReconciliationBlocked: () => blocked,
+      resolveRequiresCodeModeOnly: () =>
+        new Promise<boolean>((resolve) => {
+          finishResolve = resolve;
+        }),
+      retryDelayMs: 60_000,
+    });
+
+    const reconcile = service.reconcile(5);
+    await vi.waitFor(() => expect(finishResolve).toBeTypeOf('function'));
+    blocked = true;
+    finishResolve(true);
+    await reconcile;
+
+    expect(closeSession).not.toHaveBeenCalled();
+    expect(service.has('mutation-race')).toBe(false);
+  });
+
+  it('keeps pending when a Provider mutation starts and finishes during revalidation', async () => {
+    let running = true;
+    let generation = 0;
+    let resolveCount = 0;
+    let finishRevalidation!: (value: boolean) => void;
+    const sessions = [localCodex('transient-mutation', false, () => running)];
+    const closeSession = vi.fn(async () => {});
+    const service = new CodexRouteRebuildService({
+      maker: {
+        listActiveSessions: () => sessions,
+        closeSession,
+      },
+      getReconciliationGeneration: () => generation,
+      resolveRequiresCodeModeOnly: () => {
+        resolveCount += 1;
+        if (resolveCount <= 2 || resolveCount > 3) return Promise.resolve(true);
+        return new Promise<boolean>((resolve) => {
+          finishRevalidation = resolve;
+        });
+      },
+      retryDelayMs: 60_000,
+    });
+
+    await service.reconcile(6);
+    expect(service.has('transient-mutation')).toBe(true);
+    running = false;
+
+    const settle = service.onTurnSettled('transient-mutation');
+    await vi.waitFor(() => expect(finishRevalidation).toBeTypeOf('function'));
+    generation += 1;
+    finishRevalidation(true);
+    await settle;
+
+    expect(closeSession).not.toHaveBeenCalled();
+    expect(service.has('transient-mutation')).toBe(true);
+
+    await service.onTurnSettled('transient-mutation');
+    expect(closeSession).toHaveBeenCalledWith('transient-mutation');
+    expect(service.has('transient-mutation')).toBe(false);
+  });
+
+  it('claims one close when duplicate settle signals finish revalidation together', async () => {
+    let running = true;
+    const h = createHarness([localCodex('duplicate-settle', false, () => running)]);
+    h.setCurrentRequiresCodeModeOnly(true);
+    await h.service.reconcile(7);
+    running = false;
+
+    await Promise.all([
+      h.service.onTurnSettled('duplicate-settle'),
+      h.service.onTurnSettled('duplicate-settle'),
+    ]);
+
+    expect(h.closeSession).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancels a pending rebuild when a later catalog revision restores the frozen value', async () => {
+    let running = true;
+    const h = createHarness([localCodex('reverted', false, () => running)]);
+    h.setCurrentRequiresCodeModeOnly(true);
+    await h.service.reconcile(8);
+    expect(h.service.has('reverted')).toBe(true);
+
+    h.setCurrentRequiresCodeModeOnly(false);
+    await h.service.reconcile(9);
+    running = false;
+
+    expect(h.service.has('reverted')).toBe(false);
+    expect(h.closeSession).not.toHaveBeenCalled();
+    expect(h.onApplied).toHaveBeenCalledWith('reverted');
+  });
+
+  it('ignores remote Codex sessions', async () => {
+    const remote = {
+      ...localCodex('remote', false),
+      remoteHostId: 'ssh-host',
+    };
+    const h = createHarness([remote]);
+    h.setCurrentRequiresCodeModeOnly(true);
+
+    await h.service.reconcile(10);
+
+    expect(h.closeSession).not.toHaveBeenCalled();
+    expect(h.service.has('remote')).toBe(false);
+  });
+});

--- a/apps/desktop/src/main/maker-ipc/__tests__/codexRouteRebuild.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/codexRouteRebuild.test.ts
@@ -5,6 +5,14 @@ import {
   type CodexRouteRebuildSession,
 } from '../codexRouteRebuild.js';
 
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
 function createHarness(initialSessions: CodexRouteRebuildSession[]) {
   const sessions = [...initialSessions];
   let currentRequiresCodeModeOnly = false;
@@ -196,6 +204,44 @@ describe('CodexRouteRebuildService', () => {
     ]);
 
     expect(h.closeSession).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not wake the queue when a Provider mutation overlaps session close', async () => {
+    let routeGeneration = 0;
+    const sessions = [localCodex('close-mutation-race', false)];
+    const closeBarrier = deferred<void>();
+    const closeSession = vi.fn(async (sessionId: string) => {
+      const index = sessions.findIndex((session) => session.id === sessionId);
+      if (index >= 0) sessions.splice(index, 1);
+      await closeBarrier.promise;
+    });
+    const onApplied = vi.fn();
+    const service = new CodexRouteRebuildService({
+      maker: {
+        listActiveSessions: () => sessions,
+        closeSession,
+      },
+      getReconciliationGeneration: () => routeGeneration,
+      resolveRequiresCodeModeOnly: async () => true,
+      onApplied,
+      retryDelayMs: 60_000,
+    });
+
+    const firstReconcile = service.reconcile(11);
+    await vi.waitFor(() => expect(closeSession).toHaveBeenCalledWith('close-mutation-race'));
+
+    routeGeneration += 1;
+    await service.reconcile(12);
+    expect(onApplied).not.toHaveBeenCalled();
+
+    closeBarrier.resolve();
+    await firstReconcile;
+    expect(service.has('close-mutation-race')).toBe(true);
+    expect(onApplied).not.toHaveBeenCalled();
+
+    await service.onTurnSettled('close-mutation-race');
+    expect(service.has('close-mutation-race')).toBe(false);
+    expect(onApplied).toHaveBeenCalledWith('close-mutation-race');
   });
 
   it('cancels a pending rebuild when a later catalog revision restores the frozen value', async () => {

--- a/apps/desktop/src/main/maker-ipc/__tests__/codexRouteRebuild.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/codexRouteRebuild.test.ts
@@ -233,7 +233,7 @@ describe('CodexRouteRebuildService', () => {
     expect(h.onApplied).toHaveBeenCalledWith('busy');
   });
 
-  it('gates candidate sessions before all asynchronous route comparisons settle', async () => {
+  it('interrupts a confirmed busy route change before slower comparisons settle', async () => {
     let running = true;
     const sessions = [
       localCodex('busy-fast', false, () => running),
@@ -258,12 +258,12 @@ describe('CodexRouteRebuildService', () => {
     await vi.waitFor(() => expect(service.has('slow-lookup')).toBe(true));
 
     expect(service.has('busy-fast')).toBe(true);
-    expect(abortSession).not.toHaveBeenCalled();
+    await vi.waitFor(() => expect(abortSession).toHaveBeenCalledWith('busy-fast'));
 
     slowLookup.resolve(false);
     await reconcile;
 
-    expect(abortSession).toHaveBeenCalledWith('busy-fast');
+    expect(abortSession).toHaveBeenCalledTimes(1);
     running = false;
     await service.onTurnSettled('busy-fast');
   });
@@ -353,6 +353,12 @@ describe('CodexRouteRebuildService', () => {
     // The interrupted thread is closed immediately so direct send paths cannot
     // reuse it, but the queue remains gated until the route mutation commits.
     expect(h.closeSession).toHaveBeenCalledWith('mutation-pending');
+    expect(h.service.has('mutation-pending')).toBe(true);
+    expect(h.onApplied).not.toHaveBeenCalled();
+
+    // A close notification/retry while the mutation is still active must not
+    // release the queue merely because the old session is already absent.
+    await h.service.onTurnSettled('mutation-pending');
     expect(h.service.has('mutation-pending')).toBe(true);
     expect(h.onApplied).not.toHaveBeenCalled();
 

--- a/apps/desktop/src/main/maker-ipc/__tests__/codexRouteRebuild.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/codexRouteRebuild.test.ts
@@ -110,6 +110,40 @@ describe('CodexRouteRebuildService', () => {
     expect(h.onApplied).toHaveBeenCalledWith('busy');
   });
 
+  it('gates candidate sessions before all asynchronous route comparisons settle', async () => {
+    let running = true;
+    const sessions = [
+      localCodex('busy-fast', false, () => running),
+      localCodex('slow-lookup', false),
+    ];
+    const slowLookup = deferred<boolean>();
+    const abortSession = vi.fn(async () => {});
+    const closeSession = vi.fn(async () => {});
+    const service = new CodexRouteRebuildService({
+      maker: {
+        listActiveSessions: () => sessions,
+        closeSession,
+      },
+      abortSession,
+      resolveRequiresCodeModeOnly: (session) =>
+        session.id === 'slow-lookup' ? slowLookup.promise : Promise.resolve(true),
+      retryDelayMs: 60_000,
+    });
+
+    const reconcile = service.reconcile(4);
+    await vi.waitFor(() => expect(service.has('slow-lookup')).toBe(true));
+
+    expect(service.has('busy-fast')).toBe(true);
+    expect(abortSession).not.toHaveBeenCalled();
+
+    slowLookup.resolve(false);
+    await reconcile;
+
+    expect(abortSession).toHaveBeenCalledWith('busy-fast');
+    running = false;
+    await service.onTurnSettled('busy-fast');
+  });
+
   it('keeps the queue gated if the terminal signal arrives before abort settles', async () => {
     let running = true;
     const sessions = [localCodex('abort-terminal-race', false, () => running)];
@@ -168,7 +202,7 @@ describe('CodexRouteRebuildService', () => {
     expect(h.onApplied).toHaveBeenCalledWith('mutation-pending');
   });
 
-  it('discards an async capability snapshot if a Provider mutation starts while resolving', async () => {
+  it('keeps the session gated when a Provider mutation invalidates an async snapshot', async () => {
     const sessions = [localCodex('mutation-race', false)];
     let blocked = false;
     let finishResolve!: (value: boolean) => void;
@@ -194,7 +228,7 @@ describe('CodexRouteRebuildService', () => {
     await reconcile;
 
     expect(closeSession).not.toHaveBeenCalled();
-    expect(service.has('mutation-race')).toBe(false);
+    expect(service.has('mutation-race')).toBe(true);
   });
 
   it('retries abort after a concurrent reconciliation updates the pending revision', async () => {

--- a/apps/desktop/src/main/maker-ipc/__tests__/codexRouteRebuild.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/codexRouteRebuild.test.ts
@@ -21,12 +21,14 @@ function createHarness(initialSessions: CodexRouteRebuildSession[]) {
     const index = sessions.findIndex((session) => session.id === sessionId);
     if (index >= 0) sessions.splice(index, 1);
   });
+  const abortSession = vi.fn(async () => {});
   const onApplied = vi.fn();
   const service = new CodexRouteRebuildService({
     maker: {
       listActiveSessions: () => sessions,
       closeSession,
     },
+    abortSession,
     isReconciliationBlocked: () => reconciliationBlocked,
     resolveRequiresCodeModeOnly: async () => currentRequiresCodeModeOnly,
     onApplied,
@@ -36,6 +38,7 @@ function createHarness(initialSessions: CodexRouteRebuildSession[]) {
     service,
     sessions,
     closeSession,
+    abortSession,
     onApplied,
     setCurrentRequiresCodeModeOnly(value: boolean) {
       currentRequiresCodeModeOnly = value;
@@ -86,14 +89,18 @@ describe('CodexRouteRebuildService', () => {
     expect(h.onApplied).toHaveBeenCalledWith('idle');
   });
 
-  it('gates a busy session and closes it after the turn settles', async () => {
+  it('interrupts a busy turn once, then closes after the terminal boundary', async () => {
     let running = true;
     const h = createHarness([localCodex('busy', false, () => running)]);
     h.setCurrentRequiresCodeModeOnly(true);
 
     await h.service.reconcile(3);
     expect(h.service.has('busy')).toBe(true);
+    expect(h.abortSession).toHaveBeenCalledWith('busy');
     expect(h.closeSession).not.toHaveBeenCalled();
+
+    await h.service.reconcile(4);
+    expect(h.abortSession).toHaveBeenCalledTimes(1);
 
     running = false;
     await h.service.onTurnSettled('busy');
@@ -101,6 +108,42 @@ describe('CodexRouteRebuildService', () => {
     expect(h.closeSession).toHaveBeenCalledWith('busy');
     expect(h.service.has('busy')).toBe(false);
     expect(h.onApplied).toHaveBeenCalledWith('busy');
+  });
+
+  it('keeps the queue gated if the terminal signal arrives before abort settles', async () => {
+    let running = true;
+    const sessions = [localCodex('abort-terminal-race', false, () => running)];
+    const abortBarrier = deferred<void>();
+    const abortSession = vi.fn(async () => abortBarrier.promise);
+    const closeSession = vi.fn(async () => {
+      sessions.splice(0, 1);
+    });
+    const onApplied = vi.fn();
+    const service = new CodexRouteRebuildService({
+      maker: {
+        listActiveSessions: () => sessions,
+        closeSession,
+      },
+      abortSession,
+      resolveRequiresCodeModeOnly: async () => true,
+      onApplied,
+      retryDelayMs: 60_000,
+    });
+
+    const reconcile = service.reconcile(4);
+    await vi.waitFor(() => expect(abortSession).toHaveBeenCalledWith('abort-terminal-race'));
+
+    running = false;
+    await service.onTurnSettled('abort-terminal-race');
+    expect(closeSession).not.toHaveBeenCalled();
+    expect(service.has('abort-terminal-race')).toBe(true);
+
+    abortBarrier.resolve();
+    await reconcile;
+
+    expect(closeSession).toHaveBeenCalledWith('abort-terminal-race');
+    expect(service.has('abort-terminal-race')).toBe(false);
+    expect(onApplied).toHaveBeenCalledWith('abort-terminal-race');
   });
 
   it('keeps a pending rebuild queue-gated while a Provider route mutation is active', async () => {
@@ -113,13 +156,16 @@ describe('CodexRouteRebuildService', () => {
     running = false;
     h.setReconciliationBlocked(true);
     await h.service.onTurnSettled('mutation-pending');
-    expect(h.closeSession).not.toHaveBeenCalled();
+    // The interrupted thread is closed immediately so direct send paths cannot
+    // reuse it, but the queue remains gated until the route mutation commits.
+    expect(h.closeSession).toHaveBeenCalledWith('mutation-pending');
     expect(h.service.has('mutation-pending')).toBe(true);
+    expect(h.onApplied).not.toHaveBeenCalled();
 
     h.setReconciliationBlocked(false);
     await h.service.onTurnSettled('mutation-pending');
-    expect(h.closeSession).toHaveBeenCalledWith('mutation-pending');
     expect(h.service.has('mutation-pending')).toBe(false);
+    expect(h.onApplied).toHaveBeenCalledWith('mutation-pending');
   });
 
   it('discards an async capability snapshot if a Provider mutation starts while resolving', async () => {
@@ -132,6 +178,7 @@ describe('CodexRouteRebuildService', () => {
         listActiveSessions: () => sessions,
         closeSession,
       },
+      abortSession: vi.fn(async () => {}),
       isReconciliationBlocked: () => blocked,
       resolveRequiresCodeModeOnly: () =>
         new Promise<boolean>((resolve) => {
@@ -150,45 +197,46 @@ describe('CodexRouteRebuildService', () => {
     expect(service.has('mutation-race')).toBe(false);
   });
 
-  it('keeps pending when a Provider mutation starts and finishes during revalidation', async () => {
+  it('retries abort after a concurrent reconciliation updates the pending revision', async () => {
     let running = true;
-    let generation = 0;
-    let resolveCount = 0;
-    let finishRevalidation!: (value: boolean) => void;
-    const sessions = [localCodex('transient-mutation', false, () => running)];
-    const closeSession = vi.fn(async () => {});
+    let rejectFirstAbort!: (reason?: unknown) => void;
+    const firstAbort = new Promise<void>((_resolve, reject) => {
+      rejectFirstAbort = reject;
+    });
+    const sessions = [localCodex('abort-retry', false, () => running)];
+    const closeSession = vi.fn(async () => {
+      sessions.splice(0, 1);
+    });
+    const abortSession = vi
+      .fn<() => Promise<void>>()
+      .mockImplementationOnce(() => firstAbort)
+      .mockImplementationOnce(async () => {
+        running = false;
+      });
     const service = new CodexRouteRebuildService({
       maker: {
         listActiveSessions: () => sessions,
         closeSession,
       },
-      getReconciliationGeneration: () => generation,
-      resolveRequiresCodeModeOnly: () => {
-        resolveCount += 1;
-        if (resolveCount <= 2 || resolveCount > 3) return Promise.resolve(true);
-        return new Promise<boolean>((resolve) => {
-          finishRevalidation = resolve;
-        });
-      },
+      abortSession,
+      resolveRequiresCodeModeOnly: async () => true,
       retryDelayMs: 60_000,
     });
 
-    await service.reconcile(6);
-    expect(service.has('transient-mutation')).toBe(true);
-    running = false;
+    const firstReconcile = service.reconcile(6);
+    await vi.waitFor(() => expect(abortSession).toHaveBeenCalledTimes(1));
+    await service.reconcile(7);
 
-    const settle = service.onTurnSettled('transient-mutation');
-    await vi.waitFor(() => expect(finishRevalidation).toBeTypeOf('function'));
-    generation += 1;
-    finishRevalidation(true);
-    await settle;
-
+    rejectFirstAbort(new Error('abort failed'));
+    await firstReconcile;
+    expect(service.has('abort-retry')).toBe(true);
     expect(closeSession).not.toHaveBeenCalled();
-    expect(service.has('transient-mutation')).toBe(true);
 
-    await service.onTurnSettled('transient-mutation');
-    expect(closeSession).toHaveBeenCalledWith('transient-mutation');
-    expect(service.has('transient-mutation')).toBe(false);
+    await service.onTurnSettled('abort-retry');
+
+    expect(abortSession).toHaveBeenCalledTimes(2);
+    expect(closeSession).toHaveBeenCalledWith('abort-retry');
+    expect(service.has('abort-retry')).toBe(false);
   });
 
   it('claims one close when duplicate settle signals finish revalidation together', async () => {
@@ -221,6 +269,7 @@ describe('CodexRouteRebuildService', () => {
         listActiveSessions: () => sessions,
         closeSession,
       },
+      abortSession: vi.fn(async () => {}),
       getReconciliationGeneration: () => routeGeneration,
       resolveRequiresCodeModeOnly: async () => true,
       onApplied,
@@ -244,20 +293,41 @@ describe('CodexRouteRebuildService', () => {
     expect(onApplied).toHaveBeenCalledWith('close-mutation-race');
   });
 
-  it('cancels a pending rebuild when a later catalog revision restores the frozen value', async () => {
+  it('does not release an interrupted session when a later catalog revision restores the frozen value', async () => {
     let running = true;
-    const h = createHarness([localCodex('reverted', false, () => running)]);
-    h.setCurrentRequiresCodeModeOnly(true);
-    await h.service.reconcile(8);
-    expect(h.service.has('reverted')).toBe(true);
+    const sessions = [localCodex('reverted', false, () => running)];
+    let currentRequiresCodeModeOnly = true;
+    const abortBarrier = deferred<void>();
+    const abortSession = vi.fn(async () => abortBarrier.promise);
+    const closeSession = vi.fn(async () => {});
+    const onApplied = vi.fn();
+    const service = new CodexRouteRebuildService({
+      maker: {
+        listActiveSessions: () => sessions,
+        closeSession,
+      },
+      abortSession,
+      resolveRequiresCodeModeOnly: async () => currentRequiresCodeModeOnly,
+      onApplied,
+      retryDelayMs: 60_000,
+    });
 
-    h.setCurrentRequiresCodeModeOnly(false);
-    await h.service.reconcile(9);
+    const firstReconcile = service.reconcile(8);
+    await vi.waitFor(() => expect(abortSession).toHaveBeenCalledWith('reverted'));
+    expect(service.has('reverted')).toBe(true);
+
+    currentRequiresCodeModeOnly = false;
+    await service.reconcile(9);
+    expect(service.has('reverted')).toBe(true);
+    expect(onApplied).not.toHaveBeenCalled();
+
     running = false;
+    abortBarrier.resolve();
+    await firstReconcile;
 
-    expect(h.service.has('reverted')).toBe(false);
-    expect(h.closeSession).not.toHaveBeenCalled();
-    expect(h.onApplied).toHaveBeenCalledWith('reverted');
+    expect(service.has('reverted')).toBe(false);
+    expect(closeSession).toHaveBeenCalledWith('reverted');
+    expect(onApplied).toHaveBeenCalledWith('reverted');
   });
 
   it('ignores remote Codex sessions', async () => {

--- a/apps/desktop/src/main/maker-ipc/__tests__/codexRouteRebuild.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/codexRouteRebuild.test.ts
@@ -4,6 +4,7 @@ import {
   CodexRouteRebuildService,
   type CodexRouteRebuildSession,
 } from '../codexRouteRebuild.js';
+import { CodexThreadRotationSupersededError } from '../codexThreadRotation.js';
 
 function deferred<T>() {
   let resolve!: (value: T | PromiseLike<T>) => void;
@@ -119,6 +120,31 @@ describe('CodexRouteRebuildService', () => {
     expect(prepareCodexThreadRotation.mock.invocationCallOrder[0]).toBeLessThan(
       closeSession.mock.invocationCallOrder[0],
     );
+  });
+
+  it('retires a stale catalog rebuild when a newer lifecycle owns the thread binding', async () => {
+    const sessions = [localCodex('rotation-superseded', false)];
+    const prepareCodexThreadRotation = vi.fn(async () => {
+      throw new CodexThreadRotationSupersededError('rotation-superseded');
+    });
+    const onApplied = vi.fn();
+    const service = new CodexRouteRebuildService({
+      maker: {
+        listActiveSessions: () => sessions,
+        closeSession: vi.fn(async () => undefined),
+      },
+      abortSession: vi.fn(async () => undefined),
+      resolveRequiresCodeModeOnly: async () => true,
+      prepareCodexThreadRotation,
+      onApplied,
+      retryDelayMs: 60_000,
+    });
+
+    await service.reconcile(2);
+
+    expect(prepareCodexThreadRotation).toHaveBeenCalledTimes(1);
+    expect(service.has('rotation-superseded')).toBe(false);
+    expect(onApplied).toHaveBeenCalledWith('rotation-superseded');
   });
 
   it('interrupts a busy turn once, then closes after the terminal boundary', async () => {

--- a/apps/desktop/src/main/maker-ipc/__tests__/codexRouteRebuild.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/codexRouteRebuild.test.ts
@@ -60,6 +60,9 @@ function localCodex(
     agentKind: 'codex',
     remoteHostId: null,
     model: 'codex/gpt-5.5',
+    sdkSessionId: `thread-${id}`,
+    workDir: '/work',
+    providerId: 'xd',
     codexRouteRequiresCodeModeOnly: frozen,
     isTurnRunning,
   };
@@ -87,6 +90,35 @@ describe('CodexRouteRebuildService', () => {
     expect(h.closeSession).toHaveBeenCalledWith('idle');
     expect(h.service.has('idle')).toBe(false);
     expect(h.onApplied).toHaveBeenCalledWith('idle');
+  });
+
+  it('rotates the native thread before an idle catalog rebuild', async () => {
+    const sessions = [localCodex('rotate', false)];
+    const closeSession = vi.fn(async () => {
+      sessions.splice(0, 1);
+    });
+    const prepareCodexThreadRotation = vi.fn(async () => ({
+      newSdkSessionId: 'thread-rotate-new',
+      rollback: vi.fn(async () => undefined),
+    }));
+    const service = new CodexRouteRebuildService({
+      maker: { listActiveSessions: () => sessions, closeSession },
+      abortSession: vi.fn(async () => undefined),
+      resolveRequiresCodeModeOnly: async () => true,
+      prepareCodexThreadRotation,
+      retryDelayMs: 60_000,
+    });
+
+    await service.reconcile(2);
+
+    expect(prepareCodexThreadRotation).toHaveBeenCalledWith(expect.objectContaining({
+      sessionId: 'rotate',
+      sourceSdkSessionId: 'thread-rotate',
+      sourceProviderId: 'xd',
+    }));
+    expect(prepareCodexThreadRotation.mock.invocationCallOrder[0]).toBeLessThan(
+      closeSession.mock.invocationCallOrder[0],
+    );
   });
 
   it('interrupts a busy turn once, then closes after the terminal boundary', async () => {
@@ -142,6 +174,40 @@ describe('CodexRouteRebuildService', () => {
     expect(abortSession).toHaveBeenCalledWith('busy-fast');
     running = false;
     await service.onTurnSettled('busy-fast');
+  });
+
+  it('does not rotate when an unrelated close races an unchanged catalog comparison', async () => {
+    const sessions = [localCodex('close-before-compare', false)];
+    const lookup = deferred<boolean>();
+    const prepareCodexThreadRotation = vi.fn(async () => ({
+      newSdkSessionId: 'thread-close-before-compare-new',
+      rollback: vi.fn(async () => undefined),
+    }));
+    const onApplied = vi.fn();
+    const service = new CodexRouteRebuildService({
+      maker: {
+        listActiveSessions: () => sessions,
+        closeSession: vi.fn(async () => undefined),
+      },
+      abortSession: vi.fn(async () => undefined),
+      resolveRequiresCodeModeOnly: () => lookup.promise,
+      prepareCodexThreadRotation,
+      onApplied,
+      retryDelayMs: 60_000,
+    });
+
+    const reconcile = service.reconcile(4);
+    await vi.waitFor(() => expect(service.has('close-before-compare')).toBe(true));
+    sessions.splice(0, 1);
+    service.onSessionClosed('close-before-compare');
+
+    expect(prepareCodexThreadRotation).not.toHaveBeenCalled();
+    lookup.resolve(false);
+    await reconcile;
+
+    expect(prepareCodexThreadRotation).not.toHaveBeenCalled();
+    expect(service.has('close-before-compare')).toBe(false);
+    expect(onApplied).toHaveBeenCalledWith('close-before-compare');
   });
 
   it('keeps the queue gated if the terminal signal arrives before abort settles', async () => {

--- a/apps/desktop/src/main/maker-ipc/__tests__/codexRouteRebuild.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/codexRouteRebuild.test.ts
@@ -14,6 +14,25 @@ function deferred<T>() {
   return { promise, resolve };
 }
 
+const runWithoutSessionLock = <T>(_sessionId: string, task: () => Promise<T>): Promise<T> => task();
+
+function createSessionLock() {
+  let tail = Promise.resolve();
+  return async <T>(_sessionId: string, task: () => Promise<T>): Promise<T> => {
+    const previous = tail;
+    let release!: () => void;
+    tail = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await previous;
+    try {
+      return await task();
+    } finally {
+      release();
+    }
+  };
+}
+
 function createHarness(initialSessions: CodexRouteRebuildSession[]) {
   const sessions = [...initialSessions];
   let currentRequiresCodeModeOnly = false;
@@ -30,6 +49,7 @@ function createHarness(initialSessions: CodexRouteRebuildSession[]) {
       closeSession,
     },
     abortSession,
+    withSessionLock: runWithoutSessionLock,
     isReconciliationBlocked: () => reconciliationBlocked,
     resolveRequiresCodeModeOnly: async () => currentRequiresCodeModeOnly,
     onApplied,
@@ -105,6 +125,7 @@ describe('CodexRouteRebuildService', () => {
     const service = new CodexRouteRebuildService({
       maker: { listActiveSessions: () => sessions, closeSession },
       abortSession: vi.fn(async () => undefined),
+      withSessionLock: runWithoutSessionLock,
       resolveRequiresCodeModeOnly: async () => true,
       prepareCodexThreadRotation,
       retryDelayMs: 60_000,
@@ -122,6 +143,49 @@ describe('CodexRouteRebuildService', () => {
     );
   });
 
+  it('holds the session route lock until thread rotation and close finish', async () => {
+    const sessions = [localCodex('locked-rotation', false)];
+    const rotationBarrier = deferred<void>();
+    const events: string[] = [];
+    const withSessionLock = createSessionLock();
+    const closeSession = vi.fn(async () => {
+      events.push('close');
+      sessions.splice(0, 1);
+    });
+    const prepareCodexThreadRotation = vi.fn(async () => {
+      events.push('rotation-start');
+      await rotationBarrier.promise;
+      events.push('rotation-finish');
+      return {
+        newSdkSessionId: 'thread-locked-rotation-new',
+        rollback: vi.fn(async () => undefined),
+      };
+    });
+    const service = new CodexRouteRebuildService({
+      maker: { listActiveSessions: () => sessions, closeSession },
+      abortSession: vi.fn(async () => undefined),
+      withSessionLock,
+      resolveRequiresCodeModeOnly: async () => true,
+      prepareCodexThreadRotation,
+      retryDelayMs: 60_000,
+    });
+
+    const reconcile = service.reconcile(2);
+    await vi.waitFor(() => expect(prepareCodexThreadRotation).toHaveBeenCalledTimes(1));
+    const directSend = withSessionLock('locked-rotation', async () => {
+      events.push('direct-send');
+    });
+
+    await Promise.resolve();
+    expect(events).toEqual(['rotation-start']);
+
+    rotationBarrier.resolve();
+    await reconcile;
+    await directSend;
+
+    expect(events).toEqual(['rotation-start', 'rotation-finish', 'close', 'direct-send']);
+  });
+
   it('retires a stale catalog rebuild when a newer lifecycle owns the thread binding', async () => {
     const sessions = [localCodex('rotation-superseded', false)];
     const prepareCodexThreadRotation = vi.fn(async () => {
@@ -134,6 +198,7 @@ describe('CodexRouteRebuildService', () => {
         closeSession: vi.fn(async () => undefined),
       },
       abortSession: vi.fn(async () => undefined),
+      withSessionLock: runWithoutSessionLock,
       resolveRequiresCodeModeOnly: async () => true,
       prepareCodexThreadRotation,
       onApplied,
@@ -183,6 +248,7 @@ describe('CodexRouteRebuildService', () => {
         closeSession,
       },
       abortSession,
+      withSessionLock: runWithoutSessionLock,
       resolveRequiresCodeModeOnly: (session) =>
         session.id === 'slow-lookup' ? slowLookup.promise : Promise.resolve(true),
       retryDelayMs: 60_000,
@@ -216,6 +282,7 @@ describe('CodexRouteRebuildService', () => {
         closeSession: vi.fn(async () => undefined),
       },
       abortSession: vi.fn(async () => undefined),
+      withSessionLock: runWithoutSessionLock,
       resolveRequiresCodeModeOnly: () => lookup.promise,
       prepareCodexThreadRotation,
       onApplied,
@@ -251,6 +318,7 @@ describe('CodexRouteRebuildService', () => {
         closeSession,
       },
       abortSession,
+      withSessionLock: runWithoutSessionLock,
       resolveRequiresCodeModeOnly: async () => true,
       onApplied,
       retryDelayMs: 60_000,
@@ -305,6 +373,7 @@ describe('CodexRouteRebuildService', () => {
         closeSession,
       },
       abortSession: vi.fn(async () => {}),
+      withSessionLock: runWithoutSessionLock,
       isReconciliationBlocked: () => blocked,
       resolveRequiresCodeModeOnly: () =>
         new Promise<boolean>((resolve) => {
@@ -345,6 +414,7 @@ describe('CodexRouteRebuildService', () => {
         closeSession,
       },
       abortSession,
+      withSessionLock: runWithoutSessionLock,
       resolveRequiresCodeModeOnly: async () => true,
       retryDelayMs: 60_000,
     });
@@ -396,6 +466,7 @@ describe('CodexRouteRebuildService', () => {
         closeSession,
       },
       abortSession: vi.fn(async () => {}),
+      withSessionLock: runWithoutSessionLock,
       getReconciliationGeneration: () => routeGeneration,
       resolveRequiresCodeModeOnly: async () => true,
       onApplied,
@@ -433,6 +504,7 @@ describe('CodexRouteRebuildService', () => {
         closeSession,
       },
       abortSession,
+      withSessionLock: runWithoutSessionLock,
       resolveRequiresCodeModeOnly: async () => currentRequiresCodeModeOnly,
       onApplied,
       retryDelayMs: 60_000,

--- a/apps/desktop/src/main/maker-ipc/__tests__/codexThreadRotation.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/codexThreadRotation.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createCodexThreadRotationPreparer } from '../codexThreadRotation.js';
+
+describe('createCodexThreadRotationPreparer', () => {
+  const snapshot = {
+    sessionId: 'session-1',
+    sourceSdkSessionId: 'thread-old',
+    sourceModel: 'deepseek-v4',
+    sourceProviderId: 'deepseek',
+    workingDir: '/work',
+  };
+
+  it('forks the full Codex history and atomically rebinds the session', async () => {
+    const forkSdkSession = vi.fn(async () => ({
+      newSdkSessionId: 'thread-new',
+      uuidMap: new Map(),
+    }));
+    const replaceSdkSessionIdIfCurrent = vi.fn(async () => true);
+    const prepare = createCodexThreadRotationPreparer({
+      maker: { forkSdkSession },
+      replaceSdkSessionIdIfCurrent,
+    });
+
+    const prepared = await prepare(snapshot);
+
+    expect(forkSdkSession).toHaveBeenCalledWith('codex', {
+      sourceSdkSessionId: 'thread-old',
+      model: 'deepseek-v4',
+      providerId: 'deepseek',
+      workingDir: '/work',
+      upToMessageId: undefined,
+      stripEncryptedReasoning: true,
+    });
+    expect(replaceSdkSessionIdIfCurrent).toHaveBeenCalledWith(
+      'session-1',
+      'thread-old',
+      'thread-new',
+    );
+    expect(prepared.newSdkSessionId).toBe('thread-new');
+  });
+
+  it('fails closed when a newer lifecycle already changed the session binding', async () => {
+    const prepare = createCodexThreadRotationPreparer({
+      maker: {
+        forkSdkSession: vi.fn(async () => ({
+          newSdkSessionId: 'thread-new',
+          uuidMap: new Map(),
+        })),
+      },
+      replaceSdkSessionIdIfCurrent: vi.fn(async () => false),
+    });
+
+    await expect(prepare(snapshot)).rejects.toThrow(
+      'Codex thread rotation lost its session binding',
+    );
+  });
+
+  it('rolls the database binding back if closing the old live session fails', async () => {
+    const replaceSdkSessionIdIfCurrent = vi
+      .fn<(sessionId: string, expected: string, next: string) => Promise<boolean>>()
+      .mockResolvedValue(true);
+    const prepare = createCodexThreadRotationPreparer({
+      maker: {
+        forkSdkSession: vi.fn(async () => ({
+          newSdkSessionId: 'thread-new',
+          uuidMap: new Map(),
+        })),
+      },
+      replaceSdkSessionIdIfCurrent,
+    });
+
+    const prepared = await prepare(snapshot);
+    await prepared.rollback();
+
+    expect(replaceSdkSessionIdIfCurrent).toHaveBeenNthCalledWith(
+      2,
+      'session-1',
+      'thread-new',
+      'thread-old',
+    );
+  });
+});

--- a/apps/desktop/src/main/maker-ipc/__tests__/codexThreadRotation.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/codexThreadRotation.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { createCodexThreadRotationPreparer } from '../codexThreadRotation.js';
+import {
+  CodexThreadRotationSupersededError,
+  createCodexThreadRotationPreparer,
+} from '../codexThreadRotation.js';
 
 describe('createCodexThreadRotationPreparer', () => {
   const snapshot = {
@@ -40,7 +43,7 @@ describe('createCodexThreadRotationPreparer', () => {
     expect(prepared.newSdkSessionId).toBe('thread-new');
   });
 
-  it('fails closed when a newer lifecycle already changed the session binding', async () => {
+  it('reports a superseded rotation when a newer lifecycle changed the session binding', async () => {
     const prepare = createCodexThreadRotationPreparer({
       maker: {
         forkSdkSession: vi.fn(async () => ({
@@ -51,8 +54,8 @@ describe('createCodexThreadRotationPreparer', () => {
       replaceSdkSessionIdIfCurrent: vi.fn(async () => false),
     });
 
-    await expect(prepare(snapshot)).rejects.toThrow(
-      'Codex thread rotation lost its session binding',
+    await expect(prepare(snapshot)).rejects.toBeInstanceOf(
+      CodexThreadRotationSupersededError,
     );
   });
 

--- a/apps/desktop/src/main/maker-ipc/__tests__/deferredRestartQueueDrain.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/deferredRestartQueueDrain.test.ts
@@ -440,8 +440,14 @@ describe('register.ts 真实接线经由共享工厂(源码断言,#2506)', () =>
     const rebuildBlock = registerSource.slice(
       registerSource.indexOf('const codexRouteRebuildService = new CodexRouteRebuildService'),
     );
-    expect(rebuildBlock.slice(0, 1_000)).toContain(
+    expect(rebuildBlock.slice(0, 2_500)).toContain(
       'credentialMode: session.codexRouteCredentialMode',
+    );
+    expect(rebuildBlock.slice(0, 2_500)).toContain('await session.abort()');
+    expect(rebuildBlock.slice(0, 2_500)).toContain('reconcileDirectAbortBoundary(');
+    expect(rebuildBlock.slice(0, 2_500)).toContain("'catalog-route-rebuild-abort'");
+    expect(rebuildBlock.slice(0, 2_500)).toContain(
+      "cleanupPendingInteractionsForSession(sessionId, 'session_aborted')",
     );
   });
 });

--- a/apps/desktop/src/main/maker-ipc/__tests__/deferredRestartQueueDrain.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/deferredRestartQueueDrain.test.ts
@@ -435,4 +435,13 @@ describe('register.ts 真实接线经由共享工厂(源码断言,#2506)', () =>
     );
     expect(wakeBlock.slice(0, 300)).toContain('inputCoordinator.wakeSession(sessionId, reason)');
   });
+
+  it('Codex route rebuild 使用 thread 冻结的会话级凭证形态', () => {
+    const rebuildBlock = registerSource.slice(
+      registerSource.indexOf('const codexRouteRebuildService = new CodexRouteRebuildService'),
+    );
+    expect(rebuildBlock.slice(0, 1_000)).toContain(
+      'credentialMode: session.codexRouteCredentialMode',
+    );
+  });
 });

--- a/apps/desktop/src/main/maker-ipc/__tests__/deferredRestartQueueDrain.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/deferredRestartQueueDrain.test.ts
@@ -450,4 +450,12 @@ describe('register.ts 真实接线经由共享工厂(源码断言,#2506)', () =>
       "cleanupPendingInteractionsForSession(sessionId, 'session_aborted')",
     );
   });
+
+  it('owner boundary 同时清理逐会话凭证切换和 catalog rebuild 登记', () => {
+    const boundaryBlock = registerSource.slice(
+      registerSource.indexOf('export async function clearDeferredCodexRestartForOwnerBoundary'),
+    );
+    expect(boundaryBlock.slice(0, 400)).toContain('pendingCredentialSwitchHolder?.clearAll()');
+    expect(boundaryBlock.slice(0, 400)).toContain('codexRouteRebuildHolder?.clearAsync()');
+  });
 });

--- a/apps/desktop/src/main/maker-ipc/__tests__/pendingCredentialSwitch.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/pendingCredentialSwitch.test.ts
@@ -25,6 +25,14 @@ function rememberSession(sessionId: string): string {
   return sessionId;
 }
 
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
 interface HarnessSession {
   id: string;
   agentKind: 'claude-code' | 'codex';
@@ -289,6 +297,205 @@ describe('PendingCredentialSwitchService', () => {
     expect(prepareCodexThreadRotation).toHaveBeenCalledTimes(2);
     expect(h.service.has(sessionId)).toBe(false);
     expect(getSessionProvider(sessionId)).toBe('xd');
+  });
+
+  it('keeps the queue gated until a cancelled rotation and its obsolete close both settle', async () => {
+    const sessionId = rememberSession('pending-switch-codemode-clear-during-close');
+    setSessionProvider(sessionId, 'deepseek');
+    const closeStarted = deferred<void>();
+    const releaseClose = deferred<void>();
+    const rollbackStarted = deferred<void>();
+    const releaseRollback = deferred<void>();
+    const rollback = vi.fn(async () => {
+      rollbackStarted.resolve();
+      await releaseRollback.promise;
+    });
+    const h = createHarness(
+      [{ id: sessionId, agentKind: 'codex', remoteHostId: null, isTurnRunning: () => false }],
+      {
+        prepareCodexThreadRotation: vi.fn(async () => ({
+          newSdkSessionId: 'thread-new',
+          rollback,
+        })),
+        retryDelayMs: 60_000,
+      },
+    );
+    h.closeSession.mockImplementationOnce(async () => {
+      closeStarted.resolve();
+      await releaseClose.promise;
+    });
+
+    await h.service.register(sessionId, {
+      model: 'qwen3.8-max',
+      providerId: 'xd',
+      codexThreadRotation: {
+        sessionId,
+        sourceSdkSessionId: 'thread-old',
+        sourceModel: 'deepseek-v4',
+        sourceProviderId: 'deepseek',
+        workingDir: '/work',
+      },
+    });
+    const applying = h.service.onTurnSettled(sessionId);
+    await closeStarted.promise;
+
+    const clearing = h.service.clear(sessionId);
+    await rollbackStarted.promise;
+    expect(h.service.get(sessionId)).toBeUndefined();
+    expect(h.service.has(sessionId)).toBe(true);
+    expect(h.onApplied).not.toHaveBeenCalled();
+
+    releaseRollback.resolve();
+    await Promise.resolve();
+    expect(h.service.has(sessionId)).toBe(true);
+
+    releaseClose.resolve();
+    await Promise.all([applying, clearing]);
+
+    expect(rollback).toHaveBeenCalledTimes(1);
+    expect(h.service.has(sessionId)).toBe(false);
+    expect(getSessionProvider(sessionId)).toBe('deepseek');
+    expect(h.broadcastApplied).not.toHaveBeenCalled();
+    expect(h.onApplied).not.toHaveBeenCalled();
+  });
+
+  it('keeps the queue fail-closed without rejecting when a cancelled rotation cannot roll back', async () => {
+    const sessionId = rememberSession('pending-switch-codemode-clear-rollback-fail');
+    setSessionProvider(sessionId, 'deepseek');
+    const closeStarted = deferred<void>();
+    const releaseClose = deferred<void>();
+    const rollback = vi.fn(async () => {
+      throw new Error('rollback lost binding');
+    });
+    const h = createHarness(
+      [{ id: sessionId, agentKind: 'codex', remoteHostId: null, isTurnRunning: () => false }],
+      {
+        prepareCodexThreadRotation: vi.fn(async () => ({
+          newSdkSessionId: 'thread-new',
+          rollback,
+        })),
+        retryDelayMs: 60_000,
+      },
+    );
+    h.closeSession.mockImplementationOnce(async () => {
+      closeStarted.resolve();
+      await releaseClose.promise;
+    });
+
+    await h.service.register(sessionId, {
+      model: 'qwen3.8-max',
+      providerId: 'xd',
+      codexThreadRotation: {
+        sessionId,
+        sourceSdkSessionId: 'thread-old',
+        sourceModel: 'deepseek-v4',
+        sourceProviderId: 'deepseek',
+        workingDir: '/work',
+      },
+    });
+    const applying = h.service.onTurnSettled(sessionId);
+    await closeStarted.promise;
+    const clearing = h.service.clear(sessionId);
+    await vi.waitFor(() => expect(rollback).toHaveBeenCalledTimes(1));
+
+    releaseClose.resolve();
+    await expect(Promise.all([applying, clearing])).resolves.toBeDefined();
+
+    expect(h.service.get(sessionId)).toBeUndefined();
+    expect(h.service.has(sessionId)).toBe(true);
+    expect(h.onApplied).not.toHaveBeenCalled();
+    expect(h.broadcastApplied).not.toHaveBeenCalled();
+
+    await h.service.clearAll();
+    expect(h.service.has(sessionId)).toBe(false);
+  });
+
+  it('rolls back a prepared rotation before a replacement target is rotated and applied', async () => {
+    const sessionId = rememberSession('pending-switch-codemode-replace-during-close');
+    setSessionProvider(sessionId, 'deepseek');
+    const closeStarted = deferred<void>();
+    const releaseClose = deferred<void>();
+    const rollbackStarted = deferred<void>();
+    const releaseRollback = deferred<void>();
+    const events: string[] = [];
+    const firstRollback = vi.fn(async () => {
+      events.push('rollback-old-start');
+      rollbackStarted.resolve();
+      await releaseRollback.promise;
+      events.push('rollback-old-end');
+    });
+    const secondRollback = vi.fn(async () => undefined);
+    const prepareCodexThreadRotation = vi
+      .fn<NonNullable<PendingCredentialSwitchDeps['prepareCodexThreadRotation']>>()
+      .mockImplementationOnce(async () => {
+        events.push('prepare-old');
+        return { newSdkSessionId: 'thread-old-fork', rollback: firstRollback };
+      })
+      .mockImplementationOnce(async () => {
+        events.push('prepare-latest');
+        return { newSdkSessionId: 'thread-latest-fork', rollback: secondRollback };
+      });
+    const h = createHarness(
+      [{ id: sessionId, agentKind: 'codex', remoteHostId: null, isTurnRunning: () => false }],
+      { prepareCodexThreadRotation, retryDelayMs: 60_000 },
+    );
+    h.closeSession.mockImplementationOnce(async () => {
+      events.push('close-start');
+      closeStarted.resolve();
+      await releaseClose.promise;
+      events.push('close-end');
+    });
+
+    await h.service.register(sessionId, {
+      model: 'qwen3.8-max',
+      providerId: 'xd',
+      codexThreadRotation: {
+        sessionId,
+        sourceSdkSessionId: 'thread-old',
+        sourceModel: 'deepseek-v4',
+        sourceProviderId: 'deepseek',
+        workingDir: '/work',
+      },
+    });
+    const applying = h.service.onTurnSettled(sessionId);
+    await closeStarted.promise;
+
+    const replacing = h.service.register(sessionId, {
+      model: 'gpt-5.5',
+      providerId: 'openai',
+      codexThreadRotation: {
+        sessionId,
+        sourceSdkSessionId: 'thread-old',
+        sourceModel: 'deepseek-v4',
+        sourceProviderId: 'deepseek',
+        workingDir: '/work',
+      },
+    });
+    await rollbackStarted.promise;
+    expect(h.service.has(sessionId)).toBe(true);
+    expect(prepareCodexThreadRotation).toHaveBeenCalledTimes(1);
+
+    releaseRollback.resolve();
+    await replacing;
+    expect(prepareCodexThreadRotation).toHaveBeenCalledTimes(1);
+
+    releaseClose.resolve();
+    await applying;
+
+    expect(events).toEqual([
+      'prepare-old',
+      'close-start',
+      'rollback-old-start',
+      'rollback-old-end',
+      'close-end',
+      'prepare-latest',
+    ]);
+    expect(firstRollback).toHaveBeenCalledTimes(1);
+    expect(secondRollback).not.toHaveBeenCalled();
+    expect(prepareCodexThreadRotation).toHaveBeenCalledTimes(2);
+    expect(h.service.has(sessionId)).toBe(false);
+    expect(getSessionProvider(sessionId)).toBe('openai');
+    expect(h.onApplied).toHaveBeenCalledWith(sessionId);
   });
 
   it('releases a stale deferred switch when a newer lifecycle owns the thread binding', async () => {

--- a/apps/desktop/src/main/maker-ipc/__tests__/pendingCredentialSwitch.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/pendingCredentialSwitch.test.ts
@@ -9,6 +9,7 @@ import {
   PendingCredentialSwitchService,
   type PendingCredentialSwitchDeps,
 } from '../pendingCredentialSwitch.js';
+import { CodexThreadRotationSupersededError } from '../codexThreadRotation.js';
 
 const touchedSessions = new Set<string>();
 
@@ -288,6 +289,38 @@ describe('PendingCredentialSwitchService', () => {
     expect(prepareCodexThreadRotation).toHaveBeenCalledTimes(2);
     expect(h.service.has(sessionId)).toBe(false);
     expect(getSessionProvider(sessionId)).toBe('xd');
+  });
+
+  it('releases a stale deferred switch when a newer lifecycle owns the thread binding', async () => {
+    const sessionId = rememberSession('pending-switch-codemode-superseded');
+    setSessionProvider(sessionId, 'deepseek');
+    const prepareCodexThreadRotation = vi.fn(async () => {
+      throw new CodexThreadRotationSupersededError(sessionId);
+    });
+    const h = createHarness(
+      [{ id: sessionId, agentKind: 'codex', remoteHostId: null, isTurnRunning: () => false }],
+      { prepareCodexThreadRotation, retryDelayMs: 60_000 },
+    );
+
+    h.service.register(sessionId, {
+      model: 'qwen3.8-max',
+      providerId: 'xd',
+      codexThreadRotation: {
+        sessionId,
+        sourceSdkSessionId: 'thread-old',
+        sourceModel: 'deepseek-v4',
+        sourceProviderId: 'deepseek',
+        workingDir: '/work',
+      },
+    });
+    await h.service.onTurnSettled(sessionId);
+
+    expect(prepareCodexThreadRotation).toHaveBeenCalledTimes(1);
+    expect(h.service.has(sessionId)).toBe(false);
+    expect(h.closeSession).not.toHaveBeenCalled();
+    expect(getSessionProvider(sessionId)).toBe('deepseek');
+    expect(h.onApplied).toHaveBeenCalledWith(sessionId);
+    expect(h.broadcastApplied).not.toHaveBeenCalled();
   });
 
   it('drops every deferred rotation without applying it at an owner boundary', async () => {

--- a/apps/desktop/src/main/maker-ipc/__tests__/pendingCredentialSwitch.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/pendingCredentialSwitch.test.ts
@@ -33,7 +33,11 @@ interface HarnessSession {
 
 function createHarness(
   sessions: HarnessSession[],
-  opts?: { retryDelayMs?: number; resolveRoute?: PendingCredentialSwitchDeps['resolveRoute'] },
+  opts?: {
+    retryDelayMs?: number;
+    resolveRoute?: PendingCredentialSwitchDeps['resolveRoute'];
+    prepareCodexThreadRotation?: PendingCredentialSwitchDeps['prepareCodexThreadRotation'];
+  },
 ) {
   const closeSession = vi.fn(async (_sessionId: string) => {});
   const broadcastApplied = vi.fn<NonNullable<PendingCredentialSwitchDeps['broadcastApplied']>>();
@@ -50,6 +54,9 @@ function createHarness(
     onApplied,
     persistRoute,
     ...(opts?.resolveRoute ? { resolveRoute: opts.resolveRoute } : {}),
+    ...(opts?.prepareCodexThreadRotation
+      ? { prepareCodexThreadRotation: opts.prepareCodexThreadRotation }
+      : {}),
     ...(opts?.retryDelayMs !== undefined ? { retryDelayMs: opts.retryDelayMs } : {}),
   });
   return { service, closeSession, broadcastApplied, onApplied, persistRoute, sessions };
@@ -207,6 +214,110 @@ describe('PendingCredentialSwitchService', () => {
     expect(getSessionProvider(sessionId)).toBe('xd');
     expect(h.broadcastApplied).toHaveBeenCalledTimes(1);
     expect(h.onApplied).toHaveBeenCalledTimes(1);
+  });
+
+  it('rotates a deferred CodeModeOnly thread before closing and applying the route', async () => {
+    const sessionId = rememberSession('pending-switch-codemode-rotate');
+    setSessionProvider(sessionId, 'deepseek');
+    const rollback = vi.fn(async () => undefined);
+    const prepareCodexThreadRotation = vi.fn(async () => ({
+      newSdkSessionId: 'thread-new',
+      rollback,
+    }));
+    const h = createHarness(
+      [{ id: sessionId, agentKind: 'codex', remoteHostId: null, isTurnRunning: () => false }],
+      { prepareCodexThreadRotation },
+    );
+
+    h.service.register(sessionId, {
+      model: 'qwen3.8-max',
+      providerId: 'xd',
+      codexThreadRotation: {
+        sessionId,
+        sourceSdkSessionId: 'thread-old',
+        sourceModel: 'deepseek-v4',
+        sourceProviderId: 'deepseek',
+        workingDir: '/work',
+      },
+    });
+    await h.service.onTurnSettled(sessionId);
+
+    expect(prepareCodexThreadRotation).toHaveBeenCalledTimes(1);
+    expect(prepareCodexThreadRotation.mock.invocationCallOrder[0]).toBeLessThan(
+      h.closeSession.mock.invocationCallOrder[0],
+    );
+    expect(rollback).not.toHaveBeenCalled();
+    expect(getSessionProvider(sessionId)).toBe('xd');
+  });
+
+  it('rolls back and retries a deferred CodeModeOnly rotation when close fails', async () => {
+    const sessionId = rememberSession('pending-switch-codemode-close-fail');
+    setSessionProvider(sessionId, 'deepseek');
+    const firstRollback = vi.fn(async () => undefined);
+    const prepareCodexThreadRotation = vi
+      .fn<NonNullable<PendingCredentialSwitchDeps['prepareCodexThreadRotation']>>()
+      .mockResolvedValueOnce({ newSdkSessionId: 'thread-new-1', rollback: firstRollback })
+      .mockResolvedValueOnce({
+        newSdkSessionId: 'thread-new-2',
+        rollback: vi.fn(async () => undefined),
+      });
+    const h = createHarness(
+      [{ id: sessionId, agentKind: 'codex', remoteHostId: null, isTurnRunning: () => false }],
+      { prepareCodexThreadRotation, retryDelayMs: 60_000 },
+    );
+    h.closeSession.mockRejectedValueOnce(new Error('close failed'));
+
+    h.service.register(sessionId, {
+      model: 'qwen3.8-max',
+      providerId: 'xd',
+      codexThreadRotation: {
+        sessionId,
+        sourceSdkSessionId: 'thread-old',
+        sourceModel: 'deepseek-v4',
+        sourceProviderId: 'deepseek',
+        workingDir: '/work',
+      },
+    });
+    await h.service.onTurnSettled(sessionId);
+
+    expect(firstRollback).toHaveBeenCalledTimes(1);
+    expect(h.service.has(sessionId)).toBe(true);
+    expect(getSessionProvider(sessionId)).toBe('deepseek');
+
+    await h.service.onTurnSettled(sessionId);
+    expect(prepareCodexThreadRotation).toHaveBeenCalledTimes(2);
+    expect(h.service.has(sessionId)).toBe(false);
+    expect(getSessionProvider(sessionId)).toBe('xd');
+  });
+
+  it('drops every deferred rotation without applying it at an owner boundary', async () => {
+    const sessionId = rememberSession('pending-switch-owner-boundary-clear');
+    setSessionProvider(sessionId, 'deepseek');
+    const prepareCodexThreadRotation = vi.fn(async () => ({
+      newSdkSessionId: 'thread-new',
+      rollback: vi.fn(async () => undefined),
+    }));
+    const h = createHarness([], { prepareCodexThreadRotation, retryDelayMs: 60_000 });
+
+    h.service.register(sessionId, {
+      model: 'qwen3.8-max',
+      providerId: 'xd',
+      codexThreadRotation: {
+        sessionId,
+        sourceSdkSessionId: 'thread-old',
+        sourceModel: 'deepseek-v4',
+        sourceProviderId: 'deepseek',
+        workingDir: '/work',
+      },
+    });
+    h.service.clearAll();
+    h.service.onSessionClosed(sessionId);
+    await h.service.onTurnSettled(sessionId);
+
+    expect(prepareCodexThreadRotation).not.toHaveBeenCalled();
+    expect(h.service.has(sessionId)).toBe(false);
+    expect(getSessionProvider(sessionId)).toBe('deepseek');
+    expect(h.broadcastApplied).not.toHaveBeenCalled();
   });
 
   it('self-heals via the retry timer when the turn ends without a done/error event', async () => {

--- a/apps/desktop/src/main/maker-ipc/__tests__/providerHandlers.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/providerHandlers.test.ts
@@ -81,6 +81,7 @@ function makeDeps(over: Partial<ProviderHandlerDeps> = {}): ProviderHandlerDeps 
     refreshCatalog: vi.fn(async () => {}),
     beginRouteMutation: vi.fn(() => () => {}),
     broadcastChanged: vi.fn(() => {}),
+    afterRouteMutation: vi.fn(() => {}),
     listProviderIds: () => [],
     setProviderOrder: vi.fn(() => true),
     getProviderOrder: () => [],
@@ -922,6 +923,35 @@ describe('provider:custom:* CRUD handlers', () => {
     expect(await listCustomProviders()).toHaveLength(1);
     expect(deps.refreshCatalog).toHaveBeenCalledOnce();
     expect(deps.broadcastChanged).toHaveBeenCalledOnce();
+  });
+
+  it('notifies route dependents only after the provider route mutation is released', async () => {
+    mountDb();
+    const harness = new IpcHarness();
+    const calls: string[] = [];
+    const deps = makeDeps({
+      beginRouteMutation: vi.fn(() => {
+        calls.push('begin');
+        return () => calls.push('finish');
+      }),
+      refreshCatalog: vi.fn(async () => {
+        calls.push('refresh');
+      }),
+      broadcastChanged: vi.fn(() => {
+        calls.push('broadcast');
+      }),
+      afterRouteMutation: vi.fn(() => {
+        calls.push('reconcile');
+      }),
+    });
+    registerProviderHandlers(harness, deps);
+
+    await expect(
+      harness.invoke(MAKER_INVOKE.PROVIDER_CUSTOM_CREATE, validConfig),
+    ).resolves.toEqual({ ok: true });
+
+    expect(calls).toEqual(['begin', 'refresh', 'broadcast', 'finish', 'reconcile']);
+    expect(deps.afterRouteMutation).toHaveBeenCalledWith(validConfig.id);
   });
 
   it('accepts and stages a Pi-native runtime key', async () => {

--- a/apps/desktop/src/main/maker-ipc/__tests__/runtimeSetModel.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/runtimeSetModel.test.ts
@@ -370,6 +370,66 @@ describe('applyRuntimeSetModelChange', () => {
     );
   });
 
+  it('uses the rebuilt host credential mode when switching from env-key to OpenAI OAuth', async () => {
+    const sessionId = rememberSession('runtime-set-model-codemode-env-openai');
+    const setModel = vi.fn(async () => {});
+    const closeSession = vi.fn(async () => {});
+    const prepareCodexThreadRotation = vi.fn(async () => ({
+      newSdkSessionId: 'thread-openai-new',
+      rollback: vi.fn(async () => undefined),
+    }));
+    const resolver = vi.fn(async ({ credentialMode }: { credentialMode?: string }) => ({
+      requiresCodeModeOnly: credentialMode === 'gateway-key',
+    }));
+    const maker: RuntimeSetModelMaker = {
+      getSession: () => ({
+        agentKind: 'codex',
+        remoteHostId: null,
+        codexProxyActive: true,
+        model: 'gpt-5.4',
+        sdkSessionId: 'thread-openai-old',
+        workDir: '/work',
+        setModel,
+      }),
+      listActiveSessions: () => [{
+        id: sessionId,
+        agentKind: 'codex',
+        remoteHostId: null,
+        isTurnRunning: () => false,
+      }],
+      closeSession,
+    };
+
+    await applyRuntimeSetModelChange({
+      maker,
+      sessionId,
+      model: 'gpt-5.4',
+      providerId: 'openai',
+      codexAuthInjection: 'env-key',
+      resolveCodexRouteCapabilitiesForSwitch: resolver,
+      prepareCodexThreadRotation,
+    });
+
+    expect(resolver).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      providerId: null,
+      credentialMode: 'gateway-key',
+    }));
+    expect(resolver).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      providerId: 'openai',
+      credentialMode: 'oauth-bearer',
+    }));
+    expect(prepareCodexThreadRotation).toHaveBeenCalledWith({
+      sessionId,
+      sourceSdkSessionId: 'thread-openai-old',
+      sourceModel: 'gpt-5.4',
+      sourceProviderId: null,
+      workingDir: '/work',
+    });
+    expect(closeSession).toHaveBeenCalledWith(sessionId);
+    expect(setModel).not.toHaveBeenCalled();
+    expect(getSessionProvider(sessionId)).toBe('openai');
+  });
+
   it('prefers the active proxy auth shape over an explicit provider-derived mode', async () => {
     const resolver = vi.fn(async ({
       providerId,

--- a/apps/desktop/src/main/maker-ipc/__tests__/runtimeSetModel.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/runtimeSetModel.test.ts
@@ -5,7 +5,11 @@ import {
   getSessionProvider,
   setSessionProvider,
 } from '../../maker-host/session-provider-store.js';
-import { applyRuntimeSetModelChange, type RuntimeSetModelMaker } from '../runtimeSetModel.js';
+import {
+  applyRuntimeSetModelChange,
+  crossesCodexCodeModeOnlyBoundary,
+  type RuntimeSetModelMaker,
+} from '../runtimeSetModel.js';
 
 const touchedSessions = new Set<string>();
 
@@ -314,6 +318,36 @@ describe('applyRuntimeSetModelChange', () => {
     expect(closeSession).toHaveBeenCalledWith(sessionId);
     expect(setModel).not.toHaveBeenCalled();
     expect(getSessionProvider(sessionId)).toBe('deepseek');
+  });
+
+  it('prefers the active proxy auth shape over an explicit provider-derived mode', async () => {
+    const resolver = vi.fn(async ({
+      providerId,
+      credentialMode,
+    }: {
+      providerId?: string | null;
+      credentialMode?: string;
+    }) => ({
+      requiresCodeModeOnly: providerId === 'openai' && credentialMode === 'gateway-key',
+    }));
+
+    await expect(crossesCodexCodeModeOnlyBoundary({
+      currentProviderId: 'openai',
+      nextProviderId: 'deepseek',
+      currentModel: 'gpt-5.4',
+      nextModel: 'deepseek-v4-pro',
+      codexAuthInjection: 'env-key',
+      resolver,
+    })).resolves.toBe(true);
+
+    expect(resolver).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      providerId: 'openai',
+      credentialMode: 'gateway-key',
+    }));
+    expect(resolver).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      providerId: 'deepseek',
+      credentialMode: 'gateway-key',
+    }));
   });
 
   it('defers a busy CodeModeOnly route change until the turn boundary', async () => {

--- a/apps/desktop/src/main/maker-ipc/__tests__/runtimeSetModel.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/runtimeSetModel.test.ts
@@ -22,6 +22,10 @@ function rememberSession(sessionId: string): string {
 }
 
 describe('applyRuntimeSetModelChange', () => {
+  const gatewayCodeModeCapability = async ({ providerId }: { providerId?: string | null }) => ({
+    requiresCodeModeOnly: providerId === 'xd',
+  });
+
   it('rolls back provider route when live setModel rejects', async () => {
     const sessionId = rememberSession('runtime-set-model-rollback');
     setSessionProvider(sessionId, 'xd');
@@ -273,6 +277,196 @@ describe('applyRuntimeSetModelChange', () => {
     expect(closeSession).not.toHaveBeenCalled();
     expect(setModel).toHaveBeenCalledWith('xai/grok-4.3', { providerId: 'xai' });
     expect(getSessionProvider(sessionId)).toBe('xai');
+  });
+
+  it('rebuilds an idle local Codex session when the final route changes CodeModeOnly', async () => {
+    const sessionId = rememberSession('runtime-set-model-codemode-rebuild');
+    setSessionProvider(sessionId, 'xd');
+    const setModel = vi.fn(async () => {});
+    const closeSession = vi.fn(async () => {});
+    const maker: RuntimeSetModelMaker = {
+      getSession: () => ({
+        agentKind: 'codex',
+        remoteHostId: null,
+        codexProxyActive: true,
+        model: 'shared-model',
+        setModel,
+      }),
+      listActiveSessions: () => [{
+        id: sessionId,
+        agentKind: 'codex',
+        remoteHostId: null,
+        isTurnRunning: () => false,
+      }],
+      closeSession,
+    };
+
+    const result = await applyRuntimeSetModelChange({
+      maker,
+      sessionId,
+      model: 'shared-model',
+      providerId: 'deepseek',
+      codexAuthInjection: 'env-key',
+      resolveCodexRouteCapabilitiesForSwitch: gatewayCodeModeCapability,
+    });
+
+    expect(result).toEqual({ status: 'applied' });
+    expect(closeSession).toHaveBeenCalledWith(sessionId);
+    expect(setModel).not.toHaveBeenCalled();
+    expect(getSessionProvider(sessionId)).toBe('deepseek');
+  });
+
+  it('defers a busy CodeModeOnly route change until the turn boundary', async () => {
+    const sessionId = rememberSession('runtime-set-model-codemode-defer');
+    setSessionProvider(sessionId, 'deepseek');
+    const setModel = vi.fn(async () => {});
+    const registerPendingCredentialSwitch = vi.fn();
+    const maker: RuntimeSetModelMaker = {
+      getSession: () => ({
+        agentKind: 'codex',
+        remoteHostId: null,
+        codexProxyActive: true,
+        model: 'shared-model',
+        setModel,
+      }),
+      listActiveSessions: () => [{
+        id: sessionId,
+        agentKind: 'codex',
+        remoteHostId: null,
+        isTurnRunning: () => true,
+      }],
+      closeSession: vi.fn(async () => {}),
+    };
+
+    const result = await applyRuntimeSetModelChange({
+      maker,
+      sessionId,
+      model: 'shared-model',
+      providerId: 'xd',
+      registerPendingCredentialSwitch,
+      codexAuthInjection: 'provider-oauth',
+      resolveCodexRouteCapabilitiesForSwitch: gatewayCodeModeCapability,
+    });
+
+    expect(result).toEqual({ status: 'deferred' });
+    expect(registerPendingCredentialSwitch).toHaveBeenCalledWith(sessionId, {
+      model: 'shared-model',
+      providerId: 'xd',
+    });
+    expect(setModel).not.toHaveBeenCalled();
+    expect(getSessionProvider(sessionId)).toBe('deepseek');
+  });
+
+  it('keeps an idle Codex session live when the route capability does not change', async () => {
+    const sessionId = rememberSession('runtime-set-model-codemode-same');
+    setSessionProvider(sessionId, 'xd');
+    const setModel = vi.fn(async () => {});
+    const closeSession = vi.fn(async () => {});
+    const maker: RuntimeSetModelMaker = {
+      getSession: () => ({
+        agentKind: 'codex',
+        remoteHostId: null,
+        codexProxyActive: true,
+        model: 'codex/gpt-5.5',
+        setModel,
+      }),
+      listActiveSessions: () => [{
+        id: sessionId,
+        agentKind: 'codex',
+        remoteHostId: null,
+        isTurnRunning: () => false,
+      }],
+      closeSession,
+    };
+
+    await applyRuntimeSetModelChange({
+      maker,
+      sessionId,
+      model: 'codex/gpt-5.6-sol',
+      providerId: 'xd',
+      resolveCodexRouteCapabilitiesForSwitch: gatewayCodeModeCapability,
+    });
+
+    expect(closeSession).not.toHaveBeenCalled();
+    expect(setModel).toHaveBeenCalledWith('codex/gpt-5.6-sol', { providerId: 'xd' });
+  });
+
+  it('rebuilds on a model-only switch when the implicit final route crosses CodeModeOnly', async () => {
+    const sessionId = rememberSession('runtime-set-model-codemode-model-only');
+    const setModel = vi.fn(async () => {});
+    const closeSession = vi.fn(async () => {});
+    const maker: RuntimeSetModelMaker = {
+      getSession: () => ({
+        agentKind: 'codex',
+        remoteHostId: null,
+        codexProxyActive: true,
+        model: 'deepseek-v4-pro',
+        setModel,
+      }),
+      listActiveSessions: () => [{
+        id: sessionId,
+        agentKind: 'codex',
+        remoteHostId: null,
+        isTurnRunning: () => false,
+      }],
+      closeSession,
+    };
+
+    await applyRuntimeSetModelChange({
+      maker,
+      sessionId,
+      model: 'codex/gpt-5.6-sol',
+      codexAuthInjection: 'env-key',
+      resolveCodexRouteCapabilitiesForSwitch: async ({ model }) => ({
+        requiresCodeModeOnly: model.startsWith('codex/'),
+      }),
+    });
+
+    expect(closeSession).toHaveBeenCalledWith(sessionId);
+    expect(setModel).not.toHaveBeenCalled();
+    expect(getSessionProvider(sessionId)).toBeNull();
+  });
+
+  it('rebuilds conservatively when route capability resolution fails', async () => {
+    const sessionId = rememberSession('runtime-set-model-codemode-resolver-failure');
+    setSessionProvider(sessionId, 'xd');
+    const setModel = vi.fn(async () => {});
+    const closeSession = vi.fn(async () => {});
+    const logger = { debug: vi.fn(), info: vi.fn() };
+    const maker: RuntimeSetModelMaker = {
+      getSession: () => ({
+        agentKind: 'codex',
+        remoteHostId: null,
+        codexProxyActive: true,
+        model: 'codex/gpt-5.5',
+        setModel,
+      }),
+      listActiveSessions: () => [{
+        id: sessionId,
+        agentKind: 'codex',
+        remoteHostId: null,
+        isTurnRunning: () => false,
+      }],
+      closeSession,
+    };
+
+    await applyRuntimeSetModelChange({
+      maker,
+      sessionId,
+      model: 'codex/gpt-5.6-sol',
+      providerId: 'xd',
+      resolveCodexRouteCapabilitiesForSwitch: () => {
+        throw new Error('catalog unavailable');
+      },
+      logger,
+    });
+
+    expect(closeSession).toHaveBeenCalledWith(sessionId);
+    expect(setModel).not.toHaveBeenCalled();
+    expect(logger.debug).toHaveBeenCalledWith(
+      'set-model: failed to compare CodeModeOnly route capabilities',
+      expect.objectContaining({ error: 'catalog unavailable' }),
+    );
   });
 
   it('defers a running proxy-active Codex provider switch until the turn boundary', async () => {

--- a/apps/desktop/src/main/maker-ipc/__tests__/runtimeSetModel.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/runtimeSetModel.test.ts
@@ -321,6 +321,55 @@ describe('applyRuntimeSetModelChange', () => {
     expect(getSessionProvider(sessionId)).toBe('deepseek');
   });
 
+  it('rotates a resumable Codex thread before closing across CodeModeOnly', async () => {
+    const sessionId = rememberSession('runtime-set-model-codemode-rotate');
+    setSessionProvider(sessionId, 'deepseek');
+    const setModel = vi.fn(async () => {});
+    const closeSession = vi.fn(async () => {});
+    const prepareCodexThreadRotation = vi.fn(async () => ({
+      newSdkSessionId: 'thread-new',
+      rollback: vi.fn(async () => undefined),
+    }));
+    const maker: RuntimeSetModelMaker = {
+      getSession: () => ({
+        agentKind: 'codex',
+        remoteHostId: null,
+        codexProxyActive: true,
+        model: 'shared-model',
+        sdkSessionId: 'thread-old',
+        workDir: '/work',
+        setModel,
+      }),
+      listActiveSessions: () => [{
+        id: sessionId,
+        agentKind: 'codex',
+        remoteHostId: null,
+        isTurnRunning: () => false,
+      }],
+      closeSession,
+    };
+
+    await applyRuntimeSetModelChange({
+      maker,
+      sessionId,
+      model: 'shared-model',
+      providerId: 'xd',
+      resolveCodexRouteCapabilitiesForSwitch: gatewayCodeModeCapability,
+      prepareCodexThreadRotation,
+    });
+
+    expect(prepareCodexThreadRotation).toHaveBeenCalledWith({
+      sessionId,
+      sourceSdkSessionId: 'thread-old',
+      sourceModel: 'shared-model',
+      sourceProviderId: 'deepseek',
+      workingDir: '/work',
+    });
+    expect(prepareCodexThreadRotation.mock.invocationCallOrder[0]).toBeLessThan(
+      closeSession.mock.invocationCallOrder[0],
+    );
+  });
+
   it('prefers the active proxy auth shape over an explicit provider-derived mode', async () => {
     const resolver = vi.fn(async ({
       providerId,

--- a/apps/desktop/src/main/maker-ipc/__tests__/runtimeSetModel.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/runtimeSetModel.test.ts
@@ -8,6 +8,7 @@ import {
 import {
   applyRuntimeSetModelChange,
   crossesCodexCodeModeOnlyBoundary,
+  resolveCodexCodeModeOnlyForRoute,
   type RuntimeSetModelMaker,
 } from '../runtimeSetModel.js';
 
@@ -347,6 +348,25 @@ describe('applyRuntimeSetModelChange', () => {
     expect(resolver).toHaveBeenNthCalledWith(2, expect.objectContaining({
       providerId: 'deepseek',
       credentialMode: 'gateway-key',
+    }));
+  });
+
+  it('prefers a thread-frozen credential mode over the ordinary host auth shape', async () => {
+    const resolver = vi.fn(async ({ credentialMode }: { credentialMode?: string }) => ({
+      requiresCodeModeOnly: credentialMode === 'gateway-key',
+    }));
+
+    await expect(resolveCodexCodeModeOnlyForRoute({
+      providerId: 'openai',
+      model: 'gpt-5.5',
+      credentialMode: 'oauth-bearer',
+      codexAuthInjection: 'env-key',
+      resolver,
+    })).resolves.toBe(false);
+
+    expect(resolver).toHaveBeenCalledWith(expect.objectContaining({
+      providerId: 'openai',
+      credentialMode: 'oauth-bearer',
     }));
   });
 

--- a/apps/desktop/src/main/maker-ipc/codexRouteRebuild.ts
+++ b/apps/desktop/src/main/maker-ipc/codexRouteRebuild.ts
@@ -136,9 +136,9 @@ export class CodexRouteRebuildService {
 
     const comparisons = await Promise.all(
       sessions.map(async (session) => {
+        let current: boolean;
         try {
-          const current = await this.deps.resolveRequiresCodeModeOnly(session);
-          return { session, current } as const;
+          current = await this.deps.resolveRequiresCodeModeOnly(session);
         } catch (error) {
           this.deps.logger?.warn('catalog route capability resolve failed', {
             revision,
@@ -147,6 +147,15 @@ export class CodexRouteRebuildService {
           });
           return null;
         }
+        if (
+          generation !== this.reconcileGeneration ||
+          this.deps.isReconciliationBlocked?.() === true ||
+          this.deps.getReconciliationGeneration?.() !== routeGeneration
+        ) {
+          return null;
+        }
+        await this.applyComparison(session, current, revision);
+        return { session, current } as const;
       }),
     );
     if (generation !== this.reconcileGeneration) return;
@@ -154,45 +163,6 @@ export class CodexRouteRebuildService {
     if (this.deps.getReconciliationGeneration?.() !== routeGeneration) return;
 
     const scannedIds = new Set(sessions.map((session) => session.id));
-    const toApply: string[] = [];
-    for (const comparison of comparisons) {
-      if (!comparison) continue;
-      const { session, current } = comparison;
-      const previous = this.pending.get(session.id);
-      if (current === session.codexRouteRequiresCodeModeOnly) {
-        if (previous?.instanceId === session.instanceId) {
-          previous.requiresThreadRotation = false;
-        }
-        // Once a busy turn has been interrupted, keep its queue boundary and
-        // rebuild at the abort terminal. A later catalog flip cannot undo an
-        // abort that is already in flight.
-        if (previous?.instanceId === session.instanceId && previous.abortRequested) {
-          previous.revision = revision;
-          this.scheduleRetry(session.id);
-          toApply.push(session.id);
-          continue;
-        }
-        this.finish(session.id, session.instanceId, 'catalog capability converged');
-        continue;
-      }
-      if (previous?.instanceId === session.instanceId) {
-        // Keep the same object while abort is in flight. Its completion/error
-        // path uses object identity to avoid mutating a replacement instance.
-        previous.revision = revision;
-        previous.requiresThreadRotation = true;
-      } else {
-        this.pending.set(session.id, {
-          instanceId: session.instanceId,
-          revision,
-          abortRequested: false,
-          requiresThreadRotation: true,
-          threadRotation: this.snapshotFor(session),
-        });
-      }
-      this.scheduleRetry(session.id);
-      toApply.push(session.id);
-    }
-
     for (const [sessionId, pending] of [...this.pending]) {
       if (
         !scannedIds.has(sessionId) &&
@@ -220,7 +190,6 @@ export class CodexRouteRebuildService {
         this.finish(session.id, pending.instanceId, 'capability comparison failed after session close');
       }
     }
-    await Promise.all(toApply.map((sessionId) => this.tryApply(sessionId)));
   }
 
   onTurnSettled(sessionId: string): Promise<void> {
@@ -336,6 +305,13 @@ export class CodexRouteRebuildService {
         }
         if (pending.threadRotation && !pending.preparedThreadRotation) {
           if (!(await this.prepareThreadRotation(sessionId, pending))) return;
+        }
+        if (
+          this.deps.isReconciliationBlocked?.() === true ||
+          this.deps.getReconciliationGeneration?.() !== routeGeneration
+        ) {
+          this.scheduleRetry(sessionId);
+          return;
         }
         this.finish(sessionId, pending.instanceId, 'session already closed');
       });
@@ -484,6 +460,46 @@ export class CodexRouteRebuildService {
     } finally {
       this.applying.delete(sessionId);
     }
+  }
+
+  private async applyComparison(
+    session: CodexRouteRebuildSession,
+    current: boolean,
+    revision: number,
+  ): Promise<void> {
+    const previous = this.pending.get(session.id);
+    if (current === session.codexRouteRequiresCodeModeOnly) {
+      if (previous?.instanceId === session.instanceId) {
+        previous.requiresThreadRotation = false;
+      }
+      // Once a busy turn has been interrupted, keep its queue boundary and
+      // rebuild at the abort terminal. A later catalog flip cannot undo an
+      // abort that is already in flight.
+      if (previous?.instanceId === session.instanceId && previous.abortRequested) {
+        previous.revision = revision;
+        this.scheduleRetry(session.id);
+        await this.tryApply(session.id);
+        return;
+      }
+      this.finish(session.id, session.instanceId, 'catalog capability converged');
+      return;
+    }
+    if (previous?.instanceId === session.instanceId) {
+      // Keep the same object while abort is in flight. Its completion/error
+      // path uses object identity to avoid mutating a replacement instance.
+      previous.revision = revision;
+      previous.requiresThreadRotation = true;
+    } else {
+      this.pending.set(session.id, {
+        instanceId: session.instanceId,
+        revision,
+        abortRequested: false,
+        requiresThreadRotation: true,
+        threadRotation: this.snapshotFor(session),
+      });
+    }
+    this.scheduleRetry(session.id);
+    await this.tryApply(session.id);
   }
 
   private snapshotFor(session: CodexRouteRebuildSession): CodexThreadRotationSnapshot | undefined {

--- a/apps/desktop/src/main/maker-ipc/codexRouteRebuild.ts
+++ b/apps/desktop/src/main/maker-ipc/codexRouteRebuild.ts
@@ -36,6 +36,8 @@ export interface CodexRouteRebuildDeps {
   };
   /** Interrupt the current turn before its live proxy route can drift further. */
   abortSession: (sessionId: string) => Promise<void>;
+  /** Serialize thread rotation/close with every local Session.send route decision. */
+  withSessionLock: <T>(sessionId: string, task: () => Promise<T>) => Promise<T>;
   isSessionInTurn?: (sessionId: string) => boolean;
   /** True while Provider routing is intentionally between committed snapshots. */
   isReconciliationBlocked?: () => boolean;
@@ -241,12 +243,15 @@ export class CodexRouteRebuildService {
     if (pending.requiresThreadRotation !== true) return;
     this.applying.add(sessionId);
     void (async () => {
-      if (!(await this.prepareThreadRotation(sessionId, pending))) return;
-      if (this.deps.isReconciliationBlocked?.() === true) {
-        this.scheduleRetry(sessionId);
-        return;
-      }
-      this.finish(sessionId, pending.instanceId, 'session closed');
+      await this.deps.withSessionLock(sessionId, async () => {
+        if (this.pending.get(sessionId) !== pending) return;
+        if (!(await this.prepareThreadRotation(sessionId, pending))) return;
+        if (this.deps.isReconciliationBlocked?.() === true) {
+          this.scheduleRetry(sessionId);
+          return;
+        }
+        this.finish(sessionId, pending.instanceId, 'session closed');
+      });
     })()
       .catch((error) => {
         this.deps.logger?.warn('catalog route rebuild close-boundary rotation failed', {
@@ -316,10 +321,24 @@ export class CodexRouteRebuildService {
         }
         return;
       }
-      if (pending.threadRotation && !pending.preparedThreadRotation) {
-        if (!(await this.prepareThreadRotation(sessionId, pending))) return;
-      }
-      this.finish(sessionId, pending.instanceId, 'session already closed');
+      await this.deps.withSessionLock(sessionId, async () => {
+        if (this.pending.get(sessionId) !== pending) return;
+        const currentSession = this.deps.maker
+          .listActiveSessions()
+          .find((candidate) => candidate.id === sessionId);
+        if (currentSession) {
+          if (currentSession.instanceId !== pending.instanceId) {
+            this.finish(sessionId, pending.instanceId, 'session incarnation changed');
+          } else {
+            this.scheduleRetry(sessionId);
+          }
+          return;
+        }
+        if (pending.threadRotation && !pending.preparedThreadRotation) {
+          if (!(await this.prepareThreadRotation(sessionId, pending))) return;
+        }
+        this.finish(sessionId, pending.instanceId, 'session already closed');
+      });
       return;
     }
     if (
@@ -409,25 +428,41 @@ export class CodexRouteRebuildService {
 
     this.applying.add(sessionId);
     try {
-      if (!(await this.prepareThreadRotation(sessionId, pending, session))) return;
-      await prepareLocalSessionCredentialModeSwitch({
-        maker: this.deps.maker,
-        sessionId,
-        isSessionInTurn: this.deps.isSessionInTurn,
-        signal,
+      await this.deps.withSessionLock(sessionId, async () => {
+        if (this.pending.get(sessionId) !== pending || signal.aborted) return;
+        const currentSession = this.deps.maker
+          .listActiveSessions()
+          .find((candidate) => candidate.id === sessionId);
+        if (
+          currentSession &&
+          (currentSession.instanceId !== pending.instanceId ||
+            currentSession.agentKind !== 'codex' ||
+            currentSession.remoteHostId ||
+            typeof currentSession.codexRouteRequiresCodeModeOnly !== 'boolean')
+        ) {
+          this.finish(sessionId, pending.instanceId, 'session incarnation changed');
+          return;
+        }
+        if (!(await this.prepareThreadRotation(sessionId, pending, currentSession ?? session))) return;
+        await prepareLocalSessionCredentialModeSwitch({
+          maker: this.deps.maker,
+          sessionId,
+          isSessionInTurn: this.deps.isSessionInTurn,
+          signal,
+        });
+        if (this.pending.get(sessionId) !== pending) return;
+        // Provider mutation can start while closeSession is awaiting teardown.
+        // The old thread is already gone, but waking the queue before the new
+        // route snapshot commits could recreate it against an intermediate route.
+        if (
+          this.deps.isReconciliationBlocked?.() === true ||
+          this.deps.getReconciliationGeneration?.() !== routeGeneration
+        ) {
+          this.scheduleRetry(sessionId);
+          return;
+        }
+        this.finish(sessionId, pending.instanceId, 'catalog capability changed');
       });
-      if (this.pending.get(sessionId) !== pending) return;
-      // Provider mutation can start while closeSession is awaiting teardown.
-      // The old thread is already gone, but waking the queue before the new
-      // route snapshot commits could recreate it against an intermediate route.
-      if (
-        this.deps.isReconciliationBlocked?.() === true ||
-        this.deps.getReconciliationGeneration?.() !== routeGeneration
-      ) {
-        this.scheduleRetry(sessionId);
-        return;
-      }
-      this.finish(sessionId, pending.instanceId, 'catalog capability changed');
     } catch (error) {
       if (pending.preparedThreadRotation) {
         await pending.preparedThreadRotation.rollback().catch((rollbackError) => {

--- a/apps/desktop/src/main/maker-ipc/codexRouteRebuild.ts
+++ b/apps/desktop/src/main/maker-ipc/codexRouteRebuild.ts
@@ -7,6 +7,7 @@ import {
 } from '../maker-host/codex-credential-switch.js';
 import {
   codexThreadRotationSnapshotFromSession,
+  isCodexThreadRotationSupersededError,
   type CodexThreadRotationSnapshot,
   type PrepareCodexThreadRotation,
   type PreparedCodexThreadRotation,
@@ -489,6 +490,12 @@ export class CodexRouteRebuildService {
         pending.preparedThreadRotation = prepared;
         return true;
       } catch (error) {
+        if (isCodexThreadRotationSupersededError(error)) {
+          // The DB binding moved to a newer lifecycle while the fork was in
+          // flight. Retire this stale rebuild instead of retrying forever.
+          this.finish(sessionId, pending.instanceId, 'thread rotation superseded');
+          return false;
+        }
         this.deps.logger?.warn('catalog route rebuild thread rotation failed; will retry', {
           sessionId,
           error: error instanceof Error ? error.message : String(error),

--- a/apps/desktop/src/main/maker-ipc/codexRouteRebuild.ts
+++ b/apps/desktop/src/main/maker-ipc/codexRouteRebuild.ts
@@ -24,6 +24,8 @@ export interface CodexRouteRebuildDeps {
     listActiveSessions: () => CodexRouteRebuildSession[];
     closeSession: (sessionId: string) => Promise<void>;
   };
+  /** Interrupt the current turn before its live proxy route can drift further. */
+  abortSession: (sessionId: string) => Promise<void>;
   isSessionInTurn?: (sessionId: string) => boolean;
   /** True while Provider routing is intentionally between committed snapshots. */
   isReconciliationBlocked?: () => boolean;
@@ -41,6 +43,7 @@ export interface CodexRouteRebuildDeps {
 interface PendingRouteRebuild {
   instanceId: string;
   revision: number;
+  abortRequested: boolean;
 }
 
 /**
@@ -50,6 +53,7 @@ interface PendingRouteRebuild {
  */
 export class CodexRouteRebuildService {
   private readonly pending = new Map<string, PendingRouteRebuild>();
+  private readonly interrupting = new Set<string>();
   private readonly applying = new Set<string>();
   private readonly retryTimers = new Map<string, ReturnType<typeof setTimeout>>();
   private reconcileGeneration = 0;
@@ -108,17 +112,41 @@ export class CodexRouteRebuildService {
     for (const comparison of comparisons) {
       if (!comparison) continue;
       const { session, current } = comparison;
+      const previous = this.pending.get(session.id);
       if (current === session.codexRouteRequiresCodeModeOnly) {
+        // Once a busy turn has been interrupted, keep its queue boundary and
+        // rebuild at the abort terminal. A later catalog flip cannot undo an
+        // abort that is already in flight.
+        if (previous?.instanceId === session.instanceId && previous.abortRequested) {
+          previous.revision = revision;
+          this.scheduleRetry(session.id);
+          toApply.push(session.id);
+          continue;
+        }
         this.finish(session.id, session.instanceId, 'catalog capability converged');
         continue;
       }
-      this.pending.set(session.id, { instanceId: session.instanceId, revision });
+      if (previous?.instanceId === session.instanceId) {
+        // Keep the same object while abort is in flight. Its completion/error
+        // path uses object identity to avoid mutating a replacement instance.
+        previous.revision = revision;
+      } else {
+        this.pending.set(session.id, {
+          instanceId: session.instanceId,
+          revision,
+          abortRequested: false,
+        });
+      }
       this.scheduleRetry(session.id);
       toApply.push(session.id);
     }
 
     for (const [sessionId, pending] of [...this.pending]) {
-      if (!scannedIds.has(sessionId) && !this.applying.has(sessionId)) {
+      if (
+        !scannedIds.has(sessionId) &&
+        !this.interrupting.has(sessionId) &&
+        !this.applying.has(sessionId)
+      ) {
         this.finish(sessionId, pending.instanceId, 'session no longer eligible');
       }
     }
@@ -130,7 +158,7 @@ export class CodexRouteRebuildService {
   }
 
   onSessionClosed(sessionId: string): void {
-    if (this.applying.has(sessionId)) return;
+    if (this.interrupting.has(sessionId) || this.applying.has(sessionId)) return;
     const pending = this.pending.get(sessionId);
     if (!pending) return;
     this.finish(sessionId, pending.instanceId, 'session closed');
@@ -143,13 +171,14 @@ export class CodexRouteRebuildService {
     this.lifecycleAbortController = new AbortController();
     for (const timer of this.retryTimers.values()) clearTimeout(timer);
     this.retryTimers.clear();
+    this.interrupting.clear();
     this.pending.clear();
   }
 
   private async tryApply(sessionId: string): Promise<void> {
     const pending = this.pending.get(sessionId);
-    if (!pending || this.applying.has(sessionId)) return;
-    if (this.deps.isReconciliationBlocked?.() === true) {
+    if (!pending || this.interrupting.has(sessionId) || this.applying.has(sessionId)) return;
+    if (!pending.abortRequested && this.deps.isReconciliationBlocked?.() === true) {
       this.scheduleRetry(sessionId);
       return;
     }
@@ -181,40 +210,72 @@ export class CodexRouteRebuildService {
       return;
     }
 
-    let current: boolean;
-    try {
-      current = await this.deps.resolveRequiresCodeModeOnly(session);
-    } catch (error) {
-      this.deps.logger?.warn('catalog route rebuild revalidation failed', {
-        sessionId,
-        revision: pending.revision,
-        error: error instanceof Error ? error.message : String(error),
-      });
-      this.scheduleRetry(sessionId);
-      return;
-    }
-    if (
-      lifecycleGeneration !== this.lifecycleGeneration ||
-      signal.aborted ||
-      this.pending.get(sessionId) !== pending
-    ) return;
-    if (this.deps.isReconciliationBlocked?.() === true) {
-      this.scheduleRetry(sessionId);
-      return;
-    }
-    if (this.deps.getReconciliationGeneration?.() !== routeGeneration) {
-      this.scheduleRetry(sessionId);
-      return;
-    }
-    if (current === session.codexRouteRequiresCodeModeOnly) {
-      this.finish(sessionId, pending.instanceId, 'catalog capability reverted');
-      return;
+    if (!pending.abortRequested) {
+      let current: boolean;
+      try {
+        current = await this.deps.resolveRequiresCodeModeOnly(session);
+      } catch (error) {
+        this.deps.logger?.warn('catalog route rebuild revalidation failed', {
+          sessionId,
+          revision: pending.revision,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        this.scheduleRetry(sessionId);
+        return;
+      }
+      if (
+        lifecycleGeneration !== this.lifecycleGeneration ||
+        signal.aborted ||
+        this.pending.get(sessionId) !== pending
+      )
+        return;
+      if (this.deps.isReconciliationBlocked?.() === true) {
+        this.scheduleRetry(sessionId);
+        return;
+      }
+      if (this.deps.getReconciliationGeneration?.() !== routeGeneration) {
+        this.scheduleRetry(sessionId);
+        return;
+      }
+      if (current === session.codexRouteRequiresCodeModeOnly) {
+        this.finish(sessionId, pending.instanceId, 'catalog capability reverted');
+        return;
+      }
     }
     if (isLocalSessionBusy(session, this.deps.isSessionInTurn)) {
+      // The proxy reads the live catalog on every request, while CodeModeOnly
+      // is sticky on the thread. Do not let later tool rounds in this turn mix
+      // the new route with the old thread capability: interrupt once, keep the
+      // queue gated, then close/rebuild at the terminal boundary.
+      if (!pending.abortRequested) {
+        pending.abortRequested = true;
+        this.interrupting.add(sessionId);
+        let abortSucceeded = false;
+        try {
+          await this.deps.abortSession(sessionId);
+          abortSucceeded = true;
+        } catch (error) {
+          if (this.pending.get(sessionId) === pending) {
+            pending.abortRequested = false;
+            this.deps.logger?.warn('catalog route rebuild abort failed; will retry', {
+              sessionId,
+              revision: pending.revision,
+              error: error instanceof Error ? error.message : String(error),
+            });
+          }
+        } finally {
+          this.interrupting.delete(sessionId);
+        }
+        if (abortSucceeded && this.pending.has(sessionId)) {
+          await this.tryApply(sessionId);
+          return;
+        }
+      }
+      if (this.pending.get(sessionId) !== pending) return;
       this.scheduleRetry(sessionId);
       return;
     }
-    if (this.deps.isReconciliationBlocked?.() === true) {
+    if (!pending.abortRequested && this.deps.isReconciliationBlocked?.() === true) {
       this.scheduleRetry(sessionId);
       return;
     }

--- a/apps/desktop/src/main/maker-ipc/codexRouteRebuild.ts
+++ b/apps/desktop/src/main/maker-ipc/codexRouteRebuild.ts
@@ -88,6 +88,24 @@ export class CodexRouteRebuildService {
       return;
     }
 
+    // The proxy observes the new catalog immediately, while capability
+    // resolution can await connected Provider state. Gate every candidate
+    // before that await so no later tool round can reuse the old thread
+    // profile against the new live route.
+    for (const session of sessions) {
+      const previous = this.pending.get(session.id);
+      if (previous?.instanceId === session.instanceId) {
+        previous.revision = revision;
+      } else {
+        this.pending.set(session.id, {
+          instanceId: session.instanceId,
+          revision,
+          abortRequested: false,
+        });
+      }
+      this.scheduleRetry(session.id);
+    }
+
     const comparisons = await Promise.all(
       sessions.map(async (session) => {
         try {

--- a/apps/desktop/src/main/maker-ipc/codexRouteRebuild.ts
+++ b/apps/desktop/src/main/maker-ipc/codexRouteRebuild.ts
@@ -5,6 +5,12 @@ import {
   isLocalSessionBusy,
   prepareLocalSessionCredentialModeSwitch,
 } from '../maker-host/codex-credential-switch.js';
+import {
+  codexThreadRotationSnapshotFromSession,
+  type CodexThreadRotationSnapshot,
+  type PrepareCodexThreadRotation,
+  type PreparedCodexThreadRotation,
+} from './codexThreadRotation.js';
 
 const DEFAULT_RETRY_DELAY_MS = 10_000;
 
@@ -14,6 +20,9 @@ export interface CodexRouteRebuildSession {
   agentKind: AgentKind;
   remoteHostId?: string | null;
   model: string;
+  sdkSessionId?: string | null;
+  workDir?: string | null;
+  providerId?: string | null;
   codexRouteRequiresCodeModeOnly?: boolean;
   codexRouteCredentialMode?: AgentCredentialMode;
   isTurnRunning?: () => boolean;
@@ -32,6 +41,8 @@ export interface CodexRouteRebuildDeps {
   /** Changes whenever a Provider route mutation starts, including transient ones. */
   getReconciliationGeneration?: () => number;
   resolveRequiresCodeModeOnly: (session: CodexRouteRebuildSession) => Promise<boolean>;
+  getProviderId?: (sessionId: string) => string | null;
+  prepareCodexThreadRotation?: PrepareCodexThreadRotation;
   onApplied?: (sessionId: string) => void;
   retryDelayMs?: number;
   logger?: {
@@ -44,6 +55,12 @@ interface PendingRouteRebuild {
   instanceId: string;
   revision: number;
   abortRequested: boolean;
+  /** Set only after the live catalog comparison confirms a capability change. */
+  requiresThreadRotation?: boolean;
+  /** A close arrived while the async capability comparison was still pending. */
+  closeObserved?: boolean;
+  threadRotation?: CodexThreadRotationSnapshot;
+  preparedThreadRotation?: PreparedCodexThreadRotation;
 }
 
 /**
@@ -55,6 +72,7 @@ export class CodexRouteRebuildService {
   private readonly pending = new Map<string, PendingRouteRebuild>();
   private readonly interrupting = new Set<string>();
   private readonly applying = new Set<string>();
+  private readonly rotationTasks = new Set<Promise<boolean>>();
   private readonly retryTimers = new Map<string, ReturnType<typeof setTimeout>>();
   private reconcileGeneration = 0;
   private lifecycleGeneration = 0;
@@ -96,11 +114,18 @@ export class CodexRouteRebuildService {
       const previous = this.pending.get(session.id);
       if (previous?.instanceId === session.instanceId) {
         previous.revision = revision;
+        if (!previous.abortRequested) {
+          // A new catalog revision invalidates the prior comparison. Keep the
+          // candidate gated, but do not let a close race reuse the old result.
+          previous.requiresThreadRotation = undefined;
+          previous.closeObserved = false;
+        }
       } else {
         this.pending.set(session.id, {
           instanceId: session.instanceId,
           revision,
           abortRequested: false,
+          threadRotation: this.snapshotFor(session),
         });
       }
       this.scheduleRetry(session.id);
@@ -132,6 +157,9 @@ export class CodexRouteRebuildService {
       const { session, current } = comparison;
       const previous = this.pending.get(session.id);
       if (current === session.codexRouteRequiresCodeModeOnly) {
+        if (previous?.instanceId === session.instanceId) {
+          previous.requiresThreadRotation = false;
+        }
         // Once a busy turn has been interrupted, keep its queue boundary and
         // rebuild at the abort terminal. A later catalog flip cannot undo an
         // abort that is already in flight.
@@ -148,11 +176,14 @@ export class CodexRouteRebuildService {
         // Keep the same object while abort is in flight. Its completion/error
         // path uses object identity to avoid mutating a replacement instance.
         previous.revision = revision;
+        previous.requiresThreadRotation = true;
       } else {
         this.pending.set(session.id, {
           instanceId: session.instanceId,
           revision,
           abortRequested: false,
+          requiresThreadRotation: true,
+          threadRotation: this.snapshotFor(session),
         });
       }
       this.scheduleRetry(session.id);
@@ -168,6 +199,24 @@ export class CodexRouteRebuildService {
         this.finish(sessionId, pending.instanceId, 'session no longer eligible');
       }
     }
+    // A session can close while its comparison is in flight. If that lookup
+    // failed, retire the gate without rotating; there is no positive evidence
+    // that the thread crossed a CodeModeOnly boundary.
+    const comparedIds = new Set(
+      comparisons.filter((comparison): comparison is { session: CodexRouteRebuildSession; current: boolean } =>
+        comparison !== null,
+      ).map(({ session }) => session.id),
+    );
+    for (const session of sessions) {
+      const pending = this.pending.get(session.id);
+      if (
+        pending?.instanceId === session.instanceId &&
+        pending.closeObserved &&
+        !comparedIds.has(session.id)
+      ) {
+        this.finish(session.id, pending.instanceId, 'capability comparison failed after session close');
+      }
+    }
     await Promise.all(toApply.map((sessionId) => this.tryApply(sessionId)));
   }
 
@@ -179,10 +228,42 @@ export class CodexRouteRebuildService {
     if (this.interrupting.has(sessionId) || this.applying.has(sessionId)) return;
     const pending = this.pending.get(sessionId);
     if (!pending) return;
-    this.finish(sessionId, pending.instanceId, 'session closed');
+    // The close may race the asynchronous catalog comparison. Do not fork a
+    // new thread until that comparison has positively confirmed a capability
+    // change; a failed or still-pending lookup must not rotate an unchanged
+    // session as a side effect of an unrelated close.
+    if (pending.requiresThreadRotation === false) {
+      this.finish(sessionId, pending.instanceId, 'catalog capability unchanged');
+      return;
+    }
+    pending.closeObserved = true;
+    if (pending.requiresThreadRotation !== true) return;
+    this.applying.add(sessionId);
+    void (async () => {
+      if (!(await this.prepareThreadRotation(sessionId, pending))) return;
+      if (this.deps.isReconciliationBlocked?.() === true) {
+        this.scheduleRetry(sessionId);
+        return;
+      }
+      this.finish(sessionId, pending.instanceId, 'session closed');
+    })()
+      .catch((error) => {
+        this.deps.logger?.warn('catalog route rebuild close-boundary rotation failed', {
+          sessionId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        this.scheduleRetry(sessionId);
+      })
+      .finally(() => {
+        this.applying.delete(sessionId);
+      });
   }
 
   clear(): void {
+    void this.clearAsync();
+  }
+
+  async clearAsync(): Promise<void> {
     this.reconcileGeneration += 1;
     this.lifecycleGeneration += 1;
     this.lifecycleAbortController.abort();
@@ -190,7 +271,14 @@ export class CodexRouteRebuildService {
     for (const timer of this.retryTimers.values()) clearTimeout(timer);
     this.retryTimers.clear();
     this.interrupting.clear();
+    const prepared = [...this.pending.values()]
+      .map((pending) => pending.preparedThreadRotation)
+      .filter((rotation): rotation is PreparedCodexThreadRotation => rotation !== undefined);
     this.pending.clear();
+    await Promise.allSettled([
+      ...prepared.map((rotation) => rotation.rollback()),
+      ...this.rotationTasks,
+    ]);
   }
 
   private async tryApply(sessionId: string): Promise<void> {
@@ -217,8 +305,23 @@ export class CodexRouteRebuildService {
       this.scheduleRetry(sessionId);
       return;
     }
+    if (!session) {
+      pending.closeObserved = true;
+      if (pending.requiresThreadRotation !== true) {
+        if (pending.requiresThreadRotation === false) {
+          this.finish(sessionId, pending.instanceId, 'catalog capability unchanged');
+        } else {
+          this.scheduleRetry(sessionId);
+        }
+        return;
+      }
+      if (pending.threadRotation && !pending.preparedThreadRotation) {
+        if (!(await this.prepareThreadRotation(sessionId, pending))) return;
+      }
+      this.finish(sessionId, pending.instanceId, 'session already closed');
+      return;
+    }
     if (
-      !session ||
       session.instanceId !== pending.instanceId ||
       session.agentKind !== 'codex' ||
       session.remoteHostId ||
@@ -256,9 +359,11 @@ export class CodexRouteRebuildService {
         return;
       }
       if (current === session.codexRouteRequiresCodeModeOnly) {
+        pending.requiresThreadRotation = false;
         this.finish(sessionId, pending.instanceId, 'catalog capability reverted');
         return;
       }
+      pending.requiresThreadRotation = true;
     }
     if (isLocalSessionBusy(session, this.deps.isSessionInTurn)) {
       // The proxy reads the live catalog on every request, while CodeModeOnly
@@ -303,6 +408,7 @@ export class CodexRouteRebuildService {
 
     this.applying.add(sessionId);
     try {
+      if (!(await this.prepareThreadRotation(sessionId, pending, session))) return;
       await prepareLocalSessionCredentialModeSwitch({
         maker: this.deps.maker,
         sessionId,
@@ -322,6 +428,15 @@ export class CodexRouteRebuildService {
       }
       this.finish(sessionId, pending.instanceId, 'catalog capability changed');
     } catch (error) {
+      if (pending.preparedThreadRotation) {
+        await pending.preparedThreadRotation.rollback().catch((rollbackError) => {
+          this.deps.logger?.warn('catalog route rebuild thread rotation rollback failed', {
+            sessionId,
+            error: rollbackError instanceof Error ? rollbackError.message : String(rollbackError),
+          });
+        });
+        pending.preparedThreadRotation = undefined;
+      }
       if (!isCredentialModeSwitchBusyError(error)) {
         this.deps.logger?.warn('catalog route rebuild close failed; will retry', {
           sessionId,
@@ -332,6 +447,61 @@ export class CodexRouteRebuildService {
       if (this.pending.get(sessionId) === pending) this.scheduleRetry(sessionId);
     } finally {
       this.applying.delete(sessionId);
+    }
+  }
+
+  private snapshotFor(session: CodexRouteRebuildSession): CodexThreadRotationSnapshot | undefined {
+    if (!this.deps.prepareCodexThreadRotation) return undefined;
+    return codexThreadRotationSnapshotFromSession(
+      {
+        id: session.id,
+        agentKind: session.agentKind,
+        remoteHostId: session.remoteHostId,
+        sdkSessionId: session.sdkSessionId,
+        model: session.model,
+        workDir: session.workDir,
+      },
+      this.deps.getProviderId?.(session.id) ?? session.providerId ?? null,
+    ) ?? undefined;
+  }
+
+  private async prepareThreadRotation(
+    sessionId: string,
+    pending: PendingRouteRebuild,
+    session?: CodexRouteRebuildSession,
+  ): Promise<boolean> {
+    if (!pending.threadRotation && session) pending.threadRotation = this.snapshotFor(session);
+    if (!pending.threadRotation || pending.preparedThreadRotation) return true;
+    if (!this.deps.prepareCodexThreadRotation) {
+      this.deps.logger?.warn('catalog route rebuild: Codex thread rotation unavailable; will retry', {
+        sessionId,
+      });
+      this.scheduleRetry(sessionId);
+      return false;
+    }
+    const task = (async (): Promise<boolean> => {
+      try {
+        const prepared = await this.deps.prepareCodexThreadRotation!(pending.threadRotation!);
+        if (this.pending.get(sessionId) !== pending) {
+          await prepared.rollback();
+          return false;
+        }
+        pending.preparedThreadRotation = prepared;
+        return true;
+      } catch (error) {
+        this.deps.logger?.warn('catalog route rebuild thread rotation failed; will retry', {
+          sessionId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        this.scheduleRetry(sessionId);
+        return false;
+      }
+    })();
+    this.rotationTasks.add(task);
+    try {
+      return await task;
+    } finally {
+      this.rotationTasks.delete(task);
     }
   }
 

--- a/apps/desktop/src/main/maker-ipc/codexRouteRebuild.ts
+++ b/apps/desktop/src/main/maker-ipc/codexRouteRebuild.ts
@@ -1,0 +1,276 @@
+import type { AgentKind } from '@cindy/maker-core';
+
+import {
+  isCredentialModeSwitchBusyError,
+  isLocalSessionBusy,
+  prepareLocalSessionCredentialModeSwitch,
+} from '../maker-host/codex-credential-switch.js';
+
+const DEFAULT_RETRY_DELAY_MS = 10_000;
+
+export interface CodexRouteRebuildSession {
+  id: string;
+  instanceId: string;
+  agentKind: AgentKind;
+  remoteHostId?: string | null;
+  model: string;
+  codexRouteRequiresCodeModeOnly?: boolean;
+  isTurnRunning?: () => boolean;
+}
+
+export interface CodexRouteRebuildDeps {
+  maker: {
+    listActiveSessions: () => CodexRouteRebuildSession[];
+    closeSession: (sessionId: string) => Promise<void>;
+  };
+  isSessionInTurn?: (sessionId: string) => boolean;
+  /** True while Provider routing is intentionally between committed snapshots. */
+  isReconciliationBlocked?: () => boolean;
+  /** Changes whenever a Provider route mutation starts, including transient ones. */
+  getReconciliationGeneration?: () => number;
+  resolveRequiresCodeModeOnly: (session: CodexRouteRebuildSession) => Promise<boolean>;
+  onApplied?: (sessionId: string) => void;
+  retryDelayMs?: number;
+  logger?: {
+    info: (message: string, meta?: Record<string, unknown>) => void;
+    warn: (message: string, meta?: Record<string, unknown>) => void;
+  };
+}
+
+interface PendingRouteRebuild {
+  instanceId: string;
+  revision: number;
+}
+
+/**
+ * Rebuilds only local Codex sessions whose thread-frozen CodeModeOnly value no
+ * longer matches the live catalog route. Busy sessions remain queue-gated
+ * until their terminal boundary; provider/model persistence is untouched.
+ */
+export class CodexRouteRebuildService {
+  private readonly pending = new Map<string, PendingRouteRebuild>();
+  private readonly applying = new Set<string>();
+  private readonly retryTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  private reconcileGeneration = 0;
+  private lifecycleGeneration = 0;
+  private lifecycleAbortController = new AbortController();
+
+  constructor(private readonly deps: CodexRouteRebuildDeps) {}
+
+  has(sessionId: string): boolean {
+    return this.pending.has(sessionId);
+  }
+
+  async reconcile(revision: number): Promise<void> {
+    if (this.deps.isReconciliationBlocked?.() === true) return;
+    const routeGeneration = this.deps.getReconciliationGeneration?.();
+    const generation = ++this.reconcileGeneration;
+    let sessions: CodexRouteRebuildSession[];
+    try {
+      sessions = this.deps.maker
+        .listActiveSessions()
+        .filter(
+          (session) =>
+            session.agentKind === 'codex' &&
+            !session.remoteHostId &&
+            typeof session.codexRouteRequiresCodeModeOnly === 'boolean',
+        );
+    } catch (error) {
+      this.deps.logger?.warn('catalog route rebuild scan failed', {
+        revision,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return;
+    }
+
+    const comparisons = await Promise.all(
+      sessions.map(async (session) => {
+        try {
+          const current = await this.deps.resolveRequiresCodeModeOnly(session);
+          return { session, current } as const;
+        } catch (error) {
+          this.deps.logger?.warn('catalog route capability resolve failed', {
+            revision,
+            sessionId: session.id,
+            error: error instanceof Error ? error.message : String(error),
+          });
+          return null;
+        }
+      }),
+    );
+    if (generation !== this.reconcileGeneration) return;
+    if (this.deps.isReconciliationBlocked?.() === true) return;
+    if (this.deps.getReconciliationGeneration?.() !== routeGeneration) return;
+
+    const scannedIds = new Set(sessions.map((session) => session.id));
+    const toApply: string[] = [];
+    for (const comparison of comparisons) {
+      if (!comparison) continue;
+      const { session, current } = comparison;
+      if (current === session.codexRouteRequiresCodeModeOnly) {
+        this.finish(session.id, session.instanceId, 'catalog capability converged');
+        continue;
+      }
+      this.pending.set(session.id, { instanceId: session.instanceId, revision });
+      this.scheduleRetry(session.id);
+      toApply.push(session.id);
+    }
+
+    for (const [sessionId, pending] of [...this.pending]) {
+      if (!scannedIds.has(sessionId)) {
+        this.finish(sessionId, pending.instanceId, 'session no longer eligible');
+      }
+    }
+    await Promise.all(toApply.map((sessionId) => this.tryApply(sessionId)));
+  }
+
+  onTurnSettled(sessionId: string): Promise<void> {
+    return this.tryApply(sessionId);
+  }
+
+  onSessionClosed(sessionId: string): void {
+    if (this.applying.has(sessionId)) return;
+    const pending = this.pending.get(sessionId);
+    if (!pending) return;
+    this.finish(sessionId, pending.instanceId, 'session closed');
+  }
+
+  clear(): void {
+    this.reconcileGeneration += 1;
+    this.lifecycleGeneration += 1;
+    this.lifecycleAbortController.abort();
+    this.lifecycleAbortController = new AbortController();
+    for (const timer of this.retryTimers.values()) clearTimeout(timer);
+    this.retryTimers.clear();
+    this.pending.clear();
+  }
+
+  private async tryApply(sessionId: string): Promise<void> {
+    const pending = this.pending.get(sessionId);
+    if (!pending || this.applying.has(sessionId)) return;
+    if (this.deps.isReconciliationBlocked?.() === true) {
+      this.scheduleRetry(sessionId);
+      return;
+    }
+    const routeGeneration = this.deps.getReconciliationGeneration?.();
+    const lifecycleGeneration = this.lifecycleGeneration;
+    const signal = this.lifecycleAbortController.signal;
+
+    let session: CodexRouteRebuildSession | undefined;
+    try {
+      session = this.deps.maker
+        .listActiveSessions()
+        .find((candidate) => candidate.id === sessionId);
+    } catch (error) {
+      this.deps.logger?.warn('catalog route rebuild live-session read failed', {
+        sessionId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      this.scheduleRetry(sessionId);
+      return;
+    }
+    if (
+      !session ||
+      session.instanceId !== pending.instanceId ||
+      session.agentKind !== 'codex' ||
+      session.remoteHostId ||
+      typeof session.codexRouteRequiresCodeModeOnly !== 'boolean'
+    ) {
+      this.finish(sessionId, pending.instanceId, 'session incarnation changed');
+      return;
+    }
+
+    let current: boolean;
+    try {
+      current = await this.deps.resolveRequiresCodeModeOnly(session);
+    } catch (error) {
+      this.deps.logger?.warn('catalog route rebuild revalidation failed', {
+        sessionId,
+        revision: pending.revision,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      this.scheduleRetry(sessionId);
+      return;
+    }
+    if (
+      lifecycleGeneration !== this.lifecycleGeneration ||
+      signal.aborted ||
+      this.pending.get(sessionId) !== pending
+    ) return;
+    if (this.deps.isReconciliationBlocked?.() === true) {
+      this.scheduleRetry(sessionId);
+      return;
+    }
+    if (this.deps.getReconciliationGeneration?.() !== routeGeneration) {
+      this.scheduleRetry(sessionId);
+      return;
+    }
+    if (current === session.codexRouteRequiresCodeModeOnly) {
+      this.finish(sessionId, pending.instanceId, 'catalog capability reverted');
+      return;
+    }
+    if (isLocalSessionBusy(session, this.deps.isSessionInTurn)) {
+      this.scheduleRetry(sessionId);
+      return;
+    }
+    if (this.deps.isReconciliationBlocked?.() === true) {
+      this.scheduleRetry(sessionId);
+      return;
+    }
+    // Multiple terminal/status/retry signals can finish the same async
+    // revalidation together. Claim the close only after the await boundary.
+    if (this.applying.has(sessionId)) return;
+
+    this.applying.add(sessionId);
+    try {
+      await prepareLocalSessionCredentialModeSwitch({
+        maker: this.deps.maker,
+        sessionId,
+        isSessionInTurn: this.deps.isSessionInTurn,
+        signal,
+      });
+      if (this.pending.get(sessionId) === pending) {
+        this.finish(sessionId, pending.instanceId, 'catalog capability changed');
+      }
+    } catch (error) {
+      if (!isCredentialModeSwitchBusyError(error)) {
+        this.deps.logger?.warn('catalog route rebuild close failed; will retry', {
+          sessionId,
+          revision: pending.revision,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+      if (this.pending.get(sessionId) === pending) this.scheduleRetry(sessionId);
+    } finally {
+      this.applying.delete(sessionId);
+    }
+  }
+
+  private finish(sessionId: string, instanceId: string, reason: string): void {
+    const pending = this.pending.get(sessionId);
+    if (!pending || pending.instanceId !== instanceId) return;
+    this.pending.delete(sessionId);
+    const timer = this.retryTimers.get(sessionId);
+    if (timer) clearTimeout(timer);
+    this.retryTimers.delete(sessionId);
+    this.deps.logger?.info('catalog route rebuild settled', { sessionId, reason });
+    try {
+      this.deps.onApplied?.(sessionId);
+    } catch (error) {
+      this.deps.logger?.warn('catalog route rebuild wake failed', {
+        sessionId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  private scheduleRetry(sessionId: string): void {
+    if (!this.pending.has(sessionId) || this.retryTimers.has(sessionId)) return;
+    const timer = setTimeout(() => {
+      this.retryTimers.delete(sessionId);
+      void this.tryApply(sessionId);
+    }, this.deps.retryDelayMs ?? DEFAULT_RETRY_DELAY_MS);
+    (timer as unknown as { unref?: () => void }).unref?.();
+    this.retryTimers.set(sessionId, timer);
+  }
+}

--- a/apps/desktop/src/main/maker-ipc/codexRouteRebuild.ts
+++ b/apps/desktop/src/main/maker-ipc/codexRouteRebuild.ts
@@ -1,4 +1,4 @@
-import type { AgentKind } from '@cindy/maker-core';
+import type { AgentCredentialMode, AgentKind } from '@cindy/maker-core';
 
 import {
   isCredentialModeSwitchBusyError,
@@ -15,6 +15,7 @@ export interface CodexRouteRebuildSession {
   remoteHostId?: string | null;
   model: string;
   codexRouteRequiresCodeModeOnly?: boolean;
+  codexRouteCredentialMode?: AgentCredentialMode;
   isTurnRunning?: () => boolean;
 }
 
@@ -117,7 +118,7 @@ export class CodexRouteRebuildService {
     }
 
     for (const [sessionId, pending] of [...this.pending]) {
-      if (!scannedIds.has(sessionId)) {
+      if (!scannedIds.has(sessionId) && !this.applying.has(sessionId)) {
         this.finish(sessionId, pending.instanceId, 'session no longer eligible');
       }
     }
@@ -229,9 +230,18 @@ export class CodexRouteRebuildService {
         isSessionInTurn: this.deps.isSessionInTurn,
         signal,
       });
-      if (this.pending.get(sessionId) === pending) {
-        this.finish(sessionId, pending.instanceId, 'catalog capability changed');
+      if (this.pending.get(sessionId) !== pending) return;
+      // Provider mutation can start while closeSession is awaiting teardown.
+      // The old thread is already gone, but waking the queue before the new
+      // route snapshot commits could recreate it against an intermediate route.
+      if (
+        this.deps.isReconciliationBlocked?.() === true ||
+        this.deps.getReconciliationGeneration?.() !== routeGeneration
+      ) {
+        this.scheduleRetry(sessionId);
+        return;
       }
+      this.finish(sessionId, pending.instanceId, 'catalog capability changed');
     } catch (error) {
       if (!isCredentialModeSwitchBusyError(error)) {
         this.deps.logger?.warn('catalog route rebuild close failed; will retry', {

--- a/apps/desktop/src/main/maker-ipc/codexThreadRotation.ts
+++ b/apps/desktop/src/main/maker-ipc/codexThreadRotation.ts
@@ -13,6 +13,31 @@ export interface PreparedCodexThreadRotation {
   rollback: () => Promise<void>;
 }
 
+/**
+ * The session binding changed while this rotation was being prepared.  A
+ * newer lifecycle (clear, agent switch, or another rotation) owns the
+ * session now; retrying this snapshot would keep the input gate open forever.
+ */
+export class CodexThreadRotationSupersededError extends Error {
+  readonly code = 'CODEX_THREAD_ROTATION_SUPERSEDED';
+
+  constructor(sessionId: string) {
+    super(`Codex thread rotation was superseded by a newer session binding: ${sessionId}`);
+    this.name = 'CodexThreadRotationSupersededError';
+  }
+}
+
+export function isCodexThreadRotationSupersededError(
+  error: unknown,
+): error is CodexThreadRotationSupersededError {
+  return (
+    error instanceof CodexThreadRotationSupersededError ||
+    (typeof error === 'object' &&
+      error !== null &&
+      (error as { code?: unknown }).code === 'CODEX_THREAD_ROTATION_SUPERSEDED')
+  );
+}
+
 export type PrepareCodexThreadRotation = (
   snapshot: CodexThreadRotationSnapshot,
 ) => Promise<PreparedCodexThreadRotation>;
@@ -71,9 +96,7 @@ export function createCodexThreadRotationPreparer(args: {
       fork.newSdkSessionId,
     );
     if (!applied) {
-      throw new Error(
-        `Codex thread rotation lost its session binding: ${snapshot.sessionId}`,
-      );
+      throw new CodexThreadRotationSupersededError(snapshot.sessionId);
     }
     let rolledBack = false;
     return {

--- a/apps/desktop/src/main/maker-ipc/codexThreadRotation.ts
+++ b/apps/desktop/src/main/maker-ipc/codexThreadRotation.ts
@@ -1,0 +1,97 @@
+import type { AgentKind, Maker } from '@cindy/maker-core';
+
+export interface CodexThreadRotationSnapshot {
+  sessionId: string;
+  sourceSdkSessionId: string;
+  sourceModel: string;
+  sourceProviderId: string | null;
+  workingDir: string;
+}
+
+export interface PreparedCodexThreadRotation {
+  newSdkSessionId: string;
+  rollback: () => Promise<void>;
+}
+
+export type PrepareCodexThreadRotation = (
+  snapshot: CodexThreadRotationSnapshot,
+) => Promise<PreparedCodexThreadRotation>;
+
+export function codexThreadRotationSnapshotFromSession(
+  session: {
+    id: string;
+    agentKind: AgentKind;
+    remoteHostId?: string | null;
+    sdkSessionId?: string | null;
+    model: string;
+    workDir?: string | null;
+  },
+  providerId: string | null,
+): CodexThreadRotationSnapshot | null {
+  const sdkSessionId = session.sdkSessionId;
+  const workingDir = session.workDir;
+  if (
+    session.agentKind !== 'codex' ||
+    session.remoteHostId ||
+    !sdkSessionId ||
+    sdkSessionId === '<pending>' ||
+    !workingDir
+  ) {
+    return null;
+  }
+  return {
+    sessionId: session.id,
+    sourceSdkSessionId: sdkSessionId,
+    sourceModel: session.model,
+    sourceProviderId: providerId,
+    workingDir,
+  };
+}
+
+export function createCodexThreadRotationPreparer(args: {
+  maker: Pick<Maker, 'forkSdkSession'>;
+  replaceSdkSessionIdIfCurrent: (
+    sessionId: string,
+    expectedSdkSessionId: string,
+    nextSdkSessionId: string,
+  ) => Promise<boolean>;
+}): PrepareCodexThreadRotation {
+  return async (snapshot) => {
+    const fork = await args.maker.forkSdkSession('codex', {
+      sourceSdkSessionId: snapshot.sourceSdkSessionId,
+      model: snapshot.sourceModel,
+      providerId: snapshot.sourceProviderId,
+      workingDir: snapshot.workingDir,
+      upToMessageId: undefined,
+      stripEncryptedReasoning: true,
+    });
+    const applied = await args.replaceSdkSessionIdIfCurrent(
+      snapshot.sessionId,
+      snapshot.sourceSdkSessionId,
+      fork.newSdkSessionId,
+    );
+    if (!applied) {
+      throw new Error(
+        `Codex thread rotation lost its session binding: ${snapshot.sessionId}`,
+      );
+    }
+    let rolledBack = false;
+    return {
+      newSdkSessionId: fork.newSdkSessionId,
+      rollback: async () => {
+        if (rolledBack) return;
+        rolledBack = true;
+        const restored = await args.replaceSdkSessionIdIfCurrent(
+          snapshot.sessionId,
+          fork.newSdkSessionId,
+          snapshot.sourceSdkSessionId,
+        );
+        if (!restored) {
+          throw new Error(
+            `Codex thread rotation rollback lost its session binding: ${snapshot.sessionId}`,
+          );
+        }
+      },
+    };
+  };
+}

--- a/apps/desktop/src/main/maker-ipc/pendingCredentialSwitch.ts
+++ b/apps/desktop/src/main/maker-ipc/pendingCredentialSwitch.ts
@@ -11,6 +11,7 @@ import type {
   PrepareCodexThreadRotation,
   PreparedCodexThreadRotation,
 } from './codexThreadRotation.js';
+import { isCodexThreadRotationSupersededError } from './codexThreadRotation.js';
 
 /**
  * PendingCredentialSwitchService —— 会话凭证形态切换的「延迟生效」登记表。
@@ -206,6 +207,23 @@ export class PendingCredentialSwitchService {
         target.preparedCodexThreadRotation = prepared;
         return true;
       } catch (err) {
+        if (isCodexThreadRotationSupersededError(err)) {
+          // A newer lifecycle already owns the session binding. Retrying this
+          // stale snapshot would keep the input queue gated forever.
+          if (this.pending.get(sessionId) === target) {
+            this.pending.delete(sessionId);
+            this.clearRetry(sessionId);
+            try {
+              this.deps.onApplied?.(sessionId);
+            } catch (wakeError) {
+              this.deps.logger?.warn('pending credential switch: superseded wake failed', {
+                sessionId,
+                error: wakeError instanceof Error ? wakeError.message : String(wakeError),
+              });
+            }
+          }
+          return false;
+        }
         this.deps.logger?.warn('pending credential switch: Codex thread rotation failed; keeping queue gated for retry', {
           sessionId,
           error: err instanceof Error ? err.message : String(err),

--- a/apps/desktop/src/main/maker-ipc/pendingCredentialSwitch.ts
+++ b/apps/desktop/src/main/maker-ipc/pendingCredentialSwitch.ts
@@ -127,12 +127,17 @@ export class PendingCredentialSwitchService {
   /** 同一会话的 apply 串行化:turn done/error 双事件可能背靠背触发。 */
   private readonly applying = new Set<string>();
   private readonly rotationTasks = new Set<Promise<boolean>>();
+  private readonly rotationTasksBySession = new Map<string, Promise<boolean>>();
+  private readonly rotationCleanupTasks = new Map<string, Promise<void>>();
+  /** clear 已取消登记,但旧 close / rotation 尚未收口;期间输入队列必须继续 gated。 */
+  private readonly cancelling = new Set<string>();
+  private readonly applySettledWaiters = new Map<string, Set<() => void>>();
   /** 自愈兜底定时器(per session,pending 收口即清)。 */
   private readonly retryTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
   constructor(private readonly deps: PendingCredentialSwitchDeps) {}
 
-  register(
+  async register(
     sessionId: string,
     target: {
       model: string;
@@ -141,7 +146,8 @@ export class PendingCredentialSwitchService {
       previousRoute?: { model: string; providerId: string | null; effort?: string; fastMode?: boolean };
       codexThreadRotation?: CodexThreadRotationSnapshot;
     },
-  ): void {
+  ): Promise<void> {
+    const previous = this.pending.get(sessionId);
     this.pending.set(sessionId, {
       model: target.model,
       providerId: target.providerId,
@@ -156,19 +162,46 @@ export class PendingCredentialSwitchService {
       model: target.model,
       providerId: target.providerId,
     });
+    if (previous?.preparedCodexThreadRotation) {
+      this.enqueueRotationCleanup(sessionId, previous.preparedCodexThreadRotation);
+      previous.preparedCodexThreadRotation = undefined;
+    }
+    await this.waitForRotationWork(sessionId);
   }
 
   has(sessionId: string): boolean {
-    return this.pending.has(sessionId);
+    return (
+      this.pending.has(sessionId) ||
+      this.cancelling.has(sessionId) ||
+      this.rotationCleanupTasks.has(sessionId)
+    );
   }
 
   get(sessionId: string): PendingCredentialSwitch | undefined {
     return this.pending.get(sessionId);
   }
 
-  clear(sessionId: string): void {
+  async clear(sessionId: string): Promise<void> {
+    const target = this.pending.get(sessionId);
+    const hasLifecycleWork =
+      target !== undefined ||
+      this.applying.has(sessionId) ||
+      this.rotationTasksBySession.has(sessionId) ||
+      this.rotationCleanupTasks.has(sessionId);
+    if (hasLifecycleWork) this.cancelling.add(sessionId);
     this.pending.delete(sessionId);
     this.clearRetry(sessionId);
+    if (target?.preparedCodexThreadRotation) {
+      this.enqueueRotationCleanup(sessionId, target.preparedCodexThreadRotation);
+      target.preparedCodexThreadRotation = undefined;
+    }
+    try {
+      await this.waitForRotationWork(sessionId);
+      await this.waitForApplyToSettle(sessionId);
+      await this.waitForRotationWork(sessionId);
+    } finally {
+      this.cancelling.delete(sessionId);
+    }
   }
 
   /** Drop every owner-scoped deferred switch without applying it. */
@@ -182,13 +215,91 @@ export class PendingCredentialSwitchService {
     await Promise.allSettled([
       ...prepared.map((rotation) => rotation.rollback()),
       ...this.rotationTasks,
+      ...this.rotationCleanupTasks.values(),
     ]);
+    // Owner replacement makes every old session binding unreachable. Drop
+    // fail-closed cleanup gates as part of the same owner-scoped reset.
+    this.rotationTasksBySession.clear();
+    this.rotationCleanupTasks.clear();
+    this.cancelling.clear();
+  }
+
+  private enqueueRotationCleanup(
+    sessionId: string,
+    rotation: PreparedCodexThreadRotation,
+  ): Promise<void> {
+    const previous = this.rotationCleanupTasks.get(sessionId);
+    const task = (async () => {
+      await previous;
+      await rotation.rollback();
+    })();
+    this.rotationCleanupTasks.set(sessionId, task);
+    void task.then(
+      () => {
+        if (this.rotationCleanupTasks.get(sessionId) === task) {
+          this.rotationCleanupTasks.delete(sessionId);
+        }
+      },
+      (error) => {
+        // Keep the failed cleanup as a gate: releasing queued input after a
+        // lost rollback would resume an indeterminate native thread binding.
+        this.clearRetry(sessionId);
+        const meta = {
+          sessionId,
+          error: error instanceof Error ? error.message : String(error),
+        };
+        if (this.deps.logger?.error) {
+          this.deps.logger.error(
+            'pending credential switch: thread rotation rollback failed; keeping queue gated',
+            meta,
+          );
+        } else {
+          this.deps.logger?.warn(
+            'pending credential switch: thread rotation rollback failed; keeping queue gated',
+            meta,
+          );
+        }
+      },
+    );
+    return task;
+  }
+
+  private async waitForRotationWork(sessionId: string): Promise<boolean> {
+    try {
+      while (true) {
+        const cleanup = this.rotationCleanupTasks.get(sessionId);
+        const preparation = this.rotationTasksBySession.get(sessionId);
+        if (!cleanup && !preparation) return true;
+        await Promise.all([cleanup ?? Promise.resolve(), preparation ?? Promise.resolve()]);
+      }
+    } catch {
+      return false;
+    }
+  }
+
+  private waitForApplyToSettle(sessionId: string): Promise<void> {
+    if (!this.applying.has(sessionId)) return Promise.resolve();
+    return new Promise((resolve) => {
+      const waiters = this.applySettledWaiters.get(sessionId) ?? new Set<() => void>();
+      waiters.add(resolve);
+      this.applySettledWaiters.set(sessionId, waiters);
+    });
+  }
+
+  private markApplySettled(sessionId: string): void {
+    this.applying.delete(sessionId);
+    const waiters = this.applySettledWaiters.get(sessionId);
+    if (!waiters) return;
+    this.applySettledWaiters.delete(sessionId);
+    for (const resolve of waiters) resolve();
   }
 
   private async prepareThreadRotation(
     sessionId: string,
     target: PendingCredentialSwitch,
   ): Promise<boolean> {
+    if (!(await this.waitForRotationWork(sessionId))) return false;
+    if (this.pending.get(sessionId) !== target) return false;
     if (!target.codexThreadRotation || target.preparedCodexThreadRotation) return true;
     if (!this.deps.prepareCodexThreadRotation) {
       this.deps.logger?.warn('pending credential switch: Codex thread rotation unavailable; keeping queue gated', {
@@ -233,10 +344,14 @@ export class PendingCredentialSwitchService {
       }
     })();
     this.rotationTasks.add(task);
+    this.rotationTasksBySession.set(sessionId, task);
     try {
       return await task;
     } finally {
       this.rotationTasks.delete(task);
+      if (this.rotationTasksBySession.get(sessionId) === task) {
+        this.rotationTasksBySession.delete(sessionId);
+      }
     }
   }
 
@@ -297,9 +412,10 @@ export class PendingCredentialSwitchService {
       // 收口,不能用进入函数时捕获的 stale target 覆盖后选(后选覆盖先选)。
       const latest = this.pending.get(sessionId);
       if (!latest) return;
+      if (latest !== target && !(await this.prepareThreadRotation(sessionId, latest))) return;
       await this.finalizeApplyChecked(sessionId, latest, 'turn end');
     } finally {
-      this.applying.delete(sessionId);
+      this.markApplySettled(sessionId);
     }
   }
 
@@ -317,7 +433,7 @@ export class PendingCredentialSwitchService {
     this.applying.add(sessionId);
     if (!target.codexThreadRotation) {
       void this.finalizeApplyChecked(sessionId, target, 'session close').finally(() => {
-        this.applying.delete(sessionId);
+        this.markApplySettled(sessionId);
       });
       return;
     }
@@ -325,7 +441,7 @@ export class PendingCredentialSwitchService {
       if (!(await this.prepareThreadRotation(sessionId, target))) return;
       await this.finalizeApplyChecked(sessionId, target, 'session close');
     })().finally(() => {
-      this.applying.delete(sessionId);
+      this.markApplySettled(sessionId);
     });
   }
 

--- a/apps/desktop/src/main/maker-ipc/pendingCredentialSwitch.ts
+++ b/apps/desktop/src/main/maker-ipc/pendingCredentialSwitch.ts
@@ -6,6 +6,11 @@ import {
   prepareLocalSessionCredentialModeSwitch,
 } from '../maker-host/codex-credential-switch.js';
 import { setSessionProvider } from '../maker-host/session-provider-store.js';
+import type {
+  CodexThreadRotationSnapshot,
+  PrepareCodexThreadRotation,
+  PreparedCodexThreadRotation,
+} from './codexThreadRotation.js';
 
 /**
  * PendingCredentialSwitchService —— 会话凭证形态切换的「延迟生效」登记表。
@@ -47,6 +52,10 @@ export interface PendingCredentialSwitch {
    * 缺席 = 无从回滚,退化为只清显式来源。
    */
   previousRoute?: { model: string; providerId: string | null; effort?: string; fastMode?: boolean };
+  /** CodeModeOnly is sticky to a native Codex thread; rotate it before closing. */
+  codexThreadRotation?: CodexThreadRotationSnapshot;
+  /** The DB binding already points at the fork. Do not fork again on retry. */
+  preparedCodexThreadRotation?: PreparedCodexThreadRotation;
   requestedAt: number;
 }
 
@@ -102,6 +111,7 @@ export interface PendingCredentialSwitchDeps {
     sessionId: string,
     route: { providerId: string | null; model?: string; effort?: string; fastMode?: boolean },
   ) => Promise<void>;
+  prepareCodexThreadRotation?: PrepareCodexThreadRotation;
   /** 自愈兜底重试间隔覆写(测试用)。 */
   retryDelayMs?: number;
   logger?: {
@@ -115,6 +125,7 @@ export class PendingCredentialSwitchService {
   private readonly pending = new Map<string, PendingCredentialSwitch>();
   /** 同一会话的 apply 串行化:turn done/error 双事件可能背靠背触发。 */
   private readonly applying = new Set<string>();
+  private readonly rotationTasks = new Set<Promise<boolean>>();
   /** 自愈兜底定时器(per session,pending 收口即清)。 */
   private readonly retryTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
@@ -127,6 +138,7 @@ export class PendingCredentialSwitchService {
       providerId: string | null;
       agentKind?: AgentKind;
       previousRoute?: { model: string; providerId: string | null; effort?: string; fastMode?: boolean };
+      codexThreadRotation?: CodexThreadRotationSnapshot;
     },
   ): void {
     this.pending.set(sessionId, {
@@ -134,6 +146,7 @@ export class PendingCredentialSwitchService {
       providerId: target.providerId,
       ...(target.agentKind ? { agentKind: target.agentKind } : {}),
       ...(target.previousRoute ? { previousRoute: target.previousRoute } : {}),
+      ...(target.codexThreadRotation ? { codexThreadRotation: target.codexThreadRotation } : {}),
       requestedAt: Date.now(),
     });
     this.scheduleRetry(sessionId);
@@ -157,6 +170,58 @@ export class PendingCredentialSwitchService {
     this.clearRetry(sessionId);
   }
 
+  /** Drop every owner-scoped deferred switch without applying it. */
+  async clearAll(): Promise<void> {
+    const prepared = [...this.pending.values()]
+      .map((pending) => pending.preparedCodexThreadRotation)
+      .filter((rotation): rotation is PreparedCodexThreadRotation => rotation !== undefined);
+    this.pending.clear();
+    for (const timer of this.retryTimers.values()) clearTimeout(timer);
+    this.retryTimers.clear();
+    await Promise.allSettled([
+      ...prepared.map((rotation) => rotation.rollback()),
+      ...this.rotationTasks,
+    ]);
+  }
+
+  private async prepareThreadRotation(
+    sessionId: string,
+    target: PendingCredentialSwitch,
+  ): Promise<boolean> {
+    if (!target.codexThreadRotation || target.preparedCodexThreadRotation) return true;
+    if (!this.deps.prepareCodexThreadRotation) {
+      this.deps.logger?.warn('pending credential switch: Codex thread rotation unavailable; keeping queue gated', {
+        sessionId,
+      });
+      this.scheduleRetry(sessionId);
+      return false;
+    }
+    const task = (async (): Promise<boolean> => {
+      try {
+        const prepared = await this.deps.prepareCodexThreadRotation!(target.codexThreadRotation!);
+        if (this.pending.get(sessionId) !== target) {
+          await prepared.rollback();
+          return false;
+        }
+        target.preparedCodexThreadRotation = prepared;
+        return true;
+      } catch (err) {
+        this.deps.logger?.warn('pending credential switch: Codex thread rotation failed; keeping queue gated for retry', {
+          sessionId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        if (this.pending.get(sessionId) === target) this.scheduleRetry(sessionId);
+        return false;
+      }
+    })();
+    this.rotationTasks.add(task);
+    try {
+      return await task;
+    } finally {
+      this.rotationTasks.delete(task);
+    }
+  }
+
   /**
    * turn 结束边界回调(register.ts done/error 接线 + 自愈定时器共用)。会话仍在
    * 跑(steer 接续 / 竞态)时保留 pending 等下一个边界;空闲则关会话 + 写 route,
@@ -173,6 +238,7 @@ export class PendingCredentialSwitchService {
 
     this.applying.add(sessionId);
     try {
+      if (!(await this.prepareThreadRotation(sessionId, target))) return;
       if (session) {
         try {
           await prepareLocalSessionCredentialModeSwitch({
@@ -182,7 +248,23 @@ export class PendingCredentialSwitchService {
           });
         } catch (err) {
           if (isCredentialModeSwitchBusyError(err)) {
+            if (target.preparedCodexThreadRotation) {
+              await target.preparedCodexThreadRotation.rollback();
+              target.preparedCodexThreadRotation = undefined;
+            }
             // turn done 与新 turn start 竞态:保留 pending,等下一个边界。
+            return;
+          }
+          if (target.preparedCodexThreadRotation) {
+            await target.preparedCodexThreadRotation.rollback();
+            target.preparedCodexThreadRotation = undefined;
+          }
+          if (target.codexThreadRotation) {
+            this.deps.logger?.warn('pending credential switch: thread rotation/close failed; keeping queue gated for retry', {
+              sessionId,
+              error: err instanceof Error ? err.message : String(err),
+            });
+            this.scheduleRetry(sessionId);
             return;
           }
           // 关闭失败也要落 route:下一次发送的 getHost 仲裁仍会按新来源协调,
@@ -215,7 +297,16 @@ export class PendingCredentialSwitchService {
     const target = this.pending.get(sessionId);
     if (!target) return;
     this.applying.add(sessionId);
-    void this.finalizeApplyChecked(sessionId, target, 'session close').finally(() => {
+    if (!target.codexThreadRotation) {
+      void this.finalizeApplyChecked(sessionId, target, 'session close').finally(() => {
+        this.applying.delete(sessionId);
+      });
+      return;
+    }
+    void (async () => {
+      if (!(await this.prepareThreadRotation(sessionId, target))) return;
+      await this.finalizeApplyChecked(sessionId, target, 'session close');
+    })().finally(() => {
       this.applying.delete(sessionId);
     });
   }

--- a/apps/desktop/src/main/maker-ipc/providerHandlers.ts
+++ b/apps/desktop/src/main/maker-ipc/providerHandlers.ts
@@ -219,6 +219,8 @@ export interface ProviderHandlerDeps {
   beginRouteMutation(providerId: string): () => void;
   /** CRUD 成功后广播变更（生产 = 向所有窗口 send PROVIDER_CHANGED）。 */
   broadcastChanged(): void;
+  /** Provider route mutation release 后通知依赖方重算最终路由。 */
+  afterRouteMutation?(providerId: string): void;
   /** Current selectable catalog ids, used to validate visible provider order entries. */
   listProviderIds(): string[];
   /** Merge the currently visible order into the persisted observed-provider order. */
@@ -607,6 +609,14 @@ export function registerProviderHandlers(
       }
       finishProviderConfigMutation(providerId);
       finishRouteMutation();
+      try {
+        deps.afterRouteMutation?.(providerId);
+      } catch (error) {
+        log.warn('provider route mutation follow-up failed', {
+          providerId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
     }
   };
   type KeySnapshot = { agent: AgentKind; previous: string | null };

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -11548,6 +11548,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
         }
       }
     },
+    withSessionLock: withSendToSessionLock,
     isSessionInTurn,
     isReconciliationBlocked: hasAnyProviderRouteMutationInProgress,
     getReconciliationGeneration: getProviderRouteMutationGeneration,

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -11502,6 +11502,10 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
       resolveCodexCodeModeOnlyForRoute({
         providerId: getSessionProvider(session.id),
         model: session.model,
+        // Reviewer uses an isolated proxy whose auth shape can differ from the
+        // ordinary local host. Prefer the thread-frozen per-session snapshot;
+        // the process-global injection remains a compatibility fallback.
+        credentialMode: session.codexRouteCredentialMode,
         codexAuthInjection: getCodexProxyAuthInjectionState(),
       }),
     onApplied: (sessionId) => {

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -253,6 +253,7 @@ import {
   getSessionRowSnapshot,
   getSessionRowSnapshotStrict,
   persistSessionFields,
+  replaceSessionSdkSessionIdIfCurrent,
   recycleSessionWorktreeForStatusChange,
 } from '../localDb/ipc/sessions.js';
 // sidebar-card-mode: turn-done 后触发任务现状摘要生成
@@ -802,6 +803,10 @@ import { applyRuntimeEffortWithRecovery } from './runtimeSetEffort.js';
 import { normalizeDeviceLinkSetModelWireArgs } from './setModelWireArgs.js';
 import { PendingCredentialSwitchService } from './pendingCredentialSwitch.js';
 import { CodexRouteRebuildService } from './codexRouteRebuild.js';
+import {
+  createCodexThreadRotationPreparer,
+  type PrepareCodexThreadRotation,
+} from './codexThreadRotation.js';
 import {
   DeferredCodexRestartService,
   runMemoryChangeWithCodexRestart,
@@ -2541,6 +2546,7 @@ const rewindInputSessions = new Set<string>();
 const SESSION_REWIND_INPUT_LOCK_ID = 'session-rewind';
 const SESSION_REWIND_STOP_TIMEOUT_MS = 15_000;
 let pendingCredentialSwitchHolder: PendingCredentialSwitchService | null = null;
+let prepareCodexThreadRotationHolder: PrepareCodexThreadRotation | null = null;
 function settlePendingCredentialSwitch(sessionId: string, source: string): void {
   const pending = pendingCredentialSwitchHolder?.onTurnSettled(sessionId);
   if (!pending) return;
@@ -2707,9 +2713,12 @@ export function isSessionTurnPendingCompletion(sessionId: string): boolean {
  * 重启、关掉新 owner 的会话(review P1 2026-07-23)。bootstrap 的 owner 边界
  * 收口在 maker.shutdown()/resetMaker() 前调用。
  */
-export function clearDeferredCodexRestartForOwnerBoundary(): void {
+export async function clearDeferredCodexRestartForOwnerBoundary(): Promise<void> {
   deferredCodexRestartHolder?.clear();
-  codexRouteRebuildHolder?.clear();
+  await Promise.all([
+    pendingCredentialSwitchHolder?.clearAll() ?? Promise.resolve(),
+    codexRouteRebuildHolder?.clearAsync() ?? Promise.resolve(),
+  ]);
 }
 
 /** Reconcile live local Codex threads after catalog or Provider access changes. */
@@ -2756,7 +2765,11 @@ export function cancelPendingAgentSwitchForSession(sessionId: string): void {
  */
 export async function registerPendingCredentialSwitchForSession(
   sessionId: string,
-  target: { model: string; providerId: string | null },
+  target: {
+    model: string;
+    providerId: string | null;
+    codexThreadRotation?: import('./codexThreadRotation.js').CodexThreadRotationSnapshot;
+  },
 ): Promise<void> {
   const service = pendingCredentialSwitchHolder;
   if (!service) {
@@ -2807,7 +2820,19 @@ export async function registerPendingCredentialSwitchForSession(
           },
         }
       : {}),
+    ...(target.codexThreadRotation
+      ? { codexThreadRotation: target.codexThreadRotation }
+      : {}),
   });
+}
+
+export async function prepareCodexThreadRotationForSession(
+  snapshot: import('./codexThreadRotation.js').CodexThreadRotationSnapshot,
+) {
+  if (!prepareCodexThreadRotationHolder) {
+    throw new Error('Codex thread rotation service is not initialized');
+  }
+  return prepareCodexThreadRotationHolder(snapshot);
 }
 
 export function clearPendingCredentialSwitchForSession(
@@ -11473,6 +11498,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
       await getDbClient().drizzle.update(sessions).set(patch).where(eq(sessions.id, sessionId));
       broadcastSessionPatched(sessionId, patch);
     },
+    prepareCodexThreadRotation: prepareCodexThreadRotationForSession,
     logger: log,
   });
   pendingCredentialSwitchHolder = pendingCredentialSwitchService;
@@ -11487,6 +11513,10 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
             : {}),
         }
       : undefined;
+  });
+  prepareCodexThreadRotationHolder = createCodexThreadRotationPreparer({
+    maker,
+    replaceSdkSessionIdIfCurrent: replaceSessionSdkSessionIdIfCurrent,
   });
 
   // active catalog 热更新后，proxy 会立刻读取新路由；已存活 Codex thread 的
@@ -11531,6 +11561,8 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
         credentialMode: session.codexRouteCredentialMode,
         codexAuthInjection: getCodexProxyAuthInjectionState(),
       }),
+    getProviderId: getSessionProvider,
+    prepareCodexThreadRotation: prepareCodexThreadRotationForSession,
     onApplied: (sessionId) => {
       inputCoordinator.wakeSession(sessionId, 'codex-catalog-route-rebuild-applied');
     },
@@ -13039,6 +13071,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
                 // 解析隐式来源的凭证家族,精确判定是否跨远端压缩身份边界(见
                 // shouldCloseSessionForCredentialSwitch.codexAuthInjection)。
                 codexAuthInjection: getCodexProxyAuthInjectionState(),
+                prepareCodexThreadRotation: prepareCodexThreadRotationForSession,
                 logger: log,
               }),
             (id) =>

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -2807,7 +2807,7 @@ export async function registerPendingCredentialSwitchForSession(
     prevRow = null;
   }
   const prevModel = live?.model ?? prevRow?.model ?? null;
-  service.register(sessionId, {
+  await service.register(sessionId, {
     ...target,
     ...(dbAgentKind ? { agentKind: dbToMakerAgentKind(dbAgentKind) } : {}),
     ...(prevModel
@@ -2835,11 +2835,11 @@ export async function prepareCodexThreadRotationForSession(
   return prepareCodexThreadRotationHolder(snapshot);
 }
 
-export function clearPendingCredentialSwitchForSession(
+export async function clearPendingCredentialSwitchForSession(
   sessionId: string,
   opts?: { wake?: boolean },
-): void {
-  pendingCredentialSwitchHolder?.clear(sessionId);
+): Promise<void> {
+  await pendingCredentialSwitchHolder?.clear(sessionId);
   // pending 门解除后 coordinator 没有其它唤醒源；wake:false 由调用方在
   // close + route 写入完成后显式唤醒，避免队首趁窗口派发到旧凭证。
   if (opts?.wake !== false) {

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -703,12 +703,18 @@ import {
   normalizeSessionProviderId,
   setSessionProvider,
 } from '../maker-host/session-provider-store.js';
-import { getActiveCatalog, setDiscoveredProviderModels } from '../maker-host/active-catalog.js';
+import {
+  getActiveCatalog,
+  getActiveCatalogRevision,
+  setDiscoveredProviderModels,
+} from '../maker-host/active-catalog.js';
 import { refreshXaiMediaModels } from '../maker-host/model-discovery/xai-media.js';
 import { testProviderConnection } from '../maker-host/provider-diagnostics.js';
 import { fetchProviderModels } from '../maker-host/provider-model-fetch.js';
 import {
   beginProviderRouteMutation,
+  getProviderRouteMutationGeneration,
+  hasAnyProviderRouteMutationInProgress,
   isUserProviderSession,
   setPendingCredentialSwitchReader,
 } from '../maker-host/provider-route.js';
@@ -788,10 +794,14 @@ import {
   isCredentialModeSwitchBusyError,
   isLocalSessionBusy,
 } from '../maker-host/codex-credential-switch.js';
-import { applyRuntimeSetModelChange } from './runtimeSetModel.js';
+import {
+  applyRuntimeSetModelChange,
+  resolveCodexCodeModeOnlyForRoute,
+} from './runtimeSetModel.js';
 import { applyRuntimeEffortWithRecovery } from './runtimeSetEffort.js';
 import { normalizeDeviceLinkSetModelWireArgs } from './setModelWireArgs.js';
 import { PendingCredentialSwitchService } from './pendingCredentialSwitch.js';
+import { CodexRouteRebuildService } from './codexRouteRebuild.js';
 import {
   DeferredCodexRestartService,
   runMemoryChangeWithCodexRestart,
@@ -2542,6 +2552,18 @@ function settlePendingCredentialSwitch(sessionId: string, source: string): void 
     });
   });
 }
+let codexRouteRebuildHolder: CodexRouteRebuildService | null = null;
+function settlePendingCodexRouteRebuild(sessionId: string, source: string): void {
+  const pending = codexRouteRebuildHolder?.onTurnSettled(sessionId);
+  if (!pending) return;
+  void pending.catch((err) => {
+    log.warn('pending Codex catalog route rebuild settle failed', {
+      sessionId,
+      source,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  });
+}
 // turn 收口时对远端 codex MCP 做一次 best-effort ensure 的钩子 (live turn
 // 期间被推迟的 daemon bootstrap 在 idle 时点补刀)。真实现定义在
 // registerMakerIpcs 闭包内 (依赖 maker / ensure 函数), 模块级 turn 收口
@@ -2687,6 +2709,22 @@ export function isSessionTurnPendingCompletion(sessionId: string): boolean {
  */
 export function clearDeferredCodexRestartForOwnerBoundary(): void {
   deferredCodexRestartHolder?.clear();
+  codexRouteRebuildHolder?.clear();
+}
+
+/** Reconcile live local Codex threads after catalog or Provider access changes. */
+export function reconcileCodexRouteRebuildsAfterProviderChange(
+  revision = getActiveCatalogRevision(),
+): void {
+  if (hasAnyProviderRouteMutationInProgress()) return;
+  const reconciliation = codexRouteRebuildHolder?.reconcile(revision);
+  if (!reconciliation) return;
+  void reconciliation.catch((error) => {
+    log.warn('Codex catalog route rebuild reconciliation failed', {
+      revision,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  });
 }
 
 /**
@@ -3383,6 +3421,7 @@ async function settleSilentStopDone(
   noteClaudeSessionTurnState(sessionId, false);
   agentInputCoordinatorHolder?.onTurnEvent(sessionId, 'done');
   settlePendingCredentialSwitch(sessionId, `silent-stop:${reason}`);
+  settlePendingCodexRouteRebuild(sessionId, `silent-stop:${reason}`);
   deferredCodexRestartHolder?.onSessionSettled();
   agentInputCoordinatorHolder?.onExternalTurnSettled(sessionId);
   refreshRemoteCodexMcpOnTurnSettledHolder?.(sessionId);
@@ -4060,6 +4099,7 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
         // (review P2 2026-07-04)。apply 内部串行 + 幂等,fire-and-forget 安全;
         // planned upgrade close 等场景多唤一次也只是 no-op。
         settlePendingCredentialSwitch(session.id, `event:${event.type}`);
+        settlePendingCodexRouteRebuild(session.id, `event:${event.type}`);
         deferredCodexRestartHolder?.onSessionSettled();
         agentInputCoordinatorHolder?.onExternalTurnSettled(session.id);
         refreshRemoteCodexMcpOnTurnSettledHolder?.(session.id);
@@ -5091,6 +5131,7 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
           });
           // 会话关闭:兑现延迟凭证切换(直接写 route),并唤醒被它挡住的等待者。
           pendingCredentialSwitchHolder?.onSessionClosed(session.id);
+          codexRouteRebuildHolder?.onSessionClosed(session.id);
           deferredCodexRestartHolder?.onSessionSettled();
           agentInputCoordinatorHolder?.onExternalTurnSettled(session.id);
           refreshRemoteCodexMcpOnTurnSettledHolder?.(session.id);
@@ -5751,7 +5792,11 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
     getModelVisibilityOverrides: () => getModelVisibilityMirrorSnapshot(),
     refreshCatalog: () => refreshCustomProvidersIntoCatalog(),
     beginRouteMutation: (providerId) => beginProviderRouteMutation(providerId),
-    broadcastChanged: () => broadcastToAllWindows(MAKER_PUSH.PROVIDER_CHANGED, {}),
+    broadcastChanged: () => {
+      reconcileCodexRouteRebuildsAfterProviderChange();
+      broadcastToAllWindows(MAKER_PUSH.PROVIDER_CHANGED, {});
+    },
+    afterRouteMutation: () => reconcileCodexRouteRebuildsAfterProviderChange(),
     listProviderIds: () => getDesktopSelectableCatalog().providers.map((provider) => provider.id),
     setProviderOrder: (providerIds) => setProviderOrder(providerIds),
     getProviderOrder: () => readProviderOrder(),
@@ -5899,7 +5944,10 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
         } catch {
           /* 发现失败保持纯静态目录，不影响登录结果 */
         }
-        if (isCurrent()) broadcastToAllWindows(MAKER_PUSH.PROVIDER_CHANGED, {});
+        if (isCurrent()) {
+          reconcileCodexRouteRebuildsAfterProviderChange();
+          broadcastToAllWindows(MAKER_PUSH.PROVIDER_CHANGED, {});
+        }
       }
       return {
         ...result,
@@ -10610,6 +10658,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
       resetTurnPersistState(sessionId);
       noteClaudeSessionTurnState(sessionId, false);
       settlePendingCredentialSwitch(sessionId, `reconcile:${source}`);
+      settlePendingCodexRouteRebuild(sessionId, `reconcile:${source}`);
       deferredCodexRestartHolder?.onSessionSettled();
       agentInputCoordinatorHolder?.onExternalTurnSettled(sessionId);
       refreshRemoteCodexMcpOnTurnSettledHolder?.(sessionId);
@@ -11230,7 +11279,8 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
     // 晚绑定。
     hasPendingCredentialSwitch: createDeferredRestartQueueGate({
       hasPendingCredentialSwitchEntry: (sessionId) =>
-        pendingCredentialSwitchHolder?.has(sessionId) === true,
+        pendingCredentialSwitchHolder?.has(sessionId) === true ||
+        codexRouteRebuildHolder?.has(sessionId) === true,
       isDeferredRestartPending: () => deferredCodexRestartHolder?.isPending() === true,
       listActiveSessions: () => maker.listActiveSessions(),
     }),
@@ -11438,6 +11488,28 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
         }
       : undefined;
   });
+
+  // active catalog 热更新后，proxy 会立刻读取新路由；已存活 Codex thread 的
+  // CodeModeOnly 是 start/resume 级冻结值。只重建能力跨边界的本地会话，busy
+  // 时沿用输入队列门延迟到 turn 结束，不改 Provider/model 持久状态。
+  codexRouteRebuildHolder?.clear();
+  const codexRouteRebuildService = new CodexRouteRebuildService({
+    maker,
+    isSessionInTurn,
+    isReconciliationBlocked: hasAnyProviderRouteMutationInProgress,
+    getReconciliationGeneration: getProviderRouteMutationGeneration,
+    resolveRequiresCodeModeOnly: (session) =>
+      resolveCodexCodeModeOnlyForRoute({
+        providerId: getSessionProvider(session.id),
+        model: session.model,
+        codexAuthInjection: getCodexProxyAuthInjectionState(),
+      }),
+    onApplied: (sessionId) => {
+      inputCoordinator.wakeSession(sessionId, 'codex-catalog-route-rebuild-applied');
+    },
+    logger: log,
+  });
+  codexRouteRebuildHolder = codexRouteRebuildService;
 
   // Memory 设置变更撞上 Codex busy 时的延迟软重启登记(见 deferredCodexRestart.ts)。
   // 与 pendingCredentialSwitchService 共用 turn 结束 / 会话关闭边界接线;pending

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -11491,10 +11491,33 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
 
   // active catalog 热更新后，proxy 会立刻读取新路由；已存活 Codex thread 的
   // CodeModeOnly 是 start/resume 级冻结值。只重建能力跨边界的本地会话，busy
-  // 时沿用输入队列门延迟到 turn 结束，不改 Provider/model 持久状态。
+  // 时先中断当前 turn，再在终态关闭旧 thread；不改 Provider/model 持久状态。
   codexRouteRebuildHolder?.clear();
   const codexRouteRebuildService = new CodexRouteRebuildService({
     maker,
+    abortSession: async (sessionId) => {
+      // Catalog routes are live per request but CodeModeOnly is thread-sticky.
+      // Treat this as an intentional stop so interrupted-turn auto-resume
+      // cannot continue the old turn through a changed proxy route.
+      resetAutomaticRecoveryForExplicitStop(sessionId);
+      const session = getStableSessionForTurnBoundary(sessionId);
+      if (!session) return;
+      handleAgentIslandSessionStopped(session);
+      const directAbortBoundary = beginDirectAbortReconciliation(sessionId, session);
+      try {
+        await session.abort();
+      } finally {
+        try {
+          reconcileDirectAbortBoundary(
+            sessionId,
+            directAbortBoundary,
+            'catalog-route-rebuild-abort',
+          );
+        } finally {
+          cleanupPendingInteractionsForSession(sessionId, 'session_aborted');
+        }
+      }
+    },
     isSessionInTurn,
     isReconciliationBlocked: hasAnyProviderRouteMutationInProgress,
     getReconciliationGeneration: getProviderRouteMutationGeneration,

--- a/apps/desktop/src/main/maker-ipc/runtimeSetModel.ts
+++ b/apps/desktop/src/main/maker-ipc/runtimeSetModel.ts
@@ -48,7 +48,7 @@ interface RuntimeSetModelLogger {
   info: (message: string, meta?: Record<string, unknown>) => void;
 }
 
-type CodexRouteCapabilitiesResolver = (args: Parameters<
+export type CodexRouteCapabilitiesResolver = (args: Parameters<
   typeof resolveCodexRouteCapabilities
 >[0]) =>
   | { requiresCodeModeOnly?: boolean }
@@ -126,16 +126,17 @@ function credentialModeForCodexRoute(
   return undefined;
 }
 
-async function crossesCodexCodeModeOnlyBoundary(args: {
+export async function crossesCodexCodeModeOnlyBoundary(args: {
   currentProviderId: string | null;
   nextProviderId: string | null;
   currentModel: string;
   nextModel: string;
   codexAuthInjection?: CodexProxyAuthInjection | null;
-  resolver: CodexRouteCapabilitiesResolver;
+  resolver?: CodexRouteCapabilitiesResolver;
 }): Promise<boolean> {
+  const resolver = args.resolver ?? resolveCodexRouteCapabilities;
   const [currentCapability, nextCapability] = await Promise.all([
-    args.resolver({
+    resolver({
       providerId: args.currentProviderId,
       model: args.currentModel,
       credentialMode: credentialModeForCodexRoute(
@@ -144,7 +145,7 @@ async function crossesCodexCodeModeOnlyBoundary(args: {
         args.codexAuthInjection,
       ),
     }),
-    args.resolver({
+    resolver({
       providerId: args.nextProviderId,
       model: args.nextModel,
       credentialMode: credentialModeForCodexRoute(

--- a/apps/desktop/src/main/maker-ipc/runtimeSetModel.ts
+++ b/apps/desktop/src/main/maker-ipc/runtimeSetModel.ts
@@ -114,16 +114,17 @@ function credentialModeForCodexRoute(
   model: string,
   authInjection: CodexProxyAuthInjection | null | undefined,
 ): AgentCredentialMode | undefined {
-  const explicit = resolveAgentCredentialMode({
+  // The already-spawned proxy shape is authoritative. An explicit builtin
+  // provider may remain on the session even when env-key/provider-oauth makes
+  // the proxy ignore that per-session route and use its actual default route.
+  if (authInjection === 'oauth-bearer') return 'oauth-bearer';
+  if (authInjection === 'env-key') return 'gateway-key';
+  if (authInjection === 'provider-oauth') return 'provider-oauth';
+  return resolveAgentCredentialMode({
     agentKind: 'codex',
     providerId,
     model,
   });
-  if (explicit) return explicit;
-  if (authInjection === 'oauth-bearer') return 'oauth-bearer';
-  if (authInjection === 'env-key') return 'gateway-key';
-  if (authInjection === 'provider-oauth') return 'provider-oauth';
-  return undefined;
 }
 
 export async function crossesCodexCodeModeOnlyBoundary(args: {

--- a/apps/desktop/src/main/maker-ipc/runtimeSetModel.ts
+++ b/apps/desktop/src/main/maker-ipc/runtimeSetModel.ts
@@ -169,6 +169,7 @@ export async function crossesCodexCodeModeOnlyBoundary(args: {
   nextProviderId: string | null;
   currentModel: string;
   nextModel: string;
+  nextCredentialMode?: AgentCredentialMode;
   codexAuthInjection?: CodexProxyAuthInjection | null;
   resolver?: CodexRouteCapabilitiesResolver;
 }): Promise<boolean> {
@@ -182,6 +183,7 @@ export async function crossesCodexCodeModeOnlyBoundary(args: {
     resolveCodexCodeModeOnlyForRoute({
       providerId: args.nextProviderId,
       model: args.nextModel,
+      credentialMode: args.nextCredentialMode,
       codexAuthInjection: args.codexAuthInjection,
       resolver: args.resolver,
     }),
@@ -237,6 +239,17 @@ export async function applyRuntimeSetModelChange(
         codexAuthInjection: input.codexAuthInjection,
       })
     : false;
+  // A credential-family close means the destination will no longer use the
+  // currently spawned proxy shape. Resolve that post-switch route from the
+  // target request; hot-reused hosts keep the live injection as before.
+  const nextCredentialMode =
+    shouldCloseSessionForCredentials && sess?.agentKind === 'codex'
+      ? resolveAgentCredentialMode({
+          agentKind: 'codex',
+          providerId: nextProviderId,
+          model,
+        })
+      : undefined;
   let shouldCloseSessionForCodeModeOnly = false;
   if (sess?.agentKind === 'codex' && !sess.remoteHostId) {
     try {
@@ -245,6 +258,7 @@ export async function applyRuntimeSetModelChange(
         nextProviderId,
         currentModel: sess.model,
         nextModel: model,
+        nextCredentialMode,
         codexAuthInjection: input.codexAuthInjection,
         resolver: input.resolveCodexRouteCapabilitiesForSwitch ?? resolveCodexRouteCapabilities,
       });

--- a/apps/desktop/src/main/maker-ipc/runtimeSetModel.ts
+++ b/apps/desktop/src/main/maker-ipc/runtimeSetModel.ts
@@ -21,12 +21,20 @@ import {
   prepareLocalSessionCredentialModeSwitch,
   shouldCloseSessionForCredentialSwitch,
 } from '../maker-host/codex-credential-switch.js';
+import {
+  codexThreadRotationSnapshotFromSession,
+  type CodexThreadRotationSnapshot,
+  type PrepareCodexThreadRotation,
+} from './codexThreadRotation.js';
 
 interface RuntimeSetModelSession {
+  id?: string;
   agentKind: AgentKind;
   remoteHostId?: string | null;
   codexProxyActive?: boolean | null;
   model: string;
+  sdkSessionId?: string | null;
+  workDir?: string | null;
   setModel: (model: string, opts?: { providerId?: string | null; effort?: Effort }) => Promise<void>;
 }
 
@@ -68,7 +76,11 @@ export interface ApplyRuntimeSetModelChangeInput {
    */
   registerPendingCredentialSwitch?: (
     sessionId: string,
-    target: { model: string; providerId: string | null },
+    target: {
+      model: string;
+      providerId: string | null;
+      codexThreadRotation?: CodexThreadRotationSnapshot;
+    },
   ) => void | Promise<void>;
   /**
    * 「无需切换」分支清掉旧 pending(后选覆盖先选)。典型场景:deferred 登记后
@@ -100,6 +112,8 @@ export interface ApplyRuntimeSetModelChangeInput {
   codexAuthInjection?: CodexProxyAuthInjection | null;
   /** Test seam for the final-route capability resolver. Production uses the active catalog. */
   resolveCodexRouteCapabilitiesForSwitch?: CodexRouteCapabilitiesResolver;
+  /** Fork and atomically rebind a Codex thread before crossing CodeModeOnly. */
+  prepareCodexThreadRotation?: PrepareCodexThreadRotation;
   logger?: RuntimeSetModelLogger;
 }
 
@@ -247,6 +261,19 @@ export async function applyRuntimeSetModelChange(
   }
   const shouldCloseSession =
     shouldCloseSessionForCredentials || shouldCloseSessionForCodeModeOnly;
+  const codexThreadRotation = shouldCloseSessionForCodeModeOnly && sess
+    ? codexThreadRotationSnapshotFromSession(
+        {
+          id: sessionId,
+          agentKind: sess.agentKind,
+          remoteHostId: sess.remoteHostId,
+          sdkSessionId: sess.sdkSessionId,
+          model: sess.model,
+          workDir: sess.workDir,
+        },
+        currentProviderId,
+      )
+    : null;
   let selfBusyMemo: boolean | undefined;
   const isSelfBusy = (): boolean => {
     if (selfBusyMemo !== undefined) return selfBusyMemo;
@@ -275,6 +302,7 @@ export async function applyRuntimeSetModelChange(
       await input.registerPendingCredentialSwitch(sessionId, {
         model,
         providerId: nextProviderId,
+        ...(codexThreadRotation ? { codexThreadRotation } : {}),
       });
       logger?.info('set-model: Codex provider route switch deferred until turn end', {
         sessionId,
@@ -296,6 +324,7 @@ export async function applyRuntimeSetModelChange(
       await input.registerPendingCredentialSwitch(sessionId, {
         model,
         providerId: nextProviderId,
+        ...(codexThreadRotation ? { codexThreadRotation } : {}),
       });
       logger?.info('set-model: credential switch deferred until turn end', {
         sessionId,
@@ -316,7 +345,16 @@ export async function applyRuntimeSetModelChange(
     // (Greptile review #1035)。
     const clearedPending = input.getPendingCredentialSwitch?.(sessionId);
     input.clearPendingCredentialSwitch?.(sessionId, { wake: false });
+    let preparedRotation: Awaited<ReturnType<PrepareCodexThreadRotation>> | undefined;
     try {
+      if (shouldCloseSessionForCodeModeOnly) {
+        if (codexThreadRotation && !input.prepareCodexThreadRotation) {
+          throw new Error('Codex CodeModeOnly boundary requires thread rotation');
+        }
+        if (codexThreadRotation) {
+          preparedRotation = await input.prepareCodexThreadRotation!(codexThreadRotation);
+        }
+      }
       await prepareLocalSessionCredentialModeSwitch({
         maker,
         sessionId,
@@ -326,9 +364,11 @@ export async function applyRuntimeSetModelChange(
       // 空闲判定与 close 之间的竞态(恰好起了新 turn):有 pending 通道就转延迟,
       // 没有(老调用方)保持抛 busy 的旧语义。
       if (isCredentialModeSwitchBusyError(err) && input.registerPendingCredentialSwitch) {
+        await preparedRotation?.rollback();
         input.registerPendingCredentialSwitch(sessionId, {
           model,
           providerId: nextProviderId,
+          ...(codexThreadRotation ? { codexThreadRotation } : {}),
         });
         logger?.info('set-model: credential switch deferred after busy race', {
           sessionId,
@@ -340,6 +380,7 @@ export async function applyRuntimeSetModelChange(
       if (clearedPending && input.registerPendingCredentialSwitch) {
         input.registerPendingCredentialSwitch(sessionId, clearedPending);
       }
+      await preparedRotation?.rollback();
       throw err;
     }
     if (providerId !== undefined) setSessionProvider(sessionId, nextProviderId);

--- a/apps/desktop/src/main/maker-ipc/runtimeSetModel.ts
+++ b/apps/desktop/src/main/maker-ipc/runtimeSetModel.ts
@@ -127,6 +127,26 @@ function credentialModeForCodexRoute(
   });
 }
 
+/** Resolve the final route's sticky CodeModeOnly value using the live proxy auth shape. */
+export async function resolveCodexCodeModeOnlyForRoute(args: {
+  providerId: string | null;
+  model: string;
+  codexAuthInjection?: CodexProxyAuthInjection | null;
+  resolver?: CodexRouteCapabilitiesResolver;
+}): Promise<boolean> {
+  const resolver = args.resolver ?? resolveCodexRouteCapabilities;
+  const capability = await resolver({
+    providerId: args.providerId,
+    model: args.model,
+    credentialMode: credentialModeForCodexRoute(
+      args.providerId,
+      args.model,
+      args.codexAuthInjection,
+    ),
+  });
+  return capability?.requiresCodeModeOnly === true;
+}
+
 export async function crossesCodexCodeModeOnlyBoundary(args: {
   currentProviderId: string | null;
   nextProviderId: string | null;
@@ -135,29 +155,20 @@ export async function crossesCodexCodeModeOnlyBoundary(args: {
   codexAuthInjection?: CodexProxyAuthInjection | null;
   resolver?: CodexRouteCapabilitiesResolver;
 }): Promise<boolean> {
-  const resolver = args.resolver ?? resolveCodexRouteCapabilities;
-  const [currentCapability, nextCapability] = await Promise.all([
-    resolver({
+  const [current, next] = await Promise.all([
+    resolveCodexCodeModeOnlyForRoute({
       providerId: args.currentProviderId,
       model: args.currentModel,
-      credentialMode: credentialModeForCodexRoute(
-        args.currentProviderId,
-        args.currentModel,
-        args.codexAuthInjection,
-      ),
+      codexAuthInjection: args.codexAuthInjection,
+      resolver: args.resolver,
     }),
-    resolver({
+    resolveCodexCodeModeOnlyForRoute({
       providerId: args.nextProviderId,
       model: args.nextModel,
-      credentialMode: credentialModeForCodexRoute(
-        args.nextProviderId,
-        args.nextModel,
-        args.codexAuthInjection,
-      ),
+      codexAuthInjection: args.codexAuthInjection,
+      resolver: args.resolver,
     }),
   ]);
-  const current = currentCapability?.requiresCodeModeOnly === true;
-  const next = nextCapability?.requiresCodeModeOnly === true;
   return current !== next;
 }
 

--- a/apps/desktop/src/main/maker-ipc/runtimeSetModel.ts
+++ b/apps/desktop/src/main/maker-ipc/runtimeSetModel.ts
@@ -131,6 +131,7 @@ function credentialModeForCodexRoute(
 export async function resolveCodexCodeModeOnlyForRoute(args: {
   providerId: string | null;
   model: string;
+  credentialMode?: AgentCredentialMode;
   codexAuthInjection?: CodexProxyAuthInjection | null;
   resolver?: CodexRouteCapabilitiesResolver;
 }): Promise<boolean> {
@@ -138,11 +139,13 @@ export async function resolveCodexCodeModeOnlyForRoute(args: {
   const capability = await resolver({
     providerId: args.providerId,
     model: args.model,
-    credentialMode: credentialModeForCodexRoute(
-      args.providerId,
-      args.model,
-      args.codexAuthInjection,
-    ),
+    credentialMode:
+      args.credentialMode ??
+      credentialModeForCodexRoute(
+        args.providerId,
+        args.model,
+        args.codexAuthInjection,
+      ),
   });
   return capability?.requiresCodeModeOnly === true;
 }

--- a/apps/desktop/src/main/maker-ipc/runtimeSetModel.ts
+++ b/apps/desktop/src/main/maker-ipc/runtimeSetModel.ts
@@ -88,7 +88,10 @@ export interface ApplyRuntimeSetModelChangeInput {
    * model-only 变更后 pending 的目标形态与当前进程重新同族(如从折扣模型切回
    * 普通模型)—— 不清会让已被放弃的 pending 在 turn 结束时照样生效。
    */
-  clearPendingCredentialSwitch?: (sessionId: string, opts?: { wake?: boolean }) => void;
+  clearPendingCredentialSwitch?: (
+    sessionId: string,
+    opts?: { wake?: boolean },
+  ) => void | Promise<void>;
   /**
    * 空闲切换分支收尾唤醒:关会话 + 写新 route 完成后恢复该会话输入队列的派发。
    * 不能依赖 clear 钩子的默认唤醒 —— 那发生在 close **之前**,drain 会趁 await
@@ -358,7 +361,7 @@ export async function applyRuntimeSetModelChange(
     // 记下清除前的值:后续失败(非 busy)时恢复,不让用户的待定选择随异常丢失
     // (Greptile review #1035)。
     const clearedPending = input.getPendingCredentialSwitch?.(sessionId);
-    input.clearPendingCredentialSwitch?.(sessionId, { wake: false });
+    await input.clearPendingCredentialSwitch?.(sessionId, { wake: false });
     let preparedRotation: Awaited<ReturnType<PrepareCodexThreadRotation>> | undefined;
     try {
       if (shouldCloseSessionForCodeModeOnly) {
@@ -379,7 +382,7 @@ export async function applyRuntimeSetModelChange(
       // 没有(老调用方)保持抛 busy 的旧语义。
       if (isCredentialModeSwitchBusyError(err) && input.registerPendingCredentialSwitch) {
         await preparedRotation?.rollback();
-        input.registerPendingCredentialSwitch(sessionId, {
+        await input.registerPendingCredentialSwitch(sessionId, {
           model,
           providerId: nextProviderId,
           ...(codexThreadRotation ? { codexThreadRotation } : {}),
@@ -392,7 +395,7 @@ export async function applyRuntimeSetModelChange(
       }
       // 非 busy 失败:恢复被清除的 pending,用户的待定来源选择不随异常丢失。
       if (clearedPending && input.registerPendingCredentialSwitch) {
-        input.registerPendingCredentialSwitch(sessionId, clearedPending);
+        await input.registerPendingCredentialSwitch(sessionId, clearedPending);
       }
       await preparedRotation?.rollback();
       throw err;
@@ -414,12 +417,12 @@ export async function applyRuntimeSetModelChange(
   if (providerId !== undefined) {
     setSessionProvider(sessionId, nextProviderId);
     // 显式选源且无需切换 → 取消尚未兑现的 pending(后选覆盖先选)。
-    input.clearPendingCredentialSwitch?.(sessionId);
+    await input.clearPendingCredentialSwitch?.(sessionId);
   } else if (pendingTarget !== undefined) {
     // model-only 变更 + 已有 pending:能走到无需切换分支,说明按 pending 来源 +
     // 新模型评估后凭证形态已与当前进程同族(典型:折扣模型 pending 后切回普通
     // 模型)→ 切换意图不复存在,取消 pending(review P1)。
-    input.clearPendingCredentialSwitch?.(sessionId);
+    await input.clearPendingCredentialSwitch?.(sessionId);
     logger?.info('set-model: cancelled stale pending credential switch after model-only change', {
       sessionId,
       pendingProviderId: pendingTarget.providerId,
@@ -449,7 +452,7 @@ export async function applyRuntimeSetModelChange(
     // (providerId !== undefined)时旧 pending 已被本次明确选择覆盖,恢复它会静默
     // 撤销用户最后一次选择(Greptile review #1035 七轮)。
     if (pendingTarget && input.registerPendingCredentialSwitch) {
-      input.registerPendingCredentialSwitch(sessionId, pendingTarget);
+      await input.registerPendingCredentialSwitch(sessionId, pendingTarget);
     }
     throw err;
   }

--- a/apps/desktop/src/main/maker-ipc/runtimeSetModel.ts
+++ b/apps/desktop/src/main/maker-ipc/runtimeSetModel.ts
@@ -1,4 +1,9 @@
-import type { AgentKind, Effort } from '@cindy/maker-core';
+import {
+  resolveAgentCredentialMode,
+  type AgentCredentialMode,
+  type AgentKind,
+  type Effort,
+} from '@cindy/maker-core';
 
 import {
   getSessionProvider,
@@ -8,6 +13,7 @@ import {
 } from '../maker-host/session-provider-store.js';
 // type-only import:编译期擦除,不会把 codex-proxy-host 的运行时依赖拖进本模块/单测。
 import type { CodexProxyAuthInjection } from '../maker-host/codex-proxy-host.js';
+import { resolveCodexRouteCapabilities } from '../maker-host/provider-route.js';
 import {
   CredentialModeSwitchBusyError,
   isCredentialModeSwitchBusyError,
@@ -41,6 +47,13 @@ interface RuntimeSetModelLogger {
   debug: (message: string, meta?: Record<string, unknown>) => void;
   info: (message: string, meta?: Record<string, unknown>) => void;
 }
+
+type CodexRouteCapabilitiesResolver = (args: Parameters<
+  typeof resolveCodexRouteCapabilities
+>[0]) =>
+  | { requiresCodeModeOnly?: boolean }
+  | undefined
+  | Promise<{ requiresCodeModeOnly?: boolean } | undefined>;
 
 export interface ApplyRuntimeSetModelChangeInput {
   maker: RuntimeSetModelMaker;
@@ -85,6 +98,8 @@ export interface ApplyRuntimeSetModelChangeInput {
    * 是否跨「远端压缩身份」边界;不传时该判定按未知保守处理(倾向关会话重建)。
    */
   codexAuthInjection?: CodexProxyAuthInjection | null;
+  /** Test seam for the final-route capability resolver. Production uses the active catalog. */
+  resolveCodexRouteCapabilitiesForSwitch?: CodexRouteCapabilitiesResolver;
   logger?: RuntimeSetModelLogger;
 }
 
@@ -93,6 +108,56 @@ export type ApplyRuntimeSetModelChangeResult =
   | { status: 'applied' }
   /** 凭证形态要换但会话自己在跑:已登记 pending,turn 结束后自动生效。 */
   | { status: 'deferred' };
+
+function credentialModeForCodexRoute(
+  providerId: string | null,
+  model: string,
+  authInjection: CodexProxyAuthInjection | null | undefined,
+): AgentCredentialMode | undefined {
+  const explicit = resolveAgentCredentialMode({
+    agentKind: 'codex',
+    providerId,
+    model,
+  });
+  if (explicit) return explicit;
+  if (authInjection === 'oauth-bearer') return 'oauth-bearer';
+  if (authInjection === 'env-key') return 'gateway-key';
+  if (authInjection === 'provider-oauth') return 'provider-oauth';
+  return undefined;
+}
+
+async function crossesCodexCodeModeOnlyBoundary(args: {
+  currentProviderId: string | null;
+  nextProviderId: string | null;
+  currentModel: string;
+  nextModel: string;
+  codexAuthInjection?: CodexProxyAuthInjection | null;
+  resolver: CodexRouteCapabilitiesResolver;
+}): Promise<boolean> {
+  const [currentCapability, nextCapability] = await Promise.all([
+    args.resolver({
+      providerId: args.currentProviderId,
+      model: args.currentModel,
+      credentialMode: credentialModeForCodexRoute(
+        args.currentProviderId,
+        args.currentModel,
+        args.codexAuthInjection,
+      ),
+    }),
+    args.resolver({
+      providerId: args.nextProviderId,
+      model: args.nextModel,
+      credentialMode: credentialModeForCodexRoute(
+        args.nextProviderId,
+        args.nextModel,
+        args.codexAuthInjection,
+      ),
+    }),
+  ]);
+  const current = currentCapability?.requiresCodeModeOnly === true;
+  const next = nextCapability?.requiresCodeModeOnly === true;
+  return current !== next;
+}
 
 /**
  * 应用本地运行时 model/provider 切换。
@@ -130,7 +195,7 @@ export async function applyRuntimeSetModelChange(
       : pendingTarget !== undefined
         ? pendingTarget.providerId
         : currentProviderId;
-  const shouldCloseSession = sess
+  const shouldCloseSessionForCredentials = sess
     ? shouldCloseSessionForCredentialSwitch({
         agentKind: sess.agentKind,
         remoteHostId: sess.remoteHostId,
@@ -142,6 +207,30 @@ export async function applyRuntimeSetModelChange(
         codexAuthInjection: input.codexAuthInjection,
       })
     : false;
+  let shouldCloseSessionForCodeModeOnly = false;
+  if (sess?.agentKind === 'codex' && !sess.remoteHostId) {
+    try {
+      shouldCloseSessionForCodeModeOnly = await crossesCodexCodeModeOnlyBoundary({
+        currentProviderId,
+        nextProviderId,
+        currentModel: sess.model,
+        nextModel: model,
+        codexAuthInjection: input.codexAuthInjection,
+        resolver: input.resolveCodexRouteCapabilitiesForSwitch ?? resolveCodexRouteCapabilities,
+      });
+    } catch (error) {
+      // A live thread keeps its previous thread-level value. If the final
+      // route cannot be compared, rebuild this session instead of hot-switching
+      // into a potentially incompatible sticky CodeModeOnly state.
+      shouldCloseSessionForCodeModeOnly = true;
+      logger?.debug('set-model: failed to compare CodeModeOnly route capabilities', {
+        sessionId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+  const shouldCloseSession =
+    shouldCloseSessionForCredentials || shouldCloseSessionForCodeModeOnly;
   let selfBusyMemo: boolean | undefined;
   const isSelfBusy = (): boolean => {
     if (selfBusyMemo !== undefined) return selfBusyMemo;

--- a/apps/desktop/src/main/maker-ipc/sessionAgentSwitchHandler.ts
+++ b/apps/desktop/src/main/maker-ipc/sessionAgentSwitchHandler.ts
@@ -161,7 +161,7 @@ export interface MakerSessionAgentSwitchHandlerDeps {
    * 新的跨引擎选择淘汰较早的 deferred model/provider 选择。后者可能正在等待
    * close 完成，必须先清登记，避免它在新 agent route 提交后回写旧 provider。
    */
-  supersedePendingCredentialSwitch?(sessionId: string): void;
+  supersedePendingCredentialSwitch?(sessionId: string): void | Promise<void>;
   /** 返回边界行 clientId(resume 回落时原子改写定位用)。 */
   insertBoundaryMessage(sessionId: string, content: AgentSwitchBoundaryContent): Promise<string>;
   /**
@@ -442,7 +442,7 @@ export async function performSessionAgentSwitch(
 
   // 跨引擎选择比此前登记的凭证切换更新；即使旧切换已在 await close，清掉登记后
   // 它也会在收口前重读并放弃，避免 DB 已是新 agent、内存 route 却被旧 provider 覆盖。
-  deps.supersedePendingCredentialSwitch?.(sessionId);
+  await deps.supersedePendingCredentialSwitch?.(sessionId);
 
   // 意图制:外部调用(非 applyNow)一律只登记意图——空闲/运行中同一语义,
   // 用户反复改选零成本;renderer 乐观显示意图,真切换在下一条消息发送时刻执行。

--- a/apps/desktop/src/main/scheduler-host/__tests__/runnerModelSelection.test.ts
+++ b/apps/desktop/src/main/scheduler-host/__tests__/runnerModelSelection.test.ts
@@ -1268,6 +1268,72 @@ describe('MakerScheduleRunner model selection', () => {
       );
     });
 
+    it('heartbeat 从 env-key Gateway 切到 OpenAI OAuth 时按目标凭证形态轮换 thread', async () => {
+      mocks.getSessionRowSnapshot.mockResolvedValue({ status: 'active', providerId: 'xd' });
+      const h = createSessionHarness();
+      Object.defineProperty(h.session, 'agentKind', { value: 'codex' });
+      Object.defineProperty(h.session, 'model', { value: 'gpt-5.4' });
+      Object.defineProperty(h.session, 'codexProxyActive', { value: true });
+      const resolveCodexRouteCapabilities = vi.fn(
+        async ({ credentialMode }: { credentialMode?: string }) => ({
+          requiresCodeModeOnly: credentialMode === 'gateway-key',
+        }),
+      );
+      const prepareCodexThreadRotation = vi.fn(async () => ({
+        newSdkSessionId: 'sdk-openai-forked',
+        rollback: vi.fn(async () => undefined),
+      }));
+      const harness = createRunnerHarness(
+        h,
+        {
+          model: 'gpt-5.4',
+          workDir: '/work',
+          sdkSessionId: 'sdk-openai-old',
+        },
+        {
+          sessionAlive: true,
+          getCodexAuthInjection: () => 'env-key',
+          resolveCodexRouteCapabilities,
+          prepareCodexThreadRotation,
+        },
+      );
+
+      await fireToCompletion(
+        harness,
+        h,
+        baseSchedule({
+          agentKind: 'codex',
+          model: 'gpt-5.4',
+          providerId: 'openai',
+          targetSessionId: 'scheduler-session',
+        }),
+      );
+
+      expect(resolveCodexRouteCapabilities).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({ providerId: 'xd', credentialMode: 'gateway-key' }),
+      );
+      expect(resolveCodexRouteCapabilities).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({ providerId: 'openai', credentialMode: 'oauth-bearer' }),
+      );
+      expect(prepareCodexThreadRotation).toHaveBeenCalledWith({
+        sessionId: 'scheduler-session',
+        sourceSdkSessionId: 'sdk-openai-old',
+        sourceModel: 'gpt-5.4',
+        sourceProviderId: 'xd',
+        workingDir: '/work',
+      });
+      expect(harness.closeSession).toHaveBeenCalledWith('scheduler-session');
+      expect(harness.createSession).toHaveBeenCalledWith(
+        expect.objectContaining({
+          providerId: 'openai',
+          model: 'gpt-5.4',
+          resumeSessionId: 'sdk-openai-forked',
+        }),
+      );
+    });
+
     it('heartbeat 复用本地 Codex 且仅跨 CodeModeOnly 能力 → 关闭后按新来源重建', async () => {
       mocks.getSessionRowSnapshot.mockResolvedValue({ status: 'active', providerId: 'xd' });
       const h = createSessionHarness();

--- a/apps/desktop/src/main/scheduler-host/__tests__/runnerModelSelection.test.ts
+++ b/apps/desktop/src/main/scheduler-host/__tests__/runnerModelSelection.test.ts
@@ -204,6 +204,12 @@ function createRunnerHarness(
     resolveDefaultModelRoute?: ConstructorParameters<
       typeof MakerScheduleRunner
     >[0]['resolveDefaultModelRoute'];
+    resolveCodexRouteCapabilities?: ConstructorParameters<
+      typeof MakerScheduleRunner
+    >[0]['resolveCodexRouteCapabilities'];
+    getCodexAuthInjection?: ConstructorParameters<
+      typeof MakerScheduleRunner
+    >[0]['getCodexAuthInjection'];
   } = {},
 ): RunnerHarness {
   const createSession = vi.fn(async () => h.session);
@@ -229,6 +235,8 @@ function createRunnerHarness(
     checkModelRoute: opts.checkModelRoute,
     resolveRouteCopyCapabilities: opts.resolveRouteCopyCapabilities,
     resolveDefaultModelRoute: opts.resolveDefaultModelRoute,
+    resolveCodexRouteCapabilities: opts.resolveCodexRouteCapabilities,
+    getCodexAuthInjection: opts.getCodexAuthInjection,
   });
   return { runner, createSession, closeSession };
 }
@@ -1253,6 +1261,56 @@ describe('MakerScheduleRunner model selection', () => {
         'scheduler-session',
         expect.objectContaining({ model: 'gpt-5.4', providerId: 'openai' }),
         expect.anything(),
+      );
+    });
+
+    it('heartbeat 复用本地 Codex 且仅跨 CodeModeOnly 能力 → 关闭后按新来源重建', async () => {
+      mocks.getSessionRowSnapshot.mockResolvedValue({ status: 'active', providerId: 'xd' });
+      const h = createSessionHarness();
+      Object.defineProperty(h.session, 'agentKind', { value: 'codex' });
+      Object.defineProperty(h.session, 'model', { value: 'shared-model' });
+      Object.defineProperty(h.session, 'codexProxyActive', { value: true });
+      const otherBusyCodexSession = {
+        id: 'other-busy-codex-session',
+        agentKind: 'codex',
+        remoteHostId: null,
+        isTurnRunning: () => true,
+      } as unknown as Session;
+      const harness = createRunnerHarness(
+        h,
+        {
+          model: 'shared-model',
+          workDir: '/work',
+          sdkSessionId: 'sdk-codemode-1',
+        },
+        {
+          sessionAlive: true,
+          activeSessions: [h.session, otherBusyCodexSession],
+          getCodexAuthInjection: () => 'env-key',
+          resolveCodexRouteCapabilities: async ({ providerId }) => ({
+            requiresCodeModeOnly: providerId === 'xd',
+          }),
+        },
+      );
+
+      await fireToCompletion(
+        harness,
+        h,
+        baseSchedule({
+          agentKind: 'codex',
+          model: 'shared-model',
+          providerId: 'deepseek',
+          targetSessionId: 'scheduler-session',
+        }),
+      );
+
+      expect(harness.closeSession).toHaveBeenCalledWith('scheduler-session');
+      expect(harness.closeSession).not.toHaveBeenCalledWith('other-busy-codex-session');
+      expect(harness.closeSession.mock.invocationCallOrder[0]).toBeLessThan(
+        harness.createSession.mock.invocationCallOrder[0],
+      );
+      expect(harness.createSession).toHaveBeenCalledWith(
+        expect.objectContaining({ providerId: 'deepseek', model: 'shared-model' }),
       );
     });
 

--- a/apps/desktop/src/main/scheduler-host/__tests__/runnerModelSelection.test.ts
+++ b/apps/desktop/src/main/scheduler-host/__tests__/runnerModelSelection.test.ts
@@ -210,6 +210,9 @@ function createRunnerHarness(
     getCodexAuthInjection?: ConstructorParameters<
       typeof MakerScheduleRunner
     >[0]['getCodexAuthInjection'];
+    prepareCodexThreadRotation?: ConstructorParameters<
+      typeof MakerScheduleRunner
+    >[0]['prepareCodexThreadRotation'];
   } = {},
 ): RunnerHarness {
   const createSession = vi.fn(async () => h.session);
@@ -237,6 +240,7 @@ function createRunnerHarness(
     resolveDefaultModelRoute: opts.resolveDefaultModelRoute,
     resolveCodexRouteCapabilities: opts.resolveCodexRouteCapabilities,
     getCodexAuthInjection: opts.getCodexAuthInjection,
+    prepareCodexThreadRotation: opts.prepareCodexThreadRotation,
   });
   return { runner, createSession, closeSession };
 }
@@ -1290,6 +1294,10 @@ describe('MakerScheduleRunner model selection', () => {
           resolveCodexRouteCapabilities: async ({ providerId }) => ({
             requiresCodeModeOnly: providerId === 'xd',
           }),
+          prepareCodexThreadRotation: async () => ({
+            newSdkSessionId: 'sdk-codemode-forked',
+            rollback: vi.fn(async () => undefined),
+          }),
         },
       );
 
@@ -1310,7 +1318,11 @@ describe('MakerScheduleRunner model selection', () => {
         harness.createSession.mock.invocationCallOrder[0],
       );
       expect(harness.createSession).toHaveBeenCalledWith(
-        expect.objectContaining({ providerId: 'deepseek', model: 'shared-model' }),
+        expect.objectContaining({
+          providerId: 'deepseek',
+          model: 'shared-model',
+          resumeSessionId: 'sdk-codemode-forked',
+        }),
       );
     });
 

--- a/apps/desktop/src/main/scheduler-host/__tests__/runnerQueuedDispatch.test.ts
+++ b/apps/desktop/src/main/scheduler-host/__tests__/runnerQueuedDispatch.test.ts
@@ -312,6 +312,8 @@ function createRunnerHarness(
     metaModel?: string;
     /** 停用轴裁决桩(缺省 = 不裁决,与生产未接线时一致)。 */
     checkModelRoute?: MakerScheduleRunnerDeps['checkModelRoute'];
+    resolveCodexRouteCapabilities?: MakerScheduleRunnerDeps['resolveCodexRouteCapabilities'];
+    getCodexAuthInjection?: MakerScheduleRunnerDeps['getCodexAuthInjection'];
   } = {},
 ) {
   const logger = createLogger();
@@ -342,6 +344,8 @@ function createRunnerHarness(
     logger,
     schedulerQueue,
     checkModelRoute: opts.checkModelRoute,
+    resolveCodexRouteCapabilities: opts.resolveCodexRouteCapabilities,
+    getCodexAuthInjection: opts.getCodexAuthInjection,
   });
   return { runner, logger, notifier, maker };
 }
@@ -703,6 +707,43 @@ describe('MakerScheduleRunner queued dispatch (busy bound session)', () => {
     );
     expect(harness.session.abort).toHaveBeenCalled();
     expect(mocks.setSessionProvider).not.toHaveBeenCalled();
+  });
+
+  it('排队 Codex 跨 CodeModeOnly 边界时保留当前路由，等待空闲后重建', async () => {
+    mocks.getSessionRowSnapshot.mockResolvedValue({
+      status: 'active',
+      userSendAt: null,
+      providerId: 'xd',
+    });
+    mocks.getSessionProvider.mockReturnValue('xd');
+    const harness = createSessionHarness(async () => ({ accepted: true }));
+    (harness.session as { agentKind: string }).agentKind = 'codex';
+    (harness.session as { model: string }).model = 'shared-model';
+    (harness.session as { codexProxyActive: boolean }).codexProxyActive = true;
+    const queue = createQueueHarness({ busy: true });
+    const { runner } = createRunnerHarness(harness.session, queue.deps, {
+      metaModel: 'shared-model',
+      getCodexAuthInjection: () => 'env-key',
+      resolveCodexRouteCapabilities: async ({ providerId }) => ({
+        requiresCodeModeOnly: providerId === 'xd',
+      }),
+    });
+
+    const firePromise = runner.fire(
+      heartbeatSchedule({
+        agentKind: 'codex',
+        model: 'shared-model',
+        providerId: 'deepseek',
+      }),
+      createFireContext(),
+    );
+    await vi.waitFor(() => expect(queue.enqueueCalls.length).toBe(1));
+    await queue.accept();
+
+    expect(harness.setModel).not.toHaveBeenCalled();
+    expect(mocks.setSessionProvider).not.toHaveBeenCalled();
+    harness.emit({ type: 'done', data: {}, source: 'codex' });
+    await expect(firePromise).resolves.toMatchObject({ sessionId: SESSION_ID });
   });
 
   it('排队 Pi 每次派发都写 Fast=false，清掉复用会话的旧 bridge 状态', async () => {

--- a/apps/desktop/src/main/scheduler-host/index.ts
+++ b/apps/desktop/src/main/scheduler-host/index.ts
@@ -30,6 +30,8 @@ import {
   resolveRouteCopyCapabilities,
   verdictForModelRoute,
 } from '../maker-host/model-route-guard-live.js';
+import { getCodexProxyAuthInjectionState } from '../maker-host/codex-proxy-host.js';
+import { resolveCodexRouteCapabilities } from '../maker-host/provider-route.js';
 import { getAgentIslandService } from '../agent-island/service.js';
 import { getDesktopNotificationsEnabled } from '../notificationService.js';
 import {
@@ -95,6 +97,8 @@ export async function startScheduler(deps: StartSchedulerDeps): Promise<Schedule
     // 隐式改道后按落地拷贝 reconcile effort/Fast(见 runner deps 注释,R27)。
     resolveRouteCopyCapabilities,
     resolveDefaultModelRoute: resolveDefaultScheduleRoute,
+    resolveCodexRouteCapabilities,
+    getCodexAuthInjection: getCodexProxyAuthInjectionState,
     // 心跳撞忙排队桥:实现挂在 maker-ipc/register.ts 的 coordinator 装配处
     // (holder 未就绪时 isSessionBusy 返回 false → runner 走原直发路径)。
     schedulerQueue: {

--- a/apps/desktop/src/main/scheduler-host/index.ts
+++ b/apps/desktop/src/main/scheduler-host/index.ts
@@ -44,6 +44,7 @@ import {
   isSchedulerPromptTracked,
   isSchedulerTargetSessionBusy,
   onSchedulerAutoResumeFailed,
+  prepareCodexThreadRotationForSession,
   removeQueuedSchedulerPrompt,
 } from '../maker-ipc/register.js';
 import { DrizzleScheduleStorage, type SchedulerDrizzleDb } from './storage';
@@ -99,6 +100,7 @@ export async function startScheduler(deps: StartSchedulerDeps): Promise<Schedule
     resolveDefaultModelRoute: resolveDefaultScheduleRoute,
     resolveCodexRouteCapabilities,
     getCodexAuthInjection: getCodexProxyAuthInjectionState,
+    prepareCodexThreadRotation: prepareCodexThreadRotationForSession,
     // 心跳撞忙排队桥:实现挂在 maker-ipc/register.ts 的 coordinator 装配处
     // (holder 未就绪时 isSessionBusy 返回 false → runner 走原直发路径)。
     schedulerQueue: {

--- a/apps/desktop/src/main/scheduler-host/runner.ts
+++ b/apps/desktop/src/main/scheduler-host/runner.ts
@@ -31,7 +31,7 @@
 
 import { randomUUID } from 'node:crypto';
 
-import { isTerminalAgentErrorEvent } from '@cindy/maker-core';
+import { isTerminalAgentErrorEvent, resolveAgentCredentialMode } from '@cindy/maker-core';
 import type {
   Maker,
   AgentEvent,
@@ -360,6 +360,7 @@ export class MakerScheduleRunner implements ScheduleRunner {
     currentModel: string,
     nextModel: string,
   ): Promise<SchedulerRouteRebuildRequirement | null> {
+    const codexAuthInjection = this.deps.getCodexAuthInjection?.();
     const crossesCredentialMode = shouldCloseSessionForCredentialSwitch({
       agentKind: session.agentKind,
       remoteHostId: session.remoteHostId,
@@ -368,8 +369,18 @@ export class MakerScheduleRunner implements ScheduleRunner {
       currentModel,
       nextModel,
       currentCodexProxyActive: session.codexProxyActive,
-      codexAuthInjection: this.deps.getCodexAuthInjection?.(),
+      codexAuthInjection,
     });
+    // A credential-family rebuild discards the live proxy auth shape, so the
+    // destination capability must be resolved from the target request.
+    const nextCredentialMode =
+      crossesCredentialMode && session.agentKind === 'codex'
+        ? resolveAgentCredentialMode({
+            agentKind: 'codex',
+            providerId: nextProviderId,
+            model: nextModel,
+          })
+        : undefined;
     let crossesCodeModeOnly = false;
     if (
       session.agentKind === 'codex' &&
@@ -378,12 +389,13 @@ export class MakerScheduleRunner implements ScheduleRunner {
     ) {
       try {
         crossesCodeModeOnly = await crossesCodexCodeModeOnlyBoundary({
-        currentProviderId,
-        nextProviderId,
-        currentModel,
-        nextModel,
-        codexAuthInjection: this.deps.getCodexAuthInjection?.(),
-        resolver: this.deps.resolveCodexRouteCapabilities,
+          currentProviderId,
+          nextProviderId,
+          currentModel,
+          nextModel,
+          nextCredentialMode,
+          codexAuthInjection,
+          resolver: this.deps.resolveCodexRouteCapabilities,
         });
       } catch (error) {
         this.deps.logger.warn?.(

--- a/apps/desktop/src/main/scheduler-host/runner.ts
+++ b/apps/desktop/src/main/scheduler-host/runner.ts
@@ -69,8 +69,13 @@ import {
   prepareLocalSessionCredentialModeSwitch,
   shouldCloseSessionForCredentialSwitch,
 } from '../maker-host/codex-credential-switch.js';
+import type { CodexProxyAuthInjection } from '../maker-host/codex-proxy-host.js';
 import { ensureDialogueWorkspaceDir } from '../localDb/dialogueWorkspace';
 import { AcceptedCallbackDispatchCancelled } from '../maker-ipc/acceptedCallbackRunner.js';
+import {
+  crossesCodexCodeModeOnlyBoundary,
+  type CodexRouteCapabilitiesResolver,
+} from '../maker-ipc/runtimeSetModel.js';
 import {
   wireSessionToIpc,
   isSessionInTurn,
@@ -277,6 +282,10 @@ export interface MakerScheduleRunnerDeps {
     preferredProviderId?: string | null,
     modelId?: string,
   ) => Promise<{ model: string; providerId: string | null; catalogKnown?: boolean } | null>;
+  /** Codex thread-level route capability; production reads the active provider catalog. */
+  resolveCodexRouteCapabilities?: CodexRouteCapabilitiesResolver;
+  /** Current local Codex spawn credential shape, used for implicit final-route fallback. */
+  getCodexAuthInjection?: () => CodexProxyAuthInjection | null;
 }
 
 /**
@@ -331,6 +340,54 @@ export class MakerScheduleRunner implements ScheduleRunner {
   private readonly schedulerRunContextOwners = new Map<string, SchedulerRunContextOwner>();
 
   constructor(private readonly deps: MakerScheduleRunnerDeps) {}
+
+  private async routeRebuildReason(
+    session: Pick<Session, 'agentKind' | 'remoteHostId' | 'codexProxyActive'>,
+    currentProviderId: string | null,
+    nextProviderId: string | null,
+    currentModel: string,
+    nextModel: string,
+  ): Promise<'credential-mode' | 'code-mode-only' | null> {
+    if (
+      shouldCloseSessionForCredentialSwitch({
+        agentKind: session.agentKind,
+        remoteHostId: session.remoteHostId,
+        currentProviderId,
+        nextProviderId,
+        currentModel,
+        nextModel,
+        currentCodexProxyActive: session.codexProxyActive,
+        codexAuthInjection: this.deps.getCodexAuthInjection?.(),
+      })
+    ) {
+      return 'credential-mode';
+    }
+    if (
+      session.agentKind !== 'codex' ||
+      session.remoteHostId ||
+      !this.deps.resolveCodexRouteCapabilities
+    ) {
+      return null;
+    }
+    try {
+      return await crossesCodexCodeModeOnlyBoundary({
+        currentProviderId,
+        nextProviderId,
+        currentModel,
+        nextModel,
+        codexAuthInjection: this.deps.getCodexAuthInjection?.(),
+        resolver: this.deps.resolveCodexRouteCapabilities,
+      })
+        ? 'code-mode-only'
+        : null;
+    } catch (error) {
+      this.deps.logger.warn?.(
+        '[runner] failed to compare Codex route capabilities; rebuilding the session',
+        error,
+      );
+      return 'code-mode-only';
+    }
+  }
 
   /** scheduler-host/index.ts 在 startScheduler 内调一次，让 runner 反向 pause schedule */
   attachScheduler(scheduler: Scheduler): void {
@@ -911,24 +968,22 @@ export class MakerScheduleRunner implements ScheduleRunner {
         reroutedProviderId ??
         materializedDefaultProviderId ??
         currentProviderId;
-      if (
-        liveSession &&
-        shouldCloseSessionForCredentialSwitch({
-          agentKind: liveSession.agentKind,
-          remoteHostId: liveSession.remoteHostId,
+      const rebuildReason = liveSession
+        ? await this.routeRebuildReason(
+          liveSession,
           currentProviderId,
           nextProviderId,
-          currentModel: liveSession.model,
-          nextModel: model,
-          currentCodexProxyActive: liveSession.codexProxyActive,
-        })
-      ) {
+          liveSession.model,
+          model,
+        )
+        : null;
+      if (liveSession && rebuildReason) {
         if (isHeartbeat && isSessionInTurn(sessionId)) {
           return this.failOrDeferSessionRunning(schedule, ctx, sessionId, true);
         }
         try {
-          throwIfFireAborted(ctx.signal, 'credential mode switch');
-          if (liveSession.agentKind === 'codex') {
+          throwIfFireAborted(ctx.signal, 'session route rebuild');
+          if (liveSession.agentKind === 'codex' && rebuildReason === 'credential-mode') {
             await prepareLocalCodexCredentialModeSwitch({
               maker: this.deps.maker,
               isSessionInTurn,
@@ -942,7 +997,7 @@ export class MakerScheduleRunner implements ScheduleRunner {
               signal: ctx.signal,
             });
           }
-          throwIfFireAborted(ctx.signal, 'credential mode switch');
+          throwIfFireAborted(ctx.signal, 'session route rebuild');
         } catch (err) {
           if (err instanceof CredentialModeSwitchBusyError) {
             return this.failOrDeferSessionRunning(schedule, ctx, sessionId, isHeartbeat);
@@ -950,13 +1005,14 @@ export class MakerScheduleRunner implements ScheduleRunner {
           throw err;
         }
         reusedLiveSession = false;
-        this.deps.logger.info?.('[runner] closed live session after credential mode switch', {
+        this.deps.logger.info?.('[runner] closed live session after route rebuild boundary', {
           sessionId,
           agentKind: liveSession.agentKind,
           currentProviderId,
           nextProviderId,
           fromModel: liveSession.model,
           toModel: model,
+          reason: rebuildReason,
         });
       }
     }
@@ -1315,18 +1371,16 @@ export class MakerScheduleRunner implements ScheduleRunner {
           // fire 在入口改道(reroutedProviderId)并经凭证切换重建正确收敛;同凭证
           // 形态的改道热换即可生效(PR #744 review 第二十七轮)。
           if (
-            shouldCloseSessionForCredentialSwitch({
-              agentKind: session.agentKind,
-              remoteHostId: session.remoteHostId,
-              currentProviderId: dispatchProviderId,
-              nextProviderId: verdict.providerId,
-              currentModel: runtimeModel,
-              nextModel: runtimeModel,
-              currentCodexProxyActive: session.codexProxyActive,
-            })
+            await this.routeRebuildReason(
+              session,
+              dispatchProviderId,
+              verdict.providerId,
+              runtimeModel,
+              runtimeModel,
+            ) !== null
           ) {
             throw new Error(
-              `schedule route rerouted across credential modes after session creation; failing this run so the next fire rebuilds the session (model "${runtimeModel}" → provider "${verdict.providerId}")`,
+              `schedule route rerouted across a session rebuild boundary after session creation; failing this run so the next fire rebuilds the session (model "${runtimeModel}" → provider "${verdict.providerId}")`,
             );
           }
           if (effectiveAgentKind === 'pi') {
@@ -2035,7 +2089,7 @@ export class MakerScheduleRunner implements ScheduleRunner {
   /**
    * 排队派发时刻的路由热同步:schedule 显式设置的 model / effort / 来源(供应商)
    * 优先于绑定会话当前值(与直发路径 4.4.1/4.4.2 同语义);留空沿用会话当前值。
-   * 凭证形态需要关会话重建的组合(shouldCloseSessionForCredentialSwitch)无法在
+   * 凭证形态或 thread 级路由能力需要关会话重建的组合无法在
    * 派发时刻热切 —— 跳过本轮同步,沿用会话当前路由,下次空闲直发照常收敛。
    * setModel / setEffort 成功才落库 meta,失败保留旧值让下轮重试(与直发路径的
    * 复用会话语义一致)。
@@ -2085,15 +2139,13 @@ export class MakerScheduleRunner implements ScheduleRunner {
     }
     const nextProviderId = applyProviderId ?? currentProviderId;
     if (
-      shouldCloseSessionForCredentialSwitch({
-        agentKind: live.agentKind,
-        remoteHostId: live.remoteHostId,
+      await this.routeRebuildReason(
+        live,
         currentProviderId,
         nextProviderId,
-        currentModel: live.model,
-        nextModel: targetModel,
-        currentCodexProxyActive: live.codexProxyActive,
-      })
+        live.model,
+        targetModel,
+      ) !== null
     ) {
       // 早退 = 本轮沿用 live 当前路由派发:这条保留路由自己也要过停用裁决 ——
       // 目标来源启用但需要凭证切换、而**当前**来源在排队等待期间被停用时,不裁决
@@ -2111,7 +2163,7 @@ export class MakerScheduleRunner implements ScheduleRunner {
         }
       }
       this.deps.logger.info?.(
-        '[runner] queued heartbeat routing needs credential mode switch; keeping session routing this round',
+        '[runner] queued heartbeat routing needs session rebuild; keeping session routing this round',
         {
           scheduleId: schedule.id,
           sessionId: live.id,
@@ -2580,7 +2632,8 @@ type FireAbortStage =
   | 'session creation'
   | 'agent turn dispatch'
   | 'credential switch setup'
-  | 'credential mode switch';
+  | 'credential mode switch'
+  | 'session route rebuild';
 
 function throwIfFireAborted(signal: AbortSignal, stage: FireAbortStage): void {
   if (signal.aborted) {

--- a/apps/desktop/src/main/scheduler-host/runner.ts
+++ b/apps/desktop/src/main/scheduler-host/runner.ts
@@ -76,6 +76,11 @@ import {
   crossesCodexCodeModeOnlyBoundary,
   type CodexRouteCapabilitiesResolver,
 } from '../maker-ipc/runtimeSetModel.js';
+import type {
+  CodexThreadRotationSnapshot,
+  PrepareCodexThreadRotation,
+  PreparedCodexThreadRotation,
+} from '../maker-ipc/codexThreadRotation.js';
 import {
   wireSessionToIpc,
   isSessionInTurn,
@@ -286,6 +291,8 @@ export interface MakerScheduleRunnerDeps {
   resolveCodexRouteCapabilities?: CodexRouteCapabilitiesResolver;
   /** Current local Codex spawn credential shape, used for implicit final-route fallback. */
   getCodexAuthInjection?: () => CodexProxyAuthInjection | null;
+  /** Rotate a sticky native Codex thread before resuming it across CodeModeOnly. */
+  prepareCodexThreadRotation?: PrepareCodexThreadRotation;
 }
 
 /**
@@ -330,6 +337,11 @@ interface SchedulerRunContextOwner {
   runId: string;
 }
 
+interface SchedulerRouteRebuildRequirement {
+  reason: 'credential-mode' | 'code-mode-only';
+  requiresCodeModeThreadRotation: boolean;
+}
+
 export class MakerScheduleRunner implements ScheduleRunner {
   private scheduler: Scheduler | null = null;
   /**
@@ -347,46 +359,45 @@ export class MakerScheduleRunner implements ScheduleRunner {
     nextProviderId: string | null,
     currentModel: string,
     nextModel: string,
-  ): Promise<'credential-mode' | 'code-mode-only' | null> {
+  ): Promise<SchedulerRouteRebuildRequirement | null> {
+    const crossesCredentialMode = shouldCloseSessionForCredentialSwitch({
+      agentKind: session.agentKind,
+      remoteHostId: session.remoteHostId,
+      currentProviderId,
+      nextProviderId,
+      currentModel,
+      nextModel,
+      currentCodexProxyActive: session.codexProxyActive,
+      codexAuthInjection: this.deps.getCodexAuthInjection?.(),
+    });
+    let crossesCodeModeOnly = false;
     if (
-      shouldCloseSessionForCredentialSwitch({
-        agentKind: session.agentKind,
-        remoteHostId: session.remoteHostId,
-        currentProviderId,
-        nextProviderId,
-        currentModel,
-        nextModel,
-        currentCodexProxyActive: session.codexProxyActive,
-        codexAuthInjection: this.deps.getCodexAuthInjection?.(),
-      })
+      session.agentKind === 'codex' &&
+      !session.remoteHostId &&
+      this.deps.resolveCodexRouteCapabilities
     ) {
-      return 'credential-mode';
-    }
-    if (
-      session.agentKind !== 'codex' ||
-      session.remoteHostId ||
-      !this.deps.resolveCodexRouteCapabilities
-    ) {
-      return null;
-    }
-    try {
-      return await crossesCodexCodeModeOnlyBoundary({
+      try {
+        crossesCodeModeOnly = await crossesCodexCodeModeOnlyBoundary({
         currentProviderId,
         nextProviderId,
         currentModel,
         nextModel,
         codexAuthInjection: this.deps.getCodexAuthInjection?.(),
         resolver: this.deps.resolveCodexRouteCapabilities,
-      })
-        ? 'code-mode-only'
-        : null;
-    } catch (error) {
-      this.deps.logger.warn?.(
-        '[runner] failed to compare Codex route capabilities; rebuilding the session',
-        error,
-      );
-      return 'code-mode-only';
+        });
+      } catch (error) {
+        this.deps.logger.warn?.(
+          '[runner] failed to compare Codex route capabilities; rebuilding the session',
+          error,
+        );
+        crossesCodeModeOnly = true;
+      }
     }
+    if (!crossesCredentialMode && !crossesCodeModeOnly) return null;
+    return {
+      reason: crossesCredentialMode ? 'credential-mode' : 'code-mode-only',
+      requiresCodeModeThreadRotation: crossesCodeModeOnly,
+    };
   }
 
   /** scheduler-host/index.ts 在 startScheduler 内调一次，让 runner 反向 pause schedule */
@@ -981,9 +992,29 @@ export class MakerScheduleRunner implements ScheduleRunner {
         if (isHeartbeat && isSessionInTurn(sessionId)) {
           return this.failOrDeferSessionRunning(schedule, ctx, sessionId, true);
         }
+        let preparedRotation: PreparedCodexThreadRotation | undefined;
+        const sourceResumeSessionId = resumeSessionId;
         try {
           throwIfFireAborted(ctx.signal, 'session route rebuild');
-          if (liveSession.agentKind === 'codex' && rebuildReason === 'credential-mode') {
+          if (rebuildReason.requiresCodeModeThreadRotation) {
+            if (resumeSessionId && resumeSessionId !== '<pending>') {
+              if (!heartbeatWorkingDir || !this.deps.prepareCodexThreadRotation) {
+                throw new Error(
+                  'Scheduler CodeModeOnly route rebuild requires Codex thread rotation',
+                );
+              }
+              const snapshot: CodexThreadRotationSnapshot = {
+                sessionId,
+                sourceSdkSessionId: resumeSessionId,
+                sourceModel: liveSession.model,
+                sourceProviderId: currentProviderId,
+                workingDir: heartbeatWorkingDir,
+              };
+              preparedRotation = await this.deps.prepareCodexThreadRotation(snapshot);
+              resumeSessionId = preparedRotation.newSdkSessionId;
+            }
+          }
+          if (liveSession.agentKind === 'codex' && rebuildReason.reason === 'credential-mode') {
             await prepareLocalCodexCredentialModeSwitch({
               maker: this.deps.maker,
               isSessionInTurn,
@@ -999,6 +1030,10 @@ export class MakerScheduleRunner implements ScheduleRunner {
           }
           throwIfFireAborted(ctx.signal, 'session route rebuild');
         } catch (err) {
+          if (preparedRotation) {
+            await preparedRotation.rollback();
+            resumeSessionId = sourceResumeSessionId;
+          }
           if (err instanceof CredentialModeSwitchBusyError) {
             return this.failOrDeferSessionRunning(schedule, ctx, sessionId, isHeartbeat);
           }
@@ -1012,7 +1047,8 @@ export class MakerScheduleRunner implements ScheduleRunner {
           nextProviderId,
           fromModel: liveSession.model,
           toModel: model,
-          reason: rebuildReason,
+          reason: rebuildReason.reason,
+          rotatedCodexThread: rebuildReason.requiresCodeModeThreadRotation,
         });
       }
     }

--- a/packages/maker-core/src/agents/base-agent.ts
+++ b/packages/maker-core/src/agents/base-agent.ts
@@ -621,6 +621,25 @@ export interface AgentDeps {
   ) => number | null;
 
   /**
+   * Resolve whether the Codex thread's final route requires CodeModeOnly.
+   *
+   * The host owns provider catalogs and default/bridge routing; maker-core only
+   * carries the resulting route capability into thread/start and thread/resume.
+   * Missing or throwing resolution is fail-safe and treats the route as not
+   * requiring CodeModeOnly.
+   */
+  resolveCodexRouteCapabilities?: (ctx: {
+    sessionId?: string;
+    providerId?: string | null;
+    model: string;
+    credentialMode?: AgentCredentialMode;
+    remoteHostId?: string | null;
+  }) =>
+    | { requiresCodeModeOnly?: boolean }
+    | undefined
+    | Promise<{ requiresCodeModeOnly?: boolean } | undefined>;
+
+  /**
    * Agent 起 session 时追加到 system prompt 末尾的字符串（host 注入）。
    * **本轮一阶段不消费**，仅占位。后续接通后 desktop 可以传项目级 prompt。
    */

--- a/packages/maker-core/src/agents/base-agent.ts
+++ b/packages/maker-core/src/agents/base-agent.ts
@@ -1490,6 +1490,8 @@ export interface AgentSessionHandle {
   readonly codexProxyActive?: boolean;
   /** Codex-only: 当前 thread 创建/恢复时冻结的 CodeModeOnly 路由能力。 */
   readonly codexRouteRequiresCodeModeOnly?: boolean;
+  /** Codex-only: 当前 thread 解析最终路由时采用的会话级凭证形态。 */
+  readonly codexRouteCredentialMode?: AgentCredentialMode;
   /**
    * Codex-only: start/resume 成功后,产品 prompt 这一次到底有没有进入
    * codex thread history。Maker 用这个事实更新 host 持久化 bit,避免再从

--- a/packages/maker-core/src/agents/base-agent.ts
+++ b/packages/maker-core/src/agents/base-agent.ts
@@ -1488,6 +1488,8 @@ export interface AgentSessionHandle {
   ): () => void;
   /** Codex-only: 当前会话绑定的 app-server host 是否经 loopback proxy 出口。 */
   readonly codexProxyActive?: boolean;
+  /** Codex-only: 当前 thread 创建/恢复时冻结的 CodeModeOnly 路由能力。 */
+  readonly codexRouteRequiresCodeModeOnly?: boolean;
   /**
    * Codex-only: start/resume 成功后,产品 prompt 这一次到底有没有进入
    * codex thread history。Maker 用这个事实更新 host 持久化 bit,避免再从

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -3422,7 +3422,10 @@ describe('CodexAgent.startSession developerInstructions', () => {
         requiresCodeModeOnly: providerId === 'xd',
       }),
     }));
-    const host = installFakeHost(agent);
+    const host = installFakeHost(agent, (method) => {
+      if (method === Method.ExperimentalFeatureEnablementSet) return {};
+      return undefined;
+    }, { userAgent: 'mock-codex/0.145.0' });
 
     const nativeHandle = await agent.startSession({
       sessionId: 'session-native-responses',
@@ -3448,6 +3451,24 @@ describe('CodexAgent.startSession developerInstructions', () => {
     };
     expect(gatewayParams.config?.['features.code_mode_only']).toBe(true);
     await gatewayHandle.close();
+
+    host.request.mock.calls.length = 0;
+    const reviewDir = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-review-codemode-'));
+    tempRoots.push(reviewDir);
+    const reviewGatewayHandle = await agent.startSession({
+      sessionId: 'session-cindy-gateway-review-codemode',
+      model: 'codex/gpt-5.5',
+      providerId: 'xd',
+      workingDir: reviewDir,
+      reviewMode: true,
+    });
+    const reviewGatewayParams = host.request.mock.calls.find(
+      ([method]) => method === Method.ThreadStart,
+    )?.[1] as {
+      config?: Record<string, unknown>;
+    };
+    expect(reviewGatewayParams.config?.['features.code_mode_only']).toBe(true);
+    await reviewGatewayHandle.close();
 
     host.request.mock.calls.length = 0;
     const resumedNativeHandle = await agent.startSession({

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -3437,6 +3437,7 @@ describe('CodexAgent.startSession developerInstructions', () => {
       config?: Record<string, unknown>;
     };
     expect(nativeParams.config?.['features.code_mode_only']).toBeUndefined();
+    expect(nativeHandle.codexRouteRequiresCodeModeOnly).toBe(false);
     await nativeHandle.close();
 
     host.request.mock.calls.length = 0;
@@ -3450,6 +3451,7 @@ describe('CodexAgent.startSession developerInstructions', () => {
       config?: Record<string, unknown>;
     };
     expect(gatewayParams.config?.['features.code_mode_only']).toBe(true);
+    expect(gatewayHandle.codexRouteRequiresCodeModeOnly).toBe(true);
     await gatewayHandle.close();
 
     host.request.mock.calls.length = 0;
@@ -3496,6 +3498,7 @@ describe('CodexAgent.startSession developerInstructions', () => {
       config?: Record<string, unknown>;
     };
     expect(remoteGatewayParams.config?.['features.code_mode_only']).toBeUndefined();
+    expect(remoteGatewayHandle.codexRouteRequiresCodeModeOnly).toBeUndefined();
     await remoteGatewayHandle.close();
   });
 

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -3529,6 +3529,33 @@ describe('CodexAgent.startSession developerInstructions', () => {
     await remoteGatewayHandle.close();
   });
 
+  it('snapshots the effective reused host mode for route capability reconciliation', async () => {
+    const resolveCodexRouteCapabilities = vi.fn(async () => ({
+      requiresCodeModeOnly: false,
+    }));
+    const agent = new CodexAgent(createDeps({}, {
+      resolveCodexRouteCapabilities,
+    }));
+    installFakeHost(agent, undefined, { codexProxyActive: true });
+    (agent as unknown as {
+      hostEffectiveCredentialModes: Map<string, AgentCredentialMode>;
+    }).hostEffectiveCredentialModes.set('local', 'gateway-key');
+
+    const handle = await agent.startSession({
+      sessionId: 'session-provider-oauth-on-gateway-host',
+      model: 'xai/grok-4.3',
+      providerId: 'xai',
+      workingDir: '/repo',
+    });
+
+    expect(resolveCodexRouteCapabilities).toHaveBeenCalledWith(expect.objectContaining({
+      sessionId: 'session-provider-oauth-on-gateway-host',
+      credentialMode: 'gateway-key',
+    }));
+    expect(handle.codexRouteCredentialMode).toBe('gateway-key');
+    await handle.close();
+  });
+
   it('passes the OpenAI compaction provider for implicit-source sessions on an oauth-effective host', async () => {
     const agent = new CodexAgent(createDeps());
     const host = installFakeHost(agent, undefined, {

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -13,7 +13,7 @@ import {
   type AgentSessionHandle,
   type TurnPermissionPolicy,
 } from '../base-agent.js';
-import type { AuthAdapter } from '../../interfaces/auth-adapter.js';
+import type { AgentCredentialMode, AuthAdapter } from '../../interfaces/auth-adapter.js';
 import type { AgentEvent as CoreAgentEvent, InteractionDecision, InteractionRequest } from '../../types/events.js';
 import type { Logger } from '../../interfaces/logger.js';
 import {
@@ -3417,10 +3417,16 @@ describe('CodexAgent.startSession developerInstructions', () => {
   });
 
   it('scopes CodeModeOnly to Cindy Gateway threads, not native Responses providers', async () => {
+    const resolveCodexRouteCapabilities = vi.fn(async (input: {
+      sessionId?: string;
+      providerId?: string | null;
+      model: string;
+      credentialMode?: AgentCredentialMode;
+    }) => ({
+      requiresCodeModeOnly: input.providerId === 'xd',
+    }));
     const agent = new CodexAgent(createDeps({}, {
-      resolveCodexRouteCapabilities: async ({ providerId }) => ({
-        requiresCodeModeOnly: providerId === 'xd',
-      }),
+      resolveCodexRouteCapabilities,
     }));
     const host = installFakeHost(agent, (method) => {
       if (method === Method.ExperimentalFeatureEnablementSet) return {};
@@ -3438,6 +3444,7 @@ describe('CodexAgent.startSession developerInstructions', () => {
     };
     expect(nativeParams.config?.['features.code_mode_only']).toBeUndefined();
     expect(nativeHandle.codexRouteRequiresCodeModeOnly).toBe(false);
+    expect(nativeHandle.codexRouteCredentialMode).toBe('provider-oauth');
     await nativeHandle.close();
 
     host.request.mock.calls.length = 0;
@@ -3452,6 +3459,7 @@ describe('CodexAgent.startSession developerInstructions', () => {
     };
     expect(gatewayParams.config?.['features.code_mode_only']).toBe(true);
     expect(gatewayHandle.codexRouteRequiresCodeModeOnly).toBe(true);
+    expect(gatewayHandle.codexRouteCredentialMode).toBe('gateway-key');
     await gatewayHandle.close();
 
     host.request.mock.calls.length = 0;
@@ -3470,7 +3478,25 @@ describe('CodexAgent.startSession developerInstructions', () => {
       config?: Record<string, unknown>;
     };
     expect(reviewGatewayParams.config?.['features.code_mode_only']).toBe(true);
+    expect(reviewGatewayHandle.codexRouteCredentialMode).toBe('gateway-key');
     await reviewGatewayHandle.close();
+
+    host.request.mock.calls.length = 0;
+    const reviewOpenAiHandle = await agent.startSession({
+      sessionId: 'session-openai-review-codemode',
+      model: 'gpt-5.5',
+      providerId: 'openai',
+      workingDir: reviewDir,
+      reviewMode: true,
+    });
+    expect(reviewOpenAiHandle.codexRouteRequiresCodeModeOnly).toBe(false);
+    expect(reviewOpenAiHandle.codexRouteCredentialMode).toBe('oauth-bearer');
+    expect(resolveCodexRouteCapabilities).toHaveBeenLastCalledWith(expect.objectContaining({
+      sessionId: 'session-openai-review-codemode',
+      providerId: 'openai',
+      credentialMode: 'oauth-bearer',
+    }));
+    await reviewOpenAiHandle.close();
 
     host.request.mock.calls.length = 0;
     const resumedNativeHandle = await agent.startSession({
@@ -3499,6 +3525,7 @@ describe('CodexAgent.startSession developerInstructions', () => {
     };
     expect(remoteGatewayParams.config?.['features.code_mode_only']).toBeUndefined();
     expect(remoteGatewayHandle.codexRouteRequiresCodeModeOnly).toBeUndefined();
+    expect(remoteGatewayHandle.codexRouteCredentialMode).toBeUndefined();
     await remoteGatewayHandle.close();
   });
 

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -3416,6 +3416,68 @@ describe('CodexAgent.startSession developerInstructions', () => {
     await xaiHandle.close();
   });
 
+  it('scopes CodeModeOnly to Cindy Gateway threads, not native Responses providers', async () => {
+    const agent = new CodexAgent(createDeps({}, {
+      resolveCodexRouteCapabilities: async ({ providerId }) => ({
+        requiresCodeModeOnly: providerId === 'xd',
+      }),
+    }));
+    const host = installFakeHost(agent);
+
+    const nativeHandle = await agent.startSession({
+      sessionId: 'session-native-responses',
+      model: 'xai/grok-4.3',
+      providerId: 'xai',
+      workingDir: '/repo',
+    });
+    const nativeParams = host.request.mock.calls.find(([method]) => method === Method.ThreadStart)?.[1] as {
+      config?: Record<string, unknown>;
+    };
+    expect(nativeParams.config?.['features.code_mode_only']).toBeUndefined();
+    await nativeHandle.close();
+
+    host.request.mock.calls.length = 0;
+    const gatewayHandle = await agent.startSession({
+      sessionId: 'session-cindy-gateway-codemode',
+      model: 'codex/gpt-5.5',
+      providerId: 'xd',
+      workingDir: '/repo',
+    });
+    const gatewayParams = host.request.mock.calls.find(([method]) => method === Method.ThreadStart)?.[1] as {
+      config?: Record<string, unknown>;
+    };
+    expect(gatewayParams.config?.['features.code_mode_only']).toBe(true);
+    await gatewayHandle.close();
+
+    host.request.mock.calls.length = 0;
+    const resumedNativeHandle = await agent.startSession({
+      sessionId: 'session-native-responses-resume',
+      model: 'xai/grok-4.3',
+      providerId: 'xai',
+      workingDir: '/repo',
+      resumeSessionId: '123e4567-e89b-12d3-a456-426614174000',
+    });
+    const resumedNativeParams = host.request.mock.calls.find(([method]) => method === Method.ThreadResume)?.[1] as {
+      config?: Record<string, unknown>;
+    };
+    expect(resumedNativeParams.config?.['features.code_mode_only']).toBe(false);
+    await resumedNativeHandle.close();
+
+    host.request.mock.calls.length = 0;
+    const remoteGatewayHandle = await agent.startSession({
+      sessionId: 'session-remote-cindy-gateway-model',
+      model: 'codex/gpt-5.5',
+      providerId: 'xd',
+      workingDir: '/remote/repo',
+      remoteHostId: 'remote-1',
+    });
+    const remoteGatewayParams = host.request.mock.calls.find(([method]) => method === Method.ThreadStart)?.[1] as {
+      config?: Record<string, unknown>;
+    };
+    expect(remoteGatewayParams.config?.['features.code_mode_only']).toBeUndefined();
+    await remoteGatewayHandle.close();
+  });
+
   it('passes the OpenAI compaction provider for implicit-source sessions on an oauth-effective host', async () => {
     const agent = new CodexAgent(createDeps());
     const host = installFakeHost(agent, undefined, {

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -9956,6 +9956,7 @@ export class CodexAgent extends BaseAgent {
       agentKind: 'codex',
       get model() { return mutableModel; },
       get codexProxyActive() { return hostUsesCodexProxy; },
+      get codexRouteRequiresCodeModeOnly() { return routeRequiresCodeModeOnly; },
       get codexProductPromptDelivery() { return codexProductPromptDelivery; },
 
       validateSendOptions(sendOpts: SendOptions) {

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -9957,6 +9957,9 @@ export class CodexAgent extends BaseAgent {
       get model() { return mutableModel; },
       get codexProxyActive() { return hostUsesCodexProxy; },
       get codexRouteRequiresCodeModeOnly() { return routeRequiresCodeModeOnly; },
+      get codexRouteCredentialMode() {
+        return opts.remoteHostId ? undefined : sessionCredentialMode;
+      },
       get codexProductPromptDelivery() { return codexProductPromptDelivery; },
 
       validateSendOptions(sendOpts: SendOptions) {

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -4585,7 +4585,9 @@ export class CodexAgent extends BaseAgent {
       );
     }
 
-    function currentThreadWorkspaceConfig(): Pick<
+    function currentThreadWorkspaceConfig(
+      codeModeOnly?: boolean,
+    ): Pick<
       ThreadStartParams,
       | 'approvalPolicy'
       | 'approvalsReviewer'
@@ -4610,6 +4612,9 @@ export class CodexAgent extends BaseAgent {
             }
           : {}),
         ...(reviewMode ? {} : host.getSessionMcpConfig(opts.sessionInstanceId)),
+        ...(codeModeOnly === undefined
+          ? {}
+          : { 'features.code_mode_only': codeModeOnly }),
       };
       const shared = {
         approvalPolicy,
@@ -4754,6 +4759,31 @@ export class CodexAgent extends BaseAgent {
     };
 
     const hostUsesCodexProxy = host.isCodexProxyActive();
+
+    /** Resolve CodeModeOnly from the final Codex route, not the provider kind. */
+    const resolveRequiresCodeModeOnly = async (): Promise<boolean | undefined> => {
+      // Remote daemons own their own route configuration. The Desktop catalog
+      // capability only applies to the local loopback proxy.
+      if (reviewMode || opts.remoteHostId) return undefined;
+      try {
+        return (await this.deps.resolveCodexRouteCapabilities?.({
+          sessionId: sid,
+          providerId: mutableProviderId,
+          model: mutableModel,
+          credentialMode: sessionCredentialMode,
+        }))?.requiresCodeModeOnly === true;
+      } catch (error) {
+        log.warn('failed to resolve Codex route capabilities; disabling CodeModeOnly', {
+          providerId: mutableProviderId ?? null,
+          model: mutableModel,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return false;
+      }
+    };
+    // Thread config is frozen for this handle. Desktop rebuilds the session
+    // when a runtime route change crosses this capability boundary.
+    const routeRequiresCodeModeOnly = await resolveRequiresCodeModeOnly();
 
     // ── OpenAI 远端压缩身份(thread 级,start/resume 冻结)────────────────────
     // 仅当 ① host 是 oauth spawn 且下发了 OpenAI 身份 provider(见
@@ -4937,7 +4967,9 @@ export class CodexAgent extends BaseAgent {
         threadId: opts.resumeSessionId,
         ...(resumeExcludeTurnsSupported ? { excludeTurns: true } : {}),
         cwd: opts.workingDir,
-        ...currentThreadWorkspaceConfig(),
+        // Older builds set CodeModeOnly at spawn scope. Explicit false clears
+        // that legacy value when a cold recovery targets any other route.
+        ...currentThreadWorkspaceConfig(routeRequiresCodeModeOnly),
         ...(threadModelProvider ? { modelProvider: threadModelProvider } : {}),
         ...(mutableModel && mutableModel !== 'gpt-5' ? { model: mutableModel } : {}),
         ...(mutableServiceTier !== undefined ? { serviceTier: mutableServiceTier } : {}),
@@ -5010,7 +5042,7 @@ export class CodexAgent extends BaseAgent {
       // 内容为空时不发送 developerInstructions 字段。
       const params: ThreadStartParams = {
         cwd: opts.workingDir,
-        ...currentThreadWorkspaceConfig(),
+        ...currentThreadWorkspaceConfig(routeRequiresCodeModeOnly || undefined),
         ...(sessionDynamicTools.length > 0 ? { dynamicTools: sessionDynamicTools } : {}),
         ...(threadModelProvider ? { modelProvider: threadModelProvider } : {}),
         ...(mutableModel && mutableModel !== 'gpt-5' ? { model: mutableModel } : {}),
@@ -5146,7 +5178,7 @@ export class CodexAgent extends BaseAgent {
           signal,
           request: () => host.request<ThreadStartResponse>(Method.ThreadStart, {
             cwd: opts.workingDir,
-            ...currentThreadWorkspaceConfig(),
+            ...currentThreadWorkspaceConfig(routeRequiresCodeModeOnly || undefined),
             ...(sessionDynamicTools.length > 0 ? { dynamicTools: sessionDynamicTools } : {}),
             ...(threadModelProvider ? { modelProvider: threadModelProvider } : {}),
             ...(mutableModel && mutableModel !== 'gpt-5' ? { model: mutableModel } : {}),
@@ -5246,7 +5278,9 @@ export class CodexAgent extends BaseAgent {
           await replaceUnusedThreadWithCurrentProfile(signal);
           return;
         }
-        const resumeThreadWorkspaceConfig = currentThreadWorkspaceConfig();
+        const resumeThreadWorkspaceConfig = currentThreadWorkspaceConfig(
+          routeRequiresCodeModeOnly || undefined,
+        );
         const resumeServiceTierGeneration = serviceTierMutationGeneration;
         assertCurrentHost('read-only reference profile refresh');
         let resp: ThreadResumeResponse;
@@ -10009,7 +10043,9 @@ export class CodexAgent extends BaseAgent {
           // A stale-daemon retry must hydrate the exact thread-level profile
           // that matches this turn, not mutable settings changed while the
           // original turn/start RPC was pending.
-          turnThreadWorkspaceConfig = currentThreadWorkspaceConfig();
+          // This recovery may cold-load a thread persisted by a build that set
+          // CodeModeOnly at spawn scope, so false must be explicit here.
+          turnThreadWorkspaceConfig = currentThreadWorkspaceConfig(routeRequiresCodeModeOnly);
         } catch (e) {
           isTurnStartPending = false;
           endPlanCycleAfterPreStartFailure('read-only reference profile refresh failed');

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -4764,7 +4764,7 @@ export class CodexAgent extends BaseAgent {
     const resolveRequiresCodeModeOnly = async (): Promise<boolean | undefined> => {
       // Remote daemons own their own route configuration. The Desktop catalog
       // capability only applies to the local loopback proxy.
-      if (reviewMode || opts.remoteHostId) return undefined;
+      if (opts.remoteHostId) return undefined;
       try {
         return (await this.deps.resolveCodexRouteCapabilities?.({
           sessionId: sid,

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -3769,6 +3769,11 @@ export class CodexAgent extends BaseAgent {
           model: opts.model,
         }) ?? this.hostEffectiveCredentialModes.get(currentHostKey)
       : credentialMode ?? this.hostEffectiveCredentialModes.get(currentHostKey);
+    // Route fallback follows the auth shape of the host that this session
+    // actually reused, which can differ from the session's requested mode.
+    const sessionRouteCredentialMode = opts.remoteHostId
+      ? undefined
+      : this.hostEffectiveCredentialModes.get(currentHostKey) ?? sessionCredentialMode;
     const approvalsReviewerProtocolSupported =
       supportsCodexApprovalsReviewerProtocol(initResp.userAgent);
     const codexBrowserUseProvisioned = host.isCodexBrowserUseAvailable();
@@ -4770,7 +4775,7 @@ export class CodexAgent extends BaseAgent {
           sessionId: sid,
           providerId: mutableProviderId,
           model: mutableModel,
-          credentialMode: sessionCredentialMode,
+          credentialMode: sessionRouteCredentialMode,
         }))?.requiresCodeModeOnly === true;
       } catch (error) {
         log.warn('failed to resolve Codex route capabilities; disabling CodeModeOnly', {
@@ -9958,7 +9963,7 @@ export class CodexAgent extends BaseAgent {
       get codexProxyActive() { return hostUsesCodexProxy; },
       get codexRouteRequiresCodeModeOnly() { return routeRequiresCodeModeOnly; },
       get codexRouteCredentialMode() {
-        return opts.remoteHostId ? undefined : sessionCredentialMode;
+        return sessionRouteCredentialMode;
       },
       get codexProductPromptDelivery() { return codexProductPromptDelivery; },
 

--- a/packages/maker-core/src/session.ts
+++ b/packages/maker-core/src/session.ts
@@ -952,6 +952,11 @@ export class Session {
     return this.handle.codexProxyActive;
   }
 
+  /** Codex-only: 当前 thread 生命周期内冻结的 CodeModeOnly 路由能力。 */
+  get codexRouteRequiresCodeModeOnly(): boolean | undefined {
+    return this.handle.codexRouteRequiresCodeModeOnly;
+  }
+
   /** Snapshot used by temporary host overrides to avoid undoing a newer user change. */
   get permissionModeState(): PermissionModeState {
     return { ...this.permissionModeStateValue };

--- a/packages/maker-core/src/session.ts
+++ b/packages/maker-core/src/session.ts
@@ -56,6 +56,7 @@ import {
 } from './agents/base-agent.js';
 import { formatManagedImageReferences } from './agents/shared/managed-image-reference.js';
 import type { Logger } from './interfaces/logger.js';
+import type { AgentCredentialMode } from './interfaces/auth-adapter.js';
 
 export type SessionStatus = 'active' | 'aborting' | 'closed' | 'error';
 
@@ -955,6 +956,11 @@ export class Session {
   /** Codex-only: 当前 thread 生命周期内冻结的 CodeModeOnly 路由能力。 */
   get codexRouteRequiresCodeModeOnly(): boolean | undefined {
     return this.handle.codexRouteRequiresCodeModeOnly;
+  }
+
+  /** Codex-only: 当前 thread 最终路由冻结时采用的会话级凭证形态。 */
+  get codexRouteCredentialMode(): AgentCredentialMode | undefined {
+    return this.handle.codexRouteCredentialMode;
   }
 
   /** Snapshot used by temporary host overrides to avoid undoing a newer user change. */

--- a/packages/model-providers/src/__tests__/catalog.test.ts
+++ b/packages/model-providers/src/__tests__/catalog.test.ts
@@ -453,6 +453,24 @@ describe('routing modelPrefixes 服务范围契约 (issue #886)', () => {
   });
 });
 
+describe('routing requiresCodeModeOnly capability validation', () => {
+  it('accepts a boolean route capability', () => {
+    const catalog = structuredClone(BUNDLED_CATALOG);
+    const xd = catalog.providers.find((provider) => provider.id === 'xd');
+    if (!xd?.routing.codex) throw new Error('missing XD Codex route');
+    xd.routing.codex.requiresCodeModeOnly = false;
+    expect(() => parseCatalog(catalog)).not.toThrow();
+  });
+
+  it('rejects a non-boolean route capability', () => {
+    const catalog = structuredClone(BUNDLED_CATALOG) as typeof BUNDLED_CATALOG;
+    const xd = catalog.providers.find((provider) => provider.id === 'xd');
+    if (!xd?.routing.codex) throw new Error('missing XD Codex route');
+    xd.routing.codex.requiresCodeModeOnly = 'true' as never;
+    expect(() => parseCatalog(catalog)).toThrow(/requiresCodeModeOnly/);
+  });
+});
+
 describe('routing wireProtocol per-agent 契约', () => {
   it('parseCatalog 拒绝 claude-code 使用 openai-chat', () => {
     const bad = JSON.parse(JSON.stringify(BUNDLED_CATALOG)) as Catalog;

--- a/packages/model-providers/src/__tests__/source-registry.test.ts
+++ b/packages/model-providers/src/__tests__/source-registry.test.ts
@@ -298,6 +298,39 @@ describe('mergeWithBundled', () => {
     });
     expect(explicitlyDisabled.providers.find((p) => p.id === 'xd')?.routing.codex?.requiresCodeModeOnly)
       .toBe(false);
+
+    const directResponsesXd = mergeWithBundled({
+      version: '2',
+      providers: [{
+        ...oldRemoteXd,
+        routing: {
+          ...oldRemoteXd.routing,
+          codex: {
+            ...oldRemoteXd.routing.codex!,
+            authStrategy: 'api-key-header',
+            wireProtocol: 'openai-responses',
+          },
+        },
+      }],
+    });
+    expect(directResponsesXd.providers.find((p) => p.id === 'xd')?.routing.codex?.requiresCodeModeOnly)
+      .toBeUndefined();
+
+    const chatBridgeXd = mergeWithBundled({
+      version: '2',
+      providers: [{
+        ...oldRemoteXd,
+        routing: {
+          ...oldRemoteXd.routing,
+          codex: {
+            ...oldRemoteXd.routing.codex!,
+            wireProtocol: 'openai-chat',
+          },
+        },
+      }],
+    });
+    expect(chatBridgeXd.providers.find((p) => p.id === 'xd')?.routing.codex?.requiresCodeModeOnly)
+      .toBeUndefined();
   });
 
   it('旧远端改变鉴权或路由形状时不继承 bundled 图像能力', () => {

--- a/packages/model-providers/src/__tests__/source-registry.test.ts
+++ b/packages/model-providers/src/__tests__/source-registry.test.ts
@@ -274,6 +274,32 @@ describe('mergeWithBundled', () => {
     ).toEqual([]);
   });
 
+  it('旧远端 XD 路由缺少 CodeModeOnly 时继承 bundled;显式 false 仍可覆盖', () => {
+    const bundledXd = BUNDLED_CATALOG.providers.find((p) => p.id === 'xd')!;
+    const oldRemoteXd = JSON.parse(JSON.stringify(bundledXd)) as Provider;
+    delete oldRemoteXd.routing.codex?.requiresCodeModeOnly;
+
+    const inherited = mergeWithBundled({ version: '2', providers: [oldRemoteXd] });
+    expect(inherited.providers.find((p) => p.id === 'xd')?.routing.codex?.requiresCodeModeOnly)
+      .toBe(true);
+
+    const explicitlyDisabled = mergeWithBundled({
+      version: '2',
+      providers: [{
+        ...oldRemoteXd,
+        routing: {
+          ...oldRemoteXd.routing,
+          codex: {
+            ...oldRemoteXd.routing.codex!,
+            requiresCodeModeOnly: false,
+          },
+        },
+      }],
+    });
+    expect(explicitlyDisabled.providers.find((p) => p.id === 'xd')?.routing.codex?.requiresCodeModeOnly)
+      .toBe(false);
+  });
+
   it('旧远端改变鉴权或路由形状时不继承 bundled 图像能力', () => {
     const bundledXai = BUNDLED_CATALOG.providers.find((p) => p.id === 'xai')!;
     const oldRemoteXai = JSON.parse(JSON.stringify(bundledXai)) as Provider;

--- a/packages/model-providers/src/builtin.ts
+++ b/packages/model-providers/src/builtin.ts
@@ -229,6 +229,7 @@ const XD_PROVIDER: Provider = {
     codex: {
       upstream: 'https://xd-gateway.invalid/v1',
       authStrategy: 'gateway-key',
+      requiresCodeModeOnly: true,
     },
     // pi 直连网关 anthropic-messages 面(与 claude-code 同可达面);upstream 同为占位。
     pi: {

--- a/packages/model-providers/src/catalog.ts
+++ b/packages/model-providers/src/catalog.ts
@@ -338,6 +338,12 @@ function validateProvider(p: Provider): void {
         `provider '${p.id}' routing[${agent}].requestPath invalid`,
       );
     }
+    if (routing.requiresCodeModeOnly !== undefined) {
+      assert(
+        typeof routing.requiresCodeModeOnly === 'boolean',
+        `provider '${p.id}' routing[${agent}].requiresCodeModeOnly must be boolean`,
+      );
+    }
     // modelPrefixes（路由服务范围）提供了就必须是命名空间前缀形态（`xai/` 这类,以 `/` 结尾）——
     // 结构上保证 claude-* 等裸 wire model 永远不会命中,防止把 scope 声明成误伤辅助请求的形状。
     if (routing.modelPrefixes !== undefined) {

--- a/packages/model-providers/src/source.ts
+++ b/packages/model-providers/src/source.ts
@@ -251,6 +251,34 @@ function backfillPresetMetadata(
 }
 
 /**
+ * Backfill the Cindy Gateway's thread capability for catalogs produced before
+ * `requiresCodeModeOnly` existed. An explicit value, including false, remains
+ * an intentional catalog override and is never replaced.
+ */
+function backfillCodexRouteCapabilities(primary: Provider, bundled: Provider): Provider {
+  if (primary.id !== 'xd') return primary;
+  const primaryCodex = primary.routing.codex;
+  const bundledCodex = bundled.routing.codex;
+  if (
+    !primaryCodex
+    || bundledCodex?.requiresCodeModeOnly === undefined
+    || primaryCodex.requiresCodeModeOnly !== undefined
+  ) {
+    return primary;
+  }
+  return {
+    ...primary,
+    routing: {
+      ...primary.routing,
+      codex: {
+        ...primaryCodex,
+        requiresCodeModeOnly: bundledCodex.requiresCodeModeOnly,
+      },
+    },
+  };
+}
+
+/**
  * 把远端 / 本地目录与内置 bundled 合并：以输入目录为主，bundled 补它缺失的
  * provider（按 id），并给旧目录中同 id provider 补缺失的 access 与媒体能力元数据。
  * primary 明确提供的值（包括显式空媒体清单）永远优先，不被 bundled 覆盖。
@@ -265,18 +293,19 @@ export function mergeWithBundled(primary: Catalog): Catalog {
     const bundled = bundledById.get(p.id);
     const bundledAccess = bundled ? legacyAccessFor(p, bundled) : undefined;
     if (!bundled) return p;
+    const withRouteCapabilities = backfillCodexRouteCapabilities(p, bundled);
     const inheritImage =
-      p.id === 'xai' &&
-      p.imageModels === undefined &&
+      withRouteCapabilities.id === 'xai' &&
+      withRouteCapabilities.imageModels === undefined &&
       bundled.imageModels !== undefined &&
       bundledAccess !== undefined &&
-      allowsBundledImageInheritance(p.access, bundledAccess);
+      allowsBundledImageInheritance(withRouteCapabilities.access, bundledAccess);
     const inheritVideo =
-      p.id === 'xai' &&
-      p.videoModels === undefined &&
+      withRouteCapabilities.id === 'xai' &&
+      withRouteCapabilities.videoModels === undefined &&
       bundled.videoModels !== undefined &&
       bundledAccess !== undefined &&
-      allowsBundledImageInheritance(p.access, bundledAccess);
+      allowsBundledImageInheritance(withRouteCapabilities.access, bundledAccess);
     // 向量清单与 xai 的图像清单同一个道理(PR #1707 review):xd 段的向量能力是
     // 客户端新增的 bundled 元数据,而远端 / 本地目录里同 id 的 xd 可能还是升级前
     // 的结构、根本没有 embeddingModels 这个字段。primary 整体优先的规则会让那份
@@ -286,26 +315,26 @@ export function mergeWithBundled(primary: Catalog): Catalog {
     // 只在字段**缺席**时补,显式 `[]` 仍然是"这个供应商不提供向量"的停用语义,
     // 与图像清单的既有契约一致。
     const inheritEmbedding =
-      p.id === 'xd' &&
-      p.embeddingModels === undefined &&
+      withRouteCapabilities.id === 'xd' &&
+      withRouteCapabilities.embeddingModels === undefined &&
       bundled.embeddingModels !== undefined &&
       bundledAccess !== undefined &&
-      allowsBundledImageInheritance(p.access, bundledAccess);
+      allowsBundledImageInheritance(withRouteCapabilities.access, bundledAccess);
     if (
-      !(p.access === undefined && bundledAccess !== undefined) &&
+      !(withRouteCapabilities.access === undefined && bundledAccess !== undefined) &&
       !inheritImage &&
       !inheritVideo &&
       !inheritEmbedding
     ) {
-      return p;
+      return withRouteCapabilities;
     }
     return {
-      ...p,
-      ...(p.access === undefined && bundledAccess !== undefined ? { access: bundledAccess } : {}),
+      ...withRouteCapabilities,
+      ...(withRouteCapabilities.access === undefined && bundledAccess !== undefined ? { access: bundledAccess } : {}),
       ...(inheritImage
         ? {
             imageModels: bundled.imageModels,
-            ...(p.imageDefaults === undefined && bundled.imageDefaults !== undefined
+            ...(withRouteCapabilities.imageDefaults === undefined && bundled.imageDefaults !== undefined
               ? { imageDefaults: bundled.imageDefaults }
               : {}),
           }
@@ -321,7 +350,7 @@ export function mergeWithBundled(primary: Catalog): Catalog {
       ...(inheritEmbedding
         ? {
             embeddingModels: bundled.embeddingModels,
-            ...(p.embeddingDefaults === undefined && bundled.embeddingDefaults !== undefined
+            ...(withRouteCapabilities.embeddingDefaults === undefined && bundled.embeddingDefaults !== undefined
               ? { embeddingDefaults: bundled.embeddingDefaults }
               : {}),
           }

--- a/packages/model-providers/src/source.ts
+++ b/packages/model-providers/src/source.ts
@@ -263,6 +263,9 @@ function backfillCodexRouteCapabilities(primary: Provider, bundled: Provider): P
     !primaryCodex
     || bundledCodex?.requiresCodeModeOnly === undefined
     || primaryCodex.requiresCodeModeOnly !== undefined
+    || primaryCodex.authStrategy !== bundledCodex.authStrategy
+    || (primaryCodex.wireProtocol ?? 'openai-responses')
+      !== (bundledCodex.wireProtocol ?? 'openai-responses')
   ) {
     return primary;
   }

--- a/packages/model-providers/src/types.ts
+++ b/packages/model-providers/src/types.ts
@@ -178,6 +178,13 @@ export interface RoutingDescriptor {
   /** 鉴权策略（见 AuthStrategy）。 */
   authStrategy: AuthStrategy;
   /**
+   * Whether the Codex thread using this route must enable CodeModeOnly.
+   *
+   * This is a client-side route capability, not model metadata. It is optional
+   * so older catalogs and user providers keep their existing behavior.
+   */
+  requiresCodeModeOnly?: boolean;
+  /**
    * 配置保留用于展示/修复，但运行时不得向该上游路由。用于把升级前不再满足安全边界的
    * 历史配置留在设置页，同时让所有路由解析 fail closed。
    */


### PR DESCRIPTION
## 这次改了什么

### 摘要

Codex 之前在 app-server 启动层全局开启 `features.code_mode_only=true`。这个配置不仅作用于 Cindy Gateway，也会泄漏到 DeepSeek / GLM 等 Chat bridge 和 xAI / OpenRouter 等原生 Responses 路由，导致部分第三方端点无法正确处理工具调用。

本 PR 把 `CodeModeOnly` 改为最终路由能力：只有 Cindy Gateway 的 Codex 路由声明 `requiresCodeModeOnly: true`，其它桥接或原生 Responses 路由默认不启用。运行中模型、Provider、catalog 或连接状态发生变化时，只有最终路由跨越该能力边界才重建本地 Codex session；能力相同仍沿用热切换。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无；来自 DeepSeek / GLM / 原生 Responses 与 Cindy Gateway 路由差异的本地排查
- 本 PR 包含：
  - 移除 Codex spawn 层的全局 `CodeModeOnly`
  - 为 Codex `RoutingDescriptor` 增加可选的 `requiresCodeModeOnly` 能力，并只在内置 Cindy Gateway 路由启用
  - 按 proxy 的最终路由解析显式 Provider、隐式 Chat / Anthropic Messages bridge、原生 provider OAuth、禁用内置 Provider 与 Gateway fallback
  - 新建、冷恢复和 Reviewer 的本地 Codex thread 均按实际路由下发对应值；Reviewer 冻结隔离 proxy 的会话级鉴权形态，冷恢复显式下发 `false`，清除旧版本全局 spawn 配置留下的状态
  - 暴露 thread 创建/恢复时冻结的能力快照；模型、Provider、catalog 或连接状态变化后比较 live 最终路由
  - 能力变化且 session 空闲时精确关闭当前实例；busy 时立即中断当前 turn，保持输入队列 gate，并在权威 idle/close 边界关闭旧 thread
  - Provider mutation 期间延迟收敛，并用单调 generation 丢弃与短暂 mutation 重叠的异步快照；关闭 session 后再次核对 blocker / generation，避免 teardown 与 mutation 重叠时提前唤醒输入队列
- 明确不包含：DeepSeek / GLM / OpenRouter catalog 的 wire protocol 修改；远端 Codex daemon；UI、SQLite、插件、system prompt、协议或原生层修改
- 用户可见变化：第三方 Chat bridge 和原生 Responses Provider 不再继承 Cindy Gateway 专用的 `CodeModeOnly`；Cindy Gateway 行为保持不变
- 是否存在 breaking change：无。新字段可选，旧 catalog 和用户 Provider 保持原行为；不修改 Provider/model 持久值

### UI 变化

- 引用的设计规范：不涉及；本 PR 没有 UI、交互或文案改动

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：通过，全部适用 workspace 通过

pnpm --filter desktop run --if-present typecheck
pnpm --filter @cindy/maker-core run --if-present typecheck
pnpm --filter @cindy/model-providers run --if-present typecheck
结果：全部通过

Desktop 路由 / 重建定向 Vitest
结果：104/104 通过

maker-core Codex 定向 Vitest
结果：464/464 通过

git diff --cached --check
pnpm check:dco
结果：通过
```

maker-core 核心指标检查：

- 缓存率：未修改 system prompt、developer instructions、tool / MCP 定义或其顺序，模型请求前缀不变
- 性能：能力解析发生在 session 创建、模型 / Provider 切换及 catalog/连接态变化时，没有加入 event / token 热路径，也没有新增每轮网络请求
- 返回准确性：回归测试覆盖 Cindy Gateway、原生 Responses、Chat / Anthropic Messages bridge、Reviewer、冷恢复、运行时跨能力边界切换、busy turn 立即中断，以及 abort / terminal / Provider mutation 竞态
- usage / translator：未修改 usage 计量与事件 translator

### 手工验证

- 隔离 Desktop 测试中已验证 Cindy Gateway、DeepSeek Chat bridge、GLM Chat bridge、原生 Responses 的预期路由行为
- 已验证包含 `exec` 工具调用的对话；第三方非 Gateway 路由不再继承 `CodeModeOnly`，Gateway 路由保持启用
- DeepSeek 官方 `/responses` catalog 实验未包含在本 PR

### 未执行的验证

- 未在最终 commit 上重新调用所有真实外部端点；外部服务可用性与凭证不属于本 PR 的稳定测试条件
- 未做 Windows 手工运行时验证；代码不含平台分支，等待 CI 的 Windows 单测矩阵验证

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：Codex 最终路由能力判定和本地 session 重建时机

### 影响与回滚

- 影响范围：仅本地 Codex loopback proxy 的 thread 配置，以及最终路由跨越 `requiresCodeModeOnly` 能力边界时的 session 生命周期
- 不受影响：远端 Codex daemon、能力未变化的本地 session、Provider/model 持久配置
- 回滚 / 降级方式：回退本 PR 即可恢复 spawn 层全局 `CodeModeOnly`；也可移除 Cindy Gateway 路由上的能力声明以临时关闭该能力
- 配置兼容：字段为可选 boolean；旧 catalog、远端 catalog 和用户自定义 Provider 无需迁移
- 存量插件影响：无
- system prompt、SQLite migration、跨端 wire protocol、原生层与 mobile fingerprint：均不涉及

### 提交前检查

- [x] 已 review 完整 diff，独立复核无 P0/P1
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（不需要额外文档；类型注释与回归测试已覆盖新能力契约）
- [x] 已确认测试结果或说明未执行原因