### PR TITLE
fix(desktop): preserve Slack retry context

### DIFF
--- a/apps/desktop/src/main/hook-control/__tests__/dispatcher.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/dispatcher.test.ts
@@ -1282,6 +1282,8 @@ describe('dispatcher 核心语义', () => {
     await tick();
     const firstSessionId = fr.calls[0]?.sessionId;
     expect(firstSessionId).toBeTruthy();
+    expect(fr.calls[0]).toMatchObject({ isNew: true, prompt: '干活' });
+    expect(fr.calls[0]).not.toHaveProperty('replacementOfSessionId');
 
     d.handleDispatch(
       'conn-1',
@@ -1394,6 +1396,114 @@ describe('dispatcher 核心语义', () => {
     });
     expect(fr.calls).toHaveLength(1);
     expect(bindings.get('conn-1', externalKey)).toBe(replacementSessionId);
+    fr.finish();
+  });
+
+  it('replacement 再次失效时仍从最初任务恢复原始需求，不把“再试试”当上下文', async () => {
+    const dd = dialogueDep();
+    const sessions: Record<string, { workingDir: string; usable: boolean }> = {};
+    const fr = fakeRunner({ sessions });
+    const bindings = memoryBindings();
+    const externalKey = 'team-slack:C1:replacement-context';
+    const { d } = makeDispatcher({ runner: fr.runner, dialogue: dd.dep, bindings });
+    const c = collector();
+
+    d.handleDispatch(
+      'conn-1',
+      dispatch({
+        requestId: 'original',
+        externalKey,
+        sessionId: null,
+        workspace: 'xdmaker',
+        prompt: '检查支付回调失败的问题并修复',
+      }),
+      c.send,
+    );
+    await tick();
+    const originalSessionId = fr.calls[0]?.sessionId;
+    expect(originalSessionId).toBeTruthy();
+    bindings.set('conn-1', externalKey, originalSessionId!);
+    sessions[originalSessionId!] = { workingDir: WS_DIR, usable: false };
+    fr.finish({ status: 'error', errorMessage: 'token expired' });
+    await tick();
+
+    d.handleDispatch(
+      'conn-1',
+      dispatch({
+        requestId: 'retry',
+        externalKey,
+        sessionId: originalSessionId,
+        workspace: null,
+        prompt: '再试试',
+      }),
+      c.send,
+    );
+    await tick();
+
+    expect(fr.calls[1]).toMatchObject({
+      isNew: true,
+      replacementOfSessionId: originalSessionId,
+      replacementPrompt: '检查支付回调失败的问题并修复',
+      prompt: '再试试',
+    });
+    const firstReplacementId = fr.calls[1]?.sessionId;
+    expect(firstReplacementId).toBeTruthy();
+    sessions[firstReplacementId!] = { workingDir: WS_DIR, usable: false };
+    fr.finish({ status: 'error', errorMessage: 'models not ready' });
+    await tick();
+
+    d.handleDispatch(
+      'conn-1',
+      dispatch({
+        requestId: 'retry-again',
+        externalKey,
+        sessionId: firstReplacementId,
+        workspace: null,
+        prompt: '再试一次',
+      }),
+      c.send,
+    );
+    await tick();
+
+    expect(fr.calls[2]).toMatchObject({
+      isNew: true,
+      replacementOfSessionId: originalSessionId,
+      replacementPrompt: '检查支付回调失败的问题并修复',
+      prompt: '再试一次',
+    });
+    fr.finish();
+  });
+
+  it('显式失效目标不属于当前 lane 时不读取它的上下文', async () => {
+    const dd = dialogueDep();
+    const fr = fakeRunner({
+      sessions: {
+        'private-session': {
+          workingDir: path.join(DIALOGUE_ROOT, '2026-07-07', 'private-session'),
+          usable: false,
+        },
+      },
+    });
+    const externalKey = 'team-slack:C1:foreign-stale';
+    const { d } = makeDispatcher({ runner: fr.runner, dialogue: dd.dep });
+    const c = collector();
+
+    d.handleDispatch(
+      'conn-1',
+      dispatch({
+        requestId: 'foreign-stale',
+        externalKey,
+        sessionId: 'private-session',
+        workspace: null,
+        prompt: '再试试',
+      }),
+      c.send,
+    );
+    await tick();
+
+    expect(fr.calls[0]).toMatchObject({ isNew: true, prompt: '再试试' });
+    expect(fr.calls[0]).not.toHaveProperty('replacementOfSessionId');
+    expect(fr.calls[0]).not.toHaveProperty('replacementPrompt');
     fr.finish();
   });
 

--- a/apps/desktop/src/main/hook-control/__tests__/session-runner.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/session-runner.test.ts
@@ -746,7 +746,11 @@ describe('hook session-runner 的 userSendAt 时序(未分类误判回归)', () 
     ]);
     const runner = createMakerHookSessionRunner({ log });
     const outcome = await runner.run(
-      baseReq({ replacementOfSessionId: 'sess-old', prompt: '再试试' }),
+      baseReq({
+        replacementOfSessionId: 'sess-old',
+        prompt: '再试试',
+        source: { im: 'slack', channelName: '#general' },
+      }),
     );
 
     expect(outcome.status).toBe('ok');
