### PR TITLE
fix(desktop): xAI 未登录时模型发现干净跳过，不再抛 FATAL unhandledRejection

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/xaiModelDiscovery.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/xaiModelDiscovery.test.ts
@@ -123,6 +123,33 @@ describe('xAI account model discovery', () => {
     expect(applySnapshot).toHaveBeenCalledWith([]);
   });
 
+  it('skips discovery cleanly when no access token is available (not logged in)', async () => {
+    const dir = await fsp.mkdtemp(path.join(os.tmpdir(), 'cindy-xai-models-'));
+    tempDirs.push(dir);
+    const cacheFile = path.join(dir, 'xai-models.json');
+    const applySnapshot = vi.fn();
+    const fetchImpl = vi.fn();
+    const deps = {
+      fetchImpl: fetchImpl as typeof fetch,
+      getAccessToken: async () => {
+        throw new Error('xAI 未登录:请先在「设置 → 模型供应商」登录 xAI(SuperGrok)');
+      },
+      peekAccessToken: () => null,
+      hasLogin: () => false,
+      getConnectionSource: () => 'explicit-provider-oauth' as const,
+      getScopeKey: () => 'owner-a:1',
+      cacheFilePath: () => cacheFile,
+      applySnapshot,
+      invalidateAuth: vi.fn(),
+      log: { info: vi.fn(), warn: vi.fn() },
+    };
+
+    await expect(refreshXaiModelsFromHttp(deps)).resolves.toBe(false);
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(applySnapshot).not.toHaveBeenCalled();
+    expect(deps.log.warn).toHaveBeenCalledTimes(1);
+  });
+
   it('keeps the current snapshot on temporary failure and never applies late account results', async () => {
     const applySnapshot = vi.fn();
     await expect(

--- a/apps/desktop/src/main/maker-host/__tests__/xaiModelDiscovery.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/xaiModelDiscovery.test.ts
@@ -400,4 +400,48 @@ describe('xAI account model discovery', () => {
     expect(fetchImpl).not.toHaveBeenCalled();
     expect(applySnapshot).not.toHaveBeenCalled();
   });
+
+  it('warns and returns false when token refresh after invalidateAuth fails', async () => {
+    let token = 'token-old';
+    let getAccessTokenCalls = 0;
+    const applySnapshot = vi.fn();
+    const invalidateAuth = vi.fn(async () => 'refreshed' as const);
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const auth = new Headers(init?.headers).get('authorization');
+      if (auth === 'Bearer token-old') {
+        return jsonResponse(
+          { code: 'unauthenticated:bad-credentials', error: 'bad creds' },
+          403,
+        );
+      }
+      // Should never reach here because second getAccessToken fails
+      throw new Error('unexpected fetch after token failure');
+    });
+    const warn = vi.fn();
+    await expect(
+      refreshXaiModelsFromHttp({
+        fetchImpl: fetchImpl as typeof fetch,
+        getAccessToken: async () => {
+          getAccessTokenCalls += 1;
+          if (getAccessTokenCalls === 1) return token;
+          throw new Error('token refresh failed after invalidate');
+        },
+        peekAccessToken: () => token,
+        hasLogin: () => true,
+        getConnectionSource: () => 'explicit-provider-oauth' as const,
+        getScopeKey: () => 'owner-a:1',
+        cacheFilePath: () => '/unused',
+        applySnapshot,
+        invalidateAuth,
+        log: { info: vi.fn(), warn },
+      }),
+    ).resolves.toBe(false);
+    expect(invalidateAuth).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(
+      'xAI account model discovery: token refresh after invalidate failed',
+      expect.objectContaining({ error: 'token refresh failed after invalidate' }),
+    );
+    expect(applySnapshot).not.toHaveBeenCalled();
+  });
+
 });

--- a/apps/desktop/src/main/maker-host/model-discovery/xai.ts
+++ b/apps/desktop/src/main/maker-host/model-discovery/xai.ts
@@ -362,7 +362,19 @@ async function runRefresh(
   const connectionSource = deps.getConnectionSource();
   if (connectionSource !== 'explicit-provider-oauth') return false;
   const scopeKey = deps.getScopeKey();
-  let token = await deps.getAccessToken();
+  let token: string;
+  try {
+    token = await deps.getAccessToken();
+  } catch (error) {
+    // getGrokAccessToken throws when xAI is not logged in or its token cannot
+    // be refreshed — the bridge turns that into a 502 per request. Discovery
+    // runs from startup/readiness paths that have no catch site, so degrade to
+    // a clean skip instead of surfacing as an unhandled rejection.
+    deps.log.warn('xAI account model discovery skipped: no usable access token', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return false;
+  }
   onAccessTokenResolved?.(token);
   if (!isCurrent(deps, scopeKey, token)) return false;
   for (let attempt = 0; attempt < 2; attempt += 1) {

--- a/apps/desktop/src/main/maker-host/model-discovery/xai.ts
+++ b/apps/desktop/src/main/maker-host/model-discovery/xai.ts
@@ -405,7 +405,14 @@ async function runRefresh(
       });
       if (outcome !== 'refreshed' && outcome !== 'superseded') return false;
       if (deps.getScopeKey() !== scopeKey || !deps.hasLogin()) return false;
-      token = await deps.getAccessToken();
+      try {
+        token = await deps.getAccessToken();
+      } catch (tokenError) {
+        deps.log.warn('xAI account model discovery: token refresh after invalidate failed', {
+          error: tokenError instanceof Error ? tokenError.message : String(tokenError),
+        });
+        return false;
+      }
       if (!isCurrent(deps, scopeKey, token)) return false;
     }
   }


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 #3038：xAI 未登录时模型发现抛出 FATAL unhandledRejection。包装 `getAccessToken()` 在 try-catch 中，失败时优雅跳过而非崩溃。同时包装 401/403 重试后的第二次 `getAccessToken()` 调用。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：#3038
- 本 PR 包含：xAI 模型发现的 token 获取错误处理
- 用户可见变化：xAI 未登录时不再崩溃

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
cd apps/desktop && npx vitest run src/main/maker-host/__tests__/xaiModelDiscovery.test.ts
结果：11 passed
```

### 手工验证

不涉及。

### 未执行的验证

无。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围：xAI 模型发现启动路径
- 回滚 / 降级方式：revert

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已确认测试结果或说明未执行原因

Fixes #3038