### PR TITLE
feat(xai): 补齐 Grok 4.6 静态清单与参考价

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/activeCatalogDiscovery.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/activeCatalogDiscovery.test.ts
@@ -135,6 +135,18 @@ describe('active-catalog discovered augment', () => {
       'grok-build-0.1',
     ]);
     expect(xai?.models.pi).not.toEqual(xai?.models['claude-code']);
+    expect(xai?.models['claude-code']?.find((model) => model.id === 'xai/grok-4.6')).toMatchObject({
+      efforts: ['low', 'medium', 'high'],
+      defaultEffort: 'high',
+    });
+    expect(xai?.models.pi?.find((model) => model.id === 'grok-4.6')).toMatchObject({
+      efforts: [],
+      defaultEffort: null,
+    });
+    expect(xai?.models.pi?.find((model) => model.id === 'grok-4.3')).toMatchObject({
+      efforts: [],
+      defaultEffort: null,
+    });
   });
 
   it('xAI account snapshot is authoritative and projects canonical ids per harness', () => {
@@ -150,6 +162,12 @@ describe('active-catalog discovered augment', () => {
     expect(xai?.models.pi?.find((model) => model.id === 'grok-4.6')).toMatchObject({
       contextWindow: 500_000,
       supportsImageInput: true,
+      efforts: [],
+      defaultEffort: null,
+    });
+    expect(xai?.models['claude-code']?.find((model) => model.id === 'xai/grok-4.6')).toMatchObject({
+      efforts: ['low', 'medium', 'high'],
+      defaultEffort: 'high',
     });
   });
 

--- a/apps/desktop/src/main/maker-host/__tests__/catalogDerivedModels.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/catalogDerivedModels.test.ts
@@ -232,12 +232,12 @@ describe('deriveAvailableModels — dynamic-first catalog contract', () => {
     const cc = deriveAvailableModels(BUNDLED_CATALOG, 'claude-code');
     const codex = deriveAvailableModels(BUNDLED_CATALOG, 'codex');
     expect(cc.map((m) => m.id)).toEqual([
-      'xai/grok-4.5', 'xai/grok-4.3', 'xai/grok-build-0.1',
+      'xai/grok-4.6', 'xai/grok-4.5', 'xai/grok-4.3', 'xai/grok-build-0.1',
       'xai/grok-4.20-multi-agent-0309', 'xai/grok-4.20-0309-reasoning',
       'xai/grok-4.20-0309-non-reasoning', 'xai/grok-4.20', 'xai/grok-code-fast',
     ]);
     expect(codex.map((m) => m.id)).toEqual([
-      'xai/grok-4.5', 'xai/grok-4.3', 'xai/grok-build-0.1',
+      'xai/grok-4.6', 'xai/grok-4.5', 'xai/grok-4.3', 'xai/grok-build-0.1',
       'xai/grok-4.20-multi-agent-0309', 'xai/grok-4.20-0309-reasoning',
       'xai/grok-4.20-0309-non-reasoning', 'xai/grok-4.20', 'xai/grok-code-fast',
     ]);
@@ -245,6 +245,13 @@ describe('deriveAvailableModels — dynamic-first catalog contract', () => {
 
   it('xai 静态条目字段透传(窗口 / effort / 分组)', () => {
     const codex = deriveAvailableModels(BUNDLED_CATALOG, 'codex');
+    expect(codex.find((m) => m.id === 'xai/grok-4.6')).toMatchObject({
+      displayName: 'Grok 4.6',
+      contextWindow: 500_000,
+      efforts: ['low', 'medium', 'high'],
+      defaultEffort: 'high',
+      group: 'grok',
+    });
     expect(codex.find((m) => m.id === 'xai/grok-4.3')).toMatchObject({
       displayName: 'Grok 4.3',
       contextWindow: 1_000_000,
@@ -279,7 +286,7 @@ describe('deriveAvailableModels — dynamic-first catalog contract', () => {
     expect(ids).toEqual([
       'claude-opus-4-8',
       'chatgpt/gpt-5.5',
-      'xai/grok-4.5', 'xai/grok-4.3', 'xai/grok-build-0.1',
+      'xai/grok-4.6', 'xai/grok-4.5', 'xai/grok-4.3', 'xai/grok-build-0.1',
       'xai/grok-4.20-multi-agent-0309', 'xai/grok-4.20-0309-reasoning',
       'xai/grok-4.20-0309-non-reasoning', 'xai/grok-4.20', 'xai/grok-code-fast',
       'gpt-5.5',

--- a/apps/desktop/src/main/maker-host/__tests__/modelPlane.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/modelPlane.test.ts
@@ -530,7 +530,23 @@ describe('本地 override(local 永远最高)', () => {
   });
 
   it('一条 perAgent.codex patch 只修 xAI Codex 档位,claude root 与 Pi 官方目录不动', () => {
-    setActiveCatalog(baseCatalog([grokEntry()]));
+    const catalog = baseCatalog([grokEntry()]);
+    const xai = catalog.providers.find((provider) => provider.id === 'xai');
+    if (!xai) throw new Error('bundled catalog missing xai');
+    // Loaded catalogs keep CC/Codex fallback membership; official Pi extras must not leak.
+    xai.models.pi = [
+      ...(xai.models.pi ?? []),
+      {
+        id: 'grok-pi-only-fixture',
+        name: 'Pi Only Fixture',
+        group: 'grok',
+        contextWindow: 128_000,
+        efforts: ['low'],
+        defaultEffort: 'low',
+        status: 'active',
+      },
+    ];
+    setActiveCatalog(catalog);
     setLocalCatalogOverrides(
       overridesOf({
         patches: {
@@ -549,7 +565,7 @@ describe('本地 override(local 永远最高)', () => {
     expect(models('xai', 'pi').find((m) => m.id === 'grok-test')).toMatchObject({
       efforts: ['low', 'medium', 'high', 'xhigh'],
     });
-    expect(models('xai', 'pi').some((m) => m.id === 'grok-4.1-fast')).toBe(false);
+    expect(models('xai', 'pi').some((m) => m.id === 'grok-pi-only-fixture')).toBe(false);
   });
 
   it('本地 perAgent 也在 bridge 目标端生效,且不能写展示/status 字段', () => {

--- a/apps/desktop/src/main/maker-host/__tests__/modelPlane.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/modelPlane.test.ts
@@ -549,7 +549,7 @@ describe('本地 override(local 永远最高)', () => {
     expect(models('xai', 'pi').find((m) => m.id === 'grok-test')).toMatchObject({
       efforts: ['low', 'medium', 'high', 'xhigh'],
     });
-    expect(models('xai', 'pi').some((m) => m.id === 'grok-4.6')).toBe(false);
+    expect(models('xai', 'pi').some((m) => m.id === 'grok-4.1-fast')).toBe(false);
   });
 
   it('本地 perAgent 也在 bridge 目标端生效,且不能写展示/status 字段', () => {

--- a/apps/desktop/src/main/maker-host/active-catalog.ts
+++ b/apps/desktop/src/main/maker-host/active-catalog.ts
@@ -672,8 +672,8 @@ function projectXaiPiModel(provider: Provider, model: CatalogModel): CatalogMode
       ? { contextWindowVerified: model.contextWindowVerified }
       : {}),
     ...(model.maxOutput !== undefined ? { maxOutput: model.maxOutput } : {}),
-    efforts: model.efforts,
-    defaultEffort: model.defaultEffort,
+    // Official Pi effort maps stay authoritative, including explicit empty lists.
+    // CC/Codex root efforts must not leak into the Pi projection.
     status: model.status,
     defaultEnabled: model.defaultEnabled,
   };

--- a/apps/desktop/src/renderer/components/settings/AddProviderWizard.tsx
+++ b/apps/desktop/src/renderer/components/settings/AddProviderWizard.tsx
@@ -206,6 +206,7 @@ const OFFICIAL_API_PRESETS: Record<string, ProviderPreset> = {
         baseUrl: 'https://api.x.ai/v1',
         wireProtocol: 'openai-chat',
         models: [
+          { id: 'grok-4.6', name: 'Grok 4.6' },
           { id: 'grok-4.5', name: 'Grok 4.5' },
           { id: 'grok-4.3', name: 'Grok 4.3' },
         ],

--- a/apps/desktop/src/renderer/components/settings/AddProviderWizard.tsx
+++ b/apps/desktop/src/renderer/components/settings/AddProviderWizard.tsx
@@ -205,10 +205,12 @@ const OFFICIAL_API_PRESETS: Record<string, ProviderPreset> = {
       codex: {
         baseUrl: 'https://api.x.ai/v1',
         wireProtocol: 'openai-chat',
+        // contextWindow 必须与目录一致:拉取失败时 handleFinish 只读预设窗口,
+        // 缺省会落 toCatalogModel 的 200k 默认。
         models: [
-          { id: 'grok-4.6', name: 'Grok 4.6' },
-          { id: 'grok-4.5', name: 'Grok 4.5' },
-          { id: 'grok-4.3', name: 'Grok 4.3' },
+          { id: 'grok-4.6', name: 'Grok 4.6', contextWindow: 500_000 },
+          { id: 'grok-4.5', name: 'Grok 4.5', contextWindow: 500_000 },
+          { id: 'grok-4.3', name: 'Grok 4.3', contextWindow: 1_000_000 },
         ],
       },
     },

--- a/packages/model-providers/catalog/model-registry.json
+++ b/packages/model-providers/catalog/model-registry.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "updatedAt": "2026-08-14T00:00:00.000Z",
+  "updatedAt": "2026-08-17T00:00:00.000Z",
   "models": [
     {
       "id": "openai/gpt-5.6-sol",
@@ -858,11 +858,44 @@
       ]
     },
     {
+      "id": "xai/grok-4.6",
+      "name": "Grok 4.6",
+      "status": "active",
+      "group": "grok",
+      "description": "xAI Grok 4.6 旗舰,编码/agent 任务,500k 上下文(SuperGrok 订阅直连)",
+      "contextWindow": 500000,
+      "efforts": ["low", "medium", "high"],
+      "defaultEffort": "high",
+      "sortOrder": 48,
+      "routes": [
+        {
+          "providerId": "xai",
+          "modelId": "xai/grok-4.6",
+          "agents": ["claude-code", "codex"],
+          "referencePrices": [
+            {
+              "currency": "USD",
+              "variant": "standard",
+              "inputPerMtok": 2,
+              "outputPerMtok": 6,
+              "cacheReadPerMtok": 0.5,
+              "effectiveFrom": "2026-08-12",
+              "source": {
+                "kind": "provider-official",
+                "url": "https://docs.x.ai/developers/pricing",
+                "verifiedAt": "2026-08-17"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
       "id": "xai/grok-4.5",
       "name": "Grok 4.5",
       "status": "active",
       "group": "grok",
-      "description": "xAI Grok 4.5 新旗舰,编码/agent 任务最强,500k 上下文(SuperGrok 订阅直连)",
+      "description": "xAI Grok 4.5,编码/agent 任务,500k 上下文(SuperGrok 订阅直连)",
       "contextWindow": 500000,
       "efforts": ["low", "medium", "high"],
       "defaultEffort": "high",

--- a/packages/model-providers/catalog/providers.json
+++ b/packages/model-providers/catalog/providers.json
@@ -63,11 +63,22 @@
       "models": {
         "claude-code": [
           {
+            "id": "xai/grok-4.6",
+            "name": "Grok 4.6",
+            "group": "grok",
+            "sortOrder": 48,
+            "description": "xAI Grok 4.6 旗舰,编码/agent 任务,500k 上下文(SuperGrok 订阅直连)",
+            "contextWindow": 500000,
+            "efforts": ["low", "medium", "high"],
+            "defaultEffort": "high",
+            "status": "active"
+          },
+          {
             "id": "xai/grok-4.5",
             "name": "Grok 4.5",
             "group": "grok",
             "sortOrder": 49,
-            "description": "xAI Grok 4.5 新旗舰,编码/agent 任务最强,500k 上下文(SuperGrok 订阅直连)",
+            "description": "xAI Grok 4.5,编码/agent 任务,500k 上下文(SuperGrok 订阅直连)",
             "contextWindow": 500000,
             "efforts": ["low", "medium", "high"],
             "defaultEffort": "high",
@@ -159,11 +170,22 @@
         ],
         "codex": [
           {
+            "id": "xai/grok-4.6",
+            "name": "Grok 4.6",
+            "group": "grok",
+            "sortOrder": 48,
+            "description": "xAI Grok 4.6 旗舰,编码/agent 任务,500k 上下文(SuperGrok 订阅直连)",
+            "contextWindow": 500000,
+            "efforts": ["low", "medium", "high"],
+            "defaultEffort": "high",
+            "status": "active"
+          },
+          {
             "id": "xai/grok-4.5",
             "name": "Grok 4.5",
             "group": "grok",
             "sortOrder": 49,
-            "description": "xAI Grok 4.5 新旗舰,编码/agent 任务最强,500k 上下文(SuperGrok 订阅直连)",
+            "description": "xAI Grok 4.5,编码/agent 任务,500k 上下文(SuperGrok 订阅直连)",
             "contextWindow": 500000,
             "efforts": ["low", "medium", "high"],
             "defaultEffort": "high",

--- a/packages/model-providers/src/__tests__/catalog.test.ts
+++ b/packages/model-providers/src/__tests__/catalog.test.ts
@@ -28,6 +28,7 @@ const DYNAMIC_PROVIDER_IDS = ['anthropic', 'openai', 'xd'] as const;
 
 /** xAI 随包 fallback 元数据清单。 */
 const EXPECTED_XAI_IDS = [
+  'xai/grok-4.6',
   'xai/grok-4.5',
   'xai/grok-4.3',
   'xai/grok-build-0.1',
@@ -149,6 +150,11 @@ describe('bundled catalog validity (dynamic-first contract)', () => {
       supportsImageInput: true,
       efforts: [],
       defaultEffort: null,
+    });
+    expect(xai.models['claude-code']?.find((m) => m.id === 'xai/grok-4.6')).toMatchObject({
+      contextWindow: 500_000,
+      efforts: ['low', 'medium', 'high'],
+      defaultEffort: 'high',
     });
   });
 

--- a/packages/model-providers/src/__tests__/modelRegistry.test.ts
+++ b/packages/model-providers/src/__tests__/modelRegistry.test.ts
@@ -102,6 +102,16 @@ describe("model registry", () => {
 
   it("selects xAI token bands and time-effective Anthropic prices", () => {
     expect(
+      resolveModelReferencePrice(registry, "xai", "xai/grok-4.6", {
+        inputTokens: 199_999,
+      })?.price,
+    ).toMatchObject({ inputPerMtok: 2, outputPerMtok: 6, cacheReadPerMtok: 0.5 });
+    expect(
+      resolveModelReferencePrice(registry, "xai", "xai/grok-4.6", {
+        inputTokens: 200_000,
+      })?.price,
+    ).toMatchObject({ inputPerMtok: 2, outputPerMtok: 6, cacheReadPerMtok: 0.5 });
+    expect(
       resolveModelReferencePrice(registry, "xai", "xai/grok-4.5", {
         inputTokens: 199_999,
       })?.price,


### PR DESCRIPTION
## 这次改了什么

### 摘要

Grok 4.6 已经能经 SuperGrok 发现通道跑起来，但 Claude Code / Codex 的静态 fallback、参考价 registry 和 `xai-api` 向导还停在 4.5/4.3。本 PR 把 4.6 补进这三处，让离线清单、订阅价值估算和 API key 向导与现网型号对齐。

### 变更类型

- [x] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#2824 合入后识别的 Grok 4.6 清单缺口
- 本 PR 包含：
  - `model-registry.json` 增加 `xai/grok-4.6`（CC/Codex 路由，一档参考价 `$2 / $6 / $0.50 cache`）
  - `providers.json` 的 Claude Code / Codex 静态 fallback 把 4.6 放在 4.5 前
  - `xai-api` 向导补 `grok-4.6`
  - 同步 catalog / registry / 派生清单测试；Pi-only 哨兵改为 `grok-4.1-fast`
- 明确不包含：
  - 不改 Pi 官方目录（本来就有 4.6，且 `efforts: []`）
  - 不发明 4.5 那种 200k 翻倍价档
  - 不加 `xhigh`、不改 Vercel preset
  - 不改 SuperGrok 账号周用量
- 用户可见变化：未登录发现时，CC/Codex 模型列表会出现 Grok 4.6；添加 xAI API 供应商时向导默认型号含 4.6；订阅价值估算能引用 4.6 参考价
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：不涉及：仅向导静态型号列表增加一项，无视觉/交互/文案变化

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --filter @cindy/model-providers run --if-present typecheck
结果：包无 typecheck script，按 --if-present 跳过

pnpm --filter @cindy/model-providers exec vitest run \
  src/__tests__/catalog.test.ts \
  src/__tests__/modelRegistry.test.ts \
  src/__tests__/modelRegistryConsistency.test.ts
结果：3 files / 66 tests passed

pnpm --filter desktop exec vitest run \
  src/main/maker-host/__tests__/catalogDerivedModels.test.ts \
  src/main/maker-host/__tests__/modelPlane.test.ts \
  src/main/maker-host/__tests__/activeCatalogDiscovery.test.ts
结果：3 files / 73 tests passed

pnpm test:unit:related
结果：本 diff 相关的 model-providers / catalog 测试通过；desktop 全量里
ghostInstallReceipt 2 条失败。已在干净 origin/main checkout
(/Users/dash/Code/Cindy/cindy) 复现同一失败，与本 diff 无关。

bash run-unit-gate.sh
结果：除上述基线 ghostInstallReceipt 2 条外全绿（desktop 1958 passed /
2 failed，其余 workspace 通过）。不把无关基线修复混进本 PR，交给 CI 复核。
```

### 手工验证

不涉及。未做实机登录 / 向导走查；静态清单与参考价由单测锁住。

### 未执行的验证

- 未在 SuperGrok 登录后目检 CC/Codex 选择器是否把 4.6 排在最前（发现通道成功时本就会出现 4.6）
- 未手工走一遍 `xai-api` 向导
- Light / Dark 目检：无视觉改动

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：xAI 静态 fallback 成员、registry 参考价、xAI API 向导默认型号
- 回滚 / 降级方式：revert 本 PR 即可回到 4.5 为首的静态清单；已发现的 4.6 不受影响
- 存量插件影响：无

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
