### PR TITLE
fix(worktree): 按需管理 safe.directory 生命周期

### DIFF
--- a/apps/desktop/src/main/__tests__/setSessionsStatusInDb.test.ts
+++ b/apps/desktop/src/main/__tests__/setSessionsStatusInDb.test.ts
@@ -29,6 +29,7 @@ const h = vi.hoisted(() => ({
   cleanupRemovedSession: vi.fn(),
   removeSessionRefs: vi.fn(),
   recycleWorktreeForRemovedSession: vi.fn(),
+  reconcileSafeDirectories: vi.fn(),
   isOwnerScopeCurrent: vi.fn(),
   drizzle: {},
   userDataPath: '',
@@ -80,6 +81,7 @@ import {
   recycleSessionWorktreeForStatusChange,
   setSessionRemovalCancelOperations,
   setSessionRemovalCleanup,
+  setSessionSafeDirectoryReconcile,
   setSessionsStatusInDb,
 } from '../localDb/ipc/sessions.js';
 import { setSessionRouteLockImplementation } from '../localDb/sessionRouteLock.js';
@@ -94,15 +96,18 @@ beforeEach(() => {
   h.cleanupRemovedSession.mockResolvedValue(undefined);
   h.removeSessionRefs.mockResolvedValue(0);
   h.recycleWorktreeForRemovedSession.mockResolvedValue(undefined);
+  h.reconcileSafeDirectories.mockResolvedValue(undefined);
   h.isOwnerScopeCurrent.mockReturnValue(true);
   setSessionRemovalCancelOperations(h.cancelSessionOperations);
   setSessionRemovalCleanup(h.cleanupRemovedSession);
+  setSessionSafeDirectoryReconcile(h.reconcileSafeDirectories);
   setSessionRouteLockImplementation(h.withSendToSessionLock);
 });
 
 afterEach(() => {
   setSessionRemovalCancelOperations(null);
   setSessionRemovalCleanup(null);
+  setSessionSafeDirectoryReconcile(null);
   setSessionRouteLockImplementation(null);
   fs.rmSync(h.userDataPath, { recursive: true, force: true });
 });
@@ -354,6 +359,37 @@ describe('recycleSessionWorktreeForStatusChange', () => {
     expect(h.closeSession).toHaveBeenCalledWith('s1');
   });
 
+  it('reconciles safe.directory after archiving an ordinary task without worktree metadata', async () => {
+    const order: string[] = [];
+    h.closeSession.mockImplementationOnce(async () => {
+      order.push('close-runtime');
+    });
+    // 低层入口对普通任务是 no-op；状态收口仍须驱动授权生命周期。
+    h.recycleWorktreeForRemovedSession.mockImplementationOnce(async () => {
+      order.push('no-worktree');
+    });
+    h.reconcileSafeDirectories.mockImplementationOnce(async () => {
+      order.push('reconcile-safe-directory');
+    });
+
+    await recycleSessionWorktreeForStatusChange('ordinary', 'archived');
+
+    expect(order).toEqual(['close-runtime', 'no-worktree', 'reconcile-safe-directory']);
+    expect(h.reconcileSafeDirectories).toHaveBeenCalledOnce();
+  });
+
+  it('does not let safe.directory reconciliation failure block completed recycling', async () => {
+    h.reconcileSafeDirectories.mockRejectedValueOnce(new Error('config busy'));
+
+    await expect(
+      recycleSessionWorktreeForStatusChange('ordinary', 'archived'),
+    ).resolves.toBeUndefined();
+
+    expect(h.closeSession).toHaveBeenCalledWith('ordinary');
+    expect(h.recycleWorktreeForRemovedSession).toHaveBeenCalledOnce();
+    expect(h.reconcileSafeDirectories).toHaveBeenCalledOnce();
+  });
+
   it('awaits the shared close and worktree recycle chain for deleted sessions', async () => {
     const order: string[] = [];
     h.cancelSessionOperations.mockImplementationOnce(async () => {
@@ -424,6 +460,7 @@ describe('recycleSessionWorktreeForStatusChange', () => {
     expect(h.isSessionStillRemovable).not.toHaveBeenCalled();
     expect(h.closeSession).not.toHaveBeenCalled();
     expect(h.recycleWorktreeForRemovedSession).not.toHaveBeenCalled();
+    expect(h.reconcileSafeDirectories).not.toHaveBeenCalled();
     expect(h.webContentsSend).not.toHaveBeenCalledWith('worktree:changed', expect.anything());
   });
 

--- a/apps/desktop/src/main/__tests__/worktreeManagerCreate.test.ts
+++ b/apps/desktop/src/main/__tests__/worktreeManagerCreate.test.ts
@@ -6,12 +6,35 @@ import path from 'node:path';
 import type { WorktreeMeta } from '../worktree/types';
 
 const gitExecMock = vi.fn();
+const safeDirectoryWitnessRefreshMock = vi.fn(async (mutation: () => Promise<unknown>) =>
+  mutation(),
+);
+const { MockGitExecError } = vi.hoisted(() => ({
+  MockGitExecError: class extends Error {
+    constructor(public readonly stderr: string) {
+      super(stderr);
+    }
+  },
+}));
 const storeMap = new Map<string, WorktreeMeta>();
 const storeSetMock = vi.fn();
 
 vi.mock('../worktree/gitExec', () => ({
   gitExec: (...args: unknown[]) => gitExecMock(...args),
-  GitExecError: class GitExecError extends Error {},
+  GitExecError: MockGitExecError,
+}));
+
+vi.mock('../worktree/safeDirectory', () => ({
+  withSafeDirectoryRetention: async (
+    _options: unknown,
+    task: (retention: {
+      addExact: ReturnType<typeof vi.fn>;
+      addSubtree: ReturnType<typeof vi.fn>;
+    }) => Promise<unknown>,
+  ) => task({ addExact: vi.fn(), addSubtree: vi.fn() }),
+  reconcileSafeDirectories: vi.fn(async () => undefined),
+  withSafeDirectoryWitnessRefresh: (...args: unknown[]) =>
+    safeDirectoryWitnessRefreshMock(...(args as [() => Promise<unknown>])),
 }));
 
 vi.mock('../worktree/includePatternsEngine', () => ({
@@ -38,6 +61,7 @@ describe('createWorktree naming authority', () => {
     baseRepo = path.join(tmpRoot, 'repo');
     fs.mkdirSync(baseRepo, { recursive: true });
     storeMap.clear();
+    safeDirectoryWitnessRefreshMock.mockClear();
     storeSetMock.mockReset().mockImplementation(async (sessionId: string, meta: WorktreeMeta) => {
       storeMap.set(sessionId, meta);
     });
@@ -106,6 +130,43 @@ describe('createWorktree naming authority', () => {
       },
     });
     expect(storeMap.get('session-1')).toEqual(result.ok ? result.meta : undefined);
+  });
+
+  it('does not write safe.directory during a normal successful creation', async () => {
+    await expect(create('fix-login')).resolves.toMatchObject({ ok: true });
+
+    expect(
+      gitExecMock.mock.calls.some(
+        ([args]) =>
+          Array.isArray(args) &&
+          args[0] === 'config' &&
+          args.includes('--global') &&
+          args.includes('safe.directory'),
+      ),
+    ).toBe(false);
+  });
+
+  it('refreshes safe.directory witnesses around the Windows long-path fallback write', async () => {
+    let addAttempts = 0;
+    const defaultGitExec = gitExecMock.getMockImplementation()!;
+    gitExecMock.mockImplementation(async (...callArgs: unknown[]) => {
+      const args = callArgs[0] as string[];
+      if (args[0] === '-c' && args[2] === 'worktree' && args[3] === 'add') {
+        addAttempts += 1;
+        if (addAttempts === 1) throw new MockGitExecError('Filename too long');
+      }
+      return defaultGitExec(...callArgs);
+    });
+
+    await expect(create('long-paths')).resolves.toMatchObject({ ok: true });
+
+    expect(safeDirectoryWitnessRefreshMock).toHaveBeenCalledOnce();
+    expect(gitExecMock.mock.calls.map(([args]) => args)).toContainEqual([
+      'config',
+      '--global',
+      'core.longpaths',
+      'true',
+    ]);
   });
 
   it('preserves an explicit legal name and still rejects an explicit illegal name', async () => {

--- a/apps/desktop/src/main/__tests__/worktreeManagerRemove.test.ts
+++ b/apps/desktop/src/main/__tests__/worktreeManagerRemove.test.ts
@@ -21,6 +21,7 @@ const clearSnapshotRefMock = vi.fn();
 const ignoredFilesMock = vi.fn();
 const changedIncludeFilesMock = vi.fn();
 const storeSetMock = vi.fn();
+const reconcileSafeDirectoriesMock = vi.fn(async () => undefined);
 const storeMap = new Map<string, WorktreeMeta>();
 const liveSessionRows: Array<{
   id: string;
@@ -33,6 +34,17 @@ let liveSessionLookupError: Error | null = null;
 vi.mock('../worktree/gitExec', () => ({
   gitExec: (...args: unknown[]) => gitExecMock(...args),
   GitExecError: class GitExecError extends Error {},
+}));
+
+vi.mock('../worktree/safeDirectory', () => ({
+  withSafeDirectoryRetention: async (
+    _options: unknown,
+    task: (retention: {
+      addExact: ReturnType<typeof vi.fn>;
+      addSubtree: ReturnType<typeof vi.fn>;
+    }) => Promise<unknown>,
+  ) => task({ addExact: vi.fn(), addSubtree: vi.fn() }),
+  reconcileSafeDirectories: () => reconcileSafeDirectoriesMock(),
 }));
 
 vi.mock('../worktree/dirty', () => ({
@@ -117,6 +129,7 @@ describe('removeWorktreeForSession', () => {
     clearSnapshotRefMock.mockReset().mockResolvedValue(undefined);
     ignoredFilesMock.mockReset().mockResolvedValue([]);
     changedIncludeFilesMock.mockReset().mockResolvedValue([]);
+    reconcileSafeDirectoriesMock.mockReset().mockResolvedValue(undefined);
     storeSetMock.mockReset().mockImplementation(async (sessionId: string, meta: WorktreeMeta) => {
       storeMap.set(sessionId, meta);
     });
@@ -126,6 +139,7 @@ describe('removeWorktreeForSession', () => {
   it('no store entry → no-op', async () => {
     await manager.removeWorktreeForSession('nope');
     expect(gitExecMock).not.toHaveBeenCalled();
+    expect(reconcileSafeDirectoriesMock).toHaveBeenCalledOnce();
   });
 
   it('reads and recycles a historical auto-* worktree without renaming it', async () => {
@@ -1053,6 +1067,9 @@ describe('removeWorktreeForSession', () => {
     const meta = makeMeta('s1');
     storeMap.set('s1', meta);
     const gitOperations: string[] = [];
+    reconcileSafeDirectoriesMock.mockImplementation(async () => {
+      gitOperations.push('reconcile');
+    });
     gitExecMock.mockImplementation(async (args: string[]) => {
       gitOperations.push(args[0] ?? '');
       return {
@@ -1085,9 +1102,11 @@ describe('removeWorktreeForSession', () => {
     expect(gitOperations).toEqual([
       'symbolic-ref',
       'worktree',
+      'reconcile',
       'rev-parse',
       'rev-list',
       'update-ref',
+      'reconcile',
     ]);
     expect(storeMap.has('s1')).toBe(false);
   });

--- a/apps/desktop/src/main/__tests__/worktreePoolSafety.test.ts
+++ b/apps/desktop/src/main/__tests__/worktreePoolSafety.test.ts
@@ -24,6 +24,10 @@ vi.mock('../worktree/gitExec', () => ({
   gitExec: (...args: unknown[]) => gitExecMock(...args),
 }));
 
+vi.mock('../worktree/safeDirectory', () => ({
+  reconcileSafeDirectories: vi.fn(async () => undefined),
+}));
+
 vi.mock('../worktree/dirty', () => ({
   isWorktreeDirty: (...args: unknown[]) => isWorktreeDirtyMock(...args),
 }));

--- a/apps/desktop/src/main/__tests__/worktreeRestore.test.ts
+++ b/apps/desktop/src/main/__tests__/worktreeRestore.test.ts
@@ -23,6 +23,9 @@ const storeGetAllMock = vi.fn();
 const storeDelMock = vi.fn();
 const applyIncludeMock = vi.fn();
 const copyClaudeSiviDirsMock = vi.fn();
+const safeDirectoryWitnessRefreshMock = vi.fn(async (mutation: () => Promise<unknown>) =>
+  mutation(),
+);
 let dbWorktreePath: string | null = null;
 let dbWorkingDir: string | null = null;
 let dbBindingRows: Array<{
@@ -53,6 +56,11 @@ vi.mock('../worktree/includePatternsEngine', () => ({
 
 vi.mock('../worktree/WorktreeManager', () => ({
   copyClaudeSiviDirs: (...args: unknown[]) => copyClaudeSiviDirsMock(...args),
+}));
+
+vi.mock('../worktree/safeDirectory', () => ({
+  withSafeDirectoryWitnessRefresh: (...args: unknown[]) =>
+    safeDirectoryWitnessRefreshMock(...(args as [() => Promise<unknown>])),
 }));
 
 vi.mock('../localDb/client/current', () => ({
@@ -107,6 +115,7 @@ describe('worktree restore', () => {
     storeDelMock.mockReset();
     applyIncludeMock.mockReset().mockResolvedValue([]);
     copyClaudeSiviDirsMock.mockReset().mockResolvedValue(undefined);
+    safeDirectoryWitnessRefreshMock.mockClear();
     mod = await import('../worktree/restore');
   });
 
@@ -1012,6 +1021,7 @@ describe('worktree restore', () => {
     const calls = gitExecMock.mock.calls.map(argsOf);
     expect(calls.filter((args) => args[0] === '-c' && args[3] === 'add')).toHaveLength(2);
     expect(calls).toContainEqual(['config', '--global', 'core.longpaths', 'true']);
+    expect(safeDirectoryWitnessRefreshMock).toHaveBeenCalledOnce();
   });
 
   it('restore: worktree add failure → ok=false, no store write', async () => {

--- a/apps/desktop/src/main/__tests__/worktreeSafeDirectoryBootstrap.test.ts
+++ b/apps/desktop/src/main/__tests__/worktreeSafeDirectoryBootstrap.test.ts
@@ -1,0 +1,56 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const bootstrapSource = readFileSync(resolve(__dirname, '..', 'bootstrap-electron.ts'), 'utf8');
+const poolSource = readFileSync(resolve(__dirname, '..', 'worktree', 'WorktreePool.ts'), 'utf8');
+const sessionsSource = readFileSync(
+  resolve(__dirname, '..', 'localDb', 'ipc', 'sessions.ts'),
+  'utf8',
+);
+
+describe('safe.directory startup reconciliation', () => {
+  it('wires Maker liveness before local DB readiness without making base reconciliation depend on Maker', () => {
+    const wiring = bootstrapSource.indexOf('setSafeDirectorySessionRuntimeAliveProvider(');
+    const localDbRegistration = bootstrapSource.indexOf('registerLocalDbIpc({');
+    const onReady = bootstrapSource.indexOf('onReady: async (userId) => {', localDbRegistration);
+    const dbTakeover = bootstrapSource.indexOf(
+      'const dbClientTakeover = await ensureLifecycleDbClient(userId);',
+      onReady,
+    );
+    const dbReadyReconciliation = bootstrapSource.indexOf(
+      'void reconcileSafeDirectories().catch',
+      dbTakeover,
+    );
+    const unchangedBranch = bootstrapSource.indexOf(
+      "if (dbClientTakeover.mode === 'unchanged')",
+      dbTakeover,
+    );
+    expect(wiring).toBeGreaterThan(-1);
+    expect(bootstrapSource).toMatch(
+      /setSafeDirectorySessionRuntimeAliveProvider\(\s*\(sessionId\) =>\s*getMakerIfReady\(\)\?\.isSessionAlive\(sessionId\)/,
+    );
+    expect(wiring).toBeLessThan(localDbRegistration);
+    expect(dbReadyReconciliation).toBeGreaterThan(dbTakeover);
+    expect(dbReadyReconciliation).toBeLessThan(unchangedBranch);
+    expect(bootstrapSource).toContain('Maker-ready safe.directory reconcile failed (non-fatal)');
+  });
+
+  it('injects session-change reconciliation without a main-process dynamic import', () => {
+    expect(bootstrapSource).toMatch(/registerLocalDbIpc\(\{[\s\S]*reconcileSafeDirectories,/);
+    expect(sessionsSource).not.toContain("import('../../worktree/safeDirectory.js')");
+  });
+
+  it('is triggered without awaiting it in the bootstrap path', () => {
+    expect(bootstrapSource).toContain('void reconcileSafeDirectories().catch((err) => {');
+    expect(bootstrapSource).not.toContain('await reconcileSafeDirectories()');
+  });
+
+  it('does not turn recoverPool cleanup into an indirect startup blocker', () => {
+    const recoverPoolBody = poolSource.slice(
+      poolSource.indexOf('export async function recoverPool'),
+    );
+    expect(recoverPoolBody).toContain('await evictIfOverLimit(liveSessionPathKeys, false);');
+    expect(recoverPoolBody).not.toContain('reconcileSafeDirectoriesAfterCleanup()');
+  });
+});

--- a/apps/desktop/src/main/bootstrap-electron.ts
+++ b/apps/desktop/src/main/bootstrap-electron.ts
@@ -405,7 +405,9 @@ import { assertCaptureHealthy } from './device-link/invoke-registry';
 import {
   registerWorktreeIpc,
   WorktreePool,
+  reconcileSafeDirectories,
   reconcileWorktreesForDeletedSessions,
+  setSafeDirectorySessionRuntimeAliveProvider,
 } from './worktree';
 // shadow savepoint 链的启动期对账(孤儿 refs/cindy/savepoints/* 清理)
 import { reconcileSavepointRefsForDeletedSessions } from './git-snapshot/savepointCleanup';
@@ -4888,6 +4890,14 @@ const registerIpcHandlers = () => {
     void reconcileWorktreesForDeletedSessions().catch((err) => {
       console.error('[bootstrap-electron] worktree reconcile failed (non-fatal):', err);
     });
+    // Maker 的运行态真值此刻才可用；基础 DB-ready 对账会独立执行，这里再补一次，
+    // 让已归档且 runtime 已明确退出的会话及时释放授权。仍然不阻塞启动。
+    void reconcileSafeDirectories().catch((err) => {
+      console.error(
+        '[bootstrap-electron] Maker-ready safe.directory reconcile failed (non-fatal):',
+        err,
+      );
+    });
     // 同窗口的 shadow savepoint 对账:owning session 已删除的孤儿保存点链
     // (refs/cindy/savepoints/<sid>)启动期补删。fire-and-forget,不阻塞启动。
     void reconcileSavepointRefsForDeletedSessions().catch((err) => {
@@ -6925,9 +6935,16 @@ app.on('ready', async () => {
   // 首登轻量数据迁移(mToc)的确认弹窗 IPC —— 必须先于 registerLocalDbIpc 注册,
   // 保证 beforeEnsureReady 推送 confirm 态时 renderer 已能 invoke 确认通道。
   registerLegacyMigrationIpc();
+  // safe.directory 对账需要区分“产品上已归档”和“运行时仍在关闭中”。provider
+  // 提前注入且惰性读取 Maker：Agent 环境尚未通过时返回 undefined 并 fail closed，
+  // Maker 就绪后同一个 provider 才开始返回明确的运行态。
+  setSafeDirectorySessionRuntimeAliveProvider((sessionId) =>
+    getMakerIfReady()?.isSessionAlive(sessionId),
+  );
   registerLocalDbIpc({
     cancelSessionOperations: cancelIOSSimulatorSessionOperations,
     cleanupRemovedSession: cleanupIOSSimulatorRemovedSession,
+    reconcileSafeDirectories,
     reconcilePersistedSessionRuntimes: reconcilePersistedIOSSimulatorOwnership,
     withSessionLock: withSendToSessionLock,
     isOwnerCurrent: (userId) =>
@@ -7002,6 +7019,15 @@ app.on('ready', async () => {
         }
         return;
       }
+      // 这是不依赖 Agent provisioning 的基础启动路径：lifecycle DbClient 已完成
+      // 交接后即可读取当前 owner 的 sessions/profile 台账。fire-and-forget，Git
+      // 配置锁或磁盘异常不能阻塞本地 DB 就绪与主界面进入。
+      void reconcileSafeDirectories().catch((err) => {
+        console.error(
+          '[bootstrap-electron] DB-ready safe.directory reconcile failed (non-fatal):',
+          err,
+        );
+      });
       if (dbClientTakeover.mode === 'unchanged') {
         // 副窗口会再次走 localDb.ensureReady；同 owner 的 lifecycle client 已由首个
         // onReady 完整启动，因此这里只保留 DB 连接交接，不重复执行账号级启动维护。

--- a/apps/desktop/src/main/localDb/ipc/__tests__/sessionsUpdate.test.ts
+++ b/apps/desktop/src/main/localDb/ipc/__tests__/sessionsUpdate.test.ts
@@ -26,6 +26,7 @@ const h = vi.hoisted(() => ({
     persistedSdkSessionId: null,
   })),
   tapWindowBroadcast: vi.fn(),
+  reconcileSafeDirectories: vi.fn(async () => undefined),
   summarizeSession: vi.fn(async () => undefined),
   setPinnedSectionCardMode: vi.fn(),
   routeLock: vi.fn(async <T>(_sessionId: string, task: () => Promise<T>): Promise<T> =>
@@ -71,7 +72,7 @@ vi.mock('../../../maker-host/claude-transcript-relocation.js', () => ({
   relocateClaudeTranscriptsForSessionMove: h.relocate,
 }));
 
-import { registerSessionIpc } from '../sessions';
+import { registerSessionIpc, setSessionSafeDirectoryReconcile } from '../sessions';
 import { setSessionRouteLockImplementation } from '../../sessionRouteLock';
 import { assertTrustedAppRendererEvent } from '../../../security/trustedAppRenderer.js';
 
@@ -170,11 +171,13 @@ beforeEach(() => {
   h.handlers.clear();
   createDb();
   setSessionRouteLockImplementation(h.routeLock);
+  setSessionSafeDirectoryReconcile(h.reconcileSafeDirectories);
   registerSessionIpc();
 });
 
 afterEach(() => {
   setSessionRouteLockImplementation(null);
+  setSessionSafeDirectoryReconcile(null);
 });
 
 describe('local-db:sessions:update handler wiring', () => {
@@ -219,6 +222,7 @@ describe('local-db:sessions:update handler wiring', () => {
         patch: expect.objectContaining({ title: '排查远程标题同步' }),
       }),
     );
+    expect(h.reconcileSafeDirectories).not.toHaveBeenCalled();
   });
 
   it('broadcasts permission setting patches to every mounted client', async () => {
@@ -288,6 +292,17 @@ describe('local-db:sessions:update handler wiring', () => {
 
     expect(h.relocate).toHaveBeenCalledTimes(1);
     expect(h.relocate).toHaveBeenCalledWith('cc-local', '/old/dir', '/new/dir');
+    expect(h.reconcileSafeDirectories).toHaveBeenCalledTimes(1);
+  });
+
+  it('refreshes safe.directory retention when a project session moves back to dialogue', async () => {
+    h.sqlite!.prepare("UPDATE sessions SET workspace_kind = 'project' WHERE id = ?").run(
+      'codex-local',
+    );
+
+    await invokeUpdate('codex-local', { workspaceKind: 'dialogue' });
+
+    expect(h.reconcileSafeDirectories).toHaveBeenCalledTimes(1);
   });
 
   it('returns and broadcasts the sdkSessionId persisted during relocation', async () => {

--- a/apps/desktop/src/main/localDb/ipc/registerAll.ts
+++ b/apps/desktop/src/main/localDb/ipc/registerAll.ts
@@ -15,6 +15,7 @@ import {
   registerSessionIpc,
   setSessionRemovalCancelOperations,
   setSessionRemovalCleanup,
+  setSessionSafeDirectoryReconcile,
 } from './sessions';
 import { registerMessageIpc } from './messages';
 import { registerOrcaWorkflowIpc } from './orcaTeams';
@@ -80,6 +81,8 @@ export interface RegisterLocalDbIpcOpts {
   cancelSessionOperations?: (sessionId: string) => Promise<void>;
   /** Release Host-owned runtime and ownership after task removal is revalidated. */
   cleanupRemovedSession?: (sessionId: string) => Promise<void>;
+  /** Refresh shared Git trust after an archived/deleted task runtime has closed. */
+  reconcileSafeDirectories?: () => Promise<void>;
   /** Reconcile persisted Host-owned task runtimes once the owner DB is readable. */
   reconcilePersistedSessionRuntimes?: () => Promise<void>;
   /** Serialize startup tombstone cleanup with task restore/start/send operations. */
@@ -100,6 +103,7 @@ export interface RegisterLocalDbIpcOpts {
 export function registerLocalDbIpc(opts: RegisterLocalDbIpcOpts = {}): void {
   setSessionRemovalCancelOperations(opts.cancelSessionOperations ?? null);
   setSessionRemovalCleanup(opts.cleanupRemovedSession ?? null);
+  setSessionSafeDirectoryReconcile(opts.reconcileSafeDirectories ?? null);
   setSessionRouteLockImplementation(opts.withSessionLock ?? null);
   const runEnsureReady = createOwnerEnsureCoordinator({
     isOwnerCurrent: opts.isOwnerCurrent ?? (() => true),

--- a/apps/desktop/src/main/localDb/ipc/sessions.ts
+++ b/apps/desktop/src/main/localDb/ipc/sessions.ts
@@ -64,6 +64,7 @@ const SLOW_SESSION_LIST_MS = 250;
 type OwnerScope = ReturnType<typeof broadcastTap.captureDataOwnerBroadcastScope> | null;
 type SessionRemovalCancelOperations = (sessionId: string) => Promise<void>;
 type SessionRemovalCleanup = (sessionId: string) => Promise<void>;
+type SessionSafeDirectoryReconcile = () => Promise<void>;
 export interface SessionRecycleScope {
   ownerScope: OwnerScope;
   mediaDb: DbClient['drizzle'];
@@ -71,6 +72,7 @@ export interface SessionRecycleScope {
 
 let sessionRemovalCancelOperations: SessionRemovalCancelOperations | null = null;
 let sessionRemovalCleanup: SessionRemovalCleanup | null = null;
+let sessionSafeDirectoryReconcile: SessionSafeDirectoryReconcile | null = null;
 
 /** Composition-root injection for Host-owned operations that must stop before worktree recycle. */
 export function setSessionRemovalCancelOperations(
@@ -84,6 +86,34 @@ export function setSessionRemovalCleanup(
   cleanupRemovedSession: SessionRemovalCleanup | null,
 ): void {
   sessionRemovalCleanup = cleanupRemovedSession;
+}
+
+/** Composition-root injection avoids a localDb -> worktreeStore -> localDb module cycle. */
+export function setSessionSafeDirectoryReconcile(
+  reconcile: SessionSafeDirectoryReconcile | null,
+): void {
+  sessionSafeDirectoryReconcile = reconcile;
+}
+
+async function reconcileSafeDirectoriesAfterSessionChange(
+  sessionId: string,
+  reason: 'project-target' | 'status',
+): Promise<void> {
+  const reconcile = sessionSafeDirectoryReconcile;
+  if (!reconcile) {
+    log.warn('safe.directory reconcile after session change is not configured', {
+      sessionId,
+      reason,
+    });
+    return;
+  }
+  await reconcile().catch((error) => {
+    log.warn('safe.directory reconcile after session change failed', {
+      sessionId,
+      reason,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  });
 }
 
 function captureOwnerScope(): OwnerScope {
@@ -216,8 +246,8 @@ function broadcastWorktreeChanged(sessionId: string): void {
  * fire-and-forget:回收失败不影响状态写库(启动期 reconcile 兜底 deleted 场景)。
  * 先关子进程再回收——Windows 下 CLI 子进程 cwd 在 worktree 内会锁目录。
  * 既有动态 import 避免 localDb → maker-host / worktree 的静态模块环(worktreeStore
- * 反向 import 本文件的 setWorktreePathInDb)。Simulator 清理由启动组合层静态注入，
- * 避免在回收临界路径上延迟加载带原生副作用的 Host 模块。
+ * 反向 import 本文件的 setWorktreePathInDb)。Simulator 与 safe.directory 清理由启动
+ * 组合层静态注入，避免继续扩大回收临界路径上的动态加载面。
  *
  * 回收链结束后(无论成功、跳过还是失败)都广播一次 worktree:changed —— 失败/跳过
  * 时条目仍在 store 里,重拉拿到的就是"徽标还在"这个真实状态,同样是对的。
@@ -288,7 +318,13 @@ export async function recycleSessionWorktreeForStatusChange(
         });
       });
     };
-    await closeAndRecycle(sessionId, true);
+    try {
+      await closeAndRecycle(sessionId, true);
+    } finally {
+      // 普通任务没有 worktree meta，也必须在 runtime 关闭后刷新 profile 快照并
+      // 回收 Cindy 拥有的授权；运行态仍 alive/unknown 时 provider 会保守保留。
+      await reconcileSafeDirectoriesAfterSessionChange(sessionId, 'status');
+    }
   } catch (err) {
     log.warn('worktree recycle after session status change failed', {
       sessionId,
@@ -1496,6 +1532,11 @@ export function registerSessionIpc(
             ...(updated.pinnedAt === null ? { summary: null } : { status: updated.status }),
           };
     const projectTargetChanged = p.workspaceKind !== undefined || p.workingDir !== undefined;
+    if (projectTargetChanged) {
+      // retainSafeDirectoryUsage 会把首次 Git 的 cwd 保存在共享 profile 快照。项目归属
+      // 提交后立即刷新，避免移动仓库或转为 dialogue 后旧路径继续保留全局授权。
+      void reconcileSafeDirectoriesAfterSessionChange(sid, 'project-target');
+    }
     const settingsChanged = Object.keys(p).some((key) => REMOTE_PERSIST_FIELDS.has(key));
     const titleChanged = p.title !== undefined;
     if (

--- a/apps/desktop/src/main/worktree/WorktreeManager.ts
+++ b/apps/desktop/src/main/worktree/WorktreeManager.ts
@@ -27,6 +27,12 @@ import {
 import { readAttachedWorktreeBranch } from './attachedBranch';
 import { classifyError, type ClassifyInput } from './errorClassifier';
 import { gitExec, GitExecError } from './gitExec';
+import {
+  reconcileSafeDirectories,
+  type SafeDirectoryRetention,
+  withSafeDirectoryRetention,
+  withSafeDirectoryWitnessRefresh,
+} from './safeDirectory';
 import { applyWorktreeIncludeFile, listChangedWorktreeIncludeFiles } from './includePatternsEngine';
 import { hasKeepSentinel, isManagedWorktreePath } from './safety';
 import {
@@ -659,17 +665,44 @@ export async function copyClaudeSiviDirs(
  *   6. configureHooksPath
  *   7. copyClaudeSiviDirs(跳过 .claude/worktrees 这类历史工作区状态)
  *   8. applyWorktreeIncludeFile
- *   9. git config --global --add safe.directory <path>
- *  10. worktreeStore.set(sessionId, meta) → 同步写 sessions.worktree_path
+ *   9. worktreeStore.set(sessionId, meta) → 同步写 sessions.worktree_path
+ *
+ * safe.directory 不再在成功路径无条件写入；只有任一步 Git 命令真实报告 dubious
+ * ownership 时，gitExec 才通过所有权台账按需添加。
  */
 export async function createWorktree(req: CreateWorktreeReq): Promise<CreateWorktreeResp> {
-  const create = () => withCreateWorktreeQueue(req.baseRepo, () => createWorktreeInner(req));
+  const create = (): Promise<CreateWorktreeResp> =>
+    withCreateWorktreeQueue(req.baseRepo, async () => {
+      let result: CreateWorktreeResp;
+      try {
+        result = await withSafeDirectoryRetention({ exactPaths: [req.baseRepo] }, (retention) =>
+          createWorktreeInner(req, retention),
+        );
+      } catch (error) {
+        return { ok: false, error: classifyError(classifyAny(error)) };
+      }
+
+      // 失败路径可能已经按需登记过授权。持久创建声明撤销后再统一对账；
+      // 成功路径的持久化 metadata 已接管 C，无需额外 I/O。
+      if (!result.ok) {
+        await reconcileSafeDirectories().catch((error) => {
+          log.warn(
+            '[worktree] safe.directory reconcile after failed create was non-fatal:',
+            error instanceof Error ? error.message : String(error),
+          );
+        });
+      }
+      return result;
+    });
   return req.recoveryKey === undefined
     ? create()
     : withPrecreatedWorktreeOperationQueue(req.sessionId, create);
 }
 
-async function createWorktreeInner(req: CreateWorktreeReq): Promise<CreateWorktreeResp> {
+async function createWorktreeInner(
+  req: CreateWorktreeReq,
+  safeDirectoryRetention: SafeDirectoryRetention,
+): Promise<CreateWorktreeResp> {
   const snap: CreatedSnapshot = {};
   const totalStartedAt = Date.now();
   try {
@@ -728,6 +761,7 @@ async function createWorktreeInner(req: CreateWorktreeReq): Promise<CreateWorktr
       };
     }
     const baseRepo = cwdInfo.repoRoot ?? path.resolve(req.baseRepo);
+    await safeDirectoryRetention.addExact(baseRepo);
 
     // 2. branches — sourceBranch 既可以是本地分支(常规 schedule),也可以是
     //    任意 commit-ish。
@@ -773,6 +807,7 @@ async function createWorktreeInner(req: CreateWorktreeReq): Promise<CreateWorktr
       worktreePath = path.join(baseRepo, MANAGED_WORKTREE_DIR_NAME, name);
       attempts += 1;
     }
+    await safeDirectoryRetention.addSubtree(worktreePath);
 
     // 4. mkdirp parent
     const parentDir = path.dirname(worktreePath);
@@ -790,7 +825,9 @@ async function createWorktreeInner(req: CreateWorktreeReq): Promise<CreateWorktr
       if (err instanceof GitExecError && /filename too long|core\.longpaths/i.test(err.stderr)) {
         // 启用 core.longpaths 后重试一次
         try {
-          await gitExec(['config', '--global', 'core.longpaths', 'true']);
+          await withSafeDirectoryWitnessRefresh(() =>
+            gitExec(['config', '--global', 'core.longpaths', 'true']),
+          );
           await timed('git worktree add retry', () => gitExec(addArgs, baseRepo));
         } catch (retryErr) {
           return { ok: false, error: classifyError(classifyAny(retryErr)) };
@@ -856,20 +893,7 @@ async function createWorktreeInner(req: CreateWorktreeReq): Promise<CreateWorktr
       );
     }
 
-    // 9. safe.directory
-    try {
-      await timed('add safe.directory', () =>
-        gitExec(['config', '--global', '--add', 'safe.directory', worktreePath]),
-      );
-    } catch (err) {
-      // 非致命 — 仅日志
-      log.warn(
-        `[worktree] add safe.directory failed:`,
-        err instanceof Error ? err.message : String(err),
-      );
-    }
-
-    // 10. store + DB
+    // 9. store + DB
     const meta: WorktreeMeta = {
       sessionId: req.sessionId,
       name,
@@ -931,6 +955,15 @@ export interface RemoveWorktreeOptions {
   preserveDirty?: boolean;
 }
 
+async function reconcileSafeDirectoriesAfterCleanup(): Promise<void> {
+  await reconcileSafeDirectories().catch((error) => {
+    log.warn(
+      '[worktree] safe.directory reconcile after cleanup was non-fatal:',
+      error instanceof Error ? error.message : String(error),
+    );
+  });
+}
+
 /**
  * fire-and-forget: 即便失败也不抛, 仅记日志。
  *
@@ -964,6 +997,7 @@ export async function removeWorktreeForSession(
     if (removeWorktreeQueues.get(sessionId) === run) {
       removeWorktreeQueues.delete(sessionId);
     }
+    await reconcileSafeDirectoriesAfterCleanup();
   }
 }
 
@@ -1426,6 +1460,9 @@ export async function discardPrecreatedWorktree(
       );
     }
   }
+  // 上面的分支探测/删除同样经过 gitExec，可能因 dubious ownership 重新发布授权；
+  // 必须等最后一条 Git 命令结束后再收敛一次，不能只依赖目录删除阶段的对账。
+  await reconcileSafeDirectoriesAfterCleanup();
   return { status: 'discarded', branchDeleted };
 }
 

--- a/apps/desktop/src/main/worktree/WorktreePool.ts
+++ b/apps/desktop/src/main/worktree/WorktreePool.ts
@@ -25,6 +25,7 @@ import {
 } from './liveSessionRefs';
 import { getBranchName } from './nameGenerator';
 import { hasKeepSentinel, isManagedWorktreePath } from './safety';
+import { reconcileSafeDirectories } from './safeDirectory';
 import * as store from './worktreeStore';
 import { createLogger } from '../logger';
 
@@ -45,6 +46,15 @@ const inflight = new Set<string>();
 
 function repoKey(baseRepo: string): string {
   return path.resolve(baseRepo);
+}
+
+async function reconcileSafeDirectoriesAfterCleanup(): Promise<void> {
+  await reconcileSafeDirectories().catch((error) => {
+    log.warn(
+      '[WorktreePool] safe.directory reconcile after cleanup was non-fatal:',
+      error instanceof Error ? error.message : String(error),
+    );
+  });
 }
 
 // ── acquire ──────────────────────────────────────────────────────────────────
@@ -113,7 +123,10 @@ export async function acquireWorktree(
               await gitExec(['worktree', 'prune'], entry.meta.baseRepo).catch(() => {});
               return false;
             });
-          if (drained) store.del(entry.meta.sessionId);
+          if (drained) {
+            store.del(entry.meta.sessionId);
+            await reconcileSafeDirectoriesAfterCleanup();
+          }
         }
       }
     }
@@ -244,6 +257,7 @@ export async function releaseWorktree(sessionId: string): Promise<'pooled' | 'pr
         .catch(() => false);
       if (drained) {
         store.del(existing.meta.sessionId);
+        await reconcileSafeDirectoriesAfterCleanup();
       }
     }
   }
@@ -267,7 +281,10 @@ export async function releaseWorktree(sessionId: string): Promise<'pooled' | 'pr
  * 按 createdAt 从旧到新淘汰 clean 条目，dirty 条目永远不淘汰。
  * 允许因全部 dirty 而超限（不能因历史残留拒绝新工作）。
  */
-async function evictIfOverLimit(liveSessionPathKeys?: LiveSessionPathKeys): Promise<void> {
+async function evictIfOverLimit(
+  liveSessionPathKeys?: LiveSessionPathKeys,
+  reconcileAfterCleanup = true,
+): Promise<void> {
   if (store.getAll().length <= MAX_WORKTREES) return;
 
   const liveRefs =
@@ -275,20 +292,23 @@ async function evictIfOverLimit(liveSessionPathKeys?: LiveSessionPathKeys): Prom
 
   // 每轮重新读 store 取最旧的 clean 候选，避免 stale snapshot 问题
   while (store.getAll().length > MAX_WORKTREES) {
-    const candidate = await findOldestCleanCandidate(liveRefs);
+    const candidate = await findOldestCleanCandidate(liveRefs, reconcileAfterCleanup);
     if (!candidate) break; // 剩余全是 dirty / 池中在用，允许超限
 
     const drained = await drainEntry(candidate)
       .then(() => true)
       .catch(() => false);
-    if (drained) store.del(candidate.sessionId);
-    else break;
+    if (drained) {
+      store.del(candidate.sessionId);
+      if (reconcileAfterCleanup) await reconcileSafeDirectoriesAfterCleanup();
+    } else break;
   }
 }
 
 /** 从 store 中找到最旧的、可淘汰的 clean 条目。 */
 async function findOldestCleanCandidate(
   liveSessionPathKeys: LiveSessionPathKeys,
+  reconcileAfterCleanup: boolean,
 ): Promise<WorktreeMeta | null> {
   const sorted = store.getAll().sort((a, b) => a.createdAt.localeCompare(b.createdAt));
 
@@ -309,6 +329,7 @@ async function findOldestCleanCandidate(
       await fs.access(meta.path);
     } catch {
       store.del(meta.sessionId);
+      if (reconcileAfterCleanup) await reconcileSafeDirectoriesAfterCleanup();
       return null; // store 已缩减，让外层 while 重新检查
     }
 
@@ -371,6 +392,7 @@ export async function drainOne(baseRepo: string): Promise<void> {
   pool.delete(key);
   await drainEntry(entry.meta);
   store.del(entry.meta.sessionId);
+  await reconcileSafeDirectoriesAfterCleanup();
 }
 
 // ── park / recover ──────────────────────────────────────────────────────────
@@ -446,5 +468,7 @@ export async function recoverPool(): Promise<void> {
     // （可能属于仍有效的用户 session，由正常 session 生命周期管理）
   }
 
-  await evictIfOverLimit(liveSessionPathKeys);
+  // bootstrap 会在 recoverPool 返回后 fire-and-forget 触发一次统一对账；这里不能
+  // await safe.directory 配置 IO，否则会把后台任务重新变成启动阻塞点。
+  await evictIfOverLimit(liveSessionPathKeys, false);
 }

--- a/apps/desktop/src/main/worktree/__tests__/gitExec.test.ts
+++ b/apps/desktop/src/main/worktree/__tests__/gitExec.test.ts
@@ -7,6 +7,7 @@
  */
 
 import { EventEmitter } from 'node:events';
+import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 type ExecCb = (err: Error | null, stdout: string, stderr: string) => void;
@@ -14,10 +15,16 @@ type ExecCb = (err: Error | null, stdout: string, stderr: string) => void;
 const mocks = vi.hoisted(() => ({
   execFile: vi.fn(),
   killProcessTree: vi.fn(),
+  ensureSafeDirectory: vi.fn(),
+  retainSafeDirectoryUsage: vi.fn(),
 }));
 
 vi.mock('node:child_process', () => ({ execFile: mocks.execFile }));
 vi.mock('../../scheduler-host/proc-util', () => ({ killProcessTree: mocks.killProcessTree }));
+vi.mock('../safeDirectory', () => ({
+  ensureSafeDirectory: (...args: unknown[]) => mocks.ensureSafeDirectory(...args),
+  retainSafeDirectoryUsage: (...args: unknown[]) => mocks.retainSafeDirectoryUsage(...args),
+}));
 
 import { gitExec, GitExecError } from '../gitExec';
 
@@ -98,6 +105,23 @@ function installExecFileMock(): FakeGit {
   return state;
 }
 
+function installQueuedGitMock() {
+  const callbacks: ExecCb[] = [];
+  const argsSeen: string[][] = [];
+  mocks.execFile.mockImplementation((file: string, args: string[], _opts: unknown, cb?: ExecCb) => {
+    if (file !== 'git') throw new Error(`unexpected execFile: ${file}`);
+    argsSeen.push(args);
+    callbacks.push(cb!);
+    const child = new EventEmitter() as FakeChild;
+    child.pid = 4_000 + callbacks.length;
+    child.kill = vi.fn();
+    child.exitCode = null;
+    child.signalCode = null;
+    return child;
+  });
+  return { callbacks, argsSeen };
+}
+
 /**
  * 模拟 POSIX 进程组:kill(-pid, 0) 探测按 group.alive 应答(空组抛 ESRCH),
  * 其余信号记录后吞掉。返回可变的 group 状态与信号记录。
@@ -146,6 +170,8 @@ beforeEach(() => {
   vi.useFakeTimers();
   mocks.execFile.mockReset();
   mocks.killProcessTree.mockReset();
+  mocks.ensureSafeDirectory.mockReset().mockResolvedValue('persistent');
+  mocks.retainSafeDirectoryUsage.mockReset().mockResolvedValue(undefined);
 });
 
 afterEach(() => {
@@ -168,6 +194,7 @@ describe('gitExec timeoutMs', () => {
     );
 
     const p = gitExec(['fetch', 'origin', 'main'], '/repo', { timeoutMs: 1000 });
+    await flushMicrotasks();
     const s = probe(p);
     const expectation = expect(p).rejects.toMatchObject({
       name: 'GitExecError',
@@ -199,6 +226,7 @@ describe('gitExec timeoutMs', () => {
     );
 
     const p = gitExec(['fetch'], '/repo', { timeoutMs: 1000 });
+    await flushMicrotasks();
     const s = probe(p);
     const expectation = expect(p).rejects.toMatchObject({
       stderr: expect.stringContaining('timed out'),
@@ -231,6 +259,7 @@ describe('gitExec timeoutMs', () => {
     );
 
     const p = gitExec(['fetch'], '/repo', { timeoutMs: 1000 });
+    await flushMicrotasks();
     probe(p);
     vi.advanceTimersByTime(1000);
     await flushMicrotasks();
@@ -251,6 +280,7 @@ describe('gitExec timeoutMs', () => {
     );
 
     const p = gitExec(['fetch'], '/repo', { timeoutMs: 1000 });
+    await flushMicrotasks();
     const s = probe(p);
     const expectation = expect(p).rejects.toMatchObject({
       stderr: expect.stringContaining('process tree terminated'),
@@ -278,6 +308,7 @@ describe('gitExec timeoutMs', () => {
     );
 
     const p = gitExec(['fetch'], '/repo', { timeoutMs: 1000 });
+    await flushMicrotasks();
     const s = probe(p);
     const expectation = expect(p).rejects.toMatchObject({
       stderr: expect.stringContaining('process tree terminated'),
@@ -304,6 +335,7 @@ describe('gitExec timeoutMs', () => {
     );
 
     const p = gitExec(['fetch'], '/repo', { timeoutMs: 1000 });
+    await flushMicrotasks();
     const s = probe(p);
     const expectation = expect(p).rejects.toBeInstanceOf(GitExecError);
     vi.advanceTimersByTime(1000);
@@ -323,6 +355,7 @@ describe('gitExec timeoutMs', () => {
     );
 
     const p = gitExec(['fetch'], '/repo', { timeoutMs: 1000 });
+    await flushMicrotasks();
     const s = probe(p);
     const expectation = expect(p).rejects.toMatchObject({
       stderr: expect.stringContaining('cleanup unconfirmed'),
@@ -344,6 +377,7 @@ describe('gitExec timeoutMs', () => {
     );
 
     const p = gitExec(['fetch'], '/repo', { timeoutMs: 1000 });
+    await flushMicrotasks();
     probe(p);
     const expectation = expect(p).rejects.toMatchObject({
       stderr: expect.stringContaining('cleanup unconfirmed'),
@@ -372,6 +406,7 @@ describe('gitExec timeoutMs', () => {
     });
 
     const p = gitExec(['fetch'], '/repo', { timeoutMs: 1000 });
+    await flushMicrotasks();
     const s = probe(p);
     const expectation = expect(p).rejects.toMatchObject({
       stderr: expect.stringContaining('cleanup unconfirmed'),
@@ -389,6 +424,7 @@ describe('gitExec timeoutMs', () => {
     const { group } = installProcessKillMock();
 
     const p = gitExec(['fetch', 'origin', 'main'], '/repo', { timeoutMs: 500 });
+    await flushMicrotasks();
     const s = probe(p);
     const expectation = expect(p).rejects.toBeInstanceOf(GitExecError);
 
@@ -420,6 +456,7 @@ describe('gitExec timeoutMs', () => {
     );
 
     const p = gitExec(['fetch'], '/repo', { timeoutMs: 500 });
+    await flushMicrotasks();
     const s = probe(p);
     const expectation = expect(p).rejects.toBeInstanceOf(GitExecError);
 
@@ -448,6 +485,7 @@ describe('gitExec timeoutMs', () => {
     );
 
     const p = gitExec(['fetch'], '/repo', { timeoutMs: 500 });
+    await flushMicrotasks();
     const s = probe(p);
     const expectation = expect(p).rejects.toMatchObject({
       stderr: expect.stringContaining('cleanup unconfirmed'),
@@ -468,6 +506,7 @@ describe('gitExec timeoutMs', () => {
     group.alive = false;
 
     const p = gitExec(['fetch'], '/repo', { timeoutMs: 500 });
+    await flushMicrotasks();
     const expectation = expect(p).rejects.toBeInstanceOf(GitExecError);
     vi.advanceTimersByTime(500);
     await expectation;
@@ -481,6 +520,7 @@ describe('gitExec timeoutMs', () => {
     const state = installExecFileMock();
 
     const p = gitExec(['status'], '/repo', { timeoutMs: 1000 });
+    await flushMicrotasks();
     state.gitCb!(null, 'clean', '');
     await expect(p).resolves.toEqual({ stdout: 'clean', stderr: '' });
 
@@ -495,6 +535,7 @@ describe('gitExec timeoutMs', () => {
     const { group } = installProcessKillMock();
 
     const p = gitExec(['fetch'], '/repo', { timeoutMs: 500 });
+    await flushMicrotasks();
     const s = probe(p);
     const expectation = expect(p).rejects.toMatchObject({
       stderr: expect.stringContaining('timed out'),
@@ -519,6 +560,7 @@ describe('gitExec timeoutMs', () => {
     const { group } = installProcessKillMock();
 
     const p = gitExec(['fetch'], '/repo', { timeoutMs: 300 });
+    await flushMicrotasks();
     const expectation = expect(p).rejects.toMatchObject({
       stderr: expect.stringContaining('timed out'),
     });
@@ -536,8 +578,153 @@ describe('gitExec timeoutMs', () => {
     const state = installExecFileMock();
 
     const p = gitExec(['status'], '/repo');
+    await flushMicrotasks();
     state.gitCb!(null, 'ok', '');
     await expect(p).resolves.toEqual({ stdout: 'ok', stderr: '' });
+    expect(mocks.retainSafeDirectoryUsage).toHaveBeenCalledWith('/repo');
     expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('跨 profile 保留声明完成前不启动 Git', async () => {
+    const { callbacks } = installQueuedGitMock();
+    let releasePublication!: () => void;
+    mocks.retainSafeDirectoryUsage.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        releasePublication = resolve;
+      }),
+    );
+
+    const p = gitExec(['status'], '/repo');
+    await flushMicrotasks();
+    expect(callbacks).toHaveLength(0);
+
+    releasePublication();
+    await flushMicrotasks();
+    expect(callbacks).toHaveLength(1);
+    callbacks[0](null, 'clean\n', '');
+    await expect(p).resolves.toEqual({ stdout: 'clean\n', stderr: '' });
+  });
+
+  it('跨 profile 保留声明失败时首个 Git 也只使用命令作用域授权', async () => {
+    const { callbacks, argsSeen } = installQueuedGitMock();
+    mocks.retainSafeDirectoryUsage.mockRejectedValueOnce(new Error('ledger unavailable'));
+
+    const p = gitExec(['status', '--short'], '/repo');
+    await flushMicrotasks();
+
+    expect(argsSeen).toEqual([['-c', 'safe.directory=/repo', 'status', '--short']]);
+    callbacks[0](null, 'clean\n', '');
+    await expect(p).resolves.toEqual({ stdout: 'clean\n', stderr: '' });
+    expect(mocks.ensureSafeDirectory).not.toHaveBeenCalled();
+  });
+
+  it('真实 dubious-ownership 才登记精确路径，并在成功后只重试原命令一次', async () => {
+    const { callbacks, argsSeen } = installQueuedGitMock();
+    const repositoryPath = path.join('/repo', "worktree with 'quote'");
+    const p = gitExec(['status', '--short'], repositoryPath, {
+      extraEnv: { LC_ALL: 'C' },
+    });
+    await flushMicrotasks();
+    const firstFailure = Object.assign(new Error('git failed'), { code: 128 });
+
+    callbacks[0](
+      firstFailure,
+      '',
+      `fatal: detected dubious ownership in repository at '${repositoryPath}'\n`,
+    );
+    await flushMicrotasks();
+
+    expect(mocks.ensureSafeDirectory).toHaveBeenCalledWith(repositoryPath, { LC_ALL: 'C' });
+    expect(argsSeen).toEqual([
+      ['status', '--short'],
+      ['status', '--short'],
+    ]);
+
+    callbacks[1](null, 'clean\n', '');
+    await expect(p).resolves.toEqual({ stdout: 'clean\n', stderr: '' });
+  });
+
+  it('从跨行 dubious 诊断中保留路径里的换行与引号', async () => {
+    const { callbacks, argsSeen } = installQueuedGitMock();
+    const repositoryPath = path.join('/repo', "line one\nline 'two'");
+    const p = gitExec(['status'], repositoryPath);
+    await flushMicrotasks();
+    const firstFailure = Object.assign(new Error('git failed'), { code: 128 });
+
+    callbacks[0](
+      firstFailure,
+      '',
+      `fatal: detected dubious ownership in repository at '${repositoryPath}'\n` +
+        'To add an exception for this directory, call:\n\n' +
+        `\tgit config --global --add safe.directory '${repositoryPath}'\n`,
+    );
+    await flushMicrotasks();
+
+    expect(mocks.ensureSafeDirectory).toHaveBeenCalledWith(repositoryPath, undefined);
+    expect(argsSeen).toEqual([['status'], ['status']]);
+    callbacks[1](null, 'clean\n', '');
+    await expect(p).resolves.toEqual({ stdout: 'clean\n', stderr: '' });
+  });
+
+  it('全局条目无法精确拥有时只给重试命令添加 safe.directory', async () => {
+    const { callbacks, argsSeen } = installQueuedGitMock();
+    const repositoryPath = path.join('/repo', 'reset-history');
+    mocks.ensureSafeDirectory.mockResolvedValueOnce('command');
+    const p = gitExec(['status', '--short'], repositoryPath);
+    await flushMicrotasks();
+    const firstFailure = Object.assign(new Error('git failed'), { code: 128 });
+
+    callbacks[0](
+      firstFailure,
+      '',
+      `fatal: detected dubious ownership in repository at '${repositoryPath}'\n`,
+    );
+    await flushMicrotasks();
+
+    expect(argsSeen).toEqual([
+      ['status', '--short'],
+      ['-c', `safe.directory=${repositoryPath}`, 'status', '--short'],
+    ]);
+    callbacks[1](null, 'clean\n', '');
+    await expect(p).resolves.toEqual({ stdout: 'clean\n', stderr: '' });
+  });
+
+  it('无法从标准错误中证明绝对路径时不回退使用 cwd', async () => {
+    const { callbacks, argsSeen } = installQueuedGitMock();
+    const p = gitExec(['status'], '/repo');
+    await flushMicrotasks();
+    const firstFailure = Object.assign(new Error('git failed'), { code: 128 });
+
+    callbacks[0](firstFailure, '', 'fatal: detected dubious ownership\n');
+
+    await expect(p).rejects.toMatchObject({
+      name: 'GitExecError',
+      stderr: 'fatal: detected dubious ownership\n',
+    });
+    expect(mocks.ensureSafeDirectory).not.toHaveBeenCalled();
+    expect(argsSeen).toEqual([['status']]);
+  });
+
+  it('dubious 恢复的台账或配置写入失败时降级为精确的命令作用域授权', async () => {
+    const { callbacks, argsSeen } = installQueuedGitMock();
+    const repositoryPath = path.join('/repo', 'worktree');
+    const p = gitExec(['status'], repositoryPath);
+    await flushMicrotasks();
+    const firstFailure = Object.assign(new Error('git failed'), { code: 128 });
+    mocks.ensureSafeDirectory.mockRejectedValueOnce(new Error('ledger unavailable'));
+
+    callbacks[0](
+      firstFailure,
+      '',
+      `fatal: detected dubious ownership in repository at '${repositoryPath}'\n`,
+    );
+    await flushMicrotasks();
+
+    expect(argsSeen).toEqual([
+      ['status'],
+      ['-c', `safe.directory=${repositoryPath}`, 'status'],
+    ]);
+    callbacks[1](null, 'clean\n', '');
+    await expect(p).resolves.toEqual({ stdout: 'clean\n', stderr: '' });
   });
 });

--- a/apps/desktop/src/main/worktree/__tests__/liveSessionRefs.test.ts
+++ b/apps/desktop/src/main/worktree/__tests__/liveSessionRefs.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const harness = vi.hoisted(() => ({
+  rows: [] as Array<{
+    id: string;
+    status: string | null;
+    workspaceKind: 'project' | 'dialogue' | null;
+    workingDir: string | null;
+    worktreePath: string | null;
+  }>,
+}));
+
+vi.mock('../../localDb/client/current', () => ({
+  getDbClient: () => ({
+    drizzle: {
+      select: () => ({
+        from: () => ({
+          where: () => harness.rows,
+        }),
+      }),
+    },
+  }),
+}));
+
+import { loadLiveSessionPathKeys, pathKey } from '../liveSessionRefs';
+
+describe('live session path references', () => {
+  beforeEach(() => {
+    harness.rows.length = 0;
+  });
+
+  it('excludes dialogue history from capability retention when requested', async () => {
+    harness.rows.push(
+      {
+        id: 'project-session',
+        status: 'active',
+        workspaceKind: 'project',
+        workingDir: '/repo/project',
+        worktreePath: '/repo/project/.cindy-worktrees/live',
+      },
+      {
+        id: 'dialogue-session',
+        status: 'active',
+        workspaceKind: 'dialogue',
+        workingDir: '/repo/historical-project',
+        worktreePath: '/repo/historical-project/.cindy-worktrees/stale',
+      },
+    );
+
+    const keys = await loadLiveSessionPathKeys({ excludeDialoguePaths: true });
+
+    expect(keys).toEqual(
+      new Set([pathKey('/repo/project'), pathKey('/repo/project/.cindy-worktrees/live')]),
+    );
+  });
+
+  it('keeps dialogue paths by default for conservative deletion guards', async () => {
+    harness.rows.push({
+      id: 'dialogue-session',
+      status: 'active',
+      workspaceKind: 'dialogue',
+      workingDir: '/repo/historical-project',
+      worktreePath: '/repo/historical-project/.cindy-worktrees/stale',
+    });
+
+    const keys = await loadLiveSessionPathKeys();
+
+    expect(keys).toEqual(
+      new Set([
+        pathKey('/repo/historical-project'),
+        pathKey('/repo/historical-project/.cindy-worktrees/stale'),
+      ]),
+    );
+  });
+});

--- a/apps/desktop/src/main/worktree/__tests__/safeDirectory.git-integration.test.ts
+++ b/apps/desktop/src/main/worktree/__tests__/safeDirectory.git-integration.test.ts
@@ -1,0 +1,369 @@
+import { execFile } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import type { WorktreeMeta } from '../types';
+import { gitExec } from '../gitExec';
+import {
+  _resetSafeDirectoryStateForTests,
+  _setActiveWorktreesProviderForTests,
+  _setSafeDirectoryCrossProcessLockRunnerForTests,
+  _setLiveSessionPathKeysProviderForTests,
+  _setSafeDirectoryLedgerStoreForTests,
+  _setSafeDirectoryProfilePathProviderForTests,
+  reconcileSafeDirectories,
+  withSafeDirectoryWitnessRefresh,
+} from '../safeDirectory';
+
+class MemoryLedgerStore {
+  grants: unknown[] = [];
+  profileRetentions: unknown[] = [];
+  profileRetentionRevision = 0;
+
+  constructor(readonly path: string) {}
+
+  get(
+    key: 'grants' | 'profileRetentions' | 'profileRetentionRevision',
+    defaultValue: unknown,
+  ): unknown {
+    return this[key] ?? defaultValue;
+  }
+
+  set(key: 'grants' | 'profileRetentions' | 'profileRetentionRevision', value: unknown): void {
+    if (key === 'profileRetentionRevision') {
+      this.profileRetentionRevision = value as number;
+      return;
+    }
+    this[key] = structuredClone(value as unknown[]);
+  }
+}
+
+function invokeGit(
+  args: readonly string[],
+  cwd?: string,
+): Promise<{ stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      'git',
+      [...args],
+      { cwd, encoding: 'utf8', env: process.env },
+      (error, stdout, stderr) => {
+        if (error) {
+          reject(Object.assign(error, { stdout, stderr }));
+          return;
+        }
+        resolve({ stdout, stderr });
+      },
+    );
+  });
+}
+
+function makeMeta(baseRepo: string, worktreePath: string): WorktreeMeta {
+  return {
+    sessionId: 'session-1',
+    name: path.basename(worktreePath),
+    path: worktreePath,
+    baseRepo,
+    branch: `cindy/${path.basename(worktreePath)}`,
+    sourceBranch: 'main',
+    createdAt: '2026-08-13T00:00:00.000Z',
+  };
+}
+
+describe('safe.directory real Git lifecycle', () => {
+  const environmentKeys = [
+    'HOME',
+    'XDG_CONFIG_HOME',
+    'GIT_CONFIG_NOSYSTEM',
+    'GIT_TEST_ASSUME_DIFFERENT_OWNER',
+    'LC_ALL',
+  ] as const;
+  let previousEnvironment: Partial<Record<(typeof environmentKeys)[number], string>>;
+  let tmpRoot: string;
+  let globalConfig: string;
+  let activeWorktrees: WorktreeMeta[];
+  let liveSessionPathKeys: Set<string> | null;
+  let ledger: MemoryLedgerStore;
+
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'cindy-safe-directory-git-'));
+    activeWorktrees = [];
+    liveSessionPathKeys = new Set();
+    ledger = new MemoryLedgerStore(path.join(tmpRoot, 'ledger.json'));
+    previousEnvironment = {};
+    for (const key of environmentKeys) {
+      if (process.env[key] !== undefined) previousEnvironment[key] = process.env[key];
+    }
+
+    process.env.HOME = path.join(tmpRoot, 'home');
+    process.env.XDG_CONFIG_HOME = path.join(tmpRoot, 'xdg');
+    globalConfig = path.join(process.env.HOME, '.gitconfig');
+    process.env.GIT_CONFIG_NOSYSTEM = '1';
+    delete process.env.GIT_TEST_ASSUME_DIFFERENT_OWNER;
+    process.env.LC_ALL = 'C';
+    fs.mkdirSync(process.env.HOME, { recursive: true });
+    fs.mkdirSync(process.env.XDG_CONFIG_HOME, { recursive: true });
+
+    _setSafeDirectoryLedgerStoreForTests(ledger);
+    _setActiveWorktreesProviderForTests(() => activeWorktrees);
+    _setLiveSessionPathKeysProviderForTests(async () => liveSessionPathKeys);
+    _setSafeDirectoryProfilePathProviderForTests(() => path.join(tmpRoot, 'profile'));
+    _setSafeDirectoryCrossProcessLockRunnerForTests((_lockPath, _options, task) =>
+      task({ held: true }),
+    );
+  });
+
+  afterEach(() => {
+    _resetSafeDirectoryStateForTests();
+    for (const key of environmentKeys) {
+      const previous = previousEnvironment[key];
+      if (previous === undefined) delete process.env[key];
+      else process.env[key] = previous;
+    }
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  async function createRepository(name: string): Promise<string> {
+    const baseRepo = path.join(tmpRoot, `base-${name}`);
+    fs.mkdirSync(baseRepo, { recursive: true });
+    await invokeGit(['init', '--initial-branch=main'], baseRepo);
+    fs.writeFileSync(path.join(baseRepo, 'README.md'), 'test\n');
+    await invokeGit(['add', 'README.md'], baseRepo);
+    await invokeGit(
+      [
+        '-c',
+        'user.name=Cindy Test',
+        '-c',
+        'user.email=cindy@example.invalid',
+        'commit',
+        '--no-gpg-sign',
+        '-m',
+        'initial',
+      ],
+      baseRepo,
+    );
+    return baseRepo;
+  }
+
+  async function createLinkedWorktree(name: string): Promise<{
+    baseRepo: string;
+    worktreePath: string;
+    trustedPath: string;
+  }> {
+    const baseRepo = await createRepository(name);
+    const worktreePath = path.join(baseRepo, '.cindy-worktrees', name);
+    await invokeGit(['worktree', 'add', '-b', 'feature', worktreePath], baseRepo);
+    return { baseRepo, worktreePath, trustedPath: fs.realpathSync(worktreePath) };
+  }
+
+  it('adds only after a real dubious error, keeps while active, and cleans after manual deletion', async () => {
+    const { baseRepo, worktreePath, trustedPath } =
+      await createLinkedWorktree("worktree with 'quote'");
+    activeWorktrees = [makeMeta(baseRepo, worktreePath)];
+    process.env.GIT_TEST_ASSUME_DIFFERENT_OWNER = '1';
+
+    await expect(invokeGit(['status', '--short'], worktreePath)).rejects.toMatchObject({
+      stderr: expect.stringContaining('dubious ownership'),
+    });
+
+    await expect(gitExec(['status', '--short'], worktreePath)).resolves.toMatchObject({
+      stdout: '',
+    });
+    await expect(
+      invokeGit(['config', '--global', '--get-all', 'safe.directory']),
+    ).resolves.toMatchObject({ stdout: `${trustedPath}\n` });
+    expect(ledger.grants).toEqual([
+      expect.objectContaining({ value: trustedPath, state: 'owned', origin: globalConfig }),
+    ]);
+
+    await reconcileSafeDirectories();
+    await expect(
+      invokeGit(['config', '--global', '--get-all', 'safe.directory']),
+    ).resolves.toMatchObject({ stdout: `${trustedPath}\n` });
+
+    // 模拟会话先归档、用户随后在终端自行删除 worktree；store 中仍留有历史记录。
+    fs.rmSync(worktreePath, { recursive: true, force: true });
+    await reconcileSafeDirectories();
+
+    await expect(
+      invokeGit(['config', '--global', '--get-all', 'safe.directory']),
+    ).rejects.toMatchObject({ code: 1 });
+    expect(ledger.grants).toEqual([]);
+  });
+
+  it('keeps a real Git grant while an ordinary task works inside the repository', async () => {
+    const repositoryPath = await createRepository('ordinary-task');
+    const trustedPath = fs.realpathSync(repositoryPath);
+    const workingDir = path.join(repositoryPath, 'packages', 'desktop');
+    fs.mkdirSync(workingDir, { recursive: true });
+    liveSessionPathKeys = new Set([workingDir]);
+    process.env.GIT_TEST_ASSUME_DIFFERENT_OWNER = '1';
+
+    await expect(gitExec(['status', '--short'], repositoryPath)).resolves.toMatchObject({
+      stdout: '',
+    });
+    await reconcileSafeDirectories();
+    await expect(
+      invokeGit(['config', '--global', '--get-all', 'safe.directory']),
+    ).resolves.toMatchObject({ stdout: `${trustedPath}\n` });
+
+    liveSessionPathKeys = new Set();
+    await reconcileSafeDirectories();
+
+    await expect(
+      invokeGit(['config', '--global', '--get-all', 'safe.directory']),
+    ).rejects.toMatchObject({ code: 1 });
+    expect(ledger.grants).toEqual([]);
+  });
+
+  it('owns and cleans a grant when the global config is a symbolic link', async () => {
+    const dotfilesDir = path.join(tmpRoot, 'dotfiles');
+    const configTarget = path.join(dotfilesDir, 'gitconfig');
+    fs.mkdirSync(dotfilesDir, { recursive: true });
+    fs.writeFileSync(configTarget, '[user]\n\tname = Existing User\n');
+    const resolvedConfigTarget = fs.realpathSync(configTarget);
+    fs.symlinkSync(configTarget, globalConfig);
+    const repositoryPath = await createRepository('symlinked-global-config');
+    const trustedPath = fs.realpathSync(repositoryPath);
+    process.env.GIT_TEST_ASSUME_DIFFERENT_OWNER = '1';
+
+    await expect(gitExec(['status', '--short'], repositoryPath)).resolves.toMatchObject({
+      stdout: '',
+    });
+    expect(fs.lstatSync(globalConfig).isSymbolicLink()).toBe(true);
+    expect(fs.realpathSync(globalConfig)).toBe(resolvedConfigTarget);
+    expect(ledger.grants).toEqual([
+      expect.objectContaining({
+        value: trustedPath,
+        state: 'owned',
+        origin: globalConfig,
+        originWitness: expect.objectContaining({
+          realPath: resolvedConfigTarget,
+          symbolicLink: expect.objectContaining({ target: configTarget }),
+        }),
+      }),
+    ]);
+
+    await reconcileSafeDirectories();
+
+    await expect(
+      invokeGit(['config', '--global', '--get-all', 'safe.directory']),
+    ).rejects.toMatchObject({ code: 1 });
+    expect(fs.lstatSync(globalConfig).isSymbolicLink()).toBe(true);
+    expect(fs.readFileSync(configTarget, 'utf8')).toContain('Existing User');
+    expect(ledger.grants).toEqual([]);
+  });
+
+  it('preserves a same-value entry after the global config link is switched externally', async () => {
+    const dotfilesDir = path.join(tmpRoot, 'dotfiles-switch');
+    const originalTarget = path.join(dotfilesDir, 'original.gitconfig');
+    const replacementTarget = path.join(dotfilesDir, 'replacement.gitconfig');
+    fs.mkdirSync(dotfilesDir, { recursive: true });
+    fs.writeFileSync(originalTarget, '');
+    fs.symlinkSync(originalTarget, globalConfig);
+    const repositoryPath = await createRepository('switched-global-config-link');
+    const trustedPath = fs.realpathSync(repositoryPath);
+    process.env.GIT_TEST_ASSUME_DIFFERENT_OWNER = '1';
+
+    await gitExec(['status', '--short'], repositoryPath);
+    await invokeGit([
+      'config',
+      '--file',
+      replacementTarget,
+      '--add',
+      'safe.directory',
+      trustedPath,
+    ]);
+    fs.renameSync(globalConfig, `${globalConfig}.cindy-original-link`);
+    fs.symlinkSync(replacementTarget, globalConfig);
+
+    await reconcileSafeDirectories();
+
+    await expect(
+      invokeGit(['config', '--global', '--get-all', 'safe.directory']),
+    ).resolves.toMatchObject({ stdout: `${trustedPath}\n` });
+    expect(ledger.grants).toEqual([
+      expect.objectContaining({ value: trustedPath, state: 'owned', origin: globalConfig }),
+    ]);
+  });
+
+  it('recovers a real dubious-ownership path containing a newline', async () => {
+    const repositoryPath = await createRepository('line\nbreak');
+    const trustedPath = fs.realpathSync(repositoryPath);
+    process.env.GIT_TEST_ASSUME_DIFFERENT_OWNER = '1';
+
+    await expect(gitExec(['status', '--short'], repositoryPath)).resolves.toMatchObject({
+      stdout: '',
+    });
+    await expect(
+      invokeGit(['config', '--global', '--null', '--get-all', 'safe.directory']),
+    ).resolves.toMatchObject({ stdout: `${trustedPath}\0` });
+
+    await reconcileSafeDirectories();
+    await expect(
+      invokeGit(['config', '--global', '--get-all', 'safe.directory']),
+    ).rejects.toMatchObject({ code: 1 });
+  });
+
+  it('cleans an owned grant after another known Cindy global config write', async () => {
+    const repositoryPath = await createRepository('global-config-write');
+    process.env.GIT_TEST_ASSUME_DIFFERENT_OWNER = '1';
+
+    await gitExec(['status', '--short'], repositoryPath);
+    await withSafeDirectoryWitnessRefresh(() =>
+      invokeGit(['config', '--global', 'core.longpaths', 'true']),
+    );
+    await reconcileSafeDirectories();
+
+    await expect(
+      invokeGit(['config', '--global', '--get-all', 'safe.directory']),
+    ).rejects.toMatchObject({ code: 1 });
+    expect(ledger.grants).toEqual([]);
+  });
+
+  it('preserves a same-value global entry recreated outside Cindy', async () => {
+    const { worktreePath, trustedPath } = await createLinkedWorktree('user-recreated');
+    process.env.GIT_TEST_ASSUME_DIFFERENT_OWNER = '1';
+
+    await gitExec(['status', '--short'], worktreePath);
+    await invokeGit([
+      'config',
+      '--global',
+      '--fixed-value',
+      '--unset',
+      'safe.directory',
+      trustedPath,
+    ]);
+    await invokeGit(['config', '--global', '--add', 'safe.directory', trustedPath]);
+
+    await reconcileSafeDirectories();
+
+    await expect(
+      invokeGit(['config', '--global', '--get-all', 'safe.directory']),
+    ).resolves.toMatchObject({ stdout: `${trustedPath}\n` });
+    expect(ledger.grants).toEqual([
+      expect.objectContaining({ value: trustedPath, state: 'owned' }),
+    ]);
+  });
+
+  it('uses command-scoped trust when an earlier exact value was invalidated by an empty reset', async () => {
+    const { worktreePath, trustedPath } = await createLinkedWorktree('after-reset');
+    process.env.GIT_TEST_ASSUME_DIFFERENT_OWNER = '1';
+    await invokeGit(['config', '--global', '--add', 'safe.directory', trustedPath]);
+    await invokeGit(['config', '--global', '--add', 'safe.directory', '']);
+
+    await expect(invokeGit(['status', '--short'], worktreePath)).rejects.toMatchObject({
+      stderr: expect.stringContaining('dubious ownership'),
+    });
+    await expect(gitExec(['status', '--short'], worktreePath)).resolves.toMatchObject({
+      stdout: '',
+    });
+
+    await expect(
+      invokeGit(['config', '--global', '--null', '--get-all', 'safe.directory']),
+    ).resolves.toMatchObject({ stdout: `${trustedPath}\0\0` });
+    expect(ledger.grants).toEqual([]);
+  });
+});

--- a/apps/desktop/src/main/worktree/__tests__/safeDirectory.test.ts
+++ b/apps/desktop/src/main/worktree/__tests__/safeDirectory.test.ts
@@ -1,0 +1,793 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import type { WorktreeMeta } from '../types';
+import {
+  _resetSafeDirectoryStateForTests,
+  _setGlobalConfigWriteOriginProviderForTests,
+  _setActiveWorktreesProviderForTests,
+  _setSafeDirectoryCrossProcessLockRunnerForTests,
+  _setLiveSessionPathKeysProviderForTests,
+  _setSafeDirectoryGitRunnerForTests,
+  _setSafeDirectoryHomePathProviderForTests,
+  _setSafeDirectoryLedgerStoreForTests,
+  _setSafeDirectoryProfilePathProviderForTests,
+  _setSafeDirectoryProcessProvidersForTests,
+  ensureSafeDirectory,
+  reconcileSafeDirectories,
+  resolveSafeDirectorySharedStateRoot,
+  retainSafeDirectoryUsage,
+  withSafeDirectoryRetention,
+  withSafeDirectoryWitnessRefresh,
+} from '../safeDirectory';
+
+class ConfigFailure extends Error {
+  readonly exitCode: number;
+
+  constructor(exitCode: number, message: string) {
+    super(message);
+    this.exitCode = exitCode;
+  }
+}
+
+class MemoryLedgerStore {
+  grants: unknown[] = [];
+  profileRetentions: unknown[] = [];
+  profileRetentionRevision = 0;
+
+  constructor(readonly path: string) {}
+
+  get(
+    key: 'grants' | 'profileRetentions' | 'profileRetentionRevision',
+    defaultValue: unknown,
+  ): unknown {
+    return this[key] ?? defaultValue;
+  }
+
+  set(key: 'grants' | 'profileRetentions' | 'profileRetentionRevision', value: unknown): void {
+    if (key === 'profileRetentionRevision') {
+      this.profileRetentionRevision = value as number;
+      return;
+    }
+    this[key] = structuredClone(value as unknown[]);
+  }
+}
+
+interface ConfigEntry {
+  filePath: string;
+  value: string;
+}
+
+function makeMeta(baseRepo: string, worktreePath: string): WorktreeMeta {
+  return {
+    sessionId: 'session-1',
+    name: path.basename(worktreePath),
+    path: worktreePath,
+    baseRepo,
+    branch: `cindy/${path.basename(worktreePath)}`,
+    sourceBranch: 'main',
+    createdAt: '2026-08-13T00:00:00.000Z',
+  };
+}
+
+describe('safe.directory ownership ledger', () => {
+  let tmpRoot: string;
+  let globalConfig: string;
+  let entries: ConfigEntry[];
+  let activeWorktrees: WorktreeMeta[];
+  let liveSessionPathKeys: Set<string> | null;
+  let currentProfilePath: string;
+  let currentProcessId: number;
+  let processLiveness: Map<number, 'alive' | 'missing' | 'unknown'>;
+  let ledger: MemoryLedgerStore;
+  let duplicateOnAdd: boolean;
+  let recreateAfterNextAdd: boolean;
+  let recreateBeforeNextShowOrigin: boolean;
+  let executeConfig: ReturnType<typeof vi.fn>;
+  let persistEntries: (replaceFile?: boolean) => void;
+
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'cindy-safe-directory-'));
+    globalConfig = path.join(tmpRoot, 'global.gitconfig');
+    entries = [];
+    activeWorktrees = [];
+    liveSessionPathKeys = new Set();
+    currentProfilePath = path.join(tmpRoot, 'profile-a');
+    currentProcessId = 101;
+    processLiveness = new Map([[101, 'alive']]);
+    ledger = new MemoryLedgerStore(path.join(tmpRoot, 'ledger.json'));
+    duplicateOnAdd = false;
+    recreateAfterNextAdd = false;
+    recreateBeforeNextShowOrigin = false;
+    persistEntries = (replaceFile = false) => {
+      const contents = JSON.stringify(entries);
+      if (!replaceFile) {
+        fs.writeFileSync(globalConfig, contents);
+        return;
+      }
+      const replacement = `${globalConfig}.replacement`;
+      fs.writeFileSync(replacement, contents);
+      fs.renameSync(replacement, globalConfig);
+    };
+
+    executeConfig = vi.fn(async (args: readonly string[]) => {
+      if (args.includes('--show-origin')) {
+        if (recreateBeforeNextShowOrigin && entries.length > 0) {
+          recreateBeforeNextShowOrigin = false;
+          const recreated = entries.at(-1)!;
+          entries = [];
+          persistEntries(true);
+          entries = [recreated];
+          persistEntries(true);
+        }
+        if (entries.length === 0) throw new ConfigFailure(1, 'missing key');
+        return {
+          stdout: entries.map((entry) => `file:${entry.filePath}\0${entry.value}\0`).join(''),
+          stderr: '',
+        };
+      }
+
+      if (args.includes('--file') && args.includes('--add')) {
+        const filePath = args[args.indexOf('--file') + 1];
+        const value = args.at(-1)!;
+        entries.push({ filePath: globalConfig, value });
+        if (duplicateOnAdd) entries.push({ filePath: globalConfig, value });
+        if (recreateAfterNextAdd) {
+          recreateAfterNextAdd = false;
+          recreateBeforeNextShowOrigin = true;
+        }
+        fs.writeFileSync(filePath, JSON.stringify(entries));
+        return { stdout: '', stderr: '' };
+      }
+
+      if (args.includes('--file') && args.includes('--get-all')) {
+        const filePath = args[args.indexOf('--file') + 1];
+        const values = entries
+          .filter((entry) => entry.filePath === filePath)
+          .map((entry) => entry.value);
+        if (values.length === 0) throw new ConfigFailure(1, 'missing key');
+        return { stdout: values.map((value) => `${value}\0`).join(''), stderr: '' };
+      }
+
+      if (args.includes('--file') && args.includes('--unset')) {
+        const filePath = args[args.indexOf('--file') + 1];
+        const realGlobalConfig = fs.realpathSync(globalConfig);
+        const isCindyStagingFile = filePath.startsWith(`${realGlobalConfig}.lock.cindy-`);
+        const entryOrigin = isCindyStagingFile ? globalConfig : filePath;
+        const value = args.at(-1)!;
+        const matches = entries.filter(
+          (entry) => entry.filePath === entryOrigin && entry.value === value,
+        );
+        if (matches.length !== 1) throw new ConfigFailure(5, 'multiple matches');
+        const index = entries.findIndex(
+          (entry) => entry.filePath === entryOrigin && entry.value === value,
+        );
+        entries.splice(index, 1);
+        fs.writeFileSync(filePath, JSON.stringify(entries));
+        return { stdout: '', stderr: '' };
+      }
+
+      throw new Error(`unexpected git config args: ${args.join(' ')}`);
+    });
+
+    _setSafeDirectoryLedgerStoreForTests(ledger);
+    _setSafeDirectoryGitRunnerForTests(executeConfig);
+    _setGlobalConfigWriteOriginProviderForTests(async () => globalConfig);
+    _setActiveWorktreesProviderForTests(() => activeWorktrees);
+    _setLiveSessionPathKeysProviderForTests(async () => liveSessionPathKeys);
+    _setSafeDirectoryProfilePathProviderForTests(() => currentProfilePath);
+    _setSafeDirectoryProcessProvidersForTests(
+      () => currentProcessId,
+      (processId) => processLiveness.get(processId) ?? 'missing',
+    );
+    _setSafeDirectoryCrossProcessLockRunnerForTests((_lockPath, _options, task) =>
+      task({ held: true }),
+    );
+  });
+
+  afterEach(() => {
+    _resetSafeDirectoryStateForTests();
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('does not claim or remove an exact value that already existed', async () => {
+    const repositoryPath = path.join(tmpRoot, "repo with 'quote'");
+    entries.push({ filePath: globalConfig, value: repositoryPath });
+
+    await ensureSafeDirectory(repositoryPath);
+    await reconcileSafeDirectories();
+
+    expect(entries).toEqual([{ filePath: globalConfig, value: repositoryPath }]);
+    expect(ledger.grants).toEqual([]);
+    expect(executeConfig.mock.calls.some(([args]) => args.includes('--add'))).toBe(false);
+  });
+
+  it('uses command scope after an empty reset when the same value cannot be uniquely owned', async () => {
+    const repositoryPath = path.join(tmpRoot, 'repo');
+    entries.push(
+      { filePath: globalConfig, value: repositoryPath },
+      { filePath: globalConfig, value: '' },
+    );
+    persistEntries();
+
+    await expect(ensureSafeDirectory(repositoryPath)).resolves.toBe('command');
+
+    expect(entries).toEqual([
+      { filePath: globalConfig, value: repositoryPath },
+      { filePath: globalConfig, value: '' },
+    ]);
+    expect(ledger.grants).toEqual([]);
+    expect(executeConfig.mock.calls.some(([args]) => args.includes('--add'))).toBe(false);
+  });
+
+  it('uses the app home path when a Windows-style environment has no HOME', async () => {
+    globalConfig = path.join(tmpRoot, '.gitconfig');
+    _setGlobalConfigWriteOriginProviderForTests(null);
+    _setSafeDirectoryHomePathProviderForTests(() => tmpRoot);
+    const repositoryPath = path.join(tmpRoot, 'repo');
+
+    await ensureSafeDirectory(repositoryPath, {
+      HOME: '',
+      USERPROFILE: tmpRoot,
+      XDG_CONFIG_HOME: path.join(tmpRoot, 'missing-xdg'),
+    });
+
+    expect(entries).toEqual([{ filePath: globalConfig, value: repositoryPath }]);
+    expect(ledger.grants).toEqual([
+      expect.objectContaining({ value: repositoryPath, state: 'owned', origin: globalConfig }),
+    ]);
+  });
+
+  it('keeps an owned value for an active worktree, then removes it after out-of-band deletion', async () => {
+    const baseRepo = path.join(tmpRoot, 'repo');
+    const worktreePath = path.join(baseRepo, '.cindy-worktrees', 'feature');
+    const unrelatedPath = path.join(tmpRoot, 'user-owned-repo');
+    fs.mkdirSync(worktreePath, { recursive: true });
+    activeWorktrees = [makeMeta(baseRepo, worktreePath)];
+    entries.push({ filePath: globalConfig, value: unrelatedPath });
+
+    await ensureSafeDirectory(worktreePath);
+    await reconcileSafeDirectories();
+
+    expect(entries).toEqual([
+      { filePath: globalConfig, value: unrelatedPath },
+      { filePath: globalConfig, value: worktreePath },
+    ]);
+    expect(ledger.grants).toEqual([
+      expect.objectContaining({ value: worktreePath, state: 'owned', origin: globalConfig }),
+    ]);
+
+    // 模拟用户绕过 Cindy，在终端直接删除目录，但 worktree store 仍残留旧记录。
+    fs.rmSync(worktreePath, { recursive: true, force: true });
+    await reconcileSafeDirectories();
+
+    expect(entries).toEqual([{ filePath: globalConfig, value: unrelatedPath }]);
+    expect(ledger.grants).toEqual([]);
+    const unsetCall = executeConfig.mock.calls.find(([args]) => args.includes('--unset'))?.[0];
+    expect(unsetCall).toEqual([
+      'config',
+      '--file',
+      expect.stringMatching(
+        new RegExp(
+          `^${fs.realpathSync(globalConfig).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\.lock\\.cindy-`,
+        ),
+      ),
+      '--fixed-value',
+      '--unset',
+      'safe.directory',
+      worktreePath,
+    ]);
+    expect(executeConfig.mock.calls.some(([args]) => args.includes('--unset-all'))).toBe(false);
+  });
+
+  it('keeps an owned value while an ordinary task works inside the repository', async () => {
+    const repositoryPath = path.join(tmpRoot, 'ordinary-repo');
+    const workingDir = path.join(repositoryPath, 'packages', 'desktop');
+    fs.mkdirSync(workingDir, { recursive: true });
+    liveSessionPathKeys = new Set([workingDir]);
+
+    await ensureSafeDirectory(repositoryPath);
+    await reconcileSafeDirectories();
+
+    expect(entries).toEqual([{ filePath: globalConfig, value: repositoryPath }]);
+    expect(ledger.grants).toEqual([
+      expect.objectContaining({ value: repositoryPath, state: 'owned', origin: globalConfig }),
+    ]);
+
+    liveSessionPathKeys = new Set();
+    await reconcileSafeDirectories();
+
+    expect(entries).toEqual([]);
+    expect(ledger.grants).toEqual([]);
+  });
+
+  it('ignores an archived session path after its worktree is definitively gone', async () => {
+    const repositoryPath = path.join(tmpRoot, 'archived-repo');
+    fs.mkdirSync(repositoryPath, { recursive: true });
+    liveSessionPathKeys = new Set([path.join(repositoryPath, '.cindy-worktrees', 'archived')]);
+
+    await ensureSafeDirectory(repositoryPath);
+    await reconcileSafeDirectories();
+
+    expect(entries).toEqual([]);
+    expect(ledger.grants).toEqual([]);
+  });
+
+  it('preserves owned values when live session references cannot be loaded', async () => {
+    const repositoryPath = path.join(tmpRoot, 'ordinary-repo');
+    fs.mkdirSync(repositoryPath, { recursive: true });
+    liveSessionPathKeys = null;
+
+    await ensureSafeDirectory(repositoryPath);
+    await reconcileSafeDirectories();
+
+    expect(entries).toEqual([{ filePath: globalConfig, value: repositoryPath }]);
+    expect(ledger.grants).toEqual([
+      expect.objectContaining({ value: repositoryPath, state: 'owned', origin: globalConfig }),
+    ]);
+    expect(executeConfig.mock.calls.some(([args]) => args.includes('--unset'))).toBe(false);
+  });
+
+  it('preserves duplicate exact values because ownership is ambiguous', async () => {
+    const repositoryPath = path.join(tmpRoot, 'repo');
+    await ensureSafeDirectory(repositoryPath);
+    entries.push({ filePath: globalConfig, value: repositoryPath });
+    persistEntries(true);
+
+    await reconcileSafeDirectories();
+
+    expect(entries).toHaveLength(2);
+    expect(ledger.grants).toEqual([
+      expect.objectContaining({ value: repositoryPath, state: 'owned' }),
+    ]);
+    expect(executeConfig.mock.calls.some(([args]) => args.includes('--unset'))).toBe(false);
+  });
+
+  it('does not delete a same-value entry recreated by the user', async () => {
+    const repositoryPath = path.join(tmpRoot, 'repo');
+    await ensureSafeDirectory(repositoryPath);
+
+    // 最终 value + origin 与 Cindy 写入时完全相同，但配置文件已被外部删除并重建。
+    entries = [];
+    persistEntries(true);
+    entries = [{ filePath: globalConfig, value: repositoryPath }];
+    persistEntries(true);
+
+    await reconcileSafeDirectories();
+
+    expect(entries).toEqual([{ filePath: globalConfig, value: repositoryPath }]);
+    expect(ledger.grants).toEqual([
+      expect.objectContaining({ value: repositoryPath, state: 'owned' }),
+    ]);
+    expect(executeConfig.mock.calls.some(([args]) => args.includes('--unset'))).toBe(false);
+  });
+
+  it('does not claim a same-value entry recreated after the atomic add', async () => {
+    const repositoryPath = path.join(tmpRoot, 'repo');
+    recreateAfterNextAdd = true;
+
+    await ensureSafeDirectory(repositoryPath);
+    await reconcileSafeDirectories();
+
+    expect(entries).toEqual([{ filePath: globalConfig, value: repositoryPath }]);
+    expect(ledger.grants).toEqual([
+      expect.objectContaining({ value: repositoryPath, state: 'pending' }),
+    ]);
+    expect(executeConfig.mock.calls.some(([args]) => args.includes('--unset'))).toBe(false);
+  });
+
+  it('rechecks the witness after acquiring the Git config lock', async () => {
+    const repositoryPath = path.join(tmpRoot, 'repo');
+    await ensureSafeDirectory(repositoryPath);
+    const open = fs.promises.open.bind(fs.promises);
+    const openSpy = vi.spyOn(fs.promises, 'open').mockImplementationOnce(async (...args) => {
+      // 模拟外部工具在锁取得前删除并重建同值配置；锁内见证必须让删除失效。
+      entries = [];
+      persistEntries(true);
+      entries = [{ filePath: globalConfig, value: repositoryPath }];
+      persistEntries(true);
+      return open(...args);
+    });
+
+    try {
+      await reconcileSafeDirectories();
+    } finally {
+      openSpy.mockRestore();
+    }
+    expect(entries).toEqual([{ filePath: globalConfig, value: repositoryPath }]);
+    expect(ledger.grants).toEqual([
+      expect.objectContaining({ value: repositoryPath, state: 'owned' }),
+    ]);
+    expect(executeConfig.mock.calls.some(([args]) => args.includes('--unset'))).toBe(false);
+  });
+
+  it('keeps all same-value claims when owned and pending records overlap', async () => {
+    const repositoryPath = path.join(tmpRoot, 'repo');
+    await ensureSafeDirectory(repositoryPath);
+    const owned = ledger.grants[0] as Record<string, unknown>;
+    ledger.grants.push({
+      ...owned,
+      id: 'pending-overlap',
+      state: 'pending',
+      origin: undefined,
+      originWitness: undefined,
+    });
+
+    await reconcileSafeDirectories();
+
+    expect(entries).toEqual([{ filePath: globalConfig, value: repositoryPath }]);
+    expect(ledger.grants).toHaveLength(2);
+    expect(executeConfig.mock.calls.some(([args]) => args.includes('--unset'))).toBe(false);
+  });
+
+  it('refreshes witnesses across multiple Cindy additions and removals in one config file', async () => {
+    const firstPath = path.join(tmpRoot, 'first');
+    const secondPath = path.join(tmpRoot, 'second');
+
+    await ensureSafeDirectory(firstPath);
+    await ensureSafeDirectory(secondPath);
+    await reconcileSafeDirectories();
+
+    expect(entries).toEqual([]);
+    expect(ledger.grants).toEqual([]);
+    expect(executeConfig.mock.calls.filter(([args]) => args.includes('--unset'))).toHaveLength(2);
+  });
+
+  it('refreshes owned witnesses after another known Cindy global config write', async () => {
+    const repositoryPath = path.join(tmpRoot, 'repo');
+    await ensureSafeDirectory(repositoryPath);
+
+    await withSafeDirectoryWitnessRefresh(async () => {
+      // `git config --global core.longpaths true` rewrites the same file without
+      // changing the effective safe.directory entries.
+      persistEntries(true);
+    });
+    await reconcileSafeDirectories();
+
+    expect(entries).toEqual([]);
+    expect(ledger.grants).toEqual([]);
+    expect(executeConfig.mock.calls.filter(([args]) => args.includes('--unset'))).toHaveLength(1);
+  });
+
+  it('never deletes a grant made ambiguous by a concurrent duplicate, but compacts A after B is gone', async () => {
+    const repositoryPath = path.join(tmpRoot, 'repo');
+    duplicateOnAdd = true;
+
+    await ensureSafeDirectory(repositoryPath);
+    await reconcileSafeDirectories();
+
+    expect(entries).toHaveLength(2);
+    expect(ledger.grants).toEqual([
+      expect.objectContaining({ value: repositoryPath, state: 'ambiguous' }),
+    ]);
+    expect(executeConfig.mock.calls.some(([args]) => args.includes('--unset'))).toBe(false);
+
+    entries = [];
+    await reconcileSafeDirectories();
+    expect(ledger.grants).toEqual([]);
+  });
+
+  it('treats an in-flight creation claim as C until worktree metadata can be persisted', async () => {
+    const worktreePath = path.join(tmpRoot, 'repo', '.cindy-worktrees', 'creating');
+    await withSafeDirectoryRetention({ subtreePaths: [worktreePath] }, async () => {
+      await ensureSafeDirectory(worktreePath);
+      await reconcileSafeDirectories();
+      expect(entries).toEqual([{ filePath: globalConfig, value: worktreePath }]);
+    });
+    await reconcileSafeDirectories();
+    expect(entries).toEqual([]);
+  });
+
+  it('keeps a shared global grant while another profile still publishes a dependency', async () => {
+    const repositoryPath = path.join(tmpRoot, 'repo');
+    const nestedWorkingDirectory = path.join(repositoryPath, 'packages', 'desktop');
+    fs.mkdirSync(nestedWorkingDirectory, { recursive: true });
+    await ensureSafeDirectory(repositoryPath);
+
+    currentProfilePath = path.join(tmpRoot, 'profile-b');
+    currentProcessId = 202;
+    processLiveness.set(202, 'alive');
+    liveSessionPathKeys = new Set();
+    await retainSafeDirectoryUsage(nestedWorkingDirectory);
+    await retainSafeDirectoryUsage(path.join(tmpRoot, 'other-repo'));
+
+    currentProfilePath = path.join(tmpRoot, 'profile-a');
+    currentProcessId = 101;
+    liveSessionPathKeys = new Set();
+    await reconcileSafeDirectories();
+    expect(entries).toEqual([{ filePath: globalConfig, value: repositoryPath }]);
+
+    currentProfilePath = path.join(tmpRoot, 'profile-b');
+    currentProcessId = 202;
+    liveSessionPathKeys = new Set();
+    await reconcileSafeDirectories();
+    expect(entries).toEqual([]);
+  });
+
+  it('drops another profile snapshot only after its process is definitively missing', async () => {
+    const repositoryPath = path.join(tmpRoot, 'stale-profile-repo');
+    fs.mkdirSync(repositoryPath, { recursive: true });
+    await ensureSafeDirectory(repositoryPath);
+
+    currentProfilePath = path.join(tmpRoot, 'profile-b');
+    currentProcessId = 202;
+    processLiveness.set(202, 'alive');
+    await retainSafeDirectoryUsage(repositoryPath);
+
+    currentProfilePath = path.join(tmpRoot, 'profile-a');
+    currentProcessId = 101;
+    liveSessionPathKeys = new Set();
+    await reconcileSafeDirectories();
+    expect(entries).toEqual([{ filePath: globalConfig, value: repositoryPath }]);
+
+    processLiveness.set(202, 'unknown');
+    await reconcileSafeDirectories();
+    expect(entries).toEqual([{ filePath: globalConfig, value: repositoryPath }]);
+
+    processLiveness.set(202, 'missing');
+    await reconcileSafeDirectories();
+
+    expect(entries).toEqual([]);
+    expect(ledger.profileRetentions).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ profilePath: path.join(tmpRoot, 'profile-b'), processId: 202 }),
+      ]),
+    );
+  });
+
+  it('keeps slow reconciliation inspection outside the mutation lock', async () => {
+    const repositoryPath = path.join(tmpRoot, 'slow-inspection-repo');
+    await ensureSafeDirectory(repositoryPath);
+
+    let mutationLockHeld = false;
+    const mutationWaits: number[] = [];
+    _setSafeDirectoryCrossProcessLockRunnerForTests(async (lockPath, options, task) => {
+      if (!lockPath.endsWith('.mutation.lock')) return task({ held: true });
+      mutationWaits.push(options.waitMs ?? 0);
+      mutationLockHeld = true;
+      try {
+        return await task({ held: true });
+      } finally {
+        mutationLockHeld = false;
+      }
+    });
+
+    const originalExecuteConfig = executeConfig.getMockImplementation()!;
+    const slowInspectionLockStates: boolean[] = [];
+    executeConfig.mockImplementation(async (args: readonly string[]) => {
+      if (args.includes('--show-origin') || args.includes('--get-all')) {
+        slowInspectionLockStates.push(mutationLockHeld);
+      }
+      return originalExecuteConfig(args);
+    });
+
+    await reconcileSafeDirectories();
+
+    expect(slowInspectionLockStates).not.toHaveLength(0);
+    expect(slowInspectionLockStates.every((held) => !held)).toBe(true);
+    expect(mutationWaits.every((waitMs) => waitMs > 10_000)).toBe(true);
+    expect(entries).toEqual([]);
+  });
+
+  it('keeps the final retention proof outside the mutation lock', async () => {
+    const repositoryPath = path.join(tmpRoot, 'final-proof-repo');
+    let mutationLockHeld = false;
+    _setSafeDirectoryCrossProcessLockRunnerForTests(async (lockPath, _options, task) => {
+      if (!lockPath.endsWith('.mutation.lock')) return task({ held: true });
+      mutationLockHeld = true;
+      try {
+        return await task({ held: true });
+      } finally {
+        mutationLockHeld = false;
+      }
+    });
+
+    const lookupLockStates: boolean[] = [];
+    _setLiveSessionPathKeysProviderForTests(async () => {
+      lookupLockStates.push(mutationLockHeld);
+      return new Set();
+    });
+    await ensureSafeDirectory(repositoryPath);
+    lookupLockStates.length = 0;
+
+    await reconcileSafeDirectories();
+
+    expect(lookupLockStates.length).toBeGreaterThan(0);
+    expect(lookupLockStates.every((held) => !held)).toBe(true);
+    expect(entries).toEqual([]);
+  });
+
+  it('abandons removal when the profile retention revision changes during the final proof', async () => {
+    const repositoryPath = path.join(tmpRoot, 'retention-revision-repo');
+    let lookupCount = 0;
+    _setLiveSessionPathKeysProviderForTests(async () => {
+      lookupCount += 1;
+      if (lookupCount === 3) {
+        const originalRecords = structuredClone(ledger.profileRetentions);
+        ledger.profileRetentions.push({
+          profilePath: path.join(tmpRoot, 'profile-b'),
+          processId: 202,
+          roots: [{ path: repositoryPath, mode: 'exact' }],
+          liveSessionPaths: [],
+        });
+        ledger.profileRetentionRevision += 1;
+        ledger.profileRetentions = originalRecords;
+        ledger.profileRetentionRevision += 1;
+      }
+      return new Set();
+    });
+    await ensureSafeDirectory(repositoryPath);
+    lookupCount = 0;
+
+    await reconcileSafeDirectories();
+
+    expect(lookupCount).toBeGreaterThanOrEqual(3);
+    expect(entries).toEqual([{ filePath: globalConfig, value: repositoryPath }]);
+    expect(ledger.grants).toEqual([
+      expect.objectContaining({ value: repositoryPath, state: 'owned' }),
+    ]);
+  });
+
+  it('does not keep lock-free inspection in the local mutation queue', async () => {
+    const repositoryPath = path.join(tmpRoot, 'hot-path-repo');
+    await ensureSafeDirectory(repositoryPath);
+
+    let signalInspectionStarted!: () => void;
+    let releaseInspection!: () => void;
+    const inspectionStarted = new Promise<void>((resolve) => {
+      signalInspectionStarted = resolve;
+    });
+    const inspectionRelease = new Promise<void>((resolve) => {
+      releaseInspection = resolve;
+    });
+    const originalExecuteConfig = executeConfig.getMockImplementation()!;
+    let pauseInspection = true;
+    executeConfig.mockImplementation(async (args: readonly string[]) => {
+      const result = await originalExecuteConfig(args);
+      if (pauseInspection && args.includes('--show-origin')) {
+        pauseInspection = false;
+        signalInspectionStarted();
+        await inspectionRelease;
+      }
+      return result;
+    });
+
+    const reconciliation = reconcileSafeDirectories();
+    await inspectionStarted;
+
+    let signalTaskStarted!: () => void;
+    let releaseTask!: () => void;
+    const taskStarted = new Promise<void>((resolve) => {
+      signalTaskStarted = resolve;
+    });
+    const taskRelease = new Promise<void>((resolve) => {
+      releaseTask = resolve;
+    });
+    const retention = withSafeDirectoryRetention({ exactPaths: [repositoryPath] }, async () => {
+      signalTaskStarted();
+      await taskRelease;
+    });
+
+    let startTimeout: ReturnType<typeof setTimeout> | undefined;
+    try {
+      await Promise.race([
+        taskStarted,
+        new Promise<never>((_, reject) => {
+          startTimeout = setTimeout(
+            () => reject(new Error('retention publication was blocked by lock-free inspection')),
+            1_000,
+          );
+        }),
+      ]);
+      releaseInspection();
+      await reconciliation;
+      expect(entries).toEqual([{ filePath: globalConfig, value: repositoryPath }]);
+    } finally {
+      if (startTimeout) clearTimeout(startTimeout);
+      releaseInspection();
+      releaseTask();
+      await Promise.allSettled([reconciliation, retention]);
+    }
+
+    await reconcileSafeDirectories();
+    expect(entries).toEqual([]);
+  });
+
+  it('rechecks a cross-profile claim published during lock-free inspection', async () => {
+    const repositoryPath = path.join(tmpRoot, 'late-cross-profile-claim');
+    await ensureSafeDirectory(repositoryPath);
+
+    const originalExecuteConfig = executeConfig.getMockImplementation()!;
+    let published = false;
+    executeConfig.mockImplementation(async (args: readonly string[]) => {
+      const result = await originalExecuteConfig(args);
+      if (!published && args.includes('--show-origin')) {
+        published = true;
+        processLiveness.set(202, 'alive');
+        ledger.profileRetentions.push({
+          profilePath: path.join(tmpRoot, 'profile-b'),
+          processId: 202,
+          roots: [{ path: repositoryPath, mode: 'exact' }],
+          liveSessionPaths: [],
+        });
+      }
+      return result;
+    });
+
+    await reconcileSafeDirectories();
+
+    expect(published).toBe(true);
+    expect(entries).toEqual([{ filePath: globalConfig, value: repositoryPath }]);
+    expect(executeConfig.mock.calls.some(([args]) => args.includes('--unset'))).toBe(false);
+  });
+
+  it('holds the mutation lock only while publishing and withdrawing the persistent claim', async () => {
+    let mutationLockHeld = false;
+    _setSafeDirectoryCrossProcessLockRunnerForTests(async (lockPath, _options, task) => {
+      if (!lockPath.endsWith('.mutation.lock')) return task({ held: true });
+      mutationLockHeld = true;
+      try {
+        return await task({ held: true });
+      } finally {
+        mutationLockHeld = false;
+      }
+    });
+
+    const dynamicallyAddedPath = path.join(tmpRoot, 'dynamic-worktree');
+    await withSafeDirectoryRetention({ exactPaths: [tmpRoot] }, async (retention) => {
+      expect(mutationLockHeld).toBe(false);
+      await retention.addSubtree(dynamicallyAddedPath);
+      expect(mutationLockHeld).toBe(false);
+      expect(ledger.profileRetentions).toEqual([
+        expect.objectContaining({
+          roots: expect.arrayContaining([
+            expect.objectContaining({ path: dynamicallyAddedPath, mode: 'subtree' }),
+          ]),
+        }),
+      ]);
+    });
+  });
+
+  it('keeps creation available when shared retention publication is unavailable', async () => {
+    const repositoryPath = path.join(tmpRoot, 'repo');
+    const dynamicallyAddedPath = path.join(repositoryPath, '.cindy-worktrees', 'creating');
+    _setSafeDirectoryCrossProcessLockRunnerForTests((lockPath, _options, task) =>
+      task(lockPath.endsWith('.mutation.lock') ? { held: false, reason: 'busy' } : { held: true }),
+    );
+
+    const result = await withSafeDirectoryRetention(
+      { exactPaths: [repositoryPath] },
+      async (retention) => {
+        await retention.addSubtree(dynamicallyAddedPath);
+        return 'created';
+      },
+    );
+
+    expect(result).toBe('created');
+    expect(ledger.profileRetentions).toEqual([]);
+    expect(entries).toEqual([]);
+  });
+
+  it('derives one stable shared state root independently of profile userData', () => {
+    const appDataPath = path.join(tmpRoot, 'app-data');
+    expect(resolveSafeDirectorySharedStateRoot(appDataPath)).toBe(
+      path.join(appDataPath, 'CindyShared'),
+    );
+  });
+
+  it('does not mutate the ledger or global config without the cross-process mutation lock', async () => {
+    const repositoryPath = path.join(tmpRoot, 'repo');
+    _setSafeDirectoryCrossProcessLockRunnerForTests((lockPath, _options, task) =>
+      task(lockPath.endsWith('.mutation.lock') ? { held: false, reason: 'busy' } : { held: true }),
+    );
+
+    await expect(ensureSafeDirectory(repositoryPath)).rejects.toThrow(
+      'safe.directory mutation lock busy',
+    );
+    expect(entries).toEqual([]);
+    expect(ledger.grants).toEqual([]);
+    expect(executeConfig.mock.calls.some(([args]) => args.includes('--add'))).toBe(false);
+  });
+});

--- a/apps/desktop/src/main/worktree/gitExec.ts
+++ b/apps/desktop/src/main/worktree/gitExec.ts
@@ -4,7 +4,8 @@
  * 职责:
  *   - 用 child_process.execFile 调用 git, 保留 stderr/stdout/exitCode
  *   - 自动处理 dubious-ownership: 若 stderr 含 "dubious ownership", 提取路径,
- *     `git config --global --add safe.directory <path>`, 重试**一次**原命令
+ *     交给 safeDirectory 所有权台账按需添加全局信任；若全局配置无法精确拥有，
+ *     用单次命令作用域信任重试**一次**
  *   - 抛出 GitExecError 让上层 errorClassifier 解析为 WorktreeError
  *
  * 不在这里做 errorClassifier — 那是上层 createWorktree/removeWorktree 的职责,
@@ -12,8 +13,10 @@
  */
 
 import { execFile, type ExecFileOptions } from 'node:child_process';
+import path from 'node:path';
 
 import { killProcessTree } from '../scheduler-host/proc-util';
+import { ensureSafeDirectory, retainSafeDirectoryUsage } from './safeDirectory';
 
 export interface GitExecResult {
   stdout: string;
@@ -437,13 +440,33 @@ function execFileOnce(
  *   fatal: detected dubious ownership in repository at C:/path/to/repo
  */
 function extractDubiousPath(stderr: string): string | null {
-  // 优先匹配带引号的形态(各平台/版本通用)
-  const quoted = stderr.match(/dubious ownership in repository at ['"]([^'"]+)['"]/i);
-  if (quoted) return quoted[1];
-  // 兜底: 不带引号(老 git 版本)
-  const bare = stderr.match(/dubious ownership in repository at\s+(\S+)/i);
-  if (bare) return bare[1];
-  return null;
+  // Git 对含换行的 POSIX 路径会把 fatal 诊断也展开成多行；以随后固定的建议段
+  // 作为边界。不能用 [^'"]+：合法路径本身可以含引号。
+  const match = /^fatal: detected dubious ownership in repository at[\t ]+/im.exec(stderr);
+  if (!match) return null;
+  const remainder = stderr.slice(match.index + match[0].length);
+  const suggestion = /\r?\nTo add an exception for this directory, call:\r?\n/.exec(remainder);
+  let candidate = suggestion
+    ? remainder.slice(0, suggestion.index)
+    : (remainder.match(/^[^\r\n]*/)?.[0] ?? '');
+  if (
+    candidate.length >= 2 &&
+    ((candidate.startsWith("'") && candidate.endsWith("'")) ||
+      (candidate.startsWith('"') && candidate.endsWith('"')))
+  ) {
+    candidate = candidate.slice(1, -1);
+  } else {
+    candidate = candidate.trim();
+  }
+  if (!candidate || candidate.includes('\0') || !path.isAbsolute(candidate)) return null;
+  return candidate;
+}
+
+function withCommandScopedSafeDirectory(
+  args: readonly string[],
+  repositoryPath: string,
+): readonly string[] {
+  return ['-c', `safe.directory=${repositoryPath}`, ...args];
 }
 
 /**
@@ -451,7 +474,8 @@ function extractDubiousPath(stderr: string): string | null {
  *
  * 行为:
  *   - 第一次 execFile 成功 → 直接 resolve
- *   - 失败 + stderr 含 "dubious ownership" → 提取 path, 配 safe.directory, 重试**一次**
+ *   - 失败 + 标准 dubious-ownership 提示 → 提取绝对 path, 按需登记 safe.directory,
+ *     重试**一次**
  *   - 重试仍失败 → 抛 GitExecError(stderr 仍是 dubious-ownership, 让 classifier 走兜底)
  *   - 任何其他失败 → 抛 GitExecError 不重试
  */
@@ -460,26 +484,47 @@ export async function gitExec(
   cwd?: string,
   opts?: GitExecOpts,
 ): Promise<GitExecResult> {
+  // 必须先发布跨 profile 依赖，再让 Git 读取全局配置。否则并发对账可能在本次命令
+  // 已读到旧授权后将其删除，而成功分支不会触发 dubious 恢复，后续 Agent Git 失去信任。
+  // 台账暂不可用时也不能退回“直接启动 Git”：改用只对本次进程生效的 -c 授权，
+  // 不依赖全局条目，且不会留下无法证明所有权的持久配置。
+  let retentionPublished = true;
+  let firstAttemptArgs = args;
+  if (cwd && path.isAbsolute(cwd)) {
+    try {
+      await retainSafeDirectoryUsage(cwd);
+    } catch {
+      retentionPublished = false;
+      firstAttemptArgs = withCommandScopedSafeDirectory(args, cwd);
+    }
+  }
   try {
-    return await execFileOnce(args, cwd, opts);
+    return await execFileOnce(firstAttemptArgs, cwd, opts);
   } catch (err) {
     if (!(err instanceof GitExecError)) throw err;
     // spawn ENOENT(git 未安装) 也走 GitExecError, 这里不该重试
     if (err.cause?.code === 'ENOENT') throw err;
 
-    if (/dubious ownership/i.test(err.stderr)) {
-      const dubiousPath = extractDubiousPath(err.stderr) ?? cwd;
-      if (dubiousPath) {
-        try {
-          await execFileOnce(
-            ['config', '--global', '--add', 'safe.directory', dubiousPath],
-          );
-          // 配完 safe.directory 后重试原命令
-          return await execFileOnce(args, cwd, opts);
-        } catch {
-          // 重试或配置失败都直接抛原始错误(让 classifier 报 dubious-ownership)
-          throw err;
-        }
+    const dubiousPath = extractDubiousPath(err.stderr);
+    if (dubiousPath) {
+      let retryArgs: readonly string[];
+      try {
+        const recoveryMode = retentionPublished
+          ? await ensureSafeDirectory(dubiousPath, opts?.extraEnv)
+          : 'command';
+        retryArgs =
+          recoveryMode === 'command'
+            ? withCommandScopedSafeDirectory(args, dubiousPath)
+            : args;
+      } catch {
+        // 台账/配置写入失败仍可安全执行：精确路径只进入这一次 Git 子进程的配置。
+        retryArgs = withCommandScopedSafeDirectory(args, dubiousPath);
+      }
+      try {
+        return await execFileOnce(retryArgs, cwd, opts);
+      } catch {
+        // 重试失败保留原始 dubious 错误，让 classifier 给出稳定诊断。
+        throw err;
       }
     }
     throw err;

--- a/apps/desktop/src/main/worktree/index.ts
+++ b/apps/desktop/src/main/worktree/index.ts
@@ -33,6 +33,10 @@ export {
   reconcileWorktreesForDeletedSessions,
 } from './sessionRemovalRecycle';
 export {
+  reconcileSafeDirectories,
+  setSafeDirectorySessionRuntimeAliveProvider,
+} from './safeDirectory';
+export {
   getWorktreeRestoreStatus,
   restoreMissingManagedWorktreeForSession,
   restoreWorktreeForSession,

--- a/apps/desktop/src/main/worktree/liveSessionRefs.ts
+++ b/apps/desktop/src/main/worktree/liveSessionRefs.ts
@@ -48,6 +48,11 @@ export interface LoadLiveSessionPathKeysOptions {
   /** 日志上下文（定位是哪条 worktree 的检查失败）。 */
   contextPath?: string;
   /**
+   * dialogue 行可能为历史展示保留先前项目的 workingDir/worktreePath。授权生命周期可以
+   * 忽略这些旧路径；删除/淘汰安全门仍应使用默认 false，避免扩大回收范围。
+   */
+  excludeDialoguePaths?: boolean;
+  /**
    * 排除的会话 id：显式删除/归档会话时，该会话自己的 workingDir/worktreePath
    * 不构成"仍在用"；显式回收观察器存在时，其它终态会话仍需运行态证明才能排除。
    */
@@ -65,6 +70,7 @@ export async function loadLiveSessionPathKeys(
       .select({
         id: sessions.id,
         status: sessions.status,
+        workspaceKind: sessions.workspaceKind,
         workingDir: sessions.workingDir,
         worktreePath: sessions.worktreePath,
       })
@@ -78,6 +84,7 @@ export async function loadLiveSessionPathKeys(
     const keys = new Set<string>();
     for (const row of rows) {
       if (opts.excludeSessionId && row.id === opts.excludeSessionId) continue;
+      if (opts.excludeDialoguePaths && row.workspaceKind === 'dialogue') continue;
       const isTerminal = row.status === 'archived' || row.status === 'deleted';
       if (!opts.isSessionRuntimeAlive && row.status === 'deleted') {
         continue;

--- a/apps/desktop/src/main/worktree/restore.ts
+++ b/apps/desktop/src/main/worktree/restore.ts
@@ -25,6 +25,7 @@ import { readAttachedWorktreeBranch } from './attachedBranch';
 import { gitExec, GitExecError } from './gitExec';
 import { applyWorktreeIncludeFile } from './includePatternsEngine';
 import { pathKey } from './liveSessionRefs';
+import { withSafeDirectoryWitnessRefresh } from './safeDirectory';
 import {
   getWorktreeRestoreMutation,
   getWorktreeRestoreMutationVersion,
@@ -258,7 +259,9 @@ async function addRestoredWorktree(
     if (!(err instanceof GitExecError) || !/filename too long|core\.longpaths/i.test(err.stderr)) {
       throw err;
     }
-    await gitExec(['config', '--global', 'core.longpaths', 'true']);
+    await withSafeDirectoryWitnessRefresh(() =>
+      gitExec(['config', '--global', 'core.longpaths', 'true']),
+    );
     await gitExec(addArgs, baseRepo);
   }
 }

--- a/apps/desktop/src/main/worktree/safeDirectory.ts
+++ b/apps/desktop/src/main/worktree/safeDirectory.ts
@@ -1,0 +1,1864 @@
+/**
+ * Git safe.directory 的所有权台账与声明式对账。
+ *
+ * Cindy 只在 Git 明确报 dubious ownership 时写全局配置。写入前先持久化 pending
+ * 记录，写入后再根据全局配置的精确 value + origin 确认所有权。清理时只删除：
+ *   A. 台账能证明由 Cindy 独占写入；
+ *   B. 当前全局配置仍只有这一条精确记录；
+ *   C. 已不存在需要它的 Cindy worktree 或普通任务。
+ *
+ * pending、并发产生的重复项、来源不明或读取失败都按保守方向保留，绝不使用
+ * `--unset-all`。台账、profile 进程快照与 mutation 锁都位于跨 profile 的共享
+ * appData 作用域；创建声明、台账和全局配置变更统一经过这一个严格跨进程锁。
+ */
+
+import { execFile } from 'node:child_process';
+import { createHash, randomUUID } from 'node:crypto';
+import type { BigIntStats } from 'node:fs';
+import type { FileHandle } from 'node:fs/promises';
+import path from 'node:path';
+import fs from 'node:fs/promises';
+
+import { app } from 'electron';
+import Store from 'electron-store';
+
+import {
+  withSecurityBoundaryLock,
+  type FileLockOptions,
+  type LockStatus,
+} from '../device-link/crossProcessLock';
+import { createLogger } from '../logger';
+import { loadLiveSessionPathKeys, type LiveSessionPathKeys } from './liveSessionRefs';
+import * as worktreeStore from './worktreeStore';
+
+import type { WorktreeMeta } from './types';
+
+const log = createLogger('worktreeSafeDirectory');
+
+type SafeDirectoryGrantState = 'pending' | 'owned' | 'ambiguous';
+
+interface SafeDirectoryGrantRecord {
+  id: string;
+  value: string;
+  state: SafeDirectoryGrantState;
+  createdAt: string;
+  /** owned 状态下 Cindy 写入记录所在的精确配置文件。 */
+  origin?: string;
+  /**
+   * Cindy 最后一次改动该配置文件后留下的见证。只要文件被外部重写，即使同值
+   * safe.directory 又出现，也不再把它当成 Cindy 原先写入的那一条。
+   */
+  originWitness?: ConfigFileWitness;
+  /** ambiguous 状态下观测到的候选文件，仅用于确认记录是否已由外部清除。 */
+  candidateOrigins?: string[];
+}
+
+interface ConfigFileWitness {
+  realPath: string;
+  device: string;
+  inode: string;
+  mode: string;
+  size: string;
+  modifiedAtNs: string;
+  changedAtNs: string;
+  sha256: string;
+  /** 最终路径本身是符号链接时，同时锁定链接身份与 link text。 */
+  symbolicLink?: ConfigSymbolicLinkWitness;
+}
+
+interface ConfigSymbolicLinkWitness {
+  target: string;
+  device: string;
+  inode: string;
+  mode: string;
+  size: string;
+  modifiedAtNs: string;
+  changedAtNs: string;
+}
+
+interface SafeDirectoryLedgerShape {
+  version: number;
+  grants: SafeDirectoryGrantRecord[];
+  profileRetentions: SafeDirectoryProfileRetentionRecord[];
+  profileRetentionRevision: number;
+}
+
+interface SafeDirectoryLedgerStore {
+  readonly path: string;
+  get(key: 'grants', defaultValue: SafeDirectoryGrantRecord[]): unknown;
+  get(key: 'profileRetentions', defaultValue: SafeDirectoryProfileRetentionRecord[]): unknown;
+  get(key: 'profileRetentionRevision', defaultValue: number): unknown;
+  set(key: 'grants', value: SafeDirectoryGrantRecord[]): void;
+  set(key: 'profileRetentions', value: SafeDirectoryProfileRetentionRecord[]): void;
+  set(key: 'profileRetentionRevision', value: number): void;
+}
+
+interface GitConfigResult {
+  stdout: string;
+  stderr: string;
+}
+
+type GitConfigRunner = (
+  args: readonly string[],
+  extraEnv?: Record<string, string>,
+) => Promise<GitConfigResult>;
+
+interface GlobalSafeDirectoryEntry {
+  origin: string;
+  filePath: string | null;
+  value: string;
+}
+
+type RetentionMode = 'exact' | 'subtree';
+
+interface RetentionRoot {
+  path: string;
+  mode: RetentionMode;
+}
+
+interface RetentionSnapshot {
+  roots: RetentionRoot[];
+  /** null 表示会话引用无法确认；删除必须 fail closed。 */
+  liveSessionPathKeys: LiveSessionPathKeys;
+}
+
+interface SafeDirectoryProfileRetentionRecord {
+  profilePath: string;
+  processId: number;
+  roots: RetentionRoot[];
+  /** null 表示该 profile 的会话引用无法确认；全局删除必须 fail closed。 */
+  liveSessionPaths: string[] | null;
+}
+
+export interface SafeDirectoryRetention {
+  /** 保留与该路径完全相同的 safe.directory（用于 base repository）。 */
+  addExact(value: string): Promise<void>;
+  /** 保留该目录及其内部仓库的 safe.directory（用于 linked worktree）。 */
+  addSubtree(value: string): Promise<void>;
+}
+
+export type SafeDirectoryRecoveryMode = 'persistent' | 'command';
+
+interface LocalSafeDirectoryRetention {
+  addExact(value: string): boolean;
+  addSubtree(value: string): boolean;
+  release(): void;
+}
+
+type CrossProcessLockRunner = <T>(
+  lockPath: string,
+  options: FileLockOptions,
+  task: (status: LockStatus) => Promise<T>,
+) => Promise<T>;
+
+type ProcessLiveness = 'alive' | 'missing' | 'unknown';
+type GlobalConfigWriteOriginProvider = (
+  extraEnv?: Record<string, string>,
+) => Promise<string | null>;
+
+class GitConfigError extends Error {
+  readonly exitCode: number | null;
+
+  constructor(message: string, exitCode: number | null) {
+    super(message);
+    this.name = 'GitConfigError';
+    this.exitCode = exitCode;
+  }
+}
+
+let ledgerStore: SafeDirectoryLedgerStore | null = null;
+let gitConfigRunner: GitConfigRunner = runGitConfig;
+let activeWorktreesProvider: () => readonly WorktreeMeta[] = () => worktreeStore.getAll();
+type SessionRuntimeAliveProvider = (sessionId: string) => boolean | undefined;
+let sessionRuntimeAliveProvider: SessionRuntimeAliveProvider | null = null;
+const loadCurrentLiveSessionPathKeys = (): Promise<LiveSessionPathKeys> =>
+  loadLiveSessionPathKeys({
+    excludeDialoguePaths: true,
+    ...(sessionRuntimeAliveProvider ? { isSessionRuntimeAlive: sessionRuntimeAliveProvider } : {}),
+  });
+let liveSessionPathKeysProvider: () => Promise<LiveSessionPathKeys> =
+  loadCurrentLiveSessionPathKeys;
+let crossProcessLockRunner: CrossProcessLockRunner = withSecurityBoundaryLock;
+let sharedStateRootProvider: () => string = () =>
+  resolveSafeDirectorySharedStateRoot(app.getPath('appData'));
+let currentProfilePathProvider: () => string = () => app.getPath('userData');
+let currentProcessIdProvider: () => number = () => process.pid;
+let processLivenessProvider: (processId: number) => ProcessLiveness = probeProcessLiveness;
+let globalConfigWriteOriginProvider: GlobalConfigWriteOriginProvider =
+  resolveGlobalConfigWriteOrigin;
+let homePathProvider: () => string = () => app.getPath('home');
+let operationTail: Promise<void> = Promise.resolve();
+
+const inflightRetentionRoots = new Map<string, RetentionRoot & { count: number }>();
+const publishedUsagePaths = new Set<string>();
+let inflightRetentionGeneration = 0;
+
+const GIT_CONFIG_TIMEOUT_MS = 10_000;
+// 两阶段对账的最终提交最多只包一条 Git 配置 mutation（受上面的 10 秒 deadline
+// 约束）与本地见证刷新。声明发布等待一个提交窗口，不会沿用严格锁默认的 3 秒
+// 后直接失败。
+const MUTATION_LOCK_WAIT_MS = 30_000;
+
+export function resolveSafeDirectorySharedStateRoot(appDataPath: string): string {
+  if (!isAbsolutePath(appDataPath)) {
+    throw new Error('safe.directory appData path must be absolute');
+  }
+  return path.join(appDataPath, 'CindyShared');
+}
+
+function getLedgerStore(): SafeDirectoryLedgerStore {
+  if (ledgerStore) return ledgerStore;
+  const sharedStateRoot = sharedStateRootProvider();
+  if (!isAbsolutePath(sharedStateRoot)) {
+    throw new Error('safe.directory shared state root must be absolute');
+  }
+  ledgerStore = new Store<SafeDirectoryLedgerShape>({
+    name: 'git-safe-directory-grants',
+    cwd: sharedStateRoot,
+    defaults: { version: 2, grants: [], profileRetentions: [], profileRetentionRevision: 0 },
+    schema: {
+      version: { type: 'number' },
+      grants: { type: 'array' },
+      profileRetentions: { type: 'array' },
+      profileRetentionRevision: { type: 'number', minimum: 0 },
+    },
+    clearInvalidConfig: true,
+  }) as unknown as SafeDirectoryLedgerStore;
+  return ledgerStore;
+}
+
+type SafeDirectoryLockKind = 'mutation';
+
+function crossProcessLockPath(kind: SafeDirectoryLockKind): string {
+  const storePath = getLedgerStore().path;
+  if (!isAbsolutePath(storePath)) {
+    throw new Error('safe.directory ledger path must be absolute');
+  }
+  return `${storePath}.${kind}.lock`;
+}
+
+function runWithCrossProcessLock<T>(
+  kind: SafeDirectoryLockKind,
+  task: (status: LockStatus) => Promise<T>,
+): Promise<T> {
+  return crossProcessLockRunner(
+    crossProcessLockPath(kind),
+    { label: `safe.directory ${kind}`, waitMs: MUTATION_LOCK_WAIT_MS },
+    task,
+  );
+}
+
+function runWithRequiredCrossProcessLock<T>(
+  kind: SafeDirectoryLockKind,
+  task: () => Promise<T>,
+): Promise<T> {
+  return runWithCrossProcessLock(kind, (status) => {
+    if (!status.held) {
+      throw new Error(`safe.directory ${kind} lock ${status.reason}`);
+    }
+    return task();
+  });
+}
+
+function serializeMutationOperation<T>(operation: () => Promise<T>): Promise<T> {
+  return serializeOperation(() => runWithRequiredCrossProcessLock('mutation', operation));
+}
+
+async function runReconciliationWithMutationLock<T>(task: () => Promise<T>): Promise<T | null> {
+  return runWithCrossProcessLock('mutation', async (status) => {
+    if (!status.held) {
+      log.warn(`[safe.directory] skipped reconciliation: mutation lock ${status.reason}`);
+      return null;
+    }
+    return task();
+  });
+}
+
+function isAbsolutePath(value: unknown): value is string {
+  return (
+    typeof value === 'string' && value.length > 0 && !value.includes('\0') && path.isAbsolute(value)
+  );
+}
+
+function isGrantState(value: unknown): value is SafeDirectoryGrantState {
+  return value === 'pending' || value === 'owned' || value === 'ambiguous';
+}
+
+function parseConfigFileWitness(value: unknown): ConfigFileWitness | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const candidate = value as Partial<ConfigFileWitness>;
+  const decimalFields = [
+    candidate.device,
+    candidate.inode,
+    candidate.mode,
+    candidate.size,
+    candidate.modifiedAtNs,
+    candidate.changedAtNs,
+  ];
+  if (
+    !isAbsolutePath(candidate.realPath) ||
+    decimalFields.some((field) => typeof field !== 'string' || !/^\d+$/.test(field)) ||
+    typeof candidate.sha256 !== 'string' ||
+    !/^[0-9a-f]{64}$/.test(candidate.sha256)
+  ) {
+    return null;
+  }
+  let symbolicLink: ConfigSymbolicLinkWitness | undefined;
+  if (candidate.symbolicLink !== undefined) {
+    const parsed = parseConfigSymbolicLinkWitness(candidate.symbolicLink);
+    if (!parsed) return null;
+    symbolicLink = parsed;
+  }
+  return {
+    ...(candidate as ConfigFileWitness),
+    ...(symbolicLink ? { symbolicLink } : {}),
+  };
+}
+
+function parseConfigSymbolicLinkWitness(value: unknown): ConfigSymbolicLinkWitness | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const candidate = value as Partial<ConfigSymbolicLinkWitness>;
+  const decimalFields = [
+    candidate.device,
+    candidate.inode,
+    candidate.mode,
+    candidate.size,
+    candidate.modifiedAtNs,
+    candidate.changedAtNs,
+  ];
+  if (
+    typeof candidate.target !== 'string' ||
+    !candidate.target ||
+    candidate.target.includes('\0') ||
+    decimalFields.some((field) => typeof field !== 'string' || !/^\d+$/.test(field))
+  ) {
+    return null;
+  }
+  return candidate as ConfigSymbolicLinkWitness;
+}
+
+function parseGrantRecord(value: unknown): SafeDirectoryGrantRecord | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const candidate = value as Partial<SafeDirectoryGrantRecord>;
+  if (
+    typeof candidate.id !== 'string' ||
+    !candidate.id ||
+    !isAbsolutePath(candidate.value) ||
+    !isGrantState(candidate.state) ||
+    typeof candidate.createdAt !== 'string'
+  ) {
+    return null;
+  }
+
+  const origins = Array.isArray(candidate.candidateOrigins)
+    ? [...new Set(candidate.candidateOrigins.filter(isAbsolutePath))]
+    : undefined;
+  const origin = isAbsolutePath(candidate.origin) ? candidate.origin : undefined;
+  const originWitness = parseConfigFileWitness(candidate.originWitness);
+  if (candidate.state === 'owned' && (!origin || !originWitness)) return null;
+
+  return {
+    id: candidate.id,
+    value: candidate.value,
+    state: candidate.state,
+    createdAt: candidate.createdAt,
+    ...(origin ? { origin } : {}),
+    ...(originWitness ? { originWitness } : {}),
+    ...(origins && origins.length > 0 ? { candidateOrigins: origins } : {}),
+  };
+}
+
+function readLedger(): SafeDirectoryGrantRecord[] {
+  const raw = getLedgerStore().get('grants', []);
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .map(parseGrantRecord)
+    .filter((record): record is SafeDirectoryGrantRecord => record !== null);
+}
+
+function writeLedger(records: readonly SafeDirectoryGrantRecord[]): void {
+  getLedgerStore().set('grants', [...records]);
+}
+
+function parseRetentionRoot(value: unknown): RetentionRoot | null {
+  if (!value || typeof value !== 'object') return null;
+  const candidate = value as Partial<RetentionRoot>;
+  if (!isAbsolutePath(candidate.path)) return null;
+  if (candidate.mode !== 'exact' && candidate.mode !== 'subtree') return null;
+  return { path: path.resolve(candidate.path), mode: candidate.mode };
+}
+
+function parseProfileRetentionRecord(value: unknown): SafeDirectoryProfileRetentionRecord | null {
+  if (!value || typeof value !== 'object') return null;
+  const candidate = value as Partial<SafeDirectoryProfileRetentionRecord>;
+  if (!isAbsolutePath(candidate.profilePath)) return null;
+  if (!Number.isSafeInteger(candidate.processId) || (candidate.processId ?? 0) <= 0) return null;
+  if (!Array.isArray(candidate.roots)) return null;
+  const roots = candidate.roots.map(parseRetentionRoot);
+  if (roots.some((root) => root === null)) return null;
+  let liveSessionPaths: string[] | null;
+  if (candidate.liveSessionPaths === null) {
+    liveSessionPaths = null;
+  } else if (Array.isArray(candidate.liveSessionPaths)) {
+    liveSessionPaths = candidate.liveSessionPaths
+      .filter(isAbsolutePath)
+      .map((entry) => path.resolve(entry));
+    if (liveSessionPaths.length !== candidate.liveSessionPaths.length) return null;
+  } else {
+    return null;
+  }
+  return {
+    profilePath: path.resolve(candidate.profilePath),
+    processId: candidate.processId as number,
+    roots: roots as RetentionRoot[],
+    liveSessionPaths,
+  };
+}
+
+/** null 表示任一跨 profile 快照格式不可信；删除必须 fail closed。 */
+function readProfileRetentions(): SafeDirectoryProfileRetentionRecord[] | null {
+  const raw = getLedgerStore().get('profileRetentions', []);
+  if (!Array.isArray(raw)) return null;
+  const records = raw.map(parseProfileRetentionRecord);
+  if (records.some((record) => record === null)) return null;
+  const parsed = records as SafeDirectoryProfileRetentionRecord[];
+  const instances = new Set<string>();
+  for (const record of parsed) {
+    const key = `${comparablePath(record.profilePath)}\0${record.processId}`;
+    if (instances.has(key)) return null;
+    instances.add(key);
+  }
+  return parsed;
+}
+
+interface ProfileRetentionState {
+  records: SafeDirectoryProfileRetentionRecord[];
+  revision: number;
+}
+
+function readProfileRetentionRevision(): number | null {
+  const value = getLedgerStore().get('profileRetentionRevision', 0);
+  return Number.isSafeInteger(value) && (value as number) >= 0 ? (value as number) : null;
+}
+
+function readProfileRetentionState(): ProfileRetentionState | null {
+  const records = readProfileRetentions();
+  const revision = readProfileRetentionRevision();
+  return records === null || revision === null ? null : { records, revision };
+}
+
+function writeProfileRetentions(records: readonly SafeDirectoryProfileRetentionRecord[]): void {
+  const revision = readProfileRetentionRevision();
+  if (revision === null || revision === Number.MAX_SAFE_INTEGER) {
+    throw new Error('safe.directory profile retention revision is invalid');
+  }
+  // records 先落盘、revision 后提交。锁外读者无论看见新旧哪一半，锁内复核都会因
+  // records 或 revision 不同而放弃；进程在两步间退出时，读者评估的仍是实际 records。
+  getLedgerStore().set('profileRetentions', [...records]);
+  getLedgerStore().set('profileRetentionRevision', revision + 1);
+}
+
+function currentProfilePath(): string {
+  const value = currentProfilePathProvider();
+  if (!isAbsolutePath(value)) {
+    throw new Error('safe.directory profile path must be absolute');
+  }
+  return path.resolve(value);
+}
+
+function currentProcessId(): number {
+  const value = currentProcessIdProvider();
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new Error('safe.directory process id must be a positive integer');
+  }
+  return value;
+}
+
+function probeProcessLiveness(processId: number): ProcessLiveness {
+  if (processId === process.pid) return 'alive';
+  try {
+    process.kill(processId, 0);
+    return 'alive';
+  } catch (error) {
+    return (error as NodeJS.ErrnoException)?.code === 'ESRCH' ? 'missing' : 'unknown';
+  }
+}
+
+function sameRetentionInstance(
+  record: SafeDirectoryProfileRetentionRecord,
+  profilePath: string,
+  processId: number,
+): boolean {
+  return (
+    record.processId === processId &&
+    comparablePath(record.profilePath) === comparablePath(profilePath)
+  );
+}
+
+function retentionRecordToSnapshot(record: SafeDirectoryProfileRetentionRecord): RetentionSnapshot {
+  return {
+    roots: record.roots,
+    liveSessionPathKeys: record.liveSessionPaths === null ? null : new Set(record.liveSessionPaths),
+  };
+}
+
+function writeCurrentProfileRetention(
+  snapshot: RetentionSnapshot,
+  extraLivePaths: readonly string[] = [],
+  preserveExistingLivePaths = false,
+): void {
+  const records = readProfileRetentions();
+  if (records === null) {
+    throw new Error('safe.directory profile retention ledger is malformed');
+  }
+  const profilePath = currentProfilePath();
+  const processId = currentProcessId();
+  const normalizedExtraPaths = extraLivePaths.map(normalizeRetentionPath);
+  if (normalizedExtraPaths.some((value) => value === null)) {
+    throw new Error('safe.directory retention path must be absolute');
+  }
+  const previous = records.find((record) => sameRetentionInstance(record, profilePath, processId));
+  const liveSessionPaths =
+    snapshot.liveSessionPathKeys === null
+      ? null
+      : [
+          ...new Set([
+            ...snapshot.liveSessionPathKeys,
+            ...(preserveExistingLivePaths && previous?.liveSessionPaths
+              ? previous.liveSessionPaths
+              : []),
+            ...(normalizedExtraPaths as string[]),
+          ]),
+        ];
+  const next: SafeDirectoryProfileRetentionRecord = {
+    profilePath,
+    processId,
+    roots: snapshot.roots,
+    liveSessionPaths,
+  };
+  writeProfileRetentions([
+    ...records.filter((record) => !sameRetentionInstance(record, profilePath, processId)),
+    next,
+  ]);
+}
+
+/**
+ * 只在 OS 明确证明 PID 不存在（ESRCH）时回收实例快照。PID 复用、权限错误或探测
+ * 不可用都会保守保留，因此 liveness 误判最多延迟回收，不会误删仍在使用的授权。
+ */
+function compactExitedProcessRetentions(
+  records: readonly SafeDirectoryProfileRetentionRecord[],
+): SafeDirectoryProfileRetentionRecord[] {
+  const profilePath = currentProfilePath();
+  const processId = currentProcessId();
+  const next = records.filter((record) => {
+    if (sameRetentionInstance(record, profilePath, processId)) return true;
+    return processLivenessProvider(record.processId) !== 'missing';
+  });
+  if (next.length !== records.length) {
+    writeProfileRetentions(next);
+  }
+  return next;
+}
+
+function runGitConfig(
+  args: readonly string[],
+  extraEnv?: Record<string, string>,
+): Promise<GitConfigResult> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      'git',
+      [...args],
+      {
+        encoding: 'utf8',
+        maxBuffer: 4 * 1024 * 1024,
+        timeout: GIT_CONFIG_TIMEOUT_MS,
+        windowsHide: true,
+        env: extraEnv ? { ...process.env, ...extraEnv } : undefined,
+      },
+      (err, stdout, stderr) => {
+        const stdoutText = typeof stdout === 'string' ? stdout : String(stdout ?? '');
+        const stderrText = typeof stderr === 'string' ? stderr : String(stderr ?? '');
+        if (err) {
+          const code = (err as unknown as { code?: unknown }).code;
+          reject(
+            new GitConfigError(
+              stderrText.trim() || err.message,
+              typeof code === 'number' ? code : null,
+            ),
+          );
+          return;
+        }
+        resolve({ stdout: stdoutText, stderr: stderrText });
+      },
+    );
+  });
+}
+
+function exitCodeOf(error: unknown): number | null {
+  if (!error || typeof error !== 'object') return null;
+  const exitCode = (error as { exitCode?: unknown }).exitCode;
+  if (typeof exitCode === 'number') return exitCode;
+  const code = (error as { code?: unknown }).code;
+  return typeof code === 'number' ? code : null;
+}
+
+function parseNullFields(stdout: string): string[] {
+  const fields = stdout.split('\0');
+  if (fields.at(-1) === '') fields.pop();
+  return fields;
+}
+
+function filePathFromOrigin(origin: string): string | null {
+  if (!origin.startsWith('file:')) return null;
+  const candidate = origin.slice('file:'.length);
+  return isAbsolutePath(candidate) ? candidate : null;
+}
+
+function parseGlobalEntries(stdout: string): GlobalSafeDirectoryEntry[] {
+  if (!stdout) return [];
+  const fields = parseNullFields(stdout);
+  if (fields.length % 2 !== 0) {
+    throw new Error('git config returned malformed --show-origin --null output');
+  }
+
+  const entries: GlobalSafeDirectoryEntry[] = [];
+  for (let index = 0; index < fields.length; index += 2) {
+    const origin = fields[index];
+    const value = fields[index + 1];
+    entries.push({ origin, filePath: filePathFromOrigin(origin), value });
+  }
+  return entries;
+}
+
+function effectiveGlobalEntries(
+  entries: readonly GlobalSafeDirectoryEntry[],
+): readonly GlobalSafeDirectoryEntry[] {
+  // Git 按配置读取顺序解释 safe.directory；空值会清空此前累积的信任列表。
+  // 因而“重置前已有同值”不能阻止我们在真实 dubious error 后追加有效条目。
+  let lastReset = -1;
+  for (let index = 0; index < entries.length; index += 1) {
+    if (entries[index].value === '') lastReset = index;
+  }
+  return entries.slice(lastReset + 1);
+}
+
+async function listGlobalEntries(
+  extraEnv?: Record<string, string>,
+): Promise<GlobalSafeDirectoryEntry[]> {
+  try {
+    const { stdout } = await gitConfigRunner(
+      [
+        'config',
+        '--global',
+        '--includes',
+        '--show-origin',
+        '--null',
+        '--get-all',
+        'safe.directory',
+      ],
+      extraEnv,
+    );
+    return parseGlobalEntries(stdout);
+  } catch (error) {
+    // `git config --get-all` 用 exit 1 表示 key 不存在，不是读取失败。
+    if (exitCodeOf(error) === 1) return [];
+    throw error;
+  }
+}
+
+async function listValuesAtOrigin(origin: string): Promise<string[]> {
+  if (!isAbsolutePath(origin)) throw new Error('invalid safe.directory config origin');
+  try {
+    const { stdout } = await gitConfigRunner([
+      'config',
+      '--file',
+      origin,
+      '--null',
+      '--get-all',
+      'safe.directory',
+    ]);
+    return parseNullFields(stdout);
+  } catch (error) {
+    if (exitCodeOf(error) === 1) return [];
+    throw error;
+  }
+}
+
+function serializeOperation<T>(operation: () => Promise<T>): Promise<T> {
+  const result = operationTail.then(operation, operation);
+  operationTail = result.then(
+    () => undefined,
+    () => undefined,
+  );
+  return result;
+}
+
+function replaceRecord(
+  records: readonly SafeDirectoryGrantRecord[],
+  replacement: SafeDirectoryGrantRecord,
+): SafeDirectoryGrantRecord[] {
+  return records.map((record) => (record.id === replacement.id ? replacement : record));
+}
+
+function uniqueFileOrigins(entries: readonly GlobalSafeDirectoryEntry[]): string[] {
+  return [
+    ...new Set(
+      entries.map((entry) => entry.filePath).filter((origin): origin is string => origin !== null),
+    ),
+  ];
+}
+
+function sameConfigFileWitness(
+  left: ConfigFileWitness | undefined,
+  right: ConfigFileWitness | null | undefined,
+): boolean {
+  return (
+    left !== undefined &&
+    right != null &&
+    left.realPath === right.realPath &&
+    left.device === right.device &&
+    left.inode === right.inode &&
+    left.mode === right.mode &&
+    left.size === right.size &&
+    left.modifiedAtNs === right.modifiedAtNs &&
+    left.changedAtNs === right.changedAtNs &&
+    left.sha256 === right.sha256 &&
+    sameConfigSymbolicLinkWitness(left.symbolicLink, right.symbolicLink)
+  );
+}
+
+function sameConfigSymbolicLinkWitness(
+  left: ConfigSymbolicLinkWitness | undefined,
+  right: ConfigSymbolicLinkWitness | undefined,
+): boolean {
+  if (!left || !right) return left === right;
+  return (
+    left.target === right.target &&
+    left.device === right.device &&
+    left.inode === right.inode &&
+    left.mode === right.mode &&
+    left.size === right.size &&
+    left.modifiedAtNs === right.modifiedAtNs &&
+    left.changedAtNs === right.changedAtNs
+  );
+}
+
+function sameFileIdentity(left: BigIntStats, right: BigIntStats): boolean {
+  return (
+    left.dev === right.dev &&
+    left.ino === right.ino &&
+    left.mode === right.mode &&
+    left.size === right.size &&
+    left.mtimeNs === right.mtimeNs &&
+    left.ctimeNs === right.ctimeNs
+  );
+}
+
+function symbolicLinkWitness(stats: BigIntStats, target: string): ConfigSymbolicLinkWitness {
+  return {
+    target,
+    device: stats.dev.toString(),
+    inode: stats.ino.toString(),
+    mode: stats.mode.toString(),
+    size: stats.size.toString(),
+    modifiedAtNs: stats.mtimeNs.toString(),
+    changedAtNs: stats.ctimeNs.toString(),
+  };
+}
+
+async function captureConfigFileWitness(filePath: string): Promise<ConfigFileWitness | null> {
+  if (!isAbsolutePath(filePath)) return null;
+  try {
+    const beforeEntry = await fs.lstat(filePath, { bigint: true });
+    if (!beforeEntry.isFile() && !beforeEntry.isSymbolicLink()) return null;
+    const beforeLinkTarget = beforeEntry.isSymbolicLink() ? await fs.readlink(filePath) : null;
+    const beforeRealPath = await fs.realpath(filePath);
+    const beforeTarget = await fs.stat(filePath, { bigint: true });
+    if (!beforeTarget.isFile()) return null;
+    const contents = await fs.readFile(filePath);
+    const afterEntry = await fs.lstat(filePath, { bigint: true });
+    const afterLinkTarget = afterEntry.isSymbolicLink() ? await fs.readlink(filePath) : null;
+    const afterRealPath = await fs.realpath(filePath);
+    const afterTarget = await fs.stat(filePath, { bigint: true });
+    if (
+      !afterTarget.isFile() ||
+      beforeRealPath !== afterRealPath ||
+      !sameFileIdentity(beforeTarget, afterTarget) ||
+      beforeEntry.isSymbolicLink() !== afterEntry.isSymbolicLink() ||
+      (!beforeEntry.isSymbolicLink() && !afterEntry.isFile()) ||
+      (beforeEntry.isSymbolicLink() &&
+        (!afterEntry.isSymbolicLink() ||
+          beforeLinkTarget !== afterLinkTarget ||
+          !sameFileIdentity(beforeEntry, afterEntry)))
+    ) {
+      return null;
+    }
+
+    return {
+      realPath: afterRealPath,
+      device: afterTarget.dev.toString(),
+      inode: afterTarget.ino.toString(),
+      mode: afterTarget.mode.toString(),
+      size: afterTarget.size.toString(),
+      modifiedAtNs: afterTarget.mtimeNs.toString(),
+      changedAtNs: afterTarget.ctimeNs.toString(),
+      sha256: createHash('sha256').update(contents).digest('hex'),
+      ...(afterEntry.isSymbolicLink() && afterLinkTarget !== null
+        ? { symbolicLink: symbolicLinkWitness(afterEntry, afterLinkTarget) }
+        : {}),
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function unlinkTemporaryPath(filePath: string): Promise<void> {
+  try {
+    await fs.unlink(filePath);
+  } catch (error) {
+    if (!isDefinitivelyMissing(error)) throw error;
+  }
+}
+
+async function pathIsDefinitivelyMissing(filePath: string): Promise<boolean> {
+  try {
+    await fs.lstat(filePath);
+    return false;
+  } catch (error) {
+    if (isDefinitivelyMissing(error)) return true;
+    throw error;
+  }
+}
+
+function effectiveEnvironmentValue(
+  key: string,
+  extraEnv?: Record<string, string>,
+): string | undefined {
+  return extraEnv && Object.prototype.hasOwnProperty.call(extraEnv, key)
+    ? extraEnv[key]
+    : process.env[key];
+}
+
+/** Mirrors Git's documented --global write target selection. */
+async function resolveGlobalConfigWriteOrigin(
+  extraEnv?: Record<string, string>,
+): Promise<string | null> {
+  const override = effectiveEnvironmentValue('GIT_CONFIG_GLOBAL', extraEnv);
+  if (override !== undefined) return isAbsolutePath(override) ? path.resolve(override) : null;
+
+  const configuredHome = effectiveEnvironmentValue('HOME', extraEnv);
+  const home = isAbsolutePath(configuredHome) ? configuredHome : homePathProvider();
+  if (!isAbsolutePath(home)) return null;
+  const homeConfig = path.join(home, '.gitconfig');
+  if (!(await pathIsDefinitivelyMissing(homeConfig))) return homeConfig;
+
+  const configuredXdgHome = effectiveEnvironmentValue('XDG_CONFIG_HOME', extraEnv);
+  if (configuredXdgHome !== undefined && !isAbsolutePath(configuredXdgHome)) return null;
+  const xdgHome = configuredXdgHome || path.join(home, '.config');
+  const xdgConfig = path.join(xdgHome, 'git', 'config');
+  return (await pathIsDefinitivelyMissing(xdgConfig)) ? homeConfig : xdgConfig;
+}
+
+/**
+ * 用 Git 约定的 `<config>.lock` 封闭配置变更。变更先在同目录副本上交给 Git
+ * 自己解析，再在锁内重验 origin；只有原文件未变化才原子替换。
+ */
+async function mutateConfigFileAtomically(
+  origin: string,
+  expectedWitness: ConfigFileWitness | null,
+  mutation: (stagingPath: string) => Promise<void>,
+  onCommitted?: (afterWitness: ConfigFileWitness) => Promise<void>,
+): Promise<ConfigFileWitness> {
+  const mutationOrigin = expectedWitness?.realPath ?? origin;
+  if (!isAbsolutePath(mutationOrigin)) throw new Error('invalid witnessed config origin');
+
+  const lockPath = `${mutationOrigin}.lock`;
+  const stagingPath = `${lockPath}.cindy-${process.pid}-${randomUUID()}`;
+  let lockHandle: FileHandle | null = null;
+  let lockIdentity: BigIntStats | null = null;
+  try {
+    const mode = expectedWitness ? Number(BigInt(expectedWitness.mode) & 0o777n) : 0o600;
+    lockHandle = await fs.open(lockPath, 'wx', 0o600);
+    lockIdentity = await lockHandle.stat({ bigint: true });
+
+    const lockedWitness = await captureConfigFileWitness(origin);
+    const unchangedBeforeMutation = expectedWitness
+      ? sameConfigFileWitness(expectedWitness, lockedWitness)
+      : lockedWitness === null && (await pathIsDefinitivelyMissing(origin));
+    if (!unchangedBeforeMutation) {
+      throw new Error('safe.directory config changed before mutation lock was acquired');
+    }
+
+    const stagingHandle = await fs.open(stagingPath, 'wx', mode);
+    await stagingHandle.close();
+    if (expectedWitness) await fs.copyFile(mutationOrigin, stagingPath);
+    await mutation(stagingPath);
+
+    // 不遵守 Git lockfile 的外部工具仍可能直接替换配置；提交前再 fail closed。
+    const commitWitness = await captureConfigFileWitness(origin);
+    const unchangedBeforeCommit = expectedWitness
+      ? sameConfigFileWitness(expectedWitness, commitWitness)
+      : commitWitness === null && (await pathIsDefinitivelyMissing(origin));
+    if (!unchangedBeforeCommit) {
+      throw new Error('safe.directory config changed while mutation lock was held');
+    }
+    await fs.rename(stagingPath, mutationOrigin);
+    const afterWitness = await captureConfigFileWitness(origin);
+    if (!afterWitness) throw new Error('safe.directory config witness unavailable after mutation');
+    await onCommitted?.(afterWitness);
+    return afterWitness;
+  } finally {
+    await unlinkTemporaryPath(stagingPath).catch((error) => {
+      log.warn(
+        '[safe.directory] failed to remove config staging file:',
+        error instanceof Error ? error.message : String(error),
+      );
+    });
+    await lockHandle?.close().catch(() => undefined);
+    if (lockIdentity) {
+      try {
+        const currentLock = await fs.lstat(lockPath, { bigint: true });
+        if (sameFileIdentity(lockIdentity, currentLock)) await fs.unlink(lockPath);
+      } catch (error) {
+        if (!isDefinitivelyMissing(error)) {
+          log.warn(
+            '[safe.directory] failed to release config mutation lock:',
+            error instanceof Error ? error.message : String(error),
+          );
+        }
+      }
+    }
+  }
+}
+
+async function removeOwnedConfigValueAtomically(
+  origin: string,
+  expectedWitness: ConfigFileWitness,
+  value: string,
+): Promise<ConfigFileWitness> {
+  return mutateConfigFileAtomically(origin, expectedWitness, (stagingPath) =>
+    gitConfigRunner([
+      'config',
+      '--file',
+      stagingPath,
+      '--fixed-value',
+      '--unset',
+      'safe.directory',
+      value,
+    ]).then(() => undefined),
+  );
+}
+
+async function captureOwnedOriginWitnesses(
+  records: readonly SafeDirectoryGrantRecord[],
+): Promise<Map<string, ConfigFileWitness | null>> {
+  const origins = [
+    ...new Set(
+      records
+        .filter((record) => record.state === 'owned' && record.origin)
+        .map((record) => record.origin!),
+    ),
+  ];
+  const witnesses = await Promise.all(origins.map(captureConfigFileWitness));
+  return new Map(origins.map((origin, index) => [origin, witnesses[index]]));
+}
+
+function refreshOwnedOriginWitnesses(
+  records: readonly SafeDirectoryGrantRecord[],
+  origin: string,
+  before: ConfigFileWitness | null | undefined,
+  after: ConfigFileWitness,
+): SafeDirectoryGrantRecord[] {
+  return records.map((record) =>
+    record.state === 'owned' &&
+    record.origin !== undefined &&
+    sameConfigFile(record.origin, origin) &&
+    sameConfigFileWitness(record.originWitness, before)
+      ? { ...record, originWitness: after }
+      : record,
+  );
+}
+
+interface OwnedOriginSnapshot {
+  witness: ConfigFileWitness;
+  safeDirectoryValues: string[];
+}
+
+async function captureOwnedOriginSnapshots(
+  records: readonly SafeDirectoryGrantRecord[],
+): Promise<Map<string, OwnedOriginSnapshot>> {
+  const witnesses = await captureOwnedOriginWitnesses(records);
+  const snapshots = new Map<string, OwnedOriginSnapshot>();
+  await Promise.all(
+    [...witnesses].map(async ([origin, witness]) => {
+      if (!witness) return;
+      try {
+        snapshots.set(origin, {
+          witness,
+          safeDirectoryValues: await listValuesAtOrigin(origin),
+        });
+      } catch (error) {
+        log.warn(
+          '[safe.directory] failed to snapshot an owned origin before a global config write:',
+          error instanceof Error ? error.message : String(error),
+        );
+      }
+    }),
+  );
+  return snapshots;
+}
+
+function sameStringValues(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length && left.every((value, index) => value === right[index]);
+}
+
+async function refreshOwnedWitnessesAfterKnownConfigWrite(
+  records: readonly SafeDirectoryGrantRecord[],
+  before: ReadonlyMap<string, OwnedOriginSnapshot>,
+): Promise<void> {
+  let refreshed = [...records];
+  for (const [origin, snapshot] of before) {
+    try {
+      const [afterWitness, afterValues] = await Promise.all([
+        captureConfigFileWitness(origin),
+        listValuesAtOrigin(origin),
+      ]);
+      if (
+        !afterWitness ||
+        !sameStringValues(snapshot.safeDirectoryValues, afterValues) ||
+        sameConfigFileWitness(snapshot.witness, afterWitness)
+      ) {
+        continue;
+      }
+      refreshed = refreshOwnedOriginWitnesses(refreshed, origin, snapshot.witness, afterWitness);
+    } catch (error) {
+      // 无法证明写入只改了其它 Git 配置时保留旧见证，后续清理自然 fail closed。
+      log.warn(
+        '[safe.directory] failed to refresh an owned origin after a global config write:',
+        error instanceof Error ? error.message : String(error),
+      );
+    }
+  }
+
+  try {
+    writeLedger(refreshed);
+  } catch (error) {
+    // 见证刷新失败最多留下无法自动回收的授权，不应把已成功的配置修复改判为失败。
+    log.warn(
+      '[safe.directory] failed to persist refreshed origin witnesses:',
+      error instanceof Error ? error.message : String(error),
+    );
+  }
+}
+
+/**
+ * 包裹 Cindy 已知的、不会修改 safe.directory 的全局 Git 配置写入。Git 会通过
+ * lockfile 重写整份配置文件；只有写入前后的 safe.directory 值完全相同，才刷新
+ * 仍与写前见证匹配的 owned 记录。写入失败也执行刷新探测，以覆盖“文件已重写但
+ * 命令最终报错”的保守边界。
+ */
+export function withSafeDirectoryWitnessRefresh<T>(mutation: () => Promise<T>): Promise<T> {
+  return serializeMutationOperation(async () => {
+    const records = readLedger();
+    const before = await captureOwnedOriginSnapshots(records);
+    let completed = false;
+    let result: T | undefined;
+    let mutationError: unknown;
+    try {
+      result = await mutation();
+      completed = true;
+    } catch (error) {
+      mutationError = error;
+    }
+
+    await refreshOwnedWitnessesAfterKnownConfigWrite(records, before);
+    if (!completed) throw mutationError;
+    return result as T;
+  });
+}
+
+function classifyAddedRecord(
+  pending: SafeDirectoryGrantRecord,
+  matches: readonly GlobalSafeDirectoryEntry[],
+  addSucceeded: boolean,
+  originWitness: ConfigFileWitness | null,
+  expectedOrigin: string,
+): SafeDirectoryGrantRecord {
+  if (
+    addSucceeded &&
+    matches.length === 1 &&
+    sameConfigFile(matches[0].filePath, expectedOrigin) &&
+    originWitness
+  ) {
+    return {
+      ...pending,
+      state: 'owned',
+      origin: expectedOrigin,
+      originWitness,
+      candidateOrigins: undefined,
+    };
+  }
+  return {
+    ...pending,
+    state: 'ambiguous',
+    origin: undefined,
+    originWitness: undefined,
+    candidateOrigins: uniqueFileOrigins(matches),
+  };
+}
+
+/**
+ * Git 确实报告 dubious ownership 后调用。若同值有效则不取得所有权；若同值只在
+ * 空值重置前存在则返回 command，让调用方使用单次 -c 覆写；否则先记 pending，再
+ * 新增全局配置并确认 value + origin。所有检查和写入同时经过进程内队列与跨进程
+ * mutation 锁，避免跨 profile 实例制造重复项或覆盖共享台账。
+ */
+export function ensureSafeDirectory(
+  repositoryPath: string,
+  extraEnv?: Record<string, string>,
+): Promise<SafeDirectoryRecoveryMode> {
+  if (!isAbsolutePath(repositoryPath)) {
+    return Promise.reject(new Error('safe.directory path must be absolute'));
+  }
+
+  return serializeMutationOperation(async () => {
+    writeCurrentProfileRetention(await collectRetentionSnapshot(), [repositoryPath], true);
+    const before = await listGlobalEntries(extraEnv);
+    if (effectiveGlobalEntries(before).some((entry) => entry.value === repositoryPath)) {
+      return 'persistent';
+    }
+    // 同值只出现在最后一个空值重置之前时，重新 append 虽能恢复本次 Git，但同一
+    // origin 内的两个同值无法用 git config --unset 精确区分。改用本次命令的 -c
+    // 覆写，不制造一条以后无法证明并回收的全局授权。
+    if (before.some((entry) => entry.value === repositoryPath)) return 'command';
+
+    const writeOrigin = await globalConfigWriteOriginProvider(extraEnv);
+    if (!writeOrigin) return 'command';
+    const beforeWriteWitness = await captureConfigFileWitness(writeOrigin);
+    if (!beforeWriteWitness && !(await pathIsDefinitivelyMissing(writeOrigin))) return 'command';
+
+    const records = readLedger();
+    const reusablePending = records.find(
+      (record) => record.value === repositoryPath && record.state === 'pending',
+    );
+    const pending: SafeDirectoryGrantRecord = reusablePending
+      ? { ...reusablePending, createdAt: new Date().toISOString() }
+      : {
+          id: randomUUID(),
+          value: repositoryPath,
+          state: 'pending',
+          createdAt: new Date().toISOString(),
+        };
+    const withPending = reusablePending ? replaceRecord(records, pending) : [...records, pending];
+
+    // 台账无法落盘时不允许先改 Git；否则将失去“只删除自己写入项”的证明。
+    writeLedger(withPending);
+
+    let addError: unknown;
+    try {
+      await mutateConfigFileAtomically(
+        writeOrigin,
+        beforeWriteWitness,
+        (stagingPath) =>
+          gitConfigRunner(
+            ['config', '--file', stagingPath, '--add', 'safe.directory', repositoryPath],
+            extraEnv,
+          ).then(() => undefined),
+        async (afterWriteWitness) => {
+          try {
+            const after = await listGlobalEntries(extraEnv);
+            const confirmedWitness = await captureConfigFileWitness(writeOrigin);
+            if (!sameConfigFileWitness(afterWriteWitness, confirmedWitness)) {
+              log.warn(
+                '[safe.directory] global config changed before ownership confirmation; keeping pending grant',
+              );
+              return;
+            }
+            const matches = effectiveGlobalEntries(after).filter(
+              (entry) => entry.value === repositoryPath,
+            );
+            const refreshedRecords = refreshOwnedOriginWitnesses(
+              withPending,
+              writeOrigin,
+              beforeWriteWitness,
+              afterWriteWitness,
+            );
+            const finalized = classifyAddedRecord(
+              pending,
+              matches,
+              true,
+              afterWriteWitness,
+              writeOrigin,
+            );
+            try {
+              writeLedger(replaceRecord(refreshedRecords, finalized));
+            } catch (error) {
+              // pending 已先持久化；最终状态写失败时宁可永不自动删。
+              log.warn(
+                '[safe.directory] failed to finalize grant ownership; keeping pending grant:',
+                error instanceof Error ? error.message : String(error),
+              );
+            }
+          } catch (error) {
+            // 原子写入已完成但无法在同一配置锁内确认；pending 永远不会被自动删除。
+            log.warn(
+              '[safe.directory] failed to verify global config after add; keeping pending grant:',
+              error instanceof Error ? error.message : String(error),
+            );
+          }
+        },
+      );
+    } catch (error) {
+      addError = error;
+    }
+
+    if (addError) {
+      let matches: GlobalSafeDirectoryEntry[] = [];
+      try {
+        matches = effectiveGlobalEntries(await listGlobalEntries(extraEnv)).filter(
+          (entry) => entry.value === repositoryPath,
+        );
+      } catch {
+        // 无法证明配置未变化，保留 pending。
+        return 'persistent';
+      }
+      if (matches.length === 0) {
+        writeLedger(withPending.filter((record) => record.id !== pending.id));
+        throw addError;
+      }
+    }
+    return 'persistent';
+  });
+}
+
+function normalizeRetentionPath(value: string): string | null {
+  if (!value || value.includes('\0')) return null;
+  try {
+    return path.resolve(value);
+  } catch {
+    return null;
+  }
+}
+
+function retentionMapKey(value: string, mode: RetentionMode): string {
+  const folded = process.platform === 'win32' ? value.toLowerCase() : value;
+  return `${mode}\0${folded}`;
+}
+
+/**
+ * 创建流程在 worktreeStore 落盘前持有的 C 集合补充项，防止启动后台对账与创建竞态。
+ */
+function beginLocalSafeDirectoryRetention(
+  options: {
+    exactPaths?: readonly string[];
+    subtreePaths?: readonly string[];
+  } = {},
+): LocalSafeDirectoryRetention {
+  const ownedKeys = new Set<string>();
+  let released = false;
+
+  const add = (value: string, mode: RetentionMode): boolean => {
+    if (released) return false;
+    const normalized = normalizeRetentionPath(value);
+    if (!normalized) return false;
+    const key = retentionMapKey(normalized, mode);
+    if (ownedKeys.has(key)) return false;
+    ownedKeys.add(key);
+    const existing = inflightRetentionRoots.get(key);
+    inflightRetentionRoots.set(key, {
+      path: normalized,
+      mode,
+      count: (existing?.count ?? 0) + 1,
+    });
+    inflightRetentionGeneration += 1;
+    return true;
+  };
+
+  for (const value of options.exactPaths ?? []) add(value, 'exact');
+  for (const value of options.subtreePaths ?? []) add(value, 'subtree');
+
+  return {
+    addExact: (value) => add(value, 'exact'),
+    addSubtree: (value) => add(value, 'subtree'),
+    release: () => {
+      if (released) return;
+      released = true;
+      let changed = false;
+      for (const key of ownedKeys) {
+        const current = inflightRetentionRoots.get(key);
+        if (!current) continue;
+        if (current.count <= 1) inflightRetentionRoots.delete(key);
+        else inflightRetentionRoots.set(key, { ...current, count: current.count - 1 });
+        changed = true;
+      }
+      ownedKeys.clear();
+      if (changed) inflightRetentionGeneration += 1;
+    },
+  };
+}
+
+/**
+ * 创建流程的持久声明守卫。mutation 锁只包共享声明的发布／撤销；耗时 Git、checkout
+ * 与复制不持锁。共享声明只是全局授权的生命周期优化，发布失败时任务仍继续，后续
+ * gitExec 会对每条实际 Git 命令降级为命令作用域授权，不能让台账成为创建硬依赖。
+ */
+export function withSafeDirectoryRetention<T>(
+  options: {
+    exactPaths?: readonly string[];
+    subtreePaths?: readonly string[];
+  },
+  task: (retention: SafeDirectoryRetention) => Promise<T>,
+): Promise<T> {
+  const localRetention = beginLocalSafeDirectoryRetention(options);
+  const publishCurrentRetention = async (phase: string): Promise<void> => {
+    try {
+      await serializeMutationOperation(async () => {
+        writeCurrentProfileRetention(await collectRetentionSnapshot(), [], true);
+      });
+    } catch (error) {
+      log.warn(
+        `[safe.directory] failed to publish ${phase}; Git can fall back to command-scoped authorization:`,
+        error instanceof Error ? error.message : String(error),
+      );
+    }
+  };
+  const publishAddedRoot = async (value: string, mode: RetentionMode): Promise<void> => {
+    const changed =
+      mode === 'exact' ? localRetention.addExact(value) : localRetention.addSubtree(value);
+    if (!changed) return;
+    await publishCurrentRetention('dynamically added creation retention');
+  };
+  const retention: SafeDirectoryRetention = {
+    addExact: (value) => publishAddedRoot(value, 'exact'),
+    addSubtree: (value) => publishAddedRoot(value, 'subtree'),
+  };
+  return (async () => {
+    try {
+      await publishCurrentRetention('creation retention');
+      return await task(retention);
+    } finally {
+      localRetention.release();
+      await serializeMutationOperation(async () => {
+        writeCurrentProfileRetention(await collectRetentionSnapshot(), [], true);
+      }).catch((error) => {
+        // 进入守卫时的持久声明仍会保守保留；最终刷新失败只可能延迟回收，不能误删。
+        log.warn(
+          '[safe.directory] failed to refresh profile retention after creation:',
+          error instanceof Error ? error.message : String(error),
+        );
+      });
+    }
+  })();
+}
+
+function isDefinitivelyMissing(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+  const code = (error as { code?: unknown }).code;
+  return code === 'ENOENT' || code === 'ENOTDIR';
+}
+
+async function pathMayExist(value: string): Promise<boolean> {
+  try {
+    await fs.access(value);
+    return true;
+  } catch (error) {
+    // 权限、瞬时 IO 等无法证明“不存在”，必须保留。
+    return !isDefinitivelyMissing(error);
+  }
+}
+
+async function collectRetentionSnapshot(): Promise<RetentionSnapshot> {
+  const roots: RetentionRoot[] = [...inflightRetentionRoots.values()].map(
+    ({ path: value, mode }) => ({
+      path: value,
+      mode,
+    }),
+  );
+  const metas = activeWorktreesProvider();
+  const liveSessionPathKeys = await liveSessionPathKeysProvider();
+
+  for (const meta of metas) {
+    if (!meta || !isAbsolutePath(meta.path) || !isAbsolutePath(meta.baseRepo)) {
+      throw new Error('worktree store contains malformed path data');
+    }
+    if (meta.quarantinePath !== undefined && !isAbsolutePath(meta.quarantinePath)) {
+      throw new Error('worktree store contains malformed quarantine path data');
+    }
+
+    const physicalCandidates = meta.quarantinePath ? [meta.path, meta.quarantinePath] : [meta.path];
+    const existence = await Promise.all(physicalCandidates.map(pathMayExist));
+    if (!existence.some(Boolean)) continue;
+
+    // baseRepo 只能保留它自身；不能把同仓库下已经消失的兄弟 worktree 一并保留。
+    roots.push({ path: meta.baseRepo, mode: 'exact' });
+    roots.push({ path: meta.path, mode: 'subtree' });
+    if (meta.quarantinePath) roots.push({ path: meta.quarantinePath, mode: 'subtree' });
+  }
+  return { roots, liveSessionPathKeys };
+}
+
+/**
+ * Git 首次在某个 cwd 运行前发布一次当前 profile 的共享依赖。这样即使另一个 profile
+ * 已经添加了同一条 safe.directory，本 profile 没有触发 dubious-ownership 恢复，也会
+ * 在命令开始前进入全局 C 集合。后续对账会用 DB/worktree 真值刷新并清掉过期路径。
+ */
+export function retainSafeDirectoryUsage(workingDirectory: string): Promise<void> {
+  const normalized = normalizeRetentionPath(workingDirectory);
+  if (!normalized) {
+    return Promise.reject(new Error('safe.directory usage path must be absolute'));
+  }
+  const key = comparablePath(normalized);
+  if (publishedUsagePaths.has(key)) return Promise.resolve();
+
+  return serializeMutationOperation(async () => {
+    if (publishedUsagePaths.has(key)) return;
+    writeCurrentProfileRetention(await collectRetentionSnapshot(), [normalized], true);
+    publishedUsagePaths.add(key);
+  });
+}
+
+function comparablePath(value: string): string {
+  const resolved = path.resolve(value);
+  return process.platform === 'win32' ? resolved.toLowerCase() : resolved;
+}
+
+async function pathVariants(value: string): Promise<string[]> {
+  const variants = new Set<string>([comparablePath(value)]);
+  try {
+    variants.add(comparablePath(await fs.realpath(value)));
+  } catch {
+    // 路径已删除时逻辑路径仍足够完成 A/B/C 对账。
+  }
+  return [...variants];
+}
+
+function isInside(root: string, candidate: string): boolean {
+  const relative = path.relative(root, candidate);
+  return (
+    relative === '' ||
+    (relative !== '..' && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative))
+  );
+}
+
+async function isGrantRetained(
+  value: string,
+  snapshot: RetentionSnapshot,
+  variantsCache: Map<string, Promise<string[]>>,
+): Promise<boolean> {
+  // DB 尚未就绪或查询失败时无法证明没有普通任务仍在使用该授权。
+  if (snapshot.liveSessionPathKeys === null) return true;
+
+  const variantsFor = (candidate: string) => {
+    let pending = variantsCache.get(candidate);
+    if (!pending) {
+      pending = pathVariants(candidate);
+      variantsCache.set(candidate, pending);
+    }
+    return pending;
+  };
+
+  const grantVariants = await variantsFor(value);
+  for (const root of snapshot.roots) {
+    const rootVariants = await variantsFor(root.path);
+    for (const rootVariant of rootVariants) {
+      for (const grantVariant of grantVariants) {
+        if (
+          root.mode === 'exact' ? rootVariant === grantVariant : isInside(rootVariant, grantVariant)
+        ) {
+          return true;
+        }
+      }
+    }
+  }
+
+  // 普通任务可能从仓库的任意子目录启动。safe.directory 记录的是 Git 报告的
+  // 仓库根，因此这里按“授权路径包含 workingDir/worktreePath”的方向匹配。
+  for (const liveSessionPath of snapshot.liveSessionPathKeys) {
+    // archived/deleted 任务会保留历史路径；磁盘已明确不存在时不能继续把它当 C。
+    // 权限或瞬时 I/O 无法证明缺失，pathMayExist 会继续保守保留。
+    if (!(await pathMayExist(liveSessionPath))) continue;
+    const liveSessionVariants = await variantsFor(liveSessionPath);
+    for (const grantVariant of grantVariants) {
+      for (const liveSessionVariant of liveSessionVariants) {
+        if (isInside(grantVariant, liveSessionVariant)) return true;
+      }
+    }
+  }
+  return false;
+}
+
+/**
+ * 锁外证明当前 C 集合不包含 value，并返回证明对应的本进程代次。null 表示仍被
+ * 保留、快照未知或探测期间代次持续变化；调用方必须按不可删除处理。
+ */
+async function prepareRetentionAbsenceGeneration(
+  value: string,
+  profileRetentions: readonly SafeDirectoryProfileRetentionRecord[],
+  variantsCache: Map<string, Promise<string[]>>,
+): Promise<number | null> {
+  const profilePath = currentProfilePath();
+  const processId = currentProcessId();
+  const otherInstances = profileRetentions.filter(
+    (record) => !sameRetentionInstance(record, profilePath, processId),
+  );
+
+  // 当前进程的创建声明可能在异步磁盘探测期间变化。只有前后代次一致，且所有其它
+  // profile 的持久快照也都确认不保留，才允许删除；持续变化或未知快照一律保留。
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    const generation = inflightRetentionGeneration;
+    if (await isGrantRetained(value, await collectRetentionSnapshot(), variantsCache)) return null;
+    if (generation !== inflightRetentionGeneration) continue;
+    for (const record of otherInstances) {
+      if (await isGrantRetained(value, retentionRecordToSnapshot(record), variantsCache))
+        return null;
+    }
+    if (generation === inflightRetentionGeneration) return generation;
+  }
+  return null;
+}
+
+async function isGrantRetainedAcrossProfilesNow(
+  value: string,
+  profileRetentions: readonly SafeDirectoryProfileRetentionRecord[],
+  variantsCache: Map<string, Promise<string[]>>,
+): Promise<boolean> {
+  return (
+    (await prepareRetentionAbsenceGeneration(value, profileRetentions, variantsCache)) === null
+  );
+}
+
+function sameConfigFile(left: string | null, right: string): boolean {
+  if (!left) return false;
+  try {
+    return comparablePath(left) === comparablePath(right);
+  } catch {
+    return false;
+  }
+}
+
+async function candidateOriginsAreEmpty(record: SafeDirectoryGrantRecord): Promise<boolean> {
+  const origins = record.candidateOrigins ?? [];
+  if (origins.length === 0) return true;
+  try {
+    const values = await Promise.all(origins.map(listValuesAtOrigin));
+    return values.every((entries) => !entries.includes(record.value));
+  } catch {
+    return false;
+  }
+}
+
+type ReconciliationAction =
+  | { kind: 'compact'; record: SafeDirectoryGrantRecord }
+  | { kind: 'remove'; record: SafeDirectoryGrantRecord };
+
+function sameGrantRecord(left: SafeDirectoryGrantRecord, right: SafeDirectoryGrantRecord): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function sameProfileRetentions(
+  left: readonly SafeDirectoryProfileRetentionRecord[],
+  right: readonly SafeDirectoryProfileRetentionRecord[],
+): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function sameOwnedGrantCore(
+  current: SafeDirectoryGrantRecord,
+  inspected: SafeDirectoryGrantRecord,
+): boolean {
+  return (
+    current.id === inspected.id &&
+    current.value === inspected.value &&
+    current.state === 'owned' &&
+    inspected.state === 'owned' &&
+    current.createdAt === inspected.createdAt &&
+    current.origin !== undefined &&
+    inspected.origin !== undefined &&
+    sameConfigFile(current.origin, inspected.origin)
+  );
+}
+
+/**
+ * 慢速 Git/文件探测不持 mutation 锁，只生成候选动作。候选不是删除授权；真正提交
+ * 时会重新读取共享台账、C 集合和 origin 见证，任何变化都放弃本轮动作。
+ */
+async function inspectReconciliationActions(
+  records: readonly SafeDirectoryGrantRecord[],
+  profileRetentions: readonly SafeDirectoryProfileRetentionRecord[],
+): Promise<ReconciliationAction[]> {
+  const globalEntries = await listGlobalEntries();
+  const variantsCache = new Map<string, Promise<string[]>>();
+  const actions: ReconciliationAction[] = [];
+
+  for (const record of records) {
+    if (await isGrantRetainedAcrossProfilesNow(record.value, profileRetentions, variantsCache)) {
+      continue;
+    }
+
+    const globalMatches = globalEntries.filter((entry) => entry.value === record.value);
+    if (record.state !== 'owned' || !record.origin) {
+      if (globalMatches.length === 0 && (await candidateOriginsAreEmpty(record))) {
+        actions.push({ kind: 'compact', record });
+      }
+      continue;
+    }
+
+    if (globalMatches.length === 0) {
+      try {
+        if (!(await listValuesAtOrigin(record.origin)).includes(record.value)) {
+          actions.push({ kind: 'compact', record });
+        }
+      } catch {
+        // 无法证明 B 与原 origin 都已没有该值，保留台账。
+      }
+      continue;
+    }
+
+    const sameValueClaims = records.filter((candidate) => candidate.value === record.value);
+    if (
+      globalMatches.length !== 1 ||
+      !sameConfigFile(globalMatches[0].filePath, record.origin) ||
+      sameValueClaims.length !== 1
+    ) {
+      continue;
+    }
+
+    let valuesAtOrigin: string[];
+    try {
+      valuesAtOrigin = await listValuesAtOrigin(record.origin);
+    } catch (error) {
+      log.warn(
+        '[safe.directory] failed to inspect owned config entry; preserving:',
+        error instanceof Error ? error.message : String(error),
+      );
+      continue;
+    }
+    if (valuesAtOrigin.filter((value) => value === record.value).length !== 1) continue;
+
+    const currentWitness = await captureConfigFileWitness(record.origin);
+    if (sameConfigFileWitness(record.originWitness, currentWitness)) {
+      actions.push({ kind: 'remove', record });
+    }
+  }
+
+  return actions;
+}
+
+interface RetentionAbsenceProof {
+  inflightGeneration: number;
+  profileRetentionRevision: number;
+  profileRetentions: SafeDirectoryProfileRetentionRecord[];
+}
+
+async function prepareRetentionAbsenceProof(value: string): Promise<RetentionAbsenceProof | null> {
+  const state = readProfileRetentionState();
+  if (!state) {
+    log.warn('[safe.directory] skipped removal: profile retention ledger is malformed');
+    return null;
+  }
+  const inflightGeneration = await prepareRetentionAbsenceGeneration(
+    value,
+    state.records,
+    new Map<string, Promise<string[]>>(),
+  );
+  if (inflightGeneration === null) return null;
+  return {
+    inflightGeneration,
+    profileRetentionRevision: state.revision,
+    profileRetentions: state.records,
+  };
+}
+
+async function commitReconciliationAction(action: ReconciliationAction): Promise<void> {
+  // compact 不会修改全局 Git 配置；remove 的最终 C 证明则必须在 mutation 锁外完成。
+  const retentionProof =
+    action.kind === 'remove' ? await prepareRetentionAbsenceProof(action.record.value) : null;
+  if (action.kind === 'remove' && !retentionProof) return;
+
+  await serializeOperation(() =>
+    runReconciliationWithMutationLock(async () => {
+      let records = readLedger();
+      const current = records.find((record) => record.id === action.record.id);
+      if (!current) return;
+
+      if (action.kind === 'compact') {
+        // 只压缩与锁外探测完全相同的不确定记录；任何并发 finalization 都使动作失效。
+        if (!sameGrantRecord(current, action.record)) return;
+        writeLedger(records.filter((record) => record.id !== current.id));
+        return;
+      }
+      if (!retentionProof) return;
+
+      // 同一 origin 的前一个删除会合法刷新见证，因此 remove 候选允许见证变化，但
+      // id/value/state/origin 必须仍是锁外检查过的 owned 记录，且不能出现同值新 claim。
+      if (!sameOwnedGrantCore(current, action.record)) return;
+      if (records.filter((record) => record.value === current.value).length !== 1) return;
+
+      const retentionState = readProfileRetentionState();
+      if (!retentionState) {
+        log.warn('[safe.directory] skipped removal: profile retention ledger is malformed');
+        return;
+      }
+      if (
+        inflightRetentionGeneration !== retentionProof.inflightGeneration ||
+        retentionState.revision !== retentionProof.profileRetentionRevision ||
+        !sameProfileRetentions(retentionState.records, retentionProof.profileRetentions)
+      ) {
+        return;
+      }
+
+      const currentWitness = await captureConfigFileWitness(current.origin!);
+      if (!currentWitness || !sameConfigFileWitness(current.originWitness, currentWitness)) return;
+
+      try {
+        const afterWitness = await removeOwnedConfigValueAtomically(
+          current.origin!,
+          currentWitness,
+          current.value,
+        );
+
+        records = records.filter((record) => record.id !== current.id);
+        // 原子替换会改变配置文件见证；其它 owned 记录只有仍匹配删除前见证时
+        // 才继承新见证。
+        records = refreshOwnedOriginWitnesses(
+          records,
+          current.origin!,
+          currentWitness,
+          afterWitness,
+        );
+        writeLedger(records);
+      } catch (error) {
+        // `--unset` 在重复匹配时会失败；其它写入/锁错误也都只保留，不影响 worktree 清理。
+        log.warn(
+          '[safe.directory] failed to remove owned config entry; preserving ownership record:',
+          error instanceof Error ? error.message : String(error),
+        );
+      }
+    }),
+  );
+}
+
+/**
+ * 按 A ∩ (B - C) 对账：A 是 Cindy 的跨 profile 所有权台账，B 是当前全局 Git 配置，
+ * C 是所有已登记 profile 中仍保留的 worktree、创建声明与任务工作目录的并集。
+ */
+export function reconcileSafeDirectories(): Promise<void> {
+  // 同一进程已有尚未持久化完毕的创建声明时跳过删除，即为安全结果。
+  if (inflightRetentionRoots.size > 0) return Promise.resolve();
+  return (async () => {
+    const generation = inflightRetentionGeneration;
+    const snapshot = await collectRetentionSnapshot();
+    if (generation !== inflightRetentionGeneration || inflightRetentionRoots.size > 0) return;
+
+    const prepared = await serializeOperation(() =>
+      runReconciliationWithMutationLock(async () => {
+        // 获取锁期间若本进程开始创建，旧快照不能覆盖它刚发布或即将发布的声明。
+        if (generation !== inflightRetentionGeneration || inflightRetentionRoots.size > 0) {
+          return { skipped: true as const };
+        }
+        writeCurrentProfileRetention(snapshot);
+        publishedUsagePaths.clear();
+        let profileRetentions = readProfileRetentions();
+        if (profileRetentions === null) {
+          return { malformed: true as const };
+        }
+        profileRetentions = compactExitedProcessRetentions(profileRetentions);
+        return { records: readLedger(), profileRetentions };
+      }),
+    );
+    if (!prepared || 'skipped' in prepared) return;
+    if ('malformed' in prepared) {
+      log.warn('[safe.directory] skipped reconciliation: profile retention ledger is malformed');
+      return;
+    }
+    if (prepared.records.length === 0) return;
+
+    const actions = await inspectReconciliationActions(
+      prepared.records,
+      prepared.profileRetentions,
+    );
+    for (const action of actions) {
+      await commitReconciliationAction(action);
+    }
+  })();
+}
+
+/**
+ * 由 Desktop 组合根注入 Maker 的运行态真值。未注入或 Maker 尚未就绪时返回
+ * undefined，终态会话继续 fail closed 保留；明确 false 后归档/删除任务才退出 C 集合。
+ */
+export function setSafeDirectorySessionRuntimeAliveProvider(
+  provider: SessionRuntimeAliveProvider | null,
+): void {
+  sessionRuntimeAliveProvider = provider;
+}
+
+// ── 测试钩子 ────────────────────────────────────────────────────────────────
+
+export function _setSafeDirectoryLedgerStoreForTests(value: SafeDirectoryLedgerStore | null): void {
+  ledgerStore = value;
+}
+
+export function _setSafeDirectoryGitRunnerForTests(value: GitConfigRunner | null): void {
+  gitConfigRunner = value ?? runGitConfig;
+}
+
+export function _setGlobalConfigWriteOriginProviderForTests(
+  value: GlobalConfigWriteOriginProvider | null,
+): void {
+  globalConfigWriteOriginProvider = value ?? resolveGlobalConfigWriteOrigin;
+}
+
+export function _setSafeDirectoryHomePathProviderForTests(value: (() => string) | null): void {
+  homePathProvider = value ?? (() => app.getPath('home'));
+}
+
+export function _setActiveWorktreesProviderForTests(
+  value: (() => readonly WorktreeMeta[]) | null,
+): void {
+  activeWorktreesProvider = value ?? (() => worktreeStore.getAll());
+}
+
+export function _setLiveSessionPathKeysProviderForTests(
+  value: (() => Promise<LiveSessionPathKeys>) | null,
+): void {
+  liveSessionPathKeysProvider = value ?? loadCurrentLiveSessionPathKeys;
+}
+
+export function _setSafeDirectoryCrossProcessLockRunnerForTests(
+  value: CrossProcessLockRunner | null,
+): void {
+  crossProcessLockRunner = value ?? withSecurityBoundaryLock;
+}
+
+export function _setSafeDirectoryProfilePathProviderForTests(value: (() => string) | null): void {
+  currentProfilePathProvider = value ?? (() => app.getPath('userData'));
+}
+
+export function _setSafeDirectoryProcessProvidersForTests(
+  processId: (() => number) | null,
+  liveness: ((processId: number) => ProcessLiveness) | null,
+): void {
+  currentProcessIdProvider = processId ?? (() => process.pid);
+  processLivenessProvider = liveness ?? probeProcessLiveness;
+}
+
+export function _resetSafeDirectoryStateForTests(): void {
+  ledgerStore = null;
+  gitConfigRunner = runGitConfig;
+  activeWorktreesProvider = () => worktreeStore.getAll();
+  sessionRuntimeAliveProvider = null;
+  liveSessionPathKeysProvider = loadCurrentLiveSessionPathKeys;
+  crossProcessLockRunner = withSecurityBoundaryLock;
+  sharedStateRootProvider = () => resolveSafeDirectorySharedStateRoot(app.getPath('appData'));
+  currentProfilePathProvider = () => app.getPath('userData');
+  currentProcessIdProvider = () => process.pid;
+  processLivenessProvider = probeProcessLiveness;
+  globalConfigWriteOriginProvider = resolveGlobalConfigWriteOrigin;
+  homePathProvider = () => app.getPath('home');
+  operationTail = Promise.resolve();
+  inflightRetentionRoots.clear();
+  publishedUsagePaths.clear();
+  inflightRetentionGeneration = 0;
+}


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Cindy 创建或使用 worktree 后，在用户全局 Git 配置中遗留 `safe.directory` 的问题。

现在只有 Git 明确报告 dubious ownership 时才会按需添加精确路径；Cindy 会持久化自己能够证明的写入记录，并根据“Cindy 写入集合、当前全局配置、仍活跃或创建中的 worktree”做声明式对账。清理只针对所有权仍可唯一证明的记录；重复值、外部重写、来源变化或读取异常都会保守保留。启动时会触发一次后台对账，但不阻塞启动流程。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Closes #2627
- 本 PR 包含：按需登记 `safe.directory`；持久化 Cindy 写入台账与配置文件见证；在 worktree 清理及非阻塞启动路径中执行 A/B/C 对账；覆盖真实 Git dubious ownership、手动删除、用户重建同值、重复值和空值重置等场景。
- 明确不包含：不会认领或删除缺少 Cindy 所有权证据的历史配置；不修改项目级 Git 配置；不改变 UI。
- 用户可见变化：正常创建 worktree 不再无条件修改全局 Git 配置；确有权限问题时，后续 Git 命令可持续使用所需信任；worktree 消失后，Cindy 能安全清理自己添加且未被用户改写的记录。
- 是否存在 breaking change：无。

### 多端适配结论

- SSH 远程工作区：不涉及。本 PR 只调整 Desktop 本机 worktree 管理器执行本机 Git 时的全局配置生命周期，没有新增直接读取远端 workdir 的本机文件操作，也未改动现有远程执行通道。
- 设备互联远程控制：不涉及。没有新增或修改 IPC channel、推送事件或 device-link 路由。
- 手机版：不涉及。没有新增入口、UI 或手机端可见行为。

### UI 变化

不涉及。

- 引用的设计规范：不涉及。

## 怎么验证的

### 自动验证

```text
pnpm --dir apps/desktop exec eslint \
  src/main/worktree/safeDirectory.ts \
  src/main/worktree/__tests__/safeDirectory.test.ts \
  src/main/worktree/__tests__/safeDirectory.git-integration.test.ts \
  src/main/worktree/gitExec.ts \
  src/main/worktree/__tests__/gitExec.test.ts \
  src/main/worktree/WorktreeManager.ts \
  src/main/worktree/WorktreePool.ts \
  src/main/worktree/index.ts \
  src/main/__tests__/worktreeManagerCreate.test.ts \
  src/main/__tests__/worktreeManagerRemove.test.ts \
  src/main/__tests__/worktreePoolSafety.test.ts \
  src/main/__tests__/worktreeSafeDirectoryBootstrap.test.ts
结果：通过。

pnpm --filter desktop run --if-present typecheck
结果：通过。

env NODE_OPTIONS=--no-experimental-webstorage pnpm test:git-integration
结果：通过；包含真实 linked worktree 和 Git 所有权模拟。

env NODE_OPTIONS=--no-experimental-webstorage pnpm test:unit
结果：全部必需 workspace 通过。

pnpm check:dco
结果：通过。
```

本机使用 Node 26；`--no-experimental-webstorage` 仅关闭 Node 26 新增的全局 Web Storage 行为，使测试环境与 CI 使用的 Node 22 一致，未跳过或缩小测试范围。

### 手工验证

不涉及；关键生命周期通过隔离 HOME/XDG 的真实 Git 集成测试验证。

### 未执行的验证

尚未在 Windows 实机手工验证；Windows 路径分支由单元测试、类型检查和 CI 覆盖。

`bootstrap-electron.ts` 的整文件 ESLint 在最新 `origin/main` 上已有 4 个未使用符号错误；本 PR 未触及这些符号，新增的静态 import 与非阻塞调用已通过类型检查、启动路径单测和完整 diff review。其余 12 个改动文件的定向 ESLint 已通过。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop worktree Git 命令重试、worktree 生命周期清理，以及用户全局 Git `safe.directory` 配置。
- 回滚 / 降级方式：回滚本 PR 可停止新的登记与对账；持久化台账会被旧版本忽略。回滚后若已有 Cindy 添加的条目，需由后续修复或用户手动清理。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
