### PR TITLE
fix(desktop): 协同 tabs 溢出时提供可点的横向滚动

### DIFF
--- a/apps/desktop/src/renderer/features/cc-agent/RolePillDropdown.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/RolePillDropdown.tsx
@@ -803,11 +803,32 @@ function WorkerTabsList({
   };
 
   return (
-    <div className="relative min-w-0 flex-1">
+    <div className="relative flex min-w-0 flex-1 items-center">
+      {/* 箭头放在滚动区域外, 两侧常驻等宽占位: 既不覆盖 tab 点击区, 也避免
+          箭头出现/隐藏时改变 scroller 宽度造成边缘状态来回抖动。 */}
+      <div className="h-6 w-5 shrink-0">
+        {scrollState.left && (
+          <button
+            type="button"
+            aria-label={t('orca.rolePill.scrollWorkersLeft')}
+            className="inline-flex h-6 w-5 items-center justify-center text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
+            onClick={() => {
+              const element = scrollRef.current;
+              if (!element) return;
+              element.scrollBy({
+                left: -workerTabsScrollStep(element.clientWidth),
+                behavior: 'smooth',
+              });
+            }}
+          >
+            <ChevronLeft size={14} />
+          </button>
+        )}
+      </div>
       <div
         ref={scrollRef}
         data-testid="worker-tabs-scroller"
-        className="flex min-w-0 flex-nowrap items-center gap-1 overflow-x-auto overscroll-x-contain pr-3 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+        className="flex min-w-0 flex-nowrap items-center gap-1 overflow-x-auto overscroll-x-contain [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
         onScroll={updateScrollState}
         onWheel={handleWheel}
       >
@@ -881,47 +902,38 @@ function WorkerTabsList({
         })}
       </div>
       {scrollState.left && (
-        <>
-          <div
-            aria-hidden
-            className="pointer-events-none absolute inset-y-0 left-0 w-8"
-            style={{ background: 'linear-gradient(to right, hsl(var(--content-area)), transparent)' }}
-          />
-          <button
-            type="button"
-            aria-label={t('orca.rolePill.scrollWorkersLeft')}
-            className="absolute inset-y-0 left-0 z-10 inline-flex w-6 items-center justify-center text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
-            onClick={() => {
-              const element = scrollRef.current;
-              if (!element) return;
-              element.scrollBy({ left: -workerTabsScrollStep(element.clientWidth), behavior: 'smooth' });
-            }}
-          >
-            <ChevronLeft size={14} />
-          </button>
-        </>
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-y-0 left-5 w-4"
+          style={{ background: 'linear-gradient(to right, hsl(var(--content-area)), transparent)' }}
+        />
       )}
       {scrollState.right && (
-        <>
-          <div
-            aria-hidden
-            className="pointer-events-none absolute inset-y-0 right-0 w-8"
-            style={{ background: 'linear-gradient(to right, transparent, hsl(var(--content-area)))' }}
-          />
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-y-0 right-5 w-4"
+          style={{ background: 'linear-gradient(to right, transparent, hsl(var(--content-area)))' }}
+        />
+      )}
+      <div className="h-6 w-5 shrink-0">
+        {scrollState.right && (
           <button
             type="button"
             aria-label={t('orca.rolePill.scrollWorkersRight')}
-            className="absolute inset-y-0 right-0 z-10 inline-flex w-6 items-center justify-center text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
+            className="inline-flex h-6 w-5 items-center justify-center text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
             onClick={() => {
               const element = scrollRef.current;
               if (!element) return;
-              element.scrollBy({ left: workerTabsScrollStep(element.clientWidth), behavior: 'smooth' });
+              element.scrollBy({
+                left: workerTabsScrollStep(element.clientWidth),
+                behavior: 'smooth',
+              });
             }}
           >
             <ChevronRight size={14} />
           </button>
-        </>
-      )}
+        )}
+      </div>
     </div>
   );
 }

