### PR TITLE
feat(desktop): 运行中状态栏显示生成 tok/s

### DIFF
--- a/apps/desktop/src/renderer/__tests__/makerChatStoreLiveGeneration.test.ts
+++ b/apps/desktop/src/renderer/__tests__/makerChatStoreLiveGeneration.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+
+import { makerChatStore } from '@/lib/makerChatStore';
+
+function applyStatus(
+  sessionId: string,
+  partial: {
+    isRunning: boolean;
+    status?: string;
+    tokenUsage?: number;
+    outputTokens?: number;
+    generationDurationMs?: number;
+    generationActive?: boolean;
+    generationReliable?: boolean;
+  },
+): void {
+  makerChatStore.__applyStatusUpdateForTest(sessionId, {
+    sessionId,
+    status: partial.status ?? (partial.isRunning ? 'Working' : 'Done'),
+    tokenUsage: partial.tokenUsage ?? 0,
+    contextTokens: 0,
+    contextWindow: 0,
+    isRunning: partial.isRunning,
+    ...(partial.outputTokens !== undefined ? { outputTokens: partial.outputTokens } : {}),
+    ...(partial.generationDurationMs !== undefined
+      ? { generationDurationMs: partial.generationDurationMs }
+      : {}),
+    ...(partial.generationActive !== undefined
+      ? { generationActive: partial.generationActive }
+      : {}),
+    ...(partial.generationReliable !== undefined
+      ? { generationReliable: partial.generationReliable }
+      : {}),
+  });
+}
+
+describe('makerChatStore live generation at turn start', () => {
+  it('keeps live fields when the first running status already carries them', () => {
+    const sessionId = `live-gen-keep-${Math.random().toString(36).slice(2, 8)}`;
+    try {
+      applyStatus(sessionId, {
+        isRunning: true,
+        status: 'Generating...',
+        tokenUsage: 235,
+        outputTokens: 40,
+        generationDurationMs: 800,
+        generationActive: true,
+        generationReliable: true,
+      });
+      expect(makerChatStore.getSnapshot(sessionId).agentStatus).toMatchObject({
+        outputTokens: 40,
+        generationDurationMs: 800,
+        generationActive: true,
+        generationReliable: true,
+      });
+    } finally {
+      makerChatStore.purgeSession(sessionId);
+    }
+  });
+
+  it('does not flash the previous turn live metrics on a bare turn start', () => {
+    const sessionId = `live-gen-reset-${Math.random().toString(36).slice(2, 8)}`;
+    try {
+      applyStatus(sessionId, {
+        isRunning: true,
+        outputTokens: 99,
+        generationDurationMs: 5_000,
+        generationActive: true,
+        generationReliable: false,
+      });
+      applyStatus(sessionId, { isRunning: false, status: 'Done' });
+      applyStatus(sessionId, { isRunning: true, status: 'Working' });
+      expect(makerChatStore.getSnapshot(sessionId).agentStatus).toMatchObject({
+        outputTokens: 0,
+        generationDurationMs: 0,
+        generationActive: false,
+        generationReliable: true,
+      });
+    } finally {
+      makerChatStore.purgeSession(sessionId);
+    }
+  });
+});

--- a/apps/desktop/src/renderer/__tests__/reducedMotionEscape.test.ts
+++ b/apps/desktop/src/renderer/__tests__/reducedMotionEscape.test.ts
@@ -101,7 +101,7 @@ describe('RunningStatusBar cadenced shimmer 的运行期 reduced-motion 切换',
     expect(sessionViewSource).toContain('shimmerPlayingRef.current = false;');
     expect(sessionViewSource).toContain('shimmerPendingRef.current = false;');
     expect(sessionViewSource).toContain(
-      '}, [visible, suppressContent, reducedMotion, status, tokenUsage]);',
+      '}, [visible, suppressContent, reducedMotion, status, tokenUsage, outputTokens, generationDurationMs]);',
     );
   });
 });

--- a/apps/desktop/src/renderer/__tests__/runningTokenUsage.test.ts
+++ b/apps/desktop/src/renderer/__tests__/runningTokenUsage.test.ts
@@ -1,15 +1,71 @@
 import { describe, expect, it } from 'vitest';
 
