### PR TITLE
fix(desktop): 用档位文字替换 Worker 列表信号条

### DIFF
--- a/apps/desktop/src/renderer/features/cc-agent/RolePillDropdown.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/RolePillDropdown.tsx
@@ -5,16 +5,17 @@
  * Popover: WORKERS header + worker rows + Create new worker 行。
  */
 
-import { useState, useRef, useEffect, useLayoutEffect, useCallback, type ReactNode, type WheelEvent } from 'react';
-import { useTranslation } from 'react-i18next';
 import {
-  Check,
-  ChevronDown,
-  ChevronUp,
-  Plus,
-  X,
-  EllipsisVertical,
-} from 'lucide-react';
+  useState,
+  useRef,
+  useEffect,
+  useLayoutEffect,
+  useCallback,
+  type ReactNode,
+  type WheelEvent,
+} from 'react';
+import { useTranslation } from 'react-i18next';
+import { Check, ChevronDown, ChevronUp, Plus, X, EllipsisVertical } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useAppShortcutDisplay } from '@/hooks/useAppShortcut';
 import { useConfirmDialog } from '@/components/ui/confirm-dialog-provider';
@@ -22,10 +23,7 @@ import { Tip } from '@/components/ui/tooltip';
 import { VendorIcon, agentKindToVendor } from '@/components/sidebar/VendorIcon';
 import type { WorkerInfo } from './hooks/useWorkers';
 import { shouldShowWorkerLabel } from './workerLabel';
-import {
-  clearWorkerAttention,
-  useWorkerAttentionSnapshot,
-} from './lib/workerAttentionStore';
+import { clearWorkerAttention, useWorkerAttentionSnapshot } from './lib/workerAttentionStore';
 
 // Strip provider prefix: 'deepseek/deepseek-v4-pro' → 'deepseek-v4-pro'.
 // 通用代理网关返回的 model id 经常带 'provider/model' 形式, UI 里只显末段更清爽.
@@ -34,36 +32,31 @@ function simplifyModelName(model: string): string {
   return slash >= 0 ? model.slice(slash + 1) : model;
 }
 
