### PR TITLE
fix(desktop): recheck snapshot identity on the fast path

### DIFF
--- a/apps/desktop/src/main/cindy-brain/__tests__/ghostSnapshotIdentity.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/ghostSnapshotIdentity.test.ts
@@ -10,7 +10,9 @@ import {
   sameGhostSnapshotInodeIdentity,
   sameGhostSnapshotTargetIdentity,
 } from '../ghostSnapshotIdentity';
+import { hashApprovedSkillContent } from '../ghostInstallReceipt';
 import { runGhostSnapshotWorkerRequest } from '../ghostSnapshotWorkerProcess';
+import { validateGhostManifest } from '../../../shared/ghost';
 
 let workDir: string;
 
@@ -146,5 +148,67 @@ describe('runGhostSnapshotWorkerRequest remove', () => {
 
     expect(fs.existsSync(target)).toBe(false);
     expect((await fs.promises.readdir(workDir)).some((name) => name.startsWith('skilled.remove-'))).toBe(false);
+  });
+});
+
+describe('runGhostSnapshotWorkerRequest ensure fast path', () => {
+  it('rejects an ABA replacement of the snapshot root during matches()', async () => {
+    workDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'cindy-snapshot-aba-'));
+    const idDir = path.join(workDir, 'skilled');
+    const revision = '11111111-1111-4111-8111-111111111111';
+    const target = path.join(idDir, revision);
+    const replacement = path.join(workDir, 'replacement');
+    const skillMd = '---\nname: demo\ndescription: Demo skill\n---\n\nApproved instructions\n';
+    await fs.promises.mkdir(path.join(target, 'skills', 'demo'), { recursive: true });
+    await fs.promises.mkdir(path.join(replacement, 'skills', 'demo'), { recursive: true });
+    await fs.promises.writeFile(path.join(target, 'skills', 'demo', 'SKILL.md'), skillMd);
+    await fs.promises.writeFile(path.join(replacement, 'skills', 'demo', 'SKILL.md'), skillMd);
+
+    const validated = validateGhostManifest({
+      schemaVersion: 2,
+      id: 'skilled',
+      name: 'Skilled',
+      version: '1.0.0',
+      kind: 'chip',
+      entry: 'main.js',
+      slots: ['tool', 'skill'],
+      tools: [{ name: 'do_thing', description: 'do' }],
+      skill: { items: [{ dir: 'skills/demo', name: 'demo', description: 'Demo skill' }] },
+    });
+    if (!validated.ok) throw new Error(validated.reason);
+    const skillContentSha256 = await hashApprovedSkillContent(validated.manifest, target);
+    const parentStats = await fs.promises.lstat(workDir, { bigint: true });
+    const realReaddir = fs.promises.readdir;
+    let swapped = false;
+
+    vi.spyOn(fs.promises, 'readdir').mockImplementation(((
+      candidate: fs.PathLike,
+      options?: Parameters<typeof realReaddir>[1],
+    ) => {
+      const run = async () => {
+        if (!swapped && path.resolve(String(candidate)).startsWith(path.resolve(target))) {
+          swapped = true;
+          await fs.promises.rename(target, `${target}.original`);
+          await fs.promises.rename(replacement, target);
+        }
+        return realReaddir(candidate, options as never);
+      };
+      return run();
+    }) as typeof fs.promises.readdir);
+
+    await expect(runGhostSnapshotWorkerRequest({
+      expectedParent: {
+        realPath: await fs.promises.realpath(workDir),
+        dev: parentStats.dev,
+        ino: parentStats.ino,
+      },
+      operation: 'ensure',
+      targetName: `skilled/${revision}`,
+      sourceDir: target,
+      receipt: {
+        manifest: validated.manifest,
+        skillContentSha256,
+      },
+    }, workDir)).rejects.toThrow(/ghost content root changed while reading|snapshot target identity changed/);
   });
 });

--- a/apps/desktop/src/main/cindy-brain/__tests__/ghostSnapshotIdentity.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/ghostSnapshotIdentity.test.ts
@@ -2,9 +2,11 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  captureGhostSnapshotTargetIdentity,
+  sameCapturedGhostSnapshotTargetIdentity,
   sameGhostSnapshotInodeIdentity,
   sameGhostSnapshotTargetIdentity,
 } from '../ghostSnapshotIdentity';
@@ -13,6 +15,7 @@ import { runGhostSnapshotWorkerRequest } from '../ghostSnapshotWorkerProcess';
 let workDir: string;
 
 afterEach(async () => {
+  vi.restoreAllMocks();
   if (workDir) await fs.promises.rm(workDir, { recursive: true, force: true });
 });
 
