### PR TITLE
fix(pi): keep CINDY_PI_BASH_PACKAGE_HOME in env for bridge reloads

### DIFF
--- a/packages/maker-core/src/agents/pi/__tests__/cindyBridgeSource.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/cindyBridgeSource.test.ts
@@ -1599,4 +1599,20 @@ describe('cindy-bridge extension source', () => {
       ).toContain(sourcePath);
     },
   );
+
+
+  it('does not delete CINDY_PI_BASH_PACKAGE_HOME from process.env', () => {
+    // #3070: cindyBridge() must NOT delete the env var after reading it.
+    // When cindyBridge() is called again in the same process (hot reload,
+    // bridge rewrite), the var must still be available.
+    // See also: CINDY_PI_PACKAGE_MANAGEMENT_ENV is still deleted (defense in depth).
+    expect(CINDY_BRIDGE_EXTENSION_SOURCE).not.toContain(
+      'delete process.env[PI_BASH_PACKAGE_HOME_ENV]',
+    );
+    // Verify the other secret IS still deleted (as intended).
+    expect(CINDY_BRIDGE_EXTENSION_SOURCE).toContain(
+      'delete process.env[PI_PACKAGE_MANAGEMENT_ENV]',
+    );
+  });
+
 });


### PR DESCRIPTION
## 这次改了什么

删除 `cindy-bridge-source.ts` 中 `delete process.env[PI_BASH_PACKAGE_HOME_ENV]` 这一行。

**根因**：`cindyBridge()` 读取 `CINDY_PI_BASH_PACKAGE_HOME` 后立即从 `process.env` 删除。同一 Pi 进程中再次执行 `cindyBridge()`（bridge 热重载、源码重写后 reload）时，变量已不存在 → `bashPackageHome` 为 `undefined` → `isolatedBashEnvironment` 抛出 `Cindy isolated Pi package home is unavailable` → 所有本地 bash 永久失败。

**修法**：不删除 env var。变量已捕获在局部变量 `bashPackageHome` 中，child bash 隔离由 `isolatedBashEnvironment()` 通过 `withoutPiSecrets()` 从 child env 中移除，不依赖父进程 `process.env` 的 delete。

## 怎么验证的

- 新增测试：验证源码不含 `delete process.env[PI_BASH_PACKAGE_HOME_ENV]`，同时确认 `CINDY_PI_PACKAGE_MANAGEMENT_ENV` 仍被删除（defense in depth）
- maker-core 全量测试 10/10 通过

## 风险

低。删除的是一个不必要的 delete 操作。isolated bash 子进程仍通过 `withoutPiSecrets()` 获取干净 env，不会泄露 `CINDY_PI_BASH_PACKAGE_HOME` 给 LLM shell。注意：同进程的其他 Pi 扩展理论上可改写 `process.env` 中的该变量（这正是当初 delete 的防御动机），但这是极端场景，follow-up 可用 permission file 方案彻底解决。

---

@DavidShenXD 感谢详细 re-review！已处理：

1. ✅ **简化测试**：改为 `toContain`/`not.toContain` 检查源码，放在已有 `delete process.env[PI_PACKAGE_MANAGEMENT_ENV]` 测试旁边
2. ✅ **修正 commit message**：`Related to #3070`（不是 `Fixes`），因为 follow-up 还要做 permission file 快照
3. ✅ **修正风险评估**：承认同进程扩展可改写 `process.env` 的风险，标注为 follow-up

PR 已从 draft 转为 ready，测试 10/10 通过。请 re-review。