### PR TITLE
fix(maker-core): guard grok tool loops and short rotations

### DIFF
--- a/packages/maker-core/src/agents/claude-code/__tests__/upstream-idle-watchdog.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/upstream-idle-watchdog.test.ts
@@ -541,6 +541,75 @@ describe('Claude Code tool-loop guard runtime integration', () => {
     expect(result.interruptCalls).toBe(1);
   });
 
+  it('xai/grok 会话下 4 个不同 Grep 的 ABCD 轮转在第 16 个结果处中断', async () => {
+    const { handle, stream, events, fakeQuery, collected } = await startSessionWithStream(
+      'xai/grok-4.5',
+    );
+
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout', 'Date'] });
+    try {
+      await handle.send({ type: 'user', content: 'find the missing implementation' });
+
+      const greps = [
+        'grep -R "planA" packages',
+        'grep -R "planB" packages',
+        'grep -R "planC" packages',
+        'grep -R "planD" packages',
+      ];
+      for (let i = 0; i < 16; i += 1) {
+        const id = `toolu_grok_rotation_${i}`;
+        stream.emit(assistantToolUse(id, greps[i % 4]));
+        stream.emit(userToolResult(id, `no result ${i}`));
+      }
+
+      await pumpUntil(
+        () => events.filter((event) => event.type === 'tool_result_full').length === 16,
+        'grok rotation tool results processed',
+      );
+      await vi.advanceTimersByTimeAsync(1);
+
+      expect(toolLoopError(events)).toMatchObject({
+        type: 'error',
+        data: {
+          reason: 'tool_use_loop_detected',
+          loopKind: 'rotation',
+          loopCount: 16,
+          model: 'xai/grok-4.5',
+          isTerminal: true,
+        },
+        source: 'claude-code',
+      });
+      expect(fakeQuery.interrupt).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+      stream.end();
+      await handle.close().catch(() => undefined);
+      await collected;
+    }
+  });
+
+  it('claude 会话下裸 id 形态的 grok sidechain 同样受 guard 保护', async () => {
+    const result = await runStableAbabLoop(
+      await startSessionWithStream('claude-opus-5'),
+      'delegate the investigation to a grok subagent',
+      'toolu_grok_sidechain',
+      { parentToolUseId: 'toolu_agent_grok', model: 'grok-4.5' },
+    );
+
+    expect(result.loopError).toMatchObject({
+      type: 'error',
+      data: {
+        reason: 'tool_use_loop_detected',
+        loopKind: 'pingpong',
+        loopCount: 12,
+        model: 'grok-4.5',
+        isTerminal: true,
+      },
+      source: 'claude-code',
+    });
+    expect(result.interruptCalls).toBe(1);
+  });
+
   it('deepseek 会话下裸 id 形态的 deepseek sidechain 仍受 guard 保护', async () => {
     // 流内原始 id 是 deepseek-v4-flash(无 deepseek/ 前缀),家族前缀匹配不得漏判。
     const result = await runStableAbabLoop(
@@ -564,7 +633,7 @@ describe('Claude Code tool-loop guard runtime integration', () => {
     expect(result.interruptCalls).toBe(1);
   });
 
-  it.each(['deepseek/deepseek-v4-flash', 'claude-opus-5'])(
+  it.each(['deepseek/deepseek-v4-flash', 'claude-opus-5', 'xai/grok-4.5'])(
     '%s 真实 SDK 事件流中的 150 次不同调用与空结果可以完成同一个 turn',
     async (model) => {
       const { handle, stream, events, fakeQuery, collected } = await startSessionWithStream(model);
@@ -590,7 +659,7 @@ describe('Claude Code tool-loop guard runtime integration', () => {
     },
   );
 
-  it.each(['deepseek/deepseek-v4-flash', 'claude-opus-5'])(
+  it.each(['deepseek/deepseek-v4-flash', 'claude-opus-5', 'xai/grok-4.5'])(
     '%s 真实 SDK 事件流中的稳定 TaskOutput 轮询不会中断 turn',
     async (model) => {
       const { handle, stream, events, fakeQuery, collected } = await startSessionWithStream(model);

--- a/packages/maker-core/src/agents/claude-code/__tests__/upstream-idle-watchdog.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/upstream-idle-watchdog.test.ts
@@ -588,6 +588,55 @@ describe('Claude Code tool-loop guard runtime integration', () => {
     }
   });
 
+  it('x-ai/grok 网关形态会话下 4 个不同 Grep 的 ABCD 轮转同样会被中断', async () => {
+    // x-ai/ 是网关侧 grok 命名空间(classification.ts 与 xai/ 分开登记),
+    // toSdkModelString 原样透传,顶层会话模型即该形态 —— 不得漏出 guard 覆盖。
+    const { handle, stream, events, fakeQuery, collected } = await startSessionWithStream(
+      'x-ai/grok-4.6',
+    );
+
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout', 'Date'] });
+    try {
+      await handle.send({ type: 'user', content: 'find the missing implementation' });
+
+      const greps = [
+        'grep -R "planA" packages',
+        'grep -R "planB" packages',
+        'grep -R "planC" packages',
+        'grep -R "planD" packages',
+      ];
+      for (let i = 0; i < 16; i += 1) {
+        const id = `toolu_gateway_grok_rotation_${i}`;
+        stream.emit(assistantToolUse(id, greps[i % 4]));
+        stream.emit(userToolResult(id, `no result ${i}`));
+      }
+
+      await pumpUntil(
+        () => events.filter((event) => event.type === 'tool_result_full').length === 16,
+        'gateway grok rotation tool results processed',
+      );
+      await vi.advanceTimersByTimeAsync(1);
+
+      expect(toolLoopError(events)).toMatchObject({
+        type: 'error',
+        data: {
+          reason: 'tool_use_loop_detected',
+          loopKind: 'rotation',
+          loopCount: 16,
+          model: 'x-ai/grok-4.6',
+          isTerminal: true,
+        },
+        source: 'claude-code',
+      });
+      expect(fakeQuery.interrupt).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+      stream.end();
+      await handle.close().catch(() => undefined);
+      await collected;
+    }
+  });
+
   it('claude 会话下裸 id 形态的 grok sidechain 同样受 guard 保护', async () => {
     const result = await runStableAbabLoop(
       await startSessionWithStream('claude-opus-5'),

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -247,12 +247,15 @@ function isProviderRoutedModel(model: string): boolean {
  * 就自动扩大行为。会话级判断用 maker-core 公开 model id(deepseek/…、xai/…);
  * sidechain 的判断来自 SDK 流内的原始 id(可能是裸 deepseek-… / grok-… 形态,
  * 同 toSdkModelString 的双形态),因此按家族前缀匹配,不带 [1m] 的 SDK 改写。
+ * grok 家族按 model-providers classification 口径同时认三种形态:xai/(订阅直连)、
+ * x-ai/(网关命名空间,toSdkModelString 原样透传)与裸 grok-(sidechain 原始 id)。
  */
 function shouldUseToolLoopGuard(model: string): boolean {
   return (
     model.startsWith('deepseek')
     || model.startsWith('claude-')
     || model.startsWith('xai/')
+    || model.startsWith('x-ai/')
     || model.startsWith('grok-')
   );
 }

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -241,14 +241,20 @@ function isProviderRoutedModel(model: string): boolean {
 }
 
 /**
- * 结果感知的硬中断目前只覆盖既有 DeepSeek 与原生 Claude 系列。
+ * 结果感知的硬中断目前覆盖 DeepSeek、原生 Claude 与 xai Grok 系列
+ * (Grok 为 2026-08 维护者确认新增:单 turn 在 4 个不同 Grep 里轮转上千次调用的实锤)。
  * 其他 provider-routed 模型需要独立确认产品口径,不能因共用 Claude Code harness
- * 就自动扩大行为。会话级判断用 maker-core 公开 model id(deepseek/…);sidechain 的
- * 判断来自 SDK 流内的原始 id(可能是裸 deepseek-… 形态,同 toSdkModelString 的双形态),
- * 因此 DeepSeek 按家族前缀匹配,不带 [1m] 的 SDK 改写。
+ * 就自动扩大行为。会话级判断用 maker-core 公开 model id(deepseek/…、xai/…);
+ * sidechain 的判断来自 SDK 流内的原始 id(可能是裸 deepseek-… / grok-… 形态,
+ * 同 toSdkModelString 的双形态),因此按家族前缀匹配,不带 [1m] 的 SDK 改写。
  */
 function shouldUseToolLoopGuard(model: string): boolean {
-  return model.startsWith('deepseek') || model.startsWith('claude-');
+  return (
+    model.startsWith('deepseek')
+    || model.startsWith('claude-')
+    || model.startsWith('xai/')
+    || model.startsWith('grok-')
+  );
 }
 
 /** URL → host(路由决策日志用,失败返回 undefined,不抛)。 */

--- a/packages/maker-core/src/agents/shared/loop-guard.test.ts
+++ b/packages/maker-core/src/agents/shared/loop-guard.test.ts
@@ -62,6 +62,42 @@ describe('ToolLoopGuard', () => {
     }
   });
 
+  // ── 第 3 层: 长窗口轮转(ABCD…) ───────────────────────────────────────────
+  it('4 个不同调用轮转(ABCDABCD…)在轮转窗口填满时判 rotation(对应 grok 4-Grep 实锤)', () => {
+    const g = new ToolLoopGuard(); // rotationWindowSize 16, rotationDistinct<=4
+    const cmds = ['grep -R a', 'grep -R b', 'grep -R c', 'grep -R d'];
+    for (let i = 0; i < 16; i += 1) {
+      const v = feed(g, `id${i}`, 'Grep', { pattern: cmds[i % 4] }, `hits-${i}`);
+      if (i < 15) expect(v.kind).toBe('ok');
+      else expect(v).toMatchObject({ kind: 'hard', reason: 'rotation', count: 16, toolName: 'Grep' });
+    }
+  });
+
+  it('3 个不同调用轮转同样被 rotation 层捕获', () => {
+    const g = new ToolLoopGuard();
+    for (let i = 0; i < 16; i += 1) {
+      const v = feed(g, `id${i}`, 'Bash', { cmd: `check-${i % 3}` }, `o${i}`);
+      if (i < 15) expect(v.kind).toBe('ok');
+      else expect(v).toMatchObject({ kind: 'hard', reason: 'rotation' });
+    }
+  });
+
+  it('5 个不同调用轮转不判 rotation(distinct 超过上限,留给更长证据)', () => {
+    const g = new ToolLoopGuard();
+    for (let i = 0; i < 40; i += 1) {
+      expect(feed(g, `id${i}`, 'Bash', { cmd: `probe-${i % 5}` }, `o${i}`).kind).toBe('ok');
+    }
+  });
+
+  it('轮转中途出现新调用会把窗口 distinct 顶出上限,不误判', () => {
+    const g = new ToolLoopGuard();
+    for (let i = 0; i < 48; i += 1) {
+      // 每 8 次插入一个全新 input:任何 16 连续窗口 distinct ≥ 5
+      const input = i % 8 === 7 ? { cmd: `novel-${i}` } : { cmd: `fix-${i % 4}` };
+      expect(feed(g, `id${i}`, 'Bash', input, `o${i}`).kind).toBe('ok');
+    }
+  });
+
   // ── 合法长 turn / 原生轮询工具 ───────────────────────────────────────────
   it('TaskOutput 状态长期不变仍放行,不会被通用重复判据中断', () => {
     const g = new ToolLoopGuard();

--- a/packages/maker-core/src/agents/shared/loop-guard.ts
+++ b/packages/maker-core/src/agents/shared/loop-guard.ts
@@ -16,6 +16,16 @@ const DEFAULT_WINDOW_SIZE = 12;
 /** 第 2 层:窗口填满后, distinct 指纹数 ≤ 此值即判循环(2 = 一直在 ≤2 种调用里转)。 */
 const DEFAULT_WINDOW_DISTINCT_LIMIT = 2;
 /**
+ * 第 3 层(轮转):更长窗口 + 更宽 distinct 上限,抓第 2 层漏掉的 3-4 个调用
+ * 轮转(ABCDABCD…)。实锤:xai/grok 单 turn 在 4 个不同 Grep 里轮转一千多次
+ * 调用(2026-08),distinct=4 > 2 从第 2 层漏网。16/4 = 每种指纹平均重复 4 次
+ * 才判,比直接把第 2 层 distinct 提到 4 的误判面小;连续 16 次调用零新指纹
+ * 的合法工作流(纯读排查也会穿插不同参数)实践中几乎不存在。
+ */
+const DEFAULT_ROTATION_WINDOW_SIZE = 16;
+/** 第 3 层:轮转窗口填满后, distinct 指纹数 ≤ 此值即判循环。 */
+const DEFAULT_ROTATION_DISTINCT_LIMIT = 4;
+/**
  * TaskOutput 是 SDK 明确定义的等待/轮询工具。状态文本不变只代表任务仍在等待,
  * 不能作为模型死循环证据。它本身不进入指纹,但也不重置普通工具的轨迹,
  * 避免模型通过在重复调用间插入轮询来绕过检测。
@@ -34,21 +44,26 @@ export interface ToolLoopGuardOptions {
   windowSize?: number;
   /** 第 2 层:窗口内 distinct 指纹 ≤ 此值判循环。 */
   windowDistinctLimit?: number;
+  /** 第 3 层:轮转检测的滑动窗口大小。 */
+  rotationWindowSize?: number;
+  /** 第 3 层:轮转窗口内 distinct 指纹 ≤ 此值判循环。 */
+  rotationDistinctLimit?: number;
 }
 
-/** 命中哪一层判据。consecutive=机械重复 / pingpong=短循环。 */
-export type ToolLoopReason = 'consecutive' | 'pingpong';
+/** 命中哪一层判据。consecutive=机械重复 / pingpong=短循环 / rotation=3-4 调用轮转。 */
+export type ToolLoopReason = 'consecutive' | 'pingpong' | 'rotation';
 
 export type ToolLoopGuardVerdict =
   | { kind: 'ok' }
   | { kind: 'hard'; reason: ToolLoopReason; count: number; toolName: string };
 
 /**
- * Result-aware tool loop detector(两层防御)。
+ * Result-aware tool loop detector(三层防御)。
  *
  * 只在非轮询工具结果返回后判断。任一层命中即返回 hard, 由调用方决定如何中断:
  *   1. 连续完全相同(name+input+output)—— 快路径, 零误判;
  *   2. name+input 滑动窗口多样性坍缩 —— 抓 ABAB 交替 / output 易变的重复;
+ *   3. 更长窗口的轮转检测 —— 抓 3-4 个调用的 ABCD 轮转(第 2 层 distinct 上限盖不住)。
  *
  * 不按调用总数或任意长度的重复序列硬中断:仅凭工具 trace 无法区分合法批处理、
  * 稳定状态轮询与死循环,有限窗口也只能移动误判/漏判边界。
@@ -59,6 +74,8 @@ export class ToolLoopGuard {
   readonly consecutiveLimit: number;
   readonly windowSize: number;
   readonly windowDistinctLimit: number;
+  readonly rotationWindowSize: number;
+  readonly rotationDistinctLimit: number;
 
   private pendingToolUses = new Map<string, PendingToolUse>();
 
@@ -66,13 +83,15 @@ export class ToolLoopGuard {
   private lastFullFingerprint: string | null = null;
   private consecutiveStreak = 0;
 
-  // 第 2 层状态: 最近 windowSize 个 name+input 指纹
+  // 第 2/3 层共用状态: 最近 max(windowSize, rotationWindowSize) 个 name+input 指纹
   private callWindow: string[] = [];
 
   constructor(options: ToolLoopGuardOptions = {}) {
     this.consecutiveLimit = options.consecutiveLimit ?? DEFAULT_CONSECUTIVE_LIMIT;
     this.windowSize = options.windowSize ?? DEFAULT_WINDOW_SIZE;
     this.windowDistinctLimit = options.windowDistinctLimit ?? DEFAULT_WINDOW_DISTINCT_LIMIT;
+    this.rotationWindowSize = options.rotationWindowSize ?? DEFAULT_ROTATION_WINDOW_SIZE;
+    this.rotationDistinctLimit = options.rotationDistinctLimit ?? DEFAULT_ROTATION_DISTINCT_LIMIT;
   }
 
   /**
@@ -112,17 +131,35 @@ export class ToolLoopGuard {
       };
     }
 
-    // 第 2 层: name+input 滑动窗口多样性坍缩(指纹不含 output)
+    // 第 2/3 层: name+input 滑动窗口多样性坍缩(指纹不含 output)
     const callFingerprint = fingerprintToolCall(toolUse.name, toolUse.input, null);
     this.callWindow.push(callFingerprint);
-    if (this.callWindow.length > this.windowSize) this.callWindow.shift();
+    const bufferSize = Math.max(this.windowSize, this.rotationWindowSize);
+    if (this.callWindow.length > bufferSize) this.callWindow.shift();
+
+    // 第 2 层: 短窗口 ping-pong(≤2 种调用来回打转)
     if (this.callWindow.length >= this.windowSize) {
-      const distinct = new Set(this.callWindow).size;
+      const recent = this.callWindow.slice(-this.windowSize);
+      const distinct = new Set(recent).size;
       if (distinct <= this.windowDistinctLimit) {
         return {
           kind: 'hard',
           reason: 'pingpong',
-          count: this.callWindow.length,
+          count: recent.length,
+          toolName: toolUse.name,
+        };
+      }
+    }
+
+    // 第 3 层: 长窗口轮转(3-4 种调用 ABCD 轮转,第 2 层 distinct 上限盖不住)
+    if (this.callWindow.length >= this.rotationWindowSize) {
+      const recent = this.callWindow.slice(-this.rotationWindowSize);
+      const distinct = new Set(recent).size;
+      if (distinct <= this.rotationDistinctLimit) {
+        return {
+          kind: 'hard',
+          reason: 'rotation',
+          count: recent.length,
           toolName: toolUse.name,
         };
       }


### PR DESCRIPTION
## 这次改了什么

### 摘要

同事实测 `xai/grok` 模型单 turn 在 4 个不同 Grep 之间轮转（ABCDABCD…）一千多次工具调用、烧掉约 $39，现有 tool-loop guard 两层判据全部漏网：guard 白名单不含 grok（完全未启用），且 4 种不同调用的轮转既不满足"连续全同"、也超出 12 窗口 distinct ≤ 2 的 ping-pong 上限。

本 PR 按维护者确认的口径（只扩 xai Grok，不做全量 provider-routed 启用）做两件事：把 xai Grok 家族加入 guard 白名单；给 `ToolLoopGuard` 新增第 3 层轮转判据（16 窗口 distinct ≤ 4），抓 3-4 个调用的短轮转。

Review 跟进（87e4f8486）：白名单补上网关命名空间形态 `x-ai/grok-*`（与 `xai/`、裸 `grok-` 三形态齐全，对齐 model-providers classification 的 grok 家族口径），并补 `x-ai/grok-4.6` 轮转中断回归。

Review 跟进（实测补齐）：按 `docs/dev-rules/maker-core-and-agent-behavior.md` §3.4 补齐核心指标实测——热路径耗时 A/B 对比与真实 turn 终止行为抽查，方法、原始数据与结论见「怎么验证的」。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他

### 范围

- 关联 Issue / 需求：#2721 的 grok 同型事故（PR #2779 的 follow-up）
- 本 PR 包含：
  - `shouldUseToolLoopGuard` 白名单加 xai Grok 家族（公开 id `xai/grok-*`、网关命名空间 `x-ai/grok-*` 与 sidechain 流内裸 id `grok-*` 三形态）
  - `ToolLoopGuard` 第 3 层轮转判据：16 窗口 distinct ≤ 4，verdict reason 记为 `rotation`；第 1/2 层判据与阈值不变
  - grok ABCD 轮转运行时回归（第 16 个结果处中断，含 `xai/grok-4.5` 与 `x-ai/grok-4.6` 两种会话形态）、裸 grok id sidechain 回归
  - 负例扩充：`xai/grok-4.5` 加入 150 次不同调用与 TaskOutput 轮询 it.each；新增 5 调用轮转不误判、轮转中穿插新调用不误判
- 明确不包含：
  - 不做全量 provider-routed 启用（维护者拍板只加 grok；codex 等仍不启用，有既有边界测试钉住）
  - 不改第 1/2 层判据与阈值
- 用户可见变化：xai Grok 模型（含作为 subagent 时）陷入 ≤2 调用 ping-pong 或 3-4 调用轮转时，产生 `tool_use_loop_detected` 终态错误并中断当前 turn；deepseek/claude 会话同样获得第 3 层轮转保护
- 是否存在 breaking change：无

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 受影响指标（对应 maker-core-and-agent-behavior.md §3.4）

- (a) 受影响指标：**性能/返回速度**（event loop 每工具结果热路径新增 slice/Set 处理）与**返回内容准确性**（自动硬中断范围扩大到 grok + 第 3 层，属终止行为准确性）。**缓存率与 usage 计量不受影响**（无 prompt 拼接、tool 定义或请求内容改动）。
- (b) 方法：热路径耗时用同进程 A/B 基准（baseline = origin/main 的两层 guard，current = 本 PR head 的三层 guard，两版代码喂完全相同的受控事件流）；终止行为用本机真实会话转录重放抽查 + 正负例单测。
- (c) 结论：每工具结果新增绝对开销约 0.3–1.4 µs（详见下），真实 turn 零误中断。

### 自动验证

```text
pnpm --filter @cindy/maker-core exec vitest run src/agents/shared/loop-guard.test.ts src/agents/claude-code/__tests__/upstream-idle-watchdog.test.ts src/agents/claude-code/__tests__/translator-subagent-model.test.ts
结果：3 个文件、43 项测试全部通过（退出码 0）

pnpm --filter @cindy/maker-core exec vitest run src/agents/claude-code/__tests__/rewind-runtime-settings.test.ts
结果：40 项测试全部通过（x-ai/grok-4.6 热切换用例所在文件）

pnpm --filter @cindy/maker-core run build（tsc --noEmit，maker-core 无 typecheck script，按门禁规则该步跳过、以 build 替代）
结果：本 PR 改动文件 0 类型错误；剩余错误全部集中在 src/agents/codex/index.test.ts、src/agents/pi/__tests__/rpc-client.test.ts、src/agents/pi/__tests__/transport.test.ts 三个本 PR 未触碰的既有测试文件（与 origin/main 内容一致），属仓库既有问题

pnpm test:unit:related
结果：packages/maker-core（related 4 文件）、packages/lizi-mcps、packages/orca-workflow 通过；
apps/desktop 的 ghostInstallReceipt.test.ts 2 项失败——
已在干净 PR head（不含本轮改动）与干净 origin/main 的 cindy-brain 源码下分别复现同样失败，属仓库既有失败，与本改动无关（本 PR 只改 packages/maker-core）

pnpm check:dco
结果：2 commits 通过
```

### 手工验证：热路径耗时对比（实测数字）

方法：本机（Apple M4 / arm64，Node v25.8.0）用临时脚本（不进仓库）构造受控事件流，同进程内 A/B 轮换跑 baseline（origin/main 的 `loop-guard.ts`）与本 PR 版本，每轮 `--expose-gc` 强制 GC，10 轮取中位数；完整跑两遍取区间。三场景：

| 场景 | baseline 每事件 | current 每事件 | 增量 |
|---|---|---|---|
| varied：每次调用指纹全异、三层判据全部走完但不触发（N=200k） | 5.4–6.2 µs | 6.1–6.9 µs | **+0.67–0.76 µs（+12%）** |
| rotation：ABCD 轮转、第 16 个结果起持续命中（N=100k） | 3.5–3.8 µs | 4.0–4.1 µs | **+0.32–0.44 µs（+9–13%）** |
| heavy：大 input/output、哈希主导（N=50k） | 10.3–14.5 µs | 10.9–15.9 µs | **+0.52–1.42 µs（+5–10%）** |

新增开销的独立来源测量：`slice(-16)` + `Set(16).size` 裸操作 634–702 ns/op，与上表绝对增量同量级。

结论：每工具结果新增绝对开销约 **0.3–1.4 µs**，不随 payload 大小放大（heavy 场景绝对增量与轻场景同量级，说明增量来自 slice/Set 而非哈希）；guard 既有每事件总成本 4–16 µs，相对增量 ≤ ~12%。工具结果按秒级到达、每 turn 通常几十个，病态 1000 次工具调用/turn 也只多 ~1 ms 墙钟，不可感知。新增成本仅为 16 元素小数组的 slice+Set，无同步 IO、无深拷贝、无大临时对象，符合 §3.2 热路径约束。

### 手工验证：典型真实 turn 终止行为抽查

方法与数据：取本机 Cindy 实际运行产生的真实会话转录（Claude Code JSONL，含 main 与 sidechain 事件流），按生产语义重放——per-turn `resetTurn`、sidechain 按 parentToolUseId 分 scope、TaskOutput 豁免——baseline 与本 PR 两个 guard 喂同一事件流并行对比。**未采集、未提交任何会话内容**，只统计聚合计数与工具名。

- 覆盖：120 个会话（本机仓库会话中按模型名 grep 出的全部 50 个 grok 会话 + 最近 60 个会话 + 2 个 Cindy dialogues 目录 + 8 个 grok subagent 会话，去重后 120 个）、654 turns、4,666 条工具结果、约 108 MB。
- 模型分布：`xai/grok-4.6` 3,710 条、`glm-5.3` 243、`deepseek-v4-pro` 199、`claude-opus-4-6` 190、未知模型 324；生产启用范围（grok/deepseek/claude 家族）内 4,099 条。
- 结果：baseline 与本 PR guard **均 0 次 hard 判定**——真实典型 turn（含 3,710 条真实 grok 工具结果）零误中断，第 3 层在真实数据上不产生额外误杀。
- 阳性对照（验证管线敏感、0 命中即真实无循环而非漏检）：同一重放管线对真实会话前缀注入 64 事件 ABCD 轮转，本 PR guard 在第 16 个注入结果处判 `rotation` 并持续命中（64 事件 49 次 hard），baseline 0 次。

### 未执行的验证

未用真实 xAI 账号复跑完整事故（事故 trace 在同事机，本机无该数据）；终止行为已用「真实事件流重放抽查 + 事故形态确定性回归（第 16 个结果收口）+ 阳性对照」组合覆盖。热路径实测数字本机可得、方法已在上一节写明，可复跑。

## 风险

### 风险分类

- [ ] 无已知风险
- [x] 其他：新增第 3 层轮转判据对已启用 guard 的模型（deepseek/claude/xai）统一生效，理论上扩大了硬中断的触发面

### 影响与回滚

- 影响范围：第 3 层要求 16 次连续调用零新指纹（每种平均重复 4 次）才判，合法工作流插入任何一个新参数调用即把 distinct 顶出上限；负例（150 次不同调用、33 项固定序列、TaskOutput 轮询、5 调用轮转、穿插新调用的轮转）全部通过；真实 turn 抽查（654 turns / 4,666 条工具结果，含 3,710 条真实 grok 结果）0 误触发。性能增量实测见「怎么验证的」（每工具结果 +0.3–1.4 µs）。
- 回滚 / 降级方式：回退本 PR 的 commits 即恢复 PR #2779 合入后的行为（仅 deepseek/claude、两层判据）

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动不涉及
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要测试
- [x] 已确认测试结果
