### PR TITLE
fix(desktop): 阻止裸 Grok 误入默认网关

### DIFF
--- a/apps/desktop/src/main/__tests__/makerEventHotPathOrdering.test.ts
+++ b/apps/desktop/src/main/__tests__/makerEventHotPathOrdering.test.ts
@@ -892,7 +892,7 @@ describe('maker:event hot path ordering', () => {
       "isClaudeSubscriptionSession && !m.money && isAnthropicModel(m.model)",
     );
     expect(claudeDoneSource).toContain(
-      "m.source === 'subscription' && isSubscriptionDirectModel(m.model)",
+      "m.source === 'subscription' && isSubscriptionDirectRoute(m.model)",
     );
     expect(claudeDoneSource).toMatch(
       /estimateClaudeSubscriptionTurnValue\(\s*perModel,\s*currentLedgerCurrency\(\),\s*pricing,\s*\)/,

--- a/apps/desktop/src/main/__tests__/makerEventHotPathOrdering.test.ts
+++ b/apps/desktop/src/main/__tests__/makerEventHotPathOrdering.test.ts
@@ -789,7 +789,7 @@ describe('maker:event hot path ordering', () => {
     expect(codexDoneSource).toContain('const isCustomProviderRoute =');
     expect(codexDoneSource).toContain('isUserProviderSession(session.id)');
     expect(codexDoneSource).toMatch(/&&\s*pricingModel\.startsWith\('codex\/'\);/);
-    expect(codexDoneSource).toMatch(/&&\s*pricingModel\.startsWith\(XAI_MODEL_PREFIX\);/);
+    expect(codexDoneSource).toMatch(/&&\s*isExclusiveXaiModelId\(pricingModel\);/);
     expect(codexDoneSource).toContain('const hasGatewayKey = Boolean(readClaudeApiKey());');
     expect(codexDoneSource).toContain('const hasEffectiveGatewayRoute =');
     expect(codexDoneSource).toContain('!isCustomProviderRoute');

--- a/apps/desktop/src/main/im/shared/__tests__/cardActionTakeoverReplace.test.ts
+++ b/apps/desktop/src/main/im/shared/__tests__/cardActionTakeoverReplace.test.ts
@@ -794,7 +794,9 @@ describe('model:pick 持久化失败', () => {
       'openrouter',
     );
     expect(mocks.setSessionProvider).toHaveBeenCalledWith('sess-target', 'openrouter');
-    expect(live.setModel).toHaveBeenCalledWith('claude-sonnet-4-6');
+    expect(live.setModel).toHaveBeenCalledWith('claude-sonnet-4-6', {
+      providerId: 'openrouter',
+    });
     expect(live.setEffort).toHaveBeenNthCalledWith(1, 'high');
     expect(live.setEffort).toHaveBeenNthCalledWith(2, 'medium');
     expect(im.updateInteractiveCard).toHaveBeenCalledWith(
@@ -834,6 +836,9 @@ describe('model:pick 持久化失败', () => {
       null,
     );
     expect(mocks.setSessionProvider).toHaveBeenCalledWith('sess-target', null);
+    expect(live.setModel).toHaveBeenCalledWith('claude-sonnet-4-6', {
+      providerId: null,
+    });
   });
 });
 

--- a/apps/desktop/src/main/im/shared/cardActionHandler.ts
+++ b/apps/desktop/src/main/im/shared/cardActionHandler.ts
@@ -347,13 +347,13 @@ export function createCardActionHandler(
         }
       };
       const rollbackRuntimeChange = async (reason: string): Promise<void> => {
-        if (providerId !== undefined) {
-          setSessionProvider(sessionId, previousProviderId);
-        }
+        setSessionProvider(sessionId, previousProviderId);
         const liveForRollback = turnRunner.getMakerSessionById(sessionId);
         if (!liveForRollback || !previousRoute) return;
         try {
-          await liveForRollback.setModel(previousRoute.model);
+          await liveForRollback.setModel(previousRoute.model, {
+            providerId: previousRoute.providerId,
+          });
           if (effort) {
             await liveForRollback.setEffort(previousRoute.effort);
           }

--- a/apps/desktop/src/main/maker-host/__tests__/claudeProxyScopeGate.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/claudeProxyScopeGate.test.ts
@@ -177,6 +177,53 @@ describe('cc routingTransform — xAI 会话的辅助请求回落默认路由 (i
     );
     expect(readClaudeSessionRoute('sess-grok')).toBe('gateway');
   });
+
+  it('裸 grok-4.6 不 fail-open 进默认网关,改走订阅桥或拒绝', async () => {
+    clearSessionProvider('sess-grok');
+    const transform = createModelRoutingTransform();
+    const decision = await Promise.resolve(
+      transform(
+        { model: 'grok-4.6' },
+        ctxWith({ ...SESSION_HEADER, authorization: 'Bearer sk-ant-oat01' }),
+      ),
+    );
+    expect(decision?.localHandler).toEqual(expect.any(Function));
+    expect(decision).not.toEqual(expect.objectContaining({
+      headerOverride: expect.anything(),
+    }));
+  });
+
+  it('显式自定义供应商的裸 grok-4.6 不被 SuperGrok bridge 改写成 xai/', async () => {
+    setSessionProvider('sess-grok', 'my-litellm');
+    const transform = createModelRoutingTransform();
+    const parsedBody = { model: 'grok-4.6' };
+    const decision = await Promise.resolve(
+      transform(
+        parsedBody,
+        ctxWith({ ...SESSION_HEADER, authorization: 'Bearer sk-ant-oat01' }),
+      ),
+    );
+    const writeHead = vi.fn();
+    const end = vi.fn();
+    await decision?.localHandler?.({
+      parsedBody,
+      res: { writeHead, end },
+    } as never);
+    expect(parsedBody.model).toBe('grok-4.6');
+    expect(parsedBody.model.startsWith('xai/')).toBe(false);
+  });
+
+  it('网关风格 x-ai/grok-4.6 仍走默认路由(不是 SuperGrok 独占户口)', () => {
+    clearSessionProvider('sess-grok');
+    const transform = createModelRoutingTransform();
+    const decision = transform(
+      { model: 'x-ai/grok-4.6' },
+      ctxWith({ ...SESSION_HEADER, authorization: 'Bearer sk-ant-oat01' }),
+    );
+    expect(decision).toEqual({
+      headerOverride: { 'x-api-key': 'sk-gw', authorization: 'Bearer sk-gw' },
+    });
+  });
 });
 
 describe('pi routingTransform — xdt session header selects the Pi provider route', () => {
@@ -380,6 +427,26 @@ describe('pi routingTransform — xdt session header selects the Pi provider rou
     await decision?.localHandler?.({ res: response } as never);
     expect(response.status).toBe(401);
     expect(response.body).toContain('invalid_pi_session_token');
+  });
+
+  it('Pi 裸 grok-4.6 且未绑 xAI 时拒绝默认网关,不让 LiteLLM 报 Invalid model name', async () => {
+    setClaudeProxyGatewayKeyReader(() => 'sk-gw');
+    registerPiProxySession('sess-pi', 'session-secret');
+    const decision = await Promise.resolve(createModelRoutingTransform()(
+      { model: 'grok-4.6' },
+      ctxWith({
+        'x-cindy-pi-session-id': 'sess-pi',
+        'x-cindy-pi-session-token': 'session-secret',
+        'x-api-key': 'cindy-pi-provider-auth-placeholder',
+      }),
+    ));
+    const writeHead = vi.fn();
+    const end = vi.fn();
+    await decision?.localHandler?.({ res: { writeHead, end } } as never);
+    expect(writeHead).toHaveBeenCalledWith(400, expect.any(Object));
+    expect(JSON.parse(end.mock.calls[0][0])).toMatchObject({
+      error: { code: 'exclusive_xai_route_required' },
+    });
   });
 
   it('never forwards an orphaned internal Pi token header', async () => {

--- a/apps/desktop/src/main/maker-host/__tests__/claudeProxyScopeGate.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/claudeProxyScopeGate.test.ts
@@ -193,6 +193,24 @@ describe('cc routingTransform — xAI 会话的辅助请求回落默认路由 (i
     }));
   });
 
+  it('内置 anthropic 会话上的裸 grok-4.6 拒绝进 SuperGrok,避免来源与记账分叉', async () => {
+    setSessionProvider('sess-grok', 'anthropic');
+    const transform = createModelRoutingTransform();
+    const decision = await Promise.resolve(
+      transform(
+        { model: 'grok-4.6' },
+        ctxWith({ ...SESSION_HEADER, authorization: 'Bearer sk-ant-oat01' }),
+      ),
+    );
+    const writeHead = vi.fn();
+    const end = vi.fn();
+    await decision?.localHandler?.({ res: { writeHead, end } } as never);
+    expect(writeHead).toHaveBeenCalledWith(400, expect.any(Object));
+    expect(JSON.parse(end.mock.calls[0][0])).toMatchObject({
+      error: { code: 'exclusive_xai_route_required' },
+    });
+  });
+
   it('显式自定义供应商的裸 grok-4.6 不被 SuperGrok bridge 改写成 xai/', async () => {
     setSessionProvider('sess-grok', 'my-litellm');
     const transform = createModelRoutingTransform();

--- a/apps/desktop/src/main/maker-host/__tests__/claudeProxyScopeGate.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/claudeProxyScopeGate.test.ts
@@ -193,6 +193,24 @@ describe('cc routingTransform — xAI 会话的辅助请求回落默认路由 (i
     }));
   });
 
