### PR TITLE
fix(orca): bridge worker terminal diagnostics to lead

### DIFF
--- a/apps/desktop/src/main/maker-ipc/__tests__/orcaTeamService.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/orcaTeamService.test.ts
@@ -1007,6 +1007,28 @@ describe('OrcaTeamService', () => {
     expect(leadMessages).toEqual(['[Auto-bridged: worker 完成但未调 send_to_lead]\n\n部分输出']);
   });
 
+  it('bridges the terminal diagnostic when an errored worker produced no output', async () => {
+    const leadMessages: string[] = [];
+    const { service } = createDeps({
+      sendAutoBridgeToLead: vi.fn(async (_leadSessionId, message) => {
+        leadMessages.push(message);
+        return { accepted: true };
+      }),
+    });
+
+    await service.sendToWorker({ callerLeadSessionId: 'lead-1', targetSessionId: 'worker-session-1', message: '只读审计' });
+    await service.handleWorkerTerminalTurn({
+      sessionId: 'worker-session-1',
+      status: 'error',
+      finalText: '',
+      diagnostic: 'Claude session exited before producing a result',
+    });
+
+    expect(leadMessages).toEqual([
+      '[Auto-bridged: worker 异常终止]\n\nClaude session exited before producing a result',
+    ]);
+  });
+
   it('marks worker idle and clears bridge state before closing its session', async () => {
     const { calls, service, setWorker } = createDeps();
     setWorker(createWorker({ status: 'running' }));

--- a/apps/desktop/src/main/maker-ipc/orcaTeamService.ts
+++ b/apps/desktop/src/main/maker-ipc/orcaTeamService.ts
@@ -169,6 +169,8 @@ export interface WorkerTerminalTurnParams {
   sessionId: string;
   status: 'done' | 'error';
   finalText: string;
+  /** Provider/session diagnostic used when an error turn has no assistant output. */
+  diagnostic?: string;
 }
 
 /** INPUT_STOP / ABORT_SESSION 记录的手动中断快照，用来让 terminal handler 静默收尾。 */
@@ -280,6 +282,7 @@ interface AutoBridgeState {
   deferred?: {
     status: 'done' | 'error';
     finalText: string;
+    diagnostic?: string;
   };
 }
 
@@ -398,7 +401,7 @@ export function createOrcaTeamService(deps: OrcaTeamServiceDeps): OrcaTeamServic
 
   async function bridgeWorkerCompletion(
     sessionId: string,
-    turn: { status: 'done' | 'error'; finalText: string },
+    turn: { status: 'done' | 'error'; finalText: string; diagnostic?: string },
   ): Promise<'accepted' | 'deferred' | 'rejected' | 'skipped'> {
     const state = autoBridge.get(sessionId);
     if (!state) return 'skipped';
@@ -411,7 +414,11 @@ export function createOrcaTeamService(deps: OrcaTeamServiceDeps): OrcaTeamServic
     state.inFlight = true;
     state.retryAfterRejectedDelivery = false;
     const version = state.version;
-    const finalText = turn.finalText || (state.capturedText.trim().length > 0 ? state.capturedText.trim() : '(no output captured)');
+    const finalText =
+      turn.finalText.trim() ||
+      state.capturedText.trim() ||
+      turn.diagnostic?.trim() ||
+      '(no output captured)';
     const header = turn.status === 'error'
       ? '[Auto-bridged: worker 异常终止]'
       : '[Auto-bridged: worker 完成但未调 send_to_lead]';
@@ -1033,6 +1040,7 @@ export function createOrcaTeamService(deps: OrcaTeamServiceDeps): OrcaTeamServic
           await bridgeWorkerCompletion(params.sessionId, {
             status: params.status,
             finalText: params.finalText,
+            diagnostic: params.diagnostic,
           });
           return;
         }
@@ -1060,6 +1068,7 @@ export function createOrcaTeamService(deps: OrcaTeamServiceDeps): OrcaTeamServic
       await bridgeWorkerCompletion(params.sessionId, {
         status: params.status,
         finalText: params.finalText,
+        diagnostic: params.diagnostic,
       });
     },
   };

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -4405,16 +4405,31 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
         if (!isContinuationBoundary) {
           void (async () => {
             try {
-              const doneData = event.data as { result?: unknown } | null;
+              const doneData = event.data as {
+                result?: unknown;
+                message?: unknown;
+                sdkError?: unknown;
+                reason?: unknown;
+                error?: { message?: unknown };
+              } | null;
               const finalText =
                 typeof doneData?.result === 'string' && doneData.result.length > 0
                   ? doneData.result
                   : '';
+              const diagnostic = isTerminalTurnErrorEvent(event)
+                ? [
+                    doneData?.message,
+                    doneData?.sdkError,
+                    doneData?.reason,
+                    doneData?.error?.message,
+                  ].find((value): value is string => typeof value === 'string' && value.trim().length > 0)
+                : undefined;
               await workerTurnStartSequencer.waitForStart(session.id);
               await orcaTeamServiceForEvents?.handleWorkerTerminalTurn({
                 sessionId: session.id,
                 status: isTerminalTurnErrorEvent(event) ? 'error' : 'done',
                 finalText,
+                diagnostic,
               });
             } catch {
               /* non-fatal */


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 #3098：Orca worker 在成功派发后异常终止且没有 assistant 输出时，Lead 之前只能收到 (no output captured)。现在会把终止事件中的诊断信息传递给 Lead，帮助区分启动、模型、凭证、权限和 session 异常。

### 变更类型

- [x] fix 缺陷修复

### 范围

- 关联 Issue / 需求：#3098
- 本 PR 包含：终止诊断从 Desktop event adapter 到 OrcaTeamService 的传递及回归测试
- 明确不包含：协议、数据库、权限策略和 Lead UI
- 用户可见变化：Lead 收到更具体的 worker 失败原因
- 是否存在 breaking change：无；诊断字段保持可选，旧 fallback 保留

### UI 变化

不涉及：仅修改主进程事件适配和 Orca 服务内部的诊断传递，不改变 UI 组件、布局或交互。

- 引用的设计规范：不涉及 UI。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/maker-ipc/__tests__/orcaTeamService.test.ts → 71/71 通过
pnpm --filter desktop typecheck → 通过
git diff --check → 通过
```

验证环境：cindy-issue3098-20260820-1。

### 手工验证

不涉及：本 PR 无 UI 变化；通过 Orca service 定向测试验证诊断桥接。

### 未执行的验证

未执行真实多进程 Orca 打包版冒烟；自动化测试覆盖无 assistant 输出的异常终止、诊断优先级和 at-most-once 行为。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围：仅 worker 终止信息的 Lead bridge 文案。
- 回滚 / 降级方式：诊断字段是可选的；回滚提交或诊断缺失时继续使用 (no output captured) 兼容 fallback。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已确认测试结果或说明未执行原因