### PR TITLE
fix(desktop): decouple App session boundary from Ghost durable owner

### DIFF
--- a/apps/desktop/src/main/__tests__/appCapabilitiesIpc.test.ts
+++ b/apps/desktop/src/main/__tests__/appCapabilitiesIpc.test.ts
@@ -34,11 +34,14 @@ describe('requireAppCapability IPC errors', () => {
     expect(() => requireAppCapability('canUseDeviceLink')).toThrow(/\[PRECONDITION_FAILED\]/);
   });
 
-  it('keeps cloud capabilities closed while the durable owner is unstable', () => {
+  it('keeps normal cloud capabilities available when only the Ghost projection owner differs', () => {
     state.mode = 'cloud';
     state.ownerStable = false;
-    expect(() => requireAppCapability('canUseCindyAccountServices')).toThrow(
-      /\[PRECONDITION_FAILED\]/,
-    );
+    expect(() => requireAppCapability('canUseCindyAccountServices')).not.toThrow();
+    expect(() => requireAppCapability('canUseCindyGateway')).not.toThrow();
+    expect(() => requireAppCapability('canUseDeviceLink')).not.toThrow();
+    expect(() => requireAppCapability('canUseSkillHubCloud')).not.toThrow();
+    expect(() => requireAppCapability('canUseCindyOAuthBroker')).not.toThrow();
+    expect(() => requireAppCapability('canUseCindyHeartbeat')).not.toThrow();
   });
 });

--- a/apps/desktop/src/main/__tests__/appSessionBoundary.test.ts
+++ b/apps/desktop/src/main/__tests__/appSessionBoundary.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const ghostBoundary = vi.hoisted(() => ({ stable: false }));
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: (name: string) => `C:/tmp/cindy-${name}`,
+  },
+}));
+
+vi.mock('../logger.js', () => ({
+  createLogger: () => ({ info: vi.fn() }),
+}));
+
+vi.mock('../maker-host/override-settings-file.js', () => ({
+  createOverrideSettingsFile: () => ({
+    read: () => ({ activeMode: 'signed-out' }),
+    writePatch: vi.fn(),
+  }),
+}));
+
+vi.mock('../authBoundaryQuarantine.js', () => ({
+  isGhostSkillProjectionBoundaryStableForOwner: () => ghostBoundary.stable,
+}));
+
+import {
+  beginAppSessionBoundary,
+  isAppSessionBoundaryPending,
+} from '../appSessionState.js';
+
+describe('application session boundary isolation', () => {
+  it('does not treat a different durable Ghost projection owner as an App transition', () => {
+    ghostBoundary.stable = false;
+    expect(isAppSessionBoundaryPending()).toBe(false);
+  });
+
+  it('still fails closed during a real process-local App owner transition', () => {
+    const release = beginAppSessionBoundary();
+    expect(isAppSessionBoundaryPending()).toBe(true);
+    release();
+    expect(isAppSessionBoundaryPending()).toBe(false);
+  });
+});

--- a/apps/desktop/src/main/__tests__/appSessionPolicy.test.ts
+++ b/apps/desktop/src/main/__tests__/appSessionPolicy.test.ts
@@ -21,12 +21,6 @@ describe('local app-session policy', () => {
     expect(deriveAppCapabilities('cloud', false).canUseCindyAccountServices).toBe(true);
   });
 
