### PR TITLE
feat(mobile): 收起态输入框露出附件加号并与文字对齐

### DIFF
--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -6829,33 +6829,35 @@ export default function SessionScreen() {
   // 卡片态仍由 renderComposerToolbar() 渲染同一入口。
   const renderComposerCompactLeading = () => (
     <View style={styles.composerCompactLeading}>
-      <RouteActionButton
-        accessibilityHint={composerLayout.attachment.disabledReason ?? composerSendUnavailableReason ?? undefined}
-        accessibilityLabel={composerLayout.attachment.active ? composerLayout.attachment.label : t('session.common.openContextPanel')}
-        active={composerLayout.attachment.active}
-        disabled={composerLayout.attachment.disabled || (!canUseComposer && !composerLayout.attachment.active)}
-        onPress={() => {
-          setModelSheetOpen(false);
-          setContextSheetView('main');
-          setContextSheetOpen(true);
-        }}
-        style={styles.composerCompactAttachmentHit}
-        testID="session.attachmentToggleButton"
-      >
-        <View
-          pointerEvents="none"
-          style={[
-            styles.composerInlineToolButton,
-            composerLayout.attachment.active && styles.composerToolButtonActive,
-          ]}
+      <View style={styles.composerCompactAttachmentHit}>
+        <RouteActionButton
+          accessibilityHint={composerLayout.attachment.disabledReason ?? composerSendUnavailableReason ?? undefined}
+          accessibilityLabel={composerLayout.attachment.active ? composerLayout.attachment.label : t('session.common.openContextPanel')}
+          active={composerLayout.attachment.active}
+          disabled={composerLayout.attachment.disabled || (!canUseComposer && !composerLayout.attachment.active)}
+          onPress={() => {
+            setModelSheetOpen(false);
+            setContextSheetView('main');
+            setContextSheetOpen(true);
+          }}
+          style={styles.composerCompactAttachmentHitArea}
+          testID="session.attachmentToggleButton"
         >
-          <Plus
-            color={composerLayout.attachment.active ? colors.textPrimary : colors.textSecondary}
-            size={iconSize.sm}
-            strokeWidth={iconStroke.regular}
-          />
-        </View>
-      </RouteActionButton>
+          <View
+            pointerEvents="none"
+            style={[
+              styles.composerInlineToolButton,
+              composerLayout.attachment.active && styles.composerToolButtonActive,
+            ]}
+          >
+            <Plus
+              color={composerLayout.attachment.active ? colors.textPrimary : colors.textSecondary}
+              size={iconSize.sm}
+              strokeWidth={iconStroke.regular}
+            />
+          </View>
+        </RouteActionButton>
+      </View>
       {renderComposerCollapsedAttachmentBadge()}
     </View>
   );
@@ -10741,13 +10743,23 @@ const makeStyles = (colors: ThemeColors) => StyleSheet.create({
     gap: spacing.xs,
     marginRight: spacing.xs,
   },
-  // 收起态可见加号仍是 34pt;不可见外层自己撑到 44×44。
-  // hitSlop 越不过父 View 边界,不能拿它补主操作热区。
+  // 流内仍占 34pt,与输入文字 / 语音按钮共中线。
+  // 44pt 热区绝对居中外溢,不抬高 mainRow,也不靠会被父级裁掉的 hitSlop。
   composerCompactAttachmentHit: {
     alignItems: 'center',
-    height: MOBILE_COMPOSER_MIN_TOUCH_TARGET,
+    height: MOBILE_COMPOSER_CONTROL_SIZE,
     justifyContent: 'center',
-    width: MOBILE_COMPOSER_MIN_TOUCH_TARGET,
+    overflow: 'visible',
+    width: MOBILE_COMPOSER_CONTROL_SIZE,
+  },
+  composerCompactAttachmentHitArea: {
+    alignItems: 'center',
+    bottom: (MOBILE_COMPOSER_CONTROL_SIZE - MOBILE_COMPOSER_MIN_TOUCH_TARGET) / 2,
+    justifyContent: 'center',
+    left: (MOBILE_COMPOSER_CONTROL_SIZE - MOBILE_COMPOSER_MIN_TOUCH_TARGET) / 2,
+    position: 'absolute',
+    right: (MOBILE_COMPOSER_CONTROL_SIZE - MOBILE_COMPOSER_MIN_TOUCH_TARGET) / 2,
+    top: (MOBILE_COMPOSER_CONTROL_SIZE - MOBILE_COMPOSER_MIN_TOUCH_TARGET) / 2,
   },
   composerToolButtonActive: {
     backgroundColor: colors.surfaceChip,

--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -6829,7 +6829,6 @@ export default function SessionScreen() {
   // 卡片态仍由 renderComposerToolbar() 渲染同一入口。
   const renderComposerCompactLeading = () => (
     <View style={styles.composerCompactLeading}>
-      <View style={styles.composerCompactAttachmentSlot} />
       <RouteActionButton
         accessibilityHint={composerLayout.attachment.disabledReason ?? composerSendUnavailableReason ?? undefined}
         accessibilityLabel={composerLayout.attachment.active ? composerLayout.attachment.label : t('session.common.openContextPanel')}
@@ -10740,27 +10739,18 @@ const makeStyles = (colors: ThemeColors) => StyleSheet.create({
     alignItems: 'center',
     flexDirection: 'row',
     gap: spacing.xs,
-    height: MOBILE_COMPOSER_CONTROL_SIZE,
+    height: MOBILE_COMPOSER_MIN_TOUCH_TARGET,
     marginRight: spacing.xs,
-    overflow: 'visible',
-    position: 'relative',
-    zIndex: 3,
   },
-  // 流内占位仍是 34pt,避免收起行被 44pt 热区抬高。
-  composerCompactAttachmentSlot: {
-    height: MOBILE_COMPOSER_CONTROL_SIZE,
-    width: MOBILE_COMPOSER_CONTROL_SIZE,
-  },
-  // 接点击的父层本身就是 44×44,绝对居中挂在 34pt 占位上。
+  // 直接父层本身就是 44×44,负 margin 只抵消它对 mainRow 的额外占位。
+  // 可见加号仍是 34pt,与文字 / 麦克风共中线。
   composerCompactAttachmentHit: {
     alignItems: 'center',
     height: MOBILE_COMPOSER_MIN_TOUCH_TARGET,
     justifyContent: 'center',
-    left: (MOBILE_COMPOSER_CONTROL_SIZE - MOBILE_COMPOSER_MIN_TOUCH_TARGET) / 2,
-    position: 'absolute',
-    top: (MOBILE_COMPOSER_CONTROL_SIZE - MOBILE_COMPOSER_MIN_TOUCH_TARGET) / 2,
+    marginHorizontal: (MOBILE_COMPOSER_CONTROL_SIZE - MOBILE_COMPOSER_MIN_TOUCH_TARGET) / 2,
+    marginVertical: (MOBILE_COMPOSER_CONTROL_SIZE - MOBILE_COMPOSER_MIN_TOUCH_TARGET) / 2,
     width: MOBILE_COMPOSER_MIN_TOUCH_TARGET,
-    zIndex: 3,
   },
   composerToolButtonActive: {
     backgroundColor: colors.surfaceChip,

--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -10741,15 +10741,14 @@ const makeStyles = (colors: ThemeColors) => StyleSheet.create({
     gap: spacing.xs,
     height: MOBILE_COMPOSER_MIN_TOUCH_TARGET,
     marginRight: spacing.xs,
+    minWidth: MOBILE_COMPOSER_MIN_TOUCH_TARGET,
   },
-  // 直接父层本身就是 44×44,负 margin 只抵消它对 mainRow 的额外占位。
+  // 热区流内就是 44×44,祖先链不再靠负 margin / 溢出子节点。
   // 可见加号仍是 34pt,与文字 / 麦克风共中线。
   composerCompactAttachmentHit: {
     alignItems: 'center',
     height: MOBILE_COMPOSER_MIN_TOUCH_TARGET,
     justifyContent: 'center',
-    marginHorizontal: (MOBILE_COMPOSER_CONTROL_SIZE - MOBILE_COMPOSER_MIN_TOUCH_TARGET) / 2,
-    marginVertical: (MOBILE_COMPOSER_CONTROL_SIZE - MOBILE_COMPOSER_MIN_TOUCH_TARGET) / 2,
     width: MOBILE_COMPOSER_MIN_TOUCH_TARGET,
   },
   composerToolButtonActive: {

--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -6829,35 +6829,34 @@ export default function SessionScreen() {
   // 卡片态仍由 renderComposerToolbar() 渲染同一入口。
   const renderComposerCompactLeading = () => (
     <View style={styles.composerCompactLeading}>
-      <View style={styles.composerCompactAttachmentHit}>
-        <RouteActionButton
-          accessibilityHint={composerLayout.attachment.disabledReason ?? composerSendUnavailableReason ?? undefined}
-          accessibilityLabel={composerLayout.attachment.active ? composerLayout.attachment.label : t('session.common.openContextPanel')}
-          active={composerLayout.attachment.active}
-          disabled={composerLayout.attachment.disabled || (!canUseComposer && !composerLayout.attachment.active)}
-          onPress={() => {
-            setModelSheetOpen(false);
-            setContextSheetView('main');
-            setContextSheetOpen(true);
-          }}
-          style={styles.composerCompactAttachmentHitArea}
-          testID="session.attachmentToggleButton"
+      <View style={styles.composerCompactAttachmentSlot} />
+      <RouteActionButton
+        accessibilityHint={composerLayout.attachment.disabledReason ?? composerSendUnavailableReason ?? undefined}
+        accessibilityLabel={composerLayout.attachment.active ? composerLayout.attachment.label : t('session.common.openContextPanel')}
+        active={composerLayout.attachment.active}
+        disabled={composerLayout.attachment.disabled || (!canUseComposer && !composerLayout.attachment.active)}
+        onPress={() => {
+          setModelSheetOpen(false);
+          setContextSheetView('main');
+          setContextSheetOpen(true);
+        }}
+        style={styles.composerCompactAttachmentHit}
+        testID="session.attachmentToggleButton"
+      >
+        <View
+          pointerEvents="none"
+          style={[
+            styles.composerInlineToolButton,
+            composerLayout.attachment.active && styles.composerToolButtonActive,
+          ]}
         >
-          <View
-            pointerEvents="none"
-            style={[
-              styles.composerInlineToolButton,
-              composerLayout.attachment.active && styles.composerToolButtonActive,
-            ]}
-          >
-            <Plus
-              color={composerLayout.attachment.active ? colors.textPrimary : colors.textSecondary}
-              size={iconSize.sm}
-              strokeWidth={iconStroke.regular}
-            />
-          </View>
-        </RouteActionButton>
-      </View>
+          <Plus
+            color={composerLayout.attachment.active ? colors.textPrimary : colors.textSecondary}
+            size={iconSize.sm}
+            strokeWidth={iconStroke.regular}
+          />
+        </View>
+      </RouteActionButton>
       {renderComposerCollapsedAttachmentBadge()}
     </View>
   );
@@ -10741,25 +10740,27 @@ const makeStyles = (colors: ThemeColors) => StyleSheet.create({
     alignItems: 'center',
     flexDirection: 'row',
     gap: spacing.xs,
-    marginRight: spacing.xs,
-  },
-  // 流内仍占 34pt,与输入文字 / 语音按钮共中线。
-  // 44pt 热区绝对居中外溢,不抬高 mainRow,也不靠会被父级裁掉的 hitSlop。
-  composerCompactAttachmentHit: {
-    alignItems: 'center',
     height: MOBILE_COMPOSER_CONTROL_SIZE,
-    justifyContent: 'center',
+    marginRight: spacing.xs,
     overflow: 'visible',
+    position: 'relative',
+    zIndex: 3,
+  },
+  // 流内占位仍是 34pt,避免收起行被 44pt 热区抬高。
+  composerCompactAttachmentSlot: {
+    height: MOBILE_COMPOSER_CONTROL_SIZE,
     width: MOBILE_COMPOSER_CONTROL_SIZE,
   },
-  composerCompactAttachmentHitArea: {
+  // 接点击的父层本身就是 44×44,绝对居中挂在 34pt 占位上。
+  composerCompactAttachmentHit: {
     alignItems: 'center',
-    bottom: (MOBILE_COMPOSER_CONTROL_SIZE - MOBILE_COMPOSER_MIN_TOUCH_TARGET) / 2,
+    height: MOBILE_COMPOSER_MIN_TOUCH_TARGET,
     justifyContent: 'center',
     left: (MOBILE_COMPOSER_CONTROL_SIZE - MOBILE_COMPOSER_MIN_TOUCH_TARGET) / 2,
     position: 'absolute',
-    right: (MOBILE_COMPOSER_CONTROL_SIZE - MOBILE_COMPOSER_MIN_TOUCH_TARGET) / 2,
     top: (MOBILE_COMPOSER_CONTROL_SIZE - MOBILE_COMPOSER_MIN_TOUCH_TARGET) / 2,
+    width: MOBILE_COMPOSER_MIN_TOUCH_TARGET,
+    zIndex: 3,
   },
   composerToolButtonActive: {
     backgroundColor: colors.surfaceChip,

--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -6829,7 +6829,33 @@ export default function SessionScreen() {
   // 卡片态仍由 renderComposerToolbar() 渲染同一入口。
   const renderComposerCompactLeading = () => (
     <View style={styles.composerCompactLeading}>
-      {renderComposerAttachmentButton()}
+      <RouteActionButton
+        accessibilityHint={composerLayout.attachment.disabledReason ?? composerSendUnavailableReason ?? undefined}
+        accessibilityLabel={composerLayout.attachment.active ? composerLayout.attachment.label : t('session.common.openContextPanel')}
+        active={composerLayout.attachment.active}
+        disabled={composerLayout.attachment.disabled || (!canUseComposer && !composerLayout.attachment.active)}
+        onPress={() => {
+          setModelSheetOpen(false);
+          setContextSheetView('main');
+          setContextSheetOpen(true);
+        }}
+        style={styles.composerCompactAttachmentHit}
+        testID="session.attachmentToggleButton"
+      >
+        <View
+          pointerEvents="none"
+          style={[
+            styles.composerInlineToolButton,
+            composerLayout.attachment.active && styles.composerToolButtonActive,
+          ]}
+        >
+          <Plus
+            color={composerLayout.attachment.active ? colors.textPrimary : colors.textSecondary}
+            size={iconSize.sm}
+            strokeWidth={iconStroke.regular}
+          />
+        </View>
+      </RouteActionButton>
       {renderComposerCollapsedAttachmentBadge()}
     </View>
   );
@@ -10714,6 +10740,14 @@ const makeStyles = (colors: ThemeColors) => StyleSheet.create({
     flexDirection: 'row',
     gap: spacing.xs,
     marginRight: spacing.xs,
+  },
+  // 收起态可见加号仍是 34pt;不可见外层自己撑到 44×44。
+  // hitSlop 越不过父 View 边界,不能拿它补主操作热区。
+  composerCompactAttachmentHit: {
+    alignItems: 'center',
+    height: MOBILE_COMPOSER_MIN_TOUCH_TARGET,
+    justifyContent: 'center',
+    width: MOBILE_COMPOSER_MIN_TOUCH_TARGET,
   },
   composerToolButtonActive: {
     backgroundColor: colors.surfaceChip,

--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -381,6 +381,8 @@ import {
 } from '@/session/composerVoiceHold';
 import { COMPOSER_TEXT_HORIZONTAL_PADDING } from '@/session/composerTextMetrics';
 import {
+  COMPOSER_TEXT_GEOMETRIC_PADDING_BOTTOM,
+  COMPOSER_TEXT_GEOMETRIC_PADDING_TOP,
   COMPOSER_TEXT_PADDING_BOTTOM,
   COMPOSER_TEXT_PADDING_TOP,
 } from '@/session/composerTextPlatformMetrics';
@@ -2794,7 +2796,10 @@ export default function SessionScreen() {
     >
       <ScrollView
         ref={voiceDraftScrollRef}
-        contentContainerStyle={styles.voiceDraftOverlayContent}
+        contentContainerStyle={[
+          styles.voiceDraftOverlayContent,
+          !composerCardActive && !composerInputIsMultiline && styles.voiceDraftOverlayContentGeometric,
+        ]}
         onContentSizeChange={() => {
           requestAnimationFrame(() => {
             voiceDraftScrollRef.current?.scrollToEnd({ animated: false });
@@ -6820,6 +6825,15 @@ export default function SessionScreen() {
     />
   ) : null);
 
+  // 收起态把附件 + 号放在输入框左侧，避免用户必须先聚焦才能打开附件面板；
+  // 卡片态仍由 renderComposerToolbar() 渲染同一入口。
+  const renderComposerCompactLeading = () => (
+    <View style={styles.composerCompactLeading}>
+      {renderComposerAttachmentButton()}
+      {renderComposerCollapsedAttachmentBadge()}
+    </View>
+  );
+
   // 停止任务按钮(实心中性方块)。两处使用:语音/发送左边的独立槽(inline)、
   // 发送位顶替(sendSlotIsStop);同一颗按钮的两个宿主位置,样式与行为一致。
   const renderComposerStopButton = () => (
@@ -9400,6 +9414,7 @@ export default function SessionScreen() {
                         height={composerInputVisibleHeight}
                         hidden={voiceIsListening}
                         maxHeight={composerResize.inputMaxHeight}
+                        opticalPadding={composerCardActive || composerInputIsMultiline}
                         onBlur={() => {
                           setComposerFocused(false);
                           setComposerVoiceHoldArmed(false);
@@ -9427,7 +9442,7 @@ export default function SessionScreen() {
                     inputOverlay={renderComposerInputOverlay()}
                     inputStyle={voiceIsListening ? styles.inputVoiceHidden : undefined}
                     inputTestID="session.composerInput"
-                    leading={renderComposerCollapsedAttachmentBadge()}
+                    leading={renderComposerCompactLeading()}
                     maxHeight={composerResize.inputMaxHeight}
                     multilineShape={!composerCardActive && composerInputIsMultiline}
                     onBlur={() => {
@@ -10694,6 +10709,12 @@ const makeStyles = (colors: ThemeColors) => StyleSheet.create({
     height: 34,
     width: 34,
   },
+  composerCompactLeading: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: spacing.xs,
+    marginRight: spacing.xs,
+  },
   composerToolButtonActive: {
     backgroundColor: colors.surfaceChip,
     borderColor: colors.borderStrong,
@@ -10715,6 +10736,10 @@ const makeStyles = (colors: ThemeColors) => StyleSheet.create({
     paddingBottom: COMPOSER_TEXT_PADDING_BOTTOM,
     paddingHorizontal: COMPOSER_TEXT_HORIZONTAL_PADDING,
     paddingTop: COMPOSER_TEXT_PADDING_TOP,
+  },
+  voiceDraftOverlayContentGeometric: {
+    paddingBottom: COMPOSER_TEXT_GEOMETRIC_PADDING_BOTTOM,
+    paddingTop: COMPOSER_TEXT_GEOMETRIC_PADDING_TOP,
   },
   voiceDraftMeasuredBlock: {
     minHeight: COMPOSER_INPUT_LINE_HEIGHT,

--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -2798,7 +2798,7 @@ export default function SessionScreen() {
         ref={voiceDraftScrollRef}
         contentContainerStyle={[
           styles.voiceDraftOverlayContent,
-          !composerCardActive && !composerInputIsMultiline && styles.voiceDraftOverlayContentGeometric,
+          !composerCardActive && styles.voiceDraftOverlayContentGeometric,
         ]}
         onContentSizeChange={() => {
           requestAnimationFrame(() => {
@@ -9414,7 +9414,7 @@ export default function SessionScreen() {
                         height={composerInputVisibleHeight}
                         hidden={voiceIsListening}
                         maxHeight={composerResize.inputMaxHeight}
-                        opticalPadding={composerCardActive || composerInputIsMultiline}
+                        opticalPadding={composerCardActive}
                         onBlur={() => {
                           setComposerFocused(false);
                           setComposerVoiceHoldArmed(false);

--- a/apps/mobile/app/sessions/new.tsx
+++ b/apps/mobile/app/sessions/new.tsx
@@ -3786,40 +3786,39 @@ export default function NewRemoteSessionScreen() {
   // 卡片态仍由 renderComposerToolbar() 渲染同一入口。
   const renderComposerCompactLeading = () => (
     <View style={styles.composerCompactLeading}>
-      <View style={styles.composerCompactAttachmentHit}>
-        <Pressable
-          accessibilityLabel={t('session.common.openContextPanel')}
-          accessibilityRole="button"
-          disabled={creating}
-          onPress={() => {
-            setModelSheetOpen(false);
-            setAgentPickerOpen(false);
-            setPermissionSheetOpen(false);
-            setWorktreeBranchSheetOpen(false);
-            setContextSheetView('main');
-            setContextSheetOpen(true);
-          }}
-          style={({ pressed }) => [
-            styles.composerCompactAttachmentHitArea,
-            pressed && styles.pressed,
+      <View style={styles.composerCompactAttachmentSlot} />
+      <Pressable
+        accessibilityLabel={t('session.common.openContextPanel')}
+        accessibilityRole="button"
+        disabled={creating}
+        onPress={() => {
+          setModelSheetOpen(false);
+          setAgentPickerOpen(false);
+          setPermissionSheetOpen(false);
+          setWorktreeBranchSheetOpen(false);
+          setContextSheetView('main');
+          setContextSheetOpen(true);
+        }}
+        style={({ pressed }) => [
+          styles.composerCompactAttachmentHit,
+          pressed && styles.pressed,
+        ]}
+        testID="newSession.attachmentToggleButton"
+      >
+        <View
+          pointerEvents="none"
+          style={[
+            styles.composerIconButton,
+            contextSheetOpen && styles.composerIconButtonActive,
           ]}
-          testID="newSession.attachmentToggleButton"
         >
-          <View
-            pointerEvents="none"
-            style={[
-              styles.composerIconButton,
-              contextSheetOpen && styles.composerIconButtonActive,
-            ]}
-          >
-            <Plus
-              color={contextSheetOpen ? colors.textPrimary : colors.textSecondary}
-              size={iconSize.sm}
-              strokeWidth={iconStroke.regular}
-            />
-          </View>
-        </Pressable>
-      </View>
+          <Plus
+            color={contextSheetOpen ? colors.textPrimary : colors.textSecondary}
+            size={iconSize.sm}
+            strokeWidth={iconStroke.regular}
+          />
+        </View>
+      </Pressable>
       {renderComposerCollapsedAttachmentBadge()}
     </View>
   );
@@ -6568,25 +6567,27 @@ const makeStyles = (colors: ThemeColors) => StyleSheet.create({
     alignItems: 'center',
     flexDirection: 'row',
     gap: spacing.xs,
-    marginRight: spacing.xs,
-  },
-  // 流内仍占 34pt,与输入文字 / 语音按钮共中线。
-  // 44pt 热区绝对居中外溢,不抬高 mainRow,也不靠会被父级裁掉的 hitSlop。
-  composerCompactAttachmentHit: {
-    alignItems: 'center',
     height: MOBILE_COMPOSER_CONTROL_SIZE,
-    justifyContent: 'center',
+    marginRight: spacing.xs,
     overflow: 'visible',
+    position: 'relative',
+    zIndex: 3,
+  },
+  // 流内占位仍是 34pt,避免收起行被 44pt 热区抬高。
+  composerCompactAttachmentSlot: {
+    height: MOBILE_COMPOSER_CONTROL_SIZE,
     width: MOBILE_COMPOSER_CONTROL_SIZE,
   },
-  composerCompactAttachmentHitArea: {
+  // 接点击的父层本身就是 44×44,绝对居中挂在 34pt 占位上。
+  composerCompactAttachmentHit: {
     alignItems: 'center',
-    bottom: (MOBILE_COMPOSER_CONTROL_SIZE - MOBILE_COMPOSER_MIN_TOUCH_TARGET) / 2,
+    height: MOBILE_COMPOSER_MIN_TOUCH_TARGET,
     justifyContent: 'center',
     left: (MOBILE_COMPOSER_CONTROL_SIZE - MOBILE_COMPOSER_MIN_TOUCH_TARGET) / 2,
     position: 'absolute',
-    right: (MOBILE_COMPOSER_CONTROL_SIZE - MOBILE_COMPOSER_MIN_TOUCH_TARGET) / 2,
     top: (MOBILE_COMPOSER_CONTROL_SIZE - MOBILE_COMPOSER_MIN_TOUCH_TARGET) / 2,
+    width: MOBILE_COMPOSER_MIN_TOUCH_TARGET,
+    zIndex: 3,
   },
   composerIconButtonActive: {
     backgroundColor: colors.surfaceChip,

--- a/apps/mobile/app/sessions/new.tsx
+++ b/apps/mobile/app/sessions/new.tsx
@@ -6568,15 +6568,14 @@ const makeStyles = (colors: ThemeColors) => StyleSheet.create({
     gap: spacing.xs,
     height: MOBILE_COMPOSER_MIN_TOUCH_TARGET,
     marginRight: spacing.xs,
+    minWidth: MOBILE_COMPOSER_MIN_TOUCH_TARGET,
   },
-  // 直接父层本身就是 44×44,负 margin 只抵消它对 mainRow 的额外占位。
+  // 热区流内就是 44×44,祖先链不再靠负 margin / 溢出子节点。
   // 可见加号仍是 34pt,与文字 / 麦克风共中线。
   composerCompactAttachmentHit: {
     alignItems: 'center',
     height: MOBILE_COMPOSER_MIN_TOUCH_TARGET,
     justifyContent: 'center',
-    marginHorizontal: (MOBILE_COMPOSER_CONTROL_SIZE - MOBILE_COMPOSER_MIN_TOUCH_TARGET) / 2,
-    marginVertical: (MOBILE_COMPOSER_CONTROL_SIZE - MOBILE_COMPOSER_MIN_TOUCH_TARGET) / 2,
     width: MOBILE_COMPOSER_MIN_TOUCH_TARGET,
   },
   composerIconButtonActive: {

--- a/apps/mobile/app/sessions/new.tsx
+++ b/apps/mobile/app/sessions/new.tsx
@@ -3786,7 +3786,6 @@ export default function NewRemoteSessionScreen() {
   // 卡片态仍由 renderComposerToolbar() 渲染同一入口。
   const renderComposerCompactLeading = () => (
     <View style={styles.composerCompactLeading}>
-      <View style={styles.composerCompactAttachmentSlot} />
       <Pressable
         accessibilityLabel={t('session.common.openContextPanel')}
         accessibilityRole="button"
@@ -6567,27 +6566,18 @@ const makeStyles = (colors: ThemeColors) => StyleSheet.create({
     alignItems: 'center',
     flexDirection: 'row',
     gap: spacing.xs,
-    height: MOBILE_COMPOSER_CONTROL_SIZE,
+    height: MOBILE_COMPOSER_MIN_TOUCH_TARGET,
     marginRight: spacing.xs,
-    overflow: 'visible',
-    position: 'relative',
-    zIndex: 3,
   },
-  // 流内占位仍是 34pt,避免收起行被 44pt 热区抬高。
-  composerCompactAttachmentSlot: {
-    height: MOBILE_COMPOSER_CONTROL_SIZE,
-    width: MOBILE_COMPOSER_CONTROL_SIZE,
-  },
-  // 接点击的父层本身就是 44×44,绝对居中挂在 34pt 占位上。
+  // 直接父层本身就是 44×44,负 margin 只抵消它对 mainRow 的额外占位。
+  // 可见加号仍是 34pt,与文字 / 麦克风共中线。
   composerCompactAttachmentHit: {
     alignItems: 'center',
     height: MOBILE_COMPOSER_MIN_TOUCH_TARGET,
     justifyContent: 'center',
-    left: (MOBILE_COMPOSER_CONTROL_SIZE - MOBILE_COMPOSER_MIN_TOUCH_TARGET) / 2,
-    position: 'absolute',
-    top: (MOBILE_COMPOSER_CONTROL_SIZE - MOBILE_COMPOSER_MIN_TOUCH_TARGET) / 2,
+    marginHorizontal: (MOBILE_COMPOSER_CONTROL_SIZE - MOBILE_COMPOSER_MIN_TOUCH_TARGET) / 2,
+    marginVertical: (MOBILE_COMPOSER_CONTROL_SIZE - MOBILE_COMPOSER_MIN_TOUCH_TARGET) / 2,
     width: MOBILE_COMPOSER_MIN_TOUCH_TARGET,
-    zIndex: 3,
   },
   composerIconButtonActive: {
     backgroundColor: colors.surfaceChip,

--- a/apps/mobile/app/sessions/new.tsx
+++ b/apps/mobile/app/sessions/new.tsx
@@ -3786,38 +3786,40 @@ export default function NewRemoteSessionScreen() {
   // 卡片态仍由 renderComposerToolbar() 渲染同一入口。
   const renderComposerCompactLeading = () => (
     <View style={styles.composerCompactLeading}>
-      <Pressable
-        accessibilityLabel={t('session.common.openContextPanel')}
-        accessibilityRole="button"
-        disabled={creating}
-        onPress={() => {
-          setModelSheetOpen(false);
-          setAgentPickerOpen(false);
-          setPermissionSheetOpen(false);
-          setWorktreeBranchSheetOpen(false);
-          setContextSheetView('main');
-          setContextSheetOpen(true);
-        }}
-        style={({ pressed }) => [
-          styles.composerCompactAttachmentHit,
-          pressed && styles.pressed,
-        ]}
-        testID="newSession.attachmentToggleButton"
-      >
-        <View
-          pointerEvents="none"
-          style={[
-            styles.composerIconButton,
-            contextSheetOpen && styles.composerIconButtonActive,
+      <View style={styles.composerCompactAttachmentHit}>
+        <Pressable
+          accessibilityLabel={t('session.common.openContextPanel')}
+          accessibilityRole="button"
+          disabled={creating}
+          onPress={() => {
+            setModelSheetOpen(false);
+            setAgentPickerOpen(false);
+            setPermissionSheetOpen(false);
+            setWorktreeBranchSheetOpen(false);
+            setContextSheetView('main');
+            setContextSheetOpen(true);
+          }}
+          style={({ pressed }) => [
+            styles.composerCompactAttachmentHitArea,
+            pressed && styles.pressed,
           ]}
+          testID="newSession.attachmentToggleButton"
         >
-          <Plus
-            color={contextSheetOpen ? colors.textPrimary : colors.textSecondary}
-            size={iconSize.sm}
-            strokeWidth={iconStroke.regular}
-          />
-        </View>
-      </Pressable>
+          <View
+            pointerEvents="none"
+            style={[
+              styles.composerIconButton,
+              contextSheetOpen && styles.composerIconButtonActive,
+            ]}
+          >
+            <Plus
+              color={contextSheetOpen ? colors.textPrimary : colors.textSecondary}
+              size={iconSize.sm}
+              strokeWidth={iconStroke.regular}
+            />
+          </View>
+        </Pressable>
+      </View>
       {renderComposerCollapsedAttachmentBadge()}
     </View>
   );
@@ -6568,13 +6570,23 @@ const makeStyles = (colors: ThemeColors) => StyleSheet.create({
     gap: spacing.xs,
     marginRight: spacing.xs,
   },
-  // 收起态可见加号仍是 34pt;不可见外层自己撑到 44×44。
-  // hitSlop 越不过父 View 边界,不能拿它补主操作热区。
+  // 流内仍占 34pt,与输入文字 / 语音按钮共中线。
+  // 44pt 热区绝对居中外溢,不抬高 mainRow,也不靠会被父级裁掉的 hitSlop。
   composerCompactAttachmentHit: {
     alignItems: 'center',
-    height: MOBILE_COMPOSER_MIN_TOUCH_TARGET,
+    height: MOBILE_COMPOSER_CONTROL_SIZE,
     justifyContent: 'center',
-    width: MOBILE_COMPOSER_MIN_TOUCH_TARGET,
+    overflow: 'visible',
+    width: MOBILE_COMPOSER_CONTROL_SIZE,
+  },
+  composerCompactAttachmentHitArea: {
+    alignItems: 'center',
+    bottom: (MOBILE_COMPOSER_CONTROL_SIZE - MOBILE_COMPOSER_MIN_TOUCH_TARGET) / 2,
+    justifyContent: 'center',
+    left: (MOBILE_COMPOSER_CONTROL_SIZE - MOBILE_COMPOSER_MIN_TOUCH_TARGET) / 2,
+    position: 'absolute',
+    right: (MOBILE_COMPOSER_CONTROL_SIZE - MOBILE_COMPOSER_MIN_TOUCH_TARGET) / 2,
+    top: (MOBILE_COMPOSER_CONTROL_SIZE - MOBILE_COMPOSER_MIN_TOUCH_TARGET) / 2,
   },
   composerIconButtonActive: {
     backgroundColor: colors.surfaceChip,

--- a/apps/mobile/app/sessions/new.tsx
+++ b/apps/mobile/app/sessions/new.tsx
@@ -3786,7 +3786,38 @@ export default function NewRemoteSessionScreen() {
   // 卡片态仍由 renderComposerToolbar() 渲染同一入口。
   const renderComposerCompactLeading = () => (
     <View style={styles.composerCompactLeading}>
-      {renderAttachmentToggleButton()}
+      <Pressable
+        accessibilityLabel={t('session.common.openContextPanel')}
+        accessibilityRole="button"
+        disabled={creating}
+        onPress={() => {
+          setModelSheetOpen(false);
+          setAgentPickerOpen(false);
+          setPermissionSheetOpen(false);
+          setWorktreeBranchSheetOpen(false);
+          setContextSheetView('main');
+          setContextSheetOpen(true);
+        }}
+        style={({ pressed }) => [
+          styles.composerCompactAttachmentHit,
+          pressed && styles.pressed,
+        ]}
+        testID="newSession.attachmentToggleButton"
+      >
+        <View
+          pointerEvents="none"
+          style={[
+            styles.composerIconButton,
+            contextSheetOpen && styles.composerIconButtonActive,
+          ]}
+        >
+          <Plus
+            color={contextSheetOpen ? colors.textPrimary : colors.textSecondary}
+            size={iconSize.sm}
+            strokeWidth={iconStroke.regular}
+          />
+        </View>
+      </Pressable>
       {renderComposerCollapsedAttachmentBadge()}
     </View>
   );
@@ -6536,6 +6567,14 @@ const makeStyles = (colors: ThemeColors) => StyleSheet.create({
     flexDirection: 'row',
     gap: spacing.xs,
     marginRight: spacing.xs,
+  },
+  // 收起态可见加号仍是 34pt;不可见外层自己撑到 44×44。
+  // hitSlop 越不过父 View 边界,不能拿它补主操作热区。
+  composerCompactAttachmentHit: {
+    alignItems: 'center',
+    height: MOBILE_COMPOSER_MIN_TOUCH_TARGET,
+    justifyContent: 'center',
+    width: MOBILE_COMPOSER_MIN_TOUCH_TARGET,
   },
   composerIconButtonActive: {
     backgroundColor: colors.surfaceChip,

--- a/apps/mobile/app/sessions/new.tsx
+++ b/apps/mobile/app/sessions/new.tsx
@@ -234,6 +234,8 @@ import {
 } from '@/session/composerVoiceHold';
 import { COMPOSER_TEXT_HORIZONTAL_PADDING } from '@/session/composerTextMetrics';
 import {
+  COMPOSER_TEXT_GEOMETRIC_PADDING_BOTTOM,
+  COMPOSER_TEXT_GEOMETRIC_PADDING_TOP,
   COMPOSER_TEXT_PADDING_BOTTOM,
   COMPOSER_TEXT_PADDING_TOP,
 } from '@/session/composerTextPlatformMetrics';
@@ -3408,7 +3410,10 @@ export default function NewRemoteSessionScreen() {
   const renderComposerInputOverlay = () => voiceIsListening ? (
     <ScrollView
       ref={voiceDraftScrollRef}
-      contentContainerStyle={styles.voiceDraftOverlayContent}
+      contentContainerStyle={[
+        styles.voiceDraftOverlayContent,
+        !composerCardActive && !composerInputIsMultiline && styles.voiceDraftOverlayContentGeometric,
+      ]}
       onContentSizeChange={() => {
         requestAnimationFrame(() => {
           voiceDraftScrollRef.current?.scrollToEnd({ animated: false });
@@ -3776,6 +3781,15 @@ export default function NewRemoteSessionScreen() {
       testID="newSession.attachmentCollapsedBadge"
     />
   ) : null);
+
+  // 收起态把附件 + 号放在输入框左侧，避免用户必须先聚焦才能打开附件面板；
+  // 卡片态仍由 renderComposerToolbar() 渲染同一入口。
+  const renderComposerCompactLeading = () => (
+    <View style={styles.composerCompactLeading}>
+      {renderAttachmentToggleButton()}
+      {renderComposerCollapsedAttachmentBadge()}
+    </View>
+  );
   // 面板关闭即丢弃未提交的待选(不产生任何上传副作用)。
   useEffect(() => {
     if (!contextSheetOpen) setPendingMediaAssets([]);
@@ -5631,7 +5645,7 @@ export default function NewRemoteSessionScreen() {
                   caretHidden={voiceIsListening}
                   cursorColor={colors.inputCaret}
                   inputRef={firstMessageInputRef}
-                  leading={renderComposerCollapsedAttachmentBadge()}
+                  leading={renderComposerCompactLeading()}
                   inputFrameHeight={composerResize.frameHeight}
                   // 听写期间把输入区撑到 44pt 触控目标:此时「点输入区停止听写」的命中层
                   // 是这层输入区自身(TextInput 的 onPressIn),单行时只有 28pt。
@@ -6517,6 +6531,12 @@ const makeStyles = (colors: ThemeColors) => StyleSheet.create({
     justifyContent: 'center',
     width: MOBILE_COMPOSER_CONTROL_SIZE,
   },
+  composerCompactLeading: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: spacing.xs,
+    marginRight: spacing.xs,
+  },
   composerIconButtonActive: {
     backgroundColor: colors.surfaceChip,
     borderColor: colors.borderStrong,
@@ -6549,6 +6569,10 @@ const makeStyles = (colors: ThemeColors) => StyleSheet.create({
     paddingBottom: COMPOSER_TEXT_PADDING_BOTTOM,
     paddingHorizontal: COMPOSER_TEXT_HORIZONTAL_PADDING,
     paddingTop: COMPOSER_TEXT_PADDING_TOP,
+  },
+  voiceDraftOverlayContentGeometric: {
+    paddingBottom: COMPOSER_TEXT_GEOMETRIC_PADDING_BOTTOM,
+    paddingTop: COMPOSER_TEXT_GEOMETRIC_PADDING_TOP,
   },
   voiceDraftMeasuredBlock: {
     minHeight: MOBILE_COMPOSER_INPUT_LINE_HEIGHT,

--- a/apps/mobile/app/sessions/new.tsx
+++ b/apps/mobile/app/sessions/new.tsx
@@ -3412,7 +3412,7 @@ export default function NewRemoteSessionScreen() {
       ref={voiceDraftScrollRef}
       contentContainerStyle={[
         styles.voiceDraftOverlayContent,
-        !composerCardActive && !composerInputIsMultiline && styles.voiceDraftOverlayContentGeometric,
+        !composerCardActive && styles.voiceDraftOverlayContentGeometric,
       ]}
       onContentSizeChange={() => {
         requestAnimationFrame(() => {

--- a/apps/mobile/src/__tests__/composerVoiceDraftMetrics.test.ts
+++ b/apps/mobile/src/__tests__/composerVoiceDraftMetrics.test.ts
@@ -78,6 +78,7 @@ describe('composer voice draft text metrics', () => {
     expect(composerTextPaddingForPlatform('ios')).toEqual({ top: 6, bottom: 0 });
     expect(composerTextPaddingForPlatform('android')).toEqual({ top: 3, bottom: 3 });
     expect(composerTextPaddingForPlatform('default')).toEqual({ top: 3, bottom: 3 });
+    expect(composerTextPaddingForPlatform('ios', { optical: false })).toEqual({ top: 3, bottom: 3 });
   });
 
   it('renders the real composer TextInput with the shared metrics', () => {
@@ -116,6 +117,8 @@ describe('composer voice draft text metrics', () => {
         .toContain('paddingHorizontal: COMPOSER_TEXT_HORIZONTAL_PADDING');
       expect(overlayContent, `${rel} 覆盖层顶部内边距必须与输入框同源`)
         .toContain('paddingTop: COMPOSER_TEXT_PADDING_TOP');
+      expect(source, `${rel} 收起单行听写覆盖层必须切到几何居中`)
+        .toContain('voiceDraftOverlayContentGeometric');
     }
   });
 

--- a/apps/mobile/src/__tests__/composerVoiceDraftMetrics.test.ts
+++ b/apps/mobile/src/__tests__/composerVoiceDraftMetrics.test.ts
@@ -85,6 +85,8 @@ describe('composer voice draft text metrics', () => {
     const composerRowSource = read(COMPOSER_ROW);
     const block = styleBlock(composerRowSource, 'input');
     expect(composerRowSource).toContain("from '@/session/composerTextPlatformMetrics'");
+    expect(composerRowSource).toContain('const geometricSingleLine = !cardLayout;');
+    expect(composerRowSource).not.toContain('const geometricSingleLine = !cardLayout && !multilineShape;');
     expect(block).toContain('...COMPOSER_TEXT_STYLE');
     expect(block).toContain('paddingBottom: COMPOSER_TEXT_PADDING_BOTTOM');
     expect(block).toContain('paddingHorizontal: COMPOSER_TEXT_HORIZONTAL_PADDING');
@@ -117,8 +119,10 @@ describe('composer voice draft text metrics', () => {
         .toContain('paddingHorizontal: COMPOSER_TEXT_HORIZONTAL_PADDING');
       expect(overlayContent, `${rel} 覆盖层顶部内边距必须与输入框同源`)
         .toContain('paddingTop: COMPOSER_TEXT_PADDING_TOP');
-      expect(source, `${rel} 收起单行听写覆盖层必须切到几何居中`)
-        .toContain('voiceDraftOverlayContentGeometric');
+      expect(source, `${rel} 收起展示态听写覆盖层必须切到几何居中`)
+        .toContain('!composerCardActive && styles.voiceDraftOverlayContentGeometric');
+      expect(source, `${rel} 几何居中不得再看收起前的多行/manual 判定`)
+        .not.toContain('!composerCardActive && !composerInputIsMultiline && styles.voiceDraftOverlayContentGeometric');
     }
   });
 

--- a/apps/mobile/src/__tests__/newSession.test.ts
+++ b/apps/mobile/src/__tests__/newSession.test.ts
@@ -1597,12 +1597,15 @@ describe('new session composer surface', () => {
     expect(newComposerSource).toContain('trailing={composerCardActive || !composerShowCreateButton ? null : renderCreateButton()}');
     expect(newComposerSource).toContain('leading={renderComposerCompactLeading()}');
     expect(newSource).toContain('const renderComposerCompactLeading = () => (');
+    expect(newSource).toContain('styles.composerCompactAttachmentSlot');
     expect(newSource).toContain('styles.composerCompactAttachmentHit');
-    expect(newSource).toContain('styles.composerCompactAttachmentHitArea');
+    expect(newSource).not.toContain('styles.composerCompactAttachmentHitArea');
     expect(newSource).toContain('pointerEvents="none"');
     expect(newSource).toContain('testID="newSession.attachmentToggleButton"');
-    expect(newSource).toContain('overflow: \'visible\'');
-    expect(newSource).toContain('bottom: (MOBILE_COMPOSER_CONTROL_SIZE - MOBILE_COMPOSER_MIN_TOUCH_TARGET) / 2');
+    expect(newSource).toContain('height: MOBILE_COMPOSER_MIN_TOUCH_TARGET');
+    expect(newSource).toContain('width: MOBILE_COMPOSER_MIN_TOUCH_TARGET');
+    expect(newSource).toContain('left: (MOBILE_COMPOSER_CONTROL_SIZE - MOBILE_COMPOSER_MIN_TOUCH_TARGET) / 2');
+    expect(newSource).toContain("position: 'absolute'");
     expect(newSource).toContain('const renderComposerToolbar = () => (');
     expect(newSource).toContain('PaperPlaneIcon');
     expect(newSource).not.toContain('ArrowUp');

--- a/apps/mobile/src/__tests__/newSession.test.ts
+++ b/apps/mobile/src/__tests__/newSession.test.ts
@@ -1598,10 +1598,11 @@ describe('new session composer surface', () => {
     expect(newComposerSource).toContain('leading={renderComposerCompactLeading()}');
     expect(newSource).toContain('const renderComposerCompactLeading = () => (');
     expect(newSource).toContain('styles.composerCompactAttachmentHit');
+    expect(newSource).toContain('styles.composerCompactAttachmentHitArea');
     expect(newSource).toContain('pointerEvents="none"');
     expect(newSource).toContain('testID="newSession.attachmentToggleButton"');
-    expect(newSource).toContain('height: MOBILE_COMPOSER_MIN_TOUCH_TARGET');
-    expect(newSource).toContain('width: MOBILE_COMPOSER_MIN_TOUCH_TARGET');
+    expect(newSource).toContain('overflow: \'visible\'');
+    expect(newSource).toContain('bottom: (MOBILE_COMPOSER_CONTROL_SIZE - MOBILE_COMPOSER_MIN_TOUCH_TARGET) / 2');
     expect(newSource).toContain('const renderComposerToolbar = () => (');
     expect(newSource).toContain('PaperPlaneIcon');
     expect(newSource).not.toContain('ArrowUp');

--- a/apps/mobile/src/__tests__/newSession.test.ts
+++ b/apps/mobile/src/__tests__/newSession.test.ts
@@ -1597,15 +1597,15 @@ describe('new session composer surface', () => {
     expect(newComposerSource).toContain('trailing={composerCardActive || !composerShowCreateButton ? null : renderCreateButton()}');
     expect(newComposerSource).toContain('leading={renderComposerCompactLeading()}');
     expect(newSource).toContain('const renderComposerCompactLeading = () => (');
-    expect(newSource).toContain('styles.composerCompactAttachmentSlot');
+    expect(newSource).not.toContain('styles.composerCompactAttachmentSlot');
     expect(newSource).toContain('styles.composerCompactAttachmentHit');
     expect(newSource).not.toContain('styles.composerCompactAttachmentHitArea');
     expect(newSource).toContain('pointerEvents="none"');
     expect(newSource).toContain('testID="newSession.attachmentToggleButton"');
     expect(newSource).toContain('height: MOBILE_COMPOSER_MIN_TOUCH_TARGET');
     expect(newSource).toContain('width: MOBILE_COMPOSER_MIN_TOUCH_TARGET');
-    expect(newSource).toContain('left: (MOBILE_COMPOSER_CONTROL_SIZE - MOBILE_COMPOSER_MIN_TOUCH_TARGET) / 2');
-    expect(newSource).toContain("position: 'absolute'");
+    expect(newSource).toContain('marginVertical: (MOBILE_COMPOSER_CONTROL_SIZE - MOBILE_COMPOSER_MIN_TOUCH_TARGET) / 2');
+    expect(newSource).not.toContain('left: (MOBILE_COMPOSER_CONTROL_SIZE - MOBILE_COMPOSER_MIN_TOUCH_TARGET) / 2');
     expect(newSource).toContain('const renderComposerToolbar = () => (');
     expect(newSource).toContain('PaperPlaneIcon');
     expect(newSource).not.toContain('ArrowUp');

--- a/apps/mobile/src/__tests__/newSession.test.ts
+++ b/apps/mobile/src/__tests__/newSession.test.ts
@@ -1604,7 +1604,9 @@ describe('new session composer surface', () => {
     expect(newSource).toContain('testID="newSession.attachmentToggleButton"');
     expect(newSource).toContain('height: MOBILE_COMPOSER_MIN_TOUCH_TARGET');
     expect(newSource).toContain('width: MOBILE_COMPOSER_MIN_TOUCH_TARGET');
-    expect(newSource).toContain('marginVertical: (MOBILE_COMPOSER_CONTROL_SIZE - MOBILE_COMPOSER_MIN_TOUCH_TARGET) / 2');
+    expect(newSource).toContain('minWidth: MOBILE_COMPOSER_MIN_TOUCH_TARGET');
+    expect(newSource).not.toContain('marginVertical: (MOBILE_COMPOSER_CONTROL_SIZE - MOBILE_COMPOSER_MIN_TOUCH_TARGET) / 2');
+    expect(newSource).not.toContain('marginHorizontal: (MOBILE_COMPOSER_CONTROL_SIZE - MOBILE_COMPOSER_MIN_TOUCH_TARGET) / 2');
     expect(newSource).not.toContain('left: (MOBILE_COMPOSER_CONTROL_SIZE - MOBILE_COMPOSER_MIN_TOUCH_TARGET) / 2');
     expect(newSource).toContain('const renderComposerToolbar = () => (');
     expect(newSource).toContain('PaperPlaneIcon');

--- a/apps/mobile/src/__tests__/newSession.test.ts
+++ b/apps/mobile/src/__tests__/newSession.test.ts
@@ -1530,7 +1530,7 @@ describe('new session composer surface', () => {
     const createButtonEnd = newSource.indexOf('// 聚焦卡片形态的底部工具排', createButtonStart);
     const createButtonSource = newSource.slice(createButtonStart, createButtonEnd);
     const composerIconButtonStart = newSource.indexOf('composerIconButton: {');
-    const composerIconButtonEnd = newSource.indexOf('composerIconButtonActive:', composerIconButtonStart);
+    const composerIconButtonEnd = newSource.indexOf('composerCompactLeading:', composerIconButtonStart);
     const composerIconButtonStyle = newSource.slice(composerIconButtonStart, composerIconButtonEnd);
     const modelPillStart = newSource.indexOf('modelPill: {');
     const modelPillEnd = newSource.indexOf('modelPillText:', modelPillStart);
@@ -1595,6 +1595,9 @@ describe('new session composer surface', () => {
     expect(newComposerSource).toContain("placeholder={voiceIsListening ? '' : composerPlaceholder}");
     expect(newComposerSource).toContain('scrollEnabled={composerInputScrollEnabled}');
     expect(newComposerSource).toContain('trailing={composerCardActive || !composerShowCreateButton ? null : renderCreateButton()}');
+    expect(newComposerSource).toContain('leading={renderComposerCompactLeading()}');
+    expect(newSource).toContain('const renderComposerCompactLeading = () => (');
+    expect(newSource).toContain('{renderAttachmentToggleButton()}');
     expect(newSource).toContain('const renderComposerToolbar = () => (');
     expect(newSource).toContain('PaperPlaneIcon');
     expect(newSource).not.toContain('ArrowUp');

--- a/apps/mobile/src/__tests__/newSession.test.ts
+++ b/apps/mobile/src/__tests__/newSession.test.ts
@@ -1597,7 +1597,11 @@ describe('new session composer surface', () => {
     expect(newComposerSource).toContain('trailing={composerCardActive || !composerShowCreateButton ? null : renderCreateButton()}');
     expect(newComposerSource).toContain('leading={renderComposerCompactLeading()}');
     expect(newSource).toContain('const renderComposerCompactLeading = () => (');
-    expect(newSource).toContain('{renderAttachmentToggleButton()}');
+    expect(newSource).toContain('styles.composerCompactAttachmentHit');
+    expect(newSource).toContain('pointerEvents="none"');
+    expect(newSource).toContain('testID="newSession.attachmentToggleButton"');
+    expect(newSource).toContain('height: MOBILE_COMPOSER_MIN_TOUCH_TARGET');
+    expect(newSource).toContain('width: MOBILE_COMPOSER_MIN_TOUCH_TARGET');
     expect(newSource).toContain('const renderComposerToolbar = () => (');
     expect(newSource).toContain('PaperPlaneIcon');
     expect(newSource).not.toContain('ArrowUp');

--- a/apps/mobile/src/__tests__/sessionComposerDesktopFirst.test.ts
+++ b/apps/mobile/src/__tests__/sessionComposerDesktopFirst.test.ts
@@ -50,6 +50,7 @@ describe('mobile session composer desktop-first surface', () => {
     const sharedStyleStart = sharedSource.indexOf('const makeMobileComposerInputRowStyles');
     expect(sharedSource).toContain('const geometricSingleLine = !cardLayout;');
     expect(sharedSource).toContain('geometricSingleLine && styles.rowCollapsedTouch');
+    expect(sharedSource).toContain('geometricSingleLine && styles.mainRowCollapsedTouch');
     expect(sharedSource).toContain('geometricSingleLine && inputFrameMinHeight == null && styles.inputFrameSingleLine');
     expect(sharedSource).toContain('inputFrameSingleLine: {');
     expect(sharedSource).toContain('inputGeometricSingleLine: {');
@@ -116,15 +117,15 @@ describe('mobile session composer desktop-first surface', () => {
     expect(composerInputSource).toContain('cardActive={composerCardActive}');
     expect(composerInputSource).toContain('leading={renderComposerCompactLeading()}');
     expect(source).toContain('const renderComposerCompactLeading = () => (');
-    expect(source).toContain('styles.composerCompactAttachmentSlot');
+    expect(source).not.toContain('styles.composerCompactAttachmentSlot');
     expect(source).toContain('styles.composerCompactAttachmentHit');
     expect(source).not.toContain('styles.composerCompactAttachmentHitArea');
     expect(source).toContain('pointerEvents="none"');
     expect(source).toContain('testID="session.attachmentToggleButton"');
     expect(source).toContain('height: MOBILE_COMPOSER_MIN_TOUCH_TARGET');
     expect(source).toContain('width: MOBILE_COMPOSER_MIN_TOUCH_TARGET');
-    expect(source).toContain('left: (MOBILE_COMPOSER_CONTROL_SIZE - MOBILE_COMPOSER_MIN_TOUCH_TARGET) / 2');
-    expect(source).toContain("position: 'absolute'");
+    expect(source).toContain('marginVertical: (MOBILE_COMPOSER_CONTROL_SIZE - MOBILE_COMPOSER_MIN_TOUCH_TARGET) / 2');
+    expect(source).not.toContain('left: (MOBILE_COMPOSER_CONTROL_SIZE - MOBILE_COMPOSER_MIN_TOUCH_TARGET) / 2');
     expect(composerInputSource).toContain('toolbar={renderComposerToolbar()}');
     expect(source).toContain('const renderComposerToolbar = () => (');
     expect(attachmentButtonSource).toContain('<Plus');

--- a/apps/mobile/src/__tests__/sessionComposerDesktopFirst.test.ts
+++ b/apps/mobile/src/__tests__/sessionComposerDesktopFirst.test.ts
@@ -116,10 +116,11 @@ describe('mobile session composer desktop-first surface', () => {
     expect(composerInputSource).toContain('leading={renderComposerCompactLeading()}');
     expect(source).toContain('const renderComposerCompactLeading = () => (');
     expect(source).toContain('styles.composerCompactAttachmentHit');
+    expect(source).toContain('styles.composerCompactAttachmentHitArea');
     expect(source).toContain('pointerEvents="none"');
     expect(source).toContain('testID="session.attachmentToggleButton"');
-    expect(source).toContain('height: MOBILE_COMPOSER_MIN_TOUCH_TARGET');
-    expect(source).toContain('width: MOBILE_COMPOSER_MIN_TOUCH_TARGET');
+    expect(source).toContain('overflow: \'visible\'');
+    expect(source).toContain('bottom: (MOBILE_COMPOSER_CONTROL_SIZE - MOBILE_COMPOSER_MIN_TOUCH_TARGET) / 2');
     expect(composerInputSource).toContain('toolbar={renderComposerToolbar()}');
     expect(source).toContain('const renderComposerToolbar = () => (');
     expect(attachmentButtonSource).toContain('<Plus');

--- a/apps/mobile/src/__tests__/sessionComposerDesktopFirst.test.ts
+++ b/apps/mobile/src/__tests__/sessionComposerDesktopFirst.test.ts
@@ -124,7 +124,9 @@ describe('mobile session composer desktop-first surface', () => {
     expect(source).toContain('testID="session.attachmentToggleButton"');
     expect(source).toContain('height: MOBILE_COMPOSER_MIN_TOUCH_TARGET');
     expect(source).toContain('width: MOBILE_COMPOSER_MIN_TOUCH_TARGET');
-    expect(source).toContain('marginVertical: (MOBILE_COMPOSER_CONTROL_SIZE - MOBILE_COMPOSER_MIN_TOUCH_TARGET) / 2');
+    expect(source).toContain('minWidth: MOBILE_COMPOSER_MIN_TOUCH_TARGET');
+    expect(source).not.toContain('marginVertical: (MOBILE_COMPOSER_CONTROL_SIZE - MOBILE_COMPOSER_MIN_TOUCH_TARGET) / 2');
+    expect(source).not.toContain('marginHorizontal: (MOBILE_COMPOSER_CONTROL_SIZE - MOBILE_COMPOSER_MIN_TOUCH_TARGET) / 2');
     expect(source).not.toContain('left: (MOBILE_COMPOSER_CONTROL_SIZE - MOBILE_COMPOSER_MIN_TOUCH_TARGET) / 2');
     expect(composerInputSource).toContain('toolbar={renderComposerToolbar()}');
     expect(source).toContain('const renderComposerToolbar = () => (');

--- a/apps/mobile/src/__tests__/sessionComposerDesktopFirst.test.ts
+++ b/apps/mobile/src/__tests__/sessionComposerDesktopFirst.test.ts
@@ -49,6 +49,7 @@ describe('mobile session composer desktop-first surface', () => {
     const composerSurfaceStyle = source.slice(composerSurfaceStart, composerSurfaceEnd);
     const sharedStyleStart = sharedSource.indexOf('const makeMobileComposerInputRowStyles');
     expect(sharedSource).toContain('const geometricSingleLine = !cardLayout;');
+    expect(sharedSource).toContain('geometricSingleLine && styles.rowCollapsedTouch');
     expect(sharedSource).toContain('geometricSingleLine && inputFrameMinHeight == null && styles.inputFrameSingleLine');
     expect(sharedSource).toContain('inputFrameSingleLine: {');
     expect(sharedSource).toContain('inputGeometricSingleLine: {');
@@ -65,7 +66,7 @@ describe('mobile session composer desktop-first surface', () => {
     const inlineButtonEnd = source.indexOf('composerToolButtonActive:', inlineButtonStart);
     const inlineButtonStyle = source.slice(inlineButtonStart, inlineButtonEnd);
     const floatingButtonStart = sharedSource.indexOf('voiceButtonAnchor: {', sharedStyleStart);
-    const floatingButtonEnd = sharedSource.indexOf('}', floatingButtonStart);
+    const floatingButtonEnd = sharedSource.indexOf('voiceButtonAnchorWithTrailing:', floatingButtonStart);
     const floatingButtonStyle = sharedSource.slice(floatingButtonStart, floatingButtonEnd);
     const sendButtonStart = source.indexOf('sendButton: {');
     const sendButtonEnd = source.indexOf('sendButtonInactive:', sendButtonStart);
@@ -115,12 +116,15 @@ describe('mobile session composer desktop-first surface', () => {
     expect(composerInputSource).toContain('cardActive={composerCardActive}');
     expect(composerInputSource).toContain('leading={renderComposerCompactLeading()}');
     expect(source).toContain('const renderComposerCompactLeading = () => (');
+    expect(source).toContain('styles.composerCompactAttachmentSlot');
     expect(source).toContain('styles.composerCompactAttachmentHit');
-    expect(source).toContain('styles.composerCompactAttachmentHitArea');
+    expect(source).not.toContain('styles.composerCompactAttachmentHitArea');
     expect(source).toContain('pointerEvents="none"');
     expect(source).toContain('testID="session.attachmentToggleButton"');
-    expect(source).toContain('overflow: \'visible\'');
-    expect(source).toContain('bottom: (MOBILE_COMPOSER_CONTROL_SIZE - MOBILE_COMPOSER_MIN_TOUCH_TARGET) / 2');
+    expect(source).toContain('height: MOBILE_COMPOSER_MIN_TOUCH_TARGET');
+    expect(source).toContain('width: MOBILE_COMPOSER_MIN_TOUCH_TARGET');
+    expect(source).toContain('left: (MOBILE_COMPOSER_CONTROL_SIZE - MOBILE_COMPOSER_MIN_TOUCH_TARGET) / 2');
+    expect(source).toContain("position: 'absolute'");
     expect(composerInputSource).toContain('toolbar={renderComposerToolbar()}');
     expect(source).toContain('const renderComposerToolbar = () => (');
     expect(attachmentButtonSource).toContain('<Plus');
@@ -233,7 +237,8 @@ describe('mobile session composer desktop-first surface', () => {
     expect(inputStyle).toContain('paddingHorizontal: COMPOSER_TEXT_HORIZONTAL_PADDING');
     expect(inputStyle).toContain('paddingTop: COMPOSER_TEXT_PADDING_TOP');
     expect(inputStyle).toContain("textAlignVertical: 'top'");
-    expect(floatingButtonStyle).toContain("bottom: Platform.OS === 'ios' ? 8 : 11");
+    expect(floatingButtonStyle).toContain("top: '50%'");
+    expect(floatingButtonStyle).toContain('translateY: -MOBILE_COMPOSER_CONTROL_SIZE / 2');
     // Composer input is a single stable, always-multiline, always-inline instance (no compact↔expanded
     // swap that remounts the native input) so the first tap reliably opens the keyboard — guards the
     // "two taps to focus" regression. Compact rest look kept via minHeight (no fixed height that clips).
@@ -506,7 +511,8 @@ describe('mobile session composer desktop-first surface', () => {
     expect(inlineButtonStyle).not.toContain('width: 42');
     expect(floatingButtonStyle).toContain("position: 'absolute'");
     expect(floatingButtonStyle).toContain('right: MOBILE_COMPOSER_VOICE_ANCHOR_RIGHT');
-    expect(floatingButtonStyle).toContain("bottom: Platform.OS === 'ios' ? 8 : 11");
+    expect(floatingButtonStyle).toContain("top: '50%'");
+    expect(floatingButtonStyle).toContain('translateY: -MOBILE_COMPOSER_CONTROL_SIZE / 2');
     expect(floatingButtonStyle).toContain('zIndex: 2');
     expect(sharedSource).toContain('right: spacing.md + MOBILE_COMPOSER_CONTROL_SIZE + MOBILE_COMPOSER_TOOL_GAP');
     expect(sendButtonStyle).toContain('height: 34');

--- a/apps/mobile/src/__tests__/sessionComposerDesktopFirst.test.ts
+++ b/apps/mobile/src/__tests__/sessionComposerDesktopFirst.test.ts
@@ -115,7 +115,11 @@ describe('mobile session composer desktop-first surface', () => {
     expect(composerInputSource).toContain('cardActive={composerCardActive}');
     expect(composerInputSource).toContain('leading={renderComposerCompactLeading()}');
     expect(source).toContain('const renderComposerCompactLeading = () => (');
-    expect(source).toContain('{renderComposerAttachmentButton()}');
+    expect(source).toContain('styles.composerCompactAttachmentHit');
+    expect(source).toContain('pointerEvents="none"');
+    expect(source).toContain('testID="session.attachmentToggleButton"');
+    expect(source).toContain('height: MOBILE_COMPOSER_MIN_TOUCH_TARGET');
+    expect(source).toContain('width: MOBILE_COMPOSER_MIN_TOUCH_TARGET');
     expect(composerInputSource).toContain('toolbar={renderComposerToolbar()}');
     expect(source).toContain('const renderComposerToolbar = () => (');
     expect(attachmentButtonSource).toContain('<Plus');

--- a/apps/mobile/src/__tests__/sessionComposerDesktopFirst.test.ts
+++ b/apps/mobile/src/__tests__/sessionComposerDesktopFirst.test.ts
@@ -48,11 +48,13 @@ describe('mobile session composer desktop-first surface', () => {
     const composerSurfaceEnd = source.indexOf('composerSurfaceCompact:', composerSurfaceStart);
     const composerSurfaceStyle = source.slice(composerSurfaceStart, composerSurfaceEnd);
     const sharedStyleStart = sharedSource.indexOf('const makeMobileComposerInputRowStyles');
+    expect(sharedSource).toContain('const geometricSingleLine = !cardLayout;');
     expect(sharedSource).toContain('geometricSingleLine && inputFrameMinHeight == null && styles.inputFrameSingleLine');
     expect(sharedSource).toContain('inputFrameSingleLine: {');
     expect(sharedSource).toContain('inputGeometricSingleLine: {');
     expect(sharedSource).toContain('textAlignVertical: \'center\'');
-    expect(source).toContain('opticalPadding={composerCardActive || composerInputIsMultiline}');
+    expect(source).toContain('opticalPadding={composerCardActive}');
+    expect(source).not.toContain('opticalPadding={composerCardActive || composerInputIsMultiline}');
     const composerInputRowStart = sharedSource.indexOf('row: {', sharedStyleStart);
     const composerInputRowEnd = sharedSource.indexOf('rowMultiline:', composerInputRowStart);
     const composerInputRowStyle = sharedSource.slice(composerInputRowStart, composerInputRowEnd);
@@ -359,7 +361,8 @@ describe('mobile session composer desktop-first surface', () => {
     expect(source).toContain('ref={voiceDraftScrollRef}');
     expect(source).toContain('contentContainerStyle={[');
     expect(source).toContain('styles.voiceDraftOverlayContent');
-    expect(source).toContain('styles.voiceDraftOverlayContentGeometric');
+    expect(source).toContain('!composerCardActive && styles.voiceDraftOverlayContentGeometric');
+    expect(source).not.toContain('!composerCardActive && !composerInputIsMultiline && styles.voiceDraftOverlayContentGeometric');
     // 听写期间禁止碰隐藏编辑器的 caret(2026-07-28):setSelectionToEnd 底层是
     // focusEditor,WebView 程序化 focus + keyboardDisplayRequiresUserAction=false
     // 会在点语音的同时弹出软键盘。听写文字由覆盖层渲染,caret 只在用户点输入框

--- a/apps/mobile/src/__tests__/sessionComposerDesktopFirst.test.ts
+++ b/apps/mobile/src/__tests__/sessionComposerDesktopFirst.test.ts
@@ -48,6 +48,11 @@ describe('mobile session composer desktop-first surface', () => {
     const composerSurfaceEnd = source.indexOf('composerSurfaceCompact:', composerSurfaceStart);
     const composerSurfaceStyle = source.slice(composerSurfaceStart, composerSurfaceEnd);
     const sharedStyleStart = sharedSource.indexOf('const makeMobileComposerInputRowStyles');
+    expect(sharedSource).toContain('geometricSingleLine && inputFrameMinHeight == null && styles.inputFrameSingleLine');
+    expect(sharedSource).toContain('inputFrameSingleLine: {');
+    expect(sharedSource).toContain('inputGeometricSingleLine: {');
+    expect(sharedSource).toContain('textAlignVertical: \'center\'');
+    expect(source).toContain('opticalPadding={composerCardActive || composerInputIsMultiline}');
     const composerInputRowStart = sharedSource.indexOf('row: {', sharedStyleStart);
     const composerInputRowEnd = sharedSource.indexOf('rowMultiline:', composerInputRowStart);
     const composerInputRowStyle = sharedSource.slice(composerInputRowStart, composerInputRowEnd);
@@ -106,6 +111,9 @@ describe('mobile session composer desktop-first surface', () => {
     expect(source).toContain('<Scan color={colors.textPrimary}');
     expect(source).toContain('<Folder color={colors.textPrimary}');
     expect(composerInputSource).toContain('cardActive={composerCardActive}');
+    expect(composerInputSource).toContain('leading={renderComposerCompactLeading()}');
+    expect(source).toContain('const renderComposerCompactLeading = () => (');
+    expect(source).toContain('{renderComposerAttachmentButton()}');
     expect(composerInputSource).toContain('toolbar={renderComposerToolbar()}');
     expect(source).toContain('const renderComposerToolbar = () => (');
     expect(attachmentButtonSource).toContain('<Plus');
@@ -349,7 +357,9 @@ describe('mobile session composer desktop-first surface', () => {
     expect(composerInputSource).not.toContain('inputRef={composerInputRef}');
     expect(sharedSource).toContain('ref={inputRef as never}');
     expect(source).toContain('ref={voiceDraftScrollRef}');
-    expect(source).toContain('contentContainerStyle={styles.voiceDraftOverlayContent}');
+    expect(source).toContain('contentContainerStyle={[');
+    expect(source).toContain('styles.voiceDraftOverlayContent');
+    expect(source).toContain('styles.voiceDraftOverlayContentGeometric');
     // 听写期间禁止碰隐藏编辑器的 caret(2026-07-28):setSelectionToEnd 底层是
     // focusEditor,WebView 程序化 focus + keyboardDisplayRequiresUserAction=false
     // 会在点语音的同时弹出软键盘。听写文字由覆盖层渲染,caret 只在用户点输入框

--- a/apps/mobile/src/session/ComposerRichInput.tsx
+++ b/apps/mobile/src/session/ComposerRichInput.tsx
@@ -41,6 +41,7 @@ export interface ComposerRichInputProps {
   onPasteImages?: (uris: string[]) => void;
   onPasteImagesLoadFailed?: () => void;
   onPasteImagesLoading?: (count: number) => void;
+  opticalPadding?: boolean;
   placeholder: string;
   resolveSessionLinkLabel?: (href: string) => Promise<ResolvedSessionLinkSemantic | null>;
   testID?: string;
@@ -70,6 +71,7 @@ export const ComposerRichInput = forwardRef<ComposerRichInputHandle, ComposerRic
     onPasteImages,
     onPasteImagesLoadFailed,
     onPasteImagesLoading,
+    opticalPadding = true,
     placeholder,
     resolveSessionLinkLabel,
     testID,
@@ -95,6 +97,7 @@ export const ComposerRichInput = forwardRef<ComposerRichInputHandle, ComposerRic
       document,
       editable,
       maxHeight,
+      opticalPadding,
       platform: Platform.OS === 'ios' ? 'ios' as const : Platform.OS === 'android' ? 'android' as const : 'default' as const,
       placeholder,
       theme,
@@ -107,12 +110,14 @@ export const ComposerRichInput = forwardRef<ComposerRichInputHandle, ComposerRic
       accessibilityLabel,
       editable,
       maxHeight,
+      opticalPadding,
       placeholder,
       theme,
     }), [
       accessibilityLabel,
       editable,
       maxHeight,
+      opticalPadding,
       placeholder,
       theme.background,
       theme.border,

--- a/apps/mobile/src/session/MobileComposerInputRow.tsx
+++ b/apps/mobile/src/session/MobileComposerInputRow.tsx
@@ -285,6 +285,7 @@ export function MobileComposerInputRow({
       style={[
         styles.row,
         compact && styles.rowCompact,
+        geometricSingleLine && styles.rowCollapsedTouch,
         !geometricSingleLine && multilineShape && styles.rowMultiline,
         cardLayout && styles.rowCard,
         rowStyle,
@@ -512,9 +513,15 @@ const makeMobileComposerInputRowStyles = (colors: ThemeColors) => ({
     borderWidth: StyleSheet.hairlineWidth,
     flexDirection: 'column',
     minHeight: 50,
+    overflow: 'visible',
     paddingHorizontal: spacing.md,
     paddingVertical: 10,
     position: 'relative',
+  },
+  // 收起态给 leading 的 44pt 热区留出父边界,避免溢出子节点点不到。
+  rowCollapsedTouch: {
+    minHeight: MOBILE_COMPOSER_MIN_TOUCH_TARGET + 6,
+    paddingVertical: 3,
   },
   rowMultiline: {
     borderRadius: 30, // 组件几何:composer 聚焦形态专用,非通用圆角档
@@ -537,6 +544,7 @@ const makeMobileComposerInputRowStyles = (colors: ThemeColors) => ({
     flexGrow: 1,
     gap: MOBILE_COMPOSER_TOOL_GAP,
     minWidth: 0,
+    overflow: 'visible',
   },
   mainRowMultiline: {
     alignItems: 'flex-end',
@@ -598,11 +606,13 @@ const makeMobileComposerInputRowStyles = (colors: ThemeColors) => ({
   // 语音按钮的 absolute 锚点：简洁态贴输入行右侧垂直居中；
   // 有发送按钮时向左让位；卡片态下沉到底部工具排的占位上。
   voiceButtonAnchor: {
-    // iOS 的文字 padding 是 6/0,按钮随文字下移 3pt；Android 保持 3/3,
-    // 不应继承 iOS 的补偿。
-    bottom: Platform.OS === 'ios' ? 8 : 11,
+    // 收起态按行垂直居中,与 34pt 加号 / 文字共中线;
+    // 不再钉在底部,避免行高变化后麦克风掉下去。
+    bottom: undefined,
     position: 'absolute',
     right: MOBILE_COMPOSER_VOICE_ANCHOR_RIGHT,
+    top: '50%',
+    transform: [{ translateY: -MOBILE_COMPOSER_CONTROL_SIZE / 2 }],
     zIndex: 2,
   },
   voiceButtonAnchorWithTrailing: {
@@ -610,6 +620,8 @@ const makeMobileComposerInputRowStyles = (colors: ThemeColors) => ({
   },
   voiceButtonAnchorCard: {
     bottom: 8,
+    top: undefined,
+    transform: [],
   },
   // 外层横跨全行但 box-none 穿透触摸，只有中间的窄命中条接手势，
   // 避免与左右两侧按钮的 hitSlop 抢触摸。

--- a/apps/mobile/src/session/MobileComposerInputRow.tsx
+++ b/apps/mobile/src/session/MobileComposerInputRow.tsx
@@ -297,6 +297,7 @@ export function MobileComposerInputRow({
       <View
         style={[
           styles.mainRow,
+          geometricSingleLine && styles.mainRowCollapsedTouch,
           !geometricSingleLine && multilineShape && styles.mainRowMultiline,
           !cardLayout && voicePlacement?.inline && styles.mainRowVoiceInset,
         ]}
@@ -545,6 +546,9 @@ const makeMobileComposerInputRowStyles = (colors: ThemeColors) => ({
     gap: MOBILE_COMPOSER_TOOL_GAP,
     minWidth: 0,
     overflow: 'visible',
+  },
+  mainRowCollapsedTouch: {
+    minHeight: MOBILE_COMPOSER_MIN_TOUCH_TARGET,
   },
   mainRowMultiline: {
     alignItems: 'flex-end',

--- a/apps/mobile/src/session/MobileComposerInputRow.tsx
+++ b/apps/mobile/src/session/MobileComposerInputRow.tsx
@@ -226,7 +226,10 @@ export function MobileComposerInputRow({
 }: MobileComposerInputRowProps) {
   const styles = useThemedStyles(makeMobileComposerInputRowStyles);
   const cardLayout = cardActive === true;
-  const geometricSingleLine = !cardLayout && !multilineShape;
+  // 几何居中只看当前是不是收起展示态。resize 在 collapsed 下会把可见高度钉成单行,
+  // 但 mode/manual 与多行草稿判定仍会让 multilineShape 为 true;若据此关掉几何居中,
+  // 收起态文字会继续走 iOS 6/0 光学偏移,对不齐新增的 34pt +。
+  const geometricSingleLine = !cardLayout;
   // RN 里显式 height 压过 minHeight:manual 定高(用户拖过高度)时 frameHeight 可能小于
   // inputFrameMinHeight,直接铺开会把听写停止命中区又压回不足 44pt。数值高度在这里
   // 先 clamp;拖拽中的 Animated 值无法在 JS 侧 clamp(会打断跟手),那一瞬保持动画值,
@@ -282,7 +285,7 @@ export function MobileComposerInputRow({
       style={[
         styles.row,
         compact && styles.rowCompact,
-        multilineShape && styles.rowMultiline,
+        !geometricSingleLine && multilineShape && styles.rowMultiline,
         cardLayout && styles.rowCard,
         rowStyle,
       ]}
@@ -293,7 +296,7 @@ export function MobileComposerInputRow({
       <View
         style={[
           styles.mainRow,
-          multilineShape && styles.mainRowMultiline,
+          !geometricSingleLine && multilineShape && styles.mainRowMultiline,
           !cardLayout && voicePlacement?.inline && styles.mainRowVoiceInset,
         ]}
       >

--- a/apps/mobile/src/session/MobileComposerInputRow.tsx
+++ b/apps/mobile/src/session/MobileComposerInputRow.tsx
@@ -27,6 +27,8 @@ import {
   COMPOSER_TEXT_VERTICAL_PADDING,
 } from '@/session/composerTextMetrics';
 import {
+  COMPOSER_TEXT_GEOMETRIC_PADDING_BOTTOM,
+  COMPOSER_TEXT_GEOMETRIC_PADDING_TOP,
   COMPOSER_TEXT_PADDING_BOTTOM,
   COMPOSER_TEXT_PADDING_TOP,
 } from '@/session/composerTextPlatformMetrics';
@@ -224,6 +226,7 @@ export function MobileComposerInputRow({
 }: MobileComposerInputRowProps) {
   const styles = useThemedStyles(makeMobileComposerInputRowStyles);
   const cardLayout = cardActive === true;
+  const geometricSingleLine = !cardLayout && !multilineShape;
   // RN 里显式 height 压过 minHeight:manual 定高(用户拖过高度)时 frameHeight 可能小于
   // inputFrameMinHeight,直接铺开会把听写停止命中区又压回不足 44pt。数值高度在这里
   // 先 clamp;拖拽中的 Animated 值无法在 JS 侧 clamp(会打断跟手),那一瞬保持动画值,
@@ -266,6 +269,7 @@ export function MobileComposerInputRow({
       selectionColor={selectionColor}
       style={[
         styles.input,
+        geometricSingleLine && styles.inputGeometricSingleLine,
         { maxHeight },
         inputStyle,
       ]}
@@ -297,6 +301,8 @@ export function MobileComposerInputRow({
         <Animated.View
           style={[
             styles.inputFrame,
+            // 收起单行与 34pt + 并排：输入盒在行内居中。
+            geometricSingleLine && inputFrameMinHeight == null && styles.inputFrameSingleLine,
             inputFrameMinHeight != null && { minHeight: inputFrameMinHeight },
             resolvedInputFrameHeight != null && { height: resolvedInputFrameHeight },
           ]}
@@ -542,6 +548,9 @@ const makeMobileComposerInputRowStyles = (colors: ThemeColors) => ({
     minWidth: 0,
     position: 'relative',
   },
+  inputFrameSingleLine: {
+    alignItems: 'center',
+  },
   // TextInputWrapper(expo-paste-input)接管 TextInput 在 inputFrame row 里的
   // flex:1 位置;内部保持 row + stretch,TextInput 自身 flex:1 继续填满,
   // 内容自动增长与显式 inputFrameHeight(拖高)两条高度链都不经它中断。
@@ -577,6 +586,11 @@ const makeMobileComposerInputRowStyles = (colors: ThemeColors) => ({
     paddingHorizontal: COMPOSER_TEXT_HORIZONTAL_PADDING,
     paddingTop: COMPOSER_TEXT_PADDING_TOP,
     textAlignVertical: 'top',
+  },
+  inputGeometricSingleLine: {
+    paddingBottom: COMPOSER_TEXT_GEOMETRIC_PADDING_BOTTOM,
+    paddingTop: COMPOSER_TEXT_GEOMETRIC_PADDING_TOP,
+    textAlignVertical: 'center',
   },
   // 语音按钮的 absolute 锚点：简洁态贴输入行右侧垂直居中；
   // 有发送按钮时向左让位；卡片态下沉到底部工具排的占位上。

--- a/apps/mobile/src/session/composerRichInputHtml.ts
+++ b/apps/mobile/src/session/composerRichInputHtml.ts
@@ -30,6 +30,7 @@ export interface ComposerRichInputConfig {
   document: ComposerDocument;
   editable: boolean;
   maxHeight: number;
+  opticalPadding?: boolean;
   placeholder: string;
   platform?: ComposerTextPlatform;
   theme: ComposerRichInputTheme;
@@ -42,7 +43,9 @@ export interface ComposerRichInputConfig {
  */
 export function buildComposerRichInputHtml(config: ComposerRichInputConfig): string {
   const bootstrap = JSON.stringify(config).replace(/</g, '\\u003c');
-  const composerTextPadding = composerTextPaddingForPlatform(config.platform ?? 'ios');
+  const composerTextPadding = composerTextPaddingForPlatform(config.platform ?? 'ios', {
+    optical: config.opticalPadding !== false,
+  });
   return `<!doctype html>
 <html><head><meta name="viewport" content="width=device-width,initial-scale=1,maximum-scale=1,user-scalable=no">
 <style>
@@ -92,6 +95,22 @@ export function buildComposerRichInputHtml(config: ComposerRichInputConfig): str
     style.setProperty('--border', config.theme.border);
     style.setProperty('--focus', config.theme.focus);
     style.setProperty('--max-height', config.maxHeight + 'px');
+    const padding = ${JSON.stringify({
+      ios: {
+        optical: composerTextPaddingForPlatform('ios'),
+        geometric: composerTextPaddingForPlatform('ios', { optical: false }),
+      },
+      android: {
+        optical: composerTextPaddingForPlatform('android'),
+        geometric: composerTextPaddingForPlatform('android', { optical: false }),
+      },
+      default: {
+        optical: composerTextPaddingForPlatform('default'),
+        geometric: composerTextPaddingForPlatform('default', { optical: false }),
+      },
+    })}[(config.platform || 'ios')][config.opticalPadding === false ? 'geometric' : 'optical'];
+    root.style.paddingTop = padding.top + 'px';
+    root.style.paddingBottom = padding.bottom + 'px';
     root.dataset.placeholder = config.placeholder;
     root.setAttribute('aria-label', config.accessibilityLabel);
     root.contentEditable = config.editable ? 'true' : 'false';

--- a/apps/mobile/src/session/composerTextMetrics.ts
+++ b/apps/mobile/src/session/composerTextMetrics.ts
@@ -42,13 +42,21 @@ export interface ComposerTextPadding {
   top: number;
 }
 
-export function composerTextPaddingForPlatform(platform: ComposerTextPlatform): ComposerTextPadding {
-  const opticalOffset = platform === 'ios' ? COMPOSER_TEXT_OPTICAL_OFFSET_Y : 0;
+export function composerTextPaddingForPlatform(
+  platform: ComposerTextPlatform,
+  options: { optical?: boolean } = {},
+): ComposerTextPadding {
+  const opticalOffset = options.optical !== false && platform === 'ios'
+    ? COMPOSER_TEXT_OPTICAL_OFFSET_Y
+    : 0;
   return {
     bottom: COMPOSER_TEXT_VERTICAL_PADDING - opticalOffset,
     top: COMPOSER_TEXT_VERTICAL_PADDING + opticalOffset,
   };
 }
+
+/** 收起单行与 34pt + / 麦克风并排时用几何居中，不再做 iOS 光学下移。 */
+export const COMPOSER_TEXT_GEOMETRIC_PADDING = composerTextPaddingForPlatform('default');
 
 // Node-side consumers and the existing iOS WebView tests use iOS as the
 // canonical reference. React Native consumers import the platform adapter.

--- a/apps/mobile/src/session/composerTextPlatformMetrics.ts
+++ b/apps/mobile/src/session/composerTextPlatformMetrics.ts
@@ -1,5 +1,6 @@
 import { Platform } from 'react-native';
 import {
+  COMPOSER_TEXT_GEOMETRIC_PADDING,
   composerTextPaddingForPlatform,
   type ComposerTextPlatform,
 } from '@/session/composerTextMetrics';
@@ -15,3 +16,5 @@ const composerTextPadding = composerTextPaddingForPlatform(composerTextPlatform)
 /** Platform-specific padding adapter; the base metrics remain node-testable. */
 export const COMPOSER_TEXT_PADDING_TOP = composerTextPadding.top;
 export const COMPOSER_TEXT_PADDING_BOTTOM = composerTextPadding.bottom;
+export const COMPOSER_TEXT_GEOMETRIC_PADDING_TOP = COMPOSER_TEXT_GEOMETRIC_PADDING.top;
+export const COMPOSER_TEXT_GEOMETRIC_PADDING_BOTTOM = COMPOSER_TEXT_GEOMETRIC_PADDING.bottom;


### PR DESCRIPTION
## 这次改了什么

### 摘要

手机输入框没点开时，左边也能看到附件 `+`。点它直接打开原来的照片 / 拍照 / 文件面板，不用先聚焦输入框。收起单行的占位文字也改成和 `+`、麦克风同一条中线。

### 变更类型

- [x] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#898
- 本 PR 包含：
  - 会话页、新建页收起态输入框左侧露出同一个附件 `+`
  - 收起单行文字 / 占位 / 听写覆盖层改为几何居中，与 34pt `+`、麦克风共中线
  - 收起态加号可见层仍是 34pt；热区流内就是 44×44，祖先链不再靠负 margin 或溢出子节点
  - 展开或多行时仍走原来的 iOS 光学偏移
- 明确不包含：不改附件上传协议、原生依赖、runtime fingerprint、附件选择器实现
- 用户可见变化：未聚焦时即可点 `+` 加附件；收起态「继续聊一聊」与加号垂直对齐
- 是否存在 breaking change：无

### UI 变化

- 平台：iOS Simulator（Cindy Global 开发包，`dash/composer-collapsed-plus`，Metro 8081）
- 引用的设计规范：
  - `docs/design-rules/DESIGN.md` §4 Buttons：附件入口复用现有 34pt pill 控件和主题 token，Light / Dark 都走现有 themed styles
  - `apps/mobile/docs/mobile-design-guide.md` §5：主操作命中区 ≥ 44×44；收起态可见加号仍是 34pt，热区流内就是 44×44，不靠负 margin、溢出子节点或 hitSlop
  - `docs/design-rules/DESIGN.md` 双模式交付：颜色走语义 token，不新增硬编码色

## 怎么验证的

### 自动验证

```text
bash /Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh /Users/dash/Code/Cindy/cindy-composer-collapsed-plus
结果：GATE_EXIT=0

pnpm --filter mobile run --if-present typecheck
结果：通过

pnpm --filter mobile exec vitest run \
  src/__tests__/sessionComposerDesktopFirst.test.ts \
  src/__tests__/newSession.test.ts \
  src/__tests__/composerVoiceDraftMetrics.test.ts
结果：3 files / 139 tests 通过
```

### 收起态加号不变量

- 可见加号仍是 34pt，与文字、麦克风共中线
- 热区流内就是 44×44；从加号到 `row` 的整条祖先链都必须自己覆盖这 44pt，不能靠负 margin、溢出子节点或 hitSlop

### 手工验证

- 平台：Cindy 内置 iOS Simulator，iPhone 17，开发包 `com.xd.cindy`
- worktree：`cindy-composer-collapsed-plus`，分支 `dash/composer-collapsed-plus`
- Metro：本 worktree 的 8081，指纹 `dash/composer-collapsed-plus@3f772bece+…`
- 打开已有任务，不点输入框：左侧可见 `+`，点开即照片 / 拍照 / 文件
- 收起态「继续聊一聊」与 `+`、麦克风垂直对齐
- 点进输入框后底栏仍只有一个 `+`

### 未执行的验证

- Android 真机未测
- Dark 模式未单独目检；颜色复用现有 token

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Mobile 会话页与新建页的收起态输入框
- 回滚 / 降级方式：回退本 commit 即可
- 存量插件影响：无

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因