@@ -24,16 +27,15 @@ describe('sameGhostSnapshotTargetIdentity', () => {
     await fs.promises.mkdir(original);
     await fs.promises.mkdir(replacement);
 
-    const expectedStats = await fs.promises.lstat(original, { bigint: true });
-    const expected = {
-      realPath: await fs.promises.realpath(original),
-      dev: expectedStats.dev,
-      ino: expectedStats.ino,
-    };
+    const expected = await captureGhostSnapshotTargetIdentity(original);
     const replacementStats = await fs.promises.lstat(replacement, { bigint: true });
 
     expect(
-      sameGhostSnapshotTargetIdentity(expectedStats, expected.realPath, expected),
+      sameGhostSnapshotTargetIdentity(
+        await fs.promises.lstat(original, { bigint: true }),
+        expected.realPath,
+        expected,
+      ),
     ).toBe(true);
     expect(
       sameGhostSnapshotTargetIdentity(
@@ -49,12 +51,7 @@ describe('sameGhostSnapshotTargetIdentity', () => {
     const target = path.join(workDir, 'target');
     const link = path.join(workDir, 'link');
     await fs.promises.mkdir(target);
-    const expectedStats = await fs.promises.lstat(target, { bigint: true });
-    const expected = {
-      realPath: await fs.promises.realpath(target),
-      dev: expectedStats.dev,
-      ino: expectedStats.ino,
-    };
+    const expected = await captureGhostSnapshotTargetIdentity(target);
     try {
       await fs.promises.symlink(target, link, process.platform === 'win32' ? 'junction' : 'dir');
     } catch {
@@ -72,18 +69,60 @@ describe('sameGhostSnapshotTargetIdentity', () => {
     const original = path.join(workDir, 'original');
     const quarantined = path.join(workDir, 'original.remove-1');
     await fs.promises.mkdir(original);
-    const expectedStats = await fs.promises.lstat(original, { bigint: true });
-    const expected = {
-      realPath: await fs.promises.realpath(original),
-      dev: expectedStats.dev,
-      ino: expectedStats.ino,
-    };
+    const expected = await captureGhostSnapshotTargetIdentity(original);
     await fs.promises.rename(original, quarantined);
     const movedStats = await fs.promises.lstat(quarantined, { bigint: true });
     const movedRealPath = await fs.promises.realpath(quarantined);
 
     expect(sameGhostSnapshotInodeIdentity(movedStats, expected)).toBe(true);
     expect(sameGhostSnapshotTargetIdentity(movedStats, movedRealPath, expected)).toBe(false);
+  });
+
+  it('rejects a recapture that reused the inode but not the timestamps', async () => {
+    workDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'cindy-snapshot-identity-'));
+    const original = path.join(workDir, 'original');
+    await fs.promises.mkdir(original);
+    const expected = await captureGhostSnapshotTargetIdentity(original);
+    const reused = {
+      ...expected,
+      mtimeNs: expected.mtimeNs + 1n,
+      ctimeNs: expected.ctimeNs + 1n,
+    };
+
+    expect(sameCapturedGhostSnapshotTargetIdentity(reused, expected)).toBe(false);
+  });
+});
+
+describe('captureGhostSnapshotTargetIdentity', () => {
+  it('rejects a replacement between lstat and realpath', async () => {
+    workDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'cindy-snapshot-capture-'));
+    const target = path.join(workDir, 'target');
+    const replacement = path.join(workDir, 'replacement');
+    await fs.promises.mkdir(target);
+    await fs.promises.mkdir(replacement);
+    const originalStat = await fs.promises.lstat(target, { bigint: true });
+    const realLstat = fs.promises.lstat;
+    const realRealpath = fs.promises.realpath;
+    let lstatCalls = 0;
+
+    vi.spyOn(fs.promises, 'lstat').mockImplementation(async (candidate, options) => {
+      if (path.resolve(String(candidate)) === path.resolve(target) && lstatCalls === 0) {
+        lstatCalls += 1;
+        return originalStat;
+      }
+      return realLstat(candidate, options as never);
+    });
+    vi.spyOn(fs.promises, 'realpath').mockImplementation(async (candidate, options) => {
+      if (path.resolve(String(candidate)) === path.resolve(target)) {
+        await fs.promises.rm(target, { recursive: true, force: true });
+        await fs.promises.rename(replacement, target);
+      }
+      return realRealpath(candidate, options as never);
+    });
+
+    await expect(captureGhostSnapshotTargetIdentity(target)).rejects.toThrow(
+      'snapshot target identity changed while capturing',
+    );
   });
 });
 

--- a/apps/desktop/src/main/cindy-brain/__tests__/ghostSnapshotIdentity.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/ghostSnapshotIdentity.test.ts
@@ -1,0 +1,111 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  sameGhostSnapshotInodeIdentity,
+  sameGhostSnapshotTargetIdentity,
+} from '../ghostSnapshotIdentity';
+import { runGhostSnapshotWorkerRequest } from '../ghostSnapshotWorkerProcess';
+
+let workDir: string;
+
+afterEach(async () => {
+  if (workDir) await fs.promises.rm(workDir, { recursive: true, force: true });
+});
+
+describe('sameGhostSnapshotTargetIdentity', () => {
+  it('rejects a directory replacement even when the replacement has the same contents', async () => {
+    workDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'cindy-snapshot-identity-'));
+    const original = path.join(workDir, 'original');
+    const replacement = path.join(workDir, 'replacement');
+    await fs.promises.mkdir(original);
+    await fs.promises.mkdir(replacement);
+
+    const expectedStats = await fs.promises.lstat(original, { bigint: true });
+    const expected = {
+      realPath: await fs.promises.realpath(original),
+      dev: expectedStats.dev,
+      ino: expectedStats.ino,
+    };
+    const replacementStats = await fs.promises.lstat(replacement, { bigint: true });
+
+    expect(
+      sameGhostSnapshotTargetIdentity(expectedStats, expected.realPath, expected),
+    ).toBe(true);
+    expect(
+      sameGhostSnapshotTargetIdentity(
+        replacementStats,
+        await fs.promises.realpath(replacement),
+        expected,
+      ),
+    ).toBe(false);
+  });
+
+  it('rejects a linked target even when its resolved directory matches the expected path', async () => {
+    workDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'cindy-snapshot-identity-'));
+    const target = path.join(workDir, 'target');
+    const link = path.join(workDir, 'link');
+    await fs.promises.mkdir(target);
+    const expectedStats = await fs.promises.lstat(target, { bigint: true });
+    const expected = {
+      realPath: await fs.promises.realpath(target),
+      dev: expectedStats.dev,
+      ino: expectedStats.ino,
+    };
+    try {
+      await fs.promises.symlink(target, link, process.platform === 'win32' ? 'junction' : 'dir');
+    } catch {
+      return;
+    }
+
+    const linkStats = await fs.promises.lstat(link, { bigint: true });
+    expect(
+      sameGhostSnapshotTargetIdentity(linkStats, await fs.promises.realpath(link), expected),
+    ).toBe(false);
+  });
+
+  it('rejects a renamed directory when the caller still requires the original path', async () => {
+    workDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'cindy-snapshot-identity-'));
+    const original = path.join(workDir, 'original');
+    const quarantined = path.join(workDir, 'original.remove-1');
+    await fs.promises.mkdir(original);
+    const expectedStats = await fs.promises.lstat(original, { bigint: true });
+    const expected = {
+      realPath: await fs.promises.realpath(original),
+      dev: expectedStats.dev,
+      ino: expectedStats.ino,
+    };
+    await fs.promises.rename(original, quarantined);
+    const movedStats = await fs.promises.lstat(quarantined, { bigint: true });
+    const movedRealPath = await fs.promises.realpath(quarantined);
+
+    expect(sameGhostSnapshotInodeIdentity(movedStats, expected)).toBe(true);
+    expect(sameGhostSnapshotTargetIdentity(movedStats, movedRealPath, expected)).toBe(false);
+  });
+});
+
+describe('runGhostSnapshotWorkerRequest remove', () => {
+  it('deletes a real directory after renaming it to a quarantine path', async () => {
+    workDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'cindy-snapshot-remove-'));
+    const target = path.join(workDir, 'skilled');
+    await fs.promises.mkdir(target);
+    await fs.promises.writeFile(path.join(target, 'SKILL.md'), 'approved');
+    const parentStats = await fs.promises.lstat(workDir, { bigint: true });
+
+    await runGhostSnapshotWorkerRequest({
+      expectedParent: {
+        realPath: await fs.promises.realpath(workDir),
+        dev: parentStats.dev,
+        ino: parentStats.ino,
+      },
+      operation: 'remove',
+      targetName: 'skilled',
+    }, workDir);
+
+    expect(fs.existsSync(target)).toBe(false);
+    expect((await fs.promises.readdir(workDir)).some((name) => name.startsWith('skilled.remove-'))).toBe(false);
+  });
+});

