### PR TITLE
fix(desktop): Pi skill 胶囊与其它 harness 展示对齐

### DIFF
--- a/apps/desktop/src/renderer/__tests__/sentInlineAtomBody.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/sentInlineAtomBody.test.tsx
@@ -64,6 +64,23 @@ describe('SentInlineAtomBody', () => {
     expect(document.querySelector('[tabindex]')).toBeNull();
   });
 
+  it('does not turn unconfirmed /skill: prose into a /unknown chip', () => {
+    render(<SentInlineAtomBody content="/skill:unknown is prose" />);
+    expect(screen.getByText(/\/skill:unknown is prose/)).toBeTruthy();
+    expect(screen.queryByText('/unknown')).toBeNull();
+  });
+
+  it('still projects a confirmed /skill:git range to /git', () => {
+    render(
+      <SentInlineAtomBody
+        content="/skill:git follow-up"
+        slashCommandRanges={[{ start: 0, end: 10 }]}
+      />,
+    );
+    expect(screen.getByText('/git')).toBeTruthy();
+    expect(screen.queryByText('/skill:git')).toBeNull();
+  });
+
   it('leaves the pending queue single-line truncation contract to the row container', () => {
     const bodyStart = pendingQueueSource.indexOf('<SentInlineAtomBody');
     const bodyEnd = pendingQueueSource.indexOf('/>', bodyStart);

--- a/apps/desktop/src/renderer/__tests__/slashCommandDecoration.test.ts
+++ b/apps/desktop/src/renderer/__tests__/slashCommandDecoration.test.ts
@@ -103,4 +103,34 @@ describe('SlashCommandDecoration', () => {
     expect(state.doc.firstChild?.firstChild?.isText).toBe(true);
     expect(decorationRanges(plugin, state)).toEqual([{ from: 1, to: 7 }]);
   });
+
+  it('matches Pi runtime aliases and hides the skill: prefix', () => {
+    const commands = [{
+      kind: 'agent-skill' as const,
+      name: 'git',
+      description: 'git skill',
+      source: 'skill' as const,
+      runtimeCommandName: 'skill:git',
+    }];
+    const source = doc(p(txt('/skill:git follow /git')));
+
+    expect(findSlashCommandMatches(source, commands)).toMatchObject([
+      { from: 1, to: 11, command: { name: 'git' } },
+      { from: 19, to: 23, command: { name: 'git' } },
+    ]);
+
+    const plugin = createSlashCommandPlugin();
+    let state = EditorState.create({
+      schema,
+      doc: source,
+      plugins: [plugin],
+    });
+    state = state.apply(state.tr.setMeta('slashCommandDecoration', commands));
+
+    expect(decorationRanges(plugin, state)).toEqual([
+      { from: 1, to: 11 },
+      { from: 2, to: 8 },
+      { from: 19, to: 23 },
+    ]);
+  });
 });

--- a/apps/desktop/src/renderer/__tests__/slashPaletteEmptyResultGuard.test.ts
+++ b/apps/desktop/src/renderer/__tests__/slashPaletteEmptyResultGuard.test.ts
@@ -23,4 +23,13 @@ describe('slash palette empty-result keyboard guard', () => {
       selectionBlock.indexOf('if (\n              atOpen'),
     );
   });
+
+  it('inserts the human command name so Pi runtime aliases stay off the display layer', () => {
+    const insertBlock = chatInputSource.slice(
+      chatInputSource.indexOf('const insertSlashCommand = useCallback'),
+      chatInputSource.indexOf('const resolveEffectiveAtRange'),
+    );
+    expect(insertBlock).toContain('cmd.name');
+    expect(insertBlock).not.toContain('slashCommandInvocationName');
+  });
 });

--- a/apps/desktop/src/renderer/__tests__/userMessageEditBox.test.ts
+++ b/apps/desktop/src/renderer/__tests__/userMessageEditBox.test.ts
@@ -193,6 +193,34 @@ describe('UserMessageEditBox — idle 发送', () => {
     expect(commitMock.mock.calls[0][0].slashCommandRanges).toBeUndefined();
   });
 
