### PR TITLE
fix(desktop): 文字模式任务信息槽按内容收缩

### DIFF
--- a/apps/desktop/src/renderer/__tests__/automationGeneratedSessions.test.ts
+++ b/apps/desktop/src/renderer/__tests__/automationGeneratedSessions.test.ts
@@ -787,7 +787,9 @@ describe('automation-generated sessions', () => {
     expect(source).toContain('runningSessionIds,');
     // 组头右侧的时间文字与普通任务行的信息槽(SessionInfoMeta)同款字体 / 色号,
     // 含 tabular-nums(2026-08-12 用户裁决;C 期给普通行加等宽数字时组头漏跟)。
-    expect(source).toContain("'flex items-center gap-1 text-xs font-medium tabular-nums'");
+    expect(source).toContain(
+      "'col-start-1 row-start-1 flex items-center gap-1 text-xs font-medium tabular-nums'",
+    );
     expect(source).toContain("'text-sidebar-action-icon'");
   });
 

--- a/apps/desktop/src/renderer/__tests__/sidebarRemoteProjectIcon.test.ts
+++ b/apps/desktop/src/renderer/__tests__/sidebarRemoteProjectIcon.test.ts
@@ -60,7 +60,7 @@ describe('sidebar remote project icon', () => {
     );
     // C 期起右侧时间槽由 SessionInfoMeta 承担(任务信息复选),仍在同一让位容器内。
     expect(sessionItemSource).toMatch(
-      /<div className="group\/slot relative ml-auto flex h-6 shrink-0 items-center justify-end min-w-14">[\s\S]*?<WorktreeBadge[\s\S]*?<SessionInfoMeta/,
+      /<div className="group\/slot relative ml-auto flex h-6 shrink-0 items-center justify-end">[\s\S]*?<WorktreeBadge[\s\S]*?<SessionInfoMeta/,
     );
     expect(sessionCardSource).toContain('function TimeActionsSlot');
     expect(sessionCardSource).not.toMatch(/function TimeActionsSlot[\s\S]*?remoteIconKind/);

--- a/apps/desktop/src/renderer/__tests__/sidebarSessionTime.test.ts
+++ b/apps/desktop/src/renderer/__tests__/sidebarSessionTime.test.ts
@@ -105,7 +105,11 @@ describe('SessionItem activity time', () => {
 
   it('keeps the archive shortcut in the same right-side slot instead of crowding the time', () => {
     expect(sessionItemSource).toContain(
-      'relative ml-auto flex h-6 shrink-0 items-center justify-end min-w-14',
+      'relative ml-auto flex h-6 shrink-0 items-center justify-end',
+    );
+    // 文字模式信息槽按内容收缩:「任务信息 = 无」或短时间都不能再预留 56px 空位挤标题。
+    expect(sessionItemSource).not.toMatch(
+      /group\/slot relative ml-auto flex h-6 shrink-0 items-center justify-end min-w-14/,
     );
     expect(sessionItemSource).toContain('<WorktreeBadge sessionId={session.id}');
     expect(sessionItemSource).toContain('canQuickArchive && archivePending &&');

--- a/apps/desktop/src/renderer/__tests__/sidebarSessionTime.test.ts
+++ b/apps/desktop/src/renderer/__tests__/sidebarSessionTime.test.ts
@@ -121,7 +121,8 @@ describe('SessionItem activity time', () => {
       'pointer-events-none opacity-0 group-hover:pointer-events-auto group-hover:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100',
     );
     expect(sessionItemSource).toContain('absolute right-0 top-0 flex h-6 items-center gap-0.5');
-    // hover / 菜单打开时不可见操作钮进入文档流,把槽宽撑到真实按钮宽,避免叠到标题上。
+    // hover / 菜单打开时不可见操作钮与信息层叠在同一格,槽宽取较大值而不是相加。
+    expect(sessionItemSource).toContain('grid h-6 grid-cols-[max-content] items-center justify-items-end');
     expect(sessionItemSource).toContain(
       "menuPos === null && 'hidden group-hover:flex group-focus-within/slot:flex'",
     );

--- a/apps/desktop/src/renderer/__tests__/sidebarSessionTime.test.ts
+++ b/apps/desktop/src/renderer/__tests__/sidebarSessionTime.test.ts
@@ -121,5 +121,9 @@ describe('SessionItem activity time', () => {
       'pointer-events-none opacity-0 group-hover:pointer-events-auto group-hover:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100',
     );
     expect(sessionItemSource).toContain('absolute right-0 top-0 flex h-6 items-center gap-0.5');
+    // hover / 菜单打开时不可见操作钮进入文档流,把槽宽撑到真实按钮宽,避免叠到标题上。
+    expect(sessionItemSource).toContain(
+      "menuPos === null && 'hidden group-hover:flex group-focus-within/slot:flex'",
+    );
   });
 });

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/AutomationSessionGroupItem.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/AutomationSessionGroupItem.tsx
@@ -421,6 +421,7 @@ export function AutomationSessionGroupItem({
               button 点击后焦点常驻行内,整行 group-focus-within 会让选中态
               (非 hover)的 meta 文本被永久隐藏,与 SessionItem 同款修法。 */}
           <div className="group/slot relative ml-auto flex h-6 max-w-[96px] shrink-0 items-center justify-end">
+            <div className="grid h-6 max-w-[96px] grid-cols-[max-content] items-center justify-items-end">
             {/* 右侧状态槽 —— 与 SessionItem 同款五档色表 / 图标尺寸(size-4 wrapper +
                 size-2 dot / size-12 spinner),让分组头和普通任务行状态语义视觉可比。
                 showRightStatus=true 时渲染状态图标(error/awaiting/done 圆点 + running
@@ -432,7 +433,7 @@ export function AutomationSessionGroupItem({
                 // tabular-nums(C 期给普通行加的等宽数字,分组头当时漏跟),
                 // 让「9 分钟 / 4 小时」这类时间在两种行里对齐、粗细一致
                 // (2026-08-12 用户裁决)。
-                'flex items-center gap-1 text-xs font-medium tabular-nums',
+                'col-start-1 row-start-1 flex items-center gap-1 text-xs font-medium tabular-nums',
                 hasActiveHidden
                   ? 'text-[var(--sidebar-item-active-foreground)]'
                   : 'text-sidebar-action-icon',
@@ -518,7 +519,7 @@ export function AutomationSessionGroupItem({
               <div
                 aria-hidden
                 className={cn(
-                  'invisible h-6 w-[42px] shrink-0',
+                  'invisible col-start-1 row-start-1 h-6 w-[42px]',
                   !menuOpen && 'hidden group-hover:block group-focus-within/slot:block',
                 )}
               />
@@ -611,6 +612,7 @@ export function AutomationSessionGroupItem({
               </div>
               </>
             )}
+            </div>
           </div>
         </div>
       </Tip>

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/AutomationSessionGroupItem.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/AutomationSessionGroupItem.tsx
@@ -420,7 +420,7 @@ export function AutomationSessionGroupItem({
           {/* focus 隐藏条件用命名 group(/slot) 收窄到本槽位:行内 toggle/title
               button 点击后焦点常驻行内,整行 group-focus-within 会让选中态
               (非 hover)的 meta 文本被永久隐藏,与 SessionItem 同款修法。 */}
-          <div className="group/slot relative ml-auto flex h-6 min-w-14 max-w-[96px] shrink-0 items-center justify-end">
+          <div className="group/slot relative ml-auto flex h-6 max-w-[96px] shrink-0 items-center justify-end">
             {/* 右侧状态槽 —— 与 SessionItem 同款五档色表 / 图标尺寸(size-4 wrapper +
                 size-2 dot / size-12 spinner),让分组头和普通任务行状态语义视觉可比。
                 showRightStatus=true 时渲染状态图标(error/awaiting/done 圆点 + running

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/AutomationSessionGroupItem.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/AutomationSessionGroupItem.tsx
@@ -514,6 +514,14 @@ export function AutomationSessionGroupItem({
               )}
             </div>
             {scheduleId && (
+              <>
+              <div
+                aria-hidden
+                className={cn(
+                  'invisible h-6 w-[42px] shrink-0',
+                  !menuOpen && 'hidden group-hover:block group-focus-within/slot:block',
+                )}
+              />
               <div
                 className={cn(
                   'absolute right-0 top-0 flex h-6 items-center gap-0.5',
@@ -601,6 +609,7 @@ export function AutomationSessionGroupItem({
                   </DropdownMenuContent>
                 </DropdownMenu>
               </div>
+              </>
             )}
           </div>
         </div>

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionCard.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionCard.tsx
@@ -1246,6 +1246,9 @@ function TimeActionsSlot({
       </div>
 
       {canQuickArchive && archivePending && (
+        <span aria-hidden className="invisible inline-block h-[22px] w-14 shrink-0" />
+      )}
+      {canQuickArchive && archivePending && (
         <button
           ref={confirmPillRef}
           type="button"
@@ -1270,45 +1273,57 @@ function TimeActionsSlot({
       )}
 
       {!archivePending && (
-        <div
-          // 渐显(120ms)配 pointer-events 守卫:淡出期间按钮不占鼠标位置,
-          // 不会拦下卡片点击;键盘焦点不受 pointer-events 影响。
-          className={cn(
-            'absolute right-0 top-1/2 flex -translate-y-1/2 items-center gap-0.5',
-            'transition-opacity duration-[120ms]',
-            menuOpen
-              ? 'opacity-100'
-              : 'pointer-events-none opacity-0 group-hover/card:pointer-events-auto group-hover/card:opacity-100 group-focus-within/slot:pointer-events-auto group-focus-within/slot:opacity-100',
-          )}
-        >
-          <CardAction
-            variant="list"
-            isActive={isActive}
-            label={t('ccAgent.sidebar.sessionMenu.moreActions')}
-            onClick={onOpenMenu}
+        <>
+          <div
+            aria-hidden
+            className={cn(
+              'invisible flex h-5 items-center gap-0.5',
+              !menuOpen && 'hidden group-hover/card:flex group-focus-within/slot:flex',
+            )}
           >
-            <EllipsisVertical size={14} strokeWidth={2} />
-          </CardAction>
-          {isArchived && canUnarchive ? (
+            <span className="size-5 shrink-0" />
+            {(isArchived && canUnarchive) || canQuickArchive ? <span className="size-5 shrink-0" /> : null}
+          </div>
+          <div
+            // 渐显(120ms)配 pointer-events 守卫:淡出期间按钮不占鼠标位置,
+            // 不会拦下卡片点击;键盘焦点不受 pointer-events 影响。
+            className={cn(
+              'absolute right-0 top-1/2 flex -translate-y-1/2 items-center gap-0.5',
+              'transition-opacity duration-[120ms]',
+              menuOpen
+                ? 'opacity-100'
+                : 'pointer-events-none opacity-0 group-hover/card:pointer-events-auto group-hover/card:opacity-100 group-focus-within/slot:pointer-events-auto group-focus-within/slot:opacity-100',
+            )}
+          >
             <CardAction
               variant="list"
               isActive={isActive}
-              label={t('ccAgent.sidebar.sessionMenu.unarchive')}
-              onClick={() => onUnarchive()}
+              label={t('ccAgent.sidebar.sessionMenu.moreActions')}
+              onClick={onOpenMenu}
             >
-              <Undo size={14} strokeWidth={2} />
+              <EllipsisVertical size={14} strokeWidth={2} />
             </CardAction>
-          ) : canQuickArchive ? (
-            <CardAction
-              variant="list"
-              isActive={isActive}
-              label={t('ccAgent.sidebar.sessionMenu.archived')}
-              onClick={() => setArchivePending(true)}
-            >
-              <Archive size={14} strokeWidth={2} />
-            </CardAction>
-          ) : null}
-        </div>
+            {isArchived && canUnarchive ? (
+              <CardAction
+                variant="list"
+                isActive={isActive}
+                label={t('ccAgent.sidebar.sessionMenu.unarchive')}
+                onClick={() => onUnarchive()}
+              >
+                <Undo size={14} strokeWidth={2} />
+              </CardAction>
+            ) : canQuickArchive ? (
+              <CardAction
+                variant="list"
+                isActive={isActive}
+                label={t('ccAgent.sidebar.sessionMenu.archived')}
+                onClick={() => setArchivePending(true)}
+              >
+                <Archive size={14} strokeWidth={2} />
+              </CardAction>
+            ) : null}
+          </div>
+        </>
       )}
     </div>
   );

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionCard.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionCard.tsx
@@ -1225,11 +1225,12 @@ function TimeActionsSlot({
   );
   return (
     <div className="group/slot relative ml-auto flex h-[22px] shrink-0 items-center justify-end">
+      <div className="grid h-[22px] grid-cols-[max-content] items-center justify-items-end">
       {/* 默认内容:worktree + 信息槽;hover / 菜单打开 / archivePending 时淡出让位给操作钮。 */}
       <div
         className={cn(
           // duration 与操作钮的渐显同拍(120ms),让位/回归一进一出同步。
-          'flex items-center gap-1 transition-opacity duration-[120ms]',
+          'col-start-1 row-start-1 flex items-center gap-1 transition-opacity duration-[120ms]',
           !archivePending && 'group-hover/card:opacity-0 group-focus-within/slot:opacity-0',
           (menuOpen || yieldToOrdinalBadge) && 'opacity-0',
           // 确认胶囊覆盖同一槽位时立即隐藏日期，避免 120ms 淡出期间文字叠在一起。
@@ -1246,7 +1247,7 @@ function TimeActionsSlot({
       </div>
 
       {canQuickArchive && archivePending && (
-        <span aria-hidden className="invisible inline-block h-[22px] w-14 shrink-0" />
+        <span aria-hidden className="invisible col-start-1 row-start-1 inline-block h-[22px] w-14" />
       )}
       {canQuickArchive && archivePending && (
         <button
@@ -1277,7 +1278,7 @@ function TimeActionsSlot({
           <div
             aria-hidden
             className={cn(
-              'invisible flex h-5 items-center gap-0.5',
+              'invisible col-start-1 row-start-1 flex h-[22px] items-center gap-0.5',
               !menuOpen && 'hidden group-hover/card:flex group-focus-within/slot:flex',
             )}
           >
@@ -1325,6 +1326,7 @@ function TimeActionsSlot({
           </div>
         </>
       )}
+      </div>
     </div>
   );
 }

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionCard.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionCard.tsx
@@ -814,6 +814,7 @@ export function SessionCard({
                 canUnarchive={!remoteWritesBlocked}
                 onUnarchive={handleUnarchiveSelect}
                 yieldToOrdinalBadge={ordinalBadgeLabel != null}
+                ordinalBadgeLabel={ordinalBadgeLabel}
               />
             )}
           </div>
@@ -1191,6 +1192,7 @@ function TimeActionsSlot({
   onArchiveNow,
   onUnarchive,
   yieldToOrdinalBadge = false,
+  ordinalBadgeLabel,
 }: {
   sessionId: string;
   /** 任务信息复选(C 期)需要读 totalTokenUsage / totalMoney 等字段。 */
@@ -1209,6 +1211,7 @@ function TimeActionsSlot({
   onUnarchive: () => void;
   /** mod+1..9 序号徽标出现时让位:徽标独占右缘,不与时间/badge 并排。 */
   yieldToOrdinalBadge?: boolean;
+  ordinalBadgeLabel?: string | null;
 }) {
   const { t } = useTranslation();
   // 任务信息复选(C / C' 期):与 SessionItem 的时间槽同源;默认仅 time 与旧渲染等价。
@@ -1249,6 +1252,14 @@ function TimeActionsSlot({
       {canQuickArchive && archivePending && (
         <span aria-hidden className="invisible col-start-1 row-start-1 inline-block h-[22px] w-14" />
       )}
+      {yieldToOrdinalBadge && ordinalBadgeLabel ? (
+        <span
+          aria-hidden
+          className="invisible col-start-1 row-start-1 inline-flex h-5 items-center px-1.5 py-[2px] text-11 leading-none"
+        >
+          {ordinalBadgeLabel}
+        </span>
+      ) : null}
       {canQuickArchive && archivePending && (
         <button
           ref={confirmPillRef}

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionCard.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionCard.tsx
@@ -1250,7 +1250,12 @@ function TimeActionsSlot({
       </div>
 
       {canQuickArchive && archivePending && (
-        <span aria-hidden className="invisible col-start-1 row-start-1 inline-block h-[22px] w-14" />
+        <span
+          aria-hidden
+          className="invisible col-start-1 row-start-1 inline-flex h-[22px] w-max min-w-14 items-center justify-center whitespace-nowrap rounded-full px-[9px] text-11 font-semibold"
+        >
+          {t('ccAgent.sidebar.sessionMenu.archived')}
+        </span>
       )}
       {yieldToOrdinalBadge && ordinalBadgeLabel ? (
         <span

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionCard.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionCard.tsx
@@ -1258,11 +1258,8 @@ function TimeActionsSlot({
         </span>
       )}
       {yieldToOrdinalBadge && ordinalBadgeLabel ? (
-        <span
-          aria-hidden
-          className="invisible col-start-1 row-start-1 inline-flex h-5 items-center px-1.5 py-[2px] text-11 leading-none"
-        >
-          {ordinalBadgeLabel}
+        <span aria-hidden className="invisible col-start-1 row-start-1 inline-flex">
+          <SessionOrdinalBadgeKbd label={ordinalBadgeLabel} />
         </span>
       ) : null}
       {canQuickArchive && archivePending && (

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionItem.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionItem.tsx
@@ -867,7 +867,7 @@ export const SessionItem = memo(function SessionItem({
         //   indented=true → 左 22px（Project Sessions 缩进,比顶层深一档;
         //     2026-07 用户定稿在 18px 基础上再 +4px 加深层级)
         //   indented=false → 左 12px（Pinned / Unclassified / Dialogue 段）
-        // 右侧固定槽位显示最近活动时间；hover 时 archive 快捷按钮覆盖同一槽位。
+        // 右侧信息槽按内容收缩；hover 时 archive 快捷按钮覆盖同一槽位。
         indented ? 'pl-[22px] pr-2' : 'pl-3 pr-2',
         // 注意:不加 transition-colors —— 行 bg 的 hover/active 变化要瞬时,
         // 否则归档/取消归档后 DOM 列表重排,原 hover bg 在前一个屏幕位置上要
@@ -989,10 +989,11 @@ export const SessionItem = memo(function SessionItem({
           渲染), 与时间同步 hover-fade 让位给 action buttons —— 让右侧只看到一组
           视觉元素, 不和 action buttons 共存。
           archive 快捷按钮 hover/focus 时覆盖整个槽位,避免右侧拥挤;完整菜单仍走右键。
-          min-w-14 保证无 worktree 时仍保留原 56px 槽位(action buttons 锚点),有
-          worktree 时槽位自然撑开以容纳 16px 图标 + 时间。 */}
+          槽宽跟可见内容走:状态点 / worktree / 任务信息有多宽占多宽,「任务信息 =
+          无」且无状态、无 worktree 时宽度归零,把行宽还给标题。操作钮绝对定位叠在
+          槽上,不靠预留 56px 空位当锚点——否则短时间(「刚刚」)和无信息都会挤标题。 */}
       {!isEditing && (
-        <div className="group/slot relative ml-auto flex h-6 shrink-0 items-center justify-end min-w-14">
+        <div className="group/slot relative ml-auto flex h-6 shrink-0 items-center justify-end">
           {/* WorktreeBadge + time 同步 fade-out:hover/菜单打开/archivePending 时
               一起让位,确保只有 action buttons 占住右侧。fade 容器复用同一份条件,
               避免两个元素 fade 时机不一致产生闪烁。
@@ -1017,7 +1018,7 @@ export const SessionItem = memo(function SessionItem({
               <SidebarRightStatusIndicator kind={rightStatusKind} isActive={isActive} />
             ) : (
               // 任务信息复选(C 期):按用户勾选拼装 pr / tokens / cost / time;默认仅
-              // time,与旧时间槽渲染等价。全不选 → 槽位留空(min-w-14 仍保住 action 锚点)。
+              // time,与旧时间槽渲染等价。全不选 → SessionInfoMeta 渲染 null,槽宽归零。
               <SessionInfoMeta pieces={infoPieces} prRef={infoPrRef} isActive={isActive} />
             )}
           </div>

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionItem.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionItem.tsx
@@ -1051,8 +1051,9 @@ export const SessionItem = memo(function SessionItem({
           archive 快捷按钮 hover/focus 时覆盖整个槽位,避免右侧拥挤;完整菜单仍走右键。
           槽宽跟可见内容走:状态点 / worktree / 任务信息有多宽占多宽,「任务信息 =
           无」且无状态、无 worktree 时宽度归零,把行宽还给标题。hover / 菜单打开 /
-          二次确认时,不可见操作钮进入文档流撑开真实按钮宽,标题被挤回 truncate,
-          可见按钮仍绝对定位叠在同一槽上——不再常驻 56px,也不叠到标题上。 */}
+          二次确认时,信息层与操作占位叠在同一格,槽宽取两者较大值,标题走 truncate,
+          可见按钮仍绝对定位叠在同一槽上——不再常驻 56px,也不叠到标题上,更不把
+          信息宽和按钮宽相加。 */}
       {!isEditing && (
         <div className="group/slot relative ml-auto flex h-6 shrink-0 items-center justify-end">
           {/* WorktreeBadge + time 同步 fade-out:hover/菜单打开/archivePending 时
@@ -1062,9 +1063,10 @@ export const SessionItem = memo(function SessionItem({
               role="button" tabIndex=0,点击选中后焦点常驻行内,若用整行的
               group-focus-within,选中态(非 hover)时间会被永久隐藏而 action
               buttons 又不显示,右侧变空白。 */}
+          <div className="grid h-6 grid-cols-[max-content] items-center justify-items-end">
           <div
             className={cn(
-              'flex items-center gap-1',
+              'col-start-1 row-start-1 flex items-center gap-1',
               // duration 与 action 按钮组的渐显同拍(120ms),让位/回归一进一出同步。
               'transition-opacity duration-[120ms]',
               !archivePending && 'group-hover:opacity-0 group-focus-within/slot:opacity-0',
@@ -1085,7 +1087,7 @@ export const SessionItem = memo(function SessionItem({
           </div>
 
           {canQuickArchive && archivePending && (
-            <span aria-hidden className="invisible inline-block h-6 w-14 shrink-0" />
+            <span aria-hidden className="invisible col-start-1 row-start-1 inline-block h-6 w-14" />
           )}
           {canQuickArchive && archivePending && (
             <button
@@ -1124,7 +1126,7 @@ export const SessionItem = memo(function SessionItem({
               <div
                 aria-hidden
                 className={cn(
-                  'invisible flex h-6 items-center gap-0.5',
+                  'invisible col-start-1 row-start-1 flex h-6 items-center gap-0.5',
                   menuPos === null && 'hidden group-hover:flex group-focus-within/slot:flex',
                 )}
               >
@@ -1153,6 +1155,7 @@ export const SessionItem = memo(function SessionItem({
               </div>
             </>
           )}
+          </div>
         </div>
       )}
 

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionItem.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionItem.tsx
@@ -1089,6 +1089,14 @@ export const SessionItem = memo(function SessionItem({
           {canQuickArchive && archivePending && (
             <span aria-hidden className="invisible col-start-1 row-start-1 inline-block h-6 w-14" />
           )}
+          {ordinalBadgeLabel != null && (
+            <span
+              aria-hidden
+              className="invisible col-start-1 row-start-1 inline-flex h-6 items-center px-1.5 py-[2px] text-11 leading-none"
+            >
+              {ordinalBadgeLabel}
+            </span>
+          )}
           {canQuickArchive && archivePending && (
             <button
               ref={confirmPillRef}

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionItem.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionItem.tsx
@@ -1090,11 +1090,8 @@ export const SessionItem = memo(function SessionItem({
             <span aria-hidden className="invisible col-start-1 row-start-1 inline-block h-6 w-14" />
           )}
           {ordinalBadgeLabel != null && (
-            <span
-              aria-hidden
-              className="invisible col-start-1 row-start-1 inline-flex h-6 items-center px-1.5 py-[2px] text-11 leading-none"
-            >
-              {ordinalBadgeLabel}
+            <span aria-hidden className="invisible col-start-1 row-start-1 inline-flex">
+              <SessionOrdinalBadgeKbd label={ordinalBadgeLabel} />
             </span>
           )}
           {canQuickArchive && archivePending && (

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionItem.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionItem.tsx
@@ -800,6 +800,66 @@ export const SessionItem = memo(function SessionItem({
     </DropdownMenuSub>
   ) : null;
 
+  const showAutomationRunAction =
+    isAutomationGenerated &&
+    !insideAutomationGroup &&
+    !isArchived &&
+    !isEmpty &&
+    !remoteWritesBlocked &&
+    Boolean(effectiveScheduleId);
+  const sessionActionButtons = (
+    <>
+      {/* 自动化会话专属 Run 直点按钮:仅顶层散落(insideAutomationGroup
+          为 false)的 automation-generated 会话可见 —— 分组内 (SessionEntryList
+          展开的子行) 组头已经暴露过同链路操作,再挂一份纯属视觉噪音。其它硬边界:
+          未归档 + 非 draft + 非远程只读。Edit 与左侧 Timer chip 同链路,不再重复
+          暴露;Run 走 main.maker.schedule.runNow,与 AutomationSessionGroupItem
+          组头 [Run ▶️][More ⋮] 保持高频直点、低频收纳的同构。 */}
+      {showAutomationRunAction && (
+        <SessionAction
+          label={t('ccAgent.sidebar.automationGroup.menu.runNow')}
+          onClick={() => void handleAutomationRunClick()}
+          isActive={isActive}
+        >
+          <Play size={14} strokeWidth={2} />
+        </SessionAction>
+      )}
+      <SessionAction
+        label={t('ccAgent.sidebar.sessionMenu.moreActions')}
+        onClick={(e) => {
+          const rect = e.currentTarget.getBoundingClientRect();
+          prefetchRemovalPreflight();
+          setMenuPos({ x: rect.left, y: rect.bottom + 2 });
+        }}
+        isActive={isActive}
+      >
+        <EllipsisVertical size={14} strokeWidth={2} />
+      </SessionAction>
+      {isArchived && !remoteWritesBlocked ? (
+        <SessionAction
+          label={t('ccAgent.sidebar.sessionMenu.unarchive')}
+          onClick={() => handleUnarchiveSelect()}
+          isActive={isActive}
+        >
+          <Undo size={14} strokeWidth={2} />
+        </SessionAction>
+      ) : canQuickArchive ? (
+        <SessionAction
+          label={t('ccAgent.sidebar.sessionMenu.archived')}
+          onClick={() => {
+            // 第一步:亮出 Confirm 胶囊,同时把 dirty 预检发出去。用户抬手
+            // 再点第二下的间隔足够那次 git status 跑完 → 归档零等待。
+            prefetchRemovalPreflight();
+            setArchivePending(true);
+          }}
+          isActive={isActive}
+        >
+          <Archive size={14} strokeWidth={2} />
+        </SessionAction>
+      ) : null}
+    </>
+  );
+
   const row = (
     // biome-ignore lint/a11y/useSemanticElements: 行内包含菜单和快捷操作按钮，不能改成原生 button。
     <div
@@ -990,8 +1050,9 @@ export const SessionItem = memo(function SessionItem({
           视觉元素, 不和 action buttons 共存。
           archive 快捷按钮 hover/focus 时覆盖整个槽位,避免右侧拥挤;完整菜单仍走右键。
           槽宽跟可见内容走:状态点 / worktree / 任务信息有多宽占多宽,「任务信息 =
-          无」且无状态、无 worktree 时宽度归零,把行宽还给标题。操作钮绝对定位叠在
-          槽上,不靠预留 56px 空位当锚点——否则短时间(「刚刚」)和无信息都会挤标题。 */}
+          无」且无状态、无 worktree 时宽度归零,把行宽还给标题。hover / 菜单打开 /
+          二次确认时,不可见操作钮进入文档流撑开真实按钮宽,标题被挤回 truncate,
+          可见按钮仍绝对定位叠在同一槽上——不再常驻 56px,也不叠到标题上。 */}
       {!isEditing && (
         <div className="group/slot relative ml-auto flex h-6 shrink-0 items-center justify-end">
           {/* WorktreeBadge + time 同步 fade-out:hover/菜单打开/archivePending 时
@@ -1023,6 +1084,9 @@ export const SessionItem = memo(function SessionItem({
             )}
           </div>
 
+          {canQuickArchive && archivePending && (
+            <span aria-hidden className="invisible inline-block h-6 w-14 shrink-0" />
+          )}
           {canQuickArchive && archivePending && (
             <button
               ref={confirmPillRef}
@@ -1056,73 +1120,38 @@ export const SessionItem = memo(function SessionItem({
                 - archived：More + Undo（lucide Undo），单击直接走 unarchive，
                   不像 Archive 那样需要二次确认 pill（unarchive 非破坏性）。 */}
           {!archivePending && (
-            <div
-              // 渐显(120ms)配 pointer-events 守卫:淡出期间按钮不再占据鼠标位置,
-              // 解决了旧注释"渐变让按钮在 fade 期间仍占着鼠标位置、Radix Tooltip
-              // 收不到 pointerleave 导致 tip 挂着"的问题(当年因此禁用了
-              // transition-opacity);键盘焦点不受 pointer-events 影响,focus 路径不变。
-              className={cn(
-                'absolute right-0 top-0 flex h-6 items-center gap-0.5',
-                'transition-opacity duration-[120ms]',
-                menuPos !== null
-                  ? 'opacity-100'
-                  : 'pointer-events-none opacity-0 group-hover:pointer-events-auto group-hover:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100',
-              )}
-            >
-              {/* 自动化会话专属 Run 直点按钮:仅顶层散落(insideAutomationGroup
-                  为 false)的 automation-generated 会话可见 —— 分组内 (SessionEntryList
-                  展开的子行) 组头已经暴露过同链路操作,再挂一份纯属视觉噪音。其它硬边界:
-                  未归档 + 非 draft + 非远程只读。Edit 与左侧 Timer chip 同链路,不再重复
-                  暴露;Run 走 main.maker.schedule.runNow,与 AutomationSessionGroupItem
-                  组头 [Run ▶️][More ⋮] 保持高频直点、低频收纳的同构。 */}
-              {isAutomationGenerated &&
-                !insideAutomationGroup &&
-                !isArchived &&
-                !isEmpty &&
-                !remoteWritesBlocked &&
-                effectiveScheduleId && (
-                  <SessionAction
-                    label={t('ccAgent.sidebar.automationGroup.menu.runNow')}
-                    onClick={() => void handleAutomationRunClick()}
-                    isActive={isActive}
-                  >
-                    <Play size={14} strokeWidth={2} />
-                  </SessionAction>
+            <>
+              <div
+                aria-hidden
+                className={cn(
+                  'invisible flex h-6 items-center gap-0.5',
+                  menuPos === null && 'hidden group-hover:flex group-focus-within/slot:flex',
                 )}
-              <SessionAction
-                label={t('ccAgent.sidebar.sessionMenu.moreActions')}
-                onClick={(e) => {
-                  const rect = e.currentTarget.getBoundingClientRect();
-                  prefetchRemovalPreflight();
-                  setMenuPos({ x: rect.left, y: rect.bottom + 2 });
-                }}
-                isActive={isActive}
               >
-                <EllipsisVertical size={14} strokeWidth={2} />
-              </SessionAction>
-              {isArchived && !remoteWritesBlocked ? (
-                <SessionAction
-                  label={t('ccAgent.sidebar.sessionMenu.unarchive')}
-                  onClick={() => handleUnarchiveSelect()}
-                  isActive={isActive}
-                >
-                  <Undo size={14} strokeWidth={2} />
-                </SessionAction>
-              ) : canQuickArchive ? (
-                <SessionAction
-                  label={t('ccAgent.sidebar.sessionMenu.archived')}
-                  onClick={() => {
-                    // 第一步:亮出 Confirm 胶囊,同时把 dirty 预检发出去。用户抬手
-                    // 再点第二下的间隔足够那次 git status 跑完 → 归档零等待。
-                    prefetchRemovalPreflight();
-                    setArchivePending(true);
-                  }}
-                  isActive={isActive}
-                >
-                  <Archive size={14} strokeWidth={2} />
-                </SessionAction>
-              ) : null}
-            </div>
+                {showAutomationRunAction ? <span className="size-5 shrink-0" /> : null}
+                <span className="size-5 shrink-0" />
+                {isArchived && !remoteWritesBlocked ? (
+                  <span className="size-5 shrink-0" />
+                ) : canQuickArchive ? (
+                  <span className="size-5 shrink-0" />
+                ) : null}
+              </div>
+              <div
+                // 渐显(120ms)配 pointer-events 守卫:淡出期间按钮不再占据鼠标位置,
+                // 解决了旧注释"渐变让按钮在 fade 期间仍占着鼠标位置、Radix Tooltip
+                // 收不到 pointerleave 导致 tip 挂着"的问题(当年因此禁用了
+                // transition-opacity);键盘焦点不受 pointer-events 影响,focus 路径不变。
+                className={cn(
+                  'absolute right-0 top-0 flex h-6 items-center gap-0.5',
+                  'transition-opacity duration-[120ms]',
+                  menuPos !== null
+                    ? 'opacity-100'
+                    : 'pointer-events-none opacity-0 group-hover:pointer-events-auto group-hover:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100',
+                )}
+              >
+                {sessionActionButtons}
+              </div>
+            </>
           )}
         </div>
       )}

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/SessionCard.visual.test.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/SessionCard.visual.test.ts
@@ -726,6 +726,16 @@ describe('SessionCard visual cases', () => {
       if (variant === 'list') {
         // 让位容器是 time 最近的 div 祖先(time 嵌在 SessionInfoMeta span 内)。
         expect(container.querySelector('time')?.closest('div')?.className).toContain('invisible');
+        const confirmReserve = Array.from(container.querySelectorAll<HTMLElement>('span')).find(
+          (node) =>
+            node.getAttribute('aria-hidden') === 'true' &&
+            node.className.includes('w-max') &&
+            node.textContent === '归档',
+        );
+        expect(confirmReserve).toBeTruthy();
+        expect(confirmReserve?.className).toContain('px-[9px]');
+        expect(confirmReserve?.className).toContain('text-11');
+        expect(confirmReserve?.className).not.toContain('inline-block h-[22px] w-14');
       }
     },
   );

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/SessionCard.visual.test.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/SessionCard.visual.test.ts
@@ -664,9 +664,10 @@ describe('SessionCard visual cases', () => {
       expect(action.querySelector('svg')?.getAttribute('width')).toBe('14');
     }
     // C 期起 time 包在 SessionInfoMeta 的 span 里;最近的 div 祖先才是让位容器。
+    // 信息层与操作占位叠在同一格,槽根仍是 group/slot,中间多一层 max-content grid。
     const listTimeFade = listContainer.querySelector('time')?.closest('div');
     expect(listTimeFade?.className).toContain('group-focus-within/slot:opacity-0');
-    expect(listTimeFade?.parentElement?.className).toContain('group/slot');
+    expect(listTimeFade?.closest('[class*="group/slot"]')?.className).toContain('group/slot');
     cleanup();
 
     const { container: activeListContainer } = render(

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/sessionCardReviewRegressions.test.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/sessionCardReviewRegressions.test.ts
@@ -171,6 +171,15 @@ describe('SessionCard review regressions', () => {
     expect(automationGroupSource).toContain(
       'group/slot relative ml-auto flex h-6 max-w-[96px] shrink-0 items-center justify-end',
     );
+    expect(sessionItemSource).toContain(
+      "menuPos === null && 'hidden group-hover:flex group-focus-within/slot:flex'",
+    );
+    expect(automationGroupSource).toContain(
+      "!menuOpen && 'hidden group-hover:block group-focus-within/slot:block'",
+    );
+    expect(sessionCardSource).toContain(
+      "!menuOpen && 'hidden group-hover/card:flex group-focus-within/slot:flex'",
+    );
   });
 
   it('keeps card info anchored to the bottom meta row instead of the overlay layout', () => {

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/sessionCardReviewRegressions.test.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/sessionCardReviewRegressions.test.ts
@@ -163,6 +163,16 @@ describe('SessionCard review regressions', () => {
     expect(sessionCardSource).not.toContain('session-card-progress');
   });
 
+  it('lets text-mode info slots shrink to their visible content', () => {
+    expect(sessionItemSource).not.toMatch(
+      /group\/slot relative ml-auto flex h-6 shrink-0 items-center justify-end min-w-14/,
+    );
+    expect(automationGroupSource).not.toContain('min-w-14 max-w-[96px]');
+    expect(automationGroupSource).toContain(
+      'group/slot relative ml-auto flex h-6 max-w-[96px] shrink-0 items-center justify-end',
+    );
+  });
+
   it('keeps card info anchored to the bottom meta row instead of the overlay layout', () => {
     // 时间/信息槽固定在底部 meta 行右端(ml-auto),不再依赖 overlay/block 双态测量。
     // C 期起时间渲染并入 SessionInfoMeta(任务信息复选),锚点与让位语义不变。

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/sessionCardReviewRegressions.test.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/sessionCardReviewRegressions.test.ts
@@ -186,9 +186,21 @@ describe('SessionCard review regressions', () => {
       "!menuOpen && 'hidden group-hover/card:flex group-focus-within/slot:flex'",
     );
     expect(sessionItemSource).toContain(
-      'invisible col-start-1 row-start-1 inline-flex h-6 items-center px-1.5 py-[2px] text-11 leading-none',
+      'invisible col-start-1 row-start-1 inline-flex',
+    );
+    expect(sessionItemSource).toContain(
+      '<SessionOrdinalBadgeKbd label={ordinalBadgeLabel} />',
     );
     expect(sessionCardSource).toContain(
+      'invisible col-start-1 row-start-1 inline-flex',
+    );
+    expect(sessionCardSource).toContain(
+      '<SessionOrdinalBadgeKbd label={ordinalBadgeLabel} />',
+    );
+    expect(sessionItemSource).not.toContain(
+      'invisible col-start-1 row-start-1 inline-flex h-6 items-center px-1.5 py-[2px] text-11 leading-none',
+    );
+    expect(sessionCardSource).not.toContain(
       'invisible col-start-1 row-start-1 inline-flex h-5 items-center px-1.5 py-[2px] text-11 leading-none',
     );
   });

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/sessionCardReviewRegressions.test.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/sessionCardReviewRegressions.test.ts
@@ -185,6 +185,12 @@ describe('SessionCard review regressions', () => {
     expect(sessionCardSource).toContain(
       "!menuOpen && 'hidden group-hover/card:flex group-focus-within/slot:flex'",
     );
+    expect(sessionItemSource).toContain(
+      'invisible col-start-1 row-start-1 inline-flex h-6 items-center px-1.5 py-[2px] text-11 leading-none',
+    );
+    expect(sessionCardSource).toContain(
+      'invisible col-start-1 row-start-1 inline-flex h-5 items-center px-1.5 py-[2px] text-11 leading-none',
+    );
   });
 
   it('keeps card info anchored to the bottom meta row instead of the overlay layout', () => {

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/sessionCardReviewRegressions.test.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/sessionCardReviewRegressions.test.ts
@@ -181,7 +181,7 @@ describe('SessionCard review regressions', () => {
     expect(automationGroupSource).toContain(
       "!menuOpen && 'hidden group-hover:block group-focus-within/slot:block'",
     );
-    expect(sessionCardSource).toContain('grid h-5 grid-cols-[max-content] items-center justify-items-end');
+    expect(sessionCardSource).toContain('grid h-[22px] grid-cols-[max-content] items-center justify-items-end');
     expect(sessionCardSource).toContain(
       "!menuOpen && 'hidden group-hover/card:flex group-focus-within/slot:flex'",
     );

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/sessionCardReviewRegressions.test.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/sessionCardReviewRegressions.test.ts
@@ -205,6 +205,18 @@ describe('SessionCard review regressions', () => {
     expect(sessionCardSource).toContain('w-max min-w-14');
     expect(sessionCardSource).toContain('whitespace-nowrap text-11 font-semibold');
     expect(sessionCardSource).toContain(
+      'invisible col-start-1 row-start-1 inline-flex h-[22px] w-max min-w-14 items-center justify-center whitespace-nowrap rounded-full px-[9px] text-11 font-semibold',
+    );
+    expect(sessionCardSource).not.toContain(
+      'invisible col-start-1 row-start-1 inline-block h-[22px] w-14',
+    );
+    expect(sessionItemSource).toContain(
+      'invisible col-start-1 row-start-1 inline-block h-6 w-14',
+    );
+    expect(sessionItemSource).toContain(
+      'absolute right-0 top-0 flex h-6 w-14 items-center justify-center rounded-md text-xs font-medium',
+    );
+    expect(sessionCardSource).toContain(
       '!isEditing && !archivePending && ordinalBadgeLabel != null',
     );
     expect(sessionCardSource).toContain("archivePending && 'invisible opacity-0'");

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/sessionCardReviewRegressions.test.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/sessionCardReviewRegressions.test.ts
@@ -171,12 +171,17 @@ describe('SessionCard review regressions', () => {
     expect(automationGroupSource).toContain(
       'group/slot relative ml-auto flex h-6 max-w-[96px] shrink-0 items-center justify-end',
     );
+    expect(sessionItemSource).toContain('grid h-6 grid-cols-[max-content] items-center justify-items-end');
     expect(sessionItemSource).toContain(
       "menuPos === null && 'hidden group-hover:flex group-focus-within/slot:flex'",
     );
     expect(automationGroupSource).toContain(
+      'grid h-6 max-w-[96px] grid-cols-[max-content] items-center justify-items-end',
+    );
+    expect(automationGroupSource).toContain(
       "!menuOpen && 'hidden group-hover:block group-focus-within/slot:block'",
     );
+    expect(sessionCardSource).toContain('grid h-5 grid-cols-[max-content] items-center justify-items-end');
     expect(sessionCardSource).toContain(
       "!menuOpen && 'hidden group-hover/card:flex group-focus-within/slot:flex'",
     );


### PR DESCRIPTION
## 这次改了什么

### 摘要

侧栏任务行右侧信息槽不再预留 56px 空白。任务信息设成「无」时，标题铺满右侧；只显示短时间（如「刚刚」）时，也只占实际文案宽度。hover、打开菜单、二次确认或快捷键序号徽标出现时，信息层和操作占位叠在同一格，槽宽取较大值，标题走 truncate，不再被空白或图标挤短。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：
  - 文字模式任务行（`SessionItem`）右侧信息槽按内容收缩
  - 自动化分组头（`AutomationSessionGroupItem`）同样处理
  - 列表模式行（`SessionCard` 的 `list` 变体 / `TimeActionsSlot`）做同一套对称修法：静止按内容收缩，hover / 菜单 / 二次确认 / 序号徽标时同一格重叠占位
  - 相关源码与视觉回归断言
- 明确不包含：任务信息选项语义、卡片模式视觉布局、hover 操作钮交互语义
- 用户可见变化：文字模式和列表模式下，任务信息为「无」或短时间时，标题不再被右侧空白挤压；交互态图标不再叠到标题上
- 是否存在 breaking change：无

### 不变量（第 5 轮检查点）

交互态右侧槽宽 = max(信息层, 真实叠层)，叠层按真实内容测宽，不猜固定像素。

| 叠层 | 文字行 SessionItem | 列表行 TimeActionsSlot | 分组头 |
| --- | --- | --- | --- |
| hover 操作钮 | 真实 size-5 组 | 真实 size-5 组 | 42px（Run+More） |
| 确认胶囊 | 胶囊本身就是 56px，占位 56px | 按本地化文案 + 9px 内边距测宽 | 无确认胶囊 |
| 序号徽标 | 不可见的真实 `SessionOrdinalBadgeKbd` | 同样复用真实徽标 | 无序号徽标 |

静止仍按可见内容收缩；无信息则宽度归零。卡片模式视觉不改。

### UI 变化

- 引用的设计规范：DESIGN.md §1 Extreme content restraint（无内容不占位）；§5 侧栏在窄宽下内容回流；sidebar-redesign-plan.md §3.4 任务信息决定标题右侧显示哪些信息、无数据不占位；§5 列表版行 1 = 标题 + 右侧信息槽
- 界面证据：本轮未能附上截图/录屏。开发版窗口 `pid 78026` / HEAD `986bbec19` 已对上，但本机 computer-use 会话结束后无法恢复截图。文字模式 Dark 开发版此前已目检；列表模式有源码与视觉回归覆盖，实机目检仍缺。

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：apps/desktop unit PASS

pnpm --filter desktop run --if-present typecheck
结果：通过
```

### 手工验证

- 平台：macOS Desktop remote 开发版
- worktree：`cindy-sidebar-text-info-slot`
- 文字模式：任务信息分别设为「无」和时间；无信息时标题铺满右侧，有时间时只占文案宽度
- 列表模式：开发版实例已对上当前 HEAD，但本轮窗口截图权限失败，未能完成实机目检。列表模式改动有源码/视觉回归覆盖；实机核对留给复审或后续手工。

### 未执行的验证

- 列表模式实机目检未完成（开发版窗口截图失败）
- Light 模式未单独目检（改的是宽度，不改颜色；Dark 文字模式开发版已看过）
- Windows 未做手工验证（CI Windows 单测已过）

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop 侧栏文字模式任务行、自动化分组头、列表模式行的右侧槽宽
- 回滚 / 降级方式：revert 本 PR
- 存量插件影响：无

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
