### PR TITLE
fix(desktop): 修复 MCP 创建 Worker 的模型来源路由

### DIFF
--- a/apps/desktop/src/main/maker-ipc/__tests__/orcaWorkerCreationService.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/orcaWorkerCreationService.test.ts
@@ -1596,7 +1596,7 @@ describe('OrcaWorkerCreationService', () => {
     }));
   });
 
-  it('keeps the default route while validating connected sources when only the worker model is explicit', async () => {
+  it('pins the sole runtime provider when only the worker model is explicit', async () => {
     const availability = {
       'claude-code': [],
       codex: [
@@ -1618,12 +1618,47 @@ describe('OrcaWorkerCreationService', () => {
       model: 'gpt-5.4',
     })).resolves.toMatchObject({
       ok: true,
-      resolved: { providerId: null, model: 'gpt-5.4' },
+      resolved: { providerId: 'xd', model: 'gpt-5.4' },
     });
 
     expect(deps.buildCreateOptsWithStderr).toHaveBeenCalledWith(expect.objectContaining({
-      providerId: null,
+      providerId: 'xd',
       model: 'gpt-5.4',
+    }));
+  });
+
+  it('uses the sole XD catalog route for an explicit DeepSeek model instead of Codex native auth', async () => {
+    const model = 'deepseek/deepseek-v4-pro';
+    const { deps, service } = createDeps({
+      getAvailableModels: vi.fn(() => [
+        { id: model, efforts: ['high'], defaultEffort: 'high', supportsFastMode: false },
+      ]),
+      getProviderRoutingContext: vi.fn(async () => providerRoutingContext({
+        'claude-code': [],
+        codex: [{
+          id: 'xd',
+          name: 'XD Gateway',
+          models: [model],
+          // gateway-key 不属于 requiresExplicitRoute；唯一来源仍必须固化。
+          requiresExplicitRoute: false,
+        }],
+      })),
+    });
+
+    await expect(service.createWorker({
+      leadSessionId: 'lead-1',
+      role: 'developer',
+      agent: 'codex',
+      label: 'deepseek_worker',
+      model,
+    })).resolves.toMatchObject({
+      ok: true,
+      resolved: { model, providerId: 'xd' },
+    });
+
+    expect(deps.buildCreateOptsWithStderr).toHaveBeenCalledWith(expect.objectContaining({
+      model,
+      providerId: 'xd',
     }));
   });
 
@@ -1921,7 +1956,7 @@ describe('buildNoProviderMessage', () => {
     }));
   });
 
