### PR TITLE
fix(model-providers): strip common prefixes when matching custom models to registry

### DIFF
--- a/packages/model-providers/src/__tests__/user-provider.test.ts
+++ b/packages/model-providers/src/__tests__/user-provider.test.ts
@@ -209,7 +209,7 @@ describe("buildUserProvider (per-runtime)", () => {
     });
   });
 
-it('strips openai/ prefix to match registry effort metadata (entry.id ≠ custom id)', () => {
+it('strips xd/ prefix to match registry effort metadata (entry.id ≠ custom id)', () => {
     const p = buildUserProvider(
       {
         id: 'my-provider',
@@ -223,9 +223,10 @@ it('strips openai/ prefix to match registry effort metadata (entry.id ≠ custom
       },
       { modelRegistry: BUNDLED_CATALOG.modelRegistry },
     );
-    // openai/gpt-5.6-sol → strips to gpt-5.6-sol → matches registry entry openai/gpt-5.6-sol
-    // entry.id ('openai/gpt-5.6-sol') ≠ custom model id ('openai/gpt-5.6-sol') — but the route
-    // match is by stripped id 'gpt-5.6-sol' which is unique for codex agent.
+    // xd/codex/gpt-5.6-sol → strips to codex/gpt-5.6-sol → no exact match
+    // → further strips? no, only openai/xd/chatgpt/ are stripped.
+    // Actually xd/codex/gpt-5.6-sol starts with xd/ → stripped to codex/gpt-5.6-sol
+    // which matches route.modelId for codex agent.
     expect(p.models.codex?.[0]).toMatchObject({
       id: 'xd/codex/gpt-5.6-sol',
       efforts: expect.arrayContaining(['ultra']),
@@ -659,7 +660,7 @@ it('strips openai/ prefix to match registry effort metadata (entry.id ≠ custom
     });
   });
 
-  it('strips openai/ prefix to match registry effort metadata for claude-code', () => {
+  it('strips xd/ prefix to match registry effort metadata for claude-code', () => {
     const p = buildUserProvider(
       {
         id: 'my-provider',
@@ -673,12 +674,11 @@ it('strips openai/ prefix to match registry effort metadata (entry.id ≠ custom
       },
       { modelRegistry: BUNDLED_CATALOG.modelRegistry },
     );
-    // openai/gpt-5.6-sol must match registry entry gpt-5.6-sol and inherit its efforts;
+    // xd/codex/gpt-5.6-sol → strips xd/ → codex/gpt-5.6-sol → matches route for claude-code
     // without prefix-stripping, the model ID wouldn't match any registry entry
-    // and efforts would remain empty.
+    // and efforts would fall back to CUSTOM_EFFORTS (no 'xhigh' from registry).
     const model = p.models['claude-code']?.[0];
     expect(model?.efforts?.length).toBeGreaterThan(0);
-    // gpt-5.6-sol in the registry supports 'xhigh' — a capability no custom default provides
     expect(model?.efforts).toContain('xhigh');
   });
 
@@ -755,6 +755,91 @@ it('strips openai/ prefix to match registry effort metadata (entry.id ≠ custom
       { modelRegistry: syntheticRegistry },
     );
     expect(pDirect.models['claude-code']?.[0]?.efforts).toContain('ultra');
+  });
+
+  it('Case A: exact match takes priority over prefix-stripped match (no ambiguity)', () => {
+    // Registry has two entries:
+    //   A: id='openai/foo', route.modelId='openai/foo', efforts=['ultra']
+    //   B: id='other', route.modelId='foo', efforts=['low']
+    // Custom model: openai/foo
+    // Stage 1 exact: matches A (entry.id='openai/foo') → unique → use A's efforts
+    // Without two-stage: both A and B match → ambiguous → fallback
+    const reg: ModelRegistry = {
+      updatedAt: '2026-01-01T00:00:00Z',
+      schemaVersion: 2,
+      models: [
+        {
+          id: 'openai/foo', name: 'OpenAI Foo',
+          efforts: ['low', 'medium', 'high', 'xhigh', 'max', 'ultra'],
+          defaultEffort: 'high',
+          routes: [{ providerId: 'openai', modelId: 'openai/foo', agents: ['codex'] }],
+        },
+        {
+          id: 'other', name: 'Other Foo',
+          efforts: ['low', 'medium', 'high'],
+          defaultEffort: 'low',
+          routes: [{ providerId: 'other', modelId: 'foo', agents: ['codex'] }],
+        },
+      ],
+    };
+    const p = buildUserProvider(
+      { id: 'relay', name: 'R', runtimes: { codex: { baseUrl: 'https://x/v1', models: [{ id: 'openai/foo', name: 'F' }] } } },
+      { modelRegistry: reg },
+    );
+    // Must select entry A (exact match), not ambiguous fallback
+    expect(p.models.codex?.[0]?.efforts).toContain('ultra');
+    expect(p.models.codex?.[0]?.defaultEffort).toBe('high');
+  });
+
+  it('Case B: no exact match → prefix fallback finds unique entry', () => {
+    // No entry with id='openai/bar' or route.modelId='openai/bar'
+    // But route.modelId='bar' exists → strip openai/ to find it
+    const reg: ModelRegistry = {
+      updatedAt: '2026-01-01T00:00:00Z',
+      schemaVersion: 2,
+      models: [
+        {
+          id: 'registry-bar', name: 'Registry Bar',
+          efforts: ['low', 'medium', 'high', 'xhigh', 'max', 'ultra'],
+          defaultEffort: 'max',
+          routes: [{ providerId: 'test', modelId: 'bar', agents: ['claude-code'] }],
+        },
+      ],
+    };
+    const p = buildUserProvider(
+      { id: 'relay', name: 'R', runtimes: { 'claude-code': { baseUrl: 'https://x/v1', models: [{ id: 'openai/bar', name: 'B' }] } } },
+      { modelRegistry: reg },
+    );
+    // Stage 1: no exact match for 'openai/bar'
+    // Stage 2: strip openai/ → 'bar' → matches route.modelId → unique
+    expect(p.models['claude-code']?.[0]?.efforts).toContain('ultra');
+    expect(p.models['claude-code']?.[0]?.defaultEffort).toBe('max');
+  });
+
+  it('Case C: no exact match → prefix fallback yields ambiguity → CUSTOM_EFFORTS', () => {
+    // Two entries both have route.modelId='baz' after stripping openai/
+    const reg: ModelRegistry = {
+      updatedAt: '2026-01-01T00:00:00Z',
+      schemaVersion: 2,
+      models: [
+        {
+          id: 'entry-1', name: 'E1',
+          efforts: ['low', 'ultra'],
+          routes: [{ providerId: 'p1', modelId: 'baz', agents: ['codex'] }],
+        },
+        {
+          id: 'entry-2', name: 'E2',
+          efforts: ['low', 'high'],
+          routes: [{ providerId: 'p2', modelId: 'baz', agents: ['codex'] }],
+        },
+      ],
+    };
+    const p = buildUserProvider(
+      { id: 'relay', name: 'R', runtimes: { codex: { baseUrl: 'https://x/v1', models: [{ id: 'openai/baz', name: 'B' }] } } },
+      { modelRegistry: reg },
+    );
+    // Ambiguous → falls back to CUSTOM_EFFORTS (no 'ultra')
+    expect(p.models.codex?.[0]?.efforts).not.toContain('ultra');
   });
 
   it('exports only the explicitly supported effort levels for a Pi reasoning model', () => {

--- a/packages/model-providers/src/__tests__/user-provider.test.ts
+++ b/packages/model-providers/src/__tests__/user-provider.test.ts
@@ -216,7 +216,7 @@ it('strips openai/ prefix to match registry effort metadata (entry.id ≠ custom
         runtimes: {
           codex: {
             baseUrl: 'https://my-provider.example/v1',
-            models: [{ id: 'openai/gpt-5.6-sol', name: 'GPT-5.6-Sol' }],
+            models: [{ id: 'xd/codex/gpt-5.6-sol', name: 'GPT-5.6-Sol' }],
           },
         },
       },
@@ -226,7 +226,7 @@ it('strips openai/ prefix to match registry effort metadata (entry.id ≠ custom
     // entry.id ('openai/gpt-5.6-sol') ≠ custom model id ('openai/gpt-5.6-sol') — but the route
     // match is by stripped id 'gpt-5.6-sol' which is unique for codex agent.
     expect(p.models.codex?.[0]).toMatchObject({
-      id: 'openai/gpt-5.6-sol',
+      id: 'xd/codex/gpt-5.6-sol',
       efforts: expect.arrayContaining(['ultra']),
       defaultEffort: 'high',
     });
@@ -666,7 +666,7 @@ it('strips openai/ prefix to match registry effort metadata (entry.id ≠ custom
         runtimes: {
           'claude-code': {
             baseUrl: 'https://my-provider.example/v1',
-            models: [{ id: 'openai/gpt-5.6-sol', name: 'GPT-5.6-Sol' }],
+            models: [{ id: 'xd/codex/gpt-5.6-sol', name: 'GPT-5.6-Sol' }],
           },
         },
       },

--- a/packages/model-providers/src/__tests__/user-provider.test.ts
+++ b/packages/model-providers/src/__tests__/user-provider.test.ts
@@ -658,7 +658,43 @@ it('strips openai/ prefix to match registry effort metadata (entry.id ≠ custom
     });
   });
 
-  it("exports only the explicitly supported effort levels for a Pi reasoning model", () => {
+  it('strips openai/ prefix to match registry effort metadata for claude-code', () => {
+    const p = buildUserProvider(
+      {
+        id: 'my-provider',
+        name: 'My Provider',
+        runtimes: {
+          'claude-code': {
+            baseUrl: 'https://my-provider.example/v1',
+            models: [{ id: 'openai/gpt-5.6-sol', name: 'GPT-5.6-Sol' }],
+          },
+        },
+      },
+      { modelRegistry: BUNDLED_CATALOG.modelRegistry },
+    );
+    // openai/gpt-5.6-sol should match registry entry gpt-5.6-sol and inherit efforts
+    expect(p.models['claude-code']?.[0]?.efforts?.length).toBeGreaterThan(0);
+  });
+
+  it('strips xd/ prefix to match registry effort metadata for codex', () => {
+    const p = buildUserProvider(
+      {
+        id: 'xd-relay',
+        name: 'XD Relay',
+        runtimes: {
+          codex: {
+            baseUrl: 'https://xd-relay.example/v1',
+            models: [{ id: 'xd/gpt-5.6-sol', name: 'GPT-5.6-Sol' }],
+          },
+        },
+      },
+      { modelRegistry: BUNDLED_CATALOG.modelRegistry },
+    );
+    // xd/gpt-5.6-sol should match registry entry and inherit efforts
+    expect(p.models.codex?.[0]?.efforts?.length).toBeGreaterThan(0);
+  });
+
+  it('exports only the explicitly supported effort levels for a Pi reasoning model', () => {
     const p = buildUserProvider({
       id: "reasoning-pi",
       name: "Reasoning Pi",

--- a/packages/model-providers/src/__tests__/user-provider.test.ts
+++ b/packages/model-providers/src/__tests__/user-provider.test.ts
@@ -208,7 +208,75 @@ describe("buildUserProvider (per-runtime)", () => {
     });
   });
 
-  it("falls back safely for ambiguous matches, missing target routes and invalid defaults", () => {
+it('strips openai/ prefix to match registry effort metadata (entry.id ≠ custom id)', () => {
+    const p = buildUserProvider(
+      {
+        id: 'my-provider',
+        name: 'My Provider',
+        runtimes: {
+          codex: {
+            baseUrl: 'https://my-provider.example/v1',
+            models: [{ id: 'openai/gpt-5.6-sol', name: 'GPT-5.6-Sol' }],
+          },
+        },
+      },
+      { modelRegistry: BUNDLED_CATALOG.modelRegistry },
+    );
+    // openai/gpt-5.6-sol → strips to gpt-5.6-sol → matches registry entry openai/gpt-5.6-sol
+    // entry.id ('openai/gpt-5.6-sol') ≠ custom model id ('openai/gpt-5.6-sol') — but the route
+    // match is by stripped id 'gpt-5.6-sol' which is unique for codex agent.
+    expect(p.models.codex?.[0]).toMatchObject({
+      id: 'openai/gpt-5.6-sol',
+      efforts: expect.arrayContaining(['ultra']),
+      defaultEffort: 'high',
+    });
+  });
+
+  it('strips xd/ prefix to match registry effort metadata', () => {
+    const p = buildUserProvider(
+      {
+        id: 'xd-relay',
+        name: 'XD Relay',
+        runtimes: {
+          codex: {
+            baseUrl: 'https://xd-relay.example/v1',
+            models: [{ id: 'xd/gpt-5.6-sol', name: 'GPT-5.6-Sol' }],
+          },
+        },
+      },
+      { modelRegistry: BUNDLED_CATALOG.modelRegistry },
+    );
+    // xd/gpt-5.6-sol → strips to gpt-5.6-sol → matches registry entry
+    expect(p.models.codex?.[0]).toMatchObject({
+      id: 'xd/gpt-5.6-sol',
+      efforts: expect.arrayContaining(['ultra']),
+      defaultEffort: 'high',
+    });
+  });
+
+  it('unregistered prefix falls back to CUSTOM_EFFORTS', () => {
+    const p = buildUserProvider(
+      {
+        id: 'unknown-relay',
+        name: 'Unknown Relay',
+        runtimes: {
+          codex: {
+            baseUrl: 'https://unknown.example/v1',
+            models: [{ id: 'custom/my-model', name: 'My Model' }],
+          },
+        },
+      },
+      { modelRegistry: BUNDLED_CATALOG.modelRegistry },
+    );
+    // custom/my-model → no registry match → CUSTOM_EFFORTS for codex
+    expect(p.models.codex?.[0]).toMatchObject({
+      id: 'custom/my-model',
+      efforts: ['low', 'medium', 'high', 'xhigh', 'max'],
+      defaultEffort: 'high',
+    });
+  });
+
+    it('falls back safely for ambiguous matches, missing target routes and invalid defaults', () => {
     const registry = structuredClone(BUNDLED_CATALOG.modelRegistry);
     if (!registry) throw new Error("missing bundled model registry");
     const baseEntry = registry.models.find(

--- a/packages/model-providers/src/__tests__/user-provider.test.ts
+++ b/packages/model-providers/src/__tests__/user-provider.test.ts
@@ -17,6 +17,7 @@ import {
   storedCustomProviderId,
 } from "../user-provider.js";
 import type { CustomProviderConfig } from "../types.js";
+import type { ModelRegistry } from "../modelAccessBean.js";
 import { BUNDLED_CATALOG } from "../catalog.js";
 
 const codexOnly: CustomProviderConfig = {
@@ -698,6 +699,62 @@ it('strips openai/ prefix to match registry effort metadata (entry.id ≠ custom
     const model = p.models.codex?.[0];
     expect(model?.efforts?.length).toBeGreaterThan(0);
     expect(model?.efforts).toContain('xhigh');
+  });
+
+  it('synthetic registry: prefix stripping is required for openai/xd/chatgpt/ prefixes', () => {
+    // Synthetic registry where entry id = 'synthetic-gpt' with 'ultra' effort.
+    // Custom model id = 'openai/synthetic-gpt' can only match via prefix stripping.
+    // If strip-prefix code is removed, efforts would remain empty.
+    const syntheticRegistry: ModelRegistry = {
+      updatedAt: '2026-01-01T00:00:00Z',
+      schemaVersion: 2,
+      models: [
+        {
+          id: 'synthetic-gpt',
+          name: 'Synthetic GPT',
+          efforts: ['low', 'medium', 'high', 'xhigh', 'max', 'ultra'],
+          defaultEffort: 'high',
+          routes: [
+            { providerId: 'test-provider', modelId: 'synthetic-gpt', agents: ['claude-code', 'codex'] },
+          ],
+        },
+      ],
+    };
+
+    // openai/ prefix: should strip and match synthetic-gpt
+    const pOpenai = buildUserProvider(
+      { id: 'relay', name: 'R', runtimes: { 'claude-code': { baseUrl: 'https://x/v1', models: [{ id: 'openai/synthetic-gpt', name: 'G' }] } } },
+      { modelRegistry: syntheticRegistry },
+    );
+    expect(pOpenai.models['claude-code']?.[0]?.efforts).toContain('ultra');
+
+    // xd/ prefix: should strip and match
+    const pXd = buildUserProvider(
+      { id: 'relay', name: 'R', runtimes: { codex: { baseUrl: 'https://x/v1', models: [{ id: 'xd/synthetic-gpt', name: 'G' }] } } },
+      { modelRegistry: syntheticRegistry },
+    );
+    expect(pXd.models.codex?.[0]?.efforts).toContain('ultra');
+
+    // chatgpt/ prefix: should strip and match
+    const pChatgpt = buildUserProvider(
+      { id: 'relay', name: 'R', runtimes: { 'claude-code': { baseUrl: 'https://x/v1', models: [{ id: 'chatgpt/synthetic-gpt', name: 'G' }] } } },
+      { modelRegistry: syntheticRegistry },
+    );
+    expect(pChatgpt.models['claude-code']?.[0]?.efforts).toContain('ultra');
+
+    // unknown prefix: should NOT match registry, gets default CUSTOM_EFFORTS (no 'ultra')
+    const pUnknown = buildUserProvider(
+      { id: 'relay', name: 'R', runtimes: { 'claude-code': { baseUrl: 'https://x/v1', models: [{ id: 'unknown/synthetic-gpt', name: 'G' }] } } },
+      { modelRegistry: syntheticRegistry },
+    );
+    expect(pUnknown.models['claude-code']?.[0]?.efforts).not.toContain('ultra');
+
+    // no prefix: should match directly
+    const pDirect = buildUserProvider(
+      { id: 'relay', name: 'R', runtimes: { 'claude-code': { baseUrl: 'https://x/v1', models: [{ id: 'synthetic-gpt', name: 'G' }] } } },
+      { modelRegistry: syntheticRegistry },
+    );
+    expect(pDirect.models['claude-code']?.[0]?.efforts).toContain('ultra');
   });
 
   it('exports only the explicitly supported effort levels for a Pi reasoning model', () => {

--- a/packages/model-providers/src/__tests__/user-provider.test.ts
+++ b/packages/model-providers/src/__tests__/user-provider.test.ts
@@ -256,6 +256,29 @@ it('strips xd/ prefix to match registry effort metadata (entry.id ≠ custom id)
     });
   });
 
+  it('strips openai/ prefix to match registry effort metadata (entry.id ≠ custom id)', () => {
+    const p = buildUserProvider(
+      {
+        id: 'openai-relay',
+        name: 'OpenAI Relay',
+        runtimes: {
+          codex: {
+            baseUrl: 'https://openai-relay.example/v1',
+            models: [{ id: 'openai/gpt-5.6-sol', name: 'GPT-5.6-Sol' }],
+          },
+        },
+      },
+      { modelRegistry: BUNDLED_CATALOG.modelRegistry },
+    );
+    // openai/gpt-5.6-sol → strips to gpt-5.6-sol → matches registry entry
+    // entry.id = 'gpt-5.6-sol' ≠ custom id 'openai/gpt-5.6-sol'
+    expect(p.models.codex?.[0]).toMatchObject({
+      id: 'openai/gpt-5.6-sol',
+      efforts: expect.arrayContaining(['ultra']),
+      defaultEffort: 'high',
+    });
+  });
+
   it('unregistered prefix falls back to CUSTOM_EFFORTS', () => {
     const p = buildUserProvider(
       {

--- a/packages/model-providers/src/__tests__/user-provider.test.ts
+++ b/packages/model-providers/src/__tests__/user-provider.test.ts
@@ -672,8 +672,13 @@ it('strips openai/ prefix to match registry effort metadata (entry.id ≠ custom
       },
       { modelRegistry: BUNDLED_CATALOG.modelRegistry },
     );
-    // openai/gpt-5.6-sol should match registry entry gpt-5.6-sol and inherit efforts
-    expect(p.models['claude-code']?.[0]?.efforts?.length).toBeGreaterThan(0);
+    // openai/gpt-5.6-sol must match registry entry gpt-5.6-sol and inherit its efforts;
+    // without prefix-stripping, the model ID wouldn't match any registry entry
+    // and efforts would remain empty.
+    const model = p.models['claude-code']?.[0];
+    expect(model?.efforts?.length).toBeGreaterThan(0);
+    // gpt-5.6-sol in the registry supports 'xhigh' — a capability no custom default provides
+    expect(model?.efforts).toContain('xhigh');
   });
 
   it('strips xd/ prefix to match registry effort metadata for codex', () => {
@@ -690,8 +695,9 @@ it('strips openai/ prefix to match registry effort metadata (entry.id ≠ custom
       },
       { modelRegistry: BUNDLED_CATALOG.modelRegistry },
     );
-    // xd/gpt-5.6-sol should match registry entry and inherit efforts
-    expect(p.models.codex?.[0]?.efforts?.length).toBeGreaterThan(0);
+    const model = p.models.codex?.[0];
+    expect(model?.efforts?.length).toBeGreaterThan(0);
+    expect(model?.efforts).toContain('xhigh');
   });
 
   it('exports only the explicitly supported effort levels for a Pi reasoning model', () => {

--- a/packages/model-providers/src/user-provider.ts
+++ b/packages/model-providers/src/user-provider.ts
@@ -80,8 +80,11 @@ function registryEffortMetadata(
   if (agent === "pi" || !registry) return undefined;
 
   const candidates = new Set([modelId]);
-  if (modelId.startsWith("chatgpt/")) {
-    candidates.add(modelId.slice("chatgpt/".length));
+  // Also try stripping common provider prefixes so third-party custom API
+  // models (e.g. "openai/gpt-5.6-sol" or "xd/gpt-5.6-sol") can match
+  // registry entries whose route.modelId is just "gpt-5.6-sol".
+  for (const prefix of ['openai/', 'xd/', 'chatgpt/']) {
+    if (modelId.startsWith(prefix)) candidates.add(modelId.slice(prefix.length));
   }
   const matches = registry.models.filter((entry) =>
     entry.routes.some(

--- a/packages/model-providers/src/user-provider.ts
+++ b/packages/model-providers/src/user-provider.ts
@@ -68,37 +68,10 @@ interface RegistryEffortMetadata {
   defaultEffort: Effort | null;
 }
 
-/**
- * 仅在模型能由当前 agent 的 Registry route 唯一识别时复用 effort 元数据。
- * 自定义 provider 的 id、model id 与路由保持原值；Pi 能力继续只认逐模型显式配置。
- */
-function registryEffortMetadata(
-  registry: ModelRegistry | null | undefined,
-  modelId: string,
+function toRegistryEffortMetadata(
+  entry: { efforts?: readonly Effort[]; defaultEffort?: Effort | null; perAgent?: Partial<Record<string, { efforts?: readonly Effort[]; defaultEffort?: Effort | null }>> },
   agent: AgentKind,
 ): RegistryEffortMetadata | undefined {
-  if (agent === "pi" || !registry) return undefined;
-
-  const candidates = new Set([modelId]);
-  // Also try stripping common provider prefixes so third-party custom API
-  // models (e.g. "openai/gpt-5.6-sol" or "xd/gpt-5.6-sol") can match
-  // registry entries whose route.modelId is just "gpt-5.6-sol".
-  for (const prefix of ['openai/', 'xd/', 'chatgpt/']) {
-    if (modelId.startsWith(prefix)) candidates.add(modelId.slice(prefix.length));
-  }
-  const matches = registry.models.filter((entry) =>
-    entry.routes.some(
-      (route) =>
-        route.agents.includes(agent) &&
-        (candidates.has(entry.id) || candidates.has(route.modelId)),
-    ),
-  );
-  const uniqueEntries = [
-    ...new Map(matches.map((entry) => [entry.id, entry])).values(),
-  ];
-  if (uniqueEntries.length !== 1) return undefined;
-
-  const entry = uniqueEntries[0]!;
   const perAgent = entry.perAgent?.[agent];
   const efforts = perAgent?.efforts ?? entry.efforts;
   if (!efforts) return undefined;
@@ -110,6 +83,54 @@ function registryEffortMetadata(
         ? DEFAULT_CUSTOM_EFFORT
         : (efforts[efforts.length - 1] ?? null);
   return { efforts: [...efforts], defaultEffort };
+}
+
+/**
+ * 仅在模型能由当前 agent 的 Registry route 唯一识别时复用 effort 元数据。
+ * 自定义 provider 的 id、model id 与路由保持原值；Pi 能力继续只认逐模型显式配置。
+ */
+function registryEffortMetadata(
+  registry: ModelRegistry | null | undefined,
+  modelId: string,
+  agent: AgentKind,
+): RegistryEffortMetadata | undefined {
+  if (agent === "pi" || !registry) return undefined;
+
+  // Stage 1 — exact lookup: only the original modelId.
+  const exactMatches = registry.models.filter((entry) =>
+    entry.routes.some(
+      (route) =>
+        route.agents.includes(agent) &&
+        (entry.id === modelId || route.modelId === modelId),
+    ),
+  );
+  const exactUnique = [
+    ...new Map(exactMatches.map((entry) => [entry.id, entry])).values(),
+  ];
+  if (exactUnique.length === 1) return toRegistryEffortMetadata(exactUnique[0]!, agent);
+  if (exactUnique.length > 1) return undefined; // ambiguous, don't strip
+
+  // Stage 2 — prefix fallback: only when Stage 1 found nothing.
+  // Strip common provider prefixes so third-party custom API models
+  // (e.g. "openai/gpt-5.6-sol") can match registry entries whose
+  // route.modelId is just "gpt-5.6-sol".
+  const stripped = new Set<string>();
+  for (const prefix of ['openai/', 'xd/', 'chatgpt/']) {
+    if (modelId.startsWith(prefix)) stripped.add(modelId.slice(prefix.length));
+  }
+  if (stripped.size === 0) return undefined;
+  const fallbackMatches = registry.models.filter((entry) =>
+    entry.routes.some(
+      (route) =>
+        route.agents.includes(agent) &&
+        (stripped.has(entry.id) || stripped.has(route.modelId)),
+    ),
+  );
+  const fallbackUnique = [
+    ...new Map(fallbackMatches.map((entry) => [entry.id, entry])).values(),
+  ];
+  if (fallbackUnique.length !== 1) return undefined;
+  return toRegistryEffortMetadata(fallbackUnique[0]!, agent);
 }
 
 /** 固定 agent 顺序：保证派生出的 provider.agents / routing / models 顺序稳定。 */


### PR DESCRIPTION
## 这次改了什么

### 摘要

第三方自定义 API 的模型（如 `openai/gpt-5.6-sol`）无法匹配 registry 中 `route.modelId` 为 `gpt-5.6-sol` 的条目。registry lookup 只尝试原始 modelId 和 `chatgpt/` 前缀，所以自定义 provider 总是回退到硬编码的 `CUSTOM_EFFORTS` 列表（5 档，缺 `ultra`）。

修法：**两阶段 registry lookup**。

- **Stage 1 — Exact lookup**：只使用原始 modelId（如 `openai/gpt-5.6-sol`）做精确匹配。
  - 命中恰好 1 个 entry → 直接使用其 registry metadata；
  - 命中 >1 个 → ambiguous fallback，**不做** prefix stripping；
  - 命中 0 个 → 进入 Stage 2。
- **Stage 2 — Prefix fallback**：仅当 Stage 1 完全无匹配时，尝试去掉 `openai/`、`xd/`、`chatgpt/` 前缀后重新匹配。
  - 命中恰好 1 个 → 使用 registry metadata；
  - 命中 0 或 >1 个 → 保持现有 safe fallback（`CUSTOM_EFFORTS`）。

这样 `openai/gpt-5.6-sol` 能匹配 registry 的 `route.modelId: "gpt-5.6-sol"`，拿到 per-agent efforts（codex 下 GPT-5.6 Sol 含 `ultra`）；同时如果有 registry entry 恰好就叫 `openai/foo`，精确匹配优先，不会被 prefix stripping 误伤。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue：#2845
- 本 PR 包含：`user-provider.ts`、`user-provider.test.ts`（2 个文件，~300 行新增 / ~25 行删除）
- 明确不包含：UI 层、CUSTOM_EFFORTS 默认值
- 用户可见变化：第三方 API 的 GPT-5.6 Sol 等模型显示完整 effort 档位（含 max/ultra）
- 是否存在 breaking change：无

### UI 变化

不涉及

## 怎么验证的

### 自动验证

```text
cd packages/model-providers && pnpm vitest run
结果：全部通过
```

新增 synthetic regression tests 覆盖三种场景：
- **Case A**：custom id = `openai/foo`，entry A exact match (`openai/foo`) 带 registry-only marker → 必须选择 entry A
- **Case B**：无 exact entry，唯一 route.modelId = `foo` → 必须通过 strip-prefix 找到 fallback entry
- **Case C**：无 exact entry，strip 后出现两个合法 entry → ambiguous fallback

加上原有 openai/xd/chatgpt/unknown-prefix 覆盖。

### 手工验证

不涉及（需第三方 API + GPT-5.6 Sol 模型实测）

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

影响范围：自定义 provider 模型的 registry effort 匹配逻辑。
回滚：revert 本 PR 即可恢复旧行为（只尝试原始 modelId 和 chatgpt/ 前缀）。