### PR TITLE
fix(desktop): 无标题通道的供应商改走官方 Cindy AI 起名

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/titleOneShot.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/titleOneShot.test.ts
@@ -6,7 +6,8 @@
  *   2. buildTitleTarget:据 catalog titleModel 组装目标(模型 / 最低 effort / wire / upstream)
  *      —— 同时锁定 providers.json 里三家 titleModel 的配置(haiku / gpt-5.4-mini / gpt-5.4-mini)。
  *   3. generateTitleViaProvider:三家 wire 各发一次 fetch,断言 URL/headers/body 形状 + 响应解析;
- *      凭证缺失 / 非 2xx → 返回 null(不抛、不试别家)。
+ *      凭证缺失 / 非 2xx → 返回 null(不抛;有标题 wire 的供应商不试别家)。
+ *      无标题 wire 的会话供应商在官方 `xd` 已连接时回落官方通道。
  *
  * electron 在此 mock(stub app.getPath)纯粹是为了让 import 链(auth-adapters 顶层单例)能在
  * 无 electron 的 vitest 里加载;真正的凭证 / fetch / 会话 provider 全部经 deps 注入,不碰真实实现。
@@ -341,7 +342,7 @@ describe('generateTitleViaProvider — provider 解析', () => {
 });
 
 describe('generateTitleViaProviderResult — 手动重命名失败语义', () => {
-  it('direct custom DeepSeek 没有受支持的标题 wire → unsupported-provider', async () => {
+  it('无标题 wire 的会话供应商且官方未连接 → unsupported-provider', async () => {
     const fetchImpl = fakeFetch(() => ({
       json: { choices: [{ message: { content: '不应出现' } }] },
     }));
@@ -369,6 +370,43 @@ describe('generateTitleViaProviderResult — 手动重命名失败语义', () =>
         },
       ),
     ).resolves.toBeNull();
+  });
+
+  it('无标题 wire 的会话供应商 + 官方已连接 → 走 xd 网关', async () => {
+    setXdGatewayModels([xdGatewayModel('deepseek/deepseek-v4-flash', 'chat')]);
+    try {
+      const fetchImpl = fakeFetch(() => ({
+        json: { choices: [{ message: { content: '官方标题' } }] },
+      }));
+
+      await expect(
+        generateTitleViaProviderResult(
+          { sessionId: 's-deepseek-official', agentKind: 'claude-code', prompt: 'x' },
+          {
+            fetchImpl,
+            readSessionProviderId: async () => 'deepseek',
+            listConnectedProviders: async () => [providerStub('deepseek'), providerStub('xd')],
+            readGatewayKey: () => 'gk',
+          },
+        ),
+      ).resolves.toEqual({ status: 'ok', title: '官方标题' });
+      expect(String(vi.mocked(fetchImpl).mock.calls[0][0])).toContain('/v1/chat/completions');
+
+      // 自动起名同样走官方,不再折叠为启发式。
+      await expect(
+        generateTitleViaProvider(
+          { sessionId: 's-deepseek-official', agentKind: 'claude-code', prompt: 'x' },
+          {
+            fetchImpl,
+            readSessionProviderId: async () => 'deepseek',
+            listConnectedProviders: async () => [providerStub('deepseek'), providerStub('xd')],
+            readGatewayKey: () => 'gk',
+          },
+        ),
+      ).resolves.toBe('官方标题');
+    } finally {
+      setXdGatewayModels([]);
+    }
   });
 
   it('XD 结构上受支持但实时目录暂无聊天模型 → failed', async () => {

--- a/apps/desktop/src/main/maker-host/title-one-shot.ts
+++ b/apps/desktop/src/main/maker-host/title-one-shot.ts
@@ -9,8 +9,11 @@
  *   - xd 网关        → litellm chat-completions(`/v1/chat/completions`,Bearer 网关 key)
  *
  * 约束(用户敲定):
- *   - **只试本会话的单一 provider,不做跨 provider 兜底**。凭证缺失 / HTTP 失败 / 空响应 → 返回
- *     null,调用方(renderer scheduleAutoName)回落到「消息前 N 字」启发式。
+ *   - **本会话供应商有标题 wire 时,只试这一家,不做跨 provider 兜底**。凭证缺失 /
+ *     HTTP 失败 / 空响应 → 返回 null,调用方(renderer scheduleAutoName)回落「消息前 N 字」启发式。
+ *   - **本会话供应商没有标题 wire 时,回落到官方 `xd`(个人账号 Cindy AI /企业登录 XD,同一
+ *     provider)**。官方未连接或组不出标题目标 → 手动重命名报 TITLE_PROVIDER_UNSUPPORTED,自动起名仍
+ *     折叠为启发式。官方通道自己的凭证 / HTTP 失败同样不再 hop。
  *   - **不实现 token 自动 refresh** —— OAuth/订阅 token 的刷新由 cc 子进程 / codex app-server 负责
  *     (它们读写同一处凭证),本模块每次实时读当下值;过期就当次失败、优雅降级。
  *   - 三条标题调用都**不注入任何 system / 身份提示词**(实测 anthropic 裸调即 200),不触及系统提示词。
@@ -102,6 +105,9 @@ export type TitleOneShotResult =
 
 /** 当前实现具备完整凭证与 wire 契约的供应商；目标暂不可用不等于供应商不受支持。 */
 const TITLE_ONE_SHOT_PROVIDER_IDS = new Set(['anthropic', 'openai', 'xd']);
+
+/** 无标题 wire 的会话供应商回落到官方 Cindy AI / XD 网关(同一 provider id)。 */
+const OFFICIAL_TITLE_FALLBACK_ID = 'xd';
 
 /** 注入点 —— 便于单测(mock fetch / 伪造凭证 / 伪造 provider)。缺省均返回 null(回落启发式)。 */
 export interface TitleOneShotDeps {
@@ -396,8 +402,8 @@ export function parseResponsesSse(raw: string): string {
 
 /**
  * 标题 oneShot 诊断入口:解析本会话 provider → titleModel → 单次 HTTP 起标题。
- * 仅区分“当前供应商不支持”与通用失败，供手动 AI 重命名给出可操作提示。
- * 全程不打印 token(只记 providerId / model / wire / 耗时)。
+ * 无标题 wire 的会话供应商先回落官方 `xd`;仍组不出目标时才区分“当前供应商不支持”与通用失败,
+ * 供手动 AI 重命名给出可操作提示。全程不打印 token(只记 providerId / model / wire / 耗时)。
  */
 export async function generateTitleViaProviderResult(
   args: { sessionId: string; agentKind: AgentKind; prompt: string; signal?: AbortSignal },
@@ -435,13 +441,31 @@ export async function generateTitleViaProviderResult(
     return { status: 'failed' };
   }
 
-  const target = buildTitleTarget(providerId);
+  const sessionProviderId = providerId;
+  let target = buildTitleTarget(providerId);
+  // 无标题 wire 的会话供应商(自定义 DeepSeek / xAI 等)回落官方
+  // Cindy AI / XD;有 wire 的三家仍不因组不出目标而 hop。
+  if (!target && !TITLE_ONE_SHOT_PROVIDER_IDS.has(providerId)) {
+    const officialConnected = rail.some((p) => p.id === OFFICIAL_TITLE_FALLBACK_ID);
+    const officialTarget = officialConnected
+      ? buildTitleTarget(OFFICIAL_TITLE_FALLBACK_ID)
+      : null;
+    if (officialTarget) {
+      log.info('title oneShot falling back to official provider', {
+        sessionProviderId,
+        providerId: OFFICIAL_TITLE_FALLBACK_ID,
+        agentKind: args.agentKind,
+      });
+      providerId = OFFICIAL_TITLE_FALLBACK_ID;
+      target = officialTarget;
+    }
+  }
   if (!target) {
-    const status = TITLE_ONE_SHOT_PROVIDER_IDS.has(providerId)
+    const status = TITLE_ONE_SHOT_PROVIDER_IDS.has(sessionProviderId)
       ? 'failed'
       : 'unsupported-provider';
     log.debug('title oneShot skipped: no title target', {
-      providerId,
+      providerId: sessionProviderId,
       agentKind: args.agentKind,
       status,
     });

--- a/apps/desktop/src/main/maker-ipc/title.ts
+++ b/apps/desktop/src/main/maker-ipc/title.ts
@@ -4,7 +4,8 @@
  * 给会话起一个 ≤ 20 字标题。标题 oneShot 已统一为「单次 HTTP 请求」:按本会话所属 provider
  * (WYSIWYG,与模型选择器高亮同口径:DB 显式选中优先,无则取已连接供应商的原生默认)
  * 取 catalog 配的 `titleModel`(最经济模型),用该 provider 自家凭证直起
- * (见 maker-host/title-one-shot)。起不出来(零已连接 / 凭证缺失 / HTTP 失败 / 超时)
+ * (见 maker-host/title-one-shot)。无标题 wire 的会话供应商回落官方 `xd`。
+ * 起不出来(零已连接 / 官方也不可用 / 凭证缺失 / HTTP 失败 / 超时)
  * → 返回 null,renderer 回落「消息前 40 字」启发式。fire-and-forget,
  * 不阻塞主流程,也不向用户暴露失败。
  *


### PR DESCRIPTION
## 这次改了什么

### 摘要

本机点 ✨ AI 命名（以及自动起名）时，如果当前任务挂的供应商没有标题通道（xAI / 自定义 DeepSeek 等），不再直接报「当前供应商暂不支持 AI 命名」，而是回落到已连接的官方 `xd`（个人账号显示 Cindy AI，企业登录显示 XD，同一条网关）。

Anthropic / OpenAI / 官方 `xd` 自己有标题通道时，行为不变：只试这一家，凭证或 HTTP 失败不 hop。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：
  - `generateTitleViaProviderResult`：无标题 wire 且官方 `xd` 已连接时，改走官方网关最经济聊天模型
  - 自动起名走同一条回落（不再静默退化成消息前 N 字）
  - 官方未连接或组不出标题目标时，手动命名仍报 `TITLE_PROVIDER_UNSUPPORTED`
- 明确不包含：
  - 远程 / device-link 任务的控制端兜底（仍在被控端执行，旧被控端行为不变）
  - 有标题 wire 的供应商失败后跨供应商重试
  - Toast 时长或文案
- 用户可见变化：本机任务挂在 xAI / 自定义等供应商时，点 ✨ 或自动起名会用官方额度生成标题，不再闪黄字
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：不涉及：未改界面结构、样式或文案，只改标题 one-shot 的供应商回落。

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：PASS apps/desktop unit（related 3 个文件）

pnpm --filter desktop run typecheck
结果：通过

pnpm --filter desktop exec vitest run \
  src/main/maker-host/__tests__/titleOneShot.test.ts \
  src/main/maker-ipc/__tests__/regenerateSessionTitle.test.ts \
  src/main/maker-ipc/__tests__/autoTitleIpcBoundary.test.ts \
  src/renderer/__tests__/sessionRenameAiFill.test.ts
结果：4 files / 114 tests passed

pnpm check:dco
结果：1 commit signed off

本地全量 `pnpm test:unit`（run-unit-gate.sh）有 2 条失败：
apps/desktop/src/main/cindy-brain/__tests__/ghostInstallReceipt.test.ts
在干净 origin/main checkout 上复现同样失败，与本 PR diff 无关，不混入修复，交 CI 给权威结论。
```

### 手工验证

- 平台：macOS Desktop，`--region=cn --passive` 开发版，与正式版共享 `~/Library/Application Support/Cindy`
- 账号：企业登录（官方供应商显示为 XD）
- 路径：Electron.dev 窗口打开本机 Pi + xAI 任务，双击标题点 ✨ → 生成标题，不再出现「当前供应商暂不支持 AI 命名」
- 远程镜像任务不在本期范围，未要求控制端兜底

### 未执行的验证

- 个人账号（展示名 Cindy AI）路径未再单独点一次，与企业登录共用 `xd` provider
- mobile 本地验证：不涉及，改动仅 desktop main 标题 one-shot

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：无标题通道的本机任务起名会消耗官方额度

### 影响与回滚

- 影响范围：本机自动起名与 Magic 重命名；远程任务仍走被控端旧逻辑
- 回滚 / 降级方式：回退本 commit。官方未连接时行为与改前一致（手动命名黄字，自动起名启发式）
- 存量插件影响：无

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
