### PR TITLE
fix(desktop): 跨 Agent 全局 Skill 拉入默认关闭，需显式 opt-in

### DIFF
--- a/apps/desktop/src/main/__tests__/sharedGlobalSkills.test.ts
+++ b/apps/desktop/src/main/__tests__/sharedGlobalSkills.test.ts
@@ -44,13 +44,47 @@ afterEach(async () => {
 });
 
 describe('prepareSharedGlobalSkillLinks', () => {
+  it('does not pull other-agent skills into the shared index by default (opt-in gate, #2930)', async () => {
+    const root = await makeTmpDir();
+    const homeDir = path.join(root, 'home');
+    const paths = sharedGlobalSkillsPaths(homeDir);
+    await writeSkill(paths.claudeSkillsDir, 'claude-only');
+
+    const result = await prepareSharedGlobalSkillLinks({ homeDir });
+
+    expect(result.changed).toBe(false);
+    expect(result.actions).toEqual([]);
+    expect(result.warnings).toEqual([
+      'cross-agent global skill sync is disabled; set crossAgentSyncEnabled to opt in',
+    ]);
+    // 未 opt-in 时，不把 Claude 的用户技能拉进 ~/.agents/skills。
+    await expect(fs.lstat(path.join(paths.sharedSkillsDir, 'claude-only'))).rejects.toMatchObject({
+      code: 'ENOENT',
+    });
+  });
+
+  it('still projects the shared index into Claude when sync is disabled (Ghost projection)', async () => {
+    const root = await makeTmpDir();
+    const homeDir = path.join(root, 'home');
+    const paths = sharedGlobalSkillsPaths(homeDir);
+    const sharedSkill = await writeSkill(paths.sharedSkillsDir, 'ghost-managed');
+
+    const result = await prepareSharedGlobalSkillLinks({ homeDir });
+
+    expect(result.changed).toBe(true);
+    // ~/.agents → ~/.claude 的 Cindy 自有索引投影仍保留（Ghost skill 依赖它）。
+    expect(await sameRealPath(path.join(paths.claudeSkillsDir, 'ghost-managed'), sharedSkill)).toBe(true);
+    // 纯 Ghost 对账不应打扰（无其它 Agent 用户技能可同步时，不提示）。
+    expect(result.warnings).toEqual([]);
+  });
+
   it('links existing Claude skills into the shared skills root for Codex visibility', async () => {
     const root = await makeTmpDir();
     const homeDir = path.join(root, 'home');
     const paths = sharedGlobalSkillsPaths(homeDir);
     const claudeSkill = await writeSkill(paths.claudeSkillsDir, 'claude-only');
 
-    const result = await prepareSharedGlobalSkillLinks({ homeDir });
+    const result = await prepareSharedGlobalSkillLinks({ homeDir, isCrossAgentSyncEnabled: () => true });
 
     expect(result.changed).toBe(true);
     expect(result.warnings).toEqual([]);
@@ -74,6 +108,7 @@ describe('prepareSharedGlobalSkillLinks', () => {
       await expect(
         prepareSharedGlobalSkillLinks({
           homeDir,
+          isCrossAgentSyncEnabled: () => true,
           assertOwnerStable: () => {
             if (!ownerStable) throw new Error('owner changed');
           },
@@ -98,7 +133,7 @@ describe('prepareSharedGlobalSkillLinks', () => {
     const paths = sharedGlobalSkillsPaths(homeDir);
     const sharedSkill = await writeSkill(paths.sharedSkillsDir, 'shared-only');
 
-    const result = await prepareSharedGlobalSkillLinks({ homeDir });
+    const result = await prepareSharedGlobalSkillLinks({ homeDir, isCrossAgentSyncEnabled: () => true });
 
     expect(result.changed).toBe(true);
     expect(result.warnings).toEqual([]);
@@ -111,8 +146,8 @@ describe('prepareSharedGlobalSkillLinks', () => {
     const paths = sharedGlobalSkillsPaths(homeDir);
     const codexSkill = await writeSkill(paths.codexSkillsDir, 'codex-only');
 
-    await prepareSharedGlobalSkillLinks({ homeDir });
-    const secondResult = await prepareSharedGlobalSkillLinks({ homeDir });
+    await prepareSharedGlobalSkillLinks({ homeDir, isCrossAgentSyncEnabled: () => true });
+    const secondResult = await prepareSharedGlobalSkillLinks({ homeDir, isCrossAgentSyncEnabled: () => true });
 
     expect(secondResult.changed).toBe(false);
     expect(secondResult.warnings).toEqual([]);
@@ -136,6 +171,7 @@ describe('prepareSharedGlobalSkillLinks', () => {
       await expect(
         prepareSharedGlobalSkillLinks({
           homeDir,
+          isCrossAgentSyncEnabled: () => true,
           assertOwnerStable: () => {
             if (!ownerStable) throw new Error('owner changed');
           },
@@ -161,7 +197,7 @@ describe('prepareSharedGlobalSkillLinks', () => {
     const sharedSkill = await writeSkill(paths.sharedSkillsDir, 'duplicate');
     const codexSkill = await writeSkill(paths.codexSkillsDir, 'duplicate');
 
-    const result = await prepareSharedGlobalSkillLinks({ homeDir });
+    const result = await prepareSharedGlobalSkillLinks({ homeDir, isCrossAgentSyncEnabled: () => true });
 
     expect(result.warnings.some((warning) => warning.includes('duplicate'))).toBe(true);
     expect(await sameRealPath(path.join(paths.sharedSkillsDir, 'duplicate'), sharedSkill)).toBe(true);
@@ -178,7 +214,7 @@ describe('prepareSharedGlobalSkillLinks', () => {
     await fs.mkdir(paths.sharedSkillsDir, { recursive: true });
     await fs.symlink(externalSkill, sharedLink, process.platform === 'win32' ? 'junction' : 'dir');
 
-    const result = await prepareSharedGlobalSkillLinks({ homeDir });
+    const result = await prepareSharedGlobalSkillLinks({ homeDir, isCrossAgentSyncEnabled: () => true });
 
     expect(result.warnings.some((warning) => warning.includes('user-link'))).toBe(true);
     expect(await sameRealPath(sharedLink, externalSkill)).toBe(true);
@@ -191,12 +227,12 @@ describe('prepareSharedGlobalSkillLinks', () => {
     const paths = sharedGlobalSkillsPaths(homeDir);
     const codexSkill = await writeSkill(paths.codexSkillsDir, 'removed-codex-skill');
 
-    await prepareSharedGlobalSkillLinks({ homeDir });
+    await prepareSharedGlobalSkillLinks({ homeDir, isCrossAgentSyncEnabled: () => true });
     expect(await sameRealPath(path.join(paths.sharedSkillsDir, 'removed-codex-skill'), codexSkill)).toBe(true);
     expect(await sameRealPath(path.join(paths.claudeSkillsDir, 'removed-codex-skill'), codexSkill)).toBe(true);
 
     await fs.rm(codexSkill, { recursive: true, force: true });
-    const result = await prepareSharedGlobalSkillLinks({ homeDir });
+    const result = await prepareSharedGlobalSkillLinks({ homeDir, isCrossAgentSyncEnabled: () => true });
 
     expect(result.changed).toBe(true);
     await expect(fs.lstat(path.join(paths.sharedSkillsDir, 'removed-codex-skill'))).rejects.toMatchObject({
@@ -216,8 +252,8 @@ describe('prepareSharedGlobalSkillLinks', () => {
     await fs.mkdir(paths.codexSkillsDir, { recursive: true });
     await fs.symlink(sharedSkill, codexLink, process.platform === 'win32' ? 'junction' : 'dir');
 
-    await prepareSharedGlobalSkillLinks({ homeDir });
-    const secondResult = await prepareSharedGlobalSkillLinks({ homeDir });
+    await prepareSharedGlobalSkillLinks({ homeDir, isCrossAgentSyncEnabled: () => true });
+    const secondResult = await prepareSharedGlobalSkillLinks({ homeDir, isCrossAgentSyncEnabled: () => true });
 
     expect(secondResult.changed).toBe(false);
     expect(secondResult.warnings).toEqual([]);
@@ -232,7 +268,7 @@ describe('prepareSharedGlobalSkillLinks', () => {
     const sharedSkill = await writeSkill(paths.sharedSkillsDir, 'duplicate');
     const claudeSkill = await writeSkill(paths.claudeSkillsDir, 'duplicate');
 
-    const result = await prepareSharedGlobalSkillLinks({ homeDir });
+    const result = await prepareSharedGlobalSkillLinks({ homeDir, isCrossAgentSyncEnabled: () => true });
 
     expect(result.warnings.some((warning) => warning.includes('duplicate'))).toBe(true);
     expect(await sameRealPath(path.join(paths.sharedSkillsDir, 'duplicate'), sharedSkill)).toBe(true);
@@ -250,7 +286,7 @@ describe('prepareSharedGlobalSkillLinks', () => {
     await fs.mkdir(paths.claudeSkillsDir, { recursive: true });
     await fs.symlink(externalSkill, claudeLink, process.platform === 'win32' ? 'junction' : 'dir');
 
-    const result = await prepareSharedGlobalSkillLinks({ homeDir });
+    const result = await prepareSharedGlobalSkillLinks({ homeDir, isCrossAgentSyncEnabled: () => true });
 
     expect(result.warnings.some((warning) => warning.includes('user-link'))).toBe(true);
     expect(await sameRealPath(claudeLink, externalSkill)).toBe(true);
@@ -263,11 +299,11 @@ describe('prepareSharedGlobalSkillLinks', () => {
     const paths = sharedGlobalSkillsPaths(homeDir);
     const claudeSkill = await writeSkill(paths.claudeSkillsDir, 'removed-later');
 
-    await prepareSharedGlobalSkillLinks({ homeDir });
+    await prepareSharedGlobalSkillLinks({ homeDir, isCrossAgentSyncEnabled: () => true });
     expect(await sameRealPath(path.join(paths.sharedSkillsDir, 'removed-later'), claudeSkill)).toBe(true);
 
     await fs.rm(claudeSkill, { recursive: true, force: true });
-    const result = await prepareSharedGlobalSkillLinks({ homeDir });
+    const result = await prepareSharedGlobalSkillLinks({ homeDir, isCrossAgentSyncEnabled: () => true });
 
     expect(result.changed).toBe(true);
     await expect(fs.lstat(path.join(paths.sharedSkillsDir, 'removed-later'))).rejects.toMatchObject({

--- a/apps/desktop/src/main/maker-host/shared-global-skills-settings.ts
+++ b/apps/desktop/src/main/maker-host/shared-global-skills-settings.ts
@@ -1,0 +1,59 @@
+/**
+ * shared-global-skills-settings —— 全局 Skill 跨 Agent 链接的显式 opt-in。
+ *
+ * File: <userData>/shared-global-skills-settings.json
+ *   { "crossAgentSyncEnabled": true }
+ *
+ * Default off（#2930）：默认不跨 Agent 修改任何全局 Skill 根，共享必须由用户显式
+ * opt-in。文件只存被改过的字段，未改过的字段随未来默认值变化流动。
+ */
+
+import { app } from 'electron';
+import path from 'node:path';
+
+import { desktopMakerLogger } from './logger-adapter.js';
+import {
+  createOverrideSettingsFile,
+  type OverrideSettingsState,
+} from './override-settings-file.js';
+
+const log = desktopMakerLogger.child('shared-global-skills-settings');
+
+export interface SharedGlobalSkillsSettings {
+  crossAgentSyncEnabled: boolean;
+}
+
+const DEFAULTS: SharedGlobalSkillsSettings = {
+  crossAgentSyncEnabled: false,
+};
+
+function settingsFilePath(): string {
+  return path.join(app.getPath('userData'), 'shared-global-skills-settings.json');
+}
+
+function normalize(raw: unknown): SharedGlobalSkillsSettings {
+  if (!raw || typeof raw !== 'object') return { ...DEFAULTS };
+  const r = raw as Record<string, unknown>;
+  return {
+    crossAgentSyncEnabled:
+      typeof r.crossAgentSyncEnabled === 'boolean'
+        ? r.crossAgentSyncEnabled
+        : DEFAULTS.crossAgentSyncEnabled,
+  };
+}
+
+const store = createOverrideSettingsFile<SharedGlobalSkillsSettings>({
+  filePath: settingsFilePath,
+  defaults: DEFAULTS,
+  normalize,
+  log,
+  label: 'shared global skills',
+});
+
+export function readSharedGlobalSkillsSettings(): SharedGlobalSkillsSettings {
+  return store.read();
+}
+
+export function readSharedGlobalSkillsSettingsState(): OverrideSettingsState<SharedGlobalSkillsSettings> {
+  return store.readState();
+}

--- a/apps/desktop/src/main/maker-host/shared-global-skills-settings.ts
+++ b/apps/desktop/src/main/maker-host/shared-global-skills-settings.ts
@@ -51,9 +51,13 @@ const store = createOverrideSettingsFile<SharedGlobalSkillsSettings>({
 });
 
 export function readSharedGlobalSkillsSettings(): SharedGlobalSkillsSettings {
+  // 隐藏配置约定：直接改文件也是正式 opt-in 入口，读取前按 mtime 失效缓存，
+  // 否则运行期间写入 crossAgentSyncEnabled 仍会读到旧值直到重启（review P2）。
+  store.invalidateIfChanged();
   return store.read();
 }
 
 export function readSharedGlobalSkillsSettingsState(): OverrideSettingsState<SharedGlobalSkillsSettings> {
+  store.invalidateIfChanged();
   return store.readState();
 }

--- a/apps/desktop/src/main/maker-host/shared-global-skills.ts
+++ b/apps/desktop/src/main/maker-host/shared-global-skills.ts
@@ -36,6 +36,11 @@ interface PrepareOptions {
   homeDir?: string;
   /** Optional owner-bound caller guard for Ghost-managed fanout. */
   assertOwnerStable?: () => void;
+  /**
+   * 跨 Agent 链接的显式 opt-in 判定（#2930）。缺省时读
+   * shared-global-skills-settings（默认关）；注入用于单测确定性控制。
+   */
+  isCrossAgentSyncEnabled?: () => boolean;
 }
 
 export interface SharedProjectSkillLinksResult {
@@ -336,6 +341,15 @@ export async function prepareSharedGlobalSkillLinks(
 ): Promise<SharedGlobalSkillLinksResult> {
   opts.assertOwnerStable?.();
   const paths = sharedGlobalSkillsPaths(opts.homeDir);
+  // #2930：跨 Agent 的「拉入」默认关闭，必须显式 opt-in（Claude→shared、
+  // Codex→Claude、Codex→shared）。Cindy 自有索引向 Claude 的投影（shared→Claude）
+  // 保留，避免破坏 Ghost skill 的 .claude 兼容链接（职责分界见 skillSlot.ts）。
+  const crossAgentSyncEnabled = opts.isCrossAgentSyncEnabled
+    ? opts.isCrossAgentSyncEnabled()
+    : // 延迟 import：本模块是纯 Node（无 electron 静态依赖），settings store 引
+      // electron 的 app.getPath，静态引入会拖坏单测环境。
+      (await import('./shared-global-skills-settings.js'))
+        .readSharedGlobalSkillsSettings().crossAgentSyncEnabled;
   opts.assertOwnerStable?.();
   await fsp.mkdir(paths.sharedSkillsDir, { recursive: true });
   opts.assertOwnerStable?.();
@@ -369,17 +383,46 @@ export async function prepareSharedGlobalSkillLinks(
     opts.assertOwnerStable,
   )) || changed;
 
-  const initialClaudeEntries = (await listSkillEntries('claude', paths.claudeSkillsDir))
+  // 其它 Agent 根里、且不是「指向受管根」投影的用户技能，才是跨 Agent 拉入的对象。
+  const claudeEntries = (await listSkillEntries('claude', paths.claudeSkillsDir))
     .filter((entry) => !(entry.isSymlink && pointsInto(entry, [sharedRootCompare, codexRootCompare])));
-  const claudeToShared = await linkEntriesIntoRoot(
-    initialClaudeEntries,
-    paths.sharedSkillsDir,
-    false,
-    opts.assertOwnerStable,
-  );
-  actions.push(...claudeToShared.actions);
-  warnings.push(...claudeToShared.warnings);
-  changed = changed || claudeToShared.changed;
+  const codexEntries = (await listSkillEntries('codex', paths.codexSkillsDir))
+    .filter((entry) => !(entry.isSymlink && pointsInto(entry, [sharedRootCompare, claudeRootCompare])));
+
+  if (crossAgentSyncEnabled) {
+    const claudeToShared = await linkEntriesIntoRoot(
+      claudeEntries,
+      paths.sharedSkillsDir,
+      false,
+      opts.assertOwnerStable,
+    );
+    actions.push(...claudeToShared.actions);
+    warnings.push(...claudeToShared.warnings);
+    changed = changed || claudeToShared.changed;
+
+    const codexToClaude = await linkEntriesIntoRoot(
+      codexEntries,
+      paths.claudeSkillsDir,
+      false,
+      opts.assertOwnerStable,
+    );
+    actions.push(...codexToClaude.actions);
+    warnings.push(...codexToClaude.warnings);
+    changed = changed || codexToClaude.changed;
+
+    const codexToShared = await linkEntriesIntoRoot(
+      codexEntries,
+      paths.sharedSkillsDir,
+      false,
+      opts.assertOwnerStable,
+    );
+    actions.push(...codexToShared.actions);
+    warnings.push(...codexToShared.warnings);
+    changed = changed || codexToShared.changed;
+  } else if (claudeEntries.length > 0 || codexEntries.length > 0) {
+    // 未 opt-in 且存在可同步的用户技能时才提示；纯 Ghost 对账不打扰。
+    warnings.push('cross-agent global skill sync is disabled; set crossAgentSyncEnabled to opt in');
+  }
 
   const sharedEntries = await listSkillEntries('shared', paths.sharedSkillsDir);
   const sharedToClaude = await linkEntriesIntoRoot(
@@ -391,28 +434,6 @@ export async function prepareSharedGlobalSkillLinks(
   actions.push(...sharedToClaude.actions);
   warnings.push(...sharedToClaude.warnings);
   changed = changed || sharedToClaude.changed;
-
-  const codexEntries = (await listSkillEntries('codex', paths.codexSkillsDir))
-    .filter((entry) => !(entry.isSymlink && pointsInto(entry, [sharedRootCompare, claudeRootCompare])));
-  const codexToClaude = await linkEntriesIntoRoot(
-    codexEntries,
-    paths.claudeSkillsDir,
-    false,
-    opts.assertOwnerStable,
-  );
-  actions.push(...codexToClaude.actions);
-  warnings.push(...codexToClaude.warnings);
-  changed = changed || codexToClaude.changed;
-
-  const codexToShared = await linkEntriesIntoRoot(
-    codexEntries,
-    paths.sharedSkillsDir,
-    false,
-    opts.assertOwnerStable,
-  );
-  actions.push(...codexToShared.actions);
-  warnings.push(...codexToShared.warnings);
-  changed = changed || codexToShared.changed;
 
   opts.assertOwnerStable?.();
   return {


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 #2930（High：跨 Agent 信任边界 / 持久化全局配置污染）。`prepareSharedGlobalSkillLinks` 此前无条件做三路双向扇出，把用户只在 Claude/Codex 一侧安装、甚至已在另一侧明确禁用的全局 Skill 静默重新注入（issue 中的 `using-superpowers` 注入链）。

本 PR 把「拉入」方向的扇出默认关闭、改为显式 opt-in：

- **默认关闭**：`~/.claude/skills → ~/.agents/skills`、`~/.codex/skills → ~/.claude/skills`、`~/.codex/skills → ~/.agents/skills` 不再自动发生。
- **保留**：Cindy 自有索引 `~/.agents/skills → ~/.claude/skills` 的投影，因为它承载 Ghost skill 的 `.claude` 兼容链接（职责分界见 `skillSlot.ts`）。
- **opt-in 方式**：在 userData 下创建 `shared-global-skills-settings.json`，内容 `{"crossAgentSyncEnabled": true}`。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#2930
- 本 PR 包含：`shared-global-skills.ts` 的 opt-in 门 + 新增 `shared-global-skills-settings.ts`（默认关的 settings store）+ 单测（默认不拉入、Ghost 投影保留、显式 opt-in 后行为不变）。
- 明确不包含：#2930 的其余要求——写入前 dry-run 清单、per-Agent denylist /「永不桥接此 Skill」、链接 ownership manifest、卸载/关闭时只回滚 Cindy 自建链接、受影响用户一次性清理入口。这些需要更大的设计与迁移面，本 PR 只落地最基础的安全边界「默认不拉入 + 显式 opt-in」。
- 用户可见变化：默认不再把其它 Agent 的全局 Skill 拉进 Cindy 索引；opt-in 后行为与之前完全一致。
- 是否存在 breaking change：无（对未 opt-in 用户是行为收紧；Ghost 投影不受影响）。

### UI 变化

不涉及：纯主进程文件系统链接逻辑改动，无视觉/交互/文案变化。

- 引用的设计规范：不涉及（无视觉/交互/文案层面新增）

## 怎么验证的

### 自动验证

```text
cd apps/desktop && corepack pnpm vitest run \
  src/main/__tests__/sharedGlobalSkills.test.ts \
  src/main/cindy-brain/__tests__/skillSlot.test.ts \
  src/main/learn-host/__tests__/apply.test.ts \
  src/main/maker-host/__tests__/claudeAuthAdapterOAuthEnv.test.ts \
  src/main/skillhub/__tests__/autoSyncService.test.ts \
  src/main/skillhub/__tests__/importLocalSkill.test.ts \
  src/main/skillhub/__tests__/installService.test.ts
结果：161 通过、0 失败

corepack pnpm exec eslint \
  src/main/maker-host/shared-global-skills.ts \
  src/main/maker-host/shared-global-skills-settings.ts \
  src/main/__tests__/sharedGlobalSkills.test.ts
结果：无输出（干净）
```

### 手工验证

不涉及（纯 Node 主进程逻辑，单测已覆盖链接行为）。

### 未执行的验证

- 完整 desktop typecheck 未跑通：仓库现有 `@cindy/maker-pi-manager` 缺失导致的既有报错（3 处，均在 pi-manager / remote-ssh，与本次改动无关），本次改动的 3 个文件无新增报错。
- 未在真实 desktop 运行时端到端验证 opt-in 文件被读取（单测通过 electron stub 的 userData 路径覆盖了默认关闭路径）。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅全局 Skill 的跨 Agent 链接行为。未 opt-in 用户不再被拉入其它 Agent 的技能；opt-in 用户行为与之前一致；Ghost skill 的 `.claude` 投影不受影响。
- 回滚 / 降级方式：revert 本 commit 即恢复无条件扇出；无持久化 schema 变更。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在「UI 变化」注明（不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（settings store 头部注释说明文件格式与 opt-in 方式）
- [x] 已确认测试结果或说明未执行原因

### 需要把关人确认的设计点

1. **`shared→Claude` 投影被保留**：这是为不破坏 Ghost skill 的 `.claude` 兼容链接。若团队认为「默认关闭」也应覆盖这条投影，需要另行拆分 Ghost 投影与用户技能扇出，本 PR 未做。
2. **opt-in 目前是手写 JSON**、没有 UI 开关——这是有意的最小实现；UI 化、dry-run 清单、denylist、ownership manifest、回滚/清理入口等留给 #2930 后续。

Refs #2930
