### PR TITLE
fix(desktop): 把设置页顶栏收成与聊天同高的 46px 标题栏

### DIFF
--- a/apps/desktop/src/renderer/components/layout/ContentHeader.tsx
+++ b/apps/desktop/src/renderer/components/layout/ContentHeader.tsx
@@ -93,8 +93,8 @@ export function ContentHeader({
   // 全屏态按钮回到 rail 内，也由 Sidebar 的既有洞覆盖。
   const needsRailChromeActionsHitHole = isMac && !isFullscreen && isSidebarRail;
 
-  // 设置页：Sidebar 隐藏且无折叠按钮占位 → header 退化为"隐形 chrome"
-  // （仅拖拽区 + Windows 窗口控制），不画下边框。
+  // 设置页：Sidebar 隐藏且无折叠按钮占位 → 不画下边框（用户决策 2026-06-11）。
+  // 返回 + 标题仍由 SettingsView 注入本 header，与聊天共用 46px 行高。
   const isInvisibleChrome = !sidebarVisible && !showCollapsedActions;
 
   // 空 header 隐藏（用户决策 2026-06-11）：技能中心 / 自动化 / 文件浏览 /

--- a/apps/desktop/src/renderer/components/layout/MainLayout.tsx
+++ b/apps/desktop/src/renderer/components/layout/MainLayout.tsx
@@ -1346,8 +1346,8 @@ export function MainLayout() {
     //     折叠按钮（见 Sidebar.tsx）。
     //   - 右侧 <main> 第一行是 ContentHeader Shell：窗口拖拽区 + Windows 窗口
     //     控制按钮 + 折叠态快捷按钮回流；中部由路由视图注入（会话标题等）。
-    //   - 设置页：Sidebar 隐藏不变，ContentHeader 退化为"隐形 chrome"（无折叠
-    //     按钮，仅拖拽区 + Windows 窗口控制 + mac 红绿灯让位）。
+    //   - 设置页：Sidebar 隐藏不变；ContentHeader 仍是 46px 顶栏（返回 + 标题
+    //     由 SettingsView 注入），无折叠按钮，不画下边框。
     // sidebar-card-mode: rail 态(拖到最窄 64px)在 slot provider 上与 collapsed 同义
     // (都表达"窄布局"),Sidebar 另收 isRail 区分"完全隐藏 vs 窄轨"。
     // peek 可见期强制展开语义:抽屉里要呈现完整展开列表(ExpandedView)。

--- a/apps/desktop/src/renderer/components/settings/SettingsContentHeader.tsx
+++ b/apps/desktop/src/renderer/components/settings/SettingsContentHeader.tsx
@@ -11,6 +11,7 @@ import { useTranslation } from 'react-i18next';
 import { ArrowLeft } from 'lucide-react';
 
 import { WINDOW_NO_DRAG_STYLE } from '@/components/layout/windowDrag';
+import { Tip } from '@/components/ui/tooltip';
 import { useRegisterContentHeader } from '@/features/feature-context';
 
 export function SettingsContentHeaderRegistration() {
@@ -21,18 +22,21 @@ export function SettingsContentHeaderRegistration() {
 export function SettingsContentHeader() {
   const navigate = useNavigate();
   const { t } = useTranslation();
+  const backLabel = t('settings.back');
 
   return (
     <div className="flex h-full min-w-0 items-center gap-2.5">
-      <button
-        type="button"
-        onClick={() => navigate('/')}
-        aria-label={t('settings.back')}
-        className="flex h-7 w-7 items-center justify-center rounded-md text-[var(--settings-back-icon)] transition-colors hover:bg-titlebar-button-hover hover:text-[var(--settings-back-text)]"
-        style={WINDOW_NO_DRAG_STYLE}
-      >
-        <ArrowLeft size={15} />
-      </button>
+      <Tip text={backLabel} side="bottom">
+        <button
+          type="button"
+          onClick={() => navigate('/')}
+          aria-label={backLabel}
+          className="flex h-7 w-7 items-center justify-center rounded-full text-[var(--settings-back-icon)] transition-colors hover:bg-titlebar-button-hover hover:text-[var(--settings-back-text)]"
+          style={WINDOW_NO_DRAG_STYLE}
+        >
+          <ArrowLeft size={15} />
+        </button>
+      </Tip>
       <h1 className="truncate text-sm font-medium text-[var(--settings-back-text)]">
         {t('settings.title')}
       </h1>

--- a/apps/desktop/src/renderer/components/settings/SettingsContentHeader.tsx
+++ b/apps/desktop/src/renderer/components/settings/SettingsContentHeader.tsx
@@ -31,7 +31,7 @@ export function SettingsContentHeader() {
           type="button"
           onClick={() => navigate('/')}
           aria-label={backLabel}
-          className="flex h-7 w-7 items-center justify-center rounded-full text-[var(--settings-back-icon)] transition-colors hover:bg-titlebar-button-hover hover:text-[var(--settings-back-text)]"
+          className="flex h-7 w-7 items-center justify-center rounded-full text-[var(--settings-back-icon)] transition-[color,background-color,transform] duration-150 hover:bg-titlebar-button-hover hover:text-[var(--settings-back-text)] active:scale-[0.98]"
           style={WINDOW_NO_DRAG_STYLE}
         >
           <ArrowLeft size={15} />

--- a/apps/desktop/src/renderer/components/settings/SettingsContentHeader.tsx
+++ b/apps/desktop/src/renderer/components/settings/SettingsContentHeader.tsx
@@ -1,0 +1,41 @@
+/**
+ * SettingsContentHeader — 设置页注入 ContentHeader 的中部内容
+ * ---------------------------------------------------------------------------
+ * 设置页的返回 + 标题走和聊天一样的 46px ContentHeader，不再在侧栏上方
+ * 再叠一层页头留白。交互控件挖 no-drag 洞，其余区域继续拖窗口。
+ */
+
+import { useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { ArrowLeft } from 'lucide-react';
+
+import { WINDOW_NO_DRAG_STYLE } from '@/components/layout/windowDrag';
+import { useRegisterContentHeader } from '@/features/feature-context';
+
+export function SettingsContentHeaderRegistration() {
+  useRegisterContentHeader(useMemo(() => <SettingsContentHeader />, []));
+  return null;
+}
+
+export function SettingsContentHeader() {
+  const navigate = useNavigate();
+  const { t } = useTranslation();
+
+  return (
+    <div className="flex h-full min-w-0 items-center gap-2.5">
+      <button
+        type="button"
+        onClick={() => navigate('/')}
+        aria-label={t('settings.back')}
+        className="flex h-7 w-7 items-center justify-center rounded-md text-[var(--settings-back-icon)] transition-colors hover:bg-titlebar-button-hover hover:text-[var(--settings-back-text)]"
+        style={WINDOW_NO_DRAG_STYLE}
+      >
+        <ArrowLeft size={15} />
+      </button>
+      <h1 className="truncate text-sm font-medium text-[var(--settings-back-text)]">
+        {t('settings.title')}
+      </h1>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/components/settings/SettingsView.tsx
+++ b/apps/desktop/src/renderer/components/settings/SettingsView.tsx
@@ -1,12 +1,12 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Navigate, useNavigate, useOutletContext, useSearchParams } from 'react-router-dom';
+import { Navigate, useOutletContext, useSearchParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useSyncExternalStore } from 'react';
-import { ArrowLeft } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
 import { TAB_IDS, isSettingsTab } from '@/lib/tabLabels';
 import type { SettingsTab } from '@/lib/tabLabels';
+import { SettingsContentHeaderRegistration } from './SettingsContentHeader';
 import { SettingsSidebarNav } from './SettingsSidebarNav';
 import { UserProfileCard } from './UserProfileCard';
 import { VoiceInputSection } from './VoiceInputSection';
@@ -55,7 +55,6 @@ interface SettingsOutletContext {
 }
 
 export function SettingsView() {
-  const navigate = useNavigate();
   const outletContext = useOutletContext<SettingsOutletContext | null>();
   const [searchParams, setSearchParams] = useSearchParams();
   const { t } = useTranslation();
@@ -187,29 +186,16 @@ export function SettingsView() {
       role="main"
       aria-label={t('settings.title')}
     >
+      {/* 返回 + 标题注入 46px ContentHeader，与聊天标题栏同高，不再额外叠顶栏留白。 */}
+      <SettingsContentHeaderRegistration />
       {/* Outer container — page itself does not scroll; columns own their scroll behavior. */}
-      <div className="flex h-full min-h-0 w-full justify-start pt-7 pb-5">
+      <div className="flex h-full min-h-0 w-full justify-start pb-5">
         {/* Inner sidebar mirrors the main sidebar width for a stable route transition. */}
         <aside
-          className="flex h-full min-h-0 shrink-0 flex-col gap-2 overflow-y-auto pl-6 pr-4"
+          className="flex h-full min-h-0 shrink-0 flex-col overflow-y-auto pl-6 pr-4"
           style={{ width: menuWidth }}
           aria-label={t('settings.title')}
         >
-          {/* Back navigation — gap 10, pb 18, aligned with menu items via px-3 */}
-          <div className="flex items-center gap-2.5 px-3 pb-[18px]">
-            <button
-              type="button"
-              onClick={() => navigate('/')}
-              aria-label={t('settings.back')}
-              className="flex items-center justify-center text-[var(--settings-back-icon)] transition-colors hover:text-[var(--settings-back-text)]"
-            >
-              <ArrowLeft size={20} />
-            </button>
-            <h1 className="text-24 font-medium leading-[1.1] text-[var(--settings-back-text)]">
-              {t('settings.title')}
-            </h1>
-          </div>
-
           <SettingsSidebarNav
             tabIds={visibleTabIds}
             activeTab={activeTab}
@@ -221,14 +207,13 @@ export function SettingsView() {
             Most tabs scroll as a page; Session Import and Plugins use a fixed-height
             workspace so only their inner lists scroll.
             right padding mirrors sidebar's 24px left inset.
-            pt-[56px] pushes content top to align with the first nav tab (General),
-            skipping the "Settings" header height (h1 24/1.1 + pb-18 + gap-2 ≈ 52px).
+            顶栏已收进 ContentHeader，内容与左侧第一个导航项顶对齐。
             scrollbar-gutter:stable —— 所有分区都预留同一滚动条槽位；即使
             Session Import 自身不滚动，也要保持与普通滚动页相同的内容宽度。 */}
         <div
           ref={contentScrollRef}
           className={cn(
-            'flex h-full min-h-0 min-w-0 flex-1 flex-col pl-4 pr-6 pt-[56px] [scrollbar-gutter:stable]',
+            'flex h-full min-h-0 min-w-0 flex-1 flex-col pl-4 pr-6 [scrollbar-gutter:stable]',
             activeTab === 'import' || activeTab === 'ghosts'
               ? 'overflow-hidden'
               : 'overflow-y-auto',

--- a/apps/desktop/src/renderer/components/settings/__tests__/SettingsContentHeader.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/__tests__/SettingsContentHeader.test.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+
+import { FeatureSidebarSlotProvider, useFeatureContentHeader } from '@/features/feature-context';
+import {
+  SettingsContentHeader,
+  SettingsContentHeaderRegistration,
+} from '../SettingsContentHeader';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) =>
+      ({
+        'settings.title': 'Settings',
+        'settings.back': 'Back',
+      })[key] ?? key,
+  }),
+}));
+
+function HeaderSlotProbe() {
+  const headerContent = useFeatureContentHeader();
+  return <div data-testid="header-slot">{headerContent}</div>;
+}
+
+describe('SettingsContentHeader', () => {
+  it('renders the settings title at chat-titlebar typography', () => {
+    render(
+      <MemoryRouter>
+        <SettingsContentHeader />
+      </MemoryRouter>,
+    );
+
+    const title = screen.getByRole('heading', { name: 'Settings' });
+    expect(title.className).toContain('text-sm');
+    expect(title.className).toContain('font-medium');
+  });
+
+  it('keeps the back button outside the window drag region and returns home', () => {
+    render(
+      <MemoryRouter initialEntries={['/settings']}>
+        <Routes>
+          <Route path="/" element={<div>home</div>} />
+          <Route path="/settings" element={<SettingsContentHeader />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    const back = screen.getByRole('button', { name: 'Back' });
+    expect(
+      (back.style as CSSStyleDeclaration & { WebkitAppRegion: string }).WebkitAppRegion,
+    ).toBe('no-drag');
+
+    fireEvent.click(back);
+    expect(screen.getByText('home')).toBeTruthy();
+  });
+
+  it('registers the title into the shared ContentHeader slot', () => {
+    render(
+      <MemoryRouter>
+        <FeatureSidebarSlotProvider isCollapsed={false}>
+          <SettingsContentHeaderRegistration />
+          <HeaderSlotProbe />
+        </FeatureSidebarSlotProvider>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByTestId('header-slot').textContent).toContain('Settings');
+    expect(screen.getByRole('button', { name: 'Back' })).toBeTruthy();
+  });
+});

--- a/apps/desktop/src/renderer/components/settings/__tests__/SettingsContentHeader.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/__tests__/SettingsContentHeader.test.tsx
@@ -49,6 +49,7 @@ describe('SettingsContentHeader', () => {
 
     const back = screen.getByRole('button', { name: 'Back' });
     expect(back.className).toContain('rounded-full');
+    expect(back.className).toContain('active:scale-[0.98]');
     expect(back.getAttribute('data-state')).toBe('closed');
     expect(
       (back.style as CSSStyleDeclaration & { WebkitAppRegion: string }).WebkitAppRegion,

--- a/apps/desktop/src/renderer/components/settings/__tests__/SettingsContentHeader.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/__tests__/SettingsContentHeader.test.tsx
@@ -48,6 +48,8 @@ describe('SettingsContentHeader', () => {
     );
 
     const back = screen.getByRole('button', { name: 'Back' });
+    expect(back.className).toContain('rounded-full');
+    expect(back.getAttribute('data-state')).toBe('closed');
     expect(
       (back.style as CSSStyleDeclaration & { WebkitAppRegion: string }).WebkitAppRegion,
     ).toBe('no-drag');


### PR DESCRIPTION
## 这次改了什么

### 摘要

设置页顶部原先叠了两层：46px 的 `ContentHeader` 隐形拖拽条，再加上页面自己的 `pt-7` 和独立「← 设置」页头，留白明显高于聊天标题栏。现在返回和标题注入同一条 46px `ContentHeader`，去掉多余顶距，和聊天标题栏对齐。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：设置页顶栏改走共享 `ContentHeader`；去掉 `SettingsView` 的额外顶距；补注入/返回/拖拽挖洞单测
- 明确不包含：设置内容区排版、导航信息架构、主题 token 调整
- 用户可见变化：设置页顶部留白降到与聊天标题栏同高；「← 设置」出现在 46px 顶栏里
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：
  - `DESIGN.md` §5 Layout Principles / Whitespace Philosophy：去掉没有内容的重复顶栏留白，只保留一条必要的窗口标题栏
  - `DESIGN.md` §8 Window & Adaptive Behavior，以及现有桌面 chrome 不变量：主窗标题栏行高 46px（`ContentHeader` / `ChromeActions` / `trafficLightPosition` 同源）
  - `DESIGN.md` §3 桌面 UI 字号白名单：标题改用 `text-sm` / `font-medium`，与聊天标题栏一致
  - `DESIGN.md` §10 Dual-Mode Delivery Gate：颜色继续走 `--settings-back-*` / `titlebar-button-hover` 语义 token，无硬编码色值
- 平台：Desktop macOS Dark 已在隔离开发版目检；Light 未实机目检（复用既有 token，不把它写成已验证）

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：PASS apps/desktop unit (11.9s)

pnpm --filter desktop run typecheck
结果：通过

pnpm check:dco
结果：1 commit signed off（c7e87448..ddb0d91c）
```

本地全量 `run-unit-gate.sh` 红在 `ghostInstallReceipt.test.ts` 的 2 条 setup receipt 用例。同一文件在干净 `origin/main`（`c7e87448d`）上同样失败，与本 PR diff 无关；不混入修复，交给 CI 给权威结论。

### 手工验证

- macOS Desktop，隔离沙箱 `CindyGlobal-dev2-settings-header`（`--isolated=settings-header`，region=global）
- `pnpm desktop:whoami`：root / commit / ready 均匹配本 worktree
- Dark 模式打开设置：顶栏高度与聊天标题栏一致，「← 设置」在标题栏内，左侧导航与内容顶对齐

### 未执行的验证

- Light 模式未实机目检
- Windows 未实机目检（沿用现有 `ContentHeader` 的 Windows 窗口控制与拖拽区）

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Desktop 设置页顶栏布局
- 回滚 / 降级方式：revert 本 PR 即可恢复旧页头

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
