### PR TITLE
feat(desktop): 点击原收起位置收合灵动岛

### DIFF
--- a/apps/desktop/native/agent-island/macos-agent-island-helper.swift
+++ b/apps/desktop/native/agent-island/macos-agent-island-helper.swift
@@ -2746,12 +2746,7 @@ struct IdleIslandView: View {
         idleCreateEntry
 
         HStack {
-          Color.clear
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .contentShape(Rectangle())
-            .onTapGesture {
-              eventSink(["type": "collapse"])
-            }
+          Spacer(minLength: 0)
           ExpandedIslandToolbarControls(strings: strings, soundEnabled: soundEnabled, eventSink: eventSink)
         }
         .padding(.horizontal, expandedIslandCardHorizontalPadding)
@@ -2801,12 +2796,6 @@ struct IdleIslandView: View {
         .frame(width: sideWidth, alignment: .leading)
         .clipped()
       Spacer(minLength: layout.notchWidth)
-        .contentShape(Rectangle())
-        .onTapGesture {
-          if layout.expanded {
-            eventSink(["type": "collapse"])
-          }
-        }
       Color.clear
         .frame(width: sideWidth)
     }
@@ -2918,7 +2907,7 @@ struct ExpandedIslandTopBar: View {
   private var regularBody: some View {
     HStack(spacing: 8) {
       leadingContent
-      compactCollapseHit
+      Spacer(minLength: 8)
       ExpandedIslandToolbarControls(strings: strings, soundEnabled: soundEnabled, eventSink: eventSink)
     }
     .frame(maxWidth: .infinity, minHeight: expandedIslandTopBarHeight, alignment: .center)
@@ -2933,7 +2922,7 @@ struct ExpandedIslandTopBar: View {
           .frame(width: sideWidth, alignment: .leading)
           .clipped()
 
-        compactCollapseHit
+        Color.clear
           .frame(width: notchWidth)
 
         ExpandedIslandToolbarControls(strings: strings, soundEnabled: soundEnabled, eventSink: eventSink)
@@ -2967,15 +2956,6 @@ struct ExpandedIslandTopBar: View {
         }
       }
     }
-  }
-
-  private var compactCollapseHit: some View {
-    Color.clear
-      .frame(minWidth: 8, maxWidth: .infinity, maxHeight: .infinity)
-      .contentShape(Rectangle())
-      .onTapGesture {
-        eventSink(["type": "collapse"])
-      }
   }
 }
 
@@ -5277,6 +5257,8 @@ final class AgentIslandController {
       return
     }
     pendingMoveInteraction = nil
