### PR TITLE
fix(desktop): Codex Micro 在 Cindy 外单击语音键不再立刻结束

### DIFF
--- a/apps/desktop/src/main/worklouder-codex/__tests__/systemFrontmostInput.test.ts
+++ b/apps/desktop/src/main/worklouder-codex/__tests__/systemFrontmostInput.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { joystickScrollSpeed } from '../../../shared/workLouderCodexScroll.js';
 import {
@@ -10,15 +10,67 @@ import {
 } from '../systemFrontmostInput.js';
 
 describe('createWorkLouderCodexSystemFrontmostInput', () => {
-  it('maps a held microphone to the global overlay start/end phases', () => {
-    const triggerVoice = vi.fn();
-    const input = createWorkLouderCodexSystemFrontmostInput({ triggerVoice });
+  describe('microphone key outside Cindy', () => {
+    const HOLD_DELAY_MS = 450;
 
-    expect(input.handle({ type: 'voice', phase: 'press' })).toBe(true);
-    expect(input.handle({ type: 'voice', phase: 'release' })).toBe(true);
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
 
-    expect(triggerVoice).toHaveBeenNthCalledWith(1, 'start');
-    expect(triggerVoice).toHaveBeenNthCalledWith(2, 'end');
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    function createVoiceInput() {
+      const triggerVoice = vi.fn();
+      return {
+        triggerVoice,
+        input: createWorkLouderCodexSystemFrontmostInput({
+          triggerVoice,
+          holdDelayMs: HOLD_DELAY_MS,
+          createScrollPump: () => ({ setSpeed: vi.fn(), stop: vi.fn() }),
+        }),
+      };
+    }
+
+    it('keeps the overlay recording after a short tap', () => {
+      const { triggerVoice, input } = createVoiceInput();
+
+      expect(input.handle({ type: 'voice', phase: 'press' })).toBe(true);
+      vi.advanceTimersByTime(HOLD_DELAY_MS - 1);
+      expect(input.handle({ type: 'voice', phase: 'release' })).toBe(true);
+
+      expect(triggerVoice.mock.calls.map(([phase]) => phase)).toEqual(['start', 'tap']);
+    });
+
+    it('submits when the key is held past the hold threshold', () => {
+      const { triggerVoice, input } = createVoiceInput();
+
+      expect(input.handle({ type: 'voice', phase: 'press' })).toBe(true);
+      vi.advanceTimersByTime(HOLD_DELAY_MS);
+      expect(input.handle({ type: 'voice', phase: 'release' })).toBe(true);
+
+      expect(triggerVoice.mock.calls.map(([phase]) => phase)).toEqual(['start', 'end']);
+    });
+
+    it('ignores repeated key-down messages while the key is held', () => {
+      const { triggerVoice, input } = createVoiceInput();
+
+      input.handle({ type: 'voice', phase: 'press' });
+      input.handle({ type: 'voice', phase: 'press' });
+      vi.advanceTimersByTime(HOLD_DELAY_MS);
+      input.handle({ type: 'voice', phase: 'release' });
+
+      expect(triggerVoice.mock.calls.map(([phase]) => phase)).toEqual(['start', 'end']);
+    });
+
+    it('drops a release that has no matching press', () => {
+      const { triggerVoice, input } = createVoiceInput();
+
+      expect(input.handle({ type: 'voice', phase: 'release' })).toBe(true);
+
+      expect(triggerVoice).not.toHaveBeenCalled();
+    });
   });
 
   it('sends Return for the send key', () => {

--- a/apps/desktop/src/main/worklouder-codex/systemFrontmostInput.ts
+++ b/apps/desktop/src/main/worklouder-codex/systemFrontmostInput.ts
@@ -300,9 +300,8 @@ export function createWorkLouderCodexSystemFrontmostInput(deps?: {
   // broken unless it was held.
   //
   // No separate suspend/wake reset here: unlike the native shortcut listeners,
-  // the keypad owner already forces a `release` when the device disconnects or
-  // the layout stops owning the key (`releaseHeldHardwareGestures`), so a lost
-  // key-up cannot strand this controller in its pressed state.
+  // the keypad owner forces a `release` when the layout stops owning the key or
+  // its task slots are suspended (`releaseHeldHardwareGestures`).
   const voicePhases = new ShortcutHoldPhaseController({
     holdDelayMs: deps?.holdDelayMs,
     onTrigger: triggerVoice,

--- a/apps/desktop/src/main/worklouder-codex/systemFrontmostInput.ts
+++ b/apps/desktop/src/main/worklouder-codex/systemFrontmostInput.ts
@@ -4,6 +4,7 @@ import { promisify } from 'node:util';
 import type { ChildProcess } from 'node:child_process';
 
 import { createLogger } from '../logger.js';
+import { ShortcutHoldPhaseController } from '../voice-input/ShortcutHoldPhaseController.js';
 import {
   runMacTextInsertionHelperCommand,
   spawnMacTextInsertionHelper,
@@ -279,6 +280,7 @@ export function createWorkLouderCodexSystemFrontmostInput(deps?: {
   runner?: SystemFrontmostInputRunner;
   triggerVoice?: (phase: 'start' | 'tap' | 'end') => void;
   now?: () => number;
+  holdDelayMs?: number;
   createScrollPump?: (runner: SystemFrontmostInputRunner) => SystemFrontmostScrollPump;
   spawnHoldScroll?: () => Promise<HoldScrollChild>;
 }) {
@@ -292,22 +294,24 @@ export function createWorkLouderCodexSystemFrontmostInput(deps?: {
       ? createMacHoldScrollPump(fallbackPump, deps?.spawnHoldScroll)
       : fallbackPump);
   let scrolling = false;
-  let voicePressed = false;
+  // Outside Cindy the microphone key must feel like the system shortcut: a short
+  // tap leaves the overlay recording (a second tap submits), and only a real
+  // hold submits on release. Sending `end` on every release made the key look
+  // broken unless it was held.
+  //
+  // No separate suspend/wake reset here: unlike the native shortcut listeners,
+  // the keypad owner already forces a `release` when the device disconnects or
+  // the layout stops owning the key (`releaseHeldHardwareGestures`), so a lost
+  // key-up cannot strand this controller in its pressed state.
+  const voicePhases = new ShortcutHoldPhaseController({
+    holdDelayMs: deps?.holdDelayMs,
+    onTrigger: triggerVoice,
+  });
 
   return {
     handle(action: WorkLouderCodexRendererAction): boolean {
       if (action.type === 'voice') {
-        if (action.phase === 'press') {
-          if (!voicePressed) {
-            voicePressed = true;
-            triggerVoice('start');
-          }
-          return true;
-        }
-        if (voicePressed) {
-          voicePressed = false;
-          triggerVoice('end');
-        }
+        voicePhases.setPressed(action.phase === 'press');
         return true;
       }
       if (action.type === 'command' && action.commandId === 'composer.submit') {


### PR DESCRIPTION
## 这次改了什么

### 摘要

Cindy 不是前台应用时，Codex Micro 的硬件语音键走 `systemFrontmostInput`：过去按下发 `start`、松手立刻发 `end`，短按等于按下的同一瞬间就提交，浮窗录不进内容。

现在复用系统语音快捷键已经在用的 `ShortcutHoldPhaseController`：短按（<450ms）发 `tap`，浮窗继续录音；按住超过阈值再松手才发 `end` 提交。硬件键和系统快捷键共用同一套状态机和阈值。Cindy 在前台时本来就走 renderer gesture，未改。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：Cindy 非前台时，WorkLouder Codex Micro 硬件语音键的 tap / hold 相位
- 明确不包含：Cindy 前台时的 renderer gesture、系统快捷键路径、灯效 / 布局
- 用户可见变化：Cindy 不在前台时，单击语音键会开始录音而不是立刻提交；按住说话再松手才会提交
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：不涉及：只改 main 进程硬件键相位，没有界面、文案或视觉变化。

## 怎么验证的

### 自动验证

```text
cd /Users/dash/Code/Cindy/cindy-worklouder-external-voice-tap
pnpm test:unit:related
结果：PASS apps/desktop unit (15.0s)；相关测试覆盖短按 tap、长按 end、重复 key-down、无 press 的 release

pnpm --filter desktop run typecheck
结果：通过

pnpm check:dco
结果：DCO check passed: 1 commit signed off — range 05264ab0..de59529c (base origin/main)

bash /Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh <worktree>
结果：apps/desktop 全量 2 failed / 27359 passed。失败项是
src/main/cindy-brain/__tests__/ghostInstallReceipt.test.ts
两条 GhostInstallReceiptStore cleanup 断言（state: invalid vs approved）。
本 PR 只改 worklouder-codex 的 systemFrontmostInput 两文件，与失败文件
origin/main...HEAD 无 diff，判定为基线/本机问题，不混入修复，交给 CI 给权威结论。
```

### 手工验证

未在本机接 Codex Micro 复测。单测覆盖 tap / hold / 重复按下 / 孤立松手。

### 未执行的验证

真机：Cindy 不在前台时单击 / 按住硬件语音键。需要接 Codex Micro 后由使用者确认手感。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Cindy 非前台时，Codex Micro 硬件语音键的 tap/hold 语义；macOS / Windows 共用 `ShortcutHoldPhaseController`。布局不再占用该键、挂起 task slots 或关掉启用时，既有 `releaseHeldHardwareGestures` 会补发 `release`。设备断开那条路径不会补 release，本 PR 不加新的断开清理机制。
- 回滚 / 降级方式：revert 本 PR 即回到「松手立刻 end」。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