+  it('后文已确认的命令 range 不会让首行未确认的 /skill: 散文被改回', async () => {
+    const original = '/skill:unknown\n/help later';
+    const helpStart = original.indexOf('/help');
+    const box = renderBox({
+      initialText: original,
+      initialSubmitText: original,
+      slashCommandRanges: [{ start: helpStart, end: helpStart + 5 }],
+    });
+    fireEvent.change(box.textarea, { target: { value: '/unknown\n/help later' } });
+    fireEvent.click(box.sendBtn);
+    await waitFor(() => expect(commitMock).toHaveBeenCalledTimes(1));
+    expect(commitMock.mock.calls[0][0].text).toBe('/unknown\n/help later');
+    expect(commitMock.mock.calls[0][0].slashCommandRanges).toBeUndefined();
+  });
+
+  it('已确认 range 覆盖的 Pi skill 编辑后仍恢复 runtime 名', async () => {
+    const box = renderBox({
+      initialText: '/git please',
+      initialSubmitText: '/skill:git please',
+      slashCommandRanges: [{ start: 0, end: 10 }],
+    });
+    fireEvent.change(box.textarea, { target: { value: '/git review' } });
+    fireEvent.click(box.sendBtn);
+    await waitFor(() => expect(commitMock).toHaveBeenCalledTimes(1));
+    expect(commitMock.mock.calls[0][0].text).toBe('/skill:git review');
+    expect(commitMock.mock.calls[0][0].slashCommandRanges).toEqual([{ start: 0, end: 10 }]);
+  });
+
   it('被拦消息覆盖重发在文本未修改时透传语义引用与 chip ranges', async () => {
     const override = vi.fn(async () => {});
     const agentReferences = [{

--- a/apps/desktop/src/renderer/__tests__/userMessageEditBox.test.ts
+++ b/apps/desktop/src/renderer/__tests__/userMessageEditBox.test.ts
@@ -181,6 +181,18 @@ describe('UserMessageEditBox — idle 发送', () => {
     expect(commitMock.mock.calls[0][0].slashCommandRanges).toBeUndefined();
   });
 
+  it('未确认的 /skill: 散文被用户删掉前缀后不再静默改回 runtime 名', async () => {
+    const box = renderBox({
+      initialText: '/skill:unknown is prose',
+      slashCommandRanges: [],
+    });
+    fireEvent.change(box.textarea, { target: { value: '/unknown is prose' } });
+    fireEvent.click(box.sendBtn);
+    await waitFor(() => expect(commitMock).toHaveBeenCalledTimes(1));
+    expect(commitMock.mock.calls[0][0].text).toBe('/unknown is prose');
+    expect(commitMock.mock.calls[0][0].slashCommandRanges).toBeUndefined();
+  });
+
   it('被拦消息覆盖重发在文本未修改时透传语义引用与 chip ranges', async () => {
     const override = vi.fn(async () => {});
     const agentReferences = [{

--- a/apps/desktop/src/renderer/__tests__/userMessageEditBox.test.ts
+++ b/apps/desktop/src/renderer/__tests__/userMessageEditBox.test.ts
@@ -221,6 +221,27 @@ describe('UserMessageEditBox — idle 发送', () => {
     expect(commitMock.mock.calls[0][0].slashCommandRanges).toEqual([{ start: 0, end: 10 }]);
   });
 
+  it('引用 marker 落库坐标仍能恢复可见 /git',
+    async () => {
+    const wire = [
+      '> <!-- cindy-composer-quote -->',
+      '> quoted',
+      '',
+      '/skill:git follow-up',
+    ].join('\n');
+    const skillStart = wire.indexOf('/skill:git');
+    const box = renderBox({
+      initialText: 'quoted\n\n/git follow-up',
+      initialSubmitText: wire,
+      quotesEncoded: true,
+      slashCommandRanges: [{ start: skillStart, end: skillStart + 10 }],
+    });
+    fireEvent.change(box.textarea, { target: { value: 'quoted\n\n/git please' } });
+    fireEvent.click(box.sendBtn);
+    await waitFor(() => expect(commitMock).toHaveBeenCalledTimes(1));
+    expect(commitMock.mock.calls[0][0].text).toBe('quoted\n\n/skill:git please');
+  });
+
   it('被拦消息覆盖重发在文本未修改时透传语义引用与 chip ranges', async () => {
     const override = vi.fn(async () => {});
     const agentReferences = [{

--- a/apps/desktop/src/renderer/components/chat/UserMessage.tsx
+++ b/apps/desktop/src/renderer/components/chat/UserMessage.tsx
@@ -1146,9 +1146,13 @@ export function UserMessage({
   // copy text per V1.2: original text + (if files) "\n\n附件：a.md, b.md"
   // ghost-summon-card:copy 给用户的是"他自己的话"(剥离机器追加段);
   // 追加段原文在卡片展开区可查可选中。
-  const copyBody = projectSlashCommandsInText(
-    quotesEncoded ? stripChatQuoteMarkerLines(ghostBody) : ghostBody,
-  );
+  const visibleSource = quotesEncoded ? stripChatQuoteMarkerLines(ghostBody) : ghostBody;
+  const copyBody = projectSlashCommandsInText(visibleSource, slashCommandRanges);
+  const editSubmitText = quotesEncoded
+    ? ghostBody
+    : copyBody !== visibleSource
+      ? visibleSource
+      : undefined;
   const copyText = hasFiles
     ? `${copyBody}\n\n${t('chat.userMessage.attachmentPrefix')}${files!.map((f) => f.name).join(', ')}`
     : copyBody;
@@ -1476,7 +1480,7 @@ export function UserMessage({
                 sessionId={sessionId}
                 messageClientId={messageClientId}
                 initialText={copyBody}
-                initialSubmitText={quotesEncoded ? ghostBody : undefined}
+                initialSubmitText={editSubmitText}
                 images={images}
                 files={files}
                 workingDir={workingDir}

--- a/apps/desktop/src/renderer/components/chat/UserMessage.tsx
+++ b/apps/desktop/src/renderer/components/chat/UserMessage.tsx
@@ -26,6 +26,10 @@ import {
   Target,
 } from 'lucide-react';
 import { readAgentInputReferences } from '@cindy/maker-shared/agent-input-projection';
+import {
+  projectSlashCommandsInText,
+  slashCommandDisplayLabel,
+} from '@cindy/maker-shared/composer-palette';
 import { useTranslation } from 'react-i18next';
 import type { TFunction } from 'i18next';
 import { cn } from '@/lib/utils';
@@ -472,7 +476,8 @@ function looksLikePath(ref: string): boolean {
  * noise like `/1312312`.
  */
 function looksLikeCommand(word: string): boolean {
-  return /^[a-zA-Z][a-zA-Z0-9_-]{0,29}$/.test(word);
+  const display = word.replace(/^skill:/i, '');
+  return /^[a-zA-Z][a-zA-Z0-9_-]{0,29}$/.test(display);
 }
 
 /**
@@ -526,11 +531,12 @@ function renderContentWithoutPastedText(
     // Check for /command at line start — only if it looks like a real command
     const slashMatch = line.match(/^\/(\S+)/);
     if (renderLegacySlashCommands && slashMatch && looksLikeCommand(slashMatch[1])) {
+      const slashLabel = slashCommandDisplayLabel(`/${slashMatch[1]}`);
       nodes.push(
         <InlineReferenceChip
           key={`s-${li}`}
-          label={`/${slashMatch[1]}`}
-          tooltip={`/${slashMatch[1]}`}
+          label={slashLabel}
+          tooltip={slashLabel}
           className="relative top-[-1px] -my-[1px] max-w-[min(240px,55vw)] align-middle text-[var(--msg-user-text)]"
         />,
       );
@@ -857,11 +863,12 @@ export function renderContent(
   const useLegacySlashHeuristic = slashCommandRanges === undefined;
   return tokens.map((token, index) => {
     if (token.kind === 'slash') {
+      const slashLabel = slashCommandDisplayLabel(token.text);
       return (
         <InlineReferenceChip
           key={`slash-chip-${index}`}
-          label={token.text}
-          tooltip={token.text}
+          label={slashLabel}
+          tooltip={slashLabel}
           className="relative top-[-1px] -my-[1px] max-w-[min(240px,55vw)] align-middle text-[var(--msg-user-text)]"
         />
       );
@@ -1139,7 +1146,9 @@ export function UserMessage({
   // copy text per V1.2: original text + (if files) "\n\n附件：a.md, b.md"
   // ghost-summon-card:copy 给用户的是"他自己的话"(剥离机器追加段);
   // 追加段原文在卡片展开区可查可选中。
-  const copyBody = quotesEncoded ? stripChatQuoteMarkerLines(ghostBody) : ghostBody;
+  const copyBody = projectSlashCommandsInText(
+    quotesEncoded ? stripChatQuoteMarkerLines(ghostBody) : ghostBody,
+  );
   const copyText = hasFiles
     ? `${copyBody}\n\n${t('chat.userMessage.attachmentPrefix')}${files!.map((f) => f.name).join(', ')}`
     : copyBody;

--- a/apps/desktop/src/renderer/components/chat/UserMessage.tsx
+++ b/apps/desktop/src/renderer/components/chat/UserMessage.tsx
@@ -476,8 +476,7 @@ function looksLikePath(ref: string): boolean {
  * noise like `/1312312`.
  */
 function looksLikeCommand(word: string): boolean {
-  const display = word.replace(/^skill:/i, '');
-  return /^[a-zA-Z][a-zA-Z0-9_-]{0,29}$/.test(display);
+  return /^[a-zA-Z][a-zA-Z0-9_-]{0,29}$/.test(word);
 }
 
 /**
@@ -531,7 +530,7 @@ function renderContentWithoutPastedText(
     // Check for /command at line start — only if it looks like a real command
     const slashMatch = line.match(/^\/(\S+)/);
     if (renderLegacySlashCommands && slashMatch && looksLikeCommand(slashMatch[1])) {
-      const slashLabel = slashCommandDisplayLabel(`/${slashMatch[1]}`);
+      const slashLabel = `/${slashMatch[1]}`;
       nodes.push(
         <InlineReferenceChip
           key={`s-${li}`}

--- a/apps/desktop/src/renderer/components/chat/UserMessage.tsx
+++ b/apps/desktop/src/renderer/components/chat/UserMessage.tsx
@@ -1146,8 +1146,11 @@ export function UserMessage({
   // copy text per V1.2: original text + (if files) "\n\n附件：a.md, b.md"
   // ghost-summon-card:copy 给用户的是"他自己的话"(剥离机器追加段);
   // 追加段原文在卡片展开区可查可选中。
+  // Project on the persisted wire text first so slashCommandRanges stay valid,
+  // then strip private quote markers for copy / edit display.
+  const projectedSource = projectSlashCommandsInText(ghostBody, slashCommandRanges);
+  const copyBody = quotesEncoded ? stripChatQuoteMarkerLines(projectedSource) : projectedSource;
   const visibleSource = quotesEncoded ? stripChatQuoteMarkerLines(ghostBody) : ghostBody;
-  const copyBody = projectSlashCommandsInText(visibleSource, slashCommandRanges);
   const editSubmitText = quotesEncoded
     ? ghostBody
     : copyBody !== visibleSource

--- a/apps/desktop/src/renderer/components/chat/UserMessageEditBox.tsx
+++ b/apps/desktop/src/renderer/components/chat/UserMessageEditBox.tsx
@@ -30,6 +30,8 @@
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { restoreSlashCommandRuntimeAlias } from '@cindy/maker-shared/composer-palette';
+import { stripChatQuoteMarkerLines } from '@/lib/chatQuotes';
 import { cn } from '@/lib/utils';
 import { Spinner } from '@/components/ui/spinner';
 import { ListComposerTextarea } from '@/components/new-chat/ListComposerTextarea';
@@ -172,7 +174,12 @@ export function UserMessageEditBox({
   const doCommit = useCallback(async () => {
     try {
       const visibleTextUnchanged = text === initialText;
-      const submitText = visibleTextUnchanged ? (initialSubmitText ?? text) : text;
+      const originalVisibleText = quotesEncoded
+        ? stripChatQuoteMarkerLines(initialSubmitText ?? initialText)
+        : (initialSubmitText ?? initialText);
+      const submitText = visibleTextUnchanged
+        ? (initialSubmitText ?? text)
+        : restoreSlashCommandRuntimeAlias(originalVisibleText, text);
       const preserveQuoteMetadata = quotesEncoded && visibleTextUnchanged;
       const preservedAgentReferences =
         visibleTextUnchanged && agentReferences && agentReferences.length > 0

--- a/apps/desktop/src/renderer/components/chat/UserMessageEditBox.tsx
+++ b/apps/desktop/src/renderer/components/chat/UserMessageEditBox.tsx
@@ -180,9 +180,12 @@ export function UserMessageEditBox({
       const originalVisibleText = quotesEncoded
         ? stripChatQuoteMarkerLines(initialSubmitText ?? initialText)
         : (initialSubmitText ?? initialText);
+      const originalHadConfirmedRange = Boolean(slashCommandRanges && slashCommandRanges.length > 0);
       const submitText = visibleTextUnchanged
         ? (initialSubmitText ?? text)
-        : restoreSlashCommandRuntimeAlias(originalVisibleText, text);
+        : originalHadConfirmedRange
+          ? restoreSlashCommandRuntimeAlias(originalVisibleText, text)
+          : text;
       const preserveQuoteMetadata = quotesEncoded && visibleTextUnchanged;
       const preservedAgentReferences =
         visibleTextUnchanged && agentReferences && agentReferences.length > 0
@@ -196,7 +199,6 @@ export function UserMessageEditBox({
       const submitTokenIsRuntimeAlias = rebuiltSlashRange
         ? submitText.slice(rebuiltSlashRange.start, rebuiltSlashRange.end).toLowerCase().startsWith('/skill:')
         : false;
-      const originalHadConfirmedRange = Boolean(slashCommandRanges && slashCommandRanges.length > 0);
       const preservedSlashCommandRanges = visibleTextUnchanged && slashCommandRanges !== undefined
         ? [...slashCommandRanges]
         : submitTokenIsRuntimeAlias && originalHadConfirmedRange && rebuiltSlashRange

--- a/apps/desktop/src/renderer/components/chat/UserMessageEditBox.tsx
+++ b/apps/desktop/src/renderer/components/chat/UserMessageEditBox.tsx
@@ -30,7 +30,10 @@
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { restoreSlashCommandRuntimeAlias } from '@cindy/maker-shared/composer-palette';
+import {
+  leadingSlashCommandRange,
+  restoreSlashCommandRuntimeAlias,
+} from '@cindy/maker-shared/composer-palette';
 import { stripChatQuoteMarkerLines } from '@/lib/chatQuotes';
 import { cn } from '@/lib/utils';
 import { Spinner } from '@/components/ui/spinner';
@@ -189,9 +192,11 @@ export function UserMessageEditBox({
         visibleTextUnchanged && pastedTextRanges && pastedTextRanges.length > 0
           ? [...pastedTextRanges]
           : undefined;
-      const preservedSlashCommandRanges =
-        visibleTextUnchanged && slashCommandRanges !== undefined
-          ? [...slashCommandRanges]
+      const rebuiltSlashRange = leadingSlashCommandRange(submitText);
+      const preservedSlashCommandRanges = visibleTextUnchanged && slashCommandRanges !== undefined
+        ? [...slashCommandRanges]
+        : rebuiltSlashRange
+          ? [rebuiltSlashRange]
           : undefined;
       if (onCommitOverride) {
         // 被拦消息:普通重发(不 rewind)。失败抛错落入下方 catch 保留编辑态。

--- a/apps/desktop/src/renderer/components/chat/UserMessageEditBox.tsx
+++ b/apps/desktop/src/renderer/components/chat/UserMessageEditBox.tsx
@@ -36,7 +36,6 @@ import {
   restoreSlashCommandRuntimeAlias,
   slashCommandRangeCoversToken,
 } from '@cindy/maker-shared/composer-palette';
-import { stripChatQuoteMarkerLines } from '@/lib/chatQuotes';
 import { cn } from '@/lib/utils';
 import { Spinner } from '@/components/ui/spinner';
 import { ListComposerTextarea } from '@/components/new-chat/ListComposerTextarea';
@@ -179,16 +178,14 @@ export function UserMessageEditBox({
   const doCommit = useCallback(async () => {
     try {
       const visibleTextUnchanged = text === initialText;
-      const originalVisibleText = quotesEncoded
-        ? stripChatQuoteMarkerLines(initialSubmitText ?? initialText)
-        : (initialSubmitText ?? initialText);
+      const originalWireText = initialSubmitText ?? initialText;
       const originalHadConfirmedRange = slashCommandRangeCoversToken(
         slashCommandRanges,
-        findSlashCommandToken(originalVisibleText),
+        findSlashCommandToken(originalWireText),
       );
       const submitText = visibleTextUnchanged
-        ? (initialSubmitText ?? text)
-        : restoreSlashCommandRuntimeAlias(originalVisibleText, text, slashCommandRanges);
+        ? originalWireText
+        : restoreSlashCommandRuntimeAlias(originalWireText, text, slashCommandRanges);
       const preserveQuoteMetadata = quotesEncoded && visibleTextUnchanged;
       const preservedAgentReferences =
         visibleTextUnchanged && agentReferences && agentReferences.length > 0

--- a/apps/desktop/src/renderer/components/chat/UserMessageEditBox.tsx
+++ b/apps/desktop/src/renderer/components/chat/UserMessageEditBox.tsx
@@ -31,8 +31,10 @@ import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react
 import { useTranslation } from 'react-i18next';
 
 import {
+  findSlashCommandToken,
   leadingSlashCommandRange,
   restoreSlashCommandRuntimeAlias,
+  slashCommandRangeCoversToken,
 } from '@cindy/maker-shared/composer-palette';
 import { stripChatQuoteMarkerLines } from '@/lib/chatQuotes';
 import { cn } from '@/lib/utils';
@@ -180,12 +182,13 @@ export function UserMessageEditBox({
       const originalVisibleText = quotesEncoded
         ? stripChatQuoteMarkerLines(initialSubmitText ?? initialText)
         : (initialSubmitText ?? initialText);
-      const originalHadConfirmedRange = Boolean(slashCommandRanges && slashCommandRanges.length > 0);
+      const originalHadConfirmedRange = slashCommandRangeCoversToken(
+        slashCommandRanges,
+        findSlashCommandToken(originalVisibleText),
+      );
       const submitText = visibleTextUnchanged
         ? (initialSubmitText ?? text)
-        : originalHadConfirmedRange
-          ? restoreSlashCommandRuntimeAlias(originalVisibleText, text)
-          : text;
+        : restoreSlashCommandRuntimeAlias(originalVisibleText, text, slashCommandRanges);
       const preserveQuoteMetadata = quotesEncoded && visibleTextUnchanged;
       const preservedAgentReferences =
         visibleTextUnchanged && agentReferences && agentReferences.length > 0

--- a/apps/desktop/src/renderer/components/chat/UserMessageEditBox.tsx
+++ b/apps/desktop/src/renderer/components/chat/UserMessageEditBox.tsx
@@ -193,11 +193,17 @@ export function UserMessageEditBox({
           ? [...pastedTextRanges]
           : undefined;
       const rebuiltSlashRange = leadingSlashCommandRange(submitText);
+      const submitTokenIsRuntimeAlias = rebuiltSlashRange
+        ? submitText.slice(rebuiltSlashRange.start, rebuiltSlashRange.end).toLowerCase().startsWith('/skill:')
+        : false;
+      const originalHadConfirmedRange = Boolean(slashCommandRanges && slashCommandRanges.length > 0);
       const preservedSlashCommandRanges = visibleTextUnchanged && slashCommandRanges !== undefined
         ? [...slashCommandRanges]
-        : rebuiltSlashRange
+        : submitTokenIsRuntimeAlias && originalHadConfirmedRange && rebuiltSlashRange
           ? [rebuiltSlashRange]
-          : undefined;
+          : slashCommandRanges !== undefined
+            ? []
+            : undefined;
       if (onCommitOverride) {
         // 被拦消息:普通重发(不 rewind)。失败抛错落入下方 catch 保留编辑态。
         await onCommitOverride({

--- a/apps/desktop/src/renderer/components/chat/UserMessageEditBox.tsx
+++ b/apps/desktop/src/renderer/components/chat/UserMessageEditBox.tsx
@@ -201,9 +201,7 @@ export function UserMessageEditBox({
         ? [...slashCommandRanges]
         : submitTokenIsRuntimeAlias && originalHadConfirmedRange && rebuiltSlashRange
           ? [rebuiltSlashRange]
-          : slashCommandRanges !== undefined
-            ? []
-            : undefined;
+          : undefined;
       if (onCommitOverride) {
         // 被拦消息:普通重发(不 rewind)。失败抛错落入下方 catch 保留编辑态。
         await onCommitOverride({

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -223,7 +223,6 @@ import {
   loadAllCommands,
   nextAvailableSlashCommandIndex,
   PI_RUNTIME_SKILL_RETRY_DELAYS_MS,
-  slashCommandInvocationName,
   type SlashCommandRosterState,
   type UnifiedCommand,
 } from '@/lib/slashCommands';
@@ -4415,14 +4414,13 @@ export function ChatInput({
             // 识别并追加机器指令,序列化零特判。
             tr.replaceWith(from, runEnd, editor.schema.text(`$${cmd.name} `));
           } else {
-            // Slash 也保持纯文本;SlashCommandDecoration 只负责视觉确认,
-            // Backspace / 光标移动因此与普通文字完全一致。
+            // 展示层写入人类名(`/git`);Pi 线路名(`/skill:git`)只在发送期改写。
             replaceSlashCommandRunWithText(
               tr,
               editor.schema,
               from,
               runEnd,
-              slashCommandInvocationName(cmd),
+              cmd.name,
             );
           }
           return true;

--- a/apps/desktop/src/renderer/components/new-chat/SlashCommandDecoration.ts
+++ b/apps/desktop/src/renderer/components/new-chat/SlashCommandDecoration.ts
@@ -14,12 +14,17 @@ import type { Node as PMNode, Schema } from '@tiptap/pm/model';
 import { Plugin, PluginKey, type EditorState, type Transaction } from '@tiptap/pm/state';
 import { Decoration, DecorationSet } from '@tiptap/pm/view';
 
+import { slashCommandRuntimePrefixLength } from '@cindy/maker-shared/composer-palette';
+
 import type { UnifiedCommand } from '@/lib/slashCommands';
 
 const PLUGIN_KEY = new PluginKey<SlashCommandPluginState>('slashCommandDecoration');
 const META_KEY = 'slashCommandDecoration';
 
-export type SlashCommandRoster = ReadonlyArray<Pick<UnifiedCommand, 'name' | 'description'>>;
+export type SlashCommandRosterItem = Pick<UnifiedCommand, 'name' | 'description'> & {
+  runtimeCommandName?: string;
+};
+export type SlashCommandRoster = ReadonlyArray<SlashCommandRosterItem>;
 
 interface SlashCommandPluginState {
   commands: SlashCommandRoster;
@@ -29,7 +34,7 @@ interface SlashCommandPluginState {
 export interface SlashCommandMatch {
   from: number;
   to: number;
-  command: Pick<UnifiedCommand, 'name' | 'description'>;
+  command: SlashCommandRosterItem;
 }
 
 function previousInlineAllowsSlash(parent: PMNode, childIndex: number): boolean {
@@ -52,10 +57,13 @@ export function findSlashCommandMatches(
   commands: SlashCommandRoster,
 ): SlashCommandMatch[] {
   if (commands.length === 0) return [];
-  const byName = new Map<string, Pick<UnifiedCommand, 'name' | 'description'>>();
+  const byName = new Map<string, SlashCommandRosterItem>();
   for (const command of commands) {
     const name = command.name.trim();
     if (name) byName.set(name.toLowerCase(), command);
+    const runtime = command.runtimeCommandName?.trim();
+    // Palette shows `git`; Pi wire form is `skill:git`. Both must light the pill.
+    if (runtime) byName.set(runtime.toLowerCase(), command);
   }
   if (byName.size === 0) return [];
 
@@ -83,9 +91,7 @@ export function findSlashCommandMatches(
   return matches;
 }
 
-function slashPillAttrs(
-  command: Pick<UnifiedCommand, 'name' | 'description'>,
-): Record<string, string> {
+function slashPillAttrs(command: SlashCommandRosterItem): Record<string, string> {
   return {
     class: 'slash-cmd-pill',
     'data-slash-command': command.name,
@@ -96,10 +102,20 @@ function slashPillAttrs(
 function buildDecorations(doc: PMNode, commands: SlashCommandRoster): DecorationSet {
   const matches = findSlashCommandMatches(doc, commands);
   if (matches.length === 0) return DecorationSet.empty;
-  return DecorationSet.create(
-    doc,
-    matches.map((match) => Decoration.inline(match.from, match.to, slashPillAttrs(match.command))),
-  );
+  const decorations: Decoration[] = [];
+  for (const match of matches) {
+    const token = doc.textBetween(match.from, match.to);
+    const prefixLength = slashCommandRuntimePrefixLength(token, match.command);
+    if (prefixLength > 0) {
+      decorations.push(
+        Decoration.inline(match.from + 1, match.from + 1 + prefixLength, {
+          class: 'slash-cmd-runtime-prefix',
+        }),
+      );
+    }
+    decorations.push(Decoration.inline(match.from, match.to, slashPillAttrs(match.command)));
+  }
+  return DecorationSet.create(doc, decorations);
 }
 
 /** Palette 选择后用普通文本替换 slash run,不创建 mentionChip atom。 */

--- a/apps/desktop/src/renderer/components/new-chat/composerContentSerialization.ts
+++ b/apps/desktop/src/renderer/components/new-chat/composerContentSerialization.ts
@@ -27,7 +27,12 @@ import type { PastedTextRange, SlashCommandRange } from '@/lib/imageRef';
 
 import type { MentionChipAttrs } from './MentionChipNode';
 import type { PastedTextChipAttrs } from './PastedTextChipNode';
-import { getDecoratedSlashCommandMatches, type SlashCommandMatch } from './SlashCommandDecoration';
+import { projectKnownRuntimeSlashCommands } from '@cindy/maker-shared/composer-palette';
+import {
+  getDecoratedSlashCommandMatches,
+  getSlashCommandRoster,
+  type SlashCommandMatch,
+} from './SlashCommandDecoration';
 import { serializeSessionChipText } from './sessionLinkPaste';
 import { serializeProjectChipText } from './pastePipeline';
 
@@ -616,8 +621,14 @@ export function serializeEditorSlice(editor: Editor | null, slice: Slice): strin
         }
       }
     }
-    return serializeComposerDocument(replaced, []).text;
+    return projectKnownRuntimeSlashCommands(
+      serializeComposerDocument(replaced, []).text,
+      getSlashCommandRoster(editor.state),
+    );
   } catch {
-    return slice.content.textBetween(0, slice.content.size, '\n');
+    return projectKnownRuntimeSlashCommands(
+      slice.content.textBetween(0, slice.content.size, '\n'),
+      getSlashCommandRoster(editor.state),
+    );
   }
 }

--- a/apps/desktop/src/renderer/components/new-chat/composerContentSerialization.ts
+++ b/apps/desktop/src/renderer/components/new-chat/composerContentSerialization.ts
@@ -27,12 +27,7 @@ import type { PastedTextRange, SlashCommandRange } from '@/lib/imageRef';
 
 import type { MentionChipAttrs } from './MentionChipNode';
 import type { PastedTextChipAttrs } from './PastedTextChipNode';
-import { projectKnownRuntimeSlashCommands } from '@cindy/maker-shared/composer-palette';
-import {
-  getDecoratedSlashCommandMatches,
-  getSlashCommandRoster,
-  type SlashCommandMatch,
-} from './SlashCommandDecoration';
+import { getDecoratedSlashCommandMatches, type SlashCommandMatch } from './SlashCommandDecoration';
 import { serializeSessionChipText } from './sessionLinkPaste';
 import { serializeProjectChipText } from './pastePipeline';
 
@@ -621,14 +616,8 @@ export function serializeEditorSlice(editor: Editor | null, slice: Slice): strin
         }
       }
     }
-    return projectKnownRuntimeSlashCommands(
-      serializeComposerDocument(replaced, []).text,
-      getSlashCommandRoster(editor.state),
-    );
+    return serializeComposerDocument(replaced, []).text;
   } catch {
-    return projectKnownRuntimeSlashCommands(
-      slice.content.textBetween(0, slice.content.size, '\n'),
-      getSlashCommandRoster(editor.state),
-    );
+    return slice.content.textBetween(0, slice.content.size, '\n');
   }
 }

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
@@ -144,6 +144,7 @@ import { useAnimatedNumber } from '@/hooks/useAnimatedNumber';
 import {
   loadAllCommands,
   dispatchCommand,
+  leadingSlashInvocation,
   PI_RUNTIME_SKILL_RETRY_DELAYS_MS,
   rebaseInlineRangesAfterSlashCommandRewrite,
   reconcilePiRuntimeCommandForDispatch,
@@ -2498,9 +2499,13 @@ export function CCAgentSessionView({
       },
     ): Promise<{ handled: boolean; accepted: boolean; message: string }> => {
       const slashMatch = message.match(/^\/(\S+)(?:\s+(.*))?$/s);
-      if (!slashMatch) return { handled: false, accepted: false, message };
-      const cmdName = slashMatch[1].toLowerCase();
-      const args = slashMatch[2] ?? '';
+      const agentKind = dbToMakerAgentKind(session?.agentKind);
+      const leading = !slashMatch && agentKind === 'pi'
+        ? leadingSlashInvocation(message)
+        : undefined;
+      if (!slashMatch && !leading) return { handled: false, accepted: false, message };
+      const cmdName = (slashMatch?.[1] ?? leading!.name).toLowerCase();
+      const args = slashMatch?.[2] ?? '';
       const allowDesktopDispatch = options?.allowDesktopDispatch ?? true;
       const workingDir = options?.workingDirOverride ?? session?.workingDir;
       const cached = allCommandsRef.current;
@@ -2511,7 +2516,6 @@ export function CCAgentSessionView({
         : cached.length > 0
           ? cached
           : await getHelpCommandsSnapshot();
-      const agentKind = dbToMakerAgentKind(session?.agentKind);
       const reconcileParams = {
         agentKind,
         sessionId: session?.id,
@@ -2549,6 +2553,8 @@ export function CCAgentSessionView({
             agentKind === 'pi' ? rewriteAgentSkillInvocationForDispatch(message, hit) : message,
         };
       }
+      // Desktop commands stay `^/` only. A whitespace-prefixed `/help` is not a dispatch.
+      if (!slashMatch) return { handled: false, accepted: false, message };
       if (!allowDesktopDispatch) return { handled: false, accepted: false, message };
       // Review is handed to Main immediately with this invocation's serialized
       // attachments. It must not depend on this React view remaining mounted,

--- a/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
@@ -119,6 +119,10 @@ import { NewGoalDialog } from '@/components/new-chat/NewGoalDialog';
 import { cleanupStagedChatAttachmentFiles } from '@/lib/chatAttachmentStageCleanup';
 import type { GoalLimitValues } from '@/components/new-chat/GoalAdvancedLimits';
 import { makerChatStore } from '@/lib/makerChatStore';
+import {
+  rebaseInlineRangesAfterSlashCommandRewrite,
+  rewritePiSkillMessageForSend,
+} from '@/lib/slashCommands';
 import { worktreeCreationStore } from '@/lib/worktreeCreationStore';
 import { useRefreshWorktrees } from '@/contexts/WorktreeContext';
 import { crossAgentConvertService } from '@/lib/crossAgentConvertService';
@@ -3545,9 +3549,21 @@ export function NewMakerDraftRoute() {
                   }
                 }
 
+                const dispatchedMessage = await rewritePiSkillMessageForSend({
+                  agentKind: persistedAgentKind === 'cc' ? 'claude-code' : persistedAgentKind,
+                  message,
+                  workingDir: newDir,
+                  sessionId: newSession.id,
+                });
+                const rebaseRanges = <T extends { start: number; end: number }>(
+                  ranges: readonly T[] | undefined,
+                ): T[] | undefined => {
+                  if (!ranges) return undefined;
+                  return rebaseInlineRangesAfterSlashCommandRewrite(ranges, message, dispatchedMessage);
+                };
                 const accepted = await makerChatStore.sendMessage(
                   newSession.id,
-                  message,
+                  dispatchedMessage,
                   model,
                   effort,
                   permissionMode,
@@ -3557,13 +3573,13 @@ export function NewMakerDraftRoute() {
                   {
                     ...(opts?.quotesEncoded ? { quotesEncoded: true } : {}),
                     ...(opts?.agentReferences?.length
-                      ? { agentReferences: opts.agentReferences }
+                      ? { agentReferences: rebaseRanges(opts.agentReferences) }
                       : {}),
                     ...(opts?.pastedTextRanges?.length
-                      ? { pastedTextRanges: opts.pastedTextRanges }
+                      ? { pastedTextRanges: rebaseRanges(opts.pastedTextRanges) }
                       : {}),
                     ...(opts?.slashCommandRanges !== undefined
-                      ? { slashCommandRanges: opts.slashCommandRanges }
+                      ? { slashCommandRanges: rebaseRanges(opts.slashCommandRanges) }
                       : {}),
                   },
                 );

--- a/apps/desktop/src/renderer/lib/__tests__/slashCommands.test.ts
+++ b/apps/desktop/src/renderer/lib/__tests__/slashCommands.test.ts
@@ -162,7 +162,7 @@ describe('Pi project skill availability', () => {
     expect(isSlashCommandUnavailable(skill({ scope: 'repo' }))).toBe(false);
   });
 
-  it('keeps the palette label while invoking Pi skills by their runtime command name', () => {
+  it('keeps the palette / composer label while invoking Pi skills by their runtime command name', () => {
     const loaded = skill({
       name: 'demo',
       scope: 'repo',

--- a/apps/desktop/src/renderer/lib/__tests__/slashCommands.test.ts
+++ b/apps/desktop/src/renderer/lib/__tests__/slashCommands.test.ts
@@ -12,6 +12,7 @@ import {
   reconcilePiRuntimeCommandForDispatch,
   reconcilePiRuntimeCommandForDispatchWithRetry,
   rewriteAgentSkillInvocationForDispatch,
+  rewritePiSkillMessageForSend,
   slashCommandInvocationName,
   type UnifiedCommand,
 } from '@/lib/slashCommands';
@@ -71,6 +72,13 @@ describe('rewriteAgentSkillInvocationForDispatch', () => {
       runtimeStatus: 'loaded',
     })).toBe('/other');
     expect(rewriteAgentSkillInvocationForDispatch('/demo', desktop)).toBe('/demo');
+  });
+
+  it('leaves non-Pi first messages untouched without loading a roster', async () => {
+    await expect(rewritePiSkillMessageForSend({
+      agentKind: 'codex',
+      message: '/git please',
+    })).resolves.toBe('/git please');
   });
 });
 

--- a/apps/desktop/src/renderer/lib/__tests__/slashCommands.test.ts
+++ b/apps/desktop/src/renderer/lib/__tests__/slashCommands.test.ts
@@ -12,6 +12,7 @@ import {
   reconcilePiRuntimeCommandForDispatch,
   reconcilePiRuntimeCommandForDispatchWithRetry,
   rewriteAgentSkillInvocationForDispatch,
+  rewritePiSkillAliasFromCommand,
   rewritePiSkillMessageForSend,
   slashCommandInvocationName,
   type UnifiedCommand,
@@ -79,6 +80,17 @@ describe('rewriteAgentSkillInvocationForDispatch', () => {
       agentKind: 'codex',
       message: '/git please',
     })).resolves.toBe('/git please');
+  });
+
+  it('rewrites a discovered Pi project skill that already has a runtime alias', () => {
+    const discovered = skill({
+      name: 'git',
+      scope: 'repo',
+      runtimeStatus: 'discovered',
+      runtimeCommandName: 'skill:git',
+    });
+    expect(rewriteAgentSkillInvocationForDispatch('/git please', discovered)).toBe('/git please');
+    expect(rewritePiSkillAliasFromCommand('/git please', discovered)).toBe('/skill:git please');
   });
 });
 

--- a/apps/desktop/src/renderer/lib/__tests__/slashCommands.test.ts
+++ b/apps/desktop/src/renderer/lib/__tests__/slashCommands.test.ts
@@ -37,6 +37,13 @@ describe('rewriteAgentSkillInvocationForDispatch', () => {
     expect(rewriteAgentSkillInvocationForDispatch('/demo   keep spacing', loaded)).toBe(
       '/skill:demo   keep spacing',
     );
+    expect(rewriteAgentSkillInvocationForDispatch('  \n/demo keep', loaded)).toBe(
+      '  \n/skill:demo keep',
+    );
+    expect(rewriteAgentSkillInvocationForDispatch('please /demo', loaded)).toBe('please /demo');
+    expect(rewriteAgentSkillInvocationForDispatch('> quoted\n\n/demo', loaded)).toBe(
+      '> quoted\n\n/demo',
+    );
   });
 
   it('rebases command and later inline metadata when the runtime alias grows', () => {
@@ -55,6 +62,18 @@ describe('rewriteAgentSkillInvocationForDispatch', () => {
       { start: 0, end: 11, kind: 'slash' },
       { start: 12, end: 17, kind: 'reference' },
       { start: 18, end: 24, kind: 'paste' },
+    ]);
+
+    expect(rebaseInlineRangesAfterSlashCommandRewrite(
+      [
+        { start: 3, end: 8, kind: 'slash' },
+        { start: 9, end: 14, kind: 'reference' },
+      ],
+      '  \n/demo @task',
+      '  \n/skill:demo @task',
+    )).toEqual([
+      { start: 3, end: 14, kind: 'slash' },
+      { start: 15, end: 20, kind: 'reference' },
     ]);
   });
 
@@ -91,6 +110,8 @@ describe('rewriteAgentSkillInvocationForDispatch', () => {
     });
     expect(rewriteAgentSkillInvocationForDispatch('/git please', discovered)).toBe('/git please');
     expect(rewritePiSkillAliasFromCommand('/git please', discovered)).toBe('/skill:git please');
+    expect(rewritePiSkillAliasFromCommand(' \n/git please', discovered)).toBe(' \n/skill:git please');
+    expect(rewritePiSkillAliasFromCommand('note /git', discovered)).toBe('note /git');
   });
 });
 

--- a/apps/desktop/src/renderer/lib/slashCommands.ts
+++ b/apps/desktop/src/renderer/lib/slashCommands.ts
@@ -44,8 +44,8 @@ export function slashCommandInvocationName(command: UnifiedCommand): string {
 }
 
 /**
- * Palette selection already inserts runtimeCommandName. Apply the same mapping
- * to a matching command that the user typed or pasted directly before send.
+ * Palette / composer keep the human name (`/git`). Rewrite only at dispatch so
+ * Pi receives the runtime alias (`/skill:git`) without leaking it into the UI.
  */
 export function rewriteAgentSkillInvocationForDispatch(
   message: string,

--- a/apps/desktop/src/renderer/lib/slashCommands.ts
+++ b/apps/desktop/src/renderer/lib/slashCommands.ts
@@ -17,6 +17,9 @@
  */
 
 import type { UnifiedCommand, AgentKind } from '@cindy/maker-core';
+import { leadingSlashInvocation } from '@cindy/maker-shared';
+
+export { leadingSlashInvocation };
 
 import { createLogger } from '@/lib/logger';
 
@@ -59,9 +62,9 @@ export function rewriteAgentSkillInvocationForDispatch(
   ) {
     return message;
   }
-  const match = message.match(/^\/(\S+)([\s\S]*)$/);
-  if (!match || match[1].toLowerCase() !== command.name.toLowerCase()) return message;
-  return `/${command.runtimeCommandName}${match[2]}`;
+  const leading = leadingSlashInvocation(message);
+  if (!leading || leading.name.toLowerCase() !== command.name.toLowerCase()) return message;
+  return `${message.slice(0, leading.start)}/${command.runtimeCommandName}${message.slice(leading.end)}`;
 }
 
 /** Rewrite `/git` → `/skill:git` even when the skill is still `discovered`. */
@@ -69,16 +72,16 @@ export function rewritePiSkillAliasFromCommand(
   message: string,
   command: UnifiedCommand | undefined,
 ): string {
-  const token = message.match(/^\/(\S+)/)?.[1];
+  const leading = leadingSlashInvocation(message);
   if (
-    !token
+    !leading
     || command?.kind !== 'agent-skill'
     || !command.runtimeCommandName
-    || token.toLowerCase() !== command.name.toLowerCase()
+    || leading.name.toLowerCase() !== command.name.toLowerCase()
   ) {
     return rewriteAgentSkillInvocationForDispatch(message, command);
   }
-  return `/${command.runtimeCommandName}${message.slice(token.length + 1)}`;
+  return `${message.slice(0, leading.start)}/${command.runtimeCommandName}${message.slice(leading.end)}`;
 }
 
 /** First-message / worktree send paths that skip SessionView dispatch. */
@@ -89,12 +92,12 @@ export async function rewritePiSkillMessageForSend(params: {
   sessionId?: string;
 }): Promise<string> {
   if (params.agentKind !== 'pi') return params.message;
-  const token = params.message.match(/^\/(\S+)/)?.[1];
-  if (!token) return params.message;
+  const leading = leadingSlashInvocation(params.message);
+  if (!leading) return params.message;
   const commands = await loadAllCommands(params.agentKind, params.workingDir, {
     ...(params.sessionId ? { sessionId: params.sessionId } : {}),
   });
-  const hit = commands.find((command) => command.name.toLowerCase() === token.toLowerCase());
+  const hit = commands.find((command) => command.name.toLowerCase() === leading.name.toLowerCase());
   return rewritePiSkillAliasFromCommand(params.message, hit);
 }
 
@@ -108,12 +111,13 @@ export function rebaseInlineRangesAfterSlashCommandRewrite<T extends { start: nu
   rewrittenMessage: string,
 ): T[] {
   if (originalMessage === rewrittenMessage) return [...ranges];
-  const originalCommand = originalMessage.match(/^\/\S+/)?.[0];
-  const rewrittenCommand = rewrittenMessage.match(/^\/\S+/)?.[0];
+  const originalCommand = leadingSlashInvocation(originalMessage);
+  const rewrittenCommand = leadingSlashInvocation(rewrittenMessage);
   if (!originalCommand || !rewrittenCommand) return [...ranges];
 
-  const boundary = originalCommand.length;
-  const delta = rewrittenCommand.length - boundary;
+  const boundary = originalCommand.end;
+  const delta = (rewrittenCommand.end - rewrittenCommand.start)
+    - (originalCommand.end - originalCommand.start);
   if (delta === 0) return [...ranges];
   return ranges.map((range) => ({
     ...range,

--- a/apps/desktop/src/renderer/lib/slashCommands.ts
+++ b/apps/desktop/src/renderer/lib/slashCommands.ts
@@ -64,6 +64,23 @@ export function rewriteAgentSkillInvocationForDispatch(
   return `/${command.runtimeCommandName}${match[2]}`;
 }
 
+/** First-message / worktree send paths that skip SessionView dispatch. */
+export async function rewritePiSkillMessageForSend(params: {
+  agentKind: AgentKind;
+  message: string;
+  workingDir?: string | null;
+  sessionId?: string;
+}): Promise<string> {
+  if (params.agentKind !== 'pi') return params.message;
+  const token = params.message.match(/^\/(\S+)/)?.[1];
+  if (!token) return params.message;
+  const commands = await loadAllCommands(params.agentKind, params.workingDir, {
+    ...(params.sessionId ? { sessionId: params.sessionId } : {}),
+  });
+  const hit = commands.find((command) => command.name.toLowerCase() === token.toLowerCase());
+  return rewriteAgentSkillInvocationForDispatch(params.message, hit);
+}
+
 /**
  * Rebase persisted/render-only inline ranges after the leading slash-command
  * token grows or shrinks during runtime alias rewriting.

--- a/apps/desktop/src/renderer/lib/slashCommands.ts
+++ b/apps/desktop/src/renderer/lib/slashCommands.ts
@@ -64,6 +64,23 @@ export function rewriteAgentSkillInvocationForDispatch(
   return `/${command.runtimeCommandName}${match[2]}`;
 }
 
+/** Rewrite `/git` → `/skill:git` even when the skill is still `discovered`. */
+export function rewritePiSkillAliasFromCommand(
+  message: string,
+  command: UnifiedCommand | undefined,
+): string {
+  const token = message.match(/^\/(\S+)/)?.[1];
+  if (
+    !token
+    || command?.kind !== 'agent-skill'
+    || !command.runtimeCommandName
+    || token.toLowerCase() !== command.name.toLowerCase()
+  ) {
+    return rewriteAgentSkillInvocationForDispatch(message, command);
+  }
+  return `/${command.runtimeCommandName}${message.slice(token.length + 1)}`;
+}
+
 /** First-message / worktree send paths that skip SessionView dispatch. */
 export async function rewritePiSkillMessageForSend(params: {
   agentKind: AgentKind;
@@ -78,7 +95,7 @@ export async function rewritePiSkillMessageForSend(params: {
     ...(params.sessionId ? { sessionId: params.sessionId } : {}),
   });
   const hit = commands.find((command) => command.name.toLowerCase() === token.toLowerCase());
-  return rewriteAgentSkillInvocationForDispatch(params.message, hit);
+  return rewritePiSkillAliasFromCommand(params.message, hit);
 }
 
 /**

--- a/apps/desktop/src/renderer/styles/globals.css
+++ b/apps/desktop/src/renderer/styles/globals.css
@@ -747,16 +747,42 @@ html:lang(ko) {
 }
 
 /* Slash 指令确认胶囊 — doc 里仍是普通 `/command` 文本。字号、字重和文字色
-   完全继承 composer 正文;仅用 surface/border/radius 表达“已命中命令”。 */
+   完全继承 composer 正文;仅用 surface/border/radius 表达“已命中命令”。
+   inline-flex 让 padding 进布局,避免行首悬挂绘制溢出输入卡片。 */
 .ProseMirror .slash-cmd-pill {
+  display: inline-flex;
+  align-items: center;
+  box-sizing: border-box;
   background: var(--surface-chip);
   border: 1px solid var(--border-default);
   border-radius: 9999px;
   padding: 2px 8px 3px;
+  margin-inline: 0 4px;
   color: var(--chat-input-text);
   font: inherit;
   box-decoration-break: clone;
   -webkit-box-decoration-break: clone;
+}
+/* Pi 线路名 `/skill:git` 里的 `skill:` 只做识别:展示层与 CC/Codex 一样只留 `/git`。 */
+.ProseMirror .slash-cmd-runtime-prefix {
+  display: none;
+}
+/* 隐藏 runtime 前缀后 ProseMirror 会把胶囊切成相邻 span,接缝拼回一颗。 */
+.ProseMirror .slash-cmd-pill:has(+ .slash-cmd-pill),
+.ProseMirror .slash-cmd-pill:has(+ .slash-cmd-runtime-prefix) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+  border-right: 0;
+  margin-right: 0;
+  padding-right: 0;
+}
+.ProseMirror .slash-cmd-pill + .slash-cmd-pill,
+.ProseMirror .slash-cmd-runtime-prefix + .slash-cmd-pill {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+  border-left: 0;
+  margin-left: 0;
+  padding-left: 0;
 }
 
 /* 快速开始预填胶囊 — QuickStartPillMark。点击 New Maker 快速开始卡片后

--- a/apps/mobile/src/__tests__/messageActions.test.ts
+++ b/apps/mobile/src/__tests__/messageActions.test.ts
@@ -84,6 +84,12 @@ describe('messageActions', () => {
     expect(mobileMessageShowsActionBar({ ...base, hasSystemCard: true, kind: 'user' })).toBe(false);
   });
 
+  it('projects Pi runtime /skill: aliases when copying a user message', () => {
+    expect(buildMobileMessageCopyText(normalizedMessage({
+      body: '/skill:git follow-up review',
+    }))).toBe('/git follow-up review');
+  });
+
   it('builds desktop-compatible copy text with attachment names', () => {
     expect(buildMobileMessageCopyText(normalizedMessage({
       body: 'Please inspect this.',

--- a/apps/mobile/src/__tests__/messageActions.test.ts
+++ b/apps/mobile/src/__tests__/messageActions.test.ts
@@ -84,10 +84,14 @@ describe('messageActions', () => {
     expect(mobileMessageShowsActionBar({ ...base, hasSystemCard: true, kind: 'user' })).toBe(false);
   });
 
-  it('projects Pi runtime /skill: aliases when copying a user message', () => {
+  it('projects confirmed Pi runtime /skill: aliases when copying a user message', () => {
     expect(buildMobileMessageCopyText(normalizedMessage({
       body: '/skill:git follow-up review',
+      slashCommandRanges: [{ start: 0, end: 10 }],
     }))).toBe('/git follow-up review');
+    expect(buildMobileMessageCopyText(normalizedMessage({
+      body: '/skill:git is just prose here',
+    }))).toBe('/skill:git is just prose here');
   });
 
   it('builds desktop-compatible copy text with attachment names', () => {

--- a/apps/mobile/src/__tests__/messageActions.test.ts
+++ b/apps/mobile/src/__tests__/messageActions.test.ts
@@ -92,6 +92,19 @@ describe('messageActions', () => {
     expect(buildMobileMessageCopyText(normalizedMessage({
       body: '/skill:git is just prose here',
     }))).toBe('/skill:git is just prose here');
+    const quoted = [
+      '> <!-- cindy-composer-quote -->',
+      '> quoted',
+      '',
+      '/skill:git follow-up review',
+    ].join('\n');
+    expect(buildMobileMessageCopyText(normalizedMessage({
+      body: quoted,
+      quotesEncoded: true,
+      slashCommandRanges: [
+        { start: quoted.indexOf('/skill:git'), end: quoted.indexOf('/skill:git') + 10 },
+      ],
+    }))).toBe(['> quoted', '', '/git follow-up review'].join('\n'));
   });
 
   it('builds desktop-compatible copy text with attachment names', () => {

--- a/apps/mobile/src/__tests__/sentMessageAtoms.test.ts
+++ b/apps/mobile/src/__tests__/sentMessageAtoms.test.ts
@@ -88,4 +88,12 @@ describe('sent message atoms', () => {
       [{ start, end: start + 'private payload'.length, display: 'Pasted text (1 line)' }],
     ))).toBe('before Pasted text (1 line) after');
   });
+
+  it('projects Pi runtime /skill: chips to the human slash label', () => {
+    expect(sentInlineTokensDisplayText(buildSentInlineTokens(
+      '/skill:git follow-up',
+      [],
+      [{ start: 0, end: 10 }],
+    ))).toBe('/git follow-up');
+  });
 });

--- a/apps/mobile/src/session/SentInlineAtomBody.tsx
+++ b/apps/mobile/src/session/SentInlineAtomBody.tsx
@@ -6,6 +6,7 @@ import {
   type TextStyle,
   type ViewStyle,
 } from "react-native";
+import { slashCommandDisplayLabel } from "@cindy/maker-shared/composer-palette";
 import { FileText } from "lucide-react-native";
 import { Text } from "@/components/AppText";
 import { InlineQuoteChip } from "@/session/InlineQuoteChip";
@@ -100,11 +101,12 @@ export function SentInlineAtomBody({
           );
         }
         if (token.kind === "slash") {
+          const slashLabel = slashCommandDisplayLabel(token.text);
           return (
             <InlineReferenceChip
-              accessibilityLabel={token.text}
+              accessibilityLabel={slashLabel}
               key={`slash:${index}`}
-              label={token.text}
+              label={slashLabel}
               testID="message.slashCommandChip"
             />
           );

--- a/apps/mobile/src/session/conversationShareProjection.ts
+++ b/apps/mobile/src/session/conversationShareProjection.ts
@@ -2,6 +2,7 @@ import {
   parseChatQuoteSegments,
   stripChatQuoteMarkerLines,
 } from '@cindy/maker-shared/chat-quotes';
+import { slashCommandDisplayLabel } from '@cindy/maker-shared/composer-palette';
 import {
   type ConversationShareAttachment,
   type ConversationShareBodyPart,
@@ -130,7 +131,7 @@ function projectBodyParts(
       if (token.display) parts.push({ kind: 'pasted', label: token.display });
       continue;
     }
-    if (token.text) parts.push({ kind: 'slash', label: token.text });
+    if (token.text) parts.push({ kind: 'slash', label: slashCommandDisplayLabel(token.text) });
   }
   return parts;
 }

--- a/apps/mobile/src/session/messageActions.ts
+++ b/apps/mobile/src/session/messageActions.ts
@@ -1,5 +1,6 @@
 import type { NormalizedRemoteMessage } from '@/session/messageNormalize';
 import { stripChatQuoteMarkerLines } from '@cindy/maker-shared/chat-quotes';
+import { projectSlashCommandsInText } from '@cindy/maker-shared/composer-palette';
 import { formatCompactTokens } from '@cindy/maker-shared/usage-format';
 import { i18n } from '@/i18n';
 import {
@@ -25,9 +26,10 @@ type ClipboardNavigator = {
 };
 
 export function buildMobileMessageCopyText(message: NormalizedRemoteMessage): string {
-  const body = message.quotesEncoded
+  const rawBody = message.quotesEncoded
     ? stripChatQuoteMarkerLines(message.body)
     : message.body;
+  const body = projectSlashCommandsInText(rawBody);
   const parts = [body];
   if (message.secondaryBody) parts.push(message.secondaryBody);
   const attachments = message.attachments?.map((item) => item.name).filter(Boolean) ?? [];

--- a/apps/mobile/src/session/messageActions.ts
+++ b/apps/mobile/src/session/messageActions.ts
@@ -29,7 +29,7 @@ export function buildMobileMessageCopyText(message: NormalizedRemoteMessage): st
   const rawBody = message.quotesEncoded
     ? stripChatQuoteMarkerLines(message.body)
     : message.body;
-  const body = projectSlashCommandsInText(rawBody);
+  const body = projectSlashCommandsInText(rawBody, message.slashCommandRanges);
   const parts = [body];
   if (message.secondaryBody) parts.push(message.secondaryBody);
   const attachments = message.attachments?.map((item) => item.name).filter(Boolean) ?? [];

--- a/apps/mobile/src/session/messageActions.ts
+++ b/apps/mobile/src/session/messageActions.ts
@@ -26,10 +26,10 @@ type ClipboardNavigator = {
 };
 
 export function buildMobileMessageCopyText(message: NormalizedRemoteMessage): string {
-  const rawBody = message.quotesEncoded
-    ? stripChatQuoteMarkerLines(message.body)
-    : message.body;
-  const body = projectSlashCommandsInText(rawBody, message.slashCommandRanges);
+  const projectedBody = projectSlashCommandsInText(message.body, message.slashCommandRanges);
+  const body = message.quotesEncoded
+    ? stripChatQuoteMarkerLines(projectedBody)
+    : projectedBody;
   const parts = [body];
   if (message.secondaryBody) parts.push(message.secondaryBody);
   const attachments = message.attachments?.map((item) => item.name).filter(Boolean) ?? [];

--- a/apps/mobile/src/session/sentMessageAtoms.ts
+++ b/apps/mobile/src/session/sentMessageAtoms.ts
@@ -3,6 +3,7 @@ import {
   type ChatQuote,
   type ChatQuoteSegment,
 } from '@cindy/maker-shared/chat-quotes';
+import { slashCommandDisplayLabel } from '@cindy/maker-shared/composer-palette';
 
 export interface SentPastedTextRange {
   start: number;
@@ -178,7 +179,11 @@ export function sentInlineTokensDisplayText(tokens: readonly SentInlineToken[]):
       if (!display.endsWith('\n')) display += '\n';
       continue;
     }
-    display += token.kind === 'pasted' ? token.display : token.text;
+    display += token.kind === 'pasted'
+      ? token.display
+      : token.kind === 'slash'
+        ? slashCommandDisplayLabel(token.text)
+        : token.text;
   }
   return display.trimEnd();
 }

--- a/packages/maker-shared/src/__tests__/composerPalette.test.ts
+++ b/packages/maker-shared/src/__tests__/composerPalette.test.ts
@@ -6,7 +6,10 @@ import {
   insertAtResource,
   insertSlashCommand,
   mergeSlashCommands,
+  projectSlashCommandsInText,
   serializeAtResource,
+  slashCommandDisplayLabel,
+  slashCommandRuntimePrefixLength,
 } from '../composerPalette.js';
 
 describe('shared composer palette model', () => {
@@ -97,5 +100,26 @@ describe('shared composer palette model', () => {
       .toBe('@.claude/agents/reviewer.md');
     expect(serializeAtResource({ type: 'file', name: 'design notes.md', relPath: 'docs/design notes.md' }))
       .toBe('@"docs/design notes.md"');
+  });
+
+  it('projects Pi runtime /skill: aliases to the human slash label', () => {
+    expect(slashCommandDisplayLabel('/skill:git')).toBe('/git');
+    expect(slashCommandDisplayLabel('/git')).toBe('/git');
+    expect(slashCommandDisplayLabel('/compact')).toBe('/compact');
+    expect(projectSlashCommandsInText(['/skill:git follow-up', '/skill:help'].join('\n'))).toBe(
+      ['/git follow-up', '/help'].join('\n'),
+    );
+    expect(
+      slashCommandRuntimePrefixLength('/skill:git', {
+        name: 'git',
+        runtimeCommandName: 'skill:git',
+      }),
+    ).toBe(6);
+    expect(
+      slashCommandRuntimePrefixLength('/git', {
+        name: 'git',
+        runtimeCommandName: 'skill:git',
+      }),
+    ).toBe(0);
   });
 });

--- a/packages/maker-shared/src/__tests__/composerPalette.test.ts
+++ b/packages/maker-shared/src/__tests__/composerPalette.test.ts
@@ -7,6 +7,7 @@ import {
   insertSlashCommand,
   mergeSlashCommands,
   projectSlashCommandsInText,
+  restoreSlashCommandRuntimeAlias,
   serializeAtResource,
   slashCommandDisplayLabel,
   slashCommandRuntimePrefixLength,
@@ -106,9 +107,14 @@ describe('shared composer palette model', () => {
     expect(slashCommandDisplayLabel('/skill:git')).toBe('/git');
     expect(slashCommandDisplayLabel('/git')).toBe('/git');
     expect(slashCommandDisplayLabel('/compact')).toBe('/compact');
-    expect(projectSlashCommandsInText(['/skill:git follow-up', '/skill:help'].join('\n'))).toBe(
-      ['/git follow-up', '/help'].join('\n'),
+    expect(projectSlashCommandsInText('/skill:git follow-up')).toBe('/skill:git follow-up');
+    expect(projectSlashCommandsInText('/skill:git follow-up', [{ start: 0, end: 10 }])).toBe(
+      '/git follow-up',
     );
+    expect(
+      restoreSlashCommandRuntimeAlias('/skill:git follow-up', '/git please review'),
+    ).toBe('/skill:git please review');
+    expect(restoreSlashCommandRuntimeAlias('/skill:git follow-up', '/help')).toBe('/help');
     expect(
       slashCommandRuntimePrefixLength('/skill:git', {
         name: 'git',

--- a/packages/maker-shared/src/__tests__/composerPalette.test.ts
+++ b/packages/maker-shared/src/__tests__/composerPalette.test.ts
@@ -5,6 +5,7 @@ import {
   filterSlashCommands,
   insertAtResource,
   insertSlashCommand,
+  leadingSlashCommandRange,
   mergeSlashCommands,
   projectSlashCommandsInText,
   restoreSlashCommandRuntimeAlias,
@@ -115,6 +116,17 @@ describe('shared composer palette model', () => {
       restoreSlashCommandRuntimeAlias('/skill:git follow-up', '/git please review'),
     ).toBe('/skill:git please review');
     expect(restoreSlashCommandRuntimeAlias('/skill:git follow-up', '/help')).toBe('/help');
+    expect(leadingSlashCommandRange('/skill:git please review')).toEqual({ start: 0, end: 10 });
+    const quoted = [
+      '> <!-- cindy-composer-quote -->',
+      '> quoted',
+      '',
+      '/skill:git follow-up',
+    ].join('\n');
+    const skillStart = quoted.indexOf('/skill:git');
+    expect(
+      projectSlashCommandsInText(quoted, [{ start: skillStart, end: skillStart + 10 }]),
+    ).toContain('/git follow-up');
     expect(
       slashCommandRuntimePrefixLength('/skill:git', {
         name: 'git',

--- a/packages/maker-shared/src/__tests__/composerPalette.test.ts
+++ b/packages/maker-shared/src/__tests__/composerPalette.test.ts
@@ -132,6 +132,11 @@ describe('shared composer palette model', () => {
         { runtimeCommandName: 'skill:git' },
       ]),
     ).toBe('/git and /skill:unknown');
+    expect(
+      projectKnownRuntimeSlashCommands('docs/skill:git and x/skill:git text', [
+        { runtimeCommandName: 'skill:git' },
+      ]),
+    ).toBe('docs/skill:git and x/skill:git text');
     const quoted = [
       '> <!-- cindy-composer-quote -->',
       '> quoted',

--- a/packages/maker-shared/src/__tests__/composerPalette.test.ts
+++ b/packages/maker-shared/src/__tests__/composerPalette.test.ts
@@ -6,8 +6,8 @@ import {
   insertAtResource,
   insertSlashCommand,
   leadingSlashCommandRange,
+  leadingSlashInvocation,
   mergeSlashCommands,
-  projectKnownRuntimeSlashCommands,
   projectSlashCommandsInText,
   restoreSlashCommandRuntimeAlias,
   serializeAtResource,
@@ -127,16 +127,13 @@ describe('shared composer palette model', () => {
       start: quotedRuntimeStart,
       end: quotedRuntimeStart + 10,
     });
-    expect(
-      projectKnownRuntimeSlashCommands('/skill:git and /skill:unknown', [
-        { runtimeCommandName: 'skill:git' },
-      ]),
-    ).toBe('/git and /skill:unknown');
-    expect(
-      projectKnownRuntimeSlashCommands('docs/skill:git and x/skill:git text', [
-        { runtimeCommandName: 'skill:git' },
-      ]),
-    ).toBe('docs/skill:git and x/skill:git text');
+    expect(leadingSlashInvocation('  \n/git please')).toEqual({
+      start: 3,
+      end: 7,
+      name: 'git',
+    });
+    expect(leadingSlashInvocation('please /git')).toBeUndefined();
+    expect(leadingSlashInvocation('> quoted\n\n/git')).toBeUndefined();
     const quoted = [
       '> <!-- cindy-composer-quote -->',
       '> quoted',

--- a/packages/maker-shared/src/__tests__/composerPalette.test.ts
+++ b/packages/maker-shared/src/__tests__/composerPalette.test.ts
@@ -114,12 +114,36 @@ describe('shared composer palette model', () => {
       '/git follow-up',
     );
     expect(
-      restoreSlashCommandRuntimeAlias('/skill:git follow-up', '/git please review'),
+      restoreSlashCommandRuntimeAlias(
+        '/skill:git follow-up',
+        '/git please review',
+        [{ start: 0, end: 10 }],
+      ),
     ).toBe('/skill:git please review');
-    expect(restoreSlashCommandRuntimeAlias('/skill:git follow-up', '/help')).toBe('/help');
+    expect(restoreSlashCommandRuntimeAlias('/skill:git follow-up', '/git please review')).toBe(
+      '/git please review',
+    );
     expect(
-      restoreSlashCommandRuntimeAlias('> quoted\n\n/skill:git follow-up', '> quoted\n\n/git please'),
+      restoreSlashCommandRuntimeAlias('/skill:git follow-up', '/help', [{ start: 0, end: 10 }]),
+    ).toBe('/help');
+    const quotedOriginal = '> quoted\n\n/skill:git follow-up';
+    const quotedSkillStart = quotedOriginal.indexOf('/skill:git');
+    expect(
+      restoreSlashCommandRuntimeAlias(
+        quotedOriginal,
+        '> quoted\n\n/git please',
+        [{ start: quotedSkillStart, end: quotedSkillStart + 10 }],
+      ),
     ).toBe('> quoted\n\n/skill:git please');
+    const mixed = '/skill:unknown\n/help later';
+    const helpStart = mixed.indexOf('/help');
+    expect(
+      restoreSlashCommandRuntimeAlias(
+        mixed,
+        '/unknown\n/help later',
+        [{ start: helpStart, end: helpStart + 5 }],
+      ),
+    ).toBe('/unknown\n/help later');
     expect(leadingSlashCommandRange('/skill:git please review')).toEqual({ start: 0, end: 10 });
     const quotedRuntime = '> quoted\n\n/skill:git please';
     const quotedRuntimeStart = quotedRuntime.indexOf('/skill:git');

--- a/packages/maker-shared/src/__tests__/composerPalette.test.ts
+++ b/packages/maker-shared/src/__tests__/composerPalette.test.ts
@@ -3,6 +3,7 @@ import {
   detectComposerTrigger,
   filterAtResources,
   filterSlashCommands,
+  findSlashCommandToken,
   insertAtResource,
   insertSlashCommand,
   leadingSlashCommandRange,
@@ -144,6 +145,32 @@ describe('shared composer palette model', () => {
         [{ start: helpStart, end: helpStart + 5 }],
       ),
     ).toBe('/unknown\n/help later');
+    expect(findSlashCommandToken('  /skill:git old')).toEqual({
+      start: 2,
+      end: 12,
+      name: 'skill:git',
+    });
+    expect(
+      restoreSlashCommandRuntimeAlias(
+        '  /skill:git old',
+        '  /git new',
+        [{ start: 2, end: 12 }],
+      ),
+    ).toBe('  /skill:git new');
+    const wireQuote = [
+      '> <!-- cindy-composer-quote -->',
+      '> quoted',
+      '',
+      '/skill:git follow-up',
+    ].join('\n');
+    const wireSkillStart = wireQuote.indexOf('/skill:git');
+    expect(
+      restoreSlashCommandRuntimeAlias(
+        wireQuote,
+        'quoted\n\n/git please',
+        [{ start: wireSkillStart, end: wireSkillStart + 10 }],
+      ),
+    ).toBe('quoted\n\n/skill:git please');
     expect(leadingSlashCommandRange('/skill:git please review')).toEqual({ start: 0, end: 10 });
     const quotedRuntime = '> quoted\n\n/skill:git please';
     const quotedRuntimeStart = quotedRuntime.indexOf('/skill:git');

--- a/packages/maker-shared/src/__tests__/composerPalette.test.ts
+++ b/packages/maker-shared/src/__tests__/composerPalette.test.ts
@@ -7,6 +7,7 @@ import {
   insertSlashCommand,
   leadingSlashCommandRange,
   mergeSlashCommands,
+  projectKnownRuntimeSlashCommands,
   projectSlashCommandsInText,
   restoreSlashCommandRuntimeAlias,
   serializeAtResource,
@@ -116,7 +117,21 @@ describe('shared composer palette model', () => {
       restoreSlashCommandRuntimeAlias('/skill:git follow-up', '/git please review'),
     ).toBe('/skill:git please review');
     expect(restoreSlashCommandRuntimeAlias('/skill:git follow-up', '/help')).toBe('/help');
+    expect(
+      restoreSlashCommandRuntimeAlias('> quoted\n\n/skill:git follow-up', '> quoted\n\n/git please'),
+    ).toBe('> quoted\n\n/skill:git please');
     expect(leadingSlashCommandRange('/skill:git please review')).toEqual({ start: 0, end: 10 });
+    const quotedRuntime = '> quoted\n\n/skill:git please';
+    const quotedRuntimeStart = quotedRuntime.indexOf('/skill:git');
+    expect(leadingSlashCommandRange(quotedRuntime)).toEqual({
+      start: quotedRuntimeStart,
+      end: quotedRuntimeStart + 10,
+    });
+    expect(
+      projectKnownRuntimeSlashCommands('/skill:git and /skill:unknown', [
+        { runtimeCommandName: 'skill:git' },
+      ]),
+    ).toBe('/git and /skill:unknown');
     const quoted = [
       '> <!-- cindy-composer-quote -->',
       '> quoted',

--- a/packages/maker-shared/src/composerPalette.ts
+++ b/packages/maker-shared/src/composerPalette.ts
@@ -97,6 +97,37 @@ export function insertSlashCommand(
   return `${text.slice(0, trigger.from)}/${command.name} `;
 }
 
+/** Pi runtime invocation is `/skill:name`. Display layer always shows `/name`. */
+const PI_SKILL_RUNTIME_TOKEN_RE = /^\/skill:(\S+)$/i;
+const PI_SKILL_RUNTIME_IN_TEXT_RE = /(^|\n)\/skill:(\S+)/gi;
+const PI_SKILL_RUNTIME_PREFIX = 'skill:';
+
+/** Project a stored slash token (`/skill:git` or `/git`) to the human label. */
+export function slashCommandDisplayLabel(commandText: string): string {
+  const match = commandText.match(PI_SKILL_RUNTIME_TOKEN_RE);
+  return match ? `/${match[1]}` : commandText;
+}
+
+/** Project every line-start `/skill:name` in a message body to `/name`. */
+export function projectSlashCommandsInText(text: string): string {
+  return text.replace(PI_SKILL_RUNTIME_IN_TEXT_RE, '$1/$2');
+}
+
+/**
+ * Length of the hidden `skill:` run after `/` when the visible token is a Pi
+ * runtime alias. Zero when the document already uses the human name.
+ */
+export function slashCommandRuntimePrefixLength(
+  commandText: string,
+  command: { name?: string; runtimeCommandName?: string },
+): number {
+  const runtime = command.runtimeCommandName?.trim();
+  if (!runtime || !runtime.toLowerCase().startsWith(PI_SKILL_RUNTIME_PREFIX)) return 0;
+  const body = commandText.startsWith('/') ? commandText.slice(1) : commandText;
+  if (body.toLowerCase() !== runtime.toLowerCase()) return 0;
+  return PI_SKILL_RUNTIME_PREFIX.length;
+}
+
 export function insertAtResource(
   text: string,
   trigger: ComposerTrigger,

--- a/packages/maker-shared/src/composerPalette.ts
+++ b/packages/maker-shared/src/composerPalette.ts
@@ -99,7 +99,6 @@ export function insertSlashCommand(
 
 /** Pi runtime invocation is `/skill:name`. Display layer always shows `/name`. */
 const PI_SKILL_RUNTIME_TOKEN_RE = /^\/skill:(\S+)$/i;
-const PI_SKILL_RUNTIME_IN_TEXT_RE = /(^|\n)\/skill:(\S+)/gi;
 const PI_SKILL_RUNTIME_PREFIX = 'skill:';
 
 /** Project a stored slash token (`/skill:git` or `/git`) to the human label. */
@@ -108,9 +107,43 @@ export function slashCommandDisplayLabel(commandText: string): string {
   return match ? `/${match[1]}` : commandText;
 }
 
-/** Project every line-start `/skill:name` in a message body to `/name`. */
-export function projectSlashCommandsInText(text: string): string {
-  return text.replace(PI_SKILL_RUNTIME_IN_TEXT_RE, '$1/$2');
+/**
+ * Project confirmed slash runs in a message body to the human label.
+ * Without ranges, leave the text untouched — ordinary `/skill:foo` prose
+ * must not be rewritten.
+ */
+export function projectSlashCommandsInText(
+  text: string,
+  ranges?: readonly { start: number; end: number }[],
+): string {
+  if (!ranges || ranges.length === 0) return text;
+  let result = text;
+  const ordered = [...ranges].sort((a, b) => b.start - a.start);
+  for (const range of ordered) {
+    if (range.start < 0 || range.end > result.length || range.end <= range.start) continue;
+    const token = result.slice(range.start, range.end);
+    const display = slashCommandDisplayLabel(token);
+    if (display === token) continue;
+    result = `${result.slice(0, range.start)}${display}${result.slice(range.end)}`;
+  }
+  return result;
+}
+
+/**
+ * Put a displayed `/git ...` back to the stored `/skill:git ...` when the
+ * user is resending an edited Pi skill message. Leave other commands alone.
+ */
+export function restoreSlashCommandRuntimeAlias(
+  originalText: string,
+  editedText: string,
+): string {
+  const originalCommand = originalText.match(/^\/(\S+)/)?.[1];
+  const editedCommand = editedText.match(/^\/(\S+)/)?.[1];
+  if (!originalCommand || !editedCommand) return editedText;
+  if (!originalCommand.toLowerCase().startsWith(PI_SKILL_RUNTIME_PREFIX)) return editedText;
+  const humanName = originalCommand.slice(PI_SKILL_RUNTIME_PREFIX.length);
+  if (!humanName || editedCommand.toLowerCase() !== humanName.toLowerCase()) return editedText;
+  return `/${originalCommand}${editedText.slice(editedCommand.length + 1)}`;
 }
 
 /**

--- a/packages/maker-shared/src/composerPalette.ts
+++ b/packages/maker-shared/src/composerPalette.ts
@@ -133,25 +133,51 @@ export function projectSlashCommandsInText(
  * Put a displayed `/git ...` back to the stored `/skill:git ...` when the
  * user is resending an edited Pi skill message. Leave other commands alone.
  */
+export function findSlashCommandToken(
+  text: string,
+): { start: number; end: number; name: string } | undefined {
+  const match = /(?:^|\n)(\/\S+)/.exec(text);
+  if (!match || match.index === undefined) return undefined;
+  const start = match.index + match[0].length - match[1].length;
+  return { start, end: start + match[1].length, name: match[1].slice(1) };
+}
+
 export function restoreSlashCommandRuntimeAlias(
   originalText: string,
   editedText: string,
 ): string {
-  const originalCommand = originalText.match(/^\/(\S+)/)?.[1];
-  const editedCommand = editedText.match(/^\/(\S+)/)?.[1];
-  if (!originalCommand || !editedCommand) return editedText;
-  if (!originalCommand.toLowerCase().startsWith(PI_SKILL_RUNTIME_PREFIX)) return editedText;
-  const humanName = originalCommand.slice(PI_SKILL_RUNTIME_PREFIX.length);
-  if (!humanName || editedCommand.toLowerCase() !== humanName.toLowerCase()) return editedText;
-  return `/${originalCommand}${editedText.slice(editedCommand.length + 1)}`;
+  const original = findSlashCommandToken(originalText);
+  const edited = findSlashCommandToken(editedText);
+  if (!original || !edited) return editedText;
+  if (!original.name.toLowerCase().startsWith(PI_SKILL_RUNTIME_PREFIX)) return editedText;
+  const humanName = original.name.slice(PI_SKILL_RUNTIME_PREFIX.length);
+  if (!humanName || edited.name.toLowerCase() !== humanName.toLowerCase()) return editedText;
+  return `${editedText.slice(0, edited.start)}/${original.name}${editedText.slice(edited.end)}`;
 }
 
-/** Range of a leading `/command` token in already-restored submit text. */
+/** Range of the first `/command` token in already-restored submit text. */
 export function leadingSlashCommandRange(
   text: string,
 ): { start: number; end: number } | undefined {
-  const match = text.match(/^\/\S+/);
-  return match ? { start: 0, end: match[0].length } : undefined;
+  const token = findSlashCommandToken(text);
+  return token ? { start: token.start, end: token.end } : undefined;
+}
+
+/** Clipboard / display projection for roster-known `/skill:name` tokens. */
+export function projectKnownRuntimeSlashCommands(
+  text: string,
+  commands: readonly { runtimeCommandName?: string }[],
+): string {
+  const known = new Set(
+    commands
+      .map((command) => command.runtimeCommandName?.trim().toLowerCase())
+      .filter((name): name is string => Boolean(name?.startsWith(PI_SKILL_RUNTIME_PREFIX))),
+  );
+  if (known.size === 0) return text;
+  return text.replace(/\/skill:\S+/gi, (token) => {
+    const name = token.slice(1).toLowerCase();
+    return known.has(name) ? slashCommandDisplayLabel(token) : token;
+  });
 }
 
 /**

--- a/packages/maker-shared/src/composerPalette.ts
+++ b/packages/maker-shared/src/composerPalette.ts
@@ -174,9 +174,9 @@ export function projectKnownRuntimeSlashCommands(
       .filter((name): name is string => Boolean(name?.startsWith(PI_SKILL_RUNTIME_PREFIX))),
   );
   if (known.size === 0) return text;
-  return text.replace(/\/skill:\S+/gi, (token) => {
+  return text.replace(/(^|[\s\n])(\/skill:\S+)/gi, (full, prefix: string, token: string) => {
     const name = token.slice(1).toLowerCase();
-    return known.has(name) ? slashCommandDisplayLabel(token) : token;
+    return known.has(name) ? `${prefix}${slashCommandDisplayLabel(token)}` : full;
   });
 }
 

--- a/packages/maker-shared/src/composerPalette.ts
+++ b/packages/maker-shared/src/composerPalette.ts
@@ -146,6 +146,14 @@ export function restoreSlashCommandRuntimeAlias(
   return `/${originalCommand}${editedText.slice(editedCommand.length + 1)}`;
 }
 
+/** Range of a leading `/command` token in already-restored submit text. */
+export function leadingSlashCommandRange(
+  text: string,
+): { start: number; end: number } | undefined {
+  const match = text.match(/^\/\S+/);
+  return match ? { start: 0, end: match[0].length } : undefined;
+}
+
 /**
  * Length of the hidden `skill:` run after `/` when the visible token is a Pi
  * runtime alias. Zero when the document already uses the human name.

--- a/packages/maker-shared/src/composerPalette.ts
+++ b/packages/maker-shared/src/composerPalette.ts
@@ -163,21 +163,19 @@ export function leadingSlashCommandRange(
   return token ? { start: token.start, end: token.end } : undefined;
 }
 
-/** Clipboard / display projection for roster-known `/skill:name` tokens. */
-export function projectKnownRuntimeSlashCommands(
+/**
+ * First `/token` after leading whitespace. Same recognition window as Pi
+ * (`text.trimStart().startsWith('/skill:')`): leading spaces/newlines count,
+ * a quote block or other prose before the slash does not.
+ */
+export function leadingSlashInvocation(
   text: string,
-  commands: readonly { runtimeCommandName?: string }[],
-): string {
-  const known = new Set(
-    commands
-      .map((command) => command.runtimeCommandName?.trim().toLowerCase())
-      .filter((name): name is string => Boolean(name?.startsWith(PI_SKILL_RUNTIME_PREFIX))),
-  );
-  if (known.size === 0) return text;
-  return text.replace(/(^|[\s\n])(\/skill:\S+)/gi, (full, prefix: string, token: string) => {
-    const name = token.slice(1).toLowerCase();
-    return known.has(name) ? `${prefix}${slashCommandDisplayLabel(token)}` : full;
-  });
+): { start: number; end: number; name: string } | undefined {
+  const start = text.search(/\S/);
+  if (start < 0 || text[start] !== '/') return undefined;
+  const token = text.slice(start).match(/^\/\S+/)?.[0];
+  if (!token) return undefined;
+  return { start, end: start + token.length, name: token.slice(1) };
 }
 
 /**

--- a/packages/maker-shared/src/composerPalette.ts
+++ b/packages/maker-shared/src/composerPalette.ts
@@ -136,7 +136,7 @@ export function projectSlashCommandsInText(
 export function findSlashCommandToken(
   text: string,
 ): { start: number; end: number; name: string } | undefined {
-  const match = /(?:^|\n)(\/\S+)/.exec(text);
+  const match = /(?:^|\n)[^\S\n]*(\/\S+)/.exec(text);
   if (!match || match.index === undefined) return undefined;
   const start = match.index + match[0].length - match[1].length;
   return { start, end: start + match[1].length, name: match[1].slice(1) };

--- a/packages/maker-shared/src/composerPalette.ts
+++ b/packages/maker-shared/src/composerPalette.ts
@@ -142,13 +142,24 @@ export function findSlashCommandToken(
   return { start, end: start + match[1].length, name: match[1].slice(1) };
 }
 
+/** True when a confirmed slash range covers this token. */
+export function slashCommandRangeCoversToken(
+  ranges: readonly { start: number; end: number }[] | undefined,
+  token: { start: number; end: number } | undefined,
+): boolean {
+  if (!ranges || !token) return false;
+  return ranges.some((range) => range.start <= token.start && range.end >= token.end);
+}
+
 export function restoreSlashCommandRuntimeAlias(
   originalText: string,
   editedText: string,
+  confirmedRanges?: readonly { start: number; end: number }[],
 ): string {
   const original = findSlashCommandToken(originalText);
   const edited = findSlashCommandToken(editedText);
   if (!original || !edited) return editedText;
+  if (!slashCommandRangeCoversToken(confirmedRanges, original)) return editedText;
   if (!original.name.toLowerCase().startsWith(PI_SKILL_RUNTIME_PREFIX)) return editedText;
   const humanName = original.name.slice(PI_SKILL_RUNTIME_PREFIX.length);
   if (!humanName || edited.name.toLowerCase() !== humanName.toLowerCase()) return editedText;


### PR DESCRIPTION
## 这次改了什么

### 摘要

Pi 点选 skill 后，输入框和已发送气泡会把线路名 `/skill:git` 直接画成胶囊，和 Claude Code / Codex 的 `/git` 不一致，长 token 还会把行首 padding 画到输入卡片外面。

展示层现在一律显示人类名 `/git`：点选写入 `/git`，手打或旧草稿里的 `/skill:git` 点亮胶囊但藏掉 `skill:`。Pi 仍在发送时改写成 `/skill:git`，加载契约不变。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：
  - 输入框点选写入 `command.name`（`/git`）
  - 装饰同时匹配 `name` 与 `runtimeCommandName`，并隐藏 `skill:` 前缀
  - 已发送气泡、复制、再编辑、手机端分享/复制同步投影
  - slash 胶囊改为 `inline-flex`，避免行首悬挂绘制溢出
  - 发送改写与 Pi `trimStart()` 对齐（前导空白/换行后的 `/git` 会改成 `/skill:git`）
- 明确不包含：不改 Pi 发送/逃逸/Extra Dirs 线路契约；不改 CC/Codex 调用名；不按 range 改写句中或引用后的 slash
- 用户可见变化：Pi 任务里 skill 胶囊、复制文案与其它 harness 一样显示 `/git`
- 是否存在 breaking change：无

### 不变量（round 7 检查点）

1. **展示 ≠ 线路**：输入框 / 气泡 / 再编辑显示 `/git`；落库与发给 Pi 的正文才是 `/skill:git`。
2. **发送改写只认 Pi 同一条 leading 规则**：`trimStart()` 后的第一个 token（`leadingSlashInvocation`）。前导空白/换行要改写；引用块后、句中不改写——Pi 本来也不会加载。不按 `slashCommandRanges` 做全文改写。
3. **投影只走已确认 range**：无 range 不动原文。
4. **恢复别名只走已确认 range**：未确认的 `/skill:` 散文不改回。
5. **剪贴板 = 线路原文**：`serializeEditorSlice` 不投影。已删除未使用的 `projectKnownRuntimeSlashCommands`，避免第三套判据。

### UI 变化

- 引用的设计规范：DESIGN.md §1 Key Characteristics（pill-first / 9999px）；§2 Chip & Button Neutrals（`--surface-chip` / `--border-default`）；§4 Component Stylings / Buttons 与 §5 圆角三档（胶囊 9999px）。产品原则 `core-product-principles.md` §2：不把内部实现（Pi 的 `/skill:` runtime 名）暴露为用户概念。颜色走语义 token，Light/Dark 共用同一套规则；Dark 本次未做实机目检。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop run typecheck
pnpm --filter @cindy/maker-shared run typecheck
结果：通过

pnpm --filter @cindy/maker-shared exec vitest run src/__tests__/composerPalette.test.ts
pnpm --filter desktop exec vitest run src/renderer/lib/__tests__/slashCommands.test.ts src/renderer/__tests__/reviewCommandDispatch.test.ts src/renderer/__tests__/userMessageEditBox.test.ts
结果：通过

pnpm test:unit:related
结果：本次改动相关用例通过。desktop 另有 2 条 ghostInstallReceipt 失败，已在 origin/main 干净基线复现，与本 diff 无关，交 CI 兜底。
```

### 手工验证

- 平台：macOS Desktop remote dev（worktree `cindy-slash-skill-display`，`--region=global --preserve-running`）
- 路径：Pi 任务输入 `/` 选 git → 胶囊显示 `/git`，行首不再溢出；发出去的气泡与复制为 `/git`

### 未执行的验证

- Dark 模式实机目检未做（样式只改 token / 盒模型，无新硬编码色）
- Mobile 真机/模拟器未跑（改动为 JS 展示投影，不碰原生指纹）

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop/Mobile 输入框与已发送消息的 slash skill 展示；Pi 发送仍走既有 rewrite
- 回滚 / 降级方式：revert 本 PR 即可，无 migration / 协议变更

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
