### PR TITLE
fix(catalog): 给 Luna 和 GPT-5.4 Nano 补上默认思考档

### DIFF
--- a/packages/model-providers/catalog/model-registry.json
+++ b/packages/model-providers/catalog/model-registry.json
@@ -142,6 +142,7 @@
       "contextWindow": 1050000,
       "maxOutputTokens": 128000,
       "efforts": ["low", "medium", "high", "xhigh", "max"],
+      "defaultEffort": "high",
       "sortOrder": 17,
       "routes": [
         {
@@ -1607,6 +1608,7 @@
       "contextWindow": 400000,
       "maxOutputTokens": 128000,
       "efforts": ["low", "medium", "high", "xhigh"],
+      "defaultEffort": "high",
       "sortOrder": 101,
       "defaultEnabled": false,
       "routes": [

--- a/packages/model-providers/catalog/model-registry.json
+++ b/packages/model-providers/catalog/model-registry.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "updatedAt": "2026-08-05T00:00:00.000Z",
+  "updatedAt": "2026-08-14T00:00:00.000Z",
   "models": [
     {
       "id": "openai/gpt-5.6-sol",

--- a/packages/model-providers/src/__tests__/catalog.test.ts
+++ b/packages/model-providers/src/__tests__/catalog.test.ts
@@ -117,6 +117,9 @@ describe('bundled catalog validity (dynamic-first contract)', () => {
       efforts: ['low', 'medium', 'high', 'xhigh'],
       defaultEffort: 'high',
     });
+    // Corrections must forward-fix: same updatedAt + different content is a
+    // conflict, so cached clients would keep the entries without defaultEffort.
+    expect(Date.parse(registry!.updatedAt)).toBeGreaterThan(Date.parse('2026-08-05T00:00:00.000Z'));
   });
 
   it('has exactly the built-in providers in stable order', () => {

--- a/packages/model-providers/src/__tests__/catalog.test.ts
+++ b/packages/model-providers/src/__tests__/catalog.test.ts
@@ -100,6 +100,25 @@ describe('bundled catalog validity (dynamic-first contract)', () => {
     expect(() => parseCatalog(BUNDLED_CATALOG)).not.toThrow();
   });
 
+  it('keeps selectable registry efforts self-consistent with defaultEffort', () => {
+    const registry = BUNDLED_CATALOG.modelRegistry;
+    expect(registry).toBeDefined();
+    for (const entry of registry!.models) {
+      const efforts = entry.efforts ?? [];
+      if (efforts.length === 0) continue;
+      expect(entry.defaultEffort, entry.id).toBeTruthy();
+      expect(efforts, entry.id).toContain(entry.defaultEffort);
+    }
+    expect(registryEntryForRoute('openai', 'gpt-5.6-luna')).toMatchObject({
+      efforts: ['low', 'medium', 'high', 'xhigh', 'max'],
+      defaultEffort: 'high',
+    });
+    expect(registryEntryForRoute('openai', 'gpt-5.4-nano')).toMatchObject({
+      efforts: ['low', 'medium', 'high', 'xhigh'],
+      defaultEffort: 'high',
+    });
+  });
+
   it('has exactly the built-in providers in stable order', () => {
     // 顺序契约:决定选择器分段顺序与 deriveAvailableModels first-wins 优先级。
     expect(BUNDLED_CATALOG.providers.map((p) => p.id)).toEqual(['anthropic', 'openai', 'xai', 'xd', 'gemini']);


### PR DESCRIPTION
## 这次改了什么

### 摘要

`gpt-5.6-luna` 和 `gpt-5.4-nano` 在模型目录里有 `efforts`，却没有自洽的 `defaultEffort`。选择器会把这种行当成无法独立成立的模型丢掉，所以远程列表修好整表失败后，这两条自己仍可能不出现。本 PR 按同族 GPT 模型补上默认档 `high`，并加一条目录不变量测试，避免再漏。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无；从 #2644 拆出的目录数据修复
- 本 PR 包含：给 `openai/gpt-5.6-luna` 和 `openai/gpt-5.4-nano` 补 `defaultEffort: "high"`；bundled catalog 增加「有 efforts 就必须有匹配 defaultEffort」测试
- 明确不包含：远程列表容错（#2644）；不改选择器解析契约；不改其它模型的默认档
- 用户可见变化：Luna 和 GPT-5.4 Nano 会重新出现在本机 / 远程模型列表里，默认思考档与同族 GPT 一致为 high
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter @cindy/model-providers exec vitest run src/__tests__/catalog.test.ts src/__tests__/modelRegistry.test.ts
结果：2 files / 52 tests passed

pnpm --filter @cindy/model-providers run build
结果：tsc --noEmit 通过（该包没有 typecheck script）

bash /Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh /Users/dash/Code/Cindy/cindy-fix-luna-default-effort
结果：GATE_EXIT=0
```

### 手工验证

不涉及。这是目录数据修复，选择器是否重新显示 Luna / Nano 需要装到本机或远程设备后再看。

### 未执行的验证

未在运行中的 Desktop 上核对 Luna / Nano 是否重新出现在模型选择器。目录投影与选择器校验已由单测覆盖。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅这两条 registry 行的默认思考档；选择器会重新接受它们
- 回滚 / 降级方式：回退本 PR 即可

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
