### PR TITLE
fix(desktop): 侧栏 hover 恢复普通指针，不再显示 grab

### DIFF
--- a/apps/desktop/src/renderer/__tests__/sidebarRemoteProjectIcon.test.ts
+++ b/apps/desktop/src/renderer/__tests__/sidebarRemoteProjectIcon.test.ts
@@ -56,7 +56,7 @@ describe('sidebar remote project icon', () => {
 
   it('keeps remote session icons next to titles instead of in the right-side time slots', () => {
     expect(sessionItemSource).toMatch(
-      /<span[\s\S]*?className=\{cn\(\s*'min-w-0 flex flex-1 items-center gap-1\.5'[\s\S]*?<SidebarTitleMarquee[\s\S]*?\{remoteIconKind && \([\s\S]*?<RemoteProjectIcon/,
+      /<span[\s\S]*?className="min-w-0 flex flex-1 items-center gap-1\.5"[\s\S]*?<SidebarTitleMarquee[\s\S]*?\{remoteIconKind && \([\s\S]*?<RemoteProjectIcon/,
     );
     // C 期起右侧时间槽由 SessionInfoMeta 承担(任务信息复选),仍在同一让位容器内。
     expect(sessionItemSource).toMatch(

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionCard.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionCard.tsx
@@ -655,10 +655,9 @@ export function SessionCard({
         setMenuPos({ x: e.clientX, y: e.clientY });
       }}
       className={cn(
-        'group/card relative w-full overflow-hidden text-left',
-        splitDragEnabled && !needsSplitDragHandle
-          ? 'cursor-grab active:cursor-grabbing'
-          : 'cursor-pointer',
+        // 侧栏任务本身是可点击导航。拖拽能力不改变 hover 光标；
+        // grab 只在真正拖动中由 Sortable / 系统拖拽态负责。
+        'group/card relative w-full overflow-hidden text-left cursor-pointer',
         variant === 'list'
           ? cn(
               // 扁平行(类 Telegram / 对话列表):无描边、无卡片底色,仅 hover/active 行底色。
@@ -719,10 +718,7 @@ export function SessionCard({
               data-split-group-drag-handle={splitDragHandleActive ? 'true' : undefined}
               data-no-drag={splitDragHandleActive ? 'true' : undefined}
               draggable={splitDragHandleActive}
-              className={cn(
-                'relative flex h-5 min-w-0 flex-1 items-center gap-0',
-                splitDragHandleActive && 'cursor-grab active:cursor-grabbing',
-              )}
+              className="relative flex h-5 min-w-0 flex-1 items-center gap-0"
             >
               <span className="flex shrink-0 items-center">{titlePrefixNode}</span>
               {isEditing ? (
@@ -827,7 +823,6 @@ export function SessionCard({
             className={cn(
               'mt-1 overflow-hidden text-11 leading-[1.45]',
               '[display:-webkit-box] [-webkit-line-clamp:1] [-webkit-box-orient:vertical]',
-              splitDragHandleActive && 'cursor-grab active:cursor-grabbing',
               rightStatusKind !== 'time' && 'pr-5',
               awaitingText
                 ? isActive
@@ -917,10 +912,7 @@ export function SessionCard({
             data-split-group-drag-handle={splitDragHandleActive ? 'true' : undefined}
             data-no-drag={splitDragHandleActive ? 'true' : undefined}
             draggable={splitDragHandleActive}
-            className={cn(
-              'relative',
-              splitDragHandleActive && 'cursor-grab active:cursor-grabbing',
-            )}
+            className="relative"
           >
             <div
               className={cn(
@@ -972,7 +964,6 @@ export function SessionCard({
                 'mt-[4px] text-11 leading-[1.4]',
                 '[display:-webkit-box] [-webkit-box-orient:vertical] overflow-hidden',
                 'text-[var(--text-secondary)]',
-                splitDragHandleActive && 'cursor-grab active:cursor-grabbing',
               )}
               style={{ WebkitLineClamp: cardPreviewLineClamp }}
             >

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionItem.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionItem.tsx
@@ -924,10 +924,7 @@ export const SessionItem = memo(function SessionItem({
           data-split-group-drag-handle={splitDragHandleActive ? 'true' : undefined}
           data-no-drag={splitDragHandleActive ? 'true' : undefined}
           draggable={splitDragHandleActive}
-          className={cn(
-            'min-w-0 flex flex-1 items-center gap-1.5',
-            splitDragHandleActive && 'cursor-grab active:cursor-grabbing',
-          )}
+          className="min-w-0 flex flex-1 items-center gap-1.5"
         >
           {/* 绑定徽章优先于普通自动化 Timer:persistentSession 会话两者皆真,
               主图标统一为 Timer，绑定态额外承载频率/暂停信息。 */}

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/SessionCard.visual.test.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/SessionCard.visual.test.ts
@@ -338,7 +338,10 @@ describe('SessionCard visual cases', () => {
         'button[aria-label="ccAgent.sidebar.sessionMenu.moreActions"]',
       );
       expect(card?.draggable).toBe(true);
+      expect(card?.className).toContain('cursor-pointer');
+      expect(card?.className).not.toContain('cursor-grab');
       expect(card?.querySelector('[data-split-group-drag-handle="true"]')).toBeNull();
+      expect(title.className).not.toContain('cursor-grab');
       expect(actionButton).not.toBeNull();
 
       fireEvent.pointerDown(title, { button: 0, pointerType: 'mouse' });

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/sessionCardReviewRegressions.test.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/sessionCardReviewRegressions.test.ts
@@ -268,9 +268,6 @@ describe('SessionCard review regressions', () => {
 
   it('aligns the session row cursor with the actual split drag source state', () => {
     expect(sessionItemSource).toContain("!isEditing && 'cursor-pointer'");
-    expect(sessionItemSource).not.toContain('cursor-grab');
-    expect(sessionCardSource).toContain('text-left cursor-pointer');
-    expect(sessionCardSource).not.toContain('cursor-grab');
     expect(sessionItemSource).toContain(
       'draggable={splitDragEnabled && (dragContainerState.nativeSortable || !needsSplitDragHandle)}',
     );

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/sessionCardReviewRegressions.test.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/sessionCardReviewRegressions.test.ts
@@ -268,6 +268,9 @@ describe('SessionCard review regressions', () => {
 
   it('aligns the session row cursor with the actual split drag source state', () => {
     expect(sessionItemSource).toContain("!isEditing && 'cursor-pointer'");
+    expect(sessionItemSource).not.toContain('cursor-grab');
+    expect(sessionCardSource).toContain('text-left cursor-pointer');
+    expect(sessionCardSource).not.toContain('cursor-grab');
     expect(sessionItemSource).toContain(
       'draggable={splitDragEnabled && (dragContainerState.nativeSortable || !needsSplitDragHandle)}',
     );

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/sessionRowRenderIsolation.test.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/sessionRowRenderIsolation.test.ts
@@ -271,8 +271,11 @@ describe('SessionItem — 置顶分屏拖拽', () => {
       'button[aria-label="ccAgent.sidebar.sessionMenu.moreActions"]',
     );
     expect(row?.draggable).toBe(true);
+    expect(row?.className).toContain('cursor-pointer');
+    expect(row?.className).not.toContain('cursor-grab');
     expect(row?.querySelector('[data-split-group-drag-handle="true"]')).toBeNull();
     expect(title).not.toBeNull();
+    expect(title?.className).not.toContain('cursor-grab');
     expect(actionButton).not.toBeNull();
 
     fireEvent.pointerDown(title!, { button: 0, pointerType: 'mouse' });


### PR DESCRIPTION
## 这次改了什么

### 摘要

左侧任务栏悬停时不应变成可拖动的抓手光标。任务拖拽把静止 hover 也改成了 `cursor-grab`，现已改回普通 `cursor-pointer`。拖拽能力不变，grab 只在真正拖动时出现。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：侧栏任务行 / 卡片 hover 光标恢复为 `cursor-pointer`，并补回归断言
- 明确不包含：不改拖拽、分屏、置顶排序行为
- 用户可见变化：鼠标停在左侧任务上时保持普通指针，不再显示抓手
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：`docs/design-rules/DESIGN.md` §2 / 交互反馈：可点击导航以 `cursor:pointer` 作为辅助反馈；grab 只表达正在拖动，不用于静止 hover。侧栏任务仍是点击进入任务的导航控件，因此 hover 保持普通指针。
- 界面效果：只改静止 hover 的系统光标，不改行高、颜色、间距。下面是 Light / Dark 对照页，鼠标移到任务行上即可对比改前 grab 与改后 pointer。

```html
<!doctype html>
<html lang="zh-CN">
<head>
  <meta charset="utf-8" />
  <title>侧栏 hover 光标 · Light + Dark</title>
  <style>
    :root { font-family: Inter, -apple-system, sans-serif; }
    body { margin: 0; background: #cfcfcb; color: #1a1a1a; }
    .page { max-width: 980px; margin: 0 auto; padding: 24px 16px 36px; }
    h1 { font-size: 16px; font-weight: 500; margin: 0 0 6px; }
    .note { color: #6b6b67; margin: 0 0 18px; font-size: 13px; }
    .modes { display: grid; gap: 16px; }
    .mode { border-radius: 16px; padding: 14px; }
    .mode.light { background: #F2F2ED; color: #1A1A1A; }
    .mode.dark { background: #181818; color: #D4D4D4; }
    .mode h2 { font-size: 12px; font-weight: 500; letter-spacing: .4px; text-transform: uppercase; margin: 0 0 10px; opacity: .7; }
    .pair { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
    .card { border-radius: 12px; overflow: hidden; }
    .light .card { background: #F8F8F6; border: 1px solid #D7D7D4; }
    .dark .card { background: #1F1F1E; border: 1px solid #3C3C3A; }
    .cap { padding: 8px 12px 0; font-size: 11px; opacity: .65; }
    .list { padding: 8px; }
    .row { display: flex; align-items: center; gap: 10px; height: 32px; border-radius: 999px; padding: 0 12px; margin-bottom: 4px; }
    .icon { width: 15px; height: 15px; border-radius: 4px; flex: 0 0 auto; }
    .light .icon { background: #737373; }
    .dark .icon { background: #A3A3A3; }
    .title { flex: 1; font-size: 13px; font-weight: 500; }
    .time { font-size: 11px; opacity: .55; }
    .light .hov { background: #EEEEE9; }
    .dark .hov { background: #282828; }
    .old { cursor: grab; }
    .new { cursor: pointer; }
    .badge { display: inline-flex; align-items: center; gap: 6px; font-size: 11px; opacity: .7; padding: 0 12px 10px; }
    .hand, .arrow { width: 14px; height: 14px; display: inline-block; }
    .hand { border: 1.5px solid currentColor; border-radius: 3px 3px 6px 6px; position: relative; }
    .hand::before { content: ""; position: absolute; left: 2px; top: -4px; width: 2px; height: 5px; background: currentColor; box-shadow: 4px 0 0 currentColor, 8px 0 0 currentColor; }
    .arrow { border-left: 5px solid transparent; border-right: 5px solid transparent; border-bottom: 10px solid currentColor; transform: rotate(-30deg); }
    @media (max-width: 760px) { .pair { grid-template-columns: 1fr; } }
  </style>
</head>
<body>
  <div class="page">
    <h1>左侧任务栏 hover 光标</h1>
    <p class="note">左列改前：静止悬停就是 grab。右列改后：静止悬停是普通 pointer。真正拖动时仍走系统 grabbing，本页不演示。</p>
    <div class="modes">
      <section class="mode light">
        <h2>Cindy Light</h2>
        <div class="pair">
          <article class="card">
            <div class="cap">改前 · cursor: grab</div>
            <div class="list">
              <div class="row old"><span class="icon"></span><span class="title">整理周报</span><span class="time">2 分</span></div>
              <div class="row hov old"><span class="icon"></span><span class="title">修复登录跳转</span><span class="time">刚刚</span></div>
              <div class="row old"><span class="icon"></span><span class="title">侧栏重设计</span><span class="time">1 时</span></div>
            </div>
            <div class="badge"><span class="hand"></span>hover 显示抓手</div>
          </article>
          <article class="card">
            <div class="cap">改后 · cursor: pointer</div>
            <div class="list">
              <div class="row new"><span class="icon"></span><span class="title">整理周报</span><span class="time">2 分</span></div>
              <div class="row hov new"><span class="icon"></span><span class="title">修复登录跳转</span><span class="time">刚刚</span></div>
              <div class="row new"><span class="icon"></span><span class="title">侧栏重设计</span><span class="time">1 时</span></div>
            </div>
            <div class="badge"><span class="arrow"></span>hover 保持普通指针</div>
          </article>
        </div>
      </section>
      <section class="mode dark">
        <h2>Cindy Dark</h2>
        <div class="pair">
          <article class="card">
            <div class="cap">改前 · cursor: grab</div>
            <div class="list">
              <div class="row old"><span class="icon"></span><span class="title">整理周报</span><span class="time">2 分</span></div>
              <div class="row hov old"><span class="icon"></span><span class="title">修复登录跳转</span><span class="time">刚刚</span></div>
              <div class="row old"><span class="icon"></span><span class="title">侧栏重设计</span><span class="time">1 时</span></div>
            </div>
            <div class="badge"><span class="hand"></span>hover 显示抓手</div>
          </article>
          <article class="card">
            <div class="cap">改后 · cursor: pointer</div>
            <div class="list">
              <div class="row new"><span class="icon"></span><span class="title">整理周报</span><span class="time">2 分</span></div>
              <div class="row hov new"><span class="icon"></span><span class="title">修复登录跳转</span><span class="time">刚刚</span></div>
              <div class="row new"><span class="icon"></span><span class="title">侧栏重设计</span><span class="time">1 时</span></div>
            </div>
            <div class="badge"><span class="arrow"></span>hover 保持普通指针</div>
          </article>
        </div>
      </section>
    </div>
  </div>
</body>
</html>
```

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run \
  src/renderer/__tests__/sidebarRemoteProjectIcon.test.ts \
  src/renderer/features/cc-agent/sidebar/__tests__/sessionCardReviewRegressions.test.ts \
  src/renderer/features/cc-agent/sidebar/__tests__/SessionCard.visual.test.ts \
  src/renderer/features/cc-agent/sidebar/__tests__/sessionRowRenderIsolation.test.ts
结果：4 files / 92 tests passed

pnpm --filter desktop run --if-present typecheck
结果：通过
```

全量 `pnpm test:unit` 在本机并发高峰下出现与本 diff 无关的超时 / 竞态失败（desktop / mobile / lizi-im / maker-core）。已在干净 `origin/main` 上定向复现，对应用例通过，判定为基线/本机负载噪声，不混入本 PR。以 CI 为准。

### 手工验证

未在运行中的 Desktop 实例目检。改动只删除静止 hover 的 `cursor-grab`，拖拽手势与 payload 未改。

### 未执行的验证

- 实机 Light / Dark hover 目检：当前会话无法热更到该 worktree
- 完整 `pnpm test:unit`：本机并发高峰噪声，交由 CI 给权威结论

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop 左侧任务行 / 卡片的 hover 光标
- 回滚 / 降级方式：回退本 commit 即可

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因

