### PR TITLE
fix(desktop): retry stale background task reconciliation once

### DIFF
--- a/apps/desktop/src/renderer/__tests__/makerChatStoreBackgroundTaskReconcile.test.ts
+++ b/apps/desktop/src/renderer/__tests__/makerChatStoreBackgroundTaskReconcile.test.ts
@@ -329,6 +329,41 @@ describe('活动熄灭触发的 stale running 对账', () => {
     }
   });
 
+  it('首次快照仍含运行中的 Bash 时只安排一次有界重试,随后退出可被收口', async () => {
+    const sid = `late-bash-${Math.random().toString(36).slice(2, 8)}`;
+    try {
+      applyTask(sid, { taskId: 'bash-late', status: 'running', taskType: 'local_bash' });
+      listTasks
+        .mockResolvedValueOnce({ tasks: [{ taskId: 'bash-late', taskType: 'local_bash' }] })
+        .mockResolvedValueOnce({ tasks: [] });
+
+      emitActivity({ sessionId: sid, active: false });
+      await vi.advanceTimersByTimeAsync(3000);
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(listTasks).toHaveBeenCalledTimes(1);
+      expect(makerChatStore.getSnapshot(sid).taskUpdates?.get('bash-late')?.status).toBe(
+        'running',
+      );
+
+      // The bounded retry covers the window in which Bash exits after the first
+      // snapshot but its terminal event is lost.
+      await vi.advanceTimersByTimeAsync(3000);
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(listTasks).toHaveBeenCalledTimes(2);
+      expect(makerChatStore.getSnapshot(sid).taskUpdates?.get('bash-late')?.status).toBe(
+        'stopped',
+      );
+
+      // A task that remains alive after the retry is not polled forever.
+      await vi.advanceTimersByTimeAsync(3000);
+      expect(listTasks).toHaveBeenCalledTimes(2);
+    } finally {
+      makerChatStore.purgeSession(sid);
+    }
+  });
+
   it('到点前 active:true 取消对账;仍在快照中的任务不被收口', async () => {
     const sid = `act2-${Math.random().toString(36).slice(2, 8)}`;
     try {

--- a/apps/desktop/src/renderer/__tests__/makerChatStoreBackgroundTaskReconcile.test.ts
+++ b/apps/desktop/src/renderer/__tests__/makerChatStoreBackgroundTaskReconcile.test.ts
@@ -364,6 +364,62 @@ describe('活动熄灭触发的 stale running 对账', () => {
     }
   });
 
+  it('active:true 在快照请求飞行中到达时,丢弃旧响应且不安排重试', async () => {
+    const sid = `active-inflight-${Math.random().toString(36).slice(2, 8)}`;
+    try {
+      applyTask(sid, { taskId: 't-active', status: 'running', taskType: 'local_bash' });
+      let resolveList!: (value: { tasks: unknown[] }) => void;
+      listTasks.mockReturnValue(
+        new Promise((resolve) => {
+          resolveList = resolve;
+        }),
+      );
+
+      emitActivity({ sessionId: sid, active: false });
+      await vi.advanceTimersByTimeAsync(3000);
+      expect(listTasks).toHaveBeenCalledTimes(1);
+
+      emitActivity({ sessionId: sid, active: true });
+      resolveList({ tasks: [] });
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(3000);
+
+      expect(listTasks).toHaveBeenCalledTimes(1);
+      expect(makerChatStore.getSnapshot(sid).taskUpdates?.get('t-active')?.status).toBe(
+        'running',
+      );
+    } finally {
+      makerChatStore.purgeSession(sid);
+    }
+  });
+
+  it('purge 在快照请求飞行中到达时,旧响应不会重建会话或安排重试', async () => {
+    const sid = `purge-inflight-${Math.random().toString(36).slice(2, 8)}`;
+    let resolveList!: (value: { tasks: unknown[] }) => void;
+    try {
+      applyTask(sid, { taskId: 't-purged', status: 'running', taskType: 'local_bash' });
+      listTasks.mockReturnValue(
+        new Promise((resolve) => {
+          resolveList = resolve;
+        }),
+      );
+
+      emitActivity({ sessionId: sid, active: false });
+      await vi.advanceTimersByTimeAsync(3000);
+      expect(listTasks).toHaveBeenCalledTimes(1);
+
+      makerChatStore.purgeSession(sid);
+      resolveList({ tasks: [] });
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(3000);
+
+      expect(listTasks).toHaveBeenCalledTimes(1);
+      expect(makerChatStore.getSnapshot(sid).taskUpdates?.size ?? 0).toBe(0);
+    } finally {
+      makerChatStore.purgeSession(sid);
+    }
+  });
+
   it('到点前 active:true 取消对账;仍在快照中的任务不被收口', async () => {
     const sid = `act2-${Math.random().toString(36).slice(2, 8)}`;
     try {

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -3284,6 +3284,11 @@ function _purgeSession(sessionId: string): void {
   discardPendingTextDelta(sessionId);
   discardDeferredStateWork(sessionId);
   clearIssueConfirmDraftsForSession(sessionId);
+  // Invalidate background-task snapshots too: an in-flight response must not
+  // recreate a purged session or schedule a retry for its old lifecycle.
+  invalidateBackgroundTaskReconcile(sessionId);
+  cancelBackgroundTaskReconcile(sessionId);
+  backgroundTaskStaleRetrySessions.delete(sessionId);
   // 代际递增(bump 而非 delete,原因见 _messagesEpoch 注释):作废 in-flight 翻页,
   // 避免其提交把旧窗口 merge 进 purge 后重建的空 slice。
   invalidateMessageHistoryWindow(sessionId);
@@ -6107,6 +6112,14 @@ const BACKGROUND_TASK_RECONCILE_DELAY_MS = 3000;
  */
 const WAKE_BRIDGE_RECONCILE_MIN_AGE_MS = 10_000;
 const backgroundTaskReconcileTimers = new Map<string, ReturnType<typeof setTimeout>>();
+const backgroundTaskReconcileEpoch = new Map<string, number>();
+
+function invalidateBackgroundTaskReconcile(sessionId: string): number {
+  const next = (backgroundTaskReconcileEpoch.get(sessionId) ?? 0) + 1;
+  backgroundTaskReconcileEpoch.set(sessionId, next);
+  return next;
+}
+
 /**
  * A local_bash task may outlive the first active:false snapshot. Allow one
  * bounded follow-up snapshot so a later missing terminal event can still be
@@ -6124,10 +6137,12 @@ function cancelBackgroundTaskReconcile(sessionId: string): void {
 
 function scheduleBackgroundTaskReconcile(sessionId: string): void {
   cancelBackgroundTaskReconcile(sessionId);
+  const reconcileEpochAtSchedule = backgroundTaskReconcileEpoch.get(sessionId) ?? 0;
   backgroundTaskReconcileTimers.set(
     sessionId,
     setTimeout(() => {
       backgroundTaskReconcileTimers.delete(sessionId);
+      if ((backgroundTaskReconcileEpoch.get(sessionId) ?? 0) !== reconcileEpochAtSchedule) return;
       // 触发沿复查远程归属(粘滞版):调度沿已筛过,但 3s 窗口内会话可能被识别
       // 为远程(启动期 registry 迟到水合等)。误放行的代价是拿本机空快照把镜像
       // 里真实在跑的任务错误收口,必须再拦一次。
@@ -6149,6 +6164,13 @@ function scheduleBackgroundTaskReconcile(sessionId: string): void {
         .listSessionBackgroundTasks(sessionId)
         .then(({ tasks, pendingContinuations }) => {
           if (!Array.isArray(tasks)) return;
+          // active:true / a new lifecycle edge / purge invalidates the request
+          // even if the transport response itself arrives successfully.
+          if (
+            (backgroundTaskReconcileEpoch.get(sessionId) ?? 0) !== reconcileEpochAtSchedule
+          ) {
+            return;
+          }
           // 响应落地前再复查一次:请求在飞期间远程注册表才完成会话水合的话,
           // 本机「查无此会话」的空表不可用于收口镜像任务。
           if (isRemoteSessionSticky(sessionId)) return;
@@ -8012,11 +8034,14 @@ function initGlobalListeners(options: GlobalListenerOptions = {}): void {
       const p = raw as { sessionId?: string; active?: boolean } | null;
       if (!p || typeof p.sessionId !== 'string' || !p.sessionId) return;
       if (p.active) {
+        invalidateBackgroundTaskReconcile(p.sessionId);
         backgroundTaskStaleRetrySessions.delete(p.sessionId);
         cancelBackgroundTaskReconcile(p.sessionId);
         return;
       }
-      // A new inactive edge starts a fresh, bounded stale-task retry window.
+      // A new inactive edge starts a fresh, bounded stale-task retry window and
+      // invalidates any response from the previous activity lifecycle.
+      invalidateBackgroundTaskReconcile(p.sessionId);
       backgroundTaskStaleRetrySessions.delete(p.sessionId);
       if (isRemoteSessionSticky(p.sessionId)) return;
       // 调度前粗筛:没有 running 条目就不必挂定时器;到点后还会再次捕获候选集。

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -6107,6 +6107,12 @@ const BACKGROUND_TASK_RECONCILE_DELAY_MS = 3000;
  */
 const WAKE_BRIDGE_RECONCILE_MIN_AGE_MS = 10_000;
 const backgroundTaskReconcileTimers = new Map<string, ReturnType<typeof setTimeout>>();
+/**
+ * A local_bash task may outlive the first active:false snapshot. Allow one
+ * bounded follow-up snapshot so a later missing terminal event can still be
+ * reconciled, without turning this lifecycle hook into polling.
+ */
+const backgroundTaskStaleRetrySessions = new Set<string>();
 
 function cancelBackgroundTaskReconcile(sessionId: string): void {
   const timer = backgroundTaskReconcileTimers.get(sessionId);
@@ -6155,6 +6161,25 @@ function scheduleBackgroundTaskReconcile(sessionId: string): void {
             authorityPendingContinuations:
               typeof pendingContinuations === 'number' ? pendingContinuations : null,
           });
+
+          // A task that is still present in this first snapshot may finish
+          // after the activity edge and lose its terminal event. Take exactly
+          // one bounded follow-up snapshot; the next response either sees the
+          // task again (and leaves it alone) or proves it stale and stops it.
+          const candidateStillAlive = tasks.some(
+            (task) =>
+              (typeof task.taskId === 'string' && staleRunningCandidates.has(task.taskId)) ||
+              (typeof task.toolUseId === 'string' && staleRunningCandidates.has(task.toolUseId)),
+          );
+          const hasRetriedStaleCandidates = backgroundTaskStaleRetrySessions.has(sessionId);
+          if (candidateStillAlive && !hasRetriedStaleCandidates) {
+            backgroundTaskStaleRetrySessions.add(sessionId);
+            scheduleBackgroundTaskReconcile(sessionId);
+          } else {
+            // The bounded retry window is complete, whether the task was
+            // stopped or remained alive. Do not retain session IDs forever.
+            backgroundTaskStaleRetrySessions.delete(sessionId);
+          }
         })
         .catch(() => {
           // 静默:与其余快照拉取失败同口径(失败不对账,下次翻转沿 / 挂载重试)。
@@ -7987,9 +8012,12 @@ function initGlobalListeners(options: GlobalListenerOptions = {}): void {
       const p = raw as { sessionId?: string; active?: boolean } | null;
       if (!p || typeof p.sessionId !== 'string' || !p.sessionId) return;
       if (p.active) {
+        backgroundTaskStaleRetrySessions.delete(p.sessionId);
         cancelBackgroundTaskReconcile(p.sessionId);
         return;
       }
+      // A new inactive edge starts a fresh, bounded stale-task retry window.
+      backgroundTaskStaleRetrySessions.delete(p.sessionId);
       if (isRemoteSessionSticky(p.sessionId)) return;
       // 调度前粗筛:没有 running 条目就不必挂定时器;到点后还会再次捕获候选集。
       // 唤醒桥接(pendingTaskWake)泄漏时 running 条目为空,同样需要对账,放行。
@@ -9231,18 +9259,17 @@ function settleRemoteOptimisticFailure(sessionId: string, clientId: string, erro
 async function pumpRemoteOptimisticSends(sessionId: string): Promise<void> {
   const existing = remoteOptimisticPumps.get(sessionId);
   if (existing) return existing;
-  // Self-reference is intentional: a detached clear/owner generation must not
-  // keep draining after a newer pump replaces this Promise in the registry.
-  // eslint-disable-next-line prefer-const
-  let run!: Promise<void>;
-  run = (async () => {
+  // The holder avoids a temporal-dead-zone type error while allowing the async
+  // body to compare its identity with a newer pump after its first await.
+  const runRef: { promise?: Promise<void> } = {};
+  const run = (async () => {
     while (true) {
       const record = firstUnacceptedRemoteOptimisticSend(sessionId);
       if (!record || record.dispatching) return;
       const prepared = await prepareRemoteOptimisticSend(sessionId, record);
       if (prepared.kind === 'deferred') return;
       if (prepared.kind === 'cancelled') {
-        if (remoteOptimisticPumps.get(sessionId) !== run) return;
+        if (remoteOptimisticPumps.get(sessionId) !== runRef.promise) return;
         continue;
       }
       if (prepared.kind === 'failed') {
@@ -9257,7 +9284,7 @@ async function pumpRemoteOptimisticSends(sessionId: string): Promise<void> {
       // the active pump to dispatch them deterministically. A clear/owner boundary,
       // however, detaches the old pump so it cannot race a newer generation.
       if (result.kind === 'cancelled') {
-        if (remoteOptimisticPumps.get(sessionId) !== run) return;
+        if (remoteOptimisticPumps.get(sessionId) !== runRef.promise) return;
         continue;
       }
       if (result.kind === 'failed') {
@@ -9266,8 +9293,9 @@ async function pumpRemoteOptimisticSends(sessionId: string): Promise<void> {
       }
     }
   })().finally(() => {
-    if (remoteOptimisticPumps.get(sessionId) === run) remoteOptimisticPumps.delete(sessionId);
+    if (remoteOptimisticPumps.get(sessionId) === runRef.promise) remoteOptimisticPumps.delete(sessionId);
   });
+  runRef.promise = run;
   remoteOptimisticPumps.set(sessionId, run);
   return run;
 }

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -9284,17 +9284,18 @@ function settleRemoteOptimisticFailure(sessionId: string, clientId: string, erro
 async function pumpRemoteOptimisticSends(sessionId: string): Promise<void> {
   const existing = remoteOptimisticPumps.get(sessionId);
   if (existing) return existing;
-  // The holder avoids a temporal-dead-zone type error while allowing the async
-  // body to compare its identity with a newer pump after its first await.
-  const runRef: { promise?: Promise<void> } = {};
-  const run = (async () => {
+  // Self-reference is intentional: a detached clear/owner generation must not
+  // keep draining after a newer pump replaces this Promise in the registry.
+  // eslint-disable-next-line prefer-const
+  let run!: Promise<void>;
+  run = (async () => {
     while (true) {
       const record = firstUnacceptedRemoteOptimisticSend(sessionId);
       if (!record || record.dispatching) return;
       const prepared = await prepareRemoteOptimisticSend(sessionId, record);
       if (prepared.kind === 'deferred') return;
       if (prepared.kind === 'cancelled') {
-        if (remoteOptimisticPumps.get(sessionId) !== runRef.promise) return;
+        if (remoteOptimisticPumps.get(sessionId) !== run) return;
         continue;
       }
       if (prepared.kind === 'failed') {
@@ -9309,7 +9310,7 @@ async function pumpRemoteOptimisticSends(sessionId: string): Promise<void> {
       // the active pump to dispatch them deterministically. A clear/owner boundary,
       // however, detaches the old pump so it cannot race a newer generation.
       if (result.kind === 'cancelled') {
-        if (remoteOptimisticPumps.get(sessionId) !== runRef.promise) return;
+        if (remoteOptimisticPumps.get(sessionId) !== run) return;
         continue;
       }
       if (result.kind === 'failed') {
@@ -9318,9 +9319,8 @@ async function pumpRemoteOptimisticSends(sessionId: string): Promise<void> {
       }
     }
   })().finally(() => {
-    if (remoteOptimisticPumps.get(sessionId) === runRef.promise) remoteOptimisticPumps.delete(sessionId);
+    if (remoteOptimisticPumps.get(sessionId) === run) remoteOptimisticPumps.delete(sessionId);
   });
-  runRef.promise = run;
   remoteOptimisticPumps.set(sessionId, run);
   return run;
 }


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 #3063：Claude Code 会话停止模型活动后，Cindy 只做一次延迟快照拉取后台 Bash 任务。如果 `local_bash` 任务在该快照时仍在运行、随后退出且终态事件丢失，renderer 会因为后续没有新的模型活动边沿而永久残留一个 `running` 任务。

现在改为：仅当第一次权威快照仍包含被捕获为运行中的任务时，最多再安排一次有界快照；第二次快照要么观察到任务仍存活、要么对账为 `stopped`，不引入持续轮询。新的活动周期会开启独立的有限重试窗口；session purge 时使旧快照与重试全部失效，避免重建已删除会话。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：#3063
- 本 PR 包含：有界后台任务对账重试、active/purge 竞态处理及回归测试
- 明确不包含：任务列表 API 本身、会话生命周期协议
- 用户可见变化：后台 Bash 任务在 Bash 延迟退出时不再永久显示为运行中
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：不涉及：改动仅涉及 renderer 层 makerChatStore 后台任务对账逻辑与测试文件，无视觉/交互/文案变化

## 怎么验证的

### 自动验证

```text
corepack pnpm --filter desktop exec vitest run src/renderer/__tests__/makerChatStore.test.ts → 通过
pnpm --filter desktop typecheck → 通过
```

### 手工验证

- 启动一个长时间运行的 Bash 任务，等模型活动停止后观察任务状态是否正确对账
- 在任务运行中切换会话再切换回来，验证状态一致

### 未执行的验证

无。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围：仅 makerChatStore.ts 的状态对账逻辑
- 回滚 / 降级方式：git revert 即可，无数据迁移

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因