### PR TITLE
fix(pi): resume/rebind 后仍能解析 bash 隔离家目录

### DIFF
--- a/docs/dev-rules/pi-harness.md
+++ b/docs/dev-rules/pi-harness.md
@@ -120,6 +120,13 @@ Cindy 显式设置:models.json、`--append-system-prompt`、`--session-dir`、�
    extension(`cindy-bridge` / `cindy-subagent`)源码字节必须进入 launch identity:
    `CINDY_PI_EXTENSION_BUNDLE_HASH` 只由源码确定,禁止随机数或时间戳;字节不变可 reattach,
    字节变化必须 restart。
+11. **Pi bash 隔离家目录必须抗住扩展重绑**:`cindy-bridge` 不得把
+    `bash-package-home` 只记在「读一次就从 `process.env` 删掉」的
+    `CINDY_PI_BASH_PACKAGE_HOME` 上。Pi 的 `switch_session` / resume / reload / fork 会在
+    同一进程里 shutdown 再重绑扩展,第二次 factory 看不到该 env;父进程里
+    `PI_CODING_AGENT_DIR` 仍指向 Host `mkdirp` 过的 `configHome`,durable 来源是
+    `configHome/bash-package-home`。bash 子进程仍走 `withoutPiSecrets` 剥离,不变。
+    由 `cindyBridgeSource.test.ts` 守。
 
 ## 5. 已交付(2026-07 里程碑)
 

