### PR TITLE
fix(desktop): 隐藏任务菜单的 Pi 专属入口

### DIFF
--- a/apps/desktop/src/renderer/__tests__/sessionAgentSwitchRemoteRouting.test.ts
+++ b/apps/desktop/src/renderer/__tests__/sessionAgentSwitchRemoteRouting.test.ts
@@ -998,7 +998,7 @@ describe('CCAgentSessionView 上下文环压缩入口按 agent 能力分流(#192
     expect(viewSource).toContain('if (!begun) return;');
     expect(viewSource).toContain('compactRequestGuard.isCurrent(sourceSessionId, begun.epoch)');
     expect(viewSource).toContain('begun.release();');
-    // 真实 reject 必须 catch 并显示 compactFailed(与 SessionContentHeader 一致)。
+    // 真实 reject 必须 catch 并显示 compactFailed。
     expect(viewSource).toContain("toast.warning(t('ccAgent.sidebar.sessionMenu.compactFailed'))");
   });
 

--- a/apps/desktop/src/renderer/__tests__/sessionHeaderMenuParity.test.ts
+++ b/apps/desktop/src/renderer/__tests__/sessionHeaderMenuParity.test.ts
@@ -27,21 +27,21 @@ const sessionCardSource = readFileSync(
 const NON_MENU_KEY_PATTERN = /(?:Done|Failed|Blocked|Unsupported|Nothing)$/;
 const NON_MENU_KEYS = new Set(['moreActions']);
 
-// Pi 专属入口暂不进 overflow 菜单(任务分支 / 导出 HTML / 压缩上下文)。压缩仍走
-// 对话区 context ring;分支树与 HTML 导出保留后端能力。用精确 label 调用守卫,
-// 避免 compactSuccess 这类 toast key 被前缀误伤。
+// Pi 专属入口暂不进 overflow 菜单(导出 HTML / 压缩上下文)。压缩仍走对话区
+// context ring。任务分支只在存在 Cindy 分叉家族时显示,仍是头部专属项。
+// 用精确 label 调用守卫,避免 compactSuccess 这类 toast key 被前缀误伤。
 const HIDDEN_PI_MENU_LABELS = [
-  "t('ccAgent.sidebar.sessionMenu.sessionBranches')",
   "t('ccAgent.sidebar.sessionMenu.exportHtml')",
   "t('ccAgent.sidebar.sessionMenu.compact')",
   "t('ccAgent.sidebar.sessionMenu.compacting')",
 ] as const;
+const HEADER_ONLY_KEYS = new Set(['sessionBranches']);
 
 function collectSessionMenuKeys(source: string): Set<string> {
   const keys = new Set<string>();
   for (const match of source.matchAll(/ccAgent\.sidebar\.sessionMenu\.(\w+)/g)) {
     const key = match[1];
-    if (NON_MENU_KEYS.has(key) || NON_MENU_KEY_PATTERN.test(key)) continue;
+    if (NON_MENU_KEYS.has(key) || HEADER_ONLY_KEYS.has(key) || NON_MENU_KEY_PATTERN.test(key)) continue;
     keys.add(key);
   }
   return keys;
@@ -62,6 +62,14 @@ describe('session menu parity across header and sidebar variants', () => {
         expect(source).not.toContain(label);
       }
     }
+  });
+
+  it('keeps the Cindy fork-family branch entry in the header only', () => {
+    expect(headerSource).toContain("t('ccAgent.sidebar.sessionMenu.sessionBranches')");
+    expect(headerSource).toContain('canShowBranchTree = !isEmpty && hasSessionFamily');
+    expect(headerSource).not.toContain("agentKind === 'pi' || hasSessionFamily");
+    expect(sessionItemSource).not.toContain("t('ccAgent.sidebar.sessionMenu.sessionBranches')");
+    expect(sessionCardSource).not.toContain("t('ccAgent.sidebar.sessionMenu.sessionBranches')");
   });
 
   it('reuses the shared submenu / export dialog / menu style modules', () => {

--- a/apps/desktop/src/renderer/__tests__/sessionHeaderMenuParity.test.ts
+++ b/apps/desktop/src/renderer/__tests__/sessionHeaderMenuParity.test.ts
@@ -66,6 +66,8 @@ describe('session menu parity across header and sidebar variants', () => {
 
   it('keeps the Cindy fork-family branch entry in the header only', () => {
     expect(headerSource).toContain("t('ccAgent.sidebar.sessionMenu.sessionBranches')");
+    expect(headerSource).toContain("useCCSessions({ includeArchived: 'all' })");
+    expect(headerSource).toContain('Boolean(session.parentSessionId)');
     expect(headerSource).toContain('canShowBranchTree = !isEmpty && hasSessionFamily');
     expect(headerSource).not.toContain("agentKind === 'pi' || hasSessionFamily");
     expect(sessionItemSource).not.toContain("t('ccAgent.sidebar.sessionMenu.sessionBranches')");

--- a/apps/desktop/src/renderer/__tests__/sessionHeaderMenuParity.test.ts
+++ b/apps/desktop/src/renderer/__tests__/sessionHeaderMenuParity.test.ts
@@ -23,24 +23,25 @@ const sessionCardSource = readFileSync(
 //   - moreActions:SessionItem 行内 ··· 按钮的 aria-label(header 用自己的
 //     ccAgent.sessionHeader.moreActions)
 //   - *Done / *Failed / *Blocked / *Unsupported / *Nothing:动作的 toast 反馈文案
-//     (header 的 move/compact/export handler 内联在组件里,非菜单项)
+//     (header 的 move/export handler 内联在组件里,非菜单项)
 const NON_MENU_KEY_PATTERN = /(?:Done|Failed|Blocked|Unsupported|Nothing)$/;
 const NON_MENU_KEYS = new Set(['moreActions']);
 
-// 头部专属菜单项:只对「当前打开的 live 会话」有意义(据 capability 门控,如 pi 原生
-// 导出 HTML / 手动压缩),侧栏右键菜单作用于任意列表会话、无对应能力,故不要求同步。
-// 连同各自的进行中/成功态反馈文案一并排除。
-const HEADER_ONLY_KEYS = new Set([
-  'exportHtml', 'exportHtmlSuccess',
-  'compact', 'compacting', 'compactSuccess', 'compactSuccessWithTokens',
-  'sessionBranches',
-]);
+// Pi 专属入口暂不进 overflow 菜单(任务分支 / 导出 HTML / 压缩上下文)。压缩仍走
+// 对话区 context ring;分支树与 HTML 导出保留后端能力。用精确 label 调用守卫,
+// 避免 compactSuccess 这类 toast key 被前缀误伤。
+const HIDDEN_PI_MENU_LABELS = [
+  "t('ccAgent.sidebar.sessionMenu.sessionBranches')",
+  "t('ccAgent.sidebar.sessionMenu.exportHtml')",
+  "t('ccAgent.sidebar.sessionMenu.compact')",
+  "t('ccAgent.sidebar.sessionMenu.compacting')",
+] as const;
 
 function collectSessionMenuKeys(source: string): Set<string> {
   const keys = new Set<string>();
   for (const match of source.matchAll(/ccAgent\.sidebar\.sessionMenu\.(\w+)/g)) {
     const key = match[1];
-    if (NON_MENU_KEYS.has(key) || HEADER_ONLY_KEYS.has(key) || NON_MENU_KEY_PATTERN.test(key)) continue;
+    if (NON_MENU_KEYS.has(key) || NON_MENU_KEY_PATTERN.test(key)) continue;
     keys.add(key);
   }
   return keys;
@@ -53,6 +54,14 @@ describe('session menu parity across header and sidebar variants', () => {
     const cardKeys = collectSessionMenuKeys(sessionCardSource);
     expect([...headerKeys].sort()).toEqual([...sidebarKeys].sort());
     expect([...headerKeys].sort()).toEqual([...cardKeys].sort());
+  });
+
+  it('keeps Pi-only extras out of header and sidebar overflow menus', () => {
+    for (const source of [headerSource, sessionItemSource, sessionCardSource]) {
+      for (const label of HIDDEN_PI_MENU_LABELS) {
+        expect(source).not.toContain(label);
+      }
+    }
   });
 
   it('reuses the shared submenu / export dialog / menu style modules', () => {

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
@@ -3293,7 +3293,7 @@ export function CCAgentSessionView({
           // null:会话无 live 进程 / 不支持(入口已按 gate 隐藏,极少走到)。静默即可。
         } catch (err) {
           if (!compactRequestGuard.isCurrent(sourceSessionId, begun.epoch)) return;
-          // 与 SessionContentHeader 的手动压缩一致:失败给可理解提示,不泄漏裸 IPC 错误。
+          // 失败给可理解提示,不泄漏裸 IPC 错误。
           log.warn('context ring compact-session failed', err);
           toast.warning(t('ccAgent.sidebar.sessionMenu.compactFailed'));
         }

--- a/apps/desktop/src/renderer/features/cc-agent/SessionContentHeader.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/SessionContentHeader.tsx
@@ -78,7 +78,6 @@ import {
 import { SessionProjectMoveSubmenu } from './sidebar/SessionProjectMoveSubmenu';
 import type { SessionMoveTarget } from './sidebar/sessionMoveTarget';
 import { SessionShareExportDialog } from './sidebar/SessionShareExportDialog';
-import { SessionBranchTreeDialog } from './SessionBranchTreeDialog';
 import { useRemoteProjectSessions } from '@/features/device-link/remoteProjectsStore';
 import { isRemoteSessionWriteBlocked } from './lib/remoteSessionWriteGuard';
 import { Tip } from '@/components/ui/tooltip';
@@ -157,19 +156,6 @@ export function SessionContentHeader({
     !session.remoteHostId &&
     session.orcaRole !== 'worker' &&
     !session.deviceLinkDeviceId;
-  // 导出 HTML:pi 原生 export_html。仅当前打开的本地 pi 会话(需 live 进程应答 RPC),
-  // 排除空会话 / 远程 / device-link / archived(archived 无 live 进程)。
-  const canExportHtml =
-    session.agentKind === 'pi' &&
-    !isEmpty &&
-    !session.remoteHostId &&
-    !session.deviceLinkDeviceId &&
-    !isArchived;
-  // 手动压缩:pi 原生 compact,同一 live 本地 pi 会话前提(斜杠转义后用户无法手输
-  // /compact,这是 pi 会话手动压缩的唯一入口)。回合运行中 pi 拒绝压缩 → 禁用而非隐藏。
-  const canCompact = canExportHtml;
-  const [compacting, setCompacting] = useState(false);
-  const compactDisabled = compacting || runningSessionIds.has(session.id);
   const projectOptions = useProjectPickerOptions();
   // heartbeat schedule 绑定标识,与 SessionItem 同源数据;删除/过期后自动消失。
   const boundSchedules = useSessionBoundSchedules(session.id);
@@ -396,71 +382,6 @@ export function SessionContentHeader({
 
   /* ---- 导出会话(.cshare)---- 弹窗仅打开时挂载,与 SessionItem 同款。 */
   const [shareExportOpen, setShareExportOpen] = useState(false);
-  const [branchTreeOpen, setBranchTreeOpen] = useState(false);
-  const allKnownSessions = useMemo(
-    () => [...sessions, ...remoteProjectSessions],
-    [remoteProjectSessions, sessions],
-  );
-  const hasSessionFamily = useMemo(
-    () =>
-      allKnownSessions.some(
-        (item) => item.parentSessionId === session.id || item.id === session.parentSessionId,
-      ),
-    [allKnownSessions, session.id, session.parentSessionId],
-  );
-  const canShowBranchTree = !isEmpty && (session.agentKind === 'pi' || hasSessionFamily);
-
-  /* ---- 手动压缩(pi 原生 compact)---- 长操作(LLM 摘要),压缩边界经事件流自动进聊天;
-   * 回合运行中 pi 会拒绝,菜单项据 running 态禁用。compacting 状态在上方派生区声明。 */
-  const handleCompactSession = useCallback(async () => {
-    if (compacting) return;
-    setCompacting(true);
-    try {
-      const result = await window.electronAPI.maker.compactSession(session.id);
-      if (result?.noop) {
-        // 良性:上下文太小,无可压缩内容。信息性提示,不是失败。
-        toast.info(t('ccAgent.sidebar.sessionMenu.compactNothing'));
-      } else if (result) {
-        const hasNumbers =
-          typeof result.tokensBefore === 'number' &&
-          typeof result.estimatedTokensAfter === 'number';
-        toast.success(
-          hasNumbers
-            ? t('ccAgent.sidebar.sessionMenu.compactSuccessWithTokens', {
-                before: Math.round((result.tokensBefore ?? 0) / 1000),
-                after: Math.round((result.estimatedTokensAfter ?? 0) / 1000),
-              })
-            : t('ccAgent.sidebar.sessionMenu.compactSuccess'),
-        );
-      }
-      // null:会话无 live 进程 / 不支持(入口已按 gate 隐藏,极少走到)。静默即可。
-    } catch (err) {
-      log.warn('manual compact failed', err);
-      toast.warning(t('ccAgent.sidebar.sessionMenu.compactFailed'));
-    } finally {
-      setCompacting(false);
-    }
-  }, [compacting, session.id, t]);
-
-  /* ---- 导出 HTML(pi 原生 export_html)---- 主进程弹保存对话框 + 导出 + 在文件管理器显示。 */
-  const [exportingHtml, setExportingHtml] = useState(false);
-  const handleExportHtml = useCallback(async () => {
-    if (exportingHtml) return;
-    setExportingHtml(true);
-    try {
-      const written = await window.electronAPI.maker.exportSessionHtml(session.id);
-      if (written) {
-        toast.success(t('ccAgent.sidebar.sessionMenu.exportHtmlSuccess'));
-      }
-      // written == null:用户取消保存对话框,或会话无 live 进程(未打开)。取消是正常路径,
-      // 不打扰;后者极少(本入口只对当前打开会话可见),静默即可。
-    } catch (err) {
-      log.warn('export session html failed', err);
-      toast.warning(t('ccAgent.sidebar.sessionMenu.exportHtmlFailed'));
-    } finally {
-      setExportingHtml(false);
-    }
-  }, [exportingHtml, session.id, t]);
 
   /* ---- Archive / Delete / Unarchive ----
    * 执行序列共用 useSessionLifecycleActions（与 CCAgentSidebarUpper 同一实现）；
@@ -667,7 +588,9 @@ export function SessionContentHeader({
                 - Archived：Rename / Unarchive / [导出会话] / Copy ‖ Delete
                 - Draft：Rename / Copy ‖ Delete
                 - 标准：Pin↔Unpin / Rename / [移动到项目 ▸] ‖ Copy / 新窗口打开 /
-                  [导出会话] ‖ Archive / Delete */}
+                  [导出会话] ‖ Archive / Delete
+                Pi 专属入口（任务分支 / 导出 HTML / 压缩上下文）暂不进 overflow 菜单。
+                压缩仍走对话区 context ring；分支树与 HTML 导出保留后端能力。 */}
             {isArchived ? (
               <>
                 <DropdownMenuItem
@@ -698,14 +621,6 @@ export function SessionContentHeader({
                 >
                   {t('ccAgent.sidebar.sessionMenu.copySessionLink')}
                 </DropdownMenuItem>
-                {canShowBranchTree && (
-                  <DropdownMenuItem
-                    onSelect={() => setBranchTreeOpen(true)}
-                    className={MENU_ITEM_CLASS}
-                  >
-                    {t('ccAgent.sidebar.sessionMenu.sessionBranches')}
-                  </DropdownMenuItem>
-                )}
                 <DropdownMenuSeparator className={MENU_SEPARATOR_CLASS} />
                 <DropdownMenuItem
                   disabled={remoteWritesBlocked}
@@ -801,40 +716,12 @@ export function SessionContentHeader({
                 >
                   {t('ccAgent.sidebar.sessionMenu.openInNewWindow')}
                 </DropdownMenuItem>
-                {canShowBranchTree && (
-                  <DropdownMenuItem
-                    onSelect={() => setBranchTreeOpen(true)}
-                    className={MENU_ITEM_CLASS}
-                  >
-                    {t('ccAgent.sidebar.sessionMenu.sessionBranches')}
-                  </DropdownMenuItem>
-                )}
                 {canExportShare && (
                   <DropdownMenuItem
                     onSelect={() => setShareExportOpen(true)}
                     className={MENU_ITEM_CLASS}
                   >
                     {t('ccAgent.sidebar.sessionMenu.exportShare')}
-                  </DropdownMenuItem>
-                )}
-                {canExportHtml && (
-                  <DropdownMenuItem
-                    disabled={exportingHtml}
-                    onSelect={() => void handleExportHtml()}
-                    className={MENU_ITEM_CLASS}
-                  >
-                    {t('ccAgent.sidebar.sessionMenu.exportHtml')}
-                  </DropdownMenuItem>
-                )}
-                {canCompact && (
-                  <DropdownMenuItem
-                    disabled={compactDisabled}
-                    onSelect={() => void handleCompactSession()}
-                    className={MENU_ITEM_CLASS}
-                  >
-                    {compacting
-                      ? t('ccAgent.sidebar.sessionMenu.compacting')
-                      : t('ccAgent.sidebar.sessionMenu.compact')}
                   </DropdownMenuItem>
                 )}
                 <DropdownMenuSeparator className={MENU_SEPARATOR_CLASS} />
@@ -867,16 +754,6 @@ export function SessionContentHeader({
           open={shareExportOpen}
           sessionId={session.id}
           onOpenChange={setShareExportOpen}
-        />
-      )}
-      {branchTreeOpen && (
-        <SessionBranchTreeDialog
-          open={branchTreeOpen}
-          onOpenChange={setBranchTreeOpen}
-          session={session}
-          sessions={allKnownSessions}
-          running={runningSessionIds.has(session.id)}
-          writeBlocked={remoteWritesBlocked}
         />
       )}
     </div>

--- a/apps/desktop/src/renderer/features/cc-agent/SessionContentHeader.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/SessionContentHeader.tsx
@@ -127,6 +127,9 @@ export function SessionContentHeader({
 }: SessionContentHeaderProps) {
   const { t } = useTranslation();
   const { sessions, patchLocal } = useCCSessions();
+  // 分叉家族要看见已归档的父/子任务,不能只扫 active 桶。与 sidebar attention
+  // / SplitGroup 同一口径,复用已有 includeArchived:'all',不另造加载通道。
+  const { sessions: familySessions } = useCCSessions({ includeArchived: 'all' });
   const remoteProjectSessions = useRemoteProjectSessions();
   const routeSessionById = useMemo(
     () => new Map([...sessions, ...remoteProjectSessions].map((s) => [s.id, s])),
@@ -385,18 +388,20 @@ export function SessionContentHeader({
   const [shareExportOpen, setShareExportOpen] = useState(false);
   const [branchTreeOpen, setBranchTreeOpen] = useState(false);
   const allKnownSessions = useMemo(
-    () => [...sessions, ...remoteProjectSessions],
-    [remoteProjectSessions, sessions],
+    () => [...familySessions, ...remoteProjectSessions],
+    [familySessions, remoteProjectSessions],
   );
   const hasSessionFamily = useMemo(
     () =>
+      Boolean(session.parentSessionId) ||
       allKnownSessions.some(
         (item) => item.parentSessionId === session.id || item.id === session.parentSessionId,
       ),
     [allKnownSessions, session.id, session.parentSessionId],
   );
   // 只给 Cindy 任务分叉家族保留入口。Pi 原生 branch tree 不再单凭 agentKind=pi 露出,
-  // 避免普通 Pi 任务把 overflow 撑长；有父子任务时仍可打开统一树。
+  // 避免普通 Pi 任务把 overflow 撑长。当前任务带 parentSessionId,或 all 桶里能扫到
+  // 父/子(含归档),都算家族成员。
   const canShowBranchTree = !isEmpty && hasSessionFamily;
 
   /* ---- Archive / Delete / Unarchive ----

--- a/apps/desktop/src/renderer/features/cc-agent/SessionContentHeader.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/SessionContentHeader.tsx
@@ -78,6 +78,7 @@ import {
 import { SessionProjectMoveSubmenu } from './sidebar/SessionProjectMoveSubmenu';
 import type { SessionMoveTarget } from './sidebar/sessionMoveTarget';
 import { SessionShareExportDialog } from './sidebar/SessionShareExportDialog';
+import { SessionBranchTreeDialog } from './SessionBranchTreeDialog';
 import { useRemoteProjectSessions } from '@/features/device-link/remoteProjectsStore';
 import { isRemoteSessionWriteBlocked } from './lib/remoteSessionWriteGuard';
 import { Tip } from '@/components/ui/tooltip';
@@ -382,6 +383,21 @@ export function SessionContentHeader({
 
   /* ---- 导出会话(.cshare)---- 弹窗仅打开时挂载,与 SessionItem 同款。 */
   const [shareExportOpen, setShareExportOpen] = useState(false);
+  const [branchTreeOpen, setBranchTreeOpen] = useState(false);
+  const allKnownSessions = useMemo(
+    () => [...sessions, ...remoteProjectSessions],
+    [remoteProjectSessions, sessions],
+  );
+  const hasSessionFamily = useMemo(
+    () =>
+      allKnownSessions.some(
+        (item) => item.parentSessionId === session.id || item.id === session.parentSessionId,
+      ),
+    [allKnownSessions, session.id, session.parentSessionId],
+  );
+  // 只给 Cindy 任务分叉家族保留入口。Pi 原生 branch tree 不再单凭 agentKind=pi 露出,
+  // 避免普通 Pi 任务把 overflow 撑长；有父子任务时仍可打开统一树。
+  const canShowBranchTree = !isEmpty && hasSessionFamily;
 
   /* ---- Archive / Delete / Unarchive ----
    * 执行序列共用 useSessionLifecycleActions（与 CCAgentSidebarUpper 同一实现）；
@@ -589,8 +605,8 @@ export function SessionContentHeader({
                 - Draft：Rename / Copy ‖ Delete
                 - 标准：Pin↔Unpin / Rename / [移动到项目 ▸] ‖ Copy / 新窗口打开 /
                   [导出会话] ‖ Archive / Delete
-                Pi 专属入口（任务分支 / 导出 HTML / 压缩上下文）暂不进 overflow 菜单。
-                压缩仍走对话区 context ring；分支树与 HTML 导出保留后端能力。 */}
+                Pi 专属入口（导出 HTML / 压缩上下文）暂不进 overflow 菜单。
+                压缩仍走对话区 context ring。任务分支只在存在 Cindy 分叉家族时显示。 */}
             {isArchived ? (
               <>
                 <DropdownMenuItem
@@ -621,6 +637,14 @@ export function SessionContentHeader({
                 >
                   {t('ccAgent.sidebar.sessionMenu.copySessionLink')}
                 </DropdownMenuItem>
+                {canShowBranchTree && (
+                  <DropdownMenuItem
+                    onSelect={() => setBranchTreeOpen(true)}
+                    className={MENU_ITEM_CLASS}
+                  >
+                    {t('ccAgent.sidebar.sessionMenu.sessionBranches')}
+                  </DropdownMenuItem>
+                )}
                 <DropdownMenuSeparator className={MENU_SEPARATOR_CLASS} />
                 <DropdownMenuItem
                   disabled={remoteWritesBlocked}
@@ -716,6 +740,14 @@ export function SessionContentHeader({
                 >
                   {t('ccAgent.sidebar.sessionMenu.openInNewWindow')}
                 </DropdownMenuItem>
+                {canShowBranchTree && (
+                  <DropdownMenuItem
+                    onSelect={() => setBranchTreeOpen(true)}
+                    className={MENU_ITEM_CLASS}
+                  >
+                    {t('ccAgent.sidebar.sessionMenu.sessionBranches')}
+                  </DropdownMenuItem>
+                )}
                 {canExportShare && (
                   <DropdownMenuItem
                     onSelect={() => setShareExportOpen(true)}
@@ -754,6 +786,16 @@ export function SessionContentHeader({
           open={shareExportOpen}
           sessionId={session.id}
           onOpenChange={setShareExportOpen}
+        />
+      )}
+      {branchTreeOpen && (
+        <SessionBranchTreeDialog
+          open={branchTreeOpen}
+          onOpenChange={setBranchTreeOpen}
+          session={session}
+          sessions={allKnownSessions}
+          running={runningSessionIds.has(session.id)}
+          writeBlocked={remoteWritesBlocked}
         />
       )}
     </div>

--- a/docs/dev-rules/pi-harness.md
+++ b/docs/dev-rules/pi-harness.md
@@ -222,6 +222,7 @@ Pi home 复用。settings/packages/extensions 仍属于后续独立安全评审�
   user-provider 派生 → pi-host `resolvePiNativeProviders` → PiAgent writeModelsJson 原生块 +
   provider 感知 setModel。真二进制测试证明直连原生端点、网关零请求。
 - ✅ **统一会话树**(已交付):Cindy session fork 与 Pi append-only entry tree 的后端/
-  对话框实现仍在;会话头部 overflow「任务分支」入口暂隐。支持原生分支切换、可选分支摘要、
-  选中 user entry 回填原 prompt、SQLite 可见时间线原子重投影与上下文 usage 恢复;
-  device-link / mobile transport contract 同步开放。切换不回滚工作区文件。
+  对话框实现仍在。头部 overflow「任务分支」只在存在 Cindy 分叉家族时显示,不再单凭
+  `agentKind=pi` 露出。支持原生分支切换、可选分支摘要、选中 user entry 回填原 prompt、
+  SQLite 可见时间线原子重投影与上下文 usage 恢复;device-link / mobile transport
+  contract 同步开放。切换不回滚工作区文件。

--- a/docs/dev-rules/pi-harness.md
+++ b/docs/dev-rules/pi-harness.md
@@ -199,13 +199,13 @@ Pi home 复用。settings/packages/extensions 仍属于后续独立安全评审�
 
 > 续做指南(每项怎么接着做 + file:line 锚点 + 坑)见 `docs/dev-rules/pi-remaining-work.md`。
 
-- ✅ **HTML 导出**(已交付):`export_html` RPC 全链路,会话头部菜单「导出为 HTML」,
-  仅当前打开的本地 pi 会话可见。见 `Capabilities.sessionHtmlExport` /
+- ✅ **HTML 导出**(已交付):`export_html` RPC 全链路仍在。会话头部 overflow 菜单入口暂隐
+  (Pi 专属项先不进 `···`)。见 `Capabilities.sessionHtmlExport` /
   `Session.exportSessionHtml` / `MAKER_INVOKE.EXPORT_SESSION_HTML`。
-- ✅ **手动压缩**(已交付):`compact` RPC 全链路,会话头部菜单「压缩上下文」,gate 同
-  HTML 导出、回合运行中禁用。良性「nothing to compact / too small」→ `noop`(不报失败)。
+- ✅ **手动压缩**(已交付):`compact` RPC 全链路仍在。头部 overflow 菜单入口暂隐;对话区
+  context ring 仍可点按压缩。良性「nothing to compact / too small」→ `noop`(不报失败)。
   见 `Capabilities.manualCompact` / `Session.compactSession` / `MAKER_INVOKE.COMPACT_SESSION`。
-  注:pi 斜杠转义后用户无法手输 `/compact`,此菜单是 pi 会话手动压缩的唯一入口。
+  注:pi 斜杠转义后用户无法手输 `/compact`,context ring 是当前 Pi 会话手动压缩入口。
 - ✅ **subagent 接 pi 轻量引擎**(已交付):Orca worker 可选 `pi` 引擎。核心链路(MCP
   schema / worker 创建服务 / 默认模型 claude-sonnet-4-6 / PiAgent 注册)本已按 AgentKind
   接通;本次补齐 UI(CreateWorkerPopover / composer「+」菜单协同项 / draft 映射)、两个
@@ -221,7 +221,7 @@ Pi home 复用。settings/packages/extensions 仍属于后续独立安全评审�
   链路:CustomProviderDialog pi tab(+ api 选择器)→ custom-provider-store(pi runtime)→
   user-provider 派生 → pi-host `resolvePiNativeProviders` → PiAgent writeModelsJson 原生块 +
   provider 感知 setModel。真二进制测试证明直连原生端点、网关零请求。
-- ✅ **统一会话树**(已交付):会话头部「会话分支」把 Cindy 原有 session fork 与当前 Pi
-  append-only entry tree 嵌在同一棵树中。支持原生分支切换、可选分支摘要、选中 user entry
-  回填原 prompt、SQLite 可见时间线原子重投影与上下文 usage 恢复;device-link / mobile
-  transport contract 同步开放。切换不回滚工作区文件。
+- ✅ **统一会话树**(已交付):Cindy session fork 与 Pi append-only entry tree 的后端/
+  对话框实现仍在;会话头部 overflow「任务分支」入口暂隐。支持原生分支切换、可选分支摘要、
+  选中 user entry 回填原 prompt、SQLite 可见时间线原子重投影与上下文 usage 恢复;
+  device-link / mobile transport contract 同步开放。切换不回滚工作区文件。

--- a/docs/dev-rules/pi-remaining-work.md
+++ b/docs/dev-rules/pi-remaining-work.md
@@ -70,9 +70,9 @@ auto fail-closed、成本派生链、弹窗正文 harness 无关)。
   BYOM 会话中途切回网关模型 401。改为仅 anthropic/openai/xai 用占位符,BYOM/自定义拿真网关 key。
 - **保留 `cindy` provider id**(custom-provider-store.ts RESERVED_IDS):撞 pi 网关 provider id
   会让其模型既被排除出网关块又不写原生块 → `--model` 校验失败。
-- **两处源码契约测试同步 pi 改动**:`sessionHeaderMenuParity`(Pi 专属 overflow 项暂隐,
-  头部与侧栏条目对齐)、`automationGeneratedSessions`(自动组头图标改用
-  `agentKindToVendor`,pi 会话显示 π)。
+- **两处源码契约测试同步 pi 改动**:`sessionHeaderMenuParity`(导出 HTML / 压缩暂隐;
+  任务分支只在 Cindy 分叉家族时显示,仍是头部专属)、`automationGeneratedSessions`(
+  自动组头图标改用 `agentKindToVendor`,pi 会话显示 π)。
 
 **已评估暂不修(设计权衡 / 边缘,后续按需)**:
 - **#2 已解决 — 纯 BYOM 不依赖网关 key**:`getState` 按 custom provider runtime 校验自身

--- a/docs/dev-rules/pi-remaining-work.md
+++ b/docs/dev-rules/pi-remaining-work.md
@@ -70,8 +70,8 @@ auto fail-closed、成本派生链、弹窗正文 harness 无关)。
   BYOM 会话中途切回网关模型 401。改为仅 anthropic/openai/xai 用占位符,BYOM/自定义拿真网关 key。
 - **保留 `cindy` provider id**(custom-provider-store.ts RESERVED_IDS):撞 pi 网关 provider id
   会让其模型既被排除出网关块又不写原生块 → `--model` 校验失败。
-- **两处源码契约测试同步 pi 改动**:`sessionHeaderMenuParity`(导出 HTML / 手动压缩是头部专属
-  live-session 菜单项,不要求侧栏同步)、`automationGeneratedSessions`(自动组头图标改用
+- **两处源码契约测试同步 pi 改动**:`sessionHeaderMenuParity`(Pi 专属 overflow 项暂隐,
+  头部与侧栏条目对齐)、`automationGeneratedSessions`(自动组头图标改用
   `agentKindToVendor`,pi 会话显示 π)。
 
 **已评估暂不修(设计权衡 / 边缘,后续按需)**:


### PR DESCRIPTION
## 这次改了什么

### 摘要

Pi 任务顶栏 `···` 菜单被「任务分支 / 导出为 HTML / 压缩上下文」撑得很长。这三项先从 overflow 菜单拿掉，让顶栏和侧栏右键对齐。压缩仍可从对话区 context 圆环点；分支树与 HTML 导出的后端能力保留，只是暂时没有菜单入口。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无（产品侧要求先隐藏 Pi 专属 overflow 项）
- 本 PR 包含：从 `SessionContentHeader` overflow 菜单移除三项 Pi 专属入口，并补菜单对齐守卫
- 明确不包含：删除 Pi 分支树 / HTML 导出 / compact RPC；不改侧栏右键；不改 context ring 压缩
- 用户可见变化：Pi 任务顶栏 `···` 不再出现「任务分支」「导出为 HTML…」「压缩上下文」
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：`docs/design-rules/DESIGN.md` §1 Visual Theme & Atmosphere — “Extreme content restraint — each surface presents one clear idea”；“strip away everything unnecessary until only the essential tool remains”。Pi 专属能力不该默认挤进与侧栏共用的任务 overflow 菜单。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop run typecheck
结果：通过

pnpm test:unit:related
结果：通过（含 sessionHeaderMenuParity / sessionAgentSwitchRemoteRouting）

pnpm check:dco
结果：通过（1 commit signed off）
```

### 手工验证

未在运行中的宿主 Cindy 里点菜单。改动在独立 worktree，需重启该 worktree 的 Desktop 才能看到。

### 未执行的验证

本地全量 `pnpm test:unit` 在 `ghostInstallReceipt.test.ts` 的 2 条断言失败。该文件本 PR 未改；同一 2 条在本地 `main` checkout 上复现。与本次菜单改动无关，交给 CI 给权威结论，不混入修复。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop 任务顶栏 overflow 菜单。Pi 任务暂时没有「任务分支 / 导出 HTML」界面入口；压缩仍走 context ring。
- 回滚 / 降级方式：revert 本 PR 即可恢复三项菜单。
- 存量插件影响：无

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
