### PR TITLE
fix(desktop): 修复插件账号归属与市场来源恢复

### DIFF
--- a/apps/desktop/src/main/__tests__/authSessionExpiredDetection.test.ts
+++ b/apps/desktop/src/main/__tests__/authSessionExpiredDetection.test.ts
@@ -185,7 +185,7 @@ describe('desktop auth session-expiry detection', () => {
     );
   });
 
-  it('requires every Ghost runtime lookup to match the durable projection owner', () => {
+  it('gates Ghost runtime lookups only on the process-local AppSession boundary', () => {
     const ghostSource = readFileSync(
       resolve(process.cwd(), 'src/main/cindy-brain/index.ts'),
       'utf8',
@@ -193,23 +193,23 @@ describe('desktop auth session-expiry detection', () => {
     const start = ghostSource.indexOf('export function isGhostAvailableForActiveSession(');
     const end = ghostSource.indexOf('\n}\n', start);
     const body = ghostSource.slice(start, end);
-    expect(body).toContain('isGhostSkillProjectionBoundaryStableForOwner(activeOwner)');
+    expect(body).toContain('isAppSessionBoundaryPending()');
+    expect(body).toContain('getAppCapabilities().canUseCindyAccountServices');
+    expect(body).not.toContain('isGhostSkillProjectionBoundaryStableForOwner');
 
     const requireStart = ghostSource.indexOf('function requireGhostAvailableForActiveSession(');
     const requireEnd = ghostSource.indexOf('\n}\n', requireStart);
     const requireBody = ghostSource.slice(requireStart, requireEnd);
     expect(requireBody).toContain("throwIpcError(\n        'PRECONDITION_FAILED'");
     expect(requireBody).toContain('isAppSessionBoundaryPending()');
-    // A durable Ghost owner mismatch must stay a retryable precondition error
-    // (not a misleading PERMISSION_DENIED) even when the App session itself is
-    // not switching. The owner-stable check has to sit inside the
-    // PRECONDITION_FAILED branch, so require it to appear before the
-    // PERMISSION_DENIED throw — otherwise a regression that moves it into the
-    // permission branch would still pass a mere toContain.
-    const ownerStableIndex = requireBody.indexOf('!isGhostSkillProjectionBoundaryStableForOwner(activeOwner)');
+    expect(requireBody).not.toContain('isGhostSkillProjectionBoundaryStableForOwner');
+    // The durable Ghost projection is shared by sibling instances and is not a
+    // runtime authorization source. Only this process's active owner switch is
+    // retryable; a settled session without account capability remains denied.
+    const boundaryPendingIndex = requireBody.indexOf('isAppSessionBoundaryPending()');
     const permissionDeniedIndex = requireBody.indexOf("'PERMISSION_DENIED'");
-    expect(ownerStableIndex).toBeGreaterThan(-1);
+    expect(boundaryPendingIndex).toBeGreaterThan(-1);
     expect(permissionDeniedIndex).toBeGreaterThan(-1);
-    expect(ownerStableIndex).toBeLessThan(permissionDeniedIndex);
+    expect(boundaryPendingIndex).toBeLessThan(permissionDeniedIndex);
   });
 });

--- a/apps/desktop/src/main/cindy-brain/GhostManager.ts
+++ b/apps/desktop/src/main/cindy-brain/GhostManager.ts
@@ -167,6 +167,15 @@ export interface GhostManagerLogger {
   error?(message: string, meta?: Record<string, unknown>): void;
 }
 
+export interface ApprovedGhostInstallEvidence {
+  /** Immutable package hash when the approval came from a modern install/update. */
+  packageSha256: string | null;
+  /** Unlocalized manifest frozen in the Host approval receipt. */
+  approvedManifest: GhostManifest;
+  /** True only when the completed one-time migration explicitly recorded this id. */
+  legacyMigrated: boolean;
+}
+
 export interface GhostManagerOptions {
   /** 意识仓库根目录(生产:userData/cindy-brain;测试:os.tmpdir 下临时目录)。 */
   getRootDir: () => string;
@@ -1039,6 +1048,30 @@ export class GhostManager {
 
   approvalStateRoot(): string {
     return this.receiptStore.rootDir();
+  }
+
+  /**
+   * Host-owned evidence for reconnecting an installation to retained source metadata.
+   * A pending package mutation or an invalid approval fails closed. Legacy provenance
+   * is accepted only from the completed one-time migration's explicit id list.
+   */
+  approvedInstallEvidence(id: string): ApprovedGhostInstallEvidence | null {
+    this.ensureCurrentOwnerContextSync();
+    if (!isValidGhostId(id) || this.hasPendingMutationJournal(id)) return null;
+    const approval = this.readApproval(id);
+    if (approval.state !== 'approved') return null;
+    const packageSha256 = approval.receipt.packageSha256;
+    const migration = this.receiptStore.readMigrationLedger();
+    return {
+      packageSha256:
+        packageSha256 && /^[a-f0-9]{64}$/.test(packageSha256) ? packageSha256 : null,
+      approvedManifest: approval.receipt.manifest,
+      legacyMigrated: Boolean(
+        migration
+        && migration.state !== 'in-progress'
+        && migration.migratedIds.includes(id)
+      ),
+    };
   }
 
   /**

--- a/apps/desktop/src/main/cindy-brain/__tests__/GhostManager.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/GhostManager.test.ts
@@ -271,6 +271,11 @@ describe('GhostManager · 存量插件一次性迁移(§5 升级无感)', () => 
       approval: { state: 'approved' },
     });
     expect(fs.existsSync(migrationLedgerPath())).toBe(true);
+    expect(manager.approvedInstallEvidence('hello')).toMatchObject({
+      packageSha256: null,
+      approvedManifest: { id: 'hello', version: '1.0.0' },
+      legacyMigrated: true,
+    });
   });
 
   it('带 setup.kv 的旧安装无感迁移并保留标准化就绪声明', async () => {

--- a/apps/desktop/src/main/cindy-brain/__tests__/connectionAudienceResolver.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/connectionAudienceResolver.test.ts
@@ -85,6 +85,11 @@ describe('installed Plugin Connection audience resolver', () => {
       resolverOptions(manifest, { ...marketInstallation, source: 'local-market' }),
     );
     expect(resolver.resolve('plugin-a', identity)).toBeNull();
+    expect(
+      loadConnectionAudienceResolver(
+        resolverOptions(manifest, { ...marketInstallation, source: 'legacy-adopted' }),
+      ).resolve('plugin-a', identity),
+    ).toBeNull();
 
     expect(
       loadConnectionAudienceResolver(

--- a/apps/desktop/src/main/cindy-brain/__tests__/marketGhostSessionBoundary.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/marketGhostSessionBoundary.test.ts
@@ -22,8 +22,8 @@ describe('market Ghost session boundary', () => {
     const captureEnd = source.indexOf('\n}\n', captureStart);
     const captureBody = source.slice(captureStart, captureEnd);
     expect(captureBody).toContain('isAppSessionBoundaryPending()');
-    expect(captureBody).toContain('const owner = getActiveAppSession();');
-    expect(captureBody).toContain('isGhostSkillProjectionBoundaryStableForOwner(owner.dataOwnerId)');
+    expect(captureBody).toContain('return getActiveAppSession();');
+    expect(captureBody).not.toContain('isGhostSkillProjectionBoundaryStableForOwner');
 
     const leaseStart = source.indexOf(
       'function beginGhostMutation(expectedOwner?: ActiveAppSession): () => void {',
@@ -34,6 +34,7 @@ describe('market Ghost session boundary', () => {
     expect(leaseBody).toContain('currentOwner.mode !== expectedOwner.mode');
     expect(leaseBody).toContain('currentOwner.dataOwnerId !== expectedOwner.dataOwnerId');
     expect(leaseBody).toContain('currentOwner.generation !== expectedOwner.generation');
+    expect(leaseBody).not.toContain('isGhostSkillProjectionBoundaryStableForOwner');
   });
 
   it('captures before async inspection but leases only after Node authorization', () => {
@@ -192,24 +193,22 @@ describe('market Ghost session boundary', () => {
     expect(body).toContain("throwIpcError('INTERNAL', 'Unable to detach the installed Plugin source');");
   });
 
-  it('Ghost 媒体在途守卫注入 durable owner 组合条件,而不是退化成只看进程内边界', () => {
+  it('Ghost 媒体在途守卫只依赖当前进程的 AppSession owner 边界', () => {
     const helperStart = source.indexOf('function isGhostBoundaryPending(): boolean {');
     expect(helperStart).toBeGreaterThan(-1);
     const helperEnd = source.indexOf('\n}\n', helperStart);
     const helperBody = source.slice(helperStart, helperEnd);
-    // helper 必须是组合条件:进程内 App boundary + durable projection owner 稳定性。
     expect(helperBody).toContain('isAppSessionBoundaryPending()');
-    expect(helperBody).toContain('isGhostSkillProjectionBoundaryStableForOwner');
+    expect(helperBody).not.toContain('isGhostSkillProjectionBoundaryStableForOwner');
     // 两处 Ghost 专属消费点(xAI 通道与 GhostCindySlot)都必须走 helper。
     const injections =
       source.match(/isOwnerBoundaryPending: \(\) => isGhostBoundaryPending\(\)/g)?.length ?? 0;
     expect(injections).toBeGreaterThanOrEqual(2);
   });
 
-  it('Ghost 媒体持久化写入守卫(resolveOwnedMedia/saveGhostMedia)也用 durable owner 组合条件', () => {
+  it('Ghost 媒体持久化写入守卫也绑定当前进程的 owner scope', () => {
     // 这两处是 GhostCindySlot 的 deps,内部 assertStillValid 会在 ingestMedia 的
-    // await 边界反复断言。持久化写入守卫必须和入口/生成守卫一样用 isGhostBoundaryPending,
-    // 否则另一实例在落盘窗口翻转 durable owner 时,字节仍会被登记为 ghost-gallery ref。
+    // await 边界反复断言。持久化写入守卫必须同时检查本进程边界与 scope generation。
     const resolveStart = source.indexOf('resolveOwnedMedia: async (ghostId, hash, ownerScopeKey)');
     const saveStart = source.indexOf('saveGhostMedia: async ({ ghostId, buffer, mimeType, ownerScopeKey');
     expect(resolveStart).toBeGreaterThan(-1);
@@ -219,15 +218,15 @@ describe('market Ghost session boundary', () => {
     const combinedGuard = 'isGhostBoundaryPending() || activeOwnerScopeKey() !== ownerScopeKey';
     expect(resolveBody).toContain(combinedGuard);
     expect(saveBody).toContain(combinedGuard);
-    // 持久化守卫不得退化回只看进程内边界的旧写法。
+    // generation 不能退化成只看 pending 位。
     expect(source).not.toContain('isAppSessionBoundaryPending() || activeOwnerScopeKey() !== ownerScopeKey');
   });
 
-  it('networkSlot 的 saveGhostMedia(as:media fetch 落仓)也用 durable owner 组合条件', () => {
+  it('networkSlot 的 saveGhostMedia(as:media fetch 落仓)也绑定本地 owner scope', () => {
     // networkSlot 与 cindy 槽是两个独立实现,签名不带 ownerScopeKey(在函数体开头
     // 捕获)。它的落仓路径(ghost-gallery 作品归属 + recordGhostCallMedia)必须同样
-    // 有 durable owner 守卫 + assertStillValid + 补偿 journal,否则 as:'media' fetch
-    // 读取窗口内 durable owner 翻转时仍会落仓到错误 owner 的画廊。
+    // 有本地 owner 守卫 + assertStillValid + 补偿 journal,否则账号切换期间的
+    // as:'media' fetch 仍可能落仓到错误 owner 的画廊。
     const networkStart = source.indexOf('saveGhostMedia: async ({ ghostId, buffer, mimeType, label, callId }) =>');
     expect(networkStart).toBeGreaterThan(-1);
     const networkBody = source.slice(networkStart, networkStart + 1800);
@@ -237,9 +236,9 @@ describe('market Ghost session boundary', () => {
     expect(networkBody).toContain('refCompensationScope: captureMediaRefCompensationScope(ownerScopeKey)');
   });
 
-  it('depositMedia(ghost-deposit 寄存器落仓)也用 durable owner 组合条件', () => {
+  it('depositMedia(ghost-deposit 寄存器落仓)也绑定本地 owner scope', () => {
     // 寄存器引用按 ghostId 落到 owner 作用域账本(originKind:'user' 但 refId 仍是意识),
-    // 落仓窗口翻转全局 owner 时必须 fail closed,与 saveGhostMedia 同口径。
+    // 本进程账号切换时必须 fail closed,与 saveGhostMedia 同口径。
     const depositStart = source.indexOf('depositMedia: async ({ ghostId, buffer, mimeType, label }) =>');
     expect(depositStart).toBeGreaterThan(-1);
     const depositBody = source.slice(depositStart, depositStart + 1800);

--- a/apps/desktop/src/main/cindy-brain/ghostOwnerScope.ts
+++ b/apps/desktop/src/main/cindy-brain/ghostOwnerScope.ts
@@ -5,7 +5,7 @@ export interface GhostOwnerScope {
   capture(): unknown;
   /** Check the captured in-process owner and generation. */
   isCurrent(scope: unknown): boolean;
-  /** Check the durable projection marker for the captured owner. */
+  /** Check that the captured process-local owner boundary is still settled. */
   isStable(scope: unknown): boolean;
   /** Stop stale runtime work and discard owner-bound buffered work. */
   onInvalidated?(ghostId: string): void;

--- a/apps/desktop/src/main/cindy-brain/index.ts
+++ b/apps/desktop/src/main/cindy-brain/index.ts
@@ -51,10 +51,7 @@ import type {
   PluginMarketPackageReviewFacts,
 } from '../../shared/pluginMarket.js';
 import { getAppCapabilities } from '../appCapabilities.js';
-import {
-  isGhostSkillProjectionBoundaryStableForOwner,
-  withGhostSkillProjectionReconcile,
-} from '../authBoundaryQuarantine.js';
+import { withGhostSkillProjectionReconcile } from '../authBoundaryQuarantine.js';
 import {
   activeOwnerScopeKey,
   getActiveDataOwnerPushStamp,
@@ -510,11 +507,7 @@ function captureGhostMutationOwner(): ActiveAppSession {
   if (isAppSessionBoundaryPending()) {
     throw new Error('账号切换中，已取消本次 Plugin 操作');
   }
-  const owner = getActiveAppSession();
-  if (!isGhostSkillProjectionBoundaryStableForOwner(owner.dataOwnerId)) {
-    throw new Error('Plugin owner boundary is not durably stable');
-  }
-  return owner;
+  return getActiveAppSession();
 }
 
 /**
@@ -528,9 +521,6 @@ function beginGhostMutation(expectedOwner?: ActiveAppSession): () => void {
     throw new Error('账号切换中，已取消本次 Plugin 操作');
   }
   const currentOwner = getActiveAppSession();
-  if (!isGhostSkillProjectionBoundaryStableForOwner(currentOwner.dataOwnerId)) {
-    throw new Error('Plugin owner boundary is not durably stable');
-  }
   if (expectedOwner) {
     if (
       currentOwner.mode !== expectedOwner.mode ||
@@ -561,9 +551,9 @@ const ghostOwnerScope: GhostOwnerScope = {
   isCurrent: (scope) =>
     !!scope && isSameAppSession(scope as ActiveAppSession, getActiveAppSession()),
   isStable: (scope) =>
-    !!scope && isGhostSkillProjectionBoundaryStableForOwner(
-      (scope as ActiveAppSession).dataOwnerId,
-    ),
+    !!scope
+    && !isAppSessionBoundaryPending()
+    && isSameAppSession(scope as ActiveAppSession, getActiveAppSession()),
   onInvalidated: (ghostId) => {
     try {
       getGhostRuntime().stop(ghostId);
@@ -830,8 +820,7 @@ export function waitForGhostMutations(): Promise<void> {
 
 /** Account-managed built-ins are unavailable outside a verified cloud session. */
 export function isGhostAvailableForActiveSession(id: string): boolean {
-  const activeOwner = getActiveAppSession().dataOwnerId;
-  if (!isGhostSkillProjectionBoundaryStableForOwner(activeOwner)) return false;
+  if (isAppSessionBoundaryPending()) return false;
   return !isCindyAccountGhostId(id) || getAppCapabilities().canUseCindyAccountServices;
 }
 
@@ -904,14 +893,10 @@ export function listAvailableGhostsForAuthorization(): InstalledGhost[] {
 
 function requireGhostAvailableForActiveSession(id: string): void {
   if (!isGhostAvailableForActiveSession(id)) {
-    const activeOwner = getActiveAppSession().dataOwnerId;
-    if (
-      isAppSessionBoundaryPending() ||
-      !isGhostSkillProjectionBoundaryStableForOwner(activeOwner)
-    ) {
+    if (isAppSessionBoundaryPending()) {
       throwIpcError(
         'PRECONDITION_FAILED',
-        'Ghost projection is switching owners; retry after the boundary settles.',
+        'Plugin owner is switching; retry after the boundary settles.',
       );
     }
     throwIpcError('PERMISSION_DENIED', 'This Plugin requires a Cindy account.');
@@ -3408,17 +3393,11 @@ function resolveImageChannelForModel(model: string, operation: 'generate' | 'edi
 }
 
 /**
- * Combined Ghost-owner boundary gate for Ghost-only paths (media generation,
- * cindy-slot work). Unlike the app-wide isAppSessionBoundaryPending(), this
- * also fails closed while the durable projection owner (shared global marker)
- * differs, so a sibling instance flipping the owner cannot let an in-flight
- * Ghost task keep calling upstream or saving media.
+ * Plugin media and storage use the same process-local AppSession owner
+ * boundary as the rest of the owner-scoped runtime.
  */
 function isGhostBoundaryPending(): boolean {
-  return (
-    isAppSessionBoundaryPending() ||
-    !isGhostSkillProjectionBoundaryStableForOwner(getActiveAppSession().dataOwnerId)
-  );
+  return isAppSessionBoundaryPending();
 }
 
 export function getGhostCindySlot(): GhostCindySlot {
@@ -3716,8 +3695,8 @@ export function getGhostCindySlot(): GhostCindySlot {
       // 管道;记成 'ghost' 会让 ghostCanRead 的 origin 分支把它当作该意识的
       // 出生物,与"作品"混为一谈。引用方(refId)才是意识,归属由此成立。
       depositMedia: async ({ ghostId, buffer, mimeType, label }) => {
-        // 与 saveGhostMedia 同口径的 durable owner 守卫:寄存器引用按 ghostId
-        // 落到 owner 作用域账本,落盘窗口翻转全局 owner 时必须 fail closed。
+        // 与 saveGhostMedia 同口径的应用会话守卫:寄存器引用按 ghostId
+        // 落到 owner 作用域账本,落盘窗口切换账号时必须 fail closed。
         const ownerScopeKey = activeOwnerScopeKey();
         const assertOwnerScopeCurrent = (): void => {
           if (isGhostBoundaryPending() || activeOwnerScopeKey() !== ownerScopeKey) {
@@ -4124,9 +4103,9 @@ export function getGhostNetworkSlot(): GhostNetworkSlot {
       // (规则 25)。mime 白名单同一来源(blobStore),槽内归一化后再判。
       isSupportedMediaMime: (mime) => supportedMime(mime),
       saveGhostMedia: async ({ ghostId, buffer, mimeType, label, callId }) => {
-        // 与 cindy 槽 saveGhostMedia 同口径的 durable owner 守卫:落盘前与
-        // ingestMedia 每个 await 边界都复查,防止兄弟实例在 fetch 读取窗口翻转
-        // 全局 Ghost owner marker 后,字节仍被登记为 ghost-gallery 作品。
+        // 与 cindy 槽 saveGhostMedia 同口径的应用会话守卫:落盘前与
+        // ingestMedia 每个 await 边界都复查,防止当前进程在 fetch 读取窗口切换
+        // 账号后,字节仍被登记为 ghost-gallery 作品。
         const ownerScopeKey = activeOwnerScopeKey();
         const assertOwnerScopeCurrent = (): void => {
           if (isGhostBoundaryPending() || activeOwnerScopeKey() !== ownerScopeKey) {

--- a/apps/desktop/src/main/plugin-market/__tests__/ledger.test.ts
+++ b/apps/desktop/src/main/plugin-market/__tests__/ledger.test.ts
@@ -85,6 +85,25 @@ describe('PluginMarketLedger', () => {
     ).toBe(false);
   });
 
+  it('keeps a recovered organization route out of market-only authorization', () => {
+    const { ledger } = harness();
+    ledger.upsertInstallation(record({
+      scope: 'organization',
+      organizationId: 'org-a',
+    }));
+    ledger.markRemoved('cindy-test', 'user-a');
+    const disconnected = ledger.installationForGhost('cindy-test');
+    expect(disconnected).not.toBeNull();
+    if (!disconnected) return;
+
+    expect(ledger.restoreDisconnectedInstallation(disconnected, 'user-a')).toBe(true);
+    expect(ledger.installationForGhost('cindy-test')).toMatchObject({
+      installed: true,
+      source: 'legacy-adopted',
+      scope: 'organization',
+    });
+  });
+
   it('does not overwrite a disconnected record that changed after recovery captured it', () => {
     const { ledger } = harness();
     const disconnected = record({ installed: false });

--- a/apps/desktop/src/main/plugin-market/__tests__/ledger.test.ts
+++ b/apps/desktop/src/main/plugin-market/__tests__/ledger.test.ts
@@ -70,6 +70,34 @@ describe('PluginMarketLedger', () => {
     ).toBe(false);
   });
 
+  it('atomically reconnects an unchanged server record and clears its false opt-out', () => {
+    const { ledger } = harness();
+    ledger.upsertInstallation(record());
+    ledger.markRemoved('cindy-test', 'user-a');
+    const disconnected = ledger.installationForGhost('cindy-test');
+    expect(disconnected).not.toBeNull();
+    if (!disconnected) return;
+
+    expect(ledger.restoreDisconnectedInstallation(disconnected, 'user-a')).toBe(true);
+    expect(ledger.installationForGhost('cindy-test')).toMatchObject({ installed: true });
+    expect(
+      ledger.isDefaultInstallSuppressed('user-a', disconnected.pluginId),
+    ).toBe(false);
+  });
+
+  it('does not overwrite a disconnected record that changed after recovery captured it', () => {
+    const { ledger } = harness();
+    const disconnected = record({ installed: false });
+    ledger.upsertInstallation(disconnected);
+    ledger.upsertInstallation({ ...disconnected, sha256: 'c'.repeat(64) });
+
+    expect(ledger.restoreDisconnectedInstallation(disconnected, 'user-a')).toBe(false);
+    expect(ledger.installationForGhost('cindy-test')).toMatchObject({
+      installed: false,
+      sha256: 'c'.repeat(64),
+    });
+  });
+
   it('fails closed to an empty ledger for malformed or future data', () => {
     const { filePath, ledger } = harness();
     fs.mkdirSync(path.dirname(filePath), { recursive: true });

--- a/apps/desktop/src/main/plugin-market/__tests__/service.test.ts
+++ b/apps/desktop/src/main/plugin-market/__tests__/service.test.ts
@@ -563,6 +563,57 @@ describe('PluginMarketService migration and defaultInstall', () => {
     expect(runtime.install).not.toHaveBeenCalled();
   });
 
+  it('restores an organization update route without restoring market-only authorization', async () => {
+    const canonicalManifest = normalizedManifest(manifest());
+    const item = summary({
+      scope: 'organization',
+      organizationId: 'org-1',
+      currentRelease: {
+        ...summary().currentRelease,
+        id: RELEASE_ID,
+      },
+    });
+    const installDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cindy-market-org-recovery-'));
+    roots.push(installDir);
+    fs.writeFileSync(path.join(installDir, 'ghost.json'), JSON.stringify(canonicalManifest));
+    runtime.ghosts = [{
+      manifest: canonicalManifest as unknown as Record<string, unknown>,
+      dir: installDir,
+      enabled: true,
+    }];
+    runtime.approvedInstallEvidence.mockReturnValue({
+      packageSha256: item.currentRelease.sha256,
+      approvedManifest: canonicalManifest,
+      legacyMigrated: false,
+    });
+    const h = harness([item]);
+    h.ledger.upsertInstallation({
+      pluginId: item.id,
+      ghostId: item.ghostId,
+      releaseId: item.currentRelease.id,
+      version: item.currentRelease.version,
+      sha256: item.currentRelease.sha256,
+      scope: item.scope,
+      organizationId: item.organizationId,
+      source: 'market',
+      installed: true,
+      updatedAt: '2026-08-01T00:00:00.000Z',
+      manifestDigest: ghostManifestDigest(canonicalManifest),
+    });
+    h.ledger.markRemoved(item.ghostId, 'user-1');
+
+    const snapshot = await h.service.snapshot();
+
+    expect(snapshot.items[0]).toMatchObject({ installState: 'installed', enabled: true });
+    expect(h.ledger.installationForGhost(item.ghostId)).toMatchObject({
+      installed: true,
+      source: 'legacy-adopted',
+      releaseId: RELEASE_ID,
+    });
+    expect(h.api.download).not.toHaveBeenCalled();
+    expect(runtime.install).not.toHaveBeenCalled();
+  });
+
   it.each([
     { receiptCase: 'missing', receiptSha: null },
     { receiptCase: 'different', receiptSha: 'f'.repeat(64) },

--- a/apps/desktop/src/main/plugin-market/__tests__/service.test.ts
+++ b/apps/desktop/src/main/plugin-market/__tests__/service.test.ts
@@ -27,6 +27,11 @@ const runtime = vi.hoisted(() => ({
   runningErrand: false,
   cindyWork: false,
   boundaryPending: false,
+  approvedInstallEvidence: vi.fn(() => null as {
+    packageSha256: string | null;
+    approvedManifest: GhostManifest;
+    legacyMigrated: boolean;
+  } | null),
   pluginApiBaseUrl: 'https://plugin.test.invalid' as string | null,
   session: {
     mode: 'cloud' as 'signed-out' | 'local' | 'cloud',
@@ -69,6 +74,7 @@ vi.mock('../../cindy-brain/index.js', () => ({
           revision: '00000000-0000-4000-8000-000000000001',
         },
       })),
+    approvedInstallEvidence: runtime.approvedInstallEvidence,
   }),
   isGhostAvailableForActiveSession: vi.fn(() => runtime.accountGhostAvailable),
   installOrUpdateMarketGhostPackage: runtime.install,
@@ -100,6 +106,7 @@ import type { PluginMarketApi } from '../api';
 
 const roots: string[] = [];
 const PLUGIN_ID = `c${'a'.repeat(24)}`;
+const RELEASE_ID = `c${'b'.repeat(24)}`;
 const APPROVED_INSTALL_TOKEN = 'approved:00000000-0000-4000-8000-000000000001';
 
 /** 手动可控 deferred,用于精确编排"安装在飞行中"的交错。 */
@@ -121,6 +128,8 @@ afterEach(() => {
   runtime.runningErrand = false;
   runtime.cindyWork = false;
   runtime.boundaryPending = false;
+  runtime.approvedInstallEvidence.mockReset();
+  runtime.approvedInstallEvidence.mockReturnValue(null);
   runtime.pluginApiBaseUrl = 'https://plugin.test.invalid';
   runtime.session = {
     mode: 'cloud',
@@ -499,6 +508,238 @@ describe('PluginMarketService migration and defaultInstall', () => {
       sha256: 'legacy-unverified',
     });
     expect(runtime.install).not.toHaveBeenCalled();
+  });
+
+  it('silently reconnects an unchanged approved package to its historical market release', async () => {
+    const canonicalManifest = normalizedManifest(manifest());
+    const item = summary({
+      currentRelease: {
+        ...summary().currentRelease,
+        id: RELEASE_ID,
+      },
+    });
+    const installDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cindy-market-recovery-'));
+    roots.push(installDir);
+    fs.writeFileSync(path.join(installDir, 'ghost.json'), JSON.stringify(canonicalManifest));
+    runtime.ghosts = [{
+      manifest: canonicalManifest as unknown as Record<string, unknown>,
+      dir: installDir,
+      enabled: false,
+    }];
+    runtime.approvedInstallEvidence.mockReturnValue({
+      packageSha256: item.currentRelease.sha256,
+      approvedManifest: canonicalManifest,
+      legacyMigrated: false,
+    });
+    const h = harness([item]);
+    h.ledger.upsertInstallation({
+      pluginId: item.id,
+      ghostId: item.ghostId,
+      releaseId: item.currentRelease.id,
+      version: item.currentRelease.version,
+      sha256: item.currentRelease.sha256,
+      scope: item.scope,
+      organizationId: item.organizationId,
+      source: 'market',
+      installed: true,
+      updatedAt: '2026-08-01T00:00:00.000Z',
+      manifestDigest: ghostManifestDigest(canonicalManifest),
+    });
+    h.ledger.markRemoved(item.ghostId, 'user-1');
+
+    const snapshot = await h.service.snapshot();
+
+    expect(snapshot.items[0]).toMatchObject({
+      installState: 'installed',
+      enabled: false,
+    });
+    expect(h.ledger.installationForGhost(item.ghostId)).toMatchObject({
+      installed: true,
+      source: 'market',
+      releaseId: RELEASE_ID,
+    });
+    expect(h.ledger.isDefaultInstallSuppressed('user-1', item.id)).toBe(false);
+    expect(h.api.download).not.toHaveBeenCalled();
+    expect(runtime.install).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { receiptCase: 'missing', receiptSha: null },
+    { receiptCase: 'different', receiptSha: 'f'.repeat(64) },
+  ])('keeps a disconnected market route detached when its receipt hash is $receiptCase', async ({
+    receiptSha,
+  }) => {
+    const canonicalManifest = normalizedManifest(manifest());
+    const item = summary({
+      currentRelease: {
+        ...summary().currentRelease,
+        id: RELEASE_ID,
+      },
+    });
+    const installDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cindy-market-mismatch-'));
+    roots.push(installDir);
+    fs.writeFileSync(path.join(installDir, 'ghost.json'), JSON.stringify(canonicalManifest));
+    runtime.ghosts = [{
+      manifest: canonicalManifest as unknown as Record<string, unknown>,
+      dir: installDir,
+      enabled: true,
+    }];
+    runtime.approvedInstallEvidence.mockReturnValue(
+      receiptSha === null
+        ? null
+        : {
+            packageSha256: receiptSha,
+            approvedManifest: canonicalManifest,
+            // A retained migration entry must never override a present-but-different hash.
+            legacyMigrated: true,
+          },
+    );
+    const h = harness([item]);
+    h.ledger.upsertInstallation({
+      pluginId: item.id,
+      ghostId: item.ghostId,
+      releaseId: item.currentRelease.id,
+      version: item.currentRelease.version,
+      sha256: item.currentRelease.sha256,
+      scope: item.scope,
+      organizationId: item.organizationId,
+      source: 'market',
+      installed: false,
+      updatedAt: '2026-08-01T00:00:00.000Z',
+      manifestDigest: ghostManifestDigest(canonicalManifest),
+    });
+
+    const snapshot = await h.service.snapshot();
+
+    expect(snapshot.items[0]?.installState).toBe('conflict');
+    expect(h.ledger.installationForGhost(item.ghostId)?.installed).toBe(false);
+    expect(runtime.install).not.toHaveBeenCalled();
+  });
+
+  it('reconnects an explicitly migrated legacy receipt whose approved manifest is unchanged', async () => {
+    const canonicalManifest = normalizedManifest(manifest());
+    const item = summary({
+      currentRelease: {
+        ...summary().currentRelease,
+        id: RELEASE_ID,
+      },
+    });
+    const installDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cindy-market-legacy-recovery-'));
+    roots.push(installDir);
+    fs.writeFileSync(path.join(installDir, 'ghost.json'), JSON.stringify(canonicalManifest));
+    runtime.ghosts = [{
+      manifest: canonicalManifest as unknown as Record<string, unknown>,
+      dir: installDir,
+      enabled: true,
+    }];
+    runtime.approvedInstallEvidence.mockReturnValue({
+      packageSha256: null,
+      approvedManifest: canonicalManifest,
+      legacyMigrated: true,
+    });
+    const h = harness([item]);
+    h.ledger.upsertInstallation({
+      pluginId: item.id,
+      ghostId: item.ghostId,
+      releaseId: item.currentRelease.id,
+      version: item.currentRelease.version,
+      sha256: item.currentRelease.sha256,
+      scope: item.scope,
+      organizationId: item.organizationId,
+      source: 'market',
+      installed: false,
+      updatedAt: '2026-08-01T00:00:00.000Z',
+      // Old market records such as TapTap Maker predate manifestDigest.
+    });
+
+    const snapshot = await h.service.snapshot();
+
+    expect(snapshot.items[0]?.installState).toBe('installed');
+    expect(h.ledger.installationForGhost(item.ghostId)).toMatchObject({
+      installed: true,
+      source: 'market',
+      releaseId: RELEASE_ID,
+    });
+    expect(h.api.download).not.toHaveBeenCalled();
+    expect(runtime.install).not.toHaveBeenCalled();
+  });
+
+  it('keeps a migrated legacy route detached when its raw manifest changed after approval', async () => {
+    const canonicalManifest = normalizedManifest(manifest());
+    const item = summary({
+      currentRelease: {
+        ...summary().currentRelease,
+        id: RELEASE_ID,
+      },
+    });
+    const installDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cindy-market-legacy-tampered-'));
+    roots.push(installDir);
+    fs.writeFileSync(
+      path.join(installDir, 'ghost.json'),
+      JSON.stringify({ ...canonicalManifest, description: 'changed after migration' }),
+    );
+    runtime.ghosts = [{
+      manifest: canonicalManifest as unknown as Record<string, unknown>,
+      dir: installDir,
+      enabled: true,
+    }];
+    runtime.approvedInstallEvidence.mockReturnValue({
+      packageSha256: null,
+      approvedManifest: canonicalManifest,
+      legacyMigrated: true,
+    });
+    const h = harness([item]);
+    h.ledger.upsertInstallation({
+      pluginId: item.id,
+      ghostId: item.ghostId,
+      releaseId: item.currentRelease.id,
+      version: item.currentRelease.version,
+      sha256: item.currentRelease.sha256,
+      scope: item.scope,
+      organizationId: item.organizationId,
+      source: 'market',
+      installed: false,
+      updatedAt: '2026-08-01T00:00:00.000Z',
+    });
+
+    const snapshot = await h.service.snapshot();
+
+    expect(snapshot.items[0]?.installState).toBe('conflict');
+    expect(h.ledger.installationForGhost(item.ghostId)?.installed).toBe(false);
+    expect(runtime.install).not.toHaveBeenCalled();
+  });
+
+  it('does not guess a Release for a synthetic legacy-adopted record', async () => {
+    const canonicalManifest = normalizedManifest(manifest());
+    const item = summary();
+    const installDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cindy-market-legacy-unresolved-'));
+    roots.push(installDir);
+    fs.writeFileSync(path.join(installDir, 'ghost.json'), JSON.stringify(canonicalManifest));
+    runtime.ghosts = [{
+      manifest: canonicalManifest as unknown as Record<string, unknown>,
+      dir: installDir,
+      enabled: true,
+    }];
+    const h = harness([item]);
+    h.ledger.upsertInstallation({
+      pluginId: item.id,
+      ghostId: item.ghostId,
+      releaseId: `legacy-unresolved:${item.currentRelease.version}`,
+      version: item.currentRelease.version,
+      sha256: 'legacy-unverified',
+      scope: item.scope,
+      organizationId: item.organizationId,
+      source: 'legacy-adopted',
+      installed: false,
+      updatedAt: '2026-08-01T00:00:00.000Z',
+      manifestDigest: ghostManifestDigest(canonicalManifest),
+    });
+
+    await expect(h.service.snapshot()).resolves.toMatchObject({
+      items: [{ installState: 'conflict' }],
+    });
+    expect(h.api.download).not.toHaveBeenCalled();
+    expect(h.ledger.installationForGhost(item.ghostId)?.installed).toBe(false);
   });
 
   it('installs and enables a unique defaultInstall package and records its release', async () => {

--- a/apps/desktop/src/main/plugin-market/ledger.ts
+++ b/apps/desktop/src/main/plugin-market/ledger.ts
@@ -250,6 +250,40 @@ export class PluginMarketLedger {
     this.write(data);
   }
 
+  /**
+   * Reconnect an unchanged historical server record after the approved receipt
+   * proves the original package hash. The compare-and-write prevents a
+   * concurrent uninstall or source replacement from being overwritten by a
+   * stale recovery snapshot.
+   */
+  restoreDisconnectedInstallation(
+    expected: PluginMarketInstallationRecord,
+    userId: string,
+  ): boolean {
+    const data = this.read();
+    const current = data.installations[expected.ghostId];
+    if (
+      !current
+      || current.installed
+      || (current.source !== 'market' && current.source !== 'legacy-adopted')
+      || canonicalJson(current) !== canonicalJson(expected)
+    ) {
+      return false;
+    }
+    data.installations[current.ghostId] = {
+      ...current,
+      installed: true,
+      updatedAt: new Date().toISOString(),
+    };
+    const remainingOptOuts = (data.defaultInstallOptOuts[userId] ?? []).filter(
+      (pluginId) => pluginId !== current.pluginId,
+    );
+    if (remainingOptOuts.length > 0) data.defaultInstallOptOuts[userId] = remainingOptOuts;
+    else delete data.defaultInstallOptOuts[userId];
+    this.write(data);
+    return true;
+  }
+
   markRemoved(ghostId: string, userId: string | null): void {
     const data = this.read();
     const record = data.installations[ghostId];

--- a/apps/desktop/src/main/plugin-market/ledger.ts
+++ b/apps/desktop/src/main/plugin-market/ledger.ts
@@ -251,10 +251,13 @@ export class PluginMarketLedger {
   }
 
   /**
-   * Reconnect an unchanged historical server record after the approved receipt
-   * proves the original package hash. The compare-and-write prevents a
-   * concurrent uninstall or source replacement from being overwritten by a
-   * stale recovery snapshot.
+   * Reconnect a historical server update route after the approved receipt proves
+   * its original package identity. That receipt does not attest the current
+   * directory bytes, so an organization-scoped market record is demoted to
+   * legacy-adopted until a verified market update installs fresh bytes. This
+   * keeps automatic updates available without restoring Connection JWT trust
+   * from audit-only evidence. The compare-and-write prevents a concurrent
+   * uninstall or source replacement from being overwritten by a stale snapshot.
    */
   restoreDisconnectedInstallation(
     expected: PluginMarketInstallationRecord,
@@ -272,6 +275,10 @@ export class PluginMarketLedger {
     }
     data.installations[current.ghostId] = {
       ...current,
+      source:
+        current.scope === 'organization' && current.source === 'market'
+          ? 'legacy-adopted'
+          : current.source,
       installed: true,
       updatedAt: new Date().toISOString(),
     };

--- a/apps/desktop/src/main/plugin-market/service.ts
+++ b/apps/desktop/src/main/plugin-market/service.ts
@@ -2027,6 +2027,9 @@ export class PluginMarketService {
    * package hash. Legacy receipts intentionally omitted that audit-only hash, so
    * they additionally require the completed one-time migration to name this id
    * and the raw installed manifest to equal the manifest frozen in that receipt.
+   * This evidence reconnects the server update route, not current code bytes;
+   * the ledger therefore demotes recovered organization records to
+   * legacy-adopted until a verified market update restores stronger trust.
    */
   private async recoverDisconnectedMarketInstallations(
     plugins: readonly VisiblePluginSummary[],

--- a/apps/desktop/src/main/plugin-market/service.ts
+++ b/apps/desktop/src/main/plugin-market/service.ts
@@ -20,6 +20,7 @@ import {
   ghostIconMimeType,
   isSafeGhostRelativePath,
   isOfficialGhostId,
+  isValidGhostId,
   validateGhostManifest,
   validateNormalizedGhostManifest,
   type GhostManifest,
@@ -467,6 +468,27 @@ function sameMarketInstallation(
   );
 }
 
+function sameDisconnectedMarketInstallation(
+  current: PluginMarketInstallationRecord | null,
+  expected: PluginMarketInstallationRecord,
+): current is PluginMarketInstallationRecord {
+  return Boolean(
+    current
+    && !current.installed
+    && current.pluginId === expected.pluginId
+    && current.ghostId === expected.ghostId
+    && current.releaseId === expected.releaseId
+    && current.version === expected.version
+    && current.sha256 === expected.sha256
+    && current.scope === expected.scope
+    && current.organizationId === expected.organizationId
+    && current.source === expected.source
+    && current.updatedAt === expected.updatedAt
+    && current.sourceKey === expected.sourceKey
+    && current.manifestDigest === expected.manifestDigest,
+  );
+}
+
 /** Stable local facts reused while projecting one market catalog response. */
 interface LocalInstallSnapshot {
   /** Installed Ghost runtime facts indexed once for one market operation. */
@@ -589,6 +611,7 @@ export class PluginMarketService {
     requireSameMarketOwner(owner);
     const ledger = this.ledgerForOwner(owner);
     await this.adoptLegacyInstallations(plugins, ledger, owner);
+    await this.recoverDisconnectedMarketInstallations(plugins, ledger, owner);
     await this.backfillOfficialCindyGithubTrust(ledger, owner);
     // A snapshot is passive discovery: an empty runtime list can be caused by
     // startup, an owner transition, or a transient filesystem view. Only an
@@ -1994,6 +2017,139 @@ export class PluginMarketService {
         pluginId: matches[0].id,
         exactCurrentRelease: record.releaseId === matches[0].currentRelease.id,
       });
+    }
+  }
+
+  /**
+   * Repair an existing server provenance record that an older client left
+   * disconnected while its approved package remained installed.
+   * Recovery is entirely local. Modern receipts must retain the exact Release
+   * package hash. Legacy receipts intentionally omitted that audit-only hash, so
+   * they additionally require the completed one-time migration to name this id
+   * and the raw installed manifest to equal the manifest frozen in that receipt.
+   */
+  private async recoverDisconnectedMarketInstallations(
+    plugins: readonly VisiblePluginSummary[],
+    ledger: PluginMarketLedger,
+    owner: ActiveAppSession,
+  ): Promise<void> {
+    const pluginIdCounts = new Map<string, number>();
+    const ghostCounts = ghostIdCounts(plugins);
+    for (const plugin of plugins) {
+      pluginIdCounts.set(plugin.id, (pluginIdCounts.get(plugin.id) ?? 0) + 1);
+    }
+    const summariesById = new Map(plugins.map((plugin) => [plugin.id, plugin]));
+    const records = Object.values(ledger.read().installations);
+    const installSubject = defaultInstallSubject(owner);
+
+    for (const record of records) {
+      const summary = summariesById.get(record.pluginId);
+      if (
+        record.installed
+        || (record.source !== 'market' && record.source !== 'legacy-adopted')
+        || !isValidPluginResourceId(record.pluginId)
+        || !isValidPluginResourceId(record.releaseId)
+        || !isValidGhostId(record.ghostId)
+        || !/^[a-f0-9]{64}$/.test(record.sha256)
+        || pluginIdCounts.get(record.pluginId) !== 1
+        || ghostCounts.get(record.ghostId) !== 1
+        || !summary
+        || summary.ghostId !== record.ghostId
+        || summary.scope !== record.scope
+        || summary.organizationId !== record.organizationId
+      ) {
+        continue;
+      }
+
+      const installed = getGhostManager()
+        .list()
+        .find((ghost) => ghost.manifest.id === record.ghostId);
+      if (!installed || installed.approval.state !== 'approved') continue;
+
+      try {
+        await this.withMutation(record.pluginId, async () => {
+          requireSameMarketOwner(owner);
+          await withGhostInstallLock(record.ghostId, async () => {
+            requireSameMarketOwner(owner);
+            const lockedRecord = ledger.installationForGhost(record.ghostId);
+            if (!sameDisconnectedMarketInstallation(lockedRecord, record)) return;
+            const currentInstalled = getGhostManager()
+              .list()
+              .find((ghost) => ghost.manifest.id === record.ghostId);
+            if (
+              !currentInstalled
+              || currentInstalled.approval.state !== 'approved'
+              || currentInstalled.manifest.version !== record.version
+            ) {
+              return;
+            }
+            const approvalEvidence = getGhostManager().approvedInstallEvidence(record.ghostId);
+            if (!approvalEvidence) return;
+            if (
+              approvalEvidence.packageSha256 !== null
+              && approvalEvidence.packageSha256 !== record.sha256
+            ) {
+              log.info('disconnected market recovery skipped', {
+                pluginId: record.pluginId,
+                ghostId: record.ghostId,
+                reason: 'receipt-package-sha-mismatch',
+              });
+              return;
+            }
+            const installedManifestDigest = installedGhostRawManifestDigest(currentInstalled.dir);
+            if (approvalEvidence.packageSha256 === null) {
+              if (!approvalEvidence.legacyMigrated) {
+                log.info('disconnected market recovery skipped', {
+                  pluginId: record.pluginId,
+                  ghostId: record.ghostId,
+                  reason: 'approved-source-evidence-missing',
+                });
+                return;
+              }
+              if (
+                installedManifestDigest === null
+                || installedManifestDigest !== ghostManifestDigest(
+                  approvalEvidence.approvedManifest,
+                )
+              ) {
+                log.info('disconnected market recovery skipped', {
+                  pluginId: record.pluginId,
+                  ghostId: record.ghostId,
+                  reason: 'legacy-approved-manifest-mismatch',
+                });
+                return;
+              }
+            }
+            if (
+              record.manifestDigest !== undefined
+              && installedManifestDigest !== record.manifestDigest
+            ) {
+              log.info('disconnected market recovery skipped', {
+                pluginId: record.pluginId,
+                ghostId: record.ghostId,
+                reason: 'installed-manifest-mismatch',
+              });
+              return;
+            }
+            const restored = await this.withLedgerMutation(owner, () =>
+              ledger.restoreDisconnectedInstallation(record, installSubject));
+            if (restored) {
+              log.info('disconnected market installation recovered', {
+                pluginId: record.pluginId,
+                ghostId: record.ghostId,
+                releaseId: record.releaseId,
+              });
+            }
+          });
+        });
+      } catch (error) {
+        if (isIpcError(error) && error.code === 'PRECONDITION_FAILED') throw error;
+        log.warn('disconnected market recovery deferred', {
+          pluginId: record.pluginId,
+          ghostId: record.ghostId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
     }
   }
 


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复正式版与开发版共用数据目录、登录不同账号时，插件被全局 Skill 投影 owner 误判为不可用的问题。插件列表、运行时和写入操作改为只依赖当前进程的账号会话边界。

同时根据现有市场台账与 Host 批准凭据，自动恢复被历史版本错误标记为未安装的市场插件来源及自动更新能力；不下载、不重装，也不要求用户重新确认。组织插件会先恢复为服务端更新路由，但不会仅凭旧包审计哈希恢复 Connection JWT 信任；下一次经过校验的市场包更新会恢复完整市场信任。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：插件已安装数量显示为 0、市场插件显示“替换”且无法调用
- 本 PR 包含：插件 AppSession owner 解耦；历史市场台账断链的证据校验与无感恢复；对应回归测试
- 明确不包含：UserData 路径调整、账号目录迁移、插件包重装、全局 Skill 投影机制调整、同账号双实例并发修改插件的跨进程串行化
- 用户可见变化：已安装插件按当前登录账号正常显示和调用；证据完整的历史市场安装恢复为“已安装/可更新”
- 是否存在 breaking change：无

### UI 变化

不涉及：未修改 Renderer、视觉、交互或文案，仅修正 main 侧插件状态投影与台账恢复。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：PASS apps/desktop unit

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm check:dco
结果：DCO check passed
```

### 手工验证

macOS 开发版使用存量账号数据登录并重启后：9 个插件正常显示，图标恢复，市场状态显示“已是最新”，插件可正常使用；恢复过程未下载或重装插件。

### 未执行的验证

未执行全仓 `pnpm test:unit`；提交前相关单测门禁与 Desktop typecheck 已通过，完整单测交由 CI。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [x] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop 插件 owner 判定，以及存在完整台账和批准证据的历史市场安装记录。
- 存量插件影响：无。插件目录、批准状态、凭证、Secret、OAuth、KV 和私有文件均不移动、不覆盖；证据不足时保持原状态。
- 回滚 / 降级方式：回滚本提交即可停止新的自动恢复；已经恢复的记录仍保持旧版本兼容的 schema v1，旧客户端可正常读取。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
