### PR TITLE
fix(login): 唯一登录方式跳过选择框

### DIFF
--- a/apps/desktop/src/main/__tests__/authLoginFlowReset.test.ts
+++ b/apps/desktop/src/main/__tests__/authLoginFlowReset.test.ts
@@ -63,6 +63,10 @@ describe('auth login-flow reset', () => {
     expect(body).toContain("type: 'realm-switch-required'");
     expect(body).toContain("type: 'discovery-loaded'");
     expect(body).toContain("email: ''");
+    // 唯一 SSO 不在 main 里套 start-browser：否则 renderer 要等整段浏览器
+    // 授权结束才拿得到下一步，确认框会卡住。waiting 投影归 renderer。
+    expect(body).not.toContain('soleAutoStartSsoMethod');
+    expect(body).not.toContain("type: 'start-browser'");
 
     // 跨区连接只有 confirm action 才写入 start-browser 白名单；弹窗阶段不能
     // 通过伪造 connectionId 直接跳过确认。
@@ -73,6 +77,8 @@ describe('auth login-flow reset', () => {
     );
     expect(confirmBody).toContain('discoveredMethods = confirmation.methods;');
     expect(confirmBody).toContain("type: 'discovery-loaded'");
+    expect(confirmBody).not.toContain('soleAutoStartSsoMethod');
+    expect(confirmBody).not.toContain("type: 'start-browser'");
   });
 
   it('clears stale organization realm state before personal login and a new discovery', () => {

--- a/apps/desktop/src/main/authManager.ts
+++ b/apps/desktop/src/main/authManager.ts
@@ -2868,9 +2868,10 @@ async function runLoginAction(action: DesktopLoginAction): Promise<DesktopLoginA
       return { success: true, state: loginFlowState };
     }
 
-    // 企业 SSO 入口（按组织 ID/slug/已验证域名）：结果映射进 method-choice，
-    // 同区域直接进入连接选择；跨区域先进入确认状态，确认后才把连接写入
-    // start-browser 白名单并允许继续 SSO。
+    // 企业 SSO 入口（按组织 ID/slug/已验证域名）：同区域进入连接选择；
+    // 跨区域先进入确认状态，确认后才把连接写入 start-browser 白名单。
+    // 唯一 SSO 由 renderer 接到 method-choice 后直接派发 start-browser，
+    // 以便立刻投影 browser-redirect（确认框消失、露出取消）。
     if (action.type === 'discover-sso-org') {
       const discovery = await discoverOrganizationRealm(action.org.trim().toLowerCase());
       const methods = ssoOrgDiscoveryToMethods(discovery);

--- a/apps/desktop/src/renderer/__tests__/authContextRace.test.ts
+++ b/apps/desktop/src/renderer/__tests__/authContextRace.test.ts
@@ -77,6 +77,21 @@ describe('AuthContext auth-state races', () => {
     expect(source).toContain("if (action.type === 'start-browser')");
     expect(source).toContain("setLoginState({ step: 'browser-redirect', label: action.label });");
   });
+
+  it('auto-continues a sole method-choice so fake pickers never paint', () => {
+    expect(source).toContain('soleLoginMethod(result.state.methods)');
+    expect(source).toContain("type: 'start-browser'");
+    expect(source).toContain('providerOrConnectionId: sole.connectionId');
+    expect(source).toContain("type: 'request-code'");
+    expect(source).toContain("kind: 'email'");
+    expect(source).toContain('identifier: result.state.email');
+    const projectWaiting = source.indexOf(
+      "setLoginState({ step: 'browser-redirect', label: action.label });",
+    );
+    const autoStart = source.indexOf('soleLoginMethod(result.state.methods)');
+    expect(projectWaiting).toBeGreaterThan(-1);
+    expect(autoStart).toBeGreaterThan(projectWaiting);
+  });
 });
 
 describe('data-owner live push fencing', () => {

--- a/apps/desktop/src/renderer/components/login/LoginPage.tsx
+++ b/apps/desktop/src/renderer/components/login/LoginPage.tsx
@@ -409,6 +409,19 @@ export function LoginPage() {
     setIdentifierFormatError(null);
   }, [loginState?.step]);
 
+  // 进入 verification-code 即起算 42s(含 AuthContext 自动发码、手机号提交)。
+  // 只认运行中的 step 沿,不认首帧注入(harness 直接挂验证码页仍保持可点重发)。
+  // 已在验证码页的重发成功仍走 dispatchRequestCode 的 arm。
+  const previousLoginStepRef = useRef(loginState?.step);
+  useEffect(() => {
+    const previous = previousLoginStepRef.current;
+    const step = loginState?.step;
+    previousLoginStepRef.current = step;
+    if (step === 'verification-code' && previous !== 'verification-code' && previous != null) {
+      armResendCountdown();
+    }
+  }, [loginState?.step, armResendCountdown]);
+
   const errorMessage = useMemo(() => {
     if (!errorCode) return null;
     return t(`login.errors.${errorCode}`, {

--- a/apps/desktop/src/renderer/components/login/__tests__/LoginPage.pr2a.harness.test.tsx
+++ b/apps/desktop/src/renderer/components/login/__tests__/LoginPage.pr2a.harness.test.tsx
@@ -63,6 +63,11 @@ function scenarioClient(scenario: string, region: 'cn' | 'global' = 'cn') {
   });
 }
 
+async function identifierState(scenario = 'providers:both') {
+  const providers = await scenarioClient(scenario).getProviders();
+  return reduceAuthFlow(null, { type: 'providers-loaded', providers });
+}
+
 async function methodChoiceState(scenario: string, email = 'user@example-corp.com') {
   const methods = await scenarioClient(scenario).discover(email);
   return reduceAuthFlow(null, { type: 'discovery-loaded', email, methods });
@@ -235,6 +240,19 @@ describe('verification-code', () => {
     const spin = screen.getByRole('status');
     expect(spin.className).toContain('animate-spin');
     expect(spin.className).toContain('motion-reduce:animate-none');
+  });
+
+  it('identifier → verification-code 自动起算 42s(含 AuthContext 自动发码路径)', async () => {
+    const view = mount(await identifierState());
+    expect(screen.queryByTestId('login-resend-countdown')).toBeNull();
+    loginHook.value = {
+      ...loginHook.value,
+      loginState: await verificationState(),
+    };
+    view.rerender(<LoginPage />);
+    expect(screen.getByTestId('login-resend-countdown').textContent).toBe(
+      'login.resendCountdown#42',
+    );
   });
 
   it('重发成功重置 / 失败保持(dispatch 返回值驱动 arm)', async () => {

--- a/apps/desktop/src/renderer/contexts/AuthContext.tsx
+++ b/apps/desktop/src/renderer/contexts/AuthContext.tsx
@@ -9,6 +9,7 @@ import {
   type ReactNode,
 } from 'react';
 import { useTranslation } from 'react-i18next';
+import { soleLoginMethod } from '@cindy/auth-client';
 
 import { useConfirmDialog } from '@/components/ui/confirm-dialog-provider';
 import { clearWorkersCache } from '@/features/cc-agent/hooks/useWorkers';
@@ -335,6 +336,26 @@ export function AuthProvider({
         setLoginState({ step: 'browser-redirect', label: action.label });
       }
       const result = await authServiceRef.current!.dispatchLoginAction(action);
+      // 没有真正选择时不停留 method-choice：唯一 SSO 改派 start-browser
+      //（确认窗立刻消失、露出等待态）；唯一邮箱验证码直接发码进输码页。
+      if (result.success && result.state.step === 'method-choice') {
+        const sole = soleLoginMethod(result.state.methods);
+        if (sole?.type === 'sso') {
+          return dispatchLoginAction({
+            type: 'start-browser',
+            kind: 'sso',
+            providerOrConnectionId: sole.connectionId,
+            label: sole.connectionName || sole.orgName,
+          });
+        }
+        if (sole?.type === 'email_code' && result.state.email) {
+          return dispatchLoginAction({
+            type: 'request-code',
+            kind: 'email',
+            identifier: result.state.email,
+          });
+        }
+      }
       setLoginState(result.state);
       return result;
     },

--- a/apps/mobile/src/__tests__/mobileAuthServerLogin.test.ts
+++ b/apps/mobile/src/__tests__/mobileAuthServerLogin.test.ts
@@ -204,6 +204,11 @@ describe('mobile auth-server login', () => {
     expect(authSource).toContain(
       "previousState?.step !== 'method-choice' ||",
     );
+    expect(authSource).toContain('soleLoginMethod(methods)');
+    expect(authSource).toContain('soleAutoStartSsoMethod(confirmation.methods)');
+    expect(authSource).toContain("kind: 'sso'");
+    expect(authSource).toContain('startBrowserAuthorization({');
+    expect(authSource).toContain("sole?.type === 'email_code'");
   });
 
   it('keeps account tokens inside membership selection and private tickets off screen', () => {

--- a/apps/mobile/src/auth/AuthContext.tsx
+++ b/apps/mobile/src/auth/AuthContext.tsx
@@ -19,6 +19,8 @@ import {
   parseAuthSessionRecord,
   reduceAuthFlow,
   serializeAccountDeletionReceiptRecord,
+  soleAutoStartSsoMethod,
+  soleLoginMethod,
   ssoOrgDiscoveryToMethods,
   serializeAuthSessionRecord,
   type AuthFlowState,
@@ -1026,6 +1028,15 @@ export function AuthProvider({ children }: { children: ReactNode }) {
             ) {
               throw authCodeError('INVALID_AUTH_ACTION');
             }
+            const sole = soleAutoStartSsoMethod(confirmation.methods);
+            if (sole) {
+              return startBrowserAuthorization({
+                previousState: confirmation,
+                kind: 'sso',
+                providerOrConnectionId: sole.connectionId,
+                label: sole.connectionName || sole.orgName,
+              });
+            }
             updateLoginState(
               reduceAuthFlow(confirmation, {
                 type: 'discovery-loaded',
@@ -1056,8 +1067,32 @@ export function AuthProvider({ children }: { children: ReactNode }) {
               did,
               BUILD_AUTH_REGION,
             ).discover(email);
+            const currentState = loginStateRef.current;
+            const sole = soleLoginMethod(methods);
+            if (sole?.type === 'sso' && currentState) {
+              return startBrowserAuthorization({
+                previousState: currentState,
+                kind: 'sso',
+                providerOrConnectionId: sole.connectionId,
+                label: sole.connectionName || sole.orgName,
+              });
+            }
+            if (sole?.type === 'email_code') {
+              await authClientFor(did, BUILD_AUTH_REGION).requestCode(
+                'email',
+                email,
+              );
+              updateLoginState(
+                reduceAuthFlow(currentState, {
+                  type: 'code-requested',
+                  kind: 'email',
+                  identifier: email,
+                }),
+              );
+              return true;
+            }
             updateLoginState(
-              reduceAuthFlow(loginStateRef.current, {
+              reduceAuthFlow(currentState, {
                 type: 'discovery-loaded',
                 email,
                 methods,
@@ -1065,8 +1100,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
             );
             return true;
           }
-          // 企业 SSO 入口（按组织 ID/slug/已验证域名）：结果映射进 method-choice，
-          // 复用连接选择 UI 与 start-sso 流程。
+          // 企业 SSO 入口（按组织 ID/slug/已验证域名）：唯一连接直接进浏览器；
+          // 多连接才映射进 method-choice，复用连接选择 UI 与 start-sso 流程。
           if (action.type === 'discover-sso-org') {
             const org = action.org.trim().toLowerCase();
             // 新的一次组织发现不得复用上一轮成功结果；只有本轮双区判定成功后
@@ -1118,6 +1153,15 @@ export function AuthProvider({ children }: { children: ReactNode }) {
                 }),
               );
             } else {
+              const sole = soleAutoStartSsoMethod(methods);
+              if (sole && currentState) {
+                return startBrowserAuthorization({
+                  previousState: currentState,
+                  kind: 'sso',
+                  providerOrConnectionId: sole.connectionId,
+                  label: sole.connectionName || sole.orgName,
+                });
+              }
               updateLoginState(
                 reduceAuthFlow(currentState, {
                   type: 'discovery-loaded',

--- a/docs/design-rules/DESIGN.md
+++ b/docs/design-rules/DESIGN.md
@@ -1415,7 +1415,7 @@ The execution rulebook for subsequent desktop / mobile UI updates. Sources: the 
 | 屏（step） | 职责 | 关键组件 |
 |---|---|---|
 | `identifier` | 输入手机号 / 邮箱（国区 phone / 国际区 email），含 social 圆钮行（Apple / Google / SSO，**无游客圆钮**）+ SSO 入口 + 协议同意行；**面板内常驻「跳过登录」入口**（2026-07-27 起，**仅桌面**；手机端 2026-07-28 剥离） | `LoginInput` / `LoginSkinPhoneInput` + `LoginPrimaryButton` + `LoginSocialRow` + `LoginConsentRow` + `LoginSkipEntry` / `LoginSkipLoginLink` |
-| `method-choice` | 命中企业域名时选企业 SSO / 个人邮箱验证码 | `LoginMethodRow`×2（top 158 / 278）+ `LoginTitleBlock`（`chooseMethod`） |
+| `method-choice` | 存在真正选择时：企业 SSO / 个人邮箱验证码，或多条 SSO 连接。探测结果只剩唯一 SSO 或唯一邮箱验证码时不展示本屏——前者投影 `browser-redirect`，后者直接发码进入 `verification-code`（跨区确认窗随 step 离开一并关掉） | `LoginMethodRow`×2（top 158 / 278）+ `LoginTitleBlock`（`chooseMethod`） |
 | `verification-code` | 输入 6 位验证码，42s 重发倒计时 | `LoginInput`(center) / `CodeInput` + `LoginTextLink` / `LoginResendCountdown` + `LoginPrimaryButton` |
 | `sso-verification` | SSO 登录后验证企业联系方式，两子态（`codeRequested` false = 只发码 / true = 输码 + 常驻重发，**无倒计时**） | `LoginPrimaryButton`(sendCode) → `LoginInput`(center) + `LoginPrimaryButton`(completeSignIn / signIn) + `LoginTextLink` / `LoginResendCountdown`(deadline=null) |
 | `sso-org`（`identifier` 局部子视图，非共享 step） | 输入企业 ID / 组织 slug / 已验证域名跳转 SSO（`ssoOrgMode`） | `LoginInput` + `LoginPrimaryButton` + `LoginTextLinkSlot`（ssoOrgHint） |

--- a/docs/design-rules/design-decision-log.md
+++ b/docs/design-rules/design-decision-log.md
@@ -12,6 +12,18 @@
 
 ## 2026-08
 
+- **08-16** **登录：唯一 SSO 不再经过 method-choice（拍板人 = 用户）**——
+  用户已经从登录首页选了企业 SSO（组织标识探测），或邮箱 / 组织探测结果只剩
+  一条 SSO、没有个人邮箱验证码替补时，再出「选择登录方式」是假选择（截图上只剩
+  「以企业身份登录」一行）。`soleAutoStartSsoMethod` 命中后直接进入
+  `browser-redirect`。仍经过 method-choice 的：企业 SSO + 个人邮箱；多条 SSO
+  连接。跨区企业仍先 `realm-confirmation`，确认后再套同一条唯一 SSO 规则。
+  跨区「连接企业所在区域」点继续后，确认窗必须立刻消失并进入等待登录；桌面
+  renderer 在 method-choice 唯一 SSO 时改派 `start-browser`，复用既有
+  `browser-redirect` 乐观投影，不得在 main 里套住浏览器授权把确认框卡住。
+  个人邮箱探测若只剩验证码一种方式，同样不经过「以个人身份登录」假选择，直接发码。
+  （→ `DESIGN.md §16.4` method-choice 行；`packages/auth-client` `soleAutoStartSsoMethod`）
+
 - **08-03** **排版立法:字重梯改四档、桌面字号白名单建档(拍板人 = 用户,issue #1505)**——
   本条**推翻**原 `DESIGN.md §3` 的「字重只允许 400/500、never bold」表述(§3 Principles /
   §7 Don'ts / §9 Iteration Guide 三处同步改写)。背景:2026-08-03 全仓走查发现桌面端在无守卫

--- a/packages/auth-client/fixtures/__tests__/loginScenarios.test.ts
+++ b/packages/auth-client/fixtures/__tests__/loginScenarios.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it } from "vitest";
 
 import { CindyAuthClient, AuthApiError } from "../../src/client.js";
-import { reduceAuthFlow, type ProviderConfig } from "../../src/types.js";
+import {
+  reduceAuthFlow,
+  soleAutoStartSsoMethod,
+  soleLoginMethod,
+  ssoOrgDiscoveryToMethods,
+  type ProviderConfig,
+} from "../../src/types.js";
 import {
   CINDY_LOGIN_FIXTURE_SENTINEL,
   LOGIN_SCENARIO_ERROR_ENDPOINTS,
@@ -64,20 +70,35 @@ describe("附录 A sso:* 场景(method-choice 行)", () => {
     expect(ssoRows[0]).toMatchObject({ ssoRequired: false });
     const state = reduceAuthFlow(null, { type: "discovery-loaded", email: "user@example.com", methods });
     expect(state.step).toBe("method-choice");
+    expect(soleAutoStartSsoMethod(methods)).toBeNull();
   });
   it("sso:multi → 多 connection 行", async () => {
     const methods = await clientFor("sso:multi").discover("user@example.com");
     expect(methods.filter((m) => m.type === "sso")).toHaveLength(2);
+    expect(soleAutoStartSsoMethod(methods)).toBeNull();
   });
   it("sso:required → 该企业要求通过 SSO 登录(ssoRequired=true,无 email_code)", async () => {
     const methods = await clientFor("sso:required").discover("user@example.com");
     expect(methods).toHaveLength(1);
     expect(methods[0]).toMatchObject({ type: "sso", ssoRequired: true });
+    expect(soleAutoStartSsoMethod(methods)).toMatchObject({ type: "sso", ssoRequired: true });
   });
   it("sso discovery(企业 ID 入口)→ connection 列表", async () => {
     const discovery = await clientFor("sso:multi").discoverSsoOrg("example");
     expect(discovery.connections).toHaveLength(2);
     expect(discovery.orgName).toBe("Example Org");
+    expect(soleAutoStartSsoMethod(ssoOrgDiscoveryToMethods(discovery))).toBeNull();
+  });
+  it("sso discovery 单连接 → 无真正选择，控制器应跳过 method-choice", async () => {
+    const discovery = await clientFor("sso:single").discoverSsoOrg("example");
+    const methods = ssoOrgDiscoveryToMethods(discovery);
+    expect(methods).toHaveLength(1);
+    expect(soleAutoStartSsoMethod(methods)).toMatchObject({ type: "sso" });
+  });
+  it("纯邮箱 discovery → 唯一 email_code，应跳过 method-choice 直接发码", async () => {
+    const methods = await clientFor("providers:both").discover("personal@example.com");
+    expect(soleLoginMethod(methods)).toEqual({ type: "email_code" });
+    expect(soleAutoStartSsoMethod(methods)).toBeNull();
   });
 });
 

--- a/packages/auth-client/src/__tests__/client.test.ts
+++ b/packages/auth-client/src/__tests__/client.test.ts
@@ -8,6 +8,8 @@ import {
   parseAuthSessionRecord,
   reduceAuthFlow,
   serializeAccountDeletionReceiptRecord,
+  soleAutoStartSsoMethod,
+  soleLoginMethod,
   ssoOrgDiscoveryToMethods,
   serializeAuthSessionRecord,
   type AuthFetch,
@@ -300,6 +302,12 @@ describe("CindyAuthClient", () => {
         ssoRequired: false,
       },
     ]);
+    expect(
+      soleAutoStartSsoMethod(ssoOrgDiscoveryToMethods(discovery)),
+    ).toMatchObject({
+      type: "sso",
+      connectionId: "conn-1",
+    });
   });
 
   it("maps an empty SSO connection list to the precise ORG_SSO_NOT_FOUND error", async () => {
@@ -357,6 +365,73 @@ describe("CindyAuthClient", () => {
     expect(url.pathname).toBe("/api/auth/sso/conn%2Fa/authorize");
     expect(url.searchParams.get("client_state")).toBe("state-1");
     expect(url.searchParams.get("device_id")).toBe("device-1");
+  });
+});
+
+describe("soleLoginMethod", () => {
+  it("returns the only method when discovery has no real choice", () => {
+    expect(soleLoginMethod([{ type: "email_code" }])).toEqual({
+      type: "email_code",
+    });
+  });
+
+  it("returns null when enterprise and personal methods both exist", () => {
+    expect(
+      soleLoginMethod([
+        { type: "email_code" },
+        {
+          type: "sso",
+          connectionId: "conn-1",
+          protocol: "oidc",
+          orgName: "心动网络",
+          connectionName: "心动",
+          ssoRequired: false,
+        },
+      ]),
+    ).toBeNull();
+  });
+});
+
+describe("soleAutoStartSsoMethod", () => {
+  const ssoA = {
+    type: "sso" as const,
+    connectionId: "conn-1",
+    protocol: "oidc" as const,
+    orgName: "心动网络",
+    connectionName: "心动",
+    ssoRequired: false,
+  };
+  const ssoB = {
+    ...ssoA,
+    connectionId: "conn-2",
+    connectionName: "Okta",
+  };
+
+  it("auto-starts a lone SSO connection from the org entry", () => {
+    expect(soleAutoStartSsoMethod([ssoA])).toEqual(ssoA);
+  });
+
+  it("auto-starts when enterprise email discovery only offers SSO", () => {
+    expect(soleAutoStartSsoMethod([{ ...ssoA, ssoRequired: true }])).toEqual({
+      ...ssoA,
+      ssoRequired: true,
+    });
+  });
+
+  it("keeps method-choice when the user can still pick personal email", () => {
+    expect(soleAutoStartSsoMethod([{ type: "email_code" }, ssoA])).toBeNull();
+  });
+
+  it("keeps method-choice when multiple SSO connections remain", () => {
+    expect(soleAutoStartSsoMethod([ssoA, ssoB])).toBeNull();
+  });
+
+  it("does not treat personal-only email as an SSO auto-start", () => {
+    expect(soleAutoStartSsoMethod([{ type: "email_code" }])).toBeNull();
+  });
+
+  it("does not auto-start an empty method list", () => {
+    expect(soleAutoStartSsoMethod([])).toBeNull();
   });
 });
 

--- a/packages/auth-client/src/index.ts
+++ b/packages/auth-client/src/index.ts
@@ -39,6 +39,8 @@ export {
   socialProviderSchema,
   ssoOrgConnectionSchema,
   ssoOrgDiscoverySchema,
+  soleAutoStartSsoMethod,
+  soleLoginMethod,
   ssoOrgDiscoveryToMethods,
   tokenPairSchema,
 } from "./types.js";
@@ -60,6 +62,7 @@ export type {
   LoginOutcome,
   ProviderConfig,
   SocialProvider,
+  SsoLoginMethod,
   SsoOrgConnection,
   SsoOrgDiscovery,
   SsoVerificationChannel,

--- a/packages/auth-client/src/types.ts
+++ b/packages/auth-client/src/types.ts
@@ -65,8 +65,10 @@ export const loginMethodSchema = z.discriminatedUnion("type", [
 export type LoginMethod = z.infer<typeof loginMethodSchema>;
 
 /**
- * 把企业 SSO discovery 结果映射成 LoginMethod 列表，复用 method-choice 步骤
- * 渲染连接选择（ssoRequired=false：入口本身即用户主动选 SSO，无需再提示强制）。
+ * 把企业 SSO discovery 结果映射成 LoginMethod 列表。
+ * 多连接时复用 method-choice 让用户选 IdP；唯一连接由
+ * `soleAutoStartSsoMethod` 判定后，UI 直接投影 browser-redirect
+ * （ssoRequired=false：入口本身即用户主动选 SSO，无需再提示强制）。
  */
 export function ssoOrgDiscoveryToMethods(
   discovery: SsoOrgDiscovery,
@@ -79,6 +81,28 @@ export function ssoOrgDiscoveryToMethods(
     connectionName: connection.connectionName,
     ssoRequired: false,
   }));
+}
+
+export type SsoLoginMethod = Extract<LoginMethod, { type: "sso" }>;
+
+/**
+ * method-choice 只在真正有选择时出现。探测结果只剩一种方式时，
+ * 调用方应直接发起它，不要再出「选择登录方式」。
+ *
+ * 覆盖：唯一 SSO；唯一邮箱验证码。不覆盖：SSO + 个人邮箱；多条 SSO。
+ */
+export function soleLoginMethod(
+  methods: readonly LoginMethod[],
+): LoginMethod | null {
+  return methods.length === 1 ? (methods[0] ?? null) : null;
+}
+
+/** 唯一 SSO、没有个人邮箱替补时，应直接打开该 SSO。 */
+export function soleAutoStartSsoMethod(
+  methods: readonly LoginMethod[],
+): SsoLoginMethod | null {
+  const sole = soleLoginMethod(methods);
+  return sole?.type === "sso" ? sole : null;
 }
 
 export const tokenPairSchema = z.object({


### PR DESCRIPTION
## 这次改了什么

### 摘要

登录探测如果只剩一种方式，不再弹出「选择登录方式」假选择。

- 企业 SSO 入口或邮箱探测只剩一条 SSO：直接打开浏览器，并立刻进入等待登录（跨区确认点「继续登录」后确认窗会关掉）。
- 个人邮箱探测只剩验证码：直接发码进入输码页。
- 企业 SSO + 个人邮箱、或多条 SSO 连接，选择框仍会出。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：
  - `soleLoginMethod` / `soleAutoStartSsoMethod` 共享判定
  - 桌面 renderer 在唯一方式时改派 `start-browser` / `request-code`，避免 main 套住浏览器授权把确认框卡住
  - 手机端 discover / 确认后同样自动继续
  - DESIGN.md §16.4 与决策台账同步
- 明确不包含：账号选择（`account-selection`，服务端返回多个 membership）
- 用户可见变化：唯一登录方式不再经过「选择登录方式」
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：`docs/design-rules/DESIGN.md` §16.4 登录链路逐屏：`method-choice` 只在存在真正选择时出现；唯一 SSO 投影 `browser-redirect`，唯一邮箱验证码进入 `verification-code`。跨区确认窗随 step 离开关掉。双模式几何 / token 未改。

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：auth-client / mobile 通过；desktop 全量因基线
`ghostInstallReceipt.test.ts` 2 条失败（在 origin/main 同样复现，与本 PR 无关）

pnpm --filter desktop typecheck
pnpm --filter mobile typecheck
pnpm --filter @cindy/auth-client run build
结果：通过

定向：
pnpm --filter @cindy/auth-client test
pnpm --filter desktop exec vitest run src/renderer/__tests__/authContextRace.test.ts src/main/__tests__/authLoginFlowReset.test.ts src/renderer/components/login/__tests__/LoginPage.harness.test.tsx
pnpm --filter mobile exec vitest run src/__tests__/mobileAuthServerLogin.test.ts
结果：通过
```

### 手工验证

Desktop global 开发版（worktree `cindy-skip-single-sso-method-choice`）：

- 企业 SSO 输入组织后，跨区确认点「继续登录」进入等待浏览器登录，确认窗消失
- `dash@xd.com` 个人邮箱不再经过「以个人身份登录」单选项，直接发码

### 未执行的验证

- 手机端实机未跑（逻辑已对齐，无原生 / fingerprint 改动）
- Dark 模式登录路径未再单独目检（无新色值 / 几何，沿用既有 themed 组件）

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围：登录 method-choice 自动继续；不改协议、凭证或 schema
- 回滚 / 降级方式：revert 本 PR

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
