### PR TITLE
feat(model-providers): expose max and ultra for custom Codex models

### DIFF
--- a/packages/model-providers/src/__tests__/user-provider.test.ts
+++ b/packages/model-providers/src/__tests__/user-provider.test.ts
@@ -107,7 +107,7 @@ describe('buildUserProvider (per-runtime)', () => {
     expect(p.routing.codex?.requestPath).toBe('/tenant/acme/v2/infer?stream=1');
   });
 
-  it('maps models per runtime with conservative default metadata', () => {
+  it('maps models per runtime with max/ultra available and high selected by default', () => {
     const p = buildUserProvider(codexOnly);
     const models = p.models.codex ?? [];
     expect(models.map((m) => m.id)).toEqual(['meta/llama-4-405b', 'qwen/qwen3-max']);
@@ -115,8 +115,8 @@ describe('buildUserProvider (per-runtime)', () => {
       id: 'meta/llama-4-405b',
       name: 'Llama 4 405B',
       contextWindow: DEFAULT_CUSTOM_CONTEXT_WINDOW,
-      // codex runtime：参考内置默认 effort 档位（low/medium/high/xhigh，默认 high）。
-      efforts: ['low', 'medium', 'high', 'xhigh'],
+      // codex runtime：放开原生 max/ultra effort，默认仍保持 high。
+      efforts: ['low', 'medium', 'high', 'xhigh', 'max', 'ultra'],
       defaultEffort: 'high',
       group: 'custom:openrouter',
       defaultEnabled: true,
@@ -189,7 +189,7 @@ describe('buildUserProvider (per-runtime)', () => {
       }),
       expect.objectContaining({
         id: 'unregistered-model',
-        efforts: ['low', 'medium', 'high', 'xhigh'],
+        efforts: ['low', 'medium', 'high', 'xhigh', 'max', 'ultra'],
         defaultEffort: 'high',
       }),
     ]);
@@ -228,7 +228,7 @@ describe('buildUserProvider (per-runtime)', () => {
       { modelRegistry: registry },
     );
     expect(ambiguous.models.codex?.[0]).toMatchObject({
-      efforts: ['low', 'medium', 'high', 'xhigh'],
+      efforts: ['low', 'medium', 'high', 'xhigh', 'max', 'ultra'],
       defaultEffort: 'high',
     });
 
@@ -265,7 +265,7 @@ describe('buildUserProvider (per-runtime)', () => {
       { modelRegistry: BUNDLED_CATALOG.modelRegistry },
     );
     expect(noTargetRoute.models.codex?.[0]).toMatchObject({
-      efforts: ['low', 'medium', 'high', 'xhigh'],
+      efforts: ['low', 'medium', 'high', 'xhigh', 'max', 'ultra'],
       defaultEffort: 'high',
     });
   });

--- a/packages/model-providers/src/user-provider.ts
+++ b/packages/model-providers/src/user-provider.ts
@@ -44,14 +44,14 @@ export function storedCustomProviderId(providerId: string): string {
 /**
  * 自定义模型的默认 effort 档位（「参考默认设置」）——与内置当代旗舰模型对齐：
  *   - claude-code：low/medium/high/xhigh/max（同 opus / fable）；
- *   - codex：low/medium/high/xhigh（同 gpt-5.x）。
+ *   - codex：low/medium/high/xhigh/max/ultra（按 Codex 原生 reasoning effort 透传）。
  * 让自定义模型像内置模型一样能在选择器里切 reasoning/thinking 强度（默认 high）。
  * 端点是否真支持由其后端决定：cc 经 `thinking`、codex 经 reasoning effort 透传，
  * anthropic-compat-proxy 仅对个别内置 model id strip 字段、对自定义 id 一律字节透传。
  */
 const CUSTOM_EFFORTS: Partial<Record<AgentKind, Effort[]>> = {
   'claude-code': ['low', 'medium', 'high', 'xhigh', 'max'],
-  codex: ['low', 'medium', 'high', 'xhigh'],
+  codex: ['low', 'medium', 'high', 'xhigh', 'max', 'ultra'],
 };
 /** 自定义模型默认选中的 effort（与内置旗舰一致）。 */
 const DEFAULT_CUSTOM_EFFORT: Effort = 'high';


### PR DESCRIPTION
## 这次改了什么

### 摘要

让未命中内置模型目录的自定义 Codex 模型也显示原生 `max` 与 `ultra` 思考强度，同时保留 `high` 为默认值，不会自动增加 subagent 或 API 消耗。

### 变更类型

- [x] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：自定义模型供应商的 Codex 思考强度缺少 `max` / `ultra`
- 本 PR 包含：扩展自定义 Codex 的 fallback effort 清单，并更新映射单元测试
- 明确不包含：修改 Claude Code 或 Pi 的能力清单、改变任一引擎的默认 effort、数据库、协议或 UI
- 用户可见变化：自定义 Codex 模型的强度列表新增 `max` 与 `ultra`；默认仍为 `high`
- 是否存在 breaking change：无

### UI 变化

不涉及：只调整传给既有选择器的模型能力元数据，没有修改 UI 代码、布局或文案。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：通过；test runner、Desktop、Mobile 与 model-providers 关联门禁全部通过

pnpm --filter @cindy/model-providers run test
结果：通过，18 个测试文件、541 个用例全部通过

Desktop providerCatalogRealmReload.test.ts
结果：通过，24 个用例全部通过

pnpm --filter @cindy/model-providers run --if-present typecheck
结果：通过；该 package 未定义 typecheck script，按仓库门禁约定跳过

pnpm check:dco
结果：通过，1 个提交签名有效
```

### 手工验证

未启动或重启 Desktop；本次只改模型能力元数据与单元测试。

### 未执行的验证

无额外手工 UI 验证。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：自定义端点仍需实际支持所选的 Codex `max` / `ultra` 档位

### 影响与回滚

- 影响范围：仅自定义供应商中未命中 Registry 的 Codex 模型；Registry 已声明的能力保持不变
- 默认行为：仍选择 `high`，只有用户手动选择 `max` / `ultra` 才提高消耗
- 回滚 / 降级方式：用户可选择较低 effort；代码层可回退本提交

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因