--- a/apps/desktop/src/main/cindy-brain/__tests__/ghostSnapshotIdentity.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/ghostSnapshotIdentity.test.ts
@@ -153,7 +153,13 @@ describe('runGhostSnapshotWorkerRequest remove', () => {
 
 describe('runGhostSnapshotWorkerRequest ensure fast path', () => {
   it('rejects an ABA replacement of the snapshot root during matches()', async () => {
-    workDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'cindy-snapshot-aba-'));
+    // GH Windows runners expose os.tmpdir() as an 8.3 short path while the
+    // worker resolves roots via realpath (long-name canonical). Canonicalize
+    // here so the readdir mock's path prefix matches the paths the worker
+    // actually reads, otherwise the swap never fires and the test no-ops.
+    workDir = fs.realpathSync.native(
+      await fs.promises.mkdtemp(path.join(os.tmpdir(), 'cindy-snapshot-aba-')),
+    );
     const idDir = path.join(workDir, 'skilled');
     const revision = '11111111-1111-4111-8111-111111111111';
     const target = path.join(idDir, revision);

--- a/apps/desktop/src/main/cindy-brain/ghostContentTree.ts
+++ b/apps/desktop/src/main/cindy-brain/ghostContentTree.ts
@@ -440,19 +440,6 @@ export async function hashGhostContentFiles(
       await handle.close();
     }
     const fileDigest = fileHash.digest();
-    // Between the two pathname opens, reassert the root's inode identity (not
-    // its mtime/ctime — a leaf rename legitimately changes those and must stay
-    // an "entry changed" failure). This narrows the window in which a swap of
-    // the whole root would slip the boundary assertion; it is deliberately
-    // dev/ino-only, so an inode-reusing swap is still not observable here.
-    const rootBetween = await fs.promises.lstat(rootDir, { bigint: true });
-    if (
-      rootBetween.isSymbolicLink() ||
-      !rootBetween.isDirectory() ||
-      !sameFileIdentity(rootBetween, rootIdentity)
-    ) {
-      throw new Error(`ghost content root changed while reading: ${rootDir}`);
-    }
     // Windows 的按路径 stat/lstat 在 rename/replace 后可能继续返回旧目录元数据。
     // 重新打开同一路径，并再次流式摘要；新句柄的 stat 也可能陈旧，字节对账才是最终证据。
     const verificationHandle = await fs.promises.open(

--- a/apps/desktop/src/main/cindy-brain/ghostContentTree.ts
+++ b/apps/desktop/src/main/cindy-brain/ghostContentTree.ts
@@ -440,6 +440,19 @@ export async function hashGhostContentFiles(
       await handle.close();
     }
     const fileDigest = fileHash.digest();
+    // Between the two pathname opens, reassert the root's inode identity (not
+    // its mtime/ctime — a leaf rename legitimately changes those and must stay
+    // an "entry changed" failure). This narrows the window in which a swap of
+    // the whole root would slip the boundary assertion; it is deliberately
+    // dev/ino-only, so an inode-reusing swap is still not observable here.
+    const rootBetween = await fs.promises.lstat(rootDir, { bigint: true });
+    if (
+      rootBetween.isSymbolicLink() ||
+      !rootBetween.isDirectory() ||
+      !sameFileIdentity(rootBetween, rootIdentity)
+    ) {
+      throw new Error(`ghost content root changed while reading: ${rootDir}`);
+    }
     // Windows 的按路径 stat/lstat 在 rename/replace 后可能继续返回旧目录元数据。
     // 重新打开同一路径，并再次流式摘要；新句柄的 stat 也可能陈旧，字节对账才是最终证据。
     const verificationHandle = await fs.promises.open(

--- a/apps/desktop/src/main/cindy-brain/ghostContentTree.ts
+++ b/apps/desktop/src/main/cindy-brain/ghostContentTree.ts
@@ -229,7 +229,7 @@ async function captureGhostContentRootIdentity(rootDir: string): Promise<GhostCo
   };
 }
 
-async function assertGhostContentRootIdentity(
+export async function assertGhostContentRootIdentity(
   rootDir: string,
   expected: GhostContentRootIdentity,
 ): Promise<void> {
@@ -239,8 +239,11 @@ async function assertGhostContentRootIdentity(
   } catch (error) {
     throw new Error(`ghost content root changed while reading: ${rootDir}`, { cause: error });
   }
+  const samePath = process.platform === 'win32'
+    ? current.realPath.toLowerCase() === expected.realPath.toLowerCase()
+    : current.realPath === expected.realPath;
   if (
-    current.realPath !== expected.realPath ||
+    !samePath ||
     current.dev !== expected.dev ||
     current.ino !== expected.ino ||
     current.mtimeNs !== expected.mtimeNs ||

--- a/apps/desktop/src/main/cindy-brain/ghostSnapshotIdentity.ts
+++ b/apps/desktop/src/main/cindy-brain/ghostSnapshotIdentity.ts
@@ -1,9 +1,22 @@
 import type fs from 'node:fs';
+import path from 'node:path';
 
 export interface GhostSnapshotParentIdentity {
   realPath: string;
   dev: bigint;
   ino: bigint;
+}
+
+export interface GhostSnapshotTargetIdentity {
+  realPath: string;
+  dev: bigint;
+  ino: bigint;
+}
+
+export function sameGhostSnapshotPath(left: string, right: string): boolean {
+  const normalize = (value: string) =>
+    process.platform === 'win32' ? path.resolve(value).toLowerCase() : path.resolve(value);
+  return normalize(left) === normalize(right);
 }
 
 export function sameGhostSnapshotParentIdentity(
@@ -14,4 +27,34 @@ export function sameGhostSnapshotParentIdentity(
     stats.dev !== 0n && stats.ino !== 0n &&
     expected.dev !== 0n && expected.ino !== 0n &&
     stats.dev === expected.dev && stats.ino === expected.ino;
+}
+
+/**
+ * A renamed/quarantined target is accepted only when its no-follow type and
+ * inode identity still match. The canonical path is expected to change.
+ */
+export function sameGhostSnapshotInodeIdentity(
+  stats: fs.BigIntStats,
+  expected: Pick<GhostSnapshotTargetIdentity, 'dev' | 'ino'>,
+): boolean {
+  return stats.isDirectory() && !stats.isSymbolicLink() &&
+    stats.dev !== 0n && stats.ino !== 0n &&
+    expected.dev !== 0n && expected.ino !== 0n &&
+    stats.dev === expected.dev &&
+    stats.ino === expected.ino;
+}
+
+/**
+ * A target is accepted only when its no-follow type, inode identity, and
+ * canonical path all still match the identity captured before the operation.
+ * The path comparison closes the realpath-reuse case that dev/ino alone cannot
+ * distinguish on every filesystem.
+ */
+export function sameGhostSnapshotTargetIdentity(
+  stats: fs.BigIntStats,
+  realPath: string,
+  expected: GhostSnapshotTargetIdentity,
+): boolean {
+  return sameGhostSnapshotInodeIdentity(stats, expected) &&
+    sameGhostSnapshotPath(realPath, expected.realPath);
 }

--- a/apps/desktop/src/main/cindy-brain/ghostSnapshotIdentity.ts
+++ b/apps/desktop/src/main/cindy-brain/ghostSnapshotIdentity.ts
@@ -118,3 +118,21 @@ export function sameCapturedGhostSnapshotTargetIdentity(
     current.ctimeNs === expected.ctimeNs &&
     sameGhostSnapshotPath(current.realPath, expected.realPath);
 }
+
+export function ghostContentRootIdentityFromSnapshot(
+  identity: GhostSnapshotTargetIdentity,
+): {
+  realPath: string;
+  dev: bigint;
+  ino: bigint;
+  mtimeNs: bigint;
+  ctimeNs: bigint;
+} {
+  return {
+    realPath: identity.realPath,
+    dev: identity.dev,
+    ino: identity.ino,
+    mtimeNs: identity.mtimeNs,
+    ctimeNs: identity.ctimeNs,
+  };
+}

--- a/apps/desktop/src/main/cindy-brain/ghostSnapshotIdentity.ts
+++ b/apps/desktop/src/main/cindy-brain/ghostSnapshotIdentity.ts
@@ -1,4 +1,4 @@
-import type fs from 'node:fs';
+import fs from 'node:fs';
 import path from 'node:path';
 
 export interface GhostSnapshotParentIdentity {
@@ -11,6 +11,8 @@ export interface GhostSnapshotTargetIdentity {
   realPath: string;
   dev: bigint;
   ino: bigint;
+  mtimeNs: bigint;
+  ctimeNs: bigint;
 }
 
 export function sameGhostSnapshotPath(left: string, right: string): boolean {
@@ -19,14 +21,22 @@ export function sameGhostSnapshotPath(left: string, right: string): boolean {
   return normalize(left) === normalize(right);
 }
 
+function sameFileIdentity(
+  left: Pick<fs.BigIntStats, 'dev' | 'ino'>,
+  right: Pick<fs.BigIntStats, 'dev' | 'ino'>,
+): boolean {
+  return left.dev !== 0n && left.ino !== 0n &&
+    right.dev !== 0n && right.ino !== 0n &&
+    left.dev === right.dev &&
+    left.ino === right.ino;
+}
+
 export function sameGhostSnapshotParentIdentity(
   stats: fs.BigIntStats,
   expected: GhostSnapshotParentIdentity,
 ): boolean {
   return stats.isDirectory() && !stats.isSymbolicLink() &&
-    stats.dev !== 0n && stats.ino !== 0n &&
-    expected.dev !== 0n && expected.ino !== 0n &&
-    stats.dev === expected.dev && stats.ino === expected.ino;
+    sameFileIdentity(stats, expected);
 }
 
 /**
@@ -38,23 +48,73 @@ export function sameGhostSnapshotInodeIdentity(
   expected: Pick<GhostSnapshotTargetIdentity, 'dev' | 'ino'>,
 ): boolean {
   return stats.isDirectory() && !stats.isSymbolicLink() &&
-    stats.dev !== 0n && stats.ino !== 0n &&
-    expected.dev !== 0n && expected.ino !== 0n &&
-    stats.dev === expected.dev &&
-    stats.ino === expected.ino;
+    sameFileIdentity(stats, expected);
 }
 
 /**
- * A target is accepted only when its no-follow type, inode identity, and
- * canonical path all still match the identity captured before the operation.
- * The path comparison closes the realpath-reuse case that dev/ino alone cannot
- * distinguish on every filesystem.
+ * A target is accepted only when its no-follow type, inode identity, stable
+ * timestamps, and canonical path all still match the identity captured before
+ * the operation. Timestamps close inode reuse; the path comparison closes the
+ * realpath-reuse case that inode identity alone cannot distinguish.
  */
 export function sameGhostSnapshotTargetIdentity(
   stats: fs.BigIntStats,
   realPath: string,
   expected: GhostSnapshotTargetIdentity,
 ): boolean {
-  return sameGhostSnapshotInodeIdentity(stats, expected) &&
+  return stats.isDirectory() &&
+    !stats.isSymbolicLink() &&
+    sameFileIdentity(stats, expected) &&
+    stats.mtimeNs === expected.mtimeNs &&
+    stats.ctimeNs === expected.ctimeNs &&
     sameGhostSnapshotPath(realPath, expected.realPath);
+}
+
+export function ghostSnapshotTargetIdentityFrom(
+  stats: fs.BigIntStats,
+  realPath: string,
+): GhostSnapshotTargetIdentity {
+  return {
+    realPath,
+    dev: stats.dev,
+    ino: stats.ino,
+    mtimeNs: stats.mtimeNs,
+    ctimeNs: stats.ctimeNs,
+  };
+}
+
+/**
+ * Bind lstat, realpath, and a confirming lstat to one directory object.
+ * Separate pathname reads can otherwise mix an old inode with a replacement
+ * path at the same lexical location.
+ */
+export async function captureGhostSnapshotTargetIdentity(
+  targetPath: string,
+): Promise<GhostSnapshotTargetIdentity> {
+  const lexicalBefore = await fs.promises.lstat(targetPath, { bigint: true });
+  if (lexicalBefore.isSymbolicLink() || !lexicalBefore.isDirectory()) {
+    throw new Error('snapshot target is not a real directory');
+  }
+  const realPath = await fs.promises.realpath(targetPath);
+  const lexicalAfter = await fs.promises.lstat(targetPath, { bigint: true });
+  if (
+    !lexicalAfter.isDirectory() ||
+    lexicalAfter.isSymbolicLink() ||
+    !sameFileIdentity(lexicalBefore, lexicalAfter) ||
+    lexicalBefore.mtimeNs !== lexicalAfter.mtimeNs ||
+    lexicalBefore.ctimeNs !== lexicalAfter.ctimeNs
+  ) {
+    throw new Error('snapshot target identity changed while capturing');
+  }
+  return ghostSnapshotTargetIdentityFrom(lexicalAfter, realPath);
+}
+
+export function sameCapturedGhostSnapshotTargetIdentity(
+  current: GhostSnapshotTargetIdentity,
+  expected: GhostSnapshotTargetIdentity,
+): boolean {
+  return sameFileIdentity(current, expected) &&
+    current.mtimeNs === expected.mtimeNs &&
+    current.ctimeNs === expected.ctimeNs &&
+    sameGhostSnapshotPath(current.realPath, expected.realPath);
 }

--- a/apps/desktop/src/main/cindy-brain/ghostSnapshotWorkerProcess.ts
+++ b/apps/desktop/src/main/cindy-brain/ghostSnapshotWorkerProcess.ts
@@ -28,8 +28,12 @@ import {
   resolveGhostContentPath,
 } from './ghostContentTree.js';
 import {
+  sameGhostSnapshotInodeIdentity,
   sameGhostSnapshotParentIdentity,
+  sameGhostSnapshotPath,
+  sameGhostSnapshotTargetIdentity,
   type GhostSnapshotParentIdentity,
+  type GhostSnapshotTargetIdentity,
 } from './ghostSnapshotIdentity.js';
 import { checkSkillMdConsistency } from './skillSlot.js';
 
@@ -51,11 +55,6 @@ const port = (process as unknown as { parentPort?: Port }).parentPort;
 const send = (message: unknown): void => port?.postMessage(message);
 const hasCode = (error: unknown, code: string): boolean =>
   Boolean(error && typeof error === 'object' && (error as NodeJS.ErrnoException).code === code);
-function samePath(left: string, right: string): boolean {
-  const normalize = (value: string) =>
-    process.platform === 'win32' ? path.resolve(value).toLowerCase() : path.resolve(value);
-  return normalize(left) === normalize(right);
-}
 function targetParts(request: GhostSnapshotWorkerRequest): string[] {
   const parts = request.targetName.split('/');
   if (request.operation === 'ensure') {
@@ -71,7 +70,9 @@ function targetParts(request: GhostSnapshotWorkerRequest): string[] {
 async function verifyParent(expected: GhostSnapshotParentIdentity, workingDir: string): Promise<void> {
   const stats = await fs.promises.lstat(workingDir, { bigint: true });
   if (!sameGhostSnapshotParentIdentity(stats, expected)) throw new Error('snapshot parent identity changed');
-  if (!samePath(await fs.promises.realpath(workingDir), expected.realPath)) throw new Error('snapshot parent path changed');
+  if (!sameGhostSnapshotPath(await fs.promises.realpath(workingDir), expected.realPath)) {
+    throw new Error('snapshot parent path changed');
+  }
 }
 async function verifyDirectory(workingDir: string, name: string): Promise<void> {
   const target = path.join(workingDir, name);
@@ -83,30 +84,20 @@ async function removeVerifiedDirectory(
   workingDir: string,
   targetPath: string,
   parentName: string,
-  expectedTarget?: { realPath: string; dev: bigint; ino: bigint },
+  expectedTarget?: GhostSnapshotTargetIdentity,
 ): Promise<void> {
   const targetStat = await fs.promises.lstat(targetPath, { bigint: true });
-  if (!targetStat.isDirectory() || targetStat.isSymbolicLink()) {
-    throw new Error('snapshot target is not a real directory');
-  }
   const targetRealPath = await fs.promises.realpath(targetPath);
-  if (expectedTarget && (
-    targetStat.dev !== expectedTarget.dev ||
-    targetStat.ino !== expectedTarget.ino ||
-    !samePath(targetRealPath, expectedTarget.realPath)
-  )) {
+  if (expectedTarget && !sameGhostSnapshotTargetIdentity(targetStat, targetRealPath, expectedTarget)) {
     throw new Error('snapshot target identity changed before removal');
+  }
+  if (!expectedTarget && (!targetStat.isDirectory() || targetStat.isSymbolicLink())) {
+    throw new Error('snapshot target is not a real directory');
   }
   const quarantinePath = `${targetPath}.remove-${process.pid}-${Date.now()}`;
   await fs.promises.rename(targetPath, quarantinePath);
   const movedStat = await fs.promises.lstat(quarantinePath, { bigint: true });
-  if (
-    !movedStat.isDirectory()
-    || movedStat.isSymbolicLink()
-    || movedStat.dev !== targetStat.dev
-    || movedStat.ino !== targetStat.ino
-    || !samePath(await fs.promises.realpath(quarantinePath), targetRealPath)
-  ) {
+  if (!sameGhostSnapshotInodeIdentity(movedStat, targetStat)) {
     // Never recursively delete an unverified path. Leave the quarantined
     // directory for a later owner-checked cleanup pass.
     throw new Error('snapshot target identity changed during removal');
@@ -114,8 +105,12 @@ async function removeVerifiedDirectory(
   // The pathname was renamed through a mutable parent. Revalidate the
   // owner-bound parent before recursive deletion; on failure the isolated
   // directory is intentionally left for a later guarded cleanup pass.
+  // Removing `<id>` itself leaves no child directory to recheck — the
+  // snapshots root is already covered by verifyParent.
   await verifyParent(expectedParent, workingDir);
-  await verifyDirectory(workingDir, parentName);
+  if (!sameGhostSnapshotPath(path.dirname(targetPath), workingDir)) {
+    await verifyDirectory(workingDir, parentName);
+  }
   await fs.promises.rm(quarantinePath, { recursive: true, force: true });
 }
 async function copyDirectory(source: string, target: string): Promise<void> {
@@ -182,7 +177,7 @@ export async function runGhostSnapshotWorkerRequest(
   }
   if (!request.receipt || !request.sourceDir) throw new Error('approved skill snapshot is missing');
   let exists = false;
-  let existingTargetIdentity: { realPath: string; dev: bigint; ino: bigint } | undefined;
+  let existingTargetIdentity: GhostSnapshotTargetIdentity | undefined;
   try {
     const stat = await fs.promises.lstat(targetPath, { bigint: true });
     if (!stat.isDirectory() || stat.isSymbolicLink()) throw new Error('snapshot target is not a real directory');
@@ -196,14 +191,19 @@ export async function runGhostSnapshotWorkerRequest(
   if (exists) {
     await verifyDirectory(workingDir, parts[0]);
     if (await matches(request.receipt, targetPath)) {
-      // matches() reads through pathnames and does not validate the
-      // baseDir itself (ghostContentTree.ts:68).  Recheck the target
-      // identity with lstat (no-follow) before accepting the fast path,
-      // so a concurrent process that swapped <id>/<revision> for a
-      // symlink after the initial lstat can't publish a linked external
-      // tree as the approved snapshot (P1, PRRT_kwDOTgdRUs6Yb404).
-      const targetKind = await classifyGhostDirEntry(targetPath);
-      if (targetKind !== 'directory') throw new Error('snapshot target is not a real directory on fast path');
+      // matches() reads through pathnames and does not validate the root
+      // itself. Re-read and compare the complete target identity before
+      // accepting the fast path, so a concurrent replacement cannot turn a
+      // content match into an approval for a different directory.
+      const targetStatAfterMatch = await fs.promises.lstat(targetPath, { bigint: true });
+      const targetRealPathAfterMatch = await fs.promises.realpath(targetPath);
+      if (!existingTargetIdentity || !sameGhostSnapshotTargetIdentity(
+        targetStatAfterMatch,
+        targetRealPathAfterMatch,
+        existingTargetIdentity,
+      )) {
+        throw new Error('snapshot target identity changed after fast path match');
+      }
       send({ ok: true }); return;
     }
   }
@@ -289,7 +289,9 @@ export async function runGhostSnapshotWorkerRequest(
     // after matches() so a concurrent swap to a symlink with identical
     // bytes is caught before we send ok (same P1 as PRRT_kwDOTgdRUs6Yb404).
     const targetKindAfterMatch = await classifyGhostDirEntry(targetPath);
-    if (targetKindAfterMatch !== 'directory') throw new Error('snapshot target no longer a real directory after match');
+    if (targetKindAfterMatch !== 'directory') {
+      throw new Error('snapshot target no longer a real directory after match');
+    }
     send({ ok: true });
   } finally {
     if (await verifyParent(request.expectedParent, workingDir).then(() => true, () => false) &&

--- a/apps/desktop/src/main/cindy-brain/ghostSnapshotWorkerProcess.ts
+++ b/apps/desktop/src/main/cindy-brain/ghostSnapshotWorkerProcess.ts
@@ -21,6 +21,7 @@ import path from 'node:path';
 
 import { GHOST_SKILL_MD_MAX_BYTES } from '../../shared/ghost.js';
 import {
+  assertGhostContentRootIdentity,
   classifyGhostDirEntry,
   collectGhostContentFiles,
   hashGhostContentFiles,
@@ -29,6 +30,7 @@ import {
 } from './ghostContentTree.js';
 import {
   captureGhostSnapshotTargetIdentity,
+  ghostContentRootIdentityFromSnapshot,
   sameCapturedGhostSnapshotTargetIdentity,
   sameGhostSnapshotInodeIdentity,
   sameGhostSnapshotParentIdentity,
@@ -122,17 +124,45 @@ async function copyDirectory(source: string, target: string): Promise<void> {
     else await fs.promises.copyFile(from, to, fs.constants.COPYFILE_EXCL);
   }
 }
-async function hashes(receipt: NonNullable<GhostSnapshotWorkerRequest['receipt']>, root: string): Promise<Record<string, string>> {
+async function hashes(
+  receipt: NonNullable<GhostSnapshotWorkerRequest['receipt']>,
+  root: string,
+  pinnedRoot?: GhostSnapshotTargetIdentity,
+): Promise<Record<string, string>> {
   const result: Record<string, string> = {};
+  const pinnedContentRoot = pinnedRoot
+    ? ghostContentRootIdentityFromSnapshot(pinnedRoot)
+    : undefined;
+  if (pinnedContentRoot) {
+    await assertGhostContentRootIdentity(root, pinnedContentRoot);
+  }
   for (const item of receipt.manifest.skill?.items ?? []) {
-    const itemRoot = await resolveGhostContentPath(root, item.dir, { expect: 'directory', label: 'approved skill' });
-    const tree = await collectGhostContentFiles(itemRoot, { dotEntries: 'include', nonRegular: 'throw', label: `approved skill ${item.dir}` });
+    const itemBase = pinnedContentRoot?.realPath ?? root;
+    const itemRoot = await resolveGhostContentPath(itemBase, item.dir, { expect: 'directory', label: 'approved skill' });
+    if (pinnedContentRoot) {
+      await assertGhostContentRootIdentity(root, pinnedContentRoot);
+    }
+    const tree = await collectGhostContentFiles(itemRoot, {
+      dotEntries: 'include',
+      nonRegular: 'throw',
+      label: `approved skill ${item.dir}`,
+    });
+    if (pinnedContentRoot) {
+      await assertGhostContentRootIdentity(root, pinnedContentRoot);
+    }
     result[item.dir] = await hashGhostContentFiles(itemRoot, tree.files, tree.rootIdentity);
+    if (pinnedContentRoot) {
+      await assertGhostContentRootIdentity(root, pinnedContentRoot);
+    }
   }
   return result;
 }
-async function matches(receipt: NonNullable<GhostSnapshotWorkerRequest['receipt']>, root: string): Promise<boolean> {
-  const actual = await hashes(receipt, root).catch(() => null);
+async function matches(
+  receipt: NonNullable<GhostSnapshotWorkerRequest['receipt']>,
+  root: string,
+  pinnedRoot?: GhostSnapshotTargetIdentity,
+): Promise<boolean> {
+  const actual = await hashes(receipt, root, pinnedRoot).catch(() => null);
   return Boolean(actual && (receipt.manifest.skill?.items ?? []).every(
     (item) => actual[item.dir] === receipt.skillContentSha256[item.dir],
   ));
@@ -173,7 +203,7 @@ export async function runGhostSnapshotWorkerRequest(
   } catch (error) { if (!hasCode(error, 'ENOENT')) throw error; }
   if (exists) {
     await verifyDirectory(workingDir, parts[0]);
-    if (await matches(request.receipt, targetPath)) {
+    if (await matches(request.receipt, targetPath, existingTargetIdentity)) {
       // matches() reads through pathnames and does not validate the root
       // itself. Recapture a bound identity after the content match so a
       // concurrent replacement cannot mix an old inode with a new path.

--- a/apps/desktop/src/main/cindy-brain/ghostSnapshotWorkerProcess.ts
+++ b/apps/desktop/src/main/cindy-brain/ghostSnapshotWorkerProcess.ts
@@ -287,20 +287,20 @@ export async function runGhostSnapshotWorkerRequest(
     }
     await verifyParent(request.expectedParent, workingDir);
     await verifyDirectory(workingDir, parts[0]);
-    if (!await matches(request.receipt, targetPath)) {
+    // Pin the freshly published target before matching, and recompare the
+    // identity after the match, so a swap between match and ok cannot let a
+    // replacement directory be reported as the approved snapshot.
+    const publishedIdentity = await captureGhostSnapshotTargetIdentity(targetPath);
+    if (!await matches(request.receipt, targetPath, publishedIdentity)) {
       if (await verifyParent(request.expectedParent, workingDir).then(() => true, () => false) &&
         await verifyDirectory(workingDir, parts[0]).then(() => true, () => false)) {
         await fs.promises.rm(targetPath, { recursive: true, force: true }).catch(() => undefined);
       }
       throw new Error('approved skill snapshot changed while being published');
     }
-    // matches() follows symlinks through resolveGhostContentPath and does
-    // not validate the root itself (ghostContentTree.ts:68).  Recheck
-    // after matches() so a concurrent swap to a symlink with identical
-    // bytes is caught before we send ok (same P1 as PRRT_kwDOTgdRUs6Yb404).
-    const targetKindAfterMatch = await classifyGhostDirEntry(targetPath);
-    if (targetKindAfterMatch !== 'directory') {
-      throw new Error('snapshot target no longer a real directory after match');
+    const publishedIdentityAfterMatch = await captureGhostSnapshotTargetIdentity(targetPath);
+    if (!sameCapturedGhostSnapshotTargetIdentity(publishedIdentityAfterMatch, publishedIdentity)) {
+      throw new Error('snapshot target identity changed after publish match');
     }
     send({ ok: true });
   } finally {

--- a/apps/desktop/src/main/cindy-brain/ghostSnapshotWorkerProcess.ts
+++ b/apps/desktop/src/main/cindy-brain/ghostSnapshotWorkerProcess.ts
@@ -28,10 +28,11 @@ import {
   resolveGhostContentPath,
 } from './ghostContentTree.js';
 import {
+  captureGhostSnapshotTargetIdentity,
+  sameCapturedGhostSnapshotTargetIdentity,
   sameGhostSnapshotInodeIdentity,
   sameGhostSnapshotParentIdentity,
   sameGhostSnapshotPath,
-  sameGhostSnapshotTargetIdentity,
   type GhostSnapshotParentIdentity,
   type GhostSnapshotTargetIdentity,
 } from './ghostSnapshotIdentity.js';
@@ -86,18 +87,14 @@ async function removeVerifiedDirectory(
   parentName: string,
   expectedTarget?: GhostSnapshotTargetIdentity,
 ): Promise<void> {
-  const targetStat = await fs.promises.lstat(targetPath, { bigint: true });
-  const targetRealPath = await fs.promises.realpath(targetPath);
-  if (expectedTarget && !sameGhostSnapshotTargetIdentity(targetStat, targetRealPath, expectedTarget)) {
+  const targetIdentity = await captureGhostSnapshotTargetIdentity(targetPath);
+  if (expectedTarget && !sameCapturedGhostSnapshotTargetIdentity(targetIdentity, expectedTarget)) {
     throw new Error('snapshot target identity changed before removal');
-  }
-  if (!expectedTarget && (!targetStat.isDirectory() || targetStat.isSymbolicLink())) {
-    throw new Error('snapshot target is not a real directory');
   }
   const quarantinePath = `${targetPath}.remove-${process.pid}-${Date.now()}`;
   await fs.promises.rename(targetPath, quarantinePath);
   const movedStat = await fs.promises.lstat(quarantinePath, { bigint: true });
-  if (!sameGhostSnapshotInodeIdentity(movedStat, targetStat)) {
+  if (!sameGhostSnapshotInodeIdentity(movedStat, targetIdentity)) {
     // Never recursively delete an unverified path. Leave the quarantined
     // directory for a later owner-checked cleanup pass.
     throw new Error('snapshot target identity changed during removal');
@@ -157,15 +154,7 @@ export async function runGhostSnapshotWorkerRequest(
     await verifyParent(request.expectedParent, workingDir);
     if (parts.length !== 1) throw new Error('invalid snapshot removal target');
     await verifyDirectory(workingDir, parts[0]);
-    const targetStat = await fs.promises.lstat(targetPath, { bigint: true });
-    if (!targetStat.isDirectory() || targetStat.isSymbolicLink()) {
-      throw new Error('snapshot target is not a real directory');
-    }
-    const targetIdentity = {
-      realPath: await fs.promises.realpath(targetPath),
-      dev: targetStat.dev,
-      ino: targetStat.ino,
-    };
+    const targetIdentity = await captureGhostSnapshotTargetIdentity(targetPath);
     await removeVerifiedDirectory(
       request.expectedParent,
       workingDir,
@@ -179,27 +168,18 @@ export async function runGhostSnapshotWorkerRequest(
   let exists = false;
   let existingTargetIdentity: GhostSnapshotTargetIdentity | undefined;
   try {
-    const stat = await fs.promises.lstat(targetPath, { bigint: true });
-    if (!stat.isDirectory() || stat.isSymbolicLink()) throw new Error('snapshot target is not a real directory');
+    existingTargetIdentity = await captureGhostSnapshotTargetIdentity(targetPath);
     exists = true;
-    existingTargetIdentity = {
-      realPath: await fs.promises.realpath(targetPath),
-      dev: stat.dev,
-      ino: stat.ino,
-    };
   } catch (error) { if (!hasCode(error, 'ENOENT')) throw error; }
   if (exists) {
     await verifyDirectory(workingDir, parts[0]);
     if (await matches(request.receipt, targetPath)) {
       // matches() reads through pathnames and does not validate the root
-      // itself. Re-read and compare the complete target identity before
-      // accepting the fast path, so a concurrent replacement cannot turn a
-      // content match into an approval for a different directory.
-      const targetStatAfterMatch = await fs.promises.lstat(targetPath, { bigint: true });
-      const targetRealPathAfterMatch = await fs.promises.realpath(targetPath);
-      if (!existingTargetIdentity || !sameGhostSnapshotTargetIdentity(
-        targetStatAfterMatch,
-        targetRealPathAfterMatch,
+      // itself. Recapture a bound identity after the content match so a
+      // concurrent replacement cannot mix an old inode with a new path.
+      const targetIdentityAfterMatch = await captureGhostSnapshotTargetIdentity(targetPath);
+      if (!existingTargetIdentity || !sameCapturedGhostSnapshotTargetIdentity(
+        targetIdentityAfterMatch,
         existingTargetIdentity,
       )) {
         throw new Error('snapshot target identity changed after fast path match');


### PR DESCRIPTION
## 这次改了什么

### 摘要

补上 PR #2696 合并后遗留的 Greptile finding：技能快照快速成功路径在内容匹配后，必须把目标的 no-follow 类型、inode 和 canonical path 与执行开始时捕获的身份完整比对，不能只确认它仍是普通目录。

删除/替换路径同步收口：隔离 rename 后只按 inode 复验，不再要求路径不变；删除 `<id>` 自身时不再复验已经搬走的子目录。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：PR #2696 Greptile follow-up
- 本 PR 包含：
  - snapshot fast path 的完整目标身份复验（`dev` / `ino` / `realPath`）
  - 删除路径在 quarantine rename 后改为 inode-only 复验
  - 删除 `<id>` 自身时跳过已不存在的子目录复验
  - 对应身份比较与删除路径回归测试
- 明确不包含：
  - 插件批准迁移、stable-owner 重试、OAuth / 旧凭证迁移等 #2696 已合入内容
  - 插件 manifest、安装包格式或批准状态 schema 变更
  - UI 变化
  - 数据库 migration
- 用户可见变化：无
- 是否存在 breaking change：无

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：通过

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm check:dco
结果：通过，1 个 commit 已签名
```

### 手工验证

不涉及。

### 未执行的验证

未执行 macOS 手工验证。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [x] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop 技能快照 worker 的 ensure/remove 身份复验
- 存量插件影响：无。不改变 receipt schema、安装布局、指纹格式或已批准权限；用户升级后无需重新安装、重新确认或重新配置
- 回滚 / 降级方式：回滚本提交即可；不改写用户本地插件数据
- 插件基座改动仍需白名单放行人明确 Approve

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要测试
- [x] 已确认测试结果或说明未执行原因
