### PR TITLE
fix(mobile): 修复队列消息操作菜单不刷新

### DIFF
--- a/apps/mobile/src/__tests__/pendingSendItems.test.ts
+++ b/apps/mobile/src/__tests__/pendingSendItems.test.ts
@@ -9,7 +9,9 @@
 import { describe, expect, it } from 'vitest';
 import { formatQuoteForSend } from '@cindy/maker-shared/chat-quotes';
 import {
+  buildMobileMessageListExtraData,
   buildPendingSendItems,
+  isPendingSendItemSelected,
   pendingSendItemKey,
   pendingSendSpins,
   type MobilePendingSendActions,
@@ -186,6 +188,26 @@ describe('buildPendingSendItems', () => {
 });
 
 describe('pending_send 渲染接线', () => {
+  it('changes the list refresh signal and exposes queue actions when a bubble is selected', () => {
+    const [item] = build({
+      queue: [queued('selected')],
+      presentationByClientId: new Map([['selected', {
+        actions: {
+          remove: { disabled: false, disabledReason: null },
+          edit: { disabled: false, disabledReason: null },
+          steer: { disabled: false, disabledReason: null },
+        },
+        hint: null,
+      }]]),
+    });
+    const collapsed = buildMobileMessageListExtraData(null, false);
+    const expanded = buildMobileMessageListExtraData(item.clientId, false);
+
+    expect(expanded).not.toEqual(collapsed);
+    expect(isPendingSendItemSelected(item, collapsed.pendingSendSelectedClientId)).toBe(false);
+    expect(isPendingSendItemSelected(item, expanded.pendingSendSelectedClientId)).toBe(true);
+  });
+
   it('keeps pendingSend on the renderer actions object', async () => {
     // 回归防线:MessageRenderer 的 actions 是显式组装的 useMemo。漏掉这一项时 props 和
     // 类型都还对(interface 上有、JSX 也传了),但 actions.pendingSend 是 undefined,渲染
@@ -200,7 +222,7 @@ describe('pending_send 渲染接线', () => {
     const actionsEnd = source.indexOf('viewportLayout.contentWidth,\n  ]);', actionsStart);
     const actionsBlock = source.slice(actionsStart, actionsEnd);
     expect(actionsBlock).toContain('pendingSend,');
-    expect(source).toContain('pendingSendSelectedClientId: pendingSend?.selectedClientId ?? null');
+    expect(source).toContain('buildMobileMessageListExtraData(');
     expect(source).toContain('extraData={messageListExtraData}');
     // 渲染分支存在,且 items 的联合类型里有这一支。
     expect(source).toContain("case 'pending_send':");

--- a/apps/mobile/src/__tests__/pendingSendItems.test.ts
+++ b/apps/mobile/src/__tests__/pendingSendItems.test.ts
@@ -200,6 +200,8 @@ describe('pending_send 渲染接线', () => {
     const actionsEnd = source.indexOf('viewportLayout.contentWidth,\n  ]);', actionsStart);
     const actionsBlock = source.slice(actionsStart, actionsEnd);
     expect(actionsBlock).toContain('pendingSend,');
+    expect(source).toContain('pendingSendSelectedClientId: pendingSend?.selectedClientId ?? null');
+    expect(source).toContain('extraData={messageListExtraData}');
     // 渲染分支存在,且 items 的联合类型里有这一支。
     expect(source).toContain("case 'pending_send':");
     expect(source).toContain('actions={actions.pendingSend}');

--- a/apps/mobile/src/session/MessageRenderer.tsx
+++ b/apps/mobile/src/session/MessageRenderer.tsx
@@ -237,6 +237,7 @@ import {
   PendingSendBubble,
   type PendingSendBubbleActions,
 } from '@/session/PendingSendBubble';
+import { buildMobileMessageListExtraData } from '@/session/pendingSendItems';
 import { dedupeToolMediaByUrl } from '@cindy/maker-shared/message-render';
 import { tokenizeThinkingText } from '@cindy/maker-shared/thinking-text';
 import {
@@ -1385,10 +1386,13 @@ export function MessageRenderer({
   // pending_send 的展开态不改变 listData；LegendList 会复用现有行，单靠 renderItem
   // 闭包更新不足以保证可见行重绘。把选中项显式纳入 extraData，确保轻点气泡后
   // 「取消 / 编辑 / 插话」操作行立即出现，不依赖滚动触发回收重渲染。
-  const messageListExtraData = useMemo(() => ({
-    pendingSendSelectedClientId: pendingSend?.selectedClientId ?? null,
-    shareSelectionActive,
-  }), [pendingSend?.selectedClientId, shareSelectionActive]);
+  const messageListExtraData = useMemo(
+    () => buildMobileMessageListExtraData(
+      pendingSend?.selectedClientId ?? null,
+      shareSelectionActive === true,
+    ),
+    [pendingSend?.selectedClientId, shareSelectionActive],
+  );
 
   return (
     // chat-text-quote:Provider 恒挂载(值可为 null),避免启用态翻转时整棵消息树

--- a/apps/mobile/src/session/MessageRenderer.tsx
+++ b/apps/mobile/src/session/MessageRenderer.tsx
@@ -1382,6 +1382,13 @@ export function MessageRenderer({
       item={item}
     />
   ), [actions, focusedItemKey]);
+  // pending_send 的展开态不改变 listData；LegendList 会复用现有行，单靠 renderItem
+  // 闭包更新不足以保证可见行重绘。把选中项显式纳入 extraData，确保轻点气泡后
+  // 「取消 / 编辑 / 插话」操作行立即出现，不依赖滚动触发回收重渲染。
+  const messageListExtraData = useMemo(() => ({
+    pendingSendSelectedClientId: pendingSend?.selectedClientId ?? null,
+    shareSelectionActive,
+  }), [pendingSend?.selectedClientId, shareSelectionActive]);
 
   return (
     // chat-text-quote:Provider 恒挂载(值可为 null),避免启用态翻转时整棵消息树
@@ -1393,7 +1400,7 @@ export function MessageRenderer({
         // (替代手搓的隐藏+rAF 落底 + open-settle)。
         key={scrollResetKey}
         data={listData}
-        extraData={shareSelectionActive}
+        extraData={messageListExtraData}
         keyExtractor={(item) => item.key}
         renderItem={renderMessageItem}
         recycleItems={false}

--- a/apps/mobile/src/session/PendingSendBubble.tsx
+++ b/apps/mobile/src/session/PendingSendBubble.tsx
@@ -30,7 +30,11 @@ import {
   getSentAttachmentThumbUri,
   useSentAttachmentThumbsVersion,
 } from '@/session/sentAttachmentThumbStore';
-import { pendingSendSpins, type MobilePendingSendItem } from '@/session/pendingSendItems';
+import {
+  isPendingSendItemSelected,
+  pendingSendSpins,
+  type MobilePendingSendItem,
+} from '@/session/pendingSendItems';
 import {
   isDesktopLocalMediaUrl,
   type ResolveRemoteMediaFn,
@@ -191,7 +195,7 @@ export function PendingSendBubble({
   const editing = item.phase === 'editing';
   const failed = item.phase === 'failed';
   const interactive = item.actions !== null || failed;
-  const selected = interactive && actions.selectedClientId === item.clientId;
+  const selected = isPendingSendItemSelected(item, actions.selectedClientId);
   const bubbleLabel = item.text || t('message.queue.attachmentMessage');
   const uploadsPending = item.phase === 'uploading';
   const rendersSentInlineBody = item.sentInlineTokens.some((token) => token.kind !== 'text');

--- a/apps/mobile/src/session/pendingSendItems.ts
+++ b/apps/mobile/src/session/pendingSendItems.ts
@@ -73,6 +73,31 @@ export interface MobilePendingSendItem {
   hint: string | null;
 }
 
+export interface MobileMessageListExtraData {
+  pendingSendSelectedClientId: string | null;
+  shareSelectionActive: boolean;
+}
+
+/**
+ * LegendList 的行外刷新信号。待发送气泡的展开态不改变 data，必须把选中项放进
+ * extraData，才能让已复用的可见行重新计算操作区。
+ */
+export function buildMobileMessageListExtraData(
+  pendingSendSelectedClientId: string | null,
+  shareSelectionActive: boolean,
+): MobileMessageListExtraData {
+  return { pendingSendSelectedClientId, shareSelectionActive };
+}
+
+/** 待发送气泡是否处于展开态；生产渲染与状态转换测试共用同一判据。 */
+export function isPendingSendItemSelected(
+  item: Pick<MobilePendingSendItem, 'actions' | 'clientId' | 'phase'>,
+  selectedClientId: string | null,
+): boolean {
+  const interactive = item.actions !== null || item.phase === 'failed';
+  return interactive && selectedClientId === item.clientId;
+}
+
 export function pendingSendItemKey(clientId: string): string {
   return `message-${clientId}`;
 }


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Mobile 端队列消息点击后操作菜单不刷新的问题。此前点击气泡只更新本地选中态，但虚拟列表可能复用现有行，导致“取消 / 编辑 / 插话”菜单不出现；现在将选中的客户端消息 ID 显式传入列表刷新依赖。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：用户反馈 Mobile 端队列消息难以调出“插话 / 删除”操作菜单
- 本 PR 包含：将 `pendingSend.selectedClientId` 纳入 `LegendList.extraData`，并补充选中态回归检查
- 明确不包含：网络请求、IPC、队列发送逻辑及视觉样式调整
- 用户可见变化：点击队列消息后会立即显示“取消 / 编辑 / 插话”操作
- 是否存在 breaking change：无

### UI 变化

不涉及视觉样式变化；仅修复既有操作菜单在选中态变化后未及时刷新的交互问题。

- 引用的设计规范：`docs/design-rules/DESIGN.md` 的交互反馈与状态可见性要求；沿用现有菜单、语义颜色和 Light / Dark 样式，不新增视觉 token 或布局变化

## 怎么验证的

### 自动验证

```text
pnpm --filter mobile exec vitest run src/__tests__/pendingSendItems.test.ts
结果：11/11 通过

pnpm --filter mobile run --if-present typecheck
结果：通过

pnpm test:unit:related
结果：通过

pnpm --filter mobile test:scope
结果：通过

git diff --check
结果：通过
```

### 手工验证

未进行手机实机目检。

### 未执行的验证

- 未进行 Mobile 实机 Light / Dark 模式目检；本次没有样式变化，仅复用现有 themed 样式
- 未启动 Metro 或生成 `__DEV__` build label；本次通过定向单测、Mobile scope 测试和类型检查验证

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Mobile 消息列表对队列消息选中态的刷新依赖
- 回滚 / 降级方式：回退本提交即可恢复原行为
- 冷更新判断：不触发。改动仅涉及 Mobile TypeScript 渲染逻辑和单测，不修改原生配置、原生依赖、config plugin、原生模块或其它 runtime fingerprint 输入

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次无需文档变更）
- [x] 已确认测试结果或说明未执行原因