### PR TITLE
fix(mobile): stabilize composer voice transitions

### DIFF
--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -331,8 +331,8 @@ import {
   resolveMobileComposerVoiceButtonPlacement,
 } from '@/session/MobileComposerInputRow';
 import { VoiceRecordingPillContent, useMobileVoiceRecordingTimer } from '@/session/VoiceRecordingPill';
-import { useComposerCardTransition } from '@/session/useComposerCardTransition';
 import { useComposerResize } from '@/session/useComposerResize';
+import { useVoiceRecordingPillWidthStyle } from '@/session/useComposerControlMotion';
 import { useMobileKeyboardState } from '@/session/useMobileKeyboardState';
 import { buildSessionComposerLayout } from '@/session/sessionComposerLayout';
 import { discardMobileUploadedAttachment } from '@/session/mobileAttachmentUpload';
@@ -2478,6 +2478,9 @@ export default function SessionScreen() {
     expanded: voiceIsListening || voiceStartPending,
     counting: voiceIsListening,
   });
+  // 语音胶囊宽度换档(34 → 72 / 80)的局部动画 style:由 MobileComposerInputRow
+  // 的 Reanimated 锚点外壳消费;工具排占位 slot 用同一份时长/曲线,两处同段运动。
+  const voicePillWidthStyle = useVoiceRecordingPillWidthStyle(voiceRecordingTimer.pillWidth);
   const composerEffectiveContentHeight = composerInputContentHeight;
   const voiceDraftShowsListeningPrompt = voiceIsListening && draft.length === 0;
   // 状态行只承载错误信息;「正在听 / 转写中」不再占一行,对齐桌面版——
