### PR TITLE
fix(desktop): 折叠项目提醒点对齐任务行右侧状态槽

### DIFF
--- a/apps/desktop/src/renderer/__tests__/projectCollapsedAttention.test.ts
+++ b/apps/desktop/src/renderer/__tests__/projectCollapsedAttention.test.ts
@@ -20,6 +20,7 @@ const sidebarUpperSource = readFileSync(
   resolvePath(__dirname, '..', 'features', 'cc-agent', 'CCAgentSidebarUpper.tsx'),
   'utf8',
 );
+const sessionItemSource = readFileSync(resolvePath(sidebarDir, 'SessionItem.tsx'), 'utf8');
 
 const sessions = (ids: string[]) => ids.map((id) => ({ id }));
 
@@ -111,13 +112,28 @@ describe('collapsed project attention tone', () => {
 });
 
 describe('collapsed project attention wiring', () => {
-  it('renders the aggregate dot only while the project is collapsed', () => {
+  it('renders the aggregate status on the trailing slot while the project is collapsed', () => {
+    const slotChrome = 'group/slot relative ml-auto flex h-6 shrink-0 items-center justify-end';
+    const gridChrome = 'grid h-6 grid-cols-[max-content] items-center justify-items-end';
+    expect(projectNodeSource).toContain('isCollapsed && collapsedAttentionTone ? (');
     expect(projectNodeSource).toContain(
-      '!isEditingName && isCollapsed && collapsedAttentionTone ? (',
+      '<SidebarRightStatusIndicator kind={collapsedAttentionTone} isActive={false} />',
     );
-    expect(projectNodeSource).toContain(
-      '<AttentionDot size={6} tone={collapsedAttentionTone} className="shrink-0" />',
+    expect(projectNodeSource).not.toContain('AttentionDot');
+    expect(projectNodeSource).toContain(slotChrome);
+    expect(sessionItemSource).toContain(slotChrome);
+    expect(projectNodeSource).toContain(gridChrome);
+    expect(sessionItemSource).toContain(gridChrome);
+    const nameSpan = projectNodeSource.indexOf(
+      '<span className="min-w-0 max-w-full shrink truncate">{project.displayName}</span>',
     );
+    const trailingSlot = projectNodeSource.indexOf(slotChrome);
+    const indicator = projectNodeSource.indexOf(
+      '<SidebarRightStatusIndicator kind={collapsedAttentionTone} isActive={false} />',
+    );
+    expect(nameSpan).toBeGreaterThan(0);
+    expect(trailingSlot).toBeGreaterThan(nameSpan);
+    expect(indicator).toBeGreaterThan(trailingSlot);
   });
 
   it('feeds both regular and pinned project rows from their displayed children', () => {

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/sections/ProjectNode.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/sections/ProjectNode.tsx
@@ -29,7 +29,6 @@ import { useTranslation } from 'react-i18next';
 
 import { cn } from '@/lib/utils';
 import { Tip } from '@/components/ui/tooltip';
-import { AttentionDot } from '@/components/sidebar/AttentionDot';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -55,6 +54,7 @@ import type { SessionMoveTarget } from '../sessionMoveTarget';
 import type { FilterStatus } from '../../hooks/useSidebarFilter';
 import { MENU_CONTENT_CLASS, MENU_ITEM_CLASS, MENU_SEPARATOR_CLASS } from '../menuStyles';
 import { RemoteProjectIcon } from '../RemoteProjectIcon';
+import { SidebarRightStatusIndicator } from '../SidebarRightStatusIndicator';
 import { isDeviceLinkWriteBlocked } from '../../lib/remoteSessionWriteGuard';
 import { projectBulkArchiveActionForStatus } from '../../lib/projectBulkArchiveAction';
 import { getRemoteProjectMachineIdentity } from '../../lib/remoteProjectIdentity';
@@ -71,7 +71,7 @@ export interface ProjectNodeProps {
   /** 当前会话状态筛选，决定项目菜单是批量归档还是批量恢复。 */
   statusFilter: FilterStatus;
   isCollapsed: boolean;
-  /** 折叠时汇总子任务的红/绿状态点；展开态由子任务行各自展示。 */
+  /** 折叠时汇总子任务的红/绿状态点，放在行右侧状态槽(与会话行同一位置);展开态由子任务行各自展示。 */
   collapsedAttentionTone?: CollapsedProjectAttentionTone | null;
   /** 父级 Projects 段整体收起时,也要让项目内「显示全部」在动画后复位。 */
   parentSectionCollapsed: boolean;
@@ -298,7 +298,7 @@ export function ProjectNode({
           // 2026-07 用户定稿:项目行作分组容器退后半步,让会话行更突出)。
           // h-8 + rounded-full:hover 底与顶部导航行 / 会话行同款药丸形,三处
           // 高度、圆角、左右边界(同容器 w-full)完全一致(2026-07 用户定稿)。
-          'group flex h-8 w-full items-center gap-2.5 rounded-full pl-3 pr-1',
+          'group flex h-8 w-full items-center gap-2.5 rounded-full pl-3 pr-2',
           'text-sm font-normal text-[var(--sidebar-list-muted)]',
           // 整行点击 = toggle 折叠，常态用 pointer。即便支持手动拖拽排序也不显示
           // grab 光标——只有真正进入拖拽时（SortableList onStart 给 body 挂
@@ -347,9 +347,6 @@ export function ProjectNode({
             // (2026-08-12 用户裁决,与会话行的标题 + 远程图标同款)。
             <span className="min-w-0 max-w-full shrink truncate">{project.displayName}</span>
           )}
-          {!isEditingName && isCollapsed && collapsedAttentionTone ? (
-            <AttentionDot size={6} tone={collapsedAttentionTone} className="shrink-0" />
-          ) : null}
           {!isEditingName && isDeviceLink ? (
             <Tip text={remoteIdentity?.displayLabel ?? project.deviceLinkDeviceId ?? ''}>
               <RemoteProjectIcon
@@ -383,42 +380,73 @@ export function ProjectNode({
             />
           )}
         </div>
-        {/* 悬浮工具组——常态隐藏，hover 整行时淡入。
-            stopPropagation 阻止冒泡触发 Header 的 toggle。 */}
+        {/* 右侧状态槽几何与 SessionItem 同一份:ml-auto + h-6 + 16px 指示器入流,
+            hover 时 invisible spacer 把槽撑成按钮宽。绿/红点因此与任务行同大小、
+            同右边缘(pr-2 + size-4 槽 + size-2 圆点)。 */}
         {!isEditingName && (
-          <div
-            className={cn(
-              'shrink-0 flex items-center gap-0.5',
-              'opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100',
-            )}
-          >
-            {/* More 按钮 —— 点击锚定 menuPos 到按钮正下方,复用下面同一份
-                DropdownMenu(右键也走它,菜单 items 一份维护)。原本 Search /
-                ShowFiles / OpenInExplorer 三个独立按钮整合到这个菜单里。 */}
-            <ProjectAction
-              label={t('ccAgent.common.moreActions')}
-              onClick={(e) => {
-                const rect = e.currentTarget.getBoundingClientRect();
-                setMenuPos({ x: rect.left, y: rect.bottom + 2 });
-              }}
-            >
-              <EllipsisVertical size={14} strokeWidth={2} />
-            </ProjectAction>
-            {/* delayed-create:在此目录新建会话——保留为独立按钮(primary 操作,
-                跟 SessionItem 的 Archive/Undo 等位)。父层会预填 workingDir 到
-                newMakerDraft store 并 navigate('/cc-agent/new')。vendor 由
-                NewMakerDraftRoute 内的 segmented switcher 决定(默认走用户上次选择)。 */}
-            <ProjectAction
-              label={
-                projectWritesBlocked
-                  ? t('ccAgent.remoteSession.actionsUnavailable')
-                  : t('ccAgent.sidebar.projectAction.newInDirectory')
-              }
-              disabled={projectWritesBlocked}
-              onClick={handleCreateInProject}
-            >
-              <SquarePen size={14} strokeWidth={2} />
-            </ProjectAction>
+          <div className="group/slot relative ml-auto flex h-6 shrink-0 items-center justify-end">
+            <div className="grid h-6 grid-cols-[max-content] items-center justify-items-end">
+              {isCollapsed && collapsedAttentionTone ? (
+                <div
+                  className={cn(
+                    'col-start-1 row-start-1 flex items-center gap-1',
+                    'transition-opacity duration-[120ms]',
+                    'group-hover:opacity-0 group-focus-within/slot:opacity-0',
+                    menuPos !== null && 'opacity-0',
+                  )}
+                >
+                  <SidebarRightStatusIndicator kind={collapsedAttentionTone} isActive={false} />
+                </div>
+              ) : null}
+              <div
+                aria-hidden
+                className={cn(
+                  'invisible col-start-1 row-start-1 h-6 items-center gap-0.5',
+                  menuPos !== null
+                    ? 'flex'
+                    : 'hidden group-hover:flex group-focus-within/slot:flex',
+                )}
+              >
+                <span className="size-5 shrink-0" />
+                <span className="size-5 shrink-0" />
+              </div>
+              <div
+                className={cn(
+                  'absolute right-0 top-0 flex h-6 items-center gap-0.5',
+                  menuPos !== null
+                    ? 'opacity-100'
+                    : 'pointer-events-none opacity-0 group-hover:pointer-events-auto group-hover:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100',
+                )}
+              >
+                {/* More 按钮 —— 点击锚定 menuPos 到按钮正下方,复用下面同一份
+                    DropdownMenu(右键也走它,菜单 items 一份维护)。原本 Search /
+                    ShowFiles / OpenInExplorer 三个独立按钮整合到这个菜单里。 */}
+                <ProjectAction
+                  label={t('ccAgent.common.moreActions')}
+                  onClick={(e) => {
+                    const rect = e.currentTarget.getBoundingClientRect();
+                    setMenuPos({ x: rect.left, y: rect.bottom + 2 });
+                  }}
+                >
+                  <EllipsisVertical size={14} strokeWidth={2} />
+                </ProjectAction>
+                {/* delayed-create:在此目录新建会话——保留为独立按钮(primary 操作,
+                    跟 SessionItem 的 Archive/Undo 等位)。父层会预填 workingDir 到
+                    newMakerDraft store 并 navigate('/cc-agent/new')。vendor 由
+                    NewMakerDraftRoute 内的 segmented switcher 决定(默认走用户上次选择)。 */}
+                <ProjectAction
+                  label={
+                    projectWritesBlocked
+                      ? t('ccAgent.remoteSession.actionsUnavailable')
+                      : t('ccAgent.sidebar.projectAction.newInDirectory')
+                  }
+                  disabled={projectWritesBlocked}
+                  onClick={handleCreateInProject}
+                >
+                  <SquarePen size={14} strokeWidth={2} />
+                </ProjectAction>
+              </div>
+            </div>
           </div>
         )}
       </div>


### PR DESCRIPTION
## 这次改了什么

### 摘要

折叠项目的红/绿提醒点原先紧跟在项目名后面，和任务行右侧状态点不在一条竖线上。这次把它改到与 `SessionItem` 同一套右侧状态槽：同一组件、同一 8px 圆点 / 16px 槽、同一 `pr-2` 右边缘；hover 时让位给 More / 新建按钮。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：
  - `ProjectNode` 折叠提醒点从标题旁移到行尾状态槽
  - 槽几何与 `SessionItem` 对齐（`ml-auto` + `h-6` grid + hover spacer）
  - 行右内边距 `pr-1` → `pr-2`，与任务行一致
  - 源码级测试锁定与任务行共用的槽 class
- 明确不包含：
  - 折叠/展开时是否显示提醒点的产品规则（仍仅折叠显示）
  - 侧栏 rail 项目面板、手机首页项目行
- 用户可见变化：桌面侧栏折叠项目的红/绿点出现在行最右侧，大小和位置与任务行一致；hover 项目行时点让位给操作按钮
- 是否存在 breaking change：无

### UI 变化

桌面侧栏项目行。Light / Dark 都走 `SidebarRightStatusIndicator` 的语义 token，未做双模式实机目检。

- 引用的设计规范：
  - `docs/design-rules/DESIGN.md` §2 Semantic & Accent：红/绿状态点使用 `--card-status-error` / `--card-status-done`，不引入新色
  - `docs/design-rules/DESIGN.md` §10 Theme System：颜色只走 token，双模式同一套组件
  - `docs/design-rules/DESIGN.md` §14.4 Motion：hover 让位是功能 opacity 过渡，时长与 `SessionItem` 右侧槽相同（120ms）

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop run typecheck
结果：通过

pnpm test:unit:related
结果：通过（apps/desktop related，含 projectCollapsedAttention.test.ts）

pnpm --dir apps/desktop exec vitest run src/renderer/__tests__/projectCollapsedAttention.test.ts
结果：8 passed

pnpm check:dco
结果：通过

bash /Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh <worktree>
结果：FAIL — apps/desktop 全量 2 failed / 27349 passed
失败项：src/main/cindy-brain/__tests__/ghostInstallReceipt.test.ts
（writes setup in the author format… / still reads normalized setup receipts…）
已在干净 origin/main（6d4acdba5，无本 PR diff）复现同一 2 条失败，与本次侧栏改动无关，不混入修复，交 CI 给权威结论。
```

### 手工验证

不涉及。改动在 Cindy worktree 内，宿主实例不会热更这些文件。

### 未执行的验证

- 未实机并排目检 Light / Dark 下项目行与任务行的红/绿点
- 未跑 `pnpm test:all`

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：桌面侧栏折叠项目行右侧状态点与 hover 操作按钮让位
- 回滚 / 降级方式：revert 本 PR
- 存量插件影响：无

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
