### PR TITLE
fix(subagent): 修正实际模型显示与状态同步

### DIFF
--- a/apps/desktop/src/main/localDb/__tests__/subagentRuns.test.ts
+++ b/apps/desktop/src/main/localDb/__tests__/subagentRuns.test.ts
@@ -386,6 +386,56 @@ describe('durable Subagent runs', () => {
     });
   });
 
+  it('persists a synchronous completed Claude Agent result as its first observation', async () => {
+    insertMessage(
+      'claude-sync-tool-use',
+      'tool_use',
+      '{}',
+      'toolu_sync_agent',
+      900,
+    );
+
+    const orphanTerminal = await persistSubagentTaskUpdate(
+      'session-1',
+      observed(
+        {
+          provider: 'claude-code',
+          taskId: 'orphan-terminal',
+          status: 'completed',
+        },
+        { kind: 'terminal' },
+      ),
+      'claude-code',
+    );
+    expect(orphanTerminal).toBeNull();
+
+    const created = await persistSubagentTaskUpdate(
+      'session-1',
+      observed(
+        {
+          provider: 'claude-code',
+          taskId: 'agent-sync',
+          parentToolUseId: 'toolu_sync_agent',
+          status: 'completed',
+          model: 'vendor-a/model-sol',
+          usage: { totalTokens: 22_113, toolUses: 0, durationMs: 4_949 },
+          updatedAt: '1970-01-01T00:00:01.000Z',
+        },
+        { kind: 'spawn' },
+      ),
+      'claude-code',
+    );
+
+    expect(created).toMatchObject({ created: true, firstForSession: true });
+    expect(await getSubagentRunDetail('session-1', 'claude-code', created!.runId)).toMatchObject({
+      logicalAgentId: 'agent-sync',
+      parentToolUseId: 'toolu_sync_agent',
+      status: 'completed',
+      model: 'vendor-a/model-sol',
+      usage: { totalTokens: 22_113, toolUses: 0, durationMs: 4_949 },
+    });
+  });
+
   it('honors message rewind and clear boundaries without deleting audit rows', async () => {
     insertMessage('tool-use-2', 'tool_use', '{}', 'parent-tool-2', 900);
     insertMessage('tool-result-before-clear', 'tool_result', 'old result', 'parent-tool-2', 950);

--- a/apps/desktop/src/main/maker-host/__tests__/codex-subagent-config.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codex-subagent-config.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import type { ProviderView } from '@cindy/model-providers';
 
 import {
   SUBAGENT_MODEL_SETTINGS_DEFAULTS,
@@ -14,6 +15,30 @@ import { setCustomProviders } from '../active-catalog';
 
 function settings(partial: Partial<SubagentModelSettings> = {}): SubagentModelSettings {
   return { ...SUBAGENT_MODEL_SETTINGS_DEFAULTS, ...partial };
+}
+
+function providerView(
+  id: string,
+  modelId: string,
+  options: { connected?: boolean; source?: 'builtin' | 'user' } = {},
+): ProviderView {
+  return {
+    id,
+    name: id,
+    source: options.source ?? 'builtin',
+    connected: options.connected ?? true,
+    agents: ['codex'],
+    auth: { method: 'none' },
+    routing: {
+      codex: {
+        upstream: `https://${id}.invalid/v1`,
+        authStrategy: 'oauth-passthrough',
+      },
+    },
+    models: {
+      codex: [{ id: modelId, name: modelId }],
+    },
+  } as unknown as ProviderView;
 }
 
 // 默认设置注入的两个 features 段键(Cindy 策略 + spawn 模型覆盖)。
@@ -237,6 +262,74 @@ describe('resolveCodexSubagentModelFallback', () => {
 });
 
 describe('codexSubagentRuntimeModelId', () => {
+  it('resolves a provider-less native Codex model with the selector default source', () => {
+    const route = resolveCodexSubagentRouteSnapshot(
+      settings({ codex: 'gpt-5.6-terra', codexProviderId: null }),
+      undefined,
+      [
+        providerView('xd', 'gpt-5.6-terra'),
+        providerView('openai', 'gpt-5.6-terra'),
+      ],
+    );
+
+    expect(route).toEqual({
+      providerId: 'openai',
+      catalogModel: 'gpt-5.6-terra',
+      runtimeModel: 'gpt-5.6-terra',
+    });
+    expect(withoutDelegationArgs(buildCodexSubagentSpawnArgs(
+      settings({ codex: 'gpt-5.6-terra', codexProviderId: null }),
+      route,
+    ))).toEqual(['-c', 'agents.default_subagent_model="gpt-5.6-terra"']);
+  });
+
+  it('uses the connected implicit Provider rewrite for provider-less stored settings', () => {
+    setCustomProviders([{
+      id: 'implicit-rewrite-provider',
+      name: 'Implicit Rewrite Provider',
+      source: 'user',
+      agents: ['codex'],
+      auth: { method: 'apiKey' },
+      routing: {
+        codex: {
+          wireProtocol: 'openai-responses',
+          upstream: 'https://implicit-rewrite.invalid/v1',
+          authStrategy: 'api-key-header',
+          modelIdRewrite: { stripPrefix: 'route/' },
+        },
+      },
+      models: { codex: [{ id: 'route/model-a', name: 'Model A' }] },
+    } as never]);
+    try {
+      const configured = settings({ codex: 'route/model-a', codexProviderId: null });
+      const route = resolveCodexSubagentRouteSnapshot(
+        configured,
+        undefined,
+        [providerView('implicit-rewrite-provider', 'route/model-a', { source: 'user' })],
+      );
+
+      expect(route).toEqual({
+        providerId: 'implicit-rewrite-provider',
+        catalogModel: 'route/model-a',
+        runtimeModel: 'model-a',
+      });
+      expect(withoutDelegationArgs(buildCodexSubagentSpawnArgs(configured, route))).toEqual([
+        '-c',
+        'agents.default_subagent_model="model-a"',
+      ]);
+    } finally {
+      setCustomProviders([]);
+    }
+  });
+
+  it('does not resolve a provider-less route from disconnected sources', () => {
+    expect(resolveCodexSubagentRouteSnapshot(
+      settings({ codex: 'route/model-a', codexProviderId: null }),
+      undefined,
+      [providerView('disconnected-provider', 'route/model-a', { connected: false })],
+    )).toBeUndefined();
+  });
+
   it('applies an arbitrary Provider-declared model rewrite without prefix hardcoding', () => {
     setCustomProviders([{
       id: 'runtime-rewrite-provider',

--- a/apps/desktop/src/main/maker-host/__tests__/codex-subagent-config.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codex-subagent-config.test.ts
@@ -6,8 +6,11 @@ import {
 } from '../../../shared/subagentModelSettings';
 import {
   buildCodexSubagentSpawnArgs,
+  codexSubagentRuntimeModelId,
   resolveCodexSubagentModelFallback,
+  resolveCodexSubagentRouteSnapshot,
 } from '../codex-subagent-config';
+import { setCustomProviders } from '../active-catalog';
 
 function settings(partial: Partial<SubagentModelSettings> = {}): SubagentModelSettings {
   return { ...SUBAGENT_MODEL_SETTINGS_DEFAULTS, ...partial };
@@ -119,11 +122,33 @@ describe('buildCodexSubagentSpawnArgs', () => {
     ]);
   });
 
-  it('injects discounted-route model ids verbatim (no prefix stripping)', () => {
-    // codex/ 前缀由 loopback proxy 在 HTTP 边界分流,剥前缀会把折扣路由静默改道。
-    expect(
-      withoutDelegationArgs(buildCodexSubagentSpawnArgs(settings({ codex: 'codex/gpt-5.5' }))),
-    ).toEqual(['-c', 'agents.default_subagent_model="codex/gpt-5.5"']);
+  it('uses the selected Provider rewrite for the runtime slug accepted by spawn_agent', () => {
+    setCustomProviders([{
+      id: 'spawn-rewrite-provider',
+      name: 'Spawn Rewrite Provider',
+      source: 'user',
+      agents: ['codex'],
+      auth: { method: 'apiKey' },
+      routing: {
+        codex: {
+          wireProtocol: 'openai-responses',
+          upstream: 'https://spawn-rewrite.invalid/v1',
+          authStrategy: 'api-key-header',
+          modelIdRewrite: { stripPrefix: 'vendor-a/' },
+        },
+      },
+      models: { codex: [{ id: 'vendor-a/model-a', name: 'Model A' }] },
+    } as never]);
+    try {
+      expect(
+        withoutDelegationArgs(buildCodexSubagentSpawnArgs(settings({
+          codex: 'vendor-a/model-a',
+          codexProviderId: 'spawn-rewrite-provider',
+        }))),
+      ).toEqual(['-c', 'agents.default_subagent_model="model-a"']);
+    } finally {
+      setCustomProviders([]);
+    }
   });
 
   it('maps the nested-subagents switch to agents.max_depth=2', () => {
@@ -187,7 +212,7 @@ describe('buildCodexSubagentSpawnArgs', () => {
 });
 
 describe('resolveCodexSubagentModelFallback', () => {
-  it('returns the configured model for the local app-server', () => {
+  it('preserves the configured catalog model for display and proxy routing', () => {
     expect(resolveCodexSubagentModelFallback(settings({ codex: 'codex/gpt-5.5' }))).toBe(
       'codex/gpt-5.5',
     );
@@ -208,5 +233,42 @@ describe('resolveCodexSubagentModelFallback', () => {
         settings({ codexSubagentsEnabled: false, codex: 'codex/gpt-5.5' }),
       ),
     ).toBeUndefined();
+  });
+});
+
+describe('codexSubagentRuntimeModelId', () => {
+  it('applies an arbitrary Provider-declared model rewrite without prefix hardcoding', () => {
+    setCustomProviders([{
+      id: 'runtime-rewrite-provider',
+      name: 'Runtime Rewrite Provider',
+      source: 'user',
+      agents: ['codex'],
+      auth: { method: 'apiKey' },
+      routing: {
+        codex: {
+          wireProtocol: 'openai-responses',
+          upstream: 'https://runtime-rewrite.invalid/v1',
+          authStrategy: 'api-key-header',
+          modelIdRewrite: { stripPrefix: 'route/' },
+        },
+      },
+      models: { codex: [{ id: 'route/model-a', name: 'Model A' }] },
+    } as never]);
+    try {
+      expect(codexSubagentRuntimeModelId(' route/model-a ', 'runtime-rewrite-provider'))
+        .toBe('model-a');
+      expect(codexSubagentRuntimeModelId('model-a', 'runtime-rewrite-provider'))
+        .toBe('model-a');
+      expect(resolveCodexSubagentRouteSnapshot(settings({
+        codex: 'route/model-a',
+        codexProviderId: 'runtime-rewrite-provider',
+      }))).toEqual({
+        providerId: 'runtime-rewrite-provider',
+        catalogModel: 'route/model-a',
+        runtimeModel: 'model-a',
+      });
+    } finally {
+      setCustomProviders([]);
+    }
   });
 });

--- a/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
@@ -1286,6 +1286,162 @@ describe('chatBridgeCapabilitiesForRoute', () => {
     }
   });
 
+  it('routes a rewritten default subagent model through its configured Provider', async () => {
+    const host = await freshCodexProxyHost();
+    const { setCustomProviders } = await import('../active-catalog.js');
+    const { setCustomProviderKeyReader } = await import('../provider-route.js');
+    const { setSessionProvider, clearSessionProvider } = await import('../session-provider-store.js');
+    setCustomProviders([{
+      id: 'subagent-route-provider',
+      name: 'Subagent Route Provider',
+      source: 'user',
+      agents: ['codex'],
+      auth: { method: 'apiKey' },
+      routing: {
+        codex: {
+          wireProtocol: 'openai-responses',
+          upstream: 'https://subagent-route.invalid/v1',
+          authStrategy: 'api-key-header',
+          modelIdRewrite: { stripPrefix: 'route/' },
+        },
+      },
+      models: { codex: [{ id: 'route/model-a', name: 'Model A' }] },
+    } as never]);
+    setCustomProviderKeyReader(() => 'subagent-route-key');
+    mockState.createAnthropicCompatProxy.mockResolvedValueOnce({
+      url: 'http://127.0.0.1:43210',
+      dispose: vi.fn(async () => undefined),
+    });
+    await host.ensureCodexProxyReady();
+    host.setCodexProxyAuthInjection('oauth-bearer');
+    host.setCodexProxyGatewayKeyReader(() => 'gateway-subagent-key');
+    host.registerComposed(
+      'session-openai-parent',
+      'thread-openai-parent',
+      'PRODUCT_PROMPT',
+      {
+        subagentRoute: {
+          providerId: 'subagent-route-provider',
+          catalogModel: 'route/model-a',
+          runtimeModel: 'model-a',
+        },
+      },
+    );
+    setSessionProvider('session-openai-parent', 'openai');
+
+    try {
+      const decision = await Promise.resolve(host.createModelRoutingTransform()(
+        { model: 'model-a', input: [] },
+        {
+          reqId: 1,
+          method: 'POST',
+          url: '/responses',
+          headers: {
+            'thread-id': 'thread-gateway-child',
+            'x-openai-subagent': 'collab_spawn',
+            'x-codex-parent-thread-id': 'thread-openai-parent',
+          },
+        },
+      ));
+
+      expect(decision).toEqual({
+        upstreamOverride: 'https://subagent-route.invalid/v1',
+        headerOverride: { authorization: 'Bearer subagent-route-key' },
+        headerDelete: ['chatgpt-account-id', 'openai-beta', 'originator', 'session_id'],
+      });
+      expect(mockState.capturedRegistry?.get('thread-gateway-child')).toBe('PRODUCT_PROMPT');
+    } finally {
+      host.unregister('session-openai-parent');
+      clearSessionProvider('session-openai-parent');
+      host.setCodexProxyGatewayKeyReader(() => null);
+      setCustomProviderKeyReader(() => null);
+      setCustomProviders([]);
+    }
+  });
+
+  it('keeps an explicit spawn model override on the OpenAI parent route', async () => {
+    const host = await freshCodexProxyHost();
+    const { setSessionProvider, clearSessionProvider } = await import('../session-provider-store.js');
+    const requestModel = 'gpt-5.6-sol';
+    host.setCodexProxyAuthInjection('oauth-bearer');
+    host.setCodexProxyGatewayKeyReader(() => 'gateway-subagent-key');
+    host.registerComposed(
+      'session-openai-parent',
+      'thread-openai-parent',
+      'PRODUCT_PROMPT',
+      {
+        subagentRoute: {
+          providerId: 'xd',
+          catalogModel: 'codex/gpt-5.6-terra',
+          runtimeModel: 'gpt-5.6-terra',
+        },
+      },
+    );
+    setSessionProvider('session-openai-parent', 'openai');
+
+    try {
+      const decision = await Promise.resolve(host.createModelRoutingTransform()(
+        { model: requestModel, input: [] },
+        {
+          reqId: 1,
+          method: 'POST',
+          url: '/responses',
+          headers: {
+            'thread-id': `thread-${requestModel}`,
+            'x-openai-subagent': 'collab_spawn',
+            'x-codex-parent-thread-id': 'thread-openai-parent',
+          },
+        },
+      ));
+
+      expect(decision).toEqual({ upstreamOverride: 'https://chatgpt.com/backend-api/codex' });
+    } finally {
+      host.unregister('session-openai-parent');
+      clearSessionProvider('session-openai-parent');
+      host.setCodexProxyGatewayKeyReader(() => null);
+    }
+  });
+
+  it('fails closed when a passthrough subagent Provider does not match the app-server credential', async () => {
+    const host = await freshCodexProxyHost();
+    const { setSessionProvider, clearSessionProvider } = await import('../session-provider-store.js');
+    host.setCodexProxyAuthInjection('env-key');
+    host.registerComposed(
+      'session-gateway-parent',
+      'thread-gateway-parent',
+      'PRODUCT_PROMPT',
+      {
+        subagentRoute: {
+          providerId: 'openai',
+          catalogModel: 'gpt-5.6-terra',
+          runtimeModel: 'gpt-5.6-terra',
+        },
+      },
+    );
+    setSessionProvider('session-gateway-parent', 'xd');
+
+    try {
+      const decision = await Promise.resolve(host.createModelRoutingTransform()(
+        { model: 'gpt-5.6-terra', input: [] },
+        {
+          reqId: 1,
+          method: 'POST',
+          url: '/responses',
+          headers: {
+            'thread-id': 'thread-openai-child',
+            'x-openai-subagent': 'collab_spawn',
+            'x-codex-parent-thread-id': 'thread-gateway-parent',
+          },
+        },
+      ));
+
+      expect(decision).toEqual({ localHandler: expect.any(Function) });
+    } finally {
+      host.unregister('session-gateway-parent');
+      clearSessionProvider('session-gateway-parent');
+    }
+  });
+
   it('fails closed when a collab_spawn request cannot resolve its parent route', async () => {
     const host = await freshCodexProxyHost();
     const ctx = {
@@ -2569,6 +2725,57 @@ describe('codex proxy host', () => {
       model: 'codex/gpt-5.6-sol',
       tools: [{ type: 'web_search', external_web_access: false }],
     });
+  });
+
+  it('applies the inherited Gateway route on the first collab_spawn transform pass', async () => {
+    const host = await freshCodexProxyHost();
+    const { setSessionProvider, clearSessionProvider } = await import('../session-provider-store.js');
+    mockState.createAnthropicCompatProxy.mockResolvedValueOnce({
+      url: 'http://127.0.0.1:43210',
+      dispose: vi.fn(async () => undefined),
+    });
+    await host.ensureCodexProxyReady();
+    host.setCodexProxyAuthInjection('oauth-bearer');
+    host.setCodexProxyGatewayKeyReader(() => 'gateway-subagent-key');
+    host.registerComposed(
+      'session-openai-parent',
+      'thread-openai-parent',
+      'PRODUCT_PROMPT',
+      {
+        subagentRoute: {
+          providerId: 'xd',
+          catalogModel: 'codex/gpt-5.6-sol',
+          runtimeModel: 'gpt-5.6-sol',
+        },
+      },
+    );
+    setSessionProvider('session-openai-parent', 'openai');
+
+    try {
+      const transforms = mockState.createAnthropicCompatProxy.mock.calls[0]?.[0]?.transformRequest ?? [];
+      let current: unknown = { model: 'gpt-5.6-sol' };
+      const ctx = {
+        method: 'POST',
+        url: '/responses',
+        headers: {
+          'thread-id': 'thread-gateway-child-first-request',
+          'x-openai-subagent': 'collab_spawn',
+          'x-codex-parent-thread-id': 'thread-openai-parent',
+        },
+      };
+      for (const transform of transforms) {
+        const next = transform(current, ctx);
+        if (next !== null && next !== undefined) current = next;
+      }
+      expect(current).toEqual({
+        model: 'gpt-5.6-sol',
+        tools: [{ type: 'web_search' }],
+      });
+    } finally {
+      host.unregister('session-openai-parent');
+      clearSessionProvider('session-openai-parent');
+      host.setCodexProxyGatewayKeyReader(() => null);
+    }
   });
 
   it('does not add Gateway native search to non-Gateway GPT-5.6 sessions', async () => {

--- a/apps/desktop/src/main/maker-host/__tests__/subagent-model-settings-store.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/subagent-model-settings-store.test.ts
@@ -277,8 +277,8 @@ describe('subagent model settings store', () => {
 
   it('codexSpawnConfigChanged tracks spawn-affecting keys only', () => {
     const base = withDefaults();
-    // codexProviderId 是纯客户端展示维度,claude* 走 env 通道:都不触发重启。
-    expect(codexSpawnConfigChanged(base, withDefaults({ codexProviderId: 'openai' }))).toBe(false);
+    // Provider 决定 runtime 模型改写与子线程路由，因此变化必须重启；claude* 仍走 env 通道。
+    expect(codexSpawnConfigChanged(base, withDefaults({ codexProviderId: 'openai' }))).toBe(true);
     expect(codexSpawnConfigChanged(base, withDefaults({ claudeCode: 'claude-opus-5' }))).toBe(false);
     expect(codexSpawnConfigChanged(base, withDefaults({ codex: 'gpt-5.6-terra' }))).toBe(true);
     expect(codexSpawnConfigChanged(base, withDefaults({ codexEffort: 'low' }))).toBe(true);

--- a/apps/desktop/src/main/maker-host/codex-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/codex-proxy-host.ts
@@ -46,7 +46,10 @@ import { claudeUpstreamEndpoint } from './runtime-configs.js';
 import { getActiveCatalog, getCatalogModelContextWindow } from './active-catalog.js';
 import {
   gatewayDefaultRouteDecision,
+  getProviderRoutingDescriptor,
   getSessionRoutingDescriptor,
+  resolveProviderRouteById,
+  resolveProviderRouteDecision,
   resolveSessionRoute,
   resolveSessionRouteDecision,
   resolvePendingSessionRouteDecision,
@@ -61,8 +64,11 @@ import {
   resolveImplicitProviderOAuthRouteDecision,
   resolveProviderOAuthControlRouteDecision,
   rewriteImplicitModelIdForRoute,
+  rewriteProviderModelIdForRoute,
+  rewriteProviderModelIdInBody,
   rewriteSessionModelIdForRoute,
 } from './provider-route.js';
+import type { CodexSubagentRouteSnapshot } from './codex-subagent-config.js';
 import { getSessionProvider } from './session-provider-store.js';
 import {
   composeResponseObservers,
@@ -87,6 +93,8 @@ const registry = createInstructionsRegistry();
 const sessionToThread = new Map<string, string>();
 const sessionToThreads = new Map<string, Set<string>>();
 const threadToSession = new Map<string, string>();
+const subagentRouteByParentThread = new Map<string, CodexSubagentRouteSnapshot>();
+const subagentRouteByThread = new Map<string, CodexSubagentRouteSnapshot>();
 const reviewerModelBySession = new Map<string, string>();
 const httpRecoveryReasonByThread = new Map<string, string>();
 
@@ -280,6 +288,63 @@ function sessionIdFromHeaders(
   return threadToSession.get(childThreadId);
 }
 
+function subagentRouteFromHeaders(
+  headers: Readonly<Record<string, string>>,
+  requestModel: string,
+): CodexSubagentRouteSnapshot | undefined {
+  const threadId = selectedThreadIdFromHeaders(headers);
+  if (threadId === 'unknown') return undefined;
+  const route = subagentRouteByThread.get(threadId);
+  return route?.runtimeModel === requestModel ? route : undefined;
+}
+
+interface ProviderRequestContext {
+  sessionId?: string;
+  providerId: string | null;
+  catalogModel: string;
+  subagentRoute?: CodexSubagentRouteSnapshot;
+}
+
+function providerContextForRequest(
+  headers: Readonly<Record<string, string>>,
+  requestModel: string,
+): ProviderRequestContext {
+  const sessionId = sessionIdFromHeaders(headers);
+  // The first collab_spawn request may arrive before thread/started. Resolve
+  // the session first so lazy child registration can inherit the route snapshot
+  // before request compatibility transforms inspect the effective Provider.
+  const subagentRoute = subagentRouteFromHeaders(headers, requestModel);
+  if (subagentRoute) {
+    return {
+      sessionId,
+      providerId: subagentRoute.providerId,
+      catalogModel: subagentRoute.catalogModel,
+      subagentRoute,
+    };
+  }
+  return {
+    sessionId,
+    providerId: sessionId ? getSessionProvider(sessionId) : null,
+    catalogModel: requestModel,
+  };
+}
+
+function gatewayProviderIdForRewrittenModel(model: string): string | null {
+  for (const provider of getActiveCatalog().providers) {
+    const routing = provider.routing.codex;
+    const stripPrefix = routing?.modelIdRewrite?.stripPrefix;
+    if (
+      routing?.authStrategy === 'gateway-key'
+      && stripPrefix
+      && model.startsWith(stripPrefix)
+      && model.length > stripPrefix.length
+    ) {
+      return provider.id;
+    }
+  }
+  return null;
+}
+
 function unresolvedCollabSpawnRouteDecision(): RoutingDecision {
   return {
     localHandler: async ({ res }) => {
@@ -355,7 +420,7 @@ function sessionUsesNativeOpenAIReviewer(
   // models are never treated as native OpenAI merely because a superset OAuth
   // host happens to serve the session.
   if (
-    model.startsWith('codex/') ||
+    gatewayProviderIdForRewrittenModel(model) !== null ||
     model.startsWith('chatgpt/') ||
     model.startsWith('xai/')
   ) {
@@ -444,22 +509,32 @@ function createGatewayNativeWebSearchTransform(): RequestTransform {
     const path = ctx.url.split('?', 1)[0] ?? ctx.url;
     if (ctx.method !== 'POST' || (!path.endsWith('/responses') && path !== '/responses')) return null;
 
-    const model = body.model;
-    const gatewayModel = model.replace(/^codex\//, '');
+    const requestModel = body.model;
+    const providerContext = providerContextForRequest(ctx.headers, requestModel);
+    const { sessionId, subagentRoute } = providerContext;
+    const model = providerContext.catalogModel;
+    const rewrittenGatewayProviderId = gatewayProviderIdForRewrittenModel(model);
+    const routeProviderId = providerContext.providerId
+      ?? inferProviderIdForModel(model, 'codex')
+      ?? rewrittenGatewayProviderId;
+    const gatewayModel = subagentRoute?.runtimeModel
+      ?? rewriteProviderModelIdForRoute(routeProviderId, 'codex', model);
     if (!/^gpt-5\.6(?:$|[-.])/.test(gatewayModel)) return null;
 
-    const sessionId = sessionIdFromTransformCtx(ctx);
     const authInjection = getCodexProxyAuthInjection();
-    const canUseExplicitSessionRoute = Boolean(sessionId && (
+    const canUseExplicitSessionRoute = Boolean(sessionId && !subagentRoute && (
       authInjection === 'oauth-bearer' ||
       isUserProviderSession(sessionId) ||
       isHostInjectedAuthSession(sessionId, 'codex')
     ));
-    const explicitRouting = canUseExplicitSessionRoute && sessionId
-      ? getSessionRoutingDescriptor(sessionId, 'codex', model)
-      : null;
+    const explicitRouting = subagentRoute
+      ? getProviderRoutingDescriptor(subagentRoute.providerId, 'codex', subagentRoute.catalogModel)
+      : canUseExplicitSessionRoute && sessionId
+        ? getSessionRoutingDescriptor(sessionId, 'codex', model)
+        : null;
     const resolvedExplicitRoute = explicitRouting
       && sessionId
+      && !subagentRoute
       && (authInjection === 'oauth-bearer' || authInjection === 'provider-oauth')
       ? resolveSessionRouteDecision(sessionId, 'codex', _readGatewayKey(), model)
       : null;
@@ -468,10 +543,12 @@ function createGatewayNativeWebSearchTransform(): RequestTransform {
       : null;
     const isGatewaySession = explicitRouting
       ? explicitRouting.authStrategy === 'gateway-key' &&
-        (authInjection === 'env-key' || resolvedExplicitRoute !== null)
+        (subagentRoute
+          ? _readGatewayKey() !== null
+          : authInjection === 'env-key' || resolvedExplicitRoute !== null)
       // provider-oauth 的显式来源越界后，实际路由会回落默认 Gateway；没有 descriptor
       // 时也必须与 createModelRoutingTransform 保持同源。
-      : model.startsWith('codex/') ||
+      : rewrittenGatewayProviderId !== null ||
         authInjection === 'env-key' ||
         providerOAuthGatewayFallback !== null;
     if (!isGatewaySession) return null;
@@ -1488,9 +1565,16 @@ function isByteDanceSeedModel(model: unknown): boolean {
 
 function isVolcengineArkResponsesRouting(ctx: RequestTransformCtx, model: unknown): boolean {
   if (typeof model !== 'string' || model.length === 0) return false;
-  const sessionId = sessionIdFromTransformCtx(ctx);
-  if (!sessionId) return false;
-  const routing = getSessionRoutingDescriptor(sessionId, 'codex', model);
+  const providerContext = providerContextForRequest(ctx.headers, model);
+  const routing = providerContext.subagentRoute
+    ? getProviderRoutingDescriptor(
+        providerContext.subagentRoute.providerId,
+        'codex',
+        providerContext.subagentRoute.catalogModel,
+      )
+    : providerContext.sessionId
+      ? getSessionRoutingDescriptor(providerContext.sessionId, 'codex', model)
+      : null;
   if (!routing || (routing.wireProtocol ?? 'openai-responses') !== 'openai-responses') return false;
 
   try {
@@ -1635,10 +1719,12 @@ function normalizeByteDanceSeedInput(body: Record<string, unknown>): Record<stri
  * Consecutive calls form one parallel assistant group, so their matched outputs must
  * be moved after the whole group rather than inserted between calls.
  */
-function normalizeStrictGatewayHistory(body: Record<string, unknown>): Record<string, unknown> | null {
+function normalizeStrictGatewayHistory(
+  body: Record<string, unknown>,
+  routingModel = typeof body.model === 'string' ? body.model : '',
+): Record<string, unknown> | null {
   if (
-    typeof body.model !== 'string' ||
-    !STRICT_GATEWAY_TOOL_HISTORY_MODELS.has(body.model) ||
+    !STRICT_GATEWAY_TOOL_HISTORY_MODELS.has(routingModel) ||
     !Array.isArray(body.input)
   ) {
     return null;
@@ -1719,9 +1805,10 @@ function normalizeStrictGatewayHistory(body: Record<string, unknown>): Record<st
 }
 
 function createStrictGatewayHistoryCompatTransform(): RequestTransform {
-  return (body) => {
-    if (!isPlainObject(body)) return null;
-    return normalizeStrictGatewayHistory(body);
+  return (body, ctx) => {
+    if (!isPlainObject(body) || typeof body.model !== 'string') return null;
+    const routingModel = providerContextForRequest(ctx.headers, body.model).catalogModel;
+    return normalizeStrictGatewayHistory(body, routingModel);
   };
 }
 
@@ -1768,15 +1855,17 @@ function createByteDanceSeedResponsesCompatTransform(): RequestTransform {
 function createXaiResponsesCompatTransform(): RequestTransform {
   return (body, ctx) => {
     if (!isPlainObject(body)) return null;
-    const sessionId = sessionIdFromTransformCtx(ctx);
-    const explicitProviderId = sessionId ? getSessionProvider(sessionId) : null;
+    const requestModel = typeof body.model === 'string' ? body.model : '';
+    const providerContext = providerContextForRequest(ctx.headers, requestModel);
+    const explicitProviderId = providerContext.providerId;
     const inferredProviderId =
       explicitProviderId ?? (typeof body.model === 'string' ? inferProviderIdForModel(body.model, 'codex') : null);
     if (inferredProviderId !== 'xai') return null;
     // 与路由的 scope 门同源:xai 会话里非 xai/ 前缀的请求会被 resolveSessionRouteDecision
     // 放回默认路由(ChatGPT/网关),body 不能再按 xAI 语义改写(挪 instructions / 剥
     // reasoning 会破坏默认上游的请求),transform 是否生效必须与路由是否捕获一致。
-    const wireModel = typeof body.model === 'string' ? body.model : undefined;
+    const wireModel = providerContext.subagentRoute?.catalogModel
+      ?? (typeof body.model === 'string' ? body.model : undefined);
     if (!providerRoutingServesWireModel('xai', 'codex', wireModel)) return null;
     let changed = false;
     let current = moveInstructionsIntoInput(body);
@@ -1907,9 +1996,8 @@ const MINIMAX_RESPONSES_UPSTREAMS: ReadonlySet<string> = new Set([
   'https://api.minimax.io/v1',
 ]);
 
-function isMiniMaxResponsesSession(ctx: RequestTransformCtx): boolean {
-  const sessionId = sessionIdFromTransformCtx(ctx);
-  const providerId = sessionId ? getSessionProvider(sessionId) : null;
+function isMiniMaxResponsesSession(ctx: RequestTransformCtx, requestModel: string): boolean {
+  const providerId = providerContextForRequest(ctx.headers, requestModel).providerId;
   if (!providerId) return false;
   const upstream = getActiveCatalog().providers.find((provider) => provider.id === providerId)
     ?.routing.codex?.upstream.replace(/\/+$/, '');
@@ -1919,7 +2007,11 @@ function isMiniMaxResponsesSession(ctx: RequestTransformCtx): boolean {
 /** MiniMax Responses 不接受 xhigh 或 reasoning summary，路由前收敛到官方支持字段。 */
 function createMiniMaxResponsesCompatTransform(): RequestTransform {
   return (body, ctx) => {
-    if (!isPlainObject(body) || !isMiniMaxResponsesSession(ctx)) return null;
+    if (
+      !isPlainObject(body)
+      || typeof body.model !== 'string'
+      || !isMiniMaxResponsesSession(ctx, body.model)
+    ) return null;
     const reasoning = body.reasoning;
     if (!isPlainObject(reasoning)) return null;
     let changed = false;
@@ -1938,6 +2030,15 @@ function createMiniMaxResponsesCompatTransform(): RequestTransform {
 
 function createProviderModelRewriteTransform(): RequestTransform {
   return (body, ctx) => {
+    if (isPlainObject(body) && typeof body.model === 'string') {
+      const subagentRoute = subagentRouteFromHeaders(ctx.headers, body.model);
+      if (subagentRoute) {
+        return rewriteProviderModelIdInBody(subagentRoute.providerId, 'codex', {
+          ...body,
+          model: subagentRoute.catalogModel,
+        });
+      }
+    }
     const sessionId = sessionIdFromTransformCtx(ctx);
     const explicitProviderId = sessionId ? getSessionProvider(sessionId) : null;
     if (sessionId && explicitProviderId) return rewriteSessionModelIdForRoute(sessionId, 'codex', body);
@@ -2166,7 +2267,7 @@ export function decideCodexRoute(opts: {
 }): RoutingDecision | null {
   if (opts.authInjection === 'env-key' || opts.authInjection === 'provider-oauth') return null;
   if (!opts.model) return null;
-  const toGateway = opts.model.startsWith('codex/');
+  const toGateway = gatewayProviderIdForRewrittenModel(opts.model) !== null;
   if (toGateway) {
     if (!opts.gatewayKey) return null;
     return { headerOverride: { authorization: `Bearer ${opts.gatewayKey}` } };
@@ -2184,7 +2285,7 @@ export function createModelRoutingTransform(
     const gatewayKey = _readGatewayKey();
     const authInjection = frozenAuthInjection ?? getCodexProxyAuthInjection();
     const requestModel = isPlainObject(body) && typeof body.model === 'string' ? body.model : '';
-    const model =
+    const reportedModel =
       providerAwareGuardianReviewerModel(body, ctx.headers, authInjection) ??
       requestModel;
     const threadId = selectedThreadIdFromHeaders(ctx.headers);
@@ -2192,14 +2293,26 @@ export function createModelRoutingTransform(
     if (!sessionId && isCollabSpawnRequest(ctx.headers)) {
       return unresolvedCollabSpawnRouteDecision();
     }
-    const explicitProviderId = sessionId ? getSessionProvider(sessionId) : null;
-    const pendingRoute = sessionId
+    // The runtime may require a rewritten model id for spawn_agent, while routing
+    // still needs the provider-scoped catalog id. Child threads inherit the full
+    // frozen route snapshot and use it only when the request matches its runtime id.
+    const subagentRoute = subagentRouteFromHeaders(ctx.headers, reportedModel);
+    const model = subagentRoute?.catalogModel ?? reportedModel;
+    const explicitProviderId = subagentRoute?.providerId
+      ?? (sessionId ? getSessionProvider(sessionId) : null);
+    const pendingRoute = sessionId && !subagentRoute
       ? resolvePendingSessionRouteDecision(sessionId, model || undefined)
       : null;
     if (pendingRoute) return pendingRoute;
-    const selectedRouting = sessionId
-      ? getSessionRoutingDescriptor(sessionId, 'codex', model || undefined)
-      : null;
+    const selectedRouting = subagentRoute
+      ? getProviderRoutingDescriptor(
+          subagentRoute.providerId,
+          'codex',
+          subagentRoute.catalogModel,
+        )
+      : sessionId
+        ? getSessionRoutingDescriptor(sessionId, 'codex', model || undefined)
+        : null;
     const selectedUsesLocalBridge =
       ctx.method === 'POST'
       && Boolean(model)
@@ -2207,6 +2320,38 @@ export function createModelRoutingTransform(
         selectedRouting?.wireProtocol === 'openai-chat'
         || selectedRouting?.wireProtocol === 'anthropic-messages'
       );
+
+    if (subagentRoute) {
+      if (
+        selectedRouting?.authStrategy === 'oauth-passthrough'
+        && authInjection !== 'oauth-bearer'
+      ) {
+        return unresolvedCollabSpawnRouteDecision();
+      }
+      if (selectedUsesLocalBridge) {
+        return resolveProviderRouteById(
+          subagentRoute.providerId,
+          'codex',
+          subagentRoute.catalogModel,
+        ).then((localRoute) => {
+          return createLocalBridgeDecision(
+            localRoute,
+            threadId ? registry.get(threadId) : undefined,
+            subagentRoute.catalogModel,
+            subagentRoute.catalogModel !== requestModel
+              ? subagentRoute.catalogModel
+              : undefined,
+            threadId,
+          ) ?? unresolvedCollabSpawnRouteDecision();
+        });
+      }
+      return resolveProviderRouteDecision(
+        subagentRoute.providerId,
+        'codex',
+        gatewayKey,
+        subagentRoute.catalogModel,
+      ).then((resolved) => resolved?.decision ?? unresolvedCollabSpawnRouteDecision());
+    }
 
     // ① 该会话显式选了供应商 → 据 catalog 统一路由。thread-id header → threadToSession 反解 xdt sessionId。
     //    oauth-bearer 态全量适用;env-key 态默认全量走网关、per-session 无意义(与 decideCodexRoute 的
@@ -2293,7 +2438,7 @@ export function createModelRoutingTransform(
     const decision = decideCodexRoute({ model, authInjection, gatewayKey });
     // codex/ 折扣模型该走 gateway 换 key 但没配 key → null(passthrough), 上游大概率 401, 记一条诊断。
     if (decision === null && authInjection === 'oauth-bearer' && model
-      && model.startsWith('codex/') && !gatewayKey) {
+      && gatewayProviderIdForRewrittenModel(model) !== null && !gatewayKey) {
       log.warn('codex routing → gateway but no api key configured; passthrough (可能 401)', { model });
     }
     return decision;
@@ -2620,9 +2765,26 @@ export function getCodexProxyEndpoint(): string {
  *
  * 这是同步内存 Map 写入,不做 IO / 网络,调用方可以把它当成不可失败的强时序步骤。
  */
-export function registerComposed(sessionId: string, threadId: string, text: string): void {
+export function registerComposed(
+  sessionId: string,
+  threadId: string,
+  text: string,
+  opts: { subagentRoute?: CodexSubagentRouteSnapshot } = {},
+): void {
   bindThreadToSession(sessionId, threadId);
   registry.set(threadId, text);
+  const providerId = opts.subagentRoute?.providerId.trim();
+  const catalogModel = opts.subagentRoute?.catalogModel.trim();
+  const runtimeModel = opts.subagentRoute?.runtimeModel.trim();
+  if (providerId && catalogModel && runtimeModel) {
+    subagentRouteByParentThread.set(threadId, {
+      providerId,
+      catalogModel,
+      runtimeModel,
+    });
+  } else {
+    subagentRouteByParentThread.delete(threadId);
+  }
   log.debug('registered codex prompt for thread', {
     sessionId,
     threadId,
@@ -2699,6 +2861,14 @@ export function registerChildThread(parentThreadId: string, childThreadId: strin
   sessionToThreads.set(sessionId, threads);
   threadToSession.set(childThreadId, sessionId);
   registry.set(childThreadId, text);
+  const inheritedSubagentRoute =
+    subagentRouteByThread.get(parentThreadId)
+    ?? subagentRouteByParentThread.get(parentThreadId);
+  if (inheritedSubagentRoute) {
+    subagentRouteByThread.set(childThreadId, inheritedSubagentRoute);
+  } else {
+    subagentRouteByThread.delete(childThreadId);
+  }
   log.debug('registered codex child thread route', {
     sessionId,
     parentThreadId,
@@ -2717,6 +2887,8 @@ function clearSessionThreads(sessionId: string): string[] {
     if (threadToSession.get(threadId) === sessionId) {
       threadToSession.delete(threadId);
       registry.delete(threadId);
+      subagentRouteByParentThread.delete(threadId);
+      subagentRouteByThread.delete(threadId);
       httpRecoveryReasonByThread.delete(threadId);
     }
   }
@@ -2759,6 +2931,8 @@ export async function disposeCodexProxy(): Promise<void> {
   sessionToThread.clear();
   sessionToThreads.clear();
   threadToSession.clear();
+  subagentRouteByParentThread.clear();
+  subagentRouteByThread.clear();
   reviewerModelBySession.clear();
   httpRecoveryReasonByThread.clear();
 

--- a/apps/desktop/src/main/maker-host/codex-subagent-config.ts
+++ b/apps/desktop/src/main/maker-host/codex-subagent-config.ts
@@ -24,6 +24,11 @@
  * 数字/布尔裸写。
  */
 
+import {
+  effectiveSourceIdForModel,
+  type ProviderView,
+} from '@cindy/model-providers';
+
 import type { SubagentModelSettings } from '../../shared/subagentModelSettings.js';
 import { rewriteProviderModelIdForRoute } from './provider-route.js';
 
@@ -71,10 +76,18 @@ export function codexSubagentRuntimeModelId(
 export function resolveCodexSubagentRouteSnapshot(
   settings: SubagentModelSettings,
   remoteHostId?: string,
+  providerViews?: ProviderView[],
 ): CodexSubagentRouteSnapshot | undefined {
   if (remoteHostId || !settings.codexSubagentsEnabled) return undefined;
   const catalogModel = settings.codex?.trim();
-  const providerId = settings.codexProviderId?.trim();
+  const explicitProviderId = settings.codexProviderId?.trim();
+  // Provider-less settings are a valid implicit route. Resolve them with the same connected,
+  // chat-eligible source priority as the model selector, then freeze that source for both the
+  // proxy route and Codex's spawn_agent runtime-model rewrite.
+  const providerId = explicitProviderId
+    || (catalogModel && providerViews
+      ? effectiveSourceIdForModel(providerViews, null, catalogModel, 'codex')
+      : null);
   if (!catalogModel || !providerId) return undefined;
   return {
     providerId,
@@ -83,7 +96,10 @@ export function resolveCodexSubagentRouteSnapshot(
   };
 }
 
-export function buildCodexSubagentSpawnArgs(settings: SubagentModelSettings): string[] {
+export function buildCodexSubagentSpawnArgs(
+  settings: SubagentModelSettings,
+  resolvedRoute?: CodexSubagentRouteSnapshot,
+): string[] {
   const args: string[] = [];
   if (!settings.codexSubagentsEnabled) {
     // 总开关关死后其余键无意义,不再注入。
@@ -100,7 +116,9 @@ export function buildCodexSubagentSpawnArgs(settings: SubagentModelSettings): st
   }
   args.push('-c', 'features.multi_agent_v2.expose_spawn_agent_model_overrides=true');
   if (settings.codex) {
-    const runtimeModel = codexSubagentRuntimeModelId(settings.codex, settings.codexProviderId);
+    const runtimeModel = resolvedRoute?.catalogModel === settings.codex.trim()
+      ? resolvedRoute.runtimeModel
+      : codexSubagentRuntimeModelId(settings.codex, settings.codexProviderId);
     args.push(
       '-c',
       `agents.default_subagent_model=${tomlString(runtimeModel)}`,

--- a/apps/desktop/src/main/maker-host/codex-subagent-config.ts
+++ b/apps/desktop/src/main/maker-host/codex-subagent-config.ts
@@ -16,15 +16,22 @@
  *   不改变上游何时委托的调度策略。
  * - `agents.max_depth` 仅旧版多代理(V1)生效,V2 忽略(UI hint 已注明)。
  * - `agents.default_subagent_model` 是兜底默认,模型仍可在 spawn 参数里显式覆盖。
- *   注入 Cindy 存储的 model id 原文:codex vendor 候选只有原生 slug 与 `codex/`
- *   折扣路由 id,`codex/` 前缀由 loopback proxy 在 HTTP 边界分流(decideCodexRoute),
- *   剥前缀反而会把折扣路由静默改道。
+ *   Codex 0.145 的 spawn_agent 模型白名单只接受运行时 slug（如 `gpt-5.6-terra`），
+ *   不接受客户端目录里的 `codex/` 路由前缀；因此写入 agents 配置前必须归一化。
+ *   出站供应商仍由会话/线程在 loopback proxy 的路由登记决定。
  *
  * TOML 值形态与 mcp-integrations/codexEnvironment.ts 一致:字符串带双引号,
  * 数字/布尔裸写。
  */
 
 import type { SubagentModelSettings } from '../../shared/subagentModelSettings.js';
+import { rewriteProviderModelIdForRoute } from './provider-route.js';
+
+export interface CodexSubagentRouteSnapshot {
+  providerId: string;
+  catalogModel: string;
+  runtimeModel: string;
+}
 
 /**
  * 按需委托策略(Claude Code 式):替换上游按 effort 推导的内置 multi-agent 模式
@@ -53,6 +60,29 @@ function tomlString(value: string): string {
   return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
 }
 
+/** 把 Cindy 目录模型 id 转成 Codex spawn_agent 白名单使用的运行时 slug。 */
+export function codexSubagentRuntimeModelId(
+  modelId: string,
+  providerId?: string | null,
+): string {
+  return rewriteProviderModelIdForRoute(providerId, 'codex', modelId);
+}
+
+export function resolveCodexSubagentRouteSnapshot(
+  settings: SubagentModelSettings,
+  remoteHostId?: string,
+): CodexSubagentRouteSnapshot | undefined {
+  if (remoteHostId || !settings.codexSubagentsEnabled) return undefined;
+  const catalogModel = settings.codex?.trim();
+  const providerId = settings.codexProviderId?.trim();
+  if (!catalogModel || !providerId) return undefined;
+  return {
+    providerId,
+    catalogModel,
+    runtimeModel: codexSubagentRuntimeModelId(catalogModel, providerId),
+  };
+}
+
 export function buildCodexSubagentSpawnArgs(settings: SubagentModelSettings): string[] {
   const args: string[] = [];
   if (!settings.codexSubagentsEnabled) {
@@ -70,7 +100,11 @@ export function buildCodexSubagentSpawnArgs(settings: SubagentModelSettings): st
   }
   args.push('-c', 'features.multi_agent_v2.expose_spawn_agent_model_overrides=true');
   if (settings.codex) {
-    args.push('-c', `agents.default_subagent_model=${tomlString(settings.codex)}`);
+    const runtimeModel = codexSubagentRuntimeModelId(settings.codex, settings.codexProviderId);
+    args.push(
+      '-c',
+      `agents.default_subagent_model=${tomlString(runtimeModel)}`,
+    );
   }
   if (settings.codexEffort) {
     args.push('-c', `agents.default_subagent_reasoning_effort=${tomlString(settings.codexEffort)}`);

--- a/apps/desktop/src/main/maker-host/index.ts
+++ b/apps/desktop/src/main/maker-host/index.ts
@@ -219,6 +219,7 @@ import {
 import {
   buildCodexSubagentSpawnArgs,
   resolveCodexSubagentModelFallback,
+  resolveCodexSubagentRouteSnapshot,
 } from './codex-subagent-config.js';
 import { readSubagentModelSettings } from './subagent-model-settings-store.js';
 import {
@@ -1427,6 +1428,10 @@ export function getMaker(): Maker {
           subagentModelSettings,
           ctx.remoteHostId,
         );
+        const subagentRoute = resolveCodexSubagentRouteSnapshot(
+          subagentModelSettings,
+          ctx.remoteHostId,
+        );
         return {
           // 子代理护栏/默认模型每次 createHost 现读 store:DeferredCodexRestart 兑现
           // (dispose host)后的新 spawn 自动带新值。agents.* 对 control-plane 的
@@ -1438,6 +1443,7 @@ export function getMaker(): Maker {
           ],
           extraEnv: mcpExtraEnv,
           ...(subagentModelFallback ? { subagentModelFallback } : {}),
+          ...(subagentRoute ? { subagentRoute } : {}),
           ...(buildSessionMcpConfig ? { buildSessionMcpConfig } : {}),
           codexProxyActive: ready,
           codexBrowserUseAvailable: browserCompanionSpawnConfig.codexBrowserUseAvailable,
@@ -1487,8 +1493,13 @@ export function getMaker(): Maker {
       },
       unregisterCodexMcpThreadContext,
       prepareCodexResumeSession: prepareExternalCodexSessionForResume,
-      registerCodexSystemPromptForThread: ({ sessionId, threadId, text }) =>
-        registerCodexProxyComposed(sessionId, threadId, text),
+      registerCodexSystemPromptForThread: ({
+        sessionId,
+        threadId,
+        text,
+        subagentRoute,
+      }) =>
+        registerCodexProxyComposed(sessionId, threadId, text, { subagentRoute }),
       armCodexHttpRecovery,
       registerCodexChildThreadForParent: ({ parentThreadId, childThreadId }) => {
         registerCodexProxyChildThread(parentThreadId, childThreadId);

--- a/apps/desktop/src/main/maker-host/index.ts
+++ b/apps/desktop/src/main/maker-host/index.ts
@@ -18,6 +18,7 @@ import {
   configureDefaultImageResizer,
   type McpProvider,
 } from '@cindy/maker-core';
+import type { ProviderView } from '@cindy/model-providers';
 import {
   getActiveCatalog,
   setActiveCatalogChangedListener,
@@ -110,6 +111,7 @@ import { buildPiAgent } from './pi-host.js';
 import { clearChatgptBridgeCredentialCache } from './anthropic-responses-bridge-host.js';
 import {
   getDesktopSelectableCatalog,
+  getDesktopProviderService,
   reloadActiveCatalogForEndpointChange,
   refreshDiscoveredCodexModels,
   setNativeProviderClaimListener,
@@ -1428,9 +1430,27 @@ export function getMaker(): Maker {
           subagentModelSettings,
           ctx.remoteHostId,
         );
+        let subagentProviderViews: ProviderView[] | undefined;
+        if (
+          !ctx.remoteHostId
+          && subagentModelSettings.codexSubagentsEnabled
+          && subagentModelSettings.codex?.trim()
+          && !subagentModelSettings.codexProviderId?.trim()
+        ) {
+          try {
+            subagentProviderViews = await getDesktopProviderService().listProviders({
+              allowSideEffects: false,
+            });
+          } catch (err) {
+            desktopMakerLogger.warn('Codex implicit subagent Provider resolution failed', {
+              error: err instanceof Error ? err.message : String(err),
+            });
+          }
+        }
         const subagentRoute = resolveCodexSubagentRouteSnapshot(
           subagentModelSettings,
           ctx.remoteHostId,
+          subagentProviderViews,
         );
         return {
           // 子代理护栏/默认模型每次 createHost 现读 store:DeferredCodexRestart 兑现
@@ -1438,7 +1458,9 @@ export function getMaker(): Maker {
           // model/list 无影响,不加 hostPurpose 分支。
           extraArgs: [
             ...mcpExtraArgs,
-            ...(!isReview ? buildCodexSubagentSpawnArgs(subagentModelSettings) : []),
+            ...(!isReview
+              ? buildCodexSubagentSpawnArgs(subagentModelSettings, subagentRoute)
+              : []),
             ...buildCodexProxySpawnArgs(endpoint, authInjection),
           ],
           extraEnv: mcpExtraEnv,

--- a/apps/desktop/src/main/maker-host/provider-route.ts
+++ b/apps/desktop/src/main/maker-host/provider-route.ts
@@ -534,6 +534,21 @@ export function getSessionRoutingDescriptor(
   return routing;
 }
 
+/** Resolve routing metadata directly from a provider id without consulting session state. */
+export function getProviderRoutingDescriptor(
+  providerId: string | null | undefined,
+  agent: AgentKind,
+  wireModel?: string,
+): RoutingDescriptor | null {
+  const id = providerId?.trim();
+  if (!id || isProviderRouteMutationInProgress(id)) return null;
+  if (id === 'xd' && !getAppCapabilities().canUseCindyGateway) return null;
+  const provider = getActiveCatalog().providers.find((candidate) => candidate.id === id);
+  const routing = provider ? providerRoutingForModel(provider, agent, wireModel) : null;
+  if (!routing || !routingServesWireModel(routing, wireModel)) return null;
+  return routing;
+}
+
 export interface ResolvedSessionRoute {
   providerId: string;
   providerSource: 'builtin' | 'user';
@@ -542,7 +557,7 @@ export interface ResolvedSessionRoute {
   oauthToken: string | null;
 }
 
-async function resolveProviderRouteById(
+export async function resolveProviderRouteById(
   providerId: string,
   agent: AgentKind,
   wireModel?: string,
@@ -667,19 +682,23 @@ export async function resolveProviderRouteDecision(
   providerId: string | null | undefined,
   agent: AgentKind,
   gatewayKey: string | null,
+  wireModel?: string,
 ): Promise<ResolvedProviderRouteDecision | null> {
   const id = providerId?.trim() || null;
   if (!id) return null;
   if (isProviderRouteMutationInProgress(id)) return null;
   if (id === 'xd' && !getAppCapabilities().canUseCindyGateway) return null;
   const provider = getActiveCatalog().providers.find((p) => p.id === id);
-  const routing = provider?.routing[agent];
-  if (!provider || !routing) return null;
+  const routing = provider ? providerRoutingForModel(provider, agent, wireModel) : null;
+  if (!provider || !routing || !routingServesWireModel(routing, wireModel)) return null;
   const { apiKey, oauthToken } = await readProviderRouteCredentials(provider, routing, agent);
+  const decision = buildRouteDecision(routing, gatewayKey, agent, apiKey, oauthToken);
   return {
     providerId: id,
     routing,
-    decision: buildRouteDecision(routing, gatewayKey, agent, apiKey, oauthToken),
+    decision: decision && wireModel && routing.requestPath
+      ? { ...decision, pathOverride: routing.requestPath }
+      : decision,
   };
 }
 
@@ -878,6 +897,32 @@ function rewriteModelIdForProvider(
   const rewritten = model.slice(stripPrefix.length);
   if (!rewritten) return null;
   return { ...body, model: rewritten };
+}
+
+/** Apply a provider's catalog-declared model rewrite to one model id. */
+export function rewriteProviderModelIdForRoute(
+  providerId: string | null | undefined,
+  agent: AgentKind,
+  modelId: string,
+): string {
+  const normalized = modelId.trim();
+  if (!normalized) return normalized;
+  const rewritten = rewriteModelIdForProvider(providerId?.trim() || null, agent, {
+    model: normalized,
+  });
+  return typeof rewritten?.model === 'string' && rewritten.model.length > 0
+    ? rewritten.model
+    : normalized;
+}
+
+/** Apply a provider's model rewrite to a request body without session lookup. */
+export function rewriteProviderModelIdInBody(
+  providerId: string | null | undefined,
+  agent: AgentKind,
+  body: unknown,
+): Record<string, unknown> | null {
+  if (!isPlainObject(body)) return null;
+  return rewriteModelIdForProvider(providerId?.trim() || null, agent, body);
 }
 
 /**

--- a/apps/desktop/src/renderer/__tests__/AgentTaskCard.test.ts
+++ b/apps/desktop/src/renderer/__tests__/AgentTaskCard.test.ts
@@ -111,6 +111,14 @@ describe('AgentTaskCard', () => {
   it('renders the subagent model chip from update.model (live)', () => {
     const { container } = render(
       React.createElement(AgentTaskCard, {
+        toolCall: {
+          clientId: 'c-live',
+          role: 'tool_use',
+          content: '',
+          toolName: 'Agent',
+          toolUseId: 'toolu_LIVE',
+          toolInput: { model: 'sonnet' },
+        },
         update: {
           provider: 'claude-code',
           taskId: 'task-1',
@@ -152,6 +160,40 @@ describe('AgentTaskCard', () => {
       }),
     );
     expect(modelChip(container)).toBeNull();
+  });
+
+  it('does not present a Claude Agent request model as the actual model', () => {
+    const { container } = render(
+      React.createElement(AgentTaskCard, {
+        toolCall: {
+          clientId: 'c-requested',
+          role: 'tool_use',
+          content: '',
+          toolName: 'Agent',
+          toolUseId: 'toolu_REQUESTED',
+          toolInput: { model: 'sonnet' },
+        },
+        result: 'done',
+      }),
+    );
+    expect(modelChip(container)).toBeNull();
+  });
+
+  it('keeps the existing Codex collab explicit model chip fallback', () => {
+    const { container } = render(
+      React.createElement(AgentTaskCard, {
+        toolCall: {
+          clientId: 'c-codex',
+          role: 'tool_use',
+          content: '',
+          toolName: 'collab:spawn',
+          toolUseId: 'call_CODEX',
+          toolInput: { model: 'gpt-5.6-terra' },
+        },
+        result: 'done',
+      }),
+    );
+    expect(modelChip(container)?.textContent).toBe('Gpt 5.6 Terra');
   });
 
   it('does not fall back to stale history or spawn input after an explicit model clear', () => {

--- a/apps/desktop/src/renderer/components/chat/AgentTaskCard.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentTaskCard.tsx
@@ -144,14 +144,18 @@ export function AgentTaskCard({ toolCall, update, result, subagentModel, session
   const { t } = useTranslation();
   const blockId = `task:${toolCall?.clientId ?? update?.taskId ?? 'unknown'}`;
   // subagent-model-chip: 子代理模型 —— 实时态优先 update.model(progress 事件
-  // 带),历史重载(update 缺省)回退到从子消息反查的 subagentModel;两者皆无时
-  // 再回退 spawn 参数里显式指定的 model(codex collab 卡,translator 透传
-  // item.model)。`model: null` 是实时聚合卡的显式清除指令,不能再落到历史/输入兜底,
+  // 带),历史重载(update 缺省)回退到从子消息反查的 subagentModel。Claude
+  // Agent/Task 的 input.model 只是请求值,可能被运行时个性化配置覆盖,不能冒充
+  // 实际模型；Codex collab spawn 沿用既有显式模型展示。`model: null` 是实时聚合卡
+  // 的显式清除指令,不能再落到历史/输入兜底,
   // 否则多 receiver 模型冲突时旧徽标会被重新显示。V1 多 receiver 的实时聚合结论
   // 不落库;重载后既无法证明所有 receiver 都已上报、也无法证明模型一致,所以历史态
-  // 同样不从首条子消息或 spawn 参数猜回单一徽标。默认继承主模型时 spawn 无 model
-  // 字段——不猜继承值,不渲染。
+  // 同样不从首条子消息或 spawn 参数猜回单一徽标。默认继承主模型时 Codex live tracker
+  // 会按 spawn 当刻的运行时模型冻结到 update.model；历史态若没有这条事实仍不猜。
   const receiverThreadIds = readInputStringArray(toolCall?.toolInput, 'receiverThreadIds');
+  const codexSpawnModel = toolCall?.toolName?.startsWith('collab:') === true
+    ? readInputString(toolCall.toolInput, ['model'])
+    : undefined;
   const ambiguousMultiReceiverHistory =
     !update && toolCall?.toolName?.startsWith('collab:') === true && receiverThreadIds.length > 1;
   const modelLabel = formatModelShortLabel(
@@ -159,7 +163,7 @@ export function AgentTaskCard({ toolCall, update, result, subagentModel, session
       ? undefined
       : update?.model ?? (ambiguousMultiReceiverHistory
         ? undefined
-        : subagentModel ?? readInputString(toolCall?.toolInput, ['model'])),
+        : subagentModel ?? codexSpawnModel),
   );
   // codex spawn 可为子代理显式指定思考强度(translator 透传 reasoningEffort);
   // 已知档位才走 effortLevels 词表,未知值不显示。CC 无此参数,行为不变。

--- a/apps/desktop/src/shared/subagentModelSettings.ts
+++ b/apps/desktop/src/shared/subagentModelSettings.ts
@@ -101,11 +101,12 @@ export const SUBAGENT_GUARDRAIL_KEYS = [
 ] as const satisfies readonly (keyof SubagentModelSettings)[];
 
 /**
- * 影响 codex spawn `-c` 注入的键。codexProviderId 是纯客户端展示维度、claude* 走
- * env 通道，均不在内——它们变更不需要重启共享的 codex app-server。
+ * 影响 codex spawn `-c` 注入或默认 Subagent Provider 路由的键。claude* 走 env 通道，
+ * 不在此列表内；Codex 模型或 Provider 变化都需要重启共享的 app-server。
  */
 export const CODEX_SPAWN_AFFECTING_KEYS = [
   'codex',
+  'codexProviderId',
   'codexEffort',
   'codexSubagentsEnabled',
   'codexUseCindySubagentPolicy',

--- a/packages/maker-core/src/agents/base-agent.ts
+++ b/packages/maker-core/src/agents/base-agent.ts
@@ -317,6 +317,12 @@ export interface CodexExtraSpawnConfig {
   extraEnv: Record<string, string>;
   /** Cindy-side display fallback for Codex subagent cards. */
   subagentModelFallback?: string;
+  /** Provider route frozen alongside the default subagent model for this app-server. */
+  subagentRoute?: {
+    providerId: string;
+    catalogModel: string;
+    runtimeModel: string;
+  };
   /** Whether this exact app-server spawn was provisioned with Codex Chrome. */
   codexBrowserUseAvailable?: boolean;
   /** Exact verified Chrome plugin version provisioned into this app-server. */
@@ -923,6 +929,11 @@ export interface AgentDeps {
     sessionId: string;
     threadId: string;
     text: string;
+    subagentRoute?: {
+      providerId: string;
+      catalogModel: string;
+      runtimeModel: string;
+    };
   }) => void;
 
   /**

--- a/packages/maker-core/src/agents/claude-code/__tests__/translator-subagent-model.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/translator-subagent-model.test.ts
@@ -512,7 +512,7 @@ describe('Claude Code translator subagent model attribution', () => {
       model: 'vendor-a/model-sol',
       usage: { totalTokens: 22_113, toolUses: 0, durationMs: 4_949 },
       subagentObservation: {
-        kind: 'terminal',
+        kind: 'spawn',
         logicalSubagentId: 'agent-sync',
         parentToolUseId: 'toolu_sync_agent',
       },
@@ -552,11 +552,11 @@ describe('Claude Code translator subagent model attribution', () => {
       status: 'completed',
       model: 'provider-b/model-terra',
       usage: { totalTokens: 84, toolUses: 2, durationMs: 1_250 },
-      subagentObservation: { kind: 'terminal' },
+      subagentObservation: { kind: 'spawn' },
     });
   });
 
-  it('does not guess a requested model when a completed Agent result has no actual model', async () => {
+  it('uses a child runtime model when a completed Agent result has no resolvedModel', async () => {
     const queue = createAsyncQueue<AgentEvent>();
     const ctx = createCtx();
 
@@ -574,6 +574,15 @@ describe('Claude Code translator subagent model attribution', () => {
             },
           ],
         },
+      },
+      queue,
+      ctx,
+    );
+    translateSdkMessage(
+      {
+        type: 'assistant',
+        parent_tool_use_id: 'toolu_sync_agent',
+        message: { model: 'vendor-runtime/model-actual', content: [] },
       },
       queue,
       ctx,
@@ -600,9 +609,103 @@ describe('Claude Code translator subagent model attribution', () => {
       taskId: 'agent-sync',
       parentToolUseId: 'toolu_sync_agent',
       status: 'completed',
+      model: 'vendor-runtime/model-actual',
+      subagentObservation: { kind: 'spawn' },
+    });
+    expect(taskUpdates.at(-1)?.data).not.toMatchObject({ model: 'requested-model' });
+  });
+
+  it('lets a full child assistant replace an earlier stream model when no resolvedModel exists', async () => {
+    const queue = createAsyncQueue<AgentEvent>();
+    const ctx = createCtx();
+
+    translateSdkMessage(
+      {
+        type: 'stream_event',
+        parent_tool_use_id: 'toolu_sync_agent',
+        event: {
+          type: 'message_start',
+          message: { model: 'vendor-stream/model-early', usage: { input_tokens: 0 } },
+        },
+      },
+      queue,
+      ctx,
+    );
+    translateSdkMessage(
+      {
+        type: 'user',
+        message: {
+          content: [{ type: 'tool_result', tool_use_id: 'toolu_sync_agent', content: 'done' }],
+        },
+        toolUseResult: { status: 'completed', agentId: 'agent-sync' },
+      },
+      queue,
+      ctx,
+    );
+    translateSdkMessage(
+      {
+        type: 'assistant',
+        parent_tool_use_id: 'toolu_sync_agent',
+        message: { model: 'vendor-assistant/model-actual', content: [] },
+      },
+      queue,
+      ctx,
+    );
+
+    const taskUpdates = (await collect(queue)).filter(
+      (event) => event.type === 'agent_task_update',
+    );
+    expect(taskUpdates.at(-2)?.data).toMatchObject({
+      taskId: 'agent-sync',
+      status: 'completed',
+      model: 'vendor-stream/model-early',
+      subagentObservation: { kind: 'spawn' },
+    });
+    expect(taskUpdates.at(-1)?.data).toMatchObject({
+      taskId: 'agent-sync',
+      status: 'completed',
+      model: 'vendor-assistant/model-actual',
       subagentObservation: { kind: 'terminal' },
     });
-    expect(taskUpdates.at(-1)?.data).not.toHaveProperty('model');
+  });
+
+  it('keeps resolvedModel authoritative over a later full child assistant', async () => {
+    const queue = createAsyncQueue<AgentEvent>();
+    const ctx = createCtx();
+
+    translateSdkMessage(
+      {
+        type: 'user',
+        message: {
+          content: [{ type: 'tool_result', tool_use_id: 'toolu_sync_agent', content: 'done' }],
+        },
+        toolUseResult: {
+          status: 'completed',
+          agentId: 'agent-sync',
+          resolvedModel: 'vendor-resolved/model-authoritative',
+        },
+      },
+      queue,
+      ctx,
+    );
+    translateSdkMessage(
+      {
+        type: 'assistant',
+        parent_tool_use_id: 'toolu_sync_agent',
+        message: { model: 'vendor-assistant/model-late', content: [] },
+      },
+      queue,
+      ctx,
+    );
+
+    const taskUpdates = (await collect(queue)).filter(
+      (event) => event.type === 'agent_task_update',
+    );
+    expect(taskUpdates.at(-1)?.data).toMatchObject({
+      taskId: 'agent-sync',
+      status: 'completed',
+      model: 'vendor-resolved/model-authoritative',
+    });
   });
 
   it('repairs zero task tokens from host usage and preserves zero tool uses', async () => {

--- a/packages/maker-core/src/agents/claude-code/__tests__/translator-subagent-model.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/translator-subagent-model.test.ts
@@ -177,6 +177,192 @@ describe('Claude Code assistant text streaming contract', () => {
 });
 
 describe('Claude Code translator subagent model attribution', () => {
+  it('promotes the full child assistant actual model into the parent task update', async () => {
+    const queue = createAsyncQueue<AgentEvent>();
+    const ctx = createCtx();
+
+    // 即使 partial message_start 已先写入 stream map，完整 assistant 仍必须把模型
+    // 提升成 task update；stream map 本身不是「已经对 UI 发布」的证据。
+    translateSdkMessage(
+      {
+        type: 'stream_event',
+        parent_tool_use_id: 'toolu_agent_a',
+        event: {
+          type: 'message_start',
+          message: { model: 'codex/gpt-5.6-sol', usage: { input_tokens: 0 } },
+        },
+      },
+      queue,
+      ctx,
+    );
+    translateSdkMessage(
+      {
+        type: 'assistant',
+        uuid: 'child-assistant',
+        session_id: 'sdk-session',
+        parent_tool_use_id: 'toolu_agent_a',
+        message: {
+          model: 'codex/gpt-5.6-sol',
+          content: [{ type: 'text', text: 'child answer' }],
+        },
+      },
+      queue,
+      ctx,
+    );
+
+    const events = await collect(queue);
+    expect(events.find((event) => event.type === 'agent_task_update')?.data).toEqual({
+      provider: 'claude-code',
+      taskId: 'toolu_agent_a',
+      parentToolUseId: 'toolu_agent_a',
+      status: 'running',
+      model: 'codex/gpt-5.6-sol',
+      subagentObservation: {
+        kind: 'progress',
+        logicalSubagentId: 'toolu_agent_a',
+        parentToolUseId: 'toolu_agent_a',
+      },
+    });
+    expect(events.find((event) => event.type === 'text')?.agentMeta).toEqual(
+      expect.objectContaining({
+        parentUuid: 'toolu_agent_a',
+        model: 'codex/gpt-5.6-sol',
+      }),
+    );
+  });
+
+  it('keeps the child actual model on the later terminal task update', async () => {
+    const queue = createAsyncQueue<AgentEvent>();
+    const ctx = createCtx();
+
+    translateSdkMessage(
+      {
+        type: 'assistant',
+        parent_tool_use_id: 'toolu_agent_a',
+        message: { model: 'codex/gpt-5.6-sol', content: [] },
+      },
+      queue,
+      ctx,
+    );
+    translateSdkMessage(
+      {
+        type: 'system',
+        subtype: 'task_notification',
+        task_id: 'agent-a',
+        tool_use_id: 'toolu_agent_a',
+        status: 'completed',
+        usage: { total_tokens: 42 },
+      },
+      queue,
+      ctx,
+    );
+
+    const taskUpdates = (await collect(queue)).filter(
+      (event) => event.type === 'agent_task_update',
+    );
+    expect(taskUpdates.at(-1)?.data).toMatchObject({
+      taskId: 'agent-a',
+      parentToolUseId: 'toolu_agent_a',
+      status: 'completed',
+      model: 'codex/gpt-5.6-sol',
+    });
+  });
+
+  it('does not reopen a terminal task when the full child assistant arrives late', async () => {
+    const queue = createAsyncQueue<AgentEvent>();
+    const ctx = createCtx();
+
+    translateSdkMessage(
+      {
+        type: 'system',
+        subtype: 'task_notification',
+        task_id: 'agent-a',
+        tool_use_id: 'toolu_agent_a',
+        status: 'completed',
+      },
+      queue,
+      ctx,
+    );
+    translateSdkMessage(
+      {
+        type: 'assistant',
+        parent_tool_use_id: 'toolu_agent_a',
+        message: { model: 'codex/gpt-5.6-sol', content: [] },
+      },
+      queue,
+      ctx,
+    );
+
+    const taskUpdates = (await collect(queue)).filter(
+      (event) => event.type === 'agent_task_update',
+    );
+    expect(taskUpdates.at(-1)?.data).toMatchObject({
+      taskId: 'agent-a',
+      parentToolUseId: 'toolu_agent_a',
+      status: 'completed',
+      model: 'codex/gpt-5.6-sol',
+      subagentObservation: {
+        kind: 'terminal',
+        logicalSubagentId: 'agent-a',
+        parentToolUseId: 'toolu_agent_a',
+      },
+    });
+  });
+
+  it('preserves a terminal task_updated status when the full child assistant arrives late', async () => {
+    const queue = createAsyncQueue<AgentEvent>();
+    const ctx = createCtx();
+
+    translateSdkMessage(
+      {
+        type: 'user',
+        message: {
+          content: [{ type: 'tool_result', tool_use_id: 'toolu_agent_a', content: 'launched' }],
+        },
+        toolUseResult: {
+          isAsync: true,
+          agentId: 'agent-a',
+        },
+      },
+      queue,
+      ctx,
+    );
+    translateSdkMessage(
+      {
+        type: 'system',
+        subtype: 'task_updated',
+        task_id: 'agent-a',
+        patch: { status: 'completed' },
+      },
+      queue,
+      ctx,
+    );
+    translateSdkMessage(
+      {
+        type: 'assistant',
+        parent_tool_use_id: 'toolu_agent_a',
+        message: { model: 'codex/gpt-5.6-sol', content: [] },
+      },
+      queue,
+      ctx,
+    );
+
+    const taskUpdates = (await collect(queue)).filter(
+      (event) => event.type === 'agent_task_update',
+    );
+    expect(taskUpdates.at(-1)?.data).toMatchObject({
+      taskId: 'agent-a',
+      parentToolUseId: 'toolu_agent_a',
+      status: 'completed',
+      model: 'codex/gpt-5.6-sol',
+      subagentObservation: {
+        kind: 'terminal',
+        logicalSubagentId: 'agent-a',
+        parentToolUseId: 'toolu_agent_a',
+      },
+    });
+  });
+
   it('keeps two concurrent subagent stream models isolated from the parent agent', async () => {
     const queue = createAsyncQueue<AgentEvent>();
     const ctx = createCtx();
@@ -280,6 +466,143 @@ describe('Claude Code translator subagent model attribution', () => {
         parentToolUseId: 'toolu_agent_a',
       },
     });
+  });
+
+  it('projects a synchronous completed Agent result with its actual model and usage', async () => {
+    const queue = createAsyncQueue<AgentEvent>();
+    const onSubagentTaskLaunched = vi.fn();
+    const ctx = createCtx({ onSubagentTaskLaunched });
+
+    translateSdkMessage(
+      {
+        type: 'user',
+        message: {
+          role: 'user',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'toolu_sync_agent',
+              content: [{ type: 'text', text: 'The agent completed successfully.' }],
+            },
+          ],
+        },
+        toolUseResult: {
+          status: 'completed',
+          agentId: 'agent-sync',
+          prompt: 'Review the current changes',
+          resolvedModel: 'vendor-a/model-sol',
+          totalTokens: 22_113,
+          totalToolUseCount: 0,
+          totalDurationMs: 4_949,
+        },
+      },
+      queue,
+      ctx,
+    );
+
+    const taskUpdates = (await collect(queue)).filter(
+      (event) => event.type === 'agent_task_update',
+    );
+    expect(taskUpdates).toHaveLength(1);
+    expect(taskUpdates[0].data).toEqual({
+      provider: 'claude-code',
+      taskId: 'agent-sync',
+      parentToolUseId: 'toolu_sync_agent',
+      status: 'completed',
+      model: 'vendor-a/model-sol',
+      usage: { totalTokens: 22_113, toolUses: 0, durationMs: 4_949 },
+      subagentObservation: {
+        kind: 'terminal',
+        logicalSubagentId: 'agent-sync',
+        parentToolUseId: 'toolu_sync_agent',
+      },
+    });
+    expect(onSubagentTaskLaunched).not.toHaveBeenCalled();
+  });
+
+  it('accepts snake_case fields from a synchronous completed Agent result', async () => {
+    const queue = createAsyncQueue<AgentEvent>();
+    const ctx = createCtx();
+
+    translateSdkMessage(
+      {
+        type: 'user',
+        message: {
+          content: [{ type: 'tool_result', tool_use_id: 'toolu_sync_agent', content: 'done' }],
+        },
+        tool_use_result: {
+          status: 'completed',
+          agent_id: 'agent-sync',
+          resolved_model: 'provider-b/model-terra',
+          total_tokens: 84,
+          total_tool_use_count: 2,
+          total_duration_ms: 1_250,
+        },
+      },
+      queue,
+      ctx,
+    );
+
+    const taskUpdates = (await collect(queue)).filter(
+      (event) => event.type === 'agent_task_update',
+    );
+    expect(taskUpdates[0]?.data).toMatchObject({
+      taskId: 'agent-sync',
+      parentToolUseId: 'toolu_sync_agent',
+      status: 'completed',
+      model: 'provider-b/model-terra',
+      usage: { totalTokens: 84, toolUses: 2, durationMs: 1_250 },
+      subagentObservation: { kind: 'terminal' },
+    });
+  });
+
+  it('does not guess a requested model when a completed Agent result has no actual model', async () => {
+    const queue = createAsyncQueue<AgentEvent>();
+    const ctx = createCtx();
+
+    translateSdkMessage(
+      {
+        type: 'assistant',
+        message: {
+          model: 'claude-opus-4-6',
+          content: [
+            {
+              type: 'tool_use',
+              id: 'toolu_sync_agent',
+              name: 'Agent',
+              input: { prompt: 'Review changes', model: 'requested-model' },
+            },
+          ],
+        },
+      },
+      queue,
+      ctx,
+    );
+    translateSdkMessage(
+      {
+        type: 'user',
+        message: {
+          content: [{ type: 'tool_result', tool_use_id: 'toolu_sync_agent', content: 'done' }],
+        },
+        toolUseResult: {
+          status: 'completed',
+          agentId: 'agent-sync',
+        },
+      },
+      queue,
+      ctx,
+    );
+
+    const taskUpdates = (await collect(queue)).filter(
+      (event) => event.type === 'agent_task_update',
+    );
+    expect(taskUpdates.at(-1)?.data).toMatchObject({
+      taskId: 'agent-sync',
+      parentToolUseId: 'toolu_sync_agent',
+      status: 'completed',
+      subagentObservation: { kind: 'terminal' },
+    });
+    expect(taskUpdates.at(-1)?.data).not.toHaveProperty('model');
   });
 
   it('repairs zero task tokens from host usage and preserves zero tool uses', async () => {

--- a/packages/maker-core/src/agents/claude-code/translator.ts
+++ b/packages/maker-core/src/agents/claude-code/translator.ts
@@ -115,12 +115,16 @@ export interface RuntimeState {
   /** tool_use.id → tool_use.name。用于在 tool_result echo 时区分命令输出和内容结果。 */
   toolUseIdToName: Map<string, string>;
   /**
-   * SDK partial stream 按 parent_tool_use_id 隔离的真实模型。
-   * 并发 subagent 的 stream_event 会交错，不能用会话级元数据推断。
+   * SDK child assistant 消息按 parent_tool_use_id 隔离的真实模型。
+   * 并发 subagent 的完整消息与 stream_event 都会交错，不能用会话级元数据推断。
    */
   streamModelByParentToolUseId: Map<string, string>;
-  /** Agent 异步启动回执里的权威模型，优先级高于流式事件里的 wire model。 */
+  /** Agent 工具回执里的权威模型，优先级高于流式事件里的 wire model。 */
   resolvedSubagentModelByParentToolUseId: Map<string, string>;
+  /** 已经通过 agent_task_update 下发过的模型；与 stream map 分离，避免漏发或重复发。 */
+  publishedSubagentModelByParentToolUseId: Map<string, string>;
+  /** parent tool_use.id 对应的最近任务状态；晚到的模型观测不能把终态倒退成 running。 */
+  subagentStatusByParentToolUseId: Map<string, AgentTaskStatus>;
   /** task_id 到启动它的 Agent tool_use.id 的别名映射。 */
   subagentParentToolUseIdByTaskId: Map<string, string>;
   /**
@@ -151,6 +155,8 @@ export function newRuntimeState(): RuntimeState {
     toolUseIdToName: new Map(),
     streamModelByParentToolUseId: new Map(),
     resolvedSubagentModelByParentToolUseId: new Map(),
+    publishedSubagentModelByParentToolUseId: new Map(),
+    subagentStatusByParentToolUseId: new Map(),
     subagentParentToolUseIdByTaskId: new Map(),
     confirmedSubagentTaskIds: new Set(),
     excludedSubagentTaskIds: new Set(),
@@ -338,30 +344,47 @@ function readToolResultFullText(blockRaw: unknown): { toolUseId: string; fullTex
 }
 
 /**
- * 从 Agent 工具的异步启动回执中提取权威模型。
- * Claude Code 会把最终解析后的模型放在 tool_use_result.resolvedModel；这比
- * 流式子消息的时序推断可靠，适合直接补到 AgentTaskUpdate 给任务卡展示。
+ * 从 Agent 工具回执中提取任务身份、生命周期与权威模型。
+ * Claude Code 会把最终解析后的模型放在 tool_use_result.resolvedModel；同步前台
+ * Agent 直接返回 completed，异步 Agent 返回 async_launched。两者都比根据请求参数
+ * 或流式子消息时序推断可靠，应直接投影成 AgentTaskUpdate。
  */
-interface AsyncSubagentLaunch {
+interface SubagentToolResult {
   taskId: string;
   parentToolUseId: string;
   prompt?: string;
   model?: string;
+  status: 'running' | 'completed';
+  usage?: AgentTaskUsage;
 }
 
-function extractAsyncSubagentLaunch(
+function readResultNumber(
+  result: Record<string, unknown>,
+  camelKey: string,
+  snakeKey: string,
+): number | undefined {
+  const value = result[camelKey] ?? result[snakeKey];
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function extractSubagentToolResult(
   msg: {
     message?: { content?: unknown };
     tool_use_result?: unknown;
     toolUseResult?: unknown;
   },
-): AsyncSubagentLaunch | null {
+): SubagentToolResult | null {
   const rawResult = msg.tool_use_result ?? msg.toolUseResult;
   if (!rawResult || typeof rawResult !== 'object' || Array.isArray(rawResult)) return null;
   const result = rawResult as Record<string, unknown>;
   const isAsync = result.isAsync === true || result.is_async === true;
   const status = result.status;
-  if (!isAsync && status !== 'async_launched') return null;
+  const rawAgentId = result.agentId ?? result.agent_id;
+  const agentId = typeof rawAgentId === 'string' && rawAgentId ? rawAgentId : undefined;
+  const isAsyncLaunch = isAsync || status === 'async_launched';
+  // completed 很常见，必须同时有 Agent 专属的 agentId 才能识别为同步子任务回执。
+  const isCompletedAgent = status === 'completed' && Boolean(agentId);
+  if (!isAsyncLaunch && !isCompletedAgent) return null;
 
   const model = typeof result.resolvedModel === 'string'
     ? result.resolvedModel
@@ -378,18 +401,24 @@ function extractAsyncSubagentLaunch(
   }
   if (!toolResult) return null;
 
-  const rawAgentId = result.agentId ?? result.agent_id;
-  const taskId = typeof rawAgentId === 'string' && rawAgentId
-    ? rawAgentId
-    : toolResult.toolUseId;
+  const taskId = agentId ?? toolResult.toolUseId;
   const prompt = typeof result.prompt === 'string' && result.prompt
     ? result.prompt
     : undefined;
+  const usage: AgentTaskUsage = {};
+  const totalTokens = readResultNumber(result, 'totalTokens', 'total_tokens');
+  const toolUses = readResultNumber(result, 'totalToolUseCount', 'total_tool_use_count');
+  const durationMs = readResultNumber(result, 'totalDurationMs', 'total_duration_ms');
+  if (totalTokens !== undefined) usage.totalTokens = totalTokens;
+  if (toolUses !== undefined) usage.toolUses = toolUses;
+  if (durationMs !== undefined) usage.durationMs = durationMs;
   return {
     taskId,
     parentToolUseId: toolResult.toolUseId,
     model,
     prompt,
+    status: isCompletedAgent ? 'completed' : 'running',
+    ...(Object.keys(usage).length > 0 ? { usage } : {}),
   };
 }
 
@@ -569,16 +598,18 @@ export function translateSdkMessage(
           source: 'claude-code',
         });
       }
-      const subagentLaunch = extractAsyncSubagentLaunch(msg);
-      if (subagentLaunch) {
-        const { taskId, parentToolUseId, model, prompt } = subagentLaunch;
+      const subagentResult = extractSubagentToolResult(msg);
+      if (subagentResult) {
+        const { taskId, parentToolUseId, model, prompt, status, usage } = subagentResult;
         ctx.rt.subagentParentToolUseIdByTaskId.set(taskId, parentToolUseId);
         ctx.rt.confirmedSubagentTaskIds.add(taskId);
         ctx.rt.excludedSubagentTaskIds.delete(taskId);
+        ctx.rt.subagentStatusByParentToolUseId.set(parentToolUseId, status);
         if (model) {
           ctx.rt.resolvedSubagentModelByParentToolUseId.set(parentToolUseId, model);
+          ctx.rt.publishedSubagentModelByParentToolUseId.set(parentToolUseId, model);
         }
-        if (prompt) {
+        if (status === 'running' && prompt) {
           ctx.onSubagentTaskLaunched?.({ taskId, parentToolUseId, prompt, model });
         }
         queue.push({
@@ -587,13 +618,14 @@ export function translateSdkMessage(
             provider: 'claude-code',
             taskId,
             parentToolUseId,
-            status: 'running',
+            status,
             subagentObservation: {
-              kind: 'spawn',
+              kind: status === 'running' ? 'spawn' : 'terminal',
               logicalSubagentId: taskId,
               parentToolUseId,
             },
             ...(model ? { model } : {}),
+            ...(usage ? { usage } : {}),
           },
           source: 'claude-code',
         });
@@ -930,6 +962,9 @@ function toClaudeTaskUpdate(msg: {
   if (msg.subtype === 'task_notification') {
     status = msg.status === 'failed' || msg.status === 'stopped' ? msg.status : 'completed';
   }
+  if (parentToolUseId) {
+    rt.subagentStatusByParentToolUseId.set(parentToolUseId, status);
+  }
   const sdkUsage = toClaudeTaskUsage(msg.usage);
   const hostUsage = msg.subtype === 'task_notification'
     ? getSubagentTaskUsage?.(msg.task_id)
@@ -942,6 +977,9 @@ function toClaudeTaskUpdate(msg: {
     ? rt.resolvedSubagentModelByParentToolUseId.get(parentToolUseId)
       ?? rt.streamModelByParentToolUseId.get(parentToolUseId)
     : undefined;
+  if (parentToolUseId && model) {
+    rt.publishedSubagentModelByParentToolUseId.set(parentToolUseId, model);
+  }
   // CLI 对纯心跳帧节流省略该字段;收窄失败/缺失都不下发(undefined = 下游沿用上一帧)。
   const workflowProgress = normalizeWorkflowProgressEntries(msg.workflow_progress);
   const taskType = msg.task_type;
@@ -1018,6 +1056,9 @@ function toClaudeTaskUpdatedPatch(msg: {
   const isKnownSubagent =
     !isExcludedTask &&
     (Boolean(parentToolUseId) || rt.confirmedSubagentTaskIds.has(msg.task_id));
+  if (isKnownSubagent && parentToolUseId) {
+    rt.subagentStatusByParentToolUseId.set(parentToolUseId, status);
+  }
   return {
     provider: 'claude-code',
     taskId: msg.task_id,
@@ -1141,11 +1182,47 @@ function handleAssistant(
   const parentToolUseId = typeof msg.parent_tool_use_id === 'string' && msg.parent_tool_use_id
     ? msg.parent_tool_use_id
     : undefined;
-  // 与 handleStreamEvent 的 streamModel 记录对齐:关闭 partial streaming 时 sidechain
-  // 只有 assistant 消息可作模型来源,loop guard 的按 scope 适用性判定依赖这张表。
-  if (parentToolUseId && typeof assistantMeta.model === 'string' && assistantMeta.model) {
-    ctx.rt.streamModelByParentToolUseId.set(parentToolUseId, assistantMeta.model);
+  // 完整 child assistant 是实际执行模型的正式观测来源。SDK 不保证 child 的
+  // partial message_start 一定向外暴露，所以不能只靠 handleStreamEvent 填模型；
+  // 同时保持 main 新增的 loop guard 按 parent scope 读取同一张 stream model 表。
+  // resolvedModel 若已由启动回执给出仍保持更高优先级；这里把观测提升成 parent-linked
+  // task update，让实时卡片与后续 task_notification 都能沿用同一个 actual model。
+  const assistantModel = typeof assistantMeta.model === 'string' && assistantMeta.model
+    ? assistantMeta.model
+    : undefined;
+  if (parentToolUseId && assistantModel) {
+    ctx.rt.streamModelByParentToolUseId.set(parentToolUseId, assistantModel);
+    const actualModel = ctx.rt.resolvedSubagentModelByParentToolUseId.get(parentToolUseId)
+      ?? assistantModel;
+    const publishedModel = ctx.rt.publishedSubagentModelByParentToolUseId.get(parentToolUseId);
+    if (publishedModel !== actualModel) {
+      let taskId = parentToolUseId;
+      for (const [candidateTaskId, candidateParentId] of ctx.rt.subagentParentToolUseIdByTaskId) {
+        if (candidateParentId !== parentToolUseId) continue;
+        taskId = candidateTaskId;
+        break;
+      }
+      const status = ctx.rt.subagentStatusByParentToolUseId.get(parentToolUseId) ?? 'running';
+      ctx.rt.publishedSubagentModelByParentToolUseId.set(parentToolUseId, actualModel);
+      queue.push({
+        type: 'agent_task_update',
+        data: {
+          provider: 'claude-code',
+          taskId,
+          parentToolUseId,
+          status,
+          model: actualModel,
+          subagentObservation: {
+            kind: status === 'running' ? 'progress' : 'terminal',
+            logicalSubagentId: taskId,
+            parentToolUseId,
+          },
+        },
+        source: 'claude-code',
+      });
+    }
   }
+
   const content = msg.message?.content ?? [];
   // silent-stop 观测素材: 本条消息是否带实质内容(非空 text / 非 thinking 块)。
   // 未知块 fail-safe 为有内容，避免 SDK 新 block 被误续跑。

--- a/packages/maker-core/src/agents/claude-code/translator.ts
+++ b/packages/maker-core/src/agents/claude-code/translator.ts
@@ -601,16 +601,21 @@ export function translateSdkMessage(
       const subagentResult = extractSubagentToolResult(msg);
       if (subagentResult) {
         const { taskId, parentToolUseId, model, prompt, status, usage } = subagentResult;
+        const actualModel = model
+          ?? ctx.rt.resolvedSubagentModelByParentToolUseId.get(parentToolUseId)
+          ?? ctx.rt.streamModelByParentToolUseId.get(parentToolUseId);
         ctx.rt.subagentParentToolUseIdByTaskId.set(taskId, parentToolUseId);
         ctx.rt.confirmedSubagentTaskIds.add(taskId);
         ctx.rt.excludedSubagentTaskIds.delete(taskId);
         ctx.rt.subagentStatusByParentToolUseId.set(parentToolUseId, status);
         if (model) {
           ctx.rt.resolvedSubagentModelByParentToolUseId.set(parentToolUseId, model);
-          ctx.rt.publishedSubagentModelByParentToolUseId.set(parentToolUseId, model);
+        }
+        if (actualModel) {
+          ctx.rt.publishedSubagentModelByParentToolUseId.set(parentToolUseId, actualModel);
         }
         if (status === 'running' && prompt) {
-          ctx.onSubagentTaskLaunched?.({ taskId, parentToolUseId, prompt, model });
+          ctx.onSubagentTaskLaunched?.({ taskId, parentToolUseId, prompt, model: actualModel });
         }
         queue.push({
           type: 'agent_task_update',
@@ -620,11 +625,14 @@ export function translateSdkMessage(
             parentToolUseId,
             status,
             subagentObservation: {
-              kind: status === 'running' ? 'spawn' : 'terminal',
+              // A synchronous completed Agent result may be the first and only
+              // lifecycle observation. It is authoritative to create the run,
+              // while the completed status still keeps the record terminal.
+              kind: 'spawn',
               logicalSubagentId: taskId,
               parentToolUseId,
             },
-            ...(model ? { model } : {}),
+            ...(actualModel ? { model: actualModel } : {}),
             ...(usage ? { usage } : {}),
           },
           source: 'claude-code',

--- a/packages/maker-core/src/agents/codex/__tests__/subagentLiveCards.test.ts
+++ b/packages/maker-core/src/agents/codex/__tests__/subagentLiveCards.test.ts
@@ -289,13 +289,90 @@ describe('createSubagentLiveCardTracker', () => {
 
   it('uses Cindy configured model only until the child thread reports its actual model', () => {
     const tracker = createSubagentLiveCardTracker({ now: () => 0, subagentModelFallback: 'gpt-5.6-terra' });
-    expect(tracker.noteSpawnItem(v2SpawnItem('card-1', 't-child'))).toMatchObject({
+    // Fresh spawn 的初始模型由 translator 合并进原有启动帧，tracker 不重复发帧。
+    expect(tracker.noteSpawnItem(v2SpawnItem('card-1', 't-child'))).toBeNull();
+    expect(tracker.handleDescendantNotification('t-child', 'turn/started', {})).toMatchObject({
       taskId: 'card-1',
       model: 'gpt-5.6-terra',
     });
 
     expect(tracker.noteDescendantThread('t-child', 'root-thread', 'codex/gpt-5.5')).toMatchObject({
       model: 'codex/gpt-5.5',
+    });
+  });
+
+  it('freezes the parent model for a spawn without a configured or explicit child model', () => {
+    const tracker = createSubagentLiveCardTracker({ now: () => 0 });
+    expect(tracker.noteSpawnItem(
+      v2SpawnItem('card-1', 't-child'),
+      'provider-a/model-parent',
+    )).toBeNull();
+    expect(tracker.handleDescendantNotification('t-child', 'turn/started', {})).toMatchObject({
+      taskId: 'card-1',
+      model: 'provider-a/model-parent',
+    });
+
+    // 同一 spawn 的 completed phase 晚到时，即使父线程已切模，也不能改写已冻结值。
+    expect(
+      tracker.noteSpawnItem(v2SpawnItem('card-1', 't-child'), 'provider-b/model-next'),
+    ).toMatchObject({ model: 'provider-a/model-parent' });
+    // 新 spawn 才继承新模型。
+    expect(tracker.noteSpawnItem(
+      v2SpawnItem('card-2', 't-child-2'),
+      'provider-b/model-next',
+    )).toBeNull();
+    expect(tracker.handleDescendantNotification('t-child-2', 'turn/started', {})).toMatchObject({
+      model: 'provider-b/model-next',
+    });
+  });
+
+  it('keeps explicit and configured child defaults ahead of parent inheritance', () => {
+    const configured = createSubagentLiveCardTracker({
+      now: () => 0,
+      subagentModelFallback: 'provider-config/model-child',
+    });
+    expect(configured.noteSpawnItem(
+      v2SpawnItem('card-config', 't-config'),
+      'provider-parent/model-root',
+    )).toBeNull();
+    expect(configured.handleDescendantNotification('t-config', 'turn/started', {})).toMatchObject({
+      model: 'provider-config/model-child',
+    });
+    expect(configured.noteSpawnItem(
+      v2SpawnItem('card-explicit', 't-explicit', undefined, 'provider-explicit/model-child'),
+      'provider-parent/model-root',
+    )).toBeNull();
+    expect(configured.handleDescendantNotification('t-explicit', 'turn/started', {})).toMatchObject({
+      model: 'provider-explicit/model-child',
+    });
+  });
+
+  it('inherits a nested spawn from its direct parent and lets runtime observation override it', () => {
+    const tracker = createSubagentLiveCardTracker({ now: () => 0 });
+    tracker.noteSpawnItem(v2SpawnItem('card-parent', 't-parent'), 'provider-a/model-root');
+    expect(
+      tracker.noteDescendantThread('t-grandchild', 't-parent', undefined, false, true),
+    ).toMatchObject({ model: 'provider-a/model-root' });
+
+    expect(
+      tracker.noteDescendantThread('t-grandchild', 't-parent', 'provider-b/model-actual'),
+    ).toMatchObject({ model: null });
+    expect(
+      tracker.noteDescendantThread('t-parent', 'root-thread', 'provider-b/model-actual'),
+    ).toMatchObject({ model: 'provider-b/model-actual' });
+  });
+
+  it('preserves nested inheritance when lineage arrives before the parent spawn item', () => {
+    const tracker = createSubagentLiveCardTracker({ now: () => 0 });
+    expect(
+      tracker.noteDescendantThread('t-grandchild', 't-parent', undefined, false, true),
+    ).toBeNull();
+    expect(tracker.noteSpawnItem(
+      v2SpawnItem('card-parent', 't-parent'),
+      'provider-a/model-root',
+    )).toBeNull();
+    expect(tracker.handleDescendantNotification('t-grandchild', 'turn/started', {})).toMatchObject({
+      model: 'provider-a/model-root',
     });
   });
 
@@ -326,7 +403,8 @@ describe('createSubagentLiveCardTracker', () => {
     // 多 receiver 卡:只有部分线程报了模型时,不许把局部观测投影成全卡事实;
     // 也不回退到配置兜底(已有相反观测,兜底反而更可能是错的)(codex review)。
     const tracker = createSubagentLiveCardTracker({ now: () => 0, subagentModelFallback: 'gpt-5.6-terra' });
-    expect(tracker.noteSpawnItem(v1SpawnItem('card-v1', ['t-a', 't-b']))).toMatchObject({
+    expect(tracker.noteSpawnItem(v1SpawnItem('card-v1', ['t-a', 't-b']))).toBeNull();
+    expect(tracker.handleDescendantNotification('t-a', 'turn/started', {})).toMatchObject({
       model: 'gpt-5.6-terra',
     });
 
@@ -343,10 +421,12 @@ describe('createSubagentLiveCardTracker', () => {
   it('hides the aggregate model badge when receiver threads report different models', () => {
     const tracker = createSubagentLiveCardTracker({ now: () => 0, subagentModelFallback: 'gpt-5.6-terra' });
     tracker.noteSpawnItem(v1SpawnItem('card-v1', ['t-a', 't-b']));
-    tracker.noteDescendantThread('t-a', 'root-1', 'codex/gpt-5.5');
+    expect(tracker.noteDescendantThread('t-a', 'root-1', 'codex/gpt-5.5')).toMatchObject({
+      model: null,
+    });
     const conflicting = tracker.noteDescendantThread('t-b', 'root-1', 'gpt-5.6-terra');
-    expect(conflicting).not.toBeNull();
-    expect(conflicting?.model).toBeNull();
+    // t-b 的实际值与其已冻结默认值相同，聚合结论仍是冲突，无需重复发帧。
+    expect(conflicting).toBeNull();
   });
 
   it('clears an observed model when a quiet descendant joins the card', () => {

--- a/packages/maker-core/src/agents/codex/__tests__/subagentLiveCards.test.ts
+++ b/packages/maker-core/src/agents/codex/__tests__/subagentLiveCards.test.ts
@@ -362,6 +362,46 @@ describe('createSubagentLiveCardTracker', () => {
     ).toMatchObject({ model: 'provider-b/model-actual' });
   });
 
+  it('does not let a late nested spawn fallback replace an observed runtime model', () => {
+    const tracker = createSubagentLiveCardTracker({
+      now: () => 0,
+      subagentModelFallback: 'provider-config/model-child',
+    });
+    tracker.noteSpawnItem(v2SpawnItem('card-parent', 't-parent'));
+    tracker.noteDescendantThread('t-parent', 'root-thread', 'provider-runtime/model-actual');
+    tracker.noteDescendantThread('t-grandchild', 't-parent', 'provider-runtime/model-actual');
+
+    // The nested spawn item can arrive after thread/started. Its configured
+    // fallback is lower-confidence than the already observed runtime model.
+    expect(
+      tracker.noteDescendantThread('t-grandchild', 't-parent', undefined, false, true),
+    ).toBeNull();
+    expect(
+      tracker.handleDescendantNotification('t-grandchild', 'turn/started', {
+        turn: { id: 'grandchild-turn' },
+      }),
+    ).toMatchObject({ model: 'provider-runtime/model-actual' });
+  });
+
+  it('preserves a buffered runtime model when lower-priority nested spawn metadata arrives later', () => {
+    const tracker = createSubagentLiveCardTracker({
+      now: () => 0,
+      subagentModelFallback: 'provider-config/model-child',
+    });
+    tracker.noteDescendantThread('t-grandchild', 't-parent', 'provider-runtime/model-actual');
+    tracker.noteDescendantThread('t-grandchild', 't-parent', undefined, false, true);
+    tracker.noteSpawnItem(v2SpawnItem('card-parent', 't-parent'));
+
+    expect(
+      tracker.handleDescendantNotification('t-grandchild', 'turn/started', {
+        turn: { id: 'grandchild-turn' },
+      }),
+    ).toMatchObject({ model: null });
+    expect(
+      tracker.noteDescendantThread('t-parent', 'root-thread', 'provider-runtime/model-actual'),
+    ).toMatchObject({ model: 'provider-runtime/model-actual' });
+  });
+
   it('preserves nested inheritance when lineage arrives before the parent spawn item', () => {
     const tracker = createSubagentLiveCardTracker({ now: () => 0 });
     expect(
@@ -612,6 +652,31 @@ describe('createSubagentLiveCardTracker', () => {
     tracker.handleDescendantNotification('t-a', 'turn/completed', { turn: { status: 'failed' } });
     tracker.handleDescendantNotification('t-b', 'turn/completed', { turn: { status: 'completed' } });
     expect(tracker.noteSpawnItem(v1SpawnItem('card-v1', ['t-a', 't-b']))?.status).toBe('failed');
+  });
+
+  it('re-asserts running for a fresh completed-only spawn whose agents are still active', () => {
+    const tracker = createSubagentLiveCardTracker({ now: () => 0 });
+    const completedOnly = {
+      ...v1SpawnItem('card-v1', ['t-a']),
+      status: 'completed',
+      agentsStates: { 't-a': { status: 'running' } },
+    };
+
+    expect(tracker.noteSpawnItem(completedOnly, undefined, 'completed')).toMatchObject({
+      taskId: 'card-v1',
+      status: 'running',
+    });
+  });
+
+  it('does not add a redundant frame for a fresh completed-only spawn whose agents are terminal', () => {
+    const tracker = createSubagentLiveCardTracker({ now: () => 0 });
+    const completedOnly = {
+      ...v1SpawnItem('card-v1', ['t-a']),
+      status: 'completed',
+      agentsStates: { 't-a': { status: 'completed' } },
+    };
+
+    expect(tracker.noteSpawnItem(completedOnly, undefined, 'completed')).toBeNull();
   });
 
   it('never overwrites a failed spawn terminal state with a running aggregate', () => {

--- a/packages/maker-core/src/agents/codex/app-server/host.ts
+++ b/packages/maker-core/src/agents/codex/app-server/host.ts
@@ -274,6 +274,12 @@ export interface AppServerHostOptions {
   buildSessionMcpConfig?: (sessionInstanceId: string) => Record<string, unknown>;
   /** Cindy-side fallback used only when a subagent's actual model is not reported. */
   subagentModelFallback?: string;
+  /** Frozen provider/catalog/runtime identity for the configured default subagent model. */
+  subagentRoute?: {
+    providerId: string;
+    catalogModel: string;
+    runtimeModel: string;
+  };
 }
 
 interface BufferedNotification {
@@ -432,6 +438,14 @@ export class AppServerHost {
   /** Display metadata only; observed thread model always wins. */
   getSubagentModelFallback(): string | undefined {
     return this.opts.subagentModelFallback;
+  }
+
+  getSubagentRoute(): {
+    providerId: string;
+    catalogModel: string;
+    runtimeModel: string;
+  } | undefined {
+    return this.opts.subagentRoute;
   }
 
   getConnectionId(): string {

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -371,6 +371,12 @@ function installFakeHost(
     codexBrowserUseVersion?: string;
     codexBrowserMcpToolAvailable?: boolean;
     remoteCompactionProviderId?: string;
+    subagentModelFallback?: string;
+    subagentRoute?: {
+      providerId: string;
+      catalogModel: string;
+      runtimeModel: string;
+    };
     userAgent?: string;
     codexHome?: string;
     buildSessionMcpConfig?: (sessionInstanceId?: string) => Record<string, unknown>;
@@ -441,6 +447,8 @@ function installFakeHost(
   const getSessionMcpConfig = vi.fn((sessionInstanceId?: string) =>
     opts.buildSessionMcpConfig?.(sessionInstanceId) ?? {},
   );
+  const getSubagentModelFallback = vi.fn(() => opts.subagentModelFallback);
+  const getSubagentRoute = vi.fn(() => opts.subagentRoute);
   const host = {
     ensureStarted,
     // startSession 的 initialize 直调走限时变体 (codex R13 P1): fake 里
@@ -455,6 +463,8 @@ function installFakeHost(
     waitForMcpTool,
     getRemoteCompactionProviderId,
     getSessionMcpConfig,
+    getSubagentModelFallback,
+    getSubagentRoute,
     getConnectionId: () => 'test-connection',
     getThreadHandlers: () => threadHandlers,
     // 0.145 不给 spawn 子线程发 thread/started,session 层改为从 spawn item 主动
@@ -3639,7 +3649,7 @@ describe('CodexAgent.startSession developerInstructions', () => {
     expect(unregisterCodexMcpThreadContext).toHaveBeenCalledWith('grandchild-thread-id');
   });
 
-  it('keeps thread/start developerInstructions on the websocket provider and skips proxy registration', async () => {
+  it('keeps thread/start developerInstructions on the websocket provider and registers child route context', async () => {
     const registerCodexSystemPromptForThread = vi.fn();
     const agent = new CodexAgent(createDeps(
       { systemPrompt: 'HOST PRODUCT PROMPT' },
@@ -3651,6 +3661,12 @@ describe('CodexAgent.startSession developerInstructions', () => {
     const host = installFakeHost(agent, undefined, {
       codexProxyActive: true,
       remoteCompactionProviderId: 'cindy_openai',
+      subagentModelFallback: 'codex/gpt-5.6-terra',
+      subagentRoute: {
+        providerId: 'xd',
+        catalogModel: 'codex/gpt-5.6-terra',
+        runtimeModel: 'gpt-5.6-terra',
+      },
     });
 
     const handle = await agent.startSession({
@@ -3669,7 +3685,16 @@ describe('CodexAgent.startSession developerInstructions', () => {
     expect(params.developerInstructions).toContain('HOST PRODUCT PROMPT');
     expect(params.developerInstructions).toContain('GHOST ROSTER PROMPT');
     expect(params.developerInstructions).toContain('USER PROMPT');
-    expect(registerCodexSystemPromptForThread).not.toHaveBeenCalled();
+    expect(registerCodexSystemPromptForThread).toHaveBeenCalledWith({
+      sessionId: 'session-websocket-start',
+      threadId: 'start-thread-id',
+      text: expect.stringContaining('HOST PRODUCT PROMPT'),
+      subagentRoute: {
+        providerId: 'xd',
+        catalogModel: 'codex/gpt-5.6-terra',
+        runtimeModel: 'gpt-5.6-terra',
+      },
+    });
     expect(handle.codexProductPromptDelivery).toEqual({
       threadId: 'start-thread-id',
       historyHasProductPrompt: true,
@@ -3723,7 +3748,11 @@ describe('CodexAgent.startSession developerInstructions', () => {
     expect(resumeParams.developerInstructions).toBe(startParams.developerInstructions);
     expect(resumeParams.developerInstructions).toContain('HOST PRODUCT PROMPT');
     expect(resumeParams.developerInstructions).toContain('USER PROMPT');
-    expect(registerCodexSystemPromptForThread).not.toHaveBeenCalled();
+    expect(registerCodexSystemPromptForThread).toHaveBeenCalledWith({
+      sessionId: 'session-websocket-daemon-recovery',
+      threadId: 'start-thread-id',
+      text: expect.stringContaining('HOST PRODUCT PROMPT'),
+    });
     await handle.close();
   });
 
@@ -3811,7 +3840,11 @@ describe('CodexAgent.startSession developerInstructions', () => {
     expect(params.modelProvider).toBe('cindy_openai');
     expect(params.developerInstructions).toContain('HOST PRODUCT PROMPT');
     expect(params.developerInstructions).toContain('USER PROMPT');
-    expect(registerCodexSystemPromptForThread).not.toHaveBeenCalled();
+    expect(registerCodexSystemPromptForThread).toHaveBeenCalledWith({
+      sessionId: 'session-websocket-resume',
+      threadId: 'resume-thread-id',
+      text: expect.stringContaining('HOST PRODUCT PROMPT'),
+    });
     expect(handle.codexProductPromptDelivery).toEqual({
       threadId: 'resume-thread-id',
       historyHasProductPrompt: true,
@@ -3847,7 +3880,11 @@ describe('CodexAgent.startSession developerInstructions', () => {
     expect(params.modelProvider).toBe('cindy_openai');
     expect(params.developerInstructions).toContain('HOST PRODUCT PROMPT');
     expect(params.developerInstructions).toContain('USER PROMPT');
-    expect(registerCodexSystemPromptForThread).not.toHaveBeenCalled();
+    expect(registerCodexSystemPromptForThread).toHaveBeenCalledWith({
+      sessionId: 'session-websocket-resume-existing-prompt',
+      threadId: 'resume-thread-id',
+      text: expect.stringContaining('HOST PRODUCT PROMPT'),
+    });
     expect(handle.codexProductPromptDelivery).toEqual({
       threadId: 'resume-thread-id',
       historyHasProductPrompt: true,
@@ -23114,6 +23151,17 @@ describe('CodexAgent context window reporting', () => {
       },
     });
     expect(host.registerDescendantLineage).toHaveBeenCalledWith('child-thread-v2', 'start-thread-id');
+    await vi.waitFor(() => {
+      const spawned = events
+        .filter((event) => event.type === 'agent_task_update')
+        .map((event) => event.data as { taskId?: string; status?: string; model?: string })
+        .filter((update) => update.taskId === 'spawn-v2-1');
+      // 未配置个性化子模型时，Codex 按协议继承本 turn 的父模型；卡片应冻结并显示它。
+      // 模型直接合并进 translator 原有帧，不得为显示模型额外插入第二条 running update。
+      expect(spawned).toEqual([
+        expect.objectContaining({ status: 'running', model: 'gpt-5.4' }),
+      ]);
+    });
 
     // 子线程全程只有 item / tokenUsage / turn 通知(0.145 真实形状),没有 thread/started。
     handlers.descendantNotification('child-thread-v2', 'item/completed', {
@@ -23149,13 +23197,19 @@ describe('CodexAgent context window reporting', () => {
     await vi.waitFor(() => {
       const updates = events
         .filter((e) => e.type === 'agent_task_update')
-        .map((e) => e.data as { taskId?: string; status?: string; usage?: { totalTokens?: number; toolUses?: number } })
+        .map((e) => e.data as {
+          taskId?: string;
+          status?: string;
+          model?: string;
+          usage?: { totalTokens?: number; toolUses?: number };
+        })
         .filter((u) => u.taskId === 'spawn-v2-1');
       const last = updates.at(-1);
       // 子线程 + 孙线程全部收口 → 卡片终态 completed,并带聚合用量。
       expect(last?.status).toBe('completed');
       expect(last?.usage?.toolUses).toBe(1);
       expect(last?.usage?.totalTokens).toBe(1_000);
+      expect(last?.model).toBe('gpt-5.4');
     });
 
     await handle.close();

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -19216,6 +19216,81 @@ describe('CodexAgent turn lifecycle', () => {
     await handle.close();
   });
 
+  it('REPRO: keeps a completed-only spawn running while its agentsStates are active', async () => {
+    const agent = new CodexAgent(createDeps());
+    const host = installFakeHost(agent);
+    const handle = await agent.startSession({
+      sessionId: 'session-completed-only-running-collab',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+    });
+    const handlers = host.getThreadHandlers();
+    expect(handlers).toBeDefined();
+    const iterator = handle.events()[Symbol.asyncIterator]();
+
+    handlers!.turnStarted?.({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-parent' },
+    });
+    handlers!.turnCompleted?.({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-parent', status: 'completed' },
+    });
+    expect(await nextEvent(iterator)).toMatchObject({ type: 'status' });
+    expect(await nextEvent(iterator)).toMatchObject({ type: 'done' });
+
+    handlers!.itemCompleted?.({
+      threadId: 'start-thread-id',
+      turnId: 'turn-parent',
+      item: {
+        type: 'collabAgentToolCall',
+        id: 'collab-completed-only-running',
+        tool: 'spawnAgent',
+        status: 'completed',
+        senderThreadId: 'start-thread-id',
+        receiverThreadIds: ['child-thread'],
+        prompt: 'continue after the spawn tool returns',
+        agentsStates: { 'child-thread': { status: 'running' } },
+      },
+    } as never);
+
+    expect(await nextEvent(iterator)).toMatchObject({
+      type: 'tool_use',
+      turnScope: 'background',
+      data: { toolUseId: 'collab-completed-only-running' },
+    });
+    expect(await nextEvent(iterator)).toMatchObject({
+      type: 'tool_result_full',
+      turnScope: 'background',
+    });
+    expect(await nextEvent(iterator)).toMatchObject({
+      type: 'tool_result',
+      turnScope: 'background',
+    });
+    expect(await nextEvent(iterator)).toMatchObject({
+      type: 'agent_task_update',
+      turnScope: 'background',
+      data: { taskId: 'collab-completed-only-running', status: 'completed' },
+    });
+    expect(await nextEvent(iterator)).toMatchObject({
+      type: 'agent_task_update',
+      turnScope: 'background',
+      data: { taskId: 'collab-completed-only-running', status: 'running' },
+    });
+
+    handlers!.descendantNotification?.('child-thread', 'turn/completed', {
+      threadId: 'child-thread',
+      turn: { id: 'child-turn', status: 'completed' },
+    });
+    expect(await nextEvent(iterator)).toMatchObject({
+      type: 'agent_task_update',
+      turnScope: 'background',
+      data: { taskId: 'collab-completed-only-running', status: 'completed' },
+    });
+
+    await handle.close();
+  });
+
   it('REPRO: preserves a late collab-agent terminal update after a terminal error', async () => {
     const agent = new CodexAgent(createDeps());
     const host = installFakeHost(agent);

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -140,6 +140,7 @@ import {
 import {
   createSubagentLiveCardTracker,
   type SubagentLiveCardUpdate,
+  type SubagentSpawnItemPhase,
 } from './subagent-live-cards.js';
 import {
   TurnRetryTracker,
@@ -4470,12 +4471,13 @@ export class CodexAgent extends BaseAgent {
     const noteSubagentSpawnItem = (
       item: unknown,
       rootTurnId: string,
+      phase: SubagentSpawnItemPhase,
     ): SubagentLiveCardUpdate | null => {
       if (!registerSubagentSpawnLineage(item, rootTurnId)) return null;
       // 先接 host 路由再进 tracker:registerDescendantLineage 会把子线程 TTL 缓冲里的
       // 早到通知同步补投进 handleDescendantNotification(tracker 缓冲),随后
       // noteSpawnItem 建卡时统一重放,首帧就带上真实用量。
-      return subagentLiveCards.noteSpawnItem(item);
+      return subagentLiveCards.noteSpawnItem(item, undefined, phase);
     };
     const terminateHandleAfterThreadCleanupFailure = (reason: string): void => {
       if (closed) return;
@@ -9360,7 +9362,11 @@ export class CodexAgent extends BaseAgent {
         const translatedParams = translatedItem === params.item
           ? params
           : { ...params, item: translatedItem };
-        const replayedSubagentUpdate = noteSubagentSpawnItem(translatedItem, params.turnId);
+        const replayedSubagentUpdate = noteSubagentSpawnItem(
+          translatedItem,
+          params.turnId,
+          'started',
+        );
         pushItemStatus(translatedItem);
         translateItemNotification('started', translatedParams, eventQueue, {
           rt: translatorRt,
@@ -9401,7 +9407,11 @@ export class CodexAgent extends BaseAgent {
         const translatedParams = translatedItem === params.item
           ? params
           : { ...params, item: translatedItem };
-        const replayedSubagentUpdateOnUpdated = noteSubagentSpawnItem(translatedItem, params.turnId);
+        const replayedSubagentUpdateOnUpdated = noteSubagentSpawnItem(
+          translatedItem,
+          params.turnId,
+          'updated',
+        );
         translateItemNotification('updated', translatedParams, eventQueue, {
           rt: translatorRt,
           log,
@@ -9464,6 +9474,7 @@ export class CodexAgent extends BaseAgent {
         const replayedSubagentUpdateOnCompleted = noteSubagentSpawnItem(
           translatedItem,
           params.turnId,
+          'completed',
         );
         const itemEventQueue = isLateCollabTerminal
           ? {

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -2498,6 +2498,7 @@ export class CodexAgent extends BaseAgent {
     let remoteCompactionProviderId: string | undefined;
     let buildSessionMcpConfig: CodexExtraSpawnConfig['buildSessionMcpConfig'];
     let subagentModelFallback: string | undefined;
+    let subagentRoute: CodexExtraSpawnConfig['subagentRoute'];
     for (;;) {
       const upgradedToSuperset = spawnCredentialMode !== credentialMode;
       onSpawnCredentialModeResolved?.(spawnCredentialMode);
@@ -2523,6 +2524,7 @@ export class CodexAgent extends BaseAgent {
       remoteCompactionProviderId = undefined;
       buildSessionMcpConfig = undefined;
       subagentModelFallback = undefined;
+      subagentRoute = undefined;
       if (this.deps.prepareCodexExtraSpawnConfig) {
         try {
           const cfg = await this.deps.prepareCodexExtraSpawnConfig(
@@ -2538,6 +2540,7 @@ export class CodexAgent extends BaseAgent {
           extraArgs = cfg.extraArgs;
           buildSessionMcpConfig = cfg.buildSessionMcpConfig;
           subagentModelFallback = cfg.subagentModelFallback;
+          subagentRoute = cfg.subagentRoute;
           codexProxyActive = cfg.codexProxyActive === true && !remoteHostId;
           // Remote daemons own their browser companion and its CODEX_HOME;
           // preserve the host-provided availability snapshot instead of
@@ -2632,6 +2635,7 @@ export class CodexAgent extends BaseAgent {
       remoteCompactionProviderId,
       buildSessionMcpConfig,
       subagentModelFallback,
+      subagentRoute,
       // app-server 对失败 RPC 返回 cloudRequirements + Auth/relogin 结构化错误时,当前 host
       // 持有的 token 已不可用。stderr 与工具输出只做诊断,绝不驱动鉴权状态。保留 host 只会
       // 持续撞鉴权失败; auth.invalidate 会触发 logout + 通知 UI 重登。延后到 microtask
@@ -3212,6 +3216,8 @@ export class CodexAgent extends BaseAgent {
       quarantined: boolean;
       terminalSettled: boolean;
       capabilitySelectionText: string;
+      /** Catalog model frozen for this turn/start request. */
+      model?: string;
       sendGen: number;
       startedAtMs: number;
     }>();
@@ -3237,6 +3243,7 @@ export class CodexAgent extends BaseAgent {
         quarantined: false,
         terminalSettled: false,
         capabilitySelectionText,
+        ...(activeTurnModel ? { model: activeTurnModel } : {}),
         sendGen: ownerSendGen,
         startedAtMs: Date.now(),
       });
@@ -3286,6 +3293,8 @@ export class CodexAgent extends BaseAgent {
       startSeq: number | null;
       sendGen: number;
       startedAtMs: number;
+      /** Catalog model accepted for this turn; spawn cards freeze inheritance from this value. */
+      model?: string;
     }>();
 
     const hasOtherInFlightStart = (seq: number): boolean => {
@@ -4203,10 +4212,11 @@ export class CodexAgent extends BaseAgent {
      * 只在同步的 emitSubagentCardUpdate 内为 true(见那里的注释)。
      */
     let emittingDescendantUpdate = false;
+    const configuredSubagentModelFallback = host.getSubagentModelFallback?.();
     const subagentLiveCards = createSubagentLiveCardTracker({
       // Fake/legacy hosts used by older callers may not expose this optional
       // Cindy metadata accessor; absence must remain an honest no-model state.
-      subagentModelFallback: host.getSubagentModelFallback?.(),
+      subagentModelFallback: configuredSubagentModelFallback,
     });
 
     const emitSubagentCardUpdate = (
@@ -4394,6 +4404,7 @@ export class CodexAgent extends BaseAgent {
               childThreadId,
               nested.model,
               nested.failed === true,
+              true,
             );
             if (replayedNested) {
               emitSubagentCardUpdate(
@@ -4445,6 +4456,17 @@ export class CodexAgent extends BaseAgent {
      *    status=completed —— 那只是 spawn 工具调用自己收口,子线程可能还在跑。不重新声明
      *    就会把运行中的子代理提前标成完成,还会抹掉先到的 failed/stopped(review)。
      */
+    const withFrozenSubagentSpawnModel = <T,>(item: T, rootTurnId: string): T => {
+      const registration = readCodexSubagentSpawnRegistration(item);
+      if (!registration || registration.model) return item;
+      const inheritedModel = turnOriginByTurnId.get(rootTurnId)?.model ?? activeTurnModel;
+      const model = configuredSubagentModelFallback ?? inheritedModel;
+      if (!model || !item || typeof item !== 'object' || Array.isArray(item)) return item;
+      // Codex 原生未显式指定子模型时会继承父 turn。把 spawn 当刻冻结的有效模型
+      // 注入本次内部翻译视图，让原有 tool/task 启动帧携带它；不修改上游对象。
+      return { ...(item as Record<string, unknown>), model } as T;
+    };
+
     const noteSubagentSpawnItem = (
       item: unknown,
       rootTurnId: string,
@@ -4804,7 +4826,13 @@ export class CodexAgent extends BaseAgent {
       registeredDeveloperInstructions = text;
       const register = this.deps.registerCodexSystemPromptForThread;
       if (!register) return;
-      register({ sessionId: sid, threadId, text });
+      const subagentRoute = host.getSubagentRoute?.();
+      register({
+        sessionId: sid,
+        threadId,
+        text,
+        ...(subagentRoute ? { subagentRoute } : {}),
+      });
     };
     const refreshCodexAutoReviewerRoute = (targetThreadId: string): void => {
       const routeCredentialMode = resolveAgentCredentialMode({
@@ -4960,8 +4988,10 @@ export class CodexAgent extends BaseAgent {
         }
         threadId = resp.thread.id;
         refreshCodexAutoReviewerRoute(threadId);
-        if (useProxyChannel) {
+        if (hostUsesCodexProxy) {
           registerCodexDeveloperInstructions(threadId, developerInstructions);
+        }
+        if (useProxyChannel) {
           codexProductPromptDelivery = { threadId, historyHasProductPrompt: false };
         } else if (shouldSendNativeDeveloperInstructions) {
           codexProductPromptDelivery = { threadId, historyHasProductPrompt: true };
@@ -5032,8 +5062,10 @@ export class CodexAgent extends BaseAgent {
         }
         threadId = resp.thread.id;
         refreshCodexAutoReviewerRoute(threadId);
-        if (useProxyChannel) {
+        if (hostUsesCodexProxy) {
           registerCodexDeveloperInstructions(threadId, developerInstructions);
+        }
+        if (useProxyChannel) {
           codexProductPromptDelivery = { threadId, historyHasProductPrompt: false };
         } else if (developerInstructions) {
           codexProductPromptDelivery = { threadId, historyHasProductPrompt: true };
@@ -5207,8 +5239,10 @@ export class CodexAgent extends BaseAgent {
             void pushThreadSettings({ serviceTier: mutableServiceTier ?? null });
           }
         }
-        if (useProxyChannel) {
+        if (hostUsesCodexProxy) {
           registerCodexDeveloperInstructions(threadId, developerInstructions);
+        }
+        if (useProxyChannel) {
           codexProductPromptDelivery = { threadId, historyHasProductPrompt: false };
         } else {
           codexProductPromptDelivery = developerInstructions
@@ -9051,6 +9085,7 @@ export class CodexAgent extends BaseAgent {
           ? startedOwnerEntries[0]
           : undefined;
         const existingTurnOrigin = turnOriginByTurnId.get(params.turn.id);
+        const turnModel = startedOwner?.[1].model ?? existingTurnOrigin?.model ?? activeTurnModel;
         turnOriginByTurnId.set(params.turn.id, {
           startSeq: startedOwner?.[0] ?? null,
           sendGen: startedOwner?.[1].sendGen ?? sendGeneration,
@@ -9059,6 +9094,7 @@ export class CodexAgent extends BaseAgent {
             ?? (existingTurnOrigin
               ? existingTurnOrigin.startedAtMs
               : (startedOwnerEntries.length === 0 ? Date.now() : 0)),
+          ...(turnModel ? { model: turnModel } : {}),
         });
         // Notifications may arrive before the turn/start RPC response. Bind the
         // selector at the same unique-owner boundary as turnOrigin so an early
@@ -9320,9 +9356,13 @@ export class CodexAgent extends BaseAgent {
         noteActiveToolContext(params.item, params.turnId);
         noteToolItemLifecycle(params.item, 'started');
         // 先登记再翻译:子线程通知可能紧随 spawn item 到达,映射就位才不丢首帧。
-        const replayedSubagentUpdate = noteSubagentSpawnItem(params.item, params.turnId);
-        pushItemStatus(params.item);
-        translateItemNotification('started', params, eventQueue, {
+        const translatedItem = withFrozenSubagentSpawnModel(params.item, params.turnId);
+        const translatedParams = translatedItem === params.item
+          ? params
+          : { ...params, item: translatedItem };
+        const replayedSubagentUpdate = noteSubagentSpawnItem(translatedItem, params.turnId);
+        pushItemStatus(translatedItem);
+        translateItemNotification('started', translatedParams, eventQueue, {
           rt: translatorRt,
           log,
           onCompactBoundary: handleCompactBoundary,
@@ -9357,8 +9397,12 @@ export class CodexAgent extends BaseAgent {
         // (turn 缓冲、stale turn 丢弃、上游省略),映射就要一直等到 completed 才建立 —— 期间
         // 子线程的 item / token / turn 终态全被缓冲,卡片在整个运行期(可能好几分钟)没有实时
         // 数据,最后才一次性补上。那恰好是本 PR 要解决的问题本身(review)。
-        const replayedSubagentUpdateOnUpdated = noteSubagentSpawnItem(params.item, params.turnId);
-        translateItemNotification('updated', params, eventQueue, {
+        const translatedItem = withFrozenSubagentSpawnModel(params.item, params.turnId);
+        const translatedParams = translatedItem === params.item
+          ? params
+          : { ...params, item: translatedItem };
+        const replayedSubagentUpdateOnUpdated = noteSubagentSpawnItem(translatedItem, params.turnId);
+        translateItemNotification('updated', translatedParams, eventQueue, {
           rt: translatorRt,
           log,
           onCompactBoundary: handleCompactBoundary,
@@ -9413,8 +9457,12 @@ export class CodexAgent extends BaseAgent {
         // watchdog with a fresh budget.
         if (!isLateCollabTerminal) noteToolItemLifecycle(params.item, 'completed');
         // 防御:spawn item 的 started phase 若被上游省略,completed 仍能补上映射。
+        const translatedItem = withFrozenSubagentSpawnModel(params.item, params.turnId);
+        const translatedParams = translatedItem === params.item
+          ? params
+          : { ...params, item: translatedItem };
         const replayedSubagentUpdateOnCompleted = noteSubagentSpawnItem(
-          params.item,
+          translatedItem,
           params.turnId,
         );
         const itemEventQueue = isLateCollabTerminal
@@ -9432,7 +9480,7 @@ export class CodexAgent extends BaseAgent {
             [Symbol.asyncIterator]: () => eventQueue[Symbol.asyncIterator](),
           } as AsyncQueue<AgentEvent>
           : eventQueue;
-        translateItemNotification('completed', params, itemEventQueue, {
+        translateItemNotification('completed', translatedParams, itemEventQueue, {
           rt: translatorRt,
           log,
           onCompactBoundary: handleCompactBoundary,
@@ -10139,6 +10187,7 @@ export class CodexAgent extends BaseAgent {
                 startSeq: ownerSeq,
                 sendGen: startEntry.sendGen,
                 startedAtMs: startEntry.startedAtMs,
+                ...(startEntry.model ? { model: startEntry.model } : {}),
               });
             }
             // 缓冲的歧义 started 对账 (codex R9 P2): 本响应确立在飞 RPC 的
@@ -10221,6 +10270,7 @@ export class CodexAgent extends BaseAgent {
                 capabilitySelectionText,
               );
               // 权威归属: 这个 turn 由本次 start 生出, 属于本轮 send。
+              const turnModel = startEntry?.model ?? activeTurnModel;
               turnOriginByTurnId.set(resp.turn.id, {
                 startSeq: ownerSeq,
                 sendGen: mySendGen,
@@ -10228,6 +10278,7 @@ export class CodexAgent extends BaseAgent {
                   startEntry?.startedAtMs
                   ?? turnOriginByTurnId.get(resp.turn.id)?.startedAtMs
                   ?? Date.now(),
+                ...(turnModel ? { model: turnModel } : {}),
               });
               currentTurnId = resp.turn.id;
               isTurnInFlight = true;

--- a/packages/maker-core/src/agents/codex/subagent-live-cards.ts
+++ b/packages/maker-core/src/agents/codex/subagent-live-cards.ts
@@ -39,7 +39,7 @@ export interface SubagentLiveCardUpdate {
   taskId: string;
   status: SubagentLiveCardStatus;
   agentPath?: string;
-  /** Observed child-thread model, or Cindy's explicit display fallback. `null` clears a stale badge. */
+  /** Observed child-thread model, or its frozen spawn-time default. `null` clears a stale badge. */
   model?: string | null;
   /** 本卡全部子线程 token 快照之和;现代载荷按 spawn 增量,旧 total-only 载荷保留绝对值。 */
   totalTokens: number;
@@ -56,10 +56,10 @@ export interface SubagentLiveCardTracker {
    * 声明一次(两种情形:有早到通知/血缘被重放出状态;或该 taskId 已在跟踪 —— 此时
    * translator 的合成 `completed` 帧必须被真实聚合状态盖回去)。
    *
-   * 返回 null = 非 spawn item,或 **spawn 自身失败**(translator 已推过 failed 帧,再补一帧
-   * 只会把失败盖回运行中;此时卡片被上终态闩,后续子线程通知也翻不了案)。
+   * 返回 null = 非 spawn item，或 fresh spawn 没有早到状态需要重放（初始模型已由
+   * translator 合并进原有启动帧），或 spawn 自身失败且没有早到 usage 可补。
    */
-  noteSpawnItem(item: unknown): SubagentLiveCardUpdate | null;
+  noteSpawnItem(item: unknown, inheritedModel?: string): SubagentLiveCardUpdate | null;
   /**
    * 登记「子线程 → 其父线程」的血缘(host 的 `descendantThreadStarted` 对**每一代**都触发)。
    *
@@ -78,6 +78,7 @@ export interface SubagentLiveCardTracker {
     parentThreadId: string,
     model?: string,
     spawnFailed?: boolean,
+    inheritParentModel?: boolean,
   ): SubagentLiveCardUpdate | null;
   /**
    * 消费一条子线程通知。返回聚合快照表示卡片需要刷新;返回 null = 与子代理卡无关
@@ -166,7 +167,7 @@ interface ThreadState {
   tokenUsageBaseline?: number;
   /** 基线建立前已确认的 live turn id；usage 可能晚于下一轮 turn/started 才到。 */
   observedLiveTurnIds: Set<string>;
-  /** Model observed from thread metadata or a spawn item. */
+  /** Model observed from thread metadata, an explicit spawn, or frozen parent inheritance. */
   model?: string;
   /** A failed nested spawn remains terminal despite late lifecycle events. */
   spawnFailed: boolean;
@@ -512,6 +513,7 @@ export function createSubagentLiveCardTracker(opts: {
     visited: Set<string>,
     spawnModel?: string,
     spawnFailed = false,
+    inheritedModel?: string,
   ): boolean => {
     if (visited.has(childThreadId)) return false;
     visited.add(childThreadId);
@@ -523,8 +525,10 @@ export function createSubagentLiveCardTracker(opts: {
     if (!card.threads.has(childThreadId)) {
       const observedModel = pendingThreadModels.get(childThreadId);
       pendingThreadModels.delete(childThreadId);
-      const initialModel = observedModel ?? spawnModel;
-      changed = Boolean(initialModel);
+      const initialModel = observedModel ?? spawnModel ?? inheritedModel;
+      // spawn item 自己携带的显式/默认/继承模型会由 translator 合并进原有启动帧；
+      // 只有 spawn 到达前已经观测到的实际模型才需要在登记后额外重放。
+      changed = Boolean(observedModel);
       // 已上终态闩的卡,新并入的线程直接算失败,别让它把卡拉回 running。
       card.threads.set(childThreadId, {
         status: card.spawnFailed || latchSpawnFailure ? 'failed' : 'running',
@@ -556,16 +560,19 @@ export function createSubagentLiveCardTracker(opts: {
     if (descendants) {
       pendingLineage.delete(childThreadId);
       for (const grandChildId of descendants) {
-        if (attachThread(card, grandChildId, visited)) changed = true;
+        if (attachThread(card, grandChildId, visited, undefined, false, thread.model)) changed = true;
       }
     }
     return changed;
   };
 
   return {
-    noteSpawnItem(item: unknown): SubagentLiveCardUpdate | null {
+    noteSpawnItem(item: unknown, inheritedModel?: string): SubagentLiveCardUpdate | null {
       const registration = readCodexSubagentSpawnRegistration(item);
       if (!registration) return null;
+      // 模型优先级在 spawn 当刻冻结：显式参数 > Cindy 个性化默认 > Codex 原生父线程继承。
+      // 后续 thread/started 的实际 model 仍可通过 noteDescendantThread 覆盖。
+      const spawnModel = registration.model ?? subagentModelFallback ?? inheritedModel;
 
       const existing = cards.get(registration.taskId);
       const card: TrackedCard = existing ?? {
@@ -592,7 +599,7 @@ export function createSubagentLiveCardTracker(opts: {
         const visited = new Set<string>();
         let replayedOnFailure = false;
         for (const childThreadId of registration.childThreadIds) {
-          if (attachThread(card, childThreadId, visited, registration.model)) replayedOnFailure = true;
+          if (attachThread(card, childThreadId, visited, spawnModel)) replayedOnFailure = true;
           const thread = card.threads.get(childThreadId);
           if (thread) thread.status = 'failed';
         }
@@ -600,15 +607,13 @@ export function createSubagentLiveCardTracker(opts: {
         // 重放出来;若此后再无通知,无条件返回 null 就意味着这些用量永远不显示 —— 而 translator
         // 的 failed 帧本身不带 usage(review)。有了 spawnFailed 闩,snapshot() 恒为 failed,
         // 补发这一帧不会重现"把失败盖回运行中"的老问题。
-        return replayedOnFailure || registration.model || subagentModelFallback
-          ? snapshot(card)
-          : null;
+        return replayedOnFailure ? snapshot(card) : null;
       }
 
       const visited = new Set<string>();
       let replayed = false;
       for (const childThreadId of registration.childThreadIds) {
-        if (attachThread(card, childThreadId, visited, registration.model)) replayed = true;
+        if (attachThread(card, childThreadId, visited, spawnModel)) replayed = true;
       }
 
       // 已登记过的 spawn(同一 collabAgentToolCall 的 started/completed 两个 phase 都会到
@@ -618,9 +623,7 @@ export function createSubagentLiveCardTracker(opts: {
       // 跑的子线程会被提前标成完成,先到的 failed/stopped 也会被抹掉。
       // (attachThread 幂等:已在卡上的线程不会被重置计数。)
       if (existing) return snapshot(card);
-      return replayed || registration.model || subagentModelFallback
-        ? snapshot(card)
-        : null;
+      return replayed ? snapshot(card) : null;
     },
 
     noteDescendantThread(
@@ -628,8 +631,17 @@ export function createSubagentLiveCardTracker(opts: {
       parentThreadId: string,
       model?: string,
       spawnFailed = false,
+      inheritParentModel = false,
     ): SubagentLiveCardUpdate | null {
       if (!childThreadId || !parentThreadId || childThreadId === parentThreadId) return null;
+      const parentTaskId = taskIdByThread.get(parentThreadId);
+      const parentModel = parentTaskId === undefined
+        ? undefined
+        : cards.get(parentTaskId)?.threads.get(parentThreadId)?.model;
+      // 嵌套 spawn 没有显式 model 时遵循同一优先级：个性化默认优先，否则继承直接父线程。
+      // 普通 thread/started 观测不走此兜底，避免把“没上报”误当成一次覆盖。
+      const effectiveModel = model
+        ?? (inheritParentModel ? subagentModelFallback ?? parentModel : undefined);
       const directTaskId = taskIdByThread.get(childThreadId);
       if (directTaskId !== undefined) {
         pendingThreadModels.delete(childThreadId);
@@ -638,8 +650,8 @@ export function createSubagentLiveCardTracker(opts: {
         const directThread = directCard?.threads.get(childThreadId);
         if (directCard && directThread) {
           let changed = false;
-          if (model && directThread.model !== model) {
-            directThread.model = model;
+          if (effectiveModel && directThread.model !== effectiveModel) {
+            directThread.model = effectiveModel;
             changed = true;
           }
           if (spawnFailed && !directThread.spawnFailed) {
@@ -651,12 +663,12 @@ export function createSubagentLiveCardTracker(opts: {
         }
         return null;
       }
-      if (model) {
+      if (effectiveModel) {
         if (!pendingThreadModels.has(childThreadId) && pendingThreadModels.size >= MAX_PENDING_THREAD_MODELS) {
           const oldest = pendingThreadModels.keys().next();
           if (!oldest.done) pendingThreadModels.delete(oldest.value);
         }
-        pendingThreadModels.set(childThreadId, model);
+        pendingThreadModels.set(childThreadId, effectiveModel);
       }
       if (spawnFailed) {
         if (!pendingFailedThreads.has(childThreadId) && pendingFailedThreads.size >= MAX_PENDING_THREAD_MODELS) {
@@ -665,7 +677,7 @@ export function createSubagentLiveCardTracker(opts: {
         }
         pendingFailedThreads.add(childThreadId);
       }
-      const taskId = taskIdByThread.get(parentThreadId);
+      const taskId = parentTaskId;
       if (taskId === undefined) {
         // 父线程还没归属:**不能丢**。它可能只是 spawn item 尚未到达(乱序),而本次血缘正是
         // 孙线程唯一的入卡途径 —— 丢了就再没有第二次机会。先缓冲,父线程归属时递归补绑。
@@ -679,7 +691,7 @@ export function createSubagentLiveCardTracker(opts: {
       // 不该说完成),所以发帧条件不只看有没有重放内容,还看聚合状态是否因此改变。
       const beforeStatus = aggregateStatus(card);
       const beforeModel = aggregateModel(card);
-      const replayed = attachThread(card, childThreadId, new Set<string>(), model, spawnFailed);
+      const replayed = attachThread(card, childThreadId, new Set<string>(), effectiveModel, spawnFailed);
       return replayed
         || aggregateStatus(card) !== beforeStatus
         || aggregateModel(card) !== beforeModel

--- a/packages/maker-core/src/agents/codex/subagent-live-cards.ts
+++ b/packages/maker-core/src/agents/codex/subagent-live-cards.ts
@@ -33,6 +33,7 @@
 import { readCodexSubagentSpawnRegistration } from './translator.js';
 
 export type SubagentLiveCardStatus = 'running' | 'completed' | 'failed' | 'stopped';
+export type SubagentSpawnItemPhase = 'started' | 'updated' | 'completed';
 
 /** 一次聚合结果:调用方据此发 `agent_task_update`(字段与 `AgentTaskUsage` 对齐)。 */
 export interface SubagentLiveCardUpdate {
@@ -59,7 +60,11 @@ export interface SubagentLiveCardTracker {
    * 返回 null = 非 spawn item，或 fresh spawn 没有早到状态需要重放（初始模型已由
    * translator 合并进原有启动帧），或 spawn 自身失败且没有早到 usage 可补。
    */
-  noteSpawnItem(item: unknown, inheritedModel?: string): SubagentLiveCardUpdate | null;
+  noteSpawnItem(
+    item: unknown,
+    inheritedModel?: string,
+    phase?: SubagentSpawnItemPhase,
+  ): SubagentLiveCardUpdate | null;
   /**
    * 登记「子线程 → 其父线程」的血缘(host 的 `descendantThreadStarted` 对**每一代**都触发)。
    *
@@ -169,8 +174,48 @@ interface ThreadState {
   observedLiveTurnIds: Set<string>;
   /** Model observed from thread metadata, an explicit spawn, or frozen parent inheritance. */
   model?: string;
+  /** Keep lower-confidence late spawn metadata from replacing a runtime observation. */
+  modelSource?: ThreadModelSource;
   /** A failed nested spawn remains terminal despite late lifecycle events. */
   spawnFailed: boolean;
+}
+
+type ThreadModelSource = 'inherited' | 'configured' | 'explicit' | 'runtime';
+
+const MODEL_SOURCE_PRIORITY: Record<ThreadModelSource, number> = {
+  inherited: 0,
+  configured: 1,
+  explicit: 2,
+  runtime: 3,
+};
+
+interface ThreadModelObservation {
+  model: string;
+  source: ThreadModelSource;
+}
+
+function spawnItemHasRunningAgentState(item: unknown): boolean {
+  if (!item || typeof item !== 'object') return false;
+  const record = item as { type?: unknown; agentsStates?: unknown };
+  if (
+    record.type !== 'collabAgentToolCall'
+    || !record.agentsStates
+    || typeof record.agentsStates !== 'object'
+  ) return false;
+  return Object.values(record.agentsStates as Record<string, unknown>).some((state) => {
+    let label: unknown = typeof state === 'string' ? state : undefined;
+    if (!label && state && typeof state === 'object') {
+      const stateRecord = state as Record<string, unknown>;
+      for (const key of ['status', 'state', 'phase']) {
+        if (typeof stateRecord[key] === 'string') {
+          label = stateRecord[key];
+          break;
+        }
+      }
+    }
+    return typeof label === 'string'
+      && /^(running|in[_-]?progress|started|active)$/i.test(label.trim());
+  });
 }
 
 interface TrackedCard {
@@ -217,7 +262,7 @@ export function createSubagentLiveCardTracker(opts: {
    */
   const pendingLineage = new Map<string, Set<string>>();
   /** Model observed on thread/started before its parent spawn is registered. */
-  const pendingThreadModels = new Map<string, string>();
+  const pendingThreadModels = new Map<string, ThreadModelObservation>();
   /** Failed nested spawns can be observed before their parent card is attached. */
   const pendingFailedThreads = new Set<string>();
   /**
@@ -381,6 +426,47 @@ export function createSubagentLiveCardTracker(opts: {
     thread.observedLiveTurnIds.add(turnId);
   };
 
+  const updateThreadModel = (
+    thread: ThreadState,
+    observation: ThreadModelObservation | undefined,
+  ): boolean => {
+    if (!observation) return false;
+    const previousPriority = thread.modelSource === undefined
+      ? -1
+      : MODEL_SOURCE_PRIORITY[thread.modelSource];
+    const nextPriority = MODEL_SOURCE_PRIORITY[observation.source];
+    if (
+      nextPriority < previousPriority
+      || (nextPriority === previousPriority && observation.source !== 'runtime')
+    ) return false;
+    const changed = thread.model !== observation.model;
+    thread.model = observation.model;
+    thread.modelSource = observation.source;
+    return changed;
+  };
+
+  const bufferThreadModel = (
+    childThreadId: string,
+    observation: ThreadModelObservation,
+  ): void => {
+    const previous = pendingThreadModels.get(childThreadId);
+    if (
+      previous
+      && (
+        MODEL_SOURCE_PRIORITY[previous.source] > MODEL_SOURCE_PRIORITY[observation.source]
+        || (
+          previous.source === observation.source
+          && observation.source !== 'runtime'
+        )
+      )
+    ) return;
+    if (!previous && pendingThreadModels.size >= MAX_PENDING_THREAD_MODELS) {
+      const oldest = pendingThreadModels.keys().next();
+      if (!oldest.done) pendingThreadModels.delete(oldest.value);
+    }
+    pendingThreadModels.set(childThreadId, observation);
+  };
+
   /** 应用一条通知到卡上;返回是否产生了变化(无变化不必发帧)。 */
   const applyNotification = (
     card: TrackedCard,
@@ -512,6 +598,7 @@ export function createSubagentLiveCardTracker(opts: {
     childThreadId: string,
     visited: Set<string>,
     spawnModel?: string,
+    spawnModelSource: ThreadModelSource = 'inherited',
     spawnFailed = false,
     inheritedModel?: string,
   ): boolean => {
@@ -525,7 +612,9 @@ export function createSubagentLiveCardTracker(opts: {
     if (!card.threads.has(childThreadId)) {
       const observedModel = pendingThreadModels.get(childThreadId);
       pendingThreadModels.delete(childThreadId);
-      const initialModel = observedModel ?? spawnModel ?? inheritedModel;
+      const initialModel = observedModel?.model ?? spawnModel ?? inheritedModel;
+      const initialModelSource = observedModel?.source
+        ?? (spawnModel ? spawnModelSource : inheritedModel ? 'inherited' : undefined);
       // spawn item 自己携带的显式/默认/继承模型会由 translator 合并进原有启动帧；
       // 只有 spawn 到达前已经观测到的实际模型才需要在登记后额外重放。
       changed = Boolean(observedModel);
@@ -535,11 +624,14 @@ export function createSubagentLiveCardTracker(opts: {
         totalTokens: 0,
         observedLiveTurnIds: new Set<string>(),
         ...(initialModel ? { model: initialModel } : {}),
+        ...(initialModelSource ? { modelSource: initialModelSource } : {}),
         spawnFailed: latchSpawnFailure,
       });
-    } else if (spawnModel && !card.threads.get(childThreadId)?.model) {
-      card.threads.get(childThreadId)!.model = spawnModel;
-      changed = true;
+    } else if (spawnModel) {
+      changed = updateThreadModel(card.threads.get(childThreadId)!, {
+        model: spawnModel,
+        source: spawnModelSource,
+      }) || changed;
     }
     taskIdByThread.set(childThreadId, card.taskId);
     const thread = card.threads.get(childThreadId)!;
@@ -560,19 +652,30 @@ export function createSubagentLiveCardTracker(opts: {
     if (descendants) {
       pendingLineage.delete(childThreadId);
       for (const grandChildId of descendants) {
-        if (attachThread(card, grandChildId, visited, undefined, false, thread.model)) changed = true;
+        if (attachThread(card, grandChildId, visited, undefined, 'inherited', false, thread.model)) changed = true;
       }
     }
     return changed;
   };
 
   return {
-    noteSpawnItem(item: unknown, inheritedModel?: string): SubagentLiveCardUpdate | null {
+    noteSpawnItem(
+      item: unknown,
+      inheritedModel?: string,
+      phase: SubagentSpawnItemPhase = 'started',
+    ): SubagentLiveCardUpdate | null {
       const registration = readCodexSubagentSpawnRegistration(item);
       if (!registration) return null;
       // 模型优先级在 spawn 当刻冻结：显式参数 > Cindy 个性化默认 > Codex 原生父线程继承。
       // 后续 thread/started 的实际 model 仍可通过 noteDescendantThread 覆盖。
       const spawnModel = registration.model ?? subagentModelFallback ?? inheritedModel;
+      const spawnModelSource: ThreadModelSource | undefined = registration.model
+        ? 'explicit'
+        : subagentModelFallback
+          ? 'configured'
+          : inheritedModel
+            ? 'inherited'
+            : undefined;
 
       const existing = cards.get(registration.taskId);
       const card: TrackedCard = existing ?? {
@@ -599,7 +702,7 @@ export function createSubagentLiveCardTracker(opts: {
         const visited = new Set<string>();
         let replayedOnFailure = false;
         for (const childThreadId of registration.childThreadIds) {
-          if (attachThread(card, childThreadId, visited, spawnModel)) replayedOnFailure = true;
+          if (attachThread(card, childThreadId, visited, spawnModel, spawnModelSource)) replayedOnFailure = true;
           const thread = card.threads.get(childThreadId);
           if (thread) thread.status = 'failed';
         }
@@ -613,7 +716,7 @@ export function createSubagentLiveCardTracker(opts: {
       const visited = new Set<string>();
       let replayed = false;
       for (const childThreadId of registration.childThreadIds) {
-        if (attachThread(card, childThreadId, visited, spawnModel)) replayed = true;
+        if (attachThread(card, childThreadId, visited, spawnModel, spawnModelSource)) replayed = true;
       }
 
       // 已登记过的 spawn(同一 collabAgentToolCall 的 started/completed 两个 phase 都会到
@@ -623,6 +726,10 @@ export function createSubagentLiveCardTracker(opts: {
       // 跑的子线程会被提前标成完成,先到的 failed/stopped 也会被抹掉。
       // (attachThread 幂等:已在卡上的线程不会被重置计数。)
       if (existing) return snapshot(card);
+      // app-server 可能省略 started/updated，首个可见帧直接是 completed。此时
+      // collabAgentToolCall 的完成只代表 spawn 工具已返回；agentsStates 仍明确 running
+      // 时必须让 tracker 发出 running 快照，覆盖 translator 合成的 completed。
+      if (phase === 'completed' && spawnItemHasRunningAgentState(item)) return snapshot(card);
       return replayed ? snapshot(card) : null;
     },
 
@@ -642,6 +749,13 @@ export function createSubagentLiveCardTracker(opts: {
       // 普通 thread/started 观测不走此兜底，避免把“没上报”误当成一次覆盖。
       const effectiveModel = model
         ?? (inheritParentModel ? subagentModelFallback ?? parentModel : undefined);
+      const effectiveModelSource: ThreadModelSource | undefined = model
+        ? inheritParentModel ? 'explicit' : 'runtime'
+        : inheritParentModel && subagentModelFallback
+          ? 'configured'
+          : inheritParentModel && parentModel
+            ? 'inherited'
+            : undefined;
       const directTaskId = taskIdByThread.get(childThreadId);
       if (directTaskId !== undefined) {
         pendingThreadModels.delete(childThreadId);
@@ -650,9 +764,11 @@ export function createSubagentLiveCardTracker(opts: {
         const directThread = directCard?.threads.get(childThreadId);
         if (directCard && directThread) {
           let changed = false;
-          if (effectiveModel && directThread.model !== effectiveModel) {
-            directThread.model = effectiveModel;
-            changed = true;
+          if (effectiveModel && effectiveModelSource) {
+            changed = updateThreadModel(directThread, {
+              model: effectiveModel,
+              source: effectiveModelSource,
+            }) || changed;
           }
           if (spawnFailed && !directThread.spawnFailed) {
             directThread.spawnFailed = true;
@@ -663,12 +779,11 @@ export function createSubagentLiveCardTracker(opts: {
         }
         return null;
       }
-      if (effectiveModel) {
-        if (!pendingThreadModels.has(childThreadId) && pendingThreadModels.size >= MAX_PENDING_THREAD_MODELS) {
-          const oldest = pendingThreadModels.keys().next();
-          if (!oldest.done) pendingThreadModels.delete(oldest.value);
-        }
-        pendingThreadModels.set(childThreadId, effectiveModel);
+      if (effectiveModel && effectiveModelSource) {
+        bufferThreadModel(childThreadId, {
+          model: effectiveModel,
+          source: effectiveModelSource,
+        });
       }
       if (spawnFailed) {
         if (!pendingFailedThreads.has(childThreadId) && pendingFailedThreads.size >= MAX_PENDING_THREAD_MODELS) {
@@ -691,7 +806,14 @@ export function createSubagentLiveCardTracker(opts: {
       // 不该说完成),所以发帧条件不只看有没有重放内容,还看聚合状态是否因此改变。
       const beforeStatus = aggregateStatus(card);
       const beforeModel = aggregateModel(card);
-      const replayed = attachThread(card, childThreadId, new Set<string>(), effectiveModel, spawnFailed);
+      const replayed = attachThread(
+        card,
+        childThreadId,
+        new Set<string>(),
+        effectiveModel,
+        effectiveModelSource,
+        spawnFailed,
+      );
       return replayed
         || aggregateStatus(card) !== beforeStatus
         || aggregateModel(card) !== beforeModel

--- a/packages/maker-core/src/agents/codex/translator.test.ts
+++ b/packages/maker-core/src/agents/codex/translator.test.ts
@@ -1468,6 +1468,83 @@ describe('translateItemNotification commandExecution output normalization', () =
 });
 
 describe('translateItemNotification collabAgentToolCall', () => {
+  it('does not create a Subagent card for a provisional spawn with no child thread', async () => {
+    const q = createAsyncQueue<AgentEvent>();
+    const ctx = makeCtx(newCodexRuntimeState());
+    const provisional = {
+      threadId: 'thread-1',
+      turnId: 'turn-1',
+      item: {
+        type: 'collabAgentToolCall',
+        id: 'spawn-before-validation',
+        tool: 'spawnAgent',
+        status: 'inProgress',
+        senderThreadId: 'thread-1',
+        receiverThreadIds: [],
+        prompt: 'Use the configured default model',
+        reasoningEffort: 'medium',
+        agentsStates: {},
+      },
+    };
+
+    translateItemNotification('started', provisional, q, ctx);
+    translateItemNotification('updated', provisional, q, ctx);
+
+    expect(await collect(q)).toEqual([]);
+    expect(ctx.rt.emittedToolUse.has('spawn-before-validation')).toBe(false);
+  });
+
+  it('publishes the same provisional spawn once a child receiver appears', async () => {
+    const q = createAsyncQueue<AgentEvent>();
+    const ctx = makeCtx(newCodexRuntimeState());
+    const provisional = {
+      threadId: 'thread-1',
+      turnId: 'turn-1',
+      item: {
+        type: 'collabAgentToolCall',
+        id: 'spawn-after-validation',
+        tool: 'spawnAgent',
+        status: 'inProgress',
+        senderThreadId: 'thread-1',
+        receiverThreadIds: [],
+        prompt: 'Use the configured default model',
+        reasoningEffort: 'medium',
+        agentsStates: {},
+      },
+    };
+
+    translateItemNotification('started', provisional, q, ctx);
+    translateItemNotification(
+      'updated',
+      {
+        ...provisional,
+        item: {
+          ...provisional.item,
+          receiverThreadIds: ['thread-2'],
+          model: 'gpt-5.6-terra',
+        },
+      },
+      q,
+      ctx,
+    );
+
+    const events = await collect(q);
+    expect(events.map((event) => event.type)).toEqual(['tool_use', 'agent_task_update']);
+    expect(events[0].data).toMatchObject({
+      toolUseId: 'spawn-after-validation',
+      input: { receiverThreadIds: ['thread-2'], model: 'gpt-5.6-terra' },
+    });
+    expect(events[1].data).toMatchObject({
+      taskId: 'spawn-after-validation',
+      status: 'running',
+      model: 'gpt-5.6-terra',
+      subagentObservation: {
+        kind: 'spawn',
+        providerRunIds: ['thread-2'],
+      },
+    });
+  });
+
   it('emits provider-neutral task updates alongside existing tool events', async () => {
     const rt = newCodexRuntimeState();
     const q = createAsyncQueue<AgentEvent>();

--- a/packages/maker-core/src/agents/codex/translator.ts
+++ b/packages/maker-core/src/agents/codex/translator.ts
@@ -1796,6 +1796,8 @@ function handleCollabAgentToolCall(
   ctx: CodexTranslateContext,
 ): void {
   const toolName = `collab:${item.tool}`;
+  const isSpawn = item.tool.toLowerCase().startsWith('spawn');
+  const hasSpawnReceiver = !isSpawn || item.receiverThreadIds.length > 0;
   const input: Record<string, unknown> = {
     senderThreadId: item.senderThreadId,
     receiverThreadIds: item.receiverThreadIds,
@@ -1805,6 +1807,13 @@ function handleCollabAgentToolCall(
   if (item.reasoningEffort) input.reasoningEffort = item.reasoningEffort;
 
   if (phase === 'started') {
+    // Codex can emit a provisional spawn item before validation has created a
+    // child thread. If validation then fails (for example an unknown model),
+    // 0.145 emits no matching terminal collab item. Publishing this empty-
+    // receiver placeholder would therefore leave an inline card and durable
+    // Subagent run stuck on running forever. Wait for a receiver-bearing
+    // updated/completed snapshot, which is the first proof that a child exists.
+    if (!hasSpawnReceiver) return;
     if (ctx.rt.emittedToolUse.has(item.id)) return;
     ctx.rt.emittedToolUse.add(item.id);
     queue.push({
@@ -1821,6 +1830,7 @@ function handleCollabAgentToolCall(
   }
 
   if (phase === 'updated') {
+    if (!hasSpawnReceiver) return;
     if (!ctx.rt.emittedToolUse.has(item.id)) {
       ctx.rt.emittedToolUse.add(item.id);
       queue.push({
@@ -2024,7 +2034,9 @@ function toCodexTaskUpdate(
   completedOnly = false,
 ): AgentTaskUpdateEventData {
   const isSpawn = item.tool.toLowerCase().startsWith('spawn');
-  const subagentObservation = isSpawn && (status !== 'completed' || completedOnly)
+  const subagentObservation = isSpawn
+    && item.receiverThreadIds.length > 0
+    && (status !== 'completed' || completedOnly)
     ? {
         kind: status === 'running' || completedOnly ? 'spawn' as const : 'terminal' as const,
         logicalSubagentId: item.id,

--- a/packages/model-providers/src/builtin.ts
+++ b/packages/model-providers/src/builtin.ts
@@ -229,6 +229,7 @@ const XD_PROVIDER: Provider = {
     codex: {
       upstream: 'https://xd-gateway.invalid/v1',
       authStrategy: 'gateway-key',
+      modelIdRewrite: { stripPrefix: 'codex/' },
     },
     // pi 直连网关 anthropic-messages 面(与 claude-code 同可达面);upstream 同为占位。
     pi: {


### PR DESCRIPTION
## 这次改了什么

### 摘要

修正 Subagent 卡片把请求模型误当成实际执行模型、Codex 默认继承模型缺失，以及 spawn 状态无法正确收口的问题。Claude Code 与 Codex 现在都以运行时事实为准；没有可靠事实时不猜测模型。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其它：

### 范围

- 关联 Issue / 需求：用户验收反馈
- 本 PR 包含：
  - Claude Code 同步与异步 Subagent 回执提取实际模型、任务 ID、状态及用量。
  - Codex 子模型路由透传，并在未配置个性化子模型时冻结 spawn 当刻继承的父线程模型。
  - Codex spawn 生命周期聚合，修复卡片长期停留“运行中”、模型缺失及重复运行事件。
  - AgentTaskCard 仅对 Codex 协同调用保留显式 spawn 模型兜底；Claude Code 不再把请求模型冒充实际模型。
  - 覆盖实时、完成、乱序、嵌套、多 receiver、模型冲突与无 thread/started 场景的回归测试。
- 明确不包含：数据库 schema/migration、协议字段新增、服务端改动。
- 用户可见变化：Subagent 卡片显示实际执行或冻结继承的模型；任务完成后正确结束，不再长期显示运行中。
- 是否存在 breaking change：无。

### UI 变化

仅纠正现有 Subagent 卡片模型徽标和运行状态的数据来源，不新增布局、颜色、动效或交互。引用 `docs/design-rules/DESIGN.md` §4 “Component Stylings / Cards & Containers” 与 §10 “Theme System & Token Reference”：继续复用现有卡片组件和语义 token，Light / Dark 样式不变。

- 引用的设计规范：`DESIGN.md` §4、§10

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：通过；Desktop、Mobile、lizi-mcps、maker-core、model-providers、orca-workflow 相关门禁全部通过。

pnpm --filter @cindy/maker-core run --if-present typecheck
pnpm --filter desktop run --if-present typecheck
pnpm --filter @cindy/model-providers run --if-present typecheck
结果：全部通过。

pnpm --filter @cindy/maker-core exec vitest run src/agents/codex/index.test.ts
结果：479/479 通过。

pnpm --filter @cindy/maker-core exec vitest run src/agents/codex/__tests__/subagentLiveCards.test.ts
结果：60/60 通过。

pnpm --filter desktop exec vitest run src/renderer/__tests__/AgentTaskCard.test.ts
结果：21/21 通过。

pnpm --filter @cindy/maker-core exec vitest run src/agents/claude-code/__tests__/translator-subagent-model.test.ts src/agents/codex/translator.test.ts
结果：93/93 通过。

pnpm --filter @cindy/maker-core exec vitest run
结果：2593 项通过；1 项无关的 Pi BYOM 集成测试因临时目录 models.json 出现 ENOENT 失败。强制 related 门禁随后完整通过。
```

### 手工验证

Windows Global 隔离 Dev `merry-wozniak` 已重启。用户已验收 Codex 与 Claude Code 的 Subagent 模型显示及结束状态，结果通过。

### 未执行的验证

无。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [x] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其它：Agent 运行时事件顺序与模型路由

### 影响与回滚

- 影响范围：Desktop 的 Claude Code / Codex Subagent 模型与生命周期展示，以及 Codex 子模型代理路由。
- 回滚 / 降级方式：回滚本提交即可恢复旧行为；不涉及数据迁移或持久化格式变化。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在“UI 变化”注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因