### PR TITLE
feat(computer-use): expose max_elements and max_depth in get_window_state schema

### DIFF
--- a/packages/lizi-mcps/src/computer/tools.ts
+++ b/packages/lizi-mcps/src/computer/tools.ts
@@ -88,6 +88,8 @@ export const COMPUTER_TOOLS: readonly ComputerToolDef[] = [
       query: z.string().optional(),
       screenshot_out_file: z.string().optional(),
       session: z.string().optional(),
+      max_elements: z.number().int().positive().optional().describe("Maximum number of accessibility tree elements to return. Use to limit context size for complex windows like Chrome."),
+      max_depth: z.number().int().positive().optional().describe("Maximum depth of the accessibility tree to traverse. Use to limit tree depth for complex windows."),
     },
   },
   {


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 #3148：Computer Use 的 get_window_state 工具没有暴露 max_elements 和 max_depth 参数，导致复杂窗口（如 Chrome）的无障碍树过大，超出模型上下文限制。

### 变更类型

- [x] feat 新功能

### 范围

- 关联 Issue / 需求：#3148
- 本 PR 包含：在 get_window_state schema 中添加 max_elements 和 max_depth 可选参数
- 明确不包含：cua-driver 本体变更
- 用户可见变化：Agent 可以通过 max_elements/max_depth 限制无障碍树大小
- 是否存在 breaking change：无

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter lizi-mcps typecheck → 通过
pnpm --filter lizi-mcps test → 通过
```

### 手工验证

不涉及。

### 未执行的验证

无。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围：Computer Use MCP 工具 schema
- 回滚 / 降级方式：revert

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已确认测试结果或说明未执行原因

Fixes #3148