### PR TITLE
fix(pi): 修复 subagent bash 因父 bridge 删除 env 而 fail-closed (#3132)

### DIFF
--- a/packages/maker-core/src/agents/pi/__tests__/cindyBridgeSource.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/cindyBridgeSource.test.ts
@@ -1085,7 +1085,7 @@ describe('cindy-bridge extension source', () => {
     helper.env.PI_CODING_AGENT_DIR = '/host/agent-home/run-tmp/abc';
     expect(helper.resolveBashPackageHome()).toBe(injected);
 
-    // stash 属性被替换成 plain 赋值(可写可配置)→ 不被信任 → fail-closed。
+    // stash 属性被替换成 plain 赋值(可写可配置)→ 不被信任 → 走首次加载路径。
     // (defineProperty 定义 non-configurable 属性后无法 redefine,这里用一个
     // fresh context 模拟「攻击者抢跑预置了 plain stash」的形态。)
     const hostile = loadBashPackageHomeHelper();
@@ -1096,11 +1096,11 @@ describe('cindy-bridge extension source', () => {
       configurable: true,
       enumerable: false,
     });
-    // 攻击者形态 stash 不被信任 → 走首次加载路径;env 未注入 → fail-closed。
-    expect(hostile.resolveBashPackageHome()).toBeUndefined();
+    // 攻击者形态 stash 不被信任 → 走首次加载路径;env 未注入 → 从 PI_CODING_AGENT_DIR 派生。
+    // PI_CODING_AGENT_DIR 本就常驻可写,控制它与控制注入 env 同级,不新增威胁面。
+    expect(hostile.resolveBashPackageHome()).toBe('/attacker/agent-home/bash-package-home');
 
-    // 非 Cindy 初始化的进程(env 从未注入、无 stash)保持 fail-closed 语义:
-    // 返回 undefined,下游 isolatedBashEnvironment 照旧 throw。
+    // 非 Cindy 初始化的进程(env 从未注入、无 stash、PI_CODING_AGENT_DIR 未设置)保持 fail-closed。
     const fresh = loadBashPackageHomeHelper();
     expect(fresh.resolveBashPackageHome()).toBeUndefined();
 
@@ -1125,6 +1125,24 @@ describe('cindy-bridge extension source', () => {
       source.indexOf('// 凭证/密钥路径特征由 maker-core 的单一来源生成'),
     );
     expect(helperSlice).not.toContain('CINDY_PI_PACKAGE_MANAGEMENT');
+  });
+
+  it('falls back to PI_CODING_AGENT_DIR derivation when neither env nor stash is available (subagent subprocess, #3132)', () => {
+    // subagent 子进程：父 bridge 已消费并删除 CINDY_PI_BASH_PACKAGE_HOME，子进程无 stash。
+    // PI_CODING_AGENT_DIR 存在且为绝对路径时从中派生；否则 fail-closed。
+    const sub = loadBashPackageHomeHelper();
+    sub.env.PI_CODING_AGENT_DIR = '/host/agent-home/run-tmp/abc';
+    expect(sub.resolveBashPackageHome()).toBe('/host/agent-home/run-tmp/abc/bash-package-home');
+    expect(sub.env.CINDY_PI_BASH_PACKAGE_HOME).toBeUndefined();
+
+    // 相对路径 fail-closed。
+    const rel = loadBashPackageHomeHelper();
+    rel.env.PI_CODING_AGENT_DIR = 'relative/path';
+    expect(rel.resolveBashPackageHome()).toBeUndefined();
+
+    // PI_CODING_AGENT_DIR 缺失 fail-closed。
+    const noDir = loadBashPackageHomeHelper();
+    expect(noDir.resolveBashPackageHome()).toBeUndefined();
   });
 
   it('blocks Pi package mutations before bash while preserving ordinary commands', () => {

--- a/packages/maker-core/src/agents/pi/__tests__/cindySubagentSource.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/cindySubagentSource.test.ts
@@ -293,4 +293,25 @@ describe('cindy-subagent extension source', () => {
     expect(CINDY_SUBAGENT_EXTENSION_SOURCE).not.toContain("process.on('SIGTERM'");
     expect(CINDY_SUBAGENT_EXTENSION_SOURCE).not.toContain("process.on('SIGINT'");
   });
+
+  it('writes CINDY_PI_BASH_PACKAGE_HOME into childEnv before spawn when configHome is absolute (#3132)', () => {
+    // 父 bridge 在初始化时消费并删除 CINDY_PI_BASH_PACKAGE_HOME；子进程继承的 env 里没有它，
+    // 导致子 bridge 无法解析 bash 隔离 home 而 fail-closed。runTask 在 spawn 前写回派生值。
+    const src = CINDY_SUBAGENT_EXTENSION_SOURCE;
+    expect(src).toContain("const BASH_PACKAGE_HOME_ENV = 'CINDY_PI_BASH_PACKAGE_HOME';");
+    expect(src).toContain("childEnv[BASH_PACKAGE_HOME_ENV] = join(configHome, 'bash-package-home');");
+    expect(src).toContain('isAbsolute(configHome)');
+    // 写回必须在 spawn 之前，否则子 bridge 在加载时仍读不到该变量。
+    const writeBack = src.indexOf('childEnv[BASH_PACKAGE_HOME_ENV] = join(configHome');
+    const spawnCall = src.indexOf('child = spawn(binary, args');
+    expect(writeBack).toBeGreaterThan(-1);
+    expect(spawnCall).toBeGreaterThan(-1);
+    expect(writeBack).toBeLessThan(spawnCall);
+    // 子 bridge 仍会在首次加载时把它从 bash spawn env 剥离（withoutPiSecrets）。
+    // 不把 bash 加入子代理白名单：子代理仍是只读的。
+    const allowlists = [...src.matchAll(/tools: '([^']+)'/g)].map((m) => m[1]);
+    for (const list of allowlists) {
+      expect(list.split(',').sort()).toEqual(['find', 'grep', 'ls', 'read']);
+    }
+  });
 });

--- a/packages/maker-core/src/agents/pi/__tests__/cindySubagentSource.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/cindySubagentSource.test.ts
@@ -36,6 +36,7 @@ function loadSubagentChildEnvHelper(): {
     "const BASH_PACKAGE_HOME_ENV = 'CINDY_PI_BASH_PACKAGE_HOME';",
     'function readDepth(): number { return 0; }',
     'function isAbsolute(p: string): boolean { return path.isAbsolute(p); }',
+    // join 仍保留供未来其他用途；bash-package-home 写回使用 path.posix.join（见模板改动）。
     'function join(...args: string[]): string { return path.join(...args); }',
     // configHome 在 runTask 里来自 process.env[CONFIG_HOME_ENV]（已校验非空）
     '(globalThis as any).buildChildEnv = function(',
@@ -354,10 +355,10 @@ describe('cindy-subagent extension source', () => {
     // 导致子 bridge 无法解析 bash 隔离 home 而 fail-closed。runTask 在 spawn 前写回派生值。
     const src = CINDY_SUBAGENT_EXTENSION_SOURCE;
     expect(src).toContain("const BASH_PACKAGE_HOME_ENV = 'CINDY_PI_BASH_PACKAGE_HOME';");
-    expect(src).toContain("childEnv[BASH_PACKAGE_HOME_ENV] = join(configHome, 'bash-package-home');");
+    expect(src).toContain("childEnv[BASH_PACKAGE_HOME_ENV] = path.posix.join(configHome, 'bash-package-home');");
     expect(src).toContain('isAbsolute(configHome)');
     // 写回必须在 spawn 之前，否则子 bridge 在加载时仍读不到该变量。
-    const writeBack = src.indexOf('childEnv[BASH_PACKAGE_HOME_ENV] = join(configHome');
+    const writeBack = src.indexOf('childEnv[BASH_PACKAGE_HOME_ENV] = path.posix.join(configHome');
     const spawnCall = src.indexOf('child = spawn(binary, args');
     expect(writeBack).toBeGreaterThan(-1);
     expect(spawnCall).toBeGreaterThan(-1);
@@ -375,9 +376,10 @@ describe('cindy-subagent extension source', () => {
     // 防止 isAbsolute 分支或变量绑定出现回归而文本断言仍通过的漏检场景。
     const { buildChildEnv } = loadSubagentChildEnvHelper();
 
-    // 绝对路径：CINDY_PI_BASH_PACKAGE_HOME 必须被设置。
-    const envAbs = buildChildEnv('/host/agent/run-tmp/abc');
-    expect(envAbs['CINDY_PI_BASH_PACKAGE_HOME']).toBe('/host/agent/run-tmp/abc/bash-package-home');
+    // 绝对路径：CINDY_PI_BASH_PACKAGE_HOME 必须以 posix join 形式设置（与 bridge 一致）。
+    const configHome = '/host/agent/run-tmp/abc';
+    const envAbs = buildChildEnv(configHome);
+    expect(envAbs['CINDY_PI_BASH_PACKAGE_HOME']).toBe(path.posix.join(configHome, 'bash-package-home'));
 
     // 相对路径：不设置（fail-closed 语义不变）。
     const envRel = buildChildEnv('relative/path');
@@ -390,6 +392,6 @@ describe('cindy-subagent extension source', () => {
     });
     expect(envFull['CINDY_PI_MCP_BRIDGE']).toBeUndefined();
     expect(envFull['CINDY_PI_REMOTE_MCP_SECRET_X']).toBeUndefined();
-    expect(envFull['CINDY_PI_BASH_PACKAGE_HOME']).toBe('/abs/home/bash-package-home');
+    expect(envFull['CINDY_PI_BASH_PACKAGE_HOME']).toBe(path.posix.join('/abs/home', 'bash-package-home'));
   });
 });

--- a/packages/maker-core/src/agents/pi/__tests__/cindySubagentSource.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/cindySubagentSource.test.ts
@@ -1,3 +1,7 @@
+import * as path from 'node:path';
+import { runInNewContext } from 'node:vm';
+
+import ts from 'typescript';
 import { describe, expect, it } from 'vitest';
 
 import { PI_SUBAGENT_TOOL_NAME } from '@cindy/maker-shared/agent-task';
@@ -10,6 +14,57 @@ import {
   CINDY_SUBAGENT_TOOL_NAME,
 } from '../cindy-subagent-source.js';
 import { PI_SUBAGENT_PROGRESS_MARKER } from '../subagent-progress.js';
+
+/**
+ * 提取 runTask 里的 childEnv 构造块并在 VM 里执行，返回可调用的测试辅助函数。
+ * 用于执行级断言：验证 childEnv 在 spawn 前确实被正确填充了各字段。
+ */
+function loadSubagentChildEnvHelper(): {
+  buildChildEnv: (configHome: string, extraEnv?: Record<string, string>) => Record<string, string | undefined>;
+} {
+  const source = CINDY_SUBAGENT_EXTENSION_SOURCE;
+  const start = source.indexOf('const childEnv = Object.assign({}, process.env);');
+  const end = source.indexOf('\n    let child;', start);
+  if (start < 0 || end <= start) throw new Error('childEnv construction block not found');
+  const childEnvBlock = source.slice(start, end);
+
+  const executableSource = [
+    // 复现 runTask 依赖的常量与辅助函数（不从 source 提取值，避免重命名后双盲）
+    "const DEPTH_ENV = 'CINDY_PI_SUBAGENT_DEPTH';",
+    "const PARENT_PID_ENV = 'CINDY_PI_SUBAGENT_PARENT_PID';",
+    "const MCP_BRIDGE_ENV = 'CINDY_PI_MCP_BRIDGE';",
+    "const BASH_PACKAGE_HOME_ENV = 'CINDY_PI_BASH_PACKAGE_HOME';",
+    'function readDepth(): number { return 0; }',
+    'function isAbsolute(p: string): boolean { return path.isAbsolute(p); }',
+    'function join(...args: string[]): string { return path.join(...args); }',
+    // configHome 在 runTask 里来自 process.env[CONFIG_HOME_ENV]（已校验非空）
+    '(globalThis as any).buildChildEnv = function(',
+    '  configHome: string,',
+    '  extraEnv?: Record<string, string>,',
+    '): Record<string, string | undefined> {',
+    '  process.env = Object.assign({ PI_CODING_AGENT_DIR: configHome }, extraEnv);',
+    childEnvBlock,
+    '  return childEnv;',
+    '};',
+  ].join('\n');
+
+  const compiled = ts.transpileModule(executableSource, {
+    compilerOptions: { module: ts.ModuleKind.None, target: ts.ScriptTarget.ES2022 },
+  }).outputText;
+
+  const context: Record<string, unknown> = {
+    process: { env: {}, pid: 99999 },
+    path,
+  };
+  runInNewContext(compiled, context);
+
+  const buildChildEnv = context.buildChildEnv as (
+    configHome: string,
+    extraEnv?: Record<string, string>,
+  ) => Record<string, string | undefined>;
+  if (typeof buildChildEnv !== 'function') throw new Error('buildChildEnv not loaded');
+  return { buildChildEnv };
+}
 
 /**
  * 注入源码是字符串常量,typecheck 与 vitest 都进不去,只能靠结构性断言守。这里守的是
@@ -313,5 +368,28 @@ describe('cindy-subagent extension source', () => {
     for (const list of allowlists) {
       expect(list.split(',').sort()).toEqual(['find', 'grep', 'ls', 'read']);
     }
+  });
+
+  it('actually sets CINDY_PI_BASH_PACKAGE_HOME in childEnv at execution time (guards against control-flow regression, #3132)', () => {
+    // 结构断言守文本契约；本测试执行真实 childEnv 构造逻辑并断言运行时结果，
+    // 防止 isAbsolute 分支或变量绑定出现回归而文本断言仍通过的漏检场景。
+    const { buildChildEnv } = loadSubagentChildEnvHelper();
+
+    // 绝对路径：CINDY_PI_BASH_PACKAGE_HOME 必须被设置。
+    const envAbs = buildChildEnv('/host/agent/run-tmp/abc');
+    expect(envAbs['CINDY_PI_BASH_PACKAGE_HOME']).toBe('/host/agent/run-tmp/abc/bash-package-home');
+
+    // 相对路径：不设置（fail-closed 语义不变）。
+    const envRel = buildChildEnv('relative/path');
+    expect(envRel['CINDY_PI_BASH_PACKAGE_HOME']).toBeUndefined();
+
+    // MCP bridge 仍被剥离；外部 MCP secret 也被剥离；写回不干扰这两条不变量。
+    const envFull = buildChildEnv('/abs/home', {
+      CINDY_PI_MCP_BRIDGE: 'http://localhost:3000',
+      CINDY_PI_REMOTE_MCP_SECRET_X: 'secret',
+    });
+    expect(envFull['CINDY_PI_MCP_BRIDGE']).toBeUndefined();
+    expect(envFull['CINDY_PI_REMOTE_MCP_SECRET_X']).toBeUndefined();
+    expect(envFull['CINDY_PI_BASH_PACKAGE_HOME']).toBe('/abs/home/bash-package-home');
   });
 });

--- a/packages/maker-core/src/agents/pi/cindy-bridge-source.ts
+++ b/packages/maker-core/src/agents/pi/cindy-bridge-source.ts
@@ -462,8 +462,9 @@ function whichRgOnPath(): string {
 //    与「抢跑改写注入 env」在原实现下同级别,不新增面。
 //  - env 值在已消费(stash 已建立)后再次出现,视为进程内写入:删除并忽略。
 //  - stash 缺失(非 Cindy 初始化的进程,如手工把 bridge 拷进用户 ~/.pi)或双重
-//    验证失败 → 返回 undefined,下游 isolatedBashEnvironment 保持原 fail-closed,
-//    不猜外来 runtime 的路径。
+//    验证失败,但 env 同样未注入 → 尝试 PI_CODING_AGENT_DIR 派生(#3132:subagent
+//    子进程正是此路径);PI_CODING_AGENT_DIR 非绝对路径或缺失时 fail-closed。
+//    PI_CODING_AGENT_DIR 本就常驻可写,控制它与控制注入 env 同级,不新增威胁面。
 //
 // 凭证不走本机制:CINDY_PI_PACKAGE_MANAGEMENT 是 host 签发的 bearer token,
 // 保持读一次即删、仅闭包持有(见入口注释)。
@@ -513,7 +514,9 @@ function resolveBashPackageHome(): string | undefined {
       stashBashPackageHome(injected);
       return injected;
     }
-    return undefined;
+    // env 与 stash 均不可用(subagent 子进程:父 bridge 已消费并删除 env,
+    // 子进程无 stash)—— 从 PI_CODING_AGENT_DIR 派生;非绝对路径时 fail-closed。
+    return derivedBashPackageHome();
   }
   // 重载(env 已被消费;或 env 值又被进程内写入 —— 上面的 delete 已顺手清掉):
   // stash 与 PI_CODING_AGENT_DIR 派生值双重一致才信任,否则 fail-closed。

--- a/packages/maker-core/src/agents/pi/cindy-subagent-source.ts
+++ b/packages/maker-core/src/agents/pi/cindy-subagent-source.ts
@@ -114,7 +114,7 @@ const CINDY_SUBAGENT_EXTENSION_BODY = String.raw`/**
  */
 import { spawn } from 'node:child_process';
 import { readFileSync } from 'node:fs';
-import { join, isAbsolute } from 'node:path';
+import path, { join, isAbsolute } from 'node:path';
 
 const TOOL_NAME = 'subagent';
 const MARKER = '__cindySubagent';
@@ -397,8 +397,10 @@ function runTask(binary, task, runtime, signal, onProgress) {
     }
     // 父 bridge 已消费并删除 CINDY_PI_BASH_PACKAGE_HOME；写回派生值让子 bridge
     // 能解析 bash 隔离 home。子 bridge 仍会在首次加载时删除它(withoutPiSecrets)。
+    // path.posix.join 与 bridge derivedBashPackageHome 保持一致(Windows 下 path.join
+    // 产生反斜杠路径，bridge reload 时 stash 与 posix 派生值不匹配会 fail-closed)。
     if (isAbsolute(configHome)) {
-      childEnv[BASH_PACKAGE_HOME_ENV] = join(configHome, 'bash-package-home');
+      childEnv[BASH_PACKAGE_HOME_ENV] = path.posix.join(configHome, 'bash-package-home');
     }
 
     let child;

--- a/packages/maker-core/src/agents/pi/cindy-subagent-source.ts
+++ b/packages/maker-core/src/agents/pi/cindy-subagent-source.ts
@@ -114,7 +114,7 @@ const CINDY_SUBAGENT_EXTENSION_BODY = String.raw`/**
  */
 import { spawn } from 'node:child_process';
 import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, isAbsolute } from 'node:path';
 
 const TOOL_NAME = 'subagent';
 const MARKER = '__cindySubagent';
@@ -124,6 +124,8 @@ const RUNTIME_FILE_ENV = 'CINDY_PI_SUBAGENT_RUNTIME_FILE';
 const CONFIG_HOME_ENV = 'PI_CODING_AGENT_DIR';
 // cindy-bridge 用它决定要不要连 MCP server;子代理不需要,spawn 时剥掉(见 runTask)。
 const MCP_BRIDGE_ENV = 'CINDY_PI_MCP_BRIDGE';
+// 父 bridge 已消费此 env;runTask 在 spawn 前从 configHome 重新派生写回(#3132)。
+const BASH_PACKAGE_HOME_ENV = 'CINDY_PI_BASH_PACKAGE_HOME';
 // PARENT_PID_ENV 与 PARENT_WATCHDOG_INTERVAL_MS 由末尾追加的看门狗段声明(那段要能独立
 // 跑起来受测)。**别在这里重复声明** —— 同名 const 会让拼接后的模块直接 SyntaxError,
 // 整个扩展加载失败。有测试守这条。
@@ -392,6 +394,11 @@ function runTask(binary, task, runtime, signal, onProgress) {
     // 最小凭证继承 —— 子代理只保留跑模型需要的 auth/native env。
     for (const key of Object.keys(childEnv)) {
       if (key.startsWith('CINDY_PI_REMOTE_MCP_SECRET_')) delete childEnv[key];
+    }
+    // 父 bridge 已消费并删除 CINDY_PI_BASH_PACKAGE_HOME；写回派生值让子 bridge
+    // 能解析 bash 隔离 home。子 bridge 仍会在首次加载时删除它(withoutPiSecrets)。
+    if (isAbsolute(configHome)) {
+      childEnv[BASH_PACKAGE_HOME_ENV] = join(configHome, 'bash-package-home');
     }
 
     let child;


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 #3132：Pi bash 工具在 subagent 子进程内 100% 必现 "Cindy isolated Pi package home is unavailable" 错误。

根因：父 bridge 在初始化时消费并从 `process.env` 删除 `CINDY_PI_BASH_PACKAGE_HOME`；`cindy-subagent runTask` 用 `Object.assign({}, process.env)` 构造子进程 env 时已读不到该变量，子进程里的 bridge 无 stash、无 env，`isolatedBashEnvironment` fail-closed 抛错。

两处修复，不新增机制：

1. **cindy-bridge `resolveBashPackageHome`**：env 与 stash 均不可用时（正是 subagent 子进程路径），从 `PI_CODING_AGENT_DIR` 派生 `path.posix.join(configHome, 'bash-package-home')`；非绝对路径仍 fail-closed。公式与 #3089 stash 校验一致。

2. **cindy-subagent `runTask`**：`spawn` 前，`configHome` 为绝对路径时写回 `childEnv['CINDY_PI_BASH_PACKAGE_HOME'] = join(configHome, 'bash-package-home')`，让子 bridge 首次加载时能读到该变量（子 bridge 仍会在加载时删除它）。

子代理白名单不改（仍是只读：read/grep/find/ls）。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：closes #3132
- 本 PR 包含：`cindy-bridge-source.ts`、`cindy-subagent-source.ts` 的最小修复 + 对应单测
- 明确不包含：bash 进白名单、新机制、主进程续接路径的排查（#3089 已覆盖）
- 用户可见变化：subagent 内 bash 工具不再必现报错
- 是否存在 breaking change：无

### UI 变化

不涉及

## 怎么验证的

### 自动验证

```text
# 只跑 pi 相关测试（483 个测试全部通过）
node node_modules/.bin/vitest run packages/maker-core/src/agents/pi/__tests__/
结果：Test Files 23 passed | 2 skipped (25)；Tests 483 passed | 65 skipped (548)

# typecheck
pnpm --filter "@cindy/maker-core" run --if-present typecheck
结果：无错误输出
```

新增的测试：
- `cindyBridgeSource.test.ts`：新增 `falls back to PI_CODING_AGENT_DIR derivation when neither env nor stash is available (subagent subprocess, #3132)` — 覆盖绝对路径派生成功、相对路径 fail-closed、PI_CODING_AGENT_DIR 缺失 fail-closed 三个场景。
- `cindySubagentSource.test.ts`：新增 `writes CINDY_PI_BASH_PACKAGE_HOME into childEnv before spawn when configHome is absolute (#3132)` — 结构断言写回逻辑存在且在 spawn 之前。

### 手工验证

不涉及（纯 maker-core 逻辑修复，无 UI 路径；subagent 路径的确定性 bug 由已有及新增单测覆盖）。

### 未执行的验证

真实 pi 二进制的 subagent 端到端 bash 调用：单测已用 runInNewContext 执行真实函数逻辑，集成层面的 binary 场景未在本 worktree 运行（binaries 未准备）。

## 风险

### 风险分类

- [x] 权限 / 安全 / 用户数据（bridge 安全相关代码路径）

### 影响与回滚

- 影响范围：仅 `packages/maker-core` 的 Pi bridge 和 subagent 扩展注入逻辑，不影响主进程 / IPC / 其他 agent
- 回滚：revert 本 PR；subagent bash 恢复 fail-closed 状态（0.1.57 之后的已知问题）

存量插件兼容：无（改动不涉及插件 manifest / 批准状态 / 包格式）。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（威胁模型注释已同步更新）
- [x] 已确认测试结果或说明未执行原因
