### PR TITLE
fix(desktop): restore discounted Codex route for native spawn_agent

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/codex-subagent-config.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codex-subagent-config.test.ts
@@ -119,11 +119,14 @@ describe('buildCodexSubagentSpawnArgs', () => {
     ]);
   });
 
-  it('injects discounted-route model ids verbatim (no prefix stripping)', () => {
-    // codex/ 前缀由 loopback proxy 在 HTTP 边界分流,剥前缀会把折扣路由静默改道。
+  it('strips the discounted-route prefix for the Multi-Agent V2 model catalog', () => {
+    // V2 目录只接受原生 slug；loopback proxy 会在子 thread 的 HTTP 边界恢复路由前缀。
     expect(
       withoutDelegationArgs(buildCodexSubagentSpawnArgs(settings({ codex: 'codex/gpt-5.5' }))),
-    ).toEqual(['-c', 'agents.default_subagent_model="codex/gpt-5.5"']);
+    ).toEqual(['-c', 'agents.default_subagent_model="gpt-5.5"']);
+    expect(
+      withoutDelegationArgs(buildCodexSubagentSpawnArgs(settings({ codex: 'codex/gpt-5.6-sol' }))),
+    ).toEqual(['-c', 'agents.default_subagent_model="gpt-5.6-sol"']);
   });
 
   it('maps the nested-subagents switch to agents.max_depth=2', () => {

--- a/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
@@ -24,6 +24,7 @@ const mockState = vi.hoisted(() => {
       error: vi.fn(),
     },
     createAnthropicCompatProxy: vi.fn(),
+    capturedRequestTransforms: [] as Array<(body: unknown, ctx: unknown) => unknown | null>,
     createResponsesChatHandler: vi.fn(() => ({ handle: vi.fn(async () => undefined) })),
     createResponsesAnthropicHandler: vi.fn(() => ({ handle: vi.fn(async () => undefined) })),
     injectionTransform: vi.fn<(body: unknown, ctx: unknown) => unknown | null>(() => null),
@@ -126,6 +127,16 @@ vi.mock('@cindy/responses-anthropic-bridge', () => ({
 async function freshCodexProxyHost() {
   vi.resetModules();
   mockState.createAnthropicCompatProxy.mockReset();
+  mockState.createAnthropicCompatProxy.mockImplementation(async (opts: {
+    transformRequest?: Array<(body: unknown, ctx: unknown) => unknown | null>;
+  }) => {
+    mockState.capturedRequestTransforms = opts.transformRequest ?? [];
+    return {
+      url: 'http://127.0.0.1:43210',
+      dispose: vi.fn(async () => undefined),
+    };
+  });
+  mockState.capturedRequestTransforms = [];
   mockState.createResponsesChatHandler.mockClear();
   mockState.createResponsesAnthropicHandler.mockClear();
   mockState.createInstructionsInjectionTransform.mockClear();
@@ -491,6 +502,25 @@ describe('createCrossProviderCompactionCompatTransform', () => {
     expect(transform(
       { model: 'gpt-5.5', input: [{ type: 'context_compaction', id: 'cc_2' }, { type: 'compaction', encrypted_content: '' }] },
       { ...CTX_BASE, upstreamBase: 'https://gateway.example.com/v1' },
+    )).toBeNull();
+  });
+
+  it('普通 agent_message 的加密任务正文原样透传', async () => {
+    const { createCrossProviderCompactionCompatTransform } = await import('../codex-proxy-host.js');
+    const transform = createCrossProviderCompactionCompatTransform();
+    const agentMessage = {
+      type: 'agent_message',
+      author: '/root',
+      recipient: '/root/probe',
+      content: [
+        { type: 'input_text', text: 'Message Type: NEW_TASK\nPayload:' },
+        { type: 'encrypted_content', encrypted_content: 'TASK_BODY_BLOB' },
+      ],
+    };
+
+    expect(transform(
+      { model: 'codex/gpt-5.6-sol', input: [agentMessage] },
+      { ...CTX_BASE, upstreamBase: `${XD_GATEWAY_BASE_URL}/v1` },
     )).toBeNull();
   });
 });
@@ -1286,6 +1316,159 @@ describe('chatBridgeCapabilitiesForRoute', () => {
     }
   });
 
+  it('restores the discounted route prefix for a spawned child model at the HTTP boundary', async () => {
+    const host = await freshCodexProxyHost();
+    host.setCodexProxyGatewayKeyReader(() => 'gateway-key');
+    host.setCodexProxyAuthInjection('oauth-bearer');
+    await host.ensureCodexProxyReady();
+    host.registerComposed('session-collab-discount', 'thread-collab-discount-parent', 'PRODUCT_PROMPT');
+    host.registerReviewerRouteContext(
+      'session-collab-discount',
+      'thread-collab-discount-parent',
+      'codex/gpt-5.6-sol',
+    );
+    const ctx = {
+      reqId: 1,
+      method: 'POST',
+      url: '/responses',
+      headers: {
+        'thread-id': 'thread-collab-discount-child',
+        'x-openai-subagent': 'collab_spawn',
+        'x-codex-parent-thread-id': 'thread-collab-discount-parent',
+      },
+    };
+
+    try {
+      const rawBody = { model: 'gpt-5.6-terra', input: [] };
+      expect(await host.createModelRoutingTransform()(rawBody, ctx)).toEqual({
+        headerOverride: { authorization: 'Bearer gateway-key' },
+      });
+
+      let body: unknown = rawBody;
+      for (const transform of mockState.capturedRequestTransforms) {
+        body = transform(body, ctx) ?? body;
+      }
+
+      expect(body).toMatchObject({ model: 'codex/gpt-5.6-terra' });
+      expect(mockState.capturedRegistry?.get('thread-collab-discount-child')).toBe('PRODUCT_PROMPT');
+    } finally {
+      host.unregister('session-collab-discount');
+      host.setCodexProxyGatewayKeyReader(() => null);
+    }
+  });
+
+  it('does not double-prefix an already routed spawned child model', async () => {
+    const host = await freshCodexProxyHost();
+    await host.ensureCodexProxyReady();
+    host.registerComposed('session-collab-prefixed', 'thread-collab-prefixed-parent', 'PRODUCT_PROMPT');
+    host.registerReviewerRouteContext(
+      'session-collab-prefixed',
+      'thread-collab-prefixed-parent',
+      'codex/gpt-5.6-sol',
+    );
+    const ctx = {
+      reqId: 1,
+      method: 'POST',
+      url: '/responses',
+      headers: {
+        'thread-id': 'thread-collab-prefixed-child',
+        'x-openai-subagent': 'collab_spawn',
+        'x-codex-parent-thread-id': 'thread-collab-prefixed-parent',
+      },
+    };
+
+    try {
+      let body: unknown = { model: 'codex/gpt-5.6-terra', input: [] };
+      for (const transform of mockState.capturedRequestTransforms) {
+        body = transform(body, ctx) ?? body;
+      }
+      expect(body).toMatchObject({ model: 'codex/gpt-5.6-terra' });
+    } finally {
+      host.unregister('session-collab-prefixed');
+    }
+  });
+
+  it('keeps spawned-task agent_message encrypted payloads on the gateway transform chain', async () => {
+    const host = await freshCodexProxyHost();
+    host.setCodexProxyGatewayKeyReader(() => 'gateway-key');
+    host.setCodexProxyAuthInjection('oauth-bearer');
+    await host.ensureCodexProxyReady();
+    host.registerComposed('session-collab-payload', 'thread-collab-payload-parent', 'PRODUCT_PROMPT');
+    host.registerReviewerRouteContext(
+      'session-collab-payload',
+      'thread-collab-payload-parent',
+      'codex/gpt-5.6-sol',
+    );
+    const agentMessage = {
+      type: 'agent_message',
+      author: '/root',
+      recipient: '/root/probe',
+      content: [
+        {
+          type: 'input_text',
+          text: 'Message Type: NEW_TASK\nTask name: /root/probe\nPayload:',
+        },
+        { type: 'encrypted_content', encrypted_content: 'TASK_BODY_BLOB' },
+      ],
+    };
+    const ctx = {
+      reqId: 1,
+      method: 'POST',
+      url: '/responses',
+      headers: {
+        'thread-id': 'thread-collab-payload-child',
+        'x-openai-subagent': 'collab_spawn',
+        'x-codex-parent-thread-id': 'thread-collab-payload-parent',
+      },
+      upstreamBase: `${XD_GATEWAY_BASE_URL}/v1`,
+    };
+
+    try {
+      let body: unknown = { model: 'gpt-5.6-sol', input: [agentMessage] };
+      for (const transform of mockState.capturedRequestTransforms) {
+        body = transform(body, ctx) ?? body;
+      }
+      expect(body).toMatchObject({
+        model: 'codex/gpt-5.6-sol',
+        input: [agentMessage],
+      });
+    } finally {
+      host.unregister('session-collab-payload');
+      host.setCodexProxyGatewayKeyReader(() => null);
+    }
+  });
+
+  it('keeps a native spawned child model unchanged when its parent is not discounted', async () => {
+    const host = await freshCodexProxyHost();
+    await host.ensureCodexProxyReady();
+    host.registerComposed('session-collab-native', 'thread-collab-native-parent', 'PRODUCT_PROMPT');
+    host.registerReviewerRouteContext(
+      'session-collab-native',
+      'thread-collab-native-parent',
+      'gpt-5.6-sol',
+    );
+    const ctx = {
+      reqId: 1,
+      method: 'POST',
+      url: '/responses',
+      headers: {
+        'thread-id': 'thread-collab-native-child',
+        'x-openai-subagent': 'collab_spawn',
+        'x-codex-parent-thread-id': 'thread-collab-native-parent',
+      },
+    };
+
+    try {
+      let body: unknown = { model: 'gpt-5.6-terra', input: [] };
+      for (const transform of mockState.capturedRequestTransforms) {
+        body = transform(body, ctx) ?? body;
+      }
+      expect(body).toMatchObject({ model: 'gpt-5.6-terra' });
+    } finally {
+      host.unregister('session-collab-native');
+    }
+  });
+
   it('fails closed when a collab_spawn request cannot resolve its parent route', async () => {
     const host = await freshCodexProxyHost();
     const ctx = {
@@ -1946,8 +2129,8 @@ describe('codex proxy host', () => {
         // upstream 是函数形态(每请求现取,model-access 下发可运行期换 endpoint);
         // 断言其当前求值 = 网关 base + /v1
         upstream: expect.any(Function),
-        // [encrypted activeStrip, image generation activeStrip, instructions 注入, provider-aware Guardian reviewer, Gateway 原生 web_search, 跨来源压缩块兼容, strict gateway history 兼容, xAI Responses 兼容, ByteDance Seed tool 兼容, MiniMax effort 兼容, provider model rewrite, 视觉桥(controller 未注入 → 短路透传), stripNonAnthropicFields]
-        transformRequest: [expect.any(Function), expect.any(Function), expect.any(Function), expect.any(Function), expect.any(Function), expect.any(Function), expect.any(Function), expect.any(Function), expect.any(Function), expect.any(Function), expect.any(Function), expect.any(Function), mockState.stripNonAnthropicFields],
+        // [encrypted activeStrip, image generation activeStrip, instructions 注入, provider-aware Guardian reviewer, collab_spawn 折扣路由恢复, Gateway 原生 web_search, 跨来源压缩块兼容, strict gateway history 兼容, xAI Responses 兼容, ByteDance Seed tool 兼容, MiniMax effort 兼容, provider model rewrite, 视觉桥(controller 未注入 → 短路透传), stripNonAnthropicFields]
+        transformRequest: [expect.any(Function), expect.any(Function), expect.any(Function), expect.any(Function), expect.any(Function), expect.any(Function), expect.any(Function), expect.any(Function), expect.any(Function), expect.any(Function), expect.any(Function), expect.any(Function), expect.any(Function), mockState.stripNonAnthropicFields],
         routingTransform: expect.any(Function),
         recoveryRules: expect.arrayContaining([
           expect.objectContaining({ id: 'encrypted_content' }),
@@ -4009,7 +4192,7 @@ describe('codex proxy host', () => {
     await host.ensureCodexProxyReady();
 
     const transforms = mockState.createAnthropicCompatProxy.mock.calls[0]?.[0]?.transformRequest ?? [];
-    expect(transforms).toHaveLength(14); // encrypted activeStrip, image generation activeStrip, instructions 注入, provider-aware Guardian reviewer, Gateway 原生 web_search, 跨来源压缩块兼容, strict gateway history 兼容, xAI Responses 兼容, ByteDance Seed tool 兼容, MiniMax effort 兼容, provider model rewrite, 视觉桥(短路), stripNonAnthropicFields, dump
+    expect(transforms).toHaveLength(15); // encrypted activeStrip, image generation activeStrip, instructions 注入, provider-aware Guardian reviewer, collab_spawn 折扣路由恢复, Gateway 原生 web_search, 跨来源压缩块兼容, strict gateway history 兼容, xAI Responses 兼容, ByteDance Seed tool 兼容, MiniMax effort 兼容, provider model rewrite, 视觉桥(短路), stripNonAnthropicFields, dump
     const ctx = {
       method: 'POST',
       url: '/v1/responses',

--- a/apps/desktop/src/main/maker-host/codex-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/codex-proxy-host.ts
@@ -432,6 +432,44 @@ function createProviderAwareGuardianReviewerTransform(
 }
 
 /**
+ * Multi-Agent V2 validates child model overrides against the native Codex catalog, so a
+ * discounted Cindy model reaches the child request as a bare slug. Restore the routing
+ * namespace only at the HTTP boundary, and only when the parent business session is
+ * already registered on the discounted `codex/` route. The child keeps its own explicit
+ * Sol/Terra choice; only the route namespace is inherited.
+ */
+function createDiscountedCollabSpawnModelTransform(): RequestTransform {
+  return (body, ctx) => {
+    if (!isCollabSpawnRequest(ctx.headers) || !isPlainObject(body)) return null;
+    if (typeof body.model !== 'string' || !body.model || body.model.includes('/')) return null;
+    const parentThreadId = headerValue(ctx.headers, 'x-codex-parent-thread-id');
+    const sessionId = parentThreadId ? threadToSession.get(parentThreadId) : undefined;
+    const parentModel = sessionId ? reviewerModelBySession.get(sessionId) : undefined;
+    if (!sessionId || !parentModel?.startsWith('codex/')) return null;
+
+    const model = `codex/${body.model}`;
+    log.info('restored discounted route for spawned Codex agent model', {
+      sessionId,
+      parentThreadId,
+      fromModel: body.model,
+      toModel: model,
+    });
+    return { ...body, model };
+  };
+}
+
+function discountedCollabSpawnModel(
+  model: string,
+  headers: Readonly<Record<string, string>>,
+): string {
+  if (!model || model.includes('/') || !isCollabSpawnRequest(headers)) return model;
+  const parentThreadId = headerValue(headers, 'x-codex-parent-thread-id');
+  const sessionId = parentThreadId ? threadToSession.get(parentThreadId) : undefined;
+  const parentModel = sessionId ? reviewerModelBySession.get(sessionId) : undefined;
+  return parentModel?.startsWith('codex/') ? `codex/${model}` : model;
+}
+
+/**
  * Codex Code Mode 对部分 GPT-5.6 网关模型不会发出 Responses 原生搜索声明：
  * 目录里的 `supports_search_tool` / `webSearch` 能力虽为 true，但 Gateway 只看最终
  * 请求的 `tools`。插件搜索是增强项，不能作为该基础能力的前置条件，因此在明确走
@@ -734,7 +772,9 @@ function prepareLocalBridgeBody(opts: PrepareLocalBridgeBodyOptions): unknown {
   }
   const historySafe = isChatGptUpstreamBase(opts.upstreamBase)
     ? null
-    : rewriteCrossProviderHistoryItems(body);
+    : rewriteCrossProviderHistoryItems(body, {
+      stripAgentMessageEncrypted: !isCindyGatewayUpstreamBase(opts.upstreamBase),
+    });
   if (historySafe) {
     log.info('rewrote incompatible Codex history for local bridge upstream', {
       bridge: opts.bridge,
@@ -1841,19 +1881,33 @@ function isChatGptUpstreamBase(upstreamBase: string | undefined): boolean {
   }
 }
 
+function isCindyGatewayUpstreamBase(upstreamBase: string | undefined): boolean {
+  if (!upstreamBase) return false;
+  try {
+    return new URL(upstreamBase).hostname === new URL(buildCodexGatewayBaseUrl()).hostname;
+  } catch {
+    return false;
+  }
+}
+
 /**
  * 把 body.input 里无法跨供应商重放的 Codex 历史降级成目标上游可接受的形态。
  * 返回 null = 无需改写。透明转发路径(transform 链)与 localHandler 路径共用。
  *
  * - 加密 compaction 仍替换成明文上下文缺失提示。
- * - 多 Agent 历史会在 agent_message.content 里夹带仅原供应商可解的 encrypted_content；
- *   非 ChatGPT 上游会直接拒绝整次请求。只删除这些嵌套密文，保留可读正文与路由元数据；
- *   若消息只剩密文则整条丢弃。
+ * - 多 Agent 历史会在 agent_message.content 里夹带 encrypted_content。对 xAI / 自定义
+ *   等无法解密文的上游，删除这些嵌套密文并保留可读正文；若消息只剩密文则整条丢弃。
+ *   Cindy Gateway 走同一套 Codex Responses 协议，NEW_TASK 的任务正文就在这块密文里，
+ *   剥掉会让子代理只看到空 Payload（#2921）。网关路径因此保持原样。
  * - reasoning.encrypted_content 不属于本故障；继续交给后续供应商兼容层判断，
  *   不在这里扩大删除面。
  */
-function rewriteCrossProviderHistoryItems(body: unknown): Record<string, unknown> | null {
+function rewriteCrossProviderHistoryItems(
+  body: unknown,
+  opts: { stripAgentMessageEncrypted?: boolean } = {},
+): Record<string, unknown> | null {
   if (!isPlainObject(body) || !Array.isArray(body.input)) return null;
+  const stripAgentMessageEncrypted = opts.stripAgentMessageEncrypted !== false;
   let changed = false;
   const input: unknown[] = [];
   for (const item of body.input) {
@@ -1871,7 +1925,12 @@ function rewriteCrossProviderHistoryItems(body: unknown): Record<string, unknown
       });
       continue;
     }
-    if (isPlainObject(item) && item.type === 'agent_message' && Array.isArray(item.content)) {
+    if (
+      stripAgentMessageEncrypted
+      && isPlainObject(item)
+      && item.type === 'agent_message'
+      && Array.isArray(item.content)
+    ) {
       const content = item.content.filter(
         (part) => !(isPlainObject(part) && part.type === 'encrypted_content'),
       );
@@ -1891,7 +1950,9 @@ export function createCrossProviderCompactionCompatTransform(): RequestTransform
     // upstreamBase 未注入(理论不发生)按非 ChatGPT 保守处理?否——保守方向是不改写:
     // 改写会丢加密块,误伤真 ChatGPT 请求的代价(远端压缩语义被破坏)高于维持现状。
     if (!ctx.upstreamBase || isChatGptUpstreamBase(ctx.upstreamBase)) return null;
-    const replaced = rewriteCrossProviderHistoryItems(body);
+    const replaced = rewriteCrossProviderHistoryItems(body, {
+      stripAgentMessageEncrypted: !isCindyGatewayUpstreamBase(ctx.upstreamBase),
+    });
     if (!replaced) return null;
     log.info('rewrote incompatible Codex history for non-ChatGPT upstream', {
       reqId: ctx.reqId,
@@ -2186,7 +2247,7 @@ export function createModelRoutingTransform(
     const requestModel = isPlainObject(body) && typeof body.model === 'string' ? body.model : '';
     const model =
       providerAwareGuardianReviewerModel(body, ctx.headers, authInjection) ??
-      requestModel;
+      discountedCollabSpawnModel(requestModel, ctx.headers);
     const threadId = selectedThreadIdFromHeaders(ctx.headers);
     const sessionId = sessionIdFromHeaders(ctx.headers);
     if (!sessionId && isCollabSpawnRequest(ctx.headers)) {
@@ -2319,6 +2380,7 @@ function createTransformRequestChain(
     // session and select that session's real provider model before provider
     // compatibility transforms inspect the request.
     createProviderAwareGuardianReviewerTransform(frozenAuthInjection),
+    createDiscountedCollabSpawnModelTransform(),
     createGatewayNativeWebSearchTransform(),
     // 必须先于 xAI/MiniMax 兼容改写:先把供应商绑定的历史项降级成标准 message，
     // 后续针对具体供应商的 input 归一化才能稳定处理。

--- a/apps/desktop/src/main/maker-host/codex-subagent-config.ts
+++ b/apps/desktop/src/main/maker-host/codex-subagent-config.ts
@@ -16,9 +16,9 @@
  *   不改变上游何时委托的调度策略。
  * - `agents.max_depth` 仅旧版多代理(V1)生效,V2 忽略(UI hint 已注明)。
  * - `agents.default_subagent_model` 是兜底默认,模型仍可在 spawn 参数里显式覆盖。
- *   注入 Cindy 存储的 model id 原文:codex vendor 候选只有原生 slug 与 `codex/`
- *   折扣路由 id,`codex/` 前缀由 loopback proxy 在 HTTP 边界分流(decideCodexRoute),
- *   剥前缀反而会把折扣路由静默改道。
+ *   Multi-Agent V2 目录只接受原生 slug,因此 Cindy 存储的 `codex/` 折扣路由前缀
+ *   必须在这里剥掉；子 thread 发出首个 HTTP 请求时，loopback proxy 再根据父会话
+ *   的真实模型来源恢复前缀。这样目录校验与 Gateway 路由各自在自己的边界生效。
  *
  * TOML 值形态与 mcp-integrations/codexEnvironment.ts 一致:字符串带双引号,
  * 数字/布尔裸写。
@@ -53,6 +53,10 @@ function tomlString(value: string): string {
   return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
 }
 
+function codexSubagentCatalogModelId(value: string): string {
+  return value.startsWith('codex/') ? value.slice('codex/'.length) : value;
+}
+
 export function buildCodexSubagentSpawnArgs(settings: SubagentModelSettings): string[] {
   const args: string[] = [];
   if (!settings.codexSubagentsEnabled) {
@@ -70,7 +74,10 @@ export function buildCodexSubagentSpawnArgs(settings: SubagentModelSettings): st
   }
   args.push('-c', 'features.multi_agent_v2.expose_spawn_agent_model_overrides=true');
   if (settings.codex) {
-    args.push('-c', `agents.default_subagent_model=${tomlString(settings.codex)}`);
+    args.push(
+      '-c',
+      `agents.default_subagent_model=${tomlString(codexSubagentCatalogModelId(settings.codex))}`,
+    );
   }
   if (settings.codexEffort) {
     args.push('-c', `agents.default_subagent_reasoning_effort=${tomlString(settings.codexEffort)}`);

--- a/apps/desktop/src/main/maker-host/index.ts
+++ b/apps/desktop/src/main/maker-host/index.ts
@@ -152,6 +152,7 @@ import {
   setCodexProxyGatewayKeyReader,
   registerComposed as registerCodexProxyComposed,
   registerChildThread as registerCodexProxyChildThread,
+  registerReviewerRouteContext,
   unregister as unregisterCodexProxyPrompt,
 } from './codex-proxy-host.js';
 import { createDesktopMcpProviders } from '../mcp-integrations/mcp-providers.js';
@@ -1489,6 +1490,8 @@ export function getMaker(): Maker {
       prepareCodexResumeSession: prepareExternalCodexSessionForResume,
       registerCodexSystemPromptForThread: ({ sessionId, threadId, text }) =>
         registerCodexProxyComposed(sessionId, threadId, text),
+      registerCodexThreadRouteContext: ({ sessionId, threadId, model }) =>
+        registerReviewerRouteContext(sessionId, threadId, model),
       armCodexHttpRecovery,
       registerCodexChildThreadForParent: ({ parentThreadId, childThreadId }) => {
         registerCodexProxyChildThread(parentThreadId, childThreadId);

--- a/packages/maker-core/src/agents/base-agent.ts
+++ b/packages/maker-core/src/agents/base-agent.ts
@@ -926,6 +926,21 @@ export interface AgentDeps {
   }) => void;
 
   /**
+   * Codex 专用：把父 thread 当前实际模型登记给 host 的 proxy 路由表。
+   *
+   * Codex Multi-Agent V2 的子代理目录使用原生模型 slug，而 Cindy Gateway 的折扣
+   * 路由使用 `codex/` 前缀。host 需要父会话的模型来源，才能在子 thread 首个
+   * collab_spawn HTTP 请求上恢复该前缀。模型或 provider 运行时切换后必须重登。
+   *
+   * 约束：同步、纯内存、不可做 IO / 网络；缺省时保留上游原始行为。
+   */
+  registerCodexThreadRouteContext?: (args: {
+    sessionId: string;
+    threadId: string;
+    model: string;
+  }) => void;
+
+  /**
    * Codex 专用：WS turn 命中仅 HTTP proxy 能处理的请求体恢复错误时，通知宿主把
    * 该 thread 的后续 WS upgrade 导回 HTTP。
    *

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -3571,6 +3571,39 @@ describe('CodexAgent.startSession developerInstructions', () => {
     await proxyHandle.close();
   });
 
+  it('registers and refreshes the parent thread model used by spawned agent routing', async () => {
+    const registerCodexThreadRouteContext = vi.fn();
+    const agent = new CodexAgent(createDeps(
+      { systemPrompt: 'HOST PRODUCT PROMPT' },
+      {
+        registerCodexSystemPromptForThread: vi.fn(),
+        registerCodexThreadRouteContext,
+      },
+    ));
+    installFakeHost(agent, undefined, { codexProxyActive: true });
+    const handle = await agent.startSession({
+      sessionId: 'session-subagent-route',
+      model: 'codex/gpt-5.6-sol',
+      workingDir: '/repo',
+    });
+
+    expect(registerCodexThreadRouteContext).toHaveBeenCalledWith({
+      sessionId: 'session-subagent-route',
+      threadId: 'start-thread-id',
+      model: 'codex/gpt-5.6-sol',
+    });
+
+    if (!handle.setModel) throw new Error('expected setModel');
+    await handle.setModel('codex/gpt-5.6-terra');
+
+    expect(registerCodexThreadRouteContext).toHaveBeenLastCalledWith({
+      sessionId: 'session-subagent-route',
+      threadId: 'start-thread-id',
+      model: 'codex/gpt-5.6-terra',
+    });
+    await handle.close();
+  });
+
   it('reports Codex child and descendant threads to the host-owned proxy route registry', async () => {
     const registerCodexChildThreadForParent = vi.fn();
     const registerCodexMcpThreadContext = vi.fn();

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -4810,6 +4810,11 @@ export class CodexAgent extends BaseAgent {
       register({ sessionId: sid, threadId, text });
     };
     const refreshCodexAutoReviewerRoute = (targetThreadId: string): void => {
+      this.deps.registerCodexThreadRouteContext?.({
+        sessionId: sid,
+        threadId: targetThreadId,
+        model: mutableModel,
+      });
       const routeCredentialMode = resolveAgentCredentialMode({
         agentKind: 'codex',
         providerId: mutableProviderId,


### PR DESCRIPTION
## 这次改了什么

### 摘要

Cindy 走折扣路由时，Codex 原生 `spawn_agent` 的模型 ID 在两层之间没有可用交集：Multi-Agent V2 目录只接受 `gpt-5.6-sol` / `gpt-5.6-terra`，Gateway 账号只允许 `codex/*`。本 PR 把命名空间转换放到正确边界——进入子代理目录前剥掉 `codex/`，子线程发出 HTTP 请求时再按父会话路由补回。Cindy Gateway 上保留普通 `agent_message` 的加密任务正文；xAI / 自定义上游仍按原逻辑剥密文，避免跨源 resume 被拒。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#2921（相关 #2678）
- 本 PR 包含：
  - `agents.default_subagent_model` 写入原生 slug
  - 父 thread 实际模型登记到 proxy 路由表
  - `collab_spawn` 子请求在 HTTP 边界恢复 `codex/` 前缀，并同步给路由决策
  - Cindy Gateway 路径保留 `agent_message` 加密任务正文；第三方上游继续剥密文
  - 回归：已带前缀的子模型不重复加前缀
- 明确不包含：
  - 把 Luna 加入 Multi-Agent V2 原生子代理目录
  - 安装包发布 / 正式包端到端探针
  - 改 silent retry 对 `encrypted_content` 的重试剥离策略
- 用户可见变化：折扣路由主会话里，显式指定 Sol/Terra 的原生子代理应能打到 Gateway，而不再固定 403；Gateway 上的子任务正文应能到达模型。
- 是否存在 breaking change：无。原生 slug 父会话保持原样，不补 `codex/`。第三方上游的密文剥离行为与 `main` 一致。

### UI 变化

- 引用的设计规范：不涉及：只改 Codex proxy 路由与 maker-core 的父 thread 模型登记，没有界面、样式或文案变化。

## 核心指标（maker-core §3.4）

改动落在 model 映射路径，四项指标如下：

| 指标 | 影响 | 实测 |
|---|---|---|
| 缓存率 | 无。未改 system prompt、tool schema、拼接顺序或会话中途 MCP 注册。 | 对照 diff：无 prompt / tool 面改动。 |
| 性能 | 可忽略。只在 session start / setModel 做同步内存 Map 登记，并在 `collab_spawn` HTTP 请求上多一次模型名前缀判断。不在 token / event 热路径。 | 相关单测 164 + 480 项在数秒内跑完，无新增 await / IO。 |
| 返回内容准确性 | 正向修复。原先折扣路由子请求用裸 slug 打到 Gateway（403），且 Gateway 上的任务正文被当成跨源密文删掉。 | 单测锁住：子模型恢复为 `codex/gpt-5.6-terra`、Gateway 链路上保留 `TASK_BODY_BLOB`、第三方上游仍剥 `AGENT_ENC`。 |
| 模型路由 | 有意改动。目录层用原生 slug，HTTP 边界按父会话恢复 `codex/`。 | `createModelRoutingTransform` 对折扣父会话返回 Gateway `headerOverride`；非折扣父会话保持裸 slug。 |

未做正式包实机探针：当前运行中的 Cindy 仍是旧安装包，本 PR 不能替换它。协议边界已用与 #2921 相同的 `collab_spawn` 头和任务正文形状锁住。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/maker-host/__tests__/codex-subagent-config.test.ts src/main/maker-host/__tests__/codexProxyHost.test.ts
结果：2 files / 164 tests passed

pnpm --filter @cindy/maker-core exec vitest run src/agents/codex/index.test.ts
结果：1 file / 480 tests passed

node scripts/check-dco.mjs
结果：通过
```

### 手工验证

不涉及。当前运行中的 Cindy 安装包仍是旧逻辑，本 PR 未构建或替换正式包。

### 未执行的验证

未在本机跑通完整 `pnpm test:unit`：开发机 Node 26 与 `.nvmrc` Node 22 / `better-sqlite3` ABI 冲突。相关 workspace 单测已通过，完整矩阵交给 CI。

rebase 到最新 `main` 后，本地 desktop typecheck 因 `cindy-protocol` 工作区残留报出一批与本 PR 无关的缺包错误（`@cindy/ios-simulator-runtime` / 协议 export）。这些文件不在本 PR 的 8 个改动里。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [x] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：只在父会话已登记为 `codex/` 折扣路由时，给无前缀的子模型补回命名空间；只在 Cindy Gateway 上游保留 `agent_message` 密文。

### 影响与回滚

- 影响范围：Codex 原生子代理的模型目录注入、父 thread 路由登记、`collab_spawn` HTTP 模型名，以及 Gateway 上的 `agent_message` 密文去留。
- 回滚 / 降级方式：回退本 PR 即恢复旧行为。不改 schema、不改 prompt、不改安装布局。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
