### PR TITLE
fix(desktop): 修复插件批准凭据的清单与回滚兼容

### DIFF
--- a/apps/desktop/src/main/cindy-brain/GhostManager.ts
+++ b/apps/desktop/src/main/cindy-brain/GhostManager.ts
@@ -23,6 +23,7 @@ import {
   resolveGhostManifestLocale,
   validateGhostManifest,
   validateGhostManifestLocaleResource,
+  validateNormalizedGhostManifest,
   withGhostResolvedLocale,
   type GhostManifest,
   type GhostManifestLocaleResource,
@@ -3557,7 +3558,7 @@ export class GhostManager {
     });
     const sourceManifestRaw = JSON.parse(fs.readFileSync(sourceManifestPath, 'utf8')) as unknown;
     const sourceManifest = validateGhostManifest(sourceManifestRaw);
-    const expectedManifest = validateGhostManifest(manifest);
+    const expectedManifest = validateNormalizedGhostManifest(manifest);
     if (
       !sourceManifest.ok ||
       !expectedManifest.ok ||

--- a/apps/desktop/src/main/cindy-brain/__tests__/GhostManager.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/GhostManager.test.ts
@@ -72,6 +72,16 @@ function goodManifest(id = 'hello'): Record<string, unknown> {
   };
 }
 
