### PR TITLE
fix(desktop): reset goal host on account boundary (#3117)

### DIFF
--- a/apps/desktop/src/main/bootstrap-electron.ts
+++ b/apps/desktop/src/main/bootstrap-electron.ts
@@ -855,6 +855,9 @@ import { createLogger as createSchedulerLogger } from './logger.js';
 
 let makerProviderRefreshConfigured = false;
 let startPendingAccountProviderReadiness: { ownerId: string; start: () => void } | null = null;
+// Async readiness callbacks must not commit hosts after an account boundary.
+// Incremented synchronously before teardown awaits any drains.
+let accountRuntimeGeneration = 0;
 
 function markMakerProviderRefreshConfigured(): void {
   makerProviderRefreshConfigured = true;
@@ -904,6 +907,14 @@ async function waitForCurrentAccountProviderModelsReady(): Promise<void> {
  * resetScheduler 把 _scheduler 置 null，新实例不在 WeakSet 里，会重新 attach 一次。
  */
 async function attemptStartScheduler(): Promise<void> {
+  const schedulerStartGeneration = accountRuntimeGeneration;
+  const schedulerStartOwnerScopeKey = activeOwnerScopeKey();
+  const isCurrentSchedulerStart = (): boolean =>
+    schedulerStartGeneration === accountRuntimeGeneration &&
+    !isAppSessionBoundaryPending() &&
+    schedulerStartOwnerScopeKey === activeOwnerScopeKey();
+
+  if (!isCurrentSchedulerStart()) return;
   // 两个前置条件必须满足才能启动：
   //   1. maker 单例已构造 (splash check-environment 完成 → registerMakerIpcsAfterSplash)
   //   2. DbClient 已 smoke 通过 (user login → renderer 触发 'local-db:ensure-ready' IPC)
@@ -932,6 +943,7 @@ async function attemptStartScheduler(): Promise<void> {
   // await，确保第一个 scheduler tick 能看到用户已保存的自定义 MCP 配置。
   // 若 Maker 已被 registerMakerIpcsAfterSplash 构造过，promise 早已 resolve，no-op。
   await waitForInitialCustomMcpRefresh();
+  if (!isCurrentSchedulerStart()) return;
   const automationGitBaselineHooks = createAutomationUserTurnGitBaselineHooks();
   try {
     const scheduler = await startScheduler({
@@ -942,6 +954,7 @@ async function attemptStartScheduler(): Promise<void> {
       logger: createSchedulerLogger('scheduler-host'),
       ...automationGitBaselineHooks,
     });
+    if (!isCurrentSchedulerStart()) return;
     // scheduler 真正 ready 后挂 listener + 喂入 readiness holder。WeakSet 按实例
     // 去重:localDb onReady 重试可能再次拿到同实例，此时 no-op；
     // 切账号后新实例不在 set 里，会重新 attach。
@@ -956,6 +969,7 @@ async function attemptStartScheduler(): Promise<void> {
   } catch (err) {
     console.error('[bootstrap-electron] startScheduler failed (non-fatal):', err);
   }
+  if (!isCurrentSchedulerStart()) return;
   // GoalController 与 scheduler 同就绪点启动(maker + localDb 均 ready):内部幂等
   // (_controller 已存在则直接返回),启动时 resume 所有 active goal。失败非致命。
   try {
@@ -1230,6 +1244,7 @@ async function teardownGhostProjectionBoundary(reason: string): Promise<void> {
 }
 
 async function teardownAuthAccountBoundary(reason: string): Promise<void> {
+  accountRuntimeGeneration += 1;
   const blockingFailures: unknown[] = [];
   // Hardware must stop before the long async drain. Otherwise a held stick or
   // microphone keeps acting on the outgoing account while caches and IM stop.

--- a/apps/desktop/src/main/bootstrap-electron.ts
+++ b/apps/desktop/src/main/bootstrap-electron.ts
@@ -842,7 +842,11 @@ import {
   resetSchedulerReady,
 } from './maker-ipc/schedule.js';
 import { registerProjectAutomationIpc } from './maker-ipc/project-automation.js';
-import { startGoalController, getGoalController } from './goal-host/index.js';
+import {
+  startGoalController,
+  getGoalController,
+  resetGoalController,
+} from './goal-host/index.js';
 import { startLearnHost, getLearnController, resetLearnController } from './learn-host/index.js';
 import { fetchHubSkillReference } from './learn-host/hubReference.js';
 import { registerLearnIpc, broadcastLearnEvent } from './learn-host/registerIpc.js';
@@ -1313,6 +1317,10 @@ async function teardownAuthAccountBoundary(reason: string): Promise<void> {
   // 路径同构,这里关掉 teardown 路径的对偶窗口)。
   // 不 reject _pending — 让在途请求继续等下次 setSchedulerReady,30s 超时兜底。
   resetSchedulerReady();
+  // GoalController closes over the outgoing Maker and owner DB. Dispose it at
+  // the boundary so the next readiness pass creates a controller for the new
+  // account instead of reusing a shutdown Maker.
+  resetGoalController();
   const agentIslandService = getAgentIslandService();
   agentIslandService?.resetRuntimeState();
   // ② 再停旧 scheduler。scheduler 持有旧 user 的 storage drizzle 引用,必须在

--- a/apps/desktop/src/main/goal-host/__tests__/controller.test.ts
+++ b/apps/desktop/src/main/goal-host/__tests__/controller.test.ts
@@ -3180,6 +3180,28 @@ describe('GoalController', () => {
     expect(h.session.sends).toHaveLength(0);
   });
 
+  it('does not let dispose revive a startup active snapshot after an async storage read', async () => {
+    const active = seededGoal({ sessionId: 's1', objective: 'stay disposed' });
+    let releaseGet!: (state: GoalState | null) => void;
+    const blockedGet = new Promise<GoalState | null>((resolve) => {
+      releaseGet = resolve;
+    });
+    const get = vi.spyOn(h.storage, 'get').mockReturnValueOnce(blockedGet);
+    const onEvent = vi.spyOn(h.session, 'onEvent');
+
+    await h.storage.set(active);
+    const startupResume = h.controller.resumeActiveGoals();
+    await vi.waitFor(() => expect(get).toHaveBeenCalledWith('s1'));
+
+    h.controller.dispose();
+    releaseGet(active);
+    await startupResume;
+
+    expect(onEvent).not.toHaveBeenCalled();
+    expect(h.session.sends).toHaveLength(0);
+    expect(h.updates).toHaveLength(0);
+  });
+
   it('resumeOnOpen 在释放 route 锁前挂 listener，并在会话随即关闭后迁移到重建会话', async () => {
     const firstSession = new FakeSession('s1', 'claude-code');
     const recreatedSession = new FakeSession('s1', 'claude-code');

--- a/apps/desktop/src/main/goal-host/controller.ts
+++ b/apps/desktop/src/main/goal-host/controller.ts
@@ -371,6 +371,8 @@ function freshTurn(
 // ── 控制器 ──────────────────────────────────────────────────────────────────
 
 export class GoalController {
+  /** Once disposed at an account/process boundary, this controller can never resume work. */
+  private disposed = false;
   private readonly unsubscribers = new Map<string, () => void>();
   /**
    * 每个 goal listener 当前绑定的 SessionLike 对象引用。deferred agent switch 落实后
@@ -1459,11 +1461,14 @@ export class GoalController {
    */
   async resumeActiveGoals(): Promise<void> {
     const active = await this.deps.storage.listActive();
+    if (this.disposed) return;
     let resumed = 0;
     for (const snapshot of active) {
+      if (this.disposed) return;
       // listActive 是启动扫描快照；并发 Stop 可能已经立 cancelled boundary 或写成 paused。
       if (this.turns.has(snapshot.sessionId)) continue;
       const state = await this.deps.storage.get(snapshot.sessionId);
+      if (this.disposed) return;
       if (!state || state.status !== 'active' || this.turns.has(snapshot.sessionId)) continue;
       // 保守:只对**已经活着**的会话重挂 + 续跑;不在启动时强行 spawn agent
       //(开机就偷偷跑目标过于激进)。没活的留 dormant,等用户重发 /goal 时由
@@ -1475,6 +1480,7 @@ export class GoalController {
         });
         continue;
       }
+      if (this.disposed) return;
       this.turns.set(state.sessionId, freshTurn());
       this.attachListener(state.sessionId);
       this.emit(state);
@@ -1495,8 +1501,10 @@ export class GoalController {
     // usageLimited 行:重启后 timer 丢了,按存档的 usageResetAt 重排自动续跑
     //(已过点 → delay 0 触发;未知 resetAt → 不排,留待手动 resume)。
     const limited = await this.deps.storage.listUsageLimited();
+    if (this.disposed) return;
     let rescheduled = 0;
     for (const g of limited) {
+      if (this.disposed) return;
       if (g.usageResetAt == null) continue;
       this.scheduleUsageResume(g.sessionId, g.usageResetAt);
       rescheduled += 1;
@@ -1508,6 +1516,7 @@ export class GoalController {
 
   /** 关停所有监听 + 计时器(测试 / 进程退出)。 */
   dispose(): void {
+    this.disposed = true;
     for (const sessionId of [...this.unsubscribers.keys()]) {
       this.stopSession(sessionId);
     }

--- a/apps/desktop/src/main/maker-host/__tests__/accountProviderReadinessWiring.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/accountProviderReadinessWiring.test.ts
@@ -235,4 +235,29 @@ describe('account provider readiness wiring', () => {
     expect(goalReset).toBeGreaterThan(schedulerReadyReset);
     expect(goalReset).toBeLessThan(makerShutdown);
   });
+
+  it('guards async scheduler and Goal startup against an account boundary', () => {
+    const teardown = bootstrapSource.indexOf('async function teardownAuthAccountBoundary');
+    const generationBump = bootstrapSource.indexOf('accountRuntimeGeneration += 1;', teardown);
+    const start = bootstrapSource.indexOf('async function attemptStartScheduler');
+    const capturedGeneration = bootstrapSource.indexOf(
+      'const schedulerStartGeneration = accountRuntimeGeneration;',
+      start,
+    );
+    const refresh = bootstrapSource.indexOf('await waitForInitialCustomMcpRefresh();', start);
+    const refreshGuard = bootstrapSource.indexOf('if (!isCurrentSchedulerStart()) return;', refresh);
+    const schedulerAwait = bootstrapSource.indexOf('const scheduler = await startScheduler({', start);
+    const schedulerGuard = bootstrapSource.indexOf('if (!isCurrentSchedulerStart()) return;', schedulerAwait);
+    const goalGuard = bootstrapSource.indexOf(
+      'if (!isCurrentSchedulerStart()) return;',
+      schedulerGuard + 1,
+    );
+
+    expect(teardown).toBeGreaterThanOrEqual(0);
+    expect(generationBump).toBeGreaterThan(teardown);
+    expect(capturedGeneration).toBeGreaterThan(start);
+    expect(refreshGuard).toBeGreaterThan(refresh);
+    expect(schedulerGuard).toBeGreaterThan(schedulerAwait);
+    expect(goalGuard).toBeGreaterThan(schedulerGuard);
+  });
 });

--- a/apps/desktop/src/main/maker-host/__tests__/accountProviderReadinessWiring.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/accountProviderReadinessWiring.test.ts
@@ -223,4 +223,16 @@ describe('account provider readiness wiring', () => {
     expect(joinPrevious).toBeGreaterThan(makerShutdown);
     expect(clearAfterJoin).toBeGreaterThan(joinPrevious);
   });
+
+  it('disposes GoalController before shutting down the outgoing Maker', () => {
+    const teardown = bootstrapSource.indexOf('async function teardownAuthAccountBoundary');
+    const schedulerReadyReset = bootstrapSource.indexOf('resetSchedulerReady();', teardown);
+    const goalReset = bootstrapSource.indexOf('resetGoalController();', teardown);
+    const makerShutdown = bootstrapSource.indexOf('await maker.shutdown()', teardown);
+
+    expect(teardown).toBeGreaterThanOrEqual(0);
+    expect(schedulerReadyReset).toBeGreaterThan(teardown);
+    expect(goalReset).toBeGreaterThan(schedulerReadyReset);
+    expect(goalReset).toBeLessThan(makerShutdown);
+  });
 });


### PR DESCRIPTION
## 这次改了什么

### 摘要

账号登出或切换时，释放持有旧 Maker 和旧账号数据库闭包的 GoalController。重新登录后的就绪流程会创建并绑定当前账号的新 GoalController，避免目标恢复请求落到已 shutdown 的 Maker。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#3117
- 本 PR 包含：账号边界 teardown 中 reset GoalController；增加 teardown 顺序回归测试。
- 明确不包含：Maker Core shutdown 语义、Goal 持久化模型、跨账号 Goal 自动恢复策略、UI 错误文案。
- 用户可见变化：登出或切换账号后无需重启应用即可创建/恢复目标。
- 是否存在 breaking change：无

### UI 变化

- 不涉及：仅修改 Desktop main 生命周期和源码顺序测试，没有界面、交互或文案变化。
- 引用的设计规范：不涉及。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/maker-host/__tests__/accountProviderReadinessWiring.test.ts src/main/goal-host/__tests__/controller.test.ts src/main/goal-host/__tests__/sessionRestore.test.ts
结果：3 个测试文件通过，190 个测试通过。

pnpm --filter desktop run --if-present typecheck
结果：通过。

pnpm test:unit:related
结果：apps/desktop related unit 通过。

pnpm check:dco
结果：1 个 commit 的 DCO 签名通过。
```

### 手工验证

不涉及：本 PR 未启动打包 Desktop 实例。

### 未执行的验证

未执行真实 macOS 打包应用中的登出→重新登录和账号 A→B 切换手工流程；需要维护者在目标平台确认运行时行为。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Goal host 的账号边界生命周期；Goal 数据和 Maker Core 语义不变。
- 回滚 / 降级方式：回滚本 PR commit；旧行为会重新出现，应用重启仍可重建 GoalController。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [ ] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因

## AI Assistance

Implemented with Codex; source and test changes were reviewed locally against the account-boundary lifecycle.

## Reviewer Focus

- Confirm GoalController is disposed before outgoing Maker shutdown on logout and account switch.
- Confirm the existing readiness path recreates the controller with the next account's Maker/DB.