-  it('fails closed while the durable cloud owner is not stable', () => {
-    expect(deriveAppCapabilities('cloud', false, false).canUseCindyAccountServices).toBe(false);
-    expect(deriveAppCapabilities('cloud', false, false).canUseCindyGateway).toBe(false);
-    expect(deriveAppCapabilities('cloud', false, true).canUseCindyAccountServices).toBe(true);
-  });
-
   it('rejects local DB work while the matching owner boundary is pending', () => {
     const state = { dataOwnerId: 'cloud-a' };
     expect(isLocalDbOwnerCurrent(state, 'cloud-a', false)).toBe(true);

--- a/apps/desktop/src/main/__tests__/authSessionExpiredDetection.test.ts
+++ b/apps/desktop/src/main/__tests__/authSessionExpiredDetection.test.ts
@@ -200,5 +200,16 @@ describe('desktop auth session-expiry detection', () => {
     const requireBody = ghostSource.slice(requireStart, requireEnd);
     expect(requireBody).toContain("throwIpcError(\n        'PRECONDITION_FAILED'");
     expect(requireBody).toContain('isAppSessionBoundaryPending()');
+    // A durable Ghost owner mismatch must stay a retryable precondition error
+    // (not a misleading PERMISSION_DENIED) even when the App session itself is
+    // not switching. The owner-stable check has to sit inside the
+    // PRECONDITION_FAILED branch, so require it to appear before the
+    // PERMISSION_DENIED throw — otherwise a regression that moves it into the
+    // permission branch would still pass a mere toContain.
+    const ownerStableIndex = requireBody.indexOf('!isGhostSkillProjectionBoundaryStableForOwner(activeOwner)');
+    const permissionDeniedIndex = requireBody.indexOf("'PERMISSION_DENIED'");
+    expect(ownerStableIndex).toBeGreaterThan(-1);
+    expect(permissionDeniedIndex).toBeGreaterThan(-1);
+    expect(ownerStableIndex).toBeLessThan(permissionDeniedIndex);
   });
 });

--- a/apps/desktop/src/main/appCapabilities.ts
+++ b/apps/desktop/src/main/appCapabilities.ts
@@ -10,7 +10,6 @@ import {
   isAppSessionBoundaryPending,
   type AppSessionMode,
 } from './appSessionState.js';
