### PR TITLE
fix(sidebar): hover 时标题让位给更多/归档，避免叠字

### DIFF
--- a/apps/desktop/src/renderer/__tests__/sidebarSessionTime.test.ts
+++ b/apps/desktop/src/renderer/__tests__/sidebarSessionTime.test.ts
@@ -118,13 +118,8 @@ describe('SessionItem activity time', () => {
     );
     expect(sessionItemSource).toContain('group/slot relative ml-auto');
     expect(sessionItemSource).toContain(
-      'pointer-events-none opacity-0 group-hover:pointer-events-auto group-hover:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100',
+      'grid h-6 grid-cols-[max-content] items-center justify-items-end',
     );
-    expect(sessionItemSource).toContain('absolute right-0 top-0 flex h-6 items-center gap-0.5');
-    // hover / 菜单打开时不可见操作钮与信息层叠在同一格,槽宽取较大值而不是相加。
-    expect(sessionItemSource).toContain('grid h-6 grid-cols-[max-content] items-center justify-items-end');
-    expect(sessionItemSource).toContain(
-      "menuPos === null && 'hidden group-hover:flex group-focus-within/slot:flex'",
-    );
+    expect(sessionItemSource).toContain("'hidden group-hover:flex group-focus-within/slot:flex'");
   });
 });

