### PR TITLE
fix(pi): bridge 重载后恢复一次性启动 env 的 bash 隔离 home

### DIFF
--- a/packages/maker-core/src/agents/pi/__tests__/cindyBridgeSource.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/cindyBridgeSource.test.ts
@@ -79,6 +79,37 @@ function loadBashIsolationHelper(
   ) => Record<string, string | undefined>;
 }
 
+function loadOneShotEnvHelper(): {
+  takeOneShotEnv: (name: string) => string | undefined;
+  env: Record<string, string | undefined>;
+  globalThis: Record<string, unknown>;
+} {
+  const source = CINDY_BRIDGE_EXTENSION_SOURCE;
+  const start = source.indexOf('const BRIDGE_RELOAD_STASH_GLOBAL');
+  const end = source.indexOf('// 凭证/密钥路径特征由 maker-core 的单一来源生成');
+  if (start < 0 || end <= start) throw new Error('one-shot env helper was not found');
+  const executableSource = [
+    source.slice(start, end),
+    '(globalThis as any).takeOneShotEnv = takeOneShotEnv;',
+  ].join('\n');
+  const compiled = ts.transpileModule(executableSource, {
+    compilerOptions: {
+      module: ts.ModuleKind.None,
+      target: ts.ScriptTarget.ES2022,
+    },
+  }).outputText;
+  const context: Record<string, unknown> = {
+    process: { env: {} },
+  };
+  // runInNewContext 的 context 即该 realm 的 globalThis,stash 会落在上面。
+  runInNewContext(compiled, context);
+  const takeOneShotEnv = context.takeOneShotEnv as (name: string) => string | undefined;
+  if (typeof takeOneShotEnv !== 'function') {
+    throw new Error('one-shot env helper was not loaded');
+  }
+  return { takeOneShotEnv, env: context.process.env as Record<string, string | undefined>, globalThis: context };
+}
+
 function loadPiPackageMutationCommandHelper(): (input: unknown) => boolean {
   const source = CINDY_BRIDGE_EXTENSION_SOURCE;
   const parserStart = source.indexOf('function readShellRedirectionTarget');
@@ -1012,6 +1043,56 @@ describe('cindy-bridge extension source', () => {
     expect(CINDY_BRIDGE_EXTENSION_SOURCE).toContain("startsWith('mcp__')");
   });
 
+  it('keeps one-shot startup env available across bridge reloads without leaving it in process.env', () => {
+    // #3070 回归:首次加载读 env → 删 → stash 到 globalThis;重载时 env 已被消费,
+    // 从 stash 取回 host 注入的原始值,bash 不再永久 fail-closed。
+    const helper = loadOneShotEnvHelper();
+
+    // 首次加载:读到 host 注入值,env 随即被删,stash 建立。
+    helper.env.CINDY_PI_BASH_PACKAGE_HOME = '/host/injected/bash-package-home';
+    expect(helper.takeOneShotEnv('CINDY_PI_BASH_PACKAGE_HOME'))
+      .toBe('/host/injected/bash-package-home');
+    expect(helper.env.CINDY_PI_BASH_PACKAGE_HOME).toBeUndefined();
+
+    // 重载(#3070 现场):env 已被首次加载删除,取回 stash 的原始值。
+    expect(helper.takeOneShotEnv('CINDY_PI_BASH_PACKAGE_HOME'))
+      .toBe('/host/injected/bash-package-home');
+    expect(helper.env.CINDY_PI_BASH_PACKAGE_HOME).toBeUndefined();
+
+    // 进程内代码事后改写 env 不会污染重载:重载读的是 stash,不是 env。
+    helper.env.CINDY_PI_BASH_PACKAGE_HOME = '/attacker/controlled/home';
+    expect(helper.takeOneShotEnv('CINDY_PI_BASH_PACKAGE_HOME'))
+      .toBe('/host/injected/bash-package-home');
+
+    // 多个一次性 env 互不干扰(包管理 token 同族修复)。
+    helper.env.CINDY_PI_PACKAGE_MANAGEMENT = 'a'.repeat(48);
+    expect(helper.takeOneShotEnv('CINDY_PI_PACKAGE_MANAGEMENT')).toBe('a'.repeat(48));
+    expect(helper.env.CINDY_PI_PACKAGE_MANAGEMENT).toBeUndefined();
+    expect(helper.takeOneShotEnv('CINDY_PI_PACKAGE_MANAGEMENT')).toBe('a'.repeat(48));
+    expect(helper.takeOneShotEnv('CINDY_PI_BASH_PACKAGE_HOME'))
+      .toBe('/host/injected/bash-package-home');
+
+    // 非 Cindy 初始化的进程(env 从未注入、无 stash)保持 fail-closed 语义:
+    // 返回 undefined,下游 isolatedBashEnvironment 照旧 throw。
+    const fresh = loadOneShotEnvHelper();
+    expect(fresh.takeOneShotEnv('CINDY_PI_BASH_PACKAGE_HOME')).toBeUndefined();
+
+    // 结构断言:入口走 takeOneShotEnv,裸 delete 只存在于 helper 内部。
+    const source = CINDY_BRIDGE_EXTENSION_SOURCE;
+    expect(source).toContain('const bashPackageHome = takeOneShotEnv(PI_BASH_PACKAGE_HOME_ENV);');
+    expect(source).toContain('const piPackageManagementToken = takeOneShotEnv(PI_PACKAGE_MANAGEMENT_ENV);');
+    expect(source).not.toContain('delete process.env[PI_BASH_PACKAGE_HOME_ENV];');
+    expect(source.match(/delete process\.env\[name\];/g)).toHaveLength(1);
+    const helperSlice = source.slice(
+      source.indexOf('const BRIDGE_RELOAD_STASH_GLOBAL'),
+      source.indexOf('// 凭证/密钥路径特征由 maker-core 的单一来源生成'),
+    );
+    expect(helperSlice).toContain('delete process.env[name];');
+    expect(source.indexOf('delete process.env[name];')).toBeLessThan(
+      source.indexOf('export default async function cindyBridge'),
+    );
+  });
+
   it('blocks Pi package mutations before bash while preserving ordinary commands', () => {
     expect(CINDY_BRIDGE_EXTENSION_SOURCE).toContain('bashCommandMutatesPiPackages(nextParams)');
     expect(CINDY_BRIDGE_EXTENSION_SOURCE).toContain(
@@ -1019,9 +1100,6 @@ describe('cindy-bridge extension source', () => {
     );
     expect(CINDY_BRIDGE_EXTENSION_SOURCE).toContain('clean.PI_CODING_AGENT_DIR = bashPackageHome');
     expect(CINDY_BRIDGE_EXTENSION_SOURCE).toContain('delete clean.PI_PACKAGE_DIR');
-    expect(CINDY_BRIDGE_EXTENSION_SOURCE).toContain(
-      'delete process.env[PI_PACKAGE_MANAGEMENT_ENV]',
-    );
     expect(CINDY_BRIDGE_EXTENSION_SOURCE).toContain('token: piPackageManagementToken');
 
     const mutatesPiPackages = loadPiPackageMutationCommandHelper();

--- a/packages/maker-core/src/agents/pi/__tests__/cindyBridgeSource.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/cindyBridgeSource.test.ts
@@ -1043,7 +1043,7 @@ describe('cindy-bridge extension source', () => {
     expect(CINDY_BRIDGE_EXTENSION_SOURCE).toContain("startsWith('mcp__')");
   });
 
-  it('keeps one-shot startup env available across bridge reloads without leaving it in process.env', () => {
+  it('keeps the bash-package-home env available across bridge reloads and the package token out of globalThis', () => {
     // #3070 回归:首次加载读 env → 删 → stash 到 globalThis;重载时 env 已被消费,
     // 从 stash 取回 host 注入的原始值,bash 不再永久 fail-closed。
     const helper = loadOneShotEnvHelper();
@@ -1064,23 +1064,14 @@ describe('cindy-bridge extension source', () => {
     expect(helper.takeOneShotEnv('CINDY_PI_BASH_PACKAGE_HOME'))
       .toBe('/host/injected/bash-package-home');
 
-    // 多个一次性 env 互不干扰(包管理 token 同族修复)。
-    helper.env.CINDY_PI_PACKAGE_MANAGEMENT = 'a'.repeat(48);
-    expect(helper.takeOneShotEnv('CINDY_PI_PACKAGE_MANAGEMENT')).toBe('a'.repeat(48));
-    expect(helper.env.CINDY_PI_PACKAGE_MANAGEMENT).toBeUndefined();
-    expect(helper.takeOneShotEnv('CINDY_PI_PACKAGE_MANAGEMENT')).toBe('a'.repeat(48));
-    expect(helper.takeOneShotEnv('CINDY_PI_BASH_PACKAGE_HOME'))
-      .toBe('/host/injected/bash-package-home');
-
     // 非 Cindy 初始化的进程(env 从未注入、无 stash)保持 fail-closed 语义:
     // 返回 undefined,下游 isolatedBashEnvironment 照旧 throw。
     const fresh = loadOneShotEnvHelper();
     expect(fresh.takeOneShotEnv('CINDY_PI_BASH_PACKAGE_HOME')).toBeUndefined();
 
-    // 结构断言:入口走 takeOneShotEnv,裸 delete 只存在于 helper 内部。
+    // 结构断言:路径走 takeOneShotEnv,裸 delete 只存在于 helper 内部。
     const source = CINDY_BRIDGE_EXTENSION_SOURCE;
     expect(source).toContain('const bashPackageHome = takeOneShotEnv(PI_BASH_PACKAGE_HOME_ENV);');
-    expect(source).toContain('const piPackageManagementToken = takeOneShotEnv(PI_PACKAGE_MANAGEMENT_ENV);');
     expect(source).not.toContain('delete process.env[PI_BASH_PACKAGE_HOME_ENV];');
     expect(source.match(/delete process\.env\[name\];/g)).toHaveLength(1);
     const helperSlice = source.slice(
@@ -1091,6 +1082,17 @@ describe('cindy-bridge extension source', () => {
     expect(source.indexOf('delete process.env[name];')).toBeLessThan(
       source.indexOf('export default async function cindyBridge'),
     );
+
+    // 凭证不进 globalThis stash(review P1):包管理 token 保持读一次即删、
+    // 仅闭包持有 —— 同进程的第三方托管扩展与 bridge 共享 globalThis,stash
+    // 等于把 bearer token 暴露给任意托管代码。重载后工具退场是可接受代价。
+    expect(source).toContain('const piPackageManagementToken = process.env[PI_PACKAGE_MANAGEMENT_ENV];');
+    expect(source).toContain('delete process.env[PI_PACKAGE_MANAGEMENT_ENV];');
+    expect(source.indexOf('delete process.env[PI_PACKAGE_MANAGEMENT_ENV];')).toBeGreaterThan(
+      source.indexOf('export default async function cindyBridge'),
+    );
+    expect(helperSlice).not.toContain('CINDY_PI_PACKAGE_MANAGEMENT');
+    expect(source).not.toContain('takeOneShotEnv(PI_PACKAGE_MANAGEMENT_ENV)');
   });
 
   it('blocks Pi package mutations before bash while preserving ordinary commands', () => {

--- a/packages/maker-core/src/agents/pi/__tests__/cindyBridgeSource.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/cindyBridgeSource.test.ts
@@ -79,18 +79,19 @@ function loadBashIsolationHelper(
   ) => Record<string, string | undefined>;
 }
 
-function loadOneShotEnvHelper(): {
-  takeOneShotEnv: (name: string) => string | undefined;
+function loadBashPackageHomeHelper(): {
+  resolveBashPackageHome: () => string | undefined;
   env: Record<string, string | undefined>;
   globalThis: Record<string, unknown>;
 } {
   const source = CINDY_BRIDGE_EXTENSION_SOURCE;
   const start = source.indexOf('const BRIDGE_RELOAD_STASH_GLOBAL');
   const end = source.indexOf('// 凭证/密钥路径特征由 maker-core 的单一来源生成');
-  if (start < 0 || end <= start) throw new Error('one-shot env helper was not found');
+  if (start < 0 || end <= start) throw new Error('bash package home helper was not found');
   const executableSource = [
+    "const PI_BASH_PACKAGE_HOME_ENV = 'CINDY_PI_BASH_PACKAGE_HOME';",
     source.slice(start, end),
-    '(globalThis as any).takeOneShotEnv = takeOneShotEnv;',
+    '(globalThis as any).resolveBashPackageHome = resolveBashPackageHome;',
   ].join('\n');
   const compiled = ts.transpileModule(executableSource, {
     compilerOptions: {
@@ -100,14 +101,19 @@ function loadOneShotEnvHelper(): {
   }).outputText;
   const context: Record<string, unknown> = {
     process: { env: {} },
+    path,
   };
   // runInNewContext 的 context 即该 realm 的 globalThis,stash 会落在上面。
   runInNewContext(compiled, context);
-  const takeOneShotEnv = context.takeOneShotEnv as (name: string) => string | undefined;
-  if (typeof takeOneShotEnv !== 'function') {
-    throw new Error('one-shot env helper was not loaded');
+  const resolveBashPackageHome = context.resolveBashPackageHome as () => string | undefined;
+  if (typeof resolveBashPackageHome !== 'function') {
+    throw new Error('bash package home helper was not loaded');
   }
-  return { takeOneShotEnv, env: context.process.env as Record<string, string | undefined>, globalThis: context };
+  return {
+    resolveBashPackageHome,
+    env: context.process.env as Record<string, string | undefined>,
+    globalThis: context,
+  };
 }
 
 function loadPiPackageMutationCommandHelper(): (input: unknown) => boolean {
@@ -1043,43 +1049,66 @@ describe('cindy-bridge extension source', () => {
     expect(CINDY_BRIDGE_EXTENSION_SOURCE).toContain("startsWith('mcp__')");
   });
 
-  it('keeps the bash-package-home env available across bridge reloads and the package token out of globalThis', () => {
-    // #3070 回归:首次加载读 env → 删 → stash 到 globalThis;重载时 env 已被消费,
-    // 从 stash 取回 host 注入的原始值,bash 不再永久 fail-closed。
-    const helper = loadOneShotEnvHelper();
+  it('resolves the bash package home across reloads with a tamper-proof stash and keeps the package token out of globalThis', () => {
+    // #3070 回归:首次加载读 env → 删 → 防篡改 stash;重载时 env 已被消费,
+    // 经 stash 与 PI_CODING_AGENT_DIR 派生值双重验证后取回,bash 不再永久 fail-closed。
+    const helper = loadBashPackageHomeHelper();
+    const injected = '/host/agent-home/run-tmp/abc/bash-package-home';
 
-    // 首次加载:读到 host 注入值,env 随即被删,stash 建立。
-    helper.env.CINDY_PI_BASH_PACKAGE_HOME = '/host/injected/bash-package-home';
-    expect(helper.takeOneShotEnv('CINDY_PI_BASH_PACKAGE_HOME'))
-      .toBe('/host/injected/bash-package-home');
+    // 首次加载:读到 host 注入值,env 随即被删,stash 以 non-writable /
+    // non-configurable 属性建立。
+    helper.env.CINDY_PI_BASH_PACKAGE_HOME = injected;
+    helper.env.PI_CODING_AGENT_DIR = '/host/agent-home/run-tmp/abc';
+    expect(helper.resolveBashPackageHome()).toBe(injected);
+    expect(helper.env.CINDY_PI_BASH_PACKAGE_HOME).toBeUndefined();
+    const descriptor = Object.getOwnPropertyDescriptor(
+      helper.globalThis,
+      '__cindyBridgeBashPackageHome',
+    );
+    expect(descriptor?.writable).toBe(false);
+    expect(descriptor?.configurable).toBe(false);
+    expect(descriptor?.value).toBe(injected);
+
+    // 重载(#3070 现场):env 已被首次加载删除,stash 与 PI_CODING_AGENT_DIR 派生值
+    // 双重一致 → 取回原始值。
+    expect(helper.resolveBashPackageHome()).toBe(injected);
     expect(helper.env.CINDY_PI_BASH_PACKAGE_HOME).toBeUndefined();
 
-    // 重载(#3070 现场):env 已被首次加载删除,取回 stash 的原始值。
-    expect(helper.takeOneShotEnv('CINDY_PI_BASH_PACKAGE_HOME'))
-      .toBe('/host/injected/bash-package-home');
+    // 进程内代码事后改写注入 env:被删除并忽略,stash 值不变。
+    helper.env.CINDY_PI_BASH_PACKAGE_HOME = '/attacker/home';
+    expect(helper.resolveBashPackageHome()).toBe(injected);
     expect(helper.env.CINDY_PI_BASH_PACKAGE_HOME).toBeUndefined();
 
-    // 进程内代码事后改写 env 不会污染重载:重载读的是 stash,不是 env。
-    helper.env.CINDY_PI_BASH_PACKAGE_HOME = '/attacker/controlled/home';
-    expect(helper.takeOneShotEnv('CINDY_PI_BASH_PACKAGE_HOME'))
-      .toBe('/host/injected/bash-package-home');
+    // 事后改写 PI_CODING_AGENT_DIR(canary 失配)→ 重载 fail-closed。
+    helper.env.PI_CODING_AGENT_DIR = '/attacker/controlled';
+    expect(helper.resolveBashPackageHome()).toBeUndefined();
+    helper.env.PI_CODING_AGENT_DIR = '/host/agent-home/run-tmp/abc';
+    expect(helper.resolveBashPackageHome()).toBe(injected);
+
+    // stash 属性被替换成 plain 赋值(可写可配置)→ 不被信任 → fail-closed。
+    // (defineProperty 定义 non-configurable 属性后无法 redefine,这里用一个
+    // fresh context 模拟「攻击者抢跑预置了 plain stash」的形态。)
+    const hostile = loadBashPackageHomeHelper();
+    hostile.env.PI_CODING_AGENT_DIR = '/attacker/agent-home';
+    Object.defineProperty(hostile.globalThis, '__cindyBridgeBashPackageHome', {
+      value: '/attacker/agent-home/bash-package-home',
+      writable: true,
+      configurable: true,
+      enumerable: false,
+    });
+    // 攻击者形态 stash 不被信任 → 走首次加载路径;env 未注入 → fail-closed。
+    expect(hostile.resolveBashPackageHome()).toBeUndefined();
 
     // 非 Cindy 初始化的进程(env 从未注入、无 stash)保持 fail-closed 语义:
     // 返回 undefined,下游 isolatedBashEnvironment 照旧 throw。
-    const fresh = loadOneShotEnvHelper();
-    expect(fresh.takeOneShotEnv('CINDY_PI_BASH_PACKAGE_HOME')).toBeUndefined();
+    const fresh = loadBashPackageHomeHelper();
+    expect(fresh.resolveBashPackageHome()).toBeUndefined();
 
-    // 结构断言:路径走 takeOneShotEnv,裸 delete 只存在于 helper 内部。
+    // 结构断言:入口走 resolveBashPackageHome,注入 env 的裸 delete 只在 helper 内。
     const source = CINDY_BRIDGE_EXTENSION_SOURCE;
-    expect(source).toContain('const bashPackageHome = takeOneShotEnv(PI_BASH_PACKAGE_HOME_ENV);');
-    expect(source).not.toContain('delete process.env[PI_BASH_PACKAGE_HOME_ENV];');
-    expect(source.match(/delete process\.env\[name\];/g)).toHaveLength(1);
-    const helperSlice = source.slice(
-      source.indexOf('const BRIDGE_RELOAD_STASH_GLOBAL'),
-      source.indexOf('// 凭证/密钥路径特征由 maker-core 的单一来源生成'),
-    );
-    expect(helperSlice).toContain('delete process.env[name];');
-    expect(source.indexOf('delete process.env[name];')).toBeLessThan(
+    expect(source).toContain('const bashPackageHome = resolveBashPackageHome();');
+    expect(source.match(/delete process\.env\[PI_BASH_PACKAGE_HOME_ENV\];/g)).toHaveLength(1);
+    expect(source.indexOf('delete process.env[PI_BASH_PACKAGE_HOME_ENV];')).toBeLessThan(
       source.indexOf('export default async function cindyBridge'),
     );
 
@@ -1091,8 +1120,11 @@ describe('cindy-bridge extension source', () => {
     expect(source.indexOf('delete process.env[PI_PACKAGE_MANAGEMENT_ENV];')).toBeGreaterThan(
       source.indexOf('export default async function cindyBridge'),
     );
+    const helperSlice = source.slice(
+      source.indexOf('const BRIDGE_RELOAD_STASH_GLOBAL'),
+      source.indexOf('// 凭证/密钥路径特征由 maker-core 的单一来源生成'),
+    );
     expect(helperSlice).not.toContain('CINDY_PI_PACKAGE_MANAGEMENT');
-    expect(source).not.toContain('takeOneShotEnv(PI_PACKAGE_MANAGEMENT_ENV)');
   });
 
   it('blocks Pi package mutations before bash while preserving ordinary commands', () => {

--- a/packages/maker-core/src/agents/pi/cindy-bridge-source.ts
+++ b/packages/maker-core/src/agents/pi/cindy-bridge-source.ts
@@ -443,59 +443,82 @@ function whichRgOnPath(): string {
   return '';
 }
 
-// 一次性启动 env 的跨重载存取(#3070)。CINDY_PI_BASH_PACKAGE_HOME 由 host 在
+// bash 隔离 home 的跨重载解析(#3070)。CINDY_PI_BASH_PACKAGE_HOME 由 host 在
 // spawn 时注入一次,bridge 首次加载后即从 process.env 删除(防止进程内其它代码
 // 改写)。但 Pi 会重载扩展:同一进程里 bridge 文件被再次执行时 env 已被删,重载
 // 实例拿到 undefined —— bash 从此永久 fail-closed。解法:首次加载把值 stash 进
-// globalThis。扩展重载与首次加载共享同一 realm 与 globalThis(事故机理即重载看
-// 到了被删的 env,证明共享),重载实例从 stash 取回 host 注入的原始字节,不经过任
-// 何可改写的 env 面;事后写进 env 的值一律视为不可信并再次删除。stash 也拿不到
-// (进程从未由 Cindy 初始化,如手工把 bridge 拷进用户 ~/.pi)时返回 undefined,
-// 下游保持原 fail-closed —— 不猜外来 runtime 的路径。
+// globalThis 上的 non-configurable / non-writable 属性(语言层面不可替换、不可
+// 删除),重载实例取回时再做双重验证。
 //
-// 只 stash 路径,不 stash 凭证:CINDY_PI_PACKAGE_MANAGEMENT 是 host 签发的
-// bearer token(授权 Pi 扩展安装变更),而本进程内会加载用户安装的第三方托管
-// 扩展 —— 它们与 bridge 共享 globalThis,放进 stash 等于把 token 暴露给任意
-// 托管代码,比留在首次加载闭包里更宽(review P1)。token 因此保持原语义:读一次
-// 即删、仅闭包持有,重载后 cindy_pi_extension 工具退场是可接受代价(bash 直装
-// 被拦,用户下次新会话可再拿到工具)。bash-package-home 是路径而非凭证,且本就
-// 经 PI_CODING_AGENT_DIR 进每个 bash 子进程 env,stash 不新增暴露面。
-const BRIDGE_RELOAD_STASH_GLOBAL = '__cindyBridgeOneShotEnv';
+// 威胁模型:本进程内会加载用户安装的第三方托管扩展,它们与 bridge 共享同一
+// realm,能触碰 globalThis 与 process.env。因此:
+//  - stash 用 defineProperty(writable:false, configurable:false) 封死事后改写
+//    /替换/删除;读取时校验属性形态,可写可配置的属性一律不信任。
+//  - 重载取值要求 stash 与 PI_CODING_AGENT_DIR 派生值(path.posix.join(configHome,
+//    'bash-package-home'),与 host 侧 index.ts 的 joinRemotePosixPath 派生式逐字
+//    一致)双重相等:事后改写 PI_CODING_AGENT_DIR 会让二者失配 → fail-closed
+//    (该 env 本就常驻可写,这里顺带把它变成 canary);抢跑预置 stash(攻击者
+//    扩展先于 bridge 首次加载执行)也得同时锚定 PI_CODING_AGENT_DIR 才可能一致,
+//    与「抢跑改写注入 env」在原实现下同级别,不新增面。
+//  - env 值在已消费(stash 已建立)后再次出现,视为进程内写入:删除并忽略。
+//  - stash 缺失(非 Cindy 初始化的进程,如手工把 bridge 拷进用户 ~/.pi)或双重
+//    验证失败 → 返回 undefined,下游 isolatedBashEnvironment 保持原 fail-closed,
+//    不猜外来 runtime 的路径。
+//
+// 凭证不走本机制:CINDY_PI_PACKAGE_MANAGEMENT 是 host 签发的 bearer token,
+// 保持读一次即删、仅闭包持有(见入口注释)。
+const BRIDGE_RELOAD_STASH_GLOBAL = '__cindyBridgeBashPackageHome';
 
-function stashOneShotEnvValue(key: string, value: string): void {
+function stashBashPackageHome(value: string): void {
   try {
-    const stash = (globalThis as Record<string, unknown>)[BRIDGE_RELOAD_STASH_GLOBAL];
-    const map = (stash && typeof stash === 'object' ? stash : {}) as Record<string, string>;
-    map[key] = value;
-    (globalThis as Record<string, unknown>)[BRIDGE_RELOAD_STASH_GLOBAL] = map;
+    Object.defineProperty(globalThis, BRIDGE_RELOAD_STASH_GLOBAL, {
+      value,
+      writable: false,
+      configurable: false,
+      enumerable: false,
+    });
   } catch {
-    // globalThis 不可写的受限环境:退化为仅本次加载可见,行为与旧版一致。
+    // 属性已被抢跑占用或 globalThis 受限:本加载仍可用 env 值;重载后双重验证
+    // 会因 stash 缺失/失配而 fail-closed,不会信任被占用的值。
   }
 }
 
-function readStashedOneShotEnvValue(key: string): string | undefined {
+function readStashedBashPackageHome(): string | undefined {
   try {
-    const stash = (globalThis as Record<string, unknown>)[BRIDGE_RELOAD_STASH_GLOBAL];
-    if (!stash || typeof stash !== 'object') return undefined;
-    const value = (stash as Record<string, string | undefined>)[key];
-    return typeof value === 'string' ? value : undefined;
+    const descriptor = Object.getOwnPropertyDescriptor(globalThis, BRIDGE_RELOAD_STASH_GLOBAL);
+    // 只信任我们写入的形态:non-configurable + non-writable。可写可配置的属性
+    // (含 plain 赋值)随时可被第三方扩展替换,一律不信任。
+    if (!descriptor || descriptor.configurable || descriptor.writable) return undefined;
+    return typeof descriptor.value === 'string' ? descriptor.value : undefined;
   } catch {
     return undefined;
   }
 }
 
-function takeOneShotEnv(name: string): string | undefined {
-  const stashed = readStashedOneShotEnvValue(name);
-  const value = process.env[name];
-  if (value !== undefined) {
-    delete process.env[name];
-    // stash 已有记录而 env 又出现值,说明该值是首次加载之后被进程内代码写进来的
-    // (host 只在 spawn 时注入一次,且首次加载已删)—— 不可信,继续用 stash 原始值。
-    if (stashed === undefined) stashOneShotEnvValue(name, value);
-    return stashed ?? value;
+function derivedBashPackageHome(): string | undefined {
+  const configHome = process.env.PI_CODING_AGENT_DIR;
+  if (!configHome || !path.isAbsolute(configHome)) return undefined;
+  // 与 host 侧 index.ts 的 joinRemotePosixPath(configHome, 'bash-package-home')
+  // 逐字一致(posix join:本地 Windows 路径同样以正斜杠拼接)。
+  return path.posix.join(configHome, 'bash-package-home');
+}
+
+function resolveBashPackageHome(): string | undefined {
+  const injected = process.env[PI_BASH_PACKAGE_HOME_ENV];
+  if (injected !== undefined) delete process.env[PI_BASH_PACKAGE_HOME_ENV];
+  const stashed = readStashedBashPackageHome();
+  if (stashed === undefined) {
+    // 本进程首次加载:host 注入的 env 是权威,stash 供重载实例取回。
+    if (injected !== undefined) {
+      stashBashPackageHome(injected);
+      return injected;
+    }
+    return undefined;
   }
-  // 重载路径:env 已被首次加载消费,取回 stash 的原始值(可能为 undefined)。
-  return stashed;
+  // 重载(env 已被消费;或 env 值又被进程内写入 —— 上面的 delete 已顺手清掉):
+  // stash 与 PI_CODING_AGENT_DIR 派生值双重一致才信任,否则 fail-closed。
+  const derived = derivedBashPackageHome();
+  return derived !== undefined && stashed === derived ? stashed : undefined;
 }
 
 // 凭证/密钥路径特征由 maker-core 的单一来源生成。bridge 自包含、运行时不能 import，
@@ -2494,11 +2517,11 @@ function rgGlob(
 }
 
 export default async function cindyBridge(pi: any) {
-  // 一次性启动 env:路径走 takeOneShotEnv(首次加载读删 + stash,扩展重载(#3070)
-  // 从 stash 取回原始值,而不是拿到 undefined 让 bash 永久 fail-closed)。
+  // bash 隔离 home 经 resolveBashPackageHome 解析(首次加载读删 + 防篡改 stash,
+  // 扩展重载(#3070)经双重验证取回,而不是拿到 undefined 让 bash 永久 fail-closed)。
   // 包管理 token 是 bearer 凭证,保持读一次即删、仅闭包持有 —— 不进 globalThis
-  // stash(同进程的第三方托管扩展可读它,见 takeOneShotEnv 注释)。
-  const bashPackageHome = takeOneShotEnv(PI_BASH_PACKAGE_HOME_ENV);
+  // stash(同进程的第三方托管扩展可读它,见 resolveBashPackageHome 注释)。
+  const bashPackageHome = resolveBashPackageHome();
   const piPackageManagementToken = process.env[PI_PACKAGE_MANAGEMENT_ENV];
   delete process.env[PI_PACKAGE_MANAGEMENT_ENV];
   // 主 Pi 不传 --tools：那个白名单也会筛掉动态 MCP 与 subagent。改由 bridge 注册

--- a/packages/maker-core/src/agents/pi/cindy-bridge-source.ts
+++ b/packages/maker-core/src/agents/pi/cindy-bridge-source.ts
@@ -443,17 +443,23 @@ function whichRgOnPath(): string {
   return '';
 }
 
-// 一次性启动 env 的跨重载存取(#3070)。CINDY_PI_BASH_PACKAGE_HOME /
-// CINDY_PI_PACKAGE_MANAGEMENT 由 host 在 spawn 时注入一次,bridge 首次加载后即从
-// process.env 删除(防止进程内其它代码改写)。但 Pi 会重载扩展:同一进程里 bridge
-// 文件被再次执行时 env 已被删,重载实例拿到 undefined —— bash 从此永久
-// fail-closed。解法:首次加载把值 stash 进 globalThis。扩展重载与首次加载共享
-// 同一 realm 与 globalThis(事故机理即重载看到了被删的 env,证明共享),重载实例
-// 从 stash 取回 host 注入的原始字节,不经过任何可改写的 env 面;事后写进 env 的
-// 值一律视为不可信并再次删除。stash 本身与闭包变量同为进程内存,不比现状多暴露
-// 任何东西(值本就留在首次加载的闭包里)。stash 也拿不到(进程从未由 Cindy 初始
-// 化,如手工把 bridge 拷进用户 ~/.pi)时返回 undefined,下游保持原 fail-closed
-// —— 不猜外来 runtime 的路径。
+// 一次性启动 env 的跨重载存取(#3070)。CINDY_PI_BASH_PACKAGE_HOME 由 host 在
+// spawn 时注入一次,bridge 首次加载后即从 process.env 删除(防止进程内其它代码
+// 改写)。但 Pi 会重载扩展:同一进程里 bridge 文件被再次执行时 env 已被删,重载
+// 实例拿到 undefined —— bash 从此永久 fail-closed。解法:首次加载把值 stash 进
+// globalThis。扩展重载与首次加载共享同一 realm 与 globalThis(事故机理即重载看
+// 到了被删的 env,证明共享),重载实例从 stash 取回 host 注入的原始字节,不经过任
+// 何可改写的 env 面;事后写进 env 的值一律视为不可信并再次删除。stash 也拿不到
+// (进程从未由 Cindy 初始化,如手工把 bridge 拷进用户 ~/.pi)时返回 undefined,
+// 下游保持原 fail-closed —— 不猜外来 runtime 的路径。
+//
+// 只 stash 路径,不 stash 凭证:CINDY_PI_PACKAGE_MANAGEMENT 是 host 签发的
+// bearer token(授权 Pi 扩展安装变更),而本进程内会加载用户安装的第三方托管
+// 扩展 —— 它们与 bridge 共享 globalThis,放进 stash 等于把 token 暴露给任意
+// 托管代码,比留在首次加载闭包里更宽(review P1)。token 因此保持原语义:读一次
+// 即删、仅闭包持有,重载后 cindy_pi_extension 工具退场是可接受代价(bash 直装
+// 被拦,用户下次新会话可再拿到工具)。bash-package-home 是路径而非凭证,且本就
+// 经 PI_CODING_AGENT_DIR 进每个 bash 子进程 env,stash 不新增暴露面。
 const BRIDGE_RELOAD_STASH_GLOBAL = '__cindyBridgeOneShotEnv';
 
 function stashOneShotEnvValue(key: string, value: string): void {
@@ -2488,10 +2494,13 @@ function rgGlob(
 }
 
 export default async function cindyBridge(pi: any) {
-  // 一次性启动 env 经 takeOneShotEnv 存取:首次加载读删 + stash,扩展重载(#3070)
-  // 从 stash 取回原始值,而不是拿到 undefined 让 bash 永久 fail-closed。
+  // 一次性启动 env:路径走 takeOneShotEnv(首次加载读删 + stash,扩展重载(#3070)
+  // 从 stash 取回原始值,而不是拿到 undefined 让 bash 永久 fail-closed)。
+  // 包管理 token 是 bearer 凭证,保持读一次即删、仅闭包持有 —— 不进 globalThis
+  // stash(同进程的第三方托管扩展可读它,见 takeOneShotEnv 注释)。
   const bashPackageHome = takeOneShotEnv(PI_BASH_PACKAGE_HOME_ENV);
-  const piPackageManagementToken = takeOneShotEnv(PI_PACKAGE_MANAGEMENT_ENV);
+  const piPackageManagementToken = process.env[PI_PACKAGE_MANAGEMENT_ENV];
+  delete process.env[PI_PACKAGE_MANAGEMENT_ENV];
   // 主 Pi 不传 --tools：那个白名单也会筛掉动态 MCP 与 subagent。改由 bridge 注册
   // 专用只读工具；子代理仍用自己的 read,grep,find,ls 白名单收紧能力面。
   const grepTool = createGrepTool(process.cwd());
@@ -2624,7 +2633,7 @@ export default async function cindyBridge(pi: any) {
   // CLI from bash writes to Pi's default user home and bypasses Cindy's
   // compatibility/approval state. Normal local tasks therefore receive one
   // host-backed mutation tool; Review and SSH remoteHostId tasks do not.
-  // (token 经函数开头的 takeOneShotEnv 取得,重载后工具不再静默消失。)
+  // (token 在函数开头读一次即删、仅闭包持有;重载后本工具不再注册 —— 见开注释。)
   if (piPackageManagementToken && /^[A-Za-z0-9_-]{40,256}$/.test(piPackageManagementToken)) {
     pi.registerTool({
       name: 'cindy_pi_extension',

--- a/packages/maker-core/src/agents/pi/cindy-bridge-source.ts
+++ b/packages/maker-core/src/agents/pi/cindy-bridge-source.ts
@@ -443,6 +443,55 @@ function whichRgOnPath(): string {
   return '';
 }
 
+// 一次性启动 env 的跨重载存取(#3070)。CINDY_PI_BASH_PACKAGE_HOME /
+// CINDY_PI_PACKAGE_MANAGEMENT 由 host 在 spawn 时注入一次,bridge 首次加载后即从
+// process.env 删除(防止进程内其它代码改写)。但 Pi 会重载扩展:同一进程里 bridge
+// 文件被再次执行时 env 已被删,重载实例拿到 undefined —— bash 从此永久
+// fail-closed。解法:首次加载把值 stash 进 globalThis。扩展重载与首次加载共享
+// 同一 realm 与 globalThis(事故机理即重载看到了被删的 env,证明共享),重载实例
+// 从 stash 取回 host 注入的原始字节,不经过任何可改写的 env 面;事后写进 env 的
+// 值一律视为不可信并再次删除。stash 本身与闭包变量同为进程内存,不比现状多暴露
+// 任何东西(值本就留在首次加载的闭包里)。stash 也拿不到(进程从未由 Cindy 初始
+// 化,如手工把 bridge 拷进用户 ~/.pi)时返回 undefined,下游保持原 fail-closed
+// —— 不猜外来 runtime 的路径。
+const BRIDGE_RELOAD_STASH_GLOBAL = '__cindyBridgeOneShotEnv';
+
+function stashOneShotEnvValue(key: string, value: string): void {
+  try {
+    const stash = (globalThis as Record<string, unknown>)[BRIDGE_RELOAD_STASH_GLOBAL];
+    const map = (stash && typeof stash === 'object' ? stash : {}) as Record<string, string>;
+    map[key] = value;
+    (globalThis as Record<string, unknown>)[BRIDGE_RELOAD_STASH_GLOBAL] = map;
+  } catch {
+    // globalThis 不可写的受限环境:退化为仅本次加载可见,行为与旧版一致。
+  }
+}
+
+function readStashedOneShotEnvValue(key: string): string | undefined {
+  try {
+    const stash = (globalThis as Record<string, unknown>)[BRIDGE_RELOAD_STASH_GLOBAL];
+    if (!stash || typeof stash !== 'object') return undefined;
+    const value = (stash as Record<string, string | undefined>)[key];
+    return typeof value === 'string' ? value : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function takeOneShotEnv(name: string): string | undefined {
+  const stashed = readStashedOneShotEnvValue(name);
+  const value = process.env[name];
+  if (value !== undefined) {
+    delete process.env[name];
+    // stash 已有记录而 env 又出现值,说明该值是首次加载之后被进程内代码写进来的
+    // (host 只在 spawn 时注入一次,且首次加载已删)—— 不可信,继续用 stash 原始值。
+    if (stashed === undefined) stashOneShotEnvValue(name, value);
+    return stashed ?? value;
+  }
+  // 重载路径:env 已被首次加载消费,取回 stash 的原始值(可能为 undefined)。
+  return stashed;
+}
+
 // 凭证/密钥路径特征由 maker-core 的单一来源生成。bridge 自包含、运行时不能 import，
 // 但不再维护第二份手写名单，避免新增凭证目录时 Pi 静默漏拦。
 const CREDENTIAL_PATH_PATTERNS = ${JSON.stringify(SENSITIVE_CREDENTIAL_PATH_PATTERN_SPECS)}
@@ -2439,8 +2488,10 @@ function rgGlob(
 }
 
 export default async function cindyBridge(pi: any) {
-  const bashPackageHome = process.env[PI_BASH_PACKAGE_HOME_ENV];
-  delete process.env[PI_BASH_PACKAGE_HOME_ENV];
+  // 一次性启动 env 经 takeOneShotEnv 存取:首次加载读删 + stash,扩展重载(#3070)
+  // 从 stash 取回原始值,而不是拿到 undefined 让 bash 永久 fail-closed。
+  const bashPackageHome = takeOneShotEnv(PI_BASH_PACKAGE_HOME_ENV);
+  const piPackageManagementToken = takeOneShotEnv(PI_PACKAGE_MANAGEMENT_ENV);
   // 主 Pi 不传 --tools：那个白名单也会筛掉动态 MCP 与 subagent。改由 bridge 注册
   // 专用只读工具；子代理仍用自己的 read,grep,find,ls 白名单收紧能力面。
   const grepTool = createGrepTool(process.cwd());
@@ -2573,8 +2624,7 @@ export default async function cindyBridge(pi: any) {
   // CLI from bash writes to Pi's default user home and bypasses Cindy's
   // compatibility/approval state. Normal local tasks therefore receive one
   // host-backed mutation tool; Review and SSH remoteHostId tasks do not.
-  const piPackageManagementToken = process.env[PI_PACKAGE_MANAGEMENT_ENV];
-  delete process.env[PI_PACKAGE_MANAGEMENT_ENV];
+  // (token 经函数开头的 takeOneShotEnv 取得,重载后工具不再静默消失。)
   if (piPackageManagementToken && /^[A-Za-z0-9_-]{40,256}$/.test(piPackageManagementToken)) {
     pi.registerTool({
       name: 'cindy_pi_extension',


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 #3070：Pi 会话中途所有 bash 永久失败，报 `Cindy isolated Pi package home is unavailable`。

根因：`cindy-bridge` 首次加载时读取 host 注入的 `CINDY_PI_BASH_PACKAGE_HOME` 后立即从 `process.env` 删除（#2771 引入的防御，防止进程内代码改写）。但 Pi 进程内扩展重载会重新执行 bridge 文件：第二次加载读不到已被删除的 env，闭包里的 `bashPackageHome` 变成 `undefined`，此后每次 bash 都在 `isolatedBashEnvironment` 处 fail-closed。

修法：新增 `takeOneShotEnv` 统一存取一次性启动 env——首次加载读删并 stash 进 `globalThis`（扩展重载与首次加载共享同一 realm），重载实例从 stash 取回 host 注入的原始值。stash 已有记录而 env 又出现值时，视为进程内代码事后写入，忽略并再次删除（不信任可改写的 env 面，保留原防御）。`CINDY_PI_PACKAGE_MANAGEMENT` token 同法处理，重载后 `cindy_pi_extension` 工具不再静默消失。stash 也拿不到时仍返回 undefined，下游保持原 fail-closed，不猜外来 runtime 的路径。

与 #3072 的关系：修同一问题，但 #3072 直接不删 env，把专用变量永久留在 `process.env` 里，进程内代码（含用户可装的第三方 Pi 扩展）可改写且重载的 bridge 会静默信任改写值；本 PR 保留删除防御，值经不可由 env 改写的 stash 传递，并补齐回归测试。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：#3070
- 本 PR 包含：`cindy-bridge-source.ts` 新增 `takeOneShotEnv`（stash 存取一次性启动 env）并让 `bashPackageHome` / `piPackageManagementToken` 走该路径；`cindyBridgeSource.test.ts` 补回归测试
- 明确不包含：隔离目录丢失后的自动重建、host 侧 spawn env 逻辑改动、`SECRET_ENV_NAMES` 剥离面调整
- 用户可见变化：Pi 会话中途 bridge 重载后 bash 不再永久失败，`cindy_pi_extension` 工具重载后仍可用
- 是否存在 breaking change：无

### UI 变化

不涉及：仅 Pi 进程内扩展逻辑，无任何 UI 路径改动。

## 怎么验证的

### 自动验证

```text
pnpm --filter @cindy/maker-core run --if-present typecheck
结果：通过

pnpm test:unit:related
结果：packages/maker-core unit PASS（含新增回归用例，15 tests | 4 skipped）；
     packages/orca-workflow / lizi-mcps PASS；apps/desktop 全量见下

pnpm --filter desktop exec vitest run <desktop unit 门禁范围>
结果：2040/2041 文件通过。唯一失败为
     pi-package-store-security.test.ts 的 symlink 用例，本机 Windows
     组策略禁止无特权创建 symlink（裸测 fs.symlinkSync 即 EPERM），
     在干净 main 上同样失败、CI（Windows/Linux）上通过，与本次改动无关。

pnpm check:dco
结果：1 commit 通过 DCO 校验
```

新增回归测试覆盖：同一进程内 double-load 仍取回原始值；首次加载后向 env 写入攻击值不影响重载（取 stash 而非 env）；非 Cindy 初始化的进程返回 undefined 保持 fail-closed；多键互不干扰；入口结构断言（裸 delete 只存在于 helper 内）。

### 手工验证

在隔离沙盒 dev（`--isolated=@worktree`，CN 区，commit 05264ab01 + 本修复）实测：开 Pi 会话跑 `git --version` 正常；关闭会话后重新打开（resume）再跑 `git --version`，正常返回——修复前该路径报 `Cindy isolated Pi package home is unavailable` 且同会话内重试永久失败。

### 未执行的验证

真实 Pi 进程内扩展重载（非 resume 路径）无稳定本地复现手段，由上述 resume 路径 + 单测的 double-load 用例覆盖同一机理（重载与首次加载共享 realm，env 已被首次加载删除）。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [x] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

影响范围：Pi bash 隔离与 Pi 扩展管理工具的一次性 env 生命周期。安全面上，值存于 `globalThis` 与闭包同为进程内存，不比原实现（值留在首次加载闭包里）多暴露；bash 子进程 spawn 边界照旧剥离该变量（`SECRET_ENV_NAMES` 不变）。事后写入 env 的值一律不信任，保留并强化了原 `delete` 防御。远端会话：bridge 源码字节进入 `CINDY_PI_EXTENSION_BUNDLE_HASH`，字节变化本就要求 daemon restart，不影响 attach 语义。

移动端冷更分析：本次改动不触及 `apps/mobile` 任何 fingerprint 输入（`app.json` / `app.config.js` / `eas.json` / `package.json` / `plugins` / `modules`），仅改 `packages/maker-core` 的 Pi 扩展源码，不触发冷更。

回滚 / 降级方式：revert 本 PR 即恢复旧行为（bridge 加载后删除 env、重载后 bash fail-closed）。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（无需文档变更：行为对用户透明，代码注释已写清机理）
- [x] 已确认测试结果或说明未执行原因