### PR TITLE
fix: re-create isolated pi package home on session resume

### DIFF
--- a/packages/maker-core/src/agents/pi/__tests__/cindyBridgeSource.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/cindyBridgeSource.test.ts
@@ -79,7 +79,7 @@ function loadBashIsolationHelper(
   ) => Record<string, string | undefined>;
 }
 
-function loadBashPackageHomeHelper(): {
+function loadBashPackageHomeHelper(pathImpl: typeof path = path): {
   resolveBashPackageHome: () => string | undefined;
   env: Record<string, string | undefined>;
   globalThis: Record<string, unknown>;
@@ -101,7 +101,8 @@ function loadBashPackageHomeHelper(): {
   }).outputText;
   const context: Record<string, unknown> = {
     process: { env: {} },
-    path,
+    path: pathImpl,
+    statSync,
   };
   // runInNewContext 的 context 即该 realm 的 globalThis,stash 会落在上面。
   runInNewContext(compiled, context);
@@ -111,7 +112,7 @@ function loadBashPackageHomeHelper(): {
   }
   return {
     resolveBashPackageHome,
-    env: context.process.env as Record<string, string | undefined>,
+    env: (context.process as { env: Record<string, string | undefined> }).env,
     globalThis: context,
   };
 }
@@ -1085,6 +1086,55 @@ describe('cindy-bridge extension source', () => {
     helper.env.PI_CODING_AGENT_DIR = '/host/agent-home/run-tmp/abc';
     expect(helper.resolveBashPackageHome()).toBe(injected);
 
+    // 升级 attach:旧 bridge 已消费专用 env 且未建立 stash。只有 configHome 与
+    // permission file 同属 Cindy runtime 固定布局、且 host 创建的文件/目录仍在时,
+    // 才派生并补建 stash。
+    const legacyRoot = mkdtempSync(path.join(tmpdir(), 'cindy-legacy-bash-home-'));
+    const otherRoot = mkdtempSync(path.join(tmpdir(), 'cindy-other-runtime-'));
+    try {
+      const legacyConfigHome = path.join(legacyRoot, 'run-tmp', 'legacy');
+      const legacyRuntimeDir = path.join(legacyRoot, 'runtime');
+      const legacyDerived = path.posix.join(legacyConfigHome, 'bash-package-home');
+      mkdirSync(legacyDerived, { recursive: true });
+      mkdirSync(legacyRuntimeDir, { recursive: true });
+      const legacyPermission = path.join(legacyRuntimeDir, 'perm-legacy.json');
+      writeFileSync(legacyPermission, '{}');
+      const legacy = loadBashPackageHomeHelper();
+      legacy.env.PI_CODING_AGENT_DIR = legacyConfigHome;
+      legacy.env.CINDY_PI_PERMISSION_FILE = legacyPermission;
+      expect(legacy.resolveBashPackageHome()).toBe(legacyDerived);
+      expect(legacy.resolveBashPackageHome()).toBe(legacyDerived);
+      const legacyDescriptor = Object.getOwnPropertyDescriptor(
+        legacy.globalThis,
+        '__cindyBridgeBashPackageHome',
+      );
+      expect(legacyDescriptor?.writable).toBe(false);
+      expect(legacyDescriptor?.configurable).toBe(false);
+
+      // 只有 configHome、或 permission file 跨 agentHome 时不构成 Cindy runtime 归属证明。
+      const unowned = loadBashPackageHomeHelper();
+      unowned.env.PI_CODING_AGENT_DIR = legacyConfigHome;
+      expect(unowned.resolveBashPackageHome()).toBeUndefined();
+      const otherRuntime = path.join(otherRoot, 'runtime');
+      mkdirSync(otherRuntime, { recursive: true });
+      const otherPermission = path.join(otherRuntime, 'perm-other.json');
+      writeFileSync(otherPermission, '{}');
+      unowned.env.CINDY_PI_PERMISSION_FILE = otherPermission;
+      expect(unowned.resolveBashPackageHome()).toBeUndefined();
+
+      // Windows 使用原生分隔符做 runtime 归属/遍历判断;最终派生仍匹配 host 的
+      // posix.join 约定。statSync 在当前平台无法访问 Windows 夹具,所以这里只覆盖
+      // 路径拒绝分支(在 fs 检查之前完成)。
+      const windowsTraversal = loadBashPackageHomeHelper(path.win32);
+      windowsTraversal.env.PI_CODING_AGENT_DIR = 'D:\\agent\\run-tmp\\legacy';
+      windowsTraversal.env.CINDY_PI_PERMISSION_FILE =
+        'D:\\agent\\runtime\\..\\other\\perm-legacy.json';
+      expect(windowsTraversal.resolveBashPackageHome()).toBeUndefined();
+    } finally {
+      rmSync(legacyRoot, { recursive: true, force: true });
+      rmSync(otherRoot, { recursive: true, force: true });
+    }
+
     // stash 属性被替换成 plain 赋值(可写可配置)→ 不被信任 → fail-closed。
     // (defineProperty 定义 non-configurable 属性后无法 redefine,这里用一个
     // fresh context 模拟「攻击者抢跑预置了 plain stash」的形态。)
@@ -1096,7 +1146,7 @@ describe('cindy-bridge extension source', () => {
       configurable: true,
       enumerable: false,
     });
-    // 攻击者形态 stash 不被信任 → 走首次加载路径;env 未注入 → fail-closed。
+    // 攻击者形态 stash 不被信任,且存在该属性时禁止兼容派生 → fail-closed。
     expect(hostile.resolveBashPackageHome()).toBeUndefined();
 
     // 非 Cindy 初始化的进程(env 从未注入、无 stash)保持 fail-closed 语义:

--- a/packages/maker-core/src/agents/pi/cindy-bridge-source.ts
+++ b/packages/maker-core/src/agents/pi/cindy-bridge-source.ts
@@ -443,12 +443,11 @@ function whichRgOnPath(): string {
   return '';
 }
 
-// bash 隔离 home 的跨重载解析(#3070)。CINDY_PI_BASH_PACKAGE_HOME 由 host 在
-// spawn 时注入一次,bridge 首次加载后即从 process.env 删除(防止进程内其它代码
-// 改写)。但 Pi 会重载扩展:同一进程里 bridge 文件被再次执行时 env 已被删,重载
-// 实例拿到 undefined —— bash 从此永久 fail-closed。解法:首次加载把值 stash 进
-// globalThis 上的 non-configurable / non-writable 属性(语言层面不可替换、不可
-// 删除),重载实例取回时再做双重验证。
+// bash 隔离 home 的跨重载/升级恢复解析(#3070/#3164)。
+// CINDY_PI_BASH_PACKAGE_HOME 由 host 在 spawn 时注入一次,bridge 首次加载后即从
+// process.env 删除(防止进程内其它代码改写)。Pi 重载扩展时从不可变 stash 恢复;
+// 若存量进程里的旧 bridge 已经消费 env、却没有建立新版 stash,则从仍由 host
+// 注入的 PI_CODING_AGENT_DIR 固定派生 bash-package-home,补建 stash 后继续使用。
 //
 // 威胁模型:本进程内会加载用户安装的第三方托管扩展,它们与 bridge 共享同一
 // realm,能触碰 globalThis 与 process.env。因此:
@@ -461,9 +460,9 @@ function whichRgOnPath(): string {
 //    扩展先于 bridge 首次加载执行)也得同时锚定 PI_CODING_AGENT_DIR 才可能一致,
 //    与「抢跑改写注入 env」在原实现下同级别,不新增面。
 //  - env 值在已消费(stash 已建立)后再次出现,视为进程内写入:删除并忽略。
-//  - stash 缺失(非 Cindy 初始化的进程,如手工把 bridge 拷进用户 ~/.pi)或双重
-//    验证失败 → 返回 undefined,下游 isolatedBashEnvironment 保持原 fail-closed,
-//    不猜外来 runtime 的路径。
+//  - 旧 bridge 没有 stash 时只接受 Cindy runtime 的固定目录布局:configHome 必须
+//    位于 <agentHome>/run-tmp,权限文件必须位于同一 <agentHome>/runtime;手工把 bridge
+//    拷进用户 ~/.pi 或跨 runtime 路径仍返回 undefined,保持 fail-closed。
 //
 // 凭证不走本机制:CINDY_PI_PACKAGE_MANAGEMENT 是 host 签发的 bearer token,
 // 保持读一次即删、仅闭包持有(见入口注释)。
@@ -503,15 +502,57 @@ function derivedBashPackageHome(): string | undefined {
   return path.posix.join(configHome, 'bash-package-home');
 }
 
+function legacyBashPackageHome(): string | undefined {
+  const configHome = process.env.PI_CODING_AGENT_DIR;
+  const permissionFile = process.env.CINDY_PI_PERMISSION_FILE;
+  const derived = derivedBashPackageHome();
+  if (!configHome || !permissionFile || !derived || !path.isAbsolute(permissionFile)) {
+    return undefined;
+  }
+  // Host 的 runtime 结构固定为 <agentHome>/run-tmp/<instance> 与
+  // <agentHome>/runtime/perm-*.json。两者必须同属一个 agentHome,不能只凭一个
+  // 可改写的 PI_CODING_AGENT_DIR 猜路径。
+  // 归属校验必须用当前平台 path 语义:Windows 的反斜杠与上级引用也要被
+  // 规范化/拦截;只有最终 bash home 的派生式必须保持 host 的 posix.join。
+  const runTmpDir = path.dirname(configHome);
+  if (path.basename(runTmpDir) !== 'run-tmp') return undefined;
+  const agentHome = path.dirname(runTmpDir);
+  const runtimeDir = path.join(agentHome, 'runtime');
+  const relativePermission = path.relative(runtimeDir, permissionFile);
+  if (
+    !relativePermission ||
+    relativePermission === '..' ||
+    relativePermission.startsWith('..' + path.sep) ||
+    path.isAbsolute(relativePermission) ||
+    !path.basename(permissionFile).startsWith('perm-') ||
+    !path.basename(permissionFile).endsWith('.json')
+  ) {
+    return undefined;
+  }
+  try {
+    if (!statSync(permissionFile).isFile() || !statSync(derived).isDirectory()) return undefined;
+  } catch {
+    return undefined;
+  }
+  return derived;
+}
+
 function resolveBashPackageHome(): string | undefined {
   const injected = process.env[PI_BASH_PACKAGE_HOME_ENV];
   if (injected !== undefined) delete process.env[PI_BASH_PACKAGE_HOME_ENV];
   const stashed = readStashedBashPackageHome();
   if (stashed === undefined) {
-    // 本进程首次加载:host 注入的 env 是权威,stash 供重载实例取回。
-    if (injected !== undefined) {
-      stashBashPackageHome(injected);
-      return injected;
+    // 攻击者抢跑占用了 stash 名时不能退回派生路径,否则会把不可信属性形态
+    // 静默“修复”为受信 stash。只有属性确实缺失才允许兼容旧 bridge。
+    if (Object.prototype.hasOwnProperty.call(globalThis, BRIDGE_RELOAD_STASH_GLOBAL)) {
+      return undefined;
+    }
+    // 本进程首次加载:host 注入的 env 是权威。升级 attach 的存量进程可能已被
+    // 旧 bridge 消费 env 且没有 stash;此时从 host 的 configHome 固定派生。
+    const resolved = injected ?? legacyBashPackageHome();
+    if (resolved !== undefined) {
+      stashBashPackageHome(resolved);
+      return resolved;
     }
     return undefined;
   }


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 #3164：Pi session attach 到存量进程（surviving process）时，旧 bridge 已消费一次性环境变量 `CINDY_PI_BASH_PACKAGE_HOME` 且未建立新版 immutable stash，新 bridge 既拿不到 env 也拿不到 stash，导致每次 bash 调用都在执行前报 `Cindy isolated Pi package home is unavailable`，bash 工具永久失效。

新会话与正常恢复的会话都走 `PiAgent.startSession`（`packages/maker-core/src/agents/pi/index.ts`），它会创建 `<configHome>/bash-package-home` 并注入 env；本 PR 为「升级 / attach」兼容路径补上缺失的一环：当 stash 缺失时，仅当 config home、permission file 与既有目录能证明是 Cindy runtime 的固定布局（`<agentHome>/run-tmp` + `<agentHome>/runtime/perm-*.json`），才从 `PI_CODING_AGENT_DIR` 固定派生 `bash-package-home` 并封入现有不可变 stash；非法、跨 runtime、缺失、路径穿越的布局一律 fail-closed。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：#3164
- 本 PR 包含：`cindy-bridge-source.ts` 的 legacy attach 恢复路径 + 对应单测
- 明确不包含：host 侧 spawn 路径改动（新会话/正常 resume 已正确，无需改）
- 用户可见变化：被该 bug 击中的恢复会话 bash 恢复可用
- 是否存在 breaking change：无

### UI 变化

不涉及（纯桥接层逻辑，无 UI 路径改动）。

## 怎么验证的

### 自动验证

- focused bridge 测试：2 通过（`standalone TypeScript` 与 bash package-home resolver）；13 个无关测试按 name filter 跳过
- 变更文件 ESLint：通过
- `git diff --check`：通过
- maker-core 全量 typecheck 仍以 exit 2 退出，但与本分支的 clean-HEAD 对比为同一组既有 test typing 错误；本分支额外消除了一个既有 `context.process` typing 错误，未新增
- 完整 bridge 套件：13 通过 / 1 跳过，唯一失败与 shallow clone 缺少 `apps/ripgrep-bin/darwin-arm64/rg` 有关，与本改动无关

### 手动验证

未执行（恢复路径需要真实存量进程现场，环境不具备）；已用单测覆盖 legacy attach 恢复、immutable stash 重建、缺失/跨 runtime 拒绝、Windows 路径穿越拒绝、临时资源清理。

## 风险

- **安全面**：恢复路径只接受 Cindy runtime 固定布局（configHome 必须位于 `<agentHome>/run-tmp`、permission file 必须位于同一 `<agentHome>/runtime` 且为 `perm-*.json`、目录/权限文件必须真实存在），Windows 反斜杠与上级引用在路径归属校验中按当前平台语义规范化并拦截；最终 bash home 派生仍与 host 的 `posix.join` 约定逐字一致。stash 属性被抢跑占用时不走兼容派生（fail-closed），不会把不可信属性形态"修复"为受信 stash。手工把 bridge 拷进 `~/.pi` 或跨 runtime 路径仍返回 undefined。
- **兼容性**：仅新增缺失路径，不改既有 env 注入、stash 双重验证或 fail-closed 语义；新会话与正常 resume 行为零变化。
- **回归**：变更集中在 `cindy-bridge-source.ts` 的 `resolveBashPackageHome`/新增 `legacyBashPackageHome`，单测覆盖成功与拒绝两侧；Greptile Review confidence 5/5。
