### PR TITLE
fix(desktop): 统一工作组工具行与思考行的右侧三角槽

### DIFF
--- a/apps/desktop/src/renderer/__tests__/systemCardAutoResumeRow.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/systemCardAutoResumeRow.test.tsx
@@ -163,16 +163,18 @@ describe('SystemCard auto-resume 行', () => {
       />,
     );
     const button = screen.getByRole('button');
+    expect(button.className.split(/\s+/)).toContain('group');
     expect(button.getAttribute('aria-label')).toBeNull();
     // 可见文本 = 结论 + 摘要,读屏据此拼出无障碍名。
     expect(button.textContent).toContain('chat.systemCard.autoResume.label');
     expect(button.textContent).toContain('502 upstream unreachable');
   });
 
-  it('仅有 outcome 时仍保留 18px 三角槽,不画三角', () => {
+  it('仅有 outcome 时仍保留 18px 三角槽,不画三角,也不挂 group', () => {
     render(<SystemCard cardType="auto-resume" data={{ outcome: 'succeeded' }} />);
     const button = screen.getByRole('button');
     expect((button as HTMLButtonElement).disabled).toBe(true);
+    expect(button.className.split(/\s+/)).not.toContain('group');
     const slot = button.lastElementChild;
     expect(slot?.className).toContain('w-[18px]');
     expect(slot?.className).toContain('h-[18px]');

--- a/apps/desktop/src/renderer/__tests__/systemCardAutoResumeRow.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/systemCardAutoResumeRow.test.tsx
@@ -168,4 +168,15 @@ describe('SystemCard auto-resume 行', () => {
     expect(button.textContent).toContain('chat.systemCard.autoResume.label');
     expect(button.textContent).toContain('502 upstream unreachable');
   });
+
+  it('仅有 outcome 时仍保留 18px 三角槽,不画三角', () => {
+    render(<SystemCard cardType="auto-resume" data={{ outcome: 'succeeded' }} />);
+    const button = screen.getByRole('button');
+    expect((button as HTMLButtonElement).disabled).toBe(true);
+    const slot = button.lastElementChild;
+    expect(slot?.className).toContain('w-[18px]');
+    expect(slot?.className).toContain('h-[18px]');
+    expect(slot?.className).toContain('ml-auto');
+    expect(slot?.querySelector('svg')).toBeNull();
+  });
 });

--- a/apps/desktop/src/renderer/__tests__/workGroupBlockInteraction.test.ts
+++ b/apps/desktop/src/renderer/__tests__/workGroupBlockInteraction.test.ts
@@ -59,8 +59,10 @@ describe('WorkGroupBlock — 嵌套工作组接线静态扫描', () => {
     expect(chrome).toMatch(/group-hover:bg-\[var\(--cmd-palette-item-hover\)\]/);
     expect(chrome).toMatch(/hover:bg-\[var\(--msg-code-inline-bg\)\]/);
     expect(chrome).toMatch(/h-\[18px\] w-\[18px\]/);
-    expect(chrome).toMatch(/ACTIVITY_ROW_RADIUS_CLASS = 'rounded-lg'/);
-    expect(chrome).toMatch(/rounded-lg/);
+    expect(chrome).toMatch(/ACTIVITY_ROW_RADIUS_CLASS = 'rounded-\[8px\]'/);
+    expect(chrome).toMatch(/rounded-\[8px\]/);
+    expect(chrome).not.toMatch(/rounded-lg/);
+    expect(chrome).not.toMatch(/var\(--radius\)/);
     expect(chrome).not.toMatch(/rounded-\[4px\]/);
     expect(source).toMatch(/from '\.\/activityRowChrome'/);
     expect(source).toMatch(/ACTIVITY_ROW_CHEVRON_SLOT_CLASS/);

--- a/apps/desktop/src/renderer/__tests__/workGroupBlockInteraction.test.ts
+++ b/apps/desktop/src/renderer/__tests__/workGroupBlockInteraction.test.ts
@@ -21,6 +21,14 @@ describe('WorkGroupBlock — 嵌套工作组接线静态扫描', () => {
     resolve(__dirname, '..', 'components', 'chat', 'WorkGroupBlock.tsx'),
     'utf8',
   );
+  const chrome = readFileSync(
+    resolve(__dirname, '..', 'components', 'chat', 'activityRowChrome.ts'),
+    'utf8',
+  );
+  const actionRow = readFileSync(
+    resolve(__dirname, '..', 'components', 'chat', 'AgentActionRow.tsx'),
+    'utf8',
+  );
 
   it('onToggle 不再批量 seed 后代工作组展开态', () => {
     // 外层 click 只能翻外层自身;内层「已工作」仍由用户单独展开。
@@ -44,6 +52,22 @@ describe('WorkGroupBlock — 嵌套工作组接线静态扫描', () => {
     );
     expect(source).toMatch(
       /function ExpandedThinkingRow[\s\S]*data-message-client-id=\{message\.clientId\}/,
+    );
+  });
+
+  it('thinking 行右侧三角与工具行共用同一套槽和 hover 浮起', () => {
+    expect(chrome).toMatch(/group-hover:bg-\[var\(--cmd-palette-item-hover\)\]/);
+    expect(chrome).toMatch(/hover:bg-\[var\(--msg-code-inline-bg\)\]/);
+    expect(chrome).toMatch(/h-\[18px\] w-\[18px\]/);
+    expect(source).toMatch(/from '\.\/activityRowChrome'/);
+    expect(source).toMatch(/ACTIVITY_ROW_CHEVRON_SLOT_CLASS/);
+    expect(source).toMatch(/ACTIVITY_ROW_HOVER_SURFACE_CLASS/);
+    expect(actionRow).toMatch(/from '\.\/activityRowChrome'/);
+    expect(actionRow).toMatch(/ACTIVITY_ROW_CHEVRON_SLOT_CLASS/);
+    // 槽位始终占位;只有可展开时才画三角。旧写法把整个 span 按 canExpand 卸掉,
+    // 短思考行会比工具行更靠右,长思考行的 `>` 又会被顶到另一条 x。
+    expect(source).not.toMatch(
+      /\{canExpand && \(\s*<span aria-hidden="true" className="inline-flex h-\[18px\]/,
     );
   });
 

--- a/apps/desktop/src/renderer/__tests__/workGroupBlockInteraction.test.ts
+++ b/apps/desktop/src/renderer/__tests__/workGroupBlockInteraction.test.ts
@@ -59,11 +59,17 @@ describe('WorkGroupBlock — 嵌套工作组接线静态扫描', () => {
     expect(chrome).toMatch(/group-hover:bg-\[var\(--cmd-palette-item-hover\)\]/);
     expect(chrome).toMatch(/hover:bg-\[var\(--msg-code-inline-bg\)\]/);
     expect(chrome).toMatch(/h-\[18px\] w-\[18px\]/);
+    expect(chrome).toMatch(/ACTIVITY_ROW_RADIUS_CLASS = 'rounded-lg'/);
+    expect(chrome).toMatch(/rounded-lg/);
+    expect(chrome).not.toMatch(/rounded-\[4px\]/);
     expect(source).toMatch(/from '\.\/activityRowChrome'/);
     expect(source).toMatch(/ACTIVITY_ROW_CHEVRON_SLOT_CLASS/);
     expect(source).toMatch(/ACTIVITY_ROW_HOVER_SURFACE_CLASS/);
+    expect(source).toMatch(/ACTIVITY_ROW_RADIUS_CLASS/);
+    expect(source).not.toMatch(/function ThinkingActivityRow[\s\S]*rounded-\[6px\]/);
     expect(actionRow).toMatch(/from '\.\/activityRowChrome'/);
     expect(actionRow).toMatch(/ACTIVITY_ROW_CHEVRON_SLOT_CLASS/);
+    expect(actionRow).toMatch(/ACTIVITY_ROW_RADIUS_CLASS/);
     // 槽位始终占位;只有可展开时才画三角。旧写法把整个 span 按 canExpand 卸掉,
     // 短思考行会比工具行更靠右,长思考行的 `>` 又会被顶到另一条 x。
     expect(source).not.toMatch(

--- a/apps/desktop/src/renderer/__tests__/workGroupBlockInteraction.test.ts
+++ b/apps/desktop/src/renderer/__tests__/workGroupBlockInteraction.test.ts
@@ -29,6 +29,10 @@ describe('WorkGroupBlock — 嵌套工作组接线静态扫描', () => {
     resolve(__dirname, '..', 'components', 'chat', 'AgentActionRow.tsx'),
     'utf8',
   );
+  const systemCard = readFileSync(
+    resolve(__dirname, '..', 'components', 'chat', 'SystemCard.tsx'),
+    'utf8',
+  );
 
   it('onToggle 不再批量 seed 后代工作组展开态', () => {
     // 外层 click 只能翻外层自身;内层「已工作」仍由用户单独展开。
@@ -76,10 +80,14 @@ describe('WorkGroupBlock — 嵌套工作组接线静态扫描', () => {
     expect(actionRow).toMatch(/ACTIVITY_ROW_CHEVRON_SLOT_CLASS/);
     expect(actionRow).toMatch(/ACTIVITY_ROW_RADIUS_CLASS/);
     expect(actionRow).toMatch(/ACTIVITY_ROW_COLOR_TRANSITION_CLASS/);
+    expect(systemCard).toMatch(/ACTIVITY_ROW_CHEVRON_SLOT_CLASS/);
     // 槽位始终占位;只有可展开时才画三角。旧写法把整个 span 按 canExpand 卸掉,
-    // 短思考行会比工具行更靠右,长思考行的 `>` 又会被顶到另一条 x。
+    // 短思考行 / 仅有 outcome 的中断行会比工具行更靠右。
     expect(source).not.toMatch(
       /\{canExpand && \(\s*<span aria-hidden="true" className="inline-flex h-\[18px\]/,
+    );
+    expect(systemCard).not.toMatch(
+      /\{canExpand && \(\s*<span aria-hidden="true" className=\{ACTIVITY_ROW_CHEVRON_SLOT_CLASS\}/,
     );
   });
 

--- a/apps/desktop/src/renderer/__tests__/workGroupBlockInteraction.test.ts
+++ b/apps/desktop/src/renderer/__tests__/workGroupBlockInteraction.test.ts
@@ -61,6 +61,8 @@ describe('WorkGroupBlock — 嵌套工作组接线静态扫描', () => {
     expect(chrome).toMatch(/h-\[18px\] w-\[18px\]/);
     expect(chrome).toMatch(/ACTIVITY_ROW_RADIUS_CLASS = 'rounded-\[8px\]'/);
     expect(chrome).toMatch(/rounded-\[8px\]/);
+    expect(chrome).toMatch(/duration-\[var\(--motion-fast,150ms\)\]/);
+    expect(chrome).toMatch(/ease-\[var\(--motion-ease-out\)\]/);
     expect(chrome).not.toMatch(/rounded-lg/);
     expect(chrome).not.toMatch(/var\(--radius\)/);
     expect(chrome).not.toMatch(/rounded-\[4px\]/);
@@ -68,10 +70,12 @@ describe('WorkGroupBlock — 嵌套工作组接线静态扫描', () => {
     expect(source).toMatch(/ACTIVITY_ROW_CHEVRON_SLOT_CLASS/);
     expect(source).toMatch(/ACTIVITY_ROW_HOVER_SURFACE_CLASS/);
     expect(source).toMatch(/ACTIVITY_ROW_RADIUS_CLASS/);
+    expect(source).toMatch(/ACTIVITY_ROW_COLOR_TRANSITION_CLASS/);
     expect(source).not.toMatch(/function ThinkingActivityRow[\s\S]*rounded-\[6px\]/);
     expect(actionRow).toMatch(/from '\.\/activityRowChrome'/);
     expect(actionRow).toMatch(/ACTIVITY_ROW_CHEVRON_SLOT_CLASS/);
     expect(actionRow).toMatch(/ACTIVITY_ROW_RADIUS_CLASS/);
+    expect(actionRow).toMatch(/ACTIVITY_ROW_COLOR_TRANSITION_CLASS/);
     // 槽位始终占位;只有可展开时才画三角。旧写法把整个 span 按 canExpand 卸掉,
     // 短思考行会比工具行更靠右,长思考行的 `>` 又会被顶到另一条 x。
     expect(source).not.toMatch(

--- a/apps/desktop/src/renderer/__tests__/workGroupBlockLivePreview.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/workGroupBlockLivePreview.test.tsx
@@ -527,10 +527,12 @@ describe('WorkGroupBlock — running latest-five preview', () => {
     );
     expect(rows).toHaveLength(2);
     for (const row of rows) {
+      expect(row.className).toContain('rounded-lg');
       const slot = row.lastElementChild;
       expect(slot?.className).toContain('w-[18px]');
       expect(slot?.className).toContain('h-[18px]');
       expect(slot?.className).toContain('ml-auto');
+      expect(slot?.className).toContain('rounded-lg');
       expect(slot?.className).toContain('group-hover:bg-[var(--cmd-palette-item-hover)]');
     }
     expect(rows[0]?.querySelector('svg.lucide-chevron-right')).toBeNull();

--- a/apps/desktop/src/renderer/__tests__/workGroupBlockLivePreview.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/workGroupBlockLivePreview.test.tsx
@@ -510,6 +510,33 @@ describe('WorkGroupBlock — running latest-five preview', () => {
     expect(thinkingButton.textContent).toContain('first line\nsecond line');
   });
 
+  it('always reserves the 18px trailing chevron slot on thinking rows', () => {
+    render(
+      createElement(WorkGroupBlock, {
+        blockId: 'work:t1',
+        isStreaming: true,
+        childItems: [
+          thinking(mkThinking('short', 'brief')),
+          thinking(mkThinking('long', 'first line\nsecond line')),
+        ],
+      }),
+    );
+
+    const rows = document.querySelectorAll<HTMLButtonElement>(
+      '[data-live-work-activity="thinking"]',
+    );
+    expect(rows).toHaveLength(2);
+    for (const row of rows) {
+      const slot = row.lastElementChild;
+      expect(slot?.className).toContain('w-[18px]');
+      expect(slot?.className).toContain('h-[18px]');
+      expect(slot?.className).toContain('ml-auto');
+      expect(slot?.className).toContain('group-hover:bg-[var(--cmd-palette-item-hover)]');
+    }
+    expect(rows[0]?.querySelector('svg.lucide-chevron-right')).toBeNull();
+    expect(rows[1]?.querySelector('svg.lucide-chevron-right')).toBeTruthy();
+  });
+
   it('drops empty thinking and renders redacted thinking directly', () => {
     const redacted = { ...mkThinking('hidden', ''), thinkingRedacted: true };
     render(

--- a/apps/desktop/src/renderer/__tests__/workGroupBlockLivePreview.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/workGroupBlockLivePreview.test.tsx
@@ -527,12 +527,12 @@ describe('WorkGroupBlock — running latest-five preview', () => {
     );
     expect(rows).toHaveLength(2);
     for (const row of rows) {
-      expect(row.className).toContain('rounded-lg');
+      expect(row.className).toContain('rounded-[8px]');
       const slot = row.lastElementChild;
       expect(slot?.className).toContain('w-[18px]');
       expect(slot?.className).toContain('h-[18px]');
       expect(slot?.className).toContain('ml-auto');
-      expect(slot?.className).toContain('rounded-lg');
+      expect(slot?.className).toContain('rounded-[8px]');
       expect(slot?.className).toContain('group-hover:bg-[var(--cmd-palette-item-hover)]');
     }
     expect(rows[0]?.querySelector('svg.lucide-chevron-right')).toBeNull();

--- a/apps/desktop/src/renderer/components/chat/AgentActionRow.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentActionRow.tsx
@@ -67,6 +67,7 @@ import { useInstalledGhosts } from '@/cindy-brain/useInstalledGhosts';
 import { useChatSessionFile } from './ChatSessionFileContext';
 import {
   ACTIVITY_ROW_CHEVRON_SLOT_CLASS,
+  ACTIVITY_ROW_COLOR_TRANSITION_CLASS,
   ACTIVITY_ROW_HOVER_SURFACE_CLASS,
   ACTIVITY_ROW_RADIUS_CLASS,
 } from './activityRowChrome';
@@ -902,7 +903,7 @@ export function AgentActionRow({
           ACTIVITY_ROW_RADIUS_CLASS,
           'px-2 py-[3px]',
           ACTIVITY_ROW_HOVER_SURFACE_CLASS,
-          'transition-colors',
+          ACTIVITY_ROW_COLOR_TRANSITION_CLASS,
           'cursor-pointer select-none outline-none',
           'focus-visible:ring-2 focus-visible:ring-[var(--info-700)]/40',
           'text-left',

--- a/apps/desktop/src/renderer/components/chat/AgentActionRow.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentActionRow.tsx
@@ -65,6 +65,10 @@ import { toRemoteMediaOrigin } from '@/lib/sessionFileOrigin';
 import { rewriteToRemoteMediaOrigin } from '../../../shared/remoteMediaUrl';
 import { useInstalledGhosts } from '@/cindy-brain/useInstalledGhosts';
 import { useChatSessionFile } from './ChatSessionFileContext';
+import {
+  ACTIVITY_ROW_CHEVRON_SLOT_CLASS,
+  ACTIVITY_ROW_HOVER_SURFACE_CLASS,
+} from './activityRowChrome';
 import { ImageLightbox } from './ImageLightbox';
 import { TextLightbox } from './TextLightbox';
 import { ToolPayloadLightbox, type ToolPayloadMode } from './ToolPayloadLightbox';
@@ -895,7 +899,8 @@ export function AgentActionRow({
         className={cn(
           'group flex w-full items-center gap-[6px]',
           'rounded-[6px] px-2 py-[3px]',
-          'hover:bg-[var(--msg-code-inline-bg)] transition-colors',
+          ACTIVITY_ROW_HOVER_SURFACE_CLASS,
+          'transition-colors',
           'cursor-pointer select-none outline-none',
           'focus-visible:ring-2 focus-visible:ring-[var(--info-700)]/40',
           'text-left',
@@ -934,14 +939,7 @@ export function AgentActionRow({
         )}
         {/* v9: 移除 chevron 上的"查看详情" Tooltip。整行 button 已经是
             统一激活目标，末尾 chevron 只保留视觉提示。 */}
-        <span
-          aria-hidden="true"
-          className={cn(
-            'flex h-[18px] w-[18px] items-center justify-center rounded-[4px] shrink-0',
-            'text-[var(--msg-tool-card-chevron)]',
-            'group-hover:bg-[var(--cmd-palette-item-hover)] transition-colors',
-          )}
-        >
+        <span aria-hidden="true" className={ACTIVITY_ROW_CHEVRON_SLOT_CLASS}>
           {isInlineExpand && expanded ? (
             <ChevronDown size={13} />
           ) : (

--- a/apps/desktop/src/renderer/components/chat/AgentActionRow.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentActionRow.tsx
@@ -68,6 +68,7 @@ import { useChatSessionFile } from './ChatSessionFileContext';
 import {
   ACTIVITY_ROW_CHEVRON_SLOT_CLASS,
   ACTIVITY_ROW_HOVER_SURFACE_CLASS,
+  ACTIVITY_ROW_RADIUS_CLASS,
 } from './activityRowChrome';
 import { ImageLightbox } from './ImageLightbox';
 import { TextLightbox } from './TextLightbox';
@@ -898,7 +899,8 @@ export function AgentActionRow({
         }
         className={cn(
           'group flex w-full items-center gap-[6px]',
-          'rounded-[6px] px-2 py-[3px]',
+          ACTIVITY_ROW_RADIUS_CLASS,
+          'px-2 py-[3px]',
           ACTIVITY_ROW_HOVER_SURFACE_CLASS,
           'transition-colors',
           'cursor-pointer select-none outline-none',

--- a/apps/desktop/src/renderer/components/chat/SystemCard.tsx
+++ b/apps/desktop/src/renderer/components/chat/SystemCard.tsx
@@ -943,14 +943,14 @@ function AutoResumeActionRow({
         // 图标与 chevron 都是 aria-hidden,可见文本(动词 + 摘要)本身就是正确的无障碍名。
         disabled={!canExpand}
         className={cn(
-          'group flex w-full items-center gap-[6px]',
+          'flex w-full items-center gap-[6px]',
           ACTIVITY_ROW_RADIUS_CLASS,
           'px-2 py-[3px]',
           'text-left outline-none',
-          ACTIVITY_ROW_COLOR_TRANSITION_CLASS,
           canExpand
             ? cn(
-                'cursor-pointer select-none focus-visible:ring-2 focus-visible:ring-[var(--info-700)]/40',
+                'group cursor-pointer select-none focus-visible:ring-2 focus-visible:ring-[var(--info-700)]/40',
+                ACTIVITY_ROW_COLOR_TRANSITION_CLASS,
                 ACTIVITY_ROW_HOVER_SURFACE_CLASS,
               )
             : 'cursor-default select-none',

--- a/apps/desktop/src/renderer/components/chat/SystemCard.tsx
+++ b/apps/desktop/src/renderer/components/chat/SystemCard.tsx
@@ -873,8 +873,8 @@ function AutoResumeSeparator() {
 /**
  * 中断自愈活动行（进行中 / 已完成共用）。
  *
- * **形态刻意对齐 AgentActionRow（工具活动行）**：radius 6 / `px-2 py-[3px]` / 16px 状态
- * 图标槽位 / 14px `--msg-tool-card-chevron` 文字 / param 位 / 尾部 chevron / hover 抬到
+ * **形态刻意对齐 AgentActionRow（工具活动行）**：inner-control 8px / `px-2 py-[3px]` / 16px 状态
+ * 图标槽位 / 14px `--msg-tool-card-chevron` 文字 / param 位 / 尾部 18×18 槽始终占位 / hover 抬到
  * `--msg-code-inline-bg`。产品语义就是「这是 agent 干活流程里的一步，只不过这一步在
  * 重连」，而不是一条系统公告——所以它读起来必须像正常工作行，不是横幅、不是警告。
  *
@@ -985,11 +985,9 @@ function AutoResumeActionRow({
           </span>
         )}
         <span className="flex-1" />
-        {canExpand && (
-          <span aria-hidden="true" className={ACTIVITY_ROW_CHEVRON_SLOT_CLASS}>
-            {expanded ? <ChevronDown size={13} /> : <ChevronRight size={13} />}
-          </span>
-        )}
+        <span aria-hidden="true" className={ACTIVITY_ROW_CHEVRON_SLOT_CLASS}>
+          {canExpand ? (expanded ? <ChevronDown size={13} /> : <ChevronRight size={13} />) : null}
+        </span>
       </button>
       {canExpand && expanded && (
         <div

--- a/apps/desktop/src/renderer/components/chat/SystemCard.tsx
+++ b/apps/desktop/src/renderer/components/chat/SystemCard.tsx
@@ -31,6 +31,7 @@ import {
 } from '../../../shared/reviewRun';
 import {
   ACTIVITY_ROW_CHEVRON_SLOT_CLASS,
+  ACTIVITY_ROW_COLOR_TRANSITION_CLASS,
   ACTIVITY_ROW_HOVER_SURFACE_CLASS,
   ACTIVITY_ROW_RADIUS_CLASS,
 } from './activityRowChrome';
@@ -945,7 +946,8 @@ function AutoResumeActionRow({
           'group flex w-full items-center gap-[6px]',
           ACTIVITY_ROW_RADIUS_CLASS,
           'px-2 py-[3px]',
-          'text-left outline-none transition-colors',
+          'text-left outline-none',
+          ACTIVITY_ROW_COLOR_TRANSITION_CLASS,
           canExpand
             ? cn(
                 'cursor-pointer select-none focus-visible:ring-2 focus-visible:ring-[var(--info-700)]/40',

--- a/apps/desktop/src/renderer/components/chat/SystemCard.tsx
+++ b/apps/desktop/src/renderer/components/chat/SystemCard.tsx
@@ -32,6 +32,7 @@ import {
 import {
   ACTIVITY_ROW_CHEVRON_SLOT_CLASS,
   ACTIVITY_ROW_HOVER_SURFACE_CLASS,
+  ACTIVITY_ROW_RADIUS_CLASS,
 } from './activityRowChrome';
 import { MarkdownRenderer } from './MarkdownRenderer';
 
@@ -942,7 +943,8 @@ function AutoResumeActionRow({
         disabled={!canExpand}
         className={cn(
           'group flex w-full items-center gap-[6px]',
-          'rounded-[6px] px-2 py-[3px]',
+          ACTIVITY_ROW_RADIUS_CLASS,
+          'px-2 py-[3px]',
           'text-left outline-none transition-colors',
           canExpand
             ? cn(

--- a/apps/desktop/src/renderer/components/chat/SystemCard.tsx
+++ b/apps/desktop/src/renderer/components/chat/SystemCard.tsx
@@ -29,6 +29,10 @@ import {
   reviewFailureCodeFromLegacyError,
   type ReviewFailureCode,
 } from '../../../shared/reviewRun';
+import {
+  ACTIVITY_ROW_CHEVRON_SLOT_CLASS,
+  ACTIVITY_ROW_HOVER_SURFACE_CLASS,
+} from './activityRowChrome';
 import { MarkdownRenderer } from './MarkdownRenderer';
 
 interface SystemCardProps {
@@ -941,7 +945,10 @@ function AutoResumeActionRow({
           'rounded-[6px] px-2 py-[3px]',
           'text-left outline-none transition-colors',
           canExpand
-            ? 'cursor-pointer select-none hover:bg-[var(--msg-code-inline-bg)] focus-visible:ring-2 focus-visible:ring-[var(--info-700)]/40'
+            ? cn(
+                'cursor-pointer select-none focus-visible:ring-2 focus-visible:ring-[var(--info-700)]/40',
+                ACTIVITY_ROW_HOVER_SURFACE_CLASS,
+              )
             : 'cursor-default select-none',
         )}
       >
@@ -975,14 +982,7 @@ function AutoResumeActionRow({
         )}
         <span className="flex-1" />
         {canExpand && (
-          <span
-            aria-hidden="true"
-            className={cn(
-              'flex h-[18px] w-[18px] items-center justify-center rounded-[4px] shrink-0',
-              'text-[var(--msg-tool-card-chevron)]',
-              'transition-colors group-hover:bg-[var(--cmd-palette-item-hover)]',
-            )}
-          >
+          <span aria-hidden="true" className={ACTIVITY_ROW_CHEVRON_SLOT_CLASS}>
             {expanded ? <ChevronDown size={13} /> : <ChevronRight size={13} />}
           </span>
         )}

--- a/apps/desktop/src/renderer/components/chat/WorkGroupBlock.tsx
+++ b/apps/desktop/src/renderer/components/chat/WorkGroupBlock.tsx
@@ -40,6 +40,7 @@ import { Spinner } from '@/components/ui/spinner';
 
 import {
   ACTIVITY_ROW_CHEVRON_SLOT_CLASS,
+  ACTIVITY_ROW_COLOR_TRANSITION_CLASS,
   ACTIVITY_ROW_HOVER_SURFACE_CLASS,
   ACTIVITY_ROW_RADIUS_CLASS,
 } from './activityRowChrome';
@@ -174,7 +175,8 @@ function ThinkingActivityRow({
         expanded ? 'items-start' : 'items-center',
         canExpand
           ? [
-              'group cursor-pointer select-none transition-colors focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)]',
+              'group cursor-pointer select-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)]',
+              ACTIVITY_ROW_COLOR_TRANSITION_CLASS,
               ACTIVITY_ROW_HOVER_SURFACE_CLASS,
             ]
           : 'cursor-default',

--- a/apps/desktop/src/renderer/components/chat/WorkGroupBlock.tsx
+++ b/apps/desktop/src/renderer/components/chat/WorkGroupBlock.tsx
@@ -38,6 +38,10 @@ import { useExpandedBlockMemory } from '@/hooks/useExpandedBlockMemory';
 import { Collapse } from '@/components/ui/collapse';
 import { Spinner } from '@/components/ui/spinner';
 
+import {
+  ACTIVITY_ROW_CHEVRON_SLOT_CLASS,
+  ACTIVITY_ROW_HOVER_SURFACE_CLASS,
+} from './activityRowChrome';
 import { AgentActionRow } from './AgentActionRow';
 import { ThinkingCard, formatDuration } from './ThinkingCard';
 import { ThinkingText } from './ThinkingText';
@@ -112,7 +116,7 @@ export interface WorkGroupBlockProps {
 
 function ToolActivityRow({ activity }: { activity: ProjectedToolActivity }) {
   return (
-    <div data-live-work-activity="tool" className="min-w-0">
+    <div data-live-work-activity="tool" className="w-full min-w-0">
       <AgentActionRow
         message={activity.message}
         toolResult={activity.toolResult}
@@ -164,8 +168,14 @@ function ThinkingActivityRow({
       aria-expanded={canExpand ? expanded : undefined}
       onClick={() => setExpanded((value) => !value)}
       className={cn(
-        'flex w-full min-w-0 items-start gap-[6px] px-2 py-[3px] text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)]',
-        canExpand && 'cursor-pointer hover:opacity-80 transition-opacity',
+        'flex w-full min-w-0 gap-[6px] rounded-[6px] px-2 py-[3px] text-left outline-none',
+        expanded ? 'items-start' : 'items-center',
+        canExpand
+          ? [
+              'group cursor-pointer select-none transition-colors focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)]',
+              ACTIVITY_ROW_HOVER_SURFACE_CLASS,
+            ]
+          : 'cursor-default',
       )}
     >
       <span
@@ -184,8 +194,8 @@ function ThinkingActivityRow({
       >
         <ThinkingText content={expanded ? rawContent : activity.content} />
       </span>
-      {canExpand && (
-        <span aria-hidden="true" className="inline-flex h-[18px] shrink-0 items-center text-[var(--msg-tool-card-chevron)]">
+      <span aria-hidden="true" className={ACTIVITY_ROW_CHEVRON_SLOT_CLASS}>
+        {canExpand ? (
           <ChevronRight
             size={13}
             className={cn(
@@ -193,46 +203,16 @@ function ThinkingActivityRow({
               expanded && 'rotate-90',
             )}
           />
-        </span>
-      )}
+        ) : null}
+      </span>
     </button>
   );
 }
 
-/** 展开动作段里的 thinking:默认直接露出一行;原文多行或视觉溢出时,
- *  允许再点该行查看完整原文。live preview 继续复用上面的固定单行版本。 */
+/** 展开动作段里的 thinking:与 live preview 共用 ThinkingActivityRow,
+ *  保证右侧三角槽同一套布局;redacted 仍走 ThinkingCard。 */
 function ExpandedThinkingRow({ message }: { message: ChatMessage }) {
   const activity = thinkingActivityForMessage(message);
-  const rawContent = message.content.trim();
-  const hasExplicitLineBreak = /[\r\n]/.test(rawContent);
-  const textRef = useRef<HTMLSpanElement>(null);
-  const [canExpand, setCanExpand] = useState(hasExplicitLineBreak);
-  const { expanded, setExpanded } = useExpandedBlockMemory(`thinking:${message.clientId}`);
-
-  useLayoutEffect(() => {
-    if (!activity) return;
-    if (expanded) {
-      setCanExpand(true);
-      return;
-    }
-    const textElement = textRef.current;
-    if (!textElement) return;
-    const updateOverflow = () => {
-      setCanExpand(
-        hasExplicitLineBreak || textElement.scrollWidth > textElement.clientWidth + 1,
-      );
-    };
-    updateOverflow();
-    if (typeof ResizeObserver === 'undefined') return;
-    const observer = new ResizeObserver(updateOverflow);
-    observer.observe(textElement);
-    return () => observer.disconnect();
-  }, [activity?.content, expanded, hasExplicitLineBreak]);
-
-  const onToggle = useCallback(() => {
-    if (canExpand) setExpanded((value) => !value);
-  }, [canExpand, setExpanded]);
-
   if (!activity) {
     if (!message.thinkingRedacted) return null;
     return (
@@ -246,49 +226,7 @@ function ExpandedThinkingRow({ message }: { message: ChatMessage }) {
     );
   }
 
-  return (
-    <button
-      type="button"
-      data-live-work-activity="thinking"
-      data-message-client-id={message.clientId}
-      data-work-thinking-expandable={canExpand ? 'true' : 'false'}
-      onClick={onToggle}
-      disabled={!canExpand}
-      aria-expanded={canExpand ? expanded : undefined}
-      className={cn(
-        'flex w-full min-w-0 items-start gap-[6px] px-2 py-[3px] text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)]',
-        canExpand && 'cursor-pointer hover:opacity-80 transition-opacity',
-      )}
-    >
-      <span
-        aria-hidden="true"
-        className="inline-flex h-[18px] w-4 shrink-0 items-center justify-center text-[var(--msg-tool-card-chevron)]"
-      >
-        <Sparkles size={13} />
-      </span>
-      <span
-        ref={textRef}
-        className={cn(
-          'min-w-0 flex-1 text-14 italic text-[var(--thinking-body-text)]',
-          expanded ? 'whitespace-pre-wrap break-words' : 'truncate',
-        )}
-        title={expanded ? undefined : activity.content}
-      >
-        <ThinkingText content={expanded ? rawContent : activity.content} />
-      </span>
-      {canExpand && (
-        <span aria-hidden="true" className="inline-flex h-[18px] shrink-0 items-center text-[var(--msg-tool-card-chevron)]">
-          <ChevronRight
-            size={13}
-            className={cn(
-              'transition-transform duration-[var(--motion-fast,150ms)]',
-              expanded && 'rotate-90',
-            )}
-          />
-        </span>
-      )}
-    </button>
-  );
+  return <ThinkingActivityRow activity={activity} />;
 }
 
 /** 同一个子项渲染器递归服务运行态动作组、完成态内层动作组和外层文字时间线。 */
@@ -423,8 +361,8 @@ export function WorkGroupBlock({
     : baseSummaryText;
 
   return (
-    <div className="flex w-full justify-start">
-      <div className="w-full">
+    <div className="flex w-full min-w-0 justify-start">
+      <div className="w-full min-w-0">
         <button
           type="button"
           onClick={canToggle ? onToggle : undefined}
@@ -472,7 +410,7 @@ export function WorkGroupBlock({
           <div
             data-live-work-preview="true"
             className={cn(
-              'mt-1 border-l-2 border-[var(--agent-actions-rail)] py-[2px] pl-3',
+              'mt-1 min-w-0 border-l-2 border-[var(--agent-actions-rail)] py-[2px] pl-3',
               'flex flex-col',
             )}
           >
@@ -489,7 +427,7 @@ export function WorkGroupBlock({
         <Collapse open={effectiveExpanded}>
           <div
             className={cn(
-              'mt-1 pl-3 py-[2px]',
+              'mt-1 min-w-0 pl-3 py-[2px]',
               'border-l-2 border-[var(--agent-actions-rail)]',
               'flex flex-col gap-2',
             )}

--- a/apps/desktop/src/renderer/components/chat/WorkGroupBlock.tsx
+++ b/apps/desktop/src/renderer/components/chat/WorkGroupBlock.tsx
@@ -41,6 +41,7 @@ import { Spinner } from '@/components/ui/spinner';
 import {
   ACTIVITY_ROW_CHEVRON_SLOT_CLASS,
   ACTIVITY_ROW_HOVER_SURFACE_CLASS,
+  ACTIVITY_ROW_RADIUS_CLASS,
 } from './activityRowChrome';
 import { AgentActionRow } from './AgentActionRow';
 import { ThinkingCard, formatDuration } from './ThinkingCard';
@@ -168,7 +169,8 @@ function ThinkingActivityRow({
       aria-expanded={canExpand ? expanded : undefined}
       onClick={() => setExpanded((value) => !value)}
       className={cn(
-        'flex w-full min-w-0 gap-[6px] rounded-[6px] px-2 py-[3px] text-left outline-none',
+        'flex w-full min-w-0 gap-[6px] px-2 py-[3px] text-left outline-none',
+        ACTIVITY_ROW_RADIUS_CLASS,
         expanded ? 'items-start' : 'items-center',
         canExpand
           ? [

--- a/apps/desktop/src/renderer/components/chat/activityRowChrome.ts
+++ b/apps/desktop/src/renderer/components/chat/activityRowChrome.ts
@@ -1,8 +1,13 @@
 /**
  * Compact activity-row chrome shared by tool rows, work-group thinking rows,
  * and system interruption rows. Mixed lists must share one trailing-triangle
- * slot and one hover lift — two languages in the same column read as drift.
+ * slot, one hover lift, and one radius — two languages in the same column
+ * read as drift. Radius is DESIGN.md §5 inner-control 8px (`rounded-lg`):
+ * these rows are not pills, and 4px / 6px are not on the scale.
  */
+
+/** Compact row surface radius. Pair with padding on the clickable row. */
+export const ACTIVITY_ROW_RADIUS_CLASS = 'rounded-lg';
 
 /** Row surface that lifts on hover. Pair with `group` on the clickable row. */
 export const ACTIVITY_ROW_HOVER_SURFACE_CLASS = 'hover:bg-[var(--msg-code-inline-bg)]';
@@ -10,4 +15,4 @@ export const ACTIVITY_ROW_HOVER_SURFACE_CLASS = 'hover:bg-[var(--msg-code-inline
 /** Fixed 18×18 trailing chevron slot. Always reserve the column; hover paints
  *  the small rounded well behind the glyph (`group-hover` on the row). */
 export const ACTIVITY_ROW_CHEVRON_SLOT_CLASS =
-  'ml-auto flex h-[18px] w-[18px] shrink-0 items-center justify-center rounded-[4px] text-[var(--msg-tool-card-chevron)] transition-colors group-hover:bg-[var(--cmd-palette-item-hover)]';
+  'ml-auto flex h-[18px] w-[18px] shrink-0 items-center justify-center rounded-lg text-[var(--msg-tool-card-chevron)] transition-colors group-hover:bg-[var(--cmd-palette-item-hover)]';

--- a/apps/desktop/src/renderer/components/chat/activityRowChrome.ts
+++ b/apps/desktop/src/renderer/components/chat/activityRowChrome.ts
@@ -12,7 +12,12 @@ export const ACTIVITY_ROW_RADIUS_CLASS = 'rounded-[8px]';
 /** Row surface that lifts on hover. Pair with `group` on the clickable row. */
 export const ACTIVITY_ROW_HOVER_SURFACE_CLASS = 'hover:bg-[var(--msg-code-inline-bg)]';
 
+/** Color hover. DESIGN.md §14.4: new transitions must cite motion tokens;
+ *  `transition-colors` alone uses Tailwind's hardcoded duration/easing. */
+export const ACTIVITY_ROW_COLOR_TRANSITION_CLASS =
+  'transition-colors duration-[var(--motion-fast,150ms)] ease-[var(--motion-ease-out)]';
+
 /** Fixed 18×18 trailing chevron slot. Always reserve the column; hover paints
  *  the small rounded well behind the glyph (`group-hover` on the row). */
 export const ACTIVITY_ROW_CHEVRON_SLOT_CLASS =
-  `ml-auto flex h-[18px] w-[18px] shrink-0 items-center justify-center ${ACTIVITY_ROW_RADIUS_CLASS} text-[var(--msg-tool-card-chevron)] transition-colors group-hover:bg-[var(--cmd-palette-item-hover)]`;
+  `ml-auto flex h-[18px] w-[18px] shrink-0 items-center justify-center ${ACTIVITY_ROW_RADIUS_CLASS} ${ACTIVITY_ROW_COLOR_TRANSITION_CLASS} text-[var(--msg-tool-card-chevron)] group-hover:bg-[var(--cmd-palette-item-hover)]`;

--- a/apps/desktop/src/renderer/components/chat/activityRowChrome.ts
+++ b/apps/desktop/src/renderer/components/chat/activityRowChrome.ts
@@ -2,12 +2,12 @@
  * Compact activity-row chrome shared by tool rows, work-group thinking rows,
  * and system interruption rows. Mixed lists must share one trailing-triangle
  * slot, one hover lift, and one radius — two languages in the same column
- * read as drift. Radius is DESIGN.md §5 inner-control 8px (`rounded-lg`):
- * these rows are not pills, and 4px / 6px are not on the scale.
+ * read as drift. Radius is DESIGN.md §5 inner-control 8px. Do not use the
+ * lg radius utility: it compiles to an undefined theme variable and is dropped.
  */
 
 /** Compact row surface radius. Pair with padding on the clickable row. */
-export const ACTIVITY_ROW_RADIUS_CLASS = 'rounded-lg';
+export const ACTIVITY_ROW_RADIUS_CLASS = 'rounded-[8px]';
 
 /** Row surface that lifts on hover. Pair with `group` on the clickable row. */
 export const ACTIVITY_ROW_HOVER_SURFACE_CLASS = 'hover:bg-[var(--msg-code-inline-bg)]';
@@ -15,4 +15,4 @@ export const ACTIVITY_ROW_HOVER_SURFACE_CLASS = 'hover:bg-[var(--msg-code-inline
 /** Fixed 18×18 trailing chevron slot. Always reserve the column; hover paints
  *  the small rounded well behind the glyph (`group-hover` on the row). */
 export const ACTIVITY_ROW_CHEVRON_SLOT_CLASS =
-  'ml-auto flex h-[18px] w-[18px] shrink-0 items-center justify-center rounded-lg text-[var(--msg-tool-card-chevron)] transition-colors group-hover:bg-[var(--cmd-palette-item-hover)]';
+  `ml-auto flex h-[18px] w-[18px] shrink-0 items-center justify-center ${ACTIVITY_ROW_RADIUS_CLASS} text-[var(--msg-tool-card-chevron)] transition-colors group-hover:bg-[var(--cmd-palette-item-hover)]`;

--- a/apps/desktop/src/renderer/components/chat/activityRowChrome.ts
+++ b/apps/desktop/src/renderer/components/chat/activityRowChrome.ts
@@ -1,0 +1,13 @@
+/**
+ * Compact activity-row chrome shared by tool rows, work-group thinking rows,
+ * and system interruption rows. Mixed lists must share one trailing-triangle
+ * slot and one hover lift — two languages in the same column read as drift.
+ */
+
+/** Row surface that lifts on hover. Pair with `group` on the clickable row. */
+export const ACTIVITY_ROW_HOVER_SURFACE_CLASS = 'hover:bg-[var(--msg-code-inline-bg)]';
+
+/** Fixed 18×18 trailing chevron slot. Always reserve the column; hover paints
+ *  the small rounded well behind the glyph (`group-hover` on the row). */
+export const ACTIVITY_ROW_CHEVRON_SLOT_CLASS =
+  'ml-auto flex h-[18px] w-[18px] shrink-0 items-center justify-center rounded-[4px] text-[var(--msg-tool-card-chevron)] transition-colors group-hover:bg-[var(--cmd-palette-item-hover)]';


### PR DESCRIPTION
## 这次改了什么

### 摘要

工作组混排里，工具行、思考行、系统中断行原来各写一套右侧三角和 hover：短思考行会把末尾 `>` 整块卸掉，长思考行只靠变淡，同一列两套手感。抽出共用 chrome——固定 18×18 槽始终占位（没有三角也留空），hover 浮起走同一套 token。展开动作段的思考行不再另写一份，直接复用 live preview 那条。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：Desktop 聊天工作组里工具行 / 思考行 / 系统中断行的右侧三角槽与 hover 浮起统一
- 明确不包含：改三角尺寸或颜色、改思考展开交互语义、Mobile
- 用户可见变化：混排时短/长思考行的三角列对齐；思考行 hover 与工具行同一套底和三角井
- 是否存在 breaking change：无

### UI 变化

Desktop 聊天工作组动作列表（macOS 隔离开发版已目检 Light）。无截图。

- 引用的设计规范：
  - `docs/design-rules/DESIGN.md` §1：同一列里两套手感是多余装饰；混排只保留一套三角槽和一套 hover。
  - `docs/design-rules/DESIGN.md` §5 间距系统：行内 gap 6px、槽 18×18，沿用既有工具行节奏。行表面与三角井走 inner-control 8px（`rounded-[8px]`）。不用 `rounded-lg`：它编成未定义的 `var(--radius)`，声明会被丢掉。不沿用工具行遗留的 4px / 6px，也不新开半径档（规范三档是 8 / 12 / 9999）。
  - `docs/design-rules/DESIGN.md` §10：颜色只走 token（`--msg-code-inline-bg`、`--cmd-palette-item-hover`、`--msg-tool-card-chevron`、`--focus-ring`），无硬编码色。
  - `docs/design-rules/DESIGN.md` §10 双模式门槛：两模式都经 token，Light 在隔离开发版目检；Dark 未单独目检，不把「复用 themed 样式」写成已验证。
  - `docs/design-rules/DESIGN.md` §14.4：hover 用 `transition-colors`，时长 `--motion-fast`、曲线 `--motion-ease-out`，无装饰动效。
  - `docs/design-rules/DESIGN.md` §15.16 Dual anchoring：行 hover 继续用聊天内容区既有 alias，不拿 `--update-btn-hover` 或页面级 `--surface-hover` 去「统一」。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop run typecheck
结果：通过

pnpm test:unit:related
结果：PASS apps/desktop unit（related 6 个文件，含新增 chrome 与思考行槽位用例）

pnpm check:dco
结果：通过（4 commits signed off，base origin/main）
```

### 手工验证

macOS Desktop 隔离沙箱 `align-tool-row-chevrons-bca108`（Global，`pnpm restart:desktop:remote --region=global -- --isolated=@worktree`，`DESKTOP_DEV_VERDICT=ready`）。打开带工具行 + 长短思考行混排的任务，确认短行也留 18px 槽、可展开行三角与工具行同列，hover 底和三角井一致。

### 未执行的验证

- Dark 模式未单独目检（token 复用，未声称已验证）。
- 全量 `pnpm test:unit` 在本机跑过，失败项是 `apps/desktop/src/main/cindy-brain/__tests__/ghostInstallReceipt.test.ts` 2 例（`state: invalid` vs 期望 `approved`）。该文件不在本 PR diff 内；在不含本 PR 改动的 checkout 上复现同样失败，判定为基线问题，不混入本 PR。
- CI Windows unit tests (1/2) 红了 `importSharedCodexThread.test.ts` hook timeout / 无关断言，也不在本 PR diff 内。权威结论交给后续 CI。
- Mobile 不涉及。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop 聊天工作组动作列表的三角槽与 hover chrome；无数据、无协议。
- 回滚 / 降级方式：revert 本 PR。
- 存量插件影响：无。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
