### PR TITLE
feat(update): xd 组织登录后默认打开 beta 渠道

### DIFF
--- a/apps/desktop/src/main/__tests__/authLoginFlowReset.test.ts
+++ b/apps/desktop/src/main/__tests__/authLoginFlowReset.test.ts
@@ -316,6 +316,7 @@ describe('auth login-flow reset', () => {
     expect(betaBody).toContain('if (isPassiveSharedUserDataInstance()) return;');
     expect(betaBody).toContain('decodeAccessTokenOrgSlug(accessToken)');
     expect(betaBody).toContain('enableUncustomizedBetaChannel');
+    expect(betaBody).toContain('authStateEpoch === input.expectedAuthEpoch');
     expect(source).not.toContain('relaunchForChannelChange');
 
     const clearIntegrationsStart = source.indexOf('async function clearPerAccountIntegrations(');

--- a/apps/desktop/src/main/__tests__/authLoginFlowReset.test.ts
+++ b/apps/desktop/src/main/__tests__/authLoginFlowReset.test.ts
@@ -298,15 +298,25 @@ describe('auth login-flow reset', () => {
   it('synchronizes canary flags on every path that establishes a new auth identity', () => {
     expect(source).not.toContain('canaryFlagStore.sync(false)');
     expect(source.match(/scheduleCanaryFlagSync\(\{/g)).toHaveLength(3);
+    expect(source.match(/scheduleXdOrgBetaDefault\(\{/g)).toHaveLength(3);
     expect(source).toContain("getClientEndpoint('oauthBrokerApiBaseUrl')");
     expect(source).toContain("apiFetch('/api/user/feature-flags'");
 
     const syncStart = source.indexOf('function scheduleCanaryFlagSync(');
-    const syncEnd = source.indexOf('\n}\n\n/**\n * 冷启动流程的进程内去重', syncStart);
+    const syncEnd = source.indexOf('\n}\n\n/**\n * 登录态落地后为 xd 组织补一次设备级 beta 默认值', syncStart);
     expect(syncEnd).toBeGreaterThan(syncStart);
     const syncBody = source.slice(syncStart, syncEnd);
     expect(syncBody).toContain("if (outcome.kind === 'synced')");
     expect(syncBody).toContain('notifyRenderer();');
+
+    const betaStart = source.indexOf('function scheduleXdOrgBetaDefault(');
+    const betaEnd = source.indexOf('\n}\n\n/**\n * 冷启动流程的进程内去重', betaStart);
+    expect(betaEnd).toBeGreaterThan(betaStart);
+    const betaBody = source.slice(betaStart, betaEnd);
+    expect(betaBody).toContain('if (isPassiveSharedUserDataInstance()) return;');
+    expect(betaBody).toContain('decodeAccessTokenOrgSlug(accessToken)');
+    expect(betaBody).toContain('enableUncustomizedBetaChannel()');
+    expect(source).not.toContain('relaunchForChannelChange');
 
     const clearIntegrationsStart = source.indexOf('async function clearPerAccountIntegrations(');
     const clearIntegrationsEnd = source.indexOf('\n}', clearIntegrationsStart);

--- a/apps/desktop/src/main/__tests__/authLoginFlowReset.test.ts
+++ b/apps/desktop/src/main/__tests__/authLoginFlowReset.test.ts
@@ -315,7 +315,7 @@ describe('auth login-flow reset', () => {
     const betaBody = source.slice(betaStart, betaEnd);
     expect(betaBody).toContain('if (isPassiveSharedUserDataInstance()) return;');
     expect(betaBody).toContain('decodeAccessTokenOrgSlug(accessToken)');
-    expect(betaBody).toContain('enableUncustomizedBetaChannel()');
+    expect(betaBody).toContain('enableUncustomizedBetaChannel');
     expect(source).not.toContain('relaunchForChannelChange');
 
     const clearIntegrationsStart = source.indexOf('async function clearPerAccountIntegrations(');

--- a/apps/desktop/src/main/__tests__/manifestService.test.ts
+++ b/apps/desktop/src/main/__tests__/manifestService.test.ts
@@ -1,0 +1,101 @@
+import { EventEmitter } from 'node:events';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { TEST_CDN_BASE_URL } from '../../test/vitest/clientEndpointsFixture';
+
+const netRequest = vi.hoisted(() => vi.fn());
+const canaryRead = vi.hoisted(() => vi.fn(() => false));
+const isBetaChannelEnabled = vi.hoisted(() => vi.fn(() => false));
+const getClientEndpoint = vi.hoisted(() => vi.fn(() => TEST_CDN_BASE_URL));
+
+vi.mock('electron', () => ({
+  app: {
+    isPackaged: true,
+    getPath: vi.fn(() => '/tmp'),
+  },
+  net: { request: netRequest },
+}));
+
+vi.mock('../canaryFlagStore', () => ({
+  read: canaryRead,
+}));
+
+vi.mock('../updateChannelStore', () => ({
+  isBetaChannelEnabled,
+}));
+
+vi.mock('../clientEndpointsService', () => ({
+  getClientEndpoint,
+}));
+
+vi.mock('../logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+function mockManifestResponse(body: string, onEnd?: () => void): void {
+  const request = new EventEmitter() as EventEmitter & {
+    abort: ReturnType<typeof vi.fn>;
+    end: ReturnType<typeof vi.fn>;
+  };
+  request.abort = vi.fn();
+  request.end = vi.fn(() => {
+    const response = new EventEmitter() as EventEmitter & { statusCode: number };
+    response.statusCode = 200;
+    request.emit('response', response);
+    response.emit('data', Buffer.from(body));
+    onEnd?.();
+    response.emit('end');
+  });
+  netRequest.mockReturnValueOnce(request);
+}
+
+const RELEASE_MANIFEST = JSON.stringify({
+  app: { version: '0.0.65' },
+});
+
+describe('manifestService cache channel identity', () => {
+  beforeEach(() => {
+    netRequest.mockReset();
+    canaryRead.mockReset();
+    canaryRead.mockReturnValue(false);
+    isBetaChannelEnabled.mockReset();
+    isBetaChannelEnabled.mockReturnValue(false);
+    getClientEndpoint.mockReset();
+    getClientEndpoint.mockReturnValue(TEST_CDN_BASE_URL);
+  });
+
+  afterEach(async () => {
+    const { clearCachedManifest } = await import('../manifestService');
+    clearCachedManifest();
+  });
+
+  it('discards a cached release manifest after the shared channel switches to beta', async () => {
+    mockManifestResponse(RELEASE_MANIFEST);
+    const service = await import('../manifestService');
+
+    await expect(service.fetchManifest()).resolves.toMatchObject({ app: { version: '0.0.65' } });
+    expect(service.getCachedManifest()).toMatchObject({ app: { version: '0.0.65' } });
+
+    isBetaChannelEnabled.mockReturnValue(true);
+
+    expect(service.getCachedManifest()).toBeNull();
+    expect(netRequest.mock.calls[0]?.[0]).toContain('manifest-');
+    expect(String(netRequest.mock.calls[0]?.[0])).not.toContain('-beta.json');
+  });
+
+  it('does not cache a fetch that finishes after the shared channel changes', async () => {
+    mockManifestResponse(RELEASE_MANIFEST, () => {
+      isBetaChannelEnabled.mockReturnValue(true);
+    });
+    const service = await import('../manifestService');
+
+    await expect(service.fetchManifest()).resolves.toBeNull();
+    expect(service.getCachedManifest()).toBeNull();
+  });
+});

--- a/apps/desktop/src/main/__tests__/manifestService.test.ts
+++ b/apps/desktop/src/main/__tests__/manifestService.test.ts
@@ -99,3 +99,32 @@ describe('manifestService cache channel identity', () => {
     expect(service.getCachedManifest()).toBeNull();
   });
 });
+
+describe('probeBetaManifest', () => {
+  beforeEach(() => {
+    netRequest.mockReset();
+    canaryRead.mockReset();
+    canaryRead.mockReturnValue(false);
+    isBetaChannelEnabled.mockReset();
+    isBetaChannelEnabled.mockReturnValue(false);
+    getClientEndpoint.mockReset();
+    getClientEndpoint.mockReturnValue(TEST_CDN_BASE_URL);
+  });
+
+  afterEach(async () => {
+    const { clearCachedManifest } = await import('../manifestService');
+    clearCachedManifest();
+  });
+
+  it('rejects an HTTP 200 body that is not a usable beta manifest', async () => {
+    mockManifestResponse('<html>error</html>');
+    const service = await import('../manifestService');
+    await expect(service.probeBetaManifest()).resolves.toBe(false);
+  });
+
+  it('accepts a parseable beta manifest', async () => {
+    mockManifestResponse(RELEASE_MANIFEST);
+    const service = await import('../manifestService');
+    await expect(service.probeBetaManifest()).resolves.toBe(true);
+  });
+});

--- a/apps/desktop/src/main/__tests__/updateChannelStore.test.ts
+++ b/apps/desktop/src/main/__tests__/updateChannelStore.test.ts
@@ -58,8 +58,8 @@ describe('tryEnableUncustomizedBetaAtomic', () => {
 
   it('does not reopen beta after the user turned it off', async () => {
     const store = await loadStore();
-    store.writeEnableBeta(true);
-    store.writeEnableBeta(false);
+    await store.writeEnableBeta(true);
+    await store.writeEnableBeta(false);
 
     expect(store.readUpdateChannelSettings()).toMatchObject({ enableBeta: false });
     expect(store.isEnableBetaUserCustomized()).toBe(true);
@@ -69,7 +69,7 @@ describe('tryEnableUncustomizedBetaAtomic', () => {
 
   it('keeps a never-enabled opt-out as a user choice', async () => {
     const store = await loadStore();
-    store.writeEnableBeta(false);
+    await store.writeEnableBeta(false);
 
     expect(store.isEnableBetaUserCustomized()).toBe(true);
     expect(await store.tryEnableUncustomizedBetaAtomic()).toBe(false);
@@ -78,10 +78,19 @@ describe('tryEnableUncustomizedBetaAtomic', () => {
 
   it('is a no-op when beta is already on', async () => {
     const store = await loadStore();
-    store.writeEnableBeta(true);
+    await store.writeEnableBeta(true);
 
     expect(await store.tryEnableUncustomizedBetaAtomic()).toBe(false);
     expect(store.readUpdateChannelSettings().enableBeta).toBe(true);
     expect(store.isEnableBetaUserCustomized()).toBe(true);
+  });
+
+  it('does not write when the lock-time identity guard rejects', async () => {
+    const store = await loadStore();
+    expect(await store.tryEnableUncustomizedBetaAtomic(() => false)).toBe(false);
+    expect(store.readUpdateChannelSettings()).toEqual({
+      enableBeta: false,
+      orgDefaultEnableBeta: false,
+    });
   });
 });

--- a/apps/desktop/src/main/__tests__/updateChannelStore.test.ts
+++ b/apps/desktop/src/main/__tests__/updateChannelStore.test.ts
@@ -40,18 +40,20 @@ afterEach(() => {
 });
 
 describe('tryEnableUncustomizedBeta', () => {
-  it('writes enableBeta=true when the device has never customized the switch', async () => {
+  it('turns beta on via org default without writing a user enableBeta override', async () => {
     const store = await loadStore();
 
     expect(store.readUpdateChannelSettingsState()).toMatchObject({
-      value: { enableBeta: false },
-      isCustomized: false,
+      value: { enableBeta: false, orgDefaultEnableBeta: false },
+      customizedKeys: [],
     });
     expect(store.tryEnableUncustomizedBeta()).toBe(true);
-    expect(store.readUpdateChannelSettingsState()).toMatchObject({
-      value: { enableBeta: true },
-      isCustomized: true,
+    expect(store.readUpdateChannelSettings()).toEqual({
+      enableBeta: true,
+      orgDefaultEnableBeta: true,
     });
+    expect(store.isEnableBetaUserCustomized()).toBe(false);
+    expect(store.readUpdateChannelSettingsState().customizedKeys).toEqual(['orgDefaultEnableBeta']);
   });
 
   it('does not reopen beta after the user turned it off', async () => {
@@ -59,23 +61,19 @@ describe('tryEnableUncustomizedBeta', () => {
     store.writeEnableBeta(true);
     store.writeEnableBeta(false);
 
-    expect(store.readUpdateChannelSettingsState()).toMatchObject({
-      value: { enableBeta: false },
-      isCustomized: true,
-    });
+    expect(store.readUpdateChannelSettings()).toMatchObject({ enableBeta: false });
+    expect(store.isEnableBetaUserCustomized()).toBe(true);
     expect(store.tryEnableUncustomizedBeta()).toBe(false);
-    expect(store.readUpdateChannelSettings()).toEqual({ enableBeta: false });
+    expect(store.readUpdateChannelSettings().enableBeta).toBe(false);
   });
 
-  it('keeps a never-enabled opt-out as customized', async () => {
+  it('keeps a never-enabled opt-out as a user choice', async () => {
     const store = await loadStore();
     store.writeEnableBeta(false);
 
-    expect(store.readUpdateChannelSettingsState()).toMatchObject({
-      value: { enableBeta: false },
-      isCustomized: true,
-    });
+    expect(store.isEnableBetaUserCustomized()).toBe(true);
     expect(store.tryEnableUncustomizedBeta()).toBe(false);
+    expect(store.readUpdateChannelSettings().enableBeta).toBe(false);
   });
 
   it('is a no-op when beta is already on', async () => {
@@ -83,6 +81,7 @@ describe('tryEnableUncustomizedBeta', () => {
     store.writeEnableBeta(true);
 
     expect(store.tryEnableUncustomizedBeta()).toBe(false);
-    expect(store.readUpdateChannelSettings()).toEqual({ enableBeta: true });
+    expect(store.readUpdateChannelSettings().enableBeta).toBe(true);
+    expect(store.isEnableBetaUserCustomized()).toBe(true);
   });
 });

--- a/apps/desktop/src/main/__tests__/updateChannelStore.test.ts
+++ b/apps/desktop/src/main/__tests__/updateChannelStore.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const appGetPath = vi.fn();
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: appGetPath,
+  },
+}));
+
+vi.mock('../maker-host/logger-adapter.js', () => ({
+  desktopMakerLogger: {
+    child: () => ({
+      info: vi.fn(),
+      warn: vi.fn(),
+    }),
+  },
+}));
+
+let tempDir: string;
+
+async function loadStore() {
+  vi.resetModules();
+  return import('../updateChannelStore');
+}
+
+beforeEach(() => {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cindy-update-channel-'));
+  appGetPath.mockImplementation((name: string) => {
+    if (name === 'userData') return tempDir;
+    return tempDir;
+  });
+});
+
+afterEach(() => {
+  fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe('tryEnableUncustomizedBeta', () => {
+  it('writes enableBeta=true when the device has never customized the switch', async () => {
+    const store = await loadStore();
+
+    expect(store.readUpdateChannelSettingsState()).toMatchObject({
+      value: { enableBeta: false },
+      isCustomized: false,
+    });
+    expect(store.tryEnableUncustomizedBeta()).toBe(true);
+    expect(store.readUpdateChannelSettingsState()).toMatchObject({
+      value: { enableBeta: true },
+      isCustomized: true,
+    });
+  });
+
+  it('does not reopen beta after the user turned it off', async () => {
+    const store = await loadStore();
+    store.writeEnableBeta(true);
+    store.writeEnableBeta(false);
+
+    expect(store.readUpdateChannelSettingsState()).toMatchObject({
+      value: { enableBeta: false },
+      isCustomized: true,
+    });
+    expect(store.tryEnableUncustomizedBeta()).toBe(false);
+    expect(store.readUpdateChannelSettings()).toEqual({ enableBeta: false });
+  });
+
+  it('keeps a never-enabled opt-out as customized', async () => {
+    const store = await loadStore();
+    store.writeEnableBeta(false);
+
+    expect(store.readUpdateChannelSettingsState()).toMatchObject({
+      value: { enableBeta: false },
+      isCustomized: true,
+    });
+    expect(store.tryEnableUncustomizedBeta()).toBe(false);
+  });
+
+  it('is a no-op when beta is already on', async () => {
+    const store = await loadStore();
+    store.writeEnableBeta(true);
+
+    expect(store.tryEnableUncustomizedBeta()).toBe(false);
+    expect(store.readUpdateChannelSettings()).toEqual({ enableBeta: true });
+  });
+});

--- a/apps/desktop/src/main/__tests__/updateChannelStore.test.ts
+++ b/apps/desktop/src/main/__tests__/updateChannelStore.test.ts
@@ -39,7 +39,7 @@ afterEach(() => {
   fs.rmSync(tempDir, { recursive: true, force: true });
 });
 
-describe('tryEnableUncustomizedBeta', () => {
+describe('tryEnableUncustomizedBetaAtomic', () => {
   it('turns beta on via org default without writing a user enableBeta override', async () => {
     const store = await loadStore();
 
@@ -47,7 +47,7 @@ describe('tryEnableUncustomizedBeta', () => {
       value: { enableBeta: false, orgDefaultEnableBeta: false },
       customizedKeys: [],
     });
-    expect(store.tryEnableUncustomizedBeta()).toBe(true);
+    expect(await store.tryEnableUncustomizedBetaAtomic()).toBe(true);
     expect(store.readUpdateChannelSettings()).toEqual({
       enableBeta: true,
       orgDefaultEnableBeta: true,
@@ -63,7 +63,7 @@ describe('tryEnableUncustomizedBeta', () => {
 
     expect(store.readUpdateChannelSettings()).toMatchObject({ enableBeta: false });
     expect(store.isEnableBetaUserCustomized()).toBe(true);
-    expect(store.tryEnableUncustomizedBeta()).toBe(false);
+    expect(await store.tryEnableUncustomizedBetaAtomic()).toBe(false);
     expect(store.readUpdateChannelSettings().enableBeta).toBe(false);
   });
 
@@ -72,7 +72,7 @@ describe('tryEnableUncustomizedBeta', () => {
     store.writeEnableBeta(false);
 
     expect(store.isEnableBetaUserCustomized()).toBe(true);
-    expect(store.tryEnableUncustomizedBeta()).toBe(false);
+    expect(await store.tryEnableUncustomizedBetaAtomic()).toBe(false);
     expect(store.readUpdateChannelSettings().enableBeta).toBe(false);
   });
 
@@ -80,7 +80,7 @@ describe('tryEnableUncustomizedBeta', () => {
     const store = await loadStore();
     store.writeEnableBeta(true);
 
-    expect(store.tryEnableUncustomizedBeta()).toBe(false);
+    expect(await store.tryEnableUncustomizedBetaAtomic()).toBe(false);
     expect(store.readUpdateChannelSettings().enableBeta).toBe(true);
     expect(store.isEnableBetaUserCustomized()).toBe(true);
   });

--- a/apps/desktop/src/main/__tests__/updateService.test.ts
+++ b/apps/desktop/src/main/__tests__/updateService.test.ts
@@ -19,6 +19,8 @@ const powerMonitorGetSystemIdleTime = vi.fn(() => 600);
 const powerMonitorOn = vi.fn();
 const powerMonitorRemoveListener = vi.fn();
 const appGetVersion = vi.fn(() => '0.0.64');
+const appRelaunch = vi.fn();
+const appQuit = vi.fn();
 const appIsInApplicationsFolder = vi.fn(() => true);
 const appGetPath = vi.fn((name: string) => {
   if (name === 'userData') return TEST_USER_DATA;
@@ -40,6 +42,8 @@ vi.mock('electron', () => ({
   app: {
     getVersion: appGetVersion,
     getPath: appGetPath,
+    relaunch: appRelaunch,
+    quit: appQuit,
     isPackaged: true,
     isInApplicationsFolder: appIsInApplicationsFolder,
     moveToApplicationsFolder: vi.fn(),
@@ -116,6 +120,11 @@ vi.mock('../cindy-brain/index', () => ({
   getGhostNodeRuntimeBroker: () => ({ destroyAll: vi.fn() }),
 }));
 
+vi.mock('../security/trustedAppRenderer', () => ({
+  assertTrustedAppRendererEvent: vi.fn(),
+}));
+
+
 vi.mock('../logger', () => ({
   createLogger: () => ({
     info: logInfo,
@@ -166,6 +175,8 @@ beforeEach(() => {
   powerMonitorRemoveListener.mockReset();
   appGetVersion.mockReset();
   appGetVersion.mockReturnValue('0.0.64');
+  appRelaunch.mockReset();
+  appQuit.mockReset();
   appIsInApplicationsFolder.mockReset();
   appIsInApplicationsFolder.mockReturnValue(true);
   appGetPath.mockReset();
@@ -621,6 +632,89 @@ describe('startup update relaunch safety', () => {
       expect(service.getUpdateStatus()).toBe('ready');
       expect(fs.existsSync(destPath)).toBe(true);
       expect(fs.readFileSync(path.join(TEST_USER_DATA, 'updates', 'patch-info.json'), 'utf-8')).toContain('0.0.66');
+    } finally {
+      service.stopUpdateService();
+    }
+  });
+
+  it('drops patch-info immediately so a channel relaunch cannot revive the old zip', async () => {
+    const service = await bootWithStagedPatch({ enabled: true });
+    let releaseProbe: ((busy: boolean) => void) | undefined;
+    const probeStarted = new Promise<void>((resolveStarted) => {
+      service.setUpdateAutoRelaunchBusyProbe(
+        () =>
+          new Promise<boolean>((resolveProbe) => {
+            resolveStarted();
+            releaseProbe = resolveProbe;
+          }),
+      );
+    });
+    try {
+      await probeStarted;
+      await expect(service.enableUncustomizedBetaChannel()).resolves.toBe(true);
+      expect(service.getUpdateStatus()).toBe('ready');
+      expect(fs.existsSync(path.join(TEST_USER_DATA, 'updates', 'patch-info.json'))).toBe(false);
+
+      const relaunch = ipcHandlers.get('update-channel-relaunch');
+      expect(relaunch).toBeTypeOf('function');
+      relaunch?.({ sender: { id: 1 } });
+      expect(appRelaunch).toHaveBeenCalled();
+      expect(appQuit).toHaveBeenCalled();
+      expect(fs.existsSync(path.join(TEST_USER_DATA, 'updates', 'patch-info.json'))).toBe(false);
+    } finally {
+      releaseProbe?.(true);
+      service.stopUpdateService();
+    }
+  });
+
+  it('does not bump the channel epoch again when flushing during a same-path download', async () => {
+    const sharedHotfix = 'app/darwin-arm64/xdt-maker-hotfix.zip';
+    const service = await bootWithStagedPatch({
+      enabled: true,
+      manifest: updateManifest('0.0.65', sharedHotfix),
+    });
+    let releaseProbe: ((busy: boolean) => void) | undefined;
+    const probeStarted = new Promise<void>((resolveStarted) => {
+      service.setUpdateAutoRelaunchBusyProbe(
+        () =>
+          new Promise<boolean>((resolveProbe) => {
+            resolveStarted();
+            releaseProbe = resolveProbe;
+          }),
+      );
+    });
+    let finishDownload: (() => void) | undefined;
+    download.mockImplementation(async ({ targetPath }: { targetPath: string }) => {
+      await new Promise<void>((resolve) => {
+        finishDownload = resolve;
+      });
+      fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+      fs.writeFileSync(targetPath, 'newer-update');
+      return { path: targetPath, size: 123 };
+    });
+    try {
+      await probeStarted;
+      await expect(service.enableUncustomizedBetaChannel()).resolves.toBe(true);
+      service.setUpdateAutoRelaunchBusyProbe(() => true);
+      readUpdateChannelSettings.mockReturnValue({
+        enableBeta: true,
+        orgDefaultEnableBeta: true,
+      });
+      fetchManifest.mockResolvedValue(updateManifest('0.0.66', sharedHotfix));
+      const checkPromise = service.checkForUpdate();
+      await vi.waitFor(() => {
+        expect(finishDownload).toBeTypeOf('function');
+      });
+      releaseProbe?.(true);
+      await vi.waitFor(() => {
+        expect(service.getUpdateStatus()).toBe('superseding');
+      });
+      finishDownload?.();
+      await expect(checkPromise).resolves.toBe('ready');
+      expect(service.getUpdateStatus()).toBe('ready');
+      expect(
+        fs.readFileSync(path.join(TEST_USER_DATA, 'updates', 'patch-info.json'), 'utf-8'),
+      ).toContain('0.0.66');
     } finally {
       service.stopUpdateService();
     }

--- a/apps/desktop/src/main/__tests__/updateService.test.ts
+++ b/apps/desktop/src/main/__tests__/updateService.test.ts
@@ -201,12 +201,12 @@ afterEach(() => {
   setPlatform(originalPlatform);
 });
 
-function updateManifest(version = '0.0.65') {
+function updateManifest(version = '0.0.65', hotfixFile?: string) {
   return {
     app: {
       version,
       hotfix: {
-        file: `app/darwin-arm64/xdt-maker-${version}.zip`,
+        file: hotfixFile ?? `app/darwin-arm64/xdt-maker-${version}.zip`,
         sha256: 'abc',
         size: 123,
       },
@@ -422,10 +422,13 @@ describe('startup update relaunch safety', () => {
   });
 
   /** Boots the startup flow (staging a patch) and hands back the live module. */
-  async function bootWithStagedPatch(options: { enabled?: boolean } = {}) {
+  async function bootWithStagedPatch(options: {
+    enabled?: boolean;
+    manifest?: ReturnType<typeof updateManifest>;
+  } = {}) {
     vi.useFakeTimers();
     readAutoUpdateSettings.mockReturnValue({ autoRelaunchOnIdle: options.enabled ?? true });
-    fetchManifest.mockResolvedValue(updateManifest());
+    fetchManifest.mockResolvedValue(options.manifest ?? updateManifest());
     download.mockImplementation(async ({ targetPath }: { targetPath: string }) => {
       fs.mkdirSync(path.join(TEST_USER_DATA, 'updates'), { recursive: true });
       fs.writeFileSync(targetPath, 'update');
@@ -568,6 +571,56 @@ describe('startup update relaunch safety', () => {
         expect(service.getUpdateStatus()).toBe('idle');
       });
       expect(service.isUpdateRelaunchImminent()).toBe(false);
+    } finally {
+      service.stopUpdateService();
+    }
+  });
+
+  it('keeps a same-path newer patch after deferred channel-change clear', async () => {
+    const sharedHotfix = 'app/darwin-arm64/xdt-maker-hotfix.zip';
+    const service = await bootWithStagedPatch({
+      enabled: true,
+      manifest: updateManifest('0.0.65', sharedHotfix),
+    });
+    let releaseProbe: ((busy: boolean) => void) | undefined;
+    const probeStarted = new Promise<void>((resolveStarted) => {
+      service.setUpdateAutoRelaunchBusyProbe(
+        () =>
+          new Promise<boolean>((resolveProbe) => {
+            resolveStarted();
+            releaseProbe = resolveProbe;
+          }),
+      );
+    });
+    try {
+      await probeStarted;
+      await expect(service.enableUncustomizedBetaChannel()).resolves.toBe(true);
+      expect(service.getUpdateStatus()).toBe('ready');
+      // 后续 ready 不要再挂住另一条 probe,否则延迟清理永远不会 flush。
+      service.setUpdateAutoRelaunchBusyProbe(() => true);
+
+      readUpdateChannelSettings.mockReturnValue({
+        enableBeta: true,
+        orgDefaultEnableBeta: true,
+      });
+      fetchManifest.mockResolvedValue(updateManifest('0.0.66', sharedHotfix));
+      await expect(service.checkForUpdate()).resolves.toBe('ready');
+      expect(service.getUpdateStatus()).toBe('ready');
+
+      const destPath = path.join(TEST_USER_DATA, 'updates', path.basename(sharedHotfix));
+      expect(fs.existsSync(destPath)).toBe(true);
+
+      releaseProbe?.(true);
+      await vi.waitFor(() => {
+        expect(
+          logInfo.mock.calls.some((call) =>
+            String(call[0]).includes('keeping newer staged patch after deferred channel-change clear'),
+          ),
+        ).toBe(true);
+      });
+      expect(service.getUpdateStatus()).toBe('ready');
+      expect(fs.existsSync(destPath)).toBe(true);
+      expect(fs.readFileSync(path.join(TEST_USER_DATA, 'updates', 'patch-info.json'), 'utf-8')).toContain('0.0.66');
     } finally {
       service.stopUpdateService();
     }

--- a/apps/desktop/src/main/__tests__/updateService.test.ts
+++ b/apps/desktop/src/main/__tests__/updateService.test.ts
@@ -835,9 +835,23 @@ describe('startup update relaunch safety', () => {
       await vi.waitFor(() => {
         expect(releaseWrite).toBeTypeOf('function');
       });
-      expect(fs.existsSync(path.join(TEST_USER_DATA, 'updates', 'patch-info.json'))).toBe(false);
+      expect(fs.existsSync(path.join(TEST_USER_DATA, 'updates', 'patch-info.json'))).toBe(true);
       releaseWrite?.();
       await writePromise;
+      expect(fs.existsSync(path.join(TEST_USER_DATA, 'updates', 'patch-info.json'))).toBe(false);
+    } finally {
+      service.stopUpdateService();
+    }
+  });
+
+  it('keeps the staged patch when an org-default write is rejected', async () => {
+    const service = await bootWithStagedPatch({ enabled: false });
+    tryEnableUncustomizedBetaAtomic.mockResolvedValue(false);
+    try {
+      expect(fs.existsSync(path.join(TEST_USER_DATA, 'updates', 'patch-info.json'))).toBe(true);
+      await expect(service.enableUncustomizedBetaChannel()).resolves.toBe(false);
+      expect(service.getUpdateStatus()).toBe('ready');
+      expect(fs.existsSync(path.join(TEST_USER_DATA, 'updates', 'patch-info.json'))).toBe(true);
     } finally {
       service.stopUpdateService();
     }

--- a/apps/desktop/src/main/__tests__/updateService.test.ts
+++ b/apps/desktop/src/main/__tests__/updateService.test.ts
@@ -856,6 +856,69 @@ describe('startup update relaunch safety', () => {
       service.stopUpdateService();
     }
   });
+
+  it('releases a pending hold when the org-default write throws', async () => {
+    const service = await bootWithStagedPatch({ enabled: true });
+    let releaseProbe: ((busy: boolean) => void) | undefined;
+    const probeStarted = new Promise<void>((resolveStarted) => {
+      service.setUpdateAutoRelaunchBusyProbe(
+        () =>
+          new Promise<boolean>((resolveProbe) => {
+            resolveStarted();
+            releaseProbe = resolveProbe;
+          }),
+      );
+    });
+    tryEnableUncustomizedBetaAtomic.mockRejectedValue(new Error('lock timeout'));
+    try {
+      await probeStarted;
+      await expect(service.enableUncustomizedBetaChannel()).rejects.toThrow('lock timeout');
+      expect(fs.existsSync(path.join(TEST_USER_DATA, 'updates', 'patch-info.json'))).toBe(true);
+      releaseProbe?.(true);
+      await vi.waitFor(() => {
+        expect(service.getUpdateStatus()).toBe('ready');
+      });
+      expect(fs.existsSync(path.join(TEST_USER_DATA, 'updates', 'patch-info.json'))).toBe(true);
+    } finally {
+      service.stopUpdateService();
+    }
+  });
+
+  it('does not apply a leftover patch after an offline channel change', async () => {
+    const updatesDir = path.join(TEST_USER_DATA, 'updates');
+    fs.mkdirSync(updatesDir, { recursive: true });
+    fs.writeFileSync(path.join(updatesDir, 'xdt-maker-0.0.65.zip'), 'update');
+    fs.writeFileSync(
+      path.join(updatesDir, 'patch-info.json'),
+      JSON.stringify({
+        version: '0.0.65',
+        fileName: 'xdt-maker-0.0.65.zip',
+        sha256: 'abc',
+        enableBeta: false,
+      }),
+    );
+    readUpdateChannelSettings.mockReturnValue({
+      enableBeta: true,
+      orgDefaultEnableBeta: true,
+    });
+    fetchManifest.mockResolvedValue(null);
+    const service = await freshUpdateService('darwin');
+    service.initUpdateService();
+    try {
+      const handler = ipcHandlers.get('update-check-startup');
+      expect(handler).toBeTypeOf('function');
+      await expect(handler?.()).resolves.toMatchObject({
+        hasUpdate: false,
+        action: 'none',
+        error: 'manifest_failed',
+      });
+      expect(service.getUpdateStatus()).toBe('idle');
+      expect(fs.existsSync(path.join(updatesDir, 'patch-info.json'))).toBe(false);
+      expect(fs.existsSync(path.join(updatesDir, 'xdt-maker-0.0.65.zip'))).toBe(false);
+    } finally {
+      service.stopUpdateService();
+    }
+  });
 });
 
 describe('splash 启动下载 0% 显式广播', () => {

--- a/apps/desktop/src/main/__tests__/updateService.test.ts
+++ b/apps/desktop/src/main/__tests__/updateService.test.ts
@@ -75,6 +75,7 @@ vi.mock('../auto-update-settings-store', () => ({
 }));
 
 const tryEnableUncustomizedBetaAtomic = vi.fn(async () => true);
+const writeEnableBeta = vi.fn(async () => undefined);
 const readUpdateChannelSettings = vi.fn(() => ({
   enableBeta: false,
   orgDefaultEnableBeta: false,
@@ -96,7 +97,7 @@ vi.mock('../updateChannelStore', () => ({
     defaults: { enableBeta: false, orgDefaultEnableBeta: false },
   }),
   resetUpdateChannelSettings: () => ({ enableBeta: false, orgDefaultEnableBeta: false }),
-  writeEnableBeta: vi.fn(),
+  writeEnableBeta,
   tryEnableUncustomizedBetaAtomic,
   isEnableBetaUserCustomized: () => false,
   isBetaChannelEnabled: () => readUpdateChannelSettings().enableBeta === true,
@@ -193,6 +194,8 @@ beforeEach(() => {
   download.mockReset();
   tryEnableUncustomizedBetaAtomic.mockReset();
   tryEnableUncustomizedBetaAtomic.mockResolvedValue(true);
+  writeEnableBeta.mockReset();
+  writeEnableBeta.mockResolvedValue(undefined);
   readUpdateChannelSettings.mockReset();
   readUpdateChannelSettings.mockReturnValue({
     enableBeta: false,
@@ -773,6 +776,68 @@ describe('startup update relaunch safety', () => {
       await expect(checkPromise).resolves.toBe('idle');
       expect(service.getUpdateStatus()).toBe('idle');
       expect(fs.existsSync(path.join(TEST_USER_DATA, 'updates', 'patch-info.json'))).toBe(false);
+    } finally {
+      service.stopUpdateService();
+    }
+  });
+
+  it('aborts a manual relaunch when a channel change is still deferred', async () => {
+    const service = await bootWithStagedPatch({ enabled: true });
+    let releaseProbe: ((busy: boolean) => void) | undefined;
+    const probeStarted = new Promise<void>((resolveStarted) => {
+      service.setUpdateAutoRelaunchBusyProbe(
+        () =>
+          new Promise<boolean>((resolveProbe) => {
+            resolveStarted();
+            releaseProbe = resolveProbe;
+          }),
+      );
+    });
+    try {
+      await probeStarted;
+      const setHandler = ipcHandlers.get('update-channel-settings-set');
+      expect(setHandler).toBeTypeOf('function');
+      await setHandler?.({ sender: { id: 1 } }, { enableBeta: true });
+      expect(service.getUpdateStatus()).toBe('ready');
+      const relaunch = ipcListeners.get('update-relaunch');
+      expect(relaunch).toBeTypeOf('function');
+      logInfo.mockClear();
+      relaunch?.({}, 'dark');
+      expect(logInfo.mock.calls.map((call) => String(call[0]))).toEqual(
+        expect.arrayContaining([
+          expect.stringContaining('executeRelaunch() aborted'),
+        ]),
+      );
+      releaseProbe?.(false);
+      await vi.waitFor(() => {
+        expect(service.getUpdateStatus()).toBe('idle');
+      });
+      expect(service.isUpdateRelaunchImminent()).toBe(false);
+    } finally {
+      service.stopUpdateService();
+    }
+  });
+
+  it('invalidates the staged patch before the settings write settles', async () => {
+    const service = await bootWithStagedPatch({ enabled: false });
+    let releaseWrite: (() => void) | undefined;
+    writeEnableBeta.mockImplementation(
+      () =>
+        new Promise<undefined>((resolve) => {
+          releaseWrite = () => resolve(undefined);
+        }),
+    );
+    try {
+      const setHandler = ipcHandlers.get('update-channel-settings-set');
+      expect(setHandler).toBeTypeOf('function');
+      expect(fs.existsSync(path.join(TEST_USER_DATA, 'updates', 'patch-info.json'))).toBe(true);
+      const writePromise = setHandler?.({ sender: { id: 1 } }, { enableBeta: true });
+      await vi.waitFor(() => {
+        expect(releaseWrite).toBeTypeOf('function');
+      });
+      expect(fs.existsSync(path.join(TEST_USER_DATA, 'updates', 'patch-info.json'))).toBe(false);
+      releaseWrite?.();
+      await writePromise;
     } finally {
       service.stopUpdateService();
     }

--- a/apps/desktop/src/main/__tests__/updateService.test.ts
+++ b/apps/desktop/src/main/__tests__/updateService.test.ts
@@ -80,6 +80,7 @@ vi.mock('../manifestService', () => ({
   fetchManifest,
   getBaseUrl,
   isDev,
+  clearCachedManifest: vi.fn(),
 }));
 
 vi.mock('../updateChannelStore', () => ({
@@ -517,6 +518,31 @@ describe('startup update relaunch safety', () => {
       expect(service.getUpdateStatus()).toBe('ready');
     } finally {
       releaseProbe?.(true);
+      service.stopUpdateService();
+    }
+  });
+
+  it('clears the deferred staged patch after a busy eligibility check settles', async () => {
+    const service = await bootWithStagedPatch({ enabled: true });
+    let releaseProbe: ((busy: boolean) => void) | undefined;
+    const probeStarted = new Promise<void>((resolveStarted) => {
+      service.setUpdateAutoRelaunchBusyProbe(
+        () =>
+          new Promise<boolean>((resolveProbe) => {
+            resolveStarted();
+            releaseProbe = resolveProbe;
+          }),
+      );
+    });
+    try {
+      await probeStarted;
+      expect(service.enableUncustomizedBetaChannel()).toBe(true);
+      expect(service.getUpdateStatus()).toBe('ready');
+      releaseProbe?.(true);
+      await vi.waitFor(() => {
+        expect(service.getUpdateStatus()).toBe('idle');
+      });
+    } finally {
       service.stopUpdateService();
     }
   });

--- a/apps/desktop/src/main/__tests__/updateService.test.ts
+++ b/apps/desktop/src/main/__tests__/updateService.test.ts
@@ -572,6 +572,21 @@ describe('startup update relaunch safety', () => {
       service.stopUpdateService();
     }
   });
+
+  it('invalidates an in-flight check when another instance changes the shared channel', async () => {
+    const service = await bootWithStagedPatch({ enabled: true });
+    try {
+      expect(service.getUpdateStatus()).toBe('ready');
+      readUpdateChannelSettings.mockReturnValue({
+        enableBeta: true,
+        orgDefaultEnableBeta: true,
+      });
+      await expect(service.checkForUpdate()).resolves.toBe('idle');
+      expect(service.getUpdateStatus()).toBe('idle');
+    } finally {
+      service.stopUpdateService();
+    }
+  });
 });
 
 describe('splash 启动下载 0% 显式广播', () => {

--- a/apps/desktop/src/main/__tests__/updateService.test.ts
+++ b/apps/desktop/src/main/__tests__/updateService.test.ts
@@ -21,6 +21,7 @@ const powerMonitorRemoveListener = vi.fn();
 const appGetVersion = vi.fn(() => '0.0.64');
 const appRelaunch = vi.fn();
 const appQuit = vi.fn();
+const appGetAppPath = vi.fn(() => path.join(TEST_ROOT, 'Cindy.app', 'Contents', 'Resources', 'app.asar'));
 const appIsInApplicationsFolder = vi.fn(() => true);
 const appGetPath = vi.fn((name: string) => {
   if (name === 'userData') return TEST_USER_DATA;
@@ -44,6 +45,7 @@ vi.mock('electron', () => ({
     getPath: appGetPath,
     relaunch: appRelaunch,
     quit: appQuit,
+    getAppPath: appGetAppPath,
     isPackaged: true,
     isInApplicationsFolder: appIsInApplicationsFolder,
     moveToApplicationsFolder: vi.fn(),
@@ -906,6 +908,93 @@ describe('startup update relaunch safety', () => {
         expect(service.getUpdateStatus()).toBe('idle');
       });
       expect(fs.existsSync(path.join(TEST_USER_DATA, 'updates', 'patch-info.json'))).toBe(false);
+    } finally {
+      service.stopUpdateService();
+    }
+  });
+
+  it('applies a newer same-path patch after a deferred channel change', async () => {
+    const sharedHotfix = 'app/darwin-arm64/xdt-maker-hotfix.zip';
+    const service = await bootWithStagedPatch({
+      enabled: true,
+      manifest: updateManifest('0.0.65', sharedHotfix),
+    });
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never);
+    let releaseProbe: ((busy: boolean) => void) | undefined;
+    const probeStarted = new Promise<void>((resolveStarted) => {
+      service.setUpdateAutoRelaunchBusyProbe(
+        () =>
+          new Promise<boolean>((resolveProbe) => {
+            resolveStarted();
+            releaseProbe = resolveProbe;
+          }),
+      );
+    });
+    try {
+      await probeStarted;
+      await expect(service.enableUncustomizedBetaChannel()).resolves.toBe(true);
+      service.setUpdateAutoRelaunchBusyProbe(() => true);
+      readAutoUpdateSettings.mockReturnValue({ autoRelaunchOnIdle: false });
+      readUpdateChannelSettings.mockReturnValue({
+        enableBeta: true,
+        orgDefaultEnableBeta: true,
+      });
+      fetchManifest.mockResolvedValue(updateManifest('0.0.66', sharedHotfix));
+      await expect(service.checkForUpdate()).resolves.toBe('ready');
+      expect(service.getUpdateStatus()).toBe('ready');
+      logInfo.mockClear();
+      ipcListeners.get('update-relaunch')?.({}, 'dark');
+      expect(logInfo.mock.calls.map((call) => String(call[0])).join('\n')).not.toContain(
+        'executeRelaunch() aborted',
+      );
+      expect(logInfo.mock.calls.map((call) => String(call[0])).join('\n')).toContain(
+        'executeRelaunch() called',
+      );
+      expect(
+        fs.readFileSync(path.join(TEST_USER_DATA, 'updates', 'patch-info.json'), 'utf-8'),
+      ).toContain('0.0.66');
+    } finally {
+      exitSpy.mockRestore();
+      releaseProbe?.(true);
+      service.stopUpdateService();
+    }
+  });
+
+  it('does not treat a failed settings write as a committed channel change', async () => {
+    const service = await bootWithStagedPatch({ enabled: true });
+    let releaseProbe: ((busy: boolean) => void) | undefined;
+    const probeStarted = new Promise<void>((resolveStarted) => {
+      service.setUpdateAutoRelaunchBusyProbe(
+        () =>
+          new Promise<boolean>((resolveProbe) => {
+            resolveStarted();
+            releaseProbe = resolveProbe;
+          }),
+      );
+    });
+    let rejectWrite: ((error: Error) => void) | undefined;
+    writeEnableBeta.mockImplementation(
+      () =>
+        new Promise<undefined>((_resolve, reject) => {
+          rejectWrite = reject;
+        }),
+    );
+    try {
+      await probeStarted;
+      const setHandler = ipcHandlers.get('update-channel-settings-set');
+      expect(setHandler).toBeTypeOf('function');
+      const writePromise = setHandler?.({ sender: { id: 1 } }, { enableBeta: true });
+      await vi.waitFor(() => {
+        expect(rejectWrite).toBeTypeOf('function');
+      });
+      rejectWrite?.(new Error('lock timeout'));
+      await expect(writePromise).rejects.toThrow();
+      expect(fs.existsSync(path.join(TEST_USER_DATA, 'updates', 'patch-info.json'))).toBe(true);
+      releaseProbe?.(true);
+      await vi.waitFor(() => {
+        expect(service.getUpdateStatus()).toBe('ready');
+      });
+      expect(fs.existsSync(path.join(TEST_USER_DATA, 'updates', 'patch-info.json'))).toBe(true);
     } finally {
       service.stopUpdateService();
     }

--- a/apps/desktop/src/main/__tests__/updateService.test.ts
+++ b/apps/desktop/src/main/__tests__/updateService.test.ts
@@ -1000,6 +1000,35 @@ describe('startup update relaunch safety', () => {
     }
   });
 
+  it('does not treat a failed settings write as an external channel change', async () => {
+    const service = await bootWithStagedPatch({ enabled: true });
+    let releaseProbe: ((busy: boolean) => void) | undefined;
+    const probeStarted = new Promise<void>((resolveStarted) => {
+      service.setUpdateAutoRelaunchBusyProbe(
+        () =>
+          new Promise<boolean>((resolveProbe) => {
+            resolveStarted();
+            releaseProbe = resolveProbe;
+          }),
+      );
+    });
+    writeEnableBeta.mockRejectedValueOnce(new Error('lock timeout'));
+    try {
+      await probeStarted;
+      const setHandler = ipcHandlers.get('update-channel-settings-set');
+      expect(setHandler).toBeTypeOf('function');
+      await expect(setHandler?.({ sender: { id: 1 } }, { enableBeta: true })).rejects.toThrow();
+      expect(fs.existsSync(path.join(TEST_USER_DATA, 'updates', 'patch-info.json'))).toBe(true);
+      releaseProbe?.(true);
+      await vi.waitFor(() => {
+        expect(service.getUpdateStatus()).toBe('ready');
+      });
+      expect(fs.existsSync(path.join(TEST_USER_DATA, 'updates', 'patch-info.json'))).toBe(true);
+    } finally {
+      service.stopUpdateService();
+    }
+  });
+
   it('does not let a failed settings write overwrite a committed observed channel', async () => {
     const service = await bootWithStagedPatch({ enabled: false });
     let releaseFirstWrite: (() => void) | undefined;

--- a/apps/desktop/src/main/__tests__/updateService.test.ts
+++ b/apps/desktop/src/main/__tests__/updateService.test.ts
@@ -857,6 +857,60 @@ describe('startup update relaunch safety', () => {
     }
   });
 
+  it('keeps a settings-page hold when a concurrent org-default write throws', async () => {
+    const service = await bootWithStagedPatch({ enabled: true });
+    let releaseProbe: ((busy: boolean) => void) | undefined;
+    const probeStarted = new Promise<void>((resolveStarted) => {
+      service.setUpdateAutoRelaunchBusyProbe(
+        () =>
+          new Promise<boolean>((resolveProbe) => {
+            resolveStarted();
+            releaseProbe = resolveProbe;
+          }),
+      );
+    });
+    let releaseWrite: (() => void) | undefined;
+    writeEnableBeta.mockImplementation(
+      () =>
+        new Promise<undefined>((resolve) => {
+          releaseWrite = () => resolve(undefined);
+        }),
+    );
+    tryEnableUncustomizedBetaAtomic.mockRejectedValue(new Error('lock timeout'));
+    try {
+      await probeStarted;
+      const setHandler = ipcHandlers.get('update-channel-settings-set');
+      expect(setHandler).toBeTypeOf('function');
+      const writePromise = setHandler?.({ sender: { id: 1 } }, { enableBeta: true });
+      await vi.waitFor(() => {
+        expect(releaseWrite).toBeTypeOf('function');
+      });
+      await expect(service.enableUncustomizedBetaChannel()).rejects.toThrow('lock timeout');
+      expect(fs.existsSync(path.join(TEST_USER_DATA, 'updates', 'patch-info.json'))).toBe(true);
+      releaseProbe?.(false);
+      await vi.waitFor(() => {
+        expect(service.getUpdateStatus()).toBe('ready');
+      });
+      expect(fs.existsSync(path.join(TEST_USER_DATA, 'updates', 'patch-info.json'))).toBe(true);
+      logInfo.mockClear();
+      ipcListeners.get('update-relaunch')?.({}, 'dark');
+      expect(logInfo.mock.calls.map((call) => String(call[0]))).toEqual(
+        expect.arrayContaining([
+          expect.stringContaining('executeRelaunch() aborted'),
+        ]),
+      );
+      expect(service.getUpdateStatus()).toBe('ready');
+      releaseWrite?.();
+      await writePromise;
+      await vi.waitFor(() => {
+        expect(service.getUpdateStatus()).toBe('idle');
+      });
+      expect(fs.existsSync(path.join(TEST_USER_DATA, 'updates', 'patch-info.json'))).toBe(false);
+    } finally {
+      service.stopUpdateService();
+    }
+  });
+
   it('releases a pending hold when the org-default write throws', async () => {
     const service = await bootWithStagedPatch({ enabled: true });
     let releaseProbe: ((busy: boolean) => void) | undefined;

--- a/apps/desktop/src/main/__tests__/updateService.test.ts
+++ b/apps/desktop/src/main/__tests__/updateService.test.ts
@@ -1041,6 +1041,39 @@ describe('startup update relaunch safety', () => {
     }
   });
 
+  it('invalidates the staged patch when another instance already enabled beta', async () => {
+    const service = await bootWithStagedPatch({ enabled: true });
+    let releaseProbe: ((busy: boolean) => void) | undefined;
+    const probeStarted = new Promise<void>((resolveStarted) => {
+      service.setUpdateAutoRelaunchBusyProbe(
+        () =>
+          new Promise<boolean>((resolveProbe) => {
+            resolveStarted();
+            releaseProbe = resolveProbe;
+          }),
+      );
+    });
+    tryEnableUncustomizedBetaAtomic.mockImplementation(async () => {
+      readUpdateChannelSettings.mockReturnValue({
+        enableBeta: true,
+        orgDefaultEnableBeta: true,
+      });
+      return false;
+    });
+    try {
+      await probeStarted;
+      await expect(service.enableUncustomizedBetaChannel()).resolves.toBe(false);
+      expect(service.getUpdateStatus()).toBe('ready');
+      releaseProbe?.(false);
+      await vi.waitFor(() => {
+        expect(service.getUpdateStatus()).toBe('idle');
+      });
+      expect(fs.existsSync(path.join(TEST_USER_DATA, 'updates', 'patch-info.json'))).toBe(false);
+    } finally {
+      service.stopUpdateService();
+    }
+  });
+
   it('releases a pending hold when the org-default write throws', async () => {
     const service = await bootWithStagedPatch({ enabled: true });
     let releaseProbe: ((busy: boolean) => void) | undefined;

--- a/apps/desktop/src/main/__tests__/updateService.test.ts
+++ b/apps/desktop/src/main/__tests__/updateService.test.ts
@@ -70,7 +70,7 @@ vi.mock('../auto-update-settings-store', () => ({
   writeAutoRelaunchOnIdle: vi.fn(),
 }));
 
-const tryEnableUncustomizedBeta = vi.fn(() => true);
+const tryEnableUncustomizedBetaAtomic = vi.fn(async () => true);
 const readUpdateChannelSettings = vi.fn(() => ({
   enableBeta: false,
   orgDefaultEnableBeta: false,
@@ -93,7 +93,7 @@ vi.mock('../updateChannelStore', () => ({
   }),
   resetUpdateChannelSettings: () => ({ enableBeta: false, orgDefaultEnableBeta: false }),
   writeEnableBeta: vi.fn(),
-  tryEnableUncustomizedBeta,
+  tryEnableUncustomizedBetaAtomic,
   isEnableBetaUserCustomized: () => false,
   isBetaChannelEnabled: () => readUpdateChannelSettings().enableBeta === true,
 }));
@@ -180,8 +180,8 @@ beforeEach(() => {
   isDev.mockReset();
   isDev.mockReturnValue(false);
   download.mockReset();
-  tryEnableUncustomizedBeta.mockReset();
-  tryEnableUncustomizedBeta.mockReturnValue(true);
+  tryEnableUncustomizedBetaAtomic.mockReset();
+  tryEnableUncustomizedBetaAtomic.mockResolvedValue(true);
   readUpdateChannelSettings.mockReset();
   readUpdateChannelSettings.mockReturnValue({
     enableBeta: false,
@@ -514,7 +514,7 @@ describe('startup update relaunch safety', () => {
     try {
       await probeStarted;
       expect(service.getUpdateStatus()).toBe('ready');
-      expect(service.enableUncustomizedBetaChannel()).toBe(true);
+      await expect(service.enableUncustomizedBetaChannel()).resolves.toBe(true);
       expect(service.getUpdateStatus()).toBe('ready');
     } finally {
       releaseProbe?.(true);
@@ -536,7 +536,7 @@ describe('startup update relaunch safety', () => {
     });
     try {
       await probeStarted;
-      expect(service.enableUncustomizedBetaChannel()).toBe(true);
+      await expect(service.enableUncustomizedBetaChannel()).resolves.toBe(true);
       expect(service.getUpdateStatus()).toBe('ready');
       releaseProbe?.(true);
       await vi.waitFor(() => {
@@ -561,7 +561,7 @@ describe('startup update relaunch safety', () => {
     });
     try {
       await probeStarted;
-      expect(service.enableUncustomizedBetaChannel()).toBe(true);
+      await expect(service.enableUncustomizedBetaChannel()).resolves.toBe(true);
       expect(service.getUpdateStatus()).toBe('ready');
       releaseProbe?.(false);
       await vi.waitFor(() => {

--- a/apps/desktop/src/main/__tests__/updateService.test.ts
+++ b/apps/desktop/src/main/__tests__/updateService.test.ts
@@ -1155,6 +1155,8 @@ describe('startup update relaunch safety', () => {
         enableBeta: false,
       }),
     );
+    const flagPath = path.join(TEST_USER_DATA, 'relogin-required.flag');
+    fs.writeFileSync(flagPath, JSON.stringify({ version: '0.0.65' }));
     readUpdateChannelSettings.mockReturnValue({
       enableBeta: true,
       orgDefaultEnableBeta: true,
@@ -1173,6 +1175,7 @@ describe('startup update relaunch safety', () => {
       expect(service.getUpdateStatus()).toBe('idle');
       expect(fs.existsSync(path.join(updatesDir, 'patch-info.json'))).toBe(false);
       expect(fs.existsSync(path.join(updatesDir, 'xdt-maker-0.0.65.zip'))).toBe(false);
+      expect(fs.existsSync(flagPath)).toBe(false);
     } finally {
       service.stopUpdateService();
     }

--- a/apps/desktop/src/main/__tests__/updateService.test.ts
+++ b/apps/desktop/src/main/__tests__/updateService.test.ts
@@ -541,6 +541,18 @@ describe('startup update relaunch safety', () => {
     }
   });
 
+  it('clears a matching relogin flag when the staged patch is discarded', async () => {
+    const service = await bootWithStagedPatch({ enabled: false });
+    const flagPath = path.join(TEST_USER_DATA, 'relogin-required.flag');
+    fs.writeFileSync(flagPath, JSON.stringify({ version: '0.0.65' }));
+    try {
+      await expect(service.enableUncustomizedBetaChannel()).resolves.toBe(true);
+      expect(fs.existsSync(flagPath)).toBe(false);
+    } finally {
+      service.stopUpdateService();
+    }
+  });
+
   it('clears the deferred staged patch after a busy eligibility check settles', async () => {
     const service = await bootWithStagedPatch({ enabled: true });
     let releaseProbe: ((busy: boolean) => void) | undefined;

--- a/apps/desktop/src/main/__tests__/updateService.test.ts
+++ b/apps/desktop/src/main/__tests__/updateService.test.ts
@@ -123,6 +123,17 @@ vi.mock('../cindy-brain/index', () => ({
   getGhostNodeRuntimeBroker: () => ({ destroyAll: vi.fn() }),
 }));
 
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  return {
+    ...actual,
+    spawn: () => ({
+      unref: vi.fn(),
+      on: vi.fn(),
+    }),
+  };
+});
+
 vi.mock('../security/trustedAppRenderer', () => ({
   assertTrustedAppRendererEvent: vi.fn(),
 }));

--- a/apps/desktop/src/main/__tests__/updateService.test.ts
+++ b/apps/desktop/src/main/__tests__/updateService.test.ts
@@ -1000,6 +1000,47 @@ describe('startup update relaunch safety', () => {
     }
   });
 
+  it('does not let a failed settings write overwrite a committed observed channel', async () => {
+    const service = await bootWithStagedPatch({ enabled: false });
+    let releaseFirstWrite: (() => void) | undefined;
+    let rejectSecondWrite: ((error: Error) => void) | undefined;
+    let writeCalls = 0;
+    writeEnableBeta.mockImplementation(
+      () =>
+        new Promise<undefined>((resolve, reject) => {
+          writeCalls += 1;
+          if (writeCalls === 1) {
+            releaseFirstWrite = () => resolve(undefined);
+            return;
+          }
+          rejectSecondWrite = reject;
+        }),
+    );
+    try {
+      const setHandler = ipcHandlers.get('update-channel-settings-set');
+      expect(setHandler).toBeTypeOf('function');
+      const firstWrite = setHandler?.({ sender: { id: 1 } }, { enableBeta: true });
+      const secondWrite = setHandler?.({ sender: { id: 1 } }, { enableBeta: true });
+      await vi.waitFor(() => {
+        expect(releaseFirstWrite).toBeTypeOf('function');
+        expect(rejectSecondWrite).toBeTypeOf('function');
+      });
+      readUpdateChannelSettings.mockReturnValue({
+        enableBeta: true,
+        orgDefaultEnableBeta: true,
+      });
+      releaseFirstWrite?.();
+      await firstWrite;
+      rejectSecondWrite?.(new Error('lock timeout'));
+      await expect(secondWrite).rejects.toThrow();
+      await expect(service.checkForUpdate()).resolves.toBe('ready');
+      expect(service.getUpdateStatus()).toBe('ready');
+      expect(fs.existsSync(path.join(TEST_USER_DATA, 'updates', 'patch-info.json'))).toBe(true);
+    } finally {
+      service.stopUpdateService();
+    }
+  });
+
   it('releases a pending hold when the org-default write throws', async () => {
     const service = await bootWithStagedPatch({ enabled: true });
     let releaseProbe: ((busy: boolean) => void) | undefined;

--- a/apps/desktop/src/main/__tests__/updateService.test.ts
+++ b/apps/desktop/src/main/__tests__/updateService.test.ts
@@ -734,6 +734,49 @@ describe('startup update relaunch safety', () => {
       service.stopUpdateService();
     }
   });
+
+  it('does not restore a superseded patch after a channel change', async () => {
+    const { DownloadError } = await import('../downloader/index');
+    const service = await bootWithStagedPatch({ enabled: true });
+    let releaseProbe: ((busy: boolean) => void) | undefined;
+    const probeStarted = new Promise<void>((resolveStarted) => {
+      service.setUpdateAutoRelaunchBusyProbe(
+        () =>
+          new Promise<boolean>((resolveProbe) => {
+            resolveStarted();
+            releaseProbe = resolveProbe;
+          }),
+      );
+    });
+    let failDownload: ((error: Error) => void) | undefined;
+    download.mockImplementation(() => new Promise((_, reject) => {
+      failDownload = reject;
+    }));
+    try {
+      await probeStarted;
+      await expect(service.enableUncustomizedBetaChannel()).resolves.toBe(true);
+      service.setUpdateAutoRelaunchBusyProbe(() => true);
+      readUpdateChannelSettings.mockReturnValue({
+        enableBeta: true,
+        orgDefaultEnableBeta: true,
+      });
+      fetchManifest.mockResolvedValue(updateManifest('0.0.66'));
+      const checkPromise = service.checkForUpdate();
+      await vi.waitFor(() => {
+        expect(failDownload).toBeTypeOf('function');
+      });
+      releaseProbe?.(true);
+      await vi.waitFor(() => {
+        expect(service.getUpdateStatus()).toBe('superseding');
+      });
+      failDownload?.(new DownloadError('NETWORK', 'boom'));
+      await expect(checkPromise).resolves.toBe('idle');
+      expect(service.getUpdateStatus()).toBe('idle');
+      expect(fs.existsSync(path.join(TEST_USER_DATA, 'updates', 'patch-info.json'))).toBe(false);
+    } finally {
+      service.stopUpdateService();
+    }
+  });
 });
 
 describe('splash 启动下载 0% 显式广播', () => {

--- a/apps/desktop/src/main/__tests__/updateService.test.ts
+++ b/apps/desktop/src/main/__tests__/updateService.test.ts
@@ -70,10 +70,31 @@ vi.mock('../auto-update-settings-store', () => ({
   writeAutoRelaunchOnIdle: vi.fn(),
 }));
 
+const tryEnableUncustomizedBeta = vi.fn(() => true);
+const readUpdateChannelSettings = vi.fn(() => ({
+  enableBeta: false,
+  orgDefaultEnableBeta: false,
+}));
+
 vi.mock('../manifestService', () => ({
   fetchManifest,
   getBaseUrl,
   isDev,
+}));
+
+vi.mock('../updateChannelStore', () => ({
+  readUpdateChannelSettings,
+  readUpdateChannelSettingsState: () => ({
+    value: readUpdateChannelSettings(),
+    isCustomized: false,
+    customizedKeys: [],
+    defaults: { enableBeta: false, orgDefaultEnableBeta: false },
+  }),
+  resetUpdateChannelSettings: () => ({ enableBeta: false, orgDefaultEnableBeta: false }),
+  writeEnableBeta: vi.fn(),
+  tryEnableUncustomizedBeta,
+  isEnableBetaUserCustomized: () => false,
+  isBetaChannelEnabled: () => readUpdateChannelSettings().enableBeta === true,
 }));
 
 vi.mock('../downloader/index', () => ({
@@ -158,6 +179,13 @@ beforeEach(() => {
   isDev.mockReset();
   isDev.mockReturnValue(false);
   download.mockReset();
+  tryEnableUncustomizedBeta.mockReset();
+  tryEnableUncustomizedBeta.mockReturnValue(true);
+  readUpdateChannelSettings.mockReset();
+  readUpdateChannelSettings.mockReturnValue({
+    enableBeta: false,
+    orgDefaultEnableBeta: false,
+  });
   readAutoUpdateSettings.mockReset();
   readAutoUpdateSettings.mockReturnValue({ autoRelaunchOnIdle: true });
   logInfo.mockReset();
@@ -466,6 +494,29 @@ describe('startup update relaunch safety', () => {
       isDev.mockReturnValue(true);
       expect(service.isUpdateRelaunchImminent()).toBe(false);
     } finally {
+      service.stopUpdateService();
+    }
+  });
+
+  it('does not clear the staged patch while busyProbe is still pending', async () => {
+    const service = await bootWithStagedPatch({ enabled: true });
+    let releaseProbe: ((busy: boolean) => void) | undefined;
+    const probeStarted = new Promise<void>((resolveStarted) => {
+      service.setUpdateAutoRelaunchBusyProbe(
+        () =>
+          new Promise<boolean>((resolveProbe) => {
+            resolveStarted();
+            releaseProbe = resolveProbe;
+          }),
+      );
+    });
+    try {
+      await probeStarted;
+      expect(service.getUpdateStatus()).toBe('ready');
+      expect(service.enableUncustomizedBetaChannel()).toBe(true);
+      expect(service.getUpdateStatus()).toBe('ready');
+    } finally {
+      releaseProbe?.(true);
       service.stopUpdateService();
     }
   });

--- a/apps/desktop/src/main/__tests__/updateService.test.ts
+++ b/apps/desktop/src/main/__tests__/updateService.test.ts
@@ -546,6 +546,32 @@ describe('startup update relaunch safety', () => {
       service.stopUpdateService();
     }
   });
+
+  it('aborts auto-relaunch when the channel changes during eligibility', async () => {
+    const service = await bootWithStagedPatch({ enabled: true });
+    let releaseProbe: ((busy: boolean) => void) | undefined;
+    const probeStarted = new Promise<void>((resolveStarted) => {
+      service.setUpdateAutoRelaunchBusyProbe(
+        () =>
+          new Promise<boolean>((resolveProbe) => {
+            resolveStarted();
+            releaseProbe = resolveProbe;
+          }),
+      );
+    });
+    try {
+      await probeStarted;
+      expect(service.enableUncustomizedBetaChannel()).toBe(true);
+      expect(service.getUpdateStatus()).toBe('ready');
+      releaseProbe?.(false);
+      await vi.waitFor(() => {
+        expect(service.getUpdateStatus()).toBe('idle');
+      });
+      expect(service.isUpdateRelaunchImminent()).toBe(false);
+    } finally {
+      service.stopUpdateService();
+    }
+  });
 });
 
 describe('splash 启动下载 0% 显式广播', () => {

--- a/apps/desktop/src/main/__tests__/xdOrgBetaDefault.test.ts
+++ b/apps/desktop/src/main/__tests__/xdOrgBetaDefault.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  isXdOrgUser,
+  maybeEnableXdOrgBetaDefault,
+  type XdOrgBetaDefaultDeps,
+  type XdOrgBetaDefaultRequest,
+  type XdOrgBetaUser,
+} from '../xdOrgBetaDefault';
+
+const REQUEST: XdOrgBetaDefaultRequest = {
+  expectedAuthEpoch: 7,
+  expectedUserId: 'user-1',
+  user: {
+    membershipKind: 'org',
+    orgSlug: 'xd',
+    orgName: '心动网络',
+  },
+};
+
+function user(overrides: Partial<XdOrgBetaUser> = {}): XdOrgBetaUser {
+  return {
+    membershipKind: 'org',
+    orgSlug: 'xd',
+    orgName: '心动网络',
+    ...overrides,
+  };
+}
+
+function makeDeps(
+  overrides: Partial<{
+    authEpoch: number;
+    userId: string | null;
+    enableBeta: boolean;
+    isCustomized: boolean;
+    available: boolean;
+    probeThrows: boolean;
+  }> = {},
+): XdOrgBetaDefaultDeps & { enableBeta: ReturnType<typeof vi.fn>; probeBetaManifest: ReturnType<typeof vi.fn> } {
+  return {
+    readCurrentAuthIdentity: vi.fn(() => ({
+      authEpoch: overrides.authEpoch ?? REQUEST.expectedAuthEpoch,
+      userId: overrides.userId === undefined ? REQUEST.expectedUserId : overrides.userId,
+    })),
+    readChannelState: vi.fn(() => ({
+      enableBeta: overrides.enableBeta === true,
+      isCustomized: overrides.isCustomized === true,
+    })),
+    probeBetaManifest: overrides.probeThrows
+      ? vi.fn().mockRejectedValue(new Error('offline'))
+      : vi.fn().mockResolvedValue(overrides.available !== false),
+    enableBeta: vi.fn(),
+  };
+}
+
+describe('isXdOrgUser', () => {
+  it('allows xd org members by orgSlug', () => {
+    expect(isXdOrgUser(user({ orgSlug: 'xd', orgName: '心动网络' }))).toBe(true);
+  });
+
+  it('denies non-xd slugs even when the display name looks like xd', () => {
+    expect(isXdOrgUser(user({ orgSlug: 'disco-corp', orgName: '心动网络' }))).toBe(false);
+    expect(isXdOrgUser(user({ orgSlug: 'xd-partner', orgName: 'xd' }))).toBe(false);
+  });
+
+  it('falls back to orgName only when orgSlug is missing', () => {
+    expect(isXdOrgUser(user({ orgSlug: null, orgName: 'xd' }))).toBe(true);
+    expect(isXdOrgUser(user({ orgSlug: null, orgName: ' XD ' }))).toBe(true);
+    expect(isXdOrgUser(user({ orgSlug: null, orgName: '心动网络' }))).toBe(true);
+    expect(isXdOrgUser(user({ orgSlug: null, orgName: 'Disco Corp' }))).toBe(false);
+  });
+
+  it('denies personal accounts and missing login state', () => {
+    expect(isXdOrgUser(user({ membershipKind: 'personal', orgSlug: 'xd' }))).toBe(false);
+    expect(isXdOrgUser(null)).toBe(false);
+  });
+});
+
+describe('maybeEnableXdOrgBetaDefault', () => {
+  it('enables beta for an unused xd-org device after the probe succeeds', async () => {
+    const deps = makeDeps();
+
+    await expect(maybeEnableXdOrgBetaDefault(REQUEST, deps)).resolves.toEqual({ kind: 'enabled' });
+    expect(deps.probeBetaManifest).toHaveBeenCalledOnce();
+    expect(deps.enableBeta).toHaveBeenCalledOnce();
+  });
+
+  it('does not reopen beta after the user customized the switch off', async () => {
+    const deps = makeDeps({ isCustomized: true, enableBeta: false });
+
+    await expect(maybeEnableXdOrgBetaDefault(REQUEST, deps)).resolves.toEqual({
+      kind: 'skipped',
+      reason: 'user-customized',
+    });
+    expect(deps.probeBetaManifest).not.toHaveBeenCalled();
+    expect(deps.enableBeta).not.toHaveBeenCalled();
+  });
+
+  it('skips non-xd accounts without probing', async () => {
+    const deps = makeDeps();
+
+    await expect(
+      maybeEnableXdOrgBetaDefault({ ...REQUEST, user: user({ orgSlug: 'other', orgName: 'Other' }) }, deps),
+    ).resolves.toEqual({ kind: 'skipped', reason: 'not-xd-org' });
+    expect(deps.probeBetaManifest).not.toHaveBeenCalled();
+    expect(deps.enableBeta).not.toHaveBeenCalled();
+  });
+
+  it('skips when beta is already on', async () => {
+    const deps = makeDeps({ enableBeta: true, isCustomized: true });
+
+    await expect(maybeEnableXdOrgBetaDefault(REQUEST, deps)).resolves.toEqual({
+      kind: 'skipped',
+      reason: 'already-enabled',
+    });
+    expect(deps.probeBetaManifest).not.toHaveBeenCalled();
+    expect(deps.enableBeta).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { available: false },
+    { probeThrows: true },
+  ])('skips when the beta manifest is unavailable: %j', async (overrides) => {
+    const deps = makeDeps(overrides);
+
+    await expect(maybeEnableXdOrgBetaDefault(REQUEST, deps)).resolves.toEqual({
+      kind: 'skipped',
+      reason: 'beta-unavailable',
+    });
+    expect(deps.enableBeta).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { authEpoch: REQUEST.expectedAuthEpoch + 1, userId: REQUEST.expectedUserId },
+    { authEpoch: REQUEST.expectedAuthEpoch, userId: 'user-2' },
+    { authEpoch: REQUEST.expectedAuthEpoch, userId: null },
+  ])('discards the write after auth changes: %j', async (current) => {
+    const deps = makeDeps(current);
+
+    await expect(maybeEnableXdOrgBetaDefault(REQUEST, deps)).resolves.toEqual({
+      kind: 'skipped',
+      reason: 'stale-auth',
+    });
+    expect(deps.enableBeta).not.toHaveBeenCalled();
+  });
+
+  it('discards a late probe success after logout or account switch', async () => {
+    const deps = makeDeps();
+    let identity = {
+      authEpoch: REQUEST.expectedAuthEpoch,
+      userId: REQUEST.expectedUserId as string | null,
+    };
+    deps.readCurrentAuthIdentity = vi.fn(() => identity);
+    vi.mocked(deps.probeBetaManifest).mockImplementation(async () => {
+      identity = { authEpoch: REQUEST.expectedAuthEpoch + 1, userId: 'user-2' };
+      return true;
+    });
+
+    await expect(maybeEnableXdOrgBetaDefault(REQUEST, deps)).resolves.toEqual({
+      kind: 'skipped',
+      reason: 'stale-auth',
+    });
+    expect(deps.enableBeta).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/main/__tests__/xdOrgBetaDefault.test.ts
+++ b/apps/desktop/src/main/__tests__/xdOrgBetaDefault.test.ts
@@ -49,7 +49,7 @@ function makeDeps(
     probeBetaManifest: overrides.probeThrows
       ? vi.fn().mockRejectedValue(new Error('offline'))
       : vi.fn().mockResolvedValue(overrides.available !== false),
-    enableBeta: vi.fn(),
+    enableBeta: vi.fn().mockResolvedValue(true),
   };
 }
 

--- a/apps/desktop/src/main/authManager.ts
+++ b/apps/desktop/src/main/authManager.ts
@@ -1473,9 +1473,7 @@ function scheduleXdOrgBetaDefault(input: {
         isCustomized: isEnableBetaUserCustomized(),
       }),
       probeBetaManifest,
-      enableBeta: () => {
-        enableUncustomizedBetaChannel();
-      },
+      enableBeta: () => enableUncustomizedBetaChannel(),
     },
   )
     .then((outcome) => {

--- a/apps/desktop/src/main/authManager.ts
+++ b/apps/desktop/src/main/authManager.ts
@@ -43,7 +43,7 @@ import {
 } from '@cindy/auth-client';
 import { readReloginFlag, clearReloginFlag, enableUncustomizedBetaChannel } from './updateService';
 import { probeBetaManifest } from './manifestService';
-import { readUpdateChannelSettingsState } from './updateChannelStore';
+import { isEnableBetaUserCustomized, readUpdateChannelSettings } from './updateChannelStore';
 import * as canaryFlagStore from './canaryFlagStore';
 import { decodeAccessTokenOrgSlug } from './authTokenClaims';
 import { getProviderSecretStore } from './secrets/providerSecretStore.js';
@@ -1468,13 +1468,10 @@ function scheduleXdOrgBetaDefault(input: {
         authEpoch: authStateEpoch,
         userId: currentUser?.id ?? null,
       }),
-      readChannelState: () => {
-        const state = readUpdateChannelSettingsState();
-        return {
-          enableBeta: state.value.enableBeta,
-          isCustomized: state.isCustomized,
-        };
-      },
+      readChannelState: () => ({
+        enableBeta: readUpdateChannelSettings().enableBeta,
+        isCustomized: isEnableBetaUserCustomized(),
+      }),
       probeBetaManifest,
       enableBeta: () => {
         enableUncustomizedBetaChannel();

--- a/apps/desktop/src/main/authManager.ts
+++ b/apps/desktop/src/main/authManager.ts
@@ -41,7 +41,9 @@ import {
   type ProviderConfig,
   type SocialProvider,
 } from '@cindy/auth-client';
-import { readReloginFlag, clearReloginFlag } from './updateService';
+import { readReloginFlag, clearReloginFlag, enableUncustomizedBetaChannel } from './updateService';
+import { probeBetaManifest } from './manifestService';
+import { readUpdateChannelSettingsState } from './updateChannelStore';
 import * as canaryFlagStore from './canaryFlagStore';
 import { decodeAccessTokenOrgSlug } from './authTokenClaims';
 import { getProviderSecretStore } from './secrets/providerSecretStore.js';
@@ -55,6 +57,7 @@ import {
 } from './authRefreshFailure';
 import { awaitWithStartupTimeout } from './authStartupGate';
 import { syncCanaryFlagAfterAuth } from './canaryFlagSync';
+import { maybeEnableXdOrgBetaDefault } from './xdOrgBetaDefault';
 import { canRestoreAuthSessionForMembership } from './authRealmPolicy';
 import {
   createAuthBrowserAuthorizationSlot,
@@ -1438,6 +1441,63 @@ function scheduleCanaryFlagSync(input: {
 }
 
 /**
+ * 登录态落地后为 xd 组织补一次设备级 beta 默认值,不阻塞进主界面。
+ *
+ * expectedAuthEpoch + expectedUserId 防止探测完成时已经登出 / 换号。
+ * 用户手动关过(isCustomized)后不再打开;probe 失败也不写盘,下次登录再试。
+ */
+function scheduleXdOrgBetaDefault(input: {
+  expectedAuthEpoch: number;
+  expectedUserId: string;
+}): void {
+  if (isPassiveSharedUserDataInstance()) return;
+  const user = currentUser;
+  if (!user) return;
+  void maybeEnableXdOrgBetaDefault(
+    {
+      expectedAuthEpoch: input.expectedAuthEpoch,
+      expectedUserId: input.expectedUserId,
+      user: {
+        membershipKind: user.membershipKind,
+        orgName: user.orgName,
+        orgSlug: decodeAccessTokenOrgSlug(accessToken),
+      },
+    },
+    {
+      readCurrentAuthIdentity: () => ({
+        authEpoch: authStateEpoch,
+        userId: currentUser?.id ?? null,
+      }),
+      readChannelState: () => {
+        const state = readUpdateChannelSettingsState();
+        return {
+          enableBeta: state.value.enableBeta,
+          isCustomized: state.isCustomized,
+        };
+      },
+      probeBetaManifest,
+      enableBeta: () => {
+        enableUncustomizedBetaChannel();
+      },
+    },
+  )
+    .then((outcome) => {
+      if (outcome.kind === 'enabled') {
+        log.info('xd org beta channel default enabled');
+        return;
+      }
+      if (outcome.reason === 'stale-auth') {
+        log.debug('discarded stale xd org beta default');
+        return;
+      }
+      log.debug('xd org beta channel default skipped: reason=%s', outcome.reason);
+    })
+    .catch((err) => {
+      log.error('xd org beta channel default threw unexpectedly', err);
+    });
+}
+
+/**
  * 冷启动流程的进程内去重:主窗超时转后台之后,副窗 / 右侧栏窗口 mount 再调
  * initialize() 时复用同一个 in-flight promise(各自套各自的超时),避免两条流程
  * 并发轮换同一枚 refresh token 互相打成 INVALID_REFRESH_TOKEN。
@@ -2600,6 +2660,10 @@ async function runColdStartRefreshFlow(
       expectedAuthEpoch: epochAtStart,
       expectedUserId: refreshData.membership.id,
     });
+    scheduleXdOrgBetaDefault({
+      expectedAuthEpoch: epochAtStart,
+      expectedUserId: refreshData.membership.id,
+    });
     scheduleRefresh(refreshData.accessToken);
     // XD / Mivo key 均为本地 only,不再在冷启动从服务器同步到本地。
     // 账号边界对账:换账号则清掉上一个账号留在本机的 provider key,同账号保留(不必重填)。
@@ -2767,6 +2831,10 @@ async function completeLogin(
   });
   scheduleCanaryFlagSync({
     token: outcome.accessToken,
+    expectedAuthEpoch: loginEpoch,
+    expectedUserId: nextUser.id,
+  });
+  scheduleXdOrgBetaDefault({
     expectedAuthEpoch: loginEpoch,
     expectedUserId: nextUser.id,
   });
@@ -3366,6 +3434,10 @@ export async function refresh(): Promise<boolean> {
         }
         scheduleCanaryFlagSync({
           token: data.accessToken,
+          expectedAuthEpoch: refreshEpoch,
+          expectedUserId: nextUser.id,
+        });
+        scheduleXdOrgBetaDefault({
           expectedAuthEpoch: refreshEpoch,
           expectedUserId: nextUser.id,
         });

--- a/apps/desktop/src/main/authManager.ts
+++ b/apps/desktop/src/main/authManager.ts
@@ -1473,7 +1473,11 @@ function scheduleXdOrgBetaDefault(input: {
         isCustomized: isEnableBetaUserCustomized(),
       }),
       probeBetaManifest,
-      enableBeta: () => enableUncustomizedBetaChannel(),
+      enableBeta: () =>
+        enableUncustomizedBetaChannel(
+          () =>
+            authStateEpoch === input.expectedAuthEpoch && currentUser?.id === input.expectedUserId,
+        ),
     },
   )
     .then((outcome) => {

--- a/apps/desktop/src/main/manifestService.ts
+++ b/apps/desktop/src/main/manifestService.ts
@@ -277,8 +277,8 @@ export function clearCachedManifest(): void {
  * 「manifest 之后才判 isInstalled」顺序)——所以「能不能开」必须提前探明,
  * 而不是等用户重启后才发现坏了。
  *
- * 只判 HTTP 200 可达,不解析正文、不写 cache、不改当前发布通道。dev 不联网,
- * 直接返回 true(dev 不消费远程 manifest,无需预检)。
+ * HTTP 200 之后还要能解析出 app.version。截断 JSON / 错误页不能当成渠道可用。
+ * 不写 cache、不改当前发布通道。dev 不联网,直接返回 true。
  */
 export function probeBetaManifest(timeoutMs = 8_000): Promise<boolean> {
   if (isDev()) return Promise.resolve(true);
@@ -286,6 +286,7 @@ export function probeBetaManifest(timeoutMs = 8_000): Promise<boolean> {
   return new Promise<boolean>((resolve) => {
     try {
       const request = net.request(url);
+      let body = '';
       let settled = false;
       let timeout: ReturnType<typeof setTimeout> | undefined;
       const finish = (value: boolean, abortRequest = false): void => {
@@ -297,9 +298,23 @@ export function probeBetaManifest(timeoutMs = 8_000): Promise<boolean> {
       };
       timeout = setTimeout(() => finish(false, true), timeoutMs);
       request.on('response', (response) => {
-        // 读完响应体以正确触发流结束、避免连接泄漏(内容不关心)。
-        response.on('data', () => {});
-        response.on('end', () => finish(response.statusCode === 200));
+        if (response.statusCode !== 200) {
+          response.on('data', () => {});
+          response.on('end', () => finish(false));
+          response.on('error', () => finish(false));
+          return;
+        }
+        response.on('data', (chunk) => {
+          body += chunk.toString();
+        });
+        response.on('end', () => {
+          try {
+            const json = JSON.parse(body) as Manifest;
+            finish(typeof json.app?.version === 'string' && json.app.version.length > 0);
+          } catch {
+            finish(false);
+          }
+        });
         response.on('error', () => finish(false));
       });
       request.on('error', () => finish(false));

--- a/apps/desktop/src/main/manifestService.ts
+++ b/apps/desktop/src/main/manifestService.ts
@@ -17,7 +17,7 @@
 import { app, net } from 'electron';
 import * as canaryFlagStore from './canaryFlagStore';
 
-import { resolveUpdateChannel } from '@cindy/maker-shared/update-channel';
+import { resolveUpdateChannel, type UpdateChannel } from '@cindy/maker-shared/update-channel';
 
 import { createLogger } from './logger';
 import { getClientEndpoint } from './clientEndpointsService';
@@ -101,12 +101,18 @@ const REQUEST_TIMEOUT_MS = 30_000;
 // ── State ──────────────────────────────────────────────────────────────────
 
 let cached: Manifest | null = null;
+/** 当前缓存对应的发布通道。读取时跟磁盘对账,共库另一实例切过渠道就丢掉。 */
+let cachedChannel: UpdateChannel | null = null;
 /**
  * manifest 代际:切渠道(clearCachedManifest)时 +1。fetchManifest 发起时快照,
  * 响应完成写 cached 前核对——若期间切了渠道,这次 in-flight 的旧渠道响应直接作废,
  * 不写缓存、返回 null,让调用方(agent prepare / 更新轮询)下次按新渠道重新 fetch。
  */
 let manifestEpoch = 0;
+
+function currentUpdateChannel(): UpdateChannel {
+  return resolveUpdateChannel(canaryFlagStore.read(), isBetaChannelEnabled());
+}
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
@@ -158,10 +164,7 @@ export async function fetchManifest(
   if (isDev()) return null;
   if (signal?.aborted) return null;
 
-  const channel = resolveUpdateChannel(
-    canaryFlagStore.read(),
-    isBetaChannelEnabled(),
-  );
+  const channel = currentUpdateChannel();
   const channelSuffix = channel === 'release' ? '' : `-${channel}`;
   // Cache-bust: append timestamp to prevent Chromium / CDN serving stale manifest
   const url = `${getBaseUrl()}/manifest-${getPlatformKey()}${channelSuffix}.json?t=${Date.now()}`;
@@ -205,12 +208,14 @@ export async function fetchManifest(
             const json = JSON.parse(body) as Manifest;
             // 响应回来前切了渠道:这是旧渠道的 manifest,不作废会污染 cached,
             // 让后续 agent prepare 装旧渠道资产。返回 null 让调用方下次按新渠道重取。
-            if (epochAtStart !== manifestEpoch) {
+            // 共库另一实例改开关不会推进本进程 epoch,所以还要再对一次当前通道。
+            if (epochAtStart !== manifestEpoch || currentUpdateChannel() !== channel) {
               log.info('manifest channel changed during fetch — discarding stale response');
               finish(null);
               return;
             }
             cached = json;
+            cachedChannel = channel;
             log.info('Fetched OK: app.version=%s, hotfix=%s', json.app?.version, json.app?.hotfix?.file ?? 'none');
             finish(json);
           } catch (err) {
@@ -236,8 +241,15 @@ export async function fetchManifest(
 
 /**
  * Return the in-memory cached manifest (may be null if never fetched or dev mode).
+ * 读取时跟当前发布通道对账:共库另一实例切过渠道后,旧缓存不能再给 agent prepare 用。
  */
 export function getCachedManifest(): Manifest | null {
+  if (!cached) return null;
+  if (cachedChannel !== currentUpdateChannel()) {
+    log.info('cached manifest channel is stale — discarding');
+    clearCachedManifest();
+    return null;
+  }
   return cached;
 }
 
@@ -251,6 +263,7 @@ export function getCachedManifest(): Manifest | null {
  */
 export function clearCachedManifest(): void {
   cached = null;
+  cachedChannel = null;
   manifestEpoch += 1;
 }
 

--- a/apps/desktop/src/main/updateChannelStore.ts
+++ b/apps/desktop/src/main/updateChannelStore.ts
@@ -10,10 +10,11 @@
  *     所以这里用 createOverrideSettingsFile(与 auto-update-settings 同一套
  *     override 语义:默认值 + 用户 override、恢复默认只删 override),而不是仿
  *     canaryFlagStore 的裸 JSON。
- *   - xd 组织登录后可由 authManager 在「尚未自定义」时补一次默认打开;用户
- *     手动关过(isCustomized)后重启 / 重登都不再打开。
+ *   - xd 组织登录后可由 authManager 在「用户没拨过开关」时补一次默认打开;
+ *     用户手动关过(enableBeta override 存在)后重启 / 重登都不再打开。
  *
- * 落盘:userData/update-channel-settings.json,字段 { enableBeta: boolean }。
+ * 落盘:userData/update-channel-settings.json。用户拨动写 enableBeta;
+ * 组织默认写 orgDefaultEnableBeta,两者分开。
  * 默认关闭。manifestService.fetchManifest() 用 resolveUpdateChannel 把本开关与
  * canaryFlagStore.read() 收敛成最终发布通道(优先级 canary > beta > release)。
  */
@@ -31,10 +32,16 @@ const log = desktopMakerLogger.child('update-channel-settings');
 
 export interface UpdateChannelSettings {
   enableBeta: boolean;
+  /**
+   * xd 组织默认打开留下的标记,不是用户拨动。
+   * 有效值:用户写过 enableBeta 用用户值,否则看这个标记。
+   */
+  orgDefaultEnableBeta: boolean;
 }
 
 const DEFAULTS: UpdateChannelSettings = {
   enableBeta: false,
+  orgDefaultEnableBeta: false,
 };
 
 function settingsFilePath(): string {
@@ -45,8 +52,21 @@ function normalize(raw: unknown): UpdateChannelSettings {
   if (!raw || typeof raw !== 'object') return { ...DEFAULTS };
   const r = raw as Record<string, unknown>;
   return {
-    enableBeta:
-      typeof r.enableBeta === 'boolean' ? r.enableBeta : DEFAULTS.enableBeta,
+    // 这里只还原落盘字段。override store 读盘时会把 defaults 和 overrides 先
+    // 合并再交给 normalize,enableBeta:false 分不清是默认还是用户关过,有效值
+    // 在 resolveEffectiveSettings 里按 customizedKeys 算。
+    enableBeta: typeof r.enableBeta === 'boolean' ? r.enableBeta : DEFAULTS.enableBeta,
+    orgDefaultEnableBeta: r.orgDefaultEnableBeta === true,
+  };
+}
+
+function resolveEffectiveSettings(
+  state: OverrideSettingsState<UpdateChannelSettings>,
+): UpdateChannelSettings {
+  const userCustomized = state.customizedKeys.includes('enableBeta');
+  return {
+    enableBeta: userCustomized ? state.value.enableBeta : state.value.orgDefaultEnableBeta,
+    orgDefaultEnableBeta: state.value.orgDefaultEnableBeta,
   };
 }
 
@@ -59,7 +79,7 @@ const store = createOverrideSettingsFile<UpdateChannelSettings>({
 });
 
 export function readUpdateChannelSettings(): UpdateChannelSettings {
-  return store.read();
+  return resolveEffectiveSettings(store.readState());
 }
 
 export function readUpdateChannelSettingsState(): OverrideSettingsState<UpdateChannelSettings> {
@@ -68,22 +88,31 @@ export function readUpdateChannelSettingsState(): OverrideSettingsState<UpdateCh
 
 export function writeEnableBeta(enableBeta: boolean): void {
   // 关 beta 的值等于系统默认 false。若不 preserveDefaults,override 会被删掉,
-  // isCustomized 变回 false,xd 组织下次登录又会把开关默认打开,盖掉用户的
-  // 手动关闭。设置页每次拨动都算显式自定义。
+  // 用户键消失后会被当成未自定义,xd 组织下次登录又会默认打开。
+  // 设置页每次拨动都写 enableBeta,与组织默认标记分开。
   store.writePatch({ enableBeta }, { preserveDefaults: true });
   log.info('beta update channel setting written', { enableBeta });
 }
 
+/** 用户是否显式拨过 beta 开关。组织默认写入不算。 */
+export function isEnableBetaUserCustomized(): boolean {
+  return store.readState().customizedKeys.includes('enableBeta');
+}
+
 /**
- * 仅在用户从没改过这个开关时打开 beta。
- * 给 xd 组织默认打开用:用户手动关过(isCustomized)后必须保持关。
- * 返回是否实际写入了 true。
+ * 仅在用户从没拨过这个开关时打开 beta。
+ * 写入 orgDefaultEnableBeta,不写 enableBeta,避免把组织默认伪装成用户 override。
+ * 用户手动关过(enableBeta 键存在)后必须保持关。
+ * 返回是否实际把有效值从关写成开。
  */
 export function tryEnableUncustomizedBeta(): boolean {
   const state = store.readState();
-  if (state.value.enableBeta || state.isCustomized) return false;
-  store.writePatch({ enableBeta: true });
-  log.info('beta update channel setting written', { enableBeta: true, source: 'xd-org-default' });
+  if (state.customizedKeys.includes('enableBeta') || state.value.enableBeta) return false;
+  store.writePatch({ orgDefaultEnableBeta: true });
+  log.info('beta update channel setting written', {
+    enableBeta: true,
+    source: 'xd-org-default',
+  });
   return true;
 }
 

--- a/apps/desktop/src/main/updateChannelStore.ts
+++ b/apps/desktop/src/main/updateChannelStore.ts
@@ -86,11 +86,12 @@ export function readUpdateChannelSettingsState(): OverrideSettingsState<UpdateCh
   return store.readState();
 }
 
-export function writeEnableBeta(enableBeta: boolean): void {
+export async function writeEnableBeta(enableBeta: boolean): Promise<void> {
   // 关 beta 的值等于系统默认 false。若不 preserveDefaults,override 会被删掉,
   // 用户键消失后会被当成未自定义,xd 组织下次登录又会默认打开。
   // 设置页每次拨动都写 enableBeta,与组织默认标记分开。
-  store.writePatch({ enableBeta }, { preserveDefaults: true });
+  // 和 tryEnableUncustomizedBetaAtomic 共用同一把跨进程锁,避免默认写入盖掉用户关闭。
+  await store.writePatchAtomic({ enableBeta }, { preserveDefaults: true });
   log.info('beta update channel setting written', { enableBeta });
 }
 
@@ -109,10 +110,16 @@ export function isEnableBetaUserCustomized(): boolean {
  * 跨进程锁内现读再决定是否打开组织默认。
  * probe 前后另一实例可能已经写下用户关闭,不能用过期的 isCustomized 缓存覆盖。
  */
-export async function tryEnableUncustomizedBetaAtomic(): Promise<boolean> {
+export async function tryEnableUncustomizedBetaAtomic(
+  shouldWrite: () => boolean = () => true,
+): Promise<boolean> {
   let wrote = false;
   await store.updateAtomic((current) => {
-    if (current.customizedKeys.includes('enableBeta') || current.value.enableBeta) {
+    if (
+      !shouldWrite() ||
+      current.customizedKeys.includes('enableBeta') ||
+      current.value.enableBeta
+    ) {
       return {};
     }
     wrote = true;
@@ -127,8 +134,8 @@ export async function tryEnableUncustomizedBetaAtomic(): Promise<boolean> {
   return wrote;
 }
 
-export function resetUpdateChannelSettings(): UpdateChannelSettings {
-  return store.reset();
+export async function resetUpdateChannelSettings(): Promise<UpdateChannelSettings> {
+  return store.resetAtomic();
 }
 
 /** manifestService 消费的单一读取入口:返回是否启用 beta(设备级)。 */

--- a/apps/desktop/src/main/updateChannelStore.ts
+++ b/apps/desktop/src/main/updateChannelStore.ts
@@ -10,6 +10,8 @@
  *     所以这里用 createOverrideSettingsFile(与 auto-update-settings 同一套
  *     override 语义:默认值 + 用户 override、恢复默认只删 override),而不是仿
  *     canaryFlagStore 的裸 JSON。
+ *   - xd 组织登录后可由 authManager 在「尚未自定义」时补一次默认打开;用户
+ *     手动关过(isCustomized)后重启 / 重登都不再打开。
  *
  * 落盘:userData/update-channel-settings.json,字段 { enableBeta: boolean }。
  * 默认关闭。manifestService.fetchManifest() 用 resolveUpdateChannel 把本开关与
@@ -65,8 +67,24 @@ export function readUpdateChannelSettingsState(): OverrideSettingsState<UpdateCh
 }
 
 export function writeEnableBeta(enableBeta: boolean): void {
-  store.writePatch({ enableBeta });
+  // 关 beta 的值等于系统默认 false。若不 preserveDefaults,override 会被删掉,
+  // isCustomized 变回 false,xd 组织下次登录又会把开关默认打开,盖掉用户的
+  // 手动关闭。设置页每次拨动都算显式自定义。
+  store.writePatch({ enableBeta }, { preserveDefaults: true });
   log.info('beta update channel setting written', { enableBeta });
+}
+
+/**
+ * 仅在用户从没改过这个开关时打开 beta。
+ * 给 xd 组织默认打开用:用户手动关过(isCustomized)后必须保持关。
+ * 返回是否实际写入了 true。
+ */
+export function tryEnableUncustomizedBeta(): boolean {
+  const state = store.readState();
+  if (state.value.enableBeta || state.isCustomized) return false;
+  store.writePatch({ enableBeta: true });
+  log.info('beta update channel setting written', { enableBeta: true, source: 'xd-org-default' });
+  return true;
 }
 
 export function resetUpdateChannelSettings(): UpdateChannelSettings {

--- a/apps/desktop/src/main/updateChannelStore.ts
+++ b/apps/desktop/src/main/updateChannelStore.ts
@@ -105,15 +105,26 @@ export function isEnableBetaUserCustomized(): boolean {
  * 用户手动关过(enableBeta 键存在)后必须保持关。
  * 返回是否实际把有效值从关写成开。
  */
-export function tryEnableUncustomizedBeta(): boolean {
-  const state = store.readState();
-  if (state.customizedKeys.includes('enableBeta') || state.value.enableBeta) return false;
-  store.writePatch({ orgDefaultEnableBeta: true });
-  log.info('beta update channel setting written', {
-    enableBeta: true,
-    source: 'xd-org-default',
+/**
+ * 跨进程锁内现读再决定是否打开组织默认。
+ * probe 前后另一实例可能已经写下用户关闭,不能用过期的 isCustomized 缓存覆盖。
+ */
+export async function tryEnableUncustomizedBetaAtomic(): Promise<boolean> {
+  let wrote = false;
+  await store.updateAtomic((current) => {
+    if (current.customizedKeys.includes('enableBeta') || current.value.enableBeta) {
+      return {};
+    }
+    wrote = true;
+    return { orgDefaultEnableBeta: true };
   });
-  return true;
+  if (wrote) {
+    log.info('beta update channel setting written', {
+      enableBeta: true,
+      source: 'xd-org-default',
+    });
+  }
+  return wrote;
 }
 
 export function resetUpdateChannelSettings(): UpdateChannelSettings {

--- a/apps/desktop/src/main/updateChannelStore.ts
+++ b/apps/desktop/src/main/updateChannelStore.ts
@@ -60,12 +60,19 @@ function normalize(raw: unknown): UpdateChannelSettings {
   };
 }
 
+export function resolveEffectiveEnableBeta(
+  state: OverrideSettingsState<UpdateChannelSettings>,
+): boolean {
+  return state.customizedKeys.includes('enableBeta')
+    ? state.value.enableBeta
+    : state.value.orgDefaultEnableBeta;
+}
+
 function resolveEffectiveSettings(
   state: OverrideSettingsState<UpdateChannelSettings>,
 ): UpdateChannelSettings {
-  const userCustomized = state.customizedKeys.includes('enableBeta');
   return {
-    enableBeta: userCustomized ? state.value.enableBeta : state.value.orgDefaultEnableBeta,
+    enableBeta: resolveEffectiveEnableBeta(state),
     orgDefaultEnableBeta: state.value.orgDefaultEnableBeta,
   };
 }
@@ -79,6 +86,7 @@ const store = createOverrideSettingsFile<UpdateChannelSettings>({
 });
 
 export function readUpdateChannelSettings(): UpdateChannelSettings {
+  store.invalidateIfChanged();
   return resolveEffectiveSettings(store.readState());
 }
 

--- a/apps/desktop/src/main/updateService.ts
+++ b/apps/desktop/src/main/updateService.ts
@@ -142,6 +142,8 @@ const STARTUP_MANIFEST_TIMEOUT_MS = 8_000;
 let currentStatus: UpdateStatus = 'idle';
 let readyVersion: string | undefined;
 let readyFilePath: string | undefined;
+/** 当前 staged 补丁对应的渠道代际。延迟清理用它区分「同路径上的新旧包」。 */
+let readyChannelEpoch: number | undefined;
 /**
  * 更新渠道代际计数:用户在下载进行中关掉 beta(clearStagedPatch)时 +1,
  * 让 in-flight 的 checkForUpdate 在写回 patch-info / 恢复旧 patch 前察觉
@@ -158,10 +160,11 @@ let autoRelaunchInProgress = false;
 /** 资格检查(含异步 busyProbe)进行中的次数。这段窗口暂缓清补丁。 */
 let autoRelaunchDecisionDepth = 0;
 /**
- * 资格检查期间要求作废的那份旧补丁路径。
- * 只清这份文件,避免误删检查窗口里新渠道刚写下的 readyFilePath。
+ * 资格检查期间要求作废的那份旧补丁。
+ * 用路径 + 代际一起记:release / beta 资产 basename 相同时,新包会写回同一
+ * readyFilePath,只比路径会把刚下好的新渠道补丁清掉。
  */
-let deferredStagedPatchPath: string | undefined;
+let deferredStagedPatch: { path?: string; epoch?: number } | undefined;
 let lastAutoRelaunchBlockReason: AutoRelaunchBlockReason | null = null;
 let lastBusyAtMs: number | null = null;
 let lastResumeAtMs: number | null = null;
@@ -355,11 +358,11 @@ async function requestAutoRelaunch(
 
     if (syncObservedUpdateChannel()) {
       log.info('auto relaunch aborted — shared update channel changed');
-      deferredStagedPatchPath = readyFilePath ?? deferredStagedPatchPath;
+      rememberDeferredStagedPatch();
       return { accepted: false, blockReason: 'not-ready' };
     }
 
-    if (deferredStagedPatchPath) {
+    if (deferredStagedPatch) {
       log.info('auto relaunch aborted — update channel changed during eligibility check');
       return { accepted: false, blockReason: 'not-ready' };
     }
@@ -592,6 +595,7 @@ function checkExistingPatch(): { action: 'relaunch' | 'check' | 'none'; version?
   // Patch present, awaiting relaunch.
   readyVersion = patchInfo.version;
   readyFilePath = patchFilePath;
+  readyChannelEpoch = updateChannelEpoch;
   return { action: 'relaunch', version: patchInfo.version };
 }
 
@@ -627,14 +631,32 @@ function syncObservedUpdateChannel(): boolean {
   return true;
 }
 
+function rememberDeferredStagedPatch(): void {
+  deferredStagedPatch = {
+    path: readyFilePath ?? deferredStagedPatch?.path,
+    epoch: readyChannelEpoch ?? deferredStagedPatch?.epoch,
+  };
+}
+
+function isCurrentPatchNewerThanDeferred(
+  stale: { path?: string; epoch?: number },
+): boolean {
+  if (readyChannelEpoch != null && stale.epoch != null) {
+    return readyChannelEpoch > stale.epoch;
+  }
+  return Boolean(readyFilePath && readyFilePath !== stale.path);
+}
+
 function flushDeferredStagedPatchClear(): void {
-  if (!deferredStagedPatchPath) return;
+  if (!deferredStagedPatch) return;
   if (isUpdateApplyCommitted() || autoRelaunchDecisionDepth > 0) return;
-  const stalePath = deferredStagedPatchPath;
-  deferredStagedPatchPath = undefined;
-  if (readyFilePath && readyFilePath !== stalePath) {
+  const stale = deferredStagedPatch;
+  deferredStagedPatch = undefined;
+  if (isCurrentPatchNewerThanDeferred(stale)) {
     log.info('keeping newer staged patch after deferred channel-change clear');
-    try { fs.unlinkSync(stalePath); } catch { /* ignore */ }
+    if (stale.path && stale.path !== readyFilePath) {
+      try { fs.unlinkSync(stale.path); } catch { /* ignore */ }
+    }
     return;
   }
   clearStagedPatch();
@@ -653,7 +675,7 @@ function clearStagedPatch(): void {
     return;
   }
   if (autoRelaunchDecisionDepth > 0) {
-    deferredStagedPatchPath = readyFilePath ?? deferredStagedPatchPath;
+    rememberDeferredStagedPatch();
     // 立刻作废旧渠道 in-flight 下载,避免下载完成后又把旧补丁写成 ready。
     invalidateInFlightChannelDownloads();
     log.info('deferring staged patch clear until auto-relaunch eligibility settles');
@@ -664,6 +686,7 @@ function clearStagedPatch(): void {
   }
   readyVersion = undefined;
   readyFilePath = undefined;
+  readyChannelEpoch = undefined;
   removePatchInfo();
   invalidateInFlightChannelDownloads();
   // downloading 也要重置:opt-out 若发生在「首次 beta 下载进行中」,status 仍是
@@ -1013,6 +1036,7 @@ async function doCheckForUpdate(manifestOverride?: Manifest | null): Promise<Che
     }
     readyVersion = latestVersion;
     readyFilePath = result.path;
+    readyChannelEpoch = updateChannelEpoch;
     setStatus('ready', { version: latestVersion });
     return 'ready';
   } catch (err) {
@@ -1038,6 +1062,7 @@ async function doCheckForUpdate(manifestOverride?: Manifest | null): Promise<Che
       log.info('Superseding download failed — rolling back to ready v%s', previousReadyVersion);
       readyVersion = previousReadyVersion;
       readyFilePath = previousReadyFilePath;
+      readyChannelEpoch = channelEpochAtStart;
       setStatus('ready', { version: previousReadyVersion });
       return 'ready';
     }
@@ -1065,6 +1090,7 @@ function handleApplyFailure(reason: string): void {
   removePatchInfo();
   readyVersion = undefined;
   readyFilePath = undefined;
+  readyChannelEpoch = undefined;
   isRelaunching = false;
   autoRelaunchInProgress = false;
   setStatus('error', { errorCode: 'updater_spawn_failed' });
@@ -1506,6 +1532,7 @@ export function initUpdateService(): void {
         );
         readyVersion = undefined;
         readyFilePath = undefined;
+        readyChannelEpoch = undefined;
       }
 
       // Step 3: download (re-using the manifest we already have). Route through

--- a/apps/desktop/src/main/updateService.ts
+++ b/apps/desktop/src/main/updateService.ts
@@ -1534,8 +1534,9 @@ export function initUpdateService(): void {
     const wasBeta = readUpdateChannelSettings().enableBeta;
     // 先拦住 apply 再等落盘:writeEnableBeta 可能卡住跨进程锁。
     // 真正写成之后再删 zip;写入失败则放开 hold,旧补丁还能用。
+    // 写入前不要改 observedEnableBeta:失败路径会按磁盘对账,
+    // 乐观改成目标值会把「磁盘没变」误判成别人已经切过渠道。
     if (wasBeta !== next) {
-      observedEnableBeta = next;
       holdStagedPatchForPendingChannelChange();
     }
     try {
@@ -1559,7 +1560,6 @@ export function initUpdateService(): void {
     assertTrustedAppRendererEvent(event);
     const wasBeta = readUpdateChannelSettings().enableBeta;
     if (wasBeta) {
-      observedEnableBeta = false;
       holdStagedPatchForPendingChannelChange();
     }
     try {

--- a/apps/desktop/src/main/updateService.ts
+++ b/apps/desktop/src/main/updateService.ts
@@ -171,6 +171,10 @@ let autoRelaunchDecisionDepth = 0;
  * readyFilePath,只比路径会把刚下好的新渠道补丁清掉。
  */
 let deferredStagedPatch: { path?: string; epoch?: number } | undefined;
+/** 并发渠道写入各自持有一次 hold。失败只能放自己那次,不能清掉别人的保护。 */
+let pendingChannelChangeHolds = 0;
+/** 已经落盘成功的渠道切换。后续失败写入不能把这笔作废请求清掉。 */
+let committedChannelChangeInvalidation = false;
 let lastAutoRelaunchBlockReason: AutoRelaunchBlockReason | null = null;
 let lastBusyAtMs: number | null = null;
 let lastResumeAtMs: number | null = null;
@@ -364,7 +368,7 @@ async function requestAutoRelaunch(
 
     if (syncObservedUpdateChannel()) {
       log.info('auto relaunch aborted — shared update channel changed');
-      rememberDeferredStagedPatch();
+      markCommittedChannelChangeInvalidation();
       return { accepted: false, blockReason: 'not-ready' };
     }
 
@@ -657,9 +661,35 @@ function rememberDeferredStagedPatch(): void {
   };
 }
 
+function markCommittedChannelChangeInvalidation(): void {
+  committedChannelChangeInvalidation = true;
+  rememberDeferredStagedPatch();
+}
+
+function clearChannelChangeInvalidation(): void {
+  pendingChannelChangeHolds = 0;
+  committedChannelChangeInvalidation = false;
+  deferredStagedPatch = undefined;
+}
+
 /** 先拦住 apply,不删 zip / patch-info。写入没成功时还能继续用这份补丁。 */
 function holdStagedPatchForPendingChannelChange(): void {
+  pendingChannelChangeHolds += 1;
   rememberDeferredStagedPatch();
+}
+
+/** 只放掉本次未提交的 hold。已落盘的渠道切换仍要拦住旧补丁。 */
+function releasePendingChannelChangeHold(): void {
+  pendingChannelChangeHolds = Math.max(0, pendingChannelChangeHolds - 1);
+  if (pendingChannelChangeHolds === 0 && !committedChannelChangeInvalidation) {
+    deferredStagedPatch = undefined;
+  }
+}
+
+/** 本次写入已经改到盘上。后续失败的并发写入不能再放开 apply。 */
+function commitPendingChannelChange(): void {
+  pendingChannelChangeHolds = Math.max(0, pendingChannelChangeHolds - 1);
+  markCommittedChannelChangeInvalidation();
 }
 
 function isCurrentPatchNewerThanDeferred(
@@ -702,7 +732,7 @@ function flushDeferredStagedPatchClear(): void {
     }
     return;
   }
-  deferredStagedPatch = undefined;
+  clearChannelChangeInvalidation();
   if (isCurrentPatchNewerThanDeferred(stale)) {
     log.info('keeping newer staged patch after deferred channel-change clear');
     if (stale.path && stale.path !== readyFilePath) {
@@ -719,7 +749,7 @@ function flushDeferredStagedPatchClear(): void {
  */
 function discardUnappliedStagedPatchForChannelRelaunch(): void {
   if (isUpdateApplyCommitted()) return;
-  deferredStagedPatch = undefined;
+  clearChannelChangeInvalidation();
   discardStagedPatchFiles();
 }
 
@@ -1475,12 +1505,13 @@ export function initUpdateService(): void {
     } catch (err) {
       if (wasBeta !== next) {
         observedEnableBeta = wasBeta;
-        deferredStagedPatch = undefined;
+        releasePendingChannelChangeHold();
       }
       log.error('writeEnableBeta failed:', err);
       throwIpcError('INTERNAL', 'failed to write update channel settings');
     }
     if (wasBeta !== next) {
+      commitPendingChannelChange();
       clearStagedPatch();
     }
     return channelSettingsWire();
@@ -1498,12 +1529,13 @@ export function initUpdateService(): void {
     } catch (err) {
       if (wasBeta) {
         observedEnableBeta = wasBeta;
-        deferredStagedPatch = undefined;
+        releasePendingChannelChangeHold();
       }
       log.error('resetUpdateChannelSettings failed:', err);
       throwIpcError('INTERNAL', 'failed to reset update channel settings');
     }
     if (wasBeta) {
+      commitPendingChannelChange();
       clearStagedPatch();
     }
     return channelSettingsWire();
@@ -1706,17 +1738,18 @@ export async function enableUncustomizedBetaChannel(
     const wrote = await tryEnableUncustomizedBetaAtomic(shouldWrite);
     if (wrote && !wasBeta) {
       observedEnableBeta = true;
+      commitPendingChannelChange();
       clearStagedPatch();
       broadcastChannelSettings();
       return wrote;
     }
     if (!wasBeta) {
-      deferredStagedPatch = undefined;
+      releasePendingChannelChangeHold();
     }
     return wrote;
   } catch (err) {
     if (!wasBeta) {
-      deferredStagedPatch = undefined;
+      releasePendingChannelChangeHold();
     }
     throw err;
   }

--- a/apps/desktop/src/main/updateService.ts
+++ b/apps/desktop/src/main/updateService.ts
@@ -650,8 +650,11 @@ function readObservedEnableBetaFromDisk(): boolean {
   return readUpdateChannelSettings().enableBeta;
 }
 
-function restoreObservedEnableBetaFromDisk(): void {
-  observedEnableBeta = readObservedEnableBetaFromDisk();
+function restoreObservedEnableBetaFromDisk(): boolean {
+  const enableBeta = readObservedEnableBetaFromDisk();
+  const changed = enableBeta !== observedEnableBeta;
+  observedEnableBeta = enableBeta;
+  return changed;
 }
 
 function syncObservedUpdateChannel(): boolean {
@@ -693,12 +696,23 @@ function holdStagedPatchForPendingChannelChange(): void {
   rememberDeferredStagedPatch();
 }
 
-/** 只放掉本次未提交的 hold。已落盘的渠道切换仍要拦住旧补丁。 */
+/** 只放掉本次未提交的 hold。已落盘或共库已切渠道的作废请求必须留下。 */
 function releasePendingChannelChangeHold(): void {
   pendingChannelChangeHolds = Math.max(0, pendingChannelChangeHolds - 1);
   if (pendingChannelChangeHolds === 0 && !committedChannelChangeInvalidation) {
     deferredStagedPatch = undefined;
   }
+}
+
+/**
+ * 本次写入没提交。磁盘若已被别的实例改过,转成交割作废,不能把别人的标记清掉。
+ */
+function abandonPendingChannelChangeHold(): void {
+  if (restoreObservedEnableBetaFromDisk()) {
+    commitPendingChannelChange();
+    return;
+  }
+  releasePendingChannelChangeHold();
 }
 
 /** 本次写入已经改到盘上。后续失败的并发写入不能再放开 apply。 */
@@ -1528,9 +1542,7 @@ export function initUpdateService(): void {
       await writeEnableBeta(next);
     } catch (err) {
       if (wasBeta !== next) {
-        // 另一笔并发写入可能已经落盘成功,不能用本次开始时的 wasBeta 盖回去。
-        restoreObservedEnableBetaFromDisk();
-        releasePendingChannelChangeHold();
+        abandonPendingChannelChangeHold();
       }
       log.error('writeEnableBeta failed:', err);
       throwIpcError('INTERNAL', 'failed to write update channel settings');
@@ -1554,8 +1566,7 @@ export function initUpdateService(): void {
       await resetUpdateChannelSettings();
     } catch (err) {
       if (wasBeta) {
-        restoreObservedEnableBetaFromDisk();
-        releasePendingChannelChangeHold();
+        abandonPendingChannelChangeHold();
       }
       log.error('resetUpdateChannelSettings failed:', err);
       throwIpcError('INTERNAL', 'failed to reset update channel settings');
@@ -1771,14 +1782,12 @@ export async function enableUncustomizedBetaChannel(
       return wrote;
     }
     if (!wasBeta) {
-      restoreObservedEnableBetaFromDisk();
-      releasePendingChannelChangeHold();
+      abandonPendingChannelChangeHold();
     }
     return wrote;
   } catch (err) {
     if (!wasBeta) {
-      restoreObservedEnableBetaFromDisk();
-      releasePendingChannelChangeHold();
+      abandonPendingChannelChangeHold();
     }
     throw err;
   }

--- a/apps/desktop/src/main/updateService.ts
+++ b/apps/desktop/src/main/updateService.ts
@@ -44,7 +44,7 @@ import {
   isEnableBetaUserCustomized,
   readUpdateChannelSettings,
   resetUpdateChannelSettings,
-  tryEnableUncustomizedBeta,
+  tryEnableUncustomizedBetaAtomic,
   writeEnableBeta,
 } from './updateChannelStore';
 import { assertTrustedAppRendererEvent } from './security/trustedAppRenderer';
@@ -155,8 +155,11 @@ let lastErrorCode: string | undefined;
 let autoRelaunchInProgress = false;
 /** 资格检查(含异步 busyProbe)进行中的次数。这段窗口暂缓清补丁。 */
 let autoRelaunchDecisionDepth = 0;
-/** 资格检查期间有人要求作废旧渠道补丁,检查结束后若没真正开始应用再补清。 */
-let stagedPatchClearDeferred = false;
+/**
+ * 资格检查期间要求作废的那份旧补丁路径。
+ * 只清这份文件,避免误删检查窗口里新渠道刚写下的 readyFilePath。
+ */
+let deferredStagedPatchPath: string | undefined;
 let lastAutoRelaunchBlockReason: AutoRelaunchBlockReason | null = null;
 let lastBusyAtMs: number | null = null;
 let lastResumeAtMs: number | null = null;
@@ -348,7 +351,7 @@ async function requestAutoRelaunch(
       return { accepted: false, blockReason };
     }
 
-    if (stagedPatchClearDeferred) {
+    if (deferredStagedPatchPath) {
       log.info('auto relaunch aborted — update channel changed during eligibility check');
       return { accepted: false, blockReason: 'not-ready' };
     }
@@ -609,9 +612,15 @@ function invalidateInFlightChannelDownloads(): void {
 }
 
 function flushDeferredStagedPatchClear(): void {
-  if (!stagedPatchClearDeferred) return;
+  if (!deferredStagedPatchPath) return;
   if (isUpdateApplyCommitted() || autoRelaunchDecisionDepth > 0) return;
-  stagedPatchClearDeferred = false;
+  const stalePath = deferredStagedPatchPath;
+  deferredStagedPatchPath = undefined;
+  if (readyFilePath && readyFilePath !== stalePath) {
+    log.info('keeping newer staged patch after deferred channel-change clear');
+    try { fs.unlinkSync(stalePath); } catch { /* ignore */ }
+    return;
+  }
   clearStagedPatch();
 }
 
@@ -628,7 +637,7 @@ function clearStagedPatch(): void {
     return;
   }
   if (autoRelaunchDecisionDepth > 0) {
-    stagedPatchClearDeferred = true;
+    deferredStagedPatchPath = readyFilePath ?? deferredStagedPatchPath;
     // 立刻作废旧渠道 in-flight 下载,避免下载完成后又把旧补丁写成 ready。
     invalidateInFlightChannelDownloads();
     log.info('deferring staged patch clear until auto-relaunch eligibility settles');
@@ -1537,9 +1546,9 @@ export function initUpdateService(): void {
  * 渠道从关变开时作废已 staged 的旧渠道补丁,与设置页手动打开同一口径。
  * 不 relaunch:本次进程继续走当前通道,下次冷启动 / 用户自行重启再生效。
  */
-export function enableUncustomizedBetaChannel(): boolean {
+export async function enableUncustomizedBetaChannel(): Promise<boolean> {
   const wasBeta = readUpdateChannelSettings().enableBeta;
-  const wrote = tryEnableUncustomizedBeta();
+  const wrote = await tryEnableUncustomizedBetaAtomic();
   if (wrote && !wasBeta) {
     // 真正开始应用时 clearStagedPatch 会跳过;资格检查中会记下,结束后再补清。
     clearStagedPatch();

--- a/apps/desktop/src/main/updateService.ts
+++ b/apps/desktop/src/main/updateService.ts
@@ -731,6 +731,7 @@ function isCurrentPatchNewerThanDeferred(
 }
 
 function discardStagedPatchFiles(): void {
+  const discardedVersion = readyVersion;
   if (readyFilePath) {
     try { fs.unlinkSync(readyFilePath); } catch { /* ignore */ }
   }
@@ -738,6 +739,10 @@ function discardStagedPatchFiles(): void {
   readyFilePath = undefined;
   readyChannelEpoch = undefined;
   removePatchInfo();
+  const flag = discardedVersion ? readReloginFlag() : null;
+  if (flag?.version === discardedVersion) {
+    clearReloginFlag();
+  }
   if (
     currentStatus === 'ready' ||
     currentStatus === 'superseding' ||

--- a/apps/desktop/src/main/updateService.ts
+++ b/apps/desktop/src/main/updateService.ts
@@ -41,8 +41,8 @@ import {
   writeAutoRelaunchOnIdle,
 } from './auto-update-settings-store';
 import {
+  isEnableBetaUserCustomized,
   readUpdateChannelSettings,
-  readUpdateChannelSettingsState,
   resetUpdateChannelSettings,
   tryEnableUncustomizedBeta,
   writeEnableBeta,
@@ -559,12 +559,21 @@ function removePatchInfo(): void {
   try { fs.unlinkSync(path.join(getUpdatesDir(), PATCH_INFO_FILE)); } catch { /* ignore */ }
 }
 
+function isUpdateApplyInFlight(): boolean {
+  return isRelaunching || autoRelaunchInProgress;
+}
+
 /**
  * 清掉已 staged 的补丁(ready 态):删 zip + patch-info.json,状态回 idle。
- * 只在「用户关掉 beta 开关」时调用——opt-out 后不能仍让 staged 的 beta patch
- * 在下一次启动/后台轮询里被装上去(切渠道不等于切版本,必须把旧渠道的补丁作废)。
+ * 切渠道时调用——opt-out 后不能仍让 staged 的旧渠道 patch 在下次启动/后台
+ * 轮询里被装上去(切渠道不等于切版本,必须把旧渠道的补丁作废)。
+ * 自动重启已经过资格检查时不能清,否则 executeRelaunch 会走 no_ready_file。
  */
 function clearStagedPatch(): void {
+  if (isUpdateApplyInFlight()) {
+    log.info('skipping staged patch clear — update apply already in flight');
+    return;
+  }
   if (readyFilePath) {
     try { fs.unlinkSync(readyFilePath); } catch { /* ignore */ }
   }
@@ -1255,8 +1264,10 @@ export function initUpdateService(): void {
   // 更新设置或重启应用(旧 update-auto-settings 没断言是历史债,不构成豁免)。
   ipcMain.handle('update-channel-settings-get', (event) => {
     assertTrustedAppRendererEvent(event);
-    const state = readUpdateChannelSettingsState();
-    return { enableBeta: state.value.enableBeta, isCustomized: state.isCustomized };
+    return {
+      enableBeta: readUpdateChannelSettings().enableBeta,
+      isCustomized: isEnableBetaUserCustomized(),
+    };
   });
 
   ipcMain.handle('update-channel-settings-set', (event, payload: unknown) => {
@@ -1278,8 +1289,10 @@ export function initUpdateService(): void {
     if (wasBeta !== next) {
       clearStagedPatch();
     }
-    const state = readUpdateChannelSettingsState();
-    return { enableBeta: state.value.enableBeta, isCustomized: state.isCustomized };
+    return {
+      enableBeta: readUpdateChannelSettings().enableBeta,
+      isCustomized: isEnableBetaUserCustomized(),
+    };
   });
 
   ipcMain.handle('update-channel-settings-reset', (event) => {
@@ -1290,8 +1303,10 @@ export function initUpdateService(): void {
     if (wasBeta) {
       clearStagedPatch();
     }
-    const state = readUpdateChannelSettingsState();
-    return { enableBeta: state.value.enableBeta, isCustomized: state.isCustomized };
+    return {
+      enableBeta: readUpdateChannelSettings().enableBeta,
+      isCustomized: isEnableBetaUserCustomized(),
+    };
   });
 
   // 打开 beta 前的预检:探测 manifest-{platform}-beta.json 是否可达。
@@ -1480,7 +1495,13 @@ export function enableUncustomizedBetaChannel(): boolean {
   const wasBeta = readUpdateChannelSettings().enableBeta;
   const wrote = tryEnableUncustomizedBeta();
   if (wrote && !wasBeta) {
-    clearStagedPatch();
+    // 自动重启已经过资格检查、即将 executeRelaunch 时不能清补丁,
+    // 否则 readyFilePath 被拆掉会走 no_ready_file / updater_spawn_failed。
+    if (isUpdateApplyInFlight()) {
+      log.info('xd org beta default enabled — leaving in-flight update patch in place');
+    } else {
+      clearStagedPatch();
+    }
   }
   return wrote;
 }

--- a/apps/desktop/src/main/updateService.ts
+++ b/apps/desktop/src/main/updateService.ts
@@ -99,6 +99,12 @@ interface PatchInfo {
    * fails (deterministic — retry won't help) or when the threshold is hit.
    */
   applyAttempts?: number;
+  /**
+   * 下载这份补丁时的有效渠道。共库另一实例在本进程停机期间切过渠道后,
+   * 冷启动读盘对账会丢掉这份旧包,避免 manifest 失败时把旧渠道 zip 当匹配补丁装上。
+   * 旧 patch-info 没有这个字段,保持原行为。
+   */
+  enableBeta?: boolean;
 }
 
 /**
@@ -573,6 +579,19 @@ function checkExistingPatch(): { action: 'relaunch' | 'check' | 'none'; version?
     return { action: 'check' };
   }
 
+  const currentEnableBeta = readUpdateChannelSettings().enableBeta;
+  if (typeof patchInfo.enableBeta === 'boolean' && patchInfo.enableBeta !== currentEnableBeta) {
+    log.info(
+      'discarding staged patch v%s from another update channel (patch=%s current=%s)',
+      patchInfo.version,
+      patchInfo.enableBeta ? 'beta' : 'release',
+      currentEnableBeta ? 'beta' : 'release',
+    );
+    try { fs.unlinkSync(patchFilePath); } catch { /* ignore */ }
+    removePatchInfo();
+    return { action: 'check' };
+  }
+
   const currentVersion = app.getVersion();
   if (patchInfo.version === currentVersion) {
     // Patch matches current version → already applied; clean up and re-check.
@@ -871,6 +890,7 @@ async function doCheckForUpdate(manifestOverride?: Manifest | null): Promise<Che
   // 快照发起时的渠道代际;下载期间若用户 opt-out(clearStagedPatch 递增),
   // 成功/失败写回前都据此作废本次产物。
   const channelEpochAtStart = updateChannelEpoch;
+  const channelEnableBetaAtStart = observedEnableBeta;
 
   if (isVersionlessAppVersion(app.getVersion())) {
     log.info('Versionless build (placeholder %s) — in-app update disabled', app.getVersion());
@@ -1055,6 +1075,7 @@ async function doCheckForUpdate(manifestOverride?: Manifest | null): Promise<Che
       fileName,
       sha256: asset.sha256.toLowerCase(),
       requireRelogin,
+      enableBeta: channelEnableBetaAtStart,
     });
     // release-relogin-on-update: drop the marker the moment we've committed a
     // good patch on disk. Doing it here (rather than inside the platform
@@ -1681,17 +1702,24 @@ export async function enableUncustomizedBetaChannel(
   if (!wasBeta) {
     holdStagedPatchForPendingChannelChange();
   }
-  const wrote = await tryEnableUncustomizedBetaAtomic(shouldWrite);
-  if (wrote && !wasBeta) {
-    observedEnableBeta = true;
-    clearStagedPatch();
-    broadcastChannelSettings();
+  try {
+    const wrote = await tryEnableUncustomizedBetaAtomic(shouldWrite);
+    if (wrote && !wasBeta) {
+      observedEnableBeta = true;
+      clearStagedPatch();
+      broadcastChannelSettings();
+      return wrote;
+    }
+    if (!wasBeta) {
+      deferredStagedPatch = undefined;
+    }
     return wrote;
+  } catch (err) {
+    if (!wasBeta) {
+      deferredStagedPatch = undefined;
+    }
+    throw err;
   }
-  if (!wasBeta) {
-    deferredStagedPatch = undefined;
-  }
-  return wrote;
 }
 
 export function stopUpdateService(): void {

--- a/apps/desktop/src/main/updateService.ts
+++ b/apps/desktop/src/main/updateService.ts
@@ -1331,7 +1331,7 @@ export function initUpdateService(): void {
     return channelSettingsWire();
   });
 
-  ipcMain.handle('update-channel-settings-set', (event, payload: unknown) => {
+  ipcMain.handle('update-channel-settings-set', async (event, payload: unknown) => {
     assertTrustedAppRendererEvent(event);
     if (!payload || typeof payload !== 'object') {
       throwIpcError('INVALID_PARAMS', 'update channel settings payload required');
@@ -1341,7 +1341,7 @@ export function initUpdateService(): void {
       throwIpcError('INVALID_PARAMS', 'enableBeta required (boolean)');
     }
     const wasBeta = readUpdateChannelSettings().enableBeta;
-    writeEnableBeta(next);
+    await writeEnableBeta(next);
     // 渠道一变(无论 opt-in 还是 opt-out)就作废已 staged 的旧渠道补丁:
     // - opt-out(beta→release):否则用户关掉 beta 后仍被装到 beta 版本;
     // - opt-in(release→beta):否则旧 release 补丁仍 staged,重启后 beta manifest
@@ -1353,10 +1353,10 @@ export function initUpdateService(): void {
     return channelSettingsWire();
   });
 
-  ipcMain.handle('update-channel-settings-reset', (event) => {
+  ipcMain.handle('update-channel-settings-reset', async (event) => {
     assertTrustedAppRendererEvent(event);
     const wasBeta = readUpdateChannelSettings().enableBeta;
-    resetUpdateChannelSettings();
+    await resetUpdateChannelSettings();
     // 恢复默认 = 关闭 beta;同 set(false),渠道变化即作废已 staged 的补丁。
     if (wasBeta) {
       clearStagedPatch();
@@ -1546,9 +1546,11 @@ export function initUpdateService(): void {
  * 渠道从关变开时作废已 staged 的旧渠道补丁,与设置页手动打开同一口径。
  * 不 relaunch:本次进程继续走当前通道,下次冷启动 / 用户自行重启再生效。
  */
-export async function enableUncustomizedBetaChannel(): Promise<boolean> {
+export async function enableUncustomizedBetaChannel(
+  shouldWrite: () => boolean = () => true,
+): Promise<boolean> {
   const wasBeta = readUpdateChannelSettings().enableBeta;
-  const wrote = await tryEnableUncustomizedBetaAtomic();
+  const wrote = await tryEnableUncustomizedBetaAtomic(shouldWrite);
   if (wrote && !wasBeta) {
     // 真正开始应用时 clearStagedPatch 会跳过;资格检查中会记下,结束后再补清。
     clearStagedPatch();

--- a/apps/desktop/src/main/updateService.ts
+++ b/apps/desktop/src/main/updateService.ts
@@ -638,6 +638,11 @@ function rememberDeferredStagedPatch(): void {
   };
 }
 
+/** 先拦住 apply,不删 zip / patch-info。写入没成功时还能继续用这份补丁。 */
+function holdStagedPatchForPendingChannelChange(): void {
+  rememberDeferredStagedPatch();
+}
+
 function isCurrentPatchNewerThanDeferred(
   stale: { path?: string; epoch?: number },
 ): boolean {
@@ -1438,17 +1443,24 @@ export function initUpdateService(): void {
       throwIpcError('INVALID_PARAMS', 'enableBeta required (boolean)');
     }
     const wasBeta = readUpdateChannelSettings().enableBeta;
-    // 先作废旧补丁再等落盘:writeEnableBeta 可能卡住跨进程锁,这段空窗里
-    // busyProbe 若返回,资格检查仍会看到旧渠道+旧 zip 并提交 apply。
+    // 先拦住 apply 再等落盘:writeEnableBeta 可能卡住跨进程锁。
+    // 真正写成之后再删 zip;写入失败则放开 hold,旧补丁还能用。
     if (wasBeta !== next) {
       observedEnableBeta = next;
-      clearStagedPatch();
+      holdStagedPatchForPendingChannelChange();
     }
     try {
       await writeEnableBeta(next);
     } catch (err) {
+      if (wasBeta !== next) {
+        observedEnableBeta = wasBeta;
+        deferredStagedPatch = undefined;
+      }
       log.error('writeEnableBeta failed:', err);
       throwIpcError('INTERNAL', 'failed to write update channel settings');
+    }
+    if (wasBeta !== next) {
+      clearStagedPatch();
     }
     return channelSettingsWire();
   });
@@ -1458,13 +1470,20 @@ export function initUpdateService(): void {
     const wasBeta = readUpdateChannelSettings().enableBeta;
     if (wasBeta) {
       observedEnableBeta = false;
-      clearStagedPatch();
+      holdStagedPatchForPendingChannelChange();
     }
     try {
       await resetUpdateChannelSettings();
     } catch (err) {
+      if (wasBeta) {
+        observedEnableBeta = wasBeta;
+        deferredStagedPatch = undefined;
+      }
       log.error('resetUpdateChannelSettings failed:', err);
       throwIpcError('INTERNAL', 'failed to reset update channel settings');
+    }
+    if (wasBeta) {
+      clearStagedPatch();
     }
     return channelSettingsWire();
   });
@@ -1658,15 +1677,19 @@ export async function enableUncustomizedBetaChannel(
   shouldWrite: () => boolean = () => true,
 ): Promise<boolean> {
   const wasBeta = readUpdateChannelSettings().enableBeta;
-  // 先作废旧补丁再等落盘,避免原子写等待期间自动重启把旧渠道包装上去。
-  // 没真正写成开之前,不要把 observedEnableBeta 提前改成 true。
+  // 先拦住 apply 再等落盘。身份守卫拒绝或写入失败时,旧补丁还得能用。
   if (!wasBeta) {
-    clearStagedPatch();
+    holdStagedPatchForPendingChannelChange();
   }
   const wrote = await tryEnableUncustomizedBetaAtomic(shouldWrite);
   if (wrote && !wasBeta) {
     observedEnableBeta = true;
+    clearStagedPatch();
     broadcastChannelSettings();
+    return wrote;
+  }
+  if (!wasBeta) {
+    deferredStagedPatch = undefined;
   }
   return wrote;
 }

--- a/apps/desktop/src/main/updateService.ts
+++ b/apps/desktop/src/main/updateService.ts
@@ -153,8 +153,10 @@ let autoRelaunchPollTimer: ReturnType<typeof setInterval> | null = null;
 let isRelaunching = false;
 let lastErrorCode: string | undefined;
 let autoRelaunchInProgress = false;
-/** 资格检查(含异步 busyProbe)进行中的次数。清补丁必须避开这个窗口。 */
+/** 资格检查(含异步 busyProbe)进行中的次数。这段窗口暂缓清补丁。 */
 let autoRelaunchDecisionDepth = 0;
+/** 资格检查期间有人要求作废旧渠道补丁,检查结束后若没真正开始应用再补清。 */
+let stagedPatchClearDeferred = false;
 let lastAutoRelaunchBlockReason: AutoRelaunchBlockReason | null = null;
 let lastBusyAtMs: number | null = null;
 let lastResumeAtMs: number | null = null;
@@ -342,6 +344,9 @@ async function requestAutoRelaunch(
     return { accepted: true };
   } finally {
     autoRelaunchDecisionDepth = Math.max(0, autoRelaunchDecisionDepth - 1);
+    if (autoRelaunchDecisionDepth === 0 && !isRelaunching && !autoRelaunchInProgress) {
+      flushDeferredStagedPatchClear();
+    }
   }
 }
 
@@ -573,19 +578,32 @@ function removePatchInfo(): void {
   try { fs.unlinkSync(path.join(getUpdatesDir(), PATCH_INFO_FILE)); } catch { /* ignore */ }
 }
 
-function isUpdateApplyInFlight(): boolean {
-  return isRelaunching || autoRelaunchInProgress || autoRelaunchDecisionDepth > 0;
+function isUpdateApplyCommitted(): boolean {
+  return isRelaunching || autoRelaunchInProgress;
+}
+
+function flushDeferredStagedPatchClear(): void {
+  if (!stagedPatchClearDeferred) return;
+  if (isUpdateApplyCommitted() || autoRelaunchDecisionDepth > 0) return;
+  stagedPatchClearDeferred = false;
+  clearStagedPatch();
 }
 
 /**
  * 清掉已 staged 的补丁(ready 态):删 zip + patch-info.json,状态回 idle。
  * 切渠道时调用——opt-out 后不能仍让 staged 的旧渠道 patch 在下次启动/后台
  * 轮询里被装上去(切渠道不等于切版本,必须把旧渠道的补丁作废)。
- * 自动重启已经过资格检查时不能清,否则 executeRelaunch 会走 no_ready_file。
+ * 已经开始应用时不能清,否则 executeRelaunch 会走 no_ready_file。
+ * 资格检查还在等 busyProbe 时先记下,检查结束后若没真正开始应用再补清。
  */
 function clearStagedPatch(): void {
-  if (isUpdateApplyInFlight()) {
+  if (isUpdateApplyCommitted()) {
     log.info('skipping staged patch clear — update apply already in flight');
+    return;
+  }
+  if (autoRelaunchDecisionDepth > 0) {
+    stagedPatchClearDeferred = true;
+    log.info('deferring staged patch clear until auto-relaunch eligibility settles');
     return;
   }
   if (readyFilePath) {
@@ -1509,13 +1527,8 @@ export function enableUncustomizedBetaChannel(): boolean {
   const wasBeta = readUpdateChannelSettings().enableBeta;
   const wrote = tryEnableUncustomizedBeta();
   if (wrote && !wasBeta) {
-    // 自动重启已经过资格检查、即将 executeRelaunch 时不能清补丁,
-    // 否则 readyFilePath 被拆掉会走 no_ready_file / updater_spawn_failed。
-    if (isUpdateApplyInFlight()) {
-      log.info('xd org beta default enabled — leaving in-flight update patch in place');
-    } else {
-      clearStagedPatch();
-    }
+    // 真正开始应用时 clearStagedPatch 会跳过;资格检查中会记下,结束后再补清。
+    clearStagedPatch();
   }
   return wrote;
 }

--- a/apps/desktop/src/main/updateService.ts
+++ b/apps/desktop/src/main/updateService.ts
@@ -646,9 +646,17 @@ function invalidateInFlightChannelDownloads(): void {
   clearCachedManifest();
 }
 
+function readObservedEnableBetaFromDisk(): boolean {
+  return readUpdateChannelSettings().enableBeta;
+}
+
+function restoreObservedEnableBetaFromDisk(): void {
+  observedEnableBeta = readObservedEnableBetaFromDisk();
+}
+
 function syncObservedUpdateChannel(): boolean {
   if (pendingChannelChangeHolds > 0) return false;
-  const enableBeta = readUpdateChannelSettings().enableBeta;
+  const enableBeta = readObservedEnableBetaFromDisk();
   if (enableBeta === observedEnableBeta) return false;
   observedEnableBeta = enableBeta;
   invalidateInFlightChannelDownloads();
@@ -1520,13 +1528,15 @@ export function initUpdateService(): void {
       await writeEnableBeta(next);
     } catch (err) {
       if (wasBeta !== next) {
-        observedEnableBeta = wasBeta;
+        // 另一笔并发写入可能已经落盘成功,不能用本次开始时的 wasBeta 盖回去。
+        restoreObservedEnableBetaFromDisk();
         releasePendingChannelChangeHold();
       }
       log.error('writeEnableBeta failed:', err);
       throwIpcError('INTERNAL', 'failed to write update channel settings');
     }
     if (wasBeta !== next) {
+      observedEnableBeta = next;
       commitPendingChannelChange();
       clearStagedPatch();
     }
@@ -1544,13 +1554,14 @@ export function initUpdateService(): void {
       await resetUpdateChannelSettings();
     } catch (err) {
       if (wasBeta) {
-        observedEnableBeta = wasBeta;
+        restoreObservedEnableBetaFromDisk();
         releasePendingChannelChangeHold();
       }
       log.error('resetUpdateChannelSettings failed:', err);
       throwIpcError('INTERNAL', 'failed to reset update channel settings');
     }
     if (wasBeta) {
+      observedEnableBeta = false;
       commitPendingChannelChange();
       clearStagedPatch();
     }
@@ -1760,11 +1771,13 @@ export async function enableUncustomizedBetaChannel(
       return wrote;
     }
     if (!wasBeta) {
+      restoreObservedEnableBetaFromDisk();
       releasePendingChannelChangeHold();
     }
     return wrote;
   } catch (err) {
     if (!wasBeta) {
+      restoreObservedEnableBetaFromDisk();
       releasePendingChannelChangeHold();
     }
     throw err;

--- a/apps/desktop/src/main/updateService.ts
+++ b/apps/desktop/src/main/updateService.ts
@@ -148,6 +148,8 @@ let readyFilePath: string | undefined;
  * 「渠道已变」,放弃本次下载产物,避免 opt-out 后仍被装到 beta 版本。
  */
 let updateChannelEpoch = 0;
+/** 本进程上次看到的有效渠道。别的共库实例改开关后,用这个发现跨进程渠道变化。 */
+let observedEnableBeta = false;
 let pollTimer: ReturnType<typeof setInterval> | null = null;
 let autoRelaunchPollTimer: ReturnType<typeof setInterval> | null = null;
 let isRelaunching = false;
@@ -349,6 +351,12 @@ async function requestAutoRelaunch(
         }
       }
       return { accepted: false, blockReason };
+    }
+
+    if (syncObservedUpdateChannel()) {
+      log.info('auto relaunch aborted — shared update channel changed');
+      deferredStagedPatchPath = readyFilePath ?? deferredStagedPatchPath;
+      return { accepted: false, blockReason: 'not-ready' };
     }
 
     if (deferredStagedPatchPath) {
@@ -611,6 +619,14 @@ function invalidateInFlightChannelDownloads(): void {
   clearCachedManifest();
 }
 
+function syncObservedUpdateChannel(): boolean {
+  const enableBeta = readUpdateChannelSettings().enableBeta;
+  if (enableBeta === observedEnableBeta) return false;
+  observedEnableBeta = enableBeta;
+  invalidateInFlightChannelDownloads();
+  return true;
+}
+
 function flushDeferredStagedPatchClear(): void {
   if (!deferredStagedPatchPath) return;
   if (isUpdateApplyCommitted() || autoRelaunchDecisionDepth > 0) return;
@@ -794,6 +810,12 @@ export function isVersionlessAppVersion(version: string): boolean {
 
 async function doCheckForUpdate(manifestOverride?: Manifest | null): Promise<CheckForUpdateResult> {
   log.info('checkForUpdate() called, currentStatus=%s', currentStatus);
+  // 先跟共享设置对一次有效渠道:共库另一实例改过开关时,本进程内存代际还停在旧值。
+  if (syncObservedUpdateChannel()) {
+    log.info('shared update channel changed — discarding staged patch before check');
+    clearStagedPatch();
+    return 'idle';
+  }
   // 快照发起时的渠道代际;下载期间若用户 opt-out(clearStagedPatch 递增),
   // 成功/失败写回前都据此作废本次产物。
   const channelEpochAtStart = updateChannelEpoch;
@@ -1222,6 +1244,14 @@ function executeRelaunch(theme: 'light' | 'dark'): void {
     return;
   }
 
+  if (syncObservedUpdateChannel()) {
+    log.info('executeRelaunch() aborted — shared update channel changed');
+    isRelaunching = false;
+    autoRelaunchInProgress = false;
+    clearStagedPatch();
+    return;
+  }
+
   log.info('executeRelaunch() called, theme=%s, readyFilePath=%s', theme, maskPath(readyFilePath));
   if (!readyFilePath || !fs.existsSync(readyFilePath)) {
     log.error('No ready update file to apply');
@@ -1348,6 +1378,7 @@ export function initUpdateService(): void {
     //   拉取失败时 checkExistingPatch() 会兜底把用户装到 release 版本。
     // 切渠道不等于切版本,两个方向都要清。
     if (wasBeta !== next) {
+      observedEnableBeta = next;
       clearStagedPatch();
     }
     return channelSettingsWire();
@@ -1359,6 +1390,7 @@ export function initUpdateService(): void {
     await resetUpdateChannelSettings();
     // 恢复默认 = 关闭 beta;同 set(false),渠道变化即作废已 staged 的补丁。
     if (wasBeta) {
+      observedEnableBeta = false;
       clearStagedPatch();
     }
     return channelSettingsWire();
@@ -1538,6 +1570,7 @@ export function initUpdateService(): void {
     }, POLL_INTERVAL_MS);
   }, FIRST_CHECK_DELAY_MS);
 
+  observedEnableBeta = readUpdateChannelSettings().enableBeta;
   log.info('Initialized — first check in 10s, polling every 30min');
 }
 
@@ -1552,6 +1585,7 @@ export async function enableUncustomizedBetaChannel(
   const wasBeta = readUpdateChannelSettings().enableBeta;
   const wrote = await tryEnableUncustomizedBetaAtomic(shouldWrite);
   if (wrote && !wasBeta) {
+    observedEnableBeta = true;
     // 真正开始应用时 clearStagedPatch 会跳过;资格检查中会记下,结束后再补清。
     clearStagedPatch();
     broadcastChannelSettings();

--- a/apps/desktop/src/main/updateService.ts
+++ b/apps/desktop/src/main/updateService.ts
@@ -593,6 +593,10 @@ function checkExistingPatch(): { action: 'relaunch' | 'check' | 'none'; version?
     );
     try { fs.unlinkSync(patchFilePath); } catch { /* ignore */ }
     removePatchInfo();
+    const flag = readReloginFlag();
+    if (flag?.version === patchInfo.version) {
+      clearReloginFlag();
+    }
     return { action: 'check' };
   }
 

--- a/apps/desktop/src/main/updateService.ts
+++ b/apps/desktop/src/main/updateService.ts
@@ -1306,10 +1306,15 @@ function executeRelaunch(theme: 'light' | 'dark'): void {
     return;
   }
 
-  if (syncObservedUpdateChannel()) {
-    log.info('executeRelaunch() aborted — shared update channel changed');
+  if (syncObservedUpdateChannel() || deferredStagedPatch) {
+    log.info(
+      deferredStagedPatch
+        ? 'executeRelaunch() aborted — update channel changed during eligibility check'
+        : 'executeRelaunch() aborted — shared update channel changed',
+    );
     isRelaunching = false;
     autoRelaunchInProgress = false;
+    // 标志先放下,否则 clearStagedPatch 会当成 apply 已提交而跳过。
     clearStagedPatch();
     return;
   }
@@ -1433,15 +1438,17 @@ export function initUpdateService(): void {
       throwIpcError('INVALID_PARAMS', 'enableBeta required (boolean)');
     }
     const wasBeta = readUpdateChannelSettings().enableBeta;
-    await writeEnableBeta(next);
-    // 渠道一变(无论 opt-in 还是 opt-out)就作废已 staged 的旧渠道补丁:
-    // - opt-out(beta→release):否则用户关掉 beta 后仍被装到 beta 版本;
-    // - opt-in(release→beta):否则旧 release 补丁仍 staged,重启后 beta manifest
-    //   拉取失败时 checkExistingPatch() 会兜底把用户装到 release 版本。
-    // 切渠道不等于切版本,两个方向都要清。
+    // 先作废旧补丁再等落盘:writeEnableBeta 可能卡住跨进程锁,这段空窗里
+    // busyProbe 若返回,资格检查仍会看到旧渠道+旧 zip 并提交 apply。
     if (wasBeta !== next) {
       observedEnableBeta = next;
       clearStagedPatch();
+    }
+    try {
+      await writeEnableBeta(next);
+    } catch (err) {
+      log.error('writeEnableBeta failed:', err);
+      throwIpcError('INTERNAL', 'failed to write update channel settings');
     }
     return channelSettingsWire();
   });
@@ -1449,11 +1456,15 @@ export function initUpdateService(): void {
   ipcMain.handle('update-channel-settings-reset', async (event) => {
     assertTrustedAppRendererEvent(event);
     const wasBeta = readUpdateChannelSettings().enableBeta;
-    await resetUpdateChannelSettings();
-    // 恢复默认 = 关闭 beta;同 set(false),渠道变化即作废已 staged 的补丁。
     if (wasBeta) {
       observedEnableBeta = false;
       clearStagedPatch();
+    }
+    try {
+      await resetUpdateChannelSettings();
+    } catch (err) {
+      log.error('resetUpdateChannelSettings failed:', err);
+      throwIpcError('INTERNAL', 'failed to reset update channel settings');
     }
     return channelSettingsWire();
   });
@@ -1647,11 +1658,14 @@ export async function enableUncustomizedBetaChannel(
   shouldWrite: () => boolean = () => true,
 ): Promise<boolean> {
   const wasBeta = readUpdateChannelSettings().enableBeta;
+  // 先作废旧补丁再等落盘,避免原子写等待期间自动重启把旧渠道包装上去。
+  // 没真正写成开之前,不要把 observedEnableBeta 提前改成 true。
+  if (!wasBeta) {
+    clearStagedPatch();
+  }
   const wrote = await tryEnableUncustomizedBetaAtomic(shouldWrite);
   if (wrote && !wasBeta) {
     observedEnableBeta = true;
-    // 真正开始应用时 clearStagedPatch 会跳过;资格检查中会记下,结束后再补清。
-    clearStagedPatch();
     broadcastChannelSettings();
   }
   return wrote;

--- a/apps/desktop/src/main/updateService.ts
+++ b/apps/desktop/src/main/updateService.ts
@@ -153,6 +153,8 @@ let autoRelaunchPollTimer: ReturnType<typeof setInterval> | null = null;
 let isRelaunching = false;
 let lastErrorCode: string | undefined;
 let autoRelaunchInProgress = false;
+/** 资格检查(含异步 busyProbe)进行中的次数。清补丁必须避开这个窗口。 */
+let autoRelaunchDecisionDepth = 0;
 let lastAutoRelaunchBlockReason: AutoRelaunchBlockReason | null = null;
 let lastBusyAtMs: number | null = null;
 let lastResumeAtMs: number | null = null;
@@ -311,24 +313,36 @@ async function requestAutoRelaunch(
 ): Promise<AutoRelaunchRequestResult> {
   // The startup/splash apply path uses the lighter gate (no idle/busy checks —
   // nothing is in flight at launch); background triggers keep the full policy.
-  const blockReason = useStartupPolicy
-    ? await getStartupRelaunchBlockReason()
-    : await getAutoRelaunchBlockReasonForCurrentState();
-  if (blockReason) {
-    if (blockReason !== lastAutoRelaunchBlockReason) {
-      lastAutoRelaunchBlockReason = blockReason;
-      if (readAutoUpdateSettings().autoRelaunchOnIdle && currentStatus === 'ready') {
-        log.info('auto relaunch blocked (%s)', blockReason);
+  // 资格检查开始就抬深度:后台路径会 await busyProbe,这段空窗里 clearStagedPatch
+  // 若放行,随后 executeRelaunch 会走 no_ready_file。
+  autoRelaunchDecisionDepth += 1;
+  try {
+    const blockReason = useStartupPolicy
+      ? await getStartupRelaunchBlockReason()
+      : await getAutoRelaunchBlockReasonForCurrentState();
+    if (blockReason) {
+      if (blockReason !== lastAutoRelaunchBlockReason) {
+        lastAutoRelaunchBlockReason = blockReason;
+        if (readAutoUpdateSettings().autoRelaunchOnIdle && currentStatus === 'ready') {
+          log.info('auto relaunch blocked (%s)', blockReason);
+        }
       }
+      return { accepted: false, blockReason };
     }
-    return { accepted: false, blockReason };
-  }
 
-  lastAutoRelaunchBlockReason = null;
-  autoRelaunchInProgress = true;
-  log.info('auto relaunch conditions met (%s), applying update v%s', reason, readyVersion ?? '<unknown>');
-  executeRelaunch(theme);
-  return { accepted: true };
+    if (!readyFilePath || !fs.existsSync(readyFilePath)) {
+      log.info('auto relaunch aborted — staged patch disappeared during eligibility check');
+      return { accepted: false, blockReason: 'not-ready' };
+    }
+
+    lastAutoRelaunchBlockReason = null;
+    autoRelaunchInProgress = true;
+    log.info('auto relaunch conditions met (%s), applying update v%s', reason, readyVersion ?? '<unknown>');
+    executeRelaunch(theme);
+    return { accepted: true };
+  } finally {
+    autoRelaunchDecisionDepth = Math.max(0, autoRelaunchDecisionDepth - 1);
+  }
 }
 
 async function evaluateAutoRelaunch(reason: string): Promise<void> {
@@ -560,7 +574,7 @@ function removePatchInfo(): void {
 }
 
 function isUpdateApplyInFlight(): boolean {
-  return isRelaunching || autoRelaunchInProgress;
+  return isRelaunching || autoRelaunchInProgress || autoRelaunchDecisionDepth > 0;
 }
 
 /**

--- a/apps/desktop/src/main/updateService.ts
+++ b/apps/desktop/src/main/updateService.ts
@@ -180,6 +180,22 @@ function broadcastStatus(payload: UpdateStatusPayload): void {
   }
 }
 
+function channelSettingsWire() {
+  return {
+    enableBeta: readUpdateChannelSettings().enableBeta,
+    isCustomized: isEnableBetaUserCustomized(),
+  };
+}
+
+function broadcastChannelSettings(): void {
+  const payload = channelSettingsWire();
+  for (const win of BrowserWindow.getAllWindows()) {
+    if (!win.isDestroyed()) {
+      win.webContents.send('update-channel-settings', payload);
+    }
+  }
+}
+
 function setStatus(status: UpdateStatus, extra?: Partial<UpdateStatusPayload>): void {
   currentStatus = status;
   lastErrorCode = extra?.errorCode;
@@ -330,6 +346,11 @@ async function requestAutoRelaunch(
         }
       }
       return { accepted: false, blockReason };
+    }
+
+    if (stagedPatchClearDeferred) {
+      log.info('auto relaunch aborted — update channel changed during eligibility check');
+      return { accepted: false, blockReason: 'not-ready' };
     }
 
     if (!readyFilePath || !fs.existsSync(readyFilePath)) {
@@ -582,6 +603,11 @@ function isUpdateApplyCommitted(): boolean {
   return isRelaunching || autoRelaunchInProgress;
 }
 
+function invalidateInFlightChannelDownloads(): void {
+  updateChannelEpoch += 1;
+  clearCachedManifest();
+}
+
 function flushDeferredStagedPatchClear(): void {
   if (!stagedPatchClearDeferred) return;
   if (isUpdateApplyCommitted() || autoRelaunchDecisionDepth > 0) return;
@@ -603,6 +629,8 @@ function clearStagedPatch(): void {
   }
   if (autoRelaunchDecisionDepth > 0) {
     stagedPatchClearDeferred = true;
+    // 立刻作废旧渠道 in-flight 下载,避免下载完成后又把旧补丁写成 ready。
+    invalidateInFlightChannelDownloads();
     log.info('deferring staged patch clear until auto-relaunch eligibility settles');
     return;
   }
@@ -612,12 +640,7 @@ function clearStagedPatch(): void {
   readyVersion = undefined;
   readyFilePath = undefined;
   removePatchInfo();
-  // 递增代际:任何 in-flight 的 checkForUpdate 在写回 patch 前都会看到代际变化,
-  // 从而放弃本次(基于旧渠道的)下载产物,不把 beta patch 重新落盘。
-  updateChannelEpoch += 1;
-  // 切渠道后旧渠道的 manifest 缓存作废:否则 agent 二进制 prepare 先
-  // getCachedManifest() 会继续按旧渠道的版本号/下载地址安装资产。
-  clearCachedManifest();
+  invalidateInFlightChannelDownloads();
   // downloading 也要重置:opt-out 若发生在「首次 beta 下载进行中」,status 仍是
   // downloading;不 reset 的话,in-flight 下载完成后 discard 分支只是 `return 'idle'`
   // 而不 setStatus,update-get-status / update-check-now 会永远卡在 downloading。
@@ -1296,10 +1319,7 @@ export function initUpdateService(): void {
   // 更新设置或重启应用(旧 update-auto-settings 没断言是历史债,不构成豁免)。
   ipcMain.handle('update-channel-settings-get', (event) => {
     assertTrustedAppRendererEvent(event);
-    return {
-      enableBeta: readUpdateChannelSettings().enableBeta,
-      isCustomized: isEnableBetaUserCustomized(),
-    };
+    return channelSettingsWire();
   });
 
   ipcMain.handle('update-channel-settings-set', (event, payload: unknown) => {
@@ -1321,10 +1341,7 @@ export function initUpdateService(): void {
     if (wasBeta !== next) {
       clearStagedPatch();
     }
-    return {
-      enableBeta: readUpdateChannelSettings().enableBeta,
-      isCustomized: isEnableBetaUserCustomized(),
-    };
+    return channelSettingsWire();
   });
 
   ipcMain.handle('update-channel-settings-reset', (event) => {
@@ -1335,10 +1352,7 @@ export function initUpdateService(): void {
     if (wasBeta) {
       clearStagedPatch();
     }
-    return {
-      enableBeta: readUpdateChannelSettings().enableBeta,
-      isCustomized: isEnableBetaUserCustomized(),
-    };
+    return channelSettingsWire();
   });
 
   // 打开 beta 前的预检:探测 manifest-{platform}-beta.json 是否可达。
@@ -1529,6 +1543,7 @@ export function enableUncustomizedBetaChannel(): boolean {
   if (wrote && !wasBeta) {
     // 真正开始应用时 clearStagedPatch 会跳过;资格检查中会记下,结束后再补清。
     clearStagedPatch();
+    broadcastChannelSettings();
   }
   return wrote;
 }

--- a/apps/desktop/src/main/updateService.ts
+++ b/apps/desktop/src/main/updateService.ts
@@ -372,7 +372,7 @@ async function requestAutoRelaunch(
       return { accepted: false, blockReason: 'not-ready' };
     }
 
-    if (deferredStagedPatch) {
+    if (shouldAbortStagedPatchApply()) {
       log.info('auto relaunch aborted — update channel changed during eligibility check');
       return { accepted: false, blockReason: 'not-ready' };
     }
@@ -647,11 +647,18 @@ function invalidateInFlightChannelDownloads(): void {
 }
 
 function syncObservedUpdateChannel(): boolean {
+  if (pendingChannelChangeHolds > 0) return false;
   const enableBeta = readUpdateChannelSettings().enableBeta;
   if (enableBeta === observedEnableBeta) return false;
   observedEnableBeta = enableBeta;
   invalidateInFlightChannelDownloads();
   return true;
+}
+
+function shouldAbortStagedPatchApply(): boolean {
+  if (pendingChannelChangeHolds > 0) return true;
+  if (!deferredStagedPatch) return false;
+  return !isCurrentPatchNewerThanDeferred(deferredStagedPatch);
 }
 
 function rememberDeferredStagedPatch(): void {
@@ -721,6 +728,7 @@ function discardStagedPatchFiles(): void {
 function flushDeferredStagedPatchClear(): void {
   if (!deferredStagedPatch) return;
   if (isUpdateApplyCommitted() || autoRelaunchDecisionDepth > 0) return;
+  if (pendingChannelChangeHolds > 0) return;
   const stale = deferredStagedPatch;
   if (currentStatus === 'downloading' || currentStatus === 'superseding') {
     // 新渠道下载还在飞:不要再推进代际,也不要删同路径 dest。
@@ -1362,14 +1370,22 @@ function executeRelaunch(theme: 'light' | 'dark'): void {
     return;
   }
 
-  if (syncObservedUpdateChannel() || deferredStagedPatch) {
+  if (syncObservedUpdateChannel() || shouldAbortStagedPatchApply()) {
+    const pendingHold = pendingChannelChangeHolds > 0;
     log.info(
-      deferredStagedPatch
+      pendingHold || shouldAbortStagedPatchApply()
         ? 'executeRelaunch() aborted — update channel changed during eligibility check'
         : 'executeRelaunch() aborted — shared update channel changed',
     );
     isRelaunching = false;
     autoRelaunchInProgress = false;
+    // 写入还没落盘,或当前已经是新渠道补丁:只拦住 apply,别把 zip 清掉。
+    if (
+      pendingHold
+      || (deferredStagedPatch && isCurrentPatchNewerThanDeferred(deferredStagedPatch))
+    ) {
+      return;
+    }
     // 标志先放下,否则 clearStagedPatch 会当成 apply 已提交而跳过。
     clearStagedPatch();
     return;

--- a/apps/desktop/src/main/updateService.ts
+++ b/apps/desktop/src/main/updateService.ts
@@ -647,6 +647,23 @@ function isCurrentPatchNewerThanDeferred(
   return Boolean(readyFilePath && readyFilePath !== stale.path);
 }
 
+function discardStagedPatchFiles(): void {
+  if (readyFilePath) {
+    try { fs.unlinkSync(readyFilePath); } catch { /* ignore */ }
+  }
+  readyVersion = undefined;
+  readyFilePath = undefined;
+  readyChannelEpoch = undefined;
+  removePatchInfo();
+  if (
+    currentStatus === 'ready' ||
+    currentStatus === 'superseding' ||
+    currentStatus === 'downloading'
+  ) {
+    setStatus('idle');
+  }
+}
+
 function flushDeferredStagedPatchClear(): void {
   if (!deferredStagedPatch) return;
   if (isUpdateApplyCommitted() || autoRelaunchDecisionDepth > 0) return;
@@ -659,7 +676,26 @@ function flushDeferredStagedPatchClear(): void {
     }
     return;
   }
-  clearStagedPatch();
+  if (currentStatus === 'downloading' || currentStatus === 'superseding') {
+    // 新渠道下载还在飞:不要再推进代际,也不要删同路径 dest。
+    if (readyChannelEpoch === stale.epoch) {
+      readyVersion = undefined;
+      readyFilePath = undefined;
+      readyChannelEpoch = undefined;
+    }
+    return;
+  }
+  discardStagedPatchFiles();
+}
+
+/**
+ * 渠道切换重启前把未应用的旧补丁从盘上拿掉。
+ * 延迟清理只活在内存里,这里不补清的话,下次启动仍可能把旧渠道 zip 当匹配补丁装上。
+ */
+function discardUnappliedStagedPatchForChannelRelaunch(): void {
+  if (isUpdateApplyCommitted()) return;
+  deferredStagedPatch = undefined;
+  discardStagedPatchFiles();
 }
 
 /**
@@ -667,7 +703,8 @@ function flushDeferredStagedPatchClear(): void {
  * 切渠道时调用——opt-out 后不能仍让 staged 的旧渠道 patch 在下次启动/后台
  * 轮询里被装上去(切渠道不等于切版本,必须把旧渠道的补丁作废)。
  * 已经开始应用时不能清,否则 executeRelaunch 会走 no_ready_file。
- * 资格检查还在等 busyProbe 时先记下,检查结束后若没真正开始应用再补清。
+ * 资格检查还在等 busyProbe 时先记下 zip,但立刻丢掉 patch-info,
+ * 避免用户马上切渠道重启后旧补丁跨进程复活。
  */
 function clearStagedPatch(): void {
   if (isUpdateApplyCommitted()) {
@@ -678,27 +715,13 @@ function clearStagedPatch(): void {
     rememberDeferredStagedPatch();
     // 立刻作废旧渠道 in-flight 下载,避免下载完成后又把旧补丁写成 ready。
     invalidateInFlightChannelDownloads();
+    // patch-info 立刻拿掉:渠道重启走 app.quit(),等不到 probe/finally。
+    removePatchInfo();
     log.info('deferring staged patch clear until auto-relaunch eligibility settles');
     return;
   }
-  if (readyFilePath) {
-    try { fs.unlinkSync(readyFilePath); } catch { /* ignore */ }
-  }
-  readyVersion = undefined;
-  readyFilePath = undefined;
-  readyChannelEpoch = undefined;
-  removePatchInfo();
   invalidateInFlightChannelDownloads();
-  // downloading 也要重置:opt-out 若发生在「首次 beta 下载进行中」,status 仍是
-  // downloading;不 reset 的话,in-flight 下载完成后 discard 分支只是 `return 'idle'`
-  // 而不 setStatus,update-get-status / update-check-now 会永远卡在 downloading。
-  if (
-    currentStatus === 'ready' ||
-    currentStatus === 'superseding' ||
-    currentStatus === 'downloading'
-  ) {
-    setStatus('idle');
-  }
+  discardStagedPatchFiles();
 }
 
 function incrementApplyAttempts(): void {
@@ -861,6 +884,7 @@ async function doCheckForUpdate(manifestOverride?: Manifest | null): Promise<Che
   const wasReady = currentStatus === 'ready';
   const previousReadyVersion = wasReady ? readyVersion : undefined;
   const previousReadyFilePath = wasReady ? readyFilePath : undefined;
+  const previousReadyChannelEpoch = wasReady ? readyChannelEpoch : undefined;
 
   // 只有非 ready 路径才广播 'checking' — wasReady 路径下广播 checking 会让 banner
   // 的可见条件(status === 'ready' || 'superseding')瞬间不满足,banner 抖一下。
@@ -1062,7 +1086,7 @@ async function doCheckForUpdate(manifestOverride?: Manifest | null): Promise<Che
       log.info('Superseding download failed — rolling back to ready v%s', previousReadyVersion);
       readyVersion = previousReadyVersion;
       readyFilePath = previousReadyFilePath;
-      readyChannelEpoch = channelEpochAtStart;
+      readyChannelEpoch = previousReadyChannelEpoch;
       setStatus('ready', { version: previousReadyVersion });
       return 'ready';
     }
@@ -1436,6 +1460,7 @@ export function initUpdateService(): void {
   ipcMain.handle('update-channel-relaunch', (event) => {
     assertTrustedAppRendererEvent(event);
     log.info('relaunch requested for update channel change');
+    discardUnappliedStagedPatchForChannelRelaunch();
     app.relaunch();
     app.quit();
   });

--- a/apps/desktop/src/main/updateService.ts
+++ b/apps/desktop/src/main/updateService.ts
@@ -44,6 +44,7 @@ import {
   readUpdateChannelSettings,
   readUpdateChannelSettingsState,
   resetUpdateChannelSettings,
+  tryEnableUncustomizedBeta,
   writeEnableBeta,
 } from './updateChannelStore';
 import { assertTrustedAppRendererEvent } from './security/trustedAppRenderer';
@@ -1468,6 +1469,20 @@ export function initUpdateService(): void {
   }, FIRST_CHECK_DELAY_MS);
 
   log.info('Initialized — first check in 10s, polling every 30min');
+}
+
+/**
+ * 登录态落地后给尚未自定义过开关的设备打开 beta。
+ * 渠道从关变开时作废已 staged 的旧渠道补丁,与设置页手动打开同一口径。
+ * 不 relaunch:本次进程继续走当前通道,下次冷启动 / 用户自行重启再生效。
+ */
+export function enableUncustomizedBetaChannel(): boolean {
+  const wasBeta = readUpdateChannelSettings().enableBeta;
+  const wrote = tryEnableUncustomizedBeta();
+  if (wrote && !wasBeta) {
+    clearStagedPatch();
+  }
+  return wrote;
 }
 
 export function stopUpdateService(): void {

--- a/apps/desktop/src/main/updateService.ts
+++ b/apps/desktop/src/main/updateService.ts
@@ -668,20 +668,21 @@ function flushDeferredStagedPatchClear(): void {
   if (!deferredStagedPatch) return;
   if (isUpdateApplyCommitted() || autoRelaunchDecisionDepth > 0) return;
   const stale = deferredStagedPatch;
+  if (currentStatus === 'downloading' || currentStatus === 'superseding') {
+    // 新渠道下载还在飞:不要再推进代际,也不要删同路径 dest。
+    // 标记先留着——下载失败若把旧补丁快照写回来,后续还能再清。
+    if (readyChannelEpoch === stale.epoch) {
+      readyVersion = undefined;
+      readyFilePath = undefined;
+      readyChannelEpoch = undefined;
+    }
+    return;
+  }
   deferredStagedPatch = undefined;
   if (isCurrentPatchNewerThanDeferred(stale)) {
     log.info('keeping newer staged patch after deferred channel-change clear');
     if (stale.path && stale.path !== readyFilePath) {
       try { fs.unlinkSync(stale.path); } catch { /* ignore */ }
-    }
-    return;
-  }
-  if (currentStatus === 'downloading' || currentStatus === 'superseding') {
-    // 新渠道下载还在飞:不要再推进代际,也不要删同路径 dest。
-    if (readyChannelEpoch === stale.epoch) {
-      readyVersion = undefined;
-      readyFilePath = undefined;
-      readyChannelEpoch = undefined;
     }
     return;
   }
@@ -1077,9 +1078,20 @@ async function doCheckForUpdate(manifestOverride?: Manifest | null): Promise<Che
     // readyFilePath 全都没动过,直接重新广播 ready 让 banner 按钮从 loading 恢复成可点。
     // 下一次 30min 轮询会再次尝试 b。
     if (wasReady) {
-      // 下载期间用户切渠道:旧 patch 已被 clearStagedPatch 清掉,不能恢复。
-      if (channelEpochAtStart !== updateChannelEpoch) {
+      // 下载期间用户切渠道:旧 patch 已被作废,不能从局部快照恢复。
+      // 代际在下载开始前就可能已经推进过,所以还要看旧补丁自己的代际。
+      const staleChannelPatch =
+        channelEpochAtStart !== updateChannelEpoch ||
+        (previousReadyChannelEpoch != null && previousReadyChannelEpoch !== updateChannelEpoch);
+      if (staleChannelPatch) {
         log.info('update channel changed during superseding download — not restoring stale patch');
+        if (previousReadyFilePath) {
+          try { fs.unlinkSync(previousReadyFilePath); } catch { /* ignore */ }
+        }
+        readyVersion = undefined;
+        readyFilePath = undefined;
+        readyChannelEpoch = undefined;
+        removePatchInfo();
         setStatus('idle');
         return 'idle';
       }

--- a/apps/desktop/src/main/xdOrgBetaDefault.ts
+++ b/apps/desktop/src/main/xdOrgBetaDefault.ts
@@ -24,6 +24,7 @@ export interface XdOrgBetaUser {
 
 export interface XdOrgBetaChannelState {
   enableBeta: boolean;
+  /** 用户是否显式拨过开关。组织默认写入不算。 */
   isCustomized: boolean;
 }
 

--- a/apps/desktop/src/main/xdOrgBetaDefault.ts
+++ b/apps/desktop/src/main/xdOrgBetaDefault.ts
@@ -38,7 +38,7 @@ export interface XdOrgBetaDefaultDeps {
   readCurrentAuthIdentity(): { authEpoch: number; userId: string | null };
   readChannelState(): XdOrgBetaChannelState;
   probeBetaManifest(): Promise<boolean>;
-  enableBeta(): void;
+  enableBeta(): boolean | Promise<boolean>;
 }
 
 export type XdOrgBetaDefaultOutcome =
@@ -102,6 +102,11 @@ export async function maybeEnableXdOrgBetaDefault(
     return { kind: 'skipped', reason: 'stale-auth' };
   }
 
-  deps.enableBeta();
+  const wrote = await deps.enableBeta();
+  if (!wrote) {
+    const latest = deps.readChannelState();
+    if (latest.enableBeta) return { kind: 'skipped', reason: 'already-enabled' };
+    return { kind: 'skipped', reason: 'user-customized' };
+  }
   return { kind: 'enabled' };
 }

--- a/apps/desktop/src/main/xdOrgBetaDefault.ts
+++ b/apps/desktop/src/main/xdOrgBetaDefault.ts
@@ -1,0 +1,106 @@
+/**
+ * xdOrgBetaDefault — 心动 / xd 组织的 beta 测试渠道默认打开策略。
+ *
+ * beta 本身是设备级本地开关(update-channel-settings.json,登出不清)。
+ * 这里只在 cloud 登录态落地后补一次默认值:
+ *   - 仅 xd 组织账号;
+ *   - 用户从没改过这个开关(isCustomized === false);
+ *   - 当前仍是关的;
+ *   - CDN 上 beta manifest 可达。
+ *
+ * 用户手动关掉后 isCustomized 为 true,重启 / 重登都不再打开。
+ * 真正的发布通道切换仍留给下次 fetchManifest / 用户自行重启,这里不 relaunch。
+ */
+
+export const XD_ORG_SLUG = 'xd';
+
+const XD_ORG_NAME_FALLBACKS = new Set(['xd', '心动网络']);
+
+export interface XdOrgBetaUser {
+  membershipKind: 'personal' | 'org';
+  orgSlug: string | null;
+  orgName: string | null;
+}
+
+export interface XdOrgBetaChannelState {
+  enableBeta: boolean;
+  isCustomized: boolean;
+}
+
+export interface XdOrgBetaDefaultRequest {
+  expectedAuthEpoch: number;
+  expectedUserId: string;
+  user: XdOrgBetaUser;
+}
+
+export interface XdOrgBetaDefaultDeps {
+  readCurrentAuthIdentity(): { authEpoch: number; userId: string | null };
+  readChannelState(): XdOrgBetaChannelState;
+  probeBetaManifest(): Promise<boolean>;
+  enableBeta(): void;
+}
+
+export type XdOrgBetaDefaultOutcome =
+  | { kind: 'enabled' }
+  | {
+      kind: 'skipped';
+      reason:
+        | 'not-xd-org'
+        | 'already-enabled'
+        | 'user-customized'
+        | 'beta-unavailable'
+        | 'stale-auth';
+    };
+
+/** 当前登录用户是否是 xd 组织。orgSlug 优先,旧 token 才回退显示名。 */
+export function isXdOrgUser(user: XdOrgBetaUser | null | undefined): boolean {
+  if (!user || user.membershipKind !== 'org') return false;
+  if (user.orgSlug !== null) return user.orgSlug === XD_ORG_SLUG;
+  const name = user.orgName?.trim().toLocaleLowerCase();
+  return name !== undefined && XD_ORG_NAME_FALLBACKS.has(name);
+}
+
+function isCurrentAuth(request: XdOrgBetaDefaultRequest, deps: XdOrgBetaDefaultDeps): boolean {
+  const current = deps.readCurrentAuthIdentity();
+  return current.authEpoch === request.expectedAuthEpoch && current.userId === request.expectedUserId;
+}
+
+/**
+ * 登录态落地后尝试为 xd 组织打开设备级 beta。
+ * 任何「不应改用户选择 / 身份已变 / CDN 不可达」的情况都 skip,不写盘。
+ */
+export async function maybeEnableXdOrgBetaDefault(
+  request: XdOrgBetaDefaultRequest,
+  deps: XdOrgBetaDefaultDeps,
+): Promise<XdOrgBetaDefaultOutcome> {
+  if (!isXdOrgUser(request.user)) {
+    return { kind: 'skipped', reason: 'not-xd-org' };
+  }
+  if (!isCurrentAuth(request, deps)) {
+    return { kind: 'skipped', reason: 'stale-auth' };
+  }
+
+  const state = deps.readChannelState();
+  if (state.enableBeta) {
+    return { kind: 'skipped', reason: 'already-enabled' };
+  }
+  if (state.isCustomized) {
+    return { kind: 'skipped', reason: 'user-customized' };
+  }
+
+  let available = false;
+  try {
+    available = await deps.probeBetaManifest();
+  } catch {
+    return { kind: 'skipped', reason: 'beta-unavailable' };
+  }
+  if (!available) {
+    return { kind: 'skipped', reason: 'beta-unavailable' };
+  }
+  if (!isCurrentAuth(request, deps)) {
+    return { kind: 'skipped', reason: 'stale-auth' };
+  }
+
+  deps.enableBeta();
+  return { kind: 'enabled' };
+}

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -385,6 +385,7 @@ function createIpcFanOut(channel: string): FanOut {
 // Stage 2 C1: cc-agent:* push channel fanout 全部退役 (renderer 已切到 maker:event 等),
 // 老 7 个 fanOut + fanOutUserMessagePersisted 一起拿掉。
 const fanOutUpdateStatus = createIpcFanOut('update-status');
+const fanOutUpdateChannelSettings = createIpcFanOut('update-channel-settings');
 const fanOutOrcaWorkerChanged = createIpcFanOut('maker:orca:worker-changed');
 // 右侧栏独立子窗口(RSB window)状态 / 上下文 / 命令推送
 const fanOutRsbWindowStateChanged = createIpcFanOut('maker:rsb-window:state-changed');
@@ -3725,6 +3726,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   // ── App Update (F2/F4) ──
 
   onUpdateStatus: fanOutUpdateStatus,
+  onUpdateChannelSettings: fanOutUpdateChannelSettings,
 
   checkForUpdate: (): Promise<{
     result:

--- a/apps/desktop/src/renderer/components/settings/BetaChannelCell.tsx
+++ b/apps/desktop/src/renderer/components/settings/BetaChannelCell.tsx
@@ -17,6 +17,7 @@ import { cn } from '@/lib/utils';
 import { toast } from '@/lib/toast';
 import { useConfirmDialog } from '@/components/ui/confirm-dialog-provider';
 import { useBetaChannelSettings } from '@/hooks/useBetaChannelSettings';
+import { mapIpcErrorToI18nKey } from '@/utils/ipcError';
 
 export function BetaChannelCell() {
   const { t } = useTranslation();
@@ -71,9 +72,7 @@ export function BetaChannelCell() {
         }
       } catch (err) {
         toast.error(
-          err instanceof Error
-            ? err.message
-            : t('settings.betaChannel.toast.toggleFailed'),
+          t(mapIpcErrorToI18nKey(err, { fallback: 'settings.betaChannel.toast.toggleFailed' })),
         );
       } finally {
         setPending(false);

--- a/apps/desktop/src/renderer/hooks/useBetaChannelSettings.ts
+++ b/apps/desktop/src/renderer/hooks/useBetaChannelSettings.ts
@@ -46,8 +46,12 @@ export function useBetaChannelSettings(): {
       .catch(() => {
         if (!cancelled) setState((current) => ({ ...current, loading: false }));
       });
+    const unsubscribe = window.electronAPI.onUpdateChannelSettings((payload) => {
+      if (!cancelled) setState(normalize(payload));
+    });
     return () => {
       cancelled = true;
+      unsubscribe();
     };
   }, []);
 

--- a/apps/desktop/src/renderer/hooks/useBetaChannelSettings.ts
+++ b/apps/desktop/src/renderer/hooks/useBetaChannelSettings.ts
@@ -38,16 +38,21 @@ export function useBetaChannelSettings(): {
 
   useEffect(() => {
     let cancelled = false;
+    let latestSeq = 0;
     void window.electronAPI
       .getUpdateChannelSettings()
       .then((payload) => {
-        if (!cancelled) setState(normalize(payload));
+        if (cancelled || latestSeq !== 0) return;
+        setState(normalize(payload));
       })
       .catch(() => {
-        if (!cancelled) setState((current) => ({ ...current, loading: false }));
+        if (cancelled || latestSeq !== 0) return;
+        setState((current) => ({ ...current, loading: false }));
       });
     const unsubscribe = window.electronAPI.onUpdateChannelSettings((payload) => {
-      if (!cancelled) setState(normalize(payload));
+      if (cancelled) return;
+      latestSeq += 1;
+      setState(normalize(payload));
     });
     return () => {
       cancelled = true;

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -12,7 +12,8 @@
     "REMOTE_PROVIDER_UPDATING": "Provider credentials are being updated — retry in a moment",
     "REMOTE_PROVIDER_UNSUPPORTED": "This provider is not supported in SSH remote sessions — pick another source",
     "REMOTE_NATIVE_OAUTH_UNAVAILABLE": "Claude.ai subscription is not connected — connect it first or pick a gateway model",
-    "DEVICE_LINK_DEVICE_UNRESPONSIVE": "The target device is not responding. Check the remote device and try again."
+    "DEVICE_LINK_DEVICE_UNRESPONSIVE": "The target device is not responding. Check the remote device and try again.",
+    "INTERNAL": "Operation failed. Please try again later."
   },
   "providerError": {
     "AUTH_INVALID": "Invalid or expired API key (401). Check the key and try again",

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -12,7 +12,8 @@
     "REMOTE_PROVIDER_UPDATING": "プロバイダーの認証情報を更新中です。しばらくしてから再試行してください",
     "REMOTE_PROVIDER_UNSUPPORTED": "このプロバイダーは SSH リモートセッションに対応していません。別のソースを選択してください",
     "REMOTE_NATIVE_OAUTH_UNAVAILABLE": "Claude.ai サブスクリプションが未接続です。先に接続するか、ゲートウェイモデルを選択してください",
-    "DEVICE_LINK_DEVICE_UNRESPONSIVE": "対象デバイスが応答していません。リモートデバイスを確認して再試行してください。"
+    "DEVICE_LINK_DEVICE_UNRESPONSIVE": "対象デバイスが応答していません。リモートデバイスを確認して再試行してください。",
+    "INTERNAL": "操作に失敗しました。しばらくしてから再試行してください。"
   },
   "providerError": {
     "AUTH_INVALID": "API キーが無効か期限切れです（401）。キーを確認して再試行してください",

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -12,7 +12,8 @@
     "REMOTE_PROVIDER_UPDATING": "제공자 자격 증명을 업데이트하는 중입니다. 잠시 후 다시 시도하세요",
     "REMOTE_PROVIDER_UNSUPPORTED": "이 제공자는 SSH 원격 세션을 지원하지 않습니다. 다른 소스를 선택하세요",
     "REMOTE_NATIVE_OAUTH_UNAVAILABLE": "Claude.ai 구독이 연결되지 않았습니다. 먼저 연결하거나 게이트웨이 모델을 선택하세요",
-    "DEVICE_LINK_DEVICE_UNRESPONSIVE": "대상 장치가 응답하지 않습니다. 원격 장치를 확인한 후 다시 시도하세요."
+    "DEVICE_LINK_DEVICE_UNRESPONSIVE": "대상 장치가 응답하지 않습니다. 원격 장치를 확인한 후 다시 시도하세요.",
+    "INTERNAL": "작업에 실패했습니다. 잠시 후 다시 시도하세요."
   },
   "providerError": {
     "AUTH_INVALID": "API 키가 유효하지 않거나 만료되었습니다(401). 키를 확인한 후 다시 시도하세요",

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -9,6 +9,7 @@
     "REMOTE_PROVIDER_UNSUPPORTED": "该供应商不支持 SSH 远程会话，请更换来源",
     "REMOTE_NATIVE_OAUTH_UNAVAILABLE": "未连接 Claude.ai 订阅，请先连接或选择网关模型",
     "DEVICE_LINK_DEVICE_UNRESPONSIVE": "目标设备长时间无响应，请检查远程设备后重试",
+    "INTERNAL": "操作失败，请稍后重试。",
     "REMOTE_WORKDIR_INVALID": "远程项目目录无效，请重新选择项目目录。",
     "REMOTE_WORKDIR_NOT_FOUND": "远程项目目录不存在，请重新选择项目目录。",
     "REMOTE_WORKDIR_NOT_DIRECTORY": "远程项目路径不是文件夹，请重新选择项目目录。",

--- a/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
@@ -9,6 +9,7 @@
     "REMOTE_PROVIDER_UNSUPPORTED": "該供應商不支援 SSH 遠端會話，請更換來源",
     "REMOTE_NATIVE_OAUTH_UNAVAILABLE": "未連線 Claude.ai 訂閱，請先連線或選擇閘道器模型",
     "DEVICE_LINK_DEVICE_UNRESPONSIVE": "目標裝置長時間無響應，請檢查遠端裝置後重試",
+    "INTERNAL": "操作失敗，請稍後重試。",
     "REMOTE_WORKDIR_INVALID": "遠端專案目錄無效，請重新選擇專案目錄。",
     "REMOTE_WORKDIR_NOT_FOUND": "遠端專案目錄不存在，請重新選擇專案目錄。",
     "REMOTE_WORKDIR_NOT_DIRECTORY": "遠端專案路徑不是資料夾，請重新選擇專案目錄。",

--- a/apps/desktop/src/renderer/vite-env.d.ts
+++ b/apps/desktop/src/renderer/vite-env.d.ts
@@ -3435,6 +3435,9 @@ interface ElectronAPI {
   relaunchForChannelChange: () => Promise<void>;
   /** 打开 beta 前预检:探测 beta manifest 是否可达(HTTP 200)。 */
   probeBetaChannel: () => Promise<{ available: boolean }>;
+  onUpdateChannelSettings: (
+    callback: (payload: { enableBeta: boolean; isCustomized?: boolean }) => void,
+  ) => () => void;
   setUpdateRelaunchTheme: (theme: 'light' | 'dark') => void;
   // E4D 毛玻璃:family 切换/启动通知 main 开关 vibrancy(仅 CINDY 透壁纸)
   theme: { applyVibrancy: (familyId: string, isDark: boolean) => void };


### PR DESCRIPTION
## 这次改了什么

### 摘要

#2666 的 beta 测试渠道默认是关的。心动 / xd 组织成员在 cloud 登录态落地后（冷启动恢复、重新登录、换号），如果设备上从没改过这个开关，就默认打开。用户手动关掉后，重启和重登都不再打开。

真正切到 beta 通道仍要等下次拉 manifest 或用户自己重启，这次不自动 relaunch。

### 变更类型

- [x] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无；跟进 #2666
- 本 PR 包含：桌面端 xd 组织默认打开 beta，以及手动关闭后不再自动打开
- 明确不包含：手机端（beta store 还没有 `isCustomized`，现在一起改会盖掉手动关闭）；更新器进程；强制重启
- 用户可见变化：从没改过开关的 xd 组织用户，登录恢复后设置页「Beta 测试渠道」会被打开；再重启后才切通道
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：不涉及：没有改设置页布局、开关样式或文案，只在登录态落地后补写已有设备级开关。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop run typecheck
结果：通过

pnpm test:unit:related
结果：通过（含 xdOrgBetaDefault / updateChannelStore / authLoginFlowReset 相关单测）
```

### 手工验证

开发版登录态已核对：当前账号 `membershipKind === 'org' && orgSlug === 'xd'`。本次未在更新后的正式包上走完整「更新 → 重启 → 开关打开 → 再重启切通道」路径。

### 未执行的验证

未跑完整 `pnpm test:unit`（相关门禁已覆盖本次改动）。未做手机端验证。未做正式包更新后的实机通道切换验证。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [x] 其他：更新通道默认值。未改 cindy-updater / 更新器进程，只在登录恢复后补写设备级 `enableBeta`。

### 影响与回滚

- 影响范围：桌面端 xd 组织、且从未自定义过 beta 开关的设备。canary 优先级不变。用户手动关闭后保持关闭。
- 回滚 / 降级方式：回退本 PR 后不再自动打开。已写入的设备开关仍保留，用户可在设置页自行关闭。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因