### PR TITLE
fix(mobile): 对齐桌面端已工作时间口径

### DIFF
--- a/apps/mobile/src/__tests__/messageRenderModel.test.ts
+++ b/apps/mobile/src/__tests__/messageRenderModel.test.ts
@@ -227,7 +227,7 @@ describe('messageRenderModel', () => {
     expect(todo.todos).toEqual([{ content: 'Implement', status: 'completed', activeForm: undefined }]);
   });
 
-  it('counts restored thinking duration in completed work groups', () => {
+  it('anchors completed work duration to the user message like desktop', () => {
     const items = buildMobileMessageRenderItems([
       message({ id: 'user', role: 'user', content: 'start', createdAt: at(1) }),
       message({
@@ -241,7 +241,7 @@ describe('messageRenderModel', () => {
 
     expect(items.map((item) => item.type)).toEqual(['message', 'work_group', 'message']);
     const group = expectType(items[1], 'work_group');
-    expect(group.durationMs).toBe(23_000);
+    expect(group.durationMs).toBe(24_000);
   });
 
   it('keeps unfinished trailing work visible when no final assistant answer exists yet', () => {

--- a/packages/maker-shared/src/__tests__/messageRenderDurationAnchor.test.ts
+++ b/packages/maker-shared/src/__tests__/messageRenderDurationAnchor.test.ts
@@ -1,0 +1,141 @@
+/**
+ * 回归：共享工作组时长必须与桌面 MessageStream 使用同一条“上一边界”口径。
+ *
+ * 一次性到达的 thinking 可能只带到达窗口内的极短 duration；若从 thinking 自身时间起表，
+ * 会把用户消息到首个活动之间的真实模型等待／思考整段丢掉。Mobile 直接消费这份共享模型，
+ * 因此完成态 durationMs 与流式 startedAtMs 都必须优先锚用户消息或上一句 assistant 正文。
+ */
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildMessageRenderItems,
+  type MessageRenderItem,
+  type MessageRenderNormalizedMessage,
+  type MessageRenderSourceMessageLike,
+} from '../messageRender.js';
+
+type FixtureSource = MessageRenderSourceMessageLike & {
+  id: string;
+  clientId: string;
+  content: unknown;
+  createdAt: string;
+};
+
+type FixtureMessage = MessageRenderNormalizedMessage<FixtureSource>;
+type WorkGroup = Extract<MessageRenderItem<FixtureMessage>, { type: 'work_group' }>;
+
+const BASE_MS = Date.parse('2026-07-01T00:00:00.000Z');
+const at = (offsetMs: number): string => new Date(BASE_MS + offsetMs).toISOString();
+
+function message(
+  kind: FixtureMessage['kind'],
+  id: string,
+  offsetMs: number,
+  options: {
+    body?: string;
+    content?: unknown;
+    settledAtMs?: number;
+    turnCompleted?: boolean;
+  } = {},
+): FixtureMessage {
+  const source: FixtureSource = {
+    id,
+    clientId: id,
+    content: options.content ?? options.body ?? '',
+    createdAt: at(offsetMs),
+  };
+  return {
+    key: id,
+    source,
+    kind,
+    label: kind,
+    body: options.body ?? '',
+    createdAt: source.createdAt,
+    ...(options.settledAtMs !== undefined ? { settledAt: at(options.settledAtMs) } : {}),
+    ...(options.turnCompleted !== undefined ? { turnCompleted: options.turnCompleted } : {}),
+  };
+}
+
+function answeredTurn(): FixtureMessage[] {
+  return [
+    message('user', 'user', 0, { body: '评价一下这个项目' }),
+    message('thinking', 'thinking', 5_951, {
+      body: 'Reviewing the repository structure…',
+      content: { text: 'Reviewing the repository structure…', durationMs: 109 },
+    }),
+    message('assistant', 'progress', 6_062, { body: '我先快速看一下代码。' }),
+    message('tool', 'read', 6_500, {
+      body: 'Read(/repo)',
+      content: { toolName: 'Read', input: { file_path: '/repo' } },
+      settledAtMs: 7_000,
+    }),
+    message('assistant', 'final', 29_000, {
+      body: '总体判断：这是个工程素养很高的项目。',
+      turnCompleted: true,
+    }),
+  ];
+}
+
+function topLevelGroups(items: readonly MessageRenderItem<FixtureMessage>[]): WorkGroup[] {
+  return items.filter((item): item is WorkGroup => item.type === 'work_group');
+}
+
+function innerGroups(group: WorkGroup): WorkGroup[] {
+  return group.children.filter((item): item is WorkGroup => item.type === 'work_group');
+}
+
+describe('共享工作组时长 — 上一边界锚点', () => {
+  it('完成态把首段模型等待计入，并让内层分段之和等于外层总时长', () => {
+    const [outer] = topLevelGroups(buildMessageRenderItems(answeredTurn()));
+    const inner = innerGroups(outer);
+
+    expect(inner).toHaveLength(2);
+    expect(inner[0].durationMs).toBe(6_062);
+    expect(inner[1].durationMs).toBe(29_000 - 6_062);
+    expect(outer.durationMs).toBe(29_000);
+    expect(inner.reduce((sum, group) => sum + (group.durationMs ?? 0), 0)).toBe(outer.durationMs);
+  });
+
+  it('流式尾段从用户消息起表，而不是首个 thinking 到达时刻', () => {
+    const [group] = topLevelGroups(
+      buildMessageRenderItems(answeredTurn().slice(0, 2), {
+        isSessionStreaming: true,
+      }),
+    );
+
+    expect(group.isStreaming).toBe(true);
+    expect(group.startedAtMs).toBe(BASE_MS);
+  });
+
+  it('窗口截断没有上一边界时退回首个活动时间', () => {
+    const [outer] = topLevelGroups(buildMessageRenderItems(answeredTurn().slice(1)));
+    const [firstInner] = innerGroups(outer);
+
+    expect(firstInner.durationMs).toBe(111);
+  });
+
+  it('历史空洞后清除旧 turn 边界，不把缺失区间计入尾段', () => {
+    const items = buildMessageRenderItems([
+      message('user', 'user', 0, { body: '开始' }),
+      message('tool', 'head-tool', 60_000, {
+        body: 'Read(head)',
+        content: { toolName: 'Read', input: {} },
+        settledAtMs: 60_000,
+      }),
+      message('tool', 'tail-tool', 140 * 60_000, {
+        body: 'Read(tail)',
+        content: { toolName: 'Read', input: {} },
+        settledAtMs: 140 * 60_000,
+      }),
+      message('assistant', 'final', 141 * 60_000, {
+        body: '完成',
+        turnCompleted: true,
+      }),
+    ]);
+    const groups = topLevelGroups(items);
+
+    expect(groups).toHaveLength(2);
+    expect(groups[0].durationMs).toBe(60_000);
+    expect(groups[1].durationMs).toBe(60_000);
+  });
+});

--- a/packages/maker-shared/src/messageRender.ts
+++ b/packages/maker-shared/src/messageRender.ts
@@ -1472,16 +1472,23 @@ function groupMessageWorkRuns<
 ): MessageRenderItem<TMessage>[] {
   const out: MessageRenderItem<TMessage>[] = [];
   let currentTurn: MessageRenderItem<TMessage>[] = [];
+  // turn 开场边界（用户消息）的时间戳；窗口截断没见到用户消息时为 null，
+  // 各分组路径退回段内锚点。
+  let turnStartMs: number | null = null;
 
   const flushTurn = (activeTail: boolean) => {
     if (currentTurn.length === 0) return;
     if (activeTail && isSessionStreaming) {
-      out.push(...groupActiveWorkRuns(currentTurn));
+      out.push(...groupActiveWorkRuns(currentTurn, turnStartMs));
       currentTurn = [];
       return;
     }
-    const grouped = groupAnsweredTurnItems(currentTurn);
-    out.push(...(grouped.handled ? grouped.items : groupLegacyWorkRuns(currentTurn)));
+    const grouped = groupAnsweredTurnItems(currentTurn, turnStartMs);
+    out.push(
+      ...(grouped.handled
+        ? grouped.items
+        : groupLegacyWorkRuns(currentTurn, turnStartMs)),
+    );
     currentTurn = [];
   };
 
@@ -1501,6 +1508,7 @@ function groupMessageWorkRuns<
       flushTurn(false);
       out.push(item);
       noteEnd(item);
+      turnStartMs = itemTimestamp(item);
       continue;
     }
     // 窗口空洞:user 行是唯一的 turn 边界,窗口里缺了它,两段不相干的历史就会被折进同一个
@@ -1513,6 +1521,9 @@ function groupMessageWorkRuns<
       && startMs - prevEndMs > HISTORY_GAP_SPLIT_MS
     ) {
       flushTurn(false);
+      // 空洞切开的新段没有已知 turn 开场边界：旧 user 行在空洞另一侧（或未加载）。
+      // 清空后与窗口截断同义，各路径会退回首个活动时间，避免把空洞计入时长。
+      turnStartMs = null;
     }
     currentTurn.push(item);
     noteEnd(item);
@@ -1523,7 +1534,10 @@ function groupMessageWorkRuns<
 
 function groupAnsweredTurnItems<
   TMessage extends MessageRenderNormalizedMessage,
->(items: readonly MessageRenderItem<TMessage>[]): {
+>(
+  items: readonly MessageRenderItem<TMessage>[],
+  turnStartMs: number | null = null,
+): {
   items: MessageRenderItem<TMessage>[];
   handled: boolean;
 } {
@@ -1597,9 +1611,10 @@ function groupAnsweredTurnItems<
 
   const out: MessageRenderItem<TMessage>[] = [];
   let run: MessageRenderWorkChildItem<TMessage>[] = [];
+  let previousBoundaryMs = turnStartMs;
   const flushRun = (nextItem?: MessageRenderItem<TMessage>) => {
     if (run.length === 0) return;
-    out.push(createCompletedWorkGroup(run, nextItem));
+    out.push(createCompletedWorkGroup(run, nextItem, previousBoundaryMs));
     run = [];
   };
 
@@ -1615,6 +1630,7 @@ function groupAnsweredTurnItems<
     } else {
       flushRun(item);
       out.push(item);
+      previousBoundaryMs = boundaryTimestamp(item);
     }
   }
   flushRun();
@@ -1623,12 +1639,14 @@ function groupAnsweredTurnItems<
 
 function groupLegacyWorkRuns<TMessage extends MessageRenderNormalizedMessage>(
   items: readonly MessageRenderItem<TMessage>[],
+  turnStartMs: number | null = null,
 ): MessageRenderItem<TMessage>[] {
   const out: MessageRenderItem<TMessage>[] = [];
   let run: MessageRenderWorkChildItem<TMessage>[] = [];
+  let previousBoundaryMs = turnStartMs;
   const flushRun = (nextItem?: MessageRenderItem<TMessage>) => {
     if (run.length === 0) return;
-    out.push(createWorkGroup(run, nextItem));
+    out.push(createWorkGroup(run, nextItem, false, previousBoundaryMs));
     run = [];
   };
   for (const item of items) {
@@ -1636,6 +1654,7 @@ function groupLegacyWorkRuns<TMessage extends MessageRenderNormalizedMessage>(
     else {
       flushRun(item);
       out.push(item);
+      previousBoundaryMs = boundaryTimestamp(item);
     }
   }
   flushRun();
@@ -1645,6 +1664,7 @@ function groupLegacyWorkRuns<TMessage extends MessageRenderNormalizedMessage>(
 /** Active turn: assistant text and compact cards close the previous activity run. */
 function groupActiveWorkRuns<TMessage extends MessageRenderNormalizedMessage>(
   items: readonly MessageRenderItem<TMessage>[],
+  turnStartMs: number | null = null,
 ): MessageRenderItem<TMessage>[] {
   let lastCompletedBoundaryIndex = -1;
   for (let index = 0; index < items.length; index++) {
@@ -1656,9 +1676,17 @@ function groupActiveWorkRuns<TMessage extends MessageRenderNormalizedMessage>(
   const out: MessageRenderItem<TMessage>[] = [];
   let run: MessageRenderWorkChildItem<TMessage>[] = [];
   let runLastIndex = -1;
+  let previousBoundaryMs = turnStartMs;
   const flushRun = (nextItem?: MessageRenderItem<TMessage>) => {
     if (run.length === 0) return;
-    out.push(createWorkGroup(run, nextItem, runLastIndex > lastCompletedBoundaryIndex));
+    out.push(
+      createWorkGroup(
+        run,
+        nextItem,
+        runLastIndex > lastCompletedBoundaryIndex,
+        previousBoundaryMs,
+      ),
+    );
     run = [];
   };
   for (let index = 0; index < items.length; index++) {
@@ -1671,6 +1699,7 @@ function groupActiveWorkRuns<TMessage extends MessageRenderNormalizedMessage>(
       out.push(item.type === 'todo'
         ? { ...item, isStreaming: index > lastCompletedBoundaryIndex }
         : item);
+      previousBoundaryMs = boundaryTimestamp(item);
     }
   }
   flushRun();
@@ -1803,16 +1832,33 @@ function isWorkActivityItem<TMessage extends MessageRenderNormalizedMessage>(
     && (item.type === 'thinking' || item.type === 'tool_group' || item.type === 'agent_task');
 }
 
+/** 边界项（用户消息 / assistant 正文）的时间戳；非 message 卡片不作为时间边界。 */
+function boundaryTimestamp<TMessage extends MessageRenderNormalizedMessage>(
+  item: MessageRenderItem<TMessage> | undefined,
+): number | null {
+  return item?.type === 'message' ? itemTimestamp(item) : null;
+}
+
 function createWorkGroup<
   TMessage extends MessageRenderNormalizedMessage,
 >(
   children: MessageRenderWorkChildItem<TMessage>[],
   nextItem?: MessageRenderItem<TMessage>,
   isStreaming = false,
+  previousBoundaryMs: number | null = null,
 ): MessageRenderWorkGroupItem<TMessage> {
   const firstActivity = children.find((item) => item.type !== 'message' || item.message.kind === 'thinking');
-  const start = itemTimestamp(firstActivity ?? children[0]);
-  const end = nextItem ? itemTimestamp(nextItem) : workRunFallbackEnd(children);
+  const anchor = itemTimestamp(firstActivity ?? children[0]);
+  // 段起点优先锚上一个边界（用户消息 / 上一句正文），与桌面活表口径一致。
+  // 边界缺失（窗口截断）或时序异常时退回段内首个活动。
+  const start =
+    previousBoundaryMs !== null && (anchor === null || previousBoundaryMs <= anchor)
+      ? previousBoundaryMs
+      : anchor;
+  const end =
+    nextItem?.type === 'message'
+      ? itemTimestamp(nextItem)
+      : workRunFallbackEnd(children);
   const durationMs = start !== null && end !== null && end >= start ? end - start : undefined;
   return {
     type: 'work_group',
@@ -1827,17 +1873,21 @@ function createWorkGroup<
 function createCompletedWorkGroup<TMessage extends MessageRenderNormalizedMessage>(
   run: MessageRenderWorkChildItem<TMessage>[],
   nextItem?: MessageRenderItem<TMessage>,
+  previousBoundaryMs: number | null = null,
 ): MessageRenderWorkGroupItem<TMessage> {
   const hasAssistantText = run.some(
     (item) => item.type === 'message' && item.message.kind === 'assistant',
   );
-  if (!hasAssistantText) return createWorkGroup(run, nextItem);
+  if (!hasAssistantText) return createWorkGroup(run, nextItem, false, previousBoundaryMs);
 
   const children: MessageRenderWorkChildItem<TMessage>[] = [];
   let activityRun: MessageRenderWorkChildItem<TMessage>[] = [];
+  let innerPreviousBoundaryMs = previousBoundaryMs;
   const flushActivityRun = (activityNextItem?: MessageRenderItem<TMessage>) => {
     if (activityRun.length === 0) return;
-    children.push(createWorkGroup(activityRun, activityNextItem));
+    children.push(
+      createWorkGroup(activityRun, activityNextItem, false, innerPreviousBoundaryMs),
+    );
     activityRun = [];
   };
   for (const item of run) {
@@ -1846,10 +1896,11 @@ function createCompletedWorkGroup<TMessage extends MessageRenderNormalizedMessag
     } else {
       flushActivityRun(item);
       children.push(item);
+      innerPreviousBoundaryMs = boundaryTimestamp(item);
     }
   }
   flushActivityRun(nextItem);
-  const outer = createWorkGroup(run, nextItem);
+  const outer = createWorkGroup(run, nextItem, false, previousBoundaryMs);
   const firstActivity = run.find((item) => item.type !== 'message' || item.message.kind === 'thinking');
   return {
     ...outer,


### PR DESCRIPTION
## 这次改了什么

### 摘要

Mobile 的“已工作 / 正在工作”时长仍从首个 thinking 或 tool 开始计算，没有同步桌面端 #598 已采用的“从用户消息或上一条 assistant 正文边界起表”口径，因此会漏掉首个活动出现前的等待和思考时间。

本 PR 将共享消息渲染逻辑对齐桌面端：完成态 `durationMs` 与流式 `startedAtMs` 都优先使用上一条可见消息边界；历史窗口出现空洞时清除旧边界，避免跨空洞夸大时长；窗口截断时仍回退到首个已加载活动。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Slack 反馈 Mobile 与 Desktop 的已工作时间不一致
- 本 PR 包含：共享工作组边界计时逻辑；完成态、流式、窗口截断和历史空洞回归测试；Mobile 包装层期望更新
- 明确不包含：Desktop 逻辑改动、UI 样式或文案、原生配置和 runtime fingerprint
- 用户可见变化：Mobile 显示的“已工作 / 正在工作”时间与 Desktop 使用同一口径
- 是否存在 breaking change：无

### UI 变化

不涉及：仅调整共享渲染模型产出的计时数据，没有修改组件、布局、样式或文案。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter @cindy/maker-shared exec vitest run src/__tests__/messageRenderDurationAnchor.test.ts src/__tests__/messageRender.test.ts src/__tests__/messageRenderHistoryGap.test.ts
结果：3 个文件、75 个测试通过

pnpm --filter mobile exec vitest run src/__tests__/messageRenderModel.test.ts src/__tests__/historyWindowGap.test.ts
结果：2 个文件、48 个测试通过

pnpm --filter @cindy/maker-shared run --if-present typecheck
结果：该包没有 typecheck script，按仓库规则跳过

pnpm --filter mobile run --if-present typecheck
结果：通过

bash /Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh <worktree>
结果：Mobile 与 maker-shared 整包单测通过；全仓 25,952 个测试通过、2 个 Desktop ghostInstallReceipt 基线测试失败。两项失败已在同一 HEAD 的干净 main 工作区单独复现，和本 PR diff 无关，交由 CI 复核。
```

### 手工验证

不涉及：没有 UI、原生层或交互改动。

### 未执行的验证

- 未启动 Mobile 模拟器或实机：本次只修改共享消息模型的计时边界，已由 shared 与 Mobile wrapper 回归测试覆盖。
- 额外执行的 `pnpm --filter @cindy/maker-shared build` 被 6 个现有测试类型错误拦截；相同错误已在同一 HEAD 的干净 main 工作区复现，本 PR 改动文件没有类型错误。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Mobile 消费共享 `messageRender` 模型时，工作组的完成时长和流式起点；Desktop 不受影响。
- 回滚 / 降级方式：回退本提交即可恢复原先从首个活动起算的 Mobile 行为。历史窗口缺失边界时仍保留旧的安全回退，不会跨缺失区间计时。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [ ] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