+    // Collapse is owned here, not by SwiftUI top-bar taps, so the hit stays
+    // inside the original compact footprint instead of the whole spacer.
     if shouldTreatAsCompactClick(interaction: interaction, screenPoint: screenPoint) {
       eventSink(["type": "expand"])
     } else if shouldTreatAsCompactCollapseClick(interaction: interaction, screenPoint: screenPoint) {

--- a/apps/desktop/native/agent-island/macos-agent-island-helper.swift
+++ b/apps/desktop/native/agent-island/macos-agent-island-helper.swift
@@ -1633,6 +1633,8 @@ private let expandedIslandBodySpacing: CGFloat = 4
 private let expandedIslandBottomPadding: CGFloat = 16
 private let compactIslandBaseWidth: CGFloat = 210
 private let compactIslandMinContentWidth: CGFloat = 80
+private let compactCollapseLeadingReservedWidth: CGFloat = 80
+private let compactCollapseTrailingReservedWidth: CGFloat = 100
 private let compactIslandBadgeCollapseContentThreshold: CGFloat = 152
 private let compactIslandDetailCollapseContentThreshold: CGFloat = 190
 private let compactIslandCjkTitleMinimumWidth: CGFloat = 32
@@ -2744,7 +2746,12 @@ struct IdleIslandView: View {
         idleCreateEntry
 
         HStack {
-          Spacer(minLength: 0)
+          Color.clear
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .contentShape(Rectangle())
+            .onTapGesture {
+              eventSink(["type": "collapse"])
+            }
           ExpandedIslandToolbarControls(strings: strings, soundEnabled: soundEnabled, eventSink: eventSink)
         }
         .padding(.horizontal, expandedIslandCardHorizontalPadding)
@@ -2794,6 +2801,12 @@ struct IdleIslandView: View {
         .frame(width: sideWidth, alignment: .leading)
         .clipped()
       Spacer(minLength: layout.notchWidth)
+        .contentShape(Rectangle())
+        .onTapGesture {
+          if layout.expanded {
+            eventSink(["type": "collapse"])
+          }
+        }
       Color.clear
         .frame(width: sideWidth)
     }
@@ -2905,7 +2918,7 @@ struct ExpandedIslandTopBar: View {
   private var regularBody: some View {
     HStack(spacing: 8) {
       leadingContent
-      Spacer(minLength: 8)
+      compactCollapseHit
       ExpandedIslandToolbarControls(strings: strings, soundEnabled: soundEnabled, eventSink: eventSink)
     }
     .frame(maxWidth: .infinity, minHeight: expandedIslandTopBarHeight, alignment: .center)
@@ -2920,7 +2933,7 @@ struct ExpandedIslandTopBar: View {
           .frame(width: sideWidth, alignment: .leading)
           .clipped()
 
-        Color.clear
+        compactCollapseHit
           .frame(width: notchWidth)
 
         ExpandedIslandToolbarControls(strings: strings, soundEnabled: soundEnabled, eventSink: eventSink)
@@ -2954,6 +2967,15 @@ struct ExpandedIslandTopBar: View {
         }
       }
     }
+  }
+
+  private var compactCollapseHit: some View {
+    Color.clear
+      .frame(minWidth: 8, maxWidth: .infinity, maxHeight: .infinity)
+      .contentShape(Rectangle())
+      .onTapGesture {
+        eventSink(["type": "collapse"])
+      }
   }
 }
 
@@ -5257,6 +5279,8 @@ final class AgentIslandController {
     pendingMoveInteraction = nil
     if shouldTreatAsCompactClick(interaction: interaction, screenPoint: screenPoint) {
       eventSink(["type": "expand"])
+    } else if shouldTreatAsCompactCollapseClick(interaction: interaction, screenPoint: screenPoint) {
+      eventSink(["type": "collapse"])
     }
     handleMouseMoved(screenPoint: screenPoint, force: true)
     replayDeferredInteractionUpdateIfNeeded()
@@ -5424,8 +5448,54 @@ final class AgentIslandController {
     guard interaction.mode == .move, !interaction.startLayout.expanded else {
       return false
     }
-    return abs(screenPoint.x - interaction.startMouseX) <= agentIslandClickDragTolerance
+    return isClickWithoutDrag(interaction: interaction, screenPoint: screenPoint)
+  }
+
+  private func shouldTreatAsCompactCollapseClick(
+    interaction: PanelDragInteraction,
+    screenPoint: NSPoint
+  ) -> Bool {
+    guard interaction.mode == .move, interaction.startLayout.expanded else {
+      return false
+    }
+    guard isClickWithoutDrag(interaction: interaction, screenPoint: screenPoint) else {
+      return false
+    }
+    return isCompactFootprintClick(interaction: interaction)
+  }
+
+  private func isClickWithoutDrag(interaction: PanelDragInteraction, screenPoint: NSPoint) -> Bool {
+    abs(screenPoint.x - interaction.startMouseX) <= agentIslandClickDragTolerance
       && abs(screenPoint.y - interaction.startMouseY) <= agentIslandClickDragTolerance
+  }
+
+  /// The screen rectangle where the collapsed island sat. After expand, that
+  /// center strip is blank (hardware-notch Color.clear, or the top-bar spacer).
+  /// Clicking it should fold the island back; toolbar / title live outside it.
+  private func isCompactFootprintClick(interaction: PanelDragInteraction) -> Bool {
+    let layout = interaction.startLayout
+    let footprintWidth = compactCollapseFootprintWidth(layout: layout)
+    let centerX = interaction.startFrame.midX
+    let minX = centerX - footprintWidth / 2
+    let maxX = centerX + footprintWidth / 2
+    let clickX = interaction.startMouseX
+    guard clickX >= minX && clickX <= maxX else {
+      return false
+    }
+    if layout.hasHardwareNotch {
+      return true
+    }
+    let visualMinX = centerX - layout.width / 2
+    let visualMaxX = centerX + layout.width / 2
+    return clickX > visualMinX + compactCollapseLeadingReservedWidth
+      && clickX < visualMaxX - compactCollapseTrailingReservedWidth
+  }
+
+  private func compactCollapseFootprintWidth(layout: AgentIslandLayout) -> CGFloat {
+    if layout.hasHardwareNotch {
+      return max(1, layout.notchWidth)
+    }
+    return compactIslandBaseWidth
   }
 
   private func shouldPromotePendingMove(interaction: PanelDragInteraction, screenPoint: NSPoint) -> Bool {

--- a/apps/desktop/native/agent-island/macos-agent-island-helper.swift
+++ b/apps/desktop/native/agent-island/macos-agent-island-helper.swift
@@ -4621,6 +4621,7 @@ final class AgentIslandController {
     notchBaselineHeight: 24,
     screenMetrics: .fallback
   )
+  private var lastCompactIslandWidth: CGFloat?
   private var globalClickMonitor: Any?
   private var localClickMonitor: Any?
   private var globalMoveMonitor: Any?
@@ -4760,7 +4761,7 @@ final class AgentIslandController {
       )
       return
     }
-    lastLayout = layout
+    rememberLayout(layout)
     if state.mode == "expanded" {
       cancelPendingCarrierFrame()
     }
@@ -5458,26 +5459,36 @@ final class AgentIslandController {
     let layout = interaction.startLayout
     let footprintWidth = compactCollapseFootprintWidth(layout: layout)
     let centerX = interaction.startFrame.midX
-    let minX = centerX - footprintWidth / 2
-    let maxX = centerX + footprintWidth / 2
     let clickX = interaction.startMouseX
-    guard clickX >= minX && clickX <= maxX else {
+    guard clickX >= centerX - footprintWidth / 2 && clickX <= centerX + footprintWidth / 2 else {
       return false
-    }
-    if layout.hasHardwareNotch {
-      return true
     }
     let visualMinX = centerX - layout.width / 2
     let visualMaxX = centerX + layout.width / 2
-    return clickX > visualMinX + compactCollapseLeadingReservedWidth
-      && clickX < visualMaxX - compactCollapseTrailingReservedWidth
+    let sideChrome = layout.hasHardwareNotch
+      ? max(0, (layout.width - layout.notchWidth) / 2)
+      : 0
+    let leadingReserved = max(compactCollapseLeadingReservedWidth, sideChrome)
+    let trailingReserved = max(compactCollapseTrailingReservedWidth, sideChrome)
+    return clickX > visualMinX + leadingReserved
+      && clickX < visualMaxX - trailingReserved
   }
 
   private func compactCollapseFootprintWidth(layout: AgentIslandLayout) -> CGFloat {
+    if let remembered = lastCompactIslandWidth, remembered > 0 {
+      return remembered
+    }
     if layout.hasHardwareNotch {
       return max(1, layout.notchWidth)
     }
     return compactIslandBaseWidth
+  }
+
+  private func rememberLayout(_ layout: AgentIslandLayout) {
+    lastLayout = layout
+    if !layout.expanded, layout.width > 0 {
+      lastCompactIslandWidth = layout.width
+    }
   }
 
   private func shouldPromotePendingMove(interaction: PanelDragInteraction, screenPoint: NSPoint) -> Bool {
@@ -5530,7 +5541,7 @@ final class AgentIslandController {
       frame: frame,
       expanded: lastLayout.expanded
     )
-    lastLayout = AgentIslandLayout.compute(
+    rememberLayout(AgentIslandLayout.compute(
       state: model.state,
       availableFrameWidth: frame.width,
       locallyHovered: model.locallyHovered,
@@ -5538,7 +5549,7 @@ final class AgentIslandController {
       screenMetrics: model.screenMetrics,
       hardwareNotchLayoutEnabled: hardwareNotchLayoutEnabled,
       preferredContentWidth: currentContentWidth(frame: frame, layout: lastLayout)
-    )
+    ))
     let nextContentWidth = currentContentWidth(frame: frame, layout: lastLayout)
     if animatedSnap {
       beginCompactSnapLayoutAnimation()

--- a/apps/desktop/src/main/agent-island/MacAgentIslandNativeHost.ts
+++ b/apps/desktop/src/main/agent-island/MacAgentIslandNativeHost.ts
@@ -68,6 +68,7 @@ export interface AgentIslandNativeScreenMetrics {
 interface MacAgentIslandNativeHostOptions {
   onPointerZones: (zones: { menuBar: boolean; panel: boolean; displayId?: number | null }) => void;
   onExpand: (displayId?: number | null) => void;
+  onCollapse: (displayId?: number | null) => void;
   onFocusSession: (sessionId: string) => void;
   onOpenSettings: () => void;
   onNewMessage: () => void;
@@ -499,6 +500,11 @@ export class MacAgentIslandNativeHost {
       return;
     }
 
+    if (payload.type === 'collapse' && this.child === child) {
+      this.options.onCollapse(typeof payload.displayId === 'number' ? payload.displayId : null);
+      return;
+    }
+
     if (payload.type === 'focus-session' && this.child === child && typeof payload.sessionId === 'string') {
       this.options.onFocusSession(payload.sessionId);
       return;
@@ -779,7 +785,9 @@ async function buildDevMacAgentIslandHelper(): Promise<void> {
     return;
   }
   fs.mkdirSync(path.dirname(binary), { recursive: true });
-  await execFilePromise('swiftc', [source, '-O', '-o', binary], 20_000);
+  // Cold -O compile of the single-file helper is ~20s+ on this machine;
+  // a 20s cap kills the first build and permanently hides the island.
+  await execFilePromise('swiftc', [source, '-O', '-o', binary], 120_000);
   fs.chmodSync(binary, 0o755);
   fs.writeFileSync(hashFile, `${sourceHash}\n`, 'utf8');
   log.info('built dev macOS agent island helper', { path: binary });

--- a/apps/desktop/src/main/agent-island/__tests__/MacAgentIslandNativeHost.test.ts
+++ b/apps/desktop/src/main/agent-island/__tests__/MacAgentIslandNativeHost.test.ts
@@ -338,6 +338,26 @@ describe('MacAgentIslandNativeHost', () => {
     });
   });
 
+  it('forwards collapse events from the helper', async () => {
+    const child = createFakeChild();
+    h.spawn.mockReturnValue(child);
+    const options = createOptions();
+    const { MacAgentIslandNativeHost } = await import('../MacAgentIslandNativeHost.js');
+    const host = new MacAgentIslandNativeHost(options);
+
+    expect(host.publish(createDisplayState(), createFrame())).toBe(true);
+    await vi.advanceTimersByTimeAsync(0);
+
+    (child.stdout as PassThrough).write(`${JSON.stringify({ type: 'ready' })}\n`);
+    (child.stdout as PassThrough).write(`${JSON.stringify({
+      type: 'collapse',
+      displayId: 2,
+    })}\n`);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(options.onCollapse).toHaveBeenCalledWith(2);
+  });
+
   it('copies builtin sounds when building the dev helper', async () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-island-dev-assets-'));
     const appPath = path.join(tempDir, 'app');
@@ -565,6 +585,7 @@ function createOptions(): ConstructorParameters<typeof import('../MacAgentIsland
   return {
     onPointerZones: vi.fn(),
     onExpand: vi.fn(),
+    onCollapse: vi.fn(),
     onFocusSession: vi.fn(),
     onOpenSettings: vi.fn(),
     onNewMessage: vi.fn(),

--- a/apps/desktop/src/main/agent-island/__tests__/service.test.ts
+++ b/apps/desktop/src/main/agent-island/__tests__/service.test.ts
@@ -3583,6 +3583,43 @@ describe('AgentIslandService native publishing', () => {
     expect(latestNativeFrame(publish)).toMatchObject({ height: 214 });
   });
 
+  it('collapses a click-expanded island from the compact-position click', async () => {
+    const { AgentIslandService } = await import('../service.js');
+    const publish = vi.fn((state: AgentIslandDisplayState, frameOrFrames: AgentIslandNativeFrame | AgentIslandNativeFrame[]) => {
+      void state;
+      void frameOrFrames;
+      return true;
+    });
+    const service = new AgentIslandService({
+      getMainWindow: () => null,
+      nativeHost: { failed: false, publish },
+    });
+    syncEnabledForTest(service, publish);
+    const expand = (
+      service as unknown as {
+        handleNativeExpand(): void;
+      }
+    ).handleNativeExpand.bind(service);
+    const collapse = (
+      service as unknown as {
+        handleNativeCollapse(): void;
+      }
+    ).handleNativeCollapse.bind(service);
+
+    service.handleUserPrompt({ sessionId: 's1', agentKind: 'codex' }, 'run tests');
+    expand();
+    expect(publish.mock.calls.at(-1)?.[0]).toMatchObject({
+      mode: 'expanded',
+      displayPolicy: 'manualExpanded',
+    });
+
+    collapse();
+    expect(publish.mock.calls.at(-1)?.[0]).toMatchObject({
+      mode: 'compact',
+      displaySurface: 'collapsed',
+    });
+  });
+
   it('publishes native frames for every display in all-displays render mode', async () => {
     const { AgentIslandService } = await import('../service.js');
     const publish = vi.fn((state: AgentIslandDisplayState, frameOrFrames: AgentIslandNativeFrame | AgentIslandNativeFrame[]) => {

--- a/apps/desktop/src/main/agent-island/__tests__/state.test.ts
+++ b/apps/desktop/src/main/agent-island/__tests__/state.test.ts
@@ -20,6 +20,7 @@ import {
   dismissAgentIslandActiveReveal,
   getNextAgentIslandTimerAt,
   markAgentIslandSessionAttention,
+  requestAgentIslandManualCollapse,
   requestAgentIslandManualExpand,
   requestAgentIslandSessionFocus,
   setAgentIslandAppFocused,
@@ -1409,6 +1410,50 @@ describe('Agent Island display state', () => {
     expect(display.notchStatus).toBe('expanded');
     expect(display.displayPolicy).toBe('manualExpanded');
     expect(display.displaySurface).toBe('sessionList');
+  });
+
+  it('collapses immediately when the compact island position is clicked while expanded', () => {
+    const state = createAgentIslandState();
+    applyAgentIslandEvent(state, { sessionId: 'running', title: 'Running' }, statusEvent(true, 'Running'), 1_000);
+    expect(requestAgentIslandManualExpand(state)).toBe(true);
+    expect(buildAgentIslandDisplayState(state, 1_051).mode).toBe('expanded');
+
+    expect(requestAgentIslandManualCollapse(state, 1_100)).toBe(true);
+
+    const display = buildAgentIslandDisplayState(state, 1_101);
+    expect(display.mode).toBe('compact');
+    expect(display.notchStatus).toBe('peek');
+    expect(display.displayPolicy).toBe('peek');
+    expect(display.displaySurface).toBe('collapsed');
+  });
+
+  it('does not immediately re-expand from hover after a compact-position collapse', () => {
+    const state = createAgentIslandState();
+    applyAgentIslandEvent(state, { sessionId: 'running', title: 'Running' }, statusEvent(true, 'Running'), 1_000);
+    setAgentIslandHovered(state, true, 1_050);
+    expect(requestAgentIslandManualExpand(state)).toBe(true);
+    expect(buildAgentIslandDisplayState(state, 1_100).mode).toBe('expanded');
+
+    setAgentIslandPointerZones(state, { menuBar: true, panel: false }, 1_100);
+    expect(requestAgentIslandManualCollapse(state, 1_110)).toBe(true);
+    setAgentIslandPointerZones(state, { menuBar: true, panel: false }, 1_120);
+
+    expect(buildAgentIslandDisplayState(state, 1_200).mode).toBe('compact');
+    expect(buildAgentIslandDisplayState(state, 2_000).mode).toBe('compact');
+
+    setAgentIslandHovered(state, false, 2_100);
+    setAgentIslandHovered(state, true, 2_500);
+    expect(buildAgentIslandDisplayState(state, 3_100).mode).toBe('expanded');
+  });
+
+  it('does not collapse from a compact-position click while the island is being dragged', () => {
+    const state = createAgentIslandState();
+    applyAgentIslandEvent(state, { sessionId: 'running', title: 'Running' }, statusEvent(true, 'Running'), 1_000);
+    expect(requestAgentIslandManualExpand(state)).toBe(true);
+    expect(setAgentIslandLayoutDragActive(state, true)).toBe(true);
+
+    expect(requestAgentIslandManualCollapse(state, 1_200)).toBe(false);
+    expect(buildAgentIslandDisplayState(state, 1_201).mode).toBe('expanded');
   });
 
   it('does not expand from pending hover while the island is being dragged', () => {

--- a/apps/desktop/src/main/agent-island/service.ts
+++ b/apps/desktop/src/main/agent-island/service.ts
@@ -81,6 +81,7 @@ import {
   hasAgentIslandSessionAttention,
   isAgentIslandPendingFocusAck,
   markAgentIslandSessionAttention,
+  requestAgentIslandManualCollapse,
   requestAgentIslandManualExpand,
   patchAgentIslandMetadata,
   removeAgentIslandSession,
@@ -294,6 +295,7 @@ export class AgentIslandService {
     this.nativeHost = deps.nativeHost ?? new MacAgentIslandNativeHost({
       onPointerZones: (zones) => this.handleNativePointerZones(zones),
       onExpand: (displayId) => this.handleNativeExpand(displayId),
+      onCollapse: () => this.handleNativeCollapse(),
       onFocusSession: (sessionId) => this.focusSession(sessionId),
       onOpenSettings: () => this.dispatchMainWindowCommand('open-agent-island-settings', { playSelectSound: true }),
       onNewMessage: () => this.dispatchMainWindowCommand('new-maker', { playSelectSound: true }),
@@ -1557,6 +1559,13 @@ export class AgentIslandService {
     if (requestAgentIslandManualExpand(this.state, displayId)) {
       this.publish();
     }
+  }
+
+  private handleNativeCollapse(): void {
+    const now = Date.now();
+    if (!requestAgentIslandManualCollapse(this.state, now)) return;
+    this.playConfiguredSound('select', now);
+    this.publish();
   }
 
   private handleNativeLayoutDragActive(active: boolean): void {

--- a/apps/desktop/src/main/agent-island/state.ts
+++ b/apps/desktop/src/main/agent-island/state.ts
@@ -404,6 +404,22 @@ export function requestAgentIslandManualExpand(state: AgentIslandState, displayI
   return changed;
 }
 
+export function requestAgentIslandManualCollapse(state: AgentIslandState, now: number): boolean {
+  if (state.layoutDragActive) return false;
+  const changed = state.hoverExpanded
+    || state.hoverIntentAt !== null
+    || state.collapseAt !== null
+    || state.protectedDismissPending;
+  state.hoverIntentAt = null;
+  state.hoverExpanded = false;
+  state.collapseAt = null;
+  state.protectedDismissPending = false;
+  state.hoverCooldownUntil = now + AGENT_ISLAND_HOVER_SHORT_COOLDOWN_MS;
+  // Keep current pointer-zone flags. Hover expand only re-arms after leave+re-enter,
+  // so clicking the original compact position does not immediately pop the island open again.
+  return changed;
+}
+
 export function applyAgentIslandMetadata(
   state: AgentIslandState,
   meta: AgentIslandSessionMeta,


### PR DESCRIPTION
## 这次改了什么

### 摘要

灵动岛收起时点一下会立刻展开，但展开后再点回原来那个位置的空白处（刘海中间空隙，或顶栏中间空白）不会收起来。这次补上对称手势：点同一处立刻收合。右侧设置 / 声音 / 新任务、左侧标题、下方任务卡片不会误触。收起后鼠标还停在原处，不会马上被悬停再次展开。

开发态第一次编译 helper 超过 20 秒会被杀掉，之后整座岛永久隐藏。把 `swiftc` 超时改到 120 秒。

### 变更类型

- [x] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：macOS 灵动岛点击收合；状态机立即收合且不立刻被悬停重新展开；dev helper 编译超时放宽
- 明确不包含：Windows / 非原生岛；自动展开的权限卡 / 完成卡点击收合；新的视觉控件或文案
- 用户可见变化：展开后的灵动岛，点原来收起位置的空白处会立刻收起
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：DESIGN.md §1 Extreme content restraint — 不新增按钮或装饰，只让原收起位置的空白处成为与点击展开对称的收合热区；灵动岛是 macOS Swift helper，不引入新的 Web UI / token / 文案。

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：PASS apps/desktop unit (36.4s)

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --filter desktop exec vitest run \
  src/main/agent-island/__tests__/state.test.ts \
  src/main/agent-island/__tests__/service.test.ts \
  src/main/agent-island/__tests__/MacAgentIslandNativeHost.test.ts
结果：239 passed
```

全量 `run-unit-gate.sh` 在 `apps/desktop` 的 `ghostInstallReceipt.test.ts` 挂了 2 个用例。同一失败在干净 `origin/main`（`/Users/dash/Code/Cindy/cindy`）上复现，与本 PR diff 无关，不混入修复，交给 CI 给权威结论。

### 手工验证

macOS 开发版（worktree `cindy-collapse-island-click`，region=global）：
1. 点收起态灵动岛 → 立刻展开
2. 再点原来收起位置的空白处（刘海中间 / 顶栏中间）→ 立刻收起
3. 点右侧设置 / 声音 / 新任务或下方任务卡片 → 不误收

### 未执行的验证

无独立无刘海外接屏手势走查（本机为刘海 Mac；非刘海走顶栏中间空白热区，由代码覆盖）。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [x] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 macOS 灵动岛 helper 与 main 侧状态机；不改 mobile fingerprint / OTA。
- 回滚 / 降级方式：revert 本 PR 即恢复「只能点开、不能点回收合」。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
