### PR TITLE
fix(goal): 修复 PI Goal 投递与恢复状态机

### DIFF
--- a/apps/desktop/src/main/goal-host/__tests__/controller.test.ts
+++ b/apps/desktop/src/main/goal-host/__tests__/controller.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, beforeEach, vi } from 'vitest';
 
+import { TurnDispatchUnconfirmedError } from '@cindy/maker-core';
 import type { AgentEvent, SessionSendResult } from '@cindy/maker-core';
 
 import {
@@ -401,6 +402,75 @@ describe('GoalController', () => {
   });
 
   // ── setGoal / updateGoal ──
+  it('blocks an unconfirmed dispatch without retrying duplicate Goal work', async () => {
+    const local = makeController();
+    vi.spyOn(local.session, 'send').mockImplementation(async (
+      _message: Parameters<FakeSession['send']>[0],
+      opts: Parameters<FakeSession['send']>[1],
+    ) => {
+      opts?.onDispatching?.();
+      throw new TurnDispatchUnconfirmedError('Pi prompt acceptance timed out');
+    });
+
+    await local.controller.setGoal({ sessionId: 's1', objective: 'finish the work' });
+
+    expect(local.session.send).toHaveBeenCalledTimes(1);
+    expect(await local.storage.get('s1')).toMatchObject({
+      status: 'blocked',
+      turnsUsed: 0,
+      lastReason: expect.stringContaining('Pi prompt acceptance timed out'),
+    });
+  });
+
+  it('blocks a new Goal when its dormant agent session cannot be restored', async () => {
+    const local = makeController();
+    local.setHydratable(false);
+
+    await local.controller.setGoal({
+      sessionId: 's1',
+      objective: 'finish the work',
+      agentKind: 'pi',
+    });
+
+    expect(local.session.sends).toHaveLength(0);
+    expect(await local.storage.get('s1')).toMatchObject({
+      status: 'blocked',
+      turnsUsed: 0,
+      lastReason: expect.stringContaining('unable to restore the agent session'),
+    });
+  });
+
+  it('blocks and rejects a Goal edit when its session cannot be restored', async () => {
+    const local = makeController();
+    await local.storage.set(seededGoal({ status: 'active', objective: 'old objective' }));
+    local.setHydratable(false);
+
+    await expect(local.controller.setGoal({
+      sessionId: 's1',
+      objective: 'new objective',
+    })).rejects.toThrow('unable to restore the agent session for Goal');
+
+    expect(await local.storage.get('s1')).toMatchObject({
+      status: 'blocked',
+      objective: 'old objective',
+      lastReason: expect.stringContaining('unable to restore the agent session'),
+    });
+    expect(local.session.sends).toHaveLength(0);
+  });
+
+  it('surfaces a non-retryable first-turn send failure as blocked instead of active at zero turns', async () => {
+    const local = makeController();
+    vi.spyOn(local.session, 'send').mockRejectedValue(new Error('provider authentication failed'));
+
+    await local.controller.setGoal({ sessionId: 's1', objective: 'finish the work' });
+
+    expect(await local.storage.get('s1')).toMatchObject({
+      status: 'blocked',
+      turnsUsed: 0,
+      lastReason: expect.stringContaining('provider authentication failed'),
+    });
+  });
+
   it('setGoal creates a new goal directly with default limits and fires the first turn', async () => {
     await h.controller.setGoal({ sessionId: 's1', objective: 'ship the feature' });
     const st = await h.storage.get('s1');
@@ -1389,6 +1459,8 @@ describe('GoalController', () => {
     });
     await startGoal(local);
     expect(liveSession.sends).toHaveLength(1);
+    (local.controller as unknown as { goalTurnsInFlight: Set<string> })
+      .goalTurnsInFlight.delete('s1');
 
     const firePromise = (
       local.controller as unknown as { fireTurn(sessionId: string): Promise<void> }
@@ -1424,6 +1496,8 @@ describe('GoalController', () => {
     });
     await startGoal(local);
     expect(ensureCalls).toBe(2);
+    (local.controller as unknown as { goalTurnsInFlight: Set<string> })
+      .goalTurnsInFlight.delete('s1');
 
     const firePromise = (
       local.controller as unknown as { fireTurn(sessionId: string): Promise<void> }
@@ -1503,8 +1577,10 @@ describe('GoalController', () => {
     const internals = local.controller as unknown as {
       fireTurn(sessionId: string): Promise<void>;
       firing: Map<string, object>;
+      goalTurnsInFlight: Set<string>;
       goalDispatchAbortControllers: Map<string, { owner: object; controller: AbortController }>;
     };
+    internals.goalTurnsInFlight.delete('s1');
 
     const oldFire = internals.fireTurn('s1');
     await vi.waitFor(() => expect(acquireCalls).toBe(2));
@@ -1548,6 +1624,7 @@ describe('GoalController', () => {
       fireTurn(sessionId: string): Promise<void>;
       goalTurnsInFlight: Set<string>;
     };
+    internals.goalTurnsInFlight.delete('s1');
 
     const oldFire = internals.fireTurn('s1');
     await vi.waitFor(() => expect(sendCalls).toBe(2));
@@ -2045,14 +2122,17 @@ describe('GoalController', () => {
     expect(h.session.sends).toHaveLength(sendsBeforeResume);
   });
 
-  it('keeps a manual Resume paused when the session cannot hydrate, then allows retry', async () => {
+  it('blocks a manual Resume when the session cannot hydrate, then allows retry', async () => {
     await startGoal(h);
     await h.controller.pauseGoal('s1');
     const sendsBeforeResume = h.session.sends.length;
 
     h.setHydratable(false);
-    await h.controller.resumeGoal('s1');
-    expect((await h.storage.get('s1'))?.status).toBe('paused');
+    await expect(h.controller.resumeGoal('s1')).rejects.toThrow(
+      'unable to restore the agent session for Goal',
+    );
+    expect((await h.storage.get('s1'))?.status).toBe('blocked');
+    expect((await h.storage.get('s1'))?.lastReason).toContain('unable to restore the agent session');
     expect(h.session.sends).toHaveLength(sendsBeforeResume);
 
     h.setHydratable(true);
@@ -2106,6 +2186,20 @@ describe('GoalController', () => {
     await h.controller.resumeOnOpen('s1');
     expect(h.session.sends.length).toBeGreaterThanOrEqual(1); // 已活化并续了一轮
     expect(h.session.sends.at(-1)?.content).toContain('keep going');
+  });
+
+  it('blocks a dormant active goal when opening cannot restore its session', async () => {
+    const local = makeController();
+    local.setHydratable(false);
+    await local.storage.set(seededGoal({ status: 'active', objective: 'cannot restore' }));
+
+    await local.controller.resumeOnOpen('s1');
+
+    expect(await local.storage.get('s1')).toMatchObject({
+      status: 'blocked',
+      lastReason: expect.stringContaining('unable to restore the agent session'),
+    });
+    expect(local.session.sends).toHaveLength(0);
   });
 
   it('does not let a stale startup active snapshot overwrite a concurrent Stop', async () => {
@@ -2181,14 +2275,14 @@ describe('GoalController', () => {
     expect(h2.session.sends.length).toBe(n);
   });
 
-  it('maybeContinueActiveGoal fires only when an active goal is attached and idle', async () => {
+  it('maybeContinueActiveGoal does not overlap an accepted Goal turn before provider running state arrives', async () => {
     await h.controller.maybeContinueActiveGoal('s1'); // 无 goal → no-op
     expect(h.session.sends).toHaveLength(0);
     await startGoal(h);
     const before = h.session.sends.length;
     await h.controller.maybeContinueActiveGoal('s1');
     await tick();
-    expect(h.session.sends.length).toBe(before + 1);
+    expect(h.session.sends.length).toBe(before);
     await h.controller.pauseGoal('s1');
     const afterPause = h.session.sends.length;
     await h.controller.maybeContinueActiveGoal('s1');

--- a/apps/desktop/src/main/goal-host/__tests__/controller.test.ts
+++ b/apps/desktop/src/main/goal-host/__tests__/controller.test.ts
@@ -2849,6 +2849,96 @@ describe('GoalController', () => {
     expect(h.session.sends.length).toBe(sends);
   });
 
+  it('resumeOnOpen can return after recovery while prompt acceptance remains pending', async () => {
+    let markDispatchStarted!: () => void;
+    let releaseDispatch!: (result: SessionSendResult) => void;
+    const dispatchStarted = new Promise<void>((resolve) => {
+      markDispatchStarted = resolve;
+    });
+    const pendingDispatch = new Promise<SessionSendResult>((resolve) => {
+      releaseDispatch = resolve;
+    });
+    const local = makeController();
+    vi.spyOn(local.session, 'send').mockImplementation(async (
+      message: Parameters<FakeSession['send']>[0],
+      opts: Parameters<FakeSession['send']>[1],
+    ): Promise<SessionSendResult> => {
+      const content = typeof message === 'string' ? message : message.content;
+      local.session.sends.push({ content, originKind: opts?.origin?.kind });
+      opts?.onDispatching?.();
+      markDispatchStarted();
+      return pendingDispatch;
+    });
+    await local.storage.set(seededGoal({ status: 'active', objective: 'keep going' }));
+
+    await expect(
+      local.controller.resumeOnOpen('s1', { waitForDispatch: false }),
+    ).resolves.toBeUndefined();
+    await dispatchStarted;
+
+    expect(local.session.sends).toHaveLength(1);
+    expect(await local.storage.get('s1')).toMatchObject({ status: 'active' });
+
+    releaseDispatch({ accepted: true });
+    await Promise.resolve();
+  });
+
+  it('converges a detached resume-on-open dispatch failure to blocked', async () => {
+    let markDispatchStarted!: () => void;
+    let releaseDispatch!: () => void;
+    const dispatchStarted = new Promise<void>((resolve) => {
+      markDispatchStarted = resolve;
+    });
+    const dispatchGate = new Promise<void>((resolve) => {
+      releaseDispatch = resolve;
+    });
+    const local = makeController();
+    vi.spyOn(local.session, 'send').mockImplementation(async (
+      message: Parameters<FakeSession['send']>[0],
+      opts: Parameters<FakeSession['send']>[1],
+    ): Promise<SessionSendResult> => {
+      const content = typeof message === 'string' ? message : message.content;
+      local.session.sends.push({ content, originKind: opts?.origin?.kind });
+      opts?.onDispatching?.();
+      markDispatchStarted();
+      await dispatchGate;
+      throw new Error('provider unavailable');
+    });
+    await local.storage.set(seededGoal({ status: 'active', objective: 'recover safely' }));
+
+    await local.controller.resumeOnOpen('s1', { waitForDispatch: false });
+    await dispatchStarted;
+    expect(await local.storage.get('s1')).toMatchObject({ status: 'active' });
+
+    releaseDispatch();
+    await vi.waitFor(async () => {
+      expect(await local.storage.get('s1')).toMatchObject({
+        status: 'blocked',
+        lastReason: expect.stringContaining('provider unavailable'),
+      });
+    });
+    expect(local.session.sends).toHaveLength(1);
+  });
+
+  it('converges a detached resume-on-open preflight read failure to blocked', async () => {
+    const local = makeController();
+    const active = seededGoal({ status: 'active', objective: 'recover safely' });
+    await local.storage.set(active);
+    vi.spyOn(local.storage, 'get')
+      .mockResolvedValueOnce(active)
+      .mockRejectedValueOnce(new Error('goal state read unavailable'));
+
+    await local.controller.resumeOnOpen('s1', { waitForDispatch: false });
+
+    await vi.waitFor(async () => {
+      expect(await local.storage.get('s1')).toMatchObject({
+        status: 'blocked',
+        lastReason: expect.stringContaining('unable to read Goal state'),
+      });
+    });
+    expect(local.session.sends).toHaveLength(0);
+  });
+
   it('resumeOnOpen activates a dormant active goal (attach + fire) when the conversation is opened', async () => {
     // 模拟重启后 dormant:有 active 目标行,但没挂 listener、没 fire。
     await h.storage.set(seededGoal({ status: 'active', objective: 'keep going', turnsUsed: 0 }));

--- a/apps/desktop/src/main/goal-host/__tests__/controller.test.ts
+++ b/apps/desktop/src/main/goal-host/__tests__/controller.test.ts
@@ -650,7 +650,9 @@ describe('GoalController', () => {
     expect(await local.storage.get('s1')).toBeNull();
   });
 
-  it('aborts the git baseline and retries when the provider explicitly rejects before dispatch', async () => {
+  it('backs off once after an explicit provider rejection, then accepts without duplicate dispatch', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
     const order: string[] = [];
     const beforeDispatchUserTurn = vi.fn(async () => {
       order.push('baseline');
@@ -661,6 +663,8 @@ describe('GoalController', () => {
     const local = makeController({
       beforeDispatchUserTurn,
       onUndispatchedUserTurn,
+      now: () => Date.now(),
+      continuationDebounceMs: 150,
     });
     let attempts = 0;
     vi.spyOn(local.session, 'send').mockImplementation(async (
@@ -671,25 +675,590 @@ describe('GoalController', () => {
       local.session.sends.push({ content, originKind: opts?.origin?.kind });
       order.push('send');
       attempts += 1;
+      opts?.onDispatching?.();
+      return attempts === 1
+        ? { accepted: false, reason: 'provider-rejected-before-dispatch' }
+        : { accepted: true };
+    });
+
+    try {
+      await local.controller.setGoal({ sessionId: 's1', objective: 'ship the feature' });
+
+      expect(order).toEqual(['baseline', 'send', 'abort']);
+      expect(onUndispatchedUserTurn).toHaveBeenCalledWith('s1');
+      expect(await local.storage.get('s1')).toMatchObject({ status: 'active', turnsUsed: 0 });
+
+      // Generic idle continuation signals must not shorten the rejection backoff.
+      await local.controller.maybeContinueActiveGoal('s1');
+      await vi.advanceTimersByTimeAsync(499);
+      expect(local.session.sends).toHaveLength(1);
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(order).toEqual(['baseline', 'send', 'abort', 'baseline', 'send']);
+      expect(beforeDispatchUserTurn).toHaveBeenCalledTimes(2);
+      expect(onUndispatchedUserTurn).toHaveBeenCalledTimes(1);
+      expect(local.session.sends).toHaveLength(2);
+      expect(await local.storage.get('s1')).toMatchObject({ status: 'active', turnsUsed: 0 });
+    } finally {
+      local.controller.dispose();
+      vi.useRealTimers();
+    }
+  });
+
+  it('backs off persistent provider rejection and blocks after four confirmed non-dispatches', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const beforeDispatchUserTurn = vi.fn(async () => {});
+    const onUndispatchedUserTurn = vi.fn();
+    const local = makeController({
+      beforeDispatchUserTurn,
+      onUndispatchedUserTurn,
+      now: () => Date.now(),
+    });
+    vi.spyOn(local.session, 'send').mockImplementation(async (
+      message: Parameters<FakeSession['send']>[0],
+      opts: Parameters<FakeSession['send']>[1],
+    ): Promise<SessionSendResult> => {
+      const content = typeof message === 'string' ? message : message.content;
+      local.session.sends.push({ content, originKind: opts?.origin?.kind });
+      opts?.onDispatching?.();
+      return { accepted: false, reason: 'provider-rejected-before-dispatch' };
+    });
+
+    try {
+      await local.controller.setGoal({ sessionId: 's1', objective: 'ship the feature' });
+      expect(local.session.sends).toHaveLength(1);
+
+      await vi.advanceTimersByTimeAsync(499);
+      expect(local.session.sends).toHaveLength(1);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(local.session.sends).toHaveLength(2);
+
+      await vi.advanceTimersByTimeAsync(999);
+      expect(local.session.sends).toHaveLength(2);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(local.session.sends).toHaveLength(3);
+
+      await vi.advanceTimersByTimeAsync(1_999);
+      expect(local.session.sends).toHaveLength(3);
+      await vi.advanceTimersByTimeAsync(1);
+
+      expect(local.session.sends).toHaveLength(4);
+      expect(beforeDispatchUserTurn).toHaveBeenCalledTimes(4);
+      expect(onUndispatchedUserTurn).toHaveBeenCalledTimes(4);
+      expect(await local.storage.get('s1')).toMatchObject({
+        status: 'blocked',
+        turnsUsed: 0,
+        tokensUsed: 0,
+        lastReason: expect.stringContaining('provider repeatedly rejected attempts'),
+      });
+
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(local.session.sends).toHaveLength(4);
+    } finally {
+      local.controller.dispose();
+      vi.useRealTimers();
+    }
+  });
+
+  it('blocks when confirmed provider rejections exceed the retry time window', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const local = makeController({ now: () => Date.now() });
+    vi.spyOn(local.session, 'send').mockImplementation(async (
+      message: Parameters<FakeSession['send']>[0],
+      opts: Parameters<FakeSession['send']>[1],
+    ): Promise<SessionSendResult> => {
+      const content = typeof message === 'string' ? message : message.content;
+      local.session.sends.push({ content, originKind: opts?.origin?.kind });
+      opts?.onDispatching?.();
+      return { accepted: false, reason: 'provider-rejected-before-dispatch' };
+    });
+
+    try {
+      await local.controller.setGoal({ sessionId: 's1', objective: 'ship the feature' });
+      vi.setSystemTime(16_001);
+      await vi.advanceTimersByTimeAsync(500);
+
+      expect(local.session.sends).toHaveLength(1);
+      expect(await local.storage.get('s1')).toMatchObject({
+        status: 'blocked',
+        turnsUsed: 0,
+        lastReason: expect.stringContaining('provider repeatedly rejected attempts'),
+      });
+    } finally {
+      local.controller.dispose();
+      vi.useRealTimers();
+    }
+  });
+
+  it('gives a replacement objective a fresh rejection budget during backoff', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const local = makeController({ now: () => Date.now() });
+    vi.spyOn(local.session, 'send').mockImplementation(async (
+      message: Parameters<FakeSession['send']>[0],
+      opts: Parameters<FakeSession['send']>[1],
+    ): Promise<SessionSendResult> => {
+      const content = typeof message === 'string' ? message : message.content;
+      local.session.sends.push({ content, originKind: opts?.origin?.kind });
+      opts?.onDispatching?.();
+      return { accepted: false, reason: 'provider-rejected-before-dispatch' };
+    });
+
+    try {
+      await local.controller.setGoal({ sessionId: 's1', objective: 'old objective' });
+      await vi.advanceTimersByTimeAsync(500);
+      expect(local.session.sends).toHaveLength(2);
+
+      await local.controller.updateGoal('s1', { objective: 'replacement objective' });
+      await vi.advanceTimersByTimeAsync(0);
+      expect(local.session.sends).toHaveLength(3);
+      expect(local.session.sends.at(-1)?.content).toContain('replacement objective');
+      expect(await local.storage.get('s1')).toMatchObject({
+        status: 'active',
+        objective: 'replacement objective',
+      });
+
+      await vi.advanceTimersByTimeAsync(500);
+      await vi.advanceTimersByTimeAsync(1_000);
+      await vi.advanceTimersByTimeAsync(2_000);
+
+      expect(local.session.sends).toHaveLength(6);
+      expect(await local.storage.get('s1')).toMatchObject({
+        status: 'blocked',
+        objective: 'replacement objective',
+        turnsUsed: 0,
+        lastReason: expect.stringContaining('provider repeatedly rejected attempts'),
+      });
+    } finally {
+      local.controller.dispose();
+      vi.useRealTimers();
+    }
+  });
+
+  it('fences the old rejection timer while setGoal replacement waits for hydration', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    let ensureCalls = 0;
+    let releaseHydration!: (session: SessionLike | undefined) => void;
+    const pendingHydration = new Promise<SessionLike | undefined>((resolve) => {
+      releaseHydration = resolve;
+    });
+    const local = makeController({
+      now: () => Date.now(),
+      ensureSession: async () => {
+        ensureCalls += 1;
+        return ensureCalls === 3 ? pendingHydration : local.session;
+      },
+    });
+    let attempts = 0;
+    vi.spyOn(local.session, 'send').mockImplementation(async (
+      message: Parameters<FakeSession['send']>[0],
+      opts: Parameters<FakeSession['send']>[1],
+    ): Promise<SessionSendResult> => {
+      const content = typeof message === 'string' ? message : message.content;
+      local.session.sends.push({ content, originKind: opts?.origin?.kind });
+      attempts += 1;
+      opts?.onDispatching?.();
+      return attempts === 1
+        ? { accepted: false, reason: 'provider-rejected-before-dispatch' }
+        : { accepted: true };
+    });
+
+    try {
+      await local.controller.setGoal({ sessionId: 's1', objective: 'old objective' });
+      const replacement = local.controller.setGoal({
+        sessionId: 's1',
+        objective: 'replacement objective',
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      expect(ensureCalls).toBe(3);
+
+      await vi.advanceTimersByTimeAsync(500);
+      expect(local.session.sends).toHaveLength(1);
+
+      releaseHydration(local.session);
+      await replacement;
+      expect(local.session.sends).toHaveLength(2);
+      expect(local.session.sends.at(-1)?.content).toContain('replacement objective');
+    } finally {
+      local.controller.dispose();
+      vi.useRealTimers();
+    }
+  });
+
+  it('fences the old rejection timer while an objective marker is persisting', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    let releaseMarker!: () => void;
+    const pendingMarker = new Promise<void>((resolve) => {
+      releaseMarker = resolve;
+    });
+    const local = makeController({
+      now: () => Date.now(),
+      persistUserMessage: async (_sessionId, _content, opts) => {
+        if (opts?.goalObjective?.updated) await pendingMarker;
+      },
+    });
+    let attempts = 0;
+    vi.spyOn(local.session, 'send').mockImplementation(async (
+      message: Parameters<FakeSession['send']>[0],
+      opts: Parameters<FakeSession['send']>[1],
+    ): Promise<SessionSendResult> => {
+      const content = typeof message === 'string' ? message : message.content;
+      local.session.sends.push({ content, originKind: opts?.origin?.kind });
+      attempts += 1;
+      opts?.onDispatching?.();
+      return attempts === 1
+        ? { accepted: false, reason: 'provider-rejected-before-dispatch' }
+        : { accepted: true };
+    });
+
+    try {
+      await local.controller.setGoal({ sessionId: 's1', objective: 'old objective' });
+      const update = local.controller.updateGoal('s1', { objective: 'replacement objective' });
+      await vi.advanceTimersByTimeAsync(0);
+
+      await vi.advanceTimersByTimeAsync(500);
+      expect(local.session.sends).toHaveLength(1);
+
+      releaseMarker();
+      await update;
+      await vi.advanceTimersByTimeAsync(0);
+      expect(local.session.sends).toHaveLength(2);
+      expect(local.session.sends.at(-1)?.content).toContain('replacement objective');
+    } finally {
+      local.controller.dispose();
+      vi.useRealTimers();
+    }
+  });
+
+  it('restores the old objective retry budget when its update fails before commit', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const local = makeController({ now: () => Date.now() });
+    let attempts = 0;
+    vi.spyOn(local.session, 'send').mockImplementation(async (
+      message: Parameters<FakeSession['send']>[0],
+      opts: Parameters<FakeSession['send']>[1],
+    ): Promise<SessionSendResult> => {
+      const content = typeof message === 'string' ? message : message.content;
+      local.session.sends.push({ content, originKind: opts?.origin?.kind });
+      attempts += 1;
+      opts?.onDispatching?.();
+      return attempts === 1
+        ? { accepted: false, reason: 'provider-rejected-before-dispatch' }
+        : { accepted: true };
+    });
+
+    try {
+      await local.controller.setGoal({ sessionId: 's1', objective: 'old objective' });
+      vi.spyOn(local.storage, 'update').mockRejectedValueOnce(new Error('storage unavailable'));
+
+      await expect(
+        local.controller.updateGoal('s1', { objective: 'replacement objective' }),
+      ).rejects.toThrow('storage unavailable');
+
+      await vi.advanceTimersByTimeAsync(499);
+      expect(local.session.sends).toHaveLength(1);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(local.session.sends).toHaveLength(2);
+      expect(local.session.sends.at(-1)?.content).toContain('old objective');
+      expect(await local.storage.get('s1')).toMatchObject({
+        status: 'active',
+        objective: 'old objective',
+      });
+    } finally {
+      local.controller.dispose();
+      vi.useRealTimers();
+    }
+  });
+
+  it('aborts a retry still inside the dispatch gate before replacing the Goal', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const local = makeController({ now: () => Date.now() });
+    let attempts = 0;
+    let markRetryStarted!: () => void;
+    const retryStarted = new Promise<void>((resolve) => {
+      markRetryStarted = resolve;
+    });
+    vi.spyOn(local.session, 'send').mockImplementation(async (
+      message: Parameters<FakeSession['send']>[0],
+      opts: Parameters<FakeSession['send']>[1],
+    ): Promise<SessionSendResult> => {
+      const content = typeof message === 'string' ? message : message.content;
+      local.session.sends.push({ content, originKind: opts?.origin?.kind });
+      attempts += 1;
       if (attempts === 1) {
+        opts?.onDispatching?.();
         return { accepted: false, reason: 'provider-rejected-before-dispatch' };
+      }
+      if (attempts === 2) {
+        markRetryStarted();
+        await new Promise<void>((resolve) => {
+          opts?.signal?.addEventListener('abort', () => resolve(), { once: true });
+        });
+        return { accepted: false, reason: 'cancelled-before-dispatch' };
       }
       opts?.onDispatching?.();
       return { accepted: true };
     });
 
-    await local.controller.setGoal({ sessionId: 's1', objective: 'ship the feature' });
+    try {
+      await local.controller.setGoal({ sessionId: 's1', objective: 'old objective' });
+      const retryAdvance = vi.advanceTimersByTimeAsync(500);
+      await retryStarted;
 
-    expect(order).toEqual(['baseline', 'send', 'abort']);
-    expect(onUndispatchedUserTurn).toHaveBeenCalledWith('s1');
-    expect(await local.storage.get('s1')).toMatchObject({ status: 'active', turnsUsed: 0 });
+      const replacement = local.controller.setGoal({
+        sessionId: 's1',
+        objective: 'replacement objective',
+      });
+      await Promise.all([retryAdvance, replacement]);
 
-    await tick();
+      expect(local.session.sends).toHaveLength(3);
+      expect(local.session.sends.at(-1)?.content).toContain('replacement objective');
+      expect(await local.storage.get('s1')).toMatchObject({
+        status: 'active',
+        objective: 'replacement objective',
+      });
+    } finally {
+      local.controller.dispose();
+      vi.useRealTimers();
+    }
+  });
 
-    expect(order).toEqual(['baseline', 'send', 'abort', 'baseline', 'send']);
-    expect(beforeDispatchUserTurn).toHaveBeenCalledTimes(2);
-    expect(local.session.sends).toHaveLength(2);
-    expect(await local.storage.get('s1')).toMatchObject({ status: 'active', turnsUsed: 0 });
+  it('aborts a retry after onDispatching before replacing the Goal', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const local = makeController({ now: () => Date.now() });
+    let attempts = 0;
+    let markRetryStarted!: () => void;
+    let releaseRetry!: (result: SessionSendResult) => void;
+    const retryStarted = new Promise<void>((resolve) => {
+      markRetryStarted = resolve;
+    });
+    const pendingRetry = new Promise<SessionSendResult>((resolve) => {
+      releaseRetry = resolve;
+    });
+    vi.spyOn(local.session, 'send').mockImplementation(async (
+      message: Parameters<FakeSession['send']>[0],
+      opts: Parameters<FakeSession['send']>[1],
+    ): Promise<SessionSendResult> => {
+      const content = typeof message === 'string' ? message : message.content;
+      local.session.sends.push({ content, originKind: opts?.origin?.kind });
+      attempts += 1;
+      opts?.onDispatching?.();
+      if (attempts === 1) {
+        return { accepted: false, reason: 'provider-rejected-before-dispatch' };
+      }
+      if (attempts === 2) {
+        local.session.running = true;
+        markRetryStarted();
+        return pendingRetry;
+      }
+      return { accepted: true };
+    });
+    vi.spyOn(local.session, 'abort').mockImplementation(async () => {
+      local.session.running = false;
+      releaseRetry({ accepted: false, reason: 'cancelled-before-dispatch' });
+    });
+
+    try {
+      await local.controller.setGoal({ sessionId: 's1', objective: 'old objective' });
+      const retryAdvance = vi.advanceTimersByTimeAsync(500);
+      await retryStarted;
+
+      const replacement = local.controller.setGoal({
+        sessionId: 's1',
+        objective: 'replacement objective',
+      });
+      await Promise.all([retryAdvance, replacement]);
+
+      expect(local.session.abort).toHaveBeenCalledTimes(1);
+      expect(local.session.sends).toHaveLength(3);
+      expect(local.session.sends.at(-1)?.content).toContain('replacement objective');
+      expect(await local.storage.get('s1')).toMatchObject({
+        status: 'active',
+        objective: 'replacement objective',
+      });
+    } finally {
+      local.controller.dispose();
+      vi.useRealTimers();
+    }
+  });
+
+  it('rejects updateGoal while an old-objective retry acceptance is unresolved', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const local = makeController({ now: () => Date.now() });
+    let attempts = 0;
+    let markRetryStarted!: () => void;
+    let releaseRetry!: (result: SessionSendResult) => void;
+    const retryStarted = new Promise<void>((resolve) => {
+      markRetryStarted = resolve;
+    });
+    const pendingRetry = new Promise<SessionSendResult>((resolve) => {
+      releaseRetry = resolve;
+    });
+    vi.spyOn(local.session, 'send').mockImplementation(async (
+      message: Parameters<FakeSession['send']>[0],
+      opts: Parameters<FakeSession['send']>[1],
+    ): Promise<SessionSendResult> => {
+      const content = typeof message === 'string' ? message : message.content;
+      local.session.sends.push({ content, originKind: opts?.origin?.kind });
+      attempts += 1;
+      opts?.onDispatching?.();
+      if (attempts === 1) {
+        return { accepted: false, reason: 'provider-rejected-before-dispatch' };
+      }
+      markRetryStarted();
+      return pendingRetry;
+    });
+
+    try {
+      await local.controller.setGoal({ sessionId: 's1', objective: 'old objective' });
+      const retryAdvance = vi.advanceTimersByTimeAsync(500);
+      await retryStarted;
+
+      await expect(
+        local.controller.updateGoal('s1', { objective: 'replacement objective' }),
+      ).rejects.toThrow('current goal dispatch is still being accepted');
+      expect(await local.storage.get('s1')).toMatchObject({
+        status: 'active',
+        objective: 'old objective',
+      });
+
+      releaseRetry({ accepted: true });
+      await retryAdvance;
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(local.session.sends).toHaveLength(2);
+      expect(await local.storage.get('s1')).toMatchObject({ objective: 'old objective' });
+    } finally {
+      local.controller.dispose();
+      vi.useRealTimers();
+    }
+  });
+
+  it('restores the old rejection owner when replacement state lookup fails', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const local = makeController({ now: () => Date.now() });
+    let attempts = 0;
+    vi.spyOn(local.session, 'send').mockImplementation(async (
+      message: Parameters<FakeSession['send']>[0],
+      opts: Parameters<FakeSession['send']>[1],
+    ): Promise<SessionSendResult> => {
+      const content = typeof message === 'string' ? message : message.content;
+      local.session.sends.push({ content, originKind: opts?.origin?.kind });
+      attempts += 1;
+      opts?.onDispatching?.();
+      return attempts === 1
+        ? { accepted: false, reason: 'provider-rejected-before-dispatch' }
+        : { accepted: true };
+    });
+
+    try {
+      await local.controller.setGoal({ sessionId: 's1', objective: 'old objective' });
+      vi.spyOn(local.storage, 'get').mockRejectedValueOnce(new Error('storage unavailable'));
+
+      await expect(
+        local.controller.setGoal({ sessionId: 's1', objective: 'replacement objective' }),
+      ).rejects.toThrow('storage unavailable');
+
+      await vi.advanceTimersByTimeAsync(500);
+      expect(local.session.sends).toHaveLength(2);
+      expect(local.session.sends.at(-1)?.content).toContain('old objective');
+      expect(await local.storage.get('s1')).toMatchObject({
+        status: 'active',
+        objective: 'old objective',
+      });
+    } finally {
+      local.controller.dispose();
+      vi.useRealTimers();
+    }
+  });
+
+  it('restores the old retry when setGoal replacement fails before objective commit', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const local = makeController({ now: () => Date.now() });
+    let attempts = 0;
+    vi.spyOn(local.session, 'send').mockImplementation(async (
+      message: Parameters<FakeSession['send']>[0],
+      opts: Parameters<FakeSession['send']>[1],
+    ): Promise<SessionSendResult> => {
+      const content = typeof message === 'string' ? message : message.content;
+      local.session.sends.push({ content, originKind: opts?.origin?.kind });
+      attempts += 1;
+      opts?.onDispatching?.();
+      return attempts === 1
+        ? { accepted: false, reason: 'provider-rejected-before-dispatch' }
+        : { accepted: true };
+    });
+
+    try {
+      await local.controller.setGoal({ sessionId: 's1', objective: 'old objective' });
+      vi.spyOn(local.storage, 'update').mockRejectedValueOnce(new Error('storage unavailable'));
+
+      await expect(
+        local.controller.setGoal({ sessionId: 's1', objective: 'replacement objective' }),
+      ).rejects.toThrow('storage unavailable');
+
+      await vi.advanceTimersByTimeAsync(500);
+      expect(local.session.sends).toHaveLength(2);
+      expect(local.session.sends.at(-1)?.content).toContain('old objective');
+      expect(await local.storage.get('s1')).toMatchObject({
+        status: 'active',
+        objective: 'old objective',
+      });
+    } finally {
+      local.controller.dispose();
+      vi.useRealTimers();
+    }
+  });
+
+  it('continues the committed replacement when its objective marker fails', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const local = makeController({
+      now: () => Date.now(),
+      persistUserMessage: async (_sessionId, _content, opts) => {
+        if (opts?.goalObjective?.updated) throw new Error('marker unavailable');
+      },
+    });
+    let attempts = 0;
+    vi.spyOn(local.session, 'send').mockImplementation(async (
+      message: Parameters<FakeSession['send']>[0],
+      opts: Parameters<FakeSession['send']>[1],
+    ): Promise<SessionSendResult> => {
+      const content = typeof message === 'string' ? message : message.content;
+      local.session.sends.push({ content, originKind: opts?.origin?.kind });
+      attempts += 1;
+      opts?.onDispatching?.();
+      return attempts === 1
+        ? { accepted: false, reason: 'provider-rejected-before-dispatch' }
+        : { accepted: true };
+    });
+
+    try {
+      await local.controller.setGoal({ sessionId: 's1', objective: 'old objective' });
+      await expect(
+        local.controller.setGoal({ sessionId: 's1', objective: 'replacement objective' }),
+      ).rejects.toThrow('marker unavailable');
+
+      expect(await local.storage.get('s1')).toMatchObject({
+        status: 'active',
+        objective: 'replacement objective',
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      expect(local.session.sends).toHaveLength(2);
+      expect(local.session.sends.at(-1)?.content).toContain('replacement objective');
+    } finally {
+      local.controller.dispose();
+      vi.useRealTimers();
+    }
   });
 
   it('setGoal create resolves agentKind from the ensured (resumed) session for a dormant Codex session (no claude-code fallback)', async () => {

--- a/apps/desktop/src/main/goal-host/__tests__/controller.test.ts
+++ b/apps/desktop/src/main/goal-host/__tests__/controller.test.ts
@@ -5,6 +5,7 @@ import type { AgentEvent, SessionSendResult } from '@cindy/maker-core';
 
 import {
   GoalController,
+  GoalSessionRestoreError,
   GoalUpdateSupersededError,
   decideNextGoalState,
   deriveObjectiveFromAnswers,
@@ -422,22 +423,18 @@ describe('GoalController', () => {
     });
   });
 
-  it('blocks a new Goal when its dormant agent session cannot be restored', async () => {
+  it('rejects a new Goal when its dormant agent session cannot be restored', async () => {
     const local = makeController();
     local.setHydratable(false);
 
-    await local.controller.setGoal({
+    await expect(local.controller.setGoal({
       sessionId: 's1',
       objective: 'finish the work',
       agentKind: 'pi',
-    });
+    })).rejects.toBeInstanceOf(GoalSessionRestoreError);
 
     expect(local.session.sends).toHaveLength(0);
-    expect(await local.storage.get('s1')).toMatchObject({
-      status: 'blocked',
-      turnsUsed: 0,
-      lastReason: expect.stringContaining('unable to restore the agent session'),
-    });
+    expect(await local.storage.get('s1')).toBeNull();
   });
 
   it('blocks and rejects a Goal edit when its session cannot be restored', async () => {
@@ -448,7 +445,28 @@ describe('GoalController', () => {
     await expect(local.controller.setGoal({
       sessionId: 's1',
       objective: 'new objective',
-    })).rejects.toThrow('unable to restore the agent session for Goal');
+    })).rejects.toBeInstanceOf(GoalSessionRestoreError);
+
+    expect(await local.storage.get('s1')).toMatchObject({
+      status: 'blocked',
+      objective: 'old objective',
+      lastReason: expect.stringContaining('unable to restore the agent session'),
+    });
+    expect(local.session.sends).toHaveLength(0);
+  });
+
+  it('blocks a Goal edit when session restoration throws and preserves the old objective', async () => {
+    const local = makeController({
+      ensureSession: async () => {
+        throw new Error('agent bootstrap failed');
+      },
+    });
+    await local.storage.set(seededGoal({ status: 'active', objective: 'old objective' }));
+
+    await expect(local.controller.setGoal({
+      sessionId: 's1',
+      objective: 'new objective',
+    })).rejects.toBeInstanceOf(GoalSessionRestoreError);
 
     expect(await local.storage.get('s1')).toMatchObject({
       status: 'blocked',
@@ -469,6 +487,77 @@ describe('GoalController', () => {
       turnsUsed: 0,
       lastReason: expect.stringContaining('provider authentication failed'),
     });
+  });
+
+  it('keeps dispatch owners clean when the route-lock release throws', async () => {
+    const releaseAgentSwitchLock = vi.fn(() => {
+      throw new Error('route lock release failed');
+    });
+    const acquirePendingAgentSwitch = vi.fn(async () => releaseAgentSwitchLock);
+    const local = makeController({ acquirePendingAgentSwitch });
+
+    await local.controller.setGoal({ sessionId: 's1', objective: 'keep advancing' });
+    expect(local.session.sends).toHaveLength(1);
+
+    local.session.emitGoalTurn({
+      toolUse: true,
+      verdictJson: '```json\n{"goal_status":"continue","reason":"next"}\n```',
+      tokens: 10,
+    });
+    await tick();
+
+    expect(local.session.sends).toHaveLength(2);
+    expect(acquirePendingAgentSwitch).toHaveBeenCalledTimes(2);
+    expect(releaseAgentSwitchLock).toHaveBeenCalledTimes(2);
+  });
+
+  it('propagates a typed restore error when the route switch closes the initially ensured session', async () => {
+    const session = new FakeSession('s1', 'pi');
+    let ensureCalls = 0;
+    const local = makeController({
+      getSession: () => session,
+      ensureSession: async () => {
+        ensureCalls += 1;
+        return ensureCalls === 1 ? session : undefined;
+      },
+      acquirePendingAgentSwitch: async () => () => {},
+    });
+
+    await expect(local.controller.setGoal({
+      sessionId: 's1',
+      objective: 'recover after the switch',
+      agentKind: 'pi',
+    })).rejects.toBeInstanceOf(GoalSessionRestoreError);
+
+    expect(await local.storage.get('s1')).toMatchObject({
+      status: 'blocked',
+      lastReason: expect.stringContaining('unable to restore the agent session'),
+    });
+    expect(session.sends).toHaveLength(0);
+  });
+
+  it('propagates a typed restore error when manual Resume loses its session after route switching', async () => {
+    const session = new FakeSession('s1', 'pi');
+    let ensureCalls = 0;
+    const local = makeController({
+      getSession: () => session,
+      ensureSession: async () => {
+        ensureCalls += 1;
+        return ensureCalls === 1 ? session : undefined;
+      },
+      acquirePendingAgentSwitch: async () => () => {},
+    });
+    await local.storage.set(seededGoal({ status: 'blocked', agentKind: 'pi' }));
+
+    await expect(local.controller.resumeGoal('s1')).rejects.toBeInstanceOf(
+      GoalSessionRestoreError,
+    );
+
+    expect(await local.storage.get('s1')).toMatchObject({
+      status: 'blocked',
+      lastReason: expect.stringContaining('unable to restore the agent session'),
+    });
+    expect(session.sends).toHaveLength(0);
   });
 
   it('setGoal creates a new goal directly with default limits and fires the first turn', async () => {
@@ -2128,8 +2217,8 @@ describe('GoalController', () => {
     const sendsBeforeResume = h.session.sends.length;
 
     h.setHydratable(false);
-    await expect(h.controller.resumeGoal('s1')).rejects.toThrow(
-      'unable to restore the agent session for Goal',
+    await expect(h.controller.resumeGoal('s1')).rejects.toBeInstanceOf(
+      GoalSessionRestoreError,
     );
     expect((await h.storage.get('s1'))?.status).toBe('blocked');
     expect((await h.storage.get('s1'))?.lastReason).toContain('unable to restore the agent session');
@@ -2198,6 +2287,118 @@ describe('GoalController', () => {
     expect(await local.storage.get('s1')).toMatchObject({
       status: 'blocked',
       lastReason: expect.stringContaining('unable to restore the agent session'),
+    });
+    expect(local.session.sends).toHaveLength(0);
+  });
+
+  it('blocks and releases a dormant lifecycle boundary when agent-switch bootstrap rejects', async () => {
+    let acquireCalls = 0;
+    const acquirePendingAgentSwitch = vi.fn(async () => {
+      acquireCalls += 1;
+      if (acquireCalls === 1) throw new Error('agent switch bootstrap failed');
+      return () => {};
+    });
+    const local = makeController({ acquirePendingAgentSwitch });
+    await local.storage.set(seededGoal({ status: 'active', objective: 'recover safely' }));
+
+    await local.controller.resumeOnOpen('s1');
+
+    expect(await local.storage.get('s1')).toMatchObject({
+      status: 'blocked',
+      lastReason: expect.stringContaining('unable to restore the agent session'),
+    });
+    expect(local.session.sends).toHaveLength(0);
+
+    await local.controller.resumeGoal('s1');
+
+    expect((await local.storage.get('s1'))?.status).toBe('active');
+    expect(local.session.sends).toHaveLength(1);
+    expect(acquirePendingAgentSwitch).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps a fail-closed owner when persisting a restore failure is unavailable', async () => {
+    const acquirePendingAgentSwitch = vi.fn(async () => {
+      throw new Error('agent switch bootstrap failed');
+    });
+    const local = makeController({ acquirePendingAgentSwitch });
+    await local.storage.set(seededGoal({ status: 'active', objective: 'do not replay' }));
+    const update = vi.spyOn(local.storage, 'update').mockRejectedValueOnce(
+      new Error('goal storage unavailable'),
+    );
+
+    await expect(local.controller.resumeOnOpen('s1')).rejects.toBeInstanceOf(
+      GoalSessionRestoreError,
+    );
+    await local.controller.resumeOnOpen('s1');
+
+    expect(await local.storage.get('s1')).toMatchObject({
+      status: 'blocked',
+      objective: 'do not replay',
+      lastReason: expect.stringContaining('unable to restore the agent session'),
+    });
+    expect(update).toHaveBeenCalledTimes(2);
+    expect(acquirePendingAgentSwitch).toHaveBeenCalledTimes(1);
+    expect(local.session.sends).toHaveLength(0);
+  });
+
+  it('propagates an unpersisted second restore failure through resume-on-open', async () => {
+    const session = new FakeSession('s1', 'pi');
+    let ensureCalls = 0;
+    const local = makeController({
+      getSession: () => session,
+      ensureSession: async () => {
+        ensureCalls += 1;
+        return ensureCalls === 1 ? session : undefined;
+      },
+      acquirePendingAgentSwitch: async () => () => {},
+    });
+    await local.storage.set(seededGoal({ status: 'active', objective: 'recover once' }));
+    const update = vi.spyOn(local.storage, 'update').mockRejectedValueOnce(
+      new Error('goal storage unavailable'),
+    );
+
+    await expect(local.controller.resumeOnOpen('s1')).rejects.toBeInstanceOf(
+      GoalSessionRestoreError,
+    );
+    expect(await local.storage.get('s1')).toMatchObject({ status: 'active' });
+
+    await local.controller.resumeOnOpen('s1');
+
+    expect(await local.storage.get('s1')).toMatchObject({
+      status: 'blocked',
+      lastReason: expect.stringContaining('unable to restore the agent session'),
+    });
+    expect(update).toHaveBeenCalledTimes(2);
+    expect(ensureCalls).toBe(2);
+    expect(session.sends).toHaveLength(0);
+  });
+
+  it('does not let a late resume-on-open bootstrap failure overwrite a newer Stop boundary', async () => {
+    let markBootstrapStarted!: () => void;
+    const bootstrapStarted = new Promise<void>((resolve) => {
+      markBootstrapStarted = resolve;
+    });
+    let rejectBootstrap!: (error: Error) => void;
+    const bootstrap = new Promise<() => void>((_resolve, reject) => {
+      rejectBootstrap = reject;
+    });
+    const local = makeController({
+      acquirePendingAgentSwitch: () => {
+        markBootstrapStarted();
+        return bootstrap;
+      },
+    });
+    await local.storage.set(seededGoal({ status: 'active', objective: 'stay paused' }));
+
+    const resuming = local.controller.resumeOnOpen('s1');
+    await bootstrapStarted;
+    await local.controller.pauseGoal('s1');
+    rejectBootstrap(new Error('late bootstrap failure'));
+    await resuming;
+
+    expect(await local.storage.get('s1')).toMatchObject({
+      status: 'paused',
+      lastReason: 'paused by user',
     });
     expect(local.session.sends).toHaveLength(0);
   });

--- a/apps/desktop/src/main/goal-host/__tests__/controller.test.ts
+++ b/apps/desktop/src/main/goal-host/__tests__/controller.test.ts
@@ -650,7 +650,7 @@ describe('GoalController', () => {
     expect(await local.storage.get('s1')).toBeNull();
   });
 
-  it('aborts the git baseline when a goal continuation send is not accepted', async () => {
+  it('aborts the git baseline and retries when the provider explicitly rejects before dispatch', async () => {
     const order: string[] = [];
     const beforeDispatchUserTurn = vi.fn(async () => {
       order.push('baseline');
@@ -662,6 +662,7 @@ describe('GoalController', () => {
       beforeDispatchUserTurn,
       onUndispatchedUserTurn,
     });
+    let attempts = 0;
     vi.spyOn(local.session, 'send').mockImplementation(async (
       message: Parameters<FakeSession['send']>[0],
       opts: Parameters<FakeSession['send']>[1],
@@ -669,15 +670,26 @@ describe('GoalController', () => {
       const content = typeof message === 'string' ? message : message.content;
       local.session.sends.push({ content, originKind: opts?.origin?.kind });
       order.push('send');
-      return { accepted: false, reason: 'cancelled-before-dispatch' };
+      attempts += 1;
+      if (attempts === 1) {
+        return { accepted: false, reason: 'provider-rejected-before-dispatch' };
+      }
+      opts?.onDispatching?.();
+      return { accepted: true };
     });
 
     await local.controller.setGoal({ sessionId: 's1', objective: 'ship the feature' });
 
     expect(order).toEqual(['baseline', 'send', 'abort']);
-    expect(beforeDispatchUserTurn).toHaveBeenCalledWith('s1');
     expect(onUndispatchedUserTurn).toHaveBeenCalledWith('s1');
-    expect(local.session.sends).toHaveLength(1);
+    expect(await local.storage.get('s1')).toMatchObject({ status: 'active', turnsUsed: 0 });
+
+    await tick();
+
+    expect(order).toEqual(['baseline', 'send', 'abort', 'baseline', 'send']);
+    expect(beforeDispatchUserTurn).toHaveBeenCalledTimes(2);
+    expect(local.session.sends).toHaveLength(2);
+    expect(await local.storage.get('s1')).toMatchObject({ status: 'active', turnsUsed: 0 });
   });
 
   it('setGoal create resolves agentKind from the ensured (resumed) session for a dormant Codex session (no claude-code fallback)', async () => {

--- a/apps/desktop/src/main/goal-host/__tests__/controller.test.ts
+++ b/apps/desktop/src/main/goal-host/__tests__/controller.test.ts
@@ -705,6 +705,91 @@ describe('GoalController', () => {
     }
   });
 
+  it.each(['create', 'edit'] as const)(
+    'preserves the %s lifecycle when the final status read fails after provider rejection',
+    async (mode) => {
+      vi.useFakeTimers();
+      vi.setSystemTime(1_000);
+      const local = makeController({ now: () => Date.now() });
+      const originalGet = local.storage.get.bind(local.storage);
+      let failNextRead = false;
+      vi.spyOn(local.storage, 'get').mockImplementation(async (sessionId) => {
+        if (failNextRead) {
+          failNextRead = false;
+          throw new Error('final status read unavailable');
+        }
+        return originalGet(sessionId);
+      });
+      let attempts = 0;
+      vi.spyOn(local.session, 'send').mockImplementation(async (
+        message: Parameters<FakeSession['send']>[0],
+        opts: Parameters<FakeSession['send']>[1],
+      ): Promise<SessionSendResult> => {
+        const content = typeof message === 'string' ? message : message.content;
+        local.session.sends.push({ content, originKind: opts?.origin?.kind });
+        attempts += 1;
+        opts?.onDispatching?.();
+        if (attempts === 1) {
+          failNextRead = true;
+          return { accepted: false, reason: 'provider-rejected-before-dispatch' };
+        }
+        return { accepted: true };
+      });
+      const internals = local.controller as unknown as {
+        turns: Map<string, unknown>;
+        timers: Map<string, ReturnType<typeof setTimeout>>;
+        unsubscribers: Map<string, () => void>;
+        dispatchRejectionRetries: Map<string, unknown>;
+      };
+
+      try {
+        if (mode === 'edit') {
+          await local.storage.set(seededGoal({ status: 'paused', objective: 'old objective' }));
+        }
+
+        await expect(
+          local.controller.setGoal({ sessionId: 's1', objective: 'replacement objective' }),
+        ).rejects.toThrow('final status read unavailable');
+
+        expect(local.session.sends).toHaveLength(1);
+        expect(internals.turns.has('s1')).toBe(true);
+        expect(internals.timers.has('s1')).toBe(true);
+        expect(internals.unsubscribers.has('s1')).toBe(true);
+        expect(internals.dispatchRejectionRetries.has('s1')).toBe(true);
+        expect(await originalGet('s1')).toMatchObject({
+          status: 'active',
+          objective: 'replacement objective',
+          turnsUsed: 0,
+        });
+
+        // Opening an already managed Goal must not bypass the preserved timer.
+        await local.controller.resumeOnOpen('s1');
+        expect(local.session.sends).toHaveLength(1);
+        await vi.advanceTimersByTimeAsync(499);
+        expect(local.session.sends).toHaveLength(1);
+        await vi.advanceTimersByTimeAsync(1);
+        expect(local.session.sends).toHaveLength(2);
+        expect(internals.dispatchRejectionRetries.has('s1')).toBe(false);
+        expect(internals.unsubscribers.has('s1')).toBe(true);
+
+        local.session.emitGoalTurn({
+          toolUse: true,
+          verdictJson: '```json\n{"goal_status":"complete","reason":"done"}\n```',
+          tokens: 10,
+        });
+        await vi.waitFor(async () => {
+          expect(await originalGet('s1')).toBeNull();
+        });
+        expect(internals.turns.has('s1')).toBe(false);
+        expect(internals.timers.has('s1')).toBe(false);
+        expect(internals.unsubscribers.has('s1')).toBe(false);
+      } finally {
+        local.controller.dispose();
+        vi.useRealTimers();
+      }
+    },
+  );
+
   it('backs off persistent provider rejection and blocks after four confirmed non-dispatches', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(1_000);

--- a/apps/desktop/src/main/goal-host/__tests__/sessionRestore.test.ts
+++ b/apps/desktop/src/main/goal-host/__tests__/sessionRestore.test.ts
@@ -73,6 +73,26 @@ describe('Goal dormant session restore', () => {
     expect(deps.wireSession).toHaveBeenCalledOnce();
   });
 
+  it('rebuilds an error Session instead of returning the poisoned live object', async () => {
+    const poisoned = {
+      ...fakeSession(),
+      getStatus: vi.fn().mockReturnValue('error'),
+    } as unknown as Session;
+    const replacement = fakeSession();
+    const deps = baseDeps({
+      maker: {
+        getSession: vi.fn().mockReturnValue(poisoned),
+        getSessionMeta: vi.fn().mockResolvedValue(META),
+        createSession: vi.fn().mockResolvedValue(replacement),
+      },
+    });
+
+    await expect(restoreSessionForGoal('session-1', deps)).resolves.toBe(replacement);
+
+    expect(deps.maker.createSession).toHaveBeenCalledOnce();
+    expect(deps.wireSession).toHaveBeenCalledWith(replacement);
+  });
+
   it('preserves a persisted null provider route when restoring a Pi session', async () => {
     const deps = baseDeps({
       maker: {

--- a/apps/desktop/src/main/goal-host/controller.ts
+++ b/apps/desktop/src/main/goal-host/controller.ts
@@ -41,6 +41,12 @@ import {
 } from './types';
 
 const DEFAULT_DEBOUNCE_MS = 150;
+const DISPATCH_REJECTION_BASE_DELAY_MS = 500;
+const DISPATCH_REJECTION_MAX_DELAY_MS = 4_000;
+const DISPATCH_REJECTION_MAX_ATTEMPTS = 4;
+const DISPATCH_REJECTION_MAX_WINDOW_MS = 15_000;
+const DISPATCH_REJECTION_BLOCK_REASON =
+  'turn dispatch failed: provider repeatedly rejected attempts before accepting work';
 
 export class GoalControllerInputError extends Error {
   readonly code = 'INVALID_PARAMS';
@@ -389,6 +395,14 @@ export class GoalController {
   private readonly timers = new Map<string, ReturnType<typeof setTimeout>>();
   /** goal controller 自己发起且尚未收到终止事件的 turn。用于编辑时区分 goal turn / user turn。 */
   private readonly goalTurnsInFlight = new Set<string>();
+  /**
+   * Provider 明确拒绝(确认未接受)的连续重排窗口。只记内存：成功接受或任一显式
+   * lifecycle 操作都会清零；未知投递从不进入这里，而是直接走 fence / blocked。
+   */
+  private readonly dispatchRejectionRetries = new Map<
+    string,
+    { attempts: number; firstRejectedAt: number; retryNotBefore: number }
+  >();
   /** (Option B)已经用 AskUserQuestion 答案改写、或正在提交改写的会话。token 让失败调用
    *  只能释放自己的 claim，不能误删新目标 / 后续调用的闸门。setGoal 与 clearGoal 时重置。 */
   private readonly clarificationApplied = new Map<string, object>();
@@ -445,6 +459,34 @@ export class GoalController {
     if (!objective) throw new GoalControllerInputError('objective must not be empty');
     this.cancelDeferredManualResume(sessionId);
     let entryBoundary = this.turns.get(sessionId);
+    let rejectionTakeover:
+      | {
+          retry: { attempts: number; firstRejectedAt: number; retryNotBefore: number };
+          previousBoundary: TurnAccumulator;
+          hadGoalTurn: boolean;
+          hadFiring: boolean;
+        }
+      | undefined;
+    const rejectionRetry = this.dispatchRejectionRetries.get(sessionId);
+    if (rejectionRetry && entryBoundary) {
+      // A replacement `/goal` must synchronously fence the old objective before
+      // storage or hydration can yield. Keep a cancelled owner on failure so a
+      // stale backoff timer cannot dispatch the old objective invisibly.
+      rejectionTakeover = {
+        retry: { ...rejectionRetry },
+        previousBoundary: entryBoundary,
+        hadGoalTurn: this.goalTurnsInFlight.has(sessionId),
+        hadFiring: this.firing.has(sessionId),
+      };
+      const previousBoundary = entryBoundary;
+      this.stopSession(sessionId);
+      entryBoundary = freshTurn(
+        true,
+        previousBoundary.pendingPersistence,
+        previousBoundary.pendingCompletion,
+      );
+      this.turns.set(sessionId, entryBoundary);
+    }
     // 连续过载计数是 per-goal 状态：换目标(含替换既有目标的编辑路径)必须清零，
     // 否则上一个目标撞过载上限变 blocked 后，新目标会继承耗尽的计数，第一次容量
     // 错误就直接 blocked、拿不到自己的重试预算。
@@ -463,7 +505,22 @@ export class GoalController {
       if (this.turns.get(sessionId) !== takeoverBoundary) return null;
       entryBoundary = takeoverBoundary;
     }
-    const existing = await this.deps.storage.get(sessionId);
+    let existing: GoalState | null;
+    try {
+      existing = await this.deps.storage.get(sessionId);
+    } catch (error) {
+      if (
+        rejectionTakeover &&
+        this.turns.get(sessionId) === entryBoundary
+      ) {
+        this.turns.set(sessionId, rejectionTakeover.previousBoundary);
+        this.dispatchRejectionRetries.set(sessionId, rejectionTakeover.retry);
+        if (rejectionTakeover.hadGoalTurn) this.goalTurnsInFlight.add(sessionId);
+        this.attachListener(sessionId);
+        if (!rejectionTakeover.hadFiring) this.scheduleContinuation(sessionId);
+      }
+      throw error;
+    }
     if (this.turns.get(sessionId) !== entryBoundary) return null;
     const ts = this.now();
 
@@ -501,9 +558,13 @@ export class GoalController {
         );
         throw new GoalSessionRestoreError();
       }
-      const sessionWasBusy = this.isBusy(sessionId);
+      const sessionWasBusy =
+        rejectionTakeover?.hadGoalTurn === true || this.isBusy(sessionId);
       if (sessionWasBusy) {
-        if (!this.goalTurnsInFlight.has(sessionId)) {
+        if (
+          rejectionTakeover?.hadGoalTurn !== true &&
+          !this.goalTurnsInFlight.has(sessionId)
+        ) {
           throw new GoalControllerInputError('current conversation is still running; edit the goal after it becomes idle');
         }
         // 先 stopSession(detach listener + 清 goalTurnsInFlight/turn),再 abort:否则 abort 触发的
@@ -518,6 +579,7 @@ export class GoalController {
         previousBoundary?.pendingCompletion ?? null,
       );
       this.turns.set(sessionId, editBoundary);
+      let editObjectivePersisted = false;
       try {
         if (sessionWasBusy) {
           await session.abort();
@@ -538,6 +600,7 @@ export class GoalController {
           }),
           async (persisted) => {
             if (!persisted) return;
+            editObjectivePersisted = true;
             // 新目标已经提交后才重置澄清闸门；被 Stop 取消或写入失败的 setGoal
             // 不能重新开放旧目标的澄清改写。
             this.clarificationApplied.delete(sessionId);
@@ -560,7 +623,20 @@ export class GoalController {
         }
         return (await this.deps.storage.get(sessionId)) ?? updated;
       } catch (error) {
-        if (this.turns.get(sessionId) === editBoundary) this.turns.delete(sessionId);
+        if (this.turns.get(sessionId) === editBoundary) {
+          if (rejectionTakeover) {
+            // Keep the persisted active Goal live after either half of the edit
+            // fails. Before objective commit, resume the old rejection budget;
+            // after commit, retry only the new objective with a fresh budget.
+            if (!editObjectivePersisted) {
+              this.dispatchRejectionRetries.set(sessionId, rejectionTakeover.retry);
+            }
+            this.attachListener(sessionId);
+            this.scheduleContinuation(sessionId);
+          } else {
+            this.turns.delete(sessionId);
+          }
+        }
         throw error;
       }
     }
@@ -635,6 +711,25 @@ export class GoalController {
     const ownsOperationBoundary = existingBoundary === undefined;
     if (ownsOperationBoundary) this.turns.set(sessionId, operationBoundary);
     let entryGeneration = operationBoundary.generation;
+    let objectiveChanged = false;
+    let objectivePersisted = false;
+    let rejectionRetryRescheduled = false;
+    let frozenRejectionRetry:
+      | { attempts: number; firstRejectedAt: number; retryNotBefore: number }
+      | undefined;
+    const rescheduleRejectedDispatchForObjective = (status: GoalStatus): boolean => {
+      if (
+        rejectionRetryRescheduled ||
+        !objectiveChanged ||
+        status !== 'active' ||
+        (!frozenRejectionRetry && !this.dispatchRejectionRetries.delete(sessionId))
+      ) {
+        return false;
+      }
+      rejectionRetryRescheduled = true;
+      this.scheduleContinuation(sessionId);
+      return true;
+    };
     const entryChanged = (): boolean => {
       const current = this.turns.get(sessionId);
       return current !== operationBoundary || current.generation !== entryGeneration;
@@ -686,6 +781,7 @@ export class GoalController {
         }
         return limited;
       }
+      rescheduleRejectedDispatchForObjective(current.status);
       this.emit(current);
       return current;
     };
@@ -697,13 +793,40 @@ export class GoalController {
       const state = await this.deps.storage.get(sessionId);
       if (entryChanged()) return reconcileLifecycleChange();
       if (!state) return null;
-      const objectiveChanged =
+      objectiveChanged =
         normalized.objective != null && normalized.objective !== state.objective;
+      if (objectiveChanged && state.status === 'active') {
+        const rejectionRetry = this.dispatchRejectionRetries.get(sessionId);
+        if (rejectionRetry && this.firing.has(sessionId)) {
+          // The old retry already entered Session.send. Its acceptance is not yet
+          // known, so committing a replacement objective and scheduling another
+          // send could duplicate side effects. Leave both lifecycle and storage
+          // untouched; the caller can retry after this dispatch settles.
+          throw new GoalControllerInputError(
+            'current goal dispatch is still being accepted; retry the update after it settles',
+          );
+        }
+        if (rejectionRetry) {
+          // Freeze the old objective synchronously before persistence can yield.
+          // Bump generation so a timer callback already waiting on storage cannot
+          // cross the dispatch boundary with the stale objective.
+          frozenRejectionRetry = { ...rejectionRetry };
+          this.dispatchRejectionRetries.delete(sessionId);
+          const timer = this.timers.get(sessionId);
+          if (timer) {
+            clearTimeout(timer);
+            this.timers.delete(sessionId);
+          }
+          operationBoundary.generation += 1;
+          entryGeneration = operationBoundary.generation;
+        }
+      }
       const ts = this.now();
       const preview = { ...state, ...normalized };
       const shouldLimit = state.status === 'active' && exceedsGoalBudget(preview);
       const persistObjectiveMarker = async (changed: GoalState | null): Promise<void> => {
         if (!objectiveChanged || !changed) return;
+        objectivePersisted = true;
         await this.deps.persistUserMessage?.(sessionId, changed.objective, {
           goalObjective: { updated: true },
         });
@@ -751,6 +874,7 @@ export class GoalController {
         if (entryChanged()) return reconcileLifecycleChange();
       }
       if (!changed) return null;
+      rescheduleRejectedDispatchForObjective(changed.status);
       if (shouldLimit) {
         if (this.turns.get(sessionId) !== limitBoundary) return reconcileLifecycleChange();
         this.stopSession(sessionId);
@@ -794,11 +918,28 @@ export class GoalController {
         return reconcileLifecycleChange();
       }
       this.emit(next);
-      if (next.status === 'active' && state.status === 'budgetLimited' && !this.isBusy(sessionId)) {
+      if (
+        next.status === 'active' &&
+        state.status === 'budgetLimited' &&
+        !this.isBusy(sessionId)
+      ) {
         this.scheduleContinuation(sessionId);
       }
       return next;
     } finally {
+      if (
+        frozenRejectionRetry &&
+        !rejectionRetryRescheduled &&
+        this.turns.get(sessionId) === operationBoundary
+      ) {
+        // Storage failure keeps the old objective authoritative, so restore its
+        // retry budget. Once the objective row committed (even if its marker
+        // failed), continue only with a fresh budget for the new objective.
+        if (!objectivePersisted) {
+          this.dispatchRejectionRetries.set(sessionId, frozenRejectionRetry);
+        }
+        this.scheduleContinuation(sessionId);
+      }
       if (ownsOperationBoundary && this.turns.get(sessionId) === operationBoundary) {
         this.turns.delete(sessionId);
       }
@@ -1049,7 +1190,10 @@ export class GoalController {
     // 的目标一恢复就立刻又撞上限)。
     // **自动续跑(opts.auto)绝不清零**:到点自动续跑正是过载循环的一环,在这里清
     // 等于让计数永远回到 0,止损闸门形同不存在。
-    if (!opts?.auto) this.consecutiveOverloadTurns.delete(sessionId);
+    if (!opts?.auto) {
+      this.consecutiveOverloadTurns.delete(sessionId);
+      this.dispatchRejectionRetries.delete(sessionId);
+    }
     const budgetAlreadyExhausted = exceedsGoalBudget(state);
     if (!budgetAlreadyExhausted) {
       let ensured: SessionLike | undefined;
@@ -1355,6 +1499,7 @@ export class GoalController {
     this.unpersistedDispatchFailures.clear();
     this.turns.clear();
     this.consecutiveOverloadTurns.clear();
+    this.dispatchRejectionRetries.clear();
   }
 
   // ── 内部 ───────────────────────────────────────────────────────────────────
@@ -1379,6 +1524,7 @@ export class GoalController {
     }
     this.firing.delete(sessionId);
     this.goalTurnsInFlight.delete(sessionId);
+    this.dispatchRejectionRetries.delete(sessionId);
     this.unpersistedDispatchFailures.delete(sessionId);
     this.turns.delete(sessionId);
   }
@@ -1822,6 +1968,10 @@ export class GoalController {
   private scheduleContinuation(sessionId: string): void {
     const existing = this.timers.get(sessionId);
     if (existing) clearTimeout(existing);
+    const rejectionRetry = this.dispatchRejectionRetries.get(sessionId);
+    const delayMs = rejectionRetry
+      ? Math.max(this.debounceMs, rejectionRetry.retryNotBefore - this.now())
+      : this.debounceMs;
     const timer = setTimeout(() => {
       this.timers.delete(sessionId);
       void this.fireTurn(sessionId).catch((error) => {
@@ -1830,7 +1980,7 @@ export class GoalController {
           error: String(error),
         });
       });
-    }, this.debounceMs);
+    }, delayMs);
     // Node 环境;不 block 进程退出。
     (timer as { unref?: () => void }).unref?.();
     this.timers.set(sessionId, timer);
@@ -2054,6 +2204,24 @@ export class GoalController {
       if (limited) this.emit(limited);
       return;
     }
+    const rejectionRetry = this.dispatchRejectionRetries.get(sessionId);
+    if (
+      rejectionRetry &&
+      Math.max(0, this.now() - rejectionRetry.firstRejectedAt) >=
+        DISPATCH_REJECTION_MAX_WINDOW_MS
+    ) {
+      this.deps.logger.warn('[goal] provider rejection retry window expired', {
+        sessionId,
+        attempts: rejectionRetry.attempts,
+      });
+      await this.blockDispatchFailure(
+        sessionId,
+        lifecycleBoundary,
+        DISPATCH_REJECTION_BLOCK_REASON,
+        isCurrentLifecycle,
+      );
+      return;
+    }
     if (this.firing.has(sessionId)) return;
     // 首轮 vs 续轮由 state 派生(turnsUsed===0 = 首轮尚未真正跑完),不再由调用方指定。
     // 关键:首轮被 busy 跳过 / 被暂停后再发时,只要首轮还没跑过就仍按 first 发,否则首轮
@@ -2167,6 +2335,55 @@ export class GoalController {
         }
         if (!isCurrentDispatch()) return;
         this.goalTurnsInFlight.delete(sessionId);
+
+        if (result.reason === 'provider-rejected-before-dispatch') {
+          const rejectedAt = this.now();
+          const previousRetry = this.dispatchRejectionRetries.get(sessionId);
+          const firstRejectedAt = previousRetry?.firstRejectedAt ?? rejectedAt;
+          const attempts = (previousRetry?.attempts ?? 0) + 1;
+          const elapsedMs = Math.max(0, rejectedAt - firstRejectedAt);
+
+          if (
+            attempts >= DISPATCH_REJECTION_MAX_ATTEMPTS ||
+            elapsedMs >= DISPATCH_REJECTION_MAX_WINDOW_MS
+          ) {
+            this.deps.logger.warn('[goal] provider rejection retry limit reached', {
+              sessionId,
+              kind,
+              attempts,
+              elapsedMs,
+            });
+            await this.blockDispatchFailure(
+              sessionId,
+              dispatchBoundary,
+              DISPATCH_REJECTION_BLOCK_REASON,
+              isCurrentDispatch,
+            );
+            return;
+          }
+
+          const remainingWindowMs = DISPATCH_REJECTION_MAX_WINDOW_MS - elapsedMs;
+          const retryDelayMs = Math.min(
+            DISPATCH_REJECTION_BASE_DELAY_MS * (2 ** (attempts - 1)),
+            DISPATCH_REJECTION_MAX_DELAY_MS,
+            remainingWindowMs,
+          );
+          const retryNotBefore = rejectedAt + retryDelayMs;
+          this.dispatchRejectionRetries.set(sessionId, {
+            attempts,
+            firstRejectedAt,
+            retryNotBefore,
+          });
+          this.deps.logger.warn('[goal] provider rejected dispatch; retrying with backoff', {
+            sessionId,
+            kind,
+            attempts,
+            retryDelayMs,
+          });
+          this.scheduleContinuation(sessionId);
+          return;
+        }
+
         this.deps.logger.warn('[goal] send not accepted', { sessionId, kind, reason: result.reason });
         this.scheduleContinuation(sessionId);
       } else {
@@ -2174,6 +2391,8 @@ export class GoalController {
           baselineStarted = false;
           return;
         }
+        // Provider acceptance ends any prior confirmed-rejection retry window.
+        this.dispatchRejectionRetries.delete(sessionId);
         // onDispatching 是归属登记的唯一边界。不能在 await send 后再次 add：极快的
         // turn 可能已经发出终态并同步释放归属，重新登记会把后续用户 turn 误认成 Goal。
         baselineStarted = false;

--- a/apps/desktop/src/main/goal-host/controller.ts
+++ b/apps/desktop/src/main/goal-host/controller.ts
@@ -1342,7 +1342,10 @@ export class GoalController {
    * 活化失败则转 blocked 并给出可见原因，不能继续显示成正在推进。
    * 这样重开会话能让 active 目标自己跑下去,而不是卡死等用户重发 /goal。
    */
-  async resumeOnOpen(sessionId: string): Promise<void> {
+  async resumeOnOpen(
+    sessionId: string,
+    opts?: { waitForDispatch?: boolean },
+  ): Promise<void> {
     const pendingFailure = this.unpersistedDispatchFailures.get(sessionId);
     if (pendingFailure) {
       const persisted = await this.blockDispatchFailure(
@@ -1425,7 +1428,19 @@ export class GoalController {
     if (this.turns.get(sessionId) !== lifecycleBoundary) return;
     this.emit(state);
     if (!this.isBusy(sessionId)) {
-      await this.fireTurn(sessionId, { throwOnUnpersistedRestoreFailure: true });
+      const dispatch = this.fireTurn(sessionId, {
+        throwOnUnpersistedRestoreFailure: true,
+      });
+      if (opts?.waitForDispatch === false) {
+        void dispatch.catch((error) => {
+          this.deps.logger.warn('[goal] detached resume-on-open fire failed', {
+            sessionId,
+            error: String(error),
+          });
+        });
+      } else {
+        await dispatch;
+      }
     }
   }
 
@@ -2179,7 +2194,23 @@ export class GoalController {
     const isCurrentLifecycle = (): boolean =>
       this.turns.get(sessionId) === lifecycleBoundary &&
       lifecycleBoundary.generation === lifecycleGeneration;
-    const state = await this.deps.storage.get(sessionId);
+    let state: GoalState | null;
+    try {
+      state = await this.deps.storage.get(sessionId);
+    } catch (error) {
+      this.deps.logger.warn('[goal] fireTurn preflight state read failed', {
+        sessionId,
+        error: String(error),
+      });
+      const persisted = await this.blockDispatchFailure(
+        sessionId,
+        lifecycleBoundary,
+        'turn dispatch failed: unable to read Goal state',
+        isCurrentLifecycle,
+      );
+      if (!persisted && opts?.throwOnUnpersistedRestoreFailure) throw error;
+      return;
+    }
     // owner 身份拒绝 Stop / Resume 换代，generation 拒绝另一轮正常推进后的旧 fire；
     // 两者都不能只信上面读到的 active 存档快照。
     if (

--- a/apps/desktop/src/main/goal-host/controller.ts
+++ b/apps/desktop/src/main/goal-host/controller.ts
@@ -580,6 +580,7 @@ export class GoalController {
       );
       this.turns.set(sessionId, editBoundary);
       let editObjectivePersisted = false;
+      let updatedState: GoalState | null = null;
       try {
         if (sessionWasBusy) {
           await session.abort();
@@ -614,6 +615,7 @@ export class GoalController {
           this.turns.delete(sessionId);
           return null;
         }
+        updatedState = updated;
         this.resetTurn(sessionId);
         const activeBoundary = this.turns.get(sessionId);
         this.attachListener(sessionId);
@@ -621,7 +623,6 @@ export class GoalController {
         if (this.turns.get(sessionId) === activeBoundary) {
           await this.fireTurn(sessionId, { throwOnRestoreFailure: true });
         }
-        return (await this.deps.storage.get(sessionId)) ?? updated;
       } catch (error) {
         if (this.turns.get(sessionId) === editBoundary) {
           if (rejectionTakeover) {
@@ -639,6 +640,9 @@ export class GoalController {
         }
         throw error;
       }
+      // This is only a return-value refresh. The Goal lifecycle is already
+      // established, so a read failure must not tear down its owner or retry.
+      return (await this.deps.storage.get(sessionId)) ?? updatedState;
     }
 
     const limits = input.limits ?? this.deps.getDefaults();
@@ -650,6 +654,7 @@ export class GoalController {
       previousBoundary?.pendingCompletion ?? null,
     );
     this.turns.set(sessionId, createBoundary);
+    let createdState: GoalState | null = null;
     try {
       // 先活化(resume)会话,再据活化后的会话定 agentKind:dormant(重启后尚未活化)会话此刻
       // getSession 为空,若直接 fallback 'claude-code' 会把 Codex 目标错存成 claude-code,后续
@@ -681,6 +686,7 @@ export class GoalController {
         startedAt: ts,
         updatedAt: ts,
       };
+      createdState = state;
       await this.trackPersistence(createBoundary, this.deps.storage.upsert(state), async () => {
         this.clarificationApplied.delete(sessionId);
         // 目标创建 → 落一条目标文案作对话起点(updated:false),**只此一次**。
@@ -697,11 +703,13 @@ export class GoalController {
       if (this.turns.get(sessionId) === activeBoundary) {
         await this.fireTurn(sessionId, { throwOnRestoreFailure: true });
       }
-      return (await this.deps.storage.get(sessionId)) ?? state;
     } catch (error) {
       if (this.turns.get(sessionId) === createBoundary) this.turns.delete(sessionId);
       throw error;
     }
+    // Same as the edit path: post-dispatch status refresh is observational and
+    // cannot revoke a lifecycle that may already own a rejection retry.
+    return (await this.deps.storage.get(sessionId)) ?? createdState;
   }
 
   async updateGoal(sessionId: string, patch: GoalUpdatePatch): Promise<GoalState | null> {

--- a/apps/desktop/src/main/goal-host/controller.ts
+++ b/apps/desktop/src/main/goal-host/controller.ts
@@ -46,6 +46,19 @@ export class GoalControllerInputError extends Error {
   readonly code = 'INVALID_PARAMS';
 }
 
+/** Goal 已保守收敛，但本次入口无法恢复其底层 Agent Session。 */
+export class GoalSessionRestoreError extends Error {
+  readonly code = 'PRECONDITION_FAILED';
+
+  constructor(cause?: unknown) {
+    super(
+      'unable to restore the agent session for Goal',
+      cause === undefined ? undefined : { cause },
+    );
+    this.name = 'GoalSessionRestoreError';
+  }
+}
+
 /** Goal 仍存在，但本次编辑已被更新的生命周期或状态覆盖。 */
 export class GoalUpdateSupersededError extends Error {
   readonly code = 'PRECONDITION_FAILED';
@@ -361,6 +374,11 @@ export class GoalController {
    */
   private readonly listenerSessions = new Map<string, SessionLike>();
   private readonly turns = new Map<string, TurnAccumulator>();
+  /** blocked 落盘失败时保留同一 fail-closed owner，GET_STATUS 可重试而不是回报旧 active。 */
+  private readonly unpersistedDispatchFailures = new Map<
+    string,
+    { boundary: TurnAccumulator; lastReason: string }
+  >();
   /** 正在派发的 fire 及其 owner；旧代 finally 只能清理自己，不能删掉 Resume 新代。 */
   private readonly firing = new Map<string, object>();
   /** 尚在 Session.send 派发边界内的 Goal fire；Stop 必须能取消 dispatch 前的异步 gate。 */
@@ -450,19 +468,38 @@ export class GoalController {
     const ts = this.now();
 
     if (existing) {
-      const session = await this.deps.ensureSession(sessionId);
-      if (this.turns.get(sessionId) !== entryBoundary) return null;
-      if (!session) {
-        this.deps.logger.warn('[goal] setGoal edit: no live session', { sessionId });
-        const failureBoundary = entryBoundary ?? freshTurn();
-        if (!entryBoundary) this.turns.set(sessionId, failureBoundary);
+      const failureBoundary = entryBoundary ?? freshTurn();
+      if (!entryBoundary) {
+        entryBoundary = failureBoundary;
+        this.turns.set(sessionId, failureBoundary);
+      }
+      let session: SessionLike | undefined;
+      try {
+        session = await this.deps.ensureSession(sessionId);
+      } catch (error) {
+        if (this.turns.get(sessionId) !== failureBoundary) return null;
+        this.deps.logger.warn('[goal] setGoal edit: session restore failed', {
+          sessionId,
+          error: String(error),
+        });
         await this.blockDispatchFailure(
           sessionId,
           failureBoundary,
           'turn dispatch failed: unable to restore the agent session',
           () => this.turns.get(sessionId) === failureBoundary,
         );
-        throw new Error('unable to restore the agent session for Goal');
+        throw new GoalSessionRestoreError(error);
+      }
+      if (this.turns.get(sessionId) !== entryBoundary) return null;
+      if (!session) {
+        this.deps.logger.warn('[goal] setGoal edit: no live session', { sessionId });
+        await this.blockDispatchFailure(
+          sessionId,
+          failureBoundary,
+          'turn dispatch failed: unable to restore the agent session',
+          () => this.turns.get(sessionId) === failureBoundary,
+        );
+        throw new GoalSessionRestoreError();
       }
       const sessionWasBusy = this.isBusy(sessionId);
       if (sessionWasBusy) {
@@ -519,7 +556,7 @@ export class GoalController {
         this.attachListener(sessionId);
         this.emit(updated);
         if (this.turns.get(sessionId) === activeBoundary) {
-          await this.fireTurn(sessionId);
+          await this.fireTurn(sessionId, { throwOnRestoreFailure: true });
         }
         return (await this.deps.storage.get(sessionId)) ?? updated;
       } catch (error) {
@@ -541,8 +578,14 @@ export class GoalController {
       // 先活化(resume)会话,再据活化后的会话定 agentKind:dormant(重启后尚未活化)会话此刻
       // getSession 为空,若直接 fallback 'claude-code' 会把 Codex 目标错存成 claude-code,后续
       // getAccountLimit 读错账号配额快照 → Codex 限流目标的 reset/auto-resume 错位(reviewer #354)。
-      const ensured = await this.deps.ensureSession(sessionId);
+      let ensured: SessionLike | undefined;
+      try {
+        ensured = await this.deps.ensureSession(sessionId);
+      } catch (error) {
+        throw new GoalSessionRestoreError(error);
+      }
       if (this.turns.get(sessionId) !== createBoundary) return null;
+      if (!ensured) throw new GoalSessionRestoreError();
       await this.awaitPendingLifecycle(createBoundary);
       if (this.turns.get(sessionId) !== createBoundary) return null;
       const agentKind = input.agentKind ?? ensured?.agentKind ?? this.deps.getSession(sessionId)?.agentKind ?? 'claude-code';
@@ -576,7 +619,7 @@ export class GoalController {
       this.attachListener(sessionId);
       this.emit(state);
       if (this.turns.get(sessionId) === activeBoundary) {
-        await this.fireTurn(sessionId);
+        await this.fireTurn(sessionId, { throwOnRestoreFailure: true });
       }
       return (await this.deps.storage.get(sessionId)) ?? state;
     } catch (error) {
@@ -1017,7 +1060,7 @@ export class GoalController {
           this.cancelDeferredManualResume(sessionId, { restoreUsageResume: true });
         }
         if (this.turns.get(sessionId) === lookupBoundary) this.turns.delete(sessionId);
-        throw error;
+        throw new GoalSessionRestoreError(error);
       }
       if (this.turns.get(sessionId) !== lookupBoundary) return;
       if (!ensured) {
@@ -1033,7 +1076,7 @@ export class GoalController {
           'turn dispatch failed: unable to restore the agent session',
           () => this.turns.get(sessionId) === lookupBoundary,
         );
-        throw new Error('unable to restore the agent session for Goal');
+        throw new GoalSessionRestoreError();
       }
       if (!opts?.auto && this.isBusy(sessionId)) {
         this.deferManualResumeUntilIdle(sessionId, lookupBoundary, state);
@@ -1086,7 +1129,7 @@ export class GoalController {
     this.attachListener(sessionId);
     this.emit(updated);
     if (!this.isBusy(sessionId)) {
-      await this.fireTurn(sessionId);
+      await this.fireTurn(sessionId, { throwOnRestoreFailure: !opts?.auto });
     }
   }
 
@@ -1156,6 +1199,17 @@ export class GoalController {
    * 这样重开会话能让 active 目标自己跑下去,而不是卡死等用户重发 /goal。
    */
   async resumeOnOpen(sessionId: string): Promise<void> {
+    const pendingFailure = this.unpersistedDispatchFailures.get(sessionId);
+    if (pendingFailure) {
+      const persisted = await this.blockDispatchFailure(
+        sessionId,
+        pendingFailure.boundary,
+        pendingFailure.lastReason,
+        () => this.turns.get(sessionId) === pendingFailure.boundary,
+      );
+      if (!persisted) throw new GoalSessionRestoreError();
+      return;
+    }
     if (this.unsubscribers.has(sessionId) || this.turns.has(sessionId)) return; // 已在管或正在 Stop
     const lifecycleBoundary = freshTurn();
     this.turns.set(sessionId, lifecycleBoundary);
@@ -1176,6 +1230,8 @@ export class GoalController {
     // 发给 fireTurn 开始时捕获的旧 session。
     let releaseAgentSwitchLock = (): void => {};
     let session: SessionLike | undefined;
+    let restoreFailed = false;
+    let restoreError: unknown;
     try {
       releaseAgentSwitchLock =
         (await this.deps.acquirePendingAgentSwitch?.(sessionId)) ?? (() => {});
@@ -1187,22 +1243,45 @@ export class GoalController {
         // fireTurn 也能凭 unsubscribers 标记把 listener 迁移到重新创建的新 session。
         this.attachListener(sessionId);
       }
+    } catch (error) {
+      restoreFailed = true;
+      restoreError = error;
     } finally {
-      releaseAgentSwitchLock();
+      try {
+        releaseAgentSwitchLock();
+      } catch (error) {
+        restoreFailed = true;
+        restoreError ??= error;
+      }
     }
-    if (!session) {
-      await this.blockDispatchFailure(
+    if (restoreFailed) {
+      this.deps.logger.warn('[goal] resumeOnOpen: session restore failed', {
+        sessionId,
+        error: String(restoreError),
+      });
+      const persisted = await this.blockDispatchFailure(
         sessionId,
         lifecycleBoundary,
         'turn dispatch failed: unable to restore the agent session',
         () => this.turns.get(sessionId) === lifecycleBoundary,
       );
+      if (!persisted) throw new GoalSessionRestoreError(restoreError);
+      return;
+    }
+    if (!session) {
+      const persisted = await this.blockDispatchFailure(
+        sessionId,
+        lifecycleBoundary,
+        'turn dispatch failed: unable to restore the agent session',
+        () => this.turns.get(sessionId) === lifecycleBoundary,
+      );
+      if (!persisted) throw new GoalSessionRestoreError();
       return;
     }
     if (this.turns.get(sessionId) !== lifecycleBoundary) return;
     this.emit(state);
     if (!this.isBusy(sessionId)) {
-      await this.fireTurn(sessionId);
+      await this.fireTurn(sessionId, { throwOnUnpersistedRestoreFailure: true });
     }
   }
 
@@ -1234,7 +1313,12 @@ export class GoalController {
       this.emit(state);
       resumed += 1;
       if (!this.isBusy(state.sessionId)) {
-        void this.fireTurn(state.sessionId);
+        void this.fireTurn(state.sessionId).catch((error) => {
+          this.deps.logger.warn('[goal] detached startup fire failed', {
+            sessionId: state.sessionId,
+            error: String(error),
+          });
+        });
       }
     }
     if (active.length > 0) {
@@ -1268,6 +1352,7 @@ export class GoalController {
     }
     this.deferredManualResumes.clear();
     this.deferredManualResumeContexts.clear();
+    this.unpersistedDispatchFailures.clear();
     this.turns.clear();
     this.consecutiveOverloadTurns.clear();
   }
@@ -1294,6 +1379,7 @@ export class GoalController {
     }
     this.firing.delete(sessionId);
     this.goalTurnsInFlight.delete(sessionId);
+    this.unpersistedDispatchFailures.delete(sessionId);
     this.turns.delete(sessionId);
   }
 
@@ -1696,7 +1782,8 @@ export class GoalController {
     boundary: TurnAccumulator,
     lastReason: string,
     isCurrent: () => boolean,
-  ): Promise<void> {
+  ): Promise<boolean> {
+    if (!isCurrent()) return true;
     try {
       const blocked = await this.trackPersistence(
         boundary,
@@ -1706,15 +1793,30 @@ export class GoalController {
           updatedAt: this.now(),
         }),
       );
-      if (!isCurrent()) return;
+      if (!isCurrent()) return true;
       if (blocked) this.emit(blocked);
     } catch (persistError) {
       this.deps.logger.error('[goal] failed to persist dispatch failure', {
         sessionId,
         error: String(persistError),
       });
+      if (isCurrent()) {
+        const failClosedBoundary = freshTurn(
+          true,
+          boundary.pendingPersistence,
+          boundary.pendingCompletion,
+        );
+        this.stopSession(sessionId);
+        this.turns.set(sessionId, failClosedBoundary);
+        this.unpersistedDispatchFailures.set(sessionId, {
+          boundary: failClosedBoundary,
+          lastReason,
+        });
+      }
+      return false;
     }
     if (isCurrent()) this.stopSession(sessionId);
+    return true;
   }
 
   private scheduleContinuation(sessionId: string): void {
@@ -1722,7 +1824,12 @@ export class GoalController {
     if (existing) clearTimeout(existing);
     const timer = setTimeout(() => {
       this.timers.delete(sessionId);
-      void this.fireTurn(sessionId);
+      void this.fireTurn(sessionId).catch((error) => {
+        this.deps.logger.warn('[goal] detached continuation fire failed', {
+          sessionId,
+          error: String(error),
+        });
+      });
     }, this.debounceMs);
     // Node 环境;不 block 进程退出。
     (timer as { unref?: () => void }).unref?.();
@@ -1812,7 +1919,12 @@ export class GoalController {
     // 立刻触发(限额窗口正常是 5h / weekly,远小于上限;clamp 只是防御异常 resetAt)。
     const delay = Math.min(Math.max(0, resetAtMs - this.now()), 2_147_483_647);
     const timer = setTimeout(() => {
-      void this.autoResumeFromUsageLimit(sessionId);
+      void this.autoResumeFromUsageLimit(sessionId).catch((error) => {
+        this.deps.logger.warn('[goal] detached usage resume failed', {
+          sessionId,
+          error: String(error),
+        });
+      });
     }, delay);
     (timer as { unref?: () => void }).unref?.();
     this.usageResumeTimers.set(sessionId, timer);
@@ -1904,7 +2016,13 @@ export class GoalController {
     }
   }
 
-  private async fireTurn(sessionId: string): Promise<void> {
+  private async fireTurn(
+    sessionId: string,
+    opts?: {
+      throwOnRestoreFailure?: boolean;
+      throwOnUnpersistedRestoreFailure?: boolean;
+    },
+  ): Promise<void> {
     const lifecycleBoundary = this.turns.get(sessionId);
     if (!lifecycleBoundary || lifecycleBoundary.cancelled) return;
     const lifecycleGeneration = lifecycleBoundary.generation;
@@ -1967,6 +2085,7 @@ export class GoalController {
       this.turns.get(sessionId) === dispatchBoundary &&
       dispatchBoundary.generation === dispatchGeneration;
     let releaseAgentSwitchLock = (): void => {};
+    let restoringSession = true;
     let baselineStarted = false;
     try {
       // fireTurn 每次都可能是登记 deferred intent 后的第一条直发消息。锁必须覆盖
@@ -1977,19 +2096,8 @@ export class GoalController {
       if (!isCurrentLifecycle()) return;
       const session = await this.deps.ensureSession(sessionId);
       if (!isCurrentLifecycle()) return;
-      if (!session) {
-        this.deps.logger.warn('[goal] no live session to fire (resume failed)', {
-          sessionId,
-          kind,
-        });
-        await this.blockDispatchFailure(
-          sessionId,
-          lifecycleBoundary,
-          'turn dispatch failed: unable to restore the agent session',
-          isCurrentLifecycle,
-        );
-        return;
-      }
+      if (!session) throw new GoalSessionRestoreError();
+      restoringSession = false;
       // deferred switch 可能刚把 live session 换成目标引擎的新对象;本会话若有 goal
       // listener,必须迁到新 session,否则这轮 turn 的 done/error 事件进不了 finalizeTurn,
       // 目标卡死在 active(reviewer P1)。attachListener 按 session 身份判等,未换则 no-op;
@@ -2091,14 +2199,30 @@ export class GoalController {
       }
 
       const errorMessage = e instanceof Error ? e.message : String(e);
-      await this.blockDispatchFailure(
+      const persisted = await this.blockDispatchFailure(
         sessionId,
         failureBoundary,
         `turn dispatch failed: ${errorMessage}`,
         isCurrentFailure,
       );
+      if (
+        restoringSession &&
+        (opts?.throwOnRestoreFailure ||
+          (!persisted && opts?.throwOnUnpersistedRestoreFailure))
+      ) {
+        throw e instanceof GoalSessionRestoreError
+          ? e
+          : new GoalSessionRestoreError(e);
+      }
     } finally {
-      releaseAgentSwitchLock();
+      try {
+        releaseAgentSwitchLock();
+      } catch (error) {
+        this.deps.logger.warn('[goal] failed to release agent switch lock', {
+          sessionId,
+          error: String(error),
+        });
+      }
       if (this.goalDispatchAbortControllers.get(sessionId)?.owner === firingOwner) {
         this.goalDispatchAbortControllers.delete(sessionId);
       }

--- a/apps/desktop/src/main/goal-host/controller.ts
+++ b/apps/desktop/src/main/goal-host/controller.ts
@@ -454,7 +454,15 @@ export class GoalController {
       if (this.turns.get(sessionId) !== entryBoundary) return null;
       if (!session) {
         this.deps.logger.warn('[goal] setGoal edit: no live session', { sessionId });
-        return null;
+        const failureBoundary = entryBoundary ?? freshTurn();
+        if (!entryBoundary) this.turns.set(sessionId, failureBoundary);
+        await this.blockDispatchFailure(
+          sessionId,
+          failureBoundary,
+          'turn dispatch failed: unable to restore the agent session',
+          () => this.turns.get(sessionId) === failureBoundary,
+        );
+        throw new Error('unable to restore the agent session for Goal');
       }
       const sessionWasBusy = this.isBusy(sessionId);
       if (sessionWasBusy) {
@@ -513,7 +521,7 @@ export class GoalController {
         if (this.turns.get(sessionId) === activeBoundary) {
           await this.fireTurn(sessionId);
         }
-        return updated;
+        return (await this.deps.storage.get(sessionId)) ?? updated;
       } catch (error) {
         if (this.turns.get(sessionId) === editBoundary) this.turns.delete(sessionId);
         throw error;
@@ -570,7 +578,7 @@ export class GoalController {
       if (this.turns.get(sessionId) === activeBoundary) {
         await this.fireTurn(sessionId);
       }
-      return state;
+      return (await this.deps.storage.get(sessionId)) ?? state;
     } catch (error) {
       if (this.turns.get(sessionId) === createBoundary) this.turns.delete(sessionId);
       throw error;
@@ -1013,11 +1021,19 @@ export class GoalController {
       }
       if (this.turns.get(sessionId) !== lookupBoundary) return;
       if (!ensured) {
-        if (!opts?.auto) {
-          this.cancelDeferredManualResume(sessionId, { restoreUsageResume: true });
+        if (opts?.auto) {
+          if (this.turns.get(sessionId) === lookupBoundary) this.turns.delete(sessionId);
+          return;
         }
-        if (this.turns.get(sessionId) === lookupBoundary) this.turns.delete(sessionId);
-        return;
+        this.completeDeferredManualResume(sessionId);
+        this.cancelUsageResume(sessionId);
+        await this.blockDispatchFailure(
+          sessionId,
+          lookupBoundary,
+          'turn dispatch failed: unable to restore the agent session',
+          () => this.turns.get(sessionId) === lookupBoundary,
+        );
+        throw new Error('unable to restore the agent session for Goal');
       }
       if (!opts?.auto && this.isBusy(sessionId)) {
         this.deferManualResumeUntilIdle(sessionId, lookupBoundary, state);
@@ -1135,7 +1151,8 @@ export class GoalController {
    * resume-on-open(#review):重启后未活会话的 active 目标是 **dormant** —— resumeActiveGoals
    * 不会硬 spawn,留着 status=active 但无 listener/timer。用户**打开该会话**时(renderer
    * useGoalStatus 拉状态)调用此方法把它接着续上:active ∧ 当前未挂 listener(dormant)→
-   * ensureSession 活化 + 挂 listener + 空闲则续一轮。否则(已在管 / 非 active / 活化失败)no-op。
+   * ensureSession 活化 + 挂 listener + 空闲则续一轮。已在管 / 非 active 时 no-op；
+   * 活化失败则转 blocked 并给出可见原因，不能继续显示成正在推进。
    * 这样重开会话能让 active 目标自己跑下去,而不是卡死等用户重发 /goal。
    */
   async resumeOnOpen(sessionId: string): Promise<void> {
@@ -1172,11 +1189,16 @@ export class GoalController {
       }
     } finally {
       releaseAgentSwitchLock();
-      if (!session && this.turns.get(sessionId) === lifecycleBoundary) {
-        this.turns.delete(sessionId);
-      }
     }
-    if (!session) return; // 活化失败(如 device-link 远程不可用)→ 留 dormant,下次打开再试
+    if (!session) {
+      await this.blockDispatchFailure(
+        sessionId,
+        lifecycleBoundary,
+        'turn dispatch failed: unable to restore the agent session',
+        () => this.turns.get(sessionId) === lifecycleBoundary,
+      );
+      return;
+    }
     if (this.turns.get(sessionId) !== lifecycleBoundary) return;
     this.emit(state);
     if (!this.isBusy(sessionId)) {
@@ -1364,6 +1386,9 @@ export class GoalController {
 
   private isBusy(sessionId: string): boolean {
     if (this.firing.has(sessionId)) return true;
+    // PI may acknowledge prompt acceptance before agent_start flips the
+    // provider running flag. Goal ownership bridges that acceptance gap.
+    if (this.goalTurnsInFlight.has(sessionId)) return true;
     if (this.deps.isSessionInTurn(sessionId)) return true;
     const session = this.deps.getSession(sessionId);
     return session ? session.isTurnRunning() : false;
@@ -1666,6 +1691,32 @@ export class GoalController {
     }
   }
 
+  private async blockDispatchFailure(
+    sessionId: string,
+    boundary: TurnAccumulator,
+    lastReason: string,
+    isCurrent: () => boolean,
+  ): Promise<void> {
+    try {
+      const blocked = await this.trackPersistence(
+        boundary,
+        this.deps.storage.update(sessionId, {
+          status: 'blocked',
+          lastReason,
+          updatedAt: this.now(),
+        }),
+      );
+      if (!isCurrent()) return;
+      if (blocked) this.emit(blocked);
+    } catch (persistError) {
+      this.deps.logger.error('[goal] failed to persist dispatch failure', {
+        sessionId,
+        error: String(persistError),
+      });
+    }
+    if (isCurrent()) this.stopSession(sessionId);
+  }
+
   private scheduleContinuation(sessionId: string): void {
     const existing = this.timers.get(sessionId);
     if (existing) clearTimeout(existing);
@@ -1931,7 +1982,12 @@ export class GoalController {
           sessionId,
           kind,
         });
-        if (isCurrentLifecycle()) this.stopSession(sessionId);
+        await this.blockDispatchFailure(
+          sessionId,
+          lifecycleBoundary,
+          'turn dispatch failed: unable to restore the agent session',
+          isCurrentLifecycle,
+        );
         return;
       }
       // deferred switch 可能刚把 live session 换成目标引擎的新对象;本会话若有 goal
@@ -2004,6 +2060,7 @@ export class GoalController {
         if (!isCurrentDispatch()) return;
         this.goalTurnsInFlight.delete(sessionId);
         this.deps.logger.warn('[goal] send not accepted', { sessionId, kind, reason: result.reason });
+        this.scheduleContinuation(sessionId);
       } else {
         if (!isCurrentDispatch()) {
           baselineStarted = false;
@@ -2018,11 +2075,28 @@ export class GoalController {
         this.deps.onUndispatchedUserTurn?.(sessionId);
         baselineStarted = false;
       }
-      if (dispatchBoundary ? isCurrentDispatch() : isCurrentLifecycle()) {
+      const failureBoundary = dispatchBoundary ?? lifecycleBoundary;
+      const isCurrentFailure = (): boolean =>
+        dispatchBoundary ? isCurrentDispatch() : isCurrentLifecycle();
+      if (isCurrentFailure()) {
         this.goalTurnsInFlight.delete(sessionId);
       }
-      // SESSION_RUNNING:会话已有 turn 在跑(用户抢发等);该 turn 的 done 会再触发裁决。
       this.deps.logger.warn('[goal] fireTurn send failed', { sessionId, kind, error: String(e) });
+      if (!isCurrentFailure()) return;
+
+      if ((e as { code?: unknown } | null)?.code === 'SESSION_RUNNING') {
+        // dispatch 前的窄 race；现有 turn 的终态会暂停 Goal，空闲检查则负责稍后重试。
+        this.scheduleContinuation(sessionId);
+        return;
+      }
+
+      const errorMessage = e instanceof Error ? e.message : String(e);
+      await this.blockDispatchFailure(
+        sessionId,
+        failureBoundary,
+        `turn dispatch failed: ${errorMessage}`,
+        isCurrentFailure,
+      );
     } finally {
       releaseAgentSwitchLock();
       if (this.goalDispatchAbortControllers.get(sessionId)?.owner === firingOwner) {

--- a/apps/desktop/src/main/goal-host/sessionRestore.ts
+++ b/apps/desktop/src/main/goal-host/sessionRestore.ts
@@ -39,7 +39,10 @@ export async function restoreSessionForGoal(
   deps: RestoreGoalSessionDeps,
 ): Promise<SessionLike | undefined> {
   const live = deps.maker.getSession(sessionId);
-  if (live) return live;
+  // A failed close leaves the Session in Maker's live map with status=error.
+  // Do not hand that poisoned object back to Goal: Maker.createSession owns the
+  // retry-close-then-rebuild boundary for this exact state.
+  if (live && live.getStatus?.() !== 'error') return live;
 
   const meta = await deps.maker.getSessionMeta(sessionId).catch(() => null);
   if (!meta) {

--- a/apps/desktop/src/main/goal-host/types.ts
+++ b/apps/desktop/src/main/goal-host/types.ts
@@ -10,6 +10,7 @@ import type {
   AgentKind,
   SendOrigin,
   SessionSendResult,
+  SessionStatus,
   UserMessage,
 } from '@cindy/maker-core';
 
@@ -150,6 +151,7 @@ export interface SessionLike {
     },
   ): Promise<SessionSendResult>;
   onEvent(listener: (event: AgentEvent) => void): () => void;
+  getStatus?(): SessionStatus;
   isTurnRunning(): boolean;
   abort(): Promise<void>;
 }

--- a/apps/desktop/src/main/maker-host/__tests__/send-outcome.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/send-outcome.test.ts
@@ -219,6 +219,27 @@ describe('desktop send outcome helper', () => {
     });
   });
 
+  it('preserves provider rejection through Desktop compatibility outcomes', async () => {
+    const outcome = toDesktopSessionDispatchOutcome(
+      { accepted: false, reason: 'provider-rejected-before-dispatch' },
+      { source: 'goal', context: 'GOAL/session-4/continuation' },
+    );
+
+    expect(outcome).toEqual({
+      kind: 'session-dispatch',
+      source: 'goal',
+      dispatched: false,
+      reason: 'provider-rejected-before-dispatch',
+      context: 'GOAL/session-4/continuation',
+      message: 'Provider rejected the Session send before dispatch: GOAL/session-4/continuation',
+    });
+    expect(toCompatibleMakerSendResult(outcome)).toEqual({
+      accepted: false,
+      reason: 'provider-rejected-before-dispatch',
+      outcome,
+    });
+  });
+
   it('keeps renderer compatibility payloads while carrying the typed outcome', async () => {
     const hostPayload = toCompatibleMakerSendResult(
       createHostSendFailure('WORKDIR_MISSING', 'cwd missing'),

--- a/apps/desktop/src/main/maker-host/send-outcome.ts
+++ b/apps/desktop/src/main/maker-host/send-outcome.ts
@@ -57,7 +57,11 @@ export type DesktopSendOutcome = HostSendOutcome | DesktopSessionDispatchOutcome
 export type DesktopMakerSendResult =
   | { accepted: true; outcome: DesktopSessionDispatchSuccess }
   | { accepted: false; reason: HostSendFailureCode; outcome: HostSendOutcome }
-  | { accepted: false; reason: 'cancelled-before-dispatch'; outcome: DesktopSessionDispatchFailure };
+  | {
+      accepted: false;
+      reason: DesktopSessionDispatchFailure['reason'];
+      outcome: DesktopSessionDispatchFailure;
+    };
 
 export interface SendOutcomeLogContext {
   owner: string;

--- a/apps/desktop/src/main/maker-ipc/__tests__/goalHandlers.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/goalHandlers.test.ts
@@ -2,6 +2,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   handlers: new Map<string, (...args: unknown[]) => unknown>(),
+  controllerAvailable: true,
+  setGoal: vi.fn(),
+  getStatus: vi.fn(),
+  resumeOnOpen: vi.fn(),
+  resumeGoal: vi.fn(),
   updateGoal: vi.fn(),
 }));
 
@@ -15,7 +20,15 @@ vi.mock('electron', () => ({
 }));
 
 vi.mock('../../goal-host/index.js', () => ({
-  getGoalController: () => ({ updateGoal: mocks.updateGoal }),
+  getGoalController: () => mocks.controllerAvailable
+    ? {
+        setGoal: mocks.setGoal,
+        getStatus: mocks.getStatus,
+        resumeOnOpen: mocks.resumeOnOpen,
+        resumeGoal: mocks.resumeGoal,
+        updateGoal: mocks.updateGoal,
+      }
+    : null,
 }));
 
 vi.mock('../../logger.js', () => ({
@@ -27,21 +40,125 @@ vi.mock('../../device-link/broadcast-tap.js', () => ({
   tapWindowBroadcast: vi.fn(),
 }));
 
-import { GoalUpdateSupersededError } from '../../goal-host/controller.js';
+import {
+  GoalSessionRestoreError,
+  GoalUpdateSupersededError,
+} from '../../goal-host/controller.js';
 import { MAKER_INVOKE } from '../channels.js';
 import { registerGoalHandlers } from '../goal.js';
 
-function updateHandler(): (...args: unknown[]) => unknown {
-  const handler = mocks.handlers.get(MAKER_INVOKE.GOAL_UPDATE);
-  if (!handler) throw new Error('goal update handler was not registered');
+function handlerFor(channel: string): (...args: unknown[]) => unknown {
+  const handler = mocks.handlers.get(channel);
+  if (!handler) throw new Error(`goal handler was not registered: ${channel}`);
   return handler;
+}
+
+function updateHandler(): (...args: unknown[]) => unknown {
+  return handlerFor(MAKER_INVOKE.GOAL_UPDATE);
 }
 
 describe('goal update IPC errors', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.handlers.clear();
+    mocks.controllerAvailable = true;
     registerGoalHandlers();
+  });
+
+  it('returns INTERNAL when the Goal controller is not ready', async () => {
+    mocks.controllerAvailable = false;
+
+    const result = handlerFor(MAKER_INVOKE.GOAL_GET_STATUS)({}, 's1');
+
+    await expect(result).rejects.toMatchObject({
+      code: 'INTERNAL',
+      message: expect.stringContaining('goal controller not started'),
+    });
+  });
+
+  it('maps the initial Goal status read failure to INTERNAL without leaking storage details', async () => {
+    mocks.getStatus.mockRejectedValueOnce(new Error('sqlite path /private/user-data failed'));
+
+    const result = handlerFor(MAKER_INVOKE.GOAL_GET_STATUS)({}, 's1');
+
+    await expect(result).rejects.toMatchObject({
+      code: 'INTERNAL',
+      message: expect.stringContaining('failed to read goal status'),
+    });
+  });
+
+  it('maps the post-recovery Goal status read failure to INTERNAL', async () => {
+    mocks.getStatus
+      .mockResolvedValueOnce({ sessionId: 's1', status: 'active' })
+      .mockRejectedValueOnce(new Error('second read failed'));
+    mocks.resumeOnOpen.mockResolvedValueOnce(undefined);
+
+    const result = handlerFor(MAKER_INVOKE.GOAL_GET_STATUS)({}, 's1');
+
+    await expect(result).rejects.toMatchObject({
+      code: 'INTERNAL',
+      message: expect.stringContaining('failed to read goal status'),
+    });
+    expect(mocks.resumeOnOpen).toHaveBeenCalledWith('s1');
+  });
+
+  it('returns the post-recovery blocked state instead of a stale active snapshot', async () => {
+    const active = { sessionId: 's1', status: 'active' };
+    const blocked = {
+      sessionId: 's1',
+      status: 'blocked',
+      lastReason: 'turn dispatch failed: unable to restore the agent session',
+    };
+    mocks.getStatus
+      .mockResolvedValueOnce(active)
+      .mockResolvedValueOnce(blocked);
+    mocks.resumeOnOpen.mockResolvedValueOnce(undefined);
+
+    const result = await handlerFor(MAKER_INVOKE.GOAL_GET_STATUS)({}, 's1');
+
+    expect(result).toEqual(blocked);
+    expect(mocks.resumeOnOpen).toHaveBeenCalledWith('s1');
+    expect(mocks.getStatus).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns a structured error when dormant recovery cannot persist blocked state', async () => {
+    mocks.getStatus.mockResolvedValueOnce({ sessionId: 's1', status: 'active' });
+    mocks.resumeOnOpen.mockRejectedValueOnce(
+      new GoalSessionRestoreError(new Error('goal storage unavailable')),
+    );
+
+    const result = handlerFor(MAKER_INVOKE.GOAL_GET_STATUS)({}, 's1');
+
+    await expect(result).rejects.toMatchObject({
+      code: 'PRECONDITION_FAILED',
+      message: expect.stringContaining('unable to restore the agent session'),
+    });
+    expect(mocks.getStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it('maps GOAL_SET session restore failures to PRECONDITION_FAILED', async () => {
+    mocks.setGoal.mockRejectedValueOnce(new GoalSessionRestoreError());
+
+    const result = handlerFor(MAKER_INVOKE.GOAL_SET)(
+      {},
+      { sessionId: 's1', objective: 'recover the goal' },
+    );
+
+    await expect(result).rejects.toMatchObject({
+      code: 'PRECONDITION_FAILED',
+      message: expect.stringContaining('unable to restore the agent session'),
+    });
+  });
+
+  it('maps GOAL_RESUME session restore failures to PRECONDITION_FAILED', async () => {
+    mocks.resumeGoal.mockRejectedValueOnce(new GoalSessionRestoreError());
+
+    const result = handlerFor(MAKER_INVOKE.GOAL_RESUME)({}, 's1');
+
+    await expect(result).rejects.toMatchObject({
+      code: 'PRECONDITION_FAILED',
+      message: expect.stringContaining('unable to restore the agent session'),
+    });
   });
 
   it('maps a superseded lifecycle update to PRECONDITION_FAILED', async () => {

--- a/apps/desktop/src/main/maker-ipc/__tests__/goalHandlers.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/goalHandlers.test.ts
@@ -99,7 +99,7 @@ describe('goal update IPC errors', () => {
       code: 'INTERNAL',
       message: expect.stringContaining('failed to read goal status'),
     });
-    expect(mocks.resumeOnOpen).toHaveBeenCalledWith('s1');
+    expect(mocks.resumeOnOpen).toHaveBeenCalledWith('s1', { waitForDispatch: false });
   });
 
   it('returns the post-recovery blocked state instead of a stale active snapshot', async () => {
@@ -117,7 +117,7 @@ describe('goal update IPC errors', () => {
     const result = await handlerFor(MAKER_INVOKE.GOAL_GET_STATUS)({}, 's1');
 
     expect(result).toEqual(blocked);
-    expect(mocks.resumeOnOpen).toHaveBeenCalledWith('s1');
+    expect(mocks.resumeOnOpen).toHaveBeenCalledWith('s1', { waitForDispatch: false });
     expect(mocks.getStatus).toHaveBeenCalledTimes(2);
   });
 
@@ -133,6 +133,47 @@ describe('goal update IPC errors', () => {
       code: 'PRECONDITION_FAILED',
       message: expect.stringContaining('unable to restore the agent session'),
     });
+    expect(mocks.getStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns active status without waiting for detached prompt acceptance', async () => {
+    const active = { sessionId: 's1', status: 'active' };
+    const neverAccepted = new Promise<void>(() => {});
+    mocks.getStatus
+      .mockResolvedValueOnce(active)
+      .mockResolvedValueOnce(active);
+    mocks.resumeOnOpen.mockImplementationOnce(
+      async (_sessionId: string, opts?: { waitForDispatch?: boolean }) => {
+        if (opts?.waitForDispatch !== false) await neverAccepted;
+      },
+    );
+
+    const result = await handlerFor(MAKER_INVOKE.GOAL_GET_STATUS)({}, 's1');
+
+    expect(result).toEqual(active);
+    expect(mocks.resumeOnOpen).toHaveBeenCalledWith('s1', { waitForDispatch: false });
+    expect(mocks.getStatus).toHaveBeenCalledTimes(2);
+  });
+
+  it('maps an internal dormant recovery read failure to sanitized INTERNAL', async () => {
+    mocks.getStatus.mockResolvedValueOnce({ sessionId: 's1', status: 'active' });
+    mocks.resumeOnOpen.mockRejectedValueOnce(
+      new Error('sqlite path /private/user-data/goal.db failed'),
+    );
+
+    const result = handlerFor(MAKER_INVOKE.GOAL_GET_STATUS)({}, 's1');
+
+    let error: unknown;
+    try {
+      await result;
+    } catch (caught) {
+      error = caught;
+    }
+    expect(error).toMatchObject({
+      code: 'INTERNAL',
+      message: expect.stringContaining('failed to restore goal status'),
+    });
+    expect((error as Error).message).not.toContain('/private/user-data');
     expect(mocks.getStatus).toHaveBeenCalledTimes(1);
   });
 

--- a/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
+++ b/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
@@ -31,7 +31,11 @@ import { createMessage as createDbMessage } from '../localDb/ipc/messages.js';
 import { touchUserSendInDb } from '../localDb/ipc/sessions.js';
 import type { InterruptedTurnErrorSignals } from './interruptedTurnAutoResume.js';
 import type { SuppressedTurnErrorOwner } from './autoResumeBookkeeping.js';
-import type { HostSendFailureCode, HostSendOutcome } from '../maker-host/send-outcome.js';
+import type {
+  DesktopSessionDispatchFailure,
+  HostSendFailureCode,
+  HostSendOutcome,
+} from '../maker-host/send-outcome.js';
 import type {
   AgentInputCreateOpts,
   AgentInputDelivery,
@@ -235,7 +239,7 @@ export type AgentInputSendResult =
       kind: 'session-dispatch';
       source: string;
       dispatched: false;
-      reason: 'cancelled-before-dispatch';
+      reason: DesktopSessionDispatchFailure['reason'];
       message: string;
       context: string;
     };

--- a/apps/desktop/src/main/maker-ipc/goal.ts
+++ b/apps/desktop/src/main/maker-ipc/goal.ts
@@ -18,6 +18,7 @@ import { createLogger } from '../logger.js';
 import { throwIpcError, requireString, requireObject } from '../utils/ipcValidate.js';
 import {
   GoalControllerInputError,
+  GoalSessionRestoreError,
   GoalUpdateSupersededError,
 } from '../goal-host/controller.js';
 import { getGoalController } from '../goal-host/index.js';
@@ -28,6 +29,30 @@ import { MAKER_INVOKE, MAKER_PUSH } from './channels.js';
 const log = createLogger('maker-ipc:goal');
 
 type GoalLimitPatchKey = 'maxTurns' | 'budgetTokens' | 'noProgressLimit';
+
+function throwGoalControllerIpcError(error: unknown): never {
+  if (error instanceof GoalControllerInputError) {
+    throwIpcError('INVALID_PARAMS', error.message);
+  }
+  if (
+    error instanceof GoalSessionRestoreError ||
+    error instanceof GoalUpdateSupersededError
+  ) {
+    throwIpcError('PRECONDITION_FAILED', error.message);
+  }
+  throw error;
+}
+
+async function readGoalStatusForIpc(
+  controller: NonNullable<ReturnType<typeof getGoalController>>,
+  sessionId: string,
+) {
+  try {
+    return await controller.getStatus(sessionId);
+  } catch {
+    throwIpcError('INTERNAL', 'failed to read goal status');
+  }
+}
 
 function readOptionalLimit(value: unknown, name: GoalLimitPatchKey, patch: GoalUpdatePatch): void {
   if (value === undefined) return;
@@ -82,10 +107,7 @@ export function registerGoalHandlers(): void {
     try {
       await controller.setGoal({ sessionId, objective, ...(limits ? { limits } : {}) });
     } catch (err) {
-      if (err instanceof GoalControllerInputError) {
-        throwIpcError('INVALID_PARAMS', err.message);
-      }
-      throw err;
+      throwGoalControllerIpcError(err);
     }
     return { ok: true };
   });
@@ -101,12 +123,18 @@ export function registerGoalHandlers(): void {
   ipcMain.handle(MAKER_INVOKE.GOAL_GET_STATUS, async (_e, sessionId: unknown) => {
     const id = requireString(sessionId, 'sessionId');
     const controller = getGoalController();
-    const status = (await controller?.getStatus(id)) ?? null;
-    // resume-on-open:打开会话时若有 dormant 的 active 目标(重启后未活化、无 listener),
-    // 顺带把它续上(controller.resumeOnOpen 内部自守卫:已在管 / 非 active / 活化失败均 no-op)。
-    // fire-and-forget,不阻塞 status 返回;只针对当前打开的这个会话,不会批量 spawn。
+    if (!controller) throwIpcError('INTERNAL', 'goal controller not started');
+    let status = await readGoalStatusForIpc(controller, id);
+    // Dormant recovery may synchronously converge an apparently active Goal to
+    // blocked. Wait and re-read so this invoke response cannot overwrite the
+    // newer status push with its stale pre-recovery active snapshot.
     if (status?.status === 'active') {
-      void controller?.resumeOnOpen(id).catch(() => {});
+      try {
+        await controller.resumeOnOpen(id);
+      } catch (error) {
+        throwGoalControllerIpcError(error);
+      }
+      status = await readGoalStatusForIpc(controller, id);
     }
     return status;
   });
@@ -122,7 +150,11 @@ export function registerGoalHandlers(): void {
   // 保留计数继续;终态/active 是 no-op。
   ipcMain.handle(MAKER_INVOKE.GOAL_RESUME, async (_e, sessionId: unknown) => {
     const id = requireString(sessionId, 'sessionId');
-    await getGoalController()?.resumeGoal(id);
+    try {
+      await getGoalController()?.resumeGoal(id);
+    } catch (error) {
+      throwGoalControllerIpcError(error);
+    }
     return { ok: true };
   });
 
@@ -144,13 +176,7 @@ export function registerGoalHandlers(): void {
       if (!updated) throwIpcError('GOAL_NOT_FOUND', 'goal not found');
       return { ok: true };
     } catch (err) {
-      if (err instanceof GoalControllerInputError) {
-        throwIpcError('INVALID_PARAMS', err.message);
-      }
-      if (err instanceof GoalUpdateSupersededError) {
-        throwIpcError('PRECONDITION_FAILED', err.message);
-      }
-      throw err;
+      throwGoalControllerIpcError(err);
     }
   });
 

--- a/apps/desktop/src/main/maker-ipc/goal.ts
+++ b/apps/desktop/src/main/maker-ipc/goal.ts
@@ -126,13 +126,22 @@ export function registerGoalHandlers(): void {
     if (!controller) throwIpcError('INTERNAL', 'goal controller not started');
     let status = await readGoalStatusForIpc(controller, id);
     // Dormant recovery may synchronously converge an apparently active Goal to
-    // blocked. Wait and re-read so this invoke response cannot overwrite the
-    // newer status push with its stale pre-recovery active snapshot.
+    // blocked. Wait for storage/session recovery and re-read so this invoke
+    // response cannot overwrite the newer status push with a stale active
+    // snapshot. Actual turn dispatch stays detached: PI prompt acceptance may
+    // legitimately wait through long compaction and must not hold a read query.
     if (status?.status === 'active') {
       try {
-        await controller.resumeOnOpen(id);
+        await controller.resumeOnOpen(id, { waitForDispatch: false });
       } catch (error) {
-        throwGoalControllerIpcError(error);
+        if (
+          error instanceof GoalControllerInputError ||
+          error instanceof GoalSessionRestoreError ||
+          error instanceof GoalUpdateSupersededError
+        ) {
+          throwGoalControllerIpcError(error);
+        }
+        throwIpcError('INTERNAL', 'failed to restore goal status');
       }
       status = await readGoalStatusForIpc(controller, id);
     }

--- a/packages/maker-core/src/agents/base-agent.ts
+++ b/packages/maker-core/src/agents/base-agent.ts
@@ -1187,6 +1187,16 @@ export class TurnDispatchUnconfirmedError extends Error {
   }
 }
 
+/** The provider explicitly rejected the turn before accepting any work. */
+export class TurnDispatchRejectedError extends Error {
+  readonly code = 'TURN_DISPATCH_REJECTED';
+
+  constructor(msg: string, options?: ErrorOptions) {
+    super(msg, options);
+    this.name = 'TurnDispatchRejectedError';
+  }
+}
+
 export interface StartSessionOptions {
   /**
    * Business 层 session id (host 调用 maker.createSession 时传的 opts.id, 由

--- a/packages/maker-core/src/agents/base-agent.ts
+++ b/packages/maker-core/src/agents/base-agent.ts
@@ -1171,6 +1171,22 @@ export class AgentNotAuthenticatedError extends Error {
   }
 }
 
+/**
+ * The adapter dispatched a turn request but could not determine whether the
+ * provider accepted it. The Session wrapper must fence the ambiguous handle
+ * before surfacing this error. Fencing prevents further execution but does not
+ * roll back completed side effects, so orchestrators must not blindly replay
+ * the same turn.
+ */
+export class TurnDispatchUnconfirmedError extends Error {
+  readonly code = 'TURN_DISPATCH_UNCONFIRMED';
+
+  constructor(msg: string, options?: ErrorOptions) {
+    super(msg, options);
+    this.name = 'TurnDispatchUnconfirmedError';
+  }
+}
+
 export interface StartSessionOptions {
   /**
    * Business 层 session id (host 调用 maker.createSession 时传的 opts.id, 由

--- a/packages/maker-core/src/agents/pi/__tests__/pi-auto-review-dispatch.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/pi-auto-review-dispatch.test.ts
@@ -74,7 +74,7 @@ vi.mock('../rpc-client.js', () => ({
     }
     async request(
       cmd: Record<string, unknown> & { type: string },
-    ): Promise<{ success: boolean; data?: unknown }> {
+    ): Promise<{ success: boolean; command?: string; data?: unknown }> {
       captured.requests.push(cmd);
       if (cmd.type === 'set_model' && captured.holdSetModel) {
         await captured.holdSetModel;
@@ -87,7 +87,7 @@ vi.mock('../rpc-client.js', () => ({
         return { success: false };
       }
       if (cmd.type === 'prompt' && captured.failPrompt) {
-        return { success: false };
+        return { command: 'prompt', success: false };
       }
       if (cmd.type === 'get_state') {
         return { success: true, data: { sessionFile: '/mock/session.jsonl', model: { contextWindow: 200000 } } };

--- a/packages/maker-core/src/agents/pi/__tests__/pi-provider-routing.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/pi-provider-routing.test.ts
@@ -1568,12 +1568,11 @@ describe('Pi provider-aware model routing', () => {
       model: 'local-model',
     });
 
-    const error = await handle.send({ type: 'user', content: 'continue the goal' })
-      .then(() => null, (reason: unknown) => reason);
-    expect(error).toEqual(expect.objectContaining({
-      message: 'pi prompt rejected: prompt rejected before acceptance',
-    }));
-    expect((error as { code?: unknown }).code).toBeUndefined();
+    await expect(handle.send({ type: 'user', content: 'continue the goal' })).rejects.toMatchObject({
+      name: 'TurnDispatchRejectedError',
+      code: 'TURN_DISPATCH_REJECTED',
+      message: 'pi prompt rejected before acceptance: prompt rejected before acceptance',
+    });
     await handle.close();
   });
 

--- a/packages/maker-core/src/agents/pi/__tests__/pi-provider-routing.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/pi-provider-routing.test.ts
@@ -1525,6 +1525,58 @@ describe('Pi provider-aware model routing', () => {
     await handle.close();
   });
 
+  it.each([
+    ['transport close before response', new Error('pi process exited (code=null, signal=null)')],
+    ['unknown write result', new Error('write EPIPE')],
+    ['malformed response envelope', new Error('pi rpc: response for prompt missing boolean success')],
+  ])('marks %s after prompt request starts as an unconfirmed dispatch', async (_label, failure) => {
+    captured.requestHandler = async (command) => {
+      if (command.type === 'get_state') {
+        return { success: true, data: { sessionFile: '/mock/s.jsonl', model: { contextWindow: 200_000 } } };
+      }
+      if (command.type === 'prompt') throw failure;
+      return { success: true, data: {} };
+    };
+    const agent = new PiAgent(byomDeps(async () => ({ providers: [], env: {} })));
+    const handle = await agent.startSession({
+      sessionId: `prompt-unknown-${String(_label).replaceAll(' ', '-')}`,
+      workingDir: cwd,
+      model: 'local-model',
+    });
+
+    await expect(handle.send({ type: 'user', content: 'continue the goal' })).rejects.toMatchObject({
+      name: 'TurnDispatchUnconfirmedError',
+      code: 'TURN_DISPATCH_UNCONFIRMED',
+      cause: failure,
+    });
+    expect(captured.requests.filter((request) => request.type === 'prompt')).toHaveLength(1);
+    await handle.close();
+  });
+
+  it('keeps an explicit prompt rejection as a confirmed undispatched error', async () => {
+    captured.requestHandler = async (command) => {
+      if (command.type === 'get_state') {
+        return { success: true, data: { sessionFile: '/mock/s.jsonl', model: { contextWindow: 200_000 } } };
+      }
+      if (command.type === 'prompt') return { success: false, error: 'prompt rejected before acceptance' };
+      return { success: true, data: {} };
+    };
+    const agent = new PiAgent(byomDeps(async () => ({ providers: [], env: {} })));
+    const handle = await agent.startSession({
+      sessionId: 'prompt-explicit-rejection',
+      workingDir: cwd,
+      model: 'local-model',
+    });
+
+    const error = await handle.send({ type: 'user', content: 'continue the goal' })
+      .then(() => null, (reason: unknown) => reason);
+    expect(error).toEqual(expect.objectContaining({
+      message: 'pi prompt rejected: prompt rejected before acceptance',
+    }));
+    expect((error as { code?: unknown }).code).toBeUndefined();
+    await handle.close();
+  });
+
   it('keeps a leading /skill: command at the prompt start even when Extra Dirs are configured', async () => {
     const agent = new PiAgent(byomDeps(async () => ({ providers: [], env: {} })));
     const handle = await agent.startSession({

--- a/packages/maker-core/src/agents/pi/__tests__/pi-provider-routing.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/pi-provider-routing.test.ts
@@ -7,6 +7,10 @@ const captured = vi.hoisted(() => ({
   args: [] as string[],
   env: {} as Record<string, string | undefined>,
   requests: [] as Array<Record<string, unknown>>,
+  requestOptions: [] as Array<{
+    timeoutMs?: number;
+    refreshTimeoutOnEvent?: (event: { type: string }) => boolean;
+  } | undefined>,
   closes: 0,
   requestHandler: undefined as undefined | ((command: Record<string, unknown>) => Promise<{ success: boolean; data?: unknown; error?: string }>),
 }));
@@ -34,23 +38,44 @@ vi.mock('../transport.js', () => ({
   attachJsonlReader: () => {},
 }));
 
-vi.mock('../rpc-client.js', () => ({
-  PiRpcProcess: class {
-    isClosed = false;
-    async request(command: Record<string, unknown>) {
-      captured.requests.push(command);
-      if (captured.requestHandler) return captured.requestHandler(command);
-      if (command.type === 'get_state') {
-        return { success: true, data: { sessionFile: '/mock/s.jsonl', model: { contextWindow: 200_000 } } };
-      }
-      return { success: true, data: {} };
+vi.mock('../rpc-client.js', () => {
+  class PiRpcRequestTimeoutError extends Error {
+    readonly code = 'PI_RPC_TIMEOUT';
+    constructor(
+      readonly commandType: string,
+      readonly timeoutMs: number,
+    ) {
+      super(`pi rpc timeout after ${timeoutMs}ms: ${commandType}`);
+      this.name = 'PiRpcRequestTimeoutError';
     }
-    send(): void {}
-    async close(): Promise<void> { this.isClosed = true; captured.closes += 1; }
-  },
-}));
+  }
+  return {
+    PiRpcRequestTimeoutError,
+    PiRpcProcess: class {
+      isClosed = false;
+      async request(
+        command: Record<string, unknown>,
+        options?: {
+          timeoutMs?: number;
+          refreshTimeoutOnEvent?: (event: { type: string }) => boolean;
+        },
+      ) {
+        captured.requests.push(command);
+        captured.requestOptions.push(options);
+        if (captured.requestHandler) return captured.requestHandler(command);
+        if (command.type === 'get_state') {
+          return { success: true, data: { sessionFile: '/mock/s.jsonl', model: { contextWindow: 200_000 } } };
+        }
+        return { success: true, data: {} };
+      }
+      send(): void {}
+      async close(): Promise<void> { this.isClosed = true; captured.closes += 1; }
+    },
+  };
+});
 
 import { PiAgent } from '../index.js';
+import { PiRpcRequestTimeoutError } from '../rpc-client.js';
 import type { AgentDeps } from '../../base-agent.js';
 import type { ModelDescriptor } from '../../../types/capabilities.js';
 import type { Logger } from '../../../interfaces/logger.js';
@@ -78,6 +103,7 @@ describe('Pi provider-aware model routing', () => {
   beforeEach(() => {
     captured.args = [];
     captured.requests = [];
+    captured.requestOptions = [];
     captured.closes = 0;
     captured.requestHandler = undefined;
     agentHome = mkdtempSync(path.join(tmpdir(), 'pi-provider-home-'));
@@ -1452,6 +1478,50 @@ describe('Pi provider-aware model routing', () => {
     ).rejects.toThrow(/failed to read image attachment/);
     // 未发送任何 prompt(失败在 dispatch 前)
     expect(captured.requests).toHaveLength(0);
+    await handle.close();
+  });
+
+  it('waits through Pi preflight compaction when accepting a prompt', async () => {
+    const agent = new PiAgent(byomDeps(async () => ({ providers: [], env: {} })));
+    const handle = await agent.startSession({
+      sessionId: 'prompt-acceptance-budget',
+      workingDir: cwd,
+      model: 'local-model',
+    });
+
+    await handle.send({ type: 'user', content: 'continue the goal' });
+
+    const promptIndex = captured.requests.findIndex((request) => request.type === 'prompt');
+    expect(promptIndex).toBeGreaterThanOrEqual(0);
+    expect(captured.requestOptions[promptIndex]).toMatchObject({ timeoutMs: 600_000 });
+    const refresh = captured.requestOptions[promptIndex]?.refreshTimeoutOnEvent;
+    expect(refresh?.({ type: 'compaction_start' })).toBe(true);
+    expect(refresh?.({ type: 'summarization_retry_scheduled' })).toBe(true);
+    expect(refresh?.({ type: 'agent_start' })).toBe(false);
+    await handle.close();
+  });
+
+  it('marks a true prompt acceptance timeout as an unconfirmed dispatch', async () => {
+    captured.requestHandler = async (command) => {
+      if (command.type === 'get_state') {
+        return { success: true, data: { sessionFile: '/mock/s.jsonl', model: { contextWindow: 200_000 } } };
+      }
+      if (command.type === 'prompt') {
+        throw new PiRpcRequestTimeoutError('prompt', 600_000);
+      }
+      return { success: true, data: {} };
+    };
+    const agent = new PiAgent(byomDeps(async () => ({ providers: [], env: {} })));
+    const handle = await agent.startSession({
+      sessionId: 'prompt-acceptance-timeout',
+      workingDir: cwd,
+      model: 'local-model',
+    });
+
+    await expect(handle.send({ type: 'user', content: 'continue the goal' })).rejects.toMatchObject({
+      name: 'TurnDispatchUnconfirmedError',
+      code: 'TURN_DISPATCH_UNCONFIRMED',
+    });
     await handle.close();
   });
 

--- a/packages/maker-core/src/agents/pi/__tests__/pi-provider-routing.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/pi-provider-routing.test.ts
@@ -12,7 +12,12 @@ const captured = vi.hoisted(() => ({
     refreshTimeoutOnEvent?: (event: { type: string }) => boolean;
   } | undefined>,
   closes: 0,
-  requestHandler: undefined as undefined | ((command: Record<string, unknown>) => Promise<{ success: boolean; data?: unknown; error?: string }>),
+  requestHandler: undefined as undefined | ((command: Record<string, unknown>) => Promise<{
+    success: boolean;
+    command?: unknown;
+    data?: unknown;
+    error?: string;
+  }>),
 }));
 
 vi.mock('../transport.js', () => ({
@@ -1558,7 +1563,13 @@ describe('Pi provider-aware model routing', () => {
       if (command.type === 'get_state') {
         return { success: true, data: { sessionFile: '/mock/s.jsonl', model: { contextWindow: 200_000 } } };
       }
-      if (command.type === 'prompt') return { success: false, error: 'prompt rejected before acceptance' };
+      if (command.type === 'prompt') {
+        return {
+          command: 'prompt',
+          success: false,
+          error: 'prompt rejected before acceptance',
+        };
+      }
       return { success: true, data: {} };
     };
     const agent = new PiAgent(byomDeps(async () => ({ providers: [], env: {} })));
@@ -1573,6 +1584,48 @@ describe('Pi provider-aware model routing', () => {
       code: 'TURN_DISPATCH_REJECTED',
       message: 'pi prompt rejected before acceptance: prompt rejected before acceptance',
     });
+    await handle.close();
+  });
+
+  it.each([
+    ['missing command', { success: false, error: 'prompt rejected before acceptance' }],
+    [
+      'non-string command',
+      { command: { type: 'prompt' }, success: false, error: 'prompt rejected before acceptance' },
+    ],
+    [
+      'mismatched command',
+      { command: 'steer', success: false, error: 'prompt rejected before acceptance' },
+    ],
+  ])('treats a rejected prompt response with %s as an unconfirmed dispatch', async (
+    label,
+    rejectionResponse,
+  ) => {
+    captured.requestHandler = async (command) => {
+      if (command.type === 'get_state') {
+        return {
+          success: true,
+          data: { sessionFile: '/mock/s.jsonl', model: { contextWindow: 200_000 } },
+        };
+      }
+      if (command.type === 'prompt') return rejectionResponse;
+      return { success: true, data: {} };
+    };
+    const agent = new PiAgent(byomDeps(async () => ({ providers: [], env: {} })));
+    const handle = await agent.startSession({
+      sessionId: `prompt-rejection-${label.replaceAll(' ', '-')}`,
+      workingDir: cwd,
+      model: 'local-model',
+    });
+
+    await expect(handle.send({ type: 'user', content: 'continue the goal' })).rejects.toMatchObject({
+      name: 'TurnDispatchUnconfirmedError',
+      code: 'TURN_DISPATCH_UNCONFIRMED',
+      cause: expect.objectContaining({
+        message: 'pi prompt rejection response missing matching command',
+      }),
+    });
+    expect(captured.requests.filter((request) => request.type === 'prompt')).toHaveLength(1);
     await handle.close();
   });
 

--- a/packages/maker-core/src/agents/pi/__tests__/pi-startsession-cleanup.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/pi-startsession-cleanup.test.ts
@@ -12,7 +12,7 @@
  * resume 路径、启动 RPC 也不会即时拒),控制流本身才是被测对象。
  */
 
-import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -365,6 +365,32 @@ describe('PiAgent.startSession failure cleanup (mocked pi process)', () => {
     expect(clearIntervalSpy).toHaveBeenCalledOnce();
     expect(disposed).toBe(1); // close() 才注销
     expect(proxyDisposed).toBe(1);
+  });
+
+  it('keeps local runtime files until a close retry confirms process exit', async () => {
+    knobs.closeFailuresRemaining = 1;
+    const handle = await new PiAgent(buildDeps()).startSession(opts());
+    const env = knobs.spawnedEnvs[0]!;
+    const configHome = env.PI_CODING_AGENT_DIR!;
+    const permissionFile = env.CINDY_PI_PERMISSION_FILE!;
+    const subagentRuntimeFile = env.CINDY_PI_SUBAGENT_RUNTIME_FILE!;
+
+    expect(existsSync(configHome)).toBe(true);
+    expect(existsSync(permissionFile)).toBe(true);
+    expect(existsSync(subagentRuntimeFile)).toBe(true);
+
+    await expect(handle.close()).rejects.toThrow(/close unconfirmed/);
+    expect(existsSync(configHome)).toBe(true);
+    expect(existsSync(permissionFile)).toBe(true);
+    expect(existsSync(subagentRuntimeFile)).toBe(true);
+
+    await expect(handle.close()).resolves.toBeUndefined();
+    await vi.waitFor(() => {
+      expect(existsSync(configHome)).toBe(false);
+      expect(existsSync(permissionFile)).toBe(false);
+      expect(existsSync(subagentRuntimeFile)).toBe(false);
+    });
+    expect(knobs.closeCount).toBe(2);
   });
 
   it('always disables project trust and implicit extensions while explicitly restoring only Cindy extensions', async () => {

--- a/packages/maker-core/src/agents/pi/__tests__/pi-startsession-cleanup.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/pi-startsession-cleanup.test.ts
@@ -21,7 +21,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 const knobs = vi.hoisted(() => ({
   ctorThrows: false,
   getStateRejects: false,
+  getStateGate: null as Promise<void> | null,
   closeRejects: false,
+  closeFailuresRemaining: 0,
+  closeGate: null as Promise<void> | null,
   closeCount: 0,
   onExit: null as null | ((info: { code: number | null; signal: string | null }) => void),
   onEvent: null as null | ((event: unknown) => void),
@@ -69,6 +72,8 @@ vi.mock('../rpc-client.js', () => ({
     }
     async request(cmd: { type: string }): Promise<{ success: boolean; data?: unknown; error?: string }> {
       if (cmd.type === 'get_state') {
+        const gate = knobs.getStateGate;
+        if (gate) await gate;
         if (knobs.getStateRejects) throw new Error('get_state rejected (mock)');
         return { success: true, data: { sessionFile: '/mock/session.jsonl', model: { contextWindow: 200000 } } };
       }
@@ -78,6 +83,12 @@ vi.mock('../rpc-client.js', () => ({
     send(): void {}
     async close(): Promise<void> {
       knobs.closeCount++;
+      const gate = knobs.closeGate;
+      if (gate) await gate;
+      if (knobs.closeFailuresRemaining > 0) {
+        knobs.closeFailuresRemaining -= 1;
+        throw new Error('close unconfirmed (mock)');
+      }
       if (knobs.closeRejects) throw new Error('close unconfirmed (mock)');
       this.isClosed = true;
     }
@@ -106,7 +117,10 @@ describe('PiAgent.startSession failure cleanup (mocked pi process)', () => {
   beforeEach(() => {
     knobs.ctorThrows = false;
     knobs.getStateRejects = false;
+    knobs.getStateGate = null;
     knobs.closeRejects = false;
+    knobs.closeFailuresRemaining = 0;
+    knobs.closeGate = null;
     knobs.closeCount = 0;
     knobs.onExit = null;
     knobs.onEvent = null;
@@ -265,6 +279,72 @@ describe('PiAgent.startSession failure cleanup (mocked pi process)', () => {
     const handle = await agent.startSession(opts());
     expect(knobs.spawnedEnvs).toHaveLength(2);
     await handle.close();
+  });
+
+  it('retries every quarantined startup process during dispose and remains idempotent', async () => {
+    knobs.getStateRejects = true;
+    knobs.closeRejects = true;
+    const agent = new PiAgent(buildDeps());
+
+    await expect(agent.startSession(opts())).rejects.toThrow(/cleanup remains unconfirmed/);
+    await expect(agent.startSession({ ...opts(), sessionId: 's2' })).rejects.toThrow(
+      /cleanup remains unconfirmed/,
+    );
+    expect(knobs.closeCount).toBe(2);
+
+    knobs.closeRejects = false;
+    await agent.dispose();
+    await agent.dispose();
+
+    expect(knobs.closeCount).toBe(4);
+  });
+
+  it('reclaims a startup cleanup entry registered after dispose begins', async () => {
+    let releaseGetState!: () => void;
+    knobs.getStateGate = new Promise<void>((resolve) => {
+      releaseGetState = resolve;
+    });
+    knobs.getStateRejects = true;
+    knobs.closeFailuresRemaining = 1;
+    const agent = new PiAgent(buildDeps());
+
+    const startup = agent.startSession(opts());
+    const startupFailure = expect(startup).rejects.toThrow(/cleanup remains unconfirmed/);
+    await vi.waitFor(() => expect(knobs.spawnedEnvs).toHaveLength(1));
+    const disposing = agent.dispose();
+    releaseGetState();
+
+    await startupFailure;
+    await disposing;
+    expect(knobs.closeCount).toBe(2);
+    await expect(agent.startSession(opts())).rejects.toThrow(/disposing/);
+  });
+
+  it('shares a late dispose cleanup and fences replacement startup', async () => {
+    knobs.getStateRejects = true;
+    knobs.closeRejects = true;
+    const agent = new PiAgent(buildDeps());
+
+    await expect(agent.startSession(opts())).rejects.toThrow(/cleanup remains unconfirmed/);
+    expect(knobs.spawnedEnvs).toHaveLength(1);
+
+    let releaseClose!: () => void;
+    knobs.closeGate = new Promise<void>((resolve) => {
+      releaseClose = resolve;
+    });
+    knobs.closeRejects = false;
+    const firstDispose = agent.dispose();
+    const secondDispose = agent.dispose();
+    await vi.waitFor(() => expect(knobs.closeCount).toBe(2));
+    await expect(agent.startSession(opts())).rejects.toThrow(/disposing/);
+    expect(knobs.spawnedEnvs).toHaveLength(1);
+
+    releaseClose();
+    await Promise.all([firstDispose, secondDispose]);
+    knobs.closeGate = null;
+
+    expect(knobs.spawnedEnvs).toHaveLength(1);
+    expect(knobs.closeCount).toBe(2);
   });
 
   it('does not dispose ctx on the success path (dispose is deferred to close())', async () => {

--- a/packages/maker-core/src/agents/pi/__tests__/pi-startsession-cleanup.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/pi-startsession-cleanup.test.ts
@@ -21,6 +21,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 const knobs = vi.hoisted(() => ({
   ctorThrows: false,
   getStateRejects: false,
+  closeRejects: false,
   closeCount: 0,
   onExit: null as null | ((info: { code: number | null; signal: string | null }) => void),
   onEvent: null as null | ((event: unknown) => void),
@@ -77,6 +78,7 @@ vi.mock('../rpc-client.js', () => ({
     send(): void {}
     async close(): Promise<void> {
       knobs.closeCount++;
+      if (knobs.closeRejects) throw new Error('close unconfirmed (mock)');
       this.isClosed = true;
     }
     get pid(): number { return 1234; }
@@ -104,6 +106,7 @@ describe('PiAgent.startSession failure cleanup (mocked pi process)', () => {
   beforeEach(() => {
     knobs.ctorThrows = false;
     knobs.getStateRejects = false;
+    knobs.closeRejects = false;
     knobs.closeCount = 0;
     knobs.onExit = null;
     knobs.onEvent = null;
@@ -244,6 +247,24 @@ describe('PiAgent.startSession failure cleanup (mocked pi process)', () => {
     expect(disposed).toBe(1);
     expect(proxyDisposed).toBe(1);
     expect(knobs.closeCount).toBe(1); // 已 spawn → 必须关掉,避免僵尸持有 ?session= 路由
+  });
+
+  it('quarantines a failed startup process until cleanup is confirmed', async () => {
+    knobs.getStateRejects = true;
+    knobs.closeRejects = true;
+    const agent = new PiAgent(buildDeps());
+
+    await expect(agent.startSession(opts())).rejects.toThrow(/cleanup remains unconfirmed/);
+    expect(knobs.spawnedEnvs).toHaveLength(1);
+    // Same business id cannot spawn while the old proc still fails cleanup.
+    await expect(agent.startSession(opts())).rejects.toThrow(/close unconfirmed/);
+    expect(knobs.spawnedEnvs).toHaveLength(1);
+
+    knobs.closeRejects = false;
+    knobs.getStateRejects = false;
+    const handle = await agent.startSession(opts());
+    expect(knobs.spawnedEnvs).toHaveLength(2);
+    await handle.close();
   });
 
   it('does not dispose ctx on the success path (dispose is deferred to close())', async () => {

--- a/packages/maker-core/src/agents/pi/__tests__/rpc-client.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/rpc-client.test.ts
@@ -211,6 +211,20 @@ describe('PiRpcProcess close semantics (bridge-disconnect vs explicit close)', (
     expect(killRemoteSession).toHaveBeenCalledTimes(1);
   });
 
+  it('retries transport shutdown after an unconfirmed local close', async () => {
+    const { transport } = makeFakeTransport();
+    const transportClose = vi.mocked(transport.close);
+    transportClose
+      .mockRejectedValueOnce(new Error('pi process did not confirm exit after SIGKILL'))
+      .mockResolvedValueOnce(undefined);
+    const { proc } = makeProc({ transport });
+
+    await expect(proc.close()).rejects.toThrow(/did not confirm exit after SIGKILL/);
+    await expect(proc.close()).resolves.toBeUndefined();
+
+    expect(transportClose).toHaveBeenCalledTimes(2);
+  });
+
   it('retries remote termination after a failed close instead of reporting false success', async () => {
     const killRemoteSession = vi
       .fn()

--- a/packages/maker-core/src/agents/pi/__tests__/rpc-client.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/rpc-client.test.ts
@@ -8,7 +8,11 @@
 
 import { describe, expect, it, vi } from 'vitest';
 
-import { PiRpcProcess, type PiRpcSpawnOptions } from '../rpc-client.js';
+import {
+  PiRpcProcess,
+  PiRpcRequestTimeoutError,
+  type PiRpcSpawnOptions,
+} from '../rpc-client.js';
 import type { PiTransport, PiLineHandler, PiCloseHandler } from '../transport.js';
 
 // ── Fake transport:捕获 writeLine,手动触发 onLine/onClose ─────────────
@@ -114,6 +118,57 @@ describe('PiRpcProcess response envelope validation', () => {
     expect(resp.error).toBe('session load failed');
   });
 
+  it('reports request timeouts with a stable command-aware error', async () => {
+    vi.useFakeTimers();
+    try {
+      const { transport } = makeFakeTransport();
+      const { proc } = makeProc({ transport });
+
+      const pending = proc.request({ type: 'prompt' }, { timeoutMs: 75_000 });
+      const rejected = expect(pending).rejects.toEqual(expect.objectContaining({
+        name: 'PiRpcRequestTimeoutError',
+        code: 'PI_RPC_TIMEOUT',
+        commandType: 'prompt',
+        timeoutMs: 75_000,
+      } satisfies Partial<PiRpcRequestTimeoutError>));
+      await vi.advanceTimersByTimeAsync(75_000);
+
+      await rejected;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('refreshes a request idle timeout on matching progress events', async () => {
+    vi.useFakeTimers();
+    try {
+      const { transport, emitLine, written } = makeFakeTransport();
+      const { proc } = makeProc({ transport });
+      const pending = proc.request(
+        { type: 'prompt' },
+        {
+          timeoutMs: 100,
+          refreshTimeoutOnEvent: (event) => event.type === 'compaction_start',
+        },
+      );
+      const sentFrame = JSON.parse(written[0]!.line) as { id: string };
+
+      await vi.advanceTimersByTimeAsync(90);
+      emitLine(JSON.stringify({ type: 'compaction_start', reason: 'threshold' }));
+      await vi.advanceTimersByTimeAsync(90);
+      emitLine(JSON.stringify({
+        type: 'response',
+        id: sentFrame.id,
+        command: 'prompt',
+        success: true,
+      }));
+
+      await expect(pending).resolves.toMatchObject({ success: true });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('unmatched response (late/wrong id) is dropped with a warn, not resolved', async () => {
     const { transport, emitLine } = makeFakeTransport();
     const { proc, logger } = makeProc({ transport });
@@ -136,7 +191,7 @@ describe('PiRpcProcess close semantics (bridge-disconnect vs explicit close)', (
     // 轮 42 P2(codex-connector):bridge 断链(onClose 置 closed)后, 用户显式
     // close() 仍必须执行 killRemoteSession —— 它走独立 SSH RPC 可送达 daemon;
     // 复用 closed 做 close() 守卫会让显式关闭直接 return, 远端 pi 带凭证跑到
-    // idle 回收。closeCalled 单独跟踪「用户已显式关闭」。
+    // idle 回收。成功 close 的共享 Promise 跟踪「已经明确关闭」。
     const killRemoteSession = vi.fn(async () => {});
     const { transport } = makeFakeTransport();
     const { proc } = makeProc({ transport });
@@ -154,5 +209,20 @@ describe('PiRpcProcess close semantics (bridge-disconnect vs explicit close)', (
     // 重复 close 幂等: 不再二次 kill。
     await proc.close();
     expect(killRemoteSession).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries remote termination after a failed close instead of reporting false success', async () => {
+    const killRemoteSession = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('relay offline'))
+      .mockResolvedValueOnce(undefined);
+    const { transport } = makeFakeTransport();
+    const { proc } = makeProc({ transport });
+    (transport as unknown as { killRemoteSession: unknown }).killRemoteSession = killRemoteSession;
+
+    await expect(proc.close()).rejects.toThrow(/remote daemon session may still be running/);
+    await expect(proc.close()).resolves.toBeUndefined();
+
+    expect(killRemoteSession).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/maker-core/src/agents/pi/__tests__/transport.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/transport.test.ts
@@ -108,7 +108,7 @@ describe('createPiStdioTransport', () => {
     }
   });
 
-  it('close() resolves even if child never confirms exit after SIGKILL (round 40-w4-t3 HIGH — no hang)', async () => {
+  it('rejects without hanging when SIGKILL exit cannot be confirmed', async () => {
     vi.useFakeTimers();
     try {
       const { transport, child } = makeTransport();
@@ -118,15 +118,22 @@ describe('createPiStdioTransport', () => {
       transport.onClose(onClose);
 
       const closePromise = transport.close();
+      const rejected = expect(closePromise).rejects.toThrow(/did not confirm exit after SIGKILL/);
       // SIGTERM 宽限期(3s)→ SIGKILL
       await vi.advanceTimersByTimeAsync(3_000);
       expect(child.kill).toHaveBeenCalledWith('SIGKILL');
-      // SIGKILL 确认窗口(5s)超时 → close() 必须 resolve(不再永久挂住)
+      // SIGKILL 确认窗口(5s)超时 → close() 必须收口但不能谎报成功。
       await vi.advanceTimersByTimeAsync(5_000);
-      await closePromise;
-      // 主动 close 语义:onClose 收到通知
-      expect(onClose).toHaveBeenCalledTimes(1);
+      await rejected;
+      expect(onClose).not.toHaveBeenCalled();
       expect(transport.isClosed()).toBe(true);
+
+      // 未看到真实 exit 前，重复 close 继续 fail closed。
+      await expect(transport.close()).rejects.toThrow(/did not confirm exit after SIGKILL/);
+      // 若进程随后终于退出，确认状态解除，后续幂等 close 才可成功。
+      child.emit('close', null, 'SIGKILL');
+      expect(onClose).toHaveBeenCalledTimes(1);
+      await expect(transport.close()).resolves.toBeUndefined();
     } finally {
       vi.useRealTimers();
     }

--- a/packages/maker-core/src/agents/pi/__tests__/transport.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/transport.test.ts
@@ -108,32 +108,51 @@ describe('createPiStdioTransport', () => {
     }
   });
 
-  it('rejects without hanging when SIGKILL exit cannot be confirmed', async () => {
+  it('retries a full termination attempt after SIGKILL exit is unconfirmed', async () => {
     vi.useFakeTimers();
     try {
       const { transport, child } = makeTransport();
-      // child 不响应任何信号:不 emit close, kill 是 no-op。
       child.kill.mockImplementation(() => true);
       const onClose = vi.fn();
       transport.onClose(onClose);
 
-      const closePromise = transport.close();
-      const rejected = expect(closePromise).rejects.toThrow(/did not confirm exit after SIGKILL/);
-      // SIGTERM 宽限期(3s)→ SIGKILL
-      await vi.advanceTimersByTimeAsync(3_000);
-      expect(child.kill).toHaveBeenCalledWith('SIGKILL');
-      // SIGKILL 确认窗口(5s)超时 → close() 必须收口但不能谎报成功。
-      await vi.advanceTimersByTimeAsync(5_000);
-      await rejected;
+      const firstClose = transport.close();
+      const firstRejected = expect(firstClose).rejects.toThrow(
+        /did not confirm exit after SIGKILL/,
+      );
+      await vi.advanceTimersByTimeAsync(8_000);
+      await firstRejected;
+      expect(child.kill.mock.calls).toEqual([['SIGTERM'], ['SIGKILL']]);
       expect(onClose).not.toHaveBeenCalled();
       expect(transport.isClosed()).toBe(true);
+      await expect(transport.writeLine('{"x":1}')).rejects.toThrow(/closed/);
 
-      // 未看到真实 exit 前，重复 close 继续 fail closed。
-      await expect(transport.close()).rejects.toThrow(/did not confirm exit after SIGKILL/);
-      // 若进程随后终于退出，确认状态解除，后续幂等 close 才可成功。
+      // A new owner retry shares one in-flight attempt and sends fresh signals.
+      const retry = transport.close();
+      const concurrentRetry = transport.close();
+      expect(concurrentRetry).toBe(retry);
+      expect(child.kill.mock.calls).toEqual([
+        ['SIGTERM'],
+        ['SIGKILL'],
+        ['SIGTERM'],
+      ]);
+      await vi.advanceTimersByTimeAsync(3_000);
+      expect(child.kill.mock.calls).toEqual([
+        ['SIGTERM'],
+        ['SIGKILL'],
+        ['SIGTERM'],
+        ['SIGKILL'],
+      ]);
+
+      // A real close may arrive late from either kill attempt. It is the sole
+      // success signal and settles every waiter exactly once.
       child.emit('close', null, 'SIGKILL');
+      await expect(retry).resolves.toBeUndefined();
+      await expect(concurrentRetry).resolves.toBeUndefined();
       expect(onClose).toHaveBeenCalledTimes(1);
+
       await expect(transport.close()).resolves.toBeUndefined();
+      expect(child.kill).toHaveBeenCalledTimes(4);
     } finally {
       vi.useRealTimers();
     }

--- a/packages/maker-core/src/agents/pi/index.ts
+++ b/packages/maker-core/src/agents/pi/index.ts
@@ -2779,6 +2779,9 @@ export class PiAgent extends BaseAgent {
               PI_PROMPT_ACCEPTANCE_PROGRESS_EVENTS.has(event.type),
           });
           if (!resp.success) {
+            if (resp.command !== command.type) {
+              throw new Error('pi prompt rejection response missing matching command');
+            }
             throw new TurnDispatchRejectedError(
               `pi prompt rejected before acceptance: ${resp.error ?? 'unknown'}`,
             );

--- a/packages/maker-core/src/agents/pi/index.ts
+++ b/packages/maker-core/src/agents/pi/index.ts
@@ -56,6 +56,7 @@ function validateSdkSessionId(value: string): string {
 import {
   AgentNotAuthenticatedError,
   BaseAgent,
+  TurnDispatchRejectedError,
   TurnDispatchUnconfirmedError,
   TurnPermissionPolicyUnsupportedError,
   type AgentDeps,
@@ -2745,7 +2746,6 @@ export class PiAgent extends BaseAgent {
         activeTurnPermissionPolicy = sendOpts?.turnPermissionPolicy ?? null;
         let providerAccepted = false;
         let promptRequestStarted = false;
-        let providerRejected = false;
         try {
           if (reviewMode) {
             await assertReviewMessageContentPaths(
@@ -2779,8 +2779,9 @@ export class PiAgent extends BaseAgent {
               PI_PROMPT_ACCEPTANCE_PROGRESS_EVENTS.has(event.type),
           });
           if (!resp.success) {
-            providerRejected = true;
-            throw new Error(`pi prompt rejected: ${resp.error ?? 'unknown'}`);
+            throw new TurnDispatchRejectedError(
+              `pi prompt rejected before acceptance: ${resp.error ?? 'unknown'}`,
+            );
           }
           providerAccepted = true;
           await reportAcceptedPiUserEntry(userEntriesBefore, sendOpts?.onTranscriptUserEntry);
@@ -2792,7 +2793,11 @@ export class PiAgent extends BaseAgent {
           // request starts, a transport/write/envelope failure cannot prove
           // whether Pi accepted the prompt; only success:false is an explicit
           // rejection. Fence every other unknown result before Goal may resume.
-          if (promptRequestStarted && !providerAccepted && !providerRejected) {
+          if (
+            promptRequestStarted
+            && !providerAccepted
+            && !(err instanceof TurnDispatchRejectedError)
+          ) {
             const detail = err instanceof Error ? err.message : String(err);
             throw new TurnDispatchUnconfirmedError(
               `Pi did not confirm prompt acceptance: ${detail}`,

--- a/packages/maker-core/src/agents/pi/index.ts
+++ b/packages/maker-core/src/agents/pi/index.ts
@@ -2744,6 +2744,8 @@ export class PiAgent extends BaseAgent {
         const previousTurnPermissionPolicy = activeTurnPermissionPolicy;
         activeTurnPermissionPolicy = sendOpts?.turnPermissionPolicy ?? null;
         let providerAccepted = false;
+        let promptRequestStarted = false;
+        let providerRejected = false;
         try {
           if (reviewMode) {
             await assertReviewMessageContentPaths(
@@ -2767,6 +2769,7 @@ export class PiAgent extends BaseAgent {
             ? await readPiUserEntryIds()
             : null;
           rejectIfCancelled(sendOpts, 'send');
+          promptRequestStarted = true;
           const resp = await proc.request(command, {
             timeoutMs: PI_PROMPT_ACCEPTANCE_TIMEOUT_MS,
             // Prompt acceptance may legitimately span multiple compaction
@@ -2776,6 +2779,7 @@ export class PiAgent extends BaseAgent {
               PI_PROMPT_ACCEPTANCE_PROGRESS_EVENTS.has(event.type),
           });
           if (!resp.success) {
+            providerRejected = true;
             throw new Error(`pi prompt rejected: ${resp.error ?? 'unknown'}`);
           }
           providerAccepted = true;
@@ -2784,16 +2788,14 @@ export class PiAgent extends BaseAgent {
           // 只在 Provider 尚未接受本轮时回滚。接受后的 transcript 回调失败不代表
           // turn 没启动；此时恢复旧 policy 会让正在运行的新 turn 用错安全边界。
           if (!providerAccepted) activeTurnPermissionPolicy = previousTurnPermissionPolicy;
-          const rpcError = err as { code?: unknown; commandType?: unknown } | null;
-          if (
-            rpcError?.code === 'PI_RPC_TIMEOUT'
-            && rpcError.commandType === 'prompt'
-          ) {
-            // 接受等待超时后，原 prompt 仍可能在 preflight 压缩结束时迟到执行。
-            // 上抛稳定错误，让 Session 先占住关闭门再杀 transport；Goal 随后
-            // 明确阻塞并要求人工确认，绝不盲目重放可能已有副作用的 turn。
+          // Before proc.request the turn is known not to have reached Pi. Once
+          // request starts, a transport/write/envelope failure cannot prove
+          // whether Pi accepted the prompt; only success:false is an explicit
+          // rejection. Fence every other unknown result before Goal may resume.
+          if (promptRequestStarted && !providerAccepted && !providerRejected) {
+            const detail = err instanceof Error ? err.message : String(err);
             throw new TurnDispatchUnconfirmedError(
-              `Pi did not confirm prompt acceptance within ${PI_PROMPT_ACCEPTANCE_TIMEOUT_MS}ms`,
+              `Pi did not confirm prompt acceptance: ${detail}`,
               { cause: err },
             );
           }

--- a/packages/maker-core/src/agents/pi/index.ts
+++ b/packages/maker-core/src/agents/pi/index.ts
@@ -519,15 +519,20 @@ export class PiAgent extends BaseAgent {
   readonly kind: AgentKind = 'pi';
   readonly capabilities: Capabilities;
   private readonly failedStartupCleanups = new Map<string, FailedPiStartupCleanup>();
+  private readonly inFlightStartups = new Set<Promise<AgentSessionHandle>>();
+  private disposeStarted = false;
 
   constructor(deps: AgentDeps) {
     super(deps);
     this.capabilities = this.buildCapabilities(PiAgent.baseCapabilities());
   }
 
-  private async retryFailedStartupCleanup(sessionId: string): Promise<void> {
+  private async retryFailedStartupCleanup(
+    sessionId: string,
+    expectedEntry?: FailedPiStartupCleanup,
+  ): Promise<void> {
     const entry = this.failedStartupCleanups.get(sessionId);
-    if (!entry) return;
+    if (!entry || (expectedEntry && entry !== expectedEntry)) return;
     const cleanup = entry.promise ?? entry.proc.close();
     entry.promise = cleanup;
     try {
@@ -541,6 +546,27 @@ export class PiAgent extends BaseAgent {
     if (this.failedStartupCleanups.get(sessionId) === entry) {
       this.failedStartupCleanups.delete(sessionId);
       entry.cleanupLocal?.();
+    }
+  }
+
+  override async dispose(): Promise<void> {
+    this.disposeStarted = true;
+    const startupSnapshot = Array.from(this.inFlightStartups);
+    await Promise.allSettled(startupSnapshot);
+
+    // startSession registers before yielding and new starts are fenced above,
+    // so every failed pre-publication process is now visible in this snapshot.
+    const cleanupSnapshot = Array.from(this.failedStartupCleanups.entries());
+    const results = await Promise.allSettled(
+      cleanupSnapshot.map(([sessionId, entry]) =>
+        this.retryFailedStartupCleanup(sessionId, entry),
+      ),
+    );
+    const errors = results.flatMap((result) =>
+      result.status === 'rejected' ? [result.reason] : [],
+    );
+    if (errors.length > 0) {
+      throw new AggregateError(errors, 'Pi startup process cleanup remains unconfirmed');
     }
   }
 
@@ -895,7 +921,20 @@ export class PiAgent extends BaseAgent {
     };
   }
 
-  async startSession(opts: StartSessionOptions): Promise<AgentSessionHandle> {
+  override async startSession(opts: StartSessionOptions): Promise<AgentSessionHandle> {
+    if (this.disposeStarted) {
+      throw new Error('Pi agent is disposing; refusing to start a new session');
+    }
+    const startup = this.startSessionWhileRunning(opts);
+    this.inFlightStartups.add(startup);
+    try {
+      return await startup;
+    } finally {
+      this.inFlightStartups.delete(startup);
+    }
+  }
+
+  private async startSessionWhileRunning(opts: StartSessionOptions): Promise<AgentSessionHandle> {
     const startupCleanupKey = opts.sessionId ?? '<anonymous>';
     // A previous pre-publication Pi process for this business session must be
     // confirmed dead before another spawn can begin.
@@ -1522,7 +1561,7 @@ export class PiAgent extends BaseAgent {
      * 用它当"撤销开关"(上一版就是这么用的,那是个空操作,review 连点两轮)。运行期要收回子代理
      * 能力只有一条可证明有效的路:终止会话。
      */
-    let subagentRoutingEnabled = !reviewMode;
+    const subagentRoutingEnabled = !reviewMode;
     const writeSubagentRuntimeFile = async (
       next: { model?: string; provider?: string; pending?: boolean },
     ): Promise<boolean> => {

--- a/packages/maker-core/src/agents/pi/index.ts
+++ b/packages/maker-core/src/agents/pi/index.ts
@@ -56,6 +56,7 @@ function validateSdkSessionId(value: string): string {
 import {
   AgentNotAuthenticatedError,
   BaseAgent,
+  TurnDispatchUnconfirmedError,
   TurnPermissionPolicyUnsupportedError,
   type AgentDeps,
   type AgentSessionHandle,
@@ -190,6 +191,15 @@ function isLoopbackOnlyBaseUrl(baseUrl: string): boolean {
 const PI_IMAGE_INPUT_UNSUPPORTED_CODE = 'PI_IMAGE_INPUT_UNSUPPORTED';
 /** 手动压缩 = 一次完整 LLM 摘要调用(大上下文 + 网关排队),远超默认 30s RPC 超时。 */
 const PI_COMPACT_TIMEOUT_MS = 600_000;
+/** prompt 接受前可能自动压缩，同样必须覆盖一次完整摘要调用。 */
+const PI_PROMPT_ACCEPTANCE_TIMEOUT_MS = PI_COMPACT_TIMEOUT_MS;
+const PI_PROMPT_ACCEPTANCE_PROGRESS_EVENTS = new Set([
+  'compaction_start',
+  'compaction_end',
+  'summarization_retry_scheduled',
+  'summarization_retry_attempt_start',
+  'summarization_retry_finished',
+]);
 /** 分支摘要同样可能触发一次完整 LLM 调用。 */
 const PI_BRANCH_NAVIGATION_TIMEOUT_MS = 600_000;
 
@@ -499,13 +509,39 @@ function piExtraDirsPrompt(dirs: readonly string[]): string {
   ].join('\n');
 }
 
+interface FailedPiStartupCleanup {
+  proc: PiRpcProcess;
+  promise: Promise<void> | null;
+  cleanupLocal?: () => void;
+}
+
 export class PiAgent extends BaseAgent {
   readonly kind: AgentKind = 'pi';
   readonly capabilities: Capabilities;
+  private readonly failedStartupCleanups = new Map<string, FailedPiStartupCleanup>();
 
   constructor(deps: AgentDeps) {
     super(deps);
     this.capabilities = this.buildCapabilities(PiAgent.baseCapabilities());
+  }
+
+  private async retryFailedStartupCleanup(sessionId: string): Promise<void> {
+    const entry = this.failedStartupCleanups.get(sessionId);
+    if (!entry) return;
+    const cleanup = entry.promise ?? entry.proc.close();
+    entry.promise = cleanup;
+    try {
+      await cleanup;
+    } catch (error) {
+      if (this.failedStartupCleanups.get(sessionId) === entry && entry.promise === cleanup) {
+        entry.promise = null;
+      }
+      throw error;
+    }
+    if (this.failedStartupCleanups.get(sessionId) === entry) {
+      this.failedStartupCleanups.delete(sessionId);
+      entry.cleanupLocal?.();
+    }
   }
 
   private static baseCapabilities(): Capabilities {
@@ -860,6 +896,10 @@ export class PiAgent extends BaseAgent {
   }
 
   async startSession(opts: StartSessionOptions): Promise<AgentSessionHandle> {
+    const startupCleanupKey = opts.sessionId ?? '<anonymous>';
+    // A previous pre-publication Pi process for this business session must be
+    // confirmed dead before another spawn can begin.
+    await this.retryFailedStartupCleanup(startupCleanupKey);
     // 轮 22 LOW-6:空串 remoteHostId 规范化 —— Boolean('') 是 false 会让会话
     // 被判定本地但后续仍把 '' 传给 resolvePiNativeProviders 等, 行为分裂。
     if (opts.remoteHostId === '') opts.remoteHostId = undefined;
@@ -2357,16 +2397,35 @@ export class PiAgent extends BaseAgent {
       } catch {
         /* best-effort:注销失败不掩盖原始启动错误 */
       }
-      // 轮 42 P1(codex-connector fresh evidence):startup 失败路径的 proc.close()
-      // 被 .catch 吞掉 —— 远端 daemon 会话 killRemoteSession 失败时, pi 子进程
-      // 可能仍带着凭证 env 在跑, 这里再删 configHome/permission/subagent 会让
-      // 存活 pi 丢 bridge/permission 状态。与 onExit/close() 同口径: 远端会话
-      // 失败不清理 runtime 文件, 残留交给 daemon idle 回收 / 下次 startSession
-      // 的清陈旧目录兜底(轮 40-w4-t4); 本地 stdio close 后进程必死, 保持清理。
-      await proc.close().catch(() => {});
-      if (!remote) {
+      // startup 失败时必须确认 proc 已关闭。关闭失败的 proc 进入 session-keyed
+      // quarantine；后续同 session startSession 会先重试 cleanup，绝不直接 spawn。
+      // 远端失败时不清 runtime 文件；本地也只有确认进程结束后才清，避免存活
+      // 进程丢 bridge/permission 状态。
+      let closeError: unknown = null;
+      try {
+        await proc.close();
+      } catch (error) {
+        closeError = error;
+        this.failedStartupCleanups.set(startupCleanupKey, {
+          proc,
+          promise: null,
+          ...(!remote
+            ? { cleanupLocal: () => {
+                cleanupConfigHome();
+                cleanupRuntimeFiles();
+              } }
+            : {}),
+        });
+      }
+      if (!remote && !closeError) {
         cleanupConfigHome();
         cleanupRuntimeFiles();
+      }
+      if (closeError) {
+        throw new Error(
+          `pi startup failed and process cleanup remains unconfirmed: ${closeError instanceof Error ? closeError.message : String(closeError)}`,
+          { cause: err },
+        );
       }
       throw err;
     }
@@ -2669,7 +2728,14 @@ export class PiAgent extends BaseAgent {
             ? await readPiUserEntryIds()
             : null;
           rejectIfCancelled(sendOpts, 'send');
-          const resp = await proc.request(command);
+          const resp = await proc.request(command, {
+            timeoutMs: PI_PROMPT_ACCEPTANCE_TIMEOUT_MS,
+            // Prompt acceptance may legitimately span multiple compaction
+            // retries. Bound each silent interval, not the whole progressing
+            // preflight, so a healthy long compaction is not killed at 10m.
+            refreshTimeoutOnEvent: (event) =>
+              PI_PROMPT_ACCEPTANCE_PROGRESS_EVENTS.has(event.type),
+          });
           if (!resp.success) {
             throw new Error(`pi prompt rejected: ${resp.error ?? 'unknown'}`);
           }
@@ -2679,6 +2745,19 @@ export class PiAgent extends BaseAgent {
           // 只在 Provider 尚未接受本轮时回滚。接受后的 transcript 回调失败不代表
           // turn 没启动；此时恢复旧 policy 会让正在运行的新 turn 用错安全边界。
           if (!providerAccepted) activeTurnPermissionPolicy = previousTurnPermissionPolicy;
+          const rpcError = err as { code?: unknown; commandType?: unknown } | null;
+          if (
+            rpcError?.code === 'PI_RPC_TIMEOUT'
+            && rpcError.commandType === 'prompt'
+          ) {
+            // 接受等待超时后，原 prompt 仍可能在 preflight 压缩结束时迟到执行。
+            // 上抛稳定错误，让 Session 先占住关闭门再杀 transport；Goal 随后
+            // 明确阻塞并要求人工确认，绝不盲目重放可能已有副作用的 turn。
+            throw new TurnDispatchUnconfirmedError(
+              `Pi did not confirm prompt acceptance within ${PI_PROMPT_ACCEPTANCE_TIMEOUT_MS}ms`,
+              { cause: err },
+            );
+          }
           throw err;
         }
       },

--- a/packages/maker-core/src/agents/pi/index.ts
+++ b/packages/maker-core/src/agents/pi/index.ts
@@ -2873,22 +2873,14 @@ export class PiAgent extends BaseAgent {
             message: err instanceof Error ? err.message : String(err),
           });
         }
-        // 轮 40-w4-t10 MEDIUM(修复的修复):runtime 文件清理必须在 finally ——
-        // proc.close 抛错(如 killRemoteSession 失败)时旧实现会跳过 cleanup,
-        // 权限文件/subagent snapshot 残留在磁盘。清理不受 close 成败影响。
-        // 轮 42 P1(codex-connector 修正):**远端会话不清理** —— killRemoteSession
-        // 失败说明远端 pi 可能仍持有 configHome/permission/subagent runtime
-        // 继续跑(凭证仍在 env), 删文件会让存活 pi 丢 bridge/permission 状态。
-        // 与 onExit 同口径:远端残留交给 daemon idle 回收/下次 startSession 的
-        // 清陈旧目录兜底(轮 40-w4-t4); 本地 stdio 无 daemon, close 后进程必死。
-        try {
-          await proc.close();
-        } finally {
-          if (!remote) {
-            // 会话结束:清理隔离的 configHome 与 runtime 文件(onExit 幂等,二者先到先清)。
-            cleanupConfigHome();
-            cleanupRuntimeFiles();
-          }
+        // A local close is only complete after proc.close confirms process exit.
+        // Until then the still-live process may continue reading its isolated
+        // config, permission policy, and subagent routing snapshot.
+        await proc.close();
+        if (!remote) {
+          // 会话结束:清理隔离的 configHome 与 runtime 文件(onExit 幂等,二者先到先清)。
+          cleanupConfigHome();
+          cleanupRuntimeFiles();
         }
       },
 

--- a/packages/maker-core/src/agents/pi/rpc-client.ts
+++ b/packages/maker-core/src/agents/pi/rpc-client.ts
@@ -37,6 +37,18 @@ export interface PiRpcEvent {
   [key: string]: unknown;
 }
 
+export class PiRpcRequestTimeoutError extends Error {
+  readonly code = 'PI_RPC_TIMEOUT';
+
+  constructor(
+    public readonly commandType: string,
+    public readonly timeoutMs: number,
+  ) {
+    super(`pi rpc timeout after ${timeoutMs}ms: ${commandType}`);
+    this.name = 'PiRpcRequestTimeoutError';
+  }
+}
+
 export interface PiRpcSpawnOptions {
   /** 已建立的字节流 transport(本地 stdio 或远端 ssh channel)。 */
   transport: PiTransport;
@@ -80,18 +92,18 @@ export class PiRpcProcess {
     resolve: (resp: PiRpcResponse) => void;
     reject: (err: Error) => void;
     timer: NodeJS.Timeout;
+    timeoutMs: number;
+    refreshTimeoutOnEvent?: (event: PiRpcEvent) => boolean;
     /** 发送命令的 type —— 响应 envelope 校验用(轮 40-w4-t4 CRITICAL)。 */
     commandType: string;
   }>();
   private closed = false;
   /**
-   * 轮 42 P2(codex-connector):close() 的幂等守卫单独跟踪 —— 与 closed(进程/通道
-   * 已死)分离。bridge 断链时 onClose 置 closed, 但**用户显式 close 仍未发生过**:
-   * 复用 closed 做 close() 守卫会让显式关闭直接 return, 跳过 killRemoteSession
-   * (它走独立 SSH RPC, 断链后仍能送达 daemon), 远端 pi 带凭证跑到 idle 回收。
-   * closeCalled 只在用户(或上层)显式 close 后置位, 保证 kill 一定执行一次。
+   * In-flight/successful close is shared. A failed close clears the gate so a
+   * later call can retry remote termination instead of reporting a false
+   * idempotent success while the old daemon session may still be alive.
    */
-  private closeCalled = false;
+  private closePromise: Promise<void> | null = null;
   private readonly logger: Logger;
 
   constructor(private readonly opts: PiRpcSpawnOptions) {
@@ -124,7 +136,13 @@ export class PiRpcProcess {
   /** 发送命令并等待同 id 响应。success:false 时同样 resolve(由调用方看 success/error)。 */
   async request(
     command: Record<string, unknown>,
-    { timeoutMs = DEFAULT_REQUEST_TIMEOUT_MS }: { timeoutMs?: number } = {},
+    {
+      timeoutMs = DEFAULT_REQUEST_TIMEOUT_MS,
+      refreshTimeoutOnEvent,
+    }: {
+      timeoutMs?: number;
+      refreshTimeoutOnEvent?: (event: PiRpcEvent) => boolean;
+    } = {},
   ): Promise<PiRpcResponse> {
     if (this.isClosed) throw new Error('pi process already exited');
     const id = `c${this.nextRequestId++}`;
@@ -133,12 +151,15 @@ export class PiRpcProcess {
     return new Promise<PiRpcResponse>((resolve, reject) => {
       const timer = setTimeout(() => {
         this.pending.delete(id);
-        reject(new Error(`pi rpc timeout after ${timeoutMs}ms: ${String(command.type)}`));
+        const commandType = typeof command.type === 'string' ? command.type : '';
+        reject(new PiRpcRequestTimeoutError(commandType, timeoutMs));
       }, timeoutMs);
       this.pending.set(id, {
         resolve,
         reject,
         timer,
+        timeoutMs,
+        refreshTimeoutOnEvent,
         commandType: typeof command.type === 'string' ? command.type : '',
       });
       this.transport.writeLine(payload).catch((err) => {
@@ -164,40 +185,46 @@ export class PiRpcProcess {
     });
   }
 
-  /** 优雅关闭:交给 transport(SIGTERM → 宽限期 → SIGKILL,或关 ssh channel)。幂等。 */
-  async close(): Promise<void> {
-    // 轮 21 H-2 幂等竞态:closeCalled 必须在任何 await 前置位 —— 否则并发 close()
-    // 都通过守卫、killRemoteSession RPC 发两次(daemon 模式)+ transport.close
-    // 跑两次。置位后 killRemoteSession/close 的失败不再影响幂等语义。
-    // 轮 42 P2:守卫用 closeCalled 而非 closed —— onClose(bridge 断链)已置 closed
-    // 时, 用户显式 close 仍必须执行 killRemoteSession(独立 SSH RPC 可送达 daemon)。
-    if (this.closeCalled) return;
-    this.closeCalled = true;
+  /** 优雅关闭:交给 transport(SIGTERM → 宽限期 → SIGKILL,或关 ssh channel)。 */
+  close(): Promise<void> {
+    if (this.closePromise) return this.closePromise;
+    const attempt = this.performClose();
+    this.closePromise = attempt;
+    void attempt.catch(() => {
+      if (this.closePromise === attempt) this.closePromise = null;
+    });
+    return attempt;
+  }
+
+  private async performClose(): Promise<void> {
     this.closed = true;
     // daemon 模式:用户主动关会话 → 先杀远端 daemon 持有的 pi(对齐 CC/Codex daemon
     // 生命周期),再关 transport。顺序关键:先杀 pi 再关 channel,PiAgent 的 onExit
     // cleanup(configHome/perm)才发生在 pi 已死后 —— 否则 kill 失败而 cleanup 已删
     // configHome,daemon pi 继续跑会用已删文件(R2 生命周期 B3)。
-    // 轮 40-w4-t10 HIGH(修复的修复):kill 失败(SSH 断/daemon 不可达)时**仍必须
-    // 关 transport** —— 旧实现直接 throw 会跳过 transport.close, 把可恢复的关闭
-    // 失败变成永久半开(channel/daemon 继续存活, 重试因 closed 置位 no-op)。
-    // kill 失败只决定是否上浮错误, 不阻断底层收口。
+    // kill 失败时仍关 transport，但必须 reject；失败 gate 会被 close() 清掉，
+    // 后续可经独立 SSH RPC 真正重试 kill，不能第二次 close 伪成功。
     let killError: unknown = null;
     try {
       await this.transport.killRemoteSession?.();
     } catch (err) {
-      // 轮 40-w4-t7 HIGH:kill 失败时 pi 可能继续跑, 残留持凭证的远端 session。
-      // fail-closed:上浮错误, 让上层明确知道关闭未完成(daemon idle timeout 兜底)。
       killError = new Error(
         `pi killRemoteSession failed: ${err instanceof Error ? err.message : String(err)} — remote daemon session may still be running`,
       );
     }
+    let transportError: unknown = null;
     try {
       await this.transport.close();
-    } catch {
-      // transport.close 自身幂等且不抛;防御未来实现变更(自审轮 6 L-1 语义保留)。
+    } catch (err) {
+      transportError = err;
+    }
+    if (transportError) {
+      this.failAllPending(
+        transportError instanceof Error ? transportError : new Error(String(transportError)),
+      );
     }
     if (killError) throw killError;
+    if (transportError) throw transportError;
   }
 
   private handleStdoutLine(line: string): void {
@@ -264,7 +291,17 @@ export class PiRpcProcess {
       return;
     }
 
-    this.opts.onEvent(obj as PiRpcEvent);
+    const event = obj as PiRpcEvent;
+    for (const [id, entry] of this.pending) {
+      if (!entry.refreshTimeoutOnEvent?.(event)) continue;
+      clearTimeout(entry.timer);
+      entry.timer = setTimeout(() => {
+        if (this.pending.get(id) !== entry) return;
+        this.pending.delete(id);
+        entry.reject(new PiRpcRequestTimeoutError(entry.commandType, entry.timeoutMs));
+      }, entry.timeoutMs);
+    }
+    this.opts.onEvent(event);
   }
 
   private failAllPending(err: Error): void {

--- a/packages/maker-core/src/agents/pi/transport.ts
+++ b/packages/maker-core/src/agents/pi/transport.ts
@@ -116,6 +116,8 @@ export function createPiStdioTransport(opts: PiStdioTransportOptions): PiTranspo
   // 轮 40-w1 MEDIUM-2:close() 进行中标志 —— 防并发 close 双 SIGTERM(轮 21
   // 幂等), 与 closed(已通知)分离, 保主动 close 仍触发 onClose。
   let closing = false;
+  /** SIGKILL 后未确认退出时，后续 close 继续失败，直到 child 真正发出 close。 */
+  let closeFailure: Error | null = null;
   let disposeProcessRegistration: (() => void) | undefined;
   if (child.pid != null && child.pid > 0) {
     try {
@@ -183,6 +185,7 @@ export function createPiStdioTransport(opts: PiStdioTransportOptions): PiTranspo
     fireClose({ code: null, signal: null, reason: `pi process error: ${err.message}` });
   });
   child.on('close', (code, signal) => {
+    closeFailure = null;
     fireClose({ code, signal, reason: `pi process exited (code=${code}, signal=${signal})` });
   });
 
@@ -216,6 +219,7 @@ export function createPiStdioTransport(opts: PiStdioTransportOptions): PiTranspo
     },
 
     async close(reason = 'pi transport close()'): Promise<void> {
+      if (closeFailure) throw closeFailure;
       // 轮 21 H-1 幂等竞态:closed 必须在任何 await 前置位 —— 否则两个并发
       // close() 都通过守卫、各发一次 SIGTERM + 各设一个 SIGKILL timer。
       // 轮 40-w1 MEDIUM-2:前置 closed 会吞掉子进程 close 事件的 fireClose,
@@ -226,9 +230,8 @@ export function createPiStdioTransport(opts: PiStdioTransportOptions): PiTranspo
       // 优雅关闭:SIGTERM → 宽限期 → SIGKILL → 确认退出。幂等。
       // 轮 40-w4-t3 HIGH:旧实现 SIGKILL 后无确认超时 —— D-state/平台异常下
       // close 事件不来, await close() 永久挂住, 上层取消流程无法收口。这里
-      // 对齐 session-registry 的 waitForExit 语义:超时后仍 resolve(保 close()
-      // 的 Promise<void> 契约, PiRpcProcess.close 不 catch —— reject 会冒泡成
-      // 未处理错误), 残留子进程由进程管理器兜底, 日志告警可查。
+      // 对齐 session-registry 的 waitForExit 语义:确认窗口到点就结束等待，但
+      // reject 明确表示“未确认终止”，让 Session 保持 error 并阻止新 handle 并存。
       let survived = false;
       await new Promise<void>((resolve) => {
         let done = false;
@@ -244,10 +247,10 @@ export function createPiStdioTransport(opts: PiStdioTransportOptions): PiTranspo
         const onClose = (): void => finish();
         const killTimer = setTimeout(() => {
           try { child.kill('SIGKILL'); } catch { /* already gone */ }
-          // SIGKILL 后再给确认窗口;超时仍 resolve(尽力而为, 不挂死)。
+          // SIGKILL 后再给确认窗口;超时结束等待，随后以稳定错误 reject。
           confirmTimer = setTimeout(() => {
             survived = true;
-            logger.error('pi process did not confirm exit after SIGKILL — transport close resolves anyway', {
+            logger.error('pi process did not confirm exit after SIGKILL', {
               pid: child.pid,
             });
             finish();
@@ -264,13 +267,19 @@ export function createPiStdioTransport(opts: PiStdioTransportOptions): PiTranspo
       });
       // 子进程 close 事件若已 fireClose 则 closed=true(通知已发);否则这里补
       // 发一次(主动 close 语义:onClose 必须收到终止通知)。
-      // 轮 40-w4-t14 HIGH:未确认退出的 survived 状态经 close 通知暴露给上层
-      // (reason 带标记), 调用方/进程管理器可据此走更强回收路径, 不再当作
-      // 已正常关闭。
+      // 未确认退出只 reject，不能发 onClose（它的语义是进程已终止，PiAgent
+      // 收到后会清 runtime 文件）。child 以后真的 close 时再由全局 listener 通知。
+      const terminationError = survived
+        ? new Error('pi process did not confirm exit after SIGKILL')
+        : null;
+      if (terminationError) {
+        closeFailure = terminationError;
+        throw terminationError;
+      }
       fireClose({
         code: null,
         signal: null,
-        reason: survived ? `pi process survived SIGKILL — close() resolved without confirmed exit` : reason,
+        reason,
       });
     },
 

--- a/packages/maker-core/src/agents/pi/transport.ts
+++ b/packages/maker-core/src/agents/pi/transport.ts
@@ -113,11 +113,11 @@ export function createPiStdioTransport(opts: PiStdioTransportOptions): PiTranspo
   const logger = opts.logger;
 
   let closed = false;
-  // 轮 40-w1 MEDIUM-2:close() 进行中标志 —— 防并发 close 双 SIGTERM(轮 21
-  // 幂等), 与 closed(已通知)分离, 保主动 close 仍触发 onClose。
+  // First close permanently fences writes. Individual termination attempts are
+  // shared while in flight, then cleared after failure so a later owner can
+  // run a fresh SIGTERM -> SIGKILL sequence.
   let closing = false;
-  /** SIGKILL 后未确认退出时，后续 close 继续失败，直到 child 真正发出 close。 */
-  let closeFailure: Error | null = null;
+  let closeAttempt: Promise<void> | null = null;
   let disposeProcessRegistration: (() => void) | undefined;
   if (child.pid != null && child.pid > 0) {
     try {
@@ -185,13 +185,61 @@ export function createPiStdioTransport(opts: PiStdioTransportOptions): PiTranspo
     fireClose({ code: null, signal: null, reason: `pi process error: ${err.message}` });
   });
   child.on('close', (code, signal) => {
-    closeFailure = null;
     fireClose({ code, signal, reason: `pi process exited (code=${code}, signal=${signal})` });
   });
 
   const KILL_GRACE_MS = 3_000;
   // SIGKILL 后确认退出的窗口(轮 40-w4-t3 HIGH —— 对齐 session-registry)。
   const KILL_CONFIRM_MS = 5_000;
+
+  const runCloseAttempt = async (reason: string): Promise<void> => {
+    // Every fresh attempt gets its own timers and close listener. A previous
+    // unconfirmed SIGKILL does not prove the process exited, so retries must
+    // send both signals again instead of replaying a cached error.
+    let survived = false;
+    await new Promise<void>((resolve) => {
+      let done = false;
+      let confirmTimer: NodeJS.Timeout | undefined;
+      const finish = (): void => {
+        if (done) return;
+        done = true;
+        clearTimeout(killTimer);
+        if (confirmTimer) clearTimeout(confirmTimer);
+        child.removeListener('close', onClose);
+        resolve();
+      };
+      const onClose = (): void => finish();
+      const killTimer = setTimeout(() => {
+        try { child.kill('SIGKILL'); } catch { /* already gone */ }
+        confirmTimer = setTimeout(() => {
+          survived = true;
+          logger.error('pi process did not confirm exit after SIGKILL', {
+            pid: child.pid,
+          });
+          finish();
+        }, KILL_CONFIRM_MS);
+        confirmTimer.unref?.();
+      }, KILL_GRACE_MS);
+      killTimer.unref?.();
+      child.once('close', onClose);
+      try {
+        child.kill('SIGTERM');
+      } catch {
+        finish();
+      }
+    });
+
+    if (survived) {
+      // Do not fire onClose: its contract is confirmed process termination.
+      // A late real close remains authoritative through the global listener.
+      throw new Error('pi process did not confirm exit after SIGKILL');
+    }
+    fireClose({
+      code: null,
+      signal: null,
+      reason,
+    });
+  };
 
   return {
     writeLine(line: string): Promise<void> {
@@ -218,69 +266,25 @@ export function createPiStdioTransport(opts: PiStdioTransportOptions): PiTranspo
       return () => { closeHandlers.delete(handler); };
     },
 
-    async close(reason = 'pi transport close()'): Promise<void> {
-      if (closeFailure) throw closeFailure;
-      // 轮 21 H-1 幂等竞态:closed 必须在任何 await 前置位 —— 否则两个并发
-      // close() 都通过守卫、各发一次 SIGTERM + 各设一个 SIGKILL timer。
-      // 轮 40-w1 MEDIUM-2:前置 closed 会吞掉子进程 close 事件的 fireClose,
-      // 主动 close 不再通知 onClose(上层 PiRpcProcess 收不到 pending reject /
-      // onExit 收口)。拆两个状态:closing 防并发, closed 只在真正通知时置位。
-      if (closed || closing) return;
+    close(reason = 'pi transport close()'): Promise<void> {
+      if (closed) return Promise.resolve();
+      if (closeAttempt) return closeAttempt;
+
+      // Keep the write fence after a failed attempt: the process may still be
+      // alive, but it must never resume protocol traffic while owners retry
+      // termination through Session/PiAgent/Maker cleanup paths.
       closing = true;
-      // 优雅关闭:SIGTERM → 宽限期 → SIGKILL → 确认退出。幂等。
-      // 轮 40-w4-t3 HIGH:旧实现 SIGKILL 后无确认超时 —— D-state/平台异常下
-      // close 事件不来, await close() 永久挂住, 上层取消流程无法收口。这里
-      // 对齐 session-registry 的 waitForExit 语义:确认窗口到点就结束等待，但
-      // reject 明确表示“未确认终止”，让 Session 保持 error 并阻止新 handle 并存。
-      let survived = false;
-      await new Promise<void>((resolve) => {
-        let done = false;
-        let confirmTimer: NodeJS.Timeout | undefined;
-        const finish = (): void => {
-          if (done) return;
-          done = true;
-          clearTimeout(killTimer);
-          if (confirmTimer) clearTimeout(confirmTimer);
-          child.removeListener('close', onClose);
-          resolve();
-        };
-        const onClose = (): void => finish();
-        const killTimer = setTimeout(() => {
-          try { child.kill('SIGKILL'); } catch { /* already gone */ }
-          // SIGKILL 后再给确认窗口;超时结束等待，随后以稳定错误 reject。
-          confirmTimer = setTimeout(() => {
-            survived = true;
-            logger.error('pi process did not confirm exit after SIGKILL', {
-              pid: child.pid,
-            });
-            finish();
-          }, KILL_CONFIRM_MS);
-          confirmTimer.unref?.();
-        }, KILL_GRACE_MS);
-        killTimer.unref?.();
-        child.once('close', onClose);
-        try {
-          child.kill('SIGTERM');
-        } catch {
-          finish();
-        }
-      });
-      // 子进程 close 事件若已 fireClose 则 closed=true(通知已发);否则这里补
-      // 发一次(主动 close 语义:onClose 必须收到终止通知)。
-      // 未确认退出只 reject，不能发 onClose（它的语义是进程已终止，PiAgent
-      // 收到后会清 runtime 文件）。child 以后真的 close 时再由全局 listener 通知。
-      const terminationError = survived
-        ? new Error('pi process did not confirm exit after SIGKILL')
-        : null;
-      if (terminationError) {
-        closeFailure = terminationError;
-        throw terminationError;
-      }
-      fireClose({
-        code: null,
-        signal: null,
-        reason,
-      });
+      const attempt = runCloseAttempt(reason);
+      closeAttempt = attempt;
+      void attempt.then(
+        () => {
+          if (closeAttempt === attempt) closeAttempt = null;
+        },
+        () => {
+          if (closeAttempt === attempt) closeAttempt = null;
+        },
+      );
+      return attempt;
     },
 
     get pid(): number | undefined {

--- a/packages/maker-core/src/maker.test.ts
+++ b/packages/maker-core/src/maker.test.ts
@@ -386,6 +386,67 @@ describe('Maker session creation singleflight', () => {
     expect(close).toHaveBeenCalledTimes(2);
   });
 
+  it('detaches active sessions before the creation barrier and reclaims late publications', async () => {
+    const lifecycleStarted = createDeferred();
+    const lifecycleGate = createDeferred();
+    const initialClose = vi.fn(async () => undefined);
+    const lateClose = vi.fn(async () => undefined);
+    const initialHandle = createHandle({ id: 'initial-pi-thread', agentKind: 'pi' });
+    initialHandle.close = initialClose;
+    const lateHandle = createHandle({ id: 'late-pi-thread', agentKind: 'pi' });
+    lateHandle.close = lateClose;
+    const startSession = vi.fn(async (opts: CreateSessionOptions) =>
+      opts.id === 'session-initial' ? initialHandle : lateHandle,
+    );
+    const agent = createAgent(startSession, 'pi');
+    const dispose = vi.fn(async () => undefined);
+    agent.dispose = dispose;
+    const maker = new Maker({
+      agents: { pi: agent },
+      storage: createStorage(),
+      logger: createLogger(),
+      lifecycleHooks: {
+        prepareStartOptions: async (sessionId) => {
+          if (sessionId !== 'session-late') return;
+          lifecycleStarted.resolve();
+          await lifecycleGate.promise;
+        },
+      },
+    });
+
+    await maker.createSession({
+      id: 'session-initial',
+      agentKind: 'pi',
+      workingDir: '/repo',
+      model: 'pi-model',
+    });
+    const creatingLate = maker.createSession({
+      id: 'session-late',
+      agentKind: 'pi',
+      workingDir: '/repo',
+      model: 'pi-model',
+    });
+    await lifecycleStarted.promise;
+
+    const shuttingDown = maker.shutdown();
+    await vi.waitFor(() => expect(initialClose).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() => expect(dispose).toHaveBeenCalledTimes(1));
+    expect(lateClose).not.toHaveBeenCalled();
+
+    lifecycleGate.resolve();
+    await creatingLate;
+    await shuttingDown;
+
+    expect(initialClose).toHaveBeenCalledTimes(1);
+    expect(lateClose).toHaveBeenCalledTimes(1);
+    expect(dispose).toHaveBeenCalledTimes(2);
+    expect(maker.listActiveSessions()).toEqual([]);
+
+    await maker.shutdown();
+    expect(initialClose).toHaveBeenCalledTimes(1);
+    expect(lateClose).toHaveBeenCalledTimes(1);
+  });
+
   it('disposes an agent again after a lifecycle-blocked startup clears the creation barrier', async () => {
     const lifecycleStarted = createDeferred();
     const lifecycleGate = createDeferred();

--- a/packages/maker-core/src/maker.test.ts
+++ b/packages/maker-core/src/maker.test.ts
@@ -386,6 +386,37 @@ describe('Maker session creation singleflight', () => {
     expect(close).toHaveBeenCalledTimes(2);
   });
 
+  it('retains an active session owner when shutdown detach is unconfirmed and retries it later', async () => {
+    let closeAttempts = 0;
+    const close = vi.fn(async () => {
+      closeAttempts += 1;
+      if (closeAttempts === 1) throw new Error('termination unconfirmed');
+    });
+    const handle = createHandle({ id: 'active-pi-thread', agentKind: 'pi' });
+    handle.close = close;
+    const maker = new Maker({
+      agents: { pi: createAgent(async () => handle, 'pi') },
+      storage: createStorage(),
+      logger: createLogger(),
+    });
+    const session = await maker.createSession({
+      id: 'session-active-cleanup-retry',
+      agentKind: 'pi',
+      workingDir: '/repo',
+      model: 'pi-model',
+    });
+
+    await maker.shutdown();
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(session.getStatus()).toBe('error');
+    expect(maker.listActiveSessions()).toEqual([session]);
+
+    await maker.shutdown();
+    expect(close).toHaveBeenCalledTimes(2);
+    expect(session.getStatus()).toBe('closed');
+    expect(maker.listActiveSessions()).toEqual([]);
+  });
+
   it('detaches active sessions before the creation barrier and reclaims late publications', async () => {
     const lifecycleStarted = createDeferred();
     const lifecycleGate = createDeferred();

--- a/packages/maker-core/src/maker.test.ts
+++ b/packages/maker-core/src/maker.test.ts
@@ -112,6 +112,7 @@ function createAgent(
       extraDirs: { supported: false },
     },
     startSession,
+    async dispose() {},
   } as unknown as BaseAgent;
 }
 
@@ -312,6 +313,158 @@ describe('Maker session creation singleflight', () => {
     await expect(maker.createSession(options)).resolves.toBeInstanceOf(Session);
     expect(firstClose).toHaveBeenCalledTimes(3);
     expect(startSession).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries quarantined unpublished handles during shutdown and remains idempotent', async () => {
+    let cleanupCanSucceed = false;
+    const close = vi.fn(async () => {
+      if (!cleanupCanSucceed) throw new Error('termination unconfirmed');
+    });
+    const failedHandle = createHandle({ id: 'pi-orphan', agentKind: 'pi' });
+    failedHandle.close = close;
+    const storage = createStorage();
+    storage.create = vi.fn(async () => {
+      throw new Error('db lock');
+    });
+    const maker = new Maker({
+      agents: { pi: createAgent(async () => failedHandle, 'pi') },
+      storage,
+      logger: createLogger(),
+    });
+    const options: CreateSessionOptions = {
+      id: 'session-shutdown-cleanup',
+      agentKind: 'pi',
+      workingDir: '/repo',
+      model: 'pi-model',
+    };
+
+    await expect(maker.createSession(options)).rejects.toThrow('db lock');
+    expect(close).toHaveBeenCalledTimes(1);
+
+    cleanupCanSucceed = true;
+    await maker.shutdown();
+    await maker.shutdown();
+
+    expect(close).toHaveBeenCalledTimes(2);
+  });
+
+  it('reclaims a cleanup entry registered after shutdown begins', async () => {
+    const storageStarted = createDeferred();
+    const storageGate = createDeferred();
+    let closeAttempt = 0;
+    const close = vi.fn(async () => {
+      closeAttempt += 1;
+      if (closeAttempt === 1) throw new Error('termination unconfirmed');
+    });
+    const failedHandle = createHandle({ id: 'pi-late-orphan', agentKind: 'pi' });
+    failedHandle.close = close;
+    const storage = createStorage();
+    storage.create = vi.fn(async () => {
+      storageStarted.resolve();
+      await storageGate.promise;
+      throw new Error('db lock');
+    });
+    const maker = new Maker({
+      agents: { pi: createAgent(async () => failedHandle, 'pi') },
+      storage,
+      logger: createLogger(),
+    });
+    const options: CreateSessionOptions = {
+      id: 'session-late-shutdown-cleanup',
+      agentKind: 'pi',
+      workingDir: '/repo',
+      model: 'pi-model',
+    };
+
+    const creating = maker.createSession(options);
+    await storageStarted.promise;
+    const shuttingDown = maker.shutdown();
+    storageGate.resolve();
+
+    await expect(creating).rejects.toThrow('db lock');
+    await shuttingDown;
+    expect(close).toHaveBeenCalledTimes(2);
+  });
+
+  it('disposes an agent again after a lifecycle-blocked startup clears the creation barrier', async () => {
+    const lifecycleStarted = createDeferred();
+    const lifecycleGate = createDeferred();
+    const close = vi.fn(async () => undefined);
+    const handle = createHandle({ id: 'late-codex-thread' });
+    handle.close = close;
+    const startSession = vi.fn(async () => handle);
+    const agent = createAgent(startSession);
+    const dispose = vi.fn(async () => undefined);
+    agent.dispose = dispose;
+    const maker = new Maker({
+      agents: { codex: agent },
+      storage: createStorage(),
+      logger: createLogger(),
+      lifecycleHooks: {
+        prepareStartOptions: async () => {
+          lifecycleStarted.resolve();
+          await lifecycleGate.promise;
+        },
+      },
+    });
+    const options: CreateSessionOptions = {
+      id: 'session-late-codex-host',
+      agentKind: 'codex',
+      workingDir: '/repo',
+      model: 'gpt-5.4',
+    };
+
+    const creating = maker.createSession(options);
+    await lifecycleStarted.promise;
+    const shuttingDown = maker.shutdown();
+    await vi.waitFor(() => expect(dispose).toHaveBeenCalledTimes(1));
+    expect(startSession).not.toHaveBeenCalled();
+
+    lifecycleGate.resolve();
+    await creating;
+    await shuttingDown;
+
+    expect(startSession).toHaveBeenCalledTimes(1);
+    expect(dispose).toHaveBeenCalledTimes(2);
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it('fences replacement creation while late shutdown cleanup is in flight', async () => {
+    const closeGate = createDeferred();
+    let closeAttempt = 0;
+    const failedClose = vi.fn(async () => {
+      closeAttempt += 1;
+      if (closeAttempt === 1) throw new Error('termination unconfirmed');
+      await closeGate.promise;
+    });
+    const failedHandle = createHandle({ id: 'pi-orphan', agentKind: 'pi' });
+    failedHandle.close = failedClose;
+    const startSession = vi.fn().mockResolvedValue(failedHandle);
+    const storage = createStorage();
+    storage.create = vi.fn(async () => {
+      throw new Error('db lock');
+    });
+    const maker = new Maker({
+      agents: { pi: createAgent(startSession, 'pi') },
+      storage,
+      logger: createLogger(),
+    });
+    const options: CreateSessionOptions = {
+      id: 'session-shutdown-owner-race',
+      agentKind: 'pi',
+      workingDir: '/repo',
+      model: 'pi-model',
+    };
+
+    await expect(maker.createSession(options)).rejects.toThrow('db lock');
+    const shuttingDown = maker.shutdown();
+    await vi.waitFor(() => expect(failedClose).toHaveBeenCalledTimes(2));
+    await expect(maker.createSession(options)).rejects.toThrow(/shutting down/);
+    expect(startSession).toHaveBeenCalledTimes(1);
+
+    closeGate.resolve();
+    await shuttingDown;
+    expect(failedClose).toHaveBeenCalledTimes(2);
   });
 
   it('rejects a second business task using the same live Codex thread until close completes', async () => {

--- a/packages/maker-core/src/maker.test.ts
+++ b/packages/maker-core/src/maker.test.ts
@@ -275,6 +275,45 @@ describe('Maker session creation singleflight', () => {
     void origCreate;
   });
 
+  it('blocks a replacement spawn until an unpublished handle is confirmed closed', async () => {
+    let cleanupCanSucceed = false;
+    const firstClose = vi.fn(async () => {
+      if (!cleanupCanSucceed) throw new Error('termination unconfirmed');
+    });
+    const firstHandle = createHandle({ id: 'pi-orphan', agentKind: 'pi' });
+    firstHandle.close = firstClose;
+    const replacementHandle = createHandle({ id: 'pi-replacement', agentKind: 'pi' });
+    const startSession = vi.fn()
+      .mockResolvedValueOnce(firstHandle)
+      .mockResolvedValueOnce(replacementHandle);
+    const storage = createStorage();
+    const originalCreate = storage.create;
+    storage.create = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('db lock'))
+      .mockImplementation((input) => originalCreate.call(storage, input));
+    const maker = new Maker({
+      agents: { pi: createAgent(startSession, 'pi') },
+      storage,
+      logger: createLogger(),
+    });
+    const options: CreateSessionOptions = {
+      id: 'session-storage-cleanup-fail',
+      agentKind: 'pi',
+      workingDir: '/repo',
+      model: 'pi-model',
+    };
+
+    await expect(maker.createSession(options)).rejects.toThrow('db lock');
+    await expect(maker.createSession(options)).rejects.toThrow('termination unconfirmed');
+    expect(startSession).toHaveBeenCalledTimes(1);
+
+    cleanupCanSucceed = true;
+    await expect(maker.createSession(options)).resolves.toBeInstanceOf(Session);
+    expect(firstClose).toHaveBeenCalledTimes(3);
+    expect(startSession).toHaveBeenCalledTimes(2);
+  });
+
   it('rejects a second business task using the same live Codex thread until close completes', async () => {
     const threadId = '11111111-1111-1111-1111-111111111111';
     const closeGate = createDeferred();
@@ -2189,7 +2228,9 @@ describe('Session turn send guard', () => {
     releaseEnd();
     await closed;
 
-    await expect(sendPromise).resolves.toEqual({ accepted: false, reason: 'cancelled-before-dispatch' });
+    await expect(sendPromise).rejects.toMatchObject({
+      code: 'TURN_DISPATCH_UNCONFIRMED',
+    });
     expect(terminalErrors).toContainEqual(expect.objectContaining({
       type: 'error',
       data: expect.objectContaining({
@@ -2277,7 +2318,9 @@ describe('Session turn send guard', () => {
       });
     });
 
-    await session.send('first');
+    await expect(session.send('first')).rejects.toMatchObject({
+      code: 'TURN_DISPATCH_UNCONFIRMED',
+    });
     await statusChanged;
     await session.abort();
 
@@ -2402,7 +2445,9 @@ describe('Session turn send guard', () => {
     const sendPromise = session.send('first');
     await closed;
     releaseSend();
-    await sendPromise;
+    await expect(sendPromise).rejects.toMatchObject({
+      code: 'TURN_DISPATCH_UNCONFIRMED',
+    });
 
     expect(terminalReasons).toEqual(['original_terminal']);
   });
@@ -2492,7 +2537,9 @@ describe('Session turn send guard', () => {
     releaseCrash();
     await closed;
 
-    await expect(secondSend).resolves.toEqual({ accepted: false, reason: 'cancelled-before-dispatch' });
+    await expect(secondSend).rejects.toMatchObject({
+      code: 'TURN_DISPATCH_UNCONFIRMED',
+    });
     expect(terminalReasons).toEqual(['prior_terminal', 'session_event_loop_crashed']);
   });
 

--- a/packages/maker-core/src/maker.ts
+++ b/packages/maker-core/src/maker.ts
@@ -306,6 +306,12 @@ interface CodexThreadClaimLease {
   release(): void;
 }
 
+interface FailedHandleCleanup {
+  handle: AgentSessionHandle;
+  promise: Promise<void> | null;
+  onCleaned?: () => void;
+}
+
 export class Maker {
   protected readonly agents: Partial<Record<AgentKind, BaseAgent>>;
   protected readonly storage: SessionStorage;
@@ -322,6 +328,11 @@ export class Maker {
     string,
     { promise: Promise<Session> }
   >();
+  /**
+   * startSession 已返回、但 Session 尚未发布时 cleanup 失败的 handle。后续同 id
+   * create 必须先把它确认关闭，不能丢失所有权后再 spawn 一个并存进程。
+   */
+  private readonly failedHandleCleanups = new Map<string, FailedHandleCleanup>();
   /**
    * Codex 0.145 会忽略已加载 thread 的 thread/resume.config。不同 Cindy task
    * 若同时复用同一 native thread，后启动者会继续使用前一 Session 的 MCP URL，
@@ -413,6 +424,25 @@ export class Maker {
     };
   }
 
+  private async retryFailedHandleCleanup(sessionId: string): Promise<void> {
+    const entry = this.failedHandleCleanups.get(sessionId);
+    if (!entry) return;
+    const cleanup = entry.promise ?? entry.handle.close();
+    entry.promise = cleanup;
+    try {
+      await cleanup;
+    } catch (error) {
+      if (this.failedHandleCleanups.get(sessionId) === entry && entry.promise === cleanup) {
+        entry.promise = null;
+      }
+      throw error;
+    }
+    if (this.failedHandleCleanups.get(sessionId) === entry) {
+      this.failedHandleCleanups.delete(sessionId);
+      entry.onCleaned?.();
+    }
+  }
+
   /**
    * 创建一个新会话。
    *
@@ -423,6 +453,12 @@ export class Maker {
   async createSession(opts: CreateSessionOptions): Promise<Session> {
     if (!opts.id) {
       return this.createSessionOnce(opts);
+    }
+
+    // Any handle that failed cleanup before publication still owns this
+    // business id. Confirm its shutdown before checking/starting live state.
+    if (this.failedHandleCleanups.has(opts.id)) {
+      await this.retryFailedHandleCleanup(opts.id);
     }
 
     // 进程内已经活着或正在启动的 session, 直接复用 (避免 spawn 第二个 SDK)。
@@ -609,15 +645,24 @@ export class Maker {
       // 写失败时, 已启动的 agent handle(PI 远端 daemon session / CC / Codex)必须
       // close, 否则 PI 无 codexThreadClaim 时 handle 不关, 远端 pi-manager session/
       // MCP bridge 残留成「用户看不到、Maker 管不到」的半创建状态。
+      let cleanupFailed = false;
       try {
         await handle.close();
       } catch (closeError) {
+        cleanupFailed = true;
+        this.failedHandleCleanups.set(id, {
+          handle,
+          promise: null,
+          ...(codexThreadClaim
+            ? { onCleaned: () => codexThreadClaim?.release() }
+            : {}),
+        });
         this.logger.warn('failed to close agent handle after session storage failure', {
           sessionId: id,
           error: String(closeError),
         });
       }
-      if (codexThreadClaim) {
+      if (!cleanupFailed && codexThreadClaim) {
         codexThreadClaim.release();
       }
       throw error;

--- a/packages/maker-core/src/maker.ts
+++ b/packages/maker-core/src/maker.ts
@@ -946,9 +946,30 @@ export class Maker {
     const agentEntries = Object.entries(this.agents);
     const errors: Array<{ kind: string; name: string; error: unknown }> = [];
 
-    // Queue agent-level process shutdown before waiting for session creation.
-    // PiAgent.dispose() owns its own startup barrier, so a startup that fails
-    // after this point can still publish a quarantine entry and be reclaimed.
+    // Snapshot current sessions before the creation barrier. Existing local
+    // Claude/PI processes must start terminating immediately; a stuck startup
+    // must not consume the entire host quit window before their detach begins.
+    const initialSessionSnapshot = Array.from(this.activeSessions.values());
+    const initialSessionIdentities = new Set(initialSessionSnapshot);
+    const queueSessionDetaches = (
+      sessions: readonly Session[],
+      phase: 'initial' | 'late',
+    ): Array<Promise<void>> => {
+      for (const session of sessions) {
+        if (!this.closeReasons.has(session)) this.closeReasons.set(session, 'requested');
+      }
+      return sessions.map((session) =>
+        Promise.resolve()
+          .then(() => session.detach())
+          .catch((e) => {
+            errors.push({ kind: `session-${phase}`, name: session.id, error: e });
+          }),
+      );
+    };
+
+    // Queue agent-level process shutdown and the initial Session snapshot
+    // before waiting for session creation. PiAgent.dispose() owns its startup
+    // barrier; Session detach owns already-published local agent processes.
     const initialAgentDisposes = agentEntries.map(([kind, agent]) =>
       Promise.resolve()
         .then(() => agent.dispose())
@@ -956,10 +977,11 @@ export class Maker {
           errors.push({ kind: 'agent', name: kind, error: e });
         }),
     );
+    const initialSessionDetaches = queueSessionDetaches(initialSessionSnapshot, 'initial');
 
     // createSession registers its promise before yielding. Blocking new calls
     // above makes this a stable barrier: after it settles, every handle started
-    // before shutdown is either active or present in failedHandleCleanups.
+    // before shutdown is active, closed, or present in failedHandleCleanups.
     const creationSnapshot = Array.from(this.pendingSessionCreations);
     await Promise.allSettled(creationSnapshot);
 
@@ -971,18 +993,13 @@ export class Maker {
         }),
     );
 
-    // Snapshot only after the creation barrier. Status listeners mutate
-    // activeSessions during close, so iteration must use a stable array.
-    const sessSnapshot = Array.from(this.activeSessions.values());
+    // Only sessions published while the creation barrier was settling belong
+    // to the late pass. Identity filtering avoids detaching an initial Session
+    // twice when it remains in activeSessions until its first detach settles.
+    const lateSessionSnapshot = Array.from(this.activeSessions.values())
+      .filter((session) => !initialSessionIdentities.has(session));
+    const lateSessionDetaches = queueSessionDetaches(lateSessionSnapshot, 'late');
     const failedHandleCleanupSnapshot = Array.from(this.failedHandleCleanups.entries());
-
-    // shutdown() calls detach() directly instead of closeSession(), so record
-    // the explicit cause before any asynchronous close callback can run. This
-    // prevents app exit from looking like an unexpected provider rebuild and
-    // accidentally preserving an automatic retry lease.
-    for (const session of sessSnapshot) {
-      if (!this.closeReasons.has(session)) this.closeReasons.set(session, 'requested');
-    }
 
     const failedHandleCloses = failedHandleCleanupSnapshot.map(([sessionId, entry]) =>
       Promise.resolve()
@@ -992,18 +1009,11 @@ export class Maker {
         }),
     );
 
-    const sessionCloses = sessSnapshot.map((s) =>
-      Promise.resolve()
-        .then(() => s.detach())
-        .catch((e) => {
-          errors.push({ kind: 'session', name: s.id, error: e });
-        }),
-    );
-
     await Promise.allSettled([
+      ...initialSessionDetaches,
       ...finalAgentDisposes,
       ...failedHandleCloses,
-      ...sessionCloses,
+      ...lateSessionDetaches,
     ]);
 
     if (errors.length > 0) {

--- a/packages/maker-core/src/maker.ts
+++ b/packages/maker-core/src/maker.ts
@@ -328,6 +328,10 @@ export class Maker {
     string,
     { promise: Promise<Session> }
   >();
+  /** All create paths, including anonymous ids, that may still publish or quarantine a handle. */
+  private readonly pendingSessionCreations = new Set<Promise<Session>>();
+  /** Once shutdown starts, no new handle may race past its creation barrier. */
+  private shutdownStarted = false;
   /**
    * startSession 已返回、但 Session 尚未发布时 cleanup 失败的 handle。后续同 id
    * create 必须先把它确认关闭，不能丢失所有权后再 spawn 一个并存进程。
@@ -424,9 +428,12 @@ export class Maker {
     };
   }
 
-  private async retryFailedHandleCleanup(sessionId: string): Promise<void> {
+  private async retryFailedHandleCleanup(
+    sessionId: string,
+    expectedEntry?: FailedHandleCleanup,
+  ): Promise<void> {
     const entry = this.failedHandleCleanups.get(sessionId);
-    if (!entry) return;
+    if (!entry || (expectedEntry && entry !== expectedEntry)) return;
     const cleanup = entry.promise ?? entry.handle.close();
     entry.promise = cleanup;
     try {
@@ -451,6 +458,19 @@ export class Maker {
    * 继续聊"以及多个后台入口同时恢复同一会话的场景。
    */
   async createSession(opts: CreateSessionOptions): Promise<Session> {
+    if (this.shutdownStarted) {
+      throw new Error('Maker is shutting down; refusing to create a new session');
+    }
+    const creation = this.createSessionWhileRunning(opts);
+    this.pendingSessionCreations.add(creation);
+    try {
+      return await creation;
+    } finally {
+      this.pendingSessionCreations.delete(creation);
+    }
+  }
+
+  private async createSessionWhileRunning(opts: CreateSessionOptions): Promise<Session> {
     if (!opts.id) {
       return this.createSessionOnce(opts);
     }
@@ -922,12 +942,39 @@ export class Maker {
    * 失败一律 swallow + 聚合日志, 不抛 (before-quit 阶段不能阻断退出流程)。
    */
   async shutdown(): Promise<void> {
-    // snapshot 必须先做 (status listener 在 close 完成后会从 activeSessions 删条目,
-    // 不 snapshot 则迭代到一半 Map mutate)。
-    const sessSnapshot = Array.from(this.activeSessions.values());
+    this.shutdownStarted = true;
     const agentEntries = Object.entries(this.agents);
-
     const errors: Array<{ kind: string; name: string; error: unknown }> = [];
+
+    // Queue agent-level process shutdown before waiting for session creation.
+    // PiAgent.dispose() owns its own startup barrier, so a startup that fails
+    // after this point can still publish a quarantine entry and be reclaimed.
+    const initialAgentDisposes = agentEntries.map(([kind, agent]) =>
+      Promise.resolve()
+        .then(() => agent.dispose())
+        .catch((e) => {
+          errors.push({ kind: 'agent', name: kind, error: e });
+        }),
+    );
+
+    // createSession registers its promise before yielding. Blocking new calls
+    // above makes this a stable barrier: after it settles, every handle started
+    // before shutdown is either active or present in failedHandleCleanups.
+    const creationSnapshot = Array.from(this.pendingSessionCreations);
+    await Promise.allSettled(creationSnapshot);
+
+    const finalAgentDisposes = agentEntries.map(([kind, agent], index) =>
+      initialAgentDisposes[index]!
+        .then(() => agent.dispose())
+        .catch((e) => {
+          errors.push({ kind: 'agent-final', name: kind, error: e });
+        }),
+    );
+
+    // Snapshot only after the creation barrier. Status listeners mutate
+    // activeSessions during close, so iteration must use a stable array.
+    const sessSnapshot = Array.from(this.activeSessions.values());
+    const failedHandleCleanupSnapshot = Array.from(this.failedHandleCleanups.entries());
 
     // shutdown() calls detach() directly instead of closeSession(), so record
     // the explicit cause before any asynchronous close callback can run. This
@@ -937,19 +984,11 @@ export class Maker {
       if (!this.closeReasons.has(session)) this.closeReasons.set(session, 'requested');
     }
 
-    // **agent.dispose 优先排队**: 微任务 ordering 不是强保证 (dispose 内部还有 await
-    // hostPromise 等 hop), 但先排队意味着 SIGTERM 那一步至少不会被 session-close
-    // 的工作排在后面。真正的 safety net 是下面 Promise.allSettled 永不抛 + lifecycle
-    // 6s 超时 (lifecycle.ts) — 即便某个 disposer hang, agent dispose 已经独立把
-    // SIGTERM 送进 event loop 了, 6s 内可靠送达。
-    // **同步抛防御**: 用 Promise.resolve().then 包一层, 防 dispose() 实现哪天换成
-    // sync function 然后同步抛 — 那种情况下裸 .catch() 自己也炸, 后续的 sessionCloses
-    // 根本来不及构造。
-    const agentDisposes = agentEntries.map(([kind, agent]) =>
+    const failedHandleCloses = failedHandleCleanupSnapshot.map(([sessionId, entry]) =>
       Promise.resolve()
-        .then(() => agent.dispose())
+        .then(() => this.retryFailedHandleCleanup(sessionId, entry))
         .catch((e) => {
-          errors.push({ kind: 'agent', name: kind, error: e });
+          errors.push({ kind: 'unpublished-handle', name: sessionId, error: e });
         }),
     );
 
@@ -961,7 +1000,11 @@ export class Maker {
         }),
     );
 
-    await Promise.allSettled([...agentDisposes, ...sessionCloses]);
+    await Promise.allSettled([
+      ...finalAgentDisposes,
+      ...failedHandleCloses,
+      ...sessionCloses,
+    ]);
 
     if (errors.length > 0) {
       // Maker 没注入 logger; host 端 stdout 能看到 (before-quit 阶段, 不阻塞流程)

--- a/packages/maker-core/src/session-send-outcome.test.ts
+++ b/packages/maker-core/src/session-send-outcome.test.ts
@@ -27,6 +27,24 @@ describe('session send outcome', () => {
     });
   });
 
+  it('preserves an explicit provider rejection as safely undispatched', () => {
+    const result: SessionSendResult = {
+      accepted: false,
+      reason: 'provider-rejected-before-dispatch',
+    };
+    const context = 'goal/session-2/continuation';
+
+    expect(toSessionDispatchOutcome(result, context)).toEqual({
+      dispatched: false,
+      reason: 'provider-rejected-before-dispatch',
+      context,
+      message: 'Provider rejected the Session send before dispatch: goal/session-2/continuation',
+    });
+    expect(() => assertSendDispatched(result, context)).toThrow(
+      'Provider rejected the Session send before dispatch: goal/session-2/continuation',
+    );
+  });
+
   it('asserts dispatched only when send result was accepted', () => {
     const accepted: SessionSendResult = { accepted: true };
     const cancelled: SessionSendResult = {

--- a/packages/maker-core/src/session-send-outcome.ts
+++ b/packages/maker-core/src/session-send-outcome.ts
@@ -4,7 +4,7 @@ export type SessionDispatchOutcome =
   | { dispatched: true }
   | {
       dispatched: false;
-      reason: 'cancelled-before-dispatch';
+      reason: 'cancelled-before-dispatch' | 'provider-rejected-before-dispatch';
       message: string;
       context: string;
     };
@@ -14,11 +14,14 @@ export function toSessionDispatchOutcome(
   context: string,
 ): SessionDispatchOutcome {
   if (result.accepted) return { dispatched: true };
+  const message = result.reason === 'provider-rejected-before-dispatch'
+    ? `Provider rejected the Session send before dispatch: ${context}`
+    : `Session send was cancelled before vendor dispatch: ${context}`;
   return {
     dispatched: false,
     reason: result.reason,
     context,
-    message: `Session send was cancelled before vendor dispatch: ${context}`,
+    message,
   };
 }
 

--- a/packages/maker-core/src/session.close.test.ts
+++ b/packages/maker-core/src/session.close.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import { Session } from './session.js';
-import type { AgentSessionHandle } from './agents/base-agent.js';
+import {
+  TurnDispatchUnconfirmedError,
+  type AgentSessionHandle,
+} from './agents/base-agent.js';
 
 function createLogger() {
   const logger = {
@@ -20,6 +23,96 @@ function createDeferred(): { promise: Promise<void>; resolve: () => void } {
 }
 
 describe('Session close lifecycle', () => {
+  it('closes an ambiguous transport before surfacing an unconfirmed dispatch', async () => {
+    const eventLoop = createDeferred();
+    const abortController = new AbortController();
+    const close = vi.fn(async () => {
+      eventLoop.resolve();
+      // Give the event iterator a chance to publish its queued terminal event
+      // while Session.close() is still awaiting the handle.
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    const handle = {
+      id: 'thread-unconfirmed',
+      agentKind: 'pi',
+      model: 'gpt-5.4',
+      async send() {
+        abortController.abort();
+        throw new TurnDispatchUnconfirmedError('prompt acceptance timed out');
+      },
+      async *events() {
+        await eventLoop.promise;
+        yield {
+          type: 'error',
+          data: { message: 'late close error', isTerminal: true },
+          source: 'pi',
+        } as never;
+      },
+      close,
+      setInteractionResolver() {},
+    } as unknown as AgentSessionHandle;
+    const session = new Session({
+      id: 'session-unconfirmed',
+      agentKind: 'pi',
+      workDir: '/repo',
+      handle,
+      capabilities: {} as never,
+      logger: createLogger() as never,
+    });
+    const events: unknown[] = [];
+    session.onEvent((event) => events.push(event));
+
+    await expect(session.send('continue the goal', {
+      signal: abortController.signal,
+    })).rejects.toMatchObject({
+      code: 'TURN_DISPATCH_UNCONFIRMED',
+    });
+
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(session.getStatus()).toBe('closed');
+    expect(events).toEqual([]);
+  });
+
+  it('keeps a provider-accepted send accepted when cancellation races with its response', async () => {
+    const sendStarted = createDeferred();
+    const providerAccepted = createDeferred();
+    const eventLoop = createDeferred();
+    const abortController = new AbortController();
+    const session = new Session({
+      id: 'session-accepted-cancel-race',
+      agentKind: 'pi',
+      workDir: '/repo',
+      handle: {
+        id: 'thread-accepted-cancel-race',
+        agentKind: 'pi',
+        model: 'gpt-5.4',
+        async send() {
+          sendStarted.resolve();
+          await providerAccepted.promise;
+        },
+        async *events() {
+          await eventLoop.promise;
+          yield* [];
+        },
+        async close() {
+          eventLoop.resolve();
+        },
+        setInteractionResolver() {},
+      } as unknown as AgentSessionHandle,
+      capabilities: {} as never,
+      logger: createLogger() as never,
+    });
+
+    const sending = session.send('continue the goal', { signal: abortController.signal });
+    await sendStarted.promise;
+    abortController.abort();
+    providerAccepted.resolve();
+
+    await expect(sending).resolves.toEqual({ accepted: true });
+    await session.close();
+  });
+
   it('serializes concurrent close calls onto the same transport shutdown', async () => {
     const transportClose = createDeferred();
     const close = vi.fn(() => transportClose.promise);

--- a/packages/maker-core/src/session.close.test.ts
+++ b/packages/maker-core/src/session.close.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { Session } from './session.js';
 import {
+  TurnDispatchRejectedError,
   TurnDispatchUnconfirmedError,
   type AgentSessionHandle,
 } from './agents/base-agent.js';
@@ -72,6 +73,49 @@ describe('Session close lifecycle', () => {
     expect(close).toHaveBeenCalledTimes(1);
     expect(session.getStatus()).toBe('closed');
     expect(events).toEqual([]);
+  });
+
+  it('returns a confirmed provider rejection as safely undispatched and remains reusable', async () => {
+    const eventLoop = createDeferred();
+    const close = vi.fn(async () => {
+      eventLoop.resolve();
+    });
+    let sendAttempts = 0;
+    const session = new Session({
+      id: 'session-provider-rejected',
+      agentKind: 'pi',
+      workDir: '/repo',
+      handle: {
+        id: 'thread-provider-rejected',
+        agentKind: 'pi',
+        model: 'gpt-5.4',
+        async send() {
+          sendAttempts += 1;
+          if (sendAttempts === 1) {
+            throw new TurnDispatchRejectedError('provider rejected before acceptance');
+          }
+        },
+        async *events() {
+          await eventLoop.promise;
+          yield* [];
+        },
+        close,
+        setInteractionResolver() {},
+      } as unknown as AgentSessionHandle,
+      capabilities: {} as never,
+      logger: createLogger() as never,
+    });
+
+    await expect(session.send('continue the goal')).resolves.toEqual({
+      accepted: false,
+      reason: 'provider-rejected-before-dispatch',
+    });
+    expect(session.getStatus()).toBe('active');
+    expect(close).not.toHaveBeenCalled();
+
+    await expect(session.send('continue the goal')).resolves.toEqual({ accepted: true });
+    await session.close();
+    expect(close).toHaveBeenCalledTimes(1);
   });
 
   it('keeps a provider-accepted send accepted when cancellation races with its response', async () => {

--- a/packages/maker-core/src/session.close.test.ts
+++ b/packages/maker-core/src/session.close.test.ts
@@ -377,4 +377,39 @@ describe('Session close lifecycle', () => {
     expect(session.getStatus()).toBe('closed');
     expect(close).toHaveBeenCalledTimes(2);
   });
+
+  it('keeps the status owner when detach fails and publishes closed only after retry', async () => {
+    let attempts = 0;
+    const detach = vi.fn(async () => {
+      attempts += 1;
+      if (attempts === 1) throw new Error('transport detach failed');
+    });
+    const handle = {
+      id: 'thread-detach-retry',
+      agentKind: 'pi',
+      model: 'gpt-5.4',
+      close: vi.fn(async () => {}),
+      detach,
+      setInteractionResolver() {},
+    } as unknown as AgentSessionHandle;
+    const session = new Session({
+      id: 'session-detach-retry',
+      agentKind: 'pi',
+      workDir: '/repo',
+      handle,
+      capabilities: {} as never,
+      logger: createLogger() as never,
+    });
+    const statuses: string[] = [];
+    session.onStatusChange((status) => statuses.push(status));
+
+    await expect(session.detach()).rejects.toThrow('transport detach failed');
+    expect(statuses).toEqual(['error']);
+    expect(session.getStatus()).toBe('error');
+
+    await expect(session.detach()).resolves.toBeUndefined();
+    expect(statuses).toEqual(['error', 'closed']);
+    expect(session.getStatus()).toBe('closed');
+    expect(detach).toHaveBeenCalledTimes(2);
+  });
 });

--- a/packages/maker-core/src/session.ts
+++ b/packages/maker-core/src/session.ts
@@ -845,21 +845,29 @@ export class Session {
     // （vision bridge 等前置 hook 的 fetch），而不是等 handle.detach()/视觉通道超时——
     // 否则 handle.detach() 慢/挂起时，in-flight 视觉请求会继续拖住退出链。
     this.cancelSendReservation(this.sendReservation);
+    let detachSucceeded = false;
     try {
       if (this.handle.detach) {
         await this.handle.detach();
       } else {
         await this.handle.close();
       }
+      detachSucceeded = true;
     } finally {
       this.sendReservation = null;
       this.currentTurnOrigin = null;
       this.currentTurnAttemptToken = null;
       this.clearTerminalErrorDrain();
-      this.setStatus('closed');
       this.eventListeners.clear();
-      this.statusListeners.clear();
       this.interactionListener = null;
+      if (detachSucceeded) {
+        this.setStatus('closed');
+        this.statusListeners.clear();
+      } else {
+        // Shutdown must retain Maker's status listener and active-session owner
+        // until a later detach/close attempt confirms the process is gone.
+        this.setStatus('error');
+      }
     }
   }
 

--- a/packages/maker-core/src/session.ts
+++ b/packages/maker-core/src/session.ts
@@ -50,6 +50,7 @@ import type {
   SendOptions,
   TurnContinuationState,
 } from './agents/base-agent.js';
+import { TurnDispatchUnconfirmedError } from './agents/base-agent.js';
 import type { Logger } from './interfaces/logger.js';
 
 export type SessionStatus = 'active' | 'aborting' | 'closed' | 'error';
@@ -571,14 +572,23 @@ export class Session {
           signal: reservation.abortController.signal,
         });
       } catch (e) {
+        // Cancellation cannot downgrade an explicitly ambiguous provider result
+        // into "cancelled before dispatch"; that would skip the mandatory
+        // transport fence and could leave accepted work running invisibly.
+        if (e instanceof TurnDispatchUnconfirmedError) throw e;
         if (reservation.cancelled) {
           return { accepted: false, reason: 'cancelled-before-dispatch' };
         }
         throw e;
       }
-      if (reservation.cancelled) {
-        return { accepted: false, reason: 'cancelled-before-dispatch' };
+      if (reservation.cancelled && (this.terminationStarted || this.closePromise)) {
+        throw new TurnDispatchUnconfirmedError(
+          `Session ${this.id} terminated before provider acceptance could be reconciled`,
+        );
       }
+      // A resolved handle.send is the provider-acceptance boundary. A signal
+      // racing after that point may request abort, but cannot rewrite history
+      // and report the turn as undispatched.
       turnDispatched = true;
       // turn 真正开始跑 → 起 stall 看门狗。后续每个事件都会重置它，done / 终态
       // error 会清掉它（见 armTurnStallWatchdog）。
@@ -587,6 +597,18 @@ export class Session {
     } catch (e) {
       if (this.sendReservation === reservation) {
         this.sendReservation = null;
+      }
+      if (e instanceof TurnDispatchUnconfirmedError) {
+        // Reserve Session shutdown before closing the handle. This suppresses
+        // a synthetic terminal event from transport teardown and fences any
+        // late provider activity before the orchestrator reports blocked.
+        if (originInstalled && !turnDispatched) {
+          this.currentTurnOrigin = previousTurnOrigin;
+          this.currentTurnAttemptToken = previousTurnAttemptToken;
+          this.turnGeneration = previousTurnGeneration;
+          originInstalled = false;
+        }
+        await this.close();
       }
       throw e;
     } finally {
@@ -1688,8 +1710,9 @@ export class Session {
           // clear that fence. The fence itself prevents any later generation entering.
           observedGeneration = this.turnGeneration;
         }
+        if (this.terminationStarted) continue;
         // origin 打标与终态清理都收在 fanOutEvent 里（看门狗合成的事件共用同一语义，
-        // 见那里的注释）。
+        // 见那里的注释）。关闭门一旦占住，旧 handle 的迟到事件不得再改写业务状态。
         this.fanOutEvent(event, observedGeneration);
       }
     } catch (e) {

--- a/packages/maker-core/src/session.ts
+++ b/packages/maker-core/src/session.ts
@@ -50,7 +50,10 @@ import type {
   SendOptions,
   TurnContinuationState,
 } from './agents/base-agent.js';
-import { TurnDispatchUnconfirmedError } from './agents/base-agent.js';
+import {
+  TurnDispatchRejectedError,
+  TurnDispatchUnconfirmedError,
+} from './agents/base-agent.js';
 import type { Logger } from './interfaces/logger.js';
 
 export type SessionStatus = 'active' | 'aborting' | 'closed' | 'error';
@@ -290,7 +293,10 @@ export interface SessionTurnLifecycleObserver {
  */
 export type SessionSendResult =
   | { accepted: true }
-  | { accepted: false; reason: 'cancelled-before-dispatch' };
+  | {
+      accepted: false;
+      reason: 'cancelled-before-dispatch' | 'provider-rejected-before-dispatch';
+    };
 
 type SendReservation = {
   phase: 'accepting' | 'dispatching';
@@ -496,6 +502,7 @@ export class Session {
     // turnDispatched:handle.send 成功、本次 send 真正成为运行中的 turn。
     let originInstalled = false;
     let turnDispatched = false;
+    let dispatchConfirmedUndispatched = false;
     let previousTurnOrigin: SendOrigin | null = null;
     let previousTurnAttemptToken: number | null = null;
     const turnLifecycleObserver = this.turnLifecycleObserver;
@@ -572,6 +579,13 @@ export class Session {
           signal: reservation.abortController.signal,
         });
       } catch (e) {
+        if (e instanceof TurnDispatchRejectedError) {
+          // The provider returned a trustworthy rejection before accepting any
+          // work. This path is safe to reschedule and must not arm the
+          // ambiguous-tail drain used for unknown dispatch failures.
+          dispatchConfirmedUndispatched = true;
+          return { accepted: false, reason: 'provider-rejected-before-dispatch' };
+        }
         // Cancellation cannot downgrade an explicitly ambiguous provider result
         // into "cancelled before dispatch"; that would skip the mandatory
         // transport fence and could leave accepted work running invisibly.
@@ -630,13 +644,12 @@ export class Session {
         this.currentTurnOrigin = previousTurnOrigin;
         this.currentTurnAttemptToken = previousTurnAttemptToken;
         this.turnGeneration = previousTurnGeneration;
-        // runEventLoop may already be awaiting the failed generation. Reusing
-        // the rolled-back generation immediately creates an ABA window where
-        // a delayed terminal event from this failed dispatch can claim the
-        // next turn's origin/token. Reuse the existing bounded tail fence:
-        // an old terminal event releases it; no tail closes the ambiguous
-        // Session so Maker can rebuild before the next send.
-        this.armTerminalErrorDrain(previousTurnGeneration);
+        // Confirmed provider rejection cannot produce a turn tail, so it may
+        // immediately reuse the rolled-back generation. Other failures retain
+        // the bounded tail fence before another turn can enter.
+        if (!dispatchConfirmedUndispatched) {
+          this.armTerminalErrorDrain(previousTurnGeneration);
+        }
       }
       if (turnLifecyclePrepared && !turnDispatched) {
         try {

--- a/packages/orca-workflow/src/orca-bridge-mcp.ts
+++ b/packages/orca-workflow/src/orca-bridge-mcp.ts
@@ -8,7 +8,16 @@ import {
   ORCA_NESTED_REPORT_ERROR_MESSAGE,
   toSessionDispatchOutcome,
 } from '@cindy/maker-core';
-import type { AgentEvent, AgentKind, Logger, Maker, McpProvider, McpProviderContext, Session } from '@cindy/maker-core';
+import type {
+  AgentEvent,
+  AgentKind,
+  Logger,
+  Maker,
+  McpProvider,
+  McpProviderContext,
+  Session,
+  SessionDispatchOutcome,
+} from '@cindy/maker-core';
 import {
   isProductTurnDoneEvent,
   isTurnContinuationBoundaryEvent,
@@ -288,7 +297,7 @@ function logOrcaSendNotDispatched(
 
 function makeOrcaDispatchToolError(
   meta: OrcaSendMeta,
-  reason: 'cancelled-before-dispatch',
+  reason: Extract<SessionDispatchOutcome, { dispatched: false }>['reason'],
   extra?: Record<string, unknown>,
 ): OrcaToolResult {
   return text({


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 PI 模式 `/goal` 在 prompt 接受前触发长时间自动压缩时被 30 秒通用 RPC 超时中断、随后长期停在 `active / 0 turns` 的问题。投递结果现在严格收敛为三态：已确认接受并由 Goal 接管、已确认未投递并安全重排、接受状态未知则隔离旧 Session 并把 Goal 持久化为 `blocked`，不会盲目重放可能已经产生副作用的指令。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：PI `/goal` 在自动压缩期间出现 `pi rpc timeout after 30000ms: prompt`，持久状态残留为 `active / 0 turns`。
- 本 PR 包含：一条跨 GoalController、Session、Maker 与 PI transport 的完整投递状态机修复，覆盖压缩感知的 prompt 接受、接受竞态、恢复失败和未确认关闭隔离。
- 明确不包含：Goal 指令或 system prompt 改动、UI/文案、PI Subagent 实验、存储 schema/迁移、既有错误 Goal 数据迁移。
- 用户可见变化：健康的 PI 自动压缩可继续等待 prompt 接受；无法确认是否投递时 Goal 显示为 `blocked`，不再假装 `active / 0 turns` 或自动重复执行。
- 是否存在 breaking change：无。

入口规模门结果为非测试代码 `+352 / 9 files`、测试代码 `+453 / 8 files`。规模来自同一条端到端并发状态机的必要边界：Goal 的持久状态收敛、Session 的投递确认/fence、Maker 与 PI process 的失败 cleanup owner 隔离；拆掉任一层都会重新开放假运行、重复派发或同 business session id 双进程路径。未包含无关重构、格式化或依赖升级。maker-core 路径命中 `arch-gate`，按人工门流程等待放行。

目标环境：Desktop 的 PI agent + `/goal`。
部署前置：无。
环境 / migration / 依赖结论：无配置、数据库 schema、migration 或依赖变更。

### UI 变化

不涉及。

- 引用的设计规范：不涉及。

## 怎么验证的

### 自动验证

```text
GoalController / Session restore 定向测试：157 tests passed
Maker / PI / Session 关键状态机定向测试：113 tests passed
pnpm --filter @cindy/maker-core test
结果：1,056 tests passed，43 个条件性 integration tests skipped

pnpm --filter desktop typecheck
结果：通过

涉及文件 ESLint + git diff --check
结果：通过

pnpm test:unit:related
结果：Desktop 25,708 tests passed；2 个与本 PR 无关的
GhostInstallReceiptStore setup receipt tests failed。两项失败已在干净的 upstream/main
checkout 独立复现，本 PR 未修改对应实现、测试或插件协议路径。

pnpm check:dco
结果：1 commit signed off
```

### 手工验证

未运行真实 PI 模型端到端。此次按可确定的状态机边界与故障注入测试完成验证，没有向真实模型发出 Goal 或触发工具副作用。

复验步骤：在接近上下文上限的 Desktop PI 会话设置 `/goal`；确认自动压缩期间不会在 30 秒中断；压缩完成后首轮进入运行并正常续轮；分别验证 Stop/Resume；注入 prompt acceptance 超时或关闭失败时，确认 Goal 进入带原因的 `blocked`，且同 business session id 不会生成第二个 PI 进程。

### 未执行的验证

- 未执行真实 PI 端到端，原因是本修复的核心是投递确认与副作用 exactly-once 边界，真实模型运行无法稳定制造 acceptance/termination 竞态；已由 deterministic failure injection 覆盖。
- 未取得全绿的 `pnpm test:unit:related`，仅有上面两项已在干净 upstream/main 复现的既有 `ghostInstallReceipt` 失败。
- `@cindy/maker-core` 没有独立 `typecheck` script；其 `build` 当前受仓库既有测试 mock typing 错误阻塞，本 PR 的运行时代码由 maker-core 测试、Desktop typecheck 和 ESLint 覆盖。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：并发投递、Session 生命周期与 PI 子进程清理语义

### 影响与回滚

- 影响范围：Desktop PI Goal 的 prompt acceptance、Goal 轮次调度、通用 Session 在“provider 是否接受本轮”未知时的关闭/fence，以及未发布 Maker/PI handle 的失败 cleanup 所有权。Claude Code/Codex 的正常确认投递路径不变；共享 Session 仅在接受状态未知的异常路径采用更保守的显式错误。
- 回滚 / 降级方式：revert 本 PR 的单一 commit `360133ed9`；回滚后 PI 长压缩会重新受 30 秒 prompt RPC 超时影响，历史 `active / 0 turns` 问题也会恢复。运行时无需数据回滚或配置迁移。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
