### PR TITLE
feat(desktop): add experimental TrueForge harness

### DIFF
--- a/apps/desktop/src/main/__tests__/messagePersistBroadcaster.test.ts
+++ b/apps/desktop/src/main/__tests__/messagePersistBroadcaster.test.ts
@@ -709,6 +709,22 @@ describe('update_plan tool_use persistence', () => {
 });
 
 describe('agent_kind enqueue snapshot', () => {
+  it('persists the experimental TrueForge kind without coercing it to Claude', async () => {
+    noteSessionAgentKind(SESSION, 'trueforge');
+    onToolUseEvent(
+      SESSION,
+      { toolUseId: 'trueforge-tool', toolName: 'search', input: { query: 'cindy' } },
+      null,
+    );
+    await flushWrites();
+
+    expect(createMessage).toHaveBeenCalledWith(
+      SESSION,
+      expect.objectContaining({ role: 'tool_use', agentKind: 'trueforge' }),
+      broadcastGuard(),
+    );
+  });
+
   it('owner boundary after commit keeps the durable result instead of triggering retry', async () => {
     const result = await enqueueDurableWrite('post-commit-owner-switch', () => {
       ownerScopeState.current = false;

--- a/apps/desktop/src/main/localDb/chatHistoryReader.ts
+++ b/apps/desktop/src/main/localDb/chatHistoryReader.ts
@@ -29,7 +29,7 @@ const messageRowid = sql<number>`"messages"."rowid"`;
 // ── Types ───────────────────────────────────────────────────────────────────
 
 export type HistoryOrder = 'asc' | 'desc';
-export type HistoryAgentKind = 'cc' | 'codex' | 'pi';
+export type HistoryAgentKind = 'cc' | 'codex' | 'pi' | 'trueforge';
 
 export interface HistoryCursor {
   createdAt: number; // unix ms

--- a/apps/desktop/src/main/localDb/conversationSearch.ts
+++ b/apps/desktop/src/main/localDb/conversationSearch.ts
@@ -18,7 +18,7 @@ import { normalizeWorkingDirForGrouping } from '../../shared/workingDir.js';
 import { getDbClient } from './client/current.js';
 import { messages, sessions } from './schema.js';
 import { searchChatHistoryHybrid } from './chatHistorySearch.js';
-import { normalizeDbAgentKind } from '../../shared/agentKindConversion.js';
+import { normalizeSessionDbAgentKind } from '../../shared/agentKindConversion.js';
 import {
   collectContentHitsUntilUniqueSessions,
   fuzzyTitleMatch,
@@ -364,7 +364,7 @@ function sessionSummaryFromRow(
     title: row.title,
     workingDir: row.workingDir,
     workspaceKind: row.workspaceKind,
-    agentKind: normalizeDbAgentKind(row.agentKind),
+    agentKind: normalizeSessionDbAgentKind(row.agentKind),
     status: row.status,
     source: row.source,
     orcaRole: row.orcaRole,

--- a/apps/desktop/src/main/localDb/ipc/messages.ts
+++ b/apps/desktop/src/main/localDb/ipc/messages.ts
@@ -1281,7 +1281,7 @@ export async function createMessage(
      * agentMeta 需要它;main 侧 SDK 事件落库路径必传,renderer pending echo 等
      * 无 SDK 元信息的行留空(null 回落 session.agentKind)。
      */
-    agentKind?: 'cc' | 'codex' | 'pi' | null;
+    agentKind?: 'cc' | 'codex' | 'pi' | 'trueforge' | null;
     createdAt?: number;
   },
   opts?: {

--- a/apps/desktop/src/main/localDb/ipc/sessions.ts
+++ b/apps/desktop/src/main/localDb/ipc/sessions.ts
@@ -18,7 +18,7 @@ import type { DbClient } from '../client/DbClient';
 import { sessions, messages } from '../schema';
 import { throwIpcError, requireString, requireObject } from '../../utils/ipcValidate';
 import { resolveBusinessSessionId } from '../../sessionIds';
-import { normalizeDbAgentKind } from '../../../shared/agentKindConversion';
+import { normalizeDbAgentKind, normalizeSessionDbAgentKind } from '../../../shared/agentKindConversion';
 import {
   sessionToCamel,
   sessionCreateToRow,
@@ -1257,7 +1257,7 @@ export function registerSessionIpc(
         state: row.status === 'deleted' ? 'deleted' : 'available',
         status: row.status,
         title: row.title,
-        agentKind: normalizeDbAgentKind(row.agentKind),
+        agentKind: normalizeSessionDbAgentKind(row.agentKind),
       };
     });
   });

--- a/apps/desktop/src/main/localDb/mapper.ts
+++ b/apps/desktop/src/main/localDb/mapper.ts
@@ -378,7 +378,7 @@ export function messageCreateToRow(
     content: unknown;
     toolUseId?: string;
     agentMeta?: AgentMeta | null;
-    agentKind?: 'cc' | 'codex' | 'pi' | null;
+    agentKind?: 'cc' | 'codex' | 'pi' | 'trueforge' | null;
     createdAt?: number;
   },
   now: number,

--- a/apps/desktop/src/main/maker-host/index.ts
+++ b/apps/desktop/src/main/maker-host/index.ts
@@ -109,6 +109,7 @@ import {
   resolveVerifiedContextWindow,
 } from './catalog-to-descriptors.js';
 import { buildPiAgent } from './pi-host.js';
+import { buildTrueForgeAgent } from './trueforge-host.js';
 import { clearChatgptBridgeCredentialCache } from './anthropic-responses-bridge-host.js';
 import {
   getDesktopSelectableCatalog,
@@ -2009,6 +2010,18 @@ export function getMaker(): Maker {
       },
     });
 
+    let trueForgeAgent = null;
+    try {
+      trueForgeAgent = buildTrueForgeAgent({
+        logger: desktopMakerLogger,
+        fetch: outboundFetch,
+      });
+    } catch (error) {
+      desktopMakerLogger.warn('trueforge configuration rejected', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+
     setVisionGatewayKeyReader(readClaudeApiKey);
     _visionBridgeInstance = createVisionBridge({
       getProviderById: (providerId) =>
@@ -2036,6 +2049,7 @@ export function getMaker(): Maker {
         'claude-code': claudeAgent,
         codex: codexAgent,
         ...(piAgent ? { pi: piAgent } : {}),
+        ...(trueForgeAgent ? { trueforge: trueForgeAgent } : {}),
       },
       storage: desktopSessionStorage,
       logger: desktopMakerLogger,
@@ -2045,9 +2059,11 @@ export function getMaker(): Maker {
       // 启动前的 Skill 共享与关闭后的清理都由 desktop host 注入。
       lifecycleHooks: {
         prepareStartOptions: async (sessionId, opts) => {
-          const providerReady = await ensureCurrentAccountProviderReadiness();
-          if (!providerReady) {
-            throw new Error('Account provider models are not ready for this app session; retry.');
+          if (String(opts.agentKind) !== 'trueforge') {
+            const providerReady = await ensureCurrentAccountProviderReadiness();
+            if (!providerReady) {
+              throw new Error('Account provider models are not ready for this app session; retry.');
+            }
           }
           await preparePersistedOrcaSessionStart(sessionId, opts as MakerSessionCreateOpts);
           if (opts.agentKind === 'codex') {

--- a/apps/desktop/src/main/maker-host/session-storage.ts
+++ b/apps/desktop/src/main/maker-host/session-storage.ts
@@ -12,7 +12,11 @@
 
 import { and, eq, inArray } from 'drizzle-orm';
 
-import { dbToMakerAgentKind, makerToDbAgentKind } from '../../shared/agentKindConversion.js';
+import {
+  dbToSessionAgentKind,
+  sessionToDbAgentKind,
+  type SessionDbAgentKind,
+} from '../../shared/agentKindConversion.js';
 
 import type {
   AgentKind,
@@ -27,15 +31,13 @@ import { normalizeRemoteHostId } from '../localDb/mapper.js';
 import { DESKTOP_VISIBLE_SESSION_SOURCES } from '../../shared/sessionSource.js';
 import { normalizeWorkingDirForStorage } from '../../shared/workingDir.js';
 
-type DbAgentKind = 'cc' | 'codex' | 'pi';
-
 // 形态映射走 shared/agentKindConversion 正本(支持 pi;此前 pi 被误落成 codex)。
-function toDbKind(k: AgentKind): DbAgentKind {
-  return makerToDbAgentKind(k);
+function toDbKind(k: AgentKind): SessionDbAgentKind {
+  return sessionToDbAgentKind(k);
 }
 
 function fromDbKind(k: string): AgentKind {
-  return dbToMakerAgentKind(k);
+  return dbToSessionAgentKind(k) as AgentKind;
 }
 
 function normalizeWorkspaceKind(value: unknown): WorkspaceKind {

--- a/apps/desktop/src/main/maker-host/trueforge-host.test.ts
+++ b/apps/desktop/src/main/maker-host/trueforge-host.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+
+import { readTrueForgeHostConfig, TRUEFORGE_ENV } from './trueforge-host';
+
+function env(values: Partial<Record<(typeof TRUEFORGE_ENV)[keyof typeof TRUEFORGE_ENV], string>>) {
+  return values as NodeJS.ProcessEnv;
+}
+
+describe('readTrueForgeHostConfig', () => {
+  it('is opt-in and requires both endpoint and model', () => {
+    expect(readTrueForgeHostConfig(env({}))).toBeNull();
+    expect(() =>
+      readTrueForgeHostConfig(
+        env({
+          [TRUEFORGE_ENV.baseUrl]: 'http://127.0.0.1:8787',
+        }),
+      ),
+    ).toThrow(/configured together/);
+  });
+
+  it('accepts explicit loopback HTTP and keeps the token in main-process config', () => {
+    const config = readTrueForgeHostConfig(
+      env({
+        [TRUEFORGE_ENV.baseUrl]: 'http://localhost:8787/',
+        [TRUEFORGE_ENV.model]: 'openai/gpt-5',
+        [TRUEFORGE_ENV.displayName]: 'Team model',
+        [TRUEFORGE_ENV.contextWindow]: '200000',
+        [TRUEFORGE_ENV.idToken]: 'secret-token',
+      }),
+    );
+    expect(config).toEqual({
+      baseUrl: 'http://localhost:8787',
+      model: 'openai/gpt-5',
+      displayName: 'Team model',
+      contextWindow: 200_000,
+      idToken: 'secret-token',
+    });
+  });
+
+  it.each([
+    'http://trueforge.example.com',
+    'https://user:pass@trueforge.example.com',
+    'https://trueforge.example.com/api/v1',
+    'https://trueforge.example.com?token=secret',
+  ])('rejects unsafe or non-origin endpoint %s', (baseUrl) => {
+    expect(() =>
+      readTrueForgeHostConfig(
+        env({
+          [TRUEFORGE_ENV.baseUrl]: baseUrl,
+          [TRUEFORGE_ENV.model]: 'openai/gpt-5',
+        }),
+      ),
+    ).toThrow();
+  });
+
+  it('validates model and context window without echoing the token', () => {
+    const unsafe = env({
+      [TRUEFORGE_ENV.baseUrl]: 'https://trueforge.example.com',
+      [TRUEFORGE_ENV.model]: 'invalid',
+      [TRUEFORGE_ENV.idToken]: 'do-not-log-me',
+    });
+    let message = '';
+    try {
+      readTrueForgeHostConfig(unsafe);
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error);
+    }
+    expect(message).not.toContain('do-not-log-me');
+    expect(() =>
+      readTrueForgeHostConfig(
+        env({
+          [TRUEFORGE_ENV.baseUrl]: 'https://trueforge.example.com',
+          [TRUEFORGE_ENV.model]: 'openai/gpt-5',
+          [TRUEFORGE_ENV.contextWindow]: '0',
+        }),
+      ),
+    ).toThrow(/positive integer/);
+  });
+});

--- a/apps/desktop/src/main/maker-host/trueforge-host.ts
+++ b/apps/desktop/src/main/maker-host/trueforge-host.ts
@@ -1,0 +1,114 @@
+import { TrueForgeAgent, type AuthAdapter, type Logger } from '@cindy/maker-core';
+
+export const TRUEFORGE_ENV = {
+  baseUrl: 'CINDY_TRUEFORGE_BASE_URL',
+  model: 'CINDY_TRUEFORGE_MODEL',
+  displayName: 'CINDY_TRUEFORGE_MODEL_DISPLAY_NAME',
+  contextWindow: 'CINDY_TRUEFORGE_CONTEXT_WINDOW',
+  idToken: 'CINDY_TRUEFORGE_ID_TOKEN',
+} as const;
+
+export interface TrueForgeHostConfig {
+  baseUrl: string;
+  model: string;
+  displayName?: string;
+  contextWindow: number;
+  idToken?: string;
+}
+
+function isLoopback(hostname: string): boolean {
+  const normalized = hostname.toLowerCase();
+  return normalized === 'localhost' || normalized === '127.0.0.1' || normalized === '::1';
+}
+
+/** Parse an opt-in service config without ever returning/logging the token separately. */
+export function readTrueForgeHostConfig(
+  env: NodeJS.ProcessEnv = process.env,
+): TrueForgeHostConfig | null {
+  const rawBaseUrl = env[TRUEFORGE_ENV.baseUrl]?.trim();
+  const model = env[TRUEFORGE_ENV.model]?.trim();
+  if (!rawBaseUrl && !model) return null;
+  if (!rawBaseUrl || !model) {
+    throw new Error(
+      `${TRUEFORGE_ENV.baseUrl} and ${TRUEFORGE_ENV.model} must be configured together`,
+    );
+  }
+
+  const url = new URL(rawBaseUrl);
+  if (url.username || url.password || url.search || url.hash) {
+    throw new Error(
+      `${TRUEFORGE_ENV.baseUrl} must not contain credentials, query parameters, or a fragment`,
+    );
+  }
+  if (url.protocol !== 'https:' && !(url.protocol === 'http:' && isLoopback(url.hostname))) {
+    throw new Error(
+      `${TRUEFORGE_ENV.baseUrl} must use HTTPS, except for an explicit loopback address`,
+    );
+  }
+  if (url.pathname !== '/' && url.pathname !== '') {
+    throw new Error(
+      `${TRUEFORGE_ENV.baseUrl} must be the TrueForge origin, without /api/v1 or another path`,
+    );
+  }
+  if (!model.includes('/') || model.startsWith('/') || model.endsWith('/')) {
+    throw new Error(`${TRUEFORGE_ENV.model} must be a TrueForge provider/model name`);
+  }
+
+  const rawContextWindow = env[TRUEFORGE_ENV.contextWindow]?.trim();
+  const contextWindow = rawContextWindow ? Number(rawContextWindow) : 128_000;
+  if (!Number.isSafeInteger(contextWindow) || contextWindow <= 0) {
+    throw new Error(`${TRUEFORGE_ENV.contextWindow} must be a positive integer`);
+  }
+
+  const displayName = env[TRUEFORGE_ENV.displayName]?.trim();
+  const idToken = env[TRUEFORGE_ENV.idToken]?.trim();
+  return {
+    baseUrl: url.origin,
+    model,
+    ...(displayName ? { displayName } : {}),
+    contextWindow,
+    ...(idToken ? { idToken } : {}),
+  };
+}
+
+export interface BuildTrueForgeAgentOptions {
+  logger: Logger;
+  fetch: typeof globalThis.fetch;
+  env?: NodeJS.ProcessEnv;
+}
+
+/**
+ * Register TrueForge only when the user explicitly supplies both endpoint and
+ * model. The optional OIDC ID token stays in the main-process SDK closure.
+ */
+export function buildTrueForgeAgent(options: BuildTrueForgeAgentOptions): TrueForgeAgent | null {
+  const config = readTrueForgeHostConfig(options.env);
+  if (!config) return null;
+
+  const authState = async () => ({
+    authenticated: true as const,
+    identity: `TrueForge · ${new URL(config.baseUrl).host}`,
+    ...(config.idToken ? { authSource: 'oauth' as const } : {}),
+  });
+  const auth: AuthAdapter = {
+    getState: authState,
+    triggerLogin: authState,
+    async logout() {
+      /* environment-owned configuration cannot be mutated here */
+    },
+    async getAuthEnv() {
+      return {};
+    },
+  };
+
+  return new TrueForgeAgent(
+    {
+      auth,
+      runtimeConfig: { endpoint: config.baseUrl },
+      binaryPath: '',
+      runtimeKind: 'service',
+      logger: options.logger.child('trueforge'),
+    },
+    { ...config, fetch: options.fetch },
+  );
+}

--- a/apps/desktop/src/main/maker-ipc/__tests__/sessionCreateHandler.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/sessionCreateHandler.test.ts
@@ -33,6 +33,21 @@ function createDeps(overrides: Record<string, unknown> = {}) {
 }
 
 describe('maker session CREATE_SESSION IPC handler', () => {
+  it('rejects device-link creation of a TrueForge session', async () => {
+    const harness = new IpcHarness();
+    const deps = createDeps({ isRemoteInvoke: () => true });
+    registerMakerSessionCreateHandler(harness, deps);
+
+    await expect(
+      harness.invoke(MAKER_INVOKE.CREATE_SESSION, {
+        agentKind: 'trueforge',
+        workingDir: 'C:\\repo',
+        model: 'openai/gpt-5',
+      }),
+    ).rejects.toMatchObject({ code: 'UNSUPPORTED_CAPABILITY' });
+    expect(deps.bootstrapSession).not.toHaveBeenCalled();
+  });
+
   it('bootstraps a session and returns the public create-session payload', async () => {
     const harness = new IpcHarness();
     const deps = createDeps();

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -551,7 +551,7 @@ import {
   runPiPackageListIpcBoundary,
   runPiPackageMutationIpcBoundary,
 } from './piPackageMutationIpc.js';
-import { dbToMakerAgentKind, makerToDbAgentKind } from '../../shared/agentKindConversion.js';
+import { dbToMakerAgentKind, sessionToDbAgentKind } from '../../shared/agentKindConversion.js';
 import { readWorkflowProgressForSession } from '../workflow-progress/reader.js';
 import { AgentInputCoordinator } from './agent-input-coordinator.js';
 import {
@@ -1937,6 +1937,7 @@ export function stopOrcaIdleWatcher(): void {
 }
 
 function requireAgentKind(value: unknown): AgentKind {
+  if (value === 'trueforge') return value as AgentKind;
   if (value === 'claude-code' || value === 'codex' || value === 'pi') return value;
   throwIpcError('INVALID_PARAMS', 'agentKind required');
 }
@@ -3715,7 +3716,7 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
 
   // session-agent-switch:登记本会话当前引擎,broadcaster / user 行落库据此逐行
   // stamp messages.agent_kind(切换后历史行的 agent_meta 必须按写入时引擎解析)。
-  noteSessionAgentKind(session.id, makerToDbAgentKind(session.agentKind));
+  noteSessionAgentKind(session.id, sessionToDbAgentKind(session.agentKind));
 
   // 订阅槽①旁听 tap(独立监听,叠加在主转发之外互不干扰):AgentEvent →
   // did-turn-*。资格(用户主会话)与自动化轮次过滤都在 tap 内部,这里零逻辑。
@@ -3890,7 +3891,7 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
             markSessionTurnStarted(session.id);
           }
           if (
-            (event.source === 'claude-code' || event.source === 'codex' || event.source === 'pi') &&
+            (event.source === 'claude-code' || event.source === 'codex' || event.source === 'pi' || event.source === 'trueforge') &&
             !turnModelPromiseBySession.has(session.id)
           ) {
             turnModelPromiseBySession.set(session.id, readSessionModelForUsage(session.id));
@@ -3997,7 +3998,7 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
         // EVENT broadcast 后结束逻辑 turn，并保留 terminal grace 给 renderer 收尾；
         // 可重试 error 保持 running。
         shouldMarkTurnTerminalIdleAfterBroadcast = true;
-        if (event.source === 'claude-code' || event.source === 'codex' || event.source === 'pi') {
+        if (event.source === 'claude-code' || event.source === 'codex' || event.source === 'pi' || event.source === 'trueforge') {
           turnModelPromiseBySession.delete(session.id);
         }
         const errData =
@@ -4439,6 +4440,27 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
       // 重算 —— 修 SDK 把它们按 Anthropic 价错算 (~2.5x) 的 bug。逐模型解析后四个 sink
       // (今日 / session / per-message / 按模型) 同源同值。
       // 守卫: index.ts:388 stream_end fallback / codex done 不带 total_cost_usd, typeof 检查会跳过。
+      if (event.type === 'done' && event.source === 'trueforge') {
+        turnModelPromiseBySession.delete(session.id);
+        const rawUsage = (event.data as { usage?: unknown } | undefined)?.usage;
+        if (rawUsage && typeof rawUsage === 'object') {
+          const inputTokens = Number((rawUsage as { inputTokens?: unknown }).inputTokens) || 0;
+          const outputTokens = Number((rawUsage as { outputTokens?: unknown }).outputTokens) || 0;
+          void recordSessionTurnTokens(session.id, inputTokens + outputTokens);
+          if (turnAssistantPersistId) {
+            void recordTurnUsageOnMessage({
+              sessionId: session.id,
+              clientId: turnAssistantPersistId,
+              turnUsageDetails: buildTurnUsageDetails({
+                inputTokens,
+                outputTokens,
+                cacheReadTokens: 0,
+                cacheCreateTokens: 0,
+              }),
+            });
+          }
+        }
+      }
       if (event.type === 'done' && event.source === 'claude-code') {
         const modelPromise =
           turnModelPromiseBySession.get(session.id) ?? readSessionModelForUsage(session.id);
@@ -7290,11 +7312,18 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
 
   const makerSessionRegistry = createElectronIpcHandlerRegistry();
   registerMakerSessionCreateHandler(makerSessionRegistry, {
+    isRemoteInvoke: isDeviceLinkInvoke,
     // CREATE_SESSION 同样先走 remote ensure:remote draft (尤其 collab
     // lead) 的 SSH 重连 / agent 安装 / codex daemon MCP 注入必须先于
     // bootstrap, 否则 lead 首个 turn 没有 cindy_orca, 与 orca 架构文档的
     // "session start/resume 前置" 契约不符。本地会话 ensure 内部直接返回。
     bootstrapSession: async (co) => {
+      if ((co.agentKind as string) === 'trueforge' && co.remoteHostId) {
+        throwIpcError(
+          'UNSUPPORTED_CAPABILITY',
+          'TrueForge does not support SSH remote sessions in this version',
+        );
+      }
       await ensureRemoteReadyForSessionStart({ createOpts: co });
       const result = await bootstrapSession(co);
       // maker:create-session 是手机 / device-link 的创建入口，不经过
@@ -12389,6 +12418,12 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
     assertRemoteInputClearNotInFlight(sid, remote);
     if (remote) {
       const row = await getInputSessionRow(sid);
+      if (row.agentKind === 'trueforge') {
+        throwIpcError(
+          'UNSUPPORTED_CAPABILITY',
+          'TrueForge sessions cannot be controlled over device-link in this version',
+        );
+      }
       const durableRow = await retryPendingInputClearBoundary(sid, true, row);
       if (!inputCoordinator.isGenerationCurrent(sid, expectedInputGeneration)) {
         throwIpcError(

--- a/apps/desktop/src/main/maker-ipc/sessionCreateHandler.ts
+++ b/apps/desktop/src/main/maker-ipc/sessionCreateHandler.ts
@@ -61,6 +61,8 @@ export interface MakerSessionCreateHandlerDeps<
   allocateDialogueWorkspace?: (sessionId: string, nowMs: number) => string;
   createSessionId?: () => string;
   now?: () => number;
+  /** True for device-link/controller-originated creates. */
+  isRemoteInvoke?: () => boolean;
   /**
    * 显式 sessionId 的创建事务锁。device-link 的预创建 worktree 补偿回收使用同一把锁，
    * 防止控制端超时后晚到的 create 与 cleanup 并发，出现「刚落库就被删目录」。
@@ -85,6 +87,9 @@ export function registerMakerSessionCreateHandler<TSession extends MakerSessionC
       }),
       deps.warnStderr,
     );
+    if (deps.isRemoteInvoke?.() && (o.agentKind as string) === 'trueforge') {
+      throwIpcError('UNSUPPORTED_CAPABILITY', 'TrueForge sessions are desktop-local in this version');
+    }
 
     const run = async () => {
       let bootstrapped: Awaited<ReturnType<typeof deps.bootstrapSession>>;

--- a/apps/desktop/src/main/maker-ipc/sessionRequest.ts
+++ b/apps/desktop/src/main/maker-ipc/sessionRequest.ts
@@ -66,6 +66,7 @@ export interface ReadCreateSessionOptsDeps {
 }
 
 function readAgentKind(value: unknown): AgentKind {
+  if (value === 'trueforge') return value as AgentKind;
   if (value === 'claude-code' || value === 'codex' || value === 'pi') return value;
   throwIpcError('INVALID_PARAMS', 'agentKind required');
 }

--- a/apps/desktop/src/main/messagePersistBroadcaster.ts
+++ b/apps/desktop/src/main/messagePersistBroadcaster.ts
@@ -56,6 +56,7 @@ import { redactSensitiveText } from '@cindy/maker-shared/error-redaction';
 import { stripInternalWebCitations } from '@cindy/maker-shared/internal-citation';
 import { getSessionProvider } from './maker-host/session-provider-store.js';
 import type { AgentMeta } from '../renderer/lib/ccAgent.types';
+import type { SessionDbAgentKind } from '../shared/agentKindConversion.js';
 
 const log = createLogger('messagePersistBroadcaster');
 
@@ -110,13 +111,13 @@ type OwnerScope = ReturnType<typeof broadcastTap.captureDataOwnerBroadcastScope>
  * session.agent_kind 只代表"当前引擎",历史行的 agent_meta 必须按写入时引擎解析。
  * clearSessionPersistState 时清理。
  */
-const dbAgentKindBySession = new Map<string, 'cc' | 'codex' | 'pi'>();
+const dbAgentKindBySession = new Map<string, SessionDbAgentKind>();
 
-export function noteSessionAgentKind(sessionId: string, dbAgentKind: 'cc' | 'codex' | 'pi'): void {
+export function noteSessionAgentKind(sessionId: string, dbAgentKind: SessionDbAgentKind): void {
   dbAgentKindBySession.set(sessionId, dbAgentKind);
 }
 
-export function getSessionDbAgentKind(sessionId: string): 'cc' | 'codex' | 'pi' | null {
+export function getSessionDbAgentKind(sessionId: string): SessionDbAgentKind | null {
   return dbAgentKindBySession.get(sessionId) ?? null;
 }
 

--- a/apps/desktop/src/renderer/__tests__/agentCapabilitiesDeviceCache.test.ts
+++ b/apps/desktop/src/renderer/__tests__/agentCapabilitiesDeviceCache.test.ts
@@ -105,7 +105,7 @@ describe('useAgentCapabilities deviceId-aware cache', () => {
     );
   });
 
-  it('本机目录快照在可选 Pi 不可用时仍返回 Claude Code 与 Codex 能力', async () => {
+  it('本机目录快照在可选 Pi 不可用时仍返回核心与 TrueForge 能力', async () => {
     const { getCapabilities } = stubElectron();
     getCapabilities.mockImplementation(async (agent: string) => {
       if (agent === 'pi')
@@ -119,6 +119,7 @@ describe('useAgentCapabilities deviceId-aware cache', () => {
     await expect(mod.loadLocalCapabilitiesSnapshot()).resolves.toEqual([
       ['claude-code', caps('local:claude-code')],
       ['codex', caps('local:codex')],
+      ['trueforge', caps('local:trueforge')],
     ]);
     expect(getCapabilities).toHaveBeenCalledWith('pi');
   });

--- a/apps/desktop/src/renderer/__tests__/chatInputModelSelectorRouting.test.ts
+++ b/apps/desktop/src/renderer/__tests__/chatInputModelSelectorRouting.test.ts
@@ -81,10 +81,10 @@ describe('ChatInput model source switching wiring', () => {
    */
   it('never locks the union list to a guessed engine before session identity resolves', () => {
     expect(chatInputSource).toContain(
-      'const sessionEngineConfirmed = !sessionId || runtimeAgentKind != null;',
+      'const sessionEngineConfirmed = !sessionId || stableRuntimeAgentKind != null;',
     );
     expect(chatInputSource).toContain(
-      'inSessionEngineLocked && sessionEngineConfirmed ? (runtimeAgentKind ?? agentKind) : null',
+      'inSessionEngineLocked && sessionEngineConfirmed ? (stableRuntimeAgentKind ?? agentKind) : null',
     );
     // 防复活:锁定分支不得再直接读 vendorKey 派生的 agentKind。
     expect(chatInputSource).not.toContain(
@@ -111,10 +111,10 @@ describe('ChatInput model source switching wiring', () => {
       'engineMarkVendor={unifiedPanelActive ? composerEngineMarkVendor : null}',
     );
     expect(chatInputSource).toContain(
-      "resolveModelSelectorAgentIdentity(runtimeAgentKind, agentSwitchIntent?.target)?.vendorKey ??",
+      "resolveModelSelectorAgentIdentity(stableRuntimeAgentKind, agentSwitchIntent?.target)?.vendorKey ??",
     );
     // 草稿没有 session 身份可言,当前引擎就是 vendorKey。
-    expect(chatInputSource).toContain(': (vendorKey ?? null);');
+    expect(chatInputSource).toContain(': (stableVendorKey ?? null);');
   });
 
   it('falls back to the legacy panel only when the controlled device has no provider catalog', () => {
@@ -122,7 +122,7 @@ describe('ChatInput model source switching wiring', () => {
     // 就是一张空列表。判据必须是结构化的 unsupported,不是 providers.length===0
     // (后者在加载中恒成立,会让面板每次打开先闪一下旧布局)。
     expect(chatInputSource).toContain(
-      'const unifiedModelPanelEnabled = !deviceLinkDeviceId || !remoteProviders.unsupported;',
+      'const unifiedModelPanelEnabled = !isTrueForge && (!deviceLinkDeviceId || !remoteProviders.unsupported);',
     );
   });
 

--- a/apps/desktop/src/renderer/__tests__/newMakerCreateAgentVisualContract.test.ts
+++ b/apps/desktop/src/renderer/__tests__/newMakerCreateAgentVisualContract.test.ts
@@ -119,7 +119,8 @@ describe('NewMakerDraftRoute CREATE AGENT visual contract', () => {
       'onEffortDidChange={handleEffortDidChange}',
       'onPermissionModeDidChange={handlePermissionModeDidChange}',
       'onProviderDidChange={handleProviderDidChange}',
-      'vendorKey={normalizeDbAgentKind(draft.vendor)}',
+      "draft.vendor === 'trueforge'",
+      ": normalizeDbAgentKind(draft.vendor)",
       // #807 第二十二轮:仍然由调用方显式持有(ChatInput 不 fallback 内部一份),但远程草稿下
       // 包了一层闸门 —— 拒绝路径型附件,因为那是控制端绝对路径,发到对端读不到或读到无关文件。
       'attachmentState={guardedAttachmentState}',
@@ -129,8 +130,8 @@ describe('NewMakerDraftRoute CREATE AGENT visual contract', () => {
       // ExtraDirsButton 据此不渲染引用目录段。原因是它开的是控制端原生目录对话框,选出的本机
       // 路径发到对端会被 validateExtraDirs 静默丢掉、或撞上对端同名的无关目录 —— chip 显示的
       // 并非真实授予的上下文。本机草稿行为不变;把 picker 路由到对端后恢复,见 issue #1012。
-      'onExtraDirsChange={isDeviceLinkDraft ? undefined : handleExtraDirsChange}',
-      'onNewGoal={(text) =>',
+      'isTrueForgeDraft || isDeviceLinkDraft ? undefined : handleExtraDirsChange',
+      'onNewGoal={isTrueForgeDraft ? undefined : (text) =>',
       'rememberedEffortByModel={isDeviceLinkDraft ? undefined : draft.effortByModel}',
       'onRememberedEffortChange={',
       'isDeviceLinkDraft ? undefined : handleRememberedEffortChange',

--- a/apps/desktop/src/renderer/__tests__/newMakerProjectPicker.test.ts
+++ b/apps/desktop/src/renderer/__tests__/newMakerProjectPicker.test.ts
@@ -700,7 +700,7 @@ describe('Shared create project picker', () => {
     // 上层仍要在已选设备时下发 onAddRemoteProject —— 入口 1 与空态入口都靠它,
     // 只是那个 Globe 项不再渲染。别顺手把这个 gate 一起收掉。
     expect(newMakerDraftRouteSource).toMatch(
-      /hasAnyRemoteTarget \|\|\s*folderPickerDeviceScope\s*\?\s*handleOpenRemoteProject\s*:\s*undefined/,
+      /!isTrueForgeDraft &&\s*\(hasAnyRemoteTarget \|\| folderPickerDeviceScope\)\s*\?\s*handleOpenRemoteProject\s*:\s*undefined/,
     );
   });
 
@@ -1047,7 +1047,7 @@ describe('Shared create project picker', () => {
     expect(folderPickerPopoverSource).toContain('onAddRemoteProject?.(deviceScope.deviceId);');
     // 已选定设备时无条件下发入口(设备离线也要能浏览它)。
     expect(newMakerDraftRouteSource).toMatch(
-      /hasAnyRemoteTarget \|\|\s*folderPickerDeviceScope\s*\?\s*handleOpenRemoteProject\s*:\s*undefined/,
+      /!isTrueForgeDraft &&\s*\(hasAnyRemoteTarget \|\| folderPickerDeviceScope\)\s*\?\s*handleOpenRemoteProject\s*:\s*undefined/,
     );
   });
 
@@ -1502,7 +1502,7 @@ describe('Shared create project picker', () => {
   // 会被静默丢掉、或撞上对端同名的无关目录 —— chip 显示的并不是真实授予的上下文。
   it('hides the reference-directory picker on remote drafts', () => {
     expect(newMakerDraftRouteSource).toContain(
-      'onExtraDirsChange={isDeviceLinkDraft ? undefined : handleExtraDirsChange}',
+      'isTrueForgeDraft || isDeviceLinkDraft ? undefined : handleExtraDirsChange',
     );
     // 统一建议面板的契约:没有 onExtraDirsChange 就不装配添加/移除引用目录能力。
     expect(chatInputSource).toContain('if (onExtraDirsChange) {');

--- a/apps/desktop/src/renderer/__tests__/newMakerWorktreeSend.test.ts
+++ b/apps/desktop/src/renderer/__tests__/newMakerWorktreeSend.test.ts
@@ -36,7 +36,7 @@ describe('NewMakerDraftRoute worktree send flow', () => {
   });
 
   it('never silently downgrades an explicit worktree request to a normal session', () => {
-    const selected = source.indexOf('const selectedWorktree = { ...wtRef.current };');
+    const selected = source.indexOf('const selectedWorktree = {');
     const guard = source.indexOf(
       '&& selectedWorktree.confirmedIneligible !== true',
       selected,
@@ -45,6 +45,9 @@ describe('NewMakerDraftRoute worktree send flow', () => {
     const guardedSource = source.slice(guard, markInFlight);
 
     expect(selected).toBeGreaterThan(-1);
+    expect(source.slice(selected, guard)).toContain(
+      'enabled: isTrueForgeDraft ? false : wtRef.current.enabled',
+    );
     expect(guard).toBeGreaterThan(selected);
     expect(markInFlight).toBeGreaterThan(guard);
     expect(guardedSource).toContain('!selectedWorktree.baseRepo');

--- a/apps/desktop/src/renderer/__tests__/remoteSessionSyncInvariants.test.ts
+++ b/apps/desktop/src/renderer/__tests__/remoteSessionSyncInvariants.test.ts
@@ -113,10 +113,10 @@ describe('CCAgentSessionView 接线不变式', () => {
       'const enforceConnectedSourceGate = !sessionId || !deviceLinkDeviceId;',
     );
     expect(chatInputSrc).toMatch(
-      /const noConnectedSource =\s*enforceConnectedSourceGate &&\s*!!currentModelAgentKind/,
+      /const noConnectedSource =\s*!isTrueForge &&\s*enforceConnectedSourceGate &&\s*!!currentModelAgentKind/,
     );
     expect(chatInputSrc).toMatch(
-      /if\s*\(\s*enforceConnectedSourceGate\s*&&\s*currentModelAgentKind\s*&&[\s\S]*?\)\s*\{/,
+      /if\s*\(\s*!isTrueForge\s*&&\s*enforceConnectedSourceGate\s*&&\s*currentModelAgentKind\s*&&[\s\S]*?\)\s*\{/,
     );
   });
   it('断线缓存的远程 session 可查看,但生命周期/元数据写操作必须走统一 gate', () => {

--- a/apps/desktop/src/renderer/components/icons/TrueForgeMark.tsx
+++ b/apps/desktop/src/renderer/components/icons/TrueForgeMark.tsx
@@ -1,0 +1,13 @@
+import { cn } from '@/lib/utils';
+
+export function TrueForgeMark({ size = 14, className }: { size?: number; className?: string }) {
+  return (
+    <span
+      aria-hidden
+      className={cn('inline-flex shrink-0 items-center justify-center font-semibold tracking-[-0.08em]', className)}
+      style={{ width: size, height: size, fontSize: size * 0.58, lineHeight: `${size}px` }}
+    >
+      TF
+    </span>
+  );
+}

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -288,7 +288,11 @@ import {
   plainTextToComposerDocument,
   stripHostCapabilityChips,
 } from '@/lib/composerListDocument';
-import { useAgentCapabilities, type AgentKind } from '@/hooks/useAgentCapabilities';
+import {
+  useAgentCapabilities,
+  type AgentKind,
+  type CapabilityAgentKind,
+} from '@/hooks/useAgentCapabilities';
 import { useAvailableAgents } from '@/hooks/useAvailableAgents';
 import { useConnectedSource } from '@/hooks/useConnectedSource';
 import { useProviders } from '@/hooks/useProviders';
@@ -449,7 +453,7 @@ interface ChatInputProps {
    * 已由 session/runtime 元数据确认的当前 Agent。null/undefined 表示身份尚未加载；
    * 不能用 vendorKey 的 Claude Code 默认回退冒充真实身份。
    */
-  runtimeAgentKind?: AgentKind | null;
+  runtimeAgentKind?: CapabilityAgentKind | null;
   /**
    * 会话的 Orca 角色(lead / worker;null = 已确认非协同;undefined = 元数据未加载)。
    * 协同运行时对 agent 形态有独立
@@ -636,7 +640,7 @@ interface ChatInputProps {
    * M35: Vendor lock — when provided, ModelSelector only shows models
    * belonging to this vendor ('cc' for Claude, 'codex' for OpenAI Codex).
    */
-  vendorKey?: 'cc' | 'codex' | 'pi';
+  vendorKey?: 'cc' | 'codex' | 'pi' | 'trueforge';
   /**
    * Optional override for the composerDraftStore key used to persist editor
    * content (and via attachmentState, attachments) across mount/unmount.
@@ -769,10 +773,11 @@ function agentKindToVendor(kind: AgentKind): 'cc' | 'codex' | 'pi' {
   return kind === 'codex' ? 'codex' : kind === 'pi' ? 'pi' : 'cc';
 }
 
-function vendorKeyToAgentKind(v?: 'cc' | 'codex' | 'pi'): AgentKind | null {
+function vendorKeyToAgentKind(v?: 'cc' | 'codex' | 'pi' | 'trueforge'): CapabilityAgentKind | null {
   if (v === 'cc') return 'claude-code';
   if (v === 'codex') return 'codex';
   if (v === 'pi') return 'pi';
+  if (v === 'trueforge') return 'trueforge';
   return null;
 }
 
@@ -1286,6 +1291,7 @@ export function ChatInput({
       // 冷加载帧:runtimeAgentKind 尚未确认时就默认 claude-code,会将其他引擎的会话内容
       // 发给 Claude Code provider —— 跳过预测,等 agent 身份确认后再恢复。
       if (runtimeAgentKind == null) return;
+      if (runtimeAgentKind === 'trueforge') return;
       const latestMessages = messagesRef.current;
       const ed = editorRef.current;
       if (
@@ -1629,8 +1635,11 @@ export function ChatInput({
   // initialModel/initialEffort 缺失的瞬态(会话快照未加载)兜底:读本地草稿 lastByVendor
   // (localStorage,按 agent 分槽、sanitize 恒有种子值)。默认模型/档位偏好已全量本地化,
   // 不再依赖服务端 UserPreferences(登录态失效/离线时模型与档位选择必须照常工作)。
-  const localVendorDefaults =
-    getDraft().lastByVendor[vendorKey === 'pi' ? 'pi' : vendorKey === 'codex' ? 'codex' : 'cc'];
+  const localVendorDefaults = getDraft().lastByVendor[
+    vendorKey === 'trueforge'
+      ? 'trueforge'
+      : vendorKey === 'pi' ? 'pi' : vendorKey === 'codex' ? 'codex' : 'cc'
+  ];
   // session-agent-switch 意图制:意图期内 chip / 选择器显示用户选择的目标
   // (model/effort/provider/fast),props(镜像 DB)仍是旧引擎值——真切换在下一条
   // 消息发送时刻 apply,patched 回流后意图清除、显示交回 props。意图存放在
@@ -1718,17 +1727,31 @@ export function ChatInput({
     return () => clearTimeout(timer);
   }, [initialModel, initialEffort, initialProviderId, pendingRemoteSwitch]);
 
-  const agentKind = vendorKeyToAgentKind(vendorKey);
+  const capabilityAgentKind = vendorKeyToAgentKind(vendorKey);
+  const isTrueForge = capabilityAgentKind === 'trueforge';
+  const stableVendorKey = isTrueForge
+    ? undefined
+    : (vendorKey as 'cc' | 'codex' | 'pi' | undefined);
+  const agentKind: AgentKind | null =
+    capabilityAgentKind === 'trueforge' ? null : capabilityAgentKind;
   // device-link 远程会话:能力(模型 / fast / effort)从被控端读;本地会话 deviceLinkDeviceId undefined → 本地。
   const ccCaps = useAgentCapabilities('claude-code', deviceLinkDeviceId ?? undefined);
   const codexCaps = useAgentCapabilities('codex', deviceLinkDeviceId ?? undefined);
   const piCaps = useAgentCapabilities('pi', deviceLinkDeviceId ?? undefined);
+  const trueForgeCaps = useAgentCapabilities(
+    'trueforge',
+    isTrueForge ? undefined : deviceLinkDeviceId ?? undefined,
+  );
   const activeAgentCapabilities =
-    agentKind === 'codex'
+    capabilityAgentKind === 'trueforge'
+      ? trueForgeCaps.capabilities
+      : agentKind === 'codex'
       ? codexCaps.capabilities
       : agentKind === 'pi'
         ? piCaps.capabilities
         : ccCaps.capabilities;
+  const trueForgeModelLabel =
+    trueForgeCaps.capabilities?.availableModels[0]?.displayName ?? activeModel;
 
   // session-agent-switch 入口门控。device-link 远程会话读**被控端**的值；除了基础
   // supportsSessionAgentSwitch，还必须有 v2 CAS 能力。同引擎 no-op 的安全收尾依赖 host
@@ -1883,7 +1906,7 @@ export function ChatInput({
   // 的「已知边界」)。unsupported 是**结构化**判定(isDeviceProvidersUnsupportedError),
   // 不是 providers.length===0:后者在首帧加载中恒成立,拿它当条件会让面板每次打开先闪
   // 一下旧版布局。
-  const unifiedModelPanelEnabled = !deviceLinkDeviceId || !remoteProviders.unsupported;
+  const unifiedModelPanelEnabled = !isTrueForge && (!deviceLinkDeviceId || !remoteProviders.unsupported);
   // 联合列表参与哪些引擎 —— 以**运行时注册结果**为准(device-link 取被控端的)。
   // 撤掉新会话工具条的 AgentSelect 后,它的 hiddenVendors 门禁就落到这里:Pi 二进制缺失
   // 时模型目录照样投影 Pi 模型,只看目录会让用户一路选到 requireAgent 的 not-registered。
@@ -1915,7 +1938,7 @@ export function ChatInput({
         includeDisabled: !!sessionId,
       }).length > 0
     : false;
-  const noConnectedSource =
+  const noConnectedSource = !isTrueForge &&
     enforceConnectedSourceGate &&
     !!currentModelAgentKind &&
     !providersLoading &&
@@ -1931,7 +1954,7 @@ export function ChatInput({
   //   · 草稿(无 sessionId):sendProviderId 会 null 化 → 建会话回落默认路由,回落图标即真实,不判断开;
   //   · device-link 远程会话:连接态在被控端,控制端不判。
   // providersLoading 期间不判(规则同 noConnectedSource,避免首帧闪断开态)。
-  const selectedSourceDisconnected =
+  const selectedSourceDisconnected = !isTrueForge &&
     !!sessionId &&
     !deviceLinkDeviceId &&
     isSelectedSourceDisconnected({
@@ -1957,13 +1980,14 @@ export function ChatInput({
   //   providerId=null,路由才回落 spawn-aware 默认(字节级不变,no-break);写成显式 'xd'
   //   会改走 catalog gateway-key 路由(见 provider-route.ts),破坏默认 cohort 的路由/缓存基线。
   const sendProviderId = useMemo<string | null>(() => {
+    if (isTrueForge) return null;
     const kind = currentModelAgentKind;
     if (!kind || !activeProviderId) return null;
     return effectiveSourceIdForModel(sendProviders, activeProviderId, activeModel, kind) ===
       activeProviderId
       ? activeProviderId
       : null;
-  }, [sendProviders, currentModelAgentKind, activeProviderId, activeModel]);
+  }, [sendProviders, currentModelAgentKind, activeProviderId, activeModel, isTrueForge]);
 
   // 模型预设采用「全局默认 + 已创建会话保护」:
   //   - 本地草稿 / 已创建会话的**非选中行**都读写 providerModelMemory,所以同一
@@ -5115,6 +5139,7 @@ export function ChatInput({
         // 处理,不误伤。用 chatEligibleSourcesForModel 而非裸 sourcesForModel:
         // 非聊天来源不该被当成"可以发"放行(issue #882 第 3 点,2026-07 review)。
         if (
+          !isTrueForge &&
           enforceConnectedSourceGate &&
           currentModelAgentKind &&
           // 旧被控端明确不支持 provider:list 时，控制端没有可检查的来源镜像；
@@ -6412,11 +6437,12 @@ export function ChatInput({
   // composerEngineMarkVendor / 锚点派生校验早已同口径。意图清除(发送后 patched 回流)时
   // vendorKey 收敛成同一个值,口径无缝交回。
   const intentTargetAgent = agentSwitchIntent?.target ?? null;
+  const stableRuntimeAgentKind = runtimeAgentKind === 'trueforge' ? null : runtimeAgentKind;
   const sessionEngineFilter = useMemo(() => {
     if (!unifiedModelPanelEnabled) return undefined;
     if (!sessionId || !vendorKey || remoteHostId || !sessionAgentSwitchSupported) return undefined;
     const currentAgent = intentTargetAgent ?? vendorKeyToAgentKind(vendorKey);
-    if (!currentAgent) return undefined;
+    if (!currentAgent || currentAgent === 'trueforge') return undefined;
     return {
       currentAgent,
       onCrossEngineSelect: async ({
@@ -6501,9 +6527,9 @@ export function ChatInput({
   //     (绝不拿 vendorKey 的 Claude Code 回退冒充,见 runtimeAgentKind 的 prop 说明);
   //   · 草稿:没有 session 身份可言,当前引擎就是 vendorKey 本身。
   const composerEngineMarkVendor = sessionId
-    ? (resolveModelSelectorAgentIdentity(runtimeAgentKind, agentSwitchIntent?.target)?.vendorKey ??
+    ? (resolveModelSelectorAgentIdentity(stableRuntimeAgentKind, agentSwitchIntent?.target)?.vendorKey ??
       null)
-    : (vendorKey ?? null);
+    : (stableVendorKey ?? null);
 
   /**
    * 下发给统一面板的收藏锚点:草稿用调用方(NewMakerDraftRoute)持有的那一份,会话用上面
@@ -6544,10 +6570,10 @@ export function ChatInput({
   // 两件事撞在一起的后果不是"闪一下":Codex 会话会摆出一张**纯 Claude** 的列表,而且此时
   // 没有跨引擎兜底,点任意一行都会把 Claude 模型经 onProviderChange 塞进 Codex 会话
   // (bug4)。所以身份未确认时不锁 —— 回落旧面板一帧,等 runtimeAgentKind 落地再进统一面板。
-  const sessionEngineConfirmed = !sessionId || runtimeAgentKind != null;
+  const sessionEngineConfirmed = !sessionId || stableRuntimeAgentKind != null;
   const inSessionEngineLocked = Boolean(sessionId) && !sessionEngineFilter;
   const lockedSessionAgentKind =
-    inSessionEngineLocked && sessionEngineConfirmed ? (runtimeAgentKind ?? agentKind) : null;
+    inSessionEngineLocked && sessionEngineConfirmed ? (stableRuntimeAgentKind ?? agentKind) : null;
   // 形态偏好(三档并存,Chris 2026-08-17):'original' = 最原始选择器(含旧 harness
   // 分段切换,agentSwitch 因 unifiedPanelActive=false 自动回来);'classic'/'badge' =
   // 新选择器 A/B 版。capable 表示统一面板**可用**(老面板 footer 据此摆「尝试新
@@ -6591,7 +6617,7 @@ export function ChatInput({
     }) => {
       if (sessionId || settingsLocked) return;
       const targetKind = vendorKeyToAgentKind(selection.engine);
-      if (targetKind && selection.providerId) {
+      if (targetKind && targetKind !== 'trueforge' && selection.providerId) {
         if (selection.effort) {
           modelMemory?.setEffort(
             targetKind,
@@ -8123,16 +8149,16 @@ export function ChatInput({
                   dense={effectiveDenseToolbar}
                   visualVariant={isCreateAgentVariant ? 'create-agent' : 'default'}
                 />
-                <PermissionSelector
+                {!isTrueForge && <PermissionSelector
                   permissionMode={activePermissionMode}
                   onPermissionModeChange={handlePermissionModeChange}
-                  vendorKey={vendorKey}
+                  vendorKey={stableVendorKey}
                   deviceId={deviceLinkDeviceId ?? undefined}
                   disabled={composerEditorLocked || settingsLocked}
                   dense={effectiveDenseToolbar}
                   iconOnly={useUltraCompactToolbar}
                   visualVariant={isCreateAgentVariant ? 'create-agent' : 'default'}
-                />
+                />}
                 {useNarrowToolbar && !useCompactMiddleToolbar && <>{middleToolbarSlot}</>}
               </div>
               <div
@@ -8155,6 +8181,14 @@ export function ChatInput({
                     <>{middleToolbarSlot}</>
                   ))}
                 <div className={useNarrowToolbar ? 'min-w-0 shrink' : undefined}>
+                  {isTrueForge ? (
+                    <div
+                      className="inline-flex h-8 max-w-[220px] items-center rounded-full border border-[var(--chat-input-border)] px-3 text-12 text-[var(--text-secondary)]"
+                      title={trueForgeModelLabel}
+                    >
+                      <span className="truncate">{trueForgeModelLabel}</span>
+                    </div>
+                  ) : (
                   <ModelSelector
                     // 选中态一律是会话 / 草稿持有的 **wire model id**(sessions.model 或
                     // lastByVendor.model)。面板行的归一化 id 只活在面板内部 —— 从这里递进去
@@ -8168,14 +8202,14 @@ export function ChatInput({
                     fastMode={agentSwitchIntent?.fastMode ?? fastMode}
                     onFastModeChange={handleFastModeChange}
                     modelMemory={modelMemory}
-                    vendorKey={vendorKey}
+                    vendorKey={stableVendorKey}
                     // 稳态只接受父层已加载的 session/runtime 身份；intent 存在时则明确标成
                     // “下条消息”的目标。这样冷启动不猜 Claude Code，切换失败保留 intent
                     // 供重试时也不会长期隐藏身份或把目标冒充为当前 Agent。
                     agentIdentity={
                       sessionId
                         ? resolveModelSelectorAgentIdentity(
-                            runtimeAgentKind,
+                            stableRuntimeAgentKind,
                             agentSwitchIntent?.target,
                           )
                         : undefined
@@ -8222,17 +8256,20 @@ export function ChatInput({
                     // 行浮层引擎胶囊」完整取代(见 ModelSelectorContentProps.sessionEngineFilter
                     // 的 prop 说明),两者同时传会得到一个永远不渲染的分段。
                     agentSwitch={
+                      !isTrueForge &&
                       !unifiedPanelActive &&
                       sessionId &&
                       vendorKey &&
                       !remoteHostId &&
                       sessionAgentSwitchSupported
                         ? {
-                            currentVendor: vendorKey,
+                            currentVendor: vendorKey as 'cc' | 'codex' | 'pi',
                             // 两步分段的目标是 vendor 口径,确认门按 AgentKind 判(与意图
                             // 记录同形),在边界上转一次 —— 见 confirmAgentBrowseSwitch。
                             confirmBrowseSwitch: (targetVendor: 'cc' | 'codex' | 'pi') =>
-                              confirmAgentBrowseSwitch(vendorKeyToAgentKind(targetVendor)),
+                              confirmAgentBrowseSwitch(
+                                vendorKeyToAgentKind(targetVendor) as AgentKind,
+                              ),
                             onSwitch: performAgentSwitch,
                           }
                         : undefined
@@ -8267,6 +8304,7 @@ export function ChatInput({
                     // settings/CreateWorker 不传该 prop → Radix 回退,不 morph。
                     useMorphPopover
                   />
+                  )}
                 </div>
                 <div
                   className={

--- a/apps/desktop/src/renderer/components/new-chat/ModelSelector.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ModelSelector.tsx
@@ -2850,7 +2850,9 @@ function ModelSelectorContentView({
           <VendorSegmentedSwitcher
             value={browseVendor}
             onChange={(next) => {
-              if (next !== 'orca') void handleBrowseVendorChange(next);
+              if (next === 'cc' || next === 'codex' || next === 'pi') {
+                void handleBrowseVendorChange(next);
+              }
             }}
             dense
             width={304}

--- a/apps/desktop/src/renderer/components/new-chat/agentOptions.ts
+++ b/apps/desktop/src/renderer/components/new-chat/agentOptions.ts
@@ -17,22 +17,29 @@ import type { ComponentType } from 'react';
 import { ClaudeMark } from '@/components/icons/ClaudeMark';
 import { CodexMark } from '@/components/icons/CodexMark';
 import { PiMark } from '@/components/icons/PiMark';
+import { TrueForgeMark } from '@/components/icons/TrueForgeMark';
 import { SELECTABLE_VENDORS, type SelectableVendor } from '@/lib/agentVendors';
+import type { MakerVendor } from '@/lib/ccAgent.types';
+
+type AgentOptionVendor = Exclude<MakerVendor, 'orca'>;
 
 export interface AgentOption {
-  vendor: SelectableVendor;
+  vendor: AgentOptionVendor;
   /** 品牌名,不进 i18n(产品名跨语言不翻译)。 */
   label: string;
   Mark: ComponentType<{ size?: number; className?: string }>;
 }
 
-const VENDOR_PRESENTATION: Record<SelectableVendor, Omit<AgentOption, 'vendor'>> = {
+const VENDOR_PRESENTATION: Record<AgentOptionVendor, Omit<AgentOption, 'vendor'>> = {
   cc: { label: 'Claude', Mark: ClaudeMark },
   codex: { label: 'Codex', Mark: CodexMark },
   pi: { label: 'Pi', Mark: PiMark },
+  trueforge: { label: 'TrueForge', Mark: TrueForgeMark },
 };
 
-export const AGENT_OPTIONS: readonly AgentOption[] = SELECTABLE_VENDORS.map((vendor) => ({
+const AGENT_OPTION_VENDORS: readonly AgentOptionVendor[] = [...SELECTABLE_VENDORS, 'trueforge'];
+
+export const AGENT_OPTIONS: readonly AgentOption[] = AGENT_OPTION_VENDORS.map((vendor) => ({
   vendor,
   ...VENDOR_PRESENTATION[vendor],
 }));

--- a/apps/desktop/src/renderer/components/sidebar/VendorIcon.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/VendorIcon.tsx
@@ -16,16 +16,20 @@
 import { cn } from '@/lib/utils';
 import { ClaudeMark } from '@/components/icons/ClaudeMark';
 import { CodexMark } from '@/components/icons/CodexMark';
+import { TrueForgeMark } from '@/components/icons/TrueForgeMark';
+import type { AgentKind } from '@/lib/ccAgent.types';
 
-export type VendorIconKind = 'cc' | 'codex' | 'pi';
+export type VendorIconKind = 'cc' | 'codex' | 'pi' | 'trueforge';
 
 /**
  * agentKind → VendorIcon vendor 的唯一映射。所有渲染 agent 身份图标的调用点
  * 必须走这里,禁止各自写 `=== 'codex' ? 'codex' : 'cc'` 二元三元(那会把 pi
  * 吞成 Claude 脸,2026-07-30 实测 bug)。兼容 'claude-code' 别名与 null。
  */
+export function agentKindToVendor(kind: AgentKind | null | undefined): AgentKind;
+export function agentKindToVendor(kind: string | null | undefined): VendorIconKind;
 export function agentKindToVendor(kind: string | null | undefined): VendorIconKind {
-  return kind === 'codex' ? 'codex' : kind === 'pi' ? 'pi' : 'cc';
+  return kind === 'codex' ? 'codex' : kind === 'pi' ? 'pi' : kind === 'trueforge' ? 'trueforge' : 'cc';
 }
 
 interface VendorIconProps {
@@ -59,6 +63,8 @@ export function VendorIcon({
     <span className={wrapperClassName}>
       {vendor === 'codex' ? (
         <CodexMark size={size} />
+      ) : vendor === 'trueforge' ? (
+        <TrueForgeMark size={size} />
       ) : vendor === 'pi' ? (
         <span
           aria-hidden

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
@@ -24,7 +24,11 @@ import {
 } from 'react';
 import type { CSSProperties, ReactNode } from 'react';
 import { useLocation, useNavigate, useOutletContext, useParams } from 'react-router-dom';
-import { dbToMakerAgentKind, normalizeDbAgentKind } from '../../../shared/agentKindConversion';
+import {
+  dbToMakerAgentKind,
+  dbToSessionAgentKind,
+  normalizeDbAgentKind,
+} from '../../../shared/agentKindConversion';
 import { useTranslation } from 'react-i18next';
 import {
   isCodexResumeNotReadyProjectionError,
@@ -1560,10 +1564,11 @@ export function CCAgentSessionView({
     togglePin,
   ]);
   // 展示引擎可乐观跟随 intent；真实 event reducer 仍只读 store.agentKind。
-  const displayAgentKind = agentSwitchIntent?.target ?? dbToMakerAgentKind(session?.agentKind);
+  const displayAgentKind = agentSwitchIntent?.target ?? dbToSessionAgentKind(session?.agentKind);
   // 真实会话 agentKind(pending switch intent 不影响)——压缩分流必须用它,
   // 否则 intent 乐观切到 pi 但真实会话仍在跑 claude-code 时会错调 compact-session(#1933 review)。
-  const realAgentKind = dbToMakerAgentKind(session?.agentKind);
+  const realAgentKind = dbToSessionAgentKind(session?.agentKind);
+  const isTrueForgeSession = realAgentKind === 'trueforge';
   const isCodex = displayAgentKind === 'codex';
   // 手动压缩通道判定(#1927/#1933 review):真实 Claude Code → maker:input:compact;
   // 其余 agent 声明 manualCompact.supported(当前仅 pi)→ maker:compact-session;其余无入口。
@@ -1571,7 +1576,7 @@ export function CCAgentSessionView({
   // 用它判定会与 realAgentKind 分流不一致);remoteDeviceId 让远程 pi 取被控端能力。
   const { capabilities: realSessionCaps } = useAgentCapabilities(realAgentKind, remoteDeviceId);
   const compactChannel = useMemo(
-    () => resolveManualCompactChannel(realAgentKind, realSessionCaps),
+    () => resolveManualCompactChannel(isTrueForgeSession ? null : realAgentKind, realSessionCaps),
     [realAgentKind, realSessionCaps],
   );
   // 最新 channel 的可变镜像:useCallback 闭包在创建后固定捕获 compactChannel,确认框
@@ -3252,7 +3257,7 @@ export function CCAgentSessionView({
         sdkContextWindow: agentStatus.contextWindow,
         modelContextWindow: getModelContextWindow(
           sourceSession.model,
-          sourceSession.agentKind ?? 'cc',
+          sourceSession.agentKind === 'trueforge' ? 'cc' : (sourceSession.agentKind ?? 'cc'),
           remoteDeviceId,
         ),
       });
@@ -3477,6 +3482,7 @@ export function CCAgentSessionView({
     // sessionService.update 会写错 / refreshServerSession 对远程是 no-op。直接跳过(规则:host 为准)。
     if (getSessionDeviceId(sessionId)) return;
     const agent = displayAgentKind;
+    if (agent === 'trueforge') return;
     if (!shouldFallbackVendorModel(providers, sessionModel, agent)) return;
     // 用三值化后的 agent 映射选默认模型:Pi 会话必须回退到 Pi 目录默认,而不是被
     // `isCodex ? 'codex' : 'cc'` 误写成 CC 首选(可能是更贵的 Opus)(codex review)。
@@ -3906,7 +3912,7 @@ export function CCAgentSessionView({
       sessionTitle={session?.title ?? null}
       // 透传 agentKind 让 UserMessage 能按 capabilities.fork / rewind 决定
       // 消息下方 Fork / Rewind icon 的显示 (Codex rewind=false → 隐藏)。
-      agentKind={session?.agentKind}
+      agentKind={session?.agentKind === 'trueforge' ? undefined : session?.agentKind}
       remoteHostId={session?.remoteHostId ?? null}
       // text-lightbox-trigger-extension F1/F2: cwd flows from session
       // owner down through MessageStream → AssistantMessage / UserMessage.
@@ -4275,7 +4281,7 @@ export function CCAgentSessionView({
                   onContinue={handleErrorTailContinue}
                   onDismiss={handleErrorTailDismiss}
                   onSilentStopContinue={handleSilentStopContinue}
-                  agentKind={session?.agentKind}
+                  agentKind={session?.agentKind === 'trueforge' ? undefined : session?.agentKind}
                   remoteHostId={session?.remoteHostId ?? undefined}
                   deviceLinkDeviceId={remoteDeviceId}
                   modelId={session?.model}
@@ -4324,7 +4330,7 @@ export function CCAgentSessionView({
                 }
                 usageLimitRecovery={usageLimitRecovery}
                 onCancel={handleDismissError}
-                agentKind={session?.agentKind}
+                agentKind={session?.agentKind === 'trueforge' ? undefined : session?.agentKind}
                 remoteHostId={session?.remoteHostId ?? undefined}
                 deviceLinkDeviceId={remoteDeviceId}
                 modelId={session?.model}
@@ -4507,7 +4513,7 @@ export function CCAgentSessionView({
                   ownsHardwareComposerActions={ownsHardwareTaskActions}
                   // session=null 是冷启动 / 直链 GET 尚未回流的合法首帧；显式传 null，
                   // 让 ChatInput 暂不显示 Agent 身份，不能跟随 displayAgentKind 的 cc 回退。
-                  runtimeAgentKind={session ? dbToMakerAgentKind(session.agentKind) : null}
+                  runtimeAgentKind={session ? dbToSessionAgentKind(session.agentKind) : null}
                   // 协同会话不参与跨引擎切换；session 未加载时保留 undefined 未知态，
                   // 仅在完整元数据确认非 Orca 后传 null 开放入口。
                   sessionOrcaRole={session ? (session.orcaRole ?? null) : undefined}
@@ -4552,7 +4558,7 @@ export function CCAgentSessionView({
                   attachmentState={attachmentState}
                   externalDragOver={isDragOver}
                   onComposerDropHandled={resetFullAreaDragState}
-                  vendorKey={normalizeDbAgentKind(displayAgentKind)}
+                  vendorKey={displayAgentKind === 'trueforge' ? 'trueforge' : normalizeDbAgentKind(displayAgentKind)}
                   extraDirs={session?.extraDirs ?? []}
                   onExtraDirsChange={handleExtraDirsChange}
                   compactToolbar={compactToolbar}

--- a/apps/desktop/src/renderer/features/cc-agent/CreateWorkerPopover.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CreateWorkerPopover.tsx
@@ -340,7 +340,7 @@ export function CreateWorkerPopover({
     }
   }, [currentModel, currentModelSupportsFast, fast]);
 
-  const vendorKey = agentKindToVendor(agent);
+  const vendorKey = agentKindToVendor(agent) as 'cc' | 'codex' | 'pi';
   const updateAgent = useCallback(
     (nextAgent: 'claude-code' | 'codex' | 'pi') => {
       if (nextAgent === agent) return;

--- a/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
@@ -692,6 +692,7 @@ export function NewMakerDraftRoute() {
   // 当前 vendor 对应的 prefs(切 vendor 后这里自动重算 → 透传到 ChatInput initial*)
   const currentPrefs = draft.lastByVendor[draft.vendor];
   const chatPrefs = currentPrefs;
+  const isTrueForgeDraft = draft.vendor === 'trueforge';
   /**
    * 统一模型选择器里选中的收藏锚点(规格 §1.5)。
    *
@@ -717,6 +718,7 @@ export function NewMakerDraftRoute() {
   const persistedAgentKind: 'cc' | 'codex' | 'pi' = normalizeDbAgentKind(draft.vendor);
   const authVendor: 'cc' | 'codex' | 'pi' = persistedAgentKind;
   const capabilityAgentKind = dbToMakerAgentKind(persistedAgentKind);
+  const runtimeCapabilityAgentKind = isTrueForgeDraft ? 'trueforge' : capabilityAgentKind;
 
   // 品牌区跟随当前主题；icon / logo 的固定布局统一由 ThemeBrandLockup 负责。
   const [activeColorTheme, setActiveColorTheme] = useState<ColorTheme | null>(() =>
@@ -867,7 +869,9 @@ export function NewMakerDraftRoute() {
   );
   const hiddenSwitcherVendors = useMemo<MakerVendor[]>(() => {
     if (!availableAgentsLoaded) return [];
-    return (['cc', 'codex', 'pi'] as const).filter((vendor) => !availableVendors.has(vendor));
+    return (['cc', 'codex', 'pi', 'trueforge'] as const).filter(
+      (vendor) => !availableVendors.has(vendor),
+    );
   }, [availableAgentsLoaded, availableVendors]);
   /**
    * 「这份草稿要建到对端设备上」—— 只看 deviceId,**不再要求 workingDir**(#807)。
@@ -1186,7 +1190,7 @@ export function NewMakerDraftRoute() {
     capabilities,
     loading: capabilitiesLoading,
     error: capabilitiesError,
-  } = useAgentCapabilities(capabilityAgentKind, effectiveDeviceLinkDeviceId);
+  } = useAgentCapabilities(runtimeCapabilityAgentKind, effectiveDeviceLinkDeviceId);
   // device-link「以被控端为准」:远程草稿用被控端经隧道带来的 providers(per-provider,含 fast 能力);
   // 本地草稿用本机 providers。fast 判定统一交给 resolveFastSupported(不在控制端另写远程逻辑)。
   const { providers: localProviders, loading: localProvidersLoading } = useProviders();
@@ -1206,7 +1210,7 @@ export function NewMakerDraftRoute() {
   // 还回来 —— 否则那条链路上根本换不了引擎(只按 capable 撤掉时,默认形态下的新建草稿
   // 就彻底没有换引擎入口)。统一面板真启用时不注入(引擎跟着模型走)。
   const unifiedModelPanelEnabled =
-    !effectiveDeviceLinkDeviceId || !deviceProvidersUnsupported;
+    !isTrueForgeDraft && (!effectiveDeviceLinkDeviceId || !deviceProvidersUnsupported);
   const modelPickerLayoutPref = useModelPickerLayout();
   const unifiedModelPanelActive =
     unifiedModelPanelEnabled && modelPickerLayoutPref !== 'original';
@@ -1299,9 +1303,12 @@ export function NewMakerDraftRoute() {
     draftModelChosenByUser,
     localProvidersLoading,
   ]);
-  const calibratedDraftModel = draftCalibration.model;
+  const calibratedDraftModel = isTrueForgeDraft
+    ? (capabilities?.availableModels[0]?.id ?? chatPrefs.model)
+    : draftCalibration.model;
 
   const effectiveSourceId = useMemo<string | null>(() => {
+    if (isTrueForgeDraft) return null;
     // 本地草稿用**过滤后**的候选解析来源:SSH 场景下同一个 model id 可能既被允许的来源
     // 提供、又被排除掉的 openai-chat 来源提供,拿未过滤的 providers 解析会指到后者 ——
     // 于是 providerId 落 null、main 挑到被排除的原生默认,而 ChatInput 看到的是允许的
@@ -1330,6 +1337,7 @@ export function NewMakerDraftRoute() {
     chatPrefs.providerId,
     draftCalibration.providerId,
     calibratedDraftModel,
+    isTrueForgeDraft,
   ]);
 
   // 首页是“下一次创建会话”的配置草稿,没有正在运行的当前模型需要保护。其它对话更新同一模型
@@ -1337,6 +1345,7 @@ export function NewMakerDraftRoute() {
   // 由 CCAgentSessionView 的 live DB/runtime props 保护,不会走这里。
   const modelPresetVersion = useProviderModelMemoryVersion();
   const localDraftEffort = useMemo<Effort>(() => {
+    if (isTrueForgeDraft) return chatPrefs.effort;
     if (isDeviceLinkDraft || !effectiveSourceId) return chatPrefs.effort;
     const provider = providers.find((item) => item.id === effectiveSourceId);
     // 按**校准后**的模型推导:effort 必须和最终提交的模型属于同一个能力集合。
@@ -1361,6 +1370,7 @@ export function NewMakerDraftRoute() {
     calibratedDraftModel,
     chatPrefs.effort,
     modelPresetVersion,
+    isTrueForgeDraft,
   ]);
 
   // 草稿 live fast 读 per-(agent, 来源, 模型) 记忆(与下拉行 fastOnOf / 会话 resolveFast 同口径,
@@ -2270,6 +2280,9 @@ export function NewMakerDraftRoute() {
   // 首条消息发出时走既有 create-on-send 链路(见下方 isDeviceLinkDraft 分支)。
   const handleRemoteProjectAdded = useCallback(
     async (target: RemoteProjectTarget) => {
+      if (isTrueForgeDraft) {
+        throw new Error('TrueForge currently supports local desktop sessions only.');
+      }
       // vendor 由外层 VendorSegmentedSwitcher (draft.vendor) 单一决策 —— dialog 不再让用户选。
       const draftVendor: 'cc' | 'codex' | 'pi' = normalizeDbAgentKind(draft.vendor);
 
@@ -2481,6 +2494,7 @@ export function NewMakerDraftRoute() {
     },
     [
       draft.vendor,
+      isTrueForgeDraft,
       chatPrefs,
       chatInitialPermissionMode,
       chatInitialProviderId,
@@ -3249,6 +3263,14 @@ export function NewMakerDraftRoute() {
       },
     ): Promise<boolean | undefined> => {
       if (sendInFlightRef.current) return false;
+      if (isTrueForgeDraft && (isDeviceLinkDraft || effectiveRemoteHostId)) {
+        toast.error('TrueForge currently supports local desktop sessions only.');
+        return false;
+      }
+      if (isTrueForgeDraft && effectiveCollab.enabled) {
+        toast.error('TrueForge collaboration is not available in this experimental integration.');
+        return false;
+      }
       if (effectiveCollab.enabled && collabPolicy.loading) {
         toast.warning(t('newChat.collaboration.loadingHint'));
         return false;
@@ -3338,7 +3360,10 @@ export function NewMakerDraftRoute() {
       // 发送语义以用户按下 Send 的那一帧为准。鉴权检查期间项目/分支仍可能被 UI
       // 改动；若异步块稍后再读 live ref，会把旧 workingDir 与新 baseRepo 拼成一次
       // 混合目标创建。这里与 selectedWorkingDir 同步快照，保证整笔创建目标一致。
-      const selectedWorktree = { ...wtRef.current };
+      const selectedWorktree = {
+        ...wtRef.current,
+        enabled: isTrueForgeDraft ? false : wtRef.current.enabled,
+      };
       // worktree 是用户对本次 project session 的明确选择。探测、分支偏好或远端
       // recovery 能力尚未就绪时保留输入并提示；绝不能把勾选静默降级成普通 session。
       // Checkbox APPLY 是双向门：无论 ON→OFF 还是 OFF→ON，创建都必须等
@@ -3399,9 +3424,11 @@ export function NewMakerDraftRoute() {
           if (isDeviceLinkDraft && !isCurrentDataOwner()) return;
           // device-link:远程草稿就绪态以被控端为准(传 deviceId 走隧道查被控端 maker:agent:status);
           // 本地草稿 effectiveDeviceLinkDeviceId 为 undefined → 仍走控制端本机就绪检查(行为不变)。
-          const { proceed } = await vendorAuthGate.checkAndConfirm(authVendor, {
-            deviceId: effectiveDeviceLinkDeviceId,
-          });
+          const { proceed } = isTrueForgeDraft
+            ? { proceed: true }
+            : await vendorAuthGate.checkAndConfirm(authVendor, {
+                deviceId: effectiveDeviceLinkDeviceId,
+              });
           if (isDeviceLinkDraft && !isCurrentDataOwner()) return;
           if (!proceed) return;
 
@@ -4004,9 +4031,12 @@ export function NewMakerDraftRoute() {
             return;
           }
 
+          const createAgentKind = (
+            isTrueForgeDraft ? 'trueforge' : persistedAgentKind
+          ) as typeof persistedAgentKind;
           const newSession = await createSession({
             id: sessionId,
-            agentKind: persistedAgentKind,
+            agentKind: createAgentKind,
             model,
             effort,
             permissionMode,
@@ -4019,7 +4049,7 @@ export function NewMakerDraftRoute() {
             remoteHostId: workingDir ? (effectiveRemoteHostId ?? undefined) : undefined,
             // extraDirs 是 vendor 无关字段；Claude 与 Codex 都按只读引用目录透传。
             extraDirs: effectiveExtraDirs,
-            providerId,
+            providerId: isTrueForgeDraft ? null : providerId,
           });
           if (!newSession) {
             if (optimisticTitleSessionId) emitAutoTitlePreviewCleared(optimisticTitleSessionId);
@@ -4027,7 +4057,9 @@ export function NewMakerDraftRoute() {
             return;
           }
           // 草稿里选中的那条收藏跟着会话走(见 carryDraftFavoriteAnchorToSession)。
-          carryDraftFavoriteAnchorToSession(newSession.id, persistedAgentKind, model, providerId);
+          if (!isTrueForgeDraft) {
+            carryDraftFavoriteAnchorToSession(newSession.id, persistedAgentKind, model, providerId);
+          }
           // 计划模式是一次性选择:随本次发送被消耗,草稿勾选同步熄灭。
           if (effectivePlanMode) patchActivePrefs({ planMode: false });
           // 首条消息经 setPending → SessionView 自动发送,createOpts 读 chat store 的
@@ -4035,9 +4067,9 @@ export function NewMakerDraftRoute() {
           // seed store,否则勾了计划模式的首条消息可能以 planMode:false 发出
           // (worktree 路径同款 seed;bot review P2)。
           makerChatStore.setSessionRuntime(newSession.id, {
-            agentKind: capabilityAgentKind,
-            fastMode: effectiveFastMode,
-            planModeEnabled: effectivePlanMode,
+            agentKind: (isTrueForgeDraft ? 'trueforge' : capabilityAgentKind) as typeof capabilityAgentKind,
+            fastMode: isTrueForgeDraft ? false : effectiveFastMode,
+            planModeEnabled: isTrueForgeDraft ? false : effectivePlanMode,
           });
 
           // "创建即发送"路径:乐观回写 userSendAt 跳过 projectGrouping 的草稿兜底
@@ -4975,7 +5007,7 @@ export function NewMakerDraftRoute() {
                   // hasAnyRemoteTarget 影响 —— 它会在该设备离线时变 false,把「浏览文件夹」推回
                   // 本机原生对话框(见 FolderPickerPopover.handleChooseDifferent 的同款防护)。
                   onAddRemoteProject={
-                    hasAnyRemoteTarget || folderPickerDeviceScope
+                    !isTrueForgeDraft && (hasAnyRemoteTarget || folderPickerDeviceScope)
                       ? handleOpenRemoteProject
                       : undefined
                   }
@@ -5003,7 +5035,7 @@ export function NewMakerDraftRoute() {
                     />
                   </button>
                 </FolderPickerPopover>
-                <WorktreeChipsRow
+                {!isTrueForgeDraft && <WorktreeChipsRow
                   variant="advancedOnly"
                   compact
                   cwd={effectiveWorkingDir ?? null}
@@ -5025,7 +5057,7 @@ export function NewMakerDraftRoute() {
                   disabled={wtCreating || sendInFlight}
                   branchDisabled={wtBranchPreferenceLoading || wtBranchPreferenceSaving}
                   checkboxDisabled={wtPreferenceSaving}
-                />
+                />}
               </div>
               <ThemeBrandLockup
                 theme={activeColorTheme}
@@ -5062,7 +5094,11 @@ export function NewMakerDraftRoute() {
                     onEffortDidChange={handleEffortDidChange}
                     onPermissionModeDidChange={handlePermissionModeDidChange}
                     onProviderDidChange={handleProviderDidChange}
-                    vendorKey={normalizeDbAgentKind(draft.vendor)}
+                    vendorKey={
+                      draft.vendor === 'trueforge'
+                        ? 'trueforge'
+                        : normalizeDbAgentKind(draft.vendor)
+                    }
                     folderPickerOpen={folderPickerOpen}
                     onFolderPickerOpenChange={handleFolderPickerOpenChange}
                     showFolderPicker={false}
@@ -5093,7 +5129,7 @@ export function NewMakerDraftRoute() {
                     // 走它而非简单 worker popover。ON 态点击 onChange(enabled:false) 关闭协同。
                     // createSession 后按本次策略校验结果用 workerConfig 拉起 Worker。
                     collaboration={
-                      collabPolicyEligible
+                      collabPolicyEligible && !isTrueForgeDraft
                         ? {
                             enabled: effectiveCollab.enabled,
                             worker: effectiveCollab.worker,
@@ -5155,10 +5191,12 @@ export function NewMakerDraftRoute() {
                     // 不传 onChange 时 ExtraDirsButton 直接不渲染引用目录段(「新建目标」/ 计划模式 /
                     // Plugin 入口不受影响)。进入远程设备时 extraDirs 已被清空,不会留下无法删除的残留。
                     // 恢复这个能力要把 picker 路由到对端(设备域浏览器已有 fs:list-dir),见 follow-up。
-                    onExtraDirsChange={isDeviceLinkDraft ? undefined : handleExtraDirsChange}
+                    onExtraDirsChange={
+                      isTrueForgeDraft || isDeviceLinkDraft ? undefined : handleExtraDirsChange
+                    }
                     // 首页「新建目标」入口:草稿态没有 sessionId,由本组件 createSession→setGoal。
                     // ChatInput 把输入框当前文字传上来作默认目标内容。
-                    onNewGoal={(text) => {
+                    onNewGoal={isTrueForgeDraft ? undefined : (text) => {
                       setNewGoalInitialObjective(text);
                       setNewGoalOpen(true);
                     }}

--- a/apps/desktop/src/renderer/features/cc-agent/lib/scheduledSessionGrouping.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/lib/scheduledSessionGrouping.ts
@@ -113,7 +113,8 @@ export function groupScheduledSessions(sessions: readonly Session[], t?: TFunc):
       const latestActivityMs = sorted.length > 0 ? sortTimeMs(sorted[0]) : 0;
       if (latestActivityMs > dirLatest) dirLatest = latestActivityMs;
       // agentKind 取组内任一 session（同 schedule 的 fire 必同 agent）；老数据兜底 'cc'
-      const agentKind: AgentKind = sorted[0]?.agentKind ?? 'cc';
+      const storedAgentKind = sorted[0]?.agentKind;
+      const agentKind: AgentKind = storedAgentKind === 'trueforge' ? 'cc' : (storedAgentKind ?? 'cc');
       subGroups.push({ scheduleName, agentKind, sessions: sorted, latestActivityMs });
     }
     subGroups.sort((a, b) => b.latestActivityMs - a.latestActivityMs);

--- a/apps/desktop/src/renderer/features/scheduler/components/RunHistoryPane.tsx
+++ b/apps/desktop/src/renderer/features/scheduler/components/RunHistoryPane.tsx
@@ -87,6 +87,7 @@ export function RunHistoryPane({
   const sessionAgentMap = useMemo(() => {
     const m = new Map<string, AgentKind>();
     for (const sess of allSessions) {
+      if (sess.agentKind === 'trueforge') continue;
       m.set(sess.id, sess.agentKind === 'cc' ? 'claude-code' : sess.agentKind === 'pi' ? 'pi' : 'codex');
     }
     return m;
@@ -95,9 +96,10 @@ export function RunHistoryPane({
     (run: ScheduleRun): AgentKind => {
       if (!run.sessionId) return s.agentKind;
       const referenceAgent = sessionReferences.get(run.sessionId)?.agentKind;
+      const scheduledReferenceAgent = referenceAgent === 'trueforge' ? undefined : referenceAgent;
       return (
         sessionAgentMap.get(run.sessionId) ||
-        (referenceAgent === 'cc' ? 'claude-code' : referenceAgent) ||
+        (scheduledReferenceAgent === 'cc' ? 'claude-code' : scheduledReferenceAgent) ||
         s.agentKind
       );
     },

--- a/apps/desktop/src/renderer/features/scheduler/components/ScheduleChips.tsx
+++ b/apps/desktop/src/renderer/features/scheduler/components/ScheduleChips.tsx
@@ -1279,7 +1279,12 @@ export function ThreadPickerInline({ value, onSelect, onOpen, reference }: {
       .list(50, 'active')
       .then((list) => {
         if (!alive) return;
-        setSessions(list.filter((session) => !isReviewSessionSource(session.source)));
+        setSessions(
+          list.filter(
+            (session) =>
+              !isReviewSessionSource(session.source) && session.agentKind !== 'trueforge',
+          ),
+        );
         setError(null);
       })
       .catch((e: unknown) => {

--- a/apps/desktop/src/renderer/features/scheduler/components/__tests__/ThreadPickerInline.test.tsx
+++ b/apps/desktop/src/renderer/features/scheduler/components/__tests__/ThreadPickerInline.test.tsx
@@ -9,7 +9,7 @@ const mocks = vi.hoisted(() => ({
       [] as Array<{
         id: string;
         title: string;
-        agentKind: 'cc' | 'codex' | 'pi';
+        agentKind: 'cc' | 'codex' | 'pi' | 'trueforge';
         source?: string;
       }>,
   ),
@@ -31,6 +31,7 @@ describe('ThreadPickerInline 会话引用状态', () => {
   it('does not offer Review tasks as scheduler targets', async () => {
     mocks.list.mockResolvedValueOnce([
       { id: 'session-review', title: 'Review task', agentKind: 'codex', source: 'review' },
+      { id: 'session-trueforge', title: 'TrueForge task', agentKind: 'trueforge', source: 'desktop' },
       { id: 'session-normal', title: 'Desktop task', agentKind: 'codex', source: 'desktop' },
     ]);
 
@@ -38,6 +39,7 @@ describe('ThreadPickerInline 会话引用状态', () => {
 
     expect(await screen.findByRole('option', { name: 'Desktop task · Codex' })).toBeDefined();
     expect(screen.queryByRole('option', { name: 'Review task · Codex' })).toBeNull();
+    expect(screen.queryByRole('option', { name: /TrueForge task/ })).toBeNull();
   });
 
   it('普通绑定会话被删除后要求重新选择且不再显示打开入口', async () => {

--- a/apps/desktop/src/renderer/features/scheduler/hooks/useScheduleForm.ts
+++ b/apps/desktop/src/renderer/features/scheduler/hooks/useScheduleForm.ts
@@ -360,6 +360,9 @@ export function useScheduleForm(initial: Schedule | null = null): UseScheduleFor
         // remembered 保留旧快照 —— 用户切走再切回还能还原上一个真实绑定。
         return { ...f, targetSessionId: PENDING_SESSION_ID };
       }
+      // TrueForge is intentionally desktop-local and does not support scheduler heartbeats.
+      // Keep the current form unchanged if a stale/programmatic caller bypasses the picker gate.
+      if (session.agentKind === 'trueforge') return f;
       const next: ScheduleFormState = {
         ...f,
         targetSessionId: session.id,

--- a/apps/desktop/src/renderer/hooks/useAgentCapabilities.ts
+++ b/apps/desktop/src/renderer/hooks/useAgentCapabilities.ts
@@ -18,11 +18,13 @@ import type { Effort, PermissionMode } from '@/lib/userPreferences.types';
 const log = createLogger('useAgentCapabilities');
 
 export type AgentKind = 'claude-code' | 'codex' | 'pi';
+export type CapabilityAgentKind = AgentKind | 'trueforge';
 
 // capability 生命周期(预取 / 驱逐通知 / 本地快照刷新 / 启动预载)必须覆盖全部 agent，
 // 少一个就会让该 agent 的远程会话在断链或 provider revision 后收不到 loading 事件、
 // 也不再被重新预取，界面永久停在旧模型/能力快照(codex review)。新增 agent 只改这里。
-const ALL_AGENT_KINDS = ['claude-code', 'codex', 'pi'] as const;
+const ALL_AGENT_KINDS = ['claude-code', 'codex', 'pi', 'trueforge'] as const;
+const REMOTE_AGENT_KINDS: readonly AgentKind[] = ['claude-code', 'codex', 'pi'];
 
 // renderer 视角: id 全部是不透明 string, 渲染只读 displayName。
 // effort 的合法 id 集合 = capabilities.effortLevels 上每个项的 id。
@@ -55,7 +57,7 @@ export interface ModelDescriptor {
    * 解耦;生产环境 XD 网关由服务端按区域下发)。消费点见 modelDefinitions.newSessionDefaultModelId
    * 与 draftModelCalibration:被标记且可用的模型优先作新对话默认。
    */
-  newSessionDefault?: ('claude-code' | 'codex' | 'pi')[];
+  newSessionDefault?: ('claude-code' | 'codex' | 'pi' | 'trueforge')[];
 }
 
 export interface EffortDescriptor {
@@ -203,7 +205,7 @@ function isOptionalNewSessionDefault(value: unknown): boolean {
   if (!Array.isArray(value) || value.length === 0) return false;
   if (
     value.some(
-      (agent) => agent !== 'claude-code' && agent !== 'codex' && agent !== 'pi',
+      (agent) => agent !== 'claude-code' && agent !== 'codex' && agent !== 'pi' && agent !== 'trueforge',
     )
   ) {
     return false;
@@ -278,7 +280,7 @@ function parseAgentCapabilities(value: unknown): AgentCapabilities {
 }
 
 interface MakerApiShape {
-  getCapabilities: (agentKind: AgentKind) => Promise<AgentCapabilities>;
+  getCapabilities: (agentKind: CapabilityAgentKind) => Promise<AgentCapabilities>;
 }
 
 interface DeviceLinkShape {
@@ -307,7 +309,7 @@ function getDeviceLink(): DeviceLinkShape | null {
 // 缓存按 (deviceId, agentKind) 隔离 —— 两台机器模型/能力配置可能不同,绝不能串。
 // deviceId 省略 = 本机会话,走与改造前逐字节相同的本地路径(零回归)。
 type CacheKey = string;
-function cacheKey(agentKind: AgentKind, deviceId?: string): CacheKey {
+function cacheKey(agentKind: CapabilityAgentKind, deviceId?: string): CacheKey {
   return `${deviceId ?? 'local'}:${agentKind}`;
 }
 
@@ -318,7 +320,7 @@ let localGen = 0;
 /** 已提交的本地快照 revision；失败刷新不会前进，用来区分缺失 tombstone 与未提交。 */
 let localSnapshotRevision = 0;
 /** 已挂载 hook 的本地能力订阅者；刷新完成后一次性切到新快照，避免中途空白帧。 */
-const localListeners = new Set<(agent: AgentKind, caps: AgentCapabilities | null) => void>();
+const localListeners = new Set<(agent: CapabilityAgentKind, caps: AgentCapabilities | null) => void>();
 /** 远程能力缓存事件；驱逐时先标 stale，成功 / 失败后再结束这一轮刷新。 */
 export type DeviceCapabilitiesEvent =
   | { status: 'loading' }
@@ -360,7 +362,7 @@ export function subscribeDeviceCapabilities(
 }
 
 async function fetchCapabilities(
-  agentKind: AgentKind,
+  agentKind: CapabilityAgentKind,
   deviceId?: string,
 ): Promise<AgentCapabilities | null> {
   const key = cacheKey(agentKind, deviceId);
@@ -379,6 +381,7 @@ async function fetchCapabilities(
 
   let raw: Promise<AgentCapabilities>;
   if (deviceId) {
+    if (agentKind === 'trueforge') throw new Error('TrueForge is not available over device-link');
     // 远程:隧道到被控端的 maker:get-capabilities(已在 allowlist)。
     const dl = getDeviceLink();
     if (!dl) throw new Error('device-link IPC not available');
@@ -397,7 +400,7 @@ async function fetchCapabilities(
         cache.set(key, caps);
         inflight.delete(key);
         if (deviceId)
-          notifyRemoteCapabilities(deviceId, agentKind, { status: 'ready', capabilities: caps });
+          notifyRemoteCapabilities(deviceId, agentKind as AgentKind, { status: 'ready', capabilities: caps });
       } else if (!deviceId) {
         // 已提交的新快照优先：有值就返回当前 cache，明确删除则以 null 作为 tombstone。
         const current = cache.get(key);
@@ -416,7 +419,7 @@ async function fetchCapabilities(
       if (isCurrent()) {
         inflight.delete(key);
         if (deviceId) {
-          notifyRemoteCapabilities(deviceId, agentKind, {
+          notifyRemoteCapabilities(deviceId, agentKind as AgentKind, {
             status: 'error',
             error: e instanceof Error ? e.message : String(e),
           });
@@ -435,7 +438,7 @@ export interface UseAgentCapabilitiesResult {
 }
 
 export function useAgentCapabilities(
-  agentKind: AgentKind | null | undefined,
+  agentKind: CapabilityAgentKind | null | undefined,
   deviceId?: string,
 ): UseAgentCapabilitiesResult {
   const selectedKey = agentKind ? cacheKey(agentKind, deviceId) : null;
@@ -472,14 +475,14 @@ export function useAgentCapabilities(
       setLoading(false);
       setError(null);
     };
-    if (deviceId) return subscribeDeviceCapabilities(deviceId, agentKind, applyRemoteEvent);
+    if (deviceId) return subscribeDeviceCapabilities(deviceId, agentKind as AgentKind, applyRemoteEvent);
     const applySnapshot = (caps: AgentCapabilities | null): void => {
       setOwnerKey(key);
       setCapabilities(caps);
       setLoading(false);
       setError(null);
     };
-    const onRefresh = (refreshedAgent: AgentKind, caps: AgentCapabilities | null): void => {
+    const onRefresh = (refreshedAgent: CapabilityAgentKind, caps: AgentCapabilities | null): void => {
       if (refreshedAgent !== agentKind) return;
       applySnapshot(caps);
     };
@@ -554,7 +557,7 @@ export function useAgentCapabilities(
  * deviceId 省略 = 本机缓存(行为不变);传 deviceId = 该被控端的缓存。
  */
 export function getCachedCapabilities(
-  agentKind: AgentKind,
+  agentKind: CapabilityAgentKind,
   deviceId?: string,
 ): AgentCapabilities | null {
   return cache.get(cacheKey(agentKind, deviceId)) ?? null;
@@ -565,7 +568,7 @@ export function getCachedCapabilities(
  * 模型下拉 / fast / effort 不为空、modelDefinitions 同步层已热。失败 swallow(轮询/打开会话会再取)。
  */
 export async function prefetchDeviceCapabilities(deviceId: string): Promise<void> {
-  await Promise.allSettled(ALL_AGENT_KINDS.map((agent) => fetchCapabilities(agent, deviceId)));
+  await Promise.allSettled(REMOTE_AGENT_KINDS.map((agent) => fetchCapabilities(agent, deviceId)));
 }
 
 /** device-link:被控设备下线 / 断链时驱逐其能力缓存(只清该设备的 key)。 */
@@ -577,12 +580,12 @@ export function evictDeviceCapabilities(deviceId: string): void {
   deviceGen.set(deviceId, (deviceGen.get(deviceId) ?? 0) + 1);
   // 已挂载 hook 必须同步知道旧快照已失效；否则 provider 新快照先到时会拿旧 capabilities
   // 计算 fallback，并永久覆盖用户原本保存的模型偏好。
-  for (const agentKind of ALL_AGENT_KINDS) {
+  for (const agentKind of REMOTE_AGENT_KINDS) {
     notifyRemoteCapabilities(deviceId, agentKind, { status: 'loading' });
   }
 }
 
-export type LocalCapabilitiesSnapshot = ReadonlyArray<readonly [AgentKind, AgentCapabilities]>;
+export type LocalCapabilitiesSnapshot = ReadonlyArray<readonly [CapabilityAgentKind, AgentCapabilities]>;
 
 /** 开始一轮本地 capabilities 刷新，并作废所有更早的本地请求。 */
 export function beginLocalCapabilitiesRefresh(): number {
@@ -605,7 +608,7 @@ export async function loadLocalCapabilitiesSnapshot(): Promise<LocalCapabilities
   const api = getMakerApi();
   if (!api) throw new Error('maker IPC not available');
   const entries = await Promise.all(
-    ALL_AGENT_KINDS.map(async (agent): Promise<readonly [AgentKind, AgentCapabilities] | null> => {
+    ALL_AGENT_KINDS.map(async (agent): Promise<readonly [CapabilityAgentKind, AgentCapabilities] | null> => {
       try {
         return [agent, await api.getCapabilities(agent)] as const;
       } catch (error) {
@@ -615,14 +618,17 @@ export async function loadLocalCapabilitiesSnapshot(): Promise<LocalCapabilities
             : typeof error === 'object' && error !== null && 'message' in error
               ? String(error.message)
               : String(error);
-        if (agent !== 'pi' || !message.includes("Agent 'pi' is not registered")) throw error;
-        log.warn('optional Pi capabilities unavailable; continuing with core agents:', error);
+        const optionalRuntimeMissing =
+          (agent === 'pi' && message.includes("Agent 'pi' is not registered")) ||
+          (agent === 'trueforge' && message.includes("Agent 'trueforge' is not registered"));
+        if (!optionalRuntimeMissing) throw error;
+        log.warn(`optional ${agent} capabilities unavailable; continuing with core agents:`, error);
         return null;
       }
     }),
   );
   return entries.filter(
-    (entry): entry is readonly [AgentKind, AgentCapabilities] => entry !== null,
+    (entry): entry is readonly [CapabilityAgentKind, AgentCapabilities] => entry !== null,
   );
 }
 

--- a/apps/desktop/src/renderer/hooks/useAvailableAgents.ts
+++ b/apps/desktop/src/renderer/hooks/useAvailableAgents.ts
@@ -20,7 +20,7 @@ import { createLogger } from '@/lib/logger';
 
 const log = createLogger('useAvailableAgents');
 
-type RuntimeAgentKind = 'claude-code' | 'codex' | 'pi';
+type RuntimeAgentKind = 'claude-code' | 'codex' | 'pi' | 'trueforge';
 
 /** runtime agent id → NewMaker vendor(其余保持同名)。 */
 function toVendor(agent: RuntimeAgentKind): MakerVendor {

--- a/apps/desktop/src/renderer/lib/ccAgent.types.ts
+++ b/apps/desktop/src/renderer/lib/ccAgent.types.ts
@@ -15,7 +15,8 @@ export type DeviceLinkConnectionStatus = 'connected' | 'disconnected';
  * schema 不动；老 session DEFAULT 'cc' 兜底。
  */
 export type AgentKind = 'cc' | 'codex' | 'pi';
-export type MakerVendor = AgentKind | 'orca';
+export type SessionAgentKind = AgentKind | 'trueforge';
+export type MakerVendor = SessionAgentKind | 'orca';
 export type OrcaRole = 'lead' | 'worker';
 
 /**
@@ -235,7 +236,7 @@ export interface Session {
   userSendAt: string | null;
   status: SessionStatus;
   /** 当前 session 接的 agent。老 session DEFAULT 'cc'。 */
-  agentKind: AgentKind;
+  agentKind: SessionAgentKind;
   /** 会话来源。scheduler 表示由自动化任务创建；缺失时按 desktop 兼容旧 payload。 */
   source?: SessionSource;
   /** Orca split-session role marker. null/undefined means a regular Maker session. */
@@ -349,6 +350,6 @@ export interface Message {
    * session-agent-switch 后 session.agentKind 只代表当前活跃引擎,历史行按本字段解析;
    * null = 切换功能上线前的老消息(回落 session.agentKind)。
    */
-  agentKind?: 'cc' | 'codex' | 'pi' | null;
+  agentKind?: SessionAgentKind | null;
   createdAt: string; // ISO 8601
 }

--- a/apps/desktop/src/renderer/lib/modelDefinitions.ts
+++ b/apps/desktop/src/renderer/lib/modelDefinitions.ts
@@ -11,13 +11,15 @@
 import { getCachedCapabilities, type ModelDescriptor } from '@/hooks/useAgentCapabilities';
 import type { Effort } from '@/lib/userPreferences.types';
 
+type ModelVendor = 'cc' | 'codex' | 'pi' | 'trueforge';
+
 export interface ModelDefinition {
   id: string;
   label: string;
   description: string;
   efforts: readonly Effort[];
   defaultEffort: Effort | null;
-  vendorKey: 'cc' | 'codex' | 'pi';
+  vendorKey: ModelVendor;
   contextWindow?: number;
   supportsFastMode?: boolean;
   /** 目录展示排序;缺省排末尾(见 getDefaultModelForVendor)。 */
@@ -29,10 +31,10 @@ export interface ModelDefinition {
    * 解耦)。缺省 = 不作为默认。getDefaultModelForVendor / newSessionDefaultModelId 据它选默认;
    * Pi 只接受自己的 v3 标记，不借用其它 Agent 的默认策略。
    */
-  newSessionDefault?: ('claude-code' | 'codex' | 'pi')[];
+  newSessionDefault?: ('claude-code' | 'codex' | 'pi' | 'trueforge')[];
 }
 
-function toLegacy(m: ModelDescriptor, vendorKey: 'cc' | 'codex' | 'pi'): ModelDefinition {
+function toLegacy(m: ModelDescriptor, vendorKey: ModelVendor): ModelDefinition {
   return {
     id: m.id,
     label: m.displayName,
@@ -54,9 +56,11 @@ function toLegacy(m: ModelDescriptor, vendorKey: 'cc' | 'codex' | 'pi'): ModelDe
 function allCachedModels(deviceId?: string): ModelDefinition[] {
   const cc = getCachedCapabilities('claude-code', deviceId);
   const codex = getCachedCapabilities('codex', deviceId);
+  const trueforge = getCachedCapabilities('trueforge', deviceId);
   return [
     ...(cc?.availableModels ?? []).map((m) => toLegacy(m, 'cc')),
     ...(codex?.availableModels ?? []).map((m) => toLegacy(m, 'codex')),
+    ...(trueforge?.availableModels ?? []).map((m) => toLegacy(m, 'trueforge')),
   ];
 }
 
@@ -104,12 +108,13 @@ export function getModelById(modelId: string, deviceId?: string): ModelDefinitio
 }
 
 /** vendor → capabilities 缓存的 agent 键(pi 有自己的能力清单)。 */
-function agentKindForVendor(vendorKey: 'cc' | 'codex' | 'pi'): 'claude-code' | 'codex' | 'pi' {
+function agentKindForVendor(vendorKey: ModelVendor): 'claude-code' | 'codex' | 'pi' | 'trueforge' {
+  if (vendorKey === 'trueforge') return 'trueforge';
   return vendorKey === 'codex' ? 'codex' : vendorKey === 'pi' ? 'pi' : 'claude-code';
 }
 
 export function getModelsForVendor(
-  vendorKey: 'cc' | 'codex' | 'pi',
+  vendorKey: ModelVendor,
   deviceId?: string,
 ): readonly ModelDefinition[] {
   // 直接读该 vendor 对应 agent 的能力缓存 —— 不经 allCachedModels(后者只聚合 cc/codex 供
@@ -138,8 +143,8 @@ function firstByCatalogOrder(models: readonly ModelDefinition[]): ModelDefinitio
 
 /** vendor → 新对话默认所依据的目录 Agent 标记。 */
 function defaultMarkerAgentForVendor(
-  vendorKey: 'cc' | 'codex' | 'pi',
-): 'claude-code' | 'codex' | 'pi' {
+  vendorKey: ModelVendor,
+): 'claude-code' | 'codex' | 'pi' | 'trueforge' {
   if (vendorKey === 'cc') return 'claude-code';
   return vendorKey;
 }
@@ -155,7 +160,7 @@ function defaultMarkerAgentForVendor(
  * 本函数返回 null、默认行为不变。
  */
 export function newSessionDefaultModelId(
-  vendorKey: 'cc' | 'codex' | 'pi',
+  vendorKey: ModelVendor,
   deviceId?: string,
 ): string | null {
   const agent = defaultMarkerAgentForVendor(vendorKey);
@@ -177,7 +182,7 @@ export function newSessionDefaultModelId(
  * useScheduleForm.ts getScheduleDefaultModel,不要把这里的默认接到 scheduler 上。
  */
 export function getDefaultModelForVendor(
-  vendorKey: 'cc' | 'codex' | 'pi',
+  vendorKey: ModelVendor,
   deviceId?: string,
 ): ModelDefinition {
   const list = getModelsForVendor(vendorKey, deviceId);
@@ -208,9 +213,11 @@ export function getDefaultModelForVendor(
 const COLD_START_CC_MODEL_ID = 'claude-opus-5';
 const COLD_START_CODEX_MODEL_ID = 'gpt-5.6-sol';
 const COLD_START_PI_MODEL_ID = 'claude-sonnet-5';
+const COLD_START_TRUEFORGE_MODEL_ID = 'configured-model';
 
 /** 冷启动占位 id 的只读导出（newMakerDraft 的种子默认复用，避免另一处写死）。 */
-export function coldStartModelIdForVendor(vendorKey: 'cc' | 'codex' | 'pi'): string {
+export function coldStartModelIdForVendor(vendorKey: ModelVendor): string {
+  if (vendorKey === 'trueforge') return COLD_START_TRUEFORGE_MODEL_ID;
   return vendorKey === 'codex'
     ? COLD_START_CODEX_MODEL_ID
     : vendorKey === 'pi'
@@ -219,6 +226,7 @@ export function coldStartModelIdForVendor(vendorKey: 'cc' | 'codex' | 'pi'): str
 }
 
 /** 冷启动占位的展示名(与占位 id 同源,仅首帧短暂可见)。 */
-function coldStartLabelForVendor(vendorKey: 'cc' | 'codex' | 'pi'): string {
+function coldStartLabelForVendor(vendorKey: ModelVendor): string {
+  if (vendorKey === 'trueforge') return 'Configured model';
   return vendorKey === 'codex' ? 'GPT-5.6-Sol' : vendorKey === 'pi' ? 'Sonnet 5' : 'Opus 5';
 }

--- a/apps/desktop/src/renderer/state/newMakerDraft.ts
+++ b/apps/desktop/src/renderer/state/newMakerDraft.ts
@@ -162,6 +162,15 @@ export interface NewMakerDraft {
  * 在目录里都是默认隐藏的模型 —— 种子默认模型压根不在用户看到的清单里。
  */
 function defaultVendorPrefs(vendor: MakerVendor): VendorPrefs {
+  if (vendor === 'trueforge') {
+    return {
+      model: getDefaultModelForVendor('trueforge').id,
+      effort: 'medium',
+      permissionMode: 'ask',
+      planMode: false,
+      providerId: null,
+    };
+  }
   if (vendor === 'pi') {
     return {
       // pi 走 XD 网关(anthropic-messages 可达面),默认给网关中档模型;
@@ -218,6 +227,7 @@ function makeDefault(): NewMakerDraft {
       pi: defaultVendorPrefs('pi'),
       orca: defaultVendorPrefs('orca'),
       codex: defaultVendorPrefs('codex'),
+      trueforge: defaultVendorPrefs('trueforge'),
     },
     modelChosenByVendor: {},
   };
@@ -251,7 +261,9 @@ function sanitize(raw: unknown): NewMakerDraft {
   // 每上线一个引擎都得手工补一次;漏补则用户选中新引擎、重启后被静默重置回 Claude。
   // F-COLLAB (2026-05): 'orca' 不在表内,历史 localStorage 残留会走同一条回退路径
   // 迁到 'cc'(它已被 ChatInput 底部的协同 toggle 取代),避免空白入口。
-  const vendor: MakerVendor = isSelectableVendor(r.vendor) ? r.vendor : def.vendor;
+  const vendor: MakerVendor = r.vendor === 'trueforge'
+    ? 'trueforge'
+    : isSelectableVendor(r.vendor) ? r.vendor : def.vendor;
   const workingDir = normalizeDraftWorkingDir(r.workingDir);
   const remoteHostId =
     typeof r.remoteHostId === 'string' && r.remoteHostId.trim().length > 0
@@ -347,7 +359,7 @@ function sanitize(raw: unknown): NewMakerDraft {
       ? (r.modelChosenByVendor as Record<string, unknown>)
       : {};
   const modelChosenByVendor: Partial<Record<MakerVendor, boolean>> = {};
-  for (const v of ['cc', 'orca', 'codex', 'pi'] as const) {
+  for (const v of ['cc', 'orca', 'codex', 'pi', 'trueforge'] as const) {
     if (modelChosenRaw[v] === true) modelChosenByVendor[v] = true;
   }
   // 2026-07 已落盘但尚无显式标记的 true，只可能来自用户把当时默认 false 切到 true，
@@ -385,6 +397,7 @@ function sanitize(raw: unknown): NewMakerDraft {
       pi: sanitizeVendorPrefs(lastByVendorRaw.pi, 'pi'),
       orca: sanitizeVendorPrefs(lastByVendorRaw.orca, 'orca'),
       codex: sanitizeVendorPrefs(lastByVendorRaw.codex, 'codex'),
+      trueforge: sanitizeVendorPrefs(lastByVendorRaw.trueforge, 'trueforge'),
     },
     modelChosenByVendor,
   };

--- a/apps/desktop/src/shared/agentKindConversion.ts
+++ b/apps/desktop/src/shared/agentKindConversion.ts
@@ -12,6 +12,9 @@
 export type DbAgentKind = 'cc' | 'codex' | 'pi';
 /** maker-core / IPC 契约侧的 agent 形态。 */
 export type MakerAgentKindWire = 'claude-code' | 'codex' | 'pi';
+/** Session persistence accepts experimental harnesses without widening stable provider contracts. */
+export type SessionDbAgentKind = DbAgentKind | 'trueforge';
+export type SessionMakerAgentKindWire = MakerAgentKindWire | 'trueforge';
 
 export function dbToMakerAgentKind(db: string | null | undefined): MakerAgentKindWire {
   if (db === 'codex') return 'codex';
@@ -28,4 +31,18 @@ export function makerToDbAgentKind(maker: string | null | undefined): DbAgentKin
 /** 宽输入归一成 DbAgentKind;非法值回落 'cc'(与 sessions 表 default 同语义)。 */
 export function normalizeDbAgentKind(value: string | null | undefined): DbAgentKind {
   return value === 'codex' || value === 'pi' ? value : 'cc';
+}
+
+export function dbToSessionAgentKind(db: string | null | undefined): SessionMakerAgentKindWire {
+  return db === 'trueforge' ? 'trueforge' : dbToMakerAgentKind(db);
+}
+
+export function sessionToDbAgentKind(maker: string | null | undefined): SessionDbAgentKind {
+  return maker === 'trueforge' ? 'trueforge' : makerToDbAgentKind(maker);
+}
+
+export function normalizeSessionDbAgentKind(
+  value: string | null | undefined,
+): SessionDbAgentKind {
+  return value === 'trueforge' ? 'trueforge' : normalizeDbAgentKind(value);
 }

--- a/apps/desktop/src/shared/conversationSearch.ts
+++ b/apps/desktop/src/shared/conversationSearch.ts
@@ -2,7 +2,7 @@ import { projectDraftSessionTitle } from '@cindy/maker-shared/session-title';
 
 import type { SessionSource } from './sessionSource';
 
-export type ConversationSearchAgentKind = 'cc' | 'codex' | 'pi';
+export type ConversationSearchAgentKind = 'cc' | 'codex' | 'pi' | 'trueforge';
 export type ConversationSearchWorkspaceKind = 'project' | 'dialogue';
 export type ConversationSearchSessionStatus = 'active' | 'archived' | 'deleted';
 export type ConversationSearchOrcaRole = 'lead' | 'worker';

--- a/apps/desktop/src/shared/sessionReference.ts
+++ b/apps/desktop/src/shared/sessionReference.ts
@@ -10,5 +10,5 @@ export interface SessionReference {
   state: 'available' | 'deleted' | 'missing';
   status?: 'active' | 'archived' | 'deleted';
   title?: string;
-  agentKind?: 'cc' | 'codex' | 'pi';
+  agentKind?: 'cc' | 'codex' | 'pi' | 'trueforge';
 }

--- a/docs/trueforge-integration.md
+++ b/docs/trueforge-integration.md
@@ -1,0 +1,49 @@
+# TrueForge integration (experimental)
+
+Cindy Desktop can use a user-managed TrueForge 0.1.x service as an experimental fourth agent
+harness. Cindy does not download, launch, or update the service.
+
+## Configure
+
+Run TrueForge separately (TrueForge currently requires Node.js 22 or newer), then start Cindy with
+both required environment variables:
+
+```text
+CINDY_TRUEFORGE_BASE_URL=http://127.0.0.1:8787
+CINDY_TRUEFORGE_MODEL=openai/gpt-5
+```
+
+Optional variables:
+
+```text
+CINDY_TRUEFORGE_MODEL_DISPLAY_NAME=Team model
+CINDY_TRUEFORGE_CONTEXT_WINDOW=128000
+CINDY_TRUEFORGE_ID_TOKEN=<OIDC ID token>
+```
+
+The base URL must be an origin without `/api/v1`, credentials, query parameters, or a fragment.
+Non-loopback endpoints must use HTTPS. Endpoint and model must be supplied together; partial
+configuration fails closed instead of silently hiding the agent.
+
+The optional ID token remains in the Electron main process and is passed only to the TrueForge SDK.
+It is not returned through IPC or exposed to the renderer. Avoid putting credentials in the URL.
+
+## First-release scope
+
+- Desktop-local, ordinary chat sessions only.
+- Text input, streamed text output, tool results, approvals, user questions, stop, and usage totals.
+- One configured `provider/model` per Cindy process. Change the environment and restart Cindy to
+  select a different model.
+- TrueForge owns its agent instructions, tools, MCP configuration, sandbox, and approval policy.
+  Cindy does not inject its Claude/Codex product prompt into the service.
+- Dynamic TrueForge subagents are disabled for Cindy-created sessions so child-thread output cannot
+  be confused with the main conversation.
+
+Not supported in this first release: SSH or device-link sessions, mobile-created sessions,
+worktrees, Goals, scheduling, collaboration/Orca, Cindy plan or effort controls, session fork/rewind,
+extra directories, images/files, or local HTTP MCP bridging. TrueForge 0.1.3 streaming is not
+resumable; an SSE disconnect ends the current Cindy turn with an error even if the remote service is
+still finishing it.
+
+This integration pins `@truefoundry/trueforge-sdk` to `0.1.3`; review the event and request contract
+before upgrading it.

--- a/packages/lizi-mcps/src/xdt-helper/_history_types.ts
+++ b/packages/lizi-mcps/src/xdt-helper/_history_types.ts
@@ -8,7 +8,7 @@
 
 import type { ControlResult } from '../types.js';
 
-export type HistoryAgentKind = 'cc' | 'codex' | 'pi';
+export type HistoryAgentKind = 'cc' | 'codex' | 'pi' | 'trueforge';
 export type HistoryOrder = 'asc' | 'desc';
 
 /** Stable business errors exposed by cross-device history readers. */

--- a/packages/maker-core/package.json
+++ b/packages/maker-core/package.json
@@ -24,6 +24,7 @@
     "@anthropic-ai/claude-agent-sdk": "0.2.112",
     "@anthropic-ai/sdk": "^0.91.1",
     "@cindy/maker-shared": "workspace:*",
+    "@truefoundry/trueforge-sdk": "0.1.3",
     "diff": "^8.0.4",
     "gray-matter": "^4.0.3"
   },

--- a/packages/maker-core/src/agents/base-agent.ts
+++ b/packages/maker-core/src/agents/base-agent.ts
@@ -467,6 +467,8 @@ export interface AgentDeps {
    * 缺省 / 空串 → BaseAgent 构造期立即抛错, 不让 session 进半就绪状态。
    */
   binaryPath: string;
+  /** Service-backed harnesses opt out of the local executable requirement explicitly. */
+  runtimeKind?: 'binary' | 'service';
   logger: Logger;
 
   /**
@@ -1800,7 +1802,7 @@ export abstract class BaseAgent {
   protected memoryOverride: boolean | undefined;
 
   constructor(protected deps: AgentDeps) {
-    if (!deps.binaryPath) {
+    if (deps.runtimeKind !== 'service' && !deps.binaryPath) {
       throw new Error(
         `${this.constructor.name}: binaryPath is required at construction (host must provision binary before instantiating agent)`,
       );
@@ -2031,8 +2033,13 @@ export abstract class BaseAgent {
   }
 
   /** 同步取 binary path (host 注入时已存在, 构造期校验过)。供 maker:agent:status 用。 */
-  getBinaryPath(): string {
-    return this.deps.binaryPath;
+  getBinaryPath(): string | null {
+    return this.deps.binaryPath || null;
+  }
+
+  /** Runtime admission hook. Service adapters override this with a health probe. */
+  async isRuntimeReady(): Promise<boolean> {
+    return this.deps.runtimeKind === 'service' || !!this.deps.binaryPath;
   }
 
   // ── Memory 控制 (子类实现) ─────────────────────────────────────────────

--- a/packages/maker-core/src/agents/index.ts
+++ b/packages/maker-core/src/agents/index.ts
@@ -12,6 +12,7 @@ export { CodexAgent } from './codex/index.js';
 // finalizeCodexCitationText = 剥截断残尾 + 归一化(与流式 completed 完全同口径)。
 export { finalizeCodexCitationText, normalizeCodexFileCitations } from './codex/translator.js';
 export { PiAgent } from './pi/index.js';
+export { TrueForgeAgent, type TrueForgeAgentConfig } from './trueforge/index.js';
 export {
   canReuseCodexHostForCredentialMode,
   canReuseHostForCredentialMode,

--- a/packages/maker-core/src/agents/trueforge/index.test.ts
+++ b/packages/maker-core/src/agents/trueforge/index.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { TrueForgeAgent } from './index.js';
+
+function makeStream(events: unknown[]) {
+  return {
+    async *withMetadata() {
+      for (const data of events) yield { data };
+    },
+  };
+}
+
+function makeClient() {
+  return {
+    fetch: vi.fn(async () => ({ ok: true })),
+    sessions: {
+      get: vi.fn(async () => ({})),
+      create: vi.fn(async () => ({ data: { id: 'tf-session' } })),
+      createTurnStream: vi.fn(async (_id: string, _body: unknown, _options?: unknown) =>
+        makeStream([
+          { type: 'turn.created', id: 'turn-1' },
+          { type: 'model.message.delta', id: 'message-1', content: 'ok' },
+          {
+            type: 'turn.done',
+            id: 'turn-1',
+            state: {
+              status: 'done',
+              metrics: {
+                totalInputTokens: 2,
+                totalOutputTokens: 1,
+                totalTokens: 3,
+              },
+            },
+          },
+        ]),
+      ),
+      cancel: vi.fn(async () => ({})),
+    },
+  };
+}
+
+function makeAgent(client: ReturnType<typeof makeClient>) {
+  const logger = {
+    trace() {},
+    debug() {},
+    info() {},
+    warn() {},
+    error() {},
+    fatal() {},
+    child() {
+      return this;
+    },
+  };
+  return new TrueForgeAgent(
+    {
+      auth: {
+        async getState() {
+          return { authenticated: true };
+        },
+        async triggerLogin() {
+          return { authenticated: true };
+        },
+        async logout() {},
+        async getAuthEnv() {
+          return {};
+        },
+      },
+      runtimeConfig: {},
+      binaryPath: '',
+      runtimeKind: 'service',
+      logger,
+    } as never,
+    {
+      baseUrl: 'http://127.0.0.1:8787',
+      model: 'openai/gpt-5',
+      contextWindow: 128_000,
+      client,
+    },
+  );
+}
+
+async function start(agent: TrueForgeAgent, overrides: Record<string, unknown> = {}) {
+  return agent.startSession({
+    workingDir: '',
+    model: 'openai/gpt-5',
+    permissionMode: 'ask',
+    ...overrides,
+  } as never);
+}
+
+describe('TrueForgeAgent', () => {
+  it('creates a session with dynamic subagents disabled and streams a turn', async () => {
+    const client = makeClient();
+    const handle = await start(makeAgent(client));
+    const events = handle.events()[Symbol.asyncIterator]();
+    await expect(events.next()).resolves.toMatchObject({
+      value: { type: 'session_id', source: 'trueforge', data: 'tf-session' },
+    });
+    await handle.send({ type: 'user', content: 'hello' });
+    await vi.waitFor(() => expect(client.sessions.createTurnStream).toHaveBeenCalledTimes(1));
+
+    expect(client.sessions.create).toHaveBeenCalledWith({
+      agent: {
+        spec: {
+          model: { name: 'openai/gpt-5' },
+          config: { dynamicSubAgents: { enabled: false } },
+        },
+      },
+    });
+    expect(client.sessions.createTurnStream).toHaveBeenCalledWith(
+      'tf-session',
+      { input: [{ type: 'user.message', content: 'hello' }] },
+      { abortSignal: expect.any(AbortSignal) },
+    );
+    await handle.close();
+  });
+
+  it('poisons the handle when a cancel cannot be confirmed', async () => {
+    const client = makeClient();
+    client.sessions.createTurnStream.mockImplementationOnce(async (_id, _body, options) => {
+      const signal = (options as { abortSignal: AbortSignal }).abortSignal;
+      return await new Promise((_, reject) => {
+        signal.addEventListener('abort', () => reject(new Error('aborted')), { once: true });
+      });
+    });
+    client.sessions.cancel.mockRejectedValueOnce(new Error('cancel timeout'));
+    const handle = await start(makeAgent(client));
+    const first = handle.send({ type: 'user', content: 'first' });
+    await vi.waitFor(() => expect(client.sessions.createTurnStream).toHaveBeenCalledTimes(1));
+
+    await handle.abort();
+    await expect(first).rejects.toThrow(/aborted/);
+    await expect(handle.send({ type: 'user', content: 'second' })).rejects.toThrow(/closed/);
+  });
+
+  it('only clears a resume id after an explicit 404', async () => {
+    const authFailure = makeClient();
+    authFailure.sessions.get.mockRejectedValueOnce({ statusCode: 401 });
+    const invalidAuthResume = vi.fn(async () => true);
+    await expect(
+      start(makeAgent(authFailure), {
+        resumeSessionId: 'persisted',
+        onInvalidResumeSession: invalidAuthResume,
+      }),
+    ).rejects.toMatchObject({ statusCode: 401 });
+    expect(invalidAuthResume).not.toHaveBeenCalled();
+
+    const missing = makeClient();
+    missing.sessions.get.mockRejectedValueOnce({ statusCode: 404 });
+    const clearMissingResume = vi.fn(async () => true);
+    const handle = await start(makeAgent(missing), {
+      resumeSessionId: 'missing',
+      onInvalidResumeSession: clearMissingResume,
+    });
+    expect(clearMissingResume).toHaveBeenCalledWith('missing');
+    expect(missing.sessions.create).toHaveBeenCalledTimes(1);
+    await handle.close();
+  });
+
+  it('gates concurrent sends during the HTTP handshake and aborts locally first', async () => {
+    const client = makeClient();
+    let observedSignal: AbortSignal | undefined;
+    client.sessions.createTurnStream.mockImplementationOnce(async (_id, _body, options) => {
+      observedSignal = (options as { abortSignal: AbortSignal }).abortSignal;
+      return await new Promise((_, reject) => {
+        observedSignal?.addEventListener('abort', () => reject(new Error('aborted')), {
+          once: true,
+        });
+      });
+    });
+    const handle = await start(makeAgent(client));
+    const first = handle.send({ type: 'user', content: 'first' });
+    await vi.waitFor(() => expect(observedSignal).toBeDefined());
+    await expect(handle.send({ type: 'user', content: 'second' })).rejects.toThrow(/already has/);
+    await handle.abort();
+    expect(observedSignal?.aborted).toBe(true);
+    await expect(first).rejects.toThrow(/aborted/);
+    expect(client.sessions.cancel).toHaveBeenCalledWith('tf-session', undefined, {
+      timeoutInSeconds: 5,
+      maxRetries: 0,
+    });
+    await handle.close();
+  });
+});

--- a/packages/maker-core/src/agents/trueforge/index.ts
+++ b/packages/maker-core/src/agents/trueforge/index.ts
@@ -1,0 +1,525 @@
+import { TrueForge, isEventDelta, mergeEventDelta } from '@truefoundry/trueforge-sdk';
+
+import type { AgentKind, PermissionMode, UserMessage } from '../../types/common.js';
+import type {
+  AgentEvent,
+  InteractionRequest,
+  InteractionResolver,
+  UsageSnapshot,
+} from '../../types/events.js';
+import type { Capabilities, ModelDescriptor } from '../../types/capabilities.js';
+import { NotSupportedError } from '../../types/capabilities.js';
+import {
+  BaseAgent,
+  type AgentDeps,
+  type AgentSessionHandle,
+  type SendOptions,
+  type StartSessionOptions,
+} from '../base-agent.js';
+import { createAsyncQueue } from '../shared/async-queue.js';
+import {
+  asTrueForgeEvent,
+  parseToolArguments,
+  toolNameOf,
+  type TrueForgeEvent,
+} from './protocol.js';
+import {
+  beginTrueForgeTurn,
+  createTrueForgeTranslateState,
+  emitToolUse,
+  finishTrueForgeTurn,
+  rememberToolCalls,
+  translateTrueForgeEvent,
+  type TrueForgeTranslateState,
+} from './translator.js';
+
+interface TrueForgeStream {
+  withMetadata(): AsyncIterable<{ data: unknown; id?: string | number | null }>;
+}
+
+interface TrueForgeClientLike {
+  fetch(path: string, init?: unknown, options?: unknown): Promise<{ ok: boolean }>;
+  sessions: {
+    get(sessionId: string): Promise<unknown>;
+    create(body: unknown): Promise<{ data: { id: string } }>;
+    createTurnStream(sessionId: string, body: unknown, options?: unknown): Promise<TrueForgeStream>;
+    cancel(sessionId: string, request?: unknown, options?: unknown): Promise<unknown>;
+  };
+}
+
+export interface TrueForgeAgentConfig {
+  baseUrl: string;
+  model: string;
+  displayName?: string;
+  contextWindow: number;
+  idToken?: string;
+  fetch?: typeof globalThis.fetch;
+  /** Test seam; production always constructs the version-pinned SDK client. */
+  client?: TrueForgeClientLike;
+}
+
+interface ConsumedTurn {
+  terminal: TrueForgeEvent;
+  events: Map<string, TrueForgeEvent>;
+}
+
+function unsupported(message: string) {
+  return {
+    supported: false as const,
+    reason: 'not-implemented' as const,
+    message,
+  };
+}
+
+function textOf(message: UserMessage): string {
+  if (typeof message.content === 'string') return message.content;
+  const parts: string[] = [];
+  for (const block of message.content) {
+    if (block.type === 'text') parts.push(block.text);
+    else if (block.type === 'mention') parts.push(`@${block.name} (${block.path})`);
+    else {
+      throw new NotSupportedError(`multimodal:${block.type}`, {
+        supported: false,
+        reason: 'not-implemented',
+        message: 'TrueForge file and image forwarding is not implemented yet.',
+      });
+    }
+  }
+  return parts.join('\n').trim();
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function statusCodeOf(error: unknown): number | undefined {
+  if (!error || typeof error !== 'object') return undefined;
+  const statusCode = (error as { statusCode?: unknown }).statusCode;
+  return typeof statusCode === 'number' ? statusCode : undefined;
+}
+
+async function resolveWithAbort<T>(operation: Promise<T>, signal: AbortSignal): Promise<T> {
+  if (signal.aborted) throw new Error('TrueForge turn aborted');
+  let fail!: () => void;
+  const cancellation = new Promise<never>((_, reject) => {
+    fail = () => reject(new Error('TrueForge turn aborted'));
+    signal.addEventListener('abort', fail, { once: true });
+  });
+  try {
+    return await Promise.race([operation, cancellation]);
+  } finally {
+    signal.removeEventListener('abort', fail);
+  }
+}
+
+// Keep the experimental service adapter out of the stable three-agent union until every Cindy
+// orchestration surface has an explicit TrueForge policy. Runtime dispatch is string-keyed, so the
+// desktop host can opt in without widening unrelated scheduler/IM/device-link contracts.
+const TRUEFORGE_KIND = 'trueforge' as AgentKind;
+
+/** Experimental adapter for a user-managed TrueForge 0.1.x HTTP/SSE service. */
+export class TrueForgeAgent extends BaseAgent {
+  readonly kind: AgentKind = TRUEFORGE_KIND;
+  readonly capabilities: Capabilities;
+  private readonly client: TrueForgeClientLike;
+
+  constructor(
+    deps: AgentDeps,
+    private readonly config: TrueForgeAgentConfig,
+  ) {
+    super({ ...deps, runtimeKind: 'service', binaryPath: '' });
+    const model: ModelDescriptor = {
+      id: config.model,
+      displayName: config.displayName?.trim() || config.model,
+      contextWindow: config.contextWindow,
+      efforts: [],
+      defaultEffort: null,
+      newSessionDefault: ['trueforge'],
+    };
+    this.capabilities = this.buildCapabilities({
+      switchModel: unsupported('Change the model in the TrueForge service configuration.'),
+      availableModels: [model],
+      hasFastMode: false,
+      effort: unsupported('TrueForge does not expose a per-session reasoning-effort control.'),
+      effortLevels: [],
+      reasoningDisplay: ['off'],
+      permissionModes: [
+        {
+          id: 'ask',
+          displayName: 'TrueForge approvals',
+          description: 'Use the approval gates configured by the TrueForge agent.',
+        },
+      ],
+      setPermissionModeMidSession: unsupported(
+        'Approval policy is owned by the TrueForge agent spec.',
+      ),
+      turnPermissionPolicy: {
+        supported: unsupported(
+          'Per-turn Cindy permission policies are not bridged to TrueForge yet.',
+        ),
+        unsupportedPermissionModes: ['ask'],
+      },
+      planMode: unsupported('TrueForge does not expose Cindy plan mode.'),
+      multimodal: {
+        text: { supported: true },
+        image: unsupported('Image forwarding is not implemented yet.'),
+        file: unsupported('File forwarding is not implemented yet.'),
+      },
+      runtimeCapabilities: unsupported('TrueForge commands are managed by its server.'),
+      fork: unsupported('TrueForge session branching is not exposed by this adapter.'),
+      rewind: unsupported('TrueForge rewind is not exposed by this adapter.'),
+      sessionTree: unsupported('TrueForge thread trees are not exposed by this adapter.'),
+      abort: { supported: true },
+      sameTurnSteer: unsupported('TrueForge accepts follow-up input as a new turn.'),
+      memory: {
+        supported: unsupported('TrueForge memory is managed by its server.'),
+      },
+      extraDirs: unsupported('TrueForge cannot mount Cindy reference directories.'),
+    });
+    this.client =
+      config.client ??
+      (new TrueForge({
+        baseUrl: config.baseUrl,
+        ...(config.idToken ? { token: config.idToken } : {}),
+        ...(config.fetch ? { fetch: config.fetch } : {}),
+        timeoutInSeconds: 600,
+        maxRetries: 1,
+      }) as unknown as TrueForgeClientLike);
+  }
+
+  override async isRuntimeReady(): Promise<boolean> {
+    try {
+      const response = await this.client.fetch('/healthz', undefined, {
+        timeoutInSeconds: 5,
+        maxRetries: 0,
+      });
+      return response.ok;
+    } catch {
+      return false;
+    }
+  }
+
+  override async startSession(opts: StartSessionOptions): Promise<AgentSessionHandle> {
+    if (opts.remoteHostId) {
+      throw new NotSupportedError('remoteSession', {
+        supported: false,
+        reason: 'not-implemented',
+        message: 'TrueForge sessions are service-backed and cannot run through Cindy SSH remotes.',
+      });
+    }
+
+    let sessionId = opts.resumeSessionId?.trim() || '';
+    if (sessionId) {
+      try {
+        await this.client.sessions.get(sessionId);
+      } catch (error) {
+        if (statusCodeOf(error) !== 404) throw error;
+        const cleared = await opts.onInvalidResumeSession?.(sessionId);
+        if (!cleared) throw error;
+        sessionId = '';
+      }
+    }
+    if (!sessionId) {
+      const created = await this.client.sessions.create({
+        agent: {
+          spec: {
+            model: { name: this.config.model },
+            config: { dynamicSubAgents: { enabled: false } },
+          },
+        },
+      });
+      sessionId = created.data.id;
+    }
+
+    const queue = createAsyncQueue<AgentEvent>();
+    const state = createTrueForgeTranslateState(this.config.contextWindow);
+    let resolver: InteractionResolver | null = null;
+    let currentRun: Promise<void> | null = null;
+    let streamAbort: AbortController | null = null;
+    let cancelSettlement: Promise<void> | null = null;
+    let closed = false;
+    const client = this.client;
+    const logger = this.deps.logger;
+
+    queue.push({
+      type: 'session_id',
+      source: 'trueforge',
+      data: sessionId,
+    });
+
+    const consume = async (stream: TrueForgeStream): Promise<ConsumedTurn> => {
+      const events = new Map<string, TrueForgeEvent>();
+      let terminal: TrueForgeEvent | null = null;
+      for await (const envelope of stream.withMetadata()) {
+        const event = asTrueForgeEvent(envelope.data);
+        if (!event) continue;
+        if (event.id && isEventDelta(envelope.data as never)) {
+          const base = events.get(event.id);
+          if (base) {
+            mergeEventDelta(base as never, envelope.data as never);
+            rememberToolCalls(state, base.toolCalls);
+          }
+        } else if (event.id) {
+          events.set(event.id, event);
+          rememberToolCalls(state, event.toolCalls);
+        }
+        translateTrueForgeEvent(event, queue, state);
+        if (event.type === 'turn.done') terminal = event;
+      }
+      if (!terminal) throw new Error('TrueForge stream ended without turn.done');
+      return { terminal, events };
+    };
+
+    const sourceCall = (
+      action: TrueForgeEvent,
+      ref: { id?: string; sourceEventId?: string },
+      events: Map<string, TrueForgeEvent>,
+    ) => {
+      const source = ref.sourceEventId ? events.get(ref.sourceEventId) : undefined;
+      return (
+        source?.toolCalls?.find((call) => call.id === ref.id) ??
+        (ref.id ? state.calls.get(ref.id) : undefined) ??
+        action.toolCalls?.find((call) => call.id === ref.id)
+      );
+    };
+
+    const resolveActions = async (
+      actions: readonly TrueForgeEvent[],
+      events: Map<string, TrueForgeEvent>,
+    ): Promise<Array<Record<string, unknown>>> => {
+      if (!resolver)
+        throw new Error(
+          'TrueForge requested user input before an interaction resolver was attached',
+        );
+      const responses: Array<Record<string, unknown>> = [];
+      for (const action of actions) {
+        if (action.type === 'mcp.auth_required') {
+          const names = (action.mcpServers ?? []).map((server) => server.name).filter(Boolean);
+          throw new Error(
+            `TrueForge MCP authentication requires opening its UI${names.length ? ` for ${names.join(', ')}` : ''}`,
+          );
+        }
+        for (const ref of action.toolCalls ?? []) {
+          const call = sourceCall(action, ref, events);
+          if (!call)
+            throw new Error(
+              `TrueForge interaction is missing tool metadata for ${ref.id ?? 'unknown call'}`,
+            );
+          emitToolUse(queue, state, call);
+          const requestId = `${action.id ?? action.type}:${call.id}`;
+          if (action.type === 'tool.approval_required') {
+            const request: InteractionRequest = {
+              kind: 'permission',
+              requestId,
+              toolUseId: call.id,
+              toolName: toolNameOf(call),
+              input: parseToolArguments(call.function?.arguments),
+            };
+            const activeSignal = streamAbort?.signal;
+            if (!activeSignal) throw new Error('TrueForge turn is no longer active');
+            const decision = await resolveWithAbort(resolver(request), activeSignal);
+            if (decision.kind !== 'permission')
+              throw new Error('TrueForge received an invalid approval decision');
+            responses.push({
+              type: 'user.tool_approval',
+              threadId: action.threadId ?? 'main',
+              toolCallId: call.id,
+              approval:
+                decision.behavior === 'allow'
+                  ? { status: 'allow' }
+                  : {
+                      status: 'deny',
+                      ...(decision.reason ? { reason: decision.reason } : {}),
+                    },
+            });
+            continue;
+          }
+          if (action.type === 'tool.response_required') {
+            const input = parseToolArguments(call.function?.arguments);
+            const options = Array.isArray(input.options)
+              ? input.options.filter((value): value is string => typeof value === 'string')
+              : [];
+            const question =
+              typeof input.question === 'string'
+                ? input.question
+                : 'What should TrueForge do next?';
+            const request: InteractionRequest = {
+              kind: 'ask_user_question',
+              requestId,
+              toolUseId: call.id,
+              questions: [
+                {
+                  question,
+                  ...(options.length ? { options: options.map((label) => ({ label })) } : {}),
+                },
+              ],
+            };
+            const activeSignal = streamAbort?.signal;
+            if (!activeSignal) throw new Error('TrueForge turn is no longer active');
+            const decision = await resolveWithAbort(resolver(request), activeSignal);
+            if (decision.kind !== 'ask_user_question')
+              throw new Error('TrueForge received an invalid tool response');
+            const answer = decision.answers[question] ?? Object.values(decision.answers)[0] ?? '';
+            responses.push({
+              type: 'user.tool_response',
+              threadId: action.threadId ?? 'main',
+              toolCallId: call.id,
+              content: answer,
+            });
+          }
+        }
+      }
+      return responses;
+    };
+
+    const consumeWithContinuations = async (firstStream: TrueForgeStream): Promise<void> => {
+      let consumed = await consume(firstStream);
+      while (!closed) {
+        const status = consumed.terminal.state?.status;
+        if (status === 'error') {
+          finishTrueForgeTurn(
+            queue,
+            state,
+            consumed.terminal.state?.message || 'TrueForge turn failed',
+          );
+          return;
+        }
+        const actions = consumed.terminal.state?.requiredActions ?? [];
+        if (actions.length === 0) {
+          finishTrueForgeTurn(queue, state);
+          return;
+        }
+        const input = await resolveActions(actions, consumed.events);
+        if (input.length === 0)
+          throw new Error('TrueForge paused without a supported required action');
+        const activeSignal = streamAbort?.signal;
+        if (closed || !activeSignal || activeSignal.aborted) return;
+        const next = await client.sessions.createTurnStream(
+          sessionId,
+          { input: input as never[] },
+          { abortSignal: activeSignal },
+        );
+        consumed = await consume(next as unknown as TrueForgeStream);
+      }
+    };
+
+    const startRun = async (message: UserMessage): Promise<void> => {
+      if (closed) throw new Error('TrueForge session is closed');
+      if (cancelSettlement) await cancelSettlement;
+      if (closed) throw new Error('TrueForge session is closed');
+      if (currentRun) throw new Error('TrueForge session already has a running turn');
+      const content = textOf(message);
+      if (!content) throw new Error('TrueForge requires a non-empty text message');
+      beginTrueForgeTurn(state);
+      const activeAbort = new AbortController();
+      streamAbort = activeAbort;
+      let markStarted!: () => void;
+      let markStartFailed!: (error: unknown) => void;
+      const started = new Promise<void>((resolve, reject) => {
+        markStarted = resolve;
+        markStartFailed = reject;
+      });
+      currentRun = (async () => {
+        try {
+          const stream = await client.sessions.createTurnStream(
+            sessionId,
+            { input: [{ type: 'user.message', content }] },
+            { abortSignal: activeAbort.signal },
+          );
+          markStarted();
+          await consumeWithContinuations(stream);
+        } catch (error) {
+          markStartFailed(error);
+          throw error;
+        }
+      })()
+        .catch((error) => {
+          if (!closed && !activeAbort.signal.aborted) {
+            finishTrueForgeTurn(queue, state, errorMessage(error));
+            logger.warn('trueforge turn failed', {
+              message: errorMessage(error),
+            });
+          }
+        })
+        .finally(() => {
+          currentRun = null;
+          if (streamAbort === activeAbort) streamAbort = null;
+        });
+      await started;
+    };
+
+    const handle: AgentSessionHandle = {
+      id: sessionId,
+      agentKind: TRUEFORGE_KIND,
+      model: this.config.model,
+      async send(message: UserMessage, _sendOpts?: SendOptions): Promise<void> {
+        await startRun(message);
+      },
+      async steer(): Promise<void> {
+        throw new NotSupportedError('sameTurnSteer', {
+          supported: false,
+          reason: 'not-implemented',
+          message: 'TrueForge follow-ups start a new turn.',
+        });
+      },
+      async abort(): Promise<void> {
+        if (!currentRun) return;
+        streamAbort?.abort();
+        let cancelFailed = false;
+        const cancellation = client.sessions
+          .cancel(sessionId, undefined, { timeoutInSeconds: 5, maxRetries: 0 })
+          .then(() => undefined)
+          .catch((error) => {
+            // A timed-out cancel may still reach the service later. Poison this handle so a
+            // delayed session-scoped cancel can never terminate a newly-started turn.
+            cancelFailed = true;
+            closed = true;
+            logger.warn('trueforge cancel failed after local abort', {
+              message: errorMessage(error),
+            });
+          });
+        cancelSettlement = cancellation;
+        await cancellation;
+        if (cancelSettlement === cancellation) cancelSettlement = null;
+        if (cancelFailed) {
+          await currentRun?.catch(() => undefined);
+          queue.end();
+        }
+      },
+      async close(): Promise<void> {
+        if (closed) return;
+        closed = true;
+        if (currentRun) {
+          streamAbort?.abort();
+          void client.sessions
+            .cancel(sessionId, undefined, {
+              timeoutInSeconds: 5,
+              maxRetries: 0,
+            })
+            .catch(() => undefined);
+          await currentRun.catch(() => undefined);
+        }
+        queue.end();
+      },
+      events(): AsyncIterable<AgentEvent> {
+        return queue;
+      },
+      getUsageSnapshot(): UsageSnapshot {
+        return { ...state.usage };
+      },
+      setInteractionResolver(next: InteractionResolver): void {
+        resolver = next;
+      },
+      async setPermissionMode(mode: PermissionMode): Promise<void> {
+        if (mode !== 'ask') {
+          throw new NotSupportedError('setPermissionMode', {
+            supported: false,
+            reason: 'not-implemented',
+            message: 'TrueForge approval policy is configured on the server.',
+          });
+        }
+      },
+    };
+    return handle;
+  }
+}

--- a/packages/maker-core/src/agents/trueforge/protocol.ts
+++ b/packages/maker-core/src/agents/trueforge/protocol.ts
@@ -1,0 +1,62 @@
+/** Narrow, version-pinned subset of the TrueForge 0.1.x event contract. */
+
+export interface TrueForgeToolCall {
+  id: string;
+  function?: { name?: string; arguments?: string };
+  toolInfo?: { name?: string; type?: string };
+}
+
+export interface TrueForgeEvent {
+  type: string;
+  id?: string;
+  threadId?: string | null;
+  turnId?: string;
+  content?: string | null;
+  toolCallId?: string;
+  toolCalls?: TrueForgeToolCall[];
+  usage?: {
+    inputTokens: number;
+    outputTokens: number;
+    cacheReadTokens?: number;
+    cacheWriteTokens?: number;
+  };
+  sourceEventId?: string;
+  state?: {
+    status?: 'running' | 'done' | 'cancelled' | 'error';
+    reason?: string;
+    message?: string;
+    output?: unknown;
+    requiredActions?: TrueForgeEvent[];
+    metrics?: {
+      totalInputTokens?: number;
+      totalOutputTokens?: number;
+      totalTokens?: number;
+      totalCacheReadTokens?: number;
+      totalCacheWriteTokens?: number;
+      totalCostInUsd?: number;
+    };
+  };
+  mcpServers?: Array<{ name?: string; authUrl?: string }>;
+}
+
+export function asTrueForgeEvent(value: unknown): TrueForgeEvent | null {
+  if (!value || typeof value !== 'object') return null;
+  const event = value as TrueForgeEvent;
+  return typeof event.type === 'string' ? event : null;
+}
+
+export function parseToolArguments(value: string | undefined): Record<string, unknown> {
+  if (!value) return {};
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : { value: parsed };
+  } catch {
+    return { raw: value };
+  }
+}
+
+export function toolNameOf(call: TrueForgeToolCall): string {
+  return call.toolInfo?.name?.trim() || call.function?.name?.trim() || 'tool';
+}

--- a/packages/maker-core/src/agents/trueforge/translator.test.ts
+++ b/packages/maker-core/src/agents/trueforge/translator.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest';
+
+import type { AgentEvent } from '../../types/events.js';
+import { createAsyncQueue } from '../shared/async-queue.js';
+import {
+  beginTrueForgeTurn,
+  createTrueForgeTranslateState,
+  finishTrueForgeTurn,
+  rememberToolCalls,
+  translateTrueForgeEvent,
+} from './translator.js';
+
+async function drain(
+  queue: ReturnType<typeof createAsyncQueue<AgentEvent>>,
+): Promise<AgentEvent[]> {
+  queue.end();
+  const events: AgentEvent[] = [];
+  for await (const event of queue) events.push(event);
+  return events;
+}
+
+describe('TrueForge event translation', () => {
+  it('preserves text, assembled tool metadata, and exact continuation usage', async () => {
+    const queue = createAsyncQueue<AgentEvent>();
+    const state = createTrueForgeTranslateState(128_000);
+    beginTrueForgeTurn(state);
+
+    translateTrueForgeEvent({ type: 'turn.created' }, queue, state);
+    translateTrueForgeEvent({ type: 'model.message.delta', content: 'Hello ' }, queue, state);
+    translateTrueForgeEvent({ type: 'model.message.delta', content: 'world' }, queue, state);
+    rememberToolCalls(state, [
+      {
+        id: 'call-1',
+        function: { name: 'lookup', arguments: '{"query":"complete"}' },
+      },
+    ]);
+    translateTrueForgeEvent(
+      {
+        type: 'model.message.delta',
+        toolCalls: [{ id: 'call-1', function: { name: 'lookup', arguments: '}' } }],
+      },
+      queue,
+      state,
+    );
+    translateTrueForgeEvent(
+      {
+        type: 'tool.response',
+        toolCallId: 'call-1',
+        content: 'result',
+      },
+      queue,
+      state,
+    );
+    translateTrueForgeEvent(
+      {
+        type: 'turn.done',
+        state: {
+          metrics: {
+            totalInputTokens: 10,
+            totalOutputTokens: 4,
+            totalTokens: 14,
+          },
+        },
+      },
+      queue,
+      state,
+    );
+    translateTrueForgeEvent(
+      {
+        type: 'turn.done',
+        state: {
+          metrics: {
+            totalInputTokens: 12,
+            totalOutputTokens: 3,
+            totalTokens: 15,
+            totalCacheReadTokens: 5,
+            totalCostInUsd: 0.02,
+          },
+        },
+      },
+      queue,
+      state,
+    );
+    finishTrueForgeTurn(queue, state);
+
+    const events = await drain(queue);
+    expect(
+      events
+        .filter((event) => event.type === 'text')
+        .map((event) => (event.data as { text: string }).text),
+    ).toEqual(['Hello ', 'world']);
+    const toolUse = events.find((event) => event.type === 'tool_use');
+    expect(toolUse?.data).toMatchObject({
+      toolUseId: 'call-1',
+      toolName: 'lookup',
+      input: { query: 'complete' },
+    });
+    const done = events.find((event) => event.type === 'done');
+    expect(done?.data).toMatchObject({
+      result: 'Hello world',
+      usage: { inputTokens: 22, outputTokens: 7 },
+    });
+    expect(state.usage).toMatchObject({
+      tokenUsage: 29,
+      contextTokens: 17,
+      costUsd: 0.02,
+    });
+  });
+
+  it('translates 10k text deltas without loss', () => {
+    const queue = createAsyncQueue<AgentEvent>();
+    const state = createTrueForgeTranslateState(128_000);
+    beginTrueForgeTurn(state);
+    const startedAt = performance.now();
+    for (let i = 0; i < 10_000; i += 1) {
+      translateTrueForgeEvent({ type: 'model.message.delta', content: 'x' }, queue, state);
+    }
+    const elapsedMs = performance.now() - startedAt;
+    expect(state.finalText).toHaveLength(10_000);
+    expect(queue.pending).toBe(10_000);
+    expect(elapsedMs).toBeLessThan(2_000);
+  });
+});

--- a/packages/maker-core/src/agents/trueforge/translator.ts
+++ b/packages/maker-core/src/agents/trueforge/translator.ts
@@ -1,0 +1,184 @@
+import type { AgentEvent, UsageSnapshot } from '../../types/events.js';
+import type { AsyncQueue } from '../shared/async-queue.js';
+import type { TrueForgeEvent, TrueForgeToolCall } from './protocol.js';
+import { parseToolArguments, toolNameOf } from './protocol.js';
+
+export interface TrueForgeTranslateState {
+  finalText: string;
+  usage: UsageSnapshot;
+  inputTokens: number;
+  outputTokens: number;
+  hasModelUsage: boolean;
+  calls: Map<string, TrueForgeToolCall>;
+  emittedCalls: Set<string>;
+}
+
+export function createTrueForgeTranslateState(contextWindow: number): TrueForgeTranslateState {
+  return {
+    finalText: '',
+    usage: { tokenUsage: 0, contextTokens: 0, contextWindow, costUsd: 0 },
+    inputTokens: 0,
+    outputTokens: 0,
+    hasModelUsage: false,
+    calls: new Map(),
+    emittedCalls: new Set(),
+  };
+}
+
+export function beginTrueForgeTurn(state: TrueForgeTranslateState): void {
+  state.finalText = '';
+  state.usage.tokenUsage = 0;
+  state.usage.contextTokens = 0;
+  state.inputTokens = 0;
+  state.outputTokens = 0;
+  state.hasModelUsage = false;
+  state.calls.clear();
+  state.emittedCalls.clear();
+}
+
+export function rememberToolCalls(
+  state: TrueForgeTranslateState,
+  calls: readonly TrueForgeToolCall[] | undefined,
+): void {
+  for (const call of calls ?? []) {
+    if (call.id) state.calls.set(call.id, call);
+  }
+}
+
+export function emitToolUse(
+  queue: AsyncQueue<AgentEvent>,
+  state: TrueForgeTranslateState,
+  call: TrueForgeToolCall,
+): void {
+  if (!call.id || state.emittedCalls.has(call.id)) return;
+  state.emittedCalls.add(call.id);
+  queue.push({
+    type: 'tool_use',
+    source: 'trueforge',
+    data: {
+      toolUseId: call.id,
+      toolName: toolNameOf(call),
+      input: parseToolArguments(call.function?.arguments),
+    },
+  });
+}
+
+export function translateTrueForgeEvent(
+  event: TrueForgeEvent,
+  queue: AsyncQueue<AgentEvent>,
+  state: TrueForgeTranslateState,
+): void {
+  if (
+    (event.type === 'model.message' || event.type === 'model.message.delta') &&
+    event.threadId &&
+    event.threadId !== 'main'
+  )
+    return;
+  // Delta tool calls are fragments. The stream adapter remembers the SDK-merged base event;
+  // accepting the raw fragment here would overwrite complete arguments with partial JSON.
+  if (event.type !== 'model.message.delta') rememberToolCalls(state, event.toolCalls);
+  switch (event.type) {
+    case 'turn.created':
+      queue.push({
+        type: 'status',
+        source: 'trueforge',
+        data: { status: 'Working…', ...state.usage, isRunning: true },
+      });
+      return;
+    case 'model.message':
+      if (event.usage) {
+        state.hasModelUsage = true;
+        state.usage.contextTokens =
+          event.usage.inputTokens +
+          (event.usage.cacheReadTokens ?? 0) +
+          (event.usage.cacheWriteTokens ?? 0);
+      }
+      return;
+    case 'model.message.delta':
+      if (event.usage) {
+        state.hasModelUsage = true;
+        state.usage.contextTokens =
+          event.usage.inputTokens +
+          (event.usage.cacheReadTokens ?? 0) +
+          (event.usage.cacheWriteTokens ?? 0);
+      }
+      if (event.content) {
+        state.finalText += event.content;
+        queue.push({
+          type: 'text',
+          source: 'trueforge',
+          data: { text: event.content, isFinal: false },
+        });
+      }
+      return;
+    case 'tool.response': {
+      const call = event.toolCallId ? state.calls.get(event.toolCallId) : undefined;
+      if (call) emitToolUse(queue, state, call);
+      const toolUseId = event.toolCallId ?? '';
+      const fullText = typeof event.content === 'string' ? event.content : '';
+      queue.push({
+        type: 'tool_result_full',
+        source: 'trueforge',
+        data: { toolUseId, fullText, isError: false },
+      });
+      queue.push({
+        type: 'tool_result',
+        source: 'trueforge',
+        data: { summary: 'done', toolUseIds: [toolUseId] },
+      });
+      return;
+    }
+    case 'turn.done': {
+      const metrics = event.state?.metrics;
+      if (metrics) {
+        const input = metrics.totalInputTokens ?? 0;
+        const output = metrics.totalOutputTokens ?? 0;
+        const cacheRead = metrics.totalCacheReadTokens ?? 0;
+        const cacheWrite = metrics.totalCacheWriteTokens ?? 0;
+        state.inputTokens += input;
+        state.outputTokens += output;
+        state.usage.tokenUsage += metrics.totalTokens ?? input + output;
+        // contextTokens comes from the final model.message usage above. Turn metrics aggregate
+        // every model call and would overstate the live context gauge for tool-heavy turns.
+        if (!state.hasModelUsage) {
+          state.usage.contextTokens = input + cacheRead + cacheWrite;
+        }
+        state.usage.costUsd += metrics.totalCostInUsd ?? 0;
+      }
+      return;
+    }
+    default:
+      return;
+  }
+}
+
+export function finishTrueForgeTurn(
+  queue: AsyncQueue<AgentEvent>,
+  state: TrueForgeTranslateState,
+  error?: string,
+): void {
+  if (error) {
+    queue.push({
+      type: 'error',
+      source: 'trueforge',
+      data: { message: error, sdkError: error, isTerminal: true },
+    });
+  }
+  queue.push({
+    type: 'status',
+    source: 'trueforge',
+    data: { status: 'Done', ...state.usage, isRunning: false },
+  });
+  queue.push({
+    type: 'done',
+    source: 'trueforge',
+    data: {
+      type: 'trueforge/turn.done',
+      result: state.finalText,
+      usage: {
+        inputTokens: state.inputTokens,
+        outputTokens: state.outputTokens,
+      },
+    },
+  });
+}

--- a/packages/maker-core/src/maker.test.ts
+++ b/packages/maker-core/src/maker.test.ts
@@ -3269,6 +3269,40 @@ describe('Session permission mode leases', () => {
 });
 
 describe('Maker invalid-resume persistence bridge', () => {
+  it('injects the same compare-and-clear callback for experimental TrueForge sessions', async () => {
+    const trueForgeKind = 'trueforge' as AgentKind;
+    const storage = createStorage();
+    await storage.create({
+      id: 'trueforge-session',
+      agentKind: trueForgeKind,
+      workDir: '/repo',
+      title: 'TrueForge',
+      model: 'openai/gpt-5',
+      sdkSessionId: 'tf-old',
+    });
+    const startSession = vi.fn(async (opts: CreateSessionOptions) => {
+      expect(await opts.onInvalidResumeSession?.('tf-old')).toBe(true);
+      expect(await opts.onInvalidResumeSession?.('tf-old')).toBe(false);
+      return createHandle({ id: 'tf-new', agentKind: trueForgeKind });
+    });
+    const trueForgeAgent = createAgent(startSession);
+    (trueForgeAgent as { kind: AgentKind }).kind = trueForgeKind;
+    const maker = new Maker({
+      agents: { [trueForgeKind]: trueForgeAgent },
+      storage,
+      logger: createLogger(),
+    });
+
+    await maker.createSession({
+      id: 'trueforge-session',
+      agentKind: trueForgeKind,
+      workingDir: '/repo',
+      model: 'openai/gpt-5',
+      resumeSessionId: 'tf-old',
+    });
+    expect((await storage.get('trueforge-session'))?.sdkSessionId).toBe('tf-new');
+  });
+
   it('injects a compare-and-clear callback for resumed Claude sessions', async () => {
     const storage = createStorage();
     await storage.create({

--- a/packages/maker-core/src/maker.ts
+++ b/packages/maker-core/src/maker.ts
@@ -625,7 +625,9 @@ export class Maker {
         // 的 fresh-session self-reference 恢复),需要同一把 CAS 才能把它清掉,否则下一次
         // send 会 resume 同一个不存在的会话反复失败。
         onInvalidResumeSession:
-          opts.agentKind === 'claude-code' || opts.agentKind === 'pi'
+          opts.agentKind === 'claude-code' ||
+          opts.agentKind === 'pi' ||
+          (opts.agentKind as string) === 'trueforge'
             ? (expectedSdkSessionId) =>
                 this.invalidateAndClearSdkSessionId(id, expectedSdkSessionId)
             : undefined,
@@ -1263,7 +1265,7 @@ export class Maker {
     }
     const auth = await agent.getAuthState();
     return {
-      binaryReady: !!agent.getBinaryPath(),
+      binaryReady: await agent.isRuntimeReady(),
       binaryPath: agent.getBinaryPath(),
       authReady: auth.authenticated,
       identity: auth.identity,

--- a/packages/maker-core/src/types/capabilities.ts
+++ b/packages/maker-core/src/types/capabilities.ts
@@ -274,7 +274,7 @@ export interface ModelDescriptor {
    * host 派生时透传）。与 sortOrder / defaultEnabled 独立；渲染层选新对话默认时优先取被
    * 标记且可用可见的模型（见 modelDefinitions getDefaultModelForVendor）。maker-core 运行时不读它。
    */
-  newSessionDefault?: ('claude-code' | 'codex' | 'pi')[];
+  newSessionDefault?: ('claude-code' | 'codex' | 'pi' | 'trueforge')[];
   /**
    * 模型计费($/1M tokens,源自目录/网关刷新,host 派生时透传)。pi 用它生成
    * models.json 的 cost 让 pi 自行计价;缺省按 0 计(用量页不显示钱数)。

--- a/packages/maker-core/src/types/events.ts
+++ b/packages/maker-core/src/types/events.ts
@@ -134,7 +134,7 @@ export interface AgentEvent {
   type: AgentEventType;
   data: unknown;
   /** 事件来源标识，便于调试 */
-  source?: 'claude-code' | 'codex' | 'pi';
+  source?: 'claude-code' | 'codex' | 'pi' | 'trueforge';
   /**
    * Events that finish work owned by a completed turn can still arrive after a
    * later turn has started (for example, a V1 collab child). These are still

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1088,6 +1088,9 @@ importers:
       '@cindy/maker-shared':
         specifier: workspace:*
         version: link:../maker-shared
+      '@truefoundry/trueforge-sdk':
+        specifier: 0.1.3
+        version: 0.1.3
       better-sqlite3:
         specifier: '*'
         version: 12.11.1
@@ -4412,6 +4415,10 @@ packages:
   '@tootallnate/once@2.0.1':
     resolution: {integrity: sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==}
     engines: {node: '>= 10'}
+
+  '@truefoundry/trueforge-sdk@0.1.3':
+    resolution: {integrity: sha512-YW1I8CWOoDzIqhl8PEZYUnahibSdIlo0IPXX5A3zNT1QBSscn/jGutzB90jqgWQrPr8HKZcDF5KthnG4hmUtXA==}
+    engines: {node: '>=22'}
 
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
@@ -14107,6 +14114,8 @@ snapshots:
       - '@floating-ui/dom'
 
   '@tootallnate/once@2.0.1': {}
+
+  '@truefoundry/trueforge-sdk@0.1.3': {}
 
   '@tybys/wasm-util@0.10.3':
     dependencies:


### PR DESCRIPTION
## 这次改了什么

### 摘要

为 Cindy Desktop 增加实验性的 TrueForge agent harness。主进程通过官方 `@truefoundry/trueforge-sdk` 连接用户自行运行的 TrueForge 服务，将 HTTP/SSE 事件翻译为 Maker 统一事件，并在新会话模型选择器中提供 TrueForge 入口。

### 变更类型

- [x] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：实验性 TrueForge harness 接入
- 本 PR 包含：SDK/HTTP+SSE adapter、事件与交互翻译、取消与恢复语义、会话/usage 持久化、桌面端入口和图标、配置与安全文档、单元/契约测试
- 明确不包含：SSH、device-link、mobile、scheduler、worktree、goals、Orca、动态 subagent、TrueForge 服务下载或进程托管
- 用户可见变化：配置 TrueForge 服务后，本地新会话的 agent/model 选择器会显示 TrueForge；不支持的工作区、协作、定时任务等入口会隐藏或拒绝
- 是否存在 breaking change：无

### UI 变化

新增模型选择器中的 TrueForge 选项/标识，并对 TrueForge 会话隐藏当前不支持的工作树、协作、Goals 与额外目录入口。未附截图：本地没有可用于手工联调的 TrueForge 服务和凭证。

- 引用的设计规范：`docs/design-rules/DESIGN.md` §4 Component Stylings / Select & Dropdown（复用既有 ModelSelector 行结构、间距、hover/selected token，不新造菜单样式）；§10 Light / Dark Dual-Mode Delivery Gate（图标使用 `currentColor`，沿用现有文本 token，覆盖双模式）。

## 怎么验证的

### 自动验证

```text
corepack pnpm --filter desktop run --if-present typecheck
结果：通过

corepack pnpm --filter @cindy/mcps build
结果：通过

TrueForge adapter / translator / host / Maker / persistence / session-create / search 定向 Vitest
结果：199/199 通过

桌面 UI 相关源码契约 Vitest
结果：714/714 通过

ThreadPickerInline Vitest
结果：2/2 通过

agentCapabilitiesDeviceCache Vitest
结果：26/26 通过

corepack pnpm check:dco
结果：通过，1 个 commit 均带 Signed-off-by
```

### 手工验证

不涉及：本地没有可用于端到端联调的 TrueForge 服务与 ID token；协议与 UI 边界由 mock SDK/HTTP/SSE 测试覆盖。

### 未执行的验证

- 未执行真实 TrueForge 服务 smoke test：缺少服务端环境与凭证。
- 完整 desktop Vitest 已执行但未全绿：51 项失败集中在测试库缺少既有 `sessions.codex_plan_json` 列，以及 Windows 符号链接/20 秒超时；TrueForge 定向与受影响测试均通过。
- 根目录 related suite 中 maker-core 的 7 项 Pi 真实二进制测试因当前 Windows/WSL 环境缺失路径/符号链接能力失败；其余相关工作区通过。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [x] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：只在 Desktop 主进程检测到完整 TrueForge 环境变量时注册实验性 agent；普通 Claude Code/Codex/Pi 路径与稳定 provider/model union 不变。外部端点强制 HTTPS，仅 loopback 允许 HTTP；ID token 只保留在主进程，错误与日志会脱敏，配置不完整时 fail closed。没有 SQLite migration，现有 `agent_kind` 文本列直接保存 `trueforge`。
- 协议兼容：基于 TrueForge SDK 0.1.3；该版本 SSE turn stream 不可恢复，流断开按终态错误处理并在文档中说明。404 恢复会清除旧 session id 后新建；取消无法确认时关闭当前 handle，避免迟到 cancel 影响下一轮。
- 跨平台差异：首期仅开放本地 Desktop 普通会话；SSH、device-link、mobile、scheduler 明确拒绝或过滤。
- 回滚 / 降级方式：取消 TrueForge 环境变量即可不注册该 agent；代码层可整体回退本 commit，不涉及数据迁移。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因