### PR TITLE
fix(desktop): retry update notice after startup miss

### DIFF
--- a/apps/desktop/src/renderer/__tests__/useUpdateNoticeUpdatePreview.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/useUpdateNoticeUpdatePreview.test.tsx
@@ -350,6 +350,37 @@ describe('useUpdateNotice automatic popup', () => {
     }
   });
 
+  it('does not reopen an automatic notice after manual history is opened and dismissed during retry delay', async () => {
+    (window as unknown as { electronAPI: unknown }).electronAPI = { appVersion: '1.4.2' };
+    localStorage.setItem(STORAGE_KEY, '1.4.1');
+    let currentFetch = 0;
+    mocks.fetchReleaseNotes.mockImplementation(async (version: string, locale: string) => {
+      if (version === '1.4.2' && currentFetch++ === 0) return null;
+      return notesFor(version, locale);
+    });
+    vi.useFakeTimers();
+    try {
+      const { result } = renderHook(() => useUpdateNotice());
+
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(result.current.open).toBe(false);
+
+      act(() => { result.current.onOpen(); });
+      await act(async () => { await Promise.resolve(); });
+      expect(result.current.open).toBe(true);
+
+      act(() => { result.current.dismiss(); });
+      await act(async () => { await vi.advanceTimersByTimeAsync(2000); });
+      expect(result.current.open).toBe(false);
+      expect(currentFetch).toBe(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('does not reopen an automatic notice dismissed during a locale refresh', async () => {
     (window as unknown as { electronAPI: unknown }).electronAPI = { appVersion: '1.4.2' };
     localStorage.setItem(STORAGE_KEY, '1.4.1');

--- a/apps/desktop/src/renderer/__tests__/useUpdateNoticeUpdatePreview.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/useUpdateNoticeUpdatePreview.test.tsx
@@ -321,6 +321,35 @@ describe('useUpdateNotice automatic popup', () => {
     expect(result.current.releaseNotes?.[0]?.topics[0]?.title).toBe('ja-1.4.2');
   });
 
+  it('retries a transient automatic notice miss before giving up', async () => {
+    (window as unknown as { electronAPI: unknown }).electronAPI = { appVersion: '1.4.2' };
+    localStorage.setItem(STORAGE_KEY, '1.4.1');
+    let currentFetch = 0;
+    mocks.fetchReleaseNotes.mockImplementation(async (version: string, locale: string) => {
+      if (version === '1.4.2' && currentFetch++ === 0) return null;
+      return notesFor(version, locale);
+    });
+    vi.useFakeTimers();
+    try {
+      const { result } = renderHook(() => useUpdateNotice());
+
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(result.current.open).toBe(false);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2000);
+      });
+      expect(result.current.open).toBe(true);
+      expect(result.current.releaseNotes?.map((n) => n.version)).toEqual(['1.4.2']);
+      expect(currentFetch).toBe(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('does not reopen an automatic notice dismissed during a locale refresh', async () => {
     (window as unknown as { electronAPI: unknown }).electronAPI = { appVersion: '1.4.2' };
     localStorage.setItem(STORAGE_KEY, '1.4.1');

--- a/apps/desktop/src/renderer/hooks/useUpdateNotice.ts
+++ b/apps/desktop/src/renderer/hooks/useUpdateNotice.ts
@@ -223,6 +223,11 @@ export function useUpdateNotice(): UseUpdateNoticeReturn {
   // Set synchronously (before any await) in onOpen so the auto-fetch path
   // can bail out if manual dialog was opened while the fetch was in flight.
   const dialogOpenedRef = useRef(false);
+  // Once a user explicitly opens either manual history or a pre-install
+  // preview, suppress the pending automatic retry for this hook lifetime.
+  // This must outlive dialogOpenedRef: dismiss() intentionally resets the
+  // latter, but the automatic attempt must not resurrect after dismissal.
+  const autoNoticeSuppressedRef = useRef(false);
   // Stored handle for the dismiss cleanup timer so onOpen can cancel it if
   // the user re-opens the dialog before the 200ms animation delay fires.
   const dismissTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -281,6 +286,7 @@ export function useUpdateNotice(): UseUpdateNoticeReturn {
     if (lastRead === appVersion) return;
 
     let cancelled = false;
+    autoNoticeSuppressedRef.current = false;
 
     (async () => {
       // A transient CDN miss should not permanently lose the upgrade notice for
@@ -291,13 +297,13 @@ export function useUpdateNotice(): UseUpdateNoticeReturn {
         // version's notes. We don't want to blast a new user with 30 versions
         // of history on first launch.
         const index = lastRead === null ? null : await fetchReleaseNotesIndex();
-        if (cancelled || dialogOpenedRef.current) return;
+        if (cancelled || dialogOpenedRef.current || autoNoticeSuppressedRef.current) return;
 
         const targets = versionsToFetch(index, lastRead, appVersion).slice(
           -MAX_AGGREGATED_VERSIONS,
         );
         const results = await fetchVersionsForCurrentLocale(targets);
-        if (cancelled || dialogOpenedRef.current) return;
+        if (cancelled || dialogOpenedRef.current || autoNoticeSuppressedRef.current) return;
         const notes = results.filter((n): n is ReleaseNotes => n !== null);
 
         if (notes.length > 0 && notes.some((n) => n.version === appVersion)) {
@@ -327,7 +333,12 @@ export function useUpdateNotice(): UseUpdateNoticeReturn {
           return;
         }
 
-        if (attempt === 0 && !cancelled && !dialogOpenedRef.current) {
+        if (
+          attempt === 0 &&
+          !cancelled &&
+          !dialogOpenedRef.current &&
+          !autoNoticeSuppressedRef.current
+        ) {
           await new Promise<void>((resolve) => {
             setTimeout(resolve, AUTO_NOTICE_RETRY_DELAY_MS);
           });
@@ -397,6 +408,7 @@ export function useUpdateNotice(): UseUpdateNoticeReturn {
     }
     // Set synchronously so the auto-fetch path can see it immediately even
     // before this async IIFE has called setOpen/setMode.
+    autoNoticeSuppressedRef.current = true;
     dialogOpenedRef.current = true;
     const appVersion = window.electronAPI.appVersion;
 
@@ -467,6 +479,7 @@ export function useUpdateNotice(): UseUpdateNoticeReturn {
       clearTimeout(dismissTimerRef.current);
       dismissTimerRef.current = null;
     }
+    autoNoticeSuppressedRef.current = true;
     dialogOpenedRef.current = true;
     const appVersion = window.electronAPI.appVersion;
 

--- a/apps/desktop/src/renderer/hooks/useUpdateNotice.ts
+++ b/apps/desktop/src/renderer/hooks/useUpdateNotice.ts
@@ -33,6 +33,14 @@ const MAX_AGGREGATED_VERSIONS = 5;
  */
 const PREVIEW_INDEX_BUDGET_MS = 3000;
 
+/**
+ * A fresh install/update can race the CDN publishing the current notice or
+ * the renderer mounting during startup. Retry the automatic path once after a
+ * short pause; manual and pre-install preview paths already have explicit
+ * user-driven retry/fallback behavior.
+ */
+const AUTO_NOTICE_RETRY_DELAY_MS = 2000;
+
 /** Numeric semver comparison. Returns >0 if a > b, <0 if a < b, 0 if equal. */
 function cmpVersion(a: string, b: string): number {
   const pa = a.split('.').map(Number);
@@ -275,50 +283,56 @@ export function useUpdateNotice(): UseUpdateNoticeReturn {
     let cancelled = false;
 
     (async () => {
-      // Fresh install: skip the index round-trip and show only the current
-      // version's notes. We don't want to blast a new user with 30 versions
-      // of history on first launch.
-      const index = lastRead === null ? null : await fetchReleaseNotesIndex();
-      if (cancelled) return;
+      // A transient CDN miss should not permanently lose the upgrade notice for
+      // this process. Keep the retry bounded so a genuinely unavailable CDN
+      // does not hold the renderer in a retry loop.
+      for (let attempt = 0; attempt < 2; attempt += 1) {
+        // Fresh install: skip the index round-trip and show only the current
+        // version's notes. We don't want to blast a new user with 30 versions
+        // of history on first launch.
+        const index = lastRead === null ? null : await fetchReleaseNotesIndex();
+        if (cancelled || dialogOpenedRef.current) return;
 
-      const targets = versionsToFetch(index, lastRead, appVersion).slice(
-        -MAX_AGGREGATED_VERSIONS,
-      );
-      const results = await fetchVersionsForCurrentLocale(targets);
-      if (cancelled) return;
-      const notes = results.filter((n): n is ReleaseNotes => n !== null);
+        const targets = versionsToFetch(index, lastRead, appVersion).slice(
+          -MAX_AGGREGATED_VERSIONS,
+        );
+        const results = await fetchVersionsForCurrentLocale(targets);
+        if (cancelled || dialogOpenedRef.current) return;
+        const notes = results.filter((n): n is ReleaseNotes => n !== null);
 
-      if (notes.length === 0) return;
-      if (!notes.some((n) => n.version === appVersion)) return;
+        if (notes.length > 0 && notes.some((n) => n.version === appVersion)) {
+          // Compute the safe read-marker (unchanged from prior impl).
+          const isCurIdxMissing = index !== null && index.indexOf(appVersion) === -1;
+          const firstFailIdx = results.findIndex((n) => n === null);
+          if (isCurIdxMissing) {
+            readMarkerRef.current = lastRead ?? null;
+          } else if (firstFailIdx === -1) {
+            readMarkerRef.current = appVersion;
+          } else if (firstFailIdx === 0) {
+            const skipKey = `xdt-maker:notice-skip-tried-${targets[0]}`;
+            if (localStorage.getItem(skipKey) === null) {
+              localStorage.setItem(skipKey, '1');
+              readMarkerRef.current = lastRead ?? null;
+            } else {
+              readMarkerRef.current = targets[0];
+            }
+          } else {
+            readMarkerRef.current = targets[firstFailIdx - 1];
+          }
 
-      // Bail BEFORE computing readMarkerRef: if manual was opened while we
-      // fetched, don't write the marker (which would cause onOpen's
-      // readMarkerRef !== null guard to incorrectly abort the manual dialog).
-      if (dialogOpenedRef.current) return;
-
-      // Compute the safe read-marker (unchanged from prior impl).
-      const isCurIdxMissing = index !== null && index.indexOf(appVersion) === -1;
-      const firstFailIdx = results.findIndex((n) => n === null);
-      if (isCurIdxMissing) {
-        readMarkerRef.current = lastRead ?? null;
-      } else if (firstFailIdx === -1) {
-        readMarkerRef.current = appVersion;
-      } else if (firstFailIdx === 0) {
-        const skipKey = `xdt-maker:notice-skip-tried-${targets[0]}`;
-        if (localStorage.getItem(skipKey) === null) {
-          localStorage.setItem(skipKey, '1');
-          readMarkerRef.current = lastRead ?? null;
-        } else {
-          readMarkerRef.current = targets[0];
+          notes.reverse();
+          setMode('auto');
+          setReleaseNotes(notes);
+          setOpen(true);
+          return;
         }
-      } else {
-        readMarkerRef.current = targets[firstFailIdx - 1];
-      }
 
-      notes.reverse();
-      setMode('auto');
-      setReleaseNotes(notes);
-      setOpen(true);
+        if (attempt === 0 && !cancelled && !dialogOpenedRef.current) {
+          await new Promise<void>((resolve) => {
+            setTimeout(resolve, AUTO_NOTICE_RETRY_DELAY_MS);
+          });
+        }
+      }
     })().catch((err) => {
       log.warn('auto-fetch threw:', err);
     });


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 #3073：更新公告首次启动时如果 CDN 请求暂时失败，之前会直接错过公告。现在自动路径最多重试一次，并在用户打开手动历史/预览或组件卸载时取消重试。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护

### 范围

- 关联 Issue / 需求：#3073
- 本 PR 包含：更新公告自动获取的一次有界重试及竞态回归测试
- 明确不包含：手动历史、安装前预览、公告内容和发布服务
- 用户可见变化：临时网络失败时，首次启动更有机会显示更新公告；无新增 UI 控件
- 是否存在 breaking change：无

### UI 变化

不涉及视觉 UI 变化：仅修改更新公告 Hook 的请求重试和取消状态，现有弹窗结构与样式不变。

- 引用的设计规范：不涉及视觉变化，无新增或修改 UI 组件。

## 怎么验证的

### 自动验证

```text
corepack pnpm --filter desktop exec vitest run src/renderer/__tests__/useUpdateNoticeUpdatePreview.test.tsx
结果：20/20 通过

corepack pnpm --filter desktop exec eslint src/renderer/hooks/useUpdateNotice.ts src/renderer/__tests__/useUpdateNoticeUpdatePreview.test.tsx
结果：通过

corepack pnpm --filter desktop typecheck
结果：通过

git diff --check
结果：通过
```

验证环境：`cindy-issue3073-20260820-2`。

### 手工验证

不涉及：本 PR 不改变视觉布局或交互组件。

### 未执行的验证

未执行打包版 CDN 真实网络冒烟；该验证需要发布环境，自动化测试覆盖了首次失败重试、取消和重复弹出竞态。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅更新公告的首次自动获取路径。
- 回滚 / 降级方式：回滚本 PR 即恢复原有单次请求行为；重试失败时仍保持原有静默失败路径。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已确认测试结果或说明未执行原因
