### PR TITLE
fix(desktop): localize create-agent draft input placeholder

### DIFF
--- a/apps/desktop/src/renderer/__tests__/newMakerCreateAgentVisualContract.test.ts
+++ b/apps/desktop/src/renderer/__tests__/newMakerCreateAgentVisualContract.test.ts
@@ -134,7 +134,7 @@ describe('NewMakerDraftRoute CREATE AGENT visual contract', () => {
       'rememberedEffortByModel={isDeviceLinkDraft ? undefined : draft.effortByModel}',
       'onRememberedEffortChange={',
       'isDeviceLinkDraft ? undefined : handleRememberedEffortChange',
-      'placeholder="Hi Cindy!"',
+      "placeholder={t('newChat.chatInput.createAgentPlaceholder')}",
       // 统一模型选择器(M5):新会话的选中直通 + 收藏锚点选中态。撤掉 AgentSelect 后,
       // 「换引擎」这件事只剩这一条路径 —— 掉了它草稿就再也换不了引擎。
       'onUnifiedDraftSelect={handleUnifiedDraftSelect}',

--- a/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
@@ -4953,7 +4953,7 @@ export function NewMakerDraftRoute() {
                     externalDragOver={pageDragOver}
                     visualVariant="create-agent"
                     compactToolbar
-                    placeholder="Hi Cindy!"
+                    placeholder={t('newChat.chatInput.createAgentPlaceholder')}
                     sessionId={undefined}
                     initialWorkingDir={effectiveWorkingDir}
                     remoteHostId={draft.remoteHostId ?? null}

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -6319,6 +6319,7 @@
     },
     "chatInput": {
       "defaultPlaceholder": "What shall we work on today~",
+      "createAgentPlaceholder": "Hi {{appName}}!",
       "voiceInput": {
         "start": "Start voice input",
         "stop": "Stop voice input",

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -6344,6 +6344,7 @@
     },
     "chatInput": {
       "defaultPlaceholder": "今日は何をしましょうか〜",
+      "createAgentPlaceholder": "{{appName}}さん、こんにちは！",
       "voiceInput": {
         "start": "音声入力を開始",
         "stop": "音声入力を停止",

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -6344,6 +6344,7 @@
     },
     "chatInput": {
       "defaultPlaceholder": "오늘은 무엇을 할까요~",
+      "createAgentPlaceholder": "안녕하세요, {{appName}}!",
       "voiceInput": {
         "start": "음성 입력 시작",
         "stop": "음성 입력 중지",

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -6317,6 +6317,7 @@
     },
     "chatInput": {
       "defaultPlaceholder": "今天我们做点什么呢~",
+      "createAgentPlaceholder": "你好，{{appName}}！",
       "voiceInput": {
         "start": "开始语音输入",
         "stop": "停止语音输入",

--- a/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
@@ -6344,6 +6344,7 @@
     },
     "chatInput": {
       "defaultPlaceholder": "今天我們做點什麼呢~",
+      "createAgentPlaceholder": "你好，{{appName}}！",
       "voiceInput": {
         "start": "開始語音輸入",
         "stop": "停止語音輸入",


### PR DESCRIPTION
## 这次改了什么

### 摘要

创建 Agent 草稿路由（`NewMakerDraftRoute`）的输入框占位符硬编码为英文 `'Hi Cindy!'`，非英文 locale 下不会本地化。新增 `newChat.chatInput.createAgentPlaceholder` key 到全部五个 locale（en / ja / ko / zh-CN / zh-TW），组件改用 `t()` 读取，品牌名走 i18n 全局注入的 `{{appName}}` 插值。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：`NewMakerDraftRoute.tsx` 占位符改用 `t()`；五个 locale 的 `common.json` 各新增一条 `createAgentPlaceholder`；同步更新视觉契约测试断言
- 明确不包含：其他硬编码英文字符串的 i18n 清理
- 用户可见变化：非英文 locale 下创建 Agent 草稿输入框占位符将显示本地化文案（英文 locale 渲染结果与改动前完全一致）
- 是否存在 breaking change：无

### UI 变化

英文 locale 下占位符仍渲染为 `Hi Cindy!`（`{{appName}}` 由 i18n `defaultVariables` 全局注入，解析为 `Cindy`），与改动前像素一致，无颜色 / 间距 / 字号 / 布局变化。非英文 locale 仅文案切换为已有 locale 译文。渲染后 DOM 示意：

```html
<!-- en: 与改动前完全一致 -->
<textarea data-testid="chat-input" placeholder="Hi Cindy!"></textarea>

<!-- zh-CN -->
<textarea data-testid="chat-input" placeholder="你好，Cindy！"></textarea>

<!-- ja -->
<textarea data-testid="chat-input" placeholder="Cindyさん、こんにちは！"></textarea>

<!-- ko -->
<textarea data-testid="chat-input" placeholder="안녕하세요, Cindy!"></textarea>

<!-- zh-TW -->
<textarea data-testid="chat-input" placeholder="你好，Cindy！"></textarea>
```

- 引用的设计规范：不涉及：本次为 i18n 遗漏修复，占位符文本内容在英文 locale 下不变，仅将硬编码字符串接入已有的 i18n 管道，不涉及颜色、间距、字号、布局或交互变化。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/renderer/__tests__/newMakerCreateAgentVisualContract.test.ts
结果：15 passed (15)

pnpm --filter desktop run --if-present typecheck
结果：通过，无错误
```

### 手工验证

不涉及——改动为纯文案 i18n 接入，视觉契约测试已覆盖 `placeholder` prop 传递；英文 locale 下 `{{appName}}` 插值由 i18n `defaultVariables` 全局注入（`apps/desktop/src/renderer/i18n/index.ts`），渲染结果与原硬编码一致。

### 未执行的验证

无。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Desktop 创建 Agent 草稿路由的输入框占位符文案
- 回滚 / 降级方式：revert 本 PR 即可，无数据或 schema 变更
