### PR TITLE
fix(plugin-market): recover stale GitHub trust receipts

### DIFF
--- a/apps/desktop/src/main/plugin-market/__tests__/service.test.ts
+++ b/apps/desktop/src/main/plugin-market/__tests__/service.test.ts
@@ -8,6 +8,7 @@ import {
   validateGhostManifest,
   type GhostInstallApproval,
   type GhostManifest,
+  type GhostTrustInfo,
 } from '../../../shared/ghost.js';
 const runtime = vi.hoisted(() => ({
   ghosts: [] as Array<{
@@ -15,6 +16,7 @@ const runtime = vi.hoisted(() => ({
     dir: string;
     enabled: boolean;
     approval?: GhostInstallApproval;
+    trust?: GhostTrustInfo;
   }>,
   install: vi.fn(),
   inspect: vi.fn(),
@@ -71,6 +73,12 @@ vi.mock('../../cindy-brain/index.js', () => ({
         approval: ghost.approval ?? {
           state: 'approved',
           revision: '00000000-0000-4000-8000-000000000001',
+        },
+        trust: ghost.trust ?? {
+          level: 'unverified',
+          publisherSigned: false,
+          publisherVerified: false,
+          reviewed: false,
         },
       })),
     approvedInstallEvidence: runtime.approvedInstallEvidence,
@@ -1453,13 +1461,33 @@ describe('PluginMarketService migration and defaultInstall', () => {
     });
   });
 
-  it('旧 source:market + manifestDigest 安装会回填 cindy-github 官方 trust', async () => {
+  it('Host receipt 未可信时,目录中的完整 trust 镜像也不能阻止官方回填', async () => {
     const item = summary({ ghostId: 'cindy-github' });
     const rawManifest = manifest('cindy-github');
     const installDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cindy-market-github-'));
     roots.push(installDir);
     fs.writeFileSync(path.join(installDir, 'ghost.json'), JSON.stringify(rawManifest));
-    runtime.ghosts = [{ manifest: rawManifest, dir: installDir, enabled: true }];
+    fs.writeFileSync(
+      path.join(installDir, '.cindy-trust.json'),
+      JSON.stringify({
+        level: 'cindy-official',
+        publisherSigned: true,
+        publisherVerified: true,
+        reviewed: true,
+        publisherName: 'Cindy Plugin Market',
+      }),
+    );
+    runtime.ghosts = [{
+      manifest: rawManifest,
+      dir: installDir,
+      enabled: true,
+      trust: {
+        level: 'unverified',
+        publisherSigned: false,
+        publisherVerified: false,
+        reviewed: false,
+      },
+    }];
     const h = harness([item]);
     const digest = ghostManifestDigest(rawManifest);
     h.ledger.upsertInstallation({
@@ -1513,7 +1541,18 @@ describe('PluginMarketService migration and defaultInstall', () => {
         publisherName: 'Cindy Plugin Market',
       }),
     );
-    runtime.ghosts = [{ manifest: rawManifest, dir: installDir, enabled: true }];
+    runtime.ghosts = [{
+      manifest: rawManifest,
+      dir: installDir,
+      enabled: true,
+      trust: {
+        level: 'cindy-official',
+        publisherSigned: true,
+        publisherVerified: true,
+        reviewed: true,
+        publisherName: 'Cindy Plugin Market',
+      },
+    }];
     const h = harness([item]);
     h.ledger.upsertInstallation({
       pluginId: item.id,

--- a/apps/desktop/src/main/plugin-market/__tests__/service.test.ts
+++ b/apps/desktop/src/main/plugin-market/__tests__/service.test.ts
@@ -1574,7 +1574,58 @@ describe('PluginMarketService migration and defaultInstall', () => {
     expect(runtime.install).not.toHaveBeenCalled();
   });
 
-  it('legacy-adopted cindy-github 只通过当前市场更新获得官方 trust', async () => {
+  it('Host receipt 已可信但目录镜像缺失时仍回填旧版兼容 trust', async () => {
+    const item = summary({ ghostId: 'cindy-github' });
+    const rawManifest = manifest('cindy-github');
+    const installDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cindy-market-github-mirror-missing-'));
+    roots.push(installDir);
+    fs.writeFileSync(path.join(installDir, 'ghost.json'), JSON.stringify(rawManifest));
+    runtime.ghosts = [{
+      manifest: rawManifest,
+      dir: installDir,
+      enabled: true,
+      trust: {
+        level: 'cindy-official',
+        publisherSigned: true,
+        publisherVerified: true,
+        reviewed: true,
+        publisherName: 'Cindy Plugin Market',
+      },
+    }];
+    const h = harness([item]);
+    h.ledger.upsertInstallation({
+      pluginId: item.id,
+      ghostId: item.ghostId,
+      releaseId: item.currentRelease.id,
+      version: item.currentRelease.version,
+      sha256: item.currentRelease.sha256,
+      scope: item.scope,
+      organizationId: item.organizationId,
+      source: 'market',
+      installed: true,
+      updatedAt: '2026-08-07T00:00:00.000Z',
+      manifestDigest: ghostManifestDigest(rawManifest),
+    });
+    runtime.install.mockResolvedValue({
+      manifest: rawManifest,
+      dir: installDir,
+      enabled: true,
+      trust: { level: 'cindy-official' },
+    });
+
+    await h.service.snapshot();
+
+    expect(h.api.download).toHaveBeenCalledWith(item.id, item.currentRelease.id);
+    expect(runtime.install).toHaveBeenCalledWith(
+      expect.stringMatching(/cindy-plugin-trust-backfill-.*\.cindy$/),
+      expect.objectContaining({
+        ghostId: 'cindy-github',
+        officialCindyGithub: true,
+      }),
+    );
+  });
+
+  it('legacy-adopted 记录不能成为开发版冒充 cindy-github 的官方 trust 来源', async () => {
     const item = summary({ ghostId: 'cindy-github' });
     const rawManifest = manifest('cindy-github');
     const installDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cindy-legacy-github-'));

--- a/apps/desktop/src/main/plugin-market/service.ts
+++ b/apps/desktop/src/main/plugin-market/service.ts
@@ -63,7 +63,7 @@ import {
   isBuiltinGhostRemovedByUser,
   uninstallGhostAndCleanup,
 } from '../cindy-brain/index.js';
-import { hasCindyOfficialTrustMetadata } from '../cindy-brain/GhostManager.js';
+import { isCindyOfficialTrustInfo } from '../cindy-brain/GhostManager.js';
 import {
   getActiveAppSession,
   isAppSessionBoundaryPending,
@@ -458,7 +458,7 @@ function canBackfillOfficialCindyGithubTrust(
     record.source === 'market' &&
     record.manifestDigest !== undefined &&
     installed.approval.state === 'approved' &&
-    !hasCindyOfficialTrustMetadata(installed.dir) &&
+    !isCindyOfficialTrustInfo(installed.trust) &&
     serverRecordMatchesInstalledGhost(record.pluginId, installed, record)
   );
 }

--- a/apps/desktop/src/main/plugin-market/service.ts
+++ b/apps/desktop/src/main/plugin-market/service.ts
@@ -63,7 +63,10 @@ import {
   isBuiltinGhostRemovedByUser,
   uninstallGhostAndCleanup,
 } from '../cindy-brain/index.js';
-import { isCindyOfficialTrustInfo } from '../cindy-brain/GhostManager.js';
+import {
+  hasCindyOfficialTrustMetadata,
+  isCindyOfficialTrustInfo,
+} from '../cindy-brain/GhostManager.js';
 import {
   getActiveAppSession,
   isAppSessionBoundaryPending,
@@ -458,7 +461,10 @@ function canBackfillOfficialCindyGithubTrust(
     record.source === 'market' &&
     record.manifestDigest !== undefined &&
     installed.approval.state === 'approved' &&
-    !isCindyOfficialTrustInfo(installed.trust) &&
+    (
+      !isCindyOfficialTrustInfo(installed.trust) ||
+      !hasCindyOfficialTrustMetadata(installed.dir)
+    ) &&
     serverRecordMatchesInstalledGhost(record.pluginId, installed, record)
   );
 }


### PR DESCRIPTION
## 这次改了什么

### 摘要

Fixes #3041.

GitHub credential trust backfill 之前使用插件目录内可变的 `.cindy-trust.json` 文件作为"已修复"谓词。一个看起来完整但已过时的 mirror 可能抑制恢复，即使 Host-authoritative installed receipt 仍投影为 unverified，导致官方 GitHub 插件无法使用 gh-cli credential 路径。

修复：eligibility check 现在仅在两个表示都健康时才跳过恢复：Host-authoritative InstalledGhost.trust projection 完全为 cindy-official，且 legacy `.cindy-trust.json` compatibility mirror 完整。如果任一表示过时或缺失，protected path 会重新下载并验证 recorded official release 后再重装。market ledger、approval、manifest digest、release SHA verification、owner checks 和 install lock 保持不变，不扩大 trust 范围，保留 downgrade 兼容性。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：#3041
- 本 PR 包含：trust backfill eligibility check 双表示验证
- 明确不包含：trust model 变更、market ledger 变更
- 用户可见变化：GitHub 插件 trust 恢复更可靠
- 是否存在 breaking change：无

## 怎么验证的

- `corepack pnpm --filter desktop exec vitest run src/main/plugin-market/__tests__/service.test.ts src/main/cindy-brain/__tests__/GhostManager.test.ts`
- `corepack pnpm --filter desktop exec eslint src/main/plugin-market/service.ts src/main/plugin-market/__tests__/service.test.ts`
- `corepack pnpm --filter desktop typecheck`
- `git diff --check`

Results: 344 tests passed, 1 skipped; ESLint and typecheck passed.

## 风险

This changes the plugin trust backfill path and therefore still requires the repository's explicit maintainer approval gate.
