### PR TITLE
fix(mobile): 稳定输入工具栏与语音按钮布局

### DIFF
--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -317,6 +317,7 @@ import {
 } from '@cindy/maker-shared/synthetic-trigger';
 import {
   ComposerResizeGrabber,
+  ComposerToolbarLeftGroup,
   ComposerToolbarSpacer,
   ComposerToolbarVoiceSlot,
   MOBILE_COMPOSER_CONTROL_SIZE,
@@ -2805,51 +2806,54 @@ export default function SessionScreen() {
     );
   };
 
-  // 工具条布局(对齐 Codex):左 = [+][权限图标][计划 chip];右 = [模型][语音][动作]。
+  // 工具条布局:左 = [+][权限][计划 chip][模型];右 = [停止][语音][发送]。
+  // 模型放左侧组,不随发送/停止出现而横向跳动。
   const renderComposerToolbar = () => (
     <>
-      {renderComposerAttachmentButton()}
-      {renderSessionPermissionButton()}
-      {planModeOn ? (
-        <PlanModeChip
-          disabled={controlBusy || !canUseRemoteSessionControls}
-          onExit={() => togglePlanMode(false)}
-          testID="session.planModeChip"
-        />
-      ) : null}
+      <ComposerToolbarLeftGroup testID="session.composerToolbarLeft">
+        {renderComposerAttachmentButton()}
+        {renderSessionPermissionButton()}
+        {planModeOn ? (
+          <PlanModeChip
+            disabled={controlBusy || !canUseRemoteSessionControls}
+            onExit={() => togglePlanMode(false)}
+            testID="session.planModeChip"
+          />
+        ) : null}
+        {composerRuntimeSummary ? (
+          <ComposerRuntimePill
+            disabled={controlBusy || !canUseRemoteSessionControls}
+            fastOn={composerPillFastOn}
+            label={composerRuntimeLabel}
+            leading={agentSwitchIntent ? (
+              <MobileAgentMark
+                agentKind={agentSwitchIntent.targetAgentKind}
+                color={colors.textSecondary}
+                size={iconSize.sm}
+              />
+            ) : composerPillSourceId ? (
+              // 正常态显示真正生效来源；断开态显示 DB 中的真实来源并使用状态色，
+              // 不静默换成 activeSourceId 的默认回退 Logo。
+              <MobileModelIconMark
+                color={composerSelectedSourceDisconnected ? colors.statusError : undefined}
+                icon={currentSession && composerPillSourceProvider
+                  ? getModel(composerPillSourceProvider, currentSession.model, sessionAgentKind)?.icon
+                  : undefined}
+                name={composerPillSourceProvider?.name ?? composerPillSourceId}
+                providerId={composerPillSourceId}
+                routing={composerPillSourceProvider?.routing}
+                logoKind={composerPillSourceProvider?.logoKind}
+              />
+            ) : null}
+            onPress={toggleComposerModelPicker}
+            testID="session.composerModelButton"
+          />
+        ) : null}
+      </ComposerToolbarLeftGroup>
       <ComposerToolbarSpacer />
-      {composerRuntimeSummary ? (
-        <ComposerRuntimePill
-          disabled={controlBusy || !canUseRemoteSessionControls}
-          fastOn={composerPillFastOn}
-          label={composerRuntimeLabel}
-          leading={agentSwitchIntent ? (
-            <MobileAgentMark
-              agentKind={agentSwitchIntent.targetAgentKind}
-              color={colors.textSecondary}
-              size={iconSize.sm}
-            />
-          ) : composerPillSourceId ? (
-            // 正常态显示真正生效来源；断开态显示 DB 中的真实来源并使用状态色，
-            // 不静默换成 activeSourceId 的默认回退 Logo。
-            <MobileModelIconMark
-              color={composerSelectedSourceDisconnected ? colors.statusError : undefined}
-              icon={currentSession && composerPillSourceProvider
-                ? getModel(composerPillSourceProvider, currentSession.model, sessionAgentKind)?.icon
-                : undefined}
-              name={composerPillSourceProvider?.name ?? composerPillSourceId}
-              providerId={composerPillSourceId}
-              routing={composerPillSourceProvider?.routing}
-              logoKind={composerPillSourceProvider?.logoKind}
-            />
-          ) : null}
-          onPress={toggleComposerModelPicker}
-          testID="session.composerModelButton"
-        />
-      ) : null}
-      {/* 工具排右段顺序:[模型][停止任务][语音占位][发送槽](spacer 已在模型左侧,
-          模型右对齐对齐 Codex)。停止任务在语音左边(对齐桌面),语音占位宽度随录音
-          胶囊(红点+计时)展开,把停止任务推开——语音右缘与发送槽的邻接关系全程不变。 */}
+      {/* 工具排右段顺序:[停止任务][语音占位][发送槽]。停止任务在语音左边(对齐桌面),
+          语音占位宽度随录音胶囊(红点+计时)展开,把停止任务推开——语音右缘与发送槽
+          的邻接关系全程不变。模型在 spacer 左侧,不随右段显隐横向跳动。 */}
       {renderComposerInlineStop()}
       {composerVoicePlacement?.inline || composerVoicePlacement?.floating
         ? <ComposerToolbarVoiceSlot width={voiceRecordingTimer.pillWidth} />

--- a/apps/mobile/app/sessions/new.tsx
+++ b/apps/mobile/app/sessions/new.tsx
@@ -207,6 +207,7 @@ import { MobileVendorIcon } from '@/components/MobileVendorIcon';
 import { PlanModeChip } from '@/session/PlanModeChip';
 import {
   ComposerResizeGrabber,
+  ComposerToolbarLeftGroup,
   ComposerToolbarSpacer,
   ComposerToolbarVoiceSlot,
   MOBILE_COMPOSER_CONTROL_SIZE,
@@ -3365,43 +3366,46 @@ export default function NewRemoteSessionScreen() {
     );
   };
 
-  // 工具条布局(对齐 Codex):左 = [+][权限图标][计划 chip];右 = [模型][语音][创建]。
+  // 工具条布局:左 = [+][权限][计划 chip][模型];右 = [语音][创建]。
+  // 模型放左侧组,不随创建按钮出现而横向跳动。
   const renderComposerToolbar = () => (
     <>
-      {renderAttachmentToggleButton()}
-      {renderPermissionIconButton()}
-      {planModeOn ? (
-        <PlanModeChip
-          disabled={creating}
-          onExit={() => togglePlanMode(false)}
-          testID="newSession.planModeChip"
-        />
-      ) : null}
-      <ComposerToolbarSpacer />
-      <Pressable
-        accessibilityLabel={t('session.new.modelAccessibility', { model: runtimeSummary.modelSummary })}
-        accessibilityRole="button"
-        accessibilityState={{ expanded: modelSheetOpen || undefined }}
-        hitSlop={10}
-        onPress={toggleModelPicker}
-        style={({ pressed }) => [styles.modelPill, pressed && styles.pressed]}
-        testID="newSession.modelIndicator"
-      >
-        {activeSourceProvider ? (
-          // 图标统一规则(桌面同源):模型条目 icon(AI Gateway 设定)优先,缺省回落来源标。
-          <MobileModelIconMark
-            color={colors.textSecondary}
-            icon={getModel(activeSourceProvider, draft.model, draft.agentKind)?.icon}
-            name={activeSourceProvider.name}
-            providerId={activeSourceProvider.id}
-            routing={activeSourceProvider.routing}
-            logoKind={activeSourceProvider.logoKind}
+      <ComposerToolbarLeftGroup testID="newSession.composerToolbarLeft">
+        {renderAttachmentToggleButton()}
+        {renderPermissionIconButton()}
+        {planModeOn ? (
+          <PlanModeChip
+            disabled={creating}
+            onExit={() => togglePlanMode(false)}
+            testID="newSession.planModeChip"
           />
         ) : null}
-        <Text style={styles.modelPillText} numberOfLines={1}>{runtimeSummary.modelSummary}</Text>
-        {triggerFastOn ? <Zap color={colors.textTertiary} size={iconSize.sm} strokeWidth={iconStroke.regular} /> : null}
-        <ChevronDown color={colors.textTertiary} size={iconSize.sm} strokeWidth={iconStroke.regular} />
-      </Pressable>
+        <Pressable
+          accessibilityLabel={t('session.new.modelAccessibility', { model: runtimeSummary.modelSummary })}
+          accessibilityRole="button"
+          accessibilityState={{ expanded: modelSheetOpen || undefined }}
+          hitSlop={10}
+          onPress={toggleModelPicker}
+          style={({ pressed }) => [styles.modelPill, pressed && styles.pressed]}
+          testID="newSession.modelIndicator"
+        >
+          {activeSourceProvider ? (
+            // 图标统一规则(桌面同源):模型条目 icon(AI Gateway 设定)优先,缺省回落来源标。
+            <MobileModelIconMark
+              color={colors.textSecondary}
+              icon={getModel(activeSourceProvider, draft.model, draft.agentKind)?.icon}
+              name={activeSourceProvider.name}
+              providerId={activeSourceProvider.id}
+              routing={activeSourceProvider.routing}
+              logoKind={activeSourceProvider.logoKind}
+            />
+          ) : null}
+          <Text style={styles.modelPillText} numberOfLines={1}>{runtimeSummary.modelSummary}</Text>
+          {triggerFastOn ? <Zap color={colors.textTertiary} size={iconSize.sm} strokeWidth={iconStroke.regular} /> : null}
+          <ChevronDown color={colors.textTertiary} size={iconSize.sm} strokeWidth={iconStroke.regular} />
+        </Pressable>
+      </ComposerToolbarLeftGroup>
+      <ComposerToolbarSpacer />
       {composerVoicePlacement?.inline || composerVoicePlacement?.floating
         ? <ComposerToolbarVoiceSlot width={voiceRecordingTimer.pillWidth} />
         : null}

--- a/apps/mobile/src/__tests__/composerVoiceButtonAnchor.test.ts
+++ b/apps/mobile/src/__tests__/composerVoiceButtonAnchor.test.ts
@@ -23,7 +23,7 @@ describe('resolveMobileComposerVoiceButtonPlacement', () => {
 });
 
 describe('resolveMobileComposerVoiceButtonAnchorStyle', () => {
-  it('收起态按行垂直居中,不写 bottom 数值', () => {
+  it('收起态铺满父高、垂直居中,不写百分比 top', () => {
     const style = resolveMobileComposerVoiceButtonAnchorStyle({
       cardLayout: false,
       floating: false,
@@ -31,16 +31,17 @@ describe('resolveMobileComposerVoiceButtonAnchorStyle', () => {
     expect(style).toEqual({
       position: 'absolute',
       right: MOBILE_COMPOSER_VOICE_ANCHOR_RIGHT,
-      top: '50%',
-      bottom: 'auto',
-      transform: [{ translateY: -MOBILE_COMPOSER_CONTROL_SIZE / 2 }],
+      top: 0,
+      bottom: 0,
+      justifyContent: 'center',
+      alignItems: 'flex-end',
       zIndex: 2,
     });
-    expect(style.bottom).toBe('auto');
-    expect(style.top).not.toBe('auto');
+    expect(style.top).toBe(0);
+    expect(style.bottom).toBe(0);
   });
 
-  it('卡片态钉在工具排底边,显式清掉 top 与 translateY', () => {
+  it('卡片态同样 top:0,靠 bottom + flex-end 钉在工具排,不写 auto', () => {
     const style = resolveMobileComposerVoiceButtonAnchorStyle({
       cardLayout: true,
       floating: false,
@@ -48,16 +49,28 @@ describe('resolveMobileComposerVoiceButtonAnchorStyle', () => {
     expect(style).toEqual({
       position: 'absolute',
       right: MOBILE_COMPOSER_VOICE_ANCHOR_RIGHT,
-      top: 'auto',
+      top: 0,
       bottom: MOBILE_COMPOSER_VOICE_ANCHOR_CARD_BOTTOM,
-      transform: [],
+      justifyContent: 'flex-end',
+      alignItems: 'flex-end',
       zIndex: 2,
     });
-    expect(style.top).toBe('auto');
-    expect(style.transform).toEqual([]);
+    expect(style.top).toBe(0);
+    expect(style.justifyContent).toBe('flex-end');
     expect(Object.prototype.hasOwnProperty.call(style, 'top')).toBe(true);
     expect(Object.prototype.hasOwnProperty.call(style, 'bottom')).toBe(true);
-    expect(Object.prototype.hasOwnProperty.call(style, 'transform')).toBe(true);
+    expect(Object.prototype.hasOwnProperty.call(style, 'transform')).toBe(false);
+  });
+
+  it('两态都不用百分比 top 或 auto,避免 RN 残留把麦克风停在卡片中部', () => {
+    for (const cardLayout of [false, true]) {
+      for (const floating of [false, true]) {
+        const style = resolveMobileComposerVoiceButtonAnchorStyle({ cardLayout, floating });
+        expect(style.top).toBe(0);
+        expect(typeof style.bottom).toBe('number');
+        expect(style).not.toHaveProperty('transform');
+      }
+    }
   });
 
   it('有 trailing 时两态都向左让出发送键宽度', () => {

--- a/apps/mobile/src/__tests__/composerVoiceButtonAnchor.test.ts
+++ b/apps/mobile/src/__tests__/composerVoiceButtonAnchor.test.ts
@@ -33,6 +33,7 @@ describe('resolveMobileComposerVoiceButtonAnchorStyle', () => {
       right: MOBILE_COMPOSER_VOICE_ANCHOR_RIGHT,
       top: 0,
       bottom: 0,
+      paddingBottom: 0,
       justifyContent: 'center',
       alignItems: 'flex-end',
       zIndex: 2,
@@ -41,7 +42,7 @@ describe('resolveMobileComposerVoiceButtonAnchorStyle', () => {
     expect(style.bottom).toBe(0);
   });
 
-  it('卡片态同样 top:0,靠 bottom + flex-end 钉在工具排,不写 auto', () => {
+  it('卡片态壳延伸到底边,靠 paddingBottom + flex-end 保持按钮位置与纵向 hitSlop', () => {
     const style = resolveMobileComposerVoiceButtonAnchorStyle({
       cardLayout: true,
       floating: false,
@@ -50,12 +51,15 @@ describe('resolveMobileComposerVoiceButtonAnchorStyle', () => {
       position: 'absolute',
       right: MOBILE_COMPOSER_VOICE_ANCHOR_RIGHT,
       top: 0,
-      bottom: MOBILE_COMPOSER_VOICE_ANCHOR_CARD_BOTTOM,
+      bottom: 0,
+      paddingBottom: MOBILE_COMPOSER_VOICE_ANCHOR_CARD_BOTTOM,
       justifyContent: 'flex-end',
       alignItems: 'flex-end',
       zIndex: 2,
     });
     expect(style.top).toBe(0);
+    expect(style.bottom).toBe(0);
+    expect(style.paddingBottom).toBe(MOBILE_COMPOSER_VOICE_ANCHOR_CARD_BOTTOM);
     expect(style.justifyContent).toBe('flex-end');
     expect(Object.prototype.hasOwnProperty.call(style, 'top')).toBe(true);
     expect(Object.prototype.hasOwnProperty.call(style, 'bottom')).toBe(true);
@@ -67,7 +71,8 @@ describe('resolveMobileComposerVoiceButtonAnchorStyle', () => {
       for (const floating of [false, true]) {
         const style = resolveMobileComposerVoiceButtonAnchorStyle({ cardLayout, floating });
         expect(style.top).toBe(0);
-        expect(typeof style.bottom).toBe('number');
+        expect(style.bottom).toBe(0);
+        expect(typeof style.paddingBottom).toBe('number');
         expect(style).not.toHaveProperty('transform');
       }
     }

--- a/apps/mobile/src/__tests__/newSession.test.ts
+++ b/apps/mobile/src/__tests__/newSession.test.ts
@@ -1612,6 +1612,20 @@ describe('new session composer surface', () => {
     expect(newSource).not.toContain('marginHorizontal: (MOBILE_COMPOSER_CONTROL_SIZE - MOBILE_COMPOSER_MIN_TOUCH_TARGET) / 2');
     expect(newSource).not.toContain('left: (MOBILE_COMPOSER_CONTROL_SIZE - MOBILE_COMPOSER_MIN_TOUCH_TARGET) / 2');
     expect(newSource).toContain('const renderComposerToolbar = () => (');
+    // 左侧组包住 [+][权限][计划][模型],再接 spacer;右段 语音占位 → 创建。
+    const newToolbarStart = newSource.indexOf('const renderComposerToolbar = () => (');
+    const newToolbarEnd = newSource.indexOf('const renderComposerInputOverlay', newToolbarStart);
+    const newToolbarSource = newSource.slice(newToolbarStart, newToolbarEnd);
+    const newToolbarLeftGroupStart = newToolbarSource.indexOf('<ComposerToolbarLeftGroup testID="newSession.composerToolbarLeft">');
+    const newToolbarLeftGroupEnd = newToolbarSource.indexOf('</ComposerToolbarLeftGroup>');
+    const newToolbarModelIndex = newToolbarSource.indexOf('testID="newSession.modelIndicator"');
+    const newToolbarSpacerIndex = newToolbarSource.indexOf('<ComposerToolbarSpacer />');
+    const newToolbarVoiceSlotIndex = newToolbarSource.indexOf('<ComposerToolbarVoiceSlot width={voiceRecordingTimer.pillWidth} />');
+    expect(newToolbarLeftGroupStart).toBeGreaterThan(-1);
+    expect(newToolbarModelIndex).toBeGreaterThan(newToolbarLeftGroupStart);
+    expect(newToolbarLeftGroupEnd).toBeGreaterThan(newToolbarModelIndex);
+    expect(newToolbarSpacerIndex).toBeGreaterThan(newToolbarLeftGroupEnd);
+    expect(newToolbarVoiceSlotIndex).toBeGreaterThan(newToolbarSpacerIndex);
     expect(newSource).toContain('PaperPlaneIcon');
     expect(newSource).not.toContain('ArrowUp');
     expect(attachmentButtonSource).toContain('contextSheetOpen && styles.composerIconButtonActive');

--- a/apps/mobile/src/__tests__/sessionComposerDesktopFirst.test.ts
+++ b/apps/mobile/src/__tests__/sessionComposerDesktopFirst.test.ts
@@ -134,9 +134,10 @@ describe('mobile session composer desktop-first surface', () => {
     expect(trailingActionsSource).toContain('color={composerSendDisabled ? colors.textSecondary : colors.ctaText}');
     expect(source).toContain('const composerCardActive = (canUseComposer && composerFocused)');
     expect(source).toContain('|| permissionSheetOpen');
-    // 2026-07-29 用户裁决(对齐 Codex):权限入口是 composer 左侧图标钮 + 独立浮窗
-    // (MobilePermissionPickerList 由本 screen 直挂 SheetSurface),模型药丸右对齐;
+    // 2026-07-29 用户裁决:权限入口是 composer 左侧图标钮 + 独立浮窗
+    // (MobilePermissionPickerList 由本 screen 直挂 SheetSurface);
     // 浮窗打开时仍属于 composer 激活态,不能因输入框失焦把底排收起。
+    // 2026-08:模型药丸改到左侧组(权限/计划右侧),避免发送/停止出现时横向跳动。
     // ModelPickerSheet 的 header 权限入口隐藏(hidePermissionTrigger),不再双入口。
     expect(source).not.toContain('testID="session.composerPermissionButton"');
     expect(source).toContain('testID="session.permissionIndicator"');
@@ -475,7 +476,14 @@ describe('mobile session composer desktop-first surface', () => {
     expect(sharedSource).toContain('voicePlacement?.inline || voicePlacement?.floating');
     expect(sharedSource).toContain('resolveMobileComposerVoiceButtonAnchorStyle({');
     expect(sharedSource).toContain('floating: voicePlacement.floating,');
+    expect(sharedSource).toContain('pointerEvents="box-none"\n          style={resolveMobileComposerVoiceButtonAnchorStyle({');
+    expect(sharedSource).toContain('{floatingVoiceButton?.(floatingVoiceButtonStyle)}');
+    expect(sharedSource).toContain('export function ComposerToolbarLeftGroup');
+    expect(sharedSource).toContain('toolbarLeftGroup: {');
+    expect(sharedSource).toContain('justifyContent: \'flex-start\'');
     expect(sharedSource).not.toContain('cardLayout && styles.voiceButtonAnchorCard,');
+    expect(sharedSource).not.toContain("top: '50%'");
+    expect(sharedSource).not.toContain("top: 'auto'");
     // 录音中语音按钮以「红色停止方块」可见,禁止任何 opacity:0 隐藏样式回归
     // (旧 gestureAnchor 设计曾把听写中的按钮隐藏,会让停止录音无可见控件)。
     expect(source).not.toContain('composerInlineToolButtonGestureAnchor');
@@ -483,14 +491,23 @@ describe('mobile session composer desktop-first surface', () => {
     // 若回归三档,录音期间首段转写落地会让语音按钮整格横跳,原位正好变成停止任务。
     expect(source).not.toContain('composerFloatingVoiceButtonWithInlineStop');
     expect(source).not.toContain('composerFloatingVoiceButtonStyle');
-    // 槽位顺序不变量(对齐桌面 2026-07-25 定案):停止任务 → 语音占位 → 发送槽。
+    // 槽位顺序不变量:左侧组包住 [+][权限][计划][模型],再接 spacer;
+    // 右段 停止任务 → 语音占位 → 发送槽。药丸必须在 LeftGroup 内,不能只靠 JSX 顺序。
     const toolbarStart = source.indexOf('const renderComposerToolbar = () => (');
     const toolbarEnd = source.indexOf('const renderComposerInputOverlay', toolbarStart);
     const toolbarSource = source.slice(toolbarStart, toolbarEnd);
+    const toolbarLeftGroupStart = toolbarSource.indexOf('<ComposerToolbarLeftGroup testID="session.composerToolbarLeft">');
+    const toolbarLeftGroupEnd = toolbarSource.indexOf('</ComposerToolbarLeftGroup>');
+    const toolbarModelIndex = toolbarSource.indexOf('testID="session.composerModelButton"');
+    const toolbarSpacerIndex = toolbarSource.indexOf('<ComposerToolbarSpacer />');
     const toolbarInlineStopIndex = toolbarSource.indexOf('{renderComposerInlineStop()}');
     const toolbarVoiceSlotIndex = toolbarSource.indexOf('<ComposerToolbarVoiceSlot width={voiceRecordingTimer.pillWidth} />');
     const toolbarSendSlotIndex = toolbarSource.indexOf('{renderComposerSendSlot()}');
-    expect(toolbarInlineStopIndex).toBeGreaterThan(-1);
+    expect(toolbarLeftGroupStart).toBeGreaterThan(-1);
+    expect(toolbarModelIndex).toBeGreaterThan(toolbarLeftGroupStart);
+    expect(toolbarLeftGroupEnd).toBeGreaterThan(toolbarModelIndex);
+    expect(toolbarSpacerIndex).toBeGreaterThan(toolbarLeftGroupEnd);
+    expect(toolbarInlineStopIndex).toBeGreaterThan(toolbarSpacerIndex);
     expect(toolbarVoiceSlotIndex).toBeGreaterThan(toolbarInlineStopIndex);
     expect(toolbarSendSlotIndex).toBeGreaterThan(toolbarVoiceSlotIndex);
     const trailingFragmentStart = source.indexOf('const renderComposerTrailingActions = () => (');

--- a/apps/mobile/src/__tests__/sessionComposerDesktopFirst.test.ts
+++ b/apps/mobile/src/__tests__/sessionComposerDesktopFirst.test.ts
@@ -476,8 +476,15 @@ describe('mobile session composer desktop-first surface', () => {
     expect(sharedSource).toContain('voicePlacement?.inline || voicePlacement?.floating');
     expect(sharedSource).toContain('resolveMobileComposerVoiceButtonAnchorStyle({');
     expect(sharedSource).toContain('floating: voicePlacement.floating,');
-    expect(sharedSource).toContain('pointerEvents="box-none"\n          style={resolveMobileComposerVoiceButtonAnchorStyle({');
+    expect(sharedSource).toContain('pointerEvents="box-none"\n          style={[\n            styles.voiceButtonTouchTarget,');
+    expect(sharedSource).toContain('resolveMobileComposerVoiceButtonAnchorStyle({');
     expect(sharedSource).toContain('{floatingVoiceButton?.(floatingVoiceButtonStyle)}');
+    const voiceButtonHitAreaStyleStart = sharedSource.indexOf('voiceButtonTouchTarget: {');
+    const voiceButtonHitAreaStyleEnd = sharedSource.indexOf('\n  },', voiceButtonHitAreaStyleStart);
+    const voiceButtonHitAreaStyle = sharedSource.slice(voiceButtonHitAreaStyleStart, voiceButtonHitAreaStyleEnd);
+    expect(voiceButtonHitAreaStyleStart).toBeGreaterThan(-1);
+    expect(voiceButtonHitAreaStyle).toContain('minWidth: MOBILE_COMPOSER_MIN_TOUCH_TARGET');
+    expect(voiceButtonHitAreaStyle).not.toContain('width: MOBILE_COMPOSER_MIN_TOUCH_TARGET');
     expect(sharedSource).toContain('export function ComposerToolbarLeftGroup');
     expect(sharedSource).toContain('toolbarLeftGroup: {');
     expect(sharedSource).toContain('justifyContent: \'flex-start\'');

--- a/apps/mobile/src/session/MobileComposerInputRow.tsx
+++ b/apps/mobile/src/session/MobileComposerInputRow.tsx
@@ -98,8 +98,9 @@ export interface MobileComposerInputRowProps {
    * 由定位壳包成同一实例：简洁态在输入行右侧垂直居中、卡片态落在底部
    * 工具排（工具排里放 ComposerToolbarVoiceSlot 占位）。壳的样式走
    * resolveMobileComposerVoiceButtonAnchorStyle（数字 top/bottom +
-   * justifyContent），按钮本身不再吃 absolute inset，避免百分比 top
-   * 残留把麦克风停在卡片中部挡住文字。
+   * justifyContent），并由 voiceButtonTouchTarget 保住至少 44pt 横向命中区；
+   * 按钮本身不再吃 absolute inset，避免百分比 top 残留把麦克风停在卡片
+   * 中部挡住文字。
    */
   floatingVoiceButton?: (style: StyleProp<ViewStyle>) => ReactNode;
   floatingVoiceButtonStyle?: StyleProp<ViewStyle>;
@@ -325,10 +326,13 @@ export function MobileComposerInputRow({
       {voicePlacement?.inline || voicePlacement?.floating ? (
         <View
           pointerEvents="box-none"
-          style={resolveMobileComposerVoiceButtonAnchorStyle({
-            cardLayout,
-            floating: voicePlacement.floating,
-          })}
+          style={[
+            styles.voiceButtonTouchTarget,
+            resolveMobileComposerVoiceButtonAnchorStyle({
+              cardLayout,
+              floating: voicePlacement.floating,
+            }),
+          ]}
         >
           {floatingVoiceButton?.(floatingVoiceButtonStyle)}
         </View>
@@ -608,6 +612,12 @@ const makeMobileComposerInputRowStyles = (colors: ThemeColors) => ({
   toolbarVoiceSlot: {
     height: MOBILE_COMPOSER_CONTROL_SIZE,
     width: MOBILE_COMPOSER_CONTROL_SIZE,
+  },
+  // hitSlop 不会越过直接父边界：普通 34pt 麦克风需要至少 44pt 的横向父层。
+  // 用 minWidth 而非 width，录音计时胶囊仍可向左自然增宽；alignItems:flex-end
+  // 保持按钮右缘和原锚点不变。
+  voiceButtonTouchTarget: {
+    minWidth: MOBILE_COMPOSER_MIN_TOUCH_TARGET,
   },
   // 字号 / 行高 / 水平内边距全部走 composerTextMetrics:WebView 富文本编辑器与语音
   // 听写覆盖层用同一份度量,三边换行位置必须逐字一致(见该文件注释)。

--- a/apps/mobile/src/session/MobileComposerInputRow.tsx
+++ b/apps/mobile/src/session/MobileComposerInputRow.tsx
@@ -95,10 +95,11 @@ export interface MobileComposerInputRowProps {
   editable?: boolean;
   /**
    * 语音按钮 render。语音按钮是简洁态与卡片态都存在的常驻控件，
-   * 由组件用一份完整 absolute 样式渲染为同一实例：简洁态贴输入行右侧、
-   * 卡片态落在底部工具排右二（工具排里放 ComposerToolbarVoiceSlot 占位）。
-   * 定位走 resolveMobileComposerVoiceButtonAnchorStyle，两态都写全 top /
-   * bottom / transform，避免 RN 合并残留把麦克风停在卡片中部。
+   * 由定位壳包成同一实例：简洁态在输入行右侧垂直居中、卡片态落在底部
+   * 工具排（工具排里放 ComposerToolbarVoiceSlot 占位）。壳的样式走
+   * resolveMobileComposerVoiceButtonAnchorStyle（数字 top/bottom +
+   * justifyContent），按钮本身不再吃 absolute inset，避免百分比 top
+   * 残留把麦克风停在卡片中部挡住文字。
    */
   floatingVoiceButton?: (style: StyleProp<ViewStyle>) => ReactNode;
   floatingVoiceButtonStyle?: StyleProp<ViewStyle>;
@@ -321,15 +322,33 @@ export function MobileComposerInputRow({
           {toolbar}
         </View>
       ) : null}
-      {voicePlacement?.inline || voicePlacement?.floating
-        ? floatingVoiceButton?.([
-          resolveMobileComposerVoiceButtonAnchorStyle({
+      {voicePlacement?.inline || voicePlacement?.floating ? (
+        <View
+          pointerEvents="box-none"
+          style={resolveMobileComposerVoiceButtonAnchorStyle({
             cardLayout,
             floating: voicePlacement.floating,
-          }),
-          floatingVoiceButtonStyle,
-        ])
-        : null}
+          })}
+        >
+          {floatingVoiceButton?.(floatingVoiceButtonStyle)}
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+/** card 工具排左侧组:[+][权限][计划][模型]。包成一行内组,药丸贴着权限而不是被 spacer 推到右侧。 */
+export function ComposerToolbarLeftGroup({
+  children,
+  testID,
+}: {
+  children: ReactNode;
+  testID?: string;
+}) {
+  const styles = useThemedStyles(makeMobileComposerInputRowStyles);
+  return (
+    <View style={styles.toolbarLeftGroup} testID={testID}>
+      {children}
     </View>
   );
 }
@@ -571,10 +590,20 @@ const makeMobileComposerInputRowStyles = (colors: ThemeColors) => ({
     alignItems: 'center',
     flexDirection: 'row',
     gap: MOBILE_COMPOSER_TOOL_GAP,
+    justifyContent: 'flex-start',
     marginTop: 8,
+  },
+  toolbarLeftGroup: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    flexShrink: 1,
+    gap: MOBILE_COMPOSER_TOOL_GAP,
+    justifyContent: 'flex-start',
+    minWidth: 0,
   },
   toolbarSpacer: {
     flex: 1,
+    minWidth: 0,
   },
   toolbarVoiceSlot: {
     height: MOBILE_COMPOSER_CONTROL_SIZE,

--- a/apps/mobile/src/session/composerVoiceButtonAnchor.ts
+++ b/apps/mobile/src/session/composerVoiceButtonAnchor.ts
@@ -32,7 +32,8 @@ export type MobileComposerVoiceButtonAnchorStyle = {
   position: 'absolute';
   right: number;
   top: 0;
-  bottom: number;
+  bottom: 0;
+  paddingBottom: number;
   justifyContent: 'center' | 'flex-end';
   alignItems: 'flex-end';
   zIndex: number;
@@ -42,10 +43,12 @@ export type MobileComposerVoiceButtonAnchorStyle = {
  * 语音按钮定位壳的样式。壳铺在整张输入卡上，按钮是壳的 in-flow 子节点：
  * 收起态垂直居中，卡片态贴底（工具排）。
  *
- * 两态都写数字 top / bottom，禁止 `top: '50%'` / `'auto'` / `undefined`：
+ * 两态都写数字 top / bottom / paddingBottom，禁止 `top: '50%'` / `'auto'` /
+ * `undefined`：
  * RN 扁平化会跳过 undefined，Yoga 也清不掉已经生效的百分比 top，麦克风会
  * 停在卡片中部挡住文字（#3053 用 `top: 'auto'` 仍失败）。justifyContent
- * 负责垂直落点，不靠 transform / 百分比。
+ * 负责垂直落点，不靠 transform / 百分比。卡片态让壳延伸到卡片底边，再用
+ * paddingBottom 保持按钮视觉位置：直接父层在按钮下方仍有空间，不会裁掉 hitSlop。
  */
 export function resolveMobileComposerVoiceButtonAnchorStyle(input: {
   cardLayout: boolean;
@@ -59,7 +62,8 @@ export function resolveMobileComposerVoiceButtonAnchorStyle(input: {
     position: 'absolute',
     right,
     top: 0,
-    bottom: input.cardLayout ? MOBILE_COMPOSER_VOICE_ANCHOR_CARD_BOTTOM : 0,
+    bottom: 0,
+    paddingBottom: input.cardLayout ? MOBILE_COMPOSER_VOICE_ANCHOR_CARD_BOTTOM : 0,
     justifyContent: input.cardLayout ? 'flex-end' : 'center',
     alignItems: 'flex-end',
     zIndex: 2,

--- a/apps/mobile/src/session/composerVoiceButtonAnchor.ts
+++ b/apps/mobile/src/session/composerVoiceButtonAnchor.ts
@@ -31,17 +31,21 @@ export function resolveMobileComposerVoiceButtonPlacement(input: {
 export type MobileComposerVoiceButtonAnchorStyle = {
   position: 'absolute';
   right: number;
-  top: '50%' | 'auto';
-  bottom: number | 'auto';
-  transform: Array<{ translateY: number }>;
+  top: 0;
+  bottom: number;
+  justifyContent: 'center' | 'flex-end';
+  alignItems: 'flex-end';
   zIndex: number;
 };
 
 /**
- * 语音按钮的完整定位。必须一次性写出 top / bottom / transform 三套互斥键,
- * 不能靠 StyleSheet 数组后项写 `undefined` 去覆盖前项:
- * RN 扁平化会跳过 undefined,卡片态就会残留收起态的 `top: '50%'`,麦克风停在
- * 卡片中部(工具排占位空着)。漏写的键在原生侧也可能继续沿用上一帧的 inset。
+ * 语音按钮定位壳的样式。壳铺在整张输入卡上，按钮是壳的 in-flow 子节点：
+ * 收起态垂直居中，卡片态贴底（工具排）。
+ *
+ * 两态都写数字 top / bottom，禁止 `top: '50%'` / `'auto'` / `undefined`：
+ * RN 扁平化会跳过 undefined，Yoga 也清不掉已经生效的百分比 top，麦克风会
+ * 停在卡片中部挡住文字（#3053 用 `top: 'auto'` 仍失败）。justifyContent
+ * 负责垂直落点，不靠 transform / 百分比。
  */
 export function resolveMobileComposerVoiceButtonAnchorStyle(input: {
   cardLayout: boolean;
@@ -51,23 +55,13 @@ export function resolveMobileComposerVoiceButtonAnchorStyle(input: {
     ? MOBILE_COMPOSER_VOICE_ANCHOR_RIGHT + MOBILE_COMPOSER_CONTROL_SIZE + MOBILE_COMPOSER_TOOL_GAP
     : MOBILE_COMPOSER_VOICE_ANCHOR_RIGHT;
 
-  if (input.cardLayout) {
-    return {
-      position: 'absolute',
-      right,
-      top: 'auto',
-      bottom: MOBILE_COMPOSER_VOICE_ANCHOR_CARD_BOTTOM,
-      transform: [],
-      zIndex: 2,
-    };
-  }
-
   return {
     position: 'absolute',
     right,
-    top: '50%',
-    bottom: 'auto',
-    transform: [{ translateY: -MOBILE_COMPOSER_CONTROL_SIZE / 2 }],
+    top: 0,
+    bottom: input.cardLayout ? MOBILE_COMPOSER_VOICE_ANCHOR_CARD_BOTTOM : 0,
+    justifyContent: input.cardLayout ? 'flex-end' : 'center',
+    alignItems: 'flex-end',
     zIndex: 2,
   };
 }


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Mobile 输入卡展开后的两个布局问题：语音按钮不再因 React Native 样式残留停在多行输入区中部，模型选择控件固定在附件、权限和计划控件右侧，不再随发送或停止按钮显隐而横向跳动。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：会话页与新建任务页的输入工具栏左侧分组；语音按钮定位壳；对应单元测试
- 明确不包含：Desktop、服务端、原生配置、原生依赖和运行时 fingerprint 输入
- 用户可见变化：模型选择控件稳定左对齐；多行输入时语音按钮保持在底部工具栏，不遮挡输入文字
- 是否存在 breaking change：无

### UI 变化

- Mobile 会话页和新建任务页：`[附件][权限][计划][模型]` 固定为左侧组，右侧保留停止、语音和发送/创建操作。
- 多行输入：语音按钮由铺满输入卡的定位壳控制，收起态垂直居中、展开态贴底。
- 已在 `Cindy Share Debug - iPhone 17 Pro` 实机检查 Light / Dark 两种模式。
- 引用的设计规范：`docs/design-rules/DESIGN.md` §10「Light / Dark Dual-Mode Delivery Gate」；`apps/mobile/docs/mobile-design-guide.md` §5「间距 / 圆角 / 触控 / 安全区」。本次沿用语义主题样式、既有控件尺寸和工具栏间距，没有新增硬编码颜色或非 token 圆角。

## 怎么验证的

### 自动验证

```text
pnpm --filter mobile run --if-present typecheck
结果：通过

pnpm test:unit:related
结果：通过；apps/mobile 相关测试通过

git diff --check
结果：通过

pnpm check:dco
结果：通过；1 个提交已签名
```

### 手工验证

- 环境：`Cindy Share Debug - iPhone 17 Pro`，分支 `cindy/cheerful-kalam`，Metro 8081 属于当前 worktree；验收时 `__DEV__` build label 为 `cindy/cheerful-kalam@05264ab01+cc3386b41a`。
- 会话页空输入：模型控件保持在左侧，语音按钮位于右侧，无发送按钮。
- 输入内容后：发送按钮出现，模型控件位置不变；语音按钮向左让位且保持在工具栏。
- 多行输入：语音按钮未遮挡文字。
- 新建任务页：模型控件同样固定在左侧组。
- Light / Dark 两种模式均已验收通过。

### 未执行的验证

- 未执行 Android 实机验证；本次为共享 React Native JS/TSX 布局改动，已在 iOS 模拟器覆盖两种主题和会话页/新建任务页。
- 未执行全仓 `pnpm test:unit`；提交门禁要求的相关单测已通过，CI 将执行完整单测。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Mobile 会话输入区和新建任务输入区的 JS/TSX 布局，不涉及原生层、协议、数据库、权限或用户数据。
- 回滚 / 降级方式：恢复原工具栏控件顺序，并恢复原语音按钮 anchor 样式实现。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（无需新增独立文档；已更新代码注释与测试）
- [x] 已确认测试结果或说明未执行原因