### PR TITLE
fix(codex): 修复文件修改审批的静默拒绝与响应竞态

### DIFF
--- a/apps/desktop/src/main/__tests__/makerEventHotPathOrdering.test.ts
+++ b/apps/desktop/src/main/__tests__/makerEventHotPathOrdering.test.ts
@@ -412,10 +412,9 @@ describe('maker:event hot path ordering', () => {
     expect(epochCaptureIndex).toBeGreaterThanOrEqual(0);
     expect(currentEpochCheckIndex).toBeGreaterThan(epochCaptureIndex);
     expect(flushIndex).toBeGreaterThan(currentEpochCheckIndex);
-    expect(broadcastIndex).toBeGreaterThan(flushIndex);
-    expect(broadcastIndex).toBeGreaterThanOrEqual(0);
-    expect(pendingIndex).toBeGreaterThan(broadcastIndex);
-    expect(islandIndex).toBeGreaterThan(pendingIndex);
+    expect(pendingIndex).toBeGreaterThan(flushIndex);
+    expect(broadcastIndex).toBeGreaterThan(pendingIndex);
+    expect(islandIndex).toBeGreaterThan(broadcastIndex);
     expect(interactionListenerSource.slice(0, broadcastIndex)).not.toContain('handleInteractionRequest(');
     expect(source).toContain('Agent Island interaction update failed after maker interaction broadcast');
   });

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -3248,11 +3248,6 @@ export function installDesktopInteractionListener(session: {
         planFilePath?: unknown;
       },
     );
