### PR TITLE
fix(desktop): 把 warning toast 默认停留拉到 8 秒

### DIFF
--- a/apps/desktop/src/renderer/__tests__/toastDuration.test.ts
+++ b/apps/desktop/src/renderer/__tests__/toastDuration.test.ts
@@ -1,0 +1,68 @@
+/**
+ * toastDuration.test.ts
+ * ---------------------------------------------------------------------------
+ * warning 与 error 共用 8000ms 默认停留：警告常带操作指引，1.2s 读不完。
+ * info / success 仍保持 1200ms。显式 duration 覆盖默认。
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { getToastSnapshot, toast } from '../lib/toast';
+
+/** 退出动画时长（与 lib/toast.ts 的 EXIT_ANIMATION_MS 对齐）+ 少量余量 */
+const EXIT_MS = 300 + 50;
+
+function item(id: string) {
+  return getToastSnapshot().find((t) => t.id === id);
+}
+
+function isVisible(id: string): boolean {
+  return getToastSnapshot().some((t) => t.id === id);
+}
+
+describe('toast default duration', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    toast.dismissAll();
+    vi.advanceTimersByTime(EXIT_MS);
+    vi.useRealTimers();
+  });
+
+  it('info / success 默认 1200ms', () => {
+    const infoId = toast.info('i');
+    const successId = toast.success('s');
+    expect(item(infoId)?.duration).toBe(1200);
+    expect(item(successId)?.duration).toBe(1200);
+  });
+
+  it('warning / error 默认 8000ms', () => {
+    const warningId = toast.warning('w');
+    const errorId = toast.error('e');
+    expect(item(warningId)?.duration).toBe(8000);
+    expect(item(errorId)?.duration).toBe(8000);
+  });
+
+  it('warning 在 1200ms 后仍可见，8000ms 后退出', () => {
+    const id = toast.warning('switch provider');
+    vi.advanceTimersByTime(1200);
+    expect(isVisible(id)).toBe(true);
+    expect(item(id)?.exiting).toBe(false);
+
+    vi.advanceTimersByTime(6800);
+    expect(item(id)?.exiting).toBe(true);
+
+    vi.advanceTimersByTime(EXIT_MS);
+    expect(isVisible(id)).toBe(false);
+  });
+
+  it('显式 duration 覆盖 warning 默认', () => {
+    const id = toast.warning('custom', { duration: 4000 });
+    expect(item(id)?.duration).toBe(4000);
+
+    vi.advanceTimersByTime(4000);
+    expect(item(id)?.exiting).toBe(true);
+  });
+});

--- a/apps/desktop/src/renderer/lib/toast.ts
+++ b/apps/desktop/src/renderer/lib/toast.ts
@@ -5,8 +5,8 @@
  * - 无 Provider。任意代码（包括非 React 的 fetch 拦截器）都可调用 toast.xxx()
  * - 模块级单例 Store，用 useSyncExternalStore 订阅
  * - 最大并发 3 条，超出部分 FIFO 进入等待队列
- * - 默认 duration 按 variant 区分：success / warning 1200ms，error 8000ms
- *   （错误信息需要用户读完，太短根本来不及看清）；0 表示永久显示
+ * - 默认 duration 按 variant 区分：info / success 1200ms，warning / error 8000ms
+ *   （警告和错误都需要用户读完，太短根本来不及看清）；0 表示永久显示
  * - hover 悬停时暂停自动关闭（pauseAutoDismiss / resumeAutoDismiss），移开后按剩余时长继续
  * - 退出动画完成后（200ms）才真正从 state 移除
  *