--- a/apps/desktop/src/renderer/__tests__/sidebarSessionTime.test.ts
+++ b/apps/desktop/src/renderer/__tests__/sidebarSessionTime.test.ts
@@ -120,6 +120,10 @@ describe('SessionItem activity time', () => {
     expect(sessionItemSource).toContain(
       'grid h-6 grid-cols-[max-content] items-center justify-items-end',
     );
+    expect(sessionItemSource).toContain('absolute right-0 top-0 flex h-6 items-center gap-0.5');
+    expect(sessionItemSource).toContain(
+      'pointer-events-none opacity-0 group-hover:pointer-events-auto group-hover:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100',
+    );
     expect(sessionItemSource).toContain("'hidden group-hover:flex group-focus-within/slot:flex'");
   });
 });

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionCard.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionCard.tsx
@@ -75,7 +75,7 @@ import {
 import { SessionProjectMoveSubmenu } from './SessionProjectMoveSubmenu';
 import { SessionShareExportDialog } from './SessionShareExportDialog';
 import { SessionRenameInput } from '../SessionRenameInput';
-import type { SessionItemProps } from './SessionItem';
+import { SidebarTitleMarquee, type SessionItemProps } from './SessionItem';
 import { RemoteProjectIcon } from './RemoteProjectIcon';
 import { isRemoteSessionWriteBlocked } from '../lib/remoteSessionWriteGuard';
 import { prefetchDirtyWorktreeForRemoval } from '@/lib/worktreeRemovalWarning';
@@ -672,7 +672,11 @@ export function SessionCard({
               // inset shadow 画在盒内、不参与布局,行高与未选中时逐像素一致。
               isActive
                 ? 'bg-sidebar-item-active text-sidebar-item-active-foreground shadow-[inset_0_0_0_1px_var(--sidebar-item-active-border)]'
-                : 'hover:bg-sidebar-item-hover',
+                : cn(
+                    'hover:bg-sidebar-item-hover',
+                    // 菜单开着时鼠标常会离开行,行底仍保持 hover 色。
+                    menuPos !== null && 'bg-sidebar-item-hover',
+                  ),
             )
           : cn(
               // 卡片:白底 + 描边 + 圆角。多列瀑布由 CardMasonry/DraggableCardColumns
@@ -743,9 +747,9 @@ export function SessionCard({
                 />
               ) : (
                 <div className="flex min-w-0 flex-1 items-center gap-1">
-                  <span
+                  <SidebarTitleMarquee
+                    title={displayTitle}
                     className={cn(
-                      'min-w-0 truncate',
                       'text-sm font-medium leading-[1.3]',
                       isActive ? 'text-sidebar-item-active-foreground' : 'text-foreground',
                     )}
@@ -760,7 +764,7 @@ export function SessionCard({
                           ),
                         })
                       : displayTitle}
-                  </span>
+                  </SidebarTitleMarquee>
                   {remoteIconKind && (
                     <RemoteProjectIcon
                       kind={remoteIconKind}
@@ -1229,84 +1233,68 @@ function TimeActionsSlot({
   return (
     <div className="group/slot relative ml-auto flex h-[22px] shrink-0 items-center justify-end">
       <div className="grid h-[22px] grid-cols-[max-content] items-center justify-items-end">
-      {/* 默认内容:worktree + 信息槽;hover / 菜单打开 / archivePending 时淡出让位给操作钮。 */}
-      <div
-        className={cn(
-          // duration 与操作钮的渐显同拍(120ms),让位/回归一进一出同步。
-          'col-start-1 row-start-1 flex items-center gap-1 transition-opacity duration-[120ms]',
-          !archivePending && 'group-hover/card:opacity-0 group-focus-within/slot:opacity-0',
-          (menuOpen || yieldToOrdinalBadge) && 'opacity-0',
-          // 确认胶囊覆盖同一槽位时立即隐藏日期，避免 120ms 淡出期间文字叠在一起。
-          archivePending && 'invisible opacity-0',
-        )}
-      >
-        <WorktreeBadge sessionId={sessionId} size={11} className="size-3.5" />
-        <SessionInfoMeta
-          pieces={infoPieces}
-          prRef={infoPrRef}
-          isActive={isActive}
-          className="leading-none"
-        />
-      </div>
-
-      {canQuickArchive && archivePending && (
-        <span
-          aria-hidden
-          className="invisible col-start-1 row-start-1 inline-flex h-[22px] w-max min-w-14 items-center justify-center whitespace-nowrap rounded-full px-[9px] text-11 font-semibold"
-        >
-          {t('ccAgent.sidebar.sessionMenu.archived')}
-        </span>
-      )}
-      {yieldToOrdinalBadge && ordinalBadgeLabel ? (
-        <span aria-hidden className="invisible col-start-1 row-start-1 inline-flex">
-          <SessionOrdinalBadgeKbd label={ordinalBadgeLabel} />
-        </span>
-      ) : null}
-      {canQuickArchive && archivePending && (
-        <button
-          ref={confirmPillRef}
-          type="button"
-          onClick={(e) => {
-            e.stopPropagation();
-            setArchivePending(false);
-            onArchiveNow();
-          }}
-          onPointerDown={(e) => e.stopPropagation()}
-          onDoubleClick={(e) => e.stopPropagation()}
+        {/* 默认内容:worktree + 信息槽;hover / 菜单打开 / archivePending 时淡出让位给操作钮。 */}
+        <div
           className={cn(
-            'absolute right-0 top-1/2 z-20 flex h-[22px] w-max min-w-14 -translate-y-1/2 items-center justify-center rounded-full px-[9px]',
-            'whitespace-nowrap text-11 font-semibold',
-            'bg-[color-mix(in_srgb,hsl(var(--destructive))_15%,var(--surface-elevated))] text-[hsl(var(--destructive))]',
-            'hover:bg-[color-mix(in_srgb,hsl(var(--destructive))_25%,var(--surface-elevated))]',
-            'transition-colors focus:outline-none',
+            // duration 与操作钮的渐显同拍(120ms),让位/回归一进一出同步。
+            'col-start-1 row-start-1 flex items-center gap-1 transition-opacity duration-[120ms]',
+            !archivePending && 'group-hover/card:opacity-0 group-focus-within/slot:opacity-0',
+            (menuOpen || yieldToOrdinalBadge) && 'opacity-0',
+            // 确认胶囊覆盖同一槽位时立即隐藏日期，避免 120ms 淡出期间文字叠在一起。
+            archivePending && 'invisible opacity-0',
           )}
-          aria-label={t('ccAgent.sidebar.sessionMenu.archived')}
         >
-          {t('ccAgent.sidebar.sessionMenu.archived')}
-        </button>
-      )}
+          <WorktreeBadge sessionId={sessionId} size={11} className="size-3.5" />
+          <SessionInfoMeta
+            pieces={infoPieces}
+            prRef={infoPrRef}
+            isActive={isActive}
+            className="leading-none"
+          />
+        </div>
 
-      {!archivePending && (
-        <>
-          <div
+        {canQuickArchive && archivePending && (
+          <span
             aria-hidden
-            className={cn(
-              'invisible col-start-1 row-start-1 flex h-[22px] items-center gap-0.5',
-              !menuOpen && 'hidden group-hover/card:flex group-focus-within/slot:flex',
-            )}
+            className="invisible col-start-1 row-start-1 inline-flex h-[22px] w-max min-w-14 items-center justify-center whitespace-nowrap rounded-full px-[9px] text-11 font-semibold"
           >
-            <span className="size-5 shrink-0" />
-            {(isArchived && canUnarchive) || canQuickArchive ? <span className="size-5 shrink-0" /> : null}
-          </div>
-          <div
-            // 渐显(120ms)配 pointer-events 守卫:淡出期间按钮不占鼠标位置,
-            // 不会拦下卡片点击;键盘焦点不受 pointer-events 影响。
+            {t('ccAgent.sidebar.sessionMenu.archived')}
+          </span>
+        )}
+        {yieldToOrdinalBadge && ordinalBadgeLabel ? (
+          <span aria-hidden className="invisible col-start-1 row-start-1 inline-flex">
+            <SessionOrdinalBadgeKbd label={ordinalBadgeLabel} />
+          </span>
+        ) : null}
+        {canQuickArchive && archivePending && (
+          <button
+            ref={confirmPillRef}
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              setArchivePending(false);
+              onArchiveNow();
+            }}
+            onPointerDown={(e) => e.stopPropagation()}
+            onDoubleClick={(e) => e.stopPropagation()}
             className={cn(
-              'absolute right-0 top-1/2 flex -translate-y-1/2 items-center gap-0.5',
-              'transition-opacity duration-[120ms]',
-              menuOpen
-                ? 'opacity-100'
-                : 'pointer-events-none opacity-0 group-hover/card:pointer-events-auto group-hover/card:opacity-100 group-focus-within/slot:pointer-events-auto group-focus-within/slot:opacity-100',
+              'absolute right-0 top-1/2 z-20 flex h-[22px] w-max min-w-14 -translate-y-1/2 items-center justify-center rounded-full px-[9px]',
+              'whitespace-nowrap text-11 font-semibold',
+              'bg-[color-mix(in_srgb,hsl(var(--destructive))_15%,var(--surface-elevated))] text-[hsl(var(--destructive))]',
+              'hover:bg-[color-mix(in_srgb,hsl(var(--destructive))_25%,var(--surface-elevated))]',
+              'transition-colors focus:outline-none',
+            )}
+            aria-label={t('ccAgent.sidebar.sessionMenu.archived')}
+          >
+            {t('ccAgent.sidebar.sessionMenu.archived')}
+          </button>
+        )}
+
+        {!archivePending && (
+          <div
+            className={cn(
+              'col-start-1 row-start-1 h-[22px] items-center gap-0.5',
+              menuOpen ? 'flex' : 'hidden group-hover/card:flex group-focus-within/slot:flex',
             )}
           >
             <CardAction
@@ -1337,8 +1325,7 @@ function TimeActionsSlot({
               </CardAction>
             ) : null}
           </div>
-        </>
-      )}
+        )}
       </div>
     </div>
   );

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionCard.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionCard.tsx
@@ -1291,40 +1291,56 @@ function TimeActionsSlot({
         )}
 
         {!archivePending && (
-          <div
-            className={cn(
-              'col-start-1 row-start-1 h-[22px] items-center gap-0.5',
-              menuOpen ? 'flex' : 'hidden group-hover/card:flex group-focus-within/slot:flex',
-            )}
-          >
-            <CardAction
-              variant="list"
-              isActive={isActive}
-              label={t('ccAgent.sidebar.sessionMenu.moreActions')}
-              onClick={onOpenMenu}
+          <>
+            <div
+              aria-hidden
+              className={cn(
+                'invisible col-start-1 row-start-1 h-[22px] items-center gap-0.5',
+                menuOpen ? 'flex' : 'hidden group-hover/card:flex group-focus-within/slot:flex',
+              )}
             >
-              <EllipsisVertical size={14} strokeWidth={2} />
-            </CardAction>
-            {isArchived && canUnarchive ? (
+              <span className="size-5 shrink-0" />
+              {(isArchived && canUnarchive) || canQuickArchive ? (
+                <span className="size-5 shrink-0" />
+              ) : null}
+            </div>
+            <div
+              className={cn(
+                'absolute right-0 top-1/2 flex -translate-y-1/2 items-center gap-0.5',
+                menuOpen
+                  ? 'opacity-100'
+                  : 'pointer-events-none opacity-0 group-hover/card:pointer-events-auto group-hover/card:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100',
+              )}
+            >
               <CardAction
                 variant="list"
                 isActive={isActive}
-                label={t('ccAgent.sidebar.sessionMenu.unarchive')}
-                onClick={() => onUnarchive()}
+                label={t('ccAgent.sidebar.sessionMenu.moreActions')}
+                onClick={onOpenMenu}
               >
-                <Undo size={14} strokeWidth={2} />
+                <EllipsisVertical size={14} strokeWidth={2} />
               </CardAction>
-            ) : canQuickArchive ? (
-              <CardAction
-                variant="list"
-                isActive={isActive}
-                label={t('ccAgent.sidebar.sessionMenu.archived')}
-                onClick={() => setArchivePending(true)}
-              >
-                <Archive size={14} strokeWidth={2} />
-              </CardAction>
-            ) : null}
-          </div>
+              {isArchived && canUnarchive ? (
+                <CardAction
+                  variant="list"
+                  isActive={isActive}
+                  label={t('ccAgent.sidebar.sessionMenu.unarchive')}
+                  onClick={() => onUnarchive()}
+                >
+                  <Undo size={14} strokeWidth={2} />
+                </CardAction>
+              ) : canQuickArchive ? (
+                <CardAction
+                  variant="list"
+                  isActive={isActive}
+                  label={t('ccAgent.sidebar.sessionMenu.archived')}
+                  onClick={() => setArchivePending(true)}
+                >
+                  <Archive size={14} strokeWidth={2} />
+                </CardAction>
+              ) : null}
+            </div>
+          </>
         )}
       </div>
     </div>

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionItem.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionItem.tsx
@@ -1148,18 +1148,36 @@ export const SessionItem = memo(function SessionItem({
                 - archived：More + Undo（lucide Undo），单击直接走 unarchive，
                   不像 Archive 那样需要二次确认 pill（unarchive 非破坏性）。 */}
             {!archivePending && (
-              <div
-                // 入流而不是 absolute:hover 时槽变宽,标题自己 truncate,不会盖到字上。
-                // 不要同时写死 flex 又 hidden —— 同特异性下源码顺序会让 hidden 失效。
-                className={cn(
-                  'col-start-1 row-start-1 h-6 items-center gap-0.5',
-                  menuPos !== null
-                    ? 'flex'
-                    : 'hidden group-hover:flex group-focus-within/slot:flex',
-                )}
-              >
-                {sessionActionButtons}
-              </div>
+              <>
+                {/* 入流占位只负责把标题挤窄;真正的按钮保持可聚焦,不能 display:none。 */}
+                <div
+                  aria-hidden
+                  className={cn(
+                    'invisible col-start-1 row-start-1 h-6 items-center gap-0.5',
+                    menuPos !== null
+                      ? 'flex'
+                      : 'hidden group-hover:flex group-focus-within/slot:flex',
+                  )}
+                >
+                  {showAutomationRunAction ? <span className="size-5 shrink-0" /> : null}
+                  <span className="size-5 shrink-0" />
+                  {isArchived && !remoteWritesBlocked ? (
+                    <span className="size-5 shrink-0" />
+                  ) : canQuickArchive ? (
+                    <span className="size-5 shrink-0" />
+                  ) : null}
+                </div>
+                <div
+                  className={cn(
+                    'absolute right-0 top-0 flex h-6 items-center gap-0.5',
+                    menuPos !== null
+                      ? 'opacity-100'
+                      : 'pointer-events-none opacity-0 group-hover:pointer-events-auto group-hover:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100',
+                  )}
+                >
+                  {sessionActionButtons}
+                </div>
+              </>
             )}
           </div>
         </div>

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionItem.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionItem.tsx
@@ -129,10 +129,11 @@ interface SidebarTitleMarqueeProps {
 }
 
 /**
- * 标题保持原生省略号，只有实际溢出且鼠标停留在标题区域时才播放一次横向滚动。
+ * 标题保持原生省略号，只有实际溢出且任务行处于悬浮态时才播放一次横向滚动。
+ * 绑在行上而不是标题上:指针移到更多/归档时跑马灯不能停。
  * 通过 DOM 属性和 CSS 变量驱动，避免给高密度侧栏行增加 React 状态订阅。
  */
-function SidebarTitleMarquee({ children, className, title }: SidebarTitleMarqueeProps) {
+export function SidebarTitleMarquee({ children, className, title }: SidebarTitleMarqueeProps) {
   const containerRef = useRef<HTMLSpanElement>(null);
   const trackRef = useRef<HTMLSpanElement>(null);
   const isHoveredRef = useRef(false);
@@ -194,6 +195,31 @@ function SidebarTitleMarquee({ children, className, title }: SidebarTitleMarquee
     if (isHoveredRef.current) startMarquee();
   }, [startMarquee, title]);
 
+  useEffect(() => {
+    const row = containerRef.current?.closest('[data-sidebar-session-row="true"]');
+    if (!(row instanceof HTMLElement)) return undefined;
+
+    const onEnter = () => {
+      isHoveredRef.current = true;
+      startMarquee();
+      startObserving();
+    };
+    const onLeave = () => {
+      isHoveredRef.current = false;
+      stopObserving();
+      stopMarquee();
+    };
+
+    row.addEventListener('mouseenter', onEnter);
+    row.addEventListener('mouseleave', onLeave);
+    if (row.matches(':hover')) onEnter();
+    return () => {
+      row.removeEventListener('mouseenter', onEnter);
+      row.removeEventListener('mouseleave', onLeave);
+      onLeave();
+    };
+  }, [startMarquee, startObserving, stopMarquee, stopObserving]);
+
   useEffect(() => () => stopObserving(), [stopObserving]);
 
   return (
@@ -201,16 +227,6 @@ function SidebarTitleMarquee({ children, className, title }: SidebarTitleMarquee
       ref={containerRef}
       className="sidebar-title-marquee min-w-0 max-w-full shrink overflow-hidden"
       title={title}
-      onMouseEnter={() => {
-        isHoveredRef.current = true;
-        startMarquee();
-        startObserving();
-      }}
-      onMouseLeave={() => {
-        isHoveredRef.current = false;
-        stopObserving();
-        stopMarquee();
-      }}
     >
       <span className={cn('sidebar-title-marquee__ellipsis', className)}>{children}</span>
       <span
@@ -941,7 +957,11 @@ export const SessionItem = memo(function SessionItem({
           ? 'bg-sidebar-item-active text-sidebar-item-active-foreground shadow-[inset_0_0_0_1px_var(--sidebar-item-active-border)]'
           : isSelected
             ? 'bg-[var(--chat-input-chip-bg)] text-foreground'
-            : 'text-foreground hover:bg-sidebar-item-hover',
+            : cn(
+                'text-foreground hover:bg-sidebar-item-hover',
+                // 菜单开着时鼠标常会离开行,行底仍保持 hover 色。
+                menuPos !== null && 'bg-sidebar-item-hover',
+              ),
         isSelected && 'ring-1 ring-inset ring-[var(--focus-ring-soft)]',
       )}
       aria-current={isActive ? 'page' : undefined}
@@ -1048,12 +1068,10 @@ export const SessionItem = memo(function SessionItem({
           WorktreeBadge 紧贴时间左侧(仅在 WorktreeContext map 中存在 sessionId 时
           渲染), 与时间同步 hover-fade 让位给 action buttons —— 让右侧只看到一组
           视觉元素, 不和 action buttons 共存。
-          archive 快捷按钮 hover/focus 时覆盖整个槽位,避免右侧拥挤;完整菜单仍走右键。
-          槽宽跟可见内容走:状态点 / worktree / 任务信息有多宽占多宽,「任务信息 =
-          无」且无状态、无 worktree 时宽度归零,把行宽还给标题。hover / 菜单打开 /
-          二次确认时,信息层与操作占位叠在同一格,槽宽取两者较大值,标题走 truncate,
-          可见按钮仍绝对定位叠在同一槽上——不再常驻 56px,也不叠到标题上,更不把
-          信息宽和按钮宽相加。 */}
+          archive 快捷按钮 hover/focus 时进同一格文档流,标题 truncate 让位;
+          完整菜单仍走右键。槽宽跟可见内容走:平时信息槽有多宽占多宽,「任务信息 =
+          无」且无状态、无 worktree 时宽度归零。hover / 菜单打开时按钮入流,
+          槽宽取信息层与按钮的较大值——不再绝对定位盖到标题上。 */}
       {!isEditing && (
         <div className="group/slot relative ml-auto flex h-6 shrink-0 items-center justify-end">
           {/* WorktreeBadge + time 同步 fade-out:hover/菜单打开/archivePending 时
@@ -1064,58 +1082,61 @@ export const SessionItem = memo(function SessionItem({
               group-focus-within,选中态(非 hover)时间会被永久隐藏而 action
               buttons 又不显示,右侧变空白。 */}
           <div className="grid h-6 grid-cols-[max-content] items-center justify-items-end">
-          <div
-            className={cn(
-              'col-start-1 row-start-1 flex items-center gap-1',
-              // duration 与 action 按钮组的渐显同拍(120ms),让位/回归一进一出同步。
-              'transition-opacity duration-[120ms]',
-              !archivePending && 'group-hover:opacity-0 group-focus-within/slot:opacity-0',
-              menuPos !== null && 'opacity-0',
-              archivePending && 'opacity-0',
-              // mod+1..9 序号徽标出现时同样让位:徽标独占行尾,不与时间/badge 并排。
-              ordinalBadgeLabel != null && 'opacity-0',
-            )}
-          >
-            <WorktreeBadge sessionId={session.id} size={12} className="size-4" />
-            {showRightStatus ? (
-              <SidebarRightStatusIndicator kind={rightStatusKind} isActive={isActive} />
-            ) : (
-              // 任务信息复选(C 期):按用户勾选拼装 pr / tokens / cost / time;默认仅
-              // time,与旧时间槽渲染等价。全不选 → SessionInfoMeta 渲染 null,槽宽归零。
-              <SessionInfoMeta pieces={infoPieces} prRef={infoPrRef} isActive={isActive} />
-            )}
-          </div>
-
-          {canQuickArchive && archivePending && (
-            <span aria-hidden className="invisible col-start-1 row-start-1 inline-block h-6 w-14" />
-          )}
-          {ordinalBadgeLabel != null && (
-            <span aria-hidden className="invisible col-start-1 row-start-1 inline-flex">
-              <SessionOrdinalBadgeKbd label={ordinalBadgeLabel} />
-            </span>
-          )}
-          {canQuickArchive && archivePending && (
-            <button
-              ref={confirmPillRef}
-              type="button"
-              onClick={(e) => {
-                e.stopPropagation();
-                setArchivePending(false);
-                onAction(session.id, 'archive-now');
-              }}
-              onPointerDown={(e) => e.stopPropagation()}
-              onDoubleClick={(e) => e.stopPropagation()}
+            <div
               className={cn(
-                'absolute right-0 top-0 flex h-6 w-14 items-center justify-center rounded-md text-xs font-medium',
-                'bg-[color-mix(in_srgb,hsl(var(--destructive))_15%,transparent)] text-[hsl(var(--destructive))] hover:bg-[color-mix(in_srgb,hsl(var(--destructive))_25%,transparent)]',
-                'transition-colors focus:outline-none',
+                'col-start-1 row-start-1 flex items-center gap-1',
+                // duration 与 action 按钮组的渐显同拍(120ms),让位/回归一进一出同步。
+                'transition-opacity duration-[120ms]',
+                !archivePending && 'group-hover:opacity-0 group-focus-within/slot:opacity-0',
+                menuPos !== null && 'opacity-0',
+                archivePending && 'opacity-0',
+                // mod+1..9 序号徽标出现时同样让位:徽标独占行尾,不与时间/badge 并排。
+                ordinalBadgeLabel != null && 'opacity-0',
               )}
-              aria-label={t('ccAgent.sidebar.sessionMenu.archived')}
             >
-              {t('ccAgent.sidebar.sessionMenu.archived')}
-            </button>
-          )}
-          {/* Action 按钮组（hover/menu open 时浮现，archivePending 期间整组让位给红色 pill）。
+              <WorktreeBadge sessionId={session.id} size={12} className="size-4" />
+              {showRightStatus ? (
+                <SidebarRightStatusIndicator kind={rightStatusKind} isActive={isActive} />
+              ) : (
+                // 任务信息复选(C 期):按用户勾选拼装 pr / tokens / cost / time;默认仅
+                // time,与旧时间槽渲染等价。全不选 → SessionInfoMeta 渲染 null,槽宽归零。
+                <SessionInfoMeta pieces={infoPieces} prRef={infoPrRef} isActive={isActive} />
+              )}
+            </div>
+
+            {canQuickArchive && archivePending && (
+              <span
+                aria-hidden
+                className="invisible col-start-1 row-start-1 inline-block h-6 w-14"
+              />
+            )}
+            {ordinalBadgeLabel != null && (
+              <span aria-hidden className="invisible col-start-1 row-start-1 inline-flex">
+                <SessionOrdinalBadgeKbd label={ordinalBadgeLabel} />
+              </span>
+            )}
+            {canQuickArchive && archivePending && (
+              <button
+                ref={confirmPillRef}
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setArchivePending(false);
+                  onAction(session.id, 'archive-now');
+                }}
+                onPointerDown={(e) => e.stopPropagation()}
+                onDoubleClick={(e) => e.stopPropagation()}
+                className={cn(
+                  'absolute right-0 top-0 flex h-6 w-14 items-center justify-center rounded-md text-xs font-medium',
+                  'bg-[color-mix(in_srgb,hsl(var(--destructive))_15%,transparent)] text-[hsl(var(--destructive))] hover:bg-[color-mix(in_srgb,hsl(var(--destructive))_25%,transparent)]',
+                  'transition-colors focus:outline-none',
+                )}
+                aria-label={t('ccAgent.sidebar.sessionMenu.archived')}
+              >
+                {t('ccAgent.sidebar.sessionMenu.archived')}
+              </button>
+            )}
+            {/* Action 按钮组（hover/menu open 时浮现，archivePending 期间整组让位给红色 pill）。
               尺寸/视觉与 Project Header 的 ProjectAction 同套（size-5 / icon 14 /
               strokeWidth 2 / gap-0.5）；普通行 hover 走 sidebar-item-hover，选中行
               则用 active foreground 的半透明叠色保持红色胶囊内的反色体系。唯一差异
@@ -1126,40 +1147,20 @@ export const SessionItem = memo(function SessionItem({
                   按钮立即还原,符合用户对 "撤回 = 回到点击前" 的直觉预期。
                 - archived：More + Undo（lucide Undo），单击直接走 unarchive，
                   不像 Archive 那样需要二次确认 pill（unarchive 非破坏性）。 */}
-          {!archivePending && (
-            <>
+            {!archivePending && (
               <div
-                aria-hidden
+                // 入流而不是 absolute:hover 时槽变宽,标题自己 truncate,不会盖到字上。
+                // 不要同时写死 flex 又 hidden —— 同特异性下源码顺序会让 hidden 失效。
                 className={cn(
-                  'invisible col-start-1 row-start-1 flex h-6 items-center gap-0.5',
-                  menuPos === null && 'hidden group-hover:flex group-focus-within/slot:flex',
-                )}
-              >
-                {showAutomationRunAction ? <span className="size-5 shrink-0" /> : null}
-                <span className="size-5 shrink-0" />
-                {isArchived && !remoteWritesBlocked ? (
-                  <span className="size-5 shrink-0" />
-                ) : canQuickArchive ? (
-                  <span className="size-5 shrink-0" />
-                ) : null}
-              </div>
-              <div
-                // 渐显(120ms)配 pointer-events 守卫:淡出期间按钮不再占据鼠标位置,
-                // 解决了旧注释"渐变让按钮在 fade 期间仍占着鼠标位置、Radix Tooltip
-                // 收不到 pointerleave 导致 tip 挂着"的问题(当年因此禁用了
-                // transition-opacity);键盘焦点不受 pointer-events 影响,focus 路径不变。
-                className={cn(
-                  'absolute right-0 top-0 flex h-6 items-center gap-0.5',
-                  'transition-opacity duration-[120ms]',
+                  'col-start-1 row-start-1 h-6 items-center gap-0.5',
                   menuPos !== null
-                    ? 'opacity-100'
-                    : 'pointer-events-none opacity-0 group-hover:pointer-events-auto group-hover:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100',
+                    ? 'flex'
+                    : 'hidden group-hover:flex group-focus-within/slot:flex',
                 )}
               >
                 {sessionActionButtons}
               </div>
-            </>
-          )}
+            )}
           </div>
         </div>
       )}

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/SessionCard.visual.test.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/SessionCard.visual.test.ts
@@ -333,7 +333,9 @@ describe('SessionCard visual cases', () => {
       );
 
       const card = container.querySelector<HTMLElement>('[data-sidebar-session-row="true"]');
-      const title = within(card!).getByText(visualCase.session.title);
+      const title = within(card!).getByText(visualCase.session.title, {
+        selector: variant === 'list' ? '.sidebar-title-marquee__ellipsis' : undefined,
+      });
       const actionButton = card?.querySelector<HTMLButtonElement>(
         'button[aria-label="ccAgent.sidebar.sessionMenu.moreActions"]',
       );
@@ -658,6 +660,7 @@ describe('SessionCard visual cases', () => {
       expect(action.className).toContain('size-5');
       expect(action.className).toContain('rounded-md');
       expect(action.className).toContain('text-sidebar-action-icon');
+      expect(action.className).not.toMatch(/(?:^|\s)bg-sidebar(?:\s|$)/);
       expect(action.className).not.toContain('size-6');
       expect(action.className).not.toContain('bg-[var(--cmd-palette-bg)]');
       expect(action.className).not.toContain('border-sidebar-border');
@@ -677,6 +680,7 @@ describe('SessionCard visual cases', () => {
       name: moreActionsName,
     });
     expect(activeListMore.className).toContain('text-sidebar-item-active-foreground');
+    expect(activeListMore.className).not.toContain('bg-sidebar-item-active');
     expect(activeListMore.className).toContain(
       'hover:bg-[color-mix(in_srgb,var(--sidebar-item-active-foreground)_14%,transparent)]',
     );

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/sessionCardReviewRegressions.test.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/sessionCardReviewRegressions.test.ts
@@ -55,6 +55,9 @@ describe('SessionCard review regressions', () => {
 
   it('plays overflowing sidebar titles only while hovered', () => {
     expect(sessionItemSource).toContain('function SidebarTitleMarquee');
+    expect(sessionItemSource).toContain('[data-sidebar-session-row="true"]');
+    expect(sessionItemSource).toContain("row.addEventListener('mouseenter', onEnter)");
+    expect(sessionItemSource).toContain("row.addEventListener('mouseleave', onLeave)");
     expect(sessionItemSource).toContain("container.dataset.titleOverflowing = 'true'");
     expect(sessionItemSource).toContain('delete container.dataset.titleOverflowing');
     expect(globalsSource).toContain('@keyframes sidebar-title-marquee');
@@ -88,7 +91,7 @@ describe('SessionCard review regressions', () => {
     expect(sessionItemSource).not.toContain('var(--motion-base) * ${viewportCount * 12}');
   });
 
-  it('observes layout changes only while the title is hovered', () => {
+  it('observes layout changes only while the session row is hovered', () => {
     expect(sessionItemSource).toContain(
       'const resizeObserverRef = useRef<ResizeObserver | null>(null);',
     );
@@ -124,11 +127,11 @@ describe('SessionCard review regressions', () => {
     // 只并入 phase=running,与折叠 rail / remoteLampOf 同一口径;
     // needs-interaction 继续由右侧 awaiting 表达。
     expect(sessionItemSource).toContain(
-      'const leftIconRunning = isRunning || remoteActivity?.phase === \'running\'',
+      "const leftIconRunning = isRunning || remoteActivity?.phase === 'running'",
     );
     expect(sessionItemSource).toContain('isRunning={leftIconRunning}');
     expect(sessionCardSource).toContain(
-      'const leftIconRunning = isRunning || remoteActivity?.phase === \'running\'',
+      "const leftIconRunning = isRunning || remoteActivity?.phase === 'running'",
     );
     expect(sessionCardSource).toContain('isRunning={leftIconRunning}');
     expect(sessionCardSource).not.toContain('isRemoteSessionActivityActive');
@@ -171,32 +174,26 @@ describe('SessionCard review regressions', () => {
     expect(automationGroupSource).toContain(
       'group/slot relative ml-auto flex h-6 max-w-[96px] shrink-0 items-center justify-end',
     );
-    expect(sessionItemSource).toContain('grid h-6 grid-cols-[max-content] items-center justify-items-end');
     expect(sessionItemSource).toContain(
-      "menuPos === null && 'hidden group-hover:flex group-focus-within/slot:flex'",
+      'grid h-6 grid-cols-[max-content] items-center justify-items-end',
     );
+    expect(sessionItemSource).toContain("'hidden group-hover:flex group-focus-within/slot:flex'");
     expect(automationGroupSource).toContain(
       'grid h-6 max-w-[96px] grid-cols-[max-content] items-center justify-items-end',
     );
     expect(automationGroupSource).toContain(
       "!menuOpen && 'hidden group-hover:block group-focus-within/slot:block'",
     );
-    expect(sessionCardSource).toContain('grid h-[22px] grid-cols-[max-content] items-center justify-items-end');
     expect(sessionCardSource).toContain(
-      "!menuOpen && 'hidden group-hover/card:flex group-focus-within/slot:flex'",
-    );
-    expect(sessionItemSource).toContain(
-      'invisible col-start-1 row-start-1 inline-flex',
-    );
-    expect(sessionItemSource).toContain(
-      '<SessionOrdinalBadgeKbd label={ordinalBadgeLabel} />',
+      'grid h-[22px] grid-cols-[max-content] items-center justify-items-end',
     );
     expect(sessionCardSource).toContain(
-      'invisible col-start-1 row-start-1 inline-flex',
+      "'hidden group-hover/card:flex group-focus-within/slot:flex'",
     );
-    expect(sessionCardSource).toContain(
-      '<SessionOrdinalBadgeKbd label={ordinalBadgeLabel} />',
-    );
+    expect(sessionItemSource).toContain('invisible col-start-1 row-start-1 inline-flex');
+    expect(sessionItemSource).toContain('<SessionOrdinalBadgeKbd label={ordinalBadgeLabel} />');
+    expect(sessionCardSource).toContain('invisible col-start-1 row-start-1 inline-flex');
+    expect(sessionCardSource).toContain('<SessionOrdinalBadgeKbd label={ordinalBadgeLabel} />');
     expect(sessionItemSource).not.toContain(
       'invisible col-start-1 row-start-1 inline-flex h-6 items-center px-1.5 py-[2px] text-11 leading-none',
     );
@@ -222,9 +219,7 @@ describe('SessionCard review regressions', () => {
     expect(sessionCardSource).not.toContain(
       'invisible col-start-1 row-start-1 inline-block h-[22px] w-14',
     );
-    expect(sessionItemSource).toContain(
-      'invisible col-start-1 row-start-1 inline-block h-6 w-14',
-    );
+    expect(sessionItemSource).toContain('invisible col-start-1 row-start-1 inline-block h-6 w-14');
     expect(sessionItemSource).toContain(
       'absolute right-0 top-0 flex h-6 w-14 items-center justify-center rounded-md text-xs font-medium',
     );
@@ -336,6 +331,16 @@ describe('SessionCard review regressions', () => {
     );
   });
 
+  it('lets the title truncate by putting hover actions in flow instead of overlaying them', () => {
+    expect(sessionItemSource).toContain("'hidden group-hover:flex group-focus-within/slot:flex'");
+    expect(sessionItemSource).not.toContain('SESSION_ACTION_HOVER_SCRIM_CLASS');
+    expect(sessionItemSource).not.toContain('sessionActionScrimClass');
+    expect(sessionCardSource).toContain(
+      "'hidden group-hover/card:flex group-focus-within/slot:flex'",
+    );
+    expect(sessionCardSource).not.toContain('SESSION_ACTION_HOVER_SCRIM_CLASS');
+  });
+
   it('aligns the session row cursor with the actual split drag source state', () => {
     expect(sessionItemSource).toContain("!isEditing && 'cursor-pointer'");
     expect(sessionItemSource).toContain(
@@ -407,20 +412,23 @@ describe('SessionCard review regressions', () => {
   });
 
   it('matches list-mode title type to the text-mode session row', () => {
+    expect(sessionCardSource).toContain('<SidebarTitleMarquee');
     expect(sessionCardSource).toContain("'text-sm font-medium leading-[1.3]'");
     expect(sessionCardSource).toContain(
       'inputClassName="absolute inset-x-0 top-1/2 h-6 -translate-y-1/2 text-sm font-medium text-foreground"',
     );
     expect(sessionCardSource).toContain("'mt-1 overflow-hidden text-xs leading-[1.45]'");
     expect(sessionCardSource).toContain('className="leading-none"');
-    expect(sessionCardSource).not.toContain("'text-13 font-semibold leading-[1.3] tracking-[-0.005em]'");
+    expect(sessionCardSource).not.toContain(
+      "'text-13 font-semibold leading-[1.3] tracking-[-0.005em]'",
+    );
     expect(sessionItemSource).toContain("'text-left text-sm font-medium'");
   });
 
   it('keeps list-mode time and remote marks on the text-mode color and size', () => {
     expect(sessionCardSource).toContain('size={12}');
     expect(sessionCardSource).toContain(": 'text-sidebar-action-icon'");
-    expect(sessionCardSource).not.toContain("size={11}\n                      strokeWidth={1.8}");
+    expect(sessionCardSource).not.toContain('size={11}\n                      strokeWidth={1.8}');
     expect(sessionItemSource).toContain('size={12}');
     expect(sessionItemSource).toContain(": 'text-sidebar-action-icon'");
   });

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/sessionCardReviewRegressions.test.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/sessionCardReviewRegressions.test.ts
@@ -331,12 +331,24 @@ describe('SessionCard review regressions', () => {
     );
   });
 
-  it('lets the title truncate by putting hover actions in flow instead of overlaying them', () => {
+  it('lets the title truncate with an in-flow spacer while actions stay focusable', () => {
+    expect(sessionItemSource).toContain(
+      "'invisible col-start-1 row-start-1 h-6 items-center gap-0.5'",
+    );
     expect(sessionItemSource).toContain("'hidden group-hover:flex group-focus-within/slot:flex'");
+    expect(sessionItemSource).toContain('absolute right-0 top-0 flex h-6 items-center gap-0.5');
+    expect(sessionItemSource).toContain(
+      'pointer-events-none opacity-0 group-hover:pointer-events-auto group-hover:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100',
+    );
     expect(sessionItemSource).not.toContain('SESSION_ACTION_HOVER_SCRIM_CLASS');
-    expect(sessionItemSource).not.toContain('sessionActionScrimClass');
+    expect(sessionCardSource).toContain(
+      "'invisible col-start-1 row-start-1 h-[22px] items-center gap-0.5'",
+    );
     expect(sessionCardSource).toContain(
       "'hidden group-hover/card:flex group-focus-within/slot:flex'",
+    );
+    expect(sessionCardSource).toContain(
+      'absolute right-0 top-1/2 flex -translate-y-1/2 items-center gap-0.5',
     );
     expect(sessionCardSource).not.toContain('SESSION_ACTION_HOVER_SCRIM_CLASS');
   });


### PR DESCRIPTION
## 这次改了什么

### 摘要

侧栏任务行 hover 出来的更多 / 归档原先绝对定位叠在标题上，长标题会穿到按钮底下。这次改成按钮进入同一格文档流，标题自己 truncate 让位；文字模式和列表模式的超长标题在整行悬浮时跑马灯，移到按钮上也不会停。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：
  - `SessionItem` / `SessionCard` list：hover 操作钮入流，不再绝对定位盖标题
  - 文字模式与列表模式共用 `SidebarTitleMarquee`，监听整行 hover
  - 菜单打开时行底保持 hover 色
- 明确不包含：卡片瀑布流标题的跑马灯、自动化分组头操作钮布局
- 用户可见变化：hover 长标题会缩短给按钮留位；整行悬浮即可跑马灯
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：
  - `DESIGN.md` §10 Light / Dark Dual-Mode Delivery Gate：颜色继续走 `hover:bg-sidebar-item-hover` / `bg-sidebar-item-active` 等语义 token，不新加硬编码色。
  - `DESIGN.md` §14.4 侧栏标题跑马灯窄例外：只动 transform/opacity；溢出标题在行悬浮时横向带过视口，离开行立即恢复省略号。
  - `DESIGN.md` §2 全窗 Surface 扁平层：侧栏行分隔不靠额外按钮底色抬层。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop run typecheck
结果：通过

pnpm test:unit:related
结果：PASS apps/desktop unit (related 5)

pnpm exec vitest run \
  src/renderer/features/cc-agent/sidebar/__tests__/sessionCardReviewRegressions.test.ts \
  src/renderer/features/cc-agent/sidebar/__tests__/SessionCard.visual.test.ts \
  src/renderer/__tests__/sidebarSessionTime.test.ts \
  src/renderer/features/cc-agent/sidebar/__tests__/sessionRowRenderIsolation.test.ts
结果：通过
```

全量 `run-unit-gate.sh` 在本 worktree 还碰到 `ghostInstallReceipt.test.ts` 两条与本 diff 无关的失败（cindy-brain setup receipt 读成 invalid）。该文件不在本次改动内，相关单测已绿，交给 CI 给权威结论。

### 手工验证

- Desktop remote / region=global，worktree `cindy-sidebar-session-action-bg`
- 文字模式与列表模式：长标题 hover 后标题缩短，按钮不再压字
- 整行悬浮跑马灯，移到更多 / 归档仍继续
- Light 与 Dark 都目检过 hover / 选中态

### 未执行的验证

- Windows 未验
- 卡片瀑布流标题跑马灯不在本 PR 范围

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop 侧栏文字模式 / 列表模式任务行 hover 布局与标题跑马灯
- 回滚 / 降级方式：revert 本 commit

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
