### PR TITLE
fix(desktop): 去掉加号菜单打开时底部闪现的横线

### DIFF
--- a/apps/desktop/src/renderer/__tests__/composerMorphScope.test.ts
+++ b/apps/desktop/src/renderer/__tests__/composerMorphScope.test.ts
@@ -69,3 +69,16 @@ describe('设置字段里的 AgentSelect 宽度契约', () => {
     expect(morph).toContain('desiredW = chipRect.width;');
   });
 });
+
+// + 菜单嵌在 480 宽、1px 边框的 Morph 壳里。内层再写死 480 会横向溢出 2px,
+// 打开瞬间 scrollIntoView 点亮 .is-scrolling,底部闪 2 秒横向滚动条。
+describe('+ 菜单 embedded 宽度契约', () => {
+  it('embedded AtMentionPanel 跟 Morph 壳等宽,横轴 overflow 显式 hidden', () => {
+    const atMention = read('components/new-chat/AtMentionPanel.tsx');
+    const morph = read('components/ui/morph-popover.tsx');
+    expect(atMention).toContain("embedded ? 'w-full min-w-0' : 'w-[480px]'");
+    expect(atMention).toContain('overflow-x-hidden overflow-y-auto');
+    expect(morph).toContain('overflow-x-hidden overflow-y-hidden');
+    expect(morph).toContain("content.style.overflowX = 'hidden'");
+  });
+});

--- a/apps/desktop/src/renderer/__tests__/morphPopover.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/morphPopover.test.tsx
@@ -375,4 +375,15 @@ describe('MorphPopover interaction contract', () => {
     const panel = await screen.findByRole('group', { name: 'Morph panel' });
     expect(panel.querySelector('[data-morph-ghost]')).toBeNull();
   });
+
+  it('内容区 overflow-x 保持 hidden,避免 1px border-box 偏差闪出横向滚动条', async () => {
+    render(<Harness />);
+    fireEvent.click(screen.getByRole('button', { name: 'Toggle' }));
+    const panel = await screen.findByRole('group', { name: 'Morph panel' });
+    const content = panel.firstElementChild as HTMLElement;
+    expect(content.className).toContain('overflow-x-hidden');
+    await waitFor(() => {
+      expect(content.style.overflowX).toBe('hidden');
+    });
+  });
 });

--- a/apps/desktop/src/renderer/__tests__/planModeComposerEntry.test.ts
+++ b/apps/desktop/src/renderer/__tests__/planModeComposerEntry.test.ts
@@ -303,6 +303,39 @@ describe('统一 composer 建议入口', () => {
     );
     expect(screen.getByText('extraDirs.pluginAgentInvoked')).toBeTruthy();
   });