-import { formatRunningTokenCount } from '@/features/cc-agent/lib/runningTokenUsage';
+import {
+  formatLiveOutputTokenRate,
+  formatRunningTokenCount,
+  resolveRunningUsageMeta,
+} from '@/features/cc-agent/lib/runningTokenUsage';
 
 describe('formatRunningTokenCount', () => {
-  it('marks zero usage as pending while a turn is running', () => {
-    expect(formatRunningTokenCount(0, true)).toBe('—');
+  it('keeps authoritative completed and positive usage values', () => {
+    expect(formatRunningTokenCount(0)).toBe('0');
+    expect(formatRunningTokenCount(999)).toBe('999');
+    expect(formatRunningTokenCount(1250)).toBe('1.3k');
+  });
+});
+
+describe('formatLiveOutputTokenRate', () => {
+  it('reuses the post-turn TPS formatter', () => {
+    expect(formatLiveOutputTokenRate(235, 8_954, true)).toBe('26.2');
   });
 
-  it('keeps authoritative completed and positive usage values', () => {
-    expect(formatRunningTokenCount(0, false)).toBe('0');
-    expect(formatRunningTokenCount(999, true)).toBe('999');
-    expect(formatRunningTokenCount(1250, true)).toBe('1.3k');
+  it('hides the rate when timing is unreliable', () => {
+    expect(formatLiveOutputTokenRate(235, 8_954, false)).toBeNull();
+  });
+});
+
+describe('resolveRunningUsageMeta', () => {
+  it('shows rate when output and generation duration are both proven', () => {
+    expect(
+      resolveRunningUsageMeta({
+        outputTokens: 235,
+        generationDurationMs: 8_954,
+        generationReliable: true,
+        tokenUsage: 400,
+      }),
+    ).toEqual({ kind: 'rate', rate: '26.2' });
+  });
+
+  it('falls back to cumulative tokens once usage exists', () => {
+    expect(
+      resolveRunningUsageMeta({
+        outputTokens: 0,
+        generationDurationMs: 1_200,
+        generationReliable: true,
+        tokenUsage: 84_400,
+      }),
+    ).toEqual({ kind: 'tokens' });
+  });
+
+  it('falls back to cumulative tokens when timing is unreliable', () => {
+    expect(
+      resolveRunningUsageMeta({
+        outputTokens: 235,
+        generationDurationMs: 8_954,
+        generationReliable: false,
+        tokenUsage: 400,
+      }),
+    ).toEqual({ kind: 'tokens' });
+  });
+
+  it('hides the usage slot before any rate or tokens exist', () => {
+    expect(
+      resolveRunningUsageMeta({
+        outputTokens: 0,
+        generationDurationMs: 1_200,
+        generationReliable: true,
+        tokenUsage: 0,
+      }),
+    ).toEqual({ kind: 'none' });
   });
 });

--- a/apps/desktop/src/renderer/__tests__/usagePerformanceI18n.test.ts
+++ b/apps/desktop/src/renderer/__tests__/usagePerformanceI18n.test.ts
@@ -18,7 +18,7 @@ describe('usage performance units', () => {
   });
 
   it.each([
-    ['zh-CN', zhCN, 'token/秒'],
+    ['zh-CN', zhCN, 'tokens/秒'],
     ['ja', ja, 'トークン/秒'],
     ['ko', ko, '토큰/초'],
   ] as const)('uses a localized token-per-second unit in %s', (_locale, messages, unit) => {

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
@@ -4164,7 +4164,6 @@ export function CCAgentSessionView({
                   outputTokens={agentStatus.outputTokens ?? 0}
                   generationDurationMs={agentStatus.generationDurationMs ?? 0}
                   generationReliable={agentStatus.generationReliable ?? true}
-                  generationActive={agentStatus.generationActive ?? false}
                   startedAt={agentStatus.startedAt}
                   visible={!pendingPlanReview && (agentStatus.isRunning || backgroundTasksActive)}
                   inputWidth={inputWidth}
@@ -4918,7 +4917,6 @@ function RunningStatusBar({
   outputTokens = 0,
   generationDurationMs = 0,
   generationReliable = true,
-  generationActive = false,
   startedAt,
   visible,
   inputWidth,
@@ -4936,7 +4934,6 @@ function RunningStatusBar({
   outputTokens?: number;
   generationDurationMs?: number;
   generationReliable?: boolean;
-  generationActive?: boolean;
   startedAt: number | null;
   visible: boolean;
   inputWidth?: number;

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
@@ -97,6 +97,7 @@ import { UpgradeBanner } from '@/components/chat/UpgradeBanner';
 import { WorktreeRestoreBanner } from '@/components/chat/WorktreeRestoreBanner';
 import { ConnectProviderBanner } from '@/components/onboarding/ConnectProviderBanner';
 import { Tip } from '@/components/ui/tooltip';
+import { useAnimatedNumber } from '@/hooks/useAnimatedNumber';
 import { useConfirmDialog } from '@/components/ui/confirm-dialog-provider';
 import { useSilentEncryptedRetry } from '@/hooks/useSilentEncryptedRetry';
 import { TodaySpendChip } from '@/components/status/TodaySpendChip';
@@ -140,7 +141,6 @@ import {
   useComposerCollapsed,
   useControlledBy,
 } from '@/features/remote-device/ControlledBanner';
-import { useAnimatedNumber } from '@/hooks/useAnimatedNumber';
 import {
   loadAllCommands,
   dispatchCommand,
@@ -195,7 +195,10 @@ import { useSessionHardwareTaskActions } from './lib/sessionHardwareTaskActions'
 import { isRemoteSessionWriteBlocked } from './lib/remoteSessionWriteGuard';
 import { getModelById, getDefaultModelForVendor, getModelsForVendor } from '@/lib/modelDefinitions';
 import { resolveDisplayContextWindow } from '@/lib/contextWindow';
-import { formatRunningTokenCount } from './lib/runningTokenUsage';
+import {
+  formatRunningTokenCount,
+  resolveRunningUsageMeta,
+} from './lib/runningTokenUsage';
 import { matchNavigationCommandName, tryHandleNavigationCommand } from '@/lib/navigationCommands';
 import { extractIpcError } from '@/utils/ipcError';
 import { listActiveRunsForSession } from '@/features/learn/useLearnRun';
@@ -4158,6 +4161,10 @@ export function CCAgentSessionView({
                   key={sessionId}
                   status={agentStatus.status}
                   tokenUsage={agentStatus.tokenUsage}
+                  outputTokens={agentStatus.outputTokens ?? 0}
+                  generationDurationMs={agentStatus.generationDurationMs ?? 0}
+                  generationReliable={agentStatus.generationReliable ?? true}
+                  generationActive={agentStatus.generationActive ?? false}
                   startedAt={agentStatus.startedAt}
                   visible={!pendingPlanReview && (agentStatus.isRunning || backgroundTasksActive)}
                   inputWidth={inputWidth}
@@ -4908,6 +4915,10 @@ function getControlledBannerMaxWidth(inputWidth?: number): number {
 function RunningStatusBar({
   status,
   tokenUsage,
+  outputTokens = 0,
+  generationDurationMs = 0,
+  generationReliable = true,
+  generationActive = false,
   startedAt,
   visible,
   inputWidth,
@@ -4922,12 +4933,16 @@ function RunningStatusBar({
 }: {
   status: string;
   tokenUsage: number;
+  outputTokens?: number;
+  generationDurationMs?: number;
+  generationReliable?: boolean;
+  generationActive?: boolean;
   startedAt: number | null;
   visible: boolean;
   inputWidth?: number;
   /**
    * 当前是否处于 side-task (mivo MJ 按钮等不走 LLM 的后台任务) 运行态。
-   * true 时隐藏右侧的 elapsed · ↓ tokens 行 —— mivo 不消耗 token, 显示上一轮
+   * true 时隐藏右侧的 elapsed · rate 行 —— mivo 不消耗 token, 显示上一轮
    * 残留数字会误导用户。"Done" check icon 也不显示 (sideTaskRunning 期间永远
    * 把 status 当成进行中, 即便 status 文案恰好是 "Done")。
    */
@@ -5052,16 +5067,28 @@ function RunningStatusBar({
     }
     shimmerPlayingRef.current = true;
     setShimmerCycle((n) => n + 1);
-  }, [visible, suppressContent, reducedMotion, status, tokenUsage]);
+  }, [visible, suppressContent, reducedMotion, status, tokenUsage, outputTokens, generationDurationMs]);
 
-  // Animate the token counter so live mid-turn updates (from message_delta in
-  // agentManager) feel like a smoothly-incrementing number, the same way claude
-  // code's CLI status line ticks. The hook re-anchors from the displayed value
-  // on every target change, so rapid updates blend without snap-back.
+  // Animate the token counter so live mid-turn updates feel like a smoothly-
+  // incrementing number. Rate does not use this: locally ticking the
+  // denominator would make a paused model look like decaying speed.
   const animatedTokens = useAnimatedNumber(tokenUsage, 400);
-  const tokenText = t('chat.messageActionBar.turnTokens', {
-    tokens: formatRunningTokenCount(animatedTokens, visible),
+  const usageMeta = resolveRunningUsageMeta({
+    outputTokens,
+    generationDurationMs,
+    generationReliable,
+    tokenUsage,
   });
+  const tokenCountText = t('chat.runningStatus.tokenCount', {
+    tokens: formatRunningTokenCount(animatedTokens),
+  });
+  const tokenCountTipText = t('chat.messageActionBar.turnTokens', {
+    tokens: formatRunningTokenCount(animatedTokens),
+  });
+  const rateText =
+    usageMeta.kind === 'rate'
+      ? t('chat.runningStatus.tokenRate', { rate: usageMeta.rate })
+      : null;
 
   // 淡入淡出/隐藏占位样式 —— 同时作用于左(状态)、右(elapsed/tokens)两段。
   // visibility:hidden 只隐藏不收高,让 linger / fade 阶段稳定;淡出结束后整个
@@ -5168,15 +5195,31 @@ function RunningStatusBar({
                 <span className="text-13 font-medium text-[var(--status-bar-meta)]">
                   {elapsedText}
                 </span>
-                {!sideTaskRunning && (
+                {!sideTaskRunning && usageMeta.kind !== 'none' && (
                   <>
                     <span className="text-13 font-medium text-[var(--status-bar-meta)]">
                       &middot;
                     </span>
-                    <ArrowDown size={13} className="shrink-0 text-[var(--status-bar-meta)]" />
-                    <span className="text-13 font-medium text-[var(--status-bar-meta)]">
-                      {tokenText}
-                    </span>
+                    {rateText ? (
+                      tokenUsage > 0 ? (
+                        <Tip text={tokenCountTipText} side="top">
+                          <span className="text-13 font-medium text-[var(--status-bar-meta)]">
+                            {rateText}
+                          </span>
+                        </Tip>
+                      ) : (
+                        <span className="text-13 font-medium text-[var(--status-bar-meta)]">
+                          {rateText}
+                        </span>
+                      )
+                    ) : (
+                      <>
+                        <ArrowDown size={13} className="shrink-0 text-[var(--status-bar-meta)]" />
+                        <span className="text-13 font-medium text-[var(--status-bar-meta)]">
+                          {tokenCountText}
+                        </span>
+                      </>
+                    )}
                   </>
                 )}
               </>

--- a/apps/desktop/src/renderer/features/cc-agent/lib/runningTokenUsage.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/lib/runningTokenUsage.ts
@@ -1,6 +1,43 @@
-export function formatRunningTokenCount(tokenUsage: number, isRunning: boolean): string {
-  if (isRunning && tokenUsage === 0) return '—';
+import { formatOutputTokenRateValue } from '@/lib/turnUsageTooltip';
+
+export function formatRunningTokenCount(tokenUsage: number): string {
   return tokenUsage >= 1000
     ? `${(tokenUsage / 1000).toFixed(1)}k`
     : `${tokenUsage}`;
+}
+
+export function formatLiveOutputTokenRate(
+  outputTokens: number,
+  durationMs: number,
+  generationReliable: boolean,
+): string | null {
+  if (!generationReliable) return null;
+  return formatOutputTokenRateValue(outputTokens, durationMs);
+}
+
+export type RunningUsageMeta =
+  | { kind: 'rate'; rate: string }
+  | { kind: 'tokens' }
+  | { kind: 'none' };
+
+/**
+ * Live status prefers generation-only TPS when the harness can prove it.
+ * Otherwise fall back to cumulative tokens as soon as they exist. Hiding
+ * tokens for the whole `generationActive` window leaves a long empty timer
+ * because live output often arrives only at message end.
+ */
+export function resolveRunningUsageMeta(input: {
+  outputTokens: number;
+  generationDurationMs: number;
+  generationReliable: boolean;
+  tokenUsage: number;
+}): RunningUsageMeta {
+  const rate = formatLiveOutputTokenRate(
+    input.outputTokens,
+    input.generationDurationMs,
+    input.generationReliable,
+  );
+  if (rate) return { kind: 'rate', rate };
+  if (input.tokenUsage > 0) return { kind: 'tokens' };
+  return { kind: 'none' };
 }

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -6775,6 +6775,10 @@
       "turnTokens": "{{tokens}} tokens",
       "userTurnCostDetailsTitle": "Request details"
     },
+    "runningStatus": {
+      "tokenRate": "{{rate}} tok/s",
+      "tokenCount": "{{tokens}} tok"
+    },
     "shareImage": {
       "entry": "Share as Image",
       "title": "Share Conversation",

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -4988,7 +4988,7 @@
     "timeLine": "時間 {{duration}}",
     "costLine": "このターンの消費: {{cost}}",
     "valueLine": "このターンの token 価値: {{cost}}",
-    "tokenLine": "Token: 合計 {{total}} · 入力 {{input}} · 出力 {{output}}",
+    "tokenLine": "トークン: 合計 {{total}} · 入力 {{input}} · 出力 {{output}}",
     "cacheLine": "キャッシュ内訳: 読み取り {{read}} · 書き込み {{create}} · ヒット率 {{rate}}",
     "cacheLineNoRate": "キャッシュ内訳: 読み取り {{read}} · 書き込み {{create}}",
     "modelLine": "モデル: {{model}}",
@@ -6772,6 +6772,10 @@
       "turnCostEstimatedValue": "価値 {{cost}}",
       "turnTokens": "{{tokens}} tokens",
       "userTurnCostDetailsTitle": "リクエストの明細"
+    },
+    "runningStatus": {
+      "tokenRate": "{{rate}} tok/s",
+      "tokenCount": "{{tokens}} tok"
     },
     "shareImage": {
       "entry": "画像として共有",

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -4988,7 +4988,7 @@
     "timeLine": "시간 {{duration}}",
     "costLine": "이번 턴 비용: {{cost}}",
     "valueLine": "이번 턴 토큰 가치: {{cost}}",
-    "tokenLine": "Token: 총 {{total}} · 입력 {{input}} · 출력 {{output}}",
+    "tokenLine": "토큰: 총 {{total}} · 입력 {{input}} · 출력 {{output}}",
     "cacheLine": "캐시 세부: 읽기 {{read}} · 쓰기 {{create}} · 적중률 {{rate}}",
     "cacheLineNoRate": "캐시 세부: 읽기 {{read}} · 쓰기 {{create}}",
     "modelLine": "모델: {{model}}",
@@ -6772,6 +6772,10 @@
       "turnCostEstimatedValue": "가치 {{cost}}",
       "turnTokens": "{{tokens}} tokens",
       "userTurnCostDetailsTitle": "이번 요청 상세"
+    },
+    "runningStatus": {
+      "tokenRate": "{{rate}} tok/s",
+      "tokenCount": "{{tokens}} tok"
     },
     "shareImage": {
       "entry": "이미지로 공유",

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -4972,7 +4972,7 @@
     "tokenBreakdown": "（输入 {{input}} · 输出 {{output}}）",
     "cacheLabel": "缓存",
     "timeLabel": "耗时",
-    "timeAndRateValue": "{{duration}} 速度：{{rate}} token/秒",
+    "timeAndRateValue": "{{duration}} 速度：{{rate}} tokens/秒",
     "modelLabel": "模型",
     "staleData": "数据更新于 {{minutes}} 分钟前",
     "paceTrendFast": "按当前平均速度偏快（粗略趋势）",
@@ -4983,12 +4983,12 @@
   "usageDetails": {
     "durationSeconds": "{{value}}秒",
     "durationMinutesSeconds": "{{minutes}}分 {{seconds}}秒",
-    "performanceLine": "速度 {{rate}} token/秒 · 耗时 {{duration}}",
-    "performanceRateLine": "速度 {{rate}} token/秒",
+    "performanceLine": "速度 {{rate}} tokens/秒 · 耗时 {{duration}}",
+    "performanceRateLine": "速度 {{rate}} tokens/秒",
     "timeLine": "耗时 {{duration}}",
     "costLine": "本轮消耗：{{cost}}",
     "valueLine": "本轮 token 价值：{{cost}}",
-    "tokenLine": "Token：共 {{total}} · 输入 {{input}} · 输出 {{output}}",
+    "tokenLine": "Tokens：共 {{total}} · 输入 {{input}} · 输出 {{output}}",
     "cacheLine": "缓存拆分：读取 {{read}} · 写入 {{create}} · 命中率 {{rate}}",
     "cacheLineNoRate": "缓存拆分：读取 {{read}} · 写入 {{create}}",
     "modelLine": "模型：{{model}}",
@@ -6772,6 +6772,10 @@
       "turnCostEstimatedValue": "价值 {{cost}}",
       "turnTokens": "{{tokens}} tokens",
       "userTurnCostDetailsTitle": "本轮明细"
+    },
+    "runningStatus": {
+      "tokenRate": "{{rate}} tok/s",
+      "tokenCount": "{{tokens}} tok"
     },
     "shareImage": {
       "entry": "分享为图片",

--- a/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
@@ -4972,7 +4972,7 @@
     "tokenBreakdown": "（輸入 {{input}} · 輸出 {{output}}）",
     "cacheLabel": "快取",
     "timeLabel": "耗時",
-    "timeAndRateValue": "{{duration}} 速度：{{rate}} token/秒",
+    "timeAndRateValue": "{{duration}} 速度：{{rate}} tokens/秒",
     "modelLabel": "模型",
     "staleData": "資料更新於 {{minutes}} 分鐘前",
     "paceTrendFast": "按目前平均速度偏快（粗略趨勢）",
@@ -4983,12 +4983,12 @@
   "usageDetails": {
     "durationSeconds": "{{value}}秒",
     "durationMinutesSeconds": "{{minutes}}分 {{seconds}}秒",
-    "performanceLine": "速度 {{rate}} token/秒 · 耗時 {{duration}}",
-    "performanceRateLine": "速度 {{rate}} token/秒",
+    "performanceLine": "速度 {{rate}} tokens/秒 · 耗時 {{duration}}",
+    "performanceRateLine": "速度 {{rate}} tokens/秒",
     "timeLine": "耗時 {{duration}}",
     "costLine": "本輪消耗：{{cost}}",
     "valueLine": "本輪 token 價值：{{cost}}",
-    "tokenLine": "Token：共 {{total}} · 輸入 {{input}} · 輸出 {{output}}",
+    "tokenLine": "Tokens：共 {{total}} · 輸入 {{input}} · 輸出 {{output}}",
     "cacheLine": "快取拆分：讀取 {{read}} · 寫入 {{create}} · 命中率 {{rate}}",
     "cacheLineNoRate": "快取拆分：讀取 {{read}} · 寫入 {{create}}",
     "modelLine": "模型：{{model}}",
@@ -6771,6 +6771,10 @@
       "turnCostEstimatedValue": "價值 {{cost}}",
       "turnTokens": "{{tokens}} tokens",
       "userTurnCostDetailsTitle": "本輪明細"
+    },
+    "runningStatus": {
+      "tokenRate": "{{rate}} tok/s",
+      "tokenCount": "{{tokens}} tok"
     },
     "shareImage": {
       "entry": "分享為圖片",

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -5895,14 +5895,18 @@ function mergeLiveGenerationStatus(
   AgentStatus,
   'outputTokens' | 'generationDurationMs' | 'generationActive' | 'generationReliable'
 > {
-  if (isTurnStart) {
-    return {
-      outputTokens: 0,
-      generationDurationMs: 0,
-      generationActive: false,
-      generationReliable: true,
-    };
-  }
+  // Turn start drops leftover metrics from the previous turn, then keeps any
+  // live fields carried by this same status. A reconnect-shaped first event
+  // (isRunning false→true with output / duration already present) must not
+  // zero the values that just arrived.
+  const baseline = isTurnStart
+    ? {
+        outputTokens: 0,
+        generationDurationMs: 0,
+        generationActive: false,
+        generationReliable: true,
+      }
+    : previous;
   const hasLiveFields =
     typeof update.outputTokens === 'number' ||
     typeof update.generationDurationMs === 'number' ||
@@ -5910,27 +5914,27 @@ function mergeLiveGenerationStatus(
     typeof update.generationReliable === 'boolean';
   if (!hasLiveFields) {
     return {
-      outputTokens: previous.outputTokens,
-      generationDurationMs: previous.generationDurationMs,
-      generationActive: previous.generationActive,
-      generationReliable: previous.generationReliable,
+      outputTokens: baseline.outputTokens,
+      generationDurationMs: baseline.generationDurationMs,
+      generationActive: update.isRunning ? baseline.generationActive : false,
+      generationReliable: baseline.generationReliable,
     };
   }
   const merged = {
     outputTokens:
-      typeof update.outputTokens === 'number' ? update.outputTokens : previous.outputTokens,
+      typeof update.outputTokens === 'number' ? update.outputTokens : baseline.outputTokens,
     generationDurationMs:
       typeof update.generationDurationMs === 'number'
         ? update.generationDurationMs
-        : previous.generationDurationMs,
+        : baseline.generationDurationMs,
     generationActive:
       typeof update.generationActive === 'boolean'
         ? update.generationActive
-        : previous.generationActive,
+        : baseline.generationActive,
     generationReliable:
       typeof update.generationReliable === 'boolean'
         ? update.generationReliable
-        : previous.generationReliable,
+        : baseline.generationReliable,
   };
   if (!update.isRunning) {
     return { ...merged, generationActive: false };

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -630,6 +630,14 @@ export interface AgentStatus {
   contextWindow: number;
   isRunning: boolean;
   startedAt: number | null;
+  /** Turn-cumulative output tokens for live TPS. */
+  outputTokens?: number;
+  /** Generation-only milliseconds including any open interval at emit time. */
+  generationDurationMs?: number;
+  /** True while the model currently owns the turn. */
+  generationActive?: boolean;
+  /** False hides live TPS. Omitted on placeholder status frames. */
+  generationReliable?: boolean;
   /**
    * Side-channel running (mivo MJ 按钮等不走 LLM 的后台任务)。
    * RunningStatusBar 据此把 token 计数行隐藏掉, 避免显示"上一轮残留 718 tokens"
@@ -5879,6 +5887,57 @@ function forceFinalizeOnSessionClosed(state: SessionChatState): SessionChatState
   };
 }
 
+function mergeLiveGenerationStatus(
+  isTurnStart: boolean,
+  update: CCAgentStatusUpdate,
+  previous: AgentStatus,
+): Pick<
+  AgentStatus,
+  'outputTokens' | 'generationDurationMs' | 'generationActive' | 'generationReliable'
+> {
+  if (isTurnStart) {
+    return {
+      outputTokens: 0,
+      generationDurationMs: 0,
+      generationActive: false,
+      generationReliable: true,
+    };
+  }
+  const hasLiveFields =
+    typeof update.outputTokens === 'number' ||
+    typeof update.generationDurationMs === 'number' ||
+    typeof update.generationActive === 'boolean' ||
+    typeof update.generationReliable === 'boolean';
+  if (!hasLiveFields) {
+    return {
+      outputTokens: previous.outputTokens,
+      generationDurationMs: previous.generationDurationMs,
+      generationActive: previous.generationActive,
+      generationReliable: previous.generationReliable,
+    };
+  }
+  const merged = {
+    outputTokens:
+      typeof update.outputTokens === 'number' ? update.outputTokens : previous.outputTokens,
+    generationDurationMs:
+      typeof update.generationDurationMs === 'number'
+        ? update.generationDurationMs
+        : previous.generationDurationMs,
+    generationActive:
+      typeof update.generationActive === 'boolean'
+        ? update.generationActive
+        : previous.generationActive,
+    generationReliable:
+      typeof update.generationReliable === 'boolean'
+        ? update.generationReliable
+        : previous.generationReliable,
+  };
+  if (!update.isRunning) {
+    return { ...merged, generationActive: false };
+  }
+  return merged;
+}
+
 function handleStatusUpdate(
   state: SessionChatState,
   update: CCAgentStatusUpdate,
@@ -5992,6 +6051,7 @@ function handleStatusUpdate(
       contextWindow: cw,
       isRunning: update.isRunning,
       startedAt,
+      ...mergeLiveGenerationStatus(isTurnStart, update, state.agentStatus),
     },
     activeTurnRetryText: isTurnComplete ? null : state.activeTurnRetryText,
     continuationTurnClientId: update.isRunning ? state.continuationTurnClientId : null,

--- a/apps/desktop/src/renderer/lib/turnUsageTooltip.ts
+++ b/apps/desktop/src/renderer/lib/turnUsageTooltip.ts
@@ -30,20 +30,28 @@ function formatTokens(value: number): string {
   return formatCompactTokens(Math.max(0, Math.floor(value)));
 }
 
-export function formatOutputTokenRate(details: TurnUsageDetails): string | null {
-  const durationMs = details.durationMs;
+export function formatOutputTokenRateValue(
+  outputTokens: number,
+  durationMs: number,
+): string | null {
   if (
-    details.outputTokens <= 0 ||
+    outputTokens <= 0 ||
     typeof durationMs !== 'number' ||
     !Number.isFinite(durationMs) ||
     durationMs <= 0
   ) {
     return null;
   }
-  const rate = (details.outputTokens * 1000) / durationMs;
+  const rate = (outputTokens * 1000) / durationMs;
   if (!Number.isFinite(rate) || rate <= 0) return null;
   if (rate < 0.1) return '<0.1';
   return rate >= 100 ? rate.toFixed(0) : rate.toFixed(1).replace(/\.0$/, '');
+}
+
+export function formatOutputTokenRate(details: TurnUsageDetails): string | null {
+  return typeof details.durationMs === 'number'
+    ? formatOutputTokenRateValue(details.outputTokens, details.durationMs)
+    : null;
 }
 
 export function formatTurnDuration(durationMs: number, t?: TFunction): string | null {

--- a/apps/desktop/src/renderer/vite-env.d.ts
+++ b/apps/desktop/src/renderer/vite-env.d.ts
@@ -782,6 +782,10 @@ interface CCAgentStatusUpdate {
   costUsd?: number;
   contextTokens: number;
   contextWindow: number;
+  outputTokens?: number;
+  generationDurationMs?: number;
+  generationActive?: boolean;
+  generationReliable?: boolean;
   isRunning: boolean;
   /** Host-owned SDK boundary claim; a claimed `status(false)` is not product idle. */
   turnContinuationId?: number;

--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -9477,6 +9477,10 @@ export default function SessionScreen() {
                     sideTaskRunning={remoteSessionRunStatus.sideTaskRunning}
                     startedAt={composerActivityStartedAtMs}
                     tokenUsage={composerActivityTokenUsage}
+                    outputTokens={remoteSessionRunStatus.outputTokens}
+                    generationDurationMs={remoteSessionRunStatus.generationDurationMs}
+                    generationReliable={remoteSessionRunStatus.generationReliable}
+                    generationActive={remoteSessionRunStatus.generationActive}
                     visible={showComposerActivity}
                   />
                 </View>
@@ -10332,12 +10336,20 @@ function ComposerActivityStatus({
   sideTaskRunning,
   startedAt,
   tokenUsage,
+  outputTokens,
+  generationDurationMs,
+  generationReliable,
+  generationActive,
   visible,
 }: {
   reconnectAttempt: RemoteSessionRunStatus['reconnectAttempt'];
   sideTaskRunning: boolean;
   startedAt: number | null;
   tokenUsage: number;
+  outputTokens: number;
+  generationDurationMs: number;
+  generationReliable: boolean;
+  generationActive: boolean;
   visible: boolean;
 }) {
   const styles = useThemedStyles(makeStyles);
@@ -10362,6 +10374,13 @@ function ComposerActivityStatus({
 
   const elapsedText = formatComposerActivityElapsed(elapsed);
   const tokenText = formatComposerActivityTokens(tokenUsage);
+  const tokenA11yText = formatComposerActivityTokens(tokenUsage, { compact: false });
+  const rateText = formatComposerActivityRate(
+    outputTokens,
+    generationDurationMs,
+    generationReliable,
+  );
+  const showUsageMeta = Boolean(rateText) || tokenUsage > 0;
   // 三类进度共用这一个 attempt 字段, 但说法必须分开: 模型容量、请求限流与传输层重连
   // 的用户含义不同，混用会把用户引向错误的排查方向。
   const activityText = reconnectAttempt
@@ -10391,11 +10410,22 @@ function ComposerActivityStatus({
       </View>
       <View style={styles.composerActivityMeta}>
         <Text style={styles.composerActivityMetaText}>{elapsedText}</Text>
-        {!sideTaskRunning ? (
+        {!sideTaskRunning && showUsageMeta ? (
           <>
             <Text style={styles.composerActivityMetaText}>·</Text>
-            <ArrowDown color={colors.textSecondary} size={iconSize.xs} strokeWidth={iconStroke.regular} />
-            <Text style={styles.composerActivityMetaText}>{tokenText}</Text>
+            {rateText ? (
+              <Text
+                accessibilityLabel={tokenUsage > 0 ? tokenA11yText : undefined}
+                style={styles.composerActivityMetaText}
+              >
+                {rateText}
+              </Text>
+            ) : (
+              <>
+                <ArrowDown color={colors.textSecondary} size={iconSize.xs} strokeWidth={iconStroke.regular} />
+                <Text style={styles.composerActivityMetaText}>{tokenText}</Text>
+              </>
+            )}
           </>
         ) : null}
       </View>
@@ -10410,10 +10440,28 @@ function formatComposerActivityElapsed(seconds: number): string {
   return minutes > 0 ? `${minutes}m ${rest}s` : `${rest}s`;
 }
 
-function formatComposerActivityTokens(tokenUsage: number): string {
+function formatComposerActivityTokens(
+  tokenUsage: number,
+  options?: { compact?: boolean },
+): string {
   const safeTokens = Math.max(0, Math.round(tokenUsage));
-  if (safeTokens >= 1000) return `${(safeTokens / 1000).toFixed(1)}k tokens`;
-  return `${safeTokens} tokens`;
+  const unit = options?.compact === false ? 'tokens' : 'tok';
+  if (safeTokens >= 1000) return `${(safeTokens / 1000).toFixed(1)}k ${unit}`;
+  return `${safeTokens} ${unit}`;
+}
+
+function formatComposerActivityRate(
+  outputTokens: number,
+  durationMs: number,
+  generationReliable: boolean,
+): string | null {
+  if (!generationReliable || outputTokens <= 0 || !Number.isFinite(durationMs) || durationMs <= 0) {
+    return null;
+  }
+  const rate = (outputTokens * 1000) / durationMs;
+  if (!Number.isFinite(rate) || rate <= 0) return null;
+  const formatted = rate < 0.1 ? '<0.1' : rate >= 100 ? rate.toFixed(0) : rate.toFixed(1).replace(/\.0$/, '');
+  return `${formatted} tok/s`;
 }
 
 function ComposerPaletteRow({

--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -10419,7 +10419,7 @@ function ComposerActivityStatus({
             <Text style={styles.composerActivityMetaText}>·</Text>
             {rateText ? (
               <Text
-                accessibilityLabel={tokenUsage > 0 ? tokenA11yText : undefined}
+                accessibilityLabel={rateText}
                 style={styles.composerActivityMetaText}
               >
                 {rateText}
@@ -10427,7 +10427,12 @@ function ComposerActivityStatus({
             ) : (
               <>
                 <ArrowDown color={colors.textSecondary} size={iconSize.xs} strokeWidth={iconStroke.regular} />
-                <Text style={styles.composerActivityMetaText}>{tokenText}</Text>
+                <Text
+                  accessibilityLabel={tokenA11yText}
+                  style={styles.composerActivityMetaText}
+                >
+                  {tokenText}
+                </Text>
               </>
             )}
           </>

--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -10373,13 +10373,17 @@ function ComposerActivityStatus({
   if (!visible) return null;
 
   const elapsedText = formatComposerActivityElapsed(elapsed);
-  const tokenText = formatComposerActivityTokens(tokenUsage);
-  const tokenA11yText = formatComposerActivityTokens(tokenUsage, { compact: false });
-  const rateText = formatComposerActivityRate(
+  const tokenCount = formatComposerActivityTokenCount(tokenUsage);
+  const tokenText = t('session.screen.tokenCount', { tokens: tokenCount });
+  const tokenA11yText = t('session.screen.tokenCountFull', { tokens: tokenCount });
+  const rateValue = formatComposerActivityRateValue(
     outputTokens,
     generationDurationMs,
     generationReliable,
   );
+  const rateText = rateValue
+    ? t('session.screen.tokenRate', { rate: rateValue })
+    : null;
   const showUsageMeta = Boolean(rateText) || tokenUsage > 0;
   // 三类进度共用这一个 attempt 字段, 但说法必须分开: 模型容量、请求限流与传输层重连
   // 的用户含义不同，混用会把用户引向错误的排查方向。
@@ -10440,17 +10444,12 @@ function formatComposerActivityElapsed(seconds: number): string {
   return minutes > 0 ? `${minutes}m ${rest}s` : `${rest}s`;
 }
 
-function formatComposerActivityTokens(
-  tokenUsage: number,
-  options?: { compact?: boolean },
-): string {
+function formatComposerActivityTokenCount(tokenUsage: number): string {
   const safeTokens = Math.max(0, Math.round(tokenUsage));
-  const unit = options?.compact === false ? 'tokens' : 'tok';
-  if (safeTokens >= 1000) return `${(safeTokens / 1000).toFixed(1)}k ${unit}`;
-  return `${safeTokens} ${unit}`;
+  return safeTokens >= 1000 ? `${(safeTokens / 1000).toFixed(1)}k` : `${safeTokens}`;
 }
 
-function formatComposerActivityRate(
+function formatComposerActivityRateValue(
   outputTokens: number,
   durationMs: number,
   generationReliable: boolean,
@@ -10460,8 +10459,7 @@ function formatComposerActivityRate(
   }
   const rate = (outputTokens * 1000) / durationMs;
   if (!Number.isFinite(rate) || rate <= 0) return null;
-  const formatted = rate < 0.1 ? '<0.1' : rate >= 100 ? rate.toFixed(0) : rate.toFixed(1).replace(/\.0$/, '');
-  return `${formatted} tok/s`;
+  return rate < 0.1 ? '<0.1' : rate >= 100 ? rate.toFixed(0) : rate.toFixed(1).replace(/\.0$/, '');
 }
 
 function ComposerPaletteRow({

--- a/apps/mobile/src/__tests__/remoteSessionStore.test.ts
+++ b/apps/mobile/src/__tests__/remoteSessionStore.test.ts
@@ -2177,6 +2177,61 @@ describe('remoteSessionStore', () => {
     vi.useRealTimers();
   });
 
+  it('keeps live generation fields from the first post-reconnect status', () => {
+    remoteSessionStore.setDeviceSessions('dev-1', 'Mac', [session('s1')]);
+    pushMakerStatus('s1', {
+      isRunning: true,
+      outputTokens: 12,
+      generationDurationMs: 400,
+      generationActive: true,
+      generationReliable: true,
+    });
+    remoteSessionStore.markDeviceOffline('dev-1');
+    expect(remoteSessionStore.isSessionMakerTurnRunning('s1')).toBe(false);
+
+    remoteSessionStore.setActiveSessionSnapshots('dev-1', [{ sessionId: 's1', isTurnRunning: true }]);
+    expect(remoteSessionStore.getSessionRunStatus('s1').isRunning).toBe(true);
+    expect(remoteSessionStore.isSessionMakerTurnRunning('s1')).toBe(false);
+
+    pushMakerStatus('s1', {
+      isRunning: true,
+      status: 'Generating...',
+      tokenUsage: 235,
+      outputTokens: 40,
+      generationDurationMs: 800,
+      generationActive: true,
+      generationReliable: true,
+    });
+    expect(remoteSessionStore.getSessionRunStatus('s1')).toMatchObject({
+      isRunning: true,
+      tokenUsage: 235,
+      outputTokens: 40,
+      generationDurationMs: 800,
+      generationActive: true,
+      generationReliable: true,
+    });
+  });
+
+  it('still zeros leftover live metrics when a new turn starts without them', () => {
+    remoteSessionStore.setDeviceSessions('dev-1', 'Mac', [session('s1')]);
+    pushMakerStatus('s1', {
+      isRunning: true,
+      outputTokens: 99,
+      generationDurationMs: 5_000,
+      generationActive: true,
+      generationReliable: false,
+    });
+    pushMakerStatus('s1', { isRunning: false });
+    pushMakerStatus('s1', { isRunning: true, status: 'Thinking' });
+    expect(remoteSessionStore.getSessionRunStatus('s1')).toMatchObject({
+      isRunning: true,
+      outputTokens: 0,
+      generationDurationMs: 0,
+      generationActive: false,
+      generationReliable: true,
+    });
+  });
+
   it('clears leftover task updates on a real turn start, scoped to that session', () => {
     // Turn 1 on s1 spawns a sub-agent, then the turn ends — the live update lingers.
     pushMakerStatus('s1', { isRunning: true });

--- a/apps/mobile/src/__tests__/remoteSessionStore.test.ts
+++ b/apps/mobile/src/__tests__/remoteSessionStore.test.ts
@@ -2232,6 +2232,28 @@ describe('remoteSessionStore', () => {
     });
   });
 
+  it('clears leftover tok/s when activity restores wide running before the next maker status', () => {
+    remoteSessionStore.setDeviceSessions('dev-1', 'Mac', [session('s1')]);
+    pushMakerStatus('s1', {
+      isRunning: true,
+      outputTokens: 40,
+      generationDurationMs: 800,
+      generationActive: true,
+      generationReliable: true,
+    });
+    pushMakerStatus('s1', { isRunning: false });
+    expect(remoteSessionStore.getSessionRunStatus('s1').outputTokens).toBe(40);
+
+    remoteSessionStore.applySessionActivity('dev-1', { sessionId: 's1', phase: 'running' });
+    expect(remoteSessionStore.getSessionRunStatus('s1')).toMatchObject({
+      isRunning: true,
+      outputTokens: 0,
+      generationDurationMs: 0,
+      generationActive: false,
+      generationReliable: true,
+    });
+  });
+
   it('clears leftover task updates on a real turn start, scoped to that session', () => {
     // Turn 1 on s1 spawns a sub-agent, then the turn ends — the live update lingers.
     pushMakerStatus('s1', { isRunning: true });

--- a/apps/mobile/src/__tests__/sessionComposerDesktopFirst.test.ts
+++ b/apps/mobile/src/__tests__/sessionComposerDesktopFirst.test.ts
@@ -170,7 +170,6 @@ describe('mobile session composer desktop-first surface', () => {
     expect(source).toContain("'session.screen.modelBusyRetrying'");
     expect(source).toContain("'session.screen.rateLimitRetrying'");
     expect(source).toContain('{reconnectAttempt.attempt}/{reconnectAttempt.maxAttempts}');
-    expect(source).toContain('ArrowDown');
     expect(source).toContain('useSessionRunStatus');
     expect(source).toContain('remoteSessionRunStatus.tokenUsage');
     expect(source).toContain('remoteSessionRunStatus.startedAt ?? composerActivityStartedAt');
@@ -178,9 +177,17 @@ describe('mobile session composer desktop-first surface', () => {
     expect(source).toContain('sideTaskRunning={remoteSessionRunStatus.sideTaskRunning}');
     expect(source).toContain('startedAt={composerActivityStartedAtMs}');
     expect(source).toContain('tokenUsage={composerActivityTokenUsage}');
-    expect(source).toContain('{!sideTaskRunning ? (');
+    expect(source).toContain('outputTokens={remoteSessionRunStatus.outputTokens}');
+    expect(source).toContain('generationDurationMs={remoteSessionRunStatus.generationDurationMs}');
+    expect(source).toContain('ArrowDown');
+    expect(source).toContain('{!sideTaskRunning && showUsageMeta ? (');
+    expect(source).toContain('generationActive={remoteSessionRunStatus.generationActive}');
+    expect(source).toContain('const showUsageMeta = Boolean(rateText) || tokenUsage > 0;');
+    expect(source).toContain('return `${formatted} tok/s`;');
+    expect(source).toContain("const unit = options?.compact === false ? 'tokens' : 'tok';");
     expect(source).toContain('function formatComposerActivityElapsed');
     expect(source).toContain('function formatComposerActivityTokens');
+    expect(source).toContain('function formatComposerActivityRate');
     expect(source).toContain('composerActivityPrimary');
     expect(source).toContain('composerActivityMeta');
     expect(source).toContain('composerActivityMetaText');
@@ -688,6 +695,7 @@ describe('mobile session composer desktop-first surface', () => {
     expect(source).not.toContain('voiceDuration');
     expect(source).not.toContain('recordingDuration');
     expect(source).not.toContain('formatVoiceDuration');
-    expect(source).not.toContain('durationMs');
+    expect(source).not.toContain('voiceDurationMs');
+    expect(source).not.toMatch(/(?:const|let)\s+durationMs\b/);
   });
 });

--- a/apps/mobile/src/__tests__/sessionComposerDesktopFirst.test.ts
+++ b/apps/mobile/src/__tests__/sessionComposerDesktopFirst.test.ts
@@ -186,6 +186,9 @@ describe('mobile session composer desktop-first surface', () => {
     expect(source).toContain("t('session.screen.tokenCount'");
     expect(source).toContain("t('session.screen.tokenCountFull'");
     expect(source).toContain("t('session.screen.tokenRate'");
+    expect(source).toContain('accessibilityLabel={rateText}');
+    expect(source).toContain('accessibilityLabel={tokenA11yText}');
+    expect(source).not.toContain('accessibilityLabel={tokenUsage > 0 ? tokenA11yText : undefined}');
     expect(source).toContain('function formatComposerActivityElapsed');
     expect(source).toContain('function formatComposerActivityTokenCount');
     expect(source).toContain('function formatComposerActivityRateValue');

--- a/apps/mobile/src/__tests__/sessionComposerDesktopFirst.test.ts
+++ b/apps/mobile/src/__tests__/sessionComposerDesktopFirst.test.ts
@@ -183,11 +183,12 @@ describe('mobile session composer desktop-first surface', () => {
     expect(source).toContain('{!sideTaskRunning && showUsageMeta ? (');
     expect(source).toContain('generationActive={remoteSessionRunStatus.generationActive}');
     expect(source).toContain('const showUsageMeta = Boolean(rateText) || tokenUsage > 0;');
-    expect(source).toContain('return `${formatted} tok/s`;');
-    expect(source).toContain("const unit = options?.compact === false ? 'tokens' : 'tok';");
+    expect(source).toContain("t('session.screen.tokenCount'");
+    expect(source).toContain("t('session.screen.tokenCountFull'");
+    expect(source).toContain("t('session.screen.tokenRate'");
     expect(source).toContain('function formatComposerActivityElapsed');
-    expect(source).toContain('function formatComposerActivityTokens');
-    expect(source).toContain('function formatComposerActivityRate');
+    expect(source).toContain('function formatComposerActivityTokenCount');
+    expect(source).toContain('function formatComposerActivityRateValue');
     expect(source).toContain('composerActivityPrimary');
     expect(source).toContain('composerActivityMeta');
     expect(source).toContain('composerActivityMetaText');

--- a/apps/mobile/src/i18n/locales/en/session.json
+++ b/apps/mobile/src/i18n/locales/en/session.json
@@ -26,6 +26,9 @@
   },
   "screen": {
     "thinking": "Thinking…",
+    "tokenCount": "{{tokens}} tok",
+    "tokenCountFull": "{{tokens}} tokens",
+    "tokenRate": "{{rate}} tok/s",
     "networkReconnecting": "Reconnecting…",
     "modelBusyRetrying": "Model service busy — retrying…",
     "rateLimitRetrying": "Request rate limited — retrying…",

--- a/apps/mobile/src/i18n/locales/ja/session.json
+++ b/apps/mobile/src/i18n/locales/ja/session.json
@@ -26,6 +26,9 @@
   },
   "screen": {
     "thinking": "考えています…",
+    "tokenCount": "{{tokens}} tok",
+    "tokenCountFull": "{{tokens}} tokens",
+    "tokenRate": "{{rate}} tok/s",
     "networkReconnecting": "再接続中…",
     "modelBusyRetrying": "モデルサービスが混雑、再試行中…",
     "rateLimitRetrying": "リクエストがレート制限されました。再試行中…",

--- a/apps/mobile/src/i18n/locales/ko/session.json
+++ b/apps/mobile/src/i18n/locales/ko/session.json
@@ -26,6 +26,9 @@
   },
   "screen": {
     "thinking": "생각 중…",
+    "tokenCount": "{{tokens}} tok",
+    "tokenCountFull": "{{tokens}} tokens",
+    "tokenRate": "{{rate}} tok/s",
     "networkReconnecting": "다시 연결하는 중…",
     "modelBusyRetrying": "모델 서비스 혼잡, 다시 시도 중…",
     "rateLimitRetrying": "요청이 속도 제한에 걸렸습니다. 다시 시도 중…",

--- a/apps/mobile/src/i18n/locales/zh-CN/session.json
+++ b/apps/mobile/src/i18n/locales/zh-CN/session.json
@@ -26,6 +26,9 @@
   },
   "screen": {
     "thinking": "思考中…",
+    "tokenCount": "{{tokens}} tok",
+    "tokenCountFull": "{{tokens}} tokens",
+    "tokenRate": "{{rate}} tok/s",
     "networkReconnecting": "正在重新连接…",
     "modelBusyRetrying": "模型服务繁忙，正在重试…",
     "rateLimitRetrying": "请求受到限流，正在重试…",

--- a/apps/mobile/src/i18n/locales/zh-TW/session.json
+++ b/apps/mobile/src/i18n/locales/zh-TW/session.json
@@ -26,6 +26,9 @@
   },
   "screen": {
     "thinking": "思考中…",
+    "tokenCount": "{{tokens}} tok",
+    "tokenCountFull": "{{tokens}} tokens",
+    "tokenRate": "{{rate}} tok/s",
     "networkReconnecting": "正在重新連線…",
     "modelBusyRetrying": "模型服務繁忙，正在重試…",
     "rateLimitRetrying": "請求受到限流，正在重試…",

--- a/apps/mobile/src/session/remoteSessionStore.ts
+++ b/apps/mobile/src/session/remoteSessionStore.ts
@@ -102,6 +102,10 @@ export interface RemoteSessionRunStatus {
   startedAt: number | null;
   status: string;
   tokenUsage: number;
+  outputTokens: number;
+  generationDurationMs: number;
+  generationActive: boolean;
+  generationReliable: boolean;
 }
 
 export interface RemoteSessionReconnectAttempt {
@@ -154,6 +158,10 @@ const EMPTY_SESSION_RUN_STATUS: RemoteSessionRunStatus = Object.freeze({
   startedAt: null,
   status: '',
   tokenUsage: 0,
+  outputTokens: 0,
+  generationDurationMs: 0,
+  generationActive: false,
+  generationReliable: true,
 });
 
 const shards = new Map<string, DeviceShard>();
@@ -3129,6 +3137,35 @@ export const remoteSessionStore = {
       const tokenUsage = rawTokenUsage !== null && rawTokenUsage > 0
         ? rawTokenUsage
         : (isTurnStart ? 0 : current.tokenUsage);
+      const rawOutputTokens = readNumber(data, 'outputTokens');
+      const rawGenerationDurationMs = readNumber(data, 'generationDurationMs');
+      const hasLiveFields =
+        rawOutputTokens !== null ||
+        rawGenerationDurationMs !== null ||
+        typeof data?.generationActive === 'boolean' ||
+        typeof data?.generationReliable === 'boolean';
+      const outputTokens = isTurnStart
+        ? 0
+        : rawOutputTokens !== null
+          ? rawOutputTokens
+          : current.outputTokens;
+      const generationDurationMs = isTurnStart
+        ? 0
+        : rawGenerationDurationMs !== null
+          ? rawGenerationDurationMs
+          : current.generationDurationMs;
+      const generationActive = !isRunning || isTurnStart
+        ? false
+        : typeof data?.generationActive === 'boolean'
+          ? data.generationActive
+          : hasLiveFields
+            ? false
+            : current.generationActive;
+      const generationReliable = isTurnStart
+        ? true
+        : typeof data?.generationReliable === 'boolean'
+          ? data.generationReliable
+          : current.generationReliable;
       // maker turn 边界 false→true 时清掉上一轮残留的 live task updates:它们是 turn 级
       // live 状态,残留到下一轮会被渲染层的孤儿兜底当作"仍在运行的子 agent"追加到消息流
       // 末尾(桌面端靠 idle demote / clear 清,手机 store 是常驻单例,只能在 turn 边界收口)。
@@ -3153,6 +3190,10 @@ export const remoteSessionStore = {
         startedAt: isRunning ? (current.startedAt ?? Date.now()) : null,
         status: rawStatus ?? current.status,
         tokenUsage,
+        outputTokens,
+        generationDurationMs,
+        generationActive,
+        generationReliable,
       };
       if (
         writeSessionRunStatus(sessionId, next)

--- a/apps/mobile/src/session/remoteSessionStore.ts
+++ b/apps/mobile/src/session/remoteSessionStore.ts
@@ -3144,28 +3144,24 @@ export const remoteSessionStore = {
         rawGenerationDurationMs !== null ||
         typeof data?.generationActive === 'boolean' ||
         typeof data?.generationReliable === 'boolean';
-      const outputTokens = isTurnStart
-        ? 0
-        : rawOutputTokens !== null
-          ? rawOutputTokens
-          : current.outputTokens;
-      const generationDurationMs = isTurnStart
-        ? 0
-        : rawGenerationDurationMs !== null
-          ? rawGenerationDurationMs
-          : current.generationDurationMs;
-      const generationActive = !isRunning || isTurnStart
+      // turn 边界清的是上一轮残留,不是本条 status 自带的 live 字段。
+      // 重连/前台恢复会先清 maker-turn,活跃快照只恢复宽 isRunning,于是下一条
+      // 用量刷新被当成 isTurnStart;若这里无条件归零,权威 output / duration
+      // 会被丢掉,紧接着的终态也来不及再显示 tok/s。
+      const outputTokens = rawOutputTokens !== null
+        ? rawOutputTokens
+        : (isTurnStart ? 0 : current.outputTokens);
+      const generationDurationMs = rawGenerationDurationMs !== null
+        ? rawGenerationDurationMs
+        : (isTurnStart ? 0 : current.generationDurationMs);
+      const generationActive = !isRunning
         ? false
         : typeof data?.generationActive === 'boolean'
           ? data.generationActive
-          : hasLiveFields
-            ? false
-            : current.generationActive;
-      const generationReliable = isTurnStart
-        ? true
-        : typeof data?.generationReliable === 'boolean'
-          ? data.generationReliable
-          : current.generationReliable;
+          : (isTurnStart || hasLiveFields ? false : current.generationActive);
+      const generationReliable = typeof data?.generationReliable === 'boolean'
+        ? data.generationReliable
+        : (isTurnStart ? true : current.generationReliable);
       // maker turn 边界 false→true 时清掉上一轮残留的 live task updates:它们是 turn 级
       // live 状态,残留到下一轮会被渲染层的孤儿兜底当作"仍在运行的子 agent"追加到消息流
       // 末尾(桌面端靠 idle demote / clear 清,手机 store 是常驻单例,只能在 turn 边界收口)。

--- a/apps/mobile/src/session/remoteSessionStore.ts
+++ b/apps/mobile/src/session/remoteSessionStore.ts
@@ -2431,13 +2431,13 @@ export const remoteSessionStore = {
       : flushAndFinalizeRemoteStreamingMessages(sessionId, boundaryAgentMeta);
     const turnBoundaryChanged = writeMakerTurnRunning(sessionId, running);
     const current = readSessionRunStatus(sessionId);
-    const next: RemoteSessionRunStatus = {
+    const next = clearLiveGenerationOnWideRunStart(current, {
       ...current,
       isRunning: running,
       reconnectAttempt: running ? current.reconnectAttempt : null,
       sideTaskRunning: running ? current.sideTaskRunning : false,
       startedAt: running ? (current.startedAt ?? Date.now()) : null,
-    };
+    });
     if (writeSessionRunStatus(sessionId, next)
       || turnBoundaryChanged
       || streamingChanged
@@ -2477,13 +2477,13 @@ export const remoteSessionStore = {
       const current = readSessionRunStatus(sessionId);
       const hasNewerMakerActivity = (sessionMakerActivityEpochs.get(sessionId) ?? 0)
         > activityEpochAtFetchStart;
-      const next: RemoteSessionRunStatus = {
+      const next = clearLiveGenerationOnWideRunStart(current, {
         ...current,
         isRunning: running,
         reconnectAttempt: running && hasNewerMakerActivity ? current.reconnectAttempt : null,
         sideTaskRunning: running ? current.sideTaskRunning : false,
         startedAt: running ? (current.startedAt ?? Date.now()) : null,
-      };
+      });
       changed = writeSessionRunStatus(sessionId, next) || changed;
     }
     if (changed) emit();
@@ -2869,12 +2869,12 @@ export const remoteSessionStore = {
       };
       changed = writeSessionLiveActivity(sessionId, next) || changed;
       const current = readSessionRunStatus(sessionId);
-      changed = writeSessionRunStatus(sessionId, {
+      changed = writeSessionRunStatus(sessionId, clearLiveGenerationOnWideRunStart(current, {
         ...current,
         isRunning: true,
         sideTaskRunning: current.sideTaskRunning,
         startedAt: current.startedAt ?? Date.now(),
-      }) || changed;
+      })) || changed;
       if (phase === 'needs-interaction') {
         changed = flushAndFinalizeRemoteStreamingMessages(sessionId) || changed;
       }
@@ -3627,6 +3627,24 @@ function parseReconnectAttemptMessage(
 
 // 写 maker turn 边界,返回是否实际变化——变化必须参与调用方的 emit 判定(宽 run status
 // 可能已被 activity / 快照流改到相同值,单靠 writeSessionRunStatus 的返回值会漏通知)。
+function clearLiveGenerationOnWideRunStart(
+  current: RemoteSessionRunStatus,
+  next: RemoteSessionRunStatus,
+): RemoteSessionRunStatus {
+  if (current.isRunning || !next.isRunning) return next;
+  // Activity / snapshot / setSessionRunning can flip the wide running flag
+  // before the next maker status. Leftover tok/s belongs to the previous
+  // turn and must not flash. Maker status still writes authoritative live
+  // fields afterwards (including reconnect first-status).
+  return {
+    ...next,
+    outputTokens: 0,
+    generationDurationMs: 0,
+    generationActive: false,
+    generationReliable: true,
+  };
+}
+
 function writeMakerTurnRunning(sessionId: string, running: boolean): boolean {
   const prev = sessionMakerTurnRunning.get(sessionId) === true;
   if (running === prev) return false;

--- a/packages/maker-core/src/agents/claude-code/generation-timing.test.ts
+++ b/packages/maker-core/src/agents/claude-code/generation-timing.test.ts
@@ -1,0 +1,27 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  beginClaudeGeneration,
+  finalizeClaudeGeneration,
+  newClaudeGenerationState,
+  pauseClaudeGeneration,
+  resumeClaudeGeneration,
+} from './generation-timing.js';
+
+describe('claude generation timing', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('excludes tool intervals from the generation denominator', () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1_000);
+    const state = newClaudeGenerationState();
+    beginClaudeGeneration(state, 1_000);
+    pauseClaudeGeneration(state, 'tool-1', 1_400);
+    resumeClaudeGeneration(state, 'tool-1', 5_000);
+    finalizeClaudeGeneration(state, 5_200);
+    expect(state.reliable).toBe(true);
+    expect(state.durationMs).toBe(600);
+    expect(state.startedAt).toBeNull();
+  });
+});

--- a/packages/maker-core/src/agents/claude-code/generation-timing.test.ts
+++ b/packages/maker-core/src/agents/claude-code/generation-timing.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { createAsyncQueue } from '../shared/async-queue.js';
+import { UsageTracker } from '../shared/usage-tracker.js';
+import type { AgentEvent } from '../../types/events.js';
 import {
   beginClaudeGeneration,
   finalizeClaudeGeneration,
@@ -8,6 +11,11 @@ import {
   resetClaudeGenerationTiming,
   resumeClaudeGeneration,
 } from './generation-timing.js';
+import {
+  newRuntimeState,
+  translateSdkMessage,
+  type TurnState,
+} from './translator.js';
 
 describe('claude generation timing', () => {
   afterEach(() => {
@@ -38,5 +46,158 @@ describe('claude generation timing', () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+});
+
+function createTurnState(): TurnState {
+  return {
+    text: '',
+    toolUses: 0,
+    apiCalls: 0,
+    sawCompactBoundary: false,
+    hasEmittedText: false,
+    uiEmittedText: '',
+    pendingApiError: null,
+    interruptRequested: false,
+    generation: 0,
+    interruptGeneration: 0,
+    lastAssistantMsgHadSubstance: true,
+  };
+}
+
+function createTranslatorCtx() {
+  return {
+    rt: newRuntimeState(),
+    turn: createTurnState(),
+    log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn() },
+    getModel: () => 'claude-sonnet-4.5',
+    getEffort: () => 'medium' as const,
+    getPermissionMode: () => 'auto' as const,
+    onSessionId: vi.fn(),
+    getSdkSessionId: () => undefined,
+    getLogTitle: () => undefined,
+    tracker: new UsageTracker(),
+  };
+}
+
+describe('claude generation pause boundaries', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('keeps generating through tool-argument deltas and pauses on message_delta', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+
+    const ctx = createTranslatorCtx();
+    const queue = createAsyncQueue<AgentEvent>();
+
+    translateSdkMessage(
+      {
+        type: 'stream_event',
+        event: {
+          type: 'message_start',
+          message: { model: 'claude-sonnet-4.5', usage: { input_tokens: 10 } },
+        },
+      },
+      queue,
+      ctx,
+    );
+    expect(ctx.rt.generation.startedAt).toBe(1_000);
+    expect(ctx.rt.generation.pendingToolIds.size).toBe(0);
+
+    vi.setSystemTime(1_200);
+    translateSdkMessage(
+      {
+        type: 'stream_event',
+        event: {
+          type: 'content_block_start',
+          index: 0,
+          content_block: { type: 'tool_use', id: 'toolu_1', input: {} },
+        },
+      },
+      queue,
+      ctx,
+    );
+    expect(ctx.rt.generation.startedAt).toBe(1_000);
+    expect(ctx.rt.generation.pendingToolIds.size).toBe(0);
+    expect(ctx.rt.generation.durationMs).toBe(0);
+
+    vi.setSystemTime(1_600);
+    translateSdkMessage(
+      {
+        type: 'stream_event',
+        event: {
+          type: 'content_block_delta',
+          index: 0,
+          delta: { type: 'input_json_delta', partial_json: '{"command":"ls"}' },
+        },
+      },
+      queue,
+      ctx,
+    );
+    expect(ctx.rt.generation.startedAt).toBe(1_000);
+    expect(ctx.rt.generation.pendingToolIds.size).toBe(0);
+
+    vi.setSystemTime(1_800);
+    translateSdkMessage(
+      {
+        type: 'stream_event',
+        event: {
+          type: 'message_delta',
+          usage: { output_tokens: 40 },
+        },
+      },
+      queue,
+      ctx,
+    );
+    expect(ctx.rt.generation.startedAt).toBeNull();
+    expect(ctx.rt.generation.pendingToolIds.has('toolu_1')).toBe(true);
+    expect(ctx.rt.generation.durationMs).toBe(800);
+    expect(ctx.rt.generation.reliable).toBe(true);
+
+    resetClaudeGenerationTiming(ctx.rt.generation);
+    queue.end();
+  });
+
+  it('pauses on a completed assistant tool_use when stream_event never arrived', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+
+    const ctx = createTranslatorCtx();
+    const queue = createAsyncQueue<AgentEvent>();
+
+    translateSdkMessage(
+      {
+        type: 'stream_event',
+        event: {
+          type: 'message_start',
+          message: { model: 'claude-sonnet-4.5', usage: { input_tokens: 10 } },
+        },
+      },
+      queue,
+      ctx,
+    );
+
+    vi.setSystemTime(1_500);
+    translateSdkMessage(
+      {
+        type: 'assistant',
+        message: {
+          content: [{ type: 'tool_use', id: 'toolu_2', name: 'Read', input: { file_path: '/tmp/a' } }],
+        },
+      },
+      queue,
+      ctx,
+    );
+
+    expect(ctx.rt.generation.startedAt).toBeNull();
+    expect(ctx.rt.generation.pendingToolIds.has('toolu_2')).toBe(true);
+    expect(ctx.rt.generation.durationMs).toBe(500);
+    expect(ctx.rt.generation.reliable).toBe(true);
+
+    resetClaudeGenerationTiming(ctx.rt.generation);
+    queue.end();
   });
 });

--- a/packages/maker-core/src/agents/claude-code/generation-timing.test.ts
+++ b/packages/maker-core/src/agents/claude-code/generation-timing.test.ts
@@ -281,5 +281,38 @@ describe('claude generation pause boundaries', () => {
     resetClaudeGenerationTiming(ctx.rt.generation);
     vi.useRealTimers();
   });
+
+  it('marks timing unreliable for a complete subagent assistant without message_delta', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const ctx = createTranslatorCtx();
+    const queue = createAsyncQueue<AgentEvent>();
+    translateSdkMessage(
+      {
+        type: 'stream_event',
+        event: {
+          type: 'message_start',
+          message: { model: 'claude-sonnet-4.5', usage: { input_tokens: 10 } },
+        },
+      },
+      queue,
+      ctx,
+    );
+    expect(ctx.rt.generation.reliable).toBe(true);
+    translateSdkMessage(
+      {
+        type: 'assistant',
+        parent_tool_use_id: 'toolu-agent',
+        message: { content: [{ type: 'text', text: 'child output' }] },
+      },
+      queue,
+      ctx,
+    );
+    expect(ctx.rt.generation.reliable).toBe(false);
+    resetClaudeGenerationTiming(ctx.rt.generation);
+    queue.end();
+    vi.useRealTimers();
+  });
 });
+
 

--- a/packages/maker-core/src/agents/claude-code/generation-timing.test.ts
+++ b/packages/maker-core/src/agents/claude-code/generation-timing.test.ts
@@ -228,4 +228,58 @@ describe('claude generation pause boundaries', () => {
     resetClaudeGenerationTiming(ctx.rt.generation);
     queue.end();
   });
+
+  it('attaches live generation fields to the terminal snapshot without message_delta', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const ctx = createTranslatorCtx();
+    const queue = createAsyncQueue<AgentEvent>();
+    translateSdkMessage(
+      {
+        type: 'stream_event',
+        event: {
+          type: 'message_start',
+          message: { model: 'claude-sonnet-4.5', usage: { input_tokens: 10 } },
+        },
+      },
+      queue,
+      ctx,
+    );
+    translateSdkMessage(
+      {
+        type: 'assistant',
+        message: { content: [{ type: 'text', text: 'done' }] },
+      },
+      queue,
+      ctx,
+    );
+    vi.setSystemTime(1_800);
+    translateSdkMessage(
+      {
+        type: 'result',
+        stop_reason: 'end_turn',
+        total_cost_usd: 0,
+        num_turns: 1,
+        usage: { input_tokens: 10, output_tokens: 40 },
+      },
+      queue,
+      ctx,
+    );
+    queue.end();
+    const events: AgentEvent[] = [];
+    for await (const event of queue) events.push(event);
+    const doneStatus = events.find(
+      (event) => event.type === 'status' && (event.data as { status?: string }).status === 'Done',
+    );
+    expect(doneStatus?.data).toMatchObject({
+      isRunning: false,
+      outputTokens: 40,
+      generationDurationMs: 800,
+      generationReliable: true,
+      generationActive: false,
+    });
+    resetClaudeGenerationTiming(ctx.rt.generation);
+    vi.useRealTimers();
+  });
 });
+

--- a/packages/maker-core/src/agents/claude-code/generation-timing.test.ts
+++ b/packages/maker-core/src/agents/claude-code/generation-timing.test.ts
@@ -47,6 +47,14 @@ describe('claude generation timing', () => {
       vi.useRealTimers();
     }
   });
+
+  it('marks timing unreliable when pausing without a generation start boundary', () => {
+    const state = newClaudeGenerationState();
+    pauseClaudeGeneration(state, 'tool-1', 1_400);
+    resumeClaudeGeneration(state, 'tool-1', 5_000);
+    finalizeClaudeGeneration(state, 5_200);
+    expect(state.reliable).toBe(false);
+  });
 });
 
 function createTurnState(): TurnState {
@@ -197,6 +205,26 @@ describe('claude generation pause boundaries', () => {
     expect(ctx.rt.generation.durationMs).toBe(500);
     expect(ctx.rt.generation.reliable).toBe(true);
 
+    resetClaudeGenerationTiming(ctx.rt.generation);
+    queue.end();
+  });
+
+  it('marks timing unreliable when a completed tool_use arrives without message_start', () => {
+    const ctx = createTranslatorCtx();
+    const queue = createAsyncQueue<AgentEvent>();
+    translateSdkMessage(
+      {
+        type: 'assistant',
+        message: {
+          content: [{ type: 'tool_use', id: 'toolu_3', name: 'Read', input: { file_path: '/tmp/a' } }],
+        },
+      },
+      queue,
+      ctx,
+    );
+    expect(ctx.rt.generation.startedAt).toBeNull();
+    expect(ctx.rt.generation.pendingToolIds.has('toolu_3')).toBe(true);
+    expect(ctx.rt.generation.reliable).toBe(false);
     resetClaudeGenerationTiming(ctx.rt.generation);
     queue.end();
   });

--- a/packages/maker-core/src/agents/claude-code/generation-timing.test.ts
+++ b/packages/maker-core/src/agents/claude-code/generation-timing.test.ts
@@ -5,6 +5,7 @@ import {
   finalizeClaudeGeneration,
   newClaudeGenerationState,
   pauseClaudeGeneration,
+  resetClaudeGenerationTiming,
   resumeClaudeGeneration,
 } from './generation-timing.js';
 
@@ -23,5 +24,19 @@ describe('claude generation timing', () => {
     expect(state.reliable).toBe(true);
     expect(state.durationMs).toBe(600);
     expect(state.startedAt).toBeNull();
+  });
+
+  it('stops the heartbeat when the session is reset without a result event', () => {
+    vi.useFakeTimers();
+    try {
+      const state = newClaudeGenerationState();
+      beginClaudeGeneration(state, 1_000);
+      expect(state.heartbeatTimer).not.toBeNull();
+      resetClaudeGenerationTiming(state);
+      expect(state.heartbeatTimer).toBeNull();
+      expect(state.heartbeatAt).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/packages/maker-core/src/agents/claude-code/generation-timing.ts
+++ b/packages/maker-core/src/agents/claude-code/generation-timing.ts
@@ -84,7 +84,13 @@ export function pauseClaudeGeneration(
     return;
   }
   if (state.pendingToolIds.has(pauseId)) return;
-  if (state.pendingToolIds.size === 0) closeInterval(state, pausedAt);
+  if (state.pendingToolIds.size === 0) {
+    // No open generation interval means we never saw message_start (or it was
+    // already closed). Pausing here would resume the clock at tool_result and
+    // still count earlier output tokens, so tok/s would be inflated.
+    if (state.startedAt === null) state.reliable = false;
+    else closeInterval(state, pausedAt);
+  }
   state.pendingToolIds.add(pauseId);
 }
 

--- a/packages/maker-core/src/agents/claude-code/generation-timing.ts
+++ b/packages/maker-core/src/agents/claude-code/generation-timing.ts
@@ -1,0 +1,121 @@
+const CLAUDE_GENERATION_HEARTBEAT_MS = 5_000;
+const CLAUDE_GENERATION_SUSPEND_GAP_MS = 30_000;
+
+export interface ClaudeGenerationState {
+  startedAt: number | null;
+  durationMs: number;
+  pendingToolIds: Set<string>;
+  reliable: boolean;
+  heartbeatAt: number | null;
+  heartbeatTimer: ReturnType<typeof setInterval> | null;
+}
+
+export function newClaudeGenerationState(): ClaudeGenerationState {
+  return {
+    startedAt: null,
+    durationMs: 0,
+    pendingToolIds: new Set(),
+    reliable: true,
+    heartbeatAt: null,
+    heartbeatTimer: null,
+  };
+}
+
+function stopHeartbeat(state: ClaudeGenerationState): void {
+  if (state.heartbeatTimer !== null) clearInterval(state.heartbeatTimer);
+  state.heartbeatTimer = null;
+  state.heartbeatAt = null;
+}
+
+function sampleHeartbeat(state: ClaudeGenerationState, now = Date.now()): void {
+  const previous = state.heartbeatAt;
+  if (
+    previous !== null &&
+    now - previous > CLAUDE_GENERATION_HEARTBEAT_MS + CLAUDE_GENERATION_SUSPEND_GAP_MS
+  ) {
+    state.reliable = false;
+  }
+  state.heartbeatAt = now;
+}
+
+function startHeartbeat(state: ClaudeGenerationState): void {
+  stopHeartbeat(state);
+  state.heartbeatAt = Date.now();
+  const timer = setInterval(() => sampleHeartbeat(state), CLAUDE_GENERATION_HEARTBEAT_MS);
+  timer.unref?.();
+  state.heartbeatTimer = timer;
+}
+
+function closeInterval(state: ClaudeGenerationState, endedAt: number): void {
+  const startedAt = state.startedAt;
+  state.startedAt = null;
+  sampleHeartbeat(state);
+  stopHeartbeat(state);
+  if (startedAt === null) return;
+  if (endedAt < startedAt) {
+    state.reliable = false;
+    return;
+  }
+  state.durationMs += endedAt - startedAt;
+}
+
+export function resetClaudeGenerationTiming(state: ClaudeGenerationState): void {
+  stopHeartbeat(state);
+  state.startedAt = null;
+  state.pendingToolIds.clear();
+  state.durationMs = 0;
+  state.reliable = true;
+}
+
+export function beginClaudeGeneration(state: ClaudeGenerationState, startedAt = Date.now()): void {
+  if (state.startedAt === null && state.pendingToolIds.size === 0) {
+    state.startedAt = startedAt;
+    startHeartbeat(state);
+  }
+}
+
+export function pauseClaudeGeneration(
+  state: ClaudeGenerationState,
+  pauseId: string,
+  pausedAt = Date.now(),
+): void {
+  if (!pauseId) {
+    state.reliable = false;
+    return;
+  }
+  if (state.pendingToolIds.has(pauseId)) return;
+  if (state.pendingToolIds.size === 0) closeInterval(state, pausedAt);
+  state.pendingToolIds.add(pauseId);
+}
+
+export function resumeClaudeGeneration(
+  state: ClaudeGenerationState,
+  pauseId: string,
+  resumedAt = Date.now(),
+): void {
+  if (!state.pendingToolIds.delete(pauseId)) {
+    state.reliable = false;
+    return;
+  }
+  if (state.pendingToolIds.size === 0) {
+    state.startedAt = resumedAt;
+    startHeartbeat(state);
+  }
+}
+
+export function finalizeClaudeGeneration(
+  state: ClaudeGenerationState,
+  completedAt = Date.now(),
+): void {
+  if (state.pendingToolIds.size > 0) {
+    state.reliable = false;
+    state.startedAt = null;
+    stopHeartbeat(state);
+    return;
+  }
+  closeInterval(state, completedAt);
+}
+
+export function markClaudeGenerationUnreliable(state: ClaudeGenerationState): void {
+  state.reliable = false;
+}

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -143,6 +143,7 @@ import { findClaudeSessionJsonl } from './claude-projects-fs.js';
 import { normalizeClaudeSessionJsonlToolIds } from './jsonl-tool-id-normalize.js';
 import { isClaudeResumeSessionNotFound } from './invalid-resume.js';
 import { translateSdkMessage, newRuntimeState, type TurnState, type RuntimeState } from './translator.js';
+import { resetClaudeGenerationTiming } from './generation-timing.js';
 import type { Effort, PermissionMode } from '../../types/common.js';
 import type {
   ScanAtResourcesOptions,
@@ -2349,6 +2350,7 @@ export class ClaudeCodeAgent extends BaseAgent {
       // usageTracker.beginTurn() 只清 usage 桶；translator 的 turnState 也要在新 turn
       // 开始时清掉，避免上一轮 abnormal/abort 没走 result 时污染下一轮状态。
       usageTracker.beginTurn();
+      resetClaudeGenerationTiming(runtimeState.generation);
       turnState.text = '';
       turnState.toolUses = 0;
       turnState.apiCalls = 0;

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -3441,6 +3441,7 @@ export class ClaudeCodeAgent extends BaseAgent {
     function teardownDeadHandle(logLabel: string): void {
       // Provider death is not a successful user cancellation. Session status
       // and the queued terminal error/done must decide observer settlement.
+      resetClaudeGenerationTiming(runtimeState.generation);
       discardActiveContinuation(logLabel);
       turnInFlight = false;
       // handle 死透 → 后续没有排队 turn 可跑, counter 归零避免残留污染下一 handle 重建
@@ -5927,6 +5928,7 @@ export class ClaudeCodeAgent extends BaseAgent {
         if (closed) return;
         // Closing/dead sessions settle through Session status (or their queued
         // terminal event), never through the successful task-stop path.
+        resetClaudeGenerationTiming(runtimeState.generation);
         discardActiveContinuation('session_closed');
         clearUpstreamResponseIdle();
         pendingToolIds.clear();
@@ -5962,6 +5964,7 @@ export class ClaudeCodeAgent extends BaseAgent {
         ? {
             async detach() {
               if (closed) return;
+              resetClaudeGenerationTiming(runtimeState.generation);
               discardActiveContinuation('session_detached', true);
               clearUpstreamResponseIdle();
               pendingToolIds.clear();

--- a/packages/maker-core/src/agents/claude-code/translator.ts
+++ b/packages/maker-core/src/agents/claude-code/translator.ts
@@ -1254,6 +1254,9 @@ function handleAssistant(
   const parentToolUseId = typeof msg.parent_tool_use_id === 'string' && msg.parent_tool_use_id
     ? msg.parent_tool_use_id
     : undefined;
+  // 子代理完整 assistant 没有 message_delta 时，result.usage 仍含其子输出，
+  // 而父级 Agent 工具区间已从分母排除。与 message_delta 路径同样 fail-closed。
+  if (parentToolUseId) markClaudeGenerationUnreliable(ctx.rt.generation);
   // 完整 child assistant 是实际执行模型的正式观测来源。SDK 不保证 child 的
   // partial message_start 一定向外暴露，所以不能只靠 handleStreamEvent 填模型；
   // 同时保持 main 新增的 loop guard 按 parent scope 读取同一张 stream model 表。

--- a/packages/maker-core/src/agents/claude-code/translator.ts
+++ b/packages/maker-core/src/agents/claude-code/translator.ts
@@ -1825,6 +1825,8 @@ function handleResult(
   // turn end usage 锁定: Claude Code result.usage 是 session aggregate,
   // 这里先转成 turn delta; tracker.endTurn 内部覆盖 currentTurn 然后返回 snapshot 再 reset。
   finalizeClaudeGeneration(ctx.rt.generation);
+  const liveTurnOutput = resultUsage?.outputTokens ?? ctx.tracker.getTurnUsage().output;
+  const liveGeneration = ctx.rt.generation;
   const endSnapshot = ctx.tracker.endTurn(
     resultUsage
       ? {
@@ -2065,7 +2067,12 @@ function handleResult(
     type: 'status',
     data: {
       status: 'Done',
-      ...endSnapshot,
+      ...attachLiveGeneration(endSnapshot, {
+        outputTokens: liveTurnOutput,
+        closedDurationMs: liveGeneration.durationMs,
+        openStartedAt: null,
+        reliable: liveGeneration.reliable,
+      }),
       isRunning: false,
     },
     source: 'claude-code',

--- a/packages/maker-core/src/agents/claude-code/translator.ts
+++ b/packages/maker-core/src/agents/claude-code/translator.ts
@@ -1334,12 +1334,11 @@ function handleAssistant(
       //   toolUseId: block.id,
       //   turnToolUses: ctx.turn.toolUses,
       // });
-      if (typeof block.id === 'string' && block.id.length > 0) {
-        if (typeof block.name === 'string' && block.name.length > 0) {
-          ctx.rt.toolUseIdToName.set(block.id, block.name);
-        }
-        pauseClaudeGeneration(ctx.rt.generation, block.id);
-        ctx.onToolUseStart?.(block.id, block.name, block.input, parentToolUseId);
+      const toolUseId = rememberClaudeToolUseId(ctx, block.id, block.name);
+      if (toolUseId) {
+        // 完整 assistant 消息已带工具参数,即使没有 stream_event 也可在此停表。
+        pauseClaudeGenerationForToolUse(ctx, toolUseId);
+        ctx.onToolUseStart?.(toolUseId, block.name, block.input, parentToolUseId);
       }
       queue.push({
         type: 'tool_use',
@@ -1374,6 +1373,36 @@ function handleAssistant(
   }
 }
 
+function rememberClaudeToolUseId(
+  ctx: TranslateContext,
+  toolUseId: unknown,
+  toolName: unknown,
+): string | null {
+  if (typeof toolUseId !== 'string' || toolUseId.length === 0) return null;
+  const existingName = ctx.rt.toolUseIdToName.get(toolUseId);
+  ctx.rt.toolUseIdToName.set(
+    toolUseId,
+    typeof toolName === 'string' && toolName.length > 0
+      ? toolName
+      : (existingName ?? ''),
+  );
+  return toolUseId;
+}
+
+function pauseClaudeGenerationForToolUse(
+  ctx: TranslateContext,
+  toolUseId: unknown,
+): void {
+  if (typeof toolUseId !== 'string' || toolUseId.length === 0) return;
+  pauseClaudeGeneration(ctx.rt.generation, toolUseId);
+}
+
+function pauseClaudeGenerationForKnownTools(ctx: TranslateContext): void {
+  for (const toolUseId of ctx.rt.toolUseIdToName.keys()) {
+    pauseClaudeGenerationForToolUse(ctx, toolUseId);
+  }
+}
+
 // ── stream_event 子分支(content_block_delta / message_delta / message_start) ──
 
 function handleStreamEvent(
@@ -1405,12 +1434,15 @@ function handleStreamEvent(
       const blockIndex = typeof event.index === 'number' ? event.index : 0;
       ctx.rt.streamStopTokenByKey.delete(`${parentToolUseId ?? '__main__'}:${blockIndex}`);
     }
-    if (cb && cb.type === 'tool_use' && typeof cb.id === 'string' && cb.id.length > 0) {
-      if (typeof cb.name === 'string' && cb.name.length > 0) {
-        ctx.rt.toolUseIdToName.set(cb.id, cb.name);
+    if (cb && cb.type === 'tool_use') {
+      const toolUseId = rememberClaudeToolUseId(ctx, cb.id, cb.name);
+      if (toolUseId) {
+        // watchdog / loop-guard 仍要立刻拿到 tool id。生成计时要等
+        // message_delta 或完整 assistant tool_use: content_block_start
+        // 早于参数 input_json_delta,这里停表会把参数生成时间从分母抠掉,
+        // 而后续 message_delta 仍把这些 token 加进 outputTokens。
+        ctx.onToolUseStart?.(toolUseId, cb.name, cb.input, parentToolUseId);
       }
-      pauseClaudeGeneration(ctx.rt.generation, cb.id);
-      ctx.onToolUseStart?.(cb.id, cb.name, cb.input, parentToolUseId);
     }
   }
 
@@ -1487,6 +1519,10 @@ function handleStreamEvent(
   }
 
   if (event.type === 'message_delta') {
+    // message_delta 是整条 assistant 消息(含工具参数 token)生成完毕后的
+    // 第一个事件。在此停表,才能排除工具执行/审批等待,又不把参数生成
+    // 区间从 tok/s 分母里抠掉。
+    pauseClaudeGenerationForKnownTools(ctx);
     const usage = event.usage;
     if (usage) {
       const dIn = usage.input_tokens ?? 0;

--- a/packages/maker-core/src/agents/claude-code/translator.ts
+++ b/packages/maker-core/src/agents/claude-code/translator.ts
@@ -34,6 +34,17 @@ import {
   isContextOverflowErrorMessage,
 } from '../shared/context-overflow-error.js';
 import type { UsageTracker } from '../shared/usage-tracker.js';
+import { attachLiveGeneration } from '../shared/live-generation-snapshot.js';
+import {
+  beginClaudeGeneration,
+  finalizeClaudeGeneration,
+  markClaudeGenerationUnreliable,
+  newClaudeGenerationState,
+  pauseClaudeGeneration,
+  resetClaudeGenerationTiming,
+  resumeClaudeGeneration,
+  type ClaudeGenerationState,
+} from './generation-timing.js';
 
 // ── 共享 turn / runtime 状态 ─────────────────────────────────────────────────
 //
@@ -158,6 +169,7 @@ export interface RuntimeState {
    * 发出可见正文，不能看整轮 `uiEmittedText`，也不能跨 text block 复用。
    */
   streamStopTokenByKey: Map<string, StandaloneStopTokenHold>;
+  generation: ClaudeGenerationState;
 }
 
 export function newRuntimeState(): RuntimeState {
@@ -174,6 +186,24 @@ export function newRuntimeState(): RuntimeState {
     lastAssistantMeta: null,
     lastResultUsageAggregate: null,
     streamStopTokenByKey: new Map(),
+    generation: newClaudeGenerationState(),
+  };
+}
+
+function ccLiveStatus(
+  ctx: TranslateContext,
+  status: string,
+  isRunning: boolean,
+): { status: string; isRunning: boolean } & ReturnType<UsageTracker['snapshot']> {
+  return {
+    status,
+    ...attachLiveGeneration(ctx.tracker.snapshot(), {
+      outputTokens: ctx.tracker.getTurnUsage().output,
+      closedDurationMs: ctx.rt.generation.durationMs,
+      openStartedAt: ctx.rt.generation.startedAt,
+      reliable: ctx.rt.generation.reliable,
+    }),
+    isRunning,
   };
 }
 
@@ -680,6 +710,7 @@ export function translateSdkMessage(
         }
       }
       for (const toolUseId of completedToolUseIds) {
+        resumeClaudeGeneration(ctx.rt.generation, toolUseId);
         ctx.rt.toolUseIdToName.delete(toolUseId);
       }
       return;
@@ -1307,6 +1338,7 @@ function handleAssistant(
         if (typeof block.name === 'string' && block.name.length > 0) {
           ctx.rt.toolUseIdToName.set(block.id, block.name);
         }
+        pauseClaudeGeneration(ctx.rt.generation, block.id);
         ctx.onToolUseStart?.(block.id, block.name, block.input, parentToolUseId);
       }
       queue.push({
@@ -1377,6 +1409,7 @@ function handleStreamEvent(
       if (typeof cb.name === 'string' && cb.name.length > 0) {
         ctx.rt.toolUseIdToName.set(cb.id, cb.name);
       }
+      pauseClaudeGeneration(ctx.rt.generation, cb.id);
       ctx.onToolUseStart?.(cb.id, cb.name, cb.input, parentToolUseId);
     }
   }
@@ -1468,6 +1501,7 @@ function handleStreamEvent(
         cacheReadTokens: dCacheRead,
         cacheCreateTokens: dCacheCreate,
       });
+      if (parentToolUseId && dOut > 0) markClaudeGenerationUnreliable(ctx.rt.generation);
       // 每次 API 回合的 token 增量打一行 —— 一个 turn 可能多个 message_delta(工具循环),
       // 让人看日志能直观看到 token 是怎么涨上去的, 而不是只在 turn end 看到一个总数。
       ctx.log.debug('SDK ▷ token usage (message_delta)', {
@@ -1480,11 +1514,7 @@ function handleStreamEvent(
       const snap = ctx.tracker.snapshot();
       queue.push({
         type: 'status',
-        data: {
-          status: 'Generating...',
-          ...snap,
-          isRunning: true,
-        },
+        data: ccLiveStatus(ctx, 'Generating...', true),
         source: 'claude-code',
       });
       // Maker Memory flush 观察 (A 轻版: 只打日志). 缺省没注册时 no-op。
@@ -1521,13 +1551,10 @@ function handleStreamEvent(
 
     // 不清 tracker —— message_start 在 turn 中可能出现多次(工具循环每次 API call 都会触发),
     // 老链路 agentManager.ts:2400-2407 这里也是带 currentTurn 累计, 不重置。
+    beginClaudeGeneration(ctx.rt.generation);
     queue.push({
       type: 'status',
-      data: {
-        status: 'Generating...',
-        ...ctx.tracker.snapshot(),
-        isRunning: true,
-      },
+      data: ccLiveStatus(ctx, 'Generating...', true),
       source: 'claude-code',
     });
     return;
@@ -1761,6 +1788,7 @@ function handleResult(
 
   // turn end usage 锁定: Claude Code result.usage 是 session aggregate,
   // 这里先转成 turn delta; tracker.endTurn 内部覆盖 currentTurn 然后返回 snapshot 再 reset。
+  finalizeClaudeGeneration(ctx.rt.generation);
   const endSnapshot = ctx.tracker.endTurn(
     resultUsage
       ? {
@@ -1930,6 +1958,7 @@ function handleResult(
     // 否则下一真实 turn 会从 0 起算、把整段历史 token 全算到那一轮(Codex P2)。
     ctx.rt.lastResultUsageAggregate = aggregateBeforeThisResult;
     resetTurnState(ctx.turn);
+    resetClaudeGenerationTiming(ctx.rt.generation);
     ctx.onTurnEnd?.();
     return;
   }
@@ -2025,6 +2054,7 @@ function handleResult(
   });
   // reset turn 累积 (tracker 内部已经在 endTurn 里 reset 了 currentTurn,这里只清非 usage 状态)
   resetTurnState(ctx.turn);
+  resetClaudeGenerationTiming(ctx.rt.generation);
   // turn 结束钩子 — agent 用来清 turnInFlight 标记 (rewind preview/commit 前置守卫读它)
   ctx.onTurnEnd?.();
 }

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -15212,6 +15212,73 @@ describe('CodexAgent MCP thread context hooks', () => {
     }
   });
 
+  it('flushes throttled token usage onto the last running status before Done', async () => {
+    let now = 1_000;
+    const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => now);
+    try {
+      const agent = new CodexAgent(createDeps());
+      const host = installFakeHost(agent);
+      const handle = await agent.startSession({
+        sessionId: 'session-generation-usage-flush',
+        model: 'gpt-5.4',
+        workingDir: '/repo',
+      });
+      const handlers = host.getThreadHandlers();
+      if (!handlers?.turnStarted || !handlers.tokenUsageUpdated || !handlers.turnCompleted) {
+        throw new Error('expected generation usage handlers');
+      }
+      const events: AgentEvent[] = [];
+      void (async () => {
+        for await (const event of handle.events()) events.push(event);
+      })();
+
+      const sendPromise = handle.send({ type: 'user', content: 'fast' });
+      for (let i = 0; i < 5; i += 1) {
+        if (host.request.mock.calls.some(([method]) => method === Method.TurnStart)) break;
+        await Promise.resolve();
+      }
+      now = 1_050;
+      handlers.turnStarted({ threadId: 'start-thread-id', turn: { id: 'turn-fast' } });
+      now = 1_200;
+      handlers.tokenUsageUpdated({
+        threadId: 'start-thread-id',
+        turnId: 'turn-fast',
+        tokenUsage: {
+          last: { inputTokens: 10, outputTokens: 40, cachedInputTokens: 0 },
+        },
+      });
+      now = 1_300;
+      handlers.turnCompleted({
+        threadId: 'start-thread-id',
+        turn: { id: 'turn-fast', status: 'completed', durationMs: 300 },
+      });
+      await sendPromise;
+      await waitForExpectation(() => expect(events.some((event) => event.type === 'done')).toBe(true));
+
+      const runningLive = events.filter(
+        (event) =>
+          event.type === 'status'
+          && (event.data as { isRunning?: boolean }).isRunning === true
+          && (event.data as { outputTokens?: number }).outputTokens === 40,
+      );
+      expect(runningLive.length).toBeGreaterThan(0);
+      const doneStatus = events.find(
+        (event) =>
+          event.type === 'status'
+          && (event.data as { status?: string }).status === 'Done',
+      );
+      expect(doneStatus?.data).toMatchObject({
+        isRunning: false,
+        outputTokens: 40,
+        generationDurationMs: 250,
+      });
+
+      await handle.close();
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
   it('keeps descendant approval waits out of the root generation timer', async () => {
     let now = 1_000;
     const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => now);

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -15212,7 +15212,7 @@ describe('CodexAgent MCP thread context hooks', () => {
     }
   });
 
-  it('flushes throttled token usage onto the last running status before Done', async () => {
+  it('attaches throttled token usage to the Done snapshot without an extra running frame', async () => {
     let now = 1_000;
     const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => now);
     try {
@@ -15255,13 +15255,13 @@ describe('CodexAgent MCP thread context hooks', () => {
       await sendPromise;
       await waitForExpectation(() => expect(events.some((event) => event.type === 'done')).toBe(true));
 
-      const runningLive = events.filter(
+      const extraRunningLive = events.filter(
         (event) =>
           event.type === 'status'
           && (event.data as { isRunning?: boolean }).isRunning === true
           && (event.data as { outputTokens?: number }).outputTokens === 40,
       );
-      expect(runningLive.length).toBeGreaterThan(0);
+      expect(extraRunningLive).toHaveLength(0);
       const doneStatus = events.find(
         (event) =>
           event.type === 'status'

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -15123,6 +15123,95 @@ describe('CodexAgent MCP thread context hooks', () => {
     }
   });
 
+  it('resets generation timing when turn/start response arrives before turnStarted', async () => {
+    let now = 1_000;
+    const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => now);
+    try {
+      const firstStart = deferred<unknown>();
+      const secondStart = deferred<unknown>();
+      let attempt = 0;
+      const agent = new CodexAgent(createDeps());
+      const host = installFakeHost(agent, (method) => {
+        if (method === Method.TurnStart) {
+          attempt += 1;
+          if (attempt === 1) return firstStart.promise;
+          return secondStart.promise;
+        }
+        return undefined;
+      });
+      const handle = await agent.startSession({
+        sessionId: 'session-generation-timing-start-resp-before-started',
+        model: 'gpt-5.4',
+        workingDir: '/repo',
+      });
+      const handlers = host.getThreadHandlers();
+      if (!handlers?.turnStarted || !handlers.tokenUsageUpdated || !handlers.turnCompleted) {
+        throw new Error('expected generation timing handlers');
+      }
+      const events: AgentEvent[] = [];
+      void (async () => {
+        for await (const event of handle.events()) events.push(event);
+      })();
+
+      const send1 = handle.send({ type: 'user', content: 'first' });
+      for (let i = 0; i < 5; i += 1) {
+        if (host.request.mock.calls.some(([method]) => method === Method.TurnStart)) break;
+        await Promise.resolve();
+      }
+      handlers.turnStarted({ threadId: 'start-thread-id', turn: { id: 'turn-1' } });
+      now = 4_000;
+      handlers.tokenUsageUpdated({
+        threadId: 'start-thread-id',
+        turnId: 'turn-1',
+        tokenUsage: {
+          last: { inputTokens: 10, outputTokens: 20, cachedInputTokens: 0 },
+        },
+      });
+      now = 5_000;
+      handlers.turnCompleted({
+        threadId: 'start-thread-id',
+        turn: { id: 'turn-1', status: 'completed', durationMs: 4_000 },
+      });
+      firstStart.resolve({ turn: { id: 'turn-1' } });
+      await send1;
+      await waitForExpectation(() => expect(events.some((event) => event.type === 'done')).toBe(true));
+      events.length = 0;
+
+      const send2 = handle.send({ type: 'user', content: 'second' });
+      for (let i = 0; i < 5; i += 1) {
+        if (host.request.mock.calls.filter(([method]) => method === Method.TurnStart).length >= 2) break;
+        await Promise.resolve();
+      }
+      now = 6_000;
+      secondStart.resolve({ turn: { id: 'turn-2' } });
+      await send2;
+      now = 7_000;
+      handlers.turnStarted({ threadId: 'start-thread-id', turn: { id: 'turn-2' } });
+      now = 8_000;
+      handlers.tokenUsageUpdated({
+        threadId: 'start-thread-id',
+        turnId: 'turn-2',
+        tokenUsage: {
+          last: { inputTokens: 10, outputTokens: 40, cachedInputTokens: 0 },
+        },
+      });
+      now = 8_500;
+      handlers.turnCompleted({
+        threadId: 'start-thread-id',
+        turn: { id: 'turn-2', status: 'completed', durationMs: 2_500 },
+      });
+      await waitForExpectation(() =>
+        expect(events.some((event) => event.type === 'done')).toBe(true),
+      );
+      const done = events.find((event) => event.type === 'done');
+      expect((done?.data as { usage?: { durationMs?: number } }).usage?.durationMs).toBe(2_500);
+
+      await handle.close();
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
   it('keeps descendant approval waits out of the root generation timer', async () => {
     let now = 1_000;
     const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => now);

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -10507,6 +10507,7 @@ export class CodexAgent extends BaseAgent {
                 ...(turnModel ? { model: turnModel } : {}),
               });
               currentTurnId = resp.turn.id;
+              beginCodexGenerationTurn(translatorRt, resp.turn.id);
               isTurnInFlight = true;
               turnStartGeneration += 1; // 见声明处:延迟善后靠它判断"期间起过新 turn"
               if (reconnectStallTimer && reconnectStallTurnId === resp.turn.id) {

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -7486,13 +7486,13 @@ export class CodexAgent extends BaseAgent {
       });
     }
 
-    function maybePushUsageRefresh(): void {
+    function maybePushUsageRefresh(force = false): void {
       const now = Date.now();
       // No UI status yet: a refresh would invent a Working… frame and steal the
       // next event from tests / terminal error sequences. Real turns always
       // pushStatus or send() first, which stamps lastUsageRefreshAt.
       if (lastUsageRefreshAt === 0) return;
-      if (now - lastUsageRefreshAt < USAGE_REFRESH_MIN_MS) return;
+      if (!force && now - lastUsageRefreshAt < USAGE_REFRESH_MIN_MS) return;
       lastUsageRefreshAt = now;
       eventQueue.push({
         type: 'status',
@@ -8240,6 +8240,10 @@ export class CodexAgent extends BaseAgent {
       // 必须在 endTurn 之前取: endTurn 会用降级 aggregate 覆盖后 reset。
       const realTurnUsage = usageTracker.getTurnUsage();
       finalizeCodexGenerationTurn(translatorRt, turn.id);
+      // tokenUsageUpdated inside the 500ms window is dropped. Fast turns often
+      // land that last usage after itemCompleted's Generating… frame, so force
+      // one live snapshot before the turn bucket is reset. No extra timer.
+      if (!suppressTerminalUi) maybePushUsageRefresh(true);
       usageTracker.endTurn({
         inputTokens: lastSnap.contextTokens ?? 0,
         outputTokens: 0,
@@ -8368,7 +8372,16 @@ export class CodexAgent extends BaseAgent {
 
       eventQueue.push({
         type: 'status',
-        data: { status: 'Done', ...endSnap, isRunning: false },
+        data: {
+          status: 'Done',
+          ...attachLiveGeneration(endSnap, {
+            outputTokens: realTurnUsage.output,
+            closedDurationMs: translatorRt.generationDurationMs,
+            openStartedAt: null,
+            reliable: translatorRt.generationTimingReliable,
+          }),
+          isRunning: false,
+        },
         source: 'codex',
       });
       // 真实 per-turn 用量 (host 的 today chip / daily_model_usage 记账消费):

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -7474,6 +7474,7 @@ export class CodexAgent extends BaseAgent {
     // 由 renderer 显示最新一条, react batch 自然消化中间抖动。
     let lastStatusText = 'Working…';
     let lastUsageRefreshAt = 0;
+    let lastUsageIngestAt = 0;
     const USAGE_REFRESH_MIN_MS = 500;
 
     function pushStatus(text: string): void {
@@ -7492,7 +7493,14 @@ export class CodexAgent extends BaseAgent {
       // next event from tests / terminal error sequences. Real turns always
       // pushStatus or send() first, which stamps lastUsageRefreshAt.
       if (lastUsageRefreshAt === 0) return;
-      if (!force && now - lastUsageRefreshAt < USAGE_REFRESH_MIN_MS) return;
+      if (force) {
+        // Only emit an extra running frame when usage arrived after the last
+        // published status. Blind force-flush re-plays lastStatusText and
+        // steals sequential Done consumers (spawnAgent running… vs Done).
+        if (lastUsageIngestAt <= lastUsageRefreshAt) return;
+      } else if (now - lastUsageRefreshAt < USAGE_REFRESH_MIN_MS) {
+        return;
+      }
       lastUsageRefreshAt = now;
       eventQueue.push({
         type: 'status',
@@ -9407,6 +9415,7 @@ export class CodexAgent extends BaseAgent {
           cacheReadTokens: cached,
           cacheCreateTokens: 0,
         });
+        lastUsageIngestAt = Date.now();
         maybePushUsageRefresh();
         // Maker Memory flush 观察 (A 轻版: 只打日志). makerMemoryEnabled 关时 controller 为 null。
         if (memoryFlushController) {

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -7474,7 +7474,6 @@ export class CodexAgent extends BaseAgent {
     // 由 renderer 显示最新一条, react batch 自然消化中间抖动。
     let lastStatusText = 'Working…';
     let lastUsageRefreshAt = 0;
-    let lastUsageIngestAt = 0;
     const USAGE_REFRESH_MIN_MS = 500;
 
     function pushStatus(text: string): void {
@@ -7487,20 +7486,13 @@ export class CodexAgent extends BaseAgent {
       });
     }
 
-    function maybePushUsageRefresh(force = false): void {
+    function maybePushUsageRefresh(): void {
       const now = Date.now();
       // No UI status yet: a refresh would invent a Working… frame and steal the
       // next event from tests / terminal error sequences. Real turns always
       // pushStatus or send() first, which stamps lastUsageRefreshAt.
       if (lastUsageRefreshAt === 0) return;
-      if (force) {
-        // Only emit an extra running frame when usage arrived after the last
-        // published status. Blind force-flush re-plays lastStatusText and
-        // steals sequential Done consumers (spawnAgent running… vs Done).
-        if (lastUsageIngestAt <= lastUsageRefreshAt) return;
-      } else if (now - lastUsageRefreshAt < USAGE_REFRESH_MIN_MS) {
-        return;
-      }
+      if (now - lastUsageRefreshAt < USAGE_REFRESH_MIN_MS) return;
       lastUsageRefreshAt = now;
       eventQueue.push({
         type: 'status',
@@ -8248,10 +8240,6 @@ export class CodexAgent extends BaseAgent {
       // 必须在 endTurn 之前取: endTurn 会用降级 aggregate 覆盖后 reset。
       const realTurnUsage = usageTracker.getTurnUsage();
       finalizeCodexGenerationTurn(translatorRt, turn.id);
-      // tokenUsageUpdated inside the 500ms window is dropped. Fast turns often
-      // land that last usage after itemCompleted's Generating… frame, so force
-      // one live snapshot before the turn bucket is reset. No extra timer.
-      if (!suppressTerminalUi) maybePushUsageRefresh(true);
       usageTracker.endTurn({
         inputTokens: lastSnap.contextTokens ?? 0,
         outputTokens: 0,
@@ -9415,7 +9403,6 @@ export class CodexAgent extends BaseAgent {
           cacheReadTokens: cached,
           cacheCreateTokens: 0,
         });
-        lastUsageIngestAt = Date.now();
         maybePushUsageRefresh();
         // Maker Memory flush 观察 (A 轻版: 只打日志). makerMemoryEnabled 关时 controller 为 null。
         if (memoryFlushController) {

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -99,6 +99,7 @@ import {
 } from '../shared/auto-review-decision.js';
 import { reviewAction, type ReviewableAction } from '../shared/auto-review.js';
 import { UsageTracker } from '../shared/usage-tracker.js';
+import { attachLiveGeneration } from '../shared/live-generation-snapshot.js';
 import { getDefaultImageResizer } from '../shared/image-resizer.js';
 import { formatManagedImageReferences } from '../shared/managed-image-reference.js';
 import { REVIEW_SENSITIVE_CREDENTIAL_GLOB_PATTERNS } from '../shared/sensitive-credential-paths.js';
@@ -2904,6 +2905,12 @@ export class CodexAgent extends BaseAgent {
     const eventQueue: AsyncQueue<AgentEvent> = createAsyncQueue<AgentEvent>();
     const usageTracker = new UsageTracker();
     const translatorRt: CodexRuntimeState = newCodexRuntimeState();
+    const liveUsageSnapshot = () => attachLiveGeneration(usageTracker.snapshot(), {
+      outputTokens: usageTracker.getTurnUsage().output,
+      closedDurationMs: translatorRt.generationDurationMs,
+      openStartedAt: translatorRt.generationStartedAt,
+      reliable: translatorRt.generationTimingReliable,
+    });
     /**
      * 本 turn 用于**目录查找**的模型 id, 在构造 turnParams 时快照(取 mutableCatalogModel,
      * 不是送上游的 wire 值 —— 见该变量注释)。
@@ -7465,10 +7472,31 @@ export class CodexAgent extends BaseAgent {
     // codex 协议没这层 — 必须自己从 item.* lifecycle + thread/status/changed 推断。
     // 实现策略: 每次切换语义化阶段 push 一次, 不在 delta 里 push (会刷成风暴);
     // 由 renderer 显示最新一条, react batch 自然消化中间抖动。
+    let lastStatusText = 'Working…';
+    let lastUsageRefreshAt = 0;
+    const USAGE_REFRESH_MIN_MS = 500;
+
     function pushStatus(text: string): void {
+      lastStatusText = text;
+      lastUsageRefreshAt = Date.now();
       eventQueue.push({
         type: 'status',
-        data: { status: text, ...usageTracker.snapshot(), isRunning: true },
+        data: { status: text, ...liveUsageSnapshot(), isRunning: true },
+        source: 'codex',
+      });
+    }
+
+    function maybePushUsageRefresh(): void {
+      const now = Date.now();
+      // No UI status yet: a refresh would invent a Working… frame and steal the
+      // next event from tests / terminal error sequences. Real turns always
+      // pushStatus or send() first, which stamps lastUsageRefreshAt.
+      if (lastUsageRefreshAt === 0) return;
+      if (now - lastUsageRefreshAt < USAGE_REFRESH_MIN_MS) return;
+      lastUsageRefreshAt = now;
+      eventQueue.push({
+        type: 'status',
+        data: { status: lastStatusText, ...liveUsageSnapshot(), isRunning: true },
         source: 'codex',
       });
     }
@@ -9366,6 +9394,7 @@ export class CodexAgent extends BaseAgent {
           cacheReadTokens: cached,
           cacheCreateTokens: 0,
         });
+        maybePushUsageRefresh();
         // Maker Memory flush 观察 (A 轻版: 只打日志). makerMemoryEnabled 关时 controller 为 null。
         if (memoryFlushController) {
           const snap = usageTracker.snapshot();
@@ -10224,11 +10253,13 @@ export class CodexAgent extends BaseAgent {
           oneShotTipState.displayed.set(id, (oneShotTipState.displayed.get(id) ?? 0) + 1);
           oneShotTipState.pity.delete(id);
         }
+        lastStatusText = turnStartPick.text;
+        lastUsageRefreshAt = Date.now();
         eventQueue.push({
           type: 'status',
           data: {
             status: turnStartPick.text,
-            ...usageTracker.snapshot(),
+            ...liveUsageSnapshot(),
             isRunning: true,
           },
           source: 'codex',
@@ -11183,7 +11214,7 @@ export class CodexAgent extends BaseAgent {
       },
 
       getUsageSnapshot(): UsageSnapshot {
-        return usageTracker.snapshot();
+        return liveUsageSnapshot();
       },
 
       setInteractionResolver(resolver: InteractionResolver) {

--- a/packages/maker-core/src/agents/pi/__tests__/pi-translator.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/pi-translator.test.ts
@@ -5,7 +5,12 @@
 
 import { describe, expect, it, vi } from 'vitest';
 
-import { createPiTranslateContext, translatePiEvent, usageSnapshotOf } from '../translator.js';
+import {
+  createPiTranslateContext,
+  disposePiTranslateContext,
+  translatePiEvent,
+  usageSnapshotOf,
+} from '../translator.js';
 import type { AgentEvent } from '../../../types/events.js';
 import type { AsyncQueue } from '../../shared/async-queue.js';
 import type { Logger } from '../../../interfaces/logger.js';
@@ -602,6 +607,10 @@ describe('pi translator', () => {
     expect(usage.turnDurationMs).toBeGreaterThanOrEqual(0);
     // 快照累计 input+output。
     expect(usageSnapshotOf(ctx).tokenUsage).toBe(120);
+    expect(usageSnapshotOf(ctx).outputTokens).toBe(20);
+    expect(usageSnapshotOf(ctx).generationReliable).toBe(true);
+    expect(usageSnapshotOf(ctx).generationDurationMs).toBe(1_200);
+    expect(usageSnapshotOf(ctx).generationActive).toBe(false);
     // done.data.result 带上最终回复文本 —— register.ts 的 will-assistant-message 出口钩子
     // 与 Orca worker 终态 finalText 都读它,不带上就对 Pi 静默跳过(codex review P1)。
     expect((done!.data as { result?: unknown }).result).toBe('hi');
@@ -609,6 +618,28 @@ describe('pi translator', () => {
       type: 'status',
       data: expect.objectContaining({ status: 'Done', isRunning: false }),
     }));
+  });
+
+  it('marks generation active on message_start so the UI can tick live TPS', () => {
+    const ctx = createPiTranslateContext(noopLogger);
+    const { queue, events } = makeQueue();
+    translatePiEvent(ev({ type: 'agent_start' }), queue, ctx);
+    translatePiEvent(ev({ type: 'message_start' }), queue, ctx);
+    expect(usageSnapshotOf(ctx).generationActive).toBe(true);
+    expect(usageSnapshotOf(ctx).generationReliable).toBe(true);
+    expect(events.filter((e) => e.type === 'status')).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'status',
+          data: expect.objectContaining({
+            status: 'Working…',
+            isRunning: true,
+            generationActive: true,
+          }),
+        }),
+      ]),
+    );
+    disposePiTranslateContext(ctx);
   });
 
   it('reads Pi v0.83 generation duration from timestamp with a live heartbeat', () => {
@@ -793,11 +824,12 @@ describe('pi translator', () => {
       ctx,
     );
 
-    expect(events).toEqual([{
+    expect(events.filter((e) => e.type === 'thinking')).toEqual([{
       type: 'thinking',
       data: { stage: 'redacted', blockId: 'pi-think-1' },
       source: 'pi',
     }]);
+    disposePiTranslateContext(ctx);
   });
 
   it('cleans up a visible placeholder when redaction is only known at thinking_end', () => {

--- a/packages/maker-core/src/agents/pi/translator.ts
+++ b/packages/maker-core/src/agents/pi/translator.ts
@@ -28,6 +28,7 @@ import {
 } from '@cindy/maker-shared/internal-citation';
 import type { AgentEvent, AgentTaskUpdateEventData, UsageSnapshot } from '../../types/index.js';
 import type { AsyncQueue } from '../shared/async-queue.js';
+import { attachLiveGeneration } from '../shared/live-generation-snapshot.js';
 import {
   UPSTREAM_OVERLOAD_REASON,
   formatOverloadRetryMessage,
@@ -111,6 +112,8 @@ export interface PiTranslateContext {
   /** 整轮 wall-clock 起点；只用于诊断，不参与 TPS。 */
   turnWallClockStartedAt: number;
   generationDurationMs: number;
+  /** Open generation interval start; 0 while tools/user waits own the turn. */
+  generationOpenAt: number;
   /** False when any reported output lacks compatible parent generation timing. */
   generationTimingReliable: boolean;
   generationHeartbeatAt: number;
@@ -151,6 +154,7 @@ export function createPiTranslateContext(logger: Logger): PiTranslateContext {
     finalAssistantText: '',
     turnWallClockStartedAt: 0,
     generationDurationMs: 0,
+    generationOpenAt: 0,
     generationTimingReliable: true,
     generationHeartbeatAt: 0,
     generationHeartbeatTimer: null,
@@ -169,6 +173,7 @@ function stopPiGenerationHeartbeat(ctx: PiTranslateContext): void {
   if (ctx.generationHeartbeatTimer !== null) clearInterval(ctx.generationHeartbeatTimer);
   ctx.generationHeartbeatTimer = null;
   ctx.generationHeartbeatAt = 0;
+  ctx.generationOpenAt = 0;
 }
 
 /** Release translator-owned resources when a Pi session ends outside a normal turn boundary. */
@@ -194,18 +199,27 @@ function startPiGenerationHeartbeat(ctx: PiTranslateContext): void {
   stopPiGenerationHeartbeat(ctx);
   ctx.generationHeartbeatReliable = true;
   ctx.generationHeartbeatAt = Date.now();
+  ctx.generationOpenAt = ctx.generationHeartbeatAt;
   const timer = setInterval(() => samplePiGenerationHeartbeat(ctx), PI_GENERATION_HEARTBEAT_MS);
   timer.unref?.();
   ctx.generationHeartbeatTimer = timer;
 }
 
 export function usageSnapshotOf(ctx: PiTranslateContext): UsageSnapshot {
-  return {
-    tokenUsage: ctx.turnTokens,
-    contextTokens: ctx.contextTokens,
-    contextWindow: ctx.contextWindow,
-    costUsd: ctx.costUsd,
-  };
+  return attachLiveGeneration(
+    {
+      tokenUsage: ctx.turnTokens,
+      contextTokens: ctx.contextTokens,
+      contextWindow: ctx.contextWindow,
+      costUsd: ctx.costUsd,
+    },
+    {
+      outputTokens: ctx.turnOutput,
+      closedDurationMs: ctx.generationDurationMs,
+      openStartedAt: ctx.generationOpenAt > 0 ? ctx.generationOpenAt : null,
+      reliable: ctx.generationTimingReliable && ctx.generationHeartbeatReliable,
+    },
+  );
 }
 
 function pushStatus(
@@ -398,6 +412,9 @@ export function translatePiEvent(
       ctx.thinkingBlocks.clear();
       ctx.streamStopTokenByIndex.clear();
       startPiGenerationHeartbeat(ctx);
+      // Tell the UI generation is active so it can tick the TPS denominator
+      // locally between sparse message_end usage reports.
+      pushStatus(queue, ctx, 'Working…', true);
       return;
     }
 

--- a/packages/maker-core/src/agents/shared/live-generation-snapshot.test.ts
+++ b/packages/maker-core/src/agents/shared/live-generation-snapshot.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+
+import { attachLiveGeneration } from './live-generation-snapshot.js';
+
+const base = {
+  tokenUsage: 120,
+  contextTokens: 100,
+  contextWindow: 200_000,
+  costUsd: 0,
+};
+
+describe('attachLiveGeneration', () => {
+  it('includes output tokens even when timing is unreliable', () => {
+    expect(
+      attachLiveGeneration(base, {
+        outputTokens: 40,
+        closedDurationMs: 1_000,
+        openStartedAt: 10_000,
+        reliable: false,
+      }),
+    ).toEqual({
+      ...base,
+      outputTokens: 40,
+      generationReliable: false,
+      generationActive: false,
+    });
+  });
+
+  it('adds closed duration plus the open interval', () => {
+    expect(
+      attachLiveGeneration(base, {
+        outputTokens: 50,
+        closedDurationMs: 1_000,
+        openStartedAt: 8_000,
+        reliable: true,
+        now: 8_250,
+      }),
+    ).toEqual({
+      ...base,
+      outputTokens: 50,
+      generationReliable: true,
+      generationActive: true,
+      generationDurationMs: 1_250,
+    });
+  });
+
+  it('omits duration when nothing has been generated yet', () => {
+    expect(
+      attachLiveGeneration(base, {
+        outputTokens: 0,
+        closedDurationMs: 0,
+        openStartedAt: 5_000,
+        reliable: true,
+        now: 5_000,
+      }),
+    ).toEqual({
+      ...base,
+      outputTokens: 0,
+      generationReliable: true,
+      generationActive: true,
+    });
+  });
+});

--- a/packages/maker-core/src/agents/shared/live-generation-snapshot.ts
+++ b/packages/maker-core/src/agents/shared/live-generation-snapshot.ts
@@ -1,0 +1,57 @@
+import type { UsageSnapshot } from '../../types/events.js';
+
+export interface LiveGenerationTiming {
+  /** Turn-cumulative output tokens, including reasoning. */
+  outputTokens: number;
+  /** Closed model-active intervals for this turn. */
+  closedDurationMs: number;
+  /** Open interval start, or null while tools/user waits own the turn. */
+  openStartedAt: number | null;
+  /** False when any output lacks a compatible generation-only denominator. */
+  reliable: boolean;
+  now?: number;
+}
+
+/**
+ * Attach live TPS facts to a usage snapshot.
+ *
+ * Timing is omitted when unreliable so the UI can fail closed instead of
+ * dividing output by a partial or wall-clock denominator. `outputTokens` is
+ * still included so cumulative-token tooltips stay accurate.
+ */
+export function attachLiveGeneration(
+  snapshot: UsageSnapshot,
+  timing: LiveGenerationTiming,
+): UsageSnapshot {
+  const outputTokens =
+    typeof timing.outputTokens === 'number' && Number.isFinite(timing.outputTokens)
+      ? Math.max(0, timing.outputTokens)
+      : 0;
+  const next: UsageSnapshot = { ...snapshot, outputTokens };
+  if (!timing.reliable) {
+    return {
+      ...next,
+      generationReliable: false,
+      generationActive: false,
+    };
+  }
+
+  const now = timing.now ?? Date.now();
+  const closed =
+    typeof timing.closedDurationMs === 'number' && Number.isFinite(timing.closedDurationMs)
+      ? Math.max(0, timing.closedDurationMs)
+      : 0;
+  const openMs =
+    timing.openStartedAt != null && Number.isFinite(timing.openStartedAt)
+      ? Math.max(0, now - timing.openStartedAt)
+      : 0;
+  const generationDurationMs = closed + openMs;
+  const generationActive = timing.openStartedAt != null && Number.isFinite(timing.openStartedAt);
+
+  return {
+    ...next,
+    generationReliable: true,
+    generationActive,
+    ...(generationDurationMs > 0 ? { generationDurationMs } : {}),
+  };
+}

--- a/packages/maker-core/src/types/events.ts
+++ b/packages/maker-core/src/types/events.ts
@@ -323,6 +323,14 @@ export interface UsageSnapshot {
   contextTokens: number;
   contextWindow: number;
   costUsd: number;
+  /** Turn-cumulative output tokens (includes reasoning). */
+  outputTokens?: number;
+  /** Generation-only milliseconds for this turn, including any open interval. */
+  generationDurationMs?: number;
+  /** True while the model currently owns the turn (renderer may tick locally). */
+  generationActive?: boolean;
+  /** False when live TPS must be hidden. Omitted on placeholder status frames. */
+  generationReliable?: boolean;
 }
 
 /**


### PR DESCRIPTION
## 这次改了什么

### 摘要

运行中右下角不再只显示累计 token。有可靠的生成速率时显示 `tok/s`，没有速度但已有用量时回退累计 `tok`，还完全没用量时只保留计时。Tips / 消息明细继续用完整 `tokens` 文案，不出现 `tok` 简写。

### 变更类型

- [x] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：
  - Claude / Codex / Pi 在 status 快照里附带 generation-only 时长和 output token
  - 桌面、手机运行中状态栏：有可靠 tok/s 显示速度，否则显示累计 tok
  - 还没有任何用量时不显示 `↓ — tokens`
  - Tips 与中文明细统一为 `tokens` / `tokens/秒`
- 明确不包含：
  - 不把 live 速率和消息 Tips 的分母强行对齐（Tips 的 Claude 路径仍可用 `duration_api_ms`）
  - 不用流式文本估算尚未报到的 output token
  - 失败 / 中断的 Codex turn 不补最后一帧 tok/s（运行态已收起；round 10 止损，不再沿这个失败族打补丁）
- 用户可见变化：运行中右下角从累计 token 改为 `tok/s` / `tok` 切换；Tips 文案统一复数
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：`docs/design-rules/DESIGN.md` §14.4 Cadenced running shimmer：状态栏呼吸仍按真实进度（status / token / 速率变化）触发，不改成无限循环。双模式沿用 `--status-bar-meta`，未新增颜色或硬编码。文案：状态栏用短单位 `tok/s` / `tok`，Tips 用完整 `tokens`。

### 运行中 live 字段不变量

turn 边界清的是上一轮残留，不是本条 status 自带的 live 字段。桌面 `mergeLiveGenerationStatus` 与手机 status 分支共用这条规则。

- 真新 turn、首条没有 live 字段 → 归零，避免闪上一轮的 tok/s
- 真新 turn或重连后首条带着 output / duration / active / reliable → 用本条的值
- 同 turn 刷新没有 live 字段 → 保持当前值
- `isRunning=false` → `generationActive=false`，已经报到的 output / duration 仍保留

交错测试：`remoteSessionStore.test.ts`（离线后活跃快照只恢复宽 running，下一条用量刷新必须保住 tok/s；无字段的新 turn 必须归零）；桌面 `makerChatStoreLiveGeneration.test.ts` 对称覆盖。

### 远程与手机

按 `docs/dev-rules/remote-and-mobile-adaptation.md` 三问：

- SSH 远程工作区：计时与 usage 快照在 maker-core translator / event loop，跟 agent 进程走。SSH 工作区仍走同一套 AgentEvent，不读本机 workdir 文件。本 PR 已一并适配。
- 设备互联：没有新 IPC channel / 推送 topic。live 字段是既有 `status` 快照上的可选字段，device-link 原样转发。不涉及重试／断链半径。本 PR 已一并适配。
- 手机版：运行中状态栏、重连后首条 status、无障碍标签已接同一套字段。本 PR 已一并适配。

## 怎么验证的

### maker-core 核心指标

改动落在 translator / usage 快照路径，按 `docs/dev-rules/maker-core-and-agent-behavior.md` §3 评估：

- 缓存率：未改 system prompt、tool 定义、MCP 注册或前缀拼接顺序。status 快照只多可选字段，不进模型请求。结论：不影响 prompt cache。
- 性能：Claude 热路径只在已有 `message_start` / `message_delta` / tool 边界上记账，不新增网络往返。Codex usage 刷新仍 500ms 节流。generation heartbeat 每 5 秒一次、`unref`，并在 close / detach / teardownDeadHandle / result 收尾停掉。抽查 `generation-timing.test.ts`：工具区间不计入分母；reset 后 `heartbeatTimer` 为 null。
- 准确性：translator 不改 text / thinking / tool 事件映射。live 速率分子是 turn-cumulative output（含 reasoning），分母是 generation-only；计时不可靠时隐藏速率。Codex `turn/start` 响应先于 `turnStarted` 时也会重置计时，避免跨 turn 混用。
- 实测：`pnpm --filter @cindy/maker-core exec vitest run src/agents/claude-code/generation-timing.test.ts src/agents/shared/live-generation-snapshot.test.ts src/agents/codex/index.test.ts -t "resets generation timing when turn/start response arrives before turnStarted"` → 通过。桌面开发版发消息抽查：无用量只显示计时；有累计显示 tok；有可靠速率显示 tok/s。

### 自动验证

```text
pnpm --filter desktop exec vitest run \
  src/renderer/__tests__/usagePerformanceI18n.test.ts \
  src/renderer/__tests__/runningTokenUsage.test.ts \
  src/renderer/__tests__/reducedMotionEscape.test.ts \
  src/renderer/lib/__tests__/turnUsageTooltip.test.ts
结果：42 passed

pnpm --filter mobile exec vitest run src/__tests__/sessionComposerDesktopFirst.test.ts
结果：3 passed

pnpm --filter desktop run typecheck
pnpm --filter mobile run typecheck
结果：通过

pnpm --filter @cindy/maker-core run --if-present typecheck
结果：该包无 typecheck script，按仓库规则跳过

pnpm check:i18n
结果：5 语言 key 一致

bash /Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh <worktree>
结果：apps/desktop 2 failed / 27444 passed
失败项：ghostInstallReceipt.test.ts 两条 setup receipt 读取
在干净 origin/main 同样失败，本 PR 未改插件收据路径，不混入修复
```

### 手工验证

- 平台：macOS Desktop 开发版，隔离沙箱 `live-status-tokps-3cd2f1`，中国大陆版
- 路径：功能 worktree 启动后发消息，观察右下角计时 / tok/s / 累计 tok 切换，以及消息 Tips 文案
- 已验证：无用量时只显示计时；有累计时显示 `↓ N tok`；Tips 不再出现 `tok` 简写
- Dark 已目检；Light 未单独目检（复用 themed `--status-bar-meta`，不声称双模式都已验证）

### 未执行的验证

- 未在手机真机跑 Metro；mobile 改动由源码契约测试覆盖
- 未验证 Windows Desktop

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：运行中状态栏文案，以及 Claude / Codex / Pi 的 live usage 快照字段；不影响落盘 schema
- 回滚 / 降级方式：回退本 PR。新字段都是可选的，旧客户端忽略即可
- 存量插件影响：无

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因