-import { isGhostSkillProjectionBoundaryStableForOwner } from './authBoundaryQuarantine.js';
 import { throwIpcError } from './utils/ipcValidate.js';
 
 export interface AppCapabilities {
@@ -25,9 +24,8 @@ export interface AppCapabilities {
 export function deriveAppCapabilities(
   mode: AppSessionMode,
   boundaryPending = false,
-  ownerStable = true,
 ): AppCapabilities {
-  const cloud = mode === 'cloud' && !boundaryPending && ownerStable;
+  const cloud = mode === 'cloud' && !boundaryPending;
   return {
     canUseCindyAccountServices: cloud,
     canUseCindyGateway: cloud,
@@ -40,11 +38,7 @@ export function deriveAppCapabilities(
 
 export function getAppCapabilities(): AppCapabilities {
   const session = getActiveAppSession();
-  return deriveAppCapabilities(
-    session.mode,
-    isAppSessionBoundaryPending(),
-    isGhostSkillProjectionBoundaryStableForOwner(session.dataOwnerId),
-  );
+  return deriveAppCapabilities(session.mode, isAppSessionBoundaryPending());
 }
 
 export function requireAppCapability(
@@ -53,9 +47,8 @@ export function requireAppCapability(
 ): void {
   const session = getActiveAppSession();
   const boundaryPending = isAppSessionBoundaryPending();
-  const ownerStable = isGhostSkillProjectionBoundaryStableForOwner(session.dataOwnerId);
-  if (deriveAppCapabilities(session.mode, boundaryPending, ownerStable)[capability]) return;
-  if (boundaryPending || (session.mode === 'cloud' && !ownerStable)) {
+  if (deriveAppCapabilities(session.mode, boundaryPending)[capability]) return;
+  if (boundaryPending) {
     throwIpcError(
       'PRECONDITION_FAILED',
       'App session is switching; retry after the owner boundary settles.',

--- a/apps/desktop/src/main/appSessionState.ts
+++ b/apps/desktop/src/main/appSessionState.ts
@@ -13,7 +13,6 @@ import { createLogger } from './logger.js';
 import { createOverrideSettingsFile } from './maker-host/override-settings-file.js';
 import { LOCAL_PROFILE_DATA_OWNER_ID } from './profile/profileRegistryModel.js';
 import type { DataOwnerPushStamp } from '../shared/dataOwnerPush.js';
-import { isGhostSkillProjectionBoundaryStableForOwner } from './authBoundaryQuarantine.js';
 
 export type AppSessionMode = 'signed-out' | 'local' | 'cloud';
 
@@ -143,12 +142,10 @@ export function beginAppSessionBoundary(): () => void {
 }
 
 export function isAppSessionBoundaryPending(): boolean {
-  if (boundaryDepth > 0) return true;
-  const session = ensureLoaded();
-  return !isGhostSkillProjectionBoundaryStableForOwner(session.dataOwnerId);
+  return boundaryDepth > 0;
 }
 
-/** Process-local transition state, excluding a durable owner mismatch. */
+/** Backward-compatible alias for the process-local application transition. */
 export function isAppSessionBoundaryLocallyPending(): boolean {
   return boundaryDepth > 0;
 }

--- a/apps/desktop/src/main/cindy-brain/__tests__/cindySlot.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/cindySlot.test.ts
@@ -1015,6 +1015,28 @@ describe('代办链路', () => {
     expect(saveGhostMedia).not.toHaveBeenCalled();
   });
 
+  it('生成期间 Ghost durable owner 变为 mismatch 时不保存产物', async () => {
+    // 模拟另一实例改写全局 durable Ghost projection owner:进程内 boundaryDepth
+    // 与 owner scope key 都不变,但 Ghost 专属边界(isOwnerBoundaryPending 已含
+    // durable owner 检查)在任务执行中变 pending,在途任务必须收口。
+    let boundaryPending = false;
+    const saveGhostMedia = vi.fn();
+    const { slot } = makeSlot({
+      isOwnerBoundaryPending: () => boundaryPending,
+      generateImage: vi.fn(async () => {
+        boundaryPending = true;
+        return { buffer: new Uint8Array([1, 2, 3]), mimeType: 'image/png' };
+      }),
+      saveGhostMedia,
+    });
+
+    const result = await slot.handleModelRequest('art', REQ);
+
+    expect(result).toMatchObject({ ok: false });
+    expect((result as { message: string }).message).toContain('账号已切换');
+    expect(saveGhostMedia).not.toHaveBeenCalled();
+  });
+
   it('保存期间切换账号时不向新作用域返回旧产物', async () => {
     let ownerScopeKey = 'cloud:owner-a:1';
     const saveGhostMedia = vi.fn(async (params: { ownerScopeKey: string }) => {

--- a/apps/desktop/src/main/cindy-brain/__tests__/marketGhostSessionBoundary.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/marketGhostSessionBoundary.test.ts
@@ -205,4 +205,47 @@ describe('market Ghost session boundary', () => {
       source.match(/isOwnerBoundaryPending: \(\) => isGhostBoundaryPending\(\)/g)?.length ?? 0;
     expect(injections).toBeGreaterThanOrEqual(2);
   });
+
+  it('Ghost 媒体持久化写入守卫(resolveOwnedMedia/saveGhostMedia)也用 durable owner 组合条件', () => {
+    // 这两处是 GhostCindySlot 的 deps,内部 assertStillValid 会在 ingestMedia 的
+    // await 边界反复断言。持久化写入守卫必须和入口/生成守卫一样用 isGhostBoundaryPending,
+    // 否则另一实例在落盘窗口翻转 durable owner 时,字节仍会被登记为 ghost-gallery ref。
+    const resolveStart = source.indexOf('resolveOwnedMedia: async (ghostId, hash, ownerScopeKey)');
+    const saveStart = source.indexOf('saveGhostMedia: async ({ ghostId, buffer, mimeType, ownerScopeKey');
+    expect(resolveStart).toBeGreaterThan(-1);
+    expect(saveStart).toBeGreaterThan(-1);
+    const resolveBody = source.slice(resolveStart, resolveStart + 700);
+    const saveBody = source.slice(saveStart, saveStart + 700);
+    const combinedGuard = 'isGhostBoundaryPending() || activeOwnerScopeKey() !== ownerScopeKey';
+    expect(resolveBody).toContain(combinedGuard);
+    expect(saveBody).toContain(combinedGuard);
+    // 持久化守卫不得退化回只看进程内边界的旧写法。
+    expect(source).not.toContain('isAppSessionBoundaryPending() || activeOwnerScopeKey() !== ownerScopeKey');
+  });
+
+  it('networkSlot 的 saveGhostMedia(as:media fetch 落仓)也用 durable owner 组合条件', () => {
+    // networkSlot 与 cindy 槽是两个独立实现,签名不带 ownerScopeKey(在函数体开头
+    // 捕获)。它的落仓路径(ghost-gallery 作品归属 + recordGhostCallMedia)必须同样
+    // 有 durable owner 守卫 + assertStillValid + 补偿 journal,否则 as:'media' fetch
+    // 读取窗口内 durable owner 翻转时仍会落仓到错误 owner 的画廊。
+    const networkStart = source.indexOf('saveGhostMedia: async ({ ghostId, buffer, mimeType, label, callId }) =>');
+    expect(networkStart).toBeGreaterThan(-1);
+    const networkBody = source.slice(networkStart, networkStart + 1800);
+    expect(networkBody).toContain('const ownerScopeKey = activeOwnerScopeKey();');
+    expect(networkBody).toContain('isGhostBoundaryPending() || activeOwnerScopeKey() !== ownerScopeKey');
+    expect(networkBody).toContain('assertStillValid: assertOwnerScopeCurrent');
+    expect(networkBody).toContain('refCompensationScope: captureMediaRefCompensationScope(ownerScopeKey)');
+  });
+
+  it('depositMedia(ghost-deposit 寄存器落仓)也用 durable owner 组合条件', () => {
+    // 寄存器引用按 ghostId 落到 owner 作用域账本(originKind:'user' 但 refId 仍是意识),
+    // 落仓窗口翻转全局 owner 时必须 fail closed,与 saveGhostMedia 同口径。
+    const depositStart = source.indexOf('depositMedia: async ({ ghostId, buffer, mimeType, label }) =>');
+    expect(depositStart).toBeGreaterThan(-1);
+    const depositBody = source.slice(depositStart, depositStart + 1800);
+    expect(depositBody).toContain('const ownerScopeKey = activeOwnerScopeKey();');
+    expect(depositBody).toContain('isGhostBoundaryPending() || activeOwnerScopeKey() !== ownerScopeKey');
+    expect(depositBody).toContain('assertStillValid: assertOwnerScopeCurrent');
+    expect(depositBody).toContain('refCompensationScope: captureMediaRefCompensationScope(ownerScopeKey)');
+  });
 });

--- a/apps/desktop/src/main/cindy-brain/__tests__/marketGhostSessionBoundary.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/marketGhostSessionBoundary.test.ts
@@ -191,4 +191,18 @@ describe('market Ghost session boundary', () => {
     expect(body).toContain("throwIpcError('INTERNAL', 'Unable to verify the installed Plugin source');");
     expect(body).toContain("throwIpcError('INTERNAL', 'Unable to detach the installed Plugin source');");
   });
+
+  it('Ghost 媒体在途守卫注入 durable owner 组合条件,而不是退化成只看进程内边界', () => {
+    const helperStart = source.indexOf('function isGhostBoundaryPending(): boolean {');
+    expect(helperStart).toBeGreaterThan(-1);
+    const helperEnd = source.indexOf('\n}\n', helperStart);
+    const helperBody = source.slice(helperStart, helperEnd);
+    // helper 必须是组合条件:进程内 App boundary + durable projection owner 稳定性。
+    expect(helperBody).toContain('isAppSessionBoundaryPending()');
+    expect(helperBody).toContain('isGhostSkillProjectionBoundaryStableForOwner');
+    // 两处 Ghost 专属消费点(xAI 通道与 GhostCindySlot)都必须走 helper。
+    const injections =
+      source.match(/isOwnerBoundaryPending: \(\) => isGhostBoundaryPending\(\)/g)?.length ?? 0;
+    expect(injections).toBeGreaterThanOrEqual(2);
+  });
 });

--- a/apps/desktop/src/main/cindy-brain/__tests__/xaiImageClient.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/xaiImageClient.test.ts
@@ -214,6 +214,25 @@ describe('xaiImageClient', () => {
     expect(responseFetch).toHaveBeenCalledTimes(1);
   });
 
+  it('响应返回途中 Ghost durable owner 变为 mismatch 时中止且不返回结果', async () => {
+    // 另一实例改写全局 durable Ghost projection owner:进程内 boundaryDepth 与
+    // owner scope key 都不变,但 Ghost 专属边界(isOwnerBoundaryPending 已含
+    // durable owner 检查)在响应返回途中变 pending,必须中止且不返回结果。
+    let boundaryPending = false;
+    const doFetch = vi.fn<typeof fetch>(async () => {
+      boundaryPending = true;
+      return new Response(
+        JSON.stringify({ data: [{ b64_json: 'aW1hZ2U=', mime_type: 'image/jpeg' }] }),
+        { status: 200 },
+      );
+    });
+    const ch = channel(doFetch, { isOwnerBoundaryPending: () => boundaryPending });
+    await expect(
+      ch.generateImage({ model: 'xai/grok-imagine-image', prompt: 'p' }),
+    ).rejects.toThrow('账号已切换');
+    expect(doFetch).toHaveBeenCalledTimes(1);
+  });
+
   it('登录态决定 ready;派发拦截、源图上限与 OAuth 拒绝均在出网边界处理', async () => {
     const doFetch = vi.fn<typeof fetch>();
     const unavailable = channel(doFetch, { hasOAuthLogin: () => false });

--- a/apps/desktop/src/main/cindy-brain/index.ts
+++ b/apps/desktop/src/main/cindy-brain/index.ts
@@ -3606,7 +3606,7 @@ export function getGhostCindySlot(): GhostCindySlot {
       },
       resolveOwnedMedia: async (ghostId, hash, ownerScopeKey) => {
         const assertOwnerScopeCurrent = (): void => {
-          if (isAppSessionBoundaryPending() || activeOwnerScopeKey() !== ownerScopeKey) {
+          if (isGhostBoundaryPending() || activeOwnerScopeKey() !== ownerScopeKey) {
             throw new Error('媒体任务期间账号已切换,本次结果已丢弃');
           }
         };
@@ -3633,7 +3633,7 @@ export function getGhostCindySlot(): GhostCindySlot {
       },
       saveGhostMedia: async ({ ghostId, buffer, mimeType, ownerScopeKey, label, callId }) => {
         const assertOwnerScopeCurrent = (): void => {
-          if (isAppSessionBoundaryPending() || activeOwnerScopeKey() !== ownerScopeKey) {
+          if (isGhostBoundaryPending() || activeOwnerScopeKey() !== ownerScopeKey) {
             throw new Error('媒体任务期间账号已切换,本次结果已丢弃');
           }
         };
@@ -3676,19 +3676,34 @@ export function getGhostCindySlot(): GhostCindySlot {
       // 管道;记成 'ghost' 会让 ghostCanRead 的 origin 分支把它当作该意识的
       // 出生物,与"作品"混为一谈。引用方(refId)才是意识,归属由此成立。
       depositMedia: async ({ ghostId, buffer, mimeType, label }) => {
-        const r = await ingestMedia({
-          buffer,
-          mimeType,
-          isCache: false,
-          refs: [
-            {
-              refKind: 'ghost-deposit',
-              refId: ghostId,
-              originKind: 'user',
-              ...(label ? { label } : {}),
-            },
-          ],
-        });
+        // 与 saveGhostMedia 同口径的 durable owner 守卫:寄存器引用按 ghostId
+        // 落到 owner 作用域账本,落盘窗口翻转全局 owner 时必须 fail closed。
+        const ownerScopeKey = activeOwnerScopeKey();
+        const assertOwnerScopeCurrent = (): void => {
+          if (isGhostBoundaryPending() || activeOwnerScopeKey() !== ownerScopeKey) {
+            throw new Error('媒体任务期间账号已切换,本次结果已丢弃');
+          }
+        };
+        assertOwnerScopeCurrent();
+        const db = getDbClient().drizzle;
+        const r = await ingestMedia(
+          {
+            buffer,
+            mimeType,
+            isCache: false,
+            refs: [
+              {
+                refKind: 'ghost-deposit',
+                refId: ghostId,
+                originKind: 'user',
+                ...(label ? { label } : {}),
+              },
+            ],
+            assertStillValid: assertOwnerScopeCurrent,
+            refCompensationScope: captureMediaRefCompensationScope(ownerScopeKey),
+          },
+          db,
+        );
         return {
           url: r.url,
           hash: r.hash,
@@ -4069,20 +4084,36 @@ export function getGhostNetworkSlot(): GhostNetworkSlot {
       // (规则 25)。mime 白名单同一来源(blobStore),槽内归一化后再判。
       isSupportedMediaMime: (mime) => supportedMime(mime),
       saveGhostMedia: async ({ ghostId, buffer, mimeType, label, callId }) => {
-        const r = await ingestMedia({
-          buffer,
-          mimeType,
-          isCache: false,
-          refs: [
-            {
-              refKind: 'ghost-gallery',
-              refId: ghostId,
-              originKind: 'ghost',
-              originId: ghostId,
-              ...(label ? { label } : {}),
-            },
-          ],
-        });
+        // 与 cindy 槽 saveGhostMedia 同口径的 durable owner 守卫:落盘前与
+        // ingestMedia 每个 await 边界都复查,防止兄弟实例在 fetch 读取窗口翻转
+        // 全局 Ghost owner marker 后,字节仍被登记为 ghost-gallery 作品。
+        const ownerScopeKey = activeOwnerScopeKey();
+        const assertOwnerScopeCurrent = (): void => {
+          if (isGhostBoundaryPending() || activeOwnerScopeKey() !== ownerScopeKey) {
+            throw new Error('媒体任务期间账号已切换,本次结果已丢弃');
+          }
+        };
+        assertOwnerScopeCurrent();
+        const db = getDbClient().drizzle;
+        const r = await ingestMedia(
+          {
+            buffer,
+            mimeType,
+            isCache: false,
+            refs: [
+              {
+                refKind: 'ghost-gallery',
+                refId: ghostId,
+                originKind: 'ghost',
+                originId: ghostId,
+                ...(label ? { label } : {}),
+              },
+            ],
+            assertStillValid: assertOwnerScopeCurrent,
+            refCompensationScope: captureMediaRefCompensationScope(ownerScopeKey),
+          },
+          db,
+        );
         recordGhostCallMedia(ghostId, callId, r.url);
         return { url: r.url, hash: r.hash, ext: r.ext };
       },

--- a/apps/desktop/src/main/cindy-brain/index.ts
+++ b/apps/desktop/src/main/cindy-brain/index.ts
@@ -900,7 +900,11 @@ export function listAvailableGhostsForAuthorization(): InstalledGhost[] {
 
 function requireGhostAvailableForActiveSession(id: string): void {
   if (!isGhostAvailableForActiveSession(id)) {
-    if (isAppSessionBoundaryPending()) {
+    const activeOwner = getActiveAppSession().dataOwnerId;
+    if (
+      isAppSessionBoundaryPending() ||
+      !isGhostSkillProjectionBoundaryStableForOwner(activeOwner)
+    ) {
       throwIpcError(
         'PRECONDITION_FAILED',
         'Ghost projection is switching owners; retry after the boundary settles.',

--- a/apps/desktop/src/main/cindy-brain/index.ts
+++ b/apps/desktop/src/main/cindy-brain/index.ts
@@ -3268,7 +3268,7 @@ function getImageChannelRegistry(): ImageChannelRegistry {
         hasOAuthLogin: () => hasGrokOAuthLogin(),
         getAccessToken: () => getGrokAccessToken(),
         getOwnerScopeKey: () => activeOwnerScopeKey(),
-        isOwnerBoundaryPending: () => isAppSessionBoundaryPending(),
+        isOwnerBoundaryPending: () => isGhostBoundaryPending(),
         fetchImplementation: ((url, init) => outboundFetch(url as string, init)) as typeof fetch,
         beforeDispatch: (model) => assertMediaModelStillEnabled('image', model),
         onAuthRejected: (failure) => invalidateXaiBridgeAuth(failure),
@@ -3367,12 +3367,26 @@ function resolveImageChannelForModel(model: string, operation: 'generate' | 'edi
   return getImageChannelRegistry().resolve(entry.providerId);
 }
 
+/**
+ * Combined Ghost-owner boundary gate for Ghost-only paths (media generation,
+ * cindy-slot work). Unlike the app-wide isAppSessionBoundaryPending(), this
+ * also fails closed while the durable projection owner (shared global marker)
+ * differs, so a sibling instance flipping the owner cannot let an in-flight
+ * Ghost task keep calling upstream or saving media.
+ */
+function isGhostBoundaryPending(): boolean {
+  return (
+    isAppSessionBoundaryPending() ||
+    !isGhostSkillProjectionBoundaryStableForOwner(getActiveAppSession().dataOwnerId)
+  );
+}
+
 export function getGhostCindySlot(): GhostCindySlot {
   if (!cindySlotSingleton) {
     cindySlotSingleton = new GhostCindySlot({
       getGhost: (id) => findAvailableGhost(id),
       getOwnerScopeKey: () => activeOwnerScopeKey(),
-      isOwnerBoundaryPending: () => isAppSessionBoundaryPending(),
+      isOwnerBoundaryPending: () => isGhostBoundaryPending(),
       // model 已在 modelSlot 按白名单校验;归属来源(providerId)按白名单条目
       // 定位,经 imageChannelRegistry 取对应执行通道(2026-07 图像多来源)。
       generateImage: async ({ prompt, model, aspectRatio }) => {


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 v0.1.48 插件批准回归中的**问题二：跨实例 Ghost owner 冲突误伤整个 App**。

全局文件 `~/.cindy/ghost-skill-projection-boundary.json` 记录 durable Ghost owner。此前 `dc9614e17` 把 durable owner 不匹配并入了 `isAppSessionBoundaryPending()`，导致同一系统用户并行运行不同 owner/profile 的 Cindy 实例时（如正式版 + CindyDev），一个实例改写 owner 后，另一个实例的 Provider 绑定、模型网关、登录状态、device-link、heartbeat 等**普通账号能力**被整体误判为“切换中”，表现接近整个客户端不可用。

本修复把「进程内 App 切换」与「durable Ghost owner 稳定性」解耦：

- `isAppSessionBoundaryPending()` 只表示本进程正在切换（`boundaryDepth > 0`）。
- Ghost 技能投影 / mutation / runtime 路径保留显式 `isGhostSkillProjectionBoundaryStableForOwner()` 门，owner 不匹配时仍 fail closed。
- Ghost 媒体在途任务（xAI 图片通道、GhostCindySlot）的跨 await 守卫注入组合条件 `isGhostBoundaryPending()`（进程内 boundary 或 durable owner 不匹配），防止另一实例改写全局 marker 后在途任务继续调用上游、保存媒体。
- `requireGhostAvailableForActiveSession` 在仅 Ghost owner 不匹配时报告可重试的 `PRECONDITION_FAILED`（而非误导的 `PERMISSION_DENIED`）。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：v0.1.48 插件批准回归交接（问题二）；关联 PR #1916
- 本 PR 包含：
  - `isAppSessionBoundaryPending()` 退化为只看进程内 `boundaryDepth`
  - `deriveAppCapabilities` 移除 `ownerStable` 参数，通用云能力只依赖 `mode + boundaryPending`
  - Ghost 投影 fail-closed 显式门审计与保留
  - Ghost 媒体在途守卫恢复 durable-owner 分量（`isGhostBoundaryPending()`，修复 review 指出的 P1）
  - `requireGhostAvailableForActiveSession` 的 owner-mismatch 措辞修复
  - 对应回归测试（含新 `appSessionBoundary.test.ts`、cindySlot/xaiImageClient 在途 durable-owner 测试、marketGhostSessionBoundary 契约）
- 明确不包含：
  - setup receipt 二次误校验（问题一，另行修复）
  - Ghost 投影目录按 profile/owner 隔离的长期重构（交接文档 §5.3.5 明确非本次热修必需）
  - 插件 manifest / 安装包格式 / 批准状态 schema 变更
  - UI 变化
- 用户可见变化：不同 owner 实例并行时，普通账号能力不再被另一实例的 Ghost marker 误阻断；Ghost 投影仍按 owner 隔离
- 是否存在 breaking change：无

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
相关测试：18 文件 508/508 通过（含 appSessionBoundary、appCapabilitiesIpc、authBoundaryQuarantine、cindySlot、xaiImageClient、marketGhostSessionBoundary 契约等）

pnpm --filter desktop typecheck
结果：通过

git diff --check
结果：通过

pnpm check:dco
结果：通过，2 个 commit 已签名
```

两名独立 reviewer 对抗性 review 无 P0/P1（安全性/正确性 + 语义/测试/回归双视角）；review 指出的 Ghost 在途媒体 durable-owner 守卫缺口（P1）已修复并经独立 reviewer 复核无 P0/P1。

### 手工验证

未执行。正式版 + CindyDev 并行实例的实机验证需真实多开运行环境，本次未在本机执行。

### 未执行的验证

- 正式版 + CindyDev 并行实例实机测试（需多开运行环境）
- v0.1.47/旧状态 → 修复版、v0.1.48 已失败状态 → 修复版的真实迁移/恢复测试（属恢复与发布阶段）

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [x] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop 通用 App 能力边界（Provider / 模型网关 / 登录 / device-link / heartbeat）与 Ghost 投影隔离边界
- 回滚 / 降级方式：回滚本提交即可；不改写用户本地插件数据、不要求重装或重新确认权限
- 存量插件影响：无。不改变 receipt schema、安装布局、指纹格式或已批准权限；用户升级后无需重新安装、重新确认或重新配置

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)