### PR TITLE
revert(desktop): 回退侧边栏底部账号信息框样式调整（PR #1940）

### DIFF
--- a/apps/desktop/src/renderer/__tests__/newMakerCreateAgentVisualContract.test.ts
+++ b/apps/desktop/src/renderer/__tests__/newMakerCreateAgentVisualContract.test.ts
@@ -352,7 +352,7 @@ describe('NewMakerDraftRoute CREATE AGENT visual contract', () => {
     expect(vendorIconSource).toContain('text-[hsl(var(--sidebar-muted))]');
 
     expect(userInfoSectionSource).toContain(
-      'border border-[var(--sidebar-user-card-border)]',
+      'rounded-full border border-[var(--sidebar-user-card-border)]',
     );
     expect(userInfoSectionSource).toContain('bg-[var(--sidebar-user-card-bg)]');
     expect(userInfoSectionSource).toContain('text-[var(--sidebar-user-card-text)]');

--- a/apps/desktop/src/renderer/__tests__/userInfoSectionHover.test.ts
+++ b/apps/desktop/src/renderer/__tests__/userInfoSectionHover.test.ts
@@ -32,12 +32,12 @@ const locale = JSON.parse(readFileSync(localePath, 'utf8')) as {
 
 describe('UserInfoSection — outer wrapper takes over full-row hover', () => {
   it('outer div keeps the sidebar footer slot', () => {
-    expect(source).toContain('mt-auto pt-1');
+    expect(source).toContain('mt-auto px-3 pb-3 pt-2');
   });
 
-  it('visible user card uses the tokenized capsule style with 12px container radius', () => {
+  it('visible user card uses the rounded tokenized capsule style', () => {
     expect(source).toContain(
-      'flex h-12 items-center rounded-xl border border-[var(--sidebar-user-card-border)] bg-[var(--sidebar-user-card-bg)] pl-3 pr-1.5',
+      'flex h-10 items-center rounded-full border border-[var(--sidebar-user-card-border)] bg-[var(--sidebar-user-card-bg)] px-[7px]',
     );
   });
 
@@ -101,13 +101,13 @@ describe('UserInfoSection — 未登录态头像兜底', () => {
     // 状态名四语各不相同(未登录 / Not signed in / 未ログイン / 로그인하지 않음),
     // 取首字会渲染成「未」/「N」这类无意义字符,所以这里必须走图标分支。
     expect(source).toContain('const showNotSignedInGlyph = !user && isLocal;');
-    // 折叠 rail(36px 圆)与展开胶囊(40px 圆)两处兜底都要接上
-    const matchCount = (
-      source.match(
-        /showNotSignedInGlyph \? \(\s*\n\s*<UserRound aria-hidden="true" size=\{18\}/g,
-      ) ?? []
-    ).length;
-    expect(matchCount).toBe(2);
+    // 折叠 rail(36px 圆)与展开胶囊(27px 圆)两处兜底都要接上
+    expect(source).toMatch(
+      /showNotSignedInGlyph \? \(\s*\n\s*<UserRound aria-hidden="true" size=\{18\}/,
+    );
+    expect(source).toMatch(
+      /showNotSignedInGlyph \? \(\s*\n\s*<UserRound aria-hidden="true" size=\{15\}/,
+    );
   });
 
   it('已登录用户仍使用姓名首字兜底', () => {
@@ -119,12 +119,13 @@ describe('UserInfoSection — 未登录态头像兜底', () => {
 });
 
 describe('UserInfoSection — mobile download entry', () => {
-  it('uses the local Lucide Smartphone icon in a matching action button', () => {
+  it('uses the local Lucide Smartphone icon in a matching 22x22 capsule action', () => {
     expect(source).toContain(
       "import { Flame, Shield, Smartphone, UserRound } from 'lucide-react';",
     );
-    expect(source).toMatch(/mobile-download-btn',\s*\r?\n\s*'flex shrink-0[\s\S]*isCollapsed \? 'h-8 w-8' : 'h-9 w-9'/);
-    expect(source).toContain('<Smartphone className="h-5 w-5" aria-hidden="true" />');
+    expect(source).toMatch(/'mobile-download-btn',\s*\n\s*'flex h-\[22px\] w-\[22px\]/);
+    expect(source).toContain("!isCollapsed && 'mr-1'");
+    expect(source).toContain('<Smartphone className="h-3 w-3" aria-hidden="true" />');
   });
 
   it('suppresses capsule hover while the mobile button owns the hover state', () => {
@@ -143,7 +144,7 @@ describe('UserInfoSection — mobile download entry', () => {
 
   it('keeps the same entry and dialog available in the collapsed sidebar', () => {
     expect(source).toContain(
-      'className="mt-auto flex h-[76px] flex-col items-center justify-center gap-1 px-3"',
+      'className="mt-auto flex h-[66px] flex-col items-center justify-center gap-1 px-3"',
     );
     expect(source).toContain('{mobileDownloadEntry}');
   });
@@ -185,7 +186,7 @@ describe('UserInfoSection — inner main button no longer owns hover background'
 describe('UserInfoSection — Flame button carries .flame-btn marker class', () => {
   it("Flame button className list includes 'flame-btn' as the first entry", () => {
     // 关键: 外层 div 的 has-[.flame-btn:hover] 选择器必须能钩到这个 class
-    expect(source).toMatch(/'flame-btn',\s*\n\s*'flex h-9 w-9/);
+    expect(source).toMatch(/'flame-btn',\s*\n\s*'flex h-\[22px\] w-\[22px\]/);
   });
 
   it('Flame button retains its own hover:bg-sidebar-item-hover (capsule highlight when hovered)', () => {
@@ -193,9 +194,12 @@ describe('UserInfoSection — Flame button carries .flame-btn marker class', () 
     expect(source).toMatch(/'transition-colors hover:bg-sidebar-item-hover'/);
   });
 
-  it('Flame button keeps correct size and rounded-full inside the account capsule', () => {
+  it('Flame button keeps rounded-full + 22x22 size inside the account capsule', () => {
     expect(source).toContain(
-      'flex h-9 w-9 shrink-0 items-center justify-center rounded-full',
+      'flex h-[22px] w-[22px] shrink-0 items-center justify-center rounded-full',
+    );
+    expect(source).toContain(
+      'border border-[var(--sidebar-user-card-border)] bg-[var(--sidebar-user-card-bg)]',
     );
   });
 });

--- a/apps/desktop/src/renderer/components/sidebar/UserInfoSection.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/UserInfoSection.tsx
@@ -95,20 +95,21 @@ export function UserInfoSection({ isCollapsed, onOpenUpdateNotice }: UserInfoSec
       aria-label={t('sidebar.user.downloadMobile')}
       className={cn(
         'mobile-download-btn',
-        'flex shrink-0 items-center justify-center rounded-full',
-        isCollapsed ? 'h-8 w-8' : 'h-9 w-9',
+        'flex h-[22px] w-[22px] shrink-0 items-center justify-center rounded-full',
+        !isCollapsed && 'mr-1',
+        'border border-[var(--sidebar-user-card-border)] bg-[var(--sidebar-user-card-bg)]',
         'text-[var(--sidebar-user-card-text)] transition-colors hover:bg-sidebar-item-hover',
         'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)]',
       )}
     >
-      <Smartphone className="h-5 w-5" aria-hidden="true" />
+      <Smartphone className="h-3 w-3" aria-hidden="true" />
     </button>
   );
 
   if (isCollapsed) {
     return (
       <>
-        <div className="mt-auto flex h-[76px] flex-col items-center justify-center gap-1 px-3">
+        <div className="mt-auto flex h-[66px] flex-col items-center justify-center gap-1 px-3">
           <button
             onClick={handleClick}
             role="link"
@@ -169,13 +170,12 @@ export function UserInfoSection({ isCollapsed, onOpenUpdateNotice }: UserInfoSec
   }
 
   return (
-    <div className="mt-auto pt-1">
+    <div className="mt-auto px-3 pb-3 pt-2">
       {/* 胶囊整体承载 hover(方案 D):玻璃底色加深一档;悬停右侧操作按钮时用
-        :has() 把胶囊底色还原,只让当前按钮高亮,避免双层叠色。
-        横向填满容器、向下填满、12px 容器圆角(rounded-xl)。 */}
+        :has() 把胶囊底色还原,只让当前按钮高亮,避免双层叠色。 */}
       <div
         className={cn(
-          'flex h-12 items-center rounded-xl border border-[var(--sidebar-user-card-border)] bg-[var(--sidebar-user-card-bg)] pl-3 pr-1.5',
+          'flex h-10 items-center rounded-full border border-[var(--sidebar-user-card-border)] bg-[var(--sidebar-user-card-bg)] px-[7px]',
           'transition-colors hover:bg-[var(--sidebar-user-card-bg-hover)]',
           'has-[.flame-btn:hover]:bg-[var(--sidebar-user-card-bg)]',
           'has-[.mobile-download-btn:hover]:bg-[var(--sidebar-user-card-bg)]',
@@ -189,25 +189,25 @@ export function UserInfoSection({ isCollapsed, onOpenUpdateNotice }: UserInfoSec
         >
           {/* Avatar — admin 用户加 1.5px 反色描边 + 右下角盾牌角标 */}
           <div
-            className="relative h-10 w-10 shrink-0"
+            className="relative h-[27px] w-[27px] shrink-0"
             title={isCanary ? t('sidebar.user.canaryBadge') : undefined}
           >
             {user?.avatar && !avatarError ? (
               <img
                 src={user.avatar}
                 alt={displayName}
-                className={cn('h-10 w-10 rounded-full object-cover')}
+                className={cn('h-[27px] w-[27px] rounded-full object-cover')}
                 onError={() => setAvatarError(true)}
               />
             ) : (
               <div
                 className={cn(
-                  'flex h-10 w-10 items-center justify-center rounded-full',
-                  'border border-[var(--sidebar-user-card-border)] bg-[var(--sidebar-user-card-bg)] text-16 font-medium text-[var(--sidebar-user-card-text)]',
+                  'flex h-[27px] w-[27px] items-center justify-center rounded-full',
+                  'border border-[var(--sidebar-user-card-border)] bg-[var(--sidebar-user-card-bg)] text-14 font-medium text-[var(--sidebar-user-card-text)]',
                 )}
               >
                 {showNotSignedInGlyph ? (
-                  <UserRound aria-hidden="true" size={18} strokeWidth={1.75} />
+                  <UserRound aria-hidden="true" size={15} strokeWidth={1.75} />
                 ) : (
                   initial
                 )}
@@ -273,7 +273,8 @@ export function UserInfoSection({ isCollapsed, onOpenUpdateNotice }: UserInfoSec
             }
             className={cn(
               'flame-btn',
-              'flex h-9 w-9 shrink-0 items-center justify-center rounded-full',
+              'flex h-[22px] w-[22px] shrink-0 items-center justify-center rounded-full',
+              'border border-[var(--sidebar-user-card-border)] bg-[var(--sidebar-user-card-bg)]',
               'transition-colors hover:bg-sidebar-item-hover',
               'transition-opacity duration-200 ease-in-out',
               'opacity-100',
@@ -281,7 +282,7 @@ export function UserInfoSection({ isCollapsed, onOpenUpdateNotice }: UserInfoSec
           >
             <Flame
               className={cn(
-                'h-5 w-5',
+                'h-3 w-3',
                 isFlameReopen
                   ? 'fill-current text-[var(--sidebar-user-card-text)]'
                   : 'text-[var(--sidebar-user-card-text)]',


### PR DESCRIPTION
## 这次改了什么

### 摘要

整体回退 PR #1940（`refactor(desktop): 调整侧边栏底部账号信息框样式`）：这次样式调整不是期望的效果，恢复合入前的胶囊形账号信息框。附带效果：还开着的 #2746（移除 rounded-xl）随之失去对象，建议合并本 PR 后将其关闭。

### 变更类型

- [ ] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [x] 其他：`revert` 回退 PR #1940

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：`git revert 34808699b`（PR #1940 的 merge commit），无其他改动
- 明确不包含：不涉及 #1940 之后其他提交的任何内容
- 用户可见变化：侧边栏底部账号区域恢复 #1940 之前的样式（胶囊形 h-10 rounded-full、27px 头像、带边框的 22px 操作按钮、px-3 pb-3 外边距）
- 是否存在 breaking change：无

### UI 变化

容器从 12px 圆角矩形（rounded-xl）恢复为 #1940 合入前的胶囊形（rounded-full）。

- 引用的设计规范：恢复 #1940 合入前已在主干长期存在的样式（该形态当时即符合 docs/design-rules/DESIGN.md 的视觉与 token 约束，颜色与 token 用法未变）；本 PR 为纯回退，不引入新视觉决策。

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：通过（apps/desktop unit PASS，39.5s；test:runner 399 用例 0 fail）

pnpm --filter desktop run --if-present typecheck
结果：通过（回退前先 pnpm install 同步了 main 新增依赖 @cindy/maker-pi-manager，与本回退无关）

pnpm check:dco
结果：通过（1 commit signed off）
```

### 手工验证

不涉及。

### 未执行的验证

实机目检（Light/Dark 双模式）：未验证。纯回退到既有已合入形态，无新样式 token；建议合并前顺手目检一次侧边栏底部区域。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅侧边栏底部账号信息框（UserInfoSection）样式与其静态测试断言，不涉及逻辑、数据或 IPC
- 回滚 / 降级方式：如需恢复 #1940 的样式，revert 本 PR 即可

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)