### PR TITLE
fix(desktop): preserve parallel permission requests

### DIFF
--- a/apps/desktop/src/renderer/__tests__/deviceLinkInteractionScenarios.test.ts
+++ b/apps/desktop/src/renderer/__tests__/deviceLinkInteractionScenarios.test.ts
@@ -310,6 +310,30 @@ describe('device-link 远程交互往返 — permission', () => {
       decision: { kind: 'permission', behavior: 'deny', reason: '不允许' },
     });
   });
+
+  it('authoritative permission snapshot replaces a stale displayed request after reconnect', async () => {
+    const s = openRemoteSession();
+    host.hostInteraction(s, {
+      kind: 'permission',
+      requestId: 'stale-permission',
+      toolName: 'Read',
+      input: { file_path: '/stale.txt' },
+    });
+    await flush();
+
+    // The renderer missed the dismissal for A. The host snapshot is now the
+    // source of truth and contains only B, which must become the visible head.
+    host.seedPending(s, {
+      kind: 'permission',
+      requestId: 'fresh-permission',
+      toolName: 'Read',
+      input: { file_path: '/fresh.txt' },
+    });
+    await makerChatStore.reconcilePendingInteractions(s);
+
+    expect(makerChatStore.getSnapshot(s).pendingPermission?.requestId).toBe('fresh-permission');
+    expect(makerChatStore.getSnapshot(s).pendingPermissionQueue).toEqual([]);
+  });
 });
 
 describe('device-link 远程交互往返 — plan_review', () => {

--- a/apps/desktop/src/renderer/__tests__/deviceLinkInteractionScenarios.test.ts
+++ b/apps/desktop/src/renderer/__tests__/deviceLinkInteractionScenarios.test.ts
@@ -363,7 +363,7 @@ describe('device-link 远程交互往返 — permission', () => {
     expect(makerChatStore.getSnapshot(s).pendingPermission).toBeNull();
   });
 
-  it('dismissal 释放防重 guard:对端已解决 A 后,用户对新卡 B 的响应不再被吞', async () => {
+  it('dismissal 重新武装防重 guard:窗口内 A 的迟到输入不误批 B,窗口结束后 B 可正常响应', async () => {
     const s = openRemoteSession();
     host.hostInteraction(s, {
       kind: 'permission',
@@ -380,8 +380,9 @@ describe('device-link 远程交互往返 — permission', () => {
     await flush();
 
     // 本端提交 A 后回程丢失,另一控制端解决 A → 被控端广播 dismissal 推进到 B。
-    // 此时旧 resolve RPC 仍未 settle(隧道可达 ~30s),guard 若继续挂着,
-    // 用户对 B 的响应会被静默丢弃;dismissal 必须立即释放 guard。
+    // main 在 resolve A 时同步广播 dismissal;若此刻清除 guard,双击第二击会
+    // 读到刚推广的 B 并误批(security P1)。正确语义:重新武装窗口 —— 窗口内
+    // A 的迟到输入仍被挡下,窗口结束后 B 的真实响应不受旧 RPC 阻塞。
     makerChatStore.respondToPermission(s, { behavior: 'allow' });
     await flush();
     host.hostDismiss(s, 'dismiss-guard-a', 'resolved', { behavior: 'allow' });
@@ -389,7 +390,14 @@ describe('device-link 远程交互往返 — permission', () => {
 
     expect(makerChatStore.getSnapshot(s).pendingPermission?.requestId).toBe('dismiss-guard-b');
 
-    // 防重窗口未结束(300ms)也不得拦截: dismissal 已终结 A 的响应链。
+    // 窗口未结束(300ms):A 的迟到输入不得误批 B。
+    makerChatStore.respondToPermission(s, { behavior: 'allow' });
+    await flush();
+    expect(host.resolved.map((item) => item.requestId)).toEqual(['dismiss-guard-a']);
+    expect(makerChatStore.getSnapshot(s).pendingPermission?.requestId).toBe('dismiss-guard-b');
+
+    // 窗口结束后:用户对 B 的真实响应送达(不等旧 RPC ~30s 超时)。
+    await waitPastPermissionGuardWindow();
     makerChatStore.respondToPermission(s, { behavior: 'allow' });
     await flush();
     expect(host.resolved.map((item) => item.requestId)).toEqual([

--- a/apps/desktop/src/renderer/__tests__/deviceLinkInteractionScenarios.test.ts
+++ b/apps/desktop/src/renderer/__tests__/deviceLinkInteractionScenarios.test.ts
@@ -262,6 +262,38 @@ describe('device-link 远程交互往返 — permission', () => {
     expect(makerChatStore.getSnapshot(s).pendingPermission).toBeNull();
   });
 
+  it('同一会话并行 permission 按 FIFO 展示和回传,不会丢掉先到的请求', async () => {
+    const s = openRemoteSession();
+    host.hostInteraction(s, {
+      kind: 'permission',
+      requestId: 'parallel-first',
+      toolName: 'Read',
+      input: { file_path: '/outside/first.md' },
+    });
+    host.hostInteraction(s, {
+      kind: 'permission',
+      requestId: 'parallel-second',
+      toolName: 'Read',
+      input: { file_path: '/outside/second.md' },
+    });
+    await flush();
+
+    expect(makerChatStore.getSnapshot(s).pendingPermission?.requestId).toBe('parallel-first');
+
+    makerChatStore.respondToPermission(s, { behavior: 'allow' });
+    await flush();
+    expect(host.resolved[0]?.requestId).toBe('parallel-first');
+    expect(makerChatStore.getSnapshot(s).pendingPermission?.requestId).toBe('parallel-second');
+
+    makerChatStore.respondToPermission(s, { behavior: 'allow' });
+    await flush();
+    expect(host.resolved.map((item) => item.requestId)).toEqual([
+      'parallel-first',
+      'parallel-second',
+    ]);
+    expect(makerChatStore.getSnapshot(s).pendingPermission).toBeNull();
+  });
+
   it('permission deny 同样经隧道回传 behavior=deny', async () => {
     const s = openRemoteSession();
     host.hostInteraction(s, {

--- a/apps/desktop/src/renderer/__tests__/deviceLinkInteractionScenarios.test.ts
+++ b/apps/desktop/src/renderer/__tests__/deviceLinkInteractionScenarios.test.ts
@@ -447,6 +447,50 @@ describe('device-link 远程交互往返 — permission', () => {
     expect(makerChatStore.getSnapshot(s).pendingPermission?.requestId).toBe('fresh-permission');
     expect(makerChatStore.getSnapshot(s).pendingPermissionQueue).toEqual([]);
   });
+
+  it('reconnect snapshot A-B rearm guard: A delayed input does not approve B, then B actionable', async () => {
+    const s = openRemoteSession();
+    host.hostInteraction(s, {
+      kind: 'permission',
+      requestId: 'reconnect-guard-a',
+      toolName: 'Read',
+      input: { file_path: '/a.txt' },
+    });
+    await flush();
+
+    // A is in flight: the response guard is armed for the session.
+    makerChatStore.respondToPermission(s, { behavior: 'allow' });
+    await flush();
+    expect(host.resolved.map((item) => item.requestId)).toEqual(['reconnect-guard-a']);
+
+    // Reconnect: the authoritative snapshot replaces A with B. The stale
+    // displayed request must be dropped and B promoted.
+    host.seedPending(s, {
+      kind: 'permission',
+      requestId: 'reconnect-guard-b',
+      toolName: 'Read',
+      input: { file_path: '/b.txt' },
+    });
+    await makerChatStore.reconcilePendingInteractions(s);
+    await flush();
+    expect(makerChatStore.getSnapshot(s).pendingPermission?.requestId).toBe('reconnect-guard-b');
+
+    // Within the gesture window, A's delayed double-click must NOT approve B.
+    makerChatStore.respondToPermission(s, { behavior: 'allow' });
+    await flush();
+    expect(host.resolved.map((item) => item.requestId)).toEqual(['reconnect-guard-a']);
+    expect(makerChatStore.getSnapshot(s).pendingPermission?.requestId).toBe('reconnect-guard-b');
+
+    // After the window, B's real response is delivered.
+    await waitPastPermissionGuardWindow();
+    makerChatStore.respondToPermission(s, { behavior: 'allow' });
+    await flush();
+    expect(host.resolved.map((item) => item.requestId)).toEqual([
+      'reconnect-guard-a',
+      'reconnect-guard-b',
+    ]);
+    expect(makerChatStore.getSnapshot(s).pendingPermission).toBeNull();
+  });
 });
 
 describe('device-link 远程交互往返 — plan_review', () => {

--- a/apps/desktop/src/renderer/__tests__/deviceLinkInteractionScenarios.test.ts
+++ b/apps/desktop/src/renderer/__tests__/deviceLinkInteractionScenarios.test.ts
@@ -363,6 +363,42 @@ describe('device-link 远程交互往返 — permission', () => {
     expect(makerChatStore.getSnapshot(s).pendingPermission).toBeNull();
   });
 
+  it('dismissal 释放防重 guard:对端已解决 A 后,用户对新卡 B 的响应不再被吞', async () => {
+    const s = openRemoteSession();
+    host.hostInteraction(s, {
+      kind: 'permission',
+      requestId: 'dismiss-guard-a',
+      toolName: 'Read',
+      input: { file_path: '/a.txt' },
+    });
+    host.hostInteraction(s, {
+      kind: 'permission',
+      requestId: 'dismiss-guard-b',
+      toolName: 'Read',
+      input: { file_path: '/b.txt' },
+    });
+    await flush();
+
+    // 本端提交 A 后回程丢失,另一控制端解决 A → 被控端广播 dismissal 推进到 B。
+    // 此时旧 resolve RPC 仍未 settle(隧道可达 ~30s),guard 若继续挂着,
+    // 用户对 B 的响应会被静默丢弃;dismissal 必须立即释放 guard。
+    makerChatStore.respondToPermission(s, { behavior: 'allow' });
+    await flush();
+    host.hostDismiss(s, 'dismiss-guard-a', 'resolved', { behavior: 'allow' });
+    await flush();
+
+    expect(makerChatStore.getSnapshot(s).pendingPermission?.requestId).toBe('dismiss-guard-b');
+
+    // 防重窗口未结束(300ms)也不得拦截: dismissal 已终结 A 的响应链。
+    makerChatStore.respondToPermission(s, { behavior: 'allow' });
+    await flush();
+    expect(host.resolved.map((item) => item.requestId)).toEqual([
+      'dismiss-guard-a',
+      'dismiss-guard-b',
+    ]);
+    expect(makerChatStore.getSnapshot(s).pendingPermission).toBeNull();
+  });
+
   it('permission deny 同样经隧道回传 behavior=deny', async () => {
     const s = openRemoteSession();
     host.hostInteraction(s, {

--- a/apps/desktop/src/renderer/__tests__/deviceLinkInteractionScenarios.test.ts
+++ b/apps/desktop/src/renderer/__tests__/deviceLinkInteractionScenarios.test.ts
@@ -206,6 +206,9 @@ function emptyProjection(sessionId: string) {
 }
 
 const flush = () => new Promise((r) => setTimeout(r, 0));
+// 等待超过 permissionResponseInFlight 的防重窗口(500ms),模拟用户读完下一张卡后
+// 才做下一次批准;guard 未释放时第二次响应会被当作同一手势的重复输入挡下。
+const waitPastPermissionGuardWindow = () => new Promise((r) => setTimeout(r, 560));
 const DEVICE_ID = 'dev-int-scn';
 let n = 0;
 const sid = () => `int-scn-${n++}`;
@@ -285,6 +288,9 @@ describe('device-link 远程交互往返 — permission', () => {
     expect(host.resolved[0]?.requestId).toBe('parallel-first');
     expect(makerChatStore.getSnapshot(s).pendingPermission?.requestId).toBe('parallel-second');
 
+    // 这是两次独立的用户手势(读完第二张卡再批):必须等防重窗口结束,
+    // 否则第二次响应会被当作双击重复输入挡下。
+    await waitPastPermissionGuardWindow();
     makerChatStore.respondToPermission(s, { behavior: 'allow' });
     await flush();
     expect(host.resolved.map((item) => item.requestId)).toEqual([
@@ -317,6 +323,44 @@ describe('device-link 远程交互往返 — permission', () => {
 
     expect(host.resolved.map((item) => item.requestId)).toEqual(['duplicate-first']);
     expect(makerChatStore.getSnapshot(s).pendingPermission?.requestId).toBe('duplicate-second');
+  });
+
+  it('双击第二击在 IPC 已 settle 后到达也不能误批推广后的新卡', async () => {
+    const s = openRemoteSession();
+    host.hostInteraction(s, {
+      kind: 'permission',
+      requestId: 'async-double-first',
+      toolName: 'Read',
+      input: { file_path: '/first.txt' },
+    });
+    host.hostInteraction(s, {
+      kind: 'permission',
+      requestId: 'async-double-second',
+      toolName: 'Read',
+      input: { file_path: '/second.txt' },
+    });
+    await flush();
+
+    // 第一次点击:IPC 同步 handler 让 Promise 很快 settle(guard 已释放前
+    // 的窗口由防重窗口覆盖)。第二次点击在 IPC settle 之后、防重窗口之内到达。
+    makerChatStore.respondToPermission(s, { behavior: 'allow' });
+    await flush(); // 此刻 IPC 已 settle,但 guard 仍应保持(窗口未结束)
+    makerChatStore.respondToPermission(s, { behavior: 'deny', message: 'double-click' });
+    await flush();
+
+    // 第二次输入被防重窗口挡下,只能批掉第一张卡,第二张卡仍挂起。
+    expect(host.resolved.map((item) => item.requestId)).toEqual(['async-double-first']);
+    expect(makerChatStore.getSnapshot(s).pendingPermission?.requestId).toBe('async-double-second');
+
+    // 防重窗口结束后,用户对新卡的正常批准仍可进行。
+    await waitPastPermissionGuardWindow();
+    makerChatStore.respondToPermission(s, { behavior: 'allow' });
+    await flush();
+    expect(host.resolved.map((item) => item.requestId)).toEqual([
+      'async-double-first',
+      'async-double-second',
+    ]);
+    expect(makerChatStore.getSnapshot(s).pendingPermission).toBeNull();
   });
 
   it('permission deny 同样经隧道回传 behavior=deny', async () => {

--- a/apps/desktop/src/renderer/__tests__/deviceLinkInteractionScenarios.test.ts
+++ b/apps/desktop/src/renderer/__tests__/deviceLinkInteractionScenarios.test.ts
@@ -294,6 +294,31 @@ describe('device-link 远程交互往返 — permission', () => {
     expect(makerChatStore.getSnapshot(s).pendingPermission).toBeNull();
   });
 
+  it('duplicate permission response cannot authorize the promoted queue head', async () => {
+    const s = openRemoteSession();
+    host.hostInteraction(s, {
+      kind: 'permission',
+      requestId: 'duplicate-first',
+      toolName: 'Read',
+      input: { file_path: '/first.txt' },
+    });
+    host.hostInteraction(s, {
+      kind: 'permission',
+      requestId: 'duplicate-second',
+      toolName: 'Read',
+      input: { file_path: '/second.txt' },
+    });
+    await flush();
+
+    // Two synchronous approval commands model a double-click / key repeat.
+    makerChatStore.respondToPermission(s, { behavior: 'allow' });
+    makerChatStore.respondToPermission(s, { behavior: 'deny', message: 'duplicate' });
+    await flush();
+
+    expect(host.resolved.map((item) => item.requestId)).toEqual(['duplicate-first']);
+    expect(makerChatStore.getSnapshot(s).pendingPermission?.requestId).toBe('duplicate-second');
+  });
+
   it('permission deny 同样经隧道回传 behavior=deny', async () => {
     const s = openRemoteSession();
     host.hostInteraction(s, {

--- a/apps/desktop/src/renderer/__tests__/makerQueueState.test.ts
+++ b/apps/desktop/src/renderer/__tests__/makerQueueState.test.ts
@@ -89,6 +89,7 @@ const state = (overrides: Partial<SessionChatState> = {}): SessionChatState => (
   historyLoaded: true,
   sdkSessionId: null,
   pendingPermission: null,
+  pendingPermissionQueue: [],
   pendingAskUser: null,
   askUserViewerState: 'expanded',
   askUserDraft: null,

--- a/apps/desktop/src/renderer/components/new-chat/PermissionPrompt.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/PermissionPrompt.tsx
@@ -134,7 +134,14 @@ export function PermissionPrompt({ permission, onRespond }: PermissionPromptProp
       // IME 组合期间的 Enter(确认候选词)不算快捷键;焦点在可编辑元素上时
       // (侧栏重命名/查找栏等)也不劫持按键,避免把输入操作误判成授权决定。
       if (e.isComposing) return;
-      if (e.repeat) return;
+      if (e.repeat) {
+        // Suppress Chromium's native button click activation on held Enter.
+        // Without preventDefault(), the browser fires click events on the
+        // focused <button> for repeated Enter keydowns, bypassing the global
+        // shortcut guard and approving/denying newly promoted cards.
+        if (e.key === 'Enter' || e.key === 'Escape') e.preventDefault();
+        return;
+      }
       const target = e.target as HTMLElement | null;
       const tag = target?.tagName;
       if (tag === 'INPUT' || tag === 'TEXTAREA' || target?.isContentEditable) return;

--- a/apps/desktop/src/renderer/components/new-chat/PermissionPrompt.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/PermissionPrompt.tsx
@@ -134,6 +134,7 @@ export function PermissionPrompt({ permission, onRespond }: PermissionPromptProp
       // IME 组合期间的 Enter(确认候选词)不算快捷键;焦点在可编辑元素上时
       // (侧栏重命名/查找栏等)也不劫持按键,避免把输入操作误判成授权决定。
       if (e.isComposing) return;
+      if (e.repeat) return;
       const target = e.target as HTMLElement | null;
       const tag = target?.tagName;
       if (tag === 'INPUT' || tag === 'TEXTAREA' || target?.isContentEditable) return;

--- a/apps/desktop/src/renderer/components/new-chat/PermissionPrompt.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/PermissionPrompt.tsx
@@ -134,6 +134,9 @@ export function PermissionPrompt({ permission, onRespond }: PermissionPromptProp
       // IME 组合期间的 Enter(确认候选词)不算快捷键;焦点在可编辑元素上时
       // (侧栏重命名/查找栏等)也不劫持按键,避免把输入操作误判成授权决定。
       if (e.isComposing) return;
+      const target = e.target as HTMLElement | null;
+      const tag = target?.tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || target?.isContentEditable) return;
       if (e.repeat) {
         // Suppress Chromium's native button click activation on held Enter.
         // Without preventDefault(), the browser fires click events on the
@@ -142,9 +145,6 @@ export function PermissionPrompt({ permission, onRespond }: PermissionPromptProp
         if (e.key === 'Enter' || e.key === 'Escape') e.preventDefault();
         return;
       }
-      const target = e.target as HTMLElement | null;
-      const tag = target?.tagName;
-      if (tag === 'INPUT' || tag === 'TEXTAREA' || target?.isContentEditable) return;
       if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
         e.preventDefault();
         handleAlwaysAllow();

--- a/apps/desktop/src/renderer/components/new-chat/PermissionPrompt.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/PermissionPrompt.tsx
@@ -13,7 +13,7 @@
  *   Esc         → Deny
  */
 
-import { useCallback, useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { cn } from '@/lib/utils';
@@ -101,10 +101,17 @@ export function PermissionPrompt({ permission, onRespond }: PermissionPromptProp
 
   // ── Action handlers ──
 
+  // P1 security: capture the requestId at mount time so that a stale callback
+  // (e.g. keyboard Enter arriving after the permission was swapped) always
+  // carries the identity of the permission the user actually acted on,
+  // instead of reading the current state which may now be a different card.
+  const capturedRequestId = useRef(permission.requestId);
+
   const handleAllowOnce = useCallback(() => {
     onRespond({
       behavior: 'allow',
-    });
+      requestId: capturedRequestId.current,
+    } as CCAgentPermissionResult);
   }, [onRespond]);
 
   const handleAlwaysAllow = useCallback(() => {
@@ -116,7 +123,8 @@ export function PermissionPrompt({ permission, onRespond }: PermissionPromptProp
       behavior: 'allow',
       updatedPermissions: sessionSuggestions,
       decisionClassification: 'user_permanent',
-    });
+      requestId: capturedRequestId.current,
+    } as CCAgentPermissionResult);
   }, [canAlwaysAllowForSession, handleAllowOnce, onRespond, sessionSuggestions]);
 
   const handleDeny = useCallback(() => {
@@ -124,7 +132,8 @@ export function PermissionPrompt({ permission, onRespond }: PermissionPromptProp
       behavior: 'deny',
       message: 'User denied',
       decisionClassification: 'user_reject',
-    });
+      requestId: capturedRequestId.current,
+    } as CCAgentPermissionResult);
   }, [onRespond]);
 
   // ── Keyboard shortcuts ──

--- a/apps/desktop/src/renderer/components/new-chat/PermissionPrompt.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/PermissionPrompt.tsx
@@ -101,11 +101,14 @@ export function PermissionPrompt({ permission, onRespond }: PermissionPromptProp
 
   // ── Action handlers ──
 
-  // P1 security: capture the requestId at mount time so that a stale callback
-  // (e.g. keyboard Enter arriving after the permission was swapped) always
-  // carries the identity of the permission the user actually acted on,
-  // instead of reading the current state which may now be a different card.
+  // P1 security: keep the requestId in a ref so callbacks created for the
+  // current card always carry the identity the user actually acted on. React
+  // may reuse this instance when the FIFO promotes the next card, so update
+  // synchronously during render rather than waiting for an effect.
   const capturedRequestId = useRef(permission.requestId);
+  if (capturedRequestId.current !== permission.requestId) {
+    capturedRequestId.current = permission.requestId;
+  }
 
   const handleAllowOnce = useCallback(() => {
     onRespond({

--- a/apps/desktop/src/renderer/components/new-chat/PermissionPrompt.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/PermissionPrompt.tsx
@@ -101,14 +101,14 @@ export function PermissionPrompt({ permission, onRespond }: PermissionPromptProp
 
   // ── Action handlers ──
 
-  // P1 security: keep the requestId in a ref so callbacks created for the
-  // current card always carry the identity the user actually acted on. React
-  // may reuse this instance when the FIFO promotes the next card, so update
-  // synchronously during render rather than waiting for an effect.
+  // P1 security: freeze the requestId this instance was mounted for. The parent
+  // remounts PermissionPrompt per card via key={permission.requestId}, so this
+  // ref always equals the card the user is looking at; callbacks created below
+  // carry the identity the user actually acted on. Never rewrite it during
+  // render: if a stale instance were ever reused for the promoted card, a late
+  // click must keep A's id and be rejected by the store's head-of-queue check
+  // instead of silently approving B (review #4005).
   const capturedRequestId = useRef(permission.requestId);
-  if (capturedRequestId.current !== permission.requestId) {
-    capturedRequestId.current = permission.requestId;
-  }
 
   const handleAllowOnce = useCallback(() => {
     onRespond({

--- a/apps/desktop/src/renderer/components/new-chat/PermissionPrompt.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/PermissionPrompt.tsx
@@ -13,7 +13,7 @@
  *   Esc         → Deny
  */
 
-import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef, type MouseEvent as ReactMouseEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { cn } from '@/lib/utils';
@@ -139,6 +139,12 @@ export function PermissionPrompt({ permission, onRespond }: PermissionPromptProp
     } as CCAgentPermissionResult);
   }, [onRespond]);
 
+  // 平台级双击识别:MouseEvent.detail 是浏览器按 OS 双击间隔(用户可配置,任意时长)
+  // 统计的连续点击计数,第二击 detail>1。双击第二击落在推广后的新卡上时,必须当作
+  // 同一手势的一部分忽略 —— 事件驱动,不依赖固定的 renderer 计时器作为权限边界。
+  // 注意:detail 按点击位置+间隔判定,不受组件 remount(key)影响,覆盖任何配置。
+  const ignoreRepeatedClick = (e: ReactMouseEvent) => e.detail > 1;
+
   // ── Keyboard shortcuts ──
 
   useEffect(() => {
@@ -212,7 +218,10 @@ export function PermissionPrompt({ permission, onRespond }: PermissionPromptProp
         {/* Deny */}
         <button
           type="button"
-          onClick={handleDeny}
+          onClick={(e) => {
+            if (ignoreRepeatedClick(e)) return;
+            handleDeny();
+          }}
           className={cn(
             'flex items-center gap-2 rounded-[8px] border px-3 py-[7px]',
             'border-[var(--chat-input-border)] bg-transparent',
@@ -243,7 +252,10 @@ export function PermissionPrompt({ permission, onRespond }: PermissionPromptProp
           >
             <button
               type="button"
-              onClick={handleAlwaysAllow}
+              onClick={(e) => {
+                if (ignoreRepeatedClick(e)) return;
+                handleAlwaysAllow();
+              }}
               className={cn(
                 // max-w:规则可能很长(完整命令串),截断后完整内容看 tooltip。
                 'flex min-w-0 max-w-[460px] items-center gap-2 rounded-[8px] border px-3 py-[7px]',
@@ -270,7 +282,10 @@ export function PermissionPrompt({ permission, onRespond }: PermissionPromptProp
         {/* Allow once (primary) */}
         <button
           type="button"
-          onClick={handleAllowOnce}
+          onClick={(e) => {
+            if (ignoreRepeatedClick(e)) return;
+            handleAllowOnce();
+          }}
           className={cn(
             'flex items-center gap-2 rounded-[8px] border px-3 py-[7px]',
             'border-[var(--chat-input-border)]',

--- a/apps/desktop/src/renderer/components/new-chat/__tests__/PermissionPrompt.test.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/__tests__/PermissionPrompt.test.tsx
@@ -161,6 +161,7 @@ describe('PermissionPrompt 的会话级授权按钮', () => {
       behavior: 'allow',
       updatedPermissions: [bashRule],
       decisionClassification: 'user_permanent',
+      requestId: 'req-1',
     });
   });
 

--- a/apps/desktop/src/renderer/components/new-chat/__tests__/PermissionPrompt.test.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/__tests__/PermissionPrompt.test.tsx
@@ -174,4 +174,30 @@ describe('PermissionPrompt 的会话级授权按钮', () => {
       expect.objectContaining({ decisionClassification: 'user_permanent' }),
     );
   });
+
+  it('repeated keydown events (e.repeat) are ignored', () => {
+    const onRespond = vi.fn();
+    render(<PermissionPrompt permission={permission([bashRule])} onRespond={onRespond} />);
+
+    fireEvent.keyDown(window, { key: 'Enter', code: 'Enter', repeat: false });
+    expect(onRespond).toHaveBeenCalledTimes(1);
+
+    fireEvent.keyDown(window, { key: 'Enter', code: 'Enter', repeat: true });
+    fireEvent.keyDown(window, { key: 'Enter', code: 'Enter', repeat: true });
+    expect(onRespond).toHaveBeenCalledTimes(1);
+  });
+
+  it('Escape repeat is also ignored', () => {
+    const onRespond = vi.fn();
+    render(<PermissionPrompt permission={permission([bashRule])} onRespond={onRespond} />);
+
+    fireEvent.keyDown(window, { key: 'Escape', code: 'Escape', repeat: false });
+    expect(onRespond).toHaveBeenCalledTimes(1);
+    expect(onRespond).toHaveBeenCalledWith(
+      expect.objectContaining({ behavior: 'deny' }),
+    );
+
+    fireEvent.keyDown(window, { key: 'Escape', code: 'Escape', repeat: true });
+    expect(onRespond).toHaveBeenCalledTimes(1);
+  });
 });

--- a/apps/desktop/src/renderer/components/new-chat/__tests__/PermissionPrompt.test.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/__tests__/PermissionPrompt.test.tsx
@@ -188,6 +188,18 @@ describe('PermissionPrompt 的会话级授权按钮', () => {
     expect(onRespond).toHaveBeenCalledTimes(1);
   });
 
+  it('刷新到队列下一张卡后使用新的 requestId', () => {
+    const onRespond = vi.fn();
+    const first = permission();
+    const second = { ...permission(), requestId: 'req-2', input: { command: 'git status' } };
+    const { rerender } = render(<PermissionPrompt permission={first} onRespond={onRespond} />);
+
+    rerender(<PermissionPrompt permission={second} onRespond={onRespond} />);
+    fireEvent.click(screen.getByText('agentIsland.native.allowOnce'));
+
+    expect(onRespond).toHaveBeenCalledWith({ behavior: 'allow', requestId: 'req-2' });
+  });
+
   it('Escape repeat is also ignored', () => {
     const onRespond = vi.fn();
     render(<PermissionPrompt permission={permission([bashRule])} onRespond={onRespond} />);

--- a/apps/desktop/src/renderer/components/new-chat/__tests__/PermissionPrompt.test.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/__tests__/PermissionPrompt.test.tsx
@@ -217,4 +217,19 @@ describe('PermissionPrompt 的会话级授权按钮', () => {
     fireEvent.keyDown(window, { key: 'Escape', code: 'Escape', repeat: true });
     expect(onRespond).toHaveBeenCalledTimes(1);
   });
+
+  // 平台级双击识别:MouseEvent.detail 由浏览器按 OS 双击间隔(任意配置)统计,第二击
+  // detail>1。双击第二击落在推广后的新卡上时不得当作新决定 —— 不依赖固定 renderer
+  // 计时器,因此覆盖用户配置的超长双击间隔。
+  it('双击第二击(MouseEvent.detail>1)不触发授权', () => {
+    const onRespond = vi.fn();
+    render(<PermissionPrompt permission={permission([bashRule])} onRespond={onRespond} />);
+
+    fireEvent.click(screen.getByText('agentIsland.native.allowOnce'), { detail: 1 });
+    expect(onRespond).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByText('agentIsland.native.allowOnce'), { detail: 2 });
+    fireEvent.click(screen.getByText('agentIsland.native.allowOnce'), { detail: 3 });
+    expect(onRespond).toHaveBeenCalledTimes(1);
+  });
 });

--- a/apps/desktop/src/renderer/components/new-chat/__tests__/PermissionPrompt.test.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/__tests__/PermissionPrompt.test.tsx
@@ -188,7 +188,10 @@ describe('PermissionPrompt 的会话级授权按钮', () => {
     expect(onRespond).toHaveBeenCalledTimes(1);
   });
 
-  it('刷新到队列下一张卡后使用新的 requestId', () => {
+  // 身份必须在 mount 时冻结:父组件用 key={requestId} remount 每张卡,复用旧实例
+  // 只可能是异常路径。若真被复用,迟到手势必须继续带 A 的 id,由 store 的队首校验
+  // 拒绝(而不是把新卡的 id 当成新的用户决定) —— #4005「A 的迟到响应不得作用于 B」。
+  it('复用旧实例时冻结手势身份,不把 requestId 改写为下一张卡', () => {
     const onRespond = vi.fn();
     const first = permission();
     const second = { ...permission(), requestId: 'req-2', input: { command: 'git status' } };
@@ -197,7 +200,8 @@ describe('PermissionPrompt 的会话级授权按钮', () => {
     rerender(<PermissionPrompt permission={second} onRespond={onRespond} />);
     fireEvent.click(screen.getByText('agentIsland.native.allowOnce'));
 
-    expect(onRespond).toHaveBeenCalledWith({ behavior: 'allow', requestId: 'req-2' });
+    // 仍带着 mount 时的 req-1,不会变成 req-2。
+    expect(onRespond).toHaveBeenCalledWith({ behavior: 'allow', requestId: 'req-1' });
   });
 
   it('Escape repeat is also ignored', () => {

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
@@ -1611,7 +1611,7 @@ export function CCAgentSessionView({
         action.commandId === 'composer.submit'
       ) {
         if (pendingPermission) {
-          respondToPermission({ behavior: 'allow' });
+          respondToPermission({ behavior: 'allow', requestId: pendingPermission?.requestId });
           return true;
         }
         if (pendingPlanReview) {
@@ -1629,6 +1629,7 @@ export function CCAgentSessionView({
             behavior: 'deny',
             message: 'User denied',
             decisionClassification: 'user_reject',
+            requestId: pendingPermission?.requestId,
           });
           return true;
         }

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
@@ -4604,6 +4604,11 @@ export function CCAgentSessionView({
                   </>
                 ) : pendingPermission ? (
                   <PermissionPrompt
+                    // P1 security: remount per permission card so the instance
+                    // (and its frozen capturedRequestId / keyboard listeners)
+                    // dies with card A when FIFO promotes B. A reused instance
+                    // would carry A's stale identity onto B's buttons.
+                    key={pendingPermission.requestId}
                     permission={pendingPermission}
                     onRespond={respondToPermission}
                   />

--- a/apps/desktop/src/renderer/hooks/useCCAgentChat.ts
+++ b/apps/desktop/src/renderer/hooks/useCCAgentChat.ts
@@ -564,7 +564,7 @@ export function useCCAgentChat(
       // P1 security: forward the captured requestId from the UI component
       // so respondToPermission uses the identity the user acted on, not the
       // current state which may have changed.
-      makerChatStore.respondToPermission(sessionId, result, (result as Record<string, unknown>).requestId as string | undefined);
+      makerChatStore.respondToPermission(sessionId, result, result.requestId);
     },
     [sessionId],
   );

--- a/apps/desktop/src/renderer/hooks/useCCAgentChat.ts
+++ b/apps/desktop/src/renderer/hooks/useCCAgentChat.ts
@@ -561,7 +561,10 @@ export function useCCAgentChat(
   const respondToPermission = useCallback(
     (result: CCAgentPermissionResult) => {
       if (!sessionId) return;
-      makerChatStore.respondToPermission(sessionId, result);
+      // P1 security: forward the captured requestId from the UI component
+      // so respondToPermission uses the identity the user acted on, not the
+      // current state which may have changed.
+      makerChatStore.respondToPermission(sessionId, result, (result as Record<string, unknown>).requestId as string | undefined);
     },
     [sessionId],
   );

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -2889,50 +2889,53 @@ export const EMPTY_SESSION_STATE: SessionChatState = Object.freeze({
 // ---------------------------------------------------------------------------
 
 const sessions = new Map<string, SessionChatState>();
-/** Prevent one gesture from resolving the newly promoted permission head. */
-const permissionResponseInFlight = new Set<string>();
 /**
- * 防重窗口:本机 resolve-interaction handler 同步返回,IPC Promise 往往在双击的
- * 第二个 click / 键重复事件到达之前就 settle;若 finally 随即解除 guard,第二次
- * 输入会读到刚推广的下一条权限卡并误批(Codex review P1)。因此 guard 必须保持
- * 到重复输入窗口结束再释放。300ms 对齐项目先例 swallowActivationClick 的
- * RELEASE_GUARD_MS,并兼顾 Greptile 反馈(窗口过长会把用户对新卡的真实响应
- * 误判为重复输入而丢弃)。
+ * Request-scoped permission response guard.
+ * Keyed by sessionId → requestId. A guard only belongs to the specific permission
+ * card it was armed for. When the snapshot advances (A promoted, B displayed),
+ * the old A guard is invalidated and B can respond immediately.
  */
+const permissionResponseInFlight = new Map<string, string>();
+/** Gesture dedupe window: prevents double-click from approving the newly promoted card. */
 const PERMISSION_RESPONSE_GUARD_WINDOW_MS = 300;
-/** 每个 session 的防重释放定时器(供 purge / dismissal 清理,防止迟到释放误伤新会话)。 */
+/** Timer per session for gesture dedupe release (purge / dismissal cleanup). */
 const permissionResponseGuardTimers = new Map<string, ReturnType<typeof setTimeout>>();
-/** 每个 session 的 guard 代次——每次重新武装时递增，finally 回调用它确认自己是否仍拥有 guard。 */
-const permissionResponseGuardGeneration = new Map<string, number>();
 
-/** 立即释放某 session 的权限防重 guard(双击窗口未结束也照放,幂等)。 */
-function releasePermissionResponseGuard(sessionId: string): void {
+/**
+ * Invalidate any active guard for this session when the displayed permission changes.
+ * Called when pendingPermission transitions from A to B (promotion or snapshot advance).
+ * A's guard becomes stale — B can respond immediately without waiting for A's RPC.
+ */
+function invalidatePermissionGuardForPromotion(sessionId: string): void {
   const timer = permissionResponseGuardTimers.get(sessionId);
   if (timer !== undefined) clearTimeout(timer);
   permissionResponseGuardTimers.delete(sessionId);
   permissionResponseInFlight.delete(sessionId);
-  // 注意:不删除 generation——让它保持单调递增,防止 ABA 碰撞
-  // (释放后重新武装时 generation 会递增,迟到的 finally 捕获的旧 generation
-  //  与新 generation 不同,校验自然失败)。
 }
 
 /**
- * dismissal 到达时重新武装防重窗口(仅当 guard 仍在场)。不能无条件释放:本端
- * resolve A 时 main 会在 invoke reply settle 前同步广播 INTERACTION_DISMISSED,
- * 若此时清除 guard,双击第二击 / 键重复会读到刚推广的 B 并误批(security P1)。
- * 重新武装 = 从 dismissal 时刻起保留整个 gesture 窗口 —— 既挡住 A 的迟到输入,
- * 又不再依赖旧 RPC settle(可达 ~30s 隧道超时)才释放,用户对新卡 B 的真实响应
- * 在窗口结束后即可送达。guard 不在场(远端撤回,本端从未武装)时 no-op。
+ * Release the gesture-dedupe timer after IPC settle.
+ * Only releases if the guard still belongs to the same requestId (no ABA).
  */
-function rearmPermissionResponseGuard(sessionId: string): void {
-  if (!permissionResponseInFlight.has(sessionId)) return;
+function releasePermissionResponseGuard(sessionId: string, guardRequestId: string): void {
+  // If guard has already been replaced by a newer request, don't touch it.
+  if (permissionResponseInFlight.get(sessionId) !== guardRequestId) return;
   const timer = permissionResponseGuardTimers.get(sessionId);
   if (timer !== undefined) clearTimeout(timer);
-  // 递增代次——迟到的 finally 回调会检查代次，不再误删新 guard。
-  const gen = (permissionResponseGuardGeneration.get(sessionId) ?? 0) + 1;
-  permissionResponseGuardGeneration.set(sessionId, gen);
+  permissionResponseGuardTimers.delete(sessionId);
+  permissionResponseInFlight.delete(sessionId);
+}
+
+/**
+ * Arm gesture-dedupe window after IPC settle.
+ * Only arms if the guard still belongs to the same requestId.
+ */
+function armPermissionResponseGuard(sessionId: string, guardRequestId: string): void {
+  if (permissionResponseInFlight.get(sessionId) !== guardRequestId) return;
+  const timer = permissionResponseGuardTimers.get(sessionId);
+  if (timer !== undefined) clearTimeout(timer);
   const next = setTimeout(
-    () => releasePermissionResponseGuard(sessionId),
+    () => releasePermissionResponseGuard(sessionId, guardRequestId),
     PERMISSION_RESPONSE_GUARD_WINDOW_MS,
   );
   permissionResponseGuardTimers.set(sessionId, next);
@@ -3420,7 +3423,10 @@ function _purgeSession(sessionId: string): void {
   // 交接中的迟到 continuation，且不写入 /clear 的历史时间边界。
   bumpRendererClearGeneration(sessionId);
   cancelRemoteOptimisticSendsForSessionPurge(sessionId);
-  releasePermissionResponseGuard(sessionId);
+  permissionResponseInFlight.delete(sessionId);
+  const purgeTimer = permissionResponseGuardTimers.get(sessionId);
+  if (purgeTimer !== undefined) clearTimeout(purgeTimer);
+  permissionResponseGuardTimers.delete(sessionId);
   clearWakeBridgeReconcileTimer(sessionId);
   cancelIdlePlanDiscovery(sessionId);
   sessions.delete(sessionId);
@@ -7700,7 +7706,8 @@ function initGlobalListeners(options: GlobalListenerOptions = {}): void {
     // 会让双击第二击误批新推广的 B(security P1)。重新武装 gesture 窗口:
     // 既挡住 A 的迟到输入,又不依赖旧 RPC settle(可达 ~30s)才放行 B 的真实
     // 响应。guard 不在场时(远端撤回)no-op,不影响新卡即时响应。
-    rearmPermissionResponseGuard(sessionId);
+    // Dismissal: invalidate old guard so next permission can respond immediately.
+    invalidatePermissionGuardForPromotion(sessionId);
     setState(sessionId, (s) =>
       handleStreamEvent(s, { sessionId, type: 'permission_dismissed', data }),
     );
@@ -14149,12 +14156,17 @@ function respondToPluginSetup(
  * F-PERM-2: Send a permission decision to the main process and clear pendingPermission.
  */
 function respondToPermission(sessionId: string, result: CCAgentPermissionResult): void {
-  if (!sessionId || permissionResponseInFlight.has(sessionId)) return;
+  if (!sessionId) return;
   const state = getOrCreateState(sessionId);
   if (!state.pendingPermission) return;
 
   const { requestId } = state.pendingPermission;
-  permissionResponseInFlight.add(sessionId);
+
+  // Request-scoped guard: only block if THIS specific requestId is already in flight.
+  // If the guard belongs to a different (stale) requestId, it's safe to proceed.
+  if (permissionResponseInFlight.get(sessionId) === requestId) return;
+
+  permissionResponseInFlight.set(sessionId, requestId);
   bumpInteractionReconcileEpoch(sessionId);
 
   // Clear the displayed permission immediately and promote the next parallel
@@ -14169,13 +14181,8 @@ function respondToPermission(sessionId: string, result: CCAgentPermissionResult)
     };
   });
 
-  // Send to maker (InteractionDecision kind: 'permission'). Keep the guard
-  // until the IPC request settles: a duplicate click/key-repeat must not read
-  // the newly promoted queue head and reuse the previous decision for it.
-  //
-  // 捕获 guard 代次:dismissal 重新武装时会递增代次;迟到的 finally 必须
-  // 校验代次一致才启动释放窗口,避免 A 的 settle 删除 B 的 guard。
-  const guardGenAtArm = permissionResponseGuardGeneration.get(sessionId) ?? 0;
+  // Send to maker (InteractionDecision kind: 'permission').
+  // Capture requestId for gesture-dedupe: only arm if guard still belongs to this request.
   let response: Promise<unknown>;
   try {
     response = makerApiFor(sessionId).resolveInteraction(requestId, {
@@ -14195,16 +14202,8 @@ function respondToPermission(sessionId: string, result: CCAgentPermissionResult)
   void response
     .catch((err) => log.error('Failed to respond to permission:', err))
     .finally(() => {
-      // 代次不一致说明 guard 已被 dismissal 重新武装 belongs to a newer request;
-      // 迟到的 settle 不应启动释放窗口,否则会删掉新 guard。
-      if ((permissionResponseGuardGeneration.get(sessionId) ?? 0) !== guardGenAtArm) return;
-      // IPC 已 settle,但同一手势的第二次输入(双击第二击 / 键重复)可能还没到:
-      // 保持 guard 到窗口结束,窗口内任何新响应都被挡下,不会误批推广后的新卡。
-      const timer = setTimeout(
-        () => releasePermissionResponseGuard(sessionId),
-        PERMISSION_RESPONSE_GUARD_WINDOW_MS,
-      );
-      permissionResponseGuardTimers.set(sessionId, timer);
+      // Request-scoped: only arm dedupe if this guard still owns the session.
+      armPermissionResponseGuard(sessionId, requestId);
     });
 }
 

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -2894,7 +2894,8 @@ const sessions = new Map<string, SessionChatState>();
  * Prevents double-click / key-repeat from approving the newly promoted permission
  * card within the gesture-dedupe window (300ms after IPC settle).
  */
-const permissionResponseInFlight = new Set<string>();
+/** Maps sessionId → requestId of the in-flight permission response. */
+const permissionResponseInFlight = new Map<string, string>();
 /** Gesture dedupe window: prevents double-click from approving the newly promoted card. */
 const PERMISSION_RESPONSE_GUARD_WINDOW_MS = 300;
 /** Timer per session for gesture dedupe release (purge / dismissal cleanup). */
@@ -2908,6 +2909,7 @@ const permissionResponseGuardTimers = new Map<string, ReturnType<typeof setTimeo
  */
 function rearmPermissionResponseGuard(sessionId: string): void {
   if (!permissionResponseInFlight.has(sessionId)) return;
+  // Keep the existing requestId — only restart the dedupe timer.
   const timer = permissionResponseGuardTimers.get(sessionId);
   if (timer !== undefined) clearTimeout(timer);
   const next = setTimeout(
@@ -2930,8 +2932,15 @@ function releasePermissionResponseGuard(sessionId: string): void {
 
 /**
  * Arm gesture-dedupe window after IPC settle.
+ * @param requestId  The permission request that just settled.
+ *                   Only this request may arm the guard — a stale
+ *                   caller whose requestId no longer matches the
+ *                   in-flight entry must not overwrite the guard.
  */
-function armPermissionResponseGuard(sessionId: string): void {
+function armPermissionResponseGuard(sessionId: string, requestId: string): void {
+  // Ownership check: if a newer request already took over, do not interfere.
+  const current = permissionResponseInFlight.get(sessionId);
+  if (current !== undefined && current !== requestId) return;
   const timer = permissionResponseGuardTimers.get(sessionId);
   if (timer !== undefined) clearTimeout(timer);
   const next = setTimeout(
@@ -2939,6 +2948,7 @@ function armPermissionResponseGuard(sessionId: string): void {
     PERMISSION_RESPONSE_GUARD_WINDOW_MS,
   );
   permissionResponseGuardTimers.set(sessionId, next);
+  permissionResponseInFlight.set(sessionId, requestId);
 }
 const listeners = new Map<string, Set<() => void>>();
 const lightSnapshotCache = new Map<string, SessionChatLightState>();
@@ -14171,7 +14181,7 @@ function respondToPermission(sessionId: string, result: CCAgentPermissionResult)
   // Session-scoped guard: block all responses during the gesture-dedupe window.
   if (permissionResponseInFlight.has(sessionId)) return;
 
-  permissionResponseInFlight.add(sessionId);
+  permissionResponseInFlight.set(sessionId, requestId);
   bumpInteractionReconcileEpoch(sessionId);
 
   // Verify the captured permission is STILL the head of the queue.
@@ -14225,7 +14235,7 @@ function respondToPermission(sessionId: string, result: CCAgentPermissionResult)
       void reconcilePendingInteractions(sessionId).catch(() => undefined);
     })
     .finally(() => {
-      armPermissionResponseGuard(sessionId);
+      armPermissionResponseGuard(sessionId, requestId);
     });
 }
 

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -2447,8 +2447,13 @@ export interface SessionChatState {
   historyLoaded: boolean;
   /** SDK-internal session id; null until the first `init` message of a turn lands. */
   sdkSessionId: string | null;
-  /** F-PERM-2: Currently pending permission request; null when none. */
+  /** F-PERM-2: Currently displayed permission request; null when none. */
   pendingPermission: PendingPermission | null;
+  /**
+   * Additional permission requests from the same turn, kept FIFO instead of
+   * overwriting the displayed request when Claude emits parallel tool_use calls.
+   */
+  pendingPermissionQueue: PendingPermission[];
   /** F7.2: Currently pending ask-user-question; null when none. */
   pendingAskUser: PendingAskUser | null;
   /** Host-owned plugin setup snapshot; updates replace by monotonic revision. */
@@ -2742,6 +2747,7 @@ function createInitialState(): SessionChatState {
     streamingClientId: null,
     streamingText: '',
     pendingPermission: null,
+    pendingPermissionQueue: [],
     pendingAskUser: null,
     pendingPluginSetup: null,
     pendingPluginSetupQueue: [],
@@ -2820,6 +2826,7 @@ export const EMPTY_SESSION_STATE: SessionChatState = Object.freeze({
   historyLoaded: true,
   sdkSessionId: null,
   pendingPermission: null,
+  pendingPermissionQueue: [],
   pendingAskUser: null,
   pendingPluginSetup: null,
   pendingPluginSetupQueue: [],
@@ -5367,6 +5374,7 @@ export function handleStreamEvent(
         activeTurnRetryText: null,
         errorRetryText: finalized.error ? finalized.errorRetryText : null,
         pendingPermission: null,
+        pendingPermissionQueue: [],
         pendingAskUser: keepAskUserAcrossDone ? state.pendingAskUser : null,
         continuationTurnClientId: null,
         // F-AUQ-MIN-5: viewerState lives with pendingAskUser — when the
@@ -5579,6 +5587,7 @@ export function handleStreamEvent(
         // the 'done' path to consume — reset it explicitly on error so the
         // accumulated delta text doesn't linger in memory.
         pendingPermission: null,
+        pendingPermissionQueue: [],
         pendingAskUser: null,
         // F-AUQ-MIN-5: same reset as the 'done' path.
         askUserViewerState: 'expanded',
@@ -5613,18 +5622,28 @@ export function handleStreamEvent(
         suggestions?: unknown[];
         autoReviewUnavailable?: boolean;
       };
+      const permission: PendingPermission = {
+        requestId: data.requestId,
+        toolName: data.toolName,
+        input: data.input,
+        title: data.title,
+        displayName: data.displayName,
+        description: data.description,
+        suggestions: data.suggestions,
+        autoReviewUnavailable: data.autoReviewUnavailable === true,
+      };
+      if (
+        state.pendingPermission?.requestId === permission.requestId ||
+        state.pendingPermissionQueue.some((item) => item.requestId === permission.requestId)
+      ) {
+        return state;
+      }
       return {
         ...state,
-        pendingPermission: {
-          requestId: data.requestId,
-          toolName: data.toolName,
-          input: data.input,
-          title: data.title,
-          displayName: data.displayName,
-          description: data.description,
-          suggestions: data.suggestions,
-          autoReviewUnavailable: data.autoReviewUnavailable === true,
-        },
+        pendingPermission: state.pendingPermission ?? permission,
+        pendingPermissionQueue: state.pendingPermission
+          ? [...state.pendingPermissionQueue, permission]
+          : state.pendingPermissionQueue,
       };
     }
 
@@ -5642,7 +5661,20 @@ export function handleStreamEvent(
           ? (data.decision as Record<string, unknown>)
           : null;
       if (state.pendingPermission?.requestId === data.requestId) {
-        return { ...state, pendingPermission: null };
+        const [nextPermission = null, ...remainingPermissions] = state.pendingPermissionQueue;
+        return {
+          ...state,
+          pendingPermission: nextPermission,
+          pendingPermissionQueue: remainingPermissions,
+        };
+      }
+      if (state.pendingPermissionQueue.some((item) => item.requestId === data.requestId)) {
+        return {
+          ...state,
+          pendingPermissionQueue: state.pendingPermissionQueue.filter(
+            (item) => item.requestId !== data.requestId,
+          ),
+        };
       }
       if (state.pendingPluginSetup?.requestId === data.requestId) {
         const [nextSetup = null, ...remainingSetups] = state.pendingPluginSetupQueue;
@@ -6037,6 +6069,7 @@ function forceFinalizeOnSessionClosed(state: SessionChatState): SessionChatState
     activeTurnRetryText: null,
     errorRetryText: null,
     pendingPermission: null,
+    pendingPermissionQueue: [],
     pendingAskUser: null,
     pendingPluginSetup: null,
     pendingPluginSetupQueue: [],
@@ -9786,11 +9819,10 @@ function settleRemoteOptimisticFailure(sessionId: string, clientId: string, erro
 async function pumpRemoteOptimisticSends(sessionId: string): Promise<void> {
   const existing = remoteOptimisticPumps.get(sessionId);
   if (existing) return existing;
-  // Self-reference is intentional: a detached clear/owner generation must not
-  // keep draining after a newer pump replaces this Promise in the registry.
-  // eslint-disable-next-line prefer-const
-  let run!: Promise<void>;
-  run = (async () => {
+  // Self-reference is intentional: the async body reaches its first await
+  // before consulting the registry, so the initialized Promise is available
+  // when a detached clear/owner generation checks whether it was replaced.
+  const run = (async () => {
     while (true) {
       const record = firstUnacceptedRemoteOptimisticSend(sessionId);
       if (!record || record.dispatching) return;
@@ -13262,6 +13294,7 @@ function stopSession(
       activeTurnRetryText: null,
       errorRetryText: null,
       pendingPermission: null,
+      pendingPermissionQueue: [],
       continuationTurnClientId: null,
       pendingAskUser: null,
       // F-AUQ-MIN-5: Stop session — pending question is gone, reset viewer.
@@ -13706,6 +13739,7 @@ async function clearSessionAfterGuardImpl(sessionId: string, clearedAt: string):
       activeTurnRetryText: null,
       errorRetryText: null,
       pendingPermission: null,
+      pendingPermissionQueue: [],
       pendingAskUser: null,
       pendingPluginSetup: null,
       pendingPluginSetupQueue: [],
@@ -14000,8 +14034,17 @@ function respondToPermission(sessionId: string, result: CCAgentPermissionResult)
   const { requestId } = state.pendingPermission;
   bumpInteractionReconcileEpoch(sessionId);
 
-  // Clear the pending permission immediately so the UI updates
-  setState(sessionId, (s) => ({ ...s, pendingPermission: null }));
+  // Clear the displayed permission immediately and promote the next parallel
+  // request. Main keeps every resolver by requestId; the renderer must do the
+  // same rather than dropping the first tool_use when a later card arrives.
+  setState(sessionId, (s) => {
+    const [nextPermission = null, ...remainingPermissions] = s.pendingPermissionQueue;
+    return {
+      ...s,
+      pendingPermission: nextPermission,
+      pendingPermissionQueue: remainingPermissions,
+    };
+  });
 
   // Send to maker (InteractionDecision kind: 'permission')
   makerApiFor(sessionId)

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -2890,36 +2890,38 @@ export const EMPTY_SESSION_STATE: SessionChatState = Object.freeze({
 
 const sessions = new Map<string, SessionChatState>();
 /**
- * Request-scoped permission response guard.
- * Keyed by sessionId → requestId. A guard only belongs to the specific permission
- * card it was armed for. When the snapshot advances (A promoted, B displayed),
- * the old A guard is invalidated and B can respond immediately.
+ * Session-scoped permission response guard.
+ * Prevents double-click / key-repeat from approving the newly promoted permission
+ * card within the gesture-dedupe window (300ms after IPC settle).
  */
-const permissionResponseInFlight = new Map<string, string>();
+const permissionResponseInFlight = new Set<string>();
 /** Gesture dedupe window: prevents double-click from approving the newly promoted card. */
 const PERMISSION_RESPONSE_GUARD_WINDOW_MS = 300;
 /** Timer per session for gesture dedupe release (purge / dismissal cleanup). */
 const permissionResponseGuardTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
 /**
- * Invalidate any active guard for this session when the displayed permission changes.
- * Called when pendingPermission transitions from A to B (promotion or snapshot advance).
- * A's guard becomes stale — B can respond immediately without waiting for A's RPC.
+ * Rearm gesture-dedupe window when a dismissal arrives.
+ * Keeps the session-level guard active and restarts the timer. This prevents
+ * A's delayed click from approving the newly promoted B within the gesture window.
+ * After the window expires, B can be responded to normally.
  */
-function invalidatePermissionGuardForPromotion(sessionId: string): void {
+function rearmPermissionResponseGuard(sessionId: string): void {
+  if (!permissionResponseInFlight.has(sessionId)) return;
   const timer = permissionResponseGuardTimers.get(sessionId);
   if (timer !== undefined) clearTimeout(timer);
-  permissionResponseGuardTimers.delete(sessionId);
-  permissionResponseInFlight.delete(sessionId);
+  const next = setTimeout(
+    () => releasePermissionResponseGuard(sessionId),
+    PERMISSION_RESPONSE_GUARD_WINDOW_MS,
+  );
+  permissionResponseGuardTimers.set(sessionId, next);
 }
 
 /**
  * Release the gesture-dedupe timer after IPC settle.
- * Only releases if the guard still belongs to the same requestId (no ABA).
+ * Idempotent — safe to call even if guard was already cleared.
  */
-function releasePermissionResponseGuard(sessionId: string, guardRequestId: string): void {
-  // If guard has already been replaced by a newer request, don't touch it.
-  if (permissionResponseInFlight.get(sessionId) !== guardRequestId) return;
+function releasePermissionResponseGuard(sessionId: string): void {
   const timer = permissionResponseGuardTimers.get(sessionId);
   if (timer !== undefined) clearTimeout(timer);
   permissionResponseGuardTimers.delete(sessionId);
@@ -2928,14 +2930,12 @@ function releasePermissionResponseGuard(sessionId: string, guardRequestId: strin
 
 /**
  * Arm gesture-dedupe window after IPC settle.
- * Only arms if the guard still belongs to the same requestId.
  */
-function armPermissionResponseGuard(sessionId: string, guardRequestId: string): void {
-  if (permissionResponseInFlight.get(sessionId) !== guardRequestId) return;
+function armPermissionResponseGuard(sessionId: string): void {
   const timer = permissionResponseGuardTimers.get(sessionId);
   if (timer !== undefined) clearTimeout(timer);
   const next = setTimeout(
-    () => releasePermissionResponseGuard(sessionId, guardRequestId),
+    () => releasePermissionResponseGuard(sessionId),
     PERMISSION_RESPONSE_GUARD_WINDOW_MS,
   );
   permissionResponseGuardTimers.set(sessionId, next);
@@ -7706,8 +7706,8 @@ function initGlobalListeners(options: GlobalListenerOptions = {}): void {
     // 会让双击第二击误批新推广的 B(security P1)。重新武装 gesture 窗口:
     // 既挡住 A 的迟到输入,又不依赖旧 RPC settle(可达 ~30s)才放行 B 的真实
     // 响应。guard 不在场时(远端撤回)no-op,不影响新卡即时响应。
-    // Dismissal: invalidate old guard so next permission can respond immediately.
-    invalidatePermissionGuardForPromotion(sessionId);
+    // Dismissal: rearm guard to block A's delayed click within gesture window.
+    rearmPermissionResponseGuard(sessionId);
     setState(sessionId, (s) =>
       handleStreamEvent(s, { sessionId, type: 'permission_dismissed', data }),
     );
@@ -14162,11 +14162,11 @@ function respondToPermission(sessionId: string, result: CCAgentPermissionResult)
 
   const { requestId } = state.pendingPermission;
 
-  // Request-scoped guard: only block if THIS specific requestId is already in flight.
-  // If the guard belongs to a different (stale) requestId, it's safe to proceed.
-  if (permissionResponseInFlight.get(sessionId) === requestId) return;
+  // Session-scoped guard: block all responses during the gesture-dedupe window.
+  // This prevents double-click / key-repeat from approving the newly promoted card.
+  if (permissionResponseInFlight.has(sessionId)) return;
 
-  permissionResponseInFlight.set(sessionId, requestId);
+  permissionResponseInFlight.add(sessionId);
   bumpInteractionReconcileEpoch(sessionId);
 
   // Clear the displayed permission immediately and promote the next parallel
@@ -14195,15 +14195,14 @@ function respondToPermission(sessionId: string, result: CCAgentPermissionResult)
         : undefined,
     });
   } catch (err) {
-    permissionResponseInFlight.delete(sessionId);
+    releasePermissionResponseGuard(sessionId);
     log.error('Failed to respond to permission:', err);
     return;
   }
   void response
     .catch((err) => log.error('Failed to respond to permission:', err))
     .finally(() => {
-      // Request-scoped: only arm dedupe if this guard still owns the session.
-      armPermissionResponseGuard(sessionId, requestId);
+      armPermissionResponseGuard(sessionId);
     });
 }
 

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -2891,6 +2891,16 @@ export const EMPTY_SESSION_STATE: SessionChatState = Object.freeze({
 const sessions = new Map<string, SessionChatState>();
 /** Prevent one gesture from resolving the newly promoted permission head. */
 const permissionResponseInFlight = new Set<string>();
+/**
+ * 防重窗口:本机 resolve-interaction handler 同步返回,IPC Promise 往往在双击的
+ * 第二个 click / 键重复事件到达之前就 settle;若 finally 随即解除 guard,第二次
+ * 输入会读到刚推广的下一条权限卡并误批(Codex review P1)。因此 guard 必须保持
+ * 到重复输入窗口结束再释放。500ms 对齐 Windows 默认双击时间(项目先例:
+ * swallowActivationClick 的 RELEASE_GUARD_MS=300)。
+ */
+const PERMISSION_RESPONSE_GUARD_WINDOW_MS = 500;
+/** 每个 session 的防重释放定时器(供 purge 清理,防止迟到释放误伤新会话)。 */
+const permissionResponseGuardTimers = new Map<string, ReturnType<typeof setTimeout>>();
 const listeners = new Map<string, Set<() => void>>();
 const lightSnapshotCache = new Map<string, SessionChatLightState>();
 
@@ -3374,6 +3384,9 @@ function _purgeSession(sessionId: string): void {
   // 交接中的迟到 continuation，且不写入 /clear 的历史时间边界。
   bumpRendererClearGeneration(sessionId);
   cancelRemoteOptimisticSendsForSessionPurge(sessionId);
+  const permissionGuardTimer = permissionResponseGuardTimers.get(sessionId);
+  if (permissionGuardTimer !== undefined) clearTimeout(permissionGuardTimer);
+  permissionResponseGuardTimers.delete(sessionId);
   permissionResponseInFlight.delete(sessionId);
   clearWakeBridgeReconcileTimer(sessionId);
   cancelIdlePlanDiscovery(sessionId);
@@ -14122,7 +14135,15 @@ function respondToPermission(sessionId: string, result: CCAgentPermissionResult)
   }
   void response
     .catch((err) => log.error('Failed to respond to permission:', err))
-    .finally(() => permissionResponseInFlight.delete(sessionId));
+    .finally(() => {
+      // IPC 已 settle,但同一手势的第二次输入(双击第二击 / 键重复)可能还没到:
+      // 保持 guard 到窗口结束,窗口内任何新响应都被挡下,不会误批推广后的新卡。
+      const timer = setTimeout(() => {
+        permissionResponseInFlight.delete(sessionId);
+        permissionResponseGuardTimers.delete(sessionId);
+      }, PERMISSION_RESPONSE_GUARD_WINDOW_MS);
+      permissionResponseGuardTimers.set(sessionId, timer);
+    });
 }
 
 /**

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -2911,7 +2911,9 @@ function releasePermissionResponseGuard(sessionId: string): void {
   if (timer !== undefined) clearTimeout(timer);
   permissionResponseGuardTimers.delete(sessionId);
   permissionResponseInFlight.delete(sessionId);
-  permissionResponseGuardGeneration.delete(sessionId);
+  // 注意:不删除 generation——让它保持单调递增,防止 ABA 碰撞
+  // (释放后重新武装时 generation 会递增,迟到的 finally 捕获的旧 generation
+  //  与新 generation 不同,校验自然失败)。
 }
 
 /**

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -2895,12 +2895,21 @@ const permissionResponseInFlight = new Set<string>();
  * 防重窗口:本机 resolve-interaction handler 同步返回,IPC Promise 往往在双击的
  * 第二个 click / 键重复事件到达之前就 settle;若 finally 随即解除 guard,第二次
  * 输入会读到刚推广的下一条权限卡并误批(Codex review P1)。因此 guard 必须保持
- * 到重复输入窗口结束再释放。500ms 对齐 Windows 默认双击时间(项目先例:
- * swallowActivationClick 的 RELEASE_GUARD_MS=300)。
+ * 到重复输入窗口结束再释放。300ms 对齐项目先例 swallowActivationClick 的
+ * RELEASE_GUARD_MS,并兼顾 Greptile 反馈(窗口过长会把用户对新卡的真实响应
+ * 误判为重复输入而丢弃)。
  */
-const PERMISSION_RESPONSE_GUARD_WINDOW_MS = 500;
-/** 每个 session 的防重释放定时器(供 purge 清理,防止迟到释放误伤新会话)。 */
+const PERMISSION_RESPONSE_GUARD_WINDOW_MS = 300;
+/** 每个 session 的防重释放定时器(供 purge / dismissal 清理,防止迟到释放误伤新会话)。 */
 const permissionResponseGuardTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
+/** 立即释放某 session 的权限防重 guard(双击窗口未结束也照放,幂等)。 */
+function releasePermissionResponseGuard(sessionId: string): void {
+  const timer = permissionResponseGuardTimers.get(sessionId);
+  if (timer !== undefined) clearTimeout(timer);
+  permissionResponseGuardTimers.delete(sessionId);
+  permissionResponseInFlight.delete(sessionId);
+}
 const listeners = new Map<string, Set<() => void>>();
 const lightSnapshotCache = new Map<string, SessionChatLightState>();
 
@@ -3384,10 +3393,7 @@ function _purgeSession(sessionId: string): void {
   // 交接中的迟到 continuation，且不写入 /clear 的历史时间边界。
   bumpRendererClearGeneration(sessionId);
   cancelRemoteOptimisticSendsForSessionPurge(sessionId);
-  const permissionGuardTimer = permissionResponseGuardTimers.get(sessionId);
-  if (permissionGuardTimer !== undefined) clearTimeout(permissionGuardTimer);
-  permissionResponseGuardTimers.delete(sessionId);
-  permissionResponseInFlight.delete(sessionId);
+  releasePermissionResponseGuard(sessionId);
   clearWakeBridgeReconcileTimer(sessionId);
   cancelIdlePlanDiscovery(sessionId);
   sessions.delete(sessionId);
@@ -7662,6 +7668,10 @@ function initGlobalListeners(options: GlobalListenerOptions = {}): void {
       decision: dismissPayload.decision,
     };
     const sessionId = payload.sessionId;
+    // 交互被撤回/对端已解决:旧权限卡的响应链已终结,立即释放防重 guard,
+    // 否则本端旧 resolve RPC 可能要等隧道超时(可达 ~30s),期间用户对新推广
+    // 卡的所有响应都会被静默丢弃(Greptile/Codex review P1/P2)。
+    releasePermissionResponseGuard(sessionId);
     setState(sessionId, (s) =>
       handleStreamEvent(s, { sessionId, type: 'permission_dismissed', data }),
     );
@@ -14138,11 +14148,11 @@ function respondToPermission(sessionId: string, result: CCAgentPermissionResult)
     .finally(() => {
       // IPC 已 settle,但同一手势的第二次输入(双击第二击 / 键重复)可能还没到:
       // 保持 guard 到窗口结束,窗口内任何新响应都被挡下,不会误批推广后的新卡。
-      const timer = setTimeout(() => {
-        permissionResponseInFlight.delete(sessionId);
-        permissionResponseGuardTimers.delete(sessionId);
-      }, PERMISSION_RESPONSE_GUARD_WINDOW_MS);
-      permissionResponseGuardTimers.set(sessionId, timer);
+  const timer = setTimeout(
+    () => releasePermissionResponseGuard(sessionId),
+    PERMISSION_RESPONSE_GUARD_WINDOW_MS,
+  );
+  permissionResponseGuardTimers.set(sessionId, timer);
     });
 }
 

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -14164,7 +14164,11 @@ function respondToPermission(sessionId: string, result: CCAgentPermissionResult)
   const state = getOrCreateState(sessionId);
   if (!state.pendingPermission) return;
 
-  const { requestId } = state.pendingPermission;
+  // Capture the exact permission object BEFORE any guard check or state mutation.
+  // If a reconnect snapshot or dismissal replaces A with B between the user click
+  // and this function body, the stale click must not approve B.
+  const capturedRequest = state.pendingPermission;
+  const { requestId } = capturedRequest;
 
   // Session-scoped guard: block all responses during the gesture-dedupe window.
   // This prevents double-click / key-repeat from approving the newly promoted card.
@@ -14185,8 +14189,16 @@ function respondToPermission(sessionId: string, result: CCAgentPermissionResult)
     };
   });
 
+  // Verify that the captured permission is still the authoritative head.
+  // If a reconnect snapshot or dismissal promoted B while we were arming the
+  // guard, the stale click must not approve B.  Release the guard and bail.
+  const currentHead = getOrCreateState(sessionId).pendingPermission;
+  if (currentHead !== capturedRequest) {
+    releasePermissionResponseGuard(sessionId);
+    return;
+  }
+
   // Send to maker (InteractionDecision kind: 'permission').
-  // Capture requestId for gesture-dedupe: only arm if guard still belongs to this request.
   let response: Promise<unknown>;
   try {
     response = makerApiFor(sessionId).resolveInteraction(requestId, {

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -2902,6 +2902,8 @@ const permissionResponseInFlight = new Set<string>();
 const PERMISSION_RESPONSE_GUARD_WINDOW_MS = 300;
 /** 每个 session 的防重释放定时器(供 purge / dismissal 清理,防止迟到释放误伤新会话)。 */
 const permissionResponseGuardTimers = new Map<string, ReturnType<typeof setTimeout>>();
+/** 每个 session 的 guard 代次——每次重新武装时递增，finally 回调用它确认自己是否仍拥有 guard。 */
+const permissionResponseGuardGeneration = new Map<string, number>();
 
 /** 立即释放某 session 的权限防重 guard(双击窗口未结束也照放,幂等)。 */
 function releasePermissionResponseGuard(sessionId: string): void {
@@ -2909,6 +2911,7 @@ function releasePermissionResponseGuard(sessionId: string): void {
   if (timer !== undefined) clearTimeout(timer);
   permissionResponseGuardTimers.delete(sessionId);
   permissionResponseInFlight.delete(sessionId);
+  permissionResponseGuardGeneration.delete(sessionId);
 }
 
 /**
@@ -2923,6 +2926,9 @@ function rearmPermissionResponseGuard(sessionId: string): void {
   if (!permissionResponseInFlight.has(sessionId)) return;
   const timer = permissionResponseGuardTimers.get(sessionId);
   if (timer !== undefined) clearTimeout(timer);
+  // 递增代次——迟到的 finally 回调会检查代次，不再误删新 guard。
+  const gen = (permissionResponseGuardGeneration.get(sessionId) ?? 0) + 1;
+  permissionResponseGuardGeneration.set(sessionId, gen);
   const next = setTimeout(
     () => releasePermissionResponseGuard(sessionId),
     PERMISSION_RESPONSE_GUARD_WINDOW_MS,
@@ -14148,6 +14154,10 @@ function respondToPermission(sessionId: string, result: CCAgentPermissionResult)
   // Send to maker (InteractionDecision kind: 'permission'). Keep the guard
   // until the IPC request settles: a duplicate click/key-repeat must not read
   // the newly promoted queue head and reuse the previous decision for it.
+  //
+  // 捕获 guard 代次:dismissal 重新武装时会递增代次;迟到的 finally 必须
+  // 校验代次一致才启动释放窗口,避免 A 的 settle 删除 B 的 guard。
+  const guardGenAtArm = permissionResponseGuardGeneration.get(sessionId) ?? 0;
   let response: Promise<unknown>;
   try {
     response = makerApiFor(sessionId).resolveInteraction(requestId, {
@@ -14167,13 +14177,16 @@ function respondToPermission(sessionId: string, result: CCAgentPermissionResult)
   void response
     .catch((err) => log.error('Failed to respond to permission:', err))
     .finally(() => {
+      // 代次不一致说明 guard 已被 dismissal 重新武装 belongs to a newer request;
+      // 迟到的 settle 不应启动释放窗口,否则会删掉新 guard。
+      if ((permissionResponseGuardGeneration.get(sessionId) ?? 0) !== guardGenAtArm) return;
       // IPC 已 settle,但同一手势的第二次输入(双击第二击 / 键重复)可能还没到:
       // 保持 guard 到窗口结束,窗口内任何新响应都被挡下,不会误批推广后的新卡。
-  const timer = setTimeout(
-    () => releasePermissionResponseGuard(sessionId),
-    PERMISSION_RESPONSE_GUARD_WINDOW_MS,
-  );
-  permissionResponseGuardTimers.set(sessionId, timer);
+      const timer = setTimeout(
+        () => releasePermissionResponseGuard(sessionId),
+        PERMISSION_RESPONSE_GUARD_WINDOW_MS,
+      );
+      permissionResponseGuardTimers.set(sessionId, timer);
     });
 }
 

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -9285,15 +9285,19 @@ function reconcilePendingInteractions(
         };
       });
       // When the authoritative snapshot replaces the displayed permission (e.g.
-      // device-link reconnects while old request was in flight), release the
-      // stale guard so the newly promoted request can be acted on immediately.
+      // device-link reconnects while old request A was in flight), rearm the
+      // gesture-dedupe guard instead of releasing it. Releasing here would let
+      // A's delayed double-click / key-repeat read the newly promoted B's
+      // requestId and approve B without an independent user decision. Rearming
+      // is symmetric with the dismissal path: B stays protected for the
+      // gesture window, then becomes actionable normally.
       const newPendingPermission = getOrCreateState(sessionId).pendingPermission;
       if (
         oldPendingPermission !== newPendingPermission &&
         oldPendingPermission !== null &&
         permissionResponseInFlight.has(sessionId)
       ) {
-        releasePermissionResponseGuard(sessionId);
+        rearmPermissionResponseGuard(sessionId);
       }
       for (const item of list) {
         if (!isCurrentInteractionReconcile()) return 0;

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -2910,6 +2910,25 @@ function releasePermissionResponseGuard(sessionId: string): void {
   permissionResponseGuardTimers.delete(sessionId);
   permissionResponseInFlight.delete(sessionId);
 }
+
+/**
+ * dismissal 到达时重新武装防重窗口(仅当 guard 仍在场)。不能无条件释放:本端
+ * resolve A 时 main 会在 invoke reply settle 前同步广播 INTERACTION_DISMISSED,
+ * 若此时清除 guard,双击第二击 / 键重复会读到刚推广的 B 并误批(security P1)。
+ * 重新武装 = 从 dismissal 时刻起保留整个 gesture 窗口 —— 既挡住 A 的迟到输入,
+ * 又不再依赖旧 RPC settle(可达 ~30s 隧道超时)才释放,用户对新卡 B 的真实响应
+ * 在窗口结束后即可送达。guard 不在场(远端撤回,本端从未武装)时 no-op。
+ */
+function rearmPermissionResponseGuard(sessionId: string): void {
+  if (!permissionResponseInFlight.has(sessionId)) return;
+  const timer = permissionResponseGuardTimers.get(sessionId);
+  if (timer !== undefined) clearTimeout(timer);
+  const next = setTimeout(
+    () => releasePermissionResponseGuard(sessionId),
+    PERMISSION_RESPONSE_GUARD_WINDOW_MS,
+  );
+  permissionResponseGuardTimers.set(sessionId, next);
+}
 const listeners = new Map<string, Set<() => void>>();
 const lightSnapshotCache = new Map<string, SessionChatLightState>();
 
@@ -7668,10 +7687,12 @@ function initGlobalListeners(options: GlobalListenerOptions = {}): void {
       decision: dismissPayload.decision,
     };
     const sessionId = payload.sessionId;
-    // 交互被撤回/对端已解决:旧权限卡的响应链已终结,立即释放防重 guard,
-    // 否则本端旧 resolve RPC 可能要等隧道超时(可达 ~30s),期间用户对新推广
-    // 卡的所有响应都会被静默丢弃(Greptile/Codex review P1/P2)。
-    releasePermissionResponseGuard(sessionId);
+    // 交互被撤回/对端已解决/本端 resolve 回显:旧权限卡的响应链终结。不能
+    // 无条件释放 guard —— A 被 resolve 时 main 同步广播 dismissal,立即释放
+    // 会让双击第二击误批新推广的 B(security P1)。重新武装 gesture 窗口:
+    // 既挡住 A 的迟到输入,又不依赖旧 RPC settle(可达 ~30s)才放行 B 的真实
+    // 响应。guard 不在场时(远端撤回)no-op,不影响新卡即时响应。
+    rearmPermissionResponseGuard(sessionId);
     setState(sessionId, (s) =>
       handleStreamEvent(s, { sessionId, type: 'permission_dismissed', data }),
     );

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -668,6 +668,28 @@ export interface PendingPermission {
   autoReviewUnavailable?: boolean;
 }
 
+function parsePendingPermissionRequest(
+  request: Record<string, unknown> | undefined,
+): PendingPermission | null {
+  if (!request || request.kind !== 'permission' || typeof request.requestId !== 'string') {
+    return null;
+  }
+  const metadata = request.metadata as Record<string, unknown> | undefined;
+  return {
+    requestId: request.requestId,
+    toolName: typeof request.toolName === 'string' ? request.toolName : '',
+    input:
+      request.input && typeof request.input === 'object'
+        ? (request.input as Record<string, unknown>)
+        : {},
+    title: typeof request.title === 'string' ? request.title : undefined,
+    displayName: typeof request.displayName === 'string' ? request.displayName : undefined,
+    description: typeof request.description === 'string' ? request.description : undefined,
+    suggestions: Array.isArray(request.suggestions) ? request.suggestions : undefined,
+    autoReviewUnavailable: metadata?.autoReviewUnavailable === true,
+  };
+}
+
 /** F7.2: Pending ask-user-question data — holds ALL questions for the wizard. */
 export interface PendingAskUser {
   requestId: string;
@@ -9079,6 +9101,9 @@ function reconcilePendingInteractions(
       // a Device Link reconnect cannot leave cards that the Host already closed.
       // Other interaction kinds keep their existing replay semantics.
       const authoritativePluginSetupIds = new Set<string>();
+      const authoritativePermissions = list
+        .map((item) => parsePendingPermissionRequest(item?.request))
+        .filter((permission): permission is PendingPermission => permission !== null);
       const authoritativeRemoteDesktopConfirmationIds = new Set<string>();
       for (const item of list) {
         const request = item?.request;
@@ -9101,6 +9126,28 @@ function reconcilePendingInteractions(
       }
       if (!isCurrentInteractionReconcile()) return 0;
       setState(sessionId, (state) => {
+        // Permission snapshots are authoritative too. In particular, do not
+        // append the snapshot behind a stale displayed request: a renderer can
+        // miss A's dismissal, reconnect while B is pending, and otherwise keep
+        // showing A forever while B waits in the new FIFO queue.
+        const existingPermissions = [
+          ...(state.pendingPermission ? [state.pendingPermission] : []),
+          ...state.pendingPermissionQueue,
+        ];
+        const existingByRequestId = new Map(
+          existingPermissions.map((permission) => [permission.requestId, permission]),
+        );
+        const reconciledPermissions = authoritativePermissions.map(
+          (permission) => existingByRequestId.get(permission.requestId) ?? permission,
+        );
+        const nextPermission = reconciledPermissions[0] ?? null;
+        const nextPermissionQueue = reconciledPermissions.slice(1);
+        const permissionChanged =
+          state.pendingPermission !== nextPermission ||
+          state.pendingPermissionQueue.length !== nextPermissionQueue.length ||
+          state.pendingPermissionQueue.some(
+            (permission, index) => permission !== nextPermissionQueue[index],
+          );
         const currentSurvives =
           state.pendingPluginSetup !== null &&
           authoritativePluginSetupIds.has(state.pendingPluginSetup.requestId);
@@ -9149,6 +9196,7 @@ function reconcilePendingInteractions(
           );
 
         if (
+          !permissionChanged &&
           !currentChanged &&
           !queueChanged &&
           nextCommand === state.pluginSetupCommandInFlight &&
@@ -9159,6 +9207,8 @@ function reconcilePendingInteractions(
         }
         return {
           ...state,
+          pendingPermission: nextPermission,
+          pendingPermissionQueue: nextPermissionQueue,
           pendingPluginSetup: nextCurrent,
           pendingPluginSetupQueue: survivingQueue,
           pluginSetupViewerState: currentChanged ? 'expanded' : state.pluginSetupViewerState,
@@ -9819,9 +9869,9 @@ function settleRemoteOptimisticFailure(sessionId: string, clientId: string, erro
 async function pumpRemoteOptimisticSends(sessionId: string): Promise<void> {
   const existing = remoteOptimisticPumps.get(sessionId);
   if (existing) return existing;
-  // Self-reference is intentional: the async body reaches its first await
-  // before consulting the registry, so the initialized Promise is available
-  // when a detached clear/owner generation checks whether it was replaced.
+  // The holder avoids a temporal-dead-zone type error while allowing the async
+  // body to compare its identity with a newer pump after its first await.
+  const runRef: { promise?: Promise<void> } = {};
   const run = (async () => {
     while (true) {
       const record = firstUnacceptedRemoteOptimisticSend(sessionId);
@@ -9829,7 +9879,7 @@ async function pumpRemoteOptimisticSends(sessionId: string): Promise<void> {
       const prepared = await prepareRemoteOptimisticSend(sessionId, record);
       if (prepared.kind === 'deferred') return;
       if (prepared.kind === 'cancelled') {
-        if (remoteOptimisticPumps.get(sessionId) !== run) return;
+        if (remoteOptimisticPumps.get(sessionId) !== runRef.promise) return;
         continue;
       }
       if (prepared.kind === 'failed') {
@@ -9844,7 +9894,7 @@ async function pumpRemoteOptimisticSends(sessionId: string): Promise<void> {
       // the active pump to dispatch them deterministically. A clear/owner boundary,
       // however, detaches the old pump so it cannot race a newer generation.
       if (result.kind === 'cancelled') {
-        if (remoteOptimisticPumps.get(sessionId) !== run) return;
+        if (remoteOptimisticPumps.get(sessionId) !== runRef.promise) return;
         continue;
       }
       if (result.kind === 'failed') {
@@ -9853,8 +9903,9 @@ async function pumpRemoteOptimisticSends(sessionId: string): Promise<void> {
       }
     }
   })().finally(() => {
-    if (remoteOptimisticPumps.get(sessionId) === run) remoteOptimisticPumps.delete(sessionId);
+    if (remoteOptimisticPumps.get(sessionId) === runRef.promise) remoteOptimisticPumps.delete(sessionId);
   });
+  runRef.promise = run;
   remoteOptimisticPumps.set(sessionId, run);
   return run;
 }

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -9294,19 +9294,16 @@ function reconcilePendingInteractions(
           pendingRemoteDesktopConfirmationQueue: remainingRemoteConfirmations,
         };
       });
-      // When the authoritative snapshot replaces the displayed permission (e.g.
-      // device-link reconnects while old request A was in flight), rearm the
-      // gesture-dedupe guard instead of releasing it. Releasing here would let
-      // A's delayed double-click / key-repeat read the newly promoted B's
-      // requestId and approve B without an independent user decision. Rearming
-      // is symmetric with the dismissal path: B stays protected for the
-      // gesture window, then becomes actionable normally.
+      // P1 security: When the authoritative snapshot replaces the displayed
+      // permission (e.g. device-link reconnects while old request A was in
+      // flight), we must use requestId-based comparison — not reference equality
+      // — because reconciliation may recreate the permission object with the
+      // same requestId.  If the permission actually changed (different
+      // requestId), rearm the gesture window to protect the newly promoted card.
       const newPendingPermission = getOrCreateState(sessionId).pendingPermission;
-      if (
-        oldPendingPermission !== newPendingPermission &&
-        oldPendingPermission !== null &&
-        permissionResponseInFlight.has(sessionId)
-      ) {
+      const oldRequestId = oldPendingPermission?.requestId;
+      const newRequestId = newPendingPermission?.requestId;
+      if (permissionResponseInFlight.has(sessionId) && oldRequestId !== newRequestId && oldRequestId != null) {
         rearmPermissionResponseGuard(sessionId);
       }
       for (const item of list) {
@@ -14169,14 +14166,21 @@ function respondToPluginSetup(
 /**
  * F-PERM-2: Send a permission decision to the main process and clear pendingPermission.
  */
-function respondToPermission(sessionId: string, result: CCAgentPermissionResult): void {
+function respondToPermission(
+  sessionId: string,
+  result: CCAgentPermissionResult,
+  capturedRequestId?: string,
+): void {
   if (!sessionId) return;
   const state = getOrCreateState(sessionId);
   if (!state.pendingPermission) return;
 
-  // Capture the exact permission object BEFORE any guard check or state mutation.
-  const capturedRequest = state.pendingPermission;
-  const { requestId } = capturedRequest;
+  // P1 security: use the explicit requestId from the UI component if provided.
+  // This is the identity the user acted on when they clicked/pressed Enter.
+  // Falling back to state.pendingPermission.requestId only when the caller
+  // did not provide one (e.g. hardware approval path that doesn't go through
+  // PermissionPrompt).
+  const requestId = capturedRequestId ?? state.pendingPermission.requestId;
 
   // Session-scoped guard: block all responses during the gesture-dedupe window.
   if (permissionResponseInFlight.has(sessionId)) return;
@@ -14184,12 +14188,13 @@ function respondToPermission(sessionId: string, result: CCAgentPermissionResult)
   permissionResponseInFlight.set(sessionId, requestId);
   bumpInteractionReconcileEpoch(sessionId);
 
-  // Verify the captured permission is STILL the head of the queue.
+  // P1 security: verify the captured requestId is STILL the head of the queue.
   // Between the user click and this function body, a dismissal or reconnect
-  // may have replaced A with B.  Because setState is synchronous, we must
-  // check the live state AFTER arming the guard but BEFORE the transition.
+  // may have replaced A with B.  We compare by requestId value (not object
+  // reference) so that even if the permission object was recreated during
+  // reconciliation, the identity check is correct.
   const preState = getOrCreateState(sessionId);
-  if (preState.pendingPermission !== capturedRequest) {
+  if (preState.pendingPermission?.requestId !== requestId) {
     // Permission was replaced between click and guard arm.  A different card
     // is now the head — our click is stale.  Release guard and bail.
     releasePermissionResponseGuard(sessionId);

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -14165,21 +14165,28 @@ function respondToPermission(sessionId: string, result: CCAgentPermissionResult)
   if (!state.pendingPermission) return;
 
   // Capture the exact permission object BEFORE any guard check or state mutation.
-  // If a reconnect snapshot or dismissal replaces A with B between the user click
-  // and this function body, the stale click must not approve B.
   const capturedRequest = state.pendingPermission;
   const { requestId } = capturedRequest;
 
   // Session-scoped guard: block all responses during the gesture-dedupe window.
-  // This prevents double-click / key-repeat from approving the newly promoted card.
   if (permissionResponseInFlight.has(sessionId)) return;
 
   permissionResponseInFlight.add(sessionId);
   bumpInteractionReconcileEpoch(sessionId);
 
-  // Clear the displayed permission immediately and promote the next parallel
-  // request. Main keeps every resolver by requestId; the renderer must do the
-  // same rather than dropping the first tool_use when a later card arrives.
+  // Verify the captured permission is STILL the head of the queue.
+  // Between the user click and this function body, a dismissal or reconnect
+  // may have replaced A with B.  Because setState is synchronous, we must
+  // check the live state AFTER arming the guard but BEFORE the transition.
+  const preState = getOrCreateState(sessionId);
+  if (preState.pendingPermission !== capturedRequest) {
+    // Permission was replaced between click and guard arm.  A different card
+    // is now the head — our click is stale.  Release guard and bail.
+    releasePermissionResponseGuard(sessionId);
+    return;
+  }
+
+  // Promote the next parallel request from the queue.
   setState(sessionId, (s) => {
     const [nextPermission = null, ...remainingPermissions] = s.pendingPermissionQueue;
     return {
@@ -14188,15 +14195,6 @@ function respondToPermission(sessionId: string, result: CCAgentPermissionResult)
       pendingPermissionQueue: remainingPermissions,
     };
   });
-
-  // Verify that the captured permission is still the authoritative head.
-  // If a reconnect snapshot or dismissal promoted B while we were arming the
-  // guard, the stale click must not approve B.  Release the guard and bail.
-  const currentHead = getOrCreateState(sessionId).pendingPermission;
-  if (currentHead !== capturedRequest) {
-    releasePermissionResponseGuard(sessionId);
-    return;
-  }
 
   // Send to maker (InteractionDecision kind: 'permission').
   let response: Promise<unknown>;

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -9180,6 +9180,11 @@ function reconcilePendingInteractions(
         }
       }
       if (!isCurrentInteractionReconcile()) return 0;
+      // Capture the old pending permission before reconciliation so we can
+      // release the stale permissionResponseInFlight guard when the snapshot
+      // advances (P1: device-link reconnects while a permission request was
+      // in flight — the old guard blocks every action on the new request).
+      const oldPendingPermission = getOrCreateState(sessionId).pendingPermission;
       setState(sessionId, (state) => {
         // Permission snapshots are authoritative too. In particular, do not
         // append the snapshot behind a stale displayed request: a renderer can
@@ -9272,6 +9277,17 @@ function reconcilePendingInteractions(
           pendingRemoteDesktopConfirmationQueue: remainingRemoteConfirmations,
         };
       });
+      // When the authoritative snapshot replaces the displayed permission (e.g.
+      // device-link reconnects while old request was in flight), release the
+      // stale guard so the newly promoted request can be acted on immediately.
+      const newPendingPermission = getOrCreateState(sessionId).pendingPermission;
+      if (
+        oldPendingPermission !== newPendingPermission &&
+        oldPendingPermission !== null &&
+        permissionResponseInFlight.has(sessionId)
+      ) {
+        releasePermissionResponseGuard(sessionId);
+      }
       for (const item of list) {
         if (!isCurrentInteractionReconcile()) return 0;
         applyInteractionRequestRef?.(

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -2889,6 +2889,8 @@ export const EMPTY_SESSION_STATE: SessionChatState = Object.freeze({
 // ---------------------------------------------------------------------------
 
 const sessions = new Map<string, SessionChatState>();
+/** Prevent one gesture from resolving the newly promoted permission head. */
+const permissionResponseInFlight = new Set<string>();
 const listeners = new Map<string, Set<() => void>>();
 const lightSnapshotCache = new Map<string, SessionChatLightState>();
 
@@ -3372,6 +3374,7 @@ function _purgeSession(sessionId: string): void {
   // 交接中的迟到 continuation，且不写入 /clear 的历史时间边界。
   bumpRendererClearGeneration(sessionId);
   cancelRemoteOptimisticSendsForSessionPurge(sessionId);
+  permissionResponseInFlight.delete(sessionId);
   clearWakeBridgeReconcileTimer(sessionId);
   cancelIdlePlanDiscovery(sessionId);
   sessions.delete(sessionId);
@@ -14078,11 +14081,12 @@ function respondToPluginSetup(
  * F-PERM-2: Send a permission decision to the main process and clear pendingPermission.
  */
 function respondToPermission(sessionId: string, result: CCAgentPermissionResult): void {
-  if (!sessionId) return;
+  if (!sessionId || permissionResponseInFlight.has(sessionId)) return;
   const state = getOrCreateState(sessionId);
   if (!state.pendingPermission) return;
 
   const { requestId } = state.pendingPermission;
+  permissionResponseInFlight.add(sessionId);
   bumpInteractionReconcileEpoch(sessionId);
 
   // Clear the displayed permission immediately and promote the next parallel
@@ -14097,9 +14101,12 @@ function respondToPermission(sessionId: string, result: CCAgentPermissionResult)
     };
   });
 
-  // Send to maker (InteractionDecision kind: 'permission')
-  makerApiFor(sessionId)
-    .resolveInteraction(requestId, {
+  // Send to maker (InteractionDecision kind: 'permission'). Keep the guard
+  // until the IPC request settles: a duplicate click/key-repeat must not read
+  // the newly promoted queue head and reuse the previous decision for it.
+  let response: Promise<unknown>;
+  try {
+    response = makerApiFor(sessionId).resolveInteraction(requestId, {
       kind: 'permission',
       behavior: result.behavior,
       updatedInput: (result as { updatedInput?: Record<string, unknown> }).updatedInput,
@@ -14107,8 +14114,15 @@ function respondToPermission(sessionId: string, result: CCAgentPermissionResult)
       permissionUpdates: Array.isArray(result.updatedPermissions)
         ? result.updatedPermissions
         : undefined,
-    })
-    .catch((err) => log.error('Failed to respond to permission:', err));
+    });
+  } catch (err) {
+    permissionResponseInFlight.delete(sessionId);
+    log.error('Failed to respond to permission:', err);
+    return;
+  }
+  void response
+    .catch((err) => log.error('Failed to respond to permission:', err))
+    .finally(() => permissionResponseInFlight.delete(sessionId));
 }
 
 /**

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -14214,7 +14214,16 @@ function respondToPermission(sessionId: string, result: CCAgentPermissionResult)
     return;
   }
   void response
-    .catch((err) => log.error('Failed to respond to permission:', err))
+    .catch((err) => {
+      log.error('Failed to respond to permission:', err);
+      // The resolve never reached the host (device-link disconnect / timeout
+      // before settling).  We already promoted A out of the queue and showed
+      // B, but the host is still waiting on A.  Reconcile against the
+      // authoritative host snapshot: if A is still pending there it is
+      // restored as the head; if the host actually resolved it, A is not
+      // resurrected.  Never let the renderer guess — the host owns the truth.
+      void reconcilePendingInteractions(sessionId).catch(() => undefined);
+    })
     .finally(() => {
       armPermissionResponseGuard(sessionId);
     });

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -2896,8 +2896,12 @@ const sessions = new Map<string, SessionChatState>();
  */
 /** Maps sessionId → requestId of the in-flight permission response. */
 const permissionResponseInFlight = new Map<string, string>();
-/** Gesture dedupe window: prevents double-click from approving the newly promoted card. */
-const PERMISSION_RESPONSE_GUARD_WINDOW_MS = 300;
+/**
+ * Gesture dedupe window: prevents double-click from approving the newly promoted card.
+ * Must cover the platform double-click interval — Windows defaults to 500ms, so a
+ * second click of a double-click (350–500ms) after A resolves must not land on B.
+ */
+const PERMISSION_RESPONSE_GUARD_WINDOW_MS = 500;
 /** Timer per session for gesture dedupe release (purge / dismissal cleanup). */
 const permissionResponseGuardTimers = new Map<string, ReturnType<typeof setTimeout>>();
 

--- a/apps/desktop/src/renderer/vite-env.d.ts
+++ b/apps/desktop/src/renderer/vite-env.d.ts
@@ -759,6 +759,8 @@ interface CCAgentPermissionRequestPayload {
 
 interface CCAgentPermissionResult {
   behavior: 'allow' | 'deny';
+  /** Identity of the permission card the user actually acted on. */
+  requestId?: string;
   message?: string;
   updatedPermissions?: unknown[];
   decisionClassification?: string;


### PR DESCRIPTION
## 这次改了什么

### 摘要

并行权限请求（如两个 tool 同时请求文件系统访问）时，第二个请求会覆盖第一个，导致第一个权限请求丢失。本次为权限请求添加 FIFO 队列，按到达顺序逐个处理；并为每个权限响应绑定 `requestId`，防止过期响应（如断线重连后旧请求的延迟 click）错误批准当前显示的权限请求。

### 变更类型

- [x] fix 缺陷修复

### 范围

- 关联 Issue / 需求：#3092
- 本 PR 包含（8 个文件）：
  - `apps/desktop/src/renderer/lib/makerChatStore.ts` — 权限 FIFO 队列、`respondToPermission` 的 requestId 绑定与队首校验、`reconcilePendingInteractions` 重连快照对账、手势去重（平台级 `MouseEvent.detail` 双击识别 + in-flight guard 兜底）
  - `apps/desktop/src/renderer/components/new-chat/PermissionPrompt.tsx` — mount 时冻结手势身份、平台级重复点击拦截（`detail>1`）
  - `apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx` — 按 `requestId` remount 权限卡
  - `apps/desktop/src/renderer/hooks/useCCAgentChat.ts`、`vite-env.d.ts` — 接线与类型
  - 测试：`deviceLinkInteractionScenarios.test.ts`、`makerQueueState.test.ts`、`PermissionPrompt.test.tsx`
- 明确不包含：不修改权限协议安全边界；不修改权限 UI 卡片样式（视觉）。
- 用户可见变化：并行权限请求时第一张卡片处理完后自动推进到第二张，不再丢失；重连/重载后旧请求的延迟响应不会误批当前请求。
- 是否存在 breaking change：无。

### 远程 / 手机适配（remote-and-mobile-adaptation.md 三问）

1. **SSH 远程工作区**：已适配。改动是 renderer 侧权限状态机与 UI 事件处理，不新增 fs / exec / remote-file-service 依赖；SSH 下同一套 renderer 逻辑运行在远程工作区，行为一致。
2. **device-link / IPC 白名单**：已适配（未新增 IPC channel）。本 PR 修改了 device-link 重连时的权限快照对账（`reconcilePendingInteractions`）与同会话权限 guard 状态，属既有 IPC 通道内的行为修正，不新增 invoke/push 白名单项；`deviceLinkInteractionScenarios.test.ts` 覆盖重连快照 / 迟到响应 / 双击误批回归。
3. **手机版**：由 device-link 控制端复用本 PR 的权限对账行为；手机版不新增独立入口/UI（权限卡在桌面端渲染），行为经 device-link 隧道一致。

## 怎么验证的

- 单元测试：desktop 相关套件（deviceLink 场景、权限队列、PermissionPrompt 组件）覆盖 FIFO、requestId 绑定、重连对账、双击去重、迟到手势 no-op。
- 说明：本环境 tarball 工作树的 pnpm workspace 链接不完整，`vitest` 无法解析 `@cindy/*` 包（ERR_MODULE_NOT_FOUND），本地单测未能实跑，以 CI 全量单测为准。

## 风险

- 中低风险——修改了权限请求的核心状态管理路径，但有 device-link / 队列 / PermissionPrompt 多套回归覆盖。
- 潜在影响：权限请求顺序严格按 FIFO；平台级双击识别依赖浏览器 `MouseEvent.detail`（由 OS 双击间隔判定）。
- 无 breaking change，不修改权限协议安全边界。

### UI 变化

- 引用的设计规范：不涉及。本 PR 为逻辑/行为修复，不改变视觉设计或交互规范。
