### PR TITLE
fix(maker-core): 隐藏 Claude Code 的 GitHub 共同作者署名

### DIFF
--- a/packages/maker-core/src/agents/claude-code/__tests__/flag-settings.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/flag-settings.test.ts
@@ -15,16 +15,18 @@ describe('buildClaudeFlagSettings', () => {
           fastMode,
         });
         expect(settings.apiKeyHelper).toBe('');
+        expect(settings.attribution).toEqual({ commit: '', pr: '' });
       }
     }
   });
 
-  it('默认形态(无 memory override / fast 关)只含 showThinkingSummaries + apiKeyHelper', () => {
+  it('默认形态(无 memory override / fast 关)只含 showThinkingSummaries + apiKeyHelper + 空 attribution', () => {
     expect(
       buildClaudeFlagSettings({ showThinkingSummaries: true, fastMode: false }),
     ).toEqual({
       showThinkingSummaries: true,
       apiKeyHelper: '',
+      attribution: { commit: '', pr: '' },
     });
   });
 
@@ -34,6 +36,7 @@ describe('buildClaudeFlagSettings', () => {
     ).toEqual({
       showThinkingSummaries: false,
       apiKeyHelper: '',
+      attribution: { commit: '', pr: '' },
       autoMemoryEnabled: true,
       autoDreamEnabled: true,
     });

--- a/packages/maker-core/src/agents/claude-code/flag-settings.ts
+++ b/packages/maker-core/src/agents/claude-code/flag-settings.ts
@@ -26,6 +26,16 @@
  * - 远端 daemon:   远端机器用户的 apiKeyHelper 同样被屏蔽(远端也是 host 托管路由)。
  * 运行时 q.applyFlagSettings() 是 merge 语义(只并入传入字段),中途 toggle
  * fastMode / effort 不会丢掉本覆盖。
+ *
+ * ## attribution 恒置空 —— 不把 Claude 写成 GitHub 共同作者
+ *
+ * Claude Code 默认在 commit / PR 末尾加 `Co-Authored-By: Claude <noreply@anthropic.com>`
+ * 与 `Generated with Claude Code`。GitHub 会把前者解析成共同作者,用户用 Cindy
+ * 提交任意仓库时 Claude 会出现在 Contributors 里。官方 settings 把空字符串定义为
+ * 隐藏该段署名;flag 层无条件覆盖 user / project / local,本地与远端 cc-mgr 共用。
+ *
+ * 这与 `CLAUDE_CODE_ATTRIBUTION_HEADER` 不是同一件事:后者是打给 Anthropic API
+ * 的计费头(issue #758),订阅直连时必须保留。这里只关 git / GitHub 可见署名。
  */
 
 import type { Settings } from '@anthropic-ai/claude-agent-sdk';
@@ -61,6 +71,11 @@ export function buildClaudeFlagSettings(input: ClaudeFlagSettingsInput): Setting
     showThinkingSummaries: input.showThinkingSummaries,
     // 屏蔽用户级 apiKeyHelper,防止它劫持 oauth-spawn 的订阅鉴权(见文件头注释)。
     apiKeyHelper: '',
+    // 空字符串 = 隐藏 Claude Code 默认的 commit / PR 署名(见文件头注释)。
+    attribution: {
+      commit: '',
+      pr: '',
+    },
     ...(input.memoryOverride !== undefined && {
       autoMemoryEnabled: input.memoryOverride,
       autoDreamEnabled: input.memoryOverride,


### PR DESCRIPTION
## 这次改了什么

### 摘要

用 Cindy 里的 Claude Code 提交或开 PR 时，默认会在 commit / PR 末尾加上 `Co-Authored-By: Claude <noreply@anthropic.com>`。GitHub 会把这行解析成共同作者，于是用户自己的仓库 Contributors 里会出现 Claude。

这次在 Cindy 启动 Claude Code 时注入的最高优先级 flag settings 里，把官方 `attribution.commit` / `attribution.pr` 置成空字符串。官方文档和捆绑 SDK 都把空字符串定义为隐藏这段署名。本地会话和远端 cc-mgr 共用同一份设置。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：`buildClaudeFlagSettings()` 无条件注入 `attribution: { commit: '', pr: '' }`，并补单测
- 明确不包含：不改 Cindy 仓自己的贡献规范；不改写已推送的历史 commit；不改 `CLAUDE_CODE_ATTRIBUTION_HEADER`（那是 Anthropic API 计费头，issue #758）
- 用户可见变化：用 Cindy 的 Claude Code 新提交 / 新开 PR 时，默认不再把 Claude 写成 GitHub 共同作者
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
cd /Users/dash/Code/Cindy/cindy-hide-claude-git-attribution
pnpm test:unit:related
结果：PASS（maker-core related、以及 related 选中的 desktop / lizi-mcps / orca-workflow）

pnpm --filter @cindy/maker-core run typecheck
结果：通过

pnpm --filter @cindy/maker-core exec vitest run src/agents/claude-code/__tests__/flag-settings.test.ts
结果：6 passed

bash /Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh <worktree>
结果：GATE_EXIT=0
```

### 手工验证

不涉及。未在运行中的 Cindy 里实际走一遍 commit / 开 PR，因为这是注入给下次 spawn 的 Claude Code settings，现有会话不会热更新。

### 未执行的验证

未用 Cindy 实际对一个外部仓库做一次 commit / 开 PR 目检。合并后新开的 Claude Code 会话才会带上这份 flag settings。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Cindy 拉起的 Claude Code 会话（本地与远端）。用户在终端自己跑 `claude` 不受影响。已推送的历史 commit 不会变。
- 回滚 / 降级方式：回退本 PR。无。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
