### PR TITLE
fix(desktop): recover Pi image rejection queues

### DIFF
--- a/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
@@ -3713,6 +3713,45 @@ describe('AgentInputCoordinator send transaction', () => {
     );
   });
 
+  it('dispatches new text after a persisted Pi image capability rejection', async () => {
+    const h = createHarness();
+    const sid = 'persisted-pi-image-capability-rejection';
+    const image = makeItem('q-image', 'describe the screenshot');
+    const next = makeItem('q-next', 'continue with text');
+    h.setAgentKind('pi');
+    h.sendToAgent.mockImplementationOnce(
+      async (sessionId, _message, _createOpts, sendOpts) => {
+        await persistQueuedUserMessage(sessionId, sendOpts);
+        throw Object.assign(
+          new Error('[PI_IMAGE_INPUT_UNSUPPORTED] image input disabled'),
+          { code: 'PI_IMAGE_INPUT_UNSUPPORTED' },
+        );
+      },
+    );
+
+    h.coordinator.enqueue(sid, image);
+    await flush();
+
+    let projection = latestProjection(h.projections);
+    expect(projection.pendingQueue).toEqual([]);
+    expect(projection.recovery).toEqual({ kind: 'active-turn', item: image });
+    expect(projection.error).toBe('[PI_IMAGE_INPUT_UNSUPPORTED] image input disabled');
+
+    h.coordinator.enqueue(sid, next);
+    await flush();
+
+    projection = latestProjection(h.projections);
+    expect(h.sendToAgent).toHaveBeenCalledTimes(2);
+    expect(h.sendToAgent.mock.calls[1]?.[1]).toEqual({
+      type: 'user',
+      content: 'continue with text',
+    });
+    expect(projection.pendingQueue).toEqual([]);
+    expect(projection.recovery).toBeNull();
+    expect(projection.error).toBeNull();
+    expect(projection.queueAbortPending).toBe(false);
+  });
+
   it('recovers a persisted turn when terminal error arrives before send resolves', async () => {
     const h = createHarness();
     const sid = 'terminal-before-send-resolve';

--- a/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
+++ b/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
@@ -3427,6 +3427,7 @@ export class AgentInputCoordinator {
       }
       latest.error = errorMessage(err);
       latest.stickyError = null;
+      const piImageCapabilityRejected = isPiImageInputUnsupportedError(err);
       // 同 handleSendNotDispatched:调度来源的 prompt 不留可被人手动 Retry 的 recovery
       // (review #944 第九轮 P1;判据内建在 setActiveTurnRecovery)。
       const schedulerOrigin = this.setActiveTurnRecovery(latest, head) === 'dropped-scheduler';
@@ -3436,6 +3437,10 @@ export class AgentInputCoordinator {
         // (用户 Retry / clearError)—— 现在没有了,不主动清就等于把会话永久钉在"有活跃
         // turn":之后所有用户与调度消息全部积压到 coordinator 被重置
         // (review #944 第十轮 P1)。
+        latest.activeTurn = null;
+      } else if (piImageCapabilityRejected) {
+        // Pi 图片能力拒绝发生在 vendor RPC 之前，不会再有 terminal event 来释放 activeTurn；
+        // 已持久化的用户行仍保留 active-turn recovery，供用户切换到视觉模型后重试。
         latest.activeTurn = null;
       }
       this.notifyRejectedUserTurn(sessionId, head);


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Pi 在用户图片消息已经落库、但因 `PI_IMAGE_INPUT_UNSUPPORTED` 在 vendor dispatch 前被本地预检拒绝后留下 stale `activeTurn` 的问题。该错误仍保留现有 active-turn recovery 与错误呈现；当用户随后发送新消息并放弃恢复时，队列边界已释放，可以正常派发。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：Closes #2631
- 本 PR 包含：coordinator persisted-catch 中对 typed Pi capability rejection 的窄释放，以及覆盖真实 onPersisting → onPersisted → preflight throw → 下一条文本派发的回归测试。
- 明确不包含：图片降级、自动重发、修改 steer 路径、普通 provider 4xx、abort/close 行为、系统提示词或协议。
- 用户可见变化：遇到不支持图片的 Pi 模型后，用户仍会看到原错误，但随后发送纯文本不会再永久卡在队列里。
- 是否存在 breaking change：无。

### UI 变化

- 引用的设计规范：不涉及；未修改 UI、布局、样式或文案。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
结果：270 passed

pnpm --filter desktop run --if-present typecheck
结果：通过

PATH=<isolated Python 3>;$PATH pnpm test:unit
结果：通过（774.1s）

pnpm check:dco -- 3f772bec..HEAD
git diff --check
结果：通过
```

### 手工验证

不涉及；回归测试使用真实持久化回调顺序并断言第二条消息仅派发一次、pending queue 清空、recovery/error/queueAbortPending 状态收敛。

### 未执行的验证

- 未运行 `pnpm test:all`、Desktop 打包或真实 Pi endpoint smoke test；改动范围由全量单元测试、Desktop typecheck 和 coordinator 整文件测试覆盖。

## 风险

### 风险分类

- [x] 其他：Desktop turn/queue 状态机

### 影响与回滚

- 影响范围：仅“用户行已经持久化 + typed `PI_IMAGE_INPUT_UNSUPPORTED` + 尚未 vendor dispatch”的 catch 分支。普通未知投递错误仍保留 activeTurn，避免不确定状态下双发；steer、abort、session close 和 provider 400 路径不变。
- 回滚 / 降级方式：回滚该窄 predicate 释放即可恢复旧行为；不涉及 schema、migration 或用户数据重写。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
