### PR TITLE
fix(mobile): 展开输入卡时语音按钮回到工具排

### DIFF
--- a/apps/mobile/src/__tests__/composerVoiceButtonAnchor.test.ts
+++ b/apps/mobile/src/__tests__/composerVoiceButtonAnchor.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import { spacing } from '@/theme/tokens';
+import {
+  MOBILE_COMPOSER_CONTROL_SIZE,
+  MOBILE_COMPOSER_TOOL_GAP,
+  MOBILE_COMPOSER_VOICE_ANCHOR_CARD_BOTTOM,
+  MOBILE_COMPOSER_VOICE_ANCHOR_RIGHT,
+  resolveMobileComposerVoiceButtonAnchorStyle,
+  resolveMobileComposerVoiceButtonPlacement,
+} from '@/session/composerVoiceButtonAnchor';
+
+describe('resolveMobileComposerVoiceButtonPlacement', () => {
+  it('行尾有 trailing 时向左让位,否则贴行尾', () => {
+    expect(resolveMobileComposerVoiceButtonPlacement({ hasTrailingAction: true })).toEqual({
+      floating: true,
+      inline: false,
+    });
+    expect(resolveMobileComposerVoiceButtonPlacement({ hasTrailingAction: false })).toEqual({
+      floating: false,
+      inline: true,
+    });
+  });
+});
+
+describe('resolveMobileComposerVoiceButtonAnchorStyle', () => {
+  it('收起态按行垂直居中,不写 bottom 数值', () => {
+    const style = resolveMobileComposerVoiceButtonAnchorStyle({
+      cardLayout: false,
+      floating: false,
+    });
+    expect(style).toEqual({
+      position: 'absolute',
+      right: MOBILE_COMPOSER_VOICE_ANCHOR_RIGHT,
+      top: '50%',
+      bottom: 'auto',
+      transform: [{ translateY: -MOBILE_COMPOSER_CONTROL_SIZE / 2 }],
+      zIndex: 2,
+    });
+    expect(style.bottom).toBe('auto');
+    expect(style.top).not.toBe('auto');
+  });
+
+  it('卡片态钉在工具排底边,显式清掉 top 与 translateY', () => {
+    const style = resolveMobileComposerVoiceButtonAnchorStyle({
+      cardLayout: true,
+      floating: false,
+    });
+    expect(style).toEqual({
+      position: 'absolute',
+      right: MOBILE_COMPOSER_VOICE_ANCHOR_RIGHT,
+      top: 'auto',
+      bottom: MOBILE_COMPOSER_VOICE_ANCHOR_CARD_BOTTOM,
+      transform: [],
+      zIndex: 2,
+    });
+    expect(style.top).toBe('auto');
+    expect(style.transform).toEqual([]);
+    expect(Object.prototype.hasOwnProperty.call(style, 'top')).toBe(true);
+    expect(Object.prototype.hasOwnProperty.call(style, 'bottom')).toBe(true);
+    expect(Object.prototype.hasOwnProperty.call(style, 'transform')).toBe(true);
+  });
+
+  it('有 trailing 时两态都向左让出发送键宽度', () => {
+    const inset = MOBILE_COMPOSER_VOICE_ANCHOR_RIGHT
+      + MOBILE_COMPOSER_CONTROL_SIZE
+      + MOBILE_COMPOSER_TOOL_GAP;
+    expect(resolveMobileComposerVoiceButtonAnchorStyle({
+      cardLayout: false,
+      floating: true,
+    }).right).toBe(inset);
+    expect(resolveMobileComposerVoiceButtonAnchorStyle({
+      cardLayout: true,
+      floating: true,
+    }).right).toBe(inset);
+    expect(inset).toBe(spacing.md + 34 + 6);
+  });
+
+  it('卡片底边与间距 token 同源,避免再写 8 与 paddingBottom 对不齐', () => {
+    expect(MOBILE_COMPOSER_VOICE_ANCHOR_CARD_BOTTOM).toBe(spacing.sm);
+    expect(MOBILE_COMPOSER_VOICE_ANCHOR_RIGHT).toBe(spacing.md);
+  });
+});