@@ -2640,7 +2643,6 @@ export default function SessionScreen() {
     || permissionSheetOpen
     || voiceIsBusy
     || composerVoiceHoldActive;
-  useComposerCardTransition(composerCardActive);
   const composerChromeHeight = useMemo(() => {
     const statusReserve = voiceStatusVisible
       ? COMPOSER_STATUS_ROW_RESERVED_HEIGHT + COMPOSER_STACK_GAP_HEIGHT
@@ -5484,10 +5486,12 @@ export default function SessionScreen() {
       style={[
         styles.composerInlineToolButton,
         buttonStyle,
+        // 锚点外壳(MobileComposerInputRow 的 Reanimated 锚点)负责动画宽度,
+        // 按钮自身铺满外壳:胶囊只向左生长,右缘锚定不动。
+        { width: '100%' },
         // 胶囊底色跟随计时内容(含 pressIn 乐观 pending 期),不只 listening——
         // 否则按下瞬间胶囊已展开、底色却要等 ASR 连上才变,闪一次半成品态。
         voiceRecordingTimer.label !== null && styles.composerToolButtonPrimary,
-        voiceRecordingTimer.label !== null && { width: voiceRecordingTimer.pillWidth },
       ]}
       testID="session.voiceButton"
     >
@@ -9586,6 +9590,7 @@ export default function SessionScreen() {
                     compact={compactComposer && !composerCardActive}
                     editable={!composerLayout.input.disabled}
                     floatingVoiceButton={voiceUiAvailable ? renderComposerVoiceButton : undefined}
+                    floatingVoiceButtonStyle={voicePillWidthStyle}
                     cursorColor={colors.inputCaret}
                     inputFrameHeight={composerResize.frameHeight}
                     // 听写期间把输入区撑到 44pt 触控目标:命中层盖在 inputFrame 上,

--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -2856,7 +2856,7 @@ export default function SessionScreen() {
       {composerVoicePlacement?.inline || composerVoicePlacement?.floating
         ? <ComposerToolbarVoiceSlot width={voiceRecordingTimer.pillWidth} />
         : null}
-      {renderComposerSendSlot({ measureTarget: composerCardActive })}
+      {renderComposerSendSlot()}
     </>
   );
   const renderComposerInputOverlay = () => voiceIsListening ? (
@@ -5428,7 +5428,7 @@ export default function SessionScreen() {
       });
   }, [deviceId, startVoiceRecording, voiceIsProcessing, voiceState]);
 
-  const renderComposerVoiceButton = () => (
+  const renderComposerVoiceButton = (buttonStyle?: StyleProp<ViewStyle>) => (
     <RouteActionButton
       accessibilityLabel={voiceIsListening ? t('session.common.voiceStopRecording') : t('session.screen.voiceStartInput')}
       accessibilityHint={composerLayout.voice.disabledReason ?? composerSendUnavailableReason ?? undefined}
@@ -5485,7 +5485,8 @@ export default function SessionScreen() {
       }}
       style={[
         styles.composerInlineToolButton,
-        // MobileComposerInputRow 的 Reanimated 外壳负责定位和宽度动画,
+        buttonStyle,
+        // 锚点外壳(MobileComposerInputRow 的 Reanimated 锚点)负责动画宽度,
         // 按钮自身铺满外壳:胶囊只向左生长,右缘锚定不动。
         { width: '100%' },
         // 胶囊底色跟随计时内容(含 pressIn 乐观 pending 期),不只 listening——
@@ -7073,18 +7074,18 @@ export default function SessionScreen() {
   // 生长,「原地再点一下」永远是停止录音,不会误停任务。
   const renderComposerInlineStop = () => composerShowInlineStop ? renderComposerStopButton() : null;
 
-  const renderComposerSendSlot = ({ measureTarget = false }: { measureTarget?: boolean } = {}) => (
+  const renderComposerSendSlot = () => (
     <>
       {composerSendSlotIsStop ? (
         renderComposerStopButton()
       ) : composerShowSendButton ? (
         <RouteActionButton
-          ref={measureTarget ? sendButtonRef : undefined}
+          ref={sendButtonRef}
           accessibilityLabel={voiceIsListening ? t('session.screen.voiceStopAndSend') : t('session.screen.sendMessage')}
           accessibilityHint={composerLayout.send.disabledReason ?? composerLayout.guidanceText}
           disabled={composerSendDisabled}
           hitSlop={COMPOSER_CONTROL_HIT_SLOP}
-          onLayout={measureTarget ? measureSendButtonTarget : undefined}
+          onLayout={measureSendButtonTarget}
           onPress={send}
           pressedStyle={styles.sendButtonPressed}
           style={[
@@ -7116,7 +7117,7 @@ export default function SessionScreen() {
       {composerShowInlineStop && composerVoicePlacement?.floating
         ? <ComposerToolbarVoiceSlot width={voiceRecordingTimer.pillWidth} />
         : null}
-      {renderComposerSendSlot({ measureTarget: true })}
+      {renderComposerSendSlot()}
     </>
   );
 

--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -62,6 +62,7 @@ import {
   type TextLayoutEvent,
   type ViewStyle,
 } from 'react-native';
+import Reanimated from 'react-native-reanimated';
 import { Text, TextInput } from '@/components/AppText';
 import { MobileAgentMark } from '@/components/MobileAgentMark';
 import type { TextInput as NativeTextInput } from 'react-native';
@@ -2478,8 +2479,8 @@ export default function SessionScreen() {
     expanded: voiceIsListening || voiceStartPending,
     counting: voiceIsListening,
   });
-  // 语音胶囊宽度换档(34 → 72 / 80)的局部动画 style:由 MobileComposerInputRow
-  // 的 Reanimated 锚点外壳消费;工具排占位 slot 用同一份时长/曲线,两处同段运动。
+  // 语音胶囊宽度换档(34 → 72 / 80)的局部动画 style:由语音按钮自身消费;
+  // 工具排占位 slot 用同一份时长/曲线,两处同段运动。
   const voicePillWidthStyle = useVoiceRecordingPillWidthStyle(voiceRecordingTimer.pillWidth);
   const composerEffectiveContentHeight = composerInputContentHeight;
   const voiceDraftShowsListeningPrompt = voiceIsListening && draft.length === 0;
@@ -2856,7 +2857,7 @@ export default function SessionScreen() {
       {composerVoicePlacement?.inline || composerVoicePlacement?.floating
         ? <ComposerToolbarVoiceSlot width={voiceRecordingTimer.pillWidth} />
         : null}
-      {renderComposerSendSlot()}
+      {renderComposerSendSlot({ measureTarget: composerCardActive })}
     </>
   );
   const renderComposerInputOverlay = () => voiceIsListening ? (
@@ -5429,7 +5430,7 @@ export default function SessionScreen() {
   }, [deviceId, startVoiceRecording, voiceIsProcessing, voiceState]);
 
   const renderComposerVoiceButton = (buttonStyle?: StyleProp<ViewStyle>) => (
-    <RouteActionButton
+    <AnimatedRouteActionButton
       accessibilityLabel={voiceIsListening ? t('session.common.voiceStopRecording') : t('session.screen.voiceStartInput')}
       accessibilityHint={composerLayout.voice.disabledReason ?? composerSendUnavailableReason ?? undefined}
       active={composerLayout.voice.active}
@@ -5486,9 +5487,8 @@ export default function SessionScreen() {
       style={[
         styles.composerInlineToolButton,
         buttonStyle,
-        // 锚点外壳(MobileComposerInputRow 的 Reanimated 锚点)负责动画宽度,
-        // 按钮自身铺满外壳:胶囊只向左生长,右缘锚定不动。
-        { width: '100%' },
+        // 现有按钮自身就是 Reanimated host:宽度只向左生长,右缘锚定不动,
+        // 不增加会改变 composer 几何的中间外壳。
         // 胶囊底色跟随计时内容(含 pressIn 乐观 pending 期),不只 listening——
         // 否则按下瞬间胶囊已展开、底色却要等 ASR 连上才变,闪一次半成品态。
         voiceRecordingTimer.label !== null && styles.composerToolButtonPrimary,
@@ -5504,7 +5504,7 @@ export default function SessionScreen() {
       ) : (
         <Mic color={colors.textSecondary} size={iconSize.sm} strokeWidth={iconStroke.regular} />
       )}
-    </RouteActionButton>
+    </AnimatedRouteActionButton>
   );
 
   const removeRemoteFileAttachment = useCallback((id: string) => {
@@ -7074,18 +7074,18 @@ export default function SessionScreen() {
   // 生长,「原地再点一下」永远是停止录音,不会误停任务。
   const renderComposerInlineStop = () => composerShowInlineStop ? renderComposerStopButton() : null;
 
-  const renderComposerSendSlot = () => (
+  const renderComposerSendSlot = ({ measureTarget = false }: { measureTarget?: boolean } = {}) => (
     <>
       {composerSendSlotIsStop ? (
         renderComposerStopButton()
       ) : composerShowSendButton ? (
         <RouteActionButton
-          ref={sendButtonRef}
+          ref={measureTarget ? sendButtonRef : undefined}
           accessibilityLabel={voiceIsListening ? t('session.screen.voiceStopAndSend') : t('session.screen.sendMessage')}
           accessibilityHint={composerLayout.send.disabledReason ?? composerLayout.guidanceText}
           disabled={composerSendDisabled}
           hitSlop={COMPOSER_CONTROL_HIT_SLOP}
-          onLayout={measureSendButtonTarget}
+          onLayout={measureTarget ? measureSendButtonTarget : undefined}
           onPress={send}
           pressedStyle={styles.sendButtonPressed}
           style={[
@@ -7117,7 +7117,7 @@ export default function SessionScreen() {
       {composerShowInlineStop && composerVoicePlacement?.floating
         ? <ComposerToolbarVoiceSlot width={voiceRecordingTimer.pillWidth} />
         : null}
-      {renderComposerSendSlot()}
+      {renderComposerSendSlot({ measureTarget: true })}
     </>
   );
 
@@ -9636,7 +9636,7 @@ export default function SessionScreen() {
                     inputTestID="session.composerInput"
                     leading={renderComposerCompactLeading()}
                     maxHeight={composerResize.inputMaxHeight}
-                    multilineShape={!composerCardActive && composerInputIsMultiline}
+                    multilineShape={composerInputIsMultiline}
                     onBlur={() => {
                       setComposerFocused(false);
                       // 失焦收起与「点别处收键盘」同语义:语音结束 hold 一并解除。
@@ -10281,6 +10281,8 @@ const RouteActionButton = forwardRef<View, RouteActionButtonProps>(function Rout
     </Pressable>
   );
 });
+
+const AnimatedRouteActionButton = Reanimated.createAnimatedComponent(RouteActionButton);
 
 function ComposerRuntimePill({
   disabled = false,

--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -2856,7 +2856,7 @@ export default function SessionScreen() {
       {composerVoicePlacement?.inline || composerVoicePlacement?.floating
         ? <ComposerToolbarVoiceSlot width={voiceRecordingTimer.pillWidth} />
         : null}
-      {renderComposerSendSlot()}
+      {renderComposerSendSlot({ measureTarget: composerCardActive })}
     </>
   );
   const renderComposerInputOverlay = () => voiceIsListening ? (
@@ -5428,7 +5428,7 @@ export default function SessionScreen() {
       });
   }, [deviceId, startVoiceRecording, voiceIsProcessing, voiceState]);
 
-  const renderComposerVoiceButton = (buttonStyle?: StyleProp<ViewStyle>) => (
+  const renderComposerVoiceButton = () => (
     <RouteActionButton
       accessibilityLabel={voiceIsListening ? t('session.common.voiceStopRecording') : t('session.screen.voiceStartInput')}
       accessibilityHint={composerLayout.voice.disabledReason ?? composerSendUnavailableReason ?? undefined}
@@ -5485,8 +5485,7 @@ export default function SessionScreen() {
       }}
       style={[
         styles.composerInlineToolButton,
-        buttonStyle,
-        // 锚点外壳(MobileComposerInputRow 的 Reanimated 锚点)负责动画宽度,
+        // MobileComposerInputRow 的 Reanimated 外壳负责定位和宽度动画,
         // 按钮自身铺满外壳:胶囊只向左生长,右缘锚定不动。
         { width: '100%' },
         // 胶囊底色跟随计时内容(含 pressIn 乐观 pending 期),不只 listening——
@@ -7074,18 +7073,18 @@ export default function SessionScreen() {
   // 生长,「原地再点一下」永远是停止录音,不会误停任务。
   const renderComposerInlineStop = () => composerShowInlineStop ? renderComposerStopButton() : null;
 
-  const renderComposerSendSlot = () => (
+  const renderComposerSendSlot = ({ measureTarget = false }: { measureTarget?: boolean } = {}) => (
     <>
       {composerSendSlotIsStop ? (
         renderComposerStopButton()
       ) : composerShowSendButton ? (
         <RouteActionButton
-          ref={sendButtonRef}
+          ref={measureTarget ? sendButtonRef : undefined}
           accessibilityLabel={voiceIsListening ? t('session.screen.voiceStopAndSend') : t('session.screen.sendMessage')}
           accessibilityHint={composerLayout.send.disabledReason ?? composerLayout.guidanceText}
           disabled={composerSendDisabled}
           hitSlop={COMPOSER_CONTROL_HIT_SLOP}
-          onLayout={measureSendButtonTarget}
+          onLayout={measureTarget ? measureSendButtonTarget : undefined}
           onPress={send}
           pressedStyle={styles.sendButtonPressed}
           style={[
@@ -7117,7 +7116,7 @@ export default function SessionScreen() {
       {composerShowInlineStop && composerVoicePlacement?.floating
         ? <ComposerToolbarVoiceSlot width={voiceRecordingTimer.pillWidth} />
         : null}
-      {renderComposerSendSlot()}
+      {renderComposerSendSlot({ measureTarget: true })}
     </>
   );
 

--- a/apps/mobile/app/sessions/new.tsx
+++ b/apps/mobile/app/sessions/new.tsx
@@ -30,6 +30,7 @@ import {
   type TextLayoutEvent,
   type ViewStyle,
 } from 'react-native';
+import Reanimated from 'react-native-reanimated';
 import { Text } from '@/components/AppText';
 import type { TextInput as NativeTextInput } from 'react-native';
 import {
@@ -324,6 +325,8 @@ import { draftModelMemoryFor, hydrateDraftModelMemory } from '@/session/draftMod
 import { rowFastEditable } from '@/session/modelPickerRows';
 import { useTheme, useThemedStyles, type ThemeColors } from '@/theme';
 import { fontWeight, iconSize, iconStroke, lineHeight, radius, spacing, typeScale } from '@/theme/tokens';
+
+const AnimatedPressable = Reanimated.createAnimatedComponent(Pressable);
 
 const COMPOSER_INPUT_MULTILINE_CONTENT_THRESHOLD = 34;
 const COMPOSER_VOICE_CARET_GAP = 2;
@@ -1384,6 +1387,7 @@ export default function NewRemoteSessionScreen() {
   // 「按下即录」的乐观反馈(与会话页/桌面同款,详见 [sessionId].tsx 同名状态注释)。
   // 声明在 composerShowCreateButton 之前:pending 期就要占住创建槽。
   const [voiceStartPending, setVoiceStartPending] = useState(false);
+  const [voiceButtonPressed, setVoiceButtonPressed] = useState(false);
   const voiceStartPendingSeqRef = useRef(0);
   const voiceStartedOnPressInRef = useRef(false);
   // 语音生命周期内创建按钮常驻(与会话页发送槽同理,对齐桌面):录音中点创建
@@ -1430,8 +1434,8 @@ export default function NewRemoteSessionScreen() {
     expanded: voiceIsListening || voiceStartPending,
     counting: voiceIsListening,
   });
-  // 语音胶囊宽度换档(34 → 72 / 80)的局部动画 style:由 MobileComposerInputRow
-  // 的 Reanimated 锚点外壳消费;工具排占位 slot 用同一份时长/曲线,两处同段运动。
+  // 语音胶囊宽度换档(34 → 72 / 80)的局部动画 style:由语音按钮自身消费;
+  // 工具排占位 slot 用同一份时长/曲线,两处同段运动。
   const voicePillWidthStyle = useVoiceRecordingPillWidthStyle(voiceRecordingTimer.pillWidth);
   // 手机语音只保留官方托管路径,错误引导仅剩系统麦克风权限一条。
   const canOpenVoiceSettings = isMobileVoiceMicPermissionError(voiceError);
@@ -3463,7 +3467,7 @@ export default function NewRemoteSessionScreen() {
   ) : null;
 
   const renderComposerVoiceButton = (buttonStyle?: StyleProp<ViewStyle>) => (
-    <Pressable
+    <AnimatedPressable
       accessibilityLabel={voiceIsListening ? t('session.common.voiceStopRecording') : t('session.new.voiceInput')}
       accessibilityRole="button"
       accessibilityState={{ busy: voiceIsProcessing || undefined, disabled: creating || undefined }}
@@ -3477,24 +3481,28 @@ export default function NewRemoteSessionScreen() {
         }
         toggleVoiceRecording();
       }}
-      onPressIn={handleVoiceButtonPressIn}
+      onPressIn={() => {
+        setVoiceButtonPressed(true);
+        handleVoiceButtonPressIn();
+      }}
+      onPressOut={() => setVoiceButtonPressed(false)}
       onTouchCancel={() => {
+        setVoiceButtonPressed(false);
         // 手势被系统/滚动打断:撤销这次按下误触发的录音(与会话页同语义,
         // 正常松手不触发;cancelVoiceForDeviceSwitch 会作废在途启动并释放音频)。
         if (!voiceStartedOnPressInRef.current) return;
         voiceStartedOnPressInRef.current = false;
         cancelVoiceForDeviceSwitch();
       }}
-      style={({ pressed }) => [
+      style={[
         styles.composerIconButton,
         buttonStyle,
-        // 锚点外壳(MobileComposerInputRow 的 Reanimated 锚点)负责动画宽度,
-        // 按钮自身铺满外壳:胶囊只向左生长,右缘锚定不动。
-        { width: '100%' },
+        // 现有按钮自身就是 Reanimated host:宽度只向左生长,右缘锚定不动,
+        // 不增加会改变 composer 几何的中间外壳。
         // 胶囊底色跟随计时内容(含 pressIn 乐观 pending 期),不只 listening。
         voiceRecordingTimer.label !== null && styles.composerIconButtonActive,
         (creating || voiceIsProcessing) && styles.disabled,
-        pressed && styles.pressed,
+        voiceButtonPressed && styles.pressed,
       ]}
       testID="newSession.voiceButton"
     >
@@ -3506,7 +3514,7 @@ export default function NewRemoteSessionScreen() {
       ) : (
         <Mic color={colors.textSecondary} size={iconSize.sm} strokeWidth={iconStroke.regular} />
       )}
-    </Pressable>
+    </AnimatedPressable>
   );
 
   // 切 agent:跟随该 agent 的最近会话 → 否则该 agent 列表最上面 → 否则内置默认(见 pickAgentDefaultRuntime),
@@ -5703,7 +5711,7 @@ export default function NewRemoteSessionScreen() {
                   inputStyle={voiceIsListening ? styles.inputVoiceHidden : undefined}
                   inputTestID="newSession.firstMessageInput"
                   maxHeight={composerResize.inputMaxHeight}
-                  multilineShape={!composerCardActive && composerInputIsMultiline}
+                  multilineShape={composerInputIsMultiline}
                   onBlur={() => {
                     setFirstMessageInputFocused(false);
                     // 失焦收起与「点别处收键盘」同语义:语音结束 hold 一并解除。

--- a/apps/mobile/app/sessions/new.tsx
+++ b/apps/mobile/app/sessions/new.tsx
@@ -220,8 +220,8 @@ import {
   resolveMobileComposerVoiceButtonPlacement,
 } from '@/session/MobileComposerInputRow';
 import { VoiceRecordingPillContent, useMobileVoiceRecordingTimer } from '@/session/VoiceRecordingPill';
-import { useComposerCardTransition } from '@/session/useComposerCardTransition';
 import { useComposerResize } from '@/session/useComposerResize';
+import { useVoiceRecordingPillWidthStyle } from '@/session/useComposerControlMotion';
 import { useMobileKeyboardState } from '@/session/useMobileKeyboardState';
 import {
   isMobileVoiceMicPermissionError,
@@ -1430,6 +1430,9 @@ export default function NewRemoteSessionScreen() {
     expanded: voiceIsListening || voiceStartPending,
     counting: voiceIsListening,
   });
+  // 语音胶囊宽度换档(34 → 72 / 80)的局部动画 style:由 MobileComposerInputRow
+  // 的 Reanimated 锚点外壳消费;工具排占位 slot 用同一份时长/曲线,两处同段运动。
+  const voicePillWidthStyle = useVoiceRecordingPillWidthStyle(voiceRecordingTimer.pillWidth);
   // 手机语音只保留官方托管路径,错误引导仅剩系统麦克风权限一条。
   const canOpenVoiceSettings = isMobileVoiceMicPermissionError(voiceError);
   // 状态行只承载错误信息;「正在听 / 转写中」不再占一行,对齐桌面版——
@@ -1465,7 +1468,6 @@ export default function NewRemoteSessionScreen() {
     || permissionSheetOpen
     || voiceIsBusy
     || composerVoiceHoldActive;
-  useComposerCardTransition(composerCardActive);
   // 下拉收起 = 退出聚焦激活态(模型浮窗已是独立 Modal,拖拽手势够不到它,无需在此关闭)。
   // 语音结束 hold 态未聚焦,blur 是 no-op,需显式解除 hold 才能收回简洁态。
   const handleComposerSnapToAuto = useCallback(() => {
@@ -3486,9 +3488,11 @@ export default function NewRemoteSessionScreen() {
       style={({ pressed }) => [
         styles.composerIconButton,
         buttonStyle,
+        // 锚点外壳(MobileComposerInputRow 的 Reanimated 锚点)负责动画宽度,
+        // 按钮自身铺满外壳:胶囊只向左生长,右缘锚定不动。
+        { width: '100%' },
         // 胶囊底色跟随计时内容(含 pressIn 乐观 pending 期),不只 listening。
         voiceRecordingTimer.label !== null && styles.composerIconButtonActive,
-        voiceRecordingTimer.label !== null && { width: voiceRecordingTimer.pillWidth },
         (creating || voiceIsProcessing) && styles.disabled,
         pressed && styles.pressed,
       ]}
@@ -5725,6 +5729,7 @@ export default function NewRemoteSessionScreen() {
                   value={draft.firstMessage}
                   voicePlacement={composerVoicePlacement}
                   floatingVoiceButton={voiceUiAvailable ? renderComposerVoiceButton : undefined}
+                  floatingVoiceButtonStyle={voicePillWidthStyle}
                 />
               </View>
             </View>

--- a/apps/mobile/app/sessions/new.tsx
+++ b/apps/mobile/app/sessions/new.tsx
@@ -25,8 +25,10 @@ import {
   StyleSheet,
   View,
   useWindowDimensions,
+  type StyleProp,
   type TextInputContentSizeChangeEvent,
   type TextLayoutEvent,
+  type ViewStyle,
 } from 'react-native';
 import { Text } from '@/components/AppText';
 import type { TextInput as NativeTextInput } from 'react-native';
@@ -3460,7 +3462,7 @@ export default function NewRemoteSessionScreen() {
     </ScrollView>
   ) : null;
 
-  const renderComposerVoiceButton = () => (
+  const renderComposerVoiceButton = (buttonStyle?: StyleProp<ViewStyle>) => (
     <Pressable
       accessibilityLabel={voiceIsListening ? t('session.common.voiceStopRecording') : t('session.new.voiceInput')}
       accessibilityRole="button"
@@ -3485,7 +3487,8 @@ export default function NewRemoteSessionScreen() {
       }}
       style={({ pressed }) => [
         styles.composerIconButton,
-        // MobileComposerInputRow 的 Reanimated 外壳负责定位和宽度动画,
+        buttonStyle,
+        // 锚点外壳(MobileComposerInputRow 的 Reanimated 锚点)负责动画宽度,
         // 按钮自身铺满外壳:胶囊只向左生长,右缘锚定不动。
         { width: '100%' },
         // 胶囊底色跟随计时内容(含 pressIn 乐观 pending 期),不只 listening。

--- a/apps/mobile/app/sessions/new.tsx
+++ b/apps/mobile/app/sessions/new.tsx
@@ -25,10 +25,8 @@ import {
   StyleSheet,
   View,
   useWindowDimensions,
-  type StyleProp,
   type TextInputContentSizeChangeEvent,
   type TextLayoutEvent,
-  type ViewStyle,
 } from 'react-native';
 import { Text } from '@/components/AppText';
 import type { TextInput as NativeTextInput } from 'react-native';
@@ -3462,7 +3460,7 @@ export default function NewRemoteSessionScreen() {
     </ScrollView>
   ) : null;
 
-  const renderComposerVoiceButton = (buttonStyle?: StyleProp<ViewStyle>) => (
+  const renderComposerVoiceButton = () => (
     <Pressable
       accessibilityLabel={voiceIsListening ? t('session.common.voiceStopRecording') : t('session.new.voiceInput')}
       accessibilityRole="button"
@@ -3487,8 +3485,7 @@ export default function NewRemoteSessionScreen() {
       }}
       style={({ pressed }) => [
         styles.composerIconButton,
-        buttonStyle,
-        // 锚点外壳(MobileComposerInputRow 的 Reanimated 锚点)负责动画宽度,
+        // MobileComposerInputRow 的 Reanimated 外壳负责定位和宽度动画,
         // 按钮自身铺满外壳:胶囊只向左生长,右缘锚定不动。
         { width: '100%' },
         // 胶囊底色跟随计时内容(含 pressIn 乐观 pending 期),不只 listening。

--- a/apps/mobile/metro.config.js
+++ b/apps/mobile/metro.config.js
@@ -7,6 +7,11 @@ const workspaceNodeModules = path.join(workspaceRoot, 'node_modules');
 const appNodeModules = path.join(__dirname, 'node_modules');
 const sharedArrayBufferPolyfill = path.join(__dirname, 'src/polyfills/sharedArrayBuffer.js');
 
+// Region endpoint manifests live at the repository root and are imported by
+// the mobile runtime config. Keep that root in Metro's file map so all three
+// region branches resolve consistently (including the gitignored dev manifest).
+config.watchFolders = [...(config.watchFolders ?? []), workspaceRoot];
+
 // mobile 直接吃 TS 源码的 workspace 包(见下方 .js→.ts resolveRequest 分流)。
 const workspaceTsSourcePackages = [
   'auth-client',

--- a/apps/mobile/src/__tests__/composerVoiceButtonAnchor.test.ts
+++ b/apps/mobile/src/__tests__/composerVoiceButtonAnchor.test.ts
@@ -23,7 +23,7 @@ describe('resolveMobileComposerVoiceButtonPlacement', () => {
 });
 
 describe('resolveMobileComposerVoiceButtonAnchorStyle', () => {
-  it('收起态按行垂直居中,不写 bottom 数值', () => {
+  it('收起态与卡片态共用 bottom 锚点,切态不改纵向定位键', () => {
     const style = resolveMobileComposerVoiceButtonAnchorStyle({
       cardLayout: false,
       floating: false,
@@ -31,13 +31,13 @@ describe('resolveMobileComposerVoiceButtonAnchorStyle', () => {
     expect(style).toEqual({
       position: 'absolute',
       right: MOBILE_COMPOSER_VOICE_ANCHOR_RIGHT,
-      top: '50%',
-      bottom: 'auto',
-      transform: [{ translateY: -MOBILE_COMPOSER_CONTROL_SIZE / 2 }],
+      top: 'auto',
+      bottom: MOBILE_COMPOSER_VOICE_ANCHOR_CARD_BOTTOM,
+      transform: [],
       zIndex: 2,
     });
-    expect(style.bottom).toBe('auto');
-    expect(style.top).not.toBe('auto');
+    expect(style.bottom).toBe(MOBILE_COMPOSER_VOICE_ANCHOR_CARD_BOTTOM);
+    expect(style.top).toBe('auto');
   });
 
   it('卡片态钉在工具排底边,显式清掉 top 与 translateY', () => {
@@ -73,6 +73,16 @@ describe('resolveMobileComposerVoiceButtonAnchorStyle', () => {
       floating: true,
     }).right).toBe(inset);
     expect(inset).toBe(spacing.md + 34 + 6);
+  });
+
+  it('切换 cardLayout 只改变父容器形态,语音按钮锚点保持完全一致', () => {
+    expect(resolveMobileComposerVoiceButtonAnchorStyle({
+      cardLayout: false,
+      floating: false,
+    })).toEqual(resolveMobileComposerVoiceButtonAnchorStyle({
+      cardLayout: true,
+      floating: false,
+    }));
   });
 
   it('卡片底边与间距 token 同源,避免再写 8 与 paddingBottom 对不齐', () => {

--- a/apps/mobile/src/__tests__/designTokenDiscipline.test.ts
+++ b/apps/mobile/src/__tests__/designTokenDiscipline.test.ts
@@ -36,11 +36,6 @@ const COLOR_EXEMPT = [/Html\.ts$/i, /src\/session\/ImageLightbox\.tsx$/];
 /** 组件几何 / 特殊语义的登记豁免:file 后缀匹配 + 行内容包含 snippet 即放行。 */
 const ALLOWLIST: Array<{ file: string; snippet: string; reason: string }> = [
   {
-    file: 'src/session/MobileComposerInputRow.tsx',
-    snippet: 'borderRadius: 30',
-    reason: 'composer 多行形态组件几何(desktop-first 测试钉死)',
-  },
-  {
     file: 'app/devices/index.tsx',
     snippet: 'size={9}',
     reason: 'Pencil 微徽标,徽标容器几何依赖 9px',

--- a/apps/mobile/src/__tests__/newSession.test.ts
+++ b/apps/mobile/src/__tests__/newSession.test.ts
@@ -1764,7 +1764,10 @@ describe('new session composer surface', () => {
     expect(newSource).toContain('onReadyForEndCue: credential.settings?.playInteractionSound ? playMobileVoiceInputEndCue : undefined,');
     // Touch-down warm-up: the mic button prewarms the audio session + ASR
     // connection at pressIn, and voice startup claims that connection when fresh.
-    expect(newSource).toContain('onPressIn={handleVoiceButtonPressIn}');
+    expect(newSource).toContain('const AnimatedPressable = Reanimated.createAnimatedComponent(Pressable);');
+    expect(newSource).toContain('<AnimatedPressable');
+    expect(newSource).toContain('handleVoiceButtonPressIn();');
+    expect(newSource).not.toContain("{ width: '100%' }");
     // 托管预热:凭登录态提前拿 voice-server 票据(BYOK/穿透路径已删除,
     // 手机语音只保留 Cindy 官方托管路径)。
     expect(newSource).toContain('prewarmMobileVoiceStart(selectedDeviceId, {');

--- a/apps/mobile/src/__tests__/newSession.test.ts
+++ b/apps/mobile/src/__tests__/newSession.test.ts
@@ -1550,7 +1550,7 @@ describe('new session composer surface', () => {
     const sendButtonDisabledStart = newSource.indexOf('sendButtonDisabled: {');
     const sendButtonDisabledEnd = newSource.indexOf('sendButtonPressed:', sendButtonDisabledStart);
     const sendButtonDisabledStyle = newSource.slice(sendButtonDisabledStart, sendButtonDisabledEnd);
-    const voiceButtonStart = newSource.indexOf('const renderComposerVoiceButton = (buttonStyle?: StyleProp<ViewStyle>) => (');
+    const voiceButtonStart = newSource.indexOf('const renderComposerVoiceButton = () => (');
     const voiceButtonEnd = newSource.indexOf('// 切 agent:', voiceButtonStart);
     const voiceButtonSource = newSource.slice(voiceButtonStart, voiceButtonEnd);
     const storedAgentStart = newSource.indexOf('const storedAgentKind = newSessionPreferences?.agentKind;');

--- a/apps/mobile/src/__tests__/newSession.test.ts
+++ b/apps/mobile/src/__tests__/newSession.test.ts
@@ -1550,7 +1550,7 @@ describe('new session composer surface', () => {
     const sendButtonDisabledStart = newSource.indexOf('sendButtonDisabled: {');
     const sendButtonDisabledEnd = newSource.indexOf('sendButtonPressed:', sendButtonDisabledStart);
     const sendButtonDisabledStyle = newSource.slice(sendButtonDisabledStart, sendButtonDisabledEnd);
-    const voiceButtonStart = newSource.indexOf('const renderComposerVoiceButton = () => (');
+    const voiceButtonStart = newSource.indexOf('const renderComposerVoiceButton = (buttonStyle?: StyleProp<ViewStyle>) => (');
     const voiceButtonEnd = newSource.indexOf('// 切 agent:', voiceButtonStart);
     const voiceButtonSource = newSource.slice(voiceButtonStart, voiceButtonEnd);
     const storedAgentStart = newSource.indexOf('const storedAgentKind = newSessionPreferences?.agentKind;');

--- a/apps/mobile/src/__tests__/sessionComposerDesktopFirst.test.ts
+++ b/apps/mobile/src/__tests__/sessionComposerDesktopFirst.test.ts
@@ -221,9 +221,12 @@ describe('mobile session composer desktop-first surface', () => {
     expect(composerInputRowStyle).toContain('borderWidth: StyleSheet.hairlineWidth');
     expect(composerInputRowStyle).toContain('minHeight: 50');
     expect(composerInputRowStyle).toContain('paddingHorizontal: spacing.md');
-    // 上下内边距是卡片过渡插值端点,常量与静态样式同源。
-    expect(composerInputRowStyle).toContain('paddingVertical: ROW_PADDING_VERTICAL');
-    expect(sharedSource).toContain('const ROW_PADDING_VERTICAL = 10;');
+    // 静态默认值与收起态过渡端点分开:收起态必须落到 3pt,避免首帧 10pt 偏移。
+    expect(composerInputRowStyle).toContain('paddingVertical: ROW_BASE_PADDING_VERTICAL');
+    expect(sharedSource).toContain('const ROW_BASE_PADDING_VERTICAL = 10;');
+    expect(sharedSource).toContain('const ROW_COLLAPSED_PADDING_VERTICAL = 3;');
+    expect(sharedSource).toContain('[ROW_COLLAPSED_PADDING_VERTICAL, ROW_CARD_PADDING_BOTTOM]');
+    expect(sharedSource).toContain('[ROW_COLLAPSED_PADDING_VERTICAL, ROW_CARD_PADDING_TOP]');
     expect(composerInputRowStyle).toContain("position: 'relative'");
     expect(sharedSource).toContain("mainRowMultiline: {\n    alignItems: 'flex-end',");
     // 多行圆角 30 从静态样式挪为插值端点常量(卡片态与 pill 圆角互插)。
@@ -319,7 +322,7 @@ describe('mobile session composer desktop-first surface', () => {
     expect(composerInputSource).toContain('resizeHandle={composerCardActive ? renderComposerResizeHandle() : null}');
     expect(sharedSource).toContain('{ maxHeight },');
     expect(source).not.toContain('{ height: composerInputVisibleHeight');
-    expect(composerInputSource).toContain('multilineShape={!composerCardActive && composerInputIsMultiline}');
+    expect(composerInputSource).toContain('multilineShape={composerInputIsMultiline}');
     expect(source).toContain("position: 'absolute'");
     expect(source).toContain('bottom: 0');
     expect(source).toContain('safeAreaBottomInset: insets.bottom');
@@ -474,13 +477,26 @@ describe('mobile session composer desktop-first surface', () => {
     );
     expect(finishVoiceSource).toContain('voiceStopInFlightRef.current = false;');
     expect(composerInputSource).toContain('floatingVoiceButton={voiceUiAvailable ? renderComposerVoiceButton : undefined}');
-    // 录音胶囊的动画宽度经锚点外壳下发(全局 LayoutAnimation 已移除)。
+    // 录音胶囊的动画宽度下发给现有按钮本身,不增加改变几何的中间外壳。
     expect(composerInputSource).toContain('floatingVoiceButtonStyle={voicePillWidthStyle}');
     expect(composerInputSource).toContain('voicePlacement={composerVoicePlacement}');
     expect(sharedSource).toContain('voicePlacement?.inline || voicePlacement?.floating');
     expect(sharedSource).toContain('resolveMobileComposerVoiceButtonAnchorStyle({');
     expect(sharedSource).toContain('floating: voicePlacement.floating,');
     expect(sharedSource).not.toContain('cardLayout && styles.voiceButtonAnchorCard,');
+    expect(source).toContain('const AnimatedRouteActionButton = Reanimated.createAnimatedComponent(RouteActionButton);');
+    expect(voiceButtonSource).toContain('<AnimatedRouteActionButton');
+    expect(voiceButtonSource).not.toContain("{ width: '100%' }");
+    expect(sharedSource).toContain('const voiceInlineInset = voicePlacement?.inline');
+    expect(sharedSource).not.toContain('const voiceInlineInset = !cardLayout');
+    // 附件按真实自然高度做局部进出场和换行动画,不使用零高测量链或固定 maxHeight 裁剪。
+    expect(sharedSource).toContain('entering={accessoryEntering}');
+    expect(sharedSource).toContain('exiting={accessoryExiting}');
+    expect(sharedSource).toContain('layout={ACCESSORY_LAYOUT_TRANSITION}');
+    expect(sharedSource).toContain('height: withTiming(values.targetHeight');
+    expect(sharedSource).toContain('height: values.currentHeight');
+    expect(sharedSource).not.toContain('setAccessoryContentHeight');
+    expect(sharedSource).not.toContain('maxHeight: cardTransition.value * MOBILE_COMPOSER_INPUT_MAX_HEIGHT');
     // 录音中语音按钮以「红色停止方块」可见,禁止任何 opacity:0 隐藏样式回归
     // (旧 gestureAnchor 设计曾把听写中的按钮隐藏,会让停止录音无可见控件)。
     expect(source).not.toContain('composerInlineToolButtonGestureAnchor');
@@ -494,7 +510,7 @@ describe('mobile session composer desktop-first surface', () => {
     const toolbarSource = source.slice(toolbarStart, toolbarEnd);
     const toolbarInlineStopIndex = toolbarSource.indexOf('{renderComposerInlineStop()}');
     const toolbarVoiceSlotIndex = toolbarSource.indexOf('<ComposerToolbarVoiceSlot width={voiceRecordingTimer.pillWidth} />');
-    const toolbarSendSlotIndex = toolbarSource.indexOf('{renderComposerSendSlot()}');
+    const toolbarSendSlotIndex = toolbarSource.indexOf('{renderComposerSendSlot({ measureTarget: composerCardActive })}');
     expect(toolbarInlineStopIndex).toBeGreaterThan(-1);
     expect(toolbarVoiceSlotIndex).toBeGreaterThan(toolbarInlineStopIndex);
     expect(toolbarSendSlotIndex).toBeGreaterThan(toolbarVoiceSlotIndex);
@@ -503,10 +519,12 @@ describe('mobile session composer desktop-first surface', () => {
     const trailingFragmentSource = source.slice(trailingFragmentStart, trailingFragmentEnd);
     const trailingInlineStopIndex = trailingFragmentSource.indexOf('{renderComposerInlineStop()}');
     const trailingVoiceSlotIndex = trailingFragmentSource.indexOf('<ComposerToolbarVoiceSlot width={voiceRecordingTimer.pillWidth} />');
-    const trailingSendSlotIndex = trailingFragmentSource.indexOf('{renderComposerSendSlot()}');
+    const trailingSendSlotIndex = trailingFragmentSource.indexOf('{renderComposerSendSlot({ measureTarget: true })}');
     expect(trailingInlineStopIndex).toBeGreaterThan(-1);
     expect(trailingVoiceSlotIndex).toBeGreaterThan(trailingInlineStopIndex);
     expect(trailingSendSlotIndex).toBeGreaterThan(trailingVoiceSlotIndex);
+    expect(source).toContain('ref={measureTarget ? sendButtonRef : undefined}');
+    expect(source).toContain('onLayout={measureTarget ? measureSendButtonTarget : undefined}');
     expect(voiceButtonSource).toContain('buttonStyle');
     expect(floatingVoiceIndex).toBeGreaterThan(-1);
     expect(sendIndex).toBeGreaterThan(-1);
@@ -636,6 +654,9 @@ describe('mobile session composer desktop-first surface', () => {
     const voiceStart = source.indexOf('const startVoiceRecording = useCallback(async () => {');
     const voiceEnd = source.indexOf('const removeRemoteFileAttachment = useCallback', voiceStart);
     const voiceSource = source.slice(voiceStart, voiceEnd);
+    const voiceButtonStart = source.indexOf('const renderComposerVoiceButton = (buttonStyle?: StyleProp<ViewStyle>) => (');
+    const voiceButtonEnd = source.indexOf('const removeRemoteFileAttachment = useCallback', voiceButtonStart);
+    const voiceButtonSource = source.slice(voiceButtonStart, voiceButtonEnd);
     const composerInputStart = source.indexOf('<MobileComposerInputRow');
     const composerInputEnd = source.indexOf('/>', source.indexOf('value={draft}', composerInputStart)) + 2;
     const composerInputSource = source.slice(composerInputStart, composerInputEnd);
@@ -689,10 +710,11 @@ describe('mobile session composer desktop-first surface', () => {
     // 手势被系统/滚动打断时撤销按下即录(review P1)。
     expect(source).toContain('cancelVoiceForAppBackground();');
     expect(source).toContain('testID="session.voiceRecordingPill"');
-    // 胶囊宽度换档走局部动画:页面把动画 width style 交给锚点外壳,按钮铺满外壳,
-    // 不再在按钮上写死 { width: pillWidth }(全局 LayoutAnimation 已移除)。
+    // 胶囊宽度换档走局部动画:页面把动画 width style 交给现有按钮本身,
+    // 不再增加外壳或写死 width(全局 LayoutAnimation 已移除)。
     expect(source).toContain('floatingVoiceButtonStyle={voicePillWidthStyle}');
-    expect(source).toContain("{ width: '100%' }");
+    expect(source).toContain('const AnimatedRouteActionButton = Reanimated.createAnimatedComponent(RouteActionButton);');
+    expect(voiceButtonSource).not.toContain("{ width: '100%' }");
     expect(source).not.toContain('{ width: voiceRecordingTimer.pillWidth }');
     expect(source).not.toContain('voiceDuration');
     expect(source).not.toContain('recordingDuration');

--- a/apps/mobile/src/__tests__/sessionComposerDesktopFirst.test.ts
+++ b/apps/mobile/src/__tests__/sessionComposerDesktopFirst.test.ts
@@ -482,6 +482,9 @@ describe('mobile session composer desktop-first surface', () => {
     expect(sharedSource).toContain('floating: voicePlacement.floating,');
     expect(sharedSource).toContain('accessoryAbove != null ? (');
     expect(sharedSource).toContain('styles.accessoryReveal');
+    expect(sharedSource).toContain('maxHeight: cardTransition.value * MOBILE_COMPOSER_INPUT_MAX_HEIGHT');
+    expect(sharedSource).toContain('height: MOBILE_COMPOSER_CONTROL_SIZE');
+    expect(sharedSource).toContain('width: MOBILE_COMPOSER_CONTROL_SIZE');
     expect(sharedSource).toContain('{floatingVoiceButton?.()}');
     expect(sharedSource).not.toContain('cardLayout && styles.voiceButtonAnchorCard,');
     // 录音中语音按钮以「红色停止方块」可见,禁止任何 opacity:0 隐藏样式回归

--- a/apps/mobile/src/__tests__/sessionComposerDesktopFirst.test.ts
+++ b/apps/mobile/src/__tests__/sessionComposerDesktopFirst.test.ts
@@ -58,11 +58,8 @@ describe('mobile session composer desktop-first surface', () => {
     expect(source).toContain('opticalPadding={composerCardActive}');
     expect(source).not.toContain('opticalPadding={composerCardActive || composerInputIsMultiline}');
     const composerInputRowStart = sharedSource.indexOf('row: {', sharedStyleStart);
-    const composerInputRowEnd = sharedSource.indexOf('rowMultiline:', composerInputRowStart);
+    const composerInputRowEnd = sharedSource.indexOf('rowCompact:', composerInputRowStart);
     const composerInputRowStyle = sharedSource.slice(composerInputRowStart, composerInputRowEnd);
-    const composerInputRowMultilineStart = sharedSource.indexOf('rowMultiline: {');
-    const composerInputRowMultilineEnd = sharedSource.indexOf('rowCompact:', composerInputRowMultilineStart);
-    const composerInputRowMultilineStyle = sharedSource.slice(composerInputRowMultilineStart, composerInputRowMultilineEnd);
     const inlineButtonStart = source.indexOf('composerInlineToolButton: {');
     const inlineButtonEnd = source.indexOf('composerToolButtonActive:', inlineButtonStart);
     const inlineButtonStyle = source.slice(inlineButtonStart, inlineButtonEnd);
@@ -213,17 +210,24 @@ describe('mobile session composer desktop-first surface', () => {
     expect(composerInputRowStyle).toContain("alignItems: 'stretch'");
     expect(composerInputRowStyle).toContain("flexDirection: 'column'");
     expect(sharedSource).toContain('mainRow: {');
-    expect(sharedSource).toContain('cardLayout && toolbar != null');
+    // 工具排常驻挂载(卡片过渡是 Reanimated 局部动画,不再用全局 LayoutAnimation):
+    // 折叠态靠 toolbarReveal 外壳的高度/透明度收起,并同步关掉命中与无障碍。
+    expect(sharedSource).toContain('toolbar != null ? (');
+    expect(sharedSource).toContain('styles.toolbarReveal');
+    expect(sharedSource).toContain("importantForAccessibility={cardLayout ? undefined : 'no-hide-descendants'}");
     expect(composerInputRowStyle).toContain('backgroundColor: colors.chatCodeSurface');
     expect(composerInputRowStyle).toContain('borderColor: colors.sheetActionBorder');
     expect(composerInputRowStyle).toContain('borderRadius: radius.pill');
     expect(composerInputRowStyle).toContain('borderWidth: StyleSheet.hairlineWidth');
     expect(composerInputRowStyle).toContain('minHeight: 50');
     expect(composerInputRowStyle).toContain('paddingHorizontal: spacing.md');
-    expect(composerInputRowStyle).toContain('paddingVertical: 10');
+    // 上下内边距是卡片过渡插值端点,常量与静态样式同源。
+    expect(composerInputRowStyle).toContain('paddingVertical: ROW_PADDING_VERTICAL');
+    expect(sharedSource).toContain('const ROW_PADDING_VERTICAL = 10;');
     expect(composerInputRowStyle).toContain("position: 'relative'");
     expect(sharedSource).toContain("mainRowMultiline: {\n    alignItems: 'flex-end',");
-    expect(composerInputRowMultilineStyle).toContain('borderRadius: 30');
+    // 多行圆角 30 从静态样式挪为插值端点常量(卡片态与 pill 圆角互插)。
+    expect(sharedSource).toContain('const MOBILE_COMPOSER_ROW_RADIUS_MULTILINE = 30;');
     expect(inputStyle).toContain("backgroundColor: 'transparent'");
     expect(inputStyle).toContain('borderWidth: 0');
     expect(inputStyle).not.toContain('borderColor: colors.border');
@@ -470,7 +474,8 @@ describe('mobile session composer desktop-first surface', () => {
     );
     expect(finishVoiceSource).toContain('voiceStopInFlightRef.current = false;');
     expect(composerInputSource).toContain('floatingVoiceButton={voiceUiAvailable ? renderComposerVoiceButton : undefined}');
-    expect(composerInputSource).not.toContain('floatingVoiceButtonStyle=');
+    // 录音胶囊的动画宽度经锚点外壳下发(全局 LayoutAnimation 已移除)。
+    expect(composerInputSource).toContain('floatingVoiceButtonStyle={voicePillWidthStyle}');
     expect(composerInputSource).toContain('voicePlacement={composerVoicePlacement}');
     expect(sharedSource).toContain('voicePlacement?.inline || voicePlacement?.floating');
     expect(sharedSource).toContain('resolveMobileComposerVoiceButtonAnchorStyle({');
@@ -684,7 +689,11 @@ describe('mobile session composer desktop-first surface', () => {
     // 手势被系统/滚动打断时撤销按下即录(review P1)。
     expect(source).toContain('cancelVoiceForAppBackground();');
     expect(source).toContain('testID="session.voiceRecordingPill"');
-    expect(source).toContain('{ width: voiceRecordingTimer.pillWidth }');
+    // 胶囊宽度换档走局部动画:页面把动画 width style 交给锚点外壳,按钮铺满外壳,
+    // 不再在按钮上写死 { width: pillWidth }(全局 LayoutAnimation 已移除)。
+    expect(source).toContain('floatingVoiceButtonStyle={voicePillWidthStyle}');
+    expect(source).toContain("{ width: '100%' }");
+    expect(source).not.toContain('{ width: voiceRecordingTimer.pillWidth }');
     expect(source).not.toContain('voiceDuration');
     expect(source).not.toContain('recordingDuration');
     expect(source).not.toContain('formatVoiceDuration');

--- a/apps/mobile/src/__tests__/sessionComposerDesktopFirst.test.ts
+++ b/apps/mobile/src/__tests__/sessionComposerDesktopFirst.test.ts
@@ -38,7 +38,7 @@ describe('mobile session composer desktop-first surface', () => {
     const trailingActionsStart = attachmentButtonEnd;
     const trailingActionsEnd = source.indexOf('const resumeQueue = () => {', trailingActionsStart);
     const trailingActionsSource = source.slice(trailingActionsStart, trailingActionsEnd);
-    const voiceButtonStart = source.indexOf('const renderComposerVoiceButton = (buttonStyle?: StyleProp<ViewStyle>) => (');
+    const voiceButtonStart = source.indexOf('const renderComposerVoiceButton = () => (');
     const voiceButtonEnd = source.indexOf('const removeRemoteFileAttachment = useCallback', voiceButtonStart);
     const voiceButtonSource = source.slice(voiceButtonStart, voiceButtonEnd);
     const floatingVoiceIndex = composerInputSource.indexOf('floatingVoiceButton={voiceUiAvailable ? renderComposerVoiceButton : undefined}');
@@ -358,7 +358,7 @@ describe('mobile session composer desktop-first surface', () => {
     expect(source).toContain('const voiceUiAvailable = shouldShowMobileVoiceUi(Platform.OS);');
     expect(source).toContain('const composerVoicePlacement = voiceUiAvailable');
     expect(source).toContain('hasTrailingAction: composerSendSlotIsStop || composerShowSendButton');
-    expect(source).toContain('const renderComposerVoiceButton = (buttonStyle?: StyleProp<ViewStyle>) => (');
+    expect(source).toContain('const renderComposerVoiceButton = () => (');
     // 录音状态由语音按钮形态表达（Mic / 红点计时胶囊 / spinner），状态行只承载错误。
     expect(source).toContain('const voiceStatusVisible = voiceUiAvailable && Boolean(voiceError);');
     expect(voiceButtonSource).toContain(') : voiceRecordingTimer.label !== null ? (');
@@ -480,6 +480,9 @@ describe('mobile session composer desktop-first surface', () => {
     expect(sharedSource).toContain('voicePlacement?.inline || voicePlacement?.floating');
     expect(sharedSource).toContain('resolveMobileComposerVoiceButtonAnchorStyle({');
     expect(sharedSource).toContain('floating: voicePlacement.floating,');
+    expect(sharedSource).toContain('accessoryAbove != null ? (');
+    expect(sharedSource).toContain('styles.accessoryReveal');
+    expect(sharedSource).toContain('{floatingVoiceButton?.()}');
     expect(sharedSource).not.toContain('cardLayout && styles.voiceButtonAnchorCard,');
     // 录音中语音按钮以「红色停止方块」可见,禁止任何 opacity:0 隐藏样式回归
     // (旧 gestureAnchor 设计曾把听写中的按钮隐藏,会让停止录音无可见控件)。
@@ -494,7 +497,7 @@ describe('mobile session composer desktop-first surface', () => {
     const toolbarSource = source.slice(toolbarStart, toolbarEnd);
     const toolbarInlineStopIndex = toolbarSource.indexOf('{renderComposerInlineStop()}');
     const toolbarVoiceSlotIndex = toolbarSource.indexOf('<ComposerToolbarVoiceSlot width={voiceRecordingTimer.pillWidth} />');
-    const toolbarSendSlotIndex = toolbarSource.indexOf('{renderComposerSendSlot()}');
+    const toolbarSendSlotIndex = toolbarSource.indexOf('{renderComposerSendSlot({ measureTarget: composerCardActive })}');
     expect(toolbarInlineStopIndex).toBeGreaterThan(-1);
     expect(toolbarVoiceSlotIndex).toBeGreaterThan(toolbarInlineStopIndex);
     expect(toolbarSendSlotIndex).toBeGreaterThan(toolbarVoiceSlotIndex);
@@ -503,11 +506,11 @@ describe('mobile session composer desktop-first surface', () => {
     const trailingFragmentSource = source.slice(trailingFragmentStart, trailingFragmentEnd);
     const trailingInlineStopIndex = trailingFragmentSource.indexOf('{renderComposerInlineStop()}');
     const trailingVoiceSlotIndex = trailingFragmentSource.indexOf('<ComposerToolbarVoiceSlot width={voiceRecordingTimer.pillWidth} />');
-    const trailingSendSlotIndex = trailingFragmentSource.indexOf('{renderComposerSendSlot()}');
+    const trailingSendSlotIndex = trailingFragmentSource.indexOf('{renderComposerSendSlot({ measureTarget: true })}');
     expect(trailingInlineStopIndex).toBeGreaterThan(-1);
     expect(trailingVoiceSlotIndex).toBeGreaterThan(trailingInlineStopIndex);
     expect(trailingSendSlotIndex).toBeGreaterThan(trailingVoiceSlotIndex);
-    expect(voiceButtonSource).toContain('buttonStyle');
+    expect(voiceButtonSource).not.toContain('buttonStyle');
     expect(floatingVoiceIndex).toBeGreaterThan(-1);
     expect(sendIndex).toBeGreaterThan(-1);
     expect(floatingVoiceIndex).toBeLessThan(sendIndex);

--- a/apps/mobile/src/__tests__/sessionComposerDesktopFirst.test.ts
+++ b/apps/mobile/src/__tests__/sessionComposerDesktopFirst.test.ts
@@ -38,7 +38,7 @@ describe('mobile session composer desktop-first surface', () => {
     const trailingActionsStart = attachmentButtonEnd;
     const trailingActionsEnd = source.indexOf('const resumeQueue = () => {', trailingActionsStart);
     const trailingActionsSource = source.slice(trailingActionsStart, trailingActionsEnd);
-    const voiceButtonStart = source.indexOf('const renderComposerVoiceButton = () => (');
+    const voiceButtonStart = source.indexOf('const renderComposerVoiceButton = (buttonStyle?: StyleProp<ViewStyle>) => (');
     const voiceButtonEnd = source.indexOf('const removeRemoteFileAttachment = useCallback', voiceButtonStart);
     const voiceButtonSource = source.slice(voiceButtonStart, voiceButtonEnd);
     const floatingVoiceIndex = composerInputSource.indexOf('floatingVoiceButton={voiceUiAvailable ? renderComposerVoiceButton : undefined}');
@@ -358,7 +358,7 @@ describe('mobile session composer desktop-first surface', () => {
     expect(source).toContain('const voiceUiAvailable = shouldShowMobileVoiceUi(Platform.OS);');
     expect(source).toContain('const composerVoicePlacement = voiceUiAvailable');
     expect(source).toContain('hasTrailingAction: composerSendSlotIsStop || composerShowSendButton');
-    expect(source).toContain('const renderComposerVoiceButton = () => (');
+    expect(source).toContain('const renderComposerVoiceButton = (buttonStyle?: StyleProp<ViewStyle>) => (');
     // 录音状态由语音按钮形态表达（Mic / 红点计时胶囊 / spinner），状态行只承载错误。
     expect(source).toContain('const voiceStatusVisible = voiceUiAvailable && Boolean(voiceError);');
     expect(voiceButtonSource).toContain(') : voiceRecordingTimer.label !== null ? (');
@@ -480,12 +480,6 @@ describe('mobile session composer desktop-first surface', () => {
     expect(sharedSource).toContain('voicePlacement?.inline || voicePlacement?.floating');
     expect(sharedSource).toContain('resolveMobileComposerVoiceButtonAnchorStyle({');
     expect(sharedSource).toContain('floating: voicePlacement.floating,');
-    expect(sharedSource).toContain('accessoryAbove != null ? (');
-    expect(sharedSource).toContain('styles.accessoryReveal');
-    expect(sharedSource).toContain('maxHeight: cardTransition.value * MOBILE_COMPOSER_INPUT_MAX_HEIGHT');
-    expect(sharedSource).toContain('height: MOBILE_COMPOSER_CONTROL_SIZE');
-    expect(sharedSource).toContain('width: MOBILE_COMPOSER_CONTROL_SIZE');
-    expect(sharedSource).toContain('{floatingVoiceButton?.()}');
     expect(sharedSource).not.toContain('cardLayout && styles.voiceButtonAnchorCard,');
     // 录音中语音按钮以「红色停止方块」可见,禁止任何 opacity:0 隐藏样式回归
     // (旧 gestureAnchor 设计曾把听写中的按钮隐藏,会让停止录音无可见控件)。
@@ -500,7 +494,7 @@ describe('mobile session composer desktop-first surface', () => {
     const toolbarSource = source.slice(toolbarStart, toolbarEnd);
     const toolbarInlineStopIndex = toolbarSource.indexOf('{renderComposerInlineStop()}');
     const toolbarVoiceSlotIndex = toolbarSource.indexOf('<ComposerToolbarVoiceSlot width={voiceRecordingTimer.pillWidth} />');
-    const toolbarSendSlotIndex = toolbarSource.indexOf('{renderComposerSendSlot({ measureTarget: composerCardActive })}');
+    const toolbarSendSlotIndex = toolbarSource.indexOf('{renderComposerSendSlot()}');
     expect(toolbarInlineStopIndex).toBeGreaterThan(-1);
     expect(toolbarVoiceSlotIndex).toBeGreaterThan(toolbarInlineStopIndex);
     expect(toolbarSendSlotIndex).toBeGreaterThan(toolbarVoiceSlotIndex);
@@ -509,11 +503,11 @@ describe('mobile session composer desktop-first surface', () => {
     const trailingFragmentSource = source.slice(trailingFragmentStart, trailingFragmentEnd);
     const trailingInlineStopIndex = trailingFragmentSource.indexOf('{renderComposerInlineStop()}');
     const trailingVoiceSlotIndex = trailingFragmentSource.indexOf('<ComposerToolbarVoiceSlot width={voiceRecordingTimer.pillWidth} />');
-    const trailingSendSlotIndex = trailingFragmentSource.indexOf('{renderComposerSendSlot({ measureTarget: true })}');
+    const trailingSendSlotIndex = trailingFragmentSource.indexOf('{renderComposerSendSlot()}');
     expect(trailingInlineStopIndex).toBeGreaterThan(-1);
     expect(trailingVoiceSlotIndex).toBeGreaterThan(trailingInlineStopIndex);
     expect(trailingSendSlotIndex).toBeGreaterThan(trailingVoiceSlotIndex);
-    expect(voiceButtonSource).not.toContain('buttonStyle');
+    expect(voiceButtonSource).toContain('buttonStyle');
     expect(floatingVoiceIndex).toBeGreaterThan(-1);
     expect(sendIndex).toBeGreaterThan(-1);
     expect(floatingVoiceIndex).toBeLessThan(sendIndex);

--- a/apps/mobile/src/session/MobileComposerInputRow.tsx
+++ b/apps/mobile/src/session/MobileComposerInputRow.tsx
@@ -14,7 +14,7 @@ import { TextInput } from '@/components/AppText';
 import Constants, { ExecutionEnvironment } from 'expo-constants';
 import { TextInputWrapper, type PasteEventPayload } from 'expo-paste-input';
 import { Mic } from 'lucide-react-native';
-import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react';
+import { useCallback, useEffect, useRef, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import Reanimated, { interpolate, useAnimatedStyle, type AnimatedStyle } from 'react-native-reanimated';
 import { iconSize, iconStroke, useThemedStyles, type ThemeColors } from '@/theme';
@@ -257,14 +257,14 @@ export function MobileComposerInputRow({
     opacity: cardTransition.value,
   }));
   // 附件托盘不能跟 cardActive 一起硬挂载/卸载:缩略图卡本身有真实高度,
-  // 直接切换会把整段高度跳变带回 composer。保持内容挂载,由同一份 card progress
-  // 驱动高度/透明度,并用自然布局高度作为插值终点。父容器收起到 0 高时子 View
-  // 仍保留自然测量,所以下一次展开不会丢失高度。
-  const [accessoryContentHeight, setAccessoryContentHeight] = useState(0);
+  // 直接切换会把整段高度跳变带回 composer。保持内容挂载,用 maxHeight/opacity
+  // 由同一份 card progress 驱动揭示。maxHeight 在收起态裁掉自然内容,但不把
+  // 子内容的自然布局高度改成 0,避免「先收起挂载 → 永远测到 0 → 再也展开不了」的
+  // 首帧测量死锁。
   const accessoryRevealStyle = useAnimatedStyle(() => ({
-    height: cardTransition.value * accessoryContentHeight,
+    maxHeight: cardTransition.value * MOBILE_COMPOSER_INPUT_MAX_HEIGHT,
     opacity: cardTransition.value,
-  }), [accessoryContentHeight]);
+  }));
   // RN 里显式 height 压过 minHeight:manual 定高(用户拖过高度)时 frameHeight 可能小于
   // inputFrameMinHeight,直接铺开会把听写停止命中区又压回不足 44pt。数值高度在这里
   // 先 clamp;拖拽中的 Animated 值无法在 JS 侧 clamp(会打断跟手),那一瞬保持动画值,
@@ -333,15 +333,7 @@ export function MobileComposerInputRow({
           pointerEvents={cardLayout ? 'auto' : 'none'}
           style={[styles.accessoryReveal, accessoryRevealStyle]}
         >
-          <View
-            collapsable={false}
-            onLayout={(event) => {
-              const nextHeight = event.nativeEvent.layout.height;
-              setAccessoryContentHeight((current) => current === nextHeight ? current : nextHeight);
-            }}
-          >
-            {accessoryAbove}
-          </View>
+          {accessoryAbove}
         </Reanimated.View>
       ) : null}
       <Reanimated.View
@@ -387,6 +379,10 @@ export function MobileComposerInputRow({
         ? (
           <Reanimated.View
             style={[
+              {
+                height: MOBILE_COMPOSER_CONTROL_SIZE,
+                width: MOBILE_COMPOSER_CONTROL_SIZE,
+              },
               resolveMobileComposerVoiceButtonAnchorStyle({
                 cardLayout,
                 floating: voicePlacement.floating,
@@ -651,6 +647,8 @@ const makeMobileComposerInputRowStyles = (colors: ThemeColors) => ({
     overflow: 'hidden',
   },
   accessoryReveal: {
+    // 必须让内容自然布局,再由 animated maxHeight 裁剪揭示;不能给这里写 height:0,
+    // 否则附件缩略图的首帧布局也会被压成 0。
     overflow: 'hidden',
   },
   toolbarSpacer: {

--- a/apps/mobile/src/session/MobileComposerInputRow.tsx
+++ b/apps/mobile/src/session/MobileComposerInputRow.tsx
@@ -14,7 +14,7 @@ import { TextInput } from '@/components/AppText';
 import Constants, { ExecutionEnvironment } from 'expo-constants';
 import { TextInputWrapper, type PasteEventPayload } from 'expo-paste-input';
 import { Mic } from 'lucide-react-native';
-import { useCallback, useEffect, useRef, type ReactNode } from 'react';
+import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import Reanimated, { interpolate, useAnimatedStyle, type AnimatedStyle } from 'react-native-reanimated';
 import { iconSize, iconStroke, useThemedStyles, type ThemeColors } from '@/theme';
@@ -111,7 +111,7 @@ export interface MobileComposerInputRowProps {
    * 定位走 resolveMobileComposerVoiceButtonAnchorStyle，两态都写全 top /
    * bottom / transform，避免 RN 合并残留把麦克风停在卡片中部。
    */
-  floatingVoiceButton?: (style?: StyleProp<ViewStyle>) => ReactNode;
+  floatingVoiceButton?: () => ReactNode;
   floatingVoiceButtonStyle?: StyleProp<ViewStyle | AnimatedStyle<ViewStyle>>;
   /**
    * 输入区（inputFrame）的显式高度：拖拽跟手时传 Animated 值、manual 定高时传数值，
@@ -256,6 +256,15 @@ export function MobileComposerInputRow({
     height: cardTransition.value * MOBILE_COMPOSER_TOOLBAR_SECTION_HEIGHT,
     opacity: cardTransition.value,
   }));
+  // 附件托盘不能跟 cardActive 一起硬挂载/卸载:缩略图卡本身有真实高度,
+  // 直接切换会把整段高度跳变带回 composer。保持内容挂载,由同一份 card progress
+  // 驱动高度/透明度,并用自然布局高度作为插值终点。父容器收起到 0 高时子 View
+  // 仍保留自然测量,所以下一次展开不会丢失高度。
+  const [accessoryContentHeight, setAccessoryContentHeight] = useState(0);
+  const accessoryRevealStyle = useAnimatedStyle(() => ({
+    height: cardTransition.value * accessoryContentHeight,
+    opacity: cardTransition.value,
+  }), [accessoryContentHeight]);
   // RN 里显式 height 压过 minHeight:manual 定高(用户拖过高度)时 frameHeight 可能小于
   // inputFrameMinHeight,直接铺开会把听写停止命中区又压回不足 44pt。数值高度在这里
   // 先 clamp;拖拽中的 Animated 值无法在 JS 侧 clamp(会打断跟手),那一瞬保持动画值,
@@ -319,7 +328,22 @@ export function MobileComposerInputRow({
       testID={testID}
     >
       {resizeHandle}
-      {cardLayout ? accessoryAbove : null}
+      {accessoryAbove != null ? (
+        <Reanimated.View
+          pointerEvents={cardLayout ? 'auto' : 'none'}
+          style={[styles.accessoryReveal, accessoryRevealStyle]}
+        >
+          <View
+            collapsable={false}
+            onLayout={(event) => {
+              const nextHeight = event.nativeEvent.layout.height;
+              setAccessoryContentHeight((current) => current === nextHeight ? current : nextHeight);
+            }}
+          >
+            {accessoryAbove}
+          </View>
+        </Reanimated.View>
+      ) : null}
       <Reanimated.View
         style={[
           styles.mainRow,
@@ -360,13 +384,19 @@ export function MobileComposerInputRow({
         </Reanimated.View>
       ) : null}
       {voicePlacement?.inline || voicePlacement?.floating
-        ? floatingVoiceButton?.([
-          resolveMobileComposerVoiceButtonAnchorStyle({
-            cardLayout,
-            floating: voicePlacement.floating,
-          }),
-          floatingVoiceButtonStyle as StyleProp<ViewStyle>,
-        ])
+        ? (
+          <Reanimated.View
+            style={[
+              resolveMobileComposerVoiceButtonAnchorStyle({
+                cardLayout,
+                floating: voicePlacement.floating,
+              }),
+              floatingVoiceButtonStyle as StyleProp<ViewStyle>,
+            ]}
+          >
+            {floatingVoiceButton?.()}
+          </Reanimated.View>
+        )
         : null}
     </Reanimated.View>
   );
@@ -618,6 +648,9 @@ const makeMobileComposerInputRowStyles = (colors: ThemeColors) => ({
   },
   // 工具排常驻挂载的外壳:高度/透明度由 progress 驱动,折叠时 0 高裁掉内容。
   toolbarReveal: {
+    overflow: 'hidden',
+  },
+  accessoryReveal: {
     overflow: 'hidden',
   },
   toolbarSpacer: {

--- a/apps/mobile/src/session/MobileComposerInputRow.tsx
+++ b/apps/mobile/src/session/MobileComposerInputRow.tsx
@@ -111,7 +111,7 @@ export interface MobileComposerInputRowProps {
    * 定位走 resolveMobileComposerVoiceButtonAnchorStyle，两态都写全 top /
    * bottom / transform，避免 RN 合并残留把麦克风停在卡片中部。
    */
-  floatingVoiceButton?: () => ReactNode;
+  floatingVoiceButton?: (style?: StyleProp<ViewStyle>) => ReactNode;
   floatingVoiceButtonStyle?: StyleProp<ViewStyle | AnimatedStyle<ViewStyle>>;
   /**
    * 输入区（inputFrame）的显式高度：拖拽跟手时传 Animated 值、manual 定高时传数值，
@@ -256,15 +256,6 @@ export function MobileComposerInputRow({
     height: cardTransition.value * MOBILE_COMPOSER_TOOLBAR_SECTION_HEIGHT,
     opacity: cardTransition.value,
   }));
-  // 附件托盘不能跟 cardActive 一起硬挂载/卸载:缩略图卡本身有真实高度,
-  // 直接切换会把整段高度跳变带回 composer。保持内容挂载,用 maxHeight/opacity
-  // 由同一份 card progress 驱动揭示。maxHeight 在收起态裁掉自然内容,但不把
-  // 子内容的自然布局高度改成 0,避免「先收起挂载 → 永远测到 0 → 再也展开不了」的
-  // 首帧测量死锁。
-  const accessoryRevealStyle = useAnimatedStyle(() => ({
-    maxHeight: cardTransition.value * MOBILE_COMPOSER_INPUT_MAX_HEIGHT,
-    opacity: cardTransition.value,
-  }));
   // RN 里显式 height 压过 minHeight:manual 定高(用户拖过高度)时 frameHeight 可能小于
   // inputFrameMinHeight,直接铺开会把听写停止命中区又压回不足 44pt。数值高度在这里
   // 先 clamp;拖拽中的 Animated 值无法在 JS 侧 clamp(会打断跟手),那一瞬保持动画值,
@@ -328,14 +319,7 @@ export function MobileComposerInputRow({
       testID={testID}
     >
       {resizeHandle}
-      {accessoryAbove != null ? (
-        <Reanimated.View
-          pointerEvents={cardLayout ? 'auto' : 'none'}
-          style={[styles.accessoryReveal, accessoryRevealStyle]}
-        >
-          {accessoryAbove}
-        </Reanimated.View>
-      ) : null}
+      {cardLayout ? accessoryAbove : null}
       <Reanimated.View
         style={[
           styles.mainRow,
@@ -376,23 +360,13 @@ export function MobileComposerInputRow({
         </Reanimated.View>
       ) : null}
       {voicePlacement?.inline || voicePlacement?.floating
-        ? (
-          <Reanimated.View
-            style={[
-              {
-                height: MOBILE_COMPOSER_CONTROL_SIZE,
-                width: MOBILE_COMPOSER_CONTROL_SIZE,
-              },
-              resolveMobileComposerVoiceButtonAnchorStyle({
-                cardLayout,
-                floating: voicePlacement.floating,
-              }),
-              floatingVoiceButtonStyle as StyleProp<ViewStyle>,
-            ]}
-          >
-            {floatingVoiceButton?.()}
-          </Reanimated.View>
-        )
+        ? floatingVoiceButton?.([
+          resolveMobileComposerVoiceButtonAnchorStyle({
+            cardLayout,
+            floating: voicePlacement.floating,
+          }),
+          floatingVoiceButtonStyle as StyleProp<ViewStyle>,
+        ])
         : null}
     </Reanimated.View>
   );
@@ -644,11 +618,6 @@ const makeMobileComposerInputRowStyles = (colors: ThemeColors) => ({
   },
   // 工具排常驻挂载的外壳:高度/透明度由 progress 驱动,折叠时 0 高裁掉内容。
   toolbarReveal: {
-    overflow: 'hidden',
-  },
-  accessoryReveal: {
-    // 必须让内容自然布局,再由 animated maxHeight 裁剪揭示;不能给这里写 height:0,
-    // 否则附件缩略图的首帧布局也会被压成 0。
     overflow: 'hidden',
   },
   toolbarSpacer: {

--- a/apps/mobile/src/session/MobileComposerInputRow.tsx
+++ b/apps/mobile/src/session/MobileComposerInputRow.tsx
@@ -16,8 +16,11 @@ import { TextInputWrapper, type PasteEventPayload } from 'expo-paste-input';
 import { Mic } from 'lucide-react-native';
 import { useCallback, useEffect, useRef, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
+import Reanimated, { interpolate, useAnimatedStyle, type AnimatedStyle } from 'react-native-reanimated';
 import { iconSize, iconStroke, useThemedStyles, type ThemeColors } from '@/theme';
 import { radius, spacing } from '@/theme/tokens';
+import { useComposerCardTransition } from '@/session/useComposerCardTransition';
+import { useVoiceRecordingPillWidthStyle } from '@/session/useComposerControlMotion';
 import {
   COMPOSER_SINGLE_LINE_HEIGHT,
   COMPOSER_TEXT_HORIZONTAL_PADDING,
@@ -66,6 +69,14 @@ export const MOBILE_COMPOSER_INPUT_SINGLE_LINE_HEIGHT = COMPOSER_SINGLE_LINE_HEI
 export const MOBILE_COMPOSER_INPUT_MAX_VISIBLE_LINES = 12;
 export const MOBILE_COMPOSER_INPUT_MAX_HEIGHT = (MOBILE_COMPOSER_INPUT_LINE_HEIGHT * MOBILE_COMPOSER_INPUT_MAX_VISIBLE_LINES)
   + (MOBILE_COMPOSER_INPUT_VERTICAL_PADDING * 2);
+/** 卡片态工具排整体占用高度:toolbarRow 的 marginTop + 控件高度。 */
+const MOBILE_COMPOSER_TOOLBAR_SECTION_HEIGHT = 8 + MOBILE_COMPOSER_CONTROL_SIZE;
+/** 简洁态多行草稿的圆角(rowMultiline 几何);卡片态插值端点需要数字常量。 */
+const MOBILE_COMPOSER_ROW_RADIUS_MULTILINE = 30;
+/** 外壳(简洁态)上下内边距与卡片态上/下内边距——过渡插值的四个端点。 */
+const ROW_PADDING_VERTICAL = 10;
+const ROW_CARD_PADDING_TOP = 26;
+const ROW_CARD_PADDING_BOTTOM = 8;
 /**
  * 触控目标下限(mobile-design-guide「主操作命中区 ≥ 44×44」,iOS HIG 同值)。
  * 语音听写期间「点输入区停止听写」的命中层用它撑起 inputFrame(见 inputFrameMinHeight)。
@@ -100,8 +111,8 @@ export interface MobileComposerInputRowProps {
    * 定位走 resolveMobileComposerVoiceButtonAnchorStyle，两态都写全 top /
    * bottom / transform，避免 RN 合并残留把麦克风停在卡片中部。
    */
-  floatingVoiceButton?: (style: StyleProp<ViewStyle>) => ReactNode;
-  floatingVoiceButtonStyle?: StyleProp<ViewStyle>;
+  floatingVoiceButton?: (style?: StyleProp<ViewStyle>) => ReactNode;
+  floatingVoiceButtonStyle?: StyleProp<ViewStyle | AnimatedStyle<ViewStyle>>;
   /**
    * 输入区（inputFrame）的显式高度：拖拽跟手时传 Animated 值、manual 定高时传数值，
    * null / undefined 走内容自动增长（现状行为）。
@@ -222,6 +233,29 @@ export function MobileComposerInputRow({
   // 但 mode/manual 与多行草稿判定仍会让 multilineShape 为 true;若据此关掉几何居中,
   // 收起态文字会继续走 iOS 6/0 光学偏移,对不齐新增的 34pt +。
   const geometricSingleLine = !cardLayout;
+  // 卡片过渡是 Reanimated 局部动画(不用 LayoutAnimation,竞态会冻结无关视图,
+  // 见 useComposerCardTransition 注释)。progress 驱动外壳形变:常驻的语音
+  // absolute 锚点不需要单独动画,跟随容器形变逐帧重排自然滑到工具排位置。
+  const cardTransition = useComposerCardTransition(cardLayout);
+  const compactRowRadius = multilineShape ? MOBILE_COMPOSER_ROW_RADIUS_MULTILINE : radius.pill;
+  const rowCardTransitionStyle = useAnimatedStyle(() => ({
+    borderRadius: interpolate(cardTransition.value, [0, 1], [compactRowRadius, radius.control]),
+    paddingBottom: interpolate(cardTransition.value, [0, 1], [ROW_PADDING_VERTICAL, ROW_CARD_PADDING_BOTTOM]),
+    paddingTop: interpolate(cardTransition.value, [0, 1], [ROW_PADDING_VERTICAL, ROW_CARD_PADDING_TOP]),
+  }), [compactRowRadius]);
+  // 语音让位(简洁态 inline 时右侧 40pt)随 progress 收放;卡片态恒为 0。
+  const voiceInlineInset = !cardLayout && voicePlacement?.inline
+    ? MOBILE_COMPOSER_CONTROL_SIZE + MOBILE_COMPOSER_TOOL_GAP
+    : 0;
+  const mainRowCardTransitionStyle = useAnimatedStyle(() => ({
+    paddingRight: (1 - cardTransition.value) * voiceInlineInset,
+  }), [voiceInlineInset]);
+  // 工具排常驻挂载、高度/透明度随 progress 展开(抽屉滑出 + 原地渐显,
+  // 对齐旧 LayoutAnimation update/create 两段的观感)。
+  const toolbarRevealStyle = useAnimatedStyle(() => ({
+    height: cardTransition.value * MOBILE_COMPOSER_TOOLBAR_SECTION_HEIGHT,
+    opacity: cardTransition.value,
+  }));
   // RN 里显式 height 压过 minHeight:manual 定高(用户拖过高度)时 frameHeight 可能小于
   // inputFrameMinHeight,直接铺开会把听写停止命中区又压回不足 44pt。数值高度在这里
   // 先 clamp;拖拽中的 Animated 值无法在 JS 侧 clamp(会打断跟手),那一瞬保持动画值,
@@ -273,25 +307,26 @@ export function MobileComposerInputRow({
     />
   );
   return (
-    <View
+    <Reanimated.View
       style={[
         styles.row,
         compact && styles.rowCompact,
         geometricSingleLine && styles.rowCollapsedTouch,
         !geometricSingleLine && multilineShape && styles.rowMultiline,
-        cardLayout && styles.rowCard,
+        rowCardTransitionStyle,
         rowStyle,
       ]}
       testID={testID}
     >
       {resizeHandle}
       {cardLayout ? accessoryAbove : null}
-      <View
+      <Reanimated.View
         style={[
           styles.mainRow,
           geometricSingleLine && styles.mainRowCollapsedTouch,
           !geometricSingleLine && multilineShape && styles.mainRowMultiline,
           !cardLayout && voicePlacement?.inline && styles.mainRowVoiceInset,
+          mainRowCardTransitionStyle,
         ]}
       >
         {cardLayout ? null : leading}
@@ -312,14 +347,17 @@ export function MobileComposerInputRow({
           {inputOverlay}
         </Animated.View>
         {cardLayout ? null : trailing}
-      </View>
-      {cardLayout && toolbar != null ? (
-        <View
-          style={styles.toolbarRow}
+      </Reanimated.View>
+      {toolbar != null ? (
+        <Reanimated.View
+          accessibilityElementsHidden={!cardLayout}
+          importantForAccessibility={cardLayout ? undefined : 'no-hide-descendants'}
+          pointerEvents={cardLayout ? 'auto' : 'none'}
+          style={[styles.toolbarReveal, toolbarRevealStyle]}
           testID={testID ? `${testID}.toolbar` : undefined}
         >
-          {toolbar}
-        </View>
+          <View style={styles.toolbarRow}>{toolbar}</View>
+        </Reanimated.View>
       ) : null}
       {voicePlacement?.inline || voicePlacement?.floating
         ? floatingVoiceButton?.([
@@ -327,10 +365,10 @@ export function MobileComposerInputRow({
             cardLayout,
             floating: voicePlacement.floating,
           }),
-          floatingVoiceButtonStyle,
+          floatingVoiceButtonStyle as StyleProp<ViewStyle>,
         ])
         : null}
-    </View>
+    </Reanimated.View>
   );
 }
 
@@ -349,7 +387,12 @@ export function ComposerToolbarSpacer() {
  */
 export function ComposerToolbarVoiceSlot({ width }: { width?: number }) {
   const styles = useThemedStyles(makeMobileComposerInputRowStyles);
-  return <View style={[styles.toolbarVoiceSlot, width != null && { width }]} />;
+  // 宽度换档走局部动画(与语音按钮共用同一份时长/曲线,保持同段运动),
+  // 不再用全局 LayoutAnimation(与键盘竞态会冻结无关视图)。
+  const pillWidthStyle = useVoiceRecordingPillWidthStyle(width);
+  return (
+    <Reanimated.View style={[styles.toolbarVoiceSlot, width != null && pillWidthStyle]} />
+  );
 }
 
 export interface ComposerResizeGrabberProps {
@@ -509,7 +552,7 @@ const makeMobileComposerInputRowStyles = (colors: ThemeColors) => ({
     minHeight: 50,
     overflow: 'visible',
     paddingHorizontal: spacing.md,
-    paddingVertical: 10,
+    paddingVertical: ROW_PADDING_VERTICAL,
     position: 'relative',
   },
   // 收起态给 leading 的 44pt 热区留出父边界,避免溢出子节点点不到。
@@ -518,7 +561,7 @@ const makeMobileComposerInputRowStyles = (colors: ThemeColors) => ({
     paddingVertical: 3,
   },
   rowMultiline: {
-    borderRadius: 30, // 组件几何:composer 聚焦形态专用,非通用圆角档
+    borderRadius: MOBILE_COMPOSER_ROW_RADIUS_MULTILINE, // 组件几何:composer 聚焦形态专用,非通用圆角档
   },
   rowCompact: {
     gap: MOBILE_COMPOSER_TOOL_GAP,
@@ -527,8 +570,8 @@ const makeMobileComposerInputRowStyles = (colors: ThemeColors) => ({
   // （grabber 横条距顶约 8pt、距输入内容约 14pt，参考 Cursor 移动端）。
   rowCard: {
     borderRadius: radius.control,
-    paddingBottom: MOBILE_COMPOSER_VOICE_ANCHOR_CARD_BOTTOM,
-    paddingTop: 26,
+    paddingBottom: ROW_CARD_PADDING_BOTTOM,
+    paddingTop: ROW_CARD_PADDING_TOP,
   },
   // 水平输入行：简洁态装 [输入][发送]，card 态只剩全宽输入区；
   // 语音按钮不在流内（absolute 锚点），简洁态无发送时给它留出右侧空间。
@@ -572,6 +615,10 @@ const makeMobileComposerInputRowStyles = (colors: ThemeColors) => ({
     flexDirection: 'row',
     gap: MOBILE_COMPOSER_TOOL_GAP,
     marginTop: 8,
+  },
+  // 工具排常驻挂载的外壳:高度/透明度由 progress 驱动,折叠时 0 高裁掉内容。
+  toolbarReveal: {
+    overflow: 'hidden',
   },
   toolbarSpacer: {
     flex: 1,

--- a/apps/mobile/src/session/MobileComposerInputRow.tsx
+++ b/apps/mobile/src/session/MobileComposerInputRow.tsx
@@ -16,9 +16,19 @@ import { TextInputWrapper, type PasteEventPayload } from 'expo-paste-input';
 import { Mic } from 'lucide-react-native';
 import { useCallback, useEffect, useRef, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
-import Reanimated, { interpolate, useAnimatedStyle, type AnimatedStyle } from 'react-native-reanimated';
+import Reanimated, {
+  Easing as ReanimatedEasing,
+  LinearTransition,
+  ReduceMotion,
+  interpolate,
+  useAnimatedStyle,
+  withTiming,
+  type AnimatedStyle,
+  type EntryAnimationsValues,
+  type ExitAnimationsValues,
+} from 'react-native-reanimated';
 import { iconSize, iconStroke, useThemedStyles, type ThemeColors } from '@/theme';
-import { radius, spacing } from '@/theme/tokens';
+import { motionDuration, motionEasing, radius, spacing } from '@/theme/tokens';
 import { useComposerCardTransition } from '@/session/useComposerCardTransition';
 import { useVoiceRecordingPillWidthStyle } from '@/session/useComposerControlMotion';
 import {
@@ -73,10 +83,51 @@ export const MOBILE_COMPOSER_INPUT_MAX_HEIGHT = (MOBILE_COMPOSER_INPUT_LINE_HEIG
 const MOBILE_COMPOSER_TOOLBAR_SECTION_HEIGHT = 8 + MOBILE_COMPOSER_CONTROL_SIZE;
 /** 简洁态多行草稿的圆角(rowMultiline 几何);卡片态插值端点需要数字常量。 */
 const MOBILE_COMPOSER_ROW_RADIUS_MULTILINE = 30;
-/** 外壳(简洁态)上下内边距与卡片态上/下内边距——过渡插值的四个端点。 */
-const ROW_PADDING_VERTICAL = 10;
+/** 外壳默认/收起态上下内边距与卡片态上/下内边距——过渡插值端点。 */
+const ROW_BASE_PADDING_VERTICAL = 10;
+const ROW_COLLAPSED_PADDING_VERTICAL = 3;
 const ROW_CARD_PADDING_TOP = 26;
 const ROW_CARD_PADDING_BOTTOM = 8;
+const ACCESSORY_LAYOUT_TRANSITION = LinearTransition
+  .duration(motionDuration.base)
+  .easing(ReanimatedEasing.bezier(...motionEasing.move))
+  .reduceMotion(ReduceMotion.System);
+const accessoryEntering = (values: EntryAnimationsValues) => {
+  'worklet';
+  return {
+    initialValues: { height: 0, opacity: 0 },
+    animations: {
+      height: withTiming(values.targetHeight, {
+        duration: motionDuration.base,
+        easing: ReanimatedEasing.bezier(...motionEasing.move),
+        reduceMotion: ReduceMotion.System,
+      }),
+      opacity: withTiming(1, {
+        duration: motionDuration.fast,
+        easing: ReanimatedEasing.bezier(...motionEasing.out),
+        reduceMotion: ReduceMotion.System,
+      }),
+    },
+  };
+};
+const accessoryExiting = (values: ExitAnimationsValues) => {
+  'worklet';
+  return {
+    initialValues: { height: values.currentHeight, opacity: 1 },
+    animations: {
+      height: withTiming(0, {
+        duration: motionDuration.base,
+        easing: ReanimatedEasing.bezier(...motionEasing.move),
+        reduceMotion: ReduceMotion.System,
+      }),
+      opacity: withTiming(0, {
+        duration: motionDuration.fast,
+        easing: ReanimatedEasing.bezier(...motionEasing.in),
+        reduceMotion: ReduceMotion.System,
+      }),
+    },
+  };
+};
 /**
  * 触控目标下限(mobile-design-guide「主操作命中区 ≥ 44×44」,iOS HIG 同值)。
  * 语音听写期间「点输入区停止听写」的命中层用它撑起 inputFrame(见 inputFrameMinHeight)。
@@ -240,11 +291,11 @@ export function MobileComposerInputRow({
   const compactRowRadius = multilineShape ? MOBILE_COMPOSER_ROW_RADIUS_MULTILINE : radius.pill;
   const rowCardTransitionStyle = useAnimatedStyle(() => ({
     borderRadius: interpolate(cardTransition.value, [0, 1], [compactRowRadius, radius.control]),
-    paddingBottom: interpolate(cardTransition.value, [0, 1], [ROW_PADDING_VERTICAL, ROW_CARD_PADDING_BOTTOM]),
-    paddingTop: interpolate(cardTransition.value, [0, 1], [ROW_PADDING_VERTICAL, ROW_CARD_PADDING_TOP]),
+    paddingBottom: interpolate(cardTransition.value, [0, 1], [ROW_COLLAPSED_PADDING_VERTICAL, ROW_CARD_PADDING_BOTTOM]),
+    paddingTop: interpolate(cardTransition.value, [0, 1], [ROW_COLLAPSED_PADDING_VERTICAL, ROW_CARD_PADDING_TOP]),
   }), [compactRowRadius]);
   // 语音让位(简洁态 inline 时右侧 40pt)随 progress 收放;卡片态恒为 0。
-  const voiceInlineInset = !cardLayout && voicePlacement?.inline
+  const voiceInlineInset = voicePlacement?.inline
     ? MOBILE_COMPOSER_CONTROL_SIZE + MOBILE_COMPOSER_TOOL_GAP
     : 0;
   const mainRowCardTransitionStyle = useAnimatedStyle(() => ({
@@ -319,7 +370,16 @@ export function MobileComposerInputRow({
       testID={testID}
     >
       {resizeHandle}
-      {cardLayout ? accessoryAbove : null}
+      {cardLayout && accessoryAbove != null ? (
+        <Reanimated.View
+          entering={accessoryEntering}
+          exiting={accessoryExiting}
+          layout={ACCESSORY_LAYOUT_TRANSITION}
+          style={styles.accessoryReveal}
+        >
+          {accessoryAbove}
+        </Reanimated.View>
+      ) : null}
       <Reanimated.View
         style={[
           styles.mainRow,
@@ -552,13 +612,13 @@ const makeMobileComposerInputRowStyles = (colors: ThemeColors) => ({
     minHeight: 50,
     overflow: 'visible',
     paddingHorizontal: spacing.md,
-    paddingVertical: ROW_PADDING_VERTICAL,
+    paddingVertical: ROW_BASE_PADDING_VERTICAL,
     position: 'relative',
   },
   // 收起态给 leading 的 44pt 热区留出父边界,避免溢出子节点点不到。
   rowCollapsedTouch: {
     minHeight: MOBILE_COMPOSER_MIN_TOUCH_TARGET + 6,
-    paddingVertical: 3,
+    paddingVertical: ROW_COLLAPSED_PADDING_VERTICAL,
   },
   rowMultiline: {
     borderRadius: MOBILE_COMPOSER_ROW_RADIUS_MULTILINE, // 组件几何:composer 聚焦形态专用,非通用圆角档
@@ -618,6 +678,9 @@ const makeMobileComposerInputRowStyles = (colors: ThemeColors) => ({
   },
   // 工具排常驻挂载的外壳:高度/透明度由 progress 驱动,折叠时 0 高裁掉内容。
   toolbarReveal: {
+    overflow: 'hidden',
+  },
+  accessoryReveal: {
     overflow: 'hidden',
   },
   toolbarSpacer: {

--- a/apps/mobile/src/session/VoiceRecordingPill.tsx
+++ b/apps/mobile/src/session/VoiceRecordingPill.tsx
@@ -1,17 +1,10 @@
-import { Animated, Easing, LayoutAnimation, Platform, UIManager, View } from 'react-native';
+import { Animated, Easing, View } from 'react-native';
 import { useEffect, useRef, useState } from 'react';
 import { Text } from '@/components/AppText';
-import { getCachedReduceMotionEnabled, useReduceMotionEnabled } from '@/hooks/useReduceMotion';
+import { useReduceMotionEnabled } from '@/hooks/useReduceMotion';
 import { useThemedStyles, type ThemeColors } from '@/theme';
 import { radius, typeScale } from '@/theme/tokens';
 import { MOBILE_COMPOSER_CONTROL_SIZE } from '@/session/MobileComposerInputRow';
-
-// 旧架构 Android 需要显式开启 LayoutAnimation;新架构(Fabric)下该开关是 no-op。
-// 与 useComposerCardTransition / collapseAnimation 相同的模块级开关——本模块可能
-// 在两者都未加载时独立使用,不能依赖别处的副作用(review 反馈)。
-if (Platform.OS === 'android' && UIManager.setLayoutAnimationEnabledExperimental) {
-  UIManager.setLayoutAnimationEnabledExperimental(true);
-}
 
 /**
  * 录音中语音按钮的胶囊宽度(对齐桌面 VoiceInputButton 的红点+计时展开形态)。
@@ -51,9 +44,10 @@ export interface MobileVoiceRecordingTimer {
 
 /**
  * 录音计时状态。counting 翻 true 时从 0 重新计时,expanded 翻 false 清零。
- * 同时在展开态翻转与宽度换档的下一帧布局注册一次 LayoutAnimation
- * (一次性瞬态、用户触发、有明确结束,符合动效红线;240ms 对齐桌面胶囊
- * 展开时长),让胶囊展开/收回与左邻按钮的让位在同一段运动里完成。
+ * 胶囊宽度换档(34 → 72 / 80)的展开动画不再在这里注册全局 LayoutAnimation
+ * (与键盘竞态会冻结无关视图,见 useComposerCardTransition 注释),改由消费方
+ * (语音按钮锚点 + ComposerToolbarVoiceSlot)用 useVoiceRecordingPillWidthStyle
+ * 做局部动画,同一份时长/曲线,展开/收回与左邻按钮让位仍是同一段运动。
  */
 export function useMobileVoiceRecordingTimer(
   { expanded, counting }: MobileVoiceRecordingTimerInput,
@@ -78,20 +72,6 @@ export function useMobileVoiceRecordingTimer(
     : label.length > 4
       ? MOBILE_VOICE_RECORDING_PILL_WIDTH_WIDE
       : MOBILE_VOICE_RECORDING_PILL_WIDTH;
-
-  const prevWidthRef = useRef(pillWidth);
-  if (prevWidthRef.current !== pillWidth) {
-    prevWidthRef.current = pillWidth;
-    // reduce-motion 降级为直切,对齐桌面 prefers-reduced-motion 下
-    // pillTransition = undefined 的行为。按 useReduceMotion 的约定,null
-    // (首帧未查到)也按不播处理——缓存模块加载即预热,实际命中窗口极小。
-    if (getCachedReduceMotionEnabled() === false) {
-      LayoutAnimation.configureNext({
-        duration: 240,
-        update: { type: 'easeInEaseOut' },
-      });
-    }
-  }
 
   return { label, pillWidth };
 }

--- a/apps/mobile/src/session/composerVoiceButtonAnchor.ts
+++ b/apps/mobile/src/session/composerVoiceButtonAnchor.ts
@@ -5,7 +5,7 @@ export const MOBILE_COMPOSER_TOOL_GAP = 6;
 /** 语音按钮 absolute 锚点距 composer 内容区右缘的距离。
  * 消息列表的「跳到底部」浮标按同一常量推导麦克风所在列,保持两者圆心同列。 */
 export const MOBILE_COMPOSER_VOICE_ANCHOR_RIGHT = spacing.md;
-/** 卡片态麦克风贴工具排底边的距离,与 rowCard.paddingBottom 同源。 */
+/** 麦克风贴 composer 底边的距离,与收起态居中及 rowCard.paddingBottom 同源。 */
 export const MOBILE_COMPOSER_VOICE_ANCHOR_CARD_BOTTOM = spacing.sm;
 
 export interface MobileComposerVoiceButtonPlacement {
@@ -38,10 +38,10 @@ export type MobileComposerVoiceButtonAnchorStyle = {
 };
 
 /**
- * 语音按钮的完整定位。必须一次性写出 top / bottom / transform 三套互斥键,
- * 不能靠 StyleSheet 数组后项写 `undefined` 去覆盖前项:
- * RN 扁平化会跳过 undefined,卡片态就会残留收起态的 `top: '50%'`,麦克风停在
- * 卡片中部(工具排占位空着)。漏写的键在原生侧也可能继续沿用上一帧的 inset。
+ * 语音按钮的完整定位。收起态 50pt 高、按钮 34pt 高,bottom=8 正好垂直居中;
+ * 卡片态同样贴 8pt 底边。因此两态共用一套 top / bottom / transform,
+ * cardLayout 翻转时不再把互斥定位键从 `top: 50%` 硬切到 `bottom: 8`,
+ * 避免原生样式合并或动画中断留下半帧纵向偏移。
  */
 export function resolveMobileComposerVoiceButtonAnchorStyle(input: {
   cardLayout: boolean;
@@ -51,23 +51,12 @@ export function resolveMobileComposerVoiceButtonAnchorStyle(input: {
     ? MOBILE_COMPOSER_VOICE_ANCHOR_RIGHT + MOBILE_COMPOSER_CONTROL_SIZE + MOBILE_COMPOSER_TOOL_GAP
     : MOBILE_COMPOSER_VOICE_ANCHOR_RIGHT;
 
-  if (input.cardLayout) {
-    return {
-      position: 'absolute',
-      right,
-      top: 'auto',
-      bottom: MOBILE_COMPOSER_VOICE_ANCHOR_CARD_BOTTOM,
-      transform: [],
-      zIndex: 2,
-    };
-  }
-
   return {
     position: 'absolute',
     right,
-    top: '50%',
-    bottom: 'auto',
-    transform: [{ translateY: -MOBILE_COMPOSER_CONTROL_SIZE / 2 }],
+    top: 'auto',
+    bottom: MOBILE_COMPOSER_VOICE_ANCHOR_CARD_BOTTOM,
+    transform: [],
     zIndex: 2,
   };
 }

--- a/apps/mobile/src/session/useComposerCardTransition.ts
+++ b/apps/mobile/src/session/useComposerCardTransition.ts
@@ -1,41 +1,47 @@
-import { useRef } from 'react';
-import { LayoutAnimation, Platform, UIManager } from 'react-native';
+import { useEffect } from 'react';
+import { Easing, useSharedValue, withTiming, type SharedValue } from 'react-native-reanimated';
 
-// 旧架构 Android 需要显式开启 LayoutAnimation;新架构(Fabric)下该开关是 no-op。
-if (Platform.OS === 'android' && UIManager.setLayoutAnimationEnabledExperimental) {
-  UIManager.setLayoutAnimationEnabledExperimental(true);
-}
+import { getCachedReduceMotionEnabled } from '@/hooks/useReduceMotion';
+import { motionDuration, motionEasing } from '@/theme/tokens';
 
-/** 与 iOS 键盘弹出动画同量级的时长，让卡片展开与键盘上滑视觉上是同一段运动。 */
-const CARD_TRANSITION_DURATION_MS = 250;
+/** 展开:重浮层入场档(250ms),与 iOS 键盘弹出同量级,保持「卡片展开与键盘上滑是同一段运动」。 */
+const CARD_EXPAND_EASING = Easing.bezier(...motionEasing.out);
+/** 收起:尺寸变化档退场曲线。 */
+const CARD_COLLAPSE_EASING = Easing.bezier(...motionEasing.in);
 
 /**
- * Composer 简洁态 ↔ 聚焦卡片态切换的布局过渡动画。
+ * Composer 简洁态 ↔ 聚焦卡片态切换的过渡进度(0 = 简洁态,1 = 卡片态)。
  *
- * 检测 cardActive 翻转时注册一次 LayoutAnimation，让下一帧的布局变化
- * （输入行变全宽、工具排出现 / 消失、卡片高度与圆角变化、消息列表 padding 联动）
- * 整体平滑过渡，而不是硬切。
+ * 曾经用 LayoutAnimation.configureNext 实现整段过渡,但 LayoutAnimation 是
+ * **全局**的:同一次布局提交里所有 frame 变化的视图(消息列表 padding、
+ * 「跳到底部」浮标、KAV 重排下的任意兄弟视图)都会被卷进动画;而 cardActive
+ * 翻转的 250ms 窗口恰好与键盘起落重叠,动画被打断时原生 animator 不回滚
+ * transform,把无关视图冻结在中间态(胶囊缩在半空、浮标压在输入文字上,
+ * 都是这个竞态的实测截图)。因此这里改为 Reanimated 驱动的**局部**进度值:
+ * 只有显式消费 progress 的样式跟着动,withTiming 天然可中断重定向,
+ * 竞态窗口内被打断也只是平滑改道,不存在冻结中间态。
  *
- * 切换入口分散（聚焦 / blur / 各面板 toggle / 语音状态异步变化），无法在每个
- * 事件处理器里注册；LayoutAnimation.configureNext 只是给下一次 native 布局
- * 提交打标记、并非副作用 setState，因此在 render 期间按状态翻转调用一次是
- * 安全且唯一集中的挂点（重复调用幂等）。
+ * 消费方(MobileComposerInputRow)把圆角 / 内边距 / 工具排高度 / 语音让位
+ * 都插值在这一个 progress 上;语音按钮的 absolute 锚点不需要单独动画——
+ * 它跟随容器形变逐帧重排,与旧 LayoutAnimation 时代的位移路径一致。
  *
- * 三段动画的分工：
- * - update：存活视图的位置 / 尺寸平滑（卡片长高、输入行变全宽、absolute 锚点的
- *   麦克风从行内滑到工具排——常驻按钮靠它保持连续，不闪不跳）；
- * - create / delete（opacity）：工具排按钮（加号 / 权限 / 模型 / 发送）只在
- *   卡片态挂载，出现时在最终位置原地渐显、收起时原地渐隐，没有位移感。
+ * reduce-motion(含首帧缓存未知的窗口)直切,对齐 useReduceMotion
+ * 「只有 === false 才播」的约定。
  */
-export function useComposerCardTransition(cardActive: boolean): void {
-  const prevRef = useRef(cardActive);
-  if (prevRef.current !== cardActive) {
-    prevRef.current = cardActive;
-    LayoutAnimation.configureNext({
-      create: { property: 'opacity', type: 'easeInEaseOut' },
-      delete: { property: 'opacity', type: 'easeInEaseOut' },
-      duration: CARD_TRANSITION_DURATION_MS,
-      update: { type: 'easeInEaseOut' },
+export function useComposerCardTransition(cardActive: boolean): SharedValue<number> {
+  const progress = useSharedValue(cardActive ? 1 : 0);
+
+  useEffect(() => {
+    const target = cardActive ? 1 : 0;
+    if (getCachedReduceMotionEnabled() !== false) {
+      progress.value = target;
+      return;
+    }
+    progress.value = withTiming(target, {
+      duration: cardActive ? motionDuration.enter : motionDuration.base,
+      easing: cardActive ? CARD_EXPAND_EASING : CARD_COLLAPSE_EASING,
     });
-  }
+  }, [cardActive, progress]);
+
+  return progress;
 }

--- a/apps/mobile/src/session/useComposerControlMotion.ts
+++ b/apps/mobile/src/session/useComposerControlMotion.ts
@@ -1,0 +1,45 @@
+import { useEffect } from 'react';
+import { Easing, useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
+
+import { getCachedReduceMotionEnabled } from '@/hooks/useReduceMotion';
+import { motionDuration, motionEasing } from '@/theme/tokens';
+
+/**
+ * 语音胶囊宽度换档的局部动画参数(尺寸变化档 + move 曲线)。
+ * 按钮锚点(MobileComposerInputRow 的 floatingVoiceButtonStyle)与工具排占位
+ * (ComposerToolbarVoiceSlot)共用同一份参数,保证两处宽度始终同段运动——
+ * 曾经用 LayoutAnimation 实现,但它是全局的且与键盘竞态会冻结无关视图,
+ * 已改为 Reanimated 局部驱动(见 useComposerCardTransition 注释)。
+ */
+const VOICE_PILL_WIDTH_TIMING = {
+  duration: motionDuration.base,
+  easing: Easing.bezier(...motionEasing.move),
+} as const;
+
+/**
+ * 语音胶囊宽度的局部过渡 style(34 → 72 / 80 两档)。
+ *
+ * 返回 Reanimated 动画 style:width 跟随 `width` 参数 withTiming 过渡,
+ * 可中断重定向、只作用于挂它的那一个视图。reduce-motion(含首帧缓存未知
+ * 窗口)直切,对齐 useReduceMotion「只有 === false 才播」的约定。
+ *
+ * 消费方必须是 Reanimated 的 Animated 组件;width 为 null / undefined 时
+ * 返回的 style 不含 width(由消费方的静态样式兜底)。
+ */
+export function useVoiceRecordingPillWidthStyle(width: number | null | undefined) {
+  const animatedWidth = useSharedValue(width ?? 0);
+
+  useEffect(() => {
+    if (width == null) return;
+    if (getCachedReduceMotionEnabled() !== false) {
+      animatedWidth.value = width;
+      return;
+    }
+    animatedWidth.value = withTiming(width, VOICE_PILL_WIDTH_TIMING);
+  }, [animatedWidth, width]);
+
+  return useAnimatedStyle(
+    () => (width == null ? {} : { width: animatedWidth.value }),
+    [width == null],
+  );
+}


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复移动端 composer 语音按钮溢出、浮标压字：根因是全局 `LayoutAnimation` 和键盘 / FAB 定位竞态，卡片被卡在未完成的 transform 中间态。改成本地 Reanimated progress，语音锚点跟真实布局走，不再被全局动画带着跑。
<img width="1080" height="2348" alt="img_v3_0214o_30ba942e-d1c3-4a9c-81f2-675f9636d39g" src="https://github.com/user-attachments/assets/d86a0156-0375-4437-88d9-4da4efd1051b" />


### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：mobile composer 卡片切换、工具栏显隐、录音胶囊宽度改为本地 Reanimated；语音按钮绝对锚点样式收口
- 明确不包含：Desktop / i18n；settings 页 `collapseAnimation`；原生层 / fingerprint
- 用户可见变化：语音按钮不再偶发溢出或盖住输入文字
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：`docs/design-rules/DESIGN.md` 动效红线（杜绝跳变、动画不得把布局卡在中间态）。composer 卡片 / 工具栏 / 录音胶囊宽度用本地 progress 过渡，语音按钮锚在真实布局矩形上，不再吃全局 `LayoutAnimation`。

## 怎么验证的

### 自动验证

```text
pnpm --filter mobile typecheck
结果：通过

pnpm --filter mobile test
结果：309 files / 3639 tests pass

env -u XDT_ISOLATED pnpm test:unit:related
结果：root test:runner 425 passed / 0 failed；apps/mobile related unit passed

pnpm check:dco
结果：通过（1 commit）
```

### 手工验证

iOS Simulator（当前 `cindy/witty-euclid` worktree）：

- iOS 17：`cindy-gentle-cohen-15`
- iOS 26.5：`cindy-gentle-cohen-sharebar`
- `mobile:sim:whoami -- --region=cn` 确认 booted dev client、当前 worktree 的 8081 Metro 归属和源码指纹一致；`__DEV__` build label / host:port 与当前 worktree 匹配
- 键盘弹出 / 收起、开始与结束录音、单行与多行切换，语音按钮未再溢出或压字

### 未执行的验证

完整 root `pnpm test:unit` 未作为本 PR 的 clean-pass 依据；Desktop 单独测试 `pnpm --filter desktop test` 为 1927/1928，唯一失败是既有 `i18nCompleteness.test.ts` 缺 3 个 `zh-TW` key（`settings.subagentModels.guardrails.cindyPolicy*`）。本 PR 未改 Desktop / i18n，未发现由本次 mobile diff 引入的 Desktop 回归。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异

### 影响与回滚

- 影响范围：仅 `apps/mobile` JS。`metro.config.js` 的 `watchFolders` 是 JS-only，不改 native runtime fingerprint，不触发冷更。
- 回滚 / 降级方式：revert 本 commit。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] UI 改动已注明设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已确认测试结果或说明未执行原因
