### PR TITLE
feat(desktop): support provider-neutral image outputs

### DIFF
--- a/apps/desktop/src/main/__tests__/codexTranslator.test.ts
+++ b/apps/desktop/src/main/__tests__/codexTranslator.test.ts
@@ -426,6 +426,42 @@ describe('webSearch', () => {
   });
 });
 
+describe('imageView', () => {
+  it('模型内部读图不作为用户可见输出事件', () => {
+    feedItem('completed', {
+      type: 'imageView',
+      id: 'img-view-1',
+      path: '/tmp/login-qr.png',
+    });
+    expect(coll.events).toEqual([]);
+  });
+});
+
+describe('imageGeneration', () => {
+  it('completed 发 provider-neutral image_output', () => {
+    feedItem('completed', {
+      type: 'imageGeneration',
+      id: 'img-gen-1',
+      status: 'completed',
+      revisedPrompt: 'draw a QR code',
+      result: 'data:image/png;base64,AAAA',
+      savedPath: '/tmp/generated-qr.png',
+    });
+    expect(coll.events).toEqual([
+      {
+        type: 'image_output',
+        source: 'codex',
+        data: {
+          outputId: 'img-gen-1',
+          path: '/tmp/generated-qr.png',
+          prompt: 'draw a QR code',
+          status: 'completed',
+        },
+      },
+    ]);
+  });
+});
+
 // ── fileChange ──────────────────────────────────────────────────────────────
 
 describe('fileChange', () => {

--- a/apps/desktop/src/main/__tests__/messagePersistBroadcaster.test.ts
+++ b/apps/desktop/src/main/__tests__/messagePersistBroadcaster.test.ts
@@ -28,6 +28,13 @@ vi.mock('../localDb/ipc/messages.js', () => ({
 vi.mock('../localDb/subagentRuns.js', () => ({
   getSubagentRunDetail: vi.fn(async () => null),
 }));
+vi.mock('../cindy-media/markdownImages.js', () => ({
+  materializeMarkdownImages: vi.fn(async ({ text }: { text: string }) => ({
+    absPaths: [],
+    managedText: text,
+    textWithoutImages: text,
+  })),
+}));
 
 vi.mock('../logger.js', () => ({
   createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
@@ -69,6 +76,7 @@ import {
   writeCodexPlanTerminal,
   writeCodexPlanUpdate,
 } from '../localDb/codexPlanState.js';
+import { materializeMarkdownImages } from '../cindy-media/markdownImages.js';
 import {
   recordMediaToolResult,
   __resetMediaToolResultPoolForTesting,
@@ -80,7 +88,7 @@ import {
   persistCodexPlanOnTerminalError,
   onToolResultEvent,
   onToolResultFullEvent,
-  prepareSyntheticToolEventForBroadcast,
+  persistSyntheticToolExchange,
   onAssistantTextEvent,
   onInteractionMessage,
   onThinkingEvent,
@@ -97,6 +105,7 @@ import {
   markAssistantTurnFailed,
   noteSessionClearBoundary,
   noteSessionAgentKind,
+  noteSessionMarkdownImageContext,
   noteAgentMeta,
   enqueueDurableWrite,
   noteTurnStarted,
@@ -132,11 +141,111 @@ describe('Codex done completion boundary', () => {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  vi.mocked(materializeMarkdownImages).mockImplementation(async ({ text }) => ({
+    absPaths: [],
+    managedText: text,
+    textWithoutImages: text,
+  }));
   vi.mocked(findVisibleToolUseMessageByAliases).mockResolvedValue(null);
   vi.mocked(getSubagentRunDetail).mockResolvedValue(null);
   ownerScopeState.current = true;
   noteSessionClearBoundary(SESSION, null);
   clearSessionPersistState(SESSION);
+});
+
+describe('assistant Markdown image materialization', () => {
+  it.each(['cc', 'codex', 'pi'] as const)(
+    '%s 最终回复统一改写为 cindy-media URL',
+    async (agentKind) => {
+      const original = '完成\n![二维码](/workspace/output/qr.png)';
+      const managed = `完成\n![二维码](cindy-media://blobs/${'a'.repeat(64)}.png)`;
+      noteSessionAgentKind(SESSION, agentKind);
+      noteSessionMarkdownImageContext(SESSION, {
+        workingDir: '/workspace',
+        allowLocalPaths: true,
+      });
+      vi.mocked(materializeMarkdownImages).mockResolvedValueOnce({
+        absPaths: ['/media/qr.png'],
+        managedText: managed,
+        textWithoutImages: '完成\n二维码',
+      });
+      vi.mocked(updateMessageContent).mockResolvedValueOnce({
+        createdAt: '2026-08-20T08:00:00.000Z',
+      } as never);
+
+      const clientId = onAssistantTextEvent(SESSION, { text: original, isFinal: true }, null);
+      await flushWrites();
+      await flushWrites();
+
+      expect(materializeMarkdownImages).toHaveBeenCalledWith({
+        text: original,
+        workingDir: '/workspace',
+        sessionId: SESSION,
+        maxImages: 4,
+        allowLocalPaths: true,
+      });
+      expect(updateMessageContent).toHaveBeenCalledWith(SESSION, clientId, managed, {
+        onlyVisible: true,
+      });
+      expect(broadcastMessageRow).toHaveBeenCalledWith(
+        SESSION,
+        expect.objectContaining({ createdAt: '2026-08-20T08:00:00.000Z' }),
+        ownerScopeState.scope,
+      );
+    },
+  );
+
+  it('SSH 会话拒绝把远端绝对路径当成本机文件读取', async () => {
+    const text = '![远端图片](/home/remote/output.png)';
+    noteSessionMarkdownImageContext(SESSION, {
+      workingDir: '/home/remote',
+      allowLocalPaths: false,
+    });
+
+    onAssistantTextEvent(SESSION, { text, isFinal: true }, null);
+    await flushWrites();
+
+    expect(materializeMarkdownImages).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text,
+        workingDir: '/home/remote',
+        allowLocalPaths: false,
+      }),
+    );
+    expect(updateMessageContent).not.toHaveBeenCalled();
+  });
+
+  it('会话关闭后丢弃尚未完成的异步图片改写', async () => {
+    let resolveMaterialization:
+      | ((value: { absPaths: string[]; managedText: string; textWithoutImages: string }) => void)
+      | undefined;
+    vi.mocked(materializeMarkdownImages).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveMaterialization = resolve;
+        }),
+    );
+    noteSessionMarkdownImageContext(SESSION, {
+      workingDir: '/workspace',
+      allowLocalPaths: true,
+    });
+
+    onAssistantTextEvent(
+      SESSION,
+      { text: '![二维码](/workspace/output.png)', isFinal: true },
+      null,
+    );
+    clearSessionPersistState(SESSION);
+    resolveMaterialization?.({
+      absPaths: ['/media/output.png'],
+      managedText: `![二维码](cindy-media://blobs/${'b'.repeat(64)}.png)`,
+      textWithoutImages: '二维码',
+    });
+    await flushWrites();
+    await flushWrites();
+
+    expect(updateMessageContent).not.toHaveBeenCalled();
+  });
 });
 
 describe('update_plan tool_use persistence', () => {
@@ -1570,55 +1679,52 @@ describe('eager-create:tool_use 已到,tool_result_full 早于摘要', () => {
   });
 });
 
-describe('synthetic tool events:本地合成事件也返回 renderer 展示所需 payload', () => {
-  it('Codex imageGeneration 合成 imagegen 三联事件时带 persistId/resolvedContent', async () => {
-    const toolUse = prepareSyntheticToolEventForBroadcast(
-      SESSION,
-      {
-        type: 'tool_use',
-        data: { toolUseId: 'codex-img-1', toolName: 'imagegen', input: { status: 'completed' } },
-      },
-      null,
-    );
-    expect(toolUse).toEqual({ persistId: expect.any(String) });
-
+describe('synthetic tool exchange persistence', () => {
+  it('异步图片输出在 turn reset 后仍直接落稳定的 tool_use/tool_result 消息对', async () => {
+    const createdAt = Date.parse('2026-08-20T08:00:00.000Z');
     const imageResult = JSON.stringify({
       ok: true,
-      kind: 'generation',
+      kind: 'output',
       xdt_image_url: 'xdt-image://sess-tr/generated.png',
     });
-
-    const full = prepareSyntheticToolEventForBroadcast(
-      SESSION,
-      { type: 'tool_result_full', data: { toolUseId: 'codex-img-1', fullText: imageResult } },
-      null,
-    );
-    expect(full).toEqual({ persistId: expect.any(String), resolvedContent: imageResult });
-
-    const summary = prepareSyntheticToolEventForBroadcast(
-      SESSION,
-      { type: 'tool_result', data: { summary: 'image generated', toolUseIds: ['codex-img-1'] } },
-      null,
-    );
-    expect(summary).toEqual(full);
+    noteSessionAgentKind(SESSION, 'pi');
+    const ids = persistSyntheticToolExchange({
+      sessionId: SESSION,
+      toolUseId: 'image-output-1',
+      toolName: 'imagegen',
+      toolInput: { status: 'completed' },
+      resultContent: imageResult,
+      agentMeta: { uuid: 'image-meta' },
+      createdAt,
+    });
+    resetTurnPersistState(SESSION);
 
     await flushWrites();
     expect(createMessage).toHaveBeenCalledWith(
       SESSION,
       expect.objectContaining({
-        clientId: toolUse.persistId,
+        clientId: ids.toolUseClientId,
         role: 'tool_use',
-        toolUseId: 'codex-img-1',
+        content: {
+          toolUseId: 'image-output-1',
+          toolName: 'imagegen',
+          input: { status: 'completed' },
+        },
+        toolUseId: 'image-output-1',
+        agentKind: 'pi',
+        createdAt,
       }),
       broadcastGuard(),
     );
     expect(createMessage).toHaveBeenCalledWith(
       SESSION,
       expect.objectContaining({
-        clientId: full.persistId,
+        clientId: ids.toolResultClientId,
         role: 'tool_result',
         content: imageResult,
-        toolUseId: 'codex-img-1',
+        toolUseId: 'image-output-1',
+        agentKind: 'pi',
+        createdAt: createdAt + 1,
       }),
       broadcastGuard(),
     );

--- a/apps/desktop/src/main/cindy-media/__tests__/generatedMedia.test.ts
+++ b/apps/desktop/src/main/cindy-media/__tests__/generatedMedia.test.ts
@@ -145,7 +145,7 @@ describe('createBlobVideoStorage.saveVideo(生成视频入仓)', () => {
   });
 });
 
-describe('materializeGeneratedImage(codex 生成图物化,thin adapter 的逻辑本体)', () => {
+describe('materializeOutputImage(Agent 图片输出物化,thin adapter 的逻辑本体)', () => {
   const deps = {
     ingestFromPath: vi.fn(async ({ originalName }: { sourcePath: string; originalName?: string }) => ({
       url: `cindy-media://blobs/${'b'.repeat(64)}.png`,
@@ -155,20 +155,22 @@ describe('materializeGeneratedImage(codex 生成图物化,thin adapter 的逻辑
       url: `cindy-media://blobs/${'c'.repeat(64)}.png`,
       filename: `${'c'.repeat(64)}.png`,
     })),
+    fetchRemoteImage: vi.fn(async () => ({ buffer: PNG_BYTES })),
   };
 
   beforeEach(() => {
     deps.ingestFromPath.mockClear();
     deps.ingestBuffer.mockClear();
+    deps.fetchRemoteImage.mockClear();
   });
 
   it('托管地址(老 xdt-image / 新 cindy-media)原样透传,不重复入仓', async () => {
-    const legacy = await generatedMedia.materializeGeneratedImage(
+    const legacy = await generatedMedia.materializeOutputImage(
       { url: 'xdt-image://sess-1/pic.png' },
       deps,
     );
     expect(legacy).toEqual({ url: 'xdt-image://sess-1/pic.png', filename: 'pic.png' });
-    const blob = await generatedMedia.materializeGeneratedImage(
+    const blob = await generatedMedia.materializeOutputImage(
       { url: `cindy-media://blobs/${'d'.repeat(64)}.png` },
       deps,
     );
@@ -179,24 +181,105 @@ describe('materializeGeneratedImage(codex 生成图物化,thin adapter 的逻辑
   });
 
   it('本地路径 → ingestFromPath;data: base64 → ingestBuffer(mime 从 data url 头取)', async () => {
-    await generatedMedia.materializeGeneratedImage({ path: '/tmp/gen.png' }, deps);
+    await generatedMedia.materializeOutputImage({ path: '/tmp/gen.png' }, deps);
     expect(deps.ingestFromPath).toHaveBeenCalledWith({ sourcePath: '/tmp/gen.png', originalName: 'gen.png' });
 
     const b64 = PNG_BYTES.toString('base64');
-    await generatedMedia.materializeGeneratedImage({ url: `data:image/png;base64,${b64}` }, deps);
+    await generatedMedia.materializeOutputImage({ url: `data:image/png;base64,${b64}` }, deps);
     expect(deps.ingestBuffer).toHaveBeenCalledTimes(1);
     const bufferCalls = deps.ingestBuffer.mock.calls as unknown as Array<[{ mimeType: string }]>;
     expect(bufferCalls[0][0]).toMatchObject({ mimeType: 'image/png' });
   });
 
-  it('认不出的形状返回 null;ingest 抛错向上传播(调用方决定丢图)', async () => {
-    await expect(generatedMedia.materializeGeneratedImage({}, deps)).resolves.toBeNull();
+  it('https 输出经 SSRF 防护下载后按图片魔数入仓，http 不下载', async () => {
+    await generatedMedia.materializeOutputImage(
+      { url: 'https://cdn.example/generated.png' },
+      deps,
+    );
+    expect(deps.fetchRemoteImage).toHaveBeenCalledWith(
+      'https://cdn.example/generated.png',
+      20 * 1024 * 1024,
+    );
+    expect(deps.ingestBuffer).toHaveBeenCalledWith({
+      buffer: PNG_BYTES,
+      mimeType: 'image/png',
+    });
+
     await expect(
-      generatedMedia.materializeGeneratedImage({ url: 'data:text/plain;base64,aGk=' }, deps),
+      generatedMedia.materializeOutputImage(
+        { url: 'http://insecure.example/generated.png' },
+        deps,
+      ),
+    ).resolves.toBeNull();
+    expect(deps.fetchRemoteImage).toHaveBeenCalledTimes(1);
+  });
+
+  it('provider-neutral 输出要求稳定 outputId;相对路径与 SSH 路径拒绝本机读盘', async () => {
+    const output = {
+      outputId: 'output-1',
+      path: '/tmp/qr.png',
+    } as const;
+    expect(generatedMedia.isMaterializableImageOutput(output)).toBe(true);
+    await generatedMedia.materializeOutputImage({ path: '/tmp/qr.png' }, deps, {
+      allowLocalPath: true,
+    });
+    expect(deps.ingestFromPath).toHaveBeenCalledWith({
+      sourcePath: '/tmp/qr.png',
+      originalName: 'qr.png',
+    });
+
+    await expect(
+      generatedMedia.materializeOutputImage({ path: 'relative/qr.png' }, deps),
+    ).resolves.toBeNull();
+    await expect(
+      generatedMedia.materializeOutputImage(
+        { path: '/home/remote/qr.png' },
+        deps,
+        { allowLocalPath: false },
+      ),
+    ).resolves.toBeNull();
+    expect(deps.ingestFromPath).toHaveBeenCalledTimes(1);
+    expect(generatedMedia.isMaterializableImageOutput({ path: '/tmp/no-id.png' })).toBe(false);
+  });
+
+  it('显式图片输出统一使用 imagegen 展示契约', () => {
+    const presentation = generatedMedia.createImageOutputToolPresentation(
+      {
+        outputId: 'gen-1',
+        path: '/tmp/generated.png',
+        prompt: 'draw a cat',
+        status: 'completed',
+      },
+      {
+        url: `cindy-media://blobs/${'f'.repeat(64)}.png`,
+        filename: 'generated.png',
+      },
+    );
+    expect(presentation.toolName).toBe('imagegen');
+    expect(presentation.toolInput).toEqual({ prompt: 'draw a cat', status: 'completed' });
+    expect(JSON.parse(presentation.fullText)).toMatchObject({
+      kind: 'output',
+      text: 'image generated',
+      xdt_image_url: `cindy-media://blobs/${'f'.repeat(64)}.png`,
+      prompt: 'draw a cat',
+    });
+  });
+
+  it('认不出的形状返回 null;ingest 抛错向上传播(调用方决定丢图)', async () => {
+    expect(generatedMedia.isMaterializableImageOutput({ outputId: 'missing-source' })).toBe(false);
+    await expect(generatedMedia.materializeOutputImage({}, deps)).resolves.toBeNull();
+    await expect(
+      generatedMedia.materializeOutputImage({ url: 'data:text/plain;base64,aGk=' }, deps),
+    ).resolves.toBeNull();
+    await expect(
+      generatedMedia.materializeOutputImage(
+        { url: `data:image/png;base64,${Buffer.from('not an image').toString('base64')}` },
+        deps,
+      ),
     ).resolves.toBeNull();
     deps.ingestFromPath.mockRejectedValueOnce(new Error('unsupported image extension'));
     await expect(
-      generatedMedia.materializeGeneratedImage({ path: '/tmp/gen.avif' }, deps),
+      generatedMedia.materializeOutputImage({ path: '/tmp/gen.avif' }, deps),
     ).rejects.toThrow(/unsupported/);
   });
 });

--- a/apps/desktop/src/main/cindy-media/__tests__/markdownImages.test.ts
+++ b/apps/desktop/src/main/cindy-media/__tests__/markdownImages.test.ts
@@ -1,0 +1,119 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { materializeMarkdownImages } from '../markdownImages';
+
+const PNG_BYTES = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+const tempRoots: string[] = [];
+
+async function makeTempRoot(): Promise<string> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'cindy-markdown-image-'));
+  tempRoots.push(root);
+  return root;
+}
+
+function makeDeps(mediaAbsPath: string) {
+  return {
+    realpath: (value: string) => fs.realpath(value),
+    stat: (value: string) => fs.stat(value),
+    readFile: (value: string) => fs.readFile(value),
+    ingest: vi.fn(async () => ({
+      url: `cindy-media://blobs/${'a'.repeat(64)}.png`,
+    })),
+    resolveMediaUrl: vi.fn(() => ({ absPath: mediaAbsPath })),
+  };
+}
+
+afterEach(async () => {
+  for (const root of tempRoots.splice(0)) {
+    await fs.rm(root, { recursive: true, force: true });
+  }
+});
+
+describe('materializeMarkdownImages', () => {
+  it('将 workingDir 内本地图片改写为托管 URL，并提供去图片正文', async () => {
+    const workingDir = await makeTempRoot();
+    const sourcePath = path.join(workingDir, 'qr.png');
+    const mediaAbsPath = path.join(workingDir, 'media', 'qr.png');
+    await fs.writeFile(sourcePath, PNG_BYTES);
+    const deps = makeDeps(mediaAbsPath);
+
+    const result = await materializeMarkdownImages(
+      {
+        text: `扫码登录\n![登录二维码](${sourcePath})`,
+        workingDir,
+        sessionId: 'session-local',
+      },
+      deps,
+    );
+
+    expect(result).toEqual({
+      absPaths: [mediaAbsPath],
+      managedText: `扫码登录\n![登录二维码](cindy-media://blobs/${'a'.repeat(64)}.png)`,
+      textWithoutImages: '扫码登录\n登录二维码',
+    });
+    expect(deps.ingest).toHaveBeenCalledWith({
+      buffer: PNG_BYTES,
+      mimeType: 'image/png',
+      sessionId: 'session-local',
+    });
+  });
+
+  it('远程上下文禁用本地路径时不触碰文件系统', async () => {
+    const deps = {
+      realpath: vi.fn(async (value: string) => value),
+      stat: vi.fn(async () => ({ isFile: () => true, size: PNG_BYTES.length })),
+      readFile: vi.fn(async () => PNG_BYTES),
+      ingest: vi.fn(async () => ({
+        url: `cindy-media://blobs/${'b'.repeat(64)}.png`,
+      })),
+      resolveMediaUrl: vi.fn(() => ({ absPath: '/unused.png' })),
+    };
+    const text = '![远端图片](/home/remote/output.png)';
+
+    await expect(
+      materializeMarkdownImages(
+        {
+          text,
+          workingDir: '/home/remote',
+          sessionId: 'session-remote',
+          allowLocalPaths: false,
+        },
+        deps,
+      ),
+    ).resolves.toEqual({
+      absPaths: [],
+      managedText: text,
+      textWithoutImages: text,
+    });
+    expect(deps.realpath).not.toHaveBeenCalled();
+    expect(deps.readFile).not.toHaveBeenCalled();
+    expect(deps.ingest).not.toHaveBeenCalled();
+  });
+
+  it('拒绝通过 workingDir 内符号链接读取目录外图片', async () => {
+    const parent = await makeTempRoot();
+    const workingDir = path.join(parent, 'work');
+    const outsideDir = path.join(parent, 'outside');
+    await fs.mkdir(workingDir);
+    await fs.mkdir(outsideDir);
+    const outsidePath = path.join(outsideDir, 'secret.png');
+    const linkedPath = path.join(workingDir, 'linked.png');
+    await fs.writeFile(outsidePath, PNG_BYTES);
+    await fs.symlink(outsidePath, linkedPath);
+    const deps = makeDeps(path.join(parent, 'unused.png'));
+    const text = `![越界图片](${linkedPath})`;
+
+    await expect(
+      materializeMarkdownImages({ text, workingDir, sessionId: 'session-symlink' }, deps),
+    ).resolves.toEqual({
+      absPaths: [],
+      managedText: text,
+      textWithoutImages: text,
+    });
+    expect(deps.ingest).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/main/cindy-media/generatedMedia.ts
+++ b/apps/desktop/src/main/cindy-media/generatedMedia.ts
@@ -22,6 +22,7 @@ import path from 'node:path';
 import * as blobStore from './blobStore';
 import { ingestMedia } from './ingest';
 import type { LedgerDb } from './ledger';
+import { sniffMediaMime } from './sniffMediaMime';
 
 /** 与 @cindy/mcps SavedImage 结构对齐(structural typing,不 import 包内类型)。 */
 export interface SavedBlobImage {
@@ -155,11 +156,56 @@ export function createBlobVideoStorage(db?: LedgerDb): {
   return { saveVideo };
 }
 
-// ── codex 生成图物化(register.ts 的 thin adapter 调用,规则 14:逻辑在此可测)──
+// ── Agent 图片输出物化(register.ts 的 thin adapter 调用,规则 14:逻辑在此可测)──
 
 export interface GeneratedImageSource {
   url?: string;
   path?: string;
+}
+
+const MAX_OUTPUT_IMAGE_BYTES = 20 * 1024 * 1024;
+
+export interface ImageOutputSource extends GeneratedImageSource {
+  outputId?: string;
+  prompt?: string;
+  status?: string;
+}
+
+export function isMaterializableImageOutput(
+  data: ImageOutputSource | null | undefined,
+): data is ImageOutputSource & { outputId: string } {
+  return (
+    typeof data?.outputId === 'string' &&
+    data.outputId.length > 0 &&
+    (typeof data.path === 'string' || typeof data.url === 'string')
+  );
+}
+
+export function createImageOutputToolPresentation(
+  data: ImageOutputSource & { outputId: string },
+  cached: { url: string; filename: string },
+): {
+  toolName: 'imagegen';
+  toolInput: Record<string, string>;
+  fullText: string;
+} {
+  return {
+    toolName: 'imagegen',
+    toolInput: {
+      ...(data.prompt ? { prompt: data.prompt } : {}),
+      ...(data.status ? { status: data.status } : {}),
+    },
+    fullText: JSON.stringify({
+      ok: true,
+      kind: 'output',
+      text: 'image generated',
+      xdt_image_url: cached.url,
+      filename: cached.filename,
+      ...(data.prompt ? { prompt: data.prompt } : {}),
+      ...(data.status ? { status: data.status } : {}),
+      ...(data.path ? { original_path: data.path } : {}),
+    }),
+  };
 }
 
 /** 从 URL / 路径推导展示文件名;推不出兜底 generated-image.png。 */
@@ -184,22 +230,25 @@ function parseDataImageUrl(url: string): { mimeType: string; buffer: Buffer } | 
 }
 
 /**
- * codex 生成图 → 总仓物化:托管地址(老 xdt-image / 新 cindy-media)透传;
+ * Agent 图片输出 → 总仓物化:托管地址(老 xdt-image / 新 cindy-media)透传;
  * 本地路径 / data: base64 入仓(零引用,合成 tool_result 落库时挂账)。
  * 形状不认识返回 null;入仓失败(白名单外 mime / 读盘失败)向上抛,由调用方
  * 决定丢图语义。
  */
-export async function materializeGeneratedImage(
+export async function materializeOutputImage(
   data: GeneratedImageSource,
   deps: {
     ingestFromPath: (params: { sourcePath: string; originalName?: string }) => Promise<{ url: string; filename: string }>;
     ingestBuffer: (params: { buffer: Uint8Array; mimeType: string }) => Promise<{ url: string; filename: string }>;
+    fetchRemoteImage?: (url: string, maxBytes: number) => Promise<{ buffer: Uint8Array }>;
   },
+  opts: { allowLocalPath?: boolean } = {},
 ): Promise<{ url: string; filename: string } | null> {
   if (data.url?.startsWith('xdt-image://') || data.url?.startsWith('cindy-media://')) {
     return { url: data.url, filename: safeGeneratedImageFilename(data.url) };
   }
   if (data.path) {
+    if (opts.allowLocalPath === false || !path.isAbsolute(data.path)) return null;
     return deps.ingestFromPath({
       sourcePath: data.path,
       originalName: safeGeneratedImageFilename(data.path),
@@ -207,8 +256,16 @@ export async function materializeGeneratedImage(
   }
   if (data.url?.startsWith('data:')) {
     const parsed = parseDataImageUrl(data.url);
-    if (!parsed) return null;
-    return deps.ingestBuffer({ buffer: parsed.buffer, mimeType: parsed.mimeType });
+    if (!parsed || parsed.buffer.byteLength > MAX_OUTPUT_IMAGE_BYTES) return null;
+    const mimeType = sniffMediaMime(parsed.buffer);
+    if (!mimeType?.startsWith('image/')) return null;
+    return deps.ingestBuffer({ buffer: parsed.buffer, mimeType });
+  }
+  if (data.url?.startsWith('https://') && deps.fetchRemoteImage) {
+    const fetched = await deps.fetchRemoteImage(data.url, MAX_OUTPUT_IMAGE_BYTES);
+    const mimeType = sniffMediaMime(fetched.buffer);
+    if (!mimeType?.startsWith('image/')) return null;
+    return deps.ingestBuffer({ buffer: fetched.buffer, mimeType });
   }
   return null;
 }

--- a/apps/desktop/src/main/cindy-media/markdownImages.ts
+++ b/apps/desktop/src/main/cindy-media/markdownImages.ts
@@ -1,0 +1,220 @@
+/**
+ * Agent 最终 Markdown 图片的主进程安全物化。
+ *
+ * 本地图片只接受 canonical workingDir 内的普通图片文件；托管图片只通过
+ * cindy-media / xdt-image 的安全解析器读取。成功项同时产出两种文本：
+ * - managedText: 图片目标改写为托管 URL，供持久化聊天消息跨端展示；
+ * - textWithoutImages: 图片语法替换为 alt，供 IM 文本与附件分离发送。
+ */
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+import { resolveSafe as resolveCindyMediaUrl } from './blobStore';
+import { ingestMedia } from './ingest';
+import { sniffMediaMime } from './sniffMediaMime';
+import { resolveSafe as resolveXdtImageUrl } from '../imageCacheStore';
+
+const MARKDOWN_IMAGE_RE = /!\[([^\]\r\n]{0,512})\]\(([^)\r\n]{1,4096})\)/g;
+const DEFAULT_MAX_IMAGES = 4;
+const DEFAULT_MAX_IMAGE_BYTES = 20 * 1024 * 1024;
+
+export interface MarkdownImageMaterializeDeps {
+  realpath(value: string): Promise<string>;
+  stat(value: string): Promise<{ isFile(): boolean; size: number }>;
+  readFile(value: string): Promise<Uint8Array>;
+  ingest(params: {
+    buffer: Uint8Array;
+    mimeType: string;
+    sessionId: string;
+  }): Promise<{ url: string }>;
+  resolveMediaUrl(url: string): { absPath: string };
+}
+
+const defaultDeps: MarkdownImageMaterializeDeps = {
+  realpath: (value) => fs.realpath(value),
+  stat: (value) => fs.stat(value),
+  readFile: (value) => fs.readFile(value),
+  ingest: async ({ buffer, mimeType, sessionId }) =>
+    ingestMedia({
+      buffer,
+      mimeType,
+      refs: [
+        {
+          refKind: 'session-attachment',
+          refId: sessionId,
+          originSessionId: sessionId,
+          originKind: 'tool',
+        },
+      ],
+    }),
+  resolveMediaUrl: (url) =>
+    url.startsWith('cindy-media://') ? resolveCindyMediaUrl(url) : resolveXdtImageUrl(url),
+};
+
+function isPathInside(parentAbs: string, childAbs: string): boolean {
+  const fold = (value: string): string =>
+    process.platform === 'win32' ? value.toLowerCase() : value;
+  const relative = path.relative(fold(path.resolve(parentAbs)), fold(path.resolve(childAbs)));
+  return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
+}
+
+function markdownLocalTarget(raw: string): string | null {
+  let target = raw.trim();
+  if (target.startsWith('<') && target.endsWith('>')) {
+    target = target.slice(1, -1).trim();
+  }
+  if (!target || target.includes('\0') || !path.isAbsolute(target)) return null;
+  return target;
+}
+
+function isManagedImageTarget(value: string): boolean {
+  return value.startsWith('cindy-media://') || value.startsWith('xdt-image://');
+}
+
+function pathKey(value: string): string {
+  const resolved = path.resolve(value);
+  return process.platform === 'win32' ? resolved.toLowerCase() : resolved;
+}
+
+interface MaterializedImage {
+  managedUrl?: string;
+}
+
+export interface MaterializedMarkdownImages {
+  /** 新增且未被 existingAbsPaths 去重的媒体仓绝对路径。 */
+  absPaths: string[];
+  /** 成功物化的本地图片目标改写为托管 URL。 */
+  managedText: string;
+  /** 成功物化的图片语法替换为 alt。 */
+  textWithoutImages: string;
+}
+
+export async function materializeMarkdownImages(
+  params: {
+    text: string;
+    workingDir: string;
+    sessionId: string;
+    maxImages?: number;
+    maxImageBytes?: number;
+    existingAbsPaths?: string[];
+    allowLocalPaths?: boolean;
+  },
+  deps: MarkdownImageMaterializeDeps = defaultDeps,
+): Promise<MaterializedMarkdownImages> {
+  const matches = Array.from(params.text.matchAll(MARKDOWN_IMAGE_RE));
+  if (matches.length === 0) {
+    return {
+      absPaths: [],
+      managedText: params.text,
+      textWithoutImages: params.text,
+    };
+  }
+
+  const maxImages = Math.max(0, params.maxImages ?? DEFAULT_MAX_IMAGES);
+  const maxImageBytes = params.maxImageBytes ?? DEFAULT_MAX_IMAGE_BYTES;
+  const materializedByRealPath = new Map<string, MaterializedImage>();
+  for (const existingPath of params.existingAbsPaths ?? []) {
+    let existingKey = existingPath;
+    try {
+      existingKey = await deps.realpath(existingPath);
+    } catch {
+      // 已回收文件仍占数量名额，避免同一轮继续追加更多附件。
+    }
+    materializedByRealPath.set(pathKey(existingKey), {
+      managedUrl: undefined,
+    });
+  }
+
+  const accepted = new Map<number, { alt: string; managedUrl?: string }>();
+  const absPaths: string[] = [];
+  let workingDirReal: string | null | undefined;
+
+  for (let index = 0; index < matches.length; index += 1) {
+    const match = matches[index];
+    const rawTarget = match[2].trim();
+    const managed = isManagedImageTarget(rawTarget);
+    const localTarget = managed ? null : markdownLocalTarget(rawTarget);
+    if (!managed && !localTarget) continue;
+    if (!managed && params.allowLocalPaths === false) continue;
+
+    try {
+      const resolvedSource = managed
+        ? deps.resolveMediaUrl(rawTarget).absPath
+        : (localTarget as string);
+      const sourceReal = await deps.realpath(resolvedSource);
+      if (!managed) {
+        if (workingDirReal === undefined) {
+          try {
+            workingDirReal = await deps.realpath(params.workingDir);
+          } catch {
+            workingDirReal = null;
+          }
+        }
+        if (!workingDirReal || !isPathInside(workingDirReal, sourceReal)) continue;
+      }
+
+      const dedupeKey = pathKey(sourceReal);
+      const existing = materializedByRealPath.get(dedupeKey);
+      if (existing) {
+        accepted.set(index, {
+          alt: match[1].trim() || '图片',
+          managedUrl: managed ? rawTarget : existing.managedUrl,
+        });
+        continue;
+      }
+      if (materializedByRealPath.size >= maxImages) continue;
+
+      const stat = await deps.stat(sourceReal);
+      if (!stat.isFile() || stat.size <= 0 || stat.size > maxImageBytes) continue;
+      const buffer = await deps.readFile(sourceReal);
+      if (buffer.byteLength !== stat.size || buffer.byteLength > maxImageBytes) continue;
+      const mimeType = sniffMediaMime(buffer);
+      if (!mimeType?.startsWith('image/')) continue;
+
+      let managedUrl = rawTarget;
+      let mediaAbsPath = sourceReal;
+      if (!managed) {
+        managedUrl = (
+          await deps.ingest({
+            buffer,
+            mimeType,
+            sessionId: params.sessionId,
+          })
+        ).url;
+        mediaAbsPath = deps.resolveMediaUrl(managedUrl).absPath;
+      }
+      materializedByRealPath.set(dedupeKey, {
+        managedUrl,
+      });
+      absPaths.push(mediaAbsPath);
+      accepted.set(index, {
+        alt: match[1].trim() || '图片',
+        managedUrl,
+      });
+    } catch {
+      // 单张失败保留原 Markdown，继续处理同一回复中的其它图片。
+    }
+  }
+
+  let managedText = params.text;
+  let textWithoutImages = params.text;
+  for (let index = matches.length - 1; index >= 0; index -= 1) {
+    const replacement = accepted.get(index);
+    if (!replacement) continue;
+    const match = matches[index];
+    const start = match.index;
+    if (start === undefined) continue;
+    textWithoutImages =
+      `${textWithoutImages.slice(0, start)}${replacement.alt}` +
+      textWithoutImages.slice(start + match[0].length);
+    if (replacement.managedUrl) {
+      const managedMarkdown = `![${match[1]}](${replacement.managedUrl})`;
+      managedText =
+        `${managedText.slice(0, start)}${managedMarkdown}` +
+        managedText.slice(start + match[0].length);
+    }
+  }
+
+  return { absPaths, managedText, textWithoutImages };
+}

--- a/apps/desktop/src/main/im/shared/localMarkdownImages.ts
+++ b/apps/desktop/src/main/im/shared/localMarkdownImages.ts
@@ -1,83 +1,14 @@
 /**
  * 将 Agent 最终 Markdown 中引用的图片安全转成 IM 可上传的绝对路径。
  *
- * Agent 可能直接在 session workingDir 内生成图片，再输出
- * `![alt](C:\\...\\image.png)`。这类路径不是 tool_result 中的托管 URL，
- * turnRunner 原本不会把它交给文本型 IM 渠道上传。这里仅接受真实路径仍位于
- * 当前 workingDir 内的普通图片文件，并在发送前复制进内容寻址媒体仓，避免
- * 任意路径读取、符号链接逃逸和校验后换文件。已经是 cindy-media / xdt-image
- * 的引用则通过各自的安全解析器取回仓内路径；两类都重新核验文件与图片魔数。
+ * 路径与图片校验由 cindy-media/markdownImages 统一实现；本适配器只选择
+ * “正文移除图片语法、图片作为附件发送”的 IM 展示形态。
  */
 
-import fs from 'node:fs/promises';
-import path from 'node:path';
-
-import { resolveSafe as resolveCindyMediaUrl } from '../../cindy-media/blobStore';
-import { ingestMedia } from '../../cindy-media/ingest';
-import { sniffMediaMime } from '../../cindy-media/sniffMediaMime';
-import { resolveSafe as resolveXdtImageUrl } from '../../imageCacheStore';
-
-const LOCAL_MARKDOWN_IMAGE_RE = /!\[([^\]\r\n]{0,512})\]\(([^)\r\n]{1,4096})\)/g;
-const DEFAULT_MAX_IMAGES = 4;
-const DEFAULT_MAX_IMAGE_BYTES = 20 * 1024 * 1024;
-
-interface LocalMarkdownImageDeps {
-  realpath(value: string): Promise<string>;
-  stat(value: string): Promise<{ isFile(): boolean; size: number }>;
-  readFile(value: string): Promise<Uint8Array>;
-  ingest(params: {
-    buffer: Uint8Array;
-    mimeType: string;
-    sessionId: string;
-  }): Promise<{ url: string }>;
-  resolveMediaUrl(url: string): { absPath: string };
-}
-
-const defaultDeps: LocalMarkdownImageDeps = {
-  realpath: (value) => fs.realpath(value),
-  stat: (value) => fs.stat(value),
-  readFile: (value) => fs.readFile(value),
-  ingest: async ({ buffer, mimeType, sessionId }) =>
-    ingestMedia({
-      buffer,
-      mimeType,
-      refs: [
-        {
-          refKind: 'session-attachment',
-          refId: sessionId,
-          originSessionId: sessionId,
-          originKind: 'tool',
-        },
-      ],
-    }),
-  resolveMediaUrl: (url) =>
-    url.startsWith('cindy-media://') ? resolveCindyMediaUrl(url) : resolveXdtImageUrl(url),
-};
-
-function isPathInside(parentAbs: string, childAbs: string): boolean {
-  const fold = (value: string): string =>
-    process.platform === 'win32' ? value.toLowerCase() : value;
-  const relative = path.relative(fold(path.resolve(parentAbs)), fold(path.resolve(childAbs)));
-  return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
-}
-
-function markdownLocalTarget(raw: string): string | null {
-  let target = raw.trim();
-  if (target.startsWith('<') && target.endsWith('>')) {
-    target = target.slice(1, -1).trim();
-  }
-  if (!target || target.includes('\0') || !path.isAbsolute(target)) return null;
-  return target;
-}
-
-function isManagedImageTarget(value: string): boolean {
-  return value.startsWith('cindy-media://') || value.startsWith('xdt-image://');
-}
-
-function pathKey(value: string): string {
-  const resolved = path.resolve(value);
-  return process.platform === 'win32' ? resolved.toLowerCase() : resolved;
-}
+import {
+  materializeMarkdownImages,
+  type MarkdownImageMaterializeDeps,
+} from '../../cindy-media/markdownImages';
 
 export interface MaterializedLocalMarkdownImages {
   /** 已成功物化的媒体仓绝对路径，供 IM 渠道上传。 */
@@ -96,100 +27,11 @@ export async function materializeLocalMarkdownImages(
     /** 已由 tool_result side-channel 收集的图片；参与总数限制与去重。 */
     existingAbsPaths?: string[];
   },
-  deps: LocalMarkdownImageDeps = defaultDeps,
+  deps?: MarkdownImageMaterializeDeps,
 ): Promise<MaterializedLocalMarkdownImages> {
-  const matches = Array.from(params.text.matchAll(LOCAL_MARKDOWN_IMAGE_RE));
-  if (matches.length === 0) return { absPaths: [], text: params.text };
-
-  const maxImages = Math.max(0, params.maxImages ?? DEFAULT_MAX_IMAGES);
-  const maxImageBytes = params.maxImageBytes ?? DEFAULT_MAX_IMAGE_BYTES;
-  const materializedByRealPath = new Map<string, string>();
-  for (const existingPath of params.existingAbsPaths ?? []) {
-    // 键必须与下面的查询同口径(pathKey(sourceReal),即 realpath 之后)。按原样入表
-    // 会让含符号链接的入参查不中,同一张受管图片被判成新图重复追加。
-    //
-    // 入参不保证已规范化:它们来自 turnRunner 的 handleToolResultFullEvent,经
-    // blobStore / imageCacheStore 的 resolveSafe 用 path.join / path.resolve 拼出
-    // `<userData>/cindy-media/blobs/…` 与 `<userData>/cc-agent/images/…`,两处都不做
-    // realpath。所以只要 userData 路径链上有软链或 junction(home 被重定位、Windows
-    // AppData 重定向、macOS home 挂在别的卷),生产上就会命中。
-    let existingKey = existingPath;
-    try {
-      existingKey = await deps.realpath(existingPath);
-    } catch {
-      // 文件已被回收:退回原样路径,至少让它继续占一个 maxImages 名额。
-    }
-    materializedByRealPath.set(pathKey(existingKey), existingPath);
-  }
-  const acceptedMatchIndexes = new Set<number>();
-  const absPaths: string[] = [];
-  let workingDirReal: string | null | undefined;
-
-  for (let index = 0; index < matches.length; index += 1) {
-    const match = matches[index];
-    const rawTarget = match[2].trim();
-    const managed = isManagedImageTarget(rawTarget);
-    const localTarget = managed ? null : markdownLocalTarget(rawTarget);
-    if (!managed && !localTarget) continue;
-
-    try {
-      const resolvedSource = managed
-        ? deps.resolveMediaUrl(rawTarget).absPath
-        : (localTarget as string);
-      const sourceReal = await deps.realpath(resolvedSource);
-      if (!managed) {
-        if (workingDirReal === undefined) {
-          try {
-            workingDirReal = await deps.realpath(params.workingDir);
-          } catch {
-            workingDirReal = null;
-          }
-        }
-        if (!workingDirReal || !isPathInside(workingDirReal, sourceReal)) continue;
-      }
-      const dedupeKey = pathKey(sourceReal);
-      const existing = materializedByRealPath.get(dedupeKey);
-      if (existing) {
-        acceptedMatchIndexes.add(index);
-        continue;
-      }
-      if (materializedByRealPath.size >= maxImages) continue;
-
-      const stat = await deps.stat(sourceReal);
-      if (!stat.isFile() || stat.size <= 0 || stat.size > maxImageBytes) continue;
-      const buffer = await deps.readFile(sourceReal);
-      if (buffer.byteLength !== stat.size || buffer.byteLength > maxImageBytes) continue;
-      const mimeType = sniffMediaMime(buffer);
-      if (!mimeType?.startsWith('image/')) continue;
-
-      const mediaAbsPath = managed
-        ? sourceReal
-        : deps.resolveMediaUrl(
-            (
-              await deps.ingest({
-                buffer,
-                mimeType,
-                sessionId: params.sessionId,
-              })
-            ).url,
-          ).absPath;
-      materializedByRealPath.set(dedupeKey, mediaAbsPath);
-      absPaths.push(mediaAbsPath);
-      acceptedMatchIndexes.add(index);
-    } catch {
-      // 单张失败保留原 Markdown，继续处理同一回复中的其它图片。
-    }
-  }
-
-  let text = params.text;
-  for (let index = matches.length - 1; index >= 0; index -= 1) {
-    if (!acceptedMatchIndexes.has(index)) continue;
-    const match = matches[index];
-    const start = match.index;
-    if (start === undefined) continue;
-    const replacement = match[1].trim() || '图片';
-    text = `${text.slice(0, start)}${replacement}${text.slice(start + match[0].length)}`;
-  }
-
-  return { absPaths, text };
+  const materialized = await materializeMarkdownImages(params, deps);
+  return {
+    absPaths: materialized.absPaths,
+    text: materialized.textWithoutImages,
+  };
 }

--- a/apps/desktop/src/main/learn-host/controller.ts
+++ b/apps/desktop/src/main/learn-host/controller.ts
@@ -1177,7 +1177,7 @@ function isRevisionTurnActivityEvent(ev: { type: string; data?: unknown }): bool
     ev.type === 'tool_result' ||
     ev.type === 'tool_result_full' ||
     ev.type === 'agent_task_update' ||
-    ev.type === 'image' ||
+    ev.type === 'image_output' ||
     ev.type === 'interaction_request' ||
     ev.type === 'compact_boundary'
   );

--- a/apps/desktop/src/main/localDb/ipc/messages.ts
+++ b/apps/desktop/src/main/localDb/ipc/messages.ts
@@ -1176,17 +1176,22 @@ export async function updateMessageContent(
   sessionId: string,
   clientId: string,
   content: unknown,
+  opts?: { onlyVisible?: boolean },
 ): Promise<Message | null> {
   const db = getDbClient().drizzle;
+  const where =
+    opts?.onlyVisible === true
+      ? and(
+          eq(messages.sessionId, sessionId),
+          eq(messages.clientId, clientId),
+          isNull(messages.rewindAt),
+        )
+      : and(eq(messages.sessionId, sessionId), eq(messages.clientId, clientId));
   await db
     .update(messages)
     .set({ content: safeStringify(content) })
-    .where(and(eq(messages.sessionId, sessionId), eq(messages.clientId, clientId)));
-  const [row] = await db
-    .select()
-    .from(messages)
-    .where(and(eq(messages.sessionId, sessionId), eq(messages.clientId, clientId)))
-    .limit(1);
+    .where(where);
+  const [row] = await db.select().from(messages).where(where).limit(1);
   if (row) {
     // 挂账钩子同样覆盖"先摘要 create、后全文 update"的 tool_result 顺序
     // (review P2:vendor 事件顺序一变,首现于 update 的 blob URL 若不在这里

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -165,7 +165,13 @@ import {
 } from './atAgentCatalog.js';
 import * as imageCacheStore from '../imageCacheStore.js';
 import * as cindyChatAttachments from '../cindy-media/chatAttachments.js';
-import { materializeGeneratedImage } from '../cindy-media/generatedMedia.js';
+import { fetchPublicImageBytes } from '../im/publicImageFetch.js';
+import {
+  createImageOutputToolPresentation,
+  isMaterializableImageOutput,
+  materializeOutputImage,
+  type ImageOutputSource,
+} from '../cindy-media/generatedMedia.js';
 import {
   getDbClient,
   isDbClientNotReadyError,
@@ -413,6 +419,7 @@ import {
   markAssistantTurnFailed,
   noteAgentMeta,
   noteSessionAgentKind,
+  noteSessionMarkdownImageContext,
   noteSessionClearBoundary,
   noteTurnStarted,
   onAssistantTextEvent,
@@ -427,9 +434,9 @@ import {
   onToolResultFullEvent,
   onToolUseEvent,
   preserveTurnPersistStateForBackground,
+  persistSyntheticToolExchange,
   markAutoResumeOutcome,
   onTurnErrorEvent,
-  prepareSyntheticToolEventForBroadcast,
   resetTurnPersistState,
   saveTurnStartedAtForDeferred,
 } from '../messagePersistBroadcaster.js';
@@ -2007,14 +2014,7 @@ function summarizeIpcUserMessage(message: IpcUserMessage): Record<string, unknow
   };
 }
 
-interface CodexImageEventData {
-  kind?: 'view' | 'generation';
-  blockId?: string;
-  path?: string;
-  url?: string;
-  revisedPrompt?: string;
-  status?: string;
-}
+type ImageOutputEventData = ImageOutputSource;
 
 /**
  * 待解决的 interaction 请求(permission/ask/plan 三合一)—— 用 promise 跨 IPC 边界。
@@ -3717,6 +3717,10 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
   // session-agent-switch:登记本会话当前引擎,broadcaster / user 行落库据此逐行
   // stamp messages.agent_kind(切换后历史行的 agent_meta 必须按写入时引擎解析)。
   noteSessionAgentKind(session.id, makerToDbAgentKind(session.agentKind));
+  noteSessionMarkdownImageContext(session.id, {
+    workingDir: session.workDir,
+    allowLocalPaths: !session.remoteHostId,
+  });
 
   // 订阅槽①旁听 tap(独立监听,叠加在主转发之外互不干扰):AgentEvent →
   // did-turn-*。资格(用户主会话)与自动化轮次过滤都在 tap 内部,这里零逻辑。
@@ -3802,8 +3806,10 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
         });
         return;
       }
-      if (event.type === 'image' && event.source === 'codex') {
-        void broadcastCodexImageAsToolResult(session.id, event);
+      if (event.type === 'image_output') {
+        void broadcastImageOutputAsToolResult(session.id, event, {
+          allowLocalPath: !session.remoteHostId,
+        });
         return;
       }
       if (event.type === 'plan_mode_changed') {
@@ -14371,111 +14377,70 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
   log.info('maker:* IPC handlers registered');
 }
 
-async function broadcastCodexImageAsToolResult(
+async function broadcastImageOutputAsToolResult(
   sessionId: string,
   event: AgentEvent,
+  opts: { allowLocalPath: boolean },
 ): Promise<void> {
-  const data = event.data as CodexImageEventData | null;
-  if (data?.kind !== 'generation') return;
+  const data = event.data as ImageOutputEventData | null;
+  if (!isMaterializableImageOutput(data)) return;
+  const createdAt = Date.now();
 
   try {
-    const cached = await materializeCodexImage(sessionId, data);
+    const cached = await materializeImageOutput(sessionId, data, opts);
     if (!cached) {
-      log.warn('codex image event missing materializable image', {
+      log.warn('image output event missing materializable image', {
         sessionId,
-        blockId: data.blockId,
+        outputId: data.outputId,
         hasPath: !!data.path,
         hasUrl: !!data.url,
+        allowLocalPath: opts.allowLocalPath,
       });
       return;
     }
 
-    const toolUseId = data.blockId || `codex-image-${Date.now()}`;
-    const toolInput = {
-      ...(data.revisedPrompt ? { prompt: data.revisedPrompt } : {}),
-      ...(data.status ? { status: data.status } : {}),
-    };
-    const fullText = JSON.stringify({
-      ok: true,
-      kind: 'generation',
-      text: 'image generated',
-      xdt_image_url: cached.url,
-      filename: cached.filename,
-      ...(data.revisedPrompt ? { revised_prompt: data.revisedPrompt } : {}),
-      ...(data.status ? { status: data.status } : {}),
-      ...(data.path ? { original_path: data.path } : {}),
-    });
+    const toolUseId = data.outputId;
+    const presentation = createImageOutputToolPresentation(data, cached);
 
-    broadcastSyntheticToolEvent(sessionId, {
-      type: 'tool_use',
-      source: 'codex',
-      agentMeta: event.agentMeta,
-      data: {
-        toolUseId,
-        toolName: 'imagegen',
-        input: toolInput,
-      },
-    } satisfies AgentEvent);
-    broadcastSyntheticToolEvent(sessionId, {
-      type: 'tool_result_full',
-      source: 'codex',
-      agentMeta: event.agentMeta,
-      data: {
-        toolUseId,
-        fullText,
-        isError: false,
-      },
-    } satisfies AgentEvent);
-    broadcastSyntheticToolEvent(sessionId, {
-      type: 'tool_result',
-      source: 'codex',
-      agentMeta: event.agentMeta,
-      data: {
-        summary: 'image generated',
-        toolUseIds: [toolUseId],
-      },
-    } satisfies AgentEvent);
-  } catch (err) {
-    log.warn('failed to materialize codex image event', {
+    persistSyntheticToolExchange({
       sessionId,
-      blockId: data?.blockId,
+      toolUseId,
+      toolName: presentation.toolName,
+      toolInput: presentation.toolInput,
+      resultContent: presentation.fullText,
+      agentMeta: (event.agentMeta as AgentMeta | null | undefined) ?? null,
+      createdAt,
+    });
+  } catch (err) {
+    log.warn('failed to materialize image output event', {
+      sessionId,
+      outputId: data?.outputId,
       error: err instanceof Error ? err.message : String(err),
     });
   }
 }
 
-function broadcastSyntheticToolEvent(
+async function materializeImageOutput(
   sessionId: string,
-  event: AgentEvent & { type: 'tool_use' | 'tool_result' | 'tool_result_full' },
-): void {
-  const prepared = prepareSyntheticToolEventForBroadcast(
-    sessionId,
-    { type: event.type, data: event.data },
-    (event.agentMeta as AgentMeta | null | undefined) ?? null,
-  );
-  broadcastToAllWindows(MAKER_PUSH.EVENT, {
-    sessionId,
-    event,
-    persistId: prepared.persistId,
-    resolvedContent: prepared.resolvedContent,
-  });
-}
-
-async function materializeCodexImage(
-  sessionId: string,
-  data: CodexImageEventData,
+  data: ImageOutputEventData,
+  opts: { allowLocalPath: boolean },
 ): Promise<{ url: string; filename: string } | null> {
-  // 规则 25:生成图入 cindy-media 总仓(零引用;合成 tool_result
+  // 规则 25:Agent 图片输出入 cindy-media 总仓(零引用;合成 tool_result
   // 消息落库时由 createMessage 的挂账钩子补 session-attachment 引用)。逻辑
   // 本体在 cindy-media/generatedMedia.ts(规则 14 可测),这里只做 thin adapter。
   try {
-    return await materializeGeneratedImage(data, {
-      ingestFromPath: cindyChatAttachments.ingestChatImageFromPath,
-      ingestBuffer: cindyChatAttachments.ingestChatImageBuffer,
-    });
+    return await materializeOutputImage(
+      data,
+      {
+        ingestFromPath: cindyChatAttachments.ingestChatImageFromPath,
+        ingestBuffer: cindyChatAttachments.ingestChatImageBuffer,
+        fetchRemoteImage: fetchPublicImageBytes,
+      },
+      opts,
+    );
   } catch (err) {
     // 白名单外 mime / 读盘失败:丢图不炸事件流(与旧行为的失败面一致)。
-    log.warn('materializeCodexImage: ingest failed, dropping image', {
+    log.warn('materializeImageOutput: ingest failed, dropping image', {
       sessionId,
       error: err instanceof Error ? err.message : String(err),
     });

--- a/apps/desktop/src/main/messagePersistBroadcaster.ts
+++ b/apps/desktop/src/main/messagePersistBroadcaster.ts
@@ -63,6 +63,7 @@ import {
 } from '@cindy/maker-shared/agent-task';
 import { normalizeSubagentObservation } from '@cindy/maker-shared/subagent-observation';
 import { stripInternalWebCitations } from '@cindy/maker-shared/internal-citation';
+import { materializeMarkdownImages } from './cindy-media/markdownImages.js';
 import { getSessionProvider } from './maker-host/session-provider-store.js';
 import type { AgentMeta } from '../renderer/lib/ccAgent.types';
 
@@ -124,12 +125,26 @@ type OwnerScope = ReturnType<typeof broadcastTap.captureDataOwnerBroadcastScope>
  */
 const dbAgentKindBySession = new Map<string, 'cc' | 'codex' | 'pi'>();
 
+interface SessionMarkdownImageContext {
+  workingDir: string;
+  allowLocalPaths: boolean;
+}
+
+const markdownImageContextBySession = new Map<string, SessionMarkdownImageContext>();
+
 export function noteSessionAgentKind(sessionId: string, dbAgentKind: 'cc' | 'codex' | 'pi'): void {
   dbAgentKindBySession.set(sessionId, dbAgentKind);
 }
 
 export function getSessionDbAgentKind(sessionId: string): 'cc' | 'codex' | 'pi' | null {
   return dbAgentKindBySession.get(sessionId) ?? null;
+}
+
+export function noteSessionMarkdownImageContext(
+  sessionId: string,
+  context: { workingDir: string; allowLocalPaths: boolean },
+): void {
+  markdownImageContextBySession.set(sessionId, { ...context });
 }
 
 function withAgentKindStamp(sessionId: string, body: CreateDbMessageBody): CreateDbMessageBody {
@@ -500,6 +515,11 @@ function enqueuePersistAssistant(
     agentMeta: agentMeta ?? null,
     createdAt,
   });
+  scheduleAssistantMarkdownImageMaterialization({
+    sessionId,
+    clientId,
+    content,
+  });
   notePersistedMessage(sessionId, 'assistant', clientId, content);
   lastAssistantPersistIdBySession.set(sessionId, clientId);
   if (
@@ -510,6 +530,61 @@ function enqueuePersistAssistant(
   ) {
     lastTopLevelAssistantPersistIdBySession.set(sessionId, clientId);
   }
+}
+
+function scheduleAssistantMarkdownImageMaterialization(params: {
+  sessionId: string;
+  clientId: string;
+  content: string;
+}): void {
+  if (!params.content.includes('![')) return;
+  const context = markdownImageContextBySession.get(params.sessionId);
+  if (!context) return;
+  const ownerScope = captureOwnerScope();
+
+  void materializeMarkdownImages({
+    text: params.content,
+    workingDir: context.workingDir,
+    sessionId: params.sessionId,
+    maxImages: 4,
+    allowLocalPaths: context.allowLocalPaths,
+  })
+    .then((materialized) => {
+      if (materialized.managedText === params.content) return;
+      if (markdownImageContextBySession.get(params.sessionId) !== context) return;
+      if (!isOwnerScopeCurrent(ownerScope)) return;
+
+      enqueueWrite(
+        `assistant_media:${params.sessionId}:${params.clientId}`,
+        async (writeOwnerScope) => {
+          if (markdownImageContextBySession.get(params.sessionId) !== context) return;
+          const updated = await updateDbMessageContent(
+            params.sessionId,
+            params.clientId,
+            materialized.managedText,
+            { onlyVisible: true },
+          );
+          if (!updated) return;
+          const clearBoundary = clearBoundaryBySession.get(params.sessionId);
+          const updatedAt = Date.parse(updated.createdAt);
+          if (
+            clearBoundary !== undefined &&
+            Number.isFinite(updatedAt) &&
+            updatedAt <= clearBoundary
+          ) {
+            return;
+          }
+          broadcastMessageRow(params.sessionId, updated, writeOwnerScope);
+        },
+      );
+    })
+    .catch((err) => {
+      log.warn('assistant markdown image materialization failed', {
+        sessionId: params.sessionId,
+        clientId: params.clientId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    });
 }
 
 /**
@@ -1155,47 +1230,54 @@ export function persistCodexPlanOnTerminalError(sessionId: string, turnId?: stri
 }
 
 /**
- * Main 侧合成 tool 事件也必须遵守 renderer 的展示契约:
- * tool_result / tool_result_full 只有带 persistId + resolvedContent 才会渲染。
+ * Persist a host-produced tool exchange without borrowing mutable provider-turn state.
  *
- * 普通 agent 事件在 maker-ipc/register.ts 的 session.onEvent 热路径里逐类调用
- * onToolUseEvent / onToolResultFullEvent / onToolResultEvent 后再 broadcast；但 Codex
- * imageGeneration、Mivo button action 等本地合成事件不一定经过那段分支。这个 helper
- * 把同一套持久化 / 内容归并逻辑暴露给合成事件,避免直接 broadcast 后 renderer no-op。
+ * Image materialization can finish after `done` has reset the live tool maps. Stable
+ * client ids and the captured source-event timestamp keep this exchange durable and
+ * correctly ordered without replaying synthetic AgentEvents through the turn pipeline.
  */
-export function prepareSyntheticToolEventForBroadcast(
-  sessionId: string,
-  event: { type: 'tool_use' | 'tool_result' | 'tool_result_full'; data: unknown },
-  agentMeta: AgentMeta | null,
-): { persistId?: string; resolvedContent?: string } {
-  if (agentMeta) noteAgentMeta(sessionId, agentMeta);
+export function persistSyntheticToolExchange(params: {
+  sessionId: string;
+  toolUseId: string;
+  toolName: string;
+  toolInput: unknown;
+  resultContent: string;
+  agentMeta: AgentMeta | null;
+  createdAt: number;
+}): { toolUseClientId: string; toolResultClientId: string } {
+  const toolUseClientId = createId();
+  const toolResultClientId = createId();
+  const meta = params.agentMeta ?? lastAgentMetaBySession.get(params.sessionId) ?? null;
+  const toolUseBody = withAgentKindStamp(params.sessionId, {
+    clientId: toolUseClientId,
+    role: 'tool_use',
+    content: {
+      toolUseId: params.toolUseId,
+      toolName: params.toolName,
+      input: params.toolInput,
+    },
+    toolUseId: params.toolUseId,
+    agentMeta: meta,
+    createdAt: params.createdAt,
+  });
+  const toolResultBody = withAgentKindStamp(params.sessionId, {
+    clientId: toolResultClientId,
+    role: 'tool_result',
+    content: params.resultContent,
+    toolUseId: params.toolUseId,
+    agentMeta: meta,
+    createdAt: params.createdAt + 1,
+  });
 
-  if (event.type === 'tool_use') {
-    flushAssistantBlock(sessionId, agentMeta);
-    return {
-      persistId: onToolUseEvent(
-        sessionId,
-        event.data as { toolUseId?: unknown; toolName?: unknown; input?: unknown },
-        agentMeta,
-      ),
-    };
-  }
-
-  if (event.type === 'tool_result_full') {
-    const r = onToolResultFullEvent(
-      sessionId,
-      event.data as { toolUseId?: unknown; fullText?: unknown },
-      agentMeta,
-    );
-    return { persistId: r?.persistId, resolvedContent: r?.content };
-  }
-
-  const r = onToolResultEvent(
-    sessionId,
-    event.data as { summary?: unknown; toolUseIds?: unknown },
-    agentMeta,
+  enqueueWrite(
+    `synthetic_tool_exchange:${params.sessionId}:${params.toolUseId}`,
+    async (ownerScope) => {
+      await createVisibleDbMessage(params.sessionId, toolUseBody, ownerScope);
+      await createVisibleDbMessage(params.sessionId, toolResultBody, ownerScope);
+    },
   );
-  return { persistId: r?.persistId, resolvedContent: r?.content };
+
+  return { toolUseClientId, toolResultClientId };
 }
 
 /**
@@ -1947,6 +2029,7 @@ export function clearSessionPersistState(sessionId: string): void {
   lastTopLevelAssistantPersistIdBySession.delete(sessionId);
   lastAssistantTranscriptUuidBySession.delete(sessionId);
   dbAgentKindBySession.delete(sessionId);
+  markdownImageContextBySession.delete(sessionId);
   _turnStartedAtBySession.delete(sessionId);
   _turnAttemptTokenBySession.delete(sessionId);
   _turnDedupIdBySession.delete(sessionId);

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -6205,7 +6205,7 @@ export class CodexAgent extends BaseAgent {
         event.type === 'tool_result' ||
         event.type === 'tool_result_full' ||
         event.type === 'agent_task_update' ||
-        event.type === 'image' ||
+        event.type === 'image_output' ||
         event.type === 'done'
       ) {
         return true;

--- a/packages/maker-core/src/agents/codex/translator.ts
+++ b/packages/maker-core/src/agents/codex/translator.ts
@@ -420,7 +420,7 @@ export function translateItemNotification(
       handlePlan(phase, item as unknown as PlanItem, queue, ctx);
       return;
     case 'imageView':
-      handleImageView(phase, item as unknown as ImageViewItem, queue);
+      // imageView 只表示模型为了推理读取图片，不代表要把图片交付给用户。
       return;
     case 'imageGeneration':
       handleImageGeneration(phase, item as unknown as ImageGenerationItem, queue);
@@ -870,13 +870,6 @@ interface CollabAgentToolCallItem {
   model?: string | null;
   reasoningEffort?: string | null;
   agentsStates: Record<string, unknown>;
-}
-
-// v2.rs ThreadItem::ImageView { id, path } — 模型读图 (本地绝对路径)。
-interface ImageViewItem {
-  type: 'imageView';
-  id: string;
-  path: string;
 }
 
 // v2.rs ThreadItem::ImageGeneration — 模型生成图; result 是 url/data URL, savedPath 落盘后才有。
@@ -2072,24 +2065,7 @@ function toCodexTaskUpdate(
   };
 }
 
-// ── imageView → image event (kind='view') ────────────────────────────────────
-// 模型读了一张本地图。codex 一般只发 completed (path 必有), started/updated 防御性同样发 — 同一
-// blockId, renderer 自己判重。
-
-function handleImageView(
-  phase: ItemPhase,
-  item: ImageViewItem,
-  queue: AsyncQueue<AgentEvent>,
-): void {
-  if (phase === 'updated') return;
-  queue.push({
-    type: 'image',
-    data: { kind: 'view', blockId: item.id, path: item.path },
-    source: 'codex',
-  });
-}
-
-// ── imageGeneration → image event (kind='generation') ────────────────────────
+// ── imageGeneration → provider-neutral image_output ─────────────────────────
 // 模型生成图。result 优先识别为 url (http/data 协议头) — 否则当 path 兜底 (codex 偶尔直接给本地路径
 // 不走 savedPath 字段)。savedPath 优先 path; 同时给 revisedPrompt / status 让 UI 显示生成参数。
 // started 阶段 result/savedPath 通常没填, 只发 completed。
@@ -2105,25 +2081,23 @@ function handleImageGeneration(
 ): void {
   if (phase !== 'completed') return;
   const data: {
-    kind: 'generation';
-    blockId: string;
+    outputId: string;
     path?: string;
     url?: string;
-    revisedPrompt?: string;
+    prompt?: string;
     status?: string;
   } = {
-    kind: 'generation',
-    blockId: item.id,
+    outputId: item.id,
     status: item.status,
   };
-  if (item.revisedPrompt) data.revisedPrompt = item.revisedPrompt;
+  if (item.revisedPrompt) data.prompt = item.revisedPrompt;
   if (item.savedPath) {
     data.path = item.savedPath;
   } else if (item.result) {
     if (isUrlLike(item.result)) data.url = item.result;
     else data.path = item.result;
   }
-  queue.push({ type: 'image', data, source: 'codex' });
+  queue.push({ type: 'image_output', data, source: 'codex' });
 }
 
 // ── contextCompaction → compact_boundary ─────────────────────────────────────

--- a/packages/maker-core/src/types/events.ts
+++ b/packages/maker-core/src/types/events.ts
@@ -20,7 +20,7 @@ export type AgentEventType =
   | 'tool_result'           // 工具调用结果（精简，UI 内嵌显示）
   | 'tool_result_full'      // 工具调用结果（完整，UI 详情面板用）
   | 'agent_task_update'     // 子 agent / task 状态更新（Claude Code task_* + Codex collab agent）
-  | 'image'                 // 模型查看 / 生成的图片 (codex 独有, claude SDK 不会发)
+  | 'image_output'          // Agent 明确交付给用户的图片输出
   | 'account_usage'         // vendor-specific 账号级用量 (codex rateLimits 等); data shape 由 emit 端自定, renderer 按 source/字段嗅探
   | 'turn_diff'             // provider 对本轮工作区变更的累计 unified diff
   | 'interaction_request'   // 需要用户决策(permission / ask_user_question / plan_review)
@@ -326,26 +326,19 @@ export interface UsageSnapshot {
 }
 
 /**
- * 'image' event 的 data 形状 — codex 独有 (claude-code SDK 没有图像生成能力)。
- *
- * 两种 kind:
- *  - 'view':       模型读了一张图 (codex ImageView item, 只有 path)
- *  - 'generation': 模型生成了一张图 (codex ImageGeneration item)
- *
- * path / url 至少有一个 — view 一律走 path; generation 落盘了走 path, 否则 url
- * (codex 偶尔返 base64 data URL, renderer 自己识别协议头处理)。
+ * Agent 明确交付给用户的图片输出。Provider adapter 只在 vendor 事件本身表达
+ * “这是输出产物”时发出；模型为推理读取图片、截图或附件不属于本事件。
  */
-export interface ImageEventData {
-  kind: 'view' | 'generation';
-  /** ThreadItem id, 同一 item 的 started→completed 复用同一个 blockId 让 UI 合并。 */
-  blockId: string;
-  /** 本地绝对路径 (imageView 一定有, imageGeneration.savedPath 才有)。 */
+export interface ImageOutputEventData {
+  /** Provider item id，用于持久化与展示去重。 */
+  outputId: string;
+  /** 本地绝对路径。主机仍须校验会话来源与允许的路径边界。 */
   path?: string;
-  /** 远程 url 或 data URL (imageGeneration.result 没落盘时)。 */
+  /** 托管 URL、远程 URL 或 data URL。主机负责最终可接受协议校验。 */
   url?: string;
-  /** generation 才有: 模型实际用的 prompt (常被 OpenAI 改写过)。 */
-  revisedPrompt?: string;
-  /** generation 状态 (codex 不固定枚举, 透传字符串)。 */
+  /** Provider 实际使用的生成提示词（若提供）。 */
+  prompt?: string;
+  /** Provider 输出状态（若提供）。 */
   status?: string;
 }
 


### PR DESCRIPTION
## 这次改了什么

### 摘要

本 PR 将图片交付从 Codex 专用的 `imageView` 补丁改为 Provider-neutral 能力：

- maker-core 新增语义事件 `image_output`，只表示 Agent 明确交付给用户的图片产物。
- Codex `imageGeneration` 适配为 `image_output`；`imageView` 仅表示模型内部读图，不再错误地展示给用户。
- Desktop 对 `image_output` 统一物化到 `cindy-media`，并直接持久化稳定的 `tool_use` / `tool_result` 消息对，不依赖可能在 `done` 后被清理的轮次缓存。
- Claude Code、Codex、Pi 的最终 Assistant Markdown 共用同一套本地图片物化逻辑：合法本地图片路径改写为 `cindy-media://`，因此二维码和生成图片可作为消息内容跨窗口、重载和设备展示。

### 安全与来源边界

- 本地 Markdown 图片只允许 canonical working directory 内的绝对路径。
- 拒绝目录外路径、符号链接逃逸、非普通文件、超限文件和图片魔数不匹配。
- SSH 会话禁止把远端绝对路径当作 Desktop 本机路径读取。
- `https:` 图片输出复用现有逐跳 SSRF 防护下载器，并按实际图片魔数入仓；`http:` fail closed。
- 新媒体写入继续使用 `cindy-media`；Renderer 不参与路径授权或文件读取。
- 不解析任意 shell/exec 文本中的路径，也不引入通用 Artifact 框架。

### 变更类型

- [x] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护

### 多端结论

- **Desktop**：本地 Agent 最终 Markdown 图片与显式 `image_output` 均可进入现有图片消息展示链路。
- **Mobile**：未修改 Mobile renderer；消息持久化为现有 `cindy-media` / tool-result 契约，继续复用现有同步与媒体解析能力。
- **SSH**：不读取控制端同名绝对路径。远端若要交付图片，必须提供可安全获取的托管/HTTPS 地址或走既有远端媒体能力。

### 性能与 Agent 行为

- 不修改 system prompt、prompt cache、上下文组装或模型调用参数。
- Codex translator 只新增显式生成图输出，并丢弃非用户可见的 `imageView` 展示事件。
- 文件读取、HTTPS 下载和媒体入仓均在异步路径执行；Agent event 热路径不增加同步 I/O。
- 最终 Markdown 无图片语法时直接返回，不触发物化工作。

## 怎么验证的

### 通过

```text
pnpm --filter desktop exec vitest run \
  src/main/__tests__/codexTranslator.test.ts \
  src/main/__tests__/messagePersistBroadcaster.test.ts \
  src/main/cindy-media/__tests__/generatedMedia.test.ts \
  src/main/cindy-media/__tests__/markdownImages.test.ts \
  src/main/im/shared/__tests__/localMarkdownImages.test.ts
结果：5 个文件，156 个测试通过

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --filter @cindy/maker-core run --if-present typecheck
结果：通过

pnpm test:unit:related
结果：maker-core related、lizi-mcps、orca-workflow 通过；Desktop 27,452 通过、5 skipped、2 个基线失败（见下）

pnpm check:dco
结果：1 个 commit DCO sign-off 通过

git diff --check
结果：通过
```

针对本次新模块、测试和 maker-core 变更的 ESLint 通过。`register.ts` / `messages.ts` 整文件 lint 仍会报告 5 个本次 diff 外的既有 unused-variable 错误。

### 已确认的基线失败

`apps/desktop/src/main/cindy-brain/__tests__/ghostInstallReceipt.test.ts` 有 2 个 receipt 兼容用例失败，均返回 `state: invalid`。同一测试在未修改的基线 commit `163bee9af` worktree 中可稳定复现；本 PR 未修改 Ghost、receipt 或 plugin-protocol 调用链。

### 未执行

- 未启动完整 Desktop UI 做真实 Provider 往返。
- 未连接真实 SSH 主机；远端路径 fail-closed 行为由单测覆盖。
- 未做 Mobile 真机验证；Mobile 代码与 runtime fingerprint 未变。

## 风险与回滚

- [x] 协议兼容：`AgentEventType` 从 Codex 专用 `image` 收口为 `image_output`。
- [x] 权限 / 安全 / 用户数据：主进程负责路径、来源、大小和图片类型校验。
- [x] 跨平台差异：本地绝对路径与 canonical containment 使用 Node 平台路径语义。
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 原生层 / fingerprint / OTA

回滚本提交即可恢复旧行为；无 schema、migration 或持久数据格式变更。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] 未提交凭证、令牌或授权文件
- [x] 已记录通过项、未执行项和基线失败