### PR TITLE
fix(desktop): 修复 ChatGPT OAuth 与固定 Subagent 混用问题 #3119

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/codex-subagent-config.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codex-subagent-config.test.ts
@@ -187,6 +187,60 @@ describe('resolveEffectiveCodexSubagentSettings', () => {
     },
   );
 
+  it.each(['gateway-key', 'provider-oauth'] as const)(
+    'uses the main-task default when the saved ChatGPT OAuth source is temporarily unavailable (%s)',
+    (credentialMode) => {
+      const configured = settings({
+        codex: 'gpt-5.6-terra',
+        codexProviderId: 'openai',
+        codexEffort: 'high',
+      });
+      const effective = resolveEffectiveCodexSubagentSettings(
+        configured,
+        credentialMode,
+        undefined,
+        [],
+      );
+
+      expect(effective).toEqual({
+        ...configured,
+        codex: null,
+        codexProviderId: null,
+        codexEffort: null,
+      });
+      expect(resolveCodexSubagentRoutingProfile(
+        configured,
+        credentialMode,
+        undefined,
+        [],
+      )).toBe('default');
+    },
+  );
+
+  it('uses the main-task default when the saved ChatGPT OAuth source is disconnected', () => {
+    const configured = settings({
+      codex: 'gpt-5.6-terra',
+      codexProviderId: null,
+      codexEffort: 'high',
+    });
+    const providers = [providerView('openai', configured.codex!, { connected: false })];
+    const route = resolveCodexSubagentRouteSnapshot(configured, undefined, providers);
+
+    expect(route).toBeUndefined();
+    expect(resolveEffectiveCodexSubagentSettings(
+      configured,
+      'provider-oauth',
+      route,
+      providers,
+    ).codex).toBeNull();
+    expect(resolveCodexSubagentRoutingProfile(
+      configured,
+      'provider-oauth',
+      route,
+      providers,
+    )).toBe('default');
+  });
+
   it('also removes an effort-only override from a ChatGPT OAuth main task', () => {
     const effortOnly = settings({ codexEffort: 'high' });
     const effective = resolveEffectiveCodexSubagentSettings(effortOnly, 'oauth-bearer');

--- a/apps/desktop/src/main/maker-host/__tests__/codex-subagent-config.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codex-subagent-config.test.ts
@@ -123,6 +123,32 @@ describe('resolveEffectiveCodexSubagentSettings', () => {
     },
   );
 
+  it('marks a non-ChatGPT fixed route as OAuth-only default for host reuse', () => {
+    const thirdParty = settings({
+      codex: 'xai/grok-4.3',
+      codexProviderId: 'xai',
+      codexEffort: 'high',
+    });
+    const providers = [providerView('xai', thirdParty.codex!, {
+      source: 'user',
+      authStrategy: 'oauth-token',
+    })];
+    const route = resolveCodexSubagentRouteSnapshot(thirdParty, undefined, providers);
+
+    expect(resolveCodexSubagentRoutingProfile(
+      thirdParty,
+      'oauth-bearer',
+      route,
+      providers,
+    )).toBe('oauth-default');
+    expect(resolveCodexSubagentRoutingProfile(
+      thirdParty,
+      'provider-oauth',
+      route,
+      providers,
+    )).toBe('configured');
+  });
+
   it.each(['api-key-header', 'gateway-key', 'oauth-token', 'oauth-passthrough'] as const)(
     'does not identify a third-party Codex/GPT proxy as ChatGPT OAuth (%s)',
     (authStrategy) => {
@@ -245,7 +271,7 @@ describe('resolveEffectiveCodexSubagentSettings', () => {
     const effortOnly = settings({ codexEffort: 'high' });
     const effective = resolveEffectiveCodexSubagentSettings(effortOnly, 'oauth-bearer');
     expect(effective.codexEffort).toBeNull();
-    expect(resolveCodexSubagentRoutingProfile(effortOnly, 'oauth-bearer')).toBe('default');
+    expect(resolveCodexSubagentRoutingProfile(effortOnly, 'oauth-bearer')).toBe('oauth-default');
   });
 
   it('does not create a mode-specific profile when the master switch is off', () => {

--- a/apps/desktop/src/main/maker-host/__tests__/codex-subagent-config.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codex-subagent-config.test.ts
@@ -204,6 +204,36 @@ describe('resolveEffectiveCodexSubagentSettings', () => {
     expect(codexSubagentRouteResolutionFailed(thirdParty, route)).toBe(true);
   });
 
+  it('does not infer ChatGPT OAuth when an implicit route resolved to an available third party', () => {
+    const implicit = settings({
+      codex: 'gpt-5.6-terra',
+      codexProviderId: null,
+      codexEffort: 'high',
+    });
+    const providers = [
+      providerView('openai', implicit.codex!, { connected: false }),
+      providerView('third-party-codex-proxy', implicit.codex!, {
+        source: 'user',
+        authStrategy: 'oauth-token',
+      }),
+    ];
+    const route = resolveCodexSubagentRouteSnapshot(implicit, undefined, providers);
+
+    expect(route?.providerId).toBe('third-party-codex-proxy');
+    expect(resolveEffectiveCodexSubagentSettings(
+      implicit,
+      'provider-oauth',
+      route,
+      providers,
+    )).toBe(implicit);
+    expect(resolveCodexSubagentRoutingProfile(
+      implicit,
+      'provider-oauth',
+      route,
+      providers,
+    )).toBe('configured');
+  });
+
   it.each(['gateway-key', 'provider-oauth'] as const)(
     'uses the main-task default when a %s main task selects a ChatGPT OAuth Subagent',
     (credentialMode) => {

--- a/apps/desktop/src/main/maker-host/__tests__/codex-subagent-config.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codex-subagent-config.test.ts
@@ -179,6 +179,31 @@ describe('resolveEffectiveCodexSubagentSettings', () => {
     },
   );
 
+  it('does not infer ChatGPT OAuth by model id when an explicit third-party source is unavailable', () => {
+    const thirdParty = settings({
+      codex: 'gpt-5.6-terra',
+      codexProviderId: 'third-party-codex-proxy',
+      codexEffort: 'high',
+    });
+    const providers = [providerView('openai', thirdParty.codex!)];
+    const route = resolveCodexSubagentRouteSnapshot(thirdParty, undefined, providers);
+
+    expect(route).toBeUndefined();
+    expect(resolveEffectiveCodexSubagentSettings(
+      thirdParty,
+      'provider-oauth',
+      route,
+      providers,
+    )).toBe(thirdParty);
+    expect(resolveCodexSubagentRoutingProfile(
+      thirdParty,
+      'provider-oauth',
+      route,
+      providers,
+    )).toBe('configured');
+    expect(codexSubagentRouteResolutionFailed(thirdParty, route)).toBe(true);
+  });
+
   it.each(['gateway-key', 'provider-oauth'] as const)(
     'uses the main-task default when a %s main task selects a ChatGPT OAuth Subagent',
     (credentialMode) => {

--- a/apps/desktop/src/main/maker-host/__tests__/codex-subagent-config.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codex-subagent-config.test.ts
@@ -90,7 +90,7 @@ describe('resolveEffectiveCodexSubagentSettings', () => {
       codexProviderId: null,
       codexEffort: null,
     });
-    expect(resolveCodexSubagentRoutingProfile(configured, 'oauth-bearer')).toBe('oauth-default');
+    expect(resolveCodexSubagentRoutingProfile(configured, 'oauth-bearer')).toBe('default');
     expect(resolveCodexSubagentRouteSnapshot(effective)).toBeUndefined();
     expect(resolveCodexSubagentModelFallback(effective)).toBeUndefined();
     expect(withoutDelegationArgs(buildCodexSubagentSpawnArgs(effective))).toEqual([
@@ -245,7 +245,7 @@ describe('resolveEffectiveCodexSubagentSettings', () => {
     const effortOnly = settings({ codexEffort: 'high' });
     const effective = resolveEffectiveCodexSubagentSettings(effortOnly, 'oauth-bearer');
     expect(effective.codexEffort).toBeNull();
-    expect(resolveCodexSubagentRoutingProfile(effortOnly, 'oauth-bearer')).toBe('oauth-default');
+    expect(resolveCodexSubagentRoutingProfile(effortOnly, 'oauth-bearer')).toBe('default');
   });
 
   it('does not create a mode-specific profile when the master switch is off', () => {

--- a/apps/desktop/src/main/maker-host/__tests__/codex-subagent-config.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codex-subagent-config.test.ts
@@ -8,6 +8,8 @@ import {
 import {
   buildCodexSubagentSpawnArgs,
   codexSubagentRouteResolutionFailed,
+  resolveCodexSubagentRoutingProfile,
+  resolveEffectiveCodexSubagentSettings,
   resolveCodexSubagentHostCredentialPlan,
   resolveCodexSubagentModelFallback,
   resolveCodexSubagentRouteSnapshot,
@@ -21,19 +23,27 @@ function settings(partial: Partial<SubagentModelSettings> = {}): SubagentModelSe
 function providerView(
   id: string,
   modelId: string,
-  options: { connected?: boolean; source?: 'builtin' | 'user' } = {},
+  options: {
+    connected?: boolean;
+    source?: 'builtin' | 'user';
+    authStrategy?: 'api-key-header' | 'gateway-key' | 'oauth-passthrough' | 'oauth-token';
+  } = {},
 ): ProviderView {
+  const isChatGptSubscription = id === 'openai' && (options.source ?? 'builtin') === 'builtin';
   return {
     id,
     name: id,
     source: options.source ?? 'builtin',
     connected: options.connected ?? true,
     agents: ['codex'],
-    auth: { method: 'none' },
+    auth: { method: isChatGptSubscription ? 'oauth' : 'none' },
+    ...(isChatGptSubscription
+      ? { access: { kind: 'subscription', product: 'ChatGPT' } }
+      : {}),
     routing: {
       codex: {
         upstream: `https://${id}.invalid/v1`,
-        authStrategy: 'oauth-passthrough',
+        authStrategy: options.authStrategy ?? 'oauth-passthrough',
       },
     },
     models: {
@@ -62,6 +72,138 @@ function withoutDelegationArgs(args: string[]): string[] {
   }
   return out;
 }
+
+describe('resolveEffectiveCodexSubagentSettings', () => {
+  const configured = settings({
+    codex: 'gpt-5.6-terra',
+    codexProviderId: 'openai',
+    codexEffort: 'high',
+    codexMaxConcurrentSubagents: 4,
+    codexAllowNestedSubagents: true,
+  });
+
+  it('uses Codex defaults for a ChatGPT OAuth main task while preserving ordinary guardrails', () => {
+    const effective = resolveEffectiveCodexSubagentSettings(configured, 'oauth-bearer');
+    expect(effective).toEqual({
+      ...configured,
+      codex: null,
+      codexProviderId: null,
+      codexEffort: null,
+    });
+    expect(resolveCodexSubagentRoutingProfile(configured, 'oauth-bearer')).toBe('oauth-default');
+    expect(resolveCodexSubagentRouteSnapshot(effective)).toBeUndefined();
+    expect(resolveCodexSubagentModelFallback(effective)).toBeUndefined();
+    expect(withoutDelegationArgs(buildCodexSubagentSpawnArgs(effective))).toEqual([
+      '-c',
+      'agents.max_concurrent_threads_per_session=4',
+      '-c',
+      'agents.max_depth=2',
+    ]);
+  });
+
+  it.each(['gateway-key', 'provider-oauth'] as const)(
+    'keeps a third-party configured route for a %s main task',
+    (credentialMode) => {
+      const providers = [providerView('openai', configured.codex!, {
+        authStrategy: 'gateway-key',
+      })];
+      const route = resolveCodexSubagentRouteSnapshot(configured, undefined, providers);
+      expect(resolveEffectiveCodexSubagentSettings(
+        configured,
+        credentialMode,
+        route,
+        providers,
+      )).toBe(configured);
+      expect(resolveCodexSubagentRoutingProfile(
+        configured,
+        credentialMode,
+        route,
+        providers,
+      )).toBe('configured');
+    },
+  );
+
+  it.each(['api-key-header', 'gateway-key', 'oauth-token', 'oauth-passthrough'] as const)(
+    'does not identify a third-party Codex/GPT proxy as ChatGPT OAuth (%s)',
+    (authStrategy) => {
+      const thirdParty = settings({
+        codex: 'codex/gpt-5.6-luna',
+        codexProviderId: 'third-party-codex-proxy',
+        codexEffort: 'high',
+      });
+      const providers = [providerView(
+        'third-party-codex-proxy',
+        thirdParty.codex!,
+        { source: 'user', authStrategy },
+      )];
+      const route = resolveCodexSubagentRouteSnapshot(thirdParty, undefined, providers);
+
+      expect(resolveEffectiveCodexSubagentSettings(
+        thirdParty,
+        'provider-oauth',
+        route,
+        providers,
+      )).toBe(thirdParty);
+      expect(resolveCodexSubagentRoutingProfile(
+        thirdParty,
+        'provider-oauth',
+        route,
+        providers,
+      )).toBe('configured');
+    },
+  );
+
+  it.each(['gateway-key', 'provider-oauth'] as const)(
+    'uses the main-task default when a %s main task selects a ChatGPT OAuth Subagent',
+    (credentialMode) => {
+      const providers = [providerView('openai', configured.codex!)];
+      const route = resolveCodexSubagentRouteSnapshot(configured, undefined, providers);
+      const effective = resolveEffectiveCodexSubagentSettings(
+        configured,
+        credentialMode,
+        route,
+        providers,
+      );
+      expect(effective).toEqual({
+        ...configured,
+        codex: null,
+        codexProviderId: null,
+        codexEffort: null,
+      });
+      expect(resolveCodexSubagentRoutingProfile(
+        configured,
+        credentialMode,
+        route,
+        providers,
+      )).toBe('default');
+      expect(resolveCodexSubagentRouteSnapshot(effective, undefined, providers)).toBeUndefined();
+      expect(resolveCodexSubagentModelFallback(effective)).toBeUndefined();
+      expect(withoutDelegationArgs(buildCodexSubagentSpawnArgs(effective))).toEqual([
+        '-c',
+        'agents.max_concurrent_threads_per_session=4',
+        '-c',
+        'agents.max_depth=2',
+      ]);
+    },
+  );
+
+  it('also removes an effort-only override from a ChatGPT OAuth main task', () => {
+    const effortOnly = settings({ codexEffort: 'high' });
+    const effective = resolveEffectiveCodexSubagentSettings(effortOnly, 'oauth-bearer');
+    expect(effective.codexEffort).toBeNull();
+    expect(resolveCodexSubagentRoutingProfile(effortOnly, 'oauth-bearer')).toBe('oauth-default');
+  });
+
+  it('does not create a mode-specific profile when the master switch is off', () => {
+    const disabled = settings({
+      codex: 'gpt-5.6-terra',
+      codexProviderId: 'openai',
+      codexSubagentsEnabled: false,
+    });
+    expect(resolveEffectiveCodexSubagentSettings(disabled, 'oauth-bearer')).toBe(disabled);
+    expect(resolveCodexSubagentRoutingProfile(disabled, 'oauth-bearer')).toBe('default');
+  });
+});
 
 describe('buildCodexSubagentSpawnArgs', () => {
   it('emits only the delegation defaults for all-default settings', () => {
@@ -494,5 +636,23 @@ describe('resolveCodexSubagentHostCredentialPlan', () => {
       'provider-oauth',
       false,
     )).toEqual({ forceDisableSubagents: true });
+  });
+
+  it('does not request ChatGPT credentials for a third-party oauth-passthrough proxy', () => {
+    const route = {
+      providerId: 'third-party-codex-proxy',
+      catalogModel: 'codex/gpt-5.6-luna',
+      reasoningEffort: null,
+    };
+    expect(resolveCodexSubagentHostCredentialPlan(
+      route,
+      [providerView(
+        'third-party-codex-proxy',
+        route.catalogModel,
+        { source: 'user', authStrategy: 'oauth-passthrough' },
+      )],
+      'provider-oauth',
+      false,
+    )).toEqual({ forceDisableSubagents: false });
   });
 });

--- a/apps/desktop/src/main/maker-host/__tests__/pi-package-store-security.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/pi-package-store-security.test.ts
@@ -1,8 +1,31 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { promises as fs } from 'node:fs';
+import {
+  mkdtempSync,
+  promises as fs,
+  rmSync,
+  symlinkSync,
+} from 'node:fs';
 import { createRequire } from 'node:module';
 import os from 'node:os';
 import path from 'node:path';
+
+// Windows 未开启 Developer Mode / 无 Create Symbolic Link 权限时，文件 symlink
+// 会返回 EPERM；目录 junction 不受此限制，但本文件的竞态用例必须替换单个文件。
+// 探测真实 OS 能力，避免把权限差异误报成产品回归。
+function canCreateFileSymlink(): boolean {
+  const probeRoot = mkdtempSync(path.join(os.tmpdir(), 'cindy-pi-package-file-link-probe-'));
+  const link = path.join(probeRoot, 'link');
+  try {
+    symlinkSync(path.join(probeRoot, 'target'), link, 'file');
+    return true;
+  } catch {
+    return false;
+  } finally {
+    rmSync(probeRoot, { recursive: true, force: true });
+  }
+}
+
+const canLinkFile = canCreateFileSymlink();
 
 const runtime = vi.hoisted(() => ({
   userData: '',
@@ -1113,7 +1136,7 @@ describe('Pi package executable-code boundary', () => {
     await expect(fs.readdir(snapshotRoot)).resolves.toEqual([]);
   });
 
-  it('rejects a direct file snapshot whose package root is replaced by a symlink', async () => {
+  it.skipIf(!canLinkFile)('rejects a direct file snapshot whose package root is replaced by a symlink', async () => {
     const packageFile = path.join(runtime.userData, 'snapshot-direct-extension.ts');
     const outsideFile = path.join(runtime.userData, 'snapshot-host-private.ts');
     await fs.writeFile(packageFile, 'export default function approved() {}\n');

--- a/apps/desktop/src/main/maker-host/codex-subagent-config.ts
+++ b/apps/desktop/src/main/maker-host/codex-subagent-config.ts
@@ -143,13 +143,15 @@ export function resolveCodexSubagentRoutingProfile(
   providerViews?: ProviderView[],
 ): 'default' | 'configured' | 'oauth-default' {
   if (!hasCodexSubagentOverride(settings)) return 'default';
-  // OAuth 主任务会清除所有固定 Subagent 路由；profile 必须反映最终生效的默认路由，
-  // 这样它可以与第三方主任务因 ChatGPT OAuth 冲突而回落的默认路由复用同一个 host。
-  if (mainTaskCredentialMode === 'oauth-bearer') return 'default';
-  return codexSubagentRouteUsesChatGptOAuth(configuredRoute, providerViews)
-    || (!configuredRoute && codexSubagentSelectionUsesChatGptOAuth(settings, providerViews))
-    ? 'default'
-    : 'configured';
+  const configuredForChatGptOAuth =
+    codexSubagentRouteUsesChatGptOAuth(configuredRoute, providerViews)
+    || codexSubagentSelectionUsesChatGptOAuth(settings, providerViews);
+  // 固定 ChatGPT OAuth 时，两类主任务都会因冲突回落默认配置，可以复用同一 host。
+  // 其它固定路由只在 OAuth 主任务上临时回落；第三方主任务仍需重建为 configured host。
+  if (mainTaskCredentialMode === 'oauth-bearer') {
+    return configuredForChatGptOAuth ? 'default' : 'oauth-default';
+  }
+  return configuredForChatGptOAuth ? 'default' : 'configured';
 }
 
 /**

--- a/apps/desktop/src/main/maker-host/codex-subagent-config.ts
+++ b/apps/desktop/src/main/maker-host/codex-subagent-config.ts
@@ -148,7 +148,7 @@ export function resolveCodexSubagentRoutingProfile(
   if (!hasCodexSubagentOverride(settings)) return 'default';
   const configuredForChatGptOAuth =
     codexSubagentRouteUsesChatGptOAuth(configuredRoute, providerViews)
-    || codexSubagentSelectionUsesChatGptOAuth(settings, providerViews);
+    || (!configuredRoute && codexSubagentSelectionUsesChatGptOAuth(settings, providerViews));
   // 固定 ChatGPT OAuth 时，两类主任务都会因冲突回落默认配置，可以复用同一 host。
   // 其它固定路由只在 OAuth 主任务上临时回落；第三方主任务仍需重建为 configured host。
   if (mainTaskCredentialMode === 'oauth-bearer') {

--- a/apps/desktop/src/main/maker-host/codex-subagent-config.ts
+++ b/apps/desktop/src/main/maker-host/codex-subagent-config.ts
@@ -45,6 +45,77 @@ export interface CodexSubagentHostCredentialPlan {
   requiredSpawnCredentialMode?: 'oauth-bearer';
 }
 
+function hasCodexSubagentOverride(settings: SubagentModelSettings): boolean {
+  return settings.codexSubagentsEnabled
+    && Boolean(settings.codex?.trim() || settings.codexEffort !== null);
+}
+
+export function codexSubagentRouteUsesChatGptOAuth(
+  route: CodexSubagentRouteSnapshot | undefined,
+  providerViews: ProviderView[] | undefined,
+): boolean {
+  if (!route) return false;
+  const provider = providerViews?.find((candidate) => candidate.id === route.providerId);
+  return provider?.id === 'openai'
+    && provider.source === 'builtin'
+    && provider.auth.method === 'oauth'
+    && provider.access?.kind === 'subscription'
+    && provider.access.product === 'ChatGPT'
+    && provider.routing.codex?.authStrategy === 'oauth-passthrough';
+}
+
+function shouldUseDefaultCodexSubagent(
+  settings: SubagentModelSettings,
+  mainTaskCredentialMode: 'gateway-key' | 'oauth-bearer' | 'provider-oauth',
+  configuredRoute: CodexSubagentRouteSnapshot | undefined,
+  providerViews: ProviderView[] | undefined,
+): boolean {
+  if (!hasCodexSubagentOverride(settings)) return false;
+  return mainTaskCredentialMode === 'oauth-bearer'
+    || codexSubagentRouteUsesChatGptOAuth(configuredRoute, providerViews);
+}
+
+/**
+ * ChatGPT OAuth 与其它 Provider 的锁定 Subagent 路由不能安全混用：OAuth 主任务上的
+ * 任意锁定路由会关闭 OpenAI WebSocket；反向把 OAuth Subagent 锁到第三方主任务上则会
+ * 把子线程降到不兼容的 HTTP 流。两种情况都只忽略锁定模型、Provider 与 effort，让
+ * Codex 使用原生默认 Subagent；总开关、策略、并发和嵌套等普通编排设置仍然保留。
+ */
+export function resolveEffectiveCodexSubagentSettings(
+  settings: SubagentModelSettings,
+  mainTaskCredentialMode: 'gateway-key' | 'oauth-bearer' | 'provider-oauth',
+  configuredRoute?: CodexSubagentRouteSnapshot,
+  providerViews?: ProviderView[],
+): SubagentModelSettings {
+  if (!shouldUseDefaultCodexSubagent(
+    settings,
+    mainTaskCredentialMode,
+    configuredRoute,
+    providerViews,
+  )) {
+    return settings;
+  }
+  return {
+    ...settings,
+    codex: null,
+    codexProviderId: null,
+    codexEffort: null,
+  };
+}
+
+export function resolveCodexSubagentRoutingProfile(
+  settings: SubagentModelSettings,
+  mainTaskCredentialMode: 'gateway-key' | 'oauth-bearer' | 'provider-oauth',
+  configuredRoute?: CodexSubagentRouteSnapshot,
+  providerViews?: ProviderView[],
+): 'default' | 'configured' | 'oauth-default' {
+  if (!hasCodexSubagentOverride(settings)) return 'default';
+  if (mainTaskCredentialMode === 'oauth-bearer') return 'oauth-default';
+  return codexSubagentRouteUsesChatGptOAuth(configuredRoute, providerViews)
+    ? 'default'
+    : 'configured';
+}
+
 /**
  * OpenAI/ChatGPT 路由依赖 Codex 原生 OAuth passthrough。父任务可能使用另一家
  * Provider OAuth，因此锁定子代理必须要求带 ChatGPT OAuth 的 app-server；不能接受
@@ -57,10 +128,7 @@ export function resolveCodexSubagentHostCredentialPlan(
   hasCodexOAuthLogin: boolean,
 ): CodexSubagentHostCredentialPlan {
   if (!route) return { forceDisableSubagents: false };
-  const routing = providerViews
-    ?.find((provider) => provider.id === route.providerId)
-    ?.routing.codex;
-  if (routing?.authStrategy !== 'oauth-passthrough') {
+  if (!codexSubagentRouteUsesChatGptOAuth(route, providerViews)) {
     return { forceDisableSubagents: false };
   }
   if (!hasCodexOAuthLogin) {

--- a/apps/desktop/src/main/maker-host/codex-subagent-config.ts
+++ b/apps/desktop/src/main/maker-host/codex-subagent-config.ts
@@ -88,6 +88,9 @@ function codexSubagentSelectionUsesChatGptOAuth(
     // ChatGPT OAuth conflict. A visible non-ChatGPT replacement must win.
     return provider === undefined || providerViewUsesChatGptOAuth(provider);
   }
+  // An explicit third-party source remains authoritative when unavailable;
+  // a same-id OpenAI model must not silently replace it.
+  if (providerId) return false;
   if (!providerViews || !settings.codex?.trim()) return false;
   const model = settings.codex.trim();
   return providerViews.some((provider) =>

--- a/apps/desktop/src/main/maker-host/codex-subagent-config.ts
+++ b/apps/desktop/src/main/maker-host/codex-subagent-config.ts
@@ -55,13 +55,45 @@ export function codexSubagentRouteUsesChatGptOAuth(
   providerViews: ProviderView[] | undefined,
 ): boolean {
   if (!route) return false;
-  const provider = providerViews?.find((candidate) => candidate.id === route.providerId);
+  return providerViews?.some((provider) =>
+    provider.id === route.providerId
+    && providerViewUsesChatGptOAuth(provider)
+  ) ?? false;
+}
+
+function providerViewUsesChatGptOAuth(provider: ProviderView | undefined): boolean {
   return provider?.id === 'openai'
     && provider.source === 'builtin'
     && provider.auth.method === 'oauth'
     && provider.access?.kind === 'subscription'
     && provider.access.product === 'ChatGPT'
     && provider.routing.codex?.authStrategy === 'oauth-passthrough';
+}
+
+/**
+ * Route resolution intentionally filters disconnected/suspended sources. Keep a
+ * persisted OpenAI selection recognizable when that filtering makes the route
+ * unavailable, so a ChatGPT OAuth conflict falls back to the native subagent
+ * route instead of disabling all subagents.
+ */
+function codexSubagentSelectionUsesChatGptOAuth(
+  settings: SubagentModelSettings,
+  providerViews: ProviderView[] | undefined,
+): boolean {
+  const providerId = settings.codexProviderId?.trim();
+  if (providerId === 'openai') {
+    const provider = providerViews?.find((candidate) => candidate.id === 'openai');
+    // `openai` is the stable built-in provider id. If the catalog is temporarily
+    // unavailable, the persisted explicit source is still enough to identify the
+    // ChatGPT OAuth conflict. A visible non-ChatGPT replacement must win.
+    return provider === undefined || providerViewUsesChatGptOAuth(provider);
+  }
+  if (!providerViews || !settings.codex?.trim()) return false;
+  const model = settings.codex.trim();
+  return providerViews.some((provider) =>
+    providerViewUsesChatGptOAuth(provider)
+    && provider.models.codex?.some((candidate) => candidate.id === model) === true,
+  );
 }
 
 function shouldUseDefaultCodexSubagent(
@@ -72,7 +104,8 @@ function shouldUseDefaultCodexSubagent(
 ): boolean {
   if (!hasCodexSubagentOverride(settings)) return false;
   return mainTaskCredentialMode === 'oauth-bearer'
-    || codexSubagentRouteUsesChatGptOAuth(configuredRoute, providerViews);
+    || codexSubagentRouteUsesChatGptOAuth(configuredRoute, providerViews)
+    || (!configuredRoute && codexSubagentSelectionUsesChatGptOAuth(settings, providerViews));
 }
 
 /**
@@ -112,6 +145,7 @@ export function resolveCodexSubagentRoutingProfile(
   if (!hasCodexSubagentOverride(settings)) return 'default';
   if (mainTaskCredentialMode === 'oauth-bearer') return 'oauth-default';
   return codexSubagentRouteUsesChatGptOAuth(configuredRoute, providerViews)
+    || (!configuredRoute && codexSubagentSelectionUsesChatGptOAuth(settings, providerViews))
     ? 'default'
     : 'configured';
 }

--- a/apps/desktop/src/main/maker-host/codex-subagent-config.ts
+++ b/apps/desktop/src/main/maker-host/codex-subagent-config.ts
@@ -143,7 +143,9 @@ export function resolveCodexSubagentRoutingProfile(
   providerViews?: ProviderView[],
 ): 'default' | 'configured' | 'oauth-default' {
   if (!hasCodexSubagentOverride(settings)) return 'default';
-  if (mainTaskCredentialMode === 'oauth-bearer') return 'oauth-default';
+  // OAuth 主任务会清除所有固定 Subagent 路由；profile 必须反映最终生效的默认路由，
+  // 这样它可以与第三方主任务因 ChatGPT OAuth 冲突而回落的默认路由复用同一个 host。
+  if (mainTaskCredentialMode === 'oauth-bearer') return 'default';
   return codexSubagentRouteUsesChatGptOAuth(configuredRoute, providerViews)
     || (!configuredRoute && codexSubagentSelectionUsesChatGptOAuth(settings, providerViews))
     ? 'default'

--- a/apps/desktop/src/main/maker-host/index.ts
+++ b/apps/desktop/src/main/maker-host/index.ts
@@ -1445,12 +1445,12 @@ export function getMaker(): Maker {
         if (
           !isReview
           && !ctx.remoteHostId
-          && mainTaskCredentialMode !== 'oauth-bearer'
           && storedSubagentModelSettings.codexSubagentsEnabled
           && storedSubagentModelSettings.codex?.trim()
         ) {
-          // 显式来源同样必须按当前目录严格校验；读取失败时保留空数组，令下面的路由
-          // 解析 fail-closed，而不是信任可能已经断连或删除模型的旧设置。
+          // OAuth 主任务也需要识别固定路由的来源，区分“ChatGPT 路由在两侧都回落默认”
+          // 与“其它路由只在 OAuth 侧临时回落”；读取失败时保留空数组，令显式 OpenAI
+          // 选择仍可按稳定来源 id 识别，其它路由继续 fail-closed。
           subagentProviderViews = [];
           try {
             subagentProviderViews = await getDesktopProviderService().listProviders({

--- a/apps/desktop/src/main/maker-host/index.ts
+++ b/apps/desktop/src/main/maker-host/index.ts
@@ -223,7 +223,10 @@ import {
 } from './codex-gateway-config.js';
 import {
   buildCodexSubagentSpawnArgs,
+  codexSubagentRouteUsesChatGptOAuth,
   codexSubagentRouteResolutionFailed,
+  resolveCodexSubagentRoutingProfile,
+  resolveEffectiveCodexSubagentSettings,
   resolveCodexSubagentModelFallback,
   resolveCodexSubagentHostCredentialPlan,
   resolveCodexSubagentRouteSnapshot,
@@ -1436,16 +1439,15 @@ export function getMaker(): Maker {
         const endpoint = usesIsolatedProxy
           ? getCodexControlPlaneProxyEndpoint(authInjection)
           : getCodexProxyEndpoint();
-        const subagentModelSettings = readSubagentModelSettings();
-        const subagentModelFallback = !isReview
-          ? resolveCodexSubagentModelFallback(subagentModelSettings, ctx.remoteHostId)
-          : undefined;
+        const storedSubagentModelSettings = readSubagentModelSettings();
+        const mainTaskCredentialMode = ctx.requestedCredentialMode ?? credentialMode;
         let subagentProviderViews: ProviderView[] | undefined;
         if (
           !isReview
           && !ctx.remoteHostId
-          && subagentModelSettings.codexSubagentsEnabled
-          && subagentModelSettings.codex?.trim()
+          && mainTaskCredentialMode !== 'oauth-bearer'
+          && storedSubagentModelSettings.codexSubagentsEnabled
+          && storedSubagentModelSettings.codex?.trim()
         ) {
           // 显式来源同样必须按当前目录严格校验；读取失败时保留空数组，令下面的路由
           // 解析 fail-closed，而不是信任可能已经断连或删除模型的旧设置。
@@ -1460,12 +1462,32 @@ export function getMaker(): Maker {
             });
           }
         }
-        let subagentRoute = !isReview
+        const configuredSubagentRoute = !isReview
           ? resolveCodexSubagentRouteSnapshot(
-              subagentModelSettings,
+              storedSubagentModelSettings,
               ctx.remoteHostId,
               subagentProviderViews,
             )
+          : undefined;
+        const subagentModelSettings = resolveEffectiveCodexSubagentSettings(
+          storedSubagentModelSettings,
+          mainTaskCredentialMode,
+          configuredSubagentRoute,
+          subagentProviderViews,
+        );
+        const codexSubagentRoutingProfile = !isReview && !ctx.remoteHostId
+          ? resolveCodexSubagentRoutingProfile(
+              storedSubagentModelSettings,
+              mainTaskCredentialMode,
+              configuredSubagentRoute,
+              subagentProviderViews,
+            )
+          : 'default';
+        const subagentModelFallback = !isReview
+          ? resolveCodexSubagentModelFallback(subagentModelSettings, ctx.remoteHostId)
+          : undefined;
+        let subagentRoute = subagentModelSettings === storedSubagentModelSettings
+          ? configuredSubagentRoute
           : undefined;
         let forceDisableSubagents = false;
         if (codexSubagentRouteResolutionFailed(subagentModelSettings, subagentRoute, {
@@ -1490,10 +1512,10 @@ export function getMaker(): Maker {
           forceDisableSubagents = true;
           subagentRoute = undefined;
         } else if (subagentRoute) {
-          const selectedRouting = subagentProviderViews
-            ?.find((provider) => provider.id === subagentRoute?.providerId)
-            ?.routing.codex;
-          const hasRequiredOAuth = selectedRouting?.authStrategy === 'oauth-passthrough'
+          const hasRequiredOAuth = codexSubagentRouteUsesChatGptOAuth(
+            subagentRoute,
+            subagentProviderViews,
+          )
             ? await desktopCodexAuthAdapter.hasCodexOAuthLogin().catch(() => false)
             : false;
           const credentialPlan = resolveCodexSubagentHostCredentialPlan(
@@ -1537,6 +1559,7 @@ export function getMaker(): Maker {
           ...(buildSessionMcpConfig ? { buildSessionMcpConfig } : {}),
           codexProxyActive: ready,
           codexOpenAiWebSocketsEnabled: useOAuthBearer && ready,
+          codexSubagentRoutingProfile,
           codexBrowserUseAvailable: browserCompanionSpawnConfig.codexBrowserUseAvailable,
           ...(browserCompanion?.status === 'ready'
             ? {

--- a/apps/desktop/src/renderer/components/settings/SubagentModelSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/SubagentModelSection.tsx
@@ -584,6 +584,10 @@ export function SubagentModelSection() {
           {t('settings.subagentModels.codexV2ModelHint')}
         </p>
 
+        <p className="px-4 pb-3 text-12 leading-[1.5] text-[var(--text-tertiary)]">
+          {t('settings.subagentModels.codexOauthCompatibilityHint')}
+        </p>
+
         <p className="px-4 pb-4 text-12 leading-[1.5] text-[var(--text-secondary)]">
           {t('settings.subagentModels.hint')}
         </p>

--- a/apps/desktop/src/renderer/components/settings/__tests__/SubagentModelSectionRendering.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/__tests__/SubagentModelSectionRendering.test.tsx
@@ -513,6 +513,9 @@ describe('SubagentModelSection Codex row', () => {
     expect(selector.dataset.effort).toBe('high');
     expect(selector.dataset.currentProvider).toBe('openai');
     expect(selector.dataset.model).toBe('gpt-5.6-terra');
+    expect(
+      screen.getByText('settings.subagentModels.codexOauthCompatibilityHint'),
+    ).toBeTruthy();
     // 锁定路由由 Proxy 在子线程请求上应用实际 Provider / wire 协议，因此不得隐藏
     // DeepSeek、Kimi、GLM 等 Chat 兼容桥模型。
     expect(selector.dataset.excludeBridged).toBe('false');

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -2503,6 +2503,7 @@
       "unspecified": "Use default setting",
       "hint": "Claude Code changes apply to new sessions. Codex changes apply automatically when it is idle.",
       "codexV2ModelHint": "Claude Code uses the selected model as its default. All local Codex Subagents are locked to the selected model and reasoning effort.",
+      "codexOauthCompatibilityHint": "Fixed Subagent routing cannot safely share a task with ChatGPT OAuth. When the main Codex task uses ChatGPT OAuth, or a non-OAuth main task selects a ChatGPT OAuth Subagent, Cindy ignores the model, provider, and reasoning effort selected here and uses that task’s default Codex Subagent.",
       "saveFailed": "Failed to save subagent settings",
       "guardrails": {
         "title": "Codex subagent guardrails",

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -2502,6 +2502,7 @@
       "unspecified": "既定の設定を使用",
       "hint": "Claude Code の変更は新しいセッションから適用されます。Codex の変更はアイドル時に自動で適用されます。",
       "codexV2ModelHint": "Claude Code は選択したモデルを既定値として使用します。ローカルの Codex サブエージェントはすべて、選択したモデルと推論強度に固定されます。",
+      "codexOauthCompatibilityHint": "固定したサブエージェントのルーティングと ChatGPT OAuth は安全に併用できません。メインタスクが ChatGPT OAuth を使用する場合、または非 OAuth のメインタスクで ChatGPT OAuth のサブエージェントを指定した場合、ここで選択したモデル、プロバイダー、推論強度は適用されず、メインタスクの Codex デフォルトサブエージェントが使用されます。",
       "saveFailed": "サブエージェント設定の保存に失敗しました",
       "guardrails": {
         "title": "Codex サブエージェントガードレール",

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -2502,6 +2502,7 @@
       "unspecified": "기본 설정 사용",
       "hint": "Claude Code 변경 사항은 새 세션부터 적용됩니다. Codex 변경 사항은 유휴 상태에서 자동으로 적용됩니다.",
       "codexV2ModelHint": "Claude Code는 선택한 모델을 기본값으로 사용합니다. 모든 로컬 Codex 하위 에이전트는 선택한 모델과 추론 강도로 고정됩니다.",
+      "codexOauthCompatibilityHint": "고정 하위 에이전트 라우팅과 ChatGPT OAuth는 안전하게 함께 사용할 수 없습니다. 메인 작업이 ChatGPT OAuth를 사용하거나 비 OAuth 메인 작업에서 ChatGPT OAuth 하위 에이전트를 선택하면 여기에서 지정한 모델, 제공자, 추론 강도는 적용되지 않고 메인 작업의 Codex 기본 하위 에이전트가 사용됩니다.",
       "saveFailed": "하위 에이전트 설정 저장 실패",
       "guardrails": {
         "title": "Codex 하위 에이전트 가드레일",

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -2502,6 +2502,7 @@
       "unspecified": "跟随默认设置",
       "hint": "Claude Code 的设置从新任务开始生效；Codex 的设置会在空闲后自动应用。",
       "codexV2ModelHint": "Claude Code 使用所选模型作为默认值。Codex 的所有本机 Subagent 都固定使用所选模型和推理强度。",
+      "codexOauthCompatibilityHint": "固定 Subagent 路由与 ChatGPT OAuth 不能安全共用。主任务使用 ChatGPT OAuth，或非 OAuth 主任务指定 ChatGPT OAuth Subagent 时，Cindy 会忽略这里的模型、来源和推理强度，改用主任务的 Codex 默认 Subagent。",
       "saveFailed": "保存 Subagent 设置失败",
       "guardrails": {
         "title": "Codex Subagent 护栏",

--- a/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
@@ -2502,6 +2502,7 @@
       "unspecified": "跟隨預設設定",
       "hint": "Claude Code 的設定從新任務開始生效；Codex 的設定會在閒置後自動套用。",
       "codexV2ModelHint": "Claude Code 使用所選模型作為預設值。Codex 的所有本機 Subagent 都固定使用所選模型和推理強度。",
+      "codexOauthCompatibilityHint": "固定 Subagent 路由與 ChatGPT OAuth 無法安全共用。主任務使用 ChatGPT OAuth，或非 OAuth 主任務指定 ChatGPT OAuth Subagent 時，Cindy 會忽略這裡的模型、來源和推理強度，改用主任務的 Codex 預設 Subagent。",
       "saveFailed": "儲存 Subagent 設定失敗",
       "guardrails": {
         "title": "Codex Subagent 護欄",

--- a/packages/maker-core/src/agents/base-agent.ts
+++ b/packages/maker-core/src/agents/base-agent.ts
@@ -314,6 +314,8 @@ export interface PiExtraSpawnConfigContext {
   remoteHostId?: string | null;
 }
 
+export type CodexSubagentRoutingProfile = 'default' | 'configured' | 'oauth-default';
+
 export interface CodexExtraSpawnConfig {
   extraArgs: string[];
   extraEnv: Record<string, string>;
@@ -331,6 +333,8 @@ export interface CodexExtraSpawnConfig {
   codexBrowserUseAvailable?: boolean;
   /** Whether the OpenAI identity provider on this app-server may use Responses WebSocket. */
   codexOpenAiWebSocketsEnabled?: boolean;
+  /** Host-level Subagent route profile used to prevent incompatible local host reuse. */
+  codexSubagentRoutingProfile?: CodexSubagentRoutingProfile;
   /** Exact verified Chrome plugin version provisioned into this app-server. */
   codexBrowserUseVersion?: string;
   /** Maximum startup wait copied from the verified companion descriptor. */
@@ -724,6 +728,8 @@ export interface AgentDeps {
     ctx: {
       remoteHostId?: string;
       credentialMode?: AgentCredentialMode;
+      /** Original session request when the shared host was upgraded to a credential superset. */
+      requestedCredentialMode?: AgentCredentialMode;
       /** Marks one-off app-server work (e.g. model/list) that must not alter session routing. */
       hostPurpose?: 'control-plane' | 'review';
     },

--- a/packages/maker-core/src/agents/codex/app-server/host.ts
+++ b/packages/maker-core/src/agents/codex/app-server/host.ts
@@ -26,6 +26,7 @@
 import { randomUUID } from 'node:crypto';
 
 import type { Logger } from '../../../interfaces/logger.js';
+import type { CodexSubagentRoutingProfile } from '../../base-agent.js';
 import { AppServerClient } from './client.js';
 import type { Transport } from './transport.js';
 import {
@@ -283,6 +284,8 @@ export interface AppServerHostOptions {
   };
   /** Whether the OpenAI identity provider may use Responses WebSocket on this host. */
   codexOpenAiWebSocketsEnabled?: boolean;
+  /** Host-level Subagent route profile used to prevent incompatible local host reuse. */
+  codexSubagentRoutingProfile?: CodexSubagentRoutingProfile;
 }
 
 interface BufferedNotification {
@@ -453,6 +456,10 @@ export class AppServerHost {
 
   getOpenAiWebSocketsEnabled(): boolean {
     return this.opts.codexOpenAiWebSocketsEnabled !== false;
+  }
+
+  getSubagentRoutingProfile(): CodexSubagentRoutingProfile {
+    return this.opts.codexSubagentRoutingProfile ?? 'default';
   }
 
   getConnectionId(): string {

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -6292,6 +6292,41 @@ describe('CodexAgent MCP thread context hooks', () => {
     await agent.dispose();
   });
 
+  it('rebuilds an OAuth-default host when the next main task requires configured Subagent routing', async () => {
+    const prepareCodexExtraSpawnConfig: NonNullable<AgentDeps['prepareCodexExtraSpawnConfig']> =
+      vi.fn(async (_providers, ctx) => ({
+        extraArgs: [],
+        extraEnv: {},
+        codexProxyActive: true,
+        codexSubagentRoutingProfile:
+          (ctx.requestedCredentialMode ?? ctx.credentialMode) === 'oauth-bearer'
+            ? 'oauth-default' as const
+            : 'configured' as const,
+      }));
+    const agent = new CodexAgent(createDeps({}, { prepareCodexExtraSpawnConfig }));
+
+    const oauth = await agent.startSession({
+      sessionId: 'session-profile-non-chatgpt-oauth',
+      providerId: 'openai',
+      model: 'gpt-5.4',
+      workingDir: '/repo-oauth',
+    });
+    await oauth.close();
+
+    const thirdParty = await agent.startSession({
+      sessionId: 'session-profile-non-chatgpt-provider-oauth',
+      providerId: 'xai',
+      model: 'xai/grok-4.3',
+      workingDir: '/repo-xai',
+    });
+
+    expect(createdTransports).toHaveLength(2);
+    expect(createdTransports[0].closed).toBe(true);
+    expect(createdTransports[1].closed).toBe(false);
+    await thirdParty.close();
+    await agent.dispose();
+  });
+
   it('does not reuse a host whose Subagent routing profile belongs to the opposite main-task mode', async () => {
     const prepareCodexExtraSpawnConfig: NonNullable<AgentDeps['prepareCodexExtraSpawnConfig']> =
       vi.fn(async (_providers, ctx) => {

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -5920,7 +5920,9 @@ describe('CodexAgent MCP thread context hooks', () => {
     expect(createdTransports).toHaveLength(1);
     expect(prepareCodexExtraSpawnConfig).toHaveBeenCalledTimes(1);
     expect(prepareCodexExtraSpawnConfig).toHaveBeenCalledWith([], {
-      remoteHostId: undefined, credentialMode: 'oauth-bearer',
+      remoteHostId: undefined,
+      credentialMode: 'oauth-bearer',
+      requestedCredentialMode: 'gateway-key',
     });
     await xdHandle.close();
     await oauthHandle.close();
@@ -6028,7 +6030,9 @@ describe('CodexAgent MCP thread context hooks', () => {
     expect(createdTransports).toHaveLength(1);
     expect(prepareCodexExtraSpawnConfig).toHaveBeenCalledTimes(2);
     expect(prepareCodexExtraSpawnConfig).toHaveBeenNthCalledWith(1, [], {
-      remoteHostId: undefined, credentialMode: 'oauth-bearer',
+      remoteHostId: undefined,
+      credentialMode: 'oauth-bearer',
+      requestedCredentialMode: 'gateway-key',
     });
     expect(prepareCodexExtraSpawnConfig).toHaveBeenNthCalledWith(2, [], {
       remoteHostId: undefined, credentialMode: 'gateway-key',
@@ -6251,8 +6255,141 @@ describe('CodexAgent MCP thread context hooks', () => {
     expect(prepareCodexExtraSpawnConfig).toHaveBeenNthCalledWith(2, [], {
       remoteHostId: undefined,
       credentialMode: 'oauth-bearer',
+      requestedCredentialMode: 'provider-oauth',
     });
     await handle.close();
+    await agent.dispose();
+  });
+
+  it('does not reuse a host whose Subagent routing profile belongs to the opposite main-task mode', async () => {
+    const prepareCodexExtraSpawnConfig: NonNullable<AgentDeps['prepareCodexExtraSpawnConfig']> =
+      vi.fn(async (_providers, ctx) => {
+        const requestedCredentialMode = ctx.requestedCredentialMode ?? ctx.credentialMode;
+        if (
+          requestedCredentialMode === 'provider-oauth'
+          && ctx.credentialMode === 'provider-oauth'
+        ) {
+          return {
+            extraArgs: [],
+            extraEnv: {},
+            codexProxyActive: true,
+            requiredSpawnCredentialMode: 'oauth-bearer' as const,
+          };
+        }
+        return {
+          extraArgs: [],
+          extraEnv: {},
+          codexProxyActive: true,
+          codexSubagentRoutingProfile:
+            requestedCredentialMode === 'oauth-bearer'
+              ? 'oauth-default' as const
+              : 'configured' as const,
+        };
+      });
+    const agent = new CodexAgent(createDeps({}, { prepareCodexExtraSpawnConfig }));
+
+    const thirdParty = await agent.startSession({
+      sessionId: 'session-profile-provider-oauth',
+      providerId: 'xai',
+      model: 'xai/grok-4.3',
+      workingDir: '/repo-xai',
+    });
+    await thirdParty.close();
+
+    const oauth = await agent.startSession({
+      sessionId: 'session-profile-oauth',
+      providerId: 'openai',
+      model: 'gpt-5.4',
+      workingDir: '/repo-oauth',
+    });
+    expect(createdTransports).toHaveLength(2);
+    expect(createdTransports[0].closed).toBe(true);
+    await oauth.close();
+
+    const thirdPartyAgain = await agent.startSession({
+      sessionId: 'session-profile-provider-oauth-again',
+      providerId: 'xai',
+      model: 'xai/grok-4.3',
+      workingDir: '/repo-xai-again',
+    });
+    expect(createdTransports).toHaveLength(3);
+    expect(createdTransports[1].closed).toBe(true);
+    expect(prepareCodexExtraSpawnConfig).toHaveBeenNthCalledWith(2, [], {
+      remoteHostId: undefined,
+      credentialMode: 'oauth-bearer',
+      requestedCredentialMode: 'provider-oauth',
+    });
+    expect(prepareCodexExtraSpawnConfig).toHaveBeenNthCalledWith(3, [], {
+      remoteHostId: undefined,
+      credentialMode: 'oauth-bearer',
+    });
+    expect(prepareCodexExtraSpawnConfig).toHaveBeenNthCalledWith(5, [], {
+      remoteHostId: undefined,
+      credentialMode: 'oauth-bearer',
+      requestedCredentialMode: 'provider-oauth',
+    });
+
+    await thirdPartyAgain.close();
+    await agent.dispose();
+  });
+
+  it('does not retire an active host when only the Subagent routing profile must change', async () => {
+    const prepareCodexExtraSpawnConfig: NonNullable<AgentDeps['prepareCodexExtraSpawnConfig']> =
+      vi.fn(async (_providers, ctx) => {
+        const requestedCredentialMode = ctx.requestedCredentialMode ?? ctx.credentialMode;
+        if (
+          requestedCredentialMode === 'provider-oauth'
+          && ctx.credentialMode === 'provider-oauth'
+        ) {
+          return {
+            extraArgs: [],
+            extraEnv: {},
+            codexProxyActive: true,
+            requiredSpawnCredentialMode: 'oauth-bearer' as const,
+          };
+        }
+        return {
+          extraArgs: [],
+          extraEnv: {},
+          codexProxyActive: true,
+          codexSubagentRoutingProfile:
+            requestedCredentialMode === 'oauth-bearer'
+              ? 'oauth-default' as const
+              : 'configured' as const,
+        };
+      });
+    const prepareCodexLocalCredentialModeSwitch: NonNullable<
+      AgentDeps['prepareCodexLocalCredentialModeSwitch']
+    > = vi.fn(async () => undefined);
+    const agent = new CodexAgent(createDeps({}, {
+      prepareCodexExtraSpawnConfig,
+      prepareCodexLocalCredentialModeSwitch,
+    }));
+
+    const thirdParty = await agent.startSession({
+      sessionId: 'session-profile-busy-provider-oauth',
+      providerId: 'xai',
+      model: 'xai/grok-4.3',
+      workingDir: '/repo-xai',
+    });
+
+    await expect(agent.startSession({
+      sessionId: 'session-profile-busy-oauth',
+      providerId: 'openai',
+      model: 'gpt-5.4',
+      workingDir: '/repo-oauth',
+    })).rejects.toThrow(/still attached/i);
+
+    expect(prepareCodexLocalCredentialModeSwitch).toHaveBeenCalledWith({
+      fromMode: 'oauth-bearer',
+      fromModeEffective: 'oauth-bearer',
+      toMode: 'oauth-bearer',
+      activeSubscriptions: 1,
+    });
+    expect(createdTransports).toHaveLength(1);
+    expect(createdTransports[0].closed).toBe(false);
+
+    await thirdParty.close();
     await agent.dispose();
   });
 

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -6261,6 +6261,37 @@ describe('CodexAgent MCP thread context hooks', () => {
     await agent.dispose();
   });
 
+  it('reuses a host when both main-task modes resolve to the default Subagent profile', async () => {
+    const prepareCodexExtraSpawnConfig: NonNullable<AgentDeps['prepareCodexExtraSpawnConfig']> =
+      vi.fn(async () => ({
+        extraArgs: [],
+        extraEnv: {},
+        codexProxyActive: true,
+        codexSubagentRoutingProfile: 'default' as const,
+      }));
+    const agent = new CodexAgent(createDeps({}, { prepareCodexExtraSpawnConfig }));
+
+    const oauth = await agent.startSession({
+      sessionId: 'session-profile-default-oauth',
+      providerId: 'openai',
+      model: 'gpt-5.4',
+      workingDir: '/repo-oauth',
+    });
+
+    const thirdParty = await agent.startSession({
+      sessionId: 'session-profile-default-provider-oauth',
+      providerId: 'xai',
+      model: 'xai/grok-4.3',
+      workingDir: '/repo-xai',
+    });
+
+    expect(createdTransports).toHaveLength(1);
+    expect(createdTransports[0].closed).toBe(false);
+    await thirdParty.close();
+    await oauth.close();
+    await agent.dispose();
+  });
+
   it('does not reuse a host whose Subagent routing profile belongs to the opposite main-task mode', async () => {
     const prepareCodexExtraSpawnConfig: NonNullable<AgentDeps['prepareCodexExtraSpawnConfig']> =
       vi.fn(async (_providers, ctx) => {

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -1997,7 +1997,7 @@ export class CodexAgent extends BaseAgent {
     host: AppServerHost,
     fromMode: AgentCredentialMode | undefined,
     toMode: AgentCredentialMode | undefined,
-    opts: { ignoreBindingLeases?: number } = {},
+    opts: { ignoreBindingLeases?: number; forceRestart?: boolean } = {},
   ): Promise<void> {
     while (true) {
       const previous = this.hostCredentialModeSwitches.get(key);
@@ -2082,13 +2082,18 @@ export class CodexAgent extends BaseAgent {
     host: AppServerHost,
     fromMode: AgentCredentialMode | undefined,
     toMode: AgentCredentialMode | undefined,
-    opts: { ignoreBindingLeases?: number } = {},
+    opts: { ignoreBindingLeases?: number; forceRestart?: boolean } = {},
   ): Promise<void> {
     if (this.hosts.get(key) !== host) return;
     const currentMode = this.hostCredentialModes.get(key);
     // 仲裁用归一化形态(登记于 createHost,零额外 IO);缺失时回退原始形态。
     const currentEffective = this.hostEffectiveCredentialModes.get(key) ?? currentMode;
-    if (this.canReuseHostForCredentialRequest(host, currentEffective, toMode)) return;
+    if (
+      !opts.forceRestart
+      && this.canReuseHostForCredentialRequest(host, currentEffective, toMode)
+    ) {
+      return;
+    }
 
     let activeUseCount = this.hostActiveUseCount(key, host, opts);
     const coordinator = this.deps.prepareCodexLocalCredentialModeSwitch;
@@ -2117,6 +2122,7 @@ export class CodexAgent extends BaseAgent {
       fromMode: currentMode ?? fromMode ?? 'fallback',
       fromModeEffective: currentEffective ?? 'unresolved',
       toMode: toMode ?? 'fallback',
+      forcedBySubagentRoutingProfile: opts.forceRestart === true,
     });
     this.hosts.delete(key);
     this.hostCredentialModes.delete(key);
@@ -2162,6 +2168,14 @@ export class CodexAgent extends BaseAgent {
       }
       return requestedEffectiveMemo.value;
     };
+    const hasCompatibleSubagentRoutingProfile = async (host: AppServerHost): Promise<boolean> => {
+      const profile = host.getSubagentRoutingProfile();
+      if (profile === 'default') return true;
+      const requested = await resolveRequestedEffective();
+      return profile === 'oauth-default'
+        ? requested === 'oauth-bearer'
+        : requested !== 'oauth-bearer';
+    };
     const canReuseRegistered = async (
       host: AppServerHost,
       registeredRaw: AgentCredentialMode | undefined,
@@ -2183,7 +2197,13 @@ export class CodexAgent extends BaseAgent {
       if (existing) {
         const currentMode = this.hostCredentialModes.get(key);
         const currentEffective = this.hostEffectiveCredentialModes.get(key);
-        if (remoteHostId || (await canReuseRegistered(existing, currentMode, currentEffective))) {
+        const subagentRoutingProfileCompatible = remoteHostId
+          || await hasCompatibleSubagentRoutingProfile(existing);
+        if (
+          remoteHostId
+          || (subagentRoutingProfileCompatible
+            && await canReuseRegistered(existing, currentMode, currentEffective))
+        ) {
           return existing;
         }
         await this.shutdownHostForCredentialModeChange(
@@ -2191,7 +2211,10 @@ export class CodexAgent extends BaseAgent {
           existing,
           currentMode,
           await resolveRequestedEffective(),
-          opts,
+          {
+            ...opts,
+            forceRestart: !subagentRoutingProfileCompatible,
+          },
         );
         continue;
       }
@@ -2232,7 +2255,10 @@ export class CodexAgent extends BaseAgent {
           }
           const registeredRaw = this.hostCredentialModes.get(key) ?? inflight.credentialMode;
           const registeredEffective = this.hostEffectiveCredentialModes.get(key);
-          if (await canReuseRegistered(inflightHost, registeredRaw, registeredEffective)) {
+          if (
+            await hasCompatibleSubagentRoutingProfile(inflightHost)
+            && await canReuseRegistered(inflightHost, registeredRaw, registeredEffective)
+          ) {
             return inflightHost;
           }
           continue;
@@ -2245,12 +2271,17 @@ export class CodexAgent extends BaseAgent {
         inflight.promise.then(
           async (inflightHost) => {
             if (this.hosts.get(key) === inflightHost) {
+              const subagentRoutingProfileCompatible =
+                await hasCompatibleSubagentRoutingProfile(inflightHost);
               await this.shutdownHostForCredentialModeChange(
                 key,
                 inflightHost,
                 inflight.credentialMode,
                 requestedEffective,
-                opts,
+                {
+                  ...opts,
+                  forceRestart: !subagentRoutingProfileCompatible,
+                },
               );
               return;
             }
@@ -2508,6 +2539,7 @@ export class CodexAgent extends BaseAgent {
     let subagentModelFallback: string | undefined;
     let subagentRoute: CodexExtraSpawnConfig['subagentRoute'];
     let codexOpenAiWebSocketsEnabled = true;
+    let codexSubagentRoutingProfile: CodexExtraSpawnConfig['codexSubagentRoutingProfile'] = 'default';
     for (;;) {
       const upgradedToSuperset = spawnCredentialMode !== credentialMode;
       onSpawnCredentialModeResolved?.(spawnCredentialMode);
@@ -2535,6 +2567,7 @@ export class CodexAgent extends BaseAgent {
       subagentModelFallback = undefined;
       subagentRoute = undefined;
       codexOpenAiWebSocketsEnabled = true;
+      codexSubagentRoutingProfile = 'default';
       if (this.deps.prepareCodexExtraSpawnConfig) {
         try {
           const cfg = await this.deps.prepareCodexExtraSpawnConfig(
@@ -2542,6 +2575,9 @@ export class CodexAgent extends BaseAgent {
             {
               remoteHostId,
               credentialMode: spawnCredentialMode,
+              ...(spawnCredentialMode !== credentialMode
+                ? { requestedCredentialMode: credentialMode }
+                : {}),
               ...(hostPurpose ? { hostPurpose } : {}),
             },
           );
@@ -2565,6 +2601,7 @@ export class CodexAgent extends BaseAgent {
           subagentModelFallback = cfg.subagentModelFallback;
           subagentRoute = cfg.subagentRoute;
           codexOpenAiWebSocketsEnabled = cfg.codexOpenAiWebSocketsEnabled !== false;
+          codexSubagentRoutingProfile = cfg.codexSubagentRoutingProfile ?? 'default';
           codexProxyActive = cfg.codexProxyActive === true && !remoteHostId;
           // Remote daemons own their browser companion and its CODEX_HOME;
           // preserve the host-provided availability snapshot instead of
@@ -2667,6 +2704,7 @@ export class CodexAgent extends BaseAgent {
       subagentModelFallback,
       subagentRoute,
       codexOpenAiWebSocketsEnabled,
+      codexSubagentRoutingProfile,
       // app-server 对失败 RPC 返回 cloudRequirements + Auth/relogin 结构化错误时,当前 host
       // 持有的 token 已不可用。stderr 与工具输出只做诊断,绝不驱动鉴权状态。保留 host 只会
       // 持续撞鉴权失败; auth.invalidate 会触发 logout + 通知 UI 重登。延后到 microtask

--- a/packages/maker-core/src/agents/credential-mode.test.ts
+++ b/packages/maker-core/src/agents/credential-mode.test.ts
@@ -50,7 +50,7 @@ describe('resolveAgentCredentialMode', () => {
     expect(resolveAgentCredentialMode({
       agentKind: 'codex',
       providerId: 'custom-openai-compatible',
-      model: 'custom-model',
+      model: 'codex/gpt-5.6-luna',
     })).toBe('provider-oauth');
   });
 


### PR DESCRIPTION
## 这次改了什么

### 摘要

本 PR（fix(desktop): 修复 ChatGPT OAuth 与固定 Subagent 混用问题 #3119）修复 ChatGPT OAuth 与固定 Subagent 同时配置时的凭据路由冲突，避免第三方 Codex/GPT 代理被误判为 ChatGPT OAuth。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#3119
- 本 PR 包含：收紧内置 ChatGPT OAuth 判定；主任务与固定 Subagent 发生 OAuth/第三方混用时按未配置固定 Subagent 处理；保留普通 Subagent 总开关、并发和嵌套配置；补充设置面板说明、单测和 Windows 符号链接能力探测。
- 明确不包含：不改变第三方 Provider 的正常路由，不修改插件基座、服务端或移动端原生配置。
- 用户可见变化：Subagent 设置面板会提示 ChatGPT OAuth 与固定 Subagent 不能同时生效；混用时使用 Codex 默认 Subagent。
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：`docs/design-rules/DESIGN.md` §10「Light / Dark 双模式交付门槛」与 §11「Voice & Content」；说明文案通过现有 i18n 五语落地，沿用既有主题 token 和设置面板布局，未新增硬编码颜色。

## 怎么验证的

### 自动验证

`pnpm test:unit:related`

结果：通过（Desktop、maker-core、lizi-mcps、orca-workflow 相关单测）。

`pnpm --filter desktop run --if-present typecheck`

结果：通过。

Pi 包安全测试：65 个通过、4 个按本机文件符号链接能力跳过；不具备 Windows 文件 symlink 权限时遵循仓库既有测试约定，不放宽生产安全逻辑。

`pnpm check:dco`

结果：通过。

### 手工验证

使用 Luna 沙盒覆盖以下组合：

- 内置 ChatGPT OAuth 主任务 + 固定第三方 Subagent：固定配置被忽略，使用 Codex 默认 Subagent。
- 第三方主任务 + 固定 ChatGPT OAuth Subagent：按未配置固定 Subagent 处理。
- 第三方主任务 + 固定第三方 Subagent：固定 Subagent 正常保留。
- 模型名包含 `codex` / `gpt` 但不满足内置 ChatGPT OAuth 条件：不会误判。

结果：各组合行为符合预期。

### 未执行的验证

未执行完整 `pnpm test:unit`；本次提交门禁已通过相关单测与 desktop typecheck，完整单测交由 CI 执行。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop 的 Codex 主任务与 Subagent 选择逻辑，以及 Subagent 设置说明。只有明确识别为内置 OpenAI ChatGPT 订阅 OAuth 的组合会触发回退；第三方 Provider 不受误伤。Windows 文件 symlink 测试在能力不足时跳过竞态用例，生产代码不变。
- 移动端冷更判断：本次未修改 `apps/mobile` 原生配置、原生依赖或 runtime fingerprint，不触发冷更。
- 存量插件影响：无；未修改插件运行时、批准状态、安装布局或包格式。
- 回滚 / 降级方式：回滚本 PR 提交即可恢复原有 Subagent 路由判断。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因