### PR TITLE
fix(responses-chat-bridge): 工具输出中的不支持媒体降级为占位文本

### DIFF
--- a/packages/responses-chat-bridge/src/__tests__/translate-request.test.ts
+++ b/packages/responses-chat-bridge/src/__tests__/translate-request.test.ts
@@ -136,6 +136,73 @@ describe('translateResponsesRequest', () => {
     ]);
   });
 
+  it('degrades untranslatable tool-output media to a placeholder instead of failing the request (#2805)', () => {
+    // 上下文压缩 / 历史重放会把此前被拦截的图片以 input_image 重新带进工具
+    // 输出:纯文本路由(无 imageInput 能力)此前 fail-closed 拒绝整单,会话
+    // 从此每轮都被拒 —— 应降级为占位文本,保会话可用。
+    const out = translateResponsesRequest(base({
+      input: [
+        { type: 'function_call', call_id: 'call_img', name: 'ReadImage', arguments: '{}' },
+        {
+          type: 'function_call_output',
+          call_id: 'call_img',
+          output: [
+            { type: 'input_text', text: 'here is the screenshot' },
+            { type: 'input_image', image_url: 'data:image/png;base64,QUJD' },
+          ],
+        },
+        { type: 'message', role: 'user', content: 'continue after compaction' },
+      ],
+    }));
+    const tool = out.messages.find((m) => m.role === 'tool') as { content: string };
+    expect(tool.content).toContain('here is the screenshot');
+    expect(tool.content).toContain('[media omitted');
+    expect(tool.content).not.toContain('base64');
+    expect(out.messages.at(-1)).toEqual({ role: 'user', content: 'continue after compaction' });
+  });
+
+  it('still moves translatable tool-output media to a user message on image routes', () => {
+    // 对照组:路由支持图片时维持既有「搬运到后续 user 消息」语义。
+    const out = translateResponsesRequest(base({
+      input: [
+        { type: 'function_call', call_id: 'call_img', name: 'ReadImage', arguments: '{}' },
+        {
+          type: 'function_call_output',
+          call_id: 'call_img',
+          output: [{ type: 'input_image', image_url: 'https://img.example/a.png' }],
+        },
+        { type: 'message', role: 'user', content: 'go on' },
+      ],
+    }), { capabilities: { imageInput: 'image_url' } });
+    const tool = out.messages.find((m) => m.role === 'tool') as { content: string };
+    expect(tool.content).toContain('[media moved to the following user message]');
+    const mediaMessage = out.messages.find(
+      (m) => m.role === 'user' && Array.isArray((m as { content: unknown }).content),
+    ) as { content: Array<{ type: string }> };
+    expect(mediaMessage.content.some((part) => part.type === 'image_url')).toBe(true);
+  });
+
+  it('degrades untranslatable audio and file tool-output media the same way', () => {
+    const out = translateResponsesRequest(base({
+      input: [
+        { type: 'function_call', call_id: 'call_m', name: 'Fetch', arguments: '{}' },
+        {
+          type: 'function_call_output',
+          call_id: 'call_m',
+          output: [
+            { type: 'input_audio', input_audio: { data: 'QUJD', format: 'wav' } },
+            { type: 'input_file', file_id: 'file_123' },
+          ],
+        },
+        { type: 'message', role: 'user', content: 'continue' },
+      ],
+    }));
+    const tool = out.messages.find((m) => m.role === 'tool') as { content: string };
+    expect(tool.content).toContain('[media omitted');
+    expect(tool.content).not.toContain('QUJD');
+    expect(tool.content).not.toContain('file_123');
+  });
+
   it('injects a reasoning_content placeholder on tool-call assistant messages for thinking models', () => {
     const out = translateResponsesRequest(base({
       input: [
@@ -1172,18 +1239,26 @@ describe('translateResponsesRequest', () => {
     }), { capabilities: { imageInput: 'image_url' } })).toThrow('input_image.file_id');
   });
 
-  it('rejects unsupported media inside tool results instead of serializing it as text', () => {
+  it('replaces unsupported media inside tool results with a placeholder instead of rejecting (#2805)', () => {
+    // 行为变更(#2805):此前对工具结果里的不支持媒体 fail-closed 抛错,
+    // 压缩 / 重放历史带回的媒体会让会话每轮被拒、彻底卡死 —— 改为占位
+    // 降级,且不把原始媒体数据序列化进文本。
     for (const part of [
       { type: 'input_image', image_url: 'https://example.com/image.png' },
       { type: 'input_file', file_data: 'BASE64' },
       { type: 'input_audio', input_audio: { data: 'BASE64', format: 'wav' } },
     ]) {
-      expect(() => translateResponsesRequest(base({
+      const out = translateResponsesRequest(base({
         input: [
           { type: 'function_call', call_id: 'c1', name: 'inspect', arguments: '{}' },
           { type: 'function_call_output', call_id: 'c1', output: [part] },
+          { type: 'message', role: 'user', content: 'continue' },
         ],
-      }))).toThrow(part.type);
+      }));
+      const tool = out.messages.find((m) => m.role === 'tool') as { content: string };
+      expect(tool.content).toContain('[media omitted');
+      expect(tool.content).not.toContain('BASE64');
+      expect(tool.content).not.toContain('example.com');
     }
   });
 

--- a/packages/responses-chat-bridge/src/translate-request.ts
+++ b/packages/responses-chat-bridge/src/translate-request.ts
@@ -21,6 +21,8 @@ import { ChatBridgeToolContext } from './tool-context.js';
 const TOOL_CALL_REASONING_PLACEHOLDER = 'tool call';
 const GOOGLE_THOUGHT_SIGNATURE_PLACEHOLDER = 'skip_thought_signature_validator';
 const TOOL_RESULT_MEDIA_MOVED_MARKER = '[media moved to the following user message]';
+const TOOL_RESULT_MEDIA_OMITTED_MARKER =
+  '[media omitted: the current model route does not accept this content type]';
 
 interface ChatMediaCapabilities {
   imageInput?: ChatImageInput;
@@ -118,30 +120,20 @@ function hasAudioSource(part: Record<string, unknown>): boolean {
 function mediaPart(
   part: Record<string, unknown>,
   capabilities: ChatMediaCapabilities,
-  failClosed = false,
 ): ChatUserContentPart | undefined {
   if (isResponsesImageContentPartType(part.type)) {
     if (!hasImageSource(part)) return undefined;
-    if (capabilities.imageInput !== 'image_url') {
-      if (failClosed) throw new UnsupportedResponsesFeatureError(String(part.type));
-      return undefined;
-    }
+    if (capabilities.imageInput !== 'image_url') return undefined;
     return imagePart(part);
   }
   if (part.type === 'input_file' || part.type === 'file') {
     if (!hasFileSource(part)) return undefined;
-    if (capabilities.fileInput !== 'file') {
-      if (failClosed) throw new UnsupportedResponsesFeatureError(String(part.type));
-      return undefined;
-    }
+    if (capabilities.fileInput !== 'file') return undefined;
     return filePart(part);
   }
   if (part.type === 'input_audio') {
     if (!hasAudioSource(part)) return undefined;
-    if (capabilities.audioInput !== 'input_audio') {
-      if (failClosed) throw new UnsupportedResponsesFeatureError(String(part.type));
-      return undefined;
-    }
+    if (capabilities.audioInput !== 'input_audio') return undefined;
     return audioPart(part);
   }
   return undefined;
@@ -226,23 +218,56 @@ function stringifyToolOutput(output: unknown): string {
   }
 }
 
+/** 带媒体来源但当前路由能力不支持、无法翻译的媒体 part。 */
+function isUntranslatableMediaPart(
+  part: Record<string, unknown>,
+  capabilities: ChatMediaCapabilities,
+): boolean {
+  if (isResponsesImageContentPartType(part.type)) {
+    return hasImageSource(part) && !isImagePartTranslatable(part, capabilities);
+  }
+  if (part.type === 'input_file' || part.type === 'file') {
+    return hasFileSource(part) && capabilities.fileInput !== 'file';
+  }
+  if (part.type === 'input_audio') {
+    return hasAudioSource(part) && capabilities.audioInput !== 'input_audio';
+  }
+  return false;
+}
+
+interface ToolMediaSink {
+  media: ChatUserContentPart[];
+  /** 发生过任何替换(搬运或占位)时为 true:序列化必须用替换后的结构。 */
+  substituted: boolean;
+}
+
 function replaceToolMedia(
   value: unknown,
-  media: ChatUserContentPart[],
+  sink: ToolMediaSink,
   mediaCapabilities: ChatMediaCapabilities,
 ): unknown {
   if (Array.isArray(value)) {
-    return value.map((part) => replaceToolMedia(part, media, mediaCapabilities));
+    return value.map((part) => replaceToolMedia(part, sink, mediaCapabilities));
   }
   if (!isPlainObject(value)) return value;
-  const translated = mediaPart(value, mediaCapabilities, true);
+  const translated = mediaPart(value, mediaCapabilities);
   if (translated) {
-    media.push(translated);
+    sink.media.push(translated);
+    sink.substituted = true;
     return { type: 'text', text: TOOL_RESULT_MEDIA_MOVED_MARKER };
+  }
+  if (isUntranslatableMediaPart(value, mediaCapabilities)) {
+    // 路由不支持该媒体类型时降级为占位文本而不是 fail-closed 拒绝整单:
+    // 上下文压缩 / 历史重放会把此前由视觉桥等机制拦下的图片以 input_image
+    // 重新带进工具输出,一票否决会让会话此后每一轮都被拒、彻底卡死,只能
+    // 新建任务(#2805)。文本模型本就无法接收这类媒体,占位丢弃是唯一可
+    // 继续的表达;当轮媒体拦截 / 转换仍由上游(视觉桥)负责。
+    sink.substituted = true;
+    return { type: 'text', text: TOOL_RESULT_MEDIA_OMITTED_MARKER };
   }
   return Object.fromEntries(
     Object.entries(value).map(
-      ([key, child]) => [key, replaceToolMedia(child, media, mediaCapabilities)],
+      ([key, child]) => [key, replaceToolMedia(child, sink, mediaCapabilities)],
     ),
   );
 }
@@ -251,11 +276,11 @@ function splitToolOutput(
   output: unknown,
   mediaCapabilities: ChatMediaCapabilities,
 ): { content: string; media: ChatUserContentPart[] } {
-  const media: ChatUserContentPart[] = [];
-  const replaced = replaceToolMedia(output, media, mediaCapabilities);
+  const sink: ToolMediaSink = { media: [], substituted: false };
+  const replaced = replaceToolMedia(output, sink, mediaCapabilities);
   return {
-    content: stringifyToolOutput(media.length > 0 ? replaced : output),
-    media,
+    content: stringifyToolOutput(sink.substituted ? replaced : output),
+    media: sink.media,
   };
 }
 


### PR DESCRIPTION
## 这次改了什么

### 摘要

fix #2805。issue 现象:上下文压缩后继续对话,请求被上游以 unsupported content type(`input_image`)拒绝,且该历史随每次请求重放,会话从此卡死。

定位:报错文案与 `translate-request` 中**工具输出**媒体路径的 fail-closed 错误逐字一致(历史 user 消息里的图片自 #1329 起已有「仅保留最新轮」的降级,不会产生该文案)。压缩后回放的历史里,工具输出(如截图类工具结果)携带当前模型路由不支持的媒体时,`replaceToolMedia` 直接抛 `UnsupportedResponsesFeatureError` 拒绝整个请求——历史无法被修改,会话永久不可用。

修复:工具输出中路由不可翻译的媒体(图片/文件/音频,按各自路由能力判定)替换为占位文本 `[media omitted: the current model route does not accept this content type]`,不再抛错,也不会把原始媒体数据(base64 等)序列化进文本;路由**支持**的媒体维持既有「搬运到后续 user 消息」语义不变。

**含一处有意的行为变更**:原测试「工具结果中的不支持媒体应抛错」断言的正是本 issue 要修的卡死行为,已按新降级语义改写(测试内注释说明)。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他:

### 范围

- 关联 Issue / 需求:#2805
- 本 PR 包含:`packages/responses-chat-bridge` translate-request 的工具输出媒体路径(不可翻译判定 + 占位替换 + 仅省略无搬运时的序列化修正)与测试
- 明确不包含:历史 user 消息图片的降级(#1329 已有,行为不变);上下文压缩策略本身
- 用户可见变化:此前压缩后必卡死的会话可以继续;对应工具结果中的媒体以占位文本呈现给模型
- 是否存在 breaking change:无(对外 API 不变;错误改为降级属修复目标)

### UI 变化

不涉及。

- 引用的设计规范:不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter @cindy/responses-chat-bridge test
结果:142/142 通过。新增 3 例:不支持路由上工具输出内图片 → 占位文本、无 base64 泄漏、请求可继续;图片路由上可翻译图片仍按既有语义搬运到 user 消息;音频/文件同样降级。另按新语义改写既有抛错断言 1 例(见摘要)。

pnpm --filter @cindy/responses-chat-bridge run --if-present typecheck
结果:通过

pnpm test:unit:related
结果:目标包相关用例通过。apps/desktop 侧仅 ghostInstallReceipt.test.ts 2 例失败,为当日 main HEAD(8d3a3b53e)上干净基线即可复现的既有失败,与本 diff 无关;desktop threads 池偶发 SIGSEGV flake 以 --pool=forks 复核通过。
```

### 手工验证

不涉及(代码路径由构造的压缩后历史请求在测试中覆盖)。

### 未执行的验证

未在真实客户端复现「压缩后卡死」的完整会话流程(需要长会话 + 特定工具媒体组合才能触达压缩点);测试以最小构造历史覆盖同一翻译路径。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容(批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式)
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他:行为变更——工具输出不支持媒体从 fail-closed 抛错改为占位降级

### 影响与回滚

- 影响范围:模型看到占位文本而非请求直接失败。最坏情形是模型对被省略的媒体内容缺少感知,但占位文本明示了省略原因,相比整个会话永久不可用是严格改善;不含媒体的请求路径零变化。
- 回滚 / 降级方式:revert 单 commit 即恢复抛错行为,无数据或格式迁移。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`,见 [DCO](../DCO))
- [ ] UI 改动已在「UI 变化」注明引用的设计规范章节(不涉及 UI 则跳过)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