-// Effort 文字 → 5-bar 视觉编码 (跟主 pill 的 Codex effort 表达对齐).
-// minimal/low/medium/high/max 对应填 1/2/3/4/5 个柱.
-const EFFORT_LEVELS = ['minimal', 'low', 'medium', 'high', 'max'] as const;
-function effortFillCount(effort: string | null): number {
-  const idx = EFFORT_LEVELS.indexOf((effort ?? 'medium') as (typeof EFFORT_LEVELS)[number]);
-  return idx >= 0 ? idx + 1 : 3;
+// 各模型档位集合不同,信号条没有稳定含义。已知档才写词表里的短文案,
+// 未知值不显示,也不再默默掉回 medium。
+const WORKER_EFFORT_LEVELS = new Set(['minimal', 'low', 'medium', 'high', 'xhigh', 'max', 'ultra']);
+
+function workerEffortLabel(t: (key: string) => string, effort: string | null): string | null {
+  if (!effort || !WORKER_EFFORT_LEVELS.has(effort)) return null;
+  return t(`effortLevels.${effort}`);
 }
 
-function EffortBars({ effort }: { effort: string | null }) {
-  const fill = effortFillCount(effort);
+function WorkerModelLine({
+  model,
+  effort,
+}: {
+  model: string;
+  effort: string | null;
+}) {
+  const { t } = useTranslation();
+  const effortLabel = workerEffortLabel(t, effort);
+  // 列表选中行是浅色 chip 底,不能套深色药丸上的 --surface-on-card,
+  // 日间会糊成看不清。副行一律走次级字色。
   return (
-    <span
-      className="inline-flex items-end"
-      style={{ gap: 1.5, height: 8 }}
-      aria-label={`effort ${effort ?? 'medium'}`}
-    >
-      {[0, 1, 2, 3, 4].map((i) => (
-        <span
-          key={i}
-          style={{
-            display: 'inline-block',
-            width: 2,
-            height: 4 + i,
-            borderRadius: 1,
-            backgroundColor: i < fill ? 'var(--text-secondary)' : 'var(--text-tertiary)',
-            opacity: i < fill ? 1 : 0.35,
-          }}
-        />
-      ))}
-    </span>
+    <div className="mt-0.5 ml-[26px] whitespace-nowrap text-12 leading-snug text-[var(--text-secondary)]">
+      {simplifyModelName(model)}
+      {effortLabel ? ` · ${effortLabel}` : null}
+    </div>
   );
 }
 
@@ -243,12 +236,7 @@ function WorkerSummary({
 }) {
   return (
     <>
-      <div
-        className={cn(
-          'flex items-center gap-2 leading-snug',
-          compact ? 'text-11' : 'text-13',
-        )}
-      >
+      <div className={cn('flex items-center gap-2 leading-snug', compact ? 'text-11' : 'text-13')}>
         <WorkerAvatar
           agent={worker.agent}
           status={worker.status}
@@ -287,10 +275,7 @@ function WorkerSummary({
         )}
       </div>
       {!compact && (
-        <div className="mt-0.5 ml-[26px] flex items-center gap-1.5 text-11 leading-snug text-[var(--text-tertiary)]">
-          <span>{simplifyModelName(worker.model)}</span>
-          <EffortBars effort={worker.effort} />
-        </div>
+        <WorkerModelLine model={worker.model} effort={worker.effort} />
       )}
     </>
   );
@@ -351,9 +336,9 @@ function useAnchorMenuMaxHeight(
   anchorRef: { current: HTMLElement | null },
   open: boolean,
 ): { maxHeight: number; placeAbove: boolean } | undefined {
-  const [placement, setPlacement] = useState<{ maxHeight: number; placeAbove: boolean } | undefined>(
-    undefined,
-  );
+  const [placement, setPlacement] = useState<
+    { maxHeight: number; placeAbove: boolean } | undefined
+  >(undefined);
   useLayoutEffect(() => {
     if (!open) return;
     const update = () => {
@@ -378,13 +363,9 @@ function useAnchorMenuMaxHeight(
     window.addEventListener('resize', update);
     // 侧栏经拖拽分割线（pointermove）调整宽度时不会触发 window.resize；用 ResizeObserver
     // 监听裁剪祖先容器尺寸变化，菜单打开期间及时重算边界，避免菜单超出当前侧栏被裁掉。
-    const clipContainer = anchorRef.current
-      ? findClippingContainer(anchorRef.current)
-      : null;
+    const clipContainer = anchorRef.current ? findClippingContainer(anchorRef.current) : null;
     const resizeObserver =
-      typeof ResizeObserver !== 'undefined' && clipContainer
-        ? new ResizeObserver(update)
-        : null;
+      typeof ResizeObserver !== 'undefined' && clipContainer ? new ResizeObserver(update) : null;
     if (resizeObserver && clipContainer) resizeObserver.observe(clipContainer);
     return () => {
       window.removeEventListener('resize', update);
@@ -411,23 +392,17 @@ function useAnchorMenuMaxWidth(
       const el = anchorRef.current;
       if (!el) return;
       const anchor = el.getBoundingClientRect();
-      const bounds =
-        findClippingBounds(el) ?? { left: 0, right: window.innerWidth };
-      const available =
-        align === 'left' ? bounds.right - anchor.left : anchor.right - bounds.left;
+      const bounds = findClippingBounds(el) ?? { left: 0, right: window.innerWidth };
+      const available = align === 'left' ? bounds.right - anchor.left : anchor.right - bounds.left;
       setMaxWidth(Math.max(0, available));
     };
     update();
     window.addEventListener('resize', update);
     // 侧栏经拖拽分割线（pointermove）调整宽度时不会触发 window.resize；用 ResizeObserver
     // 监听裁剪祖先容器尺寸变化，菜单打开期间及时重算边界，避免菜单超出当前侧栏被裁掉。
-    const clipContainer = anchorRef.current
-      ? findClippingContainer(anchorRef.current)
-      : null;
+    const clipContainer = anchorRef.current ? findClippingContainer(anchorRef.current) : null;
     const resizeObserver =
-      typeof ResizeObserver !== 'undefined' && clipContainer
-        ? new ResizeObserver(update)
-        : null;
+      typeof ResizeObserver !== 'undefined' && clipContainer ? new ResizeObserver(update) : null;
     if (resizeObserver && clipContainer) resizeObserver.observe(clipContainer);
     return () => {
       window.removeEventListener('resize', update);
@@ -545,12 +520,7 @@ function WorkerLayoutMenu({
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
     >
-      <Tip
-        text={t('orca.rolePill.layoutMenuLabel')}
-        side="bottom"
-        delay={250}
-        disabled={open}
-      >
+      <Tip text={t('orca.rolePill.layoutMenuLabel')} side="bottom" delay={250} disabled={open}>
         <button
           type="button"
           aria-label={t('orca.rolePill.layoutMenuLabel')}
@@ -631,10 +601,7 @@ function WorkerLayoutMenu({
                             </>
                           )}
                         </div>
-                        <div className="mt-0.5 ml-[26px] flex items-center gap-1.5 text-11 leading-snug text-[var(--text-tertiary)]">
-                          <span>{simplifyModelName(w.model)}</span>
-                          <EffortBars effort={w.effort} />
-                        </div>
+                        <WorkerModelLine model={w.model} effort={w.effort} />
                       </button>
                       {/* hover archive ✕ */}
                       <button
@@ -778,7 +745,8 @@ function WorkerTabsList({
   const [scrollState, setScrollState] = useState({ left: false, right: false });
   const attention = useWorkerAttentionSnapshot();
   const requestArchiveWorker = useRequestArchiveWorker(onArchiveWorker);
-  const focusedWorkerId = selectedWorkerId ?? workers.find((worker) => worker.focused)?.workerId ?? null;
+  const focusedWorkerId =
+    selectedWorkerId ?? workers.find((worker) => worker.focused)?.workerId ?? null;
 
   useLayoutEffect(() => {
     if (!clearAttentionWhenVisible) return;
@@ -1143,7 +1111,7 @@ export function RolePillDropdown({
     <div className="relative" onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
       {/* ── Trigger: 单 chip [avatar 含 status + role + caret].
             model / effort 不在这里展示 — focused worker 的 model 在输入框那边自然
-            可见, dropdown 列表里 worker rows 第二行还展示简化 model + effort bars
+            可见, dropdown 列表里 worker rows 第二行还展示简化 model + 档位文字
             供切换时对比, 这里只用 role 标识 "当前活跃的 worker". ── */}
       <button
         ref={triggerRef}
@@ -1250,12 +1218,9 @@ export function RolePillDropdown({
                         </>
                       )}
                     </div>
-                    {/* 副行: 简化 model 名 (去 provider 前缀) + effort bars.
-                        Claude / Codex 都显 (两种 agent 都有 reasoning effort 概念). */}
-                    <div className="mt-0.5 ml-[26px] flex items-center gap-1.5 text-11 leading-snug text-[var(--text-tertiary)]">
-                      <span>{simplifyModelName(w.model)}</span>
-                      <EffortBars effort={w.effort} />
-                    </div>
+                    {/* 副行: 简化 model 名 (去 provider 前缀) + 档位文字.
+                        各模型档位集合不同,不用信号条假装同一把尺子. */}
+                    <WorkerModelLine model={w.model} effort={w.effort} />
                   </button>
                   {/* hover archive ✕ */}
                   <button

--- a/apps/desktop/src/renderer/features/cc-agent/RolePillDropdown.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/RolePillDropdown.tsx
@@ -52,10 +52,12 @@ function WorkerModelLine({
   const effortLabel = workerEffortLabel(t, effort);
   // 列表选中行是浅色 chip 底,不能套深色药丸上的 --surface-on-card,
   // 日间会糊成看不清。副行一律走次级字色。
+  // 菜单有 overflow-x-hidden,整行 nowrap 会把后加的档位裁掉;
+  // 模型名可截,档位词短、必须留在可见区。右侧给 archive / ERR 留空。
   return (
-    <div className="mt-0.5 ml-[26px] whitespace-nowrap text-12 leading-snug text-[var(--text-secondary)]">
-      {simplifyModelName(model)}
-      {effortLabel ? ` · ${effortLabel}` : null}
+    <div className="mt-0.5 mr-7 ml-[26px] flex min-w-0 items-baseline gap-1.5 text-12 leading-snug text-[var(--text-secondary)]">
+      <span className="min-w-0 truncate">{simplifyModelName(model)}</span>
+      {effortLabel ? <span className="shrink-0">· {effortLabel}</span> : null}
     </div>
   );
 }

--- a/apps/desktop/src/renderer/features/cc-agent/__tests__/workerEffortLabel.test.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/__tests__/workerEffortLabel.test.ts
@@ -67,9 +67,13 @@ describe('RolePillDropdown worker effort label', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /developer/ }));
 
-    const modelLine = screen.getByText('gpt-5.6-sol · effortLevels.xhigh');
-    expect(modelLine.classList.contains('text-12')).toBe(true);
-    expect(modelLine.classList.contains('text-[var(--text-secondary)]')).toBe(true);
+    const modelName = screen.getByText('gpt-5.6-sol');
+    const effort = screen.getByText('· effortLevels.xhigh');
+    expect(modelName.classList.contains('truncate')).toBe(true);
+    expect(effort.classList.contains('shrink-0')).toBe(true);
+    expect(modelName.parentElement?.classList.contains('text-12')).toBe(true);
+    expect(modelName.parentElement?.classList.contains('text-[var(--text-secondary)]')).toBe(true);
+    expect(modelName.parentElement?.classList.contains('mr-7')).toBe(true);
     expect(screen.queryByLabelText(/^effort /)).toBeNull();
   });
 
@@ -91,7 +95,8 @@ describe('RolePillDropdown worker effort label', () => {
     );
 
     fireEvent.click(screen.getByRole('button', { name: 'orca.rolePill.layoutMenuLabel' }));
-    expect(screen.getByText('gpt-5.6-sol · effortLevels.xhigh')).toBeTruthy();
+    expect(screen.getByText('gpt-5.6-sol')).toBeTruthy();
+    expect(screen.getByText('· effortLevels.xhigh')).toBeTruthy();
     expect(screen.queryByLabelText(/^effort /)).toBeNull();
 
     expect(source.match(/<WorkerModelLine\b/g)).toHaveLength(3);
@@ -136,9 +141,31 @@ describe('RolePillDropdown worker effort label', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /developer/ }));
 
-    const modelLine = screen.getByText('gpt-5.6-sol · effortLevels.xhigh');
-    expect(modelLine.classList.contains('text-12')).toBe(true);
-    expect(modelLine.classList.contains('text-[var(--text-secondary)]')).toBe(true);
-    expect(modelLine.classList.contains('opacity-80')).toBe(false);
+    const modelName = screen.getByText('gpt-5.6-sol');
+    expect(modelName.parentElement?.classList.contains('text-12')).toBe(true);
+    expect(modelName.parentElement?.classList.contains('text-[var(--text-secondary)]')).toBe(true);
+    expect(modelName.parentElement?.classList.contains('opacity-80')).toBe(false);
+    expect(screen.getByText('· effortLevels.xhigh').classList.contains('shrink-0')).toBe(true);
+  });
+
+  it('keeps a long model name truncatable so the effort suffix stays visible', () => {
+    const current = worker({
+      model: 'custom-provider/an-unreasonably-long-model-identifier-that-would-overflow',
+    });
+    render(
+      createElement(RolePillDropdown, {
+        worker: current,
+        workers: [current],
+        selectedWorkerId: current.workerId,
+        activeWorkerCount: 1,
+        onSwitchFocus: vi.fn(),
+        onArchiveWorker: vi.fn(),
+      }),
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /developer/ }));
+
+    expect(screen.getByText('an-unreasonably-long-model-identifier-that-would-overflow').classList.contains('truncate')).toBe(true);
+    expect(screen.getByText('· effortLevels.xhigh').classList.contains('shrink-0')).toBe(true);
   });
 });

--- a/apps/desktop/src/renderer/features/cc-agent/__tests__/workerEffortLabel.test.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/__tests__/workerEffortLabel.test.ts
@@ -1,0 +1,144 @@
+// @vitest-environment jsdom
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { createElement } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { WorkerInfo } from '../hooks/useWorkers';
+import { RolePillDropdown, WorkerListToolbar } from '../RolePillDropdown';
+
+const source = readFileSync(resolve(__dirname, '..', 'RolePillDropdown.tsx'), 'utf8').replace(
+  /\r\n?/g,
+  '\n',
+);
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@/hooks/useAppShortcut', () => ({
+  useAppShortcutDisplay: () => '',
+}));
+
+vi.mock('@/components/ui/confirm-dialog-provider', () => ({
+  useConfirmDialog: () => ({ confirm: vi.fn(async () => false) }),
+}));
+
+function worker(overrides: Partial<WorkerInfo> = {}): WorkerInfo {
+  return {
+    workerId: 'worker-a',
+    sessionId: 'session-a',
+    role: 'developer',
+    agent: 'codex',
+    model: 'gpt-5.6-sol',
+    effort: 'xhigh',
+    label: null,
+    status: 'idle',
+    focused: true,
+    idleSince: null,
+    ...overrides,
+  };
+}
+
+describe('RolePillDropdown worker effort label', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('shows the localized effort word instead of signal bars', () => {
+    const current = worker();
+    render(
+      createElement(RolePillDropdown, {
+        worker: current,
+        workers: [current],
+        selectedWorkerId: current.workerId,
+        activeWorkerCount: 1,
+        onSwitchFocus: vi.fn(),
+        onArchiveWorker: vi.fn(),
+      }),
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /developer/ }));
+
+    const modelLine = screen.getByText('gpt-5.6-sol · effortLevels.xhigh');
+    expect(modelLine.classList.contains('text-12')).toBe(true);
+    expect(modelLine.classList.contains('text-[var(--text-secondary)]')).toBe(true);
+    expect(screen.queryByLabelText(/^effort /)).toBeNull();
+  });
+
+  it('uses the same model line in the summary, tabs menu, and dropdown list', () => {
+    const current = worker();
+    render(
+      createElement(WorkerListToolbar, {
+        worker: current,
+        workers: [current],
+        selectedWorkerId: current.workerId,
+        activeWorkerCount: 1,
+        softLimit: 5,
+        hardLimit: 8,
+        onSwitchFocus: vi.fn(),
+        onOpenCreate: vi.fn(),
+        onOpenSettings: vi.fn(),
+        onArchiveWorker: vi.fn(),
+      }),
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'orca.rolePill.layoutMenuLabel' }));
+    expect(screen.getByText('gpt-5.6-sol · effortLevels.xhigh')).toBeTruthy();
+    expect(screen.queryByLabelText(/^effort /)).toBeNull();
+
+    expect(source.match(/<WorkerModelLine\b/g)).toHaveLength(3);
+    expect(source).toContain('<WorkerModelLine model={worker.model} effort={worker.effort} />');
+  });
+
+  it('hides unknown or missing effort instead of falling back to medium', () => {
+    const current = worker({ effort: null });
+    render(
+      createElement(RolePillDropdown, {
+        worker: current,
+        workers: [
+          current,
+          worker({ workerId: 'worker-b', sessionId: 'session-b', effort: 'unknown' }),
+        ],
+        selectedWorkerId: current.workerId,
+        activeWorkerCount: 2,
+        onSwitchFocus: vi.fn(),
+        onArchiveWorker: vi.fn(),
+      }),
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /developer/ }));
+
+    expect(screen.queryByText('effortLevels.medium')).toBeNull();
+    expect(screen.queryByText('effortLevels.unknown')).toBeNull();
+    expect(screen.queryByLabelText(/^effort /)).toBeNull();
+  });
+
+  it('uses the secondary tone for an unselected row', () => {
+    const current = worker({ focused: false });
+    render(
+      createElement(RolePillDropdown, {
+        worker: current,
+        workers: [current],
+        selectedWorkerId: null,
+        activeWorkerCount: 1,
+        onSwitchFocus: vi.fn(),
+        onArchiveWorker: vi.fn(),
+      }),
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /developer/ }));
+
+    const modelLine = screen.getByText('gpt-5.6-sol · effortLevels.xhigh');
+    expect(modelLine.classList.contains('text-12')).toBe(true);
+    expect(modelLine.classList.contains('text-[var(--text-secondary)]')).toBe(true);
+    expect(modelLine.classList.contains('opacity-80')).toBe(false);
+  });
+});


