### PR TITLE
fix(mobile): 受限照片权限不再进任务弹提醒

### DIFF
--- a/apps/mobile/src/__tests__/contextSheetMediaAssets.test.ts
+++ b/apps/mobile/src/__tests__/contextSheetMediaAssets.test.ts
@@ -2,7 +2,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const platform = vi.hoisted(() => ({ os: 'android' }));
 const mediaLibrary = vi.hoisted(() => ({
+  getAlbumAsync: vi.fn(),
   getAssetInfoAsync: vi.fn(),
+  getAssetsAsync: vi.fn(),
+  getPermissionsAsync: vi.fn(),
 }));
 const imageManipulator = vi.hoisted(() => ({
   manipulate: vi.fn(),
@@ -13,7 +16,10 @@ vi.mock('react-native', () => ({
   Platform: { get OS() { return platform.os; } },
 }));
 vi.mock('expo-media-library/legacy', () => ({
+  getAlbumAsync: mediaLibrary.getAlbumAsync,
   getAssetInfoAsync: mediaLibrary.getAssetInfoAsync,
+  getAssetsAsync: mediaLibrary.getAssetsAsync,
+  getPermissionsAsync: mediaLibrary.getPermissionsAsync,
   MediaType: { photo: 'photo' },
   SortBy: { creationTime: 'creationTime' },
 }));
@@ -26,6 +32,7 @@ vi.mock('@/i18n', () => ({
 }));
 
 import {
+  prefetchContextSheetMediaAssets,
   resolveContextSheetMediaAssetForUpload,
   type ContextSheetMediaAsset,
 } from '@/session/useContextSheetMediaAssets';
@@ -41,13 +48,47 @@ function asset(overrides: Partial<ContextSheetMediaAsset> = {}): ContextSheetMed
   };
 }
 
-describe('resolveContextSheetMediaAssetForUpload', () => {
-  beforeEach(() => {
-    platform.os = 'android';
-    mediaLibrary.getAssetInfoAsync.mockReset();
-    imageManipulator.manipulate.mockReset();
+beforeEach(() => {
+  platform.os = 'android';
+  mediaLibrary.getAlbumAsync.mockReset();
+  mediaLibrary.getAssetInfoAsync.mockReset();
+  mediaLibrary.getAssetsAsync.mockReset();
+  mediaLibrary.getPermissionsAsync.mockReset();
+  imageManipulator.manipulate.mockReset();
+});
+
+describe('prefetchContextSheetMediaAssets', () => {
+  it('iOS 受限照片权限不在页面预取时读取资产,避免每次冷启动弹系统提醒', async () => {
+    platform.os = 'ios';
+    mediaLibrary.getPermissionsAsync.mockResolvedValue({
+      accessPrivileges: 'limited',
+      granted: true,
+    });
+
+    await prefetchContextSheetMediaAssets('recent');
+
+    expect(mediaLibrary.getPermissionsAsync).toHaveBeenCalledWith(false, ['photo']);
+    expect(mediaLibrary.getAssetsAsync).not.toHaveBeenCalled();
   });
 
+  it('iOS 完全照片权限仍可静默预取资产', async () => {
+    platform.os = 'ios';
+    mediaLibrary.getPermissionsAsync.mockResolvedValue({
+      accessPrivileges: 'all',
+      granted: true,
+    });
+    mediaLibrary.getAssetsAsync.mockResolvedValue({ assets: [] });
+
+    await prefetchContextSheetMediaAssets('screenshots');
+
+    expect(mediaLibrary.getAssetsAsync).toHaveBeenCalledWith(expect.objectContaining({
+      first: 60,
+      mediaSubtypes: ['screenshot'],
+    }));
+  });
+});
+
+describe('resolveContextSheetMediaAssetForUpload', () => {
   it('Android 缺少媒体位置权限时回退列表 URI 与尺寸,继续图片上传解析', async () => {
     mediaLibrary.getAssetInfoAsync.mockRejectedValue(Object.assign(
       new Error('Unable to load asset'),

--- a/apps/mobile/src/session/useContextSheetMediaAssets.ts
+++ b/apps/mobile/src/session/useContextSheetMediaAssets.ts
@@ -68,14 +68,16 @@ async function fetchAssets(kind: ContextSheetMediaKind, first: number): Promise<
 }
 
 /**
- * 页面挂载时静默预取(打开面板即刻出图)。只在照片权限已授予时拉取——
- * 绝不在预取时机弹权限框,首次授权仍由面板打开触发;失败静默,面板打开时照常加载。
+ * 页面挂载时静默预取(打开面板即刻出图)。只在照片权限已授予、且 iOS 不是受限访问时拉取——
+ * iOS 受限访问虽然 granted=true,首次读取资产仍可能触发系统自动提醒;预取绝不能打断用户。
+ * 首次授权和受限资产读取仍由用户打开面板后触发;失败静默,面板打开时照常加载。
  */
 export async function prefetchContextSheetMediaAssets(kind: ContextSheetMediaKind = 'recent'): Promise<void> {
   if (Platform.OS === 'web' || assetsCache.has(kind)) return;
   try {
     const permission = await MediaLibrary.getPermissionsAsync(false, ['photo']);
     if (!permission.granted) return;
+    if (Platform.OS === 'ios' && permission.accessPrivileges === 'limited') return;
     const assets = await fetchAssets(kind, DEFAULT_FIRST[kind]);
     if (assets) assetsCache.set(kind, assets);
   } catch {


### PR DESCRIPTION
## 这次改了什么

### 摘要

iOS 照片权限处于「受限访问」时，系统仍会把权限报告为 `granted`。任务页原本会在挂载时静默预取最近照片，第一次读取 PhotoKit 资产因此会在每次 App 冷启动后弹出一次系统提醒。

本 PR 在静默预取路径识别 iOS limited 权限并跳过资产读取；用户主动打开附件面板时仍沿用现有加载与权限管理流程。补充回归测试，覆盖 limited 不预取与 full access 继续预取。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Slack 用户反馈：iOS App 每次重启后进入任意任务会弹一次有限照片访问提醒
- 本 PR 包含：受限照片权限下跳过任务页静默预取；权限分支回归测试
- 明确不包含：关闭用户主动打开附件面板时的系统权限提醒；原生 `Info.plist` / Expo config 修改
- 用户可见变化：使用「受限访问」照片权限的 iOS 用户，重启 App 后进入任务不再被系统弹窗打断
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：不涉及：未修改布局、样式、文案或主动交互，只阻止后台预取触发系统弹窗

## 怎么验证的

### 自动验证

```text
pnpm --filter mobile exec vitest run src/__tests__/contextSheetMediaAssets.test.ts
结果：1 个文件、6 个测试通过

pnpm --filter mobile run --if-present typecheck
结果：通过

pnpm test:unit:related
结果：apps/mobile 相关单测通过

node apps/mobile/scripts/ci-fingerprint.mjs compute / compare
结果：iOS、Android runtime fingerprint 均未变化，可通过 OTA 交付

pnpm check:dco
结果：1 个提交签名通过

bash /Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh <worktree>
结果：本 PR 相关 Mobile 与其余 workspace 通过；全仓仅 Desktop ghostInstallReceipt.test.ts 的 2 条既有测试失败（25952 通过、5 跳过）

在干净且与 origin/main 同步的主 worktree 运行：
pnpm --filter desktop exec vitest run src/main/cindy-brain/__tests__/ghostInstallReceipt.test.ts
结果：相同 2 条测试失败，确认是当前 main 基线问题，与本 PR 无关
```

### 手工验证

未执行。

### 未执行的验证

- 未运行 iOS 真机 / 模拟器：当前 Cindy 内嵌 iOS Simulator 插件未启用，Host 未提供可安全接管的外部模拟器目标。
- Mobile worktree：`cindy/steady-goodall`，`/Users/dash/Code/Cindy/cindy/.cindy-worktrees/steady-goodall`。
- 未启动 Metro，因此没有 Metro 归属或 `__DEV__` build label 证据。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [x] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 iOS 且照片权限为 limited 的任务页静默预取；iOS full access、Android、用户主动打开附件面板的流程不变。
- fingerprint / OTA：未修改原生配置，前后 iOS、Android 指纹一致，不触发冷更。
- 已知边界：用户主动打开附件面板读取受限相册时，仍可能看到 iOS 每个 App 生命周期一次的系统提醒；该时机由用户主动发起，不属于本次「进任务即弹」问题。
- 回滚 / 降级方式：回退本 PR 提交即可恢复原预取行为。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范（不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（局部缺陷修复，无需新增用户文档）
- [x] 已确认测试结果或说明未执行原因
