### PR TITLE
fix(desktop): 登录后白屏不再被附件清扫堵住

### DIFF
--- a/apps/desktop/src/main/__tests__/modelPricingPrewarmOrdering.test.ts
+++ b/apps/desktop/src/main/__tests__/modelPricingPrewarmOrdering.test.ts
@@ -48,4 +48,15 @@ describe('model pricing prewarm ordering', () => {
     expect(nextIpc).toBeGreaterThan(earlyUsageIpc);
     expect(source.slice(earlyUsageIpc, nextIpc)).not.toContain('prewarmModelPricing');
   });
+
+  it('does not block owner ensureReady on staged attachment bookkeeping', () => {
+    const onReady = source.slice(
+      source.indexOf('onReady: async (userId) => {'),
+      source.indexOf('onReadyError:'),
+    );
+    expect(onReady).toContain('void sweepStagedChatAttachmentsOnStartup({');
+    expect(onReady).toContain('loadProtectedPaths: listPersistedChatAttachmentPaths');
+    expect(onReady).not.toMatch(/await listPersistedChatAttachmentPaths\(\)/);
+    expect(onReady).not.toMatch(/await sweepStagedChatAttachmentsOnStartup\(/);
+  });
 });

--- a/apps/desktop/src/main/__tests__/modelPricingPrewarmOrdering.test.ts
+++ b/apps/desktop/src/main/__tests__/modelPricingPrewarmOrdering.test.ts
@@ -54,9 +54,14 @@ describe('model pricing prewarm ordering', () => {
       source.indexOf('onReady: async (userId) => {'),
       source.indexOf('onReadyError:'),
     );
+    expect(onReady).toContain('STARTUP_STAGED_ATTACHMENT_SWEEP_DELAY_MS');
+    expect(onReady).toContain('setTimeout(() => {');
     expect(onReady).toContain('void sweepStagedChatAttachmentsOnStartup({');
     expect(onReady).toContain('loadProtectedPaths: listPersistedChatAttachmentPaths');
     expect(onReady).not.toMatch(/await listPersistedChatAttachmentPaths\(\)/);
     expect(onReady).not.toMatch(/await sweepStagedChatAttachmentsOnStartup\(/);
+    expect(onReady.indexOf('setTimeout(() => {')).toBeLessThan(
+      onReady.indexOf('void sweepStagedChatAttachmentsOnStartup({'),
+    );
   });
 });

