### PR TITLE
fix(desktop): 并发权限卡排队展示,修复先到确认卡被覆盖后 600s 超时 (#3092)

### DIFF
--- a/apps/desktop/src/renderer/__tests__/makerQueueState.test.ts
+++ b/apps/desktop/src/renderer/__tests__/makerQueueState.test.ts
@@ -90,6 +90,7 @@ const state = (overrides: Partial<SessionChatState> = {}): SessionChatState => (
   sdkSessionId: null,
   pendingPermission: null,
   pendingPermissionQueue: [],
+  settlingPermissionRequestId: null,
   pendingAskUser: null,
   askUserViewerState: 'expanded',
   askUserDraft: null,

--- a/apps/desktop/src/renderer/__tests__/makerQueueState.test.ts
+++ b/apps/desktop/src/renderer/__tests__/makerQueueState.test.ts
@@ -89,6 +89,7 @@ const state = (overrides: Partial<SessionChatState> = {}): SessionChatState => (
   historyLoaded: true,
   sdkSessionId: null,
   pendingPermission: null,
+  pendingPermissionQueue: [],
   pendingAskUser: null,
   askUserViewerState: 'expanded',
   askUserDraft: null,

--- a/apps/desktop/src/renderer/__tests__/permissionCardQueue.test.ts
+++ b/apps/desktop/src/renderer/__tests__/permissionCardQueue.test.ts
@@ -231,6 +231,61 @@ describe('permission card queue (issue #3092)', () => {
     expect(snap.pendingPermissionQueue.map((p) => p.requestId)).toEqual(['perm-3']);
   });
 
+  it('queues a fresh request arriving in the settlement window instead of surfacing it', () => {
+    pushPermission('perm-1');
+    pushPermission('perm-2');
+
+    makerChatStore.respondToPermission(SESSION_ID, { behavior: 'allow' });
+    // perm-3 arrives while perm-1 awaits main's confirmation: it must join the
+    // back of the queue, not jump onto the empty slot ahead of perm-2
+    // (Greptile review on #3104).
+    pushPermission('perm-3');
+
+    let snap = makerChatStore.getSnapshot(SESSION_ID);
+    expect(snap.pendingPermission).toBeNull();
+    expect(snap.pendingPermissionQueue.map((p) => p.requestId)).toEqual(['perm-2', 'perm-3']);
+
+    listeners.dismissed?.({
+      sessionId: SESSION_ID,
+      requestId: 'perm-1',
+      reason: 'resolved',
+      decision: { kind: 'permission', behavior: 'allow' },
+    });
+
+    snap = makerChatStore.getSnapshot(SESSION_ID);
+    expect(snap.pendingPermission?.requestId).toBe('perm-2');
+    expect(snap.pendingPermissionQueue.map((p) => p.requestId)).toEqual(['perm-3']);
+  });
+
+  it('does not promote the queue on an unrelated dismissal in the settlement window', () => {
+    pushPermission('perm-1');
+    pushPermission('perm-2');
+
+    makerChatStore.respondToPermission(SESSION_ID, { behavior: 'allow' });
+    // e.g. an optimistically-cleared ask/plan interaction settles at this exact
+    // moment — its dismissal matches no pending state and must NOT surface
+    // perm-2 while repeat inputs may still be arriving (Codex review on #3104).
+    listeners.dismissed?.({
+      sessionId: SESSION_ID,
+      requestId: 'ask-unrelated',
+      reason: 'resolved',
+      decision: { kind: 'ask_user_question', answers: {} },
+    });
+
+    let snap = makerChatStore.getSnapshot(SESSION_ID);
+    expect(snap.pendingPermission).toBeNull();
+    expect(snap.pendingPermissionQueue.map((p) => p.requestId)).toEqual(['perm-2']);
+
+    listeners.dismissed?.({
+      sessionId: SESSION_ID,
+      requestId: 'perm-1',
+      reason: 'resolved',
+      decision: { kind: 'permission', behavior: 'allow' },
+    });
+    snap = makerChatStore.getSnapshot(SESSION_ID);
+    expect(snap.pendingPermission?.requestId).toBe('perm-2');
+  });
+
   it('refreshes on duplicate requestId without duplicating queue entries', () => {
     pushPermission('perm-1', 'first title');
     pushPermission('perm-2', 'queued title');

--- a/apps/desktop/src/renderer/__tests__/permissionCardQueue.test.ts
+++ b/apps/desktop/src/renderer/__tests__/permissionCardQueue.test.ts
@@ -1,0 +1,215 @@
+/**
+ * permissionCardQueue.test.ts
+ * ---------------------------------------------------------------------------
+ * Regression coverage for issue #3092: parallel tool_use in one assistant
+ * message broadcasts several permission requests near-simultaneously. The
+ * renderer used to keep a single `pendingPermission` slot, so the later card
+ * overwrote the earlier one — the earlier request could never be shown or
+ * answered, its main-process resolver waited out the 10-minute timeout, and
+ * the engine recorded deny('timeout') for a tool call that was never run.
+ *
+ * These tests pin the queue semantics: one card shown at a time, later
+ * requests wait in pendingPermissionQueue, and the queue advances when the
+ * current card is answered (respondToPermission) or dismissed by main.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/messageService', () => ({
+  list: vi.fn(async () => ({ items: [], hasMore: false, oldestId: null })),
+  create: vi.fn(async () => ({}) as unknown),
+  updateContent: vi.fn(async () => ({}) as unknown),
+}));
+
+vi.mock('@/lib/sessionService', () => ({
+  update: vi.fn(async () => {}),
+  touchUserSend: vi.fn(async () => {}),
+}));
+
+vi.mock('@/lib/sessionsBus', () => ({
+  emitPatch: vi.fn(),
+}));
+
+vi.mock('@/lib/userPromptStore', () => ({
+  getUserPrompt: () => '',
+}));
+
+vi.mock('@/lib/imageRef', () => ({
+  parseUserContent: vi.fn((c: string) => ({ text: c, images: [], files: [] })),
+  stringifyUserContent: vi.fn((text: string) => text),
+}));
+
+vi.mock('@/lib/composerDraftStore', () => ({
+  saveDraft: vi.fn(),
+  setRemoteOptimisticAttachmentUrls: vi.fn(),
+  plainTextToTiptapDoc: (s: string) => ({
+    type: 'doc',
+    content: [{ type: 'paragraph', content: [{ type: 'text', text: s }] }],
+  }),
+}));
+
+import { makerChatStore } from '@/lib/makerChatStore';
+
+const SESSION_ID = 'perm-card-queue';
+
+type ListenerKey =
+  | 'event'
+  | 'statusChanged'
+  | 'inputProjection'
+  | 'interaction'
+  | 'dismissed'
+  | 'messageCreated';
+
+let listeners: Partial<Record<ListenerKey, (data: unknown) => void>>;
+let resolveInteraction: ReturnType<typeof vi.fn>;
+let listActive: ReturnType<typeof vi.fn>;
+
+function subscribe(key: ListenerKey) {
+  return (cb: (data: unknown) => void) => {
+    listeners[key] = cb;
+    return vi.fn();
+  };
+}
+
+function installElectronBridge(): void {
+  resolveInteraction = vi.fn(async () => {});
+  listActive = vi.fn(async () => []);
+  listeners = {};
+  const w = globalThis as unknown as { window: Record<string, unknown> };
+  w.window = {
+    electronAPI: {
+      maker: {
+        onEvent: subscribe('event'),
+        onStatusChanged: subscribe('statusChanged'),
+        onInputProjection: subscribe('inputProjection'),
+        onInteractionRequest: subscribe('interaction'),
+        onInteractionDismissed: subscribe('dismissed'),
+        input: {
+          getProjection: vi.fn(async (sessionId: string) => ({
+            sessionId,
+            pendingQueue: [],
+            steeringQueueClientIds: [],
+            queuePaused: false,
+            queueExpanded: false,
+            queueInteractionLocks: [],
+            queueEditLocks: [],
+            queueAbortPending: false,
+            error: null,
+            recovery: null,
+            errorRetryText: null,
+          })),
+        },
+        resolveInteraction,
+        send: vi.fn(async () => {}),
+        generateTitle: vi.fn(async () => ({ title: 't' })),
+        abortSession: vi.fn(async () => {}),
+        closeSession: vi.fn(async () => {}),
+        listActive,
+      },
+      localDb: {
+        messages: {
+          onCreated: subscribe('messageCreated'),
+        },
+      },
+    },
+  };
+}
+
+function pushPermission(requestId: string, title?: string): void {
+  listeners.interaction?.({
+    sessionId: SESSION_ID,
+    request: {
+      kind: 'permission',
+      requestId,
+      toolName: 'Read',
+      input: { file_path: `/outside/${requestId}.md` },
+      title,
+    },
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  makerChatStore.__teardownGlobalListeners();
+  makerChatStore.purgeSession(SESSION_ID);
+  installElectronBridge();
+  makerChatStore.initGlobalListeners();
+});
+
+describe('permission card queue (issue #3092)', () => {
+  it('queues a second concurrent request instead of overwriting the first', () => {
+    pushPermission('perm-1');
+    pushPermission('perm-2');
+
+    const snap = makerChatStore.getSnapshot(SESSION_ID);
+    expect(snap.pendingPermission?.requestId).toBe('perm-1');
+    expect(snap.pendingPermissionQueue.map((p) => p.requestId)).toEqual(['perm-2']);
+  });
+
+  it('advances to the queued card after the current one is answered', () => {
+    pushPermission('perm-1');
+    pushPermission('perm-2');
+
+    makerChatStore.respondToPermission(SESSION_ID, { behavior: 'allow' });
+
+    expect(resolveInteraction).toHaveBeenCalledWith(
+      'perm-1',
+      expect.objectContaining({ kind: 'permission', behavior: 'allow' }),
+    );
+    const snap = makerChatStore.getSnapshot(SESSION_ID);
+    expect(snap.pendingPermission?.requestId).toBe('perm-2');
+    expect(snap.pendingPermissionQueue).toEqual([]);
+
+    makerChatStore.respondToPermission(SESSION_ID, { behavior: 'deny' });
+    expect(resolveInteraction).toHaveBeenCalledWith(
+      'perm-2',
+      expect.objectContaining({ kind: 'permission', behavior: 'deny' }),
+    );
+    expect(makerChatStore.getSnapshot(SESSION_ID).pendingPermission).toBeNull();
+  });
+
+  it('advances to the queued card when main dismisses the current one', () => {
+    pushPermission('perm-1');
+    pushPermission('perm-2');
+
+    listeners.dismissed?.({
+      sessionId: SESSION_ID,
+      requestId: 'perm-1',
+      reason: 'timeout',
+    });
+
+    const snap = makerChatStore.getSnapshot(SESSION_ID);
+    expect(snap.pendingPermission?.requestId).toBe('perm-2');
+    expect(snap.pendingPermissionQueue).toEqual([]);
+  });
+
+  it('removes a queued card that main dismissed without touching the shown one', () => {
+    pushPermission('perm-1');
+    pushPermission('perm-2');
+    pushPermission('perm-3');
+
+    listeners.dismissed?.({
+      sessionId: SESSION_ID,
+      requestId: 'perm-2',
+      reason: 'timeout',
+    });
+
+    const snap = makerChatStore.getSnapshot(SESSION_ID);
+    expect(snap.pendingPermission?.requestId).toBe('perm-1');
+    expect(snap.pendingPermissionQueue.map((p) => p.requestId)).toEqual(['perm-3']);
+  });
+
+  it('refreshes on duplicate requestId without duplicating queue entries', () => {
+    pushPermission('perm-1', 'first title');
+    pushPermission('perm-2', 'queued title');
+    // Reconcile replay re-broadcasts the same pending requests.
+    pushPermission('perm-1', 'replayed title');
+    pushPermission('perm-2', 'replayed queued title');
+
+    const snap = makerChatStore.getSnapshot(SESSION_ID);
+    expect(snap.pendingPermission?.requestId).toBe('perm-1');
+    expect(snap.pendingPermission?.title).toBe('replayed title');
+    expect(snap.pendingPermissionQueue.map((p) => p.requestId)).toEqual(['perm-2']);
+    expect(snap.pendingPermissionQueue[0]?.title).toBe('replayed queued title');
+  });
+});

--- a/apps/desktop/src/renderer/__tests__/permissionCardQueue.test.ts
+++ b/apps/desktop/src/renderer/__tests__/permissionCardQueue.test.ts
@@ -146,7 +146,7 @@ describe('permission card queue (issue #3092)', () => {
     expect(snap.pendingPermissionQueue.map((p) => p.requestId)).toEqual(['perm-2']);
   });
 
-  it('advances to the queued card after the current one is answered', () => {
+  it('advances to the queued card only after main confirms the answered one', () => {
     pushPermission('perm-1');
     pushPermission('perm-2');
 
@@ -156,7 +156,20 @@ describe('permission card queue (issue #3092)', () => {
       'perm-1',
       expect.objectContaining({ kind: 'permission', behavior: 'allow' }),
     );
-    const snap = makerChatStore.getSnapshot(SESSION_ID);
+    // Optimistic clear only — the next card must wait for main's settlement so
+    // repeat inputs (held Enter / double click) cannot spill onto it.
+    let snap = makerChatStore.getSnapshot(SESSION_ID);
+    expect(snap.pendingPermission).toBeNull();
+    expect(snap.pendingPermissionQueue.map((p) => p.requestId)).toEqual(['perm-2']);
+
+    listeners.dismissed?.({
+      sessionId: SESSION_ID,
+      requestId: 'perm-1',
+      reason: 'resolved',
+      decision: { kind: 'permission', behavior: 'allow' },
+    });
+
+    snap = makerChatStore.getSnapshot(SESSION_ID);
     expect(snap.pendingPermission?.requestId).toBe('perm-2');
     expect(snap.pendingPermissionQueue).toEqual([]);
 
@@ -166,6 +179,25 @@ describe('permission card queue (issue #3092)', () => {
       expect.objectContaining({ kind: 'permission', behavior: 'deny' }),
     );
     expect(makerChatStore.getSnapshot(SESSION_ID).pendingPermission).toBeNull();
+  });
+
+  it('ignores repeat answers while the settled card awaits main confirmation', () => {
+    pushPermission('perm-1');
+    pushPermission('perm-2');
+
+    // Held-down Enter / double click: second respond fires before main's
+    // dismissed broadcast arrives. It must not touch the queued card.
+    makerChatStore.respondToPermission(SESSION_ID, { behavior: 'allow' });
+    makerChatStore.respondToPermission(SESSION_ID, { behavior: 'allow' });
+
+    expect(resolveInteraction).toHaveBeenCalledTimes(1);
+    expect(resolveInteraction).toHaveBeenCalledWith(
+      'perm-1',
+      expect.objectContaining({ kind: 'permission', behavior: 'allow' }),
+    );
+    const snap = makerChatStore.getSnapshot(SESSION_ID);
+    expect(snap.pendingPermission).toBeNull();
+    expect(snap.pendingPermissionQueue.map((p) => p.requestId)).toEqual(['perm-2']);
   });
 
   it('advances to the queued card when main dismisses the current one', () => {

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -2422,6 +2422,15 @@ export interface SessionChatState {
    * card at a time, advance when the current card is answered or dismissed.
    */
   pendingPermissionQueue: PendingPermission[];
+  /**
+   * requestId of the permission the user just answered, until main's
+   * settlement (permission_dismissed) arrives. While set, new requests queue
+   * instead of taking the empty slot, and only THIS requestId's dismissal
+   * promotes the queue head — an unrelated ask/plan dismissal or a fresh
+   * request must not surface a card during the repeat-input window
+   * (Codex/Greptile review on #3104).
+   */
+  settlingPermissionRequestId: string | null;
   /** F7.2: Currently pending ask-user-question; null when none. */
   pendingAskUser: PendingAskUser | null;
   /** Host-owned plugin setup snapshot; updates replace by monotonic revision. */
@@ -2711,6 +2720,7 @@ function createInitialState(): SessionChatState {
     streamingText: '',
     pendingPermission: null,
     pendingPermissionQueue: [],
+    settlingPermissionRequestId: null,
     pendingAskUser: null,
     pendingPluginSetup: null,
     pendingPluginSetupQueue: [],
@@ -2788,6 +2798,7 @@ export const EMPTY_SESSION_STATE: SessionChatState = Object.freeze({
   sdkSessionId: null,
   pendingPermission: null,
   pendingPermissionQueue: [],
+  settlingPermissionRequestId: null,
   pendingAskUser: null,
   pendingPluginSetup: null,
   pendingPluginSetupQueue: [],
@@ -5229,6 +5240,7 @@ export function handleStreamEvent(
         errorRetryText: finalized.error ? finalized.errorRetryText : null,
         pendingPermission: null,
         pendingPermissionQueue: [],
+        settlingPermissionRequestId: null,
         pendingAskUser: null,
         continuationTurnClientId: null,
         // F-AUQ-MIN-5: viewerState lives with pendingAskUser — when the
@@ -5437,6 +5449,7 @@ export function handleStreamEvent(
         // accumulated delta text doesn't linger in memory.
         pendingPermission: null,
         pendingPermissionQueue: [],
+        settlingPermissionRequestId: null,
         pendingAskUser: null,
         // F-AUQ-MIN-5: same reset as the 'done' path.
         askUserViewerState: 'expanded',
@@ -5484,7 +5497,23 @@ export function handleStreamEvent(
       // tool_use 记成 deny('timeout')(issue #3092)。与 pendingPluginSetup 同构:
       // 一次展示一张,其余按到达顺序排队;同 requestId 重复投递(重连 reconcile
       // 重放)只刷新内容、不重复排队。
-      if (!state.pendingPermission || state.pendingPermission.requestId === incoming.requestId) {
+      if (state.pendingPermission?.requestId === incoming.requestId) {
+        return { ...state, pendingPermission: incoming };
+      }
+      if (state.settlingPermissionRequestId === incoming.requestId) {
+        // 已被本端应答、正等 main 收敛的请求被重复投递(reconcile 重放拉到在途
+        // 快照)→ 不重新展示;应答若真丢了,main 的超时 dismissal 会经 settling
+        // 分支收口并推进队列。
+        return state;
+      }
+      // 空槽也必须同时满足「无在途应答、队列为空」才能直接上位:settling 窗口内
+      // 或队列有存货时,新请求直接上位等于插队,且长按 Enter 的重复输入会落在
+      // 这张未审阅的新卡上(Greptile review on #3104)。
+      if (
+        !state.pendingPermission
+        && !state.settlingPermissionRequestId
+        && state.pendingPermissionQueue.length === 0
+      ) {
         return { ...state, pendingPermission: incoming };
       }
       const queuedIndex = state.pendingPermissionQueue.findIndex(
@@ -5518,6 +5547,19 @@ export function handleStreamEvent(
         const [nextPermission = null, ...remainingPermissions] = state.pendingPermissionQueue;
         return {
           ...state,
+          pendingPermission: nextPermission,
+          pendingPermissionQueue: remainingPermissions,
+        };
+      }
+      if (state.settlingPermissionRequestId === data.requestId) {
+        // 本端应答后的收敛广播(resolved,或应答丢失时 main 的 timeout 兜底)。
+        // 只有这个精确 requestId 才推进队首 —— ask/plan 等其它交互乐观清后的无
+        // 归属 dismissal 若恰好落在此窗口,不得替它放行下一张权限卡(Codex
+        // review on #3104)。
+        const [nextPermission = null, ...remainingPermissions] = state.pendingPermissionQueue;
+        return {
+          ...state,
+          settlingPermissionRequestId: null,
           pendingPermission: nextPermission,
           pendingPermissionQueue: remainingPermissions,
         };
@@ -5625,18 +5667,6 @@ export function handleStreamEvent(
                 : { ...m, planReviewStatus: 'expired' as const }
               : m,
           ),
-        };
-      }
-      // 无任何归属的 dismissed = 本端应答后(respondToPermission 乐观清)main 的
-      // resolved 收敛广播,该 requestId 已不在任何 pending 状态里。此刻才推进权限
-      // 队列 —— 与「应答即推进」相比,把下一张卡的上位挡在 main 确认之后,长按
-      // Enter / 双击的重复输入不会跨卡误批(Codex review on #3104)。
-      if (!state.pendingPermission && state.pendingPermissionQueue.length > 0) {
-        const [nextPermission = null, ...remainingPermissions] = state.pendingPermissionQueue;
-        return {
-          ...state,
-          pendingPermission: nextPermission,
-          pendingPermissionQueue: remainingPermissions,
         };
       }
       return state;
@@ -5858,6 +5888,7 @@ function forceFinalizeOnSessionClosed(state: SessionChatState): SessionChatState
     !state.isStreaming &&
     !state.pendingPermission &&
     state.pendingPermissionQueue.length === 0 &&
+    !state.settlingPermissionRequestId &&
     !state.pendingAskUser &&
     !state.pendingPluginSetup &&
     state.pendingPluginSetupQueue.length === 0 &&
@@ -5908,6 +5939,7 @@ function forceFinalizeOnSessionClosed(state: SessionChatState): SessionChatState
     errorRetryText: null,
     pendingPermission: null,
     pendingPermissionQueue: [],
+    settlingPermissionRequestId: null,
     pendingAskUser: null,
     pendingPluginSetup: null,
     pendingPluginSetupQueue: [],
@@ -12669,6 +12701,7 @@ function stopSession(
       errorRetryText: null,
       pendingPermission: null,
       pendingPermissionQueue: [],
+      settlingPermissionRequestId: null,
       continuationTurnClientId: null,
       pendingAskUser: null,
       // F-AUQ-MIN-5: Stop session — pending question is gone, reset viewer.
@@ -13114,8 +13147,9 @@ async function clearSessionAfterGuardImpl(sessionId: string, clearedAt: string):
       errorRetryText: null,
       pendingPermission: null,
       // /clear 期间远端 dismissal 可能丢失;残留队列会在新会话把 clear 前的幽灵
-      // 权限卡顶上来(Codex review on #3104)→ 与当前卡一起本地清空。
+      // 权限卡顶上来(Codex review on #3104)→ 与当前卡、settling 标记一起本地清空。
       pendingPermissionQueue: [],
+      settlingPermissionRequestId: null,
       pendingAskUser: null,
       pendingPluginSetup: null,
       pendingPluginSetupQueue: [],
@@ -13429,13 +13463,17 @@ function respondToPermission(sessionId: string, result: CCAgentPermissionResult)
   // Clear the pending permission immediately so the UI updates. Deliberately do
   // NOT promote the next queued card here: a held-down Enter (keydown repeat)
   // or a double click would land the same "allow" on a card the user has not
-  // reviewed yet (Codex review on #3104). The queue advances only when main
-  // confirms this request is settled — its permission_dismissed
-  // (reason='resolved') broadcast, or the timeout/mode-change fallback, hits
-  // the no-match tail of the permission_dismissed handler and promotes the
-  // queue head. Repeat inputs in that window land on the empty slot and are
-  // ignored by the guard above.
-  setState(sessionId, (s) => ({ ...s, pendingPermission: null }));
+  // reviewed yet (Codex review on #3104). Record the requestId being settled —
+  // the queue advances only when main's permission_dismissed for exactly this
+  // id arrives (reason='resolved', or the timeout/mode-change fallback when
+  // the response was lost). Repeat inputs in that window land on the empty slot and are
+  // ignored by the guard above; unrelated dismissals and fresh requests cannot
+  // surface a card during the window either.
+  setState(sessionId, (s) => ({
+    ...s,
+    pendingPermission: null,
+    settlingPermissionRequestId: requestId,
+  }));
 
   // Send to maker (InteractionDecision kind: 'permission')
   makerApiFor(sessionId)

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -5627,6 +5627,18 @@ export function handleStreamEvent(
           ),
         };
       }
+      // 无任何归属的 dismissed = 本端应答后(respondToPermission 乐观清)main 的
+      // resolved 收敛广播,该 requestId 已不在任何 pending 状态里。此刻才推进权限
+      // 队列 —— 与「应答即推进」相比,把下一张卡的上位挡在 main 确认之后,长按
+      // Enter / 双击的重复输入不会跨卡误批(Codex review on #3104)。
+      if (!state.pendingPermission && state.pendingPermissionQueue.length > 0) {
+        const [nextPermission = null, ...remainingPermissions] = state.pendingPermissionQueue;
+        return {
+          ...state,
+          pendingPermission: nextPermission,
+          pendingPermissionQueue: remainingPermissions,
+        };
+      }
       return state;
     }
 
@@ -13101,6 +13113,9 @@ async function clearSessionAfterGuardImpl(sessionId: string, clearedAt: string):
       activeTurnRetryText: null,
       errorRetryText: null,
       pendingPermission: null,
+      // /clear 期间远端 dismissal 可能丢失;残留队列会在新会话把 clear 前的幽灵
+      // 权限卡顶上来(Codex review on #3104)→ 与当前卡一起本地清空。
+      pendingPermissionQueue: [],
       pendingAskUser: null,
       pendingPluginSetup: null,
       pendingPluginSetupQueue: [],
@@ -13411,18 +13426,16 @@ function respondToPermission(sessionId: string, result: CCAgentPermissionResult)
   const { requestId } = state.pendingPermission;
   bumpInteractionReconcileEpoch(sessionId);
 
-  // Clear the pending permission immediately so the UI updates, and advance the
-  // queue in the same commit — parallel tool_use may have more cards waiting
-  // (issue #3092). The follow-up permission_dismissed broadcast for this
-  // requestId no longer matches the (new) current card and is a no-op.
-  setState(sessionId, (s) => {
-    const [nextPermission = null, ...remainingPermissions] = s.pendingPermissionQueue;
-    return {
-      ...s,
-      pendingPermission: nextPermission,
-      pendingPermissionQueue: remainingPermissions,
-    };
-  });
+  // Clear the pending permission immediately so the UI updates. Deliberately do
+  // NOT promote the next queued card here: a held-down Enter (keydown repeat)
+  // or a double click would land the same "allow" on a card the user has not
+  // reviewed yet (Codex review on #3104). The queue advances only when main
+  // confirms this request is settled — its permission_dismissed
+  // (reason='resolved') broadcast, or the timeout/mode-change fallback, hits
+  // the no-match tail of the permission_dismissed handler and promotes the
+  // queue head. Repeat inputs in that window land on the empty slot and are
+  // ignored by the guard above.
+  setState(sessionId, (s) => ({ ...s, pendingPermission: null }));
 
   // Send to maker (InteractionDecision kind: 'permission')
   makerApiFor(sessionId)

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -2412,6 +2412,16 @@ export interface SessionChatState {
   sdkSessionId: string | null;
   /** F-PERM-2: Currently pending permission request; null when none. */
   pendingPermission: PendingPermission | null;
+  /**
+   * Additional permission requests for this session, in arrival order. Parallel
+   * tool_use in one assistant message can broadcast several permission requests
+   * near-simultaneously; a single slot would let the later card overwrite the
+   * earlier one, which then can never be shown or answered — its main-process
+   * resolver just waits out the 10-minute timeout and the engine records
+   * deny('timeout') (issue #3092). Mirrors pendingPluginSetupQueue: show one
+   * card at a time, advance when the current card is answered or dismissed.
+   */
+  pendingPermissionQueue: PendingPermission[];
   /** F7.2: Currently pending ask-user-question; null when none. */
   pendingAskUser: PendingAskUser | null;
   /** Host-owned plugin setup snapshot; updates replace by monotonic revision. */
@@ -2700,6 +2710,7 @@ function createInitialState(): SessionChatState {
     streamingClientId: null,
     streamingText: '',
     pendingPermission: null,
+    pendingPermissionQueue: [],
     pendingAskUser: null,
     pendingPluginSetup: null,
     pendingPluginSetupQueue: [],
@@ -2776,6 +2787,7 @@ export const EMPTY_SESSION_STATE: SessionChatState = Object.freeze({
   historyLoaded: true,
   sdkSessionId: null,
   pendingPermission: null,
+  pendingPermissionQueue: [],
   pendingAskUser: null,
   pendingPluginSetup: null,
   pendingPluginSetupQueue: [],
@@ -5216,6 +5228,7 @@ export function handleStreamEvent(
         activeTurnRetryText: null,
         errorRetryText: finalized.error ? finalized.errorRetryText : null,
         pendingPermission: null,
+        pendingPermissionQueue: [],
         pendingAskUser: null,
         continuationTurnClientId: null,
         // F-AUQ-MIN-5: viewerState lives with pendingAskUser — when the
@@ -5423,6 +5436,7 @@ export function handleStreamEvent(
         // the 'done' path to consume — reset it explicitly on error so the
         // accumulated delta text doesn't linger in memory.
         pendingPermission: null,
+        pendingPermissionQueue: [],
         pendingAskUser: null,
         // F-AUQ-MIN-5: same reset as the 'done' path.
         askUserViewerState: 'expanded',
@@ -5455,18 +5469,35 @@ export function handleStreamEvent(
         suggestions?: unknown[];
         autoReviewUnavailable?: boolean;
       };
+      const incoming: PendingPermission = {
+        requestId: data.requestId,
+        toolName: data.toolName,
+        input: data.input,
+        title: data.title,
+        displayName: data.displayName,
+        description: data.description,
+        suggestions: data.suggestions,
+        autoReviewUnavailable: data.autoReviewUnavailable === true,
+      };
+      // 并发 tool_use 会几乎同时广播多个 permission 请求。单槽覆盖会让先到的卡
+      // 永远失去展示与应答机会 —— main 侧 resolver 等满 10 分钟超时,引擎把该
+      // tool_use 记成 deny('timeout')(issue #3092)。与 pendingPluginSetup 同构:
+      // 一次展示一张,其余按到达顺序排队;同 requestId 重复投递(重连 reconcile
+      // 重放)只刷新内容、不重复排队。
+      if (!state.pendingPermission || state.pendingPermission.requestId === incoming.requestId) {
+        return { ...state, pendingPermission: incoming };
+      }
+      const queuedIndex = state.pendingPermissionQueue.findIndex(
+        (item) => item.requestId === incoming.requestId,
+      );
+      if (queuedIndex >= 0) {
+        const nextQueue = state.pendingPermissionQueue.slice();
+        nextQueue[queuedIndex] = incoming;
+        return { ...state, pendingPermissionQueue: nextQueue };
+      }
       return {
         ...state,
-        pendingPermission: {
-          requestId: data.requestId,
-          toolName: data.toolName,
-          input: data.input,
-          title: data.title,
-          displayName: data.displayName,
-          description: data.description,
-          suggestions: data.suggestions,
-          autoReviewUnavailable: data.autoReviewUnavailable === true,
-        },
+        pendingPermissionQueue: [...state.pendingPermissionQueue, incoming],
       };
     }
 
@@ -5484,7 +5515,22 @@ export function handleStreamEvent(
           ? (data.decision as Record<string, unknown>)
           : null;
       if (state.pendingPermission?.requestId === data.requestId) {
-        return { ...state, pendingPermission: null };
+        const [nextPermission = null, ...remainingPermissions] = state.pendingPermissionQueue;
+        return {
+          ...state,
+          pendingPermission: nextPermission,
+          pendingPermissionQueue: remainingPermissions,
+        };
+      }
+      if (state.pendingPermissionQueue.some((item) => item.requestId === data.requestId)) {
+        // 排队中的请求也可能被 main 侧先行收口(超时 / mode 切换 / 对端应答),
+        // 从队列摘除即可,不影响当前展示的卡。
+        return {
+          ...state,
+          pendingPermissionQueue: state.pendingPermissionQueue.filter(
+            (item) => item.requestId !== data.requestId,
+          ),
+        };
       }
       if (state.pendingPluginSetup?.requestId === data.requestId) {
         const [nextSetup = null, ...remainingSetups] = state.pendingPluginSetupQueue;
@@ -5799,6 +5845,7 @@ function forceFinalizeOnSessionClosed(state: SessionChatState): SessionChatState
     !state.streamingClientId &&
     !state.isStreaming &&
     !state.pendingPermission &&
+    state.pendingPermissionQueue.length === 0 &&
     !state.pendingAskUser &&
     !state.pendingPluginSetup &&
     state.pendingPluginSetupQueue.length === 0 &&
@@ -5848,6 +5895,7 @@ function forceFinalizeOnSessionClosed(state: SessionChatState): SessionChatState
     activeTurnRetryText: null,
     errorRetryText: null,
     pendingPermission: null,
+    pendingPermissionQueue: [],
     pendingAskUser: null,
     pendingPluginSetup: null,
     pendingPluginSetupQueue: [],
@@ -12608,6 +12656,7 @@ function stopSession(
       activeTurnRetryText: null,
       errorRetryText: null,
       pendingPermission: null,
+      pendingPermissionQueue: [],
       continuationTurnClientId: null,
       pendingAskUser: null,
       // F-AUQ-MIN-5: Stop session — pending question is gone, reset viewer.
@@ -13362,8 +13411,18 @@ function respondToPermission(sessionId: string, result: CCAgentPermissionResult)
   const { requestId } = state.pendingPermission;
   bumpInteractionReconcileEpoch(sessionId);
 
-  // Clear the pending permission immediately so the UI updates
-  setState(sessionId, (s) => ({ ...s, pendingPermission: null }));
+  // Clear the pending permission immediately so the UI updates, and advance the
+  // queue in the same commit — parallel tool_use may have more cards waiting
+  // (issue #3092). The follow-up permission_dismissed broadcast for this
+  // requestId no longer matches the (new) current card and is a no-op.
+  setState(sessionId, (s) => {
+    const [nextPermission = null, ...remainingPermissions] = s.pendingPermissionQueue;
+    return {
+      ...s,
+      pendingPermission: nextPermission,
+      pendingPermissionQueue: remainingPermissions,
+    };
+  });
 
   // Send to maker (InteractionDecision kind: 'permission')
   makerApiFor(sessionId)


### PR DESCRIPTION
## 问题

同一 assistant 消息里并行多个 tool_use 时,多个 permission 请求几乎同时广播到 renderer。`makerChatStore` 的 `pendingPermission` 是单槽,后到的卡**无条件覆盖**先到的卡——被覆盖的请求再无展示与应答入口,main 侧 resolver 只能等满 `PERMISSION_INTERACTION_TIMEOUT_MS`(600s),引擎把该 tool_use 记成 `deny('timeout')`,一个本可秒过的调用白挂 10 分钟。

实测(#3092):同会话 1 小时内 4/5 批并行调用复现,挂死的全部是同批**先广播**的那个;单发调用从不挂;用户全程每次只看到一张卡。详细根因分析见 https://github.com/makecindy/cindy/issues/3092#issuecomment-5353293768

## 修复

与既有 `pendingPluginSetupQueue` 同构,给 permission 卡引入排队:

- 新增 `pendingPermissionQueue`:有在展示的卡时,后到请求按到达顺序入队;同 `requestId` 重复投递(重连 reconcile 重放)只刷新内容、不重复排队。
- 当前卡被应答(`respondToPermission`)或被 main 收口(`permission_dismissed`)后弹出队列下一张;排队中的请求被 main 先行收口(超时/mode 切换/对端应答)时按 `requestId` 摘除。
- turn done / error / stop / session-closed 的既有清场路径同步清空队列;`forceFinalizeOnSessionClosed` 的 no-op guard 加入队列判断。

UI 消费面(`pendingPermission` 单值)不变,组件无需改动。

## 测试

- 新增 `permissionCardQueue.test.ts` 5 个回归用例:并发不覆盖、应答后推进、当前卡被 dismiss 后推进、排队卡被 dismiss 摘除、重复投递去重。
- `renderer/__tests__` 全量 481 文件 / 5973 用例通过;`tsc --noEmit` 零错误(顺手补齐 `makerQueueState.test.ts` 状态构造器的新字段)。

Fixes #3092