### PR TITLE
fix(model-providers): 自定义供应商 updated_at 非数值时保存永久失败 (#3105)

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/custom-provider-store.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/custom-provider-store.test.ts
@@ -933,6 +933,47 @@ describe('custom-provider-store CRUD (per-runtime)', () => {
     expect(await updateCustomProvider('ghost', valid)).toBeNull();
   });
 
+  it('recovers when updated_at holds non-numeric text (#3105)', async () => {
+    mountDb();
+    // 非 STRICT 表允许 INTEGER 列存文本；历史脏数据让 updated_at 变成 ISO 字符串。
+    raw!.prepare(
+      `INSERT INTO custom_providers
+        (id, name, runtimes, auth, sort_order, created_at, updated_at)
+       VALUES (?, ?, ?, NULL, 0, 1786000000000, '2026-08-19T01:45:07Z')`,
+    ).run('openrouter', 'OpenRouter', JSON.stringify(valid.runtimes));
+
+    const updated = await updateCustomProvider('openrouter', valid, 1_786_500_000_000);
+    expect(updated?.name).toBe('OpenRouter');
+    const row = raw!
+      .prepare('SELECT updated_at FROM custom_providers WHERE id = ?')
+      .get('openrouter') as { updated_at: unknown };
+    expect(typeof row.updated_at).toBe('number');
+    expect(Number.isFinite(row.updated_at)).toBe(true);
+  });
+
+  it('recovers in the conditional update when updated_at holds non-numeric text (#3105)', async () => {
+    mountDb();
+    raw!.prepare(
+      `INSERT INTO custom_providers
+        (id, name, runtimes, auth, sort_order, created_at, updated_at)
+       VALUES (?, ?, ?, NULL, 0, 1786000000000, '2026-08-19T01:45:07Z')`,
+    ).run('openrouter', 'OpenRouter', JSON.stringify(valid.runtimes));
+    const snapshot = (await getCustomProvider('openrouter'))!;
+
+    expect(
+      await updateCustomProviderIfUnchanged(
+        'openrouter',
+        snapshot,
+        { ...snapshot, name: 'OR v2' },
+        1_786_500_000_000,
+      ),
+    ).toBe(true);
+    const row = raw!
+      .prepare('SELECT updated_at FROM custom_providers WHERE id = ?')
+      .get('openrouter') as { updated_at: unknown };
+    expect(typeof row.updated_at).toBe('number');
+  });
+
   it('isolates data per db file (account switch = new db)', async () => {
     mountDb();
     await createCustomProvider(valid);

--- a/apps/desktop/src/main/maker-host/custom-provider-store.ts
+++ b/apps/desktop/src/main/maker-host/custom-provider-store.ts
@@ -730,6 +730,15 @@ function parseRuntimes(raw: string): Partial<Record<AgentKind, CustomProviderRun
   return out;
 }
 
+/**
+ * #3105：custom_providers 未启用 STRICT，updated_at（INTEGER）可能存了文本（如 ISO 字符串），
+ * 直接参与 `+ 1` 运算会得 NaN，写入 NOT NULL 列违反约束，导致该行永久保存失败。
+ * 只有有限数值是合法旧时间戳，其余一律回退为 now。
+ */
+function previousUpdatedAt(value: unknown, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback;
+}
+
 function rowToConfig(row: typeof customProviders.$inferSelect): CustomProviderConfig {
   const auth = parseAuth(row.auth);
   const runtimes = parseRuntimes(row.runtimes);
@@ -812,7 +821,7 @@ export async function updateCustomProvider(
       name: c.name,
       runtimes: JSON.stringify(c.runtimes),
       auth: c.auth ? JSON.stringify(c.auth) : null,
-      updatedAt: Math.max(now, existing.updatedAt + 1),
+      updatedAt: Math.max(now, previousUpdatedAt(existing.updatedAt, now) + 1),
     })
     .where(eq(customProviders.id, id));
   return c;
@@ -850,7 +859,7 @@ export async function updateCustomProviderIfUnchanged(
       name: nextConfig.name,
       runtimes: JSON.stringify(nextConfig.runtimes),
       auth: nextConfig.auth ? JSON.stringify(nextConfig.auth) : null,
-      updatedAt: Math.max(now, existing.updatedAt + 1),
+      updatedAt: Math.max(now, previousUpdatedAt(existing.updatedAt, now) + 1),
     })
     .where(and(eq(customProviders.id, id), eq(customProviders.updatedAt, existing.updatedAt)));
   return result.changes === 1;


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 #3105：编辑自定义供应商时「保存失败」且此后永久无法保存。

`custom_providers` 表未启用 SQLite STRICT，`updated_at`（INTEGER）可能实际存了文本（如 ISO 字符串）。`updateCustomProvider` / `updateCustomProviderIfUnchanged` 两处对读到的旧值直接做 `updatedAt + 1` 运算，非数值旧值得到字符串拼接，`Math.max` 产出 `NaN`，写入 NOT NULL 整数列违反约束（`SQLITE_CONSTRAINT_NOTNULL`），该行每次保存都失败。

本次在写入前对旧时间戳做有限数值校验（`previousUpdatedAt`），非法值回退为 `now`：受影响行下一次保存即成功，且 `updated_at` 被写回合法整数，自动完成数据修复。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#3105
- 本 PR 包含：`apps/desktop/src/main/maker-host/custom-provider-store.ts` 两处 `updatedAt` 写入表达式的数值兜底；`custom-provider-store.test.ts` 新增 2 个脏数据回归测试（`updated_at` 存 ISO 字符串时 `updateCustomProvider` 与 `updateCustomProviderIfUnchanged` 均成功并修复为整数）
- 明确不包含：一次性数据迁移 / 给表加 `STRICT`（涉及 migration，单独评估）；保存失败原因透传到界面的错误展示改造（通用 IPC 错误展示口径，可另开 follow-up）
- 用户可见变化：`updated_at` 为脏数据的供应商恢复正常保存
- 是否存在 breaking change：无

### UI 变化

不涉及。

## 怎么验证的

### 自动验证

```text
# 回归测试（含新增 2 例，模拟 updated_at 存 '2026-08-19T01:45:07Z' 的脏行）
cd apps/desktop && npx vitest run src/main/maker-host/__tests__/custom-provider-store.test.ts
结果：40/40 passed。
      反向验证：stash 掉 store 修复重跑，新增 2 例失败（复现 NOT NULL 约束异常），恢复修复后全绿。

# typecheck
cd apps/desktop && pnpm typecheck（tsc --noEmit -p tsconfig.json）
结果：通过。

# lint（仅改动文件）
cd apps/desktop && npx eslint src/main/maker-host/custom-provider-store.ts src/main/maker-host/__tests__/custom-provider-store.test.ts
结果：无问题。

# 仓库根提交前门禁
pnpm test:unit:related
结果：apps/desktop 单测全绿（214.9s PASS，覆盖新增回归测试）；唯一失败项为
      packages/maker-core 的 pi-rpc-resource-discovery.integration.test.ts（3 个断言失败）。
      本 PR 仅修改 apps/desktop 下 2 个文件，packages/maker-core 与基线 upstream/main 逐字节一致，
      该失败为基线/本机环境相关问题，与本改动无关，不混入修复。
```

### 手工验证

不涉及（纯 main 进程数据写入路径修复，行为由回归测试覆盖）。

### 未执行的验证

未跑仓库根全量 `pnpm test:unit`（CI 会跑）；本机 `pnpm test:unit:related` 已覆盖全部受影响的 workspace，除上述与本 PR 无关的 maker-core 基线失败外全部通过。

## 风险

### 风险分类

- [ ] 无已知风险
- [x] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 `custom_providers` 表两个更新路径的 `updated_at` 取值逻辑。合法数值旧值行为与原先完全一致（`Math.max(now, prev + 1)`）；仅非有限数值（历史脏数据）从「写入 NaN 触发约束失败」变为「回退为 `now`，行数据修复」。无 schema / migration 变更。
- 回滚 / 降级方式：直接 revert 本 commit 即可，无数据迁移、无状态残留。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI，跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（无：修复为内部数据写入防御，行为不变）
- [x] 已确认测试结果或说明未执行原因
