### PR TITLE
fix(maker-core): guard native Claude tool loops

### DIFF
--- a/packages/maker-core/src/agents/claude-code/__tests__/upstream-idle-watchdog.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/upstream-idle-watchdog.test.ts
@@ -252,6 +252,52 @@ function toolLoopError(events: AgentEvent[]): AgentEvent | undefined {
   );
 }
 
+async function runStableAbabLoop(
+  session: Awaited<ReturnType<typeof startSessionWithStream>>,
+  userContent: string,
+  idPrefix: string,
+): Promise<{ loopError: AgentEvent | undefined; interruptCalls: number }> {
+  const { handle, stream, events, fakeQuery } = session;
+  vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout', 'Date'] });
+
+  try {
+    await handle.send({ type: 'user', content: userContent });
+    for (let i = 0; i < 12; i += 1) {
+      const id = `${idPrefix}_${i}`;
+      const isA = i % 2 === 0;
+      stream.emit(
+        assistantToolUse(
+          id,
+          isA
+            ? 'grep -R "getShellCommandPolicy" packages apps'
+            : 'grep -R "shell-command-policy" packages apps',
+        ),
+      );
+      stream.emit(userToolResult(id, isA ? 'base-agent.ts:731' : 'not found'));
+    }
+
+    await pumpUntil(
+      () => events.filter((event) => event.type === 'tool_result_full').length === 12,
+      `${idPrefix} tool results processed`,
+    );
+    await vi.advanceTimersByTimeAsync(1);
+    const result = {
+      loopError: toolLoopError(events),
+      interruptCalls: fakeQuery.interrupt.mock.calls.length,
+    };
+
+    if (handle.isTurnRunning?.()) {
+      stream.emit(successResult());
+      await pumpUntil(() => handle.isTurnRunning?.() === false, `${idPrefix} turn done`);
+    }
+    return result;
+  } finally {
+    vi.useRealTimers();
+    stream.end();
+    await handle.close().catch(() => undefined);
+  }
+}
+
 afterEach(async () => {
   vi.useRealTimers();
   sdkMock.forkSession.mockReset();
@@ -350,52 +396,112 @@ describe('upstream-response-idle watchdog suspend awareness', () => {
   });
 });
 
