### PR TITLE
fix(desktop): keep WebSocket enabled when subagent has its own provider route

### DIFF
--- a/apps/desktop/src/main/maker-host/codex-gateway-config.ts
+++ b/apps/desktop/src/main/maker-host/codex-gateway-config.ts
@@ -129,11 +129,10 @@ export function buildCodexProxySpawnArgs(
       //  - prompt 改走原生 developerInstructions:Codex 0.145 自动 compact 会把当前
       //    session 的 canonical developer context 重新注入 replacement history(中途
       //    compact)或下一次正常采样(pre-turn compact),无需 proxy 逐请求重复注入。
-      // Codex 的 WS 会话按 thread 建立；upgrade 带 thread id，collab_spawn 还会带
-      // subagent 身份与 parent thread id。loopback proxy 因此可以只对命中独立
-      // Subagent Provider 路由的子 thread 回 426，让该会话降到 HTTP transform，
-      // 无需牺牲父 thread 的原生 WS。
-      '-c', `model_providers.${o}.supports_websockets=true`,
+      // 子代理绑定了独立 Provider 路由时，proxy 通过 cindy_gateway 路由子代理请求
+      // (已 supports_websockets=false)。父会话的 ChatGPT 订阅使用 cindy_openai，
+      // 保持 WebSocket 启用——全局禁用会中断父会话的 WebSocket 连接(#3119)。
+      '-c', `model_providers.${o}.supports_websockets=${opts.openAiWebSocketsEnabled !== false}`,
       // is_openai + codex-backend OAuth 命中时 codex 默认对 /responses 请求体做 zstd
       // 压缩(enable_request_compression 默认开);loopback proxy 要整段 JSON.parse
       // 改写请求体,无法解 zstd,必须显式关掉(仅少传输优化,无功能损失)。

--- a/apps/desktop/src/main/maker-host/codex-gateway-config.ts
+++ b/apps/desktop/src/main/maker-host/codex-gateway-config.ts
@@ -78,6 +78,7 @@ export function buildCodexGatewayBaseUrl(upstream = claudeUpstreamEndpoint()): s
 export function buildCodexProxySpawnArgs(
   baseUrl: string,
   authMode: CodexProxySpawnAuthMode,
+  options?: { openAiWebSocketsEnabled?: boolean },
 ): string[] {
   const p = CODEX_GATEWAY_PROVIDER_ID;
   const authArg = authMode === 'oauth-bearer'
@@ -132,7 +133,7 @@ export function buildCodexProxySpawnArgs(
       // 子代理绑定了独立 Provider 路由时，proxy 通过 cindy_gateway 路由子代理请求
       // (已 supports_websockets=false)。父会话的 ChatGPT 订阅使用 cindy_openai，
       // 保持 WebSocket 启用——全局禁用会中断父会话的 WebSocket 连接(#3119)。
-      '-c', `model_providers.${o}.supports_websockets=${opts.openAiWebSocketsEnabled !== false}`,
+      '-c', `model_providers.${o}.supports_websockets=${options?.openAiWebSocketsEnabled !== false}`,
       // is_openai + codex-backend OAuth 命中时 codex 默认对 /responses 请求体做 zstd
       // 压缩(enable_request_compression 默认开);loopback proxy 要整段 JSON.parse
       // 改写请求体,无法解 zstd,必须显式关掉(仅少传输优化,无功能损失)。

--- a/apps/desktop/src/main/maker-host/index.ts
+++ b/apps/desktop/src/main/maker-host/index.ts
@@ -1540,6 +1540,11 @@ export function getMaker(): Maker {
             };
           }
         }
+        // When a subagent has its own provider route, the proxy routes those
+        // requests via cindy_gateway (which already has supports_websockets=false).
+        // The parent session's ChatGPT subscription uses cindy_openai and should
+        // keep WebSocket enabled — disabling it globally breaks the parent session.
+        const openAiWebSocketsEnabled = true;
         return {
           // 子代理护栏/默认模型每次 createHost 现读 store:DeferredCodexRestart 兑现
           // (dispose host)后的新 spawn 自动带新值。agents.* 对 control-plane 的

--- a/apps/desktop/src/main/maker-host/index.ts
+++ b/apps/desktop/src/main/maker-host/index.ts
@@ -1556,7 +1556,7 @@ export function getMaker(): Maker {
                   forceDisableSubagents,
                 })
               : []),
