### PR TITLE
fix(desktop): one-shot 按清单传 effort 并关闭 thinking

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/titleOneShot.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/titleOneShot.test.ts
@@ -669,6 +669,7 @@ describe('generateTitleViaProvider — anthropic(Messages)', () => {
     expect(body.model).toBe('claude-haiku-4-5-20251001'); // 经 toSdkModelString 还原
     expect(body.messages).toEqual([{ role: 'user', content: '为这条消息起标题：编译报错' }]);
     expect(body.system).toBeUndefined(); // 不注入身份段
+    expect(body.thinking).toEqual({ type: 'disabled' });
   });
   it('先验证完整响应再按旧契约截到 40 个 Unicode 字符', async () => {
     const longTitle = '标题'.repeat(30);
@@ -843,7 +844,7 @@ describe('generateTitleViaProvider — xd(网关 chat-completions)', () => {
       setXdGatewayModels([]);
     }
   });
-  it('网关模型未下发 efforts 时仍写死 reasoning_effort=low', async () => {
+  it('网关模型未下发 efforts 时不传 reasoning_effort', async () => {
     setXdGatewayModels([
       xdGatewayModel('codex/gpt-5.6-luna', 'chat', { efforts: [], defaultEffort: null }),
     ]);
@@ -864,11 +865,12 @@ describe('generateTitleViaProvider — xd(网关 chat-completions)', () => {
         string,
         { body: string },
       ];
-      expect(JSON.parse(init.body)).toMatchObject({
+      const body = JSON.parse(init.body) as Record<string, unknown>;
+      expect(body).toMatchObject({
         model: 'codex/gpt-5.6-luna',
         thinking: { type: 'disabled' },
-        reasoning_effort: 'low',
       });
+      expect(body).not.toHaveProperty('reasoning_effort');
     } finally {
       setXdGatewayModels([]);
     }

--- a/apps/desktop/src/main/maker-host/__tests__/titleOneShot.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/titleOneShot.test.ts
@@ -837,6 +837,37 @@ describe('generateTitleViaProvider — xd(网关 chat-completions)', () => {
         model: 'deepseek/deepseek-v4-flash',
         max_tokens: 32,
         thinking: { type: 'disabled' },
+        reasoning_effort: 'low',
+      });
+    } finally {
+      setXdGatewayModels([]);
+    }
+  });
+  it('网关模型未下发 efforts 时仍写死 reasoning_effort=low', async () => {
+    setXdGatewayModels([
+      xdGatewayModel('codex/gpt-5.6-luna', 'chat', { efforts: [], defaultEffort: null }),
+    ]);
+    try {
+      const fetchImpl = fakeFetch(() => ({
+        json: { choices: [{ message: { content: '下一步改超时' } }] },
+      }));
+      await generateTitleViaProvider(
+        { sessionId: 's3', agentKind: 'claude-code', prompt: 'x' },
+        {
+          fetchImpl,
+          readSessionProviderId: async () => 'xd',
+          listConnectedProviders: async () => [providerStub('xd')],
+          readGatewayKey: () => 'gk-1',
+        },
+      );
+      const [, init] = vi.mocked(fetchImpl).mock.calls[0] as [
+        string,
+        { body: string },
+      ];
+      expect(JSON.parse(init.body)).toMatchObject({
+        model: 'codex/gpt-5.6-luna',
+        thinking: { type: 'disabled' },
+        reasoning_effort: 'low',
       });
     } finally {
       setXdGatewayModels([]);

--- a/apps/desktop/src/main/maker-host/title-one-shot.ts
+++ b/apps/desktop/src/main/maker-host/title-one-shot.ts
@@ -68,8 +68,6 @@ const TITLE_MAX_TOKENS = 32;
  * 网关认 OpenAI 兼容的 thinking.type=disabled;官方 no_think / enable_thinking=false 无效。
  */
 const TITLE_GATEWAY_THINKING = { type: 'disabled' } as const;
-/** GPT / Codex 推理档 one-shot 固定用最低档，避免回落到模型默认 high。 */
-const TITLE_GATEWAY_REASONING_EFFORT = 'low' as const;
 /** 异常响应保护:完整模型输出超过此 Unicode 长度就拒绝,再按历史契约截到 40 字。 */
 const TITLE_OUTPUT_MAX_CHARS = 256;
 /**
@@ -287,6 +285,7 @@ async function fetchAnthropicTitle(
   signal: AbortSignal,
   maxTokens: number = TITLE_MAX_TOKENS,
   systemPrompt?: string,
+  thinking?: typeof TITLE_GATEWAY_THINKING | null,
 ): Promise<string> {
   // Anthropic Messages API 不支持 role: 'system' 消息 —— 系统指令必须写入
   // 顶层 `system` 字段，否则请求会被 API 拒绝。
@@ -297,6 +296,10 @@ async function fetchAnthropicTitle(
   };
   if (systemPrompt) {
     body.system = systemPrompt;
+  }
+  // 标题 / 预测只要短正文；有 thinking 的 Claude 档不关会先烧 token。
+  if (thinking) {
+    body.thinking = thinking;
   }
   const res = await fetchImpl(`${trimTrailingSlash(upstream)}/v1/messages`, {
     method: 'POST',
@@ -376,14 +379,14 @@ async function fetchGatewayTitle(
   signal: AbortSignal,
   maxTokens: number = TITLE_MAX_TOKENS,
   systemPrompt?: string,
+  thinking?: typeof TITLE_GATEWAY_THINKING | null,
+  effort?: Effort | null,
 ): Promise<string> {
   const messages: Array<{ role: string; content: string }> = [];
   if (systemPrompt) messages.push({ role: 'system', content: systemPrompt });
   messages.push({ role: 'user', content: prompt });
 
-  // thinking.type=disabled：Hy3 / DeepSeek 等网关思考模型。
-  // reasoning_effort 写死 low：GPT / Codex 推理档（如 gpt-5.6-luna）不认 thinking 字段，
-  // 且 XD /models 常不下发 efforts，依赖清单最低档会整段漏传、回落到默认 high。
+  // thinking / reasoning_effort 都由调用方按 TitleTarget 传入，函数内不写死。
   const res = await fetchImpl(`${trimTrailingSlash(upstream)}/chat/completions`, {
     method: 'POST',
     signal,
@@ -394,8 +397,8 @@ async function fetchGatewayTitle(
     body: JSON.stringify({
       model: modelId,
       max_tokens: maxTokens,
-      thinking: TITLE_GATEWAY_THINKING,
-      reasoning_effort: TITLE_GATEWAY_REASONING_EFFORT,
+      ...(thinking ? { thinking } : {}),
+      ...(effort ? { reasoning_effort: effort } : {}),
       messages,
     }),
   });
@@ -683,6 +686,7 @@ log.debug('title oneShot skipped: no title target', {
           controller.signal,
           maxTokens,
           opts?.systemPrompt,
+          TITLE_GATEWAY_THINKING,
         );
         break;
       }
@@ -806,6 +810,8 @@ log.debug('title oneShot skipped: no title target', {
           controller.signal,
           maxTokens,
           opts?.systemPrompt,
+          TITLE_GATEWAY_THINKING,
+          target.effort,
         );
         break;
       }

--- a/apps/desktop/src/main/maker-host/title-one-shot.ts
+++ b/apps/desktop/src/main/maker-host/title-one-shot.ts
@@ -68,6 +68,8 @@ const TITLE_MAX_TOKENS = 32;
  * 网关认 OpenAI 兼容的 thinking.type=disabled;官方 no_think / enable_thinking=false 无效。
  */
 const TITLE_GATEWAY_THINKING = { type: 'disabled' } as const;
+/** GPT / Codex 推理档 one-shot 固定用最低档，避免回落到模型默认 high。 */
+const TITLE_GATEWAY_REASONING_EFFORT = 'low' as const;
 /** 异常响应保护:完整模型输出超过此 Unicode 长度就拒绝,再按历史契约截到 40 字。 */
 const TITLE_OUTPUT_MAX_CHARS = 256;
 /**
@@ -379,6 +381,9 @@ async function fetchGatewayTitle(
   if (systemPrompt) messages.push({ role: 'system', content: systemPrompt });
   messages.push({ role: 'user', content: prompt });
 
+  // thinking.type=disabled：Hy3 / DeepSeek 等网关思考模型。
+  // reasoning_effort 写死 low：GPT / Codex 推理档（如 gpt-5.6-luna）不认 thinking 字段，
+  // 且 XD /models 常不下发 efforts，依赖清单最低档会整段漏传、回落到默认 high。
   const res = await fetchImpl(`${trimTrailingSlash(upstream)}/chat/completions`, {
     method: 'POST',
     signal,
@@ -390,6 +395,7 @@ async function fetchGatewayTitle(
       model: modelId,
       max_tokens: maxTokens,
       thinking: TITLE_GATEWAY_THINKING,
+      reasoning_effort: TITLE_GATEWAY_REASONING_EFFORT,
       messages,
     }),
   });


### PR DESCRIPTION
## 这次改了什么

### 摘要

输入框预测和自动起标题共用 XD 网关 / Anthropic one-shot。Luna 等 GPT 推理档不认 `thinking.type=disabled`，需要靠 `reasoning_effort` 压思考；但 `/models` 常不下发 `efforts`，写死 `low` 又可能给不支持该档的模型带去 400。

本 PR 改为：

- 网关请求按 `TitleTarget.effort`（清单最低档）传 `reasoning_effort`，没有档位就不传
- Anthropic Messages 与网关 fetcher 都接收 `thinking` 参数，由调用方传入 `TITLE_GATEWAY_THINKING`（`{ type: 'disabled' }`）

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：title / prompt-prediction one-shot 请求体按清单传 effort，并关闭 thinking
- 明确不包含：不改预测触发逻辑、超时、模型选型；不在清单为空时猜测 `low`
- 用户可见变化：清单声明了 effort 的网关模型（如 DeepSeek）会以最低档请求；Anthropic one-shot 会带 `thinking.type=disabled`
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：不涉及：仅改 one-shot HTTP 请求体，无界面、交互或文案变更

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：PASS apps/desktop unit (65.5s)

pnpm --filter desktop run typecheck
结果：通过

pnpm check:dco
结果：DCO check passed: 2 commits signed off
```

### 手工验证

定位现场：`codex/gpt-5.6-luna` 走 gateway-chat，12s abort。用于定位的临时 dump 未进 PR。

### 未执行的验证

未在改动后的新构建里再抓一次真实网关 / Anthropic 请求体（需重启 Desktop）。Haiku 对 `thinking.type=disabled` 的现网接受情况未实测。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：Anthropic Haiku 可能不认 `thinking`；清单未下发 efforts 的 Luna 仍不会带 reasoning_effort

### 影响与回滚

- 影响范围：走 XD 网关或 Anthropic 订阅的自动起标题与输入框预测
- 回滚 / 降级方式：回退本 PR 即可

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
