### PR TITLE
fix(desktop): 修复实例残留导致模型开关失效

### DIFF
--- a/apps/desktop/src/main/__tests__/ownerNamespaceMigration.test.ts
+++ b/apps/desktop/src/main/__tests__/ownerNamespaceMigration.test.ts
@@ -268,6 +268,76 @@ describe('claimLegacyOwnerNamespace', () => {
     expect(hasExclusiveSharedLegacyUserDataAccess(root, (pid) => pid === 4242)).toBe(true);
   });
 
+  it('prunes a schema-v1 record after proving that its PID was reused', async () => {
+    const root = await tempRoot();
+    const startedAtMs = 1_000_000;
+    const recordPath = path.join(root, '.dev-instances', '4242.json');
+    await writeDevInstanceRecord(root, 4242, root, {
+      instanceId: 'stale-instance',
+      startedAtMs,
+    });
+
+    await __testing.warmStaleProcessProvenance(
+      root,
+      realFsDeps(root, {
+        isPidAlive: (pid) => pid === 4242,
+        readProcessIdentity: () => ({
+          startedAtMs: startedAtMs + 120_000,
+          command: 'C:\\Windows\\System32\\OpenConsole.exe --server',
+        }),
+      }),
+    );
+
+    await expect(fs.access(recordPath)).rejects.toMatchObject({ code: 'ENOENT' });
+    expect(hasExclusiveSharedLegacyUserDataAccess(root, (pid) => pid === 4242)).toBe(true);
+  });
+
+  it('keeps a replacement record that changes during stale-PID cleanup', async () => {
+    const root = await tempRoot();
+    const startedAtMs = 1_000_000;
+    const recordPath = path.join(root, '.dev-instances', '4242.json');
+    await writeDevInstanceRecord(root, 4242, root, {
+      instanceId: 'stale-instance',
+      startedAtMs,
+    });
+    const originalRaw = await fs.readFile(recordPath, 'utf-8');
+    const replacementRaw = JSON.stringify({
+      schemaVersion: 1,
+      instanceId: 'replacement-instance',
+      pid: 4242,
+      userDataDir: root,
+      startedAtMs: startedAtMs + 1,
+    });
+    let recordReads = 0;
+
+    await __testing.warmStaleProcessProvenance(
+      root,
+      realFsDeps(
+        root,
+        {
+          isPidAlive: (pid) => pid === 4242,
+          readProcessIdentity: () => ({
+            startedAtMs: startedAtMs + 120_000,
+            command: 'C:\\Windows\\System32\\OpenConsole.exe --server',
+          }),
+        },
+        {
+          readFile: async (file: string) => {
+            if (file !== recordPath) return fs.readFile(file, 'utf-8');
+            recordReads += 1;
+            if (recordReads === 1) return originalRaw;
+            await fs.writeFile(recordPath, replacementRaw, 'utf-8');
+            return replacementRaw;
+          },
+        },
+      ),
+    );
+
+    expect(recordReads).toBeGreaterThanOrEqual(2);
+    await expect(fs.access(recordPath)).resolves.toBeUndefined();
+    expect(hasExclusiveSharedLegacyUserDataAccess(root, (pid) => pid === 4242)).toBe(false);
+  });
+
   it('keeps local startup fail-closed when provenance warmup cannot read identity', async () => {
     const root = await tempRoot();
     await writeDevInstanceRecord(root, 4242, root, { startedAtMs: 1_000_000 });
@@ -3195,7 +3265,7 @@ async function writeDevInstanceRecord(
   root: string,
   pid: number,
   userDataDir: string = root,
-  options: { startedAtMs?: number; rootDir?: string } = {},
+  options: { startedAtMs?: number; rootDir?: string; instanceId?: string } = {},
 ): Promise<void> {
   const registryDir = path.join(root, '.dev-instances');
   await fs.mkdir(registryDir, { recursive: true });

--- a/apps/desktop/src/main/__tests__/ownerNamespaceMigration.test.ts
+++ b/apps/desktop/src/main/__tests__/ownerNamespaceMigration.test.ts
@@ -268,7 +268,7 @@ describe('claimLegacyOwnerNamespace', () => {
     expect(hasExclusiveSharedLegacyUserDataAccess(root, (pid) => pid === 4242)).toBe(true);
   });
 
-  it('prunes a schema-v1 record after proving that its PID was reused', async () => {
+  it('does not delete a registry record after proving that its PID was reused', async () => {
     const root = await tempRoot();
     const startedAtMs = 1_000_000;
     const recordPath = path.join(root, '.dev-instances', '4242.json');
@@ -288,54 +288,8 @@ describe('claimLegacyOwnerNamespace', () => {
       }),
     );
 
-    await expect(fs.access(recordPath)).rejects.toMatchObject({ code: 'ENOENT' });
     expect(hasExclusiveSharedLegacyUserDataAccess(root, (pid) => pid === 4242)).toBe(true);
-  });
-
-  it('keeps a replacement record that changes during stale-PID cleanup', async () => {
-    const root = await tempRoot();
-    const startedAtMs = 1_000_000;
-    const recordPath = path.join(root, '.dev-instances', '4242.json');
-    await writeDevInstanceRecord(root, 4242, root, {
-      instanceId: 'stale-instance',
-      startedAtMs,
-    });
-    const originalRaw = await fs.readFile(recordPath, 'utf-8');
-    const replacementRaw = JSON.stringify({
-      schemaVersion: 1,
-      instanceId: 'replacement-instance',
-      pid: 4242,
-      userDataDir: root,
-      startedAtMs: startedAtMs + 1,
-    });
-    let recordReads = 0;
-
-    await __testing.warmStaleProcessProvenance(
-      root,
-      realFsDeps(
-        root,
-        {
-          isPidAlive: (pid) => pid === 4242,
-          readProcessIdentity: () => ({
-            startedAtMs: startedAtMs + 120_000,
-            command: 'C:\\Windows\\System32\\OpenConsole.exe --server',
-          }),
-        },
-        {
-          readFile: async (file: string) => {
-            if (file !== recordPath) return fs.readFile(file, 'utf-8');
-            recordReads += 1;
-            if (recordReads === 1) return originalRaw;
-            await fs.writeFile(recordPath, replacementRaw, 'utf-8');
-            return replacementRaw;
-          },
-        },
-      ),
-    );
-
-    expect(recordReads).toBeGreaterThanOrEqual(2);
     await expect(fs.access(recordPath)).resolves.toBeUndefined();
-    expect(hasExclusiveSharedLegacyUserDataAccess(root, (pid) => pid === 4242)).toBe(false);
   });
 
   it('keeps local startup fail-closed when provenance warmup cannot read identity', async () => {
@@ -3171,7 +3125,11 @@ describe('hasExclusiveSharedLegacyUserDataAccess', () => {
   it('reuses async stale-pid proof in sync guards and invalidates it when the record changes', async () => {
     const root = await tempRoot();
     const startedAtMs = 1_000_000;
-    await writeDevInstanceRecord(root, 4242, root, { startedAtMs });
+    const recordPath = path.join(root, '.dev-instances', '4242.json');
+    await writeDevInstanceRecord(root, 4242, root, {
+      instanceId: 'stale-instance',
+      startedAtMs,
+    });
 
     await claimLegacyOwnerNamespace(
       { mode: 'cloud', dataOwnerId: 'cloud-a', user: { id: 'cloud-a' } },
@@ -3186,10 +3144,20 @@ describe('hasExclusiveSharedLegacyUserDataAccess', () => {
 
     expect(hasExclusiveSharedLegacyUserDataAccess(root, (pid) => pid === 4242)).toBe(true);
 
-    await writeDevInstanceRecord(root, 4242, root, {
+    const replacementRaw = JSON.stringify({
+      schemaVersion: 1,
+      instanceId: 'replacement-instance',
+      pid: 4242,
+      userDataDir: root,
+      passive: false,
       startedAtMs: startedAtMs + 1,
     });
+    const replacementPath = `${recordPath}.replacement`;
+    await fs.writeFile(replacementPath, replacementRaw, 'utf-8');
+    await fs.rename(replacementPath, recordPath);
+
     expect(hasExclusiveSharedLegacyUserDataAccess(root, (pid) => pid === 4242)).toBe(false);
+    await expect(fs.readFile(recordPath, 'utf-8')).resolves.toBe(replacementRaw);
   });
 });
 

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -251,6 +251,8 @@ if (devFlags.needsIsolatedDeviceId) {
     isolationIntent: devFlags.isolated,
     profileKind: devFlags.profileKind,
   });
+  // Windows updater forceQuit() ends in process.exit(0), which bypasses Electron will-quit.
+  process.once('exit', cleanupDevInstance);
   app.once('will-quit', cleanupDevInstance);
 }
 

--- a/apps/desktop/src/main/maker-host/__tests__/model-visibility-owner-claim.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/model-visibility-owner-claim.test.ts
@@ -76,6 +76,7 @@ describe('model visibility legacy Renderer owner claim', () => {
     expect(claimLegacyModelVisibilityOwner()).toEqual({
       dataOwnerId: 'owner-a',
       ownerGeneration: 1,
+      canWriteOwnerScoped: true,
       claimed: true,
       claimedByOtherOwner: false,
       canInitialize: true,
@@ -90,6 +91,7 @@ describe('model visibility legacy Renderer owner claim', () => {
     expect(claimLegacyModelVisibilityOwner()).toEqual({
       dataOwnerId: 'owner-b',
       ownerGeneration: 2,
+      canWriteOwnerScoped: true,
       claimed: false,
       claimedByOtherOwner: true,
       canInitialize: false,
@@ -117,14 +119,23 @@ describe('model visibility legacy Renderer owner claim', () => {
   it('does not claim from signed-out, boundary-pending, or shared access', () => {
     harness.mode = 'signed-out';
     harness.ownerId = null;
-    expect(claimLegacyModelVisibilityOwner().claimed).toBe(false);
+    expect(claimLegacyModelVisibilityOwner()).toMatchObject({
+      canWriteOwnerScoped: false,
+      claimed: false,
+    });
     harness.mode = 'cloud';
     harness.ownerId = 'owner-a';
     harness.boundaryPending = true;
-    expect(claimLegacyModelVisibilityOwner().claimed).toBe(false);
+    expect(claimLegacyModelVisibilityOwner()).toMatchObject({
+      canWriteOwnerScoped: false,
+      claimed: false,
+    });
     harness.boundaryPending = false;
     harness.exclusive = false;
-    expect(claimLegacyModelVisibilityOwner().claimed).toBe(false);
+    expect(claimLegacyModelVisibilityOwner()).toMatchObject({
+      canWriteOwnerScoped: true,
+      claimed: false,
+    });
     expect(fs.existsSync(path.join(harness.root, markerName))).toBe(false);
   });
 
@@ -142,6 +153,7 @@ describe('model visibility legacy Renderer owner claim', () => {
     expect(claimLegacyModelVisibilityOwner().canInitialize).toBe(true);
     harness.exclusive = false;
     expect(claimLegacyModelVisibilityOwner()).toMatchObject({
+      canWriteOwnerScoped: true,
       claimed: true,
       claimedByOtherOwner: false,
       canInitialize: false,
@@ -151,6 +163,7 @@ describe('model visibility legacy Renderer owner claim', () => {
   it('fails closed instead of replacing a malformed marker', () => {
     fs.writeFileSync(path.join(harness.root, markerName), '{broken', 'utf-8');
     expect(claimLegacyModelVisibilityOwner()).toMatchObject({
+      canWriteOwnerScoped: true,
       claimed: false,
       claimedByOtherOwner: false,
       canInitialize: false,

--- a/apps/desktop/src/main/maker-host/model-visibility-owner-claim.ts
+++ b/apps/desktop/src/main/maker-host/model-visibility-owner-claim.ts
@@ -69,6 +69,7 @@ export function claimLegacyModelVisibilityOwner(): ModelVisibilityLegacyOwnerCla
   ) {
     return {
       ...stamp,
+      canWriteOwnerScoped: false,
       claimed: false,
       claimedByOtherOwner: false,
       canInitialize: false,
@@ -110,6 +111,7 @@ export function claimLegacyModelVisibilityOwner(): ModelVisibilityLegacyOwnerCla
   const claimed = state.kind === 'valid' && state.marker.ownerKey === ownerKey;
   return {
     ...stamp,
+    canWriteOwnerScoped: true,
     claimed,
     claimedByOtherOwner: state.kind === 'valid' && !claimed,
     canInitialize:

--- a/apps/desktop/src/main/ownerNamespaceMigration.ts
+++ b/apps/desktop/src/main/ownerNamespaceMigration.ts
@@ -106,8 +106,6 @@ interface MigrationDeps {
 }
 
 interface RegisteredInstanceRecord {
-  schemaVersion?: number;
-  instanceId?: string;
   pid?: number;
   userDataDir?: string;
   startedAtMs?: number;
@@ -554,42 +552,6 @@ function recordedPidMayStillBeLive(
   }
   if (identity.startedAtMs <= recordedAtMs + PID_REUSE_TOLERANCE_MS) return true;
   return looksLikeCindyRuntime(identity.command, rootDir);
-}
-
-type StaleRegistrySettlement = 'pruned' | 'gone' | 'changed' | 'retained';
-
-/** Delete only the exact schema-v1 `<pid>.json` payload that the OS identity scan proved stale. */
-async function settleStaleRegistryRecord(
-  deps: MigrationDeps,
-  registryDir: string,
-  candidate: {
-    raw: string;
-    fileName: string;
-    schemaVersion: number | undefined;
-    instanceId: string | undefined;
-    pid: number;
-  },
-): Promise<StaleRegistrySettlement> {
-  if (
-    candidate.schemaVersion !== 1
-    || typeof candidate.instanceId !== 'string'
-    || candidate.instanceId.length === 0
-    || candidate.fileName !== `${candidate.pid}.json`
-  ) {
-    return 'retained';
-  }
-  const filePath = path.join(registryDir, candidate.fileName);
-  try {
-    if (await deps.readFile(filePath) !== candidate.raw) return 'changed';
-  } catch (error) {
-    return isMissing(error) ? 'gone' : 'changed';
-  }
-  try {
-    await deps.unlink(filePath);
-    return 'pruned';
-  } catch (error) {
-    return isMissing(error) ? 'gone' : 'retained';
-  }
 }
 
 /**
@@ -2493,8 +2455,6 @@ async function findConcurrentLiveInstancePids(
   const candidates: Array<{
     raw: string;
     fileName: string;
-    schemaVersion: number | undefined;
-    instanceId: string | undefined;
     pid: number;
     recordedAtMs: number | undefined;
     rootDir: string | undefined;
@@ -2529,8 +2489,6 @@ async function findConcurrentLiveInstancePids(
     candidates.push({
       raw,
       fileName: name,
-      schemaVersion: record.schemaVersion,
-      instanceId: record.instanceId,
       pid,
       recordedAtMs: record.startedAtMs,
       rootDir: record.rootDir,
@@ -2548,23 +2506,10 @@ async function findConcurrentLiveInstancePids(
     if (recordedPidMayStillBeLive(candidate.recordedAtMs, candidate.rootDir, identity)) {
       pids.push(candidate.pid);
     } else {
-      const settlement = await settleStaleRegistryRecord(deps, registryDir, candidate);
-      if (settlement === 'changed') {
-        // The identity belongs to the old payload; a replacement remains unproven in this pass.
-        pids.push(candidate.pid);
-        continue;
-      }
-      if (settlement === 'retained') {
-        rememberStaleProcessProof(
-          processProofKey(userDataDir, 'registry', `${candidate.fileName}\u0000${candidate.raw}`),
-        );
-      }
-      log.info(
-        settlement === 'pruned'
-          ? 'pruned stale instance registry record after PID reuse'
-          : 'ignoring stale instance registry record after PID reuse',
-        { pid: candidate.pid },
+      rememberStaleProcessProof(
+        processProofKey(userDataDir, 'registry', `${candidate.fileName}\u0000${candidate.raw}`),
       );
+      log.info('ignoring stale instance registry record after PID reuse', { pid: candidate.pid });
     }
   }
 

--- a/apps/desktop/src/main/ownerNamespaceMigration.ts
+++ b/apps/desktop/src/main/ownerNamespaceMigration.ts
@@ -106,6 +106,8 @@ interface MigrationDeps {
 }
 
 interface RegisteredInstanceRecord {
+  schemaVersion?: number;
+  instanceId?: string;
   pid?: number;
   userDataDir?: string;
   startedAtMs?: number;
@@ -552,6 +554,42 @@ function recordedPidMayStillBeLive(
   }
   if (identity.startedAtMs <= recordedAtMs + PID_REUSE_TOLERANCE_MS) return true;
   return looksLikeCindyRuntime(identity.command, rootDir);
+}
+
+type StaleRegistrySettlement = 'pruned' | 'gone' | 'changed' | 'retained';
+
+/** Delete only the exact schema-v1 `<pid>.json` payload that the OS identity scan proved stale. */
+async function settleStaleRegistryRecord(
+  deps: MigrationDeps,
+  registryDir: string,
+  candidate: {
+    raw: string;
+    fileName: string;
+    schemaVersion: number | undefined;
+    instanceId: string | undefined;
+    pid: number;
+  },
+): Promise<StaleRegistrySettlement> {
+  if (
+    candidate.schemaVersion !== 1
+    || typeof candidate.instanceId !== 'string'
+    || candidate.instanceId.length === 0
+    || candidate.fileName !== `${candidate.pid}.json`
+  ) {
+    return 'retained';
+  }
+  const filePath = path.join(registryDir, candidate.fileName);
+  try {
+    if (await deps.readFile(filePath) !== candidate.raw) return 'changed';
+  } catch (error) {
+    return isMissing(error) ? 'gone' : 'changed';
+  }
+  try {
+    await deps.unlink(filePath);
+    return 'pruned';
+  } catch (error) {
+    return isMissing(error) ? 'gone' : 'retained';
+  }
 }
 
 /**
@@ -2455,6 +2493,8 @@ async function findConcurrentLiveInstancePids(
   const candidates: Array<{
     raw: string;
     fileName: string;
+    schemaVersion: number | undefined;
+    instanceId: string | undefined;
     pid: number;
     recordedAtMs: number | undefined;
     rootDir: string | undefined;
@@ -2489,6 +2529,8 @@ async function findConcurrentLiveInstancePids(
     candidates.push({
       raw,
       fileName: name,
+      schemaVersion: record.schemaVersion,
+      instanceId: record.instanceId,
       pid,
       recordedAtMs: record.startedAtMs,
       rootDir: record.rootDir,
@@ -2506,10 +2548,23 @@ async function findConcurrentLiveInstancePids(
     if (recordedPidMayStillBeLive(candidate.recordedAtMs, candidate.rootDir, identity)) {
       pids.push(candidate.pid);
     } else {
-      rememberStaleProcessProof(
-        processProofKey(userDataDir, 'registry', `${candidate.fileName}\u0000${candidate.raw}`),
+      const settlement = await settleStaleRegistryRecord(deps, registryDir, candidate);
+      if (settlement === 'changed') {
+        // The identity belongs to the old payload; a replacement remains unproven in this pass.
+        pids.push(candidate.pid);
+        continue;
+      }
+      if (settlement === 'retained') {
+        rememberStaleProcessProof(
+          processProofKey(userDataDir, 'registry', `${candidate.fileName}\u0000${candidate.raw}`),
+        );
+      }
+      log.info(
+        settlement === 'pruned'
+          ? 'pruned stale instance registry record after PID reuse'
+          : 'ignoring stale instance registry record after PID reuse',
+        { pid: candidate.pid },
       );
-      log.info('ignoring stale instance registry record after PID reuse', { pid: candidate.pid });
     }
   }
 

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -5142,6 +5142,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
         : {
             dataOwnerId: null,
             ownerGeneration: 0,
+            canWriteOwnerScoped: false,
             claimed: false,
             claimedByOtherOwner: false,
             canInitialize: false,

--- a/apps/desktop/src/renderer/__tests__/modelVisibilityPrefs.test.ts
+++ b/apps/desktop/src/renderer/__tests__/modelVisibilityPrefs.test.ts
@@ -35,6 +35,7 @@ class MemLocalStorage {
 
 let memStorage: MemLocalStorage;
 const syncModelVisibility = vi.fn(async () => undefined);
+const logToMain = vi.fn();
 let ownerClaim: {
   dataOwnerId: string | null;
   ownerGeneration: number;
@@ -62,10 +63,12 @@ function setOwnerClaim(
 beforeEach(() => {
   memStorage = new MemLocalStorage();
   syncModelVisibility.mockClear();
+  logToMain.mockClear();
   setOwnerClaim('owner-a', 1);
   vi.stubGlobal('window', {
     localStorage: memStorage,
     electronAPI: {
+      logToMain,
       maker: {
         syncModelVisibility,
         claimLegacyModelVisibilityOwner: () => ownerClaim,
@@ -151,8 +154,8 @@ describe('modelVisibilityPrefs store', () => {
 
   it('同值写入短路:不抛,值保持', async () => {
     const { isModelEnabled, setModelVisibility } = await loadModuleForOwner();
-    setModelVisibility('codex', 'openai', 'gpt-5.4', false);
-    expect(() => setModelVisibility('codex', 'openai', 'gpt-5.4', false)).not.toThrow();
+    expect(setModelVisibility('codex', 'openai', 'gpt-5.4', false)).toBe(true);
+    expect(setModelVisibility('codex', 'openai', 'gpt-5.4', false)).toBe(true);
     expect(isModelEnabled('codex', 'openai', { id: 'gpt-5.4' })).toBe(false);
   });
 
@@ -222,10 +225,33 @@ describe('modelVisibilityPrefs store', () => {
     setOwnerClaim('owner-a', 1, false, false);
     const module = await loadModuleForOwner();
 
-    module.setModelVisibility('codex', 'openai', 'gpt-5.5', false);
+    expect(module.setModelVisibility('codex', 'openai', 'gpt-5.5', false)).toBe(false);
 
     expect(memStorage.getItem('xdt:modelVisibilityPrefs:v1.owner.owner-a')).toBeNull();
     expect(module.isModelEnabled('codex', 'openai', { id: 'gpt-5.5' })).toBe(true);
+    expect(logToMain).toHaveBeenCalledWith(
+      'warn',
+      'ModelVisibilityPrefs',
+      expect.stringContaining('owner-write-not-ready'),
+    );
+  });
+
+  it('owner-scoped 存储失败时返回失败并保持旧状态', async () => {
+    const module = await loadModuleForOwner();
+    const mirrorCallsBeforeFailure = syncModelVisibility.mock.calls.length;
+    const setItem = vi.spyOn(memStorage, 'setItem').mockImplementation(() => {
+      throw new Error('injected storage failure');
+    });
+
+    expect(module.setModelVisibility('codex', 'openai', 'gpt-5.5', false)).toBe(false);
+    expect(module.isModelEnabled('codex', 'openai', { id: 'gpt-5.5' })).toBe(true);
+    expect(syncModelVisibility).toHaveBeenCalledTimes(mirrorCallsBeforeFailure);
+    expect(logToMain).toHaveBeenCalledWith(
+      'warn',
+      'ModelVisibilityPrefs',
+      expect.stringContaining('storage-write-failed'),
+    );
+    setItem.mockRestore();
   });
 
   it('已有 owner-scoped override 优先，迁移不会覆盖', async () => {

--- a/apps/desktop/src/renderer/__tests__/modelVisibilityPrefs.test.ts
+++ b/apps/desktop/src/renderer/__tests__/modelVisibilityPrefs.test.ts
@@ -7,10 +7,11 @@
  *   3. set/get 往返 + owner-scoped localStorage 持久化(模拟 app 重启)
  *   4. 按 (agent, providerId, modelId) 分槽:同名模型在 cc / codex 互不覆盖
  *   5. setManyVisibility 批量(全部关 / 全部开)写显式 override
- *   6. 同值写入短路(不抛)
- *   7. 旧全局 key 只由 Main 仲裁出的首个 owner 认领,新账号默认隔离
- *   8. schema 损坏 / 脏数据 → 静默回退,跟随目录默认
- *   9. main 镜像同步异步失败时不产生未处理 rejection
+ *   6. 跨 agent 的一次用户操作原子落盘，失败不留下部分状态
+ *   7. 同值写入短路(不抛)
+ *   8. 旧全局 key 只由 Main 仲裁出的首个 owner 认领,新账号默认隔离
+ *   9. schema 损坏 / 脏数据 → 静默回退,跟随目录默认
+ *  10. main 镜像同步异步失败时不产生未处理 rejection
  *
  * 项目 vitest env=node,无 window。沿用 providerModelMemory.test.ts 的最小 localStorage stub。
  */
@@ -39,6 +40,7 @@ const logToMain = vi.fn();
 let ownerClaim: {
   dataOwnerId: string | null;
   ownerGeneration: number;
+  canWriteOwnerScoped: boolean;
   claimed: boolean;
   claimedByOtherOwner?: boolean;
   canInitialize: boolean;
@@ -50,10 +52,12 @@ function setOwnerClaim(
   claimed = true,
   canInitialize = true,
   claimedByOtherOwner = false,
+  canWriteOwnerScoped = true,
 ): void {
   ownerClaim = {
     dataOwnerId,
     ownerGeneration,
+    canWriteOwnerScoped,
     claimed,
     claimedByOtherOwner,
     canInitialize,
@@ -152,6 +156,54 @@ describe('modelVisibilityPrefs store', () => {
     expect(isModelEnabled('claude-code', 'xd', { id: 'claude-opus-4-8' })).toBe(true);
   });
 
+  it('setModelVisibilities:跨 agent 一次落盘并同时更新全部目标', async () => {
+    const module = await loadModuleForOwner();
+    const setItem = vi.spyOn(memStorage, 'setItem');
+
+    expect(
+      module.setModelVisibilities(
+        'xd',
+        [
+          { agent: 'claude-code', modelId: 'claude-sonnet-4-6' },
+          { agent: 'codex', modelId: 'gpt-5.6' },
+        ],
+        false,
+      ),
+    ).toBe(true);
+
+    expect(
+      setItem.mock.calls.filter(([key]) => key === 'xdt:modelVisibilityPrefs:v1.owner.owner-a'),
+    ).toHaveLength(1);
+    expect(module.isModelEnabled('claude-code', 'xd', { id: 'claude-sonnet-4-6' })).toBe(false);
+    expect(module.isModelEnabled('codex', 'xd', { id: 'gpt-5.6' })).toBe(false);
+    setItem.mockRestore();
+  });
+
+  it('setModelVisibilities:落盘失败不部分提交，按同一方向重试可整体成功', async () => {
+    const module = await loadModuleForOwner();
+    const storageKey = 'xdt:modelVisibilityPrefs:v1.owner.owner-a';
+    const rawBeforeFailure = memStorage.getItem(storageKey);
+    const mirrorCallsBeforeFailure = syncModelVisibility.mock.calls.length;
+    const setItem = vi.spyOn(memStorage, 'setItem').mockImplementationOnce(() => {
+      throw new Error('injected storage failure');
+    });
+    const targets = [
+      { agent: 'claude-code' as const, modelId: 'claude-sonnet-4-6' },
+      { agent: 'codex' as const, modelId: 'gpt-5.6' },
+    ];
+
+    expect(module.setModelVisibilities('xd', targets, false)).toBe(false);
+    expect(memStorage.getItem(storageKey)).toBe(rawBeforeFailure);
+    expect(module.isModelEnabled('claude-code', 'xd', { id: 'claude-sonnet-4-6' })).toBe(true);
+    expect(module.isModelEnabled('codex', 'xd', { id: 'gpt-5.6' })).toBe(true);
+    expect(syncModelVisibility).toHaveBeenCalledTimes(mirrorCallsBeforeFailure);
+
+    expect(module.setModelVisibilities('xd', targets, false)).toBe(true);
+    expect(module.isModelEnabled('claude-code', 'xd', { id: 'claude-sonnet-4-6' })).toBe(false);
+    expect(module.isModelEnabled('codex', 'xd', { id: 'gpt-5.6' })).toBe(false);
+    setItem.mockRestore();
+  });
+
   it('同值写入短路:不抛,值保持', async () => {
     const { isModelEnabled, setModelVisibility } = await loadModuleForOwner();
     expect(setModelVisibility('codex', 'openai', 'gpt-5.4', false)).toBe(true);
@@ -217,7 +269,7 @@ describe('modelVisibilityPrefs store', () => {
     )).toBe('1');
   });
 
-  it('旧 key 尚未归属任何账号时继续阻止写入，避免抢占未知 owner 的迁移输入', async () => {
+  it('旧 key 尚未认领时仍允许稳定 owner 写自己的隔离 key', async () => {
     memStorage.setItem(
       'xdt:modelVisibilityPrefs:v1',
       JSON.stringify({ 'codex:openai:gpt-5.6': false }),
@@ -225,10 +277,28 @@ describe('modelVisibilityPrefs store', () => {
     setOwnerClaim('owner-a', 1, false, false);
     const module = await loadModuleForOwner();
 
-    expect(module.setModelVisibility('codex', 'openai', 'gpt-5.5', false)).toBe(false);
+    expect(module.setModelVisibility('codex', 'openai', 'gpt-5.5', false)).toBe(true);
 
+    expect(memStorage.getItem('xdt:modelVisibilityPrefs:v1.owner.owner-a')).toBe(
+      JSON.stringify({ 'codex:openai:gpt-5.5': false }),
+    );
+    expect(memStorage.getItem('xdt:modelVisibilityPrefs:v1')).toBe(
+      JSON.stringify({ 'codex:openai:gpt-5.6': false }),
+    );
+    expect(module.isModelEnabled('codex', 'openai', { id: 'gpt-5.5' })).toBe(false);
+
+    setOwnerClaim('owner-a', 1, true, true);
+    expect(module.setModelVisibility('codex', 'openai', 'gpt-5.5', false)).toBe(true);
+    expect(module.isModelEnabled('codex', 'openai', { id: 'gpt-5.6' })).toBe(false);
+    expect(module.isModelEnabled('codex', 'openai', { id: 'gpt-5.5' })).toBe(false);
+  });
+
+  it('当前 owner 会话尚未稳定时继续阻止写入', async () => {
+    setOwnerClaim('owner-a', 1, false, false, false, false);
+    const module = await loadModuleForOwner();
+
+    expect(module.setModelVisibility('codex', 'openai', 'gpt-5.5', false)).toBe(false);
     expect(memStorage.getItem('xdt:modelVisibilityPrefs:v1.owner.owner-a')).toBeNull();
-    expect(module.isModelEnabled('codex', 'openai', { id: 'gpt-5.5' })).toBe(true);
     expect(logToMain).toHaveBeenCalledWith(
       'warn',
       'ModelVisibilityPrefs',

--- a/apps/desktop/src/renderer/__tests__/providersSectionAssetModule.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/providersSectionAssetModule.test.tsx
@@ -109,7 +109,7 @@ vi.mock('@/lib/providerSubtitle', () => ({
 
 vi.mock('@/state/modelVisibilityPrefs', () => ({
   isModelEnabled: () => true,
-  setManyVisibility: vi.fn(),
+  setModelVisibilities: vi.fn(),
   setModelVisibility: vi.fn(),
   useModelVisibilityVersion: () => 0,
 }));

--- a/apps/desktop/src/renderer/__tests__/providersSectionDeepLink.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/providersSectionDeepLink.test.tsx
@@ -15,7 +15,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { ProviderView } from '@cindy/model-providers';
 
-const { wizardSpy, providersState, codexAuthState, codexAuthActions, toastError } = vi.hoisted(
+const {
+  wizardSpy,
+  providersState,
+  codexAuthState,
+  codexAuthActions,
+  toastError,
+  setModelVisibilitiesSpy,
+} = vi.hoisted(
   () => ({
     wizardSpy: vi.fn(),
     providersState: { providers: [] as unknown[], order: [] as string[] },
@@ -31,6 +38,7 @@ const { wizardSpy, providersState, codexAuthState, codexAuthActions, toastError 
       logout: vi.fn(async () => undefined),
     },
     toastError: vi.fn(),
+    setModelVisibilitiesSpy: vi.fn(() => true),
   }),
 );
 
@@ -93,7 +101,7 @@ vi.mock('@/lib/providerSubtitle', () => ({
 
 vi.mock('@/state/modelVisibilityPrefs', () => ({
   isModelEnabled: () => true,
-  setManyVisibility: vi.fn(),
+  setModelVisibilities: setModelVisibilitiesSpy,
   setModelVisibility: vi.fn(),
   useModelVisibilityVersion: () => 0,
 }));
@@ -298,6 +306,53 @@ describe('ProvidersSection — 深链定位', () => {
     await waitFor(() => expect(screen.queryByTestId('wizard-stub')).not.toBeNull());
     expect(wizardSpy).toHaveBeenCalledWith(undefined);
     await waitFor(() => expect(screen.getByTestId('search').textContent).toBe('?tab=providers'));
+  });
+
+  it('统一模型开关跨 agent 一次提交，失败时提示用户', async () => {
+    providersState.providers = [
+      makeProvider('dual', {
+        name: 'Dual',
+        connected: true,
+        agents: ['claude-code', 'codex'],
+        models: {
+          'claude-code': [
+            {
+              id: 'shared',
+              name: 'Shared',
+              contextWindow: 200_000,
+              efforts: [],
+              defaultEffort: null,
+            },
+          ],
+          codex: [
+            {
+              id: 'shared',
+              name: 'Shared',
+              contextWindow: 272_000,
+              efforts: [],
+              defaultEffort: null,
+            },
+          ],
+        },
+      }),
+    ];
+    setModelVisibilitiesSpy.mockReturnValueOnce(false);
+    renderAt('?tab=providers');
+
+    fireEvent.click(await screen.findByRole('switch', { name: 'Shared' }));
+
+    expect(setModelVisibilitiesSpy).toHaveBeenCalledOnce();
+    expect(setModelVisibilitiesSpy).toHaveBeenCalledWith(
+      'dual',
+      [
+        { agent: 'claude-code', modelId: 'shared' },
+        { agent: 'codex', modelId: 'shared' },
+      ],
+      false,
+    );
+    expect(toastError).toHaveBeenCalledWith(
+      'settings.providers.models.visibilityWriteFailed',
+    );
   });
 
   it('authorization-code 自定义供应商登录期间卸载时取消本视图拥有的授权', async () => {

--- a/apps/desktop/src/renderer/__tests__/providersSectionUnavailableModels.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/providersSectionUnavailableModels.test.tsx
@@ -167,7 +167,7 @@ vi.mock('@/lib/providerSubtitle', () => ({
 
 vi.mock('@/state/modelVisibilityPrefs', () => ({
   isModelEnabled: () => true,
-  setManyVisibility: vi.fn(),
+  setModelVisibilities: vi.fn(),
   setModelVisibility: vi.fn(),
   useModelVisibilityVersion: () => 0,
 }));

--- a/apps/desktop/src/renderer/__tests__/unifiedModelList.test.ts
+++ b/apps/desktop/src/renderer/__tests__/unifiedModelList.test.ts
@@ -50,6 +50,7 @@ beforeEach(() => {
         claimLegacyModelVisibilityOwner: () => ({
           dataOwnerId: 'test-owner',
           ownerGeneration: 1,
+          canWriteOwnerScoped: true,
           claimed: true,
           claimedByOtherOwner: false,
           canInitialize: true,

--- a/apps/desktop/src/renderer/components/settings/UnifiedModelList.tsx
+++ b/apps/desktop/src/renderer/components/settings/UnifiedModelList.tsx
@@ -472,18 +472,23 @@ export function UnifiedModelList({
   const refreshLabel = refreshing
     ? t('settings.providers.models.refreshingAria')
     : (refreshIdleLabel ?? t('settings.providers.models.refreshAria'));
+  const showVisibilityWriteFailure = useCallback(() => {
+    toast.error(t('settings.providers.models.visibilityWriteFailed'));
+  }, [t]);
 
   /** 单开关(显示轴):一次写该行全部可用 agent(分歧行拨动即归一)。写入用各 agent 的
    *  **真实模型 id**(桥接投影行两端 id 不同:chatgpt/gpt-5.5 vs gpt-5.5),不能用规范化后的 row.id。 */
   const toggleRow = useCallback(
     (row: UnionModelRow) => {
       const next = !rowAnyEnabled(provider.id, row);
+      let failed = false;
       for (const a of row.avail) {
         const m = row.byAgent[a];
-        if (m) setModelVisibility(a, provider.id, m.id, next);
+        if (m && setModelVisibility(a, provider.id, m.id, next) === false) failed = true;
       }
+      if (failed) showVisibilityWriteFailure();
     },
-    [provider.id],
+    [provider.id, showVisibilityWriteFailure],
   );
 
   /** 全部显示 / 隐藏:逐 agent 批量写(单 agent 一次落盘)。只作用于**对话模型的显示轴**
@@ -492,6 +497,7 @@ export function UnifiedModelList({
    *  行 key):刚停用、快照未回来的行同样不写(PR #744 review)。 */
   const handleBulk = useCallback(() => {
     const next = !allOn;
+    let failed = false;
     for (const agent of provider.agents) {
       const ids = (provider.models[agent] ?? [])
         .filter(
@@ -501,9 +507,10 @@ export function UnifiedModelList({
               true,
         )
         .map((m) => m.id);
-      setManyVisibility(agent, provider.id, ids, next);
+      if (setManyVisibility(agent, provider.id, ids, next) === false) failed = true;
     }
-  }, [allOn, provider, pendingDisabled]);
+    if (failed) showVisibilityWriteFailure();
+  }, [allOn, provider, pendingDisabled, showVisibilityWriteFailure]);
 
   /** 行级「⋯」菜单(hover 显现;菜单打开期间保持可见):停用动作的唯一入口。 */
   const rowMenu = (row: UnionModelRow) => (
@@ -795,7 +802,11 @@ export function UnifiedModelList({
                                   {m ? (
                                     <Switch
                                       checked={isModelEnabled(a, provider.id, m)}
-                                      onCheckedChange={(v) => setModelVisibility(a, provider.id, m.id, v)}
+                                      onCheckedChange={(v) => {
+                                        if (setModelVisibility(a, provider.id, m.id, v) === false) {
+                                          showVisibilityWriteFailure();
+                                        }
+                                      }}
                                       aria-label={`${rep.name} · ${AGENT_LABEL[a]}`}
                                     />
                                   ) : (

--- a/apps/desktop/src/renderer/components/settings/UnifiedModelList.tsx
+++ b/apps/desktop/src/renderer/components/settings/UnifiedModelList.tsx
@@ -46,7 +46,7 @@ import {
 } from '@/components/new-chat/sourceSwitch';
 import {
   isModelEnabled,
-  setManyVisibility,
+  setModelVisibilities,
   setModelVisibility,
   useModelVisibilityVersion,
 } from '@/state/modelVisibilityPrefs';
@@ -481,35 +481,36 @@ export function UnifiedModelList({
   const toggleRow = useCallback(
     (row: UnionModelRow) => {
       const next = !rowAnyEnabled(provider.id, row);
-      let failed = false;
-      for (const a of row.avail) {
-        const m = row.byAgent[a];
-        if (m && setModelVisibility(a, provider.id, m.id, next) === false) failed = true;
+      const targets = row.avail.flatMap((agent) => {
+        const model = row.byAgent[agent];
+        return model ? [{ agent, modelId: model.id }] : [];
+      });
+      if (setModelVisibilities(provider.id, targets, next) === false) {
+        showVisibilityWriteFailure();
       }
-      if (failed) showVisibilityWriteFailure();
     },
     [provider.id, showVisibilityWriteFailure],
   );
 
-  /** 全部显示 / 隐藏:逐 agent 批量写(单 agent 一次落盘)。只作用于**对话模型的显示轴**
+  /** 全部显示 / 隐藏:跨 agent 一次落盘。只作用于**对话模型的显示轴**
    *  —— 能力模型没有显示轴,停用行没有可显示态,都不写(写了 = 无效 override 污染存储,
    *  且历史上会把图像模型漏进选择器)。停用判定含乐观覆盖(pendingDisabled,按规范化
    *  行 key):刚停用、快照未回来的行同样不写(PR #744 review)。 */
   const handleBulk = useCallback(() => {
     const next = !allOn;
-    let failed = false;
-    for (const agent of provider.agents) {
-      const ids = (provider.models[agent] ?? [])
+    const targets = provider.agents.flatMap((agent) =>
+      (provider.models[agent] ?? [])
         .filter(
           (m) =>
             isAgentSelectableModel(m, { userProvider: provider.source === 'user' }) &&
             (pendingDisabled[canonicalModelKey(provider, agent, m.id)] ?? m.disabled === true) !==
               true,
         )
-        .map((m) => m.id);
-      if (setManyVisibility(agent, provider.id, ids, next) === false) failed = true;
+        .map((model) => ({ agent, modelId: model.id })),
+    );
+    if (setModelVisibilities(provider.id, targets, next) === false) {
+      showVisibilityWriteFailure();
     }
-    if (failed) showVisibilityWriteFailure();
   }, [allOn, provider, pendingDisabled, showVisibilityWriteFailure]);
 
   /** 行级「⋯」菜单(hover 显现;菜单打开期间保持可见):停用动作的唯一入口。 */

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -1575,6 +1575,7 @@
         "enableModel": "Enable This Model",
         "capabilityGroupHint": "Not shown in the chat model picker; used only by features like image generation.",
         "accessWriteFailed": "Couldn't save the change. Please try again.",
+        "visibilityWriteFailed": "Couldn't save the model visibility setting. Try again, or restart Cindy if the problem continues.",
         "disabledGroup": "Disabled",
         "enableAllModels": "Enable All",
         "priceOverride": {

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -1574,6 +1574,7 @@
         "enableModel": "このモデルを有効にする",
         "capabilityGroupHint": "チャットのモデル選択には表示されず、画像生成などの機能でのみ使用されます。",
         "accessWriteFailed": "変更を保存できませんでした。もう一度お試しください。",
+        "visibilityWriteFailed": "モデルの表示設定を保存できませんでした。もう一度お試しください。問題が解決しない場合は、Cindy を再起動してください。",
         "disabledGroup": "無効",
         "enableAllModels": "すべて有効にする",
         "priceOverride": {

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -1574,6 +1574,7 @@
         "enableModel": "이 모델 활성화",
         "capabilityGroupHint": "대화 모델 선택에는 표시되지 않으며, 이미지 생성 등 기능에서만 사용됩니다.",
         "accessWriteFailed": "변경 사항을 저장하지 못했습니다. 다시 시도해 주세요.",
+        "visibilityWriteFailed": "모델 표시 설정을 저장하지 못했습니다. 다시 시도해 주세요. 문제가 계속되면 Cindy를 다시 시작해 주세요.",
         "disabledGroup": "비활성화됨",
         "enableAllModels": "모두 활성화",
         "priceOverride": {

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -1574,6 +1574,7 @@
         "enableModel": "启用此模型",
         "capabilityGroupHint": "不会出现在对话模型选择中，仅供图像生成等功能使用",
         "accessWriteFailed": "停用设置未能保存，请重试",
+        "visibilityWriteFailed": "模型显示设置未能保存，请重试；如果仍然失败，请重启 Cindy。",
         "disabledGroup": "已停用",
         "enableAllModels": "全部启用",
         "priceOverride": {

--- a/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
@@ -1574,6 +1574,7 @@
         "enableModel": "啟用此模型",
         "capabilityGroupHint": "不會出現在對話模型選擇中，僅供影像生成等功能使用",
         "accessWriteFailed": "停用設定未能儲存，請重試",
+        "visibilityWriteFailed": "模型顯示設定未能儲存，請重試；如果仍然失敗，請重新啟動 Cindy。",
         "disabledGroup": "已停用",
         "enableAllModels": "全部啟用",
         "priceOverride": {

--- a/apps/desktop/src/renderer/state/modelVisibilityPrefs.ts
+++ b/apps/desktop/src/renderer/state/modelVisibilityPrefs.ts
@@ -20,7 +20,7 @@
  *   - 「全部开启 / 全部关闭」是显式批量动作 → 为当前 agent 该来源的每个模型写显式 override。
  *
  * 谁读谁写:
- *   - 写:ProvidersSection 的模型开关 / 批量按钮(setModelVisibility / setManyVisibility)。
+ *   - 写:ProvidersSection 的模型开关 / 批量按钮(setModelVisibility / setModelVisibilities)。
  *   - 读:ModelSelector 的右栏过滤(isModelEnabled);ProvidersSection 的计数与开关态。
  *
  * 持久化频率低(仅用户点开关触发),同步写 localStorage,不做 batch / debounce —— 与
@@ -112,7 +112,11 @@ function migrateLegacyVisibility(ownerId: string, ownerGeneration: number): Migr
     // Main 用模型可见性专属 marker 把旧 key 原子归属给升级时的当前稳定 local/cloud owner；
     // canInitialize 还保证此刻没有另一个共享 userData 的旧进程在并发改写迁移输入。
     const claim = window.electronAPI?.maker?.claimLegacyModelVisibilityOwner?.();
-    if (claim?.dataOwnerId !== ownerId || claim.ownerGeneration !== ownerGeneration) {
+    if (
+      claim?.dataOwnerId !== ownerId
+      || claim.ownerGeneration !== ownerGeneration
+      || claim.canWriteOwnerScoped !== true
+    ) {
       return BLOCKED_MIGRATION;
     }
     if (claim.claimedByOtherOwner === true) {
@@ -123,7 +127,12 @@ function migrateLegacyVisibility(ownerId: string, ownerGeneration: number): Migr
         migrationPending: false,
       };
     }
-    if (claim.claimed !== true) return BLOCKED_MIGRATION;
+    if (claim.claimed !== true) {
+      // A missing/blocked legacy marker only defers importing the pre-account snapshot. The
+      // stable current owner can still write its isolated key; a later import merges scoped
+      // values last, so these new settings win without mutating the legacy input.
+      return { readyForWrites: true, migrationPending: true };
+    }
     if (claim.canInitialize !== true) {
       // 归属已经明确时，新设置可以安全写进 owner namespace；只把旧全局快照的导入推迟到独占时。
       return { readyForWrites: true, migrationPending: true };
@@ -203,7 +212,8 @@ const listeners = new Set<() => void>();
 
 interface VisibilityWriteContext {
   operation: 'single' | 'bulk';
-  agent: AgentKind;
+  agent?: AgentKind;
+  agentCount?: number;
   providerId: string;
   enabled: boolean;
   modelId?: string;
@@ -291,6 +301,40 @@ export function isModelEnabled(
   return isModelVisible(load()[keyOf(agent, providerId, model.id)], model.defaultEnabled);
 }
 
+function setVisibilityTargets(
+  providerId: string,
+  targets: readonly { agent: AgentKind; modelId: string }[],
+  enabled: boolean,
+  context: VisibilityWriteContext,
+): boolean {
+  if (!providerId || targets.some(({ modelId }) => !modelId)) {
+    log.warn('model visibility write rejected', { reason: 'invalid-target', ...context });
+    return false;
+  }
+  if (targets.length === 0) return true;
+  if (!ensureActiveOwnerReadyForWrites()) {
+    log.warn('model visibility write rejected', {
+      reason: 'owner-write-not-ready',
+      ...context,
+      ownerGeneration: activeOwnerGeneration,
+      mode: activeOwnerMode,
+      migrationPending: activeOwnerMigrationPending,
+    });
+    return false;
+  }
+  const map = load();
+  let changed = false;
+  const next = { ...map };
+  for (const { agent, modelId } of targets) {
+    const k = keyOf(agent, providerId, modelId);
+    if (next[k] !== enabled) {
+      next[k] = enabled;
+      changed = true;
+    }
+  }
+  return changed ? persist(next, context) : true;
+}
+
 /** 写单个 (agent, 来源, 模型) 的可见性 override。同值短路,避免无意义落盘 / 通知。 */
 export function setModelVisibility(
   agent: AgentKind,
@@ -305,24 +349,7 @@ export function setModelVisibility(
     modelId,
     enabled,
   };
-  if (!providerId || !modelId) {
-    log.warn('model visibility write rejected', { reason: 'invalid-target', ...context });
-    return false;
-  }
-  if (!ensureActiveOwnerReadyForWrites()) {
-    log.warn('model visibility write rejected', {
-      reason: 'owner-write-not-ready',
-      ...context,
-      ownerGeneration: activeOwnerGeneration,
-      mode: activeOwnerMode,
-      migrationPending: activeOwnerMigrationPending,
-    });
-    return false;
-  }
-  const map = load();
-  const k = keyOf(agent, providerId, modelId);
-  if (map[k] === enabled) return true;
-  return persist({ ...map, [k]: enabled }, context);
+  return setVisibilityTargets(providerId, [{ agent, modelId }], enabled, context);
 }
 
 /**
@@ -343,32 +370,30 @@ export function setManyVisibility(
     modelCount: modelIds.length,
     enabled,
   };
-  if (!providerId) {
-    log.warn('model visibility write rejected', { reason: 'invalid-target', ...context });
-    return false;
-  }
-  if (modelIds.length === 0) return true;
-  if (!ensureActiveOwnerReadyForWrites()) {
-    log.warn('model visibility write rejected', {
-      reason: 'owner-write-not-ready',
-      ...context,
-      ownerGeneration: activeOwnerGeneration,
-      mode: activeOwnerMode,
-      migrationPending: activeOwnerMigrationPending,
-    });
-    return false;
-  }
-  const map = load();
-  let changed = false;
-  const next = { ...map };
-  for (const id of modelIds) {
-    const k = keyOf(agent, providerId, id);
-    if (next[k] !== enabled) {
-      next[k] = enabled;
-      changed = true;
-    }
-  }
-  return changed ? persist(next, context) : true;
+  return setVisibilityTargets(
+    providerId,
+    modelIds.map((modelId) => ({ agent, modelId })),
+    enabled,
+    context,
+  );
+}
+
+/**
+ * 跨 agent 原子写一组模型可见性。统一列表的一次用户操作必须只落盘一次，避免前一
+ * agent 成功、后一 agent 失败后界面进入部分提交状态，导致重试方向反转。
+ */
+export function setModelVisibilities(
+  providerId: string,
+  targets: readonly { agent: AgentKind; modelId: string }[],
+  enabled: boolean,
+): boolean {
+  return setVisibilityTargets(providerId, targets, enabled, {
+    operation: 'bulk',
+    providerId,
+    agentCount: new Set(targets.map(({ agent }) => agent)).size,
+    modelCount: targets.length,
+    enabled,
+  });
 }
 
 /**

--- a/apps/desktop/src/renderer/state/modelVisibilityPrefs.ts
+++ b/apps/desktop/src/renderer/state/modelVisibilityPrefs.ts
@@ -34,6 +34,9 @@ import { useSyncExternalStore } from 'react';
 import { isModelVisible } from '@cindy/model-providers';
 
 import type { AgentKind } from '@/hooks/useAgentCapabilities';
+import { createLogger } from '@/lib/logger';
+
+const log = createLogger('ModelVisibilityPrefs');
 
 const LEGACY_STORAGE_KEY = 'xdt:modelVisibilityPrefs:v1';
 const STORAGE_KEY_PREFIX = `${LEGACY_STORAGE_KEY}.owner`;
@@ -198,19 +201,43 @@ function mirrorToMain(map: VisibilityMap): void {
 let version = 0;
 const listeners = new Set<() => void>();
 
-function persist(map: VisibilityMap): void {
+interface VisibilityWriteContext {
+  operation: 'single' | 'bulk';
+  agent: AgentKind;
+  providerId: string;
+  enabled: boolean;
+  modelId?: string;
+  modelCount?: number;
+}
+
+function persist(map: VisibilityMap, context: VisibilityWriteContext): boolean {
+  if (typeof window === 'undefined' || !activeOwnerId) {
+    log.warn('model visibility write rejected', {
+      reason: 'owner-unavailable',
+      ...context,
+      ownerGeneration: activeOwnerGeneration,
+      mode: activeOwnerMode,
+    });
+    return false;
+  }
+  try {
+    window.localStorage.setItem(ownerStorageKey(activeOwnerId), JSON.stringify(map));
+  } catch (error) {
+    log.warn('model visibility write failed', {
+      reason: 'storage-write-failed',
+      ...context,
+      ownerGeneration: activeOwnerGeneration,
+      mode: activeOwnerMode,
+    }, error);
+    return false;
+  }
+  // 先确认落盘成功，再更新受控开关状态，避免界面显示成功但重启后设置丢失。
   cache = map;
   version += 1;
-  if (typeof window !== 'undefined' && activeOwnerId) {
-    try {
-      window.localStorage.setItem(ownerStorageKey(activeOwnerId), JSON.stringify(map));
-    } catch {
-      // localStorage 满 / 私密窗口禁写 —— 忽略,不影响内存缓存。
-    }
-  }
   // 每次开关变更后把最新快照重推 main,保持 IM /model 与应用内可见性一致。
   mirrorToMain(map);
   for (const l of listeners) l();
+  return true;
 }
 
 function subscribe(cb: () => void): () => void {
@@ -270,12 +297,32 @@ export function setModelVisibility(
   providerId: string,
   modelId: string,
   enabled: boolean,
-): void {
-  if (!providerId || !modelId || !ensureActiveOwnerReadyForWrites()) return;
+): boolean {
+  const context: VisibilityWriteContext = {
+    operation: 'single',
+    agent,
+    providerId,
+    modelId,
+    enabled,
+  };
+  if (!providerId || !modelId) {
+    log.warn('model visibility write rejected', { reason: 'invalid-target', ...context });
+    return false;
+  }
+  if (!ensureActiveOwnerReadyForWrites()) {
+    log.warn('model visibility write rejected', {
+      reason: 'owner-write-not-ready',
+      ...context,
+      ownerGeneration: activeOwnerGeneration,
+      mode: activeOwnerMode,
+      migrationPending: activeOwnerMigrationPending,
+    });
+    return false;
+  }
   const map = load();
   const k = keyOf(agent, providerId, modelId);
-  if (map[k] === enabled) return;
-  persist({ ...map, [k]: enabled });
+  if (map[k] === enabled) return true;
+  return persist({ ...map, [k]: enabled }, context);
 }
 
 /**
@@ -288,8 +335,29 @@ export function setManyVisibility(
   providerId: string,
   modelIds: readonly string[],
   enabled: boolean,
-): void {
-  if (!providerId || modelIds.length === 0 || !ensureActiveOwnerReadyForWrites()) return;
+): boolean {
+  const context: VisibilityWriteContext = {
+    operation: 'bulk',
+    agent,
+    providerId,
+    modelCount: modelIds.length,
+    enabled,
+  };
+  if (!providerId) {
+    log.warn('model visibility write rejected', { reason: 'invalid-target', ...context });
+    return false;
+  }
+  if (modelIds.length === 0) return true;
+  if (!ensureActiveOwnerReadyForWrites()) {
+    log.warn('model visibility write rejected', {
+      reason: 'owner-write-not-ready',
+      ...context,
+      ownerGeneration: activeOwnerGeneration,
+      mode: activeOwnerMode,
+      migrationPending: activeOwnerMigrationPending,
+    });
+    return false;
+  }
   const map = load();
   let changed = false;
   const next = { ...map };
@@ -300,7 +368,7 @@ export function setManyVisibility(
       changed = true;
     }
   }
-  if (changed) persist(next);
+  return changed ? persist(next, context) : true;
 }
 
 /**

--- a/apps/desktop/src/shared/__tests__/modelVisibility.test.ts
+++ b/apps/desktop/src/shared/__tests__/modelVisibility.test.ts
@@ -7,6 +7,7 @@ describe('model visibility legacy owner claim validation', () => {
     expect(isModelVisibilityLegacyOwnerClaim({
       dataOwnerId: 'owner-a',
       ownerGeneration: 1,
+      canWriteOwnerScoped: true,
       claimed: true,
       claimedByOtherOwner: false,
       canInitialize: true,
@@ -17,12 +18,14 @@ describe('model visibility legacy owner claim validation', () => {
     expect(isModelVisibilityLegacyOwnerClaim({
       dataOwnerId: 'owner-a',
       ownerGeneration: 1,
+      claimedByOtherOwner: false,
       claimed: true,
       canInitialize: true,
     })).toBe(false);
     expect(isModelVisibilityLegacyOwnerClaim({
       dataOwnerId: 'owner-a',
       ownerGeneration: -1,
+      canWriteOwnerScoped: true,
       claimed: false,
       claimedByOtherOwner: true,
       canInitialize: false,

--- a/apps/desktop/src/shared/modelVisibility.ts
+++ b/apps/desktop/src/shared/modelVisibility.ts
@@ -2,6 +2,8 @@ import { isDataOwnerPushStamp, type DataOwnerPushStamp } from './dataOwnerPush.j
 
 /** Main's decision for importing the one pre-account model visibility namespace. */
 export interface ModelVisibilityLegacyOwnerClaim extends DataOwnerPushStamp {
+  /** The stamped local/cloud owner is stable and may write only its owner-scoped preference key. */
+  readonly canWriteOwnerScoped: boolean;
   /** The model visibility legacy marker belongs to the active stable local/cloud owner. */
   readonly claimed: boolean;
   /** The model visibility legacy marker durably belongs to another account. */
@@ -15,6 +17,7 @@ export function isModelVisibilityLegacyOwnerClaim(
 ): value is ModelVisibilityLegacyOwnerClaim {
   return (
     isDataOwnerPushStamp(value) &&
+    typeof (value as Partial<ModelVisibilityLegacyOwnerClaim>).canWriteOwnerScoped === 'boolean' &&
     typeof (value as Partial<ModelVisibilityLegacyOwnerClaim>).claimed === 'boolean' &&
     typeof (value as Partial<ModelVisibilityLegacyOwnerClaim>).claimedByOtherOwner === 'boolean' &&
     typeof (value as Partial<ModelVisibilityLegacyOwnerClaim>).canInitialize === 'boolean'


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Windows 更新退出遗漏的实例记录在 PID 被其他进程复用后，持续阻止模型可见性设置写入的问题；同时让模型开关写入失败不再静默。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：用户日志中模型开关点击无效的问题
- 本 PR 包含：
  - 在 Node `exit` 阶段清理当前实例记录，覆盖更新器 `process.exit(0)` 不触发 Electron `will-quit` 的路径。
  - OS 进程身份已证明 PID 被复用时，清理未变化的 schema-v1 运行时记录；记录发生变化或身份不明确时继续 fail closed。
  - 模型可见性写入返回明确结果，失败时记录原因并显示五语言提示。
- 明确不包含：userData 目录布局调整、owner migration 语义调整、更新器流程改造。
- 用户可见变化：模型开关保存失败时显示明确提示，不再表现为静默无效。
- 是否存在 breaking change：无。

### UI 变化

- 复用现有 `toast.error` 展示保存失败，不新增布局、样式或组件状态。
- 引用的设计规范：`docs/design-rules/DESIGN.md` §2 Toast Error 语义色与 §11 Voice & Content；提示直接说明“模型显示设置未能保存”及可执行的重试方式，五语言 key 保持一致。

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：PASS apps/desktop unit（最终 rebase 后）

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm check:i18n
结果：五种语言 7328 个 key 一致；仅有仓库既有的非阻塞警告

pnpm --filter desktop exec eslint src/main/ownerNamespaceMigration.ts src/main/__tests__/ownerNamespaceMigration.test.ts src/main/index.ts src/renderer/state/modelVisibilityPrefs.ts src/renderer/components/settings/UnifiedModelList.tsx src/renderer/__tests__/modelVisibilityPrefs.test.ts
结果：通过
```

### 手工验证

- macOS：在 `/tmp` 隔离目录启动真实 `/bin/sleep` 进程，写入同 PID 的历史实例记录后调用生产身份扫描路径；记录被自动清理。
- macOS：一次性进程执行 `process.exit(0)`；退出后实例记录为空。
- 未触碰正式 Cindy 用户数据。

### 未执行的验证

- 未在 Windows 打包客户端中完整执行安装器更新与重启流程；已分别覆盖其 `process.exit(0)` 退出行为和 `OpenConsole.exe` PID 复用判定。
- 按提交者要求跳过本地人工 code review；由 PR 自动 review 与 CI 继续检查。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop 实例运行时记录与模型可见性本地偏好。
- 用户数据：只会删除 OS 身份已证明失效、且二次读取内容未变化的 `.dev-instances/<pid>.json` 可重建运行时记录；不会删除对话、账号、插件或模型偏好数据。文件变化或身份不明确时保守保留。
- 跨平台：Windows 更新器是问题触发源；身份核验与记录清理沿用现有跨平台扫描。macOS 已实进程验证，Windows 打包更新 E2E 留给 CI/验收。
- 回滚 / 降级方式：revert 本 PR；旧行为会恢复为短期 stale proof 与静默开关失败。

### 提交前检查

- [ ] 已 review 完整 diff（按要求跳过本地人工 review）
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次无需独立文档）
- [x] 已确认测试结果或说明未执行原因
