### PR TITLE
fix(responses-chat-bridge): 终态 provider error 后取消上游 SSE 读取

### DIFF
--- a/packages/responses-chat-bridge/src/__tests__/handler.test.ts
+++ b/packages/responses-chat-bridge/src/__tests__/handler.test.ts
@@ -534,6 +534,37 @@ describe('createResponsesChatHandler', () => {
     expect(cancelled).toHaveBeenCalled();
   });
 
+  it('finishes the downstream response even when upstream cancellation never settles (#2839)', async () => {
+    // 注入的 fetchImpl 可能给出取消长期 pending 的流:挂起的 reader.cancel()
+    // 不能阻塞下游收口。
+    const cancelled = vi.fn(() => new Promise<never>(() => {
+      // 故意永不 settle。
+    }));
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(
+          'data: {"error":{"message":"provider failed","status":502}}\n\n',
+        ));
+        // 故意不 close。
+      },
+      cancel: cancelled,
+    });
+    const handler = createResponsesChatHandler({
+      upstreamBase: 'https://provider.example/v1',
+      buildHeaders: async () => ({}),
+    }, {
+      fetchImpl: vi.fn(async () => new Response(body, {
+        status: 200,
+        headers: { 'content-type': 'text/event-stream' },
+      })) as typeof fetch,
+    });
+    const res = new FakeResponse();
+    await handler.handle({ parsedBody: { model: 'm', input: 'hi' }, res: res as never });
+    expect(res.chunks.join('')).toContain('event: response.failed');
+    expect(res.ended).toBe(true);
+    expect(cancelled).toHaveBeenCalled();
+  });
+
   it('fails a malformed SSE frame instead of silently completing', async () => {
     const handler = createResponsesChatHandler({
       upstreamBase: 'https://provider.example/v1',

--- a/packages/responses-chat-bridge/src/__tests__/handler.test.ts
+++ b/packages/responses-chat-bridge/src/__tests__/handler.test.ts
@@ -501,6 +501,39 @@ describe('createResponsesChatHandler', () => {
     expect(res.chunks.join('')).toContain('event: response.failed');
   });
 
+  it('cancels the upstream reader after a terminal provider error on a held-open stream (#2839)', async () => {
+    // provider 发出流内终态错误后保持连接不关:桥必须停止读取、取消上游
+    // reader 并及时结束下游响应,而不是继续等 EOF。
+    const cancelled = vi.fn();
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(
+          'data: {"error":{"message":"provider failed","status":502}}\n\n'
+          // 同一 chunk 里错误帧之后的剩余帧不再解析。
+          + 'data: {"id":"chat_after","choices":[{"delta":{"content":"stale"}}]}\n\n',
+        ));
+        // 故意不 close。
+      },
+      cancel: cancelled,
+    });
+    const handler = createResponsesChatHandler({
+      upstreamBase: 'https://provider.example/v1',
+      buildHeaders: async () => ({}),
+    }, {
+      fetchImpl: vi.fn(async () => new Response(body, {
+        status: 200,
+        headers: { 'content-type': 'text/event-stream' },
+      })) as typeof fetch,
+    });
+    const res = new FakeResponse();
+    await handler.handle({ parsedBody: { model: 'm', input: 'hi' }, res: res as never });
+    const wire = res.chunks.join('');
+    expect(wire).toContain('event: response.failed');
+    expect(wire).not.toContain('stale');
+    expect(res.ended).toBe(true);
+    expect(cancelled).toHaveBeenCalled();
+  });
+
   it('fails a malformed SSE frame instead of silently completing', async () => {
     const handler = createResponsesChatHandler({
       upstreamBase: 'https://provider.example/v1',

--- a/packages/responses-chat-bridge/src/handler.ts
+++ b/packages/responses-chat-bridge/src/handler.ts
@@ -424,11 +424,14 @@ export function createResponsesChatHandler(
         }
         if (upstreamErrored) {
           // 终态错误之后:当前 chunk 剩余帧不再解析,取消上游 reader 释放
-          // 连接,让下游响应立即收口。
+          // 连接。不 await:注入的 fetchImpl 可能给出取消长期 pending 的流,
+          // 挂起的取消不能阻塞下游收口。
           try {
-            await reader.cancel();
+            reader.cancel().catch(() => {
+              // 取消失败不影响下游收口。
+            });
           } catch {
-            // 取消失败不影响下游收口。
+            // 同步抛出的取消失败同样不影响下游收口。
           }
         } else {
           buffer += decoder.decode();

--- a/packages/responses-chat-bridge/src/handler.ts
+++ b/packages/responses-chat-bridge/src/handler.ts
@@ -368,11 +368,14 @@ export function createResponsesChatHandler(
         }
         writeSse(res, output, seq++);
       };
-      const parseDataPayload = (payload: string): void => {
-        if (!payload) return;
+      // 返回 true = 该帧是流内终态 provider error(已发出 response.failed):
+      // 上游可能在错误事件后保持连接不关,继续等 EOF 会让请求、上游连接与
+      // 相关会话资源一直挂着 —— 调用侧应立即停读并取消上游 reader(#2839)。
+      const parseDataPayload = (payload: string): boolean => {
+        if (!payload) return false;
         if (payload === '[DONE]') {
           translator.markTerminal();
-          return;
+          return false;
         }
         let event: unknown;
         try {
@@ -392,12 +395,14 @@ export function createResponsesChatHandler(
             JSON.stringify(streamedError).slice(0, MAX_ERROR_BODY_CHARS),
           );
           for (const output of translator.fail(message)) emit(output);
-          return;
+          return true;
         }
         for (const output of translator.push(event)) emit(output);
+        return false;
       };
+      let upstreamErrored = false;
       try {
-        for (;;) {
+        readLoop: for (;;) {
           const { done, value } = await reader.read();
           if (done) break;
           buffer += decoder.decode(value, { stream: true });
@@ -407,17 +412,31 @@ export function createResponsesChatHandler(
             const line = buffer.slice(start, newline).replace(/\r$/, '');
             start = newline + 1;
             if (!line.startsWith('data:')) continue;
-            parseDataPayload(line.slice(5).trim());
+            if (parseDataPayload(line.slice(5).trim())) {
+              upstreamErrored = true;
+              break readLoop;
+            }
           }
           if (start > 0) buffer = buffer.slice(start);
           if (buffer.length > MAX_SSE_BUFFER_CHARS) {
             throw new Error('upstream SSE line exceeds 1 MiB');
           }
         }
-        buffer += decoder.decode();
-        if (buffer.trim()) {
-          for (const line of buffer.split(/\r?\n/)) {
-            if (line.startsWith('data:')) parseDataPayload(line.slice(5).trim());
+        if (upstreamErrored) {
+          // 终态错误之后:当前 chunk 剩余帧不再解析,取消上游 reader 释放
+          // 连接,让下游响应立即收口。
+          try {
+            await reader.cancel();
+          } catch {
+            // 取消失败不影响下游收口。
+          }
+        } else {
+          buffer += decoder.decode();
+          if (buffer.trim()) {
+            for (const line of buffer.split(/\r?\n/)) {
+              if (!line.startsWith('data:')) continue;
+              if (parseDataPayload(line.slice(5).trim())) break;
+            }
           }
         }
       } catch (error) {


### PR DESCRIPTION
## 这次改了什么

### 摘要

fix #2839。上游 provider 在 SSE 流内发出终态 error(顶层 `error` 事件,已翻译为 `response.failed` 发给下游)后,如果上游连接保持打开不关,桥此前会继续 `await reader.read()` 等 EOF:下游早已收到终态事件,上游连接、reader 与关联资源却一直挂着,直到上游自己超时。

改动:`parseDataPayload` 返回「本帧是否已发出终态错误」;读循环在终态后立即跳出并 `reader.cancel()` 释放上游连接。同一 chunk 内位于错误帧之后的剩余帧、以及尾部 buffer,不再解析——协议上终态事件之后本就不应再产生有效输出,此前这些迟到帧有机会被继续解析进输出。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他:

### 范围

- 关联 Issue / 需求:#2839
- 本 PR 包含:`packages/responses-chat-bridge` handler 的 SSE 读循环终态处理 + 回归测试
- 明确不包含:其它错误路径(下游断开、单帧 JSON 解析失败等)行为不变;上游 provider 为什么终态后不关连接不在本 PR 范围
- 用户可见变化:终态错误后连接及时释放;错误帧之后的迟到内容帧不再进入输出
- 是否存在 breaking change:无

### UI 变化

不涉及。

- 引用的设计规范:不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter @cindy/responses-chat-bridge test
结果:141/141 通过。含新增回归用例:上游发出终态 error 帧 + 同 chunk 迟到内容帧后保持连接不关(受控 ReadableStream,带 cancel 探针)——断言 response.failed 送达下游、迟到内容不输出、下游响应收口、上游 reader.cancel 被调用。修复前该用例会一直挂到测试超时。

pnpm --filter @cindy/responses-chat-bridge run --if-present typecheck
结果:通过

pnpm test:unit:related
结果:目标包相关用例通过。apps/desktop 侧仅 ghostInstallReceipt.test.ts 2 例失败,为当日 main HEAD(8d3a3b53e)上干净基线即可复现的既有失败,与本 diff 无关;desktop threads 池偶发 SIGSEGV flake 以 --pool=forks 复核通过。
```

### 手工验证

不涉及(行为由受控流的回归测试覆盖)。

### 未执行的验证

未对真实 provider 路由做端到端复测:「终态后挂起连接」依赖上游 provider 行为,难以稳定复现,回归测试以受控 ReadableStream 模拟该形态。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容(批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式)
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他:

### 影响与回滚

- 影响范围:仅 responses-chat-bridge 的 SSE 读循环。行为变化点:终态错误之后的迟到帧从「可能被继续解析」变为「不解析」——协议上终态事件后不应再有有效输出帧,此为修正而非兼容风险。
- 回滚 / 降级方式:revert 单 commit 即可,无数据或格式迁移。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`,见 [DCO](../DCO))
- [ ] UI 改动已在「UI 变化」注明引用的设计规范章节(不涉及 UI 则跳过)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
