### PR TITLE
feat(desktop): 发送快捷键新增「多行消息用 ⌘/Ctrl+Enter」挡位

### DIFF
--- a/apps/desktop/src/renderer/__tests__/chatInputSteerShortcut.test.ts
+++ b/apps/desktop/src/renderer/__tests__/chatInputSteerShortcut.test.ts
@@ -166,11 +166,14 @@ describe('ChatInput steer shortcut contract', () => {
     expect(chatInputSource).toContain('newChat.sendButton.queueTooltipSendMode');
     // Both keydown paths must feed the current draft shape into the resolver;
     // the render gate must refresh when the draft crosses the multiline boundary.
-    expect(chatInputSource).toContain('multilineDraft: isMultilineDraftDoc(view.state.doc)');
+    // The shared helper must also fold in the visible voice draft, which lives
+    // in a decoration and not yet in the editor doc.
+    expect(chatInputSource).toContain('multilineDraft: isComposerDraftMultiline(view.state.doc)');
     expect(chatInputSource).toContain(
-      'multilineDraft: composerDoc ? isMultilineDraftDoc(composerDoc) : false',
+      'multilineDraft: isComposerDraftMultiline(editorRef.current?.view.state.doc)',
     );
-    expect(chatInputSource).toContain('isMultilineDraftDoc(ed.state.doc)');
+    expect(chatInputSource).toContain('isComposerDraftMultiline(ed.state.doc)');
+    expect(chatInputSource).toContain("voiceDraftTextRef.current.includes('\\n')");
     expect(pendingQueuePanelSource).toContain('isPendingQueueSteerShortcut');
     expect(pendingQueuePanelSource).toContain('void onSteer(entry.clientId);');
   });

--- a/apps/desktop/src/renderer/__tests__/chatInputSteerShortcut.test.ts
+++ b/apps/desktop/src/renderer/__tests__/chatInputSteerShortcut.test.ts
@@ -173,7 +173,14 @@ describe('ChatInput steer shortcut contract', () => {
       'multilineDraft: isComposerDraftMultiline(editorRef.current?.view.state.doc)',
     );
     expect(chatInputSource).toContain('isComposerDraftMultiline(ed.state.doc)');
-    expect(chatInputSource).toContain("voiceDraftTextRef.current.includes('\\n')");
+    // 语音稿必须限定归属当前输入框(与 decoration 同一判据):源任务还在听写时
+    // 切走,目标输入框不能拿别人的多行稿子把自己的单行草稿判成多行。
+    expect(chatInputSource).toContain(
+      "(voiceBusyOnCurrentComposerRef.current && voiceDraftTextRef.current.includes('\\n'))",
+    );
+    expect(chatInputSource).toContain(
+      'voiceBusyOnCurrentComposerRef.current = voiceBusyOnCurrentComposer;',
+    );
     expect(chatInputSource).toContain('browserCommentsRef.current.length > 0');
     expect(pendingQueuePanelSource).toContain('isPendingQueueSteerShortcut');
     expect(pendingQueuePanelSource).toContain('void onSteer(entry.clientId);');

--- a/apps/desktop/src/renderer/__tests__/chatInputSteerShortcut.test.ts
+++ b/apps/desktop/src/renderer/__tests__/chatInputSteerShortcut.test.ts
@@ -101,18 +101,21 @@ describe('ChatInput steer shortcut contract', () => {
       resolveComposerEnterIntent(makeEnterEvent(), 'enter', {
         turnRunning: false,
         platform: 'darwin',
+        multilineDraft: false,
       }),
     ).toBe('queue');
     expect(
       resolveComposerEnterIntent(makeEnterEvent({ metaKey: true }), 'enter', {
         turnRunning: true,
         platform: 'darwin',
+        multilineDraft: false,
       }),
     ).toBe('steer');
     expect(
       resolveComposerEnterIntent(makeEnterEvent({ ctrlKey: true }), 'enter', {
         turnRunning: false,
         platform: 'darwin',
+        multilineDraft: false,
       }),
     ).toBe('queue');
   });
