### PR TITLE
fix(desktop): 刚发送的任务立刻按运行中排序并提前开始音效

### DIFF
--- a/apps/desktop/src/main/__tests__/interruptedContinuationContract.test.ts
+++ b/apps/desktop/src/main/__tests__/interruptedContinuationContract.test.ts
@@ -246,6 +246,18 @@ describe('interrupted continuation enqueue contract', () => {
     expect(drainImmediate).toBeGreaterThan(enqueuePreview);
   });
 
+  it('rolls back Agent Island enqueue preview when the queued item is discarded, rejected, or blocked', () => {
+    expect(registerSource).toContain(
+      "rollbackAgentIslandUserPrompt(sessionId, item.clientId, 'discarded')",
+    );
+    expect(registerSource).toContain(
+      "rollbackAgentIslandUserPrompt(sessionId, item.clientId, 'rejected')",
+    );
+    expect(registerSource).toContain(
+      "rollbackAgentIslandUserPrompt(sessionId, item.clientId, 'blocked')",
+    );
+  });
+
   it('fails a pending scheduler auto-resume before dispatching unrelated user input', () => {
     const userEnqueueStart = registerSource.indexOf('onUserEnqueue:');
     const userEnqueueEnd = registerSource.indexOf('onDiscardedQueuedMessage:', userEnqueueStart);

--- a/apps/desktop/src/main/__tests__/interruptedContinuationContract.test.ts
+++ b/apps/desktop/src/main/__tests__/interruptedContinuationContract.test.ts
@@ -237,6 +237,15 @@ describe('interrupted continuation enqueue contract', () => {
     expect(registerSource).toMatch(/supportsScheduleIntervalNullClear:\s*true/);
   });
 
+  it('previews user enqueues to Agent Island before drain/sendToAgent', () => {
+    expect(registerSource).toContain('previewQueuedUserTurn: (sessionId, item) => {');
+    expect(registerSource).toContain("source: 'enqueue'");
+    const enqueuePreview = coordinatorSource.indexOf('this.deps.previewQueuedUserTurn?.(sessionId, item);');
+    const drainImmediate = coordinatorSource.indexOf("void this.drain(sessionId, 'enqueue-immediate');");
+    expect(enqueuePreview).toBeGreaterThan(-1);
+    expect(drainImmediate).toBeGreaterThan(enqueuePreview);
+  });
+
   it('fails a pending scheduler auto-resume before dispatching unrelated user input', () => {
     const userEnqueueStart = registerSource.indexOf('onUserEnqueue:');
     const userEnqueueEnd = registerSource.indexOf('onDiscardedQueuedMessage:', userEnqueueStart);

--- a/apps/desktop/src/main/__tests__/interruptedContinuationContract.test.ts
+++ b/apps/desktop/src/main/__tests__/interruptedContinuationContract.test.ts
@@ -240,6 +240,8 @@ describe('interrupted continuation enqueue contract', () => {
   it('previews user enqueues to Agent Island before drain/sendToAgent', () => {
     expect(registerSource).toContain('previewQueuedUserTurn: (sessionId, item) => {');
     expect(registerSource).toContain("source: 'enqueue'");
+    expect(registerSource).toContain('item.text || item.persistedContent');
+    expect(registerSource).toContain('extractPlainText(content)');
     const enqueuePreview = coordinatorSource.indexOf('this.deps.previewQueuedUserTurn?.(sessionId, item);');
     const drainImmediate = coordinatorSource.indexOf("void this.drain(sessionId, 'enqueue-immediate');");
     expect(enqueuePreview).toBeGreaterThan(-1);

--- a/apps/desktop/src/main/__tests__/interruptedContinuationContract.test.ts
+++ b/apps/desktop/src/main/__tests__/interruptedContinuationContract.test.ts
@@ -242,15 +242,15 @@ describe('interrupted continuation enqueue contract', () => {
     expect(registerSource).toContain("source: 'enqueue'");
     expect(registerSource).toContain('item.text || item.persistedContent');
     expect(registerSource).toContain('extractPlainText(content)');
+    const drainableHead = coordinatorSource.indexOf(
+      'if (this.getDrainableHead(sessionId, state) === item)',
+    );
     const enqueuePreview = coordinatorSource.indexOf('this.deps.previewQueuedUserTurn?.(sessionId, item);');
     const drainImmediate = coordinatorSource.indexOf("void this.drain(sessionId, 'enqueue-immediate');");
-    expect(enqueuePreview).toBeGreaterThan(-1);
+    expect(drainableHead).toBeGreaterThan(-1);
+    expect(enqueuePreview).toBeGreaterThan(drainableHead);
     expect(drainImmediate).toBeGreaterThan(enqueuePreview);
-    const queueHeadContinueReturn = coordinatorSource.indexOf(
-      "this.scheduleDrain(sessionId, 'ui-continue-queue-head-unlock')",
-    );
-    expect(queueHeadContinueReturn).toBeGreaterThan(-1);
-    expect(enqueuePreview).toBeGreaterThan(queueHeadContinueReturn);
+    expect(coordinatorSource).toContain('!automaticOrigin && !isUiContinuationItem(item)');
   });
 
   it('rolls back Agent Island enqueue preview when the queued item is discarded, rejected, or blocked', () => {

--- a/apps/desktop/src/main/__tests__/interruptedContinuationContract.test.ts
+++ b/apps/desktop/src/main/__tests__/interruptedContinuationContract.test.ts
@@ -244,6 +244,11 @@ describe('interrupted continuation enqueue contract', () => {
     const drainImmediate = coordinatorSource.indexOf("void this.drain(sessionId, 'enqueue-immediate');");
     expect(enqueuePreview).toBeGreaterThan(-1);
     expect(drainImmediate).toBeGreaterThan(enqueuePreview);
+    const queueHeadContinueReturn = coordinatorSource.indexOf(
+      "this.scheduleDrain(sessionId, 'ui-continue-queue-head-unlock')",
+    );
+    expect(queueHeadContinueReturn).toBeGreaterThan(-1);
+    expect(enqueuePreview).toBeGreaterThan(queueHeadContinueReturn);
   });
 
   it('rolls back Agent Island enqueue preview when the queued item is discarded, rejected, or blocked', () => {

--- a/apps/desktop/src/main/__tests__/interruptedContinuationContract.test.ts
+++ b/apps/desktop/src/main/__tests__/interruptedContinuationContract.test.ts
@@ -241,7 +241,7 @@ describe('interrupted continuation enqueue contract', () => {
     expect(registerSource).toContain('previewQueuedUserTurn: (sessionId, item) => {');
     expect(registerSource).toContain("source: 'enqueue'");
     expect(registerSource).toContain('item.text || item.persistedContent');
-    expect(registerSource).toContain('extractPlainText(content)');
+    expect(registerSource).toContain('extractAgentIslandPromptText(content)');
     const drainableHead = coordinatorSource.indexOf(
       'if (this.getDrainableHead(sessionId, state) === item)',
     );

--- a/apps/desktop/src/main/__tests__/makerSendToSessionOrdering.test.ts
+++ b/apps/desktop/src/main/__tests__/makerSendToSessionOrdering.test.ts
@@ -555,11 +555,12 @@ describe('sendToSession ordering', () => {
     const promptPreviewBlock = extractBetween(
       source,
       'function notifyAgentIslandUserPrompt',
-      'function extractAgentIslandPromptText',
+      'function dispatchAgentIslandUserPrompt',
     );
 
     expect(promptPreviewBlock).toContain('try {');
-    expect(promptPreviewBlock).toContain('getAgentIslandService()?.handleUserPrompt');
+    expect(promptPreviewBlock).toContain('getAgentIslandService()');
+    expect(promptPreviewBlock).toContain('service.handleUserPrompt');
     expect(promptPreviewBlock).toContain('log.warn(\'Agent Island prompt preview update failed after user message persistence\'');
     expect(promptPreviewBlock).toContain('clientId: options.clientId');
     expect(promptPreviewBlock).toContain('error: error instanceof Error ? error.message : String(error)');

--- a/apps/desktop/src/main/agent-island/__tests__/service.test.ts
+++ b/apps/desktop/src/main/agent-island/__tests__/service.test.ts
@@ -2323,6 +2323,39 @@ describe('AgentIslandService native publishing', () => {
     expect(sessionIds).not.toContain('session-a');
   });
 
+  it('restores the same session completion reveal after a blocked follow-up preview', async () => {
+    const { AgentIslandService } = await import('../service.js');
+    const publish = vi.fn((state: AgentIslandDisplayState, frameOrFrames: AgentIslandNativeFrame | AgentIslandNativeFrame[]) => {
+      void state;
+      void frameOrFrames;
+      return true;
+    });
+    const playSound = vi.fn<(sound: AgentIslandSoundChoice) => boolean>(() => true);
+    const service = new AgentIslandService({
+      getMainWindow: () => null,
+      nativeHost: { failed: false, publish, playSound },
+    });
+    syncEnabledForTest(service, publish);
+    service.setAppFocused(false);
+
+    service.handleUserPrompt({ sessionId: 's1', agentKind: 'codex' }, 'run tests');
+    service.handleAgentEvent({ sessionId: 's1', agentKind: 'codex' }, doneEvent());
+    expect(publish.mock.calls.at(-1)?.[0]).toMatchObject({
+      displaySurface: 'completionCard',
+      currentSessionId: 's1',
+    });
+
+    service.handleUserPrompt({ sessionId: 's1', agentKind: 'codex' }, 'follow up', {
+      clientId: 'follow',
+    });
+    service.rollbackUserPrompt('s1', 'follow');
+
+    expect(publish.mock.calls.at(-1)?.[0]).toMatchObject({
+      displaySurface: 'completionCard',
+      currentSessionId: 's1',
+    });
+  });
+
   it('removes user-stopped sessions and ignores provider completion tails without playing completion sound', async () => {
     const { AgentIslandService } = await import('../service.js');
     const publish = vi.fn((state: AgentIslandDisplayState, frameOrFrames: AgentIslandNativeFrame | AgentIslandNativeFrame[]) => {

--- a/apps/desktop/src/main/agent-island/__tests__/service.test.ts
+++ b/apps/desktop/src/main/agent-island/__tests__/service.test.ts
@@ -2239,6 +2239,59 @@ describe('AgentIslandService native publishing', () => {
     expect(playSound).toHaveBeenNthCalledWith(2, customSound('complete.wav'));
   });
 
+  it('plays the start sound on user prompt without waiting for an isRunning status event', async () => {
+    const { AgentIslandService } = await import('../service.js');
+    const publish = vi.fn((state: AgentIslandDisplayState, frameOrFrames: AgentIslandNativeFrame | AgentIslandNativeFrame[]) => {
+      void state;
+      void frameOrFrames;
+      return true;
+    });
+    const playSound = vi.fn<(sound: AgentIslandSoundChoice) => boolean>(() => true);
+    const service = new AgentIslandService({
+      getMainWindow: () => null,
+      nativeHost: { failed: false, publish, playSound },
+    });
+    syncEnabledForTest(service, publish);
+    service.setSoundSettings({
+      enabled: true,
+      sounds: {
+        ...DEFAULT_AGENT_ISLAND_SOUND_SETTINGS.sounds,
+        start: customSound('start.wav'),
+      },
+    });
+    playSound.mockClear();
+
+    service.handleUserPrompt({ sessionId: 's1', agentKind: 'codex' }, 'run tests');
+
+    expect(playSound).toHaveBeenCalledWith(customSound('start.wav'));
+    expect(publish.mock.calls.at(-1)?.[0].sessions[0]).toMatchObject({
+      sessionId: 's1',
+      phase: 'running',
+    });
+  });
+
+  it('keeps the first rollback snapshot when the same clientId is previewed again', async () => {
+    const { AgentIslandService } = await import('../service.js');
+    const publish = vi.fn((state: AgentIslandDisplayState, frameOrFrames: AgentIslandNativeFrame | AgentIslandNativeFrame[]) => {
+      void state;
+      void frameOrFrames;
+      return true;
+    });
+    const playSound = vi.fn<(sound: AgentIslandSoundChoice) => boolean>(() => true);
+    const service = new AgentIslandService({
+      getMainWindow: () => null,
+      nativeHost: { failed: false, publish, playSound },
+    });
+    syncEnabledForTest(service, publish);
+    const meta = { sessionId: 's1', agentKind: 'codex' as const };
+
+    service.handleUserPrompt(meta, 'first preview', { clientId: 'c1' });
+    service.handleUserPrompt(meta, 'persist preview', { clientId: 'c1' });
+    service.rollbackUserPrompt(meta.sessionId, 'c1');
+
+    expect(publish.mock.calls.at(-1)?.[0].sessions).toEqual([]);
+  });
+
   it('removes user-stopped sessions and ignores provider completion tails without playing completion sound', async () => {
     const { AgentIslandService } = await import('../service.js');
     const publish = vi.fn((state: AgentIslandDisplayState, frameOrFrames: AgentIslandNativeFrame | AgentIslandNativeFrame[]) => {

--- a/apps/desktop/src/main/agent-island/__tests__/service.test.ts
+++ b/apps/desktop/src/main/agent-island/__tests__/service.test.ts
@@ -2294,6 +2294,35 @@ describe('AgentIslandService native publishing', () => {
     expect(publish.mock.calls.at(-1)?.[0].sessions).toEqual([]);
   });
 
+  it('does not rewind another session reveal when rolling back a blocked preview', async () => {
+    const { AgentIslandService } = await import('../service.js');
+    const publish = vi.fn((state: AgentIslandDisplayState, frameOrFrames: AgentIslandNativeFrame | AgentIslandNativeFrame[]) => {
+      void state;
+      void frameOrFrames;
+      return true;
+    });
+    const playSound = vi.fn<(sound: AgentIslandSoundChoice) => boolean>(() => true);
+    const service = new AgentIslandService({
+      getMainWindow: () => null,
+      nativeHost: { failed: false, publish, playSound },
+    });
+    syncEnabledForTest(service, publish);
+
+    service.handleUserPrompt({ sessionId: 'session-a', agentKind: 'codex' }, 'task a', {
+      clientId: 'client-a',
+    });
+    service.handleUserPrompt({ sessionId: 'session-b', agentKind: 'codex' }, 'task b', {
+      clientId: 'client-b',
+    });
+    service.rollbackUserPrompt('session-a', 'client-a');
+
+    const sessionIds = (publish.mock.calls.at(-1)?.[0].sessions ?? []).map(
+      (session) => session.sessionId,
+    );
+    expect(sessionIds).toContain('session-b');
+    expect(sessionIds).not.toContain('session-a');
+  });
+
   it('removes user-stopped sessions and ignores provider completion tails without playing completion sound', async () => {
     const { AgentIslandService } = await import('../service.js');
     const publish = vi.fn((state: AgentIslandDisplayState, frameOrFrames: AgentIslandNativeFrame | AgentIslandNativeFrame[]) => {

--- a/apps/desktop/src/main/agent-island/__tests__/service.test.ts
+++ b/apps/desktop/src/main/agent-island/__tests__/service.test.ts
@@ -2286,7 +2286,9 @@ describe('AgentIslandService native publishing', () => {
     const meta = { sessionId: 's1', agentKind: 'codex' as const };
 
     service.handleUserPrompt(meta, 'first preview', { clientId: 'c1' });
+    playSound.mockClear();
     service.handleUserPrompt(meta, 'persist preview', { clientId: 'c1' });
+    expect(playSound).not.toHaveBeenCalled();
     service.rollbackUserPrompt(meta.sessionId, 'c1');
 
     expect(publish.mock.calls.at(-1)?.[0].sessions).toEqual([]);

--- a/apps/desktop/src/main/agent-island/service.ts
+++ b/apps/desktop/src/main/agent-island/service.ts
@@ -839,6 +839,12 @@ export class AgentIslandService {
   handleUserPrompt(meta: AgentIslandSessionMeta, prompt: string, debugMeta: AgentIslandUserPromptDebugMeta = {}): boolean {
     const receivedAt = Date.now();
     const hydrated = this.hydrateMeta(meta);
+    const rollbackKey = this.userPromptRollbackKey(hydrated.sessionId, debugMeta.clientId);
+    // 入队预览和 persist 预览共用 clientId。已经预览过的第二次只确认,不再追加
+    // activity、不推进 epoch,否则岛上同一条消息出现两遍、开始音效对应的回滚基线也会被冲掉。
+    if (rollbackKey && this.userPromptRollbackTokens.has(rollbackKey)) {
+      return true;
+    }
     const previousInteractionEpoch = this.interactionEpochBySession.get(hydrated.sessionId);
     const wasStopped = this.stoppedSessionIds.has(hydrated.sessionId);
     const wasReplacementTurnPending = this.replacementTurnPendingSessionIds.has(hydrated.sessionId);
@@ -859,10 +865,7 @@ export class AgentIslandService {
     if (deferInteractionEpochUntilDispatch) {
       this.replacementTurnDispatchingSessionIds.delete(hydrated.sessionId);
     }
-    const rollbackKey = this.userPromptRollbackKey(hydrated.sessionId, debugMeta.clientId);
-    // 入队预览和 persist 预览共用 clientId。第一次快照才是「发送前」;
-    // 第二次若覆盖,persist 失败回滚会回到 running,开始音效对应的预览就撤不掉。
-    if (rollbackKey && !this.userPromptRollbackTokens.has(rollbackKey)) {
+    if (rollbackKey) {
       this.userPromptRollbackTokens.set(rollbackKey, {
         state: createAgentIslandUserPromptRollbackToken(this.state, hydrated.sessionId),
         attention: this.sessionHadAttentionAtRunStart.has(hydrated.sessionId)

--- a/apps/desktop/src/main/agent-island/service.ts
+++ b/apps/desktop/src/main/agent-island/service.ts
@@ -860,7 +860,9 @@ export class AgentIslandService {
       this.replacementTurnDispatchingSessionIds.delete(hydrated.sessionId);
     }
     const rollbackKey = this.userPromptRollbackKey(hydrated.sessionId, debugMeta.clientId);
-    if (rollbackKey) {
+    // 入队预览和 persist 预览共用 clientId。第一次快照才是「发送前」;
+    // 第二次若覆盖,persist 失败回滚会回到 running,开始音效对应的预览就撤不掉。
+    if (rollbackKey && !this.userPromptRollbackTokens.has(rollbackKey)) {
       this.userPromptRollbackTokens.set(rollbackKey, {
         state: createAgentIslandUserPromptRollbackToken(this.state, hydrated.sessionId),
         attention: this.sessionHadAttentionAtRunStart.has(hydrated.sessionId)

--- a/apps/desktop/src/main/agent-island/state.ts
+++ b/apps/desktop/src/main/agent-island/state.ts
@@ -483,14 +483,51 @@ export function rollbackAgentIslandUserPrompt(
   state: AgentIslandState,
   token: AgentIslandUserPromptRollbackToken,
 ): void {
-  // 只还原该 session 自己的条目。全局 reveal 是岛级共享状态,回滚时不能
-  // 用入队时的快照覆盖,否则会把期间其它 session 的 reveal 一起抹掉。
+  // 只还原该 session 自己的条目和它自己的 reveal 归属。禁止整份写回
+  // activeTransientSessionId / reveal queue,否则会盖掉其它 session。
   if (token.session) {
-    state.sessions.set(token.sessionId, cloneSession(token.session));
+    const restored = cloneSession(token.session);
+    state.sessions.set(token.sessionId, restored);
+    restoreSessionScopedReveal(state, restored, Date.now());
     return;
   }
   state.sessions.delete(token.sessionId);
   removeQueuedTransientReveal(state, token.sessionId);
+}
+
+function restoreSessionScopedReveal(
+  state: AgentIslandState,
+  session: AgentIslandSessionState,
+  now: number,
+): void {
+  const sessionId = session.sessionId;
+  const wantsActive = session.revealUntil != null
+    && session.revealUntil > now
+    && session.deferredReveal !== true;
+  const wantsQueued = session.deferredRevealReason === 'queued';
+  if (!wantsActive && !wantsQueued) return;
+
+  if (wantsActive) {
+    if (!state.activeTransientSessionId || state.activeTransientSessionId === sessionId) {
+      state.activeTransientSessionId = sessionId;
+      state.transientRevealQueue = state.transientRevealQueue.filter(
+        (queuedSessionId) => queuedSessionId !== sessionId,
+      );
+      return;
+    }
+    if (!state.transientRevealQueue.includes(sessionId)) {
+      state.transientRevealQueue.push(sessionId);
+    }
+    session.deferredReveal = true;
+    session.deferredRevealReason = 'queued';
+    session.revealUntil = null;
+    return;
+  }
+
+  if (state.activeTransientSessionId === sessionId) return;
+  if (!state.transientRevealQueue.includes(sessionId)) {
+    state.transientRevealQueue.push(sessionId);
+  }
 }
 
 export function applyAgentIslandEvent(

--- a/apps/desktop/src/main/agent-island/state.ts
+++ b/apps/desktop/src/main/agent-island/state.ts
@@ -157,8 +157,6 @@ interface AgentIslandSessionState {
 export interface AgentIslandUserPromptRollbackToken {
   sessionId: string;
   session: AgentIslandSessionState | null;
-  activeTransientSessionId: string | null;
-  transientRevealQueue: string[];
 }
 
 /**
@@ -478,8 +476,6 @@ export function createAgentIslandUserPromptRollbackToken(
   return {
     sessionId,
     session: session ? cloneSession(session) : null,
-    activeTransientSessionId: state.activeTransientSessionId,
-    transientRevealQueue: [...state.transientRevealQueue],
   };
 }
 
@@ -487,13 +483,14 @@ export function rollbackAgentIslandUserPrompt(
   state: AgentIslandState,
   token: AgentIslandUserPromptRollbackToken,
 ): void {
+  // 只还原该 session 自己的条目。全局 reveal 是岛级共享状态,回滚时不能
+  // 用入队时的快照覆盖,否则会把期间其它 session 的 reveal 一起抹掉。
   if (token.session) {
     state.sessions.set(token.sessionId, cloneSession(token.session));
-  } else {
-    state.sessions.delete(token.sessionId);
+    return;
   }
-  state.activeTransientSessionId = token.activeTransientSessionId;
-  state.transientRevealQueue = [...token.transientRevealQueue];
+  state.sessions.delete(token.sessionId);
+  removeQueuedTransientReveal(state, token.sessionId);
 }
 
 export function applyAgentIslandEvent(

--- a/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
@@ -2941,6 +2941,7 @@ describe('AgentInputCoordinator send transaction', () => {
     // text 是 CONTINUE_AFTER_ERROR_PROMPT → enqueue 入口 captureOriginalSyntheticTrigger
     // 自动识别为 'continue'(isUiContinuationItem 判定),无需也不能显式赋值。
     const continueItem = makeItem('q-continue', CONTINUE_AFTER_ERROR_PROMPT);
+    h.previewQueuedUserTurn.mockClear();
     h.coordinator.enqueue(sid, continueItem);
     await flush();
 
@@ -2955,6 +2956,7 @@ describe('AgentInputCoordinator send transaction', () => {
     });
     // queue-head 从不发 onUiRetry(与 retryLastError 语义一致)。
     expect(h.onUiRetry).not.toHaveBeenCalled();
+    expect(h.previewQueuedUserTurn).not.toHaveBeenCalled();
   });
 
   it('queue-head retry never substitutes the continue prompt and redrains the original head', async () => {

--- a/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
@@ -266,6 +266,9 @@ function createHarness(opts?: {
     NonNullable<AgentInputCoordinatorDeps['onAutomaticEnqueue']>
   >(() => {});
   const onUserEnqueue = vi.fn<NonNullable<AgentInputCoordinatorDeps['onUserEnqueue']>>(() => {});
+  const previewQueuedUserTurn = vi.fn<
+    NonNullable<AgentInputCoordinatorDeps['previewQueuedUserTurn']>
+  >(() => {});
   const onDiscardedQueuedMessage = vi.fn<
     NonNullable<AgentInputCoordinatorDeps['onDiscardedQueuedMessage']>
   >(() => {});
@@ -282,6 +285,7 @@ function createHarness(opts?: {
     onUiRetry,
     onAutomaticEnqueue,
     onUserEnqueue,
+    previewQueuedUserTurn,
     onDiscardedQueuedMessage,
     onRejectedUserTurn,
     supersedeRetriedUserTurn,
@@ -356,6 +360,7 @@ function createHarness(opts?: {
     onUiRetry,
     onAutomaticEnqueue,
     onUserEnqueue,
+    previewQueuedUserTurn,
     onDiscardedQueuedMessage,
     onRejectedUserTurn,
     supersedeRetriedUserTurn,
@@ -2825,6 +2830,44 @@ describe('AgentInputCoordinator send transaction', () => {
     h.coordinator.enqueue(sid, makeItem('q-normal', '顺手问个别的'));
     await flush();
     expect(h.onUserEnqueue).toHaveBeenCalledWith(sid);
+    expect(h.previewQueuedUserTurn).toHaveBeenCalledWith(
+      sid,
+      expect.objectContaining({ clientId: 'q-normal', text: '顺手问个别的' }),
+    );
+  });
+
+  it('previews a user enqueue to Agent Island before sendToAgent starts', async () => {
+    const h = createHarness();
+    const sid = 'island-preview-before-send';
+    const sendStarted = deferred<AgentInputSendResult>();
+    h.sendToAgent.mockImplementationOnce(async () => sendStarted.promise);
+
+    h.coordinator.enqueue(sid, makeItem('q-preview', 'start this task'));
+    await flush();
+
+    expect(h.previewQueuedUserTurn).toHaveBeenCalledWith(
+      sid,
+      expect.objectContaining({ clientId: 'q-preview', text: 'start this task' }),
+    );
+    expect(h.previewQueuedUserTurn.mock.invocationCallOrder[0]).toBeLessThan(
+      h.sendToAgent.mock.invocationCallOrder[0],
+    );
+
+    sendStarted.resolve(sendSuccess());
+    await flush();
+  });
+
+  it('does not preview automatic enqueues to Agent Island', async () => {
+    const h = createHarness();
+    const sid = 'island-preview-skip-auto';
+    h.coordinator.enqueue(
+      sid,
+      makeItem('q-orca', 'worker output', {
+        origin: { kind: 'orca', senderLabel: 'worker' },
+      }),
+    );
+    await flush();
+    expect(h.previewQueuedUserTurn).not.toHaveBeenCalled();
   });
 
   it('a deduplicated resend does not report a user enqueue', async () => {

--- a/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
@@ -2830,10 +2830,6 @@ describe('AgentInputCoordinator send transaction', () => {
     h.coordinator.enqueue(sid, makeItem('q-normal', '顺手问个别的'));
     await flush();
     expect(h.onUserEnqueue).toHaveBeenCalledWith(sid);
-    expect(h.previewQueuedUserTurn).toHaveBeenCalledWith(
-      sid,
-      expect.objectContaining({ clientId: 'q-normal', text: '顺手问个别的' }),
-    );
   });
 
   it('previews a user enqueue to Agent Island before sendToAgent starts', async () => {
@@ -2852,6 +2848,25 @@ describe('AgentInputCoordinator send transaction', () => {
     expect(h.previewQueuedUserTurn.mock.invocationCallOrder[0]).toBeLessThan(
       h.sendToAgent.mock.invocationCallOrder[0],
     );
+
+    sendStarted.resolve(sendSuccess());
+    await flush();
+  });
+
+  it('does not preview a user enqueue that stays queued behind an active turn', async () => {
+    const h = createHarness();
+    const sid = 'island-preview-queued-behind';
+    const sendStarted = deferred<AgentInputSendResult>();
+    h.sendToAgent.mockImplementationOnce(async () => sendStarted.promise);
+
+    h.coordinator.enqueue(sid, makeItem('q-first', 'first'));
+    await flush();
+    expect(h.previewQueuedUserTurn).toHaveBeenCalledTimes(1);
+    h.previewQueuedUserTurn.mockClear();
+
+    h.coordinator.enqueue(sid, makeItem('q-second', 'second'));
+    await flush();
+    expect(h.previewQueuedUserTurn).not.toHaveBeenCalled();
 
     sendStarted.resolve(sendSuccess());
     await flush();

--- a/apps/desktop/src/main/maker-ipc/__tests__/agentHandoff.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/agentHandoff.test.ts
@@ -5,6 +5,7 @@ import {
   composeForkOriginHandoff,
   buildHandoffText,
   createAgentHandoffPendingRegistry,
+  extractAgentIslandPromptText,
   extractPlainText,
   prependHandoffToUserMessage,
   type HandoffSourceMessage,
@@ -59,6 +60,21 @@ describe('extractPlainText', () => {
   it('DB user envelope preserves a hand-written marker without quotesEncoded', () => {
     const text = '> <!-- cindy-composer-quote -->\n> hand written';
     expect(extractPlainText({ text, quotesEncoded: false })).toBe(text);
+  });
+});
+
+describe('extractAgentIslandPromptText', () => {
+  it('keeps literal JSON prompts instead of treating them as envelopes', () => {
+    expect(extractAgentIslandPromptText('{"foo":"bar"}')).toBe('{"foo":"bar"}');
+    expect(extractAgentIslandPromptText('[1,2]')).toBe('[1,2]');
+    expect(extractAgentIslandPromptText('{"text":"hello"}')).toBe('{"text":"hello"}');
+  });
+
+  it('unwraps stringifyUserContent envelopes only', () => {
+    expect(
+      extractAgentIslandPromptText(JSON.stringify({ text: 'hello', images: [], files: [] })),
+    ).toBe('hello');
+    expect(extractAgentIslandPromptText({ text: 'hello', images: [], files: [] })).toBe('hello');
   });
 });
 

--- a/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
+++ b/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
@@ -1528,9 +1528,6 @@ export class AgentInputCoordinator {
     // 而静默顺延(PR #972 review P2)。侧栏排序的 bump 语义保留在派发时刻 ——
     // runner 的 accepted 回调按直发路径同款调 touchUserSendInDb(ctx.firedAt)。
     if (!automaticOrigin) {
-      // 合成 Continue 在 queue-head 特判里已经 return,不会走到这里。
-      // 只预览真正留下的排队项,避免内部 Continue prompt 进灵动岛。
-      this.deps.previewQueuedUserTurn?.(sessionId, item);
       this.touchUserSend(sessionId, opts?.sendAtMs);
     }
     // 视觉连续性: 当这条入队后立即可派发(agent 空闲、队列此前为空、无暂停/锁/恢复
@@ -1541,6 +1538,11 @@ export class AgentInputCoordinator {
     // 仍有 getDrainableHead 幂等校验, 不会与既有 wake 点重复派发。agent 忙 / 队列
     // 已有积压时走 else, 维持原排队语义(emit 中间态 + 异步 drain)。
     if (this.getDrainableHead(sessionId, state) === item) {
+      // 只预览马上要派发的队首。排队项若也预览,删除较早项会把整份岛快照滚回去,
+      // 抹掉后来的预览和期间事件。合成 Continue 同样不预览内部 prompt。
+      if (!automaticOrigin && !isUiContinuationItem(item)) {
+        this.deps.previewQueuedUserTurn?.(sessionId, item);
+      }
       void this.drain(sessionId, 'enqueue-immediate');
     } else {
       this.emit(sessionId);

--- a/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
+++ b/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
@@ -1429,12 +1429,10 @@ export class AgentInputCoordinator {
       if (state.recovery?.kind !== 'queue-head') {
         this.deps.onUiRetry?.(sessionId, item.clientId, 'manual');
       }
-      this.deps.previewQueuedUserTurn?.(sessionId, item);
     } else if (automaticOrigin && !schedulerOrigin) {
       this.deps.onAutomaticEnqueue?.(sessionId);
     } else if (!automaticOrigin) {
       this.deps.onUserEnqueue?.(sessionId);
-      this.deps.previewQueuedUserTurn?.(sessionId, item);
     }
     if (!schedulerOrigin) {
       // 有用户动作入队(用户自己接手,或自愈的续跑指令本身)→ 撤掉「重新连接中」提示。
@@ -1530,6 +1528,9 @@ export class AgentInputCoordinator {
     // 而静默顺延(PR #972 review P2)。侧栏排序的 bump 语义保留在派发时刻 ——
     // runner 的 accepted 回调按直发路径同款调 touchUserSendInDb(ctx.firedAt)。
     if (!automaticOrigin) {
+      // 合成 Continue 在 queue-head 特判里已经 return,不会走到这里。
+      // 只预览真正留下的排队项,避免内部 Continue prompt 进灵动岛。
+      this.deps.previewQueuedUserTurn?.(sessionId, item);
       this.touchUserSend(sessionId, opts?.sendAtMs);
     }
     // 视觉连续性: 当这条入队后立即可派发(agent 空闲、队列此前为空、无暂停/锁/恢复

--- a/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
+++ b/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
@@ -470,6 +470,11 @@ export interface AgentInputCoordinatorDeps {
    * pendingQueue.unshift、不经这两个用户输入入口, 于是不会自我作废。
    */
   onUserEnqueue?: (sessionId: string) => void;
+  /**
+   * 真人消息刚进队、尚未 drain / sendToAgent。灵动岛用它在 agent 进程拉起前
+   * 就进入 running 并播开始音效,避免「任务开始」跟着 isRunning 一起晚响。
+   */
+  previewQueuedUserTurn?: (sessionId: string, item: AgentInputQueuedMessage) => void;
   /** 自动输入推进了会话，但不构成真人介入，也不能重置自动恢复预算。 */
   onAutomaticEnqueue?: (sessionId: string) => void;
   /**
@@ -1424,10 +1429,12 @@ export class AgentInputCoordinator {
       if (state.recovery?.kind !== 'queue-head') {
         this.deps.onUiRetry?.(sessionId, item.clientId, 'manual');
       }
+      this.deps.previewQueuedUserTurn?.(sessionId, item);
     } else if (automaticOrigin && !schedulerOrigin) {
       this.deps.onAutomaticEnqueue?.(sessionId);
     } else if (!automaticOrigin) {
       this.deps.onUserEnqueue?.(sessionId);
+      this.deps.previewQueuedUserTurn?.(sessionId, item);
     }
     if (!schedulerOrigin) {
       // 有用户动作入队(用户自己接手,或自愈的续跑指令本身)→ 撤掉「重新连接中」提示。
@@ -4422,6 +4429,7 @@ export class AgentInputCoordinator {
       if (!isSchedulerOriginItem(item)) this.deps.onAutomaticEnqueue?.(sessionId);
     } else if (!isUiContinuationItem(item)) {
       this.deps.onUserEnqueue?.(sessionId);
+      this.deps.previewQueuedUserTurn?.(sessionId, item);
     }
     this.abandonActiveTurnRecoveryForUserAction(state);
     this.clearErrorUnlessQueueHeadBlocked(state, item.clientId);

--- a/apps/desktop/src/main/maker-ipc/agentHandoff.ts
+++ b/apps/desktop/src/main/maker-ipc/agentHandoff.ts
@@ -145,6 +145,42 @@ export function extractPlainText(content: unknown): string {
   return '';
 }
 
+function isStringifyUserContentEnvelope(
+  value: unknown,
+): value is { text: string } {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const record = value as Record<string, unknown>;
+  return typeof record.text === 'string'
+    && Array.isArray(record.images)
+    && Array.isArray(record.files);
+}
+
+/** 岛上预览正文:只解开 stringifyUserContent 信封,JSON 原文提示保持原样。 */
+export function extractAgentIslandPromptText(content: unknown): string | null {
+  if (typeof content === 'string') {
+    const trimmed = content.trim();
+    if (!trimmed) return null;
+    if (trimmed.startsWith('{')) {
+      try {
+        const parsed: unknown = JSON.parse(trimmed);
+        if (isStringifyUserContentEnvelope(parsed)) {
+          const text = parsed.text.trim();
+          return text || null;
+        }
+      } catch {
+        // 用户原文就是 JSON 形字符串。
+      }
+    }
+    return trimmed;
+  }
+  if (isStringifyUserContentEnvelope(content)) {
+    const text = content.text.trim();
+    return text || null;
+  }
+  const text = extractPlainText(content).trim();
+  return text || null;
+}
+
 interface Turn {
   userText: string;
   /** 轮内按序的展示行(assistant 文本 / 工具行 / 错误行)。 */

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -11674,6 +11674,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
       publishUiSessionIntervention(sessionId);
     },
     onRejectedUserTurn: (sessionId, item) => {
+      rollbackAgentIslandUserPrompt(sessionId, item.clientId, 'rejected');
       // Auto-resume items have an exact-token cleanup boundary below. Keep
       // their attempt lease until that boundary can restore recovery and
       // finalize the suppressed error; releasing it here would make a later
@@ -11683,6 +11684,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
     },
     // 队列项未派发即被丢弃(stop/remove/clearSession) → 释放暂存的 accepted 副作用, 防回调表泄漏。
     onDiscardedQueuedMessage: (sessionId, item) => {
+      rollbackAgentIslandUserPrompt(sessionId, item.clientId, 'discarded');
       discardQueuedAttachmentOwnership(sessionId, item.clientId);
       orcaInterAgentDispatcher.discardQueuedOrcaInterAgentAcceptedCallback(item.clientId);
       // Auto-resume cleanup must run before generic claimed-retry release:
@@ -11732,13 +11734,15 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
         screenGhostUserMessage(sessionId, agentFacingText),
       );
     },
-    onUserMessageBlocked: (sessionId, item, verdict) =>
+    onUserMessageBlocked: (sessionId, item, verdict) => {
+      rollbackAgentIslandUserPrompt(sessionId, item.clientId, 'blocked');
       broadcastGhostMessageBlocked({
         sessionId,
         clientId: item.clientId,
         text: item.text,
         ...verdict,
-      }),
+      });
+    },
     onUserMessageRewritten: (sessionId, item, info) =>
       broadcastGhostMessageRewritten({ sessionId, clientId: item.clientId, ...info }),
     beforeDispatchUserTurn: async (sessionId, item) => {

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -11655,6 +11655,17 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
       failPendingSchedulerAutoResume(sessionId);
       publishUiSessionIntervention(sessionId);
     },
+    previewQueuedUserTurn: (sessionId, item) => {
+      notifyAgentIslandUserPrompt(
+        {
+          id: sessionId,
+          agentKind: item.createOpts?.agentKind,
+          workDir: item.workingDir,
+        },
+        item.persistedContent || item.text,
+        { source: 'enqueue', clientId: item.clientId },
+      );
+    },
     onAutomaticEnqueue: (sessionId) => {
       // Orca 等自动输入会推进同一会话，必须撤销旧 retry owner，避免它消费这轮事件；
       // 但预算充值仍只发生在真人消息的持久化路径，自动输入不会重置 episode。

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -693,6 +693,7 @@ import {
   type MakerSessionAgentSwitchHandlerDeps,
 } from './sessionAgentSwitchHandler.js';
 import {
+  extractPlainText,
   prependNoteToWireUserMessage,
   prependHandoffToUserMessage,
   type HandoffWireMessage,
@@ -3272,28 +3273,9 @@ function rollbackAgentIslandUserPrompt(
 }
 
 function extractAgentIslandPromptText(content: unknown): string | null {
-  if (typeof content === 'string') return content.trim() || null;
-  if (Array.isArray(content)) return extractAgentIslandPromptTextFromBlocks(content);
-  if (!content || typeof content !== 'object') return null;
-  const record = content as { content?: unknown; text?: unknown };
-  if (typeof record.content === 'string') return record.content.trim() || null;
-  if (Array.isArray(record.content)) return extractAgentIslandPromptTextFromBlocks(record.content);
-  if (typeof record.text === 'string') return record.text.trim() || null;
-  return null;
-}
-
-function extractAgentIslandPromptTextFromBlocks(blocks: unknown[]): string | null {
-  const text = blocks
-    .map((block) => {
-      if (typeof block === 'string') return block;
-      if (!block || typeof block !== 'object') return '';
-      const record = block as { type?: unknown; text?: unknown };
-      return record.type === 'text' && typeof record.text === 'string' ? record.text : '';
-    })
-    .map((line) => line.trim())
-    .filter(Boolean)
-    .join('\n')
-    .trim();
+  // 与落库信封、SDK blocks 共用 extractPlainText:stringifyUserContent JSON
+  // 不能当岛上正文显示。
+  const text = extractPlainText(content).trim();
   return text || null;
 }
 
@@ -11662,7 +11644,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
           agentKind: item.createOpts?.agentKind,
           workDir: item.workingDir,
         },
-        item.persistedContent || item.text,
+        item.text || item.persistedContent,
         { source: 'enqueue', clientId: item.clientId },
       );
     },

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -693,7 +693,7 @@ import {
   type MakerSessionAgentSwitchHandlerDeps,
 } from './sessionAgentSwitchHandler.js';
 import {
-  extractPlainText,
+  extractAgentIslandPromptText,
   prependNoteToWireUserMessage,
   prependHandoffToUserMessage,
   type HandoffWireMessage,
@@ -3272,12 +3272,7 @@ function rollbackAgentIslandUserPrompt(
   }
 }
 
-function extractAgentIslandPromptText(content: unknown): string | null {
-  // 与落库信封、SDK blocks 共用 extractPlainText:stringifyUserContent JSON
-  // 不能当岛上正文显示。
-  const text = extractPlainText(content).trim();
-  return text || null;
-}
+
 
 /**
  * 当前是否有任意一个 session 正在跑 turn。

--- a/apps/desktop/src/renderer/__tests__/mainListModel.test.ts
+++ b/apps/desktop/src/renderer/__tests__/mainListModel.test.ts
@@ -389,6 +389,27 @@ describe('buildMainListEntries — 排序口径', () => {
     expect(labels(entries)).toEqual(['s:needs-input', 's:done-unread', 's:running', 's:idle']);
   });
 
+  it('keeps a just-sent session at the top of running before the agent is actually live', () => {
+    // 组装层把 starting 并进 runningSessionIds。新发送比已在跑的更新,应压在运行中档顶;
+    // 更新的空闲任务仍在其余档,不能因为它更新就插到运行中前面。
+    const justSent = session({ updatedAt: '2026-08-12T12:00:00Z', title: 'just-sent' });
+    const runningOlder = session({ updatedAt: '2026-08-12T11:00:00Z', title: 'running-older' });
+    const idleNewer = session({ updatedAt: '2026-08-12T13:00:00Z', title: 'idle-newer' });
+    const entries = buildMainListEntries({
+      projects: [],
+      dialogues: [idleNewer, runningOlder, justSent],
+      groupBy: 'project',
+      groupDialogue: false,
+      sortBy: 'priority',
+      manualProjectOrder: [],
+      priorityContext: {
+        runningSessionIds: new Set([justSent.id, runningOlder.id]),
+        attentionSessionIds: new Set<string>(),
+      },
+    });
+    expect(labels(entries)).toEqual(['s:just-sent', 's:running-older', 's:idle-newer']);
+  });
+
   it('keeps the open unread task in place, then parks it at the top of the rest tier after leave', () => {
     const unread = session({ updatedAt: '2026-07-01T00:00:00Z', title: 'just-read' });
     const olderRest = session({ updatedAt: '2026-08-12T00:00:00Z', title: 'older-rest' });

--- a/apps/desktop/src/renderer/__tests__/newMakerWorktreeSend.test.ts
+++ b/apps/desktop/src/renderer/__tests__/newMakerWorktreeSend.test.ts
@@ -35,6 +35,15 @@ describe('NewMakerDraftRoute worktree send flow', () => {
     expect(worktreeCreate).toBeGreaterThan(navigate);
   });
 
+  it('clears starting when the first-message draft is restored after a send-before-start failure', () => {
+    const restore = source.indexOf('const restoreFirstMessageDraft = () => {');
+    const clearStarting = source.indexOf('clearSessionStarting(newSession.id)', restore);
+    const restoreEnd = source.indexOf('};', source.indexOf('emitAutoTitlePreviewCleared(newSession.id)', restore));
+    expect(restore).toBeGreaterThan(-1);
+    expect(clearStarting).toBeGreaterThan(restore);
+    expect(clearStarting).toBeLessThan(restoreEnd);
+  });
+
   it('never silently downgrades an explicit worktree request to a normal session', () => {
     const selected = source.indexOf('const selectedWorktree = { ...wtRef.current };');
     const guard = source.indexOf(

--- a/apps/desktop/src/renderer/__tests__/remoteSessionActivityStore.test.ts
+++ b/apps/desktop/src/renderer/__tests__/remoteSessionActivityStore.test.ts
@@ -12,6 +12,7 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import {
   applyRemoteSessionActivity,
   clearRemoteSessionActivity,
+  dropStaleRemoteTerminalActivity,
   getRemoteSessionActivity,
   isRemoteSessionActivityActive,
   removeRemoteSessionActivityEntry,
@@ -122,6 +123,32 @@ describe('remoteSessionActivityStore', () => {
 
     removeRemoteSessionActivityEntry('s2');
     expect(getRemoteSessionActivity('s2')).toBeUndefined();
+  });
+
+  it('drops unread completed/error mirrors but keeps an in-flight remote turn', () => {
+    applyRemoteSessionActivity('dev-1', {
+      sessionId: 'done',
+      phase: 'completed',
+      compactDetail: '',
+      attention: true,
+    });
+    applyRemoteSessionActivity('dev-1', {
+      sessionId: 'err',
+      phase: 'error',
+      compactDetail: '',
+      attention: true,
+    });
+    applyRemoteSessionActivity('dev-1', {
+      sessionId: 'run',
+      phase: 'running',
+      compactDetail: '',
+    });
+    dropStaleRemoteTerminalActivity('done');
+    dropStaleRemoteTerminalActivity('err');
+    dropStaleRemoteTerminalActivity('run');
+    expect(getRemoteSessionActivity('done')).toBeUndefined();
+    expect(getRemoteSessionActivity('err')).toBeUndefined();
+    expect(getRemoteSessionActivity('run')).toMatchObject({ phase: 'running' });
   });
 
   it('keeps snapshot reference stable when payload content is unchanged', () => {

--- a/apps/desktop/src/renderer/__tests__/sessionStartingStore.test.ts
+++ b/apps/desktop/src/renderer/__tests__/sessionStartingStore.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  applyRemoteSessionActivity,
+  clearRemoteSessionActivity,
+  getRemoteSessionActivity,
+} from '@/features/device-link/remoteSessionActivityStore';
+import {
   absorbSessionStarting,
   clearSessionStarting,
   getStartingSessionIds,
@@ -12,11 +17,13 @@ import {
 describe('sessionStartingStore', () => {
   beforeEach(() => {
     resetSessionStartingStoreForTests();
+    clearRemoteSessionActivity();
     vi.useFakeTimers();
   });
 
   afterEach(() => {
     resetSessionStartingStoreForTests();
+    clearRemoteSessionActivity();
     vi.useRealTimers();
   });
 
@@ -43,6 +50,29 @@ describe('sessionStartingStore', () => {
     clearSessionStarting('keep');
     expect([...getStartingSessionIds()]).toEqual([]);
     clearSessionStarting('keep');
+  });
+
+  it('drops a stale remote completed mirror on first mark, not on TTL refresh', () => {
+    applyRemoteSessionActivity('dev-1', {
+      sessionId: 's1',
+      phase: 'completed',
+      compactDetail: '',
+      attention: true,
+    });
+    markSessionStarting('s1');
+    expect(getRemoteSessionActivity('s1')).toBeUndefined();
+    expect([...getStartingSessionIds()]).toEqual(['s1']);
+
+    applyRemoteSessionActivity('dev-1', {
+      sessionId: 's1',
+      phase: 'completed',
+      compactDetail: '',
+      attention: true,
+    });
+    markSessionStarting('s1');
+    expect(getRemoteSessionActivity('s1')).toMatchObject({ phase: 'completed' });
+    absorbSessionStarting(['s1']);
+    expect([...getStartingSessionIds()]).toEqual([]);
   });
 
   it('expires a starting mark that never becomes running', () => {

--- a/apps/desktop/src/renderer/__tests__/sessionStartingStore.test.ts
+++ b/apps/desktop/src/renderer/__tests__/sessionStartingStore.test.ts
@@ -1,3 +1,6 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
@@ -81,5 +84,14 @@ describe('sessionStartingStore', () => {
     expect([...getStartingSessionIds()]).toEqual(['stuck']);
     vi.advanceTimersByTime(1);
     expect([...getStartingSessionIds()]).toEqual([]);
+  });
+
+  it('clears starting from asynchronous remote optimistic failure settlement', () => {
+    const source = readFileSync(resolve(__dirname, '..', 'lib', 'makerChatStore.ts'), 'utf8');
+    const start = source.indexOf('function settleRemoteOptimisticFailure');
+    const end = source.indexOf('async function pumpRemoteOptimisticSends', start);
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+    expect(source.slice(start, end)).toContain('clearSessionStarting(sessionId)');
   });
 });

--- a/apps/desktop/src/renderer/__tests__/sessionStartingStore.test.ts
+++ b/apps/desktop/src/renderer/__tests__/sessionStartingStore.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  absorbSessionStarting,
+  clearSessionStarting,
+  getStartingSessionIds,
+  markSessionStarting,
+  resetSessionStartingStoreForTests,
+  SESSION_STARTING_TTL_MS,
+} from '@/lib/sessionStartingStore';
+
+describe('sessionStartingStore', () => {
+  beforeEach(() => {
+    resetSessionStartingStoreForTests();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    resetSessionStartingStoreForTests();
+    vi.useRealTimers();
+  });
+
+  it('marks a just-sent session until it is absorbed or cleared', () => {
+    markSessionStarting('new-task');
+    expect([...getStartingSessionIds()]).toEqual(['new-task']);
+
+    absorbSessionStarting(['new-task']);
+    expect([...getStartingSessionIds()]).toEqual([]);
+  });
+
+  it('keeps snapshot identity when remaking the same session', () => {
+    markSessionStarting('s1');
+    const first = getStartingSessionIds();
+    markSessionStarting('s1');
+    expect(getStartingSessionIds()).toBe(first);
+  });
+
+  it('does not absorb unknown ids and can clear a leftover mark', () => {
+    markSessionStarting('keep');
+    absorbSessionStarting(['other']);
+    expect([...getStartingSessionIds()]).toEqual(['keep']);
+
+    clearSessionStarting('keep');
+    expect([...getStartingSessionIds()]).toEqual([]);
+    clearSessionStarting('keep');
+  });
+
+  it('expires a starting mark that never becomes running', () => {
+    markSessionStarting('stuck');
+    vi.advanceTimersByTime(SESSION_STARTING_TTL_MS - 1);
+    expect([...getStartingSessionIds()]).toEqual(['stuck']);
+    vi.advanceTimersByTime(1);
+    expect([...getStartingSessionIds()]).toEqual([]);
+  });
+});

--- a/apps/desktop/src/renderer/__tests__/sessionStartingStore.test.ts
+++ b/apps/desktop/src/renderer/__tests__/sessionStartingStore.test.ts
@@ -97,4 +97,15 @@ describe('sessionStartingStore', () => {
       'if (!remoteOptimisticSendRecords(sessionId)?.size)',
     );
   });
+
+  it('clears starting when enqueue only parks the message in a paused or locked queue', () => {
+    const source = readFileSync(resolve(__dirname, '..', 'lib', 'makerChatStore.ts'), 'utf8');
+    const start = source.indexOf('return operation.api.input');
+    const end = source.indexOf('function compactSession', start);
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+    const enqueueResult = source.slice(start, end);
+    expect(enqueueResult).toContain('projection.queuePaused');
+    expect(enqueueResult).toContain('clearSessionStarting(sessionId)');
+  });
 });

--- a/apps/desktop/src/renderer/__tests__/sessionStartingStore.test.ts
+++ b/apps/desktop/src/renderer/__tests__/sessionStartingStore.test.ts
@@ -93,5 +93,8 @@ describe('sessionStartingStore', () => {
     expect(start).toBeGreaterThan(-1);
     expect(end).toBeGreaterThan(start);
     expect(source.slice(start, end)).toContain('clearSessionStarting(sessionId)');
+    expect(source.slice(start, end)).toContain(
+      'if (!remoteOptimisticSendRecords(sessionId)?.size)',
+    );
   });
 });

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSidebarUpper.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSidebarUpper.tsx
@@ -92,6 +92,7 @@ import {
 } from '@/lib/worktreeRemovalWarning';
 import { useSessionRunningStatus } from '@/hooks/useSessionRunningStatus';
 import { useBackgroundActivitySessionIds } from '@/lib/sessionBackgroundActivityStore';
+import { useStartingSessionIds } from '@/lib/sessionStartingStore';
 import { useAttachedSessionIds } from '@/hooks/useAttachedSessionIds';
 import { useActiveMainView } from '@/hooks/useActiveMainView';
 import { useAnyGhostUnread } from '@/cindy-brain/ghostUnreadStore';
@@ -1216,21 +1217,35 @@ function ExpandedView({
   // handleMoveSession 的运行中拦截闸门,后台活动不得静默扩大行为闸门的口径
   // (move / 归档 / 通知语义都保持只认真 running)。
   const backgroundActivitySessionIds = useBackgroundActivitySessionIds();
+  // 刚发送尚未 isRunning 的任务并进 display running:排序与呼吸点马上进运行中档,
+  // 但不扩大 effectiveRunningSessionIds 的归档 / 移动闸门。
+  const startingSessionIds = useStartingSessionIds(runningSessionIds);
   const displayRunningSessionIds = useMemo(() => {
-    if (backgroundActivitySessionIds.size === 0) return effectiveRunningSessionIds;
+    if (backgroundActivitySessionIds.size === 0 && startingSessionIds.size === 0) {
+      return effectiveRunningSessionIds;
+    }
     const next = new Set(effectiveRunningSessionIds);
     for (const id of backgroundActivitySessionIds) next.add(id);
+    for (const id of startingSessionIds) next.add(id);
     for (const [leadSessionId, workerSessionIds] of orcaLeadWorkerMap) {
       if (next.has(leadSessionId)) continue;
       for (const workerSessionId of workerSessionIds) {
-        if (backgroundActivitySessionIds.has(workerSessionId)) {
+        if (
+          backgroundActivitySessionIds.has(workerSessionId) ||
+          startingSessionIds.has(workerSessionId)
+        ) {
           next.add(leadSessionId);
           break;
         }
       }
     }
     return next;
-  }, [effectiveRunningSessionIds, backgroundActivitySessionIds, orcaLeadWorkerMap]);
+  }, [
+    effectiveRunningSessionIds,
+    backgroundActivitySessionIds,
+    startingSessionIds,
+    orcaLeadWorkerMap,
+  ]);
   const collapsedAttentionToneFor = useCallback(
     (sessions: readonly Session[]) =>
       resolveCollapsedProjectAttentionTone({
@@ -3801,6 +3816,7 @@ function CollapsedView({
   const { runningSessionIds } = useSessionRunningStatus(activeSessionId);
   // 后台子任务活跃会话同样点亮呼吸(与 ExpandedView 同口径,纯视觉合并)。
   const backgroundActivitySessionIds = useBackgroundActivitySessionIds();
+  const startingSessionIds = useStartingSessionIds(runningSessionIds);
   // 瓷砖未读点颜色按 attention kind(done 绿 / awaiting TapTap 蓝 / error 红);组件层
   // 取一次,renderItem 里查表(renderItem 非组件,不能 per-item 用 hook)。
   const attentionKinds = useSessionAttentionKinds();
@@ -3834,7 +3850,11 @@ function CollapsedView({
   // 却不亮」(codex review)。
   const orcaLeadWorkerMap = useOrcaLeadWorkerMap(sessions);
   const railRunningIds = useMemo(() => {
-    const next = new Set([...runningSessionIds, ...backgroundActivitySessionIds]);
+    const next = new Set([
+      ...runningSessionIds,
+      ...backgroundActivitySessionIds,
+      ...startingSessionIds,
+    ]);
     for (const [leadSessionId, workerSessionIds] of orcaLeadWorkerMap) {
       if (next.has(leadSessionId)) continue;
       for (const workerSessionId of workerSessionIds) {
@@ -3845,7 +3865,7 @@ function CollapsedView({
       }
     }
     return next;
-  }, [runningSessionIds, backgroundActivitySessionIds, orcaLeadWorkerMap]);
+  }, [runningSessionIds, backgroundActivitySessionIds, startingSessionIds, orcaLeadWorkerMap]);
 
   return (
     <div

--- a/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
@@ -127,6 +127,7 @@ import {
 import { showWorktreeError } from '@/lib/worktreeToast';
 import * as sessionService from '@/lib/sessionService';
 import { sessionsStore } from '@/lib/sessionsStore';
+import { markSessionStarting } from '@/lib/sessionStartingStore';
 import { emitAutoTitlePreview, emitAutoTitlePreviewCleared } from '@/lib/sessionsBus';
 import { NewGoalDialog } from '@/components/new-chat/NewGoalDialog';
 import { cleanupStagedChatAttachmentFiles } from '@/lib/chatAttachmentStageCleanup';
@@ -3797,6 +3798,7 @@ export function NewMakerDraftRoute() {
               userSendAt: sendAt.toISOString(),
               updatedAt: sendAt.toISOString(),
             });
+            markSessionStarting(newSession.id);
             sessionService.touchUserSend(newSession.id, sendAt.getTime()).catch((err) => {
               log.warn('[draft worktree send] touchUserSend failed', err);
             });
@@ -4050,6 +4052,7 @@ export function NewMakerDraftRoute() {
           {
             const iso = new Date().toISOString();
             sessionsStore.patchLocal(newSession.id, { userSendAt: iso, updatedAt: iso });
+            markSessionStarting(newSession.id);
           }
 
           // F-COLLAB: draft 阶段开了协同模式 → createSession 之后立刻 enableOrca
@@ -4675,6 +4678,7 @@ export function NewMakerDraftRoute() {
         {
           const iso = new Date().toISOString();
           sessionsStore.patchLocal(newSession.id, { userSendAt: iso, updatedAt: iso });
+          markSessionStarting(newSession.id);
         }
         // 草稿开了协同 → 新建目标路径也要拉起 Worker(与 Send 路径同口径);否则用户开了协同
         // 却走「新建目标」会得到一个没有 Worker 的 lead session(codex P2)。失败 toast + 降级

--- a/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
@@ -127,7 +127,7 @@ import {
 import { showWorktreeError } from '@/lib/worktreeToast';
 import * as sessionService from '@/lib/sessionService';
 import { sessionsStore } from '@/lib/sessionsStore';
-import { markSessionStarting } from '@/lib/sessionStartingStore';
+import { clearSessionStarting, markSessionStarting } from '@/lib/sessionStartingStore';
 import { emitAutoTitlePreview, emitAutoTitlePreviewCleared } from '@/lib/sessionsBus';
 import { NewGoalDialog } from '@/components/new-chat/NewGoalDialog';
 import { cleanupStagedChatAttachmentFiles } from '@/lib/chatAttachmentStageCleanup';
@@ -3391,6 +3391,7 @@ export function NewMakerDraftRoute() {
       // (PR #1031 review P1;worktree 与 goal 两条路径各有自己的撤回点)。
       let optimisticTitleSessionId: string | null = null;
       let remoteOptimisticTitleSessionId: string | null = null;
+      let markedStartingSessionId: string | null = null;
       const autoTitleLabels = {
         image: t('ccAgent.autoTitle.image'),
         file: t('ccAgent.autoTitle.file'),
@@ -3799,6 +3800,7 @@ export function NewMakerDraftRoute() {
               updatedAt: sendAt.toISOString(),
             });
             markSessionStarting(newSession.id);
+            markedStartingSessionId = newSession.id;
             sessionService.touchUserSend(newSession.id, sendAt.getTime()).catch((err) => {
               log.warn('[draft worktree send] touchUserSend failed', err);
             });
@@ -3844,6 +3846,8 @@ export function NewMakerDraftRoute() {
                 // 会话永久显示一句**没发出去**的话(PR #1031 review P1)。
                 // 放在这里而不是各 return 前:所有「交接失败 → 还原草稿」的分支都过这一处。
                 emitAutoTitlePreviewCleared(newSession.id);
+                // 首条没发出去:撤销发送当下的 starting,避免未开始的任务钉在运行中档。
+                clearSessionStarting(newSession.id);
               };
               try {
                 rehomedFiles = await rehomeDraftAttachments(files, newSession.id);
@@ -4053,6 +4057,7 @@ export function NewMakerDraftRoute() {
             const iso = new Date().toISOString();
             sessionsStore.patchLocal(newSession.id, { userSendAt: iso, updatedAt: iso });
             markSessionStarting(newSession.id);
+            markedStartingSessionId = newSession.id;
           }
 
           // F-COLLAB: draft 阶段开了协同模式 → createSession 之后立刻 enableOrca
@@ -4129,6 +4134,7 @@ export function NewMakerDraftRoute() {
           if (remoteOptimisticTitleSessionId) {
             remoteProjectsStore.clearPendingTitlePreview(remoteOptimisticTitleSessionId);
           }
+          if (markedStartingSessionId) clearSessionStarting(markedStartingSessionId);
           if (isRemotePrecreatedWorktreeOwnerChangedError(err)) return;
           log.error('[draft send]', err);
           toast.error(
@@ -4727,6 +4733,7 @@ export function NewMakerDraftRoute() {
           // 不撤回的话标题预览会永久盖着 DB 里的哨兵(理由同 worktree 分支的
           // restoreFirstMessageDraft)。异常照旧抛给调用方展示。
           if (optimisticGoalTitle) emitAutoTitlePreviewCleared(newSession.id);
+          clearSessionStarting(newSession.id);
           if (deferredUiAssignment) {
             toast.error(t('newChat.collaboration.assignmentFailed'));
           }

--- a/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
@@ -3653,6 +3653,7 @@ export function NewMakerDraftRoute() {
               nowIso: new Date().toISOString(),
               logTag: 'draft send',
             });
+            markedStartingSessionId = remoteSessionId;
             // 草稿里选中的那条收藏跟着会话走(见 carryDraftFavoriteAnchorToSession)。锚点是
             // **控制端的 UI 态**,与被控端无关:按对端会话 id 记在本机即可,不进任何 payload。
             // 用 createArgs 里**实际提交**的 model / providerId(远程分支会按被控端目录校准)。
@@ -4463,6 +4464,7 @@ export function NewMakerDraftRoute() {
           if (!remoteSessionId) {
             throw new Error(t('ccAgent.draft.createSessionFailed'));
           }
+          goalSessionId = remoteSessionId;
           {
             const optimisticGoalTitle = normalizeAutoTitle(objective);
             if (optimisticGoalTitle) {
@@ -4752,6 +4754,7 @@ export function NewMakerDraftRoute() {
         // 预览在 createSession 之前登记。worktree 建议名 / 建树 / 回滚失败都走这里,
         // 不撤回会让空会话或未建成的 goalSessionId 一直顶着目标原文。
         if (goalSessionId && optimisticGoalTitle) emitAutoTitlePreviewCleared(goalSessionId);
+        if (goalSessionId) clearSessionStarting(goalSessionId);
         if (isLocalGoalWorktreeCleanupPendingError(error)) {
           log.error('[draft goal] incomplete local worktree session cleanup failed', {
             setupError: error.setupError,

--- a/apps/desktop/src/renderer/features/cc-agent/lib/mainListModel.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/lib/mainListModel.ts
@@ -46,6 +46,10 @@ export type MainListEntry =
 
 /** 优先级排序的运行时上下文(组装层的运行中 / 需关注集合)。 */
 export interface MainListPriorityContext {
+  /**
+   * 运行中档。组装层会把「刚发送、agent 还没 isRunning」的 starting 会话并进来,
+   * 让新任务立刻排在运行中档顶,而不是先沉到其余档再跳上来。
+   */
   runningSessionIds: ReadonlySet<string>;
   /** 需关注(等待确认 / 完成未读等 attention 通知)的 sessionIds。 */
   attentionSessionIds: ReadonlySet<string>;

--- a/apps/desktop/src/renderer/features/cc-agent/remoteSessionHandoff.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/remoteSessionHandoff.ts
@@ -27,6 +27,7 @@
 import { refreshRemoteDeviceSessions } from '@/features/device-link/refreshRemoteSessions';
 import { remoteProjectsStore } from '@/features/device-link/remoteProjectsStore';
 import { createLogger } from '@/lib/logger';
+import { markSessionStarting } from '@/lib/sessionStartingStore';
 
 import { buildProvisionalRemoteSession, type DeviceLinkCreateArgs } from './deviceLinkCreateArgs';
 
@@ -67,6 +68,8 @@ export interface RemoteSessionHandoffParams {
 export function commitRemoteSessionHandoff(p: RemoteSessionHandoffParams): void {
   // ① 归属先落地:回流失败时它是首条消息能路由到对端的唯一依据。
   remoteProjectsStore.pinSessionOrigin(p.deviceId, p.remoteSessionId);
+  // 刚提交的远程任务在对端 isRunning 回流前先按运行中排序,避免先沉底再跳顶。
+  markSessionStarting(p.remoteSessionId);
   // ② 临时行:让 SessionView 的 delayed-create 交接不必等权威快照。
   if (p.workDir) {
     remoteProjectsStore.mergeDeviceSessions(p.deviceId, p.deviceName, [

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/sections/ProjectsSection.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/sections/ProjectsSection.tsx
@@ -74,6 +74,7 @@ import {
   getRemoteSessionActivity,
   useRemoteSessionActivityRevision,
 } from '@/features/device-link/remoteSessionActivityStore';
+import { absorbSessionStarting } from '@/lib/sessionStartingStore';
 import type { DialogueDeviceTarget } from '../../lib/dialogueCreateTarget';
 import { MainListScopeHeader } from '../MainListScopeHeader';
 import { SectionCollapse } from '../SectionCollapse';
@@ -390,6 +391,44 @@ export function ProjectsSection({
     unclassified,
     remoteActivityRevision,
     viewedIdForSort,
+  ]);
+
+  // 远程权威状态 / attention 到了就收掉 starting,避免对端跑完后 starting
+  // 还把已完成任务钉在运行中档。不要用上面的 running 集合 —— 那已经并进了
+  // starting,会把自己清掉。
+  useEffect(() => {
+    const settled = new Set<string>(notifications);
+    for (const id of urgentSet) settled.add(id);
+    for (const [sessionId, kind] of attentionKinds) {
+      if (kind === 'awaiting' || kind === 'error') settled.add(sessionId);
+    }
+    const considerRemote = (session: Session) => {
+      const activity = getRemoteSessionActivity(session.id);
+      if (!activity) return;
+      if (
+        activity.phase === 'running' ||
+        activity.phase === 'needs-interaction' ||
+        activity.phase === 'error' ||
+        activity.phase === 'completed'
+      ) {
+        settled.add(session.id);
+      }
+    };
+    for (const project of projects) {
+      for (const session of project.sessions) considerRemote(session);
+    }
+    for (const session of dialogues) considerRemote(session);
+    for (const session of unclassified) considerRemote(session);
+    absorbSessionStarting(settled);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- remoteActivityRevision 代表 getRemoteSessionActivity 读到的整表内容
+  }, [
+    notifications,
+    urgentSet,
+    attentionKinds,
+    projects,
+    dialogues,
+    unclassified,
+    remoteActivityRevision,
   ]);
 
   // E 期「按设备分组」:有远程设备连接 + 开关开 → 按设备切段(本机在前,

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/sections/ProjectsSection.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/sections/ProjectsSection.tsx
@@ -72,9 +72,10 @@ import { useSessionAttentionKinds } from '@/lib/sessionAttentionStore';
 import { useSessionAttentionUrgencySet } from '../../contexts/SessionAttentionUrgencyContext';
 import {
   getRemoteSessionActivity,
+  isRemoteSessionActivityActive,
   useRemoteSessionActivityRevision,
 } from '@/features/device-link/remoteSessionActivityStore';
-import { absorbSessionStarting, getStartingSessionIds } from '@/lib/sessionStartingStore';
+import { absorbSessionStarting } from '@/lib/sessionStartingStore';
 import type { DialogueDeviceTarget } from '../../lib/dialogueCreateTarget';
 import { MainListScopeHeader } from '../MainListScopeHeader';
 import { SectionCollapse } from '../SectionCollapse';
@@ -393,36 +394,14 @@ export function ProjectsSection({
     viewedIdForSort,
   ]);
 
-  // 远程权威状态 / attention 到了就收掉 starting,避免对端跑完后 starting
-  // 还把已完成任务钉在运行中档。不要用上面的 running 集合 —— 那已经并进了
-  // starting,会把自己清掉。
+  // starting 只让位给真实 in-flight:本地 isRunning(见 useStartingSessionIds),
+  // 远程 running / needs-interaction。终态 attention 不再吸收 —— 旧终态会误伤
+  // 新发送,新终态又要代次才能和旧的区分,两边补丁会来回打。没经过 running
+  // 的快完成靠 TTL。
   useEffect(() => {
-    const starting = getStartingSessionIds();
     const settled = new Set<string>();
-    // 发送前已有的本地 done/error attention 不能吸收刚置位的 starting,
-    // 否则呼吸点要等真实 isRunning。远程终态已在 mark 时丢掉旧镜像。
-    for (const id of notifications) {
-      if (!starting.has(id)) settled.add(id);
-    }
-    for (const id of urgentSet) {
-      if (!starting.has(id)) settled.add(id);
-    }
-    for (const [sessionId, kind] of attentionKinds) {
-      if ((kind === 'awaiting' || kind === 'error') && !starting.has(sessionId)) {
-        settled.add(sessionId);
-      }
-    }
     const considerRemote = (session: Session) => {
-      const activity = getRemoteSessionActivity(session.id);
-      if (!activity) return;
-      // 上一轮 completed/error 在 markSessionStarting 时已经丢掉;这里剩下的
-      // 终态是本轮新到达的权威状态,应当吸收 starting。
-      if (
-        activity.phase === 'running' ||
-        activity.phase === 'needs-interaction' ||
-        activity.phase === 'error' ||
-        activity.phase === 'completed'
-      ) {
+      if (isRemoteSessionActivityActive(getRemoteSessionActivity(session.id))) {
         settled.add(session.id);
       }
     };
@@ -433,15 +412,7 @@ export function ProjectsSection({
     for (const session of unclassified) considerRemote(session);
     absorbSessionStarting(settled);
     // eslint-disable-next-line react-hooks/exhaustive-deps -- remoteActivityRevision 代表 getRemoteSessionActivity 读到的整表内容
-  }, [
-    notifications,
-    urgentSet,
-    attentionKinds,
-    projects,
-    dialogues,
-    unclassified,
-    remoteActivityRevision,
-  ]);
+  }, [projects, dialogues, unclassified, remoteActivityRevision]);
 
   // E 期「按设备分组」:有远程设备连接 + 开关开 → 按设备切段(本机在前,
   // 远程按设备切换栏顺序);其余情况单段直渲。切段后按当前排序重排本段。

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/sections/ProjectsSection.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/sections/ProjectsSection.tsx
@@ -74,7 +74,7 @@ import {
   getRemoteSessionActivity,
   useRemoteSessionActivityRevision,
 } from '@/features/device-link/remoteSessionActivityStore';
-import { absorbSessionStarting } from '@/lib/sessionStartingStore';
+import { absorbSessionStarting, getStartingSessionIds } from '@/lib/sessionStartingStore';
 import type { DialogueDeviceTarget } from '../../lib/dialogueCreateTarget';
 import { MainListScopeHeader } from '../MainListScopeHeader';
 import { SectionCollapse } from '../SectionCollapse';
@@ -402,14 +402,19 @@ export function ProjectsSection({
     for (const [sessionId, kind] of attentionKinds) {
       if (kind === 'awaiting' || kind === 'error') settled.add(sessionId);
     }
+    const starting = getStartingSessionIds();
     const considerRemote = (session: Session) => {
       const activity = getRemoteSessionActivity(session.id);
       if (!activity) return;
+      if (activity.phase === 'running' || activity.phase === 'needs-interaction') {
+        settled.add(session.id);
+        return;
+      }
+      // 上一轮 completed/error 镜像不能吸收刚发送的 starting,否则新 turn 的
+      // 运行中指示会被旧终态立刻清掉。
       if (
-        activity.phase === 'running' ||
-        activity.phase === 'needs-interaction' ||
-        activity.phase === 'error' ||
-        activity.phase === 'completed'
+        (activity.phase === 'error' || activity.phase === 'completed') &&
+        !starting.has(session.id)
       ) {
         settled.add(session.id);
       }

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/sections/ProjectsSection.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/sections/ProjectsSection.tsx
@@ -74,7 +74,7 @@ import {
   getRemoteSessionActivity,
   useRemoteSessionActivityRevision,
 } from '@/features/device-link/remoteSessionActivityStore';
-import { absorbSessionStarting } from '@/lib/sessionStartingStore';
+import { absorbSessionStarting, getStartingSessionIds } from '@/lib/sessionStartingStore';
 import type { DialogueDeviceTarget } from '../../lib/dialogueCreateTarget';
 import { MainListScopeHeader } from '../MainListScopeHeader';
 import { SectionCollapse } from '../SectionCollapse';
@@ -397,10 +397,20 @@ export function ProjectsSection({
   // 还把已完成任务钉在运行中档。不要用上面的 running 集合 —— 那已经并进了
   // starting,会把自己清掉。
   useEffect(() => {
-    const settled = new Set<string>(notifications);
-    for (const id of urgentSet) settled.add(id);
+    const starting = getStartingSessionIds();
+    const settled = new Set<string>();
+    // 发送前已有的本地 done/error attention 不能吸收刚置位的 starting,
+    // 否则呼吸点要等真实 isRunning。远程终态已在 mark 时丢掉旧镜像。
+    for (const id of notifications) {
+      if (!starting.has(id)) settled.add(id);
+    }
+    for (const id of urgentSet) {
+      if (!starting.has(id)) settled.add(id);
+    }
     for (const [sessionId, kind] of attentionKinds) {
-      if (kind === 'awaiting' || kind === 'error') settled.add(sessionId);
+      if ((kind === 'awaiting' || kind === 'error') && !starting.has(sessionId)) {
+        settled.add(sessionId);
+      }
     }
     const considerRemote = (session: Session) => {
       const activity = getRemoteSessionActivity(session.id);

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/sections/ProjectsSection.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/sections/ProjectsSection.tsx
@@ -74,7 +74,7 @@ import {
   getRemoteSessionActivity,
   useRemoteSessionActivityRevision,
 } from '@/features/device-link/remoteSessionActivityStore';
-import { absorbSessionStarting, getStartingSessionIds } from '@/lib/sessionStartingStore';
+import { absorbSessionStarting } from '@/lib/sessionStartingStore';
 import type { DialogueDeviceTarget } from '../../lib/dialogueCreateTarget';
 import { MainListScopeHeader } from '../MainListScopeHeader';
 import { SectionCollapse } from '../SectionCollapse';
@@ -402,19 +402,16 @@ export function ProjectsSection({
     for (const [sessionId, kind] of attentionKinds) {
       if (kind === 'awaiting' || kind === 'error') settled.add(sessionId);
     }
-    const starting = getStartingSessionIds();
     const considerRemote = (session: Session) => {
       const activity = getRemoteSessionActivity(session.id);
       if (!activity) return;
-      if (activity.phase === 'running' || activity.phase === 'needs-interaction') {
-        settled.add(session.id);
-        return;
-      }
-      // 上一轮 completed/error 镜像不能吸收刚发送的 starting,否则新 turn 的
-      // 运行中指示会被旧终态立刻清掉。
+      // 上一轮 completed/error 在 markSessionStarting 时已经丢掉;这里剩下的
+      // 终态是本轮新到达的权威状态,应当吸收 starting。
       if (
-        (activity.phase === 'error' || activity.phase === 'completed') &&
-        !starting.has(session.id)
+        activity.phase === 'running' ||
+        activity.phase === 'needs-interaction' ||
+        activity.phase === 'error' ||
+        activity.phase === 'completed'
       ) {
         settled.add(session.id);
       }

--- a/apps/desktop/src/renderer/features/device-link/remoteSessionActivityStore.ts
+++ b/apps/desktop/src/renderer/features/device-link/remoteSessionActivityStore.ts
@@ -120,6 +120,14 @@ export function applyRemoteSessionActivity(deviceId: string, payload: unknown): 
   emit();
 }
 
+/** 刚发送时丢掉上一轮 completed/error 镜像。running / needs-interaction 是本轮活档,保留。 */
+export function dropStaleRemoteTerminalActivity(sessionId: string): void {
+  const activity = activityMap.get(sessionId);
+  if (!activity) return;
+  if (activity.phase !== 'completed' && activity.phase !== 'error') return;
+  removeRemoteSessionActivityEntry(sessionId);
+}
+
 /** 单会话清除(被控端删除 / 归档该会话时由 sessions:patched 路由调用)。 */
 export function removeRemoteSessionActivityEntry(sessionId: string): void {
   sessionDeviceIndex.delete(sessionId);

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -121,6 +121,7 @@ import { setMirrorEffort, setMirrorFast } from '@/state/deviceLinkModelMirror';
 import type { AgentKind } from '@/hooks/useAgentCapabilities';
 import type { Effort } from '@/lib/userPreferences.types';
 import { emitAutoTitlePreview, emitAutoTitlePreviewCleared, emitPatch } from '@/lib/sessionsBus';
+import { clearSessionStarting, markSessionStarting } from '@/lib/sessionStartingStore';
 import { createLogger } from '@/lib/logger';
 import {
   markSessionAutomaticHistoryLoadCompleted,
@@ -11333,6 +11334,8 @@ function touchSessionUserSend(sessionId: string, workingDir: string, wasFirst: b
       ? { workingDir, userSendAt: userSendAtIso, updatedAt: userSendAtIso }
       : { userSendAt: userSendAtIso, updatedAt: userSendAtIso },
   );
+  // 侧栏优先级在真实 isRunning 之前先把刚发送的任务当成 running,避免先沉底再跳顶。
+  markSessionStarting(sessionId);
 }
 
 /**
@@ -11829,6 +11832,15 @@ function sendMessage(
             files,
           ),
       );
+    },
+  ).then(
+    (ok) => {
+      if (!ok) clearSessionStarting(sessionId);
+      return ok;
+    },
+    (err) => {
+      clearSessionStarting(sessionId);
+      throw err;
     },
   );
 }

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -9199,6 +9199,7 @@ async function dispatchRemoteOptimisticSend(
 }
 
 function settleRemoteOptimisticFailure(sessionId: string, clientId: string, error?: unknown): void {
+  clearSessionStarting(sessionId);
   const record = remoteOptimisticSendRecords(sessionId)?.get(clientId);
   if (record?.composerResolvedOptimistically && isDataOwnerGenerationCurrent(record.dataOwner)) {
     try {

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -9199,7 +9199,6 @@ async function dispatchRemoteOptimisticSend(
 }
 
 function settleRemoteOptimisticFailure(sessionId: string, clientId: string, error?: unknown): void {
-  clearSessionStarting(sessionId);
   const record = remoteOptimisticSendRecords(sessionId)?.get(clientId);
   if (record?.composerResolvedOptimistically && isDataOwnerGenerationCurrent(record.dataOwner)) {
     try {
@@ -9212,6 +9211,10 @@ function settleRemoteOptimisticFailure(sessionId: string, clientId: string, erro
   // Retire the outbox ref afterwards so media protection transfers without a
   // cleanup-eligible gap in main's renderer registry.
   clearRemoteOptimisticSend(sessionId, clientId);
+  // 同会话还有其它乐观发送在飞时不能清 starting,否则后一条会提前退出运行中档。
+  if (!remoteOptimisticSendRecords(sessionId)?.size) {
+    clearSessionStarting(sessionId);
+  }
   setState(sessionId, (s) => ({
     ...s,
     pendingQueue: s.pendingQueue.filter((item) => item.clientId !== clientId),

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -12023,6 +12023,16 @@ async function sendMessageCore(
       }
       const applied = applyInputProjectionOperationResponse(sessionId, operation, projection);
       if (applied) markSessionHasUserMessage(sessionId);
+      // 暂停 / 输入锁 / 凭证切换等待只把消息收下,不会马上派发。starting
+      // 表示「预期会跑」,不能把明确未派发的任务标成运行中。
+      if (
+        projection.pendingQueue.some((item) => item.clientId === queued.clientId)
+        && (projection.queuePaused
+          || Boolean(projection.credentialSwitchWait)
+          || projection.queueInteractionLocks.length > 0)
+      ) {
+        clearSessionStarting(sessionId);
+      }
       return true;
     })
     .catch((err) => {

--- a/apps/desktop/src/renderer/lib/sessionStartingStore.ts
+++ b/apps/desktop/src/renderer/lib/sessionStartingStore.ts
@@ -1,0 +1,108 @@
+/**
+ * sessionStartingStore —— 「用户已按下发送、agent 尚未进入 isRunning」的会话集合。
+ *
+ * 侧栏按优先级排序时,running 档只认 makerChatStore 的真实 isRunning。新建 /
+ * 刚发送的任务在 worktree、hydrate、enqueue、进程拉起这段空窗里还是 rest,
+ * 会先沉到所有运行中任务下面,等真正跑起来再跳到 running 档顶 —— 列表自己
+ * 抖一下。这里把「我已经发出去了」提前记成 starting,组装层并进 display
+ * running,排序和呼吸点与运行中同档,但不碰 isRunning(done 通知 / 归档闸门 /
+ * LRU 仍只认真 running)。
+ *
+ * 生命周期:乐观 userSendAt / sendMessage 置位;真实 running、远程权威状态、
+ * 发送失败或 TTL 清除。
+ */
+
+import { useEffect, useSyncExternalStore } from 'react';
+
+/** 发送失败 / 状态一直不到时的兜底;正常路径应在 agent 开跑时就被吸收。 */
+export const SESSION_STARTING_TTL_MS = 120_000;
+
+const listeners = new Set<() => void>();
+const startingIds = new Set<string>();
+const timers = new Map<string, ReturnType<typeof setTimeout>>();
+/** 不可变快照,只在 emit 时重建 —— 无变化时返回同一引用。 */
+let snapshot: ReadonlySet<string> = new Set();
+
+function emit(): void {
+  snapshot = new Set(startingIds);
+  for (const listener of listeners) listener();
+}
+
+function clearTimer(sessionId: string): void {
+  const timer = timers.get(sessionId);
+  if (timer === undefined) return;
+  clearTimeout(timer);
+  timers.delete(sessionId);
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function getStartingSessionIds(): ReadonlySet<string> {
+  return snapshot;
+}
+
+/** 用户已提交发送。重复标记只刷新 TTL,不抖快照。 */
+export function markSessionStarting(sessionId: string): void {
+  if (!sessionId) return;
+  const already = startingIds.has(sessionId);
+  if (!already) startingIds.add(sessionId);
+  clearTimer(sessionId);
+  timers.set(
+    sessionId,
+    setTimeout(() => {
+      timers.delete(sessionId);
+      if (!startingIds.delete(sessionId)) return;
+      emit();
+    }, SESSION_STARTING_TTL_MS),
+  );
+  if (!already) emit();
+}
+
+export function clearSessionStarting(sessionId: string): void {
+  if (!sessionId) return;
+  clearTimer(sessionId);
+  if (!startingIds.delete(sessionId)) return;
+  emit();
+}
+
+/** 会话已有权威活档(真 running / 等你处理 / 完成未读 / 远程状态)时收掉 starting。 */
+export function absorbSessionStarting(settledSessionIds: Iterable<string>): void {
+  let changed = false;
+  for (const sessionId of settledSessionIds) {
+    if (!startingIds.has(sessionId)) continue;
+    clearTimer(sessionId);
+    startingIds.delete(sessionId);
+    changed = true;
+  }
+  if (changed) emit();
+}
+
+/**
+ * 当前 starting 集合。传入 settledSessionIds 时,在 effect 里吸收已经有权威
+ * 状态的 id —— 调用方应传**真** running / attention,不要传已经并进 starting
+ * 的 display running,否则会立刻把自己清掉。
+ */
+export function useStartingSessionIds(
+  settledSessionIds?: ReadonlySet<string>,
+): ReadonlySet<string> {
+  const starting = useSyncExternalStore(subscribe, getStartingSessionIds, getStartingSessionIds);
+  useEffect(() => {
+    if (!settledSessionIds || settledSessionIds.size === 0) return;
+    absorbSessionStarting(settledSessionIds);
+  }, [settledSessionIds, starting]);
+  return starting;
+}
+
+/** 测试收尾。 */
+export function resetSessionStartingStoreForTests(): void {
+  for (const timer of timers.values()) clearTimeout(timer);
+  timers.clear();
+  startingIds.clear();
+  snapshot = new Set();
+  listeners.clear();
+}

--- a/apps/desktop/src/renderer/lib/sessionStartingStore.ts
+++ b/apps/desktop/src/renderer/lib/sessionStartingStore.ts
@@ -14,6 +14,8 @@
 
 import { useEffect, useSyncExternalStore } from 'react';
 
+import { dropStaleRemoteTerminalActivity } from '@/features/device-link/remoteSessionActivityStore';
+
 /** 发送失败 / 状态一直不到时的兜底;正常路径应在 agent 开跑时就被吸收。 */
 export const SESSION_STARTING_TTL_MS = 120_000;
 
@@ -50,7 +52,12 @@ export function getStartingSessionIds(): ReadonlySet<string> {
 export function markSessionStarting(sessionId: string): void {
   if (!sessionId) return;
   const already = startingIds.has(sessionId);
-  if (!already) startingIds.add(sessionId);
+  if (!already) {
+    // 先丢掉上一轮远程终态,再置 starting。否则 absorb 会把旧 completed/error
+    // 当成新权威立刻清掉。重复 mark 只刷新 TTL,不能再删本轮新到达的终态。
+    dropStaleRemoteTerminalActivity(sessionId);
+    startingIds.add(sessionId);
+  }
   clearTimer(sessionId);
   timers.set(
     sessionId,


### PR DESCRIPTION
## 这次改了什么

### 摘要

按优先级排序时，刚发送的任务要等 agent 真正 `isRunning` 才进「运行中」档，会先沉到所有运行中任务下面，过一会儿再跳到最上面。灵动岛「任务开始」音效也卡在同一条空窗上：以前要等 `session.send()` 受理（进程拉起之后）才响。

这次在用户按下发送 / 消息入队时就把任务当成进行中：侧栏立刻排到运行中档顶并点亮呼吸点；灵动岛开始音效在 drain / `sendToAgent` 之前就播。真实 `isRunning`、完成通知、归档 / 移动闸门不变。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：
  - 侧栏 starting 短生命周期：发送当下记一笔，并进 display running，只影响排序和呼吸点
  - 新建 / 再发送 / 远程交接的乐观 `userSendAt` 路径同步标记；发送失败、真 running、远程权威状态或 120s TTL 清除
  - 灵动岛在 coordinator 入队时预览用户 turn，开始音效不再等 agent 进程
  - 同一 `clientId` 的二次预览不覆盖第一次回滚快照，persist 失败仍能撤回发送前
- 明确不包含：
  - 不改四档优先级语义（等你处理 > 完成未读 > 运行中 > 其余）
  - 不把 starting 算进归档 / 移动闸门或完成通知
  - 不在 worktree / hydrate 完成前给灵动岛预览（岛上没有 starting TTL，失败会卡在「运行中」）
- 用户可见变化：按优先级时新发送的任务马上出现在运行中档最上面；开始音效在入队后立刻响，不再跟着进程启动一起晚
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：`docs/design-rules/DESIGN.md` / `docs/product-rules/core-product-principles.md` §4.1（状态与进行中应立刻可见，不把内部 `isRunning` 空窗暴露成列表跳动和音效延迟）。无新组件、无颜色 / 间距 / 文案改动；呼吸点复用已有运行中指示。双模式不涉及新样式。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop run typecheck
结果：通过

pnpm test:unit:related
结果：通过（desktop related 15 个文件）

/Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh
结果：desktop 全量单测 2 失败 / 27366 通过。失败项是
src/main/cindy-brain/__tests__/ghostInstallReceipt.test.ts
两条 receipt setup 兼容用例，本 PR 未改 cindy-brain。
同一 HEAD（= origin/main）单独复跑该文件同样失败，判为基线问题，不混入修复。
相关改动的定向单测（sessionStartingStore / mainListModel / coordinator /
agent-island service / interruptedContinuationContract）均通过。
```

### 手工验证

未在本机再开 Desktop 目检。改动在独立 worktree，宿主 HMR 看不到。建议验证：

1. 侧栏切到「按优先级」，先留几条正在跑的任务
2. 新建一条任务并发送：应立刻出现在运行中档最上面，呼吸点亮，不应先沉到底再跳上来
3. 已有空闲任务再发一条：同样立刻进运行中档；灵动岛开始音效应在入队后马上响，不必等模型开始吐字
4. 发送失败或很快跑完：任务不应一直钉在运行中档

### 未执行的验证

Desktop 实机目检（worktree 改动对当前宿主实例无效）。全量门禁里与本 PR 无关的 `ghostInstallReceipt` 基线失败交给 CI 再判。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop 侧栏优先级排序、运行中呼吸点、灵动岛开始音效时机。不改协议、数据库、插件或 mobile fingerprint。
- 回滚 / 降级方式：revert 本 PR 即可回到「等 isRunning / session.send accepted」。
- 存量插件影响：无

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
