### PR TITLE
fix(desktop): allow opted-in Chat bridge images

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
@@ -597,6 +597,99 @@ describe('chatBridgeCapabilitiesForRoute', () => {
     }
   });
 
+  async function captureUserChatBridgeCapabilities(options: {
+    supportsImageInput?: boolean;
+    catalogModel?: string;
+    wireModel?: string;
+    stripPrefix?: string;
+  }) {
+    const host = await freshCodexProxyHost();
+    const { buildUserProvider } = await import('@cindy/model-providers');
+    const { setCustomProviders } = await import('../active-catalog.js');
+    const { setCustomProviderKeyReader } = await import('../provider-route.js');
+    const { setSessionProvider, clearSessionProvider } = await import('../session-provider-store.js');
+    const catalogModel = options.catalogModel ?? 'vision-model';
+    const provider = buildUserProvider({
+      id: 'opt-in-chat',
+      name: 'Opt-in Chat',
+      runtimes: {
+        codex: {
+          baseUrl: 'https://chat.example/v1',
+          wireProtocol: 'openai-chat',
+          models: [{
+            id: catalogModel,
+            name: 'Vision Model',
+            ...(options.supportsImageInput !== undefined
+              ? { supportsImageInput: options.supportsImageInput }
+              : {}),
+          }],
+        },
+      },
+    });
+    const codexRouting = provider.routing.codex;
+    if (!codexRouting) throw new Error('test provider is missing Codex routing');
+    setCustomProviders([{
+      ...provider,
+      routing: {
+        ...provider.routing,
+        codex: {
+          ...codexRouting,
+          ...(options.stripPrefix
+            ? { modelIdRewrite: { stripPrefix: options.stripPrefix } }
+            : {}),
+        },
+      },
+    }]);
+    setCustomProviderKeyReader(() => 'opt-in-key');
+    host.registerComposed('session-opt-in-image', 'thread-opt-in-image', 'PRODUCT_PROMPT');
+    setSessionProvider('session-opt-in-image', 'opt-in-chat');
+    host.setCodexProxyAuthInjection('env-key');
+
+    try {
+      const decision = await Promise.resolve(host.createModelRoutingTransform()(
+        { model: options.wireModel ?? catalogModel, input: 'hello' },
+        {
+          reqId: 1,
+          method: 'POST',
+          url: '/responses',
+          headers: { 'thread-id': 'thread-opt-in-image' },
+        },
+      ));
+      expect(decision).toEqual(expect.objectContaining({ localHandler: expect.any(Function) }));
+      const handlerCall = (mockState.createResponsesChatHandler.mock.calls as unknown as Array<[
+        { capabilities?: { imageInput?: string } },
+      ]>).at(-1);
+      return handlerCall?.[0].capabilities;
+    } finally {
+      clearSessionProvider('session-opt-in-image');
+      setCustomProviderKeyReader(() => null);
+      setCustomProviders([]);
+    }
+  }
+
+  it('enables image_url for an explicitly opted-in user-provider model', async () => {
+    const capabilities = await captureUserChatBridgeCapabilities({ supportsImageInput: true });
+    expect(capabilities?.imageInput).toBe('image_url');
+  });
+
+  it.each([undefined, false])(
+    'keeps an unverified user-provider model fail-closed when supportsImageInput is %s',
+    async (supportsImageInput) => {
+      const capabilities = await captureUserChatBridgeCapabilities({ supportsImageInput });
+      expect(capabilities?.imageInput).toBeUndefined();
+    },
+  );
+
+  it('matches opted-in catalog models after stripPrefix and [1m] normalization', async () => {
+    const capabilities = await captureUserChatBridgeCapabilities({
+      supportsImageInput: true,
+      catalogModel: 'vision-model',
+      wireModel: 'vendor/vision-model[1m]',
+      stripPrefix: 'vendor/',
+    });
+    expect(capabilities?.imageInput).toBe('image_url');
+  });
+
   it('does not forward unsupported passthrough fields into the translator', async () => {
     const { chatBridgeCapabilitiesForRoute } = await freshCodexProxyHost();
     const capabilities = chatBridgeCapabilitiesForRoute(

--- a/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
@@ -123,6 +123,10 @@ vi.mock('@cindy/responses-anthropic-bridge', () => ({
   createResponsesAnthropicHandler: mockState.createResponsesAnthropicHandler,
 }));
 
+// Keep the cold SUT transform in collection time instead of charging it to the
+// first 20-second test. Later cases still use freshCodexProxyHost for isolation.
+const initiallyLoadedCodexProxyHost = await import('../codex-proxy-host.js');
+
 async function freshCodexProxyHost() {
   vi.resetModules();
   mockState.createAnthropicCompatProxy.mockReset();
@@ -147,7 +151,7 @@ describe('withCodexUpstreamRecording', () => {
   }) as never;
 
   it('records the override upstream origin for the request thread', async () => {
-    const host = await freshCodexProxyHost();
+    const host = initiallyLoadedCodexProxyHost;
     host.resetCodexThreadUpstreamForTest();
     const wrapped = host.withCodexUpstreamRecording(
       () => ({ upstreamOverride: 'https://api.x.ai/v1' }),
@@ -600,6 +604,7 @@ describe('chatBridgeCapabilitiesForRoute', () => {
   async function captureUserChatBridgeCapabilities(options: {
     supportsImageInput?: boolean;
     catalogModel?: string;
+    catalogModels?: Array<{ id: string; supportsImageInput?: boolean }>;
     wireModel?: string;
     stripPrefix?: string;
   }) {
@@ -616,13 +621,18 @@ describe('chatBridgeCapabilitiesForRoute', () => {
         codex: {
           baseUrl: 'https://chat.example/v1',
           wireProtocol: 'openai-chat',
-          models: [{
-            id: catalogModel,
-            name: 'Vision Model',
-            ...(options.supportsImageInput !== undefined
-              ? { supportsImageInput: options.supportsImageInput }
-              : {}),
-          }],
+          models: options.catalogModels?.map((model) => ({
+            ...model,
+            name: model.id,
+          })) ?? [
+            {
+              id: catalogModel,
+              name: 'Vision Model',
+              ...(options.supportsImageInput !== undefined
+                ? { supportsImageInput: options.supportsImageInput }
+                : {}),
+            },
+          ],
         },
       },
     });
@@ -688,6 +698,18 @@ describe('chatBridgeCapabilitiesForRoute', () => {
       stripPrefix: 'vendor/',
     });
     expect(capabilities?.imageInput).toBe('image_url');
+  });
+
+  it('prefers the exact catalog model over an opted-in normalized fallback', async () => {
+    const capabilities = await captureUserChatBridgeCapabilities({
+      catalogModels: [
+        { id: 'vision-model', supportsImageInput: true },
+        { id: 'vendor/vision-model[1m]' },
+      ],
+      wireModel: 'vendor/vision-model[1m]',
+      stripPrefix: 'vendor/',
+    });
+    expect(capabilities?.imageInput).toBeUndefined();
   });
 
   it('does not forward unsupported passthrough fields into the translator', async () => {

--- a/apps/desktop/src/main/maker-host/active-catalog.ts
+++ b/apps/desktop/src/main/maker-host/active-catalog.ts
@@ -982,18 +982,18 @@ export function getActiveCatalog(): Catalog {
 }
 
 /**
- * 返回指定 provider/agent 下模型的目录上下文窗口。
+ * 返回指定 provider/agent 下与 wire model 对应的目录模型。
  *
  * Codex wire model 可能带有 `[1m]` 展示后缀，或被 route 的 stripPrefix
  * 包了一层；目录始终保存原始模型 id，因此查询在这里统一做去后缀/去前缀
  * 候选归一，避免各个上游 bridge 自己复制一份模型匹配逻辑。
  */
-export function getCatalogModelContextWindow(
+export function getCatalogModel(
   providerId: string,
   agent: AgentKind,
   modelId: string,
   stripPrefix?: string,
-): number | null {
+): CatalogModel | null {
   const candidates = new Set<string>([modelId, modelId.replace(/\[1m\]$/, '')]);
   if (stripPrefix && modelId.startsWith(stripPrefix)) {
     const stripped = modelId.slice(stripPrefix.length);
@@ -1001,8 +1001,17 @@ export function getCatalogModelContextWindow(
     candidates.add(stripped.replace(/\[1m\]$/, ''));
   }
   const provider = getActiveCatalog().providers.find((entry) => entry.id === providerId);
-  const model = provider?.models[agent]?.find((entry) => candidates.has(entry.id));
-  return model?.contextWindow ?? null;
+  return provider?.models[agent]?.find((entry) => candidates.has(entry.id)) ?? null;
+}
+
+/** 返回指定 provider/agent 下模型的目录上下文窗口。 */
+export function getCatalogModelContextWindow(
+  providerId: string,
+  agent: AgentKind,
+  modelId: string,
+  stripPrefix?: string,
+): number | null {
+  return getCatalogModel(providerId, agent, modelId, stripPrefix)?.contextWindow ?? null;
 }
 
 /** 由 host 的目录加载器(ensureActiveCatalogLoaded)在拉取成功后写入基础目录。 */

--- a/apps/desktop/src/main/maker-host/active-catalog.ts
+++ b/apps/desktop/src/main/maker-host/active-catalog.ts
@@ -1001,7 +1001,12 @@ export function getCatalogModel(
     candidates.add(stripped.replace(/\[1m\]$/, ''));
   }
   const provider = getActiveCatalog().providers.find((entry) => entry.id === providerId);
-  return provider?.models[agent]?.find((entry) => candidates.has(entry.id)) ?? null;
+  const models = provider?.models[agent];
+  for (const candidate of candidates) {
+    const model = models?.find((entry) => entry.id === candidate);
+    if (model) return model;
+  }
+  return null;
 }
 
 /** 返回指定 provider/agent 下模型的目录上下文窗口。 */

--- a/apps/desktop/src/main/maker-host/codex-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/codex-proxy-host.ts
@@ -43,7 +43,7 @@ import path from 'node:path';
 
 import { buildCodexGatewayBaseUrl, CODEX_OAUTH_UPSTREAM } from './codex-gateway-config.js';
 import { claudeUpstreamEndpoint } from './runtime-configs.js';
-import { getActiveCatalog, getCatalogModelContextWindow } from './active-catalog.js';
+import { getActiveCatalog, getCatalogModel, getCatalogModelContextWindow } from './active-catalog.js';
 import {
   gatewayDefaultRouteDecision,
   getSessionRoutingDescriptor,
@@ -639,11 +639,17 @@ function createChatBridgeDecision(
         googleThoughtSignaturePlaceholder: true,
     }
     : CHAT_BRIDGE_DEFAULT_CAPABILITIES;
-  const capabilities = chatBridgeCapabilitiesForRoute(
+  const routeCapabilities = chatBridgeCapabilitiesForRoute(
     route.routing.upstream,
     realModel,
     baseCapabilities,
   );
+  const userModelSupportsImageInput =
+    route.providerSource === 'user' &&
+    getCatalogModel(route.providerId, 'codex', wireModel, stripPrefix)?.supportsImageInput === true;
+  const capabilities = userModelSupportsImageInput
+    ? { ...routeCapabilities, imageInput: 'image_url' as const }
+    : routeCapabilities;
   const onUpstreamError = route.providerSource === 'user'
     ? ({ status, body }: { status: number; body: string }): void => {
         reportProviderUpstreamError({ agent: 'codex', providerId, providerName, status, bodyText: body });

--- a/apps/desktop/src/renderer/__tests__/customProviderDialogPresetLocale.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/customProviderDialogPresetLocale.test.tsx
@@ -50,6 +50,7 @@ vi.mock('@/lib/customProviders', () => ({
   setCustomProviderModelReasoning: vi.fn(),
   setCustomProviderModelReasoningEffort: vi.fn(),
   setCustomProviderModelSupportsImageInput: vi.fn(),
+  shouldShowCustomProviderModelImageInput: vi.fn(() => false),
   updateCustomProvider: vi.fn(),
 }));
 

--- a/apps/desktop/src/renderer/components/settings/CustomProviderDialog.tsx
+++ b/apps/desktop/src/renderer/components/settings/CustomProviderDialog.tsx
@@ -41,6 +41,7 @@ import {
   setCustomProviderModelReasoning,
   setCustomProviderModelReasoningEffort,
   setCustomProviderModelSupportsImageInput,
+  shouldShowCustomProviderModelImageInput,
   updateCustomProvider,
   type RuntimeKeys,
 } from '@/lib/customProviders';
@@ -2132,7 +2133,7 @@ export function CustomProviderDialog({
                       >
                         <Trash2 size={16} />
                       </button>
-                      {activeTab === 'pi' && (
+                      {shouldShowCustomProviderModelImageInput(activeTab, f.wireProtocol) && (
                         <div className="flex basis-full flex-col gap-2 pr-12 text-[var(--settings-section-desc)]">
                           <label className="flex cursor-pointer items-start gap-2">
                             <input
@@ -2160,29 +2161,31 @@ export function CustomProviderDialog({
                               </span>
                             </span>
                           </label>
-                          <label className="flex cursor-pointer items-start gap-2">
-                            <input
-                              type="checkbox"
-                              checked={m.reasoning === true}
-                              onChange={(event) => {
-                                const reasoning = event.currentTarget.checked;
-                                patch(activeTab, (x) => ({
-                                  ...x,
-                                  models: setCustomProviderModelReasoning(x.models, i, reasoning),
-                                }));
-                              }}
-                              className="mt-0.5 h-4 w-4 shrink-0 cursor-pointer accent-[var(--settings-menu-text-selected)]"
-                            />
-                            <span className="flex flex-col gap-0.5 leading-snug">
-                              <span className="text-12 font-medium text-[var(--settings-section-sublabel)]">
-                                {t('settings.providers.custom.fields.modelSupportsReasoning')}
+                          {activeTab === 'pi' && (
+                            <label className="flex cursor-pointer items-start gap-2">
+                              <input
+                                type="checkbox"
+                                checked={m.reasoning === true}
+                                onChange={(event) => {
+                                  const reasoning = event.currentTarget.checked;
+                                  patch(activeTab, (x) => ({
+                                    ...x,
+                                    models: setCustomProviderModelReasoning(x.models, i, reasoning),
+                                  }));
+                                }}
+                                className="mt-0.5 h-4 w-4 shrink-0 cursor-pointer accent-[var(--settings-menu-text-selected)]"
+                              />
+                              <span className="flex flex-col gap-0.5 leading-snug">
+                                <span className="text-12 font-medium text-[var(--settings-section-sublabel)]">
+                                  {t('settings.providers.custom.fields.modelSupportsReasoning')}
+                                </span>
+                                <span className="text-11">
+                                  {t('settings.providers.custom.fields.modelSupportsReasoningHelp')}
+                                </span>
                               </span>
-                              <span className="text-11">
-                                {t('settings.providers.custom.fields.modelSupportsReasoningHelp')}
-                              </span>
-                            </span>
-                          </label>
-                          {m.reasoning === true && (
+                            </label>
+                          )}
+                          {activeTab === 'pi' && m.reasoning === true && (
                             <div className="ml-6 flex flex-col gap-1.5">
                               <span className="text-11 font-medium text-[var(--settings-section-sublabel)]">
                                 {t('settings.providers.custom.fields.modelReasoningEfforts')}

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -1374,7 +1374,7 @@
           "modelContextWindowPlaceholder": "Context (tokens)",
           "modelContextWindowTitle": "Context window in tokens. Leave empty for the conservative 200K default; affects the window display and compaction threshold.",
           "modelSupportsImageInput": "Supports image input",
-          "modelSupportsImageInputHelp": "Enable only when the model actually accepts visual input. Start a new Pi task after saving.",
+          "modelSupportsImageInputHelp": "Enable only when the model actually accepts visual input. Start a new session after saving.",
           "modelSupportsReasoning": "Supports reasoning",
           "modelSupportsReasoningHelp": "Enable only when the model accepts reasoning effort, then select every supported level. Changes take effect in the next Pi Agent session.",
           "modelReasoningEfforts": "Supported reasoning effort levels",

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -1374,7 +1374,7 @@
           "modelContextWindowPlaceholder": "コンテキスト(tokens)",
           "modelContextWindowTitle": "コンテキストウィンドウ(トークン数)。空欄の場合は保守的な既定値 200K。ウィンドウ表示と圧縮しきい値に影響します。",
           "modelSupportsImageInput": "画像入力に対応",
-          "modelSupportsImageInputHelp": "モデルが実際に画像入力へ対応している場合のみ有効にしてください。保存後、新しい Pi タスクで反映されます。",
+          "modelSupportsImageInputHelp": "モデルが実際に画像入力へ対応している場合のみ有効にしてください。保存後、新しいセッションで反映されます。",
           "modelSupportsReasoning": "推論に対応",
           "modelSupportsReasoningHelp": "モデルが推論強度を受け付ける場合のみ有効にし、実際に対応するすべてのレベルを選択してください。保存後、次の Pi Agent セッションから反映されます。",
           "modelReasoningEfforts": "対応する推論強度",

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -1374,7 +1374,7 @@
           "modelContextWindowPlaceholder": "컨텍스트(tokens)",
           "modelContextWindowTitle": "컨텍스트 윈도우(토큰 수). 비워 두면 보수적 기본값 200K가 적용되며, 윈도우 표시와 압축 임계값에 영향을 줍니다.",
           "modelSupportsImageInput": "이미지 입력 지원",
-          "modelSupportsImageInputHelp": "모델이 실제로 시각 입력을 지원할 때만 켜세요. 저장 후 새 Pi 작업부터 적용됩니다.",
+          "modelSupportsImageInputHelp": "모델이 실제로 시각 입력을 지원할 때만 켜세요. 저장 후 새 세션부터 적용됩니다.",
           "modelSupportsReasoning": "추론 지원",
           "modelSupportsReasoningHelp": "모델이 추론 강도를 허용할 때만 켜고 실제로 지원하는 모든 단계를 선택하세요. 저장 후 다음 Pi Agent 세션부터 적용됩니다.",
           "modelReasoningEfforts": "지원되는 추론 강도",

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -1374,7 +1374,7 @@
           "modelContextWindowPlaceholder": "上下文(tokens)",
           "modelContextWindowTitle": "上下文窗口(tokens)。留空按 200K 保守默认；影响窗口显示与压缩阈值。",
           "modelSupportsImageInput": "支持图片输入",
-          "modelSupportsImageInputHelp": "仅在该模型确实支持视觉输入时开启。保存后新建 Pi 任务生效。",
+          "modelSupportsImageInputHelp": "仅在该模型确实支持视觉输入时开启。保存后新建任务生效。",
           "modelSupportsReasoning": "支持推理",
           "modelSupportsReasoningHelp": "仅在该模型接受推理强度时开启，并勾选它实际支持的所有档位。保存后，下一个 Pi Agent 会话生效。",
           "modelReasoningEfforts": "支持的推理强度",

--- a/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
@@ -1374,7 +1374,7 @@
           "modelContextWindowPlaceholder": "上下文(tokens)",
           "modelContextWindowTitle": "上下文視窗(tokens)。留空按 200K 保守預設；影響視窗顯示與壓縮閾值。",
           "modelSupportsImageInput": "支援圖片輸入",
-          "modelSupportsImageInputHelp": "僅在該模型確實支援視覺輸入時開啟。儲存後新建 Pi 任務生效。",
+          "modelSupportsImageInputHelp": "僅在該模型確實支援視覺輸入時開啟。儲存後新建任務生效。",
           "modelSupportsReasoning": "支援推理",
           "modelSupportsReasoningHelp": "僅在該模型接受推理強度時開啟，並勾選它實際支援的所有檔位。儲存後，下一個 Pi Agent 會話生效。",
           "modelReasoningEfforts": "支援的推理強度",

--- a/apps/desktop/src/renderer/lib/__tests__/customProviderRuntimeFill.test.ts
+++ b/apps/desktop/src/renderer/lib/__tests__/customProviderRuntimeFill.test.ts
@@ -598,6 +598,43 @@ describe('custom provider runtime fill', () => {
     ]);
   });
 
+  it('preserves target Pi model protocol overrides during a models-only fill', () => {
+    const source = draft({
+      wireProtocol: 'openai-chat',
+      models: [{ id: 'model-a', name: 'Updated model' }],
+    });
+    const target = draft({
+      wireProtocol: 'openai-responses',
+      models: [{ id: 'model-a', name: 'Old model', piApi: 'openai-responses' }],
+    });
+
+    expect(
+      applyRuntimeFillFields(target, source, ['models'], {
+        sourceAgent: 'codex',
+        targetAgent: 'pi',
+      }),
+    ).toMatchObject({
+      wireProtocol: 'openai-responses',
+      models: [{ id: 'model-a', name: 'Updated model', piApi: 'openai-responses' }],
+    });
+  });
+
+  it('clears Pi model protocol overrides when explicitly filling its wire protocol', () => {
+    const source = draft({ wireProtocol: 'openai-chat' });
+    const target = draft({
+      wireProtocol: 'openai-responses',
+      models: [{ id: 'model-a', name: 'Model A', piApi: 'openai-responses' }],
+    });
+
+    const result = applyRuntimeFillFields(target, source, ['wireProtocol'], {
+      sourceAgent: 'codex',
+      targetAgent: 'pi',
+    });
+
+    expect(result.wireProtocol).toBe('openai-chat');
+    expect(result.models).toEqual([{ id: 'model-a', name: 'Model A' }]);
+  });
+
   it('copies image capability from Pi to an OpenAI Chat Codex target but drops reasoning', () => {
     const source = draft({
       models: [
@@ -736,6 +773,67 @@ describe('custom provider runtime fill', () => {
       wireProtocol: 'openai-chat',
       models: [{ id: 'model-a', name: 'Model A' }],
     });
+  });
+
+  it('keeps an endpoint switch coupled to stale image clearing when model names also differ', () => {
+    const source = draft({
+      baseUrl: 'https://api.example.test/v1',
+      wireProtocol: 'openai-chat',
+      models: [{ id: 'model-a', name: 'Source model' }],
+    });
+    const target = draft({
+      baseUrl: 'https://api.example.test/v1',
+      wireProtocol: 'openai-responses',
+      models: [{ id: 'model-a', name: 'Target model', supportsImageInput: true }],
+    });
+    const diffs = buildRuntimeFillDiffs(source, target, {
+      includeApiKey: true,
+      sourceAgent: 'pi',
+      targetAgent: 'codex',
+    });
+
+    expect(diffs.find((diff) => diff.field === 'models')).toMatchObject({
+      targetState: 'conflict',
+      implicitClear: true,
+    });
+    expect(runtimeFillFieldsForToggle('wireProtocol', diffs)).toEqual(
+      expect.arrayContaining(['wireProtocol', 'models']),
+    );
+    expect(runtimeFillFieldsForToggle('models', diffs)).toEqual(
+      expect.arrayContaining(['wireProtocol', 'models']),
+    );
+    expect(normalizeRuntimeFillSelection(['wireProtocol'], diffs)).toEqual(
+      expect.arrayContaining(['wireProtocol', 'models']),
+    );
+  });
+
+  it('keeps a Pi protocol switch coupled to override clearing when model names also differ', () => {
+    const source = draft({
+      baseUrl: 'https://api.example.test/v1',
+      wireProtocol: 'openai-chat',
+      models: [{ id: 'model-a', name: 'Source model' }],
+    });
+    const target = draft({
+      baseUrl: 'https://api.example.test/v1',
+      wireProtocol: 'openai-responses',
+      models: [{ id: 'model-a', name: 'Target model', piApi: 'openai-responses' }],
+    });
+    const diffs = buildRuntimeFillDiffs(source, target, {
+      includeApiKey: true,
+      sourceAgent: 'codex',
+      targetAgent: 'pi',
+    });
+
+    expect(diffs.find((diff) => diff.field === 'models')).toMatchObject({
+      targetState: 'conflict',
+      implicitClear: true,
+    });
+    expect(runtimeFillFieldsForToggle('wireProtocol', diffs)).toEqual(
+      expect.arrayContaining(['wireProtocol', 'models']),
+    );
+    expect(runtimeFillFieldsForToggle('models', diffs)).toEqual(
+      expect.arrayContaining(['wireProtocol', 'models']),
+    );
   });
 
   it('uses the same model and header counting semantics as save', () => {

--- a/apps/desktop/src/renderer/lib/__tests__/customProviderRuntimeFill.test.ts
+++ b/apps/desktop/src/renderer/lib/__tests__/customProviderRuntimeFill.test.ts
@@ -598,7 +598,7 @@ describe('custom provider runtime fill', () => {
     ]);
   });
 
-  it('ignores Pi-only capabilities when comparing or filling a non-Pi target', () => {
+  it('copies image capability from Pi to an OpenAI Chat Codex target but drops reasoning', () => {
     const source = draft({
       models: [
         {
@@ -617,13 +617,125 @@ describe('custom provider runtime fill', () => {
       targetAgent: 'codex',
     }).find((diff) => diff.field === 'models');
 
-    expect(modelDiff?.targetState).toBe('same');
+    expect(modelDiff?.targetState).toBe('conflict');
     expect(
       applyRuntimeFillFields(target, source, ['models'], {
         sourceAgent: 'pi',
         targetAgent: 'codex',
       }).models,
-    ).toEqual([{ id: 'model-a', name: 'Model A' }]);
+    ).toEqual([{ id: 'model-a', name: 'Model A', supportsImageInput: true }]);
+  });
+
+  it('copies image capability from OpenAI Chat Codex to Pi while preserving Pi reasoning', () => {
+    const source = draft({
+      wireProtocol: 'openai-chat',
+      models: [{ id: 'model-a', name: 'Model A', supportsImageInput: true }],
+    });
+    const target = draft({
+      models: [
+        {
+          id: 'model-a',
+          name: 'Old name',
+          reasoning: true,
+          reasoningEfforts: ['low', 'high'],
+        },
+      ],
+    });
+
+    expect(
+      applyRuntimeFillFields(target, source, ['models'], {
+        sourceAgent: 'codex',
+        targetAgent: 'pi',
+      }).models,
+    ).toEqual([
+      {
+        id: 'model-a',
+        name: 'Model A',
+        supportsImageInput: true,
+        reasoning: true,
+        reasoningEfforts: ['low', 'high'],
+      },
+    ]);
+  });
+
+  it('copies image capability when the endpoint fill makes Codex use OpenAI Chat', () => {
+    const source = draft({
+      baseUrl: 'https://api.example.test/v1',
+      models: [{ id: 'model-a', name: 'Model A', supportsImageInput: true }],
+    });
+    const target = draft({
+      baseUrl: 'https://api.example.test/v1',
+      wireProtocol: 'openai-responses',
+      models: [{ id: 'model-a', name: 'Model A' }],
+    });
+    const modelDiff = buildRuntimeFillDiffs(source, target, {
+      includeApiKey: true,
+      sourceAgent: 'pi',
+      targetAgent: 'codex',
+    }).find((diff) => diff.field === 'models');
+
+    expect(modelDiff?.targetState).toBe('conflict');
+    expect(runtimeFillFieldsForToggle('models', buildRuntimeFillDiffs(source, target, {
+      includeApiKey: true,
+      sourceAgent: 'pi',
+      targetAgent: 'codex',
+    }))).toEqual(expect.arrayContaining(['wireProtocol', 'models']));
+    expect(runtimeFillFieldsForToggle('wireProtocol', buildRuntimeFillDiffs(source, target, {
+      includeApiKey: true,
+      sourceAgent: 'pi',
+      targetAgent: 'codex',
+    }))).toEqual(expect.arrayContaining(['wireProtocol', 'models']));
+    expect(
+      applyRuntimeFillFields(target, source, ['models'], {
+        sourceAgent: 'pi',
+        targetAgent: 'codex',
+      }),
+    ).toMatchObject({
+      wireProtocol: 'openai-responses',
+      models: [{ id: 'model-a', name: 'Model A' }],
+    });
+    expect(
+      applyRuntimeFillFields(target, source, ['wireProtocol', 'models'], {
+        sourceAgent: 'pi',
+        targetAgent: 'codex',
+      }),
+    ).toMatchObject({
+      wireProtocol: 'openai-chat',
+      models: [{ id: 'model-a', name: 'Model A', supportsImageInput: true }],
+    });
+  });
+
+  it('clears a stale image opt-in when the endpoint and models adopt a false source', () => {
+    const source = draft({
+      baseUrl: 'https://api.example.test/v1',
+      models: [{ id: 'model-a', name: 'Model A' }],
+    });
+    const target = draft({
+      baseUrl: 'https://api.example.test/v1',
+      wireProtocol: 'openai-responses',
+      models: [{ id: 'model-a', name: 'Model A', supportsImageInput: true }],
+    });
+    const modelDiff = buildRuntimeFillDiffs(source, target, {
+      includeApiKey: true,
+      sourceAgent: 'pi',
+      targetAgent: 'codex',
+    }).find((diff) => diff.field === 'models');
+
+    expect(modelDiff?.targetState).toBe('conflict');
+    expect(runtimeFillFieldsForToggle('models', buildRuntimeFillDiffs(source, target, {
+      includeApiKey: true,
+      sourceAgent: 'pi',
+      targetAgent: 'codex',
+    }))).toEqual(expect.arrayContaining(['wireProtocol', 'models']));
+    expect(
+      applyRuntimeFillFields(target, source, ['wireProtocol', 'models'], {
+        sourceAgent: 'pi',
+        targetAgent: 'codex',
+      }),
+    ).toMatchObject({
+      wireProtocol: 'openai-chat',
+      models: [{ id: 'model-a', name: 'Model A' }],
+    });
   });
 
   it('uses the same model and header counting semantics as save', () => {

--- a/apps/desktop/src/renderer/lib/__tests__/customProviders.test.ts
+++ b/apps/desktop/src/renderer/lib/__tests__/customProviders.test.ts
@@ -16,6 +16,7 @@ import {
   setCustomProviderModelReasoning,
   setCustomProviderModelReasoningEffort,
   setCustomProviderModelSupportsImageInput,
+  shouldShowCustomProviderModelImageInput,
   updateCustomProvider,
 } from '../customProviders';
 import type {
@@ -286,6 +287,19 @@ describe('setCustomProviderModelSupportsImageInput', () => {
   });
 });
 
+describe('shouldShowCustomProviderModelImageInput', () => {
+  it.each([
+    ['pi', 'openai-chat', true],
+    ['pi', 'openai-responses', true],
+    ['codex', 'openai-chat', true],
+    ['codex', 'openai-responses', false],
+    ['codex', 'anthropic-messages', false],
+    ['claude-code', 'anthropic-messages', false],
+  ] as const)('returns %s / %s => %s', (agent, wireProtocol, expected) => {
+    expect(shouldShowCustomProviderModelImageInput(agent, wireProtocol)).toBe(expected);
+  });
+});
+
 describe('Pi custom-provider reasoning controls', () => {
   it('enables conservative default levels and removes the capability when disabled', () => {
     const models = [{ id: 'reasoner', name: 'Reasoner' }];
@@ -377,7 +391,7 @@ describe('customProviderModelConfigFromCatalogModel', () => {
     });
   });
 
-  it('preserves an explicit Pi image-input capability through the edit round trip', () => {
+  it('preserves an explicit image-input capability through the edit round trip', () => {
     expect(
       customProviderModelConfigFromCatalogModel({
         id: 'vision-model',
@@ -504,6 +518,7 @@ describe('providerViewToCustomProviderConfig', () => {
             contextWindow: 200_000,
             efforts: [],
             defaultEffort: null,
+            supportsImageInput: true,
           },
         ],
       },
@@ -520,7 +535,7 @@ describe('providerViewToCustomProviderConfig', () => {
           requestPath: '/tenant/acme/infer?stream=1',
           wireProtocol: 'openai-chat',
           modelsUrl: 'http://127.0.0.1:4000/v1/models',
-          models: [{ id: 'local-model', name: 'Local Model' }],
+          models: [{ id: 'local-model', name: 'Local Model', supportsImageInput: true }],
         },
       },
     });

--- a/apps/desktop/src/renderer/lib/customProviderRuntimeFill.ts
+++ b/apps/desktop/src/renderer/lib/customProviderRuntimeFill.ts
@@ -4,6 +4,7 @@ import type {
   ProviderWireProtocol,
 } from '@cindy/model-providers';
 import { savedCustomProviderModelShape } from '@/../shared/piRuntimeInitialization';
+import { clearCustomProviderModelPiApiOverrides } from './customProviders';
 
 export type RuntimeFillAgent = Extract<AgentKind, 'claude-code' | 'codex' | 'pi'>;
 export interface RuntimeFillHeaderRow {
@@ -160,6 +161,7 @@ function modelsForTarget(
   targetAgent: RuntimeFillAgent,
   sourceWire: ProviderWireProtocol,
   targetWire: ProviderWireProtocol,
+  preserveTargetPiApi: boolean,
 ) {
   const targetById = new Map(validModels(targetModels).map((model) => [model.id, model]));
   const sourceCarriesImageInput = runtimeConsumesModelImageInput(sourceAgent, sourceWire);
@@ -173,6 +175,9 @@ function modelsForTarget(
     const reasoningSource = sourceAgent === 'pi' ? sourceModel : existing;
     return {
       ...portable,
+      ...(preserveTargetPiApi && targetAgent === 'pi' && existing?.piApi
+        ? { piApi: existing.piApi }
+        : {}),
       ...(targetConsumesImageInput && supportsImageInput ? { supportsImageInput: true } : {}),
       ...(targetAgent === 'pi' &&
       reasoningSource?.reasoning === true &&
@@ -354,6 +359,7 @@ export function buildRuntimeFillDiffs(
     options.targetAgent,
     wire,
     wire,
+    false,
   );
   const targetModelsForProspectiveWire = modelsForTarget(
     target.models,
@@ -362,6 +368,7 @@ export function buildRuntimeFillDiffs(
     options.targetAgent,
     wire,
     wire,
+    false,
   );
   const sourceModelsForCurrentWire = modelsForTarget(
     source.models,
@@ -370,6 +377,7 @@ export function buildRuntimeFillDiffs(
     options.targetAgent,
     wire,
     targetWire,
+    true,
   );
   const targetModelsForCurrentWire = modelsForTarget(
     target.models,
@@ -378,12 +386,14 @@ export function buildRuntimeFillDiffs(
     options.targetAgent,
     targetWire,
     targetWire,
+    true,
   );
   const modelsDependOnEndpoint =
     wire !== targetWire &&
-    (JSON.stringify(sourceModelsForProspectiveWire) ===
-      JSON.stringify(targetModelsForProspectiveWire)) !==
-      (JSON.stringify(sourceModelsForCurrentWire) === JSON.stringify(targetModelsForCurrentWire));
+    (JSON.stringify(sourceModelsForProspectiveWire) !==
+      JSON.stringify(sourceModelsForCurrentWire) ||
+      JSON.stringify(targetModelsForProspectiveWire) !==
+        JSON.stringify(targetModelsForCurrentWire));
 
   return RUNTIME_FILL_FIELD_ORDER.filter((field) => {
     if (!options.includeApiKey && field === 'apiKey' && !implicitApiKeyClear) return false;
@@ -638,8 +648,11 @@ export function applyRuntimeFillFields(
         options.targetAgent,
         sourceWire,
         targetWire,
+        !copyWireProtocol,
       )
-    : target.models;
+    : copyWireProtocol && options.targetAgent === 'pi'
+      ? clearCustomProviderModelPiApiOverrides(target.models)
+      : target.models;
   const copyHeaders =
     selected.has('headers') &&
     !sourceHasHiddenHeaders &&

--- a/apps/desktop/src/renderer/lib/customProviderRuntimeFill.ts
+++ b/apps/desktop/src/renderer/lib/customProviderRuntimeFill.ts
@@ -29,7 +29,7 @@ export interface RuntimeFillFieldDiff {
   field: RuntimeFillField;
   targetState: RuntimeFillTargetState;
   incompatibilityReason?: RuntimeFillIncompatibilityReason;
-  /** This field must be cleared together with the endpoint bundle. */
+  /** This field must be selected or deselected together with the endpoint bundle. */
   implicitClear?: boolean;
 }
 
@@ -141,33 +141,47 @@ function canonicalHeaders(headers: RuntimeFillHeaderRow[]) {
   return [...byName].map(([name, value]) => ({ name, value }));
 }
 
+function runtimeConsumesModelImageInput(
+  agent: RuntimeFillAgent,
+  wire: ProviderWireProtocol,
+): boolean {
+  return agent === 'pi' || (agent === 'codex' && wire === 'openai-chat');
+}
+
 /**
  * Project source models into the exact shape that the target runtime will save.
- * Pi-only capability metadata belongs to the Pi runtime, so portable fills preserve
- * it for matching target model ids instead of silently deleting it.
+ * Image capability is portable between Pi and OpenAI Chat Codex. Reasoning stays
+ * Pi-only, and metadata unsupported by the source is preserved by matching id.
  */
 function modelsForTarget(
   sourceModels: ProviderRuntimeModelConfig[],
   targetModels: ProviderRuntimeModelConfig[],
   sourceAgent: RuntimeFillAgent,
   targetAgent: RuntimeFillAgent,
+  sourceWire: ProviderWireProtocol,
+  targetWire: ProviderWireProtocol,
 ) {
   const targetById = new Map(validModels(targetModels).map((model) => [model.id, model]));
+  const sourceCarriesImageInput = runtimeConsumesModelImageInput(sourceAgent, sourceWire);
+  const targetConsumesImageInput = runtimeConsumesModelImageInput(targetAgent, targetWire);
   return validModels(sourceModels).map((sourceModel) => {
-    if (targetAgent !== 'pi') return savedCustomProviderModelShape(sourceModel, false);
-    if (sourceAgent === 'pi') return savedCustomProviderModelShape(sourceModel, true);
-
     const portable = savedCustomProviderModelShape(sourceModel, false);
     const existing = targetById.get(portable.id);
+    const supportsImageInput = sourceCarriesImageInput
+      ? sourceModel.supportsImageInput === true
+      : existing?.supportsImageInput === true;
+    const reasoningSource = sourceAgent === 'pi' ? sourceModel : existing;
     return {
       ...portable,
-      ...(existing?.supportsImageInput === true ? { supportsImageInput: true } : {}),
-      ...(existing?.reasoning === true && existing.reasoningEfforts?.length
+      ...(targetConsumesImageInput && supportsImageInput ? { supportsImageInput: true } : {}),
+      ...(targetAgent === 'pi' &&
+      reasoningSource?.reasoning === true &&
+      reasoningSource.reasoningEfforts?.length
         ? {
             reasoning: true,
-            reasoningEfforts: [...existing.reasoningEfforts],
-            ...(existing.reasoningDefaultEffort
-              ? { reasoningDefaultEffort: existing.reasoningDefaultEffort }
+            reasoningEfforts: [...reasoningSource.reasoningEfforts],
+            ...(reasoningSource.reasoningDefaultEffort
+              ? { reasoningDefaultEffort: reasoningSource.reasoningDefaultEffort }
               : {}),
           }
         : {}),
@@ -307,6 +321,7 @@ export function buildRuntimeFillDiffs(
   options: { includeApiKey: boolean; sourceAgent: RuntimeFillAgent; targetAgent: RuntimeFillAgent },
 ): RuntimeFillFieldDiff[] {
   const wire = effectiveWire(options.sourceAgent, source.wireProtocol);
+  const targetWire = effectiveWire(options.targetAgent, target.wireProtocol);
   const endpointSupported = endpointBundleSupported(
     source,
     options.sourceAgent,
@@ -332,6 +347,43 @@ export function buildRuntimeFillDiffs(
     endpointChangesUrl &&
     target.apiKey.trim().length > 0 &&
     true;
+  const sourceModelsForProspectiveWire = modelsForTarget(
+    source.models,
+    target.models,
+    options.sourceAgent,
+    options.targetAgent,
+    wire,
+    wire,
+  );
+  const targetModelsForProspectiveWire = modelsForTarget(
+    target.models,
+    target.models,
+    options.targetAgent,
+    options.targetAgent,
+    wire,
+    wire,
+  );
+  const sourceModelsForCurrentWire = modelsForTarget(
+    source.models,
+    target.models,
+    options.sourceAgent,
+    options.targetAgent,
+    wire,
+    targetWire,
+  );
+  const targetModelsForCurrentWire = modelsForTarget(
+    target.models,
+    target.models,
+    options.targetAgent,
+    options.targetAgent,
+    targetWire,
+    targetWire,
+  );
+  const modelsDependOnEndpoint =
+    wire !== targetWire &&
+    (JSON.stringify(sourceModelsForProspectiveWire) ===
+      JSON.stringify(targetModelsForProspectiveWire)) !==
+      (JSON.stringify(sourceModelsForCurrentWire) === JSON.stringify(targetModelsForCurrentWire));
 
   return RUNTIME_FILL_FIELD_ORDER.filter((field) => {
     if (!options.includeApiKey && field === 'apiKey' && !implicitApiKeyClear) return false;
@@ -399,11 +451,11 @@ export function buildRuntimeFillDiffs(
 
     const sourceValue =
       field === 'models'
-        ? modelsForTarget(source.models, target.models, options.sourceAgent, options.targetAgent)
+        ? sourceModelsForProspectiveWire
         : comparableValue(field, source, options.sourceAgent);
     const targetValue =
       field === 'models'
-        ? modelsForTarget(target.models, target.models, options.targetAgent, options.targetAgent)
+        ? targetModelsForProspectiveWire
         : comparableValue(field, target, options.targetAgent);
     const same = JSON.stringify(sourceValue) === JSON.stringify(targetValue);
     const hiddenTargetHeadersOnly =
@@ -413,7 +465,8 @@ export function buildRuntimeFillDiffs(
     const shouldConfirmImplicitClear =
       (field === 'headers' && implicitHeaderClear) ||
       (field === 'modelsUrl' && (implicitModelsUrlClear || modelsUrlEndpointChange)) ||
-      (field === 'apiKey' && implicitApiKeyClear);
+      (field === 'apiKey' && implicitApiKeyClear) ||
+      (field === 'models' && modelsDependOnEndpoint);
     return {
       field,
       targetState: same && !hiddenTargetHeadersOnly
@@ -574,8 +627,18 @@ export function applyRuntimeFillFields(
     copyEndpoint &&
     target.apiKey.trim().length > 0 &&
     !selected.has('apiKey');
+  const targetWire = copyWireProtocol
+    ? sourceWire
+    : effectiveWire(options.targetAgent, target.wireProtocol);
   const models = selected.has('models')
-    ? modelsForTarget(source.models, target.models, options.sourceAgent, options.targetAgent)
+    ? modelsForTarget(
+        source.models,
+        target.models,
+        options.sourceAgent,
+        options.targetAgent,
+        sourceWire,
+        targetWire,
+      )
     : target.models;
   const copyHeaders =
     selected.has('headers') &&

--- a/apps/desktop/src/renderer/lib/customProviders.ts
+++ b/apps/desktop/src/renderer/lib/customProviders.ts
@@ -113,6 +113,14 @@ export function setCustomProviderModelSupportsImageInput(
   });
 }
 
+/** 图片开关只暴露给确实会消费该元数据的 runtime/protocol。 */
+export function shouldShowCustomProviderModelImageInput(
+  agent: AgentKind,
+  wireProtocol: ProviderWireProtocol,
+): boolean {
+  return agent === 'pi' || (agent === 'codex' && wireProtocol === 'openai-chat');
+}
+
 export function setCustomProviderModelReasoning(
   models: readonly ProviderRuntimeModelConfig[],
   targetIndex: number,

--- a/packages/model-providers/src/__tests__/user-provider.test.ts
+++ b/packages/model-providers/src/__tests__/user-provider.test.ts
@@ -448,6 +448,26 @@ describe('buildUserProvider (per-runtime)', () => {
     expect(p.models.pi?.[0]).toMatchObject({ efforts: [], defaultEffort: null });
   });
 
+  it('exports an explicit Codex image-input capability into the catalog model', () => {
+    const p = buildUserProvider({
+      id: 'vision-chat',
+      name: 'Vision Chat',
+      runtimes: {
+        codex: {
+          baseUrl: 'https://example.test/v1',
+          wireProtocol: 'openai-chat',
+          models: [
+            { id: 'vision', name: 'Vision', supportsImageInput: true },
+            { id: 'text', name: 'Text' },
+          ],
+        },
+      },
+    });
+
+    expect(p.models.codex?.[0]?.supportsImageInput).toBe(true);
+    expect(p.models.codex?.[1]).not.toHaveProperty('supportsImageInput');
+  });
+
   it('exports only the explicitly supported effort levels for a Pi reasoning model', () => {
     const p = buildUserProvider({
       id: 'reasoning-pi',

--- a/packages/model-providers/src/types.ts
+++ b/packages/model-providers/src/types.ts
@@ -381,7 +381,7 @@ export interface CatalogModel {
    */
   newSessionDefault?: AgentKind[];
   /**
-   * 该来源下的模型是否已由用户确认支持图片输入。目前只供 Pi 自定义 provider 使用；
+   * 该来源下的模型是否已由用户确认支持图片输入。供支持该能力的自定义 runtime 使用；
    * 缺省按 false 处理，避免把纯文本端点误报成视觉模型。它是 per-provider 能力，不参与
    * `modelSignature` 的同 id 跨供应商一致性校验。
    */
@@ -497,7 +497,7 @@ export interface ProviderRuntimeModelConfig {
   contextWindow?: number;
   /** 模型未被用户显式开关时的可见性；缺省保持历史行为（默认可见）。 */
   defaultEnabled?: boolean;
-  /** Pi 自定义模型是否支持原生图片输入；缺省保守视为不支持。 */
+  /** 自定义模型是否支持原生图片输入；缺省保守视为不支持。 */
   supportsImageInput?: boolean;
   /** Pi 自定义模型是否支持 reasoning；缺省 / false 均按不支持处理。 */
   reasoning?: boolean;


### PR DESCRIPTION
## 这次改了什么

### 摘要

让自定义供应商的 Codex + OpenAI Chat runtime 可以按模型显式声明图片输入能力。只有当前用户供应商、当前模型的 `supportsImageInput` 明确为 `true` 时，Responses → Chat bridge 才启用标准 `image_url`；未声明、声明为 `false`、Codex Responses、Claude 与未知协议继续 fail-closed，官方供应商白名单不变。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：Closes #2371
- 当前基线：`main@52ee98671232620ebc47a8ce700c03c6d396ecdc`
- 当前 head：`6ad6581c5c4055dab7c635972f300b21fefbcb12`
- 最终候选 tree：`7f843953328e9a799c1acf1501ea87f14450e7d1`
- 变更路径：16 个；不含 dependency input、DB schema、migration 或 localDb 路径。
- 本 PR 包含：
  - Codex + OpenAI Chat 的模型图片能力配置与 route capability 合并；
  - catalog lookup 按 raw exact → 去 `[1m]` → strip-prefix exact → strip-prefix + 去 `[1m]` 的候选优先级查找，避免 catalog 数组顺序覆盖精确模型 ID；
  - Pi ↔ Codex OpenAI Chat runtime fill 的图片能力 copy/clear；
  - endpoint 与依赖协议的 models 差异双向耦合；
  - models-only fill 保留目标 Pi 同 ID 的 `piApi`，显式复制 Pi protocol 时清除旧 override；
  - 五种 locale 文案与回归测试。
- 明确不包含：全局放开图片输入、修改 bridge translator、修改系统提示词、协议 schema 或数据库。
- Breaking change：无。

### UI 变化

- 引用的设计规范：`DESIGN.md §4 Component Stylings / Inputs & Forms`、`§10 Theme System & Token Reference / Light & Dark Dual-Mode Delivery Gate`、`§11 Voice & Content`。本次复用现有模型配置 checkbox row 和语义 token，没有新增布局、颜色或动效；五种 locale 使用现有术语。
- 截图 / 录屏：未附。仅按 runtime 条件展示既有控件；未执行 Light / Dark 实机目检，见“未执行的验证”。

## 审查修复

- 精确 catalog ID 始终优先于 normalized fallback；相同模型多配置、provider/agent 隔离、unknown/false 均 fail-closed。
- Pi 与 Codex OpenAI Chat 之间可复制或显式清除 `supportsImageInput`；reasoning 与 `reasoningDefaultEffort` 仍严格限于 Pi。
- endpoint 切换导致的模型能力或 Pi override 副作用，直接比较 source/target 在 current 与 prospective wire 下的投影，不再被模型名称等独立冲突掩盖。
- endpoint/models 的勾选和取消保持双向耦合；普通 models-only fill 仍可独立，且不会向 Codex Responses 写入可生效的图片能力。
- 最终独立复审：P0=0 / P1=0。

## 怎么验证的

### TDD 与定向回归

```text
pnpm --filter desktop exec vitest run src/renderer/lib/__tests__/customProviderRuntimeFill.test.ts -t "keeps an endpoint switch|keeps a Pi protocol switch"
RED：exit 1，2 个测试均因缺少 implicitClear 按预期失败
GREEN：exit 0，2 passed

pnpm --filter desktop exec vitest run src/renderer/lib/__tests__/customProviderRuntimeFill.test.ts src/renderer/lib/__tests__/customProviders.test.ts
结果：exit 0，66 passed
```

### 最终 Windows 冻结门禁

环境：Windows NT 10.0.26100.0，干净 detached checkout `D:\cindy-final-gate`，candidate tree `7f843953328e9a799c1acf1501ea87f14450e7d1`。

```text
pnpm install --frozen-lockfile
结果：exit 0，204276 ms，pnpm 10.33.2

pnpm --filter desktop run --if-present typecheck
结果：exit 0，224409 ms

PATH=C:\Users\ASUS\AppData\Local\Programs\Python\Python310;%PATH%
python -c "import sys; assert sys.version_info >= (3,10); print(sys.executable,sys.version)"
pnpm test:unit -- --workspace-concurrency=1
结果：Python 3.10.11 exit 0；root unit exit 0，1634759 ms
      runner self-tests 391 passed / 8 skipped / 0 failed；
      27 个可运行 workspace 全部 PASS
```

- 测试前后 source/gate tree 均为 `7f843953…`，status 干净；16-path manifest SHA256：`3DDD6893AD0FA1490B4AA7B1EB22EAC10F2B603396850D05D04325EBD3D6C7CF`。
- 44 项 dependency manifest 在 frozen install 和 root gate 前后保持 `8A06FC591F9BE3559C25F47CFD21A6A10933B10E06123D1DFBEA1C336BDC3FD9`；`@cindy/maker-pi-manager` 明确解析到 D 盘 checkout。
- `pnpm check:dco`：exit 0，`52ee9867..6ad6581c` 的 4 个提交全部 signed off。
- `git diff --check 52ee9867..6ad6581c`：exit 0。
- DB/migration 专项门禁：不适用；16 个变更路径不含 DB、migration 或 SQL。
- 完整日志：`D:\cindy-gate-logs\pr-2698-7f843953\`（`frozen-install.log`、`desktop-typecheck.log`、`root-test-unit.log` 及对应 meta）。

安装阶段的 Pi 外部 runtime binary 下载因吞吐过低被 best-effort 跳过，但命令按仓库契约 exit 0；这不改变 tracked tree，且 workspace `maker-pi-manager` 已正确解析并在 root gate 中通过。

### 未执行的验证

- 未运行 `pnpm test:all`（最终 merge gate 使用仓库要求的完整 root unit tier）。
- 未执行打包安装、真实第三方多模态 endpoint smoke test。
- 未执行 Light / Dark 实机目检；实现复用既有 themed checkbox 样式。

## 风险

### 风险分类

- [x] 协议兼容

### 影响与回滚

- 影响范围：仅用户供应商中明确启用图片能力的 Codex + OpenAI Chat 模型改变出站 Chat payload；旧配置、未声明/false、Responses/unknown、Claude 与官方白名单行为不变。
- 用户若错误声明能力，上游可能返回其原生 4xx；关闭该模型的图片输入开关即可恢复 fail-closed。
- runtime fill 会在协议切换可能改变图片能力或 Pi override 时把 endpoint/models 作为同一确认单元，避免静默恢复旧能力。
- 无 schema/migration，回滚无需数据迁移。

### 提交前检查

- [x] 已 review 完整 diff，最终独立复审 P0=0 / P1=0
- [x] 每个 commit 都带 DCO 签名
- [x] UI 改动已说明
- [x] 未提交凭证、令牌或授权文件
- [x] 已确认最终 Windows typecheck 与 root unit 门禁
