### PR TITLE
feat(sidebar): 折叠项目汇总任务状态点

### DIFF
--- a/apps/desktop/src/renderer/__tests__/projectCollapsedAttention.test.ts
+++ b/apps/desktop/src/renderer/__tests__/projectCollapsedAttention.test.ts
@@ -1,0 +1,118 @@
+import { readFileSync } from 'node:fs';
+import { resolve as resolvePath } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import type { AttentionKind } from '@/lib/sessionAttentionStore';
+import type { RemoteSessionActivityPhase } from '@/features/device-link/remoteSessionActivityStore';
+import { resolveCollapsedProjectAttentionTone } from '../features/cc-agent/sidebar/projectCollapsedAttention';
+
+const sidebarDir = resolvePath(__dirname, '..', 'features', 'cc-agent', 'sidebar');
+const projectNodeSource = readFileSync(
+  resolvePath(sidebarDir, 'sections', 'ProjectNode.tsx'),
+  'utf8',
+);
+const projectsSectionSource = readFileSync(
+  resolvePath(sidebarDir, 'sections', 'ProjectsSection.tsx'),
+  'utf8',
+);
+const sidebarUpperSource = readFileSync(
+  resolvePath(__dirname, '..', 'features', 'cc-agent', 'CCAgentSidebarUpper.tsx'),
+  'utf8',
+);
+
+const sessions = (ids: string[]) => ids.map((id) => ({ id }));
+
+function resolve({
+  ids = ['session-1'],
+  notifications = [],
+  attentionKinds = [],
+  urgent = [],
+  remotePhases = [],
+}: {
+  ids?: string[];
+  notifications?: string[];
+  attentionKinds?: [string, AttentionKind][];
+  urgent?: string[];
+  remotePhases?: [string, RemoteSessionActivityPhase][];
+} = {}) {
+  const phases = new Map(remotePhases);
+  return resolveCollapsedProjectAttentionTone({
+    sessions: sessions(ids),
+    notifications: new Set(notifications),
+    attentionKinds: new Map(attentionKinds),
+    urgentSessionIds: new Set(urgent),
+    remotePhaseOf: (sessionId) => phases.get(sessionId),
+  });
+}
+
+describe('collapsed project attention tone', () => {
+  it('returns no aggregate for idle, running, or awaiting-only children', () => {
+    expect(resolve()).toBeNull();
+    expect(
+      resolve({ notifications: ['session-1'], attentionKinds: [['session-1', 'awaiting']] }),
+    ).toBeNull();
+    expect(resolve({ remotePhases: [['session-1', 'running']] })).toBeNull();
+    expect(resolve({ remotePhases: [['session-1', 'needs-interaction']] })).toBeNull();
+  });
+
+  it('shows green for local and remote completed unread children', () => {
+    expect(resolve({ notifications: ['session-1'], attentionKinds: [['session-1', 'done']] })).toBe(
+      'done',
+    );
+    // 定时任务未读可能没有 attention kind，子任务行仍显示完成绿点。
+    expect(resolve({ notifications: ['session-1'] })).toBe('done');
+    expect(resolve({ remotePhases: [['session-1', 'completed']] })).toBe('done');
+  });
+
+  it('shows red for local errors, urgent schedules, and remote errors', () => {
+    expect(
+      resolve({ notifications: ['session-1'], attentionKinds: [['session-1', 'error']] }),
+    ).toBe('error');
+    expect(resolve({ urgent: ['session-1'] })).toBe('error');
+    expect(resolve({ remotePhases: [['session-1', 'error']] })).toBe('error');
+  });
+
+  it('gives red priority when red and green children coexist', () => {
+    expect(
+      resolve({
+        ids: ['done', 'error'],
+        notifications: ['done', 'error'],
+        attentionKinds: [
+          ['done', 'done'],
+          ['error', 'error'],
+        ],
+      }),
+    ).toBe('error');
+  });
+
+  it('treats a remote running state as authoritative over stale local attention', () => {
+    expect(
+      resolve({
+        notifications: ['session-1'],
+        attentionKinds: [['session-1', 'error']],
+        remotePhases: [['session-1', 'running']],
+      }),
+    ).toBeNull();
+  });
+});
+
+describe('collapsed project attention wiring', () => {
+  it('renders the aggregate dot only while the project is collapsed', () => {
+    expect(projectNodeSource).toContain(
+      '!isEditingName && isCollapsed && collapsedAttentionTone ? (',
+    );
+    expect(projectNodeSource).toContain(
+      '<AttentionDot size={6} tone={collapsedAttentionTone} className="shrink-0" />',
+    );
+  });
+
+  it('feeds both regular and pinned project rows from their displayed children', () => {
+    expect(projectsSectionSource).toContain(
+      'collapsed.has(project.projectKey) ? collapsedAttentionToneFor(project.sessions) : null',
+    );
+    expect(sidebarUpperSource).toMatch(
+      /collapse\.collapsed\.has\(project\.projectKey\)[\s\S]*?collapsedAttentionToneFor\(displaySessions \?\? project\.sessions\)[\s\S]*?: null/,
+    );
+  });
+});

