### PR TITLE
fix(mobile): 修复用户消息展开超框并防护 agent 回复首帧裁切

### DIFF
--- a/apps/mobile/src/__tests__/messageContentLayout.test.ts
+++ b/apps/mobile/src/__tests__/messageContentLayout.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildMessageContentLayout } from '@/session/messageContentLayout';
+import { buildMessageContentLayout, nextSettledContentWidth } from '@/session/messageContentLayout';
 
 describe('messageContentLayout', () => {
   it('compacts attachment and markdown content for iPhone SE width', () => {
@@ -50,5 +50,19 @@ describe('messageContentLayout', () => {
       imagePreviewWidth: 148,
       mediaPreviewWidth: 160,
     });
+  });
+});
+
+describe('nextSettledContentWidth', () => {
+  it('pins the first positive measured width and ignores sub-pixel jitter', () => {
+    expect(nextSettledContentWidth(0, 0)).toBe(0);
+    expect(nextSettledContentWidth(0, 360)).toBe(360);
+    expect(nextSettledContentWidth(360, 361)).toBe(360);
+    expect(nextSettledContentWidth(360, 359)).toBe(360);
+  });
+
+  it('updates when the container really changes width', () => {
+    expect(nextSettledContentWidth(360, 328)).toBe(328);
+    expect(nextSettledContentWidth(328, 390)).toBe(390);
   });
 });

