### PR TITLE
fix(desktop): gate Claude tool search by provider

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/claudeBehaviorFlags.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/claudeBehaviorFlags.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { claudeBehaviorFlagsForSpawn } from '../claude-behavior-flags.js';
+import { claudeBehaviorFlagsForSpawn, claudeToolSearchMode } from '../claude-behavior-flags.js';
+import { shouldCloseSessionForCredentialSwitch } from '../codex-credential-switch.js';
 
 describe('claudeBehaviorFlagsForSpawn', () => {
   it('disables attribution for gateway-key spawns without touching the keychain', () => {
@@ -16,14 +17,22 @@ describe('claudeBehaviorFlagsForSpawn', () => {
   it('keeps the CLI attribution default for subscription-connected non-gateway spawns (issue #758)', () => {
     // oauth-bearer / provider-oauth / 未显式指定:claude-* 请求(含分类器 scope-gate
     // 回落)可能直连 api.anthropic.com,归因块必须保留,否则分类器子请求被上游 429。
-    for (const credentialMode of ['oauth-bearer', 'provider-oauth', undefined]) {
-      const flags = claudeBehaviorFlagsForSpawn({ credentialMode, oauthConnected: () => true });
+    const cases = [
+      { credentialMode: 'oauth-bearer', providerId: 'anthropic', toolSearch: 'auto' },
+      { credentialMode: 'provider-oauth', providerId: 'openrouter-custom', toolSearch: 'false' },
+      { credentialMode: undefined, providerId: undefined, toolSearch: 'auto' },
+    ] as const;
+    for (const { credentialMode, providerId, toolSearch } of cases) {
+      const flags = claudeBehaviorFlagsForSpawn({
+        credentialMode,
+        providerId,
+        oauthConnected: () => true,
+      });
       // 显式 '1' 而非缺席:local spawn 继承宿主 process.env,宿主 shell export 过
       // CLAUDE_CODE_ATTRIBUTION_HEADER=0 时,缺席的 key 压不住继承值(#758 复现)。
       expect(flags.CLAUDE_CODE_ATTRIBUTION_HEADER).toBe('1');
-      // 其余行为开关不随 spawn 形态变化。
       expect(flags.CLAUDE_CODE_SKIP_FAST_MODE_NETWORK_ERRORS).toBe('1');
-      expect(flags.ENABLE_TOOL_SEARCH).toBe('auto');
+      expect(flags.ENABLE_TOOL_SEARCH).toBe(toolSearch);
     }
   });
 
@@ -39,5 +48,44 @@ describe('claudeBehaviorFlagsForSpawn', () => {
     expect(
       claudeBehaviorFlagsForSpawn({ oauthConnected: () => false }).CLAUDE_CODE_ATTRIBUTION_HEADER,
     ).toBe('0');
+  });
+
+  it('enables Tool Search only for known compatible upstreams', () => {
+    expect(claudeToolSearchMode('xd', 'gateway-key')).toBe('auto');
+    expect(claudeToolSearchMode('anthropic', 'oauth-bearer')).toBe('auto');
+    expect(claudeToolSearchMode(null, 'gateway-key')).toBe('auto');
+    expect(claudeToolSearchMode(null, 'oauth-bearer')).toBe('auto');
+
+    expect(claudeToolSearchMode('openrouter-custom', 'provider-oauth')).toBe('false');
+    expect(claudeToolSearchMode('xai', 'provider-oauth')).toBe('false');
+    expect(claudeToolSearchMode(null, 'provider-oauth')).toBe('false');
+  });
+
+  it('writes the custom-provider Tool Search override into the spawn flags', () => {
+    const flags = claudeBehaviorFlagsForSpawn({
+      credentialMode: 'provider-oauth',
+      providerId: 'openrouter-custom',
+      oauthConnected: () => false,
+    });
+
+    expect(flags.ENABLE_TOOL_SEARCH).toBe('false');
+  });
+
+  it('recreates local Claude sessions when Tool Search support changes', () => {
+    expect(shouldCloseSessionForCredentialSwitch({
+      agentKind: 'claude-code',
+      currentProviderId: 'xd',
+      nextProviderId: 'openrouter-custom',
+      currentModel: 'claude-sonnet-4-6',
+      nextModel: 'x-ai/grok-4.6',
+    })).toBe(true);
+
+    expect(shouldCloseSessionForCredentialSwitch({
+      agentKind: 'claude-code',
+      currentProviderId: 'openrouter-a',
+      nextProviderId: 'openrouter-b',
+      currentModel: 'x-ai/grok-4.6',
+      nextModel: 'openai/gpt-5.4',
+    })).toBe(false);
   });
 });

--- a/apps/desktop/src/main/maker-host/claude-behavior-flags.ts
+++ b/apps/desktop/src/main/maker-host/claude-behavior-flags.ts
@@ -26,14 +26,26 @@
 
 const STATIC_CLAUDE_BEHAVIOR_FLAGS: Readonly<Record<string, string>> = {
   CLAUDE_CODE_SKIP_FAST_MODE_NETWORK_ERRORS: '1',
-  // 网关 upstream 透传 tool_reference 块, 显式开启 ToolSearch
-  // 否则 CC 看到非 first-party host 默认 disable, 每次请求都全量塞工具定义。
-  ENABLE_TOOL_SEARCH: 'auto',
 };
+
+/**
+ * ToolSearch 依赖上游接受 deferred tools / tool_reference。仅对已知支持该协议的
+ * XD 网关与 Anthropic 原生路由开启；其它显式来源默认关闭，避免兼容供应商返回 400。
+ */
+export function claudeToolSearchMode(
+  providerId: string | null | undefined,
+  credentialMode?: string,
+): 'auto' | 'false' {
+  const provider = providerId?.trim() || null;
+  if (provider) return provider === 'xd' || provider === 'anthropic' ? 'auto' : 'false';
+  return credentialMode === 'provider-oauth' ? 'false' : 'auto';
+}
 
 export interface ClaudeSpawnFlagsContext {
   /** 本次 spawn 的凭证形态(maker-core AgentCredentialMode;undefined = adapter fallback)。 */
   credentialMode?: string;
+  /** 本次 spawn 的会话来源。null/undefined = 隐式默认路由。 */
+  providerId?: string | null;
   /** 是否连了 Claude.ai 订阅。惰性回调:gateway-key 分支不调用、不产生钥匙串读。 */
   oauthConnected: () => boolean;
 }
@@ -44,7 +56,9 @@ export function claudeBehaviorFlagsForSpawn(ctx: ClaudeSpawnFlagsContext): Recor
   // (env-builder cleanProcessEnv),用户 shell 若 export 过 CLAUDE_CODE_ATTRIBUTION_HEADER=0,
   // 缺席的 key 压不住继承值,#758 会原样复现。CLI 判定(cli.js c5):仅
   // '0'/'false'/'no'/'off' 视为禁用,'1' = 保留归因,与未设置同义。
-  return keepAttribution
-    ? { ...STATIC_CLAUDE_BEHAVIOR_FLAGS, CLAUDE_CODE_ATTRIBUTION_HEADER: '1' }
-    : { ...STATIC_CLAUDE_BEHAVIOR_FLAGS, CLAUDE_CODE_ATTRIBUTION_HEADER: '0' };
+  return {
+    ...STATIC_CLAUDE_BEHAVIOR_FLAGS,
+    ENABLE_TOOL_SEARCH: claudeToolSearchMode(ctx.providerId, ctx.credentialMode),
+    CLAUDE_CODE_ATTRIBUTION_HEADER: keepAttribution ? '1' : '0',
+  };
 }

--- a/apps/desktop/src/main/maker-host/codex-credential-switch.ts
+++ b/apps/desktop/src/main/maker-host/codex-credential-switch.ts
@@ -6,8 +6,9 @@ import {
   type AgentKind,
 } from '@cindy/maker-core';
 
-import { withRehydrateCloseSuppressed } from './rehydrateCloseSuppression.js';
+import { claudeToolSearchMode } from './claude-behavior-flags.js';
 import type { CodexProxyAuthInjection } from './codex-proxy-host.js';
+import { withRehydrateCloseSuppressed } from './rehydrateCloseSuppression.js';
 
 export interface ShouldCloseSessionForCredentialSwitchInput {
   agentKind: AgentKind;
@@ -177,6 +178,16 @@ export function shouldCloseSessionForCredentialSwitch(
     providerId: nextProviderId,
     model: input.nextModel,
   });
+
+  // Tool Search 是 Claude 子进程的 spawn-time env。跨越上游 capability 边界时即使
+  // provider-oauth 凭证家族可复用，也必须重建本会话，不能把旧 flag 热切到新来源。
+  if (
+    input.agentKind === 'claude-code' &&
+    claudeToolSearchMode(currentProviderId, currentMode) !==
+      claudeToolSearchMode(nextProviderId, nextMode)
+  ) {
+    return true;
+  }
 
   // ── 远端压缩身份边界(codex, proxy-active)────────────────────────────────
   // oauth spawn 的订阅直连 thread 以 OpenAI 身份 provider 创建(codex 据此走

--- a/apps/desktop/src/main/maker-host/runtime-configs.ts
+++ b/apps/desktop/src/main/maker-host/runtime-configs.ts
@@ -159,13 +159,13 @@ export function buildDesktopClaudeRuntimeConfig(endpointFn: () => string): Agent
   // 这样 AgentRuntimeConfig 接口(endpoint?: string)在结构类型上仍然成立 ——
   // 每次访问 runtimeConfig.endpoint 都会执行 endpointFn, 拿到当时最新的兼容模式状态。
   const config: AgentRuntimeConfig = {
-    // behaviorFlags 用函数形态:env-builder 在每次 spawn 时以该 spawn 的 credentialMode
-    // 调用 —— gateway-key spawn(显式 XD source / SSH remote)保持禁归因且不读钥匙串,
-    // 其余形态按**当时**的 Claude.ai 订阅连接态决定(判据与 proxy 同源)。会话中途
-    // 连/断订阅只影响新 spawn —— 与 cc 子进程凭证冻结语义一致。
+    // behaviorFlags 用函数形态:env-builder 在每次 spawn 时传入凭证形态与来源。
+    // gateway-key spawn 保持禁归因且不读钥匙串;Tool Search 仅对 XD/Anthropic 开启。
+    // 会话中途连/断订阅只影响新 spawn —— 与 cc 子进程凭证冻结语义一致。
     behaviorFlags: (ctx) => ({
       ...claudeBehaviorFlagsForSpawn({
         credentialMode: ctx.credentialMode,
+        providerId: ctx.sessionProviderId,
         oauthConnected: hasClaudeAiOAuth,
       }),
       // 工具链限核 env(agent 资源占用治理):只对本机 spawn 注入 —— 值按本机

--- a/packages/maker-core/src/agents/claude-code/__tests__/env-builder.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/env-builder.test.ts
@@ -73,17 +73,18 @@ describe('buildClaudeEnv', () => {
     expect(env.ANTHROPIC_API_KEY).toBe('key');
   });
 
-  it('evaluates function-form behaviorFlags with the spawn credentialMode and spawnMode', async () => {
+  it('evaluates function-form behaviorFlags with the spawn route context', async () => {
     const behaviorFlags = vi.fn(() => ({ CLAUDE_CODE_ATTRIBUTION_HEADER: '0' }));
 
     const env = await buildClaudeEnv(
       createAuthAdapter(),
       { behaviorFlags },
-      { credentialMode: 'gateway-key' },
+      { credentialMode: 'gateway-key', sessionProviderId: 'xd' },
     );
 
     expect(behaviorFlags).toHaveBeenCalledWith({
       credentialMode: 'gateway-key',
+      sessionProviderId: 'xd',
       spawnMode: 'local',
     });
     expect(env.CLAUDE_CODE_ATTRIBUTION_HEADER).toBe('0');
@@ -100,6 +101,7 @@ describe('buildClaudeEnv', () => {
 
     expect(behaviorFlags).toHaveBeenCalledWith({
       credentialMode: 'gateway-key',
+      sessionProviderId: undefined,
       spawnMode: 'remote',
     });
   });

--- a/packages/maker-core/src/agents/claude-code/__tests__/plan-mode.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/plan-mode.test.ts
@@ -710,6 +710,37 @@ describe('ClaudeCodeAgent plan mode', () => {
     await handle.close();
   });
 
+  it('passes the local session provider into spawn-time behavior flags', async () => {
+    const configDir = await makeTempDir();
+    process.env.CLAUDE_CONFIG_DIR = configDir;
+    const workingDir = await makeTempDir();
+    const fakeQuery = createFakeQuery();
+    sdkMock.query.mockReturnValue(fakeQuery);
+    const behaviorFlags = vi.fn((ctx: { sessionProviderId?: string | null }) => ({
+      ENABLE_TOOL_SEARCH: ctx.sessionProviderId === 'openrouter-custom' ? 'false' : 'auto',
+    }));
+    const agent = new ClaudeCodeAgent(createDeps({ runtimeConfig: { behaviorFlags } }));
+
+    const handle = await agent.startSession({
+      sessionId: 'session-local-custom-provider',
+      model: 'x-ai/grok-4.6',
+      providerId: 'openrouter-custom',
+      workingDir,
+      permissionMode: 'auto',
+    });
+
+    const env = sdkMock.query.mock.calls.at(-1)?.[0]?.options?.env as
+      | Record<string, string>
+      | undefined;
+    expect(env?.ENABLE_TOOL_SEARCH).toBe('false');
+    expect(behaviorFlags).toHaveBeenCalledWith({
+      credentialMode: 'provider-oauth',
+      sessionProviderId: 'openrouter-custom',
+      spawnMode: 'local',
+    });
+    await handle.close();
+  });
+
   it('overrides remote cc-manager env with a host-materialized Claude route', async () => {
     const configDir = await makeTempDir();
     process.env.CLAUDE_CONFIG_DIR = configDir;
@@ -728,9 +759,12 @@ describe('ClaudeCodeAgent plan mode', () => {
         ANTHROPIC_CUSTOM_HEADERS: 'authorization: Bearer k-route\nx-tenant: acme',
       },
     }));
+    const behaviorFlags = vi.fn((ctx: { sessionProviderId?: string | null }) => ({
+      ENABLE_TOOL_SEARCH: ctx.sessionProviderId === 'custom-provider' ? 'false' : 'auto',
+    }));
     const agent = new ClaudeCodeAgent(createDeps({
       // Empty gateway endpoint would fail the old remote gateway guard; routed sessions must not depend on it.
-      runtimeConfig: { remoteEndpoint: '' },
+      runtimeConfig: { remoteEndpoint: '', behaviorFlags },
       remoteCcQueryFactory,
       resolveRemoteClaudeRoute,
     }));
@@ -753,6 +787,12 @@ describe('ClaudeCodeAgent plan mode', () => {
     expect(env?.ANTHROPIC_API_KEY).toBe('k-route');
     expect(env?.ANTHROPIC_CUSTOM_HEADERS).toBe('authorization: Bearer k-route\nx-tenant: acme');
     expect(env?.ANTHROPIC_AUTH_TOKEN).toBeUndefined();
+    expect(env?.ENABLE_TOOL_SEARCH).toBe('false');
+    expect(behaviorFlags).toHaveBeenCalledWith({
+      credentialMode: 'provider-oauth',
+      sessionProviderId: 'custom-provider',
+      spawnMode: 'remote',
+    });
     await handle.close();
   });
 

--- a/packages/maker-core/src/agents/claude-code/env-builder.ts
+++ b/packages/maker-core/src/agents/claude-code/env-builder.ts
@@ -285,11 +285,15 @@ export async function buildClaudeEnv(
   const cleanEnv = mode === 'remote' ? {} : cleanProcessEnv();
   const env: Record<string, string> = { ...cleanEnv };
 
-  // 函数形态按本次 spawn 的凭证形态求值(如 attribution 归因块只对 gateway-key 禁用);
-  // spawnMode 让 host 区分本机/远端(只对本机有意义的 flag 不注到远端)。
+  // 函数形态按本次 spawn 的 route context 求值(如 attribution 按凭证形态、Tool Search
+  // 按来源能力分叉);spawnMode 让 host 区分本机/远端(只对本机有意义的 flag 不注到远端)。
   const behaviorFlags =
     typeof runtimeConfig.behaviorFlags === 'function'
-      ? runtimeConfig.behaviorFlags({ credentialMode: options.credentialMode, spawnMode: mode })
+      ? runtimeConfig.behaviorFlags({
+          credentialMode: options.credentialMode,
+          sessionProviderId: options.sessionProviderId,
+          spawnMode: mode,
+        })
       : runtimeConfig.behaviorFlags;
   if (behaviorFlags) {
     Object.assign(env, behaviorFlags);

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -1090,6 +1090,7 @@ export class ClaudeCodeAgent extends BaseAgent {
     );
     const env = await buildClaudeEnv(this.deps.auth, this.deps.runtimeConfig, {
       credentialMode,
+      sessionProviderId: opts.providerId ?? null,
       modelContextWindows: providerRoutedModels,
       // 先按「不设」建好 env(顺带删掉可能从 process.env 继承来的残留),真正的判定在下面
       // 拿到这份 env 之后做 —— 扫描需要 env 里的 CLAUDE_CONFIG_DIR 才能找对目录。
@@ -1162,6 +1163,7 @@ export class ClaudeCodeAgent extends BaseAgent {
     const remoteEnv = opts.remoteHostId
       ? await buildClaudeEnv(this.deps.auth, this.deps.runtimeConfig, {
           credentialMode,
+          sessionProviderId: opts.providerId ?? null,
           mode: 'remote',
           modelContextWindows: providerRoutedModels,
           // 远端不做本地扫描(见上),这里的值就是路由感知后的设置值 —— 保持 env 强制覆盖语义。

--- a/packages/maker-core/src/interfaces/runtime-config.ts
+++ b/packages/maker-core/src/interfaces/runtime-config.ts
@@ -10,9 +10,11 @@
 import type { SubagentModelDiagnostic } from '../agents/claude-code/subagent-model-default.js';
 import type { AgentCredentialMode } from './auth-adapter.js';
 
-/** 函数形态 behaviorFlags 的入参:本次 spawn 的凭证形态(undefined = 未显式指定,走 adapter fallback)。 */
+/** 函数形态 behaviorFlags 的入参:本次 spawn 的凭证形态、来源与执行位置。 */
 export interface BehaviorFlagsContext {
   credentialMode?: AgentCredentialMode;
+  /** 本次 spawn 的会话来源。null/undefined = 隐式默认路由。 */
+  sessionProviderId?: string | null;
   /**
    * 本次 spawn 落在哪台机器:'local' = 本机子进程,'remote' = 远端 daemon。
    * host 据此决定"只对本机有意义"的 flag(如按本机核数算的工具链限核 env)
@@ -47,12 +49,13 @@ export interface AgentRuntimeConfig {
 
   /**
    * 业务行为 flag。Agent 内部决定哪些 key 有意义。
-   * Claude 当前用到：CLAUDE_CODE_SKIP_FAST_MODE_NETWORK_ERRORS
+   * Claude 当前用到：CLAUDE_CODE_SKIP_FAST_MODE_NETWORK_ERRORS、
+   * CLAUDE_CODE_ATTRIBUTION_HEADER、ENABLE_TOOL_SEARCH
    *
-   * 函数形态:flag 需要按本次 spawn 的凭证形态分叉时用(env-builder 在组装 env 时
-   * 以 spawn 的 credentialMode 调用)。典型:CLAUDE_CODE_ATTRIBUTION_HEADER 只对
-   * gateway-key spawn 禁用——oauth 侧禁用会让订阅直连的 Auto 分类器子请求被上游
-   * 429(desktop issue #758)。静态对象形态语义不变。
+   * 函数形态:flag 需要按本次 spawn 的凭证形态或来源分叉时用(env-builder 在组装 env
+   * 时传入 route context)。典型:CLAUDE_CODE_ATTRIBUTION_HEADER 只对 gateway-key
+   * spawn 禁用(issue #758);ENABLE_TOOL_SEARCH 只对确认兼容 deferred tools 的来源
+   * 开启(issue #2929)。静态对象形态语义不变。
    */
   behaviorFlags?: Record<string, string> | ((ctx: BehaviorFlagsContext) => Record<string, string>);
 


### PR DESCRIPTION
## 这次改了什么

### 摘要

Disable Claude deferred Tool Search for custom and non-Anthropic providers while retaining it for XD and Anthropic routes.

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- Related issue: Fixes #2929
- Included: Pass provider identity into local and SSH Claude spawn flags, set `ENABLE_TOOL_SEARCH=false` for provider-routed upstreams, and recreate local sessions when a model switch crosses the deferred-tool capability boundary.
- Not included: Proxy-side deferred-tool translation or provider capability opt-in.
- User-visible change: Custom non-Anthropic Claude routes send full tool definitions instead of unsupported deferred tools.
- Breaking change: No.

### Remote and mobile adaptation

- SSH remote workspaces: Supported through the same provider-aware spawn flags.
- Device link: Not affected.
- Mobile: Not affected.

### UI 变化

Not applicable. No visual, interaction, or copy change.

- 引用的设计规范：Not applicable.

## 怎么验证的

### 自动验证

```text
pnpm test:unit
Result: passed.

pnpm --filter @cindy/maker-core run --if-present typecheck
Result: passed.

NODE_OPTIONS=--max-old-space-size=6144 pnpm --filter desktop run --if-present typecheck
Result: passed.

pnpm check:dco
Result: passed.
```

### 手工验证

Not run.

### 未执行的验证

Real OpenRouter and SSH provider sessions were not tested because no matching credentials or remote host were available.

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [x] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- Impact: Claude Code spawn configuration and local model switching.
- Risk: A custom provider that supports `tool_reference` loses the deferred-tool optimization but retains the complete tool definitions.
- Rollback: Revert the commit. No migration or cleanup is required.

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
