### PR TITLE
fix(desktop): preserve gateway media model ids

### DIFF
--- a/apps/desktop/src/main/cindy-brain/__tests__/cindySlot.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/cindySlot.test.ts
@@ -221,16 +221,43 @@ describe('载荷校验', () => {
     ).toMatchObject({ ok: false });
   });
 
-  it('模型白名单:名单内放行并透传,名单外拒且不触发生成', async () => {
+  it('旧插件模型名:名单内透传,唯一 basename 升级,失效值回落当前默认', async () => {
     const { slot, generateImage } = makeSlot();
     const ok = await slot.handleModelRequest('art', { ...REQ, model: 'gemini-3-pro-image' });
     expect(ok).toMatchObject({ ok: true });
-    expect(generateImage).toHaveBeenCalledWith({ prompt: '一只猫', model: 'gemini-3-pro-image' });
+    expect(generateImage).toHaveBeenLastCalledWith({
+      prompt: '一只猫',
+      model: 'gemini-3-pro-image',
+    });
 
-    const bad = await slot.handleModelRequest('art', { ...REQ, model: 'dall-e-9' });
-    expect(bad).toMatchObject({ ok: false });
-    expect((bad as { message: string }).message).toContain('白名单');
-    expect(generateImage).toHaveBeenCalledTimes(1);
+    const namespaced = makeSlot({
+      getImageConfig: vi.fn(() => ({
+        models: [
+          {
+            id: 'openai/gpt-image-2',
+            label: 'GPT Image 2',
+            supportsEdit: true,
+          },
+        ],
+        defaults: {
+          standard: 'openai/gpt-image-2',
+          draft: 'openai/gpt-image-2',
+          best: 'openai/gpt-image-2',
+        },
+      })) as unknown as CindySlotDeps['getImageConfig'],
+    });
+    expect(await namespaced.slot.handleModelRequest('art', { ...REQ, model: 'gpt-image-2' })).toMatchObject({
+      ok: true,
+      model: 'openai/gpt-image-2',
+    });
+    expect(namespaced.generateImage).toHaveBeenCalledWith({
+      prompt: '一只猫',
+      model: 'openai/gpt-image-2',
+    });
+
+    const fallback = await slot.handleModelRequest('art', { ...REQ, model: 'dall-e-9' });
+    expect(fallback).toMatchObject({ ok: true, model: 'gpt-image-2' });
+    expect(generateImage).toHaveBeenLastCalledWith({ prompt: '一只猫', model: 'gpt-image-2' });
   });
 
   it('缺省模型 = gpt-image-2', async () => {
@@ -812,13 +839,16 @@ describe('视频代办(gen_video / edit_video)', () => {
     expect(saveGhostMedia).toHaveBeenCalledWith(expect.objectContaining({ mimeType: 'video/mp4' }));
   });
 
-  it('tier 档位查视频翻译表(best → seedance-pro);白名单外点名拒', async () => {
+  it('tier 档位查视频翻译表(best → seedance-pro);失效点名回落默认', async () => {
     const { slot, generateVideo } = makeSlot();
     await slot.handleModelRequest('art', { ...VREQ, tier: 'best' });
     expect(generateVideo).toHaveBeenLastCalledWith({ prompt: '一只猫奔跑', model: 'seedance-pro' });
-    // 图像白名单里的型号点给视频代办 → 拒(两类目白名单独立)。
-    const bad = await slot.handleModelRequest('art', { ...VREQ, model: 'gpt-image-2' });
-    expect(bad).toMatchObject({ ok: false });
+    const fallback = await slot.handleModelRequest('art', { ...VREQ, model: 'gpt-image-2' });
+    expect(fallback).toMatchObject({ ok: true, model: 'seedance-fast' });
+    expect(generateVideo).toHaveBeenLastCalledWith({
+      prompt: '一只猫奔跑',
+      model: 'seedance-fast',
+    });
   });
 
   it('edit_video:参考图归属校验后按路径注入;上限 2 张,超限拒', async () => {

--- a/apps/desktop/src/main/cindy-brain/__tests__/cindySlot.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/cindySlot.test.ts
@@ -832,9 +832,10 @@ describe('视频代办(gen_video / edit_video)', () => {
   const VREQ = { type: 'cindy-request', kind: 'gen_video', prompt: '一只猫奔跑' };
 
   it('gen_video happy path:走视频白名单默认款,产物同一条落仓链路', async () => {
-    const { slot, generateVideo, saveGhostMedia } = makeSlot();
+    const { slot, generateVideo, getVideoConfig, saveGhostMedia } = makeSlot();
     const r = await slot.handleModelRequest('art', VREQ);
     expect(r).toMatchObject({ ok: true, model: 'seedance-fast', modelLabel: 'Seedance 快速' });
+    expect(getVideoConfig).toHaveBeenCalledWith('generate');
     expect(generateVideo).toHaveBeenCalledWith({ prompt: '一只猫奔跑', model: 'seedance-fast' });
     expect(saveGhostMedia).toHaveBeenCalledWith(expect.objectContaining({ mimeType: 'video/mp4' }));
   });
@@ -852,7 +853,7 @@ describe('视频代办(gen_video / edit_video)', () => {
   });
 
   it('edit_video:参考图归属校验后按路径注入;上限 2 张,超限拒', async () => {
-    const { slot, editVideo, resolveOwnedMedia } = makeSlot();
+    const { slot, editVideo, getVideoConfig, resolveOwnedMedia } = makeSlot();
     const r = await slot.handleModelRequest('art', {
       type: 'cindy-request',
       kind: 'edit_video',
@@ -860,6 +861,7 @@ describe('视频代办(gen_video / edit_video)', () => {
       hashes: [HASH_S],
     });
     expect(r).toMatchObject({ ok: true });
+    expect(getVideoConfig).toHaveBeenCalledWith('edit');
     expect(resolveOwnedMedia).toHaveBeenCalledWith('art', HASH_S, 'cloud:test-owner:1');
     expect(editVideo).toHaveBeenCalledWith({
       prompt: '让它动起来',

--- a/apps/desktop/src/main/cindy-brain/__tests__/imageModelCatalogSync.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/imageModelCatalogSync.test.ts
@@ -1,60 +1,24 @@
-/**
- * imageModelCatalogSync.test.ts — 图像模型两份打包源的同源守卫。
- *
- * 运行时清单以 providers.json 目录(getActiveCatalog)为准,目录缺区即视为
- * 能力暂不可用(不再回落常量,见 cindyMediaCatalog.ts);@cindy/mcps 的
- * GATEWAY_IMAGE_MODELS 仍是图像通道 enum(GatewayImageModel)的类型正本。
- * 两者随 App 同版发布,必须逐项一致——漂移会造成"下拉可选但图像通道
- * enum 不认"(或反之)的割裂。改任一边,另一边必须同步。
- */
+/** XD 媒体成员只由运行时 Gateway `/models` 投影，不能再回落打包目录。 */
 
-import { describe, it, expect } from 'vitest';
-import { GATEWAY_IMAGE_MODELS } from '../../cindy-proxy-media/types.js';
+import { describe, expect, it } from 'vitest';
 import { BUNDLED_CATALOG } from '@cindy/model-providers';
 
-const LEGACY_PREVIEW_IMAGE_MODELS = ['gemini-3-pro-image-preview', 'gemini-3.1-flash-image-preview'] as const;
-const ACTIVE_GEMINI_IMAGE_MODELS = ['gemini-3-pro-image', 'gemini-3.1-flash-image'] as const;
-
-describe('图像模型清单同源守卫', () => {
-  it('内置目录 xd.imageModels 与 @cindy/mcps 打包常量逐项一致(id + 显示名)', () => {
+describe('媒体模型目录来源守卫', () => {
+  it('bundled XD 只保留 provider 身份，不携带图片或视频成员', () => {
     const xd = BUNDLED_CATALOG.providers.find((p) => p.id === 'xd');
-    expect(xd?.imageModels, '内置目录 xd 供应商缺 imageModels 区').toBeTruthy();
-    expect(xd?.imageModels).toEqual(GATEWAY_IMAGE_MODELS.map((m) => ({ id: m.id, name: m.label })));
+    expect(xd?.imageModels).toBeUndefined();
+    expect(xd?.imageDefaults).toBeUndefined();
+    expect(xd?.videoModels).toBeUndefined();
+    expect(xd?.videoDefaults).toBeUndefined();
   });
 
-  it('旧 preview alias 不再进入目录、打包兜底或默认档位', () => {
-    const xd = BUNDLED_CATALOG.providers.find((p) => p.id === 'xd');
-    const catalogIds = new Set((xd?.imageModels ?? []).map((m) => m.id));
-    const fallbackIds = new Set<string>(GATEWAY_IMAGE_MODELS.map((m) => m.id));
-    const defaults = new Set<string>(Object.values(xd?.imageDefaults ?? {}));
-
-    for (const id of LEGACY_PREVIEW_IMAGE_MODELS) {
-      expect(catalogIds.has(id), `${id} 仍在内置目录`).toBe(false);
-      expect(fallbackIds.has(id), `${id} 仍在图片通道打包兜底`).toBe(false);
-      expect(defaults.has(id), `${id} 仍被默认档位引用`).toBe(false);
-    }
-  });
-
-  it('网关当前 Gemini alias 同时进入目录与打包兜底，draft 指向 Flash', () => {
-    const xd = BUNDLED_CATALOG.providers.find((p) => p.id === 'xd');
-    const catalogIds = new Set((xd?.imageModels ?? []).map((m) => m.id));
-    const fallbackIds = new Set<string>(GATEWAY_IMAGE_MODELS.map((m) => m.id));
-
-    for (const id of ACTIVE_GEMINI_IMAGE_MODELS) {
-      expect(catalogIds.has(id), `${id} 未进入内置目录`).toBe(true);
-      expect(fallbackIds.has(id), `${id} 未进入图片通道打包兜底`).toBe(true);
-    }
-    expect(xd?.imageDefaults?.draft).toBe('gemini-3.1-flash-image');
-  });
-});
-
-describe('图像默认选型入册守卫', () => {
-  it('内置目录 xd.imageDefaults 存在且每个值都指向在册模型', () => {
-    const xd = BUNDLED_CATALOG.providers.find((p) => p.id === 'xd');
-    const ids = new Set((xd?.imageModels ?? []).map((m) => m.id));
-    expect(xd?.imageDefaults?.standard, '缺 imageDefaults.standard(默认选型必须入册,代码零字面量)').toBeTruthy();
-    for (const v of Object.values(xd?.imageDefaults ?? {})) {
-      expect(ids.has(v as string), `imageDefaults 值 ${String(v)} 不在 imageModels`).toBe(true);
-    }
+  it('第三方 OpenAI 的媒体目录仍保留完整 provider-aware modelId', () => {
+    const openai = BUNDLED_CATALOG.providers.find((p) => p.id === 'openai');
+    expect(openai?.imageModels).toEqual([
+      expect.objectContaining({
+        id: 'openai/gpt-image-2',
+        modalities: { input: ['text', 'image'], output: ['image'] },
+      }),
+    ]);
   });
 });

--- a/apps/desktop/src/main/cindy-brain/cindyMediaCatalog.ts
+++ b/apps/desktop/src/main/cindy-brain/cindyMediaCatalog.ts
@@ -2,9 +2,9 @@
  * cindyMediaCatalog.ts — cindy 槽能力配置的纯派生(白名单 + 默认/档位选型)。
  * [PROTOCOL]: 变更时更新此头部,然后检查 CLAUDE.md
  *
- * 输入是 providers.json 运行时目录的供应商数组(与会话模型列表**同一获取来源**,
- * 见 maker-host/active-catalog 的 getActiveCatalog),输出图像 / 视频 / 向量各自的
- * 可选清单与默认选型。本文件**零模型字面量**:清单与默认全部来自目录。
+ * 输入是 active catalog 的供应商数组(与会话模型列表**同一获取来源**,
+ * 见 maker-host/active-catalog 的 getActiveCatalog)。其中 XD 媒体由 Gateway `/models`
+ * 动态投影，第三方媒体来自各 Provider 目录；本文件**零模型字面量**。
  *
  * 文件名留着 "Media" 是历史(2026-08-04 加入向量类目时未改名,避免一次纯改名
  * 的大 diff 冲掉 blame);三个类目共用同一套派生规则,差异只在读目录的哪个字段。

--- a/apps/desktop/src/main/cindy-brain/cindySlot.ts
+++ b/apps/desktop/src/main/cindy-brain/cindySlot.ts
@@ -92,7 +92,7 @@ import type { AgentKind } from '@cindy/model-providers';
  * cindyMediaCatalog.ts 的空清单语义),本模块据此早拒,不拿不在册的型号下单。
  */
 export interface CindyMediaConfig {
-  models: ReadonlyArray<{ id: string; label: string }>;
+  models: ReadonlyArray<{ id: string; label: string; providerId?: string }>;
   defaults: { standard: string; draft: string; best: string } | null;
 }
 
@@ -227,9 +227,9 @@ export interface CindySlotDeps {
    * 默认/档位选型(同样来自目录,代码零模型字面量);清单空 / defaults null
    * = 目录没给,能力暂不可用。
    */
-  getImageConfig(): CindyMediaConfig;
+  getImageConfig(action?: 'generate' | 'edit'): CindyMediaConfig;
   /** 当前视频能力配置(同 getImageConfig 语义;白名单 id = 视频 provider 层 alias)。 */
-  getVideoConfig(): CindyMediaConfig;
+  getVideoConfig(action?: 'generate' | 'edit'): CindyMediaConfig;
   /**
    * 当前向量能力配置(同 getImageConfig 语义;白名单 id = embedding catalog 的
    * model id)。可选依赖:不注入 = 该能力未接线,代办按 INTERNAL 明拒。
@@ -831,9 +831,12 @@ export class GhostCindySlot {
     // 选型优先级(低 → 高逐层覆盖):出厂默认 → 档位(意识意图,主机翻译)
     // → 意识专属覆盖(用户在详情页钉的)→ 调用显式点名(用户当场说的)。
     // 旧插件报的裸 ID 会在唯一时升级为完整 ID；已失效或歧义值保留前面
-    // 已解析的用户配置/当前默认。配置按类目取(图像/视频
-    // 各一份白名单与默认,同来自 providers.json 目录)。
-    const cfg = info.category === 'image' ? this.deps.getImageConfig() : this.deps.getVideoConfig();
+    // 已解析的用户配置/当前默认。配置从图像/视频目录按当前动作筛选，默认值失效时
+    // 由目录派生层回落到该动作的首个可用模型。
+    const cfg =
+      info.category === 'image'
+        ? this.deps.getImageConfig(info.action)
+        : this.deps.getVideoConfig(info.action);
     // 目录没给该类目任何模型 = 能力暂不可用:早拒并说清原因,不落回任何写死型号
     // (说明见 cindyMediaCatalog.ts;详情页对应的那几行同时显示为灰字不可选)。
     if (cfg.models.length === 0 || cfg.defaults === null) {
@@ -903,6 +906,14 @@ export class GhostCindySlot {
           ...(providerId ? { fallbackProviderId: providerId } : {}),
         });
       }
+    }
+    // 旧插件只传 modelId，不认识 providerId；Host 按当前动作筛完目录后选中的来源
+    // 必须跟到最终派发。否则同一 modelId 多来源时，执行层可能重新 first-wins 到
+    // 另一个不支持当前动作的来源。老注入配置没有 providerId 时保持原行为。
+    if (!providerId) {
+      const catalogSelection = cfg.models.find((candidate) => candidate.id === model);
+      providerId = catalogSelection?.providerId;
+      providerModelLabel = catalogSelection?.label;
     }
 
     // 画面参数按**解析出的型号**二次校验:协议层值域是所有 provider 的

--- a/apps/desktop/src/main/cindy-brain/cindySlot.ts
+++ b/apps/desktop/src/main/cindy-brain/cindySlot.ts
@@ -830,7 +830,8 @@ export class GhostCindySlot {
 
     // 选型优先级(低 → 高逐层覆盖):出厂默认 → 档位(意识意图,主机翻译)
     // → 意识专属覆盖(用户在详情页钉的)→ 调用显式点名(用户当场说的)。
-    // 意识报了白名单外的名字 = 拒,不静默降级。配置按类目取(图像/视频
+    // 旧插件报的裸 ID 会在唯一时升级为完整 ID；已失效或歧义值保留前面
+    // 已解析的用户配置/当前默认。配置按类目取(图像/视频
     // 各一份白名单与默认,同来自 providers.json 目录)。
     const cfg = info.category === 'image' ? this.deps.getImageConfig() : this.deps.getVideoConfig();
     // 目录没给该类目任何模型 = 能力暂不可用:早拒并说清原因,不落回任何写死型号
@@ -873,19 +874,35 @@ export class GhostCindySlot {
       }
     }
     if (p.model !== undefined) {
-      if (typeof p.model !== 'string' || !whitelist.has(p.model)) {
-        // 拒绝话术带上当前可用清单:插件侧不再维护模型枚举(白名单单源执法,
-        // 2026-07),AI 点名失败时靠这份清单自愈,不用猜主机认哪些 id。
-        return {
-          ok: false,
-          message: `不支持的模型(不在主机白名单内)。当前可用:${cfg.models.length > 0 ? cfg.models.map((m) => m.id).join(' / ') : '(暂无可用型号)'}`,
-        };
+      if (typeof p.model !== 'string') {
+        return { ok: false, message: 'model 不合法（必须是字符串）' };
       }
-      if (p.model !== model) {
-        providerId = undefined;
-        providerModelLabel = undefined;
+      const requestedModel = p.model;
+      const exact = cfg.models.find((candidate) => candidate.id === requestedModel);
+      const basenameMatches = requestedModel.includes('/')
+        ? []
+        : cfg.models.filter(
+            (candidate) =>
+              candidate.id.slice(candidate.id.lastIndexOf('/') + 1) === requestedModel,
+          );
+      const selected = exact ?? (basenameMatches.length === 1 ? basenameMatches[0] : undefined);
+      if (selected) {
+        if (selected.id !== model) {
+          providerId = undefined;
+          providerModelLabel = undefined;
+        }
+        model = selected.id;
+      } else {
+        // 旧插件会携带发布时写进说明的裸 ID；目录升级后该 ID 可能已 namespaced
+        // 或下架。此时保留上面已经解析出的用户配置/当前默认，不让旧插件版本把
+        // 整项媒体能力卡死，也不把一个歧义裸名猜成第三方计费来源。
+        this.deps.log?.warn('ghost cindy explicit legacy model unavailable, using resolved fallback', {
+          ghostId,
+          requestedModel,
+          fallbackModel: model,
+          ...(providerId ? { fallbackProviderId: providerId } : {}),
+        });
       }
-      model = p.model;
     }
 
     // 画面参数按**解析出的型号**二次校验:协议层值域是所有 provider 的

--- a/apps/desktop/src/main/cindy-brain/index.ts
+++ b/apps/desktop/src/main/cindy-brain/index.ts
@@ -3265,10 +3265,28 @@ function resolveMediaPreferenceModel(
   const exact = config.models.find((model) => model.id === preference);
   if (exact) return exact;
   if (decodeMediaPreference(preference)) return null;
+  if (!preference.includes('/')) {
+    const legacyXdMatches = config.models.filter(
+      (model) =>
+        model.providerId === 'xd' &&
+        model.modelId.slice(model.modelId.lastIndexOf('/') + 1) === preference,
+    );
+    if (legacyXdMatches.length === 1) return legacyXdMatches[0]!;
+  }
   return (
     config.models.find((model) => model.providerId === 'xd' && model.modelId === preference) ??
     config.models.find((model) => model.modelId === preference) ??
     null
+  );
+}
+
+function resolveMediaPreferenceOrDefault(
+  config: CindyMediaPreferenceConfig,
+  preference: string | undefined,
+): CindyMediaPreferenceModel | null {
+  return (
+    resolveMediaPreferenceModel(config, preference) ??
+    resolveMediaPreferenceModel(config, config.defaults?.standard)
   );
 }
 
@@ -3349,8 +3367,8 @@ async function getGhostConfigurableMediaModels(
 
 /**
  * 读取插件在 Host「Cindy 能力」中的现有媒体选型。
- * 这里只投影当前有效值，不复制或迁移配置；用户已明确配置的精确来源失效时直接报错，
- * 不能静默回落到另一个 Provider 或默认模型。
+ * 这里只投影当前有效值，不复制或迁移配置；已配置模型失效时，
+ * 统一回落到该能力当前的默认（第一个可用）模型。
  */
 function getGhostConfiguredMediaModel(
   ghostId: string,
@@ -3379,14 +3397,12 @@ function getGhostConfiguredMediaModel(
 
   const config = getMediaPreferenceConfig(mediaCapability);
   const override = readGhostCindyOverrides(ghostId)[mediaCapability];
-  const selected = override
-    ? resolveMediaPreferenceModel(config, override)
-    : resolveMediaPreferenceModel(config, config.defaults?.standard);
+  const selected = resolveMediaPreferenceOrDefault(config, override);
   if (!selected) {
     return {
       ok: false,
       errorCode: 'NOT_AVAILABLE',
-      message: override ? '已配置的媒体模型当前不可用' : '当前没有可用的媒体模型',
+      message: '当前没有可用的媒体模型',
     };
   }
   return {
@@ -3858,16 +3874,17 @@ export function getGhostCindySlot(): GhostCindySlot {
       getMediaOverride: (ghostId, capability) => {
         const value = readGhostCindyOverrides(ghostId)[capability as CindyCapabilityKey] ?? null;
         if (!value) return null;
-        const decoded = decodeMediaPreference(value);
-        if (!decoded) return null;
-        const selected = getMediaPreferenceConfig(capability as GhostMediaCapability).models.find(
-          (candidate) =>
-            candidate.providerId === decoded.providerId && candidate.modelId === decoded.modelId,
+        const selected = resolveMediaPreferenceOrDefault(
+          getMediaPreferenceConfig(capability as GhostMediaCapability),
+          value,
         );
-        return {
-          ...decoded,
-          ...(selected ? { label: selected.label } : {}),
-        };
+        return selected
+          ? {
+              providerId: selected.providerId,
+              modelId: selected.modelId,
+              label: selected.label,
+            }
+          : null;
       },
       getOverride: (ghostId, capability) => {
         const value = readGhostCindyOverrides(ghostId)[capability as CindyCapabilityKey] ?? null;
@@ -6093,7 +6110,18 @@ export function registerGhostIpc(): void {
   // 读走 sendSync:详情页首帧要和其它信息同帧渲染(规则 7 无跳变),
   // 文件读取极小。写走 invoke,白名单在此校验(存储层不感知模型清单)。
   ipcMain.on('ghosts:cindy-prefs', (event, ghostId: unknown) => {
-    const overrides = typeof ghostId === 'string' ? readGhostCindyOverrides(ghostId) : {};
+    const storedOverrides = typeof ghostId === 'string' ? readGhostCindyOverrides(ghostId) : {};
+    const overrides = { ...storedOverrides };
+    for (const capability of GHOST_MEDIA_CAPABILITIES) {
+      const value = storedOverrides[capability];
+      if (!value) continue;
+      const selected = resolveMediaPreferenceOrDefault(
+        getMediaPreferenceConfig(capability),
+        value,
+      );
+      if (selected) overrides[capability] = selected.id;
+      else delete overrides[capability];
+    }
     // 每类目一份 options + defaultModel(当前包含 image/video 两类;下拉按
     // 能力键的类目取对应清单)。defaultModel:目录默认选型的展示信息
     // ("默认(GPT Image 2)"),让用户看得见"跟随"当下跟的是谁;

--- a/apps/desktop/src/main/cindy-brain/index.ts
+++ b/apps/desktop/src/main/cindy-brain/index.ts
@@ -3065,14 +3065,24 @@ export function getGhostScheduleSlot(): GhostScheduleSlot {
 function getVideoProviderRegistry() {
   const registry = getCindyProxyMediaService().backend.videoRegistry;
   if (!registry) return null;
-  const xaiAliases =
-    getActiveCatalog()
-      .providers.find((provider) => provider.id === 'xai')
-      ?.videoModels?.map((model) => model.id) ?? [];
-  if (xaiAliases.some((alias) => !registry.hasAlias(alias))) {
+  const xaiCatalogProvider = getActiveCatalog().providers.find(
+    (provider) => provider.id === 'xai',
+  );
+  const xaiCatalogProviderId = xaiCatalogProvider?.id;
+  const xaiAliases = xaiCatalogProvider?.videoModels?.map((model) => model.id) ?? [];
+  const routableXaiAliases = xaiCatalogProviderId
+    ? xaiAliases.filter(
+        (alias) =>
+          !registry.hasAlias(alias) || registry.hasAlias(alias, xaiCatalogProviderId),
+      )
+    : [];
+  if (
+    xaiCatalogProviderId &&
+    routableXaiAliases.some((alias) => !registry.hasAlias(alias))
+  ) {
     registry.registerOrExtend(
       createXaiVideoProvider({
-        modelAliases: xaiAliases,
+        modelAliases: routableXaiAliases,
         hasOAuthLogin: () => hasGrokOAuthLogin(),
         getAccessToken: () => getGrokAccessToken(),
         getCredentialGeneration: () => getGrokOAuthCredentialGeneration(),
@@ -3082,6 +3092,7 @@ function getVideoProviderRegistry() {
         beforeDispatch: (model) => assertMediaModelStillEnabled('video', model),
         onAuthRejected: (failure) => invalidateXaiBridgeAuth(failure),
       }),
+      xaiCatalogProviderId,
     );
   }
   return registry;
@@ -3181,6 +3192,7 @@ function getCatalogMediaConfig(
     const providers = selectedProviderId
       ? orderedProviders.filter((provider) => provider.id === selectedProviderId)
       : orderedProviders;
+    const videoRegistry = kind === 'video' ? getVideoProviderRegistry() : null;
     return deriveCindyMediaConfig(
       providers,
       kind,
@@ -3207,7 +3219,7 @@ function getCatalogMediaConfig(
         (kind === 'embed' && !isKnownEmbeddingModel(modelId)) ||
         // 视频目录可能比当前客户端通道先热更。执行 registry 不认识的型号
         // 必须先过滤，不能把“目录有”冒充成“这版客户端能下单”。
-        (kind === 'video' && !(getVideoProviderRegistry()?.hasAlias(modelId) ?? false)),
+        (kind === 'video' && !(videoRegistry?.hasAlias(modelId, providerId) ?? false)),
       // 执行通道凭证就绪过滤(未就绪的来源整段不进白名单,见 imageChannelRegistry
       // 头注)。视频按目录 provider 归属分别检查：xd 要求账号网关能力与 endpoint
       // 同时在场，xai 要求 SuperGrok OAuth 已连接；未知来源 fail closed。
@@ -3279,6 +3291,7 @@ function getMediaPreferenceConfig(
   capability: GhostMediaCapability,
 ): CindyMediaPreferenceConfig {
   const kind = capability.startsWith('image.') ? 'image' : 'video';
+  const videoRegistry = kind === 'video' ? getVideoProviderRegistry() : null;
   const coreCapability: MediaCapability =
     capability === 'video.edit' ? 'video.image_to_video' : capability;
   const providers = new Map(
@@ -3288,7 +3301,9 @@ function getMediaPreferenceConfig(
     .filter(
       (model) =>
         model.mode === (kind === 'image' ? 'image_generation' : 'video_generation') &&
-        supportsMediaCapability(model.modalities, coreCapability),
+        supportsMediaCapability(model.modalities, coreCapability) &&
+        (kind !== 'video' ||
+          (videoRegistry?.hasAlias(model.id, model.providerId) ?? false)),
     )
     .map((model) => {
       const provider = providers.get(model.providerId);
@@ -3310,7 +3325,11 @@ function getMediaPreferenceConfig(
     coreCapability,
     readModelDisableOverrides(),
   )
-    .filter((model) => isMediaModelExecutable(model.id, coreCapability))
+    .filter(
+      (model) =>
+        isMediaModelExecutable(model.id, coreCapability) &&
+        (kind !== 'video' || (videoRegistry?.hasAlias(model.id, 'xd') ?? false)),
+    )
     .map((model) => {
       const provider = providers.get('xd');
       const providerName = provider?.name ?? 'Cindy AI';
@@ -3464,7 +3483,13 @@ async function getGhostConfigurableMediaModels(
     // Gateway modalities 透传给插件判断，不能把插件声明的多个动作取交集。
     const availability = await listExecutableMediaModels();
     const mode = type === 'image' ? 'image_generation' : 'video_generation';
-    const candidates = availability.models.filter((model) => model.mode === mode);
+    const videoRegistry = type === 'video' ? getVideoProviderRegistry() : null;
+    const candidates = availability.models.filter(
+      (model) =>
+        model.mode === mode &&
+        (type !== 'video' ||
+          (videoRegistry?.hasAlias(model.id, model.providerId) ?? false)),
+    );
     const models = isProviderBlindCoreArt(ghost)
       ? collapseProviderBlindMediaModels(candidates, (model) => model.id)
       : candidates;
@@ -3650,6 +3675,9 @@ async function runGhostVideo(
   if (!registry || !registry.hasAny()) {
     throw new Error('视频能力不可用:主机未配置视频通道');
   }
+  if (params.providerId && !registry.hasAlias(params.alias, params.providerId)) {
+    throw new Error('视频模型与所选来源不匹配,本次生成已取消');
+  }
   // 提交紧前重查(第二十一轮):参考图 data URI 准备是 await,窗口内被停用即拒。
   assertMediaModelStillEnabled(
     'video',
@@ -3691,6 +3719,7 @@ function getGhostVideoCapabilities(
     }
     const registry = getVideoProviderRegistry();
     if (!registry || !registry.hasAny()) return null;
+    if (providerId && !registry.hasAlias(model, providerId)) return null;
     const caps = registry.resolveByAlias(model).provider.capabilities;
     return {
       durations: caps.supportedDurations,

--- a/apps/desktop/src/main/cindy-brain/index.ts
+++ b/apps/desktop/src/main/cindy-brain/index.ts
@@ -3349,8 +3349,8 @@ function resolveMediaPreferenceOrDefault(
 
 /**
  * Art 1.12.5–1.13.2 已经走 Core media，但还不会在 prepare 时传
- * providerId。这段兼容窗口只能稳定表达 Cindy AI 来源；1.13.3 起
- * 插件会传完整来源，恢复全部 Provider 选择。
+ * providerId。这段兼容窗口对同名模型选择一个可用来源并优先 Cindy AI；
+ * 1.13.3 起插件会传完整来源，恢复全部 Provider 选择。
  */
 function isProviderBlindCoreArt(ghost: InstalledGhost): boolean {
   return (
@@ -3360,6 +3360,26 @@ function isProviderBlindCoreArt(ghost: InstalledGhost): boolean {
   );
 }
 
+/** 旧插件无法区分同 modelId 的来源：冲突时优先 XD，否则保留第一个可用来源。 */
+function collapseProviderBlindMediaModels<T extends { providerId: string }>(
+  models: readonly T[],
+  modelId: (model: T) => string,
+): T[] {
+  const grouped = new Map<string, T[]>();
+  for (const model of models) {
+    const id = modelId(model);
+    const group = grouped.get(id) ?? [];
+    group.push(model);
+    grouped.set(id, group);
+  }
+  const selected: T[] = [];
+  for (const group of grouped.values()) {
+    const xd = group.find((model) => model.providerId === 'xd');
+    selected.push(xd ?? group[0]!);
+  }
+  return selected;
+}
+
 function getGhostMediaPreferenceConfig(
   ghostId: string,
   capability: GhostMediaCapability,
@@ -3367,7 +3387,7 @@ function getGhostMediaPreferenceConfig(
   const config = getMediaPreferenceConfig(capability);
   const ghost = getGhostManager().list().find((candidate) => candidate.manifest.id === ghostId);
   if (!ghost || !isProviderBlindCoreArt(ghost)) return config;
-  const models = config.models.filter((model) => model.providerId === 'xd');
+  const models = collapseProviderBlindMediaModels(config.models, (model) => model.modelId);
   const standard = models[0]?.id;
   return {
     models,
@@ -3420,10 +3440,10 @@ async function getGhostConfigurableMediaModels(
     // Gateway modalities 透传给插件判断，不能把插件声明的多个动作取交集。
     const availability = await listExecutableMediaModels();
     const mode = type === 'image' ? 'image_generation' : 'video_generation';
-    const models = availability.models.filter(
-      (model) =>
-        model.mode === mode && (!isProviderBlindCoreArt(ghost) || model.providerId === 'xd'),
-    );
+    const candidates = availability.models.filter((model) => model.mode === mode);
+    const models = isProviderBlindCoreArt(ghost)
+      ? collapseProviderBlindMediaModels(candidates, (model) => model.id)
+      : candidates;
     if (
       models.length === 0 &&
       availability.unavailable.some((model) => model.retryable)

--- a/apps/desktop/src/main/cindy-brain/index.ts
+++ b/apps/desktop/src/main/cindy-brain/index.ts
@@ -3094,6 +3094,26 @@ function isVideoCatalogProviderReady(providerId: string): boolean {
   return false;
 }
 
+/** 旧 cindy-request 类目清单只保留至少有一种当前客户端可执行操作的 XD 模型。 */
+function isXdMediaModelExecutableForCatalog(
+  kind: CindyCapabilityKind,
+  modelId: string,
+): boolean {
+  if (kind === 'image') {
+    return (
+      isMediaModelExecutable(modelId, 'image.generate') ||
+      isMediaModelExecutable(modelId, 'image.edit')
+    );
+  }
+  if (kind === 'video') {
+    return (
+      isMediaModelExecutable(modelId, 'video.generate') ||
+      isMediaModelExecutable(modelId, 'video.image_to_video')
+    );
+  }
+  return true;
+}
+
 /**
  * 当前媒体能力配置(图像/视频同一套推导)——与会话模型列表**同一获取
  * 来源**:active catalog。XD 媒体由 Gateway `/models` 动态投影，第三方媒体
@@ -3118,6 +3138,9 @@ function getCatalogMediaConfig(kind: CindyCapabilityKind): CindyMediaCatalogConf
       (providerId, modelId) =>
         isProviderDisabled(access, providerId) ||
         isModelDisabled(access, providerId, modelId) ||
+        // active catalog 保留 Gateway 原始媒体事实源；旧 cindy-request 的同步目录
+        // 必须在消费边界复用已缓存的 Guide 预检结果，不能暴露这版客户端不可执行的型号。
+        (providerId === 'xd' && !isXdMediaModelExecutableForCatalog(kind, modelId)) ||
         // 向量:目录是热更的,可能给出客户端还不认识的型号 id(比 EmbeddingModelId
         // 这个静态联合更新)。不在这里滤掉的话,它会照常展示、可被钉选、甚至成为
         // 目录默认 —— 而执行侧 isKnownEmbeddingModel 那道纵深防御会把每一次请求

--- a/apps/desktop/src/main/cindy-brain/index.ts
+++ b/apps/desktop/src/main/cindy-brain/index.ts
@@ -3096,8 +3096,8 @@ function isVideoCatalogProviderReady(providerId: string): boolean {
 
 /**
  * 当前媒体能力配置(图像/视频同一套推导)——与会话模型列表**同一获取
- * 来源**:providers.json 运行时目录(getActiveCatalog,OSS 热更 + 内置兜底),
- * 汇总各供应商的 imageModels/imageDefaults 或 videoModels/videoDefaults。
+ * 来源**:active catalog。XD 媒体由 Gateway `/models` 动态投影，第三方媒体
+ * 保留各 Provider 的 imageModels/imageDefaults 或 videoModels/videoDefaults。
  * 清单与默认/档位选型全部来自目录,主机代码零
  * 模型字面量;派生规则见 cindyMediaCatalog.ts。
  *

--- a/apps/desktop/src/main/cindy-brain/index.ts
+++ b/apps/desktop/src/main/cindy-brain/index.ts
@@ -323,6 +323,7 @@ import {
 import { invalidateXaiBridgeAuth } from '../maker-host/xai-auth-invalidation-host.js';
 import {
   isModelDisabled,
+  isModelDisabledWithUniqueLegacyBasename,
   isProviderDisabled,
   type MediaCapability,
 } from '@cindy/model-providers';
@@ -384,6 +385,7 @@ import { isModelAccessReady } from '../model-access/readiness.js';
 import {
   filterEnabledGatewayMediaModels,
   isMediaModelExecutable,
+  isMediaModelExecutableForGuide,
   listExecutableMediaModels,
   supportsMediaCapability,
 } from '../model-access/mediaModels.js';
@@ -3094,15 +3096,25 @@ function isVideoCatalogProviderReady(providerId: string): boolean {
   return false;
 }
 
-/** 旧 cindy-request 类目清单只保留至少有一种当前客户端可执行操作的 XD 模型。 */
+const LEGACY_CINDY_REQUEST_IMAGE_GUIDE_ID = 'openai-images-v1';
+
+/** 旧 cindy-request 类目清单只保留其固定通道真正可执行的 XD 模型。 */
 function isXdMediaModelExecutableForCatalog(
   kind: CindyCapabilityKind,
   modelId: string,
 ): boolean {
   if (kind === 'image') {
     return (
-      isMediaModelExecutable(modelId, 'image.generate') ||
-      isMediaModelExecutable(modelId, 'image.edit')
+      isMediaModelExecutableForGuide(
+        modelId,
+        LEGACY_CINDY_REQUEST_IMAGE_GUIDE_ID,
+        'image.generate',
+      ) ||
+      isMediaModelExecutableForGuide(
+        modelId,
+        LEGACY_CINDY_REQUEST_IMAGE_GUIDE_ID,
+        'image.edit',
+      )
     );
   }
   if (kind === 'video') {
@@ -3132,12 +3144,25 @@ function getCatalogMediaConfig(kind: CindyCapabilityKind): CindyMediaCatalogConf
     // (与对话模型的准入口径同源,见 model-disable-store)。
     const access = readModelDisableOverrides();
     const catalog = getActiveCatalog();
+    const xdMediaModelIds = getXdGatewayModels()
+      .filter(
+        (model) =>
+          model.mode === 'image_generation' || model.mode === 'video_generation',
+      )
+      .map((model) => model.id);
     return deriveCindyMediaConfig(
       catalog.providers,
       kind,
       (providerId, modelId) =>
         isProviderDisabled(access, providerId) ||
-        isModelDisabled(access, providerId, modelId) ||
+        (providerId === 'xd' && kind !== 'embed'
+          ? isModelDisabledWithUniqueLegacyBasename(
+              access,
+              providerId,
+              modelId,
+              xdMediaModelIds,
+            )
+          : isModelDisabled(access, providerId, modelId)) ||
         // active catalog 保留 Gateway 原始媒体事实源；旧 cindy-request 的同步目录
         // 必须在消费边界复用已缓存的 Guide 预检结果，不能暴露这版客户端不可执行的型号。
         (providerId === 'xd' && !isXdMediaModelExecutableForCatalog(kind, modelId)) ||

--- a/apps/desktop/src/main/cindy-brain/index.ts
+++ b/apps/desktop/src/main/cindy-brain/index.ts
@@ -3447,13 +3447,23 @@ function resolveAndMigrateGhostMediaPreference(
 ): CindyMediaPreferenceModel | null {
   const selected = resolveMediaPreferenceOrDefault(config, preference);
   if (preference && selected && preference !== selected.id) {
-    log.info('migrating stale ghost media preference to available model', {
-      ghostId,
-      capability,
-      previousPreference: preference,
-      nextPreference: selected.id,
-    });
-    writeGhostCindyOverride(ghostId, capability, selected.id);
+    try {
+      writeGhostCindyOverride(ghostId, capability, selected.id);
+      log.info('migrating stale ghost media preference to available model', {
+        ghostId,
+        capability,
+        previousPreference: preference,
+        nextPreference: selected.id,
+      });
+    } catch (error) {
+      log.warn('persisting migrated ghost media preference failed; using runtime fallback', {
+        ghostId,
+        capability,
+        previousPreference: preference,
+        fallbackPreference: selected.id,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
   }
   return selected;
 }

--- a/apps/desktop/src/main/cindy-brain/index.ts
+++ b/apps/desktop/src/main/cindy-brain/index.ts
@@ -3150,8 +3150,17 @@ function getCatalogMediaConfig(kind: CindyCapabilityKind): CindyMediaCatalogConf
           model.mode === 'image_generation' || model.mode === 'video_generation',
       )
       .map((model) => model.id);
+    // 旧 cindy-request 偏好不携带 providerId；同一完整 modelId 同时来自 XD 与
+    // 第三方时必须让托管默认来源先参与 first-wins，避免静默改用第三方凭证计费。
+    const providers =
+      kind === 'embed'
+        ? catalog.providers
+        : [
+            ...catalog.providers.filter((provider) => provider.id === 'xd'),
+            ...catalog.providers.filter((provider) => provider.id !== 'xd'),
+          ];
     return deriveCindyMediaConfig(
-      catalog.providers,
+      providers,
       kind,
       (providerId, modelId) =>
         isProviderDisabled(access, providerId) ||

--- a/apps/desktop/src/main/cindy-brain/index.ts
+++ b/apps/desktop/src/main/cindy-brain/index.ts
@@ -3348,6 +3348,54 @@ function resolveMediaPreferenceOrDefault(
 }
 
 /**
+ * Art 1.12.5–1.13.2 已经走 Core media，但还不会在 prepare 时传
+ * providerId。这段兼容窗口只能稳定表达 Cindy AI 来源；1.13.3 起
+ * 插件会传完整来源，恢复全部 Provider 选择。
+ */
+function isProviderBlindCoreArt(ghost: InstalledGhost): boolean {
+  return (
+    ghost.manifest.id === 'cindy-art' &&
+    supportsCindyVersion(ghost.manifest.version, '1.12.5') &&
+    !supportsCindyVersion(ghost.manifest.version, '1.13.3')
+  );
+}
+
+function getGhostMediaPreferenceConfig(
+  ghostId: string,
+  capability: GhostMediaCapability,
+): CindyMediaPreferenceConfig {
+  const config = getMediaPreferenceConfig(capability);
+  const ghost = getGhostManager().list().find((candidate) => candidate.manifest.id === ghostId);
+  if (!ghost || !isProviderBlindCoreArt(ghost)) return config;
+  const models = config.models.filter((model) => model.providerId === 'xd');
+  const standard = models[0]?.id;
+  return {
+    models,
+    defaults: standard ? { standard, draft: standard, best: standard } : null,
+  };
+}
+
+/** 存量钉定已失效或旧插件无法表达时，一次性升级为当前可用选型。 */
+function resolveAndMigrateGhostMediaPreference(
+  ghostId: string,
+  capability: GhostMediaCapability,
+  config: CindyMediaPreferenceConfig,
+  preference: string | undefined,
+): CindyMediaPreferenceModel | null {
+  const selected = resolveMediaPreferenceOrDefault(config, preference);
+  if (preference && selected && preference !== selected.id) {
+    log.info('migrating stale ghost media preference to available model', {
+      ghostId,
+      capability,
+      previousPreference: preference,
+      nextPreference: selected.id,
+    });
+    writeGhostCindyOverride(ghostId, capability, selected.id);
+  }
+  return selected;
+}
+
+/**
  * 插件配置页的模型目录；这里只读目录，不提供任何生成入口。Host 只按 Gateway mode
  * 切图片/视频大类并透传 modalities，具体动作支持度由插件自行解释。
  */
@@ -3372,7 +3420,10 @@ async function getGhostConfigurableMediaModels(
     // Gateway modalities 透传给插件判断，不能把插件声明的多个动作取交集。
     const availability = await listExecutableMediaModels();
     const mode = type === 'image' ? 'image_generation' : 'video_generation';
-    const models = availability.models.filter((model) => model.mode === mode);
+    const models = availability.models.filter(
+      (model) =>
+        model.mode === mode && (!isProviderBlindCoreArt(ghost) || model.providerId === 'xd'),
+    );
     if (
       models.length === 0 &&
       availability.unavailable.some((model) => model.retryable)
@@ -3424,8 +3475,8 @@ async function getGhostConfigurableMediaModels(
 
 /**
  * 读取插件在 Host「Cindy 能力」中的现有媒体选型。
- * 这里只投影当前有效值，不复制或迁移配置；已配置模型失效时，
- * 统一回落到该能力当前的默认（第一个可用）模型。
+ * 已配置模型失效，或旧插件无法表达完整来源时，回落到当前第一个
+ * 可用模型，并一次性迁移存量配置，保证页面展示与实际执行一致。
  */
 function getGhostConfiguredMediaModel(
   ghostId: string,
@@ -3452,9 +3503,14 @@ function getGhostConfiguredMediaModel(
     };
   }
 
-  const config = getMediaPreferenceConfig(mediaCapability);
+  const config = getGhostMediaPreferenceConfig(ghostId, mediaCapability);
   const override = readGhostCindyOverrides(ghostId)[mediaCapability];
-  const selected = resolveMediaPreferenceOrDefault(config, override);
+  const selected = resolveAndMigrateGhostMediaPreference(
+    ghostId,
+    mediaCapability,
+    config,
+    override,
+  );
   if (!selected) {
     return {
       ok: false,
@@ -3931,8 +3987,11 @@ export function getGhostCindySlot(): GhostCindySlot {
       getMediaOverride: (ghostId, capability) => {
         const value = readGhostCindyOverrides(ghostId)[capability as CindyCapabilityKey] ?? null;
         if (!value) return null;
-        const selected = resolveMediaPreferenceOrDefault(
-          getMediaPreferenceConfig(capability as GhostMediaCapability),
+        const mediaCapability = capability as GhostMediaCapability;
+        const selected = resolveAndMigrateGhostMediaPreference(
+          ghostId,
+          mediaCapability,
+          getGhostMediaPreferenceConfig(ghostId, mediaCapability),
           value,
         );
         return selected
@@ -6172,8 +6231,10 @@ export function registerGhostIpc(): void {
     for (const capability of GHOST_MEDIA_CAPABILITIES) {
       const value = storedOverrides[capability];
       if (!value) continue;
-      const selected = resolveMediaPreferenceOrDefault(
-        getMediaPreferenceConfig(capability),
+      const selected = resolveAndMigrateGhostMediaPreference(
+        ghostId as string,
+        capability,
+        getGhostMediaPreferenceConfig(ghostId as string, capability),
         value,
       );
       if (selected) overrides[capability] = selected.id;
@@ -6223,10 +6284,10 @@ export function registerGhostIpc(): void {
       : null;
     event.returnValue = {
       overrides,
-      image: byKind(getMediaPreferenceConfig('image.generate')),
-      imageEdit: byKind(getMediaPreferenceConfig('image.edit')),
-      video: byKind(getMediaPreferenceConfig('video.generate')),
-      videoEdit: byKind(getMediaPreferenceConfig('video.edit')),
+      image: byKind(getGhostMediaPreferenceConfig(ghostId as string, 'image.generate')),
+      imageEdit: byKind(getGhostMediaPreferenceConfig(ghostId as string, 'image.edit')),
+      video: byKind(getGhostMediaPreferenceConfig(ghostId as string, 'video.generate')),
+      videoEdit: byKind(getGhostMediaPreferenceConfig(ghostId as string, 'video.edit')),
       text: {
         options: textOptions,
         defaultModel:
@@ -6299,10 +6360,12 @@ export function registerGhostIpc(): void {
       // fail-closed 兜底,不在这层把「暂时没配 key」当成非法值。
       if (
         !isCindyOverrideModelAllowed(capability as string, model, {
-          image: getMediaPreferenceConfig(
+          image: getGhostMediaPreferenceConfig(
+            ghostId,
             capability === 'image.edit' ? 'image.edit' : 'image.generate',
           ).models,
-          video: getMediaPreferenceConfig(
+          video: getGhostMediaPreferenceConfig(
+            ghostId,
             capability === 'video.edit' ? 'video.edit' : 'video.generate',
           ).models,
           embed: getCatalogEmbedConfig().models,

--- a/apps/desktop/src/main/cindy-brain/index.ts
+++ b/apps/desktop/src/main/cindy-brain/index.ts
@@ -3156,6 +3156,7 @@ function isXdMediaModelExecutableForCatalog(
 function getCatalogMediaConfig(
   kind: CindyCapabilityKind,
   action?: LegacyCindyMediaAction,
+  selectedProviderId?: string,
 ): CindyMediaCatalogConfig {
   try {
     // 停用过滤:用户在 设置 → 模型供应商 停用的媒体模型 / 供应商不进候选清单
@@ -3170,13 +3171,16 @@ function getCatalogMediaConfig(
       .map((model) => model.id);
     // 旧 cindy-request 偏好不携带 providerId；同一完整 modelId 同时来自 XD 与
     // 第三方时必须让托管默认来源先参与 first-wins，避免静默改用第三方凭证计费。
-    const providers =
+    const orderedProviders =
       kind === 'embed'
         ? catalog.providers
         : [
             ...catalog.providers.filter((provider) => provider.id === 'xd'),
             ...catalog.providers.filter((provider) => provider.id !== 'xd'),
           ];
+    const providers = selectedProviderId
+      ? orderedProviders.filter((provider) => provider.id === selectedProviderId)
+      : orderedProviders;
     return deriveCindyMediaConfig(
       providers,
       kind,
@@ -3584,7 +3588,7 @@ function assertMediaModelStillEnabled(
       ? getMediaPreferenceConfig(capability).models.some(
           (candidate) => candidate.providerId === providerId && candidate.modelId === model,
         )
-      : getCatalogMediaConfig(kind, action).models.some(
+      : getCatalogMediaConfig(kind, action, providerId).models.some(
           (candidate) =>
             candidate.id === model && (!providerId || candidate.providerId === providerId),
         );

--- a/apps/desktop/src/main/cindy-brain/index.ts
+++ b/apps/desktop/src/main/cindy-brain/index.ts
@@ -3097,13 +3097,22 @@ function isVideoCatalogProviderReady(providerId: string): boolean {
 }
 
 const LEGACY_CINDY_REQUEST_IMAGE_GUIDE_ID = 'openai-images-v1';
+type LegacyCindyMediaAction = 'generate' | 'edit';
 
-/** 旧 cindy-request 类目清单只保留其固定通道真正可执行的 XD 模型。 */
+/** 旧 cindy-request 类目清单只保留其固定通道对当前动作真正可执行的 XD 模型。 */
 function isXdMediaModelExecutableForCatalog(
   kind: CindyCapabilityKind,
   modelId: string,
+  action?: LegacyCindyMediaAction,
 ): boolean {
   if (kind === 'image') {
+    if (action) {
+      return isMediaModelExecutableForGuide(
+        modelId,
+        LEGACY_CINDY_REQUEST_IMAGE_GUIDE_ID,
+        action === 'edit' ? 'image.edit' : 'image.generate',
+      );
+    }
     return (
       isMediaModelExecutableForGuide(
         modelId,
@@ -3118,6 +3127,12 @@ function isXdMediaModelExecutableForCatalog(
     );
   }
   if (kind === 'video') {
+    if (action) {
+      return isMediaModelExecutable(
+        modelId,
+        action === 'edit' ? 'video.image_to_video' : 'video.generate',
+      );
+    }
     return (
       isMediaModelExecutable(modelId, 'video.generate') ||
       isMediaModelExecutable(modelId, 'video.image_to_video')
@@ -3138,7 +3153,10 @@ function isXdMediaModelExecutableForCatalog(
  * (与聊天侧「无可用性证明不展示」同口径)。下游如实降级:详情页那几行显示
  * 灰字而不是下拉,cindySlot 早拒而不是拿不在册的型号下单。
  */
-function getCatalogMediaConfig(kind: CindyCapabilityKind): CindyMediaCatalogConfig {
+function getCatalogMediaConfig(
+  kind: CindyCapabilityKind,
+  action?: LegacyCindyMediaAction,
+): CindyMediaCatalogConfig {
   try {
     // 停用过滤:用户在 设置 → 模型供应商 停用的媒体模型 / 供应商不进候选清单
     // (与对话模型的准入口径同源,见 model-disable-store)。
@@ -3174,7 +3192,7 @@ function getCatalogMediaConfig(kind: CindyCapabilityKind): CindyMediaCatalogConf
           : isModelDisabled(access, providerId, modelId)) ||
         // active catalog 保留 Gateway 原始媒体事实源；旧 cindy-request 的同步目录
         // 必须在消费边界复用已缓存的 Guide 预检结果，不能暴露这版客户端不可执行的型号。
-        (providerId === 'xd' && !isXdMediaModelExecutableForCatalog(kind, modelId)) ||
+        (providerId === 'xd' && !isXdMediaModelExecutableForCatalog(kind, modelId, action)) ||
         // 向量:目录是热更的,可能给出客户端还不认识的型号 id(比 EmbeddingModelId
         // 这个静态联合更新)。不在这里滤掉的话,它会照常展示、可被钉选、甚至成为
         // 目录默认 —— 而执行侧 isKnownEmbeddingModel 那道纵深防御会把每一次请求
@@ -3210,10 +3228,12 @@ function getCatalogMediaConfig(kind: CindyCapabilityKind): CindyMediaCatalogConf
   }
 }
 
-const getCatalogImageConfig = (): ReturnType<typeof getCatalogMediaConfig> =>
-  getCatalogMediaConfig('image');
-const getCatalogVideoConfig = (): ReturnType<typeof getCatalogMediaConfig> =>
-  getCatalogMediaConfig('video');
+const getCatalogImageConfig = (
+  action?: LegacyCindyMediaAction,
+): ReturnType<typeof getCatalogMediaConfig> => getCatalogMediaConfig('image', action);
+const getCatalogVideoConfig = (
+  action?: LegacyCindyMediaAction,
+): ReturnType<typeof getCatalogMediaConfig> => getCatalogMediaConfig('video', action);
 const getCatalogEmbedConfig = (): ReturnType<typeof getCatalogMediaConfig> =>
   getCatalogMediaConfig('embed');
 
@@ -3556,12 +3576,19 @@ function assertMediaModelStillEnabled(
   kind: 'image' | 'video',
   model: string,
   providerId?: string,
+  action: LegacyCindyMediaAction = 'generate',
 ): void {
-  const available = providerId
-    ? getMediaPreferenceConfig(kind === 'image' ? 'image.generate' : 'video.generate').models.some(
-        (candidate) => candidate.providerId === providerId && candidate.modelId === model,
-      )
-    : getCatalogMediaConfig(kind).models.some((candidate) => candidate.id === model);
+  const capability: GhostMediaCapability = `${kind}.${action}`;
+  const available =
+    providerId === 'xd'
+      ? getCatalogMediaConfig(kind, action).models.some(
+          (candidate) => candidate.providerId === providerId && candidate.id === model,
+        )
+      : providerId
+        ? getMediaPreferenceConfig(capability).models.some(
+            (candidate) => candidate.providerId === providerId && candidate.modelId === model,
+          )
+        : getCatalogMediaConfig(kind, action).models.some((candidate) => candidate.id === model);
   if (!available) {
     throw new Error(
       kind === 'image'
@@ -3621,7 +3648,12 @@ async function runGhostVideo(
     throw new Error('视频能力不可用:主机未配置视频通道');
   }
   // 提交紧前重查(第二十一轮):参考图 data URI 准备是 await,窗口内被停用即拒。
-  assertMediaModelStillEnabled('video', params.alias, params.providerId);
+  assertMediaModelStillEnabled(
+    'video',
+    params.alias,
+    params.providerId,
+    params.imageDataUris ? 'edit' : 'generate',
+  );
   const r = await submitAndAwaitVideo(registry, params);
   return {
     buffer: r.buffer,
@@ -3941,7 +3973,7 @@ export function getGhostCindySlot(): GhostCindySlot {
       // 定位,经 imageChannelRegistry 取对应执行通道(2026-07 图像多来源)。
       generateImage: async ({ prompt, model, providerId, aspectRatio }) => {
         try {
-          assertMediaModelStillEnabled('image', model, providerId);
+          assertMediaModelStillEnabled('image', model, providerId, 'generate');
           const channel = resolveImageChannelForModel(model, 'generate', providerId);
           return decodeImageResponse(
             await channel.generateImage({
@@ -3956,7 +3988,7 @@ export function getGhostCindySlot(): GhostCindySlot {
       },
       editImage: async ({ prompt, model, providerId, imagePaths, aspectRatio }) => {
         try {
-          assertMediaModelStillEnabled('image', model, providerId);
+          assertMediaModelStillEnabled('image', model, providerId, 'edit');
           const channel = resolveImageChannelForModel(model, 'edit', providerId);
           return decodeImageResponse(
             await channel.editImage({
@@ -3972,7 +4004,7 @@ export function getGhostCindySlot(): GhostCindySlot {
       },
       generateVideo: async ({ prompt, model, providerId, ...videoParams }) => {
         try {
-          assertMediaModelStillEnabled('video', model, providerId);
+          assertMediaModelStillEnabled('video', model, providerId, 'generate');
           return await runGhostVideo({ alias: model, providerId, prompt, ...videoParams });
         } catch (err) {
           humanizeImageChannelError(err);
@@ -3980,7 +4012,7 @@ export function getGhostCindySlot(): GhostCindySlot {
       },
       editVideo: async ({ prompt, model, providerId, imagePaths, refMode, ...videoParams }) => {
         try {
-          assertMediaModelStillEnabled('video', model, providerId);
+          assertMediaModelStillEnabled('video', model, providerId, 'edit');
           // 先算总量再读(闸按 refMode 分档:存量首尾帧不设闸,原样)。闸与
           // 读取绑在一个入口里,顺序是那边的结构保证、不是这里的约定;结果
           // 保序——顺序即语义:首/尾帧,或提示词里 [Image 1]… 的序号。

--- a/apps/desktop/src/main/cindy-brain/index.ts
+++ b/apps/desktop/src/main/cindy-brain/index.ts
@@ -3580,15 +3580,14 @@ function assertMediaModelStillEnabled(
 ): void {
   const capability: GhostMediaCapability = `${kind}.${action}`;
   const available =
-    providerId === 'xd'
-      ? getCatalogMediaConfig(kind, action).models.some(
-          (candidate) => candidate.providerId === providerId && candidate.id === model,
+    providerId && kind === 'image' && providerId !== 'xd'
+      ? getMediaPreferenceConfig(capability).models.some(
+          (candidate) => candidate.providerId === providerId && candidate.modelId === model,
         )
-      : providerId
-        ? getMediaPreferenceConfig(capability).models.some(
-            (candidate) => candidate.providerId === providerId && candidate.modelId === model,
-          )
-        : getCatalogMediaConfig(kind, action).models.some((candidate) => candidate.id === model);
+      : getCatalogMediaConfig(kind, action).models.some(
+          (candidate) =>
+            candidate.id === model && (!providerId || candidate.providerId === providerId),
+        );
   if (!available) {
     throw new Error(
       kind === 'image'

--- a/apps/desktop/src/main/cindy-media/__tests__/invocationService.test.ts
+++ b/apps/desktop/src/main/cindy-media/__tests__/invocationService.test.ts
@@ -284,6 +284,42 @@ describe('Cindy Core media invocation state and security boundary', () => {
     expect(mocks.ingestMedia).toHaveBeenCalledTimes(1);
   });
 
+  it('Guide 查询键无前缀时仍持久化并提交完整 Gateway modelId', async () => {
+    const fullModelId = 'openai/gpt-image-2';
+    mocks.models.mockResolvedValue([
+      { id: fullModelId, name: 'GPT Image 2', providerId: 'xd', mode: 'image_generation' },
+    ]);
+    mocks.guide.mockResolvedValue({
+      ...resolvedGuide(
+        operation({
+          mode: 'sync',
+          media: [{ path: ['data'], encoding: 'base64', kind: 'image' }],
+        }),
+      ),
+      modelId: 'gpt-image-2',
+    });
+    mocks.outboundFetch.mockResolvedValue(
+      new Response(JSON.stringify({ data: PNG.toString('base64') }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+
+    const prepared = await callCindyMedia({
+      action: 'prepare',
+      modelId: fullModelId,
+      capability: 'image.generate',
+    });
+    const invocationId = prepared.invocation_id as string;
+    await callCindyMedia({ action: 'request', invocationId, body: { prompt: 'cat' } });
+
+    expect(prepared).toMatchObject({ ok: true, model_id: fullModelId });
+    expect(mocks.guide).toHaveBeenCalledWith(fullModelId);
+    expect(mocks.rows.get(invocationId)?.modelId).toBe(fullModelId);
+    const [, init] = mocks.outboundFetch.mock.calls[0];
+    expect(JSON.parse(init.body)).toMatchObject({ model: fullModelId });
+  });
+
   it('同名媒体模型按 providerId 精确准备并调用第三方来源', async () => {
     const providerModel = {
       id: 'openai/gpt-image-2',

--- a/apps/desktop/src/main/cindy-media/__tests__/invocationService.test.ts
+++ b/apps/desktop/src/main/cindy-media/__tests__/invocationService.test.ts
@@ -372,7 +372,7 @@ describe('Cindy Core media invocation state and security boundary', () => {
     });
   });
 
-  it('旧调用未传 providerId 时同名来源优先回落 Cindy AI', async () => {
+  it('旧调用未传 providerId 时裸 ID 唯一升级且同名来源优先 Cindy AI', async () => {
     const model = {
       id: 'openai/gpt-image-2',
       name: 'GPT Image 2',
@@ -388,7 +388,7 @@ describe('Cindy Core media invocation state and security boundary', () => {
 
     const prepared = await callCindyMedia({
       action: 'prepare',
-      modelId: model.id,
+      modelId: 'gpt-image-2',
       capability: 'image.generate',
     });
     expect(prepared).toMatchObject({

--- a/apps/desktop/src/main/cindy-media/__tests__/invocationService.test.ts
+++ b/apps/desktop/src/main/cindy-media/__tests__/invocationService.test.ts
@@ -372,7 +372,7 @@ describe('Cindy Core media invocation state and security boundary', () => {
     });
   });
 
-  it('旧调用未传 providerId 时不在同名 Provider 中静默选择来源', async () => {
+  it('旧调用未传 providerId 时同名来源优先回落 Cindy AI', async () => {
     const model = {
       id: 'openai/gpt-image-2',
       name: 'GPT Image 2',
@@ -382,20 +382,21 @@ describe('Cindy Core media invocation state and security boundary', () => {
       officialDocs: 'https://platform.openai.com/docs/guides/image-generation',
     };
     mocks.models.mockResolvedValue([{ ...model, providerId: 'xd' }, model]);
+    mocks.guide.mockResolvedValue(
+      resolvedGuide(operation({ mode: 'sync', media: [] })),
+    );
 
-    await expect(
-      callCindyMedia({
-        action: 'prepare',
-        modelId: model.id,
-        capability: 'image.generate',
-      }),
-    ).resolves.toMatchObject({
-      ok: false,
-      errorCode: 'MODEL_NOT_AVAILABLE',
-      retryable: false,
-      message: expect.stringContaining('provider_id'),
+    const prepared = await callCindyMedia({
+      action: 'prepare',
+      modelId: model.id,
+      capability: 'image.generate',
     });
-    expect(mocks.guide).not.toHaveBeenCalled();
+    expect(prepared).toMatchObject({
+      ok: true,
+      provider_id: 'xd',
+      model_id: model.id,
+    });
+    expect(mocks.guide).toHaveBeenCalledWith(model.id);
     expect(mocks.providerModel).not.toHaveBeenCalled();
   });
 

--- a/apps/desktop/src/main/cindy-media/invocationService.ts
+++ b/apps/desktop/src/main/cindy-media/invocationService.ts
@@ -1198,7 +1198,8 @@ async function prepareInvocation(
     const { operations: _operations, ...guideProtocol } = resolvedGuide.guide;
     void _operations;
     preparedGuide = {
-      modelId: resolvedGuide.modelId,
+      // Guide 查询键不参与调用身份；配置、持久化和 Gateway 请求始终使用完整 modelId。
+      modelId,
       ...guideProtocol,
       ...operation,
     };

--- a/apps/desktop/src/main/cindy-media/invocationService.ts
+++ b/apps/desktop/src/main/cindy-media/invocationService.ts
@@ -1130,22 +1130,32 @@ async function prepareInvocation(
   const matchingModels = models.filter(
     (candidate) => candidate.id === modelId && (!providerId || candidate.providerId === providerId),
   );
-  if (!providerId && matchingModels.length > 1) {
-    return failure(
-      'MODEL_NOT_AVAILABLE',
-      '该模型同时来自多个 Provider，请从模型目录选择精确来源并在 prepare 时传入 provider_id',
-    );
+  const model = providerId
+    ? matchingModels[0]
+    : (matchingModels.find((candidate) => candidate.providerId === 'xd') ??
+      matchingModels[0]);
+  if (!providerId && model && matchingModels.length !== 1) {
+    log.warn('legacy media prepare resolved to available model', {
+      requestedModelId: modelId,
+      resolvedProviderId: model.providerId,
+      resolvedModelId: model.id,
+      matchingProviderCount: matchingModels.length,
+    });
   }
-  const model = matchingModels[0];
   if (!model) {
     return failure('MODEL_NOT_AVAILABLE', '该模型或指定 Provider 当前不可见，或不是请求的媒体类型');
   }
+  const resolvedModelId = model.id;
   let preparedGuide: PreparedMediaInvocationGuide;
   if (model.providerId !== 'xd') {
     if (capability !== 'image.generate' && capability !== 'image.edit') {
       return failure('CAPABILITY_NOT_SUPPORTED', '该第三方 Provider 当前不支持请求的媒体能力');
     }
-    const providerModel = resolveProviderMediaModel(model.providerId, modelId, capability);
+    const providerModel = resolveProviderMediaModel(
+      model.providerId,
+      resolvedModelId,
+      capability,
+    );
     if (!providerModel) {
       return failure('MODEL_NOT_AVAILABLE', '该第三方媒体模型或执行来源当前不可用');
     }
@@ -1153,7 +1163,7 @@ async function prepareInvocation(
   } else {
     let resolvedGuide: ResolvedMediaInvocationGuide;
     try {
-      resolvedGuide = await fetchMediaInvocationGuide(modelId);
+      resolvedGuide = await fetchMediaInvocationGuide(resolvedModelId);
       assertAuthScope(scope);
     } catch (error) {
       if (error instanceof ServerApiError && error.code === 'MEDIA_INVOCATION_GUIDE_NOT_FOUND') {
@@ -1164,7 +1174,7 @@ async function prepareInvocation(
       }
       if (error instanceof MediaGuideCompatibilityError) {
         log.warn('media Guide rejected by current client', {
-          modelId,
+          modelId: resolvedModelId,
           code: error.code,
           detail: error.detail,
         });
@@ -1199,7 +1209,7 @@ async function prepareInvocation(
     void _operations;
     preparedGuide = {
       // Guide 查询键不参与调用身份；配置、持久化和 Gateway 请求始终使用完整 modelId。
-      modelId,
+      modelId: resolvedModelId,
       ...guideProtocol,
       ...operation,
     };
@@ -1227,7 +1237,7 @@ async function prepareInvocation(
     status: 'prepared',
     invocation_id: id,
     provider_id: model.providerId,
-    model_id: modelId,
+    model_id: resolvedModelId,
     model_name: model.name ?? model.id,
     capability,
     guide_revision: preparedGuide.revision,

--- a/apps/desktop/src/main/cindy-media/invocationService.ts
+++ b/apps/desktop/src/main/cindy-media/invocationService.ts
@@ -1127,14 +1127,22 @@ async function prepareInvocation(
   assertAuthScope(scope);
   const models = await listAvailableMediaModels(capability);
   assertAuthScope(scope);
-  const matchingModels = models.filter(
+  let matchingModels = models.filter(
     (candidate) => candidate.id === modelId && (!providerId || candidate.providerId === providerId),
   );
+  if (!providerId && matchingModels.length === 0 && !modelId.includes('/')) {
+    const legacyMatches = models.filter(
+      (candidate) => candidate.id.slice(candidate.id.lastIndexOf('/') + 1) === modelId,
+    );
+    if (new Set(legacyMatches.map((candidate) => candidate.id)).size === 1) {
+      matchingModels = legacyMatches;
+    }
+  }
   const model = providerId
     ? matchingModels[0]
     : (matchingModels.find((candidate) => candidate.providerId === 'xd') ??
       matchingModels[0]);
-  if (!providerId && model && matchingModels.length !== 1) {
+  if (!providerId && model && (model.id !== modelId || matchingModels.length !== 1)) {
     log.warn('legacy media prepare resolved to available model', {
       requestedModelId: modelId,
       resolvedProviderId: model.providerId,

--- a/apps/desktop/src/main/cindy-proxy-media/video/__tests__/registry.test.ts
+++ b/apps/desktop/src/main/cindy-proxy-media/video/__tests__/registry.test.ts
@@ -80,6 +80,20 @@ describe('VideoProviderRegistry', () => {
     expect(resolved.internalModel).toBe('fp-fast');
   });
 
+  it('keeps catalog provider identity when aliases collide across sources', () => {
+    const r = new VideoProviderRegistry();
+    r.register(
+      makeFakeProvider({
+        id: 'gateway-video',
+        aliases: [{ alias: 'shared/video-model', internalModel: 'gateway-model' }],
+      }),
+      'xd',
+    );
+
+    expect(r.hasAlias('shared/video-model', 'xd')).toBe(true);
+    expect(r.hasAlias('shared/video-model', 'third-party')).toBe(false);
+  });
+
   it('throws on unknown alias', () => {
     const r = new VideoProviderRegistry();
     r.register(

--- a/apps/desktop/src/main/cindy-proxy-media/video/registry.ts
+++ b/apps/desktop/src/main/cindy-proxy-media/video/registry.ts
@@ -11,6 +11,8 @@ import type { VideoModelAlias, VideoProvider, VideoRefMode } from './types.js';
 
 interface ResolvedAlias {
   provider: VideoProvider;
+  /** 模型目录中的来源 id（例如 xd / xai），与内部执行器 id 分离。 */
+  catalogProviderId: string;
   internalModel: string;
   summary: string;
   expectedSeconds: number;
@@ -20,7 +22,7 @@ export class VideoProviderRegistry {
   private readonly providers = new Map<string, VideoProvider>();
   private readonly aliasIndex = new Map<string, ResolvedAlias>();
 
-  register(provider: VideoProvider): void {
+  register(provider: VideoProvider, catalogProviderId = 'xd'): void {
     if (this.providers.has(provider.id)) {
       throw new Error(
         `[videoRegistry] duplicate provider id: ${provider.id}`,
@@ -36,6 +38,7 @@ export class VideoProviderRegistry {
         provider.capabilities.expectedSecondsByAlias[a.alias] ?? 120;
       this.aliasIndex.set(a.alias, {
         provider,
+        catalogProviderId,
         internalModel: a.internalModel,
         summary: a.summary,
         expectedSeconds: expected,
@@ -49,15 +52,19 @@ export class VideoProviderRegistry {
    * 期间已经提交的长视频任务仍要能继续 poll/download；新请求是否可用由当前目录
    * 白名单在提交前重查。其它 provider 已占用的 alias 仍严格拒绝。
    */
-  registerOrExtend(provider: VideoProvider): void {
+  registerOrExtend(provider: VideoProvider, catalogProviderId = 'xd'): void {
     const existing = this.providers.get(provider.id);
     if (!existing) {
-      this.register(provider);
+      this.register(provider, catalogProviderId);
       return;
     }
     for (const alias of provider.capabilities.modelAliases) {
       const occupied = this.aliasIndex.get(alias.alias);
-      if (occupied && occupied.provider.id !== provider.id) {
+      if (
+        occupied &&
+        (occupied.provider.id !== provider.id ||
+          occupied.catalogProviderId !== catalogProviderId)
+      ) {
         throw new Error(
           `[videoRegistry] duplicate alias: ${alias.alias} (already registered by ${occupied.provider.id})`,
         );
@@ -66,6 +73,7 @@ export class VideoProviderRegistry {
     for (const alias of provider.capabilities.modelAliases) {
       this.aliasIndex.set(alias.alias, {
         provider,
+        catalogProviderId,
         internalModel: alias.internalModel,
         summary: alias.summary,
         expectedSeconds: provider.capabilities.expectedSecondsByAlias[alias.alias] ?? 120,
@@ -81,8 +89,12 @@ export class VideoProviderRegistry {
   }
 
   /** 目录热更可能先于客户端通道代码；未知 alias 必须从可选清单中过滤。 */
-  hasAlias(alias: string): boolean {
-    return this.aliasIndex.has(alias);
+  hasAlias(alias: string, catalogProviderId?: string): boolean {
+    const resolved = this.aliasIndex.get(alias);
+    return Boolean(
+      resolved &&
+        (catalogProviderId === undefined || resolved.catalogProviderId === catalogProviderId),
+    );
   }
 
   /** Throws on unknown alias — handler converts that to INVALID_ARGS. */

--- a/apps/desktop/src/main/maker-host/__tests__/activeCatalogXdAvailability.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/activeCatalogXdAvailability.test.ts
@@ -39,6 +39,9 @@ describe('XD 网关权威模型清单重建', () => {
     setActiveCatalog(BUNDLED_CATALOG);
     expect(xdModels('claude-code')).toEqual([]);
     expect(xdModels('codex')).toEqual([]);
+    const xd = getActiveCatalog().providers.find((provider) => provider.id === 'xd');
+    expect(xd?.imageModels).toEqual([]);
+    expect(xd?.videoModels).toEqual([]);
   });
 
   it('显式空列表保持 XD 模型不可用', () => {
@@ -48,7 +51,7 @@ describe('XD 网关权威模型清单重建', () => {
     expect(xdModels('codex')).toEqual([]);
   });
 
-  it('current Catalog controls the XD media shell while /models controls chat membership', () => {
+  it('/models 同时控制 XD chat 与媒体成员，忽略 Catalog 里的旧媒体清单', () => {
     const catalog = JSON.parse(JSON.stringify(BUNDLED_CATALOG)) as typeof BUNDLED_CATALOG;
     const catalogXd = catalog.providers.find((provider) => provider.id === 'xd');
     if (!catalogXd) throw new Error('missing XD provider fixture');
@@ -70,12 +73,42 @@ describe('XD 网关权威模型清单重建', () => {
     ];
 
     setActiveCatalog(catalog);
+    setXdGatewayModels([
+      {
+        id: 'openai/gpt-image-2',
+        name: 'GPT Image 2',
+        mode: 'image_generation',
+        agents: [],
+        modalities: { input: ['text', 'image'], output: ['image'] },
+      },
+      {
+        id: 'bytedance/seedance-2.5',
+        name: 'Seedance 2.5',
+        mode: 'video_generation',
+        agents: [],
+        modalities: { input: ['text', 'image'], output: ['video'] },
+      },
+    ]);
 
     const activeXd = getActiveCatalog().providers.find((provider) => provider.id === 'xd');
     expect(activeXd?.name).toBe('Catalog-supplied XD');
-    expect(activeXd?.imageModels).toEqual([]);
+    expect(activeXd?.imageModels).toEqual([
+      {
+        id: 'openai/gpt-image-2',
+        name: 'GPT Image 2',
+        modalities: { input: ['text', 'image'], output: ['image'] },
+      },
+    ]);
+    expect(activeXd?.imageDefaults).toEqual({ standard: 'openai/gpt-image-2' });
     expect(activeXd?.embeddingModels).toEqual([]);
-    expect(activeXd?.videoModels).toEqual([{ id: 'seedance-fast', name: 'Seedance Fast' }]);
+    expect(activeXd?.videoModels).toEqual([
+      {
+        id: 'bytedance/seedance-2.5',
+        name: 'Seedance 2.5',
+        modalities: { input: ['text', 'image'], output: ['video'] },
+      },
+    ]);
+    expect(activeXd?.videoDefaults).toEqual({ standard: 'bytedance/seedance-2.5' });
     expect(xdModels('claude-code')).toEqual([]);
   });
 

--- a/apps/desktop/src/main/maker-host/__tests__/model-disable-store.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/model-disable-store.test.ts
@@ -21,7 +21,8 @@ vi.mock('../../appSessionState.js', () => ({
   ownerScopedUserDataPath: (name: string) => path.join(tmpDir, name),
 }));
 
-const { __testing, setModelsDisabled } = await import('../model-disable-store.js');
+const { __testing, migrateLegacyNamespacedModelDisableOverrides, setModelsDisabled } =
+  await import('../model-disable-store.js');
 
 function readPrefsFile(): { disabledModels: Record<string, unknown> } {
   return JSON.parse(
@@ -67,8 +68,33 @@ describe('normalize(坏形态清洗)', () => {
   });
 });
 
+describe('旧媒体 modelId 停用项迁移', () => {
+  it('只把唯一 basename 匹配迁移为完整 modelId', () => {
+    setModelsDisabled('legacy-xd', ['gpt-image-2'], true);
+    migrateLegacyNamespacedModelDisableOverrides('legacy-xd', ['openai/gpt-image-2']);
+    expect(readPrefsFile().disabledModels).toMatchObject({
+      'legacy-xd:openai/gpt-image-2': true,
+    });
+    expect(readPrefsFile().disabledModels['legacy-xd:gpt-image-2']).toBeUndefined();
+
+    setModelsDisabled('ambiguous-xd', ['gpt-image-2'], true);
+    migrateLegacyNamespacedModelDisableOverrides('ambiguous-xd', [
+      'openai/gpt-image-2',
+      'other/gpt-image-2',
+    ]);
+    expect(readPrefsFile().disabledModels['ambiguous-xd:gpt-image-2']).toBe(true);
+    expect(readPrefsFile().disabledModels['ambiguous-xd:openai/gpt-image-2']).toBeUndefined();
+  });
+});
+
 describe('单 section 总量硬上限(深防线)', () => {
   it('disabledModels 超上限的新增被丢弃;删除不受上限影响、可继续腾出空间', () => {
+    setModelsDisabled('legacy-xd', ['gpt-image-2', 'openai/gpt-image-2'], false);
+    setModelsDisabled(
+      'ambiguous-xd',
+      ['gpt-image-2', 'openai/gpt-image-2', 'other/gpt-image-2'],
+      false,
+    );
     // IPC 边界单次 ≤512,但 store 是最后一道防线:未来新增写入口 / 手改文件绕过
     // 边界时,section 不得无界膨胀。一次灌 5000 个 → 只落 4096。
     const ids = Array.from({ length: 5000 }, (_v, i) => `m-${i}`);

--- a/apps/desktop/src/main/maker-host/__tests__/providerCatalogRealmReload.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/providerCatalogRealmReload.test.ts
@@ -551,12 +551,8 @@ describe('provider catalog realm reload', () => {
     const startupXd = getDesktopSelectableCatalog().providers.find(
       (provider) => provider.id === 'xd',
     );
-    expect(startupXd?.imageModels).toEqual(
-      BUNDLED_CATALOG.providers.find((provider) => provider.id === 'xd')?.imageModels,
-    );
-    expect(startupXd?.videoModels).toEqual(
-      BUNDLED_CATALOG.providers.find((provider) => provider.id === 'xd')?.videoModels,
-    );
+    expect(startupXd?.imageModels).toEqual([]);
+    expect(startupXd?.videoModels).toEqual([]);
     expect(startupXd?.embeddingModels).toEqual([]);
 
     h.endpoint = 'https://model.global.example';
@@ -649,7 +645,7 @@ describe('provider catalog realm reload', () => {
     const currentXd = currentCatalog.providers.find((provider) => provider.id === 'xd');
     expect(currentXd?.imageModels).toEqual([]);
     expect(currentXd?.embeddingModels).toEqual([]);
-    expect(currentXd?.videoModels).toEqual([{ id: 'seedance-fast', name: 'Seedance Fast' }]);
+    expect(currentXd?.videoModels).toEqual([]);
     expect(deriveCindyMediaConfig(currentCatalog.providers, 'embed')).toEqual({
       models: [],
       defaults: null,
@@ -721,8 +717,8 @@ describe('provider catalog realm reload', () => {
     const projectedEmbedding = getDesktopSelectableCatalog().providers.find(
       (provider) => provider.id === 'xd',
     );
-    expect(projectedEmbedding?.imageModels).toEqual(inheritedEmbeddingXd.imageModels);
-    expect(projectedEmbedding?.videoModels).toEqual(inheritedEmbeddingXd.videoModels);
+    expect(projectedEmbedding?.imageModels).toEqual([]);
+    expect(projectedEmbedding?.videoModels).toEqual([]);
     expect(projectedEmbedding?.embeddingModels).toEqual([]);
 
     const evidenceUpgrade = refreshActiveCatalogFromSource();
@@ -887,7 +883,7 @@ describe('provider catalog realm reload', () => {
         getDesktopSelectableCatalog().providers.find((provider) => provider.id === 'xd'),
       ).toMatchObject({
         imageModels: [],
-        videoModels: fallbackXd.videoModels,
+        videoModels: [],
         embeddingModels: fallbackXd.embeddingModels,
       });
       expect(events).toHaveLength(2);
@@ -980,7 +976,7 @@ describe('provider catalog realm reload', () => {
     expect(activeMarker()).toBe('catalog-current-same-registry');
     expect(promotedXd?.imageModels).toEqual([]);
     expect(promotedXd?.embeddingModels).toEqual([]);
-    expect(promotedXd?.videoModels).toEqual([{ id: 'seedance-fast', name: 'Seedance Fast' }]);
+    expect(promotedXd?.videoModels).toEqual([]);
     expect(promoted.providers.find((provider) => provider.id === 'xai')?.videoModels).toEqual(
       recoveredXai.videoModels,
     );

--- a/apps/desktop/src/main/maker-host/active-catalog.ts
+++ b/apps/desktop/src/main/maker-host/active-catalog.ts
@@ -136,9 +136,8 @@ export interface XdGatewayAgentOverride {
 
 /**
  * 服务端下发的 XD 网关模型条目(shared/modelAccess ModelAccessGatewayModel 的子集)。
- * 命名沿用历史("聊天"),但条目本身不保证是聊天模型——是否聊天模型看 mode,
- * 服务端目前只透传已经过它自己 chat 过滤的条目,过滤范围以后可能放开(issue #882);
- * 客户端一律用 isChatEligible 判定,不依赖本类型名字或服务端过滤范围。
+ * 命名沿用历史("聊天"),但条目本身不保证是聊天模型——v4 同时包含 chat 与媒体模型，
+ * 客户端一律按 agents/mode 投影到对应消费面，不从 id 猜测类型。
  *
  * 能力字段已由服务端一次归一化,客户端不再二次转换(见 model-access/index.ts)。
  */
@@ -790,6 +789,38 @@ function withEmptyModels(p: Provider): Provider {
   return { ...p, models };
 }
 
+function projectXdGatewayMediaModels(
+  provider: Provider,
+  gatewayModels: readonly XdGatewayModelInfo[],
+): Provider {
+  const imageModels = gatewayModels
+    .filter((model) => model.mode === 'image_generation')
+    .map((model) => ({
+      id: model.id,
+      name: model.name ?? model.id,
+      ...(model.modalities ? { modalities: model.modalities } : {}),
+    }));
+  const videoModels = gatewayModels
+    .filter((model) => model.mode === 'video_generation')
+    .map((model) => ({
+      id: model.id,
+      name: model.name ?? model.id,
+      ...(model.modalities ? { modalities: model.modalities } : {}),
+    }));
+  const identity = { ...provider };
+  delete identity.imageModels;
+  delete identity.imageDefaults;
+  delete identity.videoModels;
+  delete identity.videoDefaults;
+  return {
+    ...identity,
+    imageModels,
+    videoModels,
+    ...(imageModels[0] ? { imageDefaults: { standard: imageModels[0].id } } : {}),
+    ...(videoModels[0] ? { videoDefaults: { standard: videoModels[0].id } } : {}),
+  };
+}
+
 function computeMerged(): Catalog {
   const source = base ?? BUNDLED_CATALOG;
   const b =
@@ -836,9 +867,8 @@ function computeMerged(): Catalog {
   // 作者错误隔离进 warnings,由刷新路径读走打日志,不拖垮其余条目。
   const plan = planRegistryRoots(b.modelRegistry);
   lastPlanWarnings = plan.warnings;
-  // XD 的对话模型成员仍由下方 `/models` 权威重建，但 provider 壳中的媒体清单、
-  // 默认项和显式空值必须服从当前 Catalog。只有目录本身缺少 XD（生产加载经
-  // mergeWithBundled 后通常不会发生）才回落与 evidence 同级安全的 bundled 壳。
+  // XD 的模型成员与媒体清单都由下方 `/models` 权威重建。Catalog 只保留 provider
+  // 身份壳；其中残留的旧媒体字段不得成为第二事实源。
   const fallbackXdCatalog =
     baseCapabilityEvidence === 'current'
       ? projectUnverifiedCatalogFallbackForBuildRegion(
@@ -1161,7 +1191,7 @@ function computeMerged(): Catalog {
         )
         .map(({ model }) => model);
     }
-    return { ...p, models };
+    return { ...projectXdGatewayMediaModels(p, gwModels), models };
   });
 
   if (providers === b.providers) return b; // 无 augment、无 custom → 原样返回

--- a/apps/desktop/src/main/maker-host/model-disable-store.ts
+++ b/apps/desktop/src/main/maker-host/model-disable-store.ts
@@ -15,7 +15,11 @@
  *   @cindy/model-providers 的 disableOverrides.ts 头注。
  */
 
-import { modelDisableKey, type ModelDisableOverrides } from '@cindy/model-providers';
+import {
+  isModelDisabled,
+  modelDisableKey,
+  type ModelDisableOverrides,
+} from '@cindy/model-providers';
 
 import { desktopMakerLogger } from './logger-adapter.js';
 import { createOverrideSettingsFile } from './override-settings-file.js';
@@ -126,6 +130,38 @@ export function setModelsDisabled(
   if (!changed) return;
   store.writePatch({ disabledModels });
   log.info('model access override written', { providerId, count: modelIds.length, disabled });
+}
+
+/**
+ * 将旧版媒体裸 ID 的停用项迁移到当前唯一的 namespaced modelId。迁移幂等且只在
+ * 唯一匹配时落盘，避免同 basename 多模型时把用户选择错误套到另一条路由。
+ */
+export function migrateLegacyNamespacedModelDisableOverrides(
+  providerId: string,
+  modelIds: readonly string[],
+): void {
+  if (!providerId || modelIds.length === 0) return;
+  store.invalidateIfChanged();
+  const current = store.read();
+  const disabledModels = { ...current.disabledModels };
+  let migrated = 0;
+  const uniqueModelIds = [...new Set(modelIds)];
+  for (const modelId of uniqueModelIds) {
+    const slash = modelId.lastIndexOf('/');
+    if (slash < 0 || slash === modelId.length - 1) continue;
+    const basename = modelId.slice(slash + 1);
+    if (!isModelDisabled(current, providerId, basename)) continue;
+    const basenameMatches = uniqueModelIds.filter(
+      (candidate) => candidate.slice(candidate.lastIndexOf('/') + 1) === basename,
+    );
+    if (basenameMatches.length !== 1 || basenameMatches[0] !== modelId) continue;
+    disabledModels[modelDisableKey(providerId, modelId)] = true;
+    delete disabledModels[modelDisableKey(providerId, basename)];
+    migrated += 1;
+  }
+  if (migrated === 0) return;
+  store.writePatch({ disabledModels });
+  log.info('legacy namespaced model disable overrides migrated', { providerId, migrated });
 }
 
 /** 测试专用:纯函数导出(normalize 坏形态清洗;读写链路由 providerHandlers 测试覆盖)。 */

--- a/apps/desktop/src/main/model-access/__tests__/mediaModels.test.ts
+++ b/apps/desktop/src/main/model-access/__tests__/mediaModels.test.ts
@@ -193,6 +193,56 @@ describe('listAvailableMediaModels', () => {
     );
   });
 
+  it('只在 Guide 查询边界移除 modelId namespace', async () => {
+    serverApiFetchMock.mockResolvedValueOnce({
+      modelId: 'gpt-image-2',
+      guide: {
+        schemaVersion: 1,
+        guideId: 'openai-images-v1',
+        revision: '2026-08-20.1',
+        connection: { providerId: 'xd' },
+        operations: [
+          {
+            capability: 'image.generate',
+            request: {
+              method: 'POST',
+              path: '/images/generations',
+              bodyEncoding: 'json',
+              bodyModelPath: ['model'],
+              timeoutMs: 1_000,
+              maxRequestBytes: 1_024,
+              maxResponseBytes: 1_024,
+            },
+            response: {
+              mode: 'sync',
+              media: [
+                {
+                  path: ['data', '*', 'url'],
+                  encoding: 'url',
+                  kind: 'image',
+                  allowedUrlHosts: ['example.com'],
+                },
+              ],
+            },
+            instructions: '按协议组装请求。',
+            exampleBody: { prompt: 'hello' },
+            inputSchema: { type: 'object' },
+            officialDocs: 'https://example.com/images-api',
+          },
+        ],
+      },
+    });
+
+    await expect(fetchMediaInvocationGuide('openai/gpt-image-2')).resolves.toMatchObject({
+      modelId: 'gpt-image-2',
+      guide: { guideId: 'openai-images-v1' },
+    });
+    expect(serverApiFetchMock).toHaveBeenLastCalledWith(
+      '/api/model-access/invocation-guide?modelId=gpt-image-2',
+      expect.any(Object),
+    );
+  });
+
   it('把更高 Guide schemaVersion 分类为客户端需要升级', async () => {
     serverApiFetchMock.mockResolvedValueOnce({
       modelId: 'image-with-guide',

--- a/apps/desktop/src/main/model-access/__tests__/mediaModels.test.ts
+++ b/apps/desktop/src/main/model-access/__tests__/mediaModels.test.ts
@@ -28,8 +28,11 @@ vi.mock('../../cindy-media/providerMediaRuntime.js', () => ({
 
 import {
   fetchMediaInvocationGuide,
+  isMediaModelExecutableForGuide,
   listAvailableMediaModels,
+  listExecutableMediaModels,
   MediaGuideCompatibilityError,
+  resetExecutableMediaModelCache,
 } from '../mediaModels.js';
 
 const payload = {
@@ -75,6 +78,7 @@ const payload = {
 
 describe('listAvailableMediaModels', () => {
   beforeEach(() => {
+    resetExecutableMediaModelCache();
     serverApiFetchMock.mockReset().mockResolvedValue(payload);
     readModelDisableOverridesMock.mockReset().mockReturnValue({});
     listProviderMediaModelsMock.mockReset().mockReturnValue([]);
@@ -133,6 +137,18 @@ describe('listAvailableMediaModels', () => {
 
     readModelDisableOverridesMock.mockReturnValueOnce({ disabledProviders: { xd: true } });
     await expect(listAvailableMediaModels()).resolves.toEqual([]);
+  });
+
+  it('namespaced modelId 唯一时继承旧裸 ID 的停用项', async () => {
+    serverApiFetchMock.mockResolvedValueOnce({
+      ...payload,
+      models: [{ ...payload.models[1], id: 'openai/image-with-guide' }],
+    });
+    readModelDisableOverridesMock.mockReturnValueOnce({
+      disabledModels: { 'xd:image-with-guide': true },
+    });
+
+    await expect(listAvailableMediaModels('image.generate')).resolves.toEqual([]);
   });
 
   it('拒绝旧版聊天目录，不把版本不匹配静默解释为空媒体列表', async () => {
@@ -252,5 +268,72 @@ describe('listAvailableMediaModels', () => {
     await expect(fetchMediaInvocationGuide('image-with-guide')).rejects.toMatchObject({
       code: 'CLIENT_UPGRADE_REQUIRED',
     } satisfies Partial<MediaGuideCompatibilityError>);
+  });
+
+  it('批量预检缓存 modelId 对应的协议 Guide', async () => {
+    const modelId = 'openai/image-with-guide';
+    serverApiFetchMock.mockImplementation(async (path: string) => {
+      if (path.startsWith('/api/model-access/models')) {
+        return {
+          ...payload,
+          models: [{ ...payload.models[1], id: modelId }],
+        };
+      }
+      if (path === '/api/model-access/invocation-guides') {
+        return {
+          guides: [
+            {
+              modelId,
+              guide: {
+                schemaVersion: 1,
+                guideId: 'openai-images-v1',
+                revision: '2026-08-20.1',
+                connection: { providerId: 'xd' },
+                operations: [
+                  {
+                    capability: 'image.generate',
+                    request: {
+                      method: 'POST',
+                      path: '/images/generations',
+                      bodyEncoding: 'json',
+                      bodyModelPath: ['model'],
+                      timeoutMs: 1_000,
+                      maxRequestBytes: 1_024,
+                      maxResponseBytes: 1_024,
+                    },
+                    response: {
+                      mode: 'sync',
+                      media: [
+                        {
+                          path: ['data', '*', 'url'],
+                          encoding: 'url',
+                          kind: 'image',
+                          allowedUrlHosts: ['example.com'],
+                        },
+                      ],
+                    },
+                    instructions: '按协议组装请求。',
+                    exampleBody: { prompt: 'hello' },
+                    inputSchema: { type: 'object' },
+                    officialDocs: 'https://example.com/images-api',
+                  },
+                ],
+              },
+            },
+          ],
+        };
+      }
+      throw new Error(`unexpected path: ${path}`);
+    });
+
+    await expect(
+      listExecutableMediaModels(['image.generate'], { forceRefresh: true }),
+    ).resolves.toMatchObject({ models: [{ id: modelId }] });
+    expect(
+      isMediaModelExecutableForGuide(modelId, 'openai-images-v1', 'image.generate'),
+    ).toBe(true);
+    expect(
+      isMediaModelExecutableForGuide(modelId, 'other-images-v1', 'image.generate'),
+    ).toBe(false);
   });
 });

--- a/apps/desktop/src/main/model-access/index.ts
+++ b/apps/desktop/src/main/model-access/index.ts
@@ -15,6 +15,7 @@ import {
   markXdGatewayModelAccessUnknown,
   setXdGatewayModels,
 } from '../maker-host/active-catalog.js';
+import { migrateLegacyNamespacedModelDisableOverrides } from '../maker-host/model-disable-store.js';
 import { replaceGatewayModelPricing, trackGatewayModelPricingSync } from '../usage/modelPricing.js';
 import { isPricedGatewayModel } from '../../shared/modelPriceQuote.js';
 import { throwIpcError } from '../utils/ipcValidate.js';
@@ -178,6 +179,22 @@ function applyGatewayModels(
   // 一次归一化成 contextWindow / agents / efforts / supportsFastMode / modalities,
   // 同一含义只下发一个字段。这里直接用下发值，唯一事实源在服务端。
   // active-catalog 统一收口会原地刷新 Maker capabilities，再广播同一 revision。
+  try {
+    migrateLegacyNamespacedModelDisableOverrides(
+      'xd',
+      models
+        .filter(
+          (model) =>
+            model.mode === 'image_generation' || model.mode === 'video_generation',
+        )
+        .map((model) => model.id),
+    );
+  } catch (error) {
+    // 偏好迁移失败不能拖垮权威模型目录；读路径仍保留唯一 basename 兼容判定。
+    log.warn('legacy media model disable override migration failed', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
   resetExecutableMediaModelCache();
   setXdGatewayModels(models, { authoritative });
 }

--- a/apps/desktop/src/main/model-access/mediaModels.ts
+++ b/apps/desktop/src/main/model-access/mediaModels.ts
@@ -1,5 +1,5 @@
 import {
-  isModelDisabled,
+  isModelDisabledWithUniqueLegacyBasename,
   isProviderDisabled,
   MODEL_ACCESS_CATALOG_SCHEMA_VERSION,
   MODEL_ACCESS_MODELS_PATH,
@@ -74,6 +74,7 @@ export type ExecutableMediaModel = ModelCatalogEntry & { providerId: string };
 interface ExecutableMediaSnapshot {
   models: ModelCatalogEntry[];
   capabilitiesByModel: Map<string, ReadonlySet<MediaCapability>>;
+  guideIdsByModel: Map<string, string>;
   unavailableByModel: Map<string, UnavailableMediaModel>;
 }
 
@@ -101,6 +102,17 @@ export function isMediaModelExecutable(
   capability: MediaCapability,
 ): boolean {
   return executableMediaSnapshot?.capabilitiesByModel.get(modelId)?.has(capability) === true;
+}
+
+export function isMediaModelExecutableForGuide(
+  modelId: string,
+  guideId: string,
+  capability: MediaCapability,
+): boolean {
+  return (
+    executableMediaSnapshot?.guideIdsByModel.get(modelId) === guideId &&
+    isMediaModelExecutable(modelId, capability)
+  );
 }
 
 export { supportsMediaCapability } from '../cindy-media/mediaCapabilities.js';
@@ -153,8 +165,18 @@ export function filterEnabledGatewayMediaModels<
   access: ModelDisableOverrides | undefined,
 ): T[] {
   if (isProviderDisabled(access, CINDY_AI_PROVIDER_ID)) return [];
+  const candidateModelIds = models.map((model) => model.id);
   return models.filter((model) => {
-    if (isModelDisabled(access, CINDY_AI_PROVIDER_ID, model.id)) return false;
+    if (
+      isModelDisabledWithUniqueLegacyBasename(
+        access,
+        CINDY_AI_PROVIDER_ID,
+        model.id,
+        candidateModelIds,
+      )
+    ) {
+      return false;
+    }
     if (capability?.startsWith('image.') && model.mode !== 'image_generation') return false;
     if (capability?.startsWith('video.') && model.mode !== 'video_generation') return false;
     if (capability !== undefined) return supportsMediaCapability(model.modalities, capability);
@@ -346,6 +368,7 @@ async function buildExecutableMediaSnapshot(): Promise<ExecutableMediaSnapshot> 
   const models = await fetchGatewayMediaModels();
   const batch = await fetchMediaInvocationGuideBatch();
   const capabilitiesByModel = new Map<string, ReadonlySet<MediaCapability>>();
+  const guideIdsByModel = new Map<string, string>();
   const unavailableByModel = new Map<string, UnavailableMediaModel>();
 
   for (const model of models) {
@@ -385,12 +408,13 @@ async function buildExecutableMediaSnapshot(): Promise<ExecutableMediaSnapshot> 
         continue;
       }
       capabilitiesByModel.set(model.id, operations);
+      guideIdsByModel.set(model.id, resolvedGuide.guide.guideId);
     } catch (error) {
       unavailableByModel.set(model.id, unavailableFromGuideError(model.id, error));
     }
   }
 
-  return { models, capabilitiesByModel, unavailableByModel };
+  return { models, capabilitiesByModel, guideIdsByModel, unavailableByModel };
 }
 
 async function getExecutableMediaSnapshot(forceRefresh = false): Promise<ExecutableMediaSnapshot> {

--- a/apps/desktop/src/main/model-access/mediaModels.ts
+++ b/apps/desktop/src/main/model-access/mediaModels.ts
@@ -217,7 +217,8 @@ export async function fetchMediaInvocationGuide(
   modelId: string,
   timeoutMs = MEDIA_MODEL_REQUEST_TIMEOUT_MS,
 ): Promise<ResolvedMediaInvocationGuide> {
-  const query = new URLSearchParams({ modelId });
+  const guideModelId = mediaInvocationGuideModelId(modelId);
+  const query = new URLSearchParams({ modelId: guideModelId });
   const payload = await serverApiFetch<unknown>(
     `${MODEL_ACCESS_INVOCATION_GUIDE_PATH}?${query.toString()}`,
     {
@@ -226,7 +227,12 @@ export async function fetchMediaInvocationGuide(
       logLabel: MODEL_ACCESS_INVOCATION_GUIDE_PATH,
     },
   );
-  return parseResolvedGuidePayload(payload, modelId);
+  return parseResolvedGuidePayload(payload, guideModelId);
+}
+
+/** Guide 只按模型协议名查询；provider/routing namespace 仍保留在真实调用身份中。 */
+export function mediaInvocationGuideModelId(modelId: string): string {
+  return modelId.slice(modelId.lastIndexOf('/') + 1);
 }
 
 function parseResolvedGuidePayload(

--- a/packages/model-providers/src/__tests__/disableOverrides.test.ts
+++ b/packages/model-providers/src/__tests__/disableOverrides.test.ts
@@ -13,7 +13,12 @@ import { describe, expect, it } from 'vitest';
 
 import { actualSourceIdForModel, buildRegistry, connectedProvidersForAgent, effectiveSourceIdForModel, sourcesForModel } from '../registry.js';
 import { deriveModelList, deriveModelSections } from '../modelList.js';
-import { isModelDisabled, isProviderDisabled, modelDisableKey } from '../disableOverrides.js';
+import {
+  isModelDisabled,
+  isModelDisabledWithUniqueLegacyBasename,
+  isProviderDisabled,
+  modelDisableKey,
+} from '../disableOverrides.js';
 import type { Catalog, CatalogModel, Provider } from '../types.js';
 
 function model(id: string, extra: Partial<CatalogModel> = {}): CatalogModel {
@@ -51,6 +56,26 @@ describe('disableOverrides 决策函数', () => {
     expect(isProviderDisabled(access, 'alpha')).toBe(false);
     expect(isModelDisabled(undefined, 'alpha', 'claude-opus-5')).toBe(false);
     expect(isProviderDisabled(undefined, 'alpha')).toBe(false);
+  });
+
+  it('旧裸 modelId 仅在当前 namespaced 候选唯一时继承停用状态', () => {
+    const access = { disabledModels: { 'xd:gpt-image-2': true } };
+    expect(
+      isModelDisabledWithUniqueLegacyBasename(
+        access,
+        'xd',
+        'openai/gpt-image-2',
+        ['openai/gpt-image-2'],
+      ),
+    ).toBe(true);
+    expect(
+      isModelDisabledWithUniqueLegacyBasename(
+        access,
+        'xd',
+        'openai/gpt-image-2',
+        ['openai/gpt-image-2', 'other/gpt-image-2'],
+      ),
+    ).toBe(false);
   });
 });
 

--- a/packages/model-providers/src/builtin.ts
+++ b/packages/model-providers/src/builtin.ts
@@ -12,7 +12,7 @@
  *     必须静态维护的——活在 `catalog/providers.json`(仓内正本 = OSS 发布物 = dev 直读),
  *     此处从 json 引入作 bundled 兜底。
  *
- * 身份卡(id / auth / access / routing / titleModel / 媒体模型清单)是随代码走的事实:
+ * 身份卡(id / auth / access / routing / titleModel)是随代码走的事实:
  * 改它们必然伴随发版(SDK 集成 / 翻译桥 / 网关协议都是代码),所以写死在这里,
  * 不再经 OSS 下发。OSS `cfg/providers.json`(v2)只承载 xai 清单 + presets 模板,
  * 模型元数据与参考价只走同目录下严格版本化的 `model-registry.json`。
@@ -186,27 +186,6 @@ const XD_PROVIDER: Provider = {
   auth: { method: 'managed' },
   access: { kind: 'managed' },
   titleModel: 'gpt-5.4-mini',
-  imageModels: [
-    { id: 'gpt-image-2', name: 'GPT Image 2' },
-    { id: 'gemini-3-pro-image', name: 'Gemini 3 Pro Image' },
-    { id: 'gemini-3.1-flash-image', name: 'Gemini 3.1 Flash Image' },
-  ],
-  imageDefaults: {
-    standard: 'gpt-image-2',
-    draft: 'gemini-3.1-flash-image',
-  },
-  videoModels: [
-    { id: 'seedance-fast', name: 'Seedance 快速' },
-    { id: 'seedance-pro', name: 'Seedance Pro' },
-    { id: 'bytedance/seedance-2.5', name: 'Seedance 2.5' },
-    { id: 'happyhorse', name: 'HappyHorse 1.0' },
-  ],
-  // 2.5 刻意不接管 best:它只到 720p,而 seedance-pro 有 1080p —— 让 tier=best
-  // 指向 2.5 会把"要 1080p"的单子从可用变成明拒。2.5 需显式点名。
-  videoDefaults: {
-    standard: 'seedance-fast',
-    best: 'seedance-pro',
-  },
   // 向量模型:id 必须与 @cindy/embedding-client 的 EmbeddingModelId 逐字一致
   // (执行侧按 id 查 catalog 拿 provider 做 input_type 值域翻译,对不上就翻译不了)。
   // 只列 2026-08-04 经网关实测确认可用的型号 + 同族高置信的 3-large。

--- a/packages/model-providers/src/disableOverrides.ts
+++ b/packages/model-providers/src/disableOverrides.ts
@@ -43,3 +43,26 @@ export function isModelDisabled(
 ): boolean {
   return access?.disabledModels?.[modelDisableKey(providerId, modelId)] === true;
 }
+
+/**
+ * 兼容媒体模型从裸 ID 升级为带 namespace 的目录 ID。只有 basename 在当前候选中
+ * 唯一对应一个 namespaced ID 时才继承旧 override；有歧义时保持精确匹配语义。
+ */
+export function isModelDisabledWithUniqueLegacyBasename(
+  access: ModelDisableOverrides | undefined,
+  providerId: string,
+  modelId: string,
+  candidateModelIds: readonly string[],
+): boolean {
+  if (isModelDisabled(access, providerId, modelId)) return true;
+  const slash = modelId.lastIndexOf('/');
+  if (slash < 0 || slash === modelId.length - 1) return false;
+  const basename = modelId.slice(slash + 1);
+  if (!isModelDisabled(access, providerId, basename)) return false;
+  const matches = new Set(
+    candidateModelIds.filter(
+      (candidate) => candidate.slice(candidate.lastIndexOf('/') + 1) === basename,
+    ),
+  );
+  return matches.size === 1 && matches.has(modelId);
+}

--- a/packages/model-providers/src/index.ts
+++ b/packages/model-providers/src/index.ts
@@ -131,6 +131,7 @@ export type {
 export {
   modelDisableKey,
   isModelDisabled,
+  isModelDisabledWithUniqueLegacyBasename,
   isProviderDisabled,
 } from './disableOverrides.js';
 export type { ModelDisableOverrides } from './disableOverrides.js';


### PR DESCRIPTION
## 这次改了什么

### 摘要

客户端不再在 XD Provider 中硬编码媒体模型，也不再裁剪网关下发的 modelId。媒体模型从当前 Gateway catalog 按 `mode` / `modalities` 动态投影，展示、配置和实际调用始终保留完整 modelId；只有查询调用协议 Guide 时使用不带 provider namespace 的模型 basename。

兼容层保持单向且简单：旧调用缺少 providerId 且遇到同名来源时优先使用 Cindy AI；已保存的媒体选型失效时迁移到该能力当前第一个可用模型；只有列表为空时才报不可用。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护

### 范围

- 关联需求：Cindy 媒体模型完整 ID 与 Guide 查询键解耦。
- 本 PR 包含：
  - 从 Gateway catalog 动态生成 Cindy AI 媒体模型，不在客户端硬补模型。
  - 保留网关下发的完整 modelId 与 modalities，用于展示、配置和实际媒体调用。
  - 仅在 Guide 查询边界去除 namespace；prepare/submit 始终携带完整 modelId。
  - 保持第三方 Provider 的 providerId + modelId 区分，同名模型不会互相去重。
  - 兼容存量裸 modelId；已保存选型失效时迁移到当前第一个可用模型。
  - 对尚未传 providerId 的 Core Art 版本按 modelId 合并来源：优先 Cindy AI，否则保留第一个可用来源，避免兼容性导致有模型却不可用。
  - 旧调用缺 providerId 时沿用同一选择规则，页面配置与实际执行来源保持一致。
- 明确不包含：新增媒体协议、修改 Guide 内容、媒体价格/usage 适配。
- 用户可见变化：Cindy AI 的 `GPT Image 2`、`Gemini 3 Pro Image` 等模型可正常显示并按配置调用；OpenAI Provider 的同名模型仍独立可选；失效选型不再卡死媒体能力。
- Breaking change：无。服务端需先部署对应兼容 PR。

### UI 变化

- 不涉及视觉或交互改版，仅修正模型目录与调用数据链路。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop run --if-present typecheck
结果：PASS，0 errors

pnpm test:unit:related
结果：本次改动涉及的 cindySlot / invocationService 测试通过；apps/mobile 与 packages/model-providers 通过。Desktop 全量中 25 个无关的既有超时/文件监听用例失败，未在本 PR 扩散处理。

git diff --check
结果：PASS
```

### 手工验证

- 本地 Desktop 实例验证 Gateway 媒体模型可见，完整 modelId 用于调用，Guide 查询使用 basename。
- 验证 Cindy AI 与 OpenAI Provider 的同名 `GPT Image 2` 可按 provider 区分。

## 风险

### 风险分类

- [ ] 无已知风险
- [x] 协议兼容
- [x] 存量插件兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA

### 影响与回滚

- 影响范围：Desktop 的 Cindy AI 媒体模型目录、Art 插件模型配置与媒体 Guide 查询。
- 发布顺序：先合并并部署 cindy-server 的 Guide basename 兼容 PR，再合并本 PR。
- 存量插件影响：旧 `cindy-request` 仍由 Host 解析用户配置；未传 providerId 的 Core Art 会优先选择 Cindy AI，否则回落到第一个可用来源；provider-aware Art 保留完整来源选择。
- 存量配置影响：旧裸 ID 优先唯一映射到完整 XD modelId；已保存选型失效时一次性写回当前第一个可用模型，页面展示与实际执行保持一致。
- 回滚方式：回滚本 PR 即可恢复旧客户端目录逻辑；Server 兼容改动可继续保留。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] 未提交凭证、令牌或授权文件
- [x] 只保留主路径兼容测试，未为极端组合扩展用例
