### PR TITLE
fix(im): handle Discord messages without a channel id

### DIFF
--- a/packages/lizi-im/src/discord/__tests__/inbound.test.ts
+++ b/packages/lizi-im/src/discord/__tests__/inbound.test.ts
@@ -50,7 +50,7 @@ describe('normalizeDmMessage', () => {
       fs.writeFileSync(dest, 'image');
     });
 
-    const event = await normalizeDmMessage(
+    const event = (await normalizeDmMessage(
       message({
         attachments: [
           {
@@ -63,7 +63,7 @@ describe('normalizeDmMessage', () => {
         ],
       }),
       { contextId: 'app-1', mediaDir, download },
-    );
+    ))!;
 
     expect(download).toHaveBeenCalledWith(
       'https://cdn.example/photo.png',
@@ -95,7 +95,7 @@ describe('normalizeDmMessage', () => {
       resolveMediaUrl: vi.fn(() => null),
     };
 
-    const event = await normalizeDmMessage(
+    const event = (await normalizeDmMessage(
       message({
         attachments: [
           { id: 'att-1', name: 'photo.png', url: 'https://cdn.example/photo.png', size: 1024, contentType: 'image/png' },
@@ -103,7 +103,7 @@ describe('normalizeDmMessage', () => {
         ],
       }),
       { contextId: 'app-1', mediaDir, download, media },
-    );
+    ))!;
 
     expect(cacheImage).toHaveBeenCalledTimes(1);
     expect(cacheImage.mock.calls[0][0]).toMatchObject({
@@ -139,14 +139,14 @@ describe('normalizeDmMessage', () => {
       resolveMediaUrl: vi.fn(() => null),
     };
 
-    const event = await normalizeDmMessage(
+    const event = (await normalizeDmMessage(
       message({
         attachments: [
           { id: 'att-1', name: 'photo.png', url: 'https://cdn.example/photo.png', size: 1024, contentType: 'image/png' },
         ],
       }),
       { contextId: 'app-1', mediaDir, download, media },
-    );
+    ))!;
 
     expect(event.attachments[0]).toMatchObject({
       kind: 'image',
@@ -159,7 +159,7 @@ describe('normalizeDmMessage', () => {
   it('marks attachments over 50MiB unsupported without downloading', async () => {
     const download = vi.fn();
 
-    const event = await normalizeDmMessage(
+    const event = (await normalizeDmMessage(
       message({
         attachments: [
           {
@@ -172,7 +172,7 @@ describe('normalizeDmMessage', () => {
         ],
       }),
       { contextId: 'app-1', mediaDir: tempDir(), download },
-    );
+    ))!;
 
     expect(download).not.toHaveBeenCalled();
     expect(event.attachments).toEqual([]);
@@ -180,10 +180,10 @@ describe('normalizeDmMessage', () => {
   });
 
   it('marks stickers unsupported', async () => {
-    const event = await normalizeDmMessage(
+    const event = (await normalizeDmMessage(
       message({ stickers: [{ id: 'sticker-1', name: 'wave' }] }),
       { contextId: 'app-1', mediaDir: tempDir(), download: vi.fn() },
-    );
+    ))!;
 
     expect(event.unsupported).toEqual([{ type: 'sticker', label: 'wave' }]);
   });
@@ -230,6 +230,7 @@ describe('normalizeDmMessage', () => {
       ),
     ]);
 
+    if (!first || !second) throw new Error("expected both messages");
     expect(destinations).toEqual([
       path.join(mediaDir, 'msg-a-image.png'),
       path.join(mediaDir, 'msg-b-image.png'),
@@ -246,7 +247,7 @@ describe('normalizeDmMessage', () => {
       fs.writeFileSync(dest, 'image');
     });
 
-    const event = await normalizeDmMessage(
+    const event = (await normalizeDmMessage(
       message({
         id: 'msg-a',
         attachments: [
@@ -267,7 +268,7 @@ describe('normalizeDmMessage', () => {
         ],
       }),
       { contextId: 'app-1', mediaDir, download },
-    );
+    ))!;
 
     expect(event.attachments.map((a) => a.absPath)).toEqual([
       path.join(mediaDir, 'msg-a-att-1-image.png'),

--- a/packages/lizi-im/src/discord/__tests__/inbound.test.ts
+++ b/packages/lizi-im/src/discord/__tests__/inbound.test.ts
@@ -37,11 +37,30 @@ describe('normalizeDmMessage', () => {
   });
 
   it('returns null when channel id is missing so the transport suppresses it', async () => {
-    const event = await normalizeDmMessage(
+    // `channelId: ''` flows through the helper because `'' ?? 'dm-1'` is `''`
+    // (only null/undefined triggers the default). Asserts an explicit empty
+    // string is treated as a missing channel.
+    const emptyString = await normalizeDmMessage(
       message({ content: 'hello', channelId: '' }),
       { contextId: 'app-1', mediaDir: tempDir(), download: vi.fn() },
     );
-    expect(event).toBeNull();
+    expect(emptyString).toBeNull();
+
+    // A genuinely channel-less event (no channelId and no channel.id) —
+    // e.g. a partial presence update or a guild event leaking past the DM
+    // filter — must also be suppressed. The `message()` helper defaults a
+    // missing channelId to 'dm-1', so construct the raw object directly.
+    const channelLess = await normalizeDmMessage(
+      {
+        id: 'msg-x',
+        content: 'leaked guild text',
+        author: { id: 'user-1' },
+        attachments: [],
+        stickers: [],
+      } as Parameters<typeof normalizeDmMessage>[0],
+      { contextId: 'app-1', mediaDir: tempDir(), download: vi.fn() },
+    );
+    expect(channelLess).toBeNull();
   });
 
   it('downloads image attachments into the media dir', async () => {

--- a/packages/lizi-im/src/discord/__tests__/inbound.test.ts
+++ b/packages/lizi-im/src/discord/__tests__/inbound.test.ts
@@ -36,6 +36,14 @@ describe('normalizeDmMessage', () => {
     });
   });
 
+  it('returns null when channel id is missing so the transport suppresses it', async () => {
+    const event = await normalizeDmMessage(
+      message({ content: 'hello', channelId: '' }),
+      { contextId: 'app-1', mediaDir: tempDir(), download: vi.fn() },
+    );
+    expect(event).toBeNull();
+  });
+
   it('downloads image attachments into the media dir', async () => {
     const mediaDir = tempDir();
     const download = vi.fn(async (_url: string, dest: string) => {

--- a/packages/lizi-im/src/discord/inbound.ts
+++ b/packages/lizi-im/src/discord/inbound.ts
@@ -40,8 +40,15 @@ export async function normalizeDmMessage(
     /** host 媒体总仓(可选):入站图片提升进内容寻址仓,缺省回落 mediaDir。 */
     media?: IMHostMediaCache;
   },
-): Promise<IMMessageEvent> {
+): Promise<IMMessageEvent | null> {
   const chatId = m.channelId ?? m.channel?.id ?? '';
+  if (!chatId) {
+    // Malformed event without a resolvable channel (e.g. partial presence
+    // or guild event leaking through the DM filter). Return null so the
+    // transport suppresses it entirely — emitting an event with an empty
+    // chatId could inject non-DM content into the owner's agent session.
+    return null;
+  }
   const attachments: IMAttachment[] = [];
   const unsupported: IMUnsupportedEntry[] = [];
 

--- a/packages/lizi-im/src/discord/index.ts
+++ b/packages/lizi-im/src/discord/index.ts
@@ -855,6 +855,7 @@ export class DiscordIM extends BaseIM implements ChannelIM {
         download: downloadUrl,
         media: this.host.media,
       });
+      if (!event) return;
       if (
         this.disposing ||
         this.configVersion !== acceptedContext.configVersion ||


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Discord 入站消息在缺少可解析 channel id 时的崩溃:残缺的 presence 事件或漏过 DM 过滤的 guild 事件可能没有 `channelId` / `channel.id`,旧逻辑让 `encodeMessageId('', id)` 抛异常,导致整个 normalization 管线静默丢消息。现在 `normalizeDmMessage` 对无 channel 的事件返回 `null`,Discord transport 在 `index.ts` 直接 `return` 抑制该事件,而不是发出一个 `chatId` 为空的 `IMMessageEvent`(那会把非 DM 内容注入到 owner 的 agent 会话)。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他:

### 范围

- 关联 Issue / 需求:无
- 本 PR 包含:
  - `packages/lizi-im/src/discord/inbound.ts`:`chatId` 为空时返回 `null`,并补充说明为何要在 transport 层抑制而非发出空事件。
  - `packages/lizi-im/src/discord/index.ts`:`normalizeDmMessage` 返回 null 时跳过后续 handlers。
  - 对应回归测试。
- 用户可见变化:无 channel 的畸形 Discord 事件被静默丢弃,不再导致消息处理崩溃。
- 是否存在 breaking change:无。

## 怎么验证的

### 自动验证

- [x] 新增无 channel id 入站事件的回归测试。
- [x] `pnpm --filter @cindy/im exec vitest run src/discord/__tests__/inbound.test.ts`(56 tests passed)。
- [x] 本地 `pnpm test:unit:related` 通过;CI 全量门禁以 PR 检查为准。

### 手工验证

不涉及——畸形事件抑制由单测覆盖。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他:

### 影响与回滚

- 影响面:仅 Discord 入站 normalization 的一个早返回分支,无 channel 的事件本就无法定位会话,抑制是正确收口。
- 回滚:revert 单 PR 即可。
