### PR TITLE
fix(desktop): xAI 订阅档位统一规范升序,修复 Grok 4.5 思考深度滑轴反向

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/activeCatalogDiscovery.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/activeCatalogDiscovery.test.ts
@@ -209,6 +209,25 @@ describe('active-catalog discovered augment', () => {
     });
   });
 
+  it('SuperGrok discovery 下发降序档位时目录吐规范升序(Grok 4.5 滑轴反向回归)', () => {
+    // 降序数组此前只有 Grok 4.6 经 mergeKnownXaiEfforts 顺带归一,其余条目原样透传 ——
+    // 滑杆按下标画轴,4.5 的轴整条反向(Chris 2026-08-19 实测)。合并层现在对所有 xAI
+    // 条目统一 canonicalEffortOrder;本用例模拟旧降序磁盘缓存直进合并层的形态。
+    setActiveCatalog(BUNDLED_CATALOG);
+    setXaiDiscoveredModels([
+      { id: 'xai/grok-4.5', efforts: ['high', 'medium', 'low'], defaultEffort: 'high' },
+    ]);
+    const xai = getActiveCatalog().providers.find((provider) => provider.id === 'xai');
+    expect(xai?.models['claude-code']?.find((model) => model.id === 'xai/grok-4.5')).toMatchObject({
+      efforts: ['low', 'medium', 'high'],
+      defaultEffort: 'high',
+    });
+    expect(xai?.models.pi?.find((model) => model.id === 'grok-4.5')).toMatchObject({
+      efforts: ['low', 'medium', 'high'],
+      defaultEffort: 'high',
+    });
+  });
+
   it('keeps an in-list SuperGrok discovery default for non-Grok-4.6 models', () => {
     setActiveCatalog(BUNDLED_CATALOG);
     setXaiDiscoveredModels([

--- a/apps/desktop/src/main/maker-host/__tests__/xaiModelDiscovery.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/xaiModelDiscovery.test.ts
@@ -62,6 +62,32 @@ describe('xAI account model discovery', () => {
     ]);
   });
 
+  it('降序 payload 归一为规范升序(Grok 4.5 滑轴反向回归,Chris 2026-08-19)', () => {
+    // x.ai /v1/models 实测下发降序(['high','medium','low']);消费端(滑杆按下标画轴、
+    // efforts[0]=最低 / at(-1)=最高)契约都是升序,原序透传会让整条轴反向。
+    // declaredDefault 缺席于列表时的追加分支同样必须重排,不能 push 在尾部。
+    expect(
+      parseXaiAccountModels({
+        data: [
+          {
+            model: 'grok-4.5',
+            reasoningEfforts: ['high', 'medium', 'low'],
+            reasoningEffort: 'high',
+          },
+          {
+            model: 'grok-4.6',
+            reasoningEfforts: ['xhigh', 'high', 'medium'],
+            reasoningEffort: 'low',
+          },
+        ],
+      }),
+    ).toEqual([
+      { id: 'xai/grok-4.5', efforts: ['low', 'medium', 'high'], defaultEffort: 'high' },
+      // declaredDefault('low') 不在列表里 → 追加后仍是规范升序。
+      { id: 'xai/grok-4.6', efforts: ['low', 'medium', 'high', 'xhigh'], defaultEffort: 'low' },
+    ]);
+  });
+
   it('persists a successful empty table and reloads it as an authoritative LKG', async () => {
     const dir = await fsp.mkdtemp(path.join(os.tmpdir(), 'cindy-xai-models-'));
     tempDirs.push(dir);

--- a/apps/desktop/src/main/maker-host/active-catalog.ts
+++ b/apps/desktop/src/main/maker-host/active-catalog.ts
@@ -217,6 +217,17 @@ let lastPlanWarnings: ModelPlaneWarning[] = [];
 type Effort = CatalogModel['efforts'][number];
 const EFFORT_RANK: readonly Effort[] = ['minimal', 'low', 'medium', 'high', 'xhigh', 'max', 'ultra'];
 
+/**
+ * 档位集合 → **规范升序**数组(低 → 高)。x.ai discovery 的 payload 是降序,而下游
+ * (滑杆按下标画轴、`efforts[0]`=最低 / `efforts.at(-1)`=最高的全部取值点)契约都是
+ * 升序 —— 此前只有 Grok 4.6 经 mergeKnownXaiEfforts 顺带归一,其余条目原样透传,
+ * Grok 4.5 的滑杆整条轴反向(Chris 2026-08-19 实测)。所有 xAI 条目统一过这一道。
+ */
+function canonicalEffortOrder(list: readonly Effort[] | undefined): Effort[] {
+  const seen = new Set<Effort>(list ?? []);
+  return EFFORT_RANK.filter((effort) => seen.has(effort));
+}
+
 /** Union discovery with the known official ladder so an incomplete SuperGrok payload cannot hide xhigh.
  * Official source (2026-08-16): https://docs.x.ai/developers/model-capabilities/text/reasoning
  * Grok 4.6 = low | medium | high (default) | xhigh. */
@@ -224,8 +235,7 @@ function mergeKnownXaiEfforts(
   discovered: readonly Effort[] | undefined,
   baseline: readonly Effort[] | undefined,
 ): Effort[] {
-  const seen = new Set<Effort>([...(discovered ?? []), ...(baseline ?? [])]);
-  return EFFORT_RANK.filter((effort) => seen.has(effort));
+  return canonicalEffortOrder([...(discovered ?? []), ...(baseline ?? [])]);
 }
 
 function isOfficialGrok46Id(modelId: string): boolean {
@@ -242,6 +252,9 @@ function pickXaiDefaultEffort(
   }
   if (efforts.length === 0) return null;
   if (fallback === 'official-high' && efforts.includes('high')) return 'high';
+  // efforts 已规范升序(canonicalEffortOrder):'official-high' 的兜底 = 最高档;
+  // 'first' 的兜底 = 最低档 —— 没有任何来源声明默认时保守起步,这条路仅在
+  // discovery / registry / catalog 三处默认全缺时才会走到(实测 payload 都带 default)。
   return fallback === 'official-high'
     ? (efforts[efforts.length - 1] ?? null)
     : (efforts[0] ?? null);
@@ -255,11 +268,14 @@ function resolveXaiAccountCapabilities(
   catalogDefault: Effort | null | undefined,
 ): { efforts: Effort[]; defaultEffort: Effort | null } {
   const isGrok46 = isOfficialGrok46Id(entry.id);
+  // 非 4.6 仍「以 discovery 为准」(不与官方梯子并集),但**顺序必须归一**:discovery 层
+  // 已排过一道(model-discovery/xai.ts canonicalEffortOrder),这里再兜一次是防御 ——
+  // efforts 是外部输入(payload / 磁盘缓存 / registry 静态值),任何一路漏排都会让滑杆反向。
   const efforts = isGrok46
     ? mergeKnownXaiEfforts(entry.efforts, baselineEfforts)
     : entry.efforts !== undefined
-      ? [...entry.efforts]
-      : [...(baselineEfforts ?? [])];
+      ? canonicalEffortOrder(entry.efforts)
+      : canonicalEffortOrder(baselineEfforts);
   const defaultEffort = isGrok46
     ? pickXaiDefaultEffort(
         efforts,

--- a/apps/desktop/src/main/maker-host/model-discovery/xai.ts
+++ b/apps/desktop/src/main/maker-host/model-discovery/xai.ts
@@ -3,7 +3,7 @@
 import fsp from 'node:fs/promises';
 import path from 'node:path';
 
-import type { Effort } from '@cindy/model-providers';
+import { effortRank, type Effort } from '@cindy/model-providers';
 
 import { activeOwnerScopeKey, ownerScopedUserDataPath } from '../../appSessionState.js';
 import { createLogger, type Logger } from '../../logger.js';
@@ -111,6 +111,18 @@ function effort(value: unknown): Effort | undefined {
   return typeof value === 'string' && VALID_EFFORTS.has(value) ? (value as Effort) : undefined;
 }
 
+/**
+ * 档位数组一律**规范升序**(低 → 高)。x.ai 的 `/v1/models` 下发的是**降序**
+ * (Chris 2026-08-19 实测:`['high','medium','low']`),而全仓消费端(EffortSlider 的
+ * 按下标画轴、`efforts[0]`=最低 / `efforts.at(-1)`=最高的取值点)契约都是升序 ——
+ * 原序透传出去,Grok 4.5 的滑杆整条轴反向,用户以为在拉高、实际每次都写 low。
+ * 顺序是**表示细节**,在入库这一点归一,payload / 磁盘缓存怎么排都不再泄漏到下游;
+ * `parseCachedModels` 复用本函数,已落盘的降序缓存下次读取即被纠正,不必等刷新。
+ */
+function canonicalEffortOrder(list: readonly Effort[]): Effort[] {
+  return [...list].sort((a, b) => effortRank(a) - effortRank(b));
+}
+
 function parseReasoningEfforts(raw: unknown): { efforts?: Effort[]; declaredDefault?: Effort } {
   if (!Array.isArray(raw)) return {};
   const efforts: Effort[] = [];
@@ -121,7 +133,7 @@ function parseReasoningEfforts(raw: unknown): { efforts?: Effort[]; declaredDefa
     efforts.push(value);
     if (isRecord(item) && item.default === true) declaredDefault = value;
   }
-  return { efforts, declaredDefault };
+  return { efforts: canonicalEffortOrder(efforts), declaredDefault };
 }
 
 function canonicalModelId(raw: string): string {
@@ -161,7 +173,9 @@ export function parseXaiAccountModels(payload: unknown): XaiDiscoveredModel[] {
     } else if (efforts === undefined && declaredDefault) {
       efforts = [declaredDefault];
     } else if (efforts && declaredDefault && !efforts.includes(declaredDefault)) {
-      efforts = [...efforts, declaredDefault];
+      // 追加后重排:declaredDefault 直接 push 到尾部会破坏 parseReasoningEfforts
+      // 已经建立的规范升序(见 canonicalEffortOrder)。
+      efforts = canonicalEffortOrder([...efforts, declaredDefault]);
     }
     const name = stringField(value, 'name');
     const description = stringField(value, 'description');

--- a/packages/model-providers/src/__tests__/unifiedSelection.test.ts
+++ b/packages/model-providers/src/__tests__/unifiedSelection.test.ts
@@ -671,6 +671,33 @@ describe('resolveAgentCapability', () => {
     expect(resolveAgentCapability(providers, 'anthropic', 'gpt-5.5', 'codex')).toBeNull();
     expect(resolveAgentCapability(providers, 'nope', 'gpt-5.5', 'codex')).toBeNull();
   });
+
+  it('efforts 防御性规范升序:任何来源的降序/乱序数组经统一选择路径吐升序(Grok 4.5 反轴回归)', () => {
+    // efforts 是外部输入(服务端目录 / 三家 discovery / 用户 override),而消费端(滑杆按
+    // 下标画轴、efforts[0]=最低 / at(-1)=最高)契约都是升序 —— capabilityOf 的这道排序是
+    // 「任一来源漏排就反轴」整类缺陷的单点防线,必须直接锁在共享路径上,不能只靠 xAI
+    // 解析层 / 目录合并层各自的测试(那两层删了排序,这里要能红)。fixture 刻意用非 xAI
+    // 的网关来源。
+    const p = view({
+      id: 'xd',
+      authStrategy: 'gateway-key',
+      models: {
+        'claude-code': [
+          m('desc-order', { efforts: ['high', 'medium', 'low'], defaultEffort: 'high' }),
+          m('shuffled', { efforts: ['xhigh', 'low', 'high'], defaultEffort: null }),
+        ],
+      },
+    });
+    const cap = (id: string) => resolveAgentCapability([p], 'xd', id, 'claude-code');
+    expect(cap('desc-order')?.efforts).toEqual(['low', 'medium', 'high']);
+    // 排序只动表示,不动语义:目录声明的合法默认档原样保留(低→高轴上 high 落在右端)。
+    expect(cap('desc-order')?.defaultEffort).toBe('high');
+    expect(cap('desc-order')?.defaultEffortSource).toBe('catalog');
+    expect(cap('shuffled')?.efforts).toEqual(['low', 'high', 'xhigh']);
+    // 默认档回落判据按集合走(不含 medium → none),与顺序无关。
+    expect(cap('shuffled')?.defaultEffort).toBeNull();
+    expect(cap('shuffled')?.defaultEffortSource).toBe('none');
+  });
 });
 
 // ── unifiedModelEntries ───────────────────────────────────────────────────────
@@ -692,6 +719,20 @@ describe('unifiedModelEntries', () => {
     expect(row.capabilities.pi?.wireModelId).toBe('chatgpt/gpt-5.6-luna');
     // 展示元数据取推荐引擎(codex root)那条。
     expect(row.displayName).toBe('GPT-5.6-Luna');
+  });
+
+  it('行能力的 efforts 同样规范升序(user provider 降序数组 —— capabilityOf 的第二个入口)', () => {
+    // capabilityOf 只有两个调用方:resolveAgentCapability(浮层实时能力)与本函数的行合成。
+    // 两条路径都必须直接锁住排序 —— 只锁一条,另一条把排序改错时不会被发现。
+    const byom = view({
+      id: 'custom:mine',
+      source: 'user',
+      models: { codex: [m('my-model', { efforts: ['high', 'low'], defaultEffort: 'low' })] },
+    });
+    const entries = unifiedModelEntries({ providers: [byom], isVisible: alwaysVisible });
+    const row = entries.find((entry) => entry.modelId === 'my-model');
+    expect(row?.capabilities.codex?.efforts).toEqual(['low', 'high']);
+    expect(row?.capabilities.codex?.defaultEffort).toBe('low');
   });
 
   it('每个候选都有 wire id,且 wire id 必在该引擎目录里真实存在', () => {

--- a/packages/model-providers/src/unifiedSelection.ts
+++ b/packages/model-providers/src/unifiedSelection.ts
@@ -61,6 +61,7 @@ import {
   type ProviderView,
 } from './registry.js';
 import { deriveModelList } from './modelList.js';
+import { effortRank } from './effortResolution.js';
 import { CHATGPT_MODEL_PREFIX, XAI_MODEL_PREFIX, groupOf, isBudgetModel } from './classification.js';
 import type { AgentKind, CatalogModel, Effort, Provider } from './types.js';
 
@@ -440,7 +441,11 @@ function capabilityOf(
   return {
     agent,
     wireModelId: model.id,
-    efforts: model.efforts,
+    // 防御性规范升序(Chris 2026-08-19 实测:xAI discovery 下发降序,只有 Grok 4.6 被
+    // 特判归一,4.5 的滑杆整条轴反向)。efforts 是外部输入(服务端目录 / 三家 discovery /
+    // 用户 local override),而滑杆与行三元组按数组下标画轴 —— 数据侧已在 xAI 链路归一,
+    // 这里对**所有来源**再兜一道,单点成本换掉整类「某条来源漏排就反轴」的缺陷。
+    efforts: [...model.efforts].sort((a, b) => effortRank(a) - effortRank(b)),
     ...resolveDefaultEffort(model),
     // 按目录里真实那条 id 查 Fast,避免归一命中后误报 false。
     supportsFastMode: modelSupportsFastMode(provider, model.id, agent),


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 xAI 订阅下 Grok 4.5 思考深度滑杆**整条轴反向**(最右端显示「低」,用户以为在拉高、实际每次都把 low 写进档位记忆;列表行尾同样显示「低」并被标成「已自定义」)。

根因:x.ai `/v1/models` 下发的 `reasoningEfforts` 是**降序**(实测本机 discovery 缓存:`['high','medium','low']`);目录合并层只有 Grok 4.6 经 `mergeKnownXaiEfforts`(#2601「保 xhigh」)顺带归一为升序,其余条目原样透传,并在 registry overlay 之后由 `preserveNonGrok46DiscoveryEfforts` 把降序压回目录;而消费端契约都是升序(EffortSlider 按数组下标画轴与配色,`efforts[0]`=最低 / `at(-1)`=最高的取值点全仓约 25 处)。

修法(顺序是表示细节,在数据入口归一,不改任何消费端画轴逻辑):
1. `model-discovery/xai.ts`:`parseReasoningEfforts` 输出规范升序;`declaredDefault` 不在列表时的追加分支同样重排。`parseCachedModels` 复用同一函数 → **已落盘的降序缓存下次读取即被纠正**,不必等 24h 刷新。
2. `active-catalog.ts`:`canonicalEffortOrder` 推广到所有 xAI 条目(4.6 = 官方梯子并集 + 归一,其余 = 仅归一;「非 4.6 不并官方梯子」的语义不变);`pickXaiDefaultEffort` 兜底路径的升序语义写明(仅三处默认全缺时才走到)。
3. `packages/model-providers` `unifiedSelection.capabilityOf`:对**所有来源**的 efforts 防御性按 `effortRank` 排序——efforts 是外部输入(服务端目录 / 三家 discovery / 用户 override),单点兜掉「任一来源漏排就反轴」整类缺陷。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求:Chris 2026-08-19 会话内实测反馈(截图:Grok 4.5 浮层滑块拉到最右显示「低」)
- 本 PR 包含:上述三层归一 + 降序回归测试(discovery 解析层 + 目录合并层)
- 明确不包含:EffortSlider / ModelConfigFlyout 画轴逻辑(契约本就是升序数组);全仓其余按下标取值点的逐个改造;用户已写入 providerModelMemory 的档位记忆清洗(值合法,轴正过来后语义自然恢复);统一选择器其它行为(#3025 的范围)
- 用户可见变化:Grok 4.5(及任何 discovery 下发降序的 xAI 条目)滑杆恢复左低右高;推荐档 high 回到轴右侧
- 是否存在 breaking change:无

### UI 变化

不涉及:纯数据顺序修复,无视觉/交互/文案变化。

- 引用的设计规范:不涉及

## 怎么验证的

### 自动验证

```text
npx vitest run xaiModelDiscovery.test.ts activeCatalogDiscovery.test.ts
结果:33 例全过(含新增降序回归 2 例)
pnpm --filter @cindy/model-providers run typecheck / pnpm --filter desktop run typecheck
结果:均通过
pnpm test:unit:related
结果:27104 过 / 2 失败——两条失败均在 src/main/cindy-brain/__tests__/ghostInstallReceipt.test.ts
(插件安装收据),与本 diff 零交集;已在未含本改动的干净 main checkout 复验**同样失败**,
属主干基线问题,不在本 PR 修(见仓库规则:无关失败不混入修复)。
```

### 手工验证

不涉及(数据顺序修复,由单测锁定)。

### 未执行的验证

实机滑杆目检未执行(不起 Desktop DEV)。用户验证步骤:重启应用(或等下次 discovery 读缓存)后打开 xAI 订阅 Grok 4.5 的浮层,滑杆应左低右高、推荐档 high 位于右侧;列表行尾档字与浮层一致。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围:xAI 订阅模型的档位数组顺序(值集合不变,只排序);统一选择器所有来源的 efforts 展示顺序(防御排序,合法目录数据本就升序,无行为变化)。
- 回滚 / 降级方式:整 PR revert;磁盘缓存无 schema 变化。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`,见 [DCO](../DCO))
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节(不涉及 UI 则跳过)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档(注释即文档,规则文档无需变更)
- [x] 已确认测试结果或说明未执行原因