@@ -27,7 +27,7 @@ export interface ToastSource {
 }
 
 export interface ToastOptions {
-  /** 自动关闭时长（ms）。不传时按 variant 取默认：info / success / warning 1200，error 8000；0 表示永久显示 */
+  /** 自动关闭时长（ms）。不传时按 variant 取默认：info / success 1200，warning / error 8000；0 表示永久显示 */
   duration?: number;
   /** 来源身份头（见 ToastSource；主机自己的提示不传） */
   source?: ToastSource;
@@ -52,8 +52,8 @@ export interface ToastItem {
 // ============================================================
 
 const DEFAULT_DURATION = 1200;
-// error 提示需要用户读完（且常带诊断信息），默认停留时间显著拉长
-const DEFAULT_ERROR_DURATION = 8000;
+// warning / error 都需要用户读完（warning 常带操作指引，error 常带诊断），默认停留显著拉长
+const DEFAULT_ALERT_DURATION = 8000;
 const MAX_ACTIVE = 3;
 const EXIT_ANIMATION_MS = 300;
 
@@ -224,11 +224,7 @@ function finalizeRemove(id: string) {
 // 对外命令式 API
 // ============================================================
 
-function createItem(
-  variant: ToastVariant,
-  message: string,
-  options?: ToastOptions,
-): string {
+function createItem(variant: ToastVariant, message: string, options?: ToastOptions): string {
   const id = generateId();
   const item: ToastItem = {
     id,
@@ -236,7 +232,7 @@ function createItem(
     message,
     duration:
       options?.duration ??
-      (variant === 'error' ? DEFAULT_ERROR_DURATION : DEFAULT_DURATION),
+      (variant === 'error' || variant === 'warning' ? DEFAULT_ALERT_DURATION : DEFAULT_DURATION),
     ...(options?.source ? { source: options.source } : {}),
     onClose: options?.onClose,
     createdAt: Date.now(),


### PR DESCRIPTION
## 这次改了什么

### 摘要

黄色 warning toast 以前默认只停 1.2 秒，带操作指引的提示（例如「当前供应商暂不支持 AI 命名，请切换供应商后再试」）来不及读完就会消失。现在 warning 与 error 共用 8 秒默认停留；info / success 仍是 1.2 秒。显式传入的 `duration` 不受影响。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：`toast.warning()` 默认 duration 从 1200ms 改为 8000ms，并补默认时长单测
- 明确不包含：不改 toast 视觉、不改 error / info / success 默认时长、不改调用方已显式传入的 duration
- 用户可见变化：所有未自定义时长的黄色 warning toast 会多停约 6.8 秒
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：DESIGN.md §2 Semantic & Accent / Toast —— Toast 四色与 pill 视觉不变。本次只改 warning 的默认自动关闭时长（1.2s → 8s，与 error 对齐），让用户读完操作指引；info / success 仍 1.2s。悬停暂停关闭的既有行为不变。

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：PASS apps/desktop unit（含新增 toastDuration.test.ts）

pnpm --filter desktop run typecheck
结果：通过

pnpm exec prettier --check apps/desktop/src/renderer/lib/toast.ts apps/desktop/src/renderer/__tests__/toastDuration.test.ts
结果：通过

pnpm check:dco
结果：通过（1 commit signed off）

/Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh
结果：FAIL TEST_ASSERTION_FAILED apps/desktop unit
  失败项：src/main/cindy-brain/__tests__/ghostInstallReceipt.test.ts 2 条
  与本 PR diff 无关。已在干净 origin/main checkout 复现同一失败，属基线问题，交 CI 给权威结论。
```

### 手工验证

未在运行中的 Desktop 实例目检（本 worktree 改动不会热更到宿主 app）。逻辑由 `toastDuration.test.ts` 锁定：warning 在 1200ms 后仍可见，8000ms 后退出。

### 未执行的验证

实机 Light / Dark 目检未做：视觉与双模式样式未改，只改自动关闭计时。

## 风险

### 风险分类

- [x] 其他：warning toast 停留变长，短时连续触发时最多 3 条同时在场的排队窗口会更久

### 影响与回滚

- 影响范围：Desktop 所有走 `toast.warning()` 且未显式传 duration 的提示
- 回滚 / 降级方式：revert 本 PR 即可恢复 1.2s 默认
- 存量插件影响：无

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