+
+  it('embedded 面板跟 Morph 壳等宽且锁死横向滚动;独立 @ 面板仍是 480',
+    () => {
+      const entries = buildComposerSuggestionEntries({
+        query: '',
+        actions: [{ id: 'new-goal', label: 'goal', run: vi.fn() }],
+        resources: [],
+        plugins: [],
+      });
+      const props = {
+        query: '',
+        state: { kind: 'ready' as const, items: [], truncated: false },
+        entries,
+        focusedIndex: 0,
+        onFocusedIndexChange: vi.fn(),
+        onSelect: vi.fn(),
+        onClose: vi.fn(),
+        onRetry: vi.fn(),
+      };
+      const { container, rerender } = render(
+        createElement(AtMentionPanel, { ...props, embedded: true }),
+      );
+      const embeddedScroller = container.querySelector('.overflow-y-auto');
+      expect(embeddedScroller).toBeTruthy();
+      expect(embeddedScroller?.className).toContain('w-full');
+      expect(embeddedScroller?.className).toContain('overflow-x-hidden');
+      expect(embeddedScroller?.className).not.toContain('w-[480px]');
+
+      rerender(createElement(AtMentionPanel, props));
+      const standaloneScroller = container.querySelector('.overflow-y-auto');
+      expect(standaloneScroller?.className).toContain('w-[480px]');
+      expect(standaloneScroller?.className).toContain('overflow-x-hidden');
+    });
 });
 
 describe('PlanModeIndicator 激活 chip', () => {

--- a/apps/desktop/src/renderer/components/new-chat/AtMentionPanel.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/AtMentionPanel.tsx
@@ -18,7 +18,10 @@
  *   - root-query sections (Add / Plugins / Reference directories)
  *   - click-outside close (ignoring the `+` trigger button)
  *
- * Per F2 spec: 480px width and 44px row height.
+ * Per F2 spec: 480px width and 44px row height. The 480px is owned by the
+ * standalone `@` popover, or by MorphPopover's `panelWidth` when `embedded`.
+ * Embedded content must be `w-full` — a second 480px inside the 1px-bordered
+ * Morph shell overflows by 2px and flashes a 2s horizontal scrollbar.
  */
 import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -453,7 +456,11 @@ export function AtMentionPanel({
         ref={panelRef}
         onScroll={(e) => setPanelScroll(e.currentTarget.scrollTop)}
         className={cn(
-          'w-[480px] overflow-y-auto',
+          // embedded: fill the Morph shell. A nested w-[480px] is 2px wider
+          // than the border-box panel and paints a horizontal scrollbar thumb
+          // for ~2s via the global .is-scrolling auto-hide.
+          embedded ? 'w-full min-w-0' : 'w-[480px]',
+          'overflow-x-hidden overflow-y-auto',
           'p-[6px]',
           !embedded && [
             'rounded-[12px] border',

--- a/apps/desktop/src/renderer/components/ui/morph-popover.tsx
+++ b/apps/desktop/src/renderer/components/ui/morph-popover.tsx
@@ -122,6 +122,16 @@ function prefersReducedMotion(): boolean {
   );
 }
 
+/** overflow-y:auto/hidden 会把 visible 的 overflow-x 算成 auto;横轴必须显式 hidden。 */
+function setContentOverflowY(
+  content: HTMLDivElement | null,
+  overflowY: 'auto' | 'hidden',
+): void {
+  if (!content) return;
+  content.style.overflowY = overflowY;
+  content.style.overflowX = 'hidden';
+}
+
 export function MorphPopover({
   open,
   onOpenChange,
@@ -283,7 +293,7 @@ export function MorphPopover({
       // 形变期间内容区禁滚:高度未长够时滚动条短暂出现会把行宽压窄 ~10px,
       // 高度到位后又弹回 —— 行尾元素(对勾/选中条)看起来往右抖一下
       // (2026-07-22 用户反馈)。动画完成(settle)后再开自滚。
-      if (contentRef.current) contentRef.current.style.overflowY = 'hidden';
+      setContentOverflowY(contentRef.current, 'hidden');
       panel.dataset.state = 'closed';
       // 开场解除 inert(收合分支置上):closed 态面板必须整体退出 tab order,见 else 分支。
       panel.inert = false;
@@ -319,7 +329,7 @@ export function MorphPopover({
       const focusDelay = reduced ? 0 : MORPH_MS;
       closeTimerRef.current = setTimeout(() => {
         settledRef.current = true;
-        if (contentRef.current) contentRef.current.style.overflowY = 'auto';
+        setContentOverflowY(contentRef.current, 'auto');
         // RO 在 opening 期间收到的尺寸变化不会在 settled 后自动重发,这里补量一次
         // (异步 capability / provider 列表在开场动画内返回时防面板卡旧尺寸)。
         syncPanelToContent();
@@ -350,7 +360,7 @@ export function MorphPopover({
       if (rect) chipRectRef.current = rect;
       const reducedClose = reduced || !rect;
       panel.dataset.state = 'closed';
-      if (contentRef.current) contentRef.current.style.overflowY = 'hidden';
+      setContentOverflowY(contentRef.current, 'hidden');
       if (rect) applyChipGeometry(panel, rect);
       panel.style.opacity = '0';
       // 焦点归还判定(§14.2)延迟一拍快照,不在本 layout effect 里同步做:outside
@@ -535,7 +545,10 @@ export function MorphPopover({
             <div
               ref={contentRef}
               className={cn(
-                'max-h-full overflow-y-hidden',
+                // overflow-x must stay hidden: overflow-y:auto/hidden otherwise
+                // computes overflow-x to auto (CSS overflow pairing), and a 1px
+                // border-box mismatch flashes a 2s horizontal scrollbar thumb.
+                'max-h-full overflow-x-hidden overflow-y-hidden',
                 side === 'top' ? 'translate-y-[5px]' : 'translate-y-[-5px]',
                 'opacity-0 transition-[opacity,transform] delay-[50ms] duration-[140ms] ease-out',
                 'group-data-[state=open]:translate-y-0 group-data-[state=open]:opacity-100',


### PR DESCRIPTION
## 这次改了什么

### 摘要

点输入框左边的 `+` 打开菜单时，底边会短暂闪出一根横线，大约两秒后消失。原因是菜单嵌在 480px、带 1px 边框的 Morph 壳里，内层又写死 `w-[480px]`，内容比盒子宽 2px；打开时 `scrollIntoView` 点亮全局 `.is-scrolling`，横向滚动条 thumb 就会闪一下。

这次让内嵌面板跟 Morph 壳等宽，并把横轴 overflow 显式锁成 hidden，独立 `@` 面板仍保持 480px。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：`+` 菜单 / MorphPopover 横轴溢出修复，以及防止回退的契约测试
- 明确不包含：菜单内容、插件列表、`@` 独立面板的 480 定宽规格
- 用户可见变化：打开 `+` 菜单时底边不再闪横线
- 是否存在 breaking change：无

### UI 变化

无新视觉语言。只消除 2px 横向溢出造成的滚动条闪现，菜单宽、行高、圆角、token 均不变。

- 引用的设计规范：`docs/design-rules/DESIGN.md` §4 Select & Dropdown（composer `+` MorphPopover 面板由壳层持有宽度、12px 圆角、1px Board 边框）；§14.4 MorphPopover 容器形变（内容区自滚，不得因 overflow 配对冒出横向条）。双模式无新增颜色或条件补丁，Light / Dark 都走同一套 overflow 约束。

## 怎么验证的

### 自动验证

```text
cd /Users/dash/Code/Cindy/cindy-plus-menu-scrollbar-flash
pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm test:unit:related
结果：PASS apps/desktop unit (16.2s)

pnpm --filter desktop exec vitest run \
  src/renderer/__tests__/planModeComposerEntry.test.ts \
  src/renderer/__tests__/composerMorphScope.test.ts \
  src/renderer/__tests__/morphPopover.test.tsx
结果：3 files / 32 tests passed

pnpm check:dco
结果：DCO check passed（1 commit，range origin/main..HEAD）
```

### 手工验证

- 平台：macOS Desktop CN dev，worktree `/Users/dash/Code/Cindy/cindy-plus-menu-scrollbar-flash`
- 操作：`pnpm restart:desktop:remote -- --preserve-running --region=cn` 后 `pnpm desktop:whoami` 匹配该 worktree；在新建任务页点输入框左边 `+`，菜单底边不应再闪横线
- Dark 模式已在该开发版实例上核对启动成功；Light 模式未再单独目检（本次无颜色/token 变化）

### 未执行的验证

- 全量 `pnpm test:unit`：本机跑完整 unit 时 `ghostInstallReceipt.test.ts` 有 2 条失败。已在主 checkout 复现同样失败，与本 PR diff 无关（cindy-brain 安装回执，不在本次改动文件内）。不混入修复，交给 CI 给权威结论。
- Windows 未测。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop composer `+` 菜单与所有 MorphPopover 内容区的横轴 overflow
- 回滚 / 降级方式：revert 本 commit
- 存量插件影响：无

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
