### PR TITLE
fix(model-providers): 自定义 Codex 模型放开 max 档 effort

### DIFF
--- a/packages/model-providers/src/__tests__/user-provider.test.ts
+++ b/packages/model-providers/src/__tests__/user-provider.test.ts
@@ -115,8 +115,8 @@ describe('buildUserProvider (per-runtime)', () => {
       id: 'meta/llama-4-405b',
       name: 'Llama 4 405B',
       contextWindow: DEFAULT_CUSTOM_CONTEXT_WINDOW,
-      // codex runtime：参考内置默认 effort 档位（low/medium/high/xhigh，默认 high）。
-      efforts: ['low', 'medium', 'high', 'xhigh'],
+      // codex runtime：参考内置默认 effort 档位（low/medium/high/xhigh/max，默认 high）。
+      efforts: ['low', 'medium', 'high', 'xhigh', 'max'],
       defaultEffort: 'high',
       group: 'custom:openrouter',
       defaultEnabled: true,
@@ -189,7 +189,7 @@ describe('buildUserProvider (per-runtime)', () => {
       }),
       expect.objectContaining({
         id: 'unregistered-model',
-        efforts: ['low', 'medium', 'high', 'xhigh'],
+        efforts: ['low', 'medium', 'high', 'xhigh', 'max'],
         defaultEffort: 'high',
       }),
     ]);
@@ -228,7 +228,7 @@ describe('buildUserProvider (per-runtime)', () => {
       { modelRegistry: registry },
     );
     expect(ambiguous.models.codex?.[0]).toMatchObject({
-      efforts: ['low', 'medium', 'high', 'xhigh'],
+      efforts: ['low', 'medium', 'high', 'xhigh', 'max'],
       defaultEffort: 'high',
     });
 
@@ -265,7 +265,7 @@ describe('buildUserProvider (per-runtime)', () => {
       { modelRegistry: BUNDLED_CATALOG.modelRegistry },
     );
     expect(noTargetRoute.models.codex?.[0]).toMatchObject({
-      efforts: ['low', 'medium', 'high', 'xhigh'],
+      efforts: ['low', 'medium', 'high', 'xhigh', 'max'],
       defaultEffort: 'high',
     });
   });

