### PR TITLE
fix(desktop): 精简连续提问的提交操作

### DIFF
--- a/apps/desktop/src/renderer/__tests__/askUserQuestionActionLabels.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/askUserQuestionActionLabels.test.tsx
@@ -46,24 +46,17 @@ describe('AskUserQuestionPrompt action labels', () => {
     fireEvent.change(view.getByPlaceholderText('Type your answer…'), {
       target: { value: 'Custom answer' },
     });
-    expect(
-      (view.getByRole('button', { name: 'Update & Next' }) as HTMLButtonElement).disabled,
-    ).toBe(false);
+    expect((view.getByTestId('ask-user-custom-next') as HTMLButtonElement).disabled).toBe(false);
 
-    fireEvent.click(view.getByRole('button', { name: 'Update & Next' }));
+    fireEvent.click(view.getByTestId('ask-user-custom-next'));
     await waitFor(() => expect(view.queryByText('Second question')).not.toBeNull());
     await waitFor(() => expect(view.queryByRole('button', { name: /Back/ })).not.toBeNull());
 
     fireEvent.click(view.getByRole('button', { name: /Back/ }));
     await waitFor(() => expect(view.queryByText('First question')).not.toBeNull());
-    await waitFor(() => expect(view.queryByRole('button', { name: 'Next' })).not.toBeNull());
+    await waitFor(() => expect(view.queryByTestId('ask-user-custom-next')).not.toBeNull());
 
-    expect((view.getByRole('button', { name: 'Next' }) as HTMLButtonElement).disabled).toBe(
-      false,
-    );
-    expect(
-      (view.getByRole('button', { name: 'Update & Next' }) as HTMLButtonElement).disabled,
-    ).toBe(false);
+    expect((view.getByTestId('ask-user-custom-next') as HTMLButtonElement).disabled).toBe(false);
   });
 
   it('uses Submit for a custom answer on the final question without a footer duplicate', () => {
@@ -137,9 +130,6 @@ describe('AskUserQuestionPrompt action labels', () => {
     for (const [locale, labels] of Object.entries(expected)) {
       expect(i18n.t('chat.askUserQuestion.next', { lng: locale })).toBe(labels[0]);
       expect(i18n.t('chat.askUserQuestion.submit', { lng: locale })).toBe(labels[1]);
-      expect(i18n.t('chat.askUserQuestion.updateAndNext', { lng: locale })).not.toBe(
-        'chat.askUserQuestion.updateAndNext',
-      );
       expect(i18n.t('chat.askUserQuestion.customAnswer', { lng: locale })).not.toBe(
         'chat.askUserQuestion.customAnswer',
       );

--- a/apps/desktop/src/renderer/__tests__/askUserQuestionActionLabels.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/askUserQuestionActionLabels.test.tsx
@@ -1,0 +1,110 @@
+// @vitest-environment jsdom
+
+import { createElement } from 'react';
+import { cleanup, fireEvent, render, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import i18n from '@/i18n';
+import type { PendingAskUser } from '@/lib/makerChatStore';
+import { AskUserQuestionPrompt } from '../components/new-chat/AskUserQuestionPrompt';
+
+beforeEach(async () => {
+  await i18n.changeLanguage('en');
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+function renderAskUser(
+  pending: PendingAskUser,
+  onAnswer: (requestId: string, answers: Record<string, string>) => void = vi.fn(),
+) {
+  return render(
+    createElement(AskUserQuestionPrompt, {
+      pending,
+      onAnswer,
+      viewerState: 'expanded',
+      onViewerStateChange: () => {},
+      draft: null,
+      onDraftChange: () => {},
+    }),
+  );
+}
+
+describe('AskUserQuestionPrompt action labels', () => {
+  it('distinguishes updating an answer from keeping it when revisiting a middle question', async () => {
+    const view = renderAskUser({
+      requestId: 'req-revisit',
+      questions: [
+        { question: 'First question', options: [{ label: 'A' }] },
+        { question: 'Second question', options: [{ label: 'B' }] },
+      ],
+    });
+
+    fireEvent.click(view.getByText('Type something else…'));
+    fireEvent.change(view.getByPlaceholderText('Type your answer…'), {
+      target: { value: 'Custom answer' },
+    });
+    expect(
+      (view.getByRole('button', { name: 'Update & Next' }) as HTMLButtonElement).disabled,
+    ).toBe(false);
+
+    fireEvent.click(view.getByRole('button', { name: 'Update & Next' }));
+    await waitFor(() => expect(view.queryByText('Second question')).not.toBeNull());
+    await waitFor(() => expect(view.queryByRole('button', { name: /Back/ })).not.toBeNull());
+
+    fireEvent.click(view.getByRole('button', { name: /Back/ }));
+    await waitFor(() => expect(view.queryByText('First question')).not.toBeNull());
+    await waitFor(() => expect(view.queryByRole('button', { name: 'Next' })).not.toBeNull());
+
+    expect((view.getByRole('button', { name: 'Next' }) as HTMLButtonElement).disabled).toBe(
+      false,
+    );
+    expect(
+      (view.getByRole('button', { name: 'Update & Next' }) as HTMLButtonElement).disabled,
+    ).toBe(false);
+  });
+
+  it('uses Update & Submit for a custom answer on the final question', () => {
+    const onAnswer = vi.fn();
+    const view = renderAskUser(
+      {
+        requestId: 'req-submit',
+        questions: [{ question: 'Final question', options: [{ label: 'A' }] }],
+      },
+      onAnswer,
+    );
+
+    fireEvent.click(view.getByText('Type something else…'));
+    fireEvent.change(view.getByPlaceholderText('Type your answer…'), {
+      target: { value: 'Updated answer' },
+    });
+    fireEvent.click(view.getByRole('button', { name: 'Update & Submit' }));
+
+    expect(onAnswer).toHaveBeenCalledWith('req-submit', {
+      'Final question': 'Updated answer',
+    });
+  });
+
+  it('provides localized prompt copy in every supported locale', () => {
+    const expected = {
+      en: ['Update & Next', 'Update & Submit'],
+      'zh-CN': ['更新并继续', '更新并提交'],
+      'zh-TW': ['更新並繼續', '更新並提交'],
+      ja: ['更新して次へ', '更新して送信'],
+      ko: ['수정 후 다음', '수정 후 제출'],
+    } as const;
+
+    for (const [locale, labels] of Object.entries(expected)) {
+      expect(i18n.t('chat.askUserQuestion.updateAndNext', { lng: locale })).toBe(labels[0]);
+      expect(i18n.t('chat.askUserQuestion.updateAndSubmit', { lng: locale })).toBe(labels[1]);
+      expect(i18n.t('chat.askUserQuestion.customAnswer', { lng: locale })).not.toBe(
+        'chat.askUserQuestion.customAnswer',
+      );
+      expect(i18n.t('chat.askUserQuestion.answerPlaceholder', { lng: locale })).not.toBe(
+        'chat.askUserQuestion.answerPlaceholder',
+      );
+    }
+  });
+});

--- a/apps/desktop/src/renderer/__tests__/askUserQuestionActionLabels.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/askUserQuestionActionLabels.test.tsx
@@ -66,7 +66,7 @@ describe('AskUserQuestionPrompt action labels', () => {
     ).toBe(false);
   });
 
-  it('uses Update & Submit for a custom answer on the final question', () => {
+  it('uses Submit for a custom answer on the final question without a footer duplicate', () => {
     const onAnswer = vi.fn();
     const view = renderAskUser(
       {
@@ -80,25 +80,66 @@ describe('AskUserQuestionPrompt action labels', () => {
     fireEvent.change(view.getByPlaceholderText('Type your answer…'), {
       target: { value: 'Updated answer' },
     });
-    fireEvent.click(view.getByRole('button', { name: 'Update & Submit' }));
+    expect(view.getAllByRole('button', { name: 'Submit' })).toHaveLength(1);
+    fireEvent.click(view.getByRole('button', { name: 'Submit' }));
 
     expect(onAnswer).toHaveBeenCalledWith('req-submit', {
       'Final question': 'Updated answer',
     });
   });
 
+  it('does not show an inert footer Submit for an unanswered final single-select question', () => {
+    const view = renderAskUser({
+      requestId: 'req-final-unanswered',
+      questions: [{ question: 'Final question', options: [{ label: 'A' }] }],
+    });
+
+    expect(view.queryByRole('button', { name: 'Submit' })).toBeNull();
+  });
+
+  it('keeps the footer Submit for a final multi-select question', () => {
+    const onAnswer = vi.fn();
+    const view = renderAskUser(
+      {
+        requestId: 'req-final-multi-select',
+        questions: [
+          {
+            question: 'Final multi-select question',
+            multiSelect: true,
+            options: [{ label: 'A' }, { label: 'B' }],
+          },
+        ],
+      },
+      onAnswer,
+    );
+
+    const submit = view.getByRole('button', { name: 'Submit' }) as HTMLButtonElement;
+    expect(submit.disabled).toBe(true);
+
+    fireEvent.click(view.getByText('A'));
+    expect(submit.disabled).toBe(false);
+    fireEvent.click(submit);
+
+    expect(onAnswer).toHaveBeenCalledWith('req-final-multi-select', {
+      'Final multi-select question': '["A"]',
+    });
+  });
+
   it('provides localized prompt copy in every supported locale', () => {
     const expected = {
-      en: ['Update & Next', 'Update & Submit'],
-      'zh-CN': ['更新并继续', '更新并提交'],
-      'zh-TW': ['更新並繼續', '更新並提交'],
-      ja: ['更新して次へ', '更新して送信'],
-      ko: ['수정 후 다음', '수정 후 제출'],
+      en: ['Next', 'Submit'],
+      'zh-CN': ['下一题', '提交'],
+      'zh-TW': ['下一題', '提交'],
+      ja: ['次へ', '送信'],
+      ko: ['다음', '제출'],
     } as const;
 
     for (const [locale, labels] of Object.entries(expected)) {
-      expect(i18n.t('chat.askUserQuestion.updateAndNext', { lng: locale })).toBe(labels[0]);
-      expect(i18n.t('chat.askUserQuestion.updateAndSubmit', { lng: locale })).toBe(labels[1]);
+      expect(i18n.t('chat.askUserQuestion.next', { lng: locale })).toBe(labels[0]);
+      expect(i18n.t('chat.askUserQuestion.submit', { lng: locale })).toBe(labels[1]);
+      expect(i18n.t('chat.askUserQuestion.updateAndNext', { lng: locale })).not.toBe(
+        'chat.askUserQuestion.updateAndNext',
+      );
       expect(i18n.t('chat.askUserQuestion.customAnswer', { lng: locale })).not.toBe(
         'chat.askUserQuestion.customAnswer',
       );

--- a/apps/desktop/src/renderer/__tests__/askUserQuestionLongAnswer.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/askUserQuestionLongAnswer.test.tsx
@@ -45,8 +45,8 @@ describe('AskUserQuestionPrompt long answers', () => {
       vi.fn(),
     );
 
-    fireEvent.click(getByText('Type something else...'));
-    const textarea = getByPlaceholderText('Type your answer...') as HTMLTextAreaElement;
+    fireEvent.click(getByText('Type something else…'));
+    const textarea = getByPlaceholderText('Type your answer…') as HTMLTextAreaElement;
     expect(textarea.tagName).toBe('TEXTAREA');
 
     mockScrollHeight(textarea, 96);
@@ -79,7 +79,7 @@ describe('AskUserQuestionPrompt long answers', () => {
       onAnswer,
     );
 
-    const textarea = getByPlaceholderText('Type your answer...') as HTMLTextAreaElement;
+    const textarea = getByPlaceholderText('Type your answer…') as HTMLTextAreaElement;
     expect(textarea.tagName).toBe('TEXTAREA');
     fireEvent.change(textarea, { target: { value: 'First point\nSecond point' } });
 
@@ -109,8 +109,8 @@ describe('AskUserQuestionPrompt long answers', () => {
     );
 
     fireEvent.click(getByText('A'));
-    fireEvent.click(getByText('Type something else...'));
-    const textarea = getByPlaceholderText('Type your answer...');
+    fireEvent.click(getByText('Type something else…'));
+    const textarea = getByPlaceholderText('Type your answer…');
     fireEvent.change(textarea, { target: { value: 'Extra\ncontext' } });
 
     fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: true });

--- a/apps/desktop/src/renderer/__tests__/imeEnterCompositionGuard.test.ts
+++ b/apps/desktop/src/renderer/__tests__/imeEnterCompositionGuard.test.ts
@@ -51,8 +51,8 @@ describe('AskUserQuestionPrompt IME Enter guard', () => {
       onAnswer,
     );
 
-    fireEvent.click(getByText('Type something else...'));
-    const input = getByPlaceholderText('Type your answer...');
+    fireEvent.click(getByText('Type something else…'));
+    const input = getByPlaceholderText('Type your answer…');
     fireEvent.change(input, { target: { value: 'hello' } });
 
     fireEvent.keyDown(input, { key: 'Enter', isComposing: true });
@@ -70,7 +70,7 @@ describe('AskUserQuestionPrompt IME Enter guard', () => {
       onAnswer,
     );
 
-    const input = getByPlaceholderText('Type your answer...');
+    const input = getByPlaceholderText('Type your answer…');
     fireEvent.change(input, { target: { value: '你好' } });
 
     fireEvent.keyDown(input, { key: 'Enter', isComposing: true });

--- a/apps/desktop/src/renderer/components/new-chat/AskUserQuestionPrompt.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/AskUserQuestionPrompt.tsx
@@ -20,6 +20,7 @@ import {
   type RefObject,
   type TextareaHTMLAttributes,
 } from 'react';
+import { useTranslation } from 'react-i18next';
 
 import { InteractionPromptCardShell } from '@/components/interaction-portal';
 import { useAutoResize } from '@/hooks/useAutoResize';
@@ -105,6 +106,7 @@ export function AskUserQuestionPrompt({
   draft,
   onDraftChange,
 }: AskUserQuestionPromptProps) {
+  const { t } = useTranslation();
   const { requestId, questions } = pending;
   const totalQuestions = questions.length;
 
@@ -238,15 +240,29 @@ export function AskUserQuestionPrompt({
           <div className={skipClass}>
             <span className="flex items-center gap-[6px]">
               <span>&#8592;</span>
-              <span>Back</span>
+              <span>{t('chat.askUserQuestion.back')}</span>
             </span>
           </div>
         )}
-        <div className={skipClass}>Skip</div>
-        {showNext && <div className={nextClass}>{isLastQuestion ? 'Submit' : 'Next'}</div>}
+        <div className={skipClass}>{t('chat.askUserQuestion.skip')}</div>
+        {showNext && (
+          <div className={nextClass}>
+            {isLastQuestion
+              ? t('chat.askUserQuestion.submit')
+              : t('chat.askUserQuestion.next')}
+          </div>
+        )}
       </>
     );
-  }, [currentIndex, isMultiSelect, isLastQuestion, existingAnswer, selectedLabels, customInput]);
+  }, [
+    currentIndex,
+    isMultiSelect,
+    isLastQuestion,
+    existingAnswer,
+    selectedLabels,
+    customInput,
+    t,
+  ]);
 
   // ── Advance to next question or submit all ──
   const advance = useCallback(
@@ -452,7 +468,7 @@ export function AskUserQuestionPrompt({
             >
               <span className="flex items-center gap-[6px]">
                 <span>&#8592;</span>
-                <span>Back</span>
+                <span>{t('chat.askUserQuestion.back')}</span>
               </span>
             </button>
           )}
@@ -465,7 +481,7 @@ export function AskUserQuestionPrompt({
               'border border-[var(--confirm-btn-secondary-border)] bg-transparent text-[var(--confirm-btn-secondary-text)] transition-colors hover:bg-[var(--confirm-btn-secondary-hover)]',
             )}
           >
-            Skip
+            {t('chat.askUserQuestion.skip')}
           </button>
 
           {(isMultiSelect ||
@@ -496,7 +512,9 @@ export function AskUserQuestionPrompt({
                   : 'border border-[var(--confirm-btn-secondary-border)] bg-transparent text-[var(--confirm-btn-secondary-text)] transition-colors hover:bg-[var(--confirm-btn-secondary-hover)]',
               )}
             >
-              {isLastQuestion ? 'Submit' : 'Next'}
+              {isLastQuestion
+                ? t('chat.askUserQuestion.submit')
+                : t('chat.askUserQuestion.next')}
             </button>
           )}
         </>
@@ -509,10 +527,10 @@ export function AskUserQuestionPrompt({
     <InteractionPromptCardShell
       viewerState={viewerState}
       onViewerStateChange={onViewerStateChange}
-      minimizedTitle="Question pending"
+      minimizedTitle={t('chat.askUserQuestion.pendingTitle')}
       minimizedMeta={totalQuestions > 1 ? `${currentIndex + 1} / ${totalQuestions}` : undefined}
-      restoreAriaLabel="Restore question prompt"
-      minimizeAriaLabel="Minimize question prompt"
+      restoreAriaLabel={t('chat.askUserQuestion.restoreAriaLabel')}
+      minimizeAriaLabel={t('chat.askUserQuestion.minimizeAriaLabel')}
       minimizeDisabled={isAnimating}
       headerLeading={
         currentQ?.header ? (
@@ -654,7 +672,7 @@ export function AskUserQuestionPrompt({
                       setCustomInput('');
                     }
                   }}
-                  placeholder="Type your answer..."
+                  placeholder={t('chat.askUserQuestion.answerPlaceholder')}
                   className={cn(
                     'min-h-[22px] min-w-0 flex-1 bg-transparent text-14 font-normal leading-[1.571] outline-none',
                     'text-[var(--ask-input-text)] placeholder:text-[var(--ask-input-placeholder)]',
@@ -674,7 +692,9 @@ export function AskUserQuestionPrompt({
                         : 'bg-[var(--ask-send-disabled-bg)] text-[var(--ask-send-disabled-text)]',
                     )}
                   >
-                    Send
+                    {isLastQuestion
+                      ? t('chat.askUserQuestion.updateAndSubmit')
+                      : t('chat.askUserQuestion.updateAndNext')}
                   </button>
                 )}
               </div>
@@ -692,7 +712,7 @@ export function AskUserQuestionPrompt({
                     <div className="h-[18px] w-[18px] shrink-0 rounded-[4px] border-[1.5px] border-[var(--ask-checkbox-border)]" />
                   )}
                   <span className="text-14 italic text-[var(--ask-option-custom)]">
-                    Type something else...
+                    {t('chat.askUserQuestion.customAnswer')}
                   </span>
                 </div>
                 <div className="ml-3 flex h-[28px] w-[28px] shrink-0 items-center justify-center rounded-[8px] bg-[var(--ask-badge-bg)] text-13 font-medium text-[var(--ask-badge-text)]">
@@ -720,7 +740,7 @@ export function AskUserQuestionPrompt({
                   handleSkip();
                 }
               }}
-              placeholder="Type your answer..."
+              placeholder={t('chat.askUserQuestion.answerPlaceholder')}
               autoFocus
               className={cn(
                 'min-h-10 min-w-0 flex-1 rounded-[8px] border px-3 py-[8px] text-14 leading-[1.571] outline-none',
@@ -739,7 +759,9 @@ export function AskUserQuestionPrompt({
                   : 'bg-[var(--ask-send-disabled-bg)] text-[var(--ask-send-disabled-text)]',
               )}
             >
-              Send
+              {isLastQuestion
+                ? t('chat.askUserQuestion.updateAndSubmit')
+                : t('chat.askUserQuestion.updateAndNext')}
             </button>
           </div>
         )}

--- a/apps/desktop/src/renderer/components/new-chat/AskUserQuestionPrompt.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/AskUserQuestionPrompt.tsx
@@ -24,6 +24,7 @@ import { useTranslation } from 'react-i18next';
 import { ArrowRight } from 'lucide-react';
 
 import { InteractionPromptCardShell } from '@/components/interaction-portal';
+import { Tip } from '@/components/ui/tooltip';
 import { useAutoResize } from '@/hooks/useAutoResize';
 import { cn } from '@/lib/utils';
 import type { AskUserDraft, AskUserViewerState, PendingAskUser } from '@/lib/makerChatStore';
@@ -680,30 +681,31 @@ export function AskUserQuestionPrompt({
                   )}
                 />
                 {!isMultiSelect && (
-                  <button
-                    type="button"
-                    onClick={handleCustomSubmit}
-                    disabled={!customInput.trim()}
-                    aria-label={
-                      isLastQuestion ? undefined : t('chat.askUserQuestion.updateAndNext')
-                    }
-                    title={isLastQuestion ? undefined : t('chat.askUserQuestion.next')}
-                    className={cn(
-                      'self-end shrink-0 rounded-[9999px] text-13 font-medium',
-                      isLastQuestion
-                        ? 'px-[16px] py-[6px]'
-                        : 'flex h-8 w-8 items-center justify-center',
-                      customInput.trim()
-                        ? 'bg-[var(--ask-send-bg)] text-[var(--ask-send-text)]'
-                        : 'bg-[var(--ask-send-disabled-bg)] text-[var(--ask-send-disabled-text)]',
-                    )}
-                  >
-                    {isLastQuestion ? (
-                      t('chat.askUserQuestion.submit')
-                    ) : (
-                      <ArrowRight size={15} strokeWidth={2} aria-hidden="true" />
-                    )}
-                  </button>
+                  <Tip text={isLastQuestion ? null : t('chat.askUserQuestion.next')}>
+                    <button
+                      type="button"
+                      onClick={handleCustomSubmit}
+                      disabled={!customInput.trim()}
+                      aria-label={
+                        isLastQuestion ? undefined : t('chat.askUserQuestion.updateAndNext')
+                      }
+                      className={cn(
+                        'self-end shrink-0 rounded-[9999px] text-13 font-medium',
+                        isLastQuestion
+                          ? 'px-[16px] py-[6px]'
+                          : 'flex h-8 w-8 items-center justify-center',
+                        customInput.trim()
+                          ? 'bg-[var(--ask-send-bg)] text-[var(--ask-send-text)]'
+                          : 'bg-[var(--ask-send-disabled-bg)] text-[var(--ask-send-disabled-text)]',
+                      )}
+                    >
+                      {isLastQuestion ? (
+                        t('chat.askUserQuestion.submit')
+                      ) : (
+                        <ArrowRight size={15} strokeWidth={2} aria-hidden="true" />
+                      )}
+                    </button>
+                  </Tip>
                 )}
               </div>
             ) : (
@@ -756,28 +758,29 @@ export function AskUserQuestionPrompt({
                 'placeholder:text-[var(--ask-input-placeholder)]',
               )}
             />
-            <button
-              type="button"
-              onClick={() => customInput.trim() && advance(customInput.trim())}
-              disabled={!customInput.trim()}
-              aria-label={
-                isLastQuestion ? undefined : t('chat.askUserQuestion.updateAndNext')
-              }
-              title={isLastQuestion ? undefined : t('chat.askUserQuestion.next')}
-              className={cn(
-                'h-10 rounded-[9999px] text-14 font-medium transition-colors',
-                isLastQuestion ? 'px-4' : 'flex w-10 items-center justify-center',
-                customInput.trim()
-                  ? 'bg-[var(--ask-send-bg)] text-[var(--ask-send-text)]'
-                  : 'bg-[var(--ask-send-disabled-bg)] text-[var(--ask-send-disabled-text)]',
-              )}
-            >
-              {isLastQuestion ? (
-                t('chat.askUserQuestion.submit')
-              ) : (
-                <ArrowRight size={17} strokeWidth={2} aria-hidden="true" />
-              )}
-            </button>
+            <Tip text={isLastQuestion ? null : t('chat.askUserQuestion.next')}>
+              <button
+                type="button"
+                onClick={() => customInput.trim() && advance(customInput.trim())}
+                disabled={!customInput.trim()}
+                aria-label={
+                  isLastQuestion ? undefined : t('chat.askUserQuestion.updateAndNext')
+                }
+                className={cn(
+                  'h-10 rounded-[9999px] text-14 font-medium transition-colors',
+                  isLastQuestion ? 'px-4' : 'flex w-10 items-center justify-center',
+                  customInput.trim()
+                    ? 'bg-[var(--ask-send-bg)] text-[var(--ask-send-text)]'
+                    : 'bg-[var(--ask-send-disabled-bg)] text-[var(--ask-send-disabled-text)]',
+                )}
+              >
+                {isLastQuestion ? (
+                  t('chat.askUserQuestion.submit')
+                ) : (
+                  <ArrowRight size={17} strokeWidth={2} aria-hidden="true" />
+                )}
+              </button>
+            </Tip>
           </div>
         )}
       </div>

--- a/apps/desktop/src/renderer/components/new-chat/AskUserQuestionPrompt.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/AskUserQuestionPrompt.tsx
@@ -686,9 +686,8 @@ export function AskUserQuestionPrompt({
                       type="button"
                       onClick={handleCustomSubmit}
                       disabled={!customInput.trim()}
-                      aria-label={
-                        isLastQuestion ? undefined : t('chat.askUserQuestion.updateAndNext')
-                      }
+                      data-testid={isLastQuestion ? undefined : 'ask-user-custom-next'}
+                      aria-label={isLastQuestion ? undefined : t('chat.askUserQuestion.next')}
                       className={cn(
                         'self-end shrink-0 rounded-[9999px] text-13 font-medium',
                         isLastQuestion
@@ -763,9 +762,8 @@ export function AskUserQuestionPrompt({
                 type="button"
                 onClick={() => customInput.trim() && advance(customInput.trim())}
                 disabled={!customInput.trim()}
-                aria-label={
-                  isLastQuestion ? undefined : t('chat.askUserQuestion.updateAndNext')
-                }
+                data-testid={isLastQuestion ? undefined : 'ask-user-custom-next'}
+                aria-label={isLastQuestion ? undefined : t('chat.askUserQuestion.next')}
                 className={cn(
                   'h-10 rounded-[9999px] text-14 font-medium transition-colors',
                   isLastQuestion ? 'px-4' : 'flex w-10 items-center justify-center',

--- a/apps/desktop/src/renderer/components/new-chat/AskUserQuestionPrompt.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/AskUserQuestionPrompt.tsx
@@ -21,6 +21,7 @@ import {
   type TextareaHTMLAttributes,
 } from 'react';
 import { useTranslation } from 'react-i18next';
+import { ArrowRight } from 'lucide-react';
 
 import { InteractionPromptCardShell } from '@/components/interaction-portal';
 import { useAutoResize } from '@/hooks/useAutoResize';
@@ -223,7 +224,7 @@ export function AskUserQuestionPrompt({
       'border border-[var(--confirm-btn-secondary-border)] bg-transparent text-[var(--confirm-btn-secondary-text)]',
     );
     const showNext =
-      isMultiSelect || (existingAnswer !== undefined && !isMultiSelect) || isLastQuestion;
+      isMultiSelect || (!isLastQuestion && existingAnswer !== undefined && !isMultiSelect);
     const nextDisabled = isMultiSelect
       ? selectedLabels.size === 0 && !customInput.trim()
       : existingAnswer === undefined;
@@ -485,8 +486,7 @@ export function AskUserQuestionPrompt({
           </button>
 
           {(isMultiSelect ||
-            (existingAnswer !== undefined && !isMultiSelect) ||
-            isLastQuestion) && (
+            (!isLastQuestion && existingAnswer !== undefined && !isMultiSelect)) && (
             <button
               type="button"
               onClick={() => {
@@ -684,17 +684,25 @@ export function AskUserQuestionPrompt({
                     type="button"
                     onClick={handleCustomSubmit}
                     disabled={!customInput.trim()}
+                    aria-label={
+                      isLastQuestion ? undefined : t('chat.askUserQuestion.updateAndNext')
+                    }
+                    title={isLastQuestion ? undefined : t('chat.askUserQuestion.next')}
                     className={cn(
-                      'self-end shrink-0 rounded-[9999px] px-[16px] py-[6px]',
-                      'text-13 font-medium',
+                      'self-end shrink-0 rounded-[9999px] text-13 font-medium',
+                      isLastQuestion
+                        ? 'px-[16px] py-[6px]'
+                        : 'flex h-8 w-8 items-center justify-center',
                       customInput.trim()
                         ? 'bg-[var(--ask-send-bg)] text-[var(--ask-send-text)]'
                         : 'bg-[var(--ask-send-disabled-bg)] text-[var(--ask-send-disabled-text)]',
                     )}
                   >
-                    {isLastQuestion
-                      ? t('chat.askUserQuestion.updateAndSubmit')
-                      : t('chat.askUserQuestion.updateAndNext')}
+                    {isLastQuestion ? (
+                      t('chat.askUserQuestion.submit')
+                    ) : (
+                      <ArrowRight size={15} strokeWidth={2} aria-hidden="true" />
+                    )}
                   </button>
                 )}
               </div>
@@ -752,16 +760,23 @@ export function AskUserQuestionPrompt({
               type="button"
               onClick={() => customInput.trim() && advance(customInput.trim())}
               disabled={!customInput.trim()}
+              aria-label={
+                isLastQuestion ? undefined : t('chat.askUserQuestion.updateAndNext')
+              }
+              title={isLastQuestion ? undefined : t('chat.askUserQuestion.next')}
               className={cn(
-                'h-10 rounded-[9999px] px-4 text-14 font-medium transition-colors',
+                'h-10 rounded-[9999px] text-14 font-medium transition-colors',
+                isLastQuestion ? 'px-4' : 'flex w-10 items-center justify-center',
                 customInput.trim()
                   ? 'bg-[var(--ask-send-bg)] text-[var(--ask-send-text)]'
                   : 'bg-[var(--ask-send-disabled-bg)] text-[var(--ask-send-disabled-text)]',
               )}
             >
-              {isLastQuestion
-                ? t('chat.askUserQuestion.updateAndSubmit')
-                : t('chat.askUserQuestion.updateAndNext')}
+              {isLastQuestion ? (
+                t('chat.askUserQuestion.submit')
+              ) : (
+                <ArrowRight size={17} strokeWidth={2} aria-hidden="true" />
+              )}
             </button>
           </div>
         )}

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -6564,8 +6564,7 @@
       "next": "Next",
       "submit": "Submit",
       "customAnswer": "Type something else…",
-      "answerPlaceholder": "Type your answer…",
-      "updateAndNext": "Update & Next"
+      "answerPlaceholder": "Type your answer…"
     },
     "planReviewBubble": {
       "title": "Plan review",

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -6565,8 +6565,7 @@
       "submit": "Submit",
       "customAnswer": "Type something else…",
       "answerPlaceholder": "Type your answer…",
-      "updateAndNext": "Update & Next",
-      "updateAndSubmit": "Update & Submit"
+      "updateAndNext": "Update & Next"
     },
     "planReviewBubble": {
       "title": "Plan review",

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -6555,7 +6555,18 @@
   "chat": {
     "sessionLoading": "Loading task",
     "askUserQuestion": {
-      "skippedAnswer": "Skipped"
+      "skippedAnswer": "Skipped",
+      "pendingTitle": "Question pending",
+      "restoreAriaLabel": "Restore question prompt",
+      "minimizeAriaLabel": "Minimize question prompt",
+      "back": "Back",
+      "skip": "Skip",
+      "next": "Next",
+      "submit": "Submit",
+      "customAnswer": "Type something else…",
+      "answerPlaceholder": "Type your answer…",
+      "updateAndNext": "Update & Next",
+      "updateAndSubmit": "Update & Submit"
     },
     "planReviewBubble": {
       "title": "Plan review",

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -6589,8 +6589,7 @@
       "next": "次へ",
       "submit": "送信",
       "customAnswer": "別の回答を入力…",
-      "answerPlaceholder": "回答を入力…",
-      "updateAndNext": "更新して次へ"
+      "answerPlaceholder": "回答を入力…"
     },
     "planReviewBubble": {
       "title": "計画レビュー",

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -6590,8 +6590,7 @@
       "submit": "送信",
       "customAnswer": "別の回答を入力…",
       "answerPlaceholder": "回答を入力…",
-      "updateAndNext": "更新して次へ",
-      "updateAndSubmit": "更新して送信"
+      "updateAndNext": "更新して次へ"
     },
     "planReviewBubble": {
       "title": "計画レビュー",

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -6580,7 +6580,18 @@
   "chat": {
     "sessionLoading": "セッションを読み込み中",
     "askUserQuestion": {
-      "skippedAnswer": "スキップ済み"
+      "skippedAnswer": "スキップ済み",
+      "pendingTitle": "回答待ち",
+      "restoreAriaLabel": "質問カードを展開",
+      "minimizeAriaLabel": "質問カードを折りたたむ",
+      "back": "戻る",
+      "skip": "スキップ",
+      "next": "次へ",
+      "submit": "送信",
+      "customAnswer": "別の回答を入力…",
+      "answerPlaceholder": "回答を入力…",
+      "updateAndNext": "更新して次へ",
+      "updateAndSubmit": "更新して送信"
     },
     "planReviewBubble": {
       "title": "計画レビュー",

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -6589,8 +6589,7 @@
       "next": "다음",
       "submit": "제출",
       "customAnswer": "다른 답변 입력…",
-      "answerPlaceholder": "답변을 입력하세요…",
-      "updateAndNext": "수정 후 다음"
+      "answerPlaceholder": "답변을 입력하세요…"
     },
     "planReviewBubble": {
       "title": "계획 검토",

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -6590,8 +6590,7 @@
       "submit": "제출",
       "customAnswer": "다른 답변 입력…",
       "answerPlaceholder": "답변을 입력하세요…",
-      "updateAndNext": "수정 후 다음",
-      "updateAndSubmit": "수정 후 제출"
+      "updateAndNext": "수정 후 다음"
     },
     "planReviewBubble": {
       "title": "계획 검토",

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -6580,7 +6580,18 @@
   "chat": {
     "sessionLoading": "세션 불러오는 중",
     "askUserQuestion": {
-      "skippedAnswer": "건너뜀"
+      "skippedAnswer": "건너뜀",
+      "pendingTitle": "답변 대기 중",
+      "restoreAriaLabel": "질문 카드 펼치기",
+      "minimizeAriaLabel": "질문 카드 접기",
+      "back": "뒤로",
+      "skip": "건너뛰기",
+      "next": "다음",
+      "submit": "제출",
+      "customAnswer": "다른 답변 입력…",
+      "answerPlaceholder": "답변을 입력하세요…",
+      "updateAndNext": "수정 후 다음",
+      "updateAndSubmit": "수정 후 제출"
     },
     "planReviewBubble": {
       "title": "계획 검토",

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -6553,7 +6553,18 @@
   "chat": {
     "sessionLoading": "正在加载任务",
     "askUserQuestion": {
-      "skippedAnswer": "已跳过"
+      "skippedAnswer": "已跳过",
+      "pendingTitle": "等待回答",
+      "restoreAriaLabel": "展开问题卡片",
+      "minimizeAriaLabel": "收起问题卡片",
+      "back": "返回",
+      "skip": "跳过",
+      "next": "下一题",
+      "submit": "提交",
+      "customAnswer": "输入其他回答…",
+      "answerPlaceholder": "请输入回答…",
+      "updateAndNext": "更新并继续",
+      "updateAndSubmit": "更新并提交"
     },
     "planReviewBubble": {
       "title": "计划审阅",

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -6562,8 +6562,7 @@
       "next": "下一题",
       "submit": "提交",
       "customAnswer": "输入其他回答…",
-      "answerPlaceholder": "请输入回答…",
-      "updateAndNext": "更新并继续"
+      "answerPlaceholder": "请输入回答…"
     },
     "planReviewBubble": {
       "title": "计划审阅",

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -6563,8 +6563,7 @@
       "submit": "提交",
       "customAnswer": "输入其他回答…",
       "answerPlaceholder": "请输入回答…",
-      "updateAndNext": "更新并继续",
-      "updateAndSubmit": "更新并提交"
+      "updateAndNext": "更新并继续"
     },
     "planReviewBubble": {
       "title": "计划审阅",

--- a/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
@@ -6579,7 +6579,18 @@
   },
   "chat": {
     "askUserQuestion": {
-      "skippedAnswer": "已跳過"
+      "skippedAnswer": "已跳過",
+      "pendingTitle": "等待回答",
+      "restoreAriaLabel": "展開問題卡片",
+      "minimizeAriaLabel": "收起問題卡片",
+      "back": "返回",
+      "skip": "跳過",
+      "next": "下一題",
+      "submit": "提交",
+      "customAnswer": "輸入其他回答…",
+      "answerPlaceholder": "請輸入回答…",
+      "updateAndNext": "更新並繼續",
+      "updateAndSubmit": "更新並提交"
     },
     "planReviewBubble": {
       "title": "計劃審閱",

--- a/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
@@ -6589,8 +6589,7 @@
       "submit": "提交",
       "customAnswer": "輸入其他回答…",
       "answerPlaceholder": "請輸入回答…",
-      "updateAndNext": "更新並繼續",
-      "updateAndSubmit": "更新並提交"
+      "updateAndNext": "更新並繼續"
     },
     "planReviewBubble": {
       "title": "計劃審閱",

--- a/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
@@ -6588,8 +6588,7 @@
       "next": "下一題",
       "submit": "提交",
       "customAnswer": "輸入其他回答…",
-      "answerPlaceholder": "請輸入回答…",
-      "updateAndNext": "更新並繼續"
+      "answerPlaceholder": "請輸入回答…"
     },
     "planReviewBubble": {
       "title": "計劃審閱",


### PR DESCRIPTION
## 这次改了什么

### 摘要

优化连续提问卡片的自定义回答与最终提交交互，去掉重复或无法使用的操作，同时补齐多语言和无障碍提示。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#2954
- 本 PR 包含：
  - 问题卡片用户可见文案接入 en / zh-CN / zh-TW / ja / ko
  - 中间题自定义回答改为箭头操作，保存后进入下一题
  - 最后一题自定义回答使用 Submit，移除单选末题底部无用的 Submit
  - 多选末题继续保留底部 Submit
  - 箭头按钮补充本地化无障碍名称和共享 Tip
  - 增加单选、多选、返回修改与多语言回归测试
- 明确不包含：Ask User Question 协议、答案编码、Mobile 端交互
- 用户可见变化：中间题操作更紧凑，最后一题不再出现重复或始终灰显的提交按钮
- 是否存在 breaking change：无

### UI 变化

- Windows Desktop 连续提问卡片：中间题自定义输入右侧显示箭头；最后一题单选不显示底部无效 Submit；最后一题自定义输入右侧显示 Submit；多选末题仍通过底部 Submit 确认。
- 用户已在 Global 隔离 dev 沙盒完成手工验收；本 PR 未附录屏。
- 引用的设计规范：
  - `DESIGN.md §4 Buttons`：沿用现有 pill 形态与语义色 token
  - `DESIGN.md §10 Light / Dark Dual-Mode Delivery Gate`：未新增硬编码颜色，复用现有主题 token
  - `DESIGN.md §11 Voice & Content`：五种语言文案通过 i18n 落地
  - `DESIGN.md §14.6 Icon-only Controls and Tooltips`：箭头按钮同时提供本地化 `aria-label` 与共享 `Tip`

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/renderer/__tests__/askUserQuestionActionLabels.test.tsx
结果：通过，5/5

pnpm test:unit:related
结果：通过，apps/desktop 关联单测通过

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm check:i18n
结果：通过，五种语言 key 一致

pnpm check:i18n-glossary
结果：通过

pnpm check:dco
结果：通过，提交均带 DCO 签名

pnpm test:unit
结果：已完整执行；26951 项通过、68 项跳过、1 项失败。失败项为 pi-package-store-security.test.ts 的 Windows symlink 场景，本机创建符号链接返回 EPERM；单独复跑结果一致，与本次 Desktop Renderer / i18n 改动无关。
```

### 手工验证

- 平台：Windows Desktop
- 环境：Global 隔离 dev 沙盒 `fierce-leakey-0429ba`
- 结果：用户已验收中间题自定义回答、最后一题自定义回答、普通单选直达提交及底部按钮显示逻辑，确认通过

### 未执行的验证

- 未分别对 Light / Dark 做实机目检；本次样式沿用已有语义 token，没有新增颜色值
- 本地全仓单测存在上述 Windows symlink 权限失败，等待 GitHub CI 在标准环境复核

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：问题卡片交互与文案调整

### 影响与回滚

- 影响范围：仅 Desktop Renderer 的 Ask User Question 卡片及对应 i18n 文案和测试
- 移动端冷更判断：不涉及 `apps/mobile`、原生配置、原生依赖或 runtime fingerprint，不会触发移动端冷更
- 存量插件影响：无
- 回滚 / 降级方式：回退本 PR 的三个 commit 即可恢复原交互

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因