### PR TITLE
feat(plugin): 已安装插件卡片点击默认进入详情

### DIFF
--- a/apps/desktop/src/renderer/features/plugin/GhostPluginPage.tsx
+++ b/apps/desktop/src/renderer/features/plugin/GhostPluginPage.tsx
@@ -2177,17 +2177,13 @@ export function GhostPluginCard({
           {unreadSummary || item.description || item.id}
         </span>
       </span>
-      {/* 右列控制区:自行消费点击,不冒泡到整卡主动作(纯冒泡拦截层,无独立语义)。 */}
-      <span
-        className="flex shrink-0 flex-col items-end justify-between gap-2 self-stretch"
-        onClick={(event) => event.stopPropagation()}
-        onKeyDown={(event) => event.stopPropagation()}
-      >
+      {/* 右列只在真实控件上拦截冒泡;空白与「由 Agent 调用」提示仍走整卡进详情。 */}
+      <span className="flex shrink-0 flex-col items-end justify-between gap-2 self-stretch">
         <span className="flex items-center gap-1.5">
           {updateVersion && onUpdate ? (
             <button
               type="button"
-              onClick={onUpdate}
+              onClick={stopAnd(onUpdate)}
               disabled={updateBusy}
               aria-label={t('settings.ghosts.page.updateAria', {
                 name: item.name,
@@ -2206,7 +2202,7 @@ export function GhostPluginCard({
           ) : null}
           <button
             type="button"
-            onClick={onManage}
+            onClick={stopAnd(onManage)}
             aria-label={t('settings.ghosts.page.manageAria', { name: item.name })}
             title={t('settings.ghosts.page.manageAction')}
             className="grid size-7 place-items-center rounded-full text-[var(--text-tertiary)] transition-colors duration-150 hover:bg-[var(--surface-hover-soft)] hover:text-[var(--text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)]"
@@ -2218,6 +2214,13 @@ export function GhostPluginCard({
       </span>
     </article>
   );
+}
+
+function stopAnd(handler: () => void) {
+  return (event: { stopPropagation: () => void }) => {
+    event.stopPropagation();
+    handler();
+  };
 }
 
 function CardPillButton({
@@ -2234,7 +2237,7 @@ function CardPillButton({
   return (
     <button
       type="button"
-      onClick={onClick}
+      onClick={stopAnd(onClick)}
       aria-label={ariaLabel ?? label}
       className={cn(
         'inline-flex h-8 shrink-0 items-center justify-center gap-1.5 rounded-full bg-[var(--surface-chip)] px-3.5 text-12 font-medium text-[var(--text-primary)]',

--- a/apps/desktop/src/renderer/features/plugin/GhostPluginPage.tsx
+++ b/apps/desktop/src/renderer/features/plugin/GhostPluginPage.tsx
@@ -1081,7 +1081,7 @@ export function GhostPluginPage() {
     [confirm, ghosts, navigate, openGhostConfiguration, t],
   );
 
-  /** 卡片/详情主动作分发:面板型开页面内面板,指令/Host 能力型起对话,工具型进管理。 */
+  /** 卡片胶囊/详情主动作分发:面板型开页面内面板,指令/Host 能力型起对话,工具型进管理。整卡点击不走这里。 */
   const handlePrimaryAction = useCallback(
     (item: Pick<GhostPluginListItem, 'id' | 'name' | 'tabPanel' | 'canUse' | 'hostCapability'>) => {
       const action = ghostPrimaryAction(item);
@@ -2048,7 +2048,8 @@ function GhostPluginActions({
 
 /**
  * 已安装插件卡片(设计定稿):
- * - 整卡可点 = 主动作(面板「使用」/ 指令「对话」/ 工具型与停用态进管理);
+ * - 整卡可点 = 进详情(与滑杆管理入口同目标);
+ * - 主动作留在右下角胶囊(面板「使用」/ 指令或能力「对话」/ 工具型无按钮);
  * - 无启用开关(收进详情页);滑杆图标 = 管理入口;
  * - 更新 = 文字胶囊「更新到 vX」,无任何小圆点(绿点专职未读语义,PR-B 接入)。
  */
@@ -2081,12 +2082,11 @@ export function GhostPluginCard({
   const unread = useGhostUnread(item.id);
   const unreadSummary = useGhostUnreadSummary(item.id);
   const primary = ghostPrimaryAction(item);
-  const cardAction = enabled && primary !== 'manage' ? onPrimary : onManage;
   const handleCardKeyDown = (event: KeyboardEvent<HTMLElement>) => {
     if (event.target !== event.currentTarget) return;
     if (event.key !== 'Enter' && event.key !== ' ') return;
     event.preventDefault();
-    cardAction();
+    onManage();
   };
   let primaryControl: ReactNode;
   if (!enabled) {
@@ -2122,7 +2122,7 @@ export function GhostPluginCard({
     <article
       role="button"
       tabIndex={0}
-      onClick={cardAction}
+      onClick={onManage}
       onKeyDown={handleCardKeyDown}
       aria-label={item.name}
       className={cn(

--- a/apps/desktop/src/renderer/features/plugin/__tests__/GhostPluginCard.test.tsx
+++ b/apps/desktop/src/renderer/features/plugin/__tests__/GhostPluginCard.test.tsx
@@ -182,6 +182,33 @@ describe('GhostPluginCard', () => {
     expect(onManage).not.toHaveBeenCalled();
   });
 
+  it.each(['Enter', ' '] as const)(
+    'opens plugin details when the card itself is activated with %s',
+    (key) => {
+      const onPrimary = vi.fn();
+      const onManage = vi.fn();
+      render(<GhostPluginCard item={commandPlugin} onPrimary={onPrimary} onManage={onManage} />);
+
+      fireEvent.keyDown(screen.getByRole('button', { name: 'Filo Google' }), { key });
+      expect(onManage).toHaveBeenCalledTimes(1);
+      expect(onPrimary).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(['Enter', ' '] as const)(
+    'does not treat a nested pill %s as a card activation',
+    (key) => {
+      const onPrimary = vi.fn();
+      const onManage = vi.fn();
+      render(<GhostPluginCard item={commandPlugin} onPrimary={onPrimary} onManage={onManage} />);
+
+      fireEvent.keyDown(screen.getByRole('button', { name: 'settings.ghosts.page.chatAria' }), {
+        key,
+      });
+      expect(onManage).not.toHaveBeenCalled();
+    },
+  );
+
   it('labels the primary button 使用 for a tab-panel plugin', () => {
     const onPrimary = vi.fn();
     const onManage = vi.fn();

--- a/apps/desktop/src/renderer/features/plugin/__tests__/GhostPluginCard.test.tsx
+++ b/apps/desktop/src/renderer/features/plugin/__tests__/GhostPluginCard.test.tsx
@@ -317,6 +317,27 @@ describe('GhostPluginCard', () => {
     expect(onPrimary).not.toHaveBeenCalled();
   });
 
+  it('opens details from the non-interactive agent-invoked hint', () => {
+    const onPrimary = vi.fn();
+    const onManage = vi.fn();
+    render(<GhostPluginCard item={toolPlugin} onPrimary={onPrimary} onManage={onManage} />);
+
+    fireEvent.click(screen.getByText('settings.ghosts.page.agentInvoked'));
+    expect(onManage).toHaveBeenCalledTimes(1);
+    expect(onPrimary).not.toHaveBeenCalled();
+  });
+
+  it('opens details from empty space in the right action rail', () => {
+    const onPrimary = vi.fn();
+    const onManage = vi.fn();
+    render(<GhostPluginCard item={commandPlugin} onPrimary={onPrimary} onManage={onManage} />);
+
+    const manage = screen.getByRole('button', { name: 'settings.ghosts.page.manageAria' });
+    fireEvent.click(manage.parentElement as HTMLElement);
+    expect(onManage).toHaveBeenCalledTimes(1);
+    expect(onPrimary).not.toHaveBeenCalled();
+  });
+
   it('sends a disabled plugin to manage and shows no enable switch on the card', () => {
     const onPrimary = vi.fn();
     const onManage = vi.fn();

--- a/apps/desktop/src/renderer/features/plugin/__tests__/GhostPluginCard.test.tsx
+++ b/apps/desktop/src/renderer/features/plugin/__tests__/GhostPluginCard.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Regression coverage for installed Plugin card actions (redesigned card:
- * whole-card primary action, kind-specific primary button, manage entry),
+ * whole-card opens detail, kind-specific primary button, manage entry),
  * market card actions, and the legacy recovery notice.
  * [PROTOCOL]: 变更时更新此头部，然后检查 CLAUDE.md
  * @vitest-environment jsdom
@@ -160,32 +160,56 @@ describe('GhostPluginCard', () => {
   // 未读是模块级 store,用例间必须互不串味。
   afterEach(() => __resetGhostUnreadForTest());
 
-  it('fires the primary action from the whole card for a command plugin', () => {
+  it('opens plugin details from the whole card for a command plugin', () => {
     const onPrimary = vi.fn();
     const onManage = vi.fn();
     render(<GhostPluginCard item={commandPlugin} onPrimary={onPrimary} onManage={onManage} />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Filo Google' }));
+    expect(onManage).toHaveBeenCalledTimes(1);
+    expect(onPrimary).not.toHaveBeenCalled();
+    // 指令型主按钮仍是「对话」,不随整卡改成详情。
+    expect(screen.getByRole('button', { name: 'settings.ghosts.page.chatAria' })).toBeTruthy();
+  });
+
+  it('keeps the conversation pill as the command plugin primary action', () => {
+    const onPrimary = vi.fn();
+    const onManage = vi.fn();
+    render(<GhostPluginCard item={commandPlugin} onPrimary={onPrimary} onManage={onManage} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'settings.ghosts.page.chatAria' }));
     expect(onPrimary).toHaveBeenCalledTimes(1);
     expect(onManage).not.toHaveBeenCalled();
-    // 指令型主按钮 = 「对话」。
-    expect(screen.getByRole('button', { name: 'settings.ghosts.page.chatAria' })).toBeTruthy();
   });
 
   it('labels the primary button 使用 for a tab-panel plugin', () => {
     const onPrimary = vi.fn();
-    render(<GhostPluginCard item={panelPlugin} onPrimary={onPrimary} onManage={vi.fn()} />);
+    const onManage = vi.fn();
+    render(<GhostPluginCard item={panelPlugin} onPrimary={onPrimary} onManage={onManage} />);
 
     fireEvent.click(screen.getByRole('button', { name: 'settings.ghosts.page.useAria' }));
     expect(onPrimary).toHaveBeenCalledTimes(1);
+    expect(onManage).not.toHaveBeenCalled();
+  });
+
+  it('opens plugin details from the whole card for a tab-panel plugin', () => {
+    const onPrimary = vi.fn();
+    const onManage = vi.fn();
+    render(<GhostPluginCard item={panelPlugin} onPrimary={onPrimary} onManage={onManage} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Signoff Board' }));
+    expect(onManage).toHaveBeenCalledTimes(1);
+    expect(onPrimary).not.toHaveBeenCalled();
   });
 
   it('offers a conversation entry for a Host capability plugin', () => {
     const onPrimary = vi.fn();
-    render(<GhostPluginCard item={simulatorPlugin} onPrimary={onPrimary} onManage={vi.fn()} />);
+    const onManage = vi.fn();
+    render(<GhostPluginCard item={simulatorPlugin} onPrimary={onPrimary} onManage={onManage} />);
 
     fireEvent.click(screen.getByRole('button', { name: 'settings.ghosts.page.chatAria' }));
     expect(onPrimary).toHaveBeenCalledTimes(1);
+    expect(onManage).not.toHaveBeenCalled();
     expect(screen.queryByText('settings.ghosts.page.agentInvoked')).toBeNull();
   });
 
@@ -201,13 +225,14 @@ describe('GhostPluginCard', () => {
 
   it('shows the update pill and keeps it from triggering the card action', () => {
     const onPrimary = vi.fn();
+    const onManage = vi.fn();
     const onUpdate = vi.fn();
     render(
       <GhostPluginCard
         item={commandPlugin}
         updateVersion="1.1.0"
         onPrimary={onPrimary}
-        onManage={vi.fn()}
+        onManage={onManage}
         onUpdate={onUpdate}
       />,
     );
@@ -215,6 +240,7 @@ describe('GhostPluginCard', () => {
     fireEvent.click(screen.getByRole('button', { name: 'settings.ghosts.page.updateAria' }));
     expect(onUpdate).toHaveBeenCalledTimes(1);
     expect(onPrimary).not.toHaveBeenCalled();
+    expect(onManage).not.toHaveBeenCalled();
     // 有更新时不显示「已是最新」。
     expect(screen.queryByText(/upToDate/)).toBeNull();
   });

--- a/apps/desktop/src/renderer/features/plugin/lib/ghostPluginViewModel.ts
+++ b/apps/desktop/src/renderer/features/plugin/lib/ghostPluginViewModel.ts
@@ -52,11 +52,11 @@ export interface GhostPluginListItem {
 }
 
 /**
- * 卡片主动作的四分法:
+ * 卡片主动作的四分法(只驱动右下角胶囊;整卡点击一律进详情):
  * - `panel`:有页签面板 → 「使用」直接打开面板;
  * - `command`:只有 $指令 → 「对话」把指令插进输入框起话题;
  * - `capability`:Host 承载的能力 → 「对话」进入该能力的工作流;
- * - `manage`:纯工具型(Agent 对话中自动调用)→ 无主按钮,点卡片进管理页。
+ * - `manage`:纯工具型(Agent 对话中自动调用)→ 无主按钮。
  * 停靠形态(left/right)的面板由布局树承载,不算 panel 主动作。
  */
 export type GhostPrimaryAction = 'panel' | 'command' | 'capability' | 'manage';


### PR DESCRIPTION
## 这次改了什么

### 摘要

插件面板里，点击已安装插件卡片的默认动作从「对话」改成「打开插件详情」。右下角「对话 / 使用」胶囊仍走原来的主动作，滑杆管理入口不变。

### 变更类型

- [x] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：已安装插件卡片整卡点击 / 键盘激活一律进详情；单测覆盖指令型、面板型与更新胶囊不误触
- 明确不包含：市场未安装卡片、详情页主动作、插件运行时 / 权限 / 安装布局
- 用户可见变化：点已安装卡片进入详情，而不是直接起对话
- 是否存在 breaking change：无

### UI 变化

桌面端插件面板（macOS，cn 开发版已点过）。无视觉样式改动，只改整卡默认点击目标。

- 引用的设计规范：`docs/design-rules/DESIGN.md` §1「Extreme content restraint — each surface presents one clear idea」；`docs/product-rules/core-product-principles.md` §4.1「默认路径保持直接 / 用户操作的对象应清楚可见」。卡片先呈现插件对象（详情），主动作保留在明确的胶囊按钮上；市场卡本来就是点卡进详情，已安装卡与之对齐。双模式无新增颜色或条件补丁，沿用既有语义 token。

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：PASS apps/desktop unit (15.2s)，related 3 个文件

pnpm --filter desktop run typecheck
结果：通过

cd apps/desktop && pnpm exec vitest run src/renderer/features/plugin/__tests__/GhostPluginCard.test.tsx
结果：35 passed
```

全量 `pnpm test:unit` 在本机还失败 2 条 `ghostInstallReceipt.test.ts`（`state: invalid`）。同一失败在干净 `origin/main` (`61dc9e660`) 上复现，与本 PR diff 无关，交给 CI 给权威结论。

### 手工验证

macOS / `--region=cn` / `--preserve-running` 开发版（pid 16195，`desktop:whoami` root/commit/ready 匹配）。侧边栏「插件」→ 点已安装卡片进入详情；点「对话」仍起对话。Light 模式实机看过；Dark 未单独目检（无新增样式）。

### 未执行的验证

- Dark 模式实机目检：本次无视觉改动
- Mobile：不涉及

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Desktop 插件列表面板的已安装卡片点击目标
- 回滚 / 降级方式：revert 本 PR
- 存量插件影响：无。不改批准状态、指纹、manifest、安装布局或包格式。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
