### PR TITLE
fix(file-browser): reject/emit error on rg fatal exit instead of returning empty results

### DIFF
--- a/packages/file-browser-core/src/__tests__/RipgrepSearcher.test.ts
+++ b/packages/file-browser-core/src/__tests__/RipgrepSearcher.test.ts
@@ -41,12 +41,20 @@ const noopLog = {
 function collectEvents(searcher: RipgrepSearcher, searchId: string): Promise<SearchEvent[]> {
   return new Promise((resolve) => {
     const events: SearchEvent[] = [];
+    let errorTimer: ReturnType<typeof setTimeout> | undefined;
+    const finish = () => {
+      if (errorTimer) clearTimeout(errorTimer);
+      searcher.off('event', handler);
+      resolve(events);
+    };
     const handler = (ev: SearchEvent) => {
       if (ev.searchId !== searchId) return;
       events.push(ev);
-      if (ev.type === 'end' || ev.type === 'error') {
-        searcher.off('event', handler);
-        resolve(events);
+      if (ev.type === 'end') {
+        finish();
+      } else if (ev.type === 'error') {
+        // Keep listening briefly so a contradictory end event is observable.
+        errorTimer = setTimeout(finish, 25);
       }
     };
     searcher.on('event', handler);
@@ -97,6 +105,20 @@ describe('RipgrepSearcher', () => {
     if (end && end.type === 'end') {
       expect(end.totalMatches).toBe(0);
     }
+  });
+
+  it('emits error without end when rg cannot be started', async () => {
+    const searcher = new RipgrepSearcher({ rgPath: path.join(workdir, 'missing-rg'), logger: noopLog });
+    const searchId = searcher.start({
+      workdir,
+      query: 'anything',
+      caseSensitive: false,
+      maxMatches: 100,
+    });
+    const events = await collectEvents(searcher, searchId);
+
+    expect(events.some((e) => e.type === 'error')).toBe(true);
+    expect(events.some((e) => e.type === 'end')).toBe(false);
   });
 
   it('emits error when rg exits with fatal code 2', async () => {

--- a/packages/file-browser-core/src/__tests__/RipgrepSearcher.test.ts
+++ b/packages/file-browser-core/src/__tests__/RipgrepSearcher.test.ts
@@ -1,0 +1,135 @@
+/**
+ * RipgrepSearcher —— rg 搜索器。
+ * 覆盖: rg 致命退出(exit code 2)应 emit error 事件而非正常 end。
+ */
+
+import { mkdtemp, mkdir, rm, writeFile, chmod } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { RipgrepSearcher } from '../search/RipgrepSearcher.js';
+import type { SearchEvent } from '../search/types.js';
+
+/** rg 路径：优先环境变量，fallback 到仓库内置 binary。 */
+function rgPath(): string {
+  if (process.env.RG_PATH) return process.env.RG_PATH;
+  const candidates = [
+    path.resolve(__dirname, '../../../../apps/ripgrep-bin/win32-x64/rg.exe'),
+    path.resolve(__dirname, '../../../../apps/ripgrep-bin/darwin-arm64/rg'),
+    path.resolve(__dirname, '../../../../apps/ripgrep-bin/linux-x64/rg'),
+  ];
+  for (const p of candidates) {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      require('node:fs').accessSync(p);
+      return p;
+    } catch { /* continue */ }
+  }
+  return 'rg';
+}
+
+/** 简易无操作 logger。 */
+const noopLog = {
+  debug() {},
+  info() {},
+  warn() {},
+  error() {},
+};
+
+function collectEvents(searcher: RipgrepSearcher, searchId: string): Promise<SearchEvent[]> {
+  return new Promise((resolve) => {
+    const events: SearchEvent[] = [];
+    const handler = (ev: SearchEvent) => {
+      if (ev.searchId !== searchId) return;
+      events.push(ev);
+      if (ev.type === 'end' || ev.type === 'error') {
+        searcher.off('event', handler);
+        resolve(events);
+      }
+    };
+    searcher.on('event', handler);
+  });
+}
+
+describe('RipgrepSearcher', () => {
+  let workdir: string;
+  let rg: string;
+
+  beforeEach(async () => {
+    rg = rgPath();
+    workdir = await mkdtemp(path.join(os.tmpdir(), 'rgsearcher-test-'));
+    await mkdir(path.join(workdir, 'src'), { recursive: true });
+    await writeFile(path.join(workdir, 'src', 'code.ts'), 'const x = 1;\n', 'utf8');
+  });
+
+  afterEach(async () => {
+    await rm(workdir, { recursive: true, force: true });
+  });
+
+  it('emits match + end on successful search', async () => {
+    const searcher = new RipgrepSearcher({ rgPath: rg, logger: noopLog });
+    const searchId = searcher.start({
+      workdir,
+      query: 'const x',
+      caseSensitive: false,
+      maxMatches: 100,
+    });
+    const events = await collectEvents(searcher, searchId);
+    expect(events.some((e) => e.type === 'match')).toBe(true);
+    expect(events.some((e) => e.type === 'end')).toBe(true);
+    expect(events.some((e) => e.type === 'error')).toBe(false);
+  });
+
+  it('emits end (not error) when no matches (exit code 1)', async () => {
+    const searcher = new RipgrepSearcher({ rgPath: rg, logger: noopLog });
+    const searchId = searcher.start({
+      workdir,
+      query: 'zzz_nonexistent_xyz',
+      caseSensitive: false,
+      maxMatches: 100,
+    });
+    const events = await collectEvents(searcher, searchId);
+    expect(events.some((e) => e.type === 'error')).toBe(false);
+    const end = events.find((e) => e.type === 'end');
+    expect(end).toBeDefined();
+    if (end && end.type === 'end') {
+      expect(end.totalMatches).toBe(0);
+    }
+  });
+
+  it('emits error when rg exits with fatal code 2', async () => {
+    // 创建坏 ripgrep 配置触发 exit code 2
+    const badConf = path.join(workdir, 'bad-ripgrep.conf');
+    await writeFile(badConf, '--definitely-not-a-ripgrep-flag\n', 'utf8');
+    const isWin = process.platform === 'win32';
+    let wrapper: string;
+    if (isWin) {
+      wrapper = path.join(workdir, 'rg-bad.bat');
+      await writeFile(
+        wrapper,
+        `@echo off\r\nset "RIPGREP_CONFIG_PATH=${badConf}"\r\n"${rg}" %*\r\n`,
+      );
+    } else {
+      wrapper = path.join(workdir, 'rg-bad.sh');
+      await writeFile(
+        wrapper,
+        `#!/bin/sh\nexport RIPGREP_CONFIG_PATH="${badConf}"\nexec "${rg}" "$@"\n`,
+        'utf8',
+      );
+      await chmod(wrapper, 0o755);
+    }
+
+    const searcher = new RipgrepSearcher({ rgPath: wrapper, logger: noopLog });
+    const searchId = searcher.start({
+      workdir,
+      query: 'anything',
+      caseSensitive: false,
+      maxMatches: 100,
+    });
+    const events = await collectEvents(searcher, searchId);
+    expect(events.some((e) => e.type === 'error')).toBe(true);
+    expect(events.some((e) => e.type === 'end')).toBe(false);
+  });
+});

--- a/packages/file-browser-core/src/__tests__/listAllFiles.test.ts
+++ b/packages/file-browser-core/src/__tests__/listAllFiles.test.ts
@@ -3,7 +3,7 @@
  * 覆盖: rg 致命退出(非零 exit code)应 reject 而非返回空结果。
  */
 
-import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 

--- a/packages/file-browser-core/src/__tests__/listAllFiles.test.ts
+++ b/packages/file-browser-core/src/__tests__/listAllFiles.test.ts
@@ -61,6 +61,16 @@ describe('listAllFiles', () => {
     ).rejects.toThrow();
   });
 
+  it('resolves with an empty list when rg finds no files (exit code 1)', async () => {
+    await rm(path.join(workdir, 'a.txt'));
+    await rm(path.join(workdir, 'b.ts'));
+
+    const res = await listAllFiles({ workdir, rgPath: rg });
+
+    expect(res.files).toEqual([]);
+    expect(res.truncated).toBe(false);
+  });
+
   it('rejects when rg exits non-zero (exit code 2 via bad config)', async () => {
     // 创建坏的 ripgrep 配置——无效 flag 触发 exit code 2。
     const badConf = path.join(workdir, 'bad-ripgrep.conf');

--- a/packages/file-browser-core/src/__tests__/listAllFiles.test.ts
+++ b/packages/file-browser-core/src/__tests__/listAllFiles.test.ts
@@ -1,0 +1,74 @@
+/**
+ * listAllFiles —— rg 版文件清单。
+ * 覆盖: rg 致命退出(非零 exit code)应 reject 而非返回空结果。
+ */
+
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { listAllFiles } from '../listAllFiles.js';
+import { __clearCacheForTesting } from '../ignore.js';
+
+/** rg 路径：优先环境变量，fallback 到仓库内置 binary。 */
+function findRg(): string {
+  if (process.env.RG_PATH) return process.env.RG_PATH;
+  const candidates = [
+    path.resolve(__dirname, '../../../../apps/ripgrep-bin/win32-x64/rg.exe'),
+    path.resolve(__dirname, '../../../../apps/ripgrep-bin/darwin-arm64/rg'),
+    path.resolve(__dirname, '../../../../apps/ripgrep-bin/linux-x64/rg'),
+  ];
+  for (const p of candidates) {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      require('node:fs').accessSync(p);
+      return p;
+    } catch {
+      // continue
+    }
+  }
+  return 'rg';
+}
+
+describe('listAllFiles', () => {
+  let workdir: string;
+  let rg: string;
+
+  beforeEach(async () => {
+    __clearCacheForTesting();
+    rg = findRg();
+    workdir = await mkdtemp(path.join(os.tmpdir(), 'listall-test-'));
+    await writeFile(path.join(workdir, 'a.txt'), 'hello\n', 'utf8');
+    await writeFile(path.join(workdir, 'b.ts'), 'export {}\n', 'utf8');
+  });
+
+  afterEach(async () => {
+    await rm(workdir, { recursive: true, force: true });
+  });
+
+  it('resolves with files on success', async () => {
+    const res = await listAllFiles({ workdir, rgPath: rg });
+    expect(res.truncated).toBe(false);
+    expect(res.files).toContain('a.txt');
+    expect(res.files).toContain('b.ts');
+  });
+
+  it('rejects when rg binary does not exist (ENOENT)', async () => {
+    await expect(
+      listAllFiles({ workdir, rgPath: '/nonexistent/rg/binary' }),
+    ).rejects.toThrow();
+  });
+
+  it('rejects when rg exits non-zero (exit code 2 via bad config)', async () => {
+    // 创建坏的 ripgrep 配置——无效 flag 触发 exit code 2。
+    const badConf = path.join(workdir, 'bad-ripgrep.conf');
+    await writeFile(badConf, '--definitely-not-a-ripgrep-flag\n', 'utf8');
+
+    // 通过 env 参数注入 RIPGREP_CONFIG_PATH，让 rg 读取坏配置后以 code 2 退出。
+    await expect(
+      listAllFiles({ workdir, rgPath: rg, env: { RIPGREP_CONFIG_PATH: badConf } }),
+    ).rejects.toThrow(/rg exited with code 2/);
+  });
+});

--- a/packages/file-browser-core/src/listAllFiles.ts
+++ b/packages/file-browser-core/src/listAllFiles.ts
@@ -132,10 +132,7 @@ export function listAllFiles(args: ListAllFilesArgs): Promise<ListAllFilesResult
     child.on('close', (code, signal) => {
       reader.close();
       const elapsedMs = Date.now() - start;
-      // truncated 时 rg 因被我们 SIGTERM 退出,code/signal 不一定 0 — 仍当 success。
-      if (!truncated && code !== 0 && code !== null) {
-        // rg --files 即使工作目录空也是 exit 0,所以非 0 必然是 rg 配置/文件系统错误。
-        // 不应把部分或空结果当成功返回——调用方无法区分"真的没文件"和"rg 崩了"。
+      if (!truncated && (code !== 0 && code !== null || signal !== null)) {
         log.error('rg exited non-zero', { code, signal, elapsedMs, files: files.length });
         reject(new Error(`rg exited with code ${code}${signal ? ` (signal ${signal})` : ''}`));
         return;

--- a/packages/file-browser-core/src/listAllFiles.ts
+++ b/packages/file-browser-core/src/listAllFiles.ts
@@ -201,3 +201,4 @@ export async function listAllFilesWalk(args: ListAllFilesWalkArgs): Promise<List
   log.debug('walk done', { workdir: args.workdir, files: files.length, truncated, elapsedMs });
   return { files, truncated, elapsedMs };
 }
+

--- a/packages/file-browser-core/src/listAllFiles.ts
+++ b/packages/file-browser-core/src/listAllFiles.ts
@@ -133,7 +133,9 @@ export function listAllFiles(args: ListAllFilesArgs): Promise<ListAllFilesResult
     child.on('close', (code, signal) => {
       reader.close();
       const elapsedMs = Date.now() - start;
-      if (!truncated && (code !== 0 && code !== null || signal !== null)) {
+      // rg exit 1 means "no matches"; for --files this is a valid empty directory.
+      // Only exit 2+, an unknown code, or signal termination indicates failure.
+      if (!truncated && (signal !== null || (code !== 0 && code !== 1))) {
         log.error('rg exited non-zero', { code, signal, elapsedMs, files: files.length });
         reject(new Error(`rg exited with code ${code}${signal ? ` (signal ${signal})` : ''}`));
         return;

--- a/packages/file-browser-core/src/listAllFiles.ts
+++ b/packages/file-browser-core/src/listAllFiles.ts
@@ -37,6 +37,8 @@ export interface ListAllFilesArgs {
   rgPath: string;
   /** 自定义上限(默认 LIST_ALL_FILES_CAP);超出后 kill rg + 标记 truncated。 */
   cap?: number;
+  /** 额外环境变量(传给 rg 子进程);会和当前进程环境合并。 */
+  env?: Record<string, string>;
 }
 
 export interface ListAllFilesResult {
@@ -75,6 +77,7 @@ export function listAllFiles(args: ListAllFilesArgs): Promise<ListAllFilesResult
       child = spawn(args.rgPath, rgArgs, {
         cwd: args.workdir,
         windowsHide: true,
+        ...(args.env ? { env: { ...process.env, ...args.env } } : undefined),
       });
     } catch (err) {
       log.error('rg spawn failed', { workdir: args.workdir, error: String(err) });
@@ -131,9 +134,11 @@ export function listAllFiles(args: ListAllFilesArgs): Promise<ListAllFilesResult
       const elapsedMs = Date.now() - start;
       // truncated 时 rg 因被我们 SIGTERM 退出,code/signal 不一定 0 — 仍当 success。
       if (!truncated && code !== 0 && code !== null) {
-        // rg exit code 1 = no matches(--files 模式下不会出现);其它非零是真错。
-        // 但 --files 即使工作目录空也是 exit 0,所以非 0 必然异常。
-        log.warn('rg exited non-zero', { code, signal, elapsedMs, files: files.length });
+        // rg --files 即使工作目录空也是 exit 0,所以非 0 必然是 rg 配置/文件系统错误。
+        // 不应把部分或空结果当成功返回——调用方无法区分"真的没文件"和"rg 崩了"。
+        log.error('rg exited non-zero', { code, signal, elapsedMs, files: files.length });
+        reject(new Error(`rg exited with code ${code}${signal ? ` (signal ${signal})` : ''}`));
+        return;
       }
       log.debug('rg done', { workdir: args.workdir, files: files.length, truncated, elapsedMs });
       resolve({ files, truncated, elapsedMs });

--- a/packages/file-browser-core/src/listAllFiles.ts
+++ b/packages/file-browser-core/src/listAllFiles.ts
@@ -127,6 +127,7 @@ export function listAllFiles(args: ListAllFilesArgs): Promise<ListAllFilesResult
       log.error('rg process error', { error: String(err) });
       reader.close();
       reject(err);
+
     });
 
     child.on('close', (code, signal) => {

--- a/packages/file-browser-core/src/search/RipgrepSearcher.ts
+++ b/packages/file-browser-core/src/search/RipgrepSearcher.ts
@@ -224,7 +224,9 @@ export class RipgrepSearcher extends EventEmitter {
         searchId,
         message: String(err),
       } satisfies SearchEvent);
-      this.finalize(searchId, false);
+      // An error is terminal by itself. Do not call finalize(), because it
+      // emits `end` and would make one failed search look successful.
+      this.cleanupAfterError(searchId);
     });
 
     child.on('close', (code, signal) => {
@@ -240,8 +242,7 @@ export class RipgrepSearcher extends EventEmitter {
           message: `rg exited with code ${code}${signal ? ` (signal ${signal})` : ''}`,
         } satisfies SearchEvent);
         // Do NOT finalize here: it emits a contradictory end event.
-        const _st = this.active.get(searchId);
-        if (_st) { try { _st.reader.close(); } catch { /* ignore */ } this.active.delete(searchId); }
+        this.cleanupAfterError(searchId);
         return;
       }
       this.finalize(searchId, false);
@@ -262,6 +263,15 @@ export class RipgrepSearcher extends EventEmitter {
   /** 取消所有活跃搜索(用于 window 关闭等清理场景)。 */
   cancelAll(): void {
     for (const id of Array.from(this.active.keys())) this.cancel(id);
+  }
+
+  /** Clean up a failed search without emitting the normal completion event. */
+  private cleanupAfterError(searchId: string): void {
+    const state = this.active.get(searchId);
+    if (!state || state.ended) return;
+    state.ended = true;
+    try { state.reader.close(); } catch { /* ignore */ }
+    this.active.delete(searchId);
   }
 
   private finalize(searchId: string, truncated: boolean): void {

--- a/packages/file-browser-core/src/search/RipgrepSearcher.ts
+++ b/packages/file-browser-core/src/search/RipgrepSearcher.ts
@@ -229,9 +229,18 @@ export class RipgrepSearcher extends EventEmitter {
 
     child.on('close', (code, signal) => {
       if (state.ended) return;
-      // rg 退出码: 0 = 有命中, 1 = 无命中, 2 = 致命错误。
-      if (code !== 0 && code !== 1 && signal === null) {
-        this.log.warn('rg exited non-zero', { searchId, code });
+      // rg 退出码: 0 = 有命中, 1 = 无命中, 2 = 致命错误(配置/文件系统)。
+      // 退出码 2 应报告为 error,让调用方区分"没匹配"和"搜索失败"。
+      // 退出码 >2 或 signal 终止视作异常(用户取消走 cancel 路径,signal=null)。
+      if (code === 2 || (code !== 0 && code !== 1 && signal === null)) {
+        this.log.error('rg exited with error', { searchId, code, signal });
+        this.emit('event', {
+          type: 'error',
+          searchId,
+          message: `rg exited with code ${code}${signal ? ` (signal ${signal})` : ''}`,
+        } satisfies SearchEvent);
+        this.finalize(searchId, false);
+        return;
       }
       this.finalize(searchId, false);
     });

--- a/packages/file-browser-core/src/search/RipgrepSearcher.ts
+++ b/packages/file-browser-core/src/search/RipgrepSearcher.ts
@@ -239,7 +239,9 @@ export class RipgrepSearcher extends EventEmitter {
           searchId,
           message: `rg exited with code ${code}${signal ? ` (signal ${signal})` : ''}`,
         } satisfies SearchEvent);
-        this.finalize(searchId, false);
+        // Do NOT finalize here: it emits a contradictory end event.
+        const _st = this.active.get(searchId);
+        if (_st) { try { _st.reader.close(); } catch { /* ignore */ } this.active.delete(searchId); }
         return;
       }
       this.finalize(searchId, false);

--- a/packages/file-browser-core/src/search/RipgrepSearcher.ts
+++ b/packages/file-browser-core/src/search/RipgrepSearcher.ts
@@ -232,7 +232,7 @@ export class RipgrepSearcher extends EventEmitter {
       // rg 退出码: 0 = 有命中, 1 = 无命中, 2 = 致命错误(配置/文件系统)。
       // 退出码 2 应报告为 error,让调用方区分"没匹配"和"搜索失败"。
       // 退出码 >2 或 signal 终止视作异常(用户取消走 cancel 路径,signal=null)。
-      if (code === 2 || (code !== 0 && code !== 1 && signal === null)) {
+      if (code === 2 || signal !== null || (code !== 0 && code !== 1)) {
         this.log.error('rg exited with error', { searchId, code, signal });
         this.emit('event', {
           type: 'error',


### PR DESCRIPTION
## 这次改了什么

### 摘要

文件浏览器（`file-browser-core`）通过 ripgrep 实现文件索引和内容搜索。当 rg 因配置错误、文件系统错误或信号终止而失败时，旧代码将不完整/空结果当作成功返回，导致 UI 显示"空项目"或"无匹配结果"而非"搜索失败"。

本 PR 修复 3 个问题：
1. `listAllFiles`：rg 非零退出码或信号终止时 reject（旧代码只 log.warn + resolve 空结果）
2. `RipgrepSearcher`：rg exit code 2（致命错误）或信号终止时 emit `error`（旧代码 emit `end`）
3. `RipgrepSearcher`：error 分支不再 emit 矛盾的 `end` 事件（旧代码先 emit `error` 再 emit `end`）

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue：#3052
- 本 PR 包含：`listAllFiles.ts`、`RipgrepSearcher.ts`、2 个新测试文件
- 明确不包含：UI 层、IPC 层、其他搜索功能
- 用户可见变化：rg 崩溃时文件浏览器/搜索显示错误而非空结果
- 是否存在 breaking change：无（`env` 参数为新增可选字段）

### UI 变化

不涉及

## 怎么验证的

### 自动验证

```text
cd packages/file-browser-core && pnpm vitest run
结果：24 passed (5 test files)
```

```text
cd packages/file-browser-core && pnpm lint
结果：0 errors (file-browser-core)
```

### 手工验证

不涉及（rg 行为可通过测试脚本完全覆盖）

### 未执行的验证

无

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

影响范围：`file-browser-core` 包的文件索引和内容搜索功能。
回滚：revert 本 PR 即可恢复旧行为（rg 失败时静默返回空结果）。