### PR TITLE
fix(orca): guide safe Code Mode text arguments

### DIFF
--- a/packages/lizi-mcps/src/__tests__/codeModeFreeTextContract.test.ts
+++ b/packages/lizi-mcps/src/__tests__/codeModeFreeTextContract.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Orca 自由文本参数的 Code Mode 契约测试。
+ *
+ * 这些参数会被模型写入 exec 的 JavaScript 源码；schema 必须明确要求按 JSON
+ * 字符串字面量规则转义，避免反引号、插值片段或代码块在工具调用前破坏解析。
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+
+import { XdtHelperToolRegistry } from '../lizi_xdtHelperToolRegistry.js';
+import { registerCreateWorkerTool } from '../xdt-helper/create_worker.js';
+import { registerSendToWorkerTool } from '../xdt-helper/send_to_worker.js';
+
+const PARSER_HOSTILE_TEXT = [
+  '检查 `inline_code`、${workspace} 与以下代码：',
+  '```ts',
+  'const doubleQuoted = "中文";',
+  "const singleQuoted = 'text';",
+  '```',
+].join('\n');
+
+function setupCreateWorkerTool() {
+  const createWorker = vi.fn(async () => ({
+    ok: true as const,
+    workerId: 'worker-1',
+    workerSessionId: 'worker-session-1',
+  }));
+  const registry = new XdtHelperToolRegistry();
+  registerCreateWorkerTool(registry, { sessionId: 'lead-1', createWorker });
+  return { registry, createWorker };
+}
+
+function setupSendToWorkerTool() {
+  const sendToWorker = vi.fn(async () => ({
+    ok: true as const,
+    agentKind: 'codex' as const,
+    wakeKind: 'already-active' as const,
+    targetTitle: null,
+    targetLastUserSendAt: null,
+  }));
+  const registry = new XdtHelperToolRegistry();
+  registerSendToWorkerTool(registry, {
+    getSessionContext: () => ({ sessionId: 'lead-1' }),
+    sendToWorker,
+  });
+  return { registry, sendToWorker };
+}
+
+function modelVisibleFieldDescription(
+  registry: XdtHelperToolRegistry,
+  toolName: string,
+  field: string,
+): string | undefined {
+  const tool = registry.get(toolName);
+  if (!tool) throw new Error(`Missing tool: ${toolName}`);
+  const schema = z.toJSONSchema(z.object(tool.inputShape)) as {
+    properties?: Record<string, { description?: string }>;
+  };
+  return schema.properties?.[field]?.description;
+}
+
+async function callThroughGeneratedSource(
+  registry: XdtHelperToolRegistry,
+  toolName: string,
+  args: Record<string, unknown>,
+) {
+  const nestedTool = vi.fn((input: Record<string, unknown>) => registry.call(toolName, input));
+  const nestedName = `cindy_orca__${toolName}`;
+  const source = `return tools.${nestedName}(${JSON.stringify(args)});`;
+  const invoke = new Function('tools', source) as (
+    tools: Record<string, typeof nestedTool>,
+  ) => Promise<Awaited<ReturnType<typeof nestedTool>>>;
+
+  const result = await invoke({ [nestedName]: nestedTool });
+  expect(nestedTool).toHaveBeenCalledTimes(1);
+  return result;
+}
+
+describe('Orca Code Mode free-text contract', () => {
+  it.each([
+    ['create_worker', setupCreateWorkerTool, 'initial_task'],
+    ['send_to_worker', setupSendToWorkerTool, 'message'],
+  ] as const)('%s 要求把自由文本编码为 JSON 字符串字面量', (_name, setup, field) => {
+    const { registry } = setup();
+    const description = modelVisibleFieldDescription(registry, _name, field);
+
+    expect(description).toContain('JSON.stringify');
+    expect(description).toContain('模板字符串');
+    expect(description).toContain('工具调用前');
+  });
+
+  it('create_worker 原样透传包含解析敏感字符的 initial_task', async () => {
+    const { registry, createWorker } = setupCreateWorkerTool();
+
+    const result = await callThroughGeneratedSource(registry, 'create_worker', {
+      role: 'developer',
+      agent: 'codex',
+      label: 'developer_1',
+      initial_task: PARSER_HOSTILE_TEXT,
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(createWorker).toHaveBeenCalledWith(expect.objectContaining({
+      initialTask: PARSER_HOSTILE_TEXT,
+    }));
+  });
+
+  it('send_to_worker 原样透传包含解析敏感字符的 message', async () => {
+    const { registry, sendToWorker } = setupSendToWorkerTool();
+
+    const result = await callThroughGeneratedSource(registry, 'send_to_worker', {
+      target_session_id: 'worker-session-1',
+      message: PARSER_HOSTILE_TEXT,
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(sendToWorker).toHaveBeenCalledWith({
+      callerLeadSessionId: 'lead-1',
+      targetSessionId: 'worker-session-1',
+      message: PARSER_HOSTILE_TEXT,
+    });
+  });
+});

--- a/packages/lizi-mcps/src/xdt-helper/_code_mode.ts
+++ b/packages/lizi-mcps/src/xdt-helper/_code_mode.ts
@@ -1,0 +1,3 @@
+/** Code Mode 生成工具调用源码时，自由文本参数必须遵守的稳定编码契约。 */
+export const CODE_MODE_FREE_TEXT_GUIDANCE =
+  'Code Mode 生成调用源码时，必须把正文编码成 JSON 字符串字面量（采用 JSON.stringify 的转义规则）再作为参数值；禁止把原文直接嵌入模板字符串，否则反引号、${...} 或代码块会在工具调用前导致 JavaScript 解析失败';

--- a/packages/lizi-mcps/src/xdt-helper/create_worker.ts
+++ b/packages/lizi-mcps/src/xdt-helper/create_worker.ts
@@ -7,6 +7,7 @@ import { z } from 'zod';
 
 import type { XdtHelperToolRegistry } from '../lizi_xdtHelperToolRegistry.js';
 import type { ControlDispatchOutcome, ControlResult, ControlWorkerAgent } from '../lizi_xdtHelperMcpServer.js';
+import { CODE_MODE_FREE_TEXT_GUIDANCE } from './_code_mode.js';
 import { okPayload, errorPayload } from './_payload.js';
 
 const WORKER_LABEL_PATTERN = /^[a-z0-9_-]+$/i;
@@ -101,7 +102,7 @@ export const createWorkerSpecSchema = z.object({
     .string()
     .min(1)
     .optional()
-    .describe('可选, 创建后立即派给 worker 的第一条消息'),
+    .describe(`可选, 创建后立即派给 worker 的第一条消息。${CODE_MODE_FREE_TEXT_GUIDANCE}`),
 }).strict();
 
 export type CreateWorkerSpec = z.infer<typeof createWorkerSpecSchema>;

--- a/packages/lizi-mcps/src/xdt-helper/send_to_worker.ts
+++ b/packages/lizi-mcps/src/xdt-helper/send_to_worker.ts
@@ -9,6 +9,7 @@ import { z } from 'zod';
 
 import type { XdtHelperToolRegistry } from '../lizi_xdtHelperToolRegistry.js';
 import type { ControlResult } from '../lizi_xdtHelperMcpServer.js';
+import { CODE_MODE_FREE_TEXT_GUIDANCE } from './_code_mode.js';
 import { errorPayload, okPayload } from './_payload.js';
 
 export interface SendToWorkerDeps {
@@ -55,7 +56,7 @@ export function registerSendToWorkerTool(
       message: z
         .string()
         .min(1)
-        .describe('要投递给 worker 的消息正文'),
+        .describe(`要投递给 worker 的消息正文。${CODE_MODE_FREE_TEXT_GUIDANCE}`),
     },
     handler: async ({ target_session_id, message }) => {
       const ctx = deps.getSessionContext?.();


### PR DESCRIPTION
## 这次改了什么

### 摘要

为 Orca 的自由文本派工参数补充 Code Mode 安全编码契约：生成 JavaScript 工具调用源码时，正文必须按 JSON.stringify 的转义规则编码为 JSON 字符串字面量，不能把原文直接嵌入模板字符串。这样包含 Markdown 反引号、JavaScript 插值片段、单双引号、中文或代码块的任务正文，不会在嵌套工具调用前破坏源码解析。

同时新增回归测试，验证模型实际可见的 JSON Schema 包含该约束，并通过动态生成的 tools.cindy_orca__create_worker / send_to_worker 调用验证源码可解析、嵌套工具只调用一次、正文逐字透传。

### 变更类型

- [ ] feat 新功能
- [x] fix 缺陷修复
- [ ] refactor / perf 重构或性能优化
- [ ] docs / test / chore 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：关联 #2602
- 本 PR 包含：create_worker.initial_task（create_workers 共用该 schema）和 send_to_worker.message 的 Code Mode 自由文本编码说明；解析敏感字符的回归测试。
- 明确不包含：不修改系统提示词、exec 宿主或 Worker 派发状态机；Issue 评论中的恢复态 Worker 单文件读取 Unexpected end of input 未能由纯文本绝对路径复现，因此不在本 PR 中宣称修复。
- 用户可见变化：Code Mode 在生成 Orca 派工调用时获得明确的安全字符串编码约束，降低工具调用前 JavaScript 解析失败的概率。
- 是否存在 breaking change：无。

### UI 变化

不涉及。

- 引用的设计规范：不涉及。

## 怎么验证的

### 自动验证

```text
Node.js 22.22.3 / pnpm 10.33.2

node_modules/.bin/vitest.CMD run packages/lizi-mcps/src/__tests__/codeModeFreeTextContract.test.ts
结果：4 passed

node_modules/.bin/tsc.CMD --noEmit（packages/lizi-mcps）
结果：通过

node_modules/.bin/vitest.CMD run packages/lizi-mcps/src
结果：43 files passed；495 tests passed；5 skipped

pnpm test:unit:related
结果：apps/desktop unit 通过（809.3s）；packages/lizi-mcps unit 通过（24.5s）

pnpm check:dco
结果：1 commit signed off
```

首次在受限沙箱中运行 related 门禁时，桌面测试清理 E:\tmp\xdt-* 收到 EPERM 并产生连锁失败；在正常 Windows 用户权限下原样复跑后全部通过。

### 手工验证

- Windows 11：原始正文直接嵌入模板字符串时，可在嵌套工具调用前复现 SyntaxError。
- 同一正文按 JSON 字符串字面量生成调用源码后，可以正常解析；mock 嵌套工具恰好调用一次，正文逐字一致。
- 补充评论中的纯文本绝对路径按相同方式生成读取调用时，可以解析并触发 mock 读取；当前没有证据将其 Unexpected end of input 判定为与本 Issue 相同根因。

### 未执行的验证

未执行打包后的桌面 UI E2E：本改动只调整静态工具 schema 描述，不涉及 UI、Worker 业务逻辑或消息内容转换；已运行 desktop 全量 unit 门禁。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：只增加两个模型可见字段的静态描述；共享约束为 127 字符、279 UTF-8 字节，在两个 schema 中共增加 558 字节。内容固定，不引入逐轮动态值或缓存抖动；不增加 I/O、网络调用或运行时分支。参数形状和 host 透传语义保持不变。
- 回滚 / 降级方式：直接回滚本 PR 提交即可恢复原工具描述；无数据迁移或兼容处理。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（git commit -s，见 DCO）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因