### PR TITLE
fix(desktop): preserve Pi transcript during Orca rehydrate

### DIFF
--- a/apps/desktop/src/main/maker-ipc/__tests__/makerSendTransaction.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/makerSendTransaction.test.ts
@@ -1104,6 +1104,111 @@ describe('maker SEND transaction', () => {
     expect(newSession.send).toHaveBeenCalled();
   });
 
+  it('rehydrates an active Pi Orca session with the DB transcript before dispatch', async () => {
+    const callOrder: string[] = [];
+    const oldSession = createSession({
+      id: 'pi-orca-session',
+      agentKind: 'pi',
+      workDir: '/repo',
+    });
+    const newSession = createSession({
+      id: 'pi-orca-session',
+      agentKind: 'pi',
+      workDir: '/repo',
+      send: vi.fn(async (_message, opts) => {
+        callOrder.push('send');
+        await opts?.onAccepted?.();
+        opts?.onDispatching?.();
+        return { accepted: true } satisfies SessionSendResult;
+      }),
+    });
+    const dbTranscript = '/pi/sessions/original-transcript.jsonl';
+    const { deps } = createDeps({
+      getSession: vi.fn(() => oldSession),
+      isOrcaMcpHydrated: vi.fn(() => false),
+      synthesizeOrcaVendorOptionsFromDb: vi.fn(async () => true),
+      reconcileCreateOptsWithDb: vi.fn(async (_sessionId, opts) => {
+        callOrder.push('reconcile');
+        opts.resumeSessionId = dbTranscript;
+      }),
+      closeSession: vi.fn(async () => {
+        callOrder.push('close');
+      }),
+      bootstrapSession: vi.fn(async () => {
+        callOrder.push('bootstrap');
+        return {
+          session: newSession,
+          didInjectOrcaInstructions: true,
+          didInjectProjectContext: false,
+        };
+      }),
+    });
+    const transaction = createMakerSendTransaction(deps);
+
+    await expect(
+      transaction.sendToAgentAccepted('pi-orca-session', 'follow up', {
+        id: 'pi-orca-session',
+        agentKind: 'pi',
+        workingDir: '/repo',
+        model: 'cindy/pi-model',
+        orcaRole: 'lead',
+      }),
+    ).resolves.toMatchObject({
+      accepted: true,
+      outcome: { kind: 'session-dispatch', dispatched: true },
+    });
+
+    expect(deps.bootstrapSession).toHaveBeenCalledWith(expect.objectContaining({
+      resumeSessionId: dbTranscript,
+    }));
+    expect(callOrder).toEqual(['reconcile', 'close', 'bootstrap', 'send']);
+    expect(oldSession.send).not.toHaveBeenCalled();
+    expect(newSession.send).toHaveBeenCalledTimes(1);
+  });
+
+  it('prefers the DB Pi transcript over a stale caller resumeSessionId during Orca rehydrate', async () => {
+    const oldSession = createSession({
+      id: 'pi-orca-session',
+      agentKind: 'pi',
+      workDir: '/repo',
+    });
+    const newSession = createSession({
+      id: 'pi-orca-session',
+      agentKind: 'pi',
+      workDir: '/repo',
+    });
+    const dbTranscript = '/pi/sessions/latest-transcript.jsonl';
+    const { deps } = createDeps({
+      getSession: vi.fn(() => oldSession),
+      isOrcaMcpHydrated: vi.fn(() => false),
+      synthesizeOrcaVendorOptionsFromDb: vi.fn(async () => true),
+      reconcileCreateOptsWithDb: vi.fn(async (_sessionId, opts) => {
+        opts.resumeSessionId = dbTranscript;
+      }),
+      bootstrapSession: vi.fn(async () => ({
+        session: newSession,
+        didInjectOrcaInstructions: true,
+        didInjectProjectContext: false,
+      })),
+    });
+    const transaction = createMakerSendTransaction(deps);
+
+    await transaction.sendToAgentAccepted('pi-orca-session', 'follow up', {
+      id: 'pi-orca-session',
+      agentKind: 'pi',
+      workingDir: '/repo',
+      model: 'cindy/pi-model',
+      orcaRole: 'lead',
+      resumeSessionId: '/pi/sessions/stale-transcript.jsonl',
+    });
+
+    expect(deps.bootstrapSession).toHaveBeenCalledWith(expect.objectContaining({
+      resumeSessionId: dbTranscript,
+    }));
+    expect(oldSession.send).not.toHaveBeenCalled();
+    expect(newSession.send).toHaveBeenCalledTimes(1);
+  });
+
   it('returns rehydrate failure without sending when active Orca rehydrate fails', async () => {
     const oldSession = createSession({ id: 'orca-session', workDir: 'C:\\repo' });
     const { deps } = createDeps({
@@ -1135,6 +1240,7 @@ describe('maker SEND transaction', () => {
     });
 
     expect(oldSession.send).not.toHaveBeenCalled();
+    expect(deps.prepareSendUserMessage).not.toHaveBeenCalled();
   });
 
   it('projects a stable marker with a safe fallback when rehydrate Codex resume preparation is blocked', async () => {

--- a/apps/desktop/src/main/maker-ipc/makerSendTransaction.ts
+++ b/apps/desktop/src/main/maker-ipc/makerSendTransaction.ts
@@ -201,7 +201,7 @@ export interface MakerSendTransactionDeps {
   rollbackUserPromptPreview?(sessionId: string, clientId: string | undefined, source: string): void;
   isSessionRunningError(err: unknown): boolean;
   /**
-   * session-agent-switch:lazy-create 前用 DB 行(真源)校正 createOpts。
+   * send-time bootstrap/rebuild 前用 DB 行(真源)校正 createOpts。
    * 切换后 renderer/队列里可能残留旧 agentKind / 旧 resumeSessionId 的 createOpts,
    * 用它 spawn 会把消息发回旧引擎且丢交接注入;此钩子读 sessions 行,发现漂移时
    * 原地覆写 agentKind/model/resumeSessionId/providerId。undefined = 不校正(测试用)。
@@ -437,6 +437,7 @@ export function createMakerSendTransaction(deps: MakerSendTransactionDeps): Make
     sessionId: string,
     createOpts: CreateOpts,
   ): Promise<ResolveSessionResult> {
+    await deps.reconcileCreateOptsWithDb?.(sessionId, createOpts);
     const okRehydrate = await ensureWorkDirWithDbFallback(sessionId, createOpts);
     if (!okRehydrate) {
       return {

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -7940,7 +7940,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
     });
   };
 
-  // session-agent-switch:lazy-create 前以 DB 行为真源校正 createOpts。切换后
+  // send-time bootstrap/rebuild 前以 DB 行为真源校正 createOpts。切换后
   // 残留在 renderer store / 排队项里的旧 agentKind/resumeSessionId 若原样 spawn,
   // 会把会话劫持回旧引擎且丢交接注入(规则 9:代码兜底)。send 事务与
   // GET_CONTEXT_USAGE 的 lazy 分支共用(后者无校正曾是审计实锤缺口)。
@@ -7973,7 +7973,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
       // 事务内 apply 之前。agentKind 可能已一致,但 model/resume/providerId/effort/fast
       // 仍是旧值；
       // 尤其 resumeSessionId 可能是**旧引擎**的原生会话 id——resume 会以错误引擎
-      // 解释它)。lazy-create 时刻 DB 行是唯一真源,执行字段无条件对齐。
+      // 解释它)。send-time bootstrap/rebuild 时 DB 行是唯一真源,执行字段无条件对齐。
       co.model = row.model ?? undefined;
       co.resumeSessionId = row.sdkSessionId ?? undefined;
       co.providerId = row.providerId;
@@ -10666,7 +10666,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
       rollbackAgentIslandUserPrompt(sessionId, clientId, source);
     },
     isSessionRunningError,
-    // session-agent-switch:lazy-create 前以 DB 行为真源校正 createOpts(定义见
+    // send-time bootstrap/rebuild 前以 DB 行为真源校正 createOpts(定义见
     // reconcileCreateOptsAgainstDb;GET_CONTEXT_USAGE 的 lazy 分支共用)。
     reconcileCreateOptsWithDb: reconcileCreateOptsAgainstDb,
     peekPendingHandoff: (sessionId) => agentHandoffPending.peek(sessionId),


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 #2882：普通 Pi 会话在同一轮调用 `start_team` 成为 Orca Lead 后，下一条消息触发 active-Orca rehydrate 时，先用 sessions 表的执行身份对账 `createOpts`，让 bootstrap 继续 resume 原 Pi JSONL transcript，而不是从追问创建空会话。

Fixes #2882

这补齐了 send-time bootstrap/rebuild 统一使用 DB 真源的既有不变量，没有新增 Pi 专属恢复分支，也没有重构 Orca MCP 热加载。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#2882
- 本 PR 包含：active-Orca rehydrate 在关闭旧 runtime 前对账 DB createOpts；补充 Pi transcript、陈旧 resumeSessionId、调用顺序和失败不派发测试。
- 明确不包含：数据库 schema、UI、system prompt、Pi transcript 格式、Cindy 消息库历史重放、MCP 热加载重构。
- 用户可见变化：Pi 会话中途开启 Orca 后，下一条消息仍可看到开启前的任务历史。
- 是否存在 breaking change：无。

### UI 变化

不涉及。

- 引用的设计规范：不涉及。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/maker-ipc/__tests__/makerSendTransaction.test.ts
结果：62/62 通过

pnpm test:unit:related
结果：Desktop related unit tests 通过

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm check:dco
结果：通过
```

### 手工验证

不涉及 UI 手工验证。

### 未执行的验证

- 未完成真实 Pi JSONL 端到端验收（首轮对话 → `start_team` → 下一条追问）；worktree 改动不会影响当前运行中的宿主实例。
- 完整 `pnpm test:unit` 曾额外执行，但未全绿：macOS 默认 `/var` TMPDIR 下有 2 个既有 plugin receipt 测试因 `/var` 与 `/private/var` 路径别名失败；改用真实路径 TMPDIR 后该组通过，但 3 个既有 Pi resource-discovery provenance 断言因 scope 从 `temporary` 变为 `project` 失败。两组单文件分别在各自预期环境通过，本 PR 未修改相关代码。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：会话 runtime 重建路径

### 影响与回滚

- 影响范围：仅 active Orca session 在下一次 send 前进行的 runtime rebuild；不新增 IPC、wire protocol、device-link 或移动端行为。
- 回滚 / 降级方式：回滚本提交即可恢复旧 rehydrate 行为；无数据迁移和持久格式变化。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次无需文档变更）
- [x] 已确认测试结果或说明未执行原因
