### PR TITLE
fix(im): don't report connecting for transient Discord client errors

### DIFF
--- a/packages/lizi-im/src/discord/__tests__/gateway.test.ts
+++ b/packages/lizi-im/src/discord/__tests__/gateway.test.ts
@@ -207,6 +207,31 @@ describe('discord gateway pure logic', () => {
     await gateway.destroy();
   });
 
+  it('does not flip a ready client to connecting for transient errors', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const { gateway, statuses } = createGatewayHarness();
+
+    try {
+      await gateway.connect('token');
+      const client = discordMock.MockDiscordClient.instances[0];
+      emitReady(client, 'helper#0000');
+
+      statuses.length = 0;
+      expect(() => client.emit('error', new Error('rate limit hiccup'))).not.toThrow();
+      expect(() => client.emit('shardError', new Error('ws hiccup'), 2)).not.toThrow();
+
+      // A healthy, ready client should keep reporting connected for transient
+      // errors; only ShardDisconnect / ShardReconnecting / login failures may
+      // move the status off `connected`. See GitHub issue #2971.
+      expect(statuses).toEqual([]);
+      expect(warn).toHaveBeenCalledWith('[im:discord:gateway]', 'client error: rate limit hiccup');
+      expect(warn).toHaveBeenCalledWith('[im:discord:gateway]', 'shard error shard=2: ws hiccup');
+    } finally {
+      warn.mockRestore();
+      await gateway.destroy();
+    }
+  });
+
   it('does not throw from discord error handlers when status callbacks fail', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
     let rejectStatus = false;

--- a/packages/lizi-im/src/discord/gateway.ts
+++ b/packages/lizi-im/src/discord/gateway.ts
@@ -200,6 +200,14 @@ class DiscordJsGateway implements DiscordGateway {
       // Logging should never make an EventEmitter error handler throw.
     }
 
+    // Events.Error and Events.ShardError can fire for transient issues (rate
+    // limits, momentary network hiccups) while the shard is still healthy and
+    // receiving events. Reporting `connecting` in that case incorrectly arms
+    // the scheduler's reconnect withdrawal timer and stalls ingress for up to
+    // 15s. Only surface `connecting` when the client is no longer usable, as
+    // tracked by discord.js itself. See GitHub issue #2971.
+    if (client.isReady()) return;
+
     try {
       this.ev.onStatus({ kind: 'connecting' });
     } catch {


### PR DESCRIPTION
## Summary
`Events.Error` and `Events.ShardError` can fire for transient issues (rate limits, momentary network hiccups) while the shard is still healthy and receiving messages. Reporting `connecting` in that case arms the scheduler's 15s reconnect withdrawal timer, causing an otherwise healthy gateway to be force-closed. Only report `connecting` when the client is no longer ready.

Fixes #2971

## Tests
- [x] Added regression test
- [x] `pnpm --filter @cindy/im exec vitest run src/discord/__tests__/gateway.test.ts` (14 tests pass)