--- a/apps/desktop/src/renderer/features/cc-agent/RolePillDropdown.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/RolePillDropdown.tsx
@@ -808,15 +808,27 @@ function WorkerTabsList({
     <div className="relative flex min-w-0 flex-1 items-center">
       {/* 箭头放在滚动区域外, 两侧常驻等宽占位: 既不覆盖 tab 点击区, 也避免
           箭头出现/隐藏时改变 scroller 宽度造成边缘状态来回抖动。 到边后按钮只
-          禁用不卸载, 避免键盘焦点被突然丢回 body。 */}
+          禁用不卸载, 名称与 Tip 改为到边说明, 避免键盘焦点被突然丢回 body。 */}
       <div className="h-6 w-5 shrink-0">
-        <Tip text={t('orca.rolePill.scrollWorkersLeft')} side="bottom" delay={250}>
+        <Tip
+          text={
+            scrollState.left
+              ? t('orca.rolePill.scrollWorkersLeft')
+              : t('orca.rolePill.scrollWorkersLeftEdge')
+          }
+          side="bottom"
+          delay={250}
+        >
           <button
             type="button"
-            aria-label={t('orca.rolePill.scrollWorkersLeft')}
+            aria-label={
+              scrollState.left
+                ? t('orca.rolePill.scrollWorkersLeft')
+                : t('orca.rolePill.scrollWorkersLeftEdge')
+            }
             aria-disabled={!scrollState.left || undefined}
             className={cn(
-              'inline-flex h-6 w-5 items-center justify-center text-[var(--text-secondary)] hover:text-[var(--text-primary)] focus-visible:opacity-100',
+              'inline-flex h-6 w-5 items-center justify-center rounded-full text-[var(--text-secondary)] hover:text-[var(--text-primary)] focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)]',
               !scrollState.left && 'pointer-events-none opacity-0',
             )}
             onClick={() => {
@@ -923,13 +935,25 @@ function WorkerTabsList({
         />
       )}
       <div className="h-6 w-5 shrink-0">
-        <Tip text={t('orca.rolePill.scrollWorkersRight')} side="bottom" delay={250}>
+        <Tip
+          text={
+            scrollState.right
+              ? t('orca.rolePill.scrollWorkersRight')
+              : t('orca.rolePill.scrollWorkersRightEdge')
+          }
+          side="bottom"
+          delay={250}
+        >
           <button
             type="button"
-            aria-label={t('orca.rolePill.scrollWorkersRight')}
+            aria-label={
+              scrollState.right
+                ? t('orca.rolePill.scrollWorkersRight')
+                : t('orca.rolePill.scrollWorkersRightEdge')
+            }
             aria-disabled={!scrollState.right || undefined}
             className={cn(
-              'inline-flex h-6 w-5 items-center justify-center text-[var(--text-secondary)] hover:text-[var(--text-primary)] focus-visible:opacity-100',
+              'inline-flex h-6 w-5 items-center justify-center rounded-full text-[var(--text-secondary)] hover:text-[var(--text-primary)] focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)]',
               !scrollState.right && 'pointer-events-none opacity-0',
             )}
             onClick={() => {

--- a/apps/desktop/src/renderer/features/cc-agent/RolePillDropdown.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/RolePillDropdown.tsx
@@ -15,7 +15,7 @@ import {
   type WheelEvent,
 } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Check, ChevronDown, ChevronUp, Plus, X, EllipsisVertical } from 'lucide-react';
+import { Check, ChevronDown, ChevronLeft, ChevronRight, ChevronUp, Plus, X, EllipsisVertical } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useAppShortcutDisplay } from '@/hooks/useAppShortcut';
 import { useConfirmDialog } from '@/components/ui/confirm-dialog-provider';
@@ -157,6 +157,11 @@ function ensureChildHorizontallyVisible(container: HTMLElement, child: HTMLEleme
   } else if (childRect.right > containerRect.right) {
     container.scrollLeft += childRect.right - containerRect.right;
   }
+}
+
+/** Distance for one overflow nudge. Exported for unit tests. */
+export function workerTabsScrollStep(clientWidth: number): number {
+  return Math.max(80, Math.floor(clientWidth * 0.7));
 }
 
 type WorkerListLayout = 'tabs' | 'dropdown';
@@ -801,7 +806,8 @@ function WorkerTabsList({
     <div className="relative min-w-0 flex-1">
       <div
         ref={scrollRef}
-        className="flex min-w-0 items-center gap-1 overflow-x-auto pr-3 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+        data-testid="worker-tabs-scroller"
+        className="flex min-w-0 flex-nowrap items-center gap-1 overflow-x-auto overscroll-x-contain pr-3 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
         onScroll={updateScrollState}
         onWheel={handleWheel}
       >
@@ -875,18 +881,46 @@ function WorkerTabsList({
         })}
       </div>
       {scrollState.left && (
-        <div
-          aria-hidden
-          className="pointer-events-none absolute inset-y-0 left-0 w-5"
-          style={{ background: 'linear-gradient(to right, hsl(var(--content-area)), transparent)' }}
-        />
+        <>
+          <div
+            aria-hidden
+            className="pointer-events-none absolute inset-y-0 left-0 w-8"
+            style={{ background: 'linear-gradient(to right, hsl(var(--content-area)), transparent)' }}
+          />
+          <button
+            type="button"
+            aria-label={t('orca.rolePill.scrollWorkersLeft')}
+            className="absolute inset-y-0 left-0 z-10 inline-flex w-6 items-center justify-center text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
+            onClick={() => {
+              const element = scrollRef.current;
+              if (!element) return;
+              element.scrollBy({ left: -workerTabsScrollStep(element.clientWidth), behavior: 'smooth' });
+            }}
+          >
+            <ChevronLeft size={14} />
+          </button>
+        </>
       )}
       {scrollState.right && (
-        <div
-          aria-hidden
-          className="pointer-events-none absolute inset-y-0 right-0 w-7"
-          style={{ background: 'linear-gradient(to right, transparent, hsl(var(--content-area)))' }}
-        />
+        <>
+          <div
+            aria-hidden
+            className="pointer-events-none absolute inset-y-0 right-0 w-8"
+            style={{ background: 'linear-gradient(to right, transparent, hsl(var(--content-area)))' }}
+          />
+          <button
+            type="button"
+            aria-label={t('orca.rolePill.scrollWorkersRight')}
+            className="absolute inset-y-0 right-0 z-10 inline-flex w-6 items-center justify-center text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
+            onClick={() => {
+              const element = scrollRef.current;
+              if (!element) return;
+              element.scrollBy({ left: workerTabsScrollStep(element.clientWidth), behavior: 'smooth' });
+            }}
+          >
+            <ChevronRight size={14} />
+          </button>
+        </>
       )}
     </div>
   );

--- a/apps/desktop/src/renderer/features/cc-agent/RolePillDropdown.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/RolePillDropdown.tsx
@@ -18,6 +18,7 @@ import { useTranslation } from 'react-i18next';
 import { Check, ChevronDown, ChevronLeft, ChevronRight, ChevronUp, Plus, X, EllipsisVertical } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useAppShortcutDisplay } from '@/hooks/useAppShortcut';
+import { useReducedMotion } from '@/hooks/useReducedMotion';
 import { useConfirmDialog } from '@/components/ui/confirm-dialog-provider';
 import { Tip } from '@/components/ui/tooltip';
 import { VendorIcon, agentKindToVendor } from '@/components/sidebar/VendorIcon';
@@ -751,6 +752,7 @@ function WorkerTabsList({
   const focusedTabRef = useRef<HTMLButtonElement | null>(null);
   const [scrollState, setScrollState] = useState({ left: false, right: false });
   const attention = useWorkerAttentionSnapshot();
+  const reducedMotion = useReducedMotion();
   const requestArchiveWorker = useRequestArchiveWorker(onArchiveWorker);
   const focusedWorkerId =
     selectedWorkerId ?? workers.find((worker) => worker.focused)?.workerId ?? null;
@@ -805,25 +807,30 @@ function WorkerTabsList({
   return (
     <div className="relative flex min-w-0 flex-1 items-center">
       {/* 箭头放在滚动区域外, 两侧常驻等宽占位: 既不覆盖 tab 点击区, 也避免
-          箭头出现/隐藏时改变 scroller 宽度造成边缘状态来回抖动。 */}
+          箭头出现/隐藏时改变 scroller 宽度造成边缘状态来回抖动。 到边后按钮只
+          禁用不卸载, 避免键盘焦点被突然丢回 body。 */}
       <div className="h-6 w-5 shrink-0">
-        {scrollState.left && (
+        <Tip text={t('orca.rolePill.scrollWorkersLeft')} side="bottom" delay={250}>
           <button
             type="button"
             aria-label={t('orca.rolePill.scrollWorkersLeft')}
-            className="inline-flex h-6 w-5 items-center justify-center text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
+            aria-disabled={!scrollState.left || undefined}
+            className={cn(
+              'inline-flex h-6 w-5 items-center justify-center text-[var(--text-secondary)] hover:text-[var(--text-primary)] focus-visible:opacity-100',
+              !scrollState.left && 'pointer-events-none opacity-0',
+            )}
             onClick={() => {
               const element = scrollRef.current;
-              if (!element) return;
+              if (!element || !scrollState.left) return;
               element.scrollBy({
                 left: -workerTabsScrollStep(element.clientWidth),
-                behavior: 'smooth',
+                behavior: reducedMotion ? 'auto' : 'smooth',
               });
             }}
           >
             <ChevronLeft size={14} />
           </button>
-        )}
+        </Tip>
       </div>
       <div
         ref={scrollRef}
@@ -916,23 +923,27 @@ function WorkerTabsList({
         />
       )}
       <div className="h-6 w-5 shrink-0">
-        {scrollState.right && (
+        <Tip text={t('orca.rolePill.scrollWorkersRight')} side="bottom" delay={250}>
           <button
             type="button"
             aria-label={t('orca.rolePill.scrollWorkersRight')}
-            className="inline-flex h-6 w-5 items-center justify-center text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
+            aria-disabled={!scrollState.right || undefined}
+            className={cn(
+              'inline-flex h-6 w-5 items-center justify-center text-[var(--text-secondary)] hover:text-[var(--text-primary)] focus-visible:opacity-100',
+              !scrollState.right && 'pointer-events-none opacity-0',
+            )}
             onClick={() => {
               const element = scrollRef.current;
-              if (!element) return;
+              if (!element || !scrollState.right) return;
               element.scrollBy({
                 left: workerTabsScrollStep(element.clientWidth),
-                behavior: 'smooth',
+                behavior: reducedMotion ? 'auto' : 'smooth',
               });
             }}
           >
             <ChevronRight size={14} />
           </button>
-        )}
+        </Tip>
       </div>
     </div>
   );

--- a/apps/desktop/src/renderer/features/cc-agent/RolePillDropdown.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/RolePillDropdown.tsx
@@ -808,7 +808,7 @@ function WorkerTabsList({
     <div className="relative flex min-w-0 flex-1 items-center">
       {/* 箭头放在滚动区域外, 两侧常驻等宽占位: 既不覆盖 tab 点击区, 也避免
           箭头出现/隐藏时改变 scroller 宽度造成边缘状态来回抖动。 到边后按钮只
-          禁用不卸载, 名称与 Tip 改为到边说明, 避免键盘焦点被突然丢回 body。 */}
+          禁用不卸载并移出 Tab 顺序; 已持有的焦点不强制转移, 名称与 Tip 改为到边说明。 */}
       <div className="h-6 w-5 shrink-0">
         <Tip
           text={
@@ -827,6 +827,7 @@ function WorkerTabsList({
                 : t('orca.rolePill.scrollWorkersLeftEdge')
             }
             aria-disabled={!scrollState.left || undefined}
+            tabIndex={scrollState.left ? 0 : -1}
             className={cn(
               'inline-flex h-6 w-5 items-center justify-center rounded-full text-[var(--text-secondary)] hover:text-[var(--text-primary)] focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)]',
               !scrollState.left && 'pointer-events-none opacity-0',
@@ -952,6 +953,7 @@ function WorkerTabsList({
                 : t('orca.rolePill.scrollWorkersRightEdge')
             }
             aria-disabled={!scrollState.right || undefined}
+            tabIndex={scrollState.right ? 0 : -1}
             className={cn(
               'inline-flex h-6 w-5 items-center justify-center rounded-full text-[var(--text-secondary)] hover:text-[var(--text-primary)] focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)]',
               !scrollState.right && 'pointer-events-none opacity-0',

--- a/apps/desktop/src/renderer/features/cc-agent/__tests__/RolePillDropdown.tabsScroll.test.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/__tests__/RolePillDropdown.tabsScroll.test.tsx
@@ -1,0 +1,125 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { WorkerInfo } from '../hooks/useWorkers';
+import { WorkerListToolbar, workerTabsScrollStep } from '../RolePillDropdown';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@/hooks/useAppShortcut', () => ({
+  useAppShortcutDisplay: () => '',
+}));
+
+vi.mock('@/components/ui/confirm-dialog-provider', () => ({
+  useConfirmDialog: () => ({ confirm: vi.fn(async () => false) }),
+}));
+
+function worker(overrides: Partial<WorkerInfo> = {}): WorkerInfo {
+  return {
+    workerId: 'worker-a',
+    sessionId: 'session-a',
+    role: 'developer',
+    agent: 'codex',
+    model: 'gpt-5.4',
+    effort: null,
+    label: null,
+    status: 'idle',
+    focused: true,
+    idleSince: null,
+    ...overrides,
+  };
+}
+
+function manyWorkers(count: number): WorkerInfo[] {
+  return Array.from({ length: count }, (_, index) =>
+    worker({
+      workerId: `worker-${index}`,
+      sessionId: `session-${index}`,
+      focused: index === 0,
+      label: `w${index}`,
+    }),
+  );
+}
+
+function renderOverflowToolbar(workers = manyWorkers(6)) {
+  return render(
+    <WorkerListToolbar
+      worker={workers[0]}
+      workers={workers}
+      selectedWorkerId={workers[0].workerId}
+      activeWorkerCount={workers.length}
+      softLimit={5}
+      hardLimit={8}
+      onSwitchFocus={vi.fn()}
+      onOpenCreate={vi.fn()}
+      onOpenSettings={vi.fn()}
+      onArchiveWorker={vi.fn()}
+    />,
+  );
+}
+
+function mockScrollerOverflow(scroller: HTMLElement, { scrollLeft = 0, clientWidth = 200, scrollWidth = 800 } = {}) {
+  Object.defineProperty(scroller, 'clientWidth', { configurable: true, value: clientWidth });
+  Object.defineProperty(scroller, 'scrollWidth', { configurable: true, value: scrollWidth });
+  Object.defineProperty(scroller, 'scrollLeft', {
+    configurable: true,
+    get: () => scrollLeft,
+    set: (value: number) => {
+      scrollLeft = value;
+    },
+  });
+}
+
+describe('WorkerTabsList overflow scrolling', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('uses a bounded step that fits the visible tab strip', () => {
+    expect(workerTabsScrollStep(200)).toBe(140);
+    expect(workerTabsScrollStep(40)).toBe(80);
+  });
+
+  it('does not show scroll buttons when every tab fits', () => {
+    renderOverflowToolbar(manyWorkers(2));
+    const scroller = screen.getByTestId('worker-tabs-scroller');
+    mockScrollerOverflow(scroller, { clientWidth: 400, scrollWidth: 200 });
+    fireEvent.scroll(scroller);
+    expect(screen.queryByRole('button', { name: 'orca.rolePill.scrollWorkersLeft' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'orca.rolePill.scrollWorkersRight' })).toBeNull();
+  });
+
+  it('shows a right arrow when tabs overflow and scrolls one step', () => {
+    renderOverflowToolbar();
+    const scroller = screen.getByTestId('worker-tabs-scroller');
+    const scrollBy = vi.fn();
+    mockScrollerOverflow(scroller, { scrollLeft: 0, clientWidth: 200, scrollWidth: 800 });
+    scroller.scrollBy = scrollBy;
+    fireEvent.scroll(scroller);
+
+    expect(screen.queryByRole('button', { name: 'orca.rolePill.scrollWorkersLeft' })).toBeNull();
+    const right = screen.getByRole('button', { name: 'orca.rolePill.scrollWorkersRight' });
+    fireEvent.click(right);
+    expect(scrollBy).toHaveBeenCalledWith({ left: workerTabsScrollStep(200), behavior: 'smooth' });
+  });
+
+  it('shows a left arrow after scrolling and can scroll back', () => {
+    renderOverflowToolbar();
+    const scroller = screen.getByTestId('worker-tabs-scroller');
+    const scrollBy = vi.fn();
+    mockScrollerOverflow(scroller, { scrollLeft: 240, clientWidth: 200, scrollWidth: 800 });
+    scroller.scrollBy = scrollBy;
+    fireEvent.scroll(scroller);
+
+    fireEvent.click(screen.getByRole('button', { name: 'orca.rolePill.scrollWorkersLeft' }));
+    expect(scrollBy).toHaveBeenCalledWith({ left: -workerTabsScrollStep(200), behavior: 'smooth' });
+  });
+});

--- a/apps/desktop/src/renderer/features/cc-agent/__tests__/RolePillDropdown.tabsScroll.test.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/__tests__/RolePillDropdown.tabsScroll.test.tsx
@@ -110,8 +110,8 @@ describe('WorkerTabsList overflow scrolling', () => {
     const scroller = screen.getByTestId('worker-tabs-scroller');
     mockScrollerOverflow(scroller, { clientWidth: 400, scrollWidth: 200 });
     fireEvent.scroll(scroller);
-    const left = screen.getByRole('button', { name: 'orca.rolePill.scrollWorkersLeft' });
-    const right = screen.getByRole('button', { name: 'orca.rolePill.scrollWorkersRight' });
+    const left = screen.getByRole('button', { name: 'orca.rolePill.scrollWorkersLeftEdge' });
+    const right = screen.getByRole('button', { name: 'orca.rolePill.scrollWorkersRightEdge' });
     expect(left.getAttribute('aria-disabled')).toBe('true');
     expect(right.getAttribute('aria-disabled')).toBe('true');
   });
@@ -124,10 +124,12 @@ describe('WorkerTabsList overflow scrolling', () => {
     scroller.scrollBy = scrollBy;
     fireEvent.scroll(scroller);
 
-    const left = screen.getByRole('button', { name: 'orca.rolePill.scrollWorkersLeft' });
+    const left = screen.getByRole('button', { name: 'orca.rolePill.scrollWorkersLeftEdge' });
     const right = screen.getByRole('button', { name: 'orca.rolePill.scrollWorkersRight' });
     expect(left.getAttribute('aria-disabled')).toBe('true');
     expect(right.getAttribute('aria-disabled')).toBeNull();
+    expect(left.className).toContain('focus-visible:ring-[var(--focus-ring)]');
+    expect(right.className).toContain('focus-visible:ring-[var(--focus-ring)]');
     fireEvent.click(right);
     expect(scrollBy).toHaveBeenCalledWith({ left: workerTabsScrollStep(200), behavior: 'smooth' });
   });
@@ -167,6 +169,8 @@ describe('WorkerTabsList overflow scrolling', () => {
 
     expect(right.getAttribute('aria-disabled')).toBe('true');
     expect(document.activeElement).toBe(right);
+    expect(screen.getByRole('button', { name: 'orca.rolePill.scrollWorkersRightEdge' })).toBe(right);
+    expect(right.className).toContain('focus-visible:ring-[var(--focus-ring)]');
   });
 
   it('scrolls instantly for reduced motion users', () => {

--- a/apps/desktop/src/renderer/features/cc-agent/__tests__/RolePillDropdown.tabsScroll.test.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/__tests__/RolePillDropdown.tabsScroll.test.tsx
@@ -114,6 +114,8 @@ describe('WorkerTabsList overflow scrolling', () => {
     const right = screen.getByRole('button', { name: 'orca.rolePill.scrollWorkersRightEdge' });
     expect(left.getAttribute('aria-disabled')).toBe('true');
     expect(right.getAttribute('aria-disabled')).toBe('true');
+    expect(left.getAttribute('tabindex')).toBe('-1');
+    expect(right.getAttribute('tabindex')).toBe('-1');
   });
 
   it('shows a right arrow when tabs overflow and scrolls one step', () => {
@@ -128,6 +130,8 @@ describe('WorkerTabsList overflow scrolling', () => {
     const right = screen.getByRole('button', { name: 'orca.rolePill.scrollWorkersRight' });
     expect(left.getAttribute('aria-disabled')).toBe('true');
     expect(right.getAttribute('aria-disabled')).toBeNull();
+    expect(left.getAttribute('tabindex')).toBe('-1');
+    expect(right.getAttribute('tabindex')).toBe('0');
     expect(left.className).toContain('focus-visible:ring-[var(--focus-ring)]');
     expect(right.className).toContain('focus-visible:ring-[var(--focus-ring)]');
     fireEvent.click(right);
@@ -169,8 +173,36 @@ describe('WorkerTabsList overflow scrolling', () => {
 
     expect(right.getAttribute('aria-disabled')).toBe('true');
     expect(document.activeElement).toBe(right);
+    expect(right.getAttribute('tabindex')).toBe('-1');
     expect(screen.getByRole('button', { name: 'orca.rolePill.scrollWorkersRightEdge' })).toBe(right);
     expect(right.className).toContain('focus-visible:ring-[var(--focus-ring)]');
+  });
+
+  it('keeps keyboard focus on the left arrow after it reaches the start', async () => {
+    vi.useFakeTimers();
+    renderOverflowToolbar();
+    const scroller = screen.getByTestId('worker-tabs-scroller');
+    mockScrollerOverflow(scroller, { scrollLeft: 240, clientWidth: 200, scrollWidth: 800 });
+    fireEvent.scroll(scroller);
+
+    const left = screen.getByRole('button', { name: 'orca.rolePill.scrollWorkersLeft' });
+    await act(async () => {
+      left.focus();
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(300);
+    });
+    mockScrollerOverflow(scroller, { scrollLeft: 0, clientWidth: 200, scrollWidth: 800 });
+    fireEvent.scroll(scroller);
+
+    await act(async () => {
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(left.getAttribute('aria-disabled')).toBe('true');
+    expect(document.activeElement).toBe(left);
+    expect(left.getAttribute('tabindex')).toBe('-1');
+    expect(screen.getByRole('button', { name: 'orca.rolePill.scrollWorkersLeftEdge' })).toBe(left);
   });
 
   it('scrolls instantly for reduced motion users', () => {

--- a/apps/desktop/src/renderer/features/cc-agent/__tests__/RolePillDropdown.tabsScroll.test.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/__tests__/RolePillDropdown.tabsScroll.test.tsx
@@ -74,6 +74,22 @@ function mockScrollerOverflow(scroller: HTMLElement, { scrollLeft = 0, clientWid
   });
 }
 
+function setReducedMotion(reduced: boolean): void {
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    value: vi.fn().mockImplementation(() => ({
+      matches: reduced,
+      media: '(prefers-reduced-motion: reduce)',
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+}
+
 describe('WorkerTabsList overflow scrolling', () => {
   beforeEach(() => {
     localStorage.clear();
@@ -81,6 +97,7 @@ describe('WorkerTabsList overflow scrolling', () => {
 
   afterEach(() => {
     cleanup();
+    vi.useRealTimers();
   });
 
   it('uses a bounded step that fits the visible tab strip', () => {
@@ -88,13 +105,15 @@ describe('WorkerTabsList overflow scrolling', () => {
     expect(workerTabsScrollStep(40)).toBe(80);
   });
 
-  it('does not show scroll buttons when every tab fits', () => {
+  it('keeps edge scroll buttons mounted but disabled', () => {
     renderOverflowToolbar(manyWorkers(2));
     const scroller = screen.getByTestId('worker-tabs-scroller');
     mockScrollerOverflow(scroller, { clientWidth: 400, scrollWidth: 200 });
     fireEvent.scroll(scroller);
-    expect(screen.queryByRole('button', { name: 'orca.rolePill.scrollWorkersLeft' })).toBeNull();
-    expect(screen.queryByRole('button', { name: 'orca.rolePill.scrollWorkersRight' })).toBeNull();
+    const left = screen.getByRole('button', { name: 'orca.rolePill.scrollWorkersLeft' });
+    const right = screen.getByRole('button', { name: 'orca.rolePill.scrollWorkersRight' });
+    expect(left.getAttribute('aria-disabled')).toBe('true');
+    expect(right.getAttribute('aria-disabled')).toBe('true');
   });
 
   it('shows a right arrow when tabs overflow and scrolls one step', () => {
@@ -105,8 +124,10 @@ describe('WorkerTabsList overflow scrolling', () => {
     scroller.scrollBy = scrollBy;
     fireEvent.scroll(scroller);
 
-    expect(screen.queryByRole('button', { name: 'orca.rolePill.scrollWorkersLeft' })).toBeNull();
+    const left = screen.getByRole('button', { name: 'orca.rolePill.scrollWorkersLeft' });
     const right = screen.getByRole('button', { name: 'orca.rolePill.scrollWorkersRight' });
+    expect(left.getAttribute('aria-disabled')).toBe('true');
+    expect(right.getAttribute('aria-disabled')).toBeNull();
     fireEvent.click(right);
     expect(scrollBy).toHaveBeenCalledWith({ left: workerTabsScrollStep(200), behavior: 'smooth' });
   });
@@ -121,5 +142,48 @@ describe('WorkerTabsList overflow scrolling', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'orca.rolePill.scrollWorkersLeft' }));
     expect(scrollBy).toHaveBeenCalledWith({ left: -workerTabsScrollStep(200), behavior: 'smooth' });
+  });
+
+  it('keeps keyboard focus on an arrow that reaches the edge', async () => {
+    vi.useFakeTimers();
+    renderOverflowToolbar();
+    const scroller = screen.getByTestId('worker-tabs-scroller');
+    mockScrollerOverflow(scroller, { scrollLeft: 0, clientWidth: 200, scrollWidth: 800 });
+    fireEvent.scroll(scroller);
+
+    const right = screen.getByRole('button', { name: 'orca.rolePill.scrollWorkersRight' });
+    await act(async () => {
+      right.focus();
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(300);
+    });
+    mockScrollerOverflow(scroller, { scrollLeft: 600, clientWidth: 200, scrollWidth: 800 });
+    fireEvent.scroll(scroller);
+
+    await act(async () => {
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(right.getAttribute('aria-disabled')).toBe('true');
+    expect(document.activeElement).toBe(right);
+  });
+
+  it('scrolls instantly for reduced motion users', () => {
+    setReducedMotion(true);
+    renderOverflowToolbar();
+    const scroller = screen.getByTestId('worker-tabs-scroller');
+    const scrollBy = vi.fn();
+    mockScrollerOverflow(scroller, { scrollLeft: 0, clientWidth: 200, scrollWidth: 800 });
+    scroller.scrollBy = scrollBy;
+    fireEvent.scroll(scroller);
+
+    fireEvent.click(screen.getByRole('button', { name: 'orca.rolePill.scrollWorkersRight' }));
+    expect(scrollBy).toHaveBeenCalledWith({ left: workerTabsScrollStep(200), behavior: 'auto' });
+
+    mockScrollerOverflow(scroller, { scrollLeft: 240, clientWidth: 200, scrollWidth: 800 });
+    fireEvent.scroll(scroller);
+    fireEvent.click(screen.getByRole('button', { name: 'orca.rolePill.scrollWorkersLeft' }));
+    expect(scrollBy).toHaveBeenCalledWith({ left: -workerTabsScrollStep(200), behavior: 'auto' });
   });
 });

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -9763,6 +9763,8 @@
       "layoutMenuLabel": "Worker list layout",
       "layoutTabs": "Tabs",
       "layoutDropdown": "Dropdown",
+      "scrollWorkersLeft": "Scroll to earlier workers",
+      "scrollWorkersRight": "Scroll to more workers",
       "errorBadge": "ERR",
       "errorBadgeAria": "A worker has an error"
     },

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -9765,6 +9765,8 @@
       "layoutDropdown": "Dropdown",
       "scrollWorkersLeft": "Scroll to earlier workers",
       "scrollWorkersRight": "Scroll to more workers",
+      "scrollWorkersLeftEdge": "Already at the earliest worker",
+      "scrollWorkersRightEdge": "Already at the latest worker",
       "errorBadge": "ERR",
       "errorBadgeAria": "A worker has an error"
     },

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -9749,6 +9749,8 @@
       "layoutMenuLabel": "Worker リストの表示方式",
       "layoutTabs": "タブ",
       "layoutDropdown": "ドロップダウン",
+      "scrollWorkersLeft": "前の Worker を表示",
+      "scrollWorkersRight": "次の Worker を表示",
       "errorBadge": "エラー",
       "errorBadgeAria": "エラーが発生した Worker があります"
     },

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -9751,6 +9751,8 @@
       "layoutDropdown": "ドロップダウン",
       "scrollWorkersLeft": "前の Worker を表示",
       "scrollWorkersRight": "次の Worker を表示",
+      "scrollWorkersLeftEdge": "すでに先頭の Worker を表示しています",
+      "scrollWorkersRightEdge": "すでに末尾の Worker を表示しています",
       "errorBadge": "エラー",
       "errorBadgeAria": "エラーが発生した Worker があります"
     },

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -9751,6 +9751,8 @@
       "layoutDropdown": "드롭다운",
       "scrollWorkersLeft": "이전 Worker 보기",
       "scrollWorkersRight": "다음 Worker 보기",
+      "scrollWorkersLeftEdge": "이미 첫 Worker 를 표시하고 있습니다",
+      "scrollWorkersRightEdge": "이미 마지막 Worker 를 표시하고 있습니다",
       "errorBadge": "오류",
       "errorBadgeAria": "오류가 발생한 Worker 가 있습니다"
     },

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -9749,6 +9749,8 @@
       "layoutMenuLabel": "Worker 목록 표시 방식",
       "layoutTabs": "탭",
       "layoutDropdown": "드롭다운",
+      "scrollWorkersLeft": "이전 Worker 보기",
+      "scrollWorkersRight": "다음 Worker 보기",
       "errorBadge": "오류",
       "errorBadgeAria": "오류가 발생한 Worker 가 있습니다"
     },

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -9749,6 +9749,8 @@
       "layoutMenuLabel": "Worker 列表显示方式",
       "layoutTabs": "平铺",
       "layoutDropdown": "下拉",
+      "scrollWorkersLeft": "向左查看更多 Worker",
+      "scrollWorkersRight": "向右查看更多 Worker",
       "errorBadge": "错误",
       "errorBadgeAria": "有 Worker 出错"
     },

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -9751,6 +9751,8 @@
       "layoutDropdown": "下拉",
       "scrollWorkersLeft": "向左查看更多 Worker",
       "scrollWorkersRight": "向右查看更多 Worker",
+      "scrollWorkersLeftEdge": "已是最左侧的 Worker",
+      "scrollWorkersRightEdge": "已是最右侧的 Worker",
       "errorBadge": "错误",
       "errorBadgeAria": "有 Worker 出错"
     },

--- a/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
@@ -9749,6 +9749,8 @@
       "layoutMenuLabel": "Worker 列表顯示方式",
       "layoutTabs": "平鋪",
       "layoutDropdown": "下拉",
+      "scrollWorkersLeft": "向左查看更多 Worker",
+      "scrollWorkersRight": "向右查看更多 Worker",
       "errorBadge": "錯誤",
       "errorBadgeAria": "有 Worker 出錯"
     },

--- a/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
@@ -9751,6 +9751,8 @@
       "layoutDropdown": "下拉",
       "scrollWorkersLeft": "向左查看更多 Worker",
       "scrollWorkersRight": "向右查看更多 Worker",
+      "scrollWorkersLeftEdge": "已是最左側的 Worker",
+      "scrollWorkersRightEdge": "已是最右側的 Worker",
       "errorBadge": "錯誤",
       "errorBadgeAria": "有 Worker 出錯"
     },


### PR DESCRIPTION
## 这次改了什么

### 摘要

协同平铺 Worker 列表把滚动条藏掉后，人一多、窗口不够宽时很难横移，Windows 上左侧 tab 也会被裁到点不到。溢出时补可点的左右箭头，并保留已有的垂直滚轮转横向滚动。评审后把箭头移到滚动区域外，用两侧常驻等宽占位避免边缘状态抖动，并补齐可见 Tip、键盘焦点环、到边说明与 reduced-motion 行为。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [x] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#2843
- 本 PR 包含：Worker tabs 溢出时的左右箭头、四语翻译、溢出滚动回归测试，以及 Tip / focus ring / reduced-motion / 键盘焦点回归
- 明确不包含：不改 Worker 创建上限、不改协同协议
- 用户可见变化：tabs 溢出时可点带 Tip 的箭头横移；箭头不覆盖边缘 tab 和归档按钮；系统开启减少动效时立即滚动；到边禁用态会说明原因
- 是否存在 breaking change：无

### UI 变化

协同 Worker 平铺栏在溢出时出现左右箭头；箭头位于滚动区域外侧，两侧保留等宽占位，高度与现有 24px tab / `+` 按钮对齐。到边后按钮隐藏并进入 aria-disabled 态，名称和 Tip 切换为到边说明，键盘焦点保留并显示 `--focus-ring`。

- 引用的设计规范：
  - `docs/design-rules/DESIGN.md` §2 Color Palette & Roles：箭头和焦点环走现有语义 token，不新增硬编码色
  - `docs/design-rules/DESIGN.md` §10 Light / Dark Dual-Mode Delivery Gate：颜色全部走 token，两种模式同一套实现
  - `docs/design-rules/DESIGN.md` §14.6 Icon-only Controls and Tooltips：新图标控件同时有 localized accessible name 和共享 Tip；禁用态解释不可用原因

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：apps/desktop related unit PASS

pnpm --filter desktop run typecheck
结果：通过

pnpm --filter desktop exec eslint src/renderer/features/cc-agent/RolePillDropdown.tsx src/renderer/features/cc-agent/__tests__/RolePillDropdown.tabsScroll.test.tsx
结果：通过

pnpm check:i18n && pnpm check:i18n-glossary
结果：通过
```

### 手工验证

不涉及：本轮未启 Desktop 实机点击；溢出判定、箭头条件、scrollBy 步长、边缘焦点、focus-ring class 和 reduced-motion 行为由单测覆盖。

### 未执行的验证

- 未在 Windows 实机验证鼠标点击箭头（问题原文复现平台）
- 未单独目检 Light / Dark 模式（颜色复用现有 token）

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Desktop 协同 Worker 平铺栏
- 回滚 / 降级方式：revert 本提交即可

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
