### PR TITLE
fix(desktop): 修正 Windows 主界面关闭键位置

### DIFF
--- a/apps/desktop/src/renderer/components/layout/MainLayout.tsx
+++ b/apps/desktop/src/renderer/components/layout/MainLayout.tsx
@@ -1428,7 +1428,7 @@ export function MainLayout() {
             右上角（系统按钮下一行），与截图中的原位置一致。 */}
         {!isMac && (
           <div
-            className="absolute right-0 top-0 z-50 flex h-[46px] items-center"
+            className="absolute right-0 top-0 z-50 flex h-[46px] items-center pr-2"
             style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
           >
             <WindowControls />


### PR DESCRIPTION
## 这次改了什么

### 摘要

Windows 唤醒阶段的窗口控制键位置正常，但进入正式主界面后，按钮簇直接贴住无边框窗口的右侧物理边界；在非整数显示缩放下，关闭键会显得偏右。

本 PR 只给正式主界面的 Windows 窗口按钮簇增加 8px 右侧间距，使其与 Splash 阶段已有的 `px-2` 位置一致。共享 `WindowControls` 保持不变，登录页、唤醒页和辅助窗口不会被连带调整。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：用户在 Windows 实机发现正式主界面的关闭键相较唤醒阶段视觉偏右
- 本 PR 包含：为 `MainLayout` 的 Windows 窗口控制按钮容器增加 `pr-2`
- 明确不包含：不修改共享窗口控制组件、不改变按钮尺寸和关闭行为、不调整 macOS 红绿灯
- 用户可见变化：Windows 正式主界面的最小化、最大化、关闭按钮整体向左留出 8px
- 是否存在 breaking change：无

### UI 变化

- Windows：正式主界面窗口按钮簇与右侧边界保留 8px 间距，与唤醒阶段对齐
- 引用的设计规范：`docs/design-rules/DESIGN.md` §5「Spacing System」规定基础单位为 8px；本改动使用 Tailwind `pr-2` 落实该基础间距。共享组件未改色，Light / Dark 继续复用现有主题样式。

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：PASS（apps/desktop related tests）

pnpm --filter desktop run --if-present typecheck
结果：PASS

pnpm check:dco
结果：PASS（1 commit signed off）
```

### 手工验证

- 已对用户提供的 Windows 实机截图做像素定位，并与 Splash/MainLayout 两阶段源码对比
- 本地未启动新的 Desktop 实例，因此没有在本分支构建中重新目检 Light / Dark

### 未执行的验证

- 未执行 Windows 打包构建；本次仅调整一个 Tailwind 布局类，相关单测与 Desktop typecheck 已通过
- 未在本分支实机目检 Light / Dark；改动不涉及颜色或主题 token

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Windows 正式主界面右上角的窗口控制按钮簇；macOS 分支不渲染该节点
- 回滚 / 降级方式：移除 `MainLayout` 容器上的 `pr-2`

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次无需更新产品文档）
- [x] 已确认测试结果或说明未执行原因
