### PR TITLE
fix(desktop): 重新选择文件夹时恢复已移除项目

### DIFF
--- a/apps/desktop/src/renderer/__tests__/newMakerProjectPicker.test.ts
+++ b/apps/desktop/src/renderer/__tests__/newMakerProjectPicker.test.ts
@@ -136,6 +136,26 @@ describe('Shared create project picker', () => {
     expect(body).toContain('finally {');
   });
 
+  it('restores a hidden local project before applying the selected folder to the draft', () => {
+    const handlerStart = newMakerDraftRouteSource.indexOf(
+      'const handleModePickerSelect = useCallback(',
+    );
+    const handlerEnd = newMakerDraftRouteSource.indexOf(
+      'const handleWtEnabledChange = useCallback(',
+      handlerStart,
+    );
+    const handler = newMakerDraftRouteSource.slice(handlerStart, handlerEnd);
+
+    expect(handler).toContain("source !== 'dialogue' && !effectiveDeviceLinkDeviceId");
+    expect(handler).toContain('await requestSidebarProjectRestore(localProjectKey)');
+    expect(handler).toContain('selectionSeq !== modePickerSelectionSeqRef.current');
+    expect(handler.indexOf('await requestSidebarProjectRestore(localProjectKey)')).toBeLessThan(
+      handler.indexOf("handleWorkingDirChange(source === 'dialogue' ? null : path)"),
+    );
+    expect(sidebarUpperSource).toContain('registerSidebarProjectRestoreHandler((projectKey) =>');
+    expect(sidebarUpperSource).toContain('restoreSelectedHiddenProject({');
+  });
+
   it('keeps dialogue outside of the project group in the picker menu', () => {
     const topHeadingIndex = folderPickerPopoverSource.indexOf(
       "t('newChat.folderPicker.dialogueOrSelectProject')",

--- a/apps/desktop/src/renderer/__tests__/newMakerProjectPicker.test.ts
+++ b/apps/desktop/src/renderer/__tests__/newMakerProjectPicker.test.ts
@@ -23,6 +23,7 @@ const newMakerDraftRouteSource = readSource('features', 'cc-agent', 'NewMakerDra
 const worktreeChipsSource = readSource('components', 'new-chat', 'WorktreeChipsRow.tsx');
 
 const folderPickerPopoverSource = readSource('components', 'new-chat', 'FolderPickerPopover.tsx');
+const mainLayoutSource = readSource('components', 'layout', 'MainLayout.tsx');
 
 const addRemoteProjectDialogSource = readSource(
   'components',
@@ -181,6 +182,33 @@ describe('Shared create project picker', () => {
     expect(applyAt).toBeGreaterThan(restoreAt);
     expect(unlockAt).toBeGreaterThan(applyAt);
     expect(handler.slice(lockAt, unlockAt)).toContain('finally {');
+  });
+
+  it('keeps picker choices disabled until the accepted selection finishes', () => {
+    expect(folderPickerPopoverSource).toContain('if (selectionPendingRef.current) return;');
+    expect(folderPickerPopoverSource).toContain('selectionPendingRef.current = true;');
+    expect((folderPickerPopoverSource.match(/disabled=\{selectionPending\}/g) ?? []).length).toBe(
+      8,
+    );
+
+    const handlerStart = folderPickerPopoverSource.indexOf('const handleSelectPath = async (');
+    const handlerEnd = folderPickerPopoverSource.indexOf(
+      'const handleRemoveProject =',
+      handlerStart,
+    );
+    const handler = folderPickerPopoverSource.slice(handlerStart, handlerEnd);
+    expect(handler.indexOf('selectionPendingRef.current = true;')).toBeLessThan(
+      handler.indexOf('await onSelect(folderPath, source, option);'),
+    );
+    expect(handler.indexOf('await onSelect(folderPath, source, option);')).toBeLessThan(
+      handler.indexOf('onOpenChange(false);'),
+    );
+  });
+
+  it('keeps the sidebar restore owner mounted on the new-task route', () => {
+    expect(mainLayoutSource).toContain(
+      "forceMountFeatureContent={location.pathname === '/cc-agent/new'}",
+    );
   });
 
   it('invalidates an in-flight folder restore before applying a same-route dialogue target', () => {

--- a/apps/desktop/src/renderer/__tests__/newMakerProjectPicker.test.ts
+++ b/apps/desktop/src/renderer/__tests__/newMakerProjectPicker.test.ts
@@ -156,6 +156,33 @@ describe('Shared create project picker', () => {
     expect(sidebarUpperSource).toContain('restoreSelectedHiddenProject({');
   });
 
+  it('holds the existing creation lock until project restoration commits the draft target', () => {
+    const handlerStart = newMakerDraftRouteSource.indexOf(
+      'const handleModePickerSelect = useCallback(',
+    );
+    const handlerEnd = newMakerDraftRouteSource.indexOf(
+      'const handleWtEnabledChange = useCallback(',
+      handlerStart,
+    );
+    const handler = newMakerDraftRouteSource.slice(handlerStart, handlerEnd);
+    const guardAt = handler.indexOf('if (sendInFlightRef.current) return;');
+    const selectionAt = handler.indexOf(
+      'const selectionSeq = ++modePickerSelectionSeqRef.current;',
+    );
+    const lockAt = handler.indexOf('markSendInFlight(true);');
+    const restoreAt = handler.indexOf('await requestSidebarProjectRestore(localProjectKey);');
+    const applyAt = handler.indexOf('handleWorkingDirChange(path);');
+    const unlockAt = handler.indexOf('markSendInFlight(false);');
+
+    expect(guardAt).toBeGreaterThan(-1);
+    expect(selectionAt).toBeGreaterThan(guardAt);
+    expect(lockAt).toBeGreaterThan(selectionAt);
+    expect(restoreAt).toBeGreaterThan(lockAt);
+    expect(applyAt).toBeGreaterThan(restoreAt);
+    expect(unlockAt).toBeGreaterThan(applyAt);
+    expect(handler.slice(lockAt, unlockAt)).toContain('finally {');
+  });
+
   it('keeps dialogue outside of the project group in the picker menu', () => {
     const topHeadingIndex = folderPickerPopoverSource.indexOf(
       "t('newChat.folderPicker.dialogueOrSelectProject')",

--- a/apps/desktop/src/renderer/__tests__/newMakerProjectPicker.test.ts
+++ b/apps/desktop/src/renderer/__tests__/newMakerProjectPicker.test.ts
@@ -183,6 +183,22 @@ describe('Shared create project picker', () => {
     expect(handler.slice(lockAt, unlockAt)).toContain('finally {');
   });
 
+  it('invalidates an in-flight folder restore before applying a same-route dialogue target', () => {
+    const effectStart = newMakerDraftRouteSource.indexOf(
+      '// “对话”分组可能在 /cc-agent/new 已经打开时再次导航到同一路由',
+    );
+    const effectEnd = newMakerDraftRouteSource.indexOf(
+      '// 弹窗确认添加后的落点',
+      effectStart,
+    );
+    const effect = newMakerDraftRouteSource.slice(effectStart, effectEnd);
+    const invalidateAt = effect.indexOf('modePickerSelectionSeqRef.current += 1;');
+    const applyAt = effect.indexOf('applyDraftTarget({');
+
+    expect(invalidateAt).toBeGreaterThan(-1);
+    expect(applyAt).toBeGreaterThan(invalidateAt);
+  });
+
   it('keeps dialogue outside of the project group in the picker menu', () => {
     const topHeadingIndex = folderPickerPopoverSource.indexOf(
       "t('newChat.folderPicker.dialogueOrSelectProject')",

--- a/apps/desktop/src/renderer/__tests__/sidebarProjectRestore.test.ts
+++ b/apps/desktop/src/renderer/__tests__/sidebarProjectRestore.test.ts
@@ -6,6 +6,7 @@ import {
   requestSidebarProjectRestore,
   restoreHiddenProjectIfPresent,
   restoreSelectedHiddenProject,
+  restoreSelectedHiddenProjectWithoutMountedSidebar,
 } from '@/features/cc-agent/lib/sidebarProjectRestore';
 import type { Session } from '@/lib/ccAgent.types';
 
@@ -341,7 +342,9 @@ describe('sidebar project restore coordinator', () => {
     expect(handler).toHaveBeenCalledWith(PROJECT_KEY);
 
     unregister();
-    await expect(requestSidebarProjectRestore(PROJECT_KEY)).resolves.toBe(false);
+    const fallback = vi.fn().mockResolvedValue(false);
+    await expect(requestSidebarProjectRestore(PROJECT_KEY, fallback)).resolves.toBe(false);
+    expect(fallback).toHaveBeenCalledWith(PROJECT_KEY);
   });
 
   it('does not let an older cleanup unregister the current sidebar owner', async () => {
@@ -354,5 +357,27 @@ describe('sidebar project restore coordinator', () => {
     expect(currentHandler).toHaveBeenCalledOnce();
 
     unregisterCurrent();
+  });
+
+  it('restores through persisted sidebar state when no sidebar owner is mounted', async () => {
+    const setProjectHidden = vi.fn().mockResolvedValue(true);
+    const persistFilterProjects = vi.fn();
+
+    await expect(
+      restoreSelectedHiddenProjectWithoutMountedSidebar({
+        projectKey: PROJECT_KEY,
+        hiddenProjectKeys: new Set([PROJECT_KEY]),
+        setProjectHidden,
+        loadFilterProjects: () => ['local:/workspace/other'],
+        persistFilterProjects,
+        localPlatform: 'linux',
+      }),
+    ).resolves.toBe(true);
+
+    expect(setProjectHidden).toHaveBeenCalledWith(PROJECT_KEY, false);
+    expect(persistFilterProjects).toHaveBeenCalledWith([
+      'local:/workspace/other',
+      PROJECT_KEY,
+    ]);
   });
 });

--- a/apps/desktop/src/renderer/__tests__/sidebarProjectRestore.test.ts
+++ b/apps/desktop/src/renderer/__tests__/sidebarProjectRestore.test.ts
@@ -341,9 +341,7 @@ describe('sidebar project restore coordinator', () => {
     expect(handler).toHaveBeenCalledWith(PROJECT_KEY);
 
     unregister();
-    await expect(requestSidebarProjectRestore(PROJECT_KEY)).rejects.toThrow(
-      'Sidebar project restore handler is unavailable',
-    );
+    await expect(requestSidebarProjectRestore(PROJECT_KEY)).resolves.toBe(false);
   });
 
   it('does not let an older cleanup unregister the current sidebar owner', async () => {

--- a/apps/desktop/src/renderer/__tests__/sidebarProjectRestore.test.ts
+++ b/apps/desktop/src/renderer/__tests__/sidebarProjectRestore.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it, vi } from 'vitest';
 
 import {
   collectRestorableProjectKeys,
+  registerSidebarProjectRestoreHandler,
+  requestSidebarProjectRestore,
   restoreHiddenProjectIfPresent,
+  restoreSelectedHiddenProject,
 } from '@/features/cc-agent/lib/sidebarProjectRestore';
 import type { Session } from '@/lib/ccAgent.types';
 
@@ -233,5 +236,104 @@ describe('restoreHiddenProjectIfPresent', () => {
 
     await expect(result).resolves.toBe(false);
     expect(ensureProjectIncluded).not.toHaveBeenCalled();
+  });
+});
+
+describe('restoreSelectedHiddenProject', () => {
+  it('unhides a selected project and admits it to an explicit Project filter', async () => {
+    const setProjectHidden = vi.fn().mockResolvedValue(true);
+    const ensureProjectIncluded = vi.fn();
+
+    await expect(
+      restoreSelectedHiddenProject({
+        projectKey: PROJECT_KEY,
+        hiddenProjectKeys: new Set([PROJECT_KEY]),
+        setProjectHidden,
+        getCurrentProjectKeys: () => new Set([PROJECT_KEY]),
+        ensureProjectIncluded,
+        localPlatform: 'linux',
+      }),
+    ).resolves.toBe(true);
+
+    expect(setProjectHidden).toHaveBeenCalledWith(PROJECT_KEY, false);
+    expect(ensureProjectIncluded).toHaveBeenCalledWith(PROJECT_KEY);
+  });
+
+  it('keeps an already-visible project selection side-effect free', async () => {
+    const ensureProjectIncluded = vi.fn();
+
+    await expect(
+      restoreSelectedHiddenProject({
+        projectKey: PROJECT_KEY,
+        hiddenProjectKeys: new Set(),
+        setProjectHidden: vi.fn().mockResolvedValue(false),
+        getCurrentProjectKeys: () => new Set([PROJECT_KEY]),
+        ensureProjectIncluded,
+        localPlatform: 'linux',
+      }),
+    ).resolves.toBe(false);
+
+    expect(ensureProjectIncluded).not.toHaveBeenCalled();
+  });
+
+  it('finishes restoration when another window already cleared the hidden marker', async () => {
+    const ensureProjectIncluded = vi.fn();
+
+    await expect(
+      restoreSelectedHiddenProject({
+        projectKey: 'local:c:/workspace/cindy',
+        hiddenProjectKeys: new Set(['local:C:/Workspace/Cindy']),
+        setProjectHidden: vi.fn().mockResolvedValue(false),
+        getCurrentProjectKeys: () => new Set(['local:C:/Workspace/Cindy']),
+        ensureProjectIncluded,
+        localPlatform: 'win32',
+      }),
+    ).resolves.toBe(true);
+
+    expect(ensureProjectIncluded).toHaveBeenCalledWith('local:C:/Workspace/Cindy');
+  });
+
+  it('uses the selected path when the restored project has no remaining tasks', async () => {
+    const ensureProjectIncluded = vi.fn();
+
+    await expect(
+      restoreSelectedHiddenProject({
+        projectKey: PROJECT_KEY,
+        hiddenProjectKeys: new Set([PROJECT_KEY]),
+        setProjectHidden: vi.fn().mockResolvedValue(true),
+        getCurrentProjectKeys: () => new Set(),
+        ensureProjectIncluded,
+        localPlatform: 'linux',
+      }),
+    ).resolves.toBe(true);
+
+    expect(ensureProjectIncluded).toHaveBeenCalledWith(PROJECT_KEY);
+  });
+});
+
+describe('sidebar project restore coordinator', () => {
+  it('delegates selection restoration to the mounted sidebar owner', async () => {
+    const handler = vi.fn().mockResolvedValue(true);
+    const unregister = registerSidebarProjectRestoreHandler(handler);
+
+    await expect(requestSidebarProjectRestore(PROJECT_KEY)).resolves.toBe(true);
+    expect(handler).toHaveBeenCalledWith(PROJECT_KEY);
+
+    unregister();
+    await expect(requestSidebarProjectRestore(PROJECT_KEY)).rejects.toThrow(
+      'Sidebar project restore handler is unavailable',
+    );
+  });
+
+  it('does not let an older cleanup unregister the current sidebar owner', async () => {
+    const unregisterFirst = registerSidebarProjectRestoreHandler(vi.fn().mockResolvedValue(false));
+    const currentHandler = vi.fn().mockResolvedValue(true);
+    const unregisterCurrent = registerSidebarProjectRestoreHandler(currentHandler);
+
+    unregisterFirst();
+    await expect(requestSidebarProjectRestore(PROJECT_KEY)).resolves.toBe(true);
+    expect(currentHandler).toHaveBeenCalledOnce();
+
+    unregisterCurrent();
   });
 });

--- a/apps/desktop/src/renderer/__tests__/sidebarProjectRestore.test.ts
+++ b/apps/desktop/src/renderer/__tests__/sidebarProjectRestore.test.ts
@@ -259,21 +259,42 @@ describe('restoreSelectedHiddenProject', () => {
     expect(ensureProjectIncluded).toHaveBeenCalledWith(PROJECT_KEY);
   });
 
-  it('keeps an already-visible project selection side-effect free', async () => {
+  it('skips hidden-state persistence but re-admits an already-visible project', async () => {
+    const setProjectHidden = vi.fn().mockResolvedValue(false);
     const ensureProjectIncluded = vi.fn();
 
     await expect(
       restoreSelectedHiddenProject({
         projectKey: PROJECT_KEY,
         hiddenProjectKeys: new Set(),
-        setProjectHidden: vi.fn().mockResolvedValue(false),
+        setProjectHidden,
         getCurrentProjectKeys: () => new Set([PROJECT_KEY]),
         ensureProjectIncluded,
         localPlatform: 'linux',
       }),
     ).resolves.toBe(false);
 
-    expect(ensureProjectIncluded).not.toHaveBeenCalled();
+    expect(setProjectHidden).not.toHaveBeenCalled();
+    expect(ensureProjectIncluded).toHaveBeenCalledWith(PROJECT_KEY);
+  });
+
+  it('admits a newly selected path without acquiring the hidden-project write lock', async () => {
+    const setProjectHidden = vi.fn().mockResolvedValue(false);
+    const ensureProjectIncluded = vi.fn();
+
+    await expect(
+      restoreSelectedHiddenProject({
+        projectKey: PROJECT_KEY,
+        hiddenProjectKeys: new Set(),
+        setProjectHidden,
+        getCurrentProjectKeys: () => new Set(),
+        ensureProjectIncluded,
+        localPlatform: 'linux',
+      }),
+    ).resolves.toBe(false);
+
+    expect(setProjectHidden).not.toHaveBeenCalled();
+    expect(ensureProjectIncluded).toHaveBeenCalledWith(PROJECT_KEY);
   });
 
   it('finishes restoration when another window already cleared the hidden marker', async () => {

--- a/apps/desktop/src/renderer/__tests__/sidebarProjectRestore.test.ts
+++ b/apps/desktop/src/renderer/__tests__/sidebarProjectRestore.test.ts
@@ -6,7 +6,6 @@ import {
   requestSidebarProjectRestore,
   restoreHiddenProjectIfPresent,
   restoreSelectedHiddenProject,
-  restoreSelectedHiddenProjectWithoutMountedSidebar,
 } from '@/features/cc-agent/lib/sidebarProjectRestore';
 import type { Session } from '@/lib/ccAgent.types';
 
@@ -342,9 +341,7 @@ describe('sidebar project restore coordinator', () => {
     expect(handler).toHaveBeenCalledWith(PROJECT_KEY);
 
     unregister();
-    const fallback = vi.fn().mockResolvedValue(false);
-    await expect(requestSidebarProjectRestore(PROJECT_KEY, fallback)).resolves.toBe(false);
-    expect(fallback).toHaveBeenCalledWith(PROJECT_KEY);
+    await expect(requestSidebarProjectRestore(PROJECT_KEY)).resolves.toBe(false);
   });
 
   it('does not let an older cleanup unregister the current sidebar owner', async () => {
@@ -357,27 +354,5 @@ describe('sidebar project restore coordinator', () => {
     expect(currentHandler).toHaveBeenCalledOnce();
 
     unregisterCurrent();
-  });
-
-  it('restores through persisted sidebar state when no sidebar owner is mounted', async () => {
-    const setProjectHidden = vi.fn().mockResolvedValue(true);
-    const persistFilterProjects = vi.fn();
-
-    await expect(
-      restoreSelectedHiddenProjectWithoutMountedSidebar({
-        projectKey: PROJECT_KEY,
-        hiddenProjectKeys: new Set([PROJECT_KEY]),
-        setProjectHidden,
-        loadFilterProjects: () => ['local:/workspace/other'],
-        persistFilterProjects,
-        localPlatform: 'linux',
-      }),
-    ).resolves.toBe(true);
-
-    expect(setProjectHidden).toHaveBeenCalledWith(PROJECT_KEY, false);
-    expect(persistFilterProjects).toHaveBeenCalledWith([
-      'local:/workspace/other',
-      PROJECT_KEY,
-    ]);
   });
 });

--- a/apps/desktop/src/renderer/__tests__/useSidebarFilter.test.ts
+++ b/apps/desktop/src/renderer/__tests__/useSidebarFilter.test.ts
@@ -45,6 +45,7 @@ import {
   nextProjectsAfterToggle,
   nextSortByAfterGroupByChange,
   includeProjectInFilter,
+  projectFilterIncludes,
   removeProjectsFromFilter,
   gcProjectsAgainstActive,
   normalizeManualProjectOrder,
@@ -497,6 +498,21 @@ describe('includeProjectInFilter', () => {
     const prev: FilterProjects = ['local:/a', 'local:/b'];
     expect(includeProjectInFilter(prev, '/a')).toBe(prev);
   });
+
+  it('treats equivalent Windows local paths as the same filter entry', () => {
+    const prev: FilterProjects = ['local:C:/Workspace/Cindy'];
+    expect(includeProjectInFilter(prev, 'local:c:/workspace/cindy', 'win32')).toBe(prev);
+    expect(nextProjectsAfterToggle(prev, 'local:c:/workspace/cindy', 'win32')).toBe('all');
+  });
+});
+
+describe('projectFilterIncludes', () => {
+  it('matches Windows local project keys case-insensitively without folding remote keys', () => {
+    const projects = new Set(['local:C:/Workspace/Cindy', 'remote:host:C:/Workspace/Cindy']);
+
+    expect(projectFilterIncludes(projects, 'local:c:/workspace/cindy', 'win32')).toBe(true);
+    expect(projectFilterIncludes(projects, 'remote:host:c:/workspace/cindy', 'win32')).toBe(false);
+  });
 });
 
 describe('removeProjectsFromFilter', () => {
@@ -611,6 +627,11 @@ describe('gcProjectsAgainstActive', () => {
 
   it('keeps dialogue-only filters even when no projects remain', () => {
     expect(gcProjectsAgainstActive([DIALOGUE_FILTER_KEY], [])).toEqual([DIALOGUE_FILTER_KEY]);
+  });
+
+  it('keeps Windows local projects when the active path only differs by case', () => {
+    const prev: FilterProjects = ['local:C:/Workspace/Cindy'];
+    expect(gcProjectsAgainstActive(prev, ['local:c:/workspace/cindy'], 'win32')).toBe(prev);
   });
 });
 

--- a/apps/desktop/src/renderer/__tests__/useSidebarFilter.test.ts
+++ b/apps/desktop/src/renderer/__tests__/useSidebarFilter.test.ts
@@ -471,6 +471,25 @@ describe('nextProjectsAfterToggle', () => {
     expect(prev).toEqual(snapshot);
   });
 
+  it('removes every equivalent Windows local key in one toggle', () => {
+    const prev: FilterProjects = [
+      'local:C:/Workspace/Cindy',
+      'local:c:/workspace/cindy',
+      'remote:host:C:/Workspace/Cindy',
+    ];
+
+    expect(nextProjectsAfterToggle(prev, 'local:c:/WORKSPACE/CINDY', 'win32')).toEqual([
+      'remote:host:C:/Workspace/Cindy',
+    ]);
+    expect(
+      nextProjectsAfterToggle(
+        ['local:C:/Workspace/Cindy', 'local:c:/workspace/cindy'],
+        'local:c:/WORKSPACE/CINDY',
+        'win32',
+      ),
+    ).toBe('all');
+  });
+
   it("toggles the dialogue sentinel without treating it as a project path", () => {
     expect(nextProjectsAfterToggle('all', DIALOGUE_FILTER_KEY)).toEqual([DIALOGUE_FILTER_KEY]);
     expect(nextProjectsAfterToggle([DIALOGUE_FILTER_KEY], 'local:/proj-a')).toEqual([
@@ -503,6 +522,19 @@ describe('includeProjectInFilter', () => {
     const prev: FilterProjects = ['local:C:/Workspace/Cindy'];
     expect(includeProjectInFilter(prev, 'local:c:/workspace/cindy', 'win32')).toBe(prev);
     expect(nextProjectsAfterToggle(prev, 'local:c:/workspace/cindy', 'win32')).toBe('all');
+  });
+
+  it('collapses stored Windows aliases when ensuring the project is included', () => {
+    const prev: FilterProjects = [
+      'local:C:/Workspace/Cindy',
+      'local:c:/workspace/cindy',
+      'remote:host:C:/Workspace/Cindy',
+    ];
+
+    expect(includeProjectInFilter(prev, 'local:c:/WORKSPACE/CINDY', 'win32')).toEqual([
+      'local:C:/Workspace/Cindy',
+      'remote:host:C:/Workspace/Cindy',
+    ]);
   });
 });
 

--- a/apps/desktop/src/renderer/components/layout/MainLayout.tsx
+++ b/apps/desktop/src/renderer/components/layout/MainLayout.tsx
@@ -1245,6 +1245,7 @@ export function MainLayout() {
               isRail={sidebarPeek.isPeekVisible ? false : isRailMode}
               width={sidebarWidth}
               isDragging={isDragging}
+              forceMountFeatureContent={location.pathname === '/cc-agent/new'}
               onDragStart={handleDragStart}
               onResetWidth={resetWidth}
               onOpenUpdateNotice={openNotice}

--- a/apps/desktop/src/renderer/components/new-chat/FolderPickerPopover.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/FolderPickerPopover.tsx
@@ -8,6 +8,7 @@ import {
   RefreshCw,
   X,
 } from 'lucide-react';
+import { useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { cn } from '@/lib/utils';
@@ -151,19 +152,29 @@ export function FolderPickerPopover({
   const isProjectPicker = projectOptions !== undefined;
   const effectiveProjectOptions = projectOptions ?? [];
   const recentFolders = open && !isProjectPicker ? getRecentFolders() : [];
+  const selectionPendingRef = useRef(false);
+  const [selectionPending, setSelectionPending] = useState(false);
 
   const handleSelectPath = async (
     folderPath: string,
     source: FolderPickerSelectSource,
     option?: FolderPickerOption,
   ): Promise<void> => {
+    // The popover stays open while onSelect persists its target. Guard before
+    // the first await so a rapid second click cannot be silently rejected by
+    // the parent and then close the popover as though that newer choice won.
+    if (selectionPendingRef.current) return;
+    selectionPendingRef.current = true;
+    setSelectionPending(true);
     try {
       await onSelect(folderPath, source, option);
     } finally {
+      selectionPendingRef.current = false;
+      setSelectionPending(false);
       // Selection callbacks may persist the directory before handing a pending
       // send back to the parent. Close only after that hand-off completes so a
       // controlled popover cannot clear the pending payload first.
-    onOpenChange(false);
+      onOpenChange(false);
     }
   };
 
@@ -194,6 +205,7 @@ export function FolderPickerPopover({
       >
         <button
           type="button"
+          disabled={selectionPending}
           onClick={() => handleSelectPath(project.path, 'project', project)}
           className={cn(
             'flex min-w-0 flex-1 cursor-pointer items-center gap-3 text-left',
@@ -237,6 +249,7 @@ export function FolderPickerPopover({
         {canRemove && (
           <button
             type="button"
+            disabled={selectionPending}
             aria-label={t('newChat.folderPicker.removeFromList')}
             onClick={() => handleRemoveProject(project)}
             className={cn(
@@ -293,6 +306,7 @@ export function FolderPickerPopover({
           'border border-[var(--folder-picker-border)]',
         )}
         onWheel={handleFolderPickerWheel}
+        aria-busy={selectionPending}
       >
         {isProjectPicker && (
           <>
@@ -303,6 +317,7 @@ export function FolderPickerPopover({
             </div>
             <button
               type="button"
+              disabled={selectionPending}
               onClick={() => handleSelectPath('', 'dialogue')}
               className={cn(
                 'flex w-full items-center gap-3 rounded-[8px] px-3 py-[10px] text-left',
@@ -347,6 +362,7 @@ export function FolderPickerPopover({
                       {deviceScope.retry && (
                         <button
                           type="button"
+                          disabled={selectionPending}
                           onClick={deviceScope.retry}
                           className="mt-1 inline-flex h-6 items-center gap-1 rounded-full px-2 text-xs font-medium text-[var(--error-fg-strong)] hover:bg-[var(--surface-hover)]"
                         >
@@ -369,6 +385,7 @@ export function FolderPickerPopover({
                   </span>
                   <button
                     type="button"
+                    disabled={selectionPending}
                     onClick={() => {
                       onAddRemoteProject(deviceScope.deviceId);
                       onOpenChange(false);
@@ -405,6 +422,7 @@ export function FolderPickerPopover({
                 <button
                   key={folder.path}
                   type="button"
+                  disabled={selectionPending}
                   onClick={() => handleSelectPath(folder.path, 'recent')}
                   className={cn(
                     'flex w-full items-center gap-3 rounded-[8px] px-3 py-[10px] text-left',
@@ -431,6 +449,7 @@ export function FolderPickerPopover({
         {/* Choose a different folder */}
         <button
           type="button"
+          disabled={selectionPending}
           onClick={handleChooseDifferent}
           className={cn(
             'flex w-full items-center gap-3 rounded-[8px] px-3 py-[10px] text-left',
@@ -464,6 +483,7 @@ export function FolderPickerPopover({
         {isProjectPicker && onAddRemoteProject && !deviceScope && (
           <button
             type="button"
+            disabled={selectionPending}
             onClick={() => {
               onAddRemoteProject();
               onOpenChange(false);

--- a/apps/desktop/src/renderer/components/sidebar/Sidebar.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/Sidebar.tsx
@@ -45,6 +45,8 @@ interface SidebarProps {
   width?: number;
   /** Whether the user is currently dragging the resize handle. */
   isDragging?: boolean;
+  /** Keep feature state mounted while the sidebar remains visually hidden. */
+  forceMountFeatureContent?: boolean;
   /** Pointer-down handler for the resize handle. */
   onDragStart?: (e: React.PointerEvent) => void;
   /** Double-click handler to reset width to default. */
@@ -73,6 +75,7 @@ export function Sidebar({
   isRail = false,
   width,
   isDragging,
+  forceMountFeatureContent = false,
   onDragStart,
   onResetWidth,
   onOpenUpdateNotice,
@@ -98,8 +101,11 @@ export function Sidebar({
   const isPeek = peekState != null;
   // 副窗口默认完全隐藏侧栏。此时不挂载任务列表及其搜索 Provider，避免开窗
   // 首帧为了不可见内容发起两份大列表查询；展开、rail 与 peek 都仍需完整内容。
+  // 新建任务页会强制保留 feature owner：目录恢复必须原子更新该 renderer 的
+  // hidden snapshot 与 Project filter，不能退回跨窗口共享存储的无 owner 读改写。
   // 主窗口保持原有常驻挂载语义，避免改变切换与缓存体验。
-  const shouldMountFeatureContent = !isSecondaryWindow() || !isCollapsed || isPeek;
+  const shouldMountFeatureContent =
+    forceMountFeatureContent || !isSecondaryWindow() || !isCollapsed || isPeek;
 
   // 离开 peek 的交换帧必须禁用宽度过渡:peekClosing → idle(收起)时,aside 带着
   // 上一帧的 width=展开宽 回流为流内 width=0,若 transition-[width] 还挂着,这次

--- a/apps/desktop/src/renderer/components/sidebar/__tests__/Sidebar.lazy-feature-content.test.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/__tests__/Sidebar.lazy-feature-content.test.tsx
@@ -56,13 +56,24 @@ interface HarnessProps {
   isCollapsed: boolean;
   isRail?: boolean;
   peekState?: SidebarPeekState | null;
+  forceMountFeatureContent?: boolean;
 }
 
-function Harness({ isCollapsed, isRail = false, peekState = null }: HarnessProps) {
+function Harness({
+  isCollapsed,
+  isRail = false,
+  peekState = null,
+  forceMountFeatureContent = false,
+}: HarnessProps) {
   return (
     <FeatureSidebarSlotProvider isCollapsed={peekState != null ? false : isCollapsed || isRail}>
       <RegisterUpper />
-      <Sidebar isCollapsed={isCollapsed} isRail={isRail} peekState={peekState} />
+      <Sidebar
+        isCollapsed={isCollapsed}
+        isRail={isRail}
+        peekState={peekState}
+        forceMountFeatureContent={forceMountFeatureContent}
+      />
     </FeatureSidebarSlotProvider>
   );
 }
@@ -97,6 +108,13 @@ describe('Sidebar secondary-window lazy feature content', () => {
 
   it('keeps feature content mounted in a secondary rail sidebar', () => {
     render(<Harness isCollapsed={false} isRail />);
+
+    expect(screen.getByTestId('conversation-search-provider')).toBeTruthy();
+    expect(screen.getByTestId('sidebar-upper')).toBeTruthy();
+  });
+
+  it('keeps the feature owner mounted for a hidden new-task sidebar', () => {
+    render(<Harness isCollapsed forceMountFeatureContent />);
 
     expect(screen.getByTestId('conversation-search-provider')).toBeTruthy();
     expect(screen.getByTestId('sidebar-upper')).toBeTruthy();

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSidebarUpper.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSidebarUpper.tsx
@@ -202,6 +202,7 @@ import { hasSessionSelectionModifier, type SessionClickModifiers } from './sideb
 import type { SessionMoveTarget } from './sidebar/sessionMoveTarget';
 import {
   DIALOGUE_FILTER_KEY,
+  projectFilterIncludes,
   mergeVisibleReorder,
   normalizeManualPinnedOrder,
 } from './hooks/helpers/sidebarFilterCore';
@@ -1478,7 +1479,9 @@ function ExpandedView({
     );
     if (filter.projectsAsSet === null) return notHidden;
     const allowed = filter.projectsAsSet;
-    return notHidden.filter((p) => allowed.has(p.projectKey));
+    return notHidden.filter((project) =>
+      projectFilterIncludes(allowed, project.projectKey, localPlatform),
+    );
   }, [groupsWithPinnedProjects.projects, hiddenProjectKeys, filter.projectsAsSet, localPlatform]);
 
   /* ---- M41: Vendor 过滤 — 应用到 pinned / unclassified / project sessions ---- */

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSidebarUpper.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSidebarUpper.tsx
@@ -149,7 +149,9 @@ import {
 } from './lib/sidebarProjectVisibility';
 import {
   collectRestorableProjectKeys,
+  registerSidebarProjectRestoreHandler,
   restoreHiddenProjectIfPresent,
+  restoreSelectedHiddenProject,
 } from './lib/sidebarProjectRestore';
 import { PinnedSection, type PinnedSidebarEntry } from './sidebar/sections/PinnedSection';
 import { ProjectNode as ProjectNodeView } from './sidebar/sections/ProjectNode';
@@ -409,6 +411,31 @@ export function CCAgentSidebarUpper() {
   );
   const projectAliases = useProjectAliases();
   const searchProjectGroups = useProjectGroups(searchProjectSessions, projectAliases.aliases);
+  const restorableSelectionProjectKeys = useMemo(
+    () => new Set(searchProjectGroups.projects.map((project) => project.projectKey)),
+    [searchProjectGroups.projects],
+  );
+  const restorableSelectionProjectKeysRef = useRef(restorableSelectionProjectKeys);
+  restorableSelectionProjectKeysRef.current = restorableSelectionProjectKeys;
+  useLayoutEffect(
+    () =>
+      registerSidebarProjectRestoreHandler((projectKey) =>
+        restoreSelectedHiddenProject({
+          projectKey,
+          hiddenProjectKeys,
+          setProjectHidden: hiddenProjects.setProjectHidden,
+          getCurrentProjectKeys: () => restorableSelectionProjectKeysRef.current,
+          ensureProjectIncluded: filter.ensureProjectIncluded,
+          localPlatform,
+        }),
+      ),
+    [
+      filter.ensureProjectIncluded,
+      hiddenProjectKeys,
+      hiddenProjects.setProjectHidden,
+      localPlatform,
+    ],
+  );
   const visibleSearchProjects = useMemo(
     () => visibleSidebarProjects(searchProjectGroups.projects, hiddenProjectKeys, localPlatform),
     [searchProjectGroups.projects, hiddenProjectKeys, localPlatform],

--- a/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
@@ -242,6 +242,8 @@ import { resolveNewMakerDraftRightSidebar } from './newMakerDraftRightSidebar';
 import { resolveNewMakerDraftEffort } from './newMakerDraftModelPrefs';
 import { closeAllTabs as closeRightSidebarTabs } from '@/features/right-sidebar/store';
 import { revealOrcaWorkersTab } from '@/features/right-sidebar/plugins/orca-workers/actions';
+import { normalizeProjectKey } from './lib/projectGrouping';
+import { requestSidebarProjectRestore } from './lib/sidebarProjectRestore';
 
 const log = createLogger('NewMakerDraftRoute');
 const IS_MAC_PLATFORM = typeof window !== 'undefined' && window.electronAPI?.platform === 'darwin';
@@ -2541,6 +2543,13 @@ export function NewMakerDraftRoute() {
     setDevicePickerOpen(open);
     if (open) setFolderPickerOpen(false);
   }, []);
+  const modePickerSelectionSeqRef = useRef(0);
+  useEffect(
+    () => () => {
+      modePickerSelectionSeqRef.current += 1;
+    },
+    [],
+  );
   /**
    * 选中的设备真正从可选列表里消失时(对方撤销「允许被控」/ 本机关掉对它的控制 / 解除配对),
    * 把草稿收敛回本机。
@@ -2605,13 +2614,38 @@ export function NewMakerDraftRoute() {
    * picker 里列的项目必然属于当前设备,path 直接写进 draft 即可。
    */
   const handleModePickerSelect = useCallback(
-    (path: string, source: FolderPickerSelectSource) => {
+    async (path: string, source: FolderPickerSelectSource) => {
+      const selectionSeq = ++modePickerSelectionSeqRef.current;
       // 与设备 pill 同款保护:发送已在途时那次调用的闭包持有旧工作区,draft 却会可见地切到
       // 新的 —— 会话建在旧工作区里,而用户刚选的那个又被 create 后的重置清掉。
       if (sendInFlightRef.current) return;
+      // 本机项目可能曾被用户「从侧栏移除」:任务和 workingDir 仍在,但 hidden overlay
+      // 会把它们投影到「对话」。旧段头「新建项目」按钮会在重选目录时解除隐藏；按钮移除后
+      // 创建页必须接过这条恢复路径。远程项目由各自设备维护可见性,纯对话也没有项目可恢复。
+      if (source !== 'dialogue' && !effectiveDeviceLinkDeviceId) {
+        const localProjectKey = normalizeProjectKey(path);
+        if (localProjectKey?.startsWith('local:')) {
+          try {
+            await requestSidebarProjectRestore(localProjectKey);
+          } catch (err) {
+            log.warn('[new-maker] restore selected project failed', err);
+            toast.error(t('ccAgent.sidebar.createProjectFailed'));
+            return;
+          }
+          // 恢复 IPC 在途时用户仍可能通过快捷键发送或切到另一台设备。此时不能把旧的本机
+          // 选择写回新目标；保留当前草稿,让用户在最新设备语境下重新选择。
+          if (
+            selectionSeq !== modePickerSelectionSeqRef.current ||
+            sendInFlightRef.current ||
+            (getDraft().deviceLinkDeviceId ?? null) !== null
+          ) {
+            return;
+          }
+        }
+      }
       handleWorkingDirChange(source === 'dialogue' ? null : path);
     },
-    [handleWorkingDirChange],
+    [effectiveDeviceLinkDeviceId, handleWorkingDirChange, t],
   );
 
   // 用户点击 checkbox 是唯一改动路径。本地草稿直接写工作端偏好;

--- a/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
@@ -2626,6 +2626,9 @@ export function NewMakerDraftRoute() {
         const localProjectKey = normalizeProjectKey(path);
         if (localProjectKey?.startsWith('local:')) {
           try {
+            // Selecting a folder commits its project restoration. The fence below only prevents
+            // an older async completion from overwriting a newer draft target; rolling shared
+            // visibility back could re-hide a project restored by another window.
             await requestSidebarProjectRestore(localProjectKey);
           } catch (err) {
             log.warn('[new-maker] restore selected project failed', err);

--- a/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
@@ -2576,6 +2576,16 @@ export function NewMakerDraftRoute() {
     applyDraftTarget({ deviceId: null, deviceName: null, workingDir: null });
   }, [effectiveDeviceLinkDeviceId, selectableDevices, selectableDevicesLoaded, applyDraftTarget]);
 
+  // 创建目标正在异步提交时，发送、建目标以及设备／工作区切换必须共用同一把锁。
+  // ref 负责同步 guard，state 只负责驱动 UI 禁用；所有写入都经 markSendInFlight，
+  // 避免其中一半提前释放后让旧草稿目标被消费。
+  const sendInFlightRef = useRef(false);
+  const [sendInFlight, setSendInFlight] = useState(false);
+  const markSendInFlight = useCallback((value: boolean) => {
+    sendInFlightRef.current = value;
+    setSendInFlight(value);
+  }, []);
+
   /**
    * 换设备(#807)。**一并清掉 workingDir 与 extraDirs** —— 上一台机器的路径在新机器上
    * 基本不存在,留着会让用户以为项目跟过来了,发送时才在被控端 path guard 上失败。
@@ -2615,40 +2625,47 @@ export function NewMakerDraftRoute() {
    */
   const handleModePickerSelect = useCallback(
     async (path: string, source: FolderPickerSelectSource) => {
-      const selectionSeq = ++modePickerSelectionSeqRef.current;
       // 与设备 pill 同款保护:发送已在途时那次调用的闭包持有旧工作区,draft 却会可见地切到
       // 新的 —— 会话建在旧工作区里,而用户刚选的那个又被 create 后的重置清掉。
       if (sendInFlightRef.current) return;
+      // 只有真正接受的选择才能作废上一轮。若锁已占用却先递增，第二次点击会同时被拒绝、
+      // 又让第一轮完成后命中 sequence fence，最终两个选择都不生效。
+      const selectionSeq = ++modePickerSelectionSeqRef.current;
       // 本机项目可能曾被用户「从侧栏移除」:任务和 workingDir 仍在,但 hidden overlay
       // 会把它们投影到「对话」。旧段头「新建项目」按钮会在重选目录时解除隐藏；按钮移除后
       // 创建页必须接过这条恢复路径。远程项目由各自设备维护可见性,纯对话也没有项目可恢复。
       if (source !== 'dialogue' && !effectiveDeviceLinkDeviceId) {
         const localProjectKey = normalizeProjectKey(path);
         if (localProjectKey?.startsWith('local:')) {
+          // 恢复和草稿目标应用是一笔提交：期间复用创建锁，阻止 Send / Goal 或其它目标切换
+          // 消费旧 workingDir。锁保持到新目标同步写入完成，reject / fence 早退也由 finally 释放。
+          markSendInFlight(true);
           try {
             // Selecting a folder commits its project restoration. The fence below only prevents
             // an older async completion from overwriting a newer draft target; rolling shared
             // visibility back could re-hide a project restored by another window.
             await requestSidebarProjectRestore(localProjectKey);
+            // 恢复在途期间手动发送和目标切换都被同一把锁挡住；这里仍保留 sequence / device
+            // fence，覆盖卸载与权威设备状态变化等不经过交互 handler 的路径。
+            if (
+              selectionSeq !== modePickerSelectionSeqRef.current ||
+              (getDraft().deviceLinkDeviceId ?? null) !== null
+            ) {
+              return;
+            }
+            handleWorkingDirChange(path);
           } catch (err) {
             log.warn('[new-maker] restore selected project failed', err);
             toast.error(t('ccAgent.sidebar.createProjectFailed'));
-            return;
+          } finally {
+            markSendInFlight(false);
           }
-          // 恢复 IPC 在途时用户仍可能通过快捷键发送或切到另一台设备。此时不能把旧的本机
-          // 选择写回新目标；保留当前草稿,让用户在最新设备语境下重新选择。
-          if (
-            selectionSeq !== modePickerSelectionSeqRef.current ||
-            sendInFlightRef.current ||
-            (getDraft().deviceLinkDeviceId ?? null) !== null
-          ) {
-            return;
-          }
+          return;
         }
       }
       handleWorkingDirChange(source === 'dialogue' ? null : path);
     },
-    [effectiveDeviceLinkDeviceId, handleWorkingDirChange, t],
+    [effectiveDeviceLinkDeviceId, handleWorkingDirChange, markSendInFlight, t],
   );
 
   // 用户点击 checkbox 是唯一改动路径。本地草稿直接写工作端偏好;
@@ -2877,17 +2894,6 @@ export function NewMakerDraftRoute() {
     setWtName(name);
   }, []);
 
-  // 防止用户在 send 流程中再次按下 send(异步 createSession 期间)。
-  const sendInFlightRef = useRef(false);
-  /**
-   * 与 sendInFlightRef 同步的渲染态。ref 用于同步 guard(重复发送、切设备)——它必须即时可读;
-   * state 只负责让「发送在途」能驱动 UI 禁用(ref 变化不触发渲染)。两者一起改,别只动一个。
-   */
-  const [sendInFlight, setSendInFlight] = useState(false);
-  const markSendInFlight = useCallback((value: boolean) => {
-    sendInFlightRef.current = value;
-    setSendInFlight(value);
-  }, []);
   const wtRef = useRef({
     enabled: wtEnabled,
     name: wtName,

--- a/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
@@ -583,6 +583,7 @@ export function NewMakerDraftRoute() {
     [location.state],
   );
   const handledDialogueTargetRequestRef = useRef<string | null>(null);
+  const modePickerSelectionSeqRef = useRef(0);
   // 首参 914=内容封顶宽(→ inputWidth 封顶 934):大屏留出左右呼吸空间,不再顶满全宽;
   // 与进行中对话页(CCAgentSessionView 同传 914)一致,发送首条消息时输入框宽度不跳变。
   // minWidth=640:小屏兜一个体面下限(与对话页对称);窄于下限时 hook 自动回落成
@@ -2096,6 +2097,9 @@ export function NewMakerDraftRoute() {
       return;
     }
     handledDialogueTargetRequestRef.current = dialogueTargetRequest.requestId;
+    // 同路由的对话目标是比在途目录恢复更新的用户选择。先推进同一 sequence owner，
+    // 让旧 restore completion 只能释放锁，不能把目录重新写回草稿。
+    modePickerSelectionSeqRef.current += 1;
     patchCollab({ enabled: false });
     applyDraftTarget({
       deviceId: dialogueTargetRequest.deviceId,
@@ -2543,7 +2547,6 @@ export function NewMakerDraftRoute() {
     setDevicePickerOpen(open);
     if (open) setFolderPickerOpen(false);
   }, []);
-  const modePickerSelectionSeqRef = useRef(0);
   useEffect(
     () => () => {
       modePickerSelectionSeqRef.current += 1;

--- a/apps/desktop/src/renderer/features/cc-agent/hooks/__tests__/useHiddenProjectsFilterSync.test.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/hooks/__tests__/useHiddenProjectsFilterSync.test.tsx
@@ -86,16 +86,19 @@ describe('hidden-project filter synchronization', () => {
     });
     expect(firstWindow.result.current.projects).toEqual([PROJECT_B]);
     expect(secondWindow.result.current.projects).toEqual([PROJECT_B]);
+  });
+
+  it('keeps project restore scoped to the renderer that requested it', () => {
+    window.localStorage.setItem(PROJECTS_KEY, JSON.stringify([PROJECT_B]));
+    const restoringWindow = renderHook(() => useSyncedSidebarFilter());
+    const otherWindow = renderHook(() => useSyncedSidebarFilter());
 
     act(() => {
-      for (const listener of hiddenProjectsListeners) listener([], OWNER_STAMP);
-    });
-    act(() => {
-      firstWindow.result.current.ensureProjectIncluded(PROJECT_A);
+      restoringWindow.result.current.ensureProjectIncluded(PROJECT_A);
     });
 
-    expect(firstWindow.result.current.projects).toEqual([PROJECT_B, PROJECT_A]);
-    expect(secondWindow.result.current.projects).toEqual([PROJECT_B]);
+    expect(restoringWindow.result.current.projects).toEqual([PROJECT_B, PROJECT_A]);
+    expect(otherWindow.result.current.projects).toEqual([PROJECT_B]);
     expect(JSON.parse(window.localStorage.getItem(OWNER_PROJECTS_KEY) ?? 'null')).toEqual([
       PROJECT_B,
       PROJECT_A,

--- a/apps/desktop/src/renderer/features/cc-agent/hooks/helpers/sidebarFilterCore.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/hooks/helpers/sidebarFilterCore.ts
@@ -176,14 +176,18 @@ export function persistProjects(p: FilterProjects, ownerId: string | null): void
  * 返回值如果与 prev 引用相同（语义上无变化），调用方可短路不写 storage。
  * 实际上本函数总是返回新对象（除非语义无变化才返回 prev）。
  */
-export function nextProjectsAfterToggle(prev: FilterProjects, workingDir: string): FilterProjects {
+export function nextProjectsAfterToggle(
+  prev: FilterProjects,
+  workingDir: string,
+  localPlatform = 'linux',
+): FilterProjects {
   const projectKey = normalizeFilterEntry(workingDir);
   if (!projectKey) return prev;
   if (prev === 'all') {
     return [projectKey];
   }
   const normalizedPrev = normalizeFilterProjectList(prev);
-  const idx = normalizedPrev.indexOf(projectKey);
+  const idx = findProjectFilterIndex(normalizedPrev, projectKey, localPlatform);
   if (idx >= 0) {
     if (normalizedPrev.length === 1) {
       return 'all';
@@ -199,15 +203,35 @@ export function nextProjectsAfterToggle(prev: FilterProjects, workingDir: string
  * `'all'` already includes every project. Array filters append only when the
  * project is missing, unlike the user-facing toggle action.
  */
-export function includeProjectInFilter(prev: FilterProjects, workingDir: string): FilterProjects {
+export function includeProjectInFilter(
+  prev: FilterProjects,
+  workingDir: string,
+  localPlatform = 'linux',
+): FilterProjects {
   if (prev === 'all') return prev;
   const projectKey = normalizeFilterEntry(workingDir);
   if (!projectKey) return prev;
   const normalizedPrev = normalizeFilterProjectList(prev);
-  if (normalizedPrev.includes(projectKey)) {
+  if (findProjectFilterIndex(normalizedPrev, projectKey, localPlatform) >= 0) {
     return arraysEqual(normalizedPrev, prev) ? prev : normalizedPrev;
   }
   return normalizedPrev.concat(projectKey);
+}
+
+/** Match a rendered project against the persisted Project filter identity. */
+export function projectFilterIncludes(
+  projects: ReadonlySet<string>,
+  projectKey: string,
+  localPlatform: string,
+): boolean {
+  if (projectKey === DIALOGUE_FILTER_KEY) return projects.has(DIALOGUE_FILTER_KEY);
+  const comparisonKey = projectKeyComparisonKey(projectKey, localPlatform);
+  if (comparisonKey == null) return false;
+  for (const candidate of projects) {
+    if (candidate === DIALOGUE_FILTER_KEY) continue;
+    if (projectKeyComparisonKey(candidate, localPlatform) === comparisonKey) return true;
+  }
+  return false;
 }
 
 /**
@@ -750,13 +774,20 @@ export function mergeVisibleReorder(
 export function gcProjectsAgainstActive(
   prev: FilterProjects,
   activeWorkingDirs: readonly string[],
+  localPlatform = 'linux',
 ): FilterProjects {
   if (prev === 'all') return prev;
-  const activeSet = new Set(normalizeProjectKeyList(activeWorkingDirs));
-  const normalizedPrev = normalizeFilterProjectList(prev);
-  const filtered = normalizedPrev.filter(
-    (wd) => wd === DIALOGUE_FILTER_KEY || activeSet.has(wd),
+  const activeComparisonKeys = new Set(
+    normalizeProjectKeyList(activeWorkingDirs)
+      .map((projectKey) => projectKeyComparisonKey(projectKey, localPlatform))
+      .filter((projectKey): projectKey is string => projectKey != null),
   );
+  const normalizedPrev = normalizeFilterProjectList(prev);
+  const filtered = normalizedPrev.filter((projectKey) => {
+    if (projectKey === DIALOGUE_FILTER_KEY) return true;
+    const comparisonKey = projectKeyComparisonKey(projectKey, localPlatform);
+    return comparisonKey != null && activeComparisonKeys.has(comparisonKey);
+  });
   if (filtered.length === 0) return 'all';
   if (filtered.length === normalizedPrev.length && arraysEqual(normalizedPrev, prev)) return prev;
   if (filtered.length === normalizedPrev.length) return normalizedPrev;
@@ -791,6 +822,21 @@ function normalizeProjectKeyList(values: readonly unknown[]): string[] {
     out.push(key);
   }
   return out;
+}
+
+function findProjectFilterIndex(
+  projectKeys: readonly string[],
+  projectKey: string,
+  localPlatform: string,
+): number {
+  if (projectKey === DIALOGUE_FILTER_KEY) return projectKeys.indexOf(DIALOGUE_FILTER_KEY);
+  const comparisonKey = projectKeyComparisonKey(projectKey, localPlatform);
+  if (comparisonKey == null) return -1;
+  return projectKeys.findIndex(
+    (candidate) =>
+      candidate !== DIALOGUE_FILTER_KEY &&
+      projectKeyComparisonKey(candidate, localPlatform) === comparisonKey,
+  );
 }
 
 function arraysEqual(a: readonly string[], b: readonly unknown[]): boolean {

--- a/apps/desktop/src/renderer/features/cc-agent/hooks/helpers/sidebarFilterCore.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/hooks/helpers/sidebarFilterCore.ts
@@ -186,7 +186,10 @@ export function nextProjectsAfterToggle(
   if (prev === 'all') {
     return [projectKey];
   }
-  const normalizedPrev = normalizeFilterProjectList(prev);
+  // Persisted filters may contain multiple Windows spellings of the same local path from
+  // pre-comparison-key versions. Collapse them to one logical identity before toggling so a
+  // single click removes the whole selected project rather than one stale spelling at a time.
+  const normalizedPrev = normalizeFilterProjectList(prev, localPlatform);
   const idx = findProjectFilterIndex(normalizedPrev, projectKey, localPlatform);
   if (idx >= 0) {
     if (normalizedPrev.length === 1) {
@@ -211,7 +214,7 @@ export function includeProjectInFilter(
   if (prev === 'all') return prev;
   const projectKey = normalizeFilterEntry(workingDir);
   if (!projectKey) return prev;
-  const normalizedPrev = normalizeFilterProjectList(prev);
+  const normalizedPrev = normalizeFilterProjectList(prev, localPlatform);
   if (findProjectFilterIndex(normalizedPrev, projectKey, localPlatform) >= 0) {
     return arraysEqual(normalizedPrev, prev) ? prev : normalizedPrev;
   }
@@ -253,7 +256,7 @@ export function removeProjectsFromFilter(
       .filter((projectKey): projectKey is string => projectKey != null),
   );
   if (hiddenComparisonKeys.size === 0) return prev;
-  const normalizedPrev = normalizeFilterProjectList(prev);
+  const normalizedPrev = normalizeFilterProjectList(prev, localPlatform);
   const filtered = normalizedPrev.filter((projectKey) => {
     if (projectKey === DIALOGUE_FILTER_KEY) return true;
     const comparisonKey = projectKeyComparisonKey(projectKey, localPlatform);
@@ -782,7 +785,7 @@ export function gcProjectsAgainstActive(
       .map((projectKey) => projectKeyComparisonKey(projectKey, localPlatform))
       .filter((projectKey): projectKey is string => projectKey != null),
   );
-  const normalizedPrev = normalizeFilterProjectList(prev);
+  const normalizedPrev = normalizeFilterProjectList(prev, localPlatform);
   const filtered = normalizedPrev.filter((projectKey) => {
     if (projectKey === DIALOGUE_FILTER_KEY) return true;
     const comparisonKey = projectKeyComparisonKey(projectKey, localPlatform);
@@ -800,13 +803,20 @@ function normalizeFilterEntry(raw: unknown): string | null {
   return normalizeProjectKey(raw);
 }
 
-function normalizeFilterProjectList(values: readonly unknown[]): string[] {
+function normalizeFilterProjectList(
+  values: readonly unknown[],
+  localPlatform?: string,
+): string[] {
   const seen = new Set<string>();
   const out: string[] = [];
   for (const value of values) {
     const key = normalizeFilterEntry(value);
-    if (!key || seen.has(key)) continue;
-    seen.add(key);
+    if (!key) continue;
+    const identity = localPlatform == null
+      ? key
+      : (projectFilterEntryIdentity(key, localPlatform) ?? key);
+    if (seen.has(identity)) continue;
+    seen.add(identity);
     out.push(key);
   }
   return out;
@@ -829,14 +839,17 @@ function findProjectFilterIndex(
   projectKey: string,
   localPlatform: string,
 ): number {
-  if (projectKey === DIALOGUE_FILTER_KEY) return projectKeys.indexOf(DIALOGUE_FILTER_KEY);
-  const comparisonKey = projectKeyComparisonKey(projectKey, localPlatform);
-  if (comparisonKey == null) return -1;
+  const identity = projectFilterEntryIdentity(projectKey, localPlatform);
+  if (identity == null) return -1;
   return projectKeys.findIndex(
-    (candidate) =>
-      candidate !== DIALOGUE_FILTER_KEY &&
-      projectKeyComparisonKey(candidate, localPlatform) === comparisonKey,
+    (candidate) => projectFilterEntryIdentity(candidate, localPlatform) === identity,
   );
+}
+
+/** Logical identity used by every single-project filter operation. */
+function projectFilterEntryIdentity(projectKey: string, localPlatform: string): string | null {
+  if (projectKey === DIALOGUE_FILTER_KEY) return DIALOGUE_FILTER_KEY;
+  return projectKeyComparisonKey(projectKey, localPlatform);
 }
 
 function arraysEqual(a: readonly string[], b: readonly unknown[]): boolean {

--- a/apps/desktop/src/renderer/features/cc-agent/hooks/useSidebarFilter.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/hooks/useSidebarFilter.ts
@@ -393,7 +393,7 @@ export function useSidebarFilter(
   const toggleProject = useCallback(
     (workingDir: string) => {
       setProjectsState((prev) => {
-        const next = nextProjectsAfterToggle(prev, workingDir);
+        const next = nextProjectsAfterToggle(prev, workingDir, window.electronAPI.platform);
         if (next === prev) return prev;
         persistProjects(next, ownerId);
         return next;
@@ -405,7 +405,7 @@ export function useSidebarFilter(
   const ensureProjectIncluded = useCallback(
     (workingDir: string) => {
       setProjectsState((prev) => {
-        const next = includeProjectInFilter(prev, workingDir);
+        const next = includeProjectInFilter(prev, workingDir, window.electronAPI.platform);
         if (next === prev) return prev;
         persistProjects(next, ownerId);
         return next;
@@ -425,7 +425,11 @@ export function useSidebarFilter(
   const gc = useCallback(
     (activeWorkingDirs: readonly string[]) => {
       setProjectsState((prev) => {
-        const next = gcProjectsAgainstActive(prev, activeWorkingDirs);
+        const next = gcProjectsAgainstActive(
+          prev,
+          activeWorkingDirs,
+          window.electronAPI.platform,
+        );
         if (next === prev) return prev;
         persistProjects(next, ownerId);
         return next;

--- a/apps/desktop/src/renderer/features/cc-agent/lib/sidebarProjectRestore.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/lib/sidebarProjectRestore.ts
@@ -3,6 +3,47 @@ import type { Session } from '@/lib/ccAgent.types';
 import { projectKeyComparisonKey } from '../../../../shared/projectKeys';
 import { sessionActivityMs } from './dateSessionGrouping';
 import { groupSessions, projectIdentityKeyForSession } from './projectGrouping';
+import { isProjectHidden } from './sidebarProjectVisibility';
+
+type SidebarProjectRestoreHandler = (projectKey: string) => Promise<boolean>;
+
+let sidebarProjectRestoreHandler: SidebarProjectRestoreHandler | null = null;
+
+function findMatchingProjectKey(
+  projectKey: string,
+  candidates: ReadonlySet<string>,
+  localPlatform: string,
+): string | null {
+  const comparisonKey = projectKeyComparisonKey(projectKey, localPlatform);
+  if (comparisonKey == null) return null;
+  return (
+    Array.from(candidates).find(
+      (candidate) => projectKeyComparisonKey(candidate, localPlatform) === comparisonKey,
+    ) ?? null
+  );
+}
+
+/**
+ * The sidebar owns both the hidden-project snapshot and the active Project
+ * filter. Creation routes live in a sibling React tree, so they delegate the
+ * restore transaction here instead of duplicating those two pieces of state.
+ */
+export function registerSidebarProjectRestoreHandler(
+  handler: SidebarProjectRestoreHandler,
+): () => void {
+  sidebarProjectRestoreHandler = handler;
+  return () => {
+    if (sidebarProjectRestoreHandler === handler) sidebarProjectRestoreHandler = null;
+  };
+}
+
+export function requestSidebarProjectRestore(projectKey: string): Promise<boolean> {
+  const handler = sidebarProjectRestoreHandler;
+  if (!handler) {
+    return Promise.reject(new Error('Sidebar project restore handler is unavailable'));
+  }
+  return handler(projectKey);
+}
 
 type RestoreVendorPredicate = (session: Pick<Session, 'agentKind'>) => boolean;
 
@@ -84,18 +125,49 @@ export async function restoreHiddenProjectIfPresent({
     return false;
   }
 
-  const comparisonKey = projectKeyComparisonKey(projectKey, localPlatform);
-  const currentProjectKey =
-    comparisonKey == null
-      ? null
-      : Array.from(getCurrentProjectKeys()).find(
-          (candidate) =>
-            projectKeyComparisonKey(candidate, localPlatform) === comparisonKey,
-        ) ?? null;
+  const currentProjectKey = findMatchingProjectKey(
+    projectKey,
+    getCurrentProjectKeys(),
+    localPlatform,
+  );
   if (currentProjectKey == null) return false;
 
   // A restored project must also be admitted by an explicit Project filter.
   // This operation is idempotent, unlike the user-facing filter toggle.
   ensureProjectIncluded(currentProjectKey);
+  return true;
+}
+
+interface RestoreSelectedHiddenProjectOptions {
+  projectKey: string;
+  hiddenProjectKeys: ReadonlySet<string>;
+  setProjectHidden: (projectKey: string, hidden: boolean) => Promise<boolean>;
+  getCurrentProjectKeys: () => ReadonlySet<string>;
+  ensureProjectIncluded: (projectKey: string) => void;
+  localPlatform: string;
+}
+
+/**
+ * Restore a project explicitly selected from the new-task folder picker.
+ *
+ * Unlike the old sidebar "New Project" action, selection must continue into
+ * the draft after restoring. The chosen path itself is therefore the future
+ * project key even when the restored project currently has no visible tasks.
+ */
+export async function restoreSelectedHiddenProject({
+  projectKey,
+  hiddenProjectKeys,
+  setProjectHidden,
+  getCurrentProjectKeys,
+  ensureProjectIncluded,
+  localPlatform,
+}: RestoreSelectedHiddenProjectOptions): Promise<boolean> {
+  const wasHidden = isProjectHidden(projectKey, hiddenProjectKeys, localPlatform);
+  const hiddenStateChanged = await setProjectHidden(projectKey, false);
+  if (!hiddenStateChanged && !wasHidden) return false;
+
+  ensureProjectIncluded(
+    findMatchingProjectKey(projectKey, getCurrentProjectKeys(), localPlatform) ?? projectKey,
+  );
   return true;
 }

--- a/apps/desktop/src/renderer/features/cc-agent/lib/sidebarProjectRestore.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/lib/sidebarProjectRestore.ts
@@ -39,9 +39,7 @@ export function registerSidebarProjectRestoreHandler(
 
 export function requestSidebarProjectRestore(projectKey: string): Promise<boolean> {
   const handler = sidebarProjectRestoreHandler;
-  if (!handler) {
-    return Promise.reject(new Error('Sidebar project restore handler is unavailable'));
-  }
+  if (!handler) return Promise.resolve(false);
   return handler(projectKey);
 }
 

--- a/apps/desktop/src/renderer/features/cc-agent/lib/sidebarProjectRestore.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/lib/sidebarProjectRestore.ts
@@ -1,6 +1,12 @@
 import type { Session } from '@/lib/ccAgent.types';
 
 import { projectKeyComparisonKey } from '../../../../shared/projectKeys';
+import {
+  includeProjectInFilter,
+  loadProjects,
+  persistProjects,
+  type FilterProjects,
+} from '../hooks/helpers/sidebarFilterCore';
 import { sessionActivityMs } from './dateSessionGrouping';
 import { groupSessions, projectIdentityKeyForSession } from './projectGrouping';
 import { isProjectHidden } from './sidebarProjectVisibility';
@@ -37,10 +43,12 @@ export function registerSidebarProjectRestoreHandler(
   };
 }
 
-export function requestSidebarProjectRestore(projectKey: string): Promise<boolean> {
+export function requestSidebarProjectRestore(
+  projectKey: string,
+  fallback: SidebarProjectRestoreHandler = restoreSelectedHiddenProjectWithoutSidebarOwner,
+): Promise<boolean> {
   const handler = sidebarProjectRestoreHandler;
-  if (!handler) return Promise.resolve(false);
-  return handler(projectKey);
+  return (handler ?? fallback)(projectKey);
 }
 
 type RestoreVendorPredicate = (session: Pick<Session, 'agentKind'>) => boolean;
@@ -170,4 +178,53 @@ export async function restoreSelectedHiddenProject({
     findMatchingProjectKey(projectKey, getCurrentProjectKeys(), localPlatform) ?? projectKey,
   );
   return wasHidden;
+}
+
+interface RestoreSelectedHiddenProjectWithoutSidebarOwnerOptions {
+  projectKey: string;
+  hiddenProjectKeys: ReadonlySet<string>;
+  setProjectHidden: (projectKey: string, hidden: boolean) => Promise<boolean>;
+  loadFilterProjects: () => FilterProjects;
+  persistFilterProjects: (projects: FilterProjects) => void;
+  localPlatform: string;
+}
+
+/**
+ * Restores a selected project when the secondary window has not mounted its
+ * collapsed sidebar. The next sidebar mount hydrates the persisted filter.
+ */
+export async function restoreSelectedHiddenProjectWithoutMountedSidebar({
+  projectKey,
+  hiddenProjectKeys,
+  setProjectHidden,
+  loadFilterProjects,
+  persistFilterProjects,
+  localPlatform,
+}: RestoreSelectedHiddenProjectWithoutSidebarOwnerOptions): Promise<boolean> {
+  return restoreSelectedHiddenProject({
+    projectKey,
+    hiddenProjectKeys,
+    setProjectHidden,
+    getCurrentProjectKeys: () => new Set(),
+    ensureProjectIncluded: (selectedProjectKey) => {
+      const current = loadFilterProjects();
+      const next = includeProjectInFilter(current, selectedProjectKey, localPlatform);
+      if (next !== current) persistFilterProjects(next);
+    },
+    localPlatform,
+  });
+}
+
+function restoreSelectedHiddenProjectWithoutSidebarOwner(projectKey: string): Promise<boolean> {
+  const snapshot = window.electronAPI.sidebarSettings.loadSnapshot();
+  const localPlatform = window.electronAPI.platform;
+  return restoreSelectedHiddenProjectWithoutMountedSidebar({
+    projectKey,
+    hiddenProjectKeys: new Set(snapshot.hiddenProjectKeys),
+    setProjectHidden: (selectedProjectKey, hidden) =>
+      window.electronAPI.sidebarSettings.setProjectHidden(selectedProjectKey, hidden, snapshot),
+    loadFilterProjects: () => loadProjects(snapshot.dataOwnerId),
+    persistFilterProjects: (projects) => persistProjects(projects, snapshot.dataOwnerId),
+    localPlatform,
+  });
 }

--- a/apps/desktop/src/renderer/features/cc-agent/lib/sidebarProjectRestore.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/lib/sidebarProjectRestore.ts
@@ -153,6 +153,9 @@ interface RestoreSelectedHiddenProjectOptions {
  * Unlike the old sidebar "New Project" action, selection must continue into
  * the draft after restoring. The chosen path itself is therefore the future
  * project key even when the restored project currently has no visible tasks.
+ * Every explicit selection is admitted by the current Project filter, while
+ * the persisted hidden-project state is only touched when the snapshot says
+ * this project is actually hidden.
  */
 export async function restoreSelectedHiddenProject({
   projectKey,
@@ -163,11 +166,10 @@ export async function restoreSelectedHiddenProject({
   localPlatform,
 }: RestoreSelectedHiddenProjectOptions): Promise<boolean> {
   const wasHidden = isProjectHidden(projectKey, hiddenProjectKeys, localPlatform);
-  const hiddenStateChanged = await setProjectHidden(projectKey, false);
-  if (!hiddenStateChanged && !wasHidden) return false;
+  if (wasHidden) await setProjectHidden(projectKey, false);
 
   ensureProjectIncluded(
     findMatchingProjectKey(projectKey, getCurrentProjectKeys(), localPlatform) ?? projectKey,
   );
-  return true;
+  return wasHidden;
 }

--- a/apps/desktop/src/renderer/features/cc-agent/lib/sidebarProjectRestore.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/lib/sidebarProjectRestore.ts
@@ -1,12 +1,6 @@
 import type { Session } from '@/lib/ccAgent.types';
 
 import { projectKeyComparisonKey } from '../../../../shared/projectKeys';
-import {
-  includeProjectInFilter,
-  loadProjects,
-  persistProjects,
-  type FilterProjects,
-} from '../hooks/helpers/sidebarFilterCore';
 import { sessionActivityMs } from './dateSessionGrouping';
 import { groupSessions, projectIdentityKeyForSession } from './projectGrouping';
 import { isProjectHidden } from './sidebarProjectVisibility';
@@ -43,12 +37,9 @@ export function registerSidebarProjectRestoreHandler(
   };
 }
 
-export function requestSidebarProjectRestore(
-  projectKey: string,
-  fallback: SidebarProjectRestoreHandler = restoreSelectedHiddenProjectWithoutSidebarOwner,
-): Promise<boolean> {
+export function requestSidebarProjectRestore(projectKey: string): Promise<boolean> {
   const handler = sidebarProjectRestoreHandler;
-  return (handler ?? fallback)(projectKey);
+  return handler?.(projectKey) ?? Promise.resolve(false);
 }
 
 type RestoreVendorPredicate = (session: Pick<Session, 'agentKind'>) => boolean;
@@ -178,53 +169,4 @@ export async function restoreSelectedHiddenProject({
     findMatchingProjectKey(projectKey, getCurrentProjectKeys(), localPlatform) ?? projectKey,
   );
   return wasHidden;
-}
-
-interface RestoreSelectedHiddenProjectWithoutSidebarOwnerOptions {
-  projectKey: string;
-  hiddenProjectKeys: ReadonlySet<string>;
-  setProjectHidden: (projectKey: string, hidden: boolean) => Promise<boolean>;
-  loadFilterProjects: () => FilterProjects;
-  persistFilterProjects: (projects: FilterProjects) => void;
-  localPlatform: string;
-}
-
-/**
- * Restores a selected project when the secondary window has not mounted its
- * collapsed sidebar. The next sidebar mount hydrates the persisted filter.
- */
-export async function restoreSelectedHiddenProjectWithoutMountedSidebar({
-  projectKey,
-  hiddenProjectKeys,
-  setProjectHidden,
-  loadFilterProjects,
-  persistFilterProjects,
-  localPlatform,
-}: RestoreSelectedHiddenProjectWithoutSidebarOwnerOptions): Promise<boolean> {
-  return restoreSelectedHiddenProject({
-    projectKey,
-    hiddenProjectKeys,
-    setProjectHidden,
-    getCurrentProjectKeys: () => new Set(),
-    ensureProjectIncluded: (selectedProjectKey) => {
-      const current = loadFilterProjects();
-      const next = includeProjectInFilter(current, selectedProjectKey, localPlatform);
-      if (next !== current) persistFilterProjects(next);
-    },
-    localPlatform,
-  });
-}
-
-function restoreSelectedHiddenProjectWithoutSidebarOwner(projectKey: string): Promise<boolean> {
-  const snapshot = window.electronAPI.sidebarSettings.loadSnapshot();
-  const localPlatform = window.electronAPI.platform;
-  return restoreSelectedHiddenProjectWithoutMountedSidebar({
-    projectKey,
-    hiddenProjectKeys: new Set(snapshot.hiddenProjectKeys),
-    setProjectHidden: (selectedProjectKey, hidden) =>
-      window.electronAPI.sidebarSettings.setProjectHidden(selectedProjectKey, hidden, snapshot),
-    loadFilterProjects: () => loadProjects(snapshot.dataOwnerId),
-    persistFilterProjects: (projects) => persistProjects(projects, snapshot.dataOwnerId),
-    localPlatform,
-  });
 }

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/SidebarFilterPopover.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/SidebarFilterPopover.tsx
@@ -65,7 +65,10 @@ import type {
   FilterVendor,
   UseSidebarFilterReturn,
 } from '../hooks/useSidebarFilter';
-import { DIALOGUE_FILTER_KEY } from '../hooks/helpers/sidebarFilterCore';
+import {
+  DIALOGUE_FILTER_KEY,
+  projectFilterIncludes,
+} from '../hooks/helpers/sidebarFilterCore';
 import { useTaskInfoFields, type TaskInfoField } from '../hooks/useTaskInfoFields';
 import {
   MENU_CONTENT_CLASS,
@@ -332,6 +335,7 @@ export function SidebarFilterPopover({
   onOpenChange,
 }: SidebarFilterPopoverProps) {
   const { t } = useTranslation();
+  const localPlatform = window.electronAPI.platform;
   // 受控光标模式 = 调用方传了 contextMenuPos 这个 prop(值为 null 表示"当前关闭",
   // 仍算受控);段头按钮模式则完全不传。用 !== undefined 而非真值判断。
   const isContextMode = contextMenuPos !== undefined;
@@ -587,7 +591,9 @@ export function SidebarFilterPopover({
                 </DropdownMenuItem>
                 {allKnownProjects.map((project) => {
                   const selected =
-                    projects === 'all' || (projectsAsSet?.has(project.projectKey) ?? false);
+                    projects === 'all' ||
+                    (projectsAsSet != null &&
+                      projectFilterIncludes(projectsAsSet, project.projectKey, localPlatform));
                   const remoteIdentity = getRemoteProjectMachineIdentity(project);
                   return (
                     <DropdownMenuItem


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复「新建任务」选择器重新选择曾从侧栏移除的本地文件夹后，已有任务仍显示在“对话”列表的问题。

根因是旧的“新建项目”入口会清除项目隐藏标记，但入口移除后，新建任务的文件夹选择器没有承接这段恢复逻辑。现在选择本地项目目录时，会先恢复项目可见性，并补回发起选择窗口的项目筛选，再把目录应用到草稿；已有 CC 任务会重新归入对应项目，新任务也会进入同一项目。

为避免副窗口侧栏收起时缺少状态 owner，`/cc-agent/new` 会继续挂载当前 renderer 既有的侧栏 feature owner；恢复操作只由该 owner 同时更新隐藏项目快照和本窗口 Project filter，不再由无 owner fallback 直接改写共享筛选存储。恢复期间文件夹选择器保持打开并禁用后续操作，完成目录持久化与 pending send 交接后再关闭，避免快速第二次选择被静默丢弃。

本轮收敛后的不变量：

- 同一 renderer 的侧栏 owner 是隐藏项目快照与 Project filter 的唯一恢复写入者；没有 owner 时不直接修改共享筛选存储。
- 文件夹选择一旦进入异步恢复，同一个 picker 在完成前不再接受第二个操作。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Slack 反馈——重新选择已移除项目的文件夹时自动恢复项目
- 本 PR 包含：本地隐藏项目恢复、发起选择窗口的项目筛选补回、`/cc-agent/new` 在收起侧栏时保留既有状态 owner、异步选择防重入、Windows 路径大小写等价处理及回归测试
- 明确不包含：重新添加“新建项目”按钮；远程项目可见性逻辑；任务导入逻辑；改写其他已挂载窗口的显式项目筛选；为其他副窗口路由取消侧栏 feature content 的懒挂载
- 用户可见变化：在重新选择文件夹的窗口中，该项目及其已有任务会恢复到项目列表；恢复进行中 picker 暂不接受其他选择；其他已打开窗口继续保留各自独立的显式项目筛选
- 是否存在 breaking change：无

### UI 变化

交互变化：项目恢复进行中，文件夹选择器保持打开并临时禁用内部操作，完成后关闭；未修改布局、文案或新增色值。禁用态复用现有原生 `disabled` 与语义 token 样式，Light / Dark 共用同一实现。

- 引用的设计规范：`docs/design-rules/DESIGN.md` §10「Light / Dark Dual-Mode Delivery Gate」——本次触及的 disabled / loading 状态复用现有双模式 token，不新增单模式硬编码；未做 Light / Dark 实机目检，已在“未执行的验证”如实注明

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run \
  src/renderer/__tests__/sidebarProjectRestore.test.ts \
  src/renderer/__tests__/newMakerProjectPicker.test.ts \
  src/renderer/components/sidebar/__tests__/Sidebar.lazy-feature-content.test.tsx
结果：110 项测试通过；覆盖无 owner 时不写共享筛选存储、副窗口新建任务页在收起侧栏时仍挂载 owner，以及 pending 期间拒绝第二次选择。

pnpm test:unit:related
结果：Desktop 相关单测通过。

pnpm --filter desktop run --if-present typecheck
结果：通过。

pnpm check:dco
结果：8 个 PR commit 全部通过。

/Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh <worktree>
结果：较早一轮在旧基线上的本 PR 相关测试及其余 25,801 项测试通过；2 项 GhostInstallReceiptStore 测试失败，已在当时干净的 origin/main（4ac8ee560）原样复现，确认是基线问题。rebase 到当前 main 后未重跑完整门禁，交由新 HEAD 的 CI 复核。
```

### 手工验证

未启动 Desktop 做实机操作；恢复流程、窗口级筛选边界、Windows 路径匹配、收起侧栏 owner 挂载及异步选择顺序由单元测试覆盖。

### 未执行的验证

- 未执行 Desktop 实机验证，Light / Dark 均未目检。
- rebase 到当前 main 后未重跑完整单测门禁；已通过相关单测、desktop typecheck 和 DCO，完整覆盖交由 CI 复核。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop 新建任务的本地文件夹选择，以及 `/cc-agent/new` 在副窗口侧栏视觉收起时的 feature content 挂载。其他副窗口路由仍保持原懒挂载行为；远程项目与纯对话选择保持原行为。Windows 使用大小写不敏感的项目键匹配，并有对应测试。项目筛选仍按窗口独立，不新增跨窗口实时同步或共享存储锁。
- 回滚 / 降级方式：回滚本 PR 提交即可恢复原行为；不涉及数据库、协议或用户数据迁移。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次无需新增仓库文档；PR 描述已记录恢复不变量与范围）
- [x] 已确认测试结果或说明未执行原因