-describe('DeepSeek tool-loop guard runtime integration', () => {
-  it('真实 SDK 事件流中的 150 次不同调用与空结果可以完成同一个 turn', async () => {
-    const { handle, stream, events, fakeQuery } = await startSessionWithStream(
-      'deepseek/deepseek-v4-flash',
+describe('Claude Code tool-loop guard runtime integration', () => {
+  it('claude-opus-5 的稳定 ABAB Bash 循环在第 12 个结果处中断', async () => {
+    const result = await runStableAbabLoop(
+      await startSessionWithStream('claude-opus-5'),
+      'find the missing implementation',
+      'toolu_issue_2721',
     );
 
-    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout', 'Date'] });
-    await handle.send({ type: 'user', content: 'analyze 150 different projects' });
-
-    for (let i = 0; i < 150; i += 1) {
-      const id = `toolu_project_${i}`;
-      stream.emit(assistantToolUse(id, `read-project-${i}`));
-      stream.emit(userToolResult(id, ''));
-    }
-    stream.emit(successResult());
-
-    await pumpUntil(() => handle.isTurnRunning?.() === false, 'long DeepSeek turn done');
-    expect(toolLoopError(events)).toBeUndefined();
-    expect(fakeQuery.interrupt).not.toHaveBeenCalled();
-
-    vi.useRealTimers();
-    stream.end();
-    await handle.close().catch(() => undefined);
+    expect(result.loopError).toMatchObject({
+      type: 'error',
+      data: {
+        reason: 'tool_use_loop_detected',
+        loopKind: 'pingpong',
+        loopCount: 12,
+        model: 'claude-opus-5',
+        isTerminal: true,
+      },
+      source: 'claude-code',
+    });
+    expect(result.interruptCalls).toBe(1);
   });
 
-  it('真实 SDK 事件流中的稳定 TaskOutput 轮询不会中断 turn', async () => {
-    const { handle, stream, events, fakeQuery } = await startSessionWithStream(
+  it('热切到 claude-opus-5 后稳定 ABAB Bash 循环仍会中断', async () => {
+    const session = await startSessionWithStream(
       'deepseek/deepseek-v4-flash',
     );
+    await session.handle.setModel?.('claude-opus-5');
+    const result = await runStableAbabLoop(
+      session,
+      'find the missing implementation after switching models',
+      'toolu_issue_2721_switch',
+    );
 
-    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout', 'Date'] });
-    await handle.send({ type: 'user', content: 'wait for the background task' });
-
-    for (let i = 0; i < 30; i += 1) {
-      const id = `toolu_task_output_${i}`;
-      stream.emit(assistantTaskOutput(id));
-      stream.emit(userToolResult(id, 'still running'));
-    }
-    stream.emit(successResult());
-
-    await pumpUntil(() => handle.isTurnRunning?.() === false, 'TaskOutput polling turn done');
-    expect(toolLoopError(events)).toBeUndefined();
-    expect(fakeQuery.interrupt).not.toHaveBeenCalled();
-
-    vi.useRealTimers();
-    stream.end();
-    await handle.close().catch(() => undefined);
+    expect(session.fakeQuery.setModel).toHaveBeenCalledWith('claude-opus-5[1m]');
+    expect(result.loopError).toMatchObject({
+      type: 'error',
+      data: {
+        reason: 'tool_use_loop_detected',
+        loopKind: 'pingpong',
+        loopCount: 12,
+        model: 'claude-opus-5',
+        isTerminal: true,
+      },
+      source: 'claude-code',
+    });
+    expect(result.interruptCalls).toBe(1);
   });
+
+  it('未确认的 provider-routed 模型不扩展自动硬中断范围', async () => {
+    const result = await runStableAbabLoop(
+      await startSessionWithStream('codex/gpt-5.5'),
+      'run a provider-routed investigation',
+      'toolu_provider_boundary',
+    );
+
+    expect(result.loopError).toBeUndefined();
+    expect(result.interruptCalls).toBe(0);
+  });
+
+  it.each(['deepseek/deepseek-v4-flash', 'claude-opus-5'])(
+    '%s 真实 SDK 事件流中的 150 次不同调用与空结果可以完成同一个 turn',
+    async (model) => {
+      const { handle, stream, events, fakeQuery } = await startSessionWithStream(model);
+
+      vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout', 'Date'] });
+      await handle.send({ type: 'user', content: 'analyze 150 different projects' });
+
+      for (let i = 0; i < 150; i += 1) {
+        const id = `toolu_project_${i}`;
+        stream.emit(assistantToolUse(id, `read-project-${i}`));
+        stream.emit(userToolResult(id, ''));
+      }
+      stream.emit(successResult());
+
+      await pumpUntil(() => handle.isTurnRunning?.() === false, `long ${model} turn done`);
+      expect(toolLoopError(events)).toBeUndefined();
+      expect(fakeQuery.interrupt).not.toHaveBeenCalled();
+
+      vi.useRealTimers();
+      stream.end();
+      await handle.close().catch(() => undefined);
+    },
+  );
+
+  it.each(['deepseek/deepseek-v4-flash', 'claude-opus-5'])(
+    '%s 真实 SDK 事件流中的稳定 TaskOutput 轮询不会中断 turn',
+    async (model) => {
+      const { handle, stream, events, fakeQuery } = await startSessionWithStream(model);
+
+      vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout', 'Date'] });
+      await handle.send({ type: 'user', content: 'wait for the background task' });
+
+      for (let i = 0; i < 30; i += 1) {
+        const id = `toolu_task_output_${i}`;
+        stream.emit(assistantTaskOutput(id));
+        stream.emit(userToolResult(id, 'still running'));
+      }
+      stream.emit(successResult());
+
+      await pumpUntil(() => handle.isTurnRunning?.() === false, `${model} TaskOutput polling turn done`);
+      expect(toolLoopError(events)).toBeUndefined();
+      expect(fakeQuery.interrupt).not.toHaveBeenCalled();
+
+      vi.useRealTimers();
+      stream.end();
+      await handle.close().catch(() => undefined);
+    },
+  );
 });

--- a/packages/maker-core/src/agents/claude-code/__tests__/upstream-idle-watchdog.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/upstream-idle-watchdog.test.ts
@@ -190,9 +190,14 @@ function successResult(): Record<string, unknown> {
   };
 }
 
-function assistantToolUse(id: string, command = 'sleep 999'): Record<string, unknown> {
+function assistantToolUse(
+  id: string,
+  command = 'sleep 999',
+  parentToolUseId?: string,
+): Record<string, unknown> {
   return {
     type: 'assistant',
+    parent_tool_use_id: parentToolUseId ?? null,
     message: {
       role: 'assistant',
       content: [{ type: 'tool_use', id, name: 'Bash', input: { command } }],
@@ -217,9 +222,14 @@ function assistantTaskOutput(id: string): Record<string, unknown> {
   };
 }
 
-function userToolResult(id: string, content = 'done'): Record<string, unknown> {
+function userToolResult(
+  id: string,
+  content = 'done',
+  parentToolUseId?: string,
+): Record<string, unknown> {
   return {
     type: 'user',
+    parent_tool_use_id: parentToolUseId ?? null,
     message: {
       role: 'user',
       content: [{ type: 'tool_result', tool_use_id: id, content }],
@@ -257,7 +267,7 @@ async function runStableAbabLoop(
   userContent: string,
   idPrefix: string,
 ): Promise<{ loopError: AgentEvent | undefined; interruptCalls: number }> {
-  const { handle, stream, events, fakeQuery } = session;
+  const { handle, stream, events, fakeQuery, collected } = session;
   vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout', 'Date'] });
 
   try {
@@ -295,6 +305,7 @@ async function runStableAbabLoop(
     vi.useRealTimers();
     stream.end();
     await handle.close().catch(() => undefined);
+    await collected;
   }
 }
 
@@ -319,7 +330,7 @@ describe('upstream-response-idle watchdog suspend awareness', () => {
   it('清醒静默满阈值 → 开火;系统挂起 8 小时 → 不开火,随后清醒走满仍开火', async () => {
     // 150s = 60s + 60s + 30s 三个分片,覆盖"满片消耗"与"尾片短于片长"两种形态。
     process.env.XDT_CC_SSE_IDLE_TIMEOUT_MS = '150000';
-    const { handle, stream, events, fakeQuery } = await startSessionWithStream();
+    const { handle, stream, events, fakeQuery, collected } = await startSessionWithStream();
 
     vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout', 'Date'] });
     await handle.send({ type: 'user', content: 'long silent turn' });
@@ -345,11 +356,12 @@ describe('upstream-response-idle watchdog suspend awareness', () => {
     vi.useRealTimers();
     stream.end();
     await handle.close().catch(() => undefined);
+    await collected;
   });
 
   it('工具执行期间停表不开火;tool_result 配对完重新起表、走满才开火', async () => {
     process.env.XDT_CC_SSE_IDLE_TIMEOUT_MS = '120000';
-    const { handle, stream, events, fakeQuery } = await startSessionWithStream();
+    const { handle, stream, events, fakeQuery, collected } = await startSessionWithStream();
 
     vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout', 'Date'] });
     await handle.send({ type: 'user', content: 'run a long tool' });
@@ -375,11 +387,12 @@ describe('upstream-response-idle watchdog suspend awareness', () => {
     vi.useRealTimers();
     stream.end();
     await handle.close().catch(() => undefined);
+    await collected;
   });
 
   it('turn 正常结束 → 清表,不再开火', async () => {
     process.env.XDT_CC_SSE_IDLE_TIMEOUT_MS = '100000';
-    const { handle, stream, events, fakeQuery } = await startSessionWithStream();
+    const { handle, stream, events, fakeQuery, collected } = await startSessionWithStream();
 
     vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout', 'Date'] });
     await handle.send({ type: 'user', content: 'quick turn' });
@@ -393,10 +406,41 @@ describe('upstream-response-idle watchdog suspend awareness', () => {
     vi.useRealTimers();
     stream.end();
     await handle.close().catch(() => undefined);
+    await collected;
   });
 });
 
 describe('Claude Code tool-loop guard runtime integration', () => {
+  it('并发 subagent 的相同调用按 parent 隔离，不会聚合成会话级死循环', async () => {
+    const { handle, stream, events, fakeQuery, collected } = await startSessionWithStream(
+      'claude-opus-5',
+    );
+
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout', 'Date'] });
+    try {
+      await handle.send({ type: 'user', content: 'run four independent subagents' });
+
+      for (let round = 0; round < 3; round += 1) {
+        for (let agent = 0; agent < 4; agent += 1) {
+          const parentToolUseId = `toolu_agent_${agent}`;
+          const id = `${parentToolUseId}_bash_${round}`;
+          stream.emit(assistantToolUse(id, 'git status --short', parentToolUseId));
+          stream.emit(userToolResult(id, 'clean', parentToolUseId));
+        }
+      }
+      stream.emit(successResult());
+
+      await pumpUntil(() => handle.isTurnRunning?.() === false, 'parallel subagent turn done');
+      expect(toolLoopError(events)).toBeUndefined();
+      expect(fakeQuery.interrupt).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+      stream.end();
+      await handle.close().catch(() => undefined);
+      await collected;
+    }
+  });
+
   it('claude-opus-5 的稳定 ABAB Bash 循环在第 12 个结果处中断', async () => {
     const result = await runStableAbabLoop(
       await startSessionWithStream('claude-opus-5'),
@@ -458,7 +502,7 @@ describe('Claude Code tool-loop guard runtime integration', () => {
   it.each(['deepseek/deepseek-v4-flash', 'claude-opus-5'])(
     '%s 真实 SDK 事件流中的 150 次不同调用与空结果可以完成同一个 turn',
     async (model) => {
-      const { handle, stream, events, fakeQuery } = await startSessionWithStream(model);
+      const { handle, stream, events, fakeQuery, collected } = await startSessionWithStream(model);
 
       vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout', 'Date'] });
       await handle.send({ type: 'user', content: 'analyze 150 different projects' });
@@ -477,13 +521,14 @@ describe('Claude Code tool-loop guard runtime integration', () => {
       vi.useRealTimers();
       stream.end();
       await handle.close().catch(() => undefined);
+      await collected;
     },
   );
 
   it.each(['deepseek/deepseek-v4-flash', 'claude-opus-5'])(
     '%s 真实 SDK 事件流中的稳定 TaskOutput 轮询不会中断 turn',
     async (model) => {
-      const { handle, stream, events, fakeQuery } = await startSessionWithStream(model);
+      const { handle, stream, events, fakeQuery, collected } = await startSessionWithStream(model);
 
       vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout', 'Date'] });
       await handle.send({ type: 'user', content: 'wait for the background task' });
@@ -502,6 +547,7 @@ describe('Claude Code tool-loop guard runtime integration', () => {
       vi.useRealTimers();
       stream.end();
       await handle.close().catch(() => undefined);
+      await collected;
     },
   );
 });

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -232,18 +232,17 @@ function legacyToSdkModelString(model: string): string {
   return model;
 }
 
-/**
- * ToolLoopGuard 必须基于 maker-core 对外暴露的 model id 判断。
- * SDK 字符串会被 toSdkModelString 改写(例如 Sonnet 5 变成 claude-sonnet-5[1m]),
- * 容易把 provider 细节和公开模型选择混在一起; host 注入的 DeepSeek id
- * 当前为 deepseek/deepseek-v4-pro 与 deepseek/deepseek-v4-flash。
- */
-function isDeepSeekModel(model: string): boolean {
-  return model.startsWith('deepseek/');
-}
-
 function isProviderRoutedModel(model: string): boolean {
   return !model.startsWith('claude-');
+}
+
+/**
+ * 结果感知的硬中断目前只覆盖既有 DeepSeek 与原生 Claude 系列。
+ * 其他 provider-routed 模型需要独立确认产品口径,不能因共用 Claude Code harness
+ * 就自动扩大行为。这里基于 maker-core 公开 model id 判断,不使用带 [1m] 的 SDK id。
+ */
+function shouldUseToolLoopGuard(model: string): boolean {
+  return model.startsWith('deepseek/') || model.startsWith('claude-');
 }
 
 /** URL → host(路由决策日志用,失败返回 undefined,不抛)。 */
@@ -2131,7 +2130,7 @@ export class ClaudeCodeAgent extends BaseAgent {
       autoReviewDecisionCache.set(key, pending);
       return pending;
     };
-    let toolLoopGuard: ToolLoopGuard | null = isDeepSeekModel(mutableModel)
+    let toolLoopGuard: ToolLoopGuard | null = shouldUseToolLoopGuard(mutableModel)
       ? new ToolLoopGuard()
       : null;
     let mutableEffort: Effort = opts.effort ?? 'high';
@@ -5853,7 +5852,7 @@ export class ClaudeCodeAgent extends BaseAgent {
             triggerAutoCompactIfNeeded();
           }
         }
-        toolLoopGuard = isDeepSeekModel(mutableModel) ? new ToolLoopGuard() : null;
+        toolLoopGuard = shouldUseToolLoopGuard(mutableModel) ? new ToolLoopGuard() : null;
       },
 
       async setEffort(newEffort: Effort) {

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -2130,9 +2130,22 @@ export class ClaudeCodeAgent extends BaseAgent {
       autoReviewDecisionCache.set(key, pending);
       return pending;
     };
-    let toolLoopGuard: ToolLoopGuard | null = shouldUseToolLoopGuard(mutableModel)
-      ? new ToolLoopGuard()
+    let toolLoopGuards: Map<string | null, ToolLoopGuard> | null = shouldUseToolLoopGuard(mutableModel)
+      ? new Map()
       : null;
+    const getToolLoopGuard = (parentToolUseId?: string): ToolLoopGuard | null => {
+      if (!toolLoopGuards) return null;
+      const scopeKey = parentToolUseId ?? null;
+      let guard = toolLoopGuards.get(scopeKey);
+      if (!guard) {
+        guard = new ToolLoopGuard();
+        toolLoopGuards.set(scopeKey, guard);
+      }
+      return guard;
+    };
+    const resetToolLoopGuards = (): void => {
+      toolLoopGuards?.clear();
+    };
     let mutableEffort: Effort = opts.effort ?? 'high';
     let mutablePermissionMode: PermissionMode = reviewMode ? 'ask' : opts.permissionMode ?? 'default';
     // 计划模式(与 permissionMode 正交, **一次性选择**): mutablePlanMode 是 UI 勾选的
@@ -2502,7 +2515,7 @@ export class ClaudeCodeAgent extends BaseAgent {
         sdkSessionId,
       });
       beginNewTurn();
-      toolLoopGuard?.resetTurn();
+      resetToolLoopGuards();
       turnInFlight = true;
       inputQueue.push({
         type: 'user',
@@ -4150,7 +4163,7 @@ export class ClaudeCodeAgent extends BaseAgent {
             // 消息"(assistant / stream_event)为证据补登记；若 provider 已给上一
             // done 锁存 continuation claim，result-only 也能证明自动续 turn 已开始。
             // 随后镜像 send 入口的
-            // per-turn 状态重置(beginNewTurn + toolLoopGuard.resetTurn),否则 guard
+            // per-turn 状态重置(beginNewTurn + resetToolLoopGuards),否则 guard
             // 会带着上一轮的陈旧计数误判。
             // 排除两种非新 turn 场景:
             //  - interruptRequested:watchdog / tool-loop 已 q.interrupt(),SDK 残留
@@ -4193,7 +4206,7 @@ export class ClaudeCodeAgent extends BaseAgent {
                 sdkSessionId,
               });
               beginNewTurn();
-              toolLoopGuard?.resetTurn();
+              resetToolLoopGuards();
               turnInFlight = true;
             }
             noteUpstreamResponseActivity(typeof rawType === 'string' ? rawType : 'unknown');
@@ -4233,15 +4246,20 @@ export class ClaudeCodeAgent extends BaseAgent {
                 }
                 completeTranslatedTurnEnd();
               },
-              onToolUseStart: (id: string, toolName?: unknown, input?: unknown) => {
+              onToolUseStart: (
+                id: string,
+                toolName?: unknown,
+                input?: unknown,
+                parentToolUseId?: string,
+              ) => {
                 pendingToolIds.add(id);
-                toolLoopGuard?.onToolUse(id, toolName, input);
+                getToolLoopGuard(parentToolUseId)?.onToolUse(id, toolName, input);
                 clearUpstreamResponseIdle();
               },
-              onToolResultDone: (id: string, output: string) => {
+              onToolResultDone: (id: string, output: string, parentToolUseId?: string) => {
                 pendingToolIds.delete(id);
                 if (turnInFlight) {
-                  const verdict = toolLoopGuard?.onToolResult(id, output);
+                  const verdict = getToolLoopGuard(parentToolUseId)?.onToolResult(id, output);
                   if (verdict?.kind === 'hard') {
                     const loopHint = verdict.reason === 'consecutive'
                       ? `连续 ${verdict.count} 次发起完全相同的 ${verdict.toolName} 调用`
@@ -4607,7 +4625,7 @@ export class ClaudeCodeAgent extends BaseAgent {
       // 全新 query + startForwardLoop 等价于 startSession 首次起 q 的空闲态。
       if (replayInput) {
         beginNewTurn();
-        toolLoopGuard?.resetTurn();
+        resetToolLoopGuards();
         turnInFlight = true;
       }
       try {
@@ -5144,7 +5162,7 @@ export class ClaudeCodeAgent extends BaseAgent {
         // 兜底重置 currentTurn —— 上一 turn 异常 / abort 时 endTurn 可能没跑,
         // 防止 currentTurn 残留累加到下一 turn (lastApi / contextWindow / cost 跨 turn 保留)
         beginNewTurn();
-        toolLoopGuard?.resetTurn();
+        resetToolLoopGuards();
         // 标记 turn 进入 in-flight 态 (translator.onTurnEnd 在 result 事件回调时清);
         // rewind preview/commit 守卫读 isTurnRunning() 决定能否操作。
         sendInAcceptPhase = true;
@@ -5852,7 +5870,7 @@ export class ClaudeCodeAgent extends BaseAgent {
             triggerAutoCompactIfNeeded();
           }
         }
-        toolLoopGuard = shouldUseToolLoopGuard(mutableModel) ? new ToolLoopGuard() : null;
+        toolLoopGuards = shouldUseToolLoopGuard(mutableModel) ? new Map() : null;
       },
 
       async setEffort(newEffort: Effort) {

--- a/packages/maker-core/src/agents/claude-code/translator.ts
+++ b/packages/maker-core/src/agents/claude-code/translator.ts
@@ -471,15 +471,23 @@ interface TranslateContext {
    * 缺省 = 不回调 (旧调用方零改动)。
    */
   onTurnEnd?: () => void;
-  /** upstream-response-idle watchdog / loop guard: assistant / stream_event 含 tool_use 时回调。 */
-  onToolUseStart?: (toolUseId: string, toolName?: unknown, input?: unknown) => void;
+  /**
+   * upstream-response-idle watchdog / loop guard: assistant / stream_event 含 tool_use 时回调。
+   * parentToolUseId 用于隔离并发 subagent；缺省表示顶层 agent。
+   */
+  onToolUseStart?: (
+    toolUseId: string,
+    toolName?: unknown,
+    input?: unknown,
+    parentToolUseId?: string,
+  ) => void;
   /**
    * upstream-response-idle watchdog: user 含 tool_result 时出队, 配对 onToolUseStart。
    * 不要复用 extractToolResultFullText — 那里 fullText.length>0 过滤会漏空内容 result
    * (Bash 无 stdout / Write 成功 / MCP return null), 导致 pendingToolIds 永远漏减,
-   * watchdog 整 turn 失效。
+   * watchdog 整 turn 失效。parentToolUseId 与 tool_use 同源，用于隔离并发 subagent。
    */
-  onToolResultDone?: (toolUseId: string, output: string) => void;
+  onToolResultDone?: (toolUseId: string, output: string, parentToolUseId?: string) => void;
   onSubagentTaskLaunched?: (task: {
     taskId: string;
     parentToolUseId: string;
@@ -509,6 +517,7 @@ export function translateSdkMessage(
     type?: string;
     subtype?: string;
     session_id?: string;
+    parent_tool_use_id?: string | null;
     model?: string;
     message?: { content?: Array<Record<string, unknown>>; role?: string };
     event?: Record<string, unknown>;
@@ -549,6 +558,9 @@ export function translateSdkMessage(
     case 'user': {
       // streaming-input 模式下 SDK 不 echo 真实 user 输入, 只 echo tool_result 包装的 user message
       // 这里只关心后者: 抽 tool_result_full 给 renderer (老 agentManager.ts:2178-2207 同等逻辑)
+      const parentToolUseId = typeof msg.parent_tool_use_id === 'string' && msg.parent_tool_use_id
+        ? msg.parent_tool_use_id
+        : undefined;
       const fullPairs = extractToolResultFullText(msg.message, ctx.rt);
       for (const pair of fullPairs) {
         queue.push({
@@ -596,7 +608,7 @@ export function translateSdkMessage(
             const pair = rawPair ? normalizeToolResultFullText(rawPair, ctx.rt) : null;
             if (!pair) continue;
             completedToolUseIds.add(pair.toolUseId);
-            ctx.onToolResultDone(pair.toolUseId, pair.fullText);
+            ctx.onToolResultDone(pair.toolUseId, pair.fullText, parentToolUseId);
           }
         }
       } else if (Array.isArray(content)) {
@@ -1062,7 +1074,11 @@ function assistantBlockHasSubstance(block: Record<string, unknown>): boolean {
 }
 
 function handleAssistant(
-  msg: { message?: { content?: Array<Record<string, unknown>> }; error?: string },
+  msg: {
+    message?: { content?: Array<Record<string, unknown>> };
+    error?: string;
+    parent_tool_use_id?: string | null;
+  },
   queue: EventQueue,
   ctx: TranslateContext,
 ): void {
@@ -1122,6 +1138,9 @@ function handleAssistant(
   ctx.turn.pendingApiError = null;
   ctx.rt.lastAssistantMeta = assistantMeta;
 
+  const parentToolUseId = typeof msg.parent_tool_use_id === 'string' && msg.parent_tool_use_id
+    ? msg.parent_tool_use_id
+    : undefined;
   const content = msg.message?.content ?? [];
   // silent-stop 观测素材: 本条消息是否带实质内容(非空 text / 非 thinking 块)。
   // 未知块 fail-safe 为有内容，避免 SDK 新 block 被误续跑。
@@ -1152,7 +1171,7 @@ function handleAssistant(
         if (typeof block.name === 'string' && block.name.length > 0) {
           ctx.rt.toolUseIdToName.set(block.id, block.name);
         }
-        ctx.onToolUseStart?.(block.id, block.name, block.input);
+        ctx.onToolUseStart?.(block.id, block.name, block.input, parentToolUseId);
       }
       queue.push({
         type: 'tool_use',
@@ -1206,6 +1225,10 @@ function handleStreamEvent(
   } | undefined;
   if (!event) return;
 
+  const parentToolUseId = typeof msg.parent_tool_use_id === 'string' && msg.parent_tool_use_id
+    ? msg.parent_tool_use_id
+    : undefined;
+
   // 冗余 add: 防 SDK 顺序契约变化 (stream_event 先于 assistant message yield), Set 幂等。
   if (event.type === 'content_block_start') {
     const cb = event.content_block;
@@ -1213,16 +1236,13 @@ function handleStreamEvent(
       if (typeof cb.name === 'string' && cb.name.length > 0) {
         ctx.rt.toolUseIdToName.set(cb.id, cb.name);
       }
-      ctx.onToolUseStart?.(cb.id, cb.name, cb.input);
+      ctx.onToolUseStart?.(cb.id, cb.name, cb.input, parentToolUseId);
     }
   }
 
   // SDKPartialAssistantMessage 自带 parent_tool_use_id；并发 subagent 会在同一 Query
   // 事件流中交错，必须按 parent 隔离模型，不能使用会话级 lastAssistantMeta 串联。
   // 老 SDK / 单测若没有 wrapper 元数据，才保留旧兜底行为。
-  const parentToolUseId = typeof msg.parent_tool_use_id === 'string' && msg.parent_tool_use_id
-    ? msg.parent_tool_use_id
-    : undefined;
   const streamKey = parentToolUseId ?? '__main__';
   const eventModel = event.message?.model;
   if (typeof eventModel === 'string' && eventModel) {


### PR DESCRIPTION
## 这次改了什么

### 摘要

Claude Code 的结果感知工具循环保护原本只在 `deepseek/*` 模型下启用，导致 `claude-opus-5` 遇到稳定的 ABAB 工具调用循环时无法自动收口。

本 PR 复用现有 `ToolLoopGuard`，为原生 `claude-*` 模型启用相同保护，并覆盖会话启动和运行时模型切换路径。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他

### 范围

- 关联 Issue / 需求：#2721
- 本 PR 包含：
  - 为原生 `claude-*` 模型启用现有 result-aware tool-loop guard
  - 覆盖会话启动和 `setModel` 热切换路径
  - 增加 `claude-opus-5` 稳定 ABAB 循环回归
  - 保留 150 次不同调用和 `TaskOutput` 轮询负例
  - 增加 provider-routed 模型边界测试
- 明确不包含：
  - 不恢复单 turn 工具调用总数硬上限
  - 不修改现有循环判据和阈值
  - 不扩展到 Codex 等未确认的 provider-routed 模型
  - 不处理 `Shell cwd was reset` 文案
- 用户可见变化：原生 Claude 模型遇到高置信低熵工具循环时，会产生 `tool_use_loop_detected` 终态错误并中断当前 turn
- 是否存在 breaking change：无

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm.cmd --filter @cindy/maker-core exec vitest run src/agents/shared/loop-guard.test.ts src/agents/claude-code/__tests__/upstream-idle-watchdog.test.ts
结果：2 个文件、23 项测试全部通过

pnpm.cmd --filter @cindy/maker-core run --if-present typecheck
结果：退出码 0；maker-core 当前没有独立 typecheck script

pnpm.cmd test:unit:related
基准：upstream/main@9c212821b
结果：
PASS apps/desktop unit
PASS packages/lizi-mcps unit
PASS packages/maker-core related
PASS packages/orca-workflow unit

pnpm.cmd check:dco
结果：1 个 commit 通过 DCO

git diff --check
结果：通过
```

### 手工验证

不涉及。缺陷通过受控 Claude Code SDK 事件流稳定复现。

### 未执行的验证

未使用真实账号等待完整的 50 分钟循环；已用报告中的 ABAB 事件形态构造确定性运行时回归，并验证第 12 个结果处收口。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：原生 Claude 模型新增自动硬中断行为

### 影响与回滚

- 影响范围：既有 `deepseek/*` 行为保持不变；新增覆盖原生 `claude-*`。Codex 等 provider-routed 模型仍不启用该硬中断。
- 回滚 / 降级方式：回退 commit `8378a3307`，即可恢复为仅 DeepSeek 启用 guard。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动不涉及
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要测试
- [x] 已确认测试结果
