### PR TITLE
fix(desktop): 恢复 stale cua-driver session

### DIFF
--- a/apps/desktop/src/main/mcp-integrations/__tests__/computer.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/__tests__/computer.test.ts
@@ -1363,6 +1363,51 @@ describe('computer mcp integration', () => {
     );
   });
 
+  it('rotates and retries when cua-driver rejects a call because the named session has ended', async () => {
+    mcpCallToolMock.mockImplementation((call: { name: string; arguments: Record<string, unknown> }) => {
+      if (call.name === 'end_session') {
+        return { content: [{ type: 'text', text: '{"ok":true}' }] };
+      }
+      if (call.name === 'list_windows') {
+        const generation = driverSessionGeneration(
+          String(call.arguments.session),
+          'session-ended-rejected',
+        );
+        if (generation === 0) {
+          return {
+            isError: true,
+            content: [{
+              type: 'text',
+              text: `session '${String(call.arguments.session)}' has ended; tool call '${call.name}' was rejected`,
+            }],
+          };
+        }
+        return {
+          content: [{ type: 'text', text: '{"ok":true,"windows":[{"window_id":9}]}' }],
+        };
+      }
+      throw new Error(`unexpected call ${call.name}`);
+    });
+
+    await expect(callComputerDriverTool('list_windows', {
+      session: 'caller-supplied',
+    }, { sessionId: 'session-ended-rejected' })).resolves.toEqual({
+      ok: true,
+      windows: [{ window_id: 9 }],
+    });
+
+    expect(mcpConnectMock).toHaveBeenCalledTimes(2);
+    expect(mcpCloseMock).toHaveBeenCalledTimes(1);
+    const listCalls = mcpCallToolMock.mock.calls
+      .map((call) => call[0])
+      .filter((call) => call?.name === 'list_windows');
+    expectDriverSessionGenerations(
+      listCalls.map((call) => (call?.arguments as { session: string }).session),
+      'session-ended-rejected',
+      [0, 1],
+    );
+  });
+
   it('rotates the driver session and retries once when cua-driver reports not connected', async () => {
     mcpCallToolMock
       .mockRejectedValueOnce(new Error('Not connected'))

--- a/apps/desktop/src/main/mcp-integrations/computer.ts
+++ b/apps/desktop/src/main/mcp-integrations/computer.ts
@@ -1987,12 +1987,16 @@ function splitTypeTextChunks(text: string): string[] {
  * `callCuaMcpTool` 和 `shouldRetryWithFreshCuaSession` 使用，避免某种
  * plain text 结果被提升成错误后却没有进入一次性重试分支。
  */
-const STALE_CUA_SESSION_MARKER_RE = /session ended; tool call ignored|not connected/i;
+const STALE_CUA_SESSION_MARKER_RE =
+  /session(?:\s+['"`][^'"`\r\n]+['"`])?\s+(?:has\s+)?ended\b|not connected/i;
 
 function shouldCleanupCuaMcpSessionAfterError(err: unknown): boolean {
   const message = err instanceof Error ? err.message : String(err);
   if (/timed out after/.test(message)) return true;
-  return /transport (?:closed|error)|read ECONNRESET|write EPIPE|connection closed|stream closed|session ended|not connected/i.test(message);
+  return (
+    STALE_CUA_SESSION_MARKER_RE.test(message) ||
+    /transport (?:closed|error)|read ECONNRESET|write EPIPE|connection closed|stream closed/i.test(message)
+  );
 }
 
 function shouldRetryWithFreshCuaSession(name: ComputerMcpToolName, err: unknown): boolean {


### PR DESCRIPTION
## 这次改了什么

### 摘要

cua-driver 在 session 失效后返回的实际错误文案是 `session '<id>' has ended; tool call 'list_windows' was rejected`，此前 Cindy wrapper 没有识别这类带 session id、且包含 `was rejected` 的 stale session 错误，导致旧 session 未清理、generation 一直停留在 `-0`，后续 Computer Use 调用持续失败。

本 PR 扩展 stale session 错误识别，并复用现有的一次性 session 轮换与重试流程；同时新增真实错误文案的回归测试。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Computer Use stale cua-driver session 自动恢复
- 本 PR 包含：
  - 识别带 session id 的 `session ... has ended` 错误文案；
  - 进入既有 session 清理、generation 轮换并最多重试一次的流程；
  - 增加旧 session 关闭、新 session 成功重试的回归测试。
- 明确不包含：system prompt、translator、usage 计量、event loop、lizi_computer MCP server 或权限边界调整。
- 用户可见变化：cua-driver session 失效后，Computer Use 调用会自动尝试恢复一次；恢复成功时调用方无需绕过 CUA 改用 CDP/exec。
- 是否存在 breaking change：无。

## UI 变化

不涉及 UI、视觉或交互布局变化。

- 引用的设计规范：不涉及。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/mcp-integrations/__tests__/computer.test.ts
结果：140/140 tests passed

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm test:unit
结果：所有 required workspace 通过；383 passed、1 skipped、0 failed

pnpm check:dco
结果：通过；1 commit signed off

git diff --check
结果：通过
```

### 手工验证

不涉及 UI 手工验证。回归测试使用实际观测到的 cua-driver stale session 错误文案验证 wrapper 的恢复路径。

### 未执行的验证

未在真实 cua-driver 进程中进行 session 失效后的视觉或端到端验证；本次改动只调整 Cindy desktop wrapper 的错误识别，具体 driver 行为已由真实错误文案作为测试输入覆盖。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅影响 desktop Computer Use wrapper 对 stale cua-driver 错误的分类；正常调用和非 stale 错误路径不变。
- 回滚 / 降级方式：回滚本 PR commit 即可恢复原有错误分类行为。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