--- a/packages/model-providers/src/user-provider.ts
+++ b/packages/model-providers/src/user-provider.ts
@@ -44,14 +44,17 @@ export function storedCustomProviderId(providerId: string): string {
 /**
  * 自定义模型的默认 effort 档位（「参考默认设置」）——与内置当代旗舰模型对齐：
  *   - claude-code：low/medium/high/xhigh/max（同 opus / fable）；
- *   - codex：low/medium/high/xhigh（同 gpt-5.x）。
+ *   - codex：low/medium/high/xhigh/max（gpt-5.x 同款五档，ultra 仍仅限已登记模型）。
  * 让自定义模型像内置模型一样能在选择器里切 reasoning/thinking 强度（默认 high）。
  * 端点是否真支持由其后端决定：cc 经 `thinking`、codex 经 reasoning effort 透传，
  * anthropic-compat-proxy 仅对个别内置 model id strip 字段、对自定义 id 一律字节透传。
+ * 未登记模型（Registry 无法确认能力）也放开到 max：第三方 Responses 兼容端点普遍
+ * 接受与否只有端点方/用户知道，选到不支持的档位会被上游拒绝，用户改选即可；
+ * 默认档保持 high，存量行为不变（见 #2964）。
  */
 const CUSTOM_EFFORTS: Partial<Record<AgentKind, Effort[]>> = {
   'claude-code': ['low', 'medium', 'high', 'xhigh', 'max'],
-  codex: ['low', 'medium', 'high', 'xhigh'],
+  codex: ['low', 'medium', 'high', 'xhigh', 'max'],
 };
 /** 自定义模型默认选中的 effort（与内置旗舰一致）。 */
 const DEFAULT_CUSTOM_EFFORT: Effort = 'high';


### PR DESCRIPTION
## 这次改了什么

### 摘要

自定义供应商 Codex 模型的 effort 兜底档位从四档(low/medium/high/xhigh)放开到五档(+`max`),与 claude-code 的自定义档位对齐。此前 `CUSTOM_EFFORTS.codex` 写死四档,`glm-5.3` 这类未命中 Registry 的自定义模型在 UI 中选不到 max;协议与引擎层(`turn/start` 透传 effort)本就支持,只是被目录档位门控。

产品口径:第三方 Responses 兼容端点是否接受 `max` 只有端点方/用户知道——大多数端点接受,不接受的会明确拒绝,用户改选即可,兼容性由选择者承担。默认档保持 `high`,存量用户无感。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求:Closes #2964;与 #2912(同议题的 fallback 扩展 PR,含 `ultra`、待产品确认)互为替代方案——若维护者采纳逐模型声明或 #2912 的六档方案,本 PR 可直接关闭
- 本 PR 包含:`packages/model-providers` 中 `CUSTOM_EFFORTS.codex` 补 `max` 档及注释更新、`user-provider.test.ts` 对应断言更新
- 明确不包含:`ultra` 档(仍仅限 Registry 已登记模型如 GPT-5.6 Sol)、逐模型声明机制(见 issue 中分析评论的完整方案)、`anthropic-responses-bridge` 的 effort 收敛(那是 CC 引擎对内置 x.ai/codex 端点的既有行为,与 codex 引擎自定义供应商路径无关)
- 用户可见变化:自定义 Codex 模型的 effort 选择器多出「Max」档;默认档与存量行为不变
- 是否存在 breaking change:无

### UI 变化

- 引用的设计规范:不涉及:无 UI 代码改动;效果是选择器档位列表由 catalog `efforts` 驱动自动多出 max。

## 怎么验证的

### 自动验证

```text
pnpm install
结果:通过(5m48s)

pnpm test:unit:related
结果:packages/model-providers PASS(含改动后的 user-provider.test.ts)、apps/mobile PASS;
     apps/desktop 全量 2004 文件 / 26770 用例中 2 个失败,均在
     src/main/cindy-brain/__tests__/ghostInstallReceipt.test.ts —— 已在
     stash 掉本改动后于干净 main 复跑同一文件确认同样失败(2 failed | 9 passed),
     为存量问题、与本次改动无关。首次跑门禁时 desktop 在 maxWorkers=8 下进程
     SIGSEGV(基础设施抖动),降到 4 workers 后完整跑完,仅上述存量失败。

pnpm --filter @cindy/model-providers run --if-present typecheck
结果:该包无 typecheck script(自动跳过);补跑 pnpm --filter @cindy/model-providers run build
     (tsc --noEmit)有 2 个错误,均在未改动的 src/__tests__/catalog.test.ts —— 同样
     在干净 main 上复现(同为 2 个),存量问题、与本次改动无关。
```

### 手工验证

不涉及(无运行时行为分支:档位列表由静态表投影,单测已覆盖)。

### 未执行的验证

- fake OpenAI Responses upstream 的 `max` 端到端透传断言、GLM Coding Plan 真实端点的 `xhigh`/`max` 实测:本机为受限网络环境,未搭起 fake upstream;issue 分析评论中的验收建议 3/8 留给维护者按需复核(引擎透传链路已有内置 GPT-5.6 Sol `max/ultra` 档位在生产使用佐证)。

## 风险

### 风险分类

- [ ] 无已知风险
- [x] 其他:第三方端点可能不接受 `max`,请求会被上游拒绝(明确报错,非静默);用户改选 `xhigh` 即可,默认档与存量行为不变。

### 影响与回滚

- 影响范围:仅自定义供应商 Codex 模型的档位列表;Registry 可确认能力的模型仍优先继承目录声明,`ultra` 不放行。
- 回滚 / 降级方式:单 commit,revert 即完全回到四档。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`pnpm check:dco` 通过)
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节(不涉及 UI 则跳过)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
