### PR TITLE
feat(desktop): support nested list indentation in composer

### DIFF
--- a/apps/desktop/src/renderer/__tests__/chatInputListContinuation.test.ts
+++ b/apps/desktop/src/renderer/__tests__/chatInputListContinuation.test.ts
@@ -9,6 +9,7 @@ const chatInputSource = readFileSync(
 
 /**
  * ChatInput 列表接续接线契约:
+ * - Tab / Shift+Tab 在结构化列表内调整层级，无法调整时保留原有快捷键或焦点导航;
  * - Shift/Alt+Enter 优先处理结构化列表，再兼容旧纯文本列表;
  * - 普通 Enter 不由列表接续拦截,发送或原生换行由共享快捷键 resolver 决定;
  * - 守住 IME composition 边界。
@@ -18,8 +19,26 @@ describe('ChatInput list continuation wiring contract', () => {
   it('imports both structured-list commands and the legacy plain-text fallback', () => {
     expect(chatInputSource).toContain('handleStructuredListBackspace');
     expect(chatInputSource).toContain('handleStructuredListBreak');
+    expect(chatInputSource).toContain('handleStructuredListIndent');
     expect(chatInputSource).toContain('applyListBackspace');
     expect(chatInputSource).toContain('applyListContinuation');
+  });
+
+  it('tries structured-list indentation before the permission shortcut', () => {
+    const block = extractBetween(
+      chatInputSource,
+      '// Tab / Shift+Tab — indent or outdent structured list items.',
+      '// ESC — back out of the topmost thing the user is interacting with.',
+    );
+    expect(block).toContain("event.key === 'Tab'");
+    expect(block).toContain('!event.metaKey');
+    expect(block).toContain('!event.ctrlKey');
+    expect(block).toContain('!event.altKey');
+    expect(block).toContain('!event.isComposing');
+    expect(block).toContain('handleStructuredListIndent(view, event.shiftKey)');
+    expect(block.indexOf('handleStructuredListIndent(view, event.shiftKey)')).toBeLessThan(
+      block.indexOf("getAppShortcutCombos('cycle-permission-mode')"),
+    );
   });
 
   it('tries structured and legacy continuation on Shift/Alt+Enter', () => {

--- a/apps/desktop/src/renderer/__tests__/composerStructuredLists.test.ts
+++ b/apps/desktop/src/renderer/__tests__/composerStructuredLists.test.ts
@@ -623,6 +623,47 @@ describe('composer structured list input rules', () => {
 });
 
 describe('composer structured list keyboard commands', () => {
+  it.each([
+    { marker: ')' as const, separator: ' ', start: 4 },
+    { marker: '、' as const, separator: '', start: 7 },
+  ])(
+    'preserves ordered-list $marker attrs when Tab creates a nested list',
+    ({ marker, separator, start }) => {
+      const editor = makeEditor({
+        type: 'doc',
+        content: [
+          {
+            type: 'orderedList',
+            attrs: { start, marker, separator },
+            content: ['parent', 'child'].map((text) => ({
+              type: 'listItem',
+              content: [{ type: 'paragraph', content: [{ type: 'text', text }] }],
+            })),
+          },
+        ],
+      });
+      selectText(editor, 'child');
+
+      expect(handleStructuredListIndent(editor.view)).toBe(true);
+
+      const parentList = editor.state.doc.firstChild;
+      const nestedList = parentList?.firstChild?.lastChild;
+      expect(parentList?.attrs).toMatchObject({ start, marker, separator });
+      expect(nestedList?.type.name).toBe('orderedList');
+      expect(nestedList?.attrs).toMatchObject({ start, marker, separator });
+
+      const renderedLists = Array.from(editor.view.dom.querySelectorAll('ol'));
+      expect(renderedLists).toHaveLength(2);
+      expect(renderedLists[1].getAttribute('data-marker')).toBe(marker);
+
+      const expectedSeparator = separator === '' ? '' : ' ';
+      const expectedIndent = ' '.repeat(`${start}${marker}${expectedSeparator}`.length);
+      expect(serializeEditorContent(editor).text).toBe(
+        `${start}${marker}${expectedSeparator}parent\n${expectedIndent}${start}${marker}${expectedSeparator}child`,
+      );
+    },
+  );
+
   it('indents and outdents a list item under its previous sibling', () => {
     const editor = makeEditor({
       type: 'doc',

--- a/apps/desktop/src/renderer/__tests__/composerStructuredLists.test.ts
+++ b/apps/desktop/src/renderer/__tests__/composerStructuredLists.test.ts
@@ -15,8 +15,10 @@ import {
   ComposerOrderedList,
   handleStructuredListBackspace,
   handleStructuredListBreak,
+  handleStructuredListIndent,
   isTopLevelBlockSelection,
   isTrailingEmptyTopLevelParagraph,
+  orderedListMarkerStyleAtDepth,
   promoteTrailingPlainListParagraph,
 } from '@/components/new-chat/ComposerListNodes';
 import {
@@ -124,6 +126,63 @@ function selectDocumentEnd(editor: Editor): void {
   editor.view.dispatch(editor.state.tr.setSelection(TextSelection.atEnd(editor.state.doc)));
 }
 
+function selectText(editor: Editor, text: string): void {
+  let position: number | null = null;
+  editor.state.doc.descendants((node, pos) => {
+    if (position === null && node.isText && node.text === text) position = pos + node.nodeSize;
+  });
+  if (position === null) throw new Error(`Text not found in editor: ${text}`);
+  editor.commands.setTextSelection(position);
+}
+
+function textBounds(editor: Editor, text: string): { from: number; to: number } {
+  let bounds: { from: number; to: number } | null = null;
+  editor.state.doc.descendants((node, pos) => {
+    if (bounds === null && node.isText && node.text === text) {
+      bounds = { from: pos, to: pos + node.nodeSize };
+    }
+  });
+  if (bounds === null) throw new Error(`Text not found in editor: ${text}`);
+  return bounds;
+}
+
+type TestListKind = 'bulletList' | 'orderedList';
+
+function nestedListDocument(
+  kinds: TestListKind[],
+  orderedMarker: '.' | ')' | '、' = '.',
+): Record<string, unknown> {
+  let nested: Record<string, unknown> | undefined;
+  for (let index = kinds.length - 1; index >= 0; index -= 1) {
+    const kind = kinds[index];
+    nested = {
+      type: kind,
+      ...(kind === 'orderedList'
+        ? { attrs: { start: 1, marker: orderedMarker } }
+        : {}),
+      content: [
+        {
+          type: 'listItem',
+          content: [
+            {
+              type: 'paragraph',
+              content: [{ type: 'text', text: `level ${index + 1}` }],
+            },
+            ...(nested ? [nested] : []),
+          ],
+        },
+      ],
+    };
+  }
+  return { type: 'doc', content: nested ? [nested] : [{ type: 'paragraph' }] };
+}
+
+function renderedOrderedListStyles(editor: Editor): Array<string | null> {
+  return Array.from(editor.view.dom.querySelectorAll('ol')).map((list) =>
+    list.getAttribute('data-list-marker-style'),
+  );
+}
+
 afterEach(() => {
   for (const editor of editors.splice(0)) editor.destroy();
 });
@@ -220,7 +279,8 @@ describe('composer structured list input rules', () => {
 
     const list = editor.view.dom.querySelector('ol');
     expect(list?.getAttribute('data-marker')).toBe('、');
-    expect(list?.getAttribute('data-marker-digits')).toBe('1');
+    expect(list?.getAttribute('data-marker-width-chars')).toBe('1');
+    expect(list?.getAttribute('style')).toContain('--composer-list-padding: 1.5em;');
 
     const css = readFileSync(resolve(__dirname, '..', 'styles', 'globals.css'), 'utf8');
     const baseListRule = css.match(
@@ -236,12 +296,197 @@ describe('composer structured list input rules', () => {
     expect(cjkMarkerRule).toContain('--composer-list-marker-extra: 0.7em;');
   });
 
-  it('reserves enough marker width for long ordered-list numbers', () => {
+  it('reserves enough marker width for long decimal ordinals', () => {
     const editor = makeEditor();
 
     typeThroughInputRules(editor, '123456. ');
 
-    expect(editor.view.dom.querySelector('ol')?.getAttribute('data-marker-digits')).toBe('6');
+    const list = editor.view.dom.querySelector('ol');
+    expect(list?.getAttribute('data-marker-width-chars')).toBe('6');
+    expect(list?.getAttribute('style')).toContain('--composer-list-padding: 4.6em;');
+  });
+
+  it.each(['.', ')', '、'] as const)(
+    'budgets the full aa%s marker at the alphabetic level',
+    (marker) => {
+      const editor = makeEditor({
+        type: 'doc',
+        content: [
+          {
+            type: 'bulletList',
+            content: [
+              {
+                type: 'listItem',
+                content: [
+                  { type: 'paragraph', content: [{ type: 'text', text: 'parent' }] },
+                  {
+                    type: 'orderedList',
+                    attrs: { start: 27, marker },
+                    content: [
+                      {
+                        type: 'listItem',
+                        content: [
+                          { type: 'paragraph', content: [{ type: 'text', text: 'child' }] },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      });
+      const list = editor.view.dom.querySelector('ol');
+
+      expect(list?.getAttribute('data-list-marker-style')).toBe('lower-alpha');
+      expect(list?.getAttribute('data-marker-width-chars')).toBe('2');
+      expect(list?.getAttribute('style')).toContain('--composer-list-padding: 2.2em;');
+      expect(list?.getAttribute('data-marker') ?? '.').toBe(marker);
+    },
+  );
+
+  it.each(['.', ')', '、'] as const)(
+    'budgets the full lxxxviii%s marker at the roman level',
+    (marker) => {
+      const editor = makeEditor({
+        type: 'doc',
+        content: [
+          {
+            type: 'bulletList',
+            content: [
+              {
+                type: 'listItem',
+                content: [
+                  { type: 'paragraph', content: [{ type: 'text', text: 'level 1' }] },
+                  {
+                    type: 'bulletList',
+                    content: [
+                      {
+                        type: 'listItem',
+                        content: [
+                          { type: 'paragraph', content: [{ type: 'text', text: 'level 2' }] },
+                          {
+                            type: 'orderedList',
+                            attrs: { start: 88, marker },
+                            content: [
+                              {
+                                type: 'listItem',
+                                content: [
+                                  {
+                                    type: 'paragraph',
+                                    content: [{ type: 'text', text: 'level 3' }],
+                                  },
+                                ],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      });
+      const list = editor.view.dom.querySelector('ol');
+
+      expect(list?.getAttribute('data-list-marker-style')).toBe('lower-roman');
+      expect(list?.getAttribute('data-marker-width-chars')).toBe('8');
+      expect(list?.getAttribute('style')).toContain('--composer-list-padding: 5.8em;');
+      expect(list?.getAttribute('data-marker') ?? '.').toBe(marker);
+    },
+  );
+
+  it('renders arbitrary ordered-list depths with a repeating three-level marker cycle', () => {
+    const editor = makeEditor(
+      nestedListDocument(Array.from({ length: 7 }, () => 'orderedList')),
+    );
+
+    expect(renderedOrderedListStyles(editor)).toEqual([
+      'decimal',
+      'lower-alpha',
+      'lower-roman',
+      'decimal',
+      'lower-alpha',
+      'lower-roman',
+      'decimal',
+    ]);
+    expect(orderedListMarkerStyleAtDepth(700)).toBe('decimal');
+    expect(orderedListMarkerStyleAtDepth(701)).toBe('lower-alpha');
+    expect(orderedListMarkerStyleAtDepth(702)).toBe('lower-roman');
+  });
+
+  it('counts mixed bullet and ordered ancestors toward ordered-list depth', () => {
+    const editor = makeEditor(
+      nestedListDocument(['bulletList', 'orderedList', 'bulletList', 'orderedList']),
+    );
+
+    expect(renderedOrderedListStyles(editor)).toEqual(['lower-alpha', 'decimal']);
+  });
+
+  it('recomputes marker styles when restored content replaces the document', () => {
+    const editor = makeEditor();
+
+    editor.commands.setContent(
+      nestedListDocument(Array.from({ length: 7 }, () => 'orderedList')),
+    );
+
+    expect(renderedOrderedListStyles(editor)).toEqual([
+      'decimal',
+      'lower-alpha',
+      'lower-roman',
+      'decimal',
+      'lower-alpha',
+      'lower-roman',
+      'decimal',
+    ]);
+  });
+
+  it.each(['.', ')', '、'] as const)(
+    'keeps %s punctuation while cycling the rendered counter style',
+    (marker) => {
+      const editor = makeEditor(
+        nestedListDocument(['orderedList', 'orderedList', 'orderedList', 'orderedList'], marker),
+      );
+      const lists = Array.from(editor.view.dom.querySelectorAll('ol'));
+
+      expect(renderedOrderedListStyles(editor)).toEqual([
+        'decimal',
+        'lower-alpha',
+        'lower-roman',
+        'decimal',
+      ]);
+      expect(lists.map((list) => list.getAttribute('data-marker') ?? '.')).toEqual([
+        marker,
+        marker,
+        marker,
+        marker,
+      ]);
+    },
+  );
+
+  it('maps marker attributes to the three reusable CSS counter styles', () => {
+    const css = readFileSync(resolve(__dirname, '..', 'styles', 'globals.css'), 'utf8');
+    const compactCss = css.replace(/\s+/g, ' ');
+
+    expect(compactCss).toContain(
+      '[data-chat-input-root] .ProseMirror ol { list-style-type: decimal;',
+    );
+    expect(compactCss).toContain(
+      "ol[data-list-marker-style='lower-alpha'] { list-style-type: lower-alpha;",
+    );
+    expect(compactCss).toContain(
+      "ol[data-list-marker-style='lower-roman'] { list-style-type: lower-roman;",
+    );
+    expect(compactCss).toContain(
+      "ol[data-list-marker-style='lower-alpha'][data-marker=')'] > li::marker { content: counter(list-item, lower-alpha) ') ';",
+    );
+    expect(compactCss).toContain(
+      "ol[data-list-marker-style='lower-roman'][data-marker='、'] > li::marker { content: counter(list-item, lower-roman) '、';",
+    );
   });
 
   it.each([
@@ -378,6 +623,247 @@ describe('composer structured list input rules', () => {
 });
 
 describe('composer structured list keyboard commands', () => {
+  it('indents and outdents a list item under its previous sibling', () => {
+    const editor = makeEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'bulletList',
+          content: ['parent', 'child'].map((text) => ({
+            type: 'listItem',
+            content: [{ type: 'paragraph', content: [{ type: 'text', text }] }],
+          })),
+        },
+      ],
+    });
+    selectText(editor, 'child');
+
+    expect(handleStructuredListIndent(editor.view)).toBe(true);
+    expect(serializeEditorContent(editor).text).toBe('- parent\n  - child');
+    expect(handleStructuredListIndent(editor.view, true)).toBe(true);
+    expect(serializeEditorContent(editor).text).toBe('- parent\n- child');
+  });
+
+  it('outdents a top-level item into a paragraph', () => {
+    const editor = makeEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'bulletList',
+          content: ['first', 'second'].map((text) => ({
+            type: 'listItem',
+            content: [{ type: 'paragraph', content: [{ type: 'text', text }] }],
+          })),
+        },
+      ],
+    });
+    selectText(editor, 'second');
+
+    expect(handleStructuredListIndent(editor.view, true)).toBe(true);
+    expect(editor.state.doc.firstChild?.type.name).toBe('bulletList');
+    expect(editor.state.doc.lastChild?.type.name).toBe('paragraph');
+    expect(serializeEditorContent(editor).text).toBe('- first\nsecond');
+  });
+
+  it('indents and outdents a continuous multi-item selection', () => {
+    const editor = makeEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'bulletList',
+          content: ['parent', 'child one', 'child two'].map((text) => ({
+            type: 'listItem',
+            content: [{ type: 'paragraph', content: [{ type: 'text', text }] }],
+          })),
+        },
+      ],
+    });
+    const first = textBounds(editor, 'child one');
+    const second = textBounds(editor, 'child two');
+    editor.commands.setTextSelection({ from: first.from, to: second.to });
+
+    expect(handleStructuredListIndent(editor.view)).toBe(true);
+    expect(serializeEditorContent(editor).text).toBe('- parent\n  - child one\n  - child two');
+    expect(handleStructuredListIndent(editor.view, true)).toBe(true);
+    expect(serializeEditorContent(editor).text).toBe('- parent\n- child one\n- child two');
+  });
+
+  it('updates ordered marker styles immediately for a multi-item indent and outdent', () => {
+    const editor = makeEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'orderedList',
+          attrs: { start: 1, marker: '.' },
+          content: ['parent', 'child one', 'child two'].map((text) => ({
+            type: 'listItem',
+            content: [{ type: 'paragraph', content: [{ type: 'text', text }] }],
+          })),
+        },
+      ],
+    });
+    const first = textBounds(editor, 'child one');
+    const second = textBounds(editor, 'child two');
+    editor.commands.setTextSelection({ from: first.from, to: second.to });
+
+    expect(renderedOrderedListStyles(editor)).toEqual(['decimal']);
+    expect(handleStructuredListIndent(editor.view)).toBe(true);
+    expect(renderedOrderedListStyles(editor)).toEqual(['decimal', 'lower-alpha']);
+    expect(handleStructuredListIndent(editor.view, true)).toBe(true);
+    expect(renderedOrderedListStyles(editor)).toEqual(['decimal']);
+  });
+
+  it('cycles from roman back to decimal when Tab creates a fourth-level list', () => {
+    const levelThreeWithSiblings: Record<string, unknown> = {
+      type: 'orderedList',
+      attrs: { start: 1, marker: '.' },
+      content: [
+        {
+          type: 'listItem',
+          content: [
+            { type: 'paragraph', content: [{ type: 'text', text: 'level 1' }] },
+            {
+              type: 'orderedList',
+              attrs: { start: 1, marker: '.' },
+              content: [
+                {
+                  type: 'listItem',
+                  content: [
+                    { type: 'paragraph', content: [{ type: 'text', text: 'level 2' }] },
+                    {
+                      type: 'orderedList',
+                      attrs: { start: 1, marker: '.' },
+                      content: ['level 3 parent', 'level 4 candidate'].map((text) => ({
+                        type: 'listItem',
+                        content: [{ type: 'paragraph', content: [{ type: 'text', text }] }],
+                      })),
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    const editor = makeEditor({ type: 'doc', content: [levelThreeWithSiblings] });
+    selectText(editor, 'level 4 candidate');
+
+    expect(renderedOrderedListStyles(editor)).toEqual([
+      'decimal',
+      'lower-alpha',
+      'lower-roman',
+    ]);
+    expect(handleStructuredListIndent(editor.view)).toBe(true);
+    expect(renderedOrderedListStyles(editor)).toEqual([
+      'decimal',
+      'lower-alpha',
+      'lower-roman',
+      'decimal',
+    ]);
+    expect(handleStructuredListIndent(editor.view, true)).toBe(true);
+    expect(renderedOrderedListStyles(editor)).toEqual([
+      'decimal',
+      'lower-alpha',
+      'lower-roman',
+    ]);
+  });
+
+  it('recomputes a large ordinal width when indentation changes its counter style', () => {
+    const editor = makeEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'bulletList',
+          content: [
+            {
+              type: 'listItem',
+              content: [{ type: 'paragraph', content: [{ type: 'text', text: 'parent' }] }],
+            },
+            {
+              type: 'listItem',
+              content: [
+                { type: 'paragraph', content: [{ type: 'text', text: 'movable branch' }] },
+                {
+                  type: 'orderedList',
+                  attrs: { start: 88, marker: ')' },
+                  content: [
+                    {
+                      type: 'listItem',
+                      content: [
+                        { type: 'paragraph', content: [{ type: 'text', text: 'large ordinal' }] },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    selectText(editor, 'movable branch');
+
+    let lists = Array.from(editor.view.dom.querySelectorAll('ol'));
+    expect(lists).toHaveLength(1);
+    expect(lists[0].getAttribute('data-list-marker-style')).toBe('lower-alpha');
+    expect(lists[0].getAttribute('data-marker-width-chars')).toBe('2');
+    expect(lists[0].getAttribute('style')).toContain('--composer-list-padding: 2.2em;');
+
+    expect(handleStructuredListIndent(editor.view)).toBe(true);
+    lists = Array.from(editor.view.dom.querySelectorAll('ol'));
+    expect(lists).toHaveLength(1);
+    expect(lists[0].getAttribute('data-list-marker-style')).toBe('lower-roman');
+    expect(lists[0].getAttribute('data-marker-width-chars')).toBe('8');
+    expect(lists[0].getAttribute('style')).toContain('--composer-list-padding: 5.8em;');
+
+    expect(handleStructuredListIndent(editor.view, true)).toBe(true);
+    lists = Array.from(editor.view.dom.querySelectorAll('ol'));
+    expect(lists).toHaveLength(1);
+    expect(lists[0].getAttribute('data-list-marker-style')).toBe('lower-alpha');
+    expect(lists[0].getAttribute('data-marker-width-chars')).toBe('2');
+    expect(lists[0].getAttribute('style')).toContain('--composer-list-padding: 2.2em;');
+  });
+
+  it('preserves inline atoms while indenting a list item', () => {
+    const editor = makeEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'bulletList',
+          content: [
+            { type: 'listItem', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'parent' }] }] },
+            {
+              type: 'listItem',
+              content: [{ type: 'paragraph', content: [
+                { type: 'text', text: 'child ' },
+                { type: 'mentionChip', attrs: { label: 'file.ts', path: 'file.ts' } },
+              ] }],
+            },
+          ],
+        },
+      ],
+    });
+    selectText(editor, 'child ');
+
+    expect(handleStructuredListIndent(editor.view)).toBe(true);
+    const nestedParagraph = editor.state.doc.firstChild?.firstChild?.lastChild?.firstChild?.firstChild;
+    expect(nestedParagraph?.child(1).type.name).toBe('mentionChip');
+    expect(nestedParagraph?.child(1).attrs).toMatchObject({ label: 'file.ts', path: 'file.ts' });
+  });
+
+  it('leaves Tab available outside lists and when the first item cannot indent', () => {
+    const paragraphEditor = makeEditor({ type: 'doc', content: [{ type: 'paragraph' }] });
+    selectDocumentEnd(paragraphEditor);
+    expect(handleStructuredListIndent(paragraphEditor.view)).toBe(false);
+
+    const listEditor = makeEditor({ type: 'doc', content: [{
+      type: 'bulletList',
+      content: [{ type: 'listItem', content: [{ type: 'paragraph' }] }],
+    }] });
+    selectDocumentEnd(listEditor);
+    expect(handleStructuredListIndent(listEditor.view)).toBe(false);
+  });
   it('splits a non-empty item and exits from the empty continuation item', () => {
     const editor = makeEditor({
       type: 'doc',
@@ -857,6 +1343,61 @@ describe('composer live plain-list promotion', () => {
 });
 
 describe('composer structured list serialization', () => {
+  it('keeps three-level ordered-list Markdown numeric', () => {
+    const item = (text: string, nested?: Record<string, unknown>) => ({
+      type: 'listItem',
+      content: [
+        { type: 'paragraph', content: [{ type: 'text', text }] },
+        ...(nested ? [nested] : []),
+      ],
+    });
+    const list = (content: Record<string, unknown>[]) => ({
+      type: 'orderedList',
+      attrs: { start: 1, marker: '.' },
+      content,
+    });
+    const editor = makeEditor({
+      type: 'doc',
+      content: [list([item('one', list([item('two', list([item('three')]))]))])],
+    });
+
+    expect(serializeEditorContent(editor).text).toBe('1. one\n   1. two\n      1. three');
+  });
+
+  it('keeps fourth- through sixth-level ordered-list Markdown numeric', () => {
+    const editor = makeEditor(
+      nestedListDocument(Array.from({ length: 6 }, () => 'orderedList')),
+    );
+
+    expect(serializeEditorContent(editor).text).toBe(
+      '1. level 1\n' +
+        '   1. level 2\n' +
+        '      1. level 3\n' +
+        '         1. level 4\n' +
+        '            1. level 5\n' +
+        '               1. level 6',
+    );
+  });
+
+  it.each(['.', ')', '、'] as const)(
+    'keeps nested %s Markdown markers numeric at every visual style',
+    (marker) => {
+      const editor = makeEditor(
+        nestedListDocument(Array.from({ length: 4 }, () => 'orderedList'), marker),
+      );
+      const lines = serializeEditorContent(editor).text.split('\n');
+
+      expect(lines).toHaveLength(4);
+      expect(lines.map((line) => line.trimStart().startsWith(`1${marker}`))).toEqual([
+        true,
+        true,
+        true,
+        true,
+      ]);
+      expect(lines.join('\n')).not.toMatch(/(?:^|\n)\s*[a-z]+[.)、]/i);
+    },
+  );
+
   it('uses the full parent marker width for nested list indentation', () => {
     const editor = makeEditor({
       type: 'doc',

--- a/apps/desktop/src/renderer/__tests__/composerStructuredLists.test.ts
+++ b/apps/desktop/src/renderer/__tests__/composerStructuredLists.test.ts
@@ -650,19 +650,112 @@ describe('composer structured list keyboard commands', () => {
       const nestedList = parentList?.firstChild?.lastChild;
       expect(parentList?.attrs).toMatchObject({ start, marker, separator });
       expect(nestedList?.type.name).toBe('orderedList');
-      expect(nestedList?.attrs).toMatchObject({ start, marker, separator });
+      expect(nestedList?.attrs).toMatchObject({ start: 1, marker, separator });
 
       const renderedLists = Array.from(editor.view.dom.querySelectorAll('ol'));
       expect(renderedLists).toHaveLength(2);
       expect(renderedLists[1].getAttribute('data-marker')).toBe(marker);
+      expect(renderedLists[1].getAttribute('start')).toBeNull();
 
       const expectedSeparator = separator === '' ? '' : ' ';
       const expectedIndent = ' '.repeat(`${start}${marker}${expectedSeparator}`.length);
       expect(serializeEditorContent(editor).text).toBe(
-        `${start}${marker}${expectedSeparator}parent\n${expectedIndent}${start}${marker}${expectedSeparator}child`,
+        `${start}${marker}${expectedSeparator}parent\n${expectedIndent}1${marker}${expectedSeparator}child`,
       );
     },
   );
+
+  it.each([
+    { marker: '+' as const, separator: ' ' },
+    { marker: '*' as const, separator: '  ' },
+  ])(
+    'preserves bullet-list $marker attrs when Tab creates a nested list',
+    ({ marker, separator }) => {
+      const editor = makeEditor({
+        type: 'doc',
+        content: [
+          {
+            type: 'bulletList',
+            attrs: { marker, separator },
+            content: ['parent', 'child'].map((text) => ({
+              type: 'listItem',
+              content: [{ type: 'paragraph', content: [{ type: 'text', text }] }],
+            })),
+          },
+        ],
+      });
+      selectText(editor, 'child');
+
+      expect(handleStructuredListIndent(editor.view)).toBe(true);
+
+      const parentList = editor.state.doc.firstChild;
+      const nestedList = parentList?.firstChild?.lastChild;
+      expect(parentList?.attrs).toMatchObject({ marker, separator });
+      expect(nestedList?.type.name).toBe('bulletList');
+      expect(nestedList?.attrs).toMatchObject({ marker, separator });
+
+      const renderedLists = Array.from(editor.view.dom.querySelectorAll('ul'));
+      expect(renderedLists).toHaveLength(2);
+      expect(renderedLists[1].getAttribute('data-marker')).toBe(marker);
+
+      const nestedIndent = ' '.repeat(`${marker}${separator}`.length);
+      expect(serializeEditorContent(editor).text).toBe(
+        `${marker}${separator}parent\n${nestedIndent}${marker}${separator}child`,
+      );
+    },
+  );
+
+  it('reuses an existing nested ordered list without overriding its attrs', () => {
+    const editor = makeEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'orderedList',
+          attrs: { start: 5, marker: ')', separator: ' ' },
+          content: [
+            {
+              type: 'listItem',
+              content: [
+                { type: 'paragraph', content: [{ type: 'text', text: 'parent' }] },
+                {
+                  type: 'orderedList',
+                  attrs: { start: 9, marker: '、', separator: '' },
+                  content: [
+                    {
+                      type: 'listItem',
+                      content: [
+                        { type: 'paragraph', content: [{ type: 'text', text: 'existing' }] },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              type: 'listItem',
+              content: [{ type: 'paragraph', content: [{ type: 'text', text: 'target' }] }],
+            },
+          ],
+        },
+      ],
+    });
+    selectText(editor, 'target');
+
+    expect(handleStructuredListIndent(editor.view)).toBe(true);
+
+    const outerList = editor.state.doc.firstChild;
+    const parentItem = outerList?.firstChild;
+    const nestedLists = parentItem
+      ? Array.from({ length: parentItem.childCount }, (_, index) => parentItem.child(index)).filter(
+          (node) => node.type.name === 'orderedList',
+        )
+      : [];
+    expect(nestedLists).toHaveLength(1);
+    expect(nestedLists[0]?.attrs).toMatchObject({ start: 9, marker: '、', separator: '' });
+    expect(nestedLists[0]?.childCount).toBe(2);
+    expect(nestedLists[0]?.child(1).textContent).toBe('target');
+    expect(serializeEditorContent(editor).text).toBe('5) parent\n   9、existing\n   10、target');
+  });
 
   it('indents and outdents a list item under its previous sibling', () => {
     const editor = makeEditor({

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -39,6 +39,7 @@ import {
   ComposerOrderedList,
   handleStructuredListBackspace,
   handleStructuredListBreak,
+  handleStructuredListIndent,
   hasTrailingPlainListParagraph,
   isTopLevelBlockSelection,
   isTrailingEmptyTopLevelParagraph,
@@ -2381,6 +2382,25 @@ export function ChatInput({
           !event.repeat &&
           !event.isComposing &&
           acceptPromptRecommendationRef.current()
+        ) {
+          event.preventDefault();
+          return true;
+        }
+
+        // Tab / Shift+Tab — indent or outdent structured list items. Only
+        // consume the key when the schema command can actually move the
+        // selected item(s), so ordinary text keeps native focus navigation.
+        // If Shift+Tab cannot outdent, it falls through to the configured
+        // cycle-permission-mode shortcut below.
+        if (
+          event.key === 'Tab' &&
+          !event.metaKey &&
+          !event.ctrlKey &&
+          !event.altKey &&
+          !event.repeat &&
+          !event.isComposing &&
+          !composerMutationLockedRef.current &&
+          handleStructuredListIndent(view, event.shiftKey)
         ) {
           event.preventDefault();
           return true;

--- a/apps/desktop/src/renderer/components/new-chat/ComposerListNodes.ts
+++ b/apps/desktop/src/renderer/components/new-chat/ComposerListNodes.ts
@@ -7,9 +7,10 @@
  * widths with decorations.
  */
 import { InputRule, Node, mergeAttributes, wrappingInputRule, type NodeConfig } from '@tiptap/core';
-import { Fragment, type Node as PMNode, type NodeType } from '@tiptap/pm/model';
-import { liftListItem, sinkListItem, splitListItem } from '@tiptap/pm/schema-list';
+import { Fragment, Slice, type Node as PMNode, type NodeType } from '@tiptap/pm/model';
+import { liftListItem, splitListItem } from '@tiptap/pm/schema-list';
 import { Plugin, PluginKey, Selection, TextSelection } from '@tiptap/pm/state';
+import { ReplaceAroundStep } from '@tiptap/pm/transform';
 import { Decoration, DecorationSet, type EditorView } from '@tiptap/pm/view';
 
 const BULLET_MARKER_RE = /^([-+*•])([ \t]+)$/;
@@ -615,6 +616,54 @@ export function handleStructuredListBackspace(view: EditorView): boolean {
 }
 
 /**
+ * Sink the selected list item(s) while preserving attributes on a newly
+ * created nested list. ProseMirror's standard command creates that wrapper
+ * with null attrs, which resets composer marker and separator metadata.
+ */
+function sinkStructuredListItem(view: EditorView, itemType: NodeType): boolean {
+  const { state } = view;
+  const { $from, $to } = state.selection;
+  const range = $from.blockRange(
+    $to,
+    (node) => node.childCount > 0 && node.firstChild?.type === itemType,
+  );
+  if (!range || range.startIndex === 0) return false;
+
+  const parent = range.parent;
+  const nodeBefore = parent.child(range.startIndex - 1);
+  if (nodeBefore.type !== itemType) return false;
+
+  const nestedBefore = nodeBefore.lastChild?.type === parent.type;
+  const inner = Fragment.from(nestedBefore ? itemType.create() : null);
+  const nestedList = parent.type.create(nestedBefore ? null : parent.attrs, inner);
+  const openStart = nestedBefore ? 3 : 1;
+  const slice = new Slice(
+    Fragment.from(itemType.create(null, Fragment.from(nestedList))),
+    openStart,
+    0,
+  );
+  const before = range.start;
+  const after = range.end;
+
+  view.dispatch(
+    state.tr
+      .step(
+        new ReplaceAroundStep(
+          before - openStart,
+          after,
+          before,
+          after,
+          slice,
+          1,
+          true,
+        ),
+      )
+      .scrollIntoView(),
+  );
+  return true;
+}
+
+/**
  * Indent or outdent the selected structured list item(s).
  *
  * The schema-list commands already preserve mixed inline content and multi-item
@@ -624,8 +673,8 @@ export function handleStructuredListBackspace(view: EditorView): boolean {
 export function handleStructuredListIndent(view: EditorView, outdent = false): boolean {
   const itemType = view.state.schema.nodes.listItem;
   if (!itemType || selectedListItemDepth(view) === null) return false;
-  const command = outdent ? liftListItem(itemType) : sinkListItem(itemType);
-  return command(view.state, view.dispatch);
+  if (outdent) return liftListItem(itemType)(view.state, view.dispatch);
+  return sinkStructuredListItem(view, itemType);
 }
 
 /**

--- a/apps/desktop/src/renderer/components/new-chat/ComposerListNodes.ts
+++ b/apps/desktop/src/renderer/components/new-chat/ComposerListNodes.ts
@@ -635,7 +635,9 @@ function sinkStructuredListItem(view: EditorView, itemType: NodeType): boolean {
 
   const nestedBefore = nodeBefore.lastChild?.type === parent.type;
   const inner = Fragment.from(nestedBefore ? itemType.create() : null);
-  const nestedList = parent.type.create(nestedBefore ? null : parent.attrs, inner);
+  const nestedAttrs =
+    parent.type.name === 'orderedList' ? { ...parent.attrs, start: 1 } : parent.attrs;
+  const nestedList = parent.type.create(nestedBefore ? null : nestedAttrs, inner);
   const openStart = nestedBefore ? 3 : 1;
   const slice = new Slice(
     Fragment.from(itemType.create(null, Fragment.from(nestedList))),

--- a/apps/desktop/src/renderer/components/new-chat/ComposerListNodes.ts
+++ b/apps/desktop/src/renderer/components/new-chat/ComposerListNodes.ts
@@ -8,9 +8,9 @@
  */
 import { InputRule, Node, mergeAttributes, wrappingInputRule, type NodeConfig } from '@tiptap/core';
 import { Fragment, type Node as PMNode, type NodeType } from '@tiptap/pm/model';
-import { liftListItem, splitListItem } from '@tiptap/pm/schema-list';
-import { Selection, TextSelection } from '@tiptap/pm/state';
-import type { EditorView } from '@tiptap/pm/view';
+import { liftListItem, sinkListItem, splitListItem } from '@tiptap/pm/schema-list';
+import { Plugin, PluginKey, Selection, TextSelection } from '@tiptap/pm/state';
+import { Decoration, DecorationSet, type EditorView } from '@tiptap/pm/view';
 
 const BULLET_MARKER_RE = /^([-+*•])([ \t]+)$/;
 const ORDERED_MARKER_RE = /^([1-9]\d{0,8})([.)])([ \t]+)$/;
