### PR TITLE
fix(device-link): 切断反复建链全量重放并给恢复发送加探测预算

### DIFF
--- a/apps/desktop/src/main/device-link/__tests__/dispatchSendSafety.test.ts
+++ b/apps/desktop/src/main/device-link/__tests__/dispatchSendSafety.test.ts
@@ -530,17 +530,19 @@ describe('[13] forwardPush — 转发失败 best-effort,不冒泡', () => {
     expect(subscriptions.getKnownControllersForTopic('session:s1')).toEqual([]);
   });
 
-  it('revoked 控制端反复 link-open 不重复 closeLink', () => {
+  it('revoked 控制端反复 link-open 不重复 closeLink,但仍每次 purge 订阅', () => {
     const client = mkClient();
     __testing.setActiveClient(client as never);
     deviceLinkSettings.value.revokedControllers = ['ctrl-revoked'];
 
     __testing.handleLinkOpen(client as never, 'ctrl-revoked', 'open-1', undefined);
+    subscriptions.subscribe('ctrl-revoked', ['session:s1']);
     __testing.handleLinkOpen(client as never, 'ctrl-revoked', 'open-2', undefined);
     __testing.handleLinkOpen(client as never, 'ctrl-revoked', 'open-3', undefined);
 
     expect(client.closeLink).toHaveBeenCalledTimes(1);
     expect(client.sendLinkAccept).not.toHaveBeenCalled();
+    expect(subscriptions.getKnownControllersForTopic('session:s1')).toEqual([]);
   });
 
   it('legacy link-open restores wildcard behavior and replays wildcard backlog', () => {

--- a/apps/desktop/src/main/device-link/__tests__/dispatchSendSafety.test.ts
+++ b/apps/desktop/src/main/device-link/__tests__/dispatchSendSafety.test.ts
@@ -530,6 +530,19 @@ describe('[13] forwardPush — 转发失败 best-effort,不冒泡', () => {
     expect(subscriptions.getKnownControllersForTopic('session:s1')).toEqual([]);
   });
 
+  it('revoked 控制端反复 link-open 不重复 closeLink', () => {
+    const client = mkClient();
+    __testing.setActiveClient(client as never);
+    deviceLinkSettings.value.revokedControllers = ['ctrl-revoked'];
+
+    __testing.handleLinkOpen(client as never, 'ctrl-revoked', 'open-1', undefined);
+    __testing.handleLinkOpen(client as never, 'ctrl-revoked', 'open-2', undefined);
+    __testing.handleLinkOpen(client as never, 'ctrl-revoked', 'open-3', undefined);
+
+    expect(client.closeLink).toHaveBeenCalledTimes(1);
+    expect(client.sendLinkAccept).not.toHaveBeenCalled();
+  });
+
   it('legacy link-open restores wildcard behavior and replays wildcard backlog', () => {
     const client = mkClient();
     __testing.setActiveClient(client as never);

--- a/apps/desktop/src/main/device-link/__tests__/responsivenessTracker.test.ts
+++ b/apps/desktop/src/main/device-link/__tests__/responsivenessTracker.test.ts
@@ -371,6 +371,9 @@ describe('classifyDeviceSendFailure / classifyDeviceSendSuccess', () => {
       classifyDeviceSendFailure(new DeviceLinkError('VERSION_MISMATCH', 'v mismatch')),
     ).toBe('responded');
     expect(
+      classifyDeviceSendFailure(new DeviceLinkError('ACCESS_REVOKED', 'revoked')),
+    ).toBe('responded');
+    expect(
       classifyDeviceSendFailure(new DeviceLinkError('NOT_CONNECTED', 'lost')),
     ).toBe('inconclusive');
     expect(classifyDeviceSendFailure(new Error('random'))).toBe('inconclusive');

--- a/apps/desktop/src/main/device-link/dispatch.ts
+++ b/apps/desktop/src/main/device-link/dispatch.ts
@@ -1695,12 +1695,14 @@ function handleLinkOpen(
   // 逐设备黑名单:已撤销访问权限的控制端,发 link-close('revoked') 给明确信号
   // (legacy openLink 仍会超时,但控制端据此 link-close 标记「已撤销」),不接受其 link-open。
   if (isControllerRevoked(src)) {
+    // 清理必须每次都做:限频只挡 closeLink/日志,不能把 purge 也吞掉。
+    // 否则短暂解禁再撤权时,restore 窗口里装上的订阅会在 throttle 内继续收 push。
+    purgeRevokedController(src);
     const now = Date.now();
     const last = revokedLinkOpenRejectAt.get(src) ?? 0;
     if (now - last >= REVOKED_LINK_OPEN_REJECT_INTERVAL_MS) {
       log.warn(`link-open from ${shortId(src)} rejected: access revoked`);
       revokedLinkOpenRejectAt.set(src, now);
-      purgeRevokedController(src);
       client.closeLink(src, 'revoked', 'inbound');
     }
     return;

--- a/apps/desktop/src/main/device-link/dispatch.ts
+++ b/apps/desktop/src/main/device-link/dispatch.ts
@@ -1636,6 +1636,9 @@ function isControllerRevoked(deviceId: string): boolean {
  */
 const LINK_ACCEPT_RETRY_DELAYS_MS: readonly number[] = [500, 1_000, 2_000];
 const linkAcceptRetryTimers = new Map<string, ReturnType<typeof setTimeout>>();
+/** 已撤权控制端反复 open 时，closeLink 与 warn 的最小间隔。 */
+const REVOKED_LINK_OPEN_REJECT_INTERVAL_MS = 30_000;
+const revokedLinkOpenRejectAt = new Map<string, number>();
 
 function cancelLinkAcceptRetry(src: string): void {
   const timer = linkAcceptRetryTimers.get(src);
@@ -1692,9 +1695,14 @@ function handleLinkOpen(
   // 逐设备黑名单:已撤销访问权限的控制端,发 link-close('revoked') 给明确信号
   // (legacy openLink 仍会超时,但控制端据此 link-close 标记「已撤销」),不接受其 link-open。
   if (isControllerRevoked(src)) {
-    log.warn(`link-open from ${shortId(src)} rejected: access revoked`);
-    purgeRevokedController(src);
-    client.closeLink(src, 'revoked', 'inbound');
+    const now = Date.now();
+    const last = revokedLinkOpenRejectAt.get(src) ?? 0;
+    if (now - last >= REVOKED_LINK_OPEN_REJECT_INTERVAL_MS) {
+      log.warn(`link-open from ${shortId(src)} rejected: access revoked`);
+      revokedLinkOpenRejectAt.set(src, now);
+      purgeRevokedController(src);
+      client.closeLink(src, 'revoked', 'inbound');
+    }
     return;
   }
   const name = resolveControllerName(src, payload?.controllerName) ?? src.slice(0, 8);
@@ -2977,6 +2985,7 @@ export const __testing = {
     clearAllSessionActivityStages();
     clearAllMakerEventBatchStages();
     cancelAllLinkAcceptRetries();
+    revokedLinkOpenRejectAt.clear();
     setBroadcastTapListener(null);
     presenceOfflineCheck = null;
     remoteReviewInputGuard = null;

--- a/apps/desktop/src/main/device-link/index.ts
+++ b/apps/desktop/src/main/device-link/index.ts
@@ -390,6 +390,8 @@ let appliedKeepAwake: boolean | null = null;
 /** 退出路径的持有权 DELETE 完成信号:sync 阶段发起,async 阶段 disposer await(见 onQuit 注释) */
 let pendingQuitOwnershipRelease: Promise<void> | null = null;
 const openLinkInFlight = new Map<string, Promise<LinkAcceptPayload>>();
+/** 对端已对本机撤权：自动 recover/probe 不得再 openLink；用户显式重试可清掉。 */
+const revokedByRemote = new Set<string>();
 const presenceAvailableByDevice = new Map<string, boolean>();
 /**
  * 「目标设备无响应」熔断(弱网 / 对端卡死时收敛请求风暴,见 responsivenessTracker)。
@@ -615,6 +617,7 @@ export function initDeviceLinkService(options: DeviceLinkServiceOptions = {}): v
       client?.getStatus() === 'online' &&
       arbiter?.isOwner() === true &&
       presenceAvailableByDevice.get(deviceId) === true &&
+      !revokedByRemote.has(deviceId) &&
       !readDeviceLinkSettings().disabledControlDeviceIds.includes(deviceId),
     // observed:false 且是唯一豁免熔断快速拒绝的建链入口:recoverLink 是探测
     // 周期的延伸(业务/探测超时已由 tracker 记账,不重复观测),且 open 期间
@@ -802,6 +805,7 @@ export function initDeviceLinkService(options: DeviceLinkServiceOptions = {}): v
       if (reason === 'revoked') {
         // 撤权后在途请求会陆续超时——那不是「设备无响应」,是访问被收回。清熔断并
         // 作废在途结果(翻代),避免 unresponsive 状态与撤权状态并存(对齐 mobile 语义)。
+        revokedByRemote.add(env.src);
         responsivenessTracker?.clearDevice(env.src);
         broadcast(DEVICE_LINK_PUSH.ACCESS_REVOKED, { deviceId: env.src });
       }
@@ -1118,6 +1122,7 @@ function teardownActiveLink(): void {
   for (const timer of subscriptionReplayRetryTimers.values()) clearTimeout(timer);
   subscriptionReplayRetryTimers.clear();
   presenceAvailableByDevice.clear();
+  revokedByRemote.clear();
   // 词典同步驱动是进程级的,**不随单次链路起停**:多实例仲裁的 demote → acquire
   // 只会 client.start(),不会重跑 initDeviceLinkService,在这里 stop 掉它会让词典
   // 同步在降级过一次之后永久失效。清空 presence 就够了 —— 没有对端就不会发送,
@@ -1554,11 +1559,15 @@ const openLinkCloseEpochs = new Map<string, number>();
  */
 export async function openRemoteLink(
   deviceId: string,
-  opts?: { observed?: boolean },
+  opts?: { observed?: boolean; allowRevokedRetry?: boolean },
 ): Promise<LinkAcceptPayload> {
   assertNotStandby();
   assertRemoteControlTargetEnabled(deviceId);
   if (!client) throw new Error('[DEVICE_LINK_NOT_CONNECTED] device-link client not initialized');
+  if (opts?.allowRevokedRetry) revokedByRemote.delete(deviceId);
+  else if (revokedByRemote.has(deviceId)) {
+    throw new DeviceLinkError('ACCESS_REVOKED', 'access revoked by target device');
+  }
   const existing = openLinkInFlight.get(deviceId);
   if (existing) return existing;
 

--- a/apps/desktop/src/main/device-link/index.ts
+++ b/apps/desktop/src/main/device-link/index.ts
@@ -626,7 +626,12 @@ export function initDeviceLinkService(options: DeviceLinkServiceOptions = {}): v
     // 拒绝,review P2)。频度由探测退避与 openLinkInFlight 单飞约束。open
     // 期间 transport-timeout 重建照旧让位(观测入口被快速拒绝,熔断关闭后
     // 下一次触发生效),恢复统一由探测循环驱动。
-    recoverLink: (deviceId) => openRemoteLink(deviceId, { observed: false }),
+    recoverLink: (deviceId) => {
+      if (revokedByRemote.has(deviceId)) {
+        return Promise.reject(new DeviceLinkError('ACCESS_REVOKED', 'access revoked by target device'));
+      }
+      return openRemoteLink(deviceId, { observed: false });
+    },
     log: {
       info: (...args) => log.info(...args),
       warn: (...args) => log.warn(...args),
@@ -1564,10 +1569,9 @@ export async function openRemoteLink(
   assertNotStandby();
   assertRemoteControlTargetEnabled(deviceId);
   if (!client) throw new Error('[DEVICE_LINK_NOT_CONNECTED] device-link client not initialized');
+  // 自动 recover/probe 由 recoverLink + isProbeEligible 挡。presence / subscribe
+  // 必须能在对端重新授权后走这里接回；成功建链再清终态。
   if (opts?.allowRevokedRetry) revokedByRemote.delete(deviceId);
-  else if (revokedByRemote.has(deviceId)) {
-    throw new DeviceLinkError('ACCESS_REVOKED', 'access revoked by target device');
-  }
   const existing = openLinkInFlight.get(deviceId);
   if (existing) return existing;
 
@@ -1584,12 +1588,14 @@ export async function openRemoteLink(
       throw new DeviceLinkError('LINK_NOT_OPEN', 'link closed while waiting to reconnect');
     }
     if (!client) throw new Error('[DEVICE_LINK_NOT_CONNECTED] device-link client not initialized');
-    return client.openLink(deviceId, {
+    const accepted = await client.openLink(deviceId, {
       controllerName: deviceName(),
       protocolVersion: 1,
       appVersion: app.getVersion(),
       capabilities: [...CONTROLLER_CAPABILITIES],
     });
+    revokedByRemote.delete(deviceId);
+    return accepted;
   };
   // 结算所有权由 tracker.guardInvoke 统一声明(第一个 settle 的 guard 打标,
   // 后续 guard 见标不定论):observed 发起、unobserved 发起被多个业务加入者

--- a/apps/desktop/src/main/device-link/index.ts
+++ b/apps/desktop/src/main/device-link/index.ts
@@ -1564,14 +1564,13 @@ const openLinkCloseEpochs = new Map<string, number>();
  */
 export async function openRemoteLink(
   deviceId: string,
-  opts?: { observed?: boolean; allowRevokedRetry?: boolean },
+  opts?: { observed?: boolean },
 ): Promise<LinkAcceptPayload> {
   assertNotStandby();
   assertRemoteControlTargetEnabled(deviceId);
   if (!client) throw new Error('[DEVICE_LINK_NOT_CONNECTED] device-link client not initialized');
   // 自动 recover/probe 由 recoverLink + isProbeEligible 挡。presence / subscribe
-  // 必须能在对端重新授权后走这里接回；成功建链再清终态。
-  if (opts?.allowRevokedRetry) revokedByRemote.delete(deviceId);
+  // 可以在对端重新授权后走这里接回；终态只在成功建链后清除,失败重试不得提前解闩。
   const existing = openLinkInFlight.get(deviceId);
   if (existing) return existing;
 

--- a/apps/desktop/src/main/device-link/ipc.ts
+++ b/apps/desktop/src/main/device-link/ipc.ts
@@ -155,7 +155,7 @@ export function defaultDeps(): DeviceLinkIpcDeps {
     setEnabled: setRemoteControlEnabled,
     setKeepAwake: setKeepAwakeEnabled,
     apiFetch: (path, opts) => serverApiFetch(path, { ...opts, baseUrl: deviceLinkApiBase }),
-    openLink: (deviceId: string) => openRemoteLink(deviceId, { allowRevokedRetry: true }),
+    openLink: (deviceId: string) => openRemoteLink(deviceId),
     closeLink: closeRemoteLink,
     invoke: (...args) => {
       requireDeviceLinkCapability();

--- a/apps/desktop/src/main/device-link/ipc.ts
+++ b/apps/desktop/src/main/device-link/ipc.ts
@@ -155,7 +155,7 @@ export function defaultDeps(): DeviceLinkIpcDeps {
     setEnabled: setRemoteControlEnabled,
     setKeepAwake: setKeepAwakeEnabled,
     apiFetch: (path, opts) => serverApiFetch(path, { ...opts, baseUrl: deviceLinkApiBase }),
-    openLink: openRemoteLink,
+    openLink: (deviceId: string) => openRemoteLink(deviceId, { allowRevokedRetry: true }),
     closeLink: closeRemoteLink,
     invoke: (...args) => {
       requireDeviceLinkCapability();

--- a/apps/desktop/src/main/device-link/responsivenessTracker.ts
+++ b/apps/desktop/src/main/device-link/responsivenessTracker.ts
@@ -127,6 +127,7 @@ export function classifyDeviceSendFailure(error: unknown): BreakerSettleOutcome 
     error.code === 'DEVICE_OFFLINE'
     || error.code === 'REMOTE_DISABLED'
     || error.code === 'VERSION_MISMATCH'
+    || error.code === 'ACCESS_REVOKED'
   ) {
     return 'responded';
   }

--- a/packages/device-link/src/__tests__/client.test.ts
+++ b/packages/device-link/src/__tests__/client.test.ts
@@ -4763,6 +4763,38 @@ describe('定时重发的单趟预算(TRANSPORT_RETRY_PASS_BUDGET)', () => {
     h.client.stop();
   }, 10_000);
 
+  it('恢复预算还剩一点时,放不下的大消息先入队不发出', async () => {
+    const h = makeHarness({
+      timing: {
+        pingIntervalMs: 60_000,
+        transportRetryIntervalMs: 60_000,
+        transportRetryPassBudget: 3,
+        transportMaxRetryAttempts: 50,
+      },
+    });
+    h.client.start();
+    await tick();
+    h.current().ack();
+    await establishInboundReliableLink(h, 'remote-stream');
+
+    h.client.sendInvokeResult('dev-b', 'small-0', { ok: true, result: 0 });
+    h.client.sendInvokeResult('dev-b', 'small-1', { ok: true, result: 1 });
+    const ws = h.current();
+    const before = framesSent(ws);
+    const internals = h.client as unknown as {
+      peerTransport: Map<string, { linkReady: boolean }>;
+    };
+    internals.peerTransport.get('dev-b')!.linkReady = false;
+    await establishInboundReliableLink(h, 'remote-stream-2');
+    await tick();
+
+    const chunky = 'x'.repeat(2 * 128 * 1024 + 1_000);
+    h.client.sendInvokeResult('dev-b', 'too-big', { ok: true, result: chunky });
+    expect(framesSent(ws)).toBe(before + 2);
+
+    h.client.stop();
+  }, 10_000);
+
   it('恢复探测未 ACK 时定时器仍重发已发出的探针,不放行新帧', async () => {
     await withFakeTimers(async (h, advance) => {
       for (let i = 0; i < 7; i += 1) {

--- a/packages/device-link/src/__tests__/client.test.ts
+++ b/packages/device-link/src/__tests__/client.test.ts
@@ -4247,6 +4247,7 @@ describe('DeviceLinkClient relay 拥塞断连(close 1013)', () => {
         reconnectBaseMs: 1,
         reconnectMaxMs: 5,
         reconnectStableResetMs: 20,
+        congestionStableResetMs: 80,
         congestionBackoffBaseMs: 2,
         congestionBackoffMaxMs: 8,
         pingIntervalMs: 60_000,
@@ -4268,8 +4269,12 @@ describe('DeviceLinkClient relay 拥塞断连(close 1013)', () => {
     expect(h.client.getStatus()).toBe('online');
     expect(internals.congestionCloseStreak).toBe(1);
 
-    // 稳定在线满 reconnectStableResetMs 后清零
-    await tick(100);
+    // 普通稳定窗过了,拥塞连击仍在:现场 1013 间隔远大于 10s
+    await tick(40);
+    expect(internals.congestionCloseStreak).toBe(1);
+
+    // 稳定在线满 congestionStableResetMs 后才清零
+    await tick(80);
     expect(internals.congestionCloseStreak).toBe(0);
 
     // 普通断线(1006)不计入拥塞连击
@@ -4652,11 +4657,11 @@ describe('定时重发的单趟预算(TRANSPORT_RETRY_PASS_BUDGET)', () => {
     });
   }, 10_000);
 
-  it('link 重建后的 replay 不受预算限制:可达性刚被对端 link-accept 证明过', async () => {
+  it('同连接代重复 link-open 不再全量 replay', async () => {
     const h = makeHarness({
       timing: {
         pingIntervalMs: 60_000,
-        transportRetryIntervalMs: 60_000, // 定时器不参与,只看 replay 那一趟
+        transportRetryIntervalMs: 60_000,
         transportRetryPassBudget: 2,
         transportMaxRetryAttempts: 50,
       },
@@ -4672,10 +4677,57 @@ describe('定时重发的单趟预算(TRANSPORT_RETRY_PASS_BUDGET)', () => {
     const ws = h.current();
     expect(retriedSeqs(sendsBySeq(ws))).toEqual([]);
 
-    // 对端重新 link-open → 本端 link-accept → replay:一趟把 7 条全部重放
     await establishInboundReliableLink(h, 'remote-stream-2');
     await tick();
-    expect(retriedSeqs(sendsBySeq(ws)).length).toBe(7);
+    expect(retriedSeqs(sendsBySeq(ws))).toEqual([]);
+
+    h.client.stop();
+  }, 10_000);
+
+  it('真正恢复时 replay 受探测预算约束,ACK 后再继续 drain', async () => {
+    const h = makeHarness({
+      timing: {
+        pingIntervalMs: 60_000,
+        transportRetryIntervalMs: 60_000,
+        transportRetryPassBudget: 2,
+        transportMaxRetryAttempts: 50,
+      },
+    });
+    h.client.start();
+    await tick();
+    h.current().ack();
+    await establishInboundReliableLink(h, 'remote-stream');
+
+    for (let i = 0; i < 7; i += 1) {
+      h.client.sendInvokeResult('dev-b', `req-${i}`, { ok: true, result: i });
+    }
+    const ws = h.current();
+    const seqs = [...sendsBySeq(ws).keys()].sort((a, b) => a - b);
+    expect(seqs).toHaveLength(7);
+
+    const internals = h.client as unknown as {
+      peerTransport: Map<string, { linkReady: boolean }>;
+    };
+    internals.peerTransport.get('dev-b')!.linkReady = false;
+
+    await establishInboundReliableLink(h, 'remote-stream-2');
+    await tick();
+    expect(retriedSeqs(sendsBySeq(ws))).toEqual(seqs.slice(0, 2));
+
+    const streamId = parseTransportPayload(
+      ws.sent.find((env) => env.kind === 'invoke-result' && parseTransportPayload(env.payload))!.payload,
+    )!.meta.streamId;
+    ws.push({
+      v: PROTOCOL_VERSION,
+      kind: 'push',
+      src: 'dev-b',
+      payload: {
+        channel: DEVICE_LINK_TRANSPORT_ACK_CHANNEL,
+        payload: { streamId, ackSeq: seqs[1] },
+      },
+    });
+    await tick();
+    expect(retriedSeqs(sendsBySeq(ws))).toEqual([...seqs.slice(0, 2), ...seqs.slice(2, 4)]);
 
     h.client.stop();
   }, 10_000);

--- a/packages/device-link/src/__tests__/client.test.ts
+++ b/packages/device-link/src/__tests__/client.test.ts
@@ -4742,6 +4742,9 @@ describe('定时重发的单趟预算(TRANSPORT_RETRY_PASS_BUDGET)', () => {
     await tick();
     expect(retriedSeqs(sendsBySeq(ws))).toEqual(seqs.slice(0, 2));
 
+    h.client.sendInvokeResult('dev-b', 'extra-during-recovery', { ok: true, result: 'x' });
+    expect([...sendsBySeq(ws).keys()]).toHaveLength(7);
+
     const streamId = parseTransportPayload(
       ws.sent.find((env) => env.kind === 'invoke-result' && parseTransportPayload(env.payload))!.payload,
     )!.meta.streamId;

--- a/packages/device-link/src/__tests__/client.test.ts
+++ b/packages/device-link/src/__tests__/client.test.ts
@@ -4843,6 +4843,60 @@ describe('定时重发的单趟预算(TRANSPORT_RETRY_PASS_BUDGET)', () => {
     h.client.stop();
   }, 10_000);
 
+  it('恢复期 hold 时不因共享 ws 缓冲满而 BACKPRESSURE', async () => {
+    const h = makeHarness({
+      timing: {
+        pingIntervalMs: 60_000,
+        transportRetryIntervalMs: 60_000,
+        transportRetryPassBudget: 2,
+        transportMaxRetryAttempts: 50,
+      },
+    });
+    h.client.start();
+    await tick();
+    h.current().ack();
+    await establishInboundReliableLink(h, 'remote-stream');
+
+    h.client.sendInvokeResult('dev-b', 'warmup', { ok: true, result: 0 });
+    const ws = h.current();
+    const warmup = parseTransportPayload(
+      ws.sent.find((env) => env.kind === 'invoke-result' && parseTransportPayload(env.payload))!.payload,
+    )!;
+    ws.push({
+      v: PROTOCOL_VERSION,
+      kind: 'push',
+      src: 'dev-b',
+      payload: {
+        channel: DEVICE_LINK_TRANSPORT_ACK_CHANNEL,
+        payload: { streamId: warmup.meta.streamId, ackSeq: warmup.meta.seq },
+      },
+    });
+    await tick();
+    ws.push({
+      v: PROTOCOL_VERSION,
+      kind: 'link-close',
+      src: 'dev-b',
+      payload: { reason: 'transport-timeout' },
+    });
+    await tick();
+    await establishInboundReliableLink(h, 'remote-stream');
+
+    ws.bufferedAmount = MAX_TRANSPORT_WEBSOCKET_BUFFERED_BYTES;
+    expect(() => h.client.sendInvokeResult('dev-b', 'probe', { ok: true, result: 0 })).toThrow(
+      expect.objectContaining({ code: 'BACKPRESSURE' }),
+    );
+
+    ws.bufferedAmount = 0;
+    h.client.sendInvokeResult('dev-b', 'probe-0', { ok: true, result: 0 });
+    h.client.sendInvokeResult('dev-b', 'probe-1', { ok: true, result: 1 });
+    const before = framesSent(ws);
+    ws.bufferedAmount = MAX_TRANSPORT_WEBSOCKET_BUFFERED_BYTES;
+    expect(() => h.client.sendInvokeResult('dev-b', 'held', { ok: true, result: 2 })).not.toThrow();
+    expect(framesSent(ws)).toBe(before);
+
+    h.client.stop();
+  }, 10_000);
+
   it('恢复期内部分写出的分片也计入探测预算', async () => {
     const h = makeHarness({
       timing: {

--- a/packages/device-link/src/__tests__/client.test.ts
+++ b/packages/device-link/src/__tests__/client.test.ts
@@ -4795,6 +4795,54 @@ describe('定时重发的单趟预算(TRANSPORT_RETRY_PASS_BUDGET)', () => {
     h.client.stop();
   }, 10_000);
 
+  it('空队列恢复后新入队流量仍走探测预算', async () => {
+    const h = makeHarness({
+      timing: {
+        pingIntervalMs: 60_000,
+        transportRetryIntervalMs: 60_000,
+        transportRetryPassBudget: 2,
+        transportMaxRetryAttempts: 50,
+      },
+    });
+    h.client.start();
+    await tick();
+    h.current().ack();
+    await establishInboundReliableLink(h, 'remote-stream');
+
+    h.client.sendInvokeResult('dev-b', 'warmup', { ok: true, result: 0 });
+    const ws = h.current();
+    const warmup = parseTransportPayload(
+      ws.sent.find((env) => env.kind === 'invoke-result' && parseTransportPayload(env.payload))!.payload,
+    )!;
+    ws.push({
+      v: PROTOCOL_VERSION,
+      kind: 'push',
+      src: 'dev-b',
+      payload: {
+        channel: DEVICE_LINK_TRANSPORT_ACK_CHANNEL,
+        payload: { streamId: warmup.meta.streamId, ackSeq: warmup.meta.seq },
+      },
+    });
+    await tick();
+
+    ws.push({
+      v: PROTOCOL_VERSION,
+      kind: 'link-close',
+      src: 'dev-b',
+      payload: { reason: 'transport-timeout' },
+    });
+    await tick();
+    await establishInboundReliableLink(h, 'remote-stream');
+
+    const before = framesSent(ws);
+    for (let i = 0; i < 7; i += 1) {
+      h.client.sendInvokeResult('dev-b', `after-${i}`, { ok: true, result: i });
+    }
+    expect(framesSent(ws)).toBe(before + 2);
+
+    h.client.stop();
+  }, 10_000);
+
   it('恢复探测未 ACK 时定时器仍重发已发出的探针,不放行新帧', async () => {
     await withFakeTimers(async (h, advance) => {
       for (let i = 0; i < 7; i += 1) {

--- a/packages/device-link/src/__tests__/client.test.ts
+++ b/packages/device-link/src/__tests__/client.test.ts
@@ -4897,6 +4897,66 @@ describe('定时重发的单趟预算(TRANSPORT_RETRY_PASS_BUDGET)', () => {
     h.client.stop();
   }, 10_000);
 
+  it('已发探针被驱逐后恢复期允许再发一帧换 ACK', async () => {
+    const h = makeHarness({
+      timing: {
+        pingIntervalMs: 60_000,
+        transportRetryIntervalMs: 60_000,
+        transportRetryPassBudget: 2,
+        transportMaxRetryAttempts: 50,
+      },
+    });
+    h.client.start();
+    await tick();
+    h.current().ack();
+    await establishInboundReliableLink(h, 'remote-stream');
+
+    h.client.sendInvokeResult('dev-b', 'warmup', { ok: true, result: 0 });
+    const ws = h.current();
+    const warmup = parseTransportPayload(
+      ws.sent.find((env) => env.kind === 'invoke-result' && parseTransportPayload(env.payload))!.payload,
+    )!;
+    ws.push({
+      v: PROTOCOL_VERSION,
+      kind: 'push',
+      src: 'dev-b',
+      payload: {
+        channel: DEVICE_LINK_TRANSPORT_ACK_CHANNEL,
+        payload: { streamId: warmup.meta.streamId, ackSeq: warmup.meta.seq },
+      },
+    });
+    await tick();
+    ws.push({
+      v: PROTOCOL_VERSION,
+      kind: 'link-close',
+      src: 'dev-b',
+      payload: { reason: 'transport-timeout' },
+    });
+    await tick();
+    await establishInboundReliableLink(h, 'remote-stream');
+
+    h.client.sendInvokeResult('dev-b', 'probe-0', { ok: true, result: 0 });
+    h.client.sendInvokeResult('dev-b', 'probe-1', { ok: true, result: 1 });
+    const internals = h.client as unknown as {
+      peerTransport: Map<string, {
+        pending: Map<number, { sent: boolean; bytes: number }>;
+        pendingBytes: number;
+      }>;
+    };
+    const peer = internals.peerTransport.get('dev-b')!;
+    for (const [seq, pending] of [...peer.pending]) {
+      if (!pending.sent) continue;
+      peer.pending.delete(seq);
+      peer.pendingBytes -= pending.bytes;
+    }
+
+    const before = framesSent(ws);
+    h.client.sendInvokeResult('dev-b', 'reprobe', { ok: true, result: 2 });
+    expect(framesSent(ws)).toBe(before + 1);
+
+    h.client.stop();
+  }, 10_000);
+
   it('恢复期内部分写出的分片也计入探测预算', async () => {
     const h = makeHarness({
       timing: {

--- a/packages/device-link/src/__tests__/client.test.ts
+++ b/packages/device-link/src/__tests__/client.test.ts
@@ -4677,9 +4677,37 @@ describe('定时重发的单趟预算(TRANSPORT_RETRY_PASS_BUDGET)', () => {
     const ws = h.current();
     expect(retriedSeqs(sendsBySeq(ws))).toEqual([]);
 
-    await establishInboundReliableLink(h, 'remote-stream-2');
+    await establishInboundReliableLink(h, 'remote-stream');
     await tick();
     expect(retriedSeqs(sendsBySeq(ws))).toEqual([]);
+
+    h.client.stop();
+  }, 10_000);
+
+  it('对端换 stream 视为真正恢复,按探测预算 replay', async () => {
+    const h = makeHarness({
+      timing: {
+        pingIntervalMs: 60_000,
+        transportRetryIntervalMs: 60_000,
+        transportRetryPassBudget: 2,
+        transportMaxRetryAttempts: 50,
+      },
+    });
+    h.client.start();
+    await tick();
+    h.current().ack();
+    await establishInboundReliableLink(h, 'remote-stream');
+
+    for (let i = 0; i < 7; i += 1) {
+      h.client.sendInvokeResult('dev-b', `req-${i}`, { ok: true, result: i });
+    }
+    const ws = h.current();
+    const seqs = [...sendsBySeq(ws).keys()].sort((a, b) => a - b);
+    expect(retriedSeqs(sendsBySeq(ws))).toEqual([]);
+
+    await establishInboundReliableLink(h, 'remote-stream-restarted');
+    await tick();
+    expect(retriedSeqs(sendsBySeq(ws))).toEqual(seqs.slice(0, 2));
 
     h.client.stop();
   }, 10_000);
@@ -4730,6 +4758,59 @@ describe('定时重发的单趟预算(TRANSPORT_RETRY_PASS_BUDGET)', () => {
     expect(retriedSeqs(sendsBySeq(ws))).toEqual([...seqs.slice(0, 2), ...seqs.slice(2, 4)]);
 
     h.client.stop();
+  }, 10_000);
+
+  it('恢复探测未 ACK 时定时器仍重发已发出的探针,不放行新帧', async () => {
+    await withFakeTimers(async (h, advance) => {
+      for (let i = 0; i < 7; i += 1) {
+        h.client.sendInvokeResult('dev-b', `req-${i}`, { ok: true, result: i });
+      }
+      const ws = h.current();
+      const seqs = [...sendsBySeq(ws).keys()].sort((a, b) => a - b);
+      const internals = h.client as unknown as {
+        peerTransport: Map<string, { linkReady: boolean }>;
+      };
+      internals.peerTransport.get('dev-b')!.linkReady = false;
+
+      const id = `inbound-link-${++inboundLinkId}`;
+      const off = h.client.onFrame((env) => {
+        if (env.kind !== 'link-open' || env.id !== id || !env.src) return;
+        h.client.sendLinkAccept(env.src, env.id, {
+          appVersion: '1',
+          allowlistHash: 'hash',
+        });
+      });
+      h.current().push({
+        v: PROTOCOL_VERSION,
+        kind: 'link-open',
+        id,
+        src: 'dev-b',
+        payload: {
+          controllerName: 'Remote',
+          protocolVersion: 1,
+          appVersion: '1',
+          capabilities: [
+            DEVICE_LINK_CAPABILITY_RELIABLE_TRANSPORT,
+            DEVICE_LINK_CAPABILITY_TRANSPORT_TIMEOUT_CLOSE,
+          ],
+          transportStreamId: 'remote-stream-2',
+          transportBaseSeq: 1,
+        },
+      });
+      await advance(1);
+      off();
+      expect(retriedSeqs(sendsBySeq(ws))).toEqual(seqs.slice(0, 2));
+
+      await advance(200);
+      expect(retriedSeqs(sendsBySeq(ws))).toEqual(seqs.slice(0, 2));
+      expect(seqs.slice(0, 2).map((seq) => sendsBySeq(ws).get(seq))).toEqual([3, 3]);
+      expect(seqs.slice(2).every((seq) => sendsBySeq(ws).get(seq) === 1)).toBe(true);
+    }, {
+      pingIntervalMs: 600_000,
+      transportRetryIntervalMs: 200,
+      transportRetryPassBudget: 2,
+      transportMaxRetryAttempts: 50,
+    });
   }, 10_000);
 
   it('多 peer 拓扑:一个 peer 停止 ACK 被限流,另一个 peer 的投递零感知', async () => {

--- a/packages/device-link/src/__tests__/client.test.ts
+++ b/packages/device-link/src/__tests__/client.test.ts
@@ -4843,6 +4843,68 @@ describe('定时重发的单趟预算(TRANSPORT_RETRY_PASS_BUDGET)', () => {
     h.client.stop();
   }, 10_000);
 
+  it('恢复期内部分写出的分片也计入探测预算', async () => {
+    const h = makeHarness({
+      timing: {
+        pingIntervalMs: 60_000,
+        transportRetryIntervalMs: 60_000,
+        transportRetryPassBudget: 3,
+        transportMaxRetryAttempts: 50,
+      },
+    });
+    h.client.start();
+    await tick();
+    h.current().ack();
+    await establishInboundReliableLink(h, 'remote-stream');
+
+    h.client.sendInvokeResult('dev-b', 'warmup', { ok: true, result: 0 });
+    const ws = h.current();
+    const warmup = parseTransportPayload(
+      ws.sent.find((env) => env.kind === 'invoke-result' && parseTransportPayload(env.payload))!.payload,
+    )!;
+    ws.push({
+      v: PROTOCOL_VERSION,
+      kind: 'push',
+      src: 'dev-b',
+      payload: {
+        channel: DEVICE_LINK_TRANSPORT_ACK_CHANNEL,
+        payload: { streamId: warmup.meta.streamId, ackSeq: warmup.meta.seq },
+      },
+    });
+    await tick();
+    ws.push({
+      v: PROTOCOL_VERSION,
+      kind: 'link-close',
+      src: 'dev-b',
+      payload: { reason: 'transport-timeout' },
+    });
+    await tick();
+    await establishInboundReliableLink(h, 'remote-stream');
+
+    const before = framesSent(ws);
+    const origSend = ws.send.bind(ws);
+    let reliableFrames = 0;
+    ws.send = (data: string) => {
+      const env = JSON.parse(data) as Envelope;
+      if (env.kind === 'invoke-result' && parseTransportPayload(env.payload)) {
+        reliableFrames += 1;
+        if (reliableFrames >= 2) throw new Error('socket raced');
+      }
+      origSend(data);
+    };
+    const chunky = 'x'.repeat(2 * 128 * 1024 + 1_000);
+    h.client.sendInvokeResult('dev-b', 'partial', { ok: true, result: chunky });
+    expect(framesSent(ws)).toBe(before + 1);
+
+    ws.send = origSend;
+    for (let i = 0; i < 5; i += 1) {
+      h.client.sendInvokeResult('dev-b', `after-${i}`, { ok: true, result: i });
+    }
+    expect(framesSent(ws)).toBe(before + 3);
+
+    h.client.stop();
+  }, 10_000);
+
   it('恢复探测未 ACK 时定时器仍重发已发出的探针,不放行新帧', async () => {
     await withFakeTimers(async (h, advance) => {
       for (let i = 0; i < 7; i += 1) {

--- a/packages/device-link/src/client.ts
+++ b/packages/device-link/src/client.ts
@@ -2334,7 +2334,7 @@ export class DeviceLinkClient {
     peer.pending.set(seq, pending);
     peer.pendingBytes += reservedBytes;
     peer.nextSeq = seq + 1;
-    if (peer.linkReady && !this.shouldHoldRecoverySend(peer)) {
+    if (peer.linkReady && !this.shouldHoldRecoverySend(peer, this.estimateReliableFrameCount(pending))) {
       try {
         const sentFrames = this.sendReliableFrames(peer, pending);
         this.noteRecoveryFrames(peer, sentFrames);
@@ -2865,7 +2865,7 @@ export class DeviceLinkClient {
         return;
       }
       const admittingNew = !pending.sent;
-      if (admittingNew && this.shouldHoldRecoverySend(peer)) break;
+      if (admittingNew && this.shouldHoldRecoverySend(peer, this.estimateReliableFrameCount(pending))) break;
       // 发送前先按预估分片数结算:已经发过东西、且这一条会超预算时,把它留到下一趟。
       // 用预估而非真实编码结果是刻意的 —— 这是流控决策,不需要精确,重新编码一条 4MB
       // 消息只为数分片数不划算;发送后再用真实帧数扣减。
@@ -2906,8 +2906,13 @@ export class DeviceLinkClient {
     return Math.max(0, budget - peer.recoveryFramesSent);
   }
 
-  private shouldHoldRecoverySend(peer: PeerTransportState): boolean {
-    return peer.recoveryNeedsAck && peer.recoveryFramesSent >= this.recoveryPassBudget();
+  private shouldHoldRecoverySend(peer: PeerTransportState, additionalFrames = 1): boolean {
+    if (!peer.recoveryNeedsAck) return false;
+    const remaining = this.remainingRecoveryBudget(peer);
+    if (remaining <= 0) return true;
+    // 本轮恢复还没发出过任何帧时,队头可以超预算(与 retryPending 一致)。
+    if (peer.recoveryFramesSent === 0) return false;
+    return additionalFrames > remaining;
   }
 
   private noteRecoveryFrames(peer: PeerTransportState, frames: number): void {

--- a/packages/device-link/src/client.ts
+++ b/packages/device-link/src/client.ts
@@ -448,6 +448,8 @@ interface PeerTransportState {
   receive: Map<string, ReceiveStreamState>;
   highestAckSeq: number;
   lastReplayEpoch: number;
+  /** 上次真正 replay 时对端的 stream。对端重启换 stream 时不能当重复 open。 */
+  lastReplayRemoteStreamId: string | null;
   /**
    * 恢复探测：link 刚恢复或刚被 DEVICE_OFFLINE 刹停后为 true。
    * 此间出站不超过 transportRetryPassBudget，直到收到可靠 ACK。
@@ -2454,6 +2456,7 @@ export class DeviceLinkClient {
         receive: new Map(),
         highestAckSeq: 0,
         lastReplayEpoch: this.connEpoch,
+        lastReplayRemoteStreamId: null,
         recoveryNeedsAck: false,
         recoveryFramesSent: 0,
         pushAdmissionDropCount: 0,
@@ -2829,7 +2832,6 @@ export class DeviceLinkClient {
       || this.stopped
       || this.status !== 'online'
     ) return;
-    if (this.shouldHoldRecoverySend(peer)) return;
     const now = Date.now();
     // pending 是按 seq 递增插入的 Map,迭代天然旧→新 —— 正是累计 ACK 需要推进的顺序。
     // 对端长期不 ACK 时预算会一直压在队头那几条上,这**不是饥饿**而是正确形状:接收端
@@ -2852,7 +2854,7 @@ export class DeviceLinkClient {
     // peer 是净损失。量级上也不是主要矛盾:线上那 449 条的形状是几 KB 级 maker:event 塞满
     // 64 槽窗口(最大簇 213),本上限已把它压到 ≤8;「队头恰好 4MB」时溢出是 ≤32,仍低于
     // 引发事故的量级。真出现这种负载时日志会给出真实形状,届时按证据设计,不先建机制。
-    const budget = this.remainingRecoveryBudget(peer);
+    const budget = this.recoveryPassBudget();
     let framesSpent = 0;
     for (const pending of peer.pending.values()) {
       if (!opts.ignoreInterval && now - pending.lastSentAt < this.timing.transportRetryIntervalMs) {
@@ -2862,6 +2864,8 @@ export class DeviceLinkClient {
         this.handleReliableRetryExhausted(dst, pending.seq);
         return;
       }
+      const admittingNew = !pending.sent;
+      if (admittingNew && this.shouldHoldRecoverySend(peer)) break;
       // 发送前先按预估分片数结算:已经发过东西、且这一条会超预算时,把它留到下一趟。
       // 用预估而非真实编码结果是刻意的 —— 这是流控决策,不需要精确,重新编码一条 4MB
       // 消息只为数分片数不划算;发送后再用真实帧数扣减。
@@ -2874,7 +2878,7 @@ export class DeviceLinkClient {
         break;
       }
       framesSpent += Math.max(1, sentFrames);
-      this.noteRecoveryFrames(peer, sentFrames);
+      if (admittingNew) this.noteRecoveryFrames(peer, sentFrames);
       if (framesSpent >= budget) break;
     }
   }
@@ -2907,12 +2911,13 @@ export class DeviceLinkClient {
   }
 
   /**
-   * 同连接代、链路已 ready 的重复 link-open 只重发 accept,不再全量 replay、
-   * 也不重置 attempts。真正从 not-ready 恢复时进入探测预算。
+   * 同连接代、同对端 stream、链路已 ready 的重复 link-open 只重发 accept。
+   * 对端重启会换 transportStreamId，必须当真正恢复。
    */
   private completeReliableLinkResume(dst: string, peer: PeerTransportState): void {
     const wasReady = peer.linkReady;
-    const duplicateOpen = wasReady && peer.lastReplayEpoch === this.connEpoch;
+    const streamChanged = peer.lastReplayRemoteStreamId !== peer.remoteStreamId;
+    const duplicateOpen = wasReady && !streamChanged && peer.lastReplayEpoch === this.connEpoch;
     peer.linkReady = true;
     this.staleLinkNotifiedAt.delete(dst);
     this.resumeReceiveStreams(dst, peer);
@@ -2921,12 +2926,13 @@ export class DeviceLinkClient {
       return;
     }
     peer.lastReplayEpoch = this.connEpoch;
-    const enterRecovery = !wasReady && (peer.pending.size > 0 || peer.recoveryNeedsAck);
+    peer.lastReplayRemoteStreamId = peer.remoteStreamId;
+    const enterRecovery = (!wasReady || streamChanged) && (peer.pending.size > 0 || peer.recoveryNeedsAck);
     if (enterRecovery) {
       peer.recoveryNeedsAck = true;
       peer.recoveryFramesSent = 0;
     }
-    this.replayPending(dst, !wasReady);
+    this.replayPending(dst, !wasReady || streamChanged);
   }
 
   private logRecoverySend(

--- a/packages/device-link/src/client.ts
+++ b/packages/device-link/src/client.ts
@@ -2916,12 +2916,20 @@ export class DeviceLinkClient {
     return Math.max(0, budget - peer.recoveryFramesSent);
   }
 
+  private hasOutstandingRecoveryProbe(peer: PeerTransportState): boolean {
+    for (const pending of peer.pending.values()) {
+      if (pending.sent) return true;
+    }
+    return false;
+  }
+
   private shouldHoldRecoverySend(peer: PeerTransportState, additionalFrames = 1): boolean {
     if (!peer.recoveryNeedsAck) return false;
+    // hold 的前提是已有在途探针能换来 ACK。latest-wins / TTL 清掉全部已发探针后,
+    // 若仍按 recoveryFramesSent 卡住,队列只剩未发帧,恢复态永远解不开。
+    if (!this.hasOutstandingRecoveryProbe(peer)) return false;
     const remaining = this.remainingRecoveryBudget(peer);
     if (remaining <= 0) return true;
-    // 本轮恢复还没发出过任何帧时,队头可以超预算(与 retryPending 一致)。
-    if (peer.recoveryFramesSent === 0) return false;
     return additionalFrames > remaining;
   }
 

--- a/packages/device-link/src/client.ts
+++ b/packages/device-link/src/client.ts
@@ -2354,7 +2354,10 @@ export class DeviceLinkClient {
     return true;
   }
 
-  /** @returns 实际写进 ws 的**帧**数(一条逻辑消息可能分多帧);抛错时为已写出的帧数。 */
+  /**
+   * 实际写进 ws 的**帧**数(一条逻辑消息可能分多帧)。
+   * 一分片都没写出才抛;中途竞态只返回已上网的帧数,让恢复预算能结算部分突发。
+   */
   private sendReliableFrames(peer: PeerTransportState, pending: PendingReliableMessage): number {
     const frames = encodeReliableFrames(
       pending.envelope,
@@ -2370,6 +2373,12 @@ export class DeviceLinkClient {
         pending.sent = true;
         sent += 1;
       }
+    } catch (err) {
+      if (sent === 0) throw err;
+      this.log.debug(
+        `reliable transport send interrupted after ${sent} frame(s) for seq=${pending.seq}`,
+        err,
+      );
     } finally {
       if (sent > 0) {
         pending.sent = true;

--- a/packages/device-link/src/client.ts
+++ b/packages/device-link/src/client.ts
@@ -2935,9 +2935,13 @@ export class DeviceLinkClient {
       this.logRecoverySend(dst, peer, 'link-replay', true);
       return;
     }
+    const hadPriorResume = peer.lastReplayRemoteStreamId !== null;
     peer.lastReplayEpoch = this.connEpoch;
     peer.lastReplayRemoteStreamId = peer.remoteStreamId;
-    const enterRecovery = (!wasReady || streamChanged) && (peer.pending.size > 0 || peer.recoveryNeedsAck);
+    // 真正恢复不依赖当时队列是否有积压:abandon / transport-timeout 可能已清空
+    // pending。首次建链(还没 resume 过)保持原语义,空队列不进探测。
+    const enterRecovery = (!wasReady || streamChanged)
+      && (hadPriorResume || peer.pending.size > 0 || peer.recoveryNeedsAck);
     if (enterRecovery) {
       peer.recoveryNeedsAck = true;
       peer.recoveryFramesSent = 0;

--- a/packages/device-link/src/client.ts
+++ b/packages/device-link/src/client.ts
@@ -2284,11 +2284,12 @@ export class DeviceLinkClient {
       peer.pending.size < MAX_TRANSPORT_PENDING_MESSAGES
       && peer.pendingBytes + reservedBytes <= MAX_TRANSPORT_PENDING_BYTES
     );
-    // link 已 ready 时,native send buffer 满就在**任何驱逐/腾位之前**拒绝:
-    // 该帧本轮注定入不了队,先驱逐再拒绝会在连续调用下逐步清空本可重试的
-    // 镜像历史,却一帧未纳(review P1)。link 未恢复时不检——帧只进有界
-    // pending 等重放,不触碰 socket。
-    if (peer.linkReady) {
+    // socket 容量预检只服务「本轮会写出」的帧。恢复期被 hold 的消息只进
+    // pending,不碰共享 ws;其它 peer 占满 send buffer 不得让它 BACKPRESSURE。
+    // 真会发送时仍在驱逐/腾位之前预检(旧 P1:先驱逐再拒会清空镜像历史)。
+    const additionalFrames = Math.max(1, frames.length);
+    const willSendNow = peer.linkReady && !this.shouldHoldRecoverySend(peer, additionalFrames);
+    if (willSendNow) {
       this.assertWebSocketCapacity(this.measureReliableFrames(frames));
     }
     if (!hasPendingCapacity()) {
@@ -2334,7 +2335,7 @@ export class DeviceLinkClient {
     peer.pending.set(seq, pending);
     peer.pendingBytes += reservedBytes;
     peer.nextSeq = seq + 1;
-    if (peer.linkReady && !this.shouldHoldRecoverySend(peer, this.estimateReliableFrameCount(pending))) {
+    if (willSendNow) {
       try {
         const sentFrames = this.sendReliableFrames(peer, pending);
         this.noteRecoveryFrames(peer, sentFrames);

--- a/packages/device-link/src/client.ts
+++ b/packages/device-link/src/client.ts
@@ -2878,7 +2878,12 @@ export class DeviceLinkClient {
         break;
       }
       framesSpent += Math.max(1, sentFrames);
-      if (admittingNew) this.noteRecoveryFrames(peer, sentFrames);
+      // 首趟恢复 replay(ignoreInterval)要把已在途的探针也记进预算,
+      // 否则 sent===true 的重放不占额度,新入队帧还能再灌一整批。
+      // 后续定时重发只给新帧记账,同一批探针可继续重传。
+      if (admittingNew || (peer.recoveryNeedsAck && opts.ignoreInterval)) {
+        this.noteRecoveryFrames(peer, sentFrames);
+      }
       if (framesSpent >= budget) break;
     }
   }

--- a/packages/device-link/src/client.ts
+++ b/packages/device-link/src/client.ts
@@ -217,8 +217,8 @@ export interface DeviceLinkTiming {
   /** 单个连接世代内的最大发送次数；耗尽后主动重连并在新世代继续。 */
   transportMaxRetryAttempts: number;
   /**
-   * **定时器驱动**的单趟重发条数上限（理由与线上证据见
-   * TRANSPORT_RETRY_PASS_BUDGET）。link 重建后的 replay 不受此限。
+   * 单趟恢复/重发帧预算（理由与线上证据见 TRANSPORT_RETRY_PASS_BUDGET）。
+   * 定时重发、link 重建 replay、恢复期内的首发共用；不再给 replay 无限额度。
    */
   transportRetryPassBudget: number;
   /** presence fire-and-forget 帧命中 WebSocket 背压后的合并重试间隔。 */
@@ -240,10 +240,16 @@ export interface DeviceLinkTiming {
    * 断连恰恰常发生在「在线很久 → 出站洪峰 → 被踢」之后——若冷却随稳定期
    * 归零,客户端会以 1s 级节奏反复「重连 → 全量重放洪峰 → 再被踢」
    * (2026-08-08 线上:两次 1013 间隔仅 15s,第二条连接只活了 7s)。
-   * 连续拥塞计数同样只在稳定在线一个 reconnectStableResetMs 后清零。
+   * 连续拥塞计数只在稳定在线满 congestionStableResetMs 后清零——现场 1013
+   * 间隔常是数分钟，若与 10s 的普通稳定窗共用，streak 永远回 1。
    */
   congestionBackoffBaseMs: number;
   congestionBackoffMaxMs: number;
+  /**
+   * 拥塞连击清零所需的稳定在线时长。与 reconnectStableResetMs 刻意分开：
+   * 普通退避 10s 即可恢复快速重连；拥塞冷却必须跨过现场 3–8 分钟一踢的间隔。
+   */
+  congestionStableResetMs: number;
 }
 
 const DEFAULT_TIMING: DeviceLinkTiming = {
@@ -262,6 +268,7 @@ const DEFAULT_TIMING: DeviceLinkTiming = {
   stalledLinkPendingMaxAgeMs: 60_000,
   congestionBackoffBaseMs: 5_000,
   congestionBackoffMaxMs: 30_000,
+  congestionStableResetMs: 15 * 60_000,
 };
 
 /**
@@ -274,6 +281,14 @@ function normalizeRetryPassBudget(value: number | undefined): number {
   if (typeof value !== 'number' || !Number.isFinite(value)) return TRANSPORT_RETRY_PASS_BUDGET;
   const floored = Math.floor(value);
   return floored >= 1 ? floored : TRANSPORT_RETRY_PASS_BUDGET;
+}
+
+function normalizeCongestionStableResetMs(value: number | undefined): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return DEFAULT_TIMING.congestionStableResetMs;
+  }
+  const floored = Math.floor(value);
+  return floored >= 1 ? floored : DEFAULT_TIMING.congestionStableResetMs;
 }
 
 /**
@@ -433,6 +448,13 @@ interface PeerTransportState {
   receive: Map<string, ReceiveStreamState>;
   highestAckSeq: number;
   lastReplayEpoch: number;
+  /**
+   * 恢复探测：link 刚恢复或刚被 DEVICE_OFFLINE 刹停后为 true。
+   * 此间出站不超过 transportRetryPassBudget，直到收到可靠 ACK。
+   */
+  recoveryNeedsAck: boolean;
+  /** 本轮恢复探测已写出的帧数（含 replay 与恢复期内首发）。 */
+  recoveryFramesSent: number;
   /** latest-wins 腾位驱逐的聚合计数(自上次告警起),仅服务日志聚合。 */
   pushAdmissionDropCount: number;
   /** 上次输出 latest-wins 驱逐告警的单调时刻;0 表示从未输出。 */
@@ -483,14 +505,15 @@ export class DeviceLinkClient {
   /**
    * 连续 relay 拥塞断连(1013)计数,驱动重连冷却下限(computeReconnectDelayMs)。
    * 与 reconnectAttempt 生命周期刻意不同:attempt 在稳定在线后归零以恢复快速
-   * 重连,本计数只在稳定在线满 reconnectStableResetMs 后清零——拥塞信号不因
-   * 「重连握手成功」而失效,否则回到「重连 → 重放洪峰 → 再被踢」的紧循环。
+   * 重连,本计数只在稳定在线满 congestionStableResetMs 后清零——拥塞信号不因
+   * 「重连握手成功」或短稳定窗而失效,否则现场数分钟一踢时 streak 永远是 1。
    * connectNow / restartConnection(用户显式等待的前台恢复/唤醒)清 attempt
    * 但不清本计数:立即重连可以,但若再被踢,冷却按更深一档生效。
    */
   private congestionCloseStreak = 0;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private reconnectStableTimer: ReturnType<typeof setTimeout> | null = null;
+  private congestionStableTimer: ReturnType<typeof setTimeout> | null = null;
   private handshakeTimer: ReturnType<typeof setTimeout> | null = null;
   /** 连续握手超时次数;任一次 hello-ack 上线即复位(驱动握手窗口自适应放宽)。 */
   private handshakeTimeoutStreak = 0;
@@ -1016,14 +1039,7 @@ export class DeviceLinkClient {
     // 对端已重开链路:若仍有待重发的 transport-timeout 通知,不再需要。
     this.cancelTimeoutCloseNotify(dst);
     if (peerSupportsReliable) {
-      const resumedLink = !peer.linkReady;
-      peer.linkReady = true;
-      // link 恢复即清 before-link 通知节流:节流只该覆盖「同一次尚未恢复的中断」,
-      // 否则恢复后 30s 内再次丢 link-accept 时新帧全被节流掉,host 的唯一恢复出口
-      // 不再入队,第二次自愈最坏被推迟整个窗口(review P2)。
-      this.staleLinkNotifiedAt.delete(dst);
-      this.resumeReceiveStreams(dst, peer);
-      this.replayPending(dst, resumedLink);
+      this.completeReliableLinkResume(dst, peer);
     }
   }
 
@@ -1340,6 +1356,8 @@ export class DeviceLinkClient {
     this.clearPendingPresence();
     for (const peer of this.peerTransport.values()) {
       peer.linkReady = false;
+      peer.recoveryNeedsAck = true;
+      peer.recoveryFramesSent = 0;
       if (peer.retryTimer) {
         clearInterval(peer.retryTimer);
         peer.retryTimer = null;
@@ -1486,6 +1504,10 @@ export class DeviceLinkClient {
     if (this.reconnectStableTimer) {
       clearTimeout(this.reconnectStableTimer);
       this.reconnectStableTimer = null;
+    }
+    if (this.congestionStableTimer) {
+      clearTimeout(this.congestionStableTimer);
+      this.congestionStableTimer = null;
     }
     if (this.handshakeTimer) {
       clearTimeout(this.handshakeTimer);
@@ -1688,6 +1710,7 @@ export class DeviceLinkClient {
         this.setStatus('online');
         if (!wasOnline) this.onlineSinceAt = Date.now();
         this.armReconnectStableReset();
+        this.armCongestionStableReset();
         this.startHeartbeat();
         // 重复 hello-ack(已在线还收到 ack)单独判别:这不是新连接,而是 relay 在同一条
         // socket 上重发(relay 侧恢复 / 迁移)。若与真实重连共用同一条 online 日志,
@@ -1729,17 +1752,12 @@ export class DeviceLinkClient {
               'outbound-accept',
             );
             const peer = this.getPeerTransport(env.src);
-            const resumedLink = !peer.linkReady;
-            peer.linkReady = true;
             peer.outboundExplicitlyClosed = false;
-            // 见 sendLinkAccept 同处注释:link 恢复即清 before-link 通知节流。
-            this.staleLinkNotifiedAt.delete(env.src);
             // 注意:不得在此将 linkAcceptedInbound 改回 false。互控场景下本机可能
             // 既是对端的被控端(入站已 accept)又是其控制端(本帧 accept 出站
             // link),两个方向共享同一份 PeerTransportState——覆盖会让入站方向
             // 的重试耗尽误拆整条共享 relay(字段注释有完整语义)。
-            this.resumeReceiveStreams(env.src, peer);
-            this.replayPending(env.src, resumedLink);
+            this.completeReliableLinkResume(env.src, peer);
           }
           this.pending.delete(env.id!);
           p.resolve(env);
@@ -1777,6 +1795,8 @@ export class DeviceLinkClient {
         if (payload.dst && terminalRouteFailure) {
           const peer = this.getPeerTransport(payload.dst);
           peer.linkReady = false;
+          peer.recoveryNeedsAck = true;
+          peer.recoveryFramesSent = 0;
           if (peer.retryTimer) {
             clearInterval(peer.retryTimer);
             peer.retryTimer = null;
@@ -1804,7 +1824,10 @@ export class DeviceLinkClient {
             at: Date.now(),
           });
         }
-        this.log.warn(`relay-error: [${payload.code}] ${payload.message}`);
+        this.log.warn(
+          `relay-error: [${payload.code}] ${payload.message}`
+          + (payload.dst ? ` dst=${payload.dst.slice(0, 8)}` : ''),
+        );
         return this.emitFrame(env);
       }
       default:
@@ -2309,9 +2332,10 @@ export class DeviceLinkClient {
     peer.pending.set(seq, pending);
     peer.pendingBytes += reservedBytes;
     peer.nextSeq = seq + 1;
-    if (peer.linkReady) {
+    if (peer.linkReady && !this.shouldHoldRecoverySend(peer)) {
       try {
-        this.sendReliableFrames(peer, pending);
+        const sentFrames = this.sendReliableFrames(peer, pending);
+        this.noteRecoveryFrames(peer, sentFrames);
       } catch (err) {
         // 容量预检后的 ws.send 仍可能因 socket 竞态失败。完全未写入时安全回滚；
         // 已部分写入则保留同 seq 等待重放，调用方继续等待，不制造重复请求。
@@ -2430,6 +2454,8 @@ export class DeviceLinkClient {
         receive: new Map(),
         highestAckSeq: 0,
         lastReplayEpoch: this.connEpoch,
+        recoveryNeedsAck: false,
+        recoveryFramesSent: 0,
         pushAdmissionDropCount: 0,
         pushAdmissionDropLogAt: 0,
       };
@@ -2613,6 +2639,11 @@ export class DeviceLinkClient {
       peer.pending.delete(seq);
       peer.pendingBytes -= pending.bytes;
     }
+    if (peer.recoveryNeedsAck) {
+      peer.recoveryNeedsAck = false;
+      peer.recoveryFramesSent = 0;
+      this.retryPending(src, { ignoreInterval: true });
+    }
     if (peer.pending.size === 0 && peer.retryTimer) {
       clearInterval(peer.retryTimer);
       peer.retryTimer = null;
@@ -2775,23 +2806,20 @@ export class DeviceLinkClient {
     const peer = this.getPeerTransport(dst);
     if (peer.retryTimer) return;
     peer.retryTimer = setInterval(
-      () => this.retryPending(dst, { ignoreInterval: false, unlimited: false }),
+      () => this.retryPending(dst, { ignoreInterval: false }),
       this.timing.transportRetryIntervalMs,
     );
   }
 
   /**
-   * 一趟重发。两个开关**刻意分开**——它们是两个独立的量,合成一个 `force` 会让「生成
-   * skip 占位」这类既不证明可达性、又需要立刻发出的路径顺带拿到无限预算(codex P2):
+   * 一趟重发。
    *
    * @param opts.ignoreInterval 忽略 transportRetryIntervalMs 的最小间隔,本趟立刻发。
-   * @param opts.unlimited 不受单趟帧预算约束。**只有可达性刚被证明的路径才配**:收到
-   *   对端 link-accept 后的 replayPending。其余一切(定时器、skip 占位替换)都必须
-   *   受预算约束(理由与线上证据见 TRANSPORT_RETRY_PASS_BUDGET)。
+   * 单趟额度一律走 remainingRecoveryBudget,不再接受无限额度。
    */
   private retryPending(
     dst: string,
-    opts: { ignoreInterval: boolean; unlimited: boolean },
+    opts: { ignoreInterval: boolean },
   ): void {
     const peer = this.peerTransport.get(dst);
     if (
@@ -2801,6 +2829,7 @@ export class DeviceLinkClient {
       || this.stopped
       || this.status !== 'online'
     ) return;
+    if (this.shouldHoldRecoverySend(peer)) return;
     const now = Date.now();
     // pending 是按 seq 递增插入的 Map,迭代天然旧→新 —— 正是累计 ACK 需要推进的顺序。
     // 对端长期不 ACK 时预算会一直压在队头那几条上,这**不是饥饿**而是正确形状:接收端
@@ -2823,9 +2852,7 @@ export class DeviceLinkClient {
     // peer 是净损失。量级上也不是主要矛盾:线上那 449 条的形状是几 KB 级 maker:event 塞满
     // 64 槽窗口(最大簇 213),本上限已把它压到 ≤8;「队头恰好 4MB」时溢出是 ≤32,仍低于
     // 引发事故的量级。真出现这种负载时日志会给出真实形状,届时按证据设计,不先建机制。
-    const budget = opts.unlimited
-      ? Number.POSITIVE_INFINITY
-      : normalizeRetryPassBudget(this.timing.transportRetryPassBudget);
+    const budget = this.remainingRecoveryBudget(peer);
     let framesSpent = 0;
     for (const pending of peer.pending.values()) {
       if (!opts.ignoreInterval && now - pending.lastSentAt < this.timing.transportRetryIntervalMs) {
@@ -2847,6 +2874,7 @@ export class DeviceLinkClient {
         break;
       }
       framesSpent += Math.max(1, sentFrames);
+      this.noteRecoveryFrames(peer, sentFrames);
       if (framesSpent >= budget) break;
     }
   }
@@ -2857,6 +2885,63 @@ export class DeviceLinkClient {
    */
   private estimateReliableFrameCount(pending: PendingReliableMessage): number {
     return Math.max(1, Math.ceil(pending.bytes / MAX_TRANSPORT_CHUNK_BYTES));
+  }
+
+  private recoveryPassBudget(): number {
+    return normalizeRetryPassBudget(this.timing.transportRetryPassBudget);
+  }
+
+  private remainingRecoveryBudget(peer: PeerTransportState): number {
+    const budget = this.recoveryPassBudget();
+    if (!peer.recoveryNeedsAck) return budget;
+    return Math.max(0, budget - peer.recoveryFramesSent);
+  }
+
+  private shouldHoldRecoverySend(peer: PeerTransportState): boolean {
+    return peer.recoveryNeedsAck && peer.recoveryFramesSent >= this.recoveryPassBudget();
+  }
+
+  private noteRecoveryFrames(peer: PeerTransportState, frames: number): void {
+    if (!peer.recoveryNeedsAck || frames <= 0) return;
+    peer.recoveryFramesSent += frames;
+  }
+
+  /**
+   * 同连接代、链路已 ready 的重复 link-open 只重发 accept,不再全量 replay、
+   * 也不重置 attempts。真正从 not-ready 恢复时进入探测预算。
+   */
+  private completeReliableLinkResume(dst: string, peer: PeerTransportState): void {
+    const wasReady = peer.linkReady;
+    const duplicateOpen = wasReady && peer.lastReplayEpoch === this.connEpoch;
+    peer.linkReady = true;
+    this.staleLinkNotifiedAt.delete(dst);
+    this.resumeReceiveStreams(dst, peer);
+    if (duplicateOpen) {
+      this.logRecoverySend(dst, peer, 'link-replay', true);
+      return;
+    }
+    peer.lastReplayEpoch = this.connEpoch;
+    const enterRecovery = !wasReady && (peer.pending.size > 0 || peer.recoveryNeedsAck);
+    if (enterRecovery) {
+      peer.recoveryNeedsAck = true;
+      peer.recoveryFramesSent = 0;
+    }
+    this.replayPending(dst, !wasReady);
+  }
+
+  private logRecoverySend(
+    dst: string,
+    peer: PeerTransportState,
+    trigger: 'link-replay',
+    duplicateOpen: boolean,
+  ): void {
+    this.log.info(
+      `device-link recovery dst=${dst.slice(0, 8)} trigger=${trigger}`
+      + ` pending=${peer.pending.size}/${peer.pendingBytes}`
+      + ` recoveryFrames=${peer.recoveryFramesSent}/${this.recoveryPassBudget()}`
+      + ` needsAck=${peer.recoveryNeedsAck} duplicateOpen=${duplicateOpen}`
+      + ` stream=${peer.streamId.slice(0, 8)} conn=${this.connEpoch}`,
+    );
   }
 
   private replayPending(dst: string, resumedLink = false): void {
@@ -2875,9 +2960,9 @@ export class DeviceLinkClient {
         pending.lastSentAt = 0;
       }
     }
-    // 可达性刚被对端 link-accept 证明过:本趟不限预算,尽快把积压交付出去。
-    this.retryPending(dst, { ignoreInterval: true, unlimited: true });
+    this.retryPending(dst, { ignoreInterval: true });
     this.ensureRetryTimer(dst);
+    this.logRecoverySend(dst, peer, 'link-replay', false);
   }
 
   /**
@@ -3114,11 +3199,21 @@ export class DeviceLinkClient {
       if (this.stopped || this.status !== 'online') return;
       this.reconnectAttempt = 0;
       this.shortLivedStreak = 0;
-      // 拥塞冷却与普通退避在同一稳定判据下清零:稳定在线一个窗口说明出站
-      // 速率已被 relay 接受,下一次普通断线不再背负拥塞冷却。
-      this.congestionCloseStreak = 0;
       if (this.connectionIssue?.kind === 'unstable') this.setConnectionIssue(null);
     }, this.timing.reconnectStableResetMs);
+  }
+
+  private armCongestionStableReset(): void {
+    if (this.congestionStableTimer) clearTimeout(this.congestionStableTimer);
+    if (this.congestionCloseStreak <= 0) {
+      this.congestionStableTimer = null;
+      return;
+    }
+    this.congestionStableTimer = setTimeout(() => {
+      this.congestionStableTimer = null;
+      if (this.stopped || this.status !== 'online') return;
+      this.congestionCloseStreak = 0;
+    }, normalizeCongestionStableResetMs(this.timing.congestionStableResetMs));
   }
 }
 

--- a/packages/device-link/src/transport.ts
+++ b/packages/device-link/src/transport.ts
@@ -67,8 +67,10 @@ export const TRANSPORT_MAX_RETRY_ATTEMPTS = 5;
  * 213 条 → 上限 8 条/趟）。它是**每趟**上限，不是窗口上限，不改变可靠交付语义:
  * 没发出去的消息仍在 pending 里，下一趟继续。
  *
- * **只作用于定时器驱动的趟次**:link 重建后的 replay 由收到对端 link-accept 触发，
- * 可达性刚被证明过，不受此限（见 client.replayPending）。
+ * **所有恢复发送共用这一预算**（定时重发、link 重建 replay、outbox / drain
+ * 经 sendPeerEnvelope 的首发）。对端刚 accept 只证明 inbound 到了，outbound
+ * 仍可能立刻 DEVICE_OFFLINE；再给 replay 无限额度会把同一批 pending 在反复
+ * open 之间倒很多遍。恢复态先按本预算探测，收到可靠 ACK 后再继续 drain。
  */
 export const TRANSPORT_RETRY_PASS_BUDGET = 8;
 /**


### PR DESCRIPTION
## 这次改了什么

### 摘要

8/14–8/15 远程连接再次出现比 8/08 更大的 `DEVICE_OFFLINE` 簇。根因不是「定时重发缺一个 8」，而是：**同一连接代反复 `link-open` 会 unlimited 重放同一批 pending**；`DEVICE_OFFLINE` 异步回来后 pending 还在，下一次 open 再倒一遍。

本 PR 同时做四件事：

1. 同 stream / 同连接代的重复 `link-open` 只重发 accept，不再全量 replay。
2. 真正恢复时 replay / 恢复期内首发共用 `TRANSPORT_RETRY_PASS_BUDGET`：先小批探测，可靠 ACK 后再继续 drain。
3. 1013 拥塞连击改独立稳定窗（默认 15 分钟）清零，不再被 10 秒普通重连窗洗成永远 streak=1。
4. 对端撤权后自动 recover/probe 不再 `openLink`；host 对已撤权控制端的 `closeLink` 限频。`DEVICE_OFFLINE` 日志带上 `dst`，恢复发送打聚合诊断。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：8/8 事故链一周复核（#2167 / #2185 / #2189 / #2202 / #2232 之后的第三条放大路径）
- 本 PR 包含：重复建链不再全量 replay、恢复探测预算、1013 streak 独立清零、撤权终态、可归因日志
- 明确不包含：relay 按 dst 限流、分片游标 / 跨趟续传、`listDevices` single-flight / standby 门控
- 用户可见变化：弱网 / 对端假活时恢复更慢一点（分批送达），但不应再把整条 relay 打成 1013 循环。撤权后控制端不再每 2–3 秒重开。
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter @cindy/device-link exec vitest run
结果：6 files / 199 tests passed

pnpm --filter desktop exec vitest run \
  src/main/device-link/__tests__/client 相关已在 package 内 \
  src/main/device-link/__tests__/responsivenessTracker.test.ts \
  src/main/device-link/__tests__/dispatchSendSafety.test.ts \
  src/main/device-link/__tests__/linkRecovery.test.ts
结果：44 tests passed

pnpm --filter desktop run typecheck
结果：通过

pnpm test:unit:related（run-unit-gate.sh）
结果：本 diff 相关包通过。desktop 全量里 ghostInstallReceipt.test.ts 2 条失败，干净 origin/main 同样复现，与本 PR 无关。
```

### 手工验证

不涉及。恢复洪峰需要真实 relay + 假活控制端，上线后靠 `device-link recovery` / `relay-error ... dst=` 日志复核。

### 未执行的验证

未做多端实机 1013 / 撤权重开演练。

## 多端 / 故障半径

1. **故障层**：peer 级反复 open + 恢复洪峰，以及连接级 1013 冷却被 10s 窗洗掉。
2. **动作半径**：peer 级（重复 open 不 replay、per-peer 探测预算、撤权终态）；1013 streak 仍是连接级保险丝，与故障同层。
3. **多 peer**：已有「一个 peer 停 ACK 另一个零感知」和「1013 后两个控制端对称重放」用例；新增恢复预算仍按 peer 记账。

## 风险

### 风险分类

- [x] 协议兼容
- [x] 其他：恢复发送变慢

### 影响与回滚

- 影响范围：`packages/device-link` 可靠层恢复发送；desktop host 撤权 / 熔断探测。wire 帧格式不变，只改发送节奏与日志。
- 回滚 / 降级方式：revert 本 PR。旧控制端仍可 openLink；host 侧重复 open 不再倾倒 pending。
- 存量插件影响：无

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
