### PR TITLE
fix(desktop): 修复全屏桥不兼容导致的 Ghost 面板崩溃

### DIFF
--- a/apps/desktop/src/renderer/hooks/__tests__/useMacFullscreen.test.ts
+++ b/apps/desktop/src/renderer/hooks/__tests__/useMacFullscreen.test.ts
@@ -11,10 +11,17 @@ describe('useMacFullscreen', () => {
     delete (window as { electronAPI?: unknown }).electronAPI;
   });
 
-  it('does not crash when an older preload has no fullscreen bridge', () => {
+  it.each([
+    ['missing', { platform: 'darwin' }],
+    ['incompatible', {
+      platform: 'darwin',
+      getFullscreenState: false,
+      onFullscreenChange: {},
+    }],
+  ])('does not crash when an older preload has a %s fullscreen bridge', (_name, electronAPI) => {
     Object.defineProperty(window, 'electronAPI', {
       configurable: true,
-      value: { platform: 'darwin' },
+      value: electronAPI,
     });
 
     const { result } = renderHook(() => useMacFullscreen());

--- a/apps/desktop/src/renderer/hooks/useMacFullscreen.ts
+++ b/apps/desktop/src/renderer/hooks/useMacFullscreen.ts
@@ -21,18 +21,22 @@ export function useMacFullscreen(): { isMac: boolean; isFullscreen: boolean } {
   useEffect(() => {
     if (!isMac) return;
     let cancelled = false;
-    window.electronAPI?.getFullscreenState?.().then((fs) => {
-      if (!cancelled) setIsFullscreen(fs);
-    });
+    const api = window.electronAPI;
+    if (typeof api?.getFullscreenState === 'function') {
+      void api.getFullscreenState().then((fs) => {
+        if (!cancelled) setIsFullscreen(fs);
+      });
+    }
     // Older packaged preload scripts (or a renderer/preload mismatch during an
-    // update) may not expose the fullscreen bridge yet. The layout can safely
-    // fall back to the non-fullscreen spacing; it must not crash the window.
-    const unsub = window.electronAPI?.onFullscreenChange?.((fs: boolean) => {
-      setIsFullscreen(fs);
-    });
+    // update) may expose a missing or incompatible fullscreen bridge. The layout
+    // can safely fall back to the non-fullscreen spacing; it must not crash.
+    const unsub =
+      typeof api?.onFullscreenChange === 'function'
+        ? api.onFullscreenChange((fs: boolean) => setIsFullscreen(fs))
+        : undefined;
     return () => {
       cancelled = true;
-      unsub?.();
+      if (typeof unsub === 'function') unsub();
     };
   }, [isMac]);
 


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 macOS 界面在 preload 全屏桥缺失或形状不兼容时抛出 `TypeError: onFullscreenChange is not a function` 并中断渲染的问题。共享全屏 Hook 现在会在调用桥方法和取消订阅函数前校验运行时类型，并在桥不可用时安全降级为非全屏间距。

### 变更类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 重构
- [ ] 性能优化
- [x] 测试
- [ ] 文档
- [ ] 构建 / CI / 工程配置
- [ ] 其他：

### 范围

- 关联 Issue / 需求：界面报错 `TypeError: c.onFullscreenChange is not a function`
- 本 PR 包含：全屏桥运行时函数类型校验；缺失与不兼容桥对象的回归测试。
- 明确不包含：preload API 重构、窗口全屏行为调整、视觉或文案修改。
- 用户可见变化：桥版本不匹配时界面不再崩溃；全屏状态能力不可用时安全降级为非全屏间距。
- 是否存在 breaking change：无。

### UI 变化

不涉及：仅增强共享全屏 Hook 对 preload bridge 的运行时兼容保护，不改变界面视觉、布局规范、交互或文案。

- 引用的设计规范：不涉及，未产生视觉或交互设计变化。

## 怎么验证的

### 自动验证

- [x] `pnpm test:unit:related`
- [x] `pnpm --filter desktop run --if-present typecheck`
- [x] `pnpm --filter desktop exec vitest run src/renderer/hooks/__tests__/useMacFullscreen.test.ts src/renderer/cindy-brain/__tests__/ghostPanels.test.tsx`（17 个测试通过）
- [x] `pnpm check:dco`
- [x] `git diff origin/main...HEAD --check`

### 手工验证

- 检查已安装 Cindy 包内报错位置，确认压缩后的调用点来自 `useMacFullscreen` 对 `onFullscreenChange` 的调用。
- 检查已安装 preload 包，确认正常版本暴露函数；回归测试覆盖旧版桥缺失及属性存在但不是函数的兼容场景。

### 未执行的验证

- 未启动 Desktop 做完整界面复现：当前修复针对已定位的运行时类型错误，自动回归测试已覆盖同形输入。
- Windows 未实机验证：Windows/Linux 不进入 macOS 全屏订阅路径，行为不变。

## 风险

### 风险分类

- [ ] SQLite migration
- [ ] System prompt / Agent 行为
- [ ] 协议兼容
- [ ] 原生层
- [x] 跨平台差异
- [ ] Mobile runtime fingerprint / OTA
- [ ] 插件基座 / 存量插件兼容
- [x] 无其他高风险改动

### 影响与回滚

- 影响范围：macOS 下使用 `useMacFullscreen` 的主窗口、分离侧栏及插件面板窗口；仅桥异常时改变行为。
- 回滚 / 降级方式：可直接回滚本提交。当前实现遇到异常桥时降级为非全屏间距，不影响主要界面功能。
- 跨平台说明：Windows/Linux 的 `isMac` 为 false，不执行全屏桥订阅；未改变其行为。
- 存量插件影响：无。未修改插件运行时、manifest、权限、批准状态或安装布局。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明不涉及及理由
- [x] 未提交凭证、令牌或授权文件
- [x] 已确认无需补充文档
- [x] 已确认测试结果并说明未执行项
