### PR TITLE
fix(desktop): 移除已连接设备的绿色状态点

### DIFF
--- a/apps/desktop/src/renderer/__tests__/sidebarRemoteProjectIcon.test.ts
+++ b/apps/desktop/src/renderer/__tests__/sidebarRemoteProjectIcon.test.ts
@@ -91,6 +91,16 @@ describe('sidebar remote project icon', () => {
     );
   });
 
+  // 2026-08-17 用户裁决:绿点容易被误认成未读标记。在线是设备段的常态,不额外画点;
+  // 离线仍保留灰点 + 文字,异常状态不能静默。
+  it('shows a status dot only for offline device group headers', () => {
+    expect(projectsSectionSource).not.toContain('bg-[var(--card-status-done)]');
+    expect(projectsSectionSource).toMatch(
+      /\{!online && \([\s\S]*?bg-\[var\(--text-tertiary\)\][\s\S]*?\)\}/,
+    );
+    expect(projectsSectionSource).toContain("t('ccAgent.sidebar.deviceGroup.offline')");
+  });
+
   // 2026-08-12 用户裁决:按设备分组时列表已按设备切段、段头写着设备名,项目行不再
   // 重复标注归属;远程图标保留(表达「远程 + 连接状态」,不重复归属信息)。
   it('drops the per-row machine label while device grouping is active, keeping the remote icon', () => {

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/sections/ProjectsSection.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/sections/ProjectsSection.tsx
@@ -809,7 +809,7 @@ export function ProjectsSection({
               const sectionCollapsed = collapsedDevices.has(key);
               return (
                 <div key={key} className="flex flex-col gap-1">
-                  {/* 设备分组头:可折叠,在线状态点(绿/灰)+ 名称 + 条数。 */}
+                  {/* 设备分组头:可折叠。在线设备不画状态点;离线设备保留灰点与文字提示。 */}
                   <button
                     type="button"
                     onClick={() => toggleDeviceSection(key)}
@@ -831,13 +831,12 @@ export function ProjectsSection({
                     )}
                     <MonitorSmartphone size={13} strokeWidth={2} className="shrink-0" />
                     <span className="min-w-0 truncate text-xs font-medium">{name}</span>
-                    <span
-                      aria-hidden
-                      className={cn(
-                        'size-1.5 shrink-0 rounded-full',
-                        online ? 'bg-[var(--card-status-done)]' : 'bg-[var(--text-tertiary)]',
-                      )}
-                    />
+                    {!online && (
+                      <span
+                        aria-hidden
+                        className="size-1.5 shrink-0 rounded-full bg-[var(--text-tertiary)]"
+                      />
+                    )}
                     {/* 条数已去掉(2026-08-12 用户裁决):它数的是顶层条目
                           (项目行 + 散排对话 + 对话组),不是任务数,读起来只会误导;
                           段展开后内容本身就是答案。「离线」接手 ml-auto 保持靠右。 */}


### PR DESCRIPTION
## 这次改了什么

### 摘要

移除侧边栏设备分组标题中“已连接/在线”设备的绿色状态点，避免它被误认为未读标记。离线设备仍保留灰色状态点和“离线”文字，不削弱异常状态提示。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：用户反馈已连接设备的绿点容易与未读状态混淆
- 本 PR 包含：在线设备不再渲染状态点；离线设备继续显示灰点和“离线”；补充防回退测试
- 明确不包含：设备连接状态判定、同步与重连逻辑调整
- 用户可见变化：已连接设备名称旁不再出现绿点
- 是否存在 breaking change：无

### UI 变化

- 未附截图：本次未启动 Desktop 实机预览，变化仅为移除在线状态点
- 引用的设计规范：`docs/design-rules/DESIGN.md` §2 Semantic & Accent（状态颜色只表达必要语义，不用绿色重复表达常态）；§10 Light / Dark Dual-Mode Delivery Gate（未新增硬编码颜色，离线提示继续使用现有语义 token，兼容 Light / Dark）

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：通过，Desktop related tests 全部通过

pnpm --filter desktop run --if-present typecheck
结果：通过

bash /Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh /Users/dash/Code/Cindy/cindy-remove-connected-device-green-dot
结果：25,901 项通过、2 项失败；失败均为与本 PR 无关的 ghostInstallReceipt 基线测试

在干净 main（f97944a3）执行：
pnpm --filter desktop exec vitest run src/main/cindy-brain/__tests__/ghostInstallReceipt.test.ts
结果：同样稳定复现 2 项失败，确认是当前 main 基线问题
```

### 手工验证

未执行 Desktop 实机预览。

### 未执行的验证

- 未做 Light / Dark 实机目检；本次只移除在线状态点，离线状态继续复用既有主题语义 token
- 完整单测未全绿；仅剩当前 `main` 可复现的 2 项无关基线失败，交由 CI 再确认

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Desktop 侧边栏设备分组标题的在线状态视觉
- 回滚 / 降级方式：恢复在线状态点的条件渲染即可

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已确认无需补充产品文档
- [x] 已确认测试结果并说明未执行与基线失败原因
