### PR TITLE
fix(maker-core,desktop): 唤醒桥接与 continuation claim 超时对账,修复后台子任务完成后会话永久转圈

### DIFF
--- a/apps/desktop/src/renderer/__tests__/makerChatStoreTaskUpdates.test.ts
+++ b/apps/desktop/src/renderer/__tests__/makerChatStoreTaskUpdates.test.ts
@@ -76,7 +76,12 @@ vi.mock('@/lib/makerTransport', () => ({
   isRemoteSessionSticky: (sessionId: string) => sessionId.startsWith('remote-'),
 }));
 
-import { EMPTY_SESSION_STATE, handleStreamEvent, makerChatStore } from '@/lib/makerChatStore';
+import {
+  EMPTY_SESSION_STATE,
+  handleStreamEvent,
+  makerChatStore,
+  WAKE_BRIDGE_RECONCILE_MS,
+} from '@/lib/makerChatStore';
 import type { SessionChatState } from '@/lib/makerChatStore';
 
 describe('makerChatStore agent task updates', () => {
@@ -583,6 +588,76 @@ describe('getRunningSnapshot 后台 subagent 折算(真 store)', () => {
       await flushStopTransition();
       expect(makerChatStore.getRunningSnapshot().has(sid)).toBe(false);
     } finally {
+      makerChatStore.purgeSession(sid);
+    }
+  });
+
+  it('唤醒桥接超时对账:wake turn 永不启动时清桥接收口,不再永久转圈', async () => {
+    // 2026-08-18 事故形态:后台子 agent 在主 turn 运行中完成,上游 CLI 把
+    // task-notification 当 mid-turn 附件消费 —— 主轮 Done 后桥接(pendingTaskWake)
+    // 死等一个永远不会来的 isRunning:true,sidebar 永久转圈。修复:桥接挂起时起
+    // 对账定时器,宽限期内无 wake turn 启动即清空桥接,让 running 快照收敛为事实
+    // (任务卡早已显示终态,不丢信息)。
+    const sid = `wake-reconcile-${Math.random().toString(36).slice(2, 8)}`;
+    vi.useFakeTimers();
+    try {
+      // turn start + 子任务启动 + 主 turn 内终态 → 桥接置位 + 跨主 turn 标记
+      makerChatStore.__applyStatusUpdateForTest(sid, statusUpdate(sid, true));
+      applyTask(sid, { taskId: 't1', status: 'running', taskType: 'local_agent' });
+      applyTask(sid, { taskId: 't1', status: 'completed' });
+      expect(makerChatStore.getSnapshot(sid).pendingTaskWake).toBe(1);
+
+      // 主轮 Done:桥接按设计跨过 Done 存活,等待 wake turn —— 此刻起对账表
+      makerChatStore.__applyStatusUpdateForTest(sid, statusUpdate(sid, false, 'Done'));
+      const afterMainDone = makerChatStore.getSnapshot(sid);
+      expect(afterMainDone.pendingTaskWake).toBe(1);
+      expect(afterMainDone.pendingTaskWakeDuringTurn).toBe(0);
+      expect(makerChatStore.getRunningSnapshot().get(sid)?.isRunning).toBe(true);
+
+      // 宽限期内(差 1ms):桥接必须仍在,不得提前收口
+      await vi.advanceTimersByTimeAsync(WAKE_BRIDGE_RECONCILE_MS - 1);
+      expect(makerChatStore.getSnapshot(sid).pendingTaskWake).toBe(1);
+      expect(makerChatStore.getRunningSnapshot().get(sid)?.isRunning).toBe(true);
+
+      // 越过宽限且无 wake turn 启动 → 桥接清空,running 快照收敛
+      await vi.advanceTimersByTimeAsync(2_000);
+      const afterReconcile = makerChatStore.getSnapshot(sid);
+      expect(afterReconcile.pendingTaskWake).toBe(0);
+      expect(afterReconcile.pendingTaskWakeDuringTurn).toBe(0);
+      expect(afterReconcile.pendingTaskWakeStarted).toBe(false);
+      expect(makerChatStore.getRunningSnapshot().get(sid)?.isRunning ?? false).toBe(false);
+    } finally {
+      // 恢复真实时钟前先冲掉 fake 定时器:getRunningSnapshot 的 transition 清理是
+      // setTimeout(0) + 模块级 _stopTransitionClearScheduled 标志,不冲掉会把标志
+      // 留在 true,泄漏到后续真实时钟用例(transition 永不清除)。
+      await vi.advanceTimersByTimeAsync(10).catch(() => undefined);
+      vi.useRealTimers();
+      makerChatStore.purgeSession(sid);
+    }
+  });
+
+  it('唤醒桥接超时对账:宽限期内 wake turn 启动 → 定时器解除,不误伤健康路径', async () => {
+    const sid = `wake-reconcile-ok-${Math.random().toString(36).slice(2, 8)}`;
+    vi.useFakeTimers();
+    try {
+      makerChatStore.__applyStatusUpdateForTest(sid, statusUpdate(sid, true));
+      applyTask(sid, { taskId: 't1', status: 'running', taskType: 'local_agent' });
+      applyTask(sid, { taskId: 't1', status: 'completed' });
+      makerChatStore.__applyStatusUpdateForTest(sid, statusUpdate(sid, false, 'Done'));
+      expect(makerChatStore.getSnapshot(sid).pendingTaskWake).toBe(1);
+
+      // 宽限期内 wake turn 启动(isRunning:true)→ 桥接正常消费、定时器解除
+      await vi.advanceTimersByTimeAsync(5_000);
+      makerChatStore.__applyStatusUpdateForTest(sid, statusUpdate(sid, true));
+      expect(makerChatStore.getSnapshot(sid).pendingTaskWake).toBe(0);
+
+      // 再快进远超宽限:不得出现「事后清算」打断仍在跑的 wake turn
+      await vi.advanceTimersByTimeAsync(WAKE_BRIDGE_RECONCILE_MS * 2);
+      expect(makerChatStore.getSnapshot(sid).pendingTaskWake).toBe(0);
+      expect(makerChatStore.getRunningSnapshot().get(sid)?.isRunning).toBe(true);
+    } finally {
+      await vi.advanceTimersByTimeAsync(10).catch(() => undefined);
+      vi.useRealTimers();
       makerChatStore.purgeSession(sid);
     }
   });

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -3269,6 +3269,7 @@ function _purgeSession(sessionId: string): void {
   // 交接中的迟到 continuation，且不写入 /clear 的历史时间边界。
   bumpRendererClearGeneration(sessionId);
   cancelRemoteOptimisticSendsForSessionPurge(sessionId);
+  clearWakeBridgeReconcileTimer(sessionId);
   sessions.delete(sessionId);
   localSentUserMessageIds.delete(sessionId);
   pendingLocalRetryIntents.delete(sessionId);
@@ -3551,6 +3552,49 @@ function setState(
   // messages:created 的侧栏时间戳与 chat state 保持原有先后：先通知消息，再 patch 列表。
   flushPendingMessageCreatedPatch(sessionId);
   if (!hasDeferredStateWork()) clearDeferredStateNotificationTimer();
+}
+
+/**
+ * 唤醒桥接对账(见 pendingTaskWake 字段注释):桥接在「wake 任务终态 → wake turn
+ * 启动」的窗口里撑住 running 快照,但上游 CLI 在「后台子 agent 于主 turn 运行中完成」
+ * 的时机会把 task-notification 当 mid-turn 附件消费掉,续跑 turn 永远不会来 —— 桥接
+ * 便在主 turn Done 之后无限期等待,sidebar 永久转圈。桥接挂起(计数 > 0 且会话非
+ * running)时起表:宽限期内 isTurnStart 照常消费计数(isRunning 翻 true 即解除);
+ * 超时仍未启动则清空桥接,让 running 快照收敛为事实 —— 任务卡早已显示终态,不丢信息。
+ */
+export const WAKE_BRIDGE_RECONCILE_MS = 60_000;
+const wakeBridgeReconcileTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
+function clearWakeBridgeReconcileTimer(sessionId: string): void {
+  const timer = wakeBridgeReconcileTimers.get(sessionId);
+  if (!timer) return;
+  clearTimeout(timer);
+  wakeBridgeReconcileTimers.delete(sessionId);
+}
+
+function scheduleWakeBridgeReconciliation(sessionId: string): void {
+  const state = sessions.get(sessionId);
+  if (!state || state.pendingTaskWake <= 0 || state.agentStatus.isRunning) {
+    clearWakeBridgeReconcileTimer(sessionId);
+    return;
+  }
+  // 已在计时:保持首次挂起时刻的截止线,后续无关事件不刷新窗口。
+  if (wakeBridgeReconcileTimers.has(sessionId)) return;
+  const timer = setTimeout(() => {
+    wakeBridgeReconcileTimers.delete(sessionId);
+    // slice 可能已被 clearSession / LRU 逐出;setState 会重建 slice,先探测再动。
+    if (!sessions.has(sessionId)) return;
+    setState(sessionId, (s) => {
+      if (s.pendingTaskWake <= 0 || s.agentStatus.isRunning) return s;
+      return {
+        ...s,
+        pendingTaskWake: 0,
+        pendingTaskWakeDuringTurn: 0,
+        pendingTaskWakeStarted: false,
+      };
+    });
+  }, WAKE_BRIDGE_RECONCILE_MS);
+  wakeBridgeReconcileTimers.set(sessionId, timer);
 }
 
 function notify(sessionId: string): void {
@@ -6120,6 +6164,7 @@ function dispatchStreamEventPayload(
   } as CCAgentStreamEvent;
   supersedeInputProjectionOnTerminalEvent(sessionId, streamEvent);
   setState(sessionId, (s) => handleStreamEvent(s, streamEvent), { deferNotification });
+  scheduleWakeBridgeReconciliation(sessionId);
 }
 
 function clearTextDeltaFlushTimer(): void {
@@ -6505,6 +6550,7 @@ function initGlobalListeners(options: GlobalListenerOptions = {}): void {
         supersedeInputProjectionRequests(sessionId, { supersedeOperations: true });
       }
       setState(sessionId, (s) => handleStatusUpdate(s, update));
+      scheduleWakeBridgeReconciliation(sessionId);
       return;
     }
 
@@ -14441,6 +14487,7 @@ export const makerChatStore = {
   __applyStreamEventForTest: (sessionId: string, event: CCAgentStreamEvent): void => {
     supersedeInputProjectionOnTerminalEvent(sessionId, event);
     setState(sessionId, (s) => handleStreamEvent(s, event));
+    scheduleWakeBridgeReconciliation(sessionId);
   },
   /** Exposed for tests only: 把 status update 打进真实 store。 */
   __applyStatusUpdateForTest: (sessionId: string, update: CCAgentStatusUpdate): void => {
@@ -14448,6 +14495,7 @@ export const makerChatStore = {
       supersedeInputProjectionRequests(sessionId, { supersedeOperations: true });
     }
     setState(sessionId, (s) => handleStatusUpdate(s, update));
+    scheduleWakeBridgeReconciliation(sessionId);
   },
   /** Exposed for tests only. */
   __hydratePersistedMessageForTest: hydratePersistedMessage,

--- a/packages/maker-core/src/agents/claude-code/__tests__/abort-stops-background-tasks.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/abort-stops-background-tasks.test.ts
@@ -78,7 +78,7 @@ vi.mock('../../shared/async-queue.js', async (importOriginal) => {
   };
 });
 
-import { ClaudeCodeAgent } from '../index.js';
+import { ClaudeCodeAgent, WAKE_CONTRACT_GRACE_MS } from '../index.js';
 import { Session } from '../../../session.js';
 
 const tempDirs: string[] = [];
@@ -593,6 +593,80 @@ describe('ClaudeCodeAgent abort stops background wake tasks', () => {
 
     stream.end();
     await handle.close().catch(() => undefined);
+  });
+
+  it('wake contract reconciliation cancels an awaiting claim whose tasks are all terminal without continuation activity', async () => {
+    vi.useFakeTimers();
+    try {
+      const { handle, stream, events, fakeQuery } = await startSessionWithStream();
+
+      await handle.send({ type: 'user', content: 'spawn background work' });
+      stream.emit(taskStarted('task-agent', 'local_agent'));
+      await vi.advanceTimersByTimeAsync(0);
+      stream.emit(turnResult('waiting'));
+      await vi.advanceTimersByTimeAsync(0);
+      const continuationId = events.find((event) => event.type === 'done')?.turnContinuationId;
+      expect(continuationId).toBeTypeOf('number');
+      stream.emit(taskNotification('task-agent', 'completed'));
+      await vi.advanceTimersByTimeAsync(0);
+      expect(taskEvents(events).length).toBeGreaterThanOrEqual(2);
+
+      // 宽限期内:claim 仍在按 task_notification 续跑契约等待,不得提前收口。
+      expect(handle.beginTurnContinuationWait?.(continuationId)).toBe('awaiting');
+      expect(events.filter(isProductTerminal)).toHaveLength(0);
+
+      // 快进越过宽限窗口且无任何续跑活动:契约失守 → 取消 claim 并补合成终态。
+      await vi.advanceTimersByTimeAsync(WAKE_CONTRACT_GRACE_MS + 1_000);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(events.filter(isProductTerminal).length).toBe(1);
+      expect(
+        events.find(
+          (event) => event.type === 'done' && event.turnContinuationId === undefined,
+        )?.data,
+      ).toMatchObject({ reason: 'turn_continuation_cancelled' });
+      expect(handle.beginTurnContinuationWait?.(continuationId)).toBeNull();
+      expect(handle.isTurnRunning?.()).toBe(false);
+      // 对账不是用户 Stop:不得触碰 stopTask / interrupt。
+      expect(fakeQuery.stopTask).not.toHaveBeenCalled();
+      expect(fakeQuery.interrupt).not.toHaveBeenCalled();
+
+      stream.end();
+      await handle.close().catch(() => undefined);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('wake contract reconciliation stands down once the continuation activates', async () => {
+    vi.useFakeTimers();
+    try {
+      const { handle, stream, events } = await startSessionWithStream();
+
+      await handle.send({ type: 'user', content: 'spawn background work' });
+      stream.emit(taskStarted('task-agent', 'local_agent'));
+      await vi.advanceTimersByTimeAsync(0);
+      stream.emit(turnResult('waiting'));
+      await vi.advanceTimersByTimeAsync(0);
+      const continuationId = events.find((event) => event.type === 'done')?.turnContinuationId;
+      expect(continuationId).toBeTypeOf('number');
+      stream.emit(taskNotification('task-agent', 'completed'));
+      await vi.advanceTimersByTimeAsync(0);
+      expect(handle.beginTurnContinuationWait?.(continuationId)).toBe('awaiting');
+
+      // 健康路径:续跑段在宽限期内激活,对账定时器随之解除。
+      stream.emit(assistantText('automatic continuation started'));
+      await vi.advanceTimersByTimeAsync(0);
+      expect(handle.beginTurnContinuationWait?.(continuationId)).toBe('active');
+
+      await vi.advanceTimersByTimeAsync(WAKE_CONTRACT_GRACE_MS + 60_000);
+      expect(events.filter(isProductTerminal)).toHaveLength(0);
+      expect(handle.beginTurnContinuationWait?.(continuationId)).toBe('active');
+
+      stream.end();
+      await handle.close().catch(() => undefined);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('graceful stop lets an already active continuation finish through its interrupted result', async () => {

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -678,6 +678,13 @@ function isInvalidCompactPreservedSegmentForkError(err: unknown): boolean {
  * 少停不误停,启发式后台活动检测兜底)。
  */
 const WAKE_BACKGROUND_TASK_TYPES: ReadonlySet<string> = new Set(['local_agent', 'local_workflow']);
+/**
+ * Wake 契约对账宽限:claim 内全部 wake 任务到终态(completed/failed)后,留给 SDK
+ * 启动自动续跑段的窗口。健康路径里 dequeue → 顶层活动只需数秒;宽限内没有任何
+ * 激活即判定契约失守(CLI 在「子代理于主 turn 运行中完成」时会把通知当 mid-turn
+ * 附件消费,续跑段永远不会来),取消 claim 收口产品 turn。只影响终态低频路径。
+ */
+export const WAKE_CONTRACT_GRACE_MS = 60_000;
 
 // ── 能力声明 ──────────────────────────────────────────────────────────────────
 
@@ -3563,6 +3570,14 @@ export class ClaudeCodeAgent extends BaseAgent {
      */
     let stopTerminalEmittedGeneration: number | null = null;
     let continuationCancellationRequiresQueryRebuild = false;
+    // Wake 契约对账定时器:见 WAKE_CONTRACT_GRACE_MS。claim 激活 / 取消 / 结算 /
+    // 丢弃 / query 换代时必须清掉,防止陈旧定时器误杀后继 claim。
+    let wakeContractReconcileTimer: NodeJS.Timeout | null = null;
+    const clearWakeContractReconciliation = (): void => {
+      if (!wakeContractReconcileTimer) return;
+      clearTimeout(wakeContractReconcileTimer);
+      wakeContractReconcileTimer = null;
+    };
     const continuationClaims = new Map<number, ContinuationClaim>();
     const continuationListeners = new Set<(
       continuationId: number,
@@ -3600,6 +3615,7 @@ export class ClaudeCodeAgent extends BaseAgent {
       claim.state = 'cancelled';
       claim.settled = true;
       activeContinuationId = null;
+      clearWakeContractReconciliation();
       log.info('turn continuation cancelled', { reason, continuationId: claim.id });
       emitContinuationState(claim.id, 'cancelled');
       releaseSettledContinuationClaim(claim);
@@ -3610,6 +3626,7 @@ export class ClaudeCodeAgent extends BaseAgent {
       if (!claim || claim.state !== 'active') return;
       claim.settled = true;
       activeContinuationId = null;
+      clearWakeContractReconciliation();
       log.info('turn continuation settled without a follow-up turn', {
         reason,
         continuationId: claim.id,
@@ -3617,6 +3634,7 @@ export class ClaudeCodeAgent extends BaseAgent {
       releaseSettledContinuationClaim(claim);
     };
     const discardActiveContinuation = (reason: string, forceRelease = false): void => {
+      clearWakeContractReconciliation();
       if (continuationClaims.size > 0) {
         log.debug('discarding turn continuation claims', {
           reason,
@@ -3705,6 +3723,9 @@ export class ClaudeCodeAgent extends BaseAgent {
       continuationClaims.set(claim.id, claim);
       activeContinuationId = claim.id;
       event.turnContinuationId = claim.id;
+      // 从 active 前任 carry 出来的 completed/failed 任务可能已全部终态 —— 下一
+      // 个 continuation 段同样受 wake 契约保护,创建即武装对账。
+      armWakeContractReconciliation(claim);
       // 探针:claim 创建是「continuation 悬挂」vs「done 未到达」的关键区分点。
       // 只记 id / taskId / state 枚举,不记消息文本与 task prompt(脱敏红线)。
       log.info('turn continuation claim created', {
@@ -3723,6 +3744,9 @@ export class ClaudeCodeAgent extends BaseAgent {
       const states = [...claim.tasks.values()];
       // A completed/failed wake task still has the SDK continuation contract;
       // only an all-stopped group proves that a second `done` cannot arrive.
+      // (All-terminal-but-not-stopped groups fall through here and rely on the
+      // timed WAKE_CONTRACT_GRACE_MS reconciliation above: no continuation
+      // activity within the grace window means the contract is broken.)
       // Authority model: q.interrupt ACK is required when user Stop has no
       // provider confirmation and must revoke a completed/failed continuation
       // contract itself. An all-stopped snapshot is already provider-confirmed
@@ -3818,7 +3842,11 @@ export class ClaudeCodeAgent extends BaseAgent {
           (prev?.wake || claim.tasks.has(taskId))
         ) {
           claim.tasks.set(taskId, status);
-          if (claim.state === 'awaiting') return reconcileActiveContinuation();
+          if (claim.state === 'awaiting') {
+            const cancelledClaim = reconcileActiveContinuation();
+            if (!cancelledClaim) armWakeContractReconciliation(claim);
+            return cancelledClaim;
+          }
         }
       }
       return null;
@@ -3843,6 +3871,43 @@ export class ClaudeCodeAgent extends BaseAgent {
         continuationCancellationGeneration = turnState.generation;
         continuationCancellationRequiresQueryRebuild = true;
       }
+    };
+    const claimTasksAllTerminal = (claim: ContinuationClaim): boolean => {
+      if (claim.tasks.size === 0) return false;
+      for (const state of claim.tasks.values()) {
+        if (state === 'running') return false;
+      }
+      return true;
+    };
+    /**
+     * Wake 契约对账:awaiting claim 的全部任务都到终态后,按 task_notification 续跑
+     * 契约顶层 continuation 段应随即开始。起表等待 WAKE_CONTRACT_GRACE_MS,期间
+     * claim 激活/结算/取消/换代都会清表;超时仍未激活即判定契约失守,走与用户 Stop
+     * 相同的取消路径(合成 turn_continuation_cancelled 终态 + cancelled-tail fence),
+     * 让宿主侧收口产品 turn,不再无限等待。
+     */
+    const armWakeContractReconciliation = (claim: ContinuationClaim): void => {
+      if (claim.state !== 'awaiting' || !claimTasksAllTerminal(claim)) return;
+      clearWakeContractReconciliation();
+      wakeContractReconcileTimer = setTimeout(() => {
+        wakeContractReconcileTimer = null;
+        const current = activeContinuationClaim();
+        if (
+          !current ||
+          current.id !== claim.id ||
+          current.state !== 'awaiting' ||
+          !claimTasksAllTerminal(current)
+        ) {
+          return;
+        }
+        log.info('wake contract unfulfilled: all wake tasks terminal without continuation activity', {
+          continuationId: current.id,
+          tasks: [...current.tasks.entries()],
+        });
+        cancelActiveContinuation('wake_contract_unfulfilled');
+        emitCancelledContinuationBoundary(current, 'wake_contract_unfulfilled');
+      }, WAKE_CONTRACT_GRACE_MS);
+      (wakeContractReconcileTimer as unknown as { unref?: () => void }).unref?.();
     };
 
     const releaseEventAccounting = (event: AgentEvent): void => {
@@ -3882,6 +3947,7 @@ export class ClaudeCodeAgent extends BaseAgent {
         continuationClaims.clear();
         continuationListeners.clear();
         pendingContinuationTerminalBoundaries = 0;
+        clearWakeContractReconciliation();
       }
     };
     // 逐个发起 stopTask,但不在这里等待 RPC:interrupt 必须先按控制通道顺序发出。
@@ -4338,6 +4404,7 @@ export class ClaudeCodeAgent extends BaseAgent {
                 consumeTaskNotificationsForActiveSegment(claim);
                 claim.state = 'active';
                 emitContinuationState(claim.id, 'active');
+                clearWakeContractReconciliation();
               }
               log.debug('SDK ▶ turn activity without send — marking auto-continued turn in-flight', {
                 rawType,


### PR DESCRIPTION
## 这次改了什么

### 摘要

后台 wake 型任务（`local_agent` / `local_workflow`，即 Agent tool 后台子任务）到终态后，Cindy 有两层状态都默认「SDK 马上会自动开 wake turn 续跑」：渲染层的 `pendingTaskWake` 桥接跨主轮 Done 存活撑住 running 快照，maker-core 的 `ContinuationClaim` 保持 awaiting 不收口产品 turn。

上游 CLI（claude-code 2.1.219）在「子代理于主 turn 运行中完成」的时机会把 `task-notification` 当 mid-turn 附件消费掉（transcript 证据：`queue-operation enqueue → remove`，通知既不进模型上下文也不留队唤醒），续跑 turn 永远不会来——两层状态各自无限等待，sidebar 永久转圈，且每轮新用户消息只消费 1 个计数，转圈跨多轮回复（2026-08-18 事故形态）。

本 PR 给这两层各加一个超时对账兜底：

- **maker-core**：awaiting claim 的全部任务已到终态、且 `WAKE_CONTRACT_GRACE_MS`（60s）内没有任何续跑活动 → 走既有取消路径（合成 `turn_continuation_cancelled` 终态 + cancelled-tail fence），产品 turn 正常收口。claim 激活 / 取消 / 结算 / 丢弃 / query 换代时清表，不误杀健康续跑（健康路径 dequeue → 顶层活动只需数秒）。
- **renderer**：桥接挂起（`pendingTaskWake > 0` 且会话非 running）时起 `WAKE_BRIDGE_RECONCILE_MS`（60s）对账表；宽限期内 `isTurnStart` 照常消费计数（isRunning 翻 true 即解除），超时仍未启动则清空桥接，让 running 快照收敛为事实（任务卡早已显示终态，不丢信息）。`purgeSession` 清表防悬空定时器。

同时覆盖「终态事件在主轮 Done 之后才到达」的对称泄漏变体（此时无 claim，仅桥接挂起）。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无（用户实测发现：后台子任务完成后会话列表永久转圈、正文声称子任务仍在跑而任务注册表已无此任务）
- 本 PR 包含：maker-core claim 对账、renderer 桥接对账、两侧回归测试
- 明确不包含：上游 CLI 的通知消费 bug 本身（Cindy 侧无法修复「mid-turn 完成的子任务结果自动送回模型」）；检测后主动 re-inject 结果的兜底（行为面改动，需先与 owner 对齐）
- 用户可见变化：上述事故场景下，会话最多 60s 后正常回到「已结束」状态，不再永久转圈；健康路径行为不变
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：不涉及：纯状态机 / 会话运行判定逻辑改动，无视觉、交互或文案变化

## 怎么验证的

### 自动验证

```text
pnpm --filter @cindy/maker-core exec vitest run src/agents/claude-code/__tests__/abort-stops-background-tasks.test.ts
结果：89 passed（含新增 2 项：契约失守收口 / 健康路径不误杀）

pnpm --filter desktop exec vitest run src/renderer/__tests__/makerChatStoreTaskUpdates.test.ts
结果：31 passed（含新增 2 项：超时收口 / 宽限内启动不误伤）

pnpm --filter desktop run typecheck
结果：通过（maker-core 无 typecheck script，按规则跳过）

pnpm test:unit:related
结果：26943 通过 / 6 失败 / 68 跳过。6 个失败集中在 2 个与本改动无路径交集的文件
（claudeOrphanReaper.test.ts ×5、pi-package-store-security.test.ts ×1，后者为 Windows
下创建 symlink 的 EPERM 环境限制）。已做干净树 A/B 对照：暂存本 PR 全部改动后运行
同样的两个文件，失败完全一致（同 79 例隔离复现集），证明为存量环境失败而非本改动
引入；权威门禁以 CI（Linux runner 全量）为准。
```

### 手工验证

不涉及：上游事故依赖特定 CLI 时序（子代理恰在主 turn 运行中完成），行为差异已用单测以合成事件流逐帧锁定；真机等待 60s 的对账收敛路径与单测的 fake-timer 推进等价。

### 未执行的验证

后台子任务真实运行 60s+ 的真机双模式（Light/Dark）目检未执行：本改动不触 UI 渲染路径，仅改 running 快照收敛时机。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：超时对账存在理论误杀窗口（见下）

### 影响与回滚

- 影响范围：仅 Claude Code 会话的后台 wake 任务收口时机（Codex / Pi 不经过这两层，`isWakeAgentTask` 有 provider gate，结构上不受影响）。误杀窗口分析：健康路径里 wake turn 在终态后数秒内启动（实测 transcript dequeue → 响应 ≤ 4s），60s 宽限 >> 该间隙；若极端负载下 wake turn 启动超过 60s，代价是 sidebar 短暂闪一次「已结束→运行中」并可能触发一次 ChatInput 预测，wake turn 本身照常执行，不中断。maker-core 侧若误取消，走的是与用户 Stop 相同的既有取消语义（cancelled-tail fence + 下次 send 重建 Query），有既定恢复路径。
- 回滚 / 降级方式：revert 本 PR 即可回到原行为；两层对账相互独立，也可只回滚单侧。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