--- a/apps/desktop/src/renderer/__tests__/projectCollapsedAttention.test.ts
+++ b/apps/desktop/src/renderer/__tests__/projectCollapsedAttention.test.ts
@@ -25,12 +25,14 @@ const sessions = (ids: string[]) => ids.map((id) => ({ id }));
 
 function resolve({
   ids = ['session-1'],
+  running = [],
   notifications = [],
   attentionKinds = [],
   urgent = [],
   remotePhases = [],
 }: {
   ids?: string[];
+  running?: string[];
   notifications?: string[];
   attentionKinds?: [string, AttentionKind][];
   urgent?: string[];
@@ -39,6 +41,7 @@ function resolve({
   const phases = new Map(remotePhases);
   return resolveCollapsedProjectAttentionTone({
     sessions: sessions(ids),
+    runningSessionIds: new Set(running),
     notifications: new Set(notifications),
     attentionKinds: new Map(attentionKinds),
     urgentSessionIds: new Set(urgent),
@@ -92,6 +95,16 @@ describe('collapsed project attention tone', () => {
         notifications: ['session-1'],
         attentionKinds: [['session-1', 'error']],
         remotePhases: [['session-1', 'running']],
+      }),
+    ).toBeNull();
+  });
+
+  it('does not aggregate stale local completion while the child is running again', () => {
+    expect(
+      resolve({
+        running: ['session-1'],
+        notifications: ['session-1'],
+        attentionKinds: [['session-1', 'done']],
       }),
     ).toBeNull();
   });

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSidebarUpper.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSidebarUpper.tsx
@@ -1076,18 +1076,6 @@ function ExpandedView({
     return new Set([...notifications, ...unreadScheduleSessionIds]);
   }, [notifications, unreadScheduleSessionIds]);
   const remoteActivityRevision = useRemoteSessionActivityRevision();
-  const collapsedAttentionToneFor = useCallback(
-    (sessions: readonly Session[]) =>
-      resolveCollapsedProjectAttentionTone({
-        sessions,
-        notifications: sidebarNotifications,
-        attentionKinds,
-        urgentSessionIds: urgentSet,
-        remotePhaseOf: (sessionId) => getRemoteSessionActivity(sessionId)?.phase,
-      }),
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- remoteActivityRevision 代表 getRemoteSessionActivity 读到的整表内容
-    [sidebarNotifications, attentionKinds, urgentSet, remoteActivityRevision],
-  );
 
   const markAutomationSessionRunsRead = useCallback(
     (sessionId: string) => {
@@ -1133,6 +1121,25 @@ function ExpandedView({
     }
     return next;
   }, [effectiveRunningSessionIds, backgroundActivitySessionIds, orcaLeadWorkerMap]);
+  const collapsedAttentionToneFor = useCallback(
+    (sessions: readonly Session[]) =>
+      resolveCollapsedProjectAttentionTone({
+        sessions,
+        runningSessionIds: displayRunningSessionIds,
+        notifications: sidebarNotifications,
+        attentionKinds,
+        urgentSessionIds: urgentSet,
+        remotePhaseOf: (sessionId) => getRemoteSessionActivity(sessionId)?.phase,
+      }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- remoteActivityRevision 代表 getRemoteSessionActivity 读到的整表内容
+    [
+      displayRunningSessionIds,
+      sidebarNotifications,
+      attentionKinds,
+      urgentSet,
+      remoteActivityRevision,
+    ],
+  );
 
   // 本地会话用 effectiveIncludeArchived（snapshot 实际所属桶）避免切桶时先闪空；
   // device-link 远程镜像同时持有 active / archived 两桶，必须独立按 filter.status 筛选，

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSidebarUpper.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSidebarUpper.tsx
@@ -169,9 +169,11 @@ import type {
 } from './lib/automationSidebarGrouping';
 import { getSessionDeviceId } from '@/features/device-link/remoteProjectsStore';
 import {
+  getRemoteSessionActivity,
   useRemoteSessionActivity,
   useRemoteSessionActivityRevision,
 } from '@/features/device-link/remoteSessionActivityStore';
+import { resolveCollapsedProjectAttentionTone } from './sidebar/projectCollapsedAttention';
 import { WorkdirBrowseSidebar } from './workdir-browse/WorkdirBrowseSidebar';
 import {
   buildDocModeSwitchProjects,
@@ -1073,6 +1075,19 @@ function ExpandedView({
     if (unreadScheduleSessionIds.size === 0) return notifications;
     return new Set([...notifications, ...unreadScheduleSessionIds]);
   }, [notifications, unreadScheduleSessionIds]);
+  const remoteActivityRevision = useRemoteSessionActivityRevision();
+  const collapsedAttentionToneFor = useCallback(
+    (sessions: readonly Session[]) =>
+      resolveCollapsedProjectAttentionTone({
+        sessions,
+        notifications: sidebarNotifications,
+        attentionKinds,
+        urgentSessionIds: urgentSet,
+        remotePhaseOf: (sessionId) => getRemoteSessionActivity(sessionId)?.phase,
+      }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- remoteActivityRevision 代表 getRemoteSessionActivity 读到的整表内容
+    [sidebarNotifications, attentionKinds, urgentSet, remoteActivityRevision],
+  );
 
   const markAutomationSessionRunsRead = useCallback(
     (sessionId: string) => {
@@ -3346,6 +3361,11 @@ function ExpandedView({
                     sessionVariant={sessionVariant}
                     statusFilter={filter.status}
                     isCollapsed={collapse.collapsed.has(project.projectKey)}
+                    collapsedAttentionTone={
+                      collapse.collapsed.has(project.projectKey)
+                        ? collapsedAttentionToneFor(displaySessions ?? project.sessions)
+                        : null
+                    }
                     parentSectionCollapsed={parentSectionCollapsed}
                     activeSessionId={activeSessionId}
                     runningSessionIds={displayRunningSessionIds}

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/projectCollapsedAttention.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/projectCollapsedAttention.ts
@@ -1,0 +1,46 @@
+import type { AttentionKind } from '@/lib/sessionAttentionStore';
+import type { RemoteSessionActivityPhase } from '@/features/device-link/remoteSessionActivityStore';
+
+export type CollapsedProjectAttentionTone = 'error' | 'done';
+
+interface CollapsedProjectAttentionInput {
+  sessions: readonly { id: string }[];
+  notifications: ReadonlySet<string>;
+  attentionKinds: ReadonlyMap<string, AttentionKind>;
+  urgentSessionIds: ReadonlySet<string>;
+  remotePhaseOf: (sessionId: string) => RemoteSessionActivityPhase | undefined;
+}
+
+/**
+ * 折叠项目只汇总子任务实际可见的红/绿状态点。等待回复(蓝)与运行态不在此处
+ * 升格；若红绿同时存在，错误红点优先。
+ */
+export function resolveCollapsedProjectAttentionTone({
+  sessions,
+  notifications,
+  attentionKinds,
+  urgentSessionIds,
+  remotePhaseOf,
+}: CollapsedProjectAttentionInput): CollapsedProjectAttentionTone | null {
+  let hasDone = false;
+
+  for (const session of sessions) {
+    const remotePhase = remotePhaseOf(session.id);
+    if (remotePhase) {
+      if (remotePhase === 'error') return 'error';
+      if (remotePhase === 'completed') hasDone = true;
+      // 远程活动镜像是远程行右侧状态的权威来源；running / needs-interaction
+      // 分别显示 spinner / 蓝点，不能再被本地残留状态误汇总成红绿点。
+      continue;
+    }
+
+    if (urgentSessionIds.has(session.id)) return 'error';
+    if (!notifications.has(session.id)) continue;
+
+    const attentionKind = attentionKinds.get(session.id);
+    if (attentionKind === 'error') return 'error';
+    if (attentionKind !== 'awaiting') hasDone = true;
+  }
+
+  return hasDone ? 'done' : null;
+}

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/projectCollapsedAttention.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/projectCollapsedAttention.ts
@@ -5,6 +5,7 @@ export type CollapsedProjectAttentionTone = 'error' | 'done';
 
 interface CollapsedProjectAttentionInput {
   sessions: readonly { id: string }[];
+  runningSessionIds: ReadonlySet<string>;
   notifications: ReadonlySet<string>;
   attentionKinds: ReadonlyMap<string, AttentionKind>;
   urgentSessionIds: ReadonlySet<string>;
@@ -17,6 +18,7 @@ interface CollapsedProjectAttentionInput {
  */
 export function resolveCollapsedProjectAttentionTone({
   sessions,
+  runningSessionIds,
   notifications,
   attentionKinds,
   urgentSessionIds,
@@ -39,7 +41,8 @@ export function resolveCollapsedProjectAttentionTone({
 
     const attentionKind = attentionKinds.get(session.id);
     if (attentionKind === 'error') return 'error';
-    if (attentionKind !== 'awaiting') hasDone = true;
+    if (attentionKind === 'awaiting' || runningSessionIds.has(session.id)) continue;
+    hasDone = true;
   }
 
   return hasDone ? 'done' : null;

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/sections/ProjectNode.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/sections/ProjectNode.tsx
@@ -29,6 +29,7 @@ import { useTranslation } from 'react-i18next';
 
 import { cn } from '@/lib/utils';
 import { Tip } from '@/components/ui/tooltip';
+import { AttentionDot } from '@/components/sidebar/AttentionDot';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -57,6 +58,7 @@ import { RemoteProjectIcon } from '../RemoteProjectIcon';
 import { isDeviceLinkWriteBlocked } from '../../lib/remoteSessionWriteGuard';
 import { projectBulkArchiveActionForStatus } from '../../lib/projectBulkArchiveAction';
 import { getRemoteProjectMachineIdentity } from '../../lib/remoteProjectIdentity';
+import type { CollapsedProjectAttentionTone } from '../projectCollapsedAttention';
 
 const log = createLogger('ProjectNode');
 
@@ -69,6 +71,8 @@ export interface ProjectNodeProps {
   /** 当前会话状态筛选，决定项目菜单是批量归档还是批量恢复。 */
   statusFilter: FilterStatus;
   isCollapsed: boolean;
+  /** 折叠时汇总子任务的红/绿状态点；展开态由子任务行各自展示。 */
+  collapsedAttentionTone?: CollapsedProjectAttentionTone | null;
   /** 父级 Projects 段整体收起时,也要让项目内「显示全部」在动画后复位。 */
   parentSectionCollapsed: boolean;
   activeSessionId?: string;
@@ -123,6 +127,7 @@ export function ProjectNode({
   sessionVariant = 'text',
   statusFilter,
   isCollapsed,
+  collapsedAttentionTone = null,
   parentSectionCollapsed,
   activeSessionId,
   runningSessionIds,
@@ -342,6 +347,9 @@ export function ProjectNode({
             // (2026-08-12 用户裁决,与会话行的标题 + 远程图标同款)。
             <span className="min-w-0 max-w-full shrink truncate">{project.displayName}</span>
           )}
+          {!isEditingName && isCollapsed && collapsedAttentionTone ? (
+            <AttentionDot size={6} tone={collapsedAttentionTone} className="shrink-0" />
+          ) : null}
           {!isEditingName && isDeviceLink ? (
             <Tip text={remoteIdentity?.displayLabel ?? project.deviceLinkDeviceId ?? ''}>
               <RemoteProjectIcon

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/sections/ProjectsSection.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/sections/ProjectsSection.tsx
@@ -323,13 +323,14 @@ export function ProjectsSection({
     (sessions: readonly Session[]) =>
       resolveCollapsedProjectAttentionTone({
         sessions,
+        runningSessionIds,
         notifications,
         attentionKinds,
         urgentSessionIds: urgentSet,
         remotePhaseOf: (sessionId) => getRemoteSessionActivity(sessionId)?.phase,
       }),
     // eslint-disable-next-line react-hooks/exhaustive-deps -- remoteActivityRevision 代表 getRemoteSessionActivity 读到的整表内容
-    [notifications, attentionKinds, urgentSet, remoteActivityRevision],
+    [runningSessionIds, notifications, attentionKinds, urgentSet, remoteActivityRevision],
   );
   // 正在看的任务 id:files 路由下回落到被浏览文件所属任务。
   const viewedIdForSort = viewedSessionId ?? activeSessionId;

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/sections/ProjectsSection.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/sections/ProjectsSection.tsx
@@ -87,6 +87,7 @@ import type {
 import type { Session } from '@/lib/ccAgent.types';
 import type { FolderPickerOption } from '@/components/new-chat/FolderPickerPopover';
 import type { SessionMoveTarget } from '../sessionMoveTarget';
+import { resolveCollapsedProjectAttentionTone } from '../projectCollapsedAttention';
 
 /** 设备段折叠/对话组折叠共用的段 key:本机段 'local',远程段用 deviceId。 */
 const deviceSectionKey = (deviceId: string | null) => deviceId ?? 'local';
@@ -318,6 +319,18 @@ export function ProjectsSection({
   const attentionKinds = useSessionAttentionKinds();
   const urgentSet = useSessionAttentionUrgencySet();
   const remoteActivityRevision = useRemoteSessionActivityRevision();
+  const collapsedAttentionToneFor = useCallback(
+    (sessions: readonly Session[]) =>
+      resolveCollapsedProjectAttentionTone({
+        sessions,
+        notifications,
+        attentionKinds,
+        urgentSessionIds: urgentSet,
+        remotePhaseOf: (sessionId) => getRemoteSessionActivity(sessionId)?.phase,
+      }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- remoteActivityRevision 代表 getRemoteSessionActivity 读到的整表内容
+    [notifications, attentionKinds, urgentSet, remoteActivityRevision],
+  );
   // 正在看的任务 id:files 路由下回落到被浏览文件所属任务。
   const viewedIdForSort = viewedSessionId ?? activeSessionId;
   const priorityContext = useMemo(() => {
@@ -617,6 +630,9 @@ export function ProjectsSection({
       project={project}
       statusFilter={filter.status}
       isCollapsed={collapsed.has(project.projectKey)}
+      collapsedAttentionTone={
+        collapsed.has(project.projectKey) ? collapsedAttentionToneFor(project.sessions) : null
+      }
       parentSectionCollapsed={false}
       activeSessionId={activeSessionId}
       runningSessionIds={runningSessionIds}


### PR DESCRIPTION
## 这次改了什么

### 摘要

项目折叠后，原本只能看到项目名，子任务的完成未读或错误状态会被一起藏起来。本 PR 在折叠项目名后汇总显示子任务的红色或绿色状态点，红色错误优先；项目展开后仍由各子任务自行显示，不重复画汇总点。

### 变更类型

- [x] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：折叠项目需要保留子任务红点、绿点提示
- 本 PR 包含：普通项目与置顶项目；本地任务、远程任务和自动化任务未读状态；红色优先级；聚合逻辑回归测试
- 明确不包含：蓝色等待回复状态、运行中状态、其它侧栏排序或状态语义调整
- 用户可见变化：折叠项目下存在完成未读任务时显示绿点，存在错误任务时显示红点；展开项目不显示汇总点
- 是否存在 breaking change：无

### UI 变化

- 未附截图：本次未启动 Desktop 做手工目检
- 引用的设计规范：`docs/design-rules/DESIGN.md`「Light / Dark Dual-Mode Delivery Gate」与主题语义色约束。复用现有 `AttentionDot` 和 `--card-status-done` / `--card-status-error` 主题 token，不新增硬编码颜色或动效，Light / Dark 共用既有双态实现。

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：通过；apps/desktop 相关单测全绿。

pnpm --filter desktop run --if-present typecheck
结果：通过。

bash /Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh /Users/dash/Code/Cindy/cindy-collapsed-project-status-dots
结果：26,078 项通过，仅 src/main/cindy-brain/__tests__/ghostInstallReceipt.test.ts 的 2 项失败。

在最新 origin/main c4fbc7e7d 的干净临时 worktree 定向运行：
pnpm exec vitest run src/main/cindy-brain/__tests__/ghostInstallReceipt.test.ts
结果：同样稳定复现相同 2 项失败，确认属于 main 基线，与本 PR 无关。
```

### 手工验证

未执行；未启动 Desktop 客户端目检折叠与展开效果。

### 未执行的验证

- 未执行 Light / Dark 实机目检；本次直接复用已有主题化 `AttentionDot`。
- 完整 unit gate 未全绿，唯一失败已在最新干净 `origin/main` 复现并确认是基线问题。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop 侧栏的项目标题行，仅项目折叠时增加状态汇总点
- 回滚 / 降级方式：回退本 PR commit 即可；无数据迁移、协议或持久化影响

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