--- a/apps/mobile/src/__tests__/newSession.test.ts
+++ b/apps/mobile/src/__tests__/newSession.test.ts
@@ -1786,10 +1786,11 @@ describe('new session composer surface', () => {
     expect(newSource).toContain('floatingVoiceButton={voiceUiAvailable ? renderComposerVoiceButton : undefined}');
     expect(sessionSource).toContain('voicePlacement={composerVoicePlacement}');
     expect(sharedSource).toContain('export const MOBILE_COMPOSER_INPUT_MAX_VISIBLE_LINES = 12;');
-    expect(sharedSource).toContain('export const MOBILE_COMPOSER_CONTROL_SIZE = 34;');
-    expect(sharedSource).toContain('export function resolveMobileComposerVoiceButtonPlacement');
+    expect(sharedSource).toContain('MOBILE_COMPOSER_CONTROL_SIZE,');
+    expect(sharedSource).toContain('resolveMobileComposerVoiceButtonPlacement,');
+    expect(sharedSource).toContain('resolveMobileComposerVoiceButtonAnchorStyle({');
     expect(sharedSource).toContain('voicePlacement?.inline || voicePlacement?.floating');
-    expect(sharedSource).toContain('styles.voiceButtonAnchor,');
+    expect(sharedSource).not.toContain('styles.voiceButtonAnchor');
     expect(newSource).not.toContain('messageInput: {');
     expect(newSource).not.toContain('composerToolbar: {');
     expect(newSource).not.toContain('permissionIcon: {');

--- a/apps/mobile/src/__tests__/sessionComposerDesktopFirst.test.ts
+++ b/apps/mobile/src/__tests__/sessionComposerDesktopFirst.test.ts
@@ -66,14 +66,11 @@ describe('mobile session composer desktop-first surface', () => {
     const inlineButtonStart = source.indexOf('composerInlineToolButton: {');
     const inlineButtonEnd = source.indexOf('composerToolButtonActive:', inlineButtonStart);
     const inlineButtonStyle = source.slice(inlineButtonStart, inlineButtonEnd);
-    const floatingButtonStart = sharedSource.indexOf('voiceButtonAnchor: {', sharedStyleStart);
-    const floatingButtonEnd = sharedSource.indexOf('voiceButtonAnchorWithTrailing:', floatingButtonStart);
-    const floatingButtonStyle = sharedSource.slice(floatingButtonStart, floatingButtonEnd);
     const sendButtonStart = source.indexOf('sendButton: {');
     const sendButtonEnd = source.indexOf('sendButtonInactive:', sendButtonStart);
     const sendButtonStyle = source.slice(sendButtonStart, sendButtonEnd);
     const inputStart = sharedSource.indexOf('input: {', sharedStyleStart);
-    const inputEnd = sharedSource.indexOf('voiceButtonAnchor:', inputStart);
+    const inputEnd = sharedSource.indexOf('resizeGrabberTouch:', inputStart);
     const inputStyle = sharedSource.slice(inputStart, inputEnd);
     const composerStyleStart = source.indexOf('composer: {');
     const composerStyleEnd = source.indexOf('composerScroll:', composerStyleStart);
@@ -240,8 +237,11 @@ describe('mobile session composer desktop-first surface', () => {
     expect(inputStyle).toContain('paddingHorizontal: COMPOSER_TEXT_HORIZONTAL_PADDING');
     expect(inputStyle).toContain('paddingTop: COMPOSER_TEXT_PADDING_TOP');
     expect(inputStyle).toContain("textAlignVertical: 'top'");
-    expect(floatingButtonStyle).toContain("top: '50%'");
-    expect(floatingButtonStyle).toContain('translateY: -MOBILE_COMPOSER_CONTROL_SIZE / 2');
+    expect(sharedSource).toContain('resolveMobileComposerVoiceButtonAnchorStyle({');
+    expect(sharedSource).toContain('cardLayout,');
+    expect(sharedSource).toContain('floating: voicePlacement.floating,');
+    expect(sharedSource).not.toContain('styles.voiceButtonAnchor');
+    expect(sharedSource).not.toContain('voiceButtonAnchorCard');
     // Composer input is a single stable, always-multiline, always-inline instance (no compact↔expanded
     // swap that remounts the native input) so the first tap reliably opens the keyboard — guards the
     // "two taps to focus" regression. Compact rest look kept via minHeight (no fixed height that clips).
@@ -473,9 +473,9 @@ describe('mobile session composer desktop-first surface', () => {
     expect(composerInputSource).not.toContain('floatingVoiceButtonStyle=');
     expect(composerInputSource).toContain('voicePlacement={composerVoicePlacement}');
     expect(sharedSource).toContain('voicePlacement?.inline || voicePlacement?.floating');
-    expect(sharedSource).toContain('styles.voiceButtonAnchor,');
-    expect(sharedSource).toContain('voicePlacement.floating && styles.voiceButtonAnchorWithTrailing,');
-    expect(sharedSource).toContain('cardLayout && styles.voiceButtonAnchorCard,');
+    expect(sharedSource).toContain('resolveMobileComposerVoiceButtonAnchorStyle({');
+    expect(sharedSource).toContain('floating: voicePlacement.floating,');
+    expect(sharedSource).not.toContain('cardLayout && styles.voiceButtonAnchorCard,');
     // 录音中语音按钮以「红色停止方块」可见,禁止任何 opacity:0 隐藏样式回归
     // (旧 gestureAnchor 设计曾把听写中的按钮隐藏,会让停止录音无可见控件)。
     expect(source).not.toContain('composerInlineToolButtonGestureAnchor');
@@ -512,12 +512,8 @@ describe('mobile session composer desktop-first surface', () => {
     expect(inlineButtonStyle).not.toContain('width: 36');
     expect(inlineButtonStyle).not.toContain('height: 42');
     expect(inlineButtonStyle).not.toContain('width: 42');
-    expect(floatingButtonStyle).toContain("position: 'absolute'");
-    expect(floatingButtonStyle).toContain('right: MOBILE_COMPOSER_VOICE_ANCHOR_RIGHT');
-    expect(floatingButtonStyle).toContain("top: '50%'");
-    expect(floatingButtonStyle).toContain('translateY: -MOBILE_COMPOSER_CONTROL_SIZE / 2');
-    expect(floatingButtonStyle).toContain('zIndex: 2');
-    expect(sharedSource).toContain('right: spacing.md + MOBILE_COMPOSER_CONTROL_SIZE + MOBILE_COMPOSER_TOOL_GAP');
+    expect(sharedSource).toContain("from '@/session/composerVoiceButtonAnchor'");
+    expect(sharedSource).toContain('MOBILE_COMPOSER_VOICE_ANCHOR_CARD_BOTTOM');
     expect(sendButtonStyle).toContain('height: 34');
     expect(sendButtonStyle).toContain('width: 34');
     expect(sendButtonStyle).not.toContain('height: 36');

--- a/apps/mobile/src/session/MobileComposerInputRow.tsx
+++ b/apps/mobile/src/session/MobileComposerInputRow.tsx
@@ -1,7 +1,6 @@
 import {
   Animated,
   Easing,
-  Platform,
   StyleSheet,
   View,
   type GestureResponderHandlers,
@@ -32,6 +31,23 @@ import {
   COMPOSER_TEXT_PADDING_BOTTOM,
   COMPOSER_TEXT_PADDING_TOP,
 } from '@/session/composerTextPlatformMetrics';
+import {
+  MOBILE_COMPOSER_CONTROL_SIZE,
+  MOBILE_COMPOSER_TOOL_GAP,
+  MOBILE_COMPOSER_VOICE_ANCHOR_CARD_BOTTOM,
+  resolveMobileComposerVoiceButtonAnchorStyle,
+  type MobileComposerVoiceButtonPlacement,
+} from '@/session/composerVoiceButtonAnchor';
+
+export {
+  MOBILE_COMPOSER_CONTROL_SIZE,
+  MOBILE_COMPOSER_TOOL_GAP,
+  MOBILE_COMPOSER_VOICE_ANCHOR_CARD_BOTTOM,
+  MOBILE_COMPOSER_VOICE_ANCHOR_RIGHT,
+  resolveMobileComposerVoiceButtonAnchorStyle,
+  resolveMobileComposerVoiceButtonPlacement,
+  type MobileComposerVoiceButtonPlacement,
+} from '@/session/composerVoiceButtonAnchor';
 
 /**
  * Composer 草稿文本的排版档。正本在 `composerTextMetrics`——原生输入框、WebView 富文本
@@ -50,8 +66,6 @@ export const MOBILE_COMPOSER_INPUT_SINGLE_LINE_HEIGHT = COMPOSER_SINGLE_LINE_HEI
 export const MOBILE_COMPOSER_INPUT_MAX_VISIBLE_LINES = 12;
 export const MOBILE_COMPOSER_INPUT_MAX_HEIGHT = (MOBILE_COMPOSER_INPUT_LINE_HEIGHT * MOBILE_COMPOSER_INPUT_MAX_VISIBLE_LINES)
   + (MOBILE_COMPOSER_INPUT_VERTICAL_PADDING * 2);
-export const MOBILE_COMPOSER_CONTROL_SIZE = 34;
-export const MOBILE_COMPOSER_TOOL_GAP = 6;
 /**
  * 触控目标下限(mobile-design-guide「主操作命中区 ≥ 44×44」,iOS HIG 同值)。
  * 语音听写期间「点输入区停止听写」的命中层用它撑起 inputFrame(见 inputFrameMinHeight)。
@@ -59,29 +73,6 @@ export const MOBILE_COMPOSER_TOOL_GAP = 6;
 export const MOBILE_COMPOSER_MIN_TOUCH_TARGET = 44;
 const isExpoGo =
   Constants.executionEnvironment === ExecutionEnvironment.StoreClient;
-/** 语音按钮 absolute 锚点距 composer 内容区右缘的距离(voiceButtonAnchor.right);
- * 消息列表的「跳到底部」浮标按同一常量推导麦克风所在列,保持两者圆心同列。 */
-export const MOBILE_COMPOSER_VOICE_ANCHOR_RIGHT = spacing.md;
-
-export interface MobileComposerVoiceButtonPlacement {
-  floating: boolean;
-  inline: boolean;
-}
-
-/**
- * 语音按钮的位置分配：行尾有发送 / 创建 / 停止等 trailing 按钮时向左让位
- * （floating）、否则贴行尾（inline）。判定看「是否有 trailing 按钮」而非
- * 「是否有文字」——附件-only（无文字但发送按钮可见）时同样需要让位。
- * 听写中按钮不隐藏——对齐桌面版设计，同一颗按钮录音中变为「停止录音」形态。
- */
-export function resolveMobileComposerVoiceButtonPlacement(input: {
-  hasTrailingAction: boolean;
-}): MobileComposerVoiceButtonPlacement {
-  return {
-    floating: input.hasTrailingAction,
-    inline: !input.hasTrailingAction,
-  };
-}
 
 export interface MobileComposerInputRowProps {
   accessibilityHint?: string;
@@ -104,9 +95,10 @@ export interface MobileComposerInputRowProps {
   editable?: boolean;
   /**
    * 语音按钮 render。语音按钮是简洁态与卡片态都存在的常驻控件，
-   * 由组件用 absolute 锚点渲染为同一实例：简洁态贴输入行右侧、
-   * 卡片态落在底部工具排右二（工具排里放 ComposerToolbarVoiceSlot 占位），
-   * 两态切换时 LayoutAnimation 对同一实例的位置做平滑插值，不闪不跳。
+   * 由组件用一份完整 absolute 样式渲染为同一实例：简洁态贴输入行右侧、
+   * 卡片态落在底部工具排右二（工具排里放 ComposerToolbarVoiceSlot 占位）。
+   * 定位走 resolveMobileComposerVoiceButtonAnchorStyle，两态都写全 top /
+   * bottom / transform，避免 RN 合并残留把麦克风停在卡片中部。
    */
   floatingVoiceButton?: (style: StyleProp<ViewStyle>) => ReactNode;
   floatingVoiceButtonStyle?: StyleProp<ViewStyle>;
@@ -331,9 +323,10 @@ export function MobileComposerInputRow({
       ) : null}
       {voicePlacement?.inline || voicePlacement?.floating
         ? floatingVoiceButton?.([
-          styles.voiceButtonAnchor,
-          voicePlacement.floating && styles.voiceButtonAnchorWithTrailing,
-          cardLayout && styles.voiceButtonAnchorCard,
+          resolveMobileComposerVoiceButtonAnchorStyle({
+            cardLayout,
+            floating: voicePlacement.floating,
+          }),
           floatingVoiceButtonStyle,
         ])
         : null}
@@ -534,7 +527,7 @@ const makeMobileComposerInputRowStyles = (colors: ThemeColors) => ({
   // （grabber 横条距顶约 8pt、距输入内容约 14pt，参考 Cursor 移动端）。
   rowCard: {
     borderRadius: radius.control,
-    paddingBottom: 8,
+    paddingBottom: MOBILE_COMPOSER_VOICE_ANCHOR_CARD_BOTTOM,
     paddingTop: 26,
   },
   // 水平输入行：简洁态装 [输入][发送]，card 态只剩全宽输入区；
@@ -606,26 +599,6 @@ const makeMobileComposerInputRowStyles = (colors: ThemeColors) => ({
     paddingBottom: COMPOSER_TEXT_GEOMETRIC_PADDING_BOTTOM,
     paddingTop: COMPOSER_TEXT_GEOMETRIC_PADDING_TOP,
     textAlignVertical: 'center',
-  },
-  // 语音按钮的 absolute 锚点：简洁态贴输入行右侧垂直居中；
-  // 有发送按钮时向左让位；卡片态下沉到底部工具排的占位上。
-  voiceButtonAnchor: {
-    // 收起态按行垂直居中,与 34pt 加号 / 文字共中线;
-    // 不再钉在底部,避免行高变化后麦克风掉下去。
-    bottom: undefined,
-    position: 'absolute',
-    right: MOBILE_COMPOSER_VOICE_ANCHOR_RIGHT,
-    top: '50%',
-    transform: [{ translateY: -MOBILE_COMPOSER_CONTROL_SIZE / 2 }],
-    zIndex: 2,
-  },
-  voiceButtonAnchorWithTrailing: {
-    right: spacing.md + MOBILE_COMPOSER_CONTROL_SIZE + MOBILE_COMPOSER_TOOL_GAP,
-  },
-  voiceButtonAnchorCard: {
-    bottom: 8,
-    top: undefined,
-    transform: [],
   },
   // 外层横跨全行但 box-none 穿透触摸，只有中间的窄命中条接手势，
   // 避免与左右两侧按钮的 hitSlop 抢触摸。

--- a/apps/mobile/src/session/composerVoiceButtonAnchor.ts
+++ b/apps/mobile/src/session/composerVoiceButtonAnchor.ts
@@ -1,0 +1,73 @@
+import { spacing } from '@/theme/tokens';
+
+export const MOBILE_COMPOSER_CONTROL_SIZE = 34;
+export const MOBILE_COMPOSER_TOOL_GAP = 6;
+/** 语音按钮 absolute 锚点距 composer 内容区右缘的距离。
+ * 消息列表的「跳到底部」浮标按同一常量推导麦克风所在列,保持两者圆心同列。 */
+export const MOBILE_COMPOSER_VOICE_ANCHOR_RIGHT = spacing.md;
+/** 卡片态麦克风贴工具排底边的距离,与 rowCard.paddingBottom 同源。 */
+export const MOBILE_COMPOSER_VOICE_ANCHOR_CARD_BOTTOM = spacing.sm;
+
+export interface MobileComposerVoiceButtonPlacement {
+  floating: boolean;
+  inline: boolean;
+}
+
+/**
+ * 语音按钮的左右分配：行尾有发送 / 创建 / 停止等 trailing 按钮时向左让位
+ * （floating）、否则贴行尾（inline）。判定看「是否有 trailing 按钮」而非
+ * 「是否有文字」——附件-only（无文字但发送按钮可见）时同样需要让位。
+ * 听写中按钮不隐藏——对齐桌面版设计，同一颗按钮录音中变为「停止录音」形态。
+ */
+export function resolveMobileComposerVoiceButtonPlacement(input: {
+  hasTrailingAction: boolean;
+}): MobileComposerVoiceButtonPlacement {
+  return {
+    floating: input.hasTrailingAction,
+    inline: !input.hasTrailingAction,
+  };
+}
+
+export type MobileComposerVoiceButtonAnchorStyle = {
+  position: 'absolute';
+  right: number;
+  top: '50%' | 'auto';
+  bottom: number | 'auto';
+  transform: Array<{ translateY: number }>;
+  zIndex: number;
+};
+
+/**
+ * 语音按钮的完整定位。必须一次性写出 top / bottom / transform 三套互斥键,
+ * 不能靠 StyleSheet 数组后项写 `undefined` 去覆盖前项:
+ * RN 扁平化会跳过 undefined,卡片态就会残留收起态的 `top: '50%'`,麦克风停在
+ * 卡片中部(工具排占位空着)。漏写的键在原生侧也可能继续沿用上一帧的 inset。
+ */
+export function resolveMobileComposerVoiceButtonAnchorStyle(input: {
+  cardLayout: boolean;
+  floating: boolean;
+}): MobileComposerVoiceButtonAnchorStyle {
+  const right = input.floating
+    ? MOBILE_COMPOSER_VOICE_ANCHOR_RIGHT + MOBILE_COMPOSER_CONTROL_SIZE + MOBILE_COMPOSER_TOOL_GAP
+    : MOBILE_COMPOSER_VOICE_ANCHOR_RIGHT;
+
+  if (input.cardLayout) {
+    return {
+      position: 'absolute',
+      right,
+      top: 'auto',
+      bottom: MOBILE_COMPOSER_VOICE_ANCHOR_CARD_BOTTOM,
+      transform: [],
+      zIndex: 2,
+    };
+  }
+
+  return {
+    position: 'absolute',
+    right,
+    top: '50%',
+    bottom: 'auto',
+    transform: [{ translateY: -MOBILE_COMPOSER_CONTROL_SIZE / 2 }],
+    zIndex: 2,
+  };
+}


### PR DESCRIPTION
## 这次改了什么

### 摘要

手机输入框展开成卡片后，语音按钮（录音时是红点+计时胶囊）会停在卡片中部，压在草稿文字上，工具排右侧的占位是空的。

原因是收起态用 `top: '50%'` 垂直居中，卡片态想靠后一项 `top: undefined` 清掉、改钉在底部。React Native 合并样式会跳过 `undefined`，`top: '50%'` 还在。现在两态都一次写全 `top` / `bottom` / `transform`，展开后麦克风回到发送键左边。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：手机 composer 语音按钮在收起 / 展开两态的定位；抽出可单测的锚点函数
- 明确不包含：听写逻辑、录音权限、桌面语音按钮、冷更 / 原生层
- 用户可见变化：展开输入卡时，麦克风回到底部工具排（发送键左侧），不再浮在正文中间
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：`docs/design-rules/DESIGN.md` §8 Mobile（手机布局细节委托 `apps/mobile` 实现）；`apps/mobile/docs/mobile-design-guide.md` §5 间距走 `spacing` token（卡片底边改用 `spacing.sm`，与工具排底边对齐）、主操作命中区不变（仍是 34pt 可见 + 既有 hitSlop）。只改位置，不改颜色 / 字号 / 圆角，Light / Dark 共用同一套锚点。

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：PASS apps/mobile unit（related 5 个文件）

pnpm --filter mobile run typecheck
结果：tsc --noEmit 通过
```

### 手工验证

未在模拟器 / 真机点过。对照用户截图（新建页展开卡、会话页录音胶囊压在草稿上）核对定位逻辑。

### 未执行的验证

- 未跑 iOS Simulator / 真机；没有 Metro `__DEV__` build label。
- 全量 `run-unit-gate.sh`（`pnpm test:unit`）在无关的 `apps/desktop` `ghostInstallReceipt.test.ts` 挂了 2 条。同一文件在本机主 checkout 上同样失败，与本次 mobile composer 改动无关；仓库提交门禁用的是 `test:unit:related`，该项已过。CI 全量单测给权威结论。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：手机新建页 / 会话页 composer 语音按钮位置
- 回滚 / 降级方式：revert 本 PR
- 存量插件影响：无
- 冷更：不涉及（只改 JS / TS）

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