+  it('内置 gemini 会话上的裸 grok-4.6 也拒绝进 SuperGrok,不靠 ID 白名单', async () => {
+    setSessionProvider('sess-grok', 'gemini');
+    const transform = createModelRoutingTransform();
+    const decision = await Promise.resolve(
+      transform(
+        { model: 'grok-4.6' },
+        ctxWith({ ...SESSION_HEADER, authorization: 'Bearer sk-ant-oat01' }),
+      ),
+    );
+    const writeHead = vi.fn();
+    const end = vi.fn();
+    await decision?.localHandler?.({ res: { writeHead, end } } as never);
+    expect(writeHead).toHaveBeenCalledWith(400, expect.any(Object));
+    expect(JSON.parse(end.mock.calls[0][0])).toMatchObject({
+      error: { code: 'exclusive_xai_route_required' },
+    });
+  });
+
   it('内置 anthropic 会话上的裸 grok-4.6 拒绝进 SuperGrok,避免来源与记账分叉', async () => {
     setSessionProvider('sess-grok', 'anthropic');
     const transform = createModelRoutingTransform();

--- a/apps/desktop/src/main/maker-host/__tests__/model-route-guard-live.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/model-route-guard-live.test.ts
@@ -10,6 +10,9 @@ vi.mock('@cindy/model-providers', () => ({
   connectedProvidersForAgent: vi.fn(() => []),
   effectiveSourceIdForModel: h.effectiveSourceIdForModel,
   getModel: vi.fn(() => null),
+  isExclusiveXaiModelId: (model: string | null | undefined) =>
+    typeof model === 'string'
+    && (model.startsWith('grok') || model.startsWith('xai/grok')),
   isModelDisabled: vi.fn(() => false),
   isModelSelectableForNewRoute: vi.fn(() => true),
   isProviderDisabled: vi.fn(() => false),
@@ -35,7 +38,10 @@ vi.mock('../model-plane/modelPlanePolicy.js', () => ({
   MODEL_PLANE_POLICIES: new Map(),
 }));
 
-import { resolveDefaultScheduleRoute } from '../model-route-guard-live.js';
+import {
+  resolveDefaultScheduleRoute,
+  resolveLenientSessionRoute,
+} from '../model-route-guard-live.js';
 
 describe('resolveDefaultScheduleRoute', () => {
   beforeEach(() => {
@@ -112,5 +118,16 @@ describe('resolveDefaultScheduleRoute', () => {
     await expect(
       resolveDefaultScheduleRoute('claude-code', null, 'claude-first-fire'),
     ).resolves.toBeNull();
+  });
+});
+
+describe('resolveLenientSessionRoute provider-list outage', () => {
+  it('拒绝把裸 Grok 原样放行成 providerId=null', async () => {
+    h.listProviders.mockRejectedValueOnce(new Error('provider list unavailable'));
+    await expect(resolveLenientSessionRoute('claude-code', 'grok-4.6', null)).resolves.toEqual({
+      model: undefined,
+      providerId: null,
+      degraded: true,
+    });
   });
 });

--- a/apps/desktop/src/main/maker-host/__tests__/model-route-guard.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/model-route-guard.test.ts
@@ -506,6 +506,21 @@ describe('materializeExclusiveProviderRoute', () => {
       .toEqual({ kind: 'reject' });
   });
 
+  it('目录里对应 xai/ 副本被停用时,裸 id 也不能 pin', () => {
+    const catalog = {
+      providers: [
+        provider('xd', [model('claude-opus-5')]),
+        {
+          ...provider('xai', [model('xai/grok-4.5', { disabled: true })]),
+          agents: ['claude-code', 'pi'],
+        },
+      ],
+    } as Catalog;
+    const views = buildRegistry(catalog, { xd: true, xai: true });
+    expect(materializeExclusiveProviderRoute(views, 'claude-code', 'grok-4.5', null))
+      .toEqual({ kind: 'reject' });
+  });
+
   it('网关风格 x-ai/ 与自定义供应商不占用独占门', () => {
     expect(materializeExclusiveProviderRoute(xaiViews(), 'claude-code', 'x-ai/grok-4.6', null))
       .toEqual({ kind: 'keep' });

--- a/apps/desktop/src/main/maker-host/__tests__/model-route-guard.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/model-route-guard.test.ts
@@ -17,6 +17,7 @@ import {
   resolveExclusiveSetModelReroute,
   resolveLenientRoute,
   resolveSetModelGuardProviderId,
+  shouldApplyExclusiveProviderReroute,
 } from '../model-route-guard.js';
 
 function model(id: string, extra: Partial<CatalogModel> = {}): CatalogModel {
@@ -517,6 +518,10 @@ describe('materializeExclusiveProviderRoute', () => {
     expect(resolveExclusiveSetModelReroute(undefined, 'my-litellm', 'xai')).toBeUndefined();
     expect(resolveExclusiveSetModelReroute(undefined, null, 'xai')).toBe('xai');
     expect(resolveExclusiveSetModelReroute(undefined, 'anthropic', 'xai')).toBe('xai');
+    expect(resolveExclusiveSetModelReroute('anthropic', 'anthropic', 'xai')).toBe('xai');
+    expect(resolveExclusiveSetModelReroute('xd', null, 'xai')).toBe('xai');
+    expect(shouldApplyExclusiveProviderReroute('anthropic')).toBe(true);
+    expect(shouldApplyExclusiveProviderReroute('my-litellm')).toBe(false);
     expect(resolveExclusiveSetModelReroute(null, 'my-litellm', 'xai')).toBe('xai');
   });
 

--- a/apps/desktop/src/main/maker-host/__tests__/model-route-guard.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/model-route-guard.test.ts
@@ -467,13 +467,21 @@ describe('materializeExclusiveProviderRoute', () => {
     const catalog = {
       providers: [
         provider('xd', [model('claude-opus-5')]),
+        provider('anthropic', [model('claude-opus-5')]),
+        provider('openai', [model('gpt-5.5')]),
+        provider('gemini', [model('gemini-3-flash')]),
         {
           ...provider('xai', [model('xai/grok-4.5')]),
           agents: ['claude-code', 'pi'],
         },
       ],
     } as Catalog;
-    return buildRegistry(catalog, connected);
+    return buildRegistry(catalog, {
+      anthropic: true,
+      openai: true,
+      gemini: true,
+      ...connected,
+    });
   }
 
   it('Claude/GPT 双来源保持 keep,不打断默认队列', () => {
@@ -524,19 +532,49 @@ describe('materializeExclusiveProviderRoute', () => {
   it('网关风格 x-ai/ 与自定义供应商不占用独占门', () => {
     expect(materializeExclusiveProviderRoute(xaiViews(), 'claude-code', 'x-ai/grok-4.6', null))
       .toEqual({ kind: 'keep' });
-    expect(materializeExclusiveProviderRoute(xaiViews(), 'claude-code', 'grok-4.6', 'my-litellm'))
+    const mixed = {
+      providers: [
+        provider('xd', [model('claude-opus-5')]),
+        {
+          ...provider('xai', [model('xai/grok-4.5')]),
+          agents: ['claude-code', 'pi'],
+        },
+        provider('gemini', [model('gemini-3-flash')]),
+        provider('my-litellm', [model('grok-4.6')], 'user'),
+      ],
+    } as Catalog;
+    const mixedViews = buildRegistry(mixed, {
+      xd: true,
+      xai: true,
+      gemini: true,
+      'my-litellm': true,
+    });
+    expect(materializeExclusiveProviderRoute(mixedViews, 'claude-code', 'grok-4.6', 'my-litellm'))
+      .toEqual({ kind: 'keep' });
+    expect(materializeExclusiveProviderRoute(mixedViews, 'claude-code', 'grok-4.6', 'gemini'))
+      .toEqual({ kind: 'pin', providerId: 'xai' });
+    expect(materializeExclusiveProviderRoute(mixedViews, 'claude-code', 'grok-4.6', 'unknown-vendor'))
       .toEqual({ kind: 'keep' });
   });
 
   it('SET_MODEL undefined 保持当前 custom 来源,不会改绑 xAI', () => {
     expect(resolveSetModelGuardProviderId(undefined, 'my-litellm')).toBe('my-litellm');
-    expect(resolveExclusiveSetModelReroute(undefined, 'my-litellm', 'xai')).toBeUndefined();
+    expect(resolveExclusiveSetModelReroute(
+      undefined,
+      'my-litellm',
+      'xai',
+      true,
+      [{ id: 'my-litellm', source: 'user' }],
+    )).toBeUndefined();
     expect(resolveExclusiveSetModelReroute(undefined, null, 'xai')).toBe('xai');
     expect(resolveExclusiveSetModelReroute(undefined, 'anthropic', 'xai')).toBe('xai');
     expect(resolveExclusiveSetModelReroute('anthropic', 'anthropic', 'xai')).toBe('xai');
     expect(resolveExclusiveSetModelReroute('xd', null, 'xai')).toBe('xai');
     expect(shouldApplyExclusiveProviderReroute('anthropic')).toBe(true);
-    expect(shouldApplyExclusiveProviderReroute('my-litellm')).toBe(false);
+    expect(shouldApplyExclusiveProviderReroute('gemini')).toBe(true);
+    expect(shouldApplyExclusiveProviderReroute('my-litellm', [{ id: 'my-litellm', source: 'user' }])).toBe(false);
+    expect(shouldApplyExclusiveProviderReroute('gemini', [{ id: 'gemini', source: 'builtin' }])).toBe(true);
+    expect(shouldApplyExclusiveProviderReroute('unknown-vendor', [{ id: 'gemini', source: 'builtin' }])).toBe(false);
     expect(resolveExclusiveSetModelReroute(null, 'my-litellm', 'xai')).toBe('xai');
   });
 
@@ -548,6 +586,8 @@ describe('materializeExclusiveProviderRoute', () => {
         undefined,
         resolveCurrentSetModelProviderId(false, null, 'my-litellm'),
         'xai',
+        true,
+        [{ id: 'my-litellm', source: 'user' }],
       ),
     ).toBeUndefined();
     expect(resolveExclusiveSetModelReroute(undefined, null, 'xai', false)).toBeUndefined();

--- a/apps/desktop/src/main/maker-host/__tests__/model-route-guard.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/model-route-guard.test.ts
@@ -487,10 +487,21 @@ describe('materializeExclusiveProviderRoute', () => {
       .toEqual({ kind: 'pin', providerId: 'xai' });
   });
 
-  it('显式 xd 或 xAI 未连接 → reject,不把 Grok 送进默认网关', () => {
+  it('显式 xd 在 xAI 已连接时改绑 xAI,未连接才 reject', () => {
     expect(materializeExclusiveProviderRoute(xaiViews(), 'claude-code', 'grok-4.6', 'xd'))
+      .toEqual({ kind: 'pin', providerId: 'xai' });
+    expect(materializeExclusiveProviderRoute(xaiViews({ xd: true, xai: false }), 'claude-code', 'grok-4.6', 'xd'))
       .toEqual({ kind: 'reject' });
     expect(materializeExclusiveProviderRoute(xaiViews({ xd: true, xai: false }), 'claude-code', 'grok-4.6', null))
+      .toEqual({ kind: 'reject' });
+  });
+
+  it('内置 anthropic/openai 上的裸 Grok 改绑 xAI,不能 keep', () => {
+    expect(materializeExclusiveProviderRoute(xaiViews(), 'claude-code', 'grok-4.6', 'anthropic'))
+      .toEqual({ kind: 'pin', providerId: 'xai' });
+    expect(materializeExclusiveProviderRoute(xaiViews(), 'claude-code', 'grok-4.6', 'openai'))
+      .toEqual({ kind: 'pin', providerId: 'xai' });
+    expect(materializeExclusiveProviderRoute(xaiViews({ xd: true, xai: false }), 'claude-code', 'grok-4.6', 'anthropic'))
       .toEqual({ kind: 'reject' });
   });
 
@@ -505,6 +516,7 @@ describe('materializeExclusiveProviderRoute', () => {
     expect(resolveSetModelGuardProviderId(undefined, 'my-litellm')).toBe('my-litellm');
     expect(resolveExclusiveSetModelReroute(undefined, 'my-litellm', 'xai')).toBeUndefined();
     expect(resolveExclusiveSetModelReroute(undefined, null, 'xai')).toBe('xai');
+    expect(resolveExclusiveSetModelReroute(undefined, 'anthropic', 'xai')).toBe('xai');
     expect(resolveExclusiveSetModelReroute(null, 'my-litellm', 'xai')).toBe('xai');
   });
 

--- a/apps/desktop/src/main/maker-host/__tests__/model-route-guard.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/model-route-guard.test.ts
@@ -11,8 +11,12 @@ import { buildRegistry, type Catalog, type CatalogModel, type Provider } from '@
 
 import {
   checkModelRoute,
+  materializeExclusiveProviderRoute,
   pickEnabledFallbackModel,
+  resolveCurrentSetModelProviderId,
+  resolveExclusiveSetModelReroute,
   resolveLenientRoute,
+  resolveSetModelGuardProviderId,
 } from '../model-route-guard.js';
 
 function model(id: string, extra: Partial<CatalogModel> = {}): CatalogModel {
@@ -454,5 +458,75 @@ describe('resolveLenientRoute(自动化直建会话的宽松降级)', () => {
     expect(
       resolveLenientRoute(views(), 'claude-code', 'claude-opus-5', null, { desiredEffort: 'max' }),
     ).toEqual({ model: 'claude-opus-5', providerId: null, degraded: false });
+  });
+});
+
+describe('materializeExclusiveProviderRoute', () => {
+  function xaiViews(connected: Record<string, boolean> = { xd: true, xai: true }) {
+    const catalog = {
+      providers: [
+        provider('xd', [model('claude-opus-5')]),
+        {
+          ...provider('xai', [model('xai/grok-4.5')]),
+          agents: ['claude-code', 'pi'],
+        },
+      ],
+    } as Catalog;
+    return buildRegistry(catalog, connected);
+  }
+
+  it('Claude/GPT 双来源保持 keep,不打断默认队列', () => {
+    expect(materializeExclusiveProviderRoute(views(), 'claude-code', 'claude-opus-5', null))
+      .toEqual({ kind: 'keep' });
+  });
+
+  it('裸 grok / xai/ 前缀在 xAI 已连接时钉死 xai', () => {
+    expect(materializeExclusiveProviderRoute(xaiViews(), 'claude-code', 'grok-4.6', null))
+      .toEqual({ kind: 'pin', providerId: 'xai' });
+    expect(materializeExclusiveProviderRoute(xaiViews(), 'claude-code', 'xai/grok-4.6', null))
+      .toEqual({ kind: 'pin', providerId: 'xai' });
+  });
+
+  it('显式 xd 或 xAI 未连接 → reject,不把 Grok 送进默认网关', () => {
+    expect(materializeExclusiveProviderRoute(xaiViews(), 'claude-code', 'grok-4.6', 'xd'))
+      .toEqual({ kind: 'reject' });
+    expect(materializeExclusiveProviderRoute(xaiViews({ xd: true, xai: false }), 'claude-code', 'grok-4.6', null))
+      .toEqual({ kind: 'reject' });
+  });
+
+  it('网关风格 x-ai/ 与自定义供应商不占用独占门', () => {
+    expect(materializeExclusiveProviderRoute(xaiViews(), 'claude-code', 'x-ai/grok-4.6', null))
+      .toEqual({ kind: 'keep' });
+    expect(materializeExclusiveProviderRoute(xaiViews(), 'claude-code', 'grok-4.6', 'my-litellm'))
+      .toEqual({ kind: 'keep' });
+  });
+
+  it('SET_MODEL undefined 保持当前 custom 来源,不会改绑 xAI', () => {
+    expect(resolveSetModelGuardProviderId(undefined, 'my-litellm')).toBe('my-litellm');
+    expect(resolveExclusiveSetModelReroute(undefined, 'my-litellm', 'xai')).toBeUndefined();
+    expect(resolveExclusiveSetModelReroute(undefined, null, 'xai')).toBe('xai');
+    expect(resolveExclusiveSetModelReroute(null, 'my-litellm', 'xai')).toBe('xai');
+  });
+
+  it('未 hydrate 时用 DB 持久来源,不把 custom 会话当成默认队列', () => {
+    expect(resolveCurrentSetModelProviderId(false, null, 'my-litellm')).toBe('my-litellm');
+    expect(resolveCurrentSetModelProviderId(true, null, 'my-litellm')).toBeNull();
+    expect(
+      resolveExclusiveSetModelReroute(
+        undefined,
+        resolveCurrentSetModelProviderId(false, null, 'my-litellm'),
+        'xai',
+      ),
+    ).toBeUndefined();
+    expect(resolveExclusiveSetModelReroute(undefined, null, 'xai', false)).toBeUndefined();
+  });
+
+  it('lenient 二次降级不会把独占 Grok 放成 providerId=null', () => {
+    const v = xaiViews({ xd: true, xai: false });
+    expect(resolveLenientRoute(v, 'claude-code', 'grok-4.6', 'xai')).toEqual({
+      model: 'claude-opus-5',
+      providerId: 'xd',
+      degraded: true,
+    });
   });
 });

--- a/apps/desktop/src/main/maker-host/__tests__/model-route-guard.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/model-route-guard.test.ts
@@ -484,6 +484,15 @@ describe('materializeExclusiveProviderRoute', () => {
     });
   }
 
+  it('checkModelRoute 对隐式裸 Grok 直接改绑 xAI,IM 默认不必再补一口', () => {
+    expect(checkModelRoute(xaiViews(), 'pi', 'grok-4.6', null))
+      .toEqual({ kind: 'reroute', providerId: 'xai' });
+    expect(checkModelRoute(xaiViews({ xd: true, xai: false }), 'pi', 'grok-4.6', null))
+      .toEqual({ kind: 'reject', reason: 'exclusive-source-unavailable' });
+    expect(checkModelRoute(views(), 'claude-code', 'claude-opus-5', null))
+      .toEqual({ kind: 'pass' });
+  });
+
   it('Claude/GPT 双来源保持 keep,不打断默认队列', () => {
     expect(materializeExclusiveProviderRoute(views(), 'claude-code', 'claude-opus-5', null))
       .toEqual({ kind: 'keep' });

--- a/apps/desktop/src/main/maker-host/__tests__/providerRoute.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/providerRoute.test.ts
@@ -451,6 +451,17 @@ describe('resolveSessionRouteDecision — modelPrefixes 服务范围门(issue #8
     )).resolves.toEqual(expect.objectContaining({ upstreamOverride: 'https://api.x.ai/v1' }));
   });
 
+  it('xAI 会话的裸 grok-4.6 仍算自家模型,不回落默认网关', async () => {
+    setSessionProvider('s-scope', 'xai');
+    setProviderOAuthTokenReader(() => Promise.resolve('xai-live-token'));
+    expect(resolveSessionRouteDecision('s-scope', 'claude-code', KEY, 'grok-4.6')).toEqual({
+      upstreamOverride: 'https://api.x.ai/v1',
+    });
+    await expect(Promise.resolve(
+      resolveSessionRouteDecision('s-scope', 'codex', KEY, 'grok-4.6'),
+    )).resolves.toEqual(expect.objectContaining({ upstreamOverride: 'https://api.x.ai/v1' }));
+  });
+
   it('pending 目标在旧 Provider scope 外时仍先 fail closed', () => {
     setSessionProvider('s-scope', 'xai');
     setPendingCredentialSwitchReader(() => ({

--- a/apps/desktop/src/main/maker-host/__tests__/subagent-override-route.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/subagent-override-route.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import { shouldKeepSubagentOverrideForParent } from '../subagent-override-route.js';
+
+function decide(
+  saved: string,
+  providerId: string | null,
+  extra: Partial<Parameters<typeof shouldKeepSubagentOverrideForParent>[0]> = {},
+) {
+  return shouldKeepSubagentOverrideForParent({
+    saved,
+    providerId,
+    parentOffersSaved: false,
+    parentCopyDisabled: false,
+    anyOffering: true,
+    allOfferingsDisabled: false,
+    ...extra,
+  });
+}
+
+describe('shouldKeepSubagentOverrideForParent', () => {
+  it('父来源自己提供该模型时按停用轴决定', () => {
+    expect(decide('claude-opus-5', 'anthropic', { parentOffersSaved: true })).toBe(true);
+    expect(decide('claude-opus-5', 'anthropic', {
+      parentOffersSaved: true,
+      parentCopyDisabled: true,
+    })).toBe(false);
+  });
+
+  it('xai/ 与 chatgpt/ 覆写在显式非供应父来源下仍注入(旧半修会丢掉)', () => {
+    expect(decide('xai/grok-4.6', 'xd')).toBe(true);
+    expect(decide('xai/grok-4.6', 'anthropic')).toBe(true);
+    expect(decide('xai/grok-4.6', 'gemini')).toBe(true);
+    expect(decide('chatgpt/gpt-5.5', 'xd')).toBe(true);
+  });
+
+  it('裸 grok 不能跟着非 xAI 父会话注入', () => {
+    expect(decide('grok-4.6', 'xd')).toBe(false);
+    expect(decide('grok-4.6', 'anthropic')).toBe(false);
+    expect(decide('grok-4.6', 'gemini')).toBe(false);
+    expect(decide('grok-4.6', 'xai', { anyOffering: false })).toBe(true);
+  });
+
+  it('普通模型在显式父来源不提供时不注入', () => {
+    expect(decide('claude-opus-5', 'gemini')).toBe(false);
+  });
+});

--- a/apps/desktop/src/main/maker-host/anthropic-compat-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/anthropic-compat-proxy-host.ts
@@ -47,7 +47,11 @@ import {
   getResponsesBridgeHandler,
 } from './anthropic-responses-bridge-host.js';
 import { getSessionEffort, getSessionFastMode } from './session-effort-store.js';
-import { isSubscriptionDirectModel } from '../../shared/subscriptionModels.js';
+import {
+  isExclusiveXaiModelId,
+  isSubscriptionDirectRoute,
+  XAI_MODEL_PREFIX,
+} from '../../shared/subscriptionModels.js';
 import {
   composeResponseObservers,
   createClaudeRateLimitHeadersObserver,
@@ -136,6 +140,34 @@ export function setClaudeProxySessionIdResolver(
 
 function isPlainObject(v: unknown): v is Record<string, unknown> {
   return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+function refuseExclusiveXaiDefaultGateway(wireModel: string): RoutingDecision {
+  return {
+    localHandler: async ({ res }) => {
+      const payload = JSON.stringify({
+        type: 'error',
+        error: {
+          type: 'invalid_request_error',
+          code: 'exclusive_xai_route_required',
+          message:
+            `model '${wireModel}' requires SuperGrok (xAI) and cannot use the default Anthropic gateway`,
+        },
+      });
+      res.writeHead(400, {
+        'content-type': 'application/json; charset=utf-8',
+        'cache-control': 'no-store',
+      });
+      res.end(payload);
+    },
+  };
+}
+
+function bridgedSubscriptionModel(wireModel: string): string {
+  if (wireModel.startsWith(XAI_MODEL_PREFIX) || !isExclusiveXaiModelId(wireModel)) {
+    return wireModel;
+  }
+  return `${XAI_MODEL_PREFIX}${wireModel.replace(/\[1m\]$/i, '')}`;
 }
 
 /** 大小写不敏感取 header 值;缺失或空串 → null。 */
@@ -271,6 +303,14 @@ export function createModelRoutingTransform(): RoutingTransform {
       : null;
     if (pendingRoute) return pendingRoute;
 
+    const selectedProviderId = sessionId ? getSessionProvider(sessionId) : null;
+    const explicitCustomProvider =
+      !!selectedProviderId
+      && selectedProviderId !== 'xai'
+      && selectedProviderId !== 'xd'
+      && selectedProviderId !== 'anthropic'
+      && selectedProviderId !== 'openai';
+
     // ⓪ 订阅直连翻译:model 带 `chatgpt/` / `xai/` 前缀 → 交给本地 responses handler
     //    (localHandler 插槽,进程内直调,不多一跳;它把 Anthropic Messages ↔ OpenAI Responses
     //    双向翻译,用对应订阅 OAuth 直打 codex / api.x.ai)。
@@ -279,9 +319,21 @@ export function createModelRoutingTransform(): RoutingTransform {
     //    放在最前:优先级高于 per-session 供应商与 spawn 默认路由。
     //    ⚠ 本分支是订阅直连的**唯一注册点**:整块摘掉 = 订阅前缀请求 passthrough 到默认上游
     //    (预期 400/502,fail-open),不需要 revert 其它代码。
-    if (!piSessionId && isSubscriptionDirectModel(wireModel)) {
+    // 显式自定义供应商 + 裸 grok id 必须走 ① 的用户上游,不能仅凭模型名劫持到 SuperGrok。
+    // `xai/` / `chatgpt/` 前缀仍是订阅户口,按 per-request 进 bridge。
+    if (
+      !piSessionId
+      && isSubscriptionDirectRoute(wireModel)
+      && !(explicitCustomProvider && isExclusiveXaiModelId(wireModel) && !wireModel.startsWith(XAI_MODEL_PREFIX))
+    ) {
       const bridgeHandler = getResponsesBridgeHandler();
       if (!bridgeHandler) {
+        if (isExclusiveXaiModelId(wireModel)) {
+          log.warn('exclusive xAI model but responses handler unavailable; refusing default gateway', {
+            wireModel,
+          });
+          return refuseExclusiveXaiDefaultGateway(wireModel);
+        }
         log.warn('订阅前缀模型但 responses handler 不可用,passthrough(该请求预期会 400)', { wireModel });
         return null;
       }
@@ -289,14 +341,21 @@ export function createModelRoutingTransform(): RoutingTransform {
       // effort / fast 放进请求体,而引擎保持零会话概念,不走任何伪 header。
       const effort = sessionId ? getSessionEffort(sessionId) : null;
       const fast = sessionId ? getSessionFastMode(sessionId) : false;
+      const bridgedModel = bridgedSubscriptionModel(wireModel);
       return {
-        localHandler: (args) =>
-          bridgeHandler.handle({ ...args, prefs: { reasoningEffort: effort ?? undefined, fast } }),
+        localHandler: (args) => {
+          if (bridgedModel !== wireModel && isPlainObject(args.parsedBody)) {
+            args.parsedBody.model = bridgedModel;
+          }
+          return bridgeHandler.handle({
+            ...args,
+            prefs: { reasoningEffort: effort ?? undefined, fast },
+          });
+        },
       };
     }
 
     const gatewayKey = _readGatewayKey();
-    const selectedProviderId = sessionId ? getSessionProvider(sessionId) : null;
 
     // ① 该会话显式选了供应商 → 据 catalog 统一路由。
     //    x-claude-code-session-id = cc sdkSessionId,经注入的 resolver 反解成 xdt sessionId。
@@ -341,6 +400,13 @@ export function createModelRoutingTransform(): RoutingTransform {
     // passthrough 会在网关吃确定性 401 → 误触发 auto→ask 降级(#831)。与 codex
     // ①.5 段 #890 修复同语义:占位 key 按「无可用凭证」处理,走下方换网关 key 的
     // 默认路由;真实 key(gateway-spawn)照旧 passthrough。
+    if (isExclusiveXaiModelId(wireModel)) {
+      log.warn('exclusive xAI model escaped subscription routing; refusing default gateway', {
+        wireModel,
+        selectedProviderId,
+      });
+      return refuseExclusiveXaiDefaultGateway(wireModel);
+    }
     const apiKeyHeader = headerValue(ctx.headers, 'x-api-key');
     const hasUsableApiKey =
       apiKeyHeader !== null && apiKeyHeader !== CLAUDE_PROVIDER_AUTH_PLACEHOLDER_KEY;

--- a/apps/desktop/src/main/maker-host/anthropic-compat-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/anthropic-compat-proxy-host.ts
@@ -63,6 +63,7 @@ import {
   type ClaudeSessionBillingRoute,
 } from './claude-session-route-registry.js';
 import { createClaudeGatewayErrorObserver } from './claude-gateway-error-observer.js';
+import { shouldApplyExclusiveProviderReroute } from './model-route-guard.js';
 import { getSessionProvider } from './session-provider-store.js';
 import {
   gatewayDefaultRouteDecision,
@@ -304,12 +305,14 @@ export function createModelRoutingTransform(): RoutingTransform {
     if (pendingRoute) return pendingRoute;
 
     const selectedProviderId = sessionId ? getSessionProvider(sessionId) : null;
+    const applyExclusiveReroute = shouldApplyExclusiveProviderReroute(
+      selectedProviderId,
+      getActiveCatalog().providers,
+    );
     const explicitCustomProvider =
       !!selectedProviderId
       && selectedProviderId !== 'xai'
-      && selectedProviderId !== 'xd'
-      && selectedProviderId !== 'anthropic'
-      && selectedProviderId !== 'openai';
+      && !applyExclusiveReroute;
 
     // ⓪ 订阅直连翻译:model 带 `chatgpt/` / `xai/` 前缀 → 交给本地 responses handler
     //    (localHandler 插槽,进程内直调,不多一跳;它把 Anthropic Messages ↔ OpenAI Responses
@@ -319,14 +322,13 @@ export function createModelRoutingTransform(): RoutingTransform {
     //    放在最前:优先级高于 per-session 供应商与 spawn 默认路由。
     //    ⚠ 本分支是订阅直连的**唯一注册点**:整块摘掉 = 订阅前缀请求 passthrough 到默认上游
     //    (预期 400/502,fail-open),不需要 revert 其它代码。
-    // 内置非 xAI 来源上的裸 Grok 不能偷走 SuperGrok 额度,否则会话仍记着 anthropic/openai/xd。
+    // 非自定义、非 xAI 来源上的裸 Grok 不能偷走 SuperGrok 额度。
     if (
       !piSessionId
       && isExclusiveXaiModelId(wireModel)
       && !wireModel.startsWith(XAI_MODEL_PREFIX)
-      && (selectedProviderId === 'xd'
-        || selectedProviderId === 'anthropic'
-        || selectedProviderId === 'openai')
+      && selectedProviderId
+      && applyExclusiveReroute
     ) {
       return refuseExclusiveXaiDefaultGateway(wireModel);
     }

--- a/apps/desktop/src/main/maker-host/anthropic-compat-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/anthropic-compat-proxy-host.ts
@@ -319,6 +319,17 @@ export function createModelRoutingTransform(): RoutingTransform {
     //    放在最前:优先级高于 per-session 供应商与 spawn 默认路由。
     //    ⚠ 本分支是订阅直连的**唯一注册点**:整块摘掉 = 订阅前缀请求 passthrough 到默认上游
     //    (预期 400/502,fail-open),不需要 revert 其它代码。
+    // 内置非 xAI 来源上的裸 Grok 不能偷走 SuperGrok 额度,否则会话仍记着 anthropic/openai/xd。
+    if (
+      !piSessionId
+      && isExclusiveXaiModelId(wireModel)
+      && !wireModel.startsWith(XAI_MODEL_PREFIX)
+      && (selectedProviderId === 'xd'
+        || selectedProviderId === 'anthropic'
+        || selectedProviderId === 'openai')
+    ) {
+      return refuseExclusiveXaiDefaultGateway(wireModel);
+    }
     // 显式自定义供应商 + 裸 grok id 必须走 ① 的用户上游,不能仅凭模型名劫持到 SuperGrok。
     // `xai/` / `chatgpt/` 前缀仍是订阅户口,按 per-request 进 bridge。
     if (

--- a/apps/desktop/src/main/maker-host/model-route-guard-live.ts
+++ b/apps/desktop/src/main/maker-host/model-route-guard-live.ts
@@ -37,6 +37,7 @@ import {
   checkModelRoute,
   materializeExclusiveProviderRoute,
   resolveLenientRoute,
+  shouldApplyExclusiveProviderReroute,
   type ModelRouteGuardOptions,
   type ModelRouteVerdict,
 } from './model-route-guard.js';
@@ -209,6 +210,12 @@ export async function pinExclusiveSessionProvider(
   }
   const exclusive = materializeExclusiveProviderRoute(views, agent, model, providerId);
   return exclusive.kind === 'pin' ? exclusive.providerId : undefined;
+}
+
+export function shouldApplyExclusiveProviderRerouteLive(
+  providerId: string | null | undefined,
+): boolean {
+  return shouldApplyExclusiveProviderReroute(providerId, getActiveCatalog().providers);
 }
 
 /**

--- a/apps/desktop/src/main/maker-host/model-route-guard-live.ts
+++ b/apps/desktop/src/main/maker-host/model-route-guard-live.ts
@@ -177,23 +177,9 @@ export async function verdictForModelRoute(
   } catch {
     const tombstoneVerdict = checkModelRoute([], agent, model, providerId, guardOptions);
     if (tombstoneVerdict.kind === 'reject') return tombstoneVerdict;
-    const exclusive = materializeExclusiveProviderRoute([], agent, model, providerId);
-    if (exclusive.kind === 'reject') {
-      return { kind: 'reject', reason: 'exclusive-source-unavailable' };
-    }
-    if (exclusive.kind === 'pin') return { kind: 'reroute', providerId: exclusive.providerId };
     return overrideOnlyVerdict(agent, model, providerId);
   }
-  const disableVerdict = checkModelRoute(views, agent, model, providerId, guardOptions);
-  if (disableVerdict.kind === 'reject') return disableVerdict;
-  const providerAfterDisable =
-    disableVerdict.kind === 'reroute' ? disableVerdict.providerId : providerId;
-  const exclusive = materializeExclusiveProviderRoute(views, agent, model, providerAfterDisable);
-  if (exclusive.kind === 'reject') {
-    return { kind: 'reject', reason: 'exclusive-source-unavailable' };
-  }
-  if (exclusive.kind === 'pin') return { kind: 'reroute', providerId: exclusive.providerId };
-  return disableVerdict;
+  return checkModelRoute(views, agent, model, providerId, guardOptions);
 }
 
 /** Resume 旧会话:只钉死独占来源,不把停用轴 reject 套到已在跑的会话上。 */

--- a/apps/desktop/src/main/maker-host/model-route-guard-live.ts
+++ b/apps/desktop/src/main/maker-host/model-route-guard-live.ts
@@ -35,6 +35,7 @@ import {
 } from './model-plane/modelPlanePolicy.js';
 import {
   checkModelRoute,
+  materializeExclusiveProviderRoute,
   resolveLenientRoute,
   type ModelRouteGuardOptions,
   type ModelRouteVerdict,
@@ -175,9 +176,39 @@ export async function verdictForModelRoute(
   } catch {
     const tombstoneVerdict = checkModelRoute([], agent, model, providerId, guardOptions);
     if (tombstoneVerdict.kind === 'reject') return tombstoneVerdict;
+    const exclusive = materializeExclusiveProviderRoute([], agent, model, providerId);
+    if (exclusive.kind === 'reject') {
+      return { kind: 'reject', reason: 'exclusive-source-unavailable' };
+    }
+    if (exclusive.kind === 'pin') return { kind: 'reroute', providerId: exclusive.providerId };
     return overrideOnlyVerdict(agent, model, providerId);
   }
-  return checkModelRoute(views, agent, model, providerId, guardOptions);
+  const disableVerdict = checkModelRoute(views, agent, model, providerId, guardOptions);
+  if (disableVerdict.kind === 'reject') return disableVerdict;
+  const providerAfterDisable =
+    disableVerdict.kind === 'reroute' ? disableVerdict.providerId : providerId;
+  const exclusive = materializeExclusiveProviderRoute(views, agent, model, providerAfterDisable);
+  if (exclusive.kind === 'reject') {
+    return { kind: 'reject', reason: 'exclusive-source-unavailable' };
+  }
+  if (exclusive.kind === 'pin') return { kind: 'reroute', providerId: exclusive.providerId };
+  return disableVerdict;
+}
+
+/** Resume 旧会话:只钉死独占来源,不把停用轴 reject 套到已在跑的会话上。 */
+export async function pinExclusiveSessionProvider(
+  agent: AgentKind,
+  model: string,
+  providerId: string | null,
+): Promise<string | undefined> {
+  let views: ProviderView[];
+  try {
+    views = await listRouteGuardProviders();
+  } catch {
+    return undefined;
+  }
+  const exclusive = materializeExclusiveProviderRoute(views, agent, model, providerId);
+  return exclusive.kind === 'pin' ? exclusive.providerId : undefined;
 }
 
 /**
@@ -206,6 +237,13 @@ export async function resolveLenientSessionRoute(
     // 目录故障降级:override-only 保守裁决(同 overrideOnlyVerdict 语义)。命中即
     // 逐级丢弃;目录不可得时没有 pick 兜底可用,model 置空由调用方失败收口。
     if (!model) return { model, providerId, degraded: false };
+    const exclusive = materializeExclusiveProviderRoute([], agent, model, providerId);
+    if (exclusive.kind === 'reject') {
+      return { model: undefined, providerId: null, degraded: true };
+    }
+    if (exclusive.kind === 'pin') {
+      return { model, providerId: exclusive.providerId, degraded: false };
+    }
     if (checkModelRoute([], agent, model, providerId, guardOptions).kind === 'reject') {
       return { model: undefined, providerId: null, degraded: true };
     }

--- a/apps/desktop/src/main/maker-host/model-route-guard.ts
+++ b/apps/desktop/src/main/maker-host/model-route-guard.ts
@@ -179,7 +179,27 @@ function copyRetired(p: ProviderView, modelId: string, agent: AgentKind): boolea
   return getModel(p, modelId, agent)?.status === 'retired';
 }
 
-export function checkModelRoute(
+function applyExclusiveRoute(
+  views: readonly ProviderView[],
+  agent: AgentKind,
+  modelId: string,
+  providerId: string | null,
+  disableVerdict: ModelRouteVerdict,
+): ModelRouteVerdict {
+  if (disableVerdict.kind === 'reject') return disableVerdict;
+  const providerAfter =
+    disableVerdict.kind === 'reroute' ? disableVerdict.providerId : providerId;
+  const exclusive = materializeExclusiveProviderRoute(views, agent, modelId, providerAfter);
+  if (exclusive.kind === 'reject') {
+    return { kind: 'reject', reason: 'exclusive-source-unavailable' };
+  }
+  if (exclusive.kind === 'pin') {
+    return { kind: 'reroute', providerId: exclusive.providerId };
+  }
+  return disableVerdict;
+}
+
+function checkDisableAxisRoute(
   views: readonly ProviderView[],
   agent: AgentKind,
   modelId: string,
@@ -279,6 +299,23 @@ export function checkModelRoute(
     : { kind: 'reject', reason: 'model-disabled' };
 }
 
+/** 停用轴 + 独占 Grok 改绑。IM / Scheduler / create 都走这里,不再各自补一口。 */
+export function checkModelRoute(
+  views: readonly ProviderView[],
+  agent: AgentKind,
+  modelId: string,
+  providerId: string | null,
+  options: ModelRouteGuardOptions = {},
+): ModelRouteVerdict {
+  return applyExclusiveRoute(
+    views,
+    agent,
+    modelId,
+    providerId,
+    checkDisableAxisRoute(views, agent, modelId, providerId, options),
+  );
+}
+
 /**
  * 目录里第一份「已连接、启用、agent 可选」的对话模型拷贝(宽松降级的最终兜底;
  * IM 默认设置的 firstModel 亦复用,避免两处「兜底选模型」口径漂移)。
@@ -352,22 +389,12 @@ export function resolveLenientRoute(
     return { model: resolvedModel, providerId: resolvedProviderId, degraded, effort };
   };
   let verdict = checkModelRoute(views, agent, model, providerId, opts);
-  if (verdict.kind === 'pass') {
-    const exclusive = materializeExclusiveProviderRoute(views, agent, model, providerId);
-    if (exclusive.kind === 'pin') return withEffort(model, exclusive.providerId, false);
-    // reject: 独占 Grok 不能落到默认网关,落到下方改走可用对话模型。
-    if (exclusive.kind !== 'reject') return { model, providerId, degraded: false };
-  }
+  if (verdict.kind === 'pass') return { model, providerId, degraded: false };
   if (verdict.kind === 'reroute') return withEffort(model, verdict.providerId, false);
   if (providerId) {
     verdict = checkModelRoute(views, agent, model, null, opts);
-    if (verdict.kind === 'pass') {
-      const exclusive = materializeExclusiveProviderRoute(views, agent, model, null);
-      if (exclusive.kind === 'pin') return withEffort(model, exclusive.providerId, true);
-      if (exclusive.kind !== 'reject') return withEffort(model, null, true);
-    } else if (verdict.kind === 'reroute') {
-      return withEffort(model, verdict.providerId, true);
-    }
+    if (verdict.kind === 'pass') return withEffort(model, null, true);
+    if (verdict.kind === 'reroute') return withEffort(model, verdict.providerId, true);
   }
   if (opts.fallbackModel && opts.fallbackModel !== model) {
     const fallback = resolveLenientRoute(views, agent, opts.fallbackModel, null, opts);

--- a/apps/desktop/src/main/maker-host/model-route-guard.ts
+++ b/apps/desktop/src/main/maker-host/model-route-guard.ts
@@ -32,6 +32,7 @@ import {
   effectiveSourceIdForModel,
   getModel,
   isAgentSelectableModel,
+  exclusiveXaiCatalogModelId,
   isExclusiveXaiModelId,
   isModelSelectableForNewRoute,
   nativeDefaultSourceId,
@@ -78,14 +79,21 @@ export function materializeExclusiveProviderRoute(
       && provider.suspended !== true
       && provider.agents.includes(agent),
   );
-  if (providerId === 'xai') {
-    return xai ? { kind: 'keep' } : { kind: 'reject' };
+  if (!xai) {
+    return providerId && !shouldApplyExclusiveProviderReroute(providerId) && providerId !== 'xai'
+      ? { kind: 'keep' }
+      : { kind: 'reject' };
   }
-  if (providerId === 'xd' || providerId === 'anthropic' || providerId === 'openai') {
-    return xai ? { kind: 'pin', providerId: 'xai' } : { kind: 'reject' };
+  const catalogId = exclusiveXaiCatalogModelId(modelId);
+  const copy =
+    (catalogId ? getModel(xai, catalogId, agent) : undefined)
+    ?? getModel(xai, modelId.replace(/\[1m\]$/i, ''), agent);
+  if (copy && !isModelSelectableForNewRoute(copy, { userProvider: false })) {
+    return { kind: 'reject' };
   }
-  if (providerId) return { kind: 'keep' };
-  return xai ? { kind: 'pin', providerId: 'xai' } : { kind: 'reject' };
+  if (providerId === 'xai') return { kind: 'keep' };
+  if (providerId && !shouldApplyExclusiveProviderReroute(providerId)) return { kind: 'keep' };
+  return { kind: 'pin', providerId: 'xai' };
 }
 
 /** SET_MODEL: undefined = 保持当前来源,不能当成显式 null 去改绑。 */

--- a/apps/desktop/src/main/maker-host/model-route-guard.ts
+++ b/apps/desktop/src/main/maker-host/model-route-guard.ts
@@ -32,6 +32,7 @@ import {
   effectiveSourceIdForModel,
   getModel,
   isAgentSelectableModel,
+  isExclusiveXaiModelId,
   isModelSelectableForNewRoute,
   nativeDefaultSourceId,
   providerOffersModel,
@@ -45,8 +46,76 @@ export type ModelRouteVerdict =
   | { kind: 'reroute'; providerId: string }
   | {
       kind: 'reject';
-      reason: 'model-disabled' | 'explicit-source-disabled' | 'capability-model' | 'model-retired';
+      reason:
+        | 'model-disabled'
+        | 'explicit-source-disabled'
+        | 'capability-model'
+        | 'model-retired'
+        | 'exclusive-source-unavailable';
     };
+
+export type ExclusiveProviderRoute =
+  | { kind: 'keep' }
+  | { kind: 'pin'; providerId: string }
+  | { kind: 'reject' };
+
+/**
+ * Grok / SuperGrok 独占模型的无痛绑定:
+ * 默认网关服务不了这些 id,providerId=null 时能连 xAI 就钉死,否则拒绝。
+ * Claude/GPT 双来源不在这里处理,继续 spawn-aware 默认。
+ */
+export function materializeExclusiveProviderRoute(
+  views: readonly ProviderView[],
+  agent: AgentKind,
+  modelId: string,
+  providerId: string | null,
+): ExclusiveProviderRoute {
+  if (!isExclusiveXaiModelId(modelId)) return { kind: 'keep' };
+  const xai = views.find(
+    (provider) =>
+      provider.id === 'xai'
+      && provider.connected
+      && provider.suspended !== true
+      && provider.agents.includes(agent),
+  );
+  if (providerId === 'xai') {
+    return xai ? { kind: 'keep' } : { kind: 'reject' };
+  }
+  if (providerId === 'xd') return { kind: 'reject' };
+  if (providerId) return { kind: 'keep' };
+  return xai ? { kind: 'pin', providerId: 'xai' } : { kind: 'reject' };
+}
+
+/** SET_MODEL: undefined = 保持当前来源,不能当成显式 null 去改绑。 */
+export function resolveSetModelGuardProviderId(
+  requestedProviderId: string | null | undefined,
+  currentProviderId: string | null,
+): string | null {
+  return requestedProviderId !== undefined ? requestedProviderId : currentProviderId;
+}
+
+/** 内存已 hydrate 用内存(含显式 null);尚未 hydrate 才回落 DB 持久值。 */
+export function resolveCurrentSetModelProviderId(
+  memoryHydrated: boolean,
+  memoryProviderId: string | null,
+  persistedProviderId: string | null,
+): string | null {
+  return memoryHydrated ? memoryProviderId : persistedProviderId;
+}
+
+/** SET_MODEL: 只有显式回到默认,或当前本来就没有来源时,才接受独占 pin。 */
+export function resolveExclusiveSetModelReroute(
+  requestedProviderId: string | null | undefined,
+  currentProviderId: string | null,
+  rerouteProviderId: string | undefined,
+  currentKnown = true,
+): string | null | undefined {
+  if (!rerouteProviderId) return requestedProviderId;
+  if (!currentKnown) return requestedProviderId;
+  if (requestedProviderId === null) return rerouteProviderId;
+  if (requestedProviderId === undefined && !currentProviderId) return rerouteProviderId;
+  return requestedProviderId;
+}
 
 export interface ModelRouteGuardOptions {
   /** Active Registry tombstones have no CatalogModel entity, so the live shell supplies this. */
@@ -247,12 +316,20 @@ export function resolveLenientRoute(
     return { model: resolvedModel, providerId: resolvedProviderId, degraded, effort };
   };
   let verdict = checkModelRoute(views, agent, model, providerId, opts);
-  if (verdict.kind === 'pass') return { model, providerId, degraded: false };
+  if (verdict.kind === 'pass') {
+    const exclusive = materializeExclusiveProviderRoute(views, agent, model, providerId);
+    if (exclusive.kind === 'pin') return withEffort(model, exclusive.providerId, false);
+    // reject: 独占 Grok 不能落到默认网关,落到下方改走可用对话模型。
+    if (exclusive.kind !== 'reject') return { model, providerId, degraded: false };
+  }
   if (verdict.kind === 'reroute') return withEffort(model, verdict.providerId, false);
   if (providerId) {
     verdict = checkModelRoute(views, agent, model, null, opts);
-    if (verdict.kind === 'pass') return withEffort(model, null, true);
-    if (verdict.kind === 'reroute') {
+    if (verdict.kind === 'pass') {
+      const exclusive = materializeExclusiveProviderRoute(views, agent, model, null);
+      if (exclusive.kind === 'pin') return withEffort(model, exclusive.providerId, true);
+      if (exclusive.kind !== 'reject') return withEffort(model, null, true);
+    } else if (verdict.kind === 'reroute') {
       return withEffort(model, verdict.providerId, true);
     }
   }

--- a/apps/desktop/src/main/maker-host/model-route-guard.ts
+++ b/apps/desktop/src/main/maker-host/model-route-guard.ts
@@ -116,15 +116,30 @@ export function resolveExclusiveSetModelReroute(
   if (!currentKnown) return requestedProviderId;
   if (requestedProviderId === null) return rerouteProviderId;
   if (
+    typeof requestedProviderId === 'string'
+    && shouldApplyExclusiveProviderReroute(requestedProviderId)
+  ) {
+    return rerouteProviderId;
+  }
+  if (
     requestedProviderId === undefined
-    && (!currentProviderId
-      || currentProviderId === 'xd'
-      || currentProviderId === 'anthropic'
-      || currentProviderId === 'openai')
+    && shouldApplyExclusiveProviderReroute(currentProviderId)
   ) {
     return rerouteProviderId;
   }
   return requestedProviderId;
+}
+
+/** 内置非 xAI 来源上的独占 Grok 应改绑 SuperGrok;自定义供应商除外。 */
+export function shouldApplyExclusiveProviderReroute(
+  providerId: string | null | undefined,
+): boolean {
+  return (
+    !providerId
+    || providerId === 'xd'
+    || providerId === 'anthropic'
+    || providerId === 'openai'
+  );
 }
 
 export interface ModelRouteGuardOptions {

--- a/apps/desktop/src/main/maker-host/model-route-guard.ts
+++ b/apps/desktop/src/main/maker-host/model-route-guard.ts
@@ -80,7 +80,7 @@ export function materializeExclusiveProviderRoute(
       && provider.agents.includes(agent),
   );
   if (!xai) {
-    return providerId && !shouldApplyExclusiveProviderReroute(providerId) && providerId !== 'xai'
+    return providerId && !shouldApplyExclusiveProviderReroute(providerId, views) && providerId !== 'xai'
       ? { kind: 'keep' }
       : { kind: 'reject' };
   }
@@ -92,7 +92,7 @@ export function materializeExclusiveProviderRoute(
     return { kind: 'reject' };
   }
   if (providerId === 'xai') return { kind: 'keep' };
-  if (providerId && !shouldApplyExclusiveProviderReroute(providerId)) return { kind: 'keep' };
+  if (providerId && !shouldApplyExclusiveProviderReroute(providerId, views)) return { kind: 'keep' };
   return { kind: 'pin', providerId: 'xai' };
 }
 
@@ -119,35 +119,38 @@ export function resolveExclusiveSetModelReroute(
   currentProviderId: string | null,
   rerouteProviderId: string | undefined,
   currentKnown = true,
+  views?: readonly Pick<ProviderView, 'id' | 'source'>[],
 ): string | null | undefined {
   if (!rerouteProviderId) return requestedProviderId;
   if (!currentKnown) return requestedProviderId;
   if (requestedProviderId === null) return rerouteProviderId;
   if (
     typeof requestedProviderId === 'string'
-    && shouldApplyExclusiveProviderReroute(requestedProviderId)
+    && shouldApplyExclusiveProviderReroute(requestedProviderId, views)
   ) {
     return rerouteProviderId;
   }
   if (
     requestedProviderId === undefined
-    && shouldApplyExclusiveProviderReroute(currentProviderId)
+    && shouldApplyExclusiveProviderReroute(currentProviderId, views)
   ) {
     return rerouteProviderId;
   }
   return requestedProviderId;
 }
 
-/** 内置非 xAI 来源上的独占 Grok 应改绑 SuperGrok;自定义供应商除外。 */
+/** 非用户自定义来源上的独占 Grok 应改绑 SuperGrok。按 catalog source 判定,不维护 ID 名单。 */
 export function shouldApplyExclusiveProviderReroute(
   providerId: string | null | undefined,
+  views?: readonly Pick<ProviderView, 'id' | 'source'>[],
 ): boolean {
-  return (
-    !providerId
-    || providerId === 'xd'
-    || providerId === 'anthropic'
-    || providerId === 'openai'
-  );
+  if (!providerId) return true;
+  if (providerId === 'xai') return false;
+  if (!views) return true;
+  const source = views.find((provider) => provider.id === providerId)?.source;
+  if (source === 'user') return false;
+  if (source) return true;
+  return false;
 }
 
 export interface ModelRouteGuardOptions {

--- a/apps/desktop/src/main/maker-host/model-route-guard.ts
+++ b/apps/desktop/src/main/maker-host/model-route-guard.ts
@@ -81,7 +81,9 @@ export function materializeExclusiveProviderRoute(
   if (providerId === 'xai') {
     return xai ? { kind: 'keep' } : { kind: 'reject' };
   }
-  if (providerId === 'xd') return { kind: 'reject' };
+  if (providerId === 'xd' || providerId === 'anthropic' || providerId === 'openai') {
+    return xai ? { kind: 'pin', providerId: 'xai' } : { kind: 'reject' };
+  }
   if (providerId) return { kind: 'keep' };
   return xai ? { kind: 'pin', providerId: 'xai' } : { kind: 'reject' };
 }
@@ -113,7 +115,15 @@ export function resolveExclusiveSetModelReroute(
   if (!rerouteProviderId) return requestedProviderId;
   if (!currentKnown) return requestedProviderId;
   if (requestedProviderId === null) return rerouteProviderId;
-  if (requestedProviderId === undefined && !currentProviderId) return rerouteProviderId;
+  if (
+    requestedProviderId === undefined
+    && (!currentProviderId
+      || currentProviderId === 'xd'
+      || currentProviderId === 'anthropic'
+      || currentProviderId === 'openai')
+  ) {
+    return rerouteProviderId;
+  }
   return requestedProviderId;
 }
 

--- a/apps/desktop/src/main/maker-host/provider-route.ts
+++ b/apps/desktop/src/main/maker-host/provider-route.ts
@@ -21,8 +21,10 @@
 
 import {
   actualSourceIdForModel,
+  isExclusiveXaiModelId,
   runtimeCustomProviderId,
   storedCustomProviderId,
+  XAI_MODEL_PREFIX,
   type AgentKind,
   type Provider,
   type ProviderView,
@@ -452,7 +454,11 @@ function routingServesWireModel(routing: RoutingDescriptor, wireModel: string | 
   if (routing.disabled) return false;
   if (!routing.modelPrefixes?.length) return true;
   if (!wireModel) return true;
-  return routing.modelPrefixes.some((prefix) => wireModel.startsWith(prefix));
+  return routing.modelPrefixes.some(
+    (prefix) =>
+      wireModel.startsWith(prefix)
+      || (prefix === XAI_MODEL_PREFIX && isExclusiveXaiModelId(wireModel)),
+  );
 }
 
 /**

--- a/apps/desktop/src/main/maker-host/runtime-configs.ts
+++ b/apps/desktop/src/main/maker-host/runtime-configs.ts
@@ -10,10 +10,8 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 import {
-  isExclusiveXaiModelId,
   isModelDisabled,
   isProviderDisabled,
-  XAI_MODEL_PREFIX,
 } from '@cindy/model-providers';
 
 import { effectiveXdGatewayBaseUrl } from '../model-access/effectiveEndpoint.js';
@@ -28,6 +26,7 @@ import skillSourcePrecedencePrompt from './skill-source-precedence-prompt.md?raw
 import { readCompactionPct } from './compaction-settings-store.js';
 import { readMemorySettings } from './memory-settings-store.js';
 import { readSubagentModelSettings } from './subagent-model-settings-store.js';
+import { shouldKeepSubagentOverrideForParent } from './subagent-override-route.js';
 import { toolchainThreadCapEnv } from './toolchain-thread-cap.js';
 
 // Claude / Codex 的 host system prompt：产品身份 → Skill 来源优先级 → agent 专属段。
@@ -251,22 +250,16 @@ function resolveSubagentModelForRoute(
       : implicitRouteId
         ? offering.find((p) => p.id === implicitRouteId)
         : undefined;
-    if (routeProvider) return copyDisabled(routeProvider.id) ? undefined : saved;
-    // 裸 Grok 不能跟着非 xAI 父会话注入。带 xai/ 前缀的订阅覆写由 proxy 按请求路由,
-    // 不能在这里丢掉。
-    if (
-      isExclusiveXaiModelId(saved)
-      && !saved.startsWith(XAI_MODEL_PREFIX)
-      && providerId !== 'xai'
-    ) {
-      return undefined;
-    }
-    // 显式父来源在目录里有该模型的其它拷贝,但本源不提供 → 不注入。
-    if (providerId && offering.length > 0) return undefined;
-    // 默认会话(providerId=null 且凭证形态未知)保持原保守口径:任一启用拷贝可用就保留覆写。
-    if (offering.length === 0) return saved;
-    const allDisabled = offering.every((p) => copyDisabled(p.id));
-    return allDisabled ? undefined : saved;
+    return shouldKeepSubagentOverrideForParent({
+      saved,
+      providerId,
+      parentOffersSaved: !!routeProvider,
+      parentCopyDisabled: routeProvider ? copyDisabled(routeProvider.id) : false,
+      anyOffering: offering.length > 0,
+      allOfferingsDisabled: offering.length > 0 && offering.every((p) => copyDisabled(p.id)),
+    })
+      ? saved
+      : undefined;
   }
   if (offering.length === 0) return saved;
   const allDisabled = offering.every((p) => copyDisabled(p.id));

--- a/apps/desktop/src/main/maker-host/runtime-configs.ts
+++ b/apps/desktop/src/main/maker-host/runtime-configs.ts
@@ -9,7 +9,11 @@ import { app } from 'electron';
 import fs from 'node:fs';
 import path from 'node:path';
 
-import { isModelDisabled, isProviderDisabled } from '@cindy/model-providers';
+import {
+  isExclusiveXaiModelId,
+  isModelDisabled,
+  isProviderDisabled,
+} from '@cindy/model-providers';
 
 import { effectiveXdGatewayBaseUrl } from '../model-access/effectiveEndpoint.js';
 import { getActiveCatalog } from './active-catalog.js';
@@ -232,7 +236,6 @@ function resolveSubagentModelForRoute(
   const offering = getActiveCatalog().providers.filter((p) =>
     (p.models['claude-code'] ?? []).some((m) => m.id === saved),
   );
-  if (offering.length === 0) return saved; // 目录不认识 → 不新增拒绝面
   const copyDisabled = (id: string) =>
     isProviderDisabled(overrides, id) || isModelDisabled(overrides, id, saved);
   if (providerId !== undefined) {
@@ -247,10 +250,17 @@ function resolveSubagentModelForRoute(
       : implicitRouteId
         ? offering.find((p) => p.id === implicitRouteId)
         : undefined;
-    // 显式/映射来源不提供该模型(跨来源 subagent 覆写)或凭证形态未知:实际落点
-    // 不明,落到下方保守判。
     if (routeProvider) return copyDisabled(routeProvider.id) ? undefined : saved;
+    // 独占 Grok 不能跟着默认/非 xAI 父会话注入裸 id。
+    if (isExclusiveXaiModelId(saved) && providerId !== 'xai') return undefined;
+    // 显式父来源在目录里有该模型的其它拷贝,但本源不提供 → 不注入。
+    if (providerId && offering.length > 0) return undefined;
+    // 默认会话(providerId=null 且凭证形态未知)保持原保守口径:任一启用拷贝可用就保留覆写。
+    if (offering.length === 0) return saved;
+    const allDisabled = offering.every((p) => copyDisabled(p.id));
+    return allDisabled ? undefined : saved;
   }
+  if (offering.length === 0) return saved;
   const allDisabled = offering.every((p) => copyDisabled(p.id));
   return allDisabled ? undefined : saved;
 }

--- a/apps/desktop/src/main/maker-host/runtime-configs.ts
+++ b/apps/desktop/src/main/maker-host/runtime-configs.ts
@@ -13,6 +13,7 @@ import {
   isExclusiveXaiModelId,
   isModelDisabled,
   isProviderDisabled,
+  XAI_MODEL_PREFIX,
 } from '@cindy/model-providers';
 
 import { effectiveXdGatewayBaseUrl } from '../model-access/effectiveEndpoint.js';
@@ -251,8 +252,15 @@ function resolveSubagentModelForRoute(
         ? offering.find((p) => p.id === implicitRouteId)
         : undefined;
     if (routeProvider) return copyDisabled(routeProvider.id) ? undefined : saved;
-    // 独占 Grok 不能跟着默认/非 xAI 父会话注入裸 id。
-    if (isExclusiveXaiModelId(saved) && providerId !== 'xai') return undefined;
+    // 裸 Grok 不能跟着非 xAI 父会话注入。带 xai/ 前缀的订阅覆写由 proxy 按请求路由,
+    // 不能在这里丢掉。
+    if (
+      isExclusiveXaiModelId(saved)
+      && !saved.startsWith(XAI_MODEL_PREFIX)
+      && providerId !== 'xai'
+    ) {
+      return undefined;
+    }
     // 显式父来源在目录里有该模型的其它拷贝,但本源不提供 → 不注入。
     if (providerId && offering.length > 0) return undefined;
     // 默认会话(providerId=null 且凭证形态未知)保持原保守口径:任一启用拷贝可用就保留覆写。

--- a/apps/desktop/src/main/maker-host/session-provider-store.ts
+++ b/apps/desktop/src/main/maker-host/session-provider-store.ts
@@ -35,6 +35,11 @@ export function getSessionProvider(sessionId: string): string | null {
   return bySession.get(sessionId) ?? null;
 }
 
+/** 内存里是否已有该会话的来源条目(含显式 null)。未 hydrate 时为 false。 */
+export function hasSessionProvider(sessionId: string): boolean {
+  return bySession.has(sessionId);
+}
+
 /**
  * 从持久化值回填(会话加载时调用)。仅在内存尚无该会话条目时写入,
  * 不覆盖运行中已有的更新值(避免 DB 旧值盖掉本次 turn 刚切的供应商)。

--- a/apps/desktop/src/main/maker-host/subagent-override-route.ts
+++ b/apps/desktop/src/main/maker-host/subagent-override-route.ts
@@ -1,0 +1,25 @@
+import {
+  isExclusiveXaiModelId,
+  isSubscriptionDirectModel,
+} from '@cindy/model-providers';
+
+/**
+ * 父会话来源已知时,保存的 Claude Code 子代理覆写是否注入。
+ * 订阅前缀(`xai/` / `chatgpt/`)由 proxy 按请求路由,与父来源无关;
+ * 裸独占 Grok 不能跟着非 xAI 父会话注入。
+ */
+export function shouldKeepSubagentOverrideForParent(input: {
+  saved: string;
+  providerId: string | null;
+  parentOffersSaved: boolean;
+  parentCopyDisabled: boolean;
+  anyOffering: boolean;
+  allOfferingsDisabled: boolean;
+}): boolean {
+  if (input.parentOffersSaved) return !input.parentCopyDisabled;
+  if (isSubscriptionDirectModel(input.saved)) return true;
+  if (isExclusiveXaiModelId(input.saved) && input.providerId !== 'xai') return false;
+  if (input.providerId && input.anyOffering) return false;
+  if (!input.anyOffering) return true;
+  return !input.allOfferingsDisabled;
+}

--- a/apps/desktop/src/main/maker-ipc/__tests__/runtimeSetModel.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/runtimeSetModel.test.ts
@@ -77,6 +77,30 @@ describe('applyRuntimeSetModelChange', () => {
     expect(getSessionProvider(sessionId)).toBe('xd');
   });
 
+  it('model-only 且未 hydrate 时不把 providerId:null 传进 runtime', async () => {
+    const sessionId = rememberSession('runtime-set-model-unhydrated-model-only');
+    const setModel = vi.fn(async () => {});
+    const maker: RuntimeSetModelMaker = {
+      getSession: () => ({
+        agentKind: 'claude-code',
+        remoteHostId: null,
+        model: 'grok-4.6',
+        setModel,
+      }),
+      listActiveSessions: () => [],
+      closeSession: vi.fn(async () => {}),
+    };
+
+    await applyRuntimeSetModelChange({
+      maker,
+      sessionId,
+      model: 'grok-4.6',
+    });
+
+    expect(setModel).toHaveBeenCalledWith('grok-4.6', {});
+    expect(getSessionProvider(sessionId)).toBeNull();
+  });
+
   it('forwards the atomic effort to live setModel for preflight validation', async () => {
     const sessionId = rememberSession('runtime-set-model-effort-preflight');
     setSessionProvider(sessionId, 'native-a');

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -6494,8 +6494,12 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
         if (reroute && shouldApplyExclusiveProviderReroute(o.providerId)) {
           o.providerId = reroute;
         }
-      } else if (!o.providerId) {
-        const pin = await pinExclusiveSessionProvider(o.agentKind, o.model, null);
+      } else if (shouldApplyExclusiveProviderReroute(o.providerId)) {
+        const pin = await pinExclusiveSessionProvider(
+          o.agentKind,
+          o.model,
+          o.providerId ?? null,
+        );
         if (pin) o.providerId = pin;
       }
     }

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -4898,6 +4898,7 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
               // 模型读取失败仍持久化 token/cache，模型显示为 unknown。
             }
             const pricingModel = normalizeModelIdForPricing(turnModel);
+            const isCustomProviderRoute = isUserProviderSession(session.id);
             const effectiveProvider =
               sessionProvider ??
               (pricingModel.startsWith(CHATGPT_MODEL_PREFIX)
@@ -4909,7 +4910,7 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
               effectiveProvider === 'openai' ||
               effectiveProvider === 'anthropic' ||
               effectiveProvider === 'xai' ||
-              isSubscriptionDirectRoute(pricingModel);
+              (!isCustomProviderRoute && isSubscriptionDirectRoute(pricingModel));
             const turnUsageDetails = buildTurnUsageDetails({
               ...tokens,
               model: turnModel,
@@ -4942,7 +4943,6 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
               // 自定义(source:'user')provider——本地 Ollama / 用户自付费兼容端点——即便
               // 模型 id 与 XD 目录重名,也不能套用 XD 网关定价当作 Cindy 消费入账;只记 token
               // (上方已入库),不写 money(codex review)。仅 xd / 默认网关与订阅路由计费。
-              const isCustomProviderRoute = isUserProviderSession(session.id);
               const pricing =
                 isSubscriptionValue || isCustomProviderRoute
                   ? null

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -764,6 +764,7 @@ import {
   resolveCurrentSetModelProviderId,
   resolveExclusiveSetModelReroute,
   resolveSetModelGuardProviderId,
+  shouldApplyExclusiveProviderReroute,
 } from '../maker-host/model-route-guard.js';
 import {
   pinExclusiveSessionProvider,
@@ -6490,7 +6491,9 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
       }
       if (!verifiedResume) {
         const reroute = await assertModelRouteUsable(o.agentKind, o.model, o.providerId ?? null);
-        if (reroute && !o.providerId) o.providerId = reroute;
+        if (reroute && shouldApplyExclusiveProviderReroute(o.providerId)) {
+          o.providerId = reroute;
+        }
       } else if (!o.providerId) {
         const pin = await pinExclusiveSessionProvider(o.agentKind, o.model, null);
         if (pin) o.providerId = pin;

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -493,7 +493,7 @@ import {
 import {
   CHATGPT_MODEL_PREFIX,
   XAI_MODEL_PREFIX,
-  isSubscriptionDirectModel,
+  isSubscriptionDirectRoute,
 } from '../../shared/subscriptionModels.js';
 import {
   addRegionalMoney,
@@ -697,6 +697,7 @@ import {
 import { readOrcaWorkerProviderRoutingContext } from './orcaProviderRoutingContext.js';
 import {
   getSessionProvider,
+  hasSessionProvider,
   hydrateSessionProvider,
   normalizeSessionProviderId,
   setSessionProvider,
@@ -760,6 +761,12 @@ import {
 } from '../maker-host/model-disable-store.js';
 import { readProviderOrder, setProviderOrder } from '../maker-host/provider-order-store.js';
 import {
+  resolveCurrentSetModelProviderId,
+  resolveExclusiveSetModelReroute,
+  resolveSetModelGuardProviderId,
+} from '../maker-host/model-route-guard.js';
+import {
+  pinExclusiveSessionProvider,
   resolveLenientSessionRoute,
   verdictForModelRoute,
 } from '../maker-host/model-route-guard-live.js';
@@ -4428,7 +4435,7 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
               const isClaudeSubscriptionValueRow =
                 isClaudeSubscriptionSession && !m.money && isAnthropicModel(m.model);
               const isBridgeSubscriptionRow =
-                m.source === 'subscription' && isSubscriptionDirectModel(m.model);
+                m.source === 'subscription' && isSubscriptionDirectRoute(m.model);
               if (isClaudeSubscriptionValueRow || isBridgeSubscriptionRow)
                 hasSubscriptionValueRow = true;
               modelUsageWrites.push(
@@ -4592,7 +4599,7 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
             // sessions.total_cost_usd(与主路径 resolveTurnCost 的 subscription gate 同口径,
             // 避免把订阅 SDK 自报 cost 误记进计费)。但显式 provider-api 是权威路由:
             // 自定义 API 供应商可能供应带订阅前缀的模型 id,不能按前缀把真实费用判掉。
-            if (route !== 'provider-api' && isSubscriptionDirectModel(resolvedModel)) {
+            if (route !== 'provider-api' && isSubscriptionDirectRoute(resolvedModel)) {
               await recordUsageOnly();
               return;
             }
@@ -4902,7 +4909,7 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
               effectiveProvider === 'openai' ||
               effectiveProvider === 'anthropic' ||
               effectiveProvider === 'xai' ||
-              isSubscriptionDirectModel(pricingModel);
+              isSubscriptionDirectRoute(pricingModel);
             const turnUsageDetails = buildTurnUsageDetails({
               ...tokens,
               model: turnModel,
@@ -4945,7 +4952,7 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
                 effectiveProvider === 'anthropic' ||
                 effectiveProvider === 'xai'
                   ? getModelPriceQuote(null, effectiveProvider, pricingModel)
-                  : isSubscriptionDirectModel(pricingModel)
+                  : isSubscriptionDirectRoute(pricingModel)
                     ? getSubscriptionDirectValuePrice(pricingModel)
                     : isCustomProviderRoute
                       ? null
@@ -6432,7 +6439,9 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
             ? `model "${model}" is not an agent chat model`
             : verdict.reason === 'model-retired'
               ? `model "${model}" has been retired from the catalog`
-              : `model "${model}" is disabled in settings`,
+              : verdict.reason === 'exclusive-source-unavailable'
+                ? `model "${model}" requires SuperGrok (xAI) and cannot use the default gateway`
+                : `model "${model}" is disabled in settings`,
       );
     }
     return verdict.kind === 'reroute' ? verdict.providerId : undefined;
@@ -6482,6 +6491,9 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
       if (!verifiedResume) {
         const reroute = await assertModelRouteUsable(o.agentKind, o.model, o.providerId ?? null);
         if (reroute && !o.providerId) o.providerId = reroute;
+      } else if (!o.providerId) {
+        const pin = await pinExclusiveSessionProvider(o.agentKind, o.model, null);
+        if (pin) o.providerId = pin;
       }
     }
     const session = await maker.createSession(o);
@@ -12814,16 +12826,55 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
         // 拦「切过去」;隐式来源的原生默认落点被停用而有启用替代拷贝时,以显式来源
         // 落地(与 bootstrapSession 同语义)。agentKind 读不到(会话行缺失等)时不拦。
         // DB 存的是 'cc' | 'codex'(messages.agent_kind 口径),目录侧是 AgentKind。
-        let effectiveProviderId = providerId;
+        const requestedProviderId = normalizeSessionProviderId(
+          typeof providerId === 'string' || providerId === null ? providerId : undefined,
+        );
+        let persistedProviderId: string | null = null;
+        let persistedProviderKnown = true;
+        if (requestedProviderId === undefined && !hasSessionProvider(sessionId)) {
+          try {
+            const db = getDbClient().drizzle;
+            const [row] = await db
+              .select({ providerId: sessions.providerId })
+              .from(sessions)
+              .where(eq(sessions.id, sessionId))
+              .limit(1);
+            persistedProviderId = row?.providerId?.trim() || null;
+            hydrateSessionProvider(sessionId, persistedProviderId);
+          } catch (err) {
+            persistedProviderKnown = false;
+            log.debug('set-model persisted provider lookup failed (non-fatal)', {
+              sessionId,
+              error: err instanceof Error ? err.message : String(err),
+            });
+          }
+        }
+        const currentProviderId = resolveCurrentSetModelProviderId(
+          hasSessionProvider(sessionId),
+          getSessionProvider(sessionId),
+          persistedProviderId,
+        );
+        const guardProviderId = resolveSetModelGuardProviderId(
+          requestedProviderId,
+          currentProviderId,
+        );
+        let effectiveProviderId = requestedProviderId;
         {
           const dbAgentKind = getSessionDbAgentKind(sessionId);
           if (dbAgentKind) {
-            const reroute = await assertModelRouteUsable(
-              dbToMakerAgentKind(dbAgentKind),
-              model,
-              typeof providerId === 'string' ? providerId : null,
+            const reroute = persistedProviderKnown
+              ? await assertModelRouteUsable(
+                  dbToMakerAgentKind(dbAgentKind),
+                  model,
+                  guardProviderId,
+                )
+              : undefined;
+            effectiveProviderId = resolveExclusiveSetModelReroute(
+              requestedProviderId,
+              currentProviderId,
+              reroute,
+              persistedProviderKnown,
             );
-            if (reroute && typeof providerId !== 'string') effectiveProviderId = reroute;
           }
         }
         try {

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -4948,14 +4948,14 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
                   ? null
                   : await getGatewayModelPricingForModel();
               const price =
-                effectiveProvider === 'openai' ||
-                effectiveProvider === 'anthropic' ||
-                effectiveProvider === 'xai'
-                  ? getModelPriceQuote(null, effectiveProvider, pricingModel)
-                  : isSubscriptionDirectRoute(pricingModel)
-                    ? getSubscriptionDirectValuePrice(pricingModel)
-                    : isCustomProviderRoute
-                      ? null
+                isCustomProviderRoute
+                  ? null
+                  : effectiveProvider === 'openai' ||
+                      effectiveProvider === 'anthropic' ||
+                      effectiveProvider === 'xai'
+                    ? getModelPriceQuote(null, effectiveProvider, pricingModel)
+                    : isSubscriptionDirectRoute(pricingModel)
+                      ? getSubscriptionDirectValuePrice(pricingModel)
                       : getModelPriceQuote(pricing, 'xd', pricingModel);
               const money = computePriceQuoteTurnMoney(
                 tokens,

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -765,11 +765,11 @@ import {
   resolveCurrentSetModelProviderId,
   resolveExclusiveSetModelReroute,
   resolveSetModelGuardProviderId,
-  shouldApplyExclusiveProviderReroute,
 } from '../maker-host/model-route-guard.js';
 import {
   pinExclusiveSessionProvider,
   resolveLenientSessionRoute,
+  shouldApplyExclusiveProviderRerouteLive,
   verdictForModelRoute,
 } from '../maker-host/model-route-guard-live.js';
 import { setClaudeProxySessionIdResolver } from '../maker-host/anthropic-compat-proxy-host.js';
@@ -6492,10 +6492,10 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
       }
       if (!verifiedResume) {
         const reroute = await assertModelRouteUsable(o.agentKind, o.model, o.providerId ?? null);
-        if (reroute && shouldApplyExclusiveProviderReroute(o.providerId)) {
+        if (reroute && shouldApplyExclusiveProviderRerouteLive(o.providerId)) {
           o.providerId = reroute;
         }
-      } else if (shouldApplyExclusiveProviderReroute(o.providerId)) {
+      } else if (shouldApplyExclusiveProviderRerouteLive(o.providerId)) {
         const pin = await pinExclusiveSessionProvider(
           o.agentKind,
           o.model,
@@ -12882,6 +12882,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
               currentProviderId,
               reroute,
               persistedProviderKnown,
+              getActiveCatalog().providers,
             );
           }
         }

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -493,6 +493,7 @@ import {
 import {
   CHATGPT_MODEL_PREFIX,
   XAI_MODEL_PREFIX,
+  isExclusiveXaiModelId,
   isSubscriptionDirectRoute,
 } from '../../shared/subscriptionModels.js';
 import {
@@ -4632,7 +4633,7 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
         void modelPromise
           .then((m) => {
             if (m && m.startsWith(CHATGPT_MODEL_PREFIX)) triggerCodexAccountUsageRefresh();
-            if (m && m.startsWith(XAI_MODEL_PREFIX)) triggerXaiSubscriptionUsageRefresh();
+            if (m && isExclusiveXaiModelId(m)) triggerXaiSubscriptionUsageRefresh();
           })
           .catch(() => {
             /* 模型解析失败: 跳过, 非致命 */
@@ -4694,7 +4695,7 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
               pricingModel.startsWith('codex/');
             const isCodexXaiProviderRoute =
               (sessionProvider == null || sessionProvider === 'xai') &&
-              pricingModel.startsWith(XAI_MODEL_PREFIX);
+              isExclusiveXaiModelId(pricingModel);
             const isCodexOpenAiProviderRoute =
               sessionProvider == null || sessionProvider === 'openai';
             const hasGatewayKey = Boolean(readClaudeApiKey());
@@ -4844,14 +4845,14 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
         void modelPromise
           .then((model) => {
             const hasGatewayKey = Boolean(readClaudeApiKey());
-            if (!isRemoteCodexSession && model.startsWith(XAI_MODEL_PREFIX)) {
+            if (!isRemoteCodexSession && isExclusiveXaiModelId(model)) {
               triggerXaiSubscriptionUsageRefresh();
               return;
             }
             if (
               !isRemoteCodexSession &&
               !isCustomProviderRoute &&
-              !model.startsWith(XAI_MODEL_PREFIX) &&
+              !isExclusiveXaiModelId(model) &&
               (codexAuthInjection === 'env-key' ||
                 model.startsWith('codex/') ||
                 (sessionProvider === 'xd' && hasGatewayKey))

--- a/apps/desktop/src/main/maker-ipc/runtimeSetModel.ts
+++ b/apps/desktop/src/main/maker-ipc/runtimeSetModel.ts
@@ -2,6 +2,7 @@ import type { AgentKind, Effort } from '@cindy/maker-core';
 
 import {
   getSessionProvider,
+  hasSessionProvider,
   normalizeSessionProviderId,
   setSessionProvider,
 } from '../maker-host/session-provider-store.js';
@@ -271,7 +272,13 @@ export async function applyRuntimeSetModelChange(
   }
   try {
     await sess.setModel(model, {
-      providerId: nextProviderId,
+      // model-only 且内存尚未确认来源时不要把 providerId:null 传进 runtime,
+      // 否则未 hydrate 的 custom 会话会被清成默认网关。
+      ...(normalizedProviderId !== undefined
+        || hasSessionProvider(sessionId)
+        || pendingTarget !== undefined
+        ? { providerId: nextProviderId }
+        : {}),
       ...(effort !== undefined ? { effort } : {}),
     });
   } catch (err) {

--- a/apps/desktop/src/main/maker-ipc/sessionAgentSwitchHandler.ts
+++ b/apps/desktop/src/main/maker-ipc/sessionAgentSwitchHandler.ts
@@ -36,7 +36,7 @@ import {
   type HandoffSourceMessage,
 } from './agentHandoff.js';
 import { throwIpcError } from '../utils/ipcValidate.js';
-import { shouldApplyExclusiveProviderReroute } from '../maker-host/model-route-guard.js';
+import { shouldApplyExclusiveProviderRerouteLive } from '../maker-host/model-route-guard-live.js';
 import { dbToMakerAgentKind, makerToDbAgentKind, normalizeDbAgentKind } from '../../shared/agentKindConversion.js';
 
 function throwIfAgentSwitchAborted(signal: AbortSignal | undefined): void {
@@ -383,7 +383,7 @@ export async function performSessionAgentSwitch(
       model,
       typeof normalizedProviderId === 'string' ? normalizedProviderId : null,
     );
-    if (reroute && shouldApplyExclusiveProviderReroute(normalizedProviderId)) {
+    if (reroute && shouldApplyExclusiveProviderRerouteLive(normalizedProviderId)) {
       normalizedProviderId = reroute;
     }
   }

--- a/apps/desktop/src/main/maker-ipc/sessionAgentSwitchHandler.ts
+++ b/apps/desktop/src/main/maker-ipc/sessionAgentSwitchHandler.ts
@@ -36,6 +36,7 @@ import {
   type HandoffSourceMessage,
 } from './agentHandoff.js';
 import { throwIpcError } from '../utils/ipcValidate.js';
+import { shouldApplyExclusiveProviderReroute } from '../maker-host/model-route-guard.js';
 import { dbToMakerAgentKind, makerToDbAgentKind, normalizeDbAgentKind } from '../../shared/agentKindConversion.js';
 
 function throwIfAgentSwitchAborted(signal: AbortSignal | undefined): void {
@@ -382,7 +383,9 @@ export async function performSessionAgentSwitch(
       model,
       typeof normalizedProviderId === 'string' ? normalizedProviderId : null,
     );
-    if (reroute && typeof normalizedProviderId !== 'string') normalizedProviderId = reroute;
+    if (reroute && shouldApplyExclusiveProviderReroute(normalizedProviderId)) {
+      normalizedProviderId = reroute;
+    }
   }
 
   const row = await deps.getSessionRow(sessionId);

--- a/apps/desktop/src/main/scheduler-host/runner.ts
+++ b/apps/desktop/src/main/scheduler-host/runner.ts
@@ -42,7 +42,7 @@ import type {
   TurnContinuationState,
 } from '@cindy/maker-core';
 import { clampEffortToSupported } from '@cindy/model-providers';
-import { shouldApplyExclusiveProviderReroute } from '../maker-host/model-route-guard.js';
+import { shouldApplyExclusiveProviderRerouteLive } from '../maker-host/model-route-guard-live.js';
 import { SCHEDULER_RUN_ID_VENDOR_OPTION } from '@cindy/maker-scheduler';
 import type {
   Schedule,
@@ -850,7 +850,7 @@ export class MakerScheduleRunner implements ScheduleRunner {
           `schedule route unavailable: model "${model}" is disabled in settings (${verdict.reason})`,
         );
       }
-      if (verdict.kind === 'reroute' && shouldApplyExclusiveProviderReroute(createProviderId)) {
+      if (verdict.kind === 'reroute' && shouldApplyExclusiveProviderRerouteLive(createProviderId)) {
         createProviderId = verdict.providerId;
         reroutedProviderId = verdict.providerId;
       }
@@ -1308,7 +1308,7 @@ export class MakerScheduleRunner implements ScheduleRunner {
             `schedule route unavailable: model "${runtimeModel}" is disabled in settings (${verdict.reason}, revalidated before dispatch)`,
           );
         }
-        if (verdict.kind === 'reroute' && shouldApplyExclusiveProviderReroute(dispatchProviderId)) {
+        if (verdict.kind === 'reroute' && shouldApplyExclusiveProviderRerouteLive(dispatchProviderId)) {
           // 晚到的隐式改道(createSession 之后目录才变)跨凭证形态时不能只热换
           // provider store:进程是旧凭证形态 spawn 的,热换后这次 send 仍用旧凭证
           // 下单或直接鉴权失败。需要关会话重建的组合按明确错误失败收口 —— 下一轮
@@ -2079,7 +2079,7 @@ export class MakerScheduleRunner implements ScheduleRunner {
           `schedule route unavailable: model "${targetModel}" is disabled in settings (${verdict.reason})`,
         );
       }
-      if (verdict.kind === 'reroute' && shouldApplyExclusiveProviderReroute(routeProviderId)) {
+      if (verdict.kind === 'reroute' && shouldApplyExclusiveProviderRerouteLive(routeProviderId)) {
         applyProviderId = verdict.providerId;
       }
     }

--- a/apps/desktop/src/main/scheduler-host/runner.ts
+++ b/apps/desktop/src/main/scheduler-host/runner.ts
@@ -42,6 +42,7 @@ import type {
   TurnContinuationState,
 } from '@cindy/maker-core';
 import { clampEffortToSupported } from '@cindy/model-providers';
+import { shouldApplyExclusiveProviderReroute } from '../maker-host/model-route-guard.js';
 import { SCHEDULER_RUN_ID_VENDOR_OPTION } from '@cindy/maker-scheduler';
 import type {
   Schedule,
@@ -849,7 +850,7 @@ export class MakerScheduleRunner implements ScheduleRunner {
           `schedule route unavailable: model "${model}" is disabled in settings (${verdict.reason})`,
         );
       }
-      if (verdict.kind === 'reroute' && !createProviderId) {
+      if (verdict.kind === 'reroute' && shouldApplyExclusiveProviderReroute(createProviderId)) {
         createProviderId = verdict.providerId;
         reroutedProviderId = verdict.providerId;
       }
@@ -1307,7 +1308,7 @@ export class MakerScheduleRunner implements ScheduleRunner {
             `schedule route unavailable: model "${runtimeModel}" is disabled in settings (${verdict.reason}, revalidated before dispatch)`,
           );
         }
-        if (verdict.kind === 'reroute' && !dispatchProviderId) {
+        if (verdict.kind === 'reroute' && shouldApplyExclusiveProviderReroute(dispatchProviderId)) {
           // 晚到的隐式改道(createSession 之后目录才变)跨凭证形态时不能只热换
           // provider store:进程是旧凭证形态 spawn 的,热换后这次 send 仍用旧凭证
           // 下单或直接鉴权失败。需要关会话重建的组合按明确错误失败收口 —— 下一轮
@@ -2078,7 +2079,7 @@ export class MakerScheduleRunner implements ScheduleRunner {
           `schedule route unavailable: model "${targetModel}" is disabled in settings (${verdict.reason})`,
         );
       }
-      if (verdict.kind === 'reroute' && !routeProviderId) {
+      if (verdict.kind === 'reroute' && shouldApplyExclusiveProviderReroute(routeProviderId)) {
         applyProviderId = verdict.providerId;
       }
     }

--- a/apps/desktop/src/main/usage/turnCostCalculator.ts
+++ b/apps/desktop/src/main/usage/turnCostCalculator.ts
@@ -20,7 +20,7 @@ import {
   type RegionalMoney,
 } from '../../shared/regionalMoney.js';
 import { buildTurnUsageDetails, type TurnUsageDetails } from '../../shared/turnUsageDetails.js';
-import { isSubscriptionDirectModel } from '../../shared/subscriptionModels.js';
+import { isSubscriptionDirectRoute } from '../../shared/subscriptionModels.js';
 import { currentLedgerCurrency } from './ledgerCurrency.js';
 import type { ModelUsageDeltaEntry } from './modelUsageDelta.js';
 
@@ -195,7 +195,7 @@ export function resolveTurnCost(args: {
   // explicitly selected provider API (for example a bridge sub-agent inside an XD session).
   if (
     context.billingRoute === 'subscription' ||
-    (context.billingRoute !== 'provider-api' && isSubscriptionDirectModel(model))
+    (context.billingRoute !== 'provider-api' && isSubscriptionDirectRoute(model))
   ) {
     return { model, money: null, source: 'subscription' };
   }

--- a/apps/desktop/src/shared/modelPriceQuote.ts
+++ b/apps/desktop/src/shared/modelPriceQuote.ts
@@ -10,7 +10,11 @@ import {
   type ModelPricingCatalog,
   type MoneyCurrency,
 } from './regionalMoney.js';
-import { CHATGPT_MODEL_PREFIX, XAI_MODEL_PREFIX } from './subscriptionModels.js';
+import {
+  CHATGPT_MODEL_PREFIX,
+  exclusiveXaiCatalogModelId,
+  XAI_MODEL_PREFIX,
+} from './subscriptionModels.js';
 
 function isNonNegativeFinite(value: unknown): value is number {
   return typeof value === 'number' && Number.isFinite(value) && value >= 0;
@@ -339,11 +343,12 @@ export function subscriptionDirectPriceQuote(
   agent?: AgentKind,
   at?: string | Date,
 ): ModelPriceQuote | undefined {
+  const routedId = exclusiveXaiCatalogModelId(modelId) ?? modelId;
   let quote: ModelPriceQuote | undefined;
-  if (modelId.startsWith(CHATGPT_MODEL_PREFIX)) {
-    quote = providerReferencePriceQuote('openai', modelId, registry, { agent, at });
-  } else if (modelId.startsWith(XAI_MODEL_PREFIX)) {
-    quote = providerReferencePriceQuote('xai', modelId, registry, { agent, at });
+  if (routedId.startsWith(CHATGPT_MODEL_PREFIX)) {
+    quote = providerReferencePriceQuote('openai', routedId, registry, { agent, at });
+  } else if (routedId.startsWith(XAI_MODEL_PREFIX)) {
+    quote = providerReferencePriceQuote('xai', routedId, registry, { agent, at });
   }
   return quote
     ? {

--- a/apps/desktop/src/shared/subscriptionModels.ts
+++ b/apps/desktop/src/shared/subscriptionModels.ts
@@ -27,6 +27,7 @@ export function isSubscriptionDirectModel(model: string | null | undefined): boo
 }
 
 export {
+  exclusiveXaiCatalogModelId,
   isExclusiveXaiModelId,
   isSubscriptionDirectRoute,
 } from '@cindy/model-providers';

--- a/apps/desktop/src/shared/subscriptionModels.ts
+++ b/apps/desktop/src/shared/subscriptionModels.ts
@@ -25,3 +25,8 @@ export function isSubscriptionDirectModel(model: string | null | undefined): boo
   if (!model) return false;
   return SUBSCRIPTION_DIRECT_MODEL_PREFIXES.some((prefix) => model.startsWith(prefix));
 }
+
+export {
+  isExclusiveXaiModelId,
+  isSubscriptionDirectRoute,
+} from '@cindy/model-providers';

--- a/packages/model-providers/src/__tests__/classification.test.ts
+++ b/packages/model-providers/src/__tests__/classification.test.ts
@@ -21,7 +21,9 @@ import {
   isBudgetModel,
   isChatEligible,
   isModelSelectableForNewRoute,
+  isExclusiveXaiModelId,
   isSubscriptionDirectModel,
+  isSubscriptionDirectRoute,
   modelBadges,
   type ModelCategory,
 } from '../classification.js';
@@ -480,6 +482,28 @@ describe('isSubscriptionDirectModel(下沉自 shared/subscriptionModels,签名�
   });
   it('前缀清单恒为 chatgpt/ + xai/(路由/记账/排除三方共用,改动即破坏)', () => {
     expect(SUBSCRIPTION_DIRECT_MODEL_PREFIXES).toEqual(['chatgpt/', 'xai/']);
+  });
+});
+
+describe('isExclusiveXaiModelId / isSubscriptionDirectRoute', () => {
+  it('认 xai/ 前缀与裸 grok id,不认网关 x-ai/ 或其它厂商', () => {
+    expect(isExclusiveXaiModelId('xai/grok-4.6')).toBe(true);
+    expect(isExclusiveXaiModelId('grok-4.6')).toBe(true);
+    expect(isExclusiveXaiModelId('grok-4.6[1m]')).toBe(true);
+    expect(isExclusiveXaiModelId('grok-build-0.1')).toBe(true);
+    expect(isExclusiveXaiModelId('x-ai/grok-4.6')).toBe(false);
+    expect(isExclusiveXaiModelId('xai/not-grok')).toBe(false);
+    expect(isExclusiveXaiModelId('claude-opus-5')).toBe(false);
+    expect(isExclusiveXaiModelId('chatgpt/gpt-5.5')).toBe(false);
+    expect(isExclusiveXaiModelId(null)).toBe(false);
+  });
+
+  it('isSubscriptionDirectRoute 覆盖前缀与独占裸 id', () => {
+    expect(isSubscriptionDirectRoute('xai/grok-4.6')).toBe(true);
+    expect(isSubscriptionDirectRoute('grok-4.6')).toBe(true);
+    expect(isSubscriptionDirectRoute('chatgpt/gpt-5.5')).toBe(true);
+    expect(isSubscriptionDirectRoute('x-ai/grok-4.6')).toBe(false);
+    expect(isSubscriptionDirectRoute('claude-opus-5')).toBe(false);
   });
 });
 

--- a/packages/model-providers/src/__tests__/classification.test.ts
+++ b/packages/model-providers/src/__tests__/classification.test.ts
@@ -21,6 +21,7 @@ import {
   isBudgetModel,
   isChatEligible,
   isModelSelectableForNewRoute,
+  exclusiveXaiCatalogModelId,
   isExclusiveXaiModelId,
   isSubscriptionDirectModel,
   isSubscriptionDirectRoute,
@@ -504,6 +505,13 @@ describe('isExclusiveXaiModelId / isSubscriptionDirectRoute', () => {
     expect(isSubscriptionDirectRoute('chatgpt/gpt-5.5')).toBe(true);
     expect(isSubscriptionDirectRoute('x-ai/grok-4.6')).toBe(false);
     expect(isSubscriptionDirectRoute('claude-opus-5')).toBe(false);
+  });
+
+  it('exclusiveXaiCatalogModelId 把裸 grok 归一成 xai/ 目录 id', () => {
+    expect(exclusiveXaiCatalogModelId('grok-4.6')).toBe('xai/grok-4.6');
+    expect(exclusiveXaiCatalogModelId('xai/grok-4.6')).toBe('xai/grok-4.6');
+    expect(exclusiveXaiCatalogModelId('x-ai/grok-4.6')).toBeNull();
+    expect(exclusiveXaiCatalogModelId('claude-opus-5')).toBeNull();
   });
 });
 

--- a/packages/model-providers/src/classification.ts
+++ b/packages/model-providers/src/classification.ts
@@ -35,6 +35,29 @@ export function isSubscriptionDirectModel(model: string | null | undefined): boo
   return SUBSCRIPTION_DIRECT_MODEL_PREFIXES.some((prefix) => model.startsWith(prefix));
 }
 
+/**
+ * xAI / SuperGrok 的独占户口:只能走 SuperGrok,不能 fail-open 进 Cindy LiteLLM。
+ *
+ * - `xai/grok-*` 已是订阅前缀
+ * - 裸 `grok-*` 是官方 / Pi 目录 id
+ * - `x-ai/grok-*` 是网关/OpenRouter 命名空间,Cindy 网关可能认,不算独占
+ */
+export function isExclusiveXaiModelId(model: string | null | undefined): boolean {
+  if (!model) return false;
+  const id = model.trim().replace(/\[1m\]$/i, '');
+  if (!id) return false;
+  if (id.startsWith(XAI_MODEL_PREFIX)) {
+    return id.slice(XAI_MODEL_PREFIX.length).startsWith('grok');
+  }
+  if (id.includes('/')) return false;
+  return id.startsWith('grok');
+}
+
+/** 订阅前缀 ∪ xAI 独占裸 id。compat-proxy 与记账必须共用,避免路由当订阅、账单当网关。 */
+export function isSubscriptionDirectRoute(model: string | null | undefined): boolean {
+  return isSubscriptionDirectModel(model) || isExclusiveXaiModelId(model);
+}
+
 // 仅用于分组展示, 不参与持久化或 onModelChange 数据流。
 // 对话厂商组(anthropic..ungrouped)在前;非对话类型组(image/tts/stt/realtime/video/embedding/
 // compression/other)在后——后者收纳网关多出的图像/语音/视频/向量/压缩等模型(它们默认关、

--- a/packages/model-providers/src/classification.ts
+++ b/packages/model-providers/src/classification.ts
@@ -58,6 +58,13 @@ export function isSubscriptionDirectRoute(model: string | null | undefined): boo
   return isSubscriptionDirectModel(model) || isExclusiveXaiModelId(model);
 }
 
+/** 独占 Grok 的目录/报价身份:裸 grok-4.6 → xai/grok-4.6。非独占返回 null。 */
+export function exclusiveXaiCatalogModelId(model: string | null | undefined): string | null {
+  if (!isExclusiveXaiModelId(model) || !model) return null;
+  const id = model.trim().replace(/\[1m\]$/i, '');
+  return id.startsWith(XAI_MODEL_PREFIX) ? id : `${XAI_MODEL_PREFIX}${id}`;
+}
+
 // 仅用于分组展示, 不参与持久化或 onModelChange 数据流。
 // 对话厂商组(anthropic..ungrouped)在前;非对话类型组(image/tts/stt/realtime/video/embedding/
 // compression/other)在后——后者收纳网关多出的图像/语音/视频/向量/压缩等模型(它们默认关、

--- a/packages/model-providers/src/index.ts
+++ b/packages/model-providers/src/index.ts
@@ -159,6 +159,8 @@ export {
   XAI_MODEL_PREFIX,
   SUBSCRIPTION_DIRECT_MODEL_PREFIXES,
   isSubscriptionDirectModel,
+  isExclusiveXaiModelId,
+  isSubscriptionDirectRoute,
   CATEGORY_ORDER,
   CHAT_VENDOR_CATEGORY_ORDER,
   categorize,

--- a/packages/model-providers/src/index.ts
+++ b/packages/model-providers/src/index.ts
@@ -160,6 +160,7 @@ export {
   SUBSCRIPTION_DIRECT_MODEL_PREFIXES,
   isSubscriptionDirectModel,
   isExclusiveXaiModelId,
+  exclusiveXaiCatalogModelId,
   isSubscriptionDirectRoute,
   CATEGORY_ORDER,
   CHAT_VENDOR_CATEGORY_ORDER,


### PR DESCRIPTION
## 这次改了什么

### 摘要

裸 `grok-4.6` 被送到 Cindy LiteLLM 的 Anthropic Messages 前门，网关按字面名单查找后返回 `Invalid model name`。根因是 xAI 柜台只认 `xai/` 前缀，来源不明时 fail-open 进默认网关。

本 PR 让 SuperGrok 独占模型在付费请求出站前必须落到可证明的来源：能连 xAI 就静默绑定；自定义 LiteLLM 保持原上游；Claude / GPT 默认队列不打断、不弹窗。代理最后一层若仍看到独占 Grok 要进默认网关，直接 400，不再让 LiteLLM 报莫名其妙的模型名错误。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：裸 `grok-4.6` 经 `anthropic_messages` 打到 LiteLLM 的 400
- 本 PR 包含：
  - 独占 SuperGrok 判定（裸 `grok*` / `xai/grok*`）
  - 新建 / 恢复 / 切模型 / 代理 / IM 回滚 / Subagent 注入的 fail-closed 与静默绑定
  - 旧 model-only SET_MODEL 保持当前来源（含未 hydrate 时读 DB）
  - 记账把裸 Grok 当作订阅直连，避免记成网关费
- 明确不包含：
  - Hook / Slack / Orca 工具协议补 provider
  - `sessions.provider_id` 改 NOT NULL
  - Subagent 真正跨供应商路由
- 用户可见变化：选 Grok 4.6 时不再出现 LiteLLM `Invalid model name`；未登录 SuperGrok 会明确提示需要 xAI，而不是网关 400。自定义供应商上的同名模型行为不变。
- 是否存在 breaking change：无

### UI 变化

不涉及：未改任何渲染层、布局、样式、动效或用户可见文案。错误由既有 IPC / 代理错误通道返回。

- 引用的设计规范：不涉及：仅路由守卫、代理决策、记账与回滚，无视觉 / 交互 / 文案变化。

## 怎么验证的

### 自动验证

```text
pnpm --filter @cindy/model-providers test src/__tests__/classification.test.ts
结果：92 passed

pnpm --filter desktop exec vitest run \
  src/main/maker-host/__tests__/model-route-guard.test.ts \
  src/main/maker-host/__tests__/model-route-guard-live.test.ts \
  src/main/maker-host/__tests__/claudeProxyScopeGate.test.ts \
  src/main/maker-ipc/__tests__/runtimeSetModel.test.ts \
  src/main/maker-ipc/__tests__/setModelWireArgs.test.ts \
  src/main/im/shared/__tests__/cardActionTakeoverReplace.test.ts \
  src/main/usage/__tests__/turnCostCalculator.test.ts \
  src/main/__tests__/makerEventHotPathOrdering.test.ts
结果：全部通过

pnpm --filter desktop run typecheck
结果：通过

pnpm check:dco
结果：通过

bash run-unit-gate.sh
结果：desktop 另有 ghostInstallReceipt.test.ts 2 例失败；已在干净 origin/main 复现，与本 diff 无关，交给 CI 兜底
```

### 手工验证

不涉及真机发消息。路由与守卫由单测覆盖：裸 Grok 不进默认网关、自定义供应商不被劫持、旧 SET_MODEL 不改绑、#886 claude-haiku 仍回默认网关。

### 未执行的验证

未用真实 SuperGrok / 自定义 LiteLLM 账号跑完整对话回合；未验证远端 SSH。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：模型路由与计费归类

### 影响与回滚

- 影响范围：Desktop 会话创建 / 切模型 / Anthropic 兼容代理 / IM 回滚 / Claude Subagent 注入 / 订阅记账归类。不改 schema、协议或 mobile fingerprint。
- 回滚 / 降级方式：revert 本 PR。
- 存量插件影响：无

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
