### PR TITLE
fix(chat): 发送后继续自动跟随最新消息

### DIFF
--- a/apps/desktop/src/renderer/__tests__/autoFollowIntent.test.ts
+++ b/apps/desktop/src/renderer/__tests__/autoFollowIntent.test.ts
@@ -6,12 +6,15 @@
  * 才能停止自动滚动。修复后解除跟随走事件意图(wheel / touch / 键盘),恢复
  * 跟随走「距离 + 向下方向」。三个纯函数的规则见 autoFollowIntent.ts 模块注释。
  */
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 import {
   resolveLastUserMessageObservation,
   resolveNearBottomOnScroll,
   resolveRenderPinDecision,
+  resolveSendWindowHandoff,
   selectTailUserMessageId,
   shouldUnpinOnUpIntent,
   shouldUnpinOnWheel,
@@ -81,7 +84,7 @@ describe('shouldUnpinOnUpIntent', () => {
 describe('resolveNearBottomOnScroll', () => {
   const BASE = { thresholdPx: 100, directionDeadZonePx: 1 };
 
-  it('距底超过阈值 → 一律 false(滚动条拖拽等无 wheel 路径的解除兜底)', () => {
+  it('距底超过阈值 + 明确上滚 / 已解除 → false(滚动条拖拽等无 wheel 路径的解除兜底)', () => {
     expect(
       resolveNearBottomOnScroll({
         ...BASE,
@@ -98,6 +101,33 @@ describe('resolveNearBottomOnScroll', () => {
         scrollDelta: 40,
       }),
     ).toBe(false);
+  });
+
+  it('已在跟 + 距底越线但未上滚 → 保持跟随(发送后内容长高 / 迟到 pin 的 scroll 不得解除)', () => {
+    expect(
+      resolveNearBottomOnScroll({
+        ...BASE,
+        wasNearBottom: true,
+        distanceFromBottom: 400,
+        scrollDelta: 0,
+      }),
+    ).toBe(true);
+    expect(
+      resolveNearBottomOnScroll({
+        ...BASE,
+        wasNearBottom: true,
+        distanceFromBottom: 400,
+        scrollDelta: 80,
+      }),
+    ).toBe(true);
+    expect(
+      resolveNearBottomOnScroll({
+        ...BASE,
+        wasNearBottom: true,
+        distanceFromBottom: 400,
+        scrollDelta: -1,
+      }),
+    ).toBe(true);
   });
 
   it('阈值带内 + 原本在跟 → 保持跟随(布局钳位 / 滚动条微拖的被动上移不解除)', () => {
@@ -272,6 +302,54 @@ describe('selectTailUserMessageId', () => {
   });
 });
 
+describe('resolveSendWindowHandoff', () => {
+  it('local send leaves any anchored window so later tail items keep following', () => {
+    expect(
+      resolveSendWindowHandoff({
+        isNewUserSend: true,
+        sentFromThisRenderer: true,
+        hasWindowAnchor: true,
+        windowCoversEnd: true,
+      }),
+    ).toEqual({ clearWindowAnchor: true, deferPinToNextRender: false });
+    expect(
+      resolveSendWindowHandoff({
+        isNewUserSend: true,
+        sentFromThisRenderer: true,
+        hasWindowAnchor: true,
+        windowCoversEnd: false,
+      }),
+    ).toEqual({ clearWindowAnchor: true, deferPinToNextRender: true });
+  });
+
+  it('does not touch the default tail window or an external injection', () => {
+    expect(
+      resolveSendWindowHandoff({
+        isNewUserSend: true,
+        sentFromThisRenderer: true,
+        hasWindowAnchor: false,
+        windowCoversEnd: true,
+      }),
+    ).toEqual({ clearWindowAnchor: false, deferPinToNextRender: false });
+    expect(
+      resolveSendWindowHandoff({
+        isNewUserSend: true,
+        sentFromThisRenderer: false,
+        hasWindowAnchor: true,
+        windowCoversEnd: false,
+      }),
+    ).toEqual({ clearWindowAnchor: false, deferPinToNextRender: false });
+    expect(
+      resolveSendWindowHandoff({
+        isNewUserSend: false,
+        sentFromThisRenderer: true,
+        hasWindowAnchor: true,
+        windowCoversEnd: true,
+      }),
+    ).toEqual({ clearWindowAnchor: false, deferPinToNextRender: false });
+  });
+});
+
 describe('resolveLastUserMessageObservation', () => {
   it('seeds a restored user tail hydrated after mount without treating it as a send', () => {
     expect(
@@ -297,5 +375,18 @@ describe('resolveLastUserMessageObservation', () => {
       baselineUserMessageId: 'historical-user',
       isNewUserSend: true,
     });
+  });
+});
+
+describe('MessageStream send-window handoff wiring', () => {
+  it('clears any anchored window on a local send and only defers pin for stale slices', () => {
+    const source = readFileSync(
+      resolve(__dirname, '../components/chat/MessageStream.tsx'),
+      'utf8',
+    );
+    expect(source).toContain('resolveSendWindowHandoff({');
+    expect(source).toContain('if (windowHandoff.clearWindowAnchor)');
+    expect(source).toContain('if (decision.pinToBottom && !windowHandoff.deferPinToNextRender)');
+    expect(source).not.toContain('realTailUserSendOutsideWindow');
   });
 });

--- a/apps/desktop/src/renderer/components/chat/MessageStream.tsx
+++ b/apps/desktop/src/renderer/components/chat/MessageStream.tsx
@@ -283,6 +283,7 @@ import {
   resolveNearBottomOnScroll,
   resolveLastUserMessageObservation,
   resolveRenderPinDecision,
+  resolveSendWindowHandoff,
   selectTailUserMessageId,
   shouldUnpinOnUpIntent,
   shouldUnpinOnWheel,
@@ -4354,45 +4355,41 @@ export function MessageStream({
             ? visibleLastItem.message
             : null;
 
-    // 锚定窗口外检测到真实的新发送：当前 effect 的 visibleRenderItems 仍是旧切片，
-    // 不能同帧 pinToBottom。先清锚并恢复 near-bottom，下一次 render 切回默认尾窗
-    // 后再自然 pin；提前同步 lastUserMsgIdRef，防下一帧重复判成新发送。
-    let windowAnchorClearedOnSend = false;
-    const realTailUserSendOutsideWindow =
-      !restoringRef.current &&
-      firstVisibleItemKey !== null &&
-      !windowCoversEnd &&
-      lastUserMsg !== null &&
-      lastUserMsg.clientId !== lastUserMsgIdRef.current;
-    if (realTailUserSendOutsideWindow) {
-      setFirstVisibleItemKey(null);
-      isNearBottomRef.current = true;
-      setIsNearBottom(true);
-      setUnreadCount(0);
-      lastUserMsgIdRef.current = lastUserMsg.clientId;
-      windowAnchorClearedOnSend = true;
-    }
+    // #2194: 未提供回调时按既有语义视为本端发送（测试 / 其它消费方不变）；
+    // 提供了回调就严格以其返回值为准——实现方误返回 undefined（如被 as any
+    // 绕过）时按外部注入处理，不用 ?? true 掩盖（Copilot review nit）。
+    const sentFromThisRenderer = lastUserMsg
+      ? isLocalUserSend
+        ? isLocalUserSend(lastUserMsg.clientId) === true
+        : true
+      : false;
     const userMessageObservation = resolveLastUserMessageObservation({
       restoring: restoringRef.current,
       tailUserMessageId: lastUserMsg?.clientId ?? null,
       previousTailUserMessageId: lastUserMsgIdRef.current,
     });
-    if (!windowAnchorClearedOnSend) {
-      lastUserMsgIdRef.current = userMessageObservation.baselineUserMessageId;
-    }
+    lastUserMsgIdRef.current = userMessageObservation.baselineUserMessageId;
     const decision = resolveRenderPinDecision({
       restoring: restoringRef.current,
       newUserSend: userMessageObservation.isNewUserSend,
-      // #2194: 未提供回调时按既有语义视为本端发送（测试 / 其它消费方不变）；
-      // 提供了回调就严格以其返回值为准——实现方误返回 undefined（如被 as any
-      // 绕过）时按外部注入处理，不用 ?? true 掩盖（Copilot review nit）。
-      sentFromThisRenderer: lastUserMsg
-        ? isLocalUserSend
-          ? isLocalUserSend(lastUserMsg.clientId) === true
-          : true
-        : false,
+      sentFromThisRenderer,
       nearBottom: isNearBottomRef.current,
     });
+    // 本端发送必须离开锚定历史窗，回到默认尾窗。只清「未覆盖末尾」的锚会漏掉
+    // 「发送时窗口仍盖住末尾、随后 assistant/工具卡把尾部顶出窗口」——视口已经
+    // 钉到最新，下一轮新消息却不再跟随。
+    const windowHandoff = resolveSendWindowHandoff({
+      isNewUserSend: userMessageObservation.isNewUserSend,
+      sentFromThisRenderer,
+      hasWindowAnchor: firstVisibleItemKey !== null,
+      windowCoversEnd,
+    });
+    if (windowHandoff.clearWindowAnchor) {
+      setFirstVisibleItemKey(null);
+      isNearBottomRef.current = true;
+      setIsNearBottom(true);
+      setUnreadCount(0);
+    }
 
     if (userMessageObservation.isNewUserSend && lastUserMsg) {
       lastUserMsgIdRef.current = lastUserMsg.clientId;
@@ -4401,7 +4398,7 @@ export function MessageStream({
       restoringRef.current = false;
       isNearBottomRef.current = true;
     }
-    if (decision.pinToBottom && !windowAnchorClearedOnSend) pinToBottom();
+    if (decision.pinToBottom && !windowHandoff.deferPinToNextRender) pinToBottom();
 
     const el = scrollRef.current;
     if (el) prevScrollTopRef.current = el.scrollTop;
@@ -4762,7 +4759,8 @@ export function MessageStream({
   // 与 pinToBottom 高频竞态(小幅上滚永远越不过距离阈值就被钉回,且
   // programmaticScrollRef 窗口会吞掉部分用户 scroll 事件),距离判定对
   // 「上滚一行就停」不可靠。本 handler 只负责:
-  //   - 离底 >= threshold → 解除(滚动条拖拽等无 wheel 事件路径的兜底);
+  //   - 离底 >= threshold 且明确上滚 → 解除(滚动条拖拽等无 wheel 路径的兜底);
+  //     已在跟时内容在下方长高不得解除,否则发送后第一块新内容会把跟随掐死;
   //   - 已解除 + 明确向下滚回阈值带内 → 恢复跟随。
   // 迁移规则收敛在 resolveNearBottomOnScroll(纯函数,见 autoFollowIntent.ts)。
   // `isNearBottomRef`(auto-follow gate)与 `isNearBottom` state(指示器显隐)

--- a/apps/desktop/src/renderer/components/chat/autoFollowIntent.ts
+++ b/apps/desktop/src/renderer/components/chat/autoFollowIntent.ts
@@ -195,6 +195,49 @@ export function resolveRenderPinDecision({
   return { clearRestoring: false, pinToBottom: nearBottom };
 }
 
+export interface ResolveSendWindowHandoffArgs {
+  /** The current render introduced a new user message at the tail. */
+  isNewUserSend: boolean;
+  /** The tail user message was sent from this renderer's composer. */
+  sentFromThisRenderer: boolean;
+  /** The stream is currently showing an anchored (non-default-tail) window. */
+  hasWindowAnchor: boolean;
+  /** The current bounded window already includes the real session tail. */
+  windowCoversEnd: boolean;
+}
+
+export interface ResolveSendWindowHandoff {
+  /** Local send while reading an anchored window: switch back to the default tail. */
+  clearWindowAnchor: boolean;
+  /**
+   * The current visible slice does not include the real tail, so pinning this
+   * frame would land on the old slice. Wait for the next render's tail window.
+   */
+  deferPinToNextRender: boolean;
+}
+
+/**
+ * After a local send, leave any historical render window so later assistant /
+ * tool items keep auto-following the real tail.
+ *
+ * An anchored window that still covers the end at send time would otherwise
+ * stay anchored; the next appended items flip `windowCoversEnd` to false and
+ * the stream treats that as "left the bottom", stopping follow. External
+ * injections must not take this handoff (#2194).
+ */
+export function resolveSendWindowHandoff({
+  isNewUserSend,
+  sentFromThisRenderer,
+  hasWindowAnchor,
+  windowCoversEnd,
+}: ResolveSendWindowHandoffArgs): ResolveSendWindowHandoff {
+  const clearWindowAnchor = isNewUserSend && sentFromThisRenderer && hasWindowAnchor;
+  return {
+    clearWindowAnchor,
+    deferPinToNextRender: clearWindowAnchor && !windowCoversEnd,
+  };
+}
+
 export interface ResolveNearBottomArgs {
   /** scroll 事件前的跟随态(isNearBottomRef) */
   wasNearBottom: boolean;
@@ -211,8 +254,10 @@ export interface ResolveNearBottomArgs {
 /**
  * scroll 事件驱动的跟随态迁移(handleScroll 消费)。
  *
- *  - 距底 >= threshold → false。离底解除,原有行为不变 — 这也是滚动条拖拽
- *    (没有 wheel 事件可听)的解除兜底。
+ *  - 距底 >= threshold 且(已解除, 或明确上滚) → false。这是滚动条拖拽
+ *    等无 wheel 路径的解除兜底。**已在跟、却只是内容在下方长高**
+ *    (发送后首块 assistant / 工具卡撑高、迟到的程序化 scroll 事件)
+ *    不得解除 — pin / ResizeObserver 会补上。
  *  - 距底 < threshold 且原本在跟 → 保持 true。阈值带内的微小上移不在这里
  *    解除(滚动条微拖、布局收缩钳位等 scrollTop 被动上移会误伤),wheel /
  *    touch / 键盘的意图解除路径已经覆盖了真实的用户上滚。
@@ -227,7 +272,10 @@ export function resolveNearBottomOnScroll({
   thresholdPx,
   directionDeadZonePx,
 }: ResolveNearBottomArgs): boolean {
-  if (distanceFromBottom >= thresholdPx) return false;
+  if (distanceFromBottom >= thresholdPx) {
+    if (!wasNearBottom) return false;
+    return scrollDelta >= -directionDeadZonePx;
+  }
   if (wasNearBottom) return true;
   return scrollDelta > directionDeadZonePx;
 }

--- a/apps/mobile/src/__tests__/messageScroll.test.ts
+++ b/apps/mobile/src/__tests__/messageScroll.test.ts
@@ -420,13 +420,25 @@ describe('resolveMobileNearBottomOnScroll', () => {
   // 阈值带 = offsetY > 972。
   const metricsAt = (offsetY: number) => ({ contentHeight: 2000, offsetY, viewportHeight: 800 });
 
-  it('距底超出阈值 → false(原有离底解除行为不变)', () => {
+  it('距底超出阈值 + 明确上滑 / 已解除 → false(原有离底解除行为不变)', () => {
     expect(resolveMobileNearBottomOnScroll({
       wasNearBottom: true, metrics: metricsAt(900), scrollDelta: -40,
     })).toBe(false);
     expect(resolveMobileNearBottomOnScroll({
       wasNearBottom: false, metrics: metricsAt(500), scrollDelta: 40,
     })).toBe(false);
+  });
+
+  it('已在跟 + 距底越线但未上滑 → 保持跟随(发送后内容长高不得解除)', () => {
+    expect(resolveMobileNearBottomOnScroll({
+      wasNearBottom: true, metrics: metricsAt(900), scrollDelta: 0,
+    })).toBe(true);
+    expect(resolveMobileNearBottomOnScroll({
+      wasNearBottom: true, metrics: metricsAt(500), scrollDelta: 80,
+    })).toBe(true);
+    expect(resolveMobileNearBottomOnScroll({
+      wasNearBottom: true, metrics: metricsAt(500), scrollDelta: -1,
+    })).toBe(true);
   });
 
   it('阈值带内 + 原本在跟 → 保持跟随(贴底期间程序化 scrollToEnd 的增量不改状态)', () => {

--- a/apps/mobile/src/session/messageScroll.ts
+++ b/apps/mobile/src/session/messageScroll.ts
@@ -125,7 +125,9 @@ export interface MobileNearBottomResolveInput {
  *
  *  - 命令式滚动 settling → 保持原跟随态,不把瞬时 offset 当成用户上翻;
  *  - 内容未撑满一屏 → true(与 isNearMessageListBottom 同口径);
- *  - 距底超出阈值 → false(离底解除,原行为不变);
+ *  - 距底超出阈值且(已解除, 或明确上滑) → false(滚动条/拖动离底的兜底)。
+ *    已在跟、只是内容在下方长高导致距底越线时保持跟随 — 发送后首块
+ *    assistant / 工具卡撑高不得把跟随掐死;
  *  - 阈值带内且原本在跟 → 保持 true(贴底期间程序化 scrollToEnd 产生的
  *    向下增量、以及被动微小位移都不改变状态);
  *  - 阈值带内且已解除 → 仅「明确向下」(增量 > 死区)才恢复跟随。**不能只看
@@ -136,7 +138,10 @@ export function resolveMobileNearBottomOnScroll(input: MobileNearBottomResolveIn
   if (input.programmaticScrollInFlight) return input.wasNearBottom;
   const { contentHeight, viewportHeight } = input.metrics;
   if (contentHeight <= viewportHeight) return true;
-  if (!isNearMobileMessageListBottom(input.metrics, input.bottomOverlayHeight)) return false;
+  if (!isNearMobileMessageListBottom(input.metrics, input.bottomOverlayHeight)) {
+    if (!input.wasNearBottom) return false;
+    return input.scrollDelta >= -MOBILE_FOLLOW_REPIN_DIRECTION_DEAD_ZONE;
+  }
   if (input.wasNearBottom) return true;
   return input.scrollDelta > MOBILE_FOLLOW_REPIN_DIRECTION_DEAD_ZONE;
 }


### PR DESCRIPTION
## 这次改了什么

### 摘要

本端发送后聊天能滚到最新，但紧接着出现的 assistant / 工具卡不再自动跟随。原因有两条：内容在下方突然撑高时，迟到的程序化 scroll 事件会被距离阈值误判成「人离开了底部」；若发送时仍停在锚定历史窗（哪怕当时还盖着末尾），下一轮新消息会把尾部顶出窗口并停掉跟随。

这次让本端发送一律回到默认尾窗，并且已经在跟时只有明确上滚才解除跟随。飞书 / 手机 / 定时任务注入的消息仍然不抢视口。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无编号；用户实报「发送后滚到最新，后面新消息不再跟」
- 本 PR 包含：桌面 `MessageStream` 发送后切回尾窗；桌面 / 手机近底判定在「已跟随 + 内容长高」时不再解除
- 明确不包含：跳底按钮、历史还原、外部入口注入消息抢视口（#2194 保持）
- 用户可见变化：本端发送后，后续流式 / 工具卡会继续贴底；用户上滚仍会立刻停跟
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：不涉及：无控件、布局、色板或文案改动；只修正发送后自动贴底跟随的判定，行为对齐既有产品约定（本端发送后跟随最新消息）。

## 怎么验证的

### 自动验证

```text
cd /Users/dash/Code/Cindy/cindy-fix-chat-follow-after-send
pnpm test:unit:related
结果：PASS apps/desktop unit (16.3s)；PASS apps/mobile unit (1.8s)

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --filter mobile run --if-present typecheck
结果：通过

bash /Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh <worktree>
结果：本 PR 相关 workspace 通过；全量 desktop unit 另有 2 条失败（见未执行的验证）
```

### 手工验证

未在实机点发送回归。改动是滚动跟随判定，建议在桌面长会话里：先上翻历史再发送，确认发送钉底后 assistant / 工具卡继续跟随；再上滚一行确认仍能立刻停跟。

### 未执行的验证

- 实机桌面 / 手机发送后跟底目检：当前会话无法热更宿主 app。
- 全量 `pnpm test:unit` 在本机失败于 `apps/desktop/src/main/cindy-brain/__tests__/ghostInstallReceipt.test.ts` 的 2 条（`writes setup in the author format accepted by the v0.1.48 receipt reader` / `still reads normalized setup receipts emitted by affected builds`）。同一 SHA `c3be1edf6` 的干净 `origin/main` 复现同样失败，与本 diff 无关，交给 CI 给权威结论。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：桌面 / 手机消息流的贴底跟随判定；不改 schema、协议、插件或原生指纹。
- 回滚 / 降级方式：revert 本 PR。
- 存量插件影响：无

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