--- a/packages/maker-core/src/agents/pi/__tests__/cindyBridgeSource.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/cindyBridgeSource.test.ts
@@ -1147,31 +1147,33 @@ describe('cindy-bridge extension source', () => {
     expect(CINDY_BRIDGE_EXTENSION_SOURCE).toContain('function resolveBashPackageHome');
     expect(CINDY_BRIDGE_EXTENSION_SOURCE).toContain("path.join(configHome, 'bash-package-home')");
 
+    const posix = path.posix;
+    const posixHome = posix.join('/tmp/run-tmp/abc', 'bash-package-home');
     const env: Record<string, string | undefined> = {
-      CINDY_PI_BASH_PACKAGE_HOME: '/tmp/run-tmp/abc/bash-package-home',
+      CINDY_PI_BASH_PACKAGE_HOME: posixHome,
       PI_CODING_AGENT_DIR: '/tmp/run-tmp/abc',
     };
-    const resolve = loadBashPackageHomeResolver(path, env);
-    expect(resolve()).toBe('/tmp/run-tmp/abc/bash-package-home');
+    const resolve = loadBashPackageHomeResolver(posix, env);
+    expect(resolve()).toBe(posixHome);
     expect(env.CINDY_PI_BASH_PACKAGE_HOME).toBeUndefined();
     // Second factory in the same process (switch_session / resume / reload / fork).
-    expect(resolve()).toBe('/tmp/run-tmp/abc/bash-package-home');
+    expect(resolve()).toBe(posixHome);
 
-    const isolate = loadBashIsolationHelper(path);
+    const isolate = loadBashIsolationHelper(posix);
     expect(
       isolate({ PI_CODING_AGENT_DIR: '/real/runtime-home' }, resolve()).PI_CODING_AGENT_DIR,
-    ).toBe('/tmp/run-tmp/abc/bash-package-home');
+    ).toBe(posixHome);
 
     const relativeEnv: Record<string, string | undefined> = {
       CINDY_PI_BASH_PACKAGE_HOME: 'relative/home',
       PI_CODING_AGENT_DIR: '/abs/config',
     };
-    expect(loadBashPackageHomeResolver(path, relativeEnv)()).toBe(
-      path.join('/abs/config', 'bash-package-home'),
+    expect(loadBashPackageHomeResolver(posix, relativeEnv)()).toBe(
+      posix.join('/abs/config', 'bash-package-home'),
     );
 
-    expect(loadBashPackageHomeResolver(path, {})()).toBeUndefined();
-    expect(() => loadBashIsolationHelper(path)({}, undefined)).toThrow(/unavailable/);
+    expect(loadBashPackageHomeResolver(posix, {})()).toBeUndefined();
+    expect(() => loadBashIsolationHelper(posix)({}, undefined)).toThrow(/unavailable/);
 
     const winEnv: Record<string, string | undefined> = {
       PI_CODING_AGENT_DIR: 'D:\\run-tmp\\abc',

--- a/packages/maker-core/src/agents/pi/__tests__/cindyBridgeSource.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/cindyBridgeSource.test.ts
@@ -79,6 +79,31 @@ function loadBashIsolationHelper(
   ) => Record<string, string | undefined>;
 }
 
+function loadBashPackageHomeResolver(
+  pathImpl: typeof path,
+  env: Record<string, string | undefined>,
+): () => string | undefined {
+  const source = CINDY_BRIDGE_EXTENSION_SOURCE;
+  const start = source.indexOf('function withoutPiSecrets');
+  const end = source.indexOf('function managedRipgrepPath');
+  if (start < 0 || end <= start) throw new Error('bash isolation helper was not found');
+  const executableSource = [
+    "const PI_BASH_PACKAGE_HOME_ENV = 'CINDY_PI_BASH_PACKAGE_HOME';",
+    "const SECRET_ENV_NAMES = new Set(['PI_CODING_AGENT_DIR', 'CINDY_PI_PACKAGE_MANAGEMENT', 'CINDY_PI_BASH_PACKAGE_HOME']);",
+    source.slice(start, end),
+    '(globalThis as any).resolveBashPackageHome = resolveBashPackageHome;',
+  ].join('\n');
+  const compiled = ts.transpileModule(executableSource, {
+    compilerOptions: {
+      module: ts.ModuleKind.None,
+      target: ts.ScriptTarget.ES2022,
+    },
+  }).outputText;
+  const context: Record<string, unknown> = { path: pathImpl, process: { env } };
+  runInNewContext(compiled, context);
+  return context.resolveBashPackageHome as () => string | undefined;
+}
+
 function loadPiPackageMutationCommandHelper(): (input: unknown) => boolean {
   const source = CINDY_BRIDGE_EXTENSION_SOURCE;
   const parserStart = source.indexOf('function readShellRedirectionTarget');
@@ -1017,6 +1042,7 @@ describe('cindy-bridge extension source', () => {
     expect(CINDY_BRIDGE_EXTENSION_SOURCE).toContain(
       "const PI_BASH_PACKAGE_HOME_ENV = 'CINDY_PI_BASH_PACKAGE_HOME'",
     );
+    expect(CINDY_BRIDGE_EXTENSION_SOURCE).toContain('const bashPackageHome = resolveBashPackageHome()');
     expect(CINDY_BRIDGE_EXTENSION_SOURCE).toContain('clean.PI_CODING_AGENT_DIR = bashPackageHome');
     expect(CINDY_BRIDGE_EXTENSION_SOURCE).toContain('delete clean.PI_PACKAGE_DIR');
     expect(CINDY_BRIDGE_EXTENSION_SOURCE).toContain(
@@ -1115,6 +1141,44 @@ describe('cindy-bridge extension source', () => {
       isolateWindows({ PI_CODING_AGENT_DIR: 'C:\\real' }, 'D:\\isolated').PI_CODING_AGENT_DIR,
     ).toBe('D:\\isolated');
     expect(() => isolateWindows({}, 'relative\\home')).toThrow(/unavailable/);
+  });
+
+  it('keeps isolated bash home after Pi rebinds the bridge in the same process', () => {
+    expect(CINDY_BRIDGE_EXTENSION_SOURCE).toContain('function resolveBashPackageHome');
+    expect(CINDY_BRIDGE_EXTENSION_SOURCE).toContain("path.join(configHome, 'bash-package-home')");
+
+    const env: Record<string, string | undefined> = {
+      CINDY_PI_BASH_PACKAGE_HOME: '/tmp/run-tmp/abc/bash-package-home',
+      PI_CODING_AGENT_DIR: '/tmp/run-tmp/abc',
+    };
+    const resolve = loadBashPackageHomeResolver(path, env);
+    expect(resolve()).toBe('/tmp/run-tmp/abc/bash-package-home');
+    expect(env.CINDY_PI_BASH_PACKAGE_HOME).toBeUndefined();
+    // Second factory in the same process (switch_session / resume / reload / fork).
+    expect(resolve()).toBe('/tmp/run-tmp/abc/bash-package-home');
+
+    const isolate = loadBashIsolationHelper(path);
+    expect(
+      isolate({ PI_CODING_AGENT_DIR: '/real/runtime-home' }, resolve()).PI_CODING_AGENT_DIR,
+    ).toBe('/tmp/run-tmp/abc/bash-package-home');
+
+    const relativeEnv: Record<string, string | undefined> = {
+      CINDY_PI_BASH_PACKAGE_HOME: 'relative/home',
+      PI_CODING_AGENT_DIR: '/abs/config',
+    };
+    expect(loadBashPackageHomeResolver(path, relativeEnv)()).toBe(
+      path.join('/abs/config', 'bash-package-home'),
+    );
+
+    expect(loadBashPackageHomeResolver(path, {})()).toBeUndefined();
+    expect(() => loadBashIsolationHelper(path)({}, undefined)).toThrow(/unavailable/);
+
+    const winEnv: Record<string, string | undefined> = {
+      PI_CODING_AGENT_DIR: 'D:\\run-tmp\\abc',
+    };
+    expect(loadBashPackageHomeResolver(path.win32, winEnv)()).toBe(
+      path.win32.join('D:\\run-tmp\\abc', 'bash-package-home'),
+    );
   });
 
   it('does not let Full Access bypass Cindy-managed extension confirmation', () => {

--- a/packages/maker-core/src/agents/pi/cindy-bridge-source.ts
+++ b/packages/maker-core/src/agents/pi/cindy-bridge-source.ts
@@ -121,6 +121,24 @@ function isolatedBashEnvironment(
   return clean;
 }
 
+// Dedicated env is consumed on the first factory call so bash children never
+// inherit it. Pi still rebinds extensions in-process on switch_session /
+// resume / reload / fork; PI_CODING_AGENT_DIR stays on the parent and Host
+// already mkdirp'd configHome/bash-package-home.
+function resolveBashPackageHome(): string | undefined {
+  const fromEnv = process.env[PI_BASH_PACKAGE_HOME_ENV];
+  if (fromEnv && path.isAbsolute(fromEnv)) {
+    delete process.env[PI_BASH_PACKAGE_HOME_ENV];
+    return fromEnv;
+  }
+  const configHome = process.env.PI_CODING_AGENT_DIR;
+  if (configHome && path.isAbsolute(configHome)) {
+    const derived = path.join(configHome, 'bash-package-home');
+    if (path.isAbsolute(derived)) return derived;
+  }
+  return undefined;
+}
+
 // The isolated package-home env and command inspection are defense in depth,
 // not an OS sandbox: Full Access code can rewrite env or launch another
 // interpreter. Reject direct/static Pi package-manager spellings to prevent
@@ -2439,8 +2457,7 @@ function rgGlob(
 }
 
 export default async function cindyBridge(pi: any) {
-  const bashPackageHome = process.env[PI_BASH_PACKAGE_HOME_ENV];
-  delete process.env[PI_BASH_PACKAGE_HOME_ENV];
+  const bashPackageHome = resolveBashPackageHome();
   // 主 Pi 不传 --tools：那个白名单也会筛掉动态 MCP 与 subagent。改由 bridge 注册
   // 专用只读工具；子代理仍用自己的 read,grep,find,ls 白名单收紧能力面。
   const grepTool = createGrepTool(process.cwd());


### PR DESCRIPTION
## 这次改了什么

### 摘要

Pi 任务第一次加载 `cindy-bridge` 时会读走并删除 `CINDY_PI_BASH_PACKAGE_HOME`，把 bash 子进程的家目录指到隔离目录。Pi 在 `switch_session` / resume / reload / fork 时会在同一进程里重绑扩展；第二次 factory 拿不到该环境变量，bash 全部 fail-closed（`Cindy isolated Pi package home is unavailable`），read/grep/ls 仍可用。

这次让隔离路径在重绑后仍能从父进程里还在的 `PI_CODING_AGENT_DIR/bash-package-home` 推出。bash 子进程继续走 `withoutPiSecrets` 剥离，不放宽隔离面。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无（线上 Pi 长任务 resume 后 bash 全灭）
- 本 PR 包含：`cindy-bridge` 隔离家目录解析、对应单测、`pi-harness.md` 不变量 11
- 明确不包含：Host spawn env 注入、desktop 启动脚本、插件收据 / Library 基线红测
- 用户可见变化：Pi 任务在空闲后继续、断线重连、切模型触发的 `switch_session` 之后，bash 不再整工具不可用
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter @cindy/maker-core exec vitest run src/agents/pi/__tests__/cindyBridgeSource.test.ts
结果：14 passed | 1 skipped（含「同一进程第二次 resolve 仍得到 bash-package-home」）

pnpm --filter @cindy/maker-core run --if-present typecheck
结果：package 无 typecheck script，跳过

pnpm test:unit:related
结果：maker-core related 通过。因改了被 desktop 依赖的公共包，脚本拉起 desktop 整包单测；`ghostInstallReceipt.test.ts` 2 条失败。该文件不在本次 diff 内，在未含本修复的 HEAD 上单独复现同样失败，属当前 main（#3079 插件 Library）基线问题，未混入本 PR。完整 `pnpm test:unit` 交给 CI。
```

### 手工验证

不涉及。未在本机用修复后的正式版 / 开发版走一遍真实 Pi resume。

### 未执行的验证

- 未跑 `pi-agent.integration.test.ts` 里那条真实 Pi 二进制的 bash 环境隔离用例（单测已覆盖 resolve / 二次 factory；端到端 resume 交给 CI / 合入后的 Pi 任务）
- 未在修复后的客户端上复现「空闲后再发消息」

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Pi 会话的 bash 子进程 `PI_CODING_AGENT_DIR`。重绑后仍指向 Host 已 `mkdirp` 的空隔离目录，不把真实 `pi-package-home` 暴露给模型 shell。两条来源都不是绝对路径时仍 fail-closed。
- 回滚 / 降级方式：revert 本 commit。已启动的 Pi 进程要等下次 `startSession` 才会覆写 bridge。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
