### PR TITLE
fix(desktop): 自定义供应商 updated_at 为非数值时不再写出 NaN

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/custom-provider-store.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/custom-provider-store.test.ts
@@ -933,6 +933,65 @@ describe('custom-provider-store CRUD (per-runtime)', () => {
     expect(await updateCustomProvider('ghost', valid)).toBeNull();
   });
 
+  // updated_at 列声明为 INTEGER，但表不是 STRICT，所以历史脏数据可能是文本。旧实现直接
+  // 对它 +1 得到字符串拼接，Math.max 变 NaN，写入 NOT NULL 整数列即失败 —— 那个供应商
+  // 此后永久保存不了。
+  it('still saves when updated_at holds a non-numeric value', async () => {
+    mountDb();
+    await createCustomProvider(valid, 1_000);
+    raw!
+      .prepare('UPDATE custom_providers SET updated_at = ? WHERE id = ?')
+      .run('2026-08-19T01:45:07.003Z', 'openrouter');
+    expect(
+      raw!.prepare("SELECT typeof(updated_at) AS t FROM custom_providers WHERE id = 'openrouter'").get(),
+    ).toEqual({ t: 'text' });
+
+    const updated = await updateCustomProvider('openrouter', { ...valid, name: 'Recovered' }, 5_000);
+
+    expect(updated?.name).toBe('Recovered');
+    expect((await getCustomProvider('openrouter'))?.name).toBe('Recovered');
+    const row = raw!
+      .prepare("SELECT updated_at AS updatedAt, typeof(updated_at) AS t FROM custom_providers WHERE id = 'openrouter'")
+      .get() as { updatedAt: number; t: string };
+    expect(row.t).toBe('integer');
+    expect(row.updatedAt).toBe(5_000);
+  });
+
+  it('keeps the optimistic-lock bump strictly increasing when the clock does not advance', async () => {
+    mountDb();
+    await createCustomProvider(valid, 9_000);
+    // now 早于库里的 updatedAt：仍必须写出更大的值，否则乐观锁比较会失效。
+    await updateCustomProvider('openrouter', { ...valid, name: 'Same tick' }, 1_000);
+    const row = raw!
+      .prepare("SELECT updated_at AS updatedAt FROM custom_providers WHERE id = 'openrouter'")
+      .get() as { updatedAt: number };
+    expect(row.updatedAt).toBe(9_001);
+  });
+
+  it('recovers a non-numeric updated_at through the snapshot-guarded write too', async () => {
+    mountDb();
+    await createCustomProvider(valid, 1_000);
+    const snapshot = await getCustomProvider('openrouter');
+    raw!
+      .prepare('UPDATE custom_providers SET updated_at = ? WHERE id = ?')
+      .run('not-a-timestamp', 'openrouter');
+
+    // where 子句用旧值做乐观锁比较，文本值也要能匹配上并写回一个合法整数。
+    expect(
+      await updateCustomProviderIfUnchanged(
+        'openrouter',
+        snapshot!,
+        { ...snapshot!, name: 'Discovered' },
+        7_000,
+      ),
+    ).toBe(true);
+    const row = raw!
+      .prepare("SELECT updated_at AS updatedAt, typeof(updated_at) AS t FROM custom_providers WHERE id = 'openrouter'")
+      .get() as { updatedAt: number; t: string };
+    expect(row.t).toBe('integer');
+    expect(row.updatedAt).toBe(7_000);
+  });
+
   it('isolates data per db file (account switch = new db)', async () => {
     mountDb();
     await createCustomProvider(valid);

--- a/apps/desktop/src/main/maker-host/custom-provider-store.ts
+++ b/apps/desktop/src/main/maker-host/custom-provider-store.ts
@@ -655,6 +655,21 @@ function parseAuth(raw: string | null): CustomProviderConfig['auth'] {
   return undefined;
 }
 
+/**
+ * 计算写回的 `updatedAt`：既要严格大于库里的旧值（`updateCustomProviderIfUnchanged` 依赖它
+ * 做乐观锁），也要不早于当前时刻。
+ *
+ * 必须先转数值再 +1：`updated_at` 列声明为 INTEGER，但 SQLite 非 STRICT 表允许存入文本，
+ * 而 `rowToConfig` 只读 id/name/runtimes/auth、不校验该列。一旦某行存的是字符串，
+ * `existing.updatedAt + 1` 会退化成字符串拼接，`Math.max` 得到 NaN，写入 NOT NULL 整数列
+ * 触发 SQLITE_CONSTRAINT_NOTNULL —— 该供应商此后永久无法保存，且错误对用户不可诉。
+ */
+function nextUpdatedAt(existingUpdatedAt: unknown, now: number): number {
+  const previous = Number(existingUpdatedAt);
+  if (!Number.isFinite(previous)) return now;
+  return Math.max(now, previous + 1);
+}
+
 /** 安全解析 runtimes JSON（坏数据兜底为 {}，逐字段防御）。 */
 function parseRuntimes(raw: string): Partial<Record<AgentKind, CustomProviderRuntimeConfig>> {
   let v: unknown;
@@ -812,7 +827,7 @@ export async function updateCustomProvider(
       name: c.name,
       runtimes: JSON.stringify(c.runtimes),
       auth: c.auth ? JSON.stringify(c.auth) : null,
-      updatedAt: Math.max(now, existing.updatedAt + 1),
+      updatedAt: nextUpdatedAt(existing.updatedAt, now),
     })
     .where(eq(customProviders.id, id));
   return c;
@@ -850,7 +865,7 @@ export async function updateCustomProviderIfUnchanged(
       name: nextConfig.name,
       runtimes: JSON.stringify(nextConfig.runtimes),
       auth: nextConfig.auth ? JSON.stringify(nextConfig.auth) : null,
-      updatedAt: Math.max(now, existing.updatedAt + 1),
+      updatedAt: nextUpdatedAt(existing.updatedAt, now),
     })
     .where(and(eq(customProviders.id, id), eq(customProviders.updatedAt, existing.updatedAt)));
   return result.changes === 1;


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 issue #3105：自定义供应商在 `custom_providers.updated_at` 存了非数值时，编辑后
点保存永久失败，界面只显示「保存失败」。

`updated_at` 声明为 INTEGER，但表不是 STRICT，SQLite 允许该列存入文本；`rowToConfig`
只读 `id/name/runtimes/auth`，不校验该列，所以异常值在写入前不会被发现。一旦某行存的是
字符串，`existing.updatedAt + 1` 退化为字符串拼接，`Math.max` 得到 `NaN`，写入 NOT NULL
整数列触发 `SQLITE_CONSTRAINT_NOTNULL`。

改法是抽出 `nextUpdatedAt()`：先 `Number()` 转换，非有限值回退为 `now`，有限值保持原有的
`Math.max(now, previous + 1)`，以维持 `updateCustomProviderIfUnchanged` 乐观锁依赖的
严格递增语义。两个写入点都改为调用它。

同一构建中其它表用的是不含 `+1` 的写法（如 `Math.max(a.updatedAt, b.updatedAt)`），
不受此问题影响，未改动。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#3105
- 本 PR 包含：`nextUpdatedAt()` 辅助函数；`updateCustomProvider` 与
  `updateCustomProviderIfUnchanged` 两处写入改为调用它；3 个回归测试。
- 明确不包含：
  - 不含数据修正。已经存在异常值的行仍需自行改回整数，本 PR 只保证之后的写入不再失败，
    并且在遇到异常值时把它覆盖成合法整数（相当于顺带自愈）。
  - 不含给表加 `STRICT`。那是 migration，风险等级不同，建议单独评估。
  - 不含保存失败时的 UI 错误提示改进。issue 里提到了，但属于另一层，未在此处动。
- 用户可见变化：受影响的自定义供应商重新可以保存。其它情况下行为不变。
- 是否存在 breaking change：无。有限数值输入的返回值与改动前逐一相同。

### UI 变化

不涉及。仅改动 `apps/desktop/src/main/maker-host/` 下的主进程数据层，无视觉、交互或
文案变化。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm vitest run src/main/maker-host/__tests__/custom-provider-store.test.ts
结果：Test Files 1 passed (1) / Tests 41 passed (41)

# 先只回退源码修复、保留新测试，确认新测试确实覆盖到缺陷：
结果：Tests 2 failed | 39 passed
      × still saves when updated_at holds a non-numeric value
        → NOT NULL constraint failed: custom_providers.updated_at
      × recovers a non-numeric updated_at through the snapshot-guarded write too
        → NOT NULL constraint failed: custom_providers.updated_at
      恢复修复后 41 passed。

pnpm exec eslint src/main/maker-host/custom-provider-store.ts \
                 src/main/maker-host/__tests__/custom-provider-store.test.ts
结果：exit 0，无输出

pnpm typecheck        （tsc --noEmit -p tsconfig.json）
结果：exit 0

pnpm check:dco
结果：DCO check passed: 1 commit signed off

pnpm vitest run src/main/maker-host/     （整目录，与干净树对比基线）
结果：本分支   Test Files 4 failed | 124 passed / Tests 50 failed | 1961 passed | 5 skipped
      干净 main Test Files 4 failed | 124 passed / Tests 50 failed | 1958 passed | 5 skipped
      失败集合完全一致，均为既有失败，与本改动无关：
        pi-package-compatibility / model-visibility-owner-claim
        pi-package-store-security / piRosterAssembly
      本改动净增 3 个通过用例。
```

### 手工验证

在一份实际出现该问题的本地数据库上确认过：该状态下界面保存必然失败、主进程日志为
`SQLITE_CONSTRAINT_NOTNULL`；把 `updated_at` 改回整数后界面即可正常保存。这验证了
issue 中描述的因果链，但由于是既有的脏数据状态，未在打包客户端上重复验证本 PR 的构建
产物（见下节）。

### 未执行的验证

- 未在打包后的 desktop 客户端上端到端复验。触发该状态需要数据库里先存在非数值
  `updated_at`，而应用自身没有会写出该值的代码路径（issue #3105 里说明了这一点：
  触发来源未知），无法在干净环境构造。改动逻辑已由上述单元测试在真实
  better-sqlite3 + drizzle 上覆盖：包含建表语句一致的内存库、写入文本值、
  两条写入路径各自的恢复行为，以及时钟未前进时的严格递增。
- 未跑 `pnpm test:all` / 全仓 lint。改动范围限于单个模块的两处表达式，按 AGENTS.md
  的风险分层跑了该模块与整个 `maker-host` 目录；跨包影响面为零（未改导出签名、
  未改 schema）。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

未勾「SQLite / migration」：本 PR 不含 migration，不改 schema，不改列类型，只改写入前
计算 `updatedAt` 的表达式。

### 影响与回滚

- 影响范围：`apps/desktop` 主进程 `custom-provider-store` 的两处更新写入。对既有的
  数值型 `updated_at`，返回值与改动前完全一致（`Math.max(now, previous + 1)`），
  行为无变化；仅在旧值非数值时改变结果——由抛错变为写入 `now`。
- 回滚 / 降级方式：revert 本 commit 即可，无数据迁移、无持久化格式变化、无需清理。
  已被本改动写成整数的行保持有效，revert 后仍可正常读写。
