### PR TITLE
fix(desktop): 拒绝 isolated 落到正式 profile，DEVICE_MISMATCH 不再删盘

### DIFF
--- a/apps/desktop/src/main/__tests__/authPassiveSharedInstance.test.ts
+++ b/apps/desktop/src/main/__tests__/authPassiveSharedInstance.test.ts
@@ -58,6 +58,11 @@ describe('passive shared-userData instance auth isolation', () => {
     );
     const preserveIdx = authSource.indexOf('preservePersistedRefreshToken: true', runtimeIdx);
     expect(preserveIdx).toBeGreaterThan(runtimeIdx);
+    expect(authSource).toContain('let foreignDeviceLocalSignOut = false');
+    expect(authSource).toContain("foreignDeviceLocalSignOut = true");
+    expect(authSource).toContain(
+      "if (foreignDeviceLocalSignOut) {",
+    );
   });
 
   it('clearAuth:passive 共享实例不删磁盘 refresh token', () => {

--- a/apps/desktop/src/main/__tests__/authPassiveSharedInstance.test.ts
+++ b/apps/desktop/src/main/__tests__/authPassiveSharedInstance.test.ts
@@ -41,8 +41,23 @@ describe('passive shared-userData instance auth isolation', () => {
     // packaged 恒不设置该 env,但仍保留 isPackaged 双保险,防 ambient env 污染线上语义。
     expect(body).toContain('!app.isPackaged');
     expect(body).toContain("process.env.XDT_PASSIVE_SHARED_USER_DATA === '1'");
-    // 不新增判定通道:isolated 沙箱有独立 userData 与 deviceId,不该出现在这条判定里。
+    // 不新增判定通道:是否共库由启动期 profileKind 落地成这个 env,本函数只读结果。
     expect(body).not.toContain('XDT_ISOLATED');
+  });
+
+  it('DEVICE_MISMATCH 只登出本进程,不删磁盘 refresh token', () => {
+    expect(authSource).toContain("action.kind === 'foreign-device'");
+    expect(authSource).toContain(
+      'cold-start refresh: DEVICE_MISMATCH — this process starts logged out and keeps the persisted refresh token',
+    );
+    expect(authSource).toContain(
+      'runtime refresh: DEVICE_MISMATCH — expiring this process and keeping the persisted refresh token',
+    );
+    const runtimeIdx = authSource.indexOf(
+      'runtime refresh: DEVICE_MISMATCH — expiring this process and keeping the persisted refresh token',
+    );
+    const preserveIdx = authSource.indexOf('preservePersistedRefreshToken: true', runtimeIdx);
+    expect(preserveIdx).toBeGreaterThan(runtimeIdx);
   });
 
   it('clearAuth:passive 共享实例不删磁盘 refresh token', () => {

--- a/apps/desktop/src/main/__tests__/authRefreshFailure.test.ts
+++ b/apps/desktop/src/main/__tests__/authRefreshFailure.test.ts
@@ -406,6 +406,11 @@ describe('runRefreshWithTransientRetry', () => {
     status: 401,
     data: { error: { code: 'INVALID_REFRESH_TOKEN' } },
   };
+  const deviceMismatch: RefreshFetchResult<unknown> = {
+    ok: false,
+    status: 401,
+    data: { error: { code: 'DEVICE_MISMATCH' } },
+  };
   /** 立即 resolve 的注入 sleep,记录每次退避时长。 */
   const makeSleep = () => {
     const calls: number[] = [];
@@ -456,6 +461,29 @@ describe('runRefreshWithTransientRetry', () => {
         status: 401,
         code: 'INVALID_REFRESH_TOKEN',
         definitive: true,
+        willRetry: false,
+      },
+    ]);
+  });
+
+  it('DEVICE_MISMATCH 立即返回,不按瞬时失败重试', async () => {
+    const doRefresh = vi.fn().mockResolvedValue(deviceMismatch);
+    const { calls, sleep } = makeSleep();
+    const failures: RefreshFailureInfo[] = [];
+    const { result, attempts } = await runRefreshWithTransientRetry(doRefresh, {
+      sleep,
+      onFailure: (info) => failures.push(info),
+    });
+    expect(result).toBe(deviceMismatch);
+    expect(attempts).toBe(1);
+    expect(doRefresh).toHaveBeenCalledTimes(1);
+    expect(calls).toEqual([]);
+    expect(failures).toEqual([
+      {
+        attempt: 1,
+        status: 401,
+        code: 'DEVICE_MISMATCH',
+        definitive: false,
         willRetry: false,
       },
     ]);

--- a/apps/desktop/src/main/__tests__/authRefreshFailure.test.ts
+++ b/apps/desktop/src/main/__tests__/authRefreshFailure.test.ts
@@ -11,6 +11,7 @@ import {
   DEFINITIVE_REFRESH_FAILURE_CODES,
   getRefreshTokenReplacementCandidate,
   isDefinitiveRefreshFailure,
+  isForeignDeviceRefreshFailure,
   pickRefreshTokenReplacementCandidate,
   resolveRefreshFailureAction,
   resolveSessionExpiredReason,
@@ -41,14 +42,15 @@ describe('isDefinitiveRefreshFailure', () => {
   });
 
   it('确定性凭据失效码 → 删除 token', () => {
-    for (const code of [
-      'REFRESH_TOKEN_EXPIRED',
-      'INVALID_REFRESH_TOKEN',
-      'DEVICE_MISMATCH',
-      'MEMBERSHIP_DISABLED',
-    ]) {
+    for (const code of ['REFRESH_TOKEN_EXPIRED', 'INVALID_REFRESH_TOKEN', 'MEMBERSHIP_DISABLED']) {
       expect(isDefinitiveRefreshFailure({ ok: false, data: { error: { code } } })).toBe(true);
     }
+  });
+
+  it('DEVICE_MISMATCH 不是确定性失效,不得授权删盘', () => {
+    const result = { ok: false, data: { error: { code: 'DEVICE_MISMATCH' } } };
+    expect(isDefinitiveRefreshFailure(result)).toBe(false);
+    expect(isForeignDeviceRefreshFailure(result)).toBe(true);
   });
 
   it('429 限流(RATE_LIMITED)→ 瞬时失败,保留 token', () => {
@@ -75,7 +77,6 @@ describe('isDefinitiveRefreshFailure', () => {
 
   it('确定性错误码集合保持冻结(防止误增删改变删除语义)', () => {
     expect([...DEFINITIVE_REFRESH_FAILURE_CODES].sort()).toEqual([
-      'DEVICE_MISMATCH',
       'INVALID_REFRESH_TOKEN',
       'MEMBERSHIP_DISABLED',
       'REFRESH_TOKEN_EXPIRED',
@@ -197,11 +198,17 @@ describe('refresh token replacement detection', () => {
     expect(resolveRefreshFailureAction(expiredToken, 'rt-old', 'rt-new')).toEqual({
       kind: 'definitive-failure',
     });
-    expect(resolveRefreshFailureAction(deviceMismatch, 'rt-old', 'rt-new')).toEqual({
-      kind: 'definitive-failure',
-    });
     expect(resolveRefreshFailureAction(membershipDisabled, 'rt-old', 'rt-new')).toEqual({
       kind: 'definitive-failure',
+    });
+  });
+
+  it('DEVICE_MISMATCH 即使磁盘已有其它 token 也不删盘,只判 foreign-device', () => {
+    expect(resolveRefreshFailureAction(deviceMismatch, 'rt-old', 'rt-new')).toEqual({
+      kind: 'foreign-device',
+    });
+    expect(resolveRefreshFailureAction(deviceMismatch, 'rt-old', 'rt-old')).toEqual({
+      kind: 'foreign-device',
     });
   });
 
@@ -305,7 +312,7 @@ describe('refresh token replacement detection', () => {
       requestedToken: 'rt-old',
       replacementRetries: 0,
       replacementRetryExhausted: false,
-      failureAction: { kind: 'definitive-failure' },
+      failureAction: { kind: 'foreign-device' },
     });
     expect(sleep).not.toHaveBeenCalled();
     expect(doRefresh).toHaveBeenCalledTimes(1);

--- a/apps/desktop/src/main/__tests__/devCliFlags.test.ts
+++ b/apps/desktop/src/main/__tests__/devCliFlags.test.ts
@@ -33,7 +33,7 @@ const base = {
   argv: ['electron', '.'] as readonly string[],
   isPackaged: false,
   envUserDataDir: undefined as string | undefined,
-  defaultUserDataDir: '/AppData/xdt-maker',
+  defaultUserDataDir: '/AppData/Cindy',
   envIsolated: undefined as string | undefined,
   envIsolationName: undefined as string | undefined,
   envUserDataDirEpoch: undefined as string | undefined,
@@ -56,6 +56,16 @@ describe('resolveDevCliFlags', () => {
       invalidIsolationName: null,
       endpointsCdn: false,
     });
+  });
+
+  it('原生自定义 userData 默认目录不是正式 profile', () => {
+    const flags = resolveDevCliFlags({
+      ...base,
+      defaultUserDataDir: '/tmp/custom-profile',
+    });
+    expect(flags.profileKind).toBe('custom');
+    expect(flags.isolatedOnProductionProfile).toBe(false);
+    expect(flags.userDataDirOverride).toBeNull();
   });
 
   it('--passive 只开被动,不动 userData / 设备标识', () => {
@@ -83,7 +93,7 @@ describe('resolveDevCliFlags', () => {
     const viaEnvSame = resolveDevCliFlags({
       ...base,
       envIsolated: '1',
-      envUserDataDir: '/AppData/xdt-maker-dev2',
+      envUserDataDir: '/AppData/Cindy-dev2',
       envUserDataDirEpoch: '1',
     });
     expect(viaEnvSame.isolatedDirIsEpochDerived).toBe(true);
@@ -93,7 +103,7 @@ describe('resolveDevCliFlags', () => {
     const viaEnvUntrusted = resolveDevCliFlags({
       ...base,
       envIsolated: '1',
-      envUserDataDir: '/AppData/xdt-maker-dev2',
+      envUserDataDir: '/AppData/Cindy-dev2',
     });
     expect(viaEnvUntrusted.isolatedDirIsEpochDerived).toBe(false);
     const custom = resolveDevCliFlags({
@@ -103,7 +113,7 @@ describe('resolveDevCliFlags', () => {
     });
     expect(custom.isolated).toBe(true);
     expect(custom.isolatedDirIsEpochDerived).toBe(false);
-    const notIsolated = resolveDevCliFlags({ ...base, envUserDataDir: '/AppData/xdt-maker-dev2' });
+    const notIsolated = resolveDevCliFlags({ ...base, envUserDataDir: '/AppData/Cindy-dev2' });
     expect(notIsolated.isolatedDirIsEpochDerived).toBe(false);
   });
 
@@ -111,9 +121,9 @@ describe('resolveDevCliFlags', () => {
     // 字符串全等会把标准纪元目录的等价写法误判成"其它目录"→ 观察模式给空沙箱
     // 抢注默认身份标记,该沙箱永久回到共享 Cindy 钥匙串。
     for (const dir of [
-      '/AppData/xdt-maker-dev2/',
-      '/AppData/./xdt-maker-dev2',
-      '/AppData/other/../xdt-maker-dev2',
+      '/AppData/Cindy-dev2/',
+      '/AppData/./Cindy-dev2',
+      '/AppData/other/../Cindy-dev2',
     ]) {
       const flags = resolveDevCliFlags({
         ...base,
@@ -129,7 +139,7 @@ describe('resolveDevCliFlags', () => {
     const sibling = resolveDevCliFlags({
       ...base,
       envIsolated: '1',
-      envUserDataDir: '/AppData/xdt-maker-dev2-extra',
+      envUserDataDir: '/AppData/Cindy-dev2-extra',
       envUserDataDirEpoch: '1',
     });
     expect(sibling.isolatedDirIsEpochDerived).toBe(false);
@@ -143,7 +153,7 @@ describe('resolveDevCliFlags', () => {
     const hit = resolveDevCliFlags({
       ...base,
       envIsolated: '1',
-      envUserDataDir: '/AppData/XDT-Maker-DEV2',
+      envUserDataDir: '/AppData/CINDY-DEV2',
       envUserDataDirEpoch: '1',
       canonicalizePath: insensitiveVolume,
     });
@@ -152,7 +162,7 @@ describe('resolveDevCliFlags', () => {
     const miss = resolveDevCliFlags({
       ...base,
       envIsolated: '1',
-      envUserDataDir: '/AppData/XDT-Maker-DEV2',
+      envUserDataDir: '/AppData/CINDY-DEV2',
       envUserDataDirEpoch: '1',
       canonicalizePath: sensitiveVolume,
     });
@@ -162,7 +172,7 @@ describe('resolveDevCliFlags', () => {
     const unprobeable = resolveDevCliFlags({
       ...base,
       envIsolated: '1',
-      envUserDataDir: '/AppData/XDT-Maker-DEV2',
+      envUserDataDir: '/AppData/CINDY-DEV2',
       envUserDataDirEpoch: '1',
     });
     expect(unprobeable.isolatedDirIsEpochDerived).toBe(false);
@@ -251,7 +261,7 @@ describe('resolveDevCliFlags', () => {
 
   it('--isolated 默认沙箱:目录 <userData>-dev2,要求派生设备标识,无名字', () => {
     const flags = resolveDevCliFlags({ ...base, argv: [...base.argv, '--isolated'] });
-    expect(flags.userDataDirOverride).toBe('/AppData/xdt-maker-dev2');
+    expect(flags.userDataDirOverride).toBe('/AppData/Cindy-dev2');
     expect(flags.isolated).toBe(true);
     expect(flags.needsIsolatedDeviceId).toBe(true);
     expect(flags.isolationName).toBeNull();
@@ -259,7 +269,7 @@ describe('resolveDevCliFlags', () => {
 
   it('--isolated=<名字> 命名沙箱:目录 <userData>-dev2-<名字>,带出名字', () => {
     const flags = resolveDevCliFlags({ ...base, argv: [...base.argv, '--isolated=feature-a'] });
-    expect(flags.userDataDirOverride).toBe('/AppData/xdt-maker-dev2-feature-a');
+    expect(flags.userDataDirOverride).toBe('/AppData/Cindy-dev2-feature-a');
     expect(flags.needsIsolatedDeviceId).toBe(true);
     expect(flags.isolationName).toBe('feature-a');
     expect(flags.invalidIsolationName).toBeNull();
@@ -267,7 +277,7 @@ describe('resolveDevCliFlags', () => {
 
   it('--isolated=<非法名字> 回落默认沙箱并带出非法名(不回落到不隔离)', () => {
     const bad = resolveDevCliFlags({ ...base, argv: [...base.argv, '--isolated=我的沙箱'] });
-    expect(bad.userDataDirOverride).toBe('/AppData/xdt-maker-dev2');
+    expect(bad.userDataDirOverride).toBe('/AppData/Cindy-dev2');
     expect(bad.needsIsolatedDeviceId).toBe(true);
     expect(bad.isolationName).toBeNull();
     expect(bad.invalidIsolationName).toBe('我的沙箱');
@@ -277,19 +287,19 @@ describe('resolveDevCliFlags', () => {
       argv: [...base.argv, `--isolated=${'a'.repeat(33)}`],
     });
     expect(long.invalidIsolationName).toBe('a'.repeat(33));
-    expect(long.userDataDirOverride).toBe('/AppData/xdt-maker-dev2');
+    expect(long.userDataDirOverride).toBe('/AppData/Cindy-dev2');
   });
 
   it('XDT_ISOLATED=1(restart 脚本默认沙箱路径)等价 --isolated', () => {
     const flags = resolveDevCliFlags({ ...base, envIsolated: '1' });
-    expect(flags.userDataDirOverride).toBe('/AppData/xdt-maker-dev2');
+    expect(flags.userDataDirOverride).toBe('/AppData/Cindy-dev2');
     expect(flags.needsIsolatedDeviceId).toBe(true);
     expect(flags.isolationName).toBeNull();
   });
 
   it('XDT_ISOLATED=1 + XDT_ISOLATED_NAME(restart 脚本命名沙箱路径)等价 --isolated=<名字>', () => {
     const flags = resolveDevCliFlags({ ...base, envIsolated: '1', envIsolationName: 'feature-b' });
-    expect(flags.userDataDirOverride).toBe('/AppData/xdt-maker-dev2-feature-b');
+    expect(flags.userDataDirOverride).toBe('/AppData/Cindy-dev2-feature-b');
     expect(flags.isolationName).toBe('feature-b');
   });
 
@@ -297,11 +307,11 @@ describe('resolveDevCliFlags', () => {
     // argv 路径
     const viaArgv = resolveDevCliFlags({ ...base, argv: [...base.argv, '--isolated=1'] });
     expect(viaArgv.isolationName).toBe('1');
-    expect(viaArgv.userDataDirOverride).toBe('/AppData/xdt-maker-dev2-1');
+    expect(viaArgv.userDataDirOverride).toBe('/AppData/Cindy-dev2-1');
     // restart env 路径:开关与名字分离,名字 '1' 原样生效
     const viaEnv = resolveDevCliFlags({ ...base, envIsolated: '1', envIsolationName: '1' });
     expect(viaEnv.isolationName).toBe('1');
-    expect(viaEnv.userDataDirOverride).toBe('/AppData/xdt-maker-dev2-1');
+    expect(viaEnv.userDataDirOverride).toBe('/AppData/Cindy-dev2-1');
   });
 
   it('XDT_ISOLATED 开关严格等于 "1" 才生效("0"/"false"/名字串都视为关)', () => {
@@ -314,7 +324,7 @@ describe('resolveDevCliFlags', () => {
 
   it('env 名字非法时回落默认沙箱并带出非法名', () => {
     const flags = resolveDevCliFlags({ ...base, envIsolated: '1', envIsolationName: '我的沙箱' });
-    expect(flags.userDataDirOverride).toBe('/AppData/xdt-maker-dev2');
+    expect(flags.userDataDirOverride).toBe('/AppData/Cindy-dev2');
     expect(flags.invalidIsolationName).toBe('我的沙箱');
   });
 
@@ -334,7 +344,7 @@ describe('resolveDevCliFlags', () => {
       argv: [...base.argv, '--isolated'],
       envUserDataDir: '   ',
     });
-    expect(flags.userDataDirOverride).toBe('/AppData/xdt-maker-dev2');
+    expect(flags.userDataDirOverride).toBe('/AppData/Cindy-dev2');
   });
 
   it('显式 XDT_DEVICE_ID_OVERRIDE 时隔离模式不再派生设备标识', () => {
@@ -369,7 +379,7 @@ describe('resolveDevCliFlags', () => {
     const flags = resolveDevCliFlags({
       ...base,
       argv: [...base.argv, '--isolated'],
-      envUserDataDir: '/AppData/xdt-maker',
+      envUserDataDir: '/AppData/Cindy',
     });
     expect(flags.isolated).toBe(true);
     expect(flags.needsIsolatedDeviceId).toBe(true);
@@ -459,7 +469,7 @@ describe('resolveDevCliFlags', () => {
     expect(flags.schedulerPassive).toBe(true);
     expect(flags.isolated).toBe(true);
     expect(flags.profileKind).toBe('isolated-sandbox');
-    expect(flags.userDataDirOverride).toBe('/AppData/xdt-maker-dev2-feature-a');
+    expect(flags.userDataDirOverride).toBe('/AppData/Cindy-dev2-feature-a');
     expect(flags.isolationName).toBe('feature-a');
   });
 });
@@ -469,15 +479,15 @@ describe('resolveDevProfileKind / isIsolatedIdentityOnProductionProfile', () => 
     expect(
       resolveDevProfileKind({
         isolatedDirIsEpochDerived: false,
-        effectiveUserDataDir: '/AppData/xdt-maker',
-        productionUserDataDir: '/AppData/xdt-maker',
+        effectiveUserDataDir: '/AppData/Cindy',
+        productionUserDataDir: '/AppData/Cindy',
       }),
     ).toBe('production-shared');
     expect(
       isIsolatedIdentityOnProductionProfile({
         isolated: true,
-        effectiveUserDataDir: '/AppData/xdt-maker',
-        productionUserDataDir: '/AppData/xdt-maker',
+        effectiveUserDataDir: '/AppData/Cindy',
+        productionUserDataDir: '/AppData/Cindy',
       }),
     ).toBe(true);
   });

--- a/apps/desktop/src/main/__tests__/devCliFlags.test.ts
+++ b/apps/desktop/src/main/__tests__/devCliFlags.test.ts
@@ -34,6 +34,7 @@ const base = {
   isPackaged: false,
   envUserDataDir: undefined as string | undefined,
   defaultUserDataDir: '/AppData/Cindy',
+  appDataDir: '/AppData',
   envIsolated: undefined as string | undefined,
   envIsolationName: undefined as string | undefined,
   envUserDataDirEpoch: undefined as string | undefined,
@@ -67,6 +68,21 @@ describe('resolveDevCliFlags', () => {
     expect(flags.isolatedOnProductionProfile).toBe(false);
     expect(flags.userDataDirOverride).toBeNull();
   });
+
+  it('原生 --user-data-dir 自定义默认 + XDT_USER_DATA_DIR 指向正式目录,仍判正式 profile',
+    () => {
+      const flags = resolveDevCliFlags({
+        ...base,
+        defaultUserDataDir: '/tmp/custom-profile',
+        appDataDir: '/AppData',
+        argv: [...base.argv, '--isolated'],
+        envUserDataDir: '/AppData/Cindy',
+      });
+      expect(flags.profileKind).toBe('production-shared');
+      expect(flags.isolatedOnProductionProfile).toBe(true);
+      expect(flags.needsIsolatedDeviceId).toBe(true);
+    },
+  );
 
   it('--passive 只开被动,不动 userData / 设备标识', () => {
     const flags = resolveDevCliFlags({ ...base, argv: [...base.argv, '--passive'] });

--- a/apps/desktop/src/main/__tests__/devCliFlags.test.ts
+++ b/apps/desktop/src/main/__tests__/devCliFlags.test.ts
@@ -508,7 +508,7 @@ describe('resolveDevProfileKind / isIsolatedIdentityOnProductionProfile', () => 
 });
 
 describe('shouldEnforcePassiveMigrationCompatibility', () => {
-  it('只对共享正式 profile 的 passive dev 启用，沙箱 / custom / packaged 不启用', () => {
+  it('对正式 profile 与非隔离 custom 的 passive 启用，沙箱 / packaged 不启用', () => {
     expect(
       shouldEnforcePassiveMigrationCompatibility({
         isPackaged: false,
@@ -520,14 +520,14 @@ describe('shouldEnforcePassiveMigrationCompatibility', () => {
       shouldEnforcePassiveMigrationCompatibility({
         isPackaged: false,
         schedulerPassive: true,
-        profileKind: 'isolated-sandbox',
+        profileKind: 'custom',
       }),
-    ).toBe(false);
+    ).toBe(true);
     expect(
       shouldEnforcePassiveMigrationCompatibility({
         isPackaged: false,
         schedulerPassive: true,
-        profileKind: 'custom',
+        profileKind: 'isolated-sandbox',
       }),
     ).toBe(false);
     expect(

--- a/apps/desktop/src/main/__tests__/devCliFlags.test.ts
+++ b/apps/desktop/src/main/__tests__/devCliFlags.test.ts
@@ -5,7 +5,9 @@ import { tmpdir } from 'node:os';
 import { basename, dirname, join } from 'node:path';
 
 import {
+  isIsolatedIdentityOnProductionProfile,
   resolveDevCliFlags,
+  resolveDevProfileKind,
   resolveSingleInstanceLockUserDataDir,
   shouldEnforcePassiveMigrationCompatibility,
   shouldRequestSingleInstanceLock,
@@ -45,6 +47,8 @@ describe('resolveDevCliFlags', () => {
     expect(resolveDevCliFlags(base)).toEqual({
       schedulerPassive: false,
       isolated: false,
+      profileKind: 'production-shared',
+      isolatedOnProductionProfile: false,
       userDataDirOverride: null,
       isolatedDirIsEpochDerived: false,
       needsIsolatedDeviceId: false,
@@ -357,6 +361,46 @@ describe('resolveDevCliFlags', () => {
     });
     expect(flags.userDataDirOverride).toBe('/custom/sandbox');
     expect(flags.needsIsolatedDeviceId).toBe(true);
+    expect(flags.profileKind).toBe('custom');
+    expect(flags.isolatedOnProductionProfile).toBe(false);
+  });
+
+  it('--isolated + 正式 profile 目录判定为非法第三态', () => {
+    const flags = resolveDevCliFlags({
+      ...base,
+      argv: [...base.argv, '--isolated'],
+      envUserDataDir: '/AppData/xdt-maker',
+    });
+    expect(flags.isolated).toBe(true);
+    expect(flags.needsIsolatedDeviceId).toBe(true);
+    expect(flags.profileKind).toBe('production-shared');
+    expect(flags.isolatedOnProductionProfile).toBe(true);
+    expect(flags.isolatedDirIsEpochDerived).toBe(false);
+  });
+
+  it('--isolated 指向另一地区正式目录也是非法第三态', () => {
+    const toCn = resolveDevCliFlags({
+      ...base,
+      argv: [...base.argv, '--isolated'],
+      envUserDataDir: '/AppData/Cindy',
+    });
+    expect(toCn.profileKind).toBe('production-shared');
+    expect(toCn.isolatedOnProductionProfile).toBe(true);
+    expect(toCn.needsIsolatedDeviceId).toBe(true);
+
+    const toGlobal = resolveDevCliFlags({
+      ...base,
+      argv: [...base.argv, '--isolated'],
+      envUserDataDir: '/AppData/CindyGlobal',
+    });
+    expect(toGlobal.profileKind).toBe('production-shared');
+    expect(toGlobal.isolatedOnProductionProfile).toBe(true);
+  });
+
+  it('--isolated 默认沙箱是 isolated-sandbox,不是正式 profile', () => {
+    const flags = resolveDevCliFlags({ ...base, argv: [...base.argv, '--isolated'] });
+    expect(flags.profileKind).toBe('isolated-sandbox');
+    expect(flags.isolatedOnProductionProfile).toBe(false);
   });
 
   it('仅设 XDT_USER_DATA_DIR(无隔离意图)沿用原语义,不派生设备标识', () => {
@@ -378,6 +422,8 @@ describe('resolveDevCliFlags', () => {
     expect(flags).toEqual({
       schedulerPassive: false,
       isolated: false,
+      profileKind: 'production-shared',
+      isolatedOnProductionProfile: false,
       userDataDirOverride: null,
       isolatedDirIsEpochDerived: false,
       needsIsolatedDeviceId: false,
@@ -412,32 +458,83 @@ describe('resolveDevCliFlags', () => {
     });
     expect(flags.schedulerPassive).toBe(true);
     expect(flags.isolated).toBe(true);
+    expect(flags.profileKind).toBe('isolated-sandbox');
     expect(flags.userDataDirOverride).toBe('/AppData/xdt-maker-dev2-feature-a');
     expect(flags.isolationName).toBe('feature-a');
   });
 });
 
+describe('resolveDevProfileKind / isIsolatedIdentityOnProductionProfile', () => {
+  it('正式目录一律是 production-shared,isolated 旗标不能把它变成沙箱', () => {
+    expect(
+      resolveDevProfileKind({
+        isolatedDirIsEpochDerived: false,
+        effectiveUserDataDir: '/AppData/xdt-maker',
+        productionUserDataDir: '/AppData/xdt-maker',
+      }),
+    ).toBe('production-shared');
+    expect(
+      isIsolatedIdentityOnProductionProfile({
+        isolated: true,
+        effectiveUserDataDir: '/AppData/xdt-maker',
+        productionUserDataDir: '/AppData/xdt-maker',
+      }),
+    ).toBe(true);
+  });
+
+  it('另一地区正式目录也算正式 profile,不能当成 custom', () => {
+    expect(
+      resolveDevProfileKind({
+        isolatedDirIsEpochDerived: false,
+        effectiveUserDataDir: '/AppData/Cindy',
+        productionUserDataDir: '/AppData/CindyGlobal',
+      }),
+    ).toBe('production-shared');
+    expect(
+      resolveDevProfileKind({
+        isolatedDirIsEpochDerived: false,
+        effectiveUserDataDir: '/AppData/CindyGlobal',
+        productionUserDataDir: '/AppData/Cindy',
+      }),
+    ).toBe('production-shared');
+    expect(
+      isIsolatedIdentityOnProductionProfile({
+        isolated: true,
+        effectiveUserDataDir: '/AppData/Cindy',
+        productionUserDataDir: '/AppData/CindyGlobal',
+      }),
+    ).toBe(true);
+  });
+});
+
 describe('shouldEnforcePassiveMigrationCompatibility', () => {
-  it('只对共享 userData 的 passive dev 启用，isolated 与 packaged 不启用', () => {
+  it('只对共享正式 profile 的 passive dev 启用，沙箱 / custom / packaged 不启用', () => {
     expect(
       shouldEnforcePassiveMigrationCompatibility({
         isPackaged: false,
         schedulerPassive: true,
-        isolated: false,
+        profileKind: 'production-shared',
       }),
     ).toBe(true);
     expect(
       shouldEnforcePassiveMigrationCompatibility({
         isPackaged: false,
         schedulerPassive: true,
-        isolated: true,
+        profileKind: 'isolated-sandbox',
+      }),
+    ).toBe(false);
+    expect(
+      shouldEnforcePassiveMigrationCompatibility({
+        isPackaged: false,
+        schedulerPassive: true,
+        profileKind: 'custom',
       }),
     ).toBe(false);
     expect(
       shouldEnforcePassiveMigrationCompatibility({
         isPackaged: true,
         schedulerPassive: true,
-        isolated: false,
+        profileKind: 'production-shared',
       }),
     ).toBe(false);
   });

--- a/apps/desktop/src/main/__tests__/isolatedOnProductionProfileStartup.test.ts
+++ b/apps/desktop/src/main/__tests__/isolatedOnProductionProfileStartup.test.ts
@@ -20,6 +20,7 @@ describe('isolated-on-production-profile startup refuse', () => {
     expect(refuseIdx).toBeGreaterThan(-1);
     expect(setPathIdx).toBeGreaterThan(refuseIdx);
     expect(deviceIdx).toBeGreaterThan(refuseIdx);
+    expect(indexSource).toContain("appDataDir: app.getPath('appData')");
     expect(indexSource).toContain("isolated: devFlags.profileKind === 'isolated-sandbox'");
     expect(indexSource).toContain('isolationIntent: devFlags.isolated');
     expect(indexSource).toContain('profileKind: devFlags.profileKind');

--- a/apps/desktop/src/main/__tests__/isolatedOnProductionProfileStartup.test.ts
+++ b/apps/desktop/src/main/__tests__/isolatedOnProductionProfileStartup.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * isolated 身份落在正式 profile 上必须在换目录 / 换 deviceId 之前拒绝启动。
+ * 2026-08-16：cindy-pi-live-model-catalog 自称 isolated、目录仍是正式 Cindy，
+ * DEVICE_MISMATCH 后清掉正式版 refresh token。
+ */
+describe('isolated-on-production-profile startup refuse', () => {
+  const indexSource = readFileSync(resolve(process.cwd(), 'src/main/index.ts'), 'utf8').replace(
+    /\r\n/g,
+    '\n',
+  );
+
+  it('main process fail-closes before applying userData or isolated deviceId', () => {
+    const refuseIdx = indexSource.indexOf('if (devFlags.isolatedOnProductionProfile)');
+    const setPathIdx = indexSource.indexOf("app.setPath('userData', devFlags.userDataDirOverride)");
+    const deviceIdx = indexSource.indexOf('if (devFlags.needsIsolatedDeviceId)');
+    expect(refuseIdx).toBeGreaterThan(-1);
+    expect(setPathIdx).toBeGreaterThan(refuseIdx);
+    expect(deviceIdx).toBeGreaterThan(refuseIdx);
+    expect(indexSource).toContain("isolated: devFlags.profileKind === 'isolated-sandbox'");
+    expect(indexSource).toContain('isolationIntent: devFlags.isolated');
+    expect(indexSource).toContain('profileKind: devFlags.profileKind');
+  });
+});

--- a/apps/desktop/src/main/__tests__/officialProfileMigrationPolicy.test.ts
+++ b/apps/desktop/src/main/__tests__/officialProfileMigrationPolicy.test.ts
@@ -1,0 +1,70 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import {
+  officialProfileWriterMigrationMessage,
+  shouldRefuseOfficialProfileWriterMigration,
+} from '../localDb/officialProfileMigrationPolicy';
+
+describe('shouldRefuseOfficialProfileWriterMigration', () => {
+  it('unpackaged writer + 正式 profile + pending 必须拒绝', () => {
+    expect(
+      shouldRefuseOfficialProfileWriterMigration({
+        isPackaged: false,
+        officialSharedProfile: true,
+        pendingCount: 1,
+      }),
+    ).toBe(true);
+  });
+
+  it('schema 已对齐时允许打开正式 profile', () => {
+    expect(
+      shouldRefuseOfficialProfileWriterMigration({
+        isPackaged: false,
+        officialSharedProfile: true,
+        pendingCount: 0,
+      }),
+    ).toBe(false);
+  });
+
+  it('packaged / 沙箱 / custom 仍可迁', () => {
+    expect(
+      shouldRefuseOfficialProfileWriterMigration({
+        isPackaged: true,
+        officialSharedProfile: true,
+        pendingCount: 3,
+      }),
+    ).toBe(false);
+    expect(
+      shouldRefuseOfficialProfileWriterMigration({
+        isPackaged: false,
+        officialSharedProfile: false,
+        pendingCount: 3,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('officialProfileWriterMigrationMessage', () => {
+  it('点名待执行 migration 并指向 isolated', () => {
+    const message = officialProfileWriterMigrationMessage(['0091_amazing_blur.sql']);
+    expect(message).toContain('0091_amazing_blur.sql');
+    expect(message).toContain('--isolated=');
+  });
+});
+
+describe('official profile writer wiring', () => {
+  it('index 对正式 profile 落地 XDT_OFFICIAL_SHARED_PROFILE,migrate 在备份前拒绝', () => {
+    const indexSource = readFileSync(resolve(process.cwd(), 'src/main/index.ts'), 'utf8');
+    const migrateSource = readFileSync(
+      resolve(process.cwd(), 'src/main/localDb/migrate.ts'),
+      'utf8',
+    );
+    expect(indexSource).toContain("process.env.XDT_OFFICIAL_SHARED_PROFILE = '1'");
+    const refuseIdx = migrateSource.indexOf('shouldRefuseOfficialProfileWriterMigration');
+    const backupIdx = migrateSource.indexOf('await backupDb(');
+    expect(refuseIdx).toBeGreaterThan(-1);
+    expect(backupIdx).toBeGreaterThan(refuseIdx);
+  });
+});

--- a/apps/desktop/src/main/__tests__/officialProfileMigrationPolicy.test.ts
+++ b/apps/desktop/src/main/__tests__/officialProfileMigrationPolicy.test.ts
@@ -62,9 +62,11 @@ describe('official profile writer wiring', () => {
       'utf8',
     );
     expect(indexSource).toContain("process.env.XDT_OFFICIAL_SHARED_PROFILE = '1'");
-    const refuseIdx = migrateSource.indexOf('shouldRefuseOfficialProfileWriterMigration');
+    const refuseIdx = migrateSource.indexOf('shouldRefuseOfficialProfileWriterMigration({');
+    const prepareIdx = migrateSource.indexOf('prepareBackupDiskSpace(');
     const backupIdx = migrateSource.indexOf('await backupDb(');
     expect(refuseIdx).toBeGreaterThan(-1);
+    expect(prepareIdx).toBeGreaterThan(refuseIdx);
     expect(backupIdx).toBeGreaterThan(refuseIdx);
   });
 });

--- a/apps/desktop/src/main/authManager.ts
+++ b/apps/desktop/src/main/authManager.ts
@@ -366,9 +366,9 @@ function createAuthClient(
  * 发生过一次,当时只把静默半死改成明确弹重登(见 authSessionExpiredDetection.test.ts),
  * 没有堵住 passive 的销毁权。
  *
- * packaged 恒不设置该 env(index.ts 启动时对 packaged / isolated 显式 delete 兜底,
- * 防 ambient env 污染),线上零影响;`--isolated` 沙箱有独立 userData 与 deviceId,
- * 本来就不共享,不受此闸门约束。
+ * packaged 恒不设置该 env(index.ts 启动时对 packaged / 非正式共享 profile 显式
+ * delete 兜底,防 ambient env 污染),线上零影响。env 由解析后的 profileKind ===
+ * production-shared 且 passive 落地,不看 isolated 旗标。
  */
 function isPassiveSharedUserDataInstance(): boolean {
   return !app.isPackaged && process.env.XDT_PASSIVE_SHARED_USER_DATA === '1';
@@ -2516,6 +2516,10 @@ async function runColdStartRefreshFlow(
           clearConfirmedDeadRefreshTokens(storedRealm, confirmedDeadTokens);
         }
         resetActiveAuthRealmToBuild();
+      } else if (action.kind === 'foreign-device') {
+        log.warn(
+          'cold-start refresh: DEVICE_MISMATCH — this process starts logged out and keeps the persisted refresh token',
+        );
       } else if (action.kind === 'replacement-retry') {
         log.warn(
           `cold-start refresh failed for a stale token after ${attempts} attempt(s) — keeping latest refresh token, starting logged out`,
@@ -3233,6 +3237,15 @@ export async function refresh(): Promise<boolean> {
           const previousUserId =
             currentUser?.id ?? getActiveAppSession().dataOwnerId ?? 'signed-out';
           await expireRuntimeAuth(previousUserId, resolveSessionExpiredReason(code));
+        } else if (action.kind === 'foreign-device') {
+          log.warn(
+            'runtime refresh: DEVICE_MISMATCH — expiring this process and keeping the persisted refresh token',
+          );
+          const previousUserId =
+            currentUser?.id ?? getActiveAppSession().dataOwnerId ?? 'signed-out';
+          await expireRuntimeAuth(previousUserId, 'device-mismatch', {
+            preservePersistedRefreshToken: true,
+          });
         } else if (action.kind === 'replacement-retry') {
           log.warn(
             `runtime refresh failed for a stale token after replacement retries status=${result.status} code=${code ?? '<none>'} — retrying in ${RUNTIME_REFRESH_RETRY_MS / 1000}s`,

--- a/apps/desktop/src/main/authManager.ts
+++ b/apps/desktop/src/main/authManager.ts
@@ -366,9 +366,9 @@ function createAuthClient(
  * 发生过一次,当时只把静默半死改成明确弹重登(见 authSessionExpiredDetection.test.ts),
  * 没有堵住 passive 的销毁权。
  *
- * packaged 恒不设置该 env(index.ts 启动时对 packaged / 非正式共享 profile 显式
- * delete 兜底,防 ambient env 污染),线上零影响。env 由解析后的 profileKind ===
- * production-shared 且 passive 落地,不看 isolated 旗标。
+ * packaged 恒不设置该 env(index.ts 启动时对 packaged / isolated-sandbox 显式
+ * delete 兜底,防 ambient env 污染),线上零影响。env 由解析后的 profileKind
+ * 不是 isolated-sandbox 且 passive 落地,覆盖正式目录与非隔离 custom 共库。
  */
 function isPassiveSharedUserDataInstance(): boolean {
   return !app.isPackaged && process.env.XDT_PASSIVE_SHARED_USER_DATA === '1';
@@ -383,6 +383,12 @@ function isPassiveSharedUserDataInstance(): boolean {
  * 直到用户在本进程显式登录或重启进程为止。
  */
 let passiveLocalSignOut = false;
+
+/**
+ * DEVICE_MISMATCH 后本进程已确认配不上磁盘 token。token 留给真正的设备,
+ * 但 initialize() 不能反复拿同一枚去撞 401。直到显式登录或进程重启为止。
+ */
+let foreignDeviceLocalSignOut = false;
 
 // ── safeStorage helpers ─────────────────────────────────────────────────────
 
@@ -2317,6 +2323,11 @@ export async function initialize(options: AuthInitializeOptions = {}): Promise<A
     commitVolatileAppSession('signed-out');
     return snapshotLoggedOutAuthState();
   }
+  if (foreignDeviceLocalSignOut) {
+    log.info('foreign-device instance stays signed out locally (tombstone)');
+    commitVolatileAppSession('signed-out');
+    return snapshotLoggedOutAuthState();
+  }
 
   // release-relogin-on-update: if the auto-updater dropped a relogin marker
   // for *this* version, wipe persisted auth and force the user back to the
@@ -2520,6 +2531,7 @@ async function runColdStartRefreshFlow(
         log.warn(
           'cold-start refresh: DEVICE_MISMATCH — this process starts logged out and keeps the persisted refresh token',
         );
+        foreignDeviceLocalSignOut = true;
       } else if (action.kind === 'replacement-retry') {
         log.warn(
           `cold-start refresh failed for a stale token after ${attempts} attempt(s) — keeping latest refresh token, starting logged out`,
@@ -2745,8 +2757,9 @@ async function completeLogin(
         clearReloginFlag();
       }
       accountDeletionRestoredNoticePending = deletionWasRestored;
-      // 显式登录解除 passive 本地登出墓碑(见 passiveLocalSignOut)。
+      // 显式登录解除本进程登出墓碑(passive / foreign-device)。
       passiveLocalSignOut = false;
+      foreignDeviceLocalSignOut = false;
       currentUser = nextUser;
       commitCloudAppSession(currentUser.id);
       pendingAuthRealm = null;
@@ -3241,6 +3254,7 @@ export async function refresh(): Promise<boolean> {
           log.warn(
             'runtime refresh: DEVICE_MISMATCH — expiring this process and keeping the persisted refresh token',
           );
+          foreignDeviceLocalSignOut = true;
           const previousUserId =
             currentUser?.id ?? getActiveAppSession().dataOwnerId ?? 'signed-out';
           await expireRuntimeAuth(previousUserId, 'device-mismatch', {

--- a/apps/desktop/src/main/authRefreshFailure.ts
+++ b/apps/desktop/src/main/authRefreshFailure.ts
@@ -245,15 +245,18 @@ export async function runRefreshWithTransientRetry<T>(
   for (const delayMs of retryDelaysMs) {
     if (result.ok) break;
     const definitive = isDefinitiveRefreshFailure(result);
+    const foreignDevice = isForeignDeviceRefreshFailure(result);
     const skipRateLimited = result.status === 429 && rateLimitDelayMs <= 0;
     opts?.onFailure?.({
       attempt: attempts,
       status: result.status,
       code: (result.data as RefreshErrorBody | null)?.error?.code,
       definitive,
-      willRetry: !definitive && !skipRateLimited,
+      willRetry: !definitive && !foreignDevice && !skipRateLimited,
     });
-    if (definitive) return { result, attempts };
+    // DEVICE_MISMATCH 不得当瞬时失败重试：会拖 1/2 秒，且后续 429/断网会把
+    // 终态盖成 transient-failure，冷启动就立不上 foreign-device 墓碑。
+    if (definitive || foreignDevice) return { result, attempts };
     if (skipRateLimited) return { result, attempts };
     const effectiveDelay = result.status === 429 ? rateLimitDelayMs : delayMs;
     await sleep(effectiveDelay);

--- a/apps/desktop/src/main/authRefreshFailure.ts
+++ b/apps/desktop/src/main/authRefreshFailure.ts
@@ -13,9 +13,15 @@
 export const DEFINITIVE_REFRESH_FAILURE_CODES: ReadonlySet<string> = new Set([
   'REFRESH_TOKEN_EXPIRED',
   'INVALID_REFRESH_TOKEN',
-  'DEVICE_MISMATCH',
   'MEMBERSHIP_DISABLED',
 ]);
+
+/**
+ * 当前进程的 device 配不上这枚 token。token 对真正的那台设备可能仍然有效，
+ * 不能单凭这个错误码删盘（2026-08-16：isolated 身份落在正式 profile 上，
+ * DEVICE_MISMATCH 后删掉正式版 refresh token）。
+ */
+export const FOREIGN_DEVICE_REFRESH_FAILURE_CODE = 'DEVICE_MISMATCH';
 
 /** 只有这个错误码可能来自同机多实例轮换竞态;其它确定性错误换 token 无效。 */
 const REPLACEMENT_RETRY_ELIGIBLE_CODES: ReadonlySet<string> = new Set(['INVALID_REFRESH_TOKEN']);
@@ -27,8 +33,8 @@ export interface RefreshErrorBody {
 
 /**
  * 判断一次 `/api/auth/refresh` 调用结果是否为「确定性凭据失效」——即应当从本地清除
- * refresh token。返回 `false` 表示:要么成功,要么是应当**保留** token 的瞬时失败
- * (429 限流 / 5xx / 断网 status:0 / 无识别码的 4xx)。
+ * refresh token。返回 `false` 表示:要么成功,要么是应当**保留** token 的失败
+ * (429 限流 / 5xx / 断网 status:0 / 无识别码的 4xx / DEVICE_MISMATCH)。
  *
  * @param result apiFetch 返回值的最小子集:`ok` + 响应体 `data`。
  */
@@ -36,6 +42,11 @@ export function isDefinitiveRefreshFailure(result: { ok: boolean; data: unknown 
   if (result.ok) return false;
   const code = (result.data as RefreshErrorBody | null)?.error?.code;
   return typeof code === 'string' && DEFINITIVE_REFRESH_FAILURE_CODES.has(code);
+}
+
+export function isForeignDeviceRefreshFailure(result: { ok: boolean; data: unknown }): boolean {
+  if (result.ok) return false;
+  return getRefreshErrorCode(result) === FOREIGN_DEVICE_REFRESH_FAILURE_CODE;
 }
 
 function getRefreshErrorCode(result: { data: unknown }): string | undefined {
@@ -119,11 +130,13 @@ export function resolveSessionExpiredReason(code: string | undefined): SessionEx
 export type RefreshFailureAction =
   | { kind: 'transient-failure' }
   | { kind: 'definitive-failure' }
+  | { kind: 'foreign-device' }
   | { kind: 'replacement-retry'; refreshToken: string };
 
 /**
- * 把 refresh 失败分为三类:
+ * 把 refresh 失败分为四类:
  * - transient: 网络/限流/服务端临时问题,保留 token 后续自愈;
+ * - foreign-device: 当前进程 device 配不上这枚 token,本进程登出但不得删盘;
  * - definitive: 当前磁盘 token 也已失败,清态重登;
  * - replacement-retry: 本次请求用的是 stale token,磁盘已有别的实例写入的新 token。
  */
@@ -135,6 +148,7 @@ export function resolveRefreshFailureAction(
   requestedToken: string,
   latestStoredToken: string | null,
 ): RefreshFailureAction {
+  if (isForeignDeviceRefreshFailure(result)) return { kind: 'foreign-device' };
   if (!isDefinitiveRefreshFailure(result)) return { kind: 'transient-failure' };
   if (!isReplacementRetryEligibleFailure(result)) return { kind: 'definitive-failure' };
   const replacement = getRefreshTokenReplacementCandidate(requestedToken, latestStoredToken);

--- a/apps/desktop/src/main/devCliFlags.ts
+++ b/apps/desktop/src/main/devCliFlags.ts
@@ -256,10 +256,10 @@ export function shouldEnforcePassiveMigrationCompatibility(input: {
 
 export function resolveOfficialUserDataDirs(defaultUserDataDir: string): string[] {
   const parent = dirname(defaultUserDataDir);
-  return [
-    defaultUserDataDir,
-    ...OFFICIAL_USER_DATA_DIR_NAMES.map((name) => join(parent, name)),
-  ];
+  // 只认已知正式目录名。不能把运行时 defaultUserDataDir 无条件算进去：
+  // 原生 `--user-data-dir=/tmp/custom` 会让 app.getPath('userData') 变成自定义
+  // 目录，再把它标成 production-shared 会误拦 pending migration。
+  return OFFICIAL_USER_DATA_DIR_NAMES.map((name) => join(parent, name));
 }
 
 function isOfficialUserDataDir(

--- a/apps/desktop/src/main/devCliFlags.ts
+++ b/apps/desktop/src/main/devCliFlags.ts
@@ -132,6 +132,12 @@ export interface DevCliFlagsInput {
   /** app.getPath('userData') 的默认值;隔离模式在其后缀 '-dev2[-<名字>]' 生成沙箱目录。 */
   defaultUserDataDir: string;
   /**
+   * Electron app.getPath('appData')。正式 profile 只从这里派生 Cindy /
+   * CindyGlobal / CindyDev，不得用当前 userData 覆写的父目录猜。
+   * 缺省回落到 dirname(defaultUserDataDir)，仅给旧测试。
+   */
+  appDataDir?: string;
+  /**
    * XDT_ISOLATED 环境变量:严格 '1' = 隔离开关开,其它任何值(含 '0'/'false'/名字)
    * 一律视为关。名字**不**挤在这个变量里——否则名叫 "1" 的沙箱会和开关标记值撞车
    * (数据目录是命名的、deviceId 却派生成默认的,把互踢问题带回来,codex review P2)。
@@ -254,12 +260,11 @@ export function shouldEnforcePassiveMigrationCompatibility(input: {
   return !input.isPackaged && input.schedulerPassive && input.profileKind !== 'isolated-sandbox';
 }
 
-export function resolveOfficialUserDataDirs(defaultUserDataDir: string): string[] {
-  const parent = dirname(defaultUserDataDir);
-  // 只认已知正式目录名。不能把运行时 defaultUserDataDir 无条件算进去：
-  // 原生 `--user-data-dir=/tmp/custom` 会让 app.getPath('userData') 变成自定义
-  // 目录，再把它标成 production-shared 会误拦 pending migration。
-  return OFFICIAL_USER_DATA_DIR_NAMES.map((name) => join(parent, name));
+export function resolveOfficialUserDataDirs(appDataDir: string): string[] {
+  // 正式集合永远从 appData 派生。不能用当前 userData 覆写的父目录猜：
+  // `--user-data-dir=/tmp/custom` + `XDT_USER_DATA_DIR=$HOME/.../Cindy` 时，
+  // 用 /tmp 当父目录会把真正的 Cindy 目录判成 custom。
+  return OFFICIAL_USER_DATA_DIR_NAMES.map((name) => join(appDataDir, name));
 }
 
 function isOfficialUserDataDir(
@@ -271,32 +276,46 @@ function isOfficialUserDataDir(
   return officialDirs.some((official) => canonicalize(official) === target);
 }
 
+function officialDirsFromInput(input: {
+  officialUserDataDirs?: readonly string[];
+  appDataDir?: string;
+  productionUserDataDir?: string;
+  effectiveUserDataDir?: string;
+}): readonly string[] {
+  if (input.officialUserDataDirs) return input.officialUserDataDirs;
+  const appDataDir =
+    input.appDataDir ??
+    dirname(input.productionUserDataDir ?? input.effectiveUserDataDir ?? '');
+  return resolveOfficialUserDataDirs(appDataDir);
+}
+
 export function isIsolatedIdentityOnProductionProfile(input: {
   isolated: boolean;
   effectiveUserDataDir: string;
   productionUserDataDir?: string;
+  appDataDir?: string;
   officialUserDataDirs?: readonly string[];
   canonicalizePath?: (value: string) => string;
 }): boolean {
   if (!input.isolated) return false;
   const canonicalize = input.canonicalizePath ?? defaultCanonicalizePath;
-  const officialDirs =
-    input.officialUserDataDirs ??
-    resolveOfficialUserDataDirs(input.productionUserDataDir ?? input.effectiveUserDataDir);
-  return isOfficialUserDataDir(input.effectiveUserDataDir, officialDirs, canonicalize);
+  return isOfficialUserDataDir(
+    input.effectiveUserDataDir,
+    officialDirsFromInput(input),
+    canonicalize,
+  );
 }
 
 export function resolveDevProfileKind(input: {
   isolatedDirIsEpochDerived: boolean;
   effectiveUserDataDir: string;
   productionUserDataDir?: string;
+  appDataDir?: string;
   officialUserDataDirs?: readonly string[];
   canonicalizePath?: (value: string) => string;
 }): DevProfileKind {
   const canonicalize = input.canonicalizePath ?? defaultCanonicalizePath;
-  const officialDirs =
-    input.officialUserDataDirs ??
-    resolveOfficialUserDataDirs(input.productionUserDataDir ?? input.effectiveUserDataDir);
+  const officialDirs = officialDirsFromInput(input);
   if (isOfficialUserDataDir(input.effectiveUserDataDir, officialDirs, canonicalize)) {
     return 'production-shared';
   }
@@ -379,7 +398,9 @@ export function resolveDevCliFlags(input: DevCliFlagsInput): DevCliFlags {
     userDataDirOverride !== null &&
     canonicalize(userDataDirOverride) === canonicalize(epochDerivedDir);
   const effectiveUserDataDir = userDataDirOverride ?? input.defaultUserDataDir;
-  const officialUserDataDirs = resolveOfficialUserDataDirs(input.defaultUserDataDir);
+  const officialUserDataDirs = resolveOfficialUserDataDirs(
+    input.appDataDir ?? dirname(input.defaultUserDataDir),
+  );
   const isolatedOnProductionProfile = isIsolatedIdentityOnProductionProfile({
     isolated,
     effectiveUserDataDir,

--- a/apps/desktop/src/main/devCliFlags.ts
+++ b/apps/desktop/src/main/devCliFlags.ts
@@ -111,6 +111,12 @@ function defaultCanonicalizePath(p: string): string {
  */
 const ISOLATION_NAME_RE = /^[A-Za-z0-9_-]{1,32}$/;
 
+/**
+ * 同机所有正式区域 profile 的目录名。当前构建区域只决定默认目录和沙箱派生，
+ * 不能缩小保护集合：Global 启动指到 CN 的 Cindy、反向同理，都仍是正式 profile。
+ */
+export const OFFICIAL_USER_DATA_DIR_NAMES = ['Cindy', 'CindyGlobal', 'CindyDev'] as const;
+
 export interface DevCliFlagsInput {
   argv: readonly string[];
   isPackaged: boolean;
@@ -148,11 +154,18 @@ export interface DevCliFlagsInput {
   envEndpointsCdn: string | undefined;
 }
 
+/** 解析后的实际 profile 归属。安全权限必须看这个，不能只看启动旗标。 */
+export type DevProfileKind = 'production-shared' | 'isolated-sandbox' | 'custom';
+
 export interface DevCliFlags {
   /** --passive:本实例定时任务不自动触发(scheduler-host 读 XDT_SCHEDULER_PASSIVE)。 */
   schedulerPassive: boolean;
   /** 是否由 --isolated / XDT_ISOLATED 明确进入独立 userData 沙箱。 */
   isolated: boolean;
+  /** 实际落地的 profile 种类。isolated 旗标指向正式目录时仍是 production-shared。 */
+  profileKind: DevProfileKind;
+  /** isolated 身份却落在正式 profile 上：启动器必须拒绝。 */
+  isolatedOnProductionProfile: boolean;
   /**
    * 生效的 userData 覆写目录;null = 不覆写。来源优先级:
    * 显式 XDT_USER_DATA_DIR > 隔离模式默认沙箱目录(<userData>-dev2[-<名字>])> 不覆写。
@@ -224,18 +237,71 @@ export function resolveSingleInstanceLockUserDataDir(input: {
 }
 
 /**
- * passive 只有在共享 userData 时才需要禁止 migration。
+ * passive 只有在共享正式 profile 时才需要禁止 migration。
  *
  * 显式 isolated 沙箱没有其它实例替它初始化数据库，仍按正常启动路径迁移；packaged
  * 不接受任何 dev-only passive 语义。调用方会把这个纯判定同步成内部 env，供延后加载
  * 的 localDb 模块在首次打开用户数据库时执行硬闸。
+ *
+ * 判定看解析后的 profileKind，不看 isolated 旗标：旗标说 isolated、目录却是正式版时
+ * 仍按 production-shared 处理（启动器应先拒绝这种组合）。
  */
 export function shouldEnforcePassiveMigrationCompatibility(input: {
   isPackaged: boolean;
   schedulerPassive: boolean;
-  isolated: boolean;
+  profileKind: DevProfileKind;
 }): boolean {
-  return !input.isPackaged && input.schedulerPassive && !input.isolated;
+  return !input.isPackaged && input.schedulerPassive && input.profileKind === 'production-shared';
+}
+
+export function resolveOfficialUserDataDirs(defaultUserDataDir: string): string[] {
+  const parent = dirname(defaultUserDataDir);
+  return [
+    defaultUserDataDir,
+    ...OFFICIAL_USER_DATA_DIR_NAMES.map((name) => join(parent, name)),
+  ];
+}
+
+function isOfficialUserDataDir(
+  dir: string,
+  officialDirs: readonly string[],
+  canonicalize: (value: string) => string,
+): boolean {
+  const target = canonicalize(dir);
+  return officialDirs.some((official) => canonicalize(official) === target);
+}
+
+export function isIsolatedIdentityOnProductionProfile(input: {
+  isolated: boolean;
+  effectiveUserDataDir: string;
+  productionUserDataDir?: string;
+  officialUserDataDirs?: readonly string[];
+  canonicalizePath?: (value: string) => string;
+}): boolean {
+  if (!input.isolated) return false;
+  const canonicalize = input.canonicalizePath ?? defaultCanonicalizePath;
+  const officialDirs =
+    input.officialUserDataDirs ??
+    resolveOfficialUserDataDirs(input.productionUserDataDir ?? input.effectiveUserDataDir);
+  return isOfficialUserDataDir(input.effectiveUserDataDir, officialDirs, canonicalize);
+}
+
+export function resolveDevProfileKind(input: {
+  isolatedDirIsEpochDerived: boolean;
+  effectiveUserDataDir: string;
+  productionUserDataDir?: string;
+  officialUserDataDirs?: readonly string[];
+  canonicalizePath?: (value: string) => string;
+}): DevProfileKind {
+  const canonicalize = input.canonicalizePath ?? defaultCanonicalizePath;
+  const officialDirs =
+    input.officialUserDataDirs ??
+    resolveOfficialUserDataDirs(input.productionUserDataDir ?? input.effectiveUserDataDir);
+  if (isOfficialUserDataDir(input.effectiveUserDataDir, officialDirs, canonicalize)) {
+    return 'production-shared';
+  }
+  if (input.isolatedDirIsEpochDerived) return 'isolated-sandbox';
+  return 'custom';
 }
 
 export function resolveDevCliFlags(input: DevCliFlagsInput): DevCliFlags {
@@ -243,6 +309,8 @@ export function resolveDevCliFlags(input: DevCliFlagsInput): DevCliFlags {
     return {
       schedulerPassive: false,
       isolated: false,
+      profileKind: 'production-shared',
+      isolatedOnProductionProfile: false,
       userDataDirOverride: null,
       isolatedDirIsEpochDerived: false,
       needsIsolatedDeviceId: false,
@@ -310,9 +378,25 @@ export function resolveDevCliFlags(input: DevCliFlagsInput): DevCliFlags {
     explicitDirTrusted &&
     userDataDirOverride !== null &&
     canonicalize(userDataDirOverride) === canonicalize(epochDerivedDir);
+  const effectiveUserDataDir = userDataDirOverride ?? input.defaultUserDataDir;
+  const officialUserDataDirs = resolveOfficialUserDataDirs(input.defaultUserDataDir);
+  const isolatedOnProductionProfile = isIsolatedIdentityOnProductionProfile({
+    isolated,
+    effectiveUserDataDir,
+    officialUserDataDirs,
+    canonicalizePath: canonicalize,
+  });
+  const profileKind = resolveDevProfileKind({
+    isolatedDirIsEpochDerived,
+    effectiveUserDataDir,
+    officialUserDataDirs,
+    canonicalizePath: canonicalize,
+  });
   return {
     schedulerPassive: input.argv.includes('--passive') || input.envSchedulerPassive === '1',
     isolated,
+    profileKind,
+    isolatedOnProductionProfile,
     userDataDirOverride,
     isolatedDirIsEpochDerived,
     needsIsolatedDeviceId: isolated && !input.envDeviceIdOverride?.trim(),

--- a/apps/desktop/src/main/devCliFlags.ts
+++ b/apps/desktop/src/main/devCliFlags.ts
@@ -243,15 +243,15 @@ export function resolveSingleInstanceLockUserDataDir(input: {
  * 不接受任何 dev-only passive 语义。调用方会把这个纯判定同步成内部 env，供延后加载
  * 的 localDb 模块在首次打开用户数据库时执行硬闸。
  *
- * 判定看解析后的 profileKind，不看 isolated 旗标：旗标说 isolated、目录却是正式版时
- * 仍按 production-shared 处理（启动器应先拒绝这种组合）。
+ * 判定看解析后的真实 profile：正式目录与非隔离 custom 覆写（两进程共一个裸
+ * XDT_USER_DATA_DIR）都受保护；只有真正的 isolated-sandbox 自己迁、自己删。
  */
 export function shouldEnforcePassiveMigrationCompatibility(input: {
   isPackaged: boolean;
   schedulerPassive: boolean;
   profileKind: DevProfileKind;
 }): boolean {
-  return !input.isPackaged && input.schedulerPassive && input.profileKind === 'production-shared';
+  return !input.isPackaged && input.schedulerPassive && input.profileKind !== 'isolated-sandbox';
 }
 
 export function resolveOfficialUserDataDirs(defaultUserDataDir: string): string[] {

--- a/apps/desktop/src/main/devStartupStatus.ts
+++ b/apps/desktop/src/main/devStartupStatus.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
 import type { CindyRegion } from '@cindy/maker-shared/brand-identity';
+import type { DevProfileKind } from './devCliFlags.js';
 
 export type DesktopDevMode = 'remote' | 'local' | 'unknown';
 export type DesktopDevInstanceState = 'starting' | 'ready' | 'failed';
@@ -28,7 +29,12 @@ export interface DesktopDevInstanceRecord {
   /** 构建区域；共享 userData 启动器据此拒绝跨区域 passive 预览。 */
   region: CindyRegion;
   passive: boolean;
+  /** 解析后是否真的落在独立纪元沙箱。不是「有 userData 覆写」。 */
   isolated: boolean;
+  /** 启动旗标是否声明了 --isolated / XDT_ISOLATED。 */
+  isolationIntent?: boolean;
+  /** 解析后的实际 profile 归属。 */
+  profileKind?: DevProfileKind;
   userDataDir: string;
   state: DesktopDevInstanceState;
   failure?: {
@@ -46,6 +52,8 @@ export interface BeginDesktopDevInstanceOptions {
   region?: CindyRegion;
   passive: boolean;
   isolated: boolean;
+  isolationIntent?: boolean;
+  profileKind?: DevProfileKind;
   pid?: number;
   startedAtMs?: number;
   instanceId?: string;
@@ -139,6 +147,8 @@ export function beginDesktopDevInstance(
     region: options.region ?? 'global',
     passive: options.passive,
     isolated: options.isolated,
+    ...(options.isolationIntent !== undefined ? { isolationIntent: options.isolationIntent } : {}),
+    ...(options.profileKind !== undefined ? { profileKind: options.profileKind } : {}),
     userDataDir: path.resolve(options.userDataDir),
     state: 'starting',
   };

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -101,6 +101,17 @@ const devFlags = resolveDevCliFlags({
   envSchedulerPassive: process.env.XDT_SCHEDULER_PASSIVE,
   envEndpointsCdn: process.env.XDT_ENDPOINTS_CDN,
 });
+if (devFlags.isolatedOnProductionProfile) {
+  // isolated 身份会换独立 deviceId；正式 profile 上的 refresh token 属于正式版设备。
+  // 两者叠在同一目录 = 必然 DEVICE_MISMATCH，再删盘会把正式版踢下线(2026-08-16)。
+  // 报实际目标目录：可能是当前区域，也可能是另一地区的正式 profile。
+  const targetDir = devFlags.userDataDirOverride ?? app.getPath('userData');
+  stderr.write(
+    `[cindy] FATAL: --isolated cannot use the official Cindy profile (${targetDir}). ` +
+      'Use the default sandbox, --isolated=<name>, or a directory that is not an official userData.\n',
+  );
+  exit(1);
+}
 if (devFlags.schedulerPassive) {
   // 统一收敛到 env:scheduler-host 只认 XDT_SCHEDULER_PASSIVE,不重复解析 argv。
   process.env.XDT_SCHEDULER_PASSIVE = '1';
@@ -109,7 +120,7 @@ if (devFlags.schedulerPassive) {
 if (shouldEnforcePassiveMigrationCompatibility({
   isPackaged: app.isPackaged,
   schedulerPassive: devFlags.schedulerPassive,
-  isolated: devFlags.isolated,
+  profileKind: devFlags.profileKind,
 })) {
   // 内部启动契约：共享 userData 的 passive dev 只能打开与当前 checkout migration
   // 完全一致的数据库，且不得自行迁移。localDb 在用户数据库首次打开时消费本标记。
@@ -228,7 +239,9 @@ if (devFlags.needsIsolatedDeviceId) {
     mode,
     region: CURRENT_CINDY_REGION,
     passive: devFlags.schedulerPassive,
-    isolated: Boolean(devFlags.userDataDirOverride),
+    isolated: devFlags.profileKind === 'isolated-sandbox',
+    isolationIntent: devFlags.isolated,
+    profileKind: devFlags.profileKind,
   });
   app.once('will-quit', cleanupDevInstance);
 }

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -112,6 +112,13 @@ if (devFlags.isolatedOnProductionProfile) {
   );
   exit(1);
 }
+if (!app.isPackaged && devFlags.profileKind === 'production-shared') {
+  // 正式 profile 上的 unpackaged writer 不得应用 pending migration。
+  // 已合入 main、但安装包还没带上的序号会把安装版打挂（2026-08-16 schema 91）。
+  process.env.XDT_OFFICIAL_SHARED_PROFILE = '1';
+} else {
+  delete process.env.XDT_OFFICIAL_SHARED_PROFILE;
+}
 if (devFlags.schedulerPassive) {
   // 统一收敛到 env:scheduler-host 只认 XDT_SCHEDULER_PASSIVE,不重复解析 argv。
   process.env.XDT_SCHEDULER_PASSIVE = '1';

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -94,6 +94,7 @@ const devFlags = resolveDevCliFlags({
   isPackaged: app.isPackaged,
   envUserDataDir: process.env.XDT_USER_DATA_DIR,
   defaultUserDataDir: app.getPath('userData'),
+  appDataDir: app.getPath('appData'),
   envIsolated: process.env.XDT_ISOLATED,
   envIsolationName: process.env.XDT_ISOLATED_NAME,
   envUserDataDirEpoch: process.env.XDT_USER_DATA_DIR_EPOCH,

--- a/apps/desktop/src/main/localDb/migrate.ts
+++ b/apps/desktop/src/main/localDb/migrate.ts
@@ -32,6 +32,10 @@ import {
   readSchemaVersion,
   runMigrationReplay,
 } from './migrationRunner';
+import {
+  officialProfileWriterMigrationMessage,
+  shouldRefuseOfficialProfileWriterMigration,
+} from './officialProfileMigrationPolicy';
 
 const log = createLogger('migrate');
 
@@ -91,6 +95,17 @@ export async function runMigrations(
       JSON.stringify({ event: 'localDb.migrate.upToDate', currentVersion }),
     );
     return;
+  }
+  if (
+    shouldRefuseOfficialProfileWriterMigration({
+      isPackaged: app.isPackaged,
+      officialSharedProfile: process.env.XDT_OFFICIAL_SHARED_PROFILE === '1',
+      pendingCount: pending.length,
+    })
+  ) {
+    throw new Error(
+      officialProfileWriterMigrationMessage(pending.map((migration) => migration.fileName)),
+    );
   }
 
   // 备份前先做磁盘侧准备：腾旧备份预算 + 剩余空间预检。

--- a/apps/desktop/src/main/localDb/officialProfileMigrationPolicy.ts
+++ b/apps/desktop/src/main/localDb/officialProfileMigrationPolicy.ts
@@ -1,0 +1,23 @@
+/**
+ * 正式 profile 上的 dev writer 不得应用 pending migration。
+ *
+ * 2026-08-16：含 0091 的 checkout 以 writer 打开正式 Cindy 目录，把安装版
+ * 0.1.50（只到 0090）打挂。`assertSharedDevMigrationPolicy` 只拦「未合入
+ * origin/main」的产物；已合入主干、但安装包还没带上的 migration 照样会写进
+ * 共享库。这一层看真实 profile + pending，不看 isolated 旗标。
+ */
+export function shouldRefuseOfficialProfileWriterMigration(input: {
+  isPackaged: boolean;
+  officialSharedProfile: boolean;
+  pendingCount: number;
+}): boolean {
+  return !input.isPackaged && input.officialSharedProfile && input.pendingCount > 0;
+}
+
+export function officialProfileWriterMigrationMessage(pendingNames: readonly string[]): string {
+  const pending = pendingNames.length > 0 ? pendingNames.join(', ') : '(unknown)';
+  return (
+    `开发版不能把正式 Cindy 目录的数据库升到当前 checkout 的 schema（待执行 ${pending}）。` +
+    '请改用 --isolated=<名字>，或等包含这些 migration 的正式版发布后再用共享目录。'
+  );
+}

--- a/docs/dev-rules/database-and-migrations.md
+++ b/docs/dev-rules/database-and-migrations.md
@@ -90,6 +90,10 @@ companion CommonJS 格式和历史 runtime identity 冻结；不能用单独 typ
 
 - 未进入 `main` 的 migration 禁止连接共享 Cindy userData 运行；否则分支换号或回退后会让
   本地 `schema_version` 与真实结构永久分叉。
+- **已合入 `main`、但安装包还没带上的 migration 同样不得写进正式 profile。** unpackaged
+  writer 在 Cindy / CindyGlobal / CindyDev 上发现 pending 就 fail closed（2026-08-16：
+  checkout 带着 0091 把 0.1.50 的共享库升到 91，安装版打不开）。要验证新 schema 必须
+  `--isolated[=<名字>]`；等正式版发布后再用共享目录。
 - 需要启动验证时，按照 `desktop-development.md` 的参数说明使用显式
   `--isolated[=<名字>]` 沙箱。migration replay 自身使用临时数据库，不污染用户数据。
 - 不得为了测试 migration 临时改写、降级或删除用户数据库；需要历史状态时新增最小 fixture。

--- a/docs/dev-rules/desktop-development.md
+++ b/docs/dev-rules/desktop-development.md
@@ -76,6 +76,8 @@ Cindy 内部而拒绝重启，或因目标 userData 被其他 checkout 占用而
 
 正式版目录保持历史兼容：CN → `Cindy`，Global → `CindyGlobal`，不在启动时改名或搬迁用户数据。
 非隔离 dev 也使用当前区域对应的正式 profile；`--isolated` 沙箱再按相同区域映射派生目录。
+**dev writer 不得把正式 profile 升到当前 checkout 比安装版更新的 schema**：有 pending
+migration 就拒绝启动，改用 `--isolated=<名字>`。`--preserve-running` / 共库 passive 仍只读。
 跨区域共享、登录态迁移或旧版本回滚应使用显式隔离目录，避免不同构建误用同一 profile。
 
 ### 并行多开 dev

--- a/docs/dev-rules/desktop-development.md
+++ b/docs/dev-rules/desktop-development.md
@@ -37,9 +37,14 @@ Cindy 内部而拒绝重启，或因目标 userData 被其他 checkout 占用而
   数据」时用。**未合入主干的 migration 必须在 `--isolated` 沙箱里跑，不得连共享 userData**
   （见 [`database-and-migrations.md`](database-and-migrations.md)）。沙箱（及任何 dev
   userData 覆写）内不触发首登旧数据迁移（mToc）：不探测老目录、不弹确认窗、不把正式
-  数据复制进沙箱。
-- `--passive`：定时任务被动模式，本实例不自动触发 schedule，但数据仍与其它实例共享；
-  多开导致定时任务重复、需要让位给 primary 时用。共享 userData 的 passive 实例对
+  数据复制进沙箱。**`--isolated` 不得落在任一正式 profile 上**：显式 `XDT_USER_DATA_DIR`
+  若指向 CN / Global / Dev 任一正式目录（不限当前构建区域），启动器与主进程都 fail closed。isolated 会换独立 deviceId，
+  正式目录里的 refresh token 属于正式版设备，叠在一起必然 `DEVICE_MISMATCH`，再删盘会
+  把正式版踢下线（2026-08-16）。
+- `--passive`：定时任务被动模式，本实例不自动触发 schedule。多开导致定时任务重复、
+  需要让位给 primary 时用。它可以和 `--isolated` 组合（隔离沙箱只看 UI、不跑定时任务
+  是合法的）。**共库只读契约不是这个旗标本身**，而是解析后的正式 profile + passive
+  才落地。共享正式 profile 的 passive 实例对
   userData 布局保持只读：不执行 owner-namespace 迁移（claim 推迟到下次独占启动），
   legacy 数据导入（`hasLegacyOwnerNamespaceClaim` 门控的 secret／IM／brain 搬账）
   一并等待。非 passive 实例执行该迁移前也会先查 `.dev-instances` 实例注册表
@@ -58,14 +63,16 @@ Cindy 内部而拒绝重启，或因目标 userData 被其他 checkout 占用而
   refresh token——那写入的是有效凭证，primary 侧由 replacement-retry 消化。反过来让
   passive 停止续期，会使它的 access token 过期后再无替换途径（primary 的续期只更新磁盘
   token，不更新 passive 进程的内存态，而直接走 `apiFetch` 的路径没有 401 refresh/retry）。
-- `--preserve-running`：并行 dev，不停止任何已有 Cindy dev 进程，每个新实例强制 passive
-  并共享当前区域的 userData／登录态；启动前必须由 `.dev-instances` 存活记录证明已运行
+- `--preserve-running`：启动编排，不是运行期模式。默认 restart 本来就不会关正式版和
+  其它 worktree，只替换**当前 checkout** 的旧 dev；本旗标连这份旧 dev 也保留，再并排
+  开一个共库预览，并强制 `--passive`。启动前必须由 `.dev-instances` 存活记录证明已运行
   实例与目标区域一致，旧记录没有 region 或跨区域都会 fail closed。仅供能证明实例归属的
-  上层编排，或用户明确「不要关当前实例／不要重新登录」时用。仅支持 remote，禁止与
-  `--isolated` 组合。共享实例若只发现没有 realm 的旧版裸 refresh token，也不得猜区域迁移
-  或轮换，保持本进程登出，交给同区域独占实例完成凭证迁移。
+  上层编排，或用户明确「不要关当前实例／不要重新登录」时用。仅支持 remote。禁止与
+  `--isolated` 或环境里的 `XDT_ISOLATED=1` 组合。共享实例若只发现没有 realm 的旧版裸
+  refresh token，也不得猜区域迁移或轮换，保持本进程登出，交给同区域独占实例完成凭证迁移。
 
 已手动设 `XDT_USER_DATA_DIR` 时尊重用户值，不覆盖，也不探测或迁移正式区域目录。
+唯一例外：`--isolated` / `XDT_ISOLATED=1` 把该目录指到正式 profile 时直接拒绝启动。
 
 正式版目录保持历史兼容：CN → `Cindy`，Global → `CindyGlobal`，不在启动时改名或搬迁用户数据。
 非隔离 dev 也使用当前区域对应的正式 profile；`--isolated` 沙箱再按相同区域映射派生目录。

--- a/scripts/__tests__/restart-desktop-remote.test.mjs
+++ b/scripts/__tests__/restart-desktop-remote.test.mjs
@@ -16,6 +16,7 @@ import {
 	isRepositoryDesktopDevProcess,
 	officialProductionUserDataDirs,
 	resolveRestartTargetUserDataDir,
+	sanitizeIsolationName,
 	formatDesktopStartupFailure,
 	inspectSharedUserDataRegion,
 	partitionDesktopDevProcesses,
@@ -200,6 +201,18 @@ test("env-only XDT_ISOLATED=1 derives the default sandbox, not the official prof
 		selectedRegion: "global",
 	});
 	assert.equal(named, defaultIsolatedUserDataDir("review", "global"));
+});
+
+test("invalid env isolation name falls back to the default sandbox", () => {
+	assert.equal(sanitizeIsolationName("../Cindy"), "");
+	assert.equal(sanitizeIsolationName("我的沙箱"), "");
+	const target = resolveRestartTargetUserDataDir({
+		isolatedEnv: "1",
+		isolatedName: "../Cindy",
+		selectedRegion: "cn",
+	});
+	assert.equal(target, defaultIsolatedUserDataDir("", "cn"));
+	assert.equal(isOfficialProductionUserDataDir(target), false);
 });
 
 test("isolated official-profile refuse happens before mkdir in the restart main flow", () => {

--- a/scripts/__tests__/restart-desktop-remote.test.mjs
+++ b/scripts/__tests__/restart-desktop-remote.test.mjs
@@ -17,6 +17,7 @@ import {
 	officialProductionUserDataDirs,
 	resolveRestartTargetUserDataDir,
 	sanitizeIsolationName,
+	canonicalizeUserDataDir,
 	formatDesktopStartupFailure,
 	inspectSharedUserDataRegion,
 	partitionDesktopDevProcesses,
@@ -213,6 +214,21 @@ test("invalid env isolation name falls back to the default sandbox", () => {
 	});
 	assert.equal(target, defaultIsolatedUserDataDir("", "cn"));
 	assert.equal(isOfficialProductionUserDataDir(target), false);
+});
+
+test("canonicalizeUserDataDir follows symlink parents when the leaf does not exist yet", () => {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), "cindy-canon-"));
+	const realParent = path.join(root, "real");
+	const linkParent = path.join(root, "link");
+	try {
+		fs.mkdirSync(realParent);
+		fs.symlinkSync(realParent, linkParent);
+		const viaLink = canonicalizeUserDataDir(path.join(linkParent, "Cindy"));
+		const viaReal = canonicalizeUserDataDir(path.join(realParent, "Cindy"));
+		assert.equal(viaLink, viaReal);
+	} finally {
+		fs.rmSync(root, { recursive: true, force: true });
+	}
 });
 
 test("isolated official-profile refuse happens before mkdir in the restart main flow", () => {

--- a/scripts/__tests__/restart-desktop-remote.test.mjs
+++ b/scripts/__tests__/restart-desktop-remote.test.mjs
@@ -187,6 +187,21 @@ test("isolated restart target pointing at the other region's official profile is
 	assert.equal(isOfficialProductionUserDataDir(globalFromCn), true);
 });
 
+test("env-only XDT_ISOLATED=1 derives the default sandbox, not the official profile", () => {
+	const target = resolveRestartTargetUserDataDir({
+		isolatedEnv: "1",
+		selectedRegion: "cn",
+	});
+	assert.equal(target, defaultIsolatedUserDataDir("", "cn"));
+	assert.equal(isOfficialProductionUserDataDir(target), false);
+	const named = resolveRestartTargetUserDataDir({
+		isolatedEnv: "1",
+		isolatedName: "review",
+		selectedRegion: "global",
+	});
+	assert.equal(named, defaultIsolatedUserDataDir("review", "global"));
+});
+
 test("isolated official-profile refuse happens before mkdir in the restart main flow", () => {
 	const source = fs.readFileSync(new URL("../restart-desktop-remote.mjs", import.meta.url), "utf8");
 	const refuseIdx = source.indexOf("isOfficialProductionUserDataDir(targetUserDataDir)");

--- a/scripts/__tests__/restart-desktop-remote.test.mjs
+++ b/scripts/__tests__/restart-desktop-remote.test.mjs
@@ -11,7 +11,11 @@ import {
 	commandUsesUserDataDir,
 	defaultIsolatedUserDataDir,
 	devEnvPrefix,
+	hasIsolationIntent,
+	isOfficialProductionUserDataDir,
 	isRepositoryDesktopDevProcess,
+	officialProductionUserDataDirs,
+	resolveRestartTargetUserDataDir,
 	formatDesktopStartupFailure,
 	inspectSharedUserDataRegion,
 	partitionDesktopDevProcesses,
@@ -149,6 +153,46 @@ test("default isolated userData path is region-aware", () => {
 	assert.equal(path.basename(defaultIsolatedUserDataDir("", "global")), "CindyGlobal-dev2");
 	assert.equal(path.basename(defaultIsolatedUserDataDir("", "cn")), "Cindy-dev2");
 	assert.equal(path.basename(defaultIsolatedUserDataDir("review", "dev")), "CindyDev-dev2-review");
+});
+
+test("hasIsolationIntent sees argv and ambient XDT_ISOLATED=1", () => {
+	assert.equal(hasIsolationIntent([]), false);
+	assert.equal(hasIsolationIntent(["--isolated"]), true);
+	assert.equal(hasIsolationIntent(["--isolated=review"]), true);
+	assert.equal(hasIsolationIntent([], { XDT_ISOLATED: "1" }), true);
+	assert.equal(hasIsolationIntent([], { XDT_ISOLATED: "0" }), false);
+});
+
+test("isOfficialProductionUserDataDir matches every official region profile", () => {
+	assert.equal(isOfficialProductionUserDataDir(productionUserDataDir("cn")), true);
+	assert.equal(isOfficialProductionUserDataDir(productionUserDataDir("global")), true);
+	assert.equal(isOfficialProductionUserDataDir(productionUserDataDir("dev")), true);
+	assert.equal(isOfficialProductionUserDataDir(defaultIsolatedUserDataDir("", "cn")), false);
+	assert.ok(officialProductionUserDataDirs().some((dir) => path.basename(dir) === "Cindy"));
+	assert.ok(officialProductionUserDataDirs().some((dir) => path.basename(dir) === "CindyGlobal"));
+});
+
+test("isolated restart target pointing at the other region's official profile is refused", () => {
+	const cnFromGlobal = resolveRestartTargetUserDataDir({
+		envUserDataDir: productionUserDataDir("cn"),
+		isolatedArg: "--isolated",
+		selectedRegion: "global",
+	});
+	assert.equal(isOfficialProductionUserDataDir(cnFromGlobal), true);
+	const globalFromCn = resolveRestartTargetUserDataDir({
+		envUserDataDir: productionUserDataDir("global"),
+		isolatedArg: "--isolated",
+		selectedRegion: "cn",
+	});
+	assert.equal(isOfficialProductionUserDataDir(globalFromCn), true);
+});
+
+test("isolated official-profile refuse happens before mkdir in the restart main flow", () => {
+	const source = fs.readFileSync(new URL("../restart-desktop-remote.mjs", import.meta.url), "utf8");
+	const refuseIdx = source.indexOf("isOfficialProductionUserDataDir(targetUserDataDir)");
+	const mkdirIdx = source.indexOf("fs.mkdirSync(process.env.XDT_USER_DATA_DIR");
+	assert.ok(refuseIdx > 0);
+	assert.ok(mkdirIdx > refuseIdx);
 });
 
 test("preserve-running only shares a target with live records from the same region", () => {

--- a/scripts/desktop-whoami.mjs
+++ b/scripts/desktop-whoami.mjs
@@ -271,6 +271,8 @@ export function mergeDesktopInstanceRecords(scanned, records, worktrees) {
       region: record.region ?? null,
       passive: Boolean(record.passive),
       isolated: Boolean(record.isolated),
+      isolationIntent: record.isolationIntent === true,
+      profileKind: typeof record.profileKind === 'string' ? record.profileKind : null,
       userDataDir: record.userDataDir,
       commit: record.commit ?? null,
       commitVerified: typeof record.commit === 'string' && record.commit.length > 0,

--- a/scripts/restart-desktop-remote.mjs
+++ b/scripts/restart-desktop-remote.mjs
@@ -6,6 +6,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
   applyDesktopDevStartupConfig,
+  DESKTOP_DEV_REGIONS,
   desktopUserDataDirNameForRegion,
   resolveDesktopDevRegion,
 } from './shared/desktop-dev-region.mjs';
@@ -449,6 +450,31 @@ function userDataDirNamed(dirName) {
   return path.join(xdgConfig, dirName);
 }
 
+export function hasIsolationIntent(argv = [], env = process.env) {
+  return argv.some((arg) => arg === '--isolated' || arg.startsWith('--isolated='))
+    || env.XDT_ISOLATED === '1';
+}
+
+export function officialProductionUserDataDirs() {
+  return DESKTOP_DEV_REGIONS.map((region) => productionUserDataDir(region));
+}
+
+export function isOfficialProductionUserDataDir(dir) {
+  const resolved = path.resolve(dir);
+  return officialProductionUserDataDirs().some((official) => path.resolve(official) === resolved);
+}
+
+export function resolveRestartTargetUserDataDir({
+  envUserDataDir,
+  isolatedArg,
+  selectedRegion,
+}) {
+  return envUserDataDir
+    || (isolatedArg
+      ? defaultIsolatedUserDataDir(parseIsolationName(isolatedArg), selectedRegion)
+      : productionUserDataDir(selectedRegion));
+}
+
 export function defaultIsolatedUserDataDir(isolationName, region = 'global') {
   // 目录纪元 v2(-dev2),与 devCliFlags.ts 的派生保持一字不差:#871 起隔离沙箱用
   // CindyDev 钥匙串身份,旧 -dev 目录留给旧 checkout(#912 review)。
@@ -791,9 +817,9 @@ async function main() {
       '--preserve-running only supports remote mode: sharing remote login storage with a local auth server could invalidate the persisted credential',
     );
   }
-  if (preserveRunning && isolatedArg) {
+  if (preserveRunning && hasIsolationIntent(argv, process.env)) {
     throw new Error(
-      '--preserve-running reuses the current Cindy login via shared userData and cannot be combined with --isolated',
+      '--preserve-running reuses the current Cindy login via shared userData and cannot be combined with --isolated or XDT_ISOLATED=1',
     );
   }
   if (startupConfig) {
@@ -853,8 +879,6 @@ async function main() {
       // 路径以默认身份打开造成双身份互写(#912 review P1)。
       process.env.XDT_USER_DATA_DIR_EPOCH = '1';
     }
-    fs.mkdirSync(process.env.XDT_USER_DATA_DIR, { recursive: true });
-    console.log(`==> Isolated dev user data${isolationName ? ` (sandbox "${isolationName}")` : ''}: ${process.env.XDT_USER_DATA_DIR}`);
   }
   if (startupConfig) ensureDesktopEnv();
 
@@ -887,10 +911,25 @@ async function main() {
   // --isolated 名字,或用户自己停掉那个实例。preserve-running 不进此门 ——
   // 它的语义就是共享 userData 的被动预览。检测是尽力而为:靠 helper 进程命令行
   // 上的 --user-data-dir,对方实例刚启动还没起 helper 时可能漏检。
-  const targetUserDataDir = process.env.XDT_USER_DATA_DIR
-    || (isolatedArg
-      ? defaultIsolatedUserDataDir(parseIsolationName(isolatedArg), selectedRegion)
-      : productionUserDataDir(selectedRegion));
+  const targetUserDataDir = resolveRestartTargetUserDataDir({
+    envUserDataDir: process.env.XDT_USER_DATA_DIR,
+    isolatedArg,
+    selectedRegion,
+  });
+  if (
+    hasIsolationIntent(argv, process.env)
+    && isOfficialProductionUserDataDir(targetUserDataDir)
+  ) {
+    throw new Error(
+      `--isolated cannot use the official Cindy profile (${targetUserDataDir}). ` +
+        'Omit XDT_USER_DATA_DIR, or point it at a sandbox directory.',
+    );
+  }
+  if (startupConfig && isolatedArg && process.env.XDT_USER_DATA_DIR) {
+    fs.mkdirSync(process.env.XDT_USER_DATA_DIR, { recursive: true });
+    const isolationName = parseIsolationName(isolatedArg);
+    console.log(`==> Isolated dev user data${isolationName ? ` (sandbox "${isolationName}")` : ''}: ${process.env.XDT_USER_DATA_DIR}`);
+  }
   if (!preserveRunning) {
     const conflicts = listDesktopDevProcesses().filter(
       (proc) => !commandContainsPath(proc.command, rootDir)

--- a/scripts/restart-desktop-remote.mjs
+++ b/scripts/restart-desktop-remote.mjs
@@ -459,9 +459,28 @@ export function officialProductionUserDataDirs() {
   return DESKTOP_DEV_REGIONS.map((region) => productionUserDataDir(region));
 }
 
-export function isOfficialProductionUserDataDir(dir) {
+/** 与 devCliFlags ISOLATION_NAME_RE 一致：非法名字回落默认沙箱，不把路径段写进目录。 */
+export const ISOLATION_NAME_RE = /^[A-Za-z0-9_-]{1,32}$/;
+
+export function sanitizeIsolationName(raw) {
+  const name = typeof raw === 'string' ? raw.trim() : '';
+  return ISOLATION_NAME_RE.test(name) ? name : '';
+}
+
+export function canonicalizeUserDataDir(dir) {
   const resolved = path.resolve(dir);
-  return officialProductionUserDataDirs().some((official) => path.resolve(official) === resolved);
+  try {
+    return fs.realpathSync.native(resolved);
+  } catch {
+    return resolved;
+  }
+}
+
+export function isOfficialProductionUserDataDir(dir) {
+  const resolved = canonicalizeUserDataDir(dir);
+  return officialProductionUserDataDirs().some(
+    (official) => canonicalizeUserDataDir(official) === resolved,
+  );
 }
 
 export function resolveRestartTargetUserDataDir({
@@ -471,9 +490,9 @@ export function resolveRestartTargetUserDataDir({
   isolatedName,
   selectedRegion,
 }) {
-  const isolationName = isolatedArg
-    ? parseIsolationName(isolatedArg)
-    : (typeof isolatedName === 'string' ? isolatedName.trim() : '');
+  const isolationName = sanitizeIsolationName(
+    isolatedArg ? parseIsolationName(isolatedArg) : isolatedName,
+  );
   const isolated = Boolean(isolatedArg) || isolatedEnv === '1';
   return envUserDataDir
     || (isolated

--- a/scripts/restart-desktop-remote.mjs
+++ b/scripts/restart-desktop-remote.mjs
@@ -467,11 +467,17 @@ export function isOfficialProductionUserDataDir(dir) {
 export function resolveRestartTargetUserDataDir({
   envUserDataDir,
   isolatedArg,
+  isolatedEnv,
+  isolatedName,
   selectedRegion,
 }) {
+  const isolationName = isolatedArg
+    ? parseIsolationName(isolatedArg)
+    : (typeof isolatedName === 'string' ? isolatedName.trim() : '');
+  const isolated = Boolean(isolatedArg) || isolatedEnv === '1';
   return envUserDataDir
-    || (isolatedArg
-      ? defaultIsolatedUserDataDir(parseIsolationName(isolatedArg), selectedRegion)
+    || (isolated
+      ? defaultIsolatedUserDataDir(isolationName, selectedRegion)
       : productionUserDataDir(selectedRegion));
 }
 
@@ -914,6 +920,8 @@ async function main() {
   const targetUserDataDir = resolveRestartTargetUserDataDir({
     envUserDataDir: process.env.XDT_USER_DATA_DIR,
     isolatedArg,
+    isolatedEnv: process.env.XDT_ISOLATED,
+    isolatedName: process.env.XDT_ISOLATED_NAME,
     selectedRegion,
   });
   if (
@@ -925,9 +933,15 @@ async function main() {
         'Omit XDT_USER_DATA_DIR, or point it at a sandbox directory.',
     );
   }
-  if (startupConfig && isolatedArg && process.env.XDT_USER_DATA_DIR) {
+  if (startupConfig && hasIsolationIntent(argv, process.env)) {
+    if (!process.env.XDT_USER_DATA_DIR) {
+      process.env.XDT_USER_DATA_DIR = targetUserDataDir;
+      process.env.XDT_USER_DATA_DIR_EPOCH = '1';
+    }
     fs.mkdirSync(process.env.XDT_USER_DATA_DIR, { recursive: true });
-    const isolationName = parseIsolationName(isolatedArg);
+    const isolationName = isolatedArg
+      ? parseIsolationName(isolatedArg)
+      : (process.env.XDT_ISOLATED_NAME || '');
     console.log(`==> Isolated dev user data${isolationName ? ` (sandbox "${isolationName}")` : ''}: ${process.env.XDT_USER_DATA_DIR}`);
   }
   if (!preserveRunning) {

--- a/scripts/restart-desktop-remote.mjs
+++ b/scripts/restart-desktop-remote.mjs
@@ -467,12 +467,57 @@ export function sanitizeIsolationName(raw) {
   return ISOLATION_NAME_RE.test(name) ? name : '';
 }
 
+function volumeIsCaseInsensitive(existingDir) {
+  let dir = existingDir;
+  for (;;) {
+    const parent = path.dirname(dir);
+    const atRoot = parent === dir;
+    if (!atRoot) {
+      try {
+        if (fs.statSync(parent).dev !== fs.statSync(dir).dev) return false;
+      } catch {
+        return false;
+      }
+    }
+    const name = path.basename(dir);
+    const flipped = name.replace(/[a-zA-Z]/g, (ch) => (
+      ch === ch.toLowerCase() ? ch.toUpperCase() : ch.toLowerCase()
+    ));
+    if (flipped !== name) {
+      try {
+        return fs.realpathSync.native(path.join(parent, flipped))
+          === fs.realpathSync.native(dir);
+      } catch {
+        return false;
+      }
+    }
+    if (atRoot) return false;
+    dir = parent;
+  }
+}
+
 export function canonicalizeUserDataDir(dir) {
   const resolved = path.resolve(dir);
   try {
-    return fs.realpathSync.native(resolved);
+    const real = fs.realpathSync.native(resolved);
+    return volumeIsCaseInsensitive(real) ? real.toLowerCase() : real;
   } catch {
-    return resolved;
+    // 叶子还不存在:沿最近存在祖先做 realpath,再按该卷语义接回剩余段。
+  }
+  let current = resolved;
+  const suffix = [];
+  for (;;) {
+    const parent = path.dirname(current);
+    suffix.unshift(path.basename(current));
+    if (parent === current) return resolved;
+    current = parent;
+    try {
+      const ancestorReal = fs.realpathSync.native(current);
+      const joined = path.join(ancestorReal, ...suffix);
+      return volumeIsCaseInsensitive(ancestorReal) ? joined.toLowerCase() : joined;
+    } catch {
+      // 继续上溯
+    }
   }
 }
 


### PR DESCRIPTION
## 这次改了什么

### 摘要

dev 实例自称 `--isolated`、实际却打开正式 userData 时，会换独立 deviceId，拿正式版 refresh token 去续期。服务端回 `DEVICE_MISMATCH` 后，客户端把共享 token 删掉，正式版稍后被强制重登。

同一天稍后，含 `0091` 的 checkout 又以 writer 打开正式目录，把安装版 0.1.50（只到 0090）的共享库升到 91，安装版打不开。`assertSharedDevMigrationPolicy` 只拦未合入 main 的产物，拦不住这条。

这次按解析后的真实目录判定正式 profile，在换 deviceId 和写目录之前 fail closed；`DEVICE_MISMATCH` 只让本进程登出，不再删盘；unpackaged writer 在正式目录发现 pending migration 也 fail closed。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无（本机 2026-08-16 正式版被踢、共享库被升到 91）
- 本 PR 包含：
  - 按真实目录判定 `production-shared` / `isolated-sandbox` / `custom`
  - `--isolated` 落到任一正式 profile 时，主进程与 restart 脚本都拒绝启动
  - `--preserve-running` 同时检查 argv 与 `XDT_ISOLATED=1`
  - restart 先做官方 profile 判定，再 `mkdir`
  - `DEVICE_MISMATCH` 从确定性删盘集合移出，冷启动 / runtime 都保留磁盘 token
  - 实例卡同时记录 `isolationIntent` 与 `profileKind`
  - unpackaged writer 不得把正式 profile 升到当前 checkout 比安装版更新的 schema
- 明确不包含：
  - 不把 `--passive` 与 `--isolated` 做成全局二选一
  - 不改默认「无参数 = 共享正式 profile + 主动 schedule」（schema 已对齐时仍可共库）
- 用户可见变化：误把 isolated 指到正式目录时启动失败；正式版不再被这种 dev 实例连坐登出；开发版在正式目录上有 pending migration 时拒绝启动，需改 `--isolated=<名字>`
- 是否存在 breaking change：无协议 breaking。开发工作流变化：`pnpm restart:desktop:remote` 不再会把正式库升到安装包没有的 schema。

### UI 变化

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop run typecheck
结果：通过

pnpm --filter desktop exec vitest run src/main/__tests__/officialProfileMigrationPolicy.test.ts src/main/__tests__/devCliFlags.test.ts src/main/__tests__/isolatedOnProductionProfileStartup.test.ts
结果：41 passed

node --test scripts/__tests__/restart-desktop-remote.test.mjs
结果：34/34 通过
```

### 手工验证

不涉及。启动拒绝路径由源码顺序守卫 + 单测覆盖；本机事故现场已回滚到 schema 90，未再故意复现升库。

### 未执行的验证

未再人为把 isolated 指到正式目录、或让 writer 对正式库执行 pending migration。原因是会再次破坏本机正式版数据。

## 风险

### 风险分类

- [ ] 无已知风险
- [x] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop dev 启动路径、auth refresh 失败处理、正式 profile 上的 unpackaged schema 写入。packaged 正式版仍可迁移自己的目录。
- 回滚 / 降级方式：revert 本 PR。回退后，isolated 指到正式目录会再次换 deviceId；`DEVICE_MISMATCH` 会重新变成删盘；dev writer 会再次把正式库升到安装包没有的 schema。
- 存量插件影响：无

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
