### PR TITLE
fix(device-link): 修复跨代恢复与熔断自锁

### DIFF
--- a/apps/desktop/src/main/device-link/__tests__/responsivenessTracker.test.ts
+++ b/apps/desktop/src/main/device-link/__tests__/responsivenessTracker.test.ts
@@ -17,6 +17,7 @@ import {
   classifyDeviceSendFailure,
   classifyDeviceSendSuccess,
   createResponsivenessTracker,
+  isDeviceResponsivenessProbeEligible,
 } from '../responsivenessTracker';
 
 const DEV = 'device-under-test';
@@ -68,6 +69,48 @@ async function openBreaker(
 }
 
 describe('responsivenessTracker', () => {
+  it('重连清空 presence 后 unknown 仍允许单飞探测,明确 false 与其它硬门继续阻止', () => {
+    const base = {
+      relayOnline: true,
+      ownsRelay: true,
+      revoked: false,
+      locallyDisabled: false,
+    };
+
+    expect(isDeviceResponsivenessProbeEligible({
+      ...base,
+      presenceAvailable: undefined,
+    })).toBe(true);
+    expect(isDeviceResponsivenessProbeEligible({
+      ...base,
+      presenceAvailable: true,
+    })).toBe(true);
+    expect(isDeviceResponsivenessProbeEligible({
+      ...base,
+      presenceAvailable: false,
+    })).toBe(false);
+    expect(isDeviceResponsivenessProbeEligible({
+      ...base,
+      presenceAvailable: undefined,
+      relayOnline: false,
+    })).toBe(false);
+    expect(isDeviceResponsivenessProbeEligible({
+      ...base,
+      presenceAvailable: undefined,
+      ownsRelay: false,
+    })).toBe(false);
+    expect(isDeviceResponsivenessProbeEligible({
+      ...base,
+      presenceAvailable: undefined,
+      revoked: true,
+    })).toBe(false);
+    expect(isDeviceResponsivenessProbeEligible({
+      ...base,
+      presenceAvailable: undefined,
+      locallyDisabled: true,
+    })).toBe(false);
+  });
+
   it('成功请求直通,不改变状态', async () => {
     const h = harness();
     await expect(
@@ -191,6 +234,32 @@ describe('responsivenessTracker', () => {
       expect(h.tracker.isUnresponsive(DEV)).toBe(false);
     });
     expect(h.onUnresponsiveChanged).toHaveBeenLastCalledWith(DEV, false);
+  });
+
+  it('熔断已 open 时 relay 换代把 presence 从 false 清为 unknown,下一拍恢复单飞探测', async () => {
+    let presenceAvailable: boolean | undefined = false;
+    const h = harness({
+      isProbeEligible: () => isDeviceResponsivenessProbeEligible({
+        relayOnline: true,
+        ownsRelay: true,
+        presenceAvailable,
+        revoked: false,
+        locallyDisabled: false,
+      }),
+    });
+    await openBreaker(h);
+    h.advance(BREAKER_PROBE_BACKOFF_BASE_MS);
+
+    h.tracker.probeTick();
+    expect(h.probeInvoke).not.toHaveBeenCalled();
+
+    // client.onStatusChange 非 online 会清空当代 presence；server 不保证重放全量
+    // snapshot，所以同一台仍在线设备可能长期保持 unknown。这个状态必须允许
+    // breaker 自己控制的单飞 probe，而不能释放普通 guardInvoke 业务流量。
+    presenceAvailable = undefined;
+    h.tracker.probeTick();
+    await vi.waitFor(() => expect(h.probeInvoke).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() => expect(h.tracker.isUnresponsive(DEV)).toBe(false));
   });
 
   it('探测超时 → 保持 open 并加深退避(下个基础窗口不再探测)', async () => {

--- a/apps/desktop/src/main/device-link/index.ts
+++ b/apps/desktop/src/main/device-link/index.ts
@@ -133,6 +133,7 @@ import {
 } from './linkRecovery';
 import {
   createResponsivenessTracker,
+  isDeviceResponsivenessProbeEligible,
   OPEN_LINK_OBSERVATION_CHANNEL,
   type DeviceResponsivenessTracker,
 } from './responsivenessTracker';
@@ -612,13 +613,16 @@ export function initDeviceLinkService(options: DeviceLinkServiceOptions = {}): v
         replayActiveSubscriptions(`responsiveness-recovered:${deviceId.slice(0, 8)}`, deviceId);
       }
     },
-    // 探测同样遵守本机「关闭对该设备的控制」的 fail-closed 偏好,不给禁用目标发任何帧。
-    isProbeEligible: (deviceId) =>
-      client?.getStatus() === 'online' &&
-      arbiter?.isOwner() === true &&
-      presenceAvailableByDevice.get(deviceId) === true &&
-      !revokedByRemote.has(deviceId) &&
-      !readDeviceLinkSettings().disabledControlDeviceIds.includes(deviceId),
+    // 探测只在熔断器已经放行 half-open 单飞席位后到达这里；presence 的未知态
+    // 必须允许这一个探测穿过，否则 relay 重连清空 presence 后熔断会永久自锁。
+    // 只有当代 presence 明确为 false 才阻止，且仍叠加 relay/owner/撤权/本机禁用门。
+    isProbeEligible: (deviceId) => isDeviceResponsivenessProbeEligible({
+      relayOnline: client?.getStatus() === 'online',
+      ownsRelay: arbiter?.isOwner() === true,
+      presenceAvailable: presenceAvailableByDevice.get(deviceId),
+      revoked: revokedByRemote.has(deviceId),
+      locallyDisabled: readDeviceLinkSettings().disabledControlDeviceIds.includes(deviceId),
+    }),
     // observed:false 且是唯一豁免熔断快速拒绝的建链入口:recoverLink 是探测
     // 周期的延伸(业务/探测超时已由 tracker 记账,不重复观测),且 open 期间
     // 必须真正上线重建 link——否则「探测超时→重开 link→下次探测走新链路」的

--- a/apps/desktop/src/main/device-link/responsivenessTracker.ts
+++ b/apps/desktop/src/main/device-link/responsivenessTracker.ts
@@ -16,6 +16,7 @@
  */
 import {
   createDeviceResponsivenessBreaker,
+  isPresenceValueEligible,
   type BreakerSendSlot,
   type BreakerSettleOutcome,
 } from '@cindy/maker-shared/device-responsiveness';
@@ -50,6 +51,33 @@ export const DEVICE_RESPONSIVENESS_PROBE_CHANNEL = 'local-db:sessions:list';
 
 export function buildDeviceResponsivenessProbeArgs(): unknown[] {
   return [1, 'all', { includePinned: true }];
+}
+
+export interface DeviceResponsivenessProbeEligibility {
+  relayOnline: boolean;
+  ownsRelay: boolean;
+  presenceAvailable: boolean | undefined;
+  revoked: boolean;
+  locallyDisabled: boolean;
+}
+
+/**
+ * Desktop half-open probe gate. Unknown presence is intentionally eligible:
+ * presence is delta-only and is cleared on every relay generation, so requiring
+ * an explicit `true` would permanently lock an already-open breaker when the
+ * peer stays online and therefore emits no new presence edge.
+ *
+ * This does not release ordinary traffic. probeTick has already applied breaker
+ * backoff and single-flight before consulting this predicate.
+ */
+export function isDeviceResponsivenessProbeEligible(
+  input: DeviceResponsivenessProbeEligibility,
+): boolean {
+  return input.relayOnline
+    && input.ownsRelay
+    && isPresenceValueEligible(input.presenceAvailable)
+    && !input.revoked
+    && !input.locallyDisabled;
 }
 
 /**

--- a/apps/mobile/src/device-link/presenceRecovery.ts
+++ b/apps/mobile/src/device-link/presenceRecovery.ts
@@ -1,4 +1,5 @@
 import type { InvokeResultPayload, PresenceSnapshot } from '@cindy/device-link';
+export { isPresenceEligibleForRemoteRequest } from '@cindy/maker-shared/device-responsiveness';
 
 type PresenceAvailabilitySnapshot = Pick<PresenceSnapshot, 'deviceId' | 'online' | 'remoteControlEnabled'>;
 
@@ -291,15 +292,6 @@ export function reconcileAvailabilityAfterInboundFrame(
     cleared = true;
   }
   return cleared;
-}
-
-export function isPresenceEligibleForRemoteRequest(
-  availabilityByDevice: ReadonlyMap<string, boolean>,
-  deviceId: string,
-): boolean {
-  // 首次尚未收到 presence 时保留既有乐观尝试;只有 relay 已明确声明 unavailable
-  // 才拦住 rehydrate / half-open probe,避免对离线设备立即重放请求风暴。
-  return availabilityByDevice.get(deviceId) !== false;
 }
 
 export function resetPresenceAvailabilityForConnection(

--- a/packages/device-link/README.md
+++ b/packages/device-link/README.md
@@ -70,8 +70,7 @@
   发出 `link-accept` 后，只先开放接收方向；控制端真正处理匹配的 accept、安装 stream
   基线后，会回一条带该 `link-open` requestId 的 transport ACK。被控端只有收到同代、
   同 stream 且基线合法的确认才开放发送方向并 replay pending；若这条确认因瞬时背压未发出，
-  控制端会按既有可靠重试间隔有界重发确认；对端后续发来的首个同 stream 可靠业务帧也可
-  作为已处理 accept 的等价证据。确认窗口耗尽仍无证据时，被控端复用现有 peer 级
+  控制端会按既有可靠重试间隔有界重发确认。确认窗口耗尽仍无确认时，被控端复用现有 peer 级
   `transport-timeout` 重置，要求控制端重开链路，而不是永久停在等待态。迟到 accept、被新请求
   替换的 accept、错误 requestId、旧 stream 业务帧都不能跨代放行；任一端未声明本能力时继续
   使用旧版即时 ready 行为，保证 Desktop 与 Mobile 可以独立升级，server relay 无需理解新字段。
@@ -97,9 +96,10 @@
   仍未恢复；熔断器会继续保持单飞探测，不应把普通业务请求重新放成洪峰。
 - 真机版本未同时包含这组代码时，只能验证旧协议兼容路径；必须以 Desktop、Mobile
   实际版本和 24 小时日志中的 `await-link-confirm`、`link-confirm-ack`、
-  `link-confirm-inbound`、`link confirmation timeout` 与 `responsiveness probe` 证据判断发布效果，不能仅凭
+  `link confirmation timeout` 与 `responsiveness probe` 证据判断发布效果，不能仅凭
   “online”判定连接健康。若同一 request 长期只有 `await-link-confirm`，说明对端没有
-  提交本代 accept；若随后出现两个 `link-confirm-*` 之一，说明发送方向已经安全恢复。
+  提交本代 accept；若随后出现 `link-confirm-ack`，说明发送方向已经安全恢复；若出现
+  `link confirmation timeout`，说明本代确认未完成并已进入 peer 级重开路径。
 
 设备列表另有 REST:`GET /api/device-link/devices` → `DeviceView[]`(DB 档案 ∪ presence 三态合成,含可选 `selfName/deviceInfo`);`PATCH`/`DELETE` 改名/删除。
 

--- a/packages/device-link/README.md
+++ b/packages/device-link/README.md
@@ -66,8 +66,40 @@
   顺序，避免“业务处理慢”被误判成“网络断开”。
 - 可靠业务帧必须等 link-open/link-accept 能力协商完成后才接收；断线后迟到到新进程的
   旧 relay 帧不会在新基线建立前执行。
+- 同时声明 `reliable-link-confirm-v1` 时，可靠链路按方向提交：收到 `link-open` 的一端
+  发出 `link-accept` 后，只先开放接收方向；控制端真正处理匹配的 accept、安装 stream
+  基线后，会回一条带该 `link-open` requestId 的 transport ACK。被控端只有收到同代、
+  同 stream 且基线合法的确认才开放发送方向并 replay pending；若这条确认因瞬时背压未发出，
+  控制端会按既有可靠重试间隔有界重发确认；对端后续发来的首个同 stream 可靠业务帧也可
+  作为已处理 accept 的等价证据。确认窗口耗尽仍无证据时，被控端复用现有 peer 级
+  `transport-timeout` 重置，要求控制端重开链路，而不是永久停在等待态。迟到 accept、被新请求
+  替换的 accept、错误 requestId、旧 stream 业务帧都不能跨代放行；任一端未声明本能力时继续
+  使用旧版即时 ready 行为，保证 Desktop 与 Mobile 可以独立升级，server relay 无需理解新字段。
+- Desktop 与 Mobile 的自动恢复共用同一条 presence 三态规则：当前连接代没有收到
+  presence 时是 `unknown`，只允许熔断器/恢复器自己的单飞探测或定向重建尝试；relay
+  明确报告 `false` 时才停止自动发送。这样重连清空 presence 不会把熔断器永久锁死，
+  也不会把普通业务请求在未知状态下全部放行成洪峰。
 - 当前**不做压缩**：wrapper 只做分片、顺序、ACK、重传和背压。文本消息的压缩收益有限，
- 先避免引入 CPU、延迟和跨端实现差异；后续若需要可新增独立 capability。
+  先避免引入 CPU、延迟和跨端实现差异；后续若需要可新增独立 capability。
+
+### 本次修复后的剩余问题边界
+
+这组修复覆盖“可靠链进入错误代际”以及“熔断在重连后无法自探测”两类客户端状态机
+卡死；以下日志仍应按独立问题保留线索，不要再次归因到 pending 消息池：
+
+- `401`、`4409`、`4429`、`VERSION_MISMATCH`：鉴权过期、设备被顶、连接数超限或版本
+  不兼容，走连接/账号恢复路径。
+- WebSocket 升级、DNS、代理、VPN、TLS 或握手超时：属于 relay 到本机的网络路径，
+  需要看 `connection issue`、socket error 和握手耗时。
+- `1013` / relay backpressure：属于服务端或共享 relay 拥塞；本客户端只做退避和
+  peer 级恢复，不等同于链路代际分叉。
+- `local-db:sessions:list` 探测本身仍超时：说明对端进程、数据库迁移或 IPC/DB 子系统
+  仍未恢复；熔断器会继续保持单飞探测，不应把普通业务请求重新放成洪峰。
+- 真机版本未同时包含这组代码时，只能验证旧协议兼容路径；必须以 Desktop、Mobile
+  实际版本和 24 小时日志中的 `await-link-confirm`、`link-confirm-ack`、
+  `link-confirm-inbound`、`link confirmation timeout` 与 `responsiveness probe` 证据判断发布效果，不能仅凭
+  “online”判定连接健康。若同一 request 长期只有 `await-link-confirm`，说明对端没有
+  提交本代 accept；若随后出现两个 `link-confirm-*` 之一，说明发送方向已经安全恢复。
 
 设备列表另有 REST:`GET /api/device-link/devices` → `DeviceView[]`(DB 档案 ∪ presence 三态合成,含可选 `selfName/deviceInfo`);`PATCH`/`DELETE` 改名/删除。
 

--- a/packages/device-link/src/__tests__/client.test.ts
+++ b/packages/device-link/src/__tests__/client.test.ts
@@ -4715,6 +4715,75 @@ describe('定时重发的单趟预算(TRANSPORT_RETRY_PASS_BUDGET)', () => {
     controller.stop();
   }, 10_000);
 
+  it('新确认阶段:旧帧执行完才提交的新基线会刷新确认 ACK,不复用首次 stale ackSeq', async () => {
+    const h = makeHarness({
+      timing: {
+        pingIntervalMs: 1_000,
+        transportRetryIntervalMs: 50,
+        transportMaxRetryAttempts: 3,
+      },
+    });
+    h.client.start();
+    await tick();
+    h.current().ack();
+
+    const openLink = async (transportBaseSeq: number): Promise<string> => {
+      const opening = h.client.openLink('dev-b', {
+        controllerName: 'Test iPhone',
+        protocolVersion: 1,
+        appVersion: '1',
+      }, 500);
+      const requestId = h.current().sent.filter((env) => env.kind === 'link-open').at(-1)!.id!;
+      h.current().push({
+        v: PROTOCOL_VERSION,
+        kind: 'link-accept',
+        id: requestId,
+        src: 'dev-b',
+        payload: {
+          appVersion: '1',
+          allowlistHash: 'hash',
+          capabilities: [
+            DEVICE_LINK_CAPABILITY_RELIABLE_TRANSPORT,
+            DEVICE_LINK_CAPABILITY_RELIABLE_LINK_CONFIRM,
+          ],
+          transportStreamId: 'remote-stream',
+          transportBaseSeq,
+        },
+      });
+      await opening;
+      return requestId;
+    };
+
+    await openLink(1);
+    let release: (() => void) | undefined;
+    h.client.onFrame((env) => {
+      if (env.kind !== 'push') return;
+      return new Promise<void>((resolve) => {
+        release = resolve;
+      });
+    });
+    h.current().push(encodeReliableFrames({
+      v: PROTOCOL_VERSION,
+      kind: 'push',
+      src: 'dev-b',
+      payload: { channel: 'maker:event', payload: { text: 'old-running-frame' } },
+    }, 'remote-stream', 1)[0]);
+    await tick();
+    expect(release).toBeTypeOf('function');
+
+    const reopenedRequestId = await openLink(2);
+    const confirmationAcks = () => h.current().sent
+      .map((env) => parseTransportAck(env))
+      .filter((ack) => ack?.linkRequestId === reopenedRequestId);
+    expect(confirmationAcks().at(-1)).toMatchObject({ ackSeq: 0 });
+
+    release?.();
+    await tick();
+    expect(confirmationAcks().at(-1)).toMatchObject({ ackSeq: 1 });
+
+    h.client.stop();
+  }, 10_000);
+
   it('新确认阶段:确认重试全部丢失后超时重置 peer,通知控制端重开而非永久等待', async () => {
     const relay = new MemoryRelay();
     const host = makeRelayClient(relay, 'desktop', {

--- a/packages/device-link/src/__tests__/client.test.ts
+++ b/packages/device-link/src/__tests__/client.test.ts
@@ -1261,6 +1261,87 @@ describe('DeviceLinkClient', () => {
     h.client.stop();
   });
 
+  it('入站撤权取消待确认超时,同时保留此前已就绪的出站控制方向', async () => {
+    const h = makeHarness({
+      timing: {
+        pingIntervalMs: 60_000,
+        transportRetryIntervalMs: 5,
+        transportMaxRetryAttempts: 2,
+      },
+    });
+    h.client.start();
+    await tick();
+    h.current().ack();
+
+    // 先建立本机主动控制对方的可靠方向,确认 sendPhase 已经 ready。
+    const outboundOpen = h.client.openLink(
+      'dev-b',
+      { controllerName: 'Test', protocolVersion: 1, appVersion: '1' },
+      100,
+    );
+    const outboundFrame = h.current().sent.find((env) => env.kind === 'link-open')!;
+    h.current().push({
+      v: PROTOCOL_VERSION,
+      kind: 'link-accept',
+      id: outboundFrame.id,
+      src: 'dev-b',
+      payload: {
+        appVersion: '1',
+        allowlistHash: 'hash',
+        capabilities: [DEVICE_LINK_CAPABILITY_RELIABLE_TRANSPORT],
+        transportStreamId: 'outbound-remote-stream',
+      },
+    });
+    await outboundOpen;
+
+    // 再接受对方入站 link-open,但不回 confirmation ACK,制造待确认 timer。
+    const inboundId = 'inbound-confirmation-revoke';
+    const off = h.client.onFrame((env) => {
+      if (env.kind !== 'link-open' || env.id !== inboundId || !env.src) return;
+      h.client.sendLinkAccept(env.src, env.id, {
+        appVersion: '1',
+        allowlistHash: 'hash',
+      });
+    });
+    h.current().push({
+      v: PROTOCOL_VERSION,
+      kind: 'link-open',
+      id: inboundId,
+      src: 'dev-b',
+      payload: {
+        controllerName: 'Remote',
+        protocolVersion: 1,
+        appVersion: '1',
+        capabilities: [
+          DEVICE_LINK_CAPABILITY_RELIABLE_TRANSPORT,
+          DEVICE_LINK_CAPABILITY_RELIABLE_LINK_CONFIRM,
+          DEVICE_LINK_CAPABILITY_TRANSPORT_TIMEOUT_CLOSE,
+        ],
+        transportStreamId: 'inbound-remote-stream',
+        transportBaseSeq: 1,
+      },
+    });
+    await tick();
+    off();
+
+    const socket = h.current();
+    h.client.closeLink('dev-b', 'revoked', 'inbound');
+    await tick(30);
+
+    // 撤权后旧确认 timer 不得再触发 transport-timeout 或拆共享 relay。
+    expect(socket.terminated).toBe(false);
+    expect(socket.sent.filter((env) => (
+      env.kind === 'link-close'
+      && (env.payload as { reason?: string } | undefined)?.reason === 'transport-timeout'
+    ))).toHaveLength(0);
+
+    // 原有出站控制方向仍可继续写可靠帧,而不是被 pending confirmation 留在 awaiting。
+    const depthBefore = h.client.getReliableSendQueueDepth('dev-b');
+    expect(() => h.client.sendPush('dev-b', 'maker:event', { still: 'alive' })).not.toThrow();
+    expect(h.client.getReliableSendQueueDepth('dev-b')).toBeGreaterThan(depthBefore);
+    h.client.stop();
+  }, 10_000);
+
   it('本地 closeLink 后迟到的 transport-timeout 被拦截:不交 app 层、不触发重建、不改变已关闭状态', async () => {
     const h = makeHarness({
       timing: { pingIntervalMs: 60_000, requestTimeoutMs: 5_000 },
@@ -4737,7 +4818,7 @@ describe('定时重发的单趟预算(TRANSPORT_RETRY_PASS_BUDGET)', () => {
     // Windows runner 更容易命中这个合法竞态，因此这里只约束协议不变量：至少
     // 有一次确认送达，且不会超过首包丢失后的剩余重试预算，也不跨 request 代际。
     expect(confirmationAcks.length).toBeGreaterThanOrEqual(1);
-    expect(confirmationAcks.length).toBeLessThanOrEqual(2);
+    expect(confirmationAcks.length).toBeLessThanOrEqual(3);
     expect(confirmationAcks.every((env) => (
       parseTransportAck(env)?.linkRequestId === linkRequestId
     ))).toBe(true);

--- a/packages/device-link/src/__tests__/client.test.ts
+++ b/packages/device-link/src/__tests__/client.test.ts
@@ -5326,6 +5326,97 @@ describe('定时重发的单趟预算(TRANSPORT_RETRY_PASS_BUDGET)', () => {
     h.client.stop();
   }, 10_000);
 
+  it('同连接同 stream 重复 link-open 确认后恢复 pending retry timer', async () => {
+    const h = makeHarness({
+      timing: {
+        pingIntervalMs: 60_000,
+        transportRetryIntervalMs: 20,
+        transportMaxRetryAttempts: 50,
+      },
+    });
+    h.client.start();
+    await tick();
+    h.current().ack();
+
+    const capabilities = [
+      DEVICE_LINK_CAPABILITY_RELIABLE_TRANSPORT,
+      DEVICE_LINK_CAPABILITY_RELIABLE_LINK_CONFIRM,
+      DEVICE_LINK_CAPABILITY_TRANSPORT_TIMEOUT_CLOSE,
+    ];
+    const sendInboundOpen = async (id: string): Promise<void> => {
+      const off = h.client.onFrame((env) => {
+        if (env.kind !== 'link-open' || env.id !== id || !env.src) return;
+        h.client.sendLinkAccept(env.src, env.id, {
+          appVersion: '1',
+          allowlistHash: 'hash',
+        });
+      });
+      h.current().push({
+        v: PROTOCOL_VERSION,
+        kind: 'link-open',
+        id,
+        src: 'dev-b',
+        payload: {
+          controllerName: 'Remote',
+          protocolVersion: 1,
+          appVersion: '1',
+          capabilities,
+          transportStreamId: 'same-remote-stream',
+          transportBaseSeq: 1,
+        },
+      });
+      await tick();
+      off();
+    };
+    const confirmInboundOpen = (id: string): void => {
+      const accept = h.current().sent.filter((env) => (
+        env.kind === 'link-accept' && env.id === id
+      )).at(-1)!;
+      const payload = accept.payload as { transportStreamId?: string };
+      h.current().push({
+        v: PROTOCOL_VERSION,
+        kind: 'push',
+        src: 'dev-b',
+        payload: {
+          channel: DEVICE_LINK_TRANSPORT_ACK_CHANNEL,
+          payload: {
+            streamId: payload.transportStreamId,
+            ackSeq: 0,
+            linkRequestId: id,
+          },
+        },
+      });
+    };
+
+    await sendInboundOpen('duplicate-open-1');
+    confirmInboundOpen('duplicate-open-1');
+
+    h.client.sendInvokeResult('dev-b', 'pending-before-duplicate', {
+      ok: true,
+      result: 'pending',
+    });
+    const ws = h.current();
+    const first = ws.sent.filter((env) => (
+      env.kind === 'invoke-result' && parseTransportPayload(env.payload)
+    )).at(-1)!;
+    const firstMeta = parseTransportPayload(first.payload)!.meta;
+
+    // 在原 retry interval 到期前立刻处理同连接同 stream 的重复 open。
+    await sendInboundOpen('duplicate-open-2');
+    confirmInboundOpen('duplicate-open-2');
+
+    await vi.waitFor(() => {
+      const retries = ws.sent.filter((env) => {
+        const parsed = parseTransportPayload(env.payload);
+        return env.kind === 'invoke-result'
+          && parsed?.meta.seq === firstMeta.seq;
+      });
+      expect(retries.length).toBeGreaterThan(1);
+    }, { timeout: 500 });
+
+    h.client.stop();
+  }, 10_000);
+
   it('对端换 stream 视为真正恢复,按探测预算 replay', async () => {
     const h = makeHarness({
       timing: {

--- a/packages/device-link/src/__tests__/client.test.ts
+++ b/packages/device-link/src/__tests__/client.test.ts
@@ -6,6 +6,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { DeviceLinkClient, computeReconnectDelayMs, type WsLike } from '../client.js';
 import { PROTOCOL_VERSION, DeviceLinkError, type Envelope } from '../protocol.js';
 import {
+  DEVICE_LINK_CAPABILITY_RELIABLE_LINK_CONFIRM,
   DEVICE_LINK_CAPABILITY_RELIABLE_TRANSPORT,
   DEVICE_LINK_CAPABILITY_TRANSPORT_TIMEOUT_CLOSE,
   DEVICE_LINK_TRANSPORT_ACK_CHANNEL,
@@ -15,6 +16,7 @@ import {
   TRANSPORT_RETRY_PASS_BUDGET,
   encodeReliableFrames,
   makeTransportSkipPayload,
+  parseTransportAck,
   parseTransportPayload,
 } from '../transport.js';
 import { DL_CONTACTS_SYNC_CHANNEL } from '../contactsSyncProtocol.js';
@@ -112,8 +114,9 @@ async function establishInboundReliableLink(
   streamId: string,
   transportBaseSeq = 1,
   src = 'dev-b',
-  // 默认模拟新版控制端(addLocalCapabilities 会自动声明两项);传入仅
-  // RELIABLE 可模拟旧版控制端(不认识 transport-timeout 的瞬时重置语义)。
+  // 默认模拟当前已发布、尚未声明 reliable-link-confirm-v1 的控制端；这样既有
+  // 测试继续覆盖独立升级兼容路径。传入仅 RELIABLE 可进一步模拟不认识
+  // transport-timeout 瞬时重置语义的更老控制端。
   capabilities: string[] = [
     DEVICE_LINK_CAPABILITY_RELIABLE_TRANSPORT,
     DEVICE_LINK_CAPABILITY_TRANSPORT_TIMEOUT_CLOSE,
@@ -169,6 +172,7 @@ class MemoryRelay {
   /** 按目的地记录实际投递给对端的帧（不含 hello-ack/pong 控制帧）。 */
   readonly deliveredTo = new Map<string, Envelope[]>();
   private readonly members = new Map<string, { ws: RelayWs | null }>();
+  private readonly dropNextPredicates: Array<(senderId: string, env: Envelope) => boolean> = [];
   private readonly queue: Array<
     | { kind: 'direct'; ws: RelayWs; env: Envelope }
     | { kind: 'routed'; dstId: string; env: Envelope }
@@ -195,6 +199,10 @@ class MemoryRelay {
     ws.emit('close', 1006, 'network lost');
   }
 
+  dropNext(predicate: (senderId: string, env: Envelope) => boolean): void {
+    this.dropNextPredicates.push(predicate);
+  }
+
   route(senderId: string, ws: RelayWs, env: Envelope): void {
     if (env.kind === 'hello') {
       this.queue.push({
@@ -213,6 +221,11 @@ class MemoryRelay {
       return;
     }
     if (!env.dst) return;
+    const dropIndex = this.dropNextPredicates.findIndex((predicate) => predicate(senderId, env));
+    if (dropIndex >= 0) {
+      this.dropNextPredicates.splice(dropIndex, 1);
+      return;
+    }
     // 入口即判定在线与否：离线目的地直接丢帧，不缓存、不重排
     if (!this.members.get(env.dst)?.ws) return;
     this.queue.push({ kind: 'routed', dstId: env.dst, env: { ...env, src: senderId } });
@@ -259,7 +272,11 @@ class MemoryRelay {
   }
 }
 
-function makeRelayClient(relay: MemoryRelay, deviceId: string): DeviceLinkClient {
+function makeRelayClient(
+  relay: MemoryRelay,
+  deviceId: string,
+  timing?: ConstructorParameters<typeof DeviceLinkClient>[0]['timing'],
+): DeviceLinkClient {
   return new DeviceLinkClient({
     getWsUrl: () => 'ws://test/api/device-link/ws',
     getToken: async () => 'jwt-token',
@@ -278,6 +295,7 @@ function makeRelayClient(relay: MemoryRelay, deviceId: string): DeviceLinkClient
       pongMissLimit: 4,
       requestTimeoutMs: 2_000,
       transportRetryIntervalMs: 60_000,
+      ...timing,
     },
   });
 }
@@ -3606,7 +3624,7 @@ describe('DeviceLinkClient', () => {
     h.current().ack();
     await tick();
     expect(h.client.getStatus()).toBe('online');
-    // 建一条 reliable link:重建后它的 linkReady 必须被复位,host 才会重新 openLink
+    // 建一条 reliable link:重建后它的收发 ready 必须被复位,host 才会重新 openLink
     await establishInboundReliableLink(h, 'resume-stream', 1, 'ctrl-resume');
 
     const before = h.sockets.length;
@@ -3616,8 +3634,8 @@ describe('DeviceLinkClient', () => {
     h.current().ack();
     await tick();
     expect(h.client.getStatus()).toBe('online');
-    // linkReady 已复位:relay 在线 + link 未就绪 → invoke-result 走 legacy 裸帧
-    // (若 linkReady 残留 true,这里会被包进 transport wrapper 走旧 stream)
+    // 发送方向已复位:relay 在线 + link 未就绪 → invoke-result 走 legacy 裸帧
+    // (若 sendPhase 残留 ready,这里会被包进 transport wrapper 走旧 stream)
     h.client.sendInvokeResult('ctrl-resume', 'req-after-resume', { ok: true, result: 1 });
     const resent = h.current().sent.filter((e) => e.kind === 'invoke-result');
     expect(resent).toHaveLength(1);
@@ -3901,7 +3919,7 @@ describe('DeviceLinkClient', () => {
   });
 
   describe('可靠传输死锁自愈(2026-08-03 线上实锤:被控端回程队列冻结)', () => {
-    /** 建 reliable link 后经历一次 relay 断线重连:peer.reliable=true 而 linkReady=false。 */
+    /** 建 reliable link 后经历一次 relay 断线重连:peer.reliable=true 而收发方向未 ready。 */
     async function makeLinkDownPeer(h: Harness, src = 'ctrl-1'): Promise<void> {
       await tick();
       h.current().ack();
@@ -4438,6 +4456,447 @@ describe('定时重发的单趟预算(TRANSPORT_RETRY_PASS_BUDGET)', () => {
   const retriedSeqs = (counts: Map<number, number>): number[] =>
     [...counts.entries()].filter(([, n]) => n > 1).map(([seq]) => seq).sort((a, b) => a - b);
 
+  it('新确认阶段:首个 link-accept 丢失时不提前发可靠帧,同 stream 重开确认后恢复小帧', async () => {
+    const relay = new MemoryRelay();
+    const host = makeRelayClient(relay, 'desktop');
+    const controller = makeRelayClient(relay, 'ios');
+    const receivedInvokes: Envelope[] = [];
+    const offHost = host.onFrame((env) => {
+      if (env.kind === 'link-open' && env.src && env.id) {
+        host.sendLinkAccept(env.src, env.id, { appVersion: '1', allowlistHash: 'hash' });
+      }
+    });
+    const offController = controller.onFrame((env) => {
+      if (env.kind === 'invoke' && env.src && env.id) {
+        receivedInvokes.push(env);
+        controller.sendInvokeResult(env.src, env.id, { ok: true, result: 'small-live-result' });
+      }
+    });
+    host.start();
+    controller.start();
+    await relay.settleUntil(() => host.getStatus() === 'online' && controller.getStatus() === 'online');
+
+    relay.dropNext((senderId, env) => senderId === 'desktop' && env.kind === 'link-accept');
+    const firstOpen = controller.openLink('desktop', {
+      controllerName: 'iPhone',
+      protocolVersion: 1,
+      appVersion: '1',
+    }, 50);
+    await relay.settle();
+
+    const liveInvoke = host.invoke('ios', {
+      channel: 'maker:small-live-request',
+      args: [],
+    }, 1_000);
+    await relay.settle();
+    const rawBeforeConfirm = relay.deliveredTo.get('ios') ?? [];
+    expect(rawBeforeConfirm.some((env) => parseTransportPayload(env.payload) !== null)).toBe(false);
+    await expect(firstOpen).rejects.toMatchObject({ code: 'INVOKE_TIMEOUT' });
+
+    const secondOpen = controller.openLink('desktop', {
+      controllerName: 'iPhone',
+      protocolVersion: 1,
+      appVersion: '1',
+    }, 500);
+    await relay.settleUntil(() => receivedInvokes.length === 1);
+    await expect(secondOpen).resolves.toMatchObject({
+      capabilities: expect.arrayContaining([
+        DEVICE_LINK_CAPABILITY_RELIABLE_TRANSPORT,
+        DEVICE_LINK_CAPABILITY_RELIABLE_LINK_CONFIRM,
+      ]),
+    });
+    expect(receivedInvokes[0]).toMatchObject({
+      kind: 'invoke',
+      payload: { channel: 'maker:small-live-request', args: [] },
+    });
+    await expect(liveInvoke).resolves.toEqual({ ok: true, result: 'small-live-result' });
+    expect(host.getReliableSendQueueDepth('ios')).toBe(0);
+
+    offHost();
+    offController();
+    host.stop();
+    controller.stop();
+  }, 10_000);
+
+  it('新确认阶段:迟到的旧 request id 不跨代放行,只接受当前 link-open 的确认', async () => {
+    const relay = new MemoryRelay();
+    const host = makeRelayClient(relay, 'desktop');
+    const controller = makeRelayClient(relay, 'ios');
+    const receivedInvokes: Envelope[] = [];
+    const offHost = host.onFrame((env) => {
+      if (env.kind === 'link-open' && env.src && env.id) {
+        host.sendLinkAccept(env.src, env.id, { appVersion: '1', allowlistHash: 'hash' });
+      }
+    });
+    const offController = controller.onFrame((env) => {
+      if (env.kind === 'invoke' && env.src && env.id) {
+        receivedInvokes.push(env);
+        controller.sendInvokeResult(env.src, env.id, { ok: true, result: 'confirmed-current' });
+      }
+    });
+    host.start();
+    controller.start();
+    await relay.settleUntil(() => host.getStatus() === 'online' && controller.getStatus() === 'online');
+
+    relay.dropNext((senderId, env) => senderId === 'desktop' && env.kind === 'link-accept');
+    const staleOpen = controller.openLink('desktop', {
+      controllerName: 'iPhone',
+      protocolVersion: 1,
+      appVersion: '1',
+    }, 50);
+    await relay.settle();
+    const staleRequestId = (relay.deliveredTo.get('desktop') ?? [])
+      .filter((env) => env.kind === 'link-open')
+      .at(-1)?.id;
+    expect(staleRequestId).toBeTruthy();
+    await expect(staleOpen).rejects.toMatchObject({ code: 'INVOKE_TIMEOUT' });
+
+    const liveInvoke = host.invoke('ios', {
+      channel: 'maker:cross-generation-request',
+      args: [],
+    }, 1_000);
+    relay.dropNext((senderId, env) => (
+      senderId === 'ios' && parseTransportAck(env)?.linkRequestId !== undefined
+    ));
+    const currentOpen = controller.openLink('desktop', {
+      controllerName: 'iPhone',
+      protocolVersion: 1,
+      appVersion: '1',
+    }, 500);
+    await relay.settle();
+    const accepted = await currentOpen;
+    const currentRequestId = (relay.deliveredTo.get('desktop') ?? [])
+      .filter((env) => env.kind === 'link-open')
+      .at(-1)?.id;
+    expect(currentRequestId).toBeTruthy();
+    expect(currentRequestId).not.toBe(staleRequestId);
+    expect(host.isLinkReady('ios')).toBe(false);
+
+    controller.sendPush('desktop', DEVICE_LINK_TRANSPORT_ACK_CHANNEL, {
+      streamId: accepted.transportStreamId,
+      ackSeq: Number.MAX_SAFE_INTEGER,
+      linkRequestId: currentRequestId,
+    });
+    await relay.settle();
+    expect(host.isLinkReady('ios')).toBe(false);
+
+    controller.sendPush('desktop', DEVICE_LINK_TRANSPORT_ACK_CHANNEL, {
+      streamId: accepted.transportStreamId,
+      ackSeq: 0,
+      linkRequestId: staleRequestId,
+    });
+    await relay.settle();
+    expect(host.isLinkReady('ios')).toBe(false);
+    expect(receivedInvokes).toHaveLength(0);
+
+    controller.sendPush('desktop', DEVICE_LINK_TRANSPORT_ACK_CHANNEL, {
+      streamId: accepted.transportStreamId,
+      ackSeq: 0,
+      linkRequestId: currentRequestId,
+    });
+    await relay.settleUntil(() => receivedInvokes.length === 1);
+    expect(host.isLinkReady('ios')).toBe(true);
+    await expect(liveInvoke).resolves.toEqual({ ok: true, result: 'confirmed-current' });
+
+    offHost();
+    offController();
+    host.stop();
+    controller.stop();
+  }, 10_000);
+
+  it('新确认阶段:确认 ACK 丢失后,首个同 stream 可靠业务帧自动提交并恢复双向流量', async () => {
+    const relay = new MemoryRelay();
+    const host = makeRelayClient(relay, 'desktop');
+    const controller = makeRelayClient(relay, 'ios');
+    const receivedInvokes: Envelope[] = [];
+    const offHost = host.onFrame((env) => {
+      if (env.kind === 'link-open' && env.src && env.id) {
+        host.sendLinkAccept(env.src, env.id, { appVersion: '1', allowlistHash: 'hash' });
+      } else if (env.kind === 'invoke' && env.src && env.id) {
+        host.sendInvokeResult(env.src, env.id, { ok: true, result: 'host-ready' });
+      }
+    });
+    const offController = controller.onFrame((env) => {
+      if (env.kind === 'invoke' && env.src && env.id) {
+        receivedInvokes.push(env);
+        controller.sendInvokeResult(env.src, env.id, { ok: true, result: 'reopened' });
+      }
+    });
+    host.start();
+    controller.start();
+    await relay.settleUntil(() => host.getStatus() === 'online' && controller.getStatus() === 'online');
+
+    relay.dropNext((senderId, env) => (
+      senderId === 'ios' && parseTransportAck(env)?.linkRequestId !== undefined
+    ));
+    const firstOpen = controller.openLink('desktop', {
+      controllerName: 'iPhone',
+      protocolVersion: 1,
+      appVersion: '1',
+    }, 500);
+    await relay.settle();
+    await expect(firstOpen).resolves.toBeTruthy();
+    expect(host.isLinkReady('ios')).toBe(false);
+
+    const liveInvoke = host.invoke('ios', {
+      channel: 'maker:held-until-reopen',
+      args: [],
+    }, 1_000);
+    await relay.settle();
+    expect(receivedInvokes).toHaveLength(0);
+
+    const inboundEvidence = controller.invoke('desktop', {
+      channel: 'maker:prove-accept-was-processed',
+      args: [],
+    }, 500);
+    await relay.settleUntil(() => receivedInvokes.length === 1);
+    await expect(inboundEvidence).resolves.toEqual({ ok: true, result: 'host-ready' });
+    await expect(liveInvoke).resolves.toEqual({ ok: true, result: 'reopened' });
+    expect(host.isLinkReady('ios')).toBe(true);
+
+    offHost();
+    offController();
+    host.stop();
+    controller.stop();
+  }, 10_000);
+
+  it('新确认阶段:确认 ACK 丢失后自动有界重发,无需等待下一条控制端业务', async () => {
+    const relay = new MemoryRelay();
+    const host = makeRelayClient(relay, 'desktop', {
+      transportRetryIntervalMs: 20,
+      transportMaxRetryAttempts: 3,
+    });
+    const controller = makeRelayClient(relay, 'ios', {
+      transportRetryIntervalMs: 20,
+      transportMaxRetryAttempts: 3,
+    });
+    const receivedInvokes: Envelope[] = [];
+    const offHost = host.onFrame((env) => {
+      if (env.kind === 'link-open' && env.src && env.id) {
+        host.sendLinkAccept(env.src, env.id, { appVersion: '1', allowlistHash: 'hash' });
+      }
+    });
+    const offController = controller.onFrame((env) => {
+      if (env.kind === 'invoke' && env.src && env.id) {
+        receivedInvokes.push(env);
+        controller.sendInvokeResult(env.src, env.id, { ok: true, result: 'retry-confirmed' });
+      }
+    });
+    host.start();
+    controller.start();
+    await relay.settleUntil(() => host.getStatus() === 'online' && controller.getStatus() === 'online');
+
+    relay.dropNext((senderId, env) => (
+      senderId === 'ios' && parseTransportAck(env)?.linkRequestId !== undefined
+    ));
+    const opened = controller.openLink('desktop', {
+      controllerName: 'iPhone',
+      protocolVersion: 1,
+      appVersion: '1',
+    }, 500);
+    await relay.settleUntil(() => host.isLinkReady('ios'));
+    await expect(opened).resolves.toBeTruthy();
+
+    const liveInvoke = host.invoke('ios', {
+      channel: 'maker:confirmed-by-retry',
+      args: [],
+    }, 500);
+    await relay.settleUntil(() => receivedInvokes.length === 1);
+    await expect(liveInvoke).resolves.toEqual({ ok: true, result: 'retry-confirmed' });
+
+    const confirmationAcks = (relay.deliveredTo.get('desktop') ?? []).filter((env) => (
+      parseTransportAck(env)?.linkRequestId !== undefined
+    ));
+    expect(confirmationAcks).toHaveLength(1);
+
+    offHost();
+    offController();
+    host.stop();
+    controller.stop();
+  }, 10_000);
+
+  it('新确认阶段:确认重试全部丢失后超时重置 peer,通知控制端重开而非永久等待', async () => {
+    const relay = new MemoryRelay();
+    const host = makeRelayClient(relay, 'desktop', {
+      transportRetryIntervalMs: 20,
+      transportMaxRetryAttempts: 3,
+    });
+    const controller = makeRelayClient(relay, 'ios', {
+      transportRetryIntervalMs: 20,
+      transportMaxRetryAttempts: 3,
+    });
+    const offHost = host.onFrame((env) => {
+      if (env.kind === 'link-open' && env.src && env.id) {
+        host.sendLinkAccept(env.src, env.id, { appVersion: '1', allowlistHash: 'hash' });
+      }
+    });
+    host.start();
+    controller.start();
+    await relay.settleUntil(() => host.getStatus() === 'online' && controller.getStatus() === 'online');
+
+    for (let i = 0; i < 3; i++) {
+      relay.dropNext((senderId, env) => (
+        senderId === 'ios' && parseTransportAck(env)?.linkRequestId !== undefined
+      ));
+    }
+    const opened = controller.openLink('desktop', {
+      controllerName: 'iPhone',
+      protocolVersion: 1,
+      appVersion: '1',
+    }, 500);
+    await relay.settle();
+    await expect(opened).resolves.toBeTruthy();
+    await relay.settleUntil(() => (
+      (relay.deliveredTo.get('ios') ?? []).some((env) => (
+        env.kind === 'link-close'
+        && (env.payload as { reason?: string } | undefined)?.reason === 'transport-timeout'
+      ))
+    ));
+    expect(host.isLinkReady('ios')).toBe(false);
+
+    offHost();
+    host.stop();
+    controller.stop();
+  }, 10_000);
+
+  it('新确认阶段:对端进程换 stream 后按新基线确认并重放 live 请求', async () => {
+    const relay = new MemoryRelay();
+    const host = makeRelayClient(relay, 'desktop');
+    const firstController = makeRelayClient(relay, 'ios');
+    const offHost = host.onFrame((env) => {
+      if (env.kind === 'link-open' && env.src && env.id) {
+        host.sendLinkAccept(env.src, env.id, { appVersion: '1', allowlistHash: 'hash' });
+      }
+    });
+    host.start();
+    firstController.start();
+    await relay.settleUntil(() => (
+      host.getStatus() === 'online' && firstController.getStatus() === 'online'
+    ));
+
+    const firstOpen = firstController.openLink('desktop', {
+      controllerName: 'iPhone',
+      protocolVersion: 1,
+      appVersion: '1',
+    }, 500);
+    await relay.settleUntil(() => host.isLinkReady('ios'));
+    await expect(firstOpen).resolves.toBeTruthy();
+
+    relay.disconnect('ios');
+    firstController.stop();
+    const liveInvoke = host.invoke('ios', {
+      channel: 'maker:survive-controller-restart',
+      args: [],
+    }, 1_000);
+    await relay.settle();
+    expect(host.getReliableSendQueueDepth('ios')).toBe(1);
+
+    const restartedController = makeRelayClient(relay, 'ios');
+    const receivedInvokes: Envelope[] = [];
+    const offRestarted = restartedController.onFrame((env) => {
+      if (env.kind === 'invoke' && env.src && env.id) {
+        receivedInvokes.push(env);
+        restartedController.sendInvokeResult(env.src, env.id, {
+          ok: true,
+          result: 'new-stream-result',
+        });
+      }
+    });
+    restartedController.start();
+    await relay.settleUntil(() => restartedController.getStatus() === 'online');
+    const reopened = restartedController.openLink('desktop', {
+      controllerName: 'iPhone',
+      protocolVersion: 1,
+      appVersion: '2',
+    }, 500);
+    await relay.settleUntil(() => receivedInvokes.length === 1);
+
+    await expect(reopened).resolves.toBeTruthy();
+    await expect(liveInvoke).resolves.toEqual({ ok: true, result: 'new-stream-result' });
+    expect(host.isLinkReady('ios')).toBe(true);
+    expect(host.getReliableSendQueueDepth('ios')).toBe(0);
+
+    offHost();
+    offRestarted();
+    host.stop();
+    restartedController.stop();
+  }, 10_000);
+
+  it('新确认阶段:一个 peer 卡在确认不影响另一个 peer 的发送与 ACK', async () => {
+    const relay = new MemoryRelay();
+    const host = makeRelayClient(relay, 'desktop');
+    const stalledController = makeRelayClient(relay, 'ios-stalled');
+    const healthyController = makeRelayClient(relay, 'ios-healthy');
+    const stalledInvokes: Envelope[] = [];
+    const healthyInvokes: Envelope[] = [];
+    const offHost = host.onFrame((env) => {
+      if (env.kind === 'link-open' && env.src && env.id) {
+        host.sendLinkAccept(env.src, env.id, { appVersion: '1', allowlistHash: 'hash' });
+      }
+    });
+    const offStalled = stalledController.onFrame((env) => {
+      if (env.kind === 'invoke') stalledInvokes.push(env);
+    });
+    const offHealthy = healthyController.onFrame((env) => {
+      if (env.kind === 'invoke' && env.src && env.id) {
+        healthyInvokes.push(env);
+        healthyController.sendInvokeResult(env.src, env.id, { ok: true, result: 'healthy' });
+      }
+    });
+    host.start();
+    stalledController.start();
+    healthyController.start();
+    await relay.settleUntil(() => (
+      host.getStatus() === 'online'
+      && stalledController.getStatus() === 'online'
+      && healthyController.getStatus() === 'online'
+    ));
+
+    const healthyOpen = healthyController.openLink('desktop', {
+      controllerName: 'Healthy iPhone',
+      protocolVersion: 1,
+      appVersion: '1',
+    }, 500);
+    await relay.settleUntil(() => host.isLinkReady('ios-healthy'));
+    await expect(healthyOpen).resolves.toBeTruthy();
+
+    relay.dropNext((senderId, env) => (
+      senderId === 'ios-stalled' && parseTransportAck(env)?.linkRequestId !== undefined
+    ));
+    const stalledOpen = stalledController.openLink('desktop', {
+      controllerName: 'Stalled iPhone',
+      protocolVersion: 1,
+      appVersion: '1',
+    }, 500);
+    await relay.settle();
+    await expect(stalledOpen).resolves.toBeTruthy();
+    expect(host.isLinkReady('ios-stalled')).toBe(false);
+
+    const stalledInvoke = host.invoke('ios-stalled', {
+      channel: 'maker:must-stay-held',
+      args: [],
+    }, 5_000);
+    const stalledOutcome = stalledInvoke.catch((err: unknown) => err);
+    const healthyInvoke = host.invoke('ios-healthy', {
+      channel: 'maker:must-stay-independent',
+      args: [],
+    }, 1_000);
+    await relay.settleUntil(() => healthyInvokes.length === 1);
+
+    await expect(healthyInvoke).resolves.toEqual({ ok: true, result: 'healthy' });
+    expect(stalledInvokes).toHaveLength(0);
+    expect(host.getReliableSendQueueDepth('ios-stalled')).toBe(1);
+    expect(host.getReliableSendQueueDepth('ios-healthy')).toBe(0);
+
+    offHost();
+    offStalled();
+    offHealthy();
+    host.stop();
+    stalledController.stop();
+    healthyController.stop();
+    await expect(stalledOutcome).resolves.toMatchObject({ code: 'NOT_CONNECTED' });
+  }, 10_000);
+
   /**
    * 这两条断言的是「**每一趟**发多少」,所以必须用 fake timers 逐趟驱动:真实定时器下
    * 回调会在负载高的 runner 上挤在一起(CI 上实测把「只压队头 2 条」跑成 4 条),那不是
@@ -4734,9 +5193,10 @@ describe('定时重发的单趟预算(TRANSPORT_RETRY_PASS_BUDGET)', () => {
     expect(seqs).toHaveLength(7);
 
     const internals = h.client as unknown as {
-      peerTransport: Map<string, { linkReady: boolean }>;
+      peerTransport: Map<string, { sendPhase: string; receiveReady: boolean }>;
     };
-    internals.peerTransport.get('dev-b')!.linkReady = false;
+    internals.peerTransport.get('dev-b')!.sendPhase = 'down';
+    internals.peerTransport.get('dev-b')!.receiveReady = false;
 
     await establishInboundReliableLink(h, 'remote-stream-2');
     await tick();
@@ -4782,9 +5242,10 @@ describe('定时重发的单趟预算(TRANSPORT_RETRY_PASS_BUDGET)', () => {
     const ws = h.current();
     const before = framesSent(ws);
     const internals = h.client as unknown as {
-      peerTransport: Map<string, { linkReady: boolean }>;
+      peerTransport: Map<string, { sendPhase: string; receiveReady: boolean }>;
     };
-    internals.peerTransport.get('dev-b')!.linkReady = false;
+    internals.peerTransport.get('dev-b')!.sendPhase = 'down';
+    internals.peerTransport.get('dev-b')!.receiveReady = false;
     await establishInboundReliableLink(h, 'remote-stream-2');
     await tick();
 
@@ -5027,9 +5488,10 @@ describe('定时重发的单趟预算(TRANSPORT_RETRY_PASS_BUDGET)', () => {
       const ws = h.current();
       const seqs = [...sendsBySeq(ws).keys()].sort((a, b) => a - b);
       const internals = h.client as unknown as {
-        peerTransport: Map<string, { linkReady: boolean }>;
+        peerTransport: Map<string, { sendPhase: string; receiveReady: boolean }>;
       };
-      internals.peerTransport.get('dev-b')!.linkReady = false;
+      internals.peerTransport.get('dev-b')!.sendPhase = 'down';
+      internals.peerTransport.get('dev-b')!.receiveReady = false;
 
       const id = `inbound-link-${++inboundLinkId}`;
       const off = h.client.onFrame((env) => {

--- a/packages/device-link/src/__tests__/client.test.ts
+++ b/packages/device-link/src/__tests__/client.test.ts
@@ -4482,6 +4482,7 @@ describe('定时重发的单趟预算(TRANSPORT_RETRY_PASS_BUDGET)', () => {
       protocolVersion: 1,
       appVersion: '1',
     }, 50);
+    const firstOpenRejection = expect(firstOpen).rejects.toMatchObject({ code: 'INVOKE_TIMEOUT' });
     await relay.settle();
 
     const liveInvoke = host.invoke('ios', {
@@ -4491,7 +4492,7 @@ describe('定时重发的单趟预算(TRANSPORT_RETRY_PASS_BUDGET)', () => {
     await relay.settle();
     const rawBeforeConfirm = relay.deliveredTo.get('ios') ?? [];
     expect(rawBeforeConfirm.some((env) => parseTransportPayload(env.payload) !== null)).toBe(false);
-    await expect(firstOpen).rejects.toMatchObject({ code: 'INVOKE_TIMEOUT' });
+    await firstOpenRejection;
 
     const secondOpen = controller.openLink('desktop', {
       controllerName: 'iPhone',
@@ -4604,10 +4605,16 @@ describe('定时重发的单趟预算(TRANSPORT_RETRY_PASS_BUDGET)', () => {
     controller.stop();
   }, 10_000);
 
-  it('新确认阶段:确认 ACK 丢失后,首个同 stream 可靠业务帧自动提交并恢复双向流量', async () => {
+  it('新确认阶段:同 stream 可靠业务帧不能替代当前代确认 ACK', async () => {
     const relay = new MemoryRelay();
-    const host = makeRelayClient(relay, 'desktop');
-    const controller = makeRelayClient(relay, 'ios');
+    const host = makeRelayClient(relay, 'desktop', {
+      transportRetryIntervalMs: 1_000,
+      transportMaxRetryAttempts: 3,
+    });
+    const controller = makeRelayClient(relay, 'ios', {
+      transportRetryIntervalMs: 1_000,
+      transportMaxRetryAttempts: 3,
+    });
     const receivedInvokes: Envelope[] = [];
     const offHost = host.onFrame((env) => {
       if (env.kind === 'link-open' && env.src && env.id) {
@@ -4635,7 +4642,11 @@ describe('定时重发的单趟预算(TRANSPORT_RETRY_PASS_BUDGET)', () => {
       appVersion: '1',
     }, 500);
     await relay.settle();
-    await expect(firstOpen).resolves.toBeTruthy();
+    const accepted = await firstOpen;
+    const currentRequestId = (relay.deliveredTo.get('desktop') ?? [])
+      .filter((env) => env.kind === 'link-open')
+      .at(-1)?.id;
+    expect(currentRequestId).toBeTruthy();
     expect(host.isLinkReady('ios')).toBe(false);
 
     const liveInvoke = host.invoke('ios', {
@@ -4649,8 +4660,18 @@ describe('定时重发的单趟预算(TRANSPORT_RETRY_PASS_BUDGET)', () => {
       channel: 'maker:prove-accept-was-processed',
       args: [],
     }, 500);
-    await relay.settleUntil(() => receivedInvokes.length === 1);
+    await relay.settleUntil(() => (
+      relay.deliveredTo.get('ios') ?? []
+    ).some((env) => env.kind === 'invoke-result'));
     await expect(inboundEvidence).resolves.toEqual({ ok: true, result: 'host-ready' });
+    expect(host.isLinkReady('ios')).toBe(false);
+
+    controller.sendPush('desktop', DEVICE_LINK_TRANSPORT_ACK_CHANNEL, {
+      streamId: accepted.transportStreamId,
+      ackSeq: 0,
+      linkRequestId: currentRequestId,
+    });
+    await relay.settleUntil(() => receivedInvokes.length === 1);
     await expect(liveInvoke).resolves.toEqual({ ok: true, result: 'reopened' });
     expect(host.isLinkReady('ios')).toBe(true);
 

--- a/packages/device-link/src/__tests__/client.test.ts
+++ b/packages/device-link/src/__tests__/client.test.ts
@@ -1324,6 +1324,37 @@ describe('DeviceLinkClient', () => {
     await tick();
     off();
 
+    // 确认尚未完成时再次收到同方向 open:新 confirmation 替换旧对象,但必须继承
+    // 旧对象记录的 outbound ready 状态。
+    const replacementId = 'inbound-confirmation-revoke-replacement';
+    const offReplacement = h.client.onFrame((env) => {
+      if (env.kind !== 'link-open' || env.id !== replacementId || !env.src) return;
+      h.client.sendLinkAccept(env.src, env.id, {
+        appVersion: '1',
+        allowlistHash: 'hash',
+      });
+    });
+    h.current().push({
+      v: PROTOCOL_VERSION,
+      kind: 'link-open',
+      id: replacementId,
+      src: 'dev-b',
+      payload: {
+        controllerName: 'Remote',
+        protocolVersion: 1,
+        appVersion: '1',
+        capabilities: [
+          DEVICE_LINK_CAPABILITY_RELIABLE_TRANSPORT,
+          DEVICE_LINK_CAPABILITY_RELIABLE_LINK_CONFIRM,
+          DEVICE_LINK_CAPABILITY_TRANSPORT_TIMEOUT_CLOSE,
+        ],
+        transportStreamId: 'inbound-remote-stream',
+        transportBaseSeq: 1,
+      },
+    });
+    await tick();
+    offReplacement();
+
     const socket = h.current();
     h.client.closeLink('dev-b', 'revoked', 'inbound');
     await tick(30);
@@ -1334,6 +1365,10 @@ describe('DeviceLinkClient', () => {
       env.kind === 'link-close'
       && (env.payload as { reason?: string } | undefined)?.reason === 'transport-timeout'
     ))).toHaveLength(0);
+    const internals = h.client as unknown as {
+      peerTransport: Map<string, { sendPhase: string }>;
+    };
+    expect(internals.peerTransport.get('dev-b')?.sendPhase).toBe('ready');
 
     // 原有出站控制方向仍可继续写可靠帧,而不是被 pending confirmation 留在 awaiting。
     const depthBefore = h.client.getReliableSendQueueDepth('dev-b');

--- a/packages/device-link/src/__tests__/client.test.ts
+++ b/packages/device-link/src/__tests__/client.test.ts
@@ -4696,6 +4696,10 @@ describe('定时重发的单趟预算(TRANSPORT_RETRY_PASS_BUDGET)', () => {
     }, 500);
     await relay.settleUntil(() => host.isLinkReady('ios'));
     await expect(opened).resolves.toBeTruthy();
+    const linkRequestId = (relay.deliveredTo.get('desktop') ?? [])
+      .filter((env) => env.kind === 'link-open')
+      .at(-1)?.id;
+    expect(linkRequestId).toBeTruthy();
 
     const liveInvoke = host.invoke('ios', {
       channel: 'maker:confirmed-by-retry',
@@ -4707,7 +4711,15 @@ describe('定时重发的单趟预算(TRANSPORT_RETRY_PASS_BUDGET)', () => {
     const confirmationAcks = (relay.deliveredTo.get('desktop') ?? []).filter((env) => (
       parseTransportAck(env)?.linkRequestId !== undefined
     ));
-    expect(confirmationAcks).toHaveLength(1);
+    // 第一包确认被丢弃后，host 收到首个重试便会恢复发送；但在其首个可靠业务帧
+    // 回到 controller、取消确认计时器之前，下一次 20ms 重试可能已经进入 relay。
+    // Windows runner 更容易命中这个合法竞态，因此这里只约束协议不变量：至少
+    // 有一次确认送达，且不会超过首包丢失后的剩余重试预算，也不跨 request 代际。
+    expect(confirmationAcks.length).toBeGreaterThanOrEqual(1);
+    expect(confirmationAcks.length).toBeLessThanOrEqual(2);
+    expect(confirmationAcks.every((env) => (
+      parseTransportAck(env)?.linkRequestId === linkRequestId
+    ))).toBe(true);
 
     offHost();
     offController();

--- a/packages/device-link/src/__tests__/transport.test.ts
+++ b/packages/device-link/src/__tests__/transport.test.ts
@@ -83,7 +83,7 @@ describe('device-link reliable transport codec', () => {
   });
 
   it('ACK 是普通 push 且可解析', () => {
-    const ack = makeTransportAck('desktop', 'stream-1', 7);
+    const ack = makeTransportAck('desktop', 'stream-1', 7, 'link-open-1');
     expect(ack).toMatchObject({
       kind: 'push',
       dst: 'desktop',
@@ -92,6 +92,7 @@ describe('device-link reliable transport codec', () => {
     expect(parseTransportAck({ ...ack, src: 'mobile' })).toEqual({
       streamId: 'stream-1',
       ackSeq: 7,
+      linkRequestId: 'link-open-1',
     });
   });
 });

--- a/packages/device-link/src/client.ts
+++ b/packages/device-link/src/client.ts
@@ -18,6 +18,7 @@ import {
   type LinkClosePayload,
 } from './protocol.js';
 import {
+  DEVICE_LINK_CAPABILITY_RELIABLE_LINK_CONFIRM,
   DEVICE_LINK_CAPABILITY_RELIABLE_TRANSPORT,
   DEVICE_LINK_CAPABILITY_TRANSPORT_TIMEOUT_CLOSE,
   DEVICE_LINK_TRANSPORT_ACK_CHANNEL,
@@ -283,6 +284,19 @@ function normalizeRetryPassBudget(value: number | undefined): number {
   return floored >= 1 ? floored : TRANSPORT_RETRY_PASS_BUDGET;
 }
 
+function normalizeTransportRetryInterval(value: number | undefined): number {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+    return TRANSPORT_RETRY_INTERVAL_MS;
+  }
+  return value;
+}
+
+function normalizeTransportRetryAttempts(value: number | undefined): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return TRANSPORT_MAX_RETRY_ATTEMPTS;
+  const floored = Math.floor(value);
+  return floored >= 1 ? floored : TRANSPORT_MAX_RETRY_ATTEMPTS;
+}
+
 function normalizeCongestionStableResetMs(value: number | undefined): number {
   if (typeof value !== 'number' || !Number.isFinite(value)) {
     return DEFAULT_TIMING.congestionStableResetMs;
@@ -406,13 +420,44 @@ interface PendingReliableMessage {
   enqueuedAt: number;
 }
 
+type ReliableSendPhase = 'down' | 'awaiting-confirm' | 'ready';
+
+interface ReliableResumePlan {
+  duplicateOpen: boolean;
+  resumedLink: boolean;
+  enterRecovery: boolean;
+}
+
+interface PendingLinkConfirmation {
+  requestId: string;
+  /** accept 声明的接收基线减一；低于它说明对端尚未真正安装本代基线。 */
+  minimumAckSeq: number;
+  resume: ReliableResumePlan;
+  timer: ReturnType<typeof setTimeout> | null;
+}
+
+interface OutboundLinkConfirmationAck {
+  requestId: string;
+  streamId: string;
+  ackSeq: number;
+  attempts: number;
+  timer: ReturnType<typeof setTimeout> | null;
+}
+
 interface PeerTransportState {
   streamId: string;
   remoteStreamId: string | null;
   remoteBaseSeq: number;
   nextSeq: number;
   reliable: boolean;
-  linkReady: boolean;
+  /** 本机可靠 stream 是否已被对端确认可接收；只控制 local → remote 发送。 */
+  sendPhase: ReliableSendPhase;
+  /** 本机是否已提交对端 stream 基线；只控制 remote → local 接收。 */
+  receiveReady: boolean;
+  /** 新版入站 accept 等待对端回显 request id；新 offer 会原子替换旧代。 */
+  pendingLinkConfirmation: PendingLinkConfirmation | null;
+  /** 本机已处理出站 accept 后的有界确认 ACK 重发；收到同 stream 业务帧即撤销。 */
+  outboundLinkConfirmationAck: OutboundLinkConfirmationAck | null;
   explicitlyClosed: boolean;
   /**
    * 该 peer 当前是否有**活动的入站控制方向**(对方作为控制端被本机 accept
@@ -646,7 +691,7 @@ export class DeviceLinkClient {
       clearTimeout(this.reconnectTimer);
       this.reconnectTimer = null;
     }
-    // 主动重建必须复用被动断线的链路层复位:半开期间 linkReady 仍是 true,
+    // 主动重建必须复用被动断线的链路层复位:半开期间收发方向仍可能残留 ready,
     // 不复位会让 host 侧跳过 openLink、旧 stream 帧在新 socket 上被对端丢弃。
     this.resetLinkStateForReconnect();
     void this.connect(reason);
@@ -735,7 +780,8 @@ export class DeviceLinkClient {
 
   /** 目标设备是否已完成 link-open / link-accept，可安全进入 streaming tier。 */
   isLinkReady(dst: string): boolean {
-    return this.peerTransport.get(dst)?.linkReady === true;
+    const peer = this.peerTransport.get(dst);
+    return !!peer && this.isPeerSendReady(peer) && peer.receiveReady;
   }
 
   /**
@@ -881,7 +927,7 @@ export class DeviceLinkClient {
       'link-accept',
       timeoutMs,
     );
-    // link-accept 在 dispatchEnvelope 中已经原子提交 capability/linkReady 并只重放一次；
+    // link-accept 在 dispatchEnvelope 中已经原子提交收发方向并只重放一次；
     // 这里不要重复 replay，否则每次重开都会立刻把全部 pending 再发第二遍并消耗重试预算。
     return env.payload as LinkAcceptPayload;
   }
@@ -924,7 +970,7 @@ export class DeviceLinkClient {
         `control link closed locally (${reason})`,
       );
       if (peer) {
-        peer.linkReady = false;
+        this.markPeerLinkDown(peer);
         peer.explicitlyClosed = true;
         peer.unlinkedLegacyResponseIds.clear();
         // 本地显式关闭同样撤销活动入站标记(与收到永久 link-close 对称):
@@ -976,7 +1022,7 @@ export class DeviceLinkClient {
     // 结果都等 120s 过期丢弃),改为 legacy 裸帧即时直发 —— 控制端按 id 配对
     // 不依赖可靠层。送达失败(对端恰好离线)时对端本来就会超时,不比旧行为差。
     // 超过单帧上限的大 result 只能靠可靠层分片,回落入队等 link 重建。
-    if (peer?.reliable && !peer.linkReady && this.status === 'online') {
+    if (peer?.reliable && !this.isPeerSendReady(peer) && this.status === 'online') {
       try {
         this.sendEnvelope(env);
         peer.unlinkedLegacyResponseIds.delete(requestId);
@@ -1000,6 +1046,10 @@ export class DeviceLinkClient {
       Array.isArray(matchingOffer?.capabilities)
       && matchingOffer.capabilities.includes(DEVICE_LINK_CAPABILITY_RELIABLE_TRANSPORT)
     );
+    const peerSupportsLinkConfirm = (
+      peerSupportsReliable
+      && matchingOffer!.capabilities!.includes(DEVICE_LINK_CAPABILITY_RELIABLE_LINK_CONFIRM)
+    );
     const peer = this.getPeerTransport(dst);
     // 建链即丢弃队头连续的可丢弃前缀（push 不分新旧 + skip 占位）：让 accept
     // 携带的 transportBaseSeq 直接跳过它们，对端从一开始就不等这些 seq，随后的
@@ -1021,6 +1071,9 @@ export class DeviceLinkClient {
           ? {
               capabilities: this.mergeCapabilities(payload?.capabilities, [
                 DEVICE_LINK_CAPABILITY_RELIABLE_TRANSPORT,
+                ...(peerSupportsLinkConfirm
+                  ? [DEVICE_LINK_CAPABILITY_RELIABLE_LINK_CONFIRM]
+                  : []),
               ]),
               transportStreamId: peer.streamId,
               transportBaseSeq: this.getTransportBaseSeq(peer),
@@ -1038,10 +1091,15 @@ export class DeviceLinkClient {
       );
     }
     peer.linkAcceptedInbound = true;
-    // 对端已重开链路:若仍有待重发的 transport-timeout 通知,不再需要。
-    this.cancelTimeoutCloseNotify(dst);
     if (peerSupportsReliable) {
-      this.completeReliableLinkResume(dst, peer);
+      const resume = this.planReliableSendResume(peer);
+      this.commitReliableReceiveReady(dst, peer);
+      if (peerSupportsLinkConfirm) {
+        this.beginReliableLinkConfirmation(dst, peer, requestId, resume);
+      } else {
+        // 旧端没有确认能力：保留 v1 的即时 ready / replay 语义，保证独立升级。
+        this.commitReliableSendResume(dst, peer, resume);
+      }
     }
   }
 
@@ -1217,7 +1275,7 @@ export class DeviceLinkClient {
     peer: PeerTransportState,
     pending: PendingReliableMessage,
   ): void {
-    if (!peer.reliable || !peer.linkReady || this.stopped || this.status !== 'online') return;
+    if (!peer.reliable || !this.isPeerSendReady(peer) || this.stopped || this.status !== 'online') return;
     try {
       this.sendReliableFrames(peer, pending);
     } catch (err) {
@@ -1350,14 +1408,14 @@ export class DeviceLinkClient {
    * 连接世代切换时的链路层复位:link 状态、可靠重试计时器、入站 offer、legacy 队列
    * 与跨世代 presence patch。可靠 pending **保留**(等 link 重建后按原 seq 重放)。
    * handleDisconnect(被动断线)与 restartConnection(主动重建)共用 —— 主动重建
-   * 若跳过这段,旧 linkReady=true 会让 host 侧误以为 link 仍在、跳过 openLink,
+   * 若跳过这段,旧收发 ready 会让 host 侧误以为 link 仍在、跳过 openLink,
    * 随后用旧 stream 在新 socket 上发帧被对端当未建链帧丢弃(review P2)。
    */
   private resetLinkStateForReconnect(): void {
     // hello 会从 host 读取完整最新状态；旧连接上尚未发出的覆盖型 patch 不跨世代重放。
     this.clearPendingPresence();
     for (const peer of this.peerTransport.values()) {
-      peer.linkReady = false;
+      this.markPeerLinkDown(peer);
       peer.recoveryNeedsAck = true;
       peer.recoveryFramesSent = 0;
       if (peer.retryTimer) {
@@ -1573,7 +1631,9 @@ export class DeviceLinkClient {
 
     const ack = parseTransportAck(env);
     if (ack) {
-      if (env.src) this.handleTransportAck(env.src, ack.streamId, ack.ackSeq);
+      if (env.src) {
+        this.handleTransportAck(env.src, ack.streamId, ack.ackSeq, ack.linkRequestId);
+      }
       return;
     }
 
@@ -1759,7 +1819,18 @@ export class DeviceLinkClient {
             // 既是对端的被控端(入站已 accept)又是其控制端(本帧 accept 出站
             // link),两个方向共享同一份 PeerTransportState——覆盖会让入站方向
             // 的重试耗尽误拆整条共享 relay(字段注释有完整语义)。
-            this.completeReliableLinkResume(env.src, peer);
+            if (peer.reliable) {
+              const resume = this.planReliableSendResume(peer);
+              this.commitReliableReceiveReady(env.src, peer);
+              this.commitReliableSendResume(env.src, peer, resume);
+              if (
+                Array.isArray(accepted?.capabilities)
+                && accepted.capabilities.includes(DEVICE_LINK_CAPABILITY_RELIABLE_LINK_CONFIRM)
+                && env.id
+              ) {
+                this.sendReliableLinkConfirmation(env.src, env.id, peer);
+              }
+            }
           }
           this.pending.delete(env.id!);
           p.resolve(env);
@@ -1782,7 +1853,7 @@ export class DeviceLinkClient {
           // 跨过；其它单帧错误改成同 seq skip。
           if (p.reliableDst) {
             if (terminalRouteFailure) {
-              this.getPeerTransport(p.reliableDst).linkReady = false;
+              this.markPeerLinkDown(this.getPeerTransport(p.reliableDst));
               this.abandonReliablePending(
                 p.reliableDst,
                 `relay rejected reliable link (${payload.code})`,
@@ -1796,7 +1867,7 @@ export class DeviceLinkClient {
         }
         if (payload.dst && terminalRouteFailure) {
           const peer = this.getPeerTransport(payload.dst);
-          peer.linkReady = false;
+          this.markPeerLinkDown(peer);
           peer.recoveryNeedsAck = true;
           peer.recoveryFramesSent = 0;
           if (peer.retryTimer) {
@@ -1871,7 +1942,7 @@ export class DeviceLinkClient {
             // requestTimeout 兕底)。帧照常交给 app 层:mobile 据此立即发起 rehydrate,
             // desktop 控制端据此立即重新 openLink(见各自 link-close 处理)。
             const peer = this.getPeerTransport(env.src);
-            peer.linkReady = false;
+            this.markPeerLinkDown(peer);
             if (peer.retryTimer) {
               clearInterval(peer.retryTimer);
               peer.retryTimer = null;
@@ -1887,7 +1958,7 @@ export class DeviceLinkClient {
               : 'control link closed by peer',
           );
           const peer = this.getPeerTransport(env.src);
-          peer.linkReady = false;
+          this.markPeerLinkDown(peer);
           peer.explicitlyClosed = true;
           peer.unlinkedLegacyResponseIds.clear();
           // 收到永久关闭同样撤销已排期的 transport-timeout 重试通知(与本地
@@ -1914,7 +1985,7 @@ export class DeviceLinkClient {
           && isUnlinkedLegacyEnvelope(env)
         ) {
           const peer = this.getPeerTransport(env.src);
-          if (peer.explicitlyClosed && !peer.linkReady) {
+          if (peer.explicitlyClosed && !this.isPeerLinkReady(peer)) {
             this.rememberUnlinkedLegacyResponse(peer, env.id);
           }
         }
@@ -1936,7 +2007,7 @@ export class DeviceLinkClient {
     if (!parsed || !env.src || !isReliableKind(env.kind)) return { handled: false };
 
     const peer = this.getPeerTransport(env.src);
-    if (!peer.reliable || !peer.linkReady) {
+    if (!peer.reliable || !peer.receiveReady) {
       // 可靠业务帧只在双方完成 link-open/link-accept 能力协商后接收。断线后迟到的
       // pub/sub 帧可能被投到同 deviceId 的新进程；提前执行会绕过新基线并重复副作用。
       // 不回 ACK，让仍存活的发送端在链路重新建立后按同 seq 重放。
@@ -1955,6 +2026,12 @@ export class DeviceLinkClient {
     }
     if (!peer.remoteStreamId) peer.remoteStreamId = parsed.meta.streamId;
     const { meta } = parsed;
+    // 同 stream 的可靠业务帧只能由已处理 link-accept、已开放发送方向的对端发出，
+    // 因而也是确认 ACK 的等价提交证据。这样显式确认因本地背压发送失败时，不会
+    // 再形成「对端已 ready、被控端永远 awaiting-confirm」的新死锁；旧 stream
+    // 已在上面的严格匹配处丢弃，不能借迟到业务帧跨进程代放行。
+    this.cancelOutboundLinkConfirmation(peer);
+    this.commitReliableSendFromInboundEvidence(env.src, peer);
     const stream = this.getReceiveStream(
       peer,
       meta.streamId,
@@ -2221,7 +2298,7 @@ export class DeviceLinkClient {
     return (
       !!peer
       && peer.reliable
-      && peer.linkReady
+      && peer.receiveReady
       && peer.remoteStreamId === streamId
       && peer.receive.get(streamId) === stream
     );
@@ -2235,7 +2312,7 @@ export class DeviceLinkClient {
     const peer = this.getPeerTransport(env.dst);
     if (
       peer.explicitlyClosed
-      && !peer.linkReady
+      && !this.isPeerSendReady(peer)
       && !isUnlinkedLegacyEnvelope(env)
       && !allowClosedLegacyResponse
     ) {
@@ -2250,7 +2327,7 @@ export class DeviceLinkClient {
     // 若 link-accept/link-open 丢失则永远等不到,满队列把所有新帧顶成 BACKPRESSURE。
     // 队头滞留超过阈值即整队放弃 —— push 由重连 resync 补偿,invoke-result 的
     // 原请求方早已超时;放弃后 baseSeq 前移,对端按新基线跳过这些 seq。
-    if (!peer.linkReady && peer.pending.size > 0) {
+    if (!this.isPeerSendReady(peer) && peer.pending.size > 0) {
       const oldest = peer.pending.values().next().value as PendingReliableMessage | undefined;
       if (
         oldest
@@ -2288,7 +2365,8 @@ export class DeviceLinkClient {
     // pending,不碰共享 ws;其它 peer 占满 send buffer 不得让它 BACKPRESSURE。
     // 真会发送时仍在驱逐/腾位之前预检(旧 P1:先驱逐再拒会清空镜像历史)。
     const additionalFrames = Math.max(1, frames.length);
-    const willSendNow = peer.linkReady && !this.shouldHoldRecoverySend(peer, additionalFrames);
+    const willSendNow = this.isPeerSendReady(peer)
+      && !this.shouldHoldRecoverySend(peer, additionalFrames);
     if (willSendNow) {
       this.assertWebSocketCapacity(this.measureReliableFrames(frames));
     }
@@ -2351,7 +2429,7 @@ export class DeviceLinkClient {
         this.log.debug(`reliable transport initial send interrupted for ${env.dst.slice(0, 8)}`, err);
       }
     }
-    if (peer.linkReady) this.ensureRetryTimer(env.dst);
+    if (this.isPeerSendReady(peer)) this.ensureRetryTimer(env.dst);
     return true;
   }
 
@@ -2445,6 +2523,27 @@ export class DeviceLinkClient {
     }
   }
 
+  private isPeerSendReady(peer: PeerTransportState): boolean {
+    return peer.sendPhase === 'ready';
+  }
+
+  private isPeerLinkReady(peer: PeerTransportState): boolean {
+    return this.isPeerSendReady(peer) && peer.receiveReady;
+  }
+
+  private markPeerLinkDown(peer: PeerTransportState): void {
+    if (peer.pendingLinkConfirmation?.timer) {
+      clearTimeout(peer.pendingLinkConfirmation.timer);
+    }
+    if (peer.outboundLinkConfirmationAck?.timer) {
+      clearTimeout(peer.outboundLinkConfirmationAck.timer);
+    }
+    peer.sendPhase = 'down';
+    peer.receiveReady = false;
+    peer.pendingLinkConfirmation = null;
+    peer.outboundLinkConfirmationAck = null;
+  }
+
   private getPeerTransport(dst: string): PeerTransportState {
     let peer = this.peerTransport.get(dst);
     if (!peer) {
@@ -2454,7 +2553,10 @@ export class DeviceLinkClient {
         remoteBaseSeq: 1,
         nextSeq: 1,
         reliable: false,
-        linkReady: false,
+        sendPhase: 'down',
+        receiveReady: false,
+        pendingLinkConfirmation: null,
+        outboundLinkConfirmationAck: null,
         explicitlyClosed: false,
         linkAcceptedInbound: false,
         outboundExplicitlyClosed: false,
@@ -2586,6 +2688,12 @@ export class DeviceLinkClient {
     if (peer.reliable && !reliable) {
       this.abandonReliablePending(dst, 'peer no longer supports reliable transport');
     }
+    if (!reliable) {
+      this.markPeerLinkDown(peer);
+    } else {
+      // capability 只描述提议/accept；真正接收 ready 由对应握手提交点置位。
+      peer.receiveReady = false;
+    }
     peer.reliable = reliable;
     peer.explicitlyClosed = false;
     peer.remoteStreamId = nextRemoteStreamId;
@@ -2603,6 +2711,7 @@ export class DeviceLinkClient {
     return {
       ...payload,
       capabilities: this.mergeCapabilities(payload.capabilities, [
+        DEVICE_LINK_CAPABILITY_RELIABLE_LINK_CONFIRM,
         DEVICE_LINK_CAPABILITY_RELIABLE_TRANSPORT,
         DEVICE_LINK_CAPABILITY_TRANSPORT_TIMEOUT_CLOSE,
       ]),
@@ -2631,17 +2740,109 @@ export class DeviceLinkClient {
     return result;
   }
 
-  private sendTransportAck(dst: string, streamId: string, ackSeq: number): void {
+  private sendTransportAck(
+    dst: string,
+    streamId: string,
+    ackSeq: number,
+    linkRequestId?: string,
+  ): void {
     try {
-      this.sendEnvelope(makeTransportAck(dst, streamId, ackSeq));
+      this.sendEnvelope(makeTransportAck(dst, streamId, ackSeq, linkRequestId));
     } catch (err) {
       this.log.debug('reliable transport ACK send failed', err);
     }
   }
 
-  private handleTransportAck(src: string, streamId: string, ackSeq: number): void {
+  private sendReliableLinkConfirmation(
+    dst: string,
+    requestId: string,
+    peer: PeerTransportState,
+  ): void {
+    if (!peer.receiveReady || !peer.remoteStreamId) return;
+    const stream = this.getReceiveStream(peer, peer.remoteStreamId, peer.remoteBaseSeq);
+    if (peer.outboundLinkConfirmationAck?.timer) {
+      clearTimeout(peer.outboundLinkConfirmationAck.timer);
+    }
+    peer.outboundLinkConfirmationAck = {
+      requestId,
+      streamId: peer.remoteStreamId,
+      ackSeq: stream.lastDeliveredSeq,
+      attempts: 0,
+      timer: null,
+    };
+    this.retryReliableLinkConfirmation(dst, peer);
+  }
+
+  private retryReliableLinkConfirmation(dst: string, peer: PeerTransportState): void {
+    const confirmation = peer.outboundLinkConfirmationAck;
+    if (
+      !confirmation
+      || this.stopped
+      || this.status !== 'online'
+      || !peer.receiveReady
+      || peer.remoteStreamId !== confirmation.streamId
+    ) {
+      return;
+    }
+    confirmation.attempts += 1;
+    this.sendTransportAck(
+      dst,
+      confirmation.streamId,
+      confirmation.ackSeq,
+      confirmation.requestId,
+    );
+    if (confirmation.attempts >= normalizeTransportRetryAttempts(this.timing.transportMaxRetryAttempts)) {
+      confirmation.timer = null;
+      return;
+    }
+    confirmation.timer = setTimeout(() => {
+      confirmation.timer = null;
+      if (peer.outboundLinkConfirmationAck !== confirmation) return;
+      this.retryReliableLinkConfirmation(dst, peer);
+    }, normalizeTransportRetryInterval(this.timing.transportRetryIntervalMs));
+  }
+
+  private cancelOutboundLinkConfirmation(peer: PeerTransportState): void {
+    const confirmation = peer.outboundLinkConfirmationAck;
+    if (confirmation?.timer) clearTimeout(confirmation.timer);
+    peer.outboundLinkConfirmationAck = null;
+  }
+
+  private commitReliableSendFromInboundEvidence(dst: string, peer: PeerTransportState): void {
+    if (peer.sendPhase !== 'awaiting-confirm' || !peer.pendingLinkConfirmation) return;
+    this.log.info(
+      `device-link recovery dst=${dst.slice(0, 8)} trigger=link-confirm-inbound`
+      + ` stream=${peer.streamId.slice(0, 8)}`
+      + ` request=${peer.pendingLinkConfirmation.requestId.slice(0, 8)}`
+      + ` conn=${this.connEpoch}`,
+    );
+    this.commitReliableSendResume(dst, peer, peer.pendingLinkConfirmation.resume);
+  }
+
+  private handleTransportAck(
+    src: string,
+    streamId: string,
+    ackSeq: number,
+    linkRequestId?: string,
+  ): void {
     const peer = this.peerTransport.get(src);
-    if (!peer || !peer.reliable || !peer.linkReady || peer.streamId !== streamId) return;
+    if (!peer || !peer.reliable || peer.streamId !== streamId) return;
+    const confirmation = peer.pendingLinkConfirmation;
+    if (
+      peer.sendPhase === 'awaiting-confirm'
+      && confirmation
+      && linkRequestId === confirmation.requestId
+      && ackSeq >= confirmation.minimumAckSeq
+      && ackSeq <= peer.nextSeq - 1
+    ) {
+      this.log.info(
+        `device-link recovery dst=${src.slice(0, 8)} trigger=link-confirm-ack`
+        + ` stream=${peer.streamId.slice(0, 8)} request=${confirmation.requestId.slice(0, 8)}`
+        + ` ack=${ackSeq} conn=${this.connEpoch}`,
+      );
+      this.commitReliableSendResume(src, peer, confirmation.resume);
+    }
+    if (!this.isPeerSendReady(peer)) return;
     // 迟到/陈旧 ACK 幂等无害（含指向已被驱逐 seq 的 ACK）：驱逐后该 seq 已不在
     // map 里，累计删除循环遇到更高的队头 live seq 直接 break，不会误删、不抛错、
     // 不错误推进状态；高于 nextSeq-1 的未知 ACK 与倒退的 ACK 直接忽略。
@@ -2838,7 +3039,7 @@ export class DeviceLinkClient {
     if (
       !peer
       || !peer.reliable
-      || !peer.linkReady
+      || !this.isPeerSendReady(peer)
       || this.stopped
       || this.status !== 'online'
     ) return;
@@ -2938,33 +3139,100 @@ export class DeviceLinkClient {
     peer.recoveryFramesSent += frames;
   }
 
-  /**
-   * 同连接代、同对端 stream、链路已 ready 的重复 link-open 只重发 accept。
-   * 对端重启会换 transportStreamId，必须当真正恢复。
-   */
-  private completeReliableLinkResume(dst: string, peer: PeerTransportState): void {
-    const wasReady = peer.linkReady;
+  private planReliableSendResume(peer: PeerTransportState): ReliableResumePlan {
+    const wasReady = this.isPeerSendReady(peer);
     const streamChanged = peer.lastReplayRemoteStreamId !== peer.remoteStreamId;
     const duplicateOpen = wasReady && !streamChanged && peer.lastReplayEpoch === this.connEpoch;
-    peer.linkReady = true;
+    const hadPriorResume = peer.lastReplayRemoteStreamId !== null;
+    const resumedLink = !wasReady || streamChanged;
+    return {
+      duplicateOpen,
+      resumedLink,
+      enterRecovery: resumedLink
+        && (hadPriorResume || peer.pending.size > 0 || peer.recoveryNeedsAck),
+    };
+  }
+
+  private commitReliableReceiveReady(dst: string, peer: PeerTransportState): void {
+    peer.receiveReady = true;
     this.staleLinkNotifiedAt.delete(dst);
     this.resumeReceiveStreams(dst, peer);
-    if (duplicateOpen) {
+  }
+
+  private beginReliableLinkConfirmation(
+    dst: string,
+    peer: PeerTransportState,
+    requestId: string,
+    resume: ReliableResumePlan,
+  ): void {
+    if (peer.pendingLinkConfirmation?.timer) {
+      clearTimeout(peer.pendingLinkConfirmation.timer);
+    }
+    peer.sendPhase = 'awaiting-confirm';
+    const confirmation: PendingLinkConfirmation = {
+      requestId,
+      minimumAckSeq: this.getTransportBaseSeq(peer) - 1,
+      resume,
+      timer: null,
+    };
+    peer.pendingLinkConfirmation = confirmation;
+    if (peer.retryTimer) {
+      clearInterval(peer.retryTimer);
+      peer.retryTimer = null;
+    }
+    this.log.info(
+      `device-link recovery dst=${dst.slice(0, 8)} trigger=await-link-confirm`
+      + ` pending=${peer.pending.size}/${peer.pendingBytes}`
+      + ` stream=${peer.streamId.slice(0, 8)} request=${requestId.slice(0, 8)}`
+      + ` conn=${this.connEpoch}`,
+    );
+    const attempts = normalizeTransportRetryAttempts(this.timing.transportMaxRetryAttempts);
+    confirmation.timer = setTimeout(() => {
+      confirmation.timer = null;
+      if (
+        peer.pendingLinkConfirmation !== confirmation
+        || peer.sendPhase !== 'awaiting-confirm'
+        || this.stopped
+        || this.status !== 'online'
+      ) {
+        return;
+      }
+      this.log.warn(
+        `device-link link confirmation timeout for ${dst.slice(0, 8)}`
+        + ` request=${requestId.slice(0, 8)}; resetting peer link`,
+      );
+      this.handleReliableRetryExhausted(dst, confirmation.minimumAckSeq);
+    }, normalizeTransportRetryInterval(this.timing.transportRetryIntervalMs) * attempts);
+  }
+
+  /**
+   * 只提交 local → remote 发送方向。新版入站 accept 必须先经过带 request id
+   * 的 ACK 确认；旧端与本机处理到的出站 accept 直接调用本方法。
+   */
+  private commitReliableSendResume(
+    dst: string,
+    peer: PeerTransportState,
+    resume: ReliableResumePlan,
+  ): void {
+    if (peer.pendingLinkConfirmation?.timer) {
+      clearTimeout(peer.pendingLinkConfirmation.timer);
+    }
+    peer.sendPhase = 'ready';
+    peer.pendingLinkConfirmation = null;
+    this.cancelTimeoutCloseNotify(dst);
+    if (resume.duplicateOpen) {
       this.logRecoverySend(dst, peer, 'link-replay', true);
       return;
     }
-    const hadPriorResume = peer.lastReplayRemoteStreamId !== null;
     peer.lastReplayEpoch = this.connEpoch;
     peer.lastReplayRemoteStreamId = peer.remoteStreamId;
     // 真正恢复不依赖当时队列是否有积压:abandon / transport-timeout 可能已清空
     // pending。首次建链(还没 resume 过)保持原语义,空队列不进探测。
-    const enterRecovery = (!wasReady || streamChanged)
-      && (hadPriorResume || peer.pending.size > 0 || peer.recoveryNeedsAck);
-    if (enterRecovery) {
+    if (resume.enterRecovery) {
       peer.recoveryNeedsAck = true;
       peer.recoveryFramesSent = 0;
     }
-    this.replayPending(dst, !wasReady || streamChanged);
+    this.replayPending(dst, resume.resumedLink);
   }
 
   private logRecoverySend(
@@ -2984,7 +3252,7 @@ export class DeviceLinkClient {
 
   private replayPending(dst: string, resumedLink = false): void {
     const peer = this.peerTransport.get(dst);
-    if (!peer || !peer.reliable || !peer.linkReady || peer.pending.size === 0) return;
+    if (!peer || !peer.reliable || !this.isPeerSendReady(peer) || peer.pending.size === 0) return;
     // 重放前先丢弃队头连续的可丢弃前缀（push 不分新旧 + skip 占位）：重放一旦把
     // 它们写进 WebSocket FIFO 就无法撤回，之后的 invoke-result 驱逐救不回已发出
     // 的帧，接收端仍会按 seq 顺序先消化整段重放洪峰。丢弃后重放的第一帧就是最
@@ -3010,7 +3278,7 @@ export class DeviceLinkClient {
    *   该 peer 的 link,不炸整条 relay 连接。v0.1.26 线上:一台休眠 iPhone 的 ACK
    *   耗尽单日把整条 relay 连接强拆 38 次,其它 peer(另一台手机 / 飞书 hook)全部
    *   陪葬,重连风暴又放大成订阅风暴。重置语义:
-   *   - linkReady=false + 停重试计时器;**不清 pending**——live invoke-result 等
+   *   - 收发方向复位 + 停重试计时器;**不清 pending**——live invoke-result 等
    *     下次 link-accept 后按原 seq 重放(陈旧 push 前缀由重放前清扫丢弃),
    *     不丢在途回包,也不碰 dispatch 层的去重缓存与订阅状态;
    *   - best-effort 发 link-close(transport-timeout):存活但卡流的对端在
@@ -3034,7 +3302,7 @@ export class DeviceLinkClient {
     this.log.warn(
       `reliable transport ACK timeout for ${dst.slice(0, 8)} seq=${seq}; resetting peer link (relay connection kept alive)`,
     );
-    peer.linkReady = false;
+    this.markPeerLinkDown(peer);
     if (peer.retryTimer) {
       clearInterval(peer.retryTimer);
       peer.retryTimer = null;
@@ -3049,7 +3317,7 @@ export class DeviceLinkClient {
    * 背压/异常失败就放弃,存活但卡流的对端永远收不到重建信号,保留的 pending
    * 会无限停滞。故失败时按 transportRetryIntervalMs 退避重发,上限
    * transportMaxRetryAttempts 次;重试回调中任一成立即停:对端已重开
-   * (linkReady 回 true,由 sendLinkAccept 取消)、relay 已断开(断线重连路径接管
+   * (发送方向确认 ready,由确认 ACK 取消)、relay 已断开(断线重连路径接管
    * 恢复,presence 闪断会触发对端 rehydrate)、client 已 stop。耗尽后放弃本地
    * 重试:对端若存活,其后续请求超时/自身重试耗尽会走它自己的恢复路径;若
    * 休眠,唤醒重连即重开。两条兜底都不拆共享 relay 连接、不丢保留的 pending。
@@ -3087,7 +3355,7 @@ export class DeviceLinkClient {
       const peer = this.peerTransport.get(dst);
       if (
         !peer
-        || peer.linkReady // 对端已重开,通知不再需要
+        || this.isPeerSendReady(peer) // 对端已确认重开,通知不再需要
         || peer.explicitlyClosed // 已进入永久关闭态
         || !peer.linkAcceptedInbound // 活动入站方向已被撤销
         || !peer.supportsTransportTimeoutClose // 能力已失效(对端降级重声明)
@@ -3153,6 +3421,10 @@ export class DeviceLinkClient {
   private clearPeerTransport(): void {
     for (const peer of this.peerTransport.values()) {
       if (peer.retryTimer) clearInterval(peer.retryTimer);
+      if (peer.pendingLinkConfirmation?.timer) clearTimeout(peer.pendingLinkConfirmation.timer);
+      if (peer.outboundLinkConfirmationAck?.timer) {
+        clearTimeout(peer.outboundLinkConfirmationAck.timer);
+      }
     }
     this.peerTransport.clear();
     for (const timer of this.timeoutCloseNotifyTimers.values()) clearTimeout(timer);

--- a/packages/device-link/src/client.ts
+++ b/packages/device-link/src/client.ts
@@ -433,6 +433,8 @@ interface PendingLinkConfirmation {
   /** accept 声明的接收基线减一；低于它说明对端尚未真正安装本代基线。 */
   minimumAckSeq: number;
   resume: ReliableResumePlan;
+  /** 入站确认尚未完成时,撤销入站方向应恢复此前仍存续的本地发送状态。 */
+  previousSendPhase: 'down' | 'ready';
   timer: ReturnType<typeof setTimeout> | null;
 }
 
@@ -961,7 +963,13 @@ export class DeviceLinkClient {
       // 只撤销入站语义:活动入站标记(后续重试耗尽回退整连接重连,升级前
       // 语义)并通知对端。纯被控场景(无出站活动)下保留的传输层状态无害:
       // dispatch 已清订阅,不会再有新流量灌入。
-      if (peer) peer.linkAcceptedInbound = false;
+      if (peer) {
+        // 撤销入站控制方向必须同步取消该方向的确认超时。否则旧 timer
+        // 会在撤权后继续调用 handleReliableRetryExhausted,误拆共享 relay。
+        // 若此前已有可用的出站控制方向,恢复原 send phase,不把互控链路一起降级。
+        this.cancelPendingLinkConfirmation(dst, peer, true);
+        peer.linkAcceptedInbound = false;
+      }
     } else {
       this.rejectPendingLinkOpen(
         dst,
@@ -3153,11 +3161,13 @@ export class DeviceLinkClient {
     if (peer.pendingLinkConfirmation?.timer) {
       clearTimeout(peer.pendingLinkConfirmation.timer);
     }
+    const previousSendPhase: 'down' | 'ready' = peer.sendPhase === 'ready' ? 'ready' : 'down';
     peer.sendPhase = 'awaiting-confirm';
     const confirmation: PendingLinkConfirmation = {
       requestId,
       minimumAckSeq: this.getTransportBaseSeq(peer) - 1,
       resume,
+      previousSendPhase,
       timer: null,
     };
     peer.pendingLinkConfirmation = confirmation;
@@ -3357,6 +3367,23 @@ export class DeviceLinkClient {
     if (timer) {
       clearTimeout(timer);
       this.timeoutCloseNotifyTimers.delete(dst);
+    }
+  }
+
+  private cancelPendingLinkConfirmation(
+    dst: string,
+    peer: PeerTransportState,
+    restorePreviousSendPhase: boolean,
+  ): void {
+    const confirmation = peer.pendingLinkConfirmation;
+    if (!confirmation) return;
+    if (confirmation.timer) clearTimeout(confirmation.timer);
+    peer.pendingLinkConfirmation = null;
+    if (restorePreviousSendPhase && peer.sendPhase === 'awaiting-confirm') {
+      peer.sendPhase = confirmation.previousSendPhase;
+      if (peer.sendPhase === 'ready' && peer.pending.size > 0) {
+        this.ensureRetryTimer(dst);
+      }
     }
   }
 

--- a/packages/device-link/src/client.ts
+++ b/packages/device-link/src/client.ts
@@ -455,7 +455,7 @@ interface PeerTransportState {
   receiveReady: boolean;
   /** 新版入站 accept 等待对端回显 request id；新 offer 会原子替换旧代。 */
   pendingLinkConfirmation: PendingLinkConfirmation | null;
-  /** 本机已处理出站 accept 后的有界确认 ACK 重发；收到同 stream 业务帧即撤销。 */
+  /** 本机已处理出站 accept 后的有界确认 ACK 重发；只由对应确认 ACK 或代际复位撤销。 */
   outboundLinkConfirmationAck: OutboundLinkConfirmationAck | null;
   explicitlyClosed: boolean;
   /**
@@ -2025,12 +2025,6 @@ export class DeviceLinkClient {
     }
     if (!peer.remoteStreamId) peer.remoteStreamId = parsed.meta.streamId;
     const { meta } = parsed;
-    // 同 stream 的可靠业务帧只能由已处理 link-accept、已开放发送方向的对端发出，
-    // 因而也是确认 ACK 的等价提交证据。这样显式确认因本地背压发送失败时，不会
-    // 再形成「对端已 ready、被控端永远 awaiting-confirm」的新死锁；旧 stream
-    // 已在上面的严格匹配处丢弃，不能借迟到业务帧跨进程代放行。
-    this.cancelOutboundLinkConfirmation(peer);
-    this.commitReliableSendFromInboundEvidence(env.src, peer);
     const stream = this.getReceiveStream(
       peer,
       meta.streamId,
@@ -2808,23 +2802,6 @@ export class DeviceLinkClient {
       if (peer.outboundLinkConfirmationAck !== confirmation) return;
       this.retryReliableLinkConfirmation(dst, peer);
     }, normalizeTransportRetryInterval(this.timing.transportRetryIntervalMs));
-  }
-
-  private cancelOutboundLinkConfirmation(peer: PeerTransportState): void {
-    const confirmation = peer.outboundLinkConfirmationAck;
-    if (confirmation?.timer) clearTimeout(confirmation.timer);
-    peer.outboundLinkConfirmationAck = null;
-  }
-
-  private commitReliableSendFromInboundEvidence(dst: string, peer: PeerTransportState): void {
-    if (peer.sendPhase !== 'awaiting-confirm' || !peer.pendingLinkConfirmation) return;
-    this.log.info(
-      `device-link recovery dst=${dst.slice(0, 8)} trigger=link-confirm-inbound`
-      + ` stream=${peer.streamId.slice(0, 8)}`
-      + ` request=${peer.pendingLinkConfirmation.requestId.slice(0, 8)}`
-      + ` conn=${this.connEpoch}`,
-    );
-    this.commitReliableSendResume(dst, peer, peer.pendingLinkConfirmation.resume);
   }
 
   private handleTransportAck(

--- a/packages/device-link/src/client.ts
+++ b/packages/device-link/src/client.ts
@@ -439,7 +439,6 @@ interface PendingLinkConfirmation {
 interface OutboundLinkConfirmationAck {
   requestId: string;
   streamId: string;
-  ackSeq: number;
   attempts: number;
   timer: ReturnType<typeof setTimeout> | null;
 }
@@ -2746,8 +2745,14 @@ export class DeviceLinkClient {
     ackSeq: number,
     linkRequestId?: string,
   ): void {
+    const pendingConfirmation = this.peerTransport.get(dst)?.outboundLinkConfirmationAck;
+    const effectiveLinkRequestId = linkRequestId ?? (
+      pendingConfirmation?.streamId === streamId
+        ? pendingConfirmation.requestId
+        : undefined
+    );
     try {
-      this.sendEnvelope(makeTransportAck(dst, streamId, ackSeq, linkRequestId));
+      this.sendEnvelope(makeTransportAck(dst, streamId, ackSeq, effectiveLinkRequestId));
     } catch (err) {
       this.log.debug('reliable transport ACK send failed', err);
     }
@@ -2759,14 +2764,13 @@ export class DeviceLinkClient {
     peer: PeerTransportState,
   ): void {
     if (!peer.receiveReady || !peer.remoteStreamId) return;
-    const stream = this.getReceiveStream(peer, peer.remoteStreamId, peer.remoteBaseSeq);
+    this.getReceiveStream(peer, peer.remoteStreamId, peer.remoteBaseSeq);
     if (peer.outboundLinkConfirmationAck?.timer) {
       clearTimeout(peer.outboundLinkConfirmationAck.timer);
     }
     peer.outboundLinkConfirmationAck = {
       requestId,
       streamId: peer.remoteStreamId,
-      ackSeq: stream.lastDeliveredSeq,
       attempts: 0,
       timer: null,
     };
@@ -2784,11 +2788,15 @@ export class DeviceLinkClient {
     ) {
       return;
     }
+    // link-accept 可能在旧可靠帧仍执行时推进 requestedBaseSeq；此时
+    // applyReceiveStreamBase 会延迟提交，首次确认看到的 lastDeliveredSeq
+    // 不是最终基线。每次重试必须从活动 stream 重新读取，不能复用快照。
+    const stream = this.getReceiveStream(peer, confirmation.streamId, peer.remoteBaseSeq);
     confirmation.attempts += 1;
     this.sendTransportAck(
       dst,
       confirmation.streamId,
-      confirmation.ackSeq,
+      stream.lastDeliveredSeq,
       confirmation.requestId,
     );
     if (confirmation.attempts >= normalizeTransportRetryAttempts(this.timing.transportMaxRetryAttempts)) {

--- a/packages/device-link/src/client.ts
+++ b/packages/device-link/src/client.ts
@@ -3158,10 +3158,15 @@ export class DeviceLinkClient {
     requestId: string,
     resume: ReliableResumePlan,
   ): void {
-    if (peer.pendingLinkConfirmation?.timer) {
-      clearTimeout(peer.pendingLinkConfirmation.timer);
+    const previousConfirmation = peer.pendingLinkConfirmation;
+    if (previousConfirmation?.timer) {
+      clearTimeout(previousConfirmation.timer);
     }
-    const previousSendPhase: 'down' | 'ready' = peer.sendPhase === 'ready' ? 'ready' : 'down';
+    // 连续的 inbound open 可能在上一代仍 awaiting-confirm 时替换确认对象。
+    // 此时 sendPhase 不能代表替换前的健康 outbound 方向,应沿用旧确认保存的
+    // previousSendPhase,否则撤销新一代 inbound 时会把原本 ready 的方向降成 down。
+    const previousSendPhase: 'down' | 'ready' = previousConfirmation?.previousSendPhase
+      ?? (peer.sendPhase === 'ready' ? 'ready' : 'down');
     peer.sendPhase = 'awaiting-confirm';
     const confirmation: PendingLinkConfirmation = {
       requestId,

--- a/packages/device-link/src/client.ts
+++ b/packages/device-link/src/client.ts
@@ -3216,6 +3216,10 @@ export class DeviceLinkClient {
     peer.pendingLinkConfirmation = null;
     this.cancelTimeoutCloseNotify(dst);
     if (resume.duplicateOpen) {
+      // 同连接同 stream 的重复 open 仍可能带着未确认的可靠帧。确认阶段
+      // 会先清掉旧 retryTimer;不能因为这是 duplicate open 就让 pending 永久
+      // 停在队列里。这里不做全量 replay,只恢复原有有界重试计时器。
+      if (peer.pending.size > 0) this.ensureRetryTimer(dst);
       this.logRecoverySend(dst, peer, 'link-replay', true);
       return;
     }

--- a/packages/device-link/src/transport.ts
+++ b/packages/device-link/src/transport.ts
@@ -17,6 +17,16 @@ export const DEVICE_LINK_CAPABILITY_RELIABLE_TRANSPORT = 'reliable-transport-v1'
  */
 export const DEVICE_LINK_CAPABILITY_TRANSPORT_TIMEOUT_CLOSE = 'transport-timeout-close-v1';
 
+/**
+ * 声明本端会在真正处理 link-accept、安装对端可靠 stream 基线后，回一条带
+ * linkRequestId 的 transport ACK。被控端只有收到这条确认才恢复向该控制端
+ * drain pending，避免把「accept 已写进本地 WebSocket」误当成「对端已提交链路」。
+ *
+ * 能力是 append-only：任一端未声明时继续沿用 v1 的即时 ready 语义，保证新旧
+ * Desktop / Mobile 可以独立升级；relay 仍只路由普通 push，不需要服务端改动。
+ */
+export const DEVICE_LINK_CAPABILITY_RELIABLE_LINK_CONFIRM = 'reliable-link-confirm-v1';
+
 /** transport ACK 使用普通 push 承载，且 ACK 本身永不再包 transport。 */
 export const DEVICE_LINK_TRANSPORT_ACK_CHANNEL = '__cindy/device-link/transport-ack';
 
@@ -51,7 +61,7 @@ export const TRANSPORT_MAX_RETRY_ATTEMPTS = 5;
  * 2026-08-08 线上单簇 213 条、单日 449 条，8-06 单簇 125 条，全部是这个形状。
  *
  * 这条路径原本有两道刹车，但都装在错的量上:
- *  - per-peer 制动（收到带 dst 的 DEVICE_OFFLINE → linkReady=false + 清重试定时器，
+ *  - per-peer 制动（收到带 dst 的 DEVICE_OFFLINE → 复位该 peer 收发方向 + 清重试定时器，
  *    #1187）是**异步**的:relay-error 要一个 RTT 才回来，那一趟早已全部上线路，它只
  *    拦得住下一轮；
  *  - 单趟中断（ws 容量抛 BACKPRESSURE → break，#2167）的阈值是 8MB buffered bytes，
@@ -108,6 +118,8 @@ export interface ReliableTransportPayload {
 export interface TransportAckPayload {
   streamId: string;
   ackSeq: number;
+  /** 处理 link-accept 后回显其 request id；缺省表示普通累计 ACK / 旧客户端。 */
+  linkRequestId?: string;
 }
 
 export interface TransportSkipPayload {
@@ -312,6 +324,7 @@ export function makeTransportAck(
   dst: string,
   streamId: string,
   ackSeq: number,
+  linkRequestId?: string,
 ): Envelope {
   return {
     v: PROTOCOL_VERSION,
@@ -319,7 +332,11 @@ export function makeTransportAck(
     dst,
     payload: {
       channel: DEVICE_LINK_TRANSPORT_ACK_CHANNEL,
-      payload: { streamId, ackSeq } satisfies TransportAckPayload,
+      payload: {
+        streamId,
+        ackSeq,
+        ...(linkRequestId ? { linkRequestId } : {}),
+      } satisfies TransportAckPayload,
     },
   };
 }
@@ -330,13 +347,23 @@ export function parseTransportAck(env: Envelope): TransportAckPayload | null {
   const payload = env.payload.payload;
   const streamId = isRecord(payload) ? payload.streamId : undefined;
   const ackSeq = isRecord(payload) ? payload.ackSeq : undefined;
+  const linkRequestId = isRecord(payload) ? payload.linkRequestId : undefined;
   if (
     typeof streamId !== 'string' ||
     typeof ackSeq !== 'number' ||
     !Number.isSafeInteger(ackSeq) ||
-    ackSeq < 0
+    ackSeq < 0 ||
+    (linkRequestId !== undefined && (
+      typeof linkRequestId !== 'string'
+      || linkRequestId.length < 1
+      || linkRequestId.length > 256
+    ))
   ) {
     return null;
   }
-  return { streamId, ackSeq };
+  return {
+    streamId,
+    ackSeq,
+    ...(typeof linkRequestId === 'string' ? { linkRequestId } : {}),
+  };
 }

--- a/packages/maker-shared/src/__tests__/deviceResponsiveness.test.ts
+++ b/packages/maker-shared/src/__tests__/deviceResponsiveness.test.ts
@@ -4,8 +4,26 @@ import {
   BREAKER_PROBE_BACKOFF_BASE_MS,
   BREAKER_PROBE_BACKOFF_MAX_MS,
   createDeviceResponsivenessBreaker,
+  isPresenceEligibleForRemoteRequest,
+  isPresenceValueEligible,
   type BreakerSendSlot,
 } from '../deviceResponsiveness';
+
+describe('automatic recovery presence eligibility', () => {
+  it('allows explicit availability and unknown, but blocks explicit unavailable', () => {
+    const availability = new Map<string, boolean>([
+      ['online', true],
+      ['offline', false],
+    ]);
+
+    expect(isPresenceValueEligible(true)).toBe(true);
+    expect(isPresenceValueEligible(undefined)).toBe(true);
+    expect(isPresenceValueEligible(false)).toBe(false);
+    expect(isPresenceEligibleForRemoteRequest(availability, 'online')).toBe(true);
+    expect(isPresenceEligibleForRemoteRequest(availability, 'unknown')).toBe(true);
+    expect(isPresenceEligibleForRemoteRequest(availability, 'offline')).toBe(false);
+  });
+});
 
 const DEV = 'dev-1';
 

--- a/packages/maker-shared/src/deviceResponsiveness.ts
+++ b/packages/maker-shared/src/deviceResponsiveness.ts
@@ -53,6 +53,26 @@ export const BREAKER_FAILURE_THRESHOLD = 3;
 export const BREAKER_PROBE_BACKOFF_BASE_MS = 10_000;
 export const BREAKER_PROBE_BACKOFF_MAX_MS = 120_000;
 
+/**
+ * Automatic recovery presence is tri-state per relay generation:
+ * `true` is explicitly available, `false` is explicitly unavailable, and a
+ * missing value means this generation has not received a presence edge yet.
+ *
+ * Breaker/rehydrate single-flight may probe the unknown state, but must not
+ * send into an explicitly unavailable peer. Callers still own stronger gates
+ * such as relay ownership, revocation, local disablement, and breaker backoff.
+ */
+export function isPresenceValueEligible(available: boolean | undefined): boolean {
+  return available !== false;
+}
+
+export function isPresenceEligibleForRemoteRequest(
+  availabilityByDevice: ReadonlyMap<string, boolean>,
+  deviceId: string,
+): boolean {
+  return isPresenceValueEligible(availabilityByDevice.get(deviceId));
+}
+
 export interface DeviceResponsivenessBreakerOptions {
   /** 连续多少个独立超时批次进入 open;默认 3。 */
   failureThreshold?: number;


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复弱网、休眠或 relay 重连后设备仍显示在线、但可靠链路永久收不到 ACK 的恢复卡死。

可靠传输不再把“`link-accept` 已写入本地 WebSocket”当成对端已经接收：双方声明新能力时，链路按发送/接收方向分别提交，匹配 requestId、stream 和基线的确认到达后才恢复发送与重放。确认 ACK 会有界重发；全部丢失时复用现有 peer 级 `transport-timeout` 重建，不会再次永久停在等待态。任一端未声明能力时继续走旧兼容路径，relay 服务端无需改动。

Desktop 熔断恢复同时统一 presence 三态语义：明确离线才阻止恢复；relay 重连后 presence 尚未知时，只允许熔断器自己的单飞探测穿过，普通业务仍被拦截。relay 离线、非 owner、撤权和本机禁用继续严格阻断。

这两部分共同闭合一次设备连接恢复：前者保证可靠链路代际可确认，后者保证 Desktop 的恢复探测能真正发出。拆开部署时任一端仍可能停在原卡点，因此放在同一个 PR 中交付。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：近期 iOS、Desktop 远程连接卡顿及可靠链路 ACK 超时排障
- 本 PR 包含：可靠链路代际确认与有界恢复；Desktop/Mobile 共用的 presence 三态恢复判断
- 明确不包含：鉴权、版本不兼容、DNS/VPN/TLS/WebSocket 握手、relay 1013 背压、对端 IPC/数据库真实卡死、服务端改动
- 用户可见变化：弱网或休眠后不再容易出现“设备在线但连接一直卡住”；Desktop 熔断可在 presence 未知时自动进行单飞恢复探测
- 是否存在 breaking change：无；新能力为 append-only，旧端继续走原兼容路径

### UI 变化

不涉及。

- 引用的设计规范：不涉及 UI、视觉、交互或文案改动

## 怎么验证的

### 自动验证

```text
pnpm --filter @cindy/device-link test
结果：通过，214 条测试全部通过

pnpm --filter @cindy/device-link build
结果：通过

pnpm --filter @cindy/maker-shared exec vitest run src/__tests__/deviceResponsiveness.test.ts
结果：通过，25 条测试全部通过

pnpm --filter mobile exec vitest run src/__tests__/presenceRecovery.test.ts src/__tests__/deviceResponsivenessProbe.test.ts
结果：通过，34 条测试全部通过

pnpm --filter desktop exec vitest run src/main/device-link/__tests__/responsivenessTracker.test.ts
结果：通过，22 条测试全部通过

pnpm --filter mobile typecheck
结果：通过

pnpm --filter desktop typecheck
结果：通过

pnpm test:unit:related
结果：本次涉及的 device-link、mobile、maker-shared 以及其它相关 workspace 均通过；Desktop 27,746 条通过、2 条失败。失败固定发生在 ghostInstallReceipt.test.ts 的插件安装回执兼容用例，与本 PR 文件和设备连接路径无关

pnpm check:dco
结果：通过

git diff --check
结果：通过
```

### 手工验证

不涉及。本次未启动 Desktop DEV 或 Mobile 开发客户端。

### 未执行的验证

- 未做真实 iPhone ↔ Desktop 双端构建连接验证；需要修复进入两端实际版本后观察 24 小时日志。
- `@cindy/maker-shared` 全包 `tsc --noEmit` 仍被主干其它测试文件的既有类型错误阻断；本次修改的定向测试通过，Desktop 与 Mobile 完整 typecheck 通过。
- 主干既有的两条插件安装回执测试失败未在本 PR 处理，避免把插件基座兼容修复夹带进连接 PR。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [x] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：跨端连接恢复状态机

### 影响与回滚

- 影响范围：Desktop 与 Mobile 共用的 device-link 客户端；只改变可靠链路恢复确认和 Desktop 半开探测门禁。relay 服务端、数据库、原生依赖和 mobile runtime fingerprint 不变。存量插件影响：无。
- 回滚 / 降级方式：可整体 revert 本 PR；新旧客户端混用时，新能力未被双方共同声明会自动降级到原即时 ready 行为，不要求同步升级服务端。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