--- a/apps/mobile/src/__tests__/messageSelectionDesktopFirst.test.ts
+++ b/apps/mobile/src/__tests__/messageSelectionDesktopFirst.test.ts
@@ -41,6 +41,15 @@ describe('mobile message text selection', () => {
 
     // 列表内正文只有原生渲染路径:无选择 WebView、无全屏选择查看器。
     expect(markdownBodySource).toContain('testID="message.markdownBody"');
+    // Agent 回复二次测宽:stretch 量到像素宽后钉死,避免 UITextView 首帧偏矮被列表裁切。
+    expect(markdownBodySource).toContain('nextSettledContentWidth');
+    expect(markdownBodySource).toContain('collapsable={false}');
+    expect(markdownBodySource).toContain('onLayout={handleSettledWidthLayout}');
+    expect(markdownBodySource).toContain('pinContentWidth');
+    expect(markdownBodySource).toContain('pinSettledWidth');
+    expect(markdownBodySource).toContain(
+      "key={`${group.key}:${pinSettledWidth ? contentWidth : 'hug'}`}",
+    );
     expect(markdownBodySource).not.toContain('SelectableMarkdownWebView');
     expect(source).not.toContain('SelectableMarkdownWebView');
     expect(source).not.toContain('MessageTextSelectionModal');

--- a/apps/mobile/src/__tests__/messageSelectionDesktopFirst.test.ts
+++ b/apps/mobile/src/__tests__/messageSelectionDesktopFirst.test.ts
@@ -47,6 +47,10 @@ describe('mobile message text selection', () => {
     expect(markdownBodySource).toContain('onLayout={handleSettledWidthLayout}');
     expect(markdownBodySource).toContain('pinContentWidth');
     expect(markdownBodySource).toContain('pinSettledWidth');
+    expect(markdownBodySource).toContain("pinContentWidth ? { alignSelf: 'stretch' } : null");
+    expect(markdownBodySource).toContain(
+      'style={pinSettledWidth ? { width: contentWidth, maxWidth: \'100%\' } : null}',
+    );
     expect(markdownBodySource).toContain(
       "key={`${group.key}:${pinSettledWidth ? contentWidth : 'hug'}`}",
     );

--- a/apps/mobile/src/__tests__/userMessageCollapse.test.ts
+++ b/apps/mobile/src/__tests__/userMessageCollapse.test.ts
@@ -155,4 +155,24 @@ describe('MessageRenderer 长消息测量接线', () => {
     expect(bubbleSource).toContain('allowIosUITextView={!shouldCollapseLongMessage}');
     expect(source).toContain('if (selectable && allowIosUITextView && Platform.OS === \'ios\')');
   });
+
+  it('keeps expanded user markdown hugging the bubble instead of pinning list width', () => {
+    const source = readFileSync(resolve(process.cwd(), 'src/session/MessageRenderer.tsx'), 'utf8');
+    const bubbleStart = source.indexOf('function MessageBubble');
+    const bubbleEnd = source.indexOf('function copyActionLabel', bubbleStart);
+    const bubbleSource = source.slice(bubbleStart, bubbleEnd);
+    const markdownBodyStart = source.indexOf('function MarkdownBody');
+    const markdownBodyEnd = source.indexOf('function ChatPathChipSpan', markdownBodyStart);
+    const markdownBodySource = source.slice(markdownBodyStart, markdownBodyEnd);
+
+    expect(bubbleSource).toContain('pinContentWidth={!isUser}');
+    expect(markdownBodySource).toContain('if (!pinContentWidth) return;');
+    const codeStart = markdownBodySource.indexOf("if (block.type === 'code')");
+    const headingStart = markdownBodySource.indexOf("if (block.type === 'heading')", codeStart);
+    const codeSource = markdownBodySource.slice(codeStart, headingStart);
+    expect(codeStart).toBeGreaterThan(-1);
+    expect(headingStart).toBeGreaterThan(codeStart);
+    expect(codeSource).not.toContain('<ScrollView');
+    expect(codeSource).toContain('围栏代码在气泡内换行');
+  });
 });

--- a/apps/mobile/src/session/MessageRenderer.tsx
+++ b/apps/mobile/src/session/MessageRenderer.tsx
@@ -216,6 +216,7 @@ import {
 } from '@/session/messageHierarchyLayout';
 import {
   buildMessageContentLayout,
+  nextSettledContentWidth,
   type MessageContentLayout,
 } from '@/session/messageContentLayout';
 import { buildMobileReadableViewportLayout } from '@/session/responsiveViewportLayout';
@@ -2147,6 +2148,7 @@ function MessageBubble({
                   markdownImageCacheKey={item.message.key}
                   onOpenPayload={actions.onOpenPayload}
                   onOpenSessionLink={actions.onOpenSessionLink}
+                  pinContentWidth={!isUser}
                   selectable={canSelectVisibleText}
                   sessionReferences={item.message.sessionReferences}
                   streaming={false}
@@ -2163,6 +2165,7 @@ function MessageBubble({
             layout={contentLayout}
             onOpenPayload={actions.onOpenPayload}
             onOpenSessionLink={actions.onOpenSessionLink}
+            pinContentWidth={!isUser}
             sessionReferences={item.message.sessionReferences}
             selectable={canSelectVisibleText}
             streaming={isStreamingAssistant}
@@ -3610,6 +3613,7 @@ function MarkdownBody({
   layout,
   onOpenPayload,
   onOpenSessionLink,
+  pinContentWidth = false,
   sessionReferences,
   selectable,
   streaming,
@@ -3623,6 +3627,11 @@ function MarkdownBody({
   onOpenPayload?: (payload: MessagePayload) => void;
   /** 会话深链 chip 点击回调(app 内跳转)。 */
   onOpenSessionLink?: (url: string) => void;
+  /**
+   * 仅 agent 拉伸气泡启用:用户气泡是 hug + maxWidth 86%,钉死测宽会把展开态撑出
+   * 气泡(长代码围栏横向裁切 + 纵向巨高空白)。
+   */
+  pinContentWidth?: boolean;
   /** 当前落库消息里的展示安全引用摘要，按 sessionId + anchor 精确匹配链接。 */
   sessionReferences?: readonly MobilePersistedSessionReferenceMetadata[];
   /** 完成态消息为 true:各块 Text 开原生选中(含内嵌图片 View 的块除外,Android 上有风险)。 */
@@ -3635,6 +3644,19 @@ function MarkdownBody({
   const { t } = useTranslation();
   const styles = useThemedStyles(makeStyles);
   const chatFilePathContext = useContext(ChatFilePathContext);
+  // iOS UITextView 在 stretch/百分比宽度下会偶发只量出部分高度,LegendList 按这次
+  // 偏矮的 onLayout 裁切 agent 回复;点分享会换上确定宽度的容器从而完整显示。
+  // 先 stretch 量到像素宽,再钉死,复现同一次二次布局,且不重挂 mermaid/公式 WebView。
+  const [contentWidth, setContentWidth] = useState(0);
+  const handleSettledWidthLayout = useCallback((event: LayoutChangeEvent) => {
+    if (!pinContentWidth) return;
+    const nextWidth = Math.round(event.nativeEvent.layout.width);
+    setContentWidth((current) => nextSettledContentWidth(current, nextWidth));
+  }, [pinContentWidth]);
+  const pinSettledWidth = pinContentWidth && contentWidth > 0;
+  const settledTextStyle = pinSettledWidth
+    ? [styles.messageText, { width: contentWidth }]
+    : styles.messageText;
   const blocks = useMemo(() => parseMobileMarkdown(text), [text]);
   // Android 的 selectable Text 内嵌 View(直连内联图)行为未定义,含这类 inline 的块不开选中。
   const inlinesSelectable = useCallback((inlines: readonly MobileMarkdownInline[]) => (
@@ -3735,9 +3757,9 @@ function MarkdownBody({
     return (
       <MarkdownSelectableText
         allowIosUITextView={allowIosUITextView}
-        key={group.key}
+        key={`${group.key}:${pinSettledWidth ? contentWidth : 'hug'}`}
         selectable={runSelectable}
-        style={styles.messageText}
+        style={settledTextStyle}
         testID="message.markdownTextRun"
       >
         {group.blocks.flatMap((block, index) => {
@@ -3771,7 +3793,17 @@ function MarkdownBody({
   };
   return (
     <View
-      style={styles.markdownBody}
+      collapsable={false}
+      onLayout={handleSettledWidthLayout}
+      style={[
+        styles.markdownBody,
+        { maxWidth: '100%' },
+        pinSettledWidth
+          ? { width: contentWidth }
+          : pinContentWidth
+            ? { alignSelf: 'stretch' }
+            : null,
+      ]}
       testID="message.markdownBody"
     >
       {groups.flatMap((group, groupIndex) => {
@@ -3811,12 +3843,12 @@ function MarkdownBody({
           );
         }
         if (block.type === 'code') {
+          // 围栏代码在气泡内换行,不用横向 ScrollView:后者在展开长用户消息时
+          // 会按未折行内容报出超高,气泡巨幅空白并把每行裁在右侧圆角外。
           return (
             <View key={block.key} style={styles.markdownCodeFrame}>
-              <ScrollView
-                horizontal
-                style={styles.markdownCodeScroll}
-                contentContainerStyle={[
+              <View
+                style={[
                   styles.markdownCodeContent,
                   {
                     paddingHorizontal: layout.codePaddingHorizontal,
@@ -3832,7 +3864,7 @@ function MarkdownBody({
                   styles={styles}
                   text={block.text}
                 />
-              </ScrollView>
+              </View>
             </View>
           );
         }
@@ -3950,9 +3982,9 @@ function MarkdownBody({
         return (
           <MarkdownSelectableText
             allowIosUITextView={allowIosUITextView}
-            key={block.key}
+            key={`${block.key}:${pinSettledWidth ? contentWidth : 'hug'}`}
             selectable={inlinesSelectable(block.inlines)}
-            style={styles.messageText}
+            style={settledTextStyle}
           >
             {renderInlines(block.inlines, spanFor(inlinesSelectable(block.inlines)))}
           </MarkdownSelectableText>
@@ -6368,6 +6400,8 @@ const makeStyles = (colors: ThemeColors) => StyleSheet.create({
     backgroundColor: colors.surfaceElevated,
     borderColor: colors.borderStrong,
     maxWidth: '86%',
+    minWidth: 0,
+    overflow: 'hidden',
   },
   agentBubble: {
     alignSelf: 'stretch',
@@ -6761,15 +6795,14 @@ const makeStyles = (colors: ThemeColors) => StyleSheet.create({
   },
   markdownListText: { flex: 1 },
   markdownCodeFrame: {
+    alignSelf: 'stretch',
     backgroundColor: colors.chatCodeSurface,
     borderColor: colors.chatCodeBorder,
     borderWidth: StyleSheet.hairlineWidth,
     borderRadius: radius.container,
     maxWidth: '100%',
+    minWidth: 0,
     overflow: 'hidden',
-  },
-  markdownCodeScroll: {
-    maxWidth: '100%',
   },
   markdownCodeContent: {
     paddingHorizontal: spacing.md,
@@ -6777,9 +6810,11 @@ const makeStyles = (colors: ThemeColors) => StyleSheet.create({
   },
   markdownCodeText: {
     color: colors.textPrimary,
+    flexShrink: 1,
     fontFamily: monoFont,
     fontSize: typeScale.code,
     lineHeight: lineHeight.code,
+    maxWidth: '100%',
   },
   // 语法着色:只上 color,其余(字体/字号/行高)继承 markdownCodeText —— 嵌套 Text
   // 只支持有限样式,且改字号会让同一行的 token 高低不齐。

--- a/apps/mobile/src/session/MessageRenderer.tsx
+++ b/apps/mobile/src/session/MessageRenderer.tsx
@@ -3646,7 +3646,8 @@ function MarkdownBody({
   const chatFilePathContext = useContext(ChatFilePathContext);
   // iOS UITextView 在 stretch/百分比宽度下会偶发只量出部分高度,LegendList 按这次
   // 偏矮的 onLayout 裁切 agent 回复;点分享会换上确定宽度的容器从而完整显示。
-  // 先 stretch 量到像素宽,再钉死,复现同一次二次布局,且不重挂 mermaid/公式 WebView。
+  // 外层始终 stretch 测可用宽,内层再钉像素宽:测宽不能钉在自己身上,否则旋转/
+  // 分屏变宽后 onLayout 仍报旧值。1px 内抖动忽略,避免公式 WebView 重挂。
   const [contentWidth, setContentWidth] = useState(0);
   const handleSettledWidthLayout = useCallback((event: LayoutChangeEvent) => {
     if (!pinContentWidth) return;
@@ -3798,14 +3799,14 @@ function MarkdownBody({
       style={[
         styles.markdownBody,
         { maxWidth: '100%' },
-        pinSettledWidth
-          ? { width: contentWidth }
-          : pinContentWidth
-            ? { alignSelf: 'stretch' }
-            : null,
+        pinContentWidth ? { alignSelf: 'stretch' } : null,
       ]}
       testID="message.markdownBody"
     >
+      <View
+        collapsable={false}
+        style={pinSettledWidth ? { width: contentWidth, maxWidth: '100%' } : null}
+      >
       {groups.flatMap((group, groupIndex) => {
         const renderedGroup = (() => {
           if (group.type === 'text_run') {
@@ -3998,6 +3999,7 @@ function MarkdownBody({
           renderedGroup,
         ];
       })}
+      </View>
     </View>
   );
 }

--- a/apps/mobile/src/session/messageContentLayout.ts
+++ b/apps/mobile/src/session/messageContentLayout.ts
@@ -72,3 +72,13 @@ export function buildMessageContentLayout(input: MessageContentLayoutInput): Mes
 function normalizeDimension(value: number | undefined, fallback: number): number {
   return Number.isFinite(value) && typeof value === 'number' && value > 0 ? value : fallback;
 }
+
+/**
+ * Agent 回复正文的二次测宽:stretch 首帧量到像素宽后钉死,避免 iOS UITextView
+ * 在不确定宽度下只报出部分高度,LegendList 按偏矮值裁切消息。1px 内抖动忽略,
+ * 防止分享勾选栏出现/旋转时来回改宽把公式 WebView 打进重挂循环。
+ */
+export function nextSettledContentWidth(current: number, next: number): number {
+  if (!(next > 0) || Math.abs(current - next) <= 1) return current;
+  return next;
+}

--- a/apps/mobile/src/session/messageContentLayout.ts
+++ b/apps/mobile/src/session/messageContentLayout.ts
@@ -74,9 +74,10 @@ function normalizeDimension(value: number | undefined, fallback: number): number
 }
 
 /**
- * Agent 回复正文的二次测宽:stretch 首帧量到像素宽后钉死,避免 iOS UITextView
+ * Agent 回复正文的二次测宽:外层 stretch 量到像素宽后钉在内层,避免 iOS UITextView
  * 在不确定宽度下只报出部分高度,LegendList 按偏矮值裁切消息。1px 内抖动忽略,
- * 防止分享勾选栏出现/旋转时来回改宽把公式 WebView 打进重挂循环。
+ * 防止分享勾选栏出现时来回改宽把公式 WebView 打进重挂循环;真实变宽(旋转/分屏)
+ * 由外层 stretch 容器继续上报,这里照常更新。
  */
 export function nextSettledContentWidth(current: number, next: number): number {
   if (!(next > 0) || Math.abs(current - next) <= 1) return current;


### PR DESCRIPTION
## 这次改了什么

### 摘要

移动端长用户消息展开后，围栏代码会按未折行内容横向撑开，造成气泡巨高空白和右侧裁字。本次把围栏改为气泡内换行，并把二次测宽只钉在 agent 拉伸气泡上，避免用户气泡被撑出 86% 上限。同时给 agent 回复补上 stretch 后钉死像素宽，减轻 iOS UITextView 首帧偏矮被列表裁切。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无（会话中发现的展开超框问题）
- 本 PR 包含：用户气泡展开溢出修复、agent 回复二次测宽钉死、相关单测
- 明确不包含：Android 实机、Dark 实机目检、桌面聊天气泡
- 用户可见变化：展开长用户消息时代码围栏在气泡内换行，不再横向裁字或留下巨高空白；短用户气泡仍 hug，不撑满 86%
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：docs/design-rules/DESIGN.md §14.5 聊天正文：正文须落在气泡内可读。本次只修展开态围栏溢出与宽度钉死，不改可点信号、颜色 token 或字号；颜色走既有语义 token，Light / Dark 共用同一套样式。
- 改动后效果（iOS Simulator · iPhone 17 Pro · Light · `cindy/upbeat-mendel`）：
  - 实机截图预览：https://htmlpreview.github.io/?https://gist.githubusercontent.com/DavidShenXD/ffca8fe61470d015f1fc0b9f8cca7948/raw/index.html
  - gist：https://gist.github.com/DavidShenXD/ffca8fe61470d015f1fc0b9f8cca7948
  - 图 1：展开后的代码围栏贴齐气泡右缘，无横向裁字、无巨高空白，底部可见「收起」
  - 图 2：长用户气泡展开全文，URL 在气泡内换行
  - 图 3：同一条点「收起」后回到截断 +「展开」

```html
<!-- 改后：用户气泡 hug + max 86%；围栏在气泡内换行，底部「收起」 -->
<article style="max-width:390px;margin:0 auto;padding:12px;background:#f4f4f5;font:14px/1.45 sans-serif">
  <div style="margin-left:auto;max-width:86%;background:#fff;border:1px solid #d4d4d8;border-radius:16px;padding:12px;overflow:hidden">
    <pre style="margin:0 0 8px;white-space:pre-wrap;word-break:break-word;background:#f4f4f5;border-radius:8px;padding:8px;overflow:hidden">### 反馈已处理
已处理：
- 围栏在气泡内换行，不再横向裁字</pre>
    <button type="button">收起</button>
  </div>
</article>
```

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：PASS apps/mobile unit (2.7s)，related 5 个文件

pnpm --filter mobile run typecheck
结果：PASS
```

### 手工验证

- 平台：Cindy Host 内嵌 iOS Simulator，设备 Cindy Share Debug - iPhone 17 Pro（iOS 26.5），Metro 8081，worktree `cindy/upbeat-mendel`，`pnpm mobile:sim:whoami` PASS（`cindy/upbeat-mendel@05264ab01+f5d186ab7c`）
- 会话：【Merged】PR-3023…
- 用户气泡展开（含 markdown 围栏的 pr-watch 模板，约 18:01）：围栏在气泡内换行，无横向 ScrollView，无右侧裁字，无巨高空白；滑到底可见完整围栏与「收起」。见图 1。
- 短/中用户气泡（19:40 prose+URL）：仍 hug，不撑到 86%。见图 2。
- 「收起」：19:40 展开后再点收起，回到截断正文 +「展开」，高度从约 500 回到约 316。见图 3。
- Light 模式实机已看；Dark 未目检

### 未执行的验证

- Dark 实机目检：未切系统外观
- Android：本次只在 iOS Simulator 验收
- Agent 回复首帧裁切：竞态不易稳定复现；代码路径与单测已覆盖，未在本轮强制打出旧现象

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 mobile 消息气泡布局（`MessageRenderer` / `messageContentLayout`）。JS/UI 改动，不触碰 fingerprint 输入，不触发冷更。
- 回滚 / 降级方式：revert 本 commit。无。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