@@ -122,6 +125,7 @@ describe('ChatInput steer shortcut contract', () => {
       resolveComposerEnterIntent(event, 'modifier-enter', {
         turnRunning: true,
         platform: 'darwin',
+        multilineDraft: false,
       });
 
     expect(modeB(makeEnterEvent())).toBe('native');
@@ -134,14 +138,39 @@ describe('ChatInput steer shortcut contract', () => {
     expect(modeB(makeEnterEvent({ metaKey: true, repeat: true }))).toBe('ignore');
   });
 
+  it('keeps multiline mode single-line drafts on mode A and multiline drafts on mode B', () => {
+    const modeC = (event: ComposerEnterEvent, multilineDraft: boolean): ComposerEnterIntent =>
+      resolveComposerEnterIntent(event, 'modifier-enter-multiline', {
+        turnRunning: true,
+        platform: 'darwin',
+        multilineDraft,
+      });
+
+    expect(modeC(makeEnterEvent(), false)).toBe('queue');
+    expect(modeC(makeEnterEvent({ metaKey: true }), false)).toBe('steer');
+    expect(modeC(makeEnterEvent(), true)).toBe('native');
+    expect(modeC(makeEnterEvent({ metaKey: true }), true)).toBe('queue');
+    expect(modeC(makeEnterEvent({ shiftKey: true }), true)).toBeNull();
+    expect(modeC(makeEnterEvent({ isComposing: true }), true)).toBe('native');
+  });
+
   it('wires Settings preference updates to ChatInput copy while preserving row-level steer', () => {
     expect(composerSettingsSource).toContain('useComposerSendShortcutPreference()');
-    expect(composerSettingsSource).toContain("setPreference(enabled ? 'modifier-enter' : 'enter')");
+    expect(composerSettingsSource).toContain(
+      'setPreference(value as ComposerSendShortcutPreference)',
+    );
     expect(composerSettingsSource).toContain("setPreference('enter');");
     expect(chatInputSource).toContain('useComposerSendShortcutPreference()');
     expect(chatInputSource).toContain('getComposerSendShortcutLabel(');
-    expect(chatInputSource).toContain("composerSendShortcutPreference === 'modifier-enter'");
+    expect(chatInputSource).toContain("composerEffectiveSendMode === 'modifier-enter'");
     expect(chatInputSource).toContain('newChat.sendButton.queueTooltipSendMode');
+    // Both keydown paths must feed the current draft shape into the resolver;
+    // the render gate must refresh when the draft crosses the multiline boundary.
+    expect(chatInputSource).toContain('multilineDraft: isMultilineDraftDoc(view.state.doc)');
+    expect(chatInputSource).toContain(
+      'multilineDraft: composerDoc ? isMultilineDraftDoc(composerDoc) : false',
+    );
+    expect(chatInputSource).toContain('isMultilineDraftDoc(ed.state.doc)');
     expect(pendingQueuePanelSource).toContain('isPendingQueueSteerShortcut');
     expect(pendingQueuePanelSource).toContain('void onSteer(entry.clientId);');
   });

--- a/apps/desktop/src/renderer/__tests__/chatInputSteerShortcut.test.ts
+++ b/apps/desktop/src/renderer/__tests__/chatInputSteerShortcut.test.ts
@@ -174,6 +174,7 @@ describe('ChatInput steer shortcut contract', () => {
     );
     expect(chatInputSource).toContain('isComposerDraftMultiline(ed.state.doc)');
     expect(chatInputSource).toContain("voiceDraftTextRef.current.includes('\\n')");
+    expect(chatInputSource).toContain('browserCommentsRef.current.length > 0');
     expect(pendingQueuePanelSource).toContain('isPendingQueueSteerShortcut');
     expect(pendingQueuePanelSource).toContain('void onSteer(entry.clientId);');
   });

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -1114,14 +1114,6 @@ export function ChatInput({
       voiceDraftTextRef.current.length === 0
     );
   };
-  // 语音听写的可见草稿(VoiceInputDraftDecoration)还没落进 editor doc;
-  // 多行判定必须把它算进去,否则多行转写在 multiline 挡下会被普通 Enter
-  // 经 stop-and-send 路径误发。keydown 稳定闭包读 ref,render 侧同样经此取值。
-  const isComposerDraftMultiline = useCallback(
-    (doc: Parameters<typeof isMultilineDraftDoc>[0] | null | undefined): boolean =>
-      (doc ? isMultilineDraftDoc(doc) : false) || voiceDraftTextRef.current.includes('\n'),
-    [],
-  );
   const resolvedPlaceholder = placeholder ?? t('newChat.chatInput.defaultPlaceholder');
   const steerShortcutLabel = useMemo(
     () => (window.electronAPI?.platform === 'darwin' ? '⌘↵' : 'Ctrl+Enter'),
@@ -1480,6 +1472,18 @@ export function ChatInput({
   const [browserComments, setBrowserComments] = useState<BrowserCommentDraftItem[]>([]);
   const browserCommentsRef = useRef<BrowserCommentDraftItem[]>(browserComments);
   browserCommentsRef.current = browserComments;
+
+  // 多行草稿判定的 ChatInput 侧合并:doc 之外还有两类"可见但不在 doc 里"的内容——
+  // 语音听写草稿(VoiceInputDraftDecoration)与浏览器评论(formatBrowserCommentsForSend
+  // 只要有评论就展开成多行块)。漏掉任何一类,multiline 挡下普通 Enter 都会误发。
+  // keydown 稳定闭包读 ref,render 侧同样经此取值。
+  const isComposerDraftMultiline = useCallback(
+    (doc: Parameters<typeof isMultilineDraftDoc>[0] | null | undefined): boolean =>
+      (doc ? isMultilineDraftDoc(doc) : false) ||
+      voiceDraftTextRef.current.includes('\n') ||
+      browserCommentsRef.current.length > 0,
+    [],
+  );
 
   // Ref bridge for Tiptap handlePaste — editorProps can't read React
   // state directly, so we expose attachment writers via stable refs.

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -1103,6 +1103,10 @@ export function ChatInput({
   // 完整输入框空判断:不仅检查 ProseMirror 文档是否为空,还检查附件、浏览器评论和语音稿。
   // 避免在用户放好了附件/评论/语音稿但正文为空时,仍发起付费的 predictNextPrompt 调用。
   const voiceDraftTextRef = useRef('');
+  // voiceDraftTextRef 是全局语音状态的镜像,切换任务时仍可能留着源任务的稿子。
+  // 判断"这段稿子属于当前输入框"要走与 decoration 同一个归属判据
+  // (voiceLocksCurrentComposer),该值在下方算出后回填这里供稳定闭包读取。
+  const voiceBusyOnCurrentComposerRef = useRef(false);
   const composerFullyEmptyRef = useRef<() => boolean>(() => true);
   composerFullyEmptyRef.current = () => {
     const ed = editorRef.current;
@@ -1476,11 +1480,13 @@ export function ChatInput({
   // 多行草稿判定的 ChatInput 侧合并:doc 之外还有两类"可见但不在 doc 里"的内容——
   // 语音听写草稿(VoiceInputDraftDecoration)与浏览器评论(formatBrowserCommentsForSend
   // 只要有评论就展开成多行块)。漏掉任何一类,multiline 挡下普通 Enter 都会误发。
+  // 语音项必须与 decoration 一样限定归属当前输入框,否则源任务还在听写时切走,
+  // 目标输入框会拿着别人的多行稿子把单行草稿判成多行。
   // keydown 稳定闭包读 ref,render 侧同样经此取值。
   const isComposerDraftMultiline = useCallback(
     (doc: Parameters<typeof isMultilineDraftDoc>[0] | null | undefined): boolean =>
       (doc ? isMultilineDraftDoc(doc) : false) ||
-      voiceDraftTextRef.current.includes('\n') ||
+      (voiceBusyOnCurrentComposerRef.current && voiceDraftTextRef.current.includes('\n')) ||
       browserCommentsRef.current.length > 0,
     [],
   );
@@ -3082,6 +3088,8 @@ export function ChatInput({
     ownerStorageKey: voiceOwnerStorageKeyRef.current,
     currentStorageKey: storageKeyForDraftRef.current,
   });
+  // 回填供 isComposerDraftMultiline 的稳定闭包判断语音稿归属(见该 helper 注释)。
+  voiceBusyOnCurrentComposerRef.current = voiceBusyOnCurrentComposer;
   const composerMutationLocked = composerEditorLocked || voiceBusyOnCurrentComposer;
   composerMutationLockedRef.current = composerMutationLocked;
   useEffect(() => {

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -1114,6 +1114,14 @@ export function ChatInput({
       voiceDraftTextRef.current.length === 0
     );
   };
+  // 语音听写的可见草稿(VoiceInputDraftDecoration)还没落进 editor doc;
+  // 多行判定必须把它算进去,否则多行转写在 multiline 挡下会被普通 Enter
+  // 经 stop-and-send 路径误发。keydown 稳定闭包读 ref,render 侧同样经此取值。
+  const isComposerDraftMultiline = useCallback(
+    (doc: Parameters<typeof isMultilineDraftDoc>[0] | null | undefined): boolean =>
+      (doc ? isMultilineDraftDoc(doc) : false) || voiceDraftTextRef.current.includes('\n'),
+    [],
+  );
   const resolvedPlaceholder = placeholder ?? t('newChat.chatInput.defaultPlaceholder');
   const steerShortcutLabel = useMemo(
     () => (window.electronAPI?.platform === 'darwin' ? '⌘↵' : 'Ctrl+Enter'),
@@ -2580,7 +2588,7 @@ export function ChatInput({
         const enterIntent = resolveComposerEnterIntent(event, getComposerSendShortcutPreference(), {
           turnRunning: showStopButtonRef.current,
           platform: window.electronAPI?.platform,
-          multilineDraft: isMultilineDraftDoc(view.state.doc),
+          multilineDraft: isComposerDraftMultiline(view.state.doc),
         });
         if (enterIntent === 'native') return false;
         if (enterIntent === 'ignore') {
@@ -2638,7 +2646,7 @@ export function ChatInput({
       const nextRenderSnapshot = composerRenderSnapshot(
         composerTriggerSnapshotOf(ed),
         !composerDocIsEmpty(ed.state.doc),
-        isMultilineDraftDoc(ed.state.doc),
+        isComposerDraftMultiline(ed.state.doc),
       );
       if (shouldRefreshComposerRender(renderSnapshotRef.current, nextRenderSnapshot)) {
         renderSnapshotRef.current = nextRenderSnapshot;
@@ -2709,7 +2717,7 @@ export function ChatInput({
       const nextRenderSnapshot = composerRenderSnapshot(
         composerTriggerSnapshotOf(ed),
         !composerDocIsEmpty(ed.state.doc),
-        isMultilineDraftDoc(ed.state.doc),
+        isComposerDraftMultiline(ed.state.doc),
       );
       if (shouldRefreshComposerRender(renderSnapshotRef.current, nextRenderSnapshot)) {
         renderSnapshotRef.current = nextRenderSnapshot;
@@ -3257,11 +3265,10 @@ export function ChatInput({
         }
       }
 
-      const composerDoc = editorRef.current?.view.state.doc;
       const enterIntent = resolveComposerEnterIntent(event, getComposerSendShortcutPreference(), {
         turnRunning: showStopButtonRef.current,
         platform,
-        multilineDraft: composerDoc ? isMultilineDraftDoc(composerDoc) : false,
+        multilineDraft: isComposerDraftMultiline(editorRef.current?.view.state.doc),
       });
       const isModifiedEnter = hasComposerModifier(event, platform);
       if (
@@ -3399,7 +3406,8 @@ export function ChatInput({
       window.removeEventListener('keyup', handleKeyUp, true);
       window.removeEventListener('blur', handleWindowBlur);
     };
-  }, []);
+    // isComposerDraftMultiline 是空依赖 useCallback,身份稳定,effect 不会因此重挂。
+  }, [isComposerDraftMultiline]);
 
   useEffect(() => {
     return window.electronAPI.voiceInput.onGlobalShortcutTrigger((payload) => {
@@ -7533,7 +7541,7 @@ export function ChatInput({
   );
 
   const hasMessage = !isEditorEmpty(editor);
-  const composerDraftMultiline = editor ? isMultilineDraftDoc(editor.state.doc) : false;
+  const composerDraftMultiline = isComposerDraftMultiline(editor?.state.doc);
   renderSnapshotRef.current = composerRenderSnapshot(trigger, hasMessage, composerDraftMultiline);
   const canSend = hasMessage || hasAttachments || browserComments.length > 0;
   // The tooltip advertises the send key for the draft as it currently stands;

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -264,9 +264,11 @@ import {
   getComposerSendShortcutLabel,
   hasComposerModifier,
   resolveComposerEnterIntent,
+  resolveEffectiveSendMode,
   useComposerSendShortcutPreference,
 } from '@/hooks/useComposerSendShortcutPreference';
 import { usePromptRecommendationPreference } from '@/hooks/usePromptRecommendationPreference';
+import { isMultilineDraftDoc } from './composerDraftMultiline';
 import { createLogger } from '@/lib/logger';
 import { subscribeWorkLouderCodexAction } from '@/lib/workLouderCodexActions';
 import { createComposerDraftSaveScheduler } from '@/lib/composerDraftSaveScheduler';
@@ -1113,10 +1115,6 @@ export function ChatInput({
     );
   };
   const resolvedPlaceholder = placeholder ?? t('newChat.chatInput.defaultPlaceholder');
-  const composerSendShortcutLabel = getComposerSendShortcutLabel(
-    composerSendShortcutPreference,
-    window.electronAPI?.platform,
-  );
   const steerShortcutLabel = useMemo(
     () => (window.electronAPI?.platform === 'darwin' ? '⌘↵' : 'Ctrl+Enter'),
     [],
@@ -2582,6 +2580,7 @@ export function ChatInput({
         const enterIntent = resolveComposerEnterIntent(event, getComposerSendShortcutPreference(), {
           turnRunning: showStopButtonRef.current,
           platform: window.electronAPI?.platform,
+          multilineDraft: isMultilineDraftDoc(view.state.doc),
         });
         if (enterIntent === 'native') return false;
         if (enterIntent === 'ignore') {
@@ -2639,6 +2638,7 @@ export function ChatInput({
       const nextRenderSnapshot = composerRenderSnapshot(
         composerTriggerSnapshotOf(ed),
         !composerDocIsEmpty(ed.state.doc),
+        isMultilineDraftDoc(ed.state.doc),
       );
       if (shouldRefreshComposerRender(renderSnapshotRef.current, nextRenderSnapshot)) {
         renderSnapshotRef.current = nextRenderSnapshot;
@@ -2709,6 +2709,7 @@ export function ChatInput({
       const nextRenderSnapshot = composerRenderSnapshot(
         composerTriggerSnapshotOf(ed),
         !composerDocIsEmpty(ed.state.doc),
+        isMultilineDraftDoc(ed.state.doc),
       );
       if (shouldRefreshComposerRender(renderSnapshotRef.current, nextRenderSnapshot)) {
         renderSnapshotRef.current = nextRenderSnapshot;
@@ -3256,9 +3257,11 @@ export function ChatInput({
         }
       }
 
+      const composerDoc = editorRef.current?.view.state.doc;
       const enterIntent = resolveComposerEnterIntent(event, getComposerSendShortcutPreference(), {
         turnRunning: showStopButtonRef.current,
         platform,
+        multilineDraft: composerDoc ? isMultilineDraftDoc(composerDoc) : false,
       });
       const isModifiedEnter = hasComposerModifier(event, platform);
       if (
@@ -7530,8 +7533,19 @@ export function ChatInput({
   );
 
   const hasMessage = !isEditorEmpty(editor);
-  renderSnapshotRef.current = composerRenderSnapshot(trigger, hasMessage);
+  const composerDraftMultiline = editor ? isMultilineDraftDoc(editor.state.doc) : false;
+  renderSnapshotRef.current = composerRenderSnapshot(trigger, hasMessage, composerDraftMultiline);
   const canSend = hasMessage || hasAttachments || browserComments.length > 0;
+  // The tooltip advertises the send key for the draft as it currently stands;
+  // in the multiline mode it flips between Enter and the modifier combo.
+  const composerEffectiveSendMode = resolveEffectiveSendMode(
+    composerSendShortcutPreference,
+    composerDraftMultiline,
+  );
+  const composerSendShortcutLabel = getComposerSendShortcutLabel(
+    composerEffectiveSendMode,
+    window.electronAPI?.platform,
+  );
   const hasVoiceDraftText =
     voiceBusyOnCurrentComposer && voiceInput.draftText.trim().length > 0;
   // 推荐 overlay 的可见判据:开关开启 + 有推荐词 + 输入框空 + 无附件/浏览器评论/语音草稿 + 输入框未锁定。
@@ -8334,7 +8348,7 @@ export function ChatInput({
                             : voiceInput.isListening && !sendButtonDisabled
                               ? `${t('newChat.chatInput.voiceInput.finishAndSend')} · ${composerSendShortcutLabel}`
                               : showStopButton
-                                ? composerSendShortcutPreference === 'modifier-enter'
+                                ? composerEffectiveSendMode === 'modifier-enter'
                                   ? t('newChat.sendButton.queueTooltipSendMode', {
                                       shortcut: composerSendShortcutLabel,
                                     })

--- a/apps/desktop/src/renderer/components/new-chat/__tests__/composerDraftMultiline.test.ts
+++ b/apps/desktop/src/renderer/components/new-chat/__tests__/composerDraftMultiline.test.ts
@@ -6,6 +6,7 @@ interface FakeNode {
   type: { name: string };
   isText: boolean;
   isTextblock: boolean;
+  text?: string | null;
   attrs: Record<string, unknown>;
 }
 
@@ -26,7 +27,13 @@ const paragraph = (): FakeNode => ({
   isTextblock: true,
   attrs: {},
 });
-const text = (): FakeNode => ({ type: { name: 'text' }, isText: true, isTextblock: false, attrs: {} });
+const text = (content = ''): FakeNode => ({
+  type: { name: 'text' },
+  isText: true,
+  isTextblock: false,
+  text: content,
+  attrs: {},
+});
 const hardBreak = (): FakeNode => ({
   type: { name: 'hardBreak' },
   isText: false,
@@ -79,6 +86,11 @@ describe('isMultilineDraftDoc', () => {
     expect(isMultilineDraftDoc(fakeDoc(1, [bulletList(), listItem(), paragraph(), text()]))).toBe(
       false,
     );
+  });
+
+  it('treats a text node carrying newlines as multiline (e.g. voice transcript via insertText)', () => {
+    expect(isMultilineDraftDoc(fakeDoc(1, [paragraph(), text('line one\nline two')]))).toBe(true);
+    expect(isMultilineDraftDoc(fakeDoc(1, [paragraph(), text('single line')]))).toBe(false);
   });
 
   it('treats a collapsed paste chip carrying newlines as multiline', () => {

--- a/apps/desktop/src/renderer/components/new-chat/__tests__/composerDraftMultiline.test.ts
+++ b/apps/desktop/src/renderer/components/new-chat/__tests__/composerDraftMultiline.test.ts
@@ -2,51 +2,107 @@ import { describe, expect, it } from 'vitest';
 
 import { isMultilineDraftDoc } from '../composerDraftMultiline';
 
-interface FakeLeaf {
+interface FakeNode {
   type: { name: string };
   isText: boolean;
+  isTextblock: boolean;
+  attrs: Record<string, unknown>;
 }
 
-function fakeDoc(childCount: number, leaves: FakeLeaf[] = []): Parameters<typeof isMultilineDraftDoc>[0] {
+function fakeDoc(childCount: number, nodes: FakeNode[] = []): Parameters<typeof isMultilineDraftDoc>[0] {
   return {
     childCount,
     descendants: (fn) => {
-      for (const leaf of leaves) {
-        if (fn(leaf) === false) return;
+      for (const node of nodes) {
+        if (fn(node) === false) return;
       }
     },
   };
 }
 
-const text = (): FakeLeaf => ({ type: { name: 'text' }, isText: true });
-const hardBreak = (): FakeLeaf => ({ type: { name: 'hardBreak' }, isText: false });
+const paragraph = (): FakeNode => ({
+  type: { name: 'paragraph' },
+  isText: false,
+  isTextblock: true,
+  attrs: {},
+});
+const text = (): FakeNode => ({ type: { name: 'text' }, isText: true, isTextblock: false, attrs: {} });
+const hardBreak = (): FakeNode => ({
+  type: { name: 'hardBreak' },
+  isText: false,
+  isTextblock: false,
+  attrs: {},
+});
+const bulletList = (): FakeNode => ({
+  type: { name: 'bulletList' },
+  isText: false,
+  isTextblock: false,
+  attrs: {},
+});
+const listItem = (): FakeNode => ({
+  type: { name: 'listItem' },
+  isText: false,
+  isTextblock: false,
+  attrs: {},
+});
+const pastedChip = (chipText: string): FakeNode => ({
+  type: { name: 'pastedTextChip' },
+  isText: false,
+  isTextblock: false,
+  attrs: { text: chipText, display: 'Pasted text' },
+});
 
 describe('isMultilineDraftDoc', () => {
   it('treats an empty or single-paragraph doc as single-line', () => {
-    expect(isMultilineDraftDoc(fakeDoc(1))).toBe(false);
-    expect(isMultilineDraftDoc(fakeDoc(1, [text()]))).toBe(false);
+    expect(isMultilineDraftDoc(fakeDoc(1, [paragraph()]))).toBe(false);
+    expect(isMultilineDraftDoc(fakeDoc(1, [paragraph(), text()]))).toBe(false);
   });
 
-  it('treats multiple block nodes as multiline', () => {
+  it('treats multiple top-level blocks as multiline', () => {
     expect(isMultilineDraftDoc(fakeDoc(2))).toBe(true);
   });
 
   it('treats a hard break inside a single block as multiline', () => {
-    expect(isMultilineDraftDoc(fakeDoc(1, [text(), hardBreak(), text()]))).toBe(true);
+    expect(isMultilineDraftDoc(fakeDoc(1, [paragraph(), text(), hardBreak(), text()]))).toBe(true);
   });
 
-  it('stops descending once a hard break is found', () => {
+  it('treats a structured list with multiple items as multiline', () => {
+    // 单个顶层 bulletList,两个 listItem 各含一个 paragraph textblock。
+    expect(
+      isMultilineDraftDoc(
+        fakeDoc(1, [bulletList(), listItem(), paragraph(), text(), listItem(), paragraph(), text()]),
+      ),
+    ).toBe(true);
+  });
+
+  it('keeps a single-item list single-line', () => {
+    expect(isMultilineDraftDoc(fakeDoc(1, [bulletList(), listItem(), paragraph(), text()]))).toBe(
+      false,
+    );
+  });
+
+  it('treats a collapsed paste chip carrying newlines as multiline', () => {
+    expect(
+      isMultilineDraftDoc(fakeDoc(1, [paragraph(), text(), pastedChip('line one\nline two')])),
+    ).toBe(true);
+  });
+
+  it('keeps a single-line paste chip single-line', () => {
+    expect(isMultilineDraftDoc(fakeDoc(1, [paragraph(), pastedChip('one line only')]))).toBe(false);
+  });
+
+  it('stops descending once multiline is confirmed', () => {
     let visits = 0;
     const doc = {
       childCount: 1,
-      descendants: (fn: (node: FakeLeaf) => boolean | void) => {
-        for (const leaf of [hardBreak(), text(), text()]) {
+      descendants: (fn: (node: FakeNode) => boolean | void) => {
+        for (const node of [paragraph(), hardBreak(), text(), text()]) {
           visits += 1;
-          if (fn(leaf) === false) return;
+          if (fn(node) === false) return;
         }
       },
     };
     expect(isMultilineDraftDoc(doc)).toBe(true);
-    expect(visits).toBe(1);
+    expect(visits).toBe(2);
   });
 });

--- a/apps/desktop/src/renderer/components/new-chat/__tests__/composerDraftMultiline.test.ts
+++ b/apps/desktop/src/renderer/components/new-chat/__tests__/composerDraftMultiline.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+
+import { isMultilineDraftDoc } from '../composerDraftMultiline';
+
+interface FakeLeaf {
+  type: { name: string };
+  isText: boolean;
+}
+
+function fakeDoc(childCount: number, leaves: FakeLeaf[] = []): Parameters<typeof isMultilineDraftDoc>[0] {
+  return {
+    childCount,
+    descendants: (fn) => {
+      for (const leaf of leaves) {
+        if (fn(leaf) === false) return;
+      }
+    },
+  };
+}
+
+const text = (): FakeLeaf => ({ type: { name: 'text' }, isText: true });
+const hardBreak = (): FakeLeaf => ({ type: { name: 'hardBreak' }, isText: false });
+
+describe('isMultilineDraftDoc', () => {
+  it('treats an empty or single-paragraph doc as single-line', () => {
+    expect(isMultilineDraftDoc(fakeDoc(1))).toBe(false);
+    expect(isMultilineDraftDoc(fakeDoc(1, [text()]))).toBe(false);
+  });
+
+  it('treats multiple block nodes as multiline', () => {
+    expect(isMultilineDraftDoc(fakeDoc(2))).toBe(true);
+  });
+
+  it('treats a hard break inside a single block as multiline', () => {
+    expect(isMultilineDraftDoc(fakeDoc(1, [text(), hardBreak(), text()]))).toBe(true);
+  });
+
+  it('stops descending once a hard break is found', () => {
+    let visits = 0;
+    const doc = {
+      childCount: 1,
+      descendants: (fn: (node: FakeLeaf) => boolean | void) => {
+        for (const leaf of [hardBreak(), text(), text()]) {
+          visits += 1;
+          if (fn(leaf) === false) return;
+        }
+      },
+    };
+    expect(isMultilineDraftDoc(doc)).toBe(true);
+    expect(visits).toBe(1);
+  });
+});

--- a/apps/desktop/src/renderer/components/new-chat/__tests__/composerDraftMultiline.test.ts
+++ b/apps/desktop/src/renderer/components/new-chat/__tests__/composerDraftMultiline.test.ts
@@ -58,6 +58,12 @@ const pastedChip = (chipText: string): FakeNode => ({
   isTextblock: false,
   attrs: { text: chipText, display: 'Pasted text' },
 });
+const quoteChip = (quoteText: string): FakeNode => ({
+  type: { name: 'composerQuote' },
+  isText: false,
+  isTextblock: false,
+  attrs: { text: quoteText },
+});
 
 describe('isMultilineDraftDoc', () => {
   it('treats an empty or single-paragraph doc as single-line', () => {
@@ -101,6 +107,11 @@ describe('isMultilineDraftDoc', () => {
 
   it('keeps a single-line paste chip single-line', () => {
     expect(isMultilineDraftDoc(fakeDoc(1, [paragraph(), pastedChip('one line only')]))).toBe(false);
+  });
+
+  it('treats a quote chip as multiline even when the quoted text is single-line', () => {
+    // formatQuoteForSend 无条件输出 marker 行 + 引用行,发送结果必然跨行。
+    expect(isMultilineDraftDoc(fakeDoc(1, [paragraph(), quoteChip('one line quote')]))).toBe(true);
   });
 
   it('stops descending once multiline is confirmed', () => {

--- a/apps/desktop/src/renderer/components/new-chat/__tests__/composerRenderGate.test.ts
+++ b/apps/desktop/src/renderer/components/new-chat/__tests__/composerRenderGate.test.ts
@@ -8,8 +8,8 @@ import {
 
 describe('composer render gate', () => {
   it('skips ordinary text updates when trigger and send state are stable', () => {
-    const none = composerRenderSnapshot({ kind: 'none' }, true);
-    expect(shouldRefreshComposerRender(none, composerRenderSnapshot({ kind: 'none' }, true))).toBe(
+    const none = composerRenderSnapshot({ kind: 'none' }, true, false);
+    expect(shouldRefreshComposerRender(none, composerRenderSnapshot({ kind: 'none' }, true, false))).toBe(
       false,
     );
   });
@@ -17,30 +17,30 @@ describe('composer render gate', () => {
   it('refreshes when text becomes sendable or empty', () => {
     expect(
       shouldRefreshComposerRender(
-        composerRenderSnapshot({ kind: 'none' }, false),
-        composerRenderSnapshot({ kind: 'none' }, true),
+        composerRenderSnapshot({ kind: 'none' }, false, false),
+        composerRenderSnapshot({ kind: 'none' }, true, false),
       ),
     ).toBe(true);
     expect(
       shouldRefreshComposerRender(
-        composerRenderSnapshot({ kind: 'none' }, true),
-        composerRenderSnapshot({ kind: 'none' }, false),
+        composerRenderSnapshot({ kind: 'none' }, true, false),
+        composerRenderSnapshot({ kind: 'none' }, false, false),
       ),
     ).toBe(true);
   });
 
   it('refreshes when a palette trigger changes', () => {
-    const before = composerRenderSnapshot({ kind: 'slash', sigil: '/', query: '', from: 1 }, true);
+    const before = composerRenderSnapshot({ kind: 'slash', sigil: '/', query: '', from: 1 }, true, false);
     expect(
       shouldRefreshComposerRender(
         before,
-        composerRenderSnapshot({ kind: 'slash', sigil: '/', query: 'he', from: 1 }, true),
+        composerRenderSnapshot({ kind: 'slash', sigil: '/', query: 'he', from: 1 }, true, false),
       ),
     ).toBe(true);
     expect(
       shouldRefreshComposerRender(
         before,
-        composerRenderSnapshot({ kind: 'slash', sigil: '$', query: '', from: 1 }, true),
+        composerRenderSnapshot({ kind: 'slash', sigil: '$', query: '', from: 1 }, true, false),
       ),
     ).toBe(true);
   });
@@ -49,24 +49,45 @@ describe('composer render gate', () => {
     // 'none' -> a palette trigger opening.
     expect(
       shouldRefreshComposerRender(
-        composerRenderSnapshot({ kind: 'none' }, true),
-        composerRenderSnapshot({ kind: 'slash', sigil: '/', query: '', from: 1 }, true),
+        composerRenderSnapshot({ kind: 'none' }, true, false),
+        composerRenderSnapshot({ kind: 'slash', sigil: '/', query: '', from: 1 }, true, false),
       ),
     ).toBe(true);
     // A palette trigger closing back to 'none'.
     expect(
       shouldRefreshComposerRender(
-        composerRenderSnapshot({ kind: 'slash', sigil: '/', query: '', from: 1 }, true),
-        composerRenderSnapshot({ kind: 'none' }, true),
+        composerRenderSnapshot({ kind: 'slash', sigil: '/', query: '', from: 1 }, true, false),
+        composerRenderSnapshot({ kind: 'none' }, true, false),
       ),
     ).toBe(true);
     // One palette trigger kind swapping directly for the other.
     expect(
       shouldRefreshComposerRender(
-        composerRenderSnapshot({ kind: 'slash', sigil: '/', query: '', from: 1 }, true),
-        composerRenderSnapshot({ kind: 'at', query: '', from: 1 }, true),
+        composerRenderSnapshot({ kind: 'slash', sigil: '/', query: '', from: 1 }, true, false),
+        composerRenderSnapshot({ kind: 'at', query: '', from: 1 }, true, false),
       ),
     ).toBe(true);
+  });
+
+  it('refreshes when the draft crosses the single/multiline boundary', () => {
+    expect(
+      shouldRefreshComposerRender(
+        composerRenderSnapshot({ kind: 'none' }, true, false),
+        composerRenderSnapshot({ kind: 'none' }, true, true),
+      ),
+    ).toBe(true);
+    expect(
+      shouldRefreshComposerRender(
+        composerRenderSnapshot({ kind: 'none' }, true, true),
+        composerRenderSnapshot({ kind: 'none' }, true, false),
+      ),
+    ).toBe(true);
+    expect(
+      shouldRefreshComposerRender(
+        composerRenderSnapshot({ kind: 'none' }, true, true),
+        composerRenderSnapshot({ kind: 'none' }, true, true),
+      ),
+    ).toBe(false);
   });
 
   it('keeps the ordinary update default explicit', () => {

--- a/apps/desktop/src/renderer/components/new-chat/composerDraftMultiline.ts
+++ b/apps/desktop/src/renderer/components/new-chat/composerDraftMultiline.ts
@@ -5,9 +5,13 @@
  *
  * 判据对齐序列化语义:凡是发送后消息文本会跨行的草稿都算多行——
  * 多个顶层块、多个 textblock(结构化列表的每个 listItem 各有一个)、
- * hardBreak、自身含换行的文本节点(tr.insertText 可整段插入换行文本),
- * 以及把换行折叠进 attrs.text 的原子节点(pastedTextChip 等)。
+ * hardBreak、自身含换行的文本节点(tr.insertText 可整段插入换行文本)、
+ * 把换行折叠进 attrs.text 的原子节点(pastedTextChip 等),以及引用 chip
+ * (formatQuoteForSend 无条件输出 marker 行 + 引用行,单行引用也必然跨行)。
+ * 浏览器评论不在 doc 里,由 ChatInput 的 isComposerDraftMultiline 合并判定。
  */
+
+import { COMPOSER_QUOTE_NODE_TYPE } from '@/lib/composerQuoteDocument';
 
 interface MinimalNodeInfo {
   type: { name: string };
@@ -28,7 +32,7 @@ export function isMultilineDraftDoc(doc: MinimalDoc): boolean {
   let multiline = false;
   doc.descendants((node) => {
     if (multiline) return false;
-    if (node.type.name === 'hardBreak') {
+    if (node.type.name === 'hardBreak' || node.type.name === COMPOSER_QUOTE_NODE_TYPE) {
       multiline = true;
       return false;
     }

--- a/apps/desktop/src/renderer/components/new-chat/composerDraftMultiline.ts
+++ b/apps/desktop/src/renderer/components/new-chat/composerDraftMultiline.ts
@@ -1,0 +1,26 @@
+/**
+ * [INPUT]: Tiptap/ProseMirror 文档节点的最小结构
+ * [OUTPUT]: isMultilineDraftDoc —— 草稿是否已是多行(供发送快捷键的 multiline 挡归约)
+ * [POS]: composer 发送快捷键语义的草稿形态判定,独立于 ChatInput 以便单测
+ */
+
+interface MinimalNode {
+  childCount: number;
+  descendants: (fn: (node: { type: { name: string }; isText: boolean }) => boolean | void) => void;
+}
+
+/**
+ * A draft counts as multiline once it has more than one block node, or a hard
+ * break inside the single block. An empty doc (one empty paragraph) is
+ * single-line by construction.
+ */
+export function isMultilineDraftDoc(doc: MinimalNode): boolean {
+  if (doc.childCount > 1) return true;
+  let found = false;
+  doc.descendants((node) => {
+    if (found) return false;
+    if (node.type.name === 'hardBreak') found = true;
+    return !found;
+  });
+  return found;
+}

--- a/apps/desktop/src/renderer/components/new-chat/composerDraftMultiline.ts
+++ b/apps/desktop/src/renderer/components/new-chat/composerDraftMultiline.ts
@@ -5,13 +5,15 @@
  *
  * 判据对齐序列化语义:凡是发送后消息文本会跨行的草稿都算多行——
  * 多个顶层块、多个 textblock(结构化列表的每个 listItem 各有一个)、
- * hardBreak,以及把换行折叠进 attrs.text 的原子节点(pastedTextChip 等)。
+ * hardBreak、自身含换行的文本节点(tr.insertText 可整段插入换行文本),
+ * 以及把换行折叠进 attrs.text 的原子节点(pastedTextChip 等)。
  */
 
 interface MinimalNodeInfo {
   type: { name: string };
   isText: boolean;
   isTextblock: boolean;
+  text?: string | null;
   attrs: Record<string, unknown>;
 }
 
@@ -40,12 +42,17 @@ export function isMultilineDraftDoc(doc: MinimalDoc): boolean {
       }
       return true;
     }
-    if (!node.isText) {
-      const text = node.attrs['text'];
-      if (typeof text === 'string' && text.includes('\n')) {
+    if (node.isText) {
+      if (node.text?.includes('\n')) {
         multiline = true;
         return false;
       }
+      return true;
+    }
+    const text = node.attrs['text'];
+    if (typeof text === 'string' && text.includes('\n')) {
+      multiline = true;
+      return false;
     }
     return true;
   });

--- a/apps/desktop/src/renderer/components/new-chat/composerDraftMultiline.ts
+++ b/apps/desktop/src/renderer/components/new-chat/composerDraftMultiline.ts
@@ -2,25 +2,52 @@
  * [INPUT]: Tiptap/ProseMirror 文档节点的最小结构
  * [OUTPUT]: isMultilineDraftDoc —— 草稿是否已是多行(供发送快捷键的 multiline 挡归约)
  * [POS]: composer 发送快捷键语义的草稿形态判定,独立于 ChatInput 以便单测
+ *
+ * 判据对齐序列化语义:凡是发送后消息文本会跨行的草稿都算多行——
+ * 多个顶层块、多个 textblock(结构化列表的每个 listItem 各有一个)、
+ * hardBreak,以及把换行折叠进 attrs.text 的原子节点(pastedTextChip 等)。
  */
 
-interface MinimalNode {
-  childCount: number;
-  descendants: (fn: (node: { type: { name: string }; isText: boolean }) => boolean | void) => void;
+interface MinimalNodeInfo {
+  type: { name: string };
+  isText: boolean;
+  isTextblock: boolean;
+  attrs: Record<string, unknown>;
 }
 
-/**
- * A draft counts as multiline once it has more than one block node, or a hard
- * break inside the single block. An empty doc (one empty paragraph) is
- * single-line by construction.
- */
-export function isMultilineDraftDoc(doc: MinimalNode): boolean {
+interface MinimalDoc {
+  childCount: number;
+  descendants: (fn: (node: MinimalNodeInfo) => boolean | void) => void;
+}
+
+export function isMultilineDraftDoc(doc: MinimalDoc): boolean {
   if (doc.childCount > 1) return true;
-  let found = false;
+  let textblocks = 0;
+  let multiline = false;
   doc.descendants((node) => {
-    if (found) return false;
-    if (node.type.name === 'hardBreak') found = true;
-    return !found;
+    if (multiline) return false;
+    if (node.type.name === 'hardBreak') {
+      multiline = true;
+      return false;
+    }
+    if (node.isTextblock) {
+      // 第二个 textblock 意味着序列化必然换行(如列表的第二个 listItem)。
+      // 不剪枝:textblock 内部还可能藏着 hardBreak 或折叠粘贴 chip。
+      textblocks += 1;
+      if (textblocks > 1) {
+        multiline = true;
+        return false;
+      }
+      return true;
+    }
+    if (!node.isText) {
+      const text = node.attrs['text'];
+      if (typeof text === 'string' && text.includes('\n')) {
+        multiline = true;
+        return false;
+      }
+    }
+    return true;
   });
-  return found;
+  return multiline;
 }

--- a/apps/desktop/src/renderer/components/new-chat/composerRenderGate.ts
+++ b/apps/desktop/src/renderer/components/new-chat/composerRenderGate.ts
@@ -6,12 +6,14 @@ export type ComposerTriggerSnapshot =
 export interface ComposerRenderSnapshot {
   trigger: ComposerTriggerSnapshot;
   hasMessage: boolean;
+  multilineDraft: boolean;
 }
 
 /**
  * Returns whether a React render is needed after an editor transaction.
  * Ordinary text updates with no active trigger keep the editor mutable outside
- * React; only palette state or the empty/non-empty send state can change.
+ * React; only palette state, the empty/non-empty send state, or the
+ * single/multiline draft shape (it drives the send-shortcut tooltip) can change.
  */
 export function shouldRefreshComposerRender(
   previous: ComposerRenderSnapshot | null,
@@ -19,6 +21,7 @@ export function shouldRefreshComposerRender(
 ): boolean {
   if (!previous) return true;
   if (previous.hasMessage !== next.hasMessage) return true;
+  if (previous.multilineDraft !== next.multilineDraft) return true;
   // Check `next` first so TS narrows `next.trigger` off `'none'` before the
   // single kind comparison below runs — that comparison then narrows
   // `previous.trigger` too, since it's checked against an already-narrowed
@@ -41,8 +44,9 @@ export function shouldRefreshComposerRender(
 export function composerRenderSnapshot(
   trigger: ComposerTriggerSnapshot,
   hasMessage: boolean,
+  multilineDraft: boolean,
 ): ComposerRenderSnapshot {
-  return { trigger, hasMessage };
+  return { trigger, hasMessage, multilineDraft };
 }
 
 export const __composerRenderGateDefaultsForTest = {

--- a/apps/desktop/src/renderer/components/settings/ComposerSendShortcutSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/ComposerSendShortcutSection.tsx
@@ -1,18 +1,38 @@
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
+import { Check, ChevronDown } from 'lucide-react';
+import * as Select from '@radix-ui/react-select';
 
-import { Switch } from '@/components/ui/switch';
+import { cn } from '@/lib/utils';
 import {
   getComposerModifierShortcutLabel,
   useComposerSendShortcutPreference,
+  type ComposerSendShortcutPreference,
 } from '@/hooks/useComposerSendShortcutPreference';
 import { toast } from '@/lib/toast';
 import { DefaultOverrideControls } from './DefaultOverrideControls';
+
+// 默认挡在前;多行挡是「单行 Enter 直发、多行 Enter 换行」的折中挡,排中间。
+const SHORTCUT_OPTIONS: ReadonlyArray<ComposerSendShortcutPreference> = [
+  'enter',
+  'modifier-enter-multiline',
+  'modifier-enter',
+];
 
 export function ComposerSendShortcutSection() {
   const { t } = useTranslation();
   const { preference, isCustomized, setPreference } = useComposerSendShortcutPreference();
   const shortcut = getComposerModifierShortcutLabel(window.electronAPI?.platform);
+
+  const onSelect = useCallback(
+    (value: string) => {
+      const result = setPreference(value as ComposerSendShortcutPreference);
+      if (!result.ok && result.conflict === 'composer-voice-input') {
+        toast.error(t('settings.shortcuts.errors.composerVoiceConflict'));
+      }
+    },
+    [setPreference, t],
+  );
 
   const onReset = useCallback(() => {
     setPreference('enter');
@@ -31,25 +51,73 @@ export function ComposerSendShortcutSection() {
         <div className="flex flex-wrap items-start justify-between gap-3">
           <div className="min-w-0 flex-1">
             <p className="text-14 font-medium leading-[1.3] text-[var(--text-primary)]">
-              {t('settings.composer.sendShortcut.label', { shortcut })}
+              {t('settings.composer.sendShortcut.label')}
             </p>
             <p className="mt-1 text-12 leading-[1.5] text-[var(--text-secondary)]">
-              {t('settings.composer.sendShortcut.hint', { shortcut })}
+              {t('settings.composer.sendShortcut.hint')}
             </p>
           </div>
 
           <div className="flex shrink-0 items-center gap-2">
             <DefaultOverrideControls isCustomized={isCustomized} onReset={onReset} />
-            <Switch
-              checked={preference === 'modifier-enter'}
-              onCheckedChange={(enabled) => {
-                const result = setPreference(enabled ? 'modifier-enter' : 'enter');
-                if (!result.ok && result.conflict === 'composer-voice-input') {
-                  toast.error(t('settings.shortcuts.errors.composerVoiceConflict'));
-                }
-              }}
-              aria-label={t('settings.composer.sendShortcut.ariaLabel', { shortcut })}
-            />
+            <Select.Root value={preference} onValueChange={onSelect}>
+              <Select.Trigger
+                aria-label={t('settings.composer.sendShortcut.ariaLabel')}
+                className={cn(
+                  'flex h-9 w-[280px] max-w-full shrink-0 items-center justify-between gap-3 rounded-full border px-3.5 text-13 outline-none transition-colors',
+                  'border-[var(--settings-input-border)] bg-[var(--settings-input-bg)] text-[var(--settings-input-text)]',
+                  'hover:bg-[var(--settings-menu-bg-hover)] focus:ring-2 focus:ring-[var(--focus-ring-soft)]',
+                )}
+              >
+                <span className="min-w-0 truncate text-left">
+                  <Select.Value />
+                </span>
+                <Select.Icon asChild>
+                  <ChevronDown
+                    size={14}
+                    className="shrink-0 text-[var(--settings-eye-icon)]"
+                    aria-hidden="true"
+                  />
+                </Select.Icon>
+              </Select.Trigger>
+              <Select.Portal>
+                <Select.Content
+                  position="popper"
+                  side="bottom"
+                  align="start"
+                  sideOffset={6}
+                  className={cn(
+                    'z-[10010] max-h-[18rem] w-[var(--radix-select-trigger-width)] min-w-[220px] overflow-y-auto rounded-xl p-2',
+                    'border border-[var(--settings-input-border)] bg-[var(--settings-theme-card-bg)]',
+                    'shadow-[var(--shadow-menu)]',
+                  )}
+                >
+                  <Select.Viewport className="flex flex-col gap-[2px]">
+                    {SHORTCUT_OPTIONS.map((opt) => (
+                      <Select.Item
+                        key={opt}
+                        value={opt}
+                        className={cn(
+                          'flex h-9 w-full cursor-pointer select-none items-center justify-between gap-3 rounded-[8px] px-3 text-left text-13 outline-none transition-colors',
+                          'text-[var(--settings-input-text)] data-[highlighted]:bg-[var(--settings-menu-bg-hover)]',
+                          'data-[state=checked]:bg-[var(--settings-menu-bg-selected)] data-[state=checked]:font-medium data-[state=checked]:text-[var(--settings-menu-text-selected)]',
+                        )}
+                      >
+                        <Select.ItemText className="min-w-0 truncate">
+                          {t(`settings.composer.sendShortcut.options.${opt}`, { shortcut })}
+                        </Select.ItemText>
+                        <Select.ItemIndicator>
+                          <Check
+                            size={16}
+                            className="shrink-0 text-[var(--settings-theme-icon-active)]"
+                          />
+                        </Select.ItemIndicator>
+                      </Select.Item>
+                    ))}
+                  </Select.Viewport>
+                </Select.Content>
+              </Select.Portal>
+            </Select.Root>
           </div>
         </div>
       </div>

--- a/apps/desktop/src/renderer/components/settings/ComposerSendShortcutSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/ComposerSendShortcutSection.tsx
@@ -87,9 +87,10 @@ export function ComposerSendShortcutSection() {
                   align="start"
                   sideOffset={6}
                   className={cn(
+                    // DESIGN.md §4 Select & Dropdown:面板不带阴影,分层靠 Card 底色 + 边框。
+                    // (LanguageSection 的 shadow 是先于该条款的存量,不复制进新代码。)
                     'z-[10010] max-h-[18rem] w-[var(--radix-select-trigger-width)] min-w-[220px] overflow-y-auto rounded-xl p-2',
                     'border border-[var(--settings-input-border)] bg-[var(--settings-theme-card-bg)]',
-                    'shadow-[var(--shadow-menu)]',
                   )}
                 >
                   <Select.Viewport className="flex flex-col gap-[2px]">

--- a/apps/desktop/src/renderer/components/settings/__tests__/ComposerSendShortcutSection.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/__tests__/ComposerSendShortcutSection.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const toastMocks = vi.hoisted(() => ({
@@ -13,10 +13,14 @@ vi.mock('react-i18next', () => ({
     t: (key: string, options?: { shortcut?: string }) => {
       const translations: Record<string, string> = {
         'settings.composer.title': 'Message input',
-        'settings.composer.sendShortcut.label': 'Use {{shortcut}} to send',
+        'settings.composer.sendShortcut.label': 'Send shortcut',
         'settings.composer.sendShortcut.hint':
-          'When enabled, {{shortcut}} sends messages. When disabled, Enter sends messages and Shift+Enter inserts a new line.',
-        'settings.composer.sendShortcut.ariaLabel': 'Use {{shortcut}} to send messages',
+          'Choose when Enter sends the message and when it inserts a new line. Shift+Enter always inserts a new line.',
+        'settings.composer.sendShortcut.ariaLabel': 'Send shortcut',
+        'settings.composer.sendShortcut.options.enter': 'Enter',
+        'settings.composer.sendShortcut.options.modifier-enter-multiline':
+          '{{shortcut}} for multiline messages',
+        'settings.composer.sendShortcut.options.modifier-enter': '{{shortcut}} always',
         'settings.defaults.customizedBadge': 'Customized',
         'settings.defaults.restore': 'Restore default',
         'settings.defaults.restored': 'Restored default',
@@ -61,6 +65,12 @@ function setVoiceInputShortcut(shortcut: object | null): void {
   });
 }
 
+async function openSelect(trigger: HTMLElement): Promise<void> {
+  trigger.focus();
+  fireEvent.keyDown(trigger, { key: 'ArrowDown', code: 'ArrowDown' });
+  await waitFor(() => expect(screen.getByRole('listbox')).toBeTruthy());
+}
+
 describe('ComposerSendShortcutSection', () => {
   beforeEach(() => {
     localStorage.clear();
@@ -68,25 +78,30 @@ describe('ComposerSendShortcutSection', () => {
     toastMocks.error.mockReset();
     toastMocks.success.mockReset();
     setPlatform('win32');
+    Object.defineProperty(Element.prototype, 'scrollIntoView', {
+      configurable: true,
+      value: vi.fn(),
+    });
   });
 
-  it('shows the default Enter mode and platform-specific shortcut copy', () => {
+  it('shows the default Enter mode and platform-specific option copy', async () => {
     setPlatform('darwin');
 
     render(<ComposerSendShortcutSection />);
 
-    expect(
-      screen.getByRole('switch', { name: 'Use ⌘+Enter to send messages' }).getAttribute('data-state'),
-    ).toBe('unchecked');
-    expect(screen.queryByText('Use ⌘+Enter to send')).not.toBeNull();
-    expect(
-      screen.queryByText(
-        'When enabled, ⌘+Enter sends messages. When disabled, Enter sends messages and Shift+Enter inserts a new line.',
-      ),
-    ).not.toBeNull();
+    const trigger = screen.getByRole('combobox', { name: 'Send shortcut' });
+    expect(trigger.textContent).toContain('Enter');
+    expect(screen.queryByText('Customized')).toBeNull();
+
+    await openSelect(trigger);
+    expect(screen.getAllByRole('option').map((option) => option.textContent)).toEqual([
+      'Enter',
+      '⌘+Enter for multiline messages',
+      '⌘+Enter always',
+    ]);
   });
 
-  it('synchronizes mode B across subscribers and restores the default override', () => {
+  it('persists mode B, synchronizes subscribers, and restores the default override', async () => {
     render(
       <>
         <ComposerSendShortcutSection />
@@ -94,23 +109,37 @@ describe('ComposerSendShortcutSection', () => {
       </>,
     );
 
-    const switches = screen.getAllByRole('switch', { name: 'Use Ctrl+Enter to send messages' });
-    fireEvent.click(switches[0]);
+    const triggers = screen.getAllByRole('combobox', { name: 'Send shortcut' });
+    await openSelect(triggers[0]);
+    fireEvent.click(screen.getByRole('option', { name: 'Ctrl+Enter always' }));
 
     expect(localStorage.getItem(COMPOSER_SEND_SHORTCUT_STORAGE_KEY)).toBe('modifier-enter');
-    expect(switches[0].getAttribute('data-state')).toBe('checked');
-    expect(switches[1].getAttribute('data-state')).toBe('checked');
+    expect(triggers[0].textContent).toContain('Ctrl+Enter always');
+    expect(triggers[1].textContent).toContain('Ctrl+Enter always');
     expect(screen.getAllByText('Customized')).toHaveLength(2);
 
     fireEvent.click(screen.getAllByRole('button', { name: 'Restore default' })[0]);
 
     expect(localStorage.getItem(COMPOSER_SEND_SHORTCUT_STORAGE_KEY)).toBeNull();
-    expect(switches[0].getAttribute('data-state')).toBe('unchecked');
-    expect(switches[1].getAttribute('data-state')).toBe('unchecked');
+    expect(triggers[0].textContent).toContain('Enter');
+    expect(triggers[1].textContent).toContain('Enter');
     expect(toastMocks.success).toHaveBeenCalledWith('Restored default');
   });
 
-  it('rejects a Composer shortcut that is already used by Voice Input', () => {
+  it('persists the multiline mode', async () => {
+    render(<ComposerSendShortcutSection />);
+
+    const trigger = screen.getByRole('combobox', { name: 'Send shortcut' });
+    await openSelect(trigger);
+    fireEvent.click(screen.getByRole('option', { name: 'Ctrl+Enter for multiline messages' }));
+
+    expect(localStorage.getItem(COMPOSER_SEND_SHORTCUT_STORAGE_KEY)).toBe(
+      'modifier-enter-multiline',
+    );
+    expect(trigger.textContent).toContain('Ctrl+Enter for multiline messages');
+  });
+
+  it('rejects modifier modes when Voice Input already uses the shortcut', async () => {
     setVoiceInputShortcut({
       trigger: 'keyboard',
       code: 'Enter',
@@ -119,14 +148,18 @@ describe('ComposerSendShortcutSection', () => {
     });
 
     render(<ComposerSendShortcutSection />);
+    const trigger = screen.getByRole('combobox', { name: 'Send shortcut' });
 
-    const switchControl = screen.getByRole('switch', { name: 'Use ⌘+Enter to send messages' });
-    fireEvent.click(switchControl);
+    for (const optionName of ['⌘+Enter always', '⌘+Enter for multiline messages']) {
+      await openSelect(trigger);
+      fireEvent.click(screen.getByRole('option', { name: optionName }));
 
-    expect(localStorage.getItem(COMPOSER_SEND_SHORTCUT_STORAGE_KEY)).toBeNull();
-    expect(switchControl.getAttribute('data-state')).toBe('unchecked');
-    expect(toastMocks.error).toHaveBeenCalledWith(
-      'Conflicts with the voice input shortcut. Change either shortcut.',
-    );
+      expect(localStorage.getItem(COMPOSER_SEND_SHORTCUT_STORAGE_KEY)).toBeNull();
+      expect(trigger.textContent).toContain('Enter');
+      expect(toastMocks.error).toHaveBeenCalledWith(
+        'Conflicts with the voice input shortcut. Change either shortcut.',
+      );
+      toastMocks.error.mockReset();
+    }
   });
 });

--- a/apps/desktop/src/renderer/hooks/__tests__/useComposerSendShortcutPreference.test.ts
+++ b/apps/desktop/src/renderer/hooks/__tests__/useComposerSendShortcutPreference.test.ts
@@ -8,6 +8,8 @@ import {
   getComposerSendShortcutPreference,
   getComposerSendShortcutLabel,
   resolveComposerEnterIntent,
+  resolveEffectiveSendMode,
+  usesModifierSendShortcut,
   useComposerSendShortcutPreference,
   type ComposerSendShortcutPreference,
 } from '../useComposerSendShortcutPreference';
@@ -54,9 +56,13 @@ describe('useComposerSendShortcutPreference', () => {
     expect(result.current.isCustomized).toBe(false);
   });
 
-  it('only accepts the modifier-enter override from storage', () => {
+  it('only accepts known non-default overrides from storage', () => {
     localStorage.setItem(KEY, 'modifier-enter');
     expect(getComposerSendShortcutPreference()).toBe('modifier-enter');
+
+    _resetComposerSendShortcutPreferenceForTests();
+    localStorage.setItem(KEY, 'modifier-enter-multiline');
+    expect(getComposerSendShortcutPreference()).toBe('modifier-enter-multiline');
 
     _resetComposerSendShortcutPreferenceForTests();
     localStorage.setItem(KEY, 'enter');
@@ -65,6 +71,17 @@ describe('useComposerSendShortcutPreference', () => {
     _resetComposerSendShortcutPreferenceForTests();
     localStorage.setItem(KEY, 'garbage');
     expect(getComposerSendShortcutPreference()).toBe('enter');
+  });
+
+  it('collapses the multiline mode into the per-draft send semantics', () => {
+    expect(resolveEffectiveSendMode('enter', true)).toBe('enter');
+    expect(resolveEffectiveSendMode('modifier-enter', false)).toBe('modifier-enter');
+    expect(resolveEffectiveSendMode('modifier-enter-multiline', false)).toBe('enter');
+    expect(resolveEffectiveSendMode('modifier-enter-multiline', true)).toBe('modifier-enter');
+
+    expect(usesModifierSendShortcut('enter')).toBe(false);
+    expect(usesModifierSendShortcut('modifier-enter')).toBe(true);
+    expect(usesModifierSendShortcut('modifier-enter-multiline')).toBe(true);
   });
 
   it('persists the non-default override and removes it when reset', () => {
@@ -133,6 +150,7 @@ describe('useComposerSendShortcutPreference', () => {
       preference: ComposerSendShortcutPreference;
       platform: string;
       turnRunning: boolean;
+      multilineDraft?: boolean;
       event: KeyboardEvent;
       expected: 'queue' | 'steer' | 'native' | 'ignore' | null;
     }> = [
@@ -256,12 +274,79 @@ describe('useComposerSendShortcutPreference', () => {
         event: new KeyboardEvent('keydown', { key: 'Escape' }),
         expected: null,
       },
+      {
+        name: 'sends with plain Enter on a single-line draft in multiline mode',
+        preference: 'modifier-enter-multiline',
+        platform: 'darwin',
+        turnRunning: false,
+        multilineDraft: false,
+        event: enterEvent(),
+        expected: 'queue',
+      },
+      {
+        name: 'steers with Cmd+Enter on a single-line draft while running in multiline mode',
+        preference: 'modifier-enter-multiline',
+        platform: 'darwin',
+        turnRunning: true,
+        multilineDraft: false,
+        event: enterEvent({ metaKey: true }),
+        expected: 'steer',
+      },
+      {
+        name: 'uses native Enter for a newline on a multiline draft in multiline mode',
+        preference: 'modifier-enter-multiline',
+        platform: 'darwin',
+        turnRunning: false,
+        multilineDraft: true,
+        event: enterEvent(),
+        expected: 'native',
+      },
+      {
+        name: 'queues with Cmd+Enter on a multiline draft in multiline mode',
+        preference: 'modifier-enter-multiline',
+        platform: 'darwin',
+        turnRunning: true,
+        multilineDraft: true,
+        event: enterEvent({ metaKey: true }),
+        expected: 'queue',
+      },
+      {
+        name: 'keeps a repeated plain Enter native on a multiline draft in multiline mode',
+        preference: 'modifier-enter-multiline',
+        platform: 'darwin',
+        turnRunning: false,
+        multilineDraft: true,
+        event: enterEvent({ repeat: true }),
+        expected: 'native',
+      },
+      {
+        name: 'leaves IME composition native on a multiline draft in multiline mode',
+        preference: 'modifier-enter-multiline',
+        platform: 'darwin',
+        turnRunning: false,
+        multilineDraft: true,
+        event: enterEvent({ isComposing: true }),
+        expected: 'native',
+      },
+      {
+        name: 'ignores Shift+Enter on a multiline draft in multiline mode',
+        preference: 'modifier-enter-multiline',
+        platform: 'darwin',
+        turnRunning: false,
+        multilineDraft: true,
+        event: enterEvent({ shiftKey: true }),
+        expected: null,
+      },
     ];
 
-    it.each(cases)('$name', ({ preference, platform, turnRunning, event, expected }) => {
-      expect(resolveComposerEnterIntent(event, preference, { turnRunning, platform })).toBe(
-        expected,
-      );
+    it.each(cases)('$name', ({ preference, platform, turnRunning, multilineDraft, event, expected }) => {
+      expect(
+        resolveComposerEnterIntent(event, preference, {
+          turnRunning,
+          platform,
+          multilineDraft: multilineDraft ?? false,
+        }),
+      ).toBe(expected);
     });
   });
 });

--- a/apps/desktop/src/renderer/hooks/useComposerSendShortcutPreference.ts
+++ b/apps/desktop/src/renderer/hooks/useComposerSendShortcutPreference.ts
@@ -6,7 +6,10 @@ import { hasComposerModifier } from '@/voice-input/composerShortcut';
 
 export { hasComposerModifier } from '@/voice-input/composerShortcut';
 
-export type ComposerSendShortcutPreference = 'enter' | 'modifier-enter';
+export type ComposerSendShortcutPreference = 'enter' | 'modifier-enter' | 'modifier-enter-multiline';
+
+/** The two concrete key semantics; the multiline preference resolves into one of them per draft. */
+export type ComposerSendMode = 'enter' | 'modifier-enter';
 
 export type ComposerEnterIntent = 'queue' | 'steer' | 'native' | 'ignore' | null;
 
@@ -27,14 +30,33 @@ export function getComposerModifierShortcutLabel(platform: string | undefined): 
 }
 
 export function getComposerSendShortcutLabel(
-  preference: ComposerSendShortcutPreference,
+  mode: ComposerSendMode,
   platform: string | undefined,
 ): string {
-  return preference === 'modifier-enter' ? getComposerModifierShortcutLabel(platform) : 'Enter';
+  return mode === 'modifier-enter' ? getComposerModifierShortcutLabel(platform) : 'Enter';
+}
+
+/** Whether the preference relies on modifier+Enter as the only way to send (some drafts, for the multiline mode). */
+export function usesModifierSendShortcut(preference: ComposerSendShortcutPreference): boolean {
+  return preference !== 'enter';
+}
+
+/**
+ * Collapse the persisted preference into the concrete key semantics for the
+ * current draft. The multiline mode is intentionally not a third branch in the
+ * intent resolver: single-line drafts keep the plain-Enter semantics, multiline
+ * drafts switch to the modifier semantics wholesale.
+ */
+export function resolveEffectiveSendMode(
+  preference: ComposerSendShortcutPreference,
+  multilineDraft: boolean,
+): ComposerSendMode {
+  if (preference === 'modifier-enter-multiline') return multilineDraft ? 'modifier-enter' : 'enter';
+  return preference;
 }
 
 function parsePreference(raw: string | null): ComposerSendShortcutPreference | null {
-  return raw === 'modifier-enter' ? raw : null;
+  return raw === 'modifier-enter' || raw === 'modifier-enter-multiline' ? raw : null;
 }
 
 /**
@@ -47,18 +69,19 @@ function parsePreference(raw: string | null): ComposerSendShortcutPreference | n
 export function resolveComposerEnterIntent(
   event: ComposerEnterEvent,
   preference: ComposerSendShortcutPreference,
-  options: { turnRunning: boolean; platform: string | undefined },
+  options: { turnRunning: boolean; platform: string | undefined; multilineDraft: boolean },
 ): ComposerEnterIntent {
   if (event.key !== 'Enter' || event.shiftKey || event.altKey) return null;
   if (event.isComposing) return 'native';
 
+  const mode = resolveEffectiveSendMode(preference, options.multilineDraft);
   const hasModifier = hasComposerModifier(event, options.platform);
   if (event.repeat) {
-    const isSendShortcut = preference === 'enter' || hasModifier;
+    const isSendShortcut = mode === 'enter' || hasModifier;
     return isSendShortcut ? 'ignore' : 'native';
   }
 
-  if (preference === 'modifier-enter') {
+  if (mode === 'modifier-enter') {
     return hasModifier ? 'queue' : 'native';
   }
 

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -2483,9 +2483,14 @@
     "composer": {
       "title": "Message input",
       "sendShortcut": {
-        "label": "Use {{shortcut}} to send",
-        "hint": "When enabled, {{shortcut}} sends messages. When disabled, Enter sends messages and Shift+Enter inserts a new line.",
-        "ariaLabel": "Use {{shortcut}} to send messages"
+        "label": "Send shortcut",
+        "hint": "Choose when Enter sends the message and when it inserts a new line. Shift+Enter always inserts a new line.",
+        "ariaLabel": "Send shortcut",
+        "options": {
+          "enter": "Enter",
+          "modifier-enter-multiline": "{{shortcut}} for multiline messages",
+          "modifier-enter": "{{shortcut}} always"
+        }
       }
     },
     "linkOpen": {

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -2482,9 +2482,14 @@
     "composer": {
       "title": "メッセージ入力",
       "sendShortcut": {
-        "label": "{{shortcut}}で送信",
-        "hint": "オンにすると{{shortcut}}でメッセージを送信します。オフにするとEnterで送信し、Shift+Enterで改行します。",
-        "ariaLabel": "{{shortcut}}でメッセージを送信"
+        "label": "送信ショートカット",
+        "hint": "Enterで送信するか改行するかを選択します。Shift+Enterは常に改行します。",
+        "ariaLabel": "送信ショートカット",
+        "options": {
+          "enter": "Enter",
+          "modifier-enter-multiline": "複数行のメッセージは{{shortcut}}",
+          "modifier-enter": "常に{{shortcut}}"
+        }
       }
     },
     "linkOpen": {

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -2482,9 +2482,14 @@
     "composer": {
       "title": "메시지 입력",
       "sendShortcut": {
-        "label": "{{shortcut}}로 보내기",
-        "hint": "켜면 {{shortcut}}로 메시지를 보냅니다. 끄면 Enter로 보내고 Shift+Enter로 줄을 바꿉니다.",
-        "ariaLabel": "{{shortcut}}로 메시지 보내기"
+        "label": "보내기 단축키",
+        "hint": "Enter로 언제 메시지를 보내고 언제 줄을 바꿀지 선택합니다. Shift+Enter는 항상 줄을 바꿉니다.",
+        "ariaLabel": "보내기 단축키",
+        "options": {
+          "enter": "Enter",
+          "modifier-enter-multiline": "여러 줄 메시지는 {{shortcut}}",
+          "modifier-enter": "항상 {{shortcut}}"
+        }
       }
     },
     "linkOpen": {

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -2416,9 +2416,14 @@
     "composer": {
       "title": "消息输入",
       "sendShortcut": {
-        "label": "使用 {{shortcut}} 发送",
-        "hint": "开启后按 {{shortcut}} 发送消息；关闭后按 Enter 发送消息，按 Shift+Enter 换行。",
-        "ariaLabel": "使用 {{shortcut}} 发送消息"
+        "label": "发送快捷键",
+        "hint": "选择 Enter 何时发送消息、何时换行。按 Shift+Enter 始终换行。",
+        "ariaLabel": "发送快捷键",
+        "options": {
+          "enter": "Enter",
+          "modifier-enter-multiline": "多行消息用 {{shortcut}}",
+          "modifier-enter": "始终用 {{shortcut}}"
+        }
       }
     },
     "linkOpen": {

--- a/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
@@ -2416,9 +2416,14 @@
     "composer": {
       "title": "訊息輸入",
       "sendShortcut": {
-        "label": "使用 {{shortcut}} 傳送",
-        "hint": "開啟後按 {{shortcut}} 傳送訊息；關閉後按 Enter 傳送訊息，按 Shift+Enter 換行。",
-        "ariaLabel": "使用 {{shortcut}} 傳送訊息"
+        "label": "傳送快捷鍵",
+        "hint": "選擇 Enter 何時傳送訊息、何時換行。按 Shift+Enter 一律換行。",
+        "ariaLabel": "傳送快捷鍵",
+        "options": {
+          "enter": "Enter",
+          "modifier-enter-multiline": "多行訊息用 {{shortcut}}",
+          "modifier-enter": "一律用 {{shortcut}}"
+        }
       }
     },
     "linkOpen": {

--- a/apps/desktop/src/renderer/voice-input/__tests__/composerVoiceInputConflict.test.ts
+++ b/apps/desktop/src/renderer/voice-input/__tests__/composerVoiceInputConflict.test.ts
@@ -74,4 +74,21 @@ describe('findComposerVoiceInputConflict', () => {
       ),
     ).toBe('composer-voice-input');
   });
+
+  it('treats the multiline mode like the modifier mode (modifier+Enter is its only send key for multiline drafts)', () => {
+    expect(
+      findComposerVoiceInputConflict(
+        'modifier-enter-multiline',
+        shortcut({ modifiers: { meta: true, ctrl: false } }),
+        'darwin',
+      ),
+    ).toBe('composer-voice-input');
+    expect(
+      findComposerVoiceInputConflict(
+        'modifier-enter-multiline',
+        shortcut({ modifiers: { meta: false, ctrl: false } }),
+        'win32',
+      ),
+    ).toBeNull();
+  });
 });

--- a/apps/desktop/src/renderer/voice-input/composerVoiceInputConflict.ts
+++ b/apps/desktop/src/renderer/voice-input/composerVoiceInputConflict.ts
@@ -1,4 +1,7 @@
-import type { ComposerSendShortcutPreference } from '@/hooks/useComposerSendShortcutPreference';
+import {
+  usesModifierSendShortcut,
+  type ComposerSendShortcutPreference,
+} from '@/hooks/useComposerSendShortcutPreference';
 import { hasComposerModifier } from './composerShortcut';
 import type { VoiceInputShortcut } from './shortcut';
 
@@ -6,14 +9,15 @@ export type ShortcutConflict = 'composer-voice-input' | null;
 
 /**
  * Return a conflict only when Voice Input owns the platform's complete
- * modifier+Enter combination used by Composer's modifier-send mode.
+ * modifier+Enter combination used by Composer's modifier-send modes
+ * (always, or for multiline drafts — either way it is the only send key).
  */
 export function findComposerVoiceInputConflict(
   preference: ComposerSendShortcutPreference,
   voiceShortcut: VoiceInputShortcut | null,
   platform: string | undefined,
 ): ShortcutConflict {
-  if (preference !== 'modifier-enter' || !voiceShortcut) return null;
+  if (!usesModifierSendShortcut(preference) || !voiceShortcut) return null;
   if (voiceShortcut.trigger === 'modifier' || voiceShortcut.modifiers.fn) return null;
   if (voiceShortcut.code !== 'Enter' || voiceShortcut.key !== 'Enter') return null;
   if (voiceShortcut.modifiers.alt || voiceShortcut.modifiers.shift) return null;

--- a/docs/design-previews/composer-send-shortcut-select/index.html
+++ b/docs/design-previews/composer-send-shortcut-select/index.html
@@ -1,0 +1,260 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+<meta charset="utf-8" />
+<title>发送快捷键三挡 Select — PR #2887 设计预览</title>
+<style>
+  /* token 值逐一取自 apps/desktop/src/renderer/themes/colors.ts(默认主题),
+     结构与类名对齐 ComposerSendShortcutSection.tsx / LanguageSection.tsx 的实现。 */
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", "Microsoft YaHei", sans-serif;
+    background: #ddd; padding: 24px;
+  }
+  h1 { font-size: 18px; margin-bottom: 4px; color: #222; }
+  .meta { font-size: 12px; color: #555; margin-bottom: 20px; line-height: 1.6; }
+  .columns { display: flex; gap: 20px; flex-wrap: wrap; }
+
+  .theme {
+    flex: 1; min-width: 560px; border-radius: 16px; padding: 24px;
+    background: var(--surface);
+  }
+  .theme h2 { font-size: 13px; margin-bottom: 16px; color: var(--text-secondary); font-weight: 500; }
+
+  .light {
+    --surface: #f8f8f6;
+    --card-bg: #faf9f5;            /* --settings-theme-card-bg → surface-card-ivory */
+    --card-border: #d7d7d4;        /* --settings-theme-card-border → border-default */
+    --text-primary: #262626;
+    --text-secondary: #737373;
+    --input-bg: #faf9f5;           /* --settings-input-bg */
+    --input-border: #d7d7d4;       /* --settings-input-border */
+    --input-text: #262626;
+    --eye-icon: #737373;           /* --settings-eye-icon → text-tertiary-stone */
+    --menu-bg-hover: #ececea;      /* --settings-menu-bg-hover */
+    --menu-bg-selected: #e8e8e6;   /* --settings-menu-bg-selected */
+    --menu-text-selected: #262626;
+    --icon-active: #262626;        /* --settings-theme-icon-active → accent-emphasis */
+    --chip: #e5e5e5;               /* --surface-chip(已自定义徽章) */
+    --shadow-menu: 0 4px 16px rgba(0, 0, 0, 0.15);
+    --section-desc: #525252;       /* --settings-section-desc → text-tertiary-mid */
+  }
+  .dark {
+    --surface: #1f1f1e;
+    --card-bg: #2c2c2a;
+    --card-border: #3c3c3a;
+    --text-primary: #d4d4d4;
+    --text-secondary: #a3a3a3;
+    --input-bg: #2c2c2a;
+    --input-border: #3c3c3a;
+    --input-text: #d4d4d4;
+    --eye-icon: #737373;
+    --menu-bg-hover: #2c2c2a;
+    --menu-bg-selected: #2c2c2a;
+    --menu-text-selected: #d4d4d4;
+    --icon-active: #d4d4d4;
+    --chip: #3c3c3a;
+    --shadow-menu: 0 4px 16px rgba(0, 0, 0, 0.5);
+    --section-desc: #737373;
+  }
+
+  .state-label { font-size: 11px; color: var(--text-secondary); margin: 20px 0 8px; }
+  .state-label:first-of-type { margin-top: 0; }
+
+  .section-title { font-size: 16px; font-weight: 500; line-height: 1.2; color: var(--text-primary); margin-bottom: 14px; }
+
+  .card {
+    display: flex; flex-wrap: wrap; align-items: flex-start; justify-content: space-between; gap: 12px;
+    border-radius: 12px; border: 1px solid var(--card-border); background: var(--card-bg); padding: 16px;
+  }
+  .card .label { font-size: 14px; font-weight: 500; line-height: 1.3; color: var(--text-primary); }
+  .card .hint { margin-top: 4px; font-size: 12px; line-height: 1.5; color: var(--text-secondary); }
+  .card .text-col { min-width: 0; flex: 1; }
+  .controls { display: flex; align-items: center; gap: 8px; flex-shrink: 0; }
+
+  .badge {
+    white-space: nowrap; border-radius: 9999px; background: var(--chip);
+    padding: 4px 8px; font-size: 11px; font-weight: 500; line-height: 1; color: var(--text-secondary);
+  }
+  .reset-btn {
+    display: flex; height: 30px; width: 30px; align-items: center; justify-content: center;
+    border-radius: 8px; border: none; background: transparent; color: var(--section-desc); cursor: pointer;
+  }
+
+  .select-trigger {
+    display: flex; height: 36px; width: 280px; max-width: 100%; align-items: center;
+    justify-content: space-between; gap: 12px; border-radius: 9999px;
+    border: 1px solid var(--input-border); background: var(--input-bg);
+    padding: 0 14px; font-size: 13px; color: var(--input-text); cursor: pointer;
+  }
+  .select-trigger .chev { color: var(--eye-icon); flex-shrink: 0; }
+
+  .popover-anchor { position: relative; }
+  .select-panel {
+    position: absolute; top: 42px; right: 0; z-index: 10;
+    width: 280px; border-radius: 12px; border: 1px solid var(--input-border);
+    background: var(--card-bg); box-shadow: var(--shadow-menu); padding: 8px;
+    display: flex; flex-direction: column; gap: 2px;
+  }
+  .option {
+    display: flex; height: 36px; width: 100%; align-items: center; justify-content: space-between;
+    gap: 12px; border-radius: 8px; padding: 0 12px; font-size: 13px; color: var(--input-text);
+  }
+  .option.selected { background: var(--menu-bg-selected); font-weight: 500; color: var(--menu-text-selected); }
+  .option.hovered { background: var(--menu-bg-hover); }
+  .option .check { color: var(--icon-active); }
+  .spacer-for-panel { height: 150px; }
+
+  svg { display: block; }
+
+  table.behavior { margin-top: 24px; border-collapse: collapse; font-size: 12px; background: #fff; border-radius: 8px; overflow: hidden; }
+  table.behavior th, table.behavior td { border: 1px solid #ccc; padding: 6px 12px; text-align: left; color: #333; }
+  table.behavior th { background: #eee; font-weight: 600; }
+</style>
+</head>
+<body>
+  <h1>发送快捷键三挡 Select(PR #2887)</h1>
+  <p class="meta">
+    设置 → 常规 → 消息输入。原「使用 ⌘+Enter 发送」Switch 替换为三选一 Select,结构与 token 逐一对齐
+    <code>LanguageSection.tsx</code> 既有下拉(DESIGN.md §4 Select &amp; Dropdown:药丸 trigger、
+    12px 圆角 popper 面板、面板宽度绑定 trigger、选项行 8px 内层圆角、选中态 check + font-medium)。
+    色值全部取自 <code>themes/colors.ts</code> 默认主题的对应 token,Light / Dark 双列。
+  </p>
+
+  <div class="columns">
+    <!-- ============ Light ============ -->
+    <div class="theme light">
+      <h2>Light</h2>
+
+      <div class="state-label">① 默认态(未自定义,选中 Enter)</div>
+      <div class="section-title">消息输入</div>
+      <div class="card">
+        <div class="text-col">
+          <div class="label">发送快捷键</div>
+          <div class="hint">选择 Enter 何时发送消息、何时换行。按 Shift+Enter 始终换行。</div>
+        </div>
+        <div class="controls">
+          <div class="select-trigger">
+            <span>Enter</span>
+            <svg class="chev" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m6 9 6 6 6-6"/></svg>
+          </div>
+        </div>
+      </div>
+
+      <div class="state-label">② 展开态(hover 在第二项)</div>
+      <div class="card popover-anchor">
+        <div class="text-col">
+          <div class="label">发送快捷键</div>
+          <div class="hint">选择 Enter 何时发送消息、何时换行。按 Shift+Enter 始终换行。</div>
+        </div>
+        <div class="controls popover-anchor">
+          <div class="select-trigger">
+            <span>Enter</span>
+            <svg class="chev" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m6 9 6 6 6-6"/></svg>
+          </div>
+          <div class="select-panel">
+            <div class="option selected">
+              <span>Enter</span>
+              <svg class="check" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20 6 9 17l-5-5"/></svg>
+            </div>
+            <div class="option hovered"><span>多行消息用 ⌘+Enter</span></div>
+            <div class="option"><span>始终用 ⌘+Enter</span></div>
+          </div>
+        </div>
+      </div>
+      <div class="spacer-for-panel"></div>
+
+      <div class="state-label">③ 已自定义态(选中多行挡,出现「已自定义」徽章 + 恢复默认)</div>
+      <div class="card">
+        <div class="text-col">
+          <div class="label">发送快捷键</div>
+          <div class="hint">选择 Enter 何时发送消息、何时换行。按 Shift+Enter 始终换行。</div>
+        </div>
+        <div class="controls">
+          <span class="badge">已自定义</span>
+          <button class="reset-btn" aria-label="恢复默认">
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"/><path d="M3 3v5h5"/></svg>
+          </button>
+          <div class="select-trigger">
+            <span>多行消息用 ⌘+Enter</span>
+            <svg class="chev" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m6 9 6 6 6-6"/></svg>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ============ Dark ============ -->
+    <div class="theme dark">
+      <h2>Dark</h2>
+
+      <div class="state-label">① 默认态(未自定义,选中 Enter)</div>
+      <div class="section-title">消息输入</div>
+      <div class="card">
+        <div class="text-col">
+          <div class="label">发送快捷键</div>
+          <div class="hint">选择 Enter 何时发送消息、何时换行。按 Shift+Enter 始终换行。</div>
+        </div>
+        <div class="controls">
+          <div class="select-trigger">
+            <span>Enter</span>
+            <svg class="chev" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m6 9 6 6 6-6"/></svg>
+          </div>
+        </div>
+      </div>
+
+      <div class="state-label">② 展开态(hover 在第二项;dark 下行高亮与面板同 token,靠 check + 字重区分选中,同语言下拉现状)</div>
+      <div class="card popover-anchor">
+        <div class="text-col">
+          <div class="label">发送快捷键</div>
+          <div class="hint">选择 Enter 何时发送消息、何时换行。按 Shift+Enter 始终换行。</div>
+        </div>
+        <div class="controls popover-anchor">
+          <div class="select-trigger">
+            <span>Enter</span>
+            <svg class="chev" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m6 9 6 6 6-6"/></svg>
+          </div>
+          <div class="select-panel">
+            <div class="option selected">
+              <span>Enter</span>
+              <svg class="check" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20 6 9 17l-5-5"/></svg>
+            </div>
+            <div class="option hovered"><span>多行消息用 ⌘+Enter</span></div>
+            <div class="option"><span>始终用 ⌘+Enter</span></div>
+          </div>
+        </div>
+      </div>
+      <div class="spacer-for-panel"></div>
+
+      <div class="state-label">③ 已自定义态</div>
+      <div class="card">
+        <div class="text-col">
+          <div class="label">发送快捷键</div>
+          <div class="hint">选择 Enter 何时发送消息、何时换行。按 Shift+Enter 始终换行。</div>
+        </div>
+        <div class="controls">
+          <span class="badge">已自定义</span>
+          <button class="reset-btn" aria-label="恢复默认">
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"/><path d="M3 3v5h5"/></svg>
+          </button>
+          <div class="select-trigger">
+            <span>多行消息用 ⌘+Enter</span>
+            <svg class="chev" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m6 9 6 6 6-6"/></svg>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <table class="behavior">
+    <tr><th>挡位</th><th>单行草稿 Enter</th><th>多行草稿 Enter</th><th>⌘/Ctrl+Enter</th><th>Shift/Option+Enter</th></tr>
+    <tr><td>Enter(默认,不变)</td><td>发送</td><td>发送</td><td>空闲发送 / 运行中插话</td><td>换行</td></tr>
+    <tr><td>多行消息用 ⌘+Enter(新增)</td><td>发送</td><td>换行</td><td>单行:同默认;多行:发送</td><td>换行</td></tr>
+    <tr><td>始终用 ⌘+Enter(原开关开启态)</td><td>换行</td><td>换行</td><td>发送</td><td>换行</td></tr>
+  </table>
+
+  <p class="meta" style="margin-top:12px">
+    Windows / Linux 上修饰键显示为 Ctrl+Enter(<code>getComposerModifierShortcutLabel</code>)。
+    发送按钮 tooltip 在多行挡下随草稿单行/多行实时切换显示 Enter 或 ⌘/Ctrl+Enter。
+  </p>
+</body>
+</html>

--- a/docs/design-previews/composer-send-shortcut-select/index.html
+++ b/docs/design-previews/composer-send-shortcut-select/index.html
@@ -36,7 +36,6 @@
     --menu-text-selected: #262626;
     --icon-active: #262626;        /* --settings-theme-icon-active → accent-emphasis */
     --chip: #e5e5e5;               /* --surface-chip(已自定义徽章) */
-    --shadow-menu: 0 4px 16px rgba(0, 0, 0, 0.15);
     --section-desc: #525252;       /* --settings-section-desc → text-tertiary-mid */
   }
   .dark {
@@ -54,7 +53,6 @@
     --menu-text-selected: #d4d4d4;
     --icon-active: #d4d4d4;
     --chip: #3c3c3a;
-    --shadow-menu: 0 4px 16px rgba(0, 0, 0, 0.5);
     --section-desc: #737373;
   }
 
@@ -93,7 +91,7 @@
   .select-panel {
     position: absolute; top: 42px; right: 0; z-index: 10;
     width: 280px; border-radius: 12px; border: 1px solid var(--input-border);
-    background: var(--card-bg); box-shadow: var(--shadow-menu); padding: 8px;
+    background: var(--card-bg); padding: 8px;
     display: flex; flex-direction: column; gap: 2px;
   }
   .option {
@@ -117,7 +115,7 @@
   <p class="meta">
     设置 → 常规 → 消息输入。原「使用 ⌘+Enter 发送」Switch 替换为三选一 Select,结构与 token 逐一对齐
     <code>LanguageSection.tsx</code> 既有下拉(DESIGN.md §4 Select &amp; Dropdown:药丸 trigger、
-    12px 圆角 popper 面板、面板宽度绑定 trigger、选项行 8px 内层圆角、选中态 check + font-medium)。
+    12px 圆角 popper 面板、无阴影、面板宽度绑定 trigger、选项行 8px 内层圆角、选中态 check + font-medium)。
     色值全部取自 <code>themes/colors.ts</code> 默认主题的对应 token,Light / Dark 双列。
   </p>
 


### PR DESCRIPTION
## 这次改了什么

### 摘要

把 Composer 发送快捷键从二元开关(Enter / ⌘+Enter 发送)升级为三挡下拉,新增中间挡「多行消息用 ⌘/Ctrl+Enter」:草稿只有一行时 Enter 直接发送,草稿已是多行时 Enter 换行、修饰键+Enter 才发送。单行快消息不用改肌肉记忆,多行长文不再误发——这是二元开关覆盖不了的"两头都要"场景,与 ChatGPT/Codex 桌面端 Composer 设置(Enter / ⌘+Enter for multiline prompts / ⌘+Enter always)对齐。

实现方式:新挡位不进入 `resolveComposerEnterIntent` 的分支树,而是入口处一步偏好归约(`resolveEffectiveSendMode`)——单行草稿整体走既有 `enter` 语义,多行草稿整体走既有 `modifier-enter` 语义。resolver 主体分支零改动,IME、按键重复、Shift/Alt+Enter、结构化列表拦截等边界行为全部保持不变。

### 变更类型

- [x] `feat` 新功能

### 范围

- 关联 Issue / 需求:#2725(维护者已确认二元开关由 #1346 落地;本 PR 是其上的增量——新增第三挡,不改任何既有语义)
- 本 PR 包含:偏好第三值 `modifier-enter-multiline`、偏好归约函数、多行草稿判定(`composerDraftMultiline.ts`)、ChatInput 两条 keydown 路径接线、渲染门快照增加单行/多行边界、设置页 Switch → 三选一 Select、语音快捷键冲突守卫覆盖新挡位、五语言文案、配套测试
- 明确不包含:PendingQueuePanel / UserMessageEditBox / AskUserQuestionPrompt 等次级输入框的快捷键偏好接入(它们此前也不读该偏好,维持现状)
- 用户可见变化:设置 → 常规 → 消息输入,原「使用 ⌘+Enter 发送」开关变为「发送快捷键」三选一下拉;发送按钮 tooltip 在多行挡下随草稿形态实时显示 Enter 或 ⌘/Ctrl+Enter
- 是否存在 breaking change:无。已存的 `enter` / `modifier-enter` 值与语义完全不变,默认值不变

### UI 变化

设置卡片内的控件由 Switch 替换为 Radix Select 下拉(布局、卡片样式、恢复默认控件不变)。

**界面效果预览**(HTML,token 值逐一取自 `themes/colors.ts` 默认主题,结构对齐实现代码):

- 仓内文件:[`docs/design-previews/composer-send-shortcut-select/index.html`](https://github.com/zyfayes/cindy/blob/feat/composer-send-shortcut-three-mode/docs/design-previews/composer-send-shortcut-select/index.html)(随本 PR 提交)
- 在线预览:https://htmlpreview.github.io/?https://github.com/zyfayes/cindy/blob/feat/composer-send-shortcut-three-mode/docs/design-previews/composer-send-shortcut-select/index.html

覆盖 Light / Dark × (默认态 / 展开态 / 已自定义态) 共 6 个状态,附三挡按键行为对照表。

- 引用的设计规范:
  - DESIGN.md §4「Select & Dropdown」:Trigger 药丸(rounded-full)+ Card bg + 1px border;Panel 12px 圆角、`position="popper"`、面板宽度绑定 trigger 宽度(`w-[var(--radix-select-trigger-width)]`);选项行高亮 8px 内层圆角(`rounded-[8px]`)、选中态 check + font-medium——实现整体复用 `LanguageSection.tsx` 既有 Select 结构与全套 `--settings-*` 语义 token
  - DESIGN.md §10「Light / Dark 双模式交付门槛」:颜色全部经语义 token 消费,无硬编码色值;实机目检情况如实登记在「未执行的验证」

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果:PASS apps/desktop unit(相关测试 10 文件 93 用例全过,含新增:多行挡行为表 7 例、
偏好归约与守卫单测、渲染门单/多行边界、multiline 判定 4 例、设置 Select 交互 4 例、
语音冲突新挡位 2 例)

pnpm --filter desktop run typecheck
结果:通过,无错误

pnpm check:i18n
结果:✅ zh-CN / zh-TW / en / ja / ko 共 7311 个 key 全部一致(警告均为存量)

pnpm check:i18n-glossary
结果:✅ 无新增违规

pnpm check:dco
结果:✅ 1 commit signed off
```

### 手工验证

不涉及(未运行实机,理由见下)。

### 未执行的验证

- Light / Dark **实机**目检未执行:本地无可运行的 dev 实例。已按 review 要求补充双模式 HTML 预览页(见「UI 变化」,token 取实值、结构对齐实现),并经浏览器截图目检;但按 §10 口径这仍不等同实机验证,如实登记。
- 实机键入行为(IME 组合、长按重复)未实机复验,依赖既有单测行为表覆盖(这些用例在 #1346 时已建立,本次全部保持通过)。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] 其他

### 影响与回滚

- 影响范围:仅 renderer 侧 Composer 发送快捷键与其设置卡;偏好仍存 localStorage 单 key `chat.sendShortcutPreference`
- 回滚 / 降级方式:revert 本 commit 即可。降级兼容:旧版本客户端读到新值 `modifier-enter-multiline` 时 `parsePreference` 不识别,回落默认 `enter`(Enter 发送),无崩溃、无数据损失;升级回来偏好值仍在

配置项说明(per docs/dev-rules/configuration-and-overrides.md):

1. 配置层级:常规可见(既有设置卡升级,不新增入口)
2. 默认值:维持 `enter`,存量与新用户零影响;推荐理由:默认承载既有习惯,不替用户做选择
3. override 记录:localStorage 单 key,`isCustomized = preference !== 'enter'`(沿用既有 hook 机制)
4. 未自定义用户随版本跟随默认;已自定义(`modifier-enter`)用户原值原语义
5. 恢复默认 = removeItem 删除 override(沿用既有「恢复默认」控件),非写入默认快照

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`,见 [DCO](../DCO))
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节(不涉及 UI 则跳过)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