### PR DESCRIPTION
## 这次改了什么

### 摘要

Worker 列表第二行原来用统一信号条表示推理档位。各模型档位集合不同，超高不在旧的 5 档映射里，会被画成中间那格。现在改成直接写档位文字，例如 `gpt-5.6-sol · 超高`。

窄菜单（280px 侧栏钳制）或长模型名下，整行 nowrap 会把档位词裁掉（review 提出）。第二个 commit 改为：模型名截断、档位词 `shrink-0` 保住、右侧给归档/ERR 留空。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：Orca Worker 列表 / hover 面板第二行的档位展示（文字化 + 窄宽度截断策略），以及对应单测
- 明确不包含：输入框上下文圆环、模型选择器档位选择、实时上下文占用
- 用户可见变化：Worker 列表第二行从信号条改为 `模型名 · 档位`；窄宽度下模型名截断、档位词保持可见
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：`docs/design-rules/DESIGN.md` §3 桌面 UI 字号白名单（副行用 12px，不用 11px 小灰字写中文档位）；§2 / §10 语义色（列表选中行是浅色 chip 底，副行用 `--text-secondary`，不套深色药丸上的 `--surface-on-card`，避免日间看不清）

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：PASS apps/desktop unit（含新增 workerEffortLabel.test.ts，覆盖档位文案、未知档隐藏、截断/保位 class）

pnpm --filter desktop run --if-present typecheck
结果：通过
```

### 手工验证

- 平台：macOS Desktop，国内版，共享正式 userData
- 路径：打开有 Worker 的协同任务 → hover / 展开 WORKERS 面板
- 结果：第二行显示 `gpt-5.6-sol · 高` 这类档位文字；日间选中行副行可读

### 未执行的验证

- 夜间模式未单独实机目检（复用 themed token，两种模式实现同一套）
- 窄菜单 + 超长模型名的截断行为未实机目检，由 jsdom 单测的 class 断言覆盖
- 未跑全量 `pnpm test:unit`（本次只改 desktop UI，相关门禁已覆盖；CI 会跑全量）
- 未在 Windows 上手动验证

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA

### 影响与回滚

- 影响范围：仅 Worker 列表第二行展示
- 回滚 / 降级方式：回退本 PR 即可恢复信号条

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因