-    broadcastToAllWindows(MAKER_PUSH.INTERACTION_REQUEST, {
-      sessionId: session.id,
-      request: req,
-      persistId: interactionPersistId,
-    });
     return new Promise<InteractionDecision>((resolve) => {
       const entry: PendingInteractionEntry = {
         sessionId: session.id,
@@ -3270,7 +3265,14 @@ export function installDesktopInteractionListener(session: {
           dismissRendererInteraction(pending, req.requestId, 'timeout', 'deny');
         }, PERMISSION_INTERACTION_TIMEOUT_MS);
       }
+      // Register before delivery so a fast renderer/device response cannot race
+      // the resolver and be discarded as an unknown request.
       pendingInteractionResolvers.set(req.requestId, entry);
+      broadcastToAllWindows(MAKER_PUSH.INTERACTION_REQUEST, {
+        sessionId: session.id,
+        request: req,
+        persistId: interactionPersistId,
+      });
       handleAgentIslandInteractionAfterBroadcast(
         session as { id: string; agentKind?: unknown; workDir?: unknown; workspaceKind?: unknown },
         req,

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -11664,6 +11664,67 @@ describe('CodexAgent MCP thread context hooks', () => {
     await handle.close();
   });
 
+  it('asks the user when a file-change approval omits grantRoot', async () => {
+    const reviewAutoPermissionAction = vi.fn<AutoReviewDelegate>(async () => ({
+      verdict: 'block' as const,
+      reason: 'The destination path is missing.',
+    }));
+    const agent = new CodexAgent(createDeps({}, { reviewAutoPermissionAction }));
+    const host = installFakeHost(agent);
+    const handle = await agent.startSession({
+      sessionId: 'session-auto-file-change-without-root',
+      model: 'gpt-5.5',
+      providerId: 'xd',
+      workingDir: '/repo',
+      permissionMode: 'auto',
+    });
+    const handlers = host.getThreadHandlers();
+    if (!handlers?.fileChangeApproval) throw new Error('expected fileChangeApproval handler');
+    const resolver = vi.fn(async (): Promise<InteractionDecision> => (
+      { kind: 'permission', behavior: 'allow' }
+    ));
+    handle.setInteractionResolver(resolver);
+
+    await expect(handlers.fileChangeApproval({
+      threadId: 'start-thread-id',
+      turnId: 'turn-file-change-without-root',
+      itemId: 'patch-without-root',
+      grantRoot: null,
+    })).resolves.toEqual({ decision: 'accept' });
+
+    expect(reviewAutoPermissionAction).not.toHaveBeenCalled();
+    expect(resolver).toHaveBeenCalledOnce();
+    expect(resolver.mock.calls[0]?.[0]).toMatchObject({
+      kind: 'permission',
+      toolName: 'file_change',
+      input: { grantRoot: null },
+      suggestions: undefined,
+    });
+    await handle.close();
+  });
+
+  it('keeps Full access non-interactive when a file-change approval omits grantRoot', async () => {
+    const agent = new CodexAgent(createDeps());
+    const host = installFakeHost(agent);
+    const handle = await agent.startSession({
+      sessionId: 'session-full-file-change-without-root',
+      model: 'gpt-5.5',
+      providerId: 'xd',
+      workingDir: '/repo',
+      permissionMode: 'bypassPermissions',
+    });
+    const handlers = host.getThreadHandlers();
+    if (!handlers?.fileChangeApproval) throw new Error('expected fileChangeApproval handler');
+
+    await expect(handlers.fileChangeApproval({
+      threadId: 'start-thread-id',
+      turnId: 'turn-full-file-change-without-root',
+      itemId: 'full-patch-without-root',
+      grantRoot: null,
+    })).resolves.toEqual({ decision: 'accept' });
+    await handle.close();
+  });
+
   it('re-checks Ask and Full access after an in-flight Cindy auto-review', async () => {
     const askReview = deferred<{ verdict: 'allow' }>();
     const askReviewer = vi.fn(() => askReview.promise);

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -11698,8 +11698,43 @@ describe('CodexAgent MCP thread context hooks', () => {
       kind: 'permission',
       toolName: 'file_change',
       input: { grantRoot: null },
-      suggestions: undefined,
     });
+    const request = resolver.mock.calls[0]?.[0];
+    expect(request?.kind).toBe('permission');
+    if (request?.kind !== 'permission') throw new Error('expected permission request');
+    expect(request.suggestions).toBeDefined();
+    await handle.close();
+  });
+
+  it('accepts a pending missing-root file approval when switching to Full access', async () => {
+    const agent = new CodexAgent(createDeps());
+    const host = installFakeHost(agent);
+    const handle = await agent.startSession({
+      sessionId: 'session-auto-file-change-without-root-mode-switch',
+      model: 'gpt-5.5',
+      providerId: 'xd',
+      workingDir: '/repo',
+      permissionMode: 'auto',
+    });
+    const handlers = host.getThreadHandlers();
+    if (!handlers?.fileChangeApproval) throw new Error('expected fileChangeApproval handler');
+    const pendingDecision = deferred<InteractionDecision>();
+    const resolver = vi.fn(() => pendingDecision.promise);
+    handle.setInteractionResolver(resolver);
+
+    const approval = handlers.fileChangeApproval({
+      threadId: 'start-thread-id',
+      turnId: 'turn-file-change-without-root-mode-switch',
+      itemId: 'patch-without-root-mode-switch',
+      grantRoot: null,
+    });
+    await vi.waitFor(() => expect(resolver).toHaveBeenCalledOnce());
+
+    if (!handle.setPermissionMode) throw new Error('expected setPermissionMode');
+    await handle.setPermissionMode('bypassPermissions');
+
+    await expect(approval).resolves.toEqual({ decision: 'accept' });
+    pendingDecision.resolve({ kind: 'permission', behavior: 'deny' });
     await handle.close();
   });
 

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -5482,6 +5482,8 @@ export class CodexAgent extends BaseAgent {
       req: InteractionRequest,
       opts?: {
         forcePrompt?: boolean;
+        /** Auto 下跳过轻量 reviewer 转人工；仍保留 Full access 自动放行与热切换语义。 */
+        promptInAuto?: boolean;
         autoReviewAction?: ReviewableAction;
         itemId?: string;
       },
@@ -5492,6 +5494,7 @@ export class CodexAgent extends BaseAgent {
           opts?.forcePrompt === true ||
           (req.kind === 'permission' &&
             forceTurnConfirmation(req.toolName, req.input));
+        const promptInAuto = opts?.promptInAuto === true;
         // Full access 的普通审批不应打断用户。Auto 在已验证路由上由 app-server
         // auto_review 负责；fallback 路由则由 user reviewer 把越界请求发回客户端，
         // 再由 Cindy reviewer 静默裁决。
@@ -5537,6 +5540,7 @@ export class CodexAgent extends BaseAgent {
         // UI 不可用时 dispatchInteraction 自然 fail-closed decline。
         if (
           !forcePrompt &&
+          !promptInAuto &&
           mutablePermissionMode === 'auto' &&
           opts?.autoReviewAction
         ) {
@@ -6357,10 +6361,11 @@ export class CodexAgent extends BaseAgent {
         // Codex may omit grantRoot for ordinary apply_patch requests. Without a
         // concrete target the lightweight reviewer cannot classify the write,
         // but silently declining is surfaced by app-server as "rejected by user"
-        // even though no user interaction happened. Escalate that protocol gap
-        // to a real confirmation; unattended callers still fail closed when no
-        // interaction resolver is available.
-        forcePrompt: mutablePermissionMode === 'auto' && !params.grantRoot?.trim(),
+        // even though no user interaction happened. In interactive Auto, route
+        // that protocol gap to the ordinary approval UI; unlike forcePrompt this
+        // still lets a pending request follow a switch to Full access. Unattended
+        // policy turns retain their earlier fail-closed branch above.
+        promptInAuto: !params.grantRoot?.trim(),
         autoReviewAction: { kind: 'file-write', path: params.grantRoot ?? undefined },
         itemId: params.itemId,
       });

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -6354,6 +6354,13 @@ export class CodexAgent extends BaseAgent {
         suggestions: codexSessionApprovalSuggestions(),
         metadata: params.reason ? { reason: params.reason } : undefined,
       }, {
+        // Codex may omit grantRoot for ordinary apply_patch requests. Without a
+        // concrete target the lightweight reviewer cannot classify the write,
+        // but silently declining is surfaced by app-server as "rejected by user"
+        // even though no user interaction happened. Escalate that protocol gap
+        // to a real confirmation; unattended callers still fail closed when no
+        // interaction resolver is available.
+        forcePrompt: mutablePermissionMode === 'auto' && !params.grantRoot?.trim(),
         autoReviewAction: { kind: 'file-write', path: params.grantRoot ?? undefined },
         itemId: params.itemId,
       });


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Cindy 0.1.46 中 Codex 文件修改审批可能在用户没有看到审批提示时被静默拒绝、最终被 app-server 表述为 `patch rejected by user` 的问题。

当 Auto 模式的 `fileChangeApproval` 没有携带 `grantRoot` 时，现在会转为真实用户确认，而不是把缺少目标路径交给轻量 reviewer 后静默 block。Full access 仍保持无交互自动允许；没有交互 resolver 的无人值守调用仍然 fail-closed。

同时将 Desktop 权限请求的 resolver 登记提前到广播之前，避免 renderer 或 device-link 的快速响应先于 resolver 注册到达并被丢弃。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Cindy 0.1.46 用户日志反馈，未关联 GitHub Issue
- 本 PR 包含：Codex 缺失 `grantRoot` 时的审批升级、Desktop 权限响应顺序修复及回归测试
- 明确不包含：修改 app-server 的错误文案、改变整轮任务取消语义、增加新的审批 UI
- 用户可见变化：Auto 模式遇到无法自动判定的文件修改时会显示现有审批提示，不再无提示地报告“用户拒绝”
- 是否存在 breaking change：无

### UI 变化

不涉及：复用现有权限审批卡，仅修正审批触发条件与 main 进程 IPC 顺序，没有视觉、布局或文案变更。

- 引用的设计规范：不涉及：未修改 UI 代码或视觉/交互组件

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related -- --workspace-concurrency=1
结果：通过；apps/desktop、packages/lizi-mcps、packages/maker-core、packages/orca-workflow 全部通过

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --filter @cindy/maker-core run --if-present typecheck
结果：命令成功；该 package 没有 typecheck script，按门禁规则跳过

pnpm check:dco
结果：通过；1 个提交已签名

git diff --check
结果：通过
```

补充：一次并发门禁复跑中 Desktop Vitest worker 出现 `ERR_IPC_CHANNEL_CLOSED`，没有测试断言失败；按仓库规则使用 `--workspace-concurrency=1` 独立复跑后全部通过。

### 手工验证

基于用户日志核对 0.1.46 的最小文件修改探针，并检查审批处理与 Desktop resolver 热路径；未在运行中的宿主应用内手工触发，因为 worktree 改动不会作用于当前宿主实例。

### 未执行的验证

未执行宿主应用实机复现：需要包含本提交的 Desktop 构建；当前以确定性回归测试覆盖 `grantRoot: null` 和 resolver 登记顺序。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Codex Auto 模式文件修改审批，以及 Desktop main 进程向 renderer/device-link 广播权限请求的时序
- 回滚 / 降级方式：回滚本 PR；Full access 行为未改变，无交互 resolver 时仍保持拒绝
- 剩余风险：缺少目标路径的 Auto 请求会增加一次真实用户确认，这是避免错误归因为“用户拒绝”的预期行为

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因