### PR TITLE
fix(desktop): 禁用 Cindy 内的 Codex 插件

### DIFF
--- a/apps/desktop/src/main/maker-host/auth-adapters.ts
+++ b/apps/desktop/src/main/maker-host/auth-adapters.ts
@@ -33,8 +33,6 @@ import { getCachedBinaryStatus, isVettedAgentBinaryPath } from '../agent-binarie
 import { createLogger } from '../logger.js';
 import { prepareCodexGlobalSkillsLinks } from './codex-global-skills.js';
 import { prepareCodexGlobalRulesCopy } from './codex-global-rules.js';
-import { prepareCodexGlobalPluginsBridge } from './codex-global-plugins.js';
-import { DESKTOP_CAPABILITY_ROUTING_POLICY } from './capability-routing.js';
 import { prepareSharedGlobalSkillLinks } from './shared-global-skills.js';
 import { relinkSharedCodexAuth } from './codex-auth-link.js';
 import { claudeOAuthSpawnEnv } from './claude-oauth-spawn-env.js';
@@ -1105,7 +1103,7 @@ export class DesktopCodexAuthAdapter implements AuthAdapter {
       (err: Error) => ({ ok: false as const, label: 'shared-skills' as const, err }),
     );
 
-    const [skillsOutcome, rulesOutcome, pluginsOutcome] = await Promise.all([
+    const [skillsOutcome, rulesOutcome] = await Promise.all([
       prepareCodexGlobalSkillsLinks(this.codexHome).then(
         (r) => ({ ok: true as const, label: 'skills' as const, warnings: r.warnings }),
         (err: Error) => ({ ok: false as const, label: 'skills' as const, err }),
@@ -1114,20 +1112,9 @@ export class DesktopCodexAuthAdapter implements AuthAdapter {
         (r) => ({ ok: true as const, label: 'rules' as const, warnings: r.warnings }),
         (err: Error) => ({ ok: false as const, label: 'rules' as const, err }),
       ),
-      prepareCodexGlobalPluginsBridge(this.codexHome, {
-        capabilityRouting: DESKTOP_CAPABILITY_ROUTING_POLICY,
-      }).then(
-        (r) => ({
-          ok: true as const,
-          label: 'plugins' as const,
-          warnings: r.warnings,
-          routingFailures: r.routingFailures,
-        }),
-        (err: Error) => ({ ok: false as const, label: 'plugins' as const, err }),
-      ),
     ]);
 
-    for (const outcome of [sharedOutcome, skillsOutcome, rulesOutcome, pluginsOutcome]) {
+    for (const outcome of [sharedOutcome, skillsOutcome, rulesOutcome]) {
       if (!outcome.ok) {
         assetPrepLog.warn('prepare Codex global asset failed', {
           asset: outcome.label,
@@ -1138,23 +1125,6 @@ export class DesktopCodexAuthAdapter implements AuthAdapter {
       for (const warning of outcome.warnings) {
         assetPrepLog.warn('Codex global asset warning', { asset: outcome.label, warning });
       }
-    }
-    if (!pluginsOutcome.ok) {
-      // Expected cache/config I/O failures are normalized by the bridge and
-      // gated against the isolated plugin enablement. A rejection here is an
-      // unexpected invariant failure, so it must remain fail-closed.
-      throw new Error(
-        `Cannot start Codex safely because Cindy could not inspect downstream plugin capabilities: ${pluginsOutcome.err.message}`,
-      );
-    }
-    if (pluginsOutcome.ok && pluginsOutcome.routingFailures.length > 0) {
-      for (const failure of pluginsOutcome.routingFailures) {
-        // failure 串可能带下游插件能力 / marketplace 身份,同资产准备告警一并不上报。
-        assetPrepLog.error('Codex capability routing enforcement failed', { failure });
-      }
-      throw new Error(
-        `Cannot start Codex safely because Cindy could not isolate a downstream plugin capability: ${pluginsOutcome.routingFailures.join('; ')}`,
-      );
     }
   }
 

--- a/apps/desktop/src/main/maker-host/auth-adapters.ts
+++ b/apps/desktop/src/main/maker-host/auth-adapters.ts
@@ -33,6 +33,8 @@ import { getCachedBinaryStatus, isVettedAgentBinaryPath } from '../agent-binarie
 import { createLogger } from '../logger.js';
 import { prepareCodexGlobalSkillsLinks } from './codex-global-skills.js';
 import { prepareCodexGlobalRulesCopy } from './codex-global-rules.js';
+import { prepareCodexGlobalPluginsBridge } from './codex-global-plugins.js';
+import { DESKTOP_CAPABILITY_ROUTING_POLICY } from './capability-routing.js';
 import { prepareSharedGlobalSkillLinks } from './shared-global-skills.js';
 import { relinkSharedCodexAuth } from './codex-auth-link.js';
 import { claudeOAuthSpawnEnv } from './claude-oauth-spawn-env.js';
@@ -1103,7 +1105,7 @@ export class DesktopCodexAuthAdapter implements AuthAdapter {
       (err: Error) => ({ ok: false as const, label: 'shared-skills' as const, err }),
     );
 
-    const [skillsOutcome, rulesOutcome] = await Promise.all([
+    const [skillsOutcome, rulesOutcome, pluginsOutcome] = await Promise.all([
       prepareCodexGlobalSkillsLinks(this.codexHome).then(
         (r) => ({ ok: true as const, label: 'skills' as const, warnings: r.warnings }),
         (err: Error) => ({ ok: false as const, label: 'skills' as const, err }),
@@ -1112,9 +1114,20 @@ export class DesktopCodexAuthAdapter implements AuthAdapter {
         (r) => ({ ok: true as const, label: 'rules' as const, warnings: r.warnings }),
         (err: Error) => ({ ok: false as const, label: 'rules' as const, err }),
       ),
+      prepareCodexGlobalPluginsBridge(this.codexHome, {
+        capabilityRouting: DESKTOP_CAPABILITY_ROUTING_POLICY,
+      }).then(
+        (r) => ({
+          ok: true as const,
+          label: 'plugins' as const,
+          warnings: r.warnings,
+          routingFailures: r.routingFailures,
+        }),
+        (err: Error) => ({ ok: false as const, label: 'plugins' as const, err }),
+      ),
     ]);
 
-    for (const outcome of [sharedOutcome, skillsOutcome, rulesOutcome]) {
+    for (const outcome of [sharedOutcome, skillsOutcome, rulesOutcome, pluginsOutcome]) {
       if (!outcome.ok) {
         assetPrepLog.warn('prepare Codex global asset failed', {
           asset: outcome.label,
@@ -1125,6 +1138,23 @@ export class DesktopCodexAuthAdapter implements AuthAdapter {
       for (const warning of outcome.warnings) {
         assetPrepLog.warn('Codex global asset warning', { asset: outcome.label, warning });
       }
+    }
+    if (!pluginsOutcome.ok) {
+      // Expected cache/config I/O failures are normalized by the bridge and
+      // gated against the isolated plugin enablement. A rejection here is an
+      // unexpected invariant failure, so it must remain fail-closed.
+      throw new Error(
+        `Cannot start Codex safely because Cindy could not inspect downstream plugin capabilities: ${pluginsOutcome.err.message}`,
+      );
+    }
+    if (pluginsOutcome.ok && pluginsOutcome.routingFailures.length > 0) {
+      for (const failure of pluginsOutcome.routingFailures) {
+        // failure 串可能带下游插件能力 / marketplace 身份,同资产准备告警一并不上报。
+        assetPrepLog.error('Codex capability routing enforcement failed', { failure });
+      }
+      throw new Error(
+        `Cannot start Codex safely because Cindy could not isolate a downstream plugin capability: ${pluginsOutcome.routingFailures.join('; ')}`,
+      );
     }
   }
 

--- a/apps/desktop/src/main/maker-host/index.ts
+++ b/apps/desktop/src/main/maker-host/index.ts
@@ -76,7 +76,7 @@ import { createToolResultImageDescriptor } from '../vision-bridge/tool-result-im
 import * as blobStore from '../cindy-media/blobStore.js';
 import { buildPiVisionBridgeEnv } from '../vision-bridge/pi-vision-bridge-env.js';
 import { resolveVisionBackendRoute, setVisionGatewayKeyReader } from './provider-route.js';
-import { createLogger, resolveSessionCcDebugFile } from '../logger.js';
+import { resolveSessionCcDebugFile } from '../logger.js';
 import { resetProviderModelAutoRefreshCooldowns } from './provider-model-auto-refresh.js';
 import { getThinkingEnabledFromMemory } from './newMakerDefaultsCache.js';
 import { createSshDaemonTransport } from './codex-remote-transport.js';
@@ -260,8 +260,6 @@ import {
   resolveCodexBrowserCompanionSpawnConfig,
 } from './codex-browser-companion.js';
 export { withRehydrateCloseSuppressed };
-
-const runtimeLog = createLogger('maker-runtime');
 
 type RemoteCcQuery = Awaited<
   ReturnType<NonNullable<ConstructorParameters<typeof ClaudeCodeAgent>[0]['remoteCcQueryFactory']>>
@@ -1230,6 +1228,7 @@ export function getMaker(): Maker {
       runtimeConfig: desktopCodexRuntimeConfig,
       binaryPath: codexPath,
       logger: desktopMakerLogger,
+      disableCodexPluginRuntime: true,
       registerLocalCodexAppServerProcess: ({ pid, role }) => registerCodexProcessRole(pid, role),
       // Codex 也接 Cindy MCP providers (跟 claude 共享同一份 provider instances);
       // codex 子进程没法消费 in-process JS instance, prepareCodexExtraSpawnConfig
@@ -1520,19 +1519,11 @@ export function getMaker(): Maker {
           }
         }
         const openAiWebSocketsEnabled = !subagentRoute;
-        runtimeLog.info('Codex plugin runtime disabled for local app-server', {
-          plugins: false,
-          remotePlugin: false,
-        });
         return {
           // 子代理护栏/默认模型每次 createHost 现读 store:DeferredCodexRestart 兑现
           // (dispose host)后的新 spawn 自动带新值。agents.* 对 control-plane 的
           // model/list 无影响,不加 hostPurpose 分支。
           extraArgs: [
-            '--disable',
-            'plugins',
-            '--disable',
-            'remote_plugin',
             ...mcpExtraArgs,
             ...(!isReview && !ctx.remoteHostId
               ? buildCodexSubagentSpawnArgs(subagentModelSettings, subagentRoute, {

--- a/apps/desktop/src/main/maker-host/index.ts
+++ b/apps/desktop/src/main/maker-host/index.ts
@@ -76,7 +76,7 @@ import { createToolResultImageDescriptor } from '../vision-bridge/tool-result-im
 import * as blobStore from '../cindy-media/blobStore.js';
 import { buildPiVisionBridgeEnv } from '../vision-bridge/pi-vision-bridge-env.js';
 import { resolveVisionBackendRoute, setVisionGatewayKeyReader } from './provider-route.js';
-import { resolveSessionCcDebugFile } from '../logger.js';
+import { createLogger, resolveSessionCcDebugFile } from '../logger.js';
 import { resetProviderModelAutoRefreshCooldowns } from './provider-model-auto-refresh.js';
 import { getThinkingEnabledFromMemory } from './newMakerDefaultsCache.js';
 import { createSshDaemonTransport } from './codex-remote-transport.js';
@@ -260,6 +260,8 @@ import {
   resolveCodexBrowserCompanionSpawnConfig,
 } from './codex-browser-companion.js';
 export { withRehydrateCloseSuppressed };
+
+const runtimeLog = createLogger('maker-runtime');
 
 type RemoteCcQuery = Awaited<
   ReturnType<NonNullable<ConstructorParameters<typeof ClaudeCodeAgent>[0]['remoteCcQueryFactory']>>
@@ -1518,11 +1520,19 @@ export function getMaker(): Maker {
           }
         }
         const openAiWebSocketsEnabled = !subagentRoute;
+        runtimeLog.info('Codex plugin runtime disabled for local app-server', {
+          plugins: false,
+          remotePlugin: false,
+        });
         return {
           // 子代理护栏/默认模型每次 createHost 现读 store:DeferredCodexRestart 兑现
           // (dispose host)后的新 spawn 自动带新值。agents.* 对 control-plane 的
           // model/list 无影响,不加 hostPurpose 分支。
           extraArgs: [
+            '--disable',
+            'plugins',
+            '--disable',
+            'remote_plugin',
             ...mcpExtraArgs,
             ...(!isReview && !ctx.remoteHostId
               ? buildCodexSubagentSpawnArgs(subagentModelSettings, subagentRoute, {

--- a/packages/maker-core/src/agents/base-agent.ts
+++ b/packages/maker-core/src/agents/base-agent.ts
@@ -730,6 +730,13 @@ export interface AgentDeps {
   ) => Promise<CodexExtraSpawnConfig>;
 
   /**
+   * Codex-only host policy: disable local app-server plugin runtimes even when
+   * dynamic spawn configuration degrades after a non-fatal preparation error.
+   * Remote transports own their runtime and ignore this local policy.
+   */
+  disableCodexPluginRuntime?: boolean;
+
+  /**
    * Codex 专用：登记本机 stdio app-server 的 PID 与职责。
    * 返回 disposer 时会跟随 transport close 调用；远端 SSH transport 不触发。
    */

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -244,13 +244,17 @@ const { MockCodexTransport, createdTransports, createdStdioOptions } = vi.hoiste
 
   const createdTransports: MockCodexTransport[] = [];
   const createdStdioOptions: Array<{
+    extraArgs?: string[];
     onProcessSpawned?: (pid: number) => void | (() => void);
   }> = [];
   return { MockCodexTransport, createdTransports, createdStdioOptions };
 });
 
 vi.mock('./app-server/stdioTransport.js', () => ({
-  createStdioTransport: (opts: { onProcessSpawned?: (pid: number) => void | (() => void) }) => {
+  createStdioTransport: (opts: {
+    extraArgs?: string[];
+    onProcessSpawned?: (pid: number) => void | (() => void);
+  }) => {
     createdStdioOptions.push(opts);
     opts.onProcessSpawned?.(7_000 + createdStdioOptions.length);
     const transport = new MockCodexTransport();
@@ -336,6 +340,33 @@ function createDeps(
     ...overrides,
   };
 }
+
+describe('CodexAgent spawn configuration', () => {
+  it('keeps host-enforced plugin disabling when dynamic spawn preparation fails', async () => {
+    const prepareCodexExtraSpawnConfig = vi.fn(async () => {
+      throw new Error('bridge unavailable');
+    });
+    const agent = new CodexAgent(createDeps({}, {
+      disableCodexPluginRuntime: true,
+      prepareCodexExtraSpawnConfig,
+    }));
+
+    const handle = await agent.startSession({
+      sessionId: 'session-plugin-runtime-fallback',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+    });
+
+    expect(createdStdioOptions[0]?.extraArgs).toEqual([
+      '--disable',
+      'plugins',
+      '--disable',
+      'remote_plugin',
+    ]);
+    await handle.close();
+    await agent.dispose();
+  });
+});
 
 function deferred<T>() {
   let resolve!: (value: T | PromiseLike<T>) => void;

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -2493,9 +2493,12 @@ export class CodexAgent extends BaseAgent {
 
     // 超集升格硬依赖 proxy。proxy 不可用时降级回原 gateway-key spawn 重来一轮;
     // 降级后 upgraded=false,循环至多跑两轮必收敛。
+    const baseExtraArgs = !remoteHostId && this.deps.disableCodexPluginRuntime
+      ? ['--disable', 'plugins', '--disable', 'remote_plugin']
+      : [];
     let effectiveMode: AgentCredentialMode | undefined;
     let env: Record<string, string> = {};
-    let extraArgs: string[] = [];
+    let extraArgs = [...baseExtraArgs];
     let codexProxyActive = false;
     let codexBrowserUseAvailable = false;
     let codexBrowserUseVersion: string | undefined;
@@ -2522,7 +2525,7 @@ export class CodexAgent extends BaseAgent {
       env = await buildCodexEnv(this.deps.auth, this.deps.runtimeConfig, authOptions);
       assertCurrentGeneration('env');
 
-      extraArgs = [];
+      extraArgs = [...baseExtraArgs];
       codexProxyActive = false;
       codexBrowserUseAvailable = false;
       codexBrowserUseVersion = undefined;
@@ -2557,7 +2560,7 @@ export class CodexAgent extends BaseAgent {
             continue;
           }
           Object.assign(env, cfg.extraEnv);
-          extraArgs = cfg.extraArgs;
+          extraArgs = [...baseExtraArgs, ...cfg.extraArgs];
           buildSessionMcpConfig = cfg.buildSessionMcpConfig;
           subagentModelFallback = cfg.subagentModelFallback;
           subagentRoute = cfg.subagentRoute;
@@ -2606,6 +2609,12 @@ export class CodexAgent extends BaseAgent {
         continue;
       }
       break;
+    }
+    if (baseExtraArgs.length > 0) {
+      this.deps.logger.info('Codex plugin runtime disabled for local app-server', {
+        plugins: false,
+        remotePlugin: false,
+      });
     }
     assertCurrentGeneration('transport');
 


### PR DESCRIPTION
## 这次改了什么

### 摘要

Cindy 在本地 Codex app-server 启动时显式关闭 `plugins` 与 `remote_plugin`，不再向用户暴露“看起来可调用、实际运行失败”的 Codex 插件能力。该禁用是 host 级启动不变量，动态 MCP / proxy 配置降级时仍会保留。现有资产准备流程保留，用于维持 Browser companion 所需的受控投影。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：当前 Codex 插件兼容桥收口需求
- 本 PR 包含：Desktop 启用内部 Codex 插件禁用 policy；maker-core 在正常及 non-fatal spawn-config fallback 路径均注入 `--disable plugins --disable remote_plugin`；增加一条持久化状态日志和一个 fallback 回归测试。
- 明确不包含：不修改或停止现有 Codex 资产准备桥；不清理或迁移现有插件缓存；不修改 Cindy `.cindy` 插件、Cindy MCP、Browser companion、模型路由、认证、UI 或远程 Codex runtime。
- 用户可见变化：Cindy 的本地 Codex 会话不再加载系统 Codex 插件；原生 Codex App / CLI 不受影响。
- 是否存在 breaking change：无受支持契约的 breaking change；仅收回 Cindy 中未能可靠运行的 Codex 外部插件暴露。

### UI 变化

不涉及。

- 引用的设计规范：不涉及。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --dir apps/desktop exec vitest run src/main/maker-host/__tests__/codex-browser-companion.test.ts src/main/maker-host/__tests__/authAdaptersImportPurity.test.ts --pool=threads --maxWorkers=1
结果：18 passed

pnpm --dir packages/maker-core exec vitest run src/agents/codex/index.test.ts -t "keeps host-enforced plugin disabling when dynamic spawn preparation fails"
结果：1 passed

git diff --cached --check
结果：通过

pnpm test:unit:related
结果：3502 passed / 1 skipped / 22 failed；失败均为 5 秒超时，集中在未修改的 file-browser watcher、Claude OAuth 与 SkillHub 用例。单 worker 仅复跑这 3 个文件后仍为相同 22 个超时，没有 Codex 插件相关断言失败。

pnpm check:dco
结果：当前 commit 含有效 Signed-off-by；脚本因 main 基线中 18 个历史 commit 的作者与签名不匹配而失败。

pnpm --filter @cindy/maker-core build
结果：未通过；报错均为仓库当前既有测试类型错误，没有命中本 PR 新增接口或实现。Desktop typecheck 通过。
```

### 手工验证

- 平台：macOS，本 PR clean worktree，分支基线 `74812cc76777a3eb4cdb6127a2992566efefb14a`。
- 完整 Desktop build 成功，开发实例 readiness verdict 为 `ready`。
- 实际 Codex 子进程 argv 包含 `app-server --disable plugins --disable remote_plugin`。
- 持久化日志包含 `Codex plugin runtime disabled for local app-server { plugins: false, remotePlugin: false }`。
- 后续 Codex MCP bridge 正常就绪（17 providers），共享 app-server 正常启动，模型请求返回 HTTP 200。
- review 修复后的最终 head 将插件禁用提升为 maker-core 的 host policy，并由定向测试覆盖 non-fatal fallback；实际 argv 与上述实测参数保持一致。按限制未自行重启实例。

### 未执行的验证

- 未在 Windows / Linux 实机验证；本次改动仅注入 Codex app-server argv，macOS 实际子进程已验证参数被接受并成功初始化。
- 未新增专用单测；本行为以 pinned Codex 二进制的实际进程参数、持久化日志和 app-server readiness 作为主要验收证据。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：Cindy 内 Codex 外部插件可见性变化

### 影响与回滚

- 影响范围：仅 Cindy 本机启动的 Codex app-server；远程 Codex、原生 Codex App / CLI、Cindy `.cindy` 插件与 MCP 不受影响。Cindy `.cindy` 存量插件影响：无。
- 回滚 / 降级方式：移除两个 `--disable` 参数及对应状态日志即可；资产准备桥无需变更。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次不涉及需同步更新的用户文档）
- [x] 已确认测试结果或说明未执行原因
