### PR TITLE
fix(sidebar): 自动任务分组默认收起

### DIFF
--- a/apps/desktop/src/renderer/__tests__/automationGroupCollapse.test.ts
+++ b/apps/desktop/src/renderer/__tests__/automationGroupCollapse.test.ts
@@ -1,8 +1,8 @@
 /**
  * useAutomationGroupCollapsed 的持久化 store(轴 1:自动化分组文件夹开/关)。
  *
- * 语义对齐项目分组:默认展开(storage 无条目)、仅持久化已收起的组、展开即删除该 key、
- * 跨"重启"记忆上次状态。项目 vitest env=node 无 window,沿用 modelVisibilityPrefs 同款
+ * 默认收起(storage 无条目)、仅持久化已展开的组、收起即删除该 key、
+ * 跨"重启"记忆上次展开。项目 vitest env=node 无 window,沿用 modelVisibilityPrefs 同款
  * 最小 localStorage stub。
  */
 import { describe, it, expect, beforeEach, vi } from 'vitest';
@@ -40,41 +40,41 @@ async function loadModule() {
 }
 
 describe('automation group collapse store', () => {
-  it('默认展开:没有条目时 isCollapsed = false', async () => {
+  it('默认收起:没有条目时 isCollapsed = true', async () => {
     const { isAutomationGroupCollapsed } = await loadModule();
-    expect(isAutomationGroupCollapsed('schedule:a', OWNER_ID)).toBe(false);
-  });
-
-  it('收起只影响目标组,其它组仍默认展开', async () => {
-    const { isAutomationGroupCollapsed, setAutomationGroupCollapsed } = await loadModule();
-    setAutomationGroupCollapsed('schedule:a', true, OWNER_ID);
     expect(isAutomationGroupCollapsed('schedule:a', OWNER_ID)).toBe(true);
-    expect(isAutomationGroupCollapsed('schedule:b', OWNER_ID)).toBe(false);
-    expect(isAutomationGroupCollapsed('schedule:a', 'owner-b')).toBe(false);
   });
 
-  it('展开 = 从存储删除该 key(恢复跟随版本默认值,而非写一份静态快照)', async () => {
+  it('展开只影响目标组,其它组仍默认收起', async () => {
     const { isAutomationGroupCollapsed, setAutomationGroupCollapsed } = await loadModule();
-    setAutomationGroupCollapsed('schedule:a', true, OWNER_ID);
     setAutomationGroupCollapsed('schedule:a', false, OWNER_ID);
     expect(isAutomationGroupCollapsed('schedule:a', OWNER_ID)).toBe(false);
+    expect(isAutomationGroupCollapsed('schedule:b', OWNER_ID)).toBe(true);
+    expect(isAutomationGroupCollapsed('schedule:a', 'owner-b')).toBe(true);
+  });
+
+  it('收起 = 从存储删除该 key(恢复跟随版本默认值,而非写一份静态快照)', async () => {
+    const { isAutomationGroupCollapsed, setAutomationGroupCollapsed } = await loadModule();
+    setAutomationGroupCollapsed('schedule:a', false, OWNER_ID);
+    setAutomationGroupCollapsed('schedule:a', true, OWNER_ID);
+    expect(isAutomationGroupCollapsed('schedule:a', OWNER_ID)).toBe(true);
     const raw = memStorage.getItem(
       sidebarOwnerStorageKey('cc-agent.sidebar.collapsedAutomationGroups', OWNER_ID),
     );
     expect(raw ? JSON.parse(raw) : {}).not.toHaveProperty('schedule:a');
   });
 
-  it('记忆上次状态:模拟应用重启后仍是收起', async () => {
+  it('记忆上次状态:模拟应用重启后仍是展开', async () => {
     const first = await loadModule();
-    first.setAutomationGroupCollapsed('schedule:a', true, OWNER_ID);
+    first.setAutomationGroupCollapsed('schedule:a', false, OWNER_ID);
 
     // 模拟重启:重置模块注册表,localStorage(memStorage)保留。
     vi.resetModules();
     const second = await loadModule();
-    expect(second.isAutomationGroupCollapsed('schedule:a', OWNER_ID)).toBe(true);
+    expect(second.isAutomationGroupCollapsed('schedule:a', OWNER_ID)).toBe(false);
   });
 
-  it('不按时间过期:很久以前收起的记录依然保留(无定时 GC,活跃组绝不自动展开)', async () => {
+  it('旧版 collapsed:true 仍按已收起读,且不按时间过期', async () => {
     const STORAGE_KEY = 'cc-agent.sidebar.collapsedAutomationGroups';
     const ancient = new Date(Date.now() - 999 * 24 * 60 * 60 * 1000).toISOString();
     memStorage.setItem(

--- a/apps/desktop/src/renderer/features/cc-agent/hooks/__tests__/useAutomationGroupCollapsedOwner.test.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/hooks/__tests__/useAutomationGroupCollapsedOwner.test.tsx
@@ -24,8 +24,8 @@ describe('automation group collapsed owner binding', () => {
   it('reloads owner and group changes while stale callbacks cannot cross a generation boundary', () => {
     const ownerAKey = sidebarOwnerStorageKey(STORAGE_KEY, 'owner-a');
     const ownerBKey = sidebarOwnerStorageKey(STORAGE_KEY, 'owner-b');
-    setAutomationGroupCollapsed('schedule:a', true, 'owner-a');
-    setAutomationGroupCollapsed('schedule:b', true, 'owner-b');
+    setAutomationGroupCollapsed('schedule:a', false, 'owner-a');
+    setAutomationGroupCollapsed('schedule:b', false, 'owner-b');
     const ownerAValue = window.localStorage.getItem(ownerAKey);
     const ownerBValue = window.localStorage.getItem(ownerBKey);
 
@@ -34,33 +34,33 @@ describe('automation group collapsed owner binding', () => {
       ({ groupKey }: { groupKey: string }) => useAutomationGroupCollapsed(groupKey),
       { initialProps: { groupKey: 'schedule:a' } },
     );
-    expect(hook.result.current[0]).toBe(true);
+    expect(hook.result.current[0]).toBe(false);
     const staleOwnerAToggle = hook.result.current[1];
 
     setDataOwnerGeneration('owner-a', 2);
     act(() => staleOwnerAToggle());
-    expect(hook.result.current[0]).toBe(true);
+    expect(hook.result.current[0]).toBe(false);
     expect(window.localStorage.getItem(ownerAKey)).toBe(ownerAValue);
 
     setDataOwnerGeneration('owner-b', 3);
     act(() => staleOwnerAToggle());
-    expect(hook.result.current[0]).toBe(true);
+    expect(hook.result.current[0]).toBe(false);
     expect(window.localStorage.getItem(ownerAKey)).toBe(ownerAValue);
     expect(window.localStorage.getItem(ownerBKey)).toBe(ownerBValue);
 
     hook.rerender({ groupKey: 'schedule:a' });
-    expect(hook.result.current[0]).toBe(false);
+    expect(hook.result.current[0]).toBe(true);
     const staleOwnerBGroupAToggle = hook.result.current[1];
 
     hook.rerender({ groupKey: 'schedule:b' });
-    expect(hook.result.current[0]).toBe(true);
+    expect(hook.result.current[0]).toBe(false);
 
     act(() => staleOwnerBGroupAToggle());
-    expect(hook.result.current[0]).toBe(true);
+    expect(hook.result.current[0]).toBe(false);
     expect(window.localStorage.getItem(ownerBKey)).toBe(ownerBValue);
 
     act(() => hook.result.current[1]());
-    expect(hook.result.current[0]).toBe(false);
+    expect(hook.result.current[0]).toBe(true);
     expect(window.localStorage.getItem(ownerAKey)).toBe(ownerAValue);
     expect(JSON.parse(window.localStorage.getItem(ownerBKey) ?? '{}')).not.toHaveProperty(
       'schedule:b',

--- a/apps/desktop/src/renderer/features/cc-agent/hooks/useAutomationGroupCollapsed.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/hooks/useAutomationGroupCollapsed.ts
@@ -6,10 +6,14 @@
  *
  * 折叠状态是**用户的明确选择,永久持久化、不按时间过期**:
  * - owner-scoped localStorage key derived from `cc-agent.sidebar.collapsedAutomationGroups`
- * - 默认展开(storage 里没有该组 = 展开);仅持久化"已收起"的组
- * - **不做定时 GC** —— 收起就一直收起,直到用户再展开,绝不"用了一阵自己弹开"。
+ * - 默认收起(storage 里没有该组 = 收起);仅持久化"已展开"的组
+ * - 冷启动跟版本默认:没写过 override 的组一律收起,避免侧栏被自动任务刷满
+ * - **不做定时 GC** —— 展开就一直展开,直到用户再收起,绝不"用了一阵自己弹开/收起"。
  *   删掉的定时任务会在本地留一条极小的孤儿记录(几十字节),量可忽略,不值得为清它引入
  *   "按时间删"从而误删活跃分组的风险(这正是早先 30 天 GC 会把活跃分组弹开的根因)。
+ *
+ * 历史兼容:旧版默认展开、只持久化 `collapsed: true`。这类条目仍按「已收起」读;
+ * 未写过条目的组不再被猜成「用户想展开」,而是跟随本版默认收起。
  *
  * 每个分组组件各自持有自己的 collapsed 状态(useState),toggle 时对 localStorage 做
  * "读-改-写、只动自己这个 key"。JS 单线程下读改写不可被打断,不同组各写各的 key,不存在
@@ -29,8 +33,8 @@ const log = createLogger('UseAutomationGroupCollapsed');
 const STORAGE_KEY = 'cc-agent.sidebar.collapsedAutomationGroups';
 
 interface StoredEntry {
-  /** 只存"已收起"的组,展开的组从 stored 中删除。 */
-  collapsed: true;
+  /** 当前版本只持久化已展开(false);旧版写入的 true 仍表示已收起。 */
+  collapsed: boolean;
   /** ISO 8601 — 上次写入时间(仅留作排查/未来用,不参与任何过期判定)。 */
   lastSeenAt: string;
 }
@@ -47,8 +51,8 @@ function loadStored(ownerId: string | null): Stored {
       for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
         if (value && typeof value === 'object') {
           const entry = value as Partial<StoredEntry>;
-          if (entry.collapsed === true && typeof entry.lastSeenAt === 'string') {
-            out[key] = { collapsed: true, lastSeenAt: entry.lastSeenAt };
+          if (typeof entry.collapsed === 'boolean' && typeof entry.lastSeenAt === 'string') {
+            out[key] = { collapsed: entry.collapsed, lastSeenAt: entry.lastSeenAt };
           }
         }
       }
@@ -68,30 +72,34 @@ function writeStored(next: Stored, ownerId: string | null): void {
   }
 }
 
-/** 读取某个分组当前是否收起(默认 false = 展开)。 */
-export function isAutomationGroupCollapsed(groupKey: string, ownerId: string | null): boolean {
-  return Boolean(loadStored(ownerId)[groupKey]);
+function isEntryCollapsed(entry: StoredEntry | undefined): boolean {
+  return entry ? entry.collapsed : true;
 }
 
-/** 写入某个分组的收起态:收起则记一条条目,展开则删除该 key(默认值跟随版本)。 */
+/** 读取某个分组当前是否收起(默认 true = 收起)。 */
+export function isAutomationGroupCollapsed(groupKey: string, ownerId: string | null): boolean {
+  return isEntryCollapsed(loadStored(ownerId)[groupKey]);
+}
+
+/** 写入某个分组的收起态:展开则记一条条目,收起则删除该 key(默认值跟随版本)。 */
 export function setAutomationGroupCollapsed(
   groupKey: string,
   collapsed: boolean,
   ownerId: string | null,
 ): void {
   const stored = loadStored(ownerId);
-  const wasCollapsed = Boolean(stored[groupKey]);
+  const wasCollapsed = isEntryCollapsed(stored[groupKey]);
   if (wasCollapsed === collapsed) return;
   if (collapsed) {
-    stored[groupKey] = { collapsed: true, lastSeenAt: new Date().toISOString() };
-  } else {
     delete stored[groupKey];
+  } else {
+    stored[groupKey] = { collapsed: false, lastSeenAt: new Date().toISOString() };
   }
   writeStored(stored, ownerId);
 }
 
 /**
- * 组件侧 hook:返回 [collapsed, toggle]。collapsed 由 localStorage 初始化(默认展开),
+ * 组件侧 hook:返回 [collapsed, toggle]。collapsed 由 localStorage 初始化(默认收起),
  * 并在 owner / group 边界变化时重新绑定；toggle 只写入创建它时对应的当前 binding。
  */
 export function useAutomationGroupCollapsed(groupKey: string): readonly [boolean, () => void] {

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/AutomationSessionGroupItem.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/AutomationSessionGroupItem.tsx
@@ -83,7 +83,7 @@ export function AutomationSessionGroupItem({
 }: AutomationSessionGroupItemProps) {
   const { t } = useTranslation();
   const navigate = useNavigate();
-  // 轴 1:文件夹开/关,持久化、记忆上次(默认展开),像项目分组一样。
+  // 轴 1:文件夹开/关,持久化、记忆上次展开(默认收起)。
   const [collapsed, toggleCollapsed] = useAutomationGroupCollapsed(group.id);
   // 轴 2:展开后运行列表内部的「前 5 条 / 显示全部」临时态,离开自动收回。
   const [showAll, setShowAll] = useState(false);


### PR DESCRIPTION
## 这次改了什么

### 摘要

侧栏自动任务分组冷启动时改为默认收起，避免一打开软件就把生成的运行记录全部摊开。用户之后手动展开或收起的选择仍记在本机，下次打开不会回到默认。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：
  - 自动任务分组（轴 1 disclosure）默认从展开改为收起
  - 只持久化用户主动展开的 override；收起删除 key，重新跟随版本默认
  - 旧版写入的 `collapsed: true` 仍按已收起读取
- 明确不包含：
  - 项目分组、对话分组的默认展开
  - 组内「前 5 条 / 显示全部」（轴 2）
  - 自动化页 TaskListPane 的项目折叠
- 用户可见变化：新装和从未点过开合的自动任务组，启动后只显示组头；用户展开过的组下次启动仍展开
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：`docs/design-rules/DESIGN.md`「Semantics → motion prototypes」中的 Expand / collapse。本次只改默认 disclosure 状态与本地 override 极性，不改分组开合的视觉、动效、token 或交互控件。双模式无颜色改动，Light / Dark 共用同一套开合逻辑。配置分层见 `docs/dev-rules/configuration-and-overrides.md` §2–3：默认收起，只持久化展开 override；未自定义用户跟随新默认，旧版显式收起记录继续保留。

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：PASS apps/desktop unit (19.1s)

pnpm --filter desktop run typecheck
结果：通过

pnpm check:dco
结果：1 commit signed off

额外：automationGroupCollapse / useAutomationGroupCollapsedOwner / automationGeneratedSessions 共 34 个相关用例通过
```

全量 `pnpm test:unit`（经 run-unit-gate.sh）另有 `ghostInstallReceipt.test.ts` 2 条失败。该文件不在本 PR diff 内，已在当前 worktree 对照 `origin/main` 确认未改；按基线问题交给 CI，不混入本 PR。

### 手工验证

未执行桌面端实机目检（worktree 改动不会热更到正在运行的宿主 Cindy）。

### 未执行的验证

- Desktop Light / Dark 实机目检：本次无视觉改动，只改默认开合状态
- Mobile：手机端自动化分组本来就是默认收起，未改

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop 侧栏自动任务分组的默认开合与 localStorage override 极性
- 回滚 / 降级方式：回退本 PR。旧版 `collapsed: true` 记录仍可读；本版写入的 `collapsed: false` 在旧版里会被忽略（旧 loader 只认 `collapsed === true`），回退后那些组会回到旧默认「展开」
- 存量插件影响：无

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
