### PR TITLE
feat(mobile): XD 组织默认开启 beta

### DIFF
--- a/apps/mobile/src/auth/AuthContext.tsx
+++ b/apps/mobile/src/auth/AuthContext.tsx
@@ -304,6 +304,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const accountDeletionReceiptMutationRef = useRef<Promise<void>>(
     Promise.resolve(),
   );
+  // OAuth deep link、常规登录和冷启动恢复可并发到达。第一次调用必须在创建
+  // device ID 前记录新旧设备状态；后续调用复用同一次 beta 偏好迁移。
+  const betaChannelPreparationRef = useRef<Promise<string> | null>(null);
 
   const suspendSessionRecoveryForLogin = useCallback(() => {
     if (sessionRecoverySuspendedRef.current) return;
@@ -336,6 +339,27 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     [],
   );
 
+  const prepareBetaChannelForCurrentDevice = useCallback((): Promise<string> => {
+    const existing = betaChannelPreparationRef.current;
+    if (existing) return existing;
+    const run = (async () => {
+      const hadExistingDeviceId = await hasStoredDeviceId();
+      const did = await ensureDeviceId();
+      // beta 偏好存储异常不能拖垮认证启动；失败时 store 保持 migration hold，
+      // 只会保守地不自动开 beta。
+      await prepareBetaChannelForDevice({ hadExistingDeviceId }).catch(
+        () => undefined,
+      );
+      return did;
+    })();
+    betaChannelPreparationRef.current = run;
+    run.catch(() => {
+      if (betaChannelPreparationRef.current === run)
+        betaChannelPreparationRef.current = null;
+    });
+    return run;
+  }, []);
+
   /** 登录态落地后为 xd 组织尝试打开设备级 beta；不阻塞主界面。 */
   const scheduleXdOrgBetaDefault = useCallback(
     (token: string, expectedAuthGeneration: number) => {
@@ -343,34 +367,37 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       const currentUser = userRef.current;
       if (!currentUser) return;
       const expectedUserId = currentUser.id;
-      void maybeEnableXdOrgBetaDefault(
-        {
-          expectedAuthGeneration,
-          expectedUserId,
-          user: {
-            membershipKind: currentUser.membershipKind,
-            orgSlug: decodeJwtOrgSlug(token),
-            orgName: currentUser.orgName,
+      void (async () => {
+        await prepareBetaChannelForCurrentDevice();
+        await maybeEnableXdOrgBetaDefault(
+          {
+            expectedAuthGeneration,
+            expectedUserId,
+            user: {
+              membershipKind: currentUser.membershipKind,
+              orgSlug: decodeJwtOrgSlug(token),
+              orgName: currentUser.orgName,
+            },
           },
-        },
-        {
-          readCurrentAuthIdentity: () => ({
-            authGeneration: authGenerationRef.current,
-            userId: userRef.current?.id ?? null,
-          }),
-          readChannelState: readBetaChannelState,
-          probeBetaManifest: () =>
-            probeBetaChannel(Platform.OS === 'android' ? 'android' : 'ios'),
-          enableBeta: () =>
-            enableUncustomizedBetaChannel(
-              () =>
-                authGenerationRef.current === expectedAuthGeneration &&
-                userRef.current?.id === expectedUserId,
-            ),
-        },
-      ).catch(() => undefined);
+          {
+            readCurrentAuthIdentity: () => ({
+              authGeneration: authGenerationRef.current,
+              userId: userRef.current?.id ?? null,
+            }),
+            readChannelState: readBetaChannelState,
+            probeBetaManifest: () =>
+              probeBetaChannel(Platform.OS === 'android' ? 'android' : 'ios'),
+            enableBeta: () =>
+              enableUncustomizedBetaChannel(
+                () =>
+                  authGenerationRef.current === expectedAuthGeneration &&
+                  userRef.current?.id === expectedUserId,
+              ),
+          },
+        );
+      })().catch(() => undefined);
     },
-    [],
+    [prepareBetaChannelForCurrentDevice],
   );
 
   const serializeRefreshTokenMutation = useCallback(
@@ -674,16 +701,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     const run = async () => {
       setIsBusy(true);
       try {
-        const hadExistingDeviceId = await hasStoredDeviceId();
-        const did = await ensureDeviceId();
+        const did = await prepareBetaChannelForCurrentDevice();
         if (cancelled || sessionRecoverySuspendedRef.current) return;
         deviceIdRef.current = did;
         setDeviceId(did);
-        // beta 偏好存储异常不能拖垮认证启动；失败时 store 保持 migration hold，
-        // 只会保守地不自动开 beta。
-        await prepareBetaChannelForDevice({ hadExistingDeviceId }).catch(
-          () => undefined,
-        );
         // Old Feishu refresh tokens are not valid in auth-server. Purge them explicitly
         // instead of sending them to the new endpoint or restoring an unrelated profile.
         await Promise.all([
@@ -802,7 +823,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     return () => {
       cancelled = true;
     };
-  }, [refresh]);
+  }, [prepareBetaChannelForCurrentDevice, refresh]);
 
   // 降级会话自愈:已安全发布的缓存用户，或因跨区清单失败而延迟发布的会话，
   // 都以退避节奏和回前台时机重试。
@@ -991,7 +1012,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         setIsBusy(true);
         setAuthError(null);
         try {
-          const did = deviceIdRef.current ?? (await ensureDeviceId());
+          const did =
+            deviceIdRef.current ?? (await prepareBetaChannelForCurrentDevice());
           deviceIdRef.current = did;
           setDeviceId(did);
           const startsBuildRealmFlow =
@@ -1411,6 +1433,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     [
       acceptOutcome,
       completeOAuthCallback,
+      prepareBetaChannelForCurrentDevice,
       suspendSessionRecoveryForLogin,
       updateLoginState,
     ],

--- a/apps/mobile/src/auth/AuthContext.tsx
+++ b/apps/mobile/src/auth/AuthContext.tsx
@@ -10,7 +10,7 @@ import {
   useState,
   type ReactNode,
 } from 'react';
-import { AppState, Linking } from 'react-native';
+import { AppState, Linking, Platform } from 'react-native';
 import {
   AuthApiError,
   CindyAuthClient,
@@ -59,8 +59,9 @@ import {
   resetMobileSessionRealm,
 } from '@/config/env';
 import { syncCanaryChannelAfterAuth } from '@/auth/canaryChannelSync';
-import { ensureDeviceId } from '@/auth/deviceId';
-import { isAccessTokenExpiring } from '@/auth/jwt';
+import { ensureDeviceId, hasStoredDeviceId } from '@/auth/deviceId';
+import { decodeJwtOrgSlug, isAccessTokenExpiring } from '@/auth/jwt';
+import { maybeEnableXdOrgBetaDefault } from '@/auth/xdOrgBetaDefault';
 import { getAuthLocale } from '@/auth/loginMessages';
 import { acquireNativeSocialCredential } from '@/auth/nativeSocial';
 import {
@@ -100,6 +101,12 @@ import {
   clearCanaryChannel,
   syncCanaryChannel,
 } from '@/update/canaryChannelStore';
+import {
+  prepareBetaChannelForDevice,
+  enableUncustomizedBetaChannel,
+  readBetaChannelState,
+} from '@/update/betaChannelStore';
+import { probeBetaChannel } from '@/update/fetchLatestRelease';
 
 WebBrowser.maybeCompleteAuthSession();
 
@@ -329,6 +336,43 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     [],
   );
 
+  /** 登录态落地后为 xd 组织尝试打开设备级 beta；不阻塞主界面。 */
+  const scheduleXdOrgBetaDefault = useCallback(
+    (token: string, expectedAuthGeneration: number) => {
+      if (!IS_OTA_SELFHOST) return;
+      const currentUser = userRef.current;
+      if (!currentUser) return;
+      const expectedUserId = currentUser.id;
+      void maybeEnableXdOrgBetaDefault(
+        {
+          expectedAuthGeneration,
+          expectedUserId,
+          user: {
+            membershipKind: currentUser.membershipKind,
+            orgSlug: decodeJwtOrgSlug(token),
+            orgName: currentUser.orgName,
+          },
+        },
+        {
+          readCurrentAuthIdentity: () => ({
+            authGeneration: authGenerationRef.current,
+            userId: userRef.current?.id ?? null,
+          }),
+          readChannelState: readBetaChannelState,
+          probeBetaManifest: () =>
+            probeBetaChannel(Platform.OS === 'android' ? 'android' : 'ios'),
+          enableBeta: () =>
+            enableUncustomizedBetaChannel(
+              () =>
+                authGenerationRef.current === expectedAuthGeneration &&
+                userRef.current?.id === expectedUserId,
+            ),
+        },
+      ).catch(() => undefined);
+    },
+    [],
+  );
+
   const serializeRefreshTokenMutation = useCallback(
     <T,>(operation: () => Promise<T>): Promise<T> => {
       const run = refreshTokenMutationRef.current.then(operation, operation);
@@ -535,6 +579,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       );
       sessionRecoverySuspendedRef.current = false;
       scheduleCanaryChannelSync(outcome.accessToken, generation);
+      scheduleXdOrgBetaDefault(outcome.accessToken, generation);
       updateLoginState(
         reduceAuthFlow(loginStateRef.current, { type: 'outcome', outcome }),
       );
@@ -549,6 +594,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       loadMe,
       persistAccountDeletionReceipt,
       scheduleCanaryChannelSync,
+      scheduleXdOrgBetaDefault,
       serializeRefreshTokenMutation,
       setToken,
       updateLoginState,
@@ -597,6 +643,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
             mergeMembershipWithExisting(pair.membership, userRef.current),
           );
           scheduleCanaryChannelSync(pair.accessToken, generation);
+          scheduleXdOrgBetaDefault(pair.accessToken, generation);
           void loadMe(pair.accessToken, did, generation).catch(() => undefined);
           return pair.accessToken;
         } catch (error) {
@@ -616,6 +663,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       applyUser,
       loadMe,
       scheduleCanaryChannelSync,
+      scheduleXdOrgBetaDefault,
       serializeRefreshTokenMutation,
       setToken,
     ],
@@ -626,10 +674,16 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     const run = async () => {
       setIsBusy(true);
       try {
+        const hadExistingDeviceId = await hasStoredDeviceId();
         const did = await ensureDeviceId();
         if (cancelled || sessionRecoverySuspendedRef.current) return;
         deviceIdRef.current = did;
         setDeviceId(did);
+        // beta 偏好存储异常不能拖垮认证启动；失败时 store 保持 migration hold，
+        // 只会保守地不自动开 beta。
+        await prepareBetaChannelForDevice({ hadExistingDeviceId }).catch(
+          () => undefined,
+        );
         // Old Feishu refresh tokens are not valid in auth-server. Purge them explicitly
         // instead of sending them to the new endpoint or restoring an unrelated profile.
         await Promise.all([
@@ -1369,12 +1423,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     // 残留由 server 侧 APNs 410 回收与换账号重注册的让位逻辑兜底。
     // Invalidate in-flight remote creates before any async logout cleanup begins.
     setMobileAuthOwner(null);
+    // 同步失效认证代次，必须早于第一个 await。否则推送 token 注销的网络等待窗口内，
+    // 迟到的 canary / XD beta 探测仍会把旧账号结果写回本地。
+    authGenerationRef.current += 1;
+    refreshInFlightRef.current = null;
     await unregisterPushTokenBestEffort(
       accessTokenRef.current,
       activeAuthRealmRef.current,
     );
-    authGenerationRef.current += 1;
-    refreshInFlightRef.current = null;
     setToken(null);
     applyUser(null);
     updateLoginState(null);

--- a/apps/mobile/src/auth/__tests__/jwt.test.ts
+++ b/apps/mobile/src/auth/__tests__/jwt.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { ACCESS_TOKEN_EXPIRY_SKEW_MS, decodeJwtExpMs, isAccessTokenExpiring } from '../jwt';
+import {
+  ACCESS_TOKEN_EXPIRY_SKEW_MS,
+  decodeJwtExpMs,
+  decodeJwtOrgSlug,
+  isAccessTokenExpiring,
+} from '../jwt';
 
 function b64url(obj: object): string {
   return Buffer.from(JSON.stringify(obj))
@@ -16,6 +21,17 @@ function makeJwt(payload: object): string {
 const NOW = 1_700_000_000_000; // epoch ms == 1_700_000_000 s
 
 describe('jwt helpers', () => {
+  it('decodes a non-empty orgSlug claim', () => {
+    expect(decodeJwtOrgSlug(makeJwt({ ctx: 'org', orgSlug: 'xd' }))).toBe('xd');
+  });
+
+  it('returns null for missing/invalid orgSlug or malformed tokens', () => {
+    expect(decodeJwtOrgSlug(makeJwt({ sub: 'x' }))).toBeNull();
+    expect(decodeJwtOrgSlug(makeJwt({ orgSlug: '' }))).toBeNull();
+    expect(decodeJwtOrgSlug(makeJwt({ orgSlug: 42 }))).toBeNull();
+    expect(decodeJwtOrgSlug('not-a-jwt')).toBeNull();
+  });
+
   it('decodes a numeric exp (seconds) into epoch ms', () => {
     expect(decodeJwtExpMs(makeJwt({ exp: 1_700_000_000 }))).toBe(1_700_000_000_000);
   });

--- a/apps/mobile/src/auth/__tests__/xdOrgBetaWiring.test.ts
+++ b/apps/mobile/src/auth/__tests__/xdOrgBetaWiring.test.ts
@@ -9,16 +9,44 @@ const source = readFileSync(
 );
 
 describe('AuthContext xd org beta wiring', () => {
-  it('prepares device migration before restoring the session', () => {
-    const hasDevice = source.indexOf('await hasStoredDeviceId()');
+  it('shares beta migration before cold start or login uses a device id', () => {
+    const preparation = source.indexOf(
+      'const prepareBetaChannelForCurrentDevice = useCallback',
+    );
+    const hasDevice = source.indexOf('await hasStoredDeviceId()', preparation);
     const ensureDevice = source.indexOf('await ensureDeviceId()', hasDevice);
-    const prepareBeta = source.indexOf('await prepareBetaChannelForDevice(');
+    const prepareBeta = source.indexOf(
+      'await prepareBetaChannelForDevice(',
+      ensureDevice,
+    );
+    const coldStart = source.indexOf(
+      'const did = await prepareBetaChannelForCurrentDevice();',
+    );
+    const login = source.indexOf(
+      'await prepareBetaChannelForCurrentDevice()',
+      coldStart + 1,
+    );
     const readSession = source.indexOf('let storedSession = await readPersistedAuthSession()');
 
+    expect(preparation).toBeGreaterThan(-1);
     expect(hasDevice).toBeGreaterThan(-1);
     expect(ensureDevice).toBeGreaterThan(hasDevice);
     expect(prepareBeta).toBeGreaterThan(ensureDevice);
-    expect(readSession).toBeGreaterThan(prepareBeta);
+    expect(coldStart).toBeGreaterThan(preparation);
+    expect(login).toBeGreaterThan(coldStart);
+    expect(readSession).toBeGreaterThan(coldStart);
+  });
+
+  it('waits for device migration before trying the xd default', () => {
+    const schedule = source.indexOf('const scheduleXdOrgBetaDefault = useCallback');
+    const waitForPreparation = source.indexOf(
+      'await prepareBetaChannelForCurrentDevice();',
+      schedule,
+    );
+    const applyDefault = source.indexOf('await maybeEnableXdOrgBetaDefault(', schedule);
+
+    expect(waitForPreparation).toBeGreaterThan(schedule);
+    expect(applyDefault).toBeGreaterThan(waitForPreparation);
   });
 
   it('schedules the xd default after both login and refresh identity are applied', () => {

--- a/apps/mobile/src/auth/__tests__/xdOrgBetaWiring.test.ts
+++ b/apps/mobile/src/auth/__tests__/xdOrgBetaWiring.test.ts
@@ -1,0 +1,64 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const source = readFileSync(
+  resolve(process.cwd(), 'src/auth/AuthContext.tsx'),
+  'utf8',
+);
+
+describe('AuthContext xd org beta wiring', () => {
+  it('prepares device migration before restoring the session', () => {
+    const hasDevice = source.indexOf('await hasStoredDeviceId()');
+    const ensureDevice = source.indexOf('await ensureDeviceId()', hasDevice);
+    const prepareBeta = source.indexOf('await prepareBetaChannelForDevice(');
+    const readSession = source.indexOf('let storedSession = await readPersistedAuthSession()');
+
+    expect(hasDevice).toBeGreaterThan(-1);
+    expect(ensureDevice).toBeGreaterThan(hasDevice);
+    expect(prepareBeta).toBeGreaterThan(ensureDevice);
+    expect(readSession).toBeGreaterThan(prepareBeta);
+  });
+
+  it('schedules the xd default after both login and refresh identity are applied', () => {
+    expect(source.match(/scheduleXdOrgBetaDefault\([^)]*generation\);/g)).toHaveLength(2);
+
+    const loginApply = source.indexOf('mergeMembershipWithExisting(outcome.membership');
+    const loginSchedule = source.indexOf(
+      'scheduleXdOrgBetaDefault(outcome.accessToken, generation);',
+    );
+    expect(loginSchedule).toBeGreaterThan(loginApply);
+
+    const refreshApply = source.indexOf('mergeMembershipWithExisting(pair.membership');
+    const refreshSchedule = source.indexOf(
+      'scheduleXdOrgBetaDefault(pair.accessToken, generation);',
+    );
+    expect(refreshSchedule).toBeGreaterThan(refreshApply);
+  });
+
+  it('rechecks generation and user id before the automatic write', () => {
+    expect(source).toContain(
+      'authGenerationRef.current === expectedAuthGeneration &&',
+    );
+    expect(source).toContain('userRef.current?.id === expectedUserId');
+  });
+
+  it('invalidates auth before logout performs asynchronous cleanup', () => {
+    const clearLocalSession = source.indexOf(
+      'const clearLocalSession = useCallback(async () => {',
+    );
+    const invalidateAuth = source.indexOf(
+      'authGenerationRef.current += 1;',
+      clearLocalSession,
+    );
+    const unregisterPush = source.indexOf(
+      'await unregisterPushTokenBestEffort(',
+      clearLocalSession,
+    );
+
+    expect(clearLocalSession).toBeGreaterThan(-1);
+    expect(invalidateAuth).toBeGreaterThan(clearLocalSession);
+    expect(unregisterPush).toBeGreaterThan(invalidateAuth);
+  });
+});

--- a/apps/mobile/src/auth/deviceId.ts
+++ b/apps/mobile/src/auth/deviceId.ts
@@ -3,6 +3,13 @@ import { getSecureItem, setSecureItem } from '@/auth/secureStorage';
 
 const DEVICE_ID_KEY = 'xdt.mobile.deviceId';
 
+/** 读取设备是否已经存在；读取失败按“已有设备”处理，避免误判新装机而自动开 beta。 */
+export async function hasStoredDeviceId(): Promise<boolean> {
+  return getSecureItem(DEVICE_ID_KEY)
+    .then((value) => Boolean(value))
+    .catch(() => true);
+}
+
 export async function ensureDeviceId(): Promise<string> {
   const existing = await getSecureItem(DEVICE_ID_KEY).catch(() => null);
   if (existing) return existing;

--- a/apps/mobile/src/auth/jwt.ts
+++ b/apps/mobile/src/auth/jwt.ts
@@ -22,6 +22,22 @@ function base64UrlDecode(segment: string): string | null {
   }
 }
 
+/** 读取 access token 的组织稳定标识；个人身份、旧 token 或解码失败返回 null。 */
+export function decodeJwtOrgSlug(token: string): string | null {
+  const parts = token.split('.');
+  if (parts.length < 2) return null;
+  const json = base64UrlDecode(parts[1]);
+  if (json === null) return null;
+  try {
+    const payload = JSON.parse(json) as { orgSlug?: unknown };
+    return typeof payload.orgSlug === 'string' && payload.orgSlug.length > 0
+      ? payload.orgSlug
+      : null;
+  } catch {
+    return null;
+  }
+}
+
 /** The token's `exp` claim in epoch milliseconds, or null when it can't be determined. */
 export function decodeJwtExpMs(token: string): number | null {
   const parts = token.split('.');

--- a/apps/mobile/src/auth/xdOrgBetaDefault.test.ts
+++ b/apps/mobile/src/auth/xdOrgBetaDefault.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  isXdOrgUser,
+  maybeEnableXdOrgBetaDefault,
+  type XdOrgBetaDefaultDeps,
+  type XdOrgBetaUser,
+} from './xdOrgBetaDefault';
+
+const XD_USER: XdOrgBetaUser = {
+  membershipKind: 'org',
+  orgSlug: 'xd',
+  orgName: '心动网络',
+};
+
+function deps(
+  overrides: Partial<XdOrgBetaDefaultDeps> = {},
+): XdOrgBetaDefaultDeps {
+  return {
+    readCurrentAuthIdentity: () => ({ authGeneration: 3, userId: 'user-1' }),
+    readChannelState: () => ({ enableBeta: false, isCustomized: false }),
+    probeBetaManifest: async () => true,
+    enableBeta: async () => true,
+    ...overrides,
+  };
+}
+
+describe('xd org beta default', () => {
+  it('orgSlug 是权威身份，只在缺失时回退组织名', () => {
+    expect(isXdOrgUser(XD_USER)).toBe(true);
+    expect(isXdOrgUser({ ...XD_USER, orgSlug: 'other' })).toBe(false);
+    expect(isXdOrgUser({ ...XD_USER, orgSlug: null, orgName: ' XD ' })).toBe(true);
+    expect(isXdOrgUser({ ...XD_USER, membershipKind: 'personal' })).toBe(false);
+  });
+
+  it('当前未自定义的 xd 身份且 beta 可用时开启', async () => {
+    await expect(
+      maybeEnableXdOrgBetaDefault(
+        { expectedAuthGeneration: 3, expectedUserId: 'user-1', user: XD_USER },
+        deps(),
+      ),
+    ).resolves.toEqual({ kind: 'enabled' });
+  });
+
+  it('保留用户 opt-out，并拒绝迟到身份', async () => {
+    await expect(
+      maybeEnableXdOrgBetaDefault(
+        { expectedAuthGeneration: 3, expectedUserId: 'user-1', user: XD_USER },
+        deps({ readChannelState: () => ({ enableBeta: false, isCustomized: true }) }),
+      ),
+    ).resolves.toEqual({ kind: 'skipped', reason: 'user-customized' });
+
+    await expect(
+      maybeEnableXdOrgBetaDefault(
+        { expectedAuthGeneration: 3, expectedUserId: 'user-1', user: XD_USER },
+        deps({
+          readCurrentAuthIdentity: () => ({ authGeneration: 4, userId: 'user-2' }),
+        }),
+      ),
+    ).resolves.toEqual({ kind: 'skipped', reason: 'stale-auth' });
+  });
+});

--- a/apps/mobile/src/auth/xdOrgBetaDefault.ts
+++ b/apps/mobile/src/auth/xdOrgBetaDefault.ts
@@ -1,0 +1,86 @@
+/** Mobile 登录后为 xd 组织补设备级 beta 默认值的纯策略。 */
+
+const XD_ORG_SLUG = 'xd';
+const XD_ORG_NAME_FALLBACKS = new Set(['xd', '心动网络']);
+
+export interface XdOrgBetaUser {
+  membershipKind: 'personal' | 'org';
+  orgSlug: string | null;
+  orgName: string | null;
+}
+
+export interface XdOrgBetaDefaultRequest {
+  expectedAuthGeneration: number;
+  expectedUserId: string;
+  user: XdOrgBetaUser;
+}
+
+export interface XdOrgBetaDefaultDeps {
+  readCurrentAuthIdentity(): { authGeneration: number; userId: string | null };
+  readChannelState(): { enableBeta: boolean; isCustomized: boolean };
+  probeBetaManifest(): Promise<boolean>;
+  enableBeta(): boolean | Promise<boolean>;
+}
+
+export type XdOrgBetaDefaultOutcome =
+  | { kind: 'enabled' }
+  | {
+      kind: 'skipped';
+      reason:
+        | 'not-xd-org'
+        | 'already-enabled'
+        | 'user-customized'
+        | 'beta-unavailable'
+        | 'stale-auth';
+    };
+
+export function isXdOrgUser(user: XdOrgBetaUser | null | undefined): boolean {
+  if (!user || user.membershipKind !== 'org') return false;
+  if (user.orgSlug !== null) return user.orgSlug === XD_ORG_SLUG;
+  const name = user.orgName?.trim().toLocaleLowerCase();
+  return name !== undefined && XD_ORG_NAME_FALLBACKS.has(name);
+}
+
+function isCurrentAuth(
+  request: XdOrgBetaDefaultRequest,
+  deps: XdOrgBetaDefaultDeps,
+): boolean {
+  const current = deps.readCurrentAuthIdentity();
+  return current.authGeneration === request.expectedAuthGeneration
+    && current.userId === request.expectedUserId;
+}
+
+export async function maybeEnableXdOrgBetaDefault(
+  request: XdOrgBetaDefaultRequest,
+  deps: XdOrgBetaDefaultDeps,
+): Promise<XdOrgBetaDefaultOutcome> {
+  if (!isXdOrgUser(request.user)) {
+    return { kind: 'skipped', reason: 'not-xd-org' };
+  }
+  if (!isCurrentAuth(request, deps)) {
+    return { kind: 'skipped', reason: 'stale-auth' };
+  }
+
+  const state = deps.readChannelState();
+  if (state.enableBeta) return { kind: 'skipped', reason: 'already-enabled' };
+  if (state.isCustomized) return { kind: 'skipped', reason: 'user-customized' };
+
+  let available = false;
+  try {
+    available = await deps.probeBetaManifest();
+  } catch {
+    return { kind: 'skipped', reason: 'beta-unavailable' };
+  }
+  if (!available) return { kind: 'skipped', reason: 'beta-unavailable' };
+  if (!isCurrentAuth(request, deps)) {
+    return { kind: 'skipped', reason: 'stale-auth' };
+  }
+
+  const wrote = await deps.enableBeta();
+  if (!wrote) {
+    const latest = deps.readChannelState();
+    if (latest.enableBeta) return { kind: 'skipped', reason: 'already-enabled' };
+    return { kind: 'skipped', reason: 'user-customized' };
+  }
+  return { kind: 'enabled' };
+}

--- a/apps/mobile/src/update/betaChannelStore.test.ts
+++ b/apps/mobile/src/update/betaChannelStore.test.ts
@@ -12,8 +12,11 @@ vi.mock('@react-native-async-storage/async-storage', () => ({
 
 import {
   __testing,
+  enableUncustomizedBetaChannel,
   hydrateBetaChannel,
   isBetaChannel,
+  prepareBetaChannelForDevice,
+  readBetaChannelState,
   subscribeBetaChannel,
   syncBetaChannel,
 } from './betaChannelStore';
@@ -35,6 +38,109 @@ describe('betaChannelStore', () => {
     await expect(hydrateBetaChannel()).resolves.toBe(false);
   });
 
+  it('结构不完整的 metadata fail-safe 为 hold，不允许组织默认开启', async () => {
+    storage.set(__testing.metaStorageKey, JSON.stringify({ version: 1 }));
+
+    await expect(hydrateBetaChannel()).resolves.toBe(false);
+    expect(readBetaChannelState()).toEqual({ enableBeta: false, isCustomized: true });
+    expect(__testing.hasPersistedMeta()).toBe(false);
+    expect(__testing.migrationBlocked()).toBe(true);
+    await prepareBetaChannelForDevice({ hadExistingDeviceId: false });
+    await expect(enableUncustomizedBetaChannel()).resolves.toBe(false);
+  });
+
+  it('损坏 metadata 存在时不把旧兼容 true 误迁移成用户 override', async () => {
+    storage.set(__testing.metaStorageKey, '{broken');
+    storage.set(__testing.storageKey, 'true');
+
+    await expect(hydrateBetaChannel()).resolves.toBe(false);
+    expect(readBetaChannelState()).toEqual({ enableBeta: false, isCustomized: true });
+    expect(__testing.readState().userOverride).toBeNull();
+    expect(__testing.migrationBlocked()).toBe(true);
+  });
+
+  it('读取失败时不反写迁移结果，避免抹掉未知的旧用户选择', async () => {
+    vi.mocked(AsyncStorage.getItem).mockRejectedValueOnce(new Error('storage unavailable'));
+
+    await expect(hydrateBetaChannel()).resolves.toBe(false);
+    expect(__testing.migrationBlocked()).toBe(true);
+    await prepareBetaChannelForDevice({ hadExistingDeviceId: false });
+    expect(AsyncStorage.setItem).not.toHaveBeenCalled();
+    await expect(enableUncustomizedBetaChannel()).resolves.toBe(false);
+  });
+
+  it('旧版本 true 迁移为用户 override，后续组织默认不能覆盖', async () => {
+    storage.set(__testing.storageKey, 'true');
+
+    await expect(hydrateBetaChannel()).resolves.toBe(true);
+    expect(readBetaChannelState()).toEqual({ enableBeta: true, isCustomized: true });
+    expect(__testing.readState()).toMatchObject({ userOverride: true });
+
+    await prepareBetaChannelForDevice({ hadExistingDeviceId: true });
+    await expect(enableUncustomizedBetaChannel()).resolves.toBe(false);
+    expect(isBetaChannel()).toBe(true);
+    expect(__testing.readState()).toMatchObject({ userOverride: true, orgDefaultEnableBeta: false });
+  });
+
+  it('新装机解除迁移 hold 后，XD 默认可开启 beta', async () => {
+    await hydrateBetaChannel();
+    expect(readBetaChannelState()).toEqual({ enableBeta: false, isCustomized: true });
+
+    await prepareBetaChannelForDevice({ hadExistingDeviceId: false });
+    expect(readBetaChannelState()).toEqual({ enableBeta: false, isCustomized: false });
+    await expect(enableUncustomizedBetaChannel()).resolves.toBe(true);
+    expect(isBetaChannel()).toBe(true);
+    expect(__testing.readState()).toMatchObject({ userOverride: null, orgDefaultEnableBeta: true });
+  });
+
+  it('组织默认开启后用户手动关闭，冷启动仍保持关闭', async () => {
+    await hydrateBetaChannel();
+    await prepareBetaChannelForDevice({ hadExistingDeviceId: false });
+    await enableUncustomizedBetaChannel();
+
+    await syncBetaChannel(false);
+    expect(readBetaChannelState()).toEqual({ enableBeta: false, isCustomized: true });
+    expect(__testing.readState()).toMatchObject({ userOverride: false, orgDefaultEnableBeta: true });
+
+    await __testing.resetMemory();
+    await expect(hydrateBetaChannel()).resolves.toBe(false);
+    expect(readBetaChannelState()).toEqual({ enableBeta: false, isCustomized: true });
+    await expect(enableUncustomizedBetaChannel()).resolves.toBe(false);
+  });
+
+  it('自动开启与用户关闭并发时，队列最终保留用户 override', async () => {
+    await hydrateBetaChannel();
+    await prepareBetaChannelForDevice({ hadExistingDeviceId: false });
+
+    const automatic = enableUncustomizedBetaChannel();
+    const optOut = syncBetaChannel(false);
+    await Promise.all([automatic, optOut]);
+
+    expect(readBetaChannelState()).toEqual({ enableBeta: false, isCustomized: true });
+    expect(__testing.readState()).toMatchObject({
+      userOverride: false,
+      orgDefaultEnableBeta: true,
+    });
+  });
+
+  it('组织默认落盘前身份失效时不写入', async () => {
+    await hydrateBetaChannel();
+    await prepareBetaChannelForDevice({ hadExistingDeviceId: false });
+
+    await expect(enableUncustomizedBetaChannel(() => false)).resolves.toBe(false);
+    expect(readBetaChannelState()).toEqual({ enableBeta: false, isCustomized: false });
+    expect(__testing.readState().orgDefaultEnableBeta).toBe(false);
+  });
+
+  it('旧装机无旧 key 保持关闭，组织默认不会覆盖迁移 hold', async () => {
+    await hydrateBetaChannel();
+    await prepareBetaChannelForDevice({ hadExistingDeviceId: true });
+
+    await expect(enableUncustomizedBetaChannel()).resolves.toBe(false);
+    expect(isBetaChannel()).toBe(false);
+    expect(readBetaChannelState().isCustomized).toBe(true);
+  });
+
   it('同步 true 跨冷启动恢复;false 删除标记', async () => {
     await syncBetaChannel(true);
     expect(isBetaChannel()).toBe(true);
@@ -46,6 +152,7 @@ describe('betaChannelStore', () => {
     await syncBetaChannel(false);
     expect(isBetaChannel()).toBe(false);
     expect(storage.has(__testing.storageKey)).toBe(false);
+    expect(__testing.readState().userOverride).toBe(false);
   });
 
   it('切换会通知订阅者，且取消订阅后不再通知', async () => {
@@ -61,7 +168,7 @@ describe('betaChannelStore', () => {
     expect(changes).toEqual([true, false]);
   });
 
-  it('落盘失败回滚内存态并 reject，避免「本次按 beta 检查、重启后回 release」漂移', async () => {
+  it('落盘失败时 reject 且不改变内存有效值', async () => {
     await hydrateBetaChannel();
     expect(isBetaChannel()).toBe(false);
 
@@ -69,25 +176,26 @@ describe('betaChannelStore', () => {
     vi.mocked(AsyncStorage.setItem).mockRejectedValueOnce(new Error('disk full'));
 
     await expect(syncBetaChannel(true)).rejects.toThrow('disk full');
-    // 回滚到落盘前的旧值(未启用)
+    // 写入成功前不发布新值，仍保持原来的 stable 状态。
     expect(isBetaChannel()).toBe(false);
   });
 
-  it('连续两次落盘都失败时，回滚到磁盘确认态而非上一次的乐观值', async () => {
+  it('连续两次落盘都失败时，仍保持磁盘确认态', async () => {
     await hydrateBetaChannel();
     expect(isBetaChannel()).toBe(false);
 
     // release → 开 → 关，两次存储操作都失败。
-    vi.mocked(AsyncStorage.setItem).mockRejectedValueOnce(new Error('full'));
-    vi.mocked(AsyncStorage.removeItem).mockRejectedValueOnce(new Error('full'));
+    vi.mocked(AsyncStorage.setItem)
+      .mockRejectedValueOnce(new Error('full'))
+      .mockRejectedValueOnce(new Error('full'));
 
     await expect(syncBetaChannel(true)).rejects.toThrow('full');
     await expect(syncBetaChannel(false)).rejects.toThrow('full');
-    // 磁盘仍是 release；内存不得停留在第一次的乐观值(已开)。
+    // 磁盘仍是 release；内存不得漂移到已开。
     expect(isBetaChannel()).toBe(false);
   });
 
-  it('前一次失败、后一次成功时，后一次成功不把内存覆盖成磁盘旧值', async () => {
+  it('前一次失败、后一次成功时，最终以内存和磁盘的成功值为准', async () => {
     await hydrateBetaChannel();
     expect(isBetaChannel()).toBe(false);
 
@@ -101,7 +209,7 @@ describe('betaChannelStore', () => {
     const p2 = syncBetaChannel(true);
     await expect(p1).rejects.toThrow('full');
     await expect(p2).resolves.toBeUndefined();
-    // 磁盘已是 beta（第二次成功落盘）；内存不得被第一次失败回滚成 release。
+    // 磁盘已是 beta（第二次成功落盘）；内存也应为 beta。
     expect(isBetaChannel()).toBe(true);
   });
 });

--- a/apps/mobile/src/update/betaChannelStore.ts
+++ b/apps/mobile/src/update/betaChannelStore.ts
@@ -1,26 +1,40 @@
 /**
- * Mobile beta 测试渠道的**设备级**本地快照。
+ * Mobile beta 渠道的设备级本地状态。
  *
- * 与 canaryChannelStore 的关键区别:
- *   - canary 是账号级、服务端下发(login 后 feature-flags → 本地持久化 → 登出清);
- *   - beta 是设备级、客户端本地设置(设置页开关),登出/换号都不清。
- *
- * 所以这里没有 clearBetaChannel(登出清理):开关只随设备走,不随账号生命周期。
- * 其余机制(AsyncStorage 快照 + hydrate 门 + mutation 队列)与 canaryChannelStore 一致,
- * 保证「冷启动任何更新请求前先恢复本地快照」、损坏 fail-safe 到 stable。
- *
- * 标记不敏感(只选择公开 CDN 指针),AsyncStorage 即可。
+ * 旧版本只有 `cindy.mobile.update.beta = "true"`，无法区分“从未设置”和
+ * “用户手动关闭”。新版本把用户 override 与 xd 组织默认拆开，仍同步维护旧
+ * key 作为回滚到旧 JS bundle 时的兼容镜像。
  */
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
-const STORAGE_KEY = 'cindy.mobile.update.beta';
+const LEGACY_STORAGE_KEY = 'cindy.mobile.update.beta';
+const META_STORAGE_KEY = 'cindy.mobile.update.beta.meta.v1';
+const META_VERSION = 1;
 
-let beta = false;
-/** 磁盘确认态:最近一次成功落盘的值。回滚一律回到它,而非上一次调用的乐观值。 */
-let committed = false;
+interface BetaMetaRecord {
+  version: 1;
+  userOverride: boolean | null;
+  orgDefaultEnableBeta: boolean;
+  legacyMigrationHold: boolean;
+}
+
+interface BetaState {
+  userOverride: boolean | null;
+  orgDefaultEnableBeta: boolean;
+  legacyMigrationHold: boolean;
+}
+
+const EMPTY: BetaState = {
+  userOverride: null,
+  orgDefaultEnableBeta: false,
+  legacyMigrationHold: true,
+};
+
+let state: BetaState = { ...EMPTY };
+let hasPersistedMeta = false;
+let migrationBlocked = false;
 let hydrated = false;
 let hydratePromise: Promise<boolean> | null = null;
-let mutationEpoch = 0;
 let mutationQueue: Promise<void> = Promise.resolve();
 const listeners = new Set<() => void>();
 
@@ -40,34 +54,100 @@ function enqueueMutation(operation: () => Promise<void>): Promise<void> {
   return run;
 }
 
-/** 冷启动时调用一次；损坏/不可读一律 fail-safe 到 false(不启用 beta)。 */
-export function hydrateBetaChannel(): Promise<boolean> {
-  if (hydrated) return Promise.resolve(beta);
+function effectiveBeta(value: BetaState): boolean {
+  if (value.userOverride !== null) return value.userOverride;
+  if (value.legacyMigrationHold) return false;
+  return value.orgDefaultEnableBeta;
+}
+
+function publicState(): { enableBeta: boolean; isCustomized: boolean } {
+  return {
+    enableBeta: effectiveBeta(state),
+    isCustomized: state.userOverride !== null || state.legacyMigrationHold,
+  };
+}
+
+function parseMeta(raw: string | null): BetaState | null {
+  if (!raw) return null;
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+    const record = parsed as Partial<BetaMetaRecord>;
+    if (
+      record.version !== META_VERSION ||
+      (record.userOverride !== null && typeof record.userOverride !== 'boolean') ||
+      typeof record.orgDefaultEnableBeta !== 'boolean' ||
+      typeof record.legacyMigrationHold !== 'boolean'
+    ) return null;
+    return {
+      userOverride: record.userOverride,
+      orgDefaultEnableBeta: record.orgDefaultEnableBeta,
+      legacyMigrationHold: record.legacyMigrationHold,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function metaPayload(value: BetaState): string {
+  const record: BetaMetaRecord = {
+    version: META_VERSION,
+    userOverride: value.userOverride,
+    orgDefaultEnableBeta: value.orgDefaultEnableBeta,
+    legacyMigrationHold: value.legacyMigrationHold,
+  };
+  return JSON.stringify(record);
+}
+
+async function persist(value: BetaState): Promise<void> {
+  await AsyncStorage.setItem(META_STORAGE_KEY, metaPayload(value));
+  // 新 metadata 是真源。旧 key 只用于回滚旧 JS bundle 时兼容；镜像失败不能让
+  // 内存回滚到旧值（metadata 已经成功写入），否则本次运行会和下次冷启动漂移。
+  try {
+    if (effectiveBeta(value)) await AsyncStorage.setItem(LEGACY_STORAGE_KEY, 'true');
+    else await AsyncStorage.removeItem(LEGACY_STORAGE_KEY);
+  } catch {
+    // best effort compatibility mirror
+  }
+}
+
+/** 冷启动读取实现；用户操作可静默 hydrate，避免把旧值作为额外变更广播。 */
+function hydrateBetaChannelInternal(notify: boolean): Promise<boolean> {
+  if (hydrated) return Promise.resolve(effectiveBeta(state));
   if (hydratePromise) return hydratePromise;
-  const epoch = mutationEpoch;
-  hydratePromise = AsyncStorage.getItem(STORAGE_KEY)
-    .then((raw) => {
-      if (epoch === mutationEpoch) {
-        const next = raw === 'true';
-        committed = next;
-        if (beta !== next || !hydrated) {
-          beta = next;
-          notifyListeners();
-        }
+  hydratePromise = Promise.all([
+    AsyncStorage.getItem(META_STORAGE_KEY),
+    AsyncStorage.getItem(LEGACY_STORAGE_KEY),
+  ])
+    .then(([metaRaw, legacyRaw]) => {
+      const meta = parseMeta(metaRaw);
+      if (meta) {
+        state = meta;
+        hasPersistedMeta = true;
+        migrationBlocked = false;
+      } else if (metaRaw === null && legacyRaw === 'true') {
+        // 旧版本的 true 只能来自用户主动开启，安全地迁移为用户 override。
+        state = { userOverride: true, orgDefaultEnableBeta: false, legacyMigrationHold: false };
+        hasPersistedMeta = false;
+        migrationBlocked = false;
+      } else {
+        // 真正无记录时再由 device id 判定新旧装机；只要存在损坏记录，就不能
+        // 当成新装机自动开启。
+        state = { ...EMPTY };
+        hasPersistedMeta = false;
+        migrationBlocked = metaRaw !== null || legacyRaw !== null;
       }
       hydrated = true;
-      return beta;
+      if (notify) notifyListeners();
+      return effectiveBeta(state);
     })
     .catch(() => {
-      if (epoch === mutationEpoch) {
-        committed = false;
-        if (beta || !hydrated) {
-          beta = false;
-          notifyListeners();
-        }
-      }
+      state = { ...EMPTY };
+      hasPersistedMeta = false;
+      migrationBlocked = true;
       hydrated = true;
-      return beta;
+      if (notify) notifyListeners();
+      return false;
     })
     .finally(() => {
       hydratePromise = null;
@@ -75,65 +155,101 @@ export function hydrateBetaChannel(): Promise<boolean> {
   return hydratePromise;
 }
 
-/** 启动 gate 完成后可同步读取。未 hydrate 时按 false(不启用 beta)。 */
-export function isBetaChannel(): boolean {
-  return hydrated && beta;
+/** 冷启动时调用一次；缺少迁移结论时 fail-safe 到 stable。 */
+export function hydrateBetaChannel(): Promise<boolean> {
+  return hydrateBetaChannelInternal(true);
 }
 
-/** 订阅开关变化；返回取消订阅函数。 */
+/** 启动 gate 完成后可同步读取；迁移未完成时按 false 处理。 */
+export function isBetaChannel(): boolean {
+  return hydrated && effectiveBeta(state);
+}
+
+export function readBetaChannelState(): { enableBeta: boolean; isCustomized: boolean } {
+  return publicState();
+}
+
 export function subscribeBetaChannel(listener: () => void): () => void {
   listeners.add(listener);
   return () => listeners.delete(listener);
 }
 
 /**
- * 设置页开关写入；内存态先行、串行落盘。落盘失败回滚内存态并重新抛错。
- *
- * 与 canaryChannelStore.syncCanaryChannel 的差异：canary 是服务端下发、落盘失败
- * 下次登录会重新同步；beta 是**用户可见**的设置开关，若不回滚会出现「设置页显示已开、
- * 本次运行按 beta 检查更新、重启后却回 release」的漂移，所以这里额外做失败回滚。
- *
- * 回滚目标是 `committed`(磁盘确认态)而非「本次调用前的内存态」:连续两次落盘都失败时,
- * 后一次的「调用前内存态」是前一次尚未落盘的乐观值,回滚到它会得到错误结果
- * (例如 release→开→关 都失败,内存反而停在「已开」)。回滚到磁盘真实值总是安全的。
+ * 在 AuthContext 已知道设备是否为旧装机后完成一次性迁移。
+ * 旧装机没有旧 beta key 时保守保持 hold；新装机解除 hold，允许 XD 默认开启。
  */
-export function syncBetaChannel(next: boolean): Promise<void> {
+export async function prepareBetaChannelForDevice(input: {
+  hadExistingDeviceId: boolean;
+}): Promise<void> {
+  await hydrateBetaChannel();
+  await enqueueMutation(async () => {
+    // 读取失败时无法知道旧 key 是否曾为 true；不要以 fail-safe 内存值反写磁盘，
+    // 避免一次瞬时 I/O 错误抹掉旧版本里用户明确开启的 beta。
+    if (hasPersistedMeta || migrationBlocked) return;
+    const next: BetaState = {
+      ...state,
+      legacyMigrationHold: input.hadExistingDeviceId ? state.legacyMigrationHold : false,
+    };
+    await persist(next);
+    state = next;
+    hasPersistedMeta = true;
+    notifyListeners();
+  });
+}
+
+/** 用户显式写入 override；false 也必须保留，防止下次 xd 登录重新打开。 */
+export async function syncBetaChannel(next: boolean): Promise<void> {
   const value = next === true;
-  mutationEpoch += 1;
-  const epoch = mutationEpoch;
-  hydrated = true;
-  beta = value;
-  notifyListeners();
+  // 先等冷启动读取完成，再把用户操作放进统一写队列；否则迟到的 hydrate 可能
+  // 用旧磁盘快照覆盖刚写入的选择。
+  await hydrateBetaChannelInternal(false);
+  await enqueueMutation(async () => {
+    const nextState: BetaState = {
+      ...state,
+      userOverride: value,
+      legacyMigrationHold: false,
+    };
+    await persist(nextState);
+    state = nextState;
+    hasPersistedMeta = true;
+    migrationBlocked = false;
+    notifyListeners();
+  });
+}
+
+/** 仅在用户未自定义且设备不是旧装机迁移 hold 时写入组织默认。 */
+export function enableUncustomizedBetaChannel(
+  shouldWrite: () => boolean = () => true,
+): Promise<boolean> {
+  let wrote = false;
   return enqueueMutation(async () => {
-    if (value) await AsyncStorage.setItem(STORAGE_KEY, 'true');
-    else await AsyncStorage.removeItem(STORAGE_KEY);
-  }).then(
-    () => {
-      committed = value;
-    },
-    (err) => {
-      // 只有自己仍是最新 mutation 时才回滚:若有更新的 mutation 已乐观设置了
-      // beta(它自己负责成功/失败),这里回滚 committed 会把它的乐观值覆盖掉,
-      // 造成「内存 release、磁盘 beta」的漂移。更新 mutation 会处理它自己的结果。
-      if (epoch === mutationEpoch) {
-        beta = committed;
-        notifyListeners();
-      }
-      throw err;
-    },
-  );
+    if (!shouldWrite() || state.userOverride !== null || state.legacyMigrationHold || effectiveBeta(state)) {
+      return;
+    }
+    const nextState: BetaState = { ...state, orgDefaultEnableBeta: true };
+    await persist(nextState);
+    state = nextState;
+    hasPersistedMeta = true;
+    migrationBlocked = false;
+    wrote = true;
+    notifyListeners();
+  }).then(() => wrote);
 }
 
 export const __testing = {
-  storageKey: STORAGE_KEY,
+  storageKey: LEGACY_STORAGE_KEY,
+  metaStorageKey: META_STORAGE_KEY,
   async resetMemory(): Promise<void> {
     await mutationQueue.catch(() => undefined);
-    beta = false;
-    committed = false;
+    state = { ...EMPTY };
+    hasPersistedMeta = false;
+    migrationBlocked = false;
     hydrated = false;
     hydratePromise = null;
-    mutationEpoch = 0;
     mutationQueue = Promise.resolve();
     listeners.clear();
   },
+  readState: () => ({ ...state }),
+  hasPersistedMeta: () => hasPersistedMeta,
+  migrationBlocked: () => migrationBlocked,
 };


### PR DESCRIPTION
## 这次改了什么

### 摘要

参考 Desktop PR #2881，在 iOS 和 Android 的自建 OTA 包中补齐 XD 组织识别：用户登录或刷新 token 后，如果身份属于 XD 组织、设备上的 beta 开关从未被用户自定义，并且 beta manifest 可用，则自动切换到 beta 更新通道。

同时升级设备级 beta 偏好存储，明确区分组织默认值和用户手动选择。用户手动关闭后，后续登录不会再次自动开启；旧安装无法确认历史选择时保守保持 stable。

### 变更类型

- [x] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Desktop PR #2881 的 Mobile 端能力补齐
- 本 PR 包含：iOS / Android XD 组织识别、beta 自动开启策略、存量偏好迁移与并发保护、相关单测
- 明确不包含：Desktop、服务端、原生依赖和原生配置改动
- 用户可见变化：自建 Mobile 包中的 XD 组织用户在未手动选择过 beta 时，登录后自动使用 beta 更新通道；无需当场 reload
- 是否存在 breaking change：无

### UI 变化

不涉及：未修改界面、交互或 UI 文案，仅改变 beta 开关的设备级默认状态来源。

- 引用的设计规范：不涉及：本次仅修改认证与本地更新通道状态逻辑，无视觉、交互或 UI 文案变化。

## 怎么验证的

### 自动验证

```text
pnpm --filter mobile exec vitest run src/auth/__tests__/xdOrgBetaWiring.test.ts src/auth/xdOrgBetaDefault.test.ts src/auth/__tests__/jwt.test.ts src/update/betaChannelStore.test.ts
结果：4 个文件、30 个用例全部通过

pnpm --filter mobile run --if-present typecheck
结果：通过

pnpm test:unit:related
结果：test:runner 与 apps/mobile unit 全部通过

pnpm check:dco
结果：2 个 commit 签名检查通过

git diff --check
结果：通过
```

Runtime fingerprint 对比：

- iOS：`e546aeba6cd3caaeb1c2c747df05704bcfc0d913`（改动前后相同）
- Android：`e32303018a056a53a00839069914afef2ddc6135`（改动前后相同）

结论：不触发冷更。

### 手工验证

不涉及：本次未启动真机或模拟器，行为由策略单测、认证接线断言、相关单测和 fingerprint 对比覆盖。

### 未执行的验证

- 未执行 iOS / Android 真机登录验证。
- 分支：`feat/mobile-xd-org-beta`
- 使用当前主工作区，未启动 Metro，因此无 Metro 归属或 `__DEV__` build label 证据。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [x] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅自建 OTA Mobile 包；非自建包直接跳过。iOS 与 Android 共用策略，只在 beta manifest 探测时传入各自平台。
- 冷更影响：无。未修改原生依赖、原生配置或 config plugin，iOS / Android runtime fingerprint 均未变化。
- 存量偏好：旧版明确开启的 `true` 迁移为用户 override；旧装机缺少可判定记录或 metadata 损坏时保持 stable；用户手动关闭持久化为显式 override。
- 回滚 / 降级方式：回滚本提交即可停止 XD 组织自动开启；旧兼容 key 仍以 best effort 方式维护，回滚旧 JS bundle 时继续可读。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范（不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要测试；无需额外文档
- [x] 已确认测试结果或说明未执行原因
