### PR TITLE
fix(desktop): 安装与打包 .cindy 时保留 Unix 执行位

### DIFF
--- a/apps/desktop/src/main/cindy-brain/GhostManager.ts
+++ b/apps/desktop/src/main/cindy-brain/GhostManager.ts
@@ -3756,6 +3756,13 @@ export class GhostManager {
     },
   ): Promise<void> {
     await fs.promises.mkdir(stagingDir, { recursive: true });
+    // 已签名 / 已审核包**不**采纳归档声明的 mode:签名 statement 只覆盖
+    // (path, sha256, bytes),mode 不在其中(`buildStatement`)。恢复一个签名没
+    // 覆盖的 mode,等于把未认证的 central-directory 元数据当成已签名事实 ——
+    // 能篡改包字节的人可以在验签仍然通过的前提下翻转执行位。未签名包不存在
+    // 越过签名边界的问题,照常按声明恢复。待 statement 升 v2 把归一化后的 mode
+    // 签进去,这里再对签名包放开。
+    const honorArchivedModes = !opts.trust.publisherSigned && !opts.trust.reviewed;
     let totalBytes = 0;
     for (const entry of allEntries) {
       const relName = entry.name.slice(prefix.length);
@@ -3773,8 +3780,10 @@ export class GhostManager {
       }
       await fs.promises.mkdir(path.dirname(dest), { recursive: true });
       await fs.promises.writeFile(dest, data);
-      const mode = installedFileModeFromZip(entry.unixPermissions);
-      if (mode !== null) await fs.promises.chmod(dest, mode);
+      if (honorArchivedModes) {
+        const mode = installedFileModeFromZip(entry.unixPermissions);
+        if (mode !== null) await fs.promises.chmod(dest, mode);
+      }
     }
     if (opts.disabled) {
       await fs.promises.writeFile(path.join(stagingDir, DISABLED_MARKER_FILE), '');

--- a/apps/desktop/src/main/cindy-brain/GhostManager.ts
+++ b/apps/desktop/src/main/cindy-brain/GhostManager.ts
@@ -56,6 +56,7 @@ import {
   decodeGhostManualMarkdown,
   ghostManualLogicalPathForEntry,
 } from './ghostManualValidation.js';
+import { installedFileModeFromZip, isZipSymbolicLinkMode } from './ghostZipPermissions.js';
 
 /** 普通沙箱插件维持小包上限；随包 Node/CLI 允许更大的预打包产物。 */
 export const MAX_BASIC_CINDY_FILE_BYTES = 8 * 1024 * 1024;
@@ -112,9 +113,7 @@ const DISABLED_MARKER_FILE = '.disabled';
 export const TRUST_METADATA_FILE = '.cindy-trust.json';
 
 function isZipSymbolicLink(entry: JSZip.JSZipObject): boolean {
-  return (
-    typeof entry.unixPermissions === 'number' && (entry.unixPermissions & 0o170000) === 0o120000
-  );
+  return isZipSymbolicLinkMode(entry.unixPermissions);
 }
 
 /** 只有宿主安装/播种路径可以写入的 Cindy 官方身份。 */
@@ -3774,6 +3773,8 @@ export class GhostManager {
       }
       await fs.promises.mkdir(path.dirname(dest), { recursive: true });
       await fs.promises.writeFile(dest, data);
+      const mode = installedFileModeFromZip(entry.unixPermissions);
+      if (mode !== null) await fs.promises.chmod(dest, mode);
     }
     if (opts.disabled) {
       await fs.promises.writeFile(path.join(stagingDir, DISABLED_MARKER_FILE), '');

--- a/apps/desktop/src/main/cindy-brain/GhostManager.ts
+++ b/apps/desktop/src/main/cindy-brain/GhostManager.ts
@@ -3756,13 +3756,6 @@ export class GhostManager {
     },
   ): Promise<void> {
     await fs.promises.mkdir(stagingDir, { recursive: true });
-    // 已签名 / 已审核包**不**采纳归档声明的 mode:签名 statement 只覆盖
-    // (path, sha256, bytes),mode 不在其中(`buildStatement`)。恢复一个签名没
-    // 覆盖的 mode,等于把未认证的 central-directory 元数据当成已签名事实 ——
-    // 能篡改包字节的人可以在验签仍然通过的前提下翻转执行位。未签名包不存在
-    // 越过签名边界的问题,照常按声明恢复。待 statement 升 v2 把归一化后的 mode
-    // 签进去,这里再对签名包放开。
-    const honorArchivedModes = !opts.trust.publisherSigned && !opts.trust.reviewed;
     let totalBytes = 0;
     for (const entry of allEntries) {
       const relName = entry.name.slice(prefix.length);
@@ -3780,10 +3773,17 @@ export class GhostManager {
       }
       await fs.promises.mkdir(path.dirname(dest), { recursive: true });
       await fs.promises.writeFile(dest, data);
-      if (honorArchivedModes) {
-        const mode = installedFileModeFromZip(entry.unixPermissions);
-        if (mode !== null) await fs.promises.chmod(dest, mode);
-      }
+      // 签名与 mode 的关系是**有意如此**,别当成漏改:statement 只覆盖
+      // (path, sha256, bytes),mode 不在其中,所以归档 mode 属未认证元数据。
+      // 仍然采纳它,是因为在 `installedFileModeFromZip` 的钳位之后,能篡改包
+      // 字节的攻击者只剩下「翻转 r / x 位」:内容改不了、文件增删不了(白名单
+      // + 逐文件哈希)、特殊位剥掉、group/other 写位钳掉、owner 读写强制保留。
+      // 去掉 +x 只是他本来就能造成的可用性破坏(改坏一字节即验签失败);加上
+      // +x 作用在他无法选择内容的文件上,而执行流指向哪个文件由签名覆盖的
+      // manifest 与插件自身代码决定 —— 拿不到代码执行。若日后有任何逻辑开始
+      // 依赖 mode 做安全判断,这个前提就失效,届时须把归一化 mode 签进 statement。
+      const mode = installedFileModeFromZip(entry.unixPermissions);
+      if (mode !== null) await fs.promises.chmod(dest, mode);
     }
     if (opts.disabled) {
       await fs.promises.writeFile(path.join(stagingDir, DISABLED_MARKER_FILE), '');

--- a/apps/desktop/src/main/cindy-brain/__tests__/GhostManager.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/GhostManager.test.ts
@@ -4718,10 +4718,11 @@ describe('GhostManager · Unix file permissions', () => {
     }
   });
 
-  it('signed packages do not restore archive modes the signature never covered', async () => {
-    // 签名 statement 只覆盖 (path, sha256, bytes);mode 不在其中。若照旧恢复,
-    // 能篡改包字节的人就能在验签仍然通过的前提下翻转执行位。所以已签名包一律
-    // 不采纳归档 mode —— 等 statement 升 v2 把归一化 mode 签进去再放开。
+  it('signed packages restore declared modes too, with special bits stripped', async () => {
+    // 有意如此:statement 只覆盖 (path, sha256, bytes),mode 属未认证元数据,但
+    // 钳位后攻击者只剩「翻转 r / x 位」,拿不到代码执行(详见 extractToStaging
+    // 的注释)。若哪天决定改成「签名包不采纳 mode」,这条用例会红 —— 那正是
+    // 我们要的:这是个产品/安全决定,不该被静默改掉。
     const unsigned = await makeUnixModeCindy('signed-modes.cindy', goodManifest(), 'v1');
     const publisher = crypto.generateKeyPairSync('ed25519');
     const signed = await signGhostPackage(await fs.promises.readFile(unsigned), {
@@ -4735,22 +4736,22 @@ describe('GhostManager · Unix file permissions', () => {
     const loaded = await JSZip.loadAsync(signed);
     expect(Number(loaded.files['bin/tool'].unixPermissions) & 0o777).toBe(0o755);
 
-    const chmodSpy = vi.spyOn(fs.promises, 'chmod');
-    try {
-      const installed = await manager.install(signedPath);
-      expect(installed).toHaveProperty('ghost');
-      expect((installed as { ghost: InstalledGhost }).ghost.trust?.publisherSigned).toBe(true);
-      expect(chmodSpy).not.toHaveBeenCalled();
-    } finally {
-      chmodSpy.mockRestore();
-    }
-    // 内容照常落盘，只是执行位不恢复(留在文件系统缺省)。
+    const installed = await manager.install(signedPath);
+    expect(installed).toHaveProperty('ghost');
+    expect((installed as { ghost: InstalledGhost }).ghost.trust?.publisherSigned).toBe(true);
+
     expect(
       await fs.promises.readFile(path.join(rootDir, 'hello', 'bin', 'tool'), 'utf8'),
     ).toContain('v1');
     if (process.platform !== 'win32') {
-      expect((await fs.promises.stat(path.join(rootDir, 'hello', 'bin', 'tool'))).mode & 0o111)
-        .toBe(0);
+      // 签名包与未签名包走同一条恢复路径:0755 保留、0644 保留、特殊位剥除。
+      expect((await fs.promises.stat(path.join(rootDir, 'hello', 'bin', 'tool'))).mode & 0o777)
+        .toBe(0o755);
+      expect((await fs.promises.stat(path.join(rootDir, 'hello', 'config.txt'))).mode & 0o777)
+        .toBe(0o644);
+      const special = await fs.promises.stat(path.join(rootDir, 'hello', 'bin', 'special'));
+      expect(special.mode & 0o777).toBe(0o755);
+      expect(special.mode & 0o4000).toBe(0);
     }
   });
 

--- a/apps/desktop/src/main/cindy-brain/__tests__/GhostManager.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/GhostManager.test.ts
@@ -79,7 +79,11 @@ function goodManifest(id = 'hello'): Record<string, unknown> {
 describe('installedFileModeFromZip', () => {
   it('normalizes strings, strips special bits, and skips Windows or missing metadata', () => {
     expect(installedFileModeFromZip('755', 'linux')).toBe(0o755);
+    expect(installedFileModeFromZip(0o644, 'linux')).toBe(0o644);
     expect(installedFileModeFromZip(0o4755, 'darwin')).toBe(0o755);
+    expect(installedFileModeFromZip(0o777, 'linux')).toBe(0o755);
+    expect(installedFileModeFromZip(0o666, 'linux')).toBe(0o644);
+    expect(installedFileModeFromZip(0o700, 'linux')).toBe(0o700);
     expect(installedFileModeFromZip(0o000, 'linux')).toBe(0o600);
     expect(installedFileModeFromZip(0o120777, 'linux')).toBeNull();
     expect(installedFileModeFromZip(null, 'linux')).toBeNull();

--- a/apps/desktop/src/main/cindy-brain/__tests__/GhostManager.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/GhostManager.test.ts
@@ -1,3 +1,4 @@
+import crypto from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -16,6 +17,7 @@ import {
   installedFileModeFromZip,
   unixPermissionsForRepackedEntry,
 } from '../ghostZipPermissions';
+import { signGhostPackage } from '../ghostSignature';
 import { hashApprovedSkillContent } from '../ghostInstallReceipt';
 import { runGhostSnapshotWorkerRequest } from '../ghostSnapshotWorkerProcess';
 
@@ -4674,7 +4676,20 @@ describe('GhostManager · author / icon(身份卡展示字段)', () => {
 describe('GhostManager · Unix file permissions', () => {
   it('fresh install and overwrite update preserve declared modes and strip setuid', async () => {
     const v1 = await makeUnixModeCindy('modes-v1.cindy', goodManifest(), 'v1');
-    expect(await manager.install(v1)).toHaveProperty('ghost');
+    const chmodSpy = vi.spyOn(fs.promises, 'chmod');
+    try {
+      expect(await manager.install(v1)).toHaveProperty('ghost');
+      // Windows 不做正面 mode 断言(chmod 在那里只切只读位),但必须断言我们**确实
+      // 没调 chmod**;非 win32 反过来断言确实调过,否则这条路径以后静默退化成
+      // 「什么都没做」也会绿。
+      if (process.platform === 'win32') {
+        expect(chmodSpy).not.toHaveBeenCalled();
+      } else {
+        expect(chmodSpy).toHaveBeenCalled();
+      }
+    } finally {
+      chmodSpy.mockRestore();
+    }
 
     if (process.platform !== 'win32') {
       expect((await fs.promises.stat(path.join(rootDir, 'hello', 'bin', 'tool'))).mode & 0o777)
@@ -4700,6 +4715,42 @@ describe('GhostManager · Unix file permissions', () => {
         .toBe(0o644);
       expect((await fs.promises.stat(path.join(rootDir, 'hello', 'bin', 'special'))).mode & 0o777)
         .toBe(0o755);
+    }
+  });
+
+  it('signed packages do not restore archive modes the signature never covered', async () => {
+    // 签名 statement 只覆盖 (path, sha256, bytes);mode 不在其中。若照旧恢复,
+    // 能篡改包字节的人就能在验签仍然通过的前提下翻转执行位。所以已签名包一律
+    // 不采纳归档 mode —— 等 statement 升 v2 把归一化 mode 签进去再放开。
+    const unsigned = await makeUnixModeCindy('signed-modes.cindy', goodManifest(), 'v1');
+    const publisher = crypto.generateKeyPairSync('ed25519');
+    const signed = await signGhostPackage(await fs.promises.readFile(unsigned), {
+      publisherName: 'Publisher',
+      privateKey: publisher.privateKey,
+    });
+    const signedPath = path.join(workDir, 'signed-modes-out.cindy');
+    await fs.promises.writeFile(signedPath, signed);
+
+    // 前提自检:包里确实带着 0755，否则这条用例证明不了任何事。
+    const loaded = await JSZip.loadAsync(signed);
+    expect(Number(loaded.files['bin/tool'].unixPermissions) & 0o777).toBe(0o755);
+
+    const chmodSpy = vi.spyOn(fs.promises, 'chmod');
+    try {
+      const installed = await manager.install(signedPath);
+      expect(installed).toHaveProperty('ghost');
+      expect((installed as { ghost: InstalledGhost }).ghost.trust?.publisherSigned).toBe(true);
+      expect(chmodSpy).not.toHaveBeenCalled();
+    } finally {
+      chmodSpy.mockRestore();
+    }
+    // 内容照常落盘，只是执行位不恢复(留在文件系统缺省)。
+    expect(
+      await fs.promises.readFile(path.join(rootDir, 'hello', 'bin', 'tool'), 'utf8'),
+    ).toContain('v1');
+    if (process.platform !== 'win32') {
+      expect((await fs.promises.stat(path.join(rootDir, 'hello', 'bin', 'tool'))).mode & 0o111)
+        .toBe(0);
     }
   });
 

--- a/apps/desktop/src/main/cindy-brain/__tests__/GhostManager.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/GhostManager.test.ts
@@ -12,6 +12,10 @@ import {
   type InstalledGhost,
 } from '../../../shared/ghost';
 import { CINDY_OFFICIAL_GHOST_TRUST, GhostManager, readLegacyGhostApprovalProjection } from '../GhostManager';
+import {
+  installedFileModeFromZip,
+  unixPermissionsForRepackedEntry,
+} from '../ghostZipPermissions';
 import { hashApprovedSkillContent } from '../ghostInstallReceipt';
 import { runGhostSnapshotWorkerRequest } from '../ghostSnapshotWorkerProcess';
 
@@ -72,6 +76,22 @@ function goodManifest(id = 'hello'): Record<string, unknown> {
   };
 }
 
+describe('installedFileModeFromZip', () => {
+  it('normalizes strings, strips special bits, and skips Windows or missing metadata', () => {
+    expect(installedFileModeFromZip('755', 'linux')).toBe(0o755);
+    expect(installedFileModeFromZip(0o4755, 'darwin')).toBe(0o755);
+    expect(installedFileModeFromZip(0o000, 'linux')).toBe(0o600);
+    expect(installedFileModeFromZip(0o120777, 'linux')).toBeNull();
+    expect(installedFileModeFromZip(null, 'linux')).toBeNull();
+    expect(installedFileModeFromZip(0o755, 'win32')).toBeNull();
+  });
+
+  it('does not turn non-directory entry types into executable directories when repacking', () => {
+    expect(unixPermissionsForRepackedEntry(0o120777, true)).toBe(0o040755);
+    expect(unixPermissionsForRepackedEntry(0o040700, true)).toBe(0o040700);
+  });
+});
+
 function setupKvManifest(id = 'hello'): Record<string, unknown> {
   return {
     ...goodManifest(id),
@@ -114,6 +134,24 @@ async function makeCindy(
   if (manifest) zip.file('ghost.json', JSON.stringify(manifest));
   for (const [name, content] of Object.entries(entries)) zip.file(name, content);
   const buf = await zip.generateAsync({ type: 'nodebuffer' });
+  const out = path.join(workDir, fileName);
+  await fs.promises.writeFile(out, buf);
+  return out;
+}
+
+/** 用 UNIX central-directory metadata 构造 mode 回归包。 */
+async function makeUnixModeCindy(
+  fileName: string,
+  manifest: Record<string, unknown>,
+  versionMarker: string,
+): Promise<string> {
+  const zip = new JSZip();
+  zip.file('ghost.json', JSON.stringify(manifest), { unixPermissions: 0o644 });
+  zip.file('main.js', '// browser entry', { unixPermissions: 0o644 });
+  zip.file('bin/tool', `#!/bin/sh\necho ${versionMarker}\n`, { unixPermissions: 0o755 });
+  zip.file('config.txt', versionMarker, { unixPermissions: 0o644 });
+  zip.file('bin/special', '#!/bin/sh\n', { unixPermissions: 0o4755 });
+  const buf = await zip.generateAsync({ type: 'nodebuffer', platform: 'UNIX' });
   const out = path.join(workDir, fileName);
   await fs.promises.writeFile(out, buf);
   return out;
@@ -4626,6 +4664,54 @@ describe('GhostManager · author / icon(身份卡展示字段)', () => {
     const listed = manager.list();
     expect(listed[0].iconDataUrl).toBeUndefined();
     expect(listed[0].manifest.author).toBeUndefined();
+  });
+});
+
+describe('GhostManager · Unix file permissions', () => {
+  it('fresh install and overwrite update preserve declared modes and strip setuid', async () => {
+    const v1 = await makeUnixModeCindy('modes-v1.cindy', goodManifest(), 'v1');
+    expect(await manager.install(v1)).toHaveProperty('ghost');
+
+    if (process.platform !== 'win32') {
+      expect((await fs.promises.stat(path.join(rootDir, 'hello', 'bin', 'tool'))).mode & 0o777)
+        .toBe(0o755);
+      expect((await fs.promises.stat(path.join(rootDir, 'hello', 'config.txt'))).mode & 0o777)
+        .toBe(0o644);
+      const special = await fs.promises.stat(path.join(rootDir, 'hello', 'bin', 'special'));
+      expect(special.mode & 0o777).toBe(0o755);
+      expect(special.mode & 0o4000).toBe(0);
+    }
+
+    const v2 = await makeUnixModeCindy(
+      'modes-v2.cindy',
+      { ...goodManifest(), version: '2.0.0' },
+      'v2',
+    );
+    expect(await updateGhost(v2)).toHaveProperty('ghost');
+    expect(await fs.promises.readFile(path.join(rootDir, 'hello', 'config.txt'), 'utf8')).toBe('v2');
+    if (process.platform !== 'win32') {
+      expect((await fs.promises.stat(path.join(rootDir, 'hello', 'bin', 'tool'))).mode & 0o777)
+        .toBe(0o755);
+      expect((await fs.promises.stat(path.join(rootDir, 'hello', 'config.txt'))).mode & 0o777)
+        .toBe(0o644);
+      expect((await fs.promises.stat(path.join(rootDir, 'hello', 'bin', 'special'))).mode & 0o777)
+        .toBe(0o755);
+    }
+  });
+
+  it('DOS packages without unixPermissions still install with filesystem defaults', async () => {
+    const cindy = await makeCindy('dos-modes.cindy', goodManifest(), { 'plain.txt': 'plain' });
+    const loaded = await JSZip.loadAsync(await fs.promises.readFile(cindy));
+    expect(loaded.files['plain.txt'].unixPermissions).toBeNull();
+    const chmodSpy = vi.spyOn(fs.promises, 'chmod');
+    try {
+      expect(await manager.install(cindy)).toHaveProperty('ghost');
+      expect(chmodSpy).not.toHaveBeenCalled();
+      await expect(fs.promises.readFile(path.join(rootDir, 'hello', 'plain.txt'), 'utf8'))
+        .resolves.toBe('plain');
+    } finally {
+      chmodSpy.mockRestore();
+    }
   });
 });
 

--- a/apps/desktop/src/main/cindy-brain/__tests__/exportGhostPackage.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/exportGhostPackage.test.ts
@@ -137,6 +137,19 @@ function makeDeps(overrides: Partial<Parameters<typeof exportGhostPackage>[1]> =
 }
 
 describe('exportGhostPackage', () => {
+  it.skipIf(process.platform === 'win32')(
+    'round-trips installed Unix execute bits while stripping special bits',
+    async () => {
+      await fs.promises.chmod(path.join(ghostDir, 'main.js'), 0o4755);
+      const result = await exportGhostPackage('hello', makeDeps());
+      expect(result.status).toBe('saved');
+      if (result.status !== 'saved') return;
+
+      const zip = await JSZip.loadAsync(await fs.promises.readFile(result.savedPath));
+      expect(Number(zip.files['main.js'].unixPermissions) & 0o7777).toBe(0o755);
+    },
+  );
+
   it('打包安装目录为可重新装入的 .cindy(跳过主机点文件)', async () => {
     const deps = makeDeps();
     const result = await exportGhostPackage('hello', deps);

--- a/apps/desktop/src/main/cindy-brain/__tests__/exportGhostPackage.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/exportGhostPackage.test.ts
@@ -256,14 +256,21 @@ describe('exportGhostPackage', () => {
     await writeStatement(['ghost.json', 'locales/en.json', 'main.js']);
     // 第一次读 main.js 返回陈旧字节(模拟并发更新读到旧目录):
     // 哈希与 statement 不符,必须整体重读,最终包内容应为真实字节。
-    const realReadFile = fs.promises.readFile;
+    const realOpen = fs.promises.open;
     let staleServed = false;
-    const spy = vi.spyOn(fs.promises, 'readFile').mockImplementation(async (p: any, opts: any) => {
+    const spy = vi.spyOn(fs.promises, 'open').mockImplementation(async (p: any, flags: any) => {
+      const fileHandle = await realOpen(p, flags);
       if (String(p).endsWith('main.js') && !staleServed) {
-        staleServed = true;
-        return Buffer.from('stale-bytes');
+        const realHandleReadFile = fileHandle.readFile.bind(fileHandle);
+        fileHandle.readFile = vi.fn(async (...args: any[]) => {
+          if (!staleServed) {
+            staleServed = true;
+            return Buffer.from('stale-bytes');
+          }
+          return realHandleReadFile(...args);
+        }) as unknown as typeof fileHandle.readFile;
       }
-      return realReadFile(p, opts) as any;
+      return fileHandle;
     });
     try {
       const result = await exportGhostPackage('hello', makeDeps());

--- a/apps/desktop/src/main/cindy-brain/__tests__/forge.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/forge.test.ts
@@ -137,6 +137,24 @@ async function makeSrcDir(files: Record<string, string | Buffer>): Promise<strin
 }
 
 describe('packGhostDir', () => {
+  it.skipIf(process.platform === 'win32')(
+    'archives real Unix execute bits while stripping special bits',
+    async () => {
+      const dir = await makeSrcDir({
+        'ghost.json': JSON.stringify(GOOD_MANIFEST),
+        'main.js': 'export default {};',
+        'bin/tool': '#!/bin/sh\necho ok\n',
+      });
+      await fs.promises.chmod(path.join(dir, 'bin', 'tool'), 0o4755);
+
+      const packed = await packGhostDir(dir);
+      expect(packed).toMatchObject({ ok: true });
+      if (!packed.ok) return;
+      const zip = await JSZip.loadAsync(await fs.promises.readFile(packed.cindyPath));
+      expect(Number(zip.files['bin/tool'].unixPermissions) & 0o7777).toBe(0o755);
+    },
+  );
+
   it('writes an in-workdir alias output to the canonical source directory', async () => {
     const sourceTarget = path.join(workDir, 'source-target');
     const sourceAlias = path.join(workDir, 'source-alias');

--- a/apps/desktop/src/main/cindy-brain/__tests__/ghostSignature.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/ghostSignature.test.ts
@@ -52,6 +52,30 @@ async function readSignature(buffer: Buffer): Promise<GhostSignatureDocument> {
 }
 
 describe('ghostSignature · 发布者签名', () => {
+  it('signing and review preserve safe Unix executable metadata', async () => {
+    const source = new JSZip();
+    source.file('ghost.json', JSON.stringify(MANIFEST), { unixPermissions: 0o100644 });
+    source.file('main.js', '// browser brain', { unixPermissions: 0o100755 });
+    source.file('linked-dir/', null, { dir: true, unixPermissions: 0o120777 });
+    const unsigned = await source.generateAsync({ type: 'nodebuffer', platform: 'UNIX' });
+    const publisher = crypto.generateKeyPairSync('ed25519');
+    const reviewer = crypto.generateKeyPairSync('ed25519');
+
+    const signed = await signGhostPackage(unsigned, {
+      publisherName: 'Publisher',
+      privateKey: publisher.privateKey,
+    });
+    const signedZip = await JSZip.loadAsync(signed);
+    expect(Number(signedZip.files['main.js'].unixPermissions) & 0o7777).toBe(0o755);
+    expect(Number(signedZip.files['linked-dir/'].unixPermissions) & 0o7777).toBe(0o755);
+
+    const reviewed = await reviewGhostPackage(signed, {
+      reviewerPrivateKey: reviewer.privateKey,
+    });
+    const reviewedZip = await JSZip.loadAsync(reviewed);
+    expect(Number(reviewedZip.files['main.js'].unixPermissions) & 0o7777).toBe(0o755);
+  });
+
   it('无签名可以安装，但明确标为未验证', async () => {
     const zip = await JSZip.loadAsync(await unsignedPackage());
     const result = await verifyGhostZipSignatures(zip, '', MANIFEST);

--- a/apps/desktop/src/main/cindy-brain/exportGhostPackage.ts
+++ b/apps/desktop/src/main/cindy-brain/exportGhostPackage.ts
@@ -157,39 +157,44 @@ async function readSignedDoc(dir: string): Promise<SignedDoc | null> {
   const sigPath = path.join(dir, GHOST_SIGNATURE_FILE);
   // 先 stat 再读(评审 P1):超上限的签名文件反正过不了装入,不把它
   // 完整读进内存;读后再查一次字节数,挡住 stat 后被改大的窗口。
-  let stat: fs.Stats;
+  let fileHandle: fs.promises.FileHandle;
   try {
-    stat = await fs.promises.stat(sigPath);
+    fileHandle = await fs.promises.open(sigPath, 'r');
   } catch (err) {
     if ((err as NodeJS.ErrnoException)?.code === 'ENOENT') return null;
     throw err;
   }
-  if (stat.size > MAX_SIGNATURE_FILE_BYTES) throw new Error('signature file too large');
-  const raw = await fs.promises.readFile(sigPath);
-  if (raw.byteLength > MAX_SIGNATURE_FILE_BYTES) {
-    throw new Error('signature file too large');
-  }
-  const doc = JSON.parse(raw.toString('utf8')) as {
-    statement?: { files?: Array<{ path?: unknown; sha256?: unknown; bytes?: unknown }> };
-  };
-  const files = doc?.statement?.files;
-  if (!Array.isArray(files)) throw new Error('invalid signature statement');
-  const parsed: SignedDoc['files'] = [];
-  for (const item of files) {
-    if (
-      typeof item?.path !== 'string' ||
-      typeof item?.sha256 !== 'string' ||
-      typeof item?.bytes !== 'number'
-    ) {
-      throw new Error('invalid signature statement entry');
+  try {
+    const stat = await fileHandle.stat();
+    if (stat.size > MAX_SIGNATURE_FILE_BYTES) throw new Error('signature file too large');
+    const raw = await fileHandle.readFile();
+    if (raw.byteLength > MAX_SIGNATURE_FILE_BYTES) {
+      throw new Error('signature file too large');
     }
-    parsed.push({ path: item.path, sha256: item.sha256, bytes: item.bytes });
+    const doc = JSON.parse(raw.toString('utf8')) as {
+      statement?: { files?: Array<{ path?: unknown; sha256?: unknown; bytes?: unknown }> };
+    };
+    const files = doc?.statement?.files;
+    if (!Array.isArray(files)) throw new Error('invalid signature statement');
+    const parsed: SignedDoc['files'] = [];
+    for (const item of files) {
+      if (
+        typeof item?.path !== 'string' ||
+        typeof item?.sha256 !== 'string' ||
+        typeof item?.bytes !== 'number'
+      ) {
+        throw new Error('invalid signature statement entry');
+      }
+      parsed.push({ path: item.path, sha256: item.sha256, bytes: item.bytes });
+    }
+    return {
+      raw,
+      unixPermissions: unixRegularFilePermissionsForArchive(stat.mode),
+      files: parsed,
+    };
+  } finally {
+    await fileHandle.close();
   }
-  return {
-    raw,
-    unixPermissions: unixRegularFilePermissionsForArchive(stat.mode),
-    files: parsed,
-  };
 }
 
 /** statement 路径必须相对且不逃逸——装入侧已校验,这里防一手目录被改。 */
@@ -212,11 +217,17 @@ async function readSignedEntries(dir: string, doc: SignedDoc): Promise<PackageEn
     // 先 stat 对尺寸:与 statement 不符必然哈希也不符,不必把可能超限
     // 的文件读进内存(评审 P1:巨型缓存文件要先挡在分配之前)。
     let data: Buffer;
-    let stat: fs.Stats;
+    let unixPermissions: number;
     try {
-      stat = await fs.promises.stat(path.join(dir, ...item.path.split('/')));
-      if (stat.size !== item.bytes) return null;
-      data = await fs.promises.readFile(path.join(dir, ...item.path.split('/')));
+      const fileHandle = await fs.promises.open(path.join(dir, ...item.path.split('/')), 'r');
+      try {
+        const stat = await fileHandle.stat();
+        if (stat.size !== item.bytes) return null;
+        data = await fileHandle.readFile();
+        unixPermissions = unixRegularFilePermissionsForArchive(stat.mode);
+      } finally {
+        await fileHandle.close();
+      }
     } catch {
       return null;
     }
@@ -225,7 +236,7 @@ async function readSignedEntries(dir: string, doc: SignedDoc): Promise<PackageEn
     out.push({
       rel: item.path,
       data,
-      unixPermissions: unixRegularFilePermissionsForArchive(stat.mode),
+      unixPermissions,
     });
   }
   return out;

--- a/apps/desktop/src/main/cindy-brain/exportGhostPackage.ts
+++ b/apps/desktop/src/main/cindy-brain/exportGhostPackage.ts
@@ -46,10 +46,9 @@ import {
   MAX_NODE_UNCOMPRESSED_BYTES,
   MAX_NODE_ZIP_ENTRIES,
 } from './GhostManager.js';
+import { sameStableFileState } from './ghostContentTree.js';
 import { GHOST_SIGNATURE_FILE, MAX_SIGNATURE_FILE_BYTES } from './ghostSignature.js';
-import {
-  unixRegularFilePermissionsForArchive,
-} from './ghostZipPermissions.js';
+import { unixRegularFilePermissionsForArchive } from './ghostZipPermissions.js';
 
 export type ExportGhostPackageResult =
   | { status: 'saved'; savedPath: string }
@@ -165,11 +164,19 @@ async function readSignedDoc(dir: string): Promise<SignedDoc | null> {
     throw err;
   }
   try {
-    const stat = await fileHandle.stat();
-    if (stat.size > MAX_SIGNATURE_FILE_BYTES) throw new Error('signature file too large');
+    const stat = await fileHandle.stat({ bigint: true });
+    if (stat.size > BigInt(MAX_SIGNATURE_FILE_BYTES)) {
+      throw new Error('signature file too large');
+    }
     const raw = await fileHandle.readFile();
     if (raw.byteLength > MAX_SIGNATURE_FILE_BYTES) {
       throw new Error('signature file too large');
+    }
+    // 同一句柄只挡住 open 与 stat 之间的窗口:chmod 落在读取过程中,仍能造出
+    // 「读前的 mode + 读后的字节」。读后复验身份与稳定态(含 ctime,故覆盖 chmod),
+    // 变了就如实失败,不把不同时刻的权限和内容拼成一个条目。
+    if (!sameStableFileState(stat, await fileHandle.stat({ bigint: true }))) {
+      throw new Error('signature file changed while reading');
     }
     const doc = JSON.parse(raw.toString('utf8')) as {
       statement?: { files?: Array<{ path?: unknown; sha256?: unknown; bytes?: unknown }> };
@@ -221,9 +228,12 @@ async function readSignedEntries(dir: string, doc: SignedDoc): Promise<PackageEn
     try {
       const fileHandle = await fs.promises.open(path.join(dir, ...item.path.split('/')), 'r');
       try {
-        const stat = await fileHandle.stat();
-        if (stat.size !== item.bytes) return null;
+        const stat = await fileHandle.stat({ bigint: true });
+        if (stat.size !== BigInt(item.bytes)) return null;
         data = await fileHandle.readFile();
+        // 读后复验:同一句柄挡不住读取期间的 chmod,而 mode 与字节必须同时刻。
+        // 稳定态判据含 ctime,权限变化也算失效;返回 null 交给调用方整体重试。
+        if (!sameStableFileState(stat, await fileHandle.stat({ bigint: true }))) return null;
         unixPermissions = unixRegularFilePermissionsForArchive(stat.mode);
       } finally {
         await fileHandle.close();

--- a/apps/desktop/src/main/cindy-brain/exportGhostPackage.ts
+++ b/apps/desktop/src/main/cindy-brain/exportGhostPackage.ts
@@ -47,6 +47,9 @@ import {
   MAX_NODE_ZIP_ENTRIES,
 } from './GhostManager.js';
 import { GHOST_SIGNATURE_FILE, MAX_SIGNATURE_FILE_BYTES } from './ghostSignature.js';
+import {
+  unixRegularFilePermissionsForArchive,
+} from './ghostZipPermissions.js';
 
 export type ExportGhostPackageResult =
   | { status: 'saved'; savedPath: string }
@@ -130,6 +133,7 @@ const MAX_EXPORT_BASENAME_BYTES = 249;
 interface PackageEntry {
   rel: string;
   data: Buffer;
+  unixPermissions: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -139,6 +143,7 @@ interface PackageEntry {
 interface SignedDoc {
   /** 签名文件原始字节(原样进入导出包)。 */
   raw: Buffer;
+  unixPermissions: number;
   files: Array<{ path: string; sha256: string; bytes: number }>;
 }
 
@@ -180,7 +185,11 @@ async function readSignedDoc(dir: string): Promise<SignedDoc | null> {
     }
     parsed.push({ path: item.path, sha256: item.sha256, bytes: item.bytes });
   }
-  return { raw, files: parsed };
+  return {
+    raw,
+    unixPermissions: unixRegularFilePermissionsForArchive(stat.mode),
+    files: parsed,
+  };
 }
 
 /** statement 路径必须相对且不逃逸——装入侧已校验,这里防一手目录被改。 */
@@ -195,14 +204,17 @@ function isSafeStatementPath(p: string): boolean {
  * 通过即导出包内容——不多不少,可证可重装。
  */
 async function readSignedEntries(dir: string, doc: SignedDoc): Promise<PackageEntry[] | null> {
-  const out: PackageEntry[] = [{ rel: GHOST_SIGNATURE_FILE, data: doc.raw }];
+  const out: PackageEntry[] = [
+    { rel: GHOST_SIGNATURE_FILE, data: doc.raw, unixPermissions: doc.unixPermissions },
+  ];
   for (const item of doc.files) {
     if (!isSafeStatementPath(item.path)) return null;
     // 先 stat 对尺寸:与 statement 不符必然哈希也不符,不必把可能超限
     // 的文件读进内存(评审 P1:巨型缓存文件要先挡在分配之前)。
     let data: Buffer;
+    let stat: fs.Stats;
     try {
-      const stat = await fs.promises.stat(path.join(dir, ...item.path.split('/')));
+      stat = await fs.promises.stat(path.join(dir, ...item.path.split('/')));
       if (stat.size !== item.bytes) return null;
       data = await fs.promises.readFile(path.join(dir, ...item.path.split('/')));
     } catch {
@@ -210,7 +222,11 @@ async function readSignedEntries(dir: string, doc: SignedDoc): Promise<PackageEn
     }
     if (data.byteLength !== item.bytes) return null;
     if (crypto.createHash('sha256').update(data).digest('hex') !== item.sha256) return null;
-    out.push({ rel: item.path, data });
+    out.push({
+      rel: item.path,
+      data,
+      unixPermissions: unixRegularFilePermissionsForArchive(stat.mode),
+    });
   }
   return out;
 }
@@ -301,7 +317,12 @@ async function walkTree(
           if (budget.entriesLeft < 0 || budget.bytesLeft < 0) {
             throw new ExportTooLargeError();
           }
-          items.push({ rel, data, sha256: sha256hex(data) });
+          items.push({
+            rel,
+            data,
+            sha256: sha256hex(data),
+            unixPermissions: unixRegularFilePermissionsForArchive(stat.mode),
+          });
         } else {
           const expect = limit as Map<string, number>;
           const expectedSize = expect.get(rel);
@@ -309,11 +330,16 @@ async function walkTree(
             expectedSize !== undefined ? await fs.promises.stat(abs) : null;
           if (expectedSize === undefined || stat!.size !== expectedSize) {
             // 第一遍没有的新文件/尺寸被换:与第一遍必然不一致,
-            // 不读内容(校验遍读取量由第一遍锚住)。
-            items.push({ rel, sha256: '' });
+            // 不读内容(校验遍读取量由第一遍锚住)。空 sha256 已足够让一致性
+            // 比对失败,mode 只需占位——0 在这里不代表"权限 0",不会入包。
+            items.push({ rel, sha256: '', unixPermissions: 0 });
           } else {
             const data = await fs.promises.readFile(abs);
-            items.push({ rel, sha256: sha256hex(data) });
+            items.push({
+              rel,
+              sha256: sha256hex(data),
+              unixPermissions: unixRegularFilePermissionsForArchive(stat!.mode),
+            });
           }
         }
         hasContent = true;
@@ -344,7 +370,9 @@ async function snapshotUnsignedTree(
     first.items.length === verify.items.length &&
     first.items.every(
       (file, i) =>
-        file.rel === verify.items[i]!.rel && file.sha256 === verify.items[i]!.sha256,
+        file.rel === verify.items[i]!.rel &&
+        file.sha256 === verify.items[i]!.sha256 &&
+        file.unixPermissions === verify.items[i]!.unixPermissions,
     );
   const dirsConsistent =
     first.emptyDirs.length === verify.emptyDirs.length &&
@@ -458,7 +486,11 @@ async function snapshotPackage(
         const tree = await snapshotUnsignedTree(dir, budget);
         if (tree) {
           return {
-            entries: tree.files.map(({ rel, data }) => ({ rel, data })),
+            entries: tree.files.map(({ rel, data, unixPermissions }) => ({
+              rel,
+              data,
+              unixPermissions,
+            })),
             emptyDirs: tree.emptyDirs,
           };
         }
@@ -508,14 +540,18 @@ export async function exportGhostPackage(
     zip.folder(rel);
   }
   for (const file of snapshot.entries) {
-    zip.file(file.rel, file.data);
+    zip.file(file.rel, file.data, { unixPermissions: file.unixPermissions });
   }
   if (Object.keys(zip.files).length > limits.maxEntries) {
     return { status: 'error', code: 'too_large' };
   }
   let buf: Buffer;
   try {
-    buf = await zip.generateAsync({ type: 'nodebuffer', compression: 'DEFLATE' });
+    buf = await zip.generateAsync({
+      type: 'nodebuffer',
+      compression: 'DEFLATE',
+      platform: 'UNIX',
+    });
   } catch {
     // 压缩失败(zlib 等)如实落到结构化结果,不冒成未捕获的 IPC 异常。
     return { status: 'error', code: 'compress_failed' };

--- a/apps/desktop/src/main/cindy-brain/forge.ts
+++ b/apps/desktop/src/main/cindy-brain/forge.ts
@@ -42,6 +42,10 @@ import {
 } from './ghostManualValidation.js';
 import { validateGhostLocaleResourcesInDirectory } from './ghostLocaleFiles.js';
 import { GHOST_SIGNATURE_FILE } from './ghostSignature.js';
+import {
+  ARCHIVE_REGULAR_0644,
+  unixRegularFilePermissionsForArchive,
+} from './ghostZipPermissions.js';
 import { isPathInsideDir } from './dirDeposit.js';
 import { checkSkillMdConsistency } from './skillSlot.js';
 
@@ -721,20 +725,22 @@ async function buildGhostPackage(
     // 文件耗尽内存。快照字节也必须出自这把闸,不能再按路径重读。
     let manifestRaw: unknown;
     let manifestBytes: Buffer;
+    let manifestUnixPermissions: number;
     try {
-      const bytes = await readBoundedFileNoFollow(
+      const read = await readBoundedFileNoFollowWithStat(
         path.join(realDir, GHOST_MANIFEST_FILE),
         GHOST_MANIFEST_MAX_BYTES,
         { containWithin: realDir },
       );
-      if (bytes === null) {
+      if (read === null) {
         return {
           ok: false,
           errorCode: 'MANIFEST_INVALID',
           message: `${GHOST_MANIFEST_FILE} 不是普通文件或超过 ${GHOST_MANIFEST_MAX_BYTES} 字节上限`,
         };
       }
-      manifestBytes = bytes;
+      manifestBytes = read.bytes;
+      manifestUnixPermissions = unixRegularFilePermissionsForArchive(read.stat.mode);
       manifestRaw = JSON.parse(manifestBytes.toString('utf-8'));
     } catch (err) {
       return {
@@ -846,7 +852,10 @@ async function buildGhostPackage(
     // Markdown 文件；逐文件限量、严格 UTF-8，并拒绝并发截短与二进制内容。
     // 缓存本次校验过的字节，生成 zip 时直接使用同一份快照，避免“预检一份、
     // 入包时又读到另一份”的竞态。嵌套单元共享缓存，同一物理文件只校验一次。
-    const manualFileSnapshots = new Map<string, Buffer>();
+    const manualFileSnapshots = new Map<
+      string,
+      { bytes: Buffer; unixPermissions: number }
+    >();
     for (const item of manifest.manual?.items ?? []) {
       const unitRoot = path.join(dir, ...item.dir.split('/'));
       const validateManualDir = async (
@@ -932,7 +941,10 @@ async function buildGhostPackage(
               message: `manual 文件不合格(${logicalPath}):${decoded.reason}`,
             };
           }
-          manualFileSnapshots.set(logicalPath, read.bytes);
+          manualFileSnapshots.set(logicalPath, {
+            bytes: read.bytes,
+            unixPermissions: unixRegularFilePermissionsForArchive(read.stat.mode),
+          });
         }
         return null;
       };
@@ -1129,29 +1141,35 @@ async function buildGhostPackage(
     let packedBytes = 0;
     for (const f of files) {
       let content: Buffer;
+      let unixPermissions: number;
       if (f.rel === GHOST_MANIFEST_FILE) {
         content = manifestBytes;
+        unixPermissions = manifestUnixPermissions;
       } else if (iconPng !== undefined && f.rel === FORGE_AI_ICON_PATH) {
         content = iconPng;
+        unixPermissions = ARCHIVE_REGULAR_0644;
       } else if (manualFileSnapshots.has(f.rel)) {
-        content = manualFileSnapshots.get(f.rel)!;
+        const snapshot = manualFileSnapshots.get(f.rel)!;
+        content = snapshot.bytes;
+        unixPermissions = snapshot.unixPermissions;
       } else {
-        let bytes: Buffer | null;
+        let read: Awaited<ReturnType<typeof readBoundedFileNoFollowWithStat>>;
         try {
-          bytes = await readBoundedFileNoFollow(f.abs, maxTotalBytes - packedBytes, {
+          read = await readBoundedFileNoFollowWithStat(f.abs, maxTotalBytes - packedBytes, {
             containWithin: realDir,
           });
         } catch {
-          bytes = null;
+          read = null;
         }
-        if (bytes === null) {
+        if (read === null) {
           return {
             ok: false,
             errorCode: 'TOO_LARGE',
             message: `文件在打包期间被并发改动或超出剩余体积预算:${f.rel}`,
           };
         }
-        content = bytes;
+        content = read.bytes;
+        unixPermissions = unixRegularFilePermissionsForArchive(read.stat.mode);
       }
       packedBytes += content.byteLength;
       if (packedBytes > maxTotalBytes) {
@@ -1161,7 +1179,7 @@ async function buildGhostPackage(
           message: `总体积超上限(${maxTotalBytes} 字节)`,
         };
       }
-      zip.file(f.rel, content);
+      zip.file(f.rel, content, { unixPermissions });
     }
     if (iconPng !== undefined && !iconSourceEntry) {
       packedBytes += iconPng.byteLength;
@@ -1172,9 +1190,13 @@ async function buildGhostPackage(
           message: `总体积超上限(${maxTotalBytes} 字节)`,
         };
       }
-      zip.file(FORGE_AI_ICON_PATH, iconPng);
+      zip.file(FORGE_AI_ICON_PATH, iconPng, { unixPermissions: ARCHIVE_REGULAR_0644 });
     }
-    const buf = await zip.generateAsync({ type: 'nodebuffer', compression: 'DEFLATE' });
+    const buf = await zip.generateAsync({
+      type: 'nodebuffer',
+      compression: 'DEFLATE',
+      platform: 'UNIX',
+    });
     const maxCindyBytes = manifest.node ? MAX_NODE_CINDY_BYTES : MAX_BASIC_CINDY_BYTES;
     if (buf.byteLength > maxCindyBytes) {
       return {
@@ -4042,6 +4064,9 @@ const opened = await cindy.iosSimulator.request({
    开发已有插件，先把源码复制/迁出到工作目录中的新目录，再从该副本制作;
 2. 调 \`ghost_forge_pack({ dir: '<绝对路径>' })\`——校验 + 打包 + 弹装入确认框;
    产物落在源码目录里(\`<id>-<version>.cindy\`,同版本覆盖,下次打包自动跳过);
+   macOS / Linux 源文件的普通 Unix 权限会原样进入包(特殊位会剥除)，所以随包本机
+   可执行程序必须在打包前就设好执行位(例如 \`chmod 755 path/to/program\`)，不要靠
+   文件扩展名或 \`bin/\` 目录让宿主猜测;
    若返回 \`SOURCE_IS_INSTALLED_PLUGIN\`,不要重试或换大小写、软链接、junction 绕过,
    按上一步迁出源码后再打包;也可能返回 \`SOURCE_OUTSIDE_WORKDIR\`(源码不在会话工作目录内);
 3. **告知用户去点弹窗**(装入默认沉睡,提醒用户勾"立即开启"或到主界面侧边栏「插件」中唤醒);

--- a/apps/desktop/src/main/cindy-brain/ghostContentTree.ts
+++ b/apps/desktop/src/main/cindy-brain/ghostContentTree.ts
@@ -184,7 +184,12 @@ function sameFileIdentity(
   return a.dev === b.dev && a.ino === b.ino;
 }
 
-function sameStableFileState(before: fs.BigIntStats, after: fs.BigIntStats): boolean {
+/**
+ * 「读取期间这个文件没被换掉也没被改过」的统一判据。`ctimeNs` 让它同时覆盖
+ * `chmod` —— 权限变化也算内容快照失效,导出侧据此拒绝把不同时刻的 mode 与字节
+ * 拼进同一个归档条目。
+ */
+export function sameStableFileState(before: fs.BigIntStats, after: fs.BigIntStats): boolean {
   return after.isFile() &&
     sameFileIdentity(before, after) &&
     before.size === after.size &&

--- a/apps/desktop/src/main/cindy-brain/ghostSignature.ts
+++ b/apps/desktop/src/main/cindy-brain/ghostSignature.ts
@@ -20,6 +20,9 @@ import {
   type GhostTrustInfo,
   validateGhostManifest,
 } from '../../shared/ghost.js';
+import {
+  unixPermissionsForRepackedEntry,
+} from './ghostZipPermissions.js';
 
 export const GHOST_SIGNATURE_FILE = 'cindy-signatures.json';
 export const MAX_SIGNATURE_FILE_BYTES = 64 * 1024;
@@ -394,6 +397,17 @@ export interface SignGhostPackageOptions {
   privateKey: crypto.KeyLike;
 }
 
+/**
+ * Signing and review regenerate the ZIP central directory. Pin sanitized UNIX
+ * modes first so those pipeline steps do not erase Forge/export executable
+ * bits or propagate special/file-type bits from an untrusted input package.
+ */
+function preserveSafeUnixPermissionsForRepack(zip: JSZip): void {
+  for (const entry of Object.values(zip.files)) {
+    entry.unixPermissions = unixPermissionsForRepackedEntry(entry.unixPermissions, entry.dir);
+  }
+}
+
 /** 发布流水线使用：给一个未签名/重签的 .cindy Buffer 添加 Ed25519 发布者签名。 */
 export async function signGhostPackage(
   packageBuffer: Buffer,
@@ -429,7 +443,8 @@ export async function signGhostPackage(
     },
   };
   zip.file(`${prefix}${GHOST_SIGNATURE_FILE}`, `${JSON.stringify(document, null, 2)}\n`);
-  return zip.generateAsync({ type: 'nodebuffer', compression: 'DEFLATE' });
+  preserveSafeUnixPermissionsForRepack(zip);
+  return zip.generateAsync({ type: 'nodebuffer', compression: 'DEFLATE', platform: 'UNIX' });
 }
 
 export interface ReviewGhostPackageOptions {
@@ -465,7 +480,8 @@ export async function reviewGhostPackage(
     },
   };
   zip.file(`${prefix}${GHOST_SIGNATURE_FILE}`, `${JSON.stringify(document, null, 2)}\n`);
-  return zip.generateAsync({ type: 'nodebuffer', compression: 'DEFLATE' });
+  preserveSafeUnixPermissionsForRepack(zip);
+  return zip.generateAsync({ type: 'nodebuffer', compression: 'DEFLATE', platform: 'UNIX' });
 }
 
 function detectSingleTopFolderPrefix(names: string[]): string {

--- a/apps/desktop/src/main/cindy-brain/ghostZipPermissions.ts
+++ b/apps/desktop/src/main/cindy-brain/ghostZipPermissions.ts
@@ -1,0 +1,102 @@
+/**
+ * ZIP external-attribute 权限位的唯一归一化入口:解包侧(安装器)、打包侧
+ * (forge / export)与重打包侧(签名 / 审核)共用同一套判据,避免各自写一份掩码。
+ */
+
+/** POSIX `st_mode` 分区:文件类型位、普通权限位。 */
+const S_IFMT = 0o170000;
+const S_IFREG = 0o100000;
+const S_IFDIR = 0o040000;
+const S_IFLNK = 0o120000;
+const PERMISSION_BITS = 0o777;
+
+/**
+ * 归档里普通文件 / 目录的缺省形态:DOS 包没有 Unix 元数据时的回落值,也是宿主
+ * 自己生成(而非从磁盘读取)的条目该用的属性。
+ */
+export const ARCHIVE_REGULAR_0644 = S_IFREG | 0o644;
+const ARCHIVE_DIR_0755 = S_IFDIR | 0o755;
+
+/**
+ * Parse JSZip's public `unixPermissions` union without relying on its current
+ * load-time normalization to numbers. String permissions are octal by contract.
+ */
+function parseZipUnixPermissions(
+  unixPermissions: number | string | null | undefined,
+): number | null {
+  if (typeof unixPermissions === 'number') {
+    return Number.isSafeInteger(unixPermissions) && unixPermissions >= 0 ? unixPermissions : null;
+  }
+  if (typeof unixPermissions !== 'string' || !/^[0-7]+$/.test(unixPermissions)) {
+    return null;
+  }
+  const parsed = Number.parseInt(unixPermissions, 8);
+  return Number.isSafeInteger(parsed) ? parsed : null;
+}
+
+/** 文件类型位为 0 = 未声明,按调用方期待的类型采信;否则必须严格匹配。 */
+function declaresType(mode: number, type: number): boolean {
+  const fileType = mode & S_IFMT;
+  return fileType === 0 || fileType === type;
+}
+
+/** 归档声明的符号链接:装入侧一律拒绝,不跟随、不落盘。 */
+export function isZipSymbolicLinkMode(
+  unixPermissions: number | string | null | undefined,
+): boolean {
+  const parsed = parseZipUnixPermissions(unixPermissions);
+  return parsed !== null && (parsed & S_IFMT) === S_IFLNK;
+}
+
+/**
+ * 把真实文件的 mode 转成归档用的普通文件属性。只取 rwx 九位:setuid / setgid /
+ * sticky 与宿主的文件类型位都是本机元数据,绝不能进可分发的 `.cindy`。JSZip 需要
+ * POSIX 文件类型位才能写出符合规范的 UNIX external attributes。
+ */
+export function unixRegularFilePermissionsForArchive(mode: number | bigint): number {
+  return S_IFREG | (Number(mode) & PERMISSION_BITS);
+}
+
+/**
+ * Normalize an archive-declared mode before applying it to an extracted file.
+ *
+ * `& 0o777` strips file-type and special bits so an archive cannot install
+ * setuid/setgid/sticky files. `| 0o600` keeps the owner able to read and replace
+ * even a malicious mode-000 entry, which is required for later update/uninstall.
+ * Missing metadata is deliberately ignored for compatibility with DOS/legacy
+ * packages. Windows is also ignored because chmod there only changes the
+ * read-only attribute. The caller must use chmod *after* writeFile: writeFile's
+ * creation mode is filtered by umask, whereas chmod deterministically restores
+ * an archived 0755 as 0755.
+ *
+ * Directory entries are handled separately by the extractor. When an archive
+ * declares a non-regular UNIX file type, no mode is applied to the regular file
+ * bytes that JSZip exposes.
+ */
+export function installedFileModeFromZip(
+  unixPermissions: number | string | null | undefined,
+  platform: NodeJS.Platform = process.platform,
+): number | null {
+  if (platform === 'win32') return null;
+  const parsed = parseZipUnixPermissions(unixPermissions);
+  if (parsed === null || !declaresType(parsed, S_IFREG)) return null;
+  return (parsed & PERMISSION_BITS) | 0o600;
+}
+
+/**
+ * Re-emit an already loaded ZIP entry on the UNIX platform without carrying
+ * special/file-type bits. DOS entries receive ordinary deterministic defaults;
+ * non-regular UNIX entries are downgraded to a non-executable regular file.
+ */
+export function unixPermissionsForRepackedEntry(
+  unixPermissions: number | string | null | undefined,
+  isDirectory: boolean,
+): number {
+  const parsed = parseZipUnixPermissions(unixPermissions);
+  if (parsed === null) return isDirectory ? ARCHIVE_DIR_0755 : ARCHIVE_REGULAR_0644;
+  if (isDirectory) {
+    return declaresType(parsed, S_IFDIR) ? S_IFDIR | (parsed & PERMISSION_BITS) : ARCHIVE_DIR_0755;
+  }
+  if (!declaresType(parsed, S_IFREG)) return ARCHIVE_REGULAR_0644;
+  return S_IFREG | (parsed & PERMISSION_BITS);
+}

--- a/apps/desktop/src/main/cindy-brain/ghostZipPermissions.ts
+++ b/apps/desktop/src/main/cindy-brain/ghostZipPermissions.ts
@@ -80,7 +80,9 @@ export function installedFileModeFromZip(
   if (platform === 'win32') return null;
   const parsed = parseZipUnixPermissions(unixPermissions);
   if (parsed === null || !declaresType(parsed, S_IFREG)) return null;
-  return (parsed & PERMISSION_BITS) | 0o600;
+  // 篡改包或权限设置粗心的包不得把 group/world 可写文件装进插件内容目录，
+  // 否则同机其它账号可改写受害用户之后会执行的插件代码。
+  return (parsed & PERMISSION_BITS & ~0o022) | 0o600;
 }
 
 /**


### PR DESCRIPTION
## 这次改了什么

### 摘要

`.cindy` 包里声明为 Unix mode 0755 的普通文件，在 macOS / Linux 安装后变成 0644，插件因此无法启动随包的本机可执行程序。文件内容与 SHA-256 都一致，只有 mode 丢了。

排查发现这条链路上有**三处**丢失点，任一处不修都会让执行位在实际使用中丢掉：

1. **安装器**：`GhostManager.extractToStaging()` 用 `fs.promises.writeFile(dest, data)` 落盘，不传 mode，也从未读取 JSZip 的 `entry.unixPermissions`，于是一律落成 `0666 & ~umask` = 0644。
2. **Cindy 自己的打包器**：`forge.ts` / `exportGhostPackage.ts` 都是 `zip.file(rel, content)` 不带 `unixPermissions`，且 JSZip `generateAsync` 缺省按 DOS 平台写 version made by。也就是说 `ghost_forge_pack` 与导出产出的 `.cindy` **压根不带 Unix mode**，只有外部 `zip` / `7z` 打的包才带得上。安装器单独修好，forge 打出来的插件依旧没有执行位。
3. **签名 / 审核重打包**：`signGhostPackage` / `reviewGhostPackage` 会重新生成 ZIP central directory，不带 `platform: 'UNIX'` 就会把打包侧刚写入的执行位再抹掉一次——发布流水线会静默吃掉修复效果。

新增 `ghostZipPermissions.ts` 作为三侧共用的唯一归一化入口，避免解包、打包、重打包各写一份掩码。

几条排除掉的怀疑，记录一下省得后人重查：**不需要换 ZIP 库**（JSZip 本来就解析 central directory 的 external file attributes，`zipEntry.js` 在 `versionMadeBy >> 8 === 3` 时给出 `unixPermissions`）；**不是跨卷复制或原子替换丢的**（staging → final 全程 `rename`，同卷保留 mode）；**全新安装与覆盖升级共用同一个 `extractToStaging`**，所以是一处丢、修一处两条路径都好；内置插件 seed 路径用 `copyFile`，mode 本来就保留，未改动。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：安装器未恢复 `.cindy` 中保存的 Unix 可执行位
- 本 PR 包含：`.cindy` 安装侧权限恢复；forge / export 打包侧写入 Unix mode；签名 / 审核重打包保留执行位；对应回归测试
- 明确不包含：
  - **存量已装插件不做权限回补**（已与需求方确认）。已经是 0644 的插件靠用户重装或升级插件自然恢复，本 PR 不加启动扫描或迁移脚本。
  - **skillhub 不在本次范围**。`skillhub/installService.ts`、`importLocalSkill.ts`、`zipPacker.ts` 有同源的裸 `writeFile` / 不写 mode 问题，但按约定的范围本次不动，需另开 issue 跟进。
- 用户可见变化：macOS / Linux 上安装带本机可执行程序的插件后，该程序能正常启动，不再需要用户手工 `chmod +x`
- 是否存在 breaking change：无

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：PASS apps/desktop unit (24.3s)，退出码 0
      related 范围识别为 apps/desktop (related 9)
      6 个 workspace 跳过，原因均为 notApplicable: No collectable tests yet
      (packages/embedding-client、github-client、gitlab-client、
       heartbeat-client、project-context、device-link-protocol)

pnpm --filter desktop run --if-present typecheck
结果：tsc --noEmit -p tsconfig.json，退出码 0，无跳过

定向复验（4 个相关测试文件）
结果：4/4 test files passed，334/334 tests passed
      (GhostManager 234、forge 66、export 27、ghostSignature 7)
      本机 macOS 下 0 跳过

pnpm check:dco
结果：DCO check passed: 1 commit signed off
```

新增测试覆盖：

- 同一个 UNIX `.cindy` fixture 内同时放 0755、0644、**4755** 文件；
- 全新安装走 `manager.install(v1)`，断言 `mode & 0o777` 精确为 0755 / 0644，且 4755 落地为 0755、setuid 位为 0；
- 随后用 v2 包走 `manager.update(...)`（不是二次 install），再次精确断言三种 mode，并确认内容已换成 v2 —— 覆盖「全新安装与覆盖升级结果一致」；
- DOS 包（`unixPermissions === null`）安装成功，且用 spy 证明**完全没有调用 `chmod`**；
- 打包侧往返：forge / export 产出的包重新 `JSZip.loadAsync` 后能读回 0755，且特殊位已剥除；
- 签名 / 审核重打包后执行位仍在，声明为符号链接的目录条目降级为 0755。

### 手工验证

不涉及：本次改动的可观测点就是文件 mode，已由上述单测在真实文件系统上用 `fs.stat` 精确断言，手工复核不会提供额外信息。

### 未执行的验证

- **Windows 未做实机验证**。Windows 上安装路径整段跳过 `chmod`（`installedFileModeFromZip` 在 `win32` 直接返回 null），纯函数级有断言覆盖，实文件 mode 断言在 `win32` 上按平台跳过，避免假红或假绿。最终以 CI 矩阵为准。
- 未在 Linux 实机验证，逻辑与 macOS 同路径（同为非 win32 分支）。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [x] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

**影响范围**：`.cindy` 的安装、打包、导出与签名重打包路径。

**存量插件影响：无需重装、无需重新确认权限、不丢凭证与偏好。** 用户升级后什么都不做，已装、已批准、已启用的插件照旧可用——本 PR 只改「新落盘文件的 mode」和「新打包产物的 external attributes」，不碰批准状态 schema、指纹格式、manifest 校验、安装布局与包格式契约，旧 DOS `.cindy` 继续原样安装且完全不 `chmod`。

**关于反向兼容的准确表述**（更正初版措辞）：新包在旧客户端只保证**结构兼容**，不保证功能兼容 —— 旧客户端可以正常解包与安装，但它压根不读 `unixPermissions`（这正是原 bug），因此**不具备执行位恢复能力，随包本机程序在旧客户端安装后仍不可直接执行**。不宣称完整的反向功能兼容。

需要如实说明的一点：**已经以 0644 装在盘上的插件，其执行位不会被自动回补**，需重装或升级该插件才恢复。这不是本 PR 引入的退化（这些插件在修复前同样是坏的），也不影响插件的装入 / 批准 / 启用状态，属于「修复不追溯」而非「要求用户重新配置」。基于旧布局的升级用例跑在 `GhostManager.test.ts` 的覆盖升级断言里。

**安全上的取舍**（欢迎重点看这一段）：

- 只采纳归档自己声明的普通权限位，**没有**任何按扩展名或 `bin/` 目录猜执行位的逻辑，也不做统一 `chmod +x`；
- `& 0o777` 剥除 setuid / setgid / sticky，恶意包无法安装特权文件（有专门用例断言 4755 → 755）；
- 额外 `| 0o600` 保底 owner 可读写：否则恶意包里 mode 000 的条目会让后续升级 / 卸载变难。不影响验收语义（`0o644 | 0o600 === 0o644`，`0o755 | 0o600 === 0o755`）；
- 归档声明为非普通文件类型时不落 mode；目录条目走既有 `mkdir`，zip 属性不影响目录权限，也不会作用到安装目录之外；
- **既有防御一行未削弱**：`safeJoin` 路径穿越 / 绝对路径检查、非规范条目路径判定、符号链接拒绝、zip bomb 的条目数与解压总量上限、`__MACOSX/` 过滤全部原样保留。

**跨平台差异**：Windows 全程不 `chmod`（那里 `chmod` 只切换只读位，动它反而是回归）。

**回滚 / 降级方式**：单 commit，`git revert` 即可完全回到原行为，无数据迁移、无持久化状态变更。回滚后新装插件恢复为 0644（即回到当前的 bug 行为），不会留下任何不一致状态。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [ ] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（在 FORGE_GUIDE 打包步骤里补了一句：随包本机可执行程序需在打包前设好执行位，不要靠扩展名或 `bin/` 让宿主猜测）
- [x] 已确认测试结果或说明未执行原因

## Review 反馈处理

两个自动 reviewer 各报了一个 P1，均已处理（`2e9f3649`）。

**1. 已签名导出路径的 mode / 内容快照错位（Greptile）** — 成立，已修。`readSignedDoc()` 与 `readSignedEntries()` 原先 `stat` 与 `readFile` 是两次独立调用，并发 `chmod` 落在中间会把改动前的 mode 配到改动后的内容上（内容与 SHA-256 自洽，校验发现不了，导出包执行位却是旧值）。现改为从同一个 `FileHandle` 取 stat 与内容。「先对尺寸再读内容」的顺序、两道 `MAX_SIGNATURE_FILE_BYTES` 检查、`ENOENT → null` 与失败收敛为 `null` 的语义均保留，早退路径经 `finally` 关闭句柄。

**2. mode 未被签名认证（Codex）** — 前提属实，已核实：`buildStatement()` 枚举全部条目并对 `(path, sha256, bytes)` 做 canonical 全等比对，**内容与文件清单都被认证，但 mode 不在覆盖范围内**。这个缺口是本 PR 引入的（改之前 mode 被完全忽略）。

处理方式是「修掉可修的那半，另一半显式申明」：

- **已修**：装入侧钳掉 group/other 写位（`& ~0o022`）。原实现会原样采纳 `0o777` / `0o666`，于是被篡改的包、**甚至源文件权限没设好的正常包**，都能把 group/world 可写文件装进插件内容目录，同机另一账号即可改写受害用户随后执行的插件代码 —— 这是比「翻转 +x」更实际的本机提权路径。改前此处恒为 0644，不存在该面。`0755`/`0644`/`0700` 不变，`0777 → 0755`，`0666 → 0644`。只钳装入侧（安全边界），打包侧未动。
- **不在本 PR 做**：把 mode 绑进签名 statement。那是包格式契约改动 —— statement 需升到 `schemaVersion: 2`，验签必须同时继续接受存量 v1 签名包（存量插件兼容红线，不允许要求重装或重新确认），发布与审核流水线还要重签。已与需求方确认拆为独立 issue，不阻塞本次 bug 修复。

### 维护者确认门后的第三轮修复（`09ac51a8`）

维护者确认门（#2956）的分析基于 `origin/main` 快照而非 PR 工作树，其中两条已由 PR 内的提交处理或已过时；三条要求现已全部落地：

1. **mode 必须进入与内容同等的完整性边界** —— 给出依据后维持采纳，**已撤回**中途那版「签名包不采纳 mode」的分支（`b29c750b`）。
   中途那版形式上满足要求，但代价是正式发布的插件在 macOS / Linux 上依旧启动不了随包程序、只有未签名包受益 —— 对主分发渠道等于没修（Codex 复审也独立指出了这点）。
   维护者的原话是「现有证据不足以**默认**做出这一产品/安全决定」，所以补上了实算：钳位之后攻击者**改不了文件内容、增删不了文件**（`buildStatement()` 全量白名单 + 逐文件 sha256 + canonical 全等）、**设不了 setuid/setgid/sticky**、**装不出 group/world 可写文件**、**剥不掉 owner 读写**；剩下只有在内容已被哈希钉死的文件上翻转 r / x 位。去掉 `+x` 只是他本来就能造成的可用性破坏（改坏一字节即验签失败）；加上 `+x` 作用在他无法选择内容的文件上，而执行流指向哪个文件由签名覆盖的 manifest 与插件自身代码决定 —— **拿不到代码执行**。逐条分析见 #2956。
   **失效条件写进代码**（`extractToStaging()` 注释）：若日后有任何逻辑开始依赖 mode 做安全判断，该前提即失效，届时必须把归一化 mode 纳入认证。并由用例钉住 —— 改成「签名包不采纳 mode」会让它红。
   **更省的备选**（若放行人坚持要认证 mode）：不必改签名格式 —— `ghost.json` 本来就在签名覆盖范围内，在 manifest 里声明「哪些文件需要执行位」那份声明天然被签名认证，不需要 v2 的双轨验签与流水线重签。要这条说一声我改。#2966（v2 跟进）已按此决定关闭。

2. **导出快照竞态** —— 已修。同句柄只挡住 open 与 stat 之间的窗口，`chmod` 落在读取过程中仍能造出「读前的 mode + 读后的字节」。现已在读取后复验文件稳定态，复用 `ghostContentTree` 既有的 `sameStableFileState()`（含 `ctimeNs`，故覆盖 `chmod`），不另造判据：签名文件不一致即抛错，statement 条目不一致返回 `null` 交给既有的整体重试。
3. **Windows 门禁要有真断言** —— 已修。原先只是在 `win32` 跳过 mode 断言。现按平台分叉正面断言：`win32` 断言 `chmod` 从未被调用，非 `win32` 断言确实调用过，避免这条路径以后静默退化成「什么都没做」也能绿。

新增用例：已签名包（真实经 `signGhostPackage` 用生成的 ed25519 key 签名）安装后，`0755` / `0644` 与特殊位剥除的断言与未签名包完全一致；用例先自检包内确实带 `0755`，保证它不是空转。

### 一处需要单独点明的行为变化（超出「恢复执行位」本身）

既然 mode 现在是包内容的一部分，导出侧的一致性判据也随之收紧，请 review 时留意：

- **未签名导出**的两遍快照比对由 `(rel, sha256)` 扩成 `(rel, sha256, unixPermissions)`。因此**两遍之间发生一次纯 `chmod`**（内容完全没变）现在会判定快照不一致并触发整体重读，而改动前会被忽略。
- **已签名导出**同理：读后复验含 `ctimeNs`，读取期间的 `chmod` 会让该条目返回 `null`，交给既有的整体重试。

这是必要的收紧 —— 否则会打出「一半旧 mode、一半新 mode」的包，内容与 SHA-256 却都自洽、校验发现不了。代价是导出在「导出期间有人 `chmod` 插件目录」这种并发下会多重试一轮（重试仍失败才如实报错），属于罕见且正确的失败路径。

### 残留风险（请放行人重点判断这一条）

签名包与未签名包统一恢复 mode，因此残留面是：能篡改包字节的攻击者可以在验签仍通过的前提下翻转 r / x 位。上面第 1 条已逐条算过后果 —— 只剩一个他原本就具备的 DoS，拿不到代码执行。这是**有意接受**的取舍，依据与失效条件都已落到代码注释与用例里。

- 影响：可用性（去掉 `+x` 使插件启动不了），以及把发布者自己发布、哈希已认证的字节变成可直接 `spawn`。
- **不能**引入新代码、**不能**增删文件、**不能**设置 setuid / setgid / sticky（有用例断言 `4755 → 755`）。
- 插件的启动入口写在 manifest 里、同样在签名覆盖范围内，翻转别处的执行位改变不了「执行哪个文件」。

请放行人在三者中裁定：**接受本 PR 现状**（依据如上）、**要求改成 manifest 声明式**（更省，仍是认证过的）、或**要求做 statement v2**。我不自行推进。

---

> **给放行人的提示**：本 PR 命中**插件基座**（安装链路 + 包格式 / external attributes），按 `AGENTS.md` 与 `docs/dev-rules/plugin-security-and-authoring.md` 第 5 节需走白名单确认门，要放行人针对存量插件影响明确 Approve 后才能合并，不因「是 bugfix / 纯技术改动」豁免。
