### PR TITLE
fix(pi): SuperGrok 心跳复用活进程不再因 grok-4.6 路由同步失败

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/piNativeProviders.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/piNativeProviders.test.ts
@@ -458,6 +458,30 @@ describe('buildPiNativeProvidersFromConfigs', () => {
     }
   });
 
+  it('publishes SuperGrok catalog models missing from this PI binary as catalog additions', () => {
+    const catalog = JSON.parse(JSON.stringify(BUNDLED_CATALOG)) as Catalog;
+    const xai = catalog.providers.find((provider) => provider.id === 'xai');
+    expect(xai?.models.pi?.some((model) => model.id === 'grok-4.6')).toBe(true);
+    expect(xai?.models.pi?.find((model) => model.id === 'grok-4.6')?.piApi).toBeUndefined();
+
+    const { providers } = buildPiSubscriptionNativeProviders(
+      catalog,
+      'http://127.0.0.1:4567/',
+      new Map([
+        ['xai', new Map([['grok-4.5', piBundledModel('grok-4.5', 'openai-completions')]])],
+      ]),
+    );
+
+    const xaiProvider = providers.find((provider) => provider.id === 'xai');
+    expect(xaiProvider?.models.find((model) => model.id === 'grok-4.6')).toMatchObject({
+      id: 'grok-4.6',
+      wireId: 'grok-4.6',
+      catalogAddition: true,
+    });
+    expect(xaiProvider?.models.find((model) => model.id === 'grok-4.6')?.api).toBeUndefined();
+    expect(xaiProvider?.models.find((model) => model.id === 'grok-4.5')?.catalogAddition).toBeUndefined();
+  });
+
   it('namespaces only colliding BYOM runtime ids and preserves their persisted source ids', () => {
     const collisions: Array<[string, string]> = [];
     const merged = mergePiNativeProviderResults(

--- a/apps/desktop/src/main/maker-host/__tests__/piNativeProviders.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/piNativeProviders.test.ts
@@ -482,6 +482,20 @@ describe('buildPiNativeProvidersFromConfigs', () => {
     expect(xaiProvider?.models.find((model) => model.id === 'grok-4.5')?.catalogAddition).toBeUndefined();
   });
 
+  it('does not mark SuperGrok models as catalog additions when the PI probe is unavailable', () => {
+    const catalog = JSON.parse(JSON.stringify(BUNDLED_CATALOG)) as Catalog;
+    expect(catalog.providers.find((provider) => provider.id === 'xai')?.models.pi?.find((model) => model.id === 'grok-4.6')?.piApi).toBeUndefined();
+
+    const { providers } = buildPiSubscriptionNativeProviders(
+      catalog,
+      'http://127.0.0.1:4567/',
+    );
+
+    const xaiProvider = providers.find((provider) => provider.id === 'xai');
+    expect(xaiProvider?.models.find((model) => model.id === 'grok-4.6')?.catalogAddition).toBeUndefined();
+    expect(xaiProvider?.models.find((model) => model.id === 'grok-4.5')?.catalogAddition).toBeUndefined();
+  });
+
   it('namespaces only colliding BYOM runtime ids and preserves their persisted source ids', () => {
     const collisions: Array<[string, string]> = [];
     const merged = mergePiNativeProviderResults(

--- a/apps/desktop/src/main/maker-host/__tests__/piNativeProviders.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/piNativeProviders.test.ts
@@ -477,6 +477,7 @@ describe('buildPiNativeProvidersFromConfigs', () => {
       id: 'grok-4.6',
       wireId: 'grok-4.6',
       catalogAddition: true,
+      cost: { input: 2, output: 6, cacheRead: 0.5, cacheWrite: 0 },
     });
     expect(xaiProvider?.models.find((model) => model.id === 'grok-4.6')?.api).toBeUndefined();
     expect(xaiProvider?.models.find((model) => model.id === 'grok-4.5')?.catalogAddition).toBeUndefined();

--- a/apps/desktop/src/main/maker-host/__tests__/piNativeProviders.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/piNativeProviders.test.ts
@@ -470,6 +470,7 @@ describe('buildPiNativeProvidersFromConfigs', () => {
       new Map([
         ['xai', new Map([['grok-4.5', piBundledModel('grok-4.5', 'openai-completions')]])],
       ]),
+      new Map([['xai', new Set(['grok-4.5'])]]),
     );
 
     const xaiProvider = providers.find((provider) => provider.id === 'xai');
@@ -511,6 +512,22 @@ describe('buildPiNativeProvidersFromConfigs', () => {
     const xaiProvider = providers.find((provider) => provider.id === 'xai');
     expect(xaiProvider?.models.find((model) => model.id === 'grok-4.6')?.catalogAddition).toBeUndefined();
     expect(xaiProvider?.models.find((model) => model.id === 'grok-4.5')?.catalogAddition).toBeUndefined();
+  });
+
+  it('does not mark SuperGrok models as catalog additions when list-models still has the id', () => {
+    const catalog = JSON.parse(JSON.stringify(BUNDLED_CATALOG)) as Catalog;
+
+    const { providers } = buildPiSubscriptionNativeProviders(
+      catalog,
+      'http://127.0.0.1:4567/',
+      new Map([
+        ['xai', new Map([['grok-4.5', piBundledModel('grok-4.5', 'openai-completions')]])],
+      ]),
+      new Map([['xai', new Set(['grok-4.5', 'grok-4.6'])]]),
+    );
+
+    const xaiProvider = providers.find((provider) => provider.id === 'xai');
+    expect(xaiProvider?.models.find((model) => model.id === 'grok-4.6')?.catalogAddition).toBeUndefined();
   });
 
   it('namespaces only colliding BYOM runtime ids and preserves their persisted source ids', () => {

--- a/apps/desktop/src/main/maker-host/__tests__/piNativeProviders.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/piNativeProviders.test.ts
@@ -497,6 +497,22 @@ describe('buildPiNativeProvidersFromConfigs', () => {
     expect(xaiProvider?.models.find((model) => model.id === 'grok-4.5')?.catalogAddition).toBeUndefined();
   });
 
+  it('does not mark SuperGrok models as catalog additions when the probe has no xAI baseline', () => {
+    const catalog = JSON.parse(JSON.stringify(BUNDLED_CATALOG)) as Catalog;
+
+    const { providers } = buildPiSubscriptionNativeProviders(
+      catalog,
+      'http://127.0.0.1:4567/',
+      new Map([
+        ['anthropic', new Map([['claude-opus-5', piBundledModel('claude-opus-5', 'anthropic-messages')]])],
+      ]),
+    );
+
+    const xaiProvider = providers.find((provider) => provider.id === 'xai');
+    expect(xaiProvider?.models.find((model) => model.id === 'grok-4.6')?.catalogAddition).toBeUndefined();
+    expect(xaiProvider?.models.find((model) => model.id === 'grok-4.5')?.catalogAddition).toBeUndefined();
+  });
+
   it('namespaces only colliding BYOM runtime ids and preserves their persisted source ids', () => {
     const collisions: Array<[string, string]> = [];
     const merged = mergePiNativeProviderResults(

--- a/apps/desktop/src/main/maker-host/pi-host.ts
+++ b/apps/desktop/src/main/maker-host/pi-host.ts
@@ -470,6 +470,14 @@ export function buildPiSubscriptionNativeProviders(
           ...(sourceProviderId === 'openai' && isAnnotatedAddition
             ? { catalogAddition: true }
             : {}),
+          // SuperGrok 没有官方列模型通道，Cindy 目录是成员唯一来源。
+          // PI 二进制常常跟不上新 Grok id（grok-4.6）：inheritModels
+          // 会把没有 piApi 的行从 models.json 滤掉，spawn 靠 custom
+          // model id 能跑，set_model 却 fail-closed。不在这个 PI 二进制
+          // 里的 SuperGrok 模型必须作为 catalog addition 写进去。
+          ...(sourceProviderId === 'xai' && !bundledModel
+            ? { catalogAddition: true }
+            : {}),
           ...(sourceProviderId !== 'openai' &&
           model.piApi &&
           (isAnnotatedAddition || isProtocolCorrection)

--- a/apps/desktop/src/main/maker-host/pi-host.ts
+++ b/apps/desktop/src/main/maker-host/pi-host.ts
@@ -512,7 +512,11 @@ export function buildPiSubscriptionNativeProviders(
                   ),
                 }
               : {}),
-          ...(preserved?.cost ? { cost: { ...preserved.cost } } : {}),
+          ...(preserved?.cost
+            ? { cost: { ...preserved.cost } }
+            : model.cost
+              ? { cost: { ...model.cost } }
+              : {}),
           ...(preserved?.headers ? { headers: { ...preserved.headers } } : {}),
           ...(preserved?.compat ? { compat: structuredClone(preserved.compat) } : {}),
         };

--- a/apps/desktop/src/main/maker-host/pi-host.ts
+++ b/apps/desktop/src/main/maker-host/pi-host.ts
@@ -96,8 +96,16 @@ export interface PiBundledModelInfo {
 }
 
 export type PiBundledModelCatalog = ReadonlyMap<string, ReadonlyMap<string, PiBundledModelInfo>>;
+export type PiListedModelIds = ReadonlyMap<string, ReadonlySet<string>>;
 
 const piBundledModelsByBinary = new Map<string, Promise<PiBundledModelCatalog | null>>();
+const listedIdsByCatalog = new WeakMap<PiBundledModelCatalog, PiListedModelIds>();
+
+export function listedPiModelIds(
+  catalog: PiBundledModelCatalog | undefined,
+): PiListedModelIds | undefined {
+  return catalog ? listedIdsByCatalog.get(catalog) : undefined;
+}
 const PI_NATIVE_APIS = new Set<PiNativeApi>([
   'anthropic-messages',
   'openai-responses',
@@ -391,7 +399,9 @@ export async function readPiBundledModels(
         initialProvider,
         initialModel,
       );
-      return catalog.size > 0 ? catalog : null;
+      if (catalog.size === 0) return null;
+      listedIdsByCatalog.set(catalog, listed);
+      return catalog;
     } catch (err) {
       log.warn(
         'readPiBundledModels: PI catalog probe failed; using daily PI annotations without bundled baseline',
@@ -443,6 +453,7 @@ export function buildPiSubscriptionNativeProviders(
   catalog: Catalog,
   endpoint: string,
   bundledModelsByProvider?: PiBundledModelCatalog,
+  listedModelIdsByProvider?: PiListedModelIds,
 ): PiNativeProvidersResult {
   const providers: PiNativeProviderSpec[] = [];
   const env: Record<string, string> = {
@@ -495,14 +506,17 @@ export function buildPiSubscriptionNativeProviders(
             ? { catalogAddition: true }
             : {}),
           // SuperGrok 没有官方列模型通道，Cindy 目录是成员唯一来源。
-          // PI 二进制常常跟不上新 Grok id（grok-4.6）：inheritModels
-          // 会把没有 piApi 的行从 models.json 滤掉，spawn 靠 custom
-          // model id 能跑，set_model 却 fail-closed。只有探针成功且
-          // 这份结果里真有 xAI 行，才能把缺 id 当成有效证明；总表
-          // 非空但 xAI 被畸形数据整表跳过时，仍走 annotated-only。
-          ...(sourceProviderId === 'xai' && bundledModels != null && !bundledModel
-            ? { catalogAddition: true }
-            : {}),
+          // 缺席证明必须来自未过滤的 --list-models id：解析后的
+          // bundled 表会丢掉未知 api 的行，不能把「解析失败」当成
+          // 「二进制没有这个模型」。
+          ...(() => {
+            if (sourceProviderId !== 'xai') return {};
+            const listedIds =
+              listedModelIdsByProvider?.get(piProviderId) ??
+              listedPiModelIds(bundledModelsByProvider)?.get(piProviderId);
+            if (!listedIds || listedIds.has(wireId)) return {};
+            return { catalogAddition: true };
+          })(),
           ...(sourceProviderId !== 'openai' &&
           model.piApi &&
           (isAnnotatedAddition || isProtocolCorrection)

--- a/apps/desktop/src/main/maker-host/pi-host.ts
+++ b/apps/desktop/src/main/maker-host/pi-host.ts
@@ -497,13 +497,10 @@ export function buildPiSubscriptionNativeProviders(
           // SuperGrok 没有官方列模型通道，Cindy 目录是成员唯一来源。
           // PI 二进制常常跟不上新 Grok id（grok-4.6）：inheritModels
           // 会把没有 piApi 的行从 models.json 滤掉，spawn 靠 custom
-          // model id 能跑，set_model 却 fail-closed。只有探针成功证明
-          // 这个 PI 二进制没有该 id 时才标 catalog addition；探针失败
-          // 时 bundledModelsByProvider 为 undefined，不得把已收录模型
-          // 的权威元数据冲掉，仍走上面的 annotated-only 路径。
-          ...(sourceProviderId === 'xai' &&
-          bundledModelsByProvider != null &&
-          !bundledModel
+          // model id 能跑，set_model 却 fail-closed。只有探针成功且
+          // 这份结果里真有 xAI 行，才能把缺 id 当成有效证明；总表
+          // 非空但 xAI 被畸形数据整表跳过时，仍走 annotated-only。
+          ...(sourceProviderId === 'xai' && bundledModels != null && !bundledModel
             ? { catalogAddition: true }
             : {}),
           ...(sourceProviderId !== 'openai' &&

--- a/apps/desktop/src/main/maker-host/pi-host.ts
+++ b/apps/desktop/src/main/maker-host/pi-host.ts
@@ -473,9 +473,13 @@ export function buildPiSubscriptionNativeProviders(
           // SuperGrok 没有官方列模型通道，Cindy 目录是成员唯一来源。
           // PI 二进制常常跟不上新 Grok id（grok-4.6）：inheritModels
           // 会把没有 piApi 的行从 models.json 滤掉，spawn 靠 custom
-          // model id 能跑，set_model 却 fail-closed。不在这个 PI 二进制
-          // 里的 SuperGrok 模型必须作为 catalog addition 写进去。
-          ...(sourceProviderId === 'xai' && !bundledModel
+          // model id 能跑，set_model 却 fail-closed。只有探针成功证明
+          // 这个 PI 二进制没有该 id 时才标 catalog addition；探针失败
+          // 时 bundledModelsByProvider 为 undefined，不得把已收录模型
+          // 的权威元数据冲掉，仍走上面的 annotated-only 路径。
+          ...(sourceProviderId === 'xai' &&
+          bundledModelsByProvider != null &&
+          !bundledModel
             ? { catalogAddition: true }
             : {}),
           ...(sourceProviderId !== 'openai' &&

--- a/apps/desktop/src/main/maker-host/pi-host.ts
+++ b/apps/desktop/src/main/maker-host/pi-host.ts
@@ -410,6 +410,29 @@ export async function readPiBundledModels(
   return pending;
 }
 
+function catalogCostForPiNative(cost: {
+  input?: number;
+  output?: number;
+  cacheRead?: number;
+  cacheWrite?: number;
+} | undefined): { input: number; output: number; cacheRead: number; cacheWrite: number } | undefined {
+  if (
+    !cost ||
+    (typeof cost.input !== 'number' &&
+      typeof cost.output !== 'number' &&
+      typeof cost.cacheRead !== 'number' &&
+      typeof cost.cacheWrite !== 'number')
+  ) {
+    return undefined;
+  }
+  return {
+    input: cost.input ?? 0,
+    output: cost.output ?? 0,
+    cacheRead: cost.cacheRead ?? 0,
+    cacheWrite: cost.cacheWrite ?? 0,
+  };
+}
+
 /**
  * Overlay Cindy's host-managed subscription endpoints onto PI's bundled
  * provider catalog. No model is copied into models.json unless the daily Cindy
@@ -460,6 +483,7 @@ export function buildPiSubscriptionNativeProviders(
           !!bundledModel &&
           bundledModel.api !== model.piApi;
         const preserved = isProtocolCorrection ? bundledModel : undefined;
+        const catalogCost = catalogCostForPiNative(model.cost);
         return {
           id: model.id,
           wireId,
@@ -514,8 +538,8 @@ export function buildPiSubscriptionNativeProviders(
               : {}),
           ...(preserved?.cost
             ? { cost: { ...preserved.cost } }
-            : model.cost
-              ? { cost: { ...model.cost } }
+            : catalogCost
+              ? { cost: catalogCost }
               : {}),
           ...(preserved?.headers ? { headers: { ...preserved.headers } } : {}),
           ...(preserved?.compat ? { compat: structuredClone(preserved.compat) } : {}),

--- a/apps/desktop/src/main/scheduler-host/runner.ts
+++ b/apps/desktop/src/main/scheduler-host/runner.ts
@@ -1029,7 +1029,7 @@ export class MakerScheduleRunner implements ScheduleRunner {
           // 对 Pi 而言失败后来源未知；继续 send 可能把内容发给旧 BYOM endpoint，
           // 不能沿用 Claude/Codex 的 non-fatal 模型切换降级。
           throw new Error(
-            `schedule Pi route sync failed before dispatch (model "${model}", provider "${reusedPiRouteProviderId ?? 'cindy'}")`,
+            `schedule Pi route sync failed before dispatch (model "${model}", provider "${reusedPiRouteProviderId ?? 'cindy'}"): ${err instanceof Error ? err.message : String(err)}`,
             { cause: err },
           );
         }
@@ -1333,7 +1333,7 @@ export class MakerScheduleRunner implements ScheduleRunner {
               await session.setModel(runtimeModel, { providerId: verdict.providerId });
             } catch (err) {
               throw new Error(
-                `schedule Pi route sync failed after pre-dispatch reroute (model "${runtimeModel}", provider "${verdict.providerId}")`,
+                `schedule Pi route sync failed after pre-dispatch reroute (model "${runtimeModel}", provider "${verdict.providerId}"): ${err instanceof Error ? err.message : String(err)}`,
                 { cause: err },
               );
             }
@@ -2142,7 +2142,7 @@ export class MakerScheduleRunner implements ScheduleRunner {
         modelApplied = false;
         if (mustSyncPiNativeRoute) {
           throw new QueuedPiRouteSyncError(
-            `schedule Pi route sync failed before queued dispatch (model "${targetModel}", provider "${nextProviderId ?? 'cindy'}")`,
+            `schedule Pi route sync failed before queued dispatch (model "${targetModel}", provider "${nextProviderId ?? 'cindy'}"): ${err instanceof Error ? err.message : String(err)}`,
             { cause: err },
           );
         }

--- a/packages/maker-core/src/agents/pi/__tests__/pi-provider-routing.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/pi-provider-routing.test.ts
@@ -268,6 +268,10 @@ describe('Pi provider-aware model routing', () => {
             models: [
               { id: 'xai/grok-4.5', wireId: 'grok-4.5' },
               {
+                id: 'grok-4.6', wireId: 'grok-4.6', catalogAddition: true,
+                contextWindow: 500_000, maxTokens: 500_000,
+              },
+              {
                 id: 'xai/grok-4.20', wireId: 'grok-4.20', api: 'openai-responses',
                 contextWindow: 1_000_000, maxTokens: 64_000,
                 cost: { input: 2, output: 6, cacheRead: 0.3, cacheWrite: 0 },
@@ -305,12 +309,18 @@ describe('Pi provider-aware model routing', () => {
     expect(models.providers.xai).not.toHaveProperty('api');
     expect(models.providers.xai?.models).toEqual([
       expect.objectContaining({
+        id: 'grok-4.6',
+        contextWindow: 500_000,
+        maxTokens: 500_000,
+      }),
+      expect.objectContaining({
         id: 'grok-4.20',
         api: 'openai-responses',
         cost: { input: 2, output: 6, cacheRead: 0.3, cacheWrite: 0 },
         compat: { supportsStrictTools: true },
       }),
     ]);
+    expect(models.providers.xai?.models?.[0]).not.toHaveProperty('api');
     expect(JSON.parse(readFileSync(path.join(configHome, 'settings.json'), 'utf8')))
       .toEqual({ transport: 'sse' });
     expect(JSON.parse(readFileSync(runtimeFileOf('subagent', 'native-subscription-routing'), 'utf8')))
@@ -519,6 +529,59 @@ describe('Pi provider-aware model routing', () => {
       provider: 'xai',
       modelId: 'xai/grok-4.6',
     });
+    await handle.close();
+  });
+
+  it('does not reissue set_model when the live session is already on the requested SuperGrok route', async () => {
+    captured.requestHandler = async (command) => {
+      if (command.type === 'set_model') {
+        return { success: false, error: 'Model "grok-4.6" not found for provider "xai"' };
+      }
+      if (command.type === 'get_state') {
+        return { success: true, data: { sessionFile: '/mock/s.jsonl', model: { contextWindow: 200_000 } } };
+      }
+      return { success: true, data: {} };
+    };
+    const agent = new PiAgent({
+      auth: {
+        getState: async () => ({ authenticated: true, identity: 'SuperGrok', authSource: 'oauth' as const }),
+        triggerLogin: async () => ({ authenticated: true }),
+        logout: async () => {},
+        getAuthEnv: async () => ({ CINDY_PI_API_KEY: 'gateway-key' }),
+      },
+      runtimeConfig: { endpoint: 'http://127.0.0.1:9' },
+      binaryPath: path.join(agentHome, 'pi'),
+      logger: noopLogger,
+      capabilityAdditions: {
+        availableModels: [{
+          id: 'grok-4.6',
+          displayName: 'Grok 4.6',
+          contextWindow: 500_000,
+          efforts: [],
+          defaultEffort: null,
+        }],
+      },
+      resolvePiAgentHome: () => agentHome,
+      resolvePiNativeProviders: async () => ({
+        providers: [{
+          id: 'xai',
+          name: 'xAI',
+          baseUrl: 'http://127.0.0.1:9',
+          api: 'anthropic-messages',
+          models: [{ id: 'grok-4.6' }],
+        }],
+        env: {},
+      }),
+    });
+    const handle = await agent.startSession({
+      sessionId: 'grok-46-same-route',
+      workingDir: cwd,
+      model: 'grok-4.6',
+      providerId: 'xai',
+    });
+    captured.requests.length = 0;
+    await expect(handle.setModel!('grok-4.6', { providerId: 'xai' })).resolves.toBeUndefined();
+    expect(captured.requests.filter((request) => request.type === 'set_model')).toEqual([]);
     await handle.close();
   });
 

--- a/packages/maker-core/src/agents/pi/__tests__/pi-provider-routing.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/pi-provider-routing.test.ts
@@ -585,6 +585,110 @@ describe('Pi provider-aware model routing', () => {
     await handle.close();
   });
 
+  it('rebuilds a missing subagent snapshot on same-route SuperGrok setModel without RPC', async () => {
+    const agent = new PiAgent({
+      auth: {
+        getState: async () => ({ authenticated: true, identity: 'SuperGrok', authSource: 'oauth' as const }),
+        triggerLogin: async () => ({ authenticated: true }),
+        logout: async () => {},
+        getAuthEnv: async () => ({ CINDY_PI_API_KEY: 'gateway-key' }),
+      },
+      runtimeConfig: { endpoint: 'http://127.0.0.1:9' },
+      binaryPath: path.join(agentHome, 'pi'),
+      logger: noopLogger,
+      capabilityAdditions: {
+        availableModels: [{
+          id: 'grok-4.6',
+          displayName: 'Grok 4.6',
+          contextWindow: 500_000,
+          efforts: [],
+          defaultEffort: null,
+        }],
+      },
+      resolvePiAgentHome: () => agentHome,
+      resolvePiNativeProviders: async () => ({
+        providers: [{
+          id: 'xai',
+          name: 'xAI',
+          baseUrl: 'http://127.0.0.1:9',
+          api: 'anthropic-messages',
+          models: [{ id: 'grok-4.6' }],
+        }],
+        env: {},
+      }),
+    });
+    const handle = await agent.startSession({
+      sessionId: 'grok-46-snapshot-retry',
+      workingDir: cwd,
+      model: 'grok-4.6',
+      providerId: 'xai',
+    });
+    const snapshotPath = runtimeFileOf('subagent', 'grok-46-snapshot-retry');
+    rmSync(snapshotPath, { force: true });
+    captured.requests.length = 0;
+    await expect(handle.setModel!('grok-4.6', { providerId: 'xai' })).resolves.toBeUndefined();
+    expect(captured.requests.filter((request) => request.type === 'set_model')).toEqual([]);
+    expect(JSON.parse(readFileSync(snapshotPath, 'utf8'))).toEqual({
+      model: 'grok-4.6',
+      provider: 'xai',
+    });
+    await handle.close();
+  });
+
+  it('clears a stuck pending subagent snapshot on same-route SuperGrok setModel', async () => {
+    const agent = new PiAgent({
+      auth: {
+        getState: async () => ({ authenticated: true, identity: 'SuperGrok', authSource: 'oauth' as const }),
+        triggerLogin: async () => ({ authenticated: true }),
+        logout: async () => {},
+        getAuthEnv: async () => ({ CINDY_PI_API_KEY: 'gateway-key' }),
+      },
+      runtimeConfig: { endpoint: 'http://127.0.0.1:9' },
+      binaryPath: path.join(agentHome, 'pi'),
+      logger: noopLogger,
+      capabilityAdditions: {
+        availableModels: [{
+          id: 'grok-4.6',
+          displayName: 'Grok 4.6',
+          contextWindow: 500_000,
+          efforts: [],
+          defaultEffort: null,
+        }],
+      },
+      resolvePiAgentHome: () => agentHome,
+      resolvePiNativeProviders: async () => ({
+        providers: [{
+          id: 'xai',
+          name: 'xAI',
+          baseUrl: 'http://127.0.0.1:9',
+          api: 'anthropic-messages',
+          models: [{ id: 'grok-4.6' }],
+        }],
+        env: {},
+      }),
+    });
+    const handle = await agent.startSession({
+      sessionId: 'grok-46-pending-clear',
+      workingDir: cwd,
+      model: 'grok-4.6',
+      providerId: 'xai',
+    });
+    const snapshotPath = runtimeFileOf('subagent', 'grok-46-pending-clear');
+    writeFileSync(snapshotPath, JSON.stringify({
+      model: 'grok-4.6',
+      provider: 'xai',
+      pending: true,
+    }) + '\n');
+    captured.requests.length = 0;
+    await expect(handle.setModel!('grok-4.6', { providerId: 'xai' })).resolves.toBeUndefined();
+    expect(captured.requests.filter((request) => request.type === 'set_model')).toEqual([]);
+    expect(JSON.parse(readFileSync(snapshotPath, 'utf8'))).toEqual({
+      model: 'grok-4.6',
+      provider: 'xai',
+    });
+    await handle.close();
+  });
+
   it('applies each native provider alias during provider-less compatibility routing', async () => {
     const provider = (id: string, aliases?: Record<string, string>) => ({
       id,

--- a/packages/maker-core/src/agents/pi/__tests__/pi-provider-routing.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/pi-provider-routing.test.ts
@@ -689,6 +689,45 @@ describe('Pi provider-aware model routing', () => {
     await handle.close();
   });
 
+  it('rejects a same-route gateway heartbeat when the live session wire protocol is stale', async () => {
+    let gatewayApi: 'anthropic-messages' | 'openai-responses' = 'anthropic-messages';
+    const agent = new PiAgent({
+      auth: {
+        getState: async () => ({ authenticated: true, identity: 'test', authSource: 'oauth' as const }),
+        triggerLogin: async () => ({ authenticated: true }),
+        logout: async () => {},
+        getAuthEnv: async () => ({}),
+      },
+      runtimeConfig: { endpoint: 'http://127.0.0.1:9' },
+      binaryPath: path.join(agentHome, 'pi'),
+      logger: noopLogger,
+      capabilityAdditions: {
+        availableModels: [{
+          id: 'shared-model',
+          displayName: 'Shared',
+          contextWindow: 128_000,
+          efforts: [],
+          defaultEffort: null,
+        }],
+      },
+      resolvePiAgentHome: () => agentHome,
+      resolvePiGatewayModelApi: () => gatewayApi,
+    });
+    const handle = await agent.startSession({
+      sessionId: 'gateway-same-route-stale',
+      workingDir: cwd,
+      model: 'shared-model',
+      providerId: 'xd',
+    });
+    gatewayApi = 'openai-responses';
+    captured.requests.length = 0;
+    await expect(handle.setModel!('shared-model', { providerId: 'xd' })).rejects.toThrow(
+      /restart the Pi session to change provider wire protocol/,
+    );
+    expect(captured.requests.filter((request) => request.type === 'set_model')).toEqual([]);
+    await handle.close();
+  });
+
   it('applies each native provider alias during provider-less compatibility routing', async () => {
     const provider = (id: string, aliases?: Record<string, string>) => ({
       id,

--- a/packages/maker-core/src/agents/pi/index.ts
+++ b/packages/maker-core/src/agents/pi/index.ts
@@ -2425,9 +2425,20 @@ export class PiAgent extends BaseAgent {
         if (setOpts?.effort) {
           assertStartupEffortAllowed(activeEffortSnapshot, setOpts.effort);
         }
+        // 同路由不打 set_model，但仍要重试子代理快照：初始写失败或确认写失败
+        // 留下 pending 时，心跳复用活进程必须能把文件重建/清 pending，
+        // 否则扩展会一直 fail-closed。不带 pending，路由已确认。
+        const provider = resolveProviderForModel(model, requestedProviderId);
+        const wireModel = resolveWireModel(provider, model);
+        if (!(await writeSubagentRuntimeFile({ model: wireModel, provider }))) {
+          deps.logger.warn('pi: same-route setModel could not refresh subagent snapshot', {
+            model,
+            provider,
+          });
+        }
         deps.logger.debug('pi: setModel no-op; already on requested route', {
           model,
-          providerId: requestedProviderId ?? mutableProviderId ?? null,
+          providerId: requestedProviderId,
         });
         return;
       }

--- a/packages/maker-core/src/agents/pi/index.ts
+++ b/packages/maker-core/src/agents/pi/index.ts
@@ -2416,6 +2416,35 @@ export class PiAgent extends BaseAgent {
       // 路由上（grok-4.6）；重复 set_model 反而 fail-closed。
       // 只对显式非 null 来源做 no-op：model-only 与 providerId=null
       // （钉回网关）仍走 RPC。
+      const assertGatewayProtocolForModel = (
+        nextModel: string,
+        nextRequestedProviderId: string | null | undefined,
+      ): void => {
+        const nextProvider = resolveProviderForModel(nextModel, nextRequestedProviderId);
+        if (nextProvider !== PI_PROVIDER_ID) return;
+        const routeProviderId = nextRequestedProviderId !== undefined
+          ? nextRequestedProviderId
+          : mutableProviderId;
+        const resolvedApi = this.deps.resolvePiGatewayModelApi?.(routeProviderId, nextModel);
+        if (
+          resolvedApi === null ||
+          (resolvedApi !== undefined &&
+            resolvedApi !== 'anthropic-messages' &&
+            resolvedApi !== 'openai-responses')
+        ) {
+          throw new Error(
+            `Model Access v3 did not provide a Pi wire protocol for model: ${nextModel}`,
+          );
+        }
+        const desiredApi = resolvedApi ?? 'anthropic-messages';
+        const configuredApi = gatewayApiByModel.get(nextModel);
+        if (configuredApi && configuredApi !== desiredApi) {
+          throw new Error(
+            `pi: provider switch for model '${nextModel}' requires API '${desiredApi}', but this session ` +
+              `started with '${configuredApi}'; restart the Pi session to change provider wire protocol.`,
+          );
+        }
+      };
       if (
         model === mutableModel &&
         requestedProviderId !== undefined &&
@@ -2425,6 +2454,7 @@ export class PiAgent extends BaseAgent {
         if (setOpts?.effort) {
           assertStartupEffortAllowed(activeEffortSnapshot, setOpts.effort);
         }
+        assertGatewayProtocolForModel(model, requestedProviderId);
         // 同路由不打 set_model，但仍要重试子代理快照：初始写失败或确认写失败
         // 留下 pending 时，心跳复用活进程必须能把文件重建/清 pending，
         // 否则扩展会一直 fail-closed。不带 pending，路由已确认。
@@ -2456,30 +2486,7 @@ export class PiAgent extends BaseAgent {
       }
       const provider = resolveProviderForModel(model, requestedProviderId);
       const wireModel = resolveWireModel(provider, model);
-      if (provider === PI_PROVIDER_ID) {
-        const routeProviderId = requestedProviderId !== undefined
-          ? requestedProviderId
-          : mutableProviderId;
-        const resolvedApi = this.deps.resolvePiGatewayModelApi?.(routeProviderId, model);
-        if (
-          resolvedApi === null ||
-          (resolvedApi !== undefined &&
-            resolvedApi !== 'anthropic-messages' &&
-            resolvedApi !== 'openai-responses')
-        ) {
-          throw new Error(
-            `Model Access v3 did not provide a Pi wire protocol for model: ${model}`,
-          );
-        }
-        const desiredApi = resolvedApi ?? 'anthropic-messages';
-        const configuredApi = gatewayApiByModel.get(model);
-        if (configuredApi && configuredApi !== desiredApi) {
-          throw new Error(
-            `pi: provider switch for model '${model}' requires API '${desiredApi}', but this session ` +
-              `started with '${configuredApi}'; restart the Pi session to change provider wire protocol.`,
-          );
-        }
-      }
+      assertGatewayProtocolForModel(model, requestedProviderId);
       // effort 能力校验必须排在写路由快照**之前**:它会抛错中止本次切换,而快照一旦落盘就
       // 指向了新 provider —— 那正是父子路由分叉的形状(upstream #1451 与本 PR 的合并点)。
       const nextEffortSnapshot = resolveStartupEffortSnapshot(provider, model);

--- a/packages/maker-core/src/agents/pi/index.ts
+++ b/packages/maker-core/src/agents/pi/index.ts
@@ -2411,6 +2411,26 @@ export class PiAgent extends BaseAgent {
       const requestedProviderId = setOpts && Object.hasOwn(setOpts, 'providerId')
         ? setOpts.providerId
         : undefined;
+      // 心跳复用活进程会把当前 (provider, model) 再下发一次。
+      // spawn 能靠 custom model id 跑在 Pi 自带目录没有的 SuperGrok
+      // 路由上（grok-4.6）；重复 set_model 反而 fail-closed。
+      // 只对显式非 null 来源做 no-op：model-only 与 providerId=null
+      // （钉回网关）仍走 RPC。
+      if (
+        model === mutableModel &&
+        requestedProviderId !== undefined &&
+        requestedProviderId !== null &&
+        Object.is(requestedProviderId, mutableProviderId)
+      ) {
+        if (setOpts?.effort) {
+          assertStartupEffortAllowed(activeEffortSnapshot, setOpts.effort);
+        }
+        deps.logger.debug('pi: setModel no-op; already on requested route', {
+          model,
+          providerId: requestedProviderId ?? mutableProviderId ?? null,
+        });
+        return;
+      }
       // 显式选一个启动快照 nativeProviderById 里“无法服务该 model”的 BYOM provider 时 fail
       // closed:要么该 provider 是会话启动后才新增的(不在快照),要么它虽在、但用户编辑
       // 配置后从中删/改了这个 model。两种都会让 resolveProviderForModel 静默回落 cindy 网关;


### PR DESCRIPTION
## 这次改了什么

### 摘要

定时任务心跳绑到 Pi + SuperGrok（`grok-4.6` / `xai`）的活会话时，gate 已经放行，却在 dispatch 前死于 `schedule Pi route sync failed before dispatch`。根因是 Pi 0.83 自带目录没有 `grok-4.6`：窗口里聊天能靠 custom model id 跑起来，心跳复用活进程时却会再打一次 `set_model`，被 fail-closed。

两处一起修：

- 已经在同一条显式来源路由上时，`setModel` 不再发 RPC（`providerId: null` 钉回网关、只改模型的调用仍走原路径）
- Cindy 目录里有、当前 Pi 二进制没有的 SuperGrok 模型写成 `catalogAddition`，写进 `models.json`
- 路由同步失败信息带上底层 cause，方便下次排查

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：现场 `PR #2803` / `#2798` / `#2807` 心跳同一报错
- 本 PR 包含：同路由 `setModel` no-op；SuperGrok 未收录模型的 catalog addition；调度错误带 cause
- 明确不包含：改 Pi 二进制目录本身；改心跳 cadence / gate
- 用户可见变化：SuperGrok 任务上的定时心跳不再因复用活进程而整轮失败
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：不涉及：只改 main/maker-core 路由同步，无界面、交互或文案变化。

### 远程 / 手机版适配

不涉及：改动均位于 PiTransport 抽象之上，无新增 workdir fs 访问、IPC channel 或手机版入口。SSH 远端会话走同一套 `set_model` RPC；device-link / 手机版不新增 invoke／push。catalog addition 只改本机写给 Pi 的 `models.json` 内容。

## 怎么验证的

### 自动验证

```text
pnpm --filter @cindy/maker-core exec vitest run \
  src/agents/pi/__tests__/pi-provider-routing.test.ts \
  src/agents/pi/__tests__/pi-auto-review-dispatch.test.ts
结果：89 passed

cd apps/desktop && pnpm exec vitest run \
  src/main/maker-host/__tests__/piNativeProviders.test.ts \
  src/main/scheduler-host/__tests__/runnerModelSelection.test.ts \
  src/main/scheduler-host/__tests__/runnerQueuedDispatch.test.ts
结果：129 passed / 1 skipped

run-unit-gate.sh
结果：本 PR 相关包绿。apps/desktop 有 2 条 ghostInstallReceipt.test.ts 失败，已在干净 origin/main@36b9c48a8 复现，与本 diff 无关，不混入修复。
```

### 手工验证

不涉及。本机现网客户端尚未带上此改动，现场心跳仍会按旧逻辑失败。

### 未执行的验证

未在个人客户端热切换后实机点「立即运行」复验心跳。单测覆盖了同路由 no-op 与 catalog addition。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Pi SuperGrok 路由同步、调度心跳复用活会话
- 回滚 / 降级方式：revert 本 PR

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
