### PR TITLE
fix(desktop): 本地化飞书权限模式失败提示

### DIFF
--- a/apps/desktop/src/main/im/feishu/__tests__/feishuAdapter.test.ts
+++ b/apps/desktop/src/main/im/feishu/__tests__/feishuAdapter.test.ts
@@ -57,6 +57,7 @@ import type {
   IMMessageEvent,
   IMStatus,
 } from '@cindy/im';
+import { getResolvedMainLocale, setMainLocale } from '../../../i18n';
 import { buildFeishuAdapter } from '../adapter';
 import { formatHistoryTime } from '../groupContext';
 
@@ -134,6 +135,27 @@ describe('feishu ImChannelAdapter characterization', () => {
   it('channel / source 恒为 feishu', () => {
     expect(adapter.channel).toBe('feishu');
     expect(adapter.sessions.source).toBe('feishu');
+  });
+
+  it('权限模式不兼容提示在发送时跟随当前语言', () => {
+    const originalLocale = getResolvedMainLocale();
+    const copy = adapter.ui.error?.permissionModeUnsupported;
+    expect(copy).toBeTypeOf('function');
+    if (typeof copy !== 'function') throw new Error('missing permission mode copy');
+
+    try {
+      setMainLocale('en');
+      expect(copy('acceptEdits')).toBe(
+        'The current Agent cannot run on this channel in this permission mode, so messages cannot be processed. Send /permission to choose a supported mode.',
+      );
+
+      setMainLocale('zh-CN');
+      expect(copy('acceptEdits')).toBe(
+        '当前 Agent 不支持以此权限模式在该渠道运行，消息将无法处理。请发送 /permission 调整权限模式。',
+      );
+    } finally {
+      setMainLocale(originalLocale);
+    }
   });
 
   it('session id 格式 feishu_{botAppId}_{openId} — 跨重启稳定, 老用户续上历史', () => {

--- a/apps/desktop/src/main/im/feishu/uiText.ts
+++ b/apps/desktop/src/main/im/feishu/uiText.ts
@@ -13,6 +13,7 @@
 
 import type { IMUnsupportedEntry } from '@cindy/im';
 
+import { t } from '../../i18n';
 import type { ImUiTextPack } from '../shared/types';
 
 export const ui = {
@@ -92,16 +93,8 @@ export const ui = {
   error: {
     agentUnsupported:
       '🤔 当前选择的 Agent 在这个渠道需要逐条权限确认，暂时上不了场，换一个 Agent 再试~',
-    permissionModeUnsupported: (permissionMode: string) => {
-      // 「完全访问」已由渠道设置显式放行(护栏取缔), 这里实际只剩
-      // acceptEdits(自动接受编辑)会被群强确认策略拒绝 — 按档位点名报错。
-      const modeLabel =
-        permissionMode === 'acceptEdits' ? '「自动接受编辑」' : '当前权限档';
-      return (
-        `⚠️ 群/话题会话不能用${modeLabel} — 群上下文里有成员可控的内容，必须保留操作确认。\n` +
-        '我往你私聊发了张修复卡，去点一下切回「自动审批」就能继续~（也可以发 /permission 手动切）'
-      );
-    },
+    permissionModeUnsupported: () =>
+      t('settings.imBot.defaults.permissionModeUnsupportedOnChannelHint'),
   },
 
   // ── card text (sent via @cindy/im InteractiveCardSpec) ──────────────────────

--- a/apps/desktop/src/main/im/shared/__tests__/turnRunnerSendOutcome.test.ts
+++ b/apps/desktop/src/main/im/shared/__tests__/turnRunnerSendOutcome.test.ts
@@ -1255,7 +1255,7 @@ describe('turnRunner send outcome policy (feishu adapter characterization)', () 
     // 群 lane 报错文案之外, 再发一张一键修复卡到 owner 私聊。
     expect(mocks.feishuIm.sendText).toHaveBeenCalledWith(
       'g/oc_group1/omt_t1',
-      expect.stringContaining('群/话题会话不能用'),
+      expect.stringContaining('/permission'),
       expect.anything(),
     );
     expect(mocks.feishuIm.sendInteractiveCard).toHaveBeenCalledWith(


### PR DESCRIPTION
## 这次改了什么

### 摘要

在现有飞书权限模式失败映射基础上，把用户提示改为读取已有的多语言通用文案。提示在实际发送时按当前语言解析，缺少对应翻译时沿用 main 侧 i18n 的英语回退；不改权限策略、发送流程或修复卡行为。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#2647
- 本 PR 包含：飞书权限模式失败提示复用现有五语 i18n key；运行期语言切换回归测试；发送路径旧文案断言同步。
- 明确不包含：权限策略、adapter / turnRunner 行为、修复卡、新增翻译 key、服务端改动。
- 用户可见变化：提示跟随当前语言，并引导发送 `/permission` 调整权限模式；缺失翻译时回退英语。
- 是否存在 breaking change：无。

### UI 变化

- 涉及飞书中用户可见的错误提示文案，不涉及 Desktop Renderer 布局、颜色、交互组件或主题样式。
- 引用的设计规范：`docs/design-rules/DESIGN.md` §11.1、§11.3；复用既有五语文案与 main 侧 fallback 链，不新增术语或单语硬编码。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop test -- src/main/im/feishu/__tests__/feishuAdapter.test.ts src/main/im/shared/__tests__/turnRunnerSendOutcome.test.ts
结果：2 个测试文件、109 项测试通过。

pnpm test:unit:related
结果：apps/desktop unit 通过。

pnpm --filter desktop run --if-present typecheck
结果：通过。

pnpm check:i18n
结果：通过；五种语言 7293 个 key 一致，只有存量非阻塞告警。

pnpm check:i18n-glossary
结果：通过；无新增术语违规，只有存量待裁决告警。

git diff --check
结果：通过。
```

### 手工验证

未执行真实飞书账号端到端发送；通过单测覆盖同一提示函数在运行期切换英语 / 简体中文，以及 turnRunner 的飞书失败发送路径。

### 未执行的验证

- 真实飞书群账号端到端验证：本次仅调整取词方式，不改发送与权限行为。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop 飞书渠道的权限模式不兼容提示文案。
- 回滚 / 降级方式：回滚本 PR commit；main 侧 i18n 已自带英语回退。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因