### PR TITLE
feat(desktop): 设置内嵌插件目录并放开未登录公开市场

### DIFF
--- a/apps/desktop/src/main/plugin-market/__tests__/service.test.ts
+++ b/apps/desktop/src/main/plugin-market/__tests__/service.test.ts
@@ -218,10 +218,7 @@ function detail(
   };
 }
 
-function reviewedInstallOptions(
-  item: VisiblePluginSummary,
-  allowSourceReplacement = false,
-) {
+function reviewedInstallOptions(item: VisiblePluginSummary, allowSourceReplacement = false) {
   return {
     expectedReleaseId: item.currentRelease.id,
     allowSourceReplacement,
@@ -400,21 +397,36 @@ describe('PluginMarketService migration and defaultInstall', () => {
     expect(h.api.listAll).toHaveBeenCalledTimes(1);
   });
 
-  it('keeps signed-out sessions out of the market until an owner is selected', async () => {
+  it('shows public market plugins when signed out without leaking local install state', async () => {
     runtime.session = {
       mode: 'signed-out',
       dataOwnerId: null,
       generation: 2,
     };
-    const h = harness([summary()]);
+    runtime.ghosts = [
+      {
+        manifest: manifest(),
+        dir: '/userData/cindy-brain/cindy-test',
+        enabled: true,
+      },
+    ];
+    const publicPlugin = summary();
+    const organizationPlugin = summary({
+      id: `c${'b'.repeat(24)}`,
+      ghostId: 'cindy-team-only',
+      scope: 'organization',
+      organizationId: 'org-1',
+    });
+    const h = harness([publicPlugin, organizationPlugin]);
 
-    await expect(h.service.snapshot()).resolves.toEqual({
-      items: [],
-      unavailableReason: 'authentication-required',
+    await expect(h.service.snapshot()).resolves.toMatchObject({
+      items: [{ pluginId: publicPlugin.id, scope: 'public', installState: 'not-installed' }],
+      unavailableReason: null,
       customSourceNames: [],
       unavailableCustomSourceNames: [],
     });
-    expect(h.api.listAll).not.toHaveBeenCalled();
+    expect(h.api.listAll).toHaveBeenCalledTimes(1);
+    expect(runtime.install).not.toHaveBeenCalled();
   });
 
   it('reports missing market configuration before requiring authentication', async () => {
@@ -1096,11 +1108,7 @@ describe('PluginMarketService migration and defaultInstall', () => {
     const h = harness([item]);
     const confirmReview = vi.fn(async () => true);
 
-    const installing = h.service.install(
-      item.id,
-      reviewedInstallOptions(item),
-      confirmReview,
-    );
+    const installing = h.service.install(item.id, reviewedInstallOptions(item), confirmReview);
     await commitStarted.promise;
     await new Promise<void>((resolve) => setImmediate(resolve));
     expect(fs.existsSync(reviewedTempPath)).toBe(true);
@@ -1256,9 +1264,7 @@ describe('PluginMarketService migration and defaultInstall', () => {
     ).resolves.toMatchObject({
       ghost: { manifest: { version: '2.0.0' } },
     });
-    expect(runtime.install.mock.calls[0]?.[1]).not.toHaveProperty(
-      'permissionBaselineManifest',
-    );
+    expect(runtime.install.mock.calls[0]?.[1]).not.toHaveProperty('permissionBaselineManifest');
     expect(h.ledger.installationForGhost(item.ghostId)).toMatchObject({
       pluginId: item.id,
       source: 'market',
@@ -1294,9 +1300,7 @@ describe('PluginMarketService migration and defaultInstall', () => {
       expectedInstalledApproval: APPROVED_INSTALL_TOKEN,
     });
 
-    expect(runtime.install.mock.calls[0]?.[1]).not.toHaveProperty(
-      'permissionBaselineManifest',
-    );
+    expect(runtime.install.mock.calls[0]?.[1]).not.toHaveProperty('permissionBaselineManifest');
   });
 
   it('installs and enables a public defaultInstall package in local mode', async () => {
@@ -1356,7 +1360,12 @@ describe('PluginMarketService migration and defaultInstall', () => {
       roots.push(installDir);
       fs.writeFileSync(path.join(installDir, 'ghost.json'), JSON.stringify(oldManifest));
       runtime.ghosts = [
-        { manifest: oldManifest, dir: installDir, enabled: false, approval: { state: approvalState } },
+        {
+          manifest: oldManifest,
+          dir: installDir,
+          enabled: false,
+          approval: { state: approvalState },
+        },
       ];
       const h = harness([item]);
       h.ledger.upsertInstallation({
@@ -2108,23 +2117,22 @@ describe('PluginMarketService migration and defaultInstall', () => {
     expect(runtime.install).not.toHaveBeenCalled();
   });
 
-  it('hides account-managed public plugins from account-free local mode', async () => {
+  it('shows account-managed public plugins in account-free local mode without auto-installing them', async () => {
     runtime.session = {
       mode: 'local',
       dataOwnerId: 'local-v1',
       generation: 2,
     };
-    const item = summary({ ghostId: 'cindy-github' });
+    const item = summary({ ghostId: 'cindy-art', defaultInstall: true });
     runtime.accountGhostAvailable = false;
     const h = harness([item]);
 
-    await expect(h.service.snapshot()).resolves.toEqual({
-      items: [],
+    await expect(h.service.snapshot()).resolves.toMatchObject({
+      items: [{ pluginId: item.id, ghostId: 'cindy-art', installState: 'not-installed' }],
       unavailableReason: null,
-      customSourceNames: [],
-      unavailableCustomSourceNames: [],
     });
     expect(h.api.listAll).toHaveBeenCalledOnce();
+    expect(runtime.install).not.toHaveBeenCalled();
   });
 
   it('does not re-enable an installed defaultInstall package disabled by the user', async () => {
@@ -2213,9 +2221,7 @@ describe('PluginMarketService migration and defaultInstall', () => {
     const completeLocalUninstall = h.service.prepareLocalUninstallTracking(item.ghostId);
     expect(completeLocalUninstall).not.toBeNull();
 
-    const downloadMock = vi.mocked(
-      (await import('../download.js')).downloadVerifiedPlugin,
-    );
+    const downloadMock = vi.mocked((await import('../download.js')).downloadVerifiedPlugin);
     const downloadStarted = deferred();
     const downloadGate = deferred();
     downloadMock.mockImplementationOnce(async () => {
@@ -2581,9 +2587,7 @@ describe('PluginMarketService migration and defaultInstall', () => {
     ).resolves.toMatchObject({
       ghost: { manifest: { id: item.ghostId } },
     });
-    expect(runtime.install.mock.calls[0]?.[1]).not.toHaveProperty(
-      'permissionBaselineManifest',
-    );
+    expect(runtime.install.mock.calls[0]?.[1]).not.toHaveProperty('permissionBaselineManifest');
     expect(h.ledger.installationForGhost(item.ghostId)).toMatchObject({
       pluginId: item.id,
       source: 'market',
@@ -2654,17 +2658,21 @@ describe('PluginMarketService migration and defaultInstall', () => {
       releaseId: 'release-1',
       version: '1.0.0',
     });
-    await expect(
-      h.service.install(item.id, reviewedInstallOptions(item)),
-    ).rejects.toThrow('[PRECONDITION_FAILED]');
+    await expect(h.service.install(item.id, reviewedInstallOptions(item))).rejects.toThrow(
+      '[PRECONDITION_FAILED]',
+    );
     expect(runtime.install).not.toHaveBeenCalled();
 
     const confirmReview = vi.fn(async () => true);
     await expect(
-      h.service.install(item.id, {
-        ...reviewedInstallOptions(item),
-        expectedInstalledApproval: APPROVED_INSTALL_TOKEN,
-      }, confirmReview),
+      h.service.install(
+        item.id,
+        {
+          ...reviewedInstallOptions(item),
+          expectedInstalledApproval: APPROVED_INSTALL_TOKEN,
+        },
+        confirmReview,
+      ),
     ).resolves.toMatchObject({
       ghost: { manifest: { version: '2.0.0' } },
     });
@@ -2907,9 +2915,7 @@ describe('PluginMarketService migration and defaultInstall', () => {
     ).resolves.toMatchObject({
       ghost: { manifest: { version: '2.0.0' } },
     });
-    expect(runtime.install.mock.calls[0]?.[1]).not.toHaveProperty(
-      'permissionBaselineManifest',
-    );
+    expect(runtime.install.mock.calls[0]?.[1]).not.toHaveProperty('permissionBaselineManifest');
   });
 
   it('rejects an update when the installed target disappears during download', async () => {
@@ -3137,14 +3143,14 @@ describe('market detail 响应身份绑定', () => {
     h.api.detail.mockImplementation(async () =>
       detail({ ...item, id: 'plg_other', ghostId: 'cindy-other' }),
     );
-    await expect(
-      h.service.install(item.id, reviewedInstallOptions(item)),
-    ).rejects.toThrow('[PRECONDITION_FAILED]');
+    await expect(h.service.install(item.id, reviewedInstallOptions(item))).rejects.toThrow(
+      '[PRECONDITION_FAILED]',
+    );
     // 只换 ghostId、id 相同也要拒:可见性与 ghostId 冲突判定都基于目录 summary。
     h.api.detail.mockImplementation(async () => detail({ ...item, ghostId: 'cindy-other' }));
-    await expect(
-      h.service.install(item.id, reviewedInstallOptions(item)),
-    ).rejects.toThrow('[PRECONDITION_FAILED]');
+    await expect(h.service.install(item.id, reviewedInstallOptions(item))).rejects.toThrow(
+      '[PRECONDITION_FAILED]',
+    );
     await expect(h.service.detail(item.id)).rejects.toThrow('[PRECONDITION_FAILED]');
     h.api.detail.mockImplementation(async () => detail({ ...item, id: 'plg_other' }));
     await expect(h.service.detail(item.id)).rejects.toThrow('[PRECONDITION_FAILED]');

--- a/apps/desktop/src/main/plugin-market/__tests__/service.test.ts
+++ b/apps/desktop/src/main/plugin-market/__tests__/service.test.ts
@@ -2185,6 +2185,24 @@ describe('PluginMarketService migration and defaultInstall', () => {
     expect(runtime.install).not.toHaveBeenCalled();
   });
 
+  it('rejects installing an account-managed public plugin in account-free local mode', async () => {
+    runtime.session = {
+      mode: 'local',
+      dataOwnerId: 'local-v1',
+      generation: 2,
+    };
+    runtime.accountGhostAvailable = false;
+    const item = summary({ ghostId: 'cindy-art', defaultInstall: true });
+    const h = harness([item]);
+
+    await expect(h.service.install(item.id, reviewedInstallOptions(item))).rejects.toThrow(
+      '[PERMISSION_DENIED]',
+    );
+    expect(h.api.detail).not.toHaveBeenCalled();
+    expect(h.api.download).not.toHaveBeenCalled();
+    expect(runtime.install).not.toHaveBeenCalled();
+  });
+
   it('does not re-enable an installed defaultInstall package disabled by the user', async () => {
     const item = summary({ defaultInstall: true });
     runtime.ghosts = [

--- a/apps/desktop/src/main/plugin-market/__tests__/service.test.ts
+++ b/apps/desktop/src/main/plugin-market/__tests__/service.test.ts
@@ -429,6 +429,56 @@ describe('PluginMarketService migration and defaultInstall', () => {
     expect(runtime.install).not.toHaveBeenCalled();
   });
 
+  it('shows public market plugin detail when signed out without leaking local install state', async () => {
+    runtime.session = {
+      mode: 'signed-out',
+      dataOwnerId: null,
+      generation: 2,
+    };
+    runtime.ghosts = [
+      {
+        manifest: manifest(),
+        dir: '/userData/cindy-brain/cindy-test',
+        enabled: true,
+      },
+    ];
+    const publicPlugin = summary();
+    const organizationPlugin = summary({
+      id: `c${'b'.repeat(24)}`,
+      ghostId: 'cindy-team-only',
+      scope: 'organization',
+      organizationId: 'org-1',
+    });
+    const h = harness([publicPlugin, organizationPlugin]);
+
+    await expect(h.service.detail(publicPlugin.id)).resolves.toMatchObject({
+      pluginId: publicPlugin.id,
+      scope: 'public',
+      installState: 'not-installed',
+      enabled: null,
+    });
+    await expect(h.service.detail(organizationPlugin.id)).rejects.toThrow('[NOT_FOUND]');
+    await expect(
+      h.service.install(publicPlugin.id, reviewedInstallOptions(publicPlugin)),
+    ).rejects.toThrow('[PRECONDITION_FAILED]');
+    expect(runtime.install).not.toHaveBeenCalled();
+  });
+
+  it('keeps signed-out detail blocked while the account boundary is pending', async () => {
+    runtime.boundaryPending = true;
+    runtime.session = {
+      mode: 'signed-out',
+      dataOwnerId: null,
+      generation: 2,
+    };
+    const item = summary();
+    const h = harness([item]);
+
+    await expect(h.service.detail(item.id)).rejects.toThrow('[PRECONDITION_FAILED]');
+    expect(h.api.listAll).not.toHaveBeenCalled();
+    expect(h.api.detail).not.toHaveBeenCalled();
+  });
+
   it('reports missing market configuration before requiring authentication', async () => {
     runtime.pluginApiBaseUrl = null;
     runtime.session = {

--- a/apps/desktop/src/main/plugin-market/service.ts
+++ b/apps/desktop/src/main/plugin-market/service.ts
@@ -969,6 +969,9 @@ export class PluginMarketService {
       if (!selected) {
         throwIpcError('NOT_FOUND', 'Plugin is unavailable to the active account');
       }
+      if (!isGhostAvailableForActiveSession(selected.ghostId)) {
+        throwIpcError('PERMISSION_DENIED', 'This Plugin requires a Cindy account');
+      }
       const plugin = await this.api.detail(pluginId);
       requireSameMarketOwner(owner);
       // 详情响应必须与请求的 pluginId 绑定:server 换身份会让用户审阅到别的插件。

--- a/apps/desktop/src/main/plugin-market/service.ts
+++ b/apps/desktop/src/main/plugin-market/service.ts
@@ -142,6 +142,15 @@ function captureMarketOwner(): ActiveAppSession {
   return session;
 }
 
+function canCaptureMarketOwner(): boolean {
+  const session = getActiveAppSession();
+  return (
+    (session.mode === 'cloud' || session.mode === 'local') &&
+    Boolean(session.dataOwnerId) &&
+    !isAppSessionBoundaryPending()
+  );
+}
+
 function requireSameMarketOwner(expected: ActiveAppSession): void {
   const current = getActiveAppSession();
   if (
@@ -680,6 +689,33 @@ export class PluginMarketService {
     }
   }
 
+  /** 未登录只读公开插件详情；安装仍必须走 owner 门禁。 */
+  private async detailPublicCatalogWithoutOwner(pluginId: string): Promise<PluginMarketDetail> {
+    const catalog = await this.api.listAll();
+    const summary = catalog.plugins.find(
+      (plugin) => plugin.id === pluginId && plugin.scope === 'public',
+    );
+    if (!summary) {
+      throwIpcError('NOT_FOUND', 'Plugin is unavailable to the active account');
+    }
+    const plugin = await this.api.detail(pluginId);
+    assertDetailMatchesSummary(summary, plugin);
+    if (plugin.scope !== 'public') {
+      throwIpcError('NOT_FOUND', 'Plugin is unavailable to the active account');
+    }
+    const compatible = validateGhostManifest(plugin.currentRelease.manifest);
+    if (!compatible.ok) {
+      throwIpcError('GHOST_FILE_INVALID', 'This Plugin manifest is not supported');
+    }
+    if (!manifestSupportsCurrentCindy(compatible.manifest)) {
+      throwIpcError('NOT_FOUND', 'This Plugin is unavailable for this Cindy version');
+    }
+    return {
+      ...this.toItem(plugin, EMPTY_LOCAL_INSTALL_SNAPSHOT),
+      manifest: compatible.manifest,
+    };
+  }
+
   /** 按当前 owner 消费一次清理汇总，避免组织插件名跨账号泄露。 */
   consumeRemovalNotice(): PluginRemovalUserNotice | null {
     const key = removalNoticeKey(captureMarketOwner());
@@ -721,6 +757,12 @@ export class PluginMarketService {
       throwIpcError('INVALID_PARAMS', 'Invalid Plugin ID');
     }
     this.requireConfigured();
+    if (!canCaptureMarketOwner()) {
+      if (isAppSessionBoundaryPending()) {
+        throwIpcError('PRECONDITION_FAILED', 'Plugin market requires a stable app session');
+      }
+      return this.detailPublicCatalogWithoutOwner(pluginId);
+    }
     return this.runForOwner(async (owner) => {
       // 本地(免账号)模式只对 public 插件暴露详情;目录 summary 也是 detail 身份
       // 绑定的依据,服务端返回的 id/ghostId/scope 与请求不一致时必须拒,防止把

--- a/apps/desktop/src/main/plugin-market/service.ts
+++ b/apps/desktop/src/main/plugin-market/service.ts
@@ -159,21 +159,16 @@ function visiblePluginsForOwner(
   plugins: readonly VisiblePluginSummary[],
 ): VisiblePluginSummary[] {
   return owner.mode === 'local'
-    ? plugins.filter(
-        (plugin) => plugin.scope === 'public' && isGhostAvailableForActiveSession(plugin.ghostId),
-      )
+    ? plugins.filter((plugin) => plugin.scope === 'public')
     : [...plugins];
 }
 
-/** 单条详情由服务端完成账号授权；本地模式仍需执行客户端能力边界。 */
+/** 目录 / 详情只按 scope 收口；账号能力只挡住运行时与默认安装。 */
 function requirePluginVisibleForOwner(
   owner: ActiveAppSession,
   plugin: VisiblePluginSummary | VisiblePluginDetail,
 ): void {
-  if (
-    owner.mode === 'local' &&
-    (plugin.scope !== 'public' || !isGhostAvailableForActiveSession(plugin.ghostId))
-  ) {
+  if (owner.mode === 'local' && plugin.scope !== 'public') {
     throwIpcError('NOT_FOUND', 'Plugin is unavailable to the active account');
   }
 }
@@ -477,6 +472,13 @@ interface LocalInstallSnapshot {
   rawDigestByGhostId: ReadonlyMap<string, string | null>;
 }
 
+/** 未登录浏览公开目录时不读本机账本 / 已装列表，避免带出上一账号的安装态。 */
+const EMPTY_LOCAL_INSTALL_SNAPSHOT: LocalInstallSnapshot = {
+  ghostsById: new Map(),
+  installations: {},
+  rawDigestByGhostId: new Map(),
+};
+
 /**
  * 清理通告 pending 汇总的 owner 隔离键。**故意不含 generation**：同一 owner
  * 重新登录（换代）后，未消费的通知仍应展示，不随会话代际作废。
@@ -527,19 +529,25 @@ export class PluginMarketService {
     try {
       owner = captureMarketOwner();
     } catch {
-      // 无稳定会话(未登录/切换中):无法可靠确定自定义数据该按哪个账号
-      // 现查,返回空自定义项并标记原因,避免在切换窗口期把上一账号的
-      // 插件数据返回给当前 Renderer。
-      return {
-        items: [],
-        unavailableReason: isAppSessionBoundaryPending()
-          ? 'session-switching'
-          : getClientEndpoint('pluginApiBaseUrl')
-            ? 'authentication-required'
-            : 'not-configured',
-        customSourceNames: [],
-        unavailableCustomSourceNames: [],
-      };
+      // 切号窗口仍 fail-closed。未登录可以浏览公开目录，但不读自定义来源
+      // 或本机账本，避免把上一账号的插件数据交给当前 Renderer。
+      if (isAppSessionBoundaryPending()) {
+        return {
+          items: [],
+          unavailableReason: 'session-switching',
+          customSourceNames: [],
+          unavailableCustomSourceNames: [],
+        };
+      }
+      if (!getClientEndpoint('pluginApiBaseUrl')) {
+        return {
+          items: [],
+          unavailableReason: 'not-configured',
+          customSourceNames: [],
+          unavailableCustomSourceNames: [],
+        };
+      }
+      return this.snapshotPublicCatalogWithoutOwner();
     }
     const iconProjectionGeneration = this.nextCustomIconProjectionGeneration();
     const customSourceNames = this.customSourceNamesSafe(owner);
@@ -563,10 +571,7 @@ export class PluginMarketService {
     let customDiscovery: CustomMarketDiscovery;
     try {
       // 官方目录与自定义发现并行；单个本地/网络盘来源卡顿不会串行拖住官方请求。
-      const [catalog, discovered] = await Promise.all([
-        this.api.listAll(),
-        customDiscoveryPromise,
-      ]);
+      const [catalog, discovered] = await Promise.all([this.api.listAll(), customDiscoveryPromise]);
       plugins = visiblePluginsForOwner(owner, catalog.plugins);
       removals = catalog.removals;
       customDiscovery = discovered;
@@ -648,6 +653,31 @@ export class PluginMarketService {
         .finally(options.onDeferredReconciliationSettled);
     }
     return snapshot;
+  }
+
+  /** 未登录只浏览公开目录：不读自定义来源、不跑默认安装、不投影本机已装态。 */
+  private async snapshotPublicCatalogWithoutOwner(): Promise<PluginMarketSnapshot> {
+    try {
+      const catalog = await this.api.listAll();
+      return {
+        items: catalog.plugins
+          .filter((plugin) => plugin.scope === 'public')
+          .map((plugin) => this.toItem(plugin, EMPTY_LOCAL_INSTALL_SNAPSHOT)),
+        unavailableReason: null,
+        customSourceNames: [],
+        unavailableCustomSourceNames: [],
+      };
+    } catch (error) {
+      log.warn('public market list unavailable', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return {
+        items: [],
+        unavailableReason: error instanceof Error ? error.message : String(error),
+        customSourceNames: [],
+        unavailableCustomSourceNames: [],
+      };
+    }
   }
 
   /** 按当前 owner 消费一次清理汇总，避免组织插件名跨账号泄露。 */
@@ -1177,11 +1207,11 @@ export class PluginMarketService {
         const currentRecord = ledger.installationForGhost(plugin.ghostId);
         const matchesSelectedRoute = Boolean(
           existing &&
-            currentRecord?.installed &&
-            currentRecord.pluginId === pluginId &&
-            currentRecord.sourceKey === sourceKey &&
-            currentRecord.manifestDigest != null &&
-            currentRecord.manifestDigest === reviewInstalledDigest,
+          currentRecord?.installed &&
+          currentRecord.pluginId === pluginId &&
+          currentRecord.sourceKey === sourceKey &&
+          currentRecord.manifestDigest != null &&
+          currentRecord.manifestDigest === reviewInstalledDigest,
         );
         if (existing && !matchesSelectedRoute && options.allowSourceReplacement !== true) {
           throwIpcError('ALREADY_EXISTS', 'A local Plugin already uses this Plugin ID');
@@ -1194,7 +1224,9 @@ export class PluginMarketService {
               'Plugin approval state was not bound to the market update',
             );
           }
-          if (ghostInstallApprovalToken(installedNow.approval) !== options.expectedInstalledApproval) {
+          if (
+            ghostInstallApprovalToken(installedNow.approval) !== options.expectedInstalledApproval
+          ) {
             throwIpcError(
               'PRECONDITION_FAILED',
               'Plugin approval state changed after permission review',
@@ -1278,11 +1310,11 @@ export class PluginMarketService {
             const record = ledger.installationForGhost(plugin.ghostId);
             const routeStillMatches = Boolean(
               existing &&
-                record?.installed &&
-                record.pluginId === pluginId &&
-                record.sourceKey === sourceKey &&
-                record.manifestDigest != null &&
-                record.manifestDigest === reviewInstalledDigest,
+              record?.installed &&
+              record.pluginId === pluginId &&
+              record.sourceKey === sourceKey &&
+              record.manifestDigest != null &&
+              record.manifestDigest === reviewInstalledDigest,
             );
             if (existing && !routeStillMatches && options.allowSourceReplacement !== true) {
               throwIpcError('PRECONDITION_FAILED', 'Installed Plugin source changed');
@@ -1306,9 +1338,7 @@ export class PluginMarketService {
           //   按 id 互斥,beforeCommit 的 runtime 复核到 installOrUpdate 落位之间,
           //   同 id 的本地装入/卸载插不进来(否则复核仍会在落位前过期)。
           withCommitLock: (fn) =>
-            this.withMutation(SOURCE_MUTATION_KEY, () =>
-              withGhostInstallLock(plugin.ghostId, fn),
-            ),
+            this.withMutation(SOURCE_MUTATION_KEY, () => withGhostInstallLock(plugin.ghostId, fn)),
           // 溯源写入仍在上面那把 ghost 锁内(afterCommit 由 commit 段调用):
           // 放到锁外时,本地装入能插在"包已落位"与"写下溯源"之间换掉同 id 的包。
           // 锁序:pluginId → SOURCE_MUTATION_KEY → ghostId → ledgerMutation。
@@ -1625,7 +1655,10 @@ export class PluginMarketService {
         );
       }
       if (ghostInstallApprovalToken(existing.approval) !== options.expectedInstalledApproval) {
-        throwIpcError('PRECONDITION_FAILED', 'Plugin approval state changed after permission review');
+        throwIpcError(
+          'PRECONDITION_FAILED',
+          'Plugin approval state changed after permission review',
+        );
       }
     }
 
@@ -1690,7 +1723,7 @@ export class PluginMarketService {
                           ...options.permissionPolicy,
                           manifest: permissionCap.manifest,
                         }
-                        : options.permissionPolicy,
+                      : options.permissionPolicy,
                 }
               : {}),
             allowSourceReplacement: options.allowSourceReplacement,
@@ -1725,7 +1758,7 @@ export class PluginMarketService {
                           ...options.permissionPolicy,
                           manifest: permissionCap.manifest,
                         }
-                        : options.permissionPolicy,
+                      : options.permissionPolicy,
                 }
               : {}),
             approvedPackageSha256: error.review.packageSha256,
@@ -1832,9 +1865,9 @@ export class PluginMarketService {
           : null;
       const replacingSource = Boolean(
         installedNow &&
-          options.allowSourceReplacement &&
-          currentRecordNow?.installed &&
-          !serverRecordMatchesInstalledGhost(plugin.id, installedNow, currentRecordNow),
+        options.allowSourceReplacement &&
+        currentRecordNow?.installed &&
+        !serverRecordMatchesInstalledGhost(plugin.id, installedNow, currentRecordNow),
       );
       let routeDetached = false;
       let replacedRouteWasSuppressed = false;
@@ -2183,6 +2216,7 @@ export class PluginMarketService {
     const local = this.localInstallSnapshot(ledger, ledgerData.installations);
     for (const summary of plugins) {
       if (!summary.defaultInstall || !uniqueGhostIds.has(summary.ghostId)) continue;
+      if (!isGhostAvailableForActiveSession(summary.ghostId)) continue;
       if (ledgerData.defaultInstallOptOuts[installSubject]?.includes(summary.id)) continue;
       if (isBuiltinGhostRemovedByUser(summary.ghostId)) continue;
       const state = this.toItem(summary, local).installState;
@@ -2222,9 +2256,7 @@ export class PluginMarketService {
               // ghostId 锁内重读卸载意图，不能让旧 snapshot 把插件装回来。
               beforeCommitInLock: () => {
                 const commitLedgerData = ledger.read();
-                if (
-                  commitLedgerData.defaultInstallOptOuts[installSubject]?.includes(summary.id)
-                ) {
+                if (commitLedgerData.defaultInstallOptOuts[installSubject]?.includes(summary.id)) {
                   throw new SilentDefaultInstallCancelledError(
                     'Default Plugin was explicitly uninstalled',
                   );
@@ -2331,28 +2363,33 @@ export class PluginMarketService {
             });
             return;
           }
-          const installed = await this.installDetail(detail, {
-            expectedInstalled: true,
-            reviewedManifest: reviewedManifest.manifest,
-            allowPermissionExpansion: true,
-            reviewedBaseline,
-            expectedInstalledApproval: ghostInstallApprovalToken(freshInstalled.approval),
-            silentBaselineMismatch: true,
-            permissionPolicy: {
-              mode: 'cap',
-              manifest: reviewedManifest.manifest,
-              sourceType: 'server',
+          const installed = await this.installDetail(
+            detail,
+            {
+              expectedInstalled: true,
+              reviewedManifest: reviewedManifest.manifest,
+              allowPermissionExpansion: true,
+              reviewedBaseline,
+              expectedInstalledApproval: ghostInstallApprovalToken(freshInstalled.approval),
+              silentBaselineMismatch: true,
+              permissionPolicy: {
+                mode: 'cap',
+                manifest: reviewedManifest.manifest,
+                sourceType: 'server',
+              },
+              beforeCommitInLock: () => {
+                if (
+                  hasPendingGhostCalls(summary.ghostId) ||
+                  hasRunningGhostErrand(summary.ghostId) ||
+                  hasRunningGhostCindyWork(summary.ghostId)
+                ) {
+                  throw new SilentUpgradeBusyError('Plugin is busy');
+                }
+              },
             },
-            beforeCommitInLock: () => {
-              if (
-                hasPendingGhostCalls(summary.ghostId) ||
-                hasRunningGhostErrand(summary.ghostId) ||
-                hasRunningGhostCindyWork(summary.ghostId)
-              ) {
-                throw new SilentUpgradeBusyError('Plugin is busy');
-              }
-            },
-          }, owner, ledger);
+            owner,
+            ledger,
+          );
           if (installed) {
             const addedPermissions = freshInstalled
               ? diffGhostPermissionItems(freshInstalled.manifest, installed.manifest).added.map(
@@ -2463,12 +2500,7 @@ export class PluginMarketService {
     try {
       ledger.markRemoved(record.ghostId, tracksDefaultInstall ? installSubject : null);
     } catch (error) {
-      this.restoreMarketRouteAfterFailedReplacement(
-        ledger,
-        record,
-        installSubject,
-        wasSuppressed,
-      );
+      this.restoreMarketRouteAfterFailedReplacement(ledger, record, installSubject, wasSuppressed);
       log.warn('failed to detach Plugin market route before replacement', {
         pluginId: record.pluginId,
         ghostId: record.ghostId,

--- a/apps/desktop/src/renderer/components/settings/HelpThreadView.tsx
+++ b/apps/desktop/src/renderer/components/settings/HelpThreadView.tsx
@@ -180,9 +180,7 @@ function HelpMessageRow({
             <ArrowUpRight size={12} />
             {t('settings.help.qnaOpenTab', {
               tab:
-                action.tab === 'api-keys' ||
-                action.tab === 'connections' ||
-                action.tab === 'ghosts'
+                action.tab === 'api-keys' || action.tab === 'connections'
                   ? t('sidebar.tabs.plugins')
                   : TAB_LABEL_KEY[action.tab]
                     ? t(TAB_LABEL_KEY[action.tab])

--- a/apps/desktop/src/renderer/components/settings/SettingsCatalogPanel.tsx
+++ b/apps/desktop/src/renderer/components/settings/SettingsCatalogPanel.tsx
@@ -1,0 +1,49 @@
+import { useState } from 'react';
+
+import { GhostPluginPage } from '@/features/plugin/GhostPluginPage';
+import { SkillhubHomeView } from '@/features/skillhub/SkillhubHomeView';
+import { useSkillhubStoreSync } from '@/features/skillhub/SkillhubFeatureLayout';
+
+/**
+ * Settings → Plugins embeds the same Plugin / Skill catalogs.
+ * Tab clicks stay inside Settings instead of routing to /plugins or /skillhub.
+ * Skills store sync waits until the Skills tab is opened so entering Plugins
+ * does not refetch CC sessions or scan skills on the first frame.
+ */
+export function SettingsCatalogPanel() {
+  const [catalogTab, setCatalogTab] = useState<'plugins' | 'skills'>('plugins');
+  const [skillsVisited, setSkillsVisited] = useState(false);
+  const showSkills = catalogTab === 'skills' || skillsVisited;
+
+  return (
+    <div className="h-full min-h-0">
+      <div className={catalogTab === 'plugins' ? 'h-full min-h-0' : 'hidden'}>
+        <GhostPluginPage
+          embedded
+          onSelectCatalogTab={(tab) => {
+            if (tab === 'skills') setSkillsVisited(true);
+            setCatalogTab(tab);
+          }}
+        />
+      </div>
+      {showSkills ? (
+        <SettingsSkillsPane active={catalogTab === 'skills'} onSelectTab={setCatalogTab} />
+      ) : null}
+    </div>
+  );
+}
+
+function SettingsSkillsPane({
+  active,
+  onSelectTab,
+}: {
+  active: boolean;
+  onSelectTab: (tab: 'plugins' | 'skills') => void;
+}) {
+  useSkillhubStoreSync();
+  return (
+    <div className={active ? 'h-full min-h-0' : 'hidden'}>
+      <SkillhubHomeView embedded onSelectCatalogTab={onSelectTab} />
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/components/settings/SettingsSidebarNav.tsx
+++ b/apps/desktop/src/renderer/components/settings/SettingsSidebarNav.tsx
@@ -1,0 +1,126 @@
+import type { ComponentType, ReactElement } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { LucideProps } from 'lucide-react';
+import {
+  Boxes,
+  CircleDollarSign,
+  CircleHelp,
+  FileUp,
+  Info,
+  Keyboard,
+  KeyRound,
+  Link2,
+  MessageCircle,
+  Mic,
+  MonitorCog,
+  MonitorSmartphone,
+  Plug,
+  Settings2,
+  Sparkles,
+  UserRound,
+  Wrench,
+} from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+import { TAB_LABEL_KEY, type SettingsTab } from '@/lib/tabLabels';
+
+const NAV_ITEM_CLASS = 'flex h-9 items-center gap-2.5 rounded-full px-3 text-sm transition-colors';
+const NAV_ITEM_IDLE_CLASS =
+  'border border-transparent text-[var(--settings-menu-text)] hover:bg-sidebar-item-hover';
+const NAV_ITEM_ACTIVE_CLASS =
+  'border border-[var(--sidebar-item-active-border)] bg-sidebar-item-active font-medium text-[var(--sidebar-item-active-foreground)]';
+
+/** Screen + top capsule: the Dynamic Island silhouette, not a generic window. */
+function AgentIslandNavIcon({
+  size = 15,
+  strokeWidth = 1.8,
+  className,
+  ...props
+}: LucideProps): ReactElement {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      {...props}
+    >
+      <rect x="4.5" y="4.5" width="15" height="15" rx="3.75" />
+      <rect x="7" y="6.25" width="10" height="3.6" rx="1.8" fill="currentColor" stroke="none" />
+    </svg>
+  );
+}
+
+type SettingsNavIcon = ComponentType<LucideProps>;
+
+const TAB_ICON: Record<SettingsTab, SettingsNavIcon> = {
+  general: Settings2,
+  billing: CircleDollarSign,
+  personalization: Sparkles,
+  providers: Boxes,
+  'api-keys': KeyRound,
+  'voice-input': Mic,
+  shortcuts: Keyboard,
+  'agent-island': AgentIslandNavIcon,
+  import: FileUp,
+  connections: Link2,
+  'remote-control': MonitorSmartphone,
+  tina: UserRound,
+  ghosts: Plug,
+  'builtin-tools': Wrench,
+  'computer-use': MonitorCog,
+  'im-bot': MessageCircle,
+  help: CircleHelp,
+  about: Info,
+};
+
+interface SettingsSidebarNavProps {
+  tabIds: readonly SettingsTab[];
+  activeTab: SettingsTab;
+  onSelectTab: (tab: SettingsTab) => void;
+}
+
+/** Settings left nav. Every item is an in-panel tab with a matching lucide mark. */
+export function SettingsSidebarNav({ tabIds, activeTab, onSelectTab }: SettingsSidebarNavProps) {
+  const { t } = useTranslation();
+
+  return (
+    <nav role="tablist" aria-label={t('settings.title')} className="flex flex-col gap-0.5">
+      {tabIds.map((tabId) => {
+        const selected = activeTab === tabId;
+        const Icon = TAB_ICON[tabId];
+        return (
+          <button
+            key={tabId}
+            id={`settings-tab-${tabId}`}
+            type="button"
+            role="tab"
+            aria-selected={selected}
+            aria-controls={`settings-panel-${tabId}`}
+            onClick={() => onSelectTab(tabId)}
+            className={cn(NAV_ITEM_CLASS, selected ? NAV_ITEM_ACTIVE_CLASS : NAV_ITEM_IDLE_CLASS)}
+          >
+            <Icon
+              size={15}
+              strokeWidth={1.8}
+              aria-hidden="true"
+              className={cn(
+                'shrink-0',
+                selected
+                  ? 'text-sidebar-item-active-foreground'
+                  : 'text-[var(--settings-menu-text)]',
+              )}
+            />
+            <span className="leading-none">{t(TAB_LABEL_KEY[tabId])}</span>
+          </button>
+        );
+      })}
+    </nav>
+  );
+}

--- a/apps/desktop/src/renderer/components/settings/SettingsView.tsx
+++ b/apps/desktop/src/renderer/components/settings/SettingsView.tsx
@@ -5,8 +5,9 @@ import { useSyncExternalStore } from 'react';
 import { ArrowLeft } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
-import { TAB_IDS, TAB_LABEL_KEY, isSettingsTab } from '@/lib/tabLabels';
+import { TAB_IDS, isSettingsTab } from '@/lib/tabLabels';
 import type { SettingsTab } from '@/lib/tabLabels';
+import { SettingsSidebarNav } from './SettingsSidebarNav';
 import { UserProfileCard } from './UserProfileCard';
 import { VoiceInputSection } from './VoiceInputSection';
 import { AppearanceSection } from './AppearanceSection';
@@ -42,6 +43,7 @@ import { BuiltinToolsSection } from './BuiltinToolsSection';
 import { ContactsSection } from './contacts/ContactsSection';
 import { ComputerUseSection } from './ComputerUseSection';
 import { useAuth } from '@/contexts/AuthContext';
+import { SettingsCatalogPanel } from './SettingsCatalogPanel';
 import { getLastWorkingDir, subscribeToLastWorkingDir } from '@/state/lastWorkingDir';
 import { BillingSettingsSection } from '@/features/billing/BillingPage';
 import { canAccessBillingSettings } from './billingVisibility';
@@ -71,8 +73,7 @@ export function SettingsView() {
     mode,
     membershipKind: user?.membershipKind ?? null,
   });
-  const shouldRedirectToPlugins =
-    rawTab === 'ghosts' || rawTab === 'api-keys' || rawTab === 'connections';
+  const shouldRedirectLegacyPluginTabs = rawTab === 'api-keys' || rawTab === 'connections';
 
   const activeTab = useMemo<SettingsTab>(() => {
     const raw = rawTab;
@@ -121,6 +122,7 @@ export function SettingsView() {
       const next = new URLSearchParams(searchParams);
       next.delete('openPanel');
       next.delete('ghost');
+      next.delete('panel');
       next.delete('imGroup');
       next.delete('section');
       // providers 页深链参数(connect/wizard)与计费页深链参数(intent):切走 tab 即
@@ -174,9 +176,10 @@ export function SettingsView() {
     if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
   }, [searchParams]);
 
-  // The plugin catalog moved to the top-level /plugins route. Keep old links
-  // working without leaving a second plugin management UI under Settings.
-  if (shouldRedirectToPlugins) return <Navigate to="/plugins" replace />;
+  // 旧「工具密钥」「第三方平台」深链落到设置里的插件分区,不再离开设置。
+  if (shouldRedirectLegacyPluginTabs) {
+    return <Navigate to="/settings?tab=ghosts" replace />;
+  }
 
   return (
     <div
@@ -207,36 +210,16 @@ export function SettingsView() {
             </h1>
           </div>
 
-          {/* Tab list —— 全部是普通 cell(「IM 机器人」的分栏切换在其页面内部) */}
-          <nav role="tablist" aria-label={t('settings.title')} className="flex flex-col gap-0.5">
-            {visibleTabIds.map((tabId) => {
-              const selected = activeTab === tabId;
-              return (
-                <button
-                  key={tabId}
-                  id={`settings-tab-${tabId}`}
-                  type="button"
-                  role="tab"
-                  aria-selected={selected}
-                  aria-controls={`settings-panel-${tabId}`}
-                  onClick={() => handleSelectTab(tabId)}
-                  className={cn(
-                    'flex h-9 items-center rounded-full px-3 text-sm transition-colors',
-                    selected
-                      ? 'border border-[var(--sidebar-item-active-border)] bg-sidebar-item-active font-medium text-[var(--sidebar-item-active-foreground)]'
-                      : 'border border-transparent text-[var(--settings-menu-text)] hover:bg-sidebar-item-hover',
-                  )}
-                >
-                  {t(TAB_LABEL_KEY[tabId])}
-                </button>
-              );
-            })}
-          </nav>
+          <SettingsSidebarNav
+            tabIds={visibleTabIds}
+            activeTab={activeTab}
+            onSelectTab={handleSelectTab}
+          />
         </aside>
 
         {/* Content column — capped and centered in the remaining space.
-            Most tabs scroll as a page; Session Import uses a fixed-height workspace
-            so only its candidate list scrolls and the import action stays visible.
+            Most tabs scroll as a page; Session Import and Plugins use a fixed-height
+            workspace so only their inner lists scroll.
             right padding mirrors sidebar's 24px left inset.
             pt-[56px] pushes content top to align with the first nav tab (General),
             skipping the "Settings" header height (h1 24/1.1 + pb-18 + gap-2 ≈ 52px).
@@ -246,7 +229,9 @@ export function SettingsView() {
           ref={contentScrollRef}
           className={cn(
             'flex h-full min-h-0 min-w-0 flex-1 flex-col pl-4 pr-6 pt-[56px] [scrollbar-gutter:stable]',
-            activeTab === 'import' ? 'overflow-hidden' : 'overflow-y-auto',
+            activeTab === 'import' || activeTab === 'ghosts'
+              ? 'overflow-hidden'
+              : 'overflow-y-auto',
           )}
         >
           {/* key={activeTab}:切分区时 wrapper 重挂跑 150ms 淡入(面板内容本就
@@ -255,7 +240,8 @@ export function SettingsView() {
             key={activeTab}
             className={cn(
               'mx-auto w-full min-w-0 max-w-[920px] px-1 animate-fade-in',
-              activeTab === 'import' ? 'h-full min-h-0' : 'pb-32',
+              activeTab === 'import' || activeTab === 'ghosts' ? 'h-full min-h-0' : 'pb-32',
+              activeTab === 'ghosts' && 'max-w-none px-0',
             )}
           >
             {activeTab === 'general' && (
@@ -380,10 +366,7 @@ export function SettingsView() {
                 <section className="pb-[18px]" aria-label={t('settings.sections.subagentModels')}>
                   <SubagentModelSection key={`subagent-models:${mode}:${dataOwnerId ?? 'none'}`} />
                 </section>
-                <section
-                  className="pb-[18px]"
-                  aria-label={t('settings.sections.visionBridge')}
-                >
+                <section className="pb-[18px]" aria-label={t('settings.sections.visionBridge')}>
                   <VisionBridgeSection key={`vision-bridge:${mode}:${dataOwnerId ?? 'none'}`} />
                 </section>
                 {/* 通讯录是本机全局库(数据与开关都不依赖云端账号),local 模式同样可用 */}
@@ -464,6 +447,17 @@ export function SettingsView() {
                 <section aria-label={t('settings.sections.remoteControl')}>
                   <RemoteControlSection />
                 </section>
+              </div>
+            )}
+
+            {activeTab === 'ghosts' && (
+              <div
+                role="tabpanel"
+                id="settings-panel-ghosts"
+                aria-labelledby="settings-tab-ghosts"
+                className="h-full min-h-0"
+              >
+                <SettingsCatalogPanel />
               </div>
             )}
 

--- a/apps/desktop/src/renderer/components/settings/__tests__/SettingsSidebarNav.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/__tests__/SettingsSidebarNav.test.tsx
@@ -1,0 +1,44 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { TAB_IDS } from '@/lib/tabLabels';
+import { SettingsSidebarNav } from '../SettingsSidebarNav';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) =>
+      ({
+        'settings.title': 'Settings',
+        'settings.tabs.ghosts': 'Plugins',
+        'settings.tabs.general': 'General',
+        'settings.tabs.builtinTools': 'Tools',
+      })[key] ?? key,
+  }),
+}));
+
+describe('SettingsSidebarNav', () => {
+  it('selects Plugins as an in-panel settings tab', () => {
+    const onSelectTab = vi.fn();
+
+    render(<SettingsSidebarNav tabIds={TAB_IDS} activeTab="general" onSelectTab={onSelectTab} />);
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Plugins' }));
+
+    expect(onSelectTab).toHaveBeenCalledWith('ghosts');
+    expect(screen.getByRole('tab', { name: 'General' }).getAttribute('aria-selected')).toBe('true');
+    expect(screen.getByRole('tab', { name: 'Plugins' }).getAttribute('aria-selected')).toBe(
+      'false',
+    );
+  });
+
+  it('renders a leading icon for every settings tab', () => {
+    render(<SettingsSidebarNav tabIds={TAB_IDS} activeTab="general" onSelectTab={vi.fn()} />);
+
+    const tabs = screen.getAllByRole('tab');
+    expect(tabs).toHaveLength(TAB_IDS.length);
+    for (const tab of tabs) {
+      expect(tab.querySelector('svg')).not.toBeNull();
+    }
+  });
+});

--- a/apps/desktop/src/renderer/features/plugin/GhostPluginPage.tsx
+++ b/apps/desktop/src/renderer/features/plugin/GhostPluginPage.tsx
@@ -1,7 +1,8 @@
 /**
  * Plugin catalog and detail coordinator backed by the latest Ghost host APIs.
  *
- * Inputs: installed Ghost snapshots and user actions.
+ * Inputs: installed Ghost snapshots and user actions. `embedded` mounts the same
+ * catalog inside Settings; `onSelectCatalogTab` keeps Plugins / Skills in-panel.
  * Outputs: the Plugin list/detail UI, focus-stable installed queue, and Plugin action flows.
  * [PROTOCOL]: 变更时更新此头部，然后检查 CLAUDE.md
  */
@@ -299,7 +300,13 @@ function readIgnoredRound(storageKey: string): string {
  * real Ghost runtime. The page deliberately keeps the previous list/detail
  * interaction shape, while every displayed field comes from InstalledGhost.
  */
-export function GhostPluginPage() {
+export function GhostPluginPage({
+  embedded = false,
+  onSelectCatalogTab,
+}: {
+  embedded?: boolean;
+  onSelectCatalogTab?: (tab: 'plugins' | 'skills') => void;
+} = {}) {
   const { i18n, t } = useTranslation();
   const marketLocale = resolveSystemLocale(i18n.resolvedLanguage ?? i18n.language);
   const navigate = useNavigate();
@@ -812,10 +819,7 @@ export function GhostPluginPage() {
       pluginId: string;
       options: PluginMarketInstallOptions;
     }): Promise<InstalledGhost | null> => {
-      const result = await window.electronAPI.pluginMarket.install(
-        input.pluginId,
-        input.options,
-      );
+      const result = await window.electronAPI.pluginMarket.install(input.pluginId, input.options);
       return result.ghost ?? null;
     },
     [],
@@ -1278,9 +1282,7 @@ export function GhostPluginPage() {
           ...(isUpdate && installedGhost
             ? { expectedInstalledApproval: ghostInstallApprovalToken(installedGhost.approval) }
             : {}),
-          ...(isUpdate &&
-            (diff!.added.length > 0 ||
-              installedGhost?.approval.state !== 'approved')
+          ...(isUpdate && (diff!.added.length > 0 || installedGhost?.approval.state !== 'approved')
             ? {
                 allowPermissionExpansion: true,
                 ...(installedGhost
@@ -1438,6 +1440,8 @@ export function GhostPluginPage() {
       onQueryChange={setQuery}
       searchPlaceholder={t('settings.ghosts.page.search')}
       clearSearchLabel={t('settings.ghosts.page.clearSearch')}
+      embedded={embedded}
+      onSelectTab={onSelectCatalogTab}
       headerActions={
         <GhostPluginActions
           onInstall={() => void handleInstall()}
@@ -1447,7 +1451,12 @@ export function GhostPluginPage() {
       }
     >
       <div className="flex min-h-0 flex-1">
-        <main className="min-h-0 w-full min-w-0 flex-1 overflow-y-auto bg-[var(--surface)] [scrollbar-gutter:stable_both-edges]">
+        <main
+          className={cn(
+            'min-h-0 w-full min-w-0 flex-1 overflow-y-auto [scrollbar-gutter:stable_both-edges]',
+            embedded ? 'bg-transparent' : 'bg-[var(--surface)]',
+          )}
+        >
           <PluginManagementPage>
             <header className="plugin-motion-page-header pb-2">
               <div className="min-w-0">
@@ -1835,9 +1844,7 @@ export function MarketPluginCard({
   const unavailable = busy;
   const replacementDescriptionId = useId();
   const replacementDescription =
-    item.installState === 'conflict'
-      ? t('settings.ghosts.market.replaceDescription')
-      : undefined;
+    item.installState === 'conflict' ? t('settings.ghosts.market.replaceDescription') : undefined;
   return (
     <article
       className={cn(
@@ -1852,9 +1859,7 @@ export function MarketPluginCard({
         onClick={onSelect}
         disabled={unavailable}
         aria-label={item.name}
-        aria-describedby={
-          replacementDescription ? replacementDescriptionId : undefined
-        }
+        aria-describedby={replacementDescription ? replacementDescriptionId : undefined}
         className={cn(
           'flex min-w-0 flex-1 items-start gap-4 self-stretch text-left',
           'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)]',
@@ -1908,9 +1913,7 @@ export function MarketPluginCard({
           onClick={onSelect}
           disabled={unavailable}
           aria-label={t('settings.ghosts.market.detailsAria', { name: item.name })}
-          aria-describedby={
-            replacementDescription ? replacementDescriptionId : undefined
-          }
+          aria-describedby={replacementDescription ? replacementDescriptionId : undefined}
           className={cn(
             'group/market-details absolute inset-0 flex items-start justify-end rounded-xl text-[var(--text-tertiary)]',
             'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)] disabled:cursor-not-allowed disabled:opacity-40',
@@ -1938,9 +1941,7 @@ export function MarketPluginCard({
                 ? t('settings.ghosts.market.replaceAria', { name: item.name })
                 : t('settings.ghosts.page.installAria', { name: item.name })
             }
-            aria-describedby={
-              replacementDescription ? replacementDescriptionId : undefined
-            }
+            aria-describedby={replacementDescription ? replacementDescriptionId : undefined}
             className={cn(
               'relative z-[1] inline-flex h-8 shrink-0 items-center rounded-full border border-[var(--border-default)] bg-[var(--surface-elevated)] px-3.5 text-12 font-medium text-[var(--text-primary)]',
               'transition-[background-color,border-color,transform,opacity] duration-150 hover:bg-[var(--surface-hover-soft)] active:scale-[0.98]',

--- a/apps/desktop/src/renderer/features/plugin/GhostPluginPage.tsx
+++ b/apps/desktop/src/renderer/features/plugin/GhostPluginPage.tsx
@@ -127,6 +127,7 @@ import { PluginScopePicker, usePluginRecentWorkdirs } from './PluginScopePicker'
 import {
   // 受体模型的两条纯推导:reapprove 路由判定 + 「市场复核目标是否命中已装」。
   // main 的卡片改版不再走 catalogItems 交织,orderPluginCatalogItems 已无引用故不引入。
+  canOfferMarketInstall,
   ghostReapprovalRoute,
   marketReviewTargetsInstalledGhost,
   pluginPresentationOrigin,
@@ -1382,7 +1383,11 @@ export function GhostPluginPage({
               marketDetailRequestRef.current += 1;
               setMarketDetail(null);
             }}
-            onInstall={mode !== 'signed-out' ? () => void handleInstallFromMarket() : undefined}
+            onInstall={
+              canOfferMarketInstall(mode, marketDetail.ghostId)
+                ? () => void handleInstallFromMarket()
+                : undefined
+            }
             onIconLoadError={handleMarketIconLoadError}
           />
         </div>
@@ -1724,7 +1729,7 @@ export function GhostPluginPage({
                                 busy={marketBusyId !== null}
                                 onSelect={() => void handleSelectMarket(item.pluginId)}
                                 onInstall={
-                                  mode !== 'signed-out'
+                                  canOfferMarketInstall(mode, item.ghostId)
                                     ? () => void handleInstallMarketItem(item.pluginId)
                                     : undefined
                                 }
@@ -1744,7 +1749,7 @@ export function GhostPluginPage({
                           busy={marketBusyId !== null}
                           onSelect={() => void handleSelectMarket(item.pluginId)}
                           onInstall={
-                            mode !== 'signed-out'
+                            canOfferMarketInstall(mode, item.ghostId)
                               ? () => void handleInstallMarketItem(item.pluginId)
                               : undefined
                           }

--- a/apps/desktop/src/renderer/features/plugin/GhostPluginPage.tsx
+++ b/apps/desktop/src/renderer/features/plugin/GhostPluginPage.tsx
@@ -1723,7 +1723,11 @@ export function GhostPluginPage({
                                 item={item}
                                 busy={marketBusyId !== null}
                                 onSelect={() => void handleSelectMarket(item.pluginId)}
-                                onInstall={() => void handleInstallMarketItem(item.pluginId)}
+                                onInstall={
+                                  mode !== 'signed-out'
+                                    ? () => void handleInstallMarketItem(item.pluginId)
+                                    : undefined
+                                }
                                 onIconLoadError={handleMarketIconLoadError}
                               />
                             ))}
@@ -1739,7 +1743,11 @@ export function GhostPluginPage({
                           item={item}
                           busy={marketBusyId !== null}
                           onSelect={() => void handleSelectMarket(item.pluginId)}
-                          onInstall={() => void handleInstallMarketItem(item.pluginId)}
+                          onInstall={
+                            mode !== 'signed-out'
+                              ? () => void handleInstallMarketItem(item.pluginId)
+                              : undefined
+                          }
                           onIconLoadError={handleMarketIconLoadError}
                         />
                       ))}

--- a/apps/desktop/src/renderer/features/plugin/GhostPluginPage.tsx
+++ b/apps/desktop/src/renderer/features/plugin/GhostPluginPage.tsx
@@ -1382,7 +1382,7 @@ export function GhostPluginPage({
               marketDetailRequestRef.current += 1;
               setMarketDetail(null);
             }}
-            onInstall={() => void handleInstallFromMarket()}
+            onInstall={mode !== 'signed-out' ? () => void handleInstallFromMarket() : undefined}
             onIconLoadError={handleMarketIconLoadError}
           />
         </div>

--- a/apps/desktop/src/renderer/features/plugin/MarketPluginDetailView.tsx
+++ b/apps/desktop/src/renderer/features/plugin/MarketPluginDetailView.tsx
@@ -14,7 +14,7 @@ interface MarketPluginDetailViewProps {
   detail: PluginMarketDetail;
   busy: boolean;
   onBack: () => void;
-  onInstall: () => void;
+  onInstall?: () => void;
   onIconLoadError: () => void;
 }
 /** 尚未安装的市场 Plugin 详情；只展示协议事实，不创建 renderer 侧安装逻辑。 */
@@ -44,9 +44,7 @@ export function MarketPluginDetailView({
   // 同 id 已装时仍展示明确的替换语义；用户点击后才会进入真实包事务。
   const replacementDescriptionId = useId();
   const replacementDescription =
-    detail.installState === 'conflict'
-      ? t('settings.ghosts.market.replaceDescription')
-      : undefined;
+    detail.installState === 'conflict' ? t('settings.ghosts.market.replaceDescription') : undefined;
 
   return (
     <main
@@ -86,24 +84,24 @@ export function MarketPluginDetailView({
                 ) : null}
               </div>
             </div>
-            <button
-              type="button"
-              onClick={onInstall}
-              disabled={actionDisabled}
-              aria-describedby={
-                replacementDescription ? replacementDescriptionId : undefined
-              }
-              className={cn(
-                'plugin-detail-primary-action inline-flex h-10 min-w-[104px] items-center justify-center gap-2 whitespace-nowrap rounded-full px-4 text-13 font-medium',
-                'bg-[var(--accent-cta-bg)] text-[var(--accent-pure-cta-fg)]',
-                'transition-[background-color,transform,opacity] duration-150 hover:bg-[var(--accent-hover)] active:scale-[0.98]',
-                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)]',
-                'disabled:cursor-not-allowed disabled:opacity-40 disabled:active:scale-100',
-              )}
-            >
-              <Download size={15} aria-hidden="true" />
-              {t(actionKey)}
-            </button>
+            {onInstall ? (
+              <button
+                type="button"
+                onClick={onInstall}
+                disabled={actionDisabled}
+                aria-describedby={replacementDescription ? replacementDescriptionId : undefined}
+                className={cn(
+                  'plugin-detail-primary-action inline-flex h-10 min-w-[104px] items-center justify-center gap-2 whitespace-nowrap rounded-full px-4 text-13 font-medium',
+                  'bg-[var(--accent-cta-bg)] text-[var(--accent-pure-cta-fg)]',
+                  'transition-[background-color,transform,opacity] duration-150 hover:bg-[var(--accent-hover)] active:scale-[0.98]',
+                  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)]',
+                  'disabled:cursor-not-allowed disabled:opacity-40 disabled:active:scale-100',
+                )}
+              >
+                <Download size={15} aria-hidden="true" />
+                {t(actionKey)}
+              </button>
+            ) : null}
           </div>
           <p
             id={replacementDescription ? replacementDescriptionId : undefined}
@@ -137,33 +135,33 @@ export function MarketPluginDetailView({
         </section>
 
         <section className="mt-10" aria-labelledby="market-permissions-title">
-            <div className="flex items-baseline gap-2">
-              <h2
-                id="market-permissions-title"
-                className="text-18 font-medium leading-[1.444] text-[var(--text-primary)]"
-              >
-                {t('settings.ghosts.perm.grantsTitle')}
-              </h2>
-              <span className="text-12 text-[var(--text-tertiary)]">
-                {t('settings.ghosts.perm.itemCount', { count: permissions.length })}
-              </span>
-            </div>
-            <div className="mt-5 max-w-[760px] divide-y divide-[var(--border-default)] rounded-xl border border-[var(--border-default)] bg-[var(--surface-elevated)] px-5">
-              {permissions.length > 0 ? (
-                permissions.map((permission, index) => (
-                  <div
-                    key={`${permission.kind}-${permission.labelKey}-${index}`}
-                    className="py-3.5 text-13 leading-5 text-[var(--text-secondary)]"
-                  >
-                    {t(`settings.ghosts.perm.${permission.labelKey}`, permission.labelArgs)}
-                  </div>
-                ))
-              ) : (
-                <div className="py-4 text-13 text-[var(--text-tertiary)]">
-                  {t('settings.ghosts.market.noPermissions')}
+          <div className="flex items-baseline gap-2">
+            <h2
+              id="market-permissions-title"
+              className="text-18 font-medium leading-[1.444] text-[var(--text-primary)]"
+            >
+              {t('settings.ghosts.perm.grantsTitle')}
+            </h2>
+            <span className="text-12 text-[var(--text-tertiary)]">
+              {t('settings.ghosts.perm.itemCount', { count: permissions.length })}
+            </span>
+          </div>
+          <div className="mt-5 max-w-[760px] divide-y divide-[var(--border-default)] rounded-xl border border-[var(--border-default)] bg-[var(--surface-elevated)] px-5">
+            {permissions.length > 0 ? (
+              permissions.map((permission, index) => (
+                <div
+                  key={`${permission.kind}-${permission.labelKey}-${index}`}
+                  className="py-3.5 text-13 leading-5 text-[var(--text-secondary)]"
+                >
+                  {t(`settings.ghosts.perm.${permission.labelKey}`, permission.labelArgs)}
                 </div>
-              )}
-            </div>
+              ))
+            ) : (
+              <div className="py-4 text-13 text-[var(--text-tertiary)]">
+                {t('settings.ghosts.market.noPermissions')}
+              </div>
+            )}
+          </div>
         </section>
       </article>
     </main>

--- a/apps/desktop/src/renderer/features/plugin/PluginManagementLayout.tsx
+++ b/apps/desktop/src/renderer/features/plugin/PluginManagementLayout.tsx
@@ -3,6 +3,8 @@
  *
  * Inputs: active tab, shared search state, optional labels with tab-derived defaults, and actions.
  * Outputs: one width, focus-order-aligned adaptive toolbar, scrolling frame, and transitions.
+ * Settings embeds the same catalog and can intercept Plugins / Skills tab
+ * clicks via `onSelectTab` so the switcher stays inside Settings.
  * [PROTOCOL]: 变更时更新此头部，然后检查 CLAUDE.md
  */
 
@@ -23,6 +25,9 @@ interface PluginManagementLayoutProps {
   searchPlaceholder?: string;
   clearSearchLabel?: string;
   headerActions?: ReactNode;
+  showPrimaryTabs?: boolean;
+  embedded?: boolean;
+  onSelectTab?: (tab: 'plugins' | 'skills') => void;
 }
 
 interface PluginManagementHeaderProps {
@@ -32,6 +37,8 @@ interface PluginManagementHeaderProps {
   onQueryChange?: (query: string) => void;
   searchPlaceholder?: string;
   clearSearchLabel?: string;
+  showPrimaryTabs?: boolean;
+  onSelectTab?: (tab: 'plugins' | 'skills') => void;
 }
 
 interface PluginManagementPageProps {
@@ -72,15 +79,25 @@ export function PluginManagementLayout({
   searchPlaceholder,
   clearSearchLabel,
   headerActions,
+  showPrimaryTabs = true,
+  embedded = false,
+  onSelectTab,
 }: PluginManagementLayoutProps) {
   return (
-    <div className="plugin-management-layout-root plugin-motion-root flex h-full min-h-0 w-full flex-col bg-[var(--surface)]">
+    <div
+      className={cn(
+        'plugin-management-layout-root plugin-motion-root flex h-full min-h-0 w-full flex-col',
+        embedded ? 'bg-transparent' : 'bg-[var(--surface)]',
+      )}
+    >
       <PluginManagementHeader
         activeTab={activeTab}
         query={query}
         onQueryChange={onQueryChange}
         searchPlaceholder={searchPlaceholder}
         clearSearchLabel={clearSearchLabel}
+        showPrimaryTabs={showPrimaryTabs}
+        onSelectTab={onSelectTab}
       >
         {headerActions}
       </PluginManagementHeader>
@@ -97,6 +114,8 @@ export function PluginManagementHeader({
   onQueryChange,
   searchPlaceholder,
   clearSearchLabel,
+  showPrimaryTabs = true,
+  onSelectTab,
 }: PluginManagementHeaderProps) {
   const { t } = useTranslation();
   const navigate = useNavigate();
@@ -125,7 +144,7 @@ export function PluginManagementHeader({
     return () => observer.disconnect();
   }, []);
 
-  const tabs = (
+  const tabs = showPrimaryTabs ? (
     <div
       key="plugin-management-tabs"
       className="plugin-motion-tabs inline-flex shrink-0 rounded-full border p-0.5 backdrop-blur-md"
@@ -141,15 +160,15 @@ export function PluginManagementHeader({
       <TabButton
         active={activeTab === 'plugins'}
         label={t('settings.ghosts.title')}
-        onClick={() => navigate('/plugins')}
+        onClick={() => (onSelectTab ? onSelectTab('plugins') : navigate('/plugins'))}
       />
       <TabButton
         active={activeTab === 'skills'}
         label={t('skillhub.home.title')}
-        onClick={() => navigate('/skillhub/local')}
+        onClick={() => (onSelectTab ? onSelectTab('skills') : navigate('/skillhub/local'))}
       />
     </div>
-  );
+  ) : null;
 
   const tools =
     searchable || children ? (

--- a/apps/desktop/src/renderer/features/plugin/__tests__/MarketPluginDetailView.test.tsx
+++ b/apps/desktop/src/renderer/features/plugin/__tests__/MarketPluginDetailView.test.tsx
@@ -93,4 +93,16 @@ describe('MarketPluginDetailView', () => {
     renderDetail({ description: null });
     expect(screen.getByText('google-calendar')).toBeTruthy();
   });
+
+  it('hides the install action when the host does not provide one', () => {
+    render(
+      <MarketPluginDetailView
+        detail={detail}
+        busy={false}
+        onBack={vi.fn()}
+        onIconLoadError={vi.fn()}
+      />,
+    );
+    expect(screen.queryByRole('button', { name: /settings\.ghosts\.market\.install/ })).toBeNull();
+  });
 });

--- a/apps/desktop/src/renderer/features/plugin/__tests__/PluginManagementLayout.test.tsx
+++ b/apps/desktop/src/renderer/features/plugin/__tests__/PluginManagementLayout.test.tsx
@@ -64,6 +64,21 @@ describe('PluginManagementLayout', () => {
     });
   });
 
+  it('keeps Plugins / Skills inside Settings when onSelectTab is provided', () => {
+    const onSelectTab = vi.fn();
+    render(
+      <MemoryRouter initialEntries={['/settings?tab=ghosts']}>
+        <PluginManagementLayout activeTab="plugins" embedded onSelectTab={onSelectTab}>
+          <CurrentPath />
+        </PluginManagementLayout>
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Skills' }));
+    expect(onSelectTab).toHaveBeenCalledWith('skills');
+    expect(screen.getByTestId('current-path').textContent).toBe('/settings');
+  });
+
   it('keeps the Plugin sidebar view active for a direct Skill deep link', () => {
     render(
       <MemoryRouter initialEntries={['/skillhub/local/skill/global/example']}>

--- a/apps/desktop/src/renderer/features/plugin/lib/__tests__/pluginMarketPresentation.test.ts
+++ b/apps/desktop/src/renderer/features/plugin/lib/__tests__/pluginMarketPresentation.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import type { PluginMarketItem } from '../../../../../shared/pluginMarket';
 import {
+  canOfferMarketInstall,
   ghostReapprovalRoute,
   marketReviewTargetsInstalledGhost,
   orderPluginCatalogItems,
@@ -84,9 +85,9 @@ describe('pluginPresentationOrigin', () => {
   });
 
   it('maps organization plugins to their organization source', () => {
-    expect(
-      pluginPresentationOrigin({ scope: 'organization', sourceType: 'server' }),
-    ).toBe('organization');
+    expect(pluginPresentationOrigin({ scope: 'organization', sourceType: 'server' })).toBe(
+      'organization',
+    );
   });
 
   it('keeps personal plugins out of the client-facing market taxonomy', () => {
@@ -94,9 +95,7 @@ describe('pluginPresentationOrigin', () => {
   });
 
   it('maps custom market sources to the custom origin regardless of scope', () => {
-    expect(pluginPresentationOrigin({ scope: 'public', sourceType: 'git-market' })).toBe(
-      'custom',
-    );
+    expect(pluginPresentationOrigin({ scope: 'public', sourceType: 'git-market' })).toBe('custom');
     expect(pluginPresentationOrigin({ scope: 'public', sourceType: 'local-market' })).toBe(
       'custom',
     );
@@ -203,5 +202,14 @@ describe('orderPluginCatalogItems', () => {
     expect(
       ordered.map(({ kind, item }) => `${kind}:${kind === 'installed' ? item.id : item.ghostId}`),
     ).toEqual(['market:first', 'installed:third']);
+  });
+});
+
+describe('canOfferMarketInstall', () => {
+  it('hides install for signed-out browsing and local account-managed plugins', () => {
+    expect(canOfferMarketInstall('signed-out', 'cindy-test')).toBe(false);
+    expect(canOfferMarketInstall('local', 'cindy-art')).toBe(false);
+    expect(canOfferMarketInstall('local', 'cindy-test')).toBe(true);
+    expect(canOfferMarketInstall('cloud', 'cindy-art')).toBe(true);
   });
 });

--- a/apps/desktop/src/renderer/features/plugin/lib/pluginMarketPresentation.ts
+++ b/apps/desktop/src/renderer/features/plugin/lib/pluginMarketPresentation.ts
@@ -5,14 +5,10 @@
  * public Plugin is installed by default is an installation policy, not a source.
  * An installed Ghost without a matching market record remains local.
  */
-import type { GhostInstallApproval } from '../../../../shared/ghost';
+import { isCindyAccountGhostId, type GhostInstallApproval } from '../../../../shared/ghost';
 import type { PluginMarketItem } from '../../../../shared/pluginMarket';
 
-export type PluginPresentationOrigin =
-  | 'public'
-  | 'organization'
-  | 'local'
-  | 'custom';
+export type PluginPresentationOrigin = 'public' | 'organization' | 'local' | 'custom';
 
 export type PluginCatalogPresentationItem<TInstalled> =
   { kind: 'installed'; item: TInstalled } | { kind: 'market'; item: PluginMarketItem };
@@ -57,7 +53,11 @@ export function marketReviewTargetsInstalledGhost(
   approvalState: GhostInstallApproval['state'] | undefined,
 ): boolean {
   if (item?.installState === 'update-available') return true;
-  return item?.installState === 'installed' && approvalState !== undefined && approvalState !== 'approved';
+  return (
+    item?.installState === 'installed' &&
+    approvalState !== undefined &&
+    approvalState !== 'approved'
+  );
 }
 
 /**
@@ -115,4 +115,13 @@ export function orderPluginCatalogItems<TInstalled extends { id: string }>(
     ordered.push({ kind: 'installed', item: installedItem });
   }
   return ordered;
+}
+
+/** 浏览可看公开目录；安装只在当前会话真能跑这个插件时露出。 */
+export function canOfferMarketInstall(
+  mode: 'signed-out' | 'local' | 'cloud',
+  ghostId: string,
+): boolean {
+  if (mode === 'signed-out') return false;
+  return mode === 'cloud' || !isCindyAccountGhostId(ghostId);
 }

--- a/apps/desktop/src/renderer/features/plugin/plugin-motion.css
+++ b/apps/desktop/src/renderer/features/plugin/plugin-motion.css
@@ -1,9 +1,5 @@
 .plugin-motion-root {
   --plugin-motion-state: 220ms;
-  --plugin-motion-enter: 420ms;
-  --plugin-motion-page: 520ms;
-  --plugin-motion-rise: 14px;
-  --plugin-motion-stagger: 44ms;
   --plugin-motion-ease-enter: cubic-bezier(0.22, 1, 0.36, 1);
   --plugin-card-shadow: var(--shadow-soft-panel);
   --plugin-icon-surface: color-mix(in srgb, var(--surface-elevated) 78%, transparent);
@@ -16,31 +12,10 @@
 }
 
 /**
- * Compositor-friendly transitions shared by Plugin and Skill management views.
+ * Shared Plugin / Skill catalog chrome. Catalog pages have no enter-rise
+ * animation; selection and overflow still ease.
  * [PROTOCOL]: 变更时更新此头部，然后检查 CLAUDE.md
  */
-
-@keyframes plugin-page-enter {
-  from {
-    opacity: 0;
-    transform: translate3d(0, var(--plugin-motion-rise), 0);
-  }
-  to {
-    opacity: 1;
-    transform: translate3d(0, 0, 0);
-  }
-}
-
-@keyframes plugin-item-enter {
-  from {
-    opacity: 0;
-    transform: translate3d(0, 10px, 0) scale(0.985);
-  }
-  to {
-    opacity: 1;
-    transform: translate3d(0, 0, 0) scale(1);
-  }
-}
 
 @keyframes plugin-selection-settle {
   from {
@@ -51,46 +26,6 @@
   }
 }
 
-.plugin-motion-tabs {
-  animation: plugin-page-enter 300ms var(--plugin-motion-ease-enter) backwards;
-}
-.plugin-motion-page-header {
-  animation: plugin-page-enter var(--plugin-motion-enter) var(--plugin-motion-ease-enter) 45ms
-    backwards;
-}
-.plugin-motion-page-section {
-  animation: plugin-page-enter var(--plugin-motion-page) var(--plugin-motion-ease-enter) 135ms
-    backwards;
-}
-.plugin-motion-stagger > * {
-  --plugin-motion-order: 0;
-  animation: plugin-item-enter var(--plugin-motion-enter) var(--plugin-motion-ease-enter) backwards;
-  animation-delay: calc(var(--plugin-motion-order) * var(--plugin-motion-stagger));
-}
-.plugin-motion-stagger > :nth-child(2) {
-  --plugin-motion-order: 1;
-}
-.plugin-motion-stagger > :nth-child(3) {
-  --plugin-motion-order: 2;
-}
-.plugin-motion-stagger > :nth-child(4) {
-  --plugin-motion-order: 3;
-}
-.plugin-motion-stagger > :nth-child(5) {
-  --plugin-motion-order: 4;
-}
-.plugin-motion-stagger > :nth-child(6) {
-  --plugin-motion-order: 5;
-}
-.plugin-motion-stagger > :nth-child(7) {
-  --plugin-motion-order: 6;
-}
-.plugin-motion-stagger > :nth-child(8) {
-  --plugin-motion-order: 7;
-}
-.plugin-motion-stagger > :nth-child(n + 9) {
-  --plugin-motion-order: 8;
-}
 .plugin-motion-selected {
   background: color-mix(in srgb, var(--surface-elevated) 86%, transparent);
   border-color: color-mix(in srgb, var(--border-default) 48%, transparent);
@@ -273,23 +208,8 @@
   }
 }
 
-@media (max-width: 767px) {
-  .plugin-motion-root {
-    --plugin-motion-rise: 10px;
-    --plugin-motion-stagger: 32ms;
-  }
-}
-
 @media (prefers-reduced-motion: reduce) {
-  .plugin-motion-root
-    :is(
-      .plugin-motion-tabs,
-      .plugin-motion-page-header,
-      .plugin-motion-page-section,
-      .plugin-motion-stagger > *,
-      .plugin-motion-selected,
-      .plugin-installed-overflow
-    ) {
+  .plugin-motion-root :is(.plugin-motion-selected, .plugin-installed-overflow) {
     animation: none !important;
     transition: none !important;
   }

--- a/apps/desktop/src/renderer/features/skillhub/SkillhubFeatureLayout.tsx
+++ b/apps/desktop/src/renderer/features/skillhub/SkillhubFeatureLayout.tsx
@@ -38,14 +38,10 @@ import { useSkillSync } from './hooks/useSkillSync';
 import { projectHash } from './lib/projectHash';
 import { useAuth } from '@/contexts/AuthContext';
 
-export function SkillhubFeatureLayout() {
+/** Shared SkillHub store sync. Settings embeds the home view without the route layout. */
+export function useSkillhubStoreSync(): void {
   const { dataOwnerId, mode } = useAuth();
   const cloudSyncEnabled = mode === 'cloud';
-  // 技能改为右侧整页(无左树导航),左侧 app 侧栏沿用 cc-agent 项目/对话列表。
-  // 显式注册同一个 CCAgentSidebarUpper:warm 导航时与 cc-agent 注册的是同一组件
-  // 类型,只 reconcile、不 remount(实例状态保留);冷启动直接进 /skillhub 时则首次
-  // 播种,避免左栏空白(详见 useRegisterCCAgentSidebar)。
-  useRegisterCCAgentSidebar();
 
   // v0.2.1: trigger batch sync whenever the skill list changes
   const { skills, syncResults, bootstrapped } = useSkillhub();
@@ -63,7 +59,13 @@ export function SkillhubFeatureLayout() {
   useEffect(() => {
     if (!cloudSyncEnabled || !bootstrapped) return;
     if (syncResults.size === 0) return; // sync 还没完成
-    const items: Array<{ name: string; absolutePath: string; version: string; authorId: string; folderHash?: string }> = [];
+    const items: Array<{
+      name: string;
+      absolutePath: string;
+      version: string;
+      authorId: string;
+      folderHash?: string;
+    }> = [];
     const itemKeys: Array<{ name: string; key: string }> = [];
     for (const s of skills) {
       if (s.kind !== 'skill') continue;
@@ -91,7 +93,9 @@ export function SkillhubFeatureLayout() {
         absolutePath: s.absolutePath,
         version: latestVersion,
         authorId: serverAuthorId,
-        ...(typeof sync.folderHash === 'string' && sync.folderHash ? { folderHash: sync.folderHash } : {}),
+        ...(typeof sync.folderHash === 'string' && sync.folderHash
+          ? { folderHash: sync.folderHash }
+          : {}),
       });
       itemKeys.push({ name: s.name, key });
     }
@@ -148,6 +152,15 @@ export function SkillhubFeatureLayout() {
     // list is unchanged or empty.
     bootstrapSkillhub();
   }, [dataOwnerId, skillhubProjects]);
+}
+
+export function SkillhubFeatureLayout() {
+  // 技能改为右侧整页(无左树导航),左侧 app 侧栏沿用 cc-agent 项目/对话列表。
+  // 显式注册同一个 CCAgentSidebarUpper:warm 导航时与 cc-agent 注册的是同一组件
+  // 类型,只 reconcile、不 remount(实例状态保留);冷启动直接进 /skillhub 时则首次
+  // 播种,避免左栏空白(详见 useRegisterCCAgentSidebar)。
+  useRegisterCCAgentSidebar();
+  useSkillhubStoreSync();
 
   return (
     <div className="flex h-full w-full flex-col">

--- a/apps/desktop/src/renderer/features/skillhub/SkillhubHomeView.tsx
+++ b/apps/desktop/src/renderer/features/skillhub/SkillhubHomeView.tsx
@@ -39,10 +39,7 @@ import { basename, deriveProjectWorkingDir } from './lib/pathDerivations';
 import { projectHash } from './lib/projectHash';
 import { marketCardPrimaryAction } from './lib/marketDetailViewModel';
 import { deriveSkillSource } from './lib/skillSource';
-import {
-  InstallTargetPicker,
-  type InstallTargetSkill,
-} from './components/InstallTargetPicker';
+import { InstallTargetPicker, type InstallTargetSkill } from './components/InstallTargetPicker';
 import { SkillhubMarketPreviewPanel } from './SkillhubMarketPreviewPanel';
 
 const KIND_ICON: Record<string, LucideIcon> = {
@@ -59,7 +56,13 @@ function includesSkillQuery(values: ReadonlyArray<string | undefined>, query: st
   return values.some((value) => value?.toLocaleLowerCase().includes(query));
 }
 
-export function SkillhubHomeView() {
+export function SkillhubHomeView({
+  embedded = false,
+  onSelectCatalogTab,
+}: {
+  embedded?: boolean;
+  onSelectCatalogTab?: (tab: 'plugins' | 'skills') => void;
+} = {}) {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const { skills, projects, bootstrapped, syncResults } = useSkillhub();
@@ -203,8 +206,15 @@ export function SkillhubHomeView() {
       onQueryChange={setQuery}
       searchPlaceholder={t('skillhub.home.search')}
       clearSearchLabel={t('skillhub.home.clearSearch')}
+      embedded={embedded}
+      onSelectTab={onSelectCatalogTab}
     >
-      <main className="relative h-full w-full overflow-x-hidden overflow-y-auto bg-[var(--surface)] [scrollbar-gutter:stable_both-edges]">
+      <main
+        className={cn(
+          'relative h-full w-full overflow-x-hidden overflow-y-auto [scrollbar-gutter:stable_both-edges]',
+          embedded ? 'bg-transparent' : 'bg-[var(--surface)]',
+        )}
+      >
         <PluginManagementPage className="gap-10">
           <header className="plugin-motion-page-header flex items-start justify-between gap-4">
             <div className="min-w-0 pt-1">
@@ -419,7 +429,11 @@ export function SkillhubHomeView() {
           failedToastKey="skillhub.home.importFailed"
           runAction={async ({ installPath, force }) => {
             if (!importGrantToken) {
-              return { success: false, errorCode: 'INVALID_FILE', message: t('skillhub.home.importFailed') };
+              return {
+                success: false,
+                errorCode: 'INVALID_FILE',
+                message: t('skillhub.home.importFailed'),
+              };
             }
             return window.electronAPI.skillhub.importLocal({
               grantToken: importGrantToken,
@@ -448,7 +462,7 @@ export function SkillhubHomeView() {
                 absolutePath: result.absolutePath ?? '',
                 engine: 'claude-code' as const,
                 kind: 'skill' as const,
-                scope: projectRoot ? 'project' as const : 'global' as const,
+                scope: projectRoot ? ('project' as const) : ('global' as const),
                 projectHash: projectRoot ? projectHash(projectRoot) : undefined,
                 name: result.name,
               };

--- a/apps/desktop/src/renderer/lib/__tests__/tabLabels.test.ts
+++ b/apps/desktop/src/renderer/lib/__tests__/tabLabels.test.ts
@@ -8,4 +8,10 @@ describe('Settings tab order', () => {
 
     expect(TAB_IDS.slice(providersIndex, providersIndex + 2)).toEqual(['providers', 'billing']);
   });
+
+  it('places Plugins immediately before builtin tools', () => {
+    const toolsIndex = TAB_IDS.indexOf('builtin-tools');
+
+    expect(TAB_IDS.slice(toolsIndex - 1, toolsIndex + 1)).toEqual(['ghosts', 'builtin-tools']);
+  });
 });

--- a/apps/desktop/src/renderer/lib/tabLabels.ts
+++ b/apps/desktop/src/renderer/lib/tabLabels.ts
@@ -2,6 +2,9 @@
  * Shared Settings tab definitions — single source of truth for tab IDs and their i18n keys.
  *
  * Used by SettingsView (sidebar labels) and HelpThreadView ("Open X tab" button label).
+ *
+ * `ghosts` is a real Settings tab that embeds the same plugin catalog as `/plugins`.
+ * Legacy `api-keys` / `connections` ids stay on the type for old deep links.
  */
 
 export type SettingsTab =
@@ -17,6 +20,7 @@ export type SettingsTab =
   | 'connections'
   | 'remote-control'
   | 'tina'
+  | 'ghosts'
   | 'builtin-tools'
   | 'computer-use'
   | 'im-bot'
@@ -30,7 +34,7 @@ export const TAB_IDS: ReadonlyArray<SettingsTab> = [
   'billing',
   // 「工具密钥」(api-keys)已于 2026-07-13 下架:面板里最后一把 mivo key 随
   // XD Mivo 意识化改由意识设置页收单(官方别名映射同一存储键)。id 仍留在
-  // SettingsTab 类型与 TAB_LABEL_KEY 保留,供旧深链重定向到插件页。
+  // SettingsTab 类型与 TAB_LABEL_KEY 保留,供旧深链重定向到插件分区。
   'voice-input',
   // IM 机器人紧随语音输入(Lizi 2026-07-15 拍板)。
   'im-bot',
@@ -39,8 +43,9 @@ export const TAB_IDS: ReadonlyArray<SettingsTab> = [
   'import',
   // 「第三方平台」(connections)已于 2026-07-15 下架:Slack 官方 MCP 随 cindy-slack
   // 意识化收尾(Google/Jira/GitHub/GitLab 此前已迁意识)。id 仍留在 SettingsTab
-  // 类型与 TAB_LABEL_KEY 保留,供旧深链重定向到插件页。
+  // 类型与 TAB_LABEL_KEY 保留,供旧深链重定向到插件分区。
   'remote-control',
+  'ghosts',
   'builtin-tools',
   'computer-use',
   'help',
@@ -60,6 +65,7 @@ export const TAB_LABEL_KEY: Record<SettingsTab, string> = {
   providers: 'settings.tabs.providers',
   'remote-control': 'settings.tabs.remoteControl',
   tina: 'settings.tabs.tina',
+  ghosts: 'settings.tabs.ghosts',
   'builtin-tools': 'settings.tabs.builtinTools',
   'computer-use': 'settings.tabs.computerUse',
   'im-bot': 'settings.tabs.imBot',

--- a/apps/desktop/src/shared/helpTypes.ts
+++ b/apps/desktop/src/shared/helpTypes.ts
@@ -25,9 +25,9 @@ export type HelpTabId =
   | 'connections'
   | 'im-bot'
   | 'about'
-  // 'ghosts' (Plugins page) and 'remote-control' (Remote & device control)
-  // are real deep-link targets. 'ghosts' redirects to /plugins in SettingsView,
-  // same as the retained 'api-keys' / 'connections' aliases.
+  // 'ghosts' (Plugins settings tab) and 'remote-control' (Remote & device control)
+  // are real deep-link targets. 'api-keys' / 'connections' remain aliases that
+  // SettingsView rewrites to the Plugins tab.
   | 'ghosts'
   | 'remote-control';
 


### PR DESCRIPTION
## 这次改了什么

### 摘要

设置里增加「插件」分区，点进去嵌同一套插件/技能目录，不再跳到 `/plugins`。设置侧栏补上图标。未登录可以浏览公开插件市场，但不自动安装账号插件，也不把上一账号的已装状态投进目录。同时去掉插件/技能页的进场抬升动画（设置内外都去掉），避免每次点进去或切换时整页抖一下。

### 变更类型

- [x] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：
  - 设置 `ghosts` tab 内嵌 `GhostPluginPage` / `SkillhubHomeView`
  - 设置侧栏图标（灵动岛用方屏 + 顶部胶囊）
  - local / signed-out 可看公开市场；默认安装仍受账号能力门禁
  - 去掉目录进场抬升动画
- 明确不包含：旁观共库实例的安装解锁；技能详情仍走原 `/skillhub` 路由
- 用户可见变化：设置多一项插件；未登录能看公开市场；插件页不再有进场位移
- 是否存在 breaking change：无

### UI 变化

- Desktop 设置左侧导航：每项 15px / 1.8 描边图标，选中跟文字同色
- 设置内容区嵌入插件/技能目录，顶栏可切换且不离开设置
- 引用的设计规范：
  - `DESIGN.md` §7：禁止大动作装饰动画；功能态过渡才允许
  - `DESIGN.md` §14.4：禁止 pointless displacement；进场抬升不属于已登记语义
  - `DESIGN.md` §4 / 侧栏既有规格：图标 15px、stroke 1.8、token 色
  - `DESIGN.md` §10：颜色走语义 token，双模式随主题

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop run typecheck
结果：通过

pnpm --filter desktop exec vitest run \
  src/renderer/lib/__tests__/tabLabels.test.ts \
  src/renderer/components/settings/__tests__/SettingsSidebarNav.test.tsx \
  src/renderer/features/plugin/__tests__/PluginManagementLayout.test.tsx \
  src/main/plugin-market/__tests__/service.test.ts
结果：4 files / 118 tests 通过

bash .../run-unit-gate.sh <worktree>
结果：desktop 全量 related 中 ghostInstallReceipt.test.ts 2 条失败。
同一文件在干净 origin/main checkout 复现同样失败，与本 PR diff 无关。
CI 全量 test:unit 仍以 GitHub 为准。
```

### 手工验证

- macOS Desktop，隔离沙箱 `CindyGlobal-dev2`，未登录：设置 → 插件可看公开市场
- 设置内插件/技能切换留在设置页
- 侧栏图标与灵动岛自定义图标目检

### 未执行的验证

- Windows 目检
- Dark / Light 双模式完整走查（token 复用，未逐项截图）
- 旁观共库实例下的安装（设计上应继续失败）

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [x] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop 设置导航、插件/技能目录壳、公开市场快照投影
- 存量插件影响：无。未改 receipt / 指纹 / manifest 校验 / 安装布局 / 包格式。未登录只读公开目录，安装仍走原有 owner 投影门禁
- 回滚 / 降级方式：回退本 PR。旧 `?tab=ghosts` 会重新变成设置内插件分区而不是跳 `/plugins`

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
