### PR TITLE
fix(desktop): 统一设备控制提示与设备列表名称

### DIFF
--- a/apps/desktop/src/main/__tests__/deviceLinkControllerDisplayNameFreshness.test.ts
+++ b/apps/desktop/src/main/__tests__/deviceLinkControllerDisplayNameFreshness.test.ts
@@ -15,6 +15,19 @@ const normalizeName = (name: string): string | null => {
 };
 
 describe('controller display-name directory freshness', () => {
+  it('仅 reset 时保持全局代次单调，但不把连接变化误判为设备名称更新', () => {
+    const freshness = createControllerDisplayNameFreshnessTracker();
+    const requestEpoch = freshness.epoch;
+
+    resetControllerDisplayNameFreshness(freshness);
+
+    expect(freshness.epoch).toBeGreaterThan(requestEpoch);
+    expect(getControllerDisplayNameFreshnessSince(freshness, 'dev-1', requestEpoch)).toEqual({
+      changedAfterRequest: false,
+      authoritativeName: null,
+    });
+  });
+
   it('列表请求跨断线重连时 freshness 代次保持单调，旧响应不得回写', () => {
     const freshness = createControllerDisplayNameFreshnessTracker();
     const setDisplayName = vi.fn();

--- a/apps/desktop/src/main/__tests__/deviceLinkControllerDisplayNameFreshness.test.ts
+++ b/apps/desktop/src/main/__tests__/deviceLinkControllerDisplayNameFreshness.test.ts
@@ -241,6 +241,45 @@ describe('controller display-name directory freshness', () => {
     expect(forgetName).not.toHaveBeenCalled();
   });
 
+  it('selfName 字段存在但为 null 时，有效 deviceName 仍是权威更新', () => {
+    const freshness = createControllerDisplayNameFreshnessTracker();
+    const requestEpoch = freshness.epoch;
+    const setDisplayName = vi.fn();
+    const rememberName = vi.fn();
+    const forgetName = vi.fn();
+
+    seedControllerDisplayNamesFromCache({ 'dev-1': '旧数据库名' }, freshness, setDisplayName);
+    setDisplayName.mockClear();
+
+    applyControllerDisplayNamePresence({
+      deviceId: 'dev-1',
+      name: '新数据库名',
+      selfName: null,
+      freshness,
+      normalizeName,
+      setDisplayName,
+      rememberName,
+      forgetName,
+    });
+    applyControllerDisplayNameDirectorySnapshot({
+      devices: [{ deviceId: 'dev-1', name: '旧数据库名' }],
+      cachedNames: { 'dev-1': '旧数据库名' },
+      freshness,
+      requestEpoch,
+      normalizeName,
+      setDisplayName,
+      rememberName,
+      forgetName,
+    });
+
+    expect(freshness.epoch).toBe(1);
+    expect(freshness.authoritativeNameByDevice.get('dev-1')).toBe('新数据库名');
+    expect(setDisplayName).toHaveBeenCalledTimes(1);
+    expect(setDisplayName).toHaveBeenCalledWith('dev-1', '新数据库名');
+    expect(rememberName).toHaveBeenCalledWith('dev-1', '新数据库名');
+    expect(forgetName).not.toHaveBeenCalled();
+  });
+
   it('无权威名时主机名 presence 仅作内存回退，不阻断后到目录名', () => {
     const freshness = createControllerDisplayNameFreshnessTracker();
     const requestEpoch = freshness.epoch;

--- a/apps/desktop/src/main/__tests__/deviceLinkControllerDisplayNameFreshness.test.ts
+++ b/apps/desktop/src/main/__tests__/deviceLinkControllerDisplayNameFreshness.test.ts
@@ -168,7 +168,7 @@ describe('controller display-name directory freshness', () => {
     expect(rememberName).not.toHaveBeenCalled();
   });
 
-  it('目录权威名不被后到的主机名 presence 覆盖或反写缓存', () => {
+  it('旧协议缺少 selfName 的主机名 presence 不覆盖目录权威名', () => {
     const freshness = createControllerDisplayNameFreshnessTracker();
     const setDisplayName = vi.fn();
     const rememberName = vi.fn();
@@ -190,7 +190,6 @@ describe('controller display-name directory freshness', () => {
     applyControllerDisplayNamePresence({
       deviceId: 'dev-1',
       name: 'Host.local',
-      selfName: 'Host.local',
       freshness,
       normalizeName,
       setDisplayName,
@@ -200,6 +199,45 @@ describe('controller display-name directory freshness', () => {
 
     expect(setDisplayName).not.toHaveBeenCalled();
     expect(rememberName).not.toHaveBeenCalled();
+    expect(forgetName).not.toHaveBeenCalled();
+  });
+
+  it('数据库名改成与 selfName 相同时仍作为权威 presence 即时刷新', () => {
+    const freshness = createControllerDisplayNameFreshnessTracker();
+    const requestEpoch = freshness.epoch;
+    const setDisplayName = vi.fn();
+    const rememberName = vi.fn();
+    const forgetName = vi.fn();
+
+    seedControllerDisplayNamesFromCache({ 'dev-1': '旧数据库名' }, freshness, setDisplayName);
+    setDisplayName.mockClear();
+
+    applyControllerDisplayNamePresence({
+      deviceId: 'dev-1',
+      name: 'Host.local',
+      selfName: 'Host.local',
+      freshness,
+      normalizeName,
+      setDisplayName,
+      rememberName,
+      forgetName,
+    });
+    applyControllerDisplayNameDirectorySnapshot({
+      devices: [{ deviceId: 'dev-1', name: '旧数据库名' }],
+      cachedNames: { 'dev-1': '旧数据库名' },
+      freshness,
+      requestEpoch,
+      normalizeName,
+      setDisplayName,
+      rememberName,
+      forgetName,
+    });
+
+    expect(freshness.epoch).toBe(1);
+    expect(freshness.authoritativeNameByDevice.get('dev-1')).toBe('Host.local');
+    expect(setDisplayName).toHaveBeenCalledTimes(1);
+    expect(setDisplayName).toHaveBeenCalledWith('dev-1', 'Host.local');
+    expect(rememberName).toHaveBeenCalledWith('dev-1', 'Host.local');
     expect(forgetName).not.toHaveBeenCalled();
   });
 
@@ -213,7 +251,6 @@ describe('controller display-name directory freshness', () => {
     applyControllerDisplayNamePresence({
       deviceId: 'dev-1',
       name: 'Host.local',
-      selfName: 'Host.local',
       freshness,
       normalizeName,
       setDisplayName,

--- a/apps/desktop/src/main/__tests__/deviceLinkControllerDisplayNameFreshness.test.ts
+++ b/apps/desktop/src/main/__tests__/deviceLinkControllerDisplayNameFreshness.test.ts
@@ -30,6 +30,7 @@ describe('controller display-name directory freshness', () => {
     applyControllerDisplayNamePresence({
       deviceId: 'dev-1',
       name: '新名称',
+      selfName: 'Host.local',
       freshness,
       normalizeName,
       setDisplayName,
@@ -58,9 +59,13 @@ describe('controller display-name directory freshness', () => {
 
     // 下一次 relay 连接走真实种入 helper，仍从 last-known 得到新名称。
     displayedName = '';
-    seedControllerDisplayNamesFromCache({ 'dev-1': persistedName }, (_deviceId, name) => {
-      displayedName = name;
-    });
+    seedControllerDisplayNamesFromCache(
+      { 'dev-1': persistedName },
+      freshness,
+      (_deviceId, name) => {
+        displayedName = name;
+      },
+    );
     expect(displayedName).toBe('新名称');
   });
 
@@ -86,8 +91,8 @@ describe('controller display-name directory freshness', () => {
     expect(forgetName).not.toHaveBeenCalled();
   });
 
-  it.each(['unknown', 'no', '   '])(
-    '首次连接在目录请求期间收到占位/空 presence(%s)时仍应用有效目录名',
+  it.each(['unknown', 'no'])(
+    '首次连接在目录请求期间收到占位 presence(%s)时仍应用有效目录名',
     (presenceName) => {
       const freshness = createControllerDisplayNameFreshnessTracker();
       const requestEpoch = freshness.epoch;
@@ -128,6 +133,110 @@ describe('controller display-name directory freshness', () => {
       expect(persistedName).toBe('数据库名称');
     },
   );
+
+  it('显式空 presence 推进新鲜度，在途旧目录响应不得恢复旧名', () => {
+    const freshness = createControllerDisplayNameFreshnessTracker();
+    const requestEpoch = freshness.epoch;
+    const setDisplayName = vi.fn();
+    const rememberName = vi.fn();
+    const forgetName = vi.fn();
+
+    applyControllerDisplayNamePresence({
+      deviceId: 'dev-1',
+      name: '',
+      freshness,
+      normalizeName,
+      setDisplayName,
+      rememberName,
+      forgetName,
+    });
+    applyControllerDisplayNameDirectorySnapshot({
+      devices: [{ deviceId: 'dev-1', name: '旧数据库名' }],
+      cachedNames: { 'dev-1': '旧数据库名' },
+      freshness,
+      requestEpoch,
+      normalizeName,
+      setDisplayName,
+      rememberName,
+      forgetName,
+    });
+
+    expect(freshness.epoch).toBe(1);
+    expect(setDisplayName).toHaveBeenCalledTimes(1);
+    expect(setDisplayName).toHaveBeenCalledWith('dev-1', '');
+    expect(forgetName).toHaveBeenCalledWith('dev-1');
+    expect(rememberName).not.toHaveBeenCalled();
+  });
+
+  it('目录权威名不被后到的主机名 presence 覆盖或反写缓存', () => {
+    const freshness = createControllerDisplayNameFreshnessTracker();
+    const setDisplayName = vi.fn();
+    const rememberName = vi.fn();
+    const forgetName = vi.fn();
+
+    applyControllerDisplayNameDirectorySnapshot({
+      devices: [{ deviceId: 'dev-1', name: '数据库展示名' }],
+      cachedNames: {},
+      freshness,
+      requestEpoch: freshness.epoch,
+      normalizeName,
+      setDisplayName,
+      rememberName,
+      forgetName,
+    });
+    setDisplayName.mockClear();
+    rememberName.mockClear();
+
+    applyControllerDisplayNamePresence({
+      deviceId: 'dev-1',
+      name: 'Host.local',
+      selfName: 'Host.local',
+      freshness,
+      normalizeName,
+      setDisplayName,
+      rememberName,
+      forgetName,
+    });
+
+    expect(setDisplayName).not.toHaveBeenCalled();
+    expect(rememberName).not.toHaveBeenCalled();
+    expect(forgetName).not.toHaveBeenCalled();
+  });
+
+  it('无权威名时主机名 presence 仅作内存回退，不阻断后到目录名', () => {
+    const freshness = createControllerDisplayNameFreshnessTracker();
+    const requestEpoch = freshness.epoch;
+    const setDisplayName = vi.fn();
+    const rememberName = vi.fn();
+    const forgetName = vi.fn();
+
+    applyControllerDisplayNamePresence({
+      deviceId: 'dev-1',
+      name: 'Host.local',
+      selfName: 'Host.local',
+      freshness,
+      normalizeName,
+      setDisplayName,
+      rememberName,
+      forgetName,
+    });
+    expect(setDisplayName).toHaveBeenLastCalledWith('dev-1', 'Host.local');
+    expect(rememberName).not.toHaveBeenCalled();
+    expect(freshness.epoch).toBe(0);
+
+    applyControllerDisplayNameDirectorySnapshot({
+      devices: [{ deviceId: 'dev-1', name: '数据库展示名' }],
+      cachedNames: {},
+      freshness,
+      requestEpoch,
+      normalizeName,
+      setDisplayName,
+      rememberName,
+      forgetName,
+    });
+    expect(setDisplayName).toHaveBeenLastCalledWith('dev-1', '数据库展示名');
+    expect(rememberName).toHaveBeenCalledWith('dev-1', '数据库展示名');
+  });
 
   it.each(['presence', 'directory'] as const)(
     '空数据库名经 %s 路径清除旧展示名与 last-known，并回退当前链路自报名',
@@ -174,7 +283,7 @@ describe('controller display-name directory freshness', () => {
       expect(persistedName).toBeUndefined();
 
       setDisplayName.mockClear();
-      seedControllerDisplayNamesFromCache({}, setDisplayName);
+      seedControllerDisplayNamesFromCache({}, freshness, setDisplayName);
       expect(setDisplayName).not.toHaveBeenCalled();
     },
   );

--- a/apps/desktop/src/main/__tests__/deviceLinkControllerDisplayNameFreshness.test.ts
+++ b/apps/desktop/src/main/__tests__/deviceLinkControllerDisplayNameFreshness.test.ts
@@ -3,8 +3,10 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   applyControllerDisplayNameDirectorySnapshot,
   applyControllerDisplayNamePresence,
+  beginControllerDisplayNameDirectoryRequest,
   createControllerDisplayNameFreshnessTracker,
   getControllerDisplayNameFreshnessSince,
+  isLatestControllerDisplayNameDirectoryRequest,
   resetControllerDisplayNameFreshness,
   seedControllerDisplayNamesFromCache,
 } from '../device-link/controllerDisplayNameFreshness';
@@ -15,6 +17,15 @@ const normalizeName = (name: string): string | null => {
 };
 
 describe('controller display-name directory freshness', () => {
+  it('后台刷新与列表刷新共享单调请求序号，只有最新目录响应可落地', () => {
+    const freshness = createControllerDisplayNameFreshnessTracker();
+    const backgroundRequest = beginControllerDisplayNameDirectoryRequest(freshness);
+    const listRequest = beginControllerDisplayNameDirectoryRequest(freshness);
+
+    expect(isLatestControllerDisplayNameDirectoryRequest(freshness, backgroundRequest)).toBe(false);
+    expect(isLatestControllerDisplayNameDirectoryRequest(freshness, listRequest)).toBe(true);
+  });
+
   it('仅 reset 时保持全局代次单调，但不把连接变化误判为设备名称更新', () => {
     const freshness = createControllerDisplayNameFreshnessTracker();
     const requestEpoch = freshness.epoch;

--- a/apps/desktop/src/main/__tests__/deviceLinkControllerDisplayNameFreshness.test.ts
+++ b/apps/desktop/src/main/__tests__/deviceLinkControllerDisplayNameFreshness.test.ts
@@ -34,6 +34,7 @@ describe('controller display-name directory freshness', () => {
       freshness,
       normalizeName,
       setDisplayName,
+      setFallbackDisplayName: setDisplayName,
       rememberName,
       forgetName,
     });
@@ -114,6 +115,7 @@ describe('controller display-name directory freshness', () => {
         freshness,
         normalizeName,
         setDisplayName,
+        setFallbackDisplayName: setDisplayName,
         rememberName,
         forgetName,
       });
@@ -147,6 +149,7 @@ describe('controller display-name directory freshness', () => {
       freshness,
       normalizeName,
       setDisplayName,
+      setFallbackDisplayName: setDisplayName,
       rememberName,
       forgetName,
     });
@@ -193,6 +196,7 @@ describe('controller display-name directory freshness', () => {
       freshness,
       normalizeName,
       setDisplayName,
+      setFallbackDisplayName: setDisplayName,
       rememberName,
       forgetName,
     });
@@ -206,6 +210,7 @@ describe('controller display-name directory freshness', () => {
     const freshness = createControllerDisplayNameFreshnessTracker();
     const requestEpoch = freshness.epoch;
     const setDisplayName = vi.fn();
+    const setFallbackDisplayName = vi.fn();
     const rememberName = vi.fn();
     const forgetName = vi.fn();
 
@@ -219,6 +224,7 @@ describe('controller display-name directory freshness', () => {
       freshness,
       normalizeName,
       setDisplayName,
+      setFallbackDisplayName,
       rememberName,
       forgetName,
     });
@@ -258,6 +264,7 @@ describe('controller display-name directory freshness', () => {
       freshness,
       normalizeName,
       setDisplayName,
+      setFallbackDisplayName: setDisplayName,
       rememberName,
       forgetName,
     });
@@ -284,6 +291,7 @@ describe('controller display-name directory freshness', () => {
     const freshness = createControllerDisplayNameFreshnessTracker();
     const requestEpoch = freshness.epoch;
     const setDisplayName = vi.fn();
+    const setFallbackDisplayName = vi.fn();
     const rememberName = vi.fn();
     const forgetName = vi.fn();
 
@@ -293,10 +301,12 @@ describe('controller display-name directory freshness', () => {
       freshness,
       normalizeName,
       setDisplayName,
+      setFallbackDisplayName,
       rememberName,
       forgetName,
     });
-    expect(setDisplayName).toHaveBeenLastCalledWith('dev-1', 'Host.local');
+    expect(setDisplayName).not.toHaveBeenCalled();
+    expect(setFallbackDisplayName).toHaveBeenCalledWith('dev-1', 'Host.local');
     expect(rememberName).not.toHaveBeenCalled();
     expect(freshness.epoch).toBe(0);
 
@@ -337,6 +347,7 @@ describe('controller display-name directory freshness', () => {
           freshness,
           normalizeName,
           setDisplayName,
+          setFallbackDisplayName: setDisplayName,
           rememberName,
           forgetName,
         });

--- a/apps/desktop/src/main/__tests__/deviceLinkControllerDisplayNameFreshness.test.ts
+++ b/apps/desktop/src/main/__tests__/deviceLinkControllerDisplayNameFreshness.test.ts
@@ -4,6 +4,8 @@ import {
   applyControllerDisplayNameDirectorySnapshot,
   applyControllerDisplayNamePresence,
   createControllerDisplayNameFreshnessTracker,
+  getControllerDisplayNameFreshnessSince,
+  resetControllerDisplayNameFreshness,
   seedControllerDisplayNamesFromCache,
 } from '../device-link/controllerDisplayNameFreshness';
 
@@ -13,6 +15,84 @@ const normalizeName = (name: string): string | null => {
 };
 
 describe('controller display-name directory freshness', () => {
+  it('列表请求跨断线重连时 freshness 代次保持单调，旧响应不得回写', () => {
+    const freshness = createControllerDisplayNameFreshnessTracker();
+    const setDisplayName = vi.fn();
+    const rememberName = vi.fn();
+    const forgetName = vi.fn();
+
+    applyControllerDisplayNamePresence({
+      deviceId: 'dev-1',
+      name: '断线前名称',
+      selfName: 'Host.local',
+      freshness,
+      normalizeName,
+      setDisplayName,
+      setFallbackDisplayName: setDisplayName,
+      rememberName,
+      forgetName,
+    });
+    const requestEpoch = freshness.epoch;
+
+    resetControllerDisplayNameFreshness(freshness);
+    applyControllerDisplayNamePresence({
+      deviceId: 'dev-1',
+      name: '重连后名称',
+      selfName: 'Host.local',
+      freshness,
+      normalizeName,
+      setDisplayName,
+      setFallbackDisplayName: setDisplayName,
+      rememberName,
+      forgetName,
+    });
+    rememberName.mockClear();
+    forgetName.mockClear();
+
+    expect(freshness.epoch).toBeGreaterThan(requestEpoch);
+    expect(getControllerDisplayNameFreshnessSince(freshness, 'dev-1', requestEpoch)).toEqual({
+      changedAfterRequest: true,
+      authoritativeName: '重连后名称',
+    });
+
+    applyControllerDisplayNameDirectorySnapshot({
+      devices: [{ deviceId: 'dev-1', name: '' }],
+      cachedNames: { 'dev-1': '断线前名称' },
+      freshness,
+      requestEpoch,
+      normalizeName,
+      setDisplayName,
+      rememberName,
+      forgetName,
+    });
+    expect(rememberName).not.toHaveBeenCalled();
+    expect(forgetName).not.toHaveBeenCalled();
+    expect(freshness.authoritativeNameByDevice.get('dev-1')).toBe('重连后名称');
+  });
+
+  it('两个控制端共享同一被控端时，一个控制端重连只恢复自己的名称状态', () => {
+    const controllerA = createControllerDisplayNameFreshnessTracker();
+    const controllerB = createControllerDisplayNameFreshnessTracker();
+    const setA = vi.fn();
+    const setB = vi.fn();
+
+    seedControllerDisplayNamesFromCache({ target: '旧名称' }, controllerA, setA);
+    seedControllerDisplayNamesFromCache({ target: '旧名称' }, controllerB, setB);
+    setA.mockClear();
+    setB.mockClear();
+
+    resetControllerDisplayNameFreshness(controllerA);
+    seedControllerDisplayNamesFromCache({ target: '新名称' }, controllerA, setA);
+    const replaySubscriptionsA = vi.fn(() =>
+      controllerA.authoritativeNameByDevice.get('target'),
+    );
+
+    expect(replaySubscriptionsA()).toBe('新名称');
+    expect(controllerB.authoritativeNameByDevice.get('target')).toBe('旧名称');
+    expect(setA).toHaveBeenCalledWith('target', '新名称');
+    expect(setB).not.toHaveBeenCalled();
+  });
+
   it('旧 REST 响应晚于新 presence 时不覆盖提示、不回写旧缓存，重连继续使用新名称', () => {
     const freshness = createControllerDisplayNameFreshnessTracker();
     const requestEpoch = freshness.epoch;

--- a/apps/desktop/src/main/__tests__/deviceLinkControllerDisplayNameFreshness.test.ts
+++ b/apps/desktop/src/main/__tests__/deviceLinkControllerDisplayNameFreshness.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it, vi } from 'vitest';
 
 import {
   applyControllerDisplayNameDirectorySnapshot,
+  applyControllerDisplayNamePresence,
   createControllerDisplayNameFreshnessTracker,
-  markControllerDisplayNamePresenceFresh,
   seedControllerDisplayNamesFromCache,
 } from '../device-link/controllerDisplayNameFreshness';
 
@@ -20,16 +20,25 @@ describe('controller display-name directory freshness', () => {
     let persistedName = '旧名称';
 
     // 请求在途时先收到新 presence：内存提示与 last-known 都已更新。
-    markControllerDisplayNamePresenceFresh(freshness, 'dev-1');
-    displayedName = '新名称';
-    persistedName = '新名称';
-
     const setDisplayName = vi.fn((_deviceId: string, name: string) => {
       displayedName = name;
     });
     const rememberName = vi.fn((_deviceId: string, name: string) => {
       persistedName = name;
     });
+    const forgetName = vi.fn();
+    applyControllerDisplayNamePresence({
+      deviceId: 'dev-1',
+      name: '新名称',
+      freshness,
+      normalizeName,
+      setDisplayName,
+      rememberName,
+      forgetName,
+    });
+
+    setDisplayName.mockClear();
+    rememberName.mockClear();
     applyControllerDisplayNameDirectorySnapshot({
       devices: [{ deviceId: 'dev-1', name: '旧名称' }],
       cachedNames: { 'dev-1': persistedName },
@@ -38,12 +47,14 @@ describe('controller display-name directory freshness', () => {
       normalizeName,
       setDisplayName,
       rememberName,
+      forgetName,
     });
 
     expect(setDisplayName).not.toHaveBeenCalled();
     expect(rememberName).not.toHaveBeenCalled();
     expect(displayedName).toBe('新名称');
     expect(persistedName).toBe('新名称');
+    expect(forgetName).not.toHaveBeenCalled();
 
     // 下一次 relay 连接走真实种入 helper，仍从 last-known 得到新名称。
     displayedName = '';
@@ -57,6 +68,7 @@ describe('controller display-name directory freshness', () => {
     const freshness = createControllerDisplayNameFreshnessTracker();
     const setDisplayName = vi.fn();
     const rememberName = vi.fn();
+    const forgetName = vi.fn();
 
     applyControllerDisplayNameDirectorySnapshot({
       devices: [{ deviceId: ' dev-1 ', name: ' 数据库名称 ' }],
@@ -66,9 +78,126 @@ describe('controller display-name directory freshness', () => {
       normalizeName,
       setDisplayName,
       rememberName,
+      forgetName,
     });
 
     expect(setDisplayName).toHaveBeenCalledWith('dev-1', '数据库名称');
     expect(rememberName).toHaveBeenCalledWith('dev-1', '数据库名称');
+    expect(forgetName).not.toHaveBeenCalled();
+  });
+
+  it.each(['unknown', 'no', '   '])(
+    '首次连接在目录请求期间收到占位/空 presence(%s)时仍应用有效目录名',
+    (presenceName) => {
+      const freshness = createControllerDisplayNameFreshnessTracker();
+      const requestEpoch = freshness.epoch;
+      let displayedName = 'Host.local';
+      let persistedName: string | undefined;
+      const setDisplayName = vi.fn((_deviceId: string, name: string) => {
+        displayedName = name || 'Host.local';
+      });
+      const rememberName = vi.fn((_deviceId: string, name: string) => {
+        persistedName = name;
+      });
+      const forgetName = vi.fn(() => {
+        persistedName = undefined;
+      });
+
+      applyControllerDisplayNamePresence({
+        deviceId: 'dev-1',
+        name: presenceName,
+        freshness,
+        normalizeName,
+        setDisplayName,
+        rememberName,
+        forgetName,
+      });
+      applyControllerDisplayNameDirectorySnapshot({
+        devices: [{ deviceId: 'dev-1', name: '数据库名称' }],
+        cachedNames: {},
+        freshness,
+        requestEpoch,
+        normalizeName,
+        setDisplayName,
+        rememberName,
+        forgetName,
+      });
+
+      expect(freshness.epoch).toBe(0);
+      expect(displayedName).toBe('数据库名称');
+      expect(persistedName).toBe('数据库名称');
+    },
+  );
+
+  it.each(['presence', 'directory'] as const)(
+    '空数据库名经 %s 路径清除旧展示名与 last-known，并回退当前链路自报名',
+    (source) => {
+      const freshness = createControllerDisplayNameFreshnessTracker();
+      let displayedName = '旧数据库名';
+      let persistedName: string | undefined = '旧数据库名';
+      const setDisplayName = vi.fn((_deviceId: string, name: string) => {
+        displayedName = name || 'Host.local';
+      });
+      const rememberName = vi.fn((_deviceId: string, name: string) => {
+        persistedName = name;
+      });
+      const forgetName = vi.fn(() => {
+        persistedName = undefined;
+      });
+
+      if (source === 'presence') {
+        applyControllerDisplayNamePresence({
+          deviceId: 'dev-1',
+          name: '',
+          freshness,
+          normalizeName,
+          setDisplayName,
+          rememberName,
+          forgetName,
+        });
+      } else {
+        applyControllerDisplayNameDirectorySnapshot({
+          devices: [{ deviceId: 'dev-1', name: '' }],
+          cachedNames: { 'dev-1': '旧数据库名' },
+          freshness,
+          requestEpoch: freshness.epoch,
+          normalizeName,
+          setDisplayName,
+          rememberName,
+          forgetName,
+        });
+      }
+
+      expect(setDisplayName).toHaveBeenCalledWith('dev-1', '');
+      expect(forgetName).toHaveBeenCalledWith('dev-1');
+      expect(displayedName).toBe('Host.local');
+      expect(persistedName).toBeUndefined();
+
+      setDisplayName.mockClear();
+      seedControllerDisplayNamesFromCache({}, setDisplayName);
+      expect(setDisplayName).not.toHaveBeenCalled();
+    },
+  );
+
+  it('目录占位名继续使用 last-known，但不写回占位值', () => {
+    const freshness = createControllerDisplayNameFreshnessTracker();
+    const setDisplayName = vi.fn();
+    const rememberName = vi.fn();
+    const forgetName = vi.fn();
+
+    applyControllerDisplayNameDirectorySnapshot({
+      devices: [{ deviceId: 'dev-1', name: 'unknown' }],
+      cachedNames: { 'dev-1': '缓存名称' },
+      freshness,
+      requestEpoch: freshness.epoch,
+      normalizeName,
+      setDisplayName,
+      rememberName,
+      forgetName,
+    });
+
+    expect(setDisplayName).toHaveBeenCalledWith('dev-1', '缓存名称');
+    expect(rememberName).not.toHaveBeenCalled();
+    expect(forgetName).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/main/__tests__/deviceLinkControllerDisplayNameFreshness.test.ts
+++ b/apps/desktop/src/main/__tests__/deviceLinkControllerDisplayNameFreshness.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  applyControllerDisplayNameDirectorySnapshot,
+  createControllerDisplayNameFreshnessTracker,
+  markControllerDisplayNamePresenceFresh,
+  seedControllerDisplayNamesFromCache,
+} from '../device-link/controllerDisplayNameFreshness';
+
+const normalizeName = (name: string): string | null => {
+  const trimmed = name.trim();
+  return trimmed && !['unknown', 'no'].includes(trimmed.toLowerCase()) ? trimmed : null;
+};
+
+describe('controller display-name directory freshness', () => {
+  it('旧 REST 响应晚于新 presence 时不覆盖提示、不回写旧缓存，重连继续使用新名称', () => {
+    const freshness = createControllerDisplayNameFreshnessTracker();
+    const requestEpoch = freshness.epoch;
+    let displayedName = '旧名称';
+    let persistedName = '旧名称';
+
+    // 请求在途时先收到新 presence：内存提示与 last-known 都已更新。
+    markControllerDisplayNamePresenceFresh(freshness, 'dev-1');
+    displayedName = '新名称';
+    persistedName = '新名称';
+
+    const setDisplayName = vi.fn((_deviceId: string, name: string) => {
+      displayedName = name;
+    });
+    const rememberName = vi.fn((_deviceId: string, name: string) => {
+      persistedName = name;
+    });
+    applyControllerDisplayNameDirectorySnapshot({
+      devices: [{ deviceId: 'dev-1', name: '旧名称' }],
+      cachedNames: { 'dev-1': persistedName },
+      freshness,
+      requestEpoch,
+      normalizeName,
+      setDisplayName,
+      rememberName,
+    });
+
+    expect(setDisplayName).not.toHaveBeenCalled();
+    expect(rememberName).not.toHaveBeenCalled();
+    expect(displayedName).toBe('新名称');
+    expect(persistedName).toBe('新名称');
+
+    // 下一次 relay 连接走真实种入 helper，仍从 last-known 得到新名称。
+    displayedName = '';
+    seedControllerDisplayNamesFromCache({ 'dev-1': persistedName }, (_deviceId, name) => {
+      displayedName = name;
+    });
+    expect(displayedName).toBe('新名称');
+  });
+
+  it('请求期间没有新 presence 时应用有效目录名并写入缓存', () => {
+    const freshness = createControllerDisplayNameFreshnessTracker();
+    const setDisplayName = vi.fn();
+    const rememberName = vi.fn();
+
+    applyControllerDisplayNameDirectorySnapshot({
+      devices: [{ deviceId: ' dev-1 ', name: ' 数据库名称 ' }],
+      cachedNames: {},
+      freshness,
+      requestEpoch: freshness.epoch,
+      normalizeName,
+      setDisplayName,
+      rememberName,
+    });
+
+    expect(setDisplayName).toHaveBeenCalledWith('dev-1', '数据库名称');
+    expect(rememberName).toHaveBeenCalledWith('dev-1', '数据库名称');
+  });
+});

--- a/apps/desktop/src/main/__tests__/deviceLinkDispatch.test.ts
+++ b/apps/desktop/src/main/__tests__/deviceLinkDispatch.test.ts
@@ -458,6 +458,7 @@ import {
   pushSessionActivityToController,
 } from '../device-link/dispatch';
 import {
+  applyControllerDisplayNameDirectorySnapshot,
   applyControllerDisplayNamePresence,
   createControllerDisplayNameFreshnessTracker,
 } from '../device-link/controllerDisplayNameFreshness';
@@ -546,24 +547,44 @@ describe('被控端控制链路生命周期', () => {
     expect(hasBroadcastTapListener()).toBe(false);
   });
 
-  it('被控提示优先使用 presence 的数据库展示名，并在重命名后立即更新', () => {
+  it('目录刷新在无 active link 时预存数据库名，并让活跃提示立即响应改名与清空', () => {
     remoteControlEnabled = true;
     const changes: ActiveController[][] = [];
     setControllersChangedListener((controllers) => changes.push(controllers));
     const { client, feed } = makeFakeClient();
     wireInboundDispatch(client);
+    const freshness = createControllerDisplayNameFreshnessTracker();
+    const applyDirectoryName = (name: string): void => {
+      applyControllerDisplayNameDirectorySnapshot({
+        devices: [{ deviceId: 'ctrl-a', name }],
+        cachedNames: {},
+        freshness,
+        requestEpoch: freshness.epoch,
+        normalizeName: (value) => value.trim() || null,
+        setDisplayName: setControllerDisplayName,
+        rememberName: vi.fn(),
+        forgetName: vi.fn(),
+      });
+    };
 
-    // presence 先到：控制帧仍携带设备自报主机名，但展示应以数据库名为准。
-    setControllerDisplayName('ctrl-a', 'MacBook-Pro-2');
+    // 目录先于 link 到达时先预存名称，之后的控制帧仍以数据库名展示。
+    applyDirectoryName('MacBook-Pro-2');
     feed(subFrame('ctrl-a', SUB, ['session:s1'], 'Chriss-MacBook-Pro-2.local'));
     expect(getActiveControllers()).toEqual([
       { deviceId: 'ctrl-a', name: 'MacBook-Pro-2' },
     ]);
 
-    // 设置页改名会广播新 presence；活跃横幅无需等重连或重订阅即可更新。
-    setControllerDisplayName('ctrl-a', '工作电脑');
+    applyDirectoryName('工作电脑');
     expect(getActiveControllers()).toEqual([{ deviceId: 'ctrl-a', name: '工作电脑' }]);
     expect(changes.at(-1)).toEqual([{ deviceId: 'ctrl-a', name: '工作电脑' }]);
+
+    applyDirectoryName('');
+    expect(getActiveControllers()).toEqual([
+      { deviceId: 'ctrl-a', name: 'Chriss-MacBook-Pro-2.local' },
+    ]);
+    expect(changes.at(-1)).toEqual([
+      { deviceId: 'ctrl-a', name: 'Chriss-MacBook-Pro-2.local' },
+    ]);
   });
 
   it('数据库展示名为空或被清空时回退到控制端自报名，再缺失时回退到设备 ID 短码', () => {

--- a/apps/desktop/src/main/__tests__/deviceLinkDispatch.test.ts
+++ b/apps/desktop/src/main/__tests__/deviceLinkDispatch.test.ts
@@ -632,6 +632,25 @@ describe('被控端控制链路生命周期', () => {
     expect(getActiveControllers()).toEqual([{ deviceId, name: '12345678' }]);
   });
 
+  it.each([
+    ['topics 为空', []],
+    ['topics 全被过滤', ['*', 'invalid-topic']],
+  ] as const)('%s 的 subscribe 自报名也会在整体断开时清理', (_label, topics) => {
+    remoteControlEnabled = true;
+    const { client, calls, feed } = makeFakeClient();
+    wireInboundDispatch(client);
+    const deviceId = '1234567890abcdef';
+
+    feed(subFrame(deviceId, SUB, [...topics], 'Old-Host.local'));
+    expect(getActiveControllers()).toEqual([]);
+
+    dropAllControllers(client, 'user');
+    expect(calls.closed).toContainEqual({ dst: deviceId, reason: 'user' });
+
+    feed(subFrame(deviceId, SUB, ['session:s1']));
+    expect(getActiveControllers()).toEqual([{ deviceId, name: '12345678' }]);
+  });
+
   it('link-open(开关关)→ 不 accept、不记录', () => {
     remoteControlEnabled = false;
     const { client, calls, feed } = makeFakeClient();

--- a/apps/desktop/src/main/__tests__/deviceLinkDispatch.test.ts
+++ b/apps/desktop/src/main/__tests__/deviceLinkDispatch.test.ts
@@ -449,6 +449,7 @@ import {
   setRemoteInvokeBusyChangedListener,
   setSessionsSubscribedListener,
   setControllerDisplayName,
+  purgeRevokedController,
   getActiveControllers,
   getUpdateRelaunchControllers,
   hasInFlightRemoteInvokes,
@@ -584,6 +585,51 @@ describe('被控端控制链路生命周期', () => {
       deviceId: '1234567890abcdef',
       name: '12345678',
     });
+  });
+
+  it('没有历史 presence 时先显示自报名，设备目录补齐后立即切换到数据库展示名', () => {
+    remoteControlEnabled = true;
+    const { client, feed } = makeFakeClient();
+    wireInboundDispatch(client);
+
+    feed(subFrame('ctrl-late-directory', SUB, ['session:s1'], 'Host.local'));
+    expect(getActiveControllers()).toEqual([
+      { deviceId: 'ctrl-late-directory', name: 'Host.local' },
+    ]);
+
+    setControllerDisplayName('ctrl-late-directory', '数据库展示名');
+    expect(getActiveControllers()).toEqual([
+      { deviceId: 'ctrl-late-directory', name: '数据库展示名' },
+    ]);
+  });
+
+  it.each([
+    ['显式断链', (feed: (env: Envelope) => unknown, deviceId: string) => feed({
+      v: 1,
+      kind: 'link-close',
+      src: deviceId,
+      payload: { reason: 'user' },
+    })],
+    ['presence 离线', (_feed: (env: Envelope) => unknown, deviceId: string) => {
+      handleControllerOffline(deviceId);
+    }],
+    ['撤销访问', (_feed: (env: Envelope) => unknown, deviceId: string) => {
+      purgeRevokedController(deviceId);
+    }],
+  ] as const)('%s 会清掉旧链路自报名，新链路缺名时回退设备 ID 短码', (_label, close) => {
+    remoteControlEnabled = true;
+    const { client, feed } = makeFakeClient();
+    wireInboundDispatch(client);
+    const deviceId = '1234567890abcdef';
+
+    setControllerDisplayName(deviceId, '数据库展示名');
+    feed(subFrame(deviceId, SUB, ['session:s1'], 'Old-Host.local'));
+    setControllerDisplayName(deviceId, '');
+    expect(getActiveControllers()).toEqual([{ deviceId, name: 'Old-Host.local' }]);
+
+    close(feed, deviceId);
+    feed(subFrame(deviceId, SUB, ['session:s2']));
+    expect(getActiveControllers()).toEqual([{ deviceId, name: '12345678' }]);
   });
 
   it('link-open(开关关)→ 不 accept、不记录', () => {

--- a/apps/desktop/src/main/__tests__/deviceLinkDispatch.test.ts
+++ b/apps/desktop/src/main/__tests__/deviceLinkDispatch.test.ts
@@ -656,6 +656,11 @@ describe('被控端控制链路生命周期', () => {
     expect(rememberName).not.toHaveBeenCalled();
     expect(forgetName).not.toHaveBeenCalled();
 
+    // 旧协议 presence 只改过当前 metadata，没有写入权威 map；空目录名仍必须
+    // 强制重算回退，不能因 delete(false) 留下旧主机名。
+    setControllerDisplayName(deviceId, '');
+    expect(getActiveControllers()).toEqual([{ deviceId, name: '12345678' }]);
+
     feed(subFrame(deviceId, SUB, ['session:s2'], 'New-Host.local'));
     expect(getActiveControllers()).toEqual([{ deviceId, name: 'New-Host.local' }]);
 
@@ -669,6 +674,9 @@ describe('被控端控制链路生命周期', () => {
       rememberName,
       forgetName,
     });
+    expect(getActiveControllers()).toEqual([{ deviceId, name: 'New-Host.local' }]);
+
+    setControllerDisplayName(deviceId, '');
     expect(getActiveControllers()).toEqual([{ deviceId, name: 'New-Host.local' }]);
   });
 

--- a/apps/desktop/src/main/__tests__/deviceLinkDispatch.test.ts
+++ b/apps/desktop/src/main/__tests__/deviceLinkDispatch.test.ts
@@ -448,6 +448,7 @@ import {
   setControllersChangedListener,
   setRemoteInvokeBusyChangedListener,
   setSessionsSubscribedListener,
+  setControllerDisplayName,
   getActiveControllers,
   getUpdateRelaunchControllers,
   hasInFlightRemoteInvokes,
@@ -537,6 +538,52 @@ describe('被控端控制链路生命周期', () => {
     expect(calls.closed).toEqual([{ dst: 'ctrl-a', reason: 'user' }]);
     expect(getActiveControllers()).toHaveLength(0);
     expect(hasBroadcastTapListener()).toBe(false);
+  });
+
+  it('被控提示优先使用 presence 的数据库展示名，并在重命名后立即更新', () => {
+    remoteControlEnabled = true;
+    const changes: ActiveController[][] = [];
+    setControllersChangedListener((controllers) => changes.push(controllers));
+    const { client, feed } = makeFakeClient();
+    wireInboundDispatch(client);
+
+    // presence 先到：控制帧仍携带设备自报主机名，但展示应以数据库名为准。
+    setControllerDisplayName('ctrl-a', 'MacBook-Pro-2');
+    feed(subFrame('ctrl-a', SUB, ['session:s1'], 'Chriss-MacBook-Pro-2.local'));
+    expect(getActiveControllers()).toEqual([
+      { deviceId: 'ctrl-a', name: 'MacBook-Pro-2' },
+    ]);
+
+    // 设置页改名会广播新 presence；活跃横幅无需等重连或重订阅即可更新。
+    setControllerDisplayName('ctrl-a', '工作电脑');
+    expect(getActiveControllers()).toEqual([{ deviceId: 'ctrl-a', name: '工作电脑' }]);
+    expect(changes.at(-1)).toEqual([{ deviceId: 'ctrl-a', name: '工作电脑' }]);
+  });
+
+  it('数据库展示名为空或被清空时回退到控制端自报名，再缺失时回退到设备 ID 短码', () => {
+    remoteControlEnabled = true;
+    const { client, feed } = makeFakeClient();
+    wireInboundDispatch(client);
+
+    setControllerDisplayName('ctrl-reported', '数据库名称');
+    feed(subFrame('ctrl-reported', SUB, ['session:s1'], 'Host.local'));
+    expect(getActiveControllers()).toContainEqual({
+      deviceId: 'ctrl-reported',
+      name: '数据库名称',
+    });
+
+    setControllerDisplayName('ctrl-reported', '   ');
+    expect(getActiveControllers()).toContainEqual({
+      deviceId: 'ctrl-reported',
+      name: 'Host.local',
+    });
+
+    setControllerDisplayName('1234567890abcdef', '');
+    feed(subFrame('1234567890abcdef', SUB, ['session:s2']));
+    expect(getActiveControllers()).toContainEqual({
+      deviceId: '1234567890abcdef',
+      name: '12345678',
+    });
   });
 
   it('link-open(开关关)→ 不 accept、不记录', () => {

--- a/apps/desktop/src/main/__tests__/deviceLinkDispatch.test.ts
+++ b/apps/desktop/src/main/__tests__/deviceLinkDispatch.test.ts
@@ -449,6 +449,7 @@ import {
   setRemoteInvokeBusyChangedListener,
   setSessionsSubscribedListener,
   setControllerDisplayName,
+  setControllerFallbackDisplayName,
   purgeRevokedController,
   getActiveControllers,
   getUpdateRelaunchControllers,
@@ -456,6 +457,10 @@ import {
   dropAllControllers,
   pushSessionActivityToController,
 } from '../device-link/dispatch';
+import {
+  applyControllerDisplayNamePresence,
+  createControllerDisplayNameFreshnessTracker,
+} from '../device-link/controllerDisplayNameFreshness';
 import { hasBroadcastTapListener, tapWindowBroadcast } from '../device-link/broadcast-tap';
 import {
   CONTROLLER_CAPABILITY_SET_MODEL_EXPLICIT_PROVIDER_NULL_V1,
@@ -601,6 +606,49 @@ describe('被控端控制链路生命周期', () => {
     expect(getActiveControllers()).toEqual([
       { deviceId: 'ctrl-late-directory', name: '数据库展示名' },
     ]);
+  });
+
+  it('旧协议 presence 临时名不遮蔽同一链路后到的控制端自报名', () => {
+    remoteControlEnabled = true;
+    const { client, feed } = makeFakeClient();
+    wireInboundDispatch(client);
+    const deviceId = '1234567890abcdef';
+    const freshness = createControllerDisplayNameFreshnessTracker();
+    const rememberName = vi.fn();
+    const forgetName = vi.fn();
+
+    feed(subFrame(deviceId, SUB, ['session:s1']));
+    expect(getActiveControllers()).toEqual([{ deviceId, name: '12345678' }]);
+
+    applyControllerDisplayNamePresence({
+      deviceId,
+      name: 'Old-Host.local',
+      freshness,
+      normalizeName: (name) => name.trim() || null,
+      setDisplayName: setControllerDisplayName,
+      setFallbackDisplayName: setControllerFallbackDisplayName,
+      rememberName,
+      forgetName,
+    });
+    expect(getActiveControllers()).toEqual([{ deviceId, name: 'Old-Host.local' }]);
+    expect(freshness.epoch).toBe(0);
+    expect(rememberName).not.toHaveBeenCalled();
+    expect(forgetName).not.toHaveBeenCalled();
+
+    feed(subFrame(deviceId, SUB, ['session:s2'], 'New-Host.local'));
+    expect(getActiveControllers()).toEqual([{ deviceId, name: 'New-Host.local' }]);
+
+    applyControllerDisplayNamePresence({
+      deviceId,
+      name: 'Older-Host.local',
+      freshness,
+      normalizeName: (name) => name.trim() || null,
+      setDisplayName: setControllerDisplayName,
+      setFallbackDisplayName: setControllerFallbackDisplayName,
+      rememberName,
+      forgetName,
+    });
+    expect(getActiveControllers()).toEqual([{ deviceId, name: 'New-Host.local' }]);
   });
 
   it.each([

--- a/apps/desktop/src/main/__tests__/deviceLinkIpc.test.ts
+++ b/apps/desktop/src/main/__tests__/deviceLinkIpc.test.ts
@@ -144,6 +144,7 @@ function makeDeps(overrides?: Partial<DeviceLinkIpcDeps>): DeviceLinkIpcDeps {
     readLastKnownDeviceNames: vi.fn(() => ({})),
     rememberLastKnownDeviceName: vi.fn(async () => false),
     forgetLastKnownDeviceName: vi.fn(async () => false),
+    applyControllerDisplayNameListSnapshot: vi.fn(),
     captureControllerDisplayNameRequestEpoch: vi.fn(() => 0),
     readControllerDisplayNameFreshnessSince: vi.fn(() => ({
       changedAfterRequest: false,
@@ -300,10 +301,12 @@ describe('device-link IPC handlers', () => {
         });
       const rememberLastKnownDeviceName = vi.fn(async () => true);
       const forgetLastKnownDeviceName = vi.fn(async () => true);
+      const applyControllerDisplayNameListSnapshot = vi.fn();
       const deps = makeDeps({
         apiFetch,
         rememberLastKnownDeviceName,
         forgetLastKnownDeviceName,
+        applyControllerDisplayNameListSnapshot,
       });
       const device = (name: string) => ({
         deviceId: 'dev-1',
@@ -332,6 +335,11 @@ describe('device-link IPC handlers', () => {
       expect(rememberLastKnownDeviceName).toHaveBeenCalledTimes(1);
       expect(rememberLastKnownDeviceName).toHaveBeenCalledWith('dev-1', '新数据库名');
       expect(forgetLastKnownDeviceName).not.toHaveBeenCalled();
+      expect(applyControllerDisplayNameListSnapshot).toHaveBeenCalledTimes(1);
+      expect(applyControllerDisplayNameListSnapshot).toHaveBeenCalledWith(
+        [expect.objectContaining({ deviceId: 'dev-1', name: '新数据库名' })],
+        0,
+      );
     },
   );
 

--- a/apps/desktop/src/main/__tests__/deviceLinkIpc.test.ts
+++ b/apps/desktop/src/main/__tests__/deviceLinkIpc.test.ts
@@ -290,6 +290,51 @@ describe('device-link IPC handlers', () => {
     await expect(handleListDevices(depsNet)).rejects.toThrowError(/\[DEVICE_LINK_UNAVAILABLE\]/);
   });
 
+  it.each(['旧目录名', ''] as const)(
+    'listDevices:并发请求中新响应先返回时，晚到旧响应(%s)跟随新结果且不回写缓存',
+    async (oldName) => {
+      const resolvers: Array<(value: unknown) => void> = [];
+      const apiFetch: DeviceLinkIpcDeps['apiFetch'] = <T>() =>
+        new Promise<T>((resolve) => {
+          resolvers.push((value) => resolve(value as T));
+        });
+      const rememberLastKnownDeviceName = vi.fn(async () => true);
+      const forgetLastKnownDeviceName = vi.fn(async () => true);
+      const deps = makeDeps({
+        apiFetch,
+        rememberLastKnownDeviceName,
+        forgetLastKnownDeviceName,
+      });
+      const device = (name: string) => ({
+        deviceId: 'dev-1',
+        name,
+        selfName: 'Host.local',
+        platform: 'darwin',
+        lastSeenAt: '2026-06-23T00:00:00.000Z',
+        online: true,
+        busy: false,
+        remoteControlEnabled: true,
+        controlEnabled: true,
+        isSelf: false,
+      });
+
+      const oldRequest = handleListDevices(deps);
+      const newRequest = handleListDevices(deps);
+      resolvers[1]?.({ devices: [device('新数据库名')] });
+      await expect(newRequest).resolves.toMatchObject({
+        devices: [{ name: '新数据库名' }],
+      });
+      resolvers[0]?.({ devices: [device(oldName)] });
+      await expect(oldRequest).resolves.toMatchObject({
+        devices: [{ name: '新数据库名' }],
+      });
+
+      expect(rememberLastKnownDeviceName).toHaveBeenCalledTimes(1);
+      expect(rememberLastKnownDeviceName).toHaveBeenCalledWith('dev-1', '新数据库名');
+      expect(forgetLastKnownDeviceName).not.toHaveBeenCalled();
+    },
+  );
+
   it('listDevices:缓存服务端返回的有效设备名', async () => {
     const rememberLastKnownDeviceName = vi.fn(async () => true);
     const deps = makeDeps({

--- a/apps/desktop/src/main/__tests__/deviceLinkIpc.test.ts
+++ b/apps/desktop/src/main/__tests__/deviceLinkIpc.test.ts
@@ -145,7 +145,9 @@ function makeDeps(overrides?: Partial<DeviceLinkIpcDeps>): DeviceLinkIpcDeps {
     rememberLastKnownDeviceName: vi.fn(async () => false),
     forgetLastKnownDeviceName: vi.fn(async () => false),
     applyControllerDisplayNameListSnapshot: vi.fn(),
+    beginControllerDisplayNameDirectoryRefresh: vi.fn(() => 1),
     captureControllerDisplayNameRequestEpoch: vi.fn(() => 0),
+    isLatestControllerDisplayNameDirectoryRefresh: vi.fn(() => true),
     readControllerDisplayNameFreshnessSince: vi.fn(() => ({
       changedAfterRequest: false,
       authoritativeName: null,
@@ -290,6 +292,44 @@ describe('device-link IPC handlers', () => {
     });
     await expect(handleListDevices(depsNet)).rejects.toThrowError(/\[DEVICE_LINK_UNAVAILABLE\]/);
   });
+
+  it.each(['旧数据库名', ''] as const)(
+    'listDevices:被更新的后台目录请求取代后，旧列表响应(%s)不得更新提示或缓存',
+    async (name) => {
+      const applyControllerDisplayNameListSnapshot = vi.fn();
+      const rememberLastKnownDeviceName = vi.fn(async () => true);
+      const forgetLastKnownDeviceName = vi.fn(async () => true);
+      const deps = makeDeps({
+        apiFetch: vi.fn().mockResolvedValue({
+          devices: [
+            {
+              deviceId: 'dev-1',
+              name,
+              selfName: 'Host.local',
+              platform: 'darwin',
+              lastSeenAt: '2026-06-23T00:00:00.000Z',
+              online: true,
+              busy: false,
+              remoteControlEnabled: true,
+              controlEnabled: true,
+              isSelf: false,
+            },
+          ],
+        }),
+        applyControllerDisplayNameListSnapshot,
+        rememberLastKnownDeviceName,
+        forgetLastKnownDeviceName,
+        beginControllerDisplayNameDirectoryRefresh: vi.fn(() => 1),
+        isLatestControllerDisplayNameDirectoryRefresh: vi.fn(() => false),
+      });
+
+      await handleListDevices(deps);
+
+      expect(applyControllerDisplayNameListSnapshot).not.toHaveBeenCalled();
+      expect(rememberLastKnownDeviceName).not.toHaveBeenCalled();
+      expect(forgetLastKnownDeviceName).not.toHaveBeenCalled();
+    },
+  );
 
   it.each(['旧目录名', ''] as const)(
     'listDevices:并发请求中新响应先返回时，晚到旧响应(%s)跟随新结果且不回写缓存',

--- a/apps/desktop/src/main/__tests__/deviceLinkIpc.test.ts
+++ b/apps/desktop/src/main/__tests__/deviceLinkIpc.test.ts
@@ -148,6 +148,7 @@ function makeDeps(overrides?: Partial<DeviceLinkIpcDeps>): DeviceLinkIpcDeps {
     beginControllerDisplayNameDirectoryRefresh: vi.fn(() => 1),
     captureControllerDisplayNameRequestEpoch: vi.fn(() => 0),
     isLatestControllerDisplayNameDirectoryRefresh: vi.fn(() => true),
+    waitForNewerControllerDisplayNameDirectoryRefresh: vi.fn(async () => {}),
     readControllerDisplayNameFreshnessSince: vi.fn(() => ({
       changedAfterRequest: false,
       authoritativeName: null,
@@ -293,12 +294,17 @@ describe('device-link IPC handlers', () => {
     await expect(handleListDevices(depsNet)).rejects.toThrowError(/\[DEVICE_LINK_UNAVAILABLE\]/);
   });
 
-  it.each(['旧数据库名', ''] as const)(
-    'listDevices:被更新的后台目录请求取代后，旧列表响应(%s)不得更新提示或缓存',
-    async (name) => {
+  it.each([
+    ['旧数据库名', '新数据库名', '新数据库名'],
+    ['', '新数据库名', '新数据库名'],
+    ['旧数据库名', null, 'Host.local'],
+  ] as const)(
+    'listDevices:被后台目录淘汰的旧响应(%s)等待后返回当前权威名(%s)',
+    async (name, authoritativeName, expectedName) => {
       const applyControllerDisplayNameListSnapshot = vi.fn();
       const rememberLastKnownDeviceName = vi.fn(async () => true);
       const forgetLastKnownDeviceName = vi.fn(async () => true);
+      const waitForNewerControllerDisplayNameDirectoryRefresh = vi.fn(async () => {});
       const deps = makeDeps({
         apiFetch: vi.fn().mockResolvedValue({
           devices: [
@@ -321,10 +327,18 @@ describe('device-link IPC handlers', () => {
         forgetLastKnownDeviceName,
         beginControllerDisplayNameDirectoryRefresh: vi.fn(() => 1),
         isLatestControllerDisplayNameDirectoryRefresh: vi.fn(() => false),
+        waitForNewerControllerDisplayNameDirectoryRefresh,
+        readControllerDisplayNameFreshnessSince: vi.fn(() => ({
+          changedAfterRequest: false,
+          authoritativeName,
+        })),
       });
 
-      await handleListDevices(deps);
+      await expect(handleListDevices(deps)).resolves.toMatchObject({
+        devices: [{ name: expectedName }],
+      });
 
+      expect(waitForNewerControllerDisplayNameDirectoryRefresh).toHaveBeenCalledWith(1);
       expect(applyControllerDisplayNameListSnapshot).not.toHaveBeenCalled();
       expect(rememberLastKnownDeviceName).not.toHaveBeenCalled();
       expect(forgetLastKnownDeviceName).not.toHaveBeenCalled();

--- a/apps/desktop/src/main/__tests__/deviceLinkIpc.test.ts
+++ b/apps/desktop/src/main/__tests__/deviceLinkIpc.test.ts
@@ -124,6 +124,7 @@ function makeDeps(overrides?: Partial<DeviceLinkIpcDeps>): DeviceLinkIpcDeps {
     broadcast: vi.fn(),
     readLastKnownDeviceNames: vi.fn(() => ({})),
     rememberLastKnownDeviceName: vi.fn(async () => false),
+    forgetLastKnownDeviceName: vi.fn(async () => false),
     ...overrides,
   };
 }
@@ -348,6 +349,43 @@ describe('device-link IPC handlers', () => {
       ],
     });
   });
+
+  it.each([
+    ['Host.local', 'Host.local'],
+    [null, '12345678'],
+  ] as const)(
+    'listDevices:数据库空名清除 last-known，并回退 selfName/设备短 ID(%s)',
+    async (selfName, expectedName) => {
+      const forgetLastKnownDeviceName = vi.fn(async () => true);
+      const rememberLastKnownDeviceName = vi.fn(async () => false);
+      const deps = makeDeps({
+        apiFetch: vi.fn().mockResolvedValue({
+          devices: [
+            {
+              deviceId: '1234567890abcdef',
+              name: '',
+              selfName,
+              platform: 'darwin',
+              lastSeenAt: '2026-06-23T00:00:00.000Z',
+              online: false,
+              busy: false,
+              remoteControlEnabled: false,
+              controlEnabled: true,
+              isSelf: false,
+            },
+          ],
+        }),
+        readLastKnownDeviceNames: vi.fn(() => ({ '1234567890abcdef': '旧缓存名' })),
+        rememberLastKnownDeviceName,
+        forgetLastKnownDeviceName,
+      });
+
+      const result = await handleListDevices(deps);
+      expect(result.devices[0]?.name).toBe(expectedName);
+      expect(forgetLastKnownDeviceName).toHaveBeenCalledWith('1234567890abcdef');
+      expect(rememberLastKnownDeviceName).not.toHaveBeenCalled();
+    },
+  );
 
   it('listDevices:按本机 disabledControlDeviceIds 合成 controlEnabled=false', async () => {
     const deps = makeDeps({

--- a/apps/desktop/src/main/__tests__/deviceLinkIpc.test.ts
+++ b/apps/desktop/src/main/__tests__/deviceLinkIpc.test.ts
@@ -111,6 +111,7 @@ import {
   applyControllerDisplayNamePresence,
   createControllerDisplayNameFreshnessTracker,
   getControllerDisplayNameFreshnessSince,
+  resetControllerDisplayNameFreshness,
 } from '../device-link/controllerDisplayNameFreshness';
 
 function makeDeps(overrides?: Partial<DeviceLinkIpcDeps>): DeviceLinkIpcDeps {
@@ -405,6 +406,66 @@ describe('device-link IPC handlers', () => {
       expect(deps.forgetLastKnownDeviceName).not.toHaveBeenCalled();
     },
   );
+
+  it('listDevices:断线重连后的新 presence 阻止断线前旧列表响应删除名称', async () => {
+    const freshness = createControllerDisplayNameFreshnessTracker();
+    applyControllerDisplayNamePresence({
+      deviceId: 'dev-1',
+      name: '断线前名称',
+      selfName: 'Host.local',
+      freshness,
+      normalizeName: normalizeCachedDeviceName,
+      setDisplayName: vi.fn(),
+      setFallbackDisplayName: vi.fn(),
+      rememberName: vi.fn(),
+      forgetName: vi.fn(),
+    });
+    const rememberLastKnownDeviceName = vi.fn(async () => true);
+    const forgetLastKnownDeviceName = vi.fn(async () => true);
+    const apiFetch: DeviceLinkIpcDeps['apiFetch'] = async <T>() => {
+      resetControllerDisplayNameFreshness(freshness);
+      applyControllerDisplayNamePresence({
+        deviceId: 'dev-1',
+        name: '重连后名称',
+        selfName: 'Host.local',
+        freshness,
+        normalizeName: normalizeCachedDeviceName,
+        setDisplayName: vi.fn(),
+        setFallbackDisplayName: vi.fn(),
+        rememberName: vi.fn(),
+        forgetName: vi.fn(),
+      });
+      return {
+        devices: [
+          {
+            deviceId: 'dev-1',
+            name: '',
+            selfName: 'Host.local',
+            platform: 'darwin',
+            lastSeenAt: '2026-06-23T00:00:00.000Z',
+            online: true,
+            busy: false,
+            remoteControlEnabled: true,
+            controlEnabled: true,
+            isSelf: false,
+          },
+        ],
+      } as T;
+    };
+    const deps = makeDeps({
+      apiFetch,
+      rememberLastKnownDeviceName,
+      forgetLastKnownDeviceName,
+      captureControllerDisplayNameRequestEpoch: () => freshness.epoch,
+      readControllerDisplayNameFreshnessSince: (deviceId, requestEpoch) =>
+        getControllerDisplayNameFreshnessSince(freshness, deviceId, requestEpoch),
+    });
+
+    const result = await handleListDevices(deps);
+    expect(result.devices[0]?.name).toBe('重连后名称');
+    expect(rememberLastKnownDeviceName).not.toHaveBeenCalled();
+    expect(forgetLastKnownDeviceName).not.toHaveBeenCalled();
+  });
 
   it.each([
     ['旧目录名', '新数据库名', 'remember', '新数据库名'],

--- a/apps/desktop/src/main/__tests__/deviceLinkIpc.test.ts
+++ b/apps/desktop/src/main/__tests__/deviceLinkIpc.test.ts
@@ -35,6 +35,11 @@ vi.mock('./index', () => ({
   remoteUnsubscribe: vi.fn(),
   disconnectAllControllers: vi.fn(),
   broadcast: vi.fn(),
+  captureControllerDisplayNameRequestEpoch: () => 0,
+  readControllerDisplayNameFreshnessSince: () => ({
+    changedAfterRequest: false,
+    authoritativeName: null,
+  }),
 }));
 vi.mock('../device-link/index', () => ({
   getDeviceLinkStatus: () => 'online',
@@ -46,6 +51,11 @@ vi.mock('../device-link/index', () => ({
   remoteUnsubscribe: vi.fn(),
   disconnectAllControllers: vi.fn(),
   broadcast: vi.fn(),
+  captureControllerDisplayNameRequestEpoch: () => 0,
+  readControllerDisplayNameFreshnessSince: () => ({
+    changedAfterRequest: false,
+    authoritativeName: null,
+  }),
 }));
 vi.mock('../device-link/dispatch', () => ({
   getActiveControllers: () => [],
@@ -92,8 +102,16 @@ import {
 } from '../device-link/ipc';
 import { DeviceLinkError } from '@cindy/device-link';
 import { ServerApiError } from '../serverApiClient';
-import { __testing as settingsTesting } from '../device-link/settings-store';
+import {
+  __testing as settingsTesting,
+  normalizeCachedDeviceName,
+} from '../device-link/settings-store';
 import { __testing as refcountTesting } from '../device-link/subscriptionRefcount';
+import {
+  applyControllerDisplayNamePresence,
+  createControllerDisplayNameFreshnessTracker,
+  getControllerDisplayNameFreshnessSince,
+} from '../device-link/controllerDisplayNameFreshness';
 
 function makeDeps(overrides?: Partial<DeviceLinkIpcDeps>): DeviceLinkIpcDeps {
   return {
@@ -125,6 +143,11 @@ function makeDeps(overrides?: Partial<DeviceLinkIpcDeps>): DeviceLinkIpcDeps {
     readLastKnownDeviceNames: vi.fn(() => ({})),
     rememberLastKnownDeviceName: vi.fn(async () => false),
     forgetLastKnownDeviceName: vi.fn(async () => false),
+    captureControllerDisplayNameRequestEpoch: vi.fn(() => 0),
+    readControllerDisplayNameFreshnessSince: vi.fn(() => ({
+      changedAfterRequest: false,
+      authoritativeName: null,
+    })),
     ...overrides,
   };
 }
@@ -349,6 +372,94 @@ describe('device-link IPC handlers', () => {
       ],
     });
   });
+
+  it.each([
+    ['unknown', 'Host.local', 'Host.local'],
+    ['no', null, '12345678'],
+  ] as const)(
+    'listDevices:目录占位名 %s 无缓存时回退 selfName/设备短 ID(%s)',
+    async (name, selfName, expectedName) => {
+      const deps = makeDeps({
+        apiFetch: vi.fn().mockResolvedValue({
+          devices: [
+            {
+              deviceId: '1234567890abcdef',
+              name,
+              selfName,
+              platform: 'darwin',
+              lastSeenAt: '2026-06-23T00:00:00.000Z',
+              online: false,
+              busy: false,
+              remoteControlEnabled: false,
+              controlEnabled: true,
+              isSelf: false,
+            },
+          ],
+        }),
+        readLastKnownDeviceNames: vi.fn(() => ({})),
+      });
+
+      const result = await handleListDevices(deps);
+      expect(result.devices[0]?.name).toBe(expectedName);
+      expect(deps.rememberLastKnownDeviceName).not.toHaveBeenCalled();
+      expect(deps.forgetLastKnownDeviceName).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    ['旧目录名', '新数据库名', 'remember', '新数据库名'],
+    ['', '新数据库名', 'forget', '新数据库名'],
+    ['旧目录名', '', 'remember', 'Host.local'],
+  ] as const)(
+    'listDevices:旧目录 %s 在 presence(%s) 后不得触发 %s，并返回当前名称',
+    async (directoryName, presenceName, _mutation, expectedName) => {
+      const freshness = createControllerDisplayNameFreshnessTracker();
+      const rememberLastKnownDeviceName = vi.fn(async () => true);
+      const forgetLastKnownDeviceName = vi.fn(async () => true);
+      const apiFetch: DeviceLinkIpcDeps['apiFetch'] = async <T>() => {
+        applyControllerDisplayNamePresence({
+          deviceId: 'dev-1',
+          name: presenceName,
+          selfName: 'Host.local',
+          freshness,
+          normalizeName: (value) => normalizeCachedDeviceName(value),
+          setDisplayName: vi.fn(),
+          setFallbackDisplayName: vi.fn(),
+          rememberName: vi.fn(),
+          forgetName: vi.fn(),
+        });
+        return {
+          devices: [
+            {
+              deviceId: 'dev-1',
+              name: directoryName,
+              selfName: 'Host.local',
+              platform: 'darwin',
+              lastSeenAt: '2026-06-23T00:00:00.000Z',
+              online: true,
+              busy: false,
+              remoteControlEnabled: true,
+              controlEnabled: true,
+              isSelf: false,
+            },
+          ],
+        } as T;
+      };
+      const deps = makeDeps({
+        apiFetch,
+        rememberLastKnownDeviceName,
+        forgetLastKnownDeviceName,
+        captureControllerDisplayNameRequestEpoch: () => freshness.epoch,
+        readControllerDisplayNameFreshnessSince: (deviceId, requestEpoch) =>
+          getControllerDisplayNameFreshnessSince(freshness, deviceId, requestEpoch),
+      });
+
+      const result = await handleListDevices(deps);
+      expect(result.devices[0]?.name).toBe(expectedName);
+      expect(rememberLastKnownDeviceName).not.toHaveBeenCalled();
+      expect(forgetLastKnownDeviceName).not.toHaveBeenCalled();
+    },
+  );
 
   it.each([
     ['Host.local', 'Host.local'],

--- a/apps/desktop/src/main/__tests__/deviceLinkIpc.test.ts
+++ b/apps/desktop/src/main/__tests__/deviceLinkIpc.test.ts
@@ -512,6 +512,44 @@ describe('device-link IPC handlers', () => {
     expect(forgetLastKnownDeviceName).not.toHaveBeenCalled();
   });
 
+  it('listDevices:仅发生 relay reset 时仍采用并缓存有效数据库展示名', async () => {
+    const freshness = createControllerDisplayNameFreshnessTracker();
+    const rememberLastKnownDeviceName = vi.fn(async () => true);
+    const forgetLastKnownDeviceName = vi.fn(async () => true);
+    const apiFetch: DeviceLinkIpcDeps['apiFetch'] = async <T>() => {
+      resetControllerDisplayNameFreshness(freshness);
+      return {
+        devices: [
+          {
+            deviceId: 'dev-1',
+            name: '数据库展示名',
+            selfName: 'Host.local',
+            platform: 'darwin',
+            lastSeenAt: '2026-06-23T00:00:00.000Z',
+            online: false,
+            busy: false,
+            remoteControlEnabled: true,
+            controlEnabled: true,
+            isSelf: false,
+          },
+        ],
+      } as T;
+    };
+    const deps = makeDeps({
+      apiFetch,
+      rememberLastKnownDeviceName,
+      forgetLastKnownDeviceName,
+      captureControllerDisplayNameRequestEpoch: () => freshness.epoch,
+      readControllerDisplayNameFreshnessSince: (deviceId, requestEpoch) =>
+        getControllerDisplayNameFreshnessSince(freshness, deviceId, requestEpoch),
+    });
+
+    const result = await handleListDevices(deps);
+    expect(result.devices[0]?.name).toBe('数据库展示名');
+    expect(rememberLastKnownDeviceName).toHaveBeenCalledWith('dev-1', '数据库展示名');
+    expect(forgetLastKnownDeviceName).not.toHaveBeenCalled();
+  });
+
   it.each([
     ['旧目录名', '新数据库名', 'remember', '新数据库名'],
     ['', '新数据库名', 'forget', '新数据库名'],

--- a/apps/desktop/src/main/__tests__/deviceLinkSettingsStore.test.ts
+++ b/apps/desktop/src/main/__tests__/deviceLinkSettingsStore.test.ts
@@ -270,6 +270,23 @@ describe('writeDeviceLinkSetting', () => {
     expect(readDeviceLinkSettings().lastKnownDeviceNames).toEqual({ 'dev-1': 'MacBook' });
   });
 
+  it('remember/forget 待落盘时，同步读取先合并最新内存意图供重连 seed 使用', async () => {
+    h.seed(SETTINGS_PATH, JSON.stringify({ lastKnownDeviceNames: { 'dev-1': '旧名称' } }));
+    const {
+      forgetLastKnownDeviceName,
+      readLastKnownDeviceNames,
+      rememberLastKnownDeviceName,
+    } = await load();
+
+    const remember = rememberLastKnownDeviceName('dev-1', '新名称');
+    expect(readLastKnownDeviceNames()).toEqual({ 'dev-1': '新名称' });
+    await expect(remember).resolves.toBe(true);
+
+    const forget = forgetLastKnownDeviceName('dev-1');
+    expect(readLastKnownDeviceNames()).toEqual({});
+    await expect(forget).resolves.toBe(true);
+  });
+
   it('rememberLastKnownDeviceName 写缓存失败时不影响调用方', async () => {
     h.writeFileSync.mockImplementationOnce(() => {
       throw new Error('disk full');

--- a/apps/desktop/src/main/__tests__/deviceLinkSettingsStore.test.ts
+++ b/apps/desktop/src/main/__tests__/deviceLinkSettingsStore.test.ts
@@ -235,6 +235,27 @@ describe('writeDeviceLinkSetting', () => {
     expect(h.writeFileSync).not.toHaveBeenCalled();
   });
 
+  it('forgetLastKnownDeviceName 删除已清空的数据库展示名缓存', async () => {
+    h.seed(SETTINGS_PATH, JSON.stringify({ lastKnownDeviceNames: { 'dev-1': 'MacBook' } }));
+    const { forgetLastKnownDeviceName, readDeviceLinkSettings } = await load();
+
+    await expect(forgetLastKnownDeviceName('dev-1')).resolves.toBe(true);
+    expect(readDeviceLinkSettings().lastKnownDeviceNames).toEqual({});
+  });
+
+  it('空名删除排在尚未完成的旧名称写入之后，最终不残留旧缓存', async () => {
+    const {
+      forgetLastKnownDeviceName,
+      readDeviceLinkSettings,
+      rememberLastKnownDeviceName,
+    } = await load();
+
+    const remember = rememberLastKnownDeviceName('dev-1', '旧名称');
+    const forget = forgetLastKnownDeviceName('dev-1');
+    await expect(Promise.all([remember, forget])).resolves.toEqual([true, true]);
+    expect(readDeviceLinkSettings().lastKnownDeviceNames).toEqual({});
+  });
+
   it('rememberLastKnownDeviceName 写缓存失败时不影响调用方', async () => {
     h.writeFileSync.mockImplementationOnce(() => {
       throw new Error('disk full');

--- a/apps/desktop/src/main/__tests__/deviceLinkSettingsStore.test.ts
+++ b/apps/desktop/src/main/__tests__/deviceLinkSettingsStore.test.ts
@@ -256,6 +256,20 @@ describe('writeDeviceLinkSetting', () => {
     expect(readDeviceLinkSettings().lastKnownDeviceNames).toEqual({});
   });
 
+  it('空名删除尚未完成时，同名有效名称恢复会排在删除后重新写回', async () => {
+    h.seed(SETTINGS_PATH, JSON.stringify({ lastKnownDeviceNames: { 'dev-1': 'MacBook' } }));
+    const {
+      forgetLastKnownDeviceName,
+      readDeviceLinkSettings,
+      rememberLastKnownDeviceName,
+    } = await load();
+
+    const forget = forgetLastKnownDeviceName('dev-1');
+    const remember = rememberLastKnownDeviceName('dev-1', 'MacBook');
+    await expect(Promise.all([forget, remember])).resolves.toEqual([true, true]);
+    expect(readDeviceLinkSettings().lastKnownDeviceNames).toEqual({ 'dev-1': 'MacBook' });
+  });
+
   it('rememberLastKnownDeviceName 写缓存失败时不影响调用方', async () => {
     h.writeFileSync.mockImplementationOnce(() => {
       throw new Error('disk full');

--- a/apps/desktop/src/main/__tests__/deviceLinkSubscriptions.test.ts
+++ b/apps/desktop/src/main/__tests__/deviceLinkSubscriptions.test.ts
@@ -86,4 +86,13 @@ describe('subscriptions registry', () => {
     subs.subscribe('dev-1234567890', ['session:s2'], 'RealName');
     expect(subs.getControlControllers()[0].name).toBe('RealName');
   });
+
+  it('updateControllerMetadata 只更新已有控制端并报告展示名是否变化', () => {
+    expect(subs.updateControllerMetadata('missing', 'Ignored')).toBe(false);
+
+    subs.subscribe('ctrl', ['session:s1'], 'Old');
+    expect(subs.updateControllerMetadata('ctrl', 'Old')).toBe(false);
+    expect(subs.updateControllerMetadata('ctrl', 'New')).toBe(true);
+    expect(subs.getControlControllers()).toEqual([{ deviceId: 'ctrl', name: 'New' }]);
+  });
 });

--- a/apps/desktop/src/main/__tests__/deviceLinkVoiceCredentialBootstrap.test.ts
+++ b/apps/desktop/src/main/__tests__/deviceLinkVoiceCredentialBootstrap.test.ts
@@ -75,7 +75,9 @@ describe('mobile voice credential sync desktop bootstrap path', () => {
     expect(deviceLinkHost).toContain(
       'applyControllerDisplayNamePresence({',
     );
-    expect(deviceLinkHost).toContain('selfName: snap.selfName,');
+    expect(deviceLinkHost).toContain(
+      "Object.prototype.hasOwnProperty.call(snap, 'selfName')",
+    );
     expect(deviceLinkHost).toContain('applyControllerDisplayNameDirectorySnapshot({');
   });
 

--- a/apps/desktop/src/main/__tests__/deviceLinkVoiceCredentialBootstrap.test.ts
+++ b/apps/desktop/src/main/__tests__/deviceLinkVoiceCredentialBootstrap.test.ts
@@ -63,9 +63,14 @@ describe('mobile voice credential sync desktop bootstrap path', () => {
       'void refreshControllerDisplayNamesFromDirectory(displayNameGeneration);',
       onlineBranch,
     );
+    const replaySubscriptions = deviceLinkHost.indexOf(
+      "replayActiveSubscriptions('ws-online');",
+      onlineBranch,
+    );
     expect(onlineBranch).toBeGreaterThanOrEqual(0);
     expect(seedCachedNames).toBeGreaterThan(onlineBranch);
     expect(refreshDirectory).toBeGreaterThan(seedCachedNames);
+    expect(replaySubscriptions).toBeGreaterThan(refreshDirectory);
     expect(deviceLinkHost).toContain(
       'generation !== controllerDisplayNameRefreshGeneration',
     );

--- a/apps/desktop/src/main/__tests__/deviceLinkVoiceCredentialBootstrap.test.ts
+++ b/apps/desktop/src/main/__tests__/deviceLinkVoiceCredentialBootstrap.test.ts
@@ -50,6 +50,27 @@ describe('mobile voice credential sync desktop bootstrap path', () => {
     expect(deviceLinkHost).toContain('replayActiveSubscriptions(`presence-online:${snap.deviceId.slice(0, 8)}`, snap.deviceId);');
   });
 
+  it('每个 relay 连接代上线时从设备目录补齐已在线控制端展示名', () => {
+    const deviceLinkHost = readFileSync(resolve(mainRoot, 'device-link/index.ts'), 'utf8');
+
+    expect(deviceLinkHost).toContain("serverApiFetch<DeviceDirectoryResponse>('/api/device-link/devices'");
+    const onlineBranch = deviceLinkHost.indexOf("if (status === 'online') {");
+    const seedCachedNames = deviceLinkHost.indexOf(
+      'seedControllerDisplayNamesFromLastKnown();',
+      onlineBranch,
+    );
+    const refreshDirectory = deviceLinkHost.indexOf(
+      'void refreshControllerDisplayNamesFromDirectory(displayNameGeneration);',
+      onlineBranch,
+    );
+    expect(onlineBranch).toBeGreaterThanOrEqual(0);
+    expect(seedCachedNames).toBeGreaterThan(onlineBranch);
+    expect(refreshDirectory).toBeGreaterThan(seedCachedNames);
+    expect(deviceLinkHost).toContain(
+      'generation !== controllerDisplayNameRefreshGeneration',
+    );
+  });
+
   it('keeps device-link:voice:credential-sync matched but rejected (feature removed, readable error for old mobile)', () => {
     const dispatch = readFileSync(resolve(mainRoot, 'device-link/dispatch.ts'), 'utf8');
 

--- a/apps/desktop/src/main/__tests__/deviceLinkVoiceCredentialBootstrap.test.ts
+++ b/apps/desktop/src/main/__tests__/deviceLinkVoiceCredentialBootstrap.test.ts
@@ -75,6 +75,7 @@ describe('mobile voice credential sync desktop bootstrap path', () => {
     expect(deviceLinkHost).toContain(
       'applyControllerDisplayNamePresence({',
     );
+    expect(deviceLinkHost).toContain('selfName: snap.selfName,');
     expect(deviceLinkHost).toContain('applyControllerDisplayNameDirectorySnapshot({');
   });
 

--- a/apps/desktop/src/main/__tests__/deviceLinkVoiceCredentialBootstrap.test.ts
+++ b/apps/desktop/src/main/__tests__/deviceLinkVoiceCredentialBootstrap.test.ts
@@ -69,11 +69,20 @@ describe('mobile voice credential sync desktop bootstrap path', () => {
     expect(deviceLinkHost).toContain(
       'generation !== controllerDisplayNameRefreshGeneration',
     );
+    expect(deviceLinkHost).toContain(
+      'const requestEpoch = controllerDisplayNameFreshness.epoch;',
+    );
+    expect(deviceLinkHost).toContain(
+      'markControllerDisplayNamePresenceFresh(controllerDisplayNameFreshness, snap.deviceId);',
+    );
+    expect(deviceLinkHost).toContain('applyControllerDisplayNameDirectorySnapshot({');
   });
 
   it('presence 占位名或空名不覆盖已有展示名，无有效名时保留 dispatch 回退链', () => {
-    const deviceLinkHost = readFileSync(resolve(mainRoot, 'device-link/index.ts'), 'utf8');
-    const dispatch = readFileSync(resolve(mainRoot, 'device-link/dispatch.ts'), 'utf8');
+    const deviceLinkHost = readFileSync(resolve(mainRoot, 'device-link/index.ts'), 'utf8')
+      .replace(/\r\n/g, '\n');
+    const dispatch = readFileSync(resolve(mainRoot, 'device-link/dispatch.ts'), 'utf8')
+      .replace(/\r\n/g, '\n');
 
     const presenceHandler = deviceLinkHost.indexOf('client.onPresenceChanged');
     const normalizePresenceName = deviceLinkHost.indexOf(

--- a/apps/desktop/src/main/__tests__/deviceLinkVoiceCredentialBootstrap.test.ts
+++ b/apps/desktop/src/main/__tests__/deviceLinkVoiceCredentialBootstrap.test.ts
@@ -71,6 +71,35 @@ describe('mobile voice credential sync desktop bootstrap path', () => {
     );
   });
 
+  it('presence 占位名或空名不覆盖已有展示名，无有效名时保留 dispatch 回退链', () => {
+    const deviceLinkHost = readFileSync(resolve(mainRoot, 'device-link/index.ts'), 'utf8');
+    const dispatch = readFileSync(resolve(mainRoot, 'device-link/dispatch.ts'), 'utf8');
+
+    const presenceHandler = deviceLinkHost.indexOf('client.onPresenceChanged');
+    const normalizePresenceName = deviceLinkHost.indexOf(
+      'const presenceDisplayName = normalizeCachedDeviceName(snap.deviceName);',
+      presenceHandler,
+    );
+    const guardedDisplayNameUpdate = deviceLinkHost.indexOf(
+      'if (presenceDisplayName) {\n      setControllerDisplayName(snap.deviceId, presenceDisplayName);\n    }',
+      normalizePresenceName,
+    );
+    expect(presenceHandler).toBeGreaterThanOrEqual(0);
+    expect(normalizePresenceName).toBeGreaterThan(presenceHandler);
+    expect(guardedDisplayNameUpdate).toBeGreaterThan(normalizePresenceName);
+    expect(deviceLinkHost.slice(presenceHandler, guardedDisplayNameUpdate)).not.toContain(
+      'setControllerDisplayName(snap.deviceId, snap.deviceName)',
+    );
+
+    // guard 不写缓存时，dispatch 继续按「数据库名 → 自报名 → 短 ID」回退。
+    expect(dispatch).toContain(
+      'return controllerDisplayNameByDevice.get(deviceId)\n    ?? normalizedReportedName\n    ?? reportedControllerNameByDevice.get(deviceId);',
+    );
+    expect(dispatch).toContain(
+      'const displayName = normalized\n    ?? reportedControllerNameByDevice.get(deviceId)\n    ?? deviceId.slice(0, 8);',
+    );
+  });
+
   it('keeps device-link:voice:credential-sync matched but rejected (feature removed, readable error for old mobile)', () => {
     const dispatch = readFileSync(resolve(mainRoot, 'device-link/dispatch.ts'), 'utf8');
 

--- a/apps/desktop/src/main/__tests__/deviceLinkVoiceCredentialBootstrap.test.ts
+++ b/apps/desktop/src/main/__tests__/deviceLinkVoiceCredentialBootstrap.test.ts
@@ -75,6 +75,12 @@ describe('mobile voice credential sync desktop bootstrap path', () => {
       'generation !== controllerDisplayNameRefreshGeneration',
     );
     expect(deviceLinkHost).toContain(
+      'const directoryRequestSequence = beginControllerDisplayNameDirectoryRefresh();',
+    );
+    expect(deviceLinkHost).toContain(
+      '!isLatestControllerDisplayNameDirectoryRefresh(directoryRequestSequence)',
+    );
+    expect(deviceLinkHost).toContain(
       'const requestEpoch = controllerDisplayNameFreshness.epoch;',
     );
     expect(deviceLinkHost).toContain(

--- a/apps/desktop/src/main/__tests__/deviceLinkVoiceCredentialBootstrap.test.ts
+++ b/apps/desktop/src/main/__tests__/deviceLinkVoiceCredentialBootstrap.test.ts
@@ -81,6 +81,9 @@ describe('mobile voice credential sync desktop bootstrap path', () => {
       '!isLatestControllerDisplayNameDirectoryRefresh(directoryRequestSequence)',
     );
     expect(deviceLinkHost).toContain(
+      'latestControllerDisplayNameDirectoryRefresh = {',
+    );
+    expect(deviceLinkHost).toContain(
       'const requestEpoch = controllerDisplayNameFreshness.epoch;',
     );
     expect(deviceLinkHost).toContain(

--- a/apps/desktop/src/main/__tests__/deviceLinkVoiceCredentialBootstrap.test.ts
+++ b/apps/desktop/src/main/__tests__/deviceLinkVoiceCredentialBootstrap.test.ts
@@ -73,32 +73,24 @@ describe('mobile voice credential sync desktop bootstrap path', () => {
       'const requestEpoch = controllerDisplayNameFreshness.epoch;',
     );
     expect(deviceLinkHost).toContain(
-      'markControllerDisplayNamePresenceFresh(controllerDisplayNameFreshness, snap.deviceId);',
+      'applyControllerDisplayNamePresence({',
     );
     expect(deviceLinkHost).toContain('applyControllerDisplayNameDirectorySnapshot({');
   });
 
-  it('presence 占位名或空名不覆盖已有展示名，无有效名时保留 dispatch 回退链', () => {
+  it('presence 展示名统一走协调器，无有效权威名时保留 dispatch 回退链', () => {
     const deviceLinkHost = readFileSync(resolve(mainRoot, 'device-link/index.ts'), 'utf8')
       .replace(/\r\n/g, '\n');
     const dispatch = readFileSync(resolve(mainRoot, 'device-link/dispatch.ts'), 'utf8')
       .replace(/\r\n/g, '\n');
 
     const presenceHandler = deviceLinkHost.indexOf('client.onPresenceChanged');
-    const normalizePresenceName = deviceLinkHost.indexOf(
-      'const presenceDisplayName = normalizeCachedDeviceName(snap.deviceName);',
+    const applyPresenceName = deviceLinkHost.indexOf(
+      'applyControllerDisplayNamePresence({',
       presenceHandler,
     );
-    const guardedDisplayNameUpdate = deviceLinkHost.indexOf(
-      'if (presenceDisplayName) {\n      setControllerDisplayName(snap.deviceId, presenceDisplayName);\n    }',
-      normalizePresenceName,
-    );
     expect(presenceHandler).toBeGreaterThanOrEqual(0);
-    expect(normalizePresenceName).toBeGreaterThan(presenceHandler);
-    expect(guardedDisplayNameUpdate).toBeGreaterThan(normalizePresenceName);
-    expect(deviceLinkHost.slice(presenceHandler, guardedDisplayNameUpdate)).not.toContain(
-      'setControllerDisplayName(snap.deviceId, snap.deviceName)',
-    );
+    expect(applyPresenceName).toBeGreaterThan(presenceHandler);
 
     // guard 不写缓存时，dispatch 继续按「数据库名 → 自报名 → 短 ID」回退。
     expect(dispatch).toContain(

--- a/apps/desktop/src/main/device-link/__tests__/mirrorCacheIpcBoundary.test.ts
+++ b/apps/desktop/src/main/device-link/__tests__/mirrorCacheIpcBoundary.test.ts
@@ -98,7 +98,9 @@ vi.mock('../outboundSessionReferences', () => ({
   rewriteOutboundSessionReferences: vi.fn(async (_c, a) => a),
 }));
 vi.mock('../settings-store', () => ({
+  forgetLastKnownDeviceName: vi.fn(),
   isPlaceholderDeviceName: () => false,
+  normalizeCachedDeviceName: (name: string) => name.trim() || null,
   readDeviceLinkSettings: () => ({
     remoteControlEnabled: true,
     keepAwake: false,

--- a/apps/desktop/src/main/device-link/__tests__/mirrorCacheIpcBoundary.test.ts
+++ b/apps/desktop/src/main/device-link/__tests__/mirrorCacheIpcBoundary.test.ts
@@ -90,6 +90,11 @@ vi.mock('../index', () => ({
   restoreController: vi.fn(),
   broadcast: vi.fn(),
   deviceLinkApiBase: 'https://example.invalid',
+  captureControllerDisplayNameRequestEpoch: () => 0,
+  readControllerDisplayNameFreshnessSince: () => ({
+    changedAfterRequest: false,
+    authoritativeName: null,
+  }),
 }));
 vi.mock('../dispatch', () => ({ getActiveControllers: () => [] }));
 vi.mock('../outboundMedia', () => ({ rewriteOutboundMedia: vi.fn(async (_c, a) => a) }));

--- a/apps/desktop/src/main/device-link/__tests__/mirrorCacheIpcBoundary.test.ts
+++ b/apps/desktop/src/main/device-link/__tests__/mirrorCacheIpcBoundary.test.ts
@@ -91,7 +91,9 @@ vi.mock('../index', () => ({
   broadcast: vi.fn(),
   deviceLinkApiBase: 'https://example.invalid',
   applyControllerDisplayNameListSnapshot: vi.fn(),
+  beginControllerDisplayNameDirectoryRefresh: vi.fn(() => 1),
   captureControllerDisplayNameRequestEpoch: () => 0,
+  isLatestControllerDisplayNameDirectoryRefresh: vi.fn(() => true),
   readControllerDisplayNameFreshnessSince: () => ({
     changedAfterRequest: false,
     authoritativeName: null,

--- a/apps/desktop/src/main/device-link/__tests__/mirrorCacheIpcBoundary.test.ts
+++ b/apps/desktop/src/main/device-link/__tests__/mirrorCacheIpcBoundary.test.ts
@@ -94,6 +94,7 @@ vi.mock('../index', () => ({
   beginControllerDisplayNameDirectoryRefresh: vi.fn(() => 1),
   captureControllerDisplayNameRequestEpoch: () => 0,
   isLatestControllerDisplayNameDirectoryRefresh: vi.fn(() => true),
+  waitForNewerControllerDisplayNameDirectoryRefresh: vi.fn(async () => {}),
   readControllerDisplayNameFreshnessSince: () => ({
     changedAfterRequest: false,
     authoritativeName: null,

--- a/apps/desktop/src/main/device-link/__tests__/mirrorCacheIpcBoundary.test.ts
+++ b/apps/desktop/src/main/device-link/__tests__/mirrorCacheIpcBoundary.test.ts
@@ -90,6 +90,7 @@ vi.mock('../index', () => ({
   restoreController: vi.fn(),
   broadcast: vi.fn(),
   deviceLinkApiBase: 'https://example.invalid',
+  applyControllerDisplayNameListSnapshot: vi.fn(),
   captureControllerDisplayNameRequestEpoch: () => 0,
   readControllerDisplayNameFreshnessSince: () => ({
     changedAfterRequest: false,

--- a/apps/desktop/src/main/device-link/controllerDisplayNameFreshness.ts
+++ b/apps/desktop/src/main/device-link/controllerDisplayNameFreshness.ts
@@ -1,5 +1,6 @@
 export interface ControllerDisplayNameFreshnessTracker {
   epoch: number;
+  directoryRequestSequence: number;
   epochByDevice: Map<string, number>;
   authoritativeNameByDevice: Map<string, string>;
 }
@@ -20,9 +21,24 @@ type ControllerDisplayNameCandidate =
 export function createControllerDisplayNameFreshnessTracker(): ControllerDisplayNameFreshnessTracker {
   return {
     epoch: 0,
+    directoryRequestSequence: 0,
     epochByDevice: new Map(),
     authoritativeNameByDevice: new Map(),
   };
+}
+
+export function beginControllerDisplayNameDirectoryRequest(
+  tracker: ControllerDisplayNameFreshnessTracker,
+): number {
+  tracker.directoryRequestSequence += 1;
+  return tracker.directoryRequestSequence;
+}
+
+export function isLatestControllerDisplayNameDirectoryRequest(
+  tracker: ControllerDisplayNameFreshnessTracker,
+  sequence: number,
+): boolean {
+  return tracker.directoryRequestSequence === sequence;
 }
 
 function markControllerDisplayNamePresenceFresh(

--- a/apps/desktop/src/main/device-link/controllerDisplayNameFreshness.ts
+++ b/apps/desktop/src/main/device-link/controllerDisplayNameFreshness.ts
@@ -8,11 +8,16 @@ export interface ControllerDisplayNameDirectoryDevice {
   name?: unknown;
 }
 
+type ControllerDisplayNameCandidate =
+  | { kind: 'valid'; name: string }
+  | { kind: 'empty' }
+  | { kind: 'placeholder' };
+
 export function createControllerDisplayNameFreshnessTracker(): ControllerDisplayNameFreshnessTracker {
   return { epoch: 0, epochByDevice: new Map() };
 }
 
-export function markControllerDisplayNamePresenceFresh(
+function markControllerDisplayNamePresenceFresh(
   tracker: ControllerDisplayNameFreshnessTracker,
   deviceId: string,
 ): void {
@@ -36,6 +41,42 @@ export function seedControllerDisplayNamesFromCache(
   }
 }
 
+function classifyControllerDisplayName(
+  value: unknown,
+  normalizeName: (name: string) => string | null,
+): ControllerDisplayNameCandidate {
+  if (typeof value !== 'string') return { kind: 'placeholder' };
+  if (!value.trim()) return { kind: 'empty' };
+  const normalized = normalizeName(value);
+  return normalized
+    ? { kind: 'valid', name: normalized }
+    : { kind: 'placeholder' };
+}
+
+/**
+ * presence 只在携带有效名称时参与目录竞态的新鲜度判定。空名是显式清除，立即
+ * 让展示回退并删除 last-known；unknown/no 等占位值不改缓存，也不阻断目录补齐。
+ */
+export function applyControllerDisplayNamePresence(options: {
+  deviceId: string;
+  name: unknown;
+  freshness: ControllerDisplayNameFreshnessTracker;
+  normalizeName: (name: string) => string | null;
+  setDisplayName: (deviceId: string, name: string) => void;
+  rememberName: (deviceId: string, name: string) => void;
+  forgetName: (deviceId: string) => void;
+}): void {
+  const candidate = classifyControllerDisplayName(options.name, options.normalizeName);
+  if (candidate.kind === 'valid') {
+    markControllerDisplayNamePresenceFresh(options.freshness, options.deviceId);
+    options.setDisplayName(options.deviceId, candidate.name);
+    options.rememberName(options.deviceId, candidate.name);
+  } else if (candidate.kind === 'empty') {
+    options.setDisplayName(options.deviceId, '');
+    options.forgetName(options.deviceId);
+  }
+}
+
 /**
  * 应用设备目录快照时，跳过请求发起后收到过 presence 的设备。presence 比在途 REST
  * 快照新，旧目录值既不能覆盖当前提示，也不能重新写回 last-known 缓存。
@@ -48,17 +89,23 @@ export function applyControllerDisplayNameDirectorySnapshot(options: {
   normalizeName: (name: string) => string | null;
   setDisplayName: (deviceId: string, name: string) => void;
   rememberName: (deviceId: string, name: string) => void;
+  forgetName: (deviceId: string) => void;
 }): void {
   for (const device of options.devices) {
     if (typeof device.deviceId !== 'string' || !device.deviceId.trim()) continue;
     const deviceId = device.deviceId.trim();
     if ((options.freshness.epochByDevice.get(deviceId) ?? 0) > options.requestEpoch) continue;
 
-    const serverName =
-      typeof device.name === 'string' ? options.normalizeName(device.name) : null;
-    const displayName = serverName ?? options.cachedNames[deviceId];
-    if (!displayName) continue;
-    options.setDisplayName(deviceId, displayName);
-    if (serverName) options.rememberName(deviceId, serverName);
+    const candidate = classifyControllerDisplayName(device.name, options.normalizeName);
+    if (candidate.kind === 'valid') {
+      options.setDisplayName(deviceId, candidate.name);
+      options.rememberName(deviceId, candidate.name);
+    } else if (candidate.kind === 'empty') {
+      options.setDisplayName(deviceId, '');
+      options.forgetName(deviceId);
+    } else {
+      const cachedName = options.cachedNames[deviceId];
+      if (cachedName) options.setDisplayName(deviceId, cachedName);
+    }
   }
 }

--- a/apps/desktop/src/main/device-link/controllerDisplayNameFreshness.ts
+++ b/apps/desktop/src/main/device-link/controllerDisplayNameFreshness.ts
@@ -55,7 +55,8 @@ function classifyControllerDisplayName(
 
 /**
  * presence.deviceName 可能是数据库展示名，也可能是旧 relay 直接转发的主机名：
- * - 现代 presence 携带 selfName，说明 deviceName 是 relay 已解析的当前展示名；
+ * - 现代 presence 携带 selfName 字段（值可为 null），说明 deviceName 是 relay
+ *   已解析的当前展示名；
  *   即使两者恰好相同，也可能是用户刚把数据库名改成了自报名，必须权威更新；
  * - 旧 presence 缺少 selfName 时无法区分展示名与主机名，只在无目录/缓存时临时回退；
  * - 空名是显式清除，必须推进新鲜度以挡住在途旧目录响应；
@@ -73,9 +74,8 @@ export function applyControllerDisplayNamePresence(options: {
 }): void {
   const candidate = classifyControllerDisplayName(options.name, options.normalizeName);
   if (candidate.kind === 'valid') {
-    const hasResolvedSelfName =
-      typeof options.selfName === 'string' && options.selfName.trim().length > 0;
-    if (!hasResolvedSelfName) {
+    const hasSelfNameField = Object.prototype.hasOwnProperty.call(options, 'selfName');
+    if (!hasSelfNameField) {
       if (options.freshness.authoritativeNameByDevice.has(options.deviceId)) return;
       options.setDisplayName(options.deviceId, candidate.name);
       return;

--- a/apps/desktop/src/main/device-link/controllerDisplayNameFreshness.ts
+++ b/apps/desktop/src/main/device-link/controllerDisplayNameFreshness.ts
@@ -10,9 +10,7 @@ export interface ControllerDisplayNameDirectoryDevice {
 }
 
 type ControllerDisplayNameCandidate =
-  | { kind: 'valid'; name: string }
-  | { kind: 'empty' }
-  | { kind: 'placeholder' };
+  { kind: 'valid'; name: string } | { kind: 'empty' } | { kind: 'placeholder' };
 
 export function createControllerDisplayNameFreshnessTracker(): ControllerDisplayNameFreshnessTracker {
   return { epoch: 0, epochByDevice: new Map(), authoritativeNameByDevice: new Map() };
@@ -52,15 +50,14 @@ function classifyControllerDisplayName(
   if (typeof value !== 'string') return { kind: 'placeholder' };
   if (!value.trim()) return { kind: 'empty' };
   const normalized = normalizeName(value);
-  return normalized
-    ? { kind: 'valid', name: normalized }
-    : { kind: 'placeholder' };
+  return normalized ? { kind: 'valid', name: normalized } : { kind: 'placeholder' };
 }
 
 /**
- * presence.deviceName 可能是数据库展示名，也可能只是 hello 自报的系统主机名：
- * - 与 selfName 不同的有效值视为服务端已解析出的权威展示名；
- * - 与 selfName 相同（或旧协议没有 selfName）的值只作临时回退，不能覆盖目录/缓存；
+ * presence.deviceName 可能是数据库展示名，也可能是旧 relay 直接转发的主机名：
+ * - 现代 presence 携带 selfName，说明 deviceName 是 relay 已解析的当前展示名；
+ *   即使两者恰好相同，也可能是用户刚把数据库名改成了自报名，必须权威更新；
+ * - 旧 presence 缺少 selfName 时无法区分展示名与主机名，只在无目录/缓存时临时回退；
  * - 空名是显式清除，必须推进新鲜度以挡住在途旧目录响应；
  * - unknown/no 等占位值不改状态，也不阻断目录补齐。
  */
@@ -76,10 +73,9 @@ export function applyControllerDisplayNamePresence(options: {
 }): void {
   const candidate = classifyControllerDisplayName(options.name, options.normalizeName);
   if (candidate.kind === 'valid') {
-    const selfCandidate = classifyControllerDisplayName(options.selfName, options.normalizeName);
-    const isSelfReportedFallback = selfCandidate.kind !== 'valid'
-      || selfCandidate.name === candidate.name;
-    if (isSelfReportedFallback) {
+    const hasResolvedSelfName =
+      typeof options.selfName === 'string' && options.selfName.trim().length > 0;
+    if (!hasResolvedSelfName) {
       if (options.freshness.authoritativeNameByDevice.has(options.deviceId)) return;
       options.setDisplayName(options.deviceId, candidate.name);
       return;

--- a/apps/desktop/src/main/device-link/controllerDisplayNameFreshness.ts
+++ b/apps/desktop/src/main/device-link/controllerDisplayNameFreshness.ts
@@ -69,6 +69,7 @@ export function applyControllerDisplayNamePresence(options: {
   freshness: ControllerDisplayNameFreshnessTracker;
   normalizeName: (name: string) => string | null;
   setDisplayName: (deviceId: string, name: string) => void;
+  setFallbackDisplayName: (deviceId: string, name: string) => void;
   rememberName: (deviceId: string, name: string) => void;
   forgetName: (deviceId: string) => void;
 }): void {
@@ -77,7 +78,7 @@ export function applyControllerDisplayNamePresence(options: {
     const hasSelfNameField = Object.prototype.hasOwnProperty.call(options, 'selfName');
     if (!hasSelfNameField) {
       if (options.freshness.authoritativeNameByDevice.has(options.deviceId)) return;
-      options.setDisplayName(options.deviceId, candidate.name);
+      options.setFallbackDisplayName(options.deviceId, candidate.name);
       return;
     }
     markControllerDisplayNamePresenceFresh(options.freshness, options.deviceId);

--- a/apps/desktop/src/main/device-link/controllerDisplayNameFreshness.ts
+++ b/apps/desktop/src/main/device-link/controllerDisplayNameFreshness.ts
@@ -9,6 +9,11 @@ export interface ControllerDisplayNameDirectoryDevice {
   name?: unknown;
 }
 
+export interface ControllerDisplayNameFreshnessSince {
+  changedAfterRequest: boolean;
+  authoritativeName: string | null;
+}
+
 type ControllerDisplayNameCandidate =
   { kind: 'valid'; name: string } | { kind: 'empty' } | { kind: 'placeholder' };
 
@@ -41,6 +46,17 @@ export function seedControllerDisplayNamesFromCache(
     freshness.authoritativeNameByDevice.set(deviceId, name);
     setDisplayName(deviceId, name);
   }
+}
+
+export function getControllerDisplayNameFreshnessSince(
+  tracker: ControllerDisplayNameFreshnessTracker,
+  deviceId: string,
+  requestEpoch: number,
+): ControllerDisplayNameFreshnessSince {
+  return {
+    changedAfterRequest: (tracker.epochByDevice.get(deviceId) ?? 0) > requestEpoch,
+    authoritativeName: tracker.authoritativeNameByDevice.get(deviceId) ?? null,
+  };
 }
 
 function classifyControllerDisplayName(
@@ -110,7 +126,12 @@ export function applyControllerDisplayNameDirectorySnapshot(options: {
   for (const device of options.devices) {
     if (typeof device.deviceId !== 'string' || !device.deviceId.trim()) continue;
     const deviceId = device.deviceId.trim();
-    if ((options.freshness.epochByDevice.get(deviceId) ?? 0) > options.requestEpoch) continue;
+    if (
+      getControllerDisplayNameFreshnessSince(options.freshness, deviceId, options.requestEpoch)
+        .changedAfterRequest
+    ) {
+      continue;
+    }
 
     const candidate = classifyControllerDisplayName(device.name, options.normalizeName);
     if (candidate.kind === 'valid') {

--- a/apps/desktop/src/main/device-link/controllerDisplayNameFreshness.ts
+++ b/apps/desktop/src/main/device-link/controllerDisplayNameFreshness.ts
@@ -1,5 +1,6 @@
 export interface ControllerDisplayNameFreshnessTracker {
   epoch: number;
+  resetEpoch: number;
   epochByDevice: Map<string, number>;
   authoritativeNameByDevice: Map<string, string>;
 }
@@ -18,7 +19,12 @@ type ControllerDisplayNameCandidate =
   { kind: 'valid'; name: string } | { kind: 'empty' } | { kind: 'placeholder' };
 
 export function createControllerDisplayNameFreshnessTracker(): ControllerDisplayNameFreshnessTracker {
-  return { epoch: 0, epochByDevice: new Map(), authoritativeNameByDevice: new Map() };
+  return {
+    epoch: 0,
+    resetEpoch: 0,
+    epochByDevice: new Map(),
+    authoritativeNameByDevice: new Map(),
+  };
 }
 
 function markControllerDisplayNamePresenceFresh(
@@ -32,7 +38,8 @@ function markControllerDisplayNamePresenceFresh(
 export function resetControllerDisplayNameFreshness(
   tracker: ControllerDisplayNameFreshnessTracker,
 ): void {
-  tracker.epoch = 0;
+  tracker.epoch += 1;
+  tracker.resetEpoch = tracker.epoch;
   tracker.epochByDevice.clear();
   tracker.authoritativeNameByDevice.clear();
 }
@@ -54,7 +61,9 @@ export function getControllerDisplayNameFreshnessSince(
   requestEpoch: number,
 ): ControllerDisplayNameFreshnessSince {
   return {
-    changedAfterRequest: (tracker.epochByDevice.get(deviceId) ?? 0) > requestEpoch,
+    changedAfterRequest:
+      tracker.resetEpoch > requestEpoch
+      || (tracker.epochByDevice.get(deviceId) ?? 0) > requestEpoch,
     authoritativeName: tracker.authoritativeNameByDevice.get(deviceId) ?? null,
   };
 }

--- a/apps/desktop/src/main/device-link/controllerDisplayNameFreshness.ts
+++ b/apps/desktop/src/main/device-link/controllerDisplayNameFreshness.ts
@@ -1,0 +1,64 @@
+export interface ControllerDisplayNameFreshnessTracker {
+  epoch: number;
+  epochByDevice: Map<string, number>;
+}
+
+export interface ControllerDisplayNameDirectoryDevice {
+  deviceId?: unknown;
+  name?: unknown;
+}
+
+export function createControllerDisplayNameFreshnessTracker(): ControllerDisplayNameFreshnessTracker {
+  return { epoch: 0, epochByDevice: new Map() };
+}
+
+export function markControllerDisplayNamePresenceFresh(
+  tracker: ControllerDisplayNameFreshnessTracker,
+  deviceId: string,
+): void {
+  tracker.epoch += 1;
+  tracker.epochByDevice.set(deviceId, tracker.epoch);
+}
+
+export function resetControllerDisplayNameFreshness(
+  tracker: ControllerDisplayNameFreshnessTracker,
+): void {
+  tracker.epoch = 0;
+  tracker.epochByDevice.clear();
+}
+
+export function seedControllerDisplayNamesFromCache(
+  cachedNames: Readonly<Record<string, string>>,
+  setDisplayName: (deviceId: string, name: string) => void,
+): void {
+  for (const [deviceId, name] of Object.entries(cachedNames)) {
+    setDisplayName(deviceId, name);
+  }
+}
+
+/**
+ * 应用设备目录快照时，跳过请求发起后收到过 presence 的设备。presence 比在途 REST
+ * 快照新，旧目录值既不能覆盖当前提示，也不能重新写回 last-known 缓存。
+ */
+export function applyControllerDisplayNameDirectorySnapshot(options: {
+  devices: readonly ControllerDisplayNameDirectoryDevice[];
+  cachedNames: Readonly<Record<string, string>>;
+  freshness: ControllerDisplayNameFreshnessTracker;
+  requestEpoch: number;
+  normalizeName: (name: string) => string | null;
+  setDisplayName: (deviceId: string, name: string) => void;
+  rememberName: (deviceId: string, name: string) => void;
+}): void {
+  for (const device of options.devices) {
+    if (typeof device.deviceId !== 'string' || !device.deviceId.trim()) continue;
+    const deviceId = device.deviceId.trim();
+    if ((options.freshness.epochByDevice.get(deviceId) ?? 0) > options.requestEpoch) continue;
+
+    const serverName =
+      typeof device.name === 'string' ? options.normalizeName(device.name) : null;
+    const displayName = serverName ?? options.cachedNames[deviceId];
+    if (!displayName) continue;
+    options.setDisplayName(deviceId, displayName);
+    if (serverName) options.rememberName(deviceId, serverName);
+  }
+}

--- a/apps/desktop/src/main/device-link/controllerDisplayNameFreshness.ts
+++ b/apps/desktop/src/main/device-link/controllerDisplayNameFreshness.ts
@@ -1,6 +1,7 @@
 export interface ControllerDisplayNameFreshnessTracker {
   epoch: number;
   epochByDevice: Map<string, number>;
+  authoritativeNameByDevice: Map<string, string>;
 }
 
 export interface ControllerDisplayNameDirectoryDevice {
@@ -14,7 +15,7 @@ type ControllerDisplayNameCandidate =
   | { kind: 'placeholder' };
 
 export function createControllerDisplayNameFreshnessTracker(): ControllerDisplayNameFreshnessTracker {
-  return { epoch: 0, epochByDevice: new Map() };
+  return { epoch: 0, epochByDevice: new Map(), authoritativeNameByDevice: new Map() };
 }
 
 function markControllerDisplayNamePresenceFresh(
@@ -30,13 +31,16 @@ export function resetControllerDisplayNameFreshness(
 ): void {
   tracker.epoch = 0;
   tracker.epochByDevice.clear();
+  tracker.authoritativeNameByDevice.clear();
 }
 
 export function seedControllerDisplayNamesFromCache(
   cachedNames: Readonly<Record<string, string>>,
+  freshness: ControllerDisplayNameFreshnessTracker,
   setDisplayName: (deviceId: string, name: string) => void,
 ): void {
   for (const [deviceId, name] of Object.entries(cachedNames)) {
+    freshness.authoritativeNameByDevice.set(deviceId, name);
     setDisplayName(deviceId, name);
   }
 }
@@ -54,12 +58,16 @@ function classifyControllerDisplayName(
 }
 
 /**
- * presence 只在携带有效名称时参与目录竞态的新鲜度判定。空名是显式清除，立即
- * 让展示回退并删除 last-known；unknown/no 等占位值不改缓存，也不阻断目录补齐。
+ * presence.deviceName 可能是数据库展示名，也可能只是 hello 自报的系统主机名：
+ * - 与 selfName 不同的有效值视为服务端已解析出的权威展示名；
+ * - 与 selfName 相同（或旧协议没有 selfName）的值只作临时回退，不能覆盖目录/缓存；
+ * - 空名是显式清除，必须推进新鲜度以挡住在途旧目录响应；
+ * - unknown/no 等占位值不改状态，也不阻断目录补齐。
  */
 export function applyControllerDisplayNamePresence(options: {
   deviceId: string;
   name: unknown;
+  selfName?: unknown;
   freshness: ControllerDisplayNameFreshnessTracker;
   normalizeName: (name: string) => string | null;
   setDisplayName: (deviceId: string, name: string) => void;
@@ -68,10 +76,21 @@ export function applyControllerDisplayNamePresence(options: {
 }): void {
   const candidate = classifyControllerDisplayName(options.name, options.normalizeName);
   if (candidate.kind === 'valid') {
+    const selfCandidate = classifyControllerDisplayName(options.selfName, options.normalizeName);
+    const isSelfReportedFallback = selfCandidate.kind !== 'valid'
+      || selfCandidate.name === candidate.name;
+    if (isSelfReportedFallback) {
+      if (options.freshness.authoritativeNameByDevice.has(options.deviceId)) return;
+      options.setDisplayName(options.deviceId, candidate.name);
+      return;
+    }
     markControllerDisplayNamePresenceFresh(options.freshness, options.deviceId);
+    options.freshness.authoritativeNameByDevice.set(options.deviceId, candidate.name);
     options.setDisplayName(options.deviceId, candidate.name);
     options.rememberName(options.deviceId, candidate.name);
   } else if (candidate.kind === 'empty') {
+    markControllerDisplayNamePresenceFresh(options.freshness, options.deviceId);
+    options.freshness.authoritativeNameByDevice.delete(options.deviceId);
     options.setDisplayName(options.deviceId, '');
     options.forgetName(options.deviceId);
   }
@@ -98,14 +117,19 @@ export function applyControllerDisplayNameDirectorySnapshot(options: {
 
     const candidate = classifyControllerDisplayName(device.name, options.normalizeName);
     if (candidate.kind === 'valid') {
+      options.freshness.authoritativeNameByDevice.set(deviceId, candidate.name);
       options.setDisplayName(deviceId, candidate.name);
       options.rememberName(deviceId, candidate.name);
     } else if (candidate.kind === 'empty') {
+      options.freshness.authoritativeNameByDevice.delete(deviceId);
       options.setDisplayName(deviceId, '');
       options.forgetName(deviceId);
     } else {
       const cachedName = options.cachedNames[deviceId];
-      if (cachedName) options.setDisplayName(deviceId, cachedName);
+      if (cachedName) {
+        options.freshness.authoritativeNameByDevice.set(deviceId, cachedName);
+        options.setDisplayName(deviceId, cachedName);
+      }
     }
   }
 }

--- a/apps/desktop/src/main/device-link/controllerDisplayNameFreshness.ts
+++ b/apps/desktop/src/main/device-link/controllerDisplayNameFreshness.ts
@@ -1,6 +1,5 @@
 export interface ControllerDisplayNameFreshnessTracker {
   epoch: number;
-  resetEpoch: number;
   epochByDevice: Map<string, number>;
   authoritativeNameByDevice: Map<string, string>;
 }
@@ -21,7 +20,6 @@ type ControllerDisplayNameCandidate =
 export function createControllerDisplayNameFreshnessTracker(): ControllerDisplayNameFreshnessTracker {
   return {
     epoch: 0,
-    resetEpoch: 0,
     epochByDevice: new Map(),
     authoritativeNameByDevice: new Map(),
   };
@@ -39,7 +37,6 @@ export function resetControllerDisplayNameFreshness(
   tracker: ControllerDisplayNameFreshnessTracker,
 ): void {
   tracker.epoch += 1;
-  tracker.resetEpoch = tracker.epoch;
   tracker.epochByDevice.clear();
   tracker.authoritativeNameByDevice.clear();
 }
@@ -61,9 +58,7 @@ export function getControllerDisplayNameFreshnessSince(
   requestEpoch: number,
 ): ControllerDisplayNameFreshnessSince {
   return {
-    changedAfterRequest:
-      tracker.resetEpoch > requestEpoch
-      || (tracker.epochByDevice.get(deviceId) ?? 0) > requestEpoch,
+    changedAfterRequest: (tracker.epochByDevice.get(deviceId) ?? 0) > requestEpoch,
     authoritativeName: tracker.authoritativeNameByDevice.get(deviceId) ?? null,
   };
 }

--- a/apps/desktop/src/main/device-link/dispatch.ts
+++ b/apps/desktop/src/main/device-link/dispatch.ts
@@ -1484,6 +1484,7 @@ export function dropAllControllers(
     ...subscriptions.getControllerIds(),
     ...topicSubscriptionControllers,
     ...acceptedLinkControllers,
+    ...reportedControllerNameByDevice.keys(),
   ]);
   for (const dst of controllerIds) {
     try {
@@ -1498,6 +1499,7 @@ export function dropAllControllers(
   subscriptions.clearAll();
   topicSubscriptionControllers.clear();
   acceptedLinkControllers.clear();
+  reportedControllerNameByDevice.clear();
   offlinePushQueue.clear();
   clearAllSessionActivityStages();
   clearAllMakerEventBatchStages();

--- a/apps/desktop/src/main/device-link/dispatch.ts
+++ b/apps/desktop/src/main/device-link/dispatch.ts
@@ -555,6 +555,14 @@ const remoteInvokeLinkEpoch = new Map<string, number>();
 const topicSubscriptionControllers = new Set<string>();
 /** 已成功 accept、尚未显式 close 的控制端；可无 active topic(现代重连等待 subscribe)。 */
 const acceptedLinkControllers = new Set<string>();
+/**
+ * relay presence 按 server 盖章的 deviceId 提供设备数据库展示名。它比控制端在
+ * link-open / subscribe 里自报的主机名更权威，用于让被控提示与设备列表一致。
+ * 仅作展示，不参与任何授权判断；账号 / 链路边界由 host 显式清空。
+ */
+const controllerDisplayNameByDevice = new Map<string, string>();
+/** 控制帧自报名称仅作数据库展示名缺失时的兼容回退。 */
+const reportedControllerNameByDevice = new Map<string, string>();
 
 /** `sessions` 订阅出现时通知 host replay 当前列表级轻量状态。 */
 type SessionsSubscribedListener = (controllerDeviceId: string) => void;
@@ -572,6 +580,46 @@ export function setRemoteInvokeBusyChangedListener(
 
 export function setSessionsSubscribedListener(cb: SessionsSubscribedListener | null): void {
   onSessionsSubscribed = cb;
+}
+
+function normalizeControllerName(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim()
+    ? value.trim().slice(0, MAX_CONTROLLER_NAME_LEN)
+    : undefined;
+}
+
+function resolveControllerName(deviceId: string, reportedName: unknown): string | undefined {
+  const normalizedReportedName = normalizeControllerName(reportedName);
+  if (normalizedReportedName) {
+    reportedControllerNameByDevice.set(deviceId, normalizedReportedName);
+  }
+  return controllerDisplayNameByDevice.get(deviceId)
+    ?? normalizedReportedName
+    ?? reportedControllerNameByDevice.get(deviceId);
+}
+
+/**
+ * presence 设备名变化(含设置页重命名)时更新展示真相；已有活跃订阅立即重发
+ * controlled-state，让横幅不用等下一次 subscribe / 重连才改名。
+ */
+export function setControllerDisplayName(deviceId: string, name: string): void {
+  const normalized = normalizeControllerName(name);
+  if (normalized) {
+    if (controllerDisplayNameByDevice.get(deviceId) === normalized) return;
+    controllerDisplayNameByDevice.set(deviceId, normalized);
+  } else {
+    if (!controllerDisplayNameByDevice.delete(deviceId)) return;
+  }
+  const displayName = normalized
+    ?? reportedControllerNameByDevice.get(deviceId)
+    ?? deviceId.slice(0, 8);
+  if (subscriptions.updateControllerMetadata(deviceId, displayName)) syncForwarding();
+}
+
+/** 账号切换 / 链路 teardown 时清空 presence 展示名，避免串到下一段身份。 */
+export function clearControllerDisplayNames(): void {
+  controllerDisplayNameByDevice.clear();
+  reportedControllerNameByDevice.clear();
 }
 
 export function getActiveControllers(): ActiveController[] {
@@ -1623,10 +1671,7 @@ function handleLinkOpen(
     client.closeLink(src, 'revoked', 'inbound');
     return;
   }
-  const name =
-    typeof payload?.controllerName === 'string' && payload.controllerName.trim()
-      ? payload.controllerName.trim().slice(0, MAX_CONTROLLER_NAME_LEN)
-      : src.slice(0, 8);
+  const name = resolveControllerName(src, payload?.controllerName) ?? src.slice(0, 8);
   // 老控制端无 subscribe 能力:link-open 视作订阅 legacy '*'(全量转发 + 横幅),向后兼容。
   // 已在当前 link 上证明支持 topic 的客户端可能重复 open;不能重新装回兼容 wildcard。
   const capabilities = sanitizeControllerCapabilities(payload?.capabilities);
@@ -2578,10 +2623,7 @@ function handleSubscriptionFrame(src: string, payload: InvokePayload): InvokeRes
     : [];
   // legacy `'*'`(全量 firehose + 点亮被控横幅)只允许走 link-open 路径,不接受 subscribe 帧
   // 携带 —— 上面 filter 已剔除,防控制端一帧订全部会话流。
-  const name =
-    typeof o.controllerName === 'string' && o.controllerName.trim()
-      ? o.controllerName.trim().slice(0, MAX_CONTROLLER_NAME_LEN)
-      : undefined;
+  const name = resolveControllerName(src, o.controllerName);
   const isSub = payload.channel === DL_SUBSCRIBE_CHANNEL;
   if (isSub) {
     // link-open provisionally installs legacy '*' for old clients. A non-empty modern subscribe
@@ -2901,6 +2943,8 @@ export const __testing = {
     remoteInvokeLinkEpoch.clear();
     topicSubscriptionControllers.clear();
     acceptedLinkControllers.clear();
+    controllerDisplayNameByDevice.clear();
+    reportedControllerNameByDevice.clear();
     onSessionsSubscribed = null;
     activeClient = null;
     offlinePushQueue.clear();

--- a/apps/desktop/src/main/device-link/dispatch.ts
+++ b/apps/desktop/src/main/device-link/dispatch.ts
@@ -598,6 +598,10 @@ function resolveControllerName(deviceId: string, reportedName: unknown): string 
     ?? reportedControllerNameByDevice.get(deviceId);
 }
 
+function clearReportedControllerName(deviceId: string): void {
+  reportedControllerNameByDevice.delete(deviceId);
+}
+
 /**
  * presence 设备名变化(含设置页重命名)时更新展示真相；已有活跃订阅立即重发
  * controlled-state，让横幅不用等下一次 subscribe / 重连才改名。
@@ -1488,6 +1492,7 @@ export function dropAllControllers(
       // 本地授权/订阅清理不能依赖弱网下 link-close 真正写进 socket。
       log.warn(`closeLink to ${shortId(dst)} failed during ${reason}: ${String(err)}`);
     }
+    clearReportedControllerName(dst);
   }
   clearAllRemoteInvokeState();
   subscriptions.clearAll();
@@ -1508,6 +1513,7 @@ export function dropAllControllers(
  */
 export function handleControllerOffline(deviceId: string): void {
   acceptedLinkControllers.delete(deviceId);
+  clearReportedControllerName(deviceId);
   clearSessionActivityStage(deviceId);
   clearMakerEventBatchStage(deviceId);
   cancelLinkAcceptRetry(deviceId);
@@ -1523,6 +1529,7 @@ export function forgetControllerInvokeState(deviceId: string): void {
 
 /** 显式撤销时清理短时离线队列与 remembered topic，避免恢复后重放撤权期间数据。 */
 export function purgeRevokedController(deviceId: string): void {
+  clearReportedControllerName(deviceId);
   offlinePushQueue.clear(deviceId);
   clearSessionActivityStage(deviceId);
   clearMakerEventBatchStage(deviceId);
@@ -1575,6 +1582,7 @@ async function handleFrame(client: DeviceLinkClient, env: Envelope): Promise<voi
       clearMakerEventBatchStage(src);
       cancelLinkAcceptRetry(src);
       acceptedLinkControllers.delete(src);
+      clearReportedControllerName(src);
       // Keep the protocol-capability marker, but discard all remembered routing.
       // A modern controller must reconnect and explicitly subscribe; restoring the
       // legacy wildcard here would silently re-enable broad delivery.

--- a/apps/desktop/src/main/device-link/dispatch.ts
+++ b/apps/desktop/src/main/device-link/dispatch.ts
@@ -612,7 +612,7 @@ export function setControllerDisplayName(deviceId: string, name: string): void {
     if (controllerDisplayNameByDevice.get(deviceId) === normalized) return;
     controllerDisplayNameByDevice.set(deviceId, normalized);
   } else {
-    if (!controllerDisplayNameByDevice.delete(deviceId)) return;
+    controllerDisplayNameByDevice.delete(deviceId);
   }
   const displayName = normalized
     ?? reportedControllerNameByDevice.get(deviceId)

--- a/apps/desktop/src/main/device-link/dispatch.ts
+++ b/apps/desktop/src/main/device-link/dispatch.ts
@@ -620,6 +620,22 @@ export function setControllerDisplayName(deviceId: string, name: string): void {
   if (subscriptions.updateControllerMetadata(deviceId, displayName)) syncForwarding();
 }
 
+/**
+ * 旧 relay presence 的主机名只刷新当前横幅，不进入数据库名或控制帧自报名缓存。
+ * 已有权威名或链路自报名时保持原优先级；断链后 metadata 随订阅一起失效。
+ */
+export function setControllerFallbackDisplayName(deviceId: string, name: string): void {
+  const normalized = normalizeControllerName(name);
+  if (
+    !normalized
+    || controllerDisplayNameByDevice.has(deviceId)
+    || reportedControllerNameByDevice.has(deviceId)
+  ) {
+    return;
+  }
+  if (subscriptions.updateControllerMetadata(deviceId, normalized)) syncForwarding();
+}
+
 /** 账号切换 / 链路 teardown 时清空 presence 展示名，避免串到下一段身份。 */
 export function clearControllerDisplayNames(): void {
   controllerDisplayNameByDevice.clear();

--- a/apps/desktop/src/main/device-link/index.ts
+++ b/apps/desktop/src/main/device-link/index.ts
@@ -89,8 +89,10 @@ import {
 import {
   applyControllerDisplayNameDirectorySnapshot,
   applyControllerDisplayNamePresence,
+  beginControllerDisplayNameDirectoryRequest,
   createControllerDisplayNameFreshnessTracker,
   getControllerDisplayNameFreshnessSince,
+  isLatestControllerDisplayNameDirectoryRequest,
   resetControllerDisplayNameFreshness,
   seedControllerDisplayNamesFromCache,
   type ControllerDisplayNameDirectoryDevice,
@@ -162,6 +164,17 @@ export function captureControllerDisplayNameRequestEpoch(): number {
   return controllerDisplayNameFreshness.epoch;
 }
 
+export function beginControllerDisplayNameDirectoryRefresh(): number {
+  return beginControllerDisplayNameDirectoryRequest(controllerDisplayNameFreshness);
+}
+
+export function isLatestControllerDisplayNameDirectoryRefresh(sequence: number): boolean {
+  return isLatestControllerDisplayNameDirectoryRequest(
+    controllerDisplayNameFreshness,
+    sequence,
+  );
+}
+
 export function readControllerDisplayNameFreshnessSince(
   deviceId: string,
   requestEpoch: number,
@@ -207,6 +220,7 @@ function seedControllerDisplayNamesFromLastKnown(): void {
  * 上线时从现有设备目录补齐展示名，避免 link-open 抢先时长期停在主机名回退。
  */
 async function refreshControllerDisplayNamesFromDirectory(generation: number): Promise<void> {
+  const directoryRequestSequence = beginControllerDisplayNameDirectoryRefresh();
   const requestEpoch = controllerDisplayNameFreshness.epoch;
   try {
     const result = await serverApiFetch<DeviceDirectoryResponse>('/api/device-link/devices', {
@@ -215,6 +229,7 @@ async function refreshControllerDisplayNamesFromDirectory(generation: number): P
     });
     if (
       generation !== controllerDisplayNameRefreshGeneration
+      || !isLatestControllerDisplayNameDirectoryRefresh(directoryRequestSequence)
       || linkTornDown
       || client?.getStatus() !== 'online'
     ) {

--- a/apps/desktop/src/main/device-link/index.ts
+++ b/apps/desktop/src/main/device-link/index.ts
@@ -84,6 +84,13 @@ import {
   getControllerPlatform,
   setControllerPlatform,
 } from './controllerPlatform';
+import {
+  applyControllerDisplayNameDirectorySnapshot,
+  createControllerDisplayNameFreshnessTracker,
+  markControllerDisplayNamePresenceFresh,
+  resetControllerDisplayNameFreshness,
+  seedControllerDisplayNamesFromCache,
+} from './controllerDisplayNameFreshness';
 import { setBusyProbe, helloBusy, pollBusyChange, resetBusyDedupe } from './busyReporter';
 import {
   DL_VOICE_DICTIONARY_SYNC_CHANNEL,
@@ -145,11 +152,10 @@ type DeviceDirectoryResponse = {
   devices?: Array<{ deviceId?: unknown; name?: unknown }>;
 };
 let controllerDisplayNameRefreshGeneration = 0;
+const controllerDisplayNameFreshness = createControllerDisplayNameFreshnessTracker();
 
 function seedControllerDisplayNamesFromLastKnown(): void {
-  for (const [deviceId, name] of Object.entries(readLastKnownDeviceNames())) {
-    setControllerDisplayName(deviceId, name);
-  }
+  seedControllerDisplayNamesFromCache(readLastKnownDeviceNames(), setControllerDisplayName);
 }
 
 /**
@@ -157,6 +163,7 @@ function seedControllerDisplayNamesFromLastKnown(): void {
  * 上线时从现有设备目录补齐展示名，避免 link-open 抢先时长期停在主机名回退。
  */
 async function refreshControllerDisplayNamesFromDirectory(generation: number): Promise<void> {
+  const requestEpoch = controllerDisplayNameFreshness.epoch;
   try {
     const result = await serverApiFetch<DeviceDirectoryResponse>('/api/device-link/devices', {
       baseUrl: deviceLinkApiBase,
@@ -170,17 +177,17 @@ async function refreshControllerDisplayNamesFromDirectory(generation: number): P
       return;
     }
     const cachedNames = readLastKnownDeviceNames();
-    for (const device of result.devices ?? []) {
-      if (typeof device.deviceId !== 'string' || !device.deviceId.trim()) continue;
-      const deviceId = device.deviceId.trim();
-      const serverName = typeof device.name === 'string'
-        ? normalizeCachedDeviceName(device.name)
-        : null;
-      const displayName = serverName ?? cachedNames[deviceId];
-      if (!displayName) continue;
-      setControllerDisplayName(deviceId, displayName);
-      if (serverName) void rememberLastKnownDeviceName(deviceId, serverName);
-    }
+    applyControllerDisplayNameDirectorySnapshot({
+      devices: result.devices ?? [],
+      cachedNames,
+      freshness: controllerDisplayNameFreshness,
+      requestEpoch,
+      normalizeName: normalizeCachedDeviceName,
+      setDisplayName: setControllerDisplayName,
+      rememberName: (deviceId, name) => {
+        void rememberLastKnownDeviceName(deviceId, name);
+      },
+    });
   } catch (err) {
     // 目录补齐是展示层 best-effort；失败时保留控制帧自报名 / 短 ID 回退，不影响建链。
     log.warn(`device directory display-name refresh failed (non-fatal): ${String(err)}`);
@@ -556,6 +563,7 @@ export function initDeviceLinkService(options: DeviceLinkServiceOptions = {}): v
     if (status !== 'online') {
       presenceOnlineByDevice.clear();
       presenceAvailableByDevice.clear();
+      resetControllerDisplayNameFreshness(controllerDisplayNameFreshness);
     }
     broadcast(DEVICE_LINK_PUSH.STATUS_CHANGED, { status });
     handleContactsDeviceLinkStatusChanged(status === 'online');
@@ -599,6 +607,7 @@ export function initDeviceLinkService(options: DeviceLinkServiceOptions = {}): v
     transportTimeoutReopen.trigger(deviceId);
   });
   client.onPresenceChanged((snap: PresenceSnapshot) => {
+    markControllerDisplayNamePresenceFresh(controllerDisplayNameFreshness, snap.deviceId);
     const wasAvailable = presenceAvailableByDevice.get(snap.deviceId);
     const available = snap.online && snap.remoteControlEnabled;
     const wasOnline = presenceOnlineByDevice.get(snap.deviceId);
@@ -1008,6 +1017,7 @@ function teardownActiveLink(): void {
   // 同步在降级过一次之后永久失效。清空 presence 就够了 —— 没有对端就不会发送,
   // client 为 null 时 sendPush 也是 no-op。
   presenceOnlineByDevice.clear();
+  resetControllerDisplayNameFreshness(controllerDisplayNameFreshness);
   clearControllerPlatforms();
   clearControllerDisplayNames();
   presenceNameByDevice.clear();

--- a/apps/desktop/src/main/device-link/index.ts
+++ b/apps/desktop/src/main/device-link/index.ts
@@ -159,6 +159,10 @@ type DeviceDirectoryResponse = {
 };
 let controllerDisplayNameRefreshGeneration = 0;
 const controllerDisplayNameFreshness = createControllerDisplayNameFreshnessTracker();
+let latestControllerDisplayNameDirectoryRefresh: {
+  sequence: number;
+  promise: Promise<void>;
+} | null = null;
 
 export function captureControllerDisplayNameRequestEpoch(): number {
   return controllerDisplayNameFreshness.epoch;
@@ -173,6 +177,18 @@ export function isLatestControllerDisplayNameDirectoryRefresh(sequence: number):
     controllerDisplayNameFreshness,
     sequence,
   );
+}
+
+export async function waitForNewerControllerDisplayNameDirectoryRefresh(
+  sequence: number,
+): Promise<void> {
+  let pending = latestControllerDisplayNameDirectoryRefresh;
+  while (pending && pending.sequence > sequence) {
+    await pending.promise;
+    const latest = latestControllerDisplayNameDirectoryRefresh;
+    if (!latest || latest.sequence <= pending.sequence) return;
+    pending = latest;
+  }
 }
 
 export function readControllerDisplayNameFreshnessSince(
@@ -219,9 +235,11 @@ function seedControllerDisplayNamesFromLastKnown(): void {
  * presence 是增量流，新建连接不会收到已在线设备的历史快照；每个 relay 连接代
  * 上线时从现有设备目录补齐展示名，避免 link-open 抢先时长期停在主机名回退。
  */
-async function refreshControllerDisplayNamesFromDirectory(generation: number): Promise<void> {
-  const directoryRequestSequence = beginControllerDisplayNameDirectoryRefresh();
-  const requestEpoch = controllerDisplayNameFreshness.epoch;
+async function runControllerDisplayNamesFromDirectory(
+  generation: number,
+  directoryRequestSequence: number,
+  requestEpoch: number,
+): Promise<void> {
   try {
     const result = await serverApiFetch<DeviceDirectoryResponse>('/api/device-link/devices', {
       baseUrl: deviceLinkApiBase,
@@ -254,6 +272,21 @@ async function refreshControllerDisplayNamesFromDirectory(generation: number): P
     // 目录补齐是展示层 best-effort；失败时保留控制帧自报名 / 短 ID 回退，不影响建链。
     log.warn(`device directory display-name refresh failed (non-fatal): ${String(err)}`);
   }
+}
+
+function refreshControllerDisplayNamesFromDirectory(generation: number): Promise<void> {
+  const directoryRequestSequence = beginControllerDisplayNameDirectoryRefresh();
+  const requestEpoch = controllerDisplayNameFreshness.epoch;
+  const promise = runControllerDisplayNamesFromDirectory(
+    generation,
+    directoryRequestSequence,
+    requestEpoch,
+  );
+  latestControllerDisplayNameDirectoryRefresh = {
+    sequence: directoryRequestSequence,
+    promise,
+  };
+  return promise;
 }
 
 let client: DeviceLinkClient | null = null;

--- a/apps/desktop/src/main/device-link/index.ts
+++ b/apps/desktop/src/main/device-link/index.ts
@@ -55,6 +55,7 @@ import {
   shouldAbortTransportTimeoutReopen,
 } from './transportTimeoutReopen';
 import {
+  forgetLastKnownDeviceName,
   normalizeCachedDeviceName,
   readDeviceLinkSettings,
   readLastKnownDeviceNames,
@@ -86,8 +87,8 @@ import {
 } from './controllerPlatform';
 import {
   applyControllerDisplayNameDirectorySnapshot,
+  applyControllerDisplayNamePresence,
   createControllerDisplayNameFreshnessTracker,
-  markControllerDisplayNamePresenceFresh,
   resetControllerDisplayNameFreshness,
   seedControllerDisplayNamesFromCache,
 } from './controllerDisplayNameFreshness';
@@ -186,6 +187,9 @@ async function refreshControllerDisplayNamesFromDirectory(generation: number): P
       setDisplayName: setControllerDisplayName,
       rememberName: (deviceId, name) => {
         void rememberLastKnownDeviceName(deviceId, name);
+      },
+      forgetName: (deviceId) => {
+        void forgetLastKnownDeviceName(deviceId);
       },
     });
   } catch (err) {
@@ -607,7 +611,6 @@ export function initDeviceLinkService(options: DeviceLinkServiceOptions = {}): v
     transportTimeoutReopen.trigger(deviceId);
   });
   client.onPresenceChanged((snap: PresenceSnapshot) => {
-    markControllerDisplayNamePresenceFresh(controllerDisplayNameFreshness, snap.deviceId);
     const wasAvailable = presenceAvailableByDevice.get(snap.deviceId);
     const available = snap.online && snap.remoteControlEnabled;
     const wasOnline = presenceOnlineByDevice.get(snap.deviceId);
@@ -621,12 +624,20 @@ export function initDeviceLinkService(options: DeviceLinkServiceOptions = {}): v
     // (review P2)。翻转判据统一为「观察到进入某状态(含从未知)即触发一次」。
     if (!available && wasAvailable !== false) responsivenessTracker?.clearDevice(snap.deviceId);
     setControllerPlatform(snap.deviceId, snap.platform);
-    const presenceDisplayName = normalizeCachedDeviceName(snap.deviceName);
-    if (presenceDisplayName) {
-      setControllerDisplayName(snap.deviceId, presenceDisplayName);
-    }
+    applyControllerDisplayNamePresence({
+      deviceId: snap.deviceId,
+      name: snap.deviceName,
+      freshness: controllerDisplayNameFreshness,
+      normalizeName: normalizeCachedDeviceName,
+      setDisplayName: setControllerDisplayName,
+      rememberName: (deviceId, name) => {
+        void rememberLastKnownDeviceName(deviceId, name);
+      },
+      forgetName: (deviceId) => {
+        void forgetLastKnownDeviceName(deviceId);
+      },
+    });
     presenceNameByDevice.set(snap.deviceId, snap.selfName || snap.deviceName);
-    void rememberLastKnownDeviceName(snap.deviceId, snap.deviceName); // best-effort 名称缓存,不阻塞 presence 处理
     broadcast(DEVICE_LINK_PUSH.PRESENCE_CHANGED, snap);
     // 被控端兜底:对等控制端下线 → 清掉它在本机的订阅 registry(防僵尸订阅持续 sendPush)。
     if (!snap.online) handleControllerOffline(snap.deviceId);

--- a/apps/desktop/src/main/device-link/index.ts
+++ b/apps/desktop/src/main/device-link/index.ts
@@ -77,6 +77,7 @@ import {
   handleControllerOffline,
   purgeRevokedController,
   setControllerDisplayName,
+  setControllerFallbackDisplayName,
   clearControllerDisplayNames,
   setDispatchPresenceOfflineCheck,
 } from './dispatch';
@@ -637,6 +638,7 @@ export function initDeviceLinkService(options: DeviceLinkServiceOptions = {}): v
       freshness: controllerDisplayNameFreshness,
       normalizeName: normalizeCachedDeviceName,
       setDisplayName: setControllerDisplayName,
+      setFallbackDisplayName: setControllerFallbackDisplayName,
       rememberName: (deviceId, name) => {
         void rememberLastKnownDeviceName(deviceId, name);
       },

--- a/apps/desktop/src/main/device-link/index.ts
+++ b/apps/desktop/src/main/device-link/index.ts
@@ -72,6 +72,8 @@ import {
   forgetControllerInvokeState,
   handleControllerOffline,
   purgeRevokedController,
+  setControllerDisplayName,
+  clearControllerDisplayNames,
   setDispatchPresenceOfflineCheck,
 } from './dispatch';
 import {
@@ -555,6 +557,7 @@ export function initDeviceLinkService(options: DeviceLinkServiceOptions = {}): v
     // (review P2)。翻转判据统一为「观察到进入某状态(含从未知)即触发一次」。
     if (!available && wasAvailable !== false) responsivenessTracker?.clearDevice(snap.deviceId);
     setControllerPlatform(snap.deviceId, snap.platform);
+    setControllerDisplayName(snap.deviceId, snap.deviceName);
     presenceNameByDevice.set(snap.deviceId, snap.selfName || snap.deviceName);
     void rememberLastKnownDeviceName(snap.deviceId, snap.deviceName); // best-effort 名称缓存,不阻塞 presence 处理
     broadcast(DEVICE_LINK_PUSH.PRESENCE_CHANGED, snap);
@@ -947,6 +950,7 @@ function teardownActiveLink(): void {
   // client 为 null 时 sendPush 也是 no-op。
   presenceOnlineByDevice.clear();
   clearControllerPlatforms();
+  clearControllerDisplayNames();
   presenceNameByDevice.clear();
   resetSubscriptionRefs();
   resetBusyDedupe(); // 重置 busy dedupe,避免重连后首个真实 busy 状态被旧值压掉

--- a/apps/desktop/src/main/device-link/index.ts
+++ b/apps/desktop/src/main/device-link/index.ts
@@ -93,6 +93,7 @@ import {
   getControllerDisplayNameFreshnessSince,
   resetControllerDisplayNameFreshness,
   seedControllerDisplayNamesFromCache,
+  type ControllerDisplayNameDirectoryDevice,
 } from './controllerDisplayNameFreshness';
 import { setBusyProbe, helloBusy, pollBusyChange, resetBusyDedupe } from './busyReporter';
 import {
@@ -170,6 +171,27 @@ export function readControllerDisplayNameFreshnessSince(
     deviceId,
     requestEpoch,
   );
+}
+
+/**
+ * renderer 的设备列表刷新同样来自权威目录。把最新响应同步进被控提示元数据，
+ * 让 REST 改名/清空无需等待 presence 或 relay 重连；last-known 落盘仍由 IPC
+ * reconcile 负责，避免同一目录响应重复排队写入。
+ */
+export function applyControllerDisplayNameListSnapshot(
+  devices: readonly ControllerDisplayNameDirectoryDevice[],
+  requestEpoch: number,
+): void {
+  applyControllerDisplayNameDirectorySnapshot({
+    devices,
+    cachedNames: readLastKnownDeviceNames(),
+    freshness: controllerDisplayNameFreshness,
+    requestEpoch,
+    normalizeName: normalizeCachedDeviceName,
+    setDisplayName: setControllerDisplayName,
+    rememberName: () => {},
+    forgetName: () => {},
+  });
 }
 
 function seedControllerDisplayNamesFromLastKnown(): void {

--- a/apps/desktop/src/main/device-link/index.ts
+++ b/apps/desktop/src/main/device-link/index.ts
@@ -55,7 +55,7 @@ import {
   shouldAbortTransportTimeoutReopen,
 } from './transportTimeoutReopen';
 import {
-  isPlaceholderDeviceName,
+  normalizeCachedDeviceName,
   readDeviceLinkSettings,
   readLastKnownDeviceNames,
   rememberLastKnownDeviceName,
@@ -173,12 +173,13 @@ async function refreshControllerDisplayNamesFromDirectory(generation: number): P
     for (const device of result.devices ?? []) {
       if (typeof device.deviceId !== 'string' || !device.deviceId.trim()) continue;
       const deviceId = device.deviceId.trim();
-      const serverName = typeof device.name === 'string' ? device.name.trim() : '';
-      const hasDisplayName = !!serverName && !isPlaceholderDeviceName(serverName);
-      const displayName = hasDisplayName ? serverName : cachedNames[deviceId];
+      const serverName = typeof device.name === 'string'
+        ? normalizeCachedDeviceName(device.name)
+        : null;
+      const displayName = serverName ?? cachedNames[deviceId];
       if (!displayName) continue;
       setControllerDisplayName(deviceId, displayName);
-      if (hasDisplayName) void rememberLastKnownDeviceName(deviceId, serverName);
+      if (serverName) void rememberLastKnownDeviceName(deviceId, serverName);
     }
   } catch (err) {
     // 目录补齐是展示层 best-effort；失败时保留控制帧自报名 / 短 ID 回退，不影响建链。
@@ -611,7 +612,10 @@ export function initDeviceLinkService(options: DeviceLinkServiceOptions = {}): v
     // (review P2)。翻转判据统一为「观察到进入某状态(含从未知)即触发一次」。
     if (!available && wasAvailable !== false) responsivenessTracker?.clearDevice(snap.deviceId);
     setControllerPlatform(snap.deviceId, snap.platform);
-    setControllerDisplayName(snap.deviceId, snap.deviceName);
+    const presenceDisplayName = normalizeCachedDeviceName(snap.deviceName);
+    if (presenceDisplayName) {
+      setControllerDisplayName(snap.deviceId, presenceDisplayName);
+    }
     presenceNameByDevice.set(snap.deviceId, snap.selfName || snap.deviceName);
     void rememberLastKnownDeviceName(snap.deviceId, snap.deviceName); // best-effort 名称缓存,不阻塞 presence 处理
     broadcast(DEVICE_LINK_PUSH.PRESENCE_CHANGED, snap);

--- a/apps/desktop/src/main/device-link/index.ts
+++ b/apps/desktop/src/main/device-link/index.ts
@@ -631,7 +631,9 @@ export function initDeviceLinkService(options: DeviceLinkServiceOptions = {}): v
     applyControllerDisplayNamePresence({
       deviceId: snap.deviceId,
       name: snap.deviceName,
-      selfName: snap.selfName,
+      ...(Object.prototype.hasOwnProperty.call(snap, 'selfName')
+        ? { selfName: snap.selfName }
+        : {}),
       freshness: controllerDisplayNameFreshness,
       normalizeName: normalizeCachedDeviceName,
       setDisplayName: setControllerDisplayName,

--- a/apps/desktop/src/main/device-link/index.ts
+++ b/apps/desktop/src/main/device-link/index.ts
@@ -42,6 +42,7 @@ import { createLogger } from '../logger';
 import { onQuit } from '../lifecycle';
 import { tryGetDbClient } from '../localDb/client/current';
 import { createOutboundHttpAgent } from '../maker-host/outbound-fetch';
+import { serverApiFetch } from '../serverApiClient';
 import {
   DeviceLinkOwnershipArbiter,
   createDbClientOwnershipStore,
@@ -54,7 +55,9 @@ import {
   shouldAbortTransportTimeoutReopen,
 } from './transportTimeoutReopen';
 import {
+  isPlaceholderDeviceName,
   readDeviceLinkSettings,
+  readLastKnownDeviceNames,
   rememberLastKnownDeviceName,
   updateDeviceLinkSetting,
   writeDeviceLinkSetting,
@@ -136,6 +139,51 @@ const WS_PATH = '/api/device-link/ws';
 /** relay REST base(media presign / devices 等);供 mediaTransfer / ipc 复用。 */
 export function deviceLinkApiBase(): string {
   return getClientEndpoint('deviceLinkApiBaseUrl');
+}
+
+type DeviceDirectoryResponse = {
+  devices?: Array<{ deviceId?: unknown; name?: unknown }>;
+};
+let controllerDisplayNameRefreshGeneration = 0;
+
+function seedControllerDisplayNamesFromLastKnown(): void {
+  for (const [deviceId, name] of Object.entries(readLastKnownDeviceNames())) {
+    setControllerDisplayName(deviceId, name);
+  }
+}
+
+/**
+ * presence 是增量流，新建连接不会收到已在线设备的历史快照；每个 relay 连接代
+ * 上线时从现有设备目录补齐展示名，避免 link-open 抢先时长期停在主机名回退。
+ */
+async function refreshControllerDisplayNamesFromDirectory(generation: number): Promise<void> {
+  try {
+    const result = await serverApiFetch<DeviceDirectoryResponse>('/api/device-link/devices', {
+      baseUrl: deviceLinkApiBase,
+      timeoutMs: 10_000,
+    });
+    if (
+      generation !== controllerDisplayNameRefreshGeneration
+      || linkTornDown
+      || client?.getStatus() !== 'online'
+    ) {
+      return;
+    }
+    const cachedNames = readLastKnownDeviceNames();
+    for (const device of result.devices ?? []) {
+      if (typeof device.deviceId !== 'string' || !device.deviceId.trim()) continue;
+      const deviceId = device.deviceId.trim();
+      const serverName = typeof device.name === 'string' ? device.name.trim() : '';
+      const hasDisplayName = !!serverName && !isPlaceholderDeviceName(serverName);
+      const displayName = hasDisplayName ? serverName : cachedNames[deviceId];
+      if (!displayName) continue;
+      setControllerDisplayName(deviceId, displayName);
+      if (hasDisplayName) void rememberLastKnownDeviceName(deviceId, serverName);
+    }
+  } catch (err) {
+    // 目录补齐是展示层 best-effort；失败时保留控制帧自报名 / 短 ID 回退，不影响建链。
+    log.warn(`device directory display-name refresh failed (non-fatal): ${String(err)}`);
+  }
 }
 
 let client: DeviceLinkClient | null = null;
@@ -487,6 +535,7 @@ export function initDeviceLinkService(options: DeviceLinkServiceOptions = {}): v
 
   client.onStatusChange((status) => {
     if (status !== 'online') {
+      controllerDisplayNameRefreshGeneration += 1;
       // 不清 openLinkInFlight:登记生命周期的唯一判据是 promise settle(每个
       // 请求 settle 时自清理,closeRemoteLink 的显式删除有取消代次兜底)。建链
       // 可能正 park 在上线等待里,状态抖动时提前删登记会让同设备的下一次调用
@@ -510,6 +559,11 @@ export function initDeviceLinkService(options: DeviceLinkServiceOptions = {}): v
     broadcast(DEVICE_LINK_PUSH.STATUS_CHANGED, { status });
     handleContactsDeviceLinkStatusChanged(status === 'online');
     if (status === 'online') {
+      // 本地 last-known 先同步种入，覆盖 REST 返回前的 link-open 竞态；随后用
+      // 当前设备目录刷新，补齐本连接代没有历史 presence 的已在线设备。
+      seedControllerDisplayNamesFromLastKnown();
+      const displayNameGeneration = ++controllerDisplayNameRefreshGeneration;
+      void refreshControllerDisplayNamesFromDirectory(displayNameGeneration);
       // 断线前攒的 maker:event 批最先出去:它在时间上早于离线积压与重连后的
       // 一切新推送,晚发会让控制端在终态之后又收到旧文本(见 dispatch 注释)。
       flushMakerEventBatchesOnReconnect();
@@ -933,6 +987,7 @@ export function getMobileNotifyGeneration(): number {
 function teardownActiveLink(): void {
   if (!client || linkTornDown) return;
   linkTornDown = true;
+  controllerDisplayNameRefreshGeneration += 1;
   mobileNotifyGeneration += 1;
   if (relayAuthRecoveryRetryTimer !== null) {
     clearTimeout(relayAuthRecoveryRetryTimer);

--- a/apps/desktop/src/main/device-link/index.ts
+++ b/apps/desktop/src/main/device-link/index.ts
@@ -90,6 +90,7 @@ import {
   applyControllerDisplayNameDirectorySnapshot,
   applyControllerDisplayNamePresence,
   createControllerDisplayNameFreshnessTracker,
+  getControllerDisplayNameFreshnessSince,
   resetControllerDisplayNameFreshness,
   seedControllerDisplayNamesFromCache,
 } from './controllerDisplayNameFreshness';
@@ -155,6 +156,21 @@ type DeviceDirectoryResponse = {
 };
 let controllerDisplayNameRefreshGeneration = 0;
 const controllerDisplayNameFreshness = createControllerDisplayNameFreshnessTracker();
+
+export function captureControllerDisplayNameRequestEpoch(): number {
+  return controllerDisplayNameFreshness.epoch;
+}
+
+export function readControllerDisplayNameFreshnessSince(
+  deviceId: string,
+  requestEpoch: number,
+): { changedAfterRequest: boolean; authoritativeName: string | null } {
+  return getControllerDisplayNameFreshnessSince(
+    controllerDisplayNameFreshness,
+    deviceId,
+    requestEpoch,
+  );
+}
 
 function seedControllerDisplayNamesFromLastKnown(): void {
   seedControllerDisplayNamesFromCache(

--- a/apps/desktop/src/main/device-link/index.ts
+++ b/apps/desktop/src/main/device-link/index.ts
@@ -156,7 +156,11 @@ let controllerDisplayNameRefreshGeneration = 0;
 const controllerDisplayNameFreshness = createControllerDisplayNameFreshnessTracker();
 
 function seedControllerDisplayNamesFromLastKnown(): void {
-  seedControllerDisplayNamesFromCache(readLastKnownDeviceNames(), setControllerDisplayName);
+  seedControllerDisplayNamesFromCache(
+    readLastKnownDeviceNames(),
+    controllerDisplayNameFreshness,
+    setControllerDisplayName,
+  );
 }
 
 /**
@@ -627,6 +631,7 @@ export function initDeviceLinkService(options: DeviceLinkServiceOptions = {}): v
     applyControllerDisplayNamePresence({
       deviceId: snap.deviceId,
       name: snap.deviceName,
+      selfName: snap.selfName,
       freshness: controllerDisplayNameFreshness,
       normalizeName: normalizeCachedDeviceName,
       setDisplayName: setControllerDisplayName,

--- a/apps/desktop/src/main/device-link/ipc.ts
+++ b/apps/desktop/src/main/device-link/ipc.ts
@@ -302,18 +302,38 @@ export async function handleSetDeviceControlEnabled(
   return { deviceId: normalizedDeviceId, enabled, disabledControlDeviceIds };
 }
 
-export async function handleListDevices(
+type DeviceListResult = { devices: DeviceLinkDeviceView[] };
+
+/**
+ * 所有 renderer 的设备列表入口最终都汇到本 handler。代次刻意跨状态变化与 teardown
+ * 单调递增：后发请求代表更新的目录意图，先发请求即使更晚返回也只能跟随最新 promise，
+ * 不能进入 reconcile 写回旧名称/空值，也不能把旧列表重新交给 UI。
+ */
+let deviceListRequestSequence = 0;
+let latestDeviceListRequest: { sequence: number; promise: Promise<DeviceListResult> } | null = null;
+
+export function handleListDevices(
   deps: DeviceLinkIpcDeps,
-): Promise<{ devices: DeviceLinkDeviceView[] }> {
+): Promise<DeviceListResult> {
+  const sequence = ++deviceListRequestSequence;
   const requestEpoch = deps.captureControllerDisplayNameRequestEpoch();
-  try {
-    const result = await deps.apiFetch<{ devices: DeviceLinkServerDeviceView[] }>(
-      '/api/device-link/devices',
-    );
-    return reconcileDeviceNames(result, deps, requestEpoch);
-  } catch (err) {
-    rethrowServerError(err);
-  }
+  let request!: Promise<DeviceListResult>;
+  request = deps.apiFetch<{ devices: DeviceLinkServerDeviceView[] }>(
+    '/api/device-link/devices',
+  ).then(
+    (result) => {
+      const latest = latestDeviceListRequest;
+      if (latest && latest.sequence > sequence) return latest.promise;
+      return reconcileDeviceNames(result, deps, requestEpoch);
+    },
+    (err: unknown) => {
+      const latest = latestDeviceListRequest;
+      if (latest && latest.sequence > sequence) return latest.promise;
+      rethrowServerError(err);
+    },
+  );
+  latestDeviceListRequest = { sequence, promise: request };
+  return request;
 }
 
 function reconcileDeviceNames(

--- a/apps/desktop/src/main/device-link/ipc.ts
+++ b/apps/desktop/src/main/device-link/ipc.ts
@@ -41,6 +41,8 @@ import {
   restoreController,
   broadcast,
   deviceLinkApiBase,
+  captureControllerDisplayNameRequestEpoch,
+  readControllerDisplayNameFreshnessSince,
 } from './index';
 import { getActiveControllers } from './dispatch';
 import { rewriteOutboundMedia } from './outboundMedia';
@@ -109,6 +111,11 @@ export interface DeviceLinkIpcDeps {
   readLastKnownDeviceNames(): Record<string, string>;
   rememberLastKnownDeviceName(deviceId: string, name: string): Promise<boolean>;
   forgetLastKnownDeviceName(deviceId: string): Promise<boolean>;
+  captureControllerDisplayNameRequestEpoch(): number;
+  readControllerDisplayNameFreshnessSince(
+    deviceId: string,
+    requestEpoch: number,
+  ): { changedAfterRequest: boolean; authoritativeName: string | null };
   /**
    * 出方向附件改写:把消息里的本机附件上传 OSS、替换成引用串(仅 send/steer/enqueue 生效)。
    * 可选 —— 测试可不注入(跳过改写,行为同旧版纯透传)。
@@ -154,6 +161,8 @@ export function defaultDeps(): DeviceLinkIpcDeps {
     readLastKnownDeviceNames,
     rememberLastKnownDeviceName,
     forgetLastKnownDeviceName,
+    captureControllerDisplayNameRequestEpoch,
+    readControllerDisplayNameFreshnessSince,
     rewriteOutboundMedia,
     rewriteOutboundSessionReferences,
   };
@@ -296,11 +305,12 @@ export async function handleSetDeviceControlEnabled(
 export async function handleListDevices(
   deps: DeviceLinkIpcDeps,
 ): Promise<{ devices: DeviceLinkDeviceView[] }> {
+  const requestEpoch = deps.captureControllerDisplayNameRequestEpoch();
   try {
     const result = await deps.apiFetch<{ devices: DeviceLinkServerDeviceView[] }>(
       '/api/device-link/devices',
     );
-    return reconcileDeviceNames(result, deps);
+    return reconcileDeviceNames(result, deps, requestEpoch);
   } catch (err) {
     rethrowServerError(err);
   }
@@ -314,13 +324,28 @@ function reconcileDeviceNames(
     | 'readLastKnownDeviceNames'
     | 'rememberLastKnownDeviceName'
     | 'forgetLastKnownDeviceName'
+    | 'readControllerDisplayNameFreshnessSince'
   >,
+  requestEpoch: number,
 ): { devices: DeviceLinkDeviceView[] } {
   const cachedNames = deps.readLastKnownDeviceNames();
   const disabledControlDeviceIds = new Set(deps.getState().disabledControlDeviceIds ?? []);
 
   const devices = result.devices.map<DeviceLinkDeviceView>((device) => {
     let name = device.name;
+    const selfName = typeof device.selfName === 'string'
+      ? normalizeCachedDeviceName(device.selfName)
+      : null;
+    const freshness = deps.readControllerDisplayNameFreshnessSince(
+      device.deviceId,
+      requestEpoch,
+    );
+    if (freshness.changedAfterRequest) {
+      name = freshness.authoritativeName ?? selfName ?? device.deviceId.slice(0, 8);
+      const controlEnabled = !disabledControlDeviceIds.has(device.deviceId);
+      return { ...device, name, controlEnabled };
+    }
+
     const trimmedName = device.name.trim();
     const hasDisplayName = !!trimmedName && !isPlaceholderDeviceName(trimmedName);
     if (hasDisplayName) {
@@ -330,12 +355,11 @@ function reconcileDeviceNames(
       }
     } else if (!trimmedName) {
       void deps.forgetLastKnownDeviceName(device.deviceId); // 显式清空与后台目录刷新保持同义
-      const selfName = typeof device.selfName === 'string'
-        ? normalizeCachedDeviceName(device.selfName)
-        : null;
       name = selfName ?? device.deviceId.slice(0, 8);
     } else if (cachedNames[device.deviceId]) {
       name = cachedNames[device.deviceId];
+    } else {
+      name = selfName ?? device.deviceId.slice(0, 8);
     }
 
     const controlEnabled = !disabledControlDeviceIds.has(device.deviceId);

--- a/apps/desktop/src/main/device-link/ipc.ts
+++ b/apps/desktop/src/main/device-link/ipc.ts
@@ -46,6 +46,7 @@ import {
   captureControllerDisplayNameRequestEpoch,
   isLatestControllerDisplayNameDirectoryRefresh,
   readControllerDisplayNameFreshnessSince,
+  waitForNewerControllerDisplayNameDirectoryRefresh,
 } from './index';
 import { getActiveControllers } from './dispatch';
 import { rewriteOutboundMedia } from './outboundMedia';
@@ -120,6 +121,7 @@ export interface DeviceLinkIpcDeps {
   ): void;
   beginControllerDisplayNameDirectoryRefresh(): number;
   isLatestControllerDisplayNameDirectoryRefresh(sequence: number): boolean;
+  waitForNewerControllerDisplayNameDirectoryRefresh(sequence: number): Promise<void>;
   captureControllerDisplayNameRequestEpoch(): number;
   readControllerDisplayNameFreshnessSince(
     deviceId: string,
@@ -175,6 +177,7 @@ export function defaultDeps(): DeviceLinkIpcDeps {
     captureControllerDisplayNameRequestEpoch,
     isLatestControllerDisplayNameDirectoryRefresh,
     readControllerDisplayNameFreshnessSince,
+    waitForNewerControllerDisplayNameDirectoryRefresh,
     rewriteOutboundMedia,
     rewriteOutboundSessionReferences,
   };
@@ -334,16 +337,26 @@ export function handleListDevices(
   request = deps.apiFetch<{ devices: DeviceLinkServerDeviceView[] }>(
     '/api/device-link/devices',
   ).then(
-    (result) => {
-      const latest = latestDeviceListRequest;
+    async (result) => {
+      let latest = latestDeviceListRequest;
       if (latest && latest.sequence > sequence) return latest.promise;
       const isLatestDirectorySnapshot = deps.isLatestControllerDisplayNameDirectoryRefresh(
         directoryRequestSequence,
       );
       if (isLatestDirectorySnapshot) {
         deps.applyControllerDisplayNameListSnapshot(result.devices, requestEpoch);
+      } else {
+        await deps.waitForNewerControllerDisplayNameDirectoryRefresh(directoryRequestSequence);
+        latest = latestDeviceListRequest;
+        if (latest && latest.sequence > sequence) return latest.promise;
       }
-      return reconcileDeviceNames(result, deps, requestEpoch, isLatestDirectorySnapshot);
+      return reconcileDeviceNames(
+        result,
+        deps,
+        requestEpoch,
+        isLatestDirectorySnapshot,
+        !isLatestDirectorySnapshot,
+      );
     },
     (err: unknown) => {
       const latest = latestDeviceListRequest;
@@ -367,6 +380,7 @@ function reconcileDeviceNames(
   >,
   requestEpoch: number,
   writeCache: boolean = true,
+  preferCurrentAuthoritativeName: boolean = false,
 ): { devices: DeviceLinkDeviceView[] } {
   const cachedNames = deps.readLastKnownDeviceNames();
   const disabledControlDeviceIds = new Set(deps.getState().disabledControlDeviceIds ?? []);
@@ -380,7 +394,7 @@ function reconcileDeviceNames(
       device.deviceId,
       requestEpoch,
     );
-    if (freshness.changedAfterRequest) {
+    if (freshness.changedAfterRequest || preferCurrentAuthoritativeName) {
       name = freshness.authoritativeName ?? selfName ?? device.deviceId.slice(0, 8);
       const controlEnabled = !disabledControlDeviceIds.has(device.deviceId);
       return { ...device, name, controlEnabled };

--- a/apps/desktop/src/main/device-link/ipc.ts
+++ b/apps/desktop/src/main/device-link/ipc.ts
@@ -41,6 +41,7 @@ import {
   restoreController,
   broadcast,
   deviceLinkApiBase,
+  applyControllerDisplayNameListSnapshot,
   captureControllerDisplayNameRequestEpoch,
   readControllerDisplayNameFreshnessSince,
 } from './index';
@@ -111,6 +112,10 @@ export interface DeviceLinkIpcDeps {
   readLastKnownDeviceNames(): Record<string, string>;
   rememberLastKnownDeviceName(deviceId: string, name: string): Promise<boolean>;
   forgetLastKnownDeviceName(deviceId: string): Promise<boolean>;
+  applyControllerDisplayNameListSnapshot(
+    devices: readonly DeviceLinkServerDeviceView[],
+    requestEpoch: number,
+  ): void;
   captureControllerDisplayNameRequestEpoch(): number;
   readControllerDisplayNameFreshnessSince(
     deviceId: string,
@@ -161,6 +166,7 @@ export function defaultDeps(): DeviceLinkIpcDeps {
     readLastKnownDeviceNames,
     rememberLastKnownDeviceName,
     forgetLastKnownDeviceName,
+    applyControllerDisplayNameListSnapshot,
     captureControllerDisplayNameRequestEpoch,
     readControllerDisplayNameFreshnessSince,
     rewriteOutboundMedia,
@@ -324,6 +330,7 @@ export function handleListDevices(
     (result) => {
       const latest = latestDeviceListRequest;
       if (latest && latest.sequence > sequence) return latest.promise;
+      deps.applyControllerDisplayNameListSnapshot(result.devices, requestEpoch);
       return reconcileDeviceNames(result, deps, requestEpoch);
     },
     (err: unknown) => {

--- a/apps/desktop/src/main/device-link/ipc.ts
+++ b/apps/desktop/src/main/device-link/ipc.ts
@@ -50,7 +50,9 @@ import {
   stripOutboundSessionReferenceSideChannels,
 } from './outboundSessionReferences';
 import {
+  forgetLastKnownDeviceName,
   isPlaceholderDeviceName,
+  normalizeCachedDeviceName,
   readDeviceLinkSettings,
   readLastKnownDeviceNames,
   rememberLastKnownDeviceName,
@@ -106,6 +108,7 @@ export interface DeviceLinkIpcDeps {
   broadcast(channel: string, payload: unknown): void;
   readLastKnownDeviceNames(): Record<string, string>;
   rememberLastKnownDeviceName(deviceId: string, name: string): Promise<boolean>;
+  forgetLastKnownDeviceName(deviceId: string): Promise<boolean>;
   /**
    * 出方向附件改写:把消息里的本机附件上传 OSS、替换成引用串(仅 send/steer/enqueue 生效)。
    * 可选 —— 测试可不注入(跳过改写,行为同旧版纯透传)。
@@ -150,6 +153,7 @@ export function defaultDeps(): DeviceLinkIpcDeps {
     broadcast,
     readLastKnownDeviceNames,
     rememberLastKnownDeviceName,
+    forgetLastKnownDeviceName,
     rewriteOutboundMedia,
     rewriteOutboundSessionReferences,
   };
@@ -306,7 +310,10 @@ function reconcileDeviceNames(
   result: { devices: DeviceLinkServerDeviceView[] },
   deps: Pick<
     DeviceLinkIpcDeps,
-    'getState' | 'readLastKnownDeviceNames' | 'rememberLastKnownDeviceName'
+    | 'getState'
+    | 'readLastKnownDeviceNames'
+    | 'rememberLastKnownDeviceName'
+    | 'forgetLastKnownDeviceName'
   >,
 ): { devices: DeviceLinkDeviceView[] } {
   const cachedNames = deps.readLastKnownDeviceNames();
@@ -321,6 +328,12 @@ function reconcileDeviceNames(
       if (device.name !== trimmedName) {
         name = trimmedName;
       }
+    } else if (!trimmedName) {
+      void deps.forgetLastKnownDeviceName(device.deviceId); // 显式清空与后台目录刷新保持同义
+      const selfName = typeof device.selfName === 'string'
+        ? normalizeCachedDeviceName(device.selfName)
+        : null;
+      name = selfName ?? device.deviceId.slice(0, 8);
     } else if (cachedNames[device.deviceId]) {
       name = cachedNames[device.deviceId];
     }

--- a/apps/desktop/src/main/device-link/ipc.ts
+++ b/apps/desktop/src/main/device-link/ipc.ts
@@ -42,7 +42,9 @@ import {
   broadcast,
   deviceLinkApiBase,
   applyControllerDisplayNameListSnapshot,
+  beginControllerDisplayNameDirectoryRefresh,
   captureControllerDisplayNameRequestEpoch,
+  isLatestControllerDisplayNameDirectoryRefresh,
   readControllerDisplayNameFreshnessSince,
 } from './index';
 import { getActiveControllers } from './dispatch';
@@ -116,6 +118,8 @@ export interface DeviceLinkIpcDeps {
     devices: readonly DeviceLinkServerDeviceView[],
     requestEpoch: number,
   ): void;
+  beginControllerDisplayNameDirectoryRefresh(): number;
+  isLatestControllerDisplayNameDirectoryRefresh(sequence: number): boolean;
   captureControllerDisplayNameRequestEpoch(): number;
   readControllerDisplayNameFreshnessSince(
     deviceId: string,
@@ -167,7 +171,9 @@ export function defaultDeps(): DeviceLinkIpcDeps {
     rememberLastKnownDeviceName,
     forgetLastKnownDeviceName,
     applyControllerDisplayNameListSnapshot,
+    beginControllerDisplayNameDirectoryRefresh,
     captureControllerDisplayNameRequestEpoch,
+    isLatestControllerDisplayNameDirectoryRefresh,
     readControllerDisplayNameFreshnessSince,
     rewriteOutboundMedia,
     rewriteOutboundSessionReferences,
@@ -322,6 +328,7 @@ export function handleListDevices(
   deps: DeviceLinkIpcDeps,
 ): Promise<DeviceListResult> {
   const sequence = ++deviceListRequestSequence;
+  const directoryRequestSequence = deps.beginControllerDisplayNameDirectoryRefresh();
   const requestEpoch = deps.captureControllerDisplayNameRequestEpoch();
   let request!: Promise<DeviceListResult>;
   request = deps.apiFetch<{ devices: DeviceLinkServerDeviceView[] }>(
@@ -330,8 +337,13 @@ export function handleListDevices(
     (result) => {
       const latest = latestDeviceListRequest;
       if (latest && latest.sequence > sequence) return latest.promise;
-      deps.applyControllerDisplayNameListSnapshot(result.devices, requestEpoch);
-      return reconcileDeviceNames(result, deps, requestEpoch);
+      const isLatestDirectorySnapshot = deps.isLatestControllerDisplayNameDirectoryRefresh(
+        directoryRequestSequence,
+      );
+      if (isLatestDirectorySnapshot) {
+        deps.applyControllerDisplayNameListSnapshot(result.devices, requestEpoch);
+      }
+      return reconcileDeviceNames(result, deps, requestEpoch, isLatestDirectorySnapshot);
     },
     (err: unknown) => {
       const latest = latestDeviceListRequest;
@@ -354,6 +366,7 @@ function reconcileDeviceNames(
     | 'readControllerDisplayNameFreshnessSince'
   >,
   requestEpoch: number,
+  writeCache: boolean = true,
 ): { devices: DeviceLinkDeviceView[] } {
   const cachedNames = deps.readLastKnownDeviceNames();
   const disabledControlDeviceIds = new Set(deps.getState().disabledControlDeviceIds ?? []);
@@ -376,12 +389,16 @@ function reconcileDeviceNames(
     const trimmedName = device.name.trim();
     const hasDisplayName = !!trimmedName && !isPlaceholderDeviceName(trimmedName);
     if (hasDisplayName) {
-      void deps.rememberLastKnownDeviceName(device.deviceId, trimmedName); // best-effort,不阻塞列表返回
+      if (writeCache) {
+        void deps.rememberLastKnownDeviceName(device.deviceId, trimmedName); // best-effort,不阻塞列表返回
+      }
       if (device.name !== trimmedName) {
         name = trimmedName;
       }
     } else if (!trimmedName) {
-      void deps.forgetLastKnownDeviceName(device.deviceId); // 显式清空与后台目录刷新保持同义
+      if (writeCache) {
+        void deps.forgetLastKnownDeviceName(device.deviceId); // 显式清空与后台目录刷新保持同义
+      }
       name = selfName ?? device.deviceId.slice(0, 8);
     } else if (cachedNames[device.deviceId]) {
       name = cachedNames[device.deviceId];

--- a/apps/desktop/src/main/device-link/settings-store.ts
+++ b/apps/desktop/src/main/device-link/settings-store.ts
@@ -274,7 +274,12 @@ export function writeDeviceLinkSetting<K extends keyof DeviceLinkSettings>(
 }
 
 export function readLastKnownDeviceNames(): Record<string, string> {
-  return { ...readDeviceLinkSettings().lastKnownDeviceNames };
+  const names = { ...readDeviceLinkSettings().lastKnownDeviceNames };
+  for (const [deviceId, pending] of pendingLastKnownDeviceNameByDevice) {
+    if (pending.name === null) delete names[deviceId];
+    else names[deviceId] = pending.name;
+  }
+  return names;
 }
 
 export function writeLastKnownDeviceNames(names: Record<string, string>): Promise<void> {
@@ -283,17 +288,31 @@ export function writeLastKnownDeviceNames(names: Record<string, string>): Promis
 
 /** 同一设备的名称判重与写入必须同序，避免旧删除覆盖紧随其后的同名恢复。 */
 const lastKnownDeviceNameMutationByDevice = new Map<string, Promise<unknown>>();
+/**
+ * presence 已生效、但设置文件写入仍在队列/跨实例锁中等待时的同步覆盖层。
+ * relay 重连 seed 必须先看到这里的最新意图，不能用旧磁盘快照覆盖当前提示。
+ */
+const pendingLastKnownDeviceNameByDevice = new Map<
+  string,
+  { name: string | null }
+>();
 
 function enqueueLastKnownDeviceNameMutation<T>(
   deviceId: string,
+  pendingName: string | null,
   mutation: () => Promise<T>,
 ): Promise<T> {
+  const pending = { name: pendingName };
+  pendingLastKnownDeviceNameByDevice.set(deviceId, pending);
   const previous = lastKnownDeviceNameMutationByDevice.get(deviceId) ?? Promise.resolve();
   const task = previous.catch(() => undefined).then(mutation);
   lastKnownDeviceNameMutationByDevice.set(deviceId, task);
   const cleanup = (): void => {
     if (lastKnownDeviceNameMutationByDevice.get(deviceId) === task) {
       lastKnownDeviceNameMutationByDevice.delete(deviceId);
+    }
+    if (pendingLastKnownDeviceNameByDevice.get(deviceId) === pending) {
+      pendingLastKnownDeviceNameByDevice.delete(deviceId);
     }
   };
   void task.then(cleanup, cleanup);
@@ -323,7 +342,7 @@ export async function setDeviceControlEnabled(
 export async function rememberLastKnownDeviceName(deviceId: string, name: string): Promise<boolean> {
   const normalizedName = normalizeCachedDeviceName(name);
   if (!deviceId.trim() || !normalizedName) return false;
-  return enqueueLastKnownDeviceNameMutation(deviceId, async () => {
+  return enqueueLastKnownDeviceNameMutation(deviceId, normalizedName, async () => {
     const settings = readDeviceLinkSettings();
     if (settings.lastKnownDeviceNames[deviceId] === normalizedName) return false;
     try {
@@ -345,7 +364,7 @@ export async function rememberLastKnownDeviceName(deviceId: string, name: string
 export async function forgetLastKnownDeviceName(deviceId: string): Promise<boolean> {
   const normalizedDeviceId = deviceId.trim();
   if (!normalizedDeviceId) return false;
-  return enqueueLastKnownDeviceNameMutation(normalizedDeviceId, async () => {
+  return enqueueLastKnownDeviceNameMutation(normalizedDeviceId, null, async () => {
     let removed = false;
     try {
       await updateDeviceLinkSetting('lastKnownDeviceNames', (latest) => {

--- a/apps/desktop/src/main/device-link/settings-store.ts
+++ b/apps/desktop/src/main/device-link/settings-store.ts
@@ -321,6 +321,28 @@ export async function rememberLastKnownDeviceName(deviceId: string, name: string
   return true;
 }
 
+export async function forgetLastKnownDeviceName(deviceId: string): Promise<boolean> {
+  const normalizedDeviceId = deviceId.trim();
+  if (!normalizedDeviceId) return false;
+  let removed = false;
+  try {
+    await updateDeviceLinkSetting('lastKnownDeviceNames', (latest) => {
+      if (!(normalizedDeviceId in latest)) return latest;
+      const next = { ...latest };
+      delete next[normalizedDeviceId];
+      removed = true;
+      return next;
+    });
+  } catch (err) {
+    log.warn('forget last-known device name failed, continuing with in-memory fallback', {
+      deviceId: normalizedDeviceId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return false;
+  }
+  return removed;
+}
+
 export function normalizeCachedDeviceName(name: string): string | null {
   const trimmed = name.trim();
   if (!trimmed || isPlaceholderDeviceName(trimmed)) return null;

--- a/apps/desktop/src/main/device-link/settings-store.ts
+++ b/apps/desktop/src/main/device-link/settings-store.ts
@@ -281,6 +281,25 @@ export function writeLastKnownDeviceNames(names: Record<string, string>): Promis
   return writeDeviceLinkSetting('lastKnownDeviceNames', { ...names });
 }
 
+/** 同一设备的名称判重与写入必须同序，避免旧删除覆盖紧随其后的同名恢复。 */
+const lastKnownDeviceNameMutationByDevice = new Map<string, Promise<unknown>>();
+
+function enqueueLastKnownDeviceNameMutation<T>(
+  deviceId: string,
+  mutation: () => Promise<T>,
+): Promise<T> {
+  const previous = lastKnownDeviceNameMutationByDevice.get(deviceId) ?? Promise.resolve();
+  const task = previous.catch(() => undefined).then(mutation);
+  lastKnownDeviceNameMutationByDevice.set(deviceId, task);
+  const cleanup = (): void => {
+    if (lastKnownDeviceNameMutationByDevice.get(deviceId) === task) {
+      lastKnownDeviceNameMutationByDevice.delete(deviceId);
+    }
+  };
+  void task.then(cleanup, cleanup);
+  return task;
+}
+
 export async function setDeviceControlEnabled(
   deviceId: string,
   enabled: boolean,
@@ -304,43 +323,47 @@ export async function setDeviceControlEnabled(
 export async function rememberLastKnownDeviceName(deviceId: string, name: string): Promise<boolean> {
   const normalizedName = normalizeCachedDeviceName(name);
   if (!deviceId.trim() || !normalizedName) return false;
-  const settings = readDeviceLinkSettings();
-  if (settings.lastKnownDeviceNames[deviceId] === normalizedName) return false;
-  try {
-    // 锁内基于盘上最新 map 合并单条,避免用旧 map 整体覆盖并发写入的其它条目
-    await updateDeviceLinkSetting('lastKnownDeviceNames', (latest) =>
-      latest[deviceId] === normalizedName ? latest : { ...latest, [deviceId]: normalizedName },
-    );
-  } catch (err) {
-    log.warn('remember last-known device name failed, continuing without cache update', {
-      deviceId,
-      error: err instanceof Error ? err.message : String(err),
-    });
-    return false;
-  }
-  return true;
+  return enqueueLastKnownDeviceNameMutation(deviceId, async () => {
+    const settings = readDeviceLinkSettings();
+    if (settings.lastKnownDeviceNames[deviceId] === normalizedName) return false;
+    try {
+      // 锁内基于盘上最新 map 合并单条,避免用旧 map 整体覆盖并发写入的其它条目
+      await updateDeviceLinkSetting('lastKnownDeviceNames', (latest) =>
+        latest[deviceId] === normalizedName ? latest : { ...latest, [deviceId]: normalizedName },
+      );
+    } catch (err) {
+      log.warn('remember last-known device name failed, continuing without cache update', {
+        deviceId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return false;
+    }
+    return true;
+  });
 }
 
 export async function forgetLastKnownDeviceName(deviceId: string): Promise<boolean> {
   const normalizedDeviceId = deviceId.trim();
   if (!normalizedDeviceId) return false;
-  let removed = false;
-  try {
-    await updateDeviceLinkSetting('lastKnownDeviceNames', (latest) => {
-      if (!(normalizedDeviceId in latest)) return latest;
-      const next = { ...latest };
-      delete next[normalizedDeviceId];
-      removed = true;
-      return next;
-    });
-  } catch (err) {
-    log.warn('forget last-known device name failed, continuing with in-memory fallback', {
-      deviceId: normalizedDeviceId,
-      error: err instanceof Error ? err.message : String(err),
-    });
-    return false;
-  }
-  return removed;
+  return enqueueLastKnownDeviceNameMutation(normalizedDeviceId, async () => {
+    let removed = false;
+    try {
+      await updateDeviceLinkSetting('lastKnownDeviceNames', (latest) => {
+        if (!(normalizedDeviceId in latest)) return latest;
+        const next = { ...latest };
+        delete next[normalizedDeviceId];
+        removed = true;
+        return next;
+      });
+    } catch (err) {
+      log.warn('forget last-known device name failed, continuing with in-memory fallback', {
+        deviceId: normalizedDeviceId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return false;
+    }
+    return removed;
+  });
 }
 
 export function normalizeCachedDeviceName(name: string): string | null {

--- a/apps/desktop/src/main/device-link/subscriptions.ts
+++ b/apps/desktop/src/main/device-link/subscriptions.ts
@@ -142,7 +142,7 @@ export function updateControllerMetadata(
   deviceId: string,
   name: string,
   capabilities?: readonly string[],
-): void {
+): boolean {
   const e = registry.get(deviceId);
   if (capabilities) {
     const normalized = normalizeCapabilities(capabilities);
@@ -151,7 +151,9 @@ export function updateControllerMetadata(
   }
   // Do not recreate a topic entry during link-open; modern controllers must still
   // replay subscribe before their remembered topics become active.
-  if (e) e.name = name;
+  if (!e || e.name === name) return false;
+  e.name = name;
+  return true;
 }
 
 export function controllerHasTopic(deviceId: string, topic: string): boolean {


### PR DESCRIPTION
## 这次改了什么

### 摘要

设备控制提示此前使用控制端自报的系统主机名，设备列表则使用数据库展示名，导致同一台设备显示成两个名字。本 PR 让被控提示优先使用 relay presence 中的数据库展示名，并在设备重命名后立即刷新。

数据库展示名为空或后来被清空时，依次回退到控制端自报名称、设备 ID 前 8 位，避免空白或残留旧名。

### 变更类型

- [x] fix 缺陷修复
- [ ] feat 新功能
- [ ] refactor / perf 重构或性能优化
- [ ] docs / test / chore 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：设备控制提示名称与设备列表不一致
- 本 PR 包含：Desktop device-link 控制端展示名选择、动态刷新、空值回退及回归测试
- 明确不包含：服务端、数据库 schema、wire protocol 或 UI 样式改动
- 用户可见变化：被控提示中的设备名与设备列表保持一致
- 是否存在 breaking change：无

### UI 变化

不涉及 UI 代码；仅修正现有提示所使用的设备名称数据。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

    pnpm test:unit:related
    结果：通过，Desktop related unit tests 全绿

    pnpm --filter desktop run --if-present typecheck
    结果：通过

    pnpm --dir apps/desktop exec vitest run src/main/device-link/__tests__/dispatchWeakNetwork.test.ts
    结果：通过，14 项；包含两个控制端共享同一被控端时，一个 peer 静默不影响另一个 peer

    git diff --check upstream/main...HEAD
    结果：通过

### 手工验证

不涉及；名称优先级、重命名刷新、数据库名清空、自报名缺失、断线重连与多 peer 隔离均由单元测试覆盖。

### 未执行的验证

未启动 Desktop 实机目检；本次为 main 进程展示名数据选择修复，无布局、样式或交互变化。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 断链恢复故障半径

- 故障层级：整条 relay 连接断开与恢复期间，展示名的 presence 新鲜度和本地 last-known 写入可能跨连接代交错。
- 动作层级：仅重置并重种当前 Desktop 进程内的展示名元数据，合并尚未落盘的 remember/forget 意图，再做原有的 best-effort 目录刷新；不关闭或重建 relay/link，不新增网络重试，不改变订阅、身份、授权或协议。
- 重放影响：本地同步 seed 在既有 subscription replay 之前完成；该修复不增加重放帧，也不会把名称问题放大为连接重连或聚合背压。
- 多 peer 结论：两个控制端共享同一被控端时，各控制端的展示名 tracker 与待写缓存相互独立；一个控制端断线重连只恢复自己的名称状态，另一个控制端的 link、订阅与在途请求不受影响。名称状态隔离、seed-before-replay 顺序以及现有“一侧静默、另一侧零感知”拓扑均有测试覆盖。

### 影响与回滚

- 影响范围：Desktop 被控状态中的控制端展示名
- 回滚 / 降级方式：回退本提交即可恢复原先使用控制端自报名的行为

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次无需额外文档）
- [x] 已确认测试结果或说明未执行原因