@@ -771,6 +775,7 @@ describe('hook session-runner 的 userSendAt 时序(未分类误判回归)', () 
         replacementOfSessionId: 'sess-old',
         replacementPrompt: '生成发布说明并提交 PR',
         prompt: '再试试',
+        source: { im: 'slack', channelName: '#general' },
       }),
     );
 
@@ -787,7 +792,11 @@ describe('hook session-runner 的 userSendAt 时序(未分类误判回归)', () 
   it('旧任务没有可读历史或进程内 prompt 时仍按当前 dispatch 正常执行', async () => {
     const runner = createMakerHookSessionRunner({ log });
     const outcome = await runner.run(
-      baseReq({ replacementOfSessionId: 'sess-old', prompt: '再试试' }),
+      baseReq({
+        replacementOfSessionId: 'sess-old',
+        prompt: '再试试',
+        source: { im: 'slack', channelName: '#general' },
+      }),
     );
 
     expect(outcome.status).toBe('ok');
@@ -795,6 +804,82 @@ describe('hook session-runner 的 userSendAt 时序(未分类误判回归)', () 
     expect(session.send.mock.calls[0][0]).toMatchObject({
       content: `再试试\n\n${SLACK_HOOK_PROMPT_NOTE}`,
     });
+  });
+
+  it('被 /clear 清除过的旧任务不恢复已丢弃的上下文', async () => {
+    h.listMessagesForAgentHandoff.mockResolvedValueOnce([]);
+    const { getSessionRowSnapshotStrict } = await import('../../localDb/ipc/sessions.js');
+    vi.mocked(getSessionRowSnapshotStrict).mockResolvedValueOnce({
+      status: 'active',
+    } as never);
+    const runner = createMakerHookSessionRunner({ log });
+    const outcome = await runner.run(
+      baseReq({
+        replacementOfSessionId: 'sess-old',
+        replacementPrompt: '原始需求',
+        prompt: '再试试',
+        source: { im: 'slack', channelName: '#general' },
+      }),
+    );
+
+    expect(outcome.status).toBe('ok');
+    const session = await fakeMaker.createSession.mock.results[0].value;
+    const sent = session.send.mock.calls[0][0].content as string;
+    expect(sent).not.toContain('原始需求');
+    expect(sent).toContain('再试试');
+  });
+
+  it('截断历史缺少首条用户消息时补入缓存的 replacementPrompt', async () => {
+    h.listMessagesForAgentHandoff.mockResolvedValueOnce([
+      {
+        clientId: 'mid-assistant',
+        role: 'assistant',
+        content: '正在处理...',
+        createdAt: 100,
+        agentMeta: null,
+      },
+      {
+        clientId: 'mid-user',
+        role: 'user',
+        content: '继续',
+        createdAt: 200,
+        agentMeta: null,
+      },
+    ]);
+    const runner = createMakerHookSessionRunner({ log });
+    const outcome = await runner.run(
+      baseReq({
+        replacementOfSessionId: 'sess-old',
+        replacementPrompt: '检查支付回调失败的问题并修复',
+        prompt: '再试试',
+        source: { im: 'slack', channelName: '#general' },
+      }),
+    );
+
+    expect(outcome.status).toBe('ok');
+    const session = await fakeMaker.createSession.mock.results[0].value;
+    const sent = session.send.mock.calls[0][0].content as string;
+    expect(sent).toContain('检查支付回调失败的问题并修复');
+    expect(sent).toContain('继续');
+    expect(sent.indexOf('检查支付回调失败的问题并修复')).toBeLessThan(sent.indexOf('继续'));
+  });
+
+  it('非 Slack 渠道的 replacement 不注入旧任务历史', async () => {
+    const runner = createMakerHookSessionRunner({ log });
+    const outcome = await runner.run(
+      baseReq({
+        replacementOfSessionId: 'sess-old',
+        replacementPrompt: '原始需求',
+        prompt: '再试试',
+        source: { im: 'telegram', channelName: 'Release topic', userText: '再试试' },
+      }),
+    );
+
+    expect(outcome.status).toBe('ok');
+    expect(h.listMessagesForAgentHandoff).not.toHaveBeenCalledWith('sess-old', 400);
+    const session = await fakeMaker.createSession.mock.results[0].value;
+    const sent = session.send.mock.calls[0][0].content as string;
+    expect(sent).not.toContain('原始需求');
   });
 
   it('pending handoff 只注入 agent wire 内容, accepted 后消费', async () => {

--- a/apps/desktop/src/main/hook-control/__tests__/session-runner.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/session-runner.test.ts
@@ -38,6 +38,13 @@ const h = vi.hoisted(() => {
     createMessage: vi.fn(async () => {
       calls.push('createMessage');
     }),
+    listMessagesForAgentHandoff: vi.fn(async () => [] as Array<{
+      clientId: string;
+      role: string;
+      content: unknown;
+      createdAt: number;
+      agentMeta: Record<string, unknown> | null;
+    }>),
     beginTurnChangeSetAtDispatch: vi.fn(async (session: { id: string }, anchorClientId: string) => {
       calls.push(`beginChangeSet:${session.id}:${anchorClientId}`);
     }),
@@ -114,8 +121,12 @@ vi.mock('../../turn-change-set/store.js', () => ({
 vi.mock('../../maker-host/send-outcome.js', () => ({
   toDesktopSessionDispatchOutcome: () => ({ dispatched: true as const }),
 }));
+vi.mock('../../messagePersistBroadcaster.js', () => ({
+  enqueueDurableWrite: vi.fn(async (_label: string, fn: () => unknown) => fn()),
+}));
 vi.mock('../../localDb/ipc/messages.js', () => ({
   createMessage: h.createMessage,
+  listMessagesForAgentHandoff: h.listMessagesForAgentHandoff,
 }));
 vi.mock('../../localDb/ipc/sessions.js', () => ({
   getSessionRowSnapshot: vi.fn(async () => null),
@@ -380,6 +391,8 @@ beforeEach(() => {
   h.resolvedConfig.permissionMode = 'bypassPermissions';
   h.resolvedConfig.providerId = null;
   h.peekPendingHandoff.mockResolvedValue(null);
+  h.listMessagesForAgentHandoff.mockReset();
+  h.listMessagesForAgentHandoff.mockResolvedValue([]);
 });
 
 describe('hook session 精确接管边界', () => {
@@ -712,6 +725,76 @@ describe('hook session-runner 的 userSendAt 时序(未分类误判回归)', () 
       content: `hello\n\n${buildHookPromptNote('telegram')}`,
     });
     expect(h.setSessionSourceInDb).toHaveBeenCalledWith('sess-new', 'telegram');
+  });
+
+  it('replacement 读取旧任务历史交接给 Agent，落库仍只保存当前 Slack 原话', async () => {
+    h.listMessagesForAgentHandoff.mockResolvedValueOnce([
+      {
+        clientId: 'old-user',
+        role: 'user',
+        content: '检查支付回调失败的问题并修复',
+        createdAt: 1,
+        agentMeta: null,
+      },
+      {
+        clientId: 'old-error',
+        role: 'error',
+        content: 'Provided authentication token is expired',
+        createdAt: 2,
+        agentMeta: null,
+      },
+    ]);
+    const runner = createMakerHookSessionRunner({ log });
+    const outcome = await runner.run(
+      baseReq({ replacementOfSessionId: 'sess-old', prompt: '再试试' }),
+    );
+
+    expect(outcome.status).toBe('ok');
+    expect(h.listMessagesForAgentHandoff).toHaveBeenCalledWith('sess-old', 400);
+    const session = await fakeMaker.createSession.mock.results[0].value;
+    const sent = session.send.mock.calls[0][0].content as string;
+    expect(sent).toContain('检查支付回调失败的问题并修复');
+    expect(sent).toContain('Provided authentication token is expired');
+    expect(sent).toContain('再试试');
+    expect(sent.indexOf('检查支付回调失败的问题并修复')).toBeLessThan(sent.indexOf('再试试'));
+    const createCalls = h.createMessage.mock.calls as unknown as Array<
+      [string, { content: unknown }]
+    >;
+    expect(createCalls[0][1].content).toBe('再试试');
+  });
+
+  it('旧任务未落库时用进程内原始 prompt 交接；读库报错也不阻断重试', async () => {
+    h.listMessagesForAgentHandoff.mockRejectedValueOnce(new Error('database unavailable'));
+    const runner = createMakerHookSessionRunner({ log });
+    const outcome = await runner.run(
+      baseReq({
+        replacementOfSessionId: 'sess-old',
+        replacementPrompt: '生成发布说明并提交 PR',
+        prompt: '再试试',
+      }),
+    );
+
+    expect(outcome.status).toBe('ok');
+    const session = await fakeMaker.createSession.mock.results[0].value;
+    const sent = session.send.mock.calls[0][0].content as string;
+    expect(sent).toContain('生成发布说明并提交 PR');
+    expect(sent).toContain('再试试');
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining('hook replacement history unavailable; using in-memory dispatch context'),
+    );
+  });
+
+  it('旧任务没有可读历史或进程内 prompt 时仍按当前 dispatch 正常执行', async () => {
+    const runner = createMakerHookSessionRunner({ log });
+    const outcome = await runner.run(
+      baseReq({ replacementOfSessionId: 'sess-old', prompt: '再试试' }),
+    );
+
+    expect(outcome.status).toBe('ok');
+    const session = await fakeMaker.createSession.mock.results[0].value;
+    expect(session.send.mock.calls[0][0]).toMatchObject({
+      content: `再试试\n\n${SLACK_HOOK_PROMPT_NOTE}`,
+    });
   });
 
   it('pending handoff 只注入 agent wire 内容, accepted 后消费', async () => {

--- a/apps/desktop/src/main/hook-control/dispatcher.ts
+++ b/apps/desktop/src/main/hook-control/dispatcher.ts
@@ -153,6 +153,16 @@ export interface HookRunRequest {
   laneKind?: 'dm' | 'group';
   /** true = 新建 session(workingDir/title 生效); false = 复用/接管已有。 */
   isNew: boolean;
+  /**
+   * 新建任务替换了哪条不可投递的旧任务。runner 用它从旧任务仍可读取的
+   * 本地消息构造一次性 Agent 交接；省略 = 普通新建，不补旧任务上下文。
+   */
+  replacementOfSessionId?: string;
+  /**
+   * 原任务尚未落库时的内存兜底 prompt。只进入新 Agent 的交接前缀，绝不作为
+   * replacement 的用户消息落库；省略 = 仅尝试读取旧任务消息。
+   */
+  replacementPrompt?: string;
   workingDir: string;
   /** dispatch options 显式指定的 agent; null = 桌面端按草稿默认落值。 */
   agentKind: string | null;
@@ -604,6 +614,9 @@ interface PendingReopen {
   /** 那一轮真正跑的目录(执行前还要按当前映射复核一次)。 */
   workingDir: string;
   source?: TaskSource;
+  /** 失败任务本身若是 replacement，下一次 replacement 继续从最初来源任务交接。 */
+  replacementOfSessionId?: string;
+  replacementPrompt?: string;
   accountGeneration: number;
   expiresAt: number;
 }
@@ -762,6 +775,19 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
     string,
     { staleSessionId: string; replacementSessionId: string }
   >();
+  /** 最近一次已受理派发的原始需求；原任务未落库时供 replacement 恢复。 */
+  const latestPromptBySession = new Map<string, string>();
+  const MAX_REMEMBERED_SESSION_PROMPTS = 2_000;
+  const MAX_REMEMBERED_PROMPT_CHARS = 20_000;
+  function rememberSessionPrompt(sessionId: string, prompt: string): void {
+    // 第一条才是 thread 的原始需求。后续“再试试”等短追问不得覆盖它。
+    if (latestPromptBySession.has(sessionId)) return;
+    latestPromptBySession.set(sessionId, prompt.slice(0, MAX_REMEMBERED_PROMPT_CHARS));
+    if (latestPromptBySession.size > MAX_REMEMBERED_SESSION_PROMPTS) {
+      const oldest = latestPromptBySession.keys().next().value;
+      if (oldest !== undefined) latestPromptBySession.delete(oldest);
+    }
+  }
   /** 每 session 的 FIFO 等待队列。 */
   const queues = new Map<string, PendingTask[]>();
   /** connectionId + requestId -> 正在执行它的 session(cancel 定位与归属校验用, 收口即清)。 */
@@ -1398,6 +1424,10 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
               externalKey: entry.externalKey,
               workingDir: entry.workingDir,
               ...(entry.source ? { source: entry.source } : {}),
+              ...(entry.replacementOfSessionId
+                ? { replacementOfSessionId: entry.replacementOfSessionId }
+                : {}),
+              ...(entry.replacementPrompt ? { replacementPrompt: entry.replacementPrompt } : {}),
               accountGeneration: entry.accountGeneration,
             },
             // 这一轮开跑时已复核过能力(见 beginContinuation), 且它的 turn.end 刚刚
@@ -1612,6 +1642,12 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
           externalKey: task.externalKey,
           workingDir: task.run.workingDir,
           ...(task.run.source ? { source: task.run.source } : {}),
+          ...(task.run.replacementOfSessionId
+            ? { replacementOfSessionId: task.run.replacementOfSessionId }
+            : {}),
+          ...(task.run.replacementPrompt
+            ? { replacementPrompt: task.run.replacementPrompt }
+            : {}),
           accountGeneration: task.accountGeneration,
         },
         task.reopenCapable,
@@ -1749,12 +1785,15 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
     let effectiveWorkspace = payload.workspace;
     let effectiveWorkspaces = config.workspaces;
     let forceNew = false;
+    let replacementOfSessionId: string | null = null;
+    let replacementPrompt: string | null = null;
     /** 旧绑定作废、本次不得不新建会话时, 随 turn.end 回给渠道的说明。 */
     let recreatedNotice: string | null = null;
 
     const laneKind = deriveLaneKind(payload.externalKey);
     const laneKey = bindingKey(connectionId, payload.externalKey);
     const namespacedBound = bindings.get(connectionId, payload.externalKey);
+    const trackedReplacement = staleTakeoverReplacements.get(laneKey);
     // v1 stored every mapping under the literal "slack" namespace.  A new
     // account/provider namespace may read it only as a candidate; it is moved
     // after current-account DB existence + workspace allowlist checks pass.
@@ -1857,6 +1896,18 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
         // 仍保留旧拒绝语义, 避免凭空选择一个工作目录。
         return { reject: 'session_not_found' };
       }
+      const canRecoverFromRequestedSession =
+        payload.sessionId === namespacedBound ||
+        (trackedReplacement !== undefined &&
+          (payload.sessionId === trackedReplacement.staleSessionId ||
+            payload.sessionId === trackedReplacement.replacementSessionId));
+      replacementOfSessionId = canRecoverFromRequestedSession
+        ? (trackedReplacement?.staleSessionId ?? payload.sessionId)
+        : null;
+      replacementPrompt =
+        replacementOfSessionId === null
+          ? null
+          : (latestPromptBySession.get(replacementOfSessionId) ?? null);
       forceNew = true;
       log.info(
         `hook takeover target ${payload.sessionId} is gone or archived; creating a fresh session in ${effectiveWorkspace}`,
@@ -1880,7 +1931,7 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
         ? bindings.get(legacyNamespace, payload.externalKey)
         : null;
     const bound = namespacedBound ?? legacyBound;
-    const trackedReplacement = staleTakeoverReplacements.get(laneKey);
+    const previousTrackedStaleSessionId = trackedReplacement?.staleSessionId ?? null;
     const reusesTrackedReplacement =
       forceNew &&
       payload.sessionId !== null &&
@@ -1998,6 +2049,12 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
       // 原因, 因此带一条说明随本次 turn.end 回去(见 execute)。
       if (!forceNew) {
         recreatedNotice = info?.usable ? NOTICE_SESSION_RECREATED : NOTICE_SESSION_GONE;
+        // 当前 lane 自己的失效绑定可以作为交接来源。legacy namespace 可能来自
+        // 另一账号，只允许迁移可用且仍在映射内的任务，绝不从失效 legacy 读历史。
+        if (!info?.usable && bound === namespacedBound) {
+          replacementOfSessionId = bound;
+          replacementPrompt = latestPromptBySession.get(bound) ?? null;
+        }
       }
       log.info(
         `hook binding for ${payload.externalKey} dropped: session ${bound} ${
@@ -2050,7 +2107,7 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
     bindings.set(connectionId, payload.externalKey, sessionId);
     if (forceNew && payload.sessionId !== null) {
       staleTakeoverReplacements.set(laneKey, {
-        staleSessionId: payload.sessionId,
+        staleSessionId: previousTrackedStaleSessionId ?? payload.sessionId,
         replacementSessionId: sessionId,
       });
     } else {
@@ -2079,6 +2136,8 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
       run: {
         sessionId,
         isNew: true,
+        ...(replacementOfSessionId !== null ? { replacementOfSessionId } : {}),
+        ...(replacementPrompt !== null ? { replacementPrompt } : {}),
         laneKind,
         workingDir: runDir,
         agentKind,
@@ -2274,6 +2333,7 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
               ...taskBase,
               ack,
             };
+            rememberSessionPrompt(sessionId, task.run.prompt);
             queue.push(task);
             queues.set(sessionId, queue);
             reply(connectionId, send, ack);
@@ -2296,6 +2356,7 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
             queuePosition: null,
           };
           const task: PendingTask = { ...taskBase, ack };
+          rememberSessionPrompt(sessionId, task.run.prompt);
           reply(connectionId, send, ack);
           ackReactions.onAccepted(ackTaskOf(task), send);
           startExecution(task);
@@ -2420,6 +2481,7 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
         // (PR #733 review 指出)。这些会话属于上一个账号, 新账号下本就不该免检。
         awaitingPersist.clear();
         staleTakeoverReplacements.clear();
+        latestPromptBySession.clear();
         keyChains.clear();
         sessionAdmissionChains.clear();
       })();
@@ -2613,6 +2675,7 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
       }
       pendingReopens.clear();
       staleTakeoverReplacements.clear();
+      latestPromptBySession.clear();
       serverFeatures.clear();
       sendFns.clear();
       pendingTurnEnds.clear();

--- a/apps/desktop/src/main/hook-control/dispatcher.ts
+++ b/apps/desktop/src/main/hook-control/dispatcher.ts
@@ -2106,6 +2106,10 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
     // 新建会话跑在别名目录(或对话根)里, 是否还能复用每次现场按映射判定
     bindings.set(connectionId, payload.externalKey, sessionId);
     if (forceNew && payload.sessionId !== null) {
+      // Security: staleSessionId is only used for routing repeated dispatches to
+      // the same replacement session (reusesTrackedReplacement path). It never
+      // grants read access — replacementOfSessionId (which enables history read)
+      // is always gated by canRecoverFromRequestedSession above.
       staleTakeoverReplacements.set(laneKey, {
         staleSessionId: previousTrackedStaleSessionId ?? payload.sessionId,
         replacementSessionId: sessionId,

--- a/apps/desktop/src/main/hook-control/session-runner.ts
+++ b/apps/desktop/src/main/hook-control/session-runner.ts
@@ -961,26 +961,50 @@ export function createMakerHookSessionRunner(deps: {
       // 见 outbound.ts 的常量注释)。
       const promptWithNote = `${req.prompt}\n\n${buildHookPromptNote(req.source?.im)}`;
       let replacementHandoff: string | null = null;
-      if (req.isNew && req.replacementOfSessionId) {
+      if (req.isNew && req.replacementOfSessionId && req.source?.im === 'slack') {
         try {
           const previousMessages = await enqueueDurableWrite(
             `hook-replacement-handoff:${req.replacementOfSessionId}`,
             () => listMessagesForAgentHandoff(req.replacementOfSessionId!, 400),
           );
-          const handoffMessages =
-            previousMessages.length > 0
-              ? previousMessages
-              : req.replacementPrompt
-                ? [
-                    {
-                      clientId: 'hook-replacement-memory',
-                      role: 'user',
-                      content: req.replacementPrompt,
-                      createdAt: startedAt,
-                      agentMeta: null,
-                    },
-                  ]
-                : [];
+          let handoffMessages: typeof previousMessages;
+          if (previousMessages.length > 0) {
+            const hasFirstUserMessage = previousMessages.some(
+              (m, i) => i === 0 && m.role === 'user',
+            );
+            if (!hasFirstUserMessage && req.replacementPrompt) {
+              handoffMessages = [
+                {
+                  clientId: 'hook-replacement-memory',
+                  role: 'user',
+                  content: req.replacementPrompt,
+                  createdAt: previousMessages[0].createdAt - 1,
+                  agentMeta: null,
+                },
+                ...previousMessages,
+              ];
+            } else {
+              handoffMessages = previousMessages;
+            }
+          } else {
+            const sessionRow = await getSessionRowSnapshotStrict(
+              req.replacementOfSessionId,
+            );
+            const sessionPersistedAndCleared = sessionRow !== null;
+            if (!sessionPersistedAndCleared && req.replacementPrompt) {
+              handoffMessages = [
+                {
+                  clientId: 'hook-replacement-memory',
+                  role: 'user',
+                  content: req.replacementPrompt,
+                  createdAt: startedAt,
+                  agentMeta: null,
+                },
+              ];
+            } else {
+              handoffMessages = [];
+            }
+          }
           if (handoffMessages.length > 0) {
             replacementHandoff = buildHandoffText(handoffMessages, {
               fromLabel: 'Cindy',

--- a/apps/desktop/src/main/hook-control/session-runner.ts
+++ b/apps/desktop/src/main/hook-control/session-runner.ts
@@ -64,7 +64,11 @@ import {
   type InteractionRouteLease,
   type TurnOrigin as RoutedTurnOrigin,
 } from '../maker-ipc/interactionRouter.js';
-import { prependHandoffToUserMessage, prependNoteToWireUserMessage } from '../maker-ipc/agentHandoff.js';
+import {
+  buildHandoffText,
+  prependHandoffToUserMessage,
+  prependNoteToWireUserMessage,
+} from '../maker-ipc/agentHandoff.js';
 import { agentHandoffPending } from '../maker-ipc/agentHandoffPendingSingleton.js';
 import { summarizeOpenPlan, buildPlanReconcileNote } from '../maker-ipc/planReconcile.js';
 import { listMessagesForAgentHandoff } from '../localDb/ipc/messages.js';
@@ -956,10 +960,63 @@ export function createMakerHookSessionRunner(deps: {
       // 用 xdt-file 引用回传文件而非误用 cindy_feishu_bot(规则 9,实踩背景
       // 见 outbound.ts 的常量注释)。
       const promptWithNote = `${req.prompt}\n\n${buildHookPromptNote(req.source?.im)}`;
-      const sendContent =
+      let replacementHandoff: string | null = null;
+      if (req.isNew && req.replacementOfSessionId) {
+        try {
+          const previousMessages = await enqueueDurableWrite(
+            `hook-replacement-handoff:${req.replacementOfSessionId}`,
+            () => listMessagesForAgentHandoff(req.replacementOfSessionId!, 400),
+          );
+          const handoffMessages =
+            previousMessages.length > 0
+              ? previousMessages
+              : req.replacementPrompt
+                ? [
+                    {
+                      clientId: 'hook-replacement-memory',
+                      role: 'user',
+                      content: req.replacementPrompt,
+                      createdAt: startedAt,
+                      agentMeta: null,
+                    },
+                  ]
+                : [];
+          if (handoffMessages.length > 0) {
+            replacementHandoff = buildHandoffText(handoffMessages, {
+              fromLabel: 'Cindy',
+              toLabel: 'Cindy',
+            });
+          }
+        } catch (err) {
+          if (req.replacementPrompt) {
+            replacementHandoff = buildHandoffText(
+              [
+                {
+                  role: 'user',
+                  content: req.replacementPrompt,
+                  createdAt: startedAt,
+                },
+              ],
+              { fromLabel: 'Cindy', toLabel: 'Cindy' },
+            );
+          }
+          log.warn(
+            `hook replacement history unavailable; ${
+              replacementHandoff ? 'using in-memory dispatch context' : 'continuing without handoff'
+            }: ${err instanceof Error ? err.name : 'unknown-error'}`,
+          );
+        }
+      }
+      const sendContentBase =
         imageBlocks.length > 0 || fileBlocks.length > 0
           ? [{ type: 'text' as const, text: promptWithNote }, ...imageBlocks, ...fileBlocks]
           : promptWithNote;
+      const sendContent = replacementHandoff
+        ? (prependHandoffToUserMessage(
+            { type: 'user', content: sendContentBase },
+            replacementHandoff,
+          ) as UserMessage).content
+        : sendContentBase;
       // 落库形态: 有附件用 {text, images, files} 对象(createMessage safeStringify
       // 存 JSON, 读回 parseUserContent 提取 images/files); 无附件纯文本 string。
       const userMessageContent =


### PR DESCRIPTION
## 这次改了什么

### 摘要

Slack channel bot 在原任务不可投递、自动创建替代任务时，之前只把“再试试”这类当前消息交给新任务，原始需求可能丢失。

本 PR 在纯客户端内部补上确定性交接：

- 优先从原任务仍可读取的本地消息记录构造有界上下文，交给替代任务的 Agent；
- 原任务尚未落库或读取失败时，使用进程内保存的首条原始派发内容兜底；
- 上下文只进入 Agent wire 内容，桌面消息记录仍只显示用户当前在 Slack 发出的原话；
- 交接来源只接受当前 lane 的 namespaced binding 或已跟踪的 replacement 链，避免跨任务读取；
- replacement 连续失败多次时仍追溯最初任务，不用中途的“再试试”覆盖原始需求。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Slack channel bot 重试后替代任务丢失原始上下文
- 本 PR 包含：Desktop hook-control 的替代任务上下文交接与回归测试
- 明确不包含：服务端改动、wire protocol 字段改动、Slack thread 获取策略改动、其它 IM 渠道行为改版
- 用户可见变化：原任务失效后在 Slack 重试，新建的替代任务会继续理解可读取的原始需求与进展
- 是否存在 breaking change：无

### UI 变化

不涉及：没有修改界面、布局、样式或 UI 文案；仅改变发给新 Agent 的内部上下文。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/hook-control/__tests__/dispatcher.test.ts src/main/hook-control/__tests__/session-runner.test.ts
结果：2 个测试文件通过，251 个测试通过

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm test:unit:related
结果：apps/desktop related unit 通过

pnpm check:dco
结果：1 个提交签名检查通过
```

### 手工验证

不涉及：当前环境未连接可复现该线上 Slack thread 的测试 workspace。回归由 dispatcher + session-runner 测试覆盖：原始需求 → 失败 → “再试试” → replacement → 再失败 → 第二个 replacement。

### 未执行的验证

- 未做真实 Slack 端到端验证：需要可控的 channel bot workspace 与失效任务场景。
- 未跑全仓 `pnpm test:unit`：改动范围集中在 Desktop hook-control，已通过仓库要求的 `test:unit:related`。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：Agent 上下文连续性

### 影响与回滚

- 影响范围：仅 Desktop 的 Slack/hook-control 替代任务路径。普通新任务、可用任务复用、wire protocol、SSH 远程、device-link 与 mobile 入口均不变。
- 安全边界：只允许从当前连接 + externalKey 的 namespaced binding 或其受跟踪 replacement 链读取旧任务记录；外国/未绑定 session id 不作为交接来源。缓存有 2,000 项和单条 20,000 字符上限，账号停用与 dispatcher dispose 时清空。
- 回滚 / 降级方式：回退本提交即可恢复旧行为；读取历史失败会自动降级为进程内首条派发内容，仍失败则使用服务端当前 `prompt`，不会阻断任务执行。
- 多端适配：不新增 IPC channel 或推送事件，不修改 device-link；mobile 只镜像任务记录，不参与 Slack hook 执行，因此不需要对应改动。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