-  it('treats an empty-string providerId as not-explicit and keeps the forced default route', async () => {
+  it('treats an empty-string providerId as not-explicit and pins a sole runtime source', async () => {
     const { service } = createDeps();
 
     await expect(service.createWorker({
@@ -1933,8 +1968,8 @@ describe('buildNoProviderMessage', () => {
       providerId: '',
     })).resolves.toMatchObject({
       ok: true,
-      // 与「显式 model 未显式来源」同语义:providerId 强制默认路由,不进显式 preflight。
-      resolved: { providerId: null, model: 'gpt-5.5' },
+      // 空串仍按未显式处理；唯一可用来源由运行时目录解析,不按模型名写死。
+      resolved: { providerId: 'xd', model: 'gpt-5.5' },
     });
   });
 

--- a/apps/desktop/src/main/maker-ipc/orcaWorkerCreationService.ts
+++ b/apps/desktop/src/main/maker-ipc/orcaWorkerCreationService.ts
@@ -733,9 +733,6 @@ export function createOrcaWorkerCreationService(deps: OrcaWorkerCreationDeps): O
     const explicitModelProviders = params.model !== undefined
       ? agentProviders.filter((provider) => provider.models.includes(resolvedConfig.model))
       : [];
-    const explicitModelProvider = explicitModelDefaultProviderId === null
-      ? undefined
-      : agentProviders.find((provider) => provider.id === explicitModelDefaultProviderId);
     const cachedProviderRouteIsStale = params.model === undefined
       && inheritedModelComesFromDefaults
       && defaults.providerId !== undefined
@@ -756,14 +753,16 @@ export function createOrcaWorkerCreationService(deps: OrcaWorkerCreationDeps): O
       : agentProviders.find((provider) => provider.id === inheritedDefaultProviderId);
     const resolved = {
       ...resolvedConfig,
-      // 仅显式指定 model 不等于显式选择来源：providerId=null 必须保留 spawn-aware 默认路由。
-      // 例外是该模型只有一个来源且它必须依赖 session provider store 注入自己的凭证。
+      // 仅显式指定 model 不等于显式选择来源：多来源模型仍保留 spawn-aware 默认路由。
+      // 但若当前只有一个可用来源,必须把该来源固化到 session。否则 preflight 虽会按
+      // 这个唯一来源校验通过,实际 spawn 却收到 providerId=null 并回落到 agent 原生认证
+      // 链路,形成「校验走 A、执行走 B」的分裂状态(如 XD 独有 DeepSeek 模型误走
+      // Codex ChatGPT OAuth)。来源取运行时 provider registry,不按模型名写死 provider id。
       providerId: explicitSourceId !== null
         ? explicitSourceId
         : params.model !== undefined
           && explicitModelProviders.length === 1
-          && explicitModelProvider?.requiresExplicitRoute
-          ? explicitModelProvider.id
+          ? explicitModelProviders[0]!.id
           : params.model !== undefined
             ? null
             : inheritedDefaultNeedsRouteResolution

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -1511,6 +1511,7 @@ interface OrcaCollabService {
     role: string;
     agent: AgentKind;
     model?: string;
+    providerId?: string;
     effort?: 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max' | 'ultra';
     fast?: boolean;
     workerPermissionMode?: OrcaWorkerPermissionMode;
@@ -1669,9 +1670,24 @@ interface OrcaCollabService {
   listAvailableModels: (params: { agent?: AgentKind }) => Promise<
     | {
         ok: true;
-        codex?: Array<{ id: string; label: string }>;
-        claude_code?: Array<{ id: string; label: string }>;
-        pi?: Array<{ id: string; label: string }>;
+        codex?: Array<{
+          id: string;
+          label: string;
+          providers?: Array<{ id: string; name: string }>;
+          defaultProviderId?: string | null;
+        }>;
+        claude_code?: Array<{
+          id: string;
+          label: string;
+          providers?: Array<{ id: string; name: string }>;
+          defaultProviderId?: string | null;
+        }>;
+        pi?: Array<{
+          id: string;
+          label: string;
+          providers?: Array<{ id: string; name: string }>;
+          defaultProviderId?: string | null;
+        }>;
       }
     | { ok: false; errorCode: string; message: string }
   >;
@@ -9979,12 +9995,26 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
     listAvailableModels: async ({ agent }) => {
       try {
         const agents: AgentKind[] = agent ? [agent] : ['codex', 'claude-code', 'pi'];
-        const result: Record<string, Array<{ id: string; label: string }>> = {};
+        const providerRouting = await getProviderRoutingContext();
+        const result: Record<string, Array<{
+          id: string;
+          label: string;
+          providers: Array<{ id: string; name: string }>;
+          defaultProviderId: string | null;
+        }>> = {};
         for (const a of agents) {
           const caps = maker.getCapabilities(a);
           // key 必须区分 pi,否则 pi 模型会被塞进 claude_code 键与 CC 模型混淆。
           const key = a === 'codex' ? 'codex' : a === 'pi' ? 'pi' : 'claude_code';
-          result[key] = caps.availableModels.map((m) => ({ id: m.id, label: m.displayName }));
+          const providers = providerRouting.availability[a] ?? [];
+          result[key] = caps.availableModels.map((m) => ({
+            id: m.id,
+            label: m.displayName,
+            providers: providers
+              .filter((provider) => provider.models.includes(m.id))
+              .map((provider) => ({ id: provider.id, name: provider.name })),
+            defaultProviderId: providerRouting.resolveDefaultProviderIdForModel(a, m.id),
+          }));
         }
         return { ok: true, ...result };
       } catch (err) {

--- a/packages/lizi-mcps/src/__tests__/createWorkerTool.test.ts
+++ b/packages/lizi-mcps/src/__tests__/createWorkerTool.test.ts
@@ -142,10 +142,29 @@ describe('create_worker tool', () => {
       agent: 'codex',
       label: 'reviewer_1',
       model: undefined,
+      providerId: undefined,
       effort: undefined,
       fast: undefined,
       initialTask: undefined,
     });
+  });
+
+  it('trims and forwards provider_id to the host creation boundary', async () => {
+    const { registry, createWorker } = setup();
+
+    const res = await registry.call('create_worker', {
+      role: 'reviewer',
+      agent: 'codex',
+      model: 'deepseek/deepseek-v4-pro',
+      provider_id: ' xd ',
+      label: 'reviewer_1',
+    });
+
+    expect(res.isError).toBeUndefined();
+    expect(createWorker).toHaveBeenCalledWith(expect.objectContaining({
+      model: 'deepseek/deepseek-v4-pro',
+      providerId: 'xd',
+    }));
   });
 
   it('accepts pi as a first-class worker agent and passes it through to host', async () => {

--- a/packages/lizi-mcps/src/__tests__/createWorkersTool.test.ts
+++ b/packages/lizi-mcps/src/__tests__/createWorkersTool.test.ts
@@ -93,6 +93,28 @@ describe('create_workers tool', () => {
     expect(createWorker).not.toHaveBeenCalled();
   });
 
+  it('forwards each worker provider_id through the shared batch schema', async () => {
+    const createWorker = vi.fn<CreateWorkerDeps['createWorker']>(async (_params) => created(1, 8));
+    const registry = setup(createWorker);
+
+    const result = await registry.call('create_workers', {
+      workers: [
+        { ...worker(1), model: 'deepseek/deepseek-v4-pro', provider_id: 'xd' },
+        { ...worker(2), model: 'gpt-5.5', provider_id: 'openai' },
+      ],
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(createWorker).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      model: 'deepseek/deepseek-v4-pro',
+      providerId: 'xd',
+    }));
+    expect(createWorker).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      model: 'gpt-5.5',
+      providerId: 'openai',
+    }));
+  });
+
   it('stops a hard=3 batch after the first limit failure and summarizes all nine requests', async () => {
     let call = 0;
     const createWorker = vi.fn<CreateWorkerDeps['createWorker']>(async () => {

--- a/packages/lizi-mcps/src/__tests__/listAvailableModelsTool.test.ts
+++ b/packages/lizi-mcps/src/__tests__/listAvailableModelsTool.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { XdtHelperToolRegistry } from '../lizi_xdtHelperToolRegistry.js';
+import type { XdtHelperToolResult } from '../lizi_xdtHelperToolRegistry.js';
+import { registerListAvailableModelsTool } from '../xdt-helper/list_available_models.js';
+
+function parse(result: XdtHelperToolResult) {
+  const [block] = result.content;
+  if (block?.type !== 'text') throw new Error('Expected first MCP content block to be text');
+  return JSON.parse(block.text);
+}
+
+describe('list_available_models tool', () => {
+  it('returns provider-aware routes without removing the existing model fields', async () => {
+    const listAvailableModels = vi.fn(async () => ({
+      ok: true as const,
+      codex: [{
+        id: 'deepseek/deepseek-v4-pro',
+        label: 'DeepSeek V4 Pro',
+        providers: [{ id: 'xd', name: 'XD Gateway' }],
+        defaultProviderId: 'xd',
+      }],
+    }));
+    const registry = new XdtHelperToolRegistry();
+    registerListAvailableModelsTool(registry, { listAvailableModels });
+
+    const result = parse(await registry.call('list_available_models', { agent: 'codex' }));
+
+    expect(result.codex).toEqual([{
+      id: 'deepseek/deepseek-v4-pro',
+      label: 'DeepSeek V4 Pro',
+      tier: 'standard',
+      providers: [{ provider_id: 'xd', provider_name: 'XD Gateway' }],
+      default_provider_id: 'xd',
+    }]);
+  });
+});

--- a/packages/lizi-mcps/src/orca/server.ts
+++ b/packages/lizi-mcps/src/orca/server.ts
@@ -52,6 +52,7 @@ import {
   registerEndTeamTool,
   registerArchiveWorkerTool,
   registerListAvailableModelsTool,
+  type ModelDescriptor,
   type QueuedMessageControlErrorCode,
   type WorkerQueuedMessageEntry,
   type WorkerSummary,
@@ -91,6 +92,7 @@ export interface OrcaMcpDeps {
     role: string;
     agent: ControlWorkerAgent;
     model?: string;
+    providerId?: string;
     effort?: 'low' | 'medium' | 'high' | 'xhigh' | 'max' | 'ultra';
     fast?: boolean;
     label: string;
@@ -173,9 +175,9 @@ export interface OrcaMcpDeps {
   /** 列出 agent 可用 model 清单。 */
   listAvailableModels: (params: { agent?: ControlWorkerAgent }) => Promise<
     ControlResult<{
-      codex?: Array<{ id: string; label: string }>;
-      claude_code?: Array<{ id: string; label: string }>;
-      pi?: Array<{ id: string; label: string }>;
+      codex?: ModelDescriptor[];
+      claude_code?: ModelDescriptor[];
+      pi?: ModelDescriptor[];
     }>
   >;
   /** 只读诊断：列出当前 Orca workflow 与 worker sessions。 */

--- a/packages/lizi-mcps/src/xdt-helper/create_worker.ts
+++ b/packages/lizi-mcps/src/xdt-helper/create_worker.ts
@@ -53,6 +53,7 @@ export interface CreateWorkerDeps {
     role: string;
     agent: ControlWorkerAgent;
     model?: string;
+    providerId?: string;
     effort?: 'low' | 'medium' | 'high' | 'xhigh' | 'max' | 'ultra';
     fast?: boolean;
     label: string;
@@ -74,6 +75,13 @@ export const createWorkerSpecSchema = z.object({
     .string()
     .optional()
     .describe('可选, worker 使用的模型 id; 不传走 host 端默认 fallback'),
+  provider_id: z
+    .string()
+    .trim()
+    .min(1)
+    .max(128)
+    .optional()
+    .describe('可选, 模型来源 provider id; 应使用 list_available_models 返回的 provider_id, 不传则由 host 按当前可用来源解析'),
   effort: z
     .enum(['low', 'medium', 'high', 'xhigh', 'max', 'ultra'])
     .optional()
@@ -118,6 +126,7 @@ const DESCRIPTION = [
   '- role: worker 角色 (developer / reviewer / tester / merger 或自定义 string)',
   '- agent: worker agent 类型 (codex / claude-code / pi)',
   '- model: 可选, worker 使用的模型 id; 不传走 host 端默认 fallback',
+  '- provider_id: 可选, 模型来源 provider id。优先使用 list_available_models 对应模型返回的 provider_id；显式传入后 host 会严格校验该来源已连接且提供所选模型。',
   '- effort: 可选, reasoning/thinking 强度 (low / medium / high / xhigh / max / ultra)。Codex: 映射 OpenAI reasoning effort(max/ultra 仅部分模型如 GPT-5.6 Sol 支持); Claude Code: 映射 extended thinking token 预算(无 ultra,自动降级为 max)。显式传入时必须匹配所选 model 能力；当前 worker 模型都不把 minimal 作为可选思考档。',
   '- fast: 可选 boolean, 是否给 worker 开启 Fast 模式 (更快输出)。用户明确说「fast / 快速 / 开/关 fast」时显式传。对 codex 与 pi worker 生效 (且需所选模型声明 supportsFastMode; 否则自动降级为关); claude-code worker 忽略此参数 (其 fast mode 在 agent 层为 no-op)。不传则继承默认 (New Maker 面板默认或 lead session 的 fastMode)。',
   '- label: worker 短标识, 1-32 chars, 只能含字母、数字、-、_, 同 workflow 内唯一, 用于 switch_focus 定位',
@@ -144,7 +153,7 @@ export function registerCreateWorkerTool(
     category: 'control',
     description: DESCRIPTION,
     inputShape: createWorkerSpecSchema.shape,
-    handler: async ({ role, agent, model, effort, fast, label, initial_task }) => {
+    handler: async ({ role, agent, model, provider_id, effort, fast, label, initial_task }) => {
       const ctx = deps.getSessionContext?.() ?? deps;
       if (!ctx.sessionId) {
         return errorPayload('LEAD_NOT_SUPPORTED', '当前 session 类型不支持作为 Lead。');
@@ -160,6 +169,7 @@ export function registerCreateWorkerTool(
         role,
         agent,
         model,
+        providerId: provider_id,
         effort,
         fast,
         label,

--- a/packages/lizi-mcps/src/xdt-helper/create_workers.ts
+++ b/packages/lizi-mcps/src/xdt-helper/create_workers.ts
@@ -148,6 +148,7 @@ export function registerCreateWorkersTool(
           role: worker.role,
           agent: worker.agent,
           model: worker.model,
+          providerId: worker.provider_id,
           effort: worker.effort,
           fast: worker.fast,
           label: worker.label,

--- a/packages/lizi-mcps/src/xdt-helper/index.ts
+++ b/packages/lizi-mcps/src/xdt-helper/index.ts
@@ -90,6 +90,7 @@ export {
 export {
   registerListAvailableModelsTool,
   type ListAvailableModelsDeps,
+  type ModelDescriptor,
 } from './list_available_models.js';
 // history tools (split out from xdt-helper but kept exports here)
 export {

--- a/packages/lizi-mcps/src/xdt-helper/list_available_models.ts
+++ b/packages/lizi-mcps/src/xdt-helper/list_available_models.ts
@@ -13,13 +13,21 @@ import { okPayload, errorPayload } from './_payload.js';
 export interface ModelDescriptor {
   id: string;
   label: string;
+  /** 当前已连接且可为该 agent 路由此模型的来源。 */
+  providers?: Array<{ id: string; name: string }>;
+  /** 未显式指定来源时,host 当前会采用的 provider id。 */
+  defaultProviderId?: string | null;
 }
 
 /** tier: 'budget' = codex/ 前缀的 gateway 折扣路由, 'standard' = 官方原版。仅出现在返回值, 供 agent 精准选型。 */
 type ModelTier = 'budget' | 'standard';
 
-interface TaggedModel extends ModelDescriptor {
+interface TaggedModel {
+  id: string;
+  label: string;
   tier: ModelTier;
+  providers?: Array<{ provider_id: string; provider_name: string }>;
+  default_provider_id?: string | null;
 }
 
 /**
@@ -34,8 +42,20 @@ interface TaggedModel extends ModelDescriptor {
 function tagTier(models: ModelDescriptor[] | undefined): TaggedModel[] | undefined {
   if (!models) return undefined;
   return models.map((m) => ({
-    ...m,
+    id: m.id,
+    label: m.label,
     tier: m.id.startsWith('codex/') ? 'budget' : 'standard',
+    ...(m.providers
+      ? {
+          providers: m.providers.map((provider) => ({
+            provider_id: provider.id,
+            provider_name: provider.name,
+          })),
+        }
+      : {}),
+    ...(m.defaultProviderId !== undefined
+      ? { default_provider_id: m.defaultProviderId }
+      : {}),
   }));
 }
 
@@ -54,11 +74,14 @@ const DESCRIPTION = [
   'Codex 和 Claude Code 支持的 model 完全不同, 不可跨用。',
   '',
   '参数:',
-  '- agent: 可选, codex 或 claude-code; 不传返两者',
+  '- agent: 可选, codex / claude-code / pi; 不传返三者',
   '',
   '返回值:',
-  '- codex: Codex agent 的可用 model 列表 [{id, label, tier}]',
-  '- claude_code: Claude Code agent 的可用 model 列表 [{id, label, tier}]',
+  '- codex: Codex agent 的可用 model 列表 [{id, label, tier, providers, default_provider_id}]',
+  '- claude_code: Claude Code agent 的可用 model 列表 [{id, label, tier, providers, default_provider_id}]',
+  '- pi: Pi agent 的可用 model 列表 [{id, label, tier, providers, default_provider_id}]',
+  '- providers: 当前已连接且实际提供该模型的来源 [{provider_id, provider_name}]。创建 Worker 时把选定的 provider_id 原样传给 create_worker/create_workers。',
+  '- default_provider_id: 未显式选择来源时 host 当前解析出的默认来源；providers 只有一项时直接使用该项。',
   '',
   'tier 字段 (用于精准选型, 不要靠 label 推断):',
   "- tier='budget': codex/ 前缀的 gateway 折扣路由 (如 codex/gpt-5.5)",


### PR DESCRIPTION
<!--
PR Title 不是下面的正文标题，而是 GitHub PR 页面最上方的标题。
格式：<type>(<scope>): <简短描述>（scope 可省略）

type：feat / fix / refactor / perf / chore / docs / test / revert / build / ci
示例：docs(readme): 补充本地模式与远程开发说明；fix: 修复登录跳转
-->

## 这次改了什么

### 摘要

修复 MCP 创建 Worker 时未携带模型来源，导致同一个 DeepSeek 模型在预检阶段使用 XD 网关、实际启动时却回落到 Codex ChatGPT 认证链路的问题。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：为 `create_worker` / `create_workers` 增加可选 `provider_id`；在模型清单中返回 provider 元数据；显式模型只有一个运行时来源时固化该来源；补充回归测试
- 明确不包含：UI、移动端、服务端、模型供应商配置方式调整
- 用户可见变化：通过 MCP 创建第三方网关模型 Worker 时会使用正确的模型来源，不再误走 ChatGPT 认证链路
- 是否存在 breaking change：无；新增字段均为可选，既有调用保持兼容

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：通过；apps/desktop unit 与 packages/lizi-mcps related 全部通过

pnpm --filter @cindy/mcps run build
结果：通过

pnpm --filter desktop run typecheck
结果：通过

pnpm --filter @cindy/mcps exec vitest run src/__tests__/createWorkerTool.test.ts src/__tests__/createWorkersTool.test.ts src/__tests__/listAvailableModelsTool.test.ts
结果：3 个文件、19 项测试通过

pnpm --filter desktop exec vitest run src/main/maker-ipc/__tests__/orcaWorkerCreationService.test.ts
结果：1 个文件、95 项测试通过

node scripts/test-workspaces.mjs --tier unit
结果：全部 required workspace unit 通过，包括 Desktop、Mobile 与共享 packages

pnpm check:dco
结果：通过；1 个 commit 已签名
```

### 手工验证

- Windows Global 隔离沙盒：`pnpm restart:desktop:remote --region=global --isolated=provider-route-blackbox`
- 用户确认 MCP 创建 DeepSeek V4 Pro Worker 的黑盒测试通过

### 未执行的验证

- 根命令 `pnpm test:unit` 的 runner 阶段有 1 项环境失败：当前 Windows 进程无目录符号链接创建权限，`symlinkSync` 返回 `EPERM`；其余 runner 测试 398 项通过、8 项跳过。随后单独执行完整 workspace unit sweep，全部通过

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop Orca Worker 创建链路与 MCP Worker 创建工具；provider 信息来自运行时 registry，没有按模型名或 `xd` 写死
- 回滚 / 降级方式：回退本 PR commit 后恢复原有默认路由行为；调用方也可不传新增的可选字段
- 移动端冷更判断：不涉及 `apps/mobile`、原生配置、原生依赖或 runtime fingerprint 输入，不触发冷更

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [ ] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [ ] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因