### PR TITLE
fix(desktop): 提前注册模型可见性同步 IPC

### DIFF
--- a/apps/desktop/src/main/__tests__/modelVisibilityOwnerClaimOrdering.test.ts
+++ b/apps/desktop/src/main/__tests__/modelVisibilityOwnerClaimOrdering.test.ts
@@ -5,9 +5,17 @@ import { describe, expect, it } from 'vitest';
 
 const source = readFileSync(resolve(__dirname, '..', 'bootstrap-electron.ts'), 'utf8');
 
-describe('model visibility owner claim IPC ordering', () => {
+describe('model visibility IPC ordering', () => {
   it('registers the synchronous claim handler before the first BrowserWindow is created', () => {
     const registration = source.indexOf('registerModelVisibilityOwnerClaimIpc();');
+    const createWindow = source.indexOf('startupWindowCreationAllowed = true;');
+
+    expect(registration).toBeGreaterThanOrEqual(0);
+    expect(createWindow).toBeGreaterThan(registration);
+  });
+
+  it('registers the initial visibility mirror handler before the first BrowserWindow is created', () => {
+    const registration = source.indexOf('registerModelVisibilitySyncIpc();');
     const createWindow = source.indexOf('startupWindowCreationAllowed = true;');
 
     expect(registration).toBeGreaterThanOrEqual(0);

--- a/apps/desktop/src/main/bootstrap-electron.ts
+++ b/apps/desktop/src/main/bootstrap-electron.ts
@@ -507,6 +507,7 @@ import {
   clearDeferredCodexRestartForOwnerBoundary,
   collectAgentInputQueueScanTexts,
   createAutomationUserTurnGitBaselineHooks,
+  registerModelVisibilitySyncIpc,
   registerMakerIpc as registerMakerCoreIpc,
   isSessionTurnPendingCompletion,
   stopOrcaIdleWatcher,
@@ -7043,6 +7044,7 @@ app.on('ready', async () => {
   // invoke-registry 捕获后供控制端隧道调用,本机 renderer 不调用)。
   registerGitReviewDeviceOp();
   registerModelVisibilityOwnerClaimIpc();
+  registerModelVisibilitySyncIpc();
   registerSidebarSettingsIpc();
   registerRemotePrecreatedWorktreeLedgerIpc();
   // RSB terminal tab: PTY backend + 8 个 terminal:* IPC channels(create/write/resize/dispose/restart

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -5179,6 +5179,30 @@ export interface RegisterMakerIpcOptions {
   onProviderModelAutoRefreshConfigured(): void;
 }
 
+/**
+ * Register before the first BrowserWindow: modelVisibilityPrefs mirrors its initial snapshot as
+ * soon as the Renderer selects an owner, before the splash-gated Maker IPC bundle is available.
+ */
+export function registerModelVisibilitySyncIpc(): void {
+  ipcMain.handle(MAKER_INVOKE.MODEL_VISIBILITY_SYNC, async (
+    event,
+    dataOwnerId: unknown,
+    ownerGeneration: unknown,
+    map: unknown,
+  ) => {
+    assertTrustedAppRendererEvent(event);
+    syncModelVisibilityMirrorForOwner(
+      map,
+      { dataOwnerId, ownerGeneration },
+      getActiveDataOwnerPushStamp(),
+      isAppSessionBoundaryPending(),
+      () => {
+        broadcastToAllWindows(MAKER_PUSH.PROVIDER_CHANGED, {});
+      },
+    );
+  });
+}
+
 export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions): void {
   log.info('registering maker:* IPC handlers');
   getAgentIslandService()?.setPermissionResolver(resolvePendingPermissionFromAgentIsland);
@@ -13212,28 +13236,6 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
       return;
     }
     await sess.setFastMode(enabled);
-  });
-
-  // renderer → main 单向镜像「模型显示/隐藏」override(整张快照,fire-and-forget,不落盘)。
-  // main 缓存供 IM /model 与 device-link provider:list 复用同一套可见性过滤。值实变时
-  // 复用 PROVIDER_CHANGED 目录失效事件，让已连接控制端驱逐缓存并重拉 override 快照。
-  // 容错存储(非对象 ⇒ 清空),无错误路径,故不需要 throwIpcError。
-  ipcMain.handle(MAKER_INVOKE.MODEL_VISIBILITY_SYNC, async (
-    event,
-    dataOwnerId: unknown,
-    ownerGeneration: unknown,
-    map: unknown,
-  ) => {
-    assertTrustedAppRendererEvent(event);
-    syncModelVisibilityMirrorForOwner(
-      map,
-      { dataOwnerId, ownerGeneration },
-      getActiveDataOwnerPushStamp(),
-      isAppSessionBoundaryPending(),
-      () => {
-        broadcastToAllWindows(MAKER_PUSH.PROVIDER_CHANGED, {});
-      },
-    );
   });
 
   // 附加只读引用目录的运行时 closure 推送。DB 持久化由 renderer 同步调

--- a/apps/desktop/src/renderer/__tests__/modelVisibilityPrefs.test.ts
+++ b/apps/desktop/src/renderer/__tests__/modelVisibilityPrefs.test.ts
@@ -10,6 +10,7 @@
  *   6. 同值写入短路(不抛)
  *   7. 旧全局 key 只由 Main 仲裁出的首个 owner 认领,新账号默认隔离
  *   8. schema 损坏 / 脏数据 → 静默回退,跟随目录默认
+ *   9. main 镜像同步异步失败时不产生未处理 rejection
  *
  * 项目 vitest env=node,无 window。沿用 providerModelMemory.test.ts 的最小 localStorage stub。
  */
@@ -251,6 +252,15 @@ describe('modelVisibilityPrefs store', () => {
 
     expect(module.isModelEnabled('codex', 'openai', { id: 'gpt-5.6' })).toBe(true);
     expect(syncModelVisibility).toHaveBeenLastCalledWith(null, 2, {});
+  });
+
+  it('main 镜像同步异步失败时静默降级', async () => {
+    syncModelVisibility.mockRejectedValueOnce(new Error('handler not registered'));
+
+    await loadModuleForOwner();
+    await Promise.resolve();
+
+    expect(syncModelVisibility).toHaveBeenCalledWith('owner-a', 1, {});
   });
 
   it('本地 profile 认领历史全局 key 并迁移到自己的 namespace', async () => {

--- a/apps/desktop/src/renderer/state/modelVisibilityPrefs.ts
+++ b/apps/desktop/src/renderer/state/modelVisibilityPrefs.ts
@@ -183,11 +183,12 @@ function load(): VisibilityMap {
  */
 function mirrorToMain(map: VisibilityMap): void {
   try {
-    void window.electronAPI?.maker?.syncModelVisibility?.(
+    const syncPromise = window.electronAPI?.maker?.syncModelVisibility?.(
       activeOwnerId,
       activeOwnerGeneration,
       map,
     );
+    if (syncPromise) void syncPromise.catch(() => undefined);
   } catch {
     // ignore — 镜像失败不影响本地可见性逻辑
   }


### PR DESCRIPTION
## 这次改了什么

### 摘要

PR #2671 增加模型可见性按账号隔离后，Renderer 会在 splash 阶段的 Maker IPC 注册完成前推送首次可见性镜像，导致启动期出现 No handler registered，并让 Main 侧丢失本次内存镜像。

本 PR 将现有模型可见性同步 handler 提前到首个 BrowserWindow 创建前注册，同时显式处理 Renderer fire-and-forget Promise 的异步拒绝。

### 变更类型

- [ ] feat 新功能
- [x] fix 缺陷修复
- [ ] refactor / perf 重构或性能优化
- [ ] docs / test / chore 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：PR #2671 启动期模型可见性同步回归
- 本 PR 包含：提前注册 MODEL_VISIBILITY_SYNC handler；捕获异步 IPC rejection；补充注册顺序与降级回归用例
- 明确不包含：PR #1916 的全局 Ghost owner 边界问题
- 用户可见变化：启动时不再出现该 IPC 未注册错误，IM 与 device-link 能收到首次模型可见性镜像
- 是否存在 breaking change：无

### UI 变化

不涉及：仅调整 Desktop 启动期 IPC 注册时序与 fire-and-forget 异常处理，无视觉、交互或文案变化。

- 引用的设计规范：不涉及：仅调整 Desktop 启动期 IPC 注册时序与异常处理，无视觉、交互或文案变化

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：通过，Desktop、Mobile 及所有 required unit workspace 均通过

pnpm --filter desktop run --if-present typecheck
结果：通过
```

### 手工验证

不涉及。

### 未执行的验证

未运行 packaged App 手工启动复现；注册顺序和异步拒绝路径已由自动回归用例覆盖。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop 启动期模型可见性 Renderer → Main 内存镜像注册时序
- 回滚 / 降级方式：revert 本 PR 即恢复原注册时序；不涉及持久数据迁移

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] UI 改动已在 UI 变化注明引用的设计规范（不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次不涉及文档）
- [x] 已确认测试结果或说明未执行原因