@@ -23,6 +23,122 @@ interface OrderedListAttrs {
   start: number;
   marker: OrderedMarker;
   separator: string;
+}
+
+export type OrderedListMarkerStyle = 'decimal' | 'lower-alpha' | 'lower-roman';
+
+interface OrderedListMarkerDecorationState {
+  decorations: DecorationSet;
+}
+
+const ORDERED_LIST_MARKER_PLUGIN_KEY = new PluginKey<OrderedListMarkerDecorationState>(
+  'composerOrderedListMarkerDecoration',
+);
+
+export function orderedListMarkerStyleAtDepth(depth: number): OrderedListMarkerStyle {
+  const cycleIndex = ((depth - 1) % 3 + 3) % 3;
+  return cycleIndex === 0 ? 'decimal' : cycleIndex === 1 ? 'lower-alpha' : 'lower-roman';
+}
+
+function lowerAlphaOrdinal(value: number): string {
+  if (!Number.isSafeInteger(value) || value < 1) return String(value);
+  let remaining = value;
+  let result = '';
+  while (remaining > 0) {
+    remaining -= 1;
+    result = String.fromCharCode(97 + (remaining % 26)) + result;
+    remaining = Math.floor(remaining / 26);
+  }
+  return result;
+}
+
+const ROMAN_ORDINAL_PARTS: ReadonlyArray<readonly [number, string]> = [
+  [1000, 'm'],
+  [900, 'cm'],
+  [500, 'd'],
+  [400, 'cd'],
+  [100, 'c'],
+  [90, 'xc'],
+  [50, 'l'],
+  [40, 'xl'],
+  [10, 'x'],
+  [9, 'ix'],
+  [5, 'v'],
+  [4, 'iv'],
+  [1, 'i'],
+];
+
+function lowerRomanOrdinal(value: number): string {
+  // CSS's predefined lower-roman counter style falls back to decimal outside
+  // its 1..3999 range.
+  if (!Number.isSafeInteger(value) || value < 1 || value > 3999) return String(value);
+  let remaining = value;
+  let result = '';
+  for (const [amount, glyphs] of ROMAN_ORDINAL_PARTS) {
+    while (remaining >= amount) {
+      result += glyphs;
+      remaining -= amount;
+    }
+  }
+  return result;
+}
+
+function orderedListMarkerText(value: number, style: OrderedListMarkerStyle): string {
+  if (style === 'lower-alpha') return lowerAlphaOrdinal(value);
+  if (style === 'lower-roman') return lowerRomanOrdinal(value);
+  return String(value);
+}
+
+function orderedListMarkerWidth(node: PMNode, style: OrderedListMarkerStyle): {
+  characters: number;
+  paddingEm: number;
+} {
+  const start = Number(node.attrs.start);
+  let characters = 1;
+  if (Number.isSafeInteger(start) && start > 0) {
+    for (let index = 0; index < node.childCount; index += 1) {
+      characters = Math.max(
+        characters,
+        orderedListMarkerText(start + index, style).length,
+      );
+    }
+  }
+  return {
+    characters,
+    paddingEm: characters === 1 ? 1.5 : Number((1 + characters * 0.6).toFixed(2)),
+  };
+}
+
+/**
+ * Decorate every ordered list from its full list ancestry. Bullet and ordered
+ * ancestors both count, while the three-value attribute keeps CSS independent
+ * from the maximum nesting depth.
+ */
+export function buildOrderedListMarkerDecorations(doc: PMNode): DecorationSet {
+  const decorations: Decoration[] = [];
+
+  const visit = (parent: PMNode, contentStart: number, ancestorListDepth: number): void => {
+    parent.forEach((child, offset) => {
+      const childPos = contentStart + offset;
+      const isList = child.type.name === 'bulletList' || child.type.name === 'orderedList';
+      const listDepth = ancestorListDepth + (isList ? 1 : 0);
+      if (child.type.name === 'orderedList') {
+        const markerStyle = orderedListMarkerStyleAtDepth(listDepth);
+        const markerWidth = orderedListMarkerWidth(child, markerStyle);
+        decorations.push(
+          Decoration.node(childPos, childPos + child.nodeSize, {
+            'data-list-marker-style': markerStyle,
+            'data-marker-width-chars': String(markerWidth.characters),
+            style: `--composer-list-padding:${markerWidth.paddingEm}em;`,
+          }),
+        );
+      }
+      if (child.childCount > 0) visit(child, childPos + 1, listDepth);
+    });
+  };
+
+  visit(doc, 0, 0);
+  return DecorationSet.create(doc, decorations);
 }
 
 interface SelectedTaskPrefix {
@@ -186,7 +302,6 @@ function fenceAwareWrappingInputRule(
 
 const listItemConfig: NodeConfig = {
   name: 'listItem',
-  group: 'block',
   content: 'paragraph block*',
   defining: true,
   parseHTML() {
@@ -307,17 +422,29 @@ export const ComposerOrderedList = Node.create({
   parseHTML() {
     return [{ tag: 'ol' }];
   },
-  renderHTML({ node, HTMLAttributes }) {
-    const start = Number(node.attrs.start);
-    const lastItem = start + Math.max(node.childCount - 1, 0);
-    const markerDigits =
-      Number.isInteger(start) && start > 0 && Number.isInteger(lastItem)
-        ? String(lastItem).length
-        : 1;
+  renderHTML({ HTMLAttributes }) {
+    return ['ol', mergeAttributes(HTMLAttributes), 0];
+  },
+  addProseMirrorPlugins() {
     return [
-      'ol',
-      mergeAttributes(HTMLAttributes, { 'data-marker-digits': String(markerDigits) }),
-      0,
+      new Plugin<OrderedListMarkerDecorationState>({
+        key: ORDERED_LIST_MARKER_PLUGIN_KEY,
+        state: {
+          init(_config, state) {
+            return { decorations: buildOrderedListMarkerDecorations(state.doc) };
+          },
+          apply(transaction, previous) {
+            return transaction.docChanged
+              ? { decorations: buildOrderedListMarkerDecorations(transaction.doc) }
+              : previous;
+          },
+        },
+        props: {
+          decorations(state) {
+            return this.getState(state)?.decorations ?? DecorationSet.empty;
+          },
+        },
+      }),
     ];
   },
   addInputRules() {
@@ -485,6 +612,20 @@ export function handleStructuredListBackspace(view: EditorView): boolean {
   }
   if (taskPrefix) return clearTaskPrefixAndLift(view, itemDepth, taskPrefix);
   return liftEmptyStructuredListItem(view, itemType);
+}
+
+/**
+ * Indent or outdent the selected structured list item(s).
+ *
+ * The schema-list commands already preserve mixed inline content and multi-item
+ * selections. Returning false outside a list keeps Tab available for normal
+ * focus navigation and other composer shortcuts.
+ */
+export function handleStructuredListIndent(view: EditorView, outdent = false): boolean {
+  const itemType = view.state.schema.nodes.listItem;
+  if (!itemType || selectedListItemDepth(view) === null) return false;
+  const command = outdent ? liftListItem(itemType) : sinkListItem(itemType);
+  return command(view.state, view.dispatch);
 }
 
 /**

--- a/apps/desktop/src/renderer/styles/globals.css
+++ b/apps/desktop/src/renderer/styles/globals.css
@@ -434,33 +434,9 @@ html:lang(ko) {
 }
 /* The ideographic comma is a full-width glyph, unlike the period / closing
    parenthesis in the other ordered markers. Keep its extra width separate
-   from the digit budget so multi-digit ordinals still compose correctly. */
+   from the decoration-computed counter-text budget. */
 [data-chat-input-root] .ProseMirror ol[data-marker='、'] {
   --composer-list-marker-extra: 0.7em;
-}
-[data-chat-input-root] .ProseMirror ol[data-marker-digits='2'] {
-  --composer-list-padding: 2.2em;
-}
-[data-chat-input-root] .ProseMirror ol[data-marker-digits='3'] {
-  --composer-list-padding: 2.8em;
-}
-[data-chat-input-root] .ProseMirror ol[data-marker-digits='4'] {
-  --composer-list-padding: 3.4em;
-}
-[data-chat-input-root] .ProseMirror ol[data-marker-digits='5'] {
-  --composer-list-padding: 4em;
-}
-[data-chat-input-root] .ProseMirror ol[data-marker-digits='6'] {
-  --composer-list-padding: 4.6em;
-}
-[data-chat-input-root] .ProseMirror ol[data-marker-digits='7'] {
-  --composer-list-padding: 5.2em;
-}
-[data-chat-input-root] .ProseMirror ol[data-marker-digits='8'] {
-  --composer-list-padding: 5.8em;
-}
-[data-chat-input-root] .ProseMirror ol[data-marker-digits='9'] {
-  --composer-list-padding: 6.4em;
 }
 [data-chat-input-root] .ProseMirror ul {
   list-style-type: disc;
@@ -468,11 +444,41 @@ html:lang(ko) {
 [data-chat-input-root] .ProseMirror ol {
   list-style-type: decimal;
 }
+[data-chat-input-root] .ProseMirror ol[data-list-marker-style='lower-alpha'] {
+  list-style-type: lower-alpha;
+}
+[data-chat-input-root] .ProseMirror ol[data-list-marker-style='lower-roman'] {
+  list-style-type: lower-roman;
+}
 [data-chat-input-root] .ProseMirror ol[data-marker=')'] > li::marker {
   content: counter(list-item) ') ';
 }
 [data-chat-input-root] .ProseMirror ol[data-marker='、'] > li::marker {
   content: counter(list-item) '、';
+}
+[data-chat-input-root]
+  .ProseMirror
+  ol[data-list-marker-style='lower-alpha'][data-marker=')']
+  > li::marker {
+  content: counter(list-item, lower-alpha) ') ';
+}
+[data-chat-input-root]
+  .ProseMirror
+  ol[data-list-marker-style='lower-alpha'][data-marker='、']
+  > li::marker {
+  content: counter(list-item, lower-alpha) '、';
+}
+[data-chat-input-root]
+  .ProseMirror
+  ol[data-list-marker-style='lower-roman'][data-marker=')']
+  > li::marker {
+  content: counter(list-item, lower-roman) ') ';
+}
+[data-chat-input-root]
+  .ProseMirror
+  ol[data-list-marker-style='lower-roman'][data-marker='、']
+  > li::marker {
+  content: counter(list-item, lower-roman) '、';
 }
 [data-chat-input-root] .ProseMirror li {
   padding-inline-start: 0.15em;


### PR DESCRIPTION
## 这次改了什么

### 摘要

为聊天输入框中的结构化列表增加 Tab / Shift+Tab 层级调整，并支持有序列表编号样式按嵌套深度无限循环。

### 变更类型

- [x] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [x] `test` 测试补充

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：
  - 裸 Tab 下沉结构化列表项
  - Shift+Tab 优先反缩进，无法反缩进时保留权限快捷键回退
  - 面板、推荐提示词、IME、repeat、修饰键和 mutation lock 行为保持不变
  - 有序列表编号按完整列表嵌套深度循环：
    - decimal
    - lower-alpha
    - lower-roman
    - 无限重复
  - 兼容 `.`, `)` 和 `、` 标点
  - 编号宽度按实际 decimal / alpha / Roman 文本长度预算
  - 首次创建嵌套列表时继承父列表的 marker / separator；新建有序子列表从 start: 1 开始
  - `)`、`、`、`+` 和 `*` 首次下沉时保留原 marker
  - 已有同类型嵌套列表继续复用，且不覆盖其 start / marker / separator
  - Markdown 序列化继续使用数字有序列表标记
- 明确不包含：
  - 不修改左侧任务列表
  - 不修改官方 `main`
  - 不涉及数据库、协议、权限、插件格式或移动端
- 用户可见变化：
  - 在聊天输入框内可使用 Tab / Shift+Tab 调整列表层级
  - 嵌套有序列表显示为 `1. → a. → i. → 1. → …`
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：
  - `docs/design-rules/DESIGN.md §14.3 Keyboard & IME`
  - 本次没有新增颜色、字体或全局设计 token。
  - UI 变化仅限聊天输入框内结构化列表的键盘交互和列表 marker 显示。

## 功能范围与边界

本 PR 为桌面端聊天输入框中的结构化 Markdown 列表增加键盘缩进能力，并优化有序列表的嵌套编号显示。

### 支持的行为

- 光标或选区位于结构化列表项时：
  - `Tab`：将列表项下沉一级。
  - `Shift+Tab`：将列表项提升一级。
- 支持单个列表项和连续多项选区。
- 支持有序列表、无序列表以及二者混合嵌套。
- 无法下沉的首个列表项不会消费 `Tab`。
- 无法提升时不会消费列表命令，并保留 Cindy 原有的快捷键回退。
- 普通文本中的 `Tab` 不会被拦截，继续使用原生焦点导航。
- `/`、`@` 面板及空输入框推荐提示词保持更高的 Tab 处理优先级。
- IME 输入、按键长按、mutation lock，以及带 Ctrl、Meta 或 Alt 的 Tab 不触发列表缩进。

### 有序列表视觉编号

有序列表按照完整的 `ul` / `ol` 祖先深度，以三层为周期循环显示：

- depth 1：decimal，例如 `1.`
- depth 2：lower-alpha，例如 `a.`
- depth 3：lower-roman，例如 `i.`
- depth 4：重新从 decimal 开始
- 后续继续按照 `decimal → lower-alpha → lower-roman` 无限循环

支持 `.`, `)` 和 `、` 三种标点。

编号宽度根据实际 marker 文本计算，例如 `aa`、`lxxxviii` 和多位十进制编号，避免正文受到挤压。

### Markdown 输出

字母和罗马数字仅用于聊天输入框内的视觉显示。

发送和 Markdown 序列化继续使用数字有序列表标记，以保持 CommonMark 兼容性，不会输出 `a.` 或 `i.`。

### 明确不支持 / 不在本 PR 范围内

- 不实现或承诺完整复刻 Word、飞书文档的连续 Backspace 列表重组行为。
- 不保证非空列表项在行首连续按 Backspace 时，会按照 Word/飞书的方式逐级提升、重新分配后续兄弟项或最终合并到上一行。
- 对带有子列表或前后兄弟项的中间条目，不承诺其 Backspace 归属规则与 Word/飞书完全一致。
- 不新增自定义文档节点、额外列表状态机或特殊草稿／Markdown 数据结构。
- 不提供 Word 式自定义多级列表模板。
- 不改变发送后消息的 Markdown 列表协议。
- 不修改左侧任务列表。
- 本功能只作用于聊天输入框。

## UI 效果证据

### CINDY Light

<img width="1280" height="900" alt="CINDY Light：聊天输入框嵌套列表静态 HTML 视觉验收" src="https://github.com/user-attachments/assets/aaf365ed-c986-4fab-83c9-22c00b48eaeb" />

### CINDY Dark

<img width="1280" height="900" alt="CINDY Dark：聊天输入框嵌套列表静态 HTML 视觉验收" src="https://github.com/user-attachments/assets/70de8ffb-099a-4e1d-8535-d039144fe6da" />

> 静态 HTML 视觉验收，不是客户端实机截图，也不替代真实交互测试。
>
> 上述图片来自基于现有 Cindy composer 尺寸、颜色令牌和列表 CSS 制作的静态 HTML 视觉验收页，用于确认编号层级、缩进、标点宽度和 Light/Dark 主题表现。它不是客户端实机截图，也不替代真实客户端中的 Tab、Shift+Tab、Backspace、粘贴和 Markdown 序列化测试。

- 交互式静态 HTML 视觉验收页：[composer-list-demo.html](https://github.com/user-attachments/files/31288231/composer-list-demo.html)
- HTML 可切换 Light/Dark、宽窄布局和 `. / ) / 、` 标点，并提供有限的 Tab/Shift+Tab 视觉演示。
- HTML 明确不模拟 Backspace。

## 怎么验证的

### 自动验证

```text
corepack pnpm --filter desktop exec vitest run src/renderer/__tests__/composerStructuredLists.test.ts src/renderer/__tests__/chatInputListContinuation.test.ts
结果：102/102 通过

corepack pnpm --filter desktop run typecheck
结果：通过

corepack pnpm test:unit:related
结果：通过

git diff --check
结果：通过
```

测试覆盖：

- 第 1～7 级及更深层级的三段式编号循环
- `27 → aa`
- `88 → lxxxviii`
- `.`, `)` 和 `、`
- `)`、`、`、`+` 和 `*` 首次下沉时的 marker 保留
- 新建有序子列表从 start: 1 开始，以及已有嵌套列表 attrs 复用
- Tab 下沉和 Shift+Tab 反缩进
- 多项选区
- inline atom
- 混合有序／无序列表
- 粘贴、草稿恢复和已有嵌套列表
- 层级变化后的即时 decoration 刷新
- 四至六级及更深层级的数字 Markdown 序列化

### 手工验证

未完成客户端实机手工验证；已补充静态 HTML 双主题视觉验收。自动测试验证了实际渲染 DOM、属性和 decoration 依据。

### 未执行的验证

客户端实机手工验证未完成。

## 风险

### 风险分类

风险集中在结构化列表的键盘处理和 DOM decoration。Tab/Shift+Tab、深层编号循环、标点、恢复和 Markdown 序列化已有自动测试覆盖。Word/飞书式连续 Backspace 行为不属于本 PR 的支持范围，本 PR 不为其增加自定义结构重组逻辑。

### 影响与回滚

- 影响范围：仅聊天输入框中的结构化列表编辑和视觉编号。
- 回滚方式：回滚本 PR 的功能提交即可恢复原有列表行为。
- 不涉及数据库、协议、权限、插件兼容性或移动端 runtime fingerprint。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个贡献提交已按仓库 DCO remediation 流程补签
- [x] UI 变化已注明设计规范
- [x] 未提交凭证、令牌或授权文件
- [x] 已确认测试结果