### PR TITLE
fix(desktop): validate custom MCP headers

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/custom-mcp-store.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/custom-mcp-store.test.ts
@@ -103,6 +103,40 @@ describe('validateCustomMcpConfig', () => {
     expect(validateCustomMcpConfig({ ...valid, headers: { X: 1 } }).ok).toBe(false);
   });
 
+  it('rejects invalid HTTP header names', () => {
+    for (const name of ['X Name', '中文', 'X\nName']) {
+      const result = validateCustomMcpConfig({ ...valid, headers: { [name]: 'value' } });
+      expect(result.ok, `${JSON.stringify(name)} should be rejected`).toBe(false);
+      expect(result.ok === false && result.message).toContain('valid HTTP tokens');
+    }
+  });
+
+  it('accepts HTTP token header names after trimming', () => {
+    expect(
+      validateCustomMcpConfig({
+        ...valid,
+        headers: { ' X-API_Key ': 'value', "X-Trace.Id!#$%&'*+-.^_`|~": 'value' },
+      }),
+    ).toEqual({ ok: true });
+  });
+
+  it('rejects non-printable ASCII header values', () => {
+    for (const value of ['中文', '😀', 'line\nfeed', 'tab\tvalue']) {
+      const result = validateCustomMcpConfig({ ...valid, headers: { 'X-Name': value } });
+      expect(result.ok, `${JSON.stringify(value)} should be rejected`).toBe(false);
+      expect(result.ok === false && result.message).toContain('printable ASCII');
+    }
+  });
+
+  it('accepts printable ASCII header values', () => {
+    expect(
+      validateCustomMcpConfig({
+        ...valid,
+        headers: { 'X-Name': 'alice', Authorization: 'Bearer token-123/+_=' },
+      }),
+    ).toEqual({ ok: true });
+  });
+
   // 撞名的自定义 MCP 会在装配层顶替同名内置 server，并继承 MCP 审批策略里对该
   // server 名的信任（策略只看 serverName），所以 id 必须在 CRUD 阶段就拒收。
   it('rejects ids reserved by builtin MCP servers', () => {

--- a/apps/desktop/src/main/maker-host/custom-mcp-store.ts
+++ b/apps/desktop/src/main/maker-host/custom-mcp-store.ts
@@ -46,6 +46,20 @@ export function isUnsafeMcpServerId(id: string): boolean {
 }
 const MAX_ID_LEN = 40;
 const MAX_NAME_LEN = 60;
+const HTTP_HEADER_NAME_RE = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/;
+
+/**
+ * Claude Code requires custom HTTP header values to be printable ASCII. Keep
+ * this check at the persisted-config boundary so an invalid value cannot be
+ * saved and fail later during a non-interactive MCP startup.
+ */
+function isPrintableAsciiHeaderValue(value: string): boolean {
+  for (let i = 0; i < value.length; i += 1) {
+    const code = value.charCodeAt(i);
+    if (code < 0x20 || code > 0x7e) return false;
+  }
+  return true;
+}
 
 /** 验证结果：ok 或带 code + message（供 handler 映射成 throwIpcError）。 */
 export type ValidationResult =
@@ -104,6 +118,13 @@ export function validateCustomMcpConfig(
     for (const [k, v] of Object.entries(c.headers as Record<string, unknown>)) {
       if (typeof k !== 'string' || typeof v !== 'string') {
         return invalid('headers must be string→string');
+      }
+      const headerName = k.trim();
+      if (headerName.length > 0 && !HTTP_HEADER_NAME_RE.test(headerName)) {
+        return invalid('header names must be valid HTTP tokens');
+      }
+      if (!isPrintableAsciiHeaderValue(v)) {
+        return invalid('header values must contain printable ASCII characters');
       }
     }
   }

--- a/apps/desktop/src/main/mcp-integrations/__tests__/custom-mcp-registry.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/__tests__/custom-mcp-registry.test.ts
@@ -14,11 +14,16 @@ import type { CustomMcpConfig } from '../../../shared/customMcp.js';
 
 const storeMock = vi.hoisted(() => ({ listCustomMcpServers: vi.fn() }));
 
-vi.mock('../../maker-host/custom-mcp-store.js', () => ({
-  listCustomMcpServers: storeMock.listCustomMcpServers,
-  // 只把读库这一步换成 mock；判定逻辑用真实实现，避免名单在测试里漂移。
-  isUnsafeMcpServerId: (id: string) => ['__proto__', 'constructor', 'prototype'].includes(id),
-}));
+vi.mock('../../maker-host/custom-mcp-store.js', async () => {
+  const actual = await vi.importActual<typeof import('../../maker-host/custom-mcp-store.js')>(
+    '../../maker-host/custom-mcp-store.js',
+  );
+  return {
+    ...actual,
+    // 只把读库这一步换成 mock；校验 / 判定逻辑用真实实现，避免名单在测试里漂移。
+    listCustomMcpServers: storeMock.listCustomMcpServers,
+  };
+});
 
 vi.mock('../../secrets/providerSecretStore.js', () => ({
   readCustomMcpToken: () => null,
@@ -111,6 +116,19 @@ describe('refreshCustomMcpProviders', () => {
     expect(arr.map((p) => p.name)).toEqual(['cindy_browser', 'safe_one']);
     // 没有污染原型：普通对象仍然干净。
     expect(Object.getPrototypeOf({} as Record<string, unknown>)).toBe(Object.prototype);
+  });
+
+  it('quarantines persisted configs with invalid custom headers', async () => {
+    const arr: McpProvider[] = [builtin('cindy_browser')];
+    registerCustomMcpArrays(arr);
+    storeMock.listCustomMcpServers.mockResolvedValue([
+      { ...config('bad_header'), headers: { 'X-Feishu-Name': '中文' } },
+      config('safe_one'),
+    ]);
+
+    await refreshCustomMcpProviders();
+
+    expect(arr.map((p) => p.name)).toEqual(['cindy_browser', 'safe_one']);
   });
 
   it('still allows ids that merely resemble a builtin name', async () => {

--- a/apps/desktop/src/main/mcp-integrations/custom-mcp-registry.ts
+++ b/apps/desktop/src/main/mcp-integrations/custom-mcp-registry.ts
@@ -16,7 +16,11 @@
 import { createLogger } from '../logger.js';
 import type { McpProvider } from '@cindy/maker-core';
 
-import { isUnsafeMcpServerId, listCustomMcpServers } from '../maker-host/custom-mcp-store.js';
+import {
+  isUnsafeMcpServerId,
+  listCustomMcpServers,
+  validateCustomMcpConfig,
+} from '../maker-host/custom-mcp-store.js';
 import { readCustomMcpToken } from '../secrets/providerSecretStore.js';
 import { CustomMcpProvider } from './custom-mcp-provider.js';
 
@@ -66,17 +70,32 @@ export const __resetCustomMcpRegistryForTest = resetCustomMcpRegistry;
  */
 export async function refreshCustomMcpProviders(): Promise<void> {
   let providers: CustomMcpProvider[] = [];
+  // 按名字去重统计：同一个撞名配置会在每个已注册数组各命中一次，累加会虚报。
+  const skippedNames = new Set<string>();
   try {
     const configs = await listCustomMcpServers();
-    providers = configs.map((c) => new CustomMcpProvider(c, readCustomMcpToken));
+    const reservedIds = getBuiltinMcpServerNames();
+    providers = configs.flatMap((config) => {
+      const validation = validateCustomMcpConfig(config, reservedIds);
+      if (!validation.ok) {
+        const serverName = typeof config.id === 'string' ? config.id : '<invalid>';
+        if (!skippedNames.has(serverName)) {
+          log.warn('skipping invalid persisted custom MCP config; edit and save it again', {
+            serverName,
+            reason: validation.message,
+          });
+        }
+        skippedNames.add(serverName);
+        return [];
+      }
+      return [new CustomMcpProvider(config, readCustomMcpToken)];
+    });
   } catch (err) {
     log.warn('list custom mcp servers failed; leaving providers unchanged', {
       error: err instanceof Error ? err.message : String(err),
     });
     return;
   }
-  // 按名字去重统计：同一个撞名配置会在每个已注册数组各命中一次，累加会虚报。
-  const skippedNames = new Set<string>();
   for (const arr of registeredArrays) {
     // 原地移除旧的 custom provider,再追加新的一批(不换数组引用)。
     for (let i = arr.length - 1; i >= 0; i--) {


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复自定义远程 MCP header 配置可以保存非 ASCII 值的问题。Claude Code 会在启动 MCP 前拒绝这类 header，本 PR 在配置保存边界校验 header name/value，并在刷新 provider 时隔离历史无效配置，避免旧配置继续导致 MCP 启动失败。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Closes #2646
- 本 PR 包含：自定义 MCP header name 的 HTTP token 校验；header value 的 printable ASCII 校验；刷新运行时 provider 时跳过历史无效配置；相关单测。
- 明确不包含：Settings UI 新提示或自动迁移历史配置。
- 用户可见变化：保存非法 header 时会收到错误；历史非法 MCP 配置不会再注入到运行时，用户需要编辑后重新保存。
- 是否存在 breaking change：无。

### UI 变化

不涉及。

- 引用的设计规范：不涉及。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop test src/main/maker-host/__tests__/custom-mcp-store.test.ts src/main/mcp-integrations/__tests__/custom-mcp-registry.test.ts src/main/mcp-integrations/__tests__/custom-mcp-provider.test.ts src/main/maker-ipc/__tests__/mcpHandlers.test.ts
结果：4 files / 52 tests passed

pnpm --filter desktop run --if-present typecheck
结果：passed

pnpm test:unit:related
结果：apps/desktop unit passed

pnpm check:dco
结果：passed
```

### 手工验证

本地用现有校验函数复现：修复前 `X-Feishu-Name: 中文` 会被 validateCustomMcpConfig 接受；修复后返回 `header values must contain printable ASCII characters`。同时确认 ASCII header 值仍可通过。

### 未执行的验证

未执行真实 Claude Code 远程 MCP 连接端到端验证；该问题的失败点在配置传给 Claude Code 前的 header 校验边界，本 PR 用 targeted unit tests 覆盖保存边界和运行时刷新隔离。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop 自定义远程 MCP 配置。非法 header name/value 不再允许保存；历史非法配置会保留在列表中但不注入运行时。
- 回滚 / 降级方式：回滚本提交即可恢复原有宽松校验；用户数据 schema 未变化，无 migration。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因