### PR TITLE
fix(desktop): 同账号 token 续期不再把主界面踢去登录页

### DIFF
--- a/apps/desktop/src/main/__tests__/authSameOwnerRefreshUi.test.ts
+++ b/apps/desktop/src/main/__tests__/authSameOwnerRefreshUi.test.ts
@@ -1,0 +1,58 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Same-owner access-token refresh must not bounce the renderer to /login.
+ *
+ * 2026-08-20: packaged 0.1.56 logged `r:tapdb logout` →
+ * `App session is switching` → `LocalDbGate` remount every ~55 minutes. The
+ * trigger was `withCloudOwnerCommit` broadcasting `snapshotLoggedOutAuthState()`
+ * during Ghost projection repair on a stable cloud owner.
+ */
+describe('same-owner token refresh keeps the signed-in shell', () => {
+  const authSource = readFileSync(resolve(process.cwd(), 'src/main/authManager.ts'), 'utf8').replace(
+    /\r\n/g,
+    '\n',
+  );
+
+  it('does not broadcast a logged-out snapshot for same-owner Ghost repair', () => {
+    const start = authSource.indexOf('async function withCloudOwnerCommit');
+    const end = authSource.indexOf('async function withAccountFreeOwnerCommit', start);
+    const body = authSource.slice(start, end);
+
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+    expect(body).toContain('if (ownerChanged) {\n          notifyRendererAuthBoundaryPending();');
+    expect(body).toContain('releaseBoundary = beginAppSessionBoundary();');
+    expect(body.indexOf('if (ownerChanged)')).toBeLessThan(body.indexOf('notifyRendererAuthBoundaryPending();'));
+    expect(body.indexOf('notifyRendererAuthBoundaryPending();')).toBeLessThan(
+      body.indexOf('releaseBoundary = beginAppSessionBoundary();'),
+    );
+    // The unguarded call that remounted the shell every refresh cycle.
+    expect(body).not.toContain(
+      'prepareTransition: async ({ ownerChanged }) => {\n        notifyRendererAuthBoundaryPending();',
+    );
+  });
+
+  it('keeps canEnterApp true while an owner boundary is pending', () => {
+    const start = authSource.indexOf('function snapshotAuthState(): AuthState {');
+    const end = authSource.indexOf('function snapshotLoggedOutAuthState', start);
+    const body = authSource.slice(start, end);
+
+    expect(body).toContain("canEnterApp: appSession.mode !== 'signed-out'");
+    expect(body).not.toContain('!isAppSessionBoundaryPending()');
+  });
+
+  it('still fakes a signed-out snapshot for a real owner change or logout', () => {
+    const cloudStart = authSource.indexOf('async function withCloudOwnerCommit');
+    const cloudEnd = authSource.indexOf('async function withAccountFreeOwnerCommit', cloudStart);
+    const accountFreeStart = cloudEnd;
+    const accountFreeEnd = authSource.indexOf('async function recoverAccountFreeOwnerAtStartup', accountFreeStart);
+
+    expect(authSource.slice(cloudStart, cloudEnd)).toContain('notifyRendererAuthBoundaryPending();');
+    expect(authSource.slice(accountFreeStart, accountFreeEnd)).toContain(
+      'notifyRendererAuthBoundaryPending();',
+    );
+  });
+});

