### PR TITLE
fix(mobile): 优化消息分享选择交互

### DIFF
--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -123,6 +123,7 @@ import {
   isFoldableBlockExpanded,
   useFoldableExpandedBlocksSnapshot,
 } from '@/session/expandedBlockMemory';
+import { ShareSelectAllButton } from '@/session/ShareSelectAllButton';
 import { ShareSelectionBar } from '@/session/ShareSelectionBar';
 import {
   shareSelectionStore,
@@ -8833,6 +8834,9 @@ export default function SessionScreen() {
               currentSession={currentSession}
               diffCount={diffCount}
               isDeviceAccessRevoked={isDeviceAccessRevoked}
+              shareSelectAllNode={shareSelectionActive ? (
+                <ShareSelectAllButton busy={conversationShareBusy} shareableIds={allShareableIds} />
+              ) : undefined}
               syncing={showSyncingIndicator}
               messageCount={Math.max(messages.length, currentSession?._count?.messages ?? 0)}
               onBack={goBackToHome}
@@ -9675,7 +9679,6 @@ export default function SessionScreen() {
             <ShareSelectionBar
               busy={conversationShareBusy}
               count={shareSelectionCount}
-              shareableIds={allShareableIds}
               screenshotTriggered={shareSelectionTriggeredByScreenshot}
               onCancel={cancelShareSelection}
               onShare={() => void shareSelectedConversation()}
@@ -9724,6 +9727,7 @@ function SessionHeaderBar({
   currentSession,
   diffCount,
   isDeviceAccessRevoked,
+  shareSelectAllNode,
   syncing,
   messageCount,
   onBack,
@@ -9744,6 +9748,8 @@ function SessionHeaderBar({
   currentSession: RemoteSession | null;
   diffCount: number;
   isDeviceAccessRevoked: boolean;
+  /** 分享选择模式下替换头部动作区。 */
+  shareSelectAllNode?: ReactNode;
   syncing: boolean;
   messageCount: number;
   onBack(): void;
@@ -9799,6 +9805,14 @@ function SessionHeaderBar({
     session: currentSession,
   });
 
+  // 分享选择模式只保留全选；底部关闭按钮负责退出。
+  if (shareSelectAllNode) {
+    return (
+      <View style={styles.sessionHeaderBar} testID="session.summary">
+        {shareSelectAllNode}
+      </View>
+    );
+  }
   return (
     <View style={styles.sessionHeaderBar} testID="session.summary">
       {onOpenSessionList ? (

--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -8834,6 +8834,9 @@ export default function SessionScreen() {
               currentSession={currentSession}
               diffCount={diffCount}
               isDeviceAccessRevoked={isDeviceAccessRevoked}
+              shareSelectionLeadingInset={nativeShellLayout.wideViewport
+                ? Math.max(0, (windowDimensions.width - nativeShellLayout.contentMaxWidth) / 2)
+                : 0}
               shareSelectAllNode={shareSelectionActive ? (
                 <ShareSelectAllButton busy={conversationShareBusy} shareableIds={allShareableIds} />
               ) : undefined}
@@ -9727,6 +9730,7 @@ function SessionHeaderBar({
   currentSession,
   diffCount,
   isDeviceAccessRevoked,
+  shareSelectionLeadingInset,
   shareSelectAllNode,
   syncing,
   messageCount,
@@ -9748,6 +9752,8 @@ function SessionHeaderBar({
   currentSession: RemoteSession | null;
   diffCount: number;
   isDeviceAccessRevoked: boolean;
+  /** 宽屏下与消息内容列共用的左侧 inset。 */
+  shareSelectionLeadingInset: number;
   /** 分享选择模式下替换头部动作区。 */
   shareSelectAllNode?: ReactNode;
   syncing: boolean;
@@ -9808,7 +9814,13 @@ function SessionHeaderBar({
   // 分享选择模式只保留全选；底部关闭按钮负责退出。
   if (shareSelectAllNode) {
     return (
-      <View style={styles.sessionHeaderBar} testID="session.summary">
+      <View
+        style={[
+          styles.sessionHeaderBar,
+          { paddingLeft: shareSelectionLeadingInset + spacing.sm },
+        ]}
+        testID="session.summary"
+      >
         {shareSelectAllNode}
       </View>
     );

--- a/apps/mobile/src/__tests__/conversationShareWebViewHtml.test.ts
+++ b/apps/mobile/src/__tests__/conversationShareWebViewHtml.test.ts
@@ -291,7 +291,8 @@ describe('buildConversationShareHtml 富内容导出', () => {
     expect(selectAllSource).toContain('<ShareCheckboxMark checked={allSelected} />');
     expect(selectAllSource).not.toContain('backgroundColor: colors.surfaceChip');
     expect(messageCheckboxSource).toContain('fill ? styles.rowButton : styles.button');
-    expect(messageRendererSource).toContain(
+    expect(messageRendererSource).toContain('<View style={styles.shareSelectionContent}>');
+    expect(messageRendererSource).not.toContain(
       'pointerEvents="none" style={styles.shareSelectionContent}',
     );
     expect(messageRendererSource).toContain('fill');
@@ -299,14 +300,20 @@ describe('buildConversationShareHtml 富内容导出', () => {
       'testID="message.shareStickyCheck"',
     );
     expect(messageRendererSource).toContain(
-      'token.item.type !== \'message\' || !isShareableMessage(token.item.message)',
+      'const shareableViews = Array.from(shareableMessageViewsRef.current.entries())',
     );
     expect(messageRendererSource).toContain(
-      'token.index < firstShareableIndex',
+      'candidates.sort((a, b) => (a.frame?.y ?? Number.POSITIVE_INFINITY)',
+    );
+    expect(messageRendererSource).toContain(
+      'const pinned = candidates.find(({ frame }) => frame',
     );
     expect(messageRendererSource).toContain(
       'frame.y + frame.height > dockY + SHARE_STICKY_CHECK_HEIGHT',
     );
+    expect(messageRendererSource).toContain('pointerEvents="box-none"');
+    expect(messageRendererSource).toContain('marginLeft: wideContentInset + spacing.lg');
+    expect(messageRendererSource).not.toContain('styles.stickyShareSpacer');
     expect(webViewSource).toContain(
       'onShouldStartLoadWithRequest={interceptNavigation}',
     );

--- a/apps/mobile/src/__tests__/conversationShareWebViewHtml.test.ts
+++ b/apps/mobile/src/__tests__/conversationShareWebViewHtml.test.ts
@@ -273,6 +273,10 @@ describe('buildConversationShareHtml 富内容导出', () => {
       resolve(process.cwd(), 'src/session/MessageRenderer.tsx'),
       'utf8',
     );
+    const sessionSource = readFileSync(
+      resolve(process.cwd(), 'app/sessions/[sessionId].tsx'),
+      'utf8',
+    );
 
     expect(html).toContain('<div class="share-gap" aria-hidden="true">⋯</div>');
     expect(html).toMatch(
@@ -290,11 +294,17 @@ describe('buildConversationShareHtml 富内容导出', () => {
     );
     expect(selectAllSource).toContain('<ShareCheckboxMark checked={allSelected} />');
     expect(selectAllSource).not.toContain('backgroundColor: colors.surfaceChip');
-    expect(messageCheckboxSource).toContain('fill ? styles.rowButton : styles.button');
+    expect(messageCheckboxSource).toContain('onStartShouldSetResponder={() => !disabled}');
+    expect(messageCheckboxSource).toContain('onResponderTerminationRequest={() => true}');
+    expect(messageCheckboxSource).toContain('shouldCommitShareSelectionTap({');
+    expect(messageCheckboxSource).toContain('<ShareSelectionRowInteractionContext.Provider');
+    expect(messageCheckboxSource).toContain('if (!gesture.consumed) toggle();');
+    expect(messageCheckboxSource).not.toContain('fill ? styles.rowButton : styles.button');
     expect(messageRendererSource).toContain('<View style={styles.shareSelectionContent}>');
     expect(messageRendererSource).not.toContain(
       'pointerEvents="none" style={styles.shareSelectionContent}',
     );
+    expect(messageRendererSource).toContain('useCancelShareSelectionRowTap()');
     expect(messageRendererSource).toContain('fill');
     expect(messageRendererSource).toContain(
       'testID="message.shareStickyCheck"',
@@ -314,6 +324,12 @@ describe('buildConversationShareHtml 富内容导出', () => {
     expect(messageRendererSource).toContain('pointerEvents="box-none"');
     expect(messageRendererSource).toContain('marginLeft: wideContentInset + spacing.lg');
     expect(messageRendererSource).not.toContain('styles.stickyShareSpacer');
+    expect(sessionSource).toContain(
+      'shareSelectionLeadingInset={nativeShellLayout.wideViewport',
+    );
+    expect(sessionSource).toContain(
+      '{ paddingLeft: shareSelectionLeadingInset + spacing.sm }',
+    );
     expect(webViewSource).toContain(
       'onShouldStartLoadWithRequest={interceptNavigation}',
     );

--- a/apps/mobile/src/__tests__/conversationShareWebViewHtml.test.ts
+++ b/apps/mobile/src/__tests__/conversationShareWebViewHtml.test.ts
@@ -260,6 +260,19 @@ describe('buildConversationShareHtml 富内容导出', () => {
       resolve(process.cwd(), 'src/session/ShareSelectionBar.tsx'),
       'utf8',
     );
+    const selectAllSource = readFileSync(
+      resolve(process.cwd(), 'src/session/ShareSelectAllButton.tsx'),
+      'utf8',
+    );
+
+    const messageCheckboxSource = readFileSync(
+      resolve(process.cwd(), 'src/session/ShareMessageCheckbox.tsx'),
+      'utf8',
+    );
+    const messageRendererSource = readFileSync(
+      resolve(process.cwd(), 'src/session/MessageRenderer.tsx'),
+      'utf8',
+    );
 
     expect(html).toContain('<div class="share-gap" aria-hidden="true">⋯</div>');
     expect(html).toMatch(
@@ -267,11 +280,32 @@ describe('buildConversationShareHtml 富内容导出', () => {
     );
     expect(shareBarSource).toContain('height: 44,');
     expect(shareBarSource).toContain('minHeight: 44,');
-    expect(shareBarSource).toContain(
+    expect(shareBarSource).toContain('minWidth: 112,');
+    expect(shareBarSource).toContain('fontSize: typeScale.body,');
+    expect(selectAllSource).toContain(
       'shareableIds.filter((clientId) =>',
     );
-    expect(shareBarSource).toContain(
+    expect(selectAllSource).toContain(
       'selectionBeforeSelectAllRef.current?.includes(clientId)',
+    );
+    expect(selectAllSource).toContain('<ShareCheckboxMark checked={allSelected} />');
+    expect(selectAllSource).not.toContain('backgroundColor: colors.surfaceChip');
+    expect(messageCheckboxSource).toContain('fill ? styles.rowButton : styles.button');
+    expect(messageRendererSource).toContain(
+      'pointerEvents="none" style={styles.shareSelectionContent}',
+    );
+    expect(messageRendererSource).toContain('fill');
+    expect(messageRendererSource).toContain(
+      'testID="message.shareStickyCheck"',
+    );
+    expect(messageRendererSource).toContain(
+      'token.item.type !== \'message\' || !isShareableMessage(token.item.message)',
+    );
+    expect(messageRendererSource).toContain(
+      'token.index < firstShareableIndex',
+    );
+    expect(messageRendererSource).toContain(
+      'frame.y + frame.height > dockY + SHARE_STICKY_CHECK_HEIGHT',
     );
     expect(webViewSource).toContain(
       'onShouldStartLoadWithRequest={interceptNavigation}',

--- a/apps/mobile/src/__tests__/shareSelectionTap.test.ts
+++ b/apps/mobile/src/__tests__/shareSelectionTap.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import {
+  SHARE_SELECTION_TAP_MAX_DISTANCE,
+  SHARE_SELECTION_TAP_MAX_DURATION_MS,
+  shareSelectionTapMoved,
+  shouldCommitShareSelectionTap,
+} from '@/session/shareSelectionTap';
+
+describe('share selection row tap', () => {
+  it('keeps a stationary short tap eligible for whole-row selection', () => {
+    expect(shareSelectionTapMoved(
+      { pageX: 24, pageY: 80 },
+      { pageX: 24 + SHARE_SELECTION_TAP_MAX_DISTANCE, pageY: 80 },
+    )).toBe(false);
+    expect(shouldCommitShareSelectionTap({
+      durationMs: SHARE_SELECTION_TAP_MAX_DURATION_MS,
+      moved: false,
+    })).toBe(true);
+  });
+
+  it('does not select after a drag or long press', () => {
+    expect(shareSelectionTapMoved(
+      { pageX: 24, pageY: 80 },
+      { pageX: 24 + SHARE_SELECTION_TAP_MAX_DISTANCE + 1, pageY: 80 },
+    )).toBe(true);
+    expect(shouldCommitShareSelectionTap({ durationMs: 120, moved: true })).toBe(false);
+    expect(shouldCommitShareSelectionTap({
+      durationMs: SHARE_SELECTION_TAP_MAX_DURATION_MS + 1,
+      moved: false,
+    })).toBe(false);
+  });
+});

--- a/apps/mobile/src/session/MessageRenderer.tsx
+++ b/apps/mobile/src/session/MessageRenderer.tsx
@@ -323,6 +323,10 @@ import { i18n } from '@/i18n';
 const MESSAGE_CONTROL_HIT_SLOP = { bottom: 10, left: 10, right: 10, top: 10 };
 const MESSAGE_CONTROL_TOUCH_SIZE = 44;
 const MESSAGE_LIST_VISIBLE_PERCENT_THRESHOLD = 5;
+
+/** 分享模式吸顶 check 与行内 check 共用 44px 触达高度。 */
+const SHARE_STICKY_CHECK_HEIGHT = 44;
+const STICKY_SHARE_CHECK_THROTTLE_MS = 150;
 const SCREENSHOT_SHARE_VISIBLE_PERCENT_THRESHOLD = 10;
 // LegendList 变高 item 的初始估高(仅影响首帧布局定位,LegendList 挂载后按实测尺寸修正)。
 /**
@@ -932,15 +936,89 @@ export function MessageRenderer({
   const viewabilityConfigRef = useRef({
     itemVisiblePercentThreshold: MESSAGE_LIST_VISIBLE_PERCENT_THRESHOLD,
   });
+  const shareSelectionActiveRef = useRef(shareSelectionActive);
+  shareSelectionActiveRef.current = shareSelectionActive;
+  const topOverlayHeightRef = useRef(topOverlayHeight);
+  topOverlayHeightRef.current = topOverlayHeight;
+  const firstShareableViewableClientIdRef = useRef<string | null>(null);
+  const [stickyShareClientId, setStickyShareClientId] = useState<string | null>(null);
+  const stickyCheckSeqRef = useRef(0);
+  const stickyCheckLastRunAtRef = useRef(0);
+  const stickyCheckTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const runStickyShareCheck = useCallback(async () => {
+    const seq = ++stickyCheckSeqRef.current;
+    if (!shareSelectionActiveRef.current) {
+      setStickyShareClientId(null);
+      return;
+    }
+    const clientId = firstShareableViewableClientIdRef.current;
+    const list = listRef.current;
+    const view = clientId ? shareableMessageViewsRef.current.get(clientId) : null;
+    if (!clientId || !list || !view) {
+      setStickyShareClientId(null);
+      return;
+    }
+    const [listFrame, frame] = await Promise.all([
+      measureInWindow(list.getNativeScrollRef()),
+      measureInWindow(view),
+    ]);
+    if (seq !== stickyCheckSeqRef.current) return;
+    if (!listFrame || !frame || frame.height <= 0) {
+      setStickyShareClientId(null);
+      return;
+    }
+    const dockY = listFrame.y + (topOverlayHeightRef.current ?? 0) + spacing.sm;
+    const pinned =
+      frame.y < dockY && frame.y + frame.height > dockY + SHARE_STICKY_CHECK_HEIGHT;
+    setStickyShareClientId((prev) => {
+      const next = pinned ? clientId : null;
+      return prev === next ? prev : next;
+    });
+  }, []);
+  const scheduleStickyShareCheck = useCallback((immediate = false) => {
+    const now = Date.now();
+    const elapsed = now - stickyCheckLastRunAtRef.current;
+    if (immediate || elapsed >= STICKY_SHARE_CHECK_THROTTLE_MS) {
+      stickyCheckLastRunAtRef.current = now;
+      void runStickyShareCheck();
+      return;
+    }
+    if (stickyCheckTimerRef.current) return;
+    stickyCheckTimerRef.current = setTimeout(() => {
+      stickyCheckTimerRef.current = null;
+      stickyCheckLastRunAtRef.current = Date.now();
+      void runStickyShareCheck();
+    }, STICKY_SHARE_CHECK_THROTTLE_MS - elapsed);
+  }, [runStickyShareCheck]);
+  const scheduleStickyShareCheckRef = useRef(scheduleStickyShareCheck);
+  scheduleStickyShareCheckRef.current = scheduleStickyShareCheck;
+  useEffect(() => {
+    if (!shareSelectionActive) setStickyShareClientId(null);
+    else scheduleStickyShareCheck(true);
+  }, [shareSelectionActive, scheduleStickyShareCheck]);
+  useEffect(() => () => {
+    if (stickyCheckTimerRef.current) clearTimeout(stickyCheckTimerRef.current);
+  }, []);
   const handleViewableItemsChangedRef = useRef((info: {
     viewableItems: ViewToken<MobileMessageRenderItem>[];
   }) => {
     let nextIndex: number | null = null;
+    let firstShareable: string | null = null;
+    let firstShareableIndex = Number.POSITIVE_INFINITY;
     for (const token of info.viewableItems) {
       if (typeof token.index !== 'number') continue;
       nextIndex = nextIndex === null ? token.index : Math.min(nextIndex, token.index);
+      if (token.item.type !== 'message' || !isShareableMessage(token.item.message)) continue;
+      const clientId = messageClientId(token.item);
+      if (clientId && token.index < firstShareableIndex) {
+        firstShareableIndex = token.index;
+        firstShareable = clientId;
+      }
     }
     if (nextIndex !== null) setFirstVisibleIndex(nextIndex);
+    const candidateChanged = firstShareableViewableClientIdRef.current !== firstShareable;
+    firstShareableViewableClientIdRef.current = firstShareable;
+    if (candidateChanged) scheduleStickyShareCheckRef.current?.(true);
   });
   const readActuallyVisibleShareableMessageIds = useCallback(async (
     viewport: ShareableMessageViewport,
@@ -1128,7 +1206,9 @@ export function MessageRenderer({
     // 拖动进近顶区时 onStartReached 边沿可能早已被消费(见 attemptAutoLoadEarlier 注释),
     // 滚动事件兜底重评估;前置短路让稳态滚动只付 1~2 次 ref 比较的成本。
     attemptAutoLoadEarlier();
-  }, [attemptAutoLoadEarlier, bottomOverlayHeight]);
+    // 分享模式:滚动驱动吸顶 check 的几何重判(内部节流,非分享模式直接返回)。
+    if (shareSelectionActiveRef.current) scheduleStickyShareCheck();
+  }, [attemptAutoLoadEarlier, bottomOverlayHeight, scheduleStickyShareCheck]);
 
   // 用户开始拖动 → 标记「上翻意图」,放行自动加载更早(onScrollBeginDrag 仅用户手势触发,
   // 程序化 scrollToEnd 不会触发,故不会误置);同时记录拖动起点 offset,供
@@ -1455,6 +1535,24 @@ export function MessageRenderer({
         >
           <ArrowUp color={colors.textPrimary} size={iconSize.md} strokeWidth={iconStroke.regular} />
         </MessageListActionButton>
+      ) : null}
+      {shareSelectionActive && stickyShareClientId ? (
+        // 与分享消息行同构，保持吸顶 check 和行内 check 水平对齐。
+        <View
+          pointerEvents="box-none"
+          style={[styles.stickyShareOverlay, { top: (topOverlayHeight ?? 0) + spacing.sm }]}
+          testID="message.shareStickyCheck"
+        >
+          <View style={styles.stickyShareRow}>
+            <View style={styles.stickyShareGutter}>
+              <ShareMessageCheckbox
+                clientId={stickyShareClientId}
+                disabled={shareSelectionBusy === true}
+              />
+            </View>
+            <View style={styles.stickyShareSpacer} />
+          </View>
+        </View>
       ) : null}
       {hasNewMessages || showJumpToLatest ? (
         // 跳到底部浮标(Telegram 风):右下角半透明圆形 chevron,弱存在感;
@@ -2331,12 +2429,15 @@ function MessageBubble({
 
   if (!shareSelectionActive) return messageNode;
   return (
-    <View style={styles.shareSelectionRow}>
-      <View style={styles.shareSelectionGutter}>
-        <ShareMessageCheckbox clientId={clientId} disabled={actions.shareSelectionBusy === true} />
+    <ShareMessageCheckbox
+      clientId={clientId}
+      disabled={actions.shareSelectionBusy === true}
+      fill
+    >
+      <View pointerEvents="none" style={styles.shareSelectionContent}>
+        {messageNode}
       </View>
-      <View style={styles.shareSelectionContent}>{messageNode}</View>
-    </View>
+    </ShareMessageCheckbox>
   );
 }
 
@@ -6356,21 +6457,30 @@ const makeStyles = (colors: ThemeColors) => StyleSheet.create({
     gap: 2,
     width: '100%',
   },
-  shareSelectionRow: {
-    alignItems: 'flex-start',
-    flexDirection: 'row',
-    gap: spacing.sm,
-    minWidth: 0,
-    width: '100%',
-  },
-  shareSelectionGutter: {
-    alignItems: 'center',
-    paddingTop: spacing.sm,
-    width: spacing.xl * 2,
-  },
   shareSelectionContent: {
     flex: 1,
     minWidth: 0,
+  },
+  stickyShareOverlay: {
+    left: 0,
+    position: 'absolute',
+    right: 0,
+    top: 0,
+    zIndex: 5,
+  },
+  // 与消息列表 padding 和分享行 gutter 同构。
+  stickyShareRow: {
+    flexDirection: 'row',
+    paddingHorizontal: spacing.lg,
+    paddingTop: 0,
+    width: '100%',
+  },
+  stickyShareGutter: {
+    alignItems: 'center',
+    width: spacing.xl * 2,
+  },
+  stickyShareSpacer: {
+    flex: 1,
   },
   sentInlineTextChunk: {
     flexBasis: '100%',

--- a/apps/mobile/src/session/MessageRenderer.tsx
+++ b/apps/mobile/src/session/MessageRenderer.tsx
@@ -47,6 +47,7 @@ import {
   StatusBar,
   useWindowDimensions,
   View,
+  type GestureResponderEvent,
   type NativeScrollEvent,
   type NativeSyntheticEvent,
   type LayoutChangeEvent,
@@ -73,7 +74,10 @@ import { mobileAgentLabelFromUnknown } from '@/session/sessionAgentSwitch';
 import { MessageActionSheet } from '@/session/MessageActionSheet';
 import { buildMobileMessageMenu, type MobileMessageMenuActionId } from '@/session/messageActionMenu';
 import { isShareableMessage } from '@/session/shareSelectionStore';
-import { ShareMessageCheckbox } from '@/session/ShareMessageCheckbox';
+import {
+  ShareMessageCheckbox,
+  useCancelShareSelectionRowTap,
+} from '@/session/ShareMessageCheckbox';
 import { SentInlineAtomBody } from '@/session/SentInlineAtomBody';
 import {
   composerDocumentFromSerializedMessage,
@@ -444,7 +448,20 @@ function MarkdownSelectableText({
  * 混入 RN Text 会破坏原生文本树。仅由 renderInline 在「块可选中且 iOS」时使用。
  */
 function MarkdownSelectableSpan(props: ComponentProps<typeof Text>) {
-  return <UITextView maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER} {...props} />;
+  const cancelShareSelectionRowTap = useCancelShareSelectionRowTap();
+  const handlePress = props.onPress
+    ? (event: GestureResponderEvent) => {
+      cancelShareSelectionRowTap?.();
+      props.onPress?.(event);
+    }
+    : undefined;
+  return (
+    <UITextView
+      maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}
+      {...props}
+      onPress={handlePress}
+    />
+  );
 }
 
 function isTextRunContinuationGroup(group: MobileMarkdownBlockGroup): boolean {

--- a/apps/mobile/src/session/MessageRenderer.tsx
+++ b/apps/mobile/src/session/MessageRenderer.tsx
@@ -606,6 +606,9 @@ export function MessageRenderer({
     screenHeight: windowDimensions.height,
     screenWidth: windowDimensions.width,
   }), [windowDimensions.height, windowDimensions.width]);
+  const wideContentInset = viewportLayout.wideViewport
+    ? Math.max(0, (windowDimensions.width - viewportLayout.contentMaxWidth) / 2)
+    : 0;
   const nearBottomRef = useRef(true);
   // ── 拖动手势追踪(贴底跟随的意图解除用)──
   // 拖动期间(onScrollBeginDrag ~ onScrollEndDrag)相对起点累计上移超过死区
@@ -841,11 +844,8 @@ export function MessageRenderer({
     const micCenterFromRight = touchLayout.composerPaddingHorizontal
       + MOBILE_COMPOSER_VOICE_ANCHOR_RIGHT
       + MOBILE_COMPOSER_CONTROL_SIZE / 2;
-    const wideInset = viewportLayout.wideViewport
-      ? Math.max(0, (windowDimensions.width - viewportLayout.contentMaxWidth) / 2)
-      : 0;
-    return Math.round(wideInset + micCenterFromRight - SCROLL_TO_BOTTOM_FAB_SIZE / 2);
-  }, [viewportLayout.contentMaxWidth, viewportLayout.wideViewport, windowDimensions.width]);
+    return Math.round(wideContentInset + micCenterFromRight - SCROLL_TO_BOTTOM_FAB_SIZE / 2);
+  }, [wideContentInset, windowDimensions.width]);
   const loadEarlierAction = buildMessageLoadEarlierAction({
     hasOlderMessages: canLoadEarlier === true,
     loading: loadingEarlier === true,
@@ -854,9 +854,10 @@ export function MessageRenderer({
   const handleShareableMessageViewChange = useCallback((clientId: string, view: View | null) => {
     if (view) {
       shareableMessageViewsRef.current.set(clientId, view);
-      return;
+    } else {
+      shareableMessageViewsRef.current.delete(clientId);
     }
-    shareableMessageViewsRef.current.delete(clientId);
+    if (shareSelectionActiveRef.current) scheduleStickyShareCheckRef.current?.(true);
   }, []);
   const actions: MessageActions & { firstUserMessageClientId?: string } = useMemo(() => ({
     onAddMessageToComposer,
@@ -940,7 +941,6 @@ export function MessageRenderer({
   shareSelectionActiveRef.current = shareSelectionActive;
   const topOverlayHeightRef = useRef(topOverlayHeight);
   topOverlayHeightRef.current = topOverlayHeight;
-  const firstShareableViewableClientIdRef = useRef<string | null>(null);
   const [stickyShareClientId, setStickyShareClientId] = useState<string | null>(null);
   const stickyCheckSeqRef = useRef(0);
   const stickyCheckLastRunAtRef = useRef(0);
@@ -951,27 +951,33 @@ export function MessageRenderer({
       setStickyShareClientId(null);
       return;
     }
-    const clientId = firstShareableViewableClientIdRef.current;
+    const shareableViews = Array.from(shareableMessageViewsRef.current.entries());
     const list = listRef.current;
-    const view = clientId ? shareableMessageViewsRef.current.get(clientId) : null;
-    if (!clientId || !list || !view) {
+    if (!list || shareableViews.length === 0) {
       setStickyShareClientId(null);
       return;
     }
-    const [listFrame, frame] = await Promise.all([
+    const [listFrame, candidates] = await Promise.all([
       measureInWindow(list.getNativeScrollRef()),
-      measureInWindow(view),
+      Promise.all(shareableViews.map(async ([clientId, view]) => ({
+        clientId,
+        frame: await measureInWindow(view),
+      }))),
     ]);
     if (seq !== stickyCheckSeqRef.current) return;
-    if (!listFrame || !frame || frame.height <= 0) {
+    if (!listFrame) {
       setStickyShareClientId(null);
       return;
     }
     const dockY = listFrame.y + (topOverlayHeightRef.current ?? 0) + spacing.sm;
-    const pinned =
-      frame.y < dockY && frame.y + frame.height > dockY + SHARE_STICKY_CHECK_HEIGHT;
+    candidates.sort((a, b) => (a.frame?.y ?? Number.POSITIVE_INFINITY)
+      - (b.frame?.y ?? Number.POSITIVE_INFINITY));
+    const pinned = candidates.find(({ frame }) => frame
+      && frame.height > 0
+      && frame.y + spacing.sm < dockY
+      && frame.y + frame.height > dockY + SHARE_STICKY_CHECK_HEIGHT);
     setStickyShareClientId((prev) => {
-      const next = pinned ? clientId : null;
+      const next = pinned?.clientId ?? null;
       return prev === next ? prev : next;
     });
   }, []);
@@ -995,7 +1001,7 @@ export function MessageRenderer({
   useEffect(() => {
     if (!shareSelectionActive) setStickyShareClientId(null);
     else scheduleStickyShareCheck(true);
-  }, [shareSelectionActive, scheduleStickyShareCheck]);
+  }, [shareSelectionActive, scheduleStickyShareCheck, topOverlayHeight]);
   useEffect(() => () => {
     if (stickyCheckTimerRef.current) clearTimeout(stickyCheckTimerRef.current);
   }, []);
@@ -1003,22 +1009,11 @@ export function MessageRenderer({
     viewableItems: ViewToken<MobileMessageRenderItem>[];
   }) => {
     let nextIndex: number | null = null;
-    let firstShareable: string | null = null;
-    let firstShareableIndex = Number.POSITIVE_INFINITY;
     for (const token of info.viewableItems) {
       if (typeof token.index !== 'number') continue;
       nextIndex = nextIndex === null ? token.index : Math.min(nextIndex, token.index);
-      if (token.item.type !== 'message' || !isShareableMessage(token.item.message)) continue;
-      const clientId = messageClientId(token.item);
-      if (clientId && token.index < firstShareableIndex) {
-        firstShareableIndex = token.index;
-        firstShareable = clientId;
-      }
     }
     if (nextIndex !== null) setFirstVisibleIndex(nextIndex);
-    const candidateChanged = firstShareableViewableClientIdRef.current !== firstShareable;
-    firstShareableViewableClientIdRef.current = firstShareable;
-    if (candidateChanged) scheduleStickyShareCheckRef.current?.(true);
   });
   const readActuallyVisibleShareableMessageIds = useCallback(async (
     viewport: ShareableMessageViewport,
@@ -1543,14 +1538,14 @@ export function MessageRenderer({
           style={[styles.stickyShareOverlay, { top: (topOverlayHeight ?? 0) + spacing.sm }]}
           testID="message.shareStickyCheck"
         >
-          <View style={styles.stickyShareRow}>
-            <View style={styles.stickyShareGutter}>
-              <ShareMessageCheckbox
-                clientId={stickyShareClientId}
-                disabled={shareSelectionBusy === true}
-              />
-            </View>
-            <View style={styles.stickyShareSpacer} />
+          <View
+            pointerEvents="box-none"
+            style={[styles.stickyShareControl, { marginLeft: wideContentInset + spacing.lg }]}
+          >
+            <ShareMessageCheckbox
+              clientId={stickyShareClientId}
+              disabled={shareSelectionBusy === true}
+            />
           </View>
         </View>
       ) : null}
@@ -2434,7 +2429,7 @@ function MessageBubble({
       disabled={actions.shareSelectionBusy === true}
       fill
     >
-      <View pointerEvents="none" style={styles.shareSelectionContent}>
+      <View style={styles.shareSelectionContent}>
         {messageNode}
       </View>
     </ShareMessageCheckbox>
@@ -6462,25 +6457,16 @@ const makeStyles = (colors: ThemeColors) => StyleSheet.create({
     minWidth: 0,
   },
   stickyShareOverlay: {
+    height: SHARE_STICKY_CHECK_HEIGHT,
     left: 0,
     position: 'absolute',
     right: 0,
     top: 0,
     zIndex: 5,
   },
-  // 与消息列表 padding 和分享行 gutter 同构。
-  stickyShareRow: {
-    flexDirection: 'row',
-    paddingHorizontal: spacing.lg,
-    paddingTop: 0,
-    width: '100%',
-  },
-  stickyShareGutter: {
+  stickyShareControl: {
     alignItems: 'center',
     width: spacing.xl * 2,
-  },
-  stickyShareSpacer: {
-    flex: 1,
   },
   sentInlineTextChunk: {
     flexBasis: '100%',

--- a/apps/mobile/src/session/ShareMessageCheckbox.tsx
+++ b/apps/mobile/src/session/ShareMessageCheckbox.tsx
@@ -1,22 +1,43 @@
+import { type ReactNode } from "react";
 import { Check } from "lucide-react-native";
 import { Pressable, StyleSheet, View } from "react-native";
 import { useTranslation } from "react-i18next";
 import { useTheme, useThemedStyles, type ThemeColors } from "@/theme";
-import { iconSize, iconStroke, radius } from "@/theme/tokens";
+import { iconSize, iconStroke, radius, spacing } from "@/theme/tokens";
 import {
   shareSelectionStore,
   useIsMessageSelected,
 } from "@/session/shareSelectionStore";
 
+export function ShareCheckboxMark({ checked }: { checked: boolean }) {
+  const { colors } = useTheme();
+  const styles = useThemedStyles(makeStyles);
+
+  return (
+    <View style={[styles.mark, checked && styles.selected]}>
+      {checked ? (
+        <Check
+          color={colors.ctaText}
+          size={iconSize.sm}
+          strokeWidth={iconStroke.bold}
+        />
+      ) : null}
+    </View>
+  );
+}
+
 export function ShareMessageCheckbox({
+  children,
   clientId,
   disabled = false,
+  fill = false,
 }: {
+  children?: ReactNode;
   clientId: string;
   disabled?: boolean;
+  fill?: boolean;
 }) {
   const { t } = useTranslation();
-  const { colors } = useTheme();
   const styles = useThemedStyles(makeStyles);
   const selected = useIsMessageSelected(clientId);
 
@@ -27,18 +48,16 @@ export function ShareMessageCheckbox({
       accessibilityState={{ checked: selected, disabled }}
       disabled={disabled}
       onPress={() => shareSelectionStore.toggle(clientId)}
-      style={({ pressed }) => [styles.button, pressed && styles.pressed]}
+      style={({ pressed }) => [
+        fill ? styles.rowButton : styles.button,
+        pressed && styles.pressed,
+      ]}
       testID={`session.shareImage.checkbox.${clientId}`}
     >
-      <View style={[styles.mark, selected && styles.selected]}>
-        {selected ? (
-          <Check
-            color={colors.ctaText}
-            size={iconSize.sm}
-            strokeWidth={iconStroke.bold}
-          />
-        ) : null}
+      <View style={fill ? styles.rowMarkGutter : undefined}>
+        <ShareCheckboxMark checked={selected} />
       </View>
+      {children}
     </Pressable>
   );
 }
@@ -50,6 +69,18 @@ const makeStyles = (colors: ThemeColors) =>
       height: 44,
       justifyContent: "center",
       width: 44,
+    },
+    rowButton: {
+      alignItems: "flex-start",
+      flexDirection: "row",
+      gap: spacing.sm,
+      minWidth: 0,
+      width: "100%",
+    },
+    rowMarkGutter: {
+      alignItems: "center",
+      paddingTop: spacing.sm,
+      width: spacing.xl * 2,
     },
     mark: {
       alignItems: "center",

--- a/apps/mobile/src/session/ShareMessageCheckbox.tsx
+++ b/apps/mobile/src/session/ShareMessageCheckbox.tsx
@@ -1,6 +1,18 @@
-import { type ReactNode } from "react";
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+} from "react";
 import { Check } from "lucide-react-native";
-import { Pressable, StyleSheet, View } from "react-native";
+import {
+  Pressable,
+  StyleSheet,
+  View,
+  type GestureResponderEvent,
+} from "react-native";
 import { useTranslation } from "react-i18next";
 import { useTheme, useThemedStyles, type ThemeColors } from "@/theme";
 import { iconSize, iconStroke, radius, spacing } from "@/theme/tokens";
@@ -8,6 +20,31 @@ import {
   shareSelectionStore,
   useIsMessageSelected,
 } from "@/session/shareSelectionStore";
+import {
+  shareSelectionTapMoved,
+  shouldCommitShareSelectionTap,
+  type ShareSelectionTapPoint,
+} from "@/session/shareSelectionTap";
+
+interface ShareSelectionRowGesture {
+  consumed: boolean;
+  moved: boolean;
+  start: ShareSelectionTapPoint;
+  startedAt: number;
+}
+
+const ShareSelectionRowInteractionContext = createContext<(() => void) | null>(null);
+
+export function useCancelShareSelectionRowTap(): (() => void) | null {
+  return useContext(ShareSelectionRowInteractionContext);
+}
+
+function tapPoint(event: GestureResponderEvent): ShareSelectionTapPoint {
+  return {
+    pageX: event.nativeEvent.pageX,
+    pageY: event.nativeEvent.pageY,
+  };
+}
 
 export function ShareCheckboxMark({ checked }: { checked: boolean }) {
   const { colors } = useTheme();
@@ -40,6 +77,87 @@ export function ShareMessageCheckbox({
   const { t } = useTranslation();
   const styles = useThemedStyles(makeStyles);
   const selected = useIsMessageSelected(clientId);
+  const rowGestureRef = useRef<ShareSelectionRowGesture | null>(null);
+  const pendingCommitFrameRef = useRef<number | null>(null);
+  const toggle = () => shareSelectionStore.toggle(clientId);
+  const cancelRowTap = useCallback(() => {
+    if (rowGestureRef.current) rowGestureRef.current.consumed = true;
+  }, []);
+  useEffect(() => () => {
+    if (pendingCommitFrameRef.current !== null) {
+      cancelAnimationFrame(pendingCommitFrameRef.current);
+    }
+  }, []);
+
+  if (fill) {
+    return (
+      <View
+        onResponderGrant={(event) => {
+          rowGestureRef.current = {
+            consumed: false,
+            moved: false,
+            start: tapPoint(event),
+            startedAt: Date.now(),
+          };
+          // Keep native descendants (selectable text, scroll views) eligible
+          // to own their gestures while this row observes a plain short tap.
+          return false;
+        }}
+        onResponderMove={(event) => {
+          const gesture = rowGestureRef.current;
+          if (!gesture || gesture.moved) return;
+          if (shareSelectionTapMoved(gesture.start, tapPoint(event))) {
+            gesture.moved = true;
+          }
+        }}
+        onResponderRelease={(event) => {
+          const gesture = rowGestureRef.current;
+          if (
+            !disabled
+            && gesture
+            && shouldCommitShareSelectionTap({
+              durationMs: Date.now() - gesture.startedAt,
+              moved: gesture.moved || shareSelectionTapMoved(gesture.start, tapPoint(event)),
+            })
+          ) {
+            // UITextView child links emit their native onPress after responder release.
+            // Wait through the native event turn so that handler can consume this gesture.
+            pendingCommitFrameRef.current = requestAnimationFrame(() => {
+              pendingCommitFrameRef.current = null;
+              if (rowGestureRef.current === gesture) rowGestureRef.current = null;
+              if (!gesture.consumed) toggle();
+            });
+          } else {
+            rowGestureRef.current = null;
+          }
+        }}
+        onResponderTerminate={() => {
+          rowGestureRef.current = null;
+        }}
+        onResponderTerminationRequest={() => true}
+        onStartShouldSetResponder={() => !disabled}
+        style={styles.rowButton}
+        testID={`session.shareImage.row.${clientId}`}
+      >
+        <View style={styles.rowMarkGutter}>
+          <Pressable
+            accessibilityLabel={t("session.shareImage.checkboxLabel")}
+            accessibilityRole="checkbox"
+            accessibilityState={{ checked: selected, disabled }}
+            disabled={disabled}
+            onPress={toggle}
+            style={({ pressed }) => [styles.rowMarkButton, pressed && styles.pressed]}
+            testID={`session.shareImage.checkbox.${clientId}`}
+          >
+            <ShareCheckboxMark checked={selected} />
+          </Pressable>
+        </View>
+        <ShareSelectionRowInteractionContext.Provider value={cancelRowTap}>
+          {children}
+        </ShareSelectionRowInteractionContext.Provider>
+      </View>
+    );
+  }
 
   return (
     <Pressable
@@ -47,17 +165,11 @@ export function ShareMessageCheckbox({
       accessibilityRole="checkbox"
       accessibilityState={{ checked: selected, disabled }}
       disabled={disabled}
-      onPress={() => shareSelectionStore.toggle(clientId)}
-      style={({ pressed }) => [
-        fill ? styles.rowButton : styles.button,
-        pressed && styles.pressed,
-      ]}
+      onPress={toggle}
+      style={({ pressed }) => [styles.button, pressed && styles.pressed]}
       testID={`session.shareImage.checkbox.${clientId}`}
     >
-      <View style={fill ? styles.rowMarkGutter : undefined}>
-        <ShareCheckboxMark checked={selected} />
-      </View>
-      {children}
+      <ShareCheckboxMark checked={selected} />
     </Pressable>
   );
 }
@@ -79,8 +191,14 @@ const makeStyles = (colors: ThemeColors) =>
     },
     rowMarkGutter: {
       alignItems: "center",
-      paddingTop: spacing.sm,
       width: spacing.xl * 2,
+    },
+    rowMarkButton: {
+      alignItems: "center",
+      height: 44,
+      justifyContent: "flex-start",
+      paddingTop: spacing.sm,
+      width: 44,
     },
     mark: {
       alignItems: "center",

--- a/apps/mobile/src/session/ShareSelectAllButton.tsx
+++ b/apps/mobile/src/session/ShareSelectAllButton.tsx
@@ -1,0 +1,99 @@
+import { Pressable, StyleSheet, View } from "react-native";
+import { useRef } from "react";
+import { useTranslation } from "react-i18next";
+import { Text } from "@/components/AppText";
+import { ShareCheckboxMark } from "@/session/ShareMessageCheckbox";
+import { shareSelectionStore, useShareSelectionRevision } from "@/session/shareSelectionStore";
+import { useThemedStyles, type ThemeColors } from "@/theme";
+import { fontWeight, spacing, typeScale } from "@/theme/tokens";
+
+export function ShareSelectAllButton({
+  busy = false,
+  shareableIds,
+}: {
+  busy?: boolean;
+  shareableIds: readonly string[];
+}) {
+  const { t } = useTranslation();
+  const styles = useThemedStyles(makeStyles);
+  useShareSelectionRevision();
+  const selectedVisibleCount =
+    shareSelectionStore.getSelectedIdsInOrder(shareableIds).length;
+  const allSelected =
+    shareableIds.length > 0 &&
+    selectedVisibleCount === shareableIds.length &&
+    selectedVisibleCount === shareSelectionStore.count();
+  const selectionBeforeSelectAllRef = useRef<string[] | null>(null);
+
+  const toggleAll = () => {
+    const selectedCount =
+      shareSelectionStore.getSelectedIdsInOrder(shareableIds).length;
+    const currentlyAllSelected =
+      shareableIds.length > 0 &&
+      selectedCount === shareableIds.length &&
+      selectedCount === shareSelectionStore.count();
+    if (currentlyAllSelected) {
+      shareSelectionStore.setSelection(
+        shareableIds.filter((clientId) =>
+          selectionBeforeSelectAllRef.current?.includes(clientId),
+        ),
+      );
+      selectionBeforeSelectAllRef.current = null;
+      return;
+    }
+    selectionBeforeSelectAllRef.current = shareSelectionStore.getSelectedIds();
+    shareSelectionStore.setSelection(shareableIds);
+  };
+
+  const label = t(
+    allSelected ? "session.shareImage.clearAll" : "session.shareImage.selectAll",
+  );
+
+  return (
+    <Pressable
+      accessibilityLabel={label}
+      accessibilityRole="checkbox"
+      accessibilityState={{
+        checked: allSelected,
+        disabled: busy === true || shareableIds.length === 0,
+      }}
+      disabled={busy === true || shareableIds.length === 0}
+      onPress={toggleAll}
+      style={({ pressed }) => [
+        styles.selectAllButton,
+        (busy || shareableIds.length === 0) && styles.disabled,
+        pressed && styles.pressed,
+      ]}
+      testID="session.shareImage.selectAll"
+    >
+      <View style={styles.selectAllMarkGutter}>
+        <ShareCheckboxMark checked={allSelected} />
+      </View>
+      <Text ellipsizeMode="tail" numberOfLines={1} style={styles.selectAllLabel}>
+        {label}
+      </Text>
+    </Pressable>
+  );
+}
+
+const makeStyles = (colors: ThemeColors) =>
+  StyleSheet.create({
+    selectAllButton: {
+      alignItems: "center",
+      flexDirection: "row",
+      gap: spacing.sm,
+      height: 44,
+      paddingLeft: spacing.sm,
+    },
+    selectAllLabel: {
+      color: colors.textPrimary,
+      fontSize: typeScale.body,
+      fontWeight: fontWeight.medium,
+    },
+    selectAllMarkGutter: {
+      alignItems: "center",
+      width: spacing.xl * 2,
+    },
+    disabled: { opacity: 0.46 },
+    pressed: { opacity: 0.72 },
+  });

--- a/apps/mobile/src/session/ShareSelectionBar.tsx
+++ b/apps/mobile/src/session/ShareSelectionBar.tsx
@@ -1,9 +1,7 @@
-import { Check, Share as ShareIcon, X } from "lucide-react-native";
+import { Share as ShareIcon, X } from "lucide-react-native";
 import { Pressable, StyleSheet, View } from "react-native";
-import { useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { Text } from "@/components/AppText";
-import { shareSelectionStore } from "@/session/shareSelectionStore";
 import { useTheme, useThemedStyles, type ThemeColors } from "@/theme";
 import {
   fontWeight,
@@ -15,17 +13,16 @@ import {
   typeScale,
 } from "@/theme/tokens";
 
+/** 分享选择模式底部只保留关闭、已选数量和分享主按钮。 */
 export function ShareSelectionBar({
   busy,
   count,
-  shareableIds,
   screenshotTriggered = false,
   onCancel,
   onShare,
 }: {
   busy?: boolean;
   count: number;
-  shareableIds: readonly string[];
   screenshotTriggered?: boolean;
   onCancel(): void;
   onShare(): void;
@@ -33,33 +30,6 @@ export function ShareSelectionBar({
   const { t } = useTranslation();
   const { colors } = useTheme();
   const styles = useThemedStyles(makeStyles);
-  const selectedVisibleCount =
-    shareSelectionStore.getSelectedIdsInOrder(shareableIds).length;
-  const allSelected =
-    shareableIds.length > 0 &&
-    selectedVisibleCount === shareableIds.length &&
-    selectedVisibleCount === count;
-  const selectionBeforeSelectAllRef = useRef<string[] | null>(null);
-
-  const toggleAll = () => {
-    const selectedCount =
-      shareSelectionStore.getSelectedIdsInOrder(shareableIds).length;
-    const currentlyAllSelected =
-      shareableIds.length > 0 &&
-      selectedCount === shareableIds.length &&
-      selectedCount === shareSelectionStore.count();
-    if (currentlyAllSelected) {
-      shareSelectionStore.setSelection(
-        shareableIds.filter((clientId) =>
-          selectionBeforeSelectAllRef.current?.includes(clientId),
-        ),
-      );
-      selectionBeforeSelectAllRef.current = null;
-      return;
-    }
-    selectionBeforeSelectAllRef.current = shareSelectionStore.getSelectedIds();
-    shareSelectionStore.setSelection(shareableIds);
-  };
 
   const cancelButton = (
     <Pressable
@@ -77,58 +47,11 @@ export function ShareSelectionBar({
       />
     </Pressable>
   );
-  const selectAllButton = (
-    <Pressable
-      accessibilityLabel={
-        allSelected
-          ? t("session.shareImage.clearAll")
-          : t("session.shareImage.selectAll")
-      }
-      accessibilityRole="checkbox"
-      accessibilityState={{
-        checked: allSelected,
-        disabled: busy === true || shareableIds.length === 0,
-      }}
-      disabled={busy === true || shareableIds.length === 0}
-      onPress={toggleAll}
-      style={({ pressed }) => [
-        styles.selectAllButton,
-        (busy || shareableIds.length === 0) && styles.disabled,
-        pressed && styles.pressed,
-      ]}
-      testID="session.shareImage.selectAll"
-    >
-      <View
-        style={[
-          styles.selectAllMark,
-          allSelected && styles.selectAllMarkSelected,
-        ]}
-      >
-        {allSelected ? (
-          <Check
-            color={colors.ctaText}
-            size={iconSize.xs}
-            strokeWidth={iconStroke.bold}
-          />
-        ) : null}
-      </View>
-      <Text style={styles.selectAllLabel}>
-        {t(
-          allSelected
-            ? "session.shareImage.clearAll"
-            : "session.shareImage.selectAll",
-        )}
-      </Text>
-    </Pressable>
-  );
-  const copy = (
+  const countLabel = (
     <View
-      style={[styles.copy, screenshotTriggered && styles.screenshotSafeCopy]}
+      style={[styles.count, screenshotTriggered && styles.screenshotSafeCount]}
     >
-      <Text style={styles.title}>
-        {t("session.shareImage.title")}
-      </Text>
-      <Text style={styles.subtitle}>
+      <Text ellipsizeMode="tail" numberOfLines={1} style={styles.countText}>
         {t("session.shareImage.selectedCount", { count })}
       </Text>
     </View>
@@ -152,7 +75,7 @@ export function ShareSelectionBar({
         size={iconSize.sm}
         strokeWidth={iconStroke.regular}
       />
-      <Text style={styles.shareLabel}>
+      <Text ellipsizeMode="tail" numberOfLines={1} style={styles.shareLabel}>
         {busy
           ? t("session.shareImage.generating")
           : t("session.shareImage.share")}
@@ -163,8 +86,7 @@ export function ShareSelectionBar({
   return (
     <View style={styles.container} testID="session.shareImage.bar">
       {cancelButton}
-      {selectAllButton}
-      {copy}
+      {countLabel}
       {shareButton}
     </View>
   );
@@ -185,66 +107,33 @@ const makeStyles = (colors: ThemeColors) =>
     },
     iconButton: {
       alignItems: "center",
-      height: 36,
-      justifyContent: "center",
-      width: 36,
-    },
-    selectAllButton: {
-      alignItems: "center",
-      backgroundColor: colors.surfaceChip,
-      borderColor: colors.border,
-      borderRadius: radius.pill,
-      borderWidth: StyleSheet.hairlineWidth,
-      flexDirection: "row",
-      gap: spacing.xs,
       height: 44,
-      paddingHorizontal: spacing.sm,
-    },
-    selectAllLabel: {
-      color: colors.textPrimary,
-      fontSize: typeScale.caption,
-      fontWeight: fontWeight.medium,
-    },
-    selectAllMark: {
-      alignItems: "center",
-      borderColor: colors.textTertiary,
-      borderRadius: radius.pill,
-      borderWidth: StyleSheet.hairlineWidth,
-      height: 16,
       justifyContent: "center",
-      width: 16,
+      width: 44,
     },
-    selectAllMarkSelected: {
-      backgroundColor: colors.cta,
-      borderColor: colors.cta,
-    },
-    copy: { flex: 1, gap: 2, minWidth: 0 },
-    title: {
+    count: { flex: 1, minWidth: 0 },
+    countText: {
       color: colors.textPrimary,
       fontSize: typeScale.body,
       fontWeight: fontWeight.medium,
       lineHeight: lineHeight.body,
     },
-    screenshotSafeCopy: {
+    screenshotSafeCount: {
       paddingLeft: spacing.xl,
-    },
-    subtitle: {
-      color: colors.textTertiary,
-      fontSize: typeScale.caption,
-      lineHeight: lineHeight.caption,
     },
     shareButton: {
       alignItems: "center",
       backgroundColor: colors.cta,
       borderRadius: radius.pill,
       flexDirection: "row",
-      gap: spacing.xs,
+      gap: spacing.sm,
       minHeight: 44,
-      paddingHorizontal: spacing.md,
+      minWidth: 112,
+      paddingHorizontal: spacing.lg,
     },
     shareLabel: {
       color: colors.ctaText,
-      fontSize: typeScale.caption,
+      fontSize: typeScale.body,
       fontWeight: fontWeight.medium,
     },
     disabled: { opacity: 0.46 },

--- a/apps/mobile/src/session/shareSelectionTap.ts
+++ b/apps/mobile/src/session/shareSelectionTap.ts
@@ -1,0 +1,26 @@
+/** Small drag slop: enough for finger jitter, below an intentional scroll gesture. */
+export const SHARE_SELECTION_TAP_MAX_DISTANCE = 8;
+/** Finish before React Native's default 500 ms long-press boundary. */
+export const SHARE_SELECTION_TAP_MAX_DURATION_MS = 450;
+
+export interface ShareSelectionTapPoint {
+  pageX: number;
+  pageY: number;
+}
+
+export function shareSelectionTapMoved(
+  start: ShareSelectionTapPoint,
+  current: ShareSelectionTapPoint,
+): boolean {
+  return Math.hypot(current.pageX - start.pageX, current.pageY - start.pageY)
+    > SHARE_SELECTION_TAP_MAX_DISTANCE;
+}
+
+export function shouldCommitShareSelectionTap(input: {
+  durationMs: number;
+  moved: boolean;
+}): boolean {
+  return !input.moved
+    && input.durationMs >= 0
+    && input.durationMs <= SHARE_SELECTION_TAP_MAX_DURATION_MS;
+}


### PR DESCRIPTION
## 这次改了什么

### 摘要

优化 Mobile 任务内消息分享选择体验：整条消息都可点击选择，头部全选与消息 check 统一并对齐，长消息滚动时保留可操作的吸顶 check，同时收敛底部操作条并放大分享主按钮。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Mobile 消息分享选择交互细节
- 本 PR 包含：整行选择、头部全选、长消息吸顶 check、底部分享条布局与对应回归测试
- 明确不包含：Desktop、原生配置、Metro / Simulator 配置、分享导出格式、插件系统
- 用户可见变化：分享选择模式下点击消息任意位置即可切换选择；全选 check 与消息 check 对齐；超长消息滚动后仍可在头部下方切换选择；分享按钮更宽、字号更清晰
- 是否存在 breaking change：无

### UI 变化

- 截图 / 录屏：本轮由用户在本地 Xcode Simulator 验收，PR 未附媒体
- 引用的设计规范：
  - `docs/design-rules/DESIGN.md` §4 Buttons：分享主操作沿用 CTA pill、语义 CTA 前景/背景 token
  - `docs/design-rules/DESIGN.md` §5 Layout Principles：沿用 8px 间距体系、低密度单行操作条、可穿 pill 的按钮保持 pill
  - `docs/design-rules/DESIGN.md` §10 Light / Dark Dual-Mode Delivery Gate：颜色全部来自现有语义 theme token，覆盖默认、按下、选中、禁用状态；未声称完成双模式实机目检
  - 移动端触达目标保持 44px，头部、行内、吸顶 check 复用同一个视觉 mark

## 怎么验证的

### 自动验证

```text
env -u XDT_ISOLATED TMPDIR=/private/tmp NODE_OPTIONS='--localstorage-file=/tmp/cindy-gentle-cohen-test-localstorage' pnpm test:unit
结果：通过（Desktop、Mobile 与全部要求的 workspace unit tests）

pnpm --filter mobile run --if-present typecheck
结果：通过

pnpm check:dco -- origin/main..HEAD
结果：通过，1 个 commit 已签名

git diff --check HEAD
结果：通过
```

### 手工验证

- 由用户在本地 Xcode Simulator / 对应 Dev Client 与 Metro 环境完成视觉和交互验收；Agent 本轮未接管模拟器。

### 未执行的验证

- 未由 Agent 目检 Light / Dark 两种模式；实现只使用语义 token，不将其表述为已完成双模式视觉验证。
- 未附截图或录屏，避免更改用户正在使用的 Metro / Simulator 测试环境。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：长消息吸顶 check 依赖列表可见性回调与节流后的 `measureInWindow`

### 影响与回滚

- 影响范围：仅 Mobile 任务内的分享选择模式；非分享状态消息交互路径不变
- 原生层 / fingerprint / OTA：不涉及，没有原生配置或依赖变更
- 回滚 / 降级方式：回退本 PR 的单个 commit 即可恢复原交互

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要测试；无需额外产品文档
- [x] 已确认测试结果或说明未执行原因