+function setupKvManifest(id = 'hello'): Record<string, unknown> {
+  return {
+    ...goodManifest(id),
+    settingsHtml: 'settings.html',
+    setup: {
+      requires: [{ anyOf: [{ kv: 'repoDir', label: '本机 cindy 项目目录' }] }],
+    },
+  };
+}
+
 function atResourceManifest(id = 'hello'): Record<string, unknown> {
   return {
     ...goodManifest(id),
@@ -261,6 +271,27 @@ describe('GhostManager · 存量插件一次性迁移(§5 升级无感)', () => 
       approval: { state: 'approved' },
     });
     expect(fs.existsSync(migrationLedgerPath())).toBe(true);
+  });
+
+  it('带 setup.kv 的旧安装无感迁移并保留标准化就绪声明', async () => {
+    await writeLegacyInstall('hello', setupKvManifest(), {
+      files: { 'settings.html': '<!doctype html>' },
+    });
+
+    const outcome = await manager.migrateLegacyApprovalsOnce();
+
+    expect(outcome.migrated).toEqual(['hello']);
+    expect(manager.list()[0]).toMatchObject({
+      enabled: true,
+      approval: { state: 'approved' },
+      manifest: {
+        setup: {
+          requires: [
+            { anyOf: [{ kind: 'kv', key: 'repoDir', label: '本机 cindy 项目目录' }] },
+          ],
+        },
+      },
+    });
   });
 
   it('未批准或 receipt 损坏的插件不展示可变 trust 镜像', async () => {
@@ -919,6 +950,34 @@ describe('GhostManager · 从已装目录重新确认(本地包第三条恢复�
     expect(manager.list()[0]).toMatchObject({ enabled: true, approval: { state: 'approved' } });
     // 启停镜像同步维护(回滚到旧客户端不错位)。
     expect(fs.existsSync(path.join(rootDir, 'hello', '.disabled'))).toBe(false);
+  });
+
+  it('带 setup.kv 的旧安装可从已装目录重新确认并恢复可用', async () => {
+    await writeLegacyInstall('hello', setupKvManifest(), {
+      files: { 'settings.html': '<!doctype html>' },
+    });
+    const inspected = await manager.inspectInstalledReapproval('hello');
+    if ('rejection' in inspected) throw new Error(JSON.stringify(inspected.rejection));
+
+    const result = await manager.reapproveInstalled('hello', {
+      enable: true,
+      expectedManifestSha256: inspected.manifestSha256,
+      expectedApprovalProjectionSha256: inspected.approvalProjectionSha256,
+      expectedInstalledApproval: 'legacy-unapproved',
+    });
+
+    if ('rejection' in result) throw new Error(JSON.stringify(result.rejection));
+    expect(manager.list()[0]).toMatchObject({
+      enabled: true,
+      approval: { state: 'approved' },
+      manifest: {
+        setup: {
+          requires: [
+            { anyOf: [{ kind: 'kv', key: 'repoDir', label: '本机 cindy 项目目录' }] },
+          ],
+        },
+      },
+    });
   });
 
   it('重新确认要求立即启用时，删除停用镜像失败必须拒绝且不提交批准', async () => {

--- a/apps/desktop/src/main/cindy-brain/__tests__/GhostManager.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/GhostManager.test.ts
@@ -3220,12 +3220,13 @@ describe('GhostManager · Host approval receipt', () => {
   const writeBundledSource = async (
     manifest: InstalledGhost['manifest'],
     files: Record<string, string> = { 'main.js': '// bundled seed' },
+    sourceManifest: unknown = manifest,
   ): Promise<{ sourceDir: string }> => {
     const sourceDir = path.join(workDir, 'bundled-seeds', manifest.id);
     await fs.promises.rm(sourceDir, { recursive: true, force: true });
     await fs.promises.mkdir(sourceDir, { recursive: true });
     trustedBundledIds.add(manifest.id);
-    await fs.promises.writeFile(path.join(sourceDir, 'ghost.json'), JSON.stringify(manifest));
+    await fs.promises.writeFile(path.join(sourceDir, 'ghost.json'), JSON.stringify(sourceManifest));
     for (const [relativePath, content] of Object.entries(files)) {
       const target = path.join(sourceDir, relativePath);
       await fs.promises.mkdir(path.dirname(target), { recursive: true });
@@ -3834,6 +3835,34 @@ describe('GhostManager · Host approval receipt', () => {
         'utf8',
       ),
     ).toContain('Approved instructions');
+  });
+
+  it('bundled approval accepts a normalized setup manifest while validating source author syntax', async () => {
+    const sourceManifest = setupKvManifest();
+    await manager.install(
+      await makeCindy('setup.cindy', sourceManifest, {
+        'main.js': '// installed setup plugin',
+        'settings.html': '<!doctype html>',
+      }),
+    );
+    const listed = manager.list()[0];
+    const source = await writeBundledSource(
+      listed.manifest,
+      {
+        'main.js': '// bundled setup plugin',
+        'settings.html': '<!doctype html>',
+      },
+      sourceManifest,
+    );
+
+    await expect(
+      manager.approveTrustedBundledInstall(listed.manifest, listed.enabled, source),
+    ).resolves.toBe(true);
+    expect(manager.list()[0].manifest.setup).toEqual({
+      requires: [
+        { anyOf: [{ kind: 'kv', key: 'repoDir', label: '本机 cindy 项目目录' }] },
+      ],
+    });
   });
 
   it('snapshot repair persists a one-way disable before the compatibility marker disappears', async () => {

--- a/apps/desktop/src/main/cindy-brain/__tests__/ghostInstallReceipt.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/ghostInstallReceipt.test.ts
@@ -4,6 +4,8 @@ import path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { validateGhostManifest } from '../../../shared/ghost';
+
 import {
   createGhostInstallReceipt,
   GhostInstallReceiptStore,
@@ -114,6 +116,52 @@ describe('GhostInstallReceiptStore cleanup', () => {
 
     await expect(store.write(receipt)).rejects.toThrow('migration marker unavailable');
     expect(fs.existsSync(path.join(stateRoot, 'hello.json'))).toBe(false);
+  });
+
+  it('writes and reads a receipt containing a normalized setup kv requirement', async () => {
+    const parsed = validateGhostManifest({
+      schemaVersion: 2,
+      id: 'hello',
+      name: 'Hello',
+      version: '1.0.0',
+      kind: 'chip',
+      entry: 'main.js',
+      settingsHtml: 'settings.html',
+      slots: ['tool'],
+      tools: [{ name: 'do_thing', description: 'Do something' }],
+      setup: {
+        requires: [{ anyOf: [{ kv: 'repoDir', label: '本机 cindy 项目目录' }] }],
+      },
+    });
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) return;
+
+    const receipt = createGhostInstallReceipt({
+      manifest: parsed.manifest,
+      localeResources: {},
+      enabled: true,
+      trust: {
+        level: 'unverified',
+        publisherSigned: false,
+        publisherVerified: false,
+        reviewed: false,
+      },
+      skillContentSha256: {},
+    });
+
+    await store.write(receipt);
+    expect(store.read('hello')).toMatchObject({
+      state: 'approved',
+      receipt: {
+        manifest: {
+          setup: {
+            requires: [
+              { anyOf: [{ kind: 'kv', key: 'repoDir', label: '本机 cindy 项目目录' }] },
+            ],
+          },
+        },
+      },
+    });
   });
 
   it('treats only a missing migration marker as absent', () => {

--- a/apps/desktop/src/main/cindy-brain/__tests__/ghostInstallReceipt.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/ghostInstallReceipt.test.ts
@@ -8,6 +8,7 @@ import { validateGhostManifest } from '../../../shared/ghost';
 
 import {
   createGhostInstallReceipt,
+  type GhostInstallReceipt,
   GhostInstallReceiptStore,
 } from '../ghostInstallReceipt';
 
@@ -29,6 +30,57 @@ describe('GhostInstallReceiptStore cleanup', () => {
     vi.restoreAllMocks();
     await fs.promises.rm(workDir, { recursive: true, force: true });
   });
+
+  function createSetupReceipt(): GhostInstallReceipt {
+    const parsed = validateGhostManifest({
+      schemaVersion: 2,
+      id: 'hello',
+      name: 'Hello',
+      version: '1.0.0',
+      kind: 'chip',
+      entry: 'main.js',
+      settingsHtml: 'settings.html',
+      slots: ['tool', 'network'],
+      tools: [{ name: 'do_thing', description: 'Do something' }],
+      network: {
+        hosts: ['api.example.com'],
+        secrets: [
+          {
+            key: 'api_key',
+            label: 'API Key',
+            inject: { header: 'Authorization', format: 'Bearer {value}' },
+          },
+        ],
+        connections: [
+          {
+            key: 'account',
+            label: 'Account',
+            inject: { header: 'X-Account', format: '{value}' },
+          },
+        ],
+      },
+      setup: {
+        requires: [
+          { anyOf: ['secret:api_key'] },
+          { anyOf: ['connection:account', { kv: 'repoDir', label: '本机 cindy 项目目录' }] },
+        ],
+      },
+    });
+    if (!parsed.ok) throw new Error(parsed.reason);
+
+    return createGhostInstallReceipt({
+      manifest: parsed.manifest,
+      localeResources: {},
+      enabled: true,
+      trust: {
+        level: 'unverified',
+        publisherSigned: false,
+        publisherVerified: false,
+        reviewed: false,
+      },
+      skillContentSha256: {},
+    });
+  }
 
   it('removes a regular receipt and managed snapshot tree', async () => {
     const receipt = path.join(stateRoot, 'hello.json');
@@ -118,49 +170,60 @@ describe('GhostInstallReceiptStore cleanup', () => {
     expect(fs.existsSync(path.join(stateRoot, 'hello.json'))).toBe(false);
   });
 
-  it('writes and reads a receipt containing a normalized setup kv requirement', async () => {
-    const parsed = validateGhostManifest({
-      schemaVersion: 2,
-      id: 'hello',
-      name: 'Hello',
-      version: '1.0.0',
-      kind: 'chip',
-      entry: 'main.js',
-      settingsHtml: 'settings.html',
-      slots: ['tool'],
-      tools: [{ name: 'do_thing', description: 'Do something' }],
-      setup: {
-        requires: [{ anyOf: [{ kv: 'repoDir', label: '本机 cindy 项目目录' }] }],
-      },
-    });
-    expect(parsed.ok).toBe(true);
-    if (!parsed.ok) return;
-
-    const receipt = createGhostInstallReceipt({
-      manifest: parsed.manifest,
-      localeResources: {},
-      enabled: true,
-      trust: {
-        level: 'unverified',
-        publisherSigned: false,
-        publisherVerified: false,
-        reviewed: false,
-      },
-      skillContentSha256: {},
-    });
-
+  it('writes setup in the author format accepted by the v0.1.48 receipt reader', async () => {
+    const receipt = createSetupReceipt();
     await store.write(receipt);
+
+    const persisted = JSON.parse(
+      await fs.promises.readFile(path.join(stateRoot, 'hello.json'), 'utf8'),
+    ) as { manifest: unknown };
+    expect(persisted.manifest).toMatchObject({
+      setup: {
+        requires: [
+          { anyOf: ['secret:api_key'] },
+          {
+            anyOf: [
+              'connection:account',
+              { kv: 'repoDir', label: '本机 cindy 项目目录' },
+            ],
+          },
+        ],
+      },
+    });
+    // v0.1.48 reads receipt manifests through this author-format validator.
+    expect(validateGhostManifest(persisted.manifest).ok).toBe(true);
+
     expect(store.read('hello')).toMatchObject({
       state: 'approved',
       receipt: {
         manifest: {
           setup: {
             requires: [
-              { anyOf: [{ kind: 'kv', key: 'repoDir', label: '本机 cindy 项目目录' }] },
+              { anyOf: [{ kind: 'secret', key: 'api_key' }] },
+              {
+                anyOf: [
+                  { kind: 'connection', key: 'account' },
+                  { kind: 'kv', key: 'repoDir', label: '本机 cindy 项目目录' },
+                ],
+              },
             ],
           },
         },
       },
+    });
+  });
+
+  it('still reads normalized setup receipts emitted by affected builds', async () => {
+    const receipt = createSetupReceipt();
+    await fs.promises.writeFile(
+      path.join(stateRoot, 'hello.json'),
+      `${JSON.stringify(receipt, null, 2)}\n`,
+      'utf8',
+    );
+
+    expect(store.read('hello')).toMatchObject({
+      state: 'approved',
+      receipt: { manifest: receipt.manifest },
     });
   });
 

--- a/apps/desktop/src/main/cindy-brain/ghostInstallReceipt.ts
+++ b/apps/desktop/src/main/cindy-brain/ghostInstallReceipt.ts
@@ -7,8 +7,8 @@ import {
   GHOST_LOCALE_MAX_BYTES,
   GHOST_SKILL_MD_MAX_BYTES,
   isValidGhostId,
-  validateGhostManifest,
   validateGhostManifestLocaleResource,
+  validateNormalizedGhostManifest,
   type GhostManifest,
   type GhostManifestLocaleResource,
   type GhostTrustInfo,
@@ -1079,7 +1079,7 @@ function validateReceipt(
   if (typeof value.revision !== 'string' || !isRevision(value.revision)) {
     return { ok: false, reason: 'receipt revision 不合法' };
   }
-  const manifestResult = validateGhostManifest(value.manifest);
+  const manifestResult = validateNormalizedGhostManifest(value.manifest);
   if (!manifestResult.ok || manifestResult.manifest.id !== expectedId) {
     return {
       ok: false,

--- a/apps/desktop/src/main/cindy-brain/ghostInstallReceipt.ts
+++ b/apps/desktop/src/main/cindy-brain/ghostInstallReceipt.ts
@@ -6,6 +6,7 @@ import { readBoundedFileNoFollowSync } from '../utils/readBoundedFile.js';
 import {
   GHOST_LOCALE_MAX_BYTES,
   GHOST_SKILL_MD_MAX_BYTES,
+  ghostManifestToAuthorFormat,
   isValidGhostId,
   validateGhostManifestLocaleResource,
   validateNormalizedGhostManifest,
@@ -273,8 +274,12 @@ export class GhostInstallReceiptStore {
       root,
       `.${receipt.id}-${process.pid}-${crypto.randomBytes(6).toString('hex')}.tmp`,
     );
+    const persistedReceipt = {
+      ...validated.receipt,
+      manifest: ghostManifestToAuthorFormat(validated.receipt.manifest),
+    };
     try {
-      await fs.promises.writeFile(temp, `${JSON.stringify(receipt, null, 2)}\n`, {
+      await fs.promises.writeFile(temp, `${JSON.stringify(persistedReceipt, null, 2)}\n`, {
         encoding: 'utf8',
         flag: 'wx',
         mode: 0o600,

--- a/apps/desktop/src/main/plugin-market/__tests__/service.test.ts
+++ b/apps/desktop/src/main/plugin-market/__tests__/service.test.ts
@@ -7,7 +7,9 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   diffGhostPermissionItems,
   ghostPermissionBaselineKey,
+  validateGhostManifest,
   type GhostInstallApproval,
+  type GhostManifest,
 } from '../../../shared/ghost.js';
 
 const runtime = vi.hoisted(() => ({
@@ -144,6 +146,41 @@ function manifest(
     entry: 'main.js',
     slots,
   };
+}
+
+function setupKvManifest(id = 'cindy-test', version = '1.0.0') {
+  return {
+    ...manifest(id, version),
+    settingsHtml: 'settings.html',
+    setup: {
+      requires: [{ anyOf: [{ kv: 'repoDir', label: '本机 cindy 项目目录' }] }],
+    },
+  };
+}
+
+function setupSecretManifest(id = 'cindy-test', version = '1.0.0') {
+  return {
+    ...manifest(id, version),
+    slots: ['notify', 'network'],
+    settingsHtml: 'settings.html',
+    network: {
+      hosts: ['api.example.com'],
+      secrets: [
+        {
+          key: 'api_key',
+          label: 'API key',
+          inject: { header: 'Authorization', format: 'Bearer {value}' },
+        },
+      ],
+    },
+    setup: { requires: [{ anyOf: ['secret:api_key'] }] },
+  };
+}
+
+function normalizedManifest(raw: unknown): GhostManifest {
+  const validated = validateGhostManifest(raw);
+  if (!validated.ok) throw new Error(validated.reason);
+  return validated.manifest;
 }
 
 function summary(overrides: Partial<VisiblePluginSummary> = {}): VisiblePluginSummary {
@@ -506,6 +543,40 @@ describe('PluginMarketService migration and defaultInstall', () => {
     });
   });
 
+  it('installs a default package whose permission cap contains normalized setup requirements', async () => {
+    const item = summary({ defaultInstall: true });
+    const rawManifest = setupKvManifest();
+    const approvedManifest = normalizedManifest(rawManifest);
+    const h = harness([item]);
+    h.api.detail.mockResolvedValueOnce({
+      ...item,
+      currentRelease: { ...item.currentRelease, manifest: rawManifest },
+    } as unknown as VisiblePluginDetail);
+    runtime.install.mockImplementation(async () => {
+      const ghost = {
+        manifest: { ...approvedManifest },
+        dir: '/userData/cindy-brain/cindy-test',
+        enabled: true,
+      };
+      runtime.ghosts = [ghost];
+      return ghost;
+    });
+
+    await expect(h.service.snapshot()).resolves.toMatchObject({
+      items: [{ installState: 'installed', enabled: true }],
+    });
+    expect(runtime.install).toHaveBeenCalledWith(
+      expect.stringMatching(/\.cindy$/),
+      expect.objectContaining({
+        permissionPolicy: {
+          mode: 'cap',
+          manifest: approvedManifest,
+          sourceType: 'server',
+        },
+      }),
+    );
+  });
+
   it('returns a Renderer snapshot before a default install download finishes', async () => {
     const item = summary({ defaultInstall: true });
     const installDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cindy-market-deferred-'));
@@ -655,6 +726,36 @@ describe('PluginMarketService migration and defaultInstall', () => {
     expect(h.api.listAll).toHaveBeenCalledTimes(1);
     // 锁定装完即开的最终结果:装入入口返回的 ghost 必须是启用态。
     expect(ghost?.enabled).toBe(true);
+  });
+
+  it('manual market install accepts the normalized setup manifest returned by detail', async () => {
+    const item = summary();
+    const rawManifest = setupSecretManifest();
+    const reviewedManifest = normalizedManifest(rawManifest);
+    const h = harness([item]);
+    h.api.detail.mockResolvedValueOnce({
+      ...item,
+      currentRelease: { ...item.currentRelease, manifest: rawManifest },
+    } as unknown as VisiblePluginDetail);
+    runtime.install.mockResolvedValue({
+      manifest: reviewedManifest,
+      dir: '/userData/cindy-brain/cindy-test',
+      enabled: true,
+    });
+
+    await expect(
+      h.service.install(item.id, {
+        ...reviewedInstallOptions(item),
+        expectedManifest: reviewedManifest,
+      }),
+    ).resolves.toMatchObject({
+      ghost: {
+        manifest: {
+          setup: { requires: [{ anyOf: [{ kind: 'secret', key: 'api_key' }] }] },
+        },
+      },
+    });
+    expect(runtime.install).toHaveBeenCalledOnce();
   });
 
   it('installs the explicitly selected official entry when another entry shares its ghostId', async () => {
@@ -1325,6 +1426,56 @@ describe('PluginMarketService migration and defaultInstall', () => {
       permissions: null,
       hasPermissionExpansion: false,
     });
+  });
+
+  it('silently upgrades a default package whose reviewed manifest contains normalized setup', async () => {
+    const item = summary({
+      scope: 'organization',
+      organizationId: 'org-1',
+      defaultInstall: true,
+      currentRelease: {
+        ...summary().currentRelease,
+        id: 'release-2',
+        version: '2.0.0',
+      },
+    });
+    const oldManifest = manifest(item.ghostId, '1.0.0');
+    const rawManifest = setupSecretManifest(item.ghostId, '2.0.0');
+    const upgradedManifest = normalizedManifest(rawManifest);
+    const installDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cindy-market-setup-upgrade-'));
+    roots.push(installDir);
+    fs.writeFileSync(path.join(installDir, 'ghost.json'), JSON.stringify(oldManifest));
+    runtime.ghosts = [{ manifest: oldManifest, dir: installDir, enabled: true }];
+    const h = harness([item]);
+    h.ledger.upsertInstallation({
+      ...recordForTest(item),
+      releaseId: 'release-1',
+      version: '1.0.0',
+      manifestDigest: ghostManifestDigest(oldManifest),
+    });
+    h.api.detail.mockResolvedValueOnce({
+      ...item,
+      currentRelease: { ...item.currentRelease, manifest: rawManifest },
+    } as unknown as VisiblePluginDetail);
+    runtime.install.mockImplementationOnce(async () => {
+      const ghost = { manifest: { ...upgradedManifest }, dir: installDir, enabled: true };
+      runtime.ghosts = [ghost];
+      return ghost;
+    });
+
+    await expect(h.service.snapshot()).resolves.toMatchObject({
+      items: [{ installState: 'installed', version: '2.0.0' }],
+    });
+    expect(runtime.install).toHaveBeenCalledWith(
+      expect.stringMatching(/\.cindy$/),
+      expect.objectContaining({
+        permissionPolicy: {
+          mode: 'cap',
+          manifest: upgradedManifest,
+          sourceType: 'server',
+        },
+      }),
+    );
   });
 
   it('integration: snapshot upgrades an organization defaultInstall release and consumes its notice', async () => {

--- a/apps/desktop/src/main/plugin-market/service.ts
+++ b/apps/desktop/src/main/plugin-market/service.ts
@@ -21,6 +21,7 @@ import {
   isSafeGhostRelativePath,
   isOfficialGhostId,
   validateGhostManifest,
+  validateNormalizedGhostManifest,
   type GhostManifest,
   type InstalledGhost,
 } from '../../shared/ghost.js';
@@ -917,7 +918,7 @@ export class PluginMarketService {
       // install.ts:184-191 的打包前比对同向（但此处比对的是预览清单而非
       // 实际打包字节，名字/版本/作者差异不在此处检测）。
       if (options.expectedManifest !== undefined) {
-        const reviewed = validateGhostManifest(options.expectedManifest);
+        const reviewed = validateNormalizedGhostManifest(options.expectedManifest);
         // 畸形 payload 会造成 ghostPermissionBaselineKey crash（slots.includes
         // 等字段解引用），先验证再比对。验证失败时直接拒——审阅过的清单连基本
         // 结构都不对，不能信任。
@@ -1629,14 +1630,14 @@ export class PluginMarketService {
     }
 
     const reviewedManifest = options.reviewedManifest
-      ? validateGhostManifest(options.reviewedManifest)
+      ? validateNormalizedGhostManifest(options.reviewedManifest)
       : null;
     if (reviewedManifest && !reviewedManifest.ok) {
       throwIpcError('GHOST_FILE_INVALID', 'This Plugin manifest is not supported');
     }
     const permissionCap =
       options.permissionPolicy?.mode === 'cap'
-        ? validateGhostManifest(options.permissionPolicy.manifest)
+        ? validateNormalizedGhostManifest(options.permissionPolicy.manifest)
         : null;
     if (permissionCap && !permissionCap.ok) {
       throwIpcError('GHOST_FILE_INVALID', 'This Plugin manifest is not supported');

--- a/apps/desktop/src/shared/__tests__/ghost.test.ts
+++ b/apps/desktop/src/shared/__tests__/ghost.test.ts
@@ -32,6 +32,7 @@ import {
   resolveGhostManifestLocale,
   validateGhostManifest,
   validateGhostManifestLocaleResource,
+  validateNormalizedGhostManifest,
   withGhostResolvedLocale,
   type GhostManifest,
 } from '../ghost';
@@ -2494,6 +2495,26 @@ describe('ghost · setup 就绪声明校验(使用前置检查,2026-07-21)', () 
         },
       ],
     });
+  });
+
+  it('Host 标准化清单可重复校验，但作者入口仍拒绝内部 setup 格式', () => {
+    const parsed = validateGhostManifest({
+      ...setupBase(),
+      setup: {
+        requires: [
+          { anyOf: ['secret:api_key_a'] },
+          { anyOf: ['connection:inst_conn', { kv: 'default_repo', label: '默认仓库' }] },
+        ],
+      },
+    });
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) return;
+
+    expect(validateGhostManifest(parsed.manifest).ok).toBe(false);
+    const repeated = validateNormalizedGhostManifest(parsed.manifest);
+    expect(repeated.ok).toBe(true);
+    if (!repeated.ok) return;
+    expect(repeated.manifest).toEqual(parsed.manifest);
   });
 
   it('不声明 setup 时清单不带该字段(缺省走宿主启发式)', () => {

--- a/apps/desktop/src/shared/ghost.ts
+++ b/apps/desktop/src/shared/ghost.ts
@@ -5321,7 +5321,11 @@ export function validateGhostManifest(raw: unknown): ManifestValidation {
  * validateGhostManifest，因此作者直接写内部格式仍会被拒绝。
  */
 export function validateNormalizedGhostManifest(raw: unknown): ManifestValidation {
-  if (!isPlainObject(raw) || raw.setup === undefined) return validateGhostManifest(raw);
+  // Durable Host state is written in author format so released clients can read it
+  // after a rollback. Still accept normalized snapshots produced by affected dev
+  // builds and passed between current Host code paths.
+  const authorResult = validateGhostManifest(raw);
+  if (authorResult.ok || !isPlainObject(raw) || raw.setup === undefined) return authorResult;
   if (!isPlainObject(raw.setup) || !Array.isArray(raw.setup.requires)) {
     return { ok: false, reason: '标准化清单 setup 必须是带 requires 数组的对象' };
   }
@@ -5353,6 +5357,29 @@ export function validateNormalizedGhostManifest(raw: unknown): ManifestValidatio
   }
 
   return validateGhostManifest({ ...raw, setup: { requires } });
+}
+
+/**
+ * 把 Host 归一化清单投影回 ghost.json 作者格式，供跨版本持久化。
+ *
+ * receipt schema v2 已随 v0.1.48 发布；旧版读取时会直接调用
+ * validateGhostManifest，因此不能把内部 `{ kind, key }` setup 形态写盘。
+ */
+export function ghostManifestToAuthorFormat(manifest: GhostManifest): Record<string, unknown> {
+  if (manifest.setup === undefined) return { ...manifest };
+  return {
+    ...manifest,
+    setup: {
+      requires: manifest.setup.requires.map((group) => ({
+        anyOf: group.anyOf.map((requirement) => {
+          if (requirement.kind === 'kv') {
+            return { kv: requirement.key, label: requirement.label };
+          }
+          return `${requirement.kind}:${requirement.key}`;
+        }),
+      })),
+    },
+  };
 }
 
 /**

--- a/apps/desktop/src/shared/ghost.ts
+++ b/apps/desktop/src/shared/ghost.ts
@@ -5313,6 +5313,49 @@ export function validateGhostManifest(raw: unknown): ManifestValidation {
 }
 
 /**
+ * 校验 Host 已归一化的 GhostManifest 快照（例如批准 receipt 中的 manifest）。
+ *
+ * ghost.json 的作者格式与运行期格式只在 setup 条目上不同：作者写字符串引用或
+ * `{ kv, label }`，Host 归一化后统一保存 `{ kind, key, label? }`。这里仅把已归一化
+ * setup 还原为作者格式，再复用同一套完整清单校验；原始 ghost.json 仍必须走
+ * validateGhostManifest，因此作者直接写内部格式仍会被拒绝。
+ */
+export function validateNormalizedGhostManifest(raw: unknown): ManifestValidation {
+  if (!isPlainObject(raw) || raw.setup === undefined) return validateGhostManifest(raw);
+  if (!isPlainObject(raw.setup) || !Array.isArray(raw.setup.requires)) {
+    return { ok: false, reason: '标准化清单 setup 必须是带 requires 数组的对象' };
+  }
+
+  const requires: Array<{ anyOf: Array<string | { kv: unknown; label: unknown }> }> = [];
+  for (const group of raw.setup.requires) {
+    if (!isPlainObject(group) || !Array.isArray(group.anyOf)) {
+      return { ok: false, reason: '标准化清单 setup.requires 每组必须是带 anyOf 数组的对象' };
+    }
+    const anyOf: Array<string | { kv: unknown; label: unknown }> = [];
+    for (const requirement of group.anyOf) {
+      if (!isPlainObject(requirement)) {
+        return { ok: false, reason: '标准化清单 setup 条目必须是 { kind, key } 对象' };
+      }
+      if (requirement.kind === 'secret' || requirement.kind === 'connection') {
+        if (typeof requirement.key !== 'string') {
+          return { ok: false, reason: '标准化清单 setup 条目的 key 必须是字符串' };
+        }
+        anyOf.push(`${requirement.kind}:${requirement.key}`);
+        continue;
+      }
+      if (requirement.kind === 'kv') {
+        anyOf.push({ kv: requirement.key, label: requirement.label });
+        continue;
+      }
+      return { ok: false, reason: '标准化清单 setup 条目的 kind 不受支持' };
+    }
+    requires.push({ anyOf });
+  }
+
+  return validateGhostManifest({ ...raw, setup: { requires } });
+}
+
+/**
  * ── 管子(脑机接口)消息协议(docs/dev-rules/plugin-security-and-authoring.md)──
  *
  * 下行(主机 → 电子脑,'ghost-pipe:message' 单向推):


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复插件批准 receipt 与 Host 标准化 manifest 之间的格式边界：原始服务器或插件包中的 `ghost.json` 继续使用作者格式严格校验，Host 内部传递的标准化清单使用专用校验入口。

同时保证回滚兼容：receipt 内存中继续使用标准化 `setup`，落盘时投影回已发布 v0.1.48 可读取的作者格式；新版读取端同时兼容作者格式和受影响开发版曾写出的 `{ kind, key }` 标准化格式。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无；修复 PR #1916 后出现的插件兼容回归
- 本 PR 包含：receipt、市场手动安装、默认安装/升级、内置插件播种中的标准化清单校验；receipt 回滚兼容；对应回归测试
- 明确不包含：不修改插件作者清单格式、不修改 receipt schema、不改变权限投影、不修改 UI
- 用户可见变化：带任意 `setup` 声明的插件可以正常迁移、安装、升级、播种和重新确认；新版写出的 receipt 回滚到 v0.1.48 后仍可读取
- 是否存在 breaking change：无
- 多端适配：不涉及 workdir、agent 进程、会话数据、IPC/device-link 或 Mobile 入口

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/shared/__tests__/ghost.test.ts src/main/cindy-brain/__tests__/ghostInstallReceipt.test.ts src/main/cindy-brain/__tests__/GhostManager.test.ts src/main/plugin-market/__tests__/service.test.ts
结果：4 个测试文件通过；522 个测试通过，1 个既有测试跳过

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm test:unit:related
结果：apps/desktop unit 通过

pnpm check:dco
结果：3 个提交通过 DCO 检查

git diff --check
结果：通过
```

### 手工验证

- Windows / Global remote 模式启动命名隔离沙盒：`pnpm restart:desktop:remote --region=global --isolated=gentle-dijkstra`
- 2026-08-14 用户完成 dev 验收并确认通过

### 未执行的验证

- 未执行完整 `pnpm test:unit`：本次改动集中在 Desktop，已运行仓库强制的相关单测门禁和四条受影响链路的定向回归
- 未执行 packaged build：不涉及构建链、原生依赖或发布产物

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [x] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 approval receipt 和 Host 内部标准化 manifest 的校验/持久化边界；原始 `ghost.json` 仍严格校验
- 存量插件影响：无负面影响；旧安装继续无感迁移，新版写出的 receipt 使用 v0.1.48 可读取的作者格式
- 兼容用例：`GhostManager.test.ts` 覆盖旧安装迁移与重新确认，`service.test.ts` 覆盖市场安装和默认安装/升级，`ghostInstallReceipt.test.ts` 覆盖 v0.1.48 回滚读取及受影响开发版 receipt 的向前恢复
- 安全边界：未知 setup kind、非法 key/label、未声明 secret/connection 等继续 fail closed；原始插件不能直接声明内部 `{ kind, key }` 格式
- 作者契约：无需同步 `FORGE_GUIDE`，本次未修改插件作者可见格式或校验规则
- 合并门禁：改到插件批准基座，按仓库规则需要指定把关人明确 Approve 后才能合并
- 回滚 / 降级方式：未修改 schema；可回滚到 v0.1.48，新版落盘 receipt 仍能被旧版读取

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（无需修改作者手册；兼容契约由回归测试锁定）
- [x] 已确认测试结果或说明未执行原因