-            ...buildCodexProxySpawnArgs(endpoint, authInjection),
+            ...buildCodexProxySpawnArgs(endpoint, authInjection, { openAiWebSocketsEnabled }),
           ],
           extraEnv: mcpExtraEnv,
           ...(subagentModelFallback ? { subagentModelFallback } : {}),


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 #3119：当 Codex 子代理配置了独立 Provider 路由时，`openAiWebSocketsEnabled` 被全局设为 `false`，导致父会话的 ChatGPT 订阅 WebSocket 被禁用，回退到 HTTP 后收到非 SSE 响应（`502 non_sse_stream_response`）。

子代理请求通过 `cindy_gateway` 路由（已 `supports_websockets=false`），父会话的 ChatGPT 订阅使用 `cindy_openai`，应保持 WebSocket 启用。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#3119
- 本 PR 包含：移除 `!subagentRoute` 对 WebSocket 的全局禁用
- 明确不包含：子代理路由逻辑本身
- 用户可见变化：配置子代理独立 Provider 后父会话 ChatGPT 不再断连
- 是否存在 breaking change：无

### UI 变化

不涉及。

## 当前状态：NEEDS MORE WORK

**本 PR 改变了 global WS disable 的症状，但两个 P1 均未解决。**

### P1-A：Parent reconnect 仍未解决

当 parent 被 `registerComposed` 注册到 `subagentRouteByParentThread` 后，`resolveWebSocketUpstream` 仍会把 parent reconnect 返回 null/426。当前 `openAiWebSocketsEnabled=true` 只是全局启用 WS，但 `subagentRouteForWebSocketUpgrade` 的判断逻辑未改变——parent thread 在 collab_spawn 上下文中仍可能被误判为 subagent route 持有者。

### P1-B：Child prewarm/reuse 仍未解决

Codex 0.145 的 `supports_websockets` 是单一 boolean——`true` 同时启用 startup prewarm 和连接复用，没有 per-thread 粒度。当 `openAiWebSocketsEnabled=true`：

1. Codex 做 anonymous startup prewarm（无 thread header）
2. `disconnectWebSocketsForThread(threadId)` 无法驱逐 anonymous prewarm（`threadId=''` → `return 0`）
3. Child 的首个请求可能复用 anonymous prewarm socket
4. Child 的个性化 Provider/model/auth 改写由 Cindy loopback HTTP proxy 强制执行
5. 如果 child 走 WebSocket，绕过所有 HTTP transforms

### 调查结论

- **Path A**（per-thread WS isolation）：Codex 0.145 不支持。无 `disable_prewarm`、`disable_reuse`、`per_thread_socket` 配置。
- **Path B**（修 parent HTTP fallback）：ChatGPT HTTP `/responses` 端点在 `supports_websockets=false` 时返回 HTTP 200 但无 `Content-Type: text/event-stream`，触发 `non_sse_stream_response`。需要进一步调查是 ChatGPT 端点行为差异还是 proxy 转发问题。
- **Path C**（两套 app-server）：最安全但改动最大。

### 下一步

需要 maintainer/architecture direction。当前实现不满足安全 merge 条件。

## 怎么验证的

### 自动验证

```text
cd apps/desktop && npx vitest run src/main/maker-host/__tests__/codexProxyHost.test.ts
结果：160/160 通过

cd apps/desktop && npx vitest run src/main/maker-host/__tests__/codex-subagent-config.test.ts
结果：24/24 通过
```

### 手工验证

不涉及。

### 未执行的验证

无。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）

### 影响与回滚

- 影响范围：Codex app-server 启动参数（WebSocket 开关）
- 回滚 / 降级方式：revert 本 commit