--- a/apps/desktop/src/main/bootstrap-electron.ts
+++ b/apps/desktop/src/main/bootstrap-electron.ts
@@ -6884,25 +6884,33 @@ app.on('ready', async () => {
       // Phase 1.1: file worker 接管 DB 连接后,释放 main 端的 _db + optimize 定时器。
       // 如果 worker takeover 失败并进入 inproc fallback,main _db 必须继续保留,
       // 否则 fallback 会拿到已关闭的连接。
-      try {
-        const protectedPaths = await listPersistedChatAttachmentPaths();
-        const result = await sweepStagedChatAttachmentsOnStartup({
-          ownerId: userId,
-          protectedPaths,
-          createdBeforeMs: PROCESS_STARTED_AT_MS,
-        });
-        if (result.removed > 0 || result.protected > 0) {
-          dbClientLog.info('[ChatAttachment] startup staged attachment sweep completed', {
-            ...result,
+      //
+      // Staged-attachment bookkeeping is not first-paint readiness. The persisted-path
+      // lookup is a LIKE + json_tree scan over every retained message body; on a
+      // multi-GB owner DB that blocked LocalDbGate for ~24s after splash had already
+      // unmounted, leaving a white window. Sweep is fire-and-forget and only queries
+      // the DB when the owner cache already has stale files.
+      void sweepStagedChatAttachmentsOnStartup({
+        ownerId: userId,
+        createdBeforeMs: PROCESS_STARTED_AT_MS,
+        loadProtectedPaths: listPersistedChatAttachmentPaths,
+        canContinue: () =>
+          getActiveAppSession().dataOwnerId === userId && !isAppSessionBoundaryPending(),
+      })
+        .then((result) => {
+          if (result.removed > 0 || result.protected > 0) {
+            dbClientLog.info('[ChatAttachment] startup staged attachment sweep completed', {
+              ...result,
+              ownerId: userId,
+            });
+          }
+        })
+        .catch((err) => {
+          dbClientLog.warn('[ChatAttachment] startup staged attachment sweep failed (non-fatal)', {
             ownerId: userId,
+            error: err instanceof Error ? err.message : String(err),
           });
-        }
-      } catch (err) {
-        dbClientLog.warn('[ChatAttachment] startup staged attachment sweep failed (non-fatal)', {
-          ownerId: userId,
-          error: err instanceof Error ? err.message : String(err),
         });
-      }
       logStartupPhase('chat-attachment-sweep');
       if (dbClientTakeover.shouldReleaseMainDb && process.env.XDT_DB_INPROC !== 'true') {
         // 只把连接交给 worker，不能释放 shared-passive schema reader lease：worker

--- a/apps/desktop/src/main/bootstrap-electron.ts
+++ b/apps/desktop/src/main/bootstrap-electron.ts
@@ -6888,29 +6888,39 @@ app.on('ready', async () => {
       // Staged-attachment bookkeeping is not first-paint readiness. The persisted-path
       // lookup is a LIKE + json_tree scan over every retained message body; on a
       // multi-GB owner DB that blocked LocalDbGate for ~24s after splash had already
-      // unmounted, leaving a white window. Sweep is fire-and-forget and only queries
-      // the DB when the owner cache already has stale files.
-      void sweepStagedChatAttachmentsOnStartup({
-        ownerId: userId,
-        createdBeforeMs: PROCESS_STARTED_AT_MS,
-        loadProtectedPaths: listPersistedChatAttachmentPaths,
-        canContinue: () =>
-          getActiveAppSession().dataOwnerId === userId && !isAppSessionBoundaryPending(),
-      })
-        .then((result) => {
-          if (result.removed > 0 || result.protected > 0) {
-            dbClientLog.info('[ChatAttachment] startup staged attachment sweep completed', {
-              ...result,
-              ownerId: userId,
-            });
-          }
+      // unmounted, leaving a white window. Sweep is fire-and-forget, only queries the
+      // DB when the owner cache already has stale files, and is delayed so the shared
+      // db worker can serve session-list / first-paint RPCs first. A stale-cache user
+      // would otherwise just move the 24s stall from the white screen onto the first
+      // task-list query (the db worker's better-sqlite3 .all() is synchronous).
+      const STARTUP_STAGED_ATTACHMENT_SWEEP_DELAY_MS = 5_000;
+      const stagedAttachmentSweepTimer = setTimeout(() => {
+        void sweepStagedChatAttachmentsOnStartup({
+          ownerId: userId,
+          createdBeforeMs: PROCESS_STARTED_AT_MS,
+          loadProtectedPaths: listPersistedChatAttachmentPaths,
+          canContinue: () =>
+            getActiveAppSession().dataOwnerId === userId && !isAppSessionBoundaryPending(),
         })
-        .catch((err) => {
-          dbClientLog.warn('[ChatAttachment] startup staged attachment sweep failed (non-fatal)', {
-            ownerId: userId,
-            error: err instanceof Error ? err.message : String(err),
+          .then((result) => {
+            if (result.removed > 0 || result.protected > 0) {
+              dbClientLog.info('[ChatAttachment] startup staged attachment sweep completed', {
+                ...result,
+                ownerId: userId,
+              });
+            }
+          })
+          .catch((err) => {
+            dbClientLog.warn(
+              '[ChatAttachment] startup staged attachment sweep failed (non-fatal)',
+              {
+                ownerId: userId,
+                error: err instanceof Error ? err.message : String(err),
+              },
+            );
           });
-        });
+      }, STARTUP_STAGED_ATTACHMENT_SWEEP_DELAY_MS);
+      stagedAttachmentSweepTimer.unref?.();
       logStartupPhase('chat-attachment-sweep');
       if (dbClientTakeover.shouldReleaseMainDb && process.env.XDT_DB_INPROC !== 'true') {
         // 只把连接交给 worker，不能释放 shared-passive schema reader lease：worker

--- a/apps/desktop/src/main/file-browser/__tests__/remoteFileCacheStaging.test.ts
+++ b/apps/desktop/src/main/file-browser/__tests__/remoteFileCacheStaging.test.ts
@@ -114,6 +114,83 @@ describe('chat attachment staging cache', () => {
     await expect(fs.stat(otherOwnerPath)).resolves.toBeDefined();
   });
 
+  it('does not load persisted paths when the owner cache has no stale files', async () => {
+    const loadProtectedPaths = vi.fn(async () => {
+      throw new Error('must not query message bodies when there is nothing to sweep');
+    });
+
+    await expect(
+      sweepStagedChatAttachmentsOnStartup({
+        ownerId: 'owner-empty',
+        createdBeforeMs: Date.now() - 1_000,
+        loadProtectedPaths,
+      }),
+    ).resolves.toMatchObject({ inspected: 0, removed: 0, protected: 0 });
+    expect(loadProtectedPaths).not.toHaveBeenCalled();
+
+    const ownerRoot = getChatAttachmentOwnerCacheRoot('owner-fresh');
+    await fs.mkdir(ownerRoot, { recursive: true });
+    const freshPath = path.join(ownerRoot, 'fresh.bin');
+    await fs.writeFile(freshPath, 'fresh');
+
+    await expect(
+      sweepStagedChatAttachmentsOnStartup({
+        ownerId: 'owner-fresh',
+        createdBeforeMs: Date.now() - 1_000,
+        loadProtectedPaths,
+      }),
+    ).resolves.toMatchObject({ inspected: 1, removed: 0, protected: 0 });
+    expect(loadProtectedPaths).not.toHaveBeenCalled();
+    await expect(fs.stat(freshPath)).resolves.toBeDefined();
+  });
+
+  it('loads persisted paths only after it finds stale cache files', async () => {
+    const ownerId = 'owner-stale';
+    const ownerRoot = getChatAttachmentOwnerCacheRoot(ownerId);
+    await fs.mkdir(ownerRoot, { recursive: true });
+    const orphanPath = path.join(ownerRoot, 'orphan.bin');
+    const protectedPath = path.join(ownerRoot, 'protected.bin');
+    await Promise.all([fs.writeFile(orphanPath, 'orphan'), fs.writeFile(protectedPath, 'kept')]);
+    const oldTime = new Date(Date.now() - 60_000);
+    await Promise.all([
+      fs.utimes(orphanPath, oldTime, oldTime),
+      fs.utimes(protectedPath, oldTime, oldTime),
+    ]);
+    const loadProtectedPaths = vi.fn(async () => [protectedPath]);
+
+    await expect(
+      sweepStagedChatAttachmentsOnStartup({
+        ownerId,
+        createdBeforeMs: Date.now() - 1_000,
+        loadProtectedPaths,
+      }),
+    ).resolves.toMatchObject({ inspected: 2, removed: 1, protected: 1 });
+    expect(loadProtectedPaths).toHaveBeenCalledOnce();
+    await expect(fs.stat(orphanPath)).rejects.toMatchObject({ code: 'ENOENT' });
+    await expect(fs.stat(protectedPath)).resolves.toBeDefined();
+  });
+
+  it('stops before deleting when the owner is no longer current', async () => {
+    const ownerId = 'owner-switch';
+    const ownerRoot = getChatAttachmentOwnerCacheRoot(ownerId);
+    await fs.mkdir(ownerRoot, { recursive: true });
+    const orphanPath = path.join(ownerRoot, 'orphan.bin');
+    await fs.writeFile(orphanPath, 'orphan');
+    await fs.utimes(orphanPath, new Date(Date.now() - 60_000), new Date(Date.now() - 60_000));
+    const loadProtectedPaths = vi.fn(async () => []);
+
+    await expect(
+      sweepStagedChatAttachmentsOnStartup({
+        ownerId,
+        createdBeforeMs: Date.now() - 1_000,
+        loadProtectedPaths,
+        canContinue: () => false,
+      }),
+    ).resolves.toMatchObject({ inspected: 1, removed: 0, protected: 0 });
+    expect(loadProtectedPaths).not.toHaveBeenCalled();
+    await expect(fs.stat(orphanPath)).resolves.toBeDefined();
+  });
+
   it('renderer cleanup removes only current-owner files not retained by messages', async () => {
     const ownerId = 'owner-a';
     const ownerRoot = getChatAttachmentOwnerCacheRoot(ownerId);

--- a/apps/desktop/src/main/file-browser/remote-file-cache.ts
+++ b/apps/desktop/src/main/file-browser/remote-file-cache.ts
@@ -134,20 +134,27 @@ export interface StartupStagedChatAttachmentSweepResult {
  * created by an earlier process and not referenced by persisted messages is
  * unreachable after restart. Files created by this process are left alone to
  * avoid racing a draft that is still being assembled.
+ *
+ * Filesystem is the source of work: persisted-path lookup only runs when the
+ * owner cache already has stale `.bin` / `.bin.part` files. A LIKE + json_tree
+ * scan over a multi-GB message table otherwise blocks startup for tens of
+ * seconds even when the cache directory does not exist.
  */
 export async function sweepStagedChatAttachmentsOnStartup(params: {
   ownerId: string;
-  protectedPaths: readonly string[];
   createdBeforeMs: number;
+  protectedPaths?: readonly string[];
+  loadProtectedPaths?: () => Promise<readonly string[]>;
+  canContinue?: () => boolean;
 }): Promise<StartupStagedChatAttachmentSweepResult> {
   const result: StartupStagedChatAttachmentSweepResult = {
     inspected: 0,
     removed: 0,
     protected: 0,
   };
-  const protectedPaths = new Set(params.protectedPaths.map(normalizePathForComparison));
   const ownerDir = chatAttachmentOwnerCacheDir(params.ownerId);
   const entries = await fs.readdir(ownerDir, { withFileTypes: true }).catch(() => []);
+  const stalePaths: string[] = [];
   for (const entry of entries) {
     if (!entry.isFile() && !entry.isSymbolicLink()) continue;
     if (!entry.name.endsWith('.bin') && !entry.name.endsWith('.bin.part')) continue;
@@ -157,10 +164,33 @@ export async function sweepStagedChatAttachmentsOnStartup(params: {
     try {
       const stat = await fs.lstat(filePath);
       if (stat.mtimeMs >= params.createdBeforeMs) continue;
-      if (protectedPaths.has(normalizePathForComparison(filePath))) {
-        result.protected += 1;
-        continue;
+      stalePaths.push(filePath);
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException | null)?.code;
+      if (code !== 'ENOENT') {
+        log.warn('startup staged chat attachment sweep failed for file', {
+          filePath,
+          error: String(err),
+        });
       }
+    }
+  }
+  if (stalePaths.length === 0) return result;
+  if (params.canContinue && !params.canContinue()) return result;
+
+  const protectedList =
+    params.protectedPaths ??
+    (params.loadProtectedPaths ? await params.loadProtectedPaths() : []);
+  if (params.canContinue && !params.canContinue()) return result;
+  const protectedPaths = new Set(protectedList.map(normalizePathForComparison));
+
+  for (const filePath of stalePaths) {
+    if (protectedPaths.has(normalizePathForComparison(filePath))) {
+      result.protected += 1;
+      continue;
+    }
+    try {
+      if (params.canContinue && !params.canContinue()) return result;
       await fs.unlink(filePath);
       result.removed += 1;
     } catch (err) {

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -9,6 +9,7 @@ import { ThemeProvider } from '@/hooks/useTheme';
 import { FontSettingsProvider } from '@/hooks/useFontSettings';
 import { LocaleProvider } from '@/hooks/useLocale';
 import { AuthProvider, useAuth } from '@/contexts/AuthContext';
+import { AppShellCoverProvider, useAppShellCover } from '@/contexts/AppShellCoverContext';
 import { LoginHandoffProvider } from '@/contexts/LoginHandoffContext';
 import { EnvCheckProvider, EnvCheckGuard } from '@/contexts/EnvCheckContext';
 import { WorktreeProvider } from '@/contexts/WorktreeContext';
@@ -71,10 +72,12 @@ import { router } from './router';
  */
 function LoginHandoffHost({ children }: { children: React.ReactNode }) {
   const { isInitializing, isAuthenticated, canEnterApp } = useAuth();
+  const { coverHeld } = useAppShellCover();
   return (
     <LoginHandoffProvider
       authResolved={!isInitializing}
       authenticated={isAuthenticated || canEnterApp}
+      coverHeld={coverHeld}
     >
       {/* 认证恢复后已登录(直进受保护路由、LoginPage 不挂载)时结束首启亮色门,
           避免 renderer localStorage 被清空但主进程仍持有会话时整个已登录会话
@@ -330,8 +333,9 @@ export function App() {
           <ConfirmDialogProvider>
             <EnvCheckProvider>
               <AuthProvider>
-                <WorktreeProvider>
-                  <PrRefsProvider>
+                <AppShellCoverProvider>
+                  <WorktreeProvider>
+                    <PrRefsProvider>
                     <Tooltip.Provider>
                       {/* LoginHandoffProvider 包 SplashScreen + RouterProvider(Step 3b
                           WHAT2 宿主契约):Splash→登录/主界面衔接动画状态机。
@@ -366,8 +370,9 @@ export function App() {
                         <LegacyMigrationDialog />
                       )}
                     </Tooltip.Provider>
-                  </PrRefsProvider>
-                </WorktreeProvider>
+                    </PrRefsProvider>
+                  </WorktreeProvider>
+                </AppShellCoverProvider>
               </AuthProvider>
             </EnvCheckProvider>
           </ConfirmDialogProvider>

--- a/apps/desktop/src/renderer/components/auth/LocalDbGate.tsx
+++ b/apps/desktop/src/renderer/components/auth/LocalDbGate.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { Outlet, useNavigate } from 'react-router-dom';
 
+import { useAppShellCover } from '@/contexts/AppShellCoverContext';
 import { useAuth } from '@/contexts/AuthContext';
 import { LocalDbFatalScreen } from '@/components/error/LocalDbFatalScreen';
 import { createLogger } from '@/lib/logger';
@@ -36,6 +37,7 @@ const DECISION_RETRY_DELAY_MS = 1_000;
 
 export function LocalDbGate() {
   const { dataOwnerId, mode, logout, exitLocalMode } = useAuth();
+  const { reportLocalDbGate } = useAppShellCover();
   const navigate = useNavigate();
   const [decision, setDecision] = useState<GateDecision>({ phase: 'checking' });
   const [retryNonce, setRetryNonce] = useState(0);
@@ -115,8 +117,22 @@ export function LocalDbGate() {
     // retryNonce 驱动失败后的有限重试重跑。
   }, [dataOwnerId, retryNonce]);
 
+  useEffect(() => {
+    if (!dataOwnerId || decision.phase === 'checking') {
+      reportLocalDbGate('pending');
+    } else if (decision.phase === 'fatal') {
+      reportLocalDbGate('fatal');
+    } else {
+      reportLocalDbGate('ready');
+    }
+    return () => {
+      reportLocalDbGate('pending');
+    };
+  }, [dataOwnerId, decision, reportLocalDbGate]);
+
   if (!dataOwnerId || decision.phase === 'checking') {
-    // 短暂检查窗口（通常 < 100ms）；返回 null 即可，App 已有 splash 兜底视觉
+    // 主界面还不能画。视觉盖由 AppShellCover + Splash / 品牌层承接
+    // (DESIGN.md §10),这里返回 null 避免先露出空壳再盖上。
     return null;
   }
 

--- a/apps/desktop/src/renderer/components/splash/SplashScreen.tsx
+++ b/apps/desktop/src/renderer/components/splash/SplashScreen.tsx
@@ -11,6 +11,7 @@ import {
 import { useAppShellCover } from '@/contexts/AppShellCoverContext';
 import { useEnvCheck } from '@/contexts/EnvCheckContext';
 import { useLoginHandoff } from '@/contexts/LoginHandoffContext';
+import { useReducedMotion } from '@/hooks/useReducedMotion';
 import { WindowControls } from '@/components/title-bar/WindowControls';
 import { desktopScale } from '@/components/login/loginScale';
 import { useViewportSize } from '@/components/login/LoginStage';
@@ -93,6 +94,7 @@ export function SplashScreen() {
   const splash = useSplash();
   const { step, totalSteps } = useEnvCheck();
   const { coverHeld } = useAppShellCover();
+  const reducedMotion = useReducedMotion();
   const handoff = useLoginHandoff();
   const [shellCoverFading, setShellCoverFading] = useState(false);
   const prevCoverHeldRef = useRef(coverHeld);
@@ -140,6 +142,12 @@ export function SplashScreen() {
 
   useEffect(() => {
     if (prevCoverHeldRef.current && !coverHeld && (realPhase === 'splash_done' || realPhase === 'splash_skipped')) {
+      // reduced-motion 把 --splash-fade-duration 置 0ms。再留 500ms 透明全屏层
+      // 会吞掉主界面刚露出时的点击(层未 pointer-events:none)。
+      if (reducedMotion) {
+        prevCoverHeldRef.current = coverHeld;
+        return;
+      }
       setShellCoverFading(true);
       const timer = window.setTimeout(() => setShellCoverFading(false), 500);
       prevCoverHeldRef.current = coverHeld;
@@ -147,7 +155,7 @@ export function SplashScreen() {
     }
     if (holdAfterDone) setShellCoverFading(false);
     prevCoverHeldRef.current = coverHeld;
-  }, [coverHeld, holdAfterDone, realPhase]);
+  }, [coverHeld, holdAfterDone, realPhase, reducedMotion]);
 
   const shellCoverVisible = holdAfterDone || shellCoverFading;
 
@@ -221,7 +229,7 @@ export function SplashScreen() {
       className={cn(
         'fixed inset-0 z-[9999] overflow-hidden',
         (realPhase === 'fading_out' || shellCoverFading) && !fixture
-          ? 'opacity-0'
+          ? 'pointer-events-none opacity-0'
           : 'opacity-100',
       )}
       style={

--- a/apps/desktop/src/renderer/components/splash/SplashScreen.tsx
+++ b/apps/desktop/src/renderer/components/splash/SplashScreen.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { cn } from '@/lib/utils';
@@ -8,6 +8,7 @@ import {
   useSplash,
   type SplashPhase,
 } from '@/hooks/useSplash';
+import { useAppShellCover } from '@/contexts/AppShellCoverContext';
 import { useEnvCheck } from '@/contexts/EnvCheckContext';
 import { useLoginHandoff } from '@/contexts/LoginHandoffContext';
 import { WindowControls } from '@/components/title-bar/WindowControls';
@@ -91,14 +92,23 @@ export function SplashScreen() {
   const { t } = useTranslation();
   const splash = useSplash();
   const { step, totalSteps } = useEnvCheck();
+  const { coverHeld } = useAppShellCover();
   const handoff = useLoginHandoff();
+  const [shellCoverFading, setShellCoverFading] = useState(false);
+  const prevCoverHeldRef = useRef(coverHeld);
   const { width, height } = useViewportSize();
   const { scale } = desktopScale(width, height);
 
   // dev fixture 只改显示 phase(附录 A splash 行;PROD 恒 null)。
   const fixture = readSplashPhaseFixture();
-  const displayPhase: SplashPhase = fixture ? splashPhaseForFixture(fixture) : splash.phase;
   const realPhase = splash.phase;
+  const holdAfterDone =
+    coverHeld && (realPhase === 'splash_done' || realPhase === 'splash_skipped');
+  const displayPhase: SplashPhase = fixture
+    ? splashPhaseForFixture(fixture)
+    : holdAfterDone || shellCoverFading
+      ? 'splash_passed'
+      : realPhase;
 
   const {
     isDownloading: realIsDownloading,
@@ -123,13 +133,27 @@ export function SplashScreen() {
     prevResetRef.current = resetSignal;
   });
 
+  const splashLifecycleActive =
+    realPhase !== 'fading_out' &&
+    realPhase !== 'splash_done' &&
+    realPhase !== 'splash_skipped';
+
+  useEffect(() => {
+    if (prevCoverHeldRef.current && !coverHeld && (realPhase === 'splash_done' || realPhase === 'splash_skipped')) {
+      setShellCoverFading(true);
+      const timer = window.setTimeout(() => setShellCoverFading(false), 500);
+      prevCoverHeldRef.current = coverHeld;
+      return () => window.clearTimeout(timer);
+    }
+    if (holdAfterDone) setShellCoverFading(false);
+    prevCoverHeldRef.current = coverHeld;
+  }, [coverHeld, holdAfterDone, realPhase]);
+
+  const shellCoverVisible = holdAfterDone || shellCoverFading;
+
   useEffect(() => {
     const root = document.documentElement;
-    if (
-      realPhase !== 'fading_out' &&
-      realPhase !== 'splash_done' &&
-      realPhase !== 'splash_skipped'
-    ) {
+    if (splashLifecycleActive || shellCoverVisible) {
       root.setAttribute('data-splash-active', '1');
     } else {
       root.removeAttribute('data-splash-active');
@@ -137,7 +161,7 @@ export function SplashScreen() {
     return () => {
       root.removeAttribute('data-splash-active');
     };
-  }, [realPhase]);
+  }, [shellCoverVisible, splashLifecycleActive]);
 
   // handoff 推进锚之一:Splash 开始退场(fading_out/done/skipped)即上报。
   const splashExitReportedRef = useRef(false);
@@ -155,7 +179,9 @@ export function SplashScreen() {
 
   // dev fixture 激活时冻结停留:真实生命周期跑完也不退场,供状态遍历/视觉走查
   // (readSplashPhaseFixture 在 PROD 恒 null,本分支不可达)。
-  if (!fixture && (realPhase === 'splash_done' || realPhase === 'splash_skipped')) return null;
+  if (!fixture && (realPhase === 'splash_done' || realPhase === 'splash_skipped') && !shellCoverVisible) {
+    return null;
+  }
 
   const isMac = window.electronAPI?.platform === 'darwin';
 
@@ -194,7 +220,9 @@ export function SplashScreen() {
     <div
       className={cn(
         'fixed inset-0 z-[9999] overflow-hidden',
-        realPhase === 'fading_out' && !fixture ? 'opacity-0' : 'opacity-100',
+        (realPhase === 'fading_out' || shellCoverFading) && !fixture
+          ? 'opacity-0'
+          : 'opacity-100',
       )}
       style={
         {

--- a/apps/desktop/src/renderer/components/splash/__tests__/SplashScreen.test.tsx
+++ b/apps/desktop/src/renderer/components/splash/__tests__/SplashScreen.test.tsx
@@ -43,6 +43,7 @@ const mocks = vi.hoisted(() => ({
     skipSplash: vi.fn(),
   },
   env: { step: undefined as 1 | 2 | undefined, totalSteps: undefined as 2 | undefined },
+  coverHeld: false,
 }));
 
 vi.mock('react-i18next', () => ({
@@ -72,6 +73,10 @@ vi.mock('@/hooks/useSplash', () => ({
 
 vi.mock('@/contexts/EnvCheckContext', () => ({
   useEnvCheck: () => ({ step: mocks.env.step, totalSteps: mocks.env.totalSteps }),
+}));
+
+vi.mock('@/contexts/AppShellCoverContext', () => ({
+  useAppShellCover: () => ({ coverHeld: mocks.coverHeld, reportLocalDbGate: () => {} }),
 }));
 
 vi.mock('@/components/title-bar/WindowControls', () => ({
@@ -126,6 +131,7 @@ beforeEach(() => {
   mocks.splash.downloadProgress = 0;
   mocks.splash.downloadInfo = { progress: 0 };
   mocks.splash.resetSignal = 0;
+  mocks.coverHeld = false;
   setPhase('splash_checking');
   document.documentElement.removeAttribute('data-splash-active');
   (window as unknown as { electronAPI: { platform: string } }).electronAPI = {
@@ -365,5 +371,14 @@ describe('SplashScreen wave4 统一面板', () => {
     setPhase('splash_skipped');
     view.rerender(<SplashScreen />);
     expect(view.container.firstElementChild).toBeNull();
+  });
+
+  it('LocalDbGate 未就绪时 splash_done 仍保持加载面板(登录后不得露白底)', () => {
+    mocks.coverHeld = true;
+    renderSplash('splash_done');
+    expect(screen.getByTestId('splash-panel')).toBeTruthy();
+    expectSpinner();
+    expect(screen.getByText('splash.tips.waking')).toBeTruthy();
+    expect(document.documentElement.getAttribute('data-splash-active')).toBe('1');
   });
 });

--- a/apps/desktop/src/renderer/components/splash/__tests__/SplashScreen.test.tsx
+++ b/apps/desktop/src/renderer/components/splash/__tests__/SplashScreen.test.tsx
@@ -381,4 +381,31 @@ describe('SplashScreen wave4 统一面板', () => {
     expect(screen.getByText('splash.tips.waking')).toBeTruthy();
     expect(document.documentElement.getAttribute('data-splash-active')).toBe('1');
   });
+
+  it('cover 放行后淡出层不拦截点击', () => {
+    mocks.coverHeld = true;
+    const view = renderSplash('splash_done');
+    mocks.coverHeld = false;
+    view.rerender(<SplashScreen />);
+    expect(screen.getByTestId('splash-root').className).toContain('pointer-events-none');
+    expect(screen.getByTestId('splash-root').className).toContain('opacity-0');
+  });
+
+  it('reduced-motion 下 cover 放行立即卸载,不留 500ms 透明遮罩', () => {
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: String(query).includes('prefers-reduced-motion'),
+      media: query,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+      dispatchEvent: () => false,
+    })) as unknown as typeof window.matchMedia;
+    mocks.coverHeld = true;
+    const view = renderSplash('splash_done');
+    expect(screen.getByTestId('splash-panel')).toBeTruthy();
+    mocks.coverHeld = false;
+    view.rerender(<SplashScreen />);
+    expect(view.container.firstElementChild).toBeNull();
+  });
 });

--- a/apps/desktop/src/renderer/contexts/AppShellCoverContext.tsx
+++ b/apps/desktop/src/renderer/contexts/AppShellCoverContext.tsx
@@ -1,0 +1,65 @@
+import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from 'react';
+
+import { useAuth } from '@/contexts/AuthContext';
+import { isGhostPanelWindow } from '@/lib/ghostPanelWindow';
+import { isSecondaryWindow } from '@/lib/secondaryWindow';
+import { isSidebarWindow } from '@/lib/sidebarWindow';
+
+/**
+ * AppShellCover — 启动 / 登录后进入主界面之前的不透明加载盖。
+ *
+ * DESIGN.md §10: splash 必须完全遮蔽已挂载 UI，直到加载完成。LocalDbGate 以前
+ * 假定这段等待 <100ms、交给 splash 兜底；一旦 ensureReady 慢于 splash 3s 地板，
+ * 品牌层卸掉后 gate 仍返回 null，窗口就露出默认白底。
+ *
+ * 本 context 把「已可进应用但主功能区还不能画」收成一个 coverHeld：
+ * splash / 品牌层在 coverHeld 期间不得退场；副窗不走 splash，也不持盖。
+ */
+export type LocalDbGateStatus = 'pending' | 'ready' | 'fatal';
+
+export interface AppShellCoverContextValue {
+  /** 主界面还不能画，启动 / 登录加载盖必须留着。 */
+  coverHeld: boolean;
+  localDbGateStatus: LocalDbGateStatus;
+  reportLocalDbGate: (status: LocalDbGateStatus) => void;
+}
+
+const AppShellCoverContext = createContext<AppShellCoverContextValue | null>(null);
+
+const FALLBACK_VALUE: AppShellCoverContextValue = Object.freeze({
+  coverHeld: false,
+  localDbGateStatus: 'pending',
+  reportLocalDbGate: () => {},
+});
+
+function isDerivedWindow(): boolean {
+  return isSecondaryWindow() || isSidebarWindow() || isGhostPanelWindow();
+}
+
+export function AppShellCoverProvider({ children }: { children: ReactNode }) {
+  const { isInitializing, canEnterApp } = useAuth();
+  const [localDbGateStatus, setLocalDbGateStatus] = useState<LocalDbGateStatus>('pending');
+
+  const reportLocalDbGate = useCallback((status: LocalDbGateStatus) => {
+    setLocalDbGateStatus(status);
+  }, []);
+
+  const value = useMemo<AppShellCoverContextValue>(() => {
+    const coverHeld =
+      !isDerivedWindow() &&
+      !isInitializing &&
+      canEnterApp &&
+      localDbGateStatus === 'pending';
+    return {
+      coverHeld,
+      localDbGateStatus,
+      reportLocalDbGate,
+    };
+  }, [canEnterApp, isInitializing, localDbGateStatus, reportLocalDbGate]);
+
+  return <AppShellCoverContext.Provider value={value}>{children}</AppShellCoverContext.Provider>;
+}
+
+export function useAppShellCover(): AppShellCoverContextValue {
+  return useContext(AppShellCoverContext) ?? FALLBACK_VALUE;
+}

--- a/apps/desktop/src/renderer/contexts/LoginHandoffContext.tsx
+++ b/apps/desktop/src/renderer/contexts/LoginHandoffContext.tsx
@@ -129,12 +129,15 @@ export function LoginHandoffProvider({
   children,
   authResolved,
   authenticated,
+  coverHeld = false,
 }: {
   children: ReactNode;
   /** auth 初始化完成(= !isInitializing;App.tsx 内层 host 从 useAuth 取,避免本模块传递性引入 AuthContext 重依赖)。 */
   authResolved: boolean;
   /** auth 初始化结果分支(仅在 authResolved 后读)。 */
   authenticated: boolean;
+  /** 已登录但 LocalDbGate 还不能画主界面时由 App 壳下传,避免本模块 import AppShellCover/Auth。 */
+  coverHeld?: boolean;
 }) {
   const [phase, setPhase] = useState<LoginHandoffPhase>('boot');
   const [branch, setBranch] = useState<LoginHandoffBranch>(null);
@@ -235,12 +238,12 @@ export function LoginHandoffProvider({
       panelBottomReserve,
       isPlaying,
       // startup 期(含 boot/播放中/brand-exit)恒挂以维持不透明白底全盖;done 后
-      // 一律跟随登录面板存在:authenticated 淡出完成且无面板 → 卸载;之后登出
-      // 回 /login,LoginPage 上报面板挂载 → 品牌层重挂(phase 恒 done = 终态:
-      // 品牌固定登录位、Slogan 直落可见、无过渡不重播——playedRef 语义不变)。
+      // 跟随登录面板或 AppShellCover:登录页要品牌底;已登录但 LocalDbGate 还在
+      // checking 时也要留着,避免登录成功卸面板后露出默认白底。登出回 /login
+      // 由 LoginPage 上报面板挂载重挂(phase 恒 done = 终态,不重播)。
       // 判定刻意不绑 branch:绑死会让 authenticated 冷启动后登出的 /login 永久
       // 丢失品牌层(登录页只剩悬空白面板,2026-07-20 对抗 review P1)。
-      brandStageMounted: phase !== 'done' ? true : panelMounted,
+      brandStageMounted: phase !== 'done' ? true : panelMounted || coverHeld,
       brandExiting: phase === 'brand-exit',
       panelRevealed: phase === 'panel' || phase === 'slogan' || phase === 'done',
       sloganRevealed: phase === 'slogan' || phase === 'done',
@@ -254,6 +257,7 @@ export function LoginHandoffProvider({
     phase,
     branch,
     panelMounted,
+    coverHeld,
     panelBottomReserve,
     reportBrandAssetsReady,
     reportSplashExited,

--- a/apps/desktop/src/renderer/contexts/__tests__/AppShellCoverContext.test.tsx
+++ b/apps/desktop/src/renderer/contexts/__tests__/AppShellCoverContext.test.tsx
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from '@testing-library/react';
+import { act } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const auth = vi.hoisted(() => ({
+  isInitializing: false,
+  canEnterApp: false,
+}));
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => auth,
+}));
+
+vi.mock('@/lib/secondaryWindow', () => ({
+  isSecondaryWindow: () => false,
+}));
+vi.mock('@/lib/sidebarWindow', () => ({
+  isSidebarWindow: () => false,
+}));
+vi.mock('@/lib/ghostPanelWindow', () => ({
+  isGhostPanelWindow: () => false,
+}));
+
+import { AppShellCoverProvider, useAppShellCover } from '../AppShellCoverContext';
+
+function Probe() {
+  const { coverHeld, localDbGateStatus } = useAppShellCover();
+  return (
+    <div>
+      <span data-testid="cover">{coverHeld ? 'held' : 'open'}</span>
+      <span data-testid="gate">{localDbGateStatus}</span>
+    </div>
+  );
+}
+
+function renderCover() {
+  return render(
+    <AppShellCoverProvider>
+      <Probe />
+    </AppShellCoverProvider>,
+  );
+}
+
+describe('AppShellCover', () => {
+  afterEach(() => {
+    cleanup();
+    auth.isInitializing = false;
+    auth.canEnterApp = false;
+  });
+
+  it('未登录不持盖,让 splash 退到登录页', () => {
+    auth.canEnterApp = false;
+    renderCover();
+    expect(screen.getByTestId('cover').textContent).toBe('open');
+  });
+
+  it('已可进应用且 LocalDbGate 仍 pending 时持盖', () => {
+    auth.canEnterApp = true;
+    renderCover();
+    expect(screen.getByTestId('cover').textContent).toBe('held');
+    expect(screen.getByTestId('gate').textContent).toBe('pending');
+  });
+
+  it('LocalDbGate ready 后放行', () => {
+    auth.canEnterApp = true;
+    function ReadyProbe() {
+      const { reportLocalDbGate, coverHeld } = useAppShellCover();
+      return (
+        <button type="button" onClick={() => reportLocalDbGate('ready')}>
+          {coverHeld ? 'held' : 'open'}
+        </button>
+      );
+    }
+    render(
+      <AppShellCoverProvider>
+        <ReadyProbe />
+      </AppShellCoverProvider>,
+    );
+    expect(screen.getByRole('button').textContent).toBe('held');
+    act(() => {
+      screen.getByRole('button').click();
+    });
+    expect(screen.getByRole('button').textContent).toBe('open');
+  });
+
+  it('auth 仍在初始化时不持盖,交给 splash 自己的 auth 锚', () => {
+    auth.isInitializing = true;
+    auth.canEnterApp = true;
+    renderCover();
+    expect(screen.getByTestId('cover').textContent).toBe('open');
+  });
+});

--- a/apps/desktop/src/renderer/hooks/__tests__/useSplashPhases.test.tsx
+++ b/apps/desktop/src/renderer/hooks/__tests__/useSplashPhases.test.tsx
@@ -17,6 +17,7 @@ const mocks = vi.hoisted(() => ({
   totalSteps: undefined as 2 | undefined,
   checkEnvironment: vi.fn(async () => undefined),
   authInitializing: false,
+  coverHeld: false,
   updateErrorCode: undefined as string | undefined,
 }));
 
@@ -45,6 +46,10 @@ vi.mock('@/hooks/useUpdateStatus', () => ({
   useUpdateStatus: () => ({ errorCode: mocks.updateErrorCode }),
 }));
 
+vi.mock('@/contexts/AppShellCoverContext', () => ({
+  useAppShellCover: () => ({ coverHeld: mocks.coverHeld, reportLocalDbGate: () => {} }),
+}));
+
 import { useSplash } from '../useSplash';
 
 describe('useSplash phase 表', () => {
@@ -54,6 +59,7 @@ describe('useSplash phase 表', () => {
     mocks.step = undefined;
     mocks.totalSteps = undefined;
     mocks.authInitializing = false;
+    mocks.coverHeld = false;
     mocks.updateErrorCode = undefined;
     mocks.checkEnvironment.mockClear();
     (
@@ -130,6 +136,16 @@ describe('useSplash phase 表', () => {
   it('auth 初始化未完成时 passed 不淡出(推进锚含 authInitializing)', () => {
     mocks.envStatus = 'passed';
     mocks.authInitializing = true;
+    const { result } = renderHook(() => useSplash());
+    act(() => {
+      vi.advanceTimersByTime(10_000);
+    });
+    expect(result.current.phase).toBe('splash_passed');
+  });
+
+  it('LocalDbGate 仍在 checking 时 passed 不淡出(启动盖必须留到主界面可画)', () => {
+    mocks.envStatus = 'passed';
+    mocks.coverHeld = true;
     const { result } = renderHook(() => useSplash());
     act(() => {
       vi.advanceTimersByTime(10_000);

--- a/apps/desktop/src/renderer/hooks/useSplash.ts
+++ b/apps/desktop/src/renderer/hooks/useSplash.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useAppShellCover } from '@/contexts/AppShellCoverContext';
 import { useEnvCheck } from '@/contexts/EnvCheckContext';
 import { useAuth } from '@/contexts/AuthContext';
 import { useUpdateStatus } from '@/hooks/useUpdateStatus';
@@ -98,6 +99,7 @@ export function useSplash() {
     checkEnvironment,
   } = useEnvCheck();
   const { isInitializing: authInitializing } = useAuth();
+  const { coverHeld } = useAppShellCover();
   const { errorCode: updateErrorCode } = useUpdateStatus();
 
   const [phase, setPhase] = useState<SplashPhase>('init');
@@ -158,11 +160,13 @@ export function useSplash() {
   }, [updateErrorCode, phase]);
 
   // ── Effect 3: fade-out trigger ──
+  // coverHeld:已登录但 LocalDbGate 还不能画主界面。splash 必须继续盖住
+  // (DESIGN.md §10),否则 3s 地板一过会露出默认白底。
   useEffect(() => {
-    if (phase === 'splash_passed' && minTimeElapsed && !authInitializing) {
+    if (phase === 'splash_passed' && minTimeElapsed && !authInitializing && !coverHeld) {
       setPhase('fading_out');
     }
-  }, [phase, minTimeElapsed, authInitializing]);
+  }, [phase, minTimeElapsed, authInitializing, coverHeld]);
 
   // ── Effect 4: fading_out fallback ──
   useEffect(() => {


### PR DESCRIPTION
## 这次改了什么

### 摘要

安装版冷启动登录后会白屏约 20 秒。根因是 `LocalDbGate` 会 await 一次全库 `LIKE + json_tree` 扫描，用来清上一轮留下的暂存附件；账号库到数 GB 时扫描本身就要二十多秒，而 splash 只盖 3 秒，盖一撤就是默认白底。`Cmd+Q` 时能短暂看到正常空界面，是因为底下的 Cindy 窗其实已经在。

这次两处一起收：启动清扫先看磁盘，没有过期文件就不查库，并且不再堵住第一屏；已登录但主界面还不能画时，splash / 品牌加载盖一直留着。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无（本机安装版 0.1.50 冷启动复现）
- 本 PR 包含：
  - 启动暂存附件清扫改为先扫磁盘；无过期 `.bin` 则跳过消息库查询
  - 该清扫改为 fire-and-forget，不再阻塞 `ensureReady` / `LocalDbGate`
  - 新增 `AppShellCover`：已可进应用但 LocalDbGate 仍 pending 时，splash / 品牌层不得退场
- 明确不包含：缩小那条 `LIKE + json_tree` SQL 本身；主线程 worktree 扫描导致的约 2–3 秒空窗
- 用户可见变化：冷启动 / 登录后不再长时间白屏，加载期继续停在既有 splash
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：DESIGN.md §10（splash 必须用不透明 `--surface` 盖住已挂载 UI，直到加载完成，2026-07-19 裁定）；§16 登录 / splash 家族（继续用既有 splash 面板 + loading 环，不另造加载页）；§14.4 spinner 例外与 reduced-motion。未改色值或新文案；Light / Dark 仍走既有 `--login-*` token。未做双模式实机目检。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop run typecheck
结果：通过

pnpm test:unit:related
结果：通过（desktop related）

/Users/dash/.agents/skills/git/scripts/run-unit-gate.sh <worktree>
结果：desktop 全量 2 个失败，均在 src/main/cindy-brain/__tests__/ghostInstallReceipt.test.ts
      本 PR 未改 cindy-brain。同一测试在干净 origin/main（36b9c48a8）复现失败。
      交给 CI 兜底，不把无关修复混进本 PR。
```

### 手工验证

开发版曾以 `--region=cn --preserve-running` 并行拉起。日志里同一账号的 `chat-attachment-sweep` 从约 24s 降到 0ms，`LocalDbGate` 约 542ms。未盯着冷启动窗口做目检，因此不能声称「实机确认零白屏」。正式版 0.1.50 仍是旧逻辑。

### 未执行的验证

冷启动实机目检（Light / Dark）；未对有大量过期 `.bin` 的账号验证后台扫描与任务列表的 DB 争用。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop 启动清扫时序；登录 / 已登录进主界面时的 splash 停留。被消息引用的附件仍会在确认有过期文件后查 `protectedPaths` 再删；本轮刚 stage 的草稿按 mtime 跳过。
- 回滚 / 降级方式：回退本 PR。孤儿暂存附件最多多留到下次启动，与清扫失败时的原语义一致。
- 存量插件影响：无

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