--- a/apps/desktop/src/main/__tests__/authSameOwnerRefreshUi.test.ts
+++ b/apps/desktop/src/main/__tests__/authSameOwnerRefreshUi.test.ts
@@ -24,7 +24,13 @@ describe('same-owner token refresh keeps the signed-in shell', () => {
     expect(start).toBeGreaterThan(-1);
     expect(end).toBeGreaterThan(start);
     expect(body).toContain('if (ownerChanged) {\n          notifyRendererAuthBoundaryPending();');
+    expect(body).toContain('enterOwnerChangeShellPending();');
+    expect(body).toContain('heldOwnerChangeShell = true;');
+    expect(body).toContain('if (heldOwnerChangeShell) leaveOwnerChangeShellPending();');
     expect(body).toContain('releaseBoundary = beginAppSessionBoundary();');
+    expect(body.indexOf('notifyRendererAuthBoundaryPending();')).toBeLessThan(
+      body.indexOf('enterOwnerChangeShellPending();'),
+    );
     expect(body.indexOf('if (ownerChanged)')).toBeLessThan(body.indexOf('notifyRendererAuthBoundaryPending();'));
     expect(body.indexOf('notifyRendererAuthBoundaryPending();')).toBeLessThan(
       body.indexOf('releaseBoundary = beginAppSessionBoundary();'),
@@ -35,12 +41,14 @@ describe('same-owner token refresh keeps the signed-in shell', () => {
     );
   });
 
-  it('keeps canEnterApp true while an owner boundary is pending', () => {
+  it('keeps canEnterApp true for IPC pending, but not a real owner-change shell', () => {
     const start = authSource.indexOf('function snapshotAuthState(): AuthState {');
     const end = authSource.indexOf('function snapshotLoggedOutAuthState', start);
     const body = authSource.slice(start, end);
 
-    expect(body).toContain("canEnterApp: appSession.mode !== 'signed-out'");
+    expect(body).toContain(
+      "canEnterApp: appSession.mode !== 'signed-out' && !isOwnerChangeShellPending()",
+    );
     expect(body).not.toContain('!isAppSessionBoundaryPending()');
   });
 

--- a/apps/desktop/src/main/authManager.ts
+++ b/apps/desktop/src/main/authManager.ts
@@ -297,6 +297,22 @@ let pendingAuthRealm: AuthRegion | null = null;
 let refreshTimer: ReturnType<typeof setTimeout> | null = null;
 let refreshPromise: Promise<boolean> | null = null;
 let sessionInvalidationPromise: Promise<void> | null = null;
+// Real owner change / logout: keep the renderer fail-closed even if a late
+// notifyRenderer() races the teardown. Same-owner Ghost repair must not set
+// this — that was the 55-minute /login flash.
+let ownerChangeShellPendingDepth = 0;
+
+function enterOwnerChangeShellPending(): void {
+  ownerChangeShellPendingDepth += 1;
+}
+
+function leaveOwnerChangeShellPending(): void {
+  ownerChangeShellPendingDepth = Math.max(0, ownerChangeShellPendingDepth - 1);
+}
+
+function isOwnerChangeShellPending(): boolean {
+  return ownerChangeShellPendingDepth > 0;
+}
 /**
  * 设备标识。默认绑定物理机(machineIdSync)。
  *
@@ -860,6 +876,7 @@ async function withCloudOwnerCommit<T>(opts: {
     return withGhostSkillProjectionReadOnlyOwner(opts.nextOwnerId, opts.commit);
   }
   let releaseBoundary: (() => void) | null = null;
+  let heldOwnerChangeShell = false;
   // A same-owner projection repair tears down the owner-bound Ghost runtime but
   // keeps the same mode/owner, so commitActiveAppSession's same-owner early
   // return would NOT advance the owner generation — stale async work that
@@ -878,6 +895,8 @@ async function withCloudOwnerCommit<T>(opts: {
         // here bounced ProtectedRoute to /login every ~55 minutes.
         if (ownerChanged) {
           notifyRendererAuthBoundaryPending();
+          enterOwnerChangeShellPending();
+          heldOwnerChangeShell = true;
         }
         releaseBoundary = beginAppSessionBoundary();
         if (ownerChanged) {
@@ -906,6 +925,7 @@ async function withCloudOwnerCommit<T>(opts: {
   } finally {
     const release = releaseBoundary as (() => void) | null;
     release?.();
+    if (heldOwnerChangeShell) leaveOwnerChangeShellPending();
     if (release) notifyRenderer();
   }
   if (committed) requestStableOwnerPostCommit('owner-commit');
@@ -934,6 +954,7 @@ async function withAccountFreeOwnerCommit(opts: {
 }): Promise<void> {
   let authCleared = opts.authAlreadyCleared ?? false;
   let releaseBoundary: (() => void) | null = null;
+  let heldOwnerChangeShell = false;
   // Same-owner account-free repair tears down the owner-bound Ghost runtime but
   // keeps the same mode/owner, so commitActiveAppSession's same-owner early
   // return would NOT advance the owner generation — stale async work that
@@ -971,6 +992,8 @@ async function withAccountFreeOwnerCommit(opts: {
       nextOwnerId: opts.nextMode === 'local' ? LOCAL_DATA_OWNER_ID : null,
       prepareTransition: async ({ ownerChanged }) => {
         notifyRendererAuthBoundaryPending();
+        enterOwnerChangeShellPending();
+        heldOwnerChangeShell = true;
         releaseBoundary = beginAppSessionBoundary();
         if (ownerChanged) {
           if (!authSessionTeardown) {
@@ -1039,6 +1062,7 @@ async function withAccountFreeOwnerCommit(opts: {
   } finally {
     const release = releaseBoundary as (() => void) | null;
     release?.();
+    if (heldOwnerChangeShell) leaveOwnerChangeShellPending();
     if (release && notify) notifyRenderer();
   }
 
@@ -1700,9 +1724,9 @@ function snapshotAuthState(): AuthState {
     mode: appSession.mode,
     dataOwnerId: appSession.dataOwnerId,
     ownerGeneration: appSession.generation,
-    // Pending is an IPC fail-closed window, not a signed-out shell. Folding it
-    // into canEnterApp made same-owner refresh remount the whole UI.
-    canEnterApp: appSession.mode !== 'signed-out',
+    // IPC pending is not a logout. Real owner change / logout still holds the
+    // shell closed so a late notifyRenderer() cannot remount the outgoing owner.
+    canEnterApp: appSession.mode !== 'signed-out' && !isOwnerChangeShellPending(),
     isAuthenticated: isCloudAuthenticated,
     isCanary: currentUser !== null && canaryFlagStore.read(),
     deviceId,

--- a/apps/desktop/src/main/authManager.ts
+++ b/apps/desktop/src/main/authManager.ts
@@ -873,7 +873,12 @@ async function withCloudOwnerCommit<T>(opts: {
       previousOwnerId: opts.previousOwnerId,
       nextOwnerId: opts.nextOwnerId,
       prepareTransition: async ({ ownerChanged }) => {
-        notifyRendererAuthBoundaryPending();
+        // Same-owner Ghost repair (token refresh when the durable projection is
+        // unstable) is not a logout. Broadcasting snapshotLoggedOutAuthState()
+        // here bounced ProtectedRoute to /login every ~55 minutes.
+        if (ownerChanged) {
+          notifyRendererAuthBoundaryPending();
+        }
         releaseBoundary = beginAppSessionBoundary();
         if (ownerChanged) {
           await opts.prepareTransition();
@@ -1695,7 +1700,9 @@ function snapshotAuthState(): AuthState {
     mode: appSession.mode,
     dataOwnerId: appSession.dataOwnerId,
     ownerGeneration: appSession.generation,
-    canEnterApp: appSession.mode !== 'signed-out' && !isAppSessionBoundaryPending(),
+    // Pending is an IPC fail-closed window, not a signed-out shell. Folding it
+    // into canEnterApp made same-owner refresh remount the whole UI.
+    canEnterApp: appSession.mode !== 'signed-out',
     isAuthenticated: isCloudAuthenticated,
     isCanary: currentUser !== null && canaryFlagStore.read(),
     deviceId,

--- a/apps/desktop/src/renderer/components/auth/ProtectedRoute.tsx
+++ b/apps/desktop/src/renderer/components/auth/ProtectedRoute.tsx
@@ -3,10 +3,12 @@ import { Navigate, Outlet } from 'react-router-dom';
 import { useAuth } from '@/contexts/AuthContext';
 
 export function ProtectedRoute() {
-  const { canEnterApp, isInitializing, dataOwnerId } = useAuth();
+  const { mode, isInitializing, dataOwnerId } = useAuth();
 
   if (isInitializing) return null;
-  if (!canEnterApp) return <Navigate to="/login" replace />;
+  // Only a real signed-out session belongs on /login. Owner-boundary pending
+  // (same-owner token refresh / Ghost repair) must keep the shell mounted.
+  if (mode === 'signed-out') return <Navigate to="/login" replace />;
   // Owner changes must remount the protected tree so transient New Maker
   // drafts and other route-local state cannot leak across data namespaces.
   return <Outlet key={dataOwnerId ?? 'signed-out'} />;

--- a/apps/desktop/src/renderer/components/auth/ProtectedRoute.tsx
+++ b/apps/desktop/src/renderer/components/auth/ProtectedRoute.tsx
@@ -3,12 +3,13 @@ import { Navigate, Outlet } from 'react-router-dom';
 import { useAuth } from '@/contexts/AuthContext';
 
 export function ProtectedRoute() {
-  const { mode, isInitializing, dataOwnerId } = useAuth();
+  const { canEnterApp, isInitializing, dataOwnerId } = useAuth();
 
   if (isInitializing) return null;
-  // Only a real signed-out session belongs on /login. Owner-boundary pending
-  // (same-owner token refresh / Ghost repair) must keep the shell mounted.
-  if (mode === 'signed-out') return <Navigate to="/login" replace />;
+  // canEnterApp is false for a real signed-out session and while a real owner
+  // change is in flight. Same-owner token refresh keeps it true.
+  if (!canEnterApp) return <Navigate to="/login" replace />;
+
   // Owner changes must remount the protected tree so transient New Maker
   // drafts and other route-local state cannot leak across data namespaces.
   return <Outlet key={dataOwnerId ?? 'signed-out'} />;

--- a/apps/desktop/src/renderer/components/auth/__tests__/ProtectedRoute.test.tsx
+++ b/apps/desktop/src/renderer/components/auth/__tests__/ProtectedRoute.test.tsx
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const authState = vi.hoisted(() => ({
+  current: {
+    mode: 'cloud' as 'signed-out' | 'local' | 'cloud',
+    isInitializing: false,
+    dataOwnerId: 'user-1' as string | null,
+    canEnterApp: true,
+  },
+}));
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => authState.current,
+}));
+
+import { ProtectedRoute } from '../ProtectedRoute';
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/login" element={<div data-testid="login-page" />} />
+        <Route element={<ProtectedRoute />}>
+          <Route path="/" element={<div data-testid="app-shell" />} />
+        </Route>
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('ProtectedRoute', () => {
+  afterEach(() => {
+    cleanup();
+    authState.current = {
+      mode: 'cloud',
+      isInitializing: false,
+      dataOwnerId: 'user-1',
+      canEnterApp: true,
+    };
+  });
+
+  it('keeps the shell mounted during a same-owner pending window', () => {
+    authState.current = {
+      mode: 'cloud',
+      isInitializing: false,
+      dataOwnerId: 'user-1',
+      canEnterApp: false,
+    };
+    renderAt('/');
+    expect(screen.getByTestId('app-shell')).toBeTruthy();
+    expect(screen.queryByTestId('login-page')).toBeNull();
+  });
+
+  it('sends a real signed-out session to login', () => {
+    authState.current = {
+      mode: 'signed-out',
+      isInitializing: false,
+      dataOwnerId: null,
+      canEnterApp: false,
+    };
+    renderAt('/');
+    expect(screen.getByTestId('login-page')).toBeTruthy();
+    expect(screen.queryByTestId('app-shell')).toBeNull();
+  });
+
+  it('lets local mode enter the app without a Cindy account', () => {
+    authState.current = {
+      mode: 'local',
+      isInitializing: false,
+      dataOwnerId: 'local-v1',
+      canEnterApp: true,
+    };
+    renderAt('/');
+    expect(screen.getByTestId('app-shell')).toBeTruthy();
+  });
+});

--- a/apps/desktop/src/renderer/components/auth/__tests__/ProtectedRoute.test.tsx
+++ b/apps/desktop/src/renderer/components/auth/__tests__/ProtectedRoute.test.tsx
@@ -43,7 +43,19 @@ describe('ProtectedRoute', () => {
     };
   });
 
-  it('keeps the shell mounted during a same-owner pending window', () => {
+  it('keeps the shell mounted while same-owner refresh still allows entry', () => {
+    authState.current = {
+      mode: 'cloud',
+      isInitializing: false,
+      dataOwnerId: 'user-1',
+      canEnterApp: true,
+    };
+    renderAt('/');
+    expect(screen.getByTestId('app-shell')).toBeTruthy();
+    expect(screen.queryByTestId('login-page')).toBeNull();
+  });
+
+  it('leaves the shell during a real owner-change window', () => {
     authState.current = {
       mode: 'cloud',
       isInitializing: false,
@@ -51,8 +63,8 @@ describe('ProtectedRoute', () => {
       canEnterApp: false,
     };
     renderAt('/');
-    expect(screen.getByTestId('app-shell')).toBeTruthy();
-    expect(screen.queryByTestId('login-page')).toBeNull();
+    expect(screen.getByTestId('login-page')).toBeTruthy();
+    expect(screen.queryByTestId('app-shell')).toBeNull();
   });
 
   it('sends a real signed-out session to login', () => {

--- a/apps/desktop/src/renderer/router.tsx
+++ b/apps/desktop/src/renderer/router.tsx
@@ -31,7 +31,7 @@ import { GhostPluginPage } from '@/features/plugin/GhostPluginPage';
  *   GuestRoute (未登录)
  *    └── /login                    → LoginPage
  *
- *   ProtectedRoute (已登录) — 仅校验 mode !== 'signed-out'
+ *   ProtectedRoute (已登录) — 校验 canEnterApp（真登出或换号窗口）
  *    └── LocalDbGate               → 等 localDb.ensureReady（按 userId 切库）
  *         └── MainLayout            → 主功能区
  *              ├── /                → Navigate to /cc-agent

--- a/apps/desktop/src/renderer/router.tsx
+++ b/apps/desktop/src/renderer/router.tsx
@@ -31,7 +31,7 @@ import { GhostPluginPage } from '@/features/plugin/GhostPluginPage';
  *   GuestRoute (未登录)
  *    └── /login                    → LoginPage
  *
- *   ProtectedRoute (已登录) — 仅校验 isAuthenticated
+ *   ProtectedRoute (已登录) — 仅校验 mode !== 'signed-out'
  *    └── LocalDbGate               → 等 localDb.ensureReady（按 userId 切库）
  *         └── MainLayout            → 主功能区
  *              ├── /                → Navigate to /cc-agent


### PR DESCRIPTION
## 这次改了什么

### 摘要

安装版 Cindy 正常使用时，大约每 55 分钟整窗闪一下并重新 loading。日志对上的是 access token 续期：Ghost projection 不稳时，同账号 refresh 会走 same-owner repair，并广播一份假的「已登出」快照。ProtectedRoute 把 `canEnterApp=false` 当成登出，整棵壳跳到 `/login` 再拉回来。

同账号边界不再广播登出快照；`canEnterApp` 不再把 owner-boundary pending 当成未登录；ProtectedRoute 只在 `mode === 'signed-out'` 时离开主界面。真换号 / 真登出仍走原来的 logged-out 投影。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：本机安装版 0.1.56 日志排查（`r:tapdb logout` → `App session is switching` → `LocalDbGate` 重挂，周期约 55 分钟）
- 本 PR 包含：
  - `withCloudOwnerCommit` 仅在 `ownerChanged` 时广播 `snapshotLoggedOutAuthState()`
  - `snapshotAuthState.canEnterApp` 只看 `mode !== 'signed-out'`
  - `ProtectedRoute` 只在真登出时跳 `/login`
- 明确不包含：
  - 不修 Ghost skill projection 为何反复不稳（续期时仍可能后台拆插件运行时）
  - 不处理 `worklouder-codex` 日志刷屏
- 用户可见变化：同账号 token 续期不再整窗闪 loading / 重进登录页
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：不涉及：仅调整登录路由守卫条件，无视觉、交互或文案变化

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop run typecheck
结果：通过

pnpm test:unit:related
结果：通过（desktop related 5 files）

pnpm check:dco
结果：通过（1 commit signed off）

/Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh <worktree>
结果：本 PR 相关单测通过；全量 desktop unit 另有 2 个失败：
src/main/cindy-brain/__tests__/ghostInstallReceipt.test.ts
（writes setup in the author format… / still reads normalized setup receipts…）
已在干净 origin/main@6d4acdba5 复现，同样 2 fail / 9 pass，与本 diff 无关。交 CI 给权威结论。
```

### 手工验证

未在安装版复现修复后的 55 分钟续期窗口。修复依据是本机 0.1.56 连续两天的周期日志（`logout` → `App session is switching` → 同一 `dataOwnerId` 再 `setUser` / `LocalDbGate`）。

### 未执行的验证

未等下一次真实 token 续期做安装版回归。发版后可用 main 日志是否再出现成对的 `r:tapdb logout` + `LocalDbGate startup readiness`（且 `rendererUptimeMs` 仍在涨）确认。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop 登录壳。真登出 / 换号仍广播 logged-out 快照并跳登录页；同账号 pending 只挡 IPC，不再拆主界面。
- 回滚 / 降级方式：revert 本 PR。
- 存量插件影响：无。未改批准状态、指纹、manifest、安装布局或包格式。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
