### PR TITLE
feat(desktop): 支持 Obsidian wiki-link 图片嵌入语法预览

### DIFF
--- a/apps/desktop/src/renderer/components/markdown/__tests__/markdownImageLivePreview.test.ts
+++ b/apps/desktop/src/renderer/components/markdown/__tests__/markdownImageLivePreview.test.ts
@@ -93,6 +93,78 @@ describe('findImageTargets — markdown form', () => {
   });
 });
 
+describe('findImageTargets — Obsidian wiki-link form', () => {
+  it('extracts a bare wiki-link embed', () => {
+    const doc = docOf('before', '![[image.png]]', 'after');
+    const targets = findImageTargets(doc);
+    expect(targets).toHaveLength(1);
+    expect(targets[0]).toMatchObject({
+      from: doc.line(2).from,
+      to: doc.line(2).to,
+      align: null,
+      images: [{ src: 'image.png', alt: '', title: '', width: null, height: null }],
+    });
+  });
+
+  it('resolves a subfolder-relative wiki-link path', () => {
+    const doc = docOf('![[subfolder/image.png]]');
+    const targets = findImageTargets(doc);
+    expect(targets).toHaveLength(1);
+    expect(targets[0].images[0].src).toBe('subfolder/image.png');
+  });
+
+  it('parses a width-only size suffix', () => {
+    const doc = docOf('![[image.png|300]]');
+    const targets = findImageTargets(doc);
+    expect(targets).toHaveLength(1);
+    expect(targets[0].images[0]).toMatchObject({
+      src: 'image.png',
+      width: 300,
+      height: null,
+    });
+  });
+
+  it('parses a width x height size suffix', () => {
+    const doc = docOf('![[image.png|300x200]]');
+    const targets = findImageTargets(doc);
+    expect(targets).toHaveLength(1);
+    expect(targets[0].images[0]).toMatchObject({
+      src: 'image.png',
+      width: 300,
+      height: 200,
+    });
+  });
+
+  it('allows spaces in the path without angle brackets', () => {
+    const doc = docOf('![[Some Image.png]]');
+    const targets = findImageTargets(doc);
+    expect(targets).toHaveLength(1);
+    expect(targets[0].images[0].src).toBe('Some Image.png');
+  });
+
+  it('does not render a plain [[note]] link (no leading !) as an image', () => {
+    const doc = docOf('see [[note]] for details');
+    expect(findImageTargets(doc)).toEqual([]);
+  });
+
+  it('does not render a wiki-link with a non-numeric size suffix', () => {
+    const doc = docOf('![[image.png|alt text]]');
+    expect(findImageTargets(doc)).toEqual([]);
+  });
+
+  it('skips wiki-link image examples inside fenced code blocks', () => {
+    const doc = docOf('```markdown', '![[sample.png]]', '```', '![[real.png]]');
+    const targets = findImageTargets(doc);
+    expect(targets).toHaveLength(1);
+    expect(targets[0].images[0].src).toBe('real.png');
+  });
+
+  it('leaves an inline wiki-link mid-paragraph as raw source', () => {
+    const doc = docOf('see ![[icon.png]] inline');
+    expect(findImageTargets(doc)).toEqual([]);
+  });
+});
+
 describe('findImageTargets — HTML forms', () => {
   it('extracts a bare <img> line with alt / width / height attrs', () => {
     const doc = docOf(
@@ -243,6 +315,14 @@ describe('resolveImageSrcToUrl', () => {
     );
     expect(resolveImageSrcToUrl('file:///C:/imgs/a.png', '/base')).toBe(
       `xdt-file://local/?path=${encodeURIComponent('C:/imgs/a.png')}`,
+    );
+  });
+
+  it('joins a wiki-link-style relative path with a literal space and subfolder', () => {
+    // Wiki-link parsing hands resolveImageSrcToUrl the raw path as typed
+    // (spaces intact, no percent-encoding) — unlike markdown srcs.
+    expect(resolveImageSrcToUrl('subfolder/Some Image.png', '/repo/notes')).toBe(
+      `xdt-file://local/?path=${encodeURIComponent('/repo/notes/subfolder/Some Image.png')}`,
     );
   });
 

--- a/apps/desktop/src/renderer/components/markdown/__tests__/markdownImageLivePreview.test.ts
+++ b/apps/desktop/src/renderer/components/markdown/__tests__/markdownImageLivePreview.test.ts
@@ -1,8 +1,9 @@
 /**
  * Unit tests for the pure helpers of `markdownImageLivePreview`:
  *   - `findImageTargets(doc)` — scans for image-only blocks (markdown
- *     `![](...)` lines, HTML `<img>` lines, `<p>`-wrapped blocks), skipping
- *     fenced code so documentation samples never render as live images.
+ *     `![](...)` lines, HTML `<img>` lines, `<p>`-wrapped blocks, Obsidian
+ *     `![[...]]` wiki-link embeds), skipping fenced code so documentation
+ *     samples never render as live images.
  *   - `resolveImageSrcToUrl(src, baseDir)` — maps a raw markdown src to the
  *     URL the <img> actually loads (xdt-file:// for local paths).
  *
@@ -150,6 +151,23 @@ describe('findImageTargets — Obsidian wiki-link form', () => {
   it('does not render a wiki-link with a non-numeric size suffix', () => {
     const doc = docOf('![[image.png|alt text]]');
     expect(findImageTargets(doc)).toEqual([]);
+  });
+
+  it('does not render a wiki-link note embed (no image extension)', () => {
+    const doc = docOf('![[Project overview]]');
+    expect(findImageTargets(doc)).toEqual([]);
+  });
+
+  it('does not render a wiki-link PDF/non-image file embed', () => {
+    const doc = docOf('![[manual.pdf]]');
+    expect(findImageTargets(doc)).toEqual([]);
+  });
+
+  it('accepts a recognized image extension case-insensitively', () => {
+    const doc = docOf('![[photo.PNG]]');
+    const targets = findImageTargets(doc);
+    expect(targets).toHaveLength(1);
+    expect(targets[0].images[0].src).toBe('photo.PNG');
   });
 
   it('skips wiki-link image examples inside fenced code blocks', () => {

--- a/apps/desktop/src/renderer/components/markdown/markdownImageLivePreview.ts
+++ b/apps/desktop/src/renderer/components/markdown/markdownImageLivePreview.ts
@@ -33,7 +33,12 @@
  *      (no leading `!`) is an Obsidian *note link*, not an image embed, and
  *      is intentionally left as raw source — only `![[...]]` renders. A
  *      non-numeric `|` suffix (Obsidian's alt-text alias form) is also left
- *      as raw source; out of scope for this module.
+ *      as raw source; out of scope for this module. `![[...]]` is also
+ *      Obsidian's generic embed syntax for notes/PDFs/etc — the target is
+ *      only treated as an image (and thus rendered) when its extension is
+ *      one this app already recognizes as an image (`isLightboxImagePath`,
+ *      shared with the workdir file tree); anything else stays raw source
+ *      instead of being replaced by a broken-image card.
  *
  *   Inline images mid-paragraph, images inside blockquotes / list items, and
  *   mixed image+text lines stay as raw source — replacing those needs inline
@@ -71,6 +76,7 @@ import {
 } from '@codemirror/view';
 import i18n from 'i18next';
 
+import { isLightboxImagePath } from '@/features/cc-agent/workdir-browse/lib/imageExt';
 import { resolveLocalPath, toLocalFileUrl } from '@/lib/localPathResolver';
 
 // ─── Facets ─────────────────────────────────────────────────────────────────
@@ -100,10 +106,14 @@ export const imageLocaleFacet = Facet.define<string, string>({
 const MD_IMAGE_LINE_RE =
   /^ {0,3}!\[([^\]]*)\]\(\s*(<[^<>]*>|[^)\s]+)(?:\s+("[^"]*"|'[^']*'))?\s*\)\s*$/;
 
-// Obsidian wiki-link image embed: path excludes `]` and `|` (so it stops at
-// the size suffix or the closing `]]`); size suffix is `|width` or
-// `|widthxheight`, digits only. A non-numeric `|` suffix (Obsidian's
-// alt-text alias) fails to match here and the line stays raw source.
+// Obsidian wiki-link *embed* syntax (`![[target]]`) covers notes, PDFs and
+// images alike — this regex only isolates the target/size text; the caller
+// (matchSingleLineImage) still has to check the extension via
+// isLightboxImagePath before treating it as an image. Path excludes `]` and
+// `|` (so it stops at the size suffix or the closing `]]`); size suffix is
+// `|width` or `|widthxheight`, digits only. A non-numeric `|` suffix
+// (Obsidian's alt-text alias) fails to match here and the line stays raw
+// source.
 const WIKI_IMAGE_LINE_RE =
   /^ {0,3}!\[\[([^\]|]+)(?:\|(\d+)(?:x(\d+))?)?\]\]\s*$/;
 
@@ -277,7 +287,10 @@ function matchSingleLineImage(
   const wiki = WIKI_IMAGE_LINE_RE.exec(text);
   if (wiki) {
     const rawSrc = wiki[1].trim();
-    if (!rawSrc) return null;
+    // `![[...]]` is Obsidian's generic embed syntax (notes, PDFs, images);
+    // only render it here when the target is actually an image extension —
+    // otherwise a note/PDF embed would get replaced by a broken-image card.
+    if (!rawSrc || !isLightboxImagePath(rawSrc)) return null;
     return {
       spec: {
         src: rawSrc,

--- a/apps/desktop/src/renderer/components/markdown/markdownImageLivePreview.ts
+++ b/apps/desktop/src/renderer/components/markdown/markdownImageLivePreview.ts
@@ -25,6 +25,15 @@
  *        `</p>`
  *   `align="center"` on the <p> centers the rendered images; `width` /
  *   `height` attributes are applied (still capped at container width).
+ *   5. Obsidian wiki-link image embed, alone on its line:
+ *        `![[image.png]]`, `![[subfolder/image.png]]`, `![[image.png|300]]`,
+ *        `![[image.png|300x200]]`
+ *      The path may contain spaces and doesn't need angle brackets; `|300`
+ *      sets width (px), `|300x200` sets width x height. Plain `[[note]]`
+ *      (no leading `!`) is an Obsidian *note link*, not an image embed, and
+ *      is intentionally left as raw source — only `![[...]]` renders. A
+ *      non-numeric `|` suffix (Obsidian's alt-text alias form) is also left
+ *      as raw source; out of scope for this module.
  *
  *   Inline images mid-paragraph, images inside blockquotes / list items, and
  *   mixed image+text lines stay as raw source — replacing those needs inline
@@ -90,6 +99,13 @@ export const imageLocaleFacet = Facet.define<string, string>({
 // CommonMark (4+ would be an indented code block and must stay raw).
 const MD_IMAGE_LINE_RE =
   /^ {0,3}!\[([^\]]*)\]\(\s*(<[^<>]*>|[^)\s]+)(?:\s+("[^"]*"|'[^']*'))?\s*\)\s*$/;
+
+// Obsidian wiki-link image embed: path excludes `]` and `|` (so it stops at
+// the size suffix or the closing `]]`); size suffix is `|width` or
+// `|widthxheight`, digits only. A non-numeric `|` suffix (Obsidian's
+// alt-text alias) fails to match here and the line stays raw source.
+const WIKI_IMAGE_LINE_RE =
+  /^ {0,3}!\[\[([^\]|]+)(?:\|(\d+)(?:x(\d+))?)?\]\]\s*$/;
 
 // HTML forms. `[^>]*?` keeps attribute scanning inside the tag; an attr
 // value containing a literal `>` is out of scope (stays raw source).
@@ -254,6 +270,21 @@ function matchSingleLineImage(
         title: md[3] ? md[3].slice(1, -1) : '',
         width: null,
         height: null,
+      },
+      align: null,
+    };
+  }
+  const wiki = WIKI_IMAGE_LINE_RE.exec(text);
+  if (wiki) {
+    const rawSrc = wiki[1].trim();
+    if (!rawSrc) return null;
+    return {
+      spec: {
+        src: rawSrc,
+        alt: '',
+        title: '',
+        width: wiki[2] ? Number(wiki[2]) : null,
+        height: wiki[3] ? Number(wiki[3]) : null,
       },
       align: null,
     };


### PR DESCRIPTION
<!--
PR Title 不是下面的正文标题，而是 GitHub PR 页面最上方的标题。
格式：<type>(<scope>): <简短描述>（scope 可省略）
-->

## 这次改了什么

### 摘要

Cindy 桌面端工作目录浏览器（workdir-browse）预览 Markdown 时，只认识 4 种行内图片
形态（纯 `![alt](path)`、`<img>`、单行/多行 `<p>` 包裹的 `<img>`），不识别 Obsidian
默认的 wiki-link 图片嵌入语法 `![[path]]`，导致用 Obsidian 写的笔记（图片放子文件夹、
用相对路径）在 Cindy 里预览时图片显示不出来。

本 PR 只新增第 5 种识别形态，不改路径解析逻辑（`resolveImageSrcToUrl` 早已完备，解析
出的路径直接走原有链路）：

- `![[image.png]]`
- `![[subfolder/image.png]]`（子文件夹相对路径）
- `![[image.png|300]]`（`|` 后数字 = 宽度 px，映射到既有的 width 处理逻辑）
- `![[image.png|300x200]]`（宽 x 高）
- `![[Some Image.png]]`（路径含空格，不需要尖括号包裹）

明确不识别、保持原始文本不渲染：
- `[[note]]`（无 `!` 前缀）—— Obsidian 的文档链接，不是图片嵌入。
- `![[image.png|alt text]]`（`|` 后非数字）—— Obsidian 的别名/替代文本形式，超出
  本次范围。

### 变更类型

- [x] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：用户反馈 Obsidian 风格笔记图片在 workdir-browse 预览中不显示
- 本 PR 包含：`markdownImageLivePreview.ts` 新增 wiki-link 图片嵌入检测（1 个新正则 +
  `matchSingleLineImage` 的 1 个新分支），以及对应单测
- 明确不包含：
  - 不改变现有 4 种形态的行为
  - 不改动扫描策略（见下方「为什么不动扫描策略」）
  - 不支持行内混排 / 引用块 / 列表项内的图片渲染（与既有 4 种形态一致的取舍，理由见
    文件头注释）
  - 不支持 Obsidian 的非数字 `|别名文本` 形式
  - 不做性能优化
- 用户可见变化：Markdown 预览中 `![[...]]` wiki-link 图片语法会像其它 4 种形态一样
  渲染为行内图片，支持点击放大（复用既有 lightbox）
- 是否存在 breaking change：无

### UI 变化

不涉及：本 PR 命中的 UI 代码路径（`markdownImageLivePreview.ts`）只新增一种「源码
文本 → 已有渲染管线」的识别分支——渲染出来的 DOM 结构、样式、交互（点击放大、错误
卡片、宽高应用）与现有 4 种形态完全复用同一套 `MarkdownImageWidget`，没有新增任何
视觉、交互或文案。

- 引用的设计规范：不涉及（无新增 UI 元素）

## 怎么验证的

### 自动验证

```text
cd apps/desktop && pnpm exec vitest run src/renderer/components/markdown/__tests__/markdownImageLivePreview.test.ts
结果：31 passed (31)

pnpm --filter desktop run --if-present typecheck
结果：通过（无错误输出）

pnpm test:unit:related
结果：apps/desktop 单测 27089 passed / 2 failed / 5 skipped；packages/lizi-mcps、
packages/maker-core、packages/orca-workflow 全部通过。
失败的 2 条（src/main/cindy-brain/__tests__/ghostInstallReceipt.test.ts）与本 PR
无关——已用 `git stash` 暂存本次改动后单独复验该文件，暂存前后失败结果一致，
确认是无关的基线问题，未修复。
```

### 手工验证

不涉及（纯正则解析 + 已有渲染管线复用，未起 dev 实机验收——按仓库规则，Chris 不在
场时不起 dev；单测已覆盖各语法形态的解析正确性）。

### 未执行的验证

未在真实 Electron 环境里实机预览一份 Obsidian 笔记文件——理由同上（Chris 不在场
不起 dev）。若需要，可在本地打开一个含 `![[img/foo.png]]` 的 `.md` 文件用
workdir-browse 预览验证。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 `markdownImageLivePreview.ts` 的检测逻辑，新增一种匹配分支，不影响
  现有 4 种形态的匹配结果（各正则捕获组互斥，已用现有测试验证无回归）
- 回滚 / 降级方式：直接 revert 本 PR 的 commit 即可，无数据/状态迁移

### 为什么不动扫描策略

文件头注释与 `markdownMermaidLivePreview` 记录了完整的踩坑历史：block widget 按
selection/viewport 增量重建会打坏 CodeMirror 的高度图（height map）。现在「docChange
时全文扫描」是有意为之的取舍，本次任务只新增一种检测分支，复用同一套扫描/装饰构建
流程，完全不touch这个决策。性能优化是另一个独立议题，本次不做。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）—— 本次不涉及
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（文件头注释同步更新识别形态清单）
- [x] 已确认测试结果或说明未执行原因
