### PR TITLE
fix(mobile): keep message list anchored after send

### DIFF
--- a/apps/mobile/src/__tests__/messageListVirtualization.test.ts
+++ b/apps/mobile/src/__tests__/messageListVirtualization.test.ts
@@ -85,6 +85,20 @@ describe('mobile message list container', () => {
     expect(scrollSource).toContain('userScrollForOlderRef.current = false');
   });
 
+  it('keeps follow verification enabled for a dead-zone drag that never actually unpins', () => {
+    const source = readFileSync(resolve(process.cwd(), 'src/session/MessageRenderer.tsx'), 'utf8');
+    const verifyStart = source.indexOf('const runStickToLatestVerify');
+    const verifyEnd = source.indexOf('// DEV-only:', verifyStart);
+    const verifySource = source.slice(verifyStart, verifyEnd);
+
+    expect(verifyStart).toBeGreaterThan(-1);
+    expect(verifyEnd).toBeGreaterThan(verifyStart);
+    expect(verifySource).toContain('stickToLatest: nearBottomRef.current');
+    expect(verifySource).not.toContain(
+      'stickToLatest: nearBottomRef.current && !userScrollForOlderRef.current',
+    );
+  });
+
   it('measures every mounted shareable message, including expanded group children', () => {
     const source = readFileSync(resolve(process.cwd(), 'src/session/MessageRenderer.tsx'), 'utf8');
     const readerStart = source.indexOf('const readActuallyVisibleShareableMessageIds');

--- a/apps/mobile/src/__tests__/messageListVirtualization.test.ts
+++ b/apps/mobile/src/__tests__/messageListVirtualization.test.ts
@@ -72,6 +72,23 @@ describe('mobile message list container', () => {
     expect(verifyAt).toBeGreaterThan(clearHistoryIntentAt);
   });
 
+  it('verifies a manual jump-to-latest after issuing the animated scroll', () => {
+    const source = readFileSync(resolve(process.cwd(), 'src/session/MessageRenderer.tsx'), 'utf8');
+    const callbackStart = source.indexOf('const scrollToBottom = useCallback');
+    const callbackEnd = source.indexOf('const jumpToPreviousUserMessage', callbackStart);
+    const callbackSource = source.slice(callbackStart, callbackEnd);
+    const scrollAt = callbackSource.indexOf('scrollToEndProgrammatically(true);');
+    const verifyAt = callbackSource.indexOf('runStickToLatestVerify();');
+
+    expect(callbackStart).toBeGreaterThan(-1);
+    expect(callbackEnd).toBeGreaterThan(callbackStart);
+    expect(scrollAt).toBeGreaterThan(-1);
+    expect(verifyAt).toBeGreaterThan(scrollAt);
+    expect(callbackSource).toContain(
+      '}, [runStickToLatestVerify, scrollToEndProgrammatically]);',
+    );
+  });
+
   it('clears stale history intent when a manual downward scroll re-pins at the bottom', () => {
     const source = readFileSync(resolve(process.cwd(), 'src/session/MessageRenderer.tsx'), 'utf8');
     const scrollStart = source.indexOf('// 近底/跟随态迁移');

--- a/apps/mobile/src/__tests__/messageListVirtualization.test.ts
+++ b/apps/mobile/src/__tests__/messageListVirtualization.test.ts
@@ -72,6 +72,19 @@ describe('mobile message list container', () => {
     expect(verifyAt).toBeGreaterThan(clearHistoryIntentAt);
   });
 
+  it('clears stale history intent when a manual downward scroll re-pins at the bottom', () => {
+    const source = readFileSync(resolve(process.cwd(), 'src/session/MessageRenderer.tsx'), 'utf8');
+    const scrollStart = source.indexOf('// 近底/跟随态迁移');
+    const scrollEnd = source.indexOf('// 用户开始拖动', scrollStart);
+    const scrollSource = source.slice(scrollStart, scrollEnd);
+
+    expect(scrollStart).toBeGreaterThan(-1);
+    expect(scrollEnd).toBeGreaterThan(scrollStart);
+    expect(scrollSource).toContain('const wasNearBottom = nearBottomRef.current');
+    expect(scrollSource).toContain('if (!wasNearBottom && nearBottom && scrollDelta > 0)');
+    expect(scrollSource).toContain('userScrollForOlderRef.current = false');
+  });
+
   it('measures every mounted shareable message, including expanded group children', () => {
     const source = readFileSync(resolve(process.cwd(), 'src/session/MessageRenderer.tsx'), 'utf8');
     const readerStart = source.indexOf('const readActuallyVisibleShareableMessageIds');

--- a/apps/mobile/src/__tests__/messageListVirtualization.test.ts
+++ b/apps/mobile/src/__tests__/messageListVirtualization.test.ts
@@ -56,6 +56,12 @@ describe('mobile message list container', () => {
     expect(source).toContain('evaluateMobileAnchorVerify({');
     expect(source).toContain('initialAnchorVerifyFrameRef');
     expect(source).toContain('scrollToEndProgrammatically(false)');
+    // mVCP 对 data / size 都常开；普通尾部追加与流式 resize 必须先记 settle 安静窗，
+    // 两套 verifier 都不能再只依赖 readingOlderRef 判断是否等待。
+    expect(source).toContain('mvcpSettleAtRef.current = mobileMvcpSettleDeadline(');
+    expect(source).toContain('markMobileMvcpSettle();');
+    expect(source.match(/isMobileMvcpSettling\(Date\.now\(\), mvcpSettleAtRef\.current\)/g))
+      .toHaveLength(2);
   });
 
   it('clears stale history intent before verifying an explicit follow-latest request', () => {

--- a/apps/mobile/src/__tests__/messageListVirtualization.test.ts
+++ b/apps/mobile/src/__tests__/messageListVirtualization.test.ts
@@ -89,6 +89,22 @@ describe('mobile message list container', () => {
     );
   });
 
+  it('waits for an animated follow scroll to settle before issuing non-animated verification retries', () => {
+    const source = readFileSync(resolve(process.cwd(), 'src/session/MessageRenderer.tsx'), 'utf8');
+    const verifyStart = source.indexOf('const runStickToLatestVerify = useCallback');
+    const verifyEnd = source.indexOf('// DEV-only:', verifyStart);
+    const verifySource = source.slice(verifyStart, verifyEnd);
+    const contentSizeStart = source.indexOf('const handleContentSize = useCallback');
+    const contentSizeEnd = source.indexOf('// 冷开落底', contentSizeStart);
+    const contentSizeSource = source.slice(contentSizeStart, contentSizeEnd);
+
+    expect(verifySource).toContain('mobileFollowVerifyStartDelayMs({');
+    expect(verifySource).toContain('followVerifyTimerRef.current = setTimeout');
+    expect(contentSizeSource).toContain('if (programmaticAnimatedScrollInFlightRef.current)');
+    expect(contentSizeSource.indexOf('if (programmaticAnimatedScrollInFlightRef.current)'))
+      .toBeLessThan(contentSizeSource.indexOf('scrollToEndProgrammatically(false)'));
+  });
+
   it('clears stale history intent when a manual downward scroll re-pins at the bottom', () => {
     const source = readFileSync(resolve(process.cwd(), 'src/session/MessageRenderer.tsx'), 'utf8');
     const scrollStart = source.indexOf('// 近底/跟随态迁移');

--- a/apps/mobile/src/__tests__/messageListVirtualization.test.ts
+++ b/apps/mobile/src/__tests__/messageListVirtualization.test.ts
@@ -58,6 +58,20 @@ describe('mobile message list container', () => {
     expect(source).toContain('scrollToEndProgrammatically(false)');
   });
 
+  it('clears stale history intent before verifying an explicit follow-latest request', () => {
+    const source = readFileSync(resolve(process.cwd(), 'src/session/MessageRenderer.tsx'), 'utf8');
+    const effectStart = source.indexOf('// 「跳到最新」请求');
+    const effectEnd = source.indexOf('// 自动加载更早', effectStart);
+    const effectSource = source.slice(effectStart, effectEnd);
+    const clearHistoryIntentAt = effectSource.indexOf('userScrollForOlderRef.current = false');
+    const verifyAt = effectSource.indexOf('runStickToLatestVerify();');
+
+    expect(effectStart).toBeGreaterThan(-1);
+    expect(effectEnd).toBeGreaterThan(effectStart);
+    expect(clearHistoryIntentAt).toBeGreaterThan(-1);
+    expect(verifyAt).toBeGreaterThan(clearHistoryIntentAt);
+  });
+
   it('measures every mounted shareable message, including expanded group children', () => {
     const source = readFileSync(resolve(process.cwd(), 'src/session/MessageRenderer.tsx'), 'utf8');
     const readerStart = source.indexOf('const readActuallyVisibleShareableMessageIds');

--- a/apps/mobile/src/__tests__/messageScroll.test.ts
+++ b/apps/mobile/src/__tests__/messageScroll.test.ts
@@ -16,6 +16,7 @@ import {
   isNearMessageListBottom,
   isNearMobileMessageListBottom,
   isNearMessageListTop,
+  mobileFollowVerifyStartDelayMs,
   MOBILE_ANCHOR_VERIFY_MAX_ATTEMPTS,
   MOBILE_ANCHOR_VERIFY_MAX_WAIT_ROUNDS,
   MOBILE_ANCHOR_VERIFY_TOLERANCE,
@@ -726,5 +727,33 @@ describe('evaluateMobileAnchorVerify (落底校验/补滚有界重试环——�
       waitRounds: MOBILE_ANCHOR_VERIFY_MAX_WAIT_ROUNDS - 1,
       metrics: metricsAt(0),
     })).toBe('wait');
+  });
+});
+
+describe('mobileFollowVerifyStartDelayMs (动画贴底完成后再启动 verifier)', () => {
+  it('动画仍在 settle 窗口内时返回剩余等待时间', () => {
+    expect(mobileFollowVerifyStartDelayMs({
+      animatedScrollInFlight: true,
+      now: 600,
+      settleAt: 1400,
+    })).toBe(800);
+  });
+
+  it('非动画、已结束或时钟已越过 settle 时立即校验', () => {
+    expect(mobileFollowVerifyStartDelayMs({
+      animatedScrollInFlight: false,
+      now: 600,
+      settleAt: 1400,
+    })).toBe(0);
+    expect(mobileFollowVerifyStartDelayMs({
+      animatedScrollInFlight: true,
+      now: 1400,
+      settleAt: 1400,
+    })).toBe(0);
+    expect(mobileFollowVerifyStartDelayMs({
+      animatedScrollInFlight: true,
+      now: 1500,
+      settleAt: 1400,
+    })).toBe(0);
   });
 });

--- a/apps/mobile/src/__tests__/messageScroll.test.ts
+++ b/apps/mobile/src/__tests__/messageScroll.test.ts
@@ -16,7 +16,9 @@ import {
   isNearMessageListBottom,
   isNearMobileMessageListBottom,
   isNearMessageListTop,
+  isMobileMvcpSettling,
   mobileFollowVerifyStartDelayMs,
+  mobileMvcpSettleDeadline,
   MOBILE_ANCHOR_VERIFY_MAX_ATTEMPTS,
   MOBILE_ANCHOR_VERIFY_MAX_WAIT_ROUNDS,
   MOBILE_ANCHOR_VERIFY_TOLERANCE,
@@ -38,6 +40,7 @@ import {
   mobileTopPaddingCompensationOffset,
   MOBILE_FOLLOW_REPIN_DIRECTION_DEAD_ZONE,
   MOBILE_FOLLOW_UNPIN_DRAG_DEAD_ZONE,
+  MOBILE_MVCP_SETTLE_QUIET_MS,
   resolveMobileNearBottomOnScroll,
   shouldUnpinMobileFollowOnDrag,
 } from '@/session/messageScroll';
@@ -727,6 +730,22 @@ describe('evaluateMobileAnchorVerify (落底校验/补滚有界重试环——�
       waitRounds: MOBILE_ANCHOR_VERIFY_MAX_WAIT_ROUNDS - 1,
       metrics: metricsAt(0),
     })).toBe('wait');
+  });
+});
+
+describe('mobile mVCP settle quiet window', () => {
+  it('keeps verification waiting through the quiet window after a data or size change', () => {
+    const settleAt = mobileMvcpSettleDeadline(0, 1_000);
+    expect(settleAt).toBe(1_000 + MOBILE_MVCP_SETTLE_QUIET_MS);
+    expect(isMobileMvcpSettling(1_000, settleAt)).toBe(true);
+    expect(isMobileMvcpSettling(settleAt - 1, settleAt)).toBe(true);
+    expect(isMobileMvcpSettling(settleAt, settleAt)).toBe(false);
+  });
+
+  it('extends an in-flight settle window when streaming content changes again', () => {
+    const firstDeadline = mobileMvcpSettleDeadline(0, 1_000);
+    const extendedDeadline = mobileMvcpSettleDeadline(firstDeadline, 1_080);
+    expect(extendedDeadline).toBe(1_080 + MOBILE_MVCP_SETTLE_QUIET_MS);
   });
 });
 

--- a/apps/mobile/src/__tests__/messageScroll.test.ts
+++ b/apps/mobile/src/__tests__/messageScroll.test.ts
@@ -9,12 +9,16 @@ import {
   buildSearchLoadEarlierAction,
   createMobileFollowEndPinState,
   DEFAULT_NEAR_BOTTOM_THRESHOLD,
+  evaluateMobileAnchorVerify,
   evaluateMobileFollowEndContentSizePin,
   findMobileRenderItemKeyByClientId,
   firstNonEmptyMessageLine,
   isNearMessageListBottom,
   isNearMobileMessageListBottom,
   isNearMessageListTop,
+  MOBILE_ANCHOR_VERIFY_MAX_ATTEMPTS,
+  MOBILE_ANCHOR_VERIFY_MAX_WAIT_ROUNDS,
+  MOBILE_ANCHOR_VERIFY_TOLERANCE,
   MOBILE_FOLLOW_END_PIN_HEIGHT_DEAD_ZONE,
   MOBILE_FOLLOW_END_PIN_MAX_REVERSALS_PER_WINDOW,
   MOBILE_FOLLOW_END_PIN_SUPPRESS_MS,
@@ -639,5 +643,88 @@ describe('evaluateMobileFollowEndContentSizePin (贴底补滚振荡断路器)', 
     // t=2000 的旧翻转被剔除,窗口内只剩本次。
     evaluateMobileFollowEndContentSizePin(state, { now: 3000, contentHeight: 1200 });
     expect(state.reversalTimestamps).toEqual([3000]);
+  });
+});
+
+describe('evaluateMobileAnchorVerify (落底校验/补滚有界重试环——冷开锚定与贴底跟随共用同一判定)', () => {
+  // 视口 800,内容 2000 → endOffset = 1200。
+  const metricsAt = (offsetY: number) => ({ contentHeight: 2000, offsetY, viewportHeight: 800 });
+  const baseInput = {
+    attempts: 0,
+    listVisible: true,
+    preserveVisibleContentPosition: false,
+    stickToLatest: true,
+    waitRounds: 0,
+  };
+
+  it('未处于贴底跟随意图(用户已解除/翻到旧消息)→ 直接 settled,不发起补滚', () => {
+    expect(evaluateMobileAnchorVerify({
+      ...baseInput, stickToLatest: false, metrics: metricsAt(0),
+    })).toBe('settled');
+  });
+
+  it('列表尚未可见(如切换会话中)→ 直接 settled', () => {
+    expect(evaluateMobileAnchorVerify({
+      ...baseInput, listVisible: false, metrics: metricsAt(0),
+    })).toBe('settled');
+  });
+
+  it('已落在容差带内 → settled(容差边界 offsetY === endOffset - TOLERANCE 视为已达)', () => {
+    expect(evaluateMobileAnchorVerify({
+      ...baseInput, metrics: metricsAt(1200),
+    })).toBe('settled');
+    expect(evaluateMobileAnchorVerify({
+      ...baseInput, metrics: metricsAt(1200 - MOBILE_ANCHOR_VERIFY_TOLERANCE),
+    })).toBe('settled');
+  });
+
+  it('偏移仍差着容差带 → retry(容差边界外 1px 即触发重试)', () => {
+    expect(evaluateMobileAnchorVerify({
+      ...baseInput, metrics: metricsAt(1200 - MOBILE_ANCHOR_VERIFY_TOLERANCE - 1),
+    })).toBe('retry');
+    expect(evaluateMobileAnchorVerify({
+      ...baseInput, metrics: metricsAt(0),
+    })).toBe('retry');
+  });
+
+  it('重试次数达到上限后仍未落底 → give-up(不无限重试)', () => {
+    expect(evaluateMobileAnchorVerify({
+      ...baseInput, attempts: MOBILE_ANCHOR_VERIFY_MAX_ATTEMPTS, metrics: metricsAt(0),
+    })).toBe('give-up');
+    // 上限前一次仍是 retry。
+    expect(evaluateMobileAnchorVerify({
+      ...baseInput, attempts: MOBILE_ANCHOR_VERIFY_MAX_ATTEMPTS - 1, metrics: metricsAt(0),
+    })).toBe('retry');
+  });
+
+  it('mVCP 仍开着(preserveVisibleContentPosition)→ wait,不在其吸收滚动的窗口内瞎重试', () => {
+    expect(evaluateMobileAnchorVerify({
+      ...baseInput, preserveVisibleContentPosition: true, metrics: metricsAt(0),
+    })).toBe('wait');
+  });
+
+  it('原生 metrics 尚未结算(contentHeight/viewportHeight <= 0)→ wait,而非误判为已落空', () => {
+    expect(evaluateMobileAnchorVerify({
+      ...baseInput, metrics: { contentHeight: 0, offsetY: 0, viewportHeight: 800 },
+    })).toBe('wait');
+    expect(evaluateMobileAnchorVerify({
+      ...baseInput, metrics: { contentHeight: 2000, offsetY: 0, viewportHeight: 0 },
+    })).toBe('wait');
+  });
+
+  it('等待轮数达到上限仍无有效 metrics/仍在 mVCP 中 → give-up(不无限期挂着)', () => {
+    expect(evaluateMobileAnchorVerify({
+      ...baseInput,
+      preserveVisibleContentPosition: true,
+      waitRounds: MOBILE_ANCHOR_VERIFY_MAX_WAIT_ROUNDS,
+      metrics: metricsAt(0),
+    })).toBe('give-up');
+    // 上限前一轮仍是 wait。
+    expect(evaluateMobileAnchorVerify({
+      ...baseInput,
+      preserveVisibleContentPosition: true,
+      waitRounds: MOBILE_ANCHOR_VERIFY_MAX_WAIT_ROUNDS - 1,
+      metrics: metricsAt(0),
+    })).toBe('wait');
   });
 });

--- a/apps/mobile/src/__tests__/remoteSessionStore.test.ts
+++ b/apps/mobile/src/__tests__/remoteSessionStore.test.ts
@@ -1908,7 +1908,7 @@ describe('remoteSessionStore', () => {
       content: '完整的长内容',
     };
     const truncated = {
-      ...messageAt('m1', 's1', '2026-01-01T10:00:01.000Z'),
+      ...messageAt('m1', 's1', '2026-01-01T10:00:01.500Z'),
       content: '[remote content truncated: payload too large]',
       agentMeta: { remoteContentTruncated: true, agentTaskStatus: 'failed' as const },
     };
@@ -1922,6 +1922,7 @@ describe('remoteSessionStore', () => {
     const rows = remoteSessionStore.getMessages('s1');
     expect(rows.map((item) => item.id)).toEqual(['m1', 'm2']);
     expect(rows[0].content).toBe('完整的长内容');
+    expect(rows[0].createdAt).toBe('2026-01-01T10:00:01.500Z');
     expect(rows[0].agentMeta?.agentTaskStatus).toBe('failed');
     expect(rows[0].agentMeta?.remoteContentTruncated).not.toBe(true);
   });
@@ -3036,6 +3037,125 @@ describe('remoteSessionStore', () => {
     }
   });
 
+  it('keeps a pre-metadata offline reply unbound until its older user row arrives', () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date('2026-01-01T00:10:00.000Z'));
+      pushMakerText('s1', 'previous-live-assistant', 'Previous reply', true);
+
+      // No session list row exists yet, so the offline transition must use the
+      // maker event's transport device rather than sessionDeviceIndex.
+      remoteSessionStore.markDeviceOffline('dev-1');
+      remoteSessionStore.upsertDeviceSession('dev-1', 'Mac', session('s1', {
+        userSendAt: '2026-01-01T00:00:02.000Z',
+        updatedAt: '2026-01-01T00:00:02.000Z',
+      }));
+      remoteSessionStore.setLatestMessageWindow('s1', [{
+        ...messageAt('current-user', 's1', '2026-01-01T00:00:02.000Z'),
+        role: 'user',
+        content: 'Current question',
+      }]);
+
+      expect(remoteSessionStore.getMessages('s1')
+        .find((item) => item.clientId === 'previous-live-assistant')?.createdAt)
+        .toBe('2026-01-01T00:10:00.000Z');
+
+      remoteSessionStore.appendMessage('s1', {
+        ...messageAt('previous-user', 's1', '2026-01-01T00:00:01.000Z'),
+        role: 'user',
+        content: 'Previous question',
+      });
+
+      const rows = remoteSessionStore.getMessages('s1');
+      expect(rows.map((item) => item.clientId)).toEqual([
+        'previous-user',
+        'previous-live-assistant',
+        'current-user',
+      ]);
+      expect(rows.find((item) => item.clientId === 'previous-live-assistant')?.createdAt)
+        .toBe('2026-01-01T00:00:01.000Z');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('flushes and freezes a pre-metadata text delta when its transport goes offline', () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date('2026-01-01T00:10:00.000Z'));
+      pushMakerText('s1', 'previous-live-assistant', 'Previous reply', false);
+
+      remoteSessionStore.markDeviceOffline('dev-1');
+      remoteSessionStore.upsertDeviceSession('dev-1', 'Mac', session('s1', {
+        userSendAt: '2026-01-01T00:00:02.000Z',
+        updatedAt: '2026-01-01T00:00:02.000Z',
+      }));
+      remoteSessionStore.setLatestMessageWindow('s1', [{
+        ...messageAt('current-user', 's1', '2026-01-01T00:00:02.000Z'),
+        role: 'user',
+        content: 'Current question',
+      }]);
+
+      expect(remoteSessionStore.getMessages('s1')
+        .find((item) => item.clientId === 'previous-live-assistant')?.createdAt)
+        .toBe('2026-01-01T00:10:00.000Z');
+
+      remoteSessionStore.appendMessage('s1', {
+        ...messageAt('previous-user', 's1', '2026-01-01T00:00:01.000Z'),
+        role: 'user',
+        content: 'Previous question',
+      });
+      expect(remoteSessionStore.getMessages('s1').map((item) => item.clientId)).toEqual([
+        'previous-user',
+        'previous-live-assistant',
+        'current-user',
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('pairs an older delayed user with the offline-unbound reply before the new round reply', () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date('2026-01-01T00:10:00.000Z'));
+      pushMakerText('s1', 'previous-live-assistant', 'Previous reply', true);
+      remoteSessionStore.markDeviceOffline('dev-1');
+
+      remoteSessionStore.upsertDeviceSession('dev-1', 'Mac', session('s1', {
+        userSendAt: '2026-01-01T00:00:02.000Z',
+        updatedAt: '2026-01-01T00:00:02.000Z',
+      }));
+      vi.setSystemTime(new Date('2026-01-01T00:11:00.000Z'));
+      pushMakerText('s1', 'current-live-assistant', 'Current reply', true);
+
+      remoteSessionStore.appendMessage('s1', {
+        ...messageAt('previous-user', 's1', '2026-01-01T00:00:01.000Z'),
+        role: 'user',
+        content: 'Previous question',
+      });
+      expect(remoteSessionStore.getMessages('s1').map((item) => item.clientId)).toEqual([
+        'previous-user',
+        'previous-live-assistant',
+        'current-live-assistant',
+      ]);
+      remoteSessionStore.appendMessage('s1', {
+        ...messageAt('current-user', 's1', '2026-01-01T00:00:02.000Z'),
+        role: 'user',
+        content: 'Current question',
+      });
+
+      expect(remoteSessionStore.getMessages('s1').map((item) => item.clientId)).toEqual([
+        'previous-user',
+        'previous-live-assistant',
+        'current-user',
+        'current-live-assistant',
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('emits when soft offline only clears pending-refresh metadata', () => {
     remoteSessionStore.setDeviceSessions('dev-1', 'Mac', [session('s1')]);
     remoteSessionStore.applyRemotePush('dev-1', 'local-db:session:error-persisted', {
@@ -4040,6 +4160,44 @@ describe('device-clock live row clamp (applyRemoteTextEvent createdAt, cross-clo
         '2026-01-01T00:00:01.000Z',
         '2026-01-01T00:00:02.000Z',
         '2026-01-01T00:00:02.000Z',
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('同一发送轮次的多条 live 回复按原顺序整体移到 user 行之后', () => {
+    vi.useFakeTimers();
+    try {
+      remoteSessionStore.setDeviceSessions('dev-1', 'Mac', [session('s1', {
+        userSendAt: '2026-01-01T00:00:01.000Z',
+        updatedAt: '2026-01-01T00:00:01.000Z',
+      })]);
+      vi.setSystemTime(new Date('2026-01-01T00:10:00.000Z'));
+      pushMakerText('s1', 'live-assistant-1', 'First reply block', true);
+      pushMakerText('s1', 'live-assistant-2', 'Second reply block', true);
+
+      remoteSessionStore.appendMessage('s1', {
+        ...messageAt('user-1', 's1', '2026-01-01T00:00:01.000Z'),
+        role: 'user',
+        content: 'Question',
+      });
+
+      expect(remoteSessionStore.getMessages('s1').map((item) => item.clientId)).toEqual([
+        'user-1',
+        'live-assistant-1',
+        'live-assistant-2',
+      ]);
+      remoteSessionStore.appendMessage('s1', {
+        ...messageAt('user-2', 's1', '2026-01-01T00:00:02.000Z'),
+        role: 'user',
+        content: 'Next question',
+      });
+      expect(remoteSessionStore.getMessages('s1').map((item) => item.clientId)).toEqual([
+        'user-1',
+        'live-assistant-1',
+        'live-assistant-2',
+        'user-2',
       ]);
     } finally {
       vi.useRealTimers();

--- a/apps/mobile/src/__tests__/remoteSessionStore.test.ts
+++ b/apps/mobile/src/__tests__/remoteSessionStore.test.ts
@@ -2969,6 +2969,32 @@ describe('remoteSessionStore', () => {
     expect(remoteSessionStore.getMessages('s1')).toHaveLength(2);
   });
 
+  it('preserves a provisional live reply anchor across transient device offline', () => {
+    vi.useFakeTimers();
+    try {
+      remoteSessionStore.setDeviceSessions('dev-1', 'Mac', [session('s1', {
+        userSendAt: '2026-01-01T00:00:02.000Z',
+        updatedAt: '2026-01-01T00:00:02.000Z',
+      })]);
+      vi.setSystemTime(new Date('2026-01-01T00:10:00.000Z'));
+      pushMakerText('s1', 'current-live-assistant', 'Current reply', true);
+
+      remoteSessionStore.markDeviceOffline('dev-1');
+      remoteSessionStore.setLatestMessageWindow('s1', [{
+        ...messageAt('current-user', 's1', '2026-01-01T00:00:02.000Z'),
+        role: 'user',
+        content: 'Current question',
+      }]);
+
+      expect(remoteSessionStore.getMessages('s1').map((item) => item.clientId)).toEqual([
+        'current-user',
+        'current-live-assistant',
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('emits when soft offline only clears pending-refresh metadata', () => {
     remoteSessionStore.setDeviceSessions('dev-1', 'Mac', [session('s1')]);
     remoteSessionStore.applyRemotePush('dev-1', 'local-db:session:error-persisted', {

--- a/apps/mobile/src/__tests__/remoteSessionStore.test.ts
+++ b/apps/mobile/src/__tests__/remoteSessionStore.test.ts
@@ -3835,6 +3835,40 @@ describe('device-clock live row clamp (applyRemoteTextEvent createdAt, cross-clo
     }
   });
 
+  it('发送前发起的旧消息窗口迟到时不消费 live 行待重锚身份', () => {
+    vi.useFakeTimers();
+    try {
+      // 此时发送前的 history 请求已经发出,但本地窗口尚未拿到任何主机时间水位。
+      vi.setSystemTime(new Date('2026-01-01T00:10:00.000Z'));
+      pushMakerText('s1', 'live-assistant', 'Current reply', true);
+
+      // 这份窗口在发送前已经开始读取,返回时不含本轮 user 行。它可以临时把 live
+      // 行拉回主机时间域,但不能消费待重锚身份；否则后续权威 user push 无法恢复顺序。
+      remoteSessionStore.setLatestMessageWindow('s1', [
+        messageAt('previous-assistant', 's1', '2026-01-01T00:00:00.000Z'),
+      ]);
+
+      remoteSessionStore.appendMessage('s1', {
+        ...messageAt('current-user', 's1', '2026-01-01T00:00:01.000Z'),
+        role: 'user',
+        content: 'Current question',
+      });
+
+      const rows = remoteSessionStore.getMessages('s1');
+      expect(rows.map((item) => item.clientId)).toEqual([
+        'previous-assistant',
+        'current-user',
+        'live-assistant',
+      ]);
+      expect(rows.slice(1).map((item) => item.createdAt)).toEqual([
+        '2026-01-01T00:00:01.000Z',
+        '2026-01-01T00:00:01.000Z',
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('多帧 live 行在会话元数据到达前持续保留待重锚标记', () => {
     vi.useFakeTimers();
     try {

--- a/apps/mobile/src/__tests__/remoteSessionStore.test.ts
+++ b/apps/mobile/src/__tests__/remoteSessionStore.test.ts
@@ -3191,6 +3191,70 @@ describe('remoteSessionStore', () => {
     expect(remoteSessionStore.getMessages('s2')).toHaveLength(1);
   });
 
+  it('discards a pre-metadata text batch when its transport is hard removed', () => {
+    vi.useFakeTimers();
+    try {
+      pushMakerText('s1', 'live-assistant', 'Stale reply', false);
+
+      remoteSessionStore.removeDevice('dev-1');
+      vi.runOnlyPendingTimers();
+
+      expect(remoteSessionStore.getMessages('s1')).toEqual([]);
+      remoteSessionStore.setDeviceSessions('dev-1', 'Mac', [session('s1')]);
+      expect(remoteSessionStore.getMessages('s1')).toEqual([]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('removes a flushed pre-metadata reply with its transport-owned anchor', () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date('2026-01-01T00:10:00.000Z'));
+      pushMakerText('s1', 'live-assistant', 'Stale reply', true);
+      expect(remoteSessionStore.getMessages('s1')).toHaveLength(1);
+
+      remoteSessionStore.removeDevice('dev-1');
+      remoteSessionStore.setDeviceSessions('dev-1', 'Mac', [session('s1', {
+        userSendAt: '2026-01-01T00:00:01.000Z',
+        updatedAt: '2026-01-01T00:00:01.000Z',
+      })]);
+      expect(remoteSessionStore.getMessages('s1')).toEqual([]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('keeps a current shard window when removing a stale transport for the same session id', () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date('2026-01-01T00:10:00.000Z'));
+      remoteSessionStore.applyRemotePush('stale-mac', 'maker:event', {
+        sessionId: 's1',
+        persistId: 'stale-live-assistant',
+        event: {
+          type: 'text',
+          data: { text: 'Stale reply', isFinal: true },
+        },
+      });
+      remoteSessionStore.setDeviceSessions('current-mac', 'Mac', [session('s1')]);
+      remoteSessionStore.setMessages('s1', [messageAt(
+        'current-assistant',
+        's1',
+        '2026-01-01T00:00:01.000Z',
+      )]);
+
+      remoteSessionStore.removeDevice('stale-mac');
+
+      expect(remoteSessionStore.getSessionDeviceId('s1')).toBe('current-mac');
+      expect(remoteSessionStore.getMessages('s1').map((item) => item.clientId)).toEqual([
+        'current-assistant',
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('writes canonicalDeviceId for a stale shard uniquely matching a current device, keeping deviceLinkDeviceId physical', () => {
     remoteSessionStore.setDeviceIdentity([{ deviceId: 'current-mac', name: 'Lizi Mac' }]);
     remoteSessionStore.setDeviceSessions('current-mac', 'Lizi Mac', [session('s-current')]);
@@ -4188,6 +4252,48 @@ describe('device-clock live row clamp (applyRemoteTextEvent createdAt, cross-clo
         'live-assistant-1',
         'live-assistant-2',
       ]);
+      remoteSessionStore.appendMessage('s1', {
+        ...messageAt('user-2', 's1', '2026-01-01T00:00:02.000Z'),
+        role: 'user',
+        content: 'Next question',
+      });
+      expect(remoteSessionStore.getMessages('s1').map((item) => item.clientId)).toEqual([
+        'user-1',
+        'live-assistant-1',
+        'live-assistant-2',
+        'user-2',
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('元数据前同一 maker turn 的多条 live 回复由首个 user 行整体消费', () => {
+    vi.useFakeTimers();
+    try {
+      remoteSessionStore.applyMakerEvent('s1', {
+        type: 'status',
+        data: { isRunning: true },
+      });
+      vi.setSystemTime(new Date('2026-01-01T00:10:00.000Z'));
+      pushMakerText('s1', 'live-assistant-1', 'First reply block', true);
+      pushMakerText('s1', 'live-assistant-2', 'Second reply block', true);
+
+      remoteSessionStore.appendMessage('s1', {
+        ...messageAt('user-1', 's1', '2026-01-01T00:00:01.000Z'),
+        role: 'user',
+        content: 'Question',
+      });
+      expect(remoteSessionStore.getMessages('s1').map((item) => item.clientId)).toEqual([
+        'user-1',
+        'live-assistant-1',
+        'live-assistant-2',
+      ]);
+
+      remoteSessionStore.applyMakerEvent('s1', {
+        type: 'status',
+        data: { isRunning: false },
+      });
       remoteSessionStore.appendMessage('s1', {
         ...messageAt('user-2', 's1', '2026-01-01T00:00:02.000Z'),
         role: 'user',

--- a/apps/mobile/src/__tests__/remoteSessionStore.test.ts
+++ b/apps/mobile/src/__tests__/remoteSessionStore.test.ts
@@ -2995,6 +2995,47 @@ describe('remoteSessionStore', () => {
     }
   });
 
+  it('does not let a reconnecting newer send claim an older offline provisional reply', () => {
+    vi.useFakeTimers();
+    try {
+      remoteSessionStore.setDeviceSessions('dev-1', 'Mac', [session('s1', {
+        userSendAt: '2026-01-01T00:00:01.000Z',
+        updatedAt: '2026-01-01T00:00:01.000Z',
+      })]);
+      vi.setSystemTime(new Date('2026-01-01T00:10:00.000Z'));
+      pushMakerText('s1', 'previous-live-assistant', 'Previous reply', true);
+
+      remoteSessionStore.markDeviceOffline('dev-1');
+      remoteSessionStore.upsertDeviceSession('dev-1', 'Mac', session('s1', {
+        userSendAt: '2026-01-01T00:00:02.000Z',
+        updatedAt: '2026-01-01T00:00:02.000Z',
+      }));
+      remoteSessionStore.setLatestMessageWindow('s1', [
+        {
+          ...messageAt('previous-user', 's1', '2026-01-01T00:00:01.000Z'),
+          role: 'user',
+          content: 'Previous question',
+        },
+        {
+          ...messageAt('current-user', 's1', '2026-01-01T00:00:02.000Z'),
+          role: 'user',
+          content: 'Current question',
+        },
+      ]);
+
+      const rows = remoteSessionStore.getMessages('s1');
+      expect(rows.map((item) => item.clientId)).toEqual([
+        'previous-user',
+        'previous-live-assistant',
+        'current-user',
+      ]);
+      expect(rows.find((item) => item.clientId === 'previous-live-assistant')?.createdAt)
+        .toBe('2026-01-01T00:00:01.000Z');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('emits when soft offline only clears pending-refresh metadata', () => {
     remoteSessionStore.setDeviceSessions('dev-1', 'Mac', [session('s1')]);
     remoteSessionStore.applyRemotePush('dev-1', 'local-db:session:error-persisted', {

--- a/apps/mobile/src/__tests__/remoteSessionStore.test.ts
+++ b/apps/mobile/src/__tests__/remoteSessionStore.test.ts
@@ -3353,6 +3353,159 @@ describe('remoteSessionStore', () => {
     }
   });
 
+  it('pairs multiple offline-unbound reply cohorts with a reconnect window in arrival order', () => {
+    vi.useFakeTimers();
+    try {
+      remoteSessionStore.applyMakerEvent('s1', {
+        type: 'status',
+        data: { isRunning: true },
+      });
+      vi.setSystemTime(new Date('2026-01-01T00:10:00.000Z'));
+      pushMakerText('s1', 'live-assistant-1', 'First reply', true);
+      remoteSessionStore.applyMakerEvent('s1', {
+        type: 'status',
+        data: { isRunning: false },
+      });
+      remoteSessionStore.applyMakerEvent('s1', {
+        type: 'status',
+        data: { isRunning: true },
+      });
+      vi.setSystemTime(new Date('2026-01-01T00:11:00.000Z'));
+      pushMakerText('s1', 'live-assistant-2', 'Second reply', true);
+
+      remoteSessionStore.markDeviceOffline('dev-1');
+      remoteSessionStore.upsertDeviceSession('dev-1', 'Mac', session('s1', {
+        userSendAt: '2026-01-01T00:00:02.000Z',
+        updatedAt: '2026-01-01T00:00:02.000Z',
+      }));
+      remoteSessionStore.setLatestMessageWindow('s1', [
+        {
+          ...messageAt('user-1', 's1', '2026-01-01T00:00:01.000Z'),
+          role: 'user',
+          content: 'First question',
+        },
+        {
+          ...messageAt('user-2', 's1', '2026-01-01T00:00:02.000Z'),
+          role: 'user',
+          content: 'Second question',
+        },
+      ]);
+
+      expect(remoteSessionStore.getMessages('s1').map((item) => item.clientId)).toEqual([
+        'user-1',
+        'live-assistant-1',
+        'user-2',
+        'live-assistant-2',
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('leaves offline-unbound cohorts pending when the reconnect window is truncated', () => {
+    vi.useFakeTimers();
+    try {
+      for (const [index, createdAt] of [
+        ['1', '2026-01-01T00:10:00.000Z'],
+        ['2', '2026-01-01T00:11:00.000Z'],
+        ['3', '2026-01-01T00:12:00.000Z'],
+      ] as const) {
+        remoteSessionStore.applyMakerEvent('s1', {
+          type: 'status',
+          data: { isRunning: true },
+        });
+        vi.setSystemTime(new Date(createdAt));
+        pushMakerText('s1', `live-assistant-${index}`, `Reply ${index}`, true);
+        remoteSessionStore.applyMakerEvent('s1', {
+          type: 'status',
+          data: { isRunning: false },
+        });
+      }
+
+      remoteSessionStore.markDeviceOffline('dev-1');
+      remoteSessionStore.upsertDeviceSession('dev-1', 'Mac', session('s1', {
+        userSendAt: '2026-01-01T00:00:03.000Z',
+        updatedAt: '2026-01-01T00:00:03.000Z',
+      }));
+      remoteSessionStore.setLatestMessageWindow('s1', [
+        {
+          ...messageAt('user-2', 's1', '2026-01-01T00:00:02.000Z'),
+          role: 'user',
+          content: 'Second question',
+        },
+        {
+          ...messageAt('user-3', 's1', '2026-01-01T00:00:03.000Z'),
+          role: 'user',
+          content: 'Third question',
+        },
+      ]);
+
+      expect(remoteSessionStore.getMessages('s1').map((item) => item.clientId)).toEqual([
+        'user-2',
+        'user-3',
+        'live-assistant-1',
+        'live-assistant-2',
+        'live-assistant-3',
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('leaves offline-unbound cohorts pending when the reconnect window has extra users', () => {
+    vi.useFakeTimers();
+    try {
+      for (const [index, createdAt] of [
+        ['1', '2026-01-01T00:10:00.000Z'],
+        ['2', '2026-01-01T00:11:00.000Z'],
+      ] as const) {
+        remoteSessionStore.applyMakerEvent('s1', {
+          type: 'status',
+          data: { isRunning: true },
+        });
+        vi.setSystemTime(new Date(createdAt));
+        pushMakerText('s1', `live-assistant-${index}`, `Reply ${index}`, true);
+        remoteSessionStore.applyMakerEvent('s1', {
+          type: 'status',
+          data: { isRunning: false },
+        });
+      }
+
+      remoteSessionStore.markDeviceOffline('dev-1');
+      remoteSessionStore.upsertDeviceSession('dev-1', 'Mac', session('s1', {
+        userSendAt: '2026-01-01T00:00:03.000Z',
+        updatedAt: '2026-01-01T00:00:03.000Z',
+      }));
+      remoteSessionStore.setLatestMessageWindow('s1', [
+        {
+          ...messageAt('user-1', 's1', '2026-01-01T00:00:01.000Z'),
+          role: 'user',
+          content: 'First question',
+        },
+        {
+          ...messageAt('user-2', 's1', '2026-01-01T00:00:02.000Z'),
+          role: 'user',
+          content: 'Second question',
+        },
+        {
+          ...messageAt('user-3', 's1', '2026-01-01T00:00:03.000Z'),
+          role: 'user',
+          content: 'Third question',
+        },
+      ]);
+
+      expect(remoteSessionStore.getMessages('s1').map((item) => item.clientId)).toEqual([
+        'user-1',
+        'user-2',
+        'user-3',
+        'live-assistant-1',
+        'live-assistant-2',
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('emits when soft offline only clears pending-refresh metadata', () => {
     remoteSessionStore.setDeviceSessions('dev-1', 'Mac', [session('s1')]);
     remoteSessionStore.applyRemotePush('dev-1', 'local-db:session:error-persisted', {
@@ -3475,6 +3628,27 @@ describe('remoteSessionStore', () => {
     ]);
   });
 
+  it('does not let a stale transport mutate or claim a persisted assistant row', () => {
+    remoteSessionStore.setDeviceIdentity([{ deviceId: 'current-mac', name: 'Mac' }]);
+    remoteSessionStore.setDeviceSessions('current-mac', 'Mac', [session('s1')]);
+    remoteSessionStore.setMessages('s1', [message('persisted-assistant', 's1')]);
+
+    remoteSessionStore.applyRemotePush('stale-mac', 'maker:event', {
+      sessionId: 's1',
+      persistId: 'persisted-assistant',
+      event: {
+        type: 'text',
+        data: { text: 'Stale replay', isFinal: true },
+      },
+    });
+    remoteSessionStore.removeDevice('stale-mac');
+
+    expect(remoteSessionStore.getSessionDeviceId('s1')).toBe('current-mac');
+    expect(remoteSessionStore.getMessages('s1')).toEqual([
+      message('persisted-assistant', 's1'),
+    ]);
+  });
+
   it.each([
     ['before the current transport batch flushes', false],
     ['after the current transport batch flushes', true],
@@ -3570,6 +3744,175 @@ describe('remoteSessionStore', () => {
       expect(remoteSessionStore.getMessages('s1').map((item) => item.clientId)).toEqual([
         'shared-live-assistant',
       ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not let a stale replay replace the current transport assembly', () => {
+    vi.useFakeTimers();
+    try {
+      remoteSessionStore.setDeviceIdentity([{ deviceId: 'current-mac', name: 'Mac' }]);
+      remoteSessionStore.setDeviceSessions('current-mac', 'Mac', [session('s1')]);
+      remoteSessionStore.applyRemotePush('current-mac', 'maker:event', {
+        sessionId: 's1',
+        persistId: 'shared-live-assistant',
+        event: {
+          type: 'text',
+          data: { text: 'Current reply', isFinal: true },
+        },
+      });
+      remoteSessionStore.applyRemotePush('stale-mac', 'maker:event', {
+        sessionId: 's1',
+        persistId: 'shared-live-assistant',
+        event: {
+          type: 'text',
+          data: { text: 'Stale replay', isFinal: true },
+        },
+      });
+
+      expect(remoteSessionStore.getMessages('s1')).toMatchObject([{
+        clientId: 'shared-live-assistant',
+        content: 'Current reply',
+      }]);
+      remoteSessionStore.removeDevice('stale-mac');
+      expect(remoteSessionStore.getMessages('s1')).toMatchObject([{
+        clientId: 'shared-live-assistant',
+        content: 'Current reply',
+      }]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not let a stale transport migrate the current generated assembly', () => {
+    vi.useFakeTimers();
+    try {
+      remoteSessionStore.setDeviceIdentity([{ deviceId: 'current-mac', name: 'Mac' }]);
+      remoteSessionStore.setDeviceSessions('current-mac', 'Mac', [session('s1')]);
+      remoteSessionStore.applyRemotePush('current-mac', 'maker:event', {
+        sessionId: 's1',
+        event: {
+          type: 'text',
+          data: { text: 'Current reply', isFinal: true },
+        },
+      });
+      const currentClientId = remoteSessionStore.getMessages('s1')[0]?.clientId;
+
+      remoteSessionStore.applyRemotePush('stale-mac', 'maker:event', {
+        sessionId: 's1',
+        persistId: 'stale-persisted-assistant',
+        event: {
+          type: 'text',
+          data: { text: 'Stale replay', isFinal: true },
+        },
+      });
+
+      expect(currentClientId).toMatch(/^mobile-stream-/);
+      expect(remoteSessionStore.getMessages('s1')).toMatchObject([{
+        clientId: currentClientId,
+        content: 'Current reply',
+      }]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('keeps current generated ownership across a done boundary before stale replay', () => {
+    vi.useFakeTimers();
+    try {
+      remoteSessionStore.setDeviceIdentity([{ deviceId: 'current-mac', name: 'Mac' }]);
+      remoteSessionStore.setDeviceSessions('current-mac', 'Mac', [session('s1')]);
+      remoteSessionStore.applyRemotePush('current-mac', 'maker:event', {
+        sessionId: 's1',
+        event: {
+          type: 'text',
+          data: { text: 'Current reply', isFinal: true },
+        },
+      });
+      const currentClientId = remoteSessionStore.getMessages('s1')[0]?.clientId;
+      remoteSessionStore.applyRemotePush('current-mac', 'maker:event', {
+        sessionId: 's1',
+        event: { type: 'done', data: {} },
+      });
+
+      remoteSessionStore.applyRemotePush('stale-mac', 'maker:event', {
+        sessionId: 's1',
+        persistId: 'stale-persisted-assistant',
+        event: {
+          type: 'text',
+          data: { text: 'Stale replay', isFinal: true },
+        },
+      });
+
+      expect(currentClientId).toMatch(/^mobile-stream-/);
+      expect(remoteSessionStore.getMessages('s1')).toMatchObject([{
+        clientId: currentClientId,
+        content: 'Current reply',
+      }]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('allows a replacement transport when no authoritative device identity is available', () => {
+    vi.useFakeTimers();
+    try {
+      remoteSessionStore.setDeviceSessions('stale-mac', 'Mac', [session('s1')]);
+      remoteSessionStore.applyRemotePush('stale-mac', 'maker:event', {
+        sessionId: 's1',
+        persistId: 'shared-live-assistant',
+        event: {
+          type: 'text',
+          data: { text: 'Stale reply', isFinal: true },
+        },
+      });
+      remoteSessionStore.applyRemotePush('current-mac', 'maker:event', {
+        sessionId: 's1',
+        persistId: 'shared-live-assistant',
+        event: {
+          type: 'text',
+          data: { text: 'Current reply', isFinal: true },
+        },
+      });
+
+      remoteSessionStore.removeDevice('stale-mac');
+      expect(remoteSessionStore.getMessages('s1')).toMatchObject([{
+        clientId: 'shared-live-assistant',
+        content: 'Current reply',
+      }]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('lets the canonical current transport replace an indexed stale assembly', () => {
+    vi.useFakeTimers();
+    try {
+      remoteSessionStore.setDeviceIdentity([{ deviceId: 'current-mac', name: 'Mac' }]);
+      remoteSessionStore.setDeviceSessions('stale-mac', 'Mac', [session('s1')]);
+      remoteSessionStore.applyRemotePush('stale-mac', 'maker:event', {
+        sessionId: 's1',
+        persistId: 'shared-live-assistant',
+        event: {
+          type: 'text',
+          data: { text: 'Stale reply', isFinal: true },
+        },
+      });
+      remoteSessionStore.applyRemotePush('current-mac', 'maker:event', {
+        sessionId: 's1',
+        persistId: 'shared-live-assistant',
+        event: {
+          type: 'text',
+          data: { text: 'Current reply', isFinal: true },
+        },
+      });
+
+      remoteSessionStore.removeDevice('stale-mac');
+      expect(remoteSessionStore.getMessages('s1')).toMatchObject([{
+        clientId: 'shared-live-assistant',
+        content: 'Current reply',
+      }]);
     } finally {
       vi.useRealTimers();
     }

--- a/apps/mobile/src/__tests__/remoteSessionStore.test.ts
+++ b/apps/mobile/src/__tests__/remoteSessionStore.test.ts
@@ -4045,6 +4045,62 @@ describe('device-clock live row clamp (applyRemoteTextEvent createdAt, cross-clo
     }
   });
 
+  it('一次权威窗口带回多轮 user 时,按窗口顺序逐条配对 provisional 回复', () => {
+    vi.useFakeTimers();
+    try {
+      remoteSessionStore.setDeviceSessions('dev-1', 'Mac', [session('s1', {
+        userSendAt: '2026-01-01T00:00:02.000Z',
+        updatedAt: '2026-01-01T00:00:02.000Z',
+      })]);
+      vi.setSystemTime(new Date('2026-01-01T00:10:00.000Z'));
+      pushMakerText('s1', 'live-assistant-1', 'First reply', true);
+      vi.setSystemTime(new Date('2026-01-01T00:11:00.000Z'));
+      pushMakerText('s1', 'live-assistant-2', 'Second reply', true);
+
+      remoteSessionStore.setLatestMessageWindow('s1', [
+        {
+          ...messageAt('user-1', 's1', '2026-01-01T00:00:01.000Z'),
+          role: 'user',
+          content: 'First question',
+        },
+        {
+          ...messageAt('user-2', 's1', '2026-01-01T00:00:02.000Z'),
+          role: 'user',
+          content: 'Second question',
+        },
+      ]);
+
+      const rows = remoteSessionStore.getMessages('s1');
+      expect(rows.map((item) => item.clientId)).toEqual([
+        'user-1',
+        'live-assistant-1',
+        'user-2',
+        'live-assistant-2',
+      ]);
+      expect(rows.map((item) => item.createdAt)).toEqual([
+        '2026-01-01T00:00:01.000Z',
+        '2026-01-01T00:00:01.000Z',
+        '2026-01-01T00:00:02.000Z',
+        '2026-01-01T00:00:02.000Z',
+      ]);
+
+      remoteSessionStore.appendMessage('s1', {
+        ...messageAt('user-3', 's1', '2026-01-01T00:00:03.000Z'),
+        role: 'user',
+        content: 'Third question',
+      });
+      expect(remoteSessionStore.getMessages('s1').map((item) => item.clientId)).toEqual([
+        'user-1',
+        'live-assistant-1',
+        'user-2',
+        'live-assistant-2',
+        'user-3',
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('早于本轮发送时间的 user 最新窗口只临时重锚,仍等待当前 user push 完成配对', () => {
     vi.useFakeTimers();
     try {

--- a/apps/mobile/src/__tests__/remoteSessionStore.test.ts
+++ b/apps/mobile/src/__tests__/remoteSessionStore.test.ts
@@ -3156,6 +3156,53 @@ describe('remoteSessionStore', () => {
     }
   });
 
+  it('pairs multiple offline-unbound reply cohorts with realtime users in arrival order', () => {
+    vi.useFakeTimers();
+    try {
+      remoteSessionStore.applyMakerEvent('s1', {
+        type: 'status',
+        data: { isRunning: true },
+      });
+      vi.setSystemTime(new Date('2026-01-01T00:10:00.000Z'));
+      pushMakerText('s1', 'live-assistant-1', 'First reply', true);
+      remoteSessionStore.applyMakerEvent('s1', {
+        type: 'status',
+        data: { isRunning: false },
+      });
+      remoteSessionStore.applyMakerEvent('s1', {
+        type: 'status',
+        data: { isRunning: true },
+      });
+      vi.setSystemTime(new Date('2026-01-01T00:11:00.000Z'));
+      pushMakerText('s1', 'live-assistant-2', 'Second reply', true);
+
+      remoteSessionStore.markDeviceOffline('dev-1');
+      remoteSessionStore.upsertDeviceSession('dev-1', 'Mac', session('s1', {
+        userSendAt: '2026-01-01T00:00:02.000Z',
+        updatedAt: '2026-01-01T00:00:02.000Z',
+      }));
+      remoteSessionStore.appendMessage('s1', {
+        ...messageAt('user-1', 's1', '2026-01-01T00:00:01.000Z'),
+        role: 'user',
+        content: 'First question',
+      });
+      remoteSessionStore.appendMessage('s1', {
+        ...messageAt('user-2', 's1', '2026-01-01T00:00:02.000Z'),
+        role: 'user',
+        content: 'Second question',
+      });
+
+      expect(remoteSessionStore.getMessages('s1').map((item) => item.clientId)).toEqual([
+        'user-1',
+        'live-assistant-1',
+        'user-2',
+        'live-assistant-2',
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('emits when soft offline only clears pending-refresh metadata', () => {
     remoteSessionStore.setDeviceSessions('dev-1', 'Mac', [session('s1')]);
     remoteSessionStore.applyRemotePush('dev-1', 'local-db:session:error-persisted', {
@@ -3212,7 +3259,9 @@ describe('remoteSessionStore', () => {
     try {
       vi.setSystemTime(new Date('2026-01-01T00:10:00.000Z'));
       pushMakerText('s1', 'live-assistant', 'Stale reply', true);
+      remoteSessionStore.setSessionRunning('s1', true);
       expect(remoteSessionStore.getMessages('s1')).toHaveLength(1);
+      expect(remoteSessionStore.getSessionRunStatus('s1').isRunning).toBe(true);
 
       remoteSessionStore.removeDevice('dev-1');
       remoteSessionStore.setDeviceSessions('dev-1', 'Mac', [session('s1', {
@@ -3220,6 +3269,7 @@ describe('remoteSessionStore', () => {
         updatedAt: '2026-01-01T00:00:01.000Z',
       })]);
       expect(remoteSessionStore.getMessages('s1')).toEqual([]);
+      expect(remoteSessionStore.getSessionRunStatus('s1').isRunning).toBe(false);
     } finally {
       vi.useRealTimers();
     }
@@ -3249,6 +3299,70 @@ describe('remoteSessionStore', () => {
       expect(remoteSessionStore.getSessionDeviceId('s1')).toBe('current-mac');
       expect(remoteSessionStore.getMessages('s1').map((item) => item.clientId)).toEqual([
         'current-assistant',
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it.each([
+    ['stale transport writes first', ['stale-mac', 'current-mac']],
+    ['stale transport writes last', ['current-mac', 'stale-mac']],
+  ] as const)('removes only the stale transport provisional reply when %s', (_label, deviceOrder) => {
+    vi.useFakeTimers();
+    try {
+      remoteSessionStore.setDeviceSessions('current-mac', 'Mac', [session('s1')]);
+      vi.setSystemTime(new Date('2026-01-01T00:10:00.000Z'));
+      for (const deviceId of deviceOrder) {
+        const isStale = deviceId === 'stale-mac';
+        remoteSessionStore.applyRemotePush(deviceId, 'maker:event', {
+          sessionId: 's1',
+          persistId: isStale ? 'stale-live-assistant' : 'current-live-assistant',
+          event: {
+            type: 'text',
+            data: {
+              text: isStale ? 'Stale reply' : 'Current reply',
+              isFinal: true,
+            },
+          },
+        });
+      }
+
+      expect(remoteSessionStore.getMessages('s1').map((item) => item.clientId).sort()).toEqual([
+        'current-live-assistant',
+        'stale-live-assistant',
+      ]);
+      remoteSessionStore.removeDevice('stale-mac');
+
+      expect(remoteSessionStore.getSessionDeviceId('s1')).toBe('current-mac');
+      expect(remoteSessionStore.getMessages('s1').map((item) => item.clientId)).toEqual([
+        'current-live-assistant',
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('keeps a provisional reply that is also owned by the current transport', () => {
+    vi.useFakeTimers();
+    try {
+      remoteSessionStore.setDeviceSessions('current-mac', 'Mac', [session('s1')]);
+      vi.setSystemTime(new Date('2026-01-01T00:10:00.000Z'));
+      for (const deviceId of ['stale-mac', 'current-mac']) {
+        remoteSessionStore.applyRemotePush(deviceId, 'maker:event', {
+          sessionId: 's1',
+          persistId: 'shared-live-assistant',
+          event: {
+            type: 'text',
+            data: { text: 'Shared reply', isFinal: true },
+          },
+        });
+      }
+
+      remoteSessionStore.removeDevice('stale-mac');
+
+      expect(remoteSessionStore.getMessages('s1').map((item) => item.clientId)).toEqual([
+        'shared-live-assistant',
       ]);
     } finally {
       vi.useRealTimers();
@@ -4519,6 +4633,79 @@ describe('device-clock live row clamp (applyRemoteTextEvent createdAt, cross-clo
         .toBe('2026-01-01T00:00:03.000Z');
       expect(rows.find((item) => item.clientId === 'live-assistant-4')?.createdAt)
         .toBe('2026-01-01T00:00:04.000Z');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('截断窗口中的中间 user 边界不会认领更旧轮次的 pending 回复', () => {
+    vi.useFakeTimers();
+    try {
+      remoteSessionStore.setDeviceSessions('dev-1', 'Mac', [session('s1', {
+        userSendAt: '2026-01-01T00:00:01.000Z',
+        updatedAt: '2026-01-01T00:00:01.000Z',
+      })]);
+      vi.setSystemTime(new Date('2026-01-01T00:10:00.000Z'));
+      pushMakerText('s1', 'live-assistant-1', 'First reply', true);
+
+      remoteSessionStore.upsertDeviceSession('dev-1', 'Mac', session('s1', {
+        userSendAt: '2026-01-01T00:00:02.000Z',
+        updatedAt: '2026-01-01T00:00:02.000Z',
+      }));
+      pushMakerText('s1', 'live-assistant-2', 'Second reply', true);
+      remoteSessionStore.appendMessage('s1', {
+        ...messageAt('user-2', 's1', '2026-01-01T00:00:02.000Z'),
+        role: 'user',
+        content: 'Second question',
+      });
+
+      remoteSessionStore.upsertDeviceSession('dev-1', 'Mac', session('s1', {
+        userSendAt: '2026-01-01T00:00:03.000Z',
+        updatedAt: '2026-01-01T00:00:03.000Z',
+      }));
+      pushMakerText('s1', 'live-assistant-3', 'Third reply', true);
+      remoteSessionStore.setLatestMessageWindow('s1', [
+        {
+          ...messageAt('user-2', 's1', '2026-01-01T00:00:02.000Z'),
+          role: 'user',
+          content: 'Second question',
+        },
+        {
+          ...messageAt('user-3', 's1', '2026-01-01T00:00:03.000Z'),
+          role: 'user',
+          content: 'Third question',
+        },
+      ]);
+
+      const truncatedRows = remoteSessionStore.getMessages('s1');
+      expect(truncatedRows.find((item) => item.clientId === 'live-assistant-1')?.createdAt)
+        .toBe('2026-01-01T00:00:01.000Z');
+      expect(truncatedRows.map((item) => item.clientId).indexOf('live-assistant-1'))
+        .toBeLessThan(truncatedRows.map((item) => item.clientId).indexOf('user-2'));
+
+      remoteSessionStore.setLatestMessageWindow('s1', [
+        {
+          ...messageAt('user-1', 's1', '2026-01-01T00:00:01.000Z'),
+          role: 'user',
+          content: 'First question',
+        },
+        {
+          ...messageAt('user-2', 's1', '2026-01-01T00:00:02.000Z'),
+          role: 'user',
+          content: 'Second question',
+        },
+        {
+          ...messageAt('user-3', 's1', '2026-01-01T00:00:03.000Z'),
+          role: 'user',
+          content: 'Third question',
+        },
+      ]);
+      const completeRowIds = remoteSessionStore.getMessages('s1').map((item) => item.clientId);
+      expect(completeRowIds.indexOf('live-assistant-1'))
+        .toBe(completeRowIds.indexOf('user-1') + 1);
+      expect(remoteSessionStore.getMessages('s1')
+        .find((item) => item.clientId === 'live-assistant-1')?.createdAt)
+        .toBe('2026-01-01T00:00:01.000Z');
     } finally {
       vi.useRealTimers();
     }

--- a/apps/mobile/src/__tests__/remoteSessionStore.test.ts
+++ b/apps/mobile/src/__tests__/remoteSessionStore.test.ts
@@ -3389,7 +3389,7 @@ describe('remoteSessionStore', () => {
           role: 'user',
           content: 'Second question',
         },
-      ]);
+      ], { moreBeyondWindow: false });
 
       expect(remoteSessionStore.getMessages('s1').map((item) => item.clientId)).toEqual([
         'user-1',
@@ -3438,7 +3438,7 @@ describe('remoteSessionStore', () => {
           role: 'user',
           content: 'Third question',
         },
-      ]);
+      ], { moreBeyondWindow: true });
 
       expect(remoteSessionStore.getMessages('s1').map((item) => item.clientId)).toEqual([
         'user-2',
@@ -3492,10 +3492,58 @@ describe('remoteSessionStore', () => {
           role: 'user',
           content: 'Third question',
         },
-      ]);
+      ], { moreBeyondWindow: false });
 
       expect(remoteSessionStore.getMessages('s1').map((item) => item.clientId)).toEqual([
         'user-1',
+        'user-2',
+        'user-3',
+        'live-assistant-1',
+        'live-assistant-2',
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('leaves offline-unbound cohorts pending when an equal-sized reconnect window is truncated', () => {
+    vi.useFakeTimers();
+    try {
+      for (const [index, createdAt] of [
+        ['1', '2026-01-01T00:10:00.000Z'],
+        ['2', '2026-01-01T00:11:00.000Z'],
+      ] as const) {
+        remoteSessionStore.applyMakerEvent('s1', {
+          type: 'status',
+          data: { isRunning: true },
+        });
+        vi.setSystemTime(new Date(createdAt));
+        pushMakerText('s1', `live-assistant-${index}`, `Reply ${index}`, true);
+        remoteSessionStore.applyMakerEvent('s1', {
+          type: 'status',
+          data: { isRunning: false },
+        });
+      }
+
+      remoteSessionStore.markDeviceOffline('dev-1');
+      remoteSessionStore.upsertDeviceSession('dev-1', 'Mac', session('s1', {
+        userSendAt: '2026-01-01T00:00:03.000Z',
+        updatedAt: '2026-01-01T00:00:03.000Z',
+      }));
+      remoteSessionStore.setLatestMessageWindow('s1', [
+        {
+          ...messageAt('user-2', 's1', '2026-01-01T00:00:02.000Z'),
+          role: 'user',
+          content: 'Second question',
+        },
+        {
+          ...messageAt('user-3', 's1', '2026-01-01T00:00:03.000Z'),
+          role: 'user',
+          content: 'Third question',
+        },
+      ], { moreBeyondWindow: true });
+
+      expect(remoteSessionStore.getMessages('s1').map((item) => item.clientId)).toEqual([
         'user-2',
         'user-3',
         'live-assistant-1',
@@ -3626,6 +3674,50 @@ describe('remoteSessionStore', () => {
     expect(remoteSessionStore.getMessages('s1')).toEqual([
       message('persisted-assistant', 's1'),
     ]);
+  });
+
+  it('retires pending identity when an identical persisted assistant echo arrives', () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+      pushMakerText('s1', 'persisted-assistant', 'hello', true);
+      remoteSessionStore.appendMessage('s1', message('persisted-assistant', 's1'));
+
+      remoteSessionStore.appendMessage('s1', {
+        ...messageAt('next-user', 's1', '2026-01-01T00:00:01.000Z'),
+        role: 'user',
+        content: 'Next question',
+      });
+
+      expect(remoteSessionStore.getMessages('s1').map((item) => item.clientId)).toEqual([
+        'persisted-assistant',
+        'next-user',
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('keeps pending identity for an identical live transport replay', () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+      pushMakerText('s1', 'live-assistant', 'hello', true);
+      pushMakerText('s1', 'live-assistant', 'hello', true);
+
+      remoteSessionStore.appendMessage('s1', {
+        ...messageAt('trigger-user', 's1', '2026-01-01T00:00:01.000Z'),
+        role: 'user',
+        content: 'Question',
+      });
+
+      expect(remoteSessionStore.getMessages('s1').map((item) => item.clientId)).toEqual([
+        'trigger-user',
+        'live-assistant',
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('does not let a stale transport mutate or claim a persisted assistant row', () => {

--- a/apps/mobile/src/__tests__/remoteSessionStore.test.ts
+++ b/apps/mobile/src/__tests__/remoteSessionStore.test.ts
@@ -4014,6 +4014,42 @@ describe('device-clock live row clamp (applyRemoteTextEvent createdAt, cross-clo
     }
   });
 
+  it('早于本轮发送时间的 user push 不会消费当前轮 live 回复的待重锚身份', () => {
+    vi.useFakeTimers();
+    try {
+      remoteSessionStore.setDeviceSessions('dev-1', 'Mac', [session('s1', {
+        userSendAt: '2026-01-01T00:00:02.000Z',
+        updatedAt: '2026-01-01T00:00:02.000Z',
+      })]);
+      vi.setSystemTime(new Date('2026-01-01T00:10:00.000Z'));
+      pushMakerText('s1', 'current-live-assistant', 'Current reply', true);
+
+      remoteSessionStore.appendMessage('s1', {
+        ...messageAt('delayed-previous-user', 's1', '2026-01-01T00:00:01.000Z'),
+        role: 'user',
+        content: 'Previous question',
+      });
+      remoteSessionStore.appendMessage('s1', {
+        ...messageAt('current-user', 's1', '2026-01-01T00:00:02.000Z'),
+        role: 'user',
+        content: 'Current question',
+      });
+
+      const rows = remoteSessionStore.getMessages('s1');
+      expect(rows.map((item) => item.clientId)).toEqual([
+        'delayed-previous-user',
+        'current-user',
+        'current-live-assistant',
+      ]);
+      expect(rows.slice(1).map((item) => item.createdAt)).toEqual([
+        '2026-01-01T00:00:02.000Z',
+        '2026-01-01T00:00:02.000Z',
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('匹配本轮发送时间的 user 最新窗口会完成配对,下一轮 user 不再认领旧回复', () => {
     vi.useFakeTimers();
     try {
@@ -4096,6 +4132,59 @@ describe('device-clock live row clamp (applyRemoteTextEvent createdAt, cross-clo
         'live-assistant-2',
         'user-3',
       ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('截断权威窗口只配对窗口内对应的最新 provisional 回复', () => {
+    vi.useFakeTimers();
+    try {
+      remoteSessionStore.setDeviceSessions('dev-1', 'Mac', [session('s1', {
+        userSendAt: '2026-01-01T00:00:03.000Z',
+        updatedAt: '2026-01-01T00:00:03.000Z',
+      })]);
+      vi.setSystemTime(new Date('2026-01-01T00:10:00.000Z'));
+      pushMakerText('s1', 'live-assistant-1', 'First reply', true);
+      pushMakerText('s1', 'live-assistant-2', 'Second reply', true);
+      pushMakerText('s1', 'live-assistant-3', 'Third reply', true);
+
+      remoteSessionStore.setLatestMessageWindow('s1', [
+        {
+          ...messageAt('user-2', 's1', '2026-01-01T00:00:02.000Z'),
+          role: 'user',
+          content: 'Second question',
+        },
+        {
+          ...messageAt('user-3', 's1', '2026-01-01T00:00:03.000Z'),
+          role: 'user',
+          content: 'Third question',
+        },
+      ]);
+
+      remoteSessionStore.upsertDeviceSession('dev-1', 'Mac', session('s1', {
+        userSendAt: '2026-01-01T00:00:04.000Z',
+        updatedAt: '2026-01-01T00:00:04.000Z',
+      }));
+      pushMakerText('s1', 'live-assistant-4', 'Fourth reply', true);
+      remoteSessionStore.appendMessage('s1', {
+        ...messageAt('user-4', 's1', '2026-01-01T00:00:04.000Z'),
+        role: 'user',
+        content: 'Fourth question',
+      });
+
+      const rows = remoteSessionStore.getMessages('s1');
+      const rowIds = rows.map((item) => item.clientId);
+      expect(rowIds.indexOf('live-assistant-2')).toBe(rowIds.indexOf('user-2') + 1);
+      expect(rowIds.indexOf('live-assistant-3')).toBe(rowIds.indexOf('user-3') + 1);
+      expect(rowIds.indexOf('live-assistant-4')).toBe(rowIds.indexOf('user-4') + 1);
+      expect(rowIds.indexOf('live-assistant-1')).toBeLessThan(rowIds.indexOf('user-4'));
+      expect(rows.find((item) => item.clientId === 'live-assistant-2')?.createdAt)
+        .toBe('2026-01-01T00:00:02.000Z');
+      expect(rows.find((item) => item.clientId === 'live-assistant-3')?.createdAt)
+        .toBe('2026-01-01T00:00:03.000Z');
+      expect(rows.find((item) => item.clientId === 'live-assistant-4')?.createdAt)
+        .toBe('2026-01-01T00:00:04.000Z');
     } finally {
       vi.useRealTimers();
     }

--- a/apps/mobile/src/__tests__/remoteSessionStore.test.ts
+++ b/apps/mobile/src/__tests__/remoteSessionStore.test.ts
@@ -3736,6 +3736,83 @@ describe('device-clock live row clamp (applyRemoteTextEvent createdAt, cross-clo
     }
   });
 
+  it('首个短 live 行早于会话元数据时,元数据到达后把设备时间重锚到主机时间域', () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date('2026-01-01T00:10:00.000Z'));
+      pushMakerText('s1', undefined, 'OK', true);
+
+      expect(remoteSessionStore.getMessages('s1')[0]?.createdAt)
+        .toBe('2026-01-01T00:10:00.000Z');
+
+      remoteSessionStore.upsertDeviceSession('dev-1', 'Mac', session('s1', {
+        userSendAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+      }));
+      remoteSessionStore.appendMessage('s1', {
+        ...messageAt('persisted-short', 's1', '2026-01-01T00:00:01.000Z'),
+        content: 'OK',
+      });
+
+      const rows = remoteSessionStore.getMessages('s1');
+      expect(rows).toHaveLength(2);
+      expect(rows[0]?.clientId).toMatch(/^mobile-stream-/);
+      expect(rows[0]?.createdAt).toBe('2026-01-01T00:00:00.000Z');
+      expect(rows[1]?.clientId).toBe('persisted-short');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('多帧 live 行在会话元数据到达前持续保留待重锚标记', () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date('2026-01-01T00:10:00.000Z'));
+      pushMakerText('s1', undefined, 'O', false);
+      vi.runOnlyPendingTimers();
+      const provisionalCreatedAt = remoteSessionStore.getMessages('s1')[0]?.createdAt;
+      pushMakerText('s1', undefined, 'K', true);
+
+      expect(remoteSessionStore.getMessages('s1')[0]).toMatchObject({
+        content: 'OK',
+        createdAt: provisionalCreatedAt,
+      });
+
+      remoteSessionStore.upsertDeviceSession('dev-1', 'Mac', session('s1', {
+        userSendAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+      }));
+
+      expect(remoteSessionStore.getMessages('s1')[0]).toMatchObject({
+        content: 'OK',
+        createdAt: '2026-01-01T00:00:00.000Z',
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('主机持久化消息早于会话元数据时,也会收口临时 live 行的设备时间', () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date('2026-01-01T00:10:00.000Z'));
+      pushMakerText('s1', undefined, 'OK', true);
+
+      remoteSessionStore.appendMessage('s1', {
+        ...messageAt('persisted-short', 's1', '2026-01-01T00:00:01.000Z'),
+        content: 'OK',
+      });
+
+      const rows = remoteSessionStore.getMessages('s1');
+      expect(rows).toHaveLength(2);
+      expect(rows[0]?.clientId).toMatch(/^mobile-stream-/);
+      expect(rows[0]?.createdAt).toBe('2026-01-01T00:00:01.000Z');
+      expect(rows[1]?.clientId).toBe('persisted-short');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('流式增量的首个 delta 落定 createdAt 后,后续 delta 沿用同一戳(不重复取设备时间/不重新钳制)', () => {
     vi.useFakeTimers();
     try {

--- a/apps/mobile/src/__tests__/remoteSessionStore.test.ts
+++ b/apps/mobile/src/__tests__/remoteSessionStore.test.ts
@@ -3979,6 +3979,103 @@ describe('device-clock live row clamp (applyRemoteTextEvent createdAt, cross-clo
     }
   });
 
+  it('延迟的非 user push 不会消费当前轮 live 回复的待重锚身份', () => {
+    vi.useFakeTimers();
+    try {
+      remoteSessionStore.setDeviceSessions('dev-1', 'Mac', [session('s1', {
+        userSendAt: '2026-01-01T00:00:02.000Z',
+        updatedAt: '2026-01-01T00:00:02.000Z',
+      })]);
+      vi.setSystemTime(new Date('2026-01-01T00:10:00.000Z'));
+      pushMakerText('s1', 'current-live-assistant', 'Current reply', true);
+
+      remoteSessionStore.appendMessage('s1', {
+        ...messageAt('delayed-previous-assistant', 's1', '2026-01-01T00:00:01.000Z'),
+        content: 'Delayed previous reply',
+      });
+      remoteSessionStore.appendMessage('s1', {
+        ...messageAt('current-user', 's1', '2026-01-01T00:00:02.000Z'),
+        role: 'user',
+        content: 'Current question',
+      });
+
+      const rows = remoteSessionStore.getMessages('s1');
+      expect(rows.map((item) => item.clientId)).toEqual([
+        'delayed-previous-assistant',
+        'current-user',
+        'current-live-assistant',
+      ]);
+      expect(rows.slice(1).map((item) => item.createdAt)).toEqual([
+        '2026-01-01T00:00:02.000Z',
+        '2026-01-01T00:00:02.000Z',
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('匹配本轮发送时间的 user 最新窗口会完成配对,下一轮 user 不再认领旧回复', () => {
+    vi.useFakeTimers();
+    try {
+      remoteSessionStore.setDeviceSessions('dev-1', 'Mac', [session('s1', {
+        userSendAt: '2026-01-01T00:00:01.000Z',
+        updatedAt: '2026-01-01T00:00:01.000Z',
+      })]);
+      vi.setSystemTime(new Date('2026-01-01T00:10:00.000Z'));
+      pushMakerText('s1', 'live-assistant-1', 'First reply', true);
+
+      remoteSessionStore.setLatestMessageWindow('s1', [{
+        ...messageAt('user-1', 's1', '2026-01-01T00:00:01.000Z'),
+        role: 'user',
+        content: 'First question',
+      }]);
+      remoteSessionStore.appendMessage('s1', {
+        ...messageAt('user-2', 's1', '2026-01-01T00:00:02.000Z'),
+        role: 'user',
+        content: 'Second question',
+      });
+
+      expect(remoteSessionStore.getMessages('s1').map((item) => item.clientId)).toEqual([
+        'user-1',
+        'live-assistant-1',
+        'user-2',
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('早于本轮发送时间的 user 最新窗口只临时重锚,仍等待当前 user push 完成配对', () => {
+    vi.useFakeTimers();
+    try {
+      remoteSessionStore.setDeviceSessions('dev-1', 'Mac', [session('s1', {
+        userSendAt: '2026-01-01T00:00:02.000Z',
+        updatedAt: '2026-01-01T00:00:02.000Z',
+      })]);
+      vi.setSystemTime(new Date('2026-01-01T00:10:00.000Z'));
+      pushMakerText('s1', 'current-live-assistant', 'Current reply', true);
+
+      remoteSessionStore.setLatestMessageWindow('s1', [{
+        ...messageAt('previous-user', 's1', '2026-01-01T00:00:01.000Z'),
+        role: 'user',
+        content: 'Previous question',
+      }]);
+      remoteSessionStore.appendMessage('s1', {
+        ...messageAt('current-user', 's1', '2026-01-01T00:00:02.000Z'),
+        role: 'user',
+        content: 'Current question',
+      });
+
+      expect(remoteSessionStore.getMessages('s1').map((item) => item.clientId)).toEqual([
+        'previous-user',
+        'current-user',
+        'current-live-assistant',
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('多帧 live 行在会话元数据到达前持续保留待重锚标记', () => {
     vi.useFakeTimers();
     try {

--- a/apps/mobile/src/__tests__/remoteSessionStore.test.ts
+++ b/apps/mobile/src/__tests__/remoteSessionStore.test.ts
@@ -3644,9 +3644,9 @@ describe('device-clock live row clamp (applyRemoteTextEvent createdAt, cross-clo
       .toBe('2026-01-01T00:00:05.000Z');
   });
 
-  it('clampLiveRowCreatedAt: 设备时间领先于既有基准 → 原样返回设备时间(常规场景不受影响)', () => {
+  it('clampLiveRowCreatedAt: 设备时间领先于既有基准 → 锚定既有基准,不让快设备时钟支配后续主机行', () => {
     expect(clampLiveRowCreatedAt('2026-01-01T00:00:05.000Z', '2026-01-01T00:00:01.000Z'))
-      .toBe('2026-01-01T00:00:05.000Z');
+      .toBe('2026-01-01T00:00:01.000Z');
   });
 
   it('clampLiveRowCreatedAt: 设备时间与既有基准相同 → 原样返回(打平,交给 compareMessageOrder 的 rowid/到达序兜底)', () => {
@@ -3684,19 +3684,28 @@ describe('device-clock live row clamp (applyRemoteTextEvent createdAt, cross-clo
     }
   });
 
-  it('常规场景(设备时钟未落后于会话已知最新行)：live 行按设备时间原样落尾,不受钳制影响', () => {
+  it('设备时钟快于主机时,后续主机持久化消息仍能排到旧 live 行之后', () => {
     vi.useFakeTimers();
     try {
       remoteSessionStore.setLatestMessageWindow('s1', [
-        messageAt('user-sent', 's1', '2026-01-01T00:00:00.000Z'),
+        messageAt('previous-user', 's1', '2026-01-01T00:00:00.000Z'),
       ]);
-      vi.setSystemTime(new Date('2026-01-01T00:05:00.000Z'));
-      pushMakerText('s1', 'live-assistant', 'streaming reply', true);
+      vi.setSystemTime(new Date('2026-01-01T00:10:00.000Z'));
+      pushMakerText('s1', 'stale-live-assistant', 'previous streaming reply', true);
+
+      remoteSessionStore.appendMessage('s1', {
+        ...messageAt('new-user', 's1', '2026-01-01T00:05:00.000Z'),
+        role: 'user',
+      });
 
       const rows = remoteSessionStore.getMessages('s1');
-      expect(rows.map((item) => item.clientId)).toEqual(['user-sent', 'live-assistant']);
-      expect(rows.find((item) => item.clientId === 'live-assistant')?.createdAt)
-        .toBe('2026-01-01T00:05:00.000Z');
+      expect(rows.map((item) => item.clientId)).toEqual([
+        'previous-user',
+        'stale-live-assistant',
+        'new-user',
+      ]);
+      expect(rows.find((item) => item.clientId === 'stale-live-assistant')?.createdAt)
+        .toBe('2026-01-01T00:00:00.000Z');
     } finally {
       vi.useRealTimers();
     }

--- a/apps/mobile/src/__tests__/remoteSessionStore.test.ts
+++ b/apps/mobile/src/__tests__/remoteSessionStore.test.ts
@@ -3813,6 +3813,82 @@ describe('device-clock live row clamp (applyRemoteTextEvent createdAt, cross-clo
     }
   });
 
+  it('首个主机 user push 在插入后再重锚,保持问题先于 live 回复', () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date('2026-01-01T00:10:00.000Z'));
+      pushMakerText('s1', undefined, 'OK', true);
+
+      remoteSessionStore.appendMessage('s1', {
+        ...messageAt('persisted-user', 's1', '2026-01-01T00:00:01.000Z'),
+        role: 'user',
+        content: 'Question',
+      });
+
+      const rows = remoteSessionStore.getMessages('s1');
+      expect(rows.map((item) => item.clientId)).toEqual([
+        'persisted-user',
+        expect.stringMatching(/^mobile-stream-/),
+      ]);
+      expect(rows.map((item) => item.createdAt)).toEqual([
+        '2026-01-01T00:00:01.000Z',
+        '2026-01-01T00:00:01.000Z',
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('权威最新消息窗口先于会话元数据到达时也会重锚临时 live 行', () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date('2026-01-01T00:10:00.000Z'));
+      pushMakerText('s1', undefined, 'OK', true);
+
+      remoteSessionStore.setLatestMessageWindow('s1', [{
+        ...messageAt('persisted-user', 's1', '2026-01-01T00:00:01.000Z'),
+        role: 'user',
+        content: 'Question',
+      }]);
+
+      const rows = remoteSessionStore.getMessages('s1');
+      expect(rows.map((item) => item.clientId)).toEqual([
+        'persisted-user',
+        expect.stringMatching(/^mobile-stream-/),
+      ]);
+      expect(rows.map((item) => item.createdAt)).toEqual([
+        '2026-01-01T00:00:01.000Z',
+        '2026-01-01T00:00:01.000Z',
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('权威 assistant 最新窗口重锚后仍让持久化行占据尾部', () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date('2026-01-01T00:10:00.000Z'));
+      pushMakerText('s1', undefined, 'OK', true);
+
+      remoteSessionStore.setLatestMessageWindow('s1', [{
+        ...messageAt('persisted-short', 's1', '2026-01-01T00:00:01.000Z'),
+        content: 'OK',
+      }]);
+
+      const rows = remoteSessionStore.getMessages('s1');
+      expect(rows).toHaveLength(2);
+      expect(rows[0]?.clientId).toMatch(/^mobile-stream-/);
+      expect(rows[1]?.clientId).toBe('persisted-short');
+      expect(rows.map((item) => item.createdAt)).toEqual([
+        '2026-01-01T00:00:01.000Z',
+        '2026-01-01T00:00:01.000Z',
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('流式增量的首个 delta 落定 createdAt 后,后续 delta 沿用同一戳(不重复取设备时间/不重新钳制)', () => {
     vi.useFakeTimers();
     try {

--- a/apps/mobile/src/__tests__/remoteSessionStore.test.ts
+++ b/apps/mobile/src/__tests__/remoteSessionStore.test.ts
@@ -632,6 +632,47 @@ describe('remoteSessionStore', () => {
     }
   });
 
+  it('resets a shared-persist streaming row after both transport batches flush', () => {
+    vi.useFakeTimers();
+    try {
+      remoteSessionStore.applyRemotePush('stale-mac', 'maker:event', {
+        sessionId: 's1',
+        persistId: 'shared-live-assistant',
+        event: {
+          type: 'text',
+          data: { text: 'Stale reply', isFinal: false },
+        },
+      });
+      vi.runOnlyPendingTimers();
+
+      remoteSessionStore.applyRemotePush('current-mac', 'maker:event', {
+        sessionId: 's1',
+        persistId: 'shared-live-assistant',
+        event: {
+          type: 'text',
+          data: { text: 'Current reply', isFinal: false },
+        },
+      });
+      vi.runOnlyPendingTimers();
+
+      expect(remoteSessionStore.getMessages('s1')).toMatchObject([{
+        clientId: 'shared-live-assistant',
+        content: 'Current reply',
+        role: 'assistant',
+      }]);
+
+      remoteSessionStore.removeDevice('stale-mac');
+
+      expect(remoteSessionStore.getMessages('s1')).toMatchObject([{
+        clientId: 'shared-live-assistant',
+        content: 'Current reply',
+        role: 'assistant',
+      }]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('treats final text as a complete block and clears streaming at done', () => {
     pushMakerText('s1', 'persist-1', 'hello', false);
     pushMakerText('s1', 'persist-1', 'hello world', true, { model: 'claude' });

--- a/apps/mobile/src/__tests__/remoteSessionStore.test.ts
+++ b/apps/mobile/src/__tests__/remoteSessionStore.test.ts
@@ -3711,7 +3711,7 @@ describe('device-clock live row clamp (applyRemoteTextEvent createdAt, cross-clo
     }
   });
 
-  it('空消息窗用会话 userSendAt 锚定短 live 行,后续主机行仍占据列表尾部', () => {
+  it('空消息窗先用会话 userSendAt 临时锚定短 live 行,再由权威消息完成重锚', () => {
     vi.useFakeTimers();
     try {
       remoteSessionStore.setDeviceSessions('dev-1', 'Mac', [session('s1', {
@@ -3721,6 +3721,9 @@ describe('device-clock live row clamp (applyRemoteTextEvent createdAt, cross-clo
       vi.setSystemTime(new Date('2026-01-01T00:10:00.000Z'));
       pushMakerText('s1', undefined, 'OK', true);
 
+      expect(remoteSessionStore.getMessages('s1')[0]?.createdAt)
+        .toBe('2026-01-01T00:00:00.000Z');
+
       remoteSessionStore.appendMessage('s1', {
         ...messageAt('persisted-short', 's1', '2026-01-01T00:00:01.000Z'),
         content: 'OK',
@@ -3729,7 +3732,7 @@ describe('device-clock live row clamp (applyRemoteTextEvent createdAt, cross-clo
       const rows = remoteSessionStore.getMessages('s1');
       expect(rows).toHaveLength(2);
       expect(rows[0]?.clientId).toMatch(/^mobile-stream-/);
-      expect(rows[0]?.createdAt).toBe('2026-01-01T00:00:00.000Z');
+      expect(rows[0]?.createdAt).toBe('2026-01-01T00:00:01.000Z');
       expect(rows[1]?.clientId).toBe('persisted-short');
     } finally {
       vi.useRealTimers();
@@ -3749,6 +3752,10 @@ describe('device-clock live row clamp (applyRemoteTextEvent createdAt, cross-clo
         userSendAt: '2026-01-01T00:00:00.000Z',
         updatedAt: '2026-01-01T00:00:00.000Z',
       }));
+
+      expect(remoteSessionStore.getMessages('s1')[0]?.createdAt)
+        .toBe('2026-01-01T00:00:00.000Z');
+
       remoteSessionStore.appendMessage('s1', {
         ...messageAt('persisted-short', 's1', '2026-01-01T00:00:01.000Z'),
         content: 'OK',
@@ -3757,8 +3764,72 @@ describe('device-clock live row clamp (applyRemoteTextEvent createdAt, cross-clo
       const rows = remoteSessionStore.getMessages('s1');
       expect(rows).toHaveLength(2);
       expect(rows[0]?.clientId).toMatch(/^mobile-stream-/);
-      expect(rows[0]?.createdAt).toBe('2026-01-01T00:00:00.000Z');
+      expect(rows[0]?.createdAt).toBe('2026-01-01T00:00:01.000Z');
       expect(rows[1]?.clientId).toBe('persisted-short');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('旧会话快照只做临时重锚,后续权威 user push 仍会恢复问题先于 live 回复', () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date('2026-01-01T00:10:00.000Z'));
+      pushMakerText('s1', 'live-assistant', 'OK', true);
+
+      remoteSessionStore.setDeviceSessions('dev-1', 'Mac', [session('s1', {
+        userSendAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+      })]);
+
+      expect(remoteSessionStore.getMessages('s1')[0]?.createdAt)
+        .toBe('2026-01-01T00:00:00.000Z');
+
+      remoteSessionStore.appendMessage('s1', {
+        ...messageAt('persisted-user', 's1', '2026-01-01T00:00:01.000Z'),
+        role: 'user',
+        content: 'Question',
+      });
+
+      const rows = remoteSessionStore.getMessages('s1');
+      expect(rows.map((item) => item.clientId)).toEqual([
+        'persisted-user',
+        'live-assistant',
+      ]);
+      expect(rows.map((item) => item.createdAt)).toEqual([
+        '2026-01-01T00:00:01.000Z',
+        '2026-01-01T00:00:01.000Z',
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('只有旧会话快照水位时,随后创建的 live 行也会等待权威消息重锚', () => {
+    vi.useFakeTimers();
+    try {
+      remoteSessionStore.setDeviceSessions('dev-1', 'Mac', [session('s1', {
+        userSendAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+      })]);
+      vi.setSystemTime(new Date('2026-01-01T00:10:00.000Z'));
+      pushMakerText('s1', 'live-assistant', 'OK', true);
+
+      remoteSessionStore.appendMessage('s1', {
+        ...messageAt('persisted-user', 's1', '2026-01-01T00:00:01.000Z'),
+        role: 'user',
+        content: 'Question',
+      });
+
+      const rows = remoteSessionStore.getMessages('s1');
+      expect(rows.map((item) => item.clientId)).toEqual([
+        'persisted-user',
+        'live-assistant',
+      ]);
+      expect(rows.map((item) => item.createdAt)).toEqual([
+        '2026-01-01T00:00:01.000Z',
+        '2026-01-01T00:00:01.000Z',
+      ]);
     } finally {
       vi.useRealTimers();
     }

--- a/apps/mobile/src/__tests__/remoteSessionStore.test.ts
+++ b/apps/mobile/src/__tests__/remoteSessionStore.test.ts
@@ -3688,7 +3688,10 @@ describe('device-clock live row clamp (applyRemoteTextEvent createdAt, cross-clo
     vi.useFakeTimers();
     try {
       remoteSessionStore.setLatestMessageWindow('s1', [
-        messageAt('previous-user', 's1', '2026-01-01T00:00:00.000Z'),
+        {
+          ...messageAt('previous-user', 's1', '2026-01-01T00:00:00.000Z'),
+          role: 'user',
+        },
       ]);
       vi.setSystemTime(new Date('2026-01-01T00:10:00.000Z'));
       pushMakerText('s1', 'stale-live-assistant', 'previous streaming reply', true);
@@ -3863,6 +3866,73 @@ describe('device-clock live row clamp (applyRemoteTextEvent createdAt, cross-clo
       expect(rows.slice(1).map((item) => item.createdAt)).toEqual([
         '2026-01-01T00:00:01.000Z',
         '2026-01-01T00:00:01.000Z',
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('非空会话的旧 assistant 尾行不能让当前 live 回复失去待重锚资格', () => {
+    vi.useFakeTimers();
+    try {
+      remoteSessionStore.setLatestMessageWindow('s1', [
+        messageAt('previous-assistant', 's1', '2026-01-01T00:00:00.000Z'),
+      ]);
+      vi.setSystemTime(new Date('2026-01-01T00:10:00.000Z'));
+      pushMakerText('s1', 'current-live-assistant', 'Current reply', true);
+
+      remoteSessionStore.appendMessage('s1', {
+        ...messageAt('current-user', 's1', '2026-01-01T00:00:01.000Z'),
+        role: 'user',
+        content: 'Current question',
+      });
+
+      const rows = remoteSessionStore.getMessages('s1');
+      expect(rows.map((item) => item.clientId)).toEqual([
+        'previous-assistant',
+        'current-user',
+        'current-live-assistant',
+      ]);
+      expect(rows.slice(1).map((item) => item.createdAt)).toEqual([
+        '2026-01-01T00:00:01.000Z',
+        '2026-01-01T00:00:01.000Z',
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('连续两轮 provisional live 回复按 user push 顺序逐条完成重锚', () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date('2026-01-01T00:10:00.000Z'));
+      pushMakerText('s1', 'live-assistant-1', 'First reply', true);
+      vi.setSystemTime(new Date('2026-01-01T00:11:00.000Z'));
+      pushMakerText('s1', 'live-assistant-2', 'Second reply', true);
+
+      remoteSessionStore.appendMessage('s1', {
+        ...messageAt('user-1', 's1', '2026-01-01T00:00:01.000Z'),
+        role: 'user',
+        content: 'First question',
+      });
+      remoteSessionStore.appendMessage('s1', {
+        ...messageAt('user-2', 's1', '2026-01-01T00:00:02.000Z'),
+        role: 'user',
+        content: 'Second question',
+      });
+
+      const rows = remoteSessionStore.getMessages('s1');
+      expect(rows.map((item) => item.clientId)).toEqual([
+        'user-1',
+        'live-assistant-1',
+        'user-2',
+        'live-assistant-2',
+      ]);
+      expect(rows.map((item) => item.createdAt)).toEqual([
+        '2026-01-01T00:00:01.000Z',
+        '2026-01-01T00:00:01.000Z',
+        '2026-01-01T00:00:02.000Z',
+        '2026-01-01T00:00:02.000Z',
       ]);
     } finally {
       vi.useRealTimers();

--- a/apps/mobile/src/__tests__/remoteSessionStore.test.ts
+++ b/apps/mobile/src/__tests__/remoteSessionStore.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { MAKER_EVENT_BATCH_CHANNEL } from '@cindy/device-link';
+import { clampLiveRowCreatedAt } from '@/session/messagePaging';
 import { remoteSessionStore, sessionPendingWrites } from '@/session/remoteSessionStore';
 import type { InputProjection, PendingInteraction, RemoteMessage, RemoteSession } from '@/session/types';
 
@@ -3632,5 +3633,100 @@ describe('任务消息内存治理', () => {
     expect(remoteSessionStore.isSessionMessageWindowSynced('s1', row)).toBe(false);
     expect(remoteSessionStore.hasPendingRefresh('s1')).toBe(true);
     expect(remoteSessionStore.isSessionMessageAuthorityCurrent(authority)).toBe(true);
+  });
+});
+
+describe('device-clock live row clamp (applyRemoteTextEvent createdAt, cross-clock-domain sort fix)', () => {
+  beforeEach(() => remoteSessionStore.clear());
+
+  it('clampLiveRowCreatedAt: 无既有基准时原样返回设备时间', () => {
+    expect(clampLiveRowCreatedAt('2026-01-01T00:00:05.000Z', undefined))
+      .toBe('2026-01-01T00:00:05.000Z');
+  });
+
+  it('clampLiveRowCreatedAt: 设备时间领先于既有基准 → 原样返回设备时间(常规场景不受影响)', () => {
+    expect(clampLiveRowCreatedAt('2026-01-01T00:00:05.000Z', '2026-01-01T00:00:01.000Z'))
+      .toBe('2026-01-01T00:00:05.000Z');
+  });
+
+  it('clampLiveRowCreatedAt: 设备时间与既有基准相同 → 原样返回(打平,交给 compareMessageOrder 的 rowid/到达序兜底)', () => {
+    expect(clampLiveRowCreatedAt('2026-01-01T00:00:05.000Z', '2026-01-01T00:00:05.000Z'))
+      .toBe('2026-01-01T00:00:05.000Z');
+  });
+
+  it('clampLiveRowCreatedAt: 设备时间落后于既有基准 → 钳制为既有基准本身,不发明 +1ms', () => {
+    expect(clampLiveRowCreatedAt('2026-01-01T00:00:01.000Z', '2026-01-01T00:00:05.000Z'))
+      .toBe('2026-01-01T00:00:05.000Z');
+  });
+
+  it('设备时钟落后会话已知最新行时,新建的 live 行不再被排到该行之前(跨时钟域错位的修复现场)', () => {
+    vi.useFakeTimers();
+    try {
+      // 会话里已有一条 createdAt 更新的行(可能是刚持久化的用户消息,也可能是更早一次
+      // 已经落定的 live 行),随后设备本地时钟给出的「现在」比它更旧 —— 这正是本 bug 的
+      // 跨时钟域场景(不论具体是设备落后还是设备超前,症状同源:新行的设备戳不保证
+      // ≥ 会话已知最新行,可能被排到它前面,`getMessages` 尾部就不是最新内容)。
+      remoteSessionStore.setLatestMessageWindow('s1', [
+        messageAt('user-sent', 's1', '2026-01-01T00:10:00.000Z'),
+      ]);
+      vi.setSystemTime(new Date('2026-01-01T00:05:00.000Z'));
+      pushMakerText('s1', 'live-assistant', 'streaming reply', true);
+
+      const rows = remoteSessionStore.getMessages('s1');
+      // 钳制后,新 live 行的 createdAt 被拉到「已知最新行」自身(打平),稳定排序下
+      // 仍落在其后 —— 不再被排到 user-sent 前面(修复前会因为设备戳更早而插到它前面,
+      // 尾部就会显示旧内容而不是刚发生的这条)。
+      expect(rows.map((item) => item.clientId)).toEqual(['user-sent', 'live-assistant']);
+      expect(rows.find((item) => item.clientId === 'live-assistant')?.createdAt)
+        .toBe('2026-01-01T00:10:00.000Z');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('常规场景(设备时钟未落后于会话已知最新行)：live 行按设备时间原样落尾,不受钳制影响', () => {
+    vi.useFakeTimers();
+    try {
+      remoteSessionStore.setLatestMessageWindow('s1', [
+        messageAt('user-sent', 's1', '2026-01-01T00:00:00.000Z'),
+      ]);
+      vi.setSystemTime(new Date('2026-01-01T00:05:00.000Z'));
+      pushMakerText('s1', 'live-assistant', 'streaming reply', true);
+
+      const rows = remoteSessionStore.getMessages('s1');
+      expect(rows.map((item) => item.clientId)).toEqual(['user-sent', 'live-assistant']);
+      expect(rows.find((item) => item.clientId === 'live-assistant')?.createdAt)
+        .toBe('2026-01-01T00:05:00.000Z');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('流式增量的首个 delta 落定 createdAt 后,后续 delta 沿用同一戳(不重复取设备时间/不重新钳制)', () => {
+    vi.useFakeTimers();
+    try {
+      remoteSessionStore.setLatestMessageWindow('s1', [
+        messageAt('user-sent', 's1', '2026-01-01T00:10:00.000Z'),
+      ]);
+      vi.setSystemTime(new Date('2026-01-01T00:05:00.000Z'));
+      pushMakerText('s1', 'live-assistant', 'partial ', false);
+      // 非 final 的增量先进 pendingTextDeltaBatches,由防抖定时器统一落定
+      // (见 remoteSessionStore.ts scheduleTextDeltaFlush/flushPendingTextDeltas)。
+      vi.runOnlyPendingTimers();
+      const firstStamp = remoteSessionStore.getMessages('s1')
+        .find((item) => item.clientId === 'live-assistant')?.createdAt;
+      expect(firstStamp).toBe('2026-01-01T00:10:00.000Z');
+
+      vi.setSystemTime(new Date('2026-01-01T00:20:00.000Z'));
+      pushMakerText('s1', 'live-assistant', 'and more', false);
+      vi.runOnlyPendingTimers();
+      const secondStamp = remoteSessionStore.getMessages('s1')
+        .find((item) => item.clientId === 'live-assistant')?.createdAt;
+      // 已存在行的 createdAt 保持不变(见 remoteSessionStore.ts applyRemoteTextEvent
+      // 对应分支的注释),不会因为设备时间继续前进而被重新戳一次。
+      expect(secondStamp).toBe(firstStamp);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/apps/mobile/src/__tests__/remoteSessionStore.test.ts
+++ b/apps/mobile/src/__tests__/remoteSessionStore.test.ts
@@ -597,6 +597,41 @@ describe('remoteSessionStore', () => {
     }
   });
 
+  it.each([
+    ['without persistId', undefined],
+    ['with the same persistId', 'shared-live-assistant'],
+  ] as const)('flushes a text delta batch when the transport changes %s', (_label, persistId) => {
+    vi.useFakeTimers();
+    try {
+      remoteSessionStore.applyRemotePush('stale-mac', 'maker:event', {
+        sessionId: 's1',
+        ...(persistId ? { persistId } : {}),
+        event: {
+          type: 'text',
+          data: { text: 'Stale reply', isFinal: false },
+        },
+      });
+      remoteSessionStore.applyRemotePush('current-mac', 'maker:event', {
+        sessionId: 's1',
+        ...(persistId ? { persistId } : {}),
+        event: {
+          type: 'text',
+          data: { text: 'Current reply', isFinal: false },
+        },
+      });
+
+      remoteSessionStore.removeDevice('stale-mac');
+      vi.runOnlyPendingTimers();
+
+      expect(remoteSessionStore.getMessages('s1')).toMatchObject([{
+        content: 'Current reply',
+        role: 'assistant',
+      }]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('treats final text as a complete block and clears streaming at done', () => {
     pushMakerText('s1', 'persist-1', 'hello', false);
     pushMakerText('s1', 'persist-1', 'hello world', true, { model: 'claude' });

--- a/apps/mobile/src/__tests__/remoteSessionStore.test.ts
+++ b/apps/mobile/src/__tests__/remoteSessionStore.test.ts
@@ -3792,6 +3792,64 @@ describe('device-clock live row clamp (applyRemoteTextEvent createdAt, cross-clo
     }
   });
 
+  it('多条 distinct live 行在首个主机水位到达前都保持待重锚', () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date('2026-01-01T00:10:00.000Z'));
+      pushMakerText('s1', 'live-assistant-1', 'First reply', true);
+      vi.setSystemTime(new Date('2026-01-01T00:11:00.000Z'));
+      pushMakerText('s1', 'live-assistant-2', 'Second reply', true);
+
+      expect(remoteSessionStore.getMessages('s1').map((item) => item.createdAt)).toEqual([
+        '2026-01-01T00:10:00.000Z',
+        '2026-01-01T00:11:00.000Z',
+      ]);
+
+      remoteSessionStore.upsertDeviceSession('dev-1', 'Mac', session('s1', {
+        userSendAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+      }));
+
+      expect(remoteSessionStore.getMessages('s1').map((item) => item.createdAt)).toEqual([
+        '2026-01-01T00:00:00.000Z',
+        '2026-01-01T00:00:00.000Z',
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('本地 system card 不会被当成首条 live 行的主机时间水位', () => {
+    vi.useFakeTimers();
+    try {
+      const localCardId = remoteSessionStore.appendLocalSystemCard(
+        's1',
+        'status',
+        {},
+        new Date('2026-01-01T00:10:00.000Z'),
+      );
+      vi.setSystemTime(new Date('2026-01-01T00:11:00.000Z'));
+      pushMakerText('s1', 'live-assistant', 'Reply after local card', true);
+
+      expect(remoteSessionStore.getMessages('s1')
+        .find((item) => item.clientId === 'live-assistant')?.createdAt)
+        .toBe('2026-01-01T00:11:00.000Z');
+
+      remoteSessionStore.upsertDeviceSession('dev-1', 'Mac', session('s1', {
+        userSendAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+      }));
+
+      const rows = remoteSessionStore.getMessages('s1');
+      expect(rows.find((item) => item.id === localCardId)?.createdAt)
+        .toBe('2026-01-01T00:10:00.000Z');
+      expect(rows.find((item) => item.clientId === 'live-assistant')?.createdAt)
+        .toBe('2026-01-01T00:00:00.000Z');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('主机持久化消息早于会话元数据时,也会收口临时 live 行的设备时间', () => {
     vi.useFakeTimers();
     try {

--- a/apps/mobile/src/__tests__/remoteSessionStore.test.ts
+++ b/apps/mobile/src/__tests__/remoteSessionStore.test.ts
@@ -2973,8 +2973,8 @@ describe('remoteSessionStore', () => {
     vi.useFakeTimers();
     try {
       remoteSessionStore.setDeviceSessions('dev-1', 'Mac', [session('s1', {
-        userSendAt: '2026-01-01T00:00:02.000Z',
-        updatedAt: '2026-01-01T00:00:02.000Z',
+        userSendAt: '2026-01-01T00:00:01.000Z',
+        updatedAt: '2026-01-01T00:00:01.000Z',
       })]);
       vi.setSystemTime(new Date('2026-01-01T00:10:00.000Z'));
       pushMakerText('s1', 'current-live-assistant', 'Current reply', true);
@@ -4055,6 +4055,9 @@ describe('device-clock live row clamp (applyRemoteTextEvent createdAt, cross-clo
         role: 'user',
         content: 'Previous question',
       });
+      expect(remoteSessionStore.getMessages('s1')
+        .find((item) => item.clientId === 'current-live-assistant')?.createdAt)
+        .toBe('2026-01-01T00:00:02.000Z');
       remoteSessionStore.appendMessage('s1', {
         ...messageAt('current-user', 's1', '2026-01-01T00:00:02.000Z'),
         role: 'user',
@@ -4216,7 +4219,7 @@ describe('device-clock live row clamp (applyRemoteTextEvent createdAt, cross-clo
     }
   });
 
-  it('早于本轮发送时间的 user 最新窗口只临时重锚,仍等待当前 user push 完成配对', () => {
+  it('早于本轮发送时间的 user 最新窗口不改写当前 live 锚点,仍等待当前 user push 完成配对', () => {
     vi.useFakeTimers();
     try {
       remoteSessionStore.setDeviceSessions('dev-1', 'Mac', [session('s1', {
@@ -4231,6 +4234,9 @@ describe('device-clock live row clamp (applyRemoteTextEvent createdAt, cross-clo
         role: 'user',
         content: 'Previous question',
       }]);
+      expect(remoteSessionStore.getMessages('s1')
+        .find((item) => item.clientId === 'current-live-assistant')?.createdAt)
+        .toBe('2026-01-01T00:00:02.000Z');
       remoteSessionStore.appendMessage('s1', {
         ...messageAt('current-user', 's1', '2026-01-01T00:00:02.000Z'),
         role: 'user',

--- a/apps/mobile/src/__tests__/remoteSessionStore.test.ts
+++ b/apps/mobile/src/__tests__/remoteSessionStore.test.ts
@@ -673,6 +673,46 @@ describe('remoteSessionStore', () => {
     }
   });
 
+  it('tracks transport stream assembly independently for interleaved persist ids', () => {
+    vi.useFakeTimers();
+    try {
+      for (const [deviceId, persistId, text] of [
+        ['stale-mac', 'assistant-a', 'Stale A'],
+        ['stale-mac', 'assistant-b', 'Stale B'],
+        ['current-mac', 'assistant-a', 'Current A'],
+      ] as const) {
+        remoteSessionStore.applyRemotePush(deviceId, 'maker:event', {
+          sessionId: 's1',
+          persistId,
+          event: {
+            type: 'text',
+            data: { text, isFinal: false },
+          },
+        });
+        vi.runOnlyPendingTimers();
+      }
+
+      expect(remoteSessionStore.getMessages('s1').map((item) => ({
+        clientId: item.clientId,
+        content: item.content,
+      })).sort((left, right) => left.clientId.localeCompare(right.clientId))).toEqual([
+        { clientId: 'assistant-a', content: 'Current A' },
+        { clientId: 'assistant-b', content: 'Stale B' },
+      ]);
+
+      remoteSessionStore.removeDevice('stale-mac');
+
+      expect(remoteSessionStore.getMessages('s1').map((item) => ({
+        clientId: item.clientId,
+        content: item.content,
+      }))).toEqual([
+        { clientId: 'assistant-a', content: 'Current A' },
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('treats final text as a complete block and clears streaming at done', () => {
     pushMakerText('s1', 'persist-1', 'hello', false);
     pushMakerText('s1', 'persist-1', 'hello world', true, { model: 'claude' });
@@ -3113,6 +3153,40 @@ describe('remoteSessionStore', () => {
     }
   });
 
+  it('keeps per-identity transport ownership across soft offline finalization', () => {
+    vi.useFakeTimers();
+    try {
+      remoteSessionStore.setDeviceSessions('stale-mac', 'Mac', [session('s1')]);
+      remoteSessionStore.applyRemotePush('stale-mac', 'maker:event', {
+        sessionId: 's1',
+        persistId: 'shared-live-assistant',
+        event: {
+          type: 'text',
+          data: { text: 'Stale reply', isFinal: false },
+        },
+      });
+      vi.runOnlyPendingTimers();
+
+      remoteSessionStore.markDeviceOffline('stale-mac');
+      remoteSessionStore.applyRemotePush('current-mac', 'maker:event', {
+        sessionId: 's1',
+        persistId: 'shared-live-assistant',
+        event: {
+          type: 'text',
+          data: { text: 'Current reply', isFinal: false },
+        },
+      });
+      vi.runOnlyPendingTimers();
+
+      expect(remoteSessionStore.getMessages('s1')).toMatchObject([{
+        clientId: 'shared-live-assistant',
+        content: 'Current reply',
+      }]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('keeps a pre-metadata offline reply unbound until its older user row arrives', () => {
     vi.useFakeTimers();
     try {
@@ -3376,6 +3450,62 @@ describe('remoteSessionStore', () => {
       expect(remoteSessionStore.getMessages('s1').map((item) => item.clientId)).toEqual([
         'current-assistant',
       ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not let an identical transport replay claim a persisted assistant row', () => {
+    remoteSessionStore.setDeviceSessions('current-mac', 'Mac', [session('s1')]);
+    remoteSessionStore.setMessages('s1', [message('persisted-assistant', 's1')]);
+
+    remoteSessionStore.applyRemotePush('stale-mac', 'maker:event', {
+      sessionId: 's1',
+      persistId: 'persisted-assistant',
+      event: {
+        type: 'text',
+        data: { text: 'hello', isFinal: true },
+      },
+    });
+    remoteSessionStore.removeDevice('stale-mac');
+
+    expect(remoteSessionStore.getSessionDeviceId('s1')).toBe('current-mac');
+    expect(remoteSessionStore.getMessages('s1')).toEqual([
+      message('persisted-assistant', 's1'),
+    ]);
+  });
+
+  it.each([
+    ['before the current transport batch flushes', false],
+    ['after the current transport batch flushes', true],
+  ] as const)('keeps replacement transport state %s when removing an indexed stale shard', (
+    _label,
+    flushBeforeRemoval,
+  ) => {
+    vi.useFakeTimers();
+    try {
+      remoteSessionStore.setDeviceSessions('stale-mac', 'Mac', [session('s1')]);
+      remoteSessionStore.applyRemotePush('current-mac', 'maker:event', {
+        sessionId: 's1',
+        persistId: 'current-live-assistant',
+        event: {
+          type: 'text',
+          data: { text: 'Current reply', isFinal: false },
+        },
+      });
+      if (flushBeforeRemoval) vi.runOnlyPendingTimers();
+
+      remoteSessionStore.removeDevice('stale-mac');
+      vi.runOnlyPendingTimers();
+
+      expect(remoteSessionStore.getMessages('s1')).toMatchObject([{
+        clientId: 'current-live-assistant',
+        content: 'Current reply',
+      }]);
+
+      remoteSessionStore.setDeviceSessions('current-mac', 'Mac', [session('s1')]);
+      expect(remoteSessionStore.getSessionDeviceId('s1')).toBe('current-mac');
+      expect(remoteSessionStore.getMessages('s1')).toHaveLength(1);
     } finally {
       vi.useRealTimers();
     }

--- a/apps/mobile/src/__tests__/remoteSessionStore.test.ts
+++ b/apps/mobile/src/__tests__/remoteSessionStore.test.ts
@@ -3711,6 +3711,31 @@ describe('device-clock live row clamp (applyRemoteTextEvent createdAt, cross-clo
     }
   });
 
+  it('空消息窗用会话 userSendAt 锚定短 live 行,后续主机行仍占据列表尾部', () => {
+    vi.useFakeTimers();
+    try {
+      remoteSessionStore.setDeviceSessions('dev-1', 'Mac', [session('s1', {
+        userSendAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+      })]);
+      vi.setSystemTime(new Date('2026-01-01T00:10:00.000Z'));
+      pushMakerText('s1', undefined, 'OK', true);
+
+      remoteSessionStore.appendMessage('s1', {
+        ...messageAt('persisted-short', 's1', '2026-01-01T00:00:01.000Z'),
+        content: 'OK',
+      });
+
+      const rows = remoteSessionStore.getMessages('s1');
+      expect(rows).toHaveLength(2);
+      expect(rows[0]?.clientId).toMatch(/^mobile-stream-/);
+      expect(rows[0]?.createdAt).toBe('2026-01-01T00:00:00.000Z');
+      expect(rows[1]?.clientId).toBe('persisted-short');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('流式增量的首个 delta 落定 createdAt 后,后续 delta 沿用同一戳(不重复取设备时间/不重新钳制)', () => {
     vi.useFakeTimers();
     try {

--- a/apps/mobile/src/__tests__/remoteSessionStore.test.ts
+++ b/apps/mobile/src/__tests__/remoteSessionStore.test.ts
@@ -3714,6 +3714,46 @@ describe('device-clock live row clamp (applyRemoteTextEvent createdAt, cross-clo
     }
   });
 
+  it('会话 userSendAt 已越过旧 user 尾行时,当前 live 回复仍等待本轮 user push 重锚', () => {
+    vi.useFakeTimers();
+    try {
+      remoteSessionStore.setDeviceSessions('dev-1', 'Mac', [session('s1', {
+        userSendAt: '2026-01-01T00:00:02.000Z',
+        updatedAt: '2026-01-01T00:00:02.000Z',
+      })]);
+      remoteSessionStore.setLatestMessageWindow('s1', [{
+        ...messageAt('previous-user', 's1', '2026-01-01T00:00:01.000Z'),
+        role: 'user',
+        content: 'Previous question',
+      }]);
+      vi.setSystemTime(new Date('2026-01-01T00:10:00.000Z'));
+      pushMakerText('s1', 'current-live-assistant', 'Current reply', true);
+
+      expect(remoteSessionStore.getMessages('s1')
+        .find((item) => item.clientId === 'current-live-assistant')?.createdAt)
+        .toBe('2026-01-01T00:00:02.000Z');
+
+      remoteSessionStore.appendMessage('s1', {
+        ...messageAt('current-user', 's1', '2026-01-01T00:00:02.000Z'),
+        role: 'user',
+        content: 'Current question',
+      });
+
+      const rows = remoteSessionStore.getMessages('s1');
+      expect(rows.map((item) => item.clientId)).toEqual([
+        'previous-user',
+        'current-user',
+        'current-live-assistant',
+      ]);
+      expect(rows.slice(1).map((item) => item.createdAt)).toEqual([
+        '2026-01-01T00:00:02.000Z',
+        '2026-01-01T00:00:02.000Z',
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('空消息窗先用会话 userSendAt 临时锚定短 live 行,再由权威消息完成重锚', () => {
     vi.useFakeTimers();
     try {

--- a/apps/mobile/src/session/MessageRenderer.tsx
+++ b/apps/mobile/src/session/MessageRenderer.tsx
@@ -781,16 +781,16 @@ export function MessageRenderer({
     }
     const step = (attempts: number, waitRounds: number) => {
       if (followVerifyGenerationRef.current !== generation) return;
-      // stickToLatest / preserveVisibleContentPosition 与冷开锚定环用同一口径:不看
-      // isDraggingRef ——用户一旦开始拖动,shouldUnpinMobileFollowOnDrag 会在下一次
-      // handleScroll 里把 nearBottomRef 翻 false,下一轮判定就会自然 settle,不需要
-      // 这里另开一条“正在拖动”的短路(也避免拖动开始与本环同一 tick 的时序竞态)。
+      // 贴底跟随意图只认 nearBottomRef:死区内轻触 / 小幅拖动并没有真实解除贴底,
+      // 不能让 userScrollForOlderRef 这根“允许加载历史”的手势记录把校验永久关掉。
+      // 真正上移超过死区时 shouldUnpinMobileFollowOnDrag 会把 nearBottomRef 翻 false,
+      // 下一轮判定自然 settle。
       const action = evaluateMobileAnchorVerify({
         attempts,
         listVisible: true,
         metrics: scrollMetricsRef.current,
         preserveVisibleContentPosition: readingOlderRef.current,
-        stickToLatest: nearBottomRef.current && !userScrollForOlderRef.current,
+        stickToLatest: nearBottomRef.current,
         waitRounds,
       });
       if (action === 'settled' || action === 'give-up') {

--- a/apps/mobile/src/session/MessageRenderer.tsx
+++ b/apps/mobile/src/session/MessageRenderer.tsx
@@ -1043,7 +1043,7 @@ export function MessageRenderer({
   }, [onVisibleShareableMessageIdsReaderChange, readActuallyVisibleShareableMessageIds]);
 
   // 贴底跟随由 handleContentSize 的手动补滚承担(nearBottomRef 是跟随意图的唯一真相);
-  // 跳底直接命令式 scrollToEnd。
+  // 跳底先命令式 scrollToEnd,随后复用同一轮有界落底校验。
   const scrollToBottom = useCallback(() => {
     nearBottomRef.current = true;
     readingOlderRef.current = false;
@@ -1059,7 +1059,8 @@ export function MessageRenderer({
     setIsAwayFromBottom(false);
     setHasNewMessages(false);
     scrollToEndProgrammatically(true);
-  }, [scrollToEndProgrammatically]);
+    runStickToLatestVerify();
+  }, [runStickToLatestVerify, scrollToEndProgrammatically]);
 
   const jumpToPreviousUserMessage = useCallback(() => {
     if (!previousUserTarget) return;

--- a/apps/mobile/src/session/MessageRenderer.tsx
+++ b/apps/mobile/src/session/MessageRenderer.tsx
@@ -1047,6 +1047,7 @@ export function MessageRenderer({
   const scrollToBottom = useCallback(() => {
     nearBottomRef.current = true;
     readingOlderRef.current = false;
+    userScrollForOlderRef.current = false;
     // 用户主动跳底是明确的重锚意图:重建补滚护栏(清掉可能仍开着的断路窗,
     // 让跳底后的贴底跟随立即恢复;振荡若还在会重新跳闸,review P2)。在飞的
     // 断路清账 timer 一并作废——本次显式跳底就是清账。
@@ -1082,6 +1083,10 @@ export function MessageRenderer({
     if (followLatestRequestKey === null || followLatestRequestKey === undefined) return;
     nearBottomRef.current = true;
     readingOlderRef.current = false;
+    // 发送后的显式贴底已经取代旧的历史浏览意图。先清掉该标记,否则 verifier 的
+    // stickToLatest 会被一次更早的拖动永久压成 false,退化回不可靠的单次 scrollToEnd。
+    // 用户若在校验期间再次拖动,onScrollBeginDrag 会重新置 true 并自然中止补滚。
+    userScrollForOlderRef.current = false;
     // 与 scrollToBottom 同语义:显式重锚清掉补滚护栏的断路窗与在飞清账 timer。
     followEndPinStateRef.current = createMobileFollowEndPinState();
     if (followEndPinRecoveryTimerRef.current) {

--- a/apps/mobile/src/session/MessageRenderer.tsx
+++ b/apps/mobile/src/session/MessageRenderer.tsx
@@ -298,7 +298,9 @@ import {
   evaluateMessageWindowUpdate,
   evaluateMobileAnchorVerify,
   evaluateMobileFollowEndContentSizePin,
+  isMobileMvcpSettling,
   mobileFollowVerifyStartDelayMs,
+  mobileMvcpSettleDeadline,
   mobileMessageListTopPadding,
   MOBILE_FOLLOW_END_PIN_SUPPRESS_MS,
   MOBILE_MESSAGE_LIST_BOTTOM_PADDING,
@@ -627,6 +629,10 @@ export function MessageRenderer({
   const readingOlderRef = useRef(false);
   // 每次补页分配 generation：旧会话 / 旧请求的异步 settle 不得清掉新请求的抑制态。
   const readingOlderRequestGenerationRef = useRef(0);
+  // LegendList mVCP 始终开启；普通尾部 append / 流式 resize 同样会触发 native 锚点
+  // 调整，不能只拿 readingOlderRef 代表 settle 状态。每次 data / size 变化延长一个短
+  // 安静窗，verifier 在窗内只等待，不消耗 6 次补滚预算。
+  const mvcpSettleAtRef = useRef(0);
   const programmaticScrollGenerationRef = useRef(0);
   const programmaticScrollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const programmaticScrollInFlightRef = useRef(false);
@@ -677,6 +683,7 @@ export function MessageRenderer({
     lastAutoLoadEarlierKeyRef.current = null;
     readingOlderRef.current = false;
     readingOlderRequestGenerationRef.current += 1;
+    mvcpSettleAtRef.current = 0;
     programmaticScrollGenerationRef.current += 1;
     programmaticScrollInFlightRef.current = false;
     programmaticAnimatedScrollInFlightRef.current = false;
@@ -768,6 +775,13 @@ export function MessageRenderer({
     }
   }, []);
 
+  const markMobileMvcpSettle = useCallback(() => {
+    mvcpSettleAtRef.current = mobileMvcpSettleDeadline(
+      mvcpSettleAtRef.current,
+      Date.now(),
+    );
+  }, []);
+
   const scrollToEndProgrammatically = useCallback((animated: boolean) => {
     markProgrammaticScroll(animated);
     void listRef.current?.scrollToEnd({ animated });
@@ -810,7 +824,8 @@ export function MessageRenderer({
         attempts,
         listVisible: true,
         metrics: scrollMetricsRef.current,
-        preserveVisibleContentPosition: readingOlderRef.current,
+        preserveVisibleContentPosition: readingOlderRef.current
+          || isMobileMvcpSettling(Date.now(), mvcpSettleAtRef.current),
         stickToLatest: nearBottomRef.current,
         waitRounds,
       });
@@ -879,6 +894,9 @@ export function MessageRenderer({
     prevListLengthRef.current = listData.length;
   }
   const itemKeys = useMemo(() => listData.map((item) => item.key), [listData]);
+  useEffect(() => {
+    markMobileMvcpSettle();
+  }, [itemKeys, markMobileMvcpSettle]);
   const firstItemKey = itemKeys[0] ?? null;
   // 本地缩略兜底映射版本:collect 内部对 cindy-oss-attach:// 附件读全局 store 做 overlay,
   // hydrate / 新注册后 gallery 需要重建,否则点开气泡本地图时 initialUrl 对不上图集条目。
@@ -1297,6 +1315,7 @@ export function MessageRenderer({
   // 上翻历史时 nearBottomRef=false,不打断。animated:false → 即时跟随、不排队动画。
   // LegendList 内置 maintainScrollAtEnd 已弃用(见 LegendList props 注释),不存在双机制叠加。
   const handleContentSize = useCallback((_width: number, height: number) => {
+    markMobileMvcpSettle();
     const { viewportHeight } = scrollMetricsRef.current;
     scrollMetricsRef.current = { ...scrollMetricsRef.current, contentHeight: height };
     // readingOlderRef:load-earlier 的 prepend 也会撑高 contentHeight,但那是顶部增长、不该贴底(review P1)。
@@ -1344,7 +1363,7 @@ export function MessageRenderer({
         runStickToLatestVerify();
       }
     }
-  }, [runStickToLatestVerify, scrollToEndProgrammatically]);
+  }, [markMobileMvcpSettle, runStickToLatestVerify, scrollToEndProgrammatically]);
 
   // 冷开落底(替代 initialScrollAtEnd,弃用原因见 LegendList props 注释):首批 items
   // commit 后先命令式落底,随后双帧校验 native metrics 是否真的到达 content end。
@@ -1379,7 +1398,8 @@ export function MessageRenderer({
     const startedAt = Date.now();
     const verify = (attempts: number, waitRounds: number) => {
       if (initialAnchorGenerationRef.current !== generation) return;
-      const preserveVisibleContentPosition = readingOlderRef.current;
+      const preserveVisibleContentPosition = readingOlderRef.current
+        || isMobileMvcpSettling(Date.now(), mvcpSettleAtRef.current);
       const action = evaluateMobileAnchorVerify({
         attempts,
         listVisible: true,

--- a/apps/mobile/src/session/MessageRenderer.tsx
+++ b/apps/mobile/src/session/MessageRenderer.tsx
@@ -651,6 +651,10 @@ export function MessageRenderer({
   // 落底 rAF / verify loop / 揭开 timer 的句柄(生命周期 = 每个 scrollResetKey 一轮)。
   const initialAnchorFrameRef = useRef<number | null>(null);
   const initialRevealTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // 贴底跟随的落底校验/补滚环(runStickToLatestVerify,独立于冷开锚定的 generation/frame——
+  // 两条校验环可能各自独立触发,互不打断/互不清对方的句柄)。
+  const followVerifyGenerationRef = useRef(0);
+  const followVerifyFrameRef = useRef<number | null>(null);
   // settle 遮罩:落底两段式期间列表保持 opacity 0,settle 窗口后揭开(规则 7 防跳动)。
   const [listRevealed, setListRevealed] = useState(false);
   // 会话切换(scrollResetKey)的 ref 复位必须在渲染期同步完成,不能只靠下方的 reset effect:
@@ -687,6 +691,11 @@ export function MessageRenderer({
     if (initialAnchorVerifyFrameRef.current !== null) {
       cancelAnimationFrame(initialAnchorVerifyFrameRef.current);
       initialAnchorVerifyFrameRef.current = null;
+    }
+    followVerifyGenerationRef.current += 1;
+    if (followVerifyFrameRef.current !== null) {
+      cancelAnimationFrame(followVerifyFrameRef.current);
+      followVerifyFrameRef.current = null;
     }
     // settle 遮罩复位必须与列表重挂同帧(渲染期 setState,React 官方 prop-change 模式):
     // 走 effect 会晚一帧,新列表以旧 revealed=true 裸挂一帧,未锚定内容闪现。
@@ -756,6 +765,58 @@ export function MessageRenderer({
     markProgrammaticScroll(true);
     void listRef.current?.scrollToIndex({ animated: true, index, viewPosition });
   }, [markProgrammaticScroll]);
+
+  // 贴底跟随的落底校验/补滚环:两条手动补滚路径——「跳到最新」(followLatestRequestKey)
+  // 与 handleContentSize 的贴底追赶——都只发一次命令式 scrollToEnd,不校验是否真的到达内容
+  // 末端。落地一刻的 native metrics 可能仍是陈旧值(测量结算未完成),或 mVCP 尚未真正关闭
+  // 吸收了这次滚动:两者都会让最新消息静默停在 composer 浮层后面(bug 现场)。复用冷开锚定
+  // 同一判定(evaluateMobileAnchorVerify)、同样的双帧节奏 + 有界重试,命中 settled/give-up
+  // 就收手——不吃冷开锚定的 generation/frame ref,两条校验环各自独立生命周期,互不打断。
+  const runStickToLatestVerify = useCallback(() => {
+    const generation = followVerifyGenerationRef.current + 1;
+    followVerifyGenerationRef.current = generation;
+    if (followVerifyFrameRef.current !== null) {
+      cancelAnimationFrame(followVerifyFrameRef.current);
+      followVerifyFrameRef.current = null;
+    }
+    const step = (attempts: number, waitRounds: number) => {
+      if (followVerifyGenerationRef.current !== generation) return;
+      // stickToLatest / preserveVisibleContentPosition 与冷开锚定环用同一口径:不看
+      // isDraggingRef ——用户一旦开始拖动,shouldUnpinMobileFollowOnDrag 会在下一次
+      // handleScroll 里把 nearBottomRef 翻 false,下一轮判定就会自然 settle,不需要
+      // 这里另开一条“正在拖动”的短路(也避免拖动开始与本环同一 tick 的时序竞态)。
+      const action = evaluateMobileAnchorVerify({
+        attempts,
+        listVisible: true,
+        metrics: scrollMetricsRef.current,
+        preserveVisibleContentPosition: readingOlderRef.current,
+        stickToLatest: nearBottomRef.current && !userScrollForOlderRef.current,
+        waitRounds,
+      });
+      if (action === 'settled' || action === 'give-up') {
+        followVerifyFrameRef.current = null;
+        return;
+      }
+      if (action === 'retry') scrollToEndProgrammatically(false);
+      followVerifyFrameRef.current = requestAnimationFrame(() => {
+        followVerifyFrameRef.current = requestAnimationFrame(() => {
+          followVerifyFrameRef.current = null;
+          step(
+            attempts + (action === 'retry' ? 1 : 0),
+            waitRounds + (action === 'wait' ? 1 : 0),
+          );
+        });
+      });
+    };
+    // 双帧等待:与冷开锚定环同源——命令式 scrollToEnd 已由调用方发出,这里只负责校验,
+    // 给原生布局至少一帧结算再读 metrics,不把「刚发出去还没生效」误判成落空。
+    followVerifyFrameRef.current = requestAnimationFrame(() => {
+      followVerifyFrameRef.current = requestAnimationFrame(() => {
+        followVerifyFrameRef.current = null;
+        step(0, 0);
+      });
+    });
+  }, [scrollToEndProgrammatically]);
 
   // DEV-only:把列表控制器 + 滚动 metrics 暴露给性能 harness(临时,profiling/回归测量用)。
   useEffect(() => {
@@ -1011,7 +1072,10 @@ export function MessageRenderer({
     scrollToIndexProgrammatically(previousUserTarget.index, 0.12);
   }, [previousUserTarget, scrollToIndexProgrammatically]);
 
-  // 「跳到最新」请求(会话外部触发):命令式滚到底,之后由 handleContentSize 补滚维持贴底。
+  // 「跳到最新」请求(会话外部触发,含发送消息后的跟随):命令式滚到底,随后跑一轮有界
+  // 校验/补滚(runStickToLatestVerify)——单发的 scrollToEnd 落地一刻的 metrics 可能仍陈旧,
+  // 或被仍开着的 mVCP 吸收掉,不校验就会静默停在旧消息上(bug 现场,与冷开锚定同一根因)。
+  // 之后的贴底由 handleContentSize 补滚维持。
   useEffect(() => {
     if (previousFollowLatestRequestKeyRef.current === followLatestRequestKey) return;
     previousFollowLatestRequestKeyRef.current = followLatestRequestKey;
@@ -1027,7 +1091,8 @@ export function MessageRenderer({
     setHasNewMessages(false);
     setIsAwayFromBottom(false);
     scrollToEndProgrammatically(true);
-  }, [followLatestRequestKey, scrollToEndProgrammatically]);
+    runStickToLatestVerify();
+  }, [followLatestRequestKey, runStickToLatestVerify, scrollToEndProgrammatically]);
 
   // 自动加载更早:电平触发判定(shouldAutoLoadEarlier),在所有可能改变判定结果的时机重评估
   // (scroll 事件 / LegendList onStartReached 边沿 / eligibility 变化 effect)。
@@ -1208,14 +1273,19 @@ export function MessageRenderer({
           followEndPinRecoveryTimerRef.current = null;
           if (nearBottomRef.current && !readingOlderRef.current) {
             scrollToEndProgrammatically(false);
+            // 清账补滚同样不保证真的落底(measurement 结算 / mVCP 吸收的静默落空同源风险),
+            // 跑一轮校验/补滚兜底。
+            runStickToLatestVerify();
           }
         }, MOBILE_FOLLOW_END_PIN_SUPPRESS_MS + 50);
       }
       if (decision.shouldScroll) {
         scrollToEndProgrammatically(false);
+        // 贴底追赶的落底一样不校验就可能落空(陈旧 metrics / mVCP 吸收),补一轮有界校验。
+        runStickToLatestVerify();
       }
     }
-  }, []);
+  }, [runStickToLatestVerify, scrollToEndProgrammatically]);
 
   // 冷开落底(替代 initialScrollAtEnd,弃用原因见 LegendList props 注释):首批 items
   // commit 后先命令式落底,随后双帧校验 native metrics 是否真的到达 content end。
@@ -1311,10 +1381,12 @@ export function MessageRenderer({
   // 但不留悬挂句柄)。
   useEffect(() => () => {
     initialAnchorGenerationRef.current += 1;
+    followVerifyGenerationRef.current += 1;
     if (followEndPinRecoveryTimerRef.current) clearTimeout(followEndPinRecoveryTimerRef.current);
     clearProgrammaticScroll();
     if (initialAnchorFrameRef.current !== null) cancelAnimationFrame(initialAnchorFrameRef.current);
     if (initialAnchorVerifyFrameRef.current !== null) cancelAnimationFrame(initialAnchorVerifyFrameRef.current);
+    if (followVerifyFrameRef.current !== null) cancelAnimationFrame(followVerifyFrameRef.current);
     if (initialRevealTimerRef.current) clearTimeout(initialRevealTimerRef.current);
   }, [clearProgrammaticScroll]);
 

--- a/apps/mobile/src/session/MessageRenderer.tsx
+++ b/apps/mobile/src/session/MessageRenderer.tsx
@@ -298,6 +298,7 @@ import {
   evaluateMessageWindowUpdate,
   evaluateMobileAnchorVerify,
   evaluateMobileFollowEndContentSizePin,
+  mobileFollowVerifyStartDelayMs,
   mobileMessageListTopPadding,
   MOBILE_FOLLOW_END_PIN_SUPPRESS_MS,
   MOBILE_MESSAGE_LIST_BOTTOM_PADDING,
@@ -629,6 +630,8 @@ export function MessageRenderer({
   const programmaticScrollGenerationRef = useRef(0);
   const programmaticScrollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const programmaticScrollInFlightRef = useRef(false);
+  const programmaticAnimatedScrollInFlightRef = useRef(false);
+  const programmaticScrollSettleAtRef = useRef(0);
   const previousFollowLatestRequestKeyRef = useRef(followLatestRequestKey);
   const previousItemKeysRef = useRef<readonly string[]>([]);
   const scrollMetricsRef = useRef<MessageScrollMetrics>({
@@ -655,6 +658,7 @@ export function MessageRenderer({
   // 两条校验环可能各自独立触发,互不打断/互不清对方的句柄)。
   const followVerifyGenerationRef = useRef(0);
   const followVerifyFrameRef = useRef<number | null>(null);
+  const followVerifyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   // settle 遮罩:落底两段式期间列表保持 opacity 0,settle 窗口后揭开(规则 7 防跳动)。
   const [listRevealed, setListRevealed] = useState(false);
   // 会话切换(scrollResetKey)的 ref 复位必须在渲染期同步完成,不能只靠下方的 reset effect:
@@ -675,6 +679,8 @@ export function MessageRenderer({
     readingOlderRequestGenerationRef.current += 1;
     programmaticScrollGenerationRef.current += 1;
     programmaticScrollInFlightRef.current = false;
+    programmaticAnimatedScrollInFlightRef.current = false;
+    programmaticScrollSettleAtRef.current = 0;
     if (programmaticScrollTimerRef.current !== null) {
       clearTimeout(programmaticScrollTimerRef.current);
       programmaticScrollTimerRef.current = null;
@@ -693,6 +699,10 @@ export function MessageRenderer({
       initialAnchorVerifyFrameRef.current = null;
     }
     followVerifyGenerationRef.current += 1;
+    if (followVerifyTimerRef.current !== null) {
+      clearTimeout(followVerifyTimerRef.current);
+      followVerifyTimerRef.current = null;
+    }
     if (followVerifyFrameRef.current !== null) {
       cancelAnimationFrame(followVerifyFrameRef.current);
       followVerifyFrameRef.current = null;
@@ -728,8 +738,13 @@ export function MessageRenderer({
   const closePayload = useCallback(() => setPayload(null), []);
   const markProgrammaticScroll = useCallback((animated: boolean) => {
     const generation = programmaticScrollGenerationRef.current + 1;
+    const settleMs = animated
+      ? MOBILE_PROGRAMMATIC_ANIMATED_SCROLL_SETTLE_MS
+      : MOBILE_PROGRAMMATIC_SCROLL_SETTLE_MS;
     programmaticScrollGenerationRef.current = generation;
     programmaticScrollInFlightRef.current = true;
+    programmaticAnimatedScrollInFlightRef.current = animated;
+    programmaticScrollSettleAtRef.current = Date.now() + settleMs;
     if (programmaticScrollTimerRef.current !== null) {
       clearTimeout(programmaticScrollTimerRef.current);
     }
@@ -737,14 +752,16 @@ export function MessageRenderer({
       if (programmaticScrollGenerationRef.current !== generation) return;
       programmaticScrollTimerRef.current = null;
       programmaticScrollInFlightRef.current = false;
-    }, animated
-      ? MOBILE_PROGRAMMATIC_ANIMATED_SCROLL_SETTLE_MS
-      : MOBILE_PROGRAMMATIC_SCROLL_SETTLE_MS);
+      programmaticAnimatedScrollInFlightRef.current = false;
+      programmaticScrollSettleAtRef.current = 0;
+    }, settleMs);
   }, []);
 
   const clearProgrammaticScroll = useCallback(() => {
     programmaticScrollGenerationRef.current += 1;
     programmaticScrollInFlightRef.current = false;
+    programmaticAnimatedScrollInFlightRef.current = false;
+    programmaticScrollSettleAtRef.current = 0;
     if (programmaticScrollTimerRef.current !== null) {
       clearTimeout(programmaticScrollTimerRef.current);
       programmaticScrollTimerRef.current = null;
@@ -779,6 +796,10 @@ export function MessageRenderer({
       cancelAnimationFrame(followVerifyFrameRef.current);
       followVerifyFrameRef.current = null;
     }
+    if (followVerifyTimerRef.current !== null) {
+      clearTimeout(followVerifyTimerRef.current);
+      followVerifyTimerRef.current = null;
+    }
     const step = (attempts: number, waitRounds: number) => {
       if (followVerifyGenerationRef.current !== generation) return;
       // 贴底跟随意图只认 nearBottomRef:死区内轻触 / 小幅拖动并没有真实解除贴底,
@@ -808,14 +829,31 @@ export function MessageRenderer({
         });
       });
     };
-    // 双帧等待:与冷开锚定环同源——命令式 scrollToEnd 已由调用方发出,这里只负责校验,
-    // 给原生布局至少一帧结算再读 metrics,不把「刚发出去还没生效」误判成落空。
-    followVerifyFrameRef.current = requestAnimationFrame(() => {
+    const start = () => {
+      if (followVerifyGenerationRef.current !== generation) return;
+      // 双帧等待:与冷开锚定环同源——命令式 scrollToEnd 已由调用方发出,这里只负责校验,
+      // 给原生布局至少一帧结算再读 metrics,不把「刚发出去还没生效」误判成落空。
       followVerifyFrameRef.current = requestAnimationFrame(() => {
-        followVerifyFrameRef.current = null;
-        step(0, 0);
+        followVerifyFrameRef.current = requestAnimationFrame(() => {
+          followVerifyFrameRef.current = null;
+          step(0, 0);
+        });
       });
+    };
+    const startDelayMs = mobileFollowVerifyStartDelayMs({
+      animatedScrollInFlight: programmaticAnimatedScrollInFlightRef.current,
+      now: Date.now(),
+      settleAt: programmaticScrollSettleAtRef.current,
     });
+    if (startDelayMs > 0) {
+      followVerifyTimerRef.current = setTimeout(() => {
+        if (followVerifyGenerationRef.current !== generation) return;
+        followVerifyTimerRef.current = null;
+        start();
+      }, startDelayMs);
+    } else {
+      start();
+    }
   }, [scrollToEndProgrammatically]);
 
   // DEV-only:把列表控制器 + 滚动 metrics 暴露给性能 harness(临时,profiling/回归测量用)。
@@ -1264,6 +1302,13 @@ export function MessageRenderer({
     // readingOlderRef:load-earlier 的 prepend 也会撑高 contentHeight,但那是顶部增长、不该贴底(review P1)。
     if (readingOlderRef.current) return;
     if (nearBottomRef.current && viewportHeight > 0 && height > viewportHeight) {
+      // Animated jump/send follow owns the viewport until its settle window closes. Content
+      // growth during that animation only reschedules the verifier; a false-animated pin here
+      // would visibly cut the smooth scroll short and jump straight to the end.
+      if (programmaticAnimatedScrollInFlightRef.current) {
+        runStickToLatestVerify();
+        return;
+      }
       // 补滚护栏:死区去噪 + 振荡断路,掐断「scrollToEnd → 重测 → onContentSizeChange」
       // 洪泛环(JS 忙死、冷开消息区空白;语义与参数见 messageScroll.ts 护栏段)。
       // 单调增长(流式/冷开/回填)不限流,每次跟进;只有高度往返振荡才跳闸。
@@ -1401,6 +1446,7 @@ export function MessageRenderer({
     if (initialAnchorFrameRef.current !== null) cancelAnimationFrame(initialAnchorFrameRef.current);
     if (initialAnchorVerifyFrameRef.current !== null) cancelAnimationFrame(initialAnchorVerifyFrameRef.current);
     if (followVerifyFrameRef.current !== null) cancelAnimationFrame(followVerifyFrameRef.current);
+    if (followVerifyTimerRef.current !== null) clearTimeout(followVerifyTimerRef.current);
     if (initialRevealTimerRef.current) clearTimeout(initialRevealTimerRef.current);
   }, [clearProgrammaticScroll]);
 

--- a/apps/mobile/src/session/MessageRenderer.tsx
+++ b/apps/mobile/src/session/MessageRenderer.tsx
@@ -1173,6 +1173,8 @@ export function MessageRenderer({
       viewportHeight: event.nativeEvent.layoutMeasurement.height,
     };
     const previousOffsetY = scrollMetricsRef.current.offsetY;
+    const wasNearBottom = nearBottomRef.current;
+    const scrollDelta = readingOlderRef.current ? 0 : metrics.offsetY - previousOffsetY;
     scrollMetricsRef.current = metrics;
     if (
       nearBottomRef.current
@@ -1189,10 +1191,16 @@ export function MessageRenderer({
         wasNearBottom: nearBottomRef.current,
         metrics,
         programmaticScrollInFlight: programmaticScrollInFlightRef.current,
-        scrollDelta: readingOlderRef.current ? 0 : metrics.offsetY - previousOffsetY,
+        scrollDelta,
         bottomOverlayHeight,
       });
       nearBottomRef.current = nearBottom;
+      // A genuine downward false→true transition means the user manually returned to the
+      // latest edge. The old history-browsing intent no longer owns follow verification;
+      // a later drag will set it again before any new upward browse.
+      if (!wasNearBottom && nearBottom && scrollDelta > 0) {
+        userScrollForOlderRef.current = false;
+      }
       setIsAwayFromBottom(!nearBottom);
       if (nearBottom) setHasNewMessages(false);
     }

--- a/apps/mobile/src/session/messagePaging.ts
+++ b/apps/mobile/src/session/messagePaging.ts
@@ -296,8 +296,10 @@ export function compareMessageOrder(a: RemoteMessage, b: RemoteMessage): number 
  * clock that is ahead of the host dominate future host-persisted rows, which must still be
  * able to sort after this temporary row. The later authoritative persisted-row reconciliation
  * overwrites the temporary row with the real host time. Without a watermark, fall back to the
- * device timestamp because there is no host-domain anchor yet. Do not fabricate a `+1ms`
- * value: that would invent an ordering fact no clock actually observed.
+ * device timestamp because there is no host-domain anchor yet; remoteSessionStore marks that row
+ * as provisional and reanchors it when the first session metadata or created-message push supplies
+ * a host timestamp. Do not fabricate a `+1ms` value: that would invent an ordering fact no clock
+ * actually observed.
  */
 export function clampLiveRowCreatedAt(
   deviceNowIso: string,

--- a/apps/mobile/src/session/messagePaging.ts
+++ b/apps/mobile/src/session/messagePaging.ts
@@ -290,21 +290,19 @@ export function compareMessageOrder(a: RemoteMessage, b: RemoteMessage): number 
  * the message list's tail then keeps showing the old live row instead of the just-sent
  * message, even though the live row is about to be reconciled away.
  *
- * Fix: clamp the device timestamp so it never sorts before the newest createdAt already
- * known for the session. If the device clock is at or ahead of that watermark, nothing
- * changes (the common case). If it is behind, reuse the watermark's own createdAt verbatim
- * — a tie is fine, compareMessageOrder's rowid/arrival-order tiebreak keeps ordering stable,
- * and the later authoritative persisted-row reconciliation overwrites this temporary row
- * with the real host time. Do not fabricate a `+1ms` value: that would invent an ordering
- * fact no clock actually observed, whereas a tie is honest about "we don't know which
- * happened first" and is exactly what the stable tiebreak exists to handle.
+ * Fix: when the session already has a newest createdAt, anchor the temporary live row to
+ * that watermark verbatim. A stable tie records the only trustworthy ordering fact we have:
+ * this live row was observed after all currently known rows. It also avoids letting a device
+ * clock that is ahead of the host dominate future host-persisted rows, which must still be
+ * able to sort after this temporary row. The later authoritative persisted-row reconciliation
+ * overwrites the temporary row with the real host time. Without a watermark, fall back to the
+ * device timestamp because there is no host-domain anchor yet. Do not fabricate a `+1ms`
+ * value: that would invent an ordering fact no clock actually observed.
  */
 export function clampLiveRowCreatedAt(
   deviceNowIso: string,
   latestExistingCreatedAt: string | undefined,
 ): string {
   if (!latestExistingCreatedAt) return deviceNowIso;
-  return deviceNowIso.localeCompare(latestExistingCreatedAt) >= 0
-    ? deviceNowIso
-    : latestExistingCreatedAt;
+  return latestExistingCreatedAt;
 }

--- a/apps/mobile/src/session/messagePaging.ts
+++ b/apps/mobile/src/session/messagePaging.ts
@@ -278,3 +278,33 @@ export function compareMessageOrder(a: RemoteMessage, b: RemoteMessage): number 
   // arrival order is meaningful; message ids are not insertion ordered.
   return 0;
 }
+
+/**
+ * Cross-clock-domain sort fix (called by remoteSessionStore.applyRemoteTextEvent when it
+ * stamps a live streaming/finalized assistant row with the *device* clock).
+ *
+ * Persisted rows carry the *host* clock's createdAt; live rows created before the host
+ * persists them are stamped with the device's local clock. When the device clock runs
+ * ahead of the host clock, a brand-new persisted row (host time) can sort *before* the
+ * stale device-stamped live row under compareMessageOrder's plain createdAt comparison —
+ * the message list's tail then keeps showing the old live row instead of the just-sent
+ * message, even though the live row is about to be reconciled away.
+ *
+ * Fix: clamp the device timestamp so it never sorts before the newest createdAt already
+ * known for the session. If the device clock is at or ahead of that watermark, nothing
+ * changes (the common case). If it is behind, reuse the watermark's own createdAt verbatim
+ * — a tie is fine, compareMessageOrder's rowid/arrival-order tiebreak keeps ordering stable,
+ * and the later authoritative persisted-row reconciliation overwrites this temporary row
+ * with the real host time. Do not fabricate a `+1ms` value: that would invent an ordering
+ * fact no clock actually observed, whereas a tie is honest about "we don't know which
+ * happened first" and is exactly what the stable tiebreak exists to handle.
+ */
+export function clampLiveRowCreatedAt(
+  deviceNowIso: string,
+  latestExistingCreatedAt: string | undefined,
+): string {
+  if (!latestExistingCreatedAt) return deviceNowIso;
+  return deviceNowIso.localeCompare(latestExistingCreatedAt) >= 0
+    ? deviceNowIso
+    : latestExistingCreatedAt;
+}

--- a/apps/mobile/src/session/messageScroll.ts
+++ b/apps/mobile/src/session/messageScroll.ts
@@ -287,13 +287,27 @@ export const MOBILE_ANCHOR_VERIFY_TOLERANCE = 2;
 export const MOBILE_ANCHOR_VERIFY_MAX_ATTEMPTS = 6;
 
 /**
- * 校验等待上限(独立于补滚预算):mVCP 还开着 / metrics 未就绪时环只等不滚,等待
- * 不消耗补滚额度——否则 mVCP 长开(open-settle cap 2s)会把预算烧光,窗口关闭后
- * 反而没额度补滚,遮挡残留(review P1)。上限按最长 mVCP 窗口取:双帧一轮 ≈ 33ms,
- * 75 轮 ≈ 2.5s > OPEN_SETTLE_CAP_MS(2000ms),窗口自然关闭后环仍活着;再长说明
- * 状态异常(如列表空置),结束环交给常规事件跟随,每轮只是一次纯函数比较,无副作用。
+ * 校验等待上限(独立于补滚预算):mVCP 还在结算 / metrics 未就绪时环只等不滚,等待
+ * 不消耗补滚额度——否则连续的 data / size 调整会先把 6 次补滚预算烧光,布局安静后
+ * 反而没额度补滚,遮挡残留(review P1)。双帧一轮约 33ms,75 轮约 2.5s；超过该
+ * 上限说明布局持续变化或状态异常,结束环交给后续 contentSize 事件继续跟随。
  */
 export const MOBILE_ANCHOR_VERIFY_MAX_WAIT_ROUNDS = 75;
+
+/**
+ * LegendList 的 mVCP 没有公开“本轮 native 调整已完成”信号。data / size 变化后保留
+ * 一个短安静窗：期间 verifier 只等待；连续流式测量会延长窗口，但仍受上面的 2.5s
+ * 总等待预算约束。120ms 约 7 帧，覆盖 JS commit、native layout 与滚动回传的常见链路。
+ */
+export const MOBILE_MVCP_SETTLE_QUIET_MS = 120;
+
+export function mobileMvcpSettleDeadline(previousDeadline: number, now: number): number {
+  return Math.max(previousDeadline, now + MOBILE_MVCP_SETTLE_QUIET_MS);
+}
+
+export function isMobileMvcpSettling(now: number, settleAt: number): boolean {
+  return now < settleAt;
+}
 
 export interface MobileFollowVerifyStartDelayInput {
   animatedScrollInFlight: boolean;

--- a/apps/mobile/src/session/messageScroll.ts
+++ b/apps/mobile/src/session/messageScroll.ts
@@ -295,6 +295,24 @@ export const MOBILE_ANCHOR_VERIFY_MAX_ATTEMPTS = 6;
  */
 export const MOBILE_ANCHOR_VERIFY_MAX_WAIT_ROUNDS = 75;
 
+export interface MobileFollowVerifyStartDelayInput {
+  animatedScrollInFlight: boolean;
+  now: number;
+  settleAt: number;
+}
+
+/**
+ * Animated `scrollToEnd` must own the viewport until its bounded settle window closes.
+ * Starting the verifier earlier would read an expected in-flight offset and replace the
+ * smooth animation with an immediate non-animated retry.
+ */
+export function mobileFollowVerifyStartDelayMs(
+  input: MobileFollowVerifyStartDelayInput,
+): number {
+  if (!input.animatedScrollInFlight) return 0;
+  return Math.max(0, input.settleAt - input.now);
+}
+
 export interface MobileAnchorVerifyInput {
   attempts: number;
   listVisible: boolean;

--- a/apps/mobile/src/session/remoteSessionStore.ts
+++ b/apps/mobile/src/session/remoteSessionStore.ts
@@ -522,6 +522,10 @@ const sessionTaskUpdates = new Map<string, ReadonlyMap<string, AgentTaskUpdate>>
 // Keep one temporary assistant row per session and reconcile it with the persisted row by
 // clientId/persistId when the database push arrives.
 const streamingAssistantClientIds = new Map<string, string>();
+// The same persisted streaming identity can be replayed by a stale transport after
+// re-link. Track the transport currently assembling that identity so a device switch
+// replaces the stale live text instead of concatenating two transports into one row.
+const streamingAssistantDeviceIds = new Map<string, string>();
 const pendingLiveAssistantClientIds = new Map<string, Set<string>>();
 // 首个 live 行可能早于 getSession / listMessages 到达。此时只能暂用手机时间，待第一份
 // 主机时间水位到达后重锚；否则快手机时钟会让短且无 persistId 的旧 live 行长期占据尾部。
@@ -560,6 +564,13 @@ const pendingTextDeltaBatches = new Map<string, {
   agentMeta: Record<string, unknown> | null;
 }>();
 let textDeltaFlushTimer: ReturnType<typeof setTimeout> | null = null;
+
+function clearStreamingAssistantAssembly(sessionId: string): boolean {
+  const clientIdChanged = streamingAssistantClientIds.delete(sessionId);
+  const deviceIdChanged = streamingAssistantDeviceIds.delete(sessionId);
+  return clientIdChanged || deviceIdChanged;
+}
+
 // 目标模式状态镜像:null = 已确认无 goal(get-status 拉过 / push 清除);缺项 = 尚未拉取。
 const sessionGoalStatus = new Map<string, MobileGoalStatusPayload | null>();
 // maker `status` 事件驱动的权威 turn 边界(与 sessionRunning 分开):sessionRunning 还会被
@@ -697,7 +708,7 @@ function invalidateSessionMessageWindowState(
   changed = sessionTaskUpdates.delete(sessionId) || changed;
   changed = sessionParkedTaskUpdates.delete(sessionId) || changed;
   changed = sessionMessageSyncMarkers.delete(sessionId) || changed;
-  changed = streamingAssistantClientIds.delete(sessionId) || changed;
+  changed = clearStreamingAssistantAssembly(sessionId) || changed;
   changed = pendingLiveAssistantClientIds.delete(sessionId) || changed;
   changed = pendingHostAnchorLiveAssistantClientIds.delete(sessionId) || changed;
   changed = activePendingHostAnchorRoundIds.delete(sessionId) || changed;
@@ -784,7 +795,7 @@ function discardTransportOwnedPendingSessionState(
   }
   const streamingClientId = streamingAssistantClientIds.get(sessionId);
   if (streamingClientId && pendingAnchorIds.has(streamingClientId)) {
-    streamingAssistantClientIds.delete(sessionId);
+    clearStreamingAssistantAssembly(sessionId);
   }
   for (const id of pendingAnchorIds) pendingAnchors.delete(id);
   if (pendingAnchors.size === 0) {
@@ -1685,7 +1696,7 @@ function reanchorPendingLiveAssistantRows(
 
 function retireGeneratedStreamingFallback(sessionId: string): void {
   const current = streamingAssistantClientIds.get(sessionId);
-  if (isGeneratedStreamingClientId(current)) streamingAssistantClientIds.delete(sessionId);
+  if (isGeneratedStreamingClientId(current)) clearStreamingAssistantAssembly(sessionId);
   forgetGeneratedPendingLiveAssistantClientIds(sessionId);
 }
 
@@ -1870,9 +1881,32 @@ function applyRemoteTextEvent(
   const isFinal = data?.isFinal === true;
   if (!text) return false;
 
+  const previousStreamingClientId = streamingAssistantClientIds.get(sessionId);
+  const previousStreamingDeviceId = streamingAssistantDeviceIds.get(sessionId);
   const clientIdResolution = streamingClientIdFor(sessionId, persistId);
   const { clientId } = clientIdResolution;
-  const existing = messages.get(sessionId)?.find((message) => message.clientId === clientId);
+  const matchedExisting = messages.get(sessionId)?.find((message) => message.clientId === clientId);
+  const continuesPreviousAssembly = previousStreamingClientId === clientId
+    || (
+      isGeneratedStreamingClientId(previousStreamingClientId)
+      && persistId?.trim() === clientId
+    );
+  const resetsTransportAssembly = continuesPreviousAssembly
+    && previousStreamingDeviceId !== undefined
+    && deviceId !== undefined
+    && previousStreamingDeviceId !== deviceId
+    && matchedExisting !== undefined
+    && isPendingLiveAssistantMessage(sessionId, matchedExisting);
+  const resetHostAnchorIdentity = resetsTransportAssembly
+    ? pendingHostAnchorIdentity(
+        sessionId,
+        matchedExisting.id,
+        matchedExisting.clientId,
+        clientId,
+      )
+    : undefined;
+  if (deviceId !== undefined) streamingAssistantDeviceIds.set(sessionId, deviceId);
+  const existing = resetsTransportAssembly ? undefined : matchedExisting;
   const finalTextWasTruncated = isFinal && (
     hasDeviceLinkTruncationMarker(event) || hasDeviceLinkTruncationMarker(data)
   );
@@ -1895,15 +1929,24 @@ function applyRemoteTextEvent(
       agentMeta: isRecord(event.agentMeta) ? event.agentMeta : null,
       createdAt,
     });
-    if (changed) {
+    if (resetsTransportAssembly && !changed) {
+      forgetPendingLiveAssistantMessageIdentity(
+        sessionId,
+        matchedExisting.id,
+        matchedExisting.clientId,
+        clientId,
+      );
+    }
+    if (changed || resetsTransportAssembly) {
       rememberPendingLiveAssistantClientId(sessionId, clientId);
-      if (hostCreatedAtAnchor.provisional) {
+      if (hostCreatedAtAnchor.provisional || resetHostAnchorIdentity) {
         rememberPendingHostAnchorLiveAssistantClientId(
           sessionId,
           clientId,
-          undefined,
-          true,
+          resetHostAnchorIdentity?.sendAt,
+          resetHostAnchorIdentity?.bindOnMetadata ?? true,
           deviceId,
+          resetHostAnchorIdentity?.unboundRoundId,
         );
       }
     }
@@ -1934,10 +1977,10 @@ function applyRemoteTextEvent(
     ? [existing.id, existing.clientId, clientId].some((id) => (
       Boolean(id) && pendingHostAnchorLiveAssistantClientIds.get(sessionId)?.has(id) === true
     ))
-    : hostCreatedAtAnchor?.provisional === true;
+    : hostCreatedAtAnchor?.provisional === true || resetHostAnchorIdentity !== undefined;
   const hostAnchorIdentity = existing
     ? pendingHostAnchorIdentity(sessionId, existing.id, existing.clientId, clientId)
-    : undefined;
+    : resetHostAnchorIdentity;
   const changed = upsertMessage(sessionId, {
     id: existing?.id ?? clientId,
     clientId,
@@ -1954,7 +1997,15 @@ function applyRemoteTextEvent(
       hostCreatedAtAnchor?.createdAt,
     ),
   });
-  if (changed) {
+  if (resetsTransportAssembly && !changed) {
+    forgetPendingLiveAssistantMessageIdentity(
+      sessionId,
+      matchedExisting.id,
+      matchedExisting.clientId,
+      clientId,
+    );
+  }
+  if (changed || resetsTransportAssembly) {
     rememberPendingLiveAssistantClientId(sessionId, clientId);
   }
   // upsertMessage intentionally clears pending reconciliation identities when it
@@ -2088,7 +2139,7 @@ function finalizeRemoteStreamingMessages(
   sessionId: string,
   boundaryAgentMeta?: Record<string, unknown> | null,
 ): boolean {
-  streamingAssistantClientIds.delete(sessionId);
+  clearStreamingAssistantAssembly(sessionId);
   const existing = messages.get(sessionId);
   if (!existing) return false;
   let changed = false;
@@ -3757,7 +3808,7 @@ export const remoteSessionStore = {
       // Background compact belongs to the previous idle cycle. Finalizing here
       // would seal a product turn that started after compaction_start.
       if (!backgroundCompact) {
-        streamingAssistantClientIds.delete(sessionId);
+        clearStreamingAssistantAssembly(sessionId);
       }
       const nextMessages = backgroundCompact
         ? existing
@@ -3894,7 +3945,7 @@ export const remoteSessionStore = {
     for (const [sessionId, batch] of [...pendingTextDeltaBatches]) {
       if (batch.deviceId !== deviceId) continue;
       changed = flushAndFinalizeRemoteStreamingMessages(sessionId) || changed;
-      changed = streamingAssistantClientIds.delete(sessionId) || changed;
+      changed = clearStreamingAssistantAssembly(sessionId) || changed;
       changed = freezeUnboundPendingHostAnchorsForOffline(sessionId, deviceId) || changed;
     }
     for (const [sessionId, indexedDeviceId] of sessionDeviceIndex) {
@@ -3913,7 +3964,7 @@ export const remoteSessionStore = {
       changed = sessionParkedTaskUpdates.delete(sessionId) || changed;
       changed = sessionMakerActivityEpochs.delete(sessionId) || changed;
       changed = flushAndFinalizeRemoteStreamingMessages(sessionId) || changed;
-      changed = streamingAssistantClientIds.delete(sessionId) || changed;
+      changed = clearStreamingAssistantAssembly(sessionId) || changed;
       // The message window survives a soft offline transition, so both pending
       // identities must survive too: one protects the live row during latest-window
       // reconciliation, and the other lets a reconnecting authoritative user row
@@ -4015,6 +4066,7 @@ export const remoteSessionStore = {
     sessionLiveStreamAcked.clear();
     sessionTaskUpdates.clear();
     streamingAssistantClientIds.clear();
+    streamingAssistantDeviceIds.clear();
     pendingLiveAssistantClientIds.clear();
     pendingHostAnchorLiveAssistantClientIds.clear();
     activePendingHostAnchorRoundIds.clear();

--- a/apps/mobile/src/session/remoteSessionStore.ts
+++ b/apps/mobile/src/session/remoteSessionStore.ts
@@ -785,6 +785,7 @@ type LiveRowCreatedAtAnchor = {
 
 function liveRowCreatedAtAnchor(sessionId: string): LiveRowCreatedAtAnchor {
   const pendingHostAnchorIds = pendingHostAnchorLiveAssistantClientIds.get(sessionId);
+  const session = mergedSessions.find((item) => item.id === sessionId);
   const authoritativeMessages = (messages.get(sessionId) ?? []).filter((message) => {
     const isPendingHostAnchor = pendingHostAnchorIds?.has(message.id) === true
       || pendingHostAnchorIds?.has(message.clientId) === true;
@@ -795,14 +796,17 @@ function liveRowCreatedAtAnchor(sessionId: string): LiveRowCreatedAtAnchor {
   const messageWatermark = newestCreatedAt(authoritativeMessages);
   if (messageWatermark) {
     const latestAuthoritativeMessage = authoritativeMessages[authoritativeMessages.length - 1];
+    const newerUserSendAt = session?.userSendAt
+      && session.userSendAt.localeCompare(messageWatermark) > 0
+      ? session.userSendAt
+      : undefined;
     return {
-      createdAt: messageWatermark,
-      // 只有明确看到本轮 user 尾行,才能认定 live 回复已经落在问题之后。旧 assistant /
-      // tool 尾行可能属于上一轮；当前 user push 仍在途时,它只能提供临时时间锚。
-      provisional: latestAuthoritativeMessage?.role !== 'user',
+      createdAt: newerUserSendAt ?? messageWatermark,
+      // user 尾行只有在没有更晚的 session.userSendAt 时才可认作本轮问题；否则它
+      // 属于旧轮次，当前 user push 仍在途。assistant / tool 尾行同样只能提供临时时间锚。
+      provisional: newerUserSendAt !== undefined || latestAuthoritativeMessage?.role !== 'user',
     };
   }
-  const session = mergedSessions.find((item) => item.id === sessionId);
   return {
     createdAt: session?.userSendAt ?? session?.updatedAt ?? session?.createdAt,
     provisional: true,

--- a/apps/mobile/src/session/remoteSessionStore.ts
+++ b/apps/mobile/src/session/remoteSessionStore.ts
@@ -993,6 +993,19 @@ function latestUserSendAt(sessionId: string): string | undefined {
   return mergedSessions.find((item) => item.id === sessionId)?.userSendAt ?? undefined;
 }
 
+function authoritativeSessionDeviceId(sessionId: string): string | undefined {
+  if (!deviceList) return undefined;
+  const session = mergedSessions.find((item) => item.id === sessionId);
+  const canonicalDeviceId = session?.canonicalDeviceId;
+  if (canonicalDeviceId && deviceList.some((device) => device.deviceId === canonicalDeviceId)) {
+    return canonicalDeviceId;
+  }
+  const indexedDeviceId = sessionDeviceIndex.get(sessionId);
+  return indexedDeviceId && deviceList.some((device) => device.deviceId === indexedDeviceId)
+    ? indexedDeviceId
+    : undefined;
+}
+
 function userMessageMatchesLatestSend(sessionId: string, message: RemoteMessage): boolean {
   if (message.role !== 'user') return false;
   const userSendAt = latestUserSendAt(sessionId);
@@ -1611,11 +1624,49 @@ function reanchorPendingLiveAssistantRows(
     && hasOfflineUnboundPendingRow
     && Boolean(latestSendAt)
     && afterMessages[0].createdAt.localeCompare(latestSendAt ?? '') < 0;
+  const offlineUnboundRoundGroups = new Map<
+    number,
+    Array<(typeof pendingRows)[number]>
+  >();
+  for (const row of pendingRows) {
+    if (
+      row.identity.sendAt !== null
+      || row.identity.bindOnMetadata
+      || row.identity.unboundRoundId === null
+    ) continue;
+    const group = offlineUnboundRoundGroups.get(row.identity.unboundRoundId) ?? [];
+    group.push(row);
+    offlineUnboundRoundGroups.set(row.identity.unboundRoundId, group);
+  }
+  const orderedOfflineUnboundRoundGroups = [...offlineUnboundRoundGroups]
+    .sort(([leftRoundId], [rightRoundId]) => leftRoundId - rightRoundId)
+    .map(([, rows]) => rows);
+  const reconnectWindowUsers = afterMessages.filter((message) => (
+    message.role === 'user'
+    && (!latestSendAt || message.createdAt.localeCompare(latestSendAt) <= 0)
+  ));
+  const pairsOfflineUnboundWindowInOrder = options.afterMessages !== undefined
+    && orderedOfflineUnboundRoundGroups.length > 1
+    && orderedOfflineUnboundRoundGroups.reduce((count, rows) => count + rows.length, 0)
+      === pendingRows.length
+    && reconnectWindowUsers.length > 0;
   // A bounded latest window represents the newest user rows, so pair it with the
   // newest pending replies. Realtime pushes do the same once the latest send marker
   // is known, except delayed users restoring multiple offline-unbound rounds: those
   // must consume the oldest eligible cohort first to preserve arrival order.
-  if (pairsPendingFromEnd && pairsOfflineUnboundFromStart) {
+  if (pairsPendingFromEnd && pairsOfflineUnboundWindowInOrder) {
+    // A reconnect window can deliver several delayed users in one authoritative page.
+    // Pair only when that page accounts for every offline cohort; a truncated latest
+    // suffix cannot prove whether its first user belongs to the oldest pending round.
+    if (reconnectWindowUsers.length === orderedOfflineUnboundRoundGroups.length) {
+      const pairedUsers = reconnectWindowUsers;
+      for (let index = 0; index < orderedOfflineUnboundRoundGroups.length; index += 1) {
+        for (const pendingRow of orderedOfflineUnboundRoundGroups[index]) {
+          pairs.push({ pendingRow, afterMessage: pairedUsers[index] });
+        }
+      }
+    }
+  } else if (pairsPendingFromEnd && pairsOfflineUnboundFromStart) {
     const afterMessage = afterMessages[0];
     const pendingRow = pendingRows
       .filter((row) => pendingRowCanPairMessage(row, afterMessage))
@@ -1940,10 +1991,66 @@ function applyRemoteTextEvent(
   const isFinal = data?.isFinal === true;
   if (!text) return false;
 
+  const authoritativeDeviceId = authoritativeSessionDeviceId(sessionId);
+  const currentMessages = messages.get(sessionId) ?? [];
+  const hasAuthoritativePendingAssembly = authoritativeDeviceId !== undefined
+    && [...(streamingAssistantDeviceIds.get(sessionId) ?? [])].some(([ownedClientId, ownerDeviceId]) => {
+      if (ownerDeviceId !== authoritativeDeviceId) return false;
+      const ownedMessage = currentMessages.find((message) => (
+        message.id === ownedClientId || message.clientId === ownedClientId
+      ));
+      if (!ownedMessage || !isPendingLiveAssistantMessage(sessionId, ownedMessage)) return false;
+      const ownedHostAnchorIdentity = pendingHostAnchorIdentity(
+        sessionId,
+        ownedMessage.id,
+        ownedMessage.clientId,
+        ownedClientId,
+      );
+      return !(
+        ownedHostAnchorIdentity?.bindOnMetadata === false
+        && ownedHostAnchorIdentity.deviceIds.has(ownerDeviceId)
+      );
+    });
+  const rejectsBeforeClientIdMutation = deviceId !== undefined
+    && authoritativeDeviceId !== undefined
+    && deviceId !== authoritativeDeviceId
+    && hasAuthoritativePendingAssembly;
+  if (rejectsBeforeClientIdMutation) return false;
+
   const clientIdResolution = streamingClientIdFor(sessionId, persistId);
   const { clientId } = clientIdResolution;
   const previousStreamingDeviceId = streamingAssistantDeviceId(sessionId, clientId);
   const matchedExisting = messages.get(sessionId)?.find((message) => message.clientId === clientId);
+  const matchedHostAnchorIdentity = matchedExisting
+    ? pendingHostAnchorIdentity(
+        sessionId,
+        matchedExisting.id,
+        matchedExisting.clientId,
+        clientId,
+      )
+    : undefined;
+  const previousTransportWasSoftOffline = previousStreamingDeviceId !== undefined
+    && matchedHostAnchorIdentity?.bindOnMetadata === false
+    && matchedHostAnchorIdentity.deviceIds.has(previousStreamingDeviceId);
+  const matchedExistingIsPending = matchedExisting !== undefined
+    && isPendingLiveAssistantMessage(sessionId, matchedExisting);
+  const matchedExistingIsPersisted = matchedExisting !== undefined
+    && !matchedExistingIsPending
+    && isPersistedAssistantMessage(matchedExisting);
+  const rejectsNonAuthoritativeTransportReplay = deviceId !== undefined
+    && authoritativeDeviceId !== undefined
+    && deviceId !== authoritativeDeviceId
+    && (
+      matchedExistingIsPersisted
+      || (
+        previousStreamingDeviceId !== undefined
+        && previousStreamingDeviceId !== deviceId
+        && previousStreamingDeviceId === authoritativeDeviceId
+        && !previousTransportWasSoftOffline
+        && matchedExistingIsPending
+      )
+    );
+  if (rejectsNonAuthoritativeTransportReplay) return clientIdResolution.changed;
   const resetsTransportAssembly = previousStreamingDeviceId !== undefined
     && deviceId !== undefined
     && previousStreamingDeviceId !== deviceId

--- a/apps/mobile/src/session/remoteSessionStore.ts
+++ b/apps/mobile/src/session/remoteSessionStore.ts
@@ -1992,7 +1992,13 @@ function enqueueRemoteTextDelta(
 
   let changed = false;
   const existing = pendingTextDeltaBatches.get(sessionId);
-  if (existing?.persistId && persistId && existing.persistId !== persistId) {
+  if (
+    existing
+    && (
+      (existing.persistId && persistId && existing.persistId !== persistId)
+      || existing.deviceId !== deviceId
+    )
+  ) {
     changed = flushPendingTextDelta(sessionId);
   }
   const current = pendingTextDeltaBatches.get(sessionId);

--- a/apps/mobile/src/session/remoteSessionStore.ts
+++ b/apps/mobile/src/session/remoteSessionStore.ts
@@ -1356,10 +1356,9 @@ function applyRemoteTextEvent(
     hasDeviceLinkTruncationMarker(event) || hasDeviceLinkTruncationMarker(data)
   );
   if (isFinal && !existing) {
-    // Device-clock stamp on a brand-new live row: clamp against the session's newest known
-    // createdAt so a device clock running ahead of the host clock can't leave this row
-    // sorting before a just-persisted message that arrives with an earlier host timestamp
-    // (see clampLiveRowCreatedAt doc comment in messagePaging.ts).
+    // Device-clock stamp on a brand-new live row: anchor it to the session's newest known
+    // createdAt so a device clock running ahead of the host clock cannot dominate a later
+    // host-persisted message (see clampLiveRowCreatedAt in messagePaging.ts).
     const createdAt = clampLiveRowCreatedAt(
       new Date().toISOString(),
       newestCreatedAt(messages.get(sessionId) ?? []),

--- a/apps/mobile/src/session/remoteSessionStore.ts
+++ b/apps/mobile/src/session/remoteSessionStore.ts
@@ -813,10 +813,26 @@ function liveRowCreatedAtAnchor(sessionId: string): LiveRowCreatedAtAnchor {
   };
 }
 
+function latestUserSendAt(sessionId: string): string | undefined {
+  return mergedSessions.find((item) => item.id === sessionId)?.userSendAt ?? undefined;
+}
+
 function userMessageMatchesLatestSend(sessionId: string, message: RemoteMessage): boolean {
   if (message.role !== 'user') return false;
-  const userSendAt = mergedSessions.find((item) => item.id === sessionId)?.userSendAt;
+  const userSendAt = latestUserSendAt(sessionId);
   return Boolean(userSendAt && message.createdAt.localeCompare(userSendAt) >= 0);
+}
+
+function userMessageCanConsumePendingLiveReply(
+  sessionId: string,
+  message: RemoteMessage,
+): boolean {
+  if (message.role !== 'user') return false;
+  const userSendAt = latestUserSendAt(sessionId);
+  // Before session metadata arrives, preserve the existing realtime ordering semantics.
+  // Once a send marker exists, an older delayed push may only provide a provisional
+  // host-time anchor; it must not claim the current reply's pending identity.
+  return !userSendAt || message.createdAt.localeCompare(userSendAt) >= 0;
 }
 
 // 当前权威设备列表(由首页从设备列表 API reconcile 后注入)。每次重算会话时基于它 + 当前 shards(stale 侧)
@@ -1258,6 +1274,8 @@ function reanchorPendingLiveAssistantRows(
     afterMessage?: RemoteMessage;
     /** 权威窗口可一次带回多轮 user；从窗口尾部向前与 pending 回复按序一对一配对。 */
     afterMessages?: readonly RemoteMessage[];
+    /** 已知本轮发送标记时，实时 user push 也只认领最新的 pending 回复。 */
+    pairPendingFromEnd?: boolean;
   } = {},
 ): boolean {
   if (!hostCreatedAtWatermark) return false;
@@ -1275,8 +1293,16 @@ function reanchorPendingLiveAssistantRows(
   }
   const afterMessages = options.afterMessages
     ?? (options.afterMessage ? [options.afterMessage] : []);
+  const pairsPendingFromEnd = options.afterMessages !== undefined
+    || options.pairPendingFromEnd === true;
   const pairCount = Math.min(pendingRows.length, afterMessages.length);
-  const pairedRows = pendingRows.slice(0, pairCount);
+  // A bounded latest window represents the newest user rows, so pair it with the
+  // newest pending replies. Realtime pushes do the same once the latest send marker
+  // is known; before metadata arrives they preserve front-to-back arrival order.
+  const pairedRowStart = pairsPendingFromEnd
+    ? pendingRows.length - pairCount
+    : 0;
+  const pairedRows = pendingRows.slice(pairedRowStart, pairedRowStart + pairCount);
   const pairedAfterMessages = afterMessages.slice(afterMessages.length - pairCount);
   const pairedCreatedAtById = new Map<string, string>();
   for (let index = 0; index < pairCount; index += 1) {
@@ -1292,6 +1318,7 @@ function reanchorPendingLiveAssistantRows(
     ) return message;
     const pairedCreatedAt = pairedCreatedAtById.get(message.id)
       ?? pairedCreatedAtById.get(message.clientId);
+    if (pairsPendingFromEnd && pairedCreatedAt === undefined) return message;
     const createdAt = pairedCreatedAt ?? hostCreatedAtWatermark;
     return message.createdAt === createdAt ? message : { ...message, createdAt };
   });
@@ -2433,7 +2460,11 @@ export const remoteSessionStore = {
       && reanchorPendingLiveAssistantRows(
         sessionId,
         message.createdAt,
-        { afterMessage: message },
+        {
+          afterMessage: message,
+          consumePending: userMessageCanConsumePendingLiveReply(sessionId, message),
+          pairPendingFromEnd: latestUserSendAt(sessionId) !== undefined,
+        },
       )
     ) {
       bumpMessageVersion();

--- a/apps/mobile/src/session/remoteSessionStore.ts
+++ b/apps/mobile/src/session/remoteSessionStore.ts
@@ -778,7 +778,14 @@ let messageVersion = 0;
 let storeVersion = 0;
 
 function liveRowCreatedAtWatermark(sessionId: string): string | undefined {
-  const messageWatermark = newestCreatedAt(messages.get(sessionId) ?? []);
+  const pendingHostAnchorIds = pendingHostAnchorLiveAssistantClientIds.get(sessionId);
+  const messageWatermark = newestCreatedAt((messages.get(sessionId) ?? []).filter((message) => {
+    const isPendingHostAnchor = pendingHostAnchorIds?.has(message.id) === true
+      || pendingHostAnchorIds?.has(message.clientId) === true;
+    const isLocalSystemCard = message.systemCardType !== undefined
+      && (message.id.startsWith('mobile-system-') || message.clientId.startsWith('mobile-system-'));
+    return !isPendingHostAnchor && !isLocalSystemCard;
+  }));
   if (messageWatermark) return messageWatermark;
   const session = mergedSessions.find((item) => item.id === sessionId);
   return session?.userSendAt ?? session?.updatedAt ?? session?.createdAt;

--- a/apps/mobile/src/session/remoteSessionStore.ts
+++ b/apps/mobile/src/session/remoteSessionStore.ts
@@ -785,14 +785,23 @@ type LiveRowCreatedAtAnchor = {
 
 function liveRowCreatedAtAnchor(sessionId: string): LiveRowCreatedAtAnchor {
   const pendingHostAnchorIds = pendingHostAnchorLiveAssistantClientIds.get(sessionId);
-  const messageWatermark = newestCreatedAt((messages.get(sessionId) ?? []).filter((message) => {
+  const authoritativeMessages = (messages.get(sessionId) ?? []).filter((message) => {
     const isPendingHostAnchor = pendingHostAnchorIds?.has(message.id) === true
       || pendingHostAnchorIds?.has(message.clientId) === true;
     const isLocalSystemCard = message.systemCardType !== undefined
       && (message.id.startsWith('mobile-system-') || message.clientId.startsWith('mobile-system-'));
     return !isPendingHostAnchor && !isLocalSystemCard;
-  }));
-  if (messageWatermark) return { createdAt: messageWatermark, provisional: false };
+  });
+  const messageWatermark = newestCreatedAt(authoritativeMessages);
+  if (messageWatermark) {
+    const latestAuthoritativeMessage = authoritativeMessages[authoritativeMessages.length - 1];
+    return {
+      createdAt: messageWatermark,
+      // 只有明确看到本轮 user 尾行,才能认定 live 回复已经落在问题之后。旧 assistant /
+      // tool 尾行可能属于上一轮；当前 user push 仍在途时,它只能提供临时时间锚。
+      provisional: latestAuthoritativeMessage?.role !== 'user',
+    };
+  }
   const session = mergedSessions.find((item) => item.id === sessionId);
   return {
     createdAt: session?.userSendAt ?? session?.updatedAt ?? session?.createdAt,
@@ -1255,11 +1264,18 @@ function reanchorPendingLiveAssistantRows(
   let next = normalizeMessages(reanchored);
   let afterMessageFound = options.afterMessage === undefined;
   const afterMessage = options.afterMessage;
+  let consumedPendingRows: RemoteMessage[] = [];
   if (afterMessage) {
-    const pendingRows = next.filter((message) => (
-      message.role === 'assistant'
-      && (pendingIds.has(message.id) || pendingIds.has(message.clientId))
-    ));
+    // user pushes are authoritative and ordered. Pair each one with the oldest still-pending
+    // live reply instead of moving every provisional row across rounds behind the same user.
+    const pendingRows = [...pendingIds].flatMap((pendingId) => {
+      const match = next.find((message) => (
+        message.role === 'assistant'
+        && (message.id === pendingId || message.clientId === pendingId)
+      ));
+      return match ? [match] : [];
+    }).slice(0, 1);
+    consumedPendingRows = pendingRows;
     const pendingRowSet = new Set(pendingRows);
     const withoutPending = next.filter((message) => !pendingRowSet.has(message));
     const anchorIndex = withoutPending.findIndex((message) => (
@@ -1275,7 +1291,15 @@ function reanchorPendingLiveAssistantRows(
     }
   }
   if (options.consumePending !== false && afterMessageFound) {
-    pendingHostAnchorLiveAssistantClientIds.delete(sessionId);
+    if (afterMessage) {
+      for (const pendingRow of consumedPendingRows) {
+        pendingIds.delete(pendingRow.id);
+        pendingIds.delete(pendingRow.clientId);
+      }
+      if (pendingIds.size === 0) pendingHostAnchorLiveAssistantClientIds.delete(sessionId);
+    } else {
+      pendingHostAnchorLiveAssistantClientIds.delete(sessionId);
+    }
   }
   if (remoteMessageListsEqual(existing, next)) return false;
   messages.set(sessionId, next);

--- a/apps/mobile/src/session/remoteSessionStore.ts
+++ b/apps/mobile/src/session/remoteSessionStore.ts
@@ -525,7 +525,7 @@ const streamingAssistantClientIds = new Map<string, string>();
 // The same persisted streaming identity can be replayed by a stale transport after
 // re-link. Track the transport currently assembling that identity so a device switch
 // replaces the stale live text instead of concatenating two transports into one row.
-const streamingAssistantDeviceIds = new Map<string, string>();
+const streamingAssistantDeviceIds = new Map<string, Map<string, string>>();
 const pendingLiveAssistantClientIds = new Map<string, Set<string>>();
 // 首个 live 行可能早于 getSession / listMessages 到达。此时只能暂用手机时间，待第一份
 // 主机时间水位到达后重锚；否则快手机时钟会让短且无 persistId 的旧 live 行长期占据尾部。
@@ -565,8 +565,36 @@ const pendingTextDeltaBatches = new Map<string, {
 }>();
 let textDeltaFlushTimer: ReturnType<typeof setTimeout> | null = null;
 
-function clearStreamingAssistantAssembly(sessionId: string): boolean {
-  const clientIdChanged = streamingAssistantClientIds.delete(sessionId);
+function streamingAssistantDeviceId(
+  sessionId: string,
+  clientId: string,
+): string | undefined {
+  return streamingAssistantDeviceIds.get(sessionId)?.get(clientId);
+}
+
+function rememberStreamingAssistantDeviceId(
+  sessionId: string,
+  clientId: string,
+  deviceId: string,
+): void {
+  const existing = streamingAssistantDeviceIds.get(sessionId) ?? new Map<string, string>();
+  existing.set(clientId, deviceId);
+  streamingAssistantDeviceIds.set(sessionId, existing);
+}
+
+function forgetStreamingAssistantDeviceId(sessionId: string, clientId: string): boolean {
+  const existing = streamingAssistantDeviceIds.get(sessionId);
+  if (!existing || !existing.delete(clientId)) return false;
+  if (existing.size === 0) streamingAssistantDeviceIds.delete(sessionId);
+  return true;
+}
+
+function clearStreamingAssistantPointer(sessionId: string): boolean {
+  return streamingAssistantClientIds.delete(sessionId);
+}
+
+function clearStreamingAssistantState(sessionId: string): boolean {
+  const clientIdChanged = clearStreamingAssistantPointer(sessionId);
   const deviceIdChanged = streamingAssistantDeviceIds.delete(sessionId);
   return clientIdChanged || deviceIdChanged;
 }
@@ -708,7 +736,7 @@ function invalidateSessionMessageWindowState(
   changed = sessionTaskUpdates.delete(sessionId) || changed;
   changed = sessionParkedTaskUpdates.delete(sessionId) || changed;
   changed = sessionMessageSyncMarkers.delete(sessionId) || changed;
-  changed = clearStreamingAssistantAssembly(sessionId) || changed;
+  changed = clearStreamingAssistantState(sessionId) || changed;
   changed = pendingLiveAssistantClientIds.delete(sessionId) || changed;
   changed = pendingHostAnchorLiveAssistantClientIds.delete(sessionId) || changed;
   changed = activePendingHostAnchorRoundIds.delete(sessionId) || changed;
@@ -762,18 +790,25 @@ function discardTransportOwnedPendingSessionState(
     changed = true;
   }
   const pendingAnchors = pendingHostAnchorLiveAssistantClientIds.get(sessionId);
-  if (!pendingAnchors) return changed;
   const pendingAnchorIds = new Set<string>();
-  for (const [id, identity] of pendingAnchors) {
-    if (!identity.deviceIds.has(deviceId)) continue;
-    if (identity.deviceIds.size > 1) {
-      pendingAnchors.set(id, {
-        ...identity,
-        deviceIds: new Set([...identity.deviceIds].filter((candidate) => candidate !== deviceId)),
-      });
-      changed = true;
-    } else {
-      pendingAnchorIds.add(id);
+  if (pendingAnchors) {
+    for (const [id, identity] of pendingAnchors) {
+      if (!identity.deviceIds.has(deviceId)) continue;
+      if (identity.deviceIds.size > 1) {
+        pendingAnchors.set(id, {
+          ...identity,
+          deviceIds: new Set([...identity.deviceIds].filter((candidate) => candidate !== deviceId)),
+        });
+        changed = true;
+      } else {
+        pendingAnchorIds.add(id);
+      }
+    }
+  }
+  const streamingDeviceIds = streamingAssistantDeviceIds.get(sessionId);
+  if (streamingDeviceIds) {
+    for (const [id, ownerDeviceId] of streamingDeviceIds) {
+      if (ownerDeviceId === deviceId) pendingAnchorIds.add(id);
     }
   }
   if (pendingAnchorIds.size === 0) return changed;
@@ -795,24 +830,43 @@ function discardTransportOwnedPendingSessionState(
   }
   const streamingClientId = streamingAssistantClientIds.get(sessionId);
   if (streamingClientId && pendingAnchorIds.has(streamingClientId)) {
-    clearStreamingAssistantAssembly(sessionId);
+    streamingAssistantClientIds.delete(sessionId);
   }
-  for (const id of pendingAnchorIds) pendingAnchors.delete(id);
-  if (pendingAnchors.size === 0) {
-    pendingHostAnchorLiveAssistantClientIds.delete(sessionId);
-    activePendingHostAnchorRoundIds.delete(sessionId);
-  } else {
-    const activeRoundId = activePendingHostAnchorRoundIds.get(sessionId);
-    if (
-      activeRoundId !== undefined
-      && ![...pendingAnchors.values()].some((identity) => (
-        identity.unboundRoundId === activeRoundId
-      ))
-    ) {
+  for (const id of pendingAnchorIds) forgetStreamingAssistantDeviceId(sessionId, id);
+  if (pendingAnchors) {
+    for (const id of pendingAnchorIds) pendingAnchors.delete(id);
+    if (pendingAnchors.size === 0) {
+      pendingHostAnchorLiveAssistantClientIds.delete(sessionId);
       activePendingHostAnchorRoundIds.delete(sessionId);
+    } else {
+      const activeRoundId = activePendingHostAnchorRoundIds.get(sessionId);
+      if (
+        activeRoundId !== undefined
+        && ![...pendingAnchors.values()].some((identity) => (
+          identity.unboundRoundId === activeRoundId
+        ))
+      ) {
+        activePendingHostAnchorRoundIds.delete(sessionId);
+      }
     }
   }
   return true;
+}
+
+function hasTransportOwnedSessionStateFromOtherDevice(
+  sessionId: string,
+  deviceId: string,
+): boolean {
+  const batchDeviceId = pendingTextDeltaBatches.get(sessionId)?.deviceId;
+  if (batchDeviceId !== undefined && batchDeviceId !== deviceId) return true;
+  const pendingAnchors = pendingHostAnchorLiveAssistantClientIds.get(sessionId);
+  if (pendingAnchors && [...pendingAnchors.values()].some((identity) => (
+    [...identity.deviceIds].some((ownerDeviceId) => ownerDeviceId !== deviceId)
+  ))) return true;
+  const streamingDeviceIds = streamingAssistantDeviceIds.get(sessionId);
+  return streamingDeviceIds
+    ? [...streamingDeviceIds.values()].some((ownerDeviceId) => ownerDeviceId !== deviceId)
+    : false;
 }
 
 function releaseSessionDetailProjections(sessionId: string): boolean {
@@ -1460,6 +1514,7 @@ function forgetPendingLiveAssistantClientId(sessionId: string, clientId: string 
       pendingHostAnchorLiveAssistantClientIds.delete(sessionId);
     }
   }
+  forgetStreamingAssistantDeviceId(sessionId, clientId);
 }
 
 function forgetPendingLiveAssistantMessageIdentity(
@@ -1696,7 +1751,7 @@ function reanchorPendingLiveAssistantRows(
 
 function retireGeneratedStreamingFallback(sessionId: string): void {
   const current = streamingAssistantClientIds.get(sessionId);
-  if (isGeneratedStreamingClientId(current)) clearStreamingAssistantAssembly(sessionId);
+  if (isGeneratedStreamingClientId(current)) streamingAssistantClientIds.delete(sessionId);
   forgetGeneratedPendingLiveAssistantClientIds(sessionId);
 }
 
@@ -1759,12 +1814,16 @@ function migrateGeneratedStreamingClientId(sessionId: string, generatedClientId:
   streamingAssistantClientIds.set(sessionId, persistId);
 
   const hadPendingLiveId = pendingLiveAssistantClientIds.get(sessionId)?.has(generatedClientId) === true;
+  const streamingDeviceId = streamingAssistantDeviceId(sessionId, generatedClientId);
   const neededHostAnchor = pendingHostAnchorLiveAssistantClientIds
     .get(sessionId)
     ?.has(generatedClientId) === true;
   const hostAnchorIdentity = pendingHostAnchorIdentity(sessionId, generatedClientId);
   forgetPendingLiveAssistantClientId(sessionId, generatedClientId);
   if (hadPendingLiveId) rememberPendingLiveAssistantClientId(sessionId, persistId);
+  if (streamingDeviceId) {
+    rememberStreamingAssistantDeviceId(sessionId, persistId, streamingDeviceId);
+  }
   if (neededHostAnchor && hostAnchorIdentity) {
     rememberPendingHostAnchorLiveAssistantClientId(
       sessionId,
@@ -1881,18 +1940,11 @@ function applyRemoteTextEvent(
   const isFinal = data?.isFinal === true;
   if (!text) return false;
 
-  const previousStreamingClientId = streamingAssistantClientIds.get(sessionId);
-  const previousStreamingDeviceId = streamingAssistantDeviceIds.get(sessionId);
   const clientIdResolution = streamingClientIdFor(sessionId, persistId);
   const { clientId } = clientIdResolution;
+  const previousStreamingDeviceId = streamingAssistantDeviceId(sessionId, clientId);
   const matchedExisting = messages.get(sessionId)?.find((message) => message.clientId === clientId);
-  const continuesPreviousAssembly = previousStreamingClientId === clientId
-    || (
-      isGeneratedStreamingClientId(previousStreamingClientId)
-      && persistId?.trim() === clientId
-    );
-  const resetsTransportAssembly = continuesPreviousAssembly
-    && previousStreamingDeviceId !== undefined
+  const resetsTransportAssembly = previousStreamingDeviceId !== undefined
     && deviceId !== undefined
     && previousStreamingDeviceId !== deviceId
     && matchedExisting !== undefined
@@ -1905,7 +1957,6 @@ function applyRemoteTextEvent(
         clientId,
       )
     : undefined;
-  if (deviceId !== undefined) streamingAssistantDeviceIds.set(sessionId, deviceId);
   const existing = resetsTransportAssembly ? undefined : matchedExisting;
   const finalTextWasTruncated = isFinal && (
     hasDeviceLinkTruncationMarker(event) || hasDeviceLinkTruncationMarker(data)
@@ -1949,6 +2000,12 @@ function applyRemoteTextEvent(
           resetHostAnchorIdentity?.unboundRoundId,
         );
       }
+    }
+    if (
+      deviceId !== undefined
+      && pendingLiveAssistantClientIds.get(sessionId)?.has(clientId) === true
+    ) {
+      rememberStreamingAssistantDeviceId(sessionId, clientId, deviceId);
     }
     return changed || clientIdResolution.changed;
   }
@@ -2021,6 +2078,12 @@ function applyRemoteTextEvent(
       deviceId,
       hostAnchorIdentity?.unboundRoundId,
     );
+  }
+  if (
+    deviceId !== undefined
+    && pendingLiveAssistantClientIds.get(sessionId)?.has(clientId) === true
+  ) {
+    rememberStreamingAssistantDeviceId(sessionId, clientId, deviceId);
   }
   return changed || clientIdResolution.changed;
 }
@@ -2139,7 +2202,7 @@ function finalizeRemoteStreamingMessages(
   sessionId: string,
   boundaryAgentMeta?: Record<string, unknown> | null,
 ): boolean {
-  clearStreamingAssistantAssembly(sessionId);
+  clearStreamingAssistantPointer(sessionId);
   const existing = messages.get(sessionId);
   if (!existing) return false;
   let changed = false;
@@ -3808,7 +3871,7 @@ export const remoteSessionStore = {
       // Background compact belongs to the previous idle cycle. Finalizing here
       // would seal a product turn that started after compaction_start.
       if (!backgroundCompact) {
-        clearStreamingAssistantAssembly(sessionId);
+        clearStreamingAssistantPointer(sessionId);
       }
       const nextMessages = backgroundCompact
         ? existing
@@ -3945,7 +4008,7 @@ export const remoteSessionStore = {
     for (const [sessionId, batch] of [...pendingTextDeltaBatches]) {
       if (batch.deviceId !== deviceId) continue;
       changed = flushAndFinalizeRemoteStreamingMessages(sessionId) || changed;
-      changed = clearStreamingAssistantAssembly(sessionId) || changed;
+      changed = clearStreamingAssistantPointer(sessionId) || changed;
       changed = freezeUnboundPendingHostAnchorsForOffline(sessionId, deviceId) || changed;
     }
     for (const [sessionId, indexedDeviceId] of sessionDeviceIndex) {
@@ -3964,7 +4027,7 @@ export const remoteSessionStore = {
       changed = sessionParkedTaskUpdates.delete(sessionId) || changed;
       changed = sessionMakerActivityEpochs.delete(sessionId) || changed;
       changed = flushAndFinalizeRemoteStreamingMessages(sessionId) || changed;
-      changed = clearStreamingAssistantAssembly(sessionId) || changed;
+      changed = clearStreamingAssistantPointer(sessionId) || changed;
       // The message window survives a soft offline transition, so both pending
       // identities must survive too: one protects the live row during latest-window
       // reconciliation, and the other lets a reconnecting authoritative user row
@@ -3985,10 +4048,10 @@ export const remoteSessionStore = {
     const hadShard = shards.delete(deviceId);
     const hadWorktreePreference = newMakerWorktreePreferences.delete(deviceId);
     const hadWorktreeBranchPreferences = newMakerWorktreeBranchPreferences.delete(deviceId);
-    // A maker event may precede the session list, so transport-owned batches and host anchors
-    // are also authoritative ownership evidence. Sweep their sessions even when no shard or
-    // sessionDeviceIndex entry exists yet; otherwise the 32ms timer can recreate messages after
-    // hard removal, or an already-flushed provisional row can survive re-authorization.
+    // A maker event may precede the session list, so transport-owned batches, host anchors,
+    // and streaming identities are also authoritative ownership evidence. Sweep their sessions
+    // even when no shard or sessionDeviceIndex entry exists yet; otherwise the 32ms timer can
+    // recreate messages after hard removal, or an already-flushed live row can survive.
     const indexedDeviceSessionIds = new Set<string>();
     const transportOwnedSessionIds = new Set<string>();
     for (const [sessionId, indexedDeviceId] of sessionDeviceIndex) {
@@ -4002,13 +4065,29 @@ export const remoteSessionStore = {
         transportOwnedSessionIds.add(sessionId);
       }
     }
+    for (const [sessionId, streamingDeviceIds] of streamingAssistantDeviceIds) {
+      if ([...streamingDeviceIds.values()].some((ownerDeviceId) => ownerDeviceId === deviceId)) {
+        transportOwnedSessionIds.add(sessionId);
+      }
+    }
+    let removedTransportState = false;
     for (const sessionId of indexedDeviceSessionIds) {
       // Keep the authority reset explicit in this hard-remove boundary: consumers must
       // never interpret the now-empty interaction list as an authoritative snapshot.
       pendingInteractionsAuthoritative.delete(sessionId);
+      if (hasTransportOwnedSessionStateFromOtherDevice(sessionId, deviceId)) {
+        // The stale shard may still own sessionDeviceIndex while a re-linked transport has
+        // already started streaming before its own session list arrives. Preserve that
+        // replacement batch/row and remove only state owned by the stale transport.
+        sessionDeviceIndex.delete(sessionId);
+        removedTransportState = discardTransportOwnedPendingSessionState(
+          sessionId,
+          deviceId,
+        ) || removedTransportState;
+        continue;
+      }
       removeSessionRuntimeState(sessionId);
     }
-    let removedTransportState = false;
     for (const sessionId of transportOwnedSessionIds) {
       if (indexedDeviceSessionIds.has(sessionId)) continue;
       // A re-linked current shard may already own the same session id. In that case
@@ -4023,6 +4102,7 @@ export const remoteSessionStore = {
         !sessionDeviceIndex.has(sessionId)
         && !pendingTextDeltaBatches.has(sessionId)
         && !pendingHostAnchorLiveAssistantClientIds.has(sessionId)
+        && !streamingAssistantDeviceIds.has(sessionId)
       ) {
         pendingInteractionsAuthoritative.delete(sessionId);
         removeSessionRuntimeState(sessionId);

--- a/apps/mobile/src/session/remoteSessionStore.ts
+++ b/apps/mobile/src/session/remoteSessionStore.ts
@@ -531,6 +531,8 @@ const pendingLiveAssistantClientIds = new Map<string, Set<string>>();
 // null 身份先经历软离线，则禁止用重连后的“首份”元数据绑定，因为它可能已经是下一轮。
 type PendingHostAnchorIdentity = {
   bindOnMetadata: boolean;
+  /** Transports that have produced this provisional identity. */
+  deviceIds: ReadonlySet<string>;
   /**
    * Local maker-turn cohort used only while host session metadata is unavailable.
    * Distinct assistant rows emitted by one running turn share this id, so the first
@@ -545,10 +547,6 @@ const pendingHostAnchorLiveAssistantClientIds = new Map<
   string,
   Map<string, PendingHostAnchorIdentity>
 >();
-// A live maker event may arrive before the session list contains its session. Keep the
-// transport device alongside the pending anchor so markDeviceOffline can still freeze an
-// unbound identity without relying on sessionDeviceIndex.
-const pendingHostAnchorDeviceIds = new Map<string, string>();
 const activePendingHostAnchorRoundIds = new Map<string, number>();
 let nextPendingHostAnchorRoundId = 0;
 let streamingFallbackSequence = 0;
@@ -702,7 +700,6 @@ function invalidateSessionMessageWindowState(
   changed = streamingAssistantClientIds.delete(sessionId) || changed;
   changed = pendingLiveAssistantClientIds.delete(sessionId) || changed;
   changed = pendingHostAnchorLiveAssistantClientIds.delete(sessionId) || changed;
-  changed = pendingHostAnchorDeviceIds.delete(sessionId) || changed;
   changed = activePendingHostAnchorRoundIds.delete(sessionId) || changed;
   if (pendingTextDeltaBatches.has(sessionId)) {
     discardPendingTextDelta(sessionId);
@@ -753,11 +750,22 @@ function discardTransportOwnedPendingSessionState(
     discardPendingTextDelta(sessionId);
     changed = true;
   }
-  if (pendingHostAnchorDeviceIds.get(sessionId) !== deviceId) return changed;
-
-  const pendingAnchorIds = new Set(
-    pendingHostAnchorLiveAssistantClientIds.get(sessionId)?.keys() ?? [],
-  );
+  const pendingAnchors = pendingHostAnchorLiveAssistantClientIds.get(sessionId);
+  if (!pendingAnchors) return changed;
+  const pendingAnchorIds = new Set<string>();
+  for (const [id, identity] of pendingAnchors) {
+    if (!identity.deviceIds.has(deviceId)) continue;
+    if (identity.deviceIds.size > 1) {
+      pendingAnchors.set(id, {
+        ...identity,
+        deviceIds: new Set([...identity.deviceIds].filter((candidate) => candidate !== deviceId)),
+      });
+      changed = true;
+    } else {
+      pendingAnchorIds.add(id);
+    }
+  }
+  if (pendingAnchorIds.size === 0) return changed;
   const existingMessages = messages.get(sessionId);
   if (existingMessages && pendingAnchorIds.size > 0) {
     const nextMessages = existingMessages.filter((message) => (
@@ -778,9 +786,21 @@ function discardTransportOwnedPendingSessionState(
   if (streamingClientId && pendingAnchorIds.has(streamingClientId)) {
     streamingAssistantClientIds.delete(sessionId);
   }
-  pendingHostAnchorLiveAssistantClientIds.delete(sessionId);
-  pendingHostAnchorDeviceIds.delete(sessionId);
-  activePendingHostAnchorRoundIds.delete(sessionId);
+  for (const id of pendingAnchorIds) pendingAnchors.delete(id);
+  if (pendingAnchors.size === 0) {
+    pendingHostAnchorLiveAssistantClientIds.delete(sessionId);
+    activePendingHostAnchorRoundIds.delete(sessionId);
+  } else {
+    const activeRoundId = activePendingHostAnchorRoundIds.get(sessionId);
+    if (
+      activeRoundId !== undefined
+      && ![...pendingAnchors.values()].some((identity) => (
+        identity.unboundRoundId === activeRoundId
+      ))
+    ) {
+      activePendingHostAnchorRoundIds.delete(sessionId);
+    }
+  }
   return true;
 }
 
@@ -1326,12 +1346,15 @@ function rememberPendingHostAnchorLiveAssistantClientId(
   clientId: string | null | undefined,
   sendAt: string | null = latestUserSendAt(sessionId) ?? null,
   bindOnMetadata = true,
-  deviceId?: string,
+  deviceIds?: string | readonly string[],
   unboundRoundId?: number | null,
 ): void {
   if (!clientId) return;
   const existing = pendingHostAnchorLiveAssistantClientIds.get(sessionId)
     ?? new Map<string, PendingHostAnchorIdentity>();
+  const nextDeviceIds = typeof deviceIds === 'string'
+    ? [deviceIds]
+    : deviceIds ?? [];
   if (!existing.has(clientId)) {
     let resolvedRoundId = unboundRoundId;
     if (resolvedRoundId === undefined) {
@@ -1349,10 +1372,22 @@ function rememberPendingHostAnchorLiveAssistantClientId(
         resolvedRoundId = ++nextPendingHostAnchorRoundId;
       }
     }
-    existing.set(clientId, { bindOnMetadata, sendAt, unboundRoundId: resolvedRoundId });
+    existing.set(clientId, {
+      bindOnMetadata,
+      deviceIds: new Set(nextDeviceIds),
+      sendAt,
+      unboundRoundId: resolvedRoundId,
+    });
+  } else if (nextDeviceIds.length > 0) {
+    const identity = existing.get(clientId);
+    if (identity && nextDeviceIds.some((deviceId) => !identity.deviceIds.has(deviceId))) {
+      existing.set(clientId, {
+        ...identity,
+        deviceIds: new Set([...identity.deviceIds, ...nextDeviceIds]),
+      });
+    }
   }
   pendingHostAnchorLiveAssistantClientIds.set(sessionId, existing);
-  if (deviceId) pendingHostAnchorDeviceIds.set(sessionId, deviceId);
 }
 
 function pendingHostAnchorIdentity(
@@ -1378,11 +1413,12 @@ function bindPendingHostAnchorSendAt(sessionId: string, sendAt: string | null | 
   }
 }
 
-function freezeUnboundPendingHostAnchorsForOffline(sessionId: string): boolean {
+function freezeUnboundPendingHostAnchorsForOffline(sessionId: string, deviceId: string): boolean {
   const existing = pendingHostAnchorLiveAssistantClientIds.get(sessionId);
   if (!existing) return false;
   let changed = false;
   for (const [id, identity] of existing) {
+    if (!identity.deviceIds.has(deviceId)) continue;
     if (identity.sendAt !== null || !identity.bindOnMetadata) continue;
     existing.set(id, { ...identity, bindOnMetadata: false });
     changed = true;
@@ -1411,7 +1447,6 @@ function forgetPendingLiveAssistantClientId(sessionId: string, clientId: string 
     pendingHostAnchorIds.delete(clientId);
     if (pendingHostAnchorIds.size === 0) {
       pendingHostAnchorLiveAssistantClientIds.delete(sessionId);
-      pendingHostAnchorDeviceIds.delete(sessionId);
     }
   }
 }
@@ -1472,6 +1507,9 @@ function reanchorPendingLiveAssistantRows(
     ...pendingRows
       .map((row) => row.identity.sendAt)
       .filter((sendAt): sendAt is string => sendAt !== null),
+    ...afterMessages
+      .filter((message) => message.role === 'user')
+      .map((message) => message.createdAt),
     ...(latestSendAt ? [latestSendAt] : []),
   ])].sort((left, right) => left.localeCompare(right));
   const hasOfflineUnboundPendingRow = pendingRows.some((row) => (
@@ -1501,10 +1539,28 @@ function reanchorPendingLiveAssistantRows(
     pendingRow: (typeof pendingRows)[number];
     afterMessage: RemoteMessage;
   }> = [];
+  const pairsOfflineUnboundFromStart = options.afterMessages === undefined
+    && afterMessages.length === 1
+    && afterMessages[0].role === 'user'
+    && hasOfflineUnboundPendingRow
+    && Boolean(latestSendAt)
+    && afterMessages[0].createdAt.localeCompare(latestSendAt ?? '') < 0;
   // A bounded latest window represents the newest user rows, so pair it with the
   // newest pending replies. Realtime pushes do the same once the latest send marker
-  // is known; before metadata arrives they preserve front-to-back arrival order.
-  if (pairsPendingFromEnd) {
+  // is known, except delayed users restoring multiple offline-unbound rounds: those
+  // must consume the oldest eligible cohort first to preserve arrival order.
+  if (pairsPendingFromEnd && pairsOfflineUnboundFromStart) {
+    const afterMessage = afterMessages[0];
+    const pendingRow = pendingRows
+      .filter((row) => pendingRowCanPairMessage(row, afterMessage))
+      .reduce<(typeof pendingRows)[number] | undefined>((oldest, row) => {
+        if (!oldest) return row;
+        const oldestRoundId = oldest.identity.unboundRoundId ?? Number.MAX_SAFE_INTEGER;
+        const rowRoundId = row.identity.unboundRoundId ?? Number.MAX_SAFE_INTEGER;
+        return rowRoundId < oldestRoundId ? row : oldest;
+      }, undefined);
+    if (pendingRow) pairs.push({ pendingRow, afterMessage });
+  } else if (pairsPendingFromEnd) {
     let maxRowIndex = pendingRows.length - 1;
     for (let afterIndex = afterMessages.length - 1; afterIndex >= 0 && maxRowIndex >= 0; afterIndex -= 1) {
       let matchedRowIndex = -1;
@@ -1617,11 +1673,9 @@ function reanchorPendingLiveAssistantRows(
       }
       if (pendingIds.size === 0) {
         pendingHostAnchorLiveAssistantClientIds.delete(sessionId);
-        pendingHostAnchorDeviceIds.delete(sessionId);
       }
     } else {
       pendingHostAnchorLiveAssistantClientIds.delete(sessionId);
-      pendingHostAnchorDeviceIds.delete(sessionId);
     }
   }
   if (remoteMessageListsEqual(existing, next)) return false;
@@ -1698,7 +1752,6 @@ function migrateGeneratedStreamingClientId(sessionId: string, generatedClientId:
     .get(sessionId)
     ?.has(generatedClientId) === true;
   const hostAnchorIdentity = pendingHostAnchorIdentity(sessionId, generatedClientId);
-  const hostAnchorDeviceId = pendingHostAnchorDeviceIds.get(sessionId);
   forgetPendingLiveAssistantClientId(sessionId, generatedClientId);
   if (hadPendingLiveId) rememberPendingLiveAssistantClientId(sessionId, persistId);
   if (neededHostAnchor && hostAnchorIdentity) {
@@ -1707,7 +1760,7 @@ function migrateGeneratedStreamingClientId(sessionId: string, generatedClientId:
       persistId,
       hostAnchorIdentity.sendAt,
       hostAnchorIdentity.bindOnMetadata,
-      hostAnchorDeviceId,
+      [...hostAnchorIdentity.deviceIds],
       hostAnchorIdentity.unboundRoundId,
     );
   }
@@ -1903,19 +1956,20 @@ function applyRemoteTextEvent(
   });
   if (changed) {
     rememberPendingLiveAssistantClientId(sessionId, clientId);
-    // upsertMessage intentionally clears pending reconciliation identities when it
-    // replaces an assistant row. A live delta/final is not host-authoritative, so
-    // carry the provisional anchor forward until metadata or a persisted row lands.
-    if (needsHostAnchor) {
-      rememberPendingHostAnchorLiveAssistantClientId(
-        sessionId,
-        clientId,
-        hostAnchorIdentity?.sendAt ?? latestUserSendAt(sessionId) ?? null,
-        hostAnchorIdentity?.bindOnMetadata ?? true,
-        deviceId,
-        hostAnchorIdentity?.unboundRoundId,
-      );
-    }
+  }
+  // upsertMessage intentionally clears pending reconciliation identities when it
+  // replaces an assistant row. A live delta/final is not host-authoritative, so
+  // carry the provisional anchor forward until metadata or a persisted row lands.
+  // Even an unchanged replay can add a second transport owner for the same identity.
+  if (needsHostAnchor) {
+    rememberPendingHostAnchorLiveAssistantClientId(
+      sessionId,
+      clientId,
+      hostAnchorIdentity?.sendAt ?? latestUserSendAt(sessionId) ?? null,
+      hostAnchorIdentity?.bindOnMetadata ?? true,
+      deviceId,
+      hostAnchorIdentity?.unboundRoundId,
+    );
   }
   return changed || clientIdResolution.changed;
 }
@@ -3835,7 +3889,7 @@ export const remoteSessionStore = {
       if (batch.deviceId !== deviceId) continue;
       changed = flushAndFinalizeRemoteStreamingMessages(sessionId) || changed;
       changed = streamingAssistantClientIds.delete(sessionId) || changed;
-      changed = freezeUnboundPendingHostAnchorsForOffline(sessionId) || changed;
+      changed = freezeUnboundPendingHostAnchorsForOffline(sessionId, deviceId) || changed;
     }
     for (const [sessionId, indexedDeviceId] of sessionDeviceIndex) {
       if (indexedDeviceId !== deviceId) continue;
@@ -3859,13 +3913,13 @@ export const remoteSessionStore = {
       // reconciliation, and the other lets a reconnecting authoritative user row
       // restore question → reply order. Persisted reconciliation, explicit window
       // invalidation, or actual device removal will retire them.
-      changed = freezeUnboundPendingHostAnchorsForOffline(sessionId) || changed;
+      changed = freezeUnboundPendingHostAnchorsForOffline(sessionId, deviceId) || changed;
       changed = writeMakerTurnRunning(sessionId, false) || changed;
       changed = writeSessionRunStatus(sessionId, EMPTY_SESSION_RUN_STATUS) || changed;
     }
-    for (const [sessionId, pendingDeviceId] of pendingHostAnchorDeviceIds) {
-      if (pendingDeviceId !== deviceId) continue;
-      changed = freezeUnboundPendingHostAnchorsForOffline(sessionId) || changed;
+    for (const [sessionId, pendingAnchors] of pendingHostAnchorLiveAssistantClientIds) {
+      if (![...pendingAnchors.values()].some((identity) => identity.deviceIds.has(deviceId))) continue;
+      changed = freezeUnboundPendingHostAnchorsForOffline(sessionId, deviceId) || changed;
     }
     if (changed) emit();
   },
@@ -3886,8 +3940,10 @@ export const remoteSessionStore = {
     for (const [sessionId, batch] of pendingTextDeltaBatches) {
       if (batch.deviceId === deviceId) transportOwnedSessionIds.add(sessionId);
     }
-    for (const [sessionId, pendingDeviceId] of pendingHostAnchorDeviceIds) {
-      if (pendingDeviceId === deviceId) transportOwnedSessionIds.add(sessionId);
+    for (const [sessionId, pendingAnchors] of pendingHostAnchorLiveAssistantClientIds) {
+      if ([...pendingAnchors.values()].some((identity) => identity.deviceIds.has(deviceId))) {
+        transportOwnedSessionIds.add(sessionId);
+      }
     }
     for (const sessionId of indexedDeviceSessionIds) {
       // Keep the authority reset explicit in this hard-remove boundary: consumers must
@@ -3898,20 +3954,23 @@ export const remoteSessionStore = {
     let removedTransportState = false;
     for (const sessionId of transportOwnedSessionIds) {
       if (indexedDeviceSessionIds.has(sessionId)) continue;
-      const indexedDeviceId = sessionDeviceIndex.get(sessionId);
-      if (!indexedDeviceId) {
-        pendingInteractionsAuthoritative.delete(sessionId);
-        removeSessionRuntimeState(sessionId);
-        removedTransportState = true;
-        continue;
-      }
       // A re-linked current shard may already own the same session id. In that case
       // remove only the stale transport's provisional rows/batch and keep the current
-      // device's authoritative window and runtime projections intact.
+      // device's authoritative window and runtime projections intact. The same precise
+      // cleanup also preserves a second pre-metadata transport when no shard exists yet.
       removedTransportState = discardTransportOwnedPendingSessionState(
         sessionId,
         deviceId,
       ) || removedTransportState;
+      if (
+        !sessionDeviceIndex.has(sessionId)
+        && !pendingTextDeltaBatches.has(sessionId)
+        && !pendingHostAnchorLiveAssistantClientIds.has(sessionId)
+      ) {
+        pendingInteractionsAuthoritative.delete(sessionId);
+        removeSessionRuntimeState(sessionId);
+        removedTransportState = true;
+      }
     }
     const removedSession = indexedDeviceSessionIds.size > 0 || removedTransportState;
     if (
@@ -3952,7 +4011,6 @@ export const remoteSessionStore = {
     streamingAssistantClientIds.clear();
     pendingLiveAssistantClientIds.clear();
     pendingHostAnchorLiveAssistantClientIds.clear();
-    pendingHostAnchorDeviceIds.clear();
     activePendingHostAnchorRoundIds.clear();
     nextPendingHostAnchorRoundId = 0;
     pendingTextDeltaBatches.clear();

--- a/apps/mobile/src/session/remoteSessionStore.ts
+++ b/apps/mobile/src/session/remoteSessionStore.ts
@@ -770,6 +770,14 @@ function applyMessageWriteRetention(sessionId: string): void {
 let mergedSessions: RemoteSession[] = [];
 let messageVersion = 0;
 let storeVersion = 0;
+
+function liveRowCreatedAtWatermark(sessionId: string): string | undefined {
+  const messageWatermark = newestCreatedAt(messages.get(sessionId) ?? []);
+  if (messageWatermark) return messageWatermark;
+  const session = mergedSessions.find((item) => item.id === sessionId);
+  return session?.userSendAt ?? session?.updatedAt ?? session?.createdAt;
+}
+
 // 当前权威设备列表(由首页从设备列表 API reconcile 后注入)。每次重算会话时基于它 + 当前 shards(stale 侧)
 // 重建身份索引,用于给会话算展示用 canonicalDeviceId(把 re-link 后残留 stale shard 认领回当前设备);
 // 为 null 时不归一,安全退化。
@@ -1356,12 +1364,12 @@ function applyRemoteTextEvent(
     hasDeviceLinkTruncationMarker(event) || hasDeviceLinkTruncationMarker(data)
   );
   if (isFinal && !existing) {
-    // Device-clock stamp on a brand-new live row: anchor it to the session's newest known
-    // createdAt so a device clock running ahead of the host clock cannot dominate a later
-    // host-persisted message (see clampLiveRowCreatedAt in messagePaging.ts).
+    // Device-clock stamp on a brand-new live row: anchor it to the newest known message,
+    // or to host-domain session activity when the message window is still empty. Otherwise
+    // an ahead device clock can dominate the first later host-persisted row.
     const createdAt = clampLiveRowCreatedAt(
       new Date().toISOString(),
-      newestCreatedAt(messages.get(sessionId) ?? []),
+      liveRowCreatedAtWatermark(sessionId),
     );
     const changed = upsertMessage(sessionId, {
       id: clientId,
@@ -1409,7 +1417,7 @@ function applyRemoteTextEvent(
     // needs the clamp — see clampLiveRowCreatedAt doc comment in messagePaging.ts.
     createdAt: existing?.createdAt ?? clampLiveRowCreatedAt(
       new Date().toISOString(),
-      newestCreatedAt(messages.get(sessionId) ?? []),
+      liveRowCreatedAtWatermark(sessionId),
     ),
   });
   if (changed) rememberPendingLiveAssistantClientId(sessionId, clientId);

--- a/apps/mobile/src/session/remoteSessionStore.ts
+++ b/apps/mobile/src/session/remoteSessionStore.ts
@@ -1252,10 +1252,12 @@ function reanchorPendingLiveAssistantRows(
   sessionId: string,
   hostCreatedAtWatermark: string | undefined,
   options: {
-    /** 会话/消息窗口快照都可能旧于本次发送，只有实时消息可消费待重锚身份。 */
+    /** 快照默认只临时重锚；实时消息或已匹配最新 userSendAt 的窗口才可消费身份。 */
     consumePending?: boolean;
     /** user 行与 live 回复同戳时，明确把回复放在触发它的 user 行之后。 */
     afterMessage?: RemoteMessage;
+    /** 权威窗口可一次带回多轮 user；从窗口尾部向前与 pending 回复按序一对一配对。 */
+    afterMessages?: readonly RemoteMessage[];
   } = {},
 ): boolean {
   if (!hostCreatedAtWatermark) return false;
@@ -1263,45 +1265,59 @@ function reanchorPendingLiveAssistantRows(
   if (!pendingIds || pendingIds.size === 0) return false;
   const existing = messages.get(sessionId);
   if (!existing) return false;
+  const pendingRows: RemoteMessage[] = [];
+  for (const pendingId of pendingIds) {
+    const match = existing.find((message) => (
+      message.role === 'assistant'
+      && (message.id === pendingId || message.clientId === pendingId)
+    ));
+    if (match && !pendingRows.includes(match)) pendingRows.push(match);
+  }
+  const afterMessages = options.afterMessages
+    ?? (options.afterMessage ? [options.afterMessage] : []);
+  const pairCount = Math.min(pendingRows.length, afterMessages.length);
+  const pairedRows = pendingRows.slice(0, pairCount);
+  const pairedAfterMessages = afterMessages.slice(afterMessages.length - pairCount);
+  const pairedCreatedAtById = new Map<string, string>();
+  for (let index = 0; index < pairCount; index += 1) {
+    const pendingRow = pairedRows[index];
+    const createdAt = pairedAfterMessages[index].createdAt;
+    pairedCreatedAtById.set(pendingRow.id, createdAt);
+    pairedCreatedAtById.set(pendingRow.clientId, createdAt);
+  }
   const reanchored = existing.map((message) => {
     if (
       message.role !== 'assistant'
       || (!pendingIds.has(message.id) && !pendingIds.has(message.clientId))
-      || message.createdAt === hostCreatedAtWatermark
     ) return message;
-    return { ...message, createdAt: hostCreatedAtWatermark };
+    const pairedCreatedAt = pairedCreatedAtById.get(message.id)
+      ?? pairedCreatedAtById.get(message.clientId);
+    const createdAt = pairedCreatedAt ?? hostCreatedAtWatermark;
+    return message.createdAt === createdAt ? message : { ...message, createdAt };
   });
   let next = normalizeMessages(reanchored);
-  let afterMessageFound = options.afterMessage === undefined;
-  const afterMessage = options.afterMessage;
-  let consumedPendingRows: RemoteMessage[] = [];
-  if (afterMessage) {
-    // user pushes are authoritative and ordered. Pair each one with the oldest still-pending
-    // live reply instead of moving every provisional row across rounds behind the same user.
-    const pendingRows = [...pendingIds].flatMap((pendingId) => {
-      const match = next.find((message) => (
-        message.role === 'assistant'
-        && (message.id === pendingId || message.clientId === pendingId)
-      ));
-      return match ? [match] : [];
-    }).slice(0, 1);
-    consumedPendingRows = pendingRows;
-    const pendingRowSet = new Set(pendingRows);
-    const withoutPending = next.filter((message) => !pendingRowSet.has(message));
+  const consumedPendingRows: RemoteMessage[] = [];
+  for (let index = 0; index < pairCount; index += 1) {
+    const pendingRowIndex = next.findIndex((message) => (
+      messageIdentityMatches(message, pairedRows[index])
+    ));
+    if (pendingRowIndex < 0) continue;
+    const pendingRow = next[pendingRowIndex];
+    const withoutPending = next.filter((_, messageIndex) => messageIndex !== pendingRowIndex);
     const anchorIndex = withoutPending.findIndex((message) => (
-      messageIdentityMatches(message, afterMessage)
+      messageIdentityMatches(message, pairedAfterMessages[index])
     ));
     if (anchorIndex >= 0) {
-      afterMessageFound = true;
       next = [
         ...withoutPending.slice(0, anchorIndex + 1),
-        ...pendingRows,
+        pendingRow,
         ...withoutPending.slice(anchorIndex + 1),
       ];
+      consumedPendingRows.push(pendingRow);
     }
   }
-  if (options.consumePending !== false && afterMessageFound) {
-    if (afterMessage) {
+  if (options.consumePending !== false) {
+    if (afterMessages.length > 0) {
       for (const pendingRow of consumedPendingRows) {
         pendingIds.delete(pendingRow.id);
         pendingIds.delete(pendingRow.clientId);
@@ -2156,6 +2172,9 @@ export const remoteSessionStore = {
     // may temporarily position the live row but must leave it eligible for the realtime push.
     const consumeReanchorAfterMerge = reanchorAfterMerge
       && userMessageMatchesLatestSend(sessionId, latestTailMessage);
+    const reanchorAfterMessages = consumeReanchorAfterMerge
+      ? latestWindow.filter((message) => message.role === 'user')
+      : undefined;
     const liveRowsReanchoredBeforeMerge = !reanchorAfterMerge
       && reanchorPendingLiveAssistantRows(
         sessionId,
@@ -2277,7 +2296,8 @@ export const remoteSessionStore = {
           sessionId,
           latestNewestCreatedAt,
           {
-            afterMessage: latestTailMessage,
+            afterMessage: consumeReanchorAfterMerge ? undefined : latestTailMessage,
+            afterMessages: reanchorAfterMessages,
             consumePending: consumeReanchorAfterMerge,
           },
         );
@@ -2291,7 +2311,8 @@ export const remoteSessionStore = {
         sessionId,
         latestNewestCreatedAt,
         {
-          afterMessage: latestTailMessage,
+          afterMessage: consumeReanchorAfterMerge ? undefined : latestTailMessage,
+          afterMessages: reanchorAfterMessages,
           consumePending: consumeReanchorAfterMerge,
         },
       );

--- a/apps/mobile/src/session/remoteSessionStore.ts
+++ b/apps/mobile/src/session/remoteSessionStore.ts
@@ -49,7 +49,7 @@ import { classifySessionRetention, type SessionRetentionKind } from '@/session/s
 import { contentToPreview } from '@/utils/contentPreview';
 import type { MobileSystemCardType } from '@/session/systemCard';
 import type { InputProjection, PendingInteraction, RemoteMessage, RemoteSession } from '@/session/types';
-import { compareMessageOrder, MESSAGE_PAGE_SIZE } from '@/session/messagePaging';
+import { clampLiveRowCreatedAt, compareMessageOrder, MESSAGE_PAGE_SIZE } from '@/session/messagePaging';
 import { normalizeRemoteMoney } from '@/session/remoteMoney';
 
 interface DeviceShard {
@@ -1356,6 +1356,14 @@ function applyRemoteTextEvent(
     hasDeviceLinkTruncationMarker(event) || hasDeviceLinkTruncationMarker(data)
   );
   if (isFinal && !existing) {
+    // Device-clock stamp on a brand-new live row: clamp against the session's newest known
+    // createdAt so a device clock running ahead of the host clock can't leave this row
+    // sorting before a just-persisted message that arrives with an earlier host timestamp
+    // (see clampLiveRowCreatedAt doc comment in messagePaging.ts).
+    const createdAt = clampLiveRowCreatedAt(
+      new Date().toISOString(),
+      newestCreatedAt(messages.get(sessionId) ?? []),
+    );
     const changed = upsertMessage(sessionId, {
       id: clientId,
       clientId,
@@ -1364,7 +1372,7 @@ function applyRemoteTextEvent(
       content: text,
       toolUseId: null,
       agentMeta: isRecord(event.agentMeta) ? event.agentMeta : null,
-      createdAt: new Date().toISOString(),
+      createdAt,
     });
     if (changed) rememberPendingLiveAssistantClientId(sessionId, clientId);
     return changed || clientIdResolution.changed;
@@ -1397,7 +1405,13 @@ function applyRemoteTextEvent(
     content: nextText,
     toolUseId: null,
     agentMeta: nextMeta,
-    createdAt: existing?.createdAt ?? new Date().toISOString(),
+    // Existing rows keep their already-stamped createdAt unchanged (it may already be a
+    // clamped value from the first delta). Only a brand-new row's fresh device-clock stamp
+    // needs the clamp — see clampLiveRowCreatedAt doc comment in messagePaging.ts.
+    createdAt: existing?.createdAt ?? clampLiveRowCreatedAt(
+      new Date().toISOString(),
+      newestCreatedAt(messages.get(sessionId) ?? []),
+    ),
   });
   if (changed) rememberPendingLiveAssistantClientId(sessionId, clientId);
   return changed || clientIdResolution.changed;

--- a/apps/mobile/src/session/remoteSessionStore.ts
+++ b/apps/mobile/src/session/remoteSessionStore.ts
@@ -527,8 +527,20 @@ const pendingLiveAssistantClientIds = new Map<string, Set<string>>();
 // 主机时间水位到达后重锚；否则快手机时钟会让短且无 persistId 的旧 live 行长期占据尾部。
 // value 记录这条 provisional 回复首次关联到的 userSendAt；重连期间 desktop 若已推进到
 // 下一轮，旧回复不能被新轮 user 行认领。null 表示 live 行早于任何 session 元数据到达，
-// 首份 userSendAt 会在 recomputeSessions 中完成一次性绑定，之后不再随新轮次前移。
-const pendingHostAnchorLiveAssistantClientIds = new Map<string, Map<string, string | null>>();
+// 首份 userSendAt 会在 recomputeSessions 中完成一次性绑定，之后不再随新轮次前移；若
+// null 身份先经历软离线，则禁止用重连后的“首份”元数据绑定，因为它可能已经是下一轮。
+type PendingHostAnchorIdentity = {
+  bindOnMetadata: boolean;
+  sendAt: string | null;
+};
+const pendingHostAnchorLiveAssistantClientIds = new Map<
+  string,
+  Map<string, PendingHostAnchorIdentity>
+>();
+// A live maker event may arrive before the session list contains its session. Keep the
+// transport device alongside the pending anchor so markDeviceOffline can still freeze an
+// unbound identity without relying on sessionDeviceIndex.
+const pendingHostAnchorDeviceIds = new Map<string, string>();
 let streamingFallbackSequence = 0;
 const GENERATED_FALLBACK_MIN_PREFIX_LENGTH = 12;
 const TEXT_DELTA_BATCH_INTERVAL_MS = 32;
@@ -536,6 +548,7 @@ const DEVICE_LINK_TRUNCATED_FLAG = '__deviceLinkTruncated';
 const pendingTextDeltaBatches = new Map<string, {
   text: string;
   persistId?: string;
+  deviceId?: string;
   agentMeta: Record<string, unknown> | null;
 }>();
 let textDeltaFlushTimer: ReturnType<typeof setTimeout> | null = null;
@@ -679,6 +692,7 @@ function invalidateSessionMessageWindowState(
   changed = streamingAssistantClientIds.delete(sessionId) || changed;
   changed = pendingLiveAssistantClientIds.delete(sessionId) || changed;
   changed = pendingHostAnchorLiveAssistantClientIds.delete(sessionId) || changed;
+  changed = pendingHostAnchorDeviceIds.delete(sessionId) || changed;
   if (pendingTextDeltaBatches.has(sessionId)) {
     discardPendingTextDelta(sessionId);
     changed = true;
@@ -833,9 +847,12 @@ function userMessageCanConsumePendingLiveReply(
   if (message.role !== 'user') return false;
   const userSendAt = latestUserSendAt(sessionId);
   // Before session metadata arrives, preserve the existing realtime ordering semantics.
-  // Once a send marker exists, an older delayed push belongs to a previous round.
-  // It must not move, retimestamp, or claim the current reply's pending identity.
-  return !userSendAt || message.createdAt.localeCompare(userSendAt) >= 0;
+  // Once a send marker exists, an older delayed push normally belongs to a previous round.
+  // The exception is an unbound reply frozen by an offline transition: only an older user
+  // row can identify that reply's original round after reconnect metadata has moved ahead.
+  return !userSendAt
+    || message.createdAt.localeCompare(userSendAt) >= 0
+    || hasOfflineUnboundPendingHostAnchor(sessionId);
 }
 
 // 当前权威设备列表(由首页从设备列表 API reconcile 后注入)。每次重算会话时基于它 + 当前 shards(stale 侧)
@@ -1144,6 +1161,7 @@ function preferCompleteMessage(existing: RemoteMessage | undefined, incoming: Re
   // (for example an Agent/Task terminal state patched after the original push).
   return {
     ...existing,
+    createdAt: incoming.createdAt,
     agentMeta: {
       ...(existing.agentMeta ?? {}),
       ...(incoming.agentMeta ?? {}),
@@ -1233,18 +1251,21 @@ function rememberPendingHostAnchorLiveAssistantClientId(
   sessionId: string,
   clientId: string | null | undefined,
   sendAt: string | null = latestUserSendAt(sessionId) ?? null,
+  bindOnMetadata = true,
+  deviceId?: string,
 ): void {
   if (!clientId) return;
   const existing = pendingHostAnchorLiveAssistantClientIds.get(sessionId)
-    ?? new Map<string, string | null>();
-  if (!existing.has(clientId)) existing.set(clientId, sendAt);
+    ?? new Map<string, PendingHostAnchorIdentity>();
+  if (!existing.has(clientId)) existing.set(clientId, { bindOnMetadata, sendAt });
   pendingHostAnchorLiveAssistantClientIds.set(sessionId, existing);
+  if (deviceId) pendingHostAnchorDeviceIds.set(sessionId, deviceId);
 }
 
-function pendingHostAnchorSendAt(
+function pendingHostAnchorIdentity(
   sessionId: string,
   ...ids: Array<string | null | undefined>
-): string | null | undefined {
+): PendingHostAnchorIdentity | undefined {
   const existing = pendingHostAnchorLiveAssistantClientIds.get(sessionId);
   if (!existing) return undefined;
   for (const id of ids) {
@@ -1257,9 +1278,32 @@ function bindPendingHostAnchorSendAt(sessionId: string, sendAt: string | null | 
   if (!sendAt) return;
   const existing = pendingHostAnchorLiveAssistantClientIds.get(sessionId);
   if (!existing) return;
-  for (const [id, pendingSendAt] of existing) {
-    if (pendingSendAt === null) existing.set(id, sendAt);
+  for (const [id, identity] of existing) {
+    if (identity.sendAt === null && identity.bindOnMetadata) {
+      existing.set(id, { ...identity, sendAt });
+    }
   }
+}
+
+function freezeUnboundPendingHostAnchorsForOffline(sessionId: string): boolean {
+  const existing = pendingHostAnchorLiveAssistantClientIds.get(sessionId);
+  if (!existing) return false;
+  let changed = false;
+  for (const [id, identity] of existing) {
+    if (identity.sendAt !== null || !identity.bindOnMetadata) continue;
+    existing.set(id, { ...identity, bindOnMetadata: false });
+    changed = true;
+  }
+  return changed;
+}
+
+function hasOfflineUnboundPendingHostAnchor(sessionId: string): boolean {
+  const existing = pendingHostAnchorLiveAssistantClientIds.get(sessionId);
+  return existing
+    ? [...existing.values()].some((identity) => (
+      identity.sendAt === null && !identity.bindOnMetadata
+    ))
+    : false;
 }
 
 function forgetPendingLiveAssistantClientId(sessionId: string, clientId: string | null | undefined): void {
@@ -1272,7 +1316,10 @@ function forgetPendingLiveAssistantClientId(sessionId: string, clientId: string 
   const pendingHostAnchorIds = pendingHostAnchorLiveAssistantClientIds.get(sessionId);
   if (pendingHostAnchorIds) {
     pendingHostAnchorIds.delete(clientId);
-    if (pendingHostAnchorIds.size === 0) pendingHostAnchorLiveAssistantClientIds.delete(sessionId);
+    if (pendingHostAnchorIds.size === 0) {
+      pendingHostAnchorLiveAssistantClientIds.delete(sessionId);
+      pendingHostAnchorDeviceIds.delete(sessionId);
+    }
   }
 }
 
@@ -1310,14 +1357,17 @@ function reanchorPendingLiveAssistantRows(
   if (!pendingIds || pendingIds.size === 0) return false;
   const existing = messages.get(sessionId);
   if (!existing) return false;
-  const pendingRows: Array<{ message: RemoteMessage; sendAt: string | null }> = [];
-  for (const [pendingId, sendAt] of pendingIds) {
+  const pendingRows: Array<{
+    identity: PendingHostAnchorIdentity;
+    message: RemoteMessage;
+  }> = [];
+  for (const [pendingId, identity] of pendingIds) {
     const match = existing.find((message) => (
       message.role === 'assistant'
       && (message.id === pendingId || message.clientId === pendingId)
     ));
     if (match && !pendingRows.some((row) => row.message === match)) {
-      pendingRows.push({ message: match, sendAt });
+      pendingRows.push({ message: match, identity });
     }
   }
   const afterMessages = options.afterMessages
@@ -1326,15 +1376,30 @@ function reanchorPendingLiveAssistantRows(
     || options.pairPendingFromEnd === true;
   const latestSendAt = latestUserSendAt(sessionId);
   const knownSendAts = [...new Set([
-    ...pendingRows.map((row) => row.sendAt).filter((sendAt): sendAt is string => sendAt !== null),
+    ...pendingRows
+      .map((row) => row.identity.sendAt)
+      .filter((sendAt): sendAt is string => sendAt !== null),
     ...(latestSendAt ? [latestSendAt] : []),
   ])].sort((left, right) => left.localeCompare(right));
+  const hasOfflineUnboundPendingRow = pendingRows.some((row) => (
+    row.identity.sendAt === null && !row.identity.bindOnMetadata
+  ));
   const pendingRowCanPairMessage = (
     row: (typeof pendingRows)[number],
     message: RemoteMessage,
   ): boolean => {
-    if (!row.sendAt || !latestSendAt || row.sendAt.localeCompare(latestSendAt) >= 0) return true;
-    const rowSendAt = row.sendAt;
+    const rowSendAt = row.identity.sendAt;
+    if (
+      hasOfflineUnboundPendingRow
+      && latestSendAt
+      && message.createdAt.localeCompare(latestSendAt) < 0
+    ) {
+      return rowSendAt === null && !row.identity.bindOnMetadata;
+    }
+    if (rowSendAt === null && !row.identity.bindOnMetadata) {
+      return Boolean(latestSendAt && message.createdAt.localeCompare(latestSendAt) < 0);
+    }
+    if (!rowSendAt || !latestSendAt || rowSendAt.localeCompare(latestSendAt) >= 0) return true;
     const nextSendAt = knownSendAts.find((sendAt) => sendAt.localeCompare(rowSendAt) > 0);
     return message.createdAt.localeCompare(rowSendAt) >= 0
       && (!nextSendAt || message.createdAt.localeCompare(nextSendAt) < 0);
@@ -1347,21 +1412,43 @@ function reanchorPendingLiveAssistantRows(
   // newest pending replies. Realtime pushes do the same once the latest send marker
   // is known; before metadata arrives they preserve front-to-back arrival order.
   if (pairsPendingFromEnd) {
-    let afterIndex = afterMessages.length - 1;
-    for (let rowIndex = pendingRows.length - 1; rowIndex >= 0 && afterIndex >= 0; rowIndex -= 1) {
-      const pendingRow = pendingRows[rowIndex];
-      while (
-        afterIndex >= 0
-        && !pendingRowCanPairMessage(pendingRow, afterMessages[afterIndex])
-      ) afterIndex -= 1;
-      if (afterIndex < 0) break;
-      pairs.unshift({ pendingRow, afterMessage: afterMessages[afterIndex] });
-      afterIndex -= 1;
+    let maxRowIndex = pendingRows.length - 1;
+    for (let afterIndex = afterMessages.length - 1; afterIndex >= 0 && maxRowIndex >= 0; afterIndex -= 1) {
+      let matchedRowIndex = -1;
+      for (let rowIndex = maxRowIndex; rowIndex >= 0; rowIndex -= 1) {
+        if (pendingRowCanPairMessage(pendingRows[rowIndex], afterMessages[afterIndex])) {
+          matchedRowIndex = rowIndex;
+          break;
+        }
+      }
+      if (matchedRowIndex < 0) continue;
+      pairs.unshift({
+        pendingRow: pendingRows[matchedRowIndex],
+        afterMessage: afterMessages[afterIndex],
+      });
+      maxRowIndex = matchedRowIndex - 1;
     }
   } else {
     const pairCount = Math.min(pendingRows.length, afterMessages.length);
     for (let index = 0; index < pairCount; index += 1) {
       pairs.push({ pendingRow: pendingRows[index], afterMessage: afterMessages[index] });
+    }
+  }
+  // A single realtime/latest-window user row identifies one send round. All live
+  // assistant blocks carrying that non-null send marker belong after the same user;
+  // move them as one ordered block instead of consuming only the last block.
+  if (afterMessages.length === 1 && pairs.length === 1) {
+    const groupedSendAt = pairs[0].pendingRow.identity.sendAt;
+    if (groupedSendAt) {
+      const afterMessage = afterMessages[0];
+      const groupedRows = pendingRows.filter((row) => (
+        row.identity.sendAt === groupedSendAt
+        && pendingRowCanPairMessage(row, afterMessage)
+      ));
+      pairs.splice(0, pairs.length, ...groupedRows.map((pendingRow) => ({
+        pendingRow,
+        afterMessage,
+      })));
     }
   }
   const pairedCreatedAtById = new Map<string, string>();
@@ -1379,37 +1466,53 @@ function reanchorPendingLiveAssistantRows(
     const pairedCreatedAt = pairedCreatedAtById.get(message.id)
       ?? pairedCreatedAtById.get(message.clientId);
     if (pairsPendingFromEnd && pairedCreatedAt === undefined) return message;
-    const pendingSendAt = pendingHostAnchorSendAt(sessionId, message.id, message.clientId);
+    const pendingIdentity = pendingHostAnchorIdentity(sessionId, message.id, message.clientId);
     if (
       pairedCreatedAt === undefined
-      && pendingSendAt
+      && pendingIdentity?.sendAt === null
+      && !pendingIdentity.bindOnMetadata
+    ) return message;
+    if (
+      pairedCreatedAt === undefined
+      && pendingIdentity?.sendAt
       && latestSendAt
-      && pendingSendAt.localeCompare(latestSendAt) < 0
+      && pendingIdentity.sendAt.localeCompare(latestSendAt) < 0
       && hostCreatedAtWatermark.localeCompare(latestSendAt) >= 0
     ) return message;
     const createdAt = pairedCreatedAt ?? hostCreatedAtWatermark;
     return message.createdAt === createdAt ? message : { ...message, createdAt };
   });
   let next = normalizeMessages(reanchored);
-  const consumedPendingRows: RemoteMessage[] = [];
+  const pairGroups: Array<{
+    afterMessage: RemoteMessage;
+    pendingRows: Array<(typeof pendingRows)[number]>;
+  }> = [];
   for (const pair of pairs) {
-    const pendingRowIndex = next.findIndex((message) => (
-      messageIdentityMatches(message, pair.pendingRow.message)
+    const group = pairGroups.find((candidate) => (
+      messageIdentityMatches(candidate.afterMessage, pair.afterMessage)
     ));
-    if (pendingRowIndex < 0) continue;
-    const pendingRow = next[pendingRowIndex];
-    const withoutPending = next.filter((_, messageIndex) => messageIndex !== pendingRowIndex);
+    if (group) group.pendingRows.push(pair.pendingRow);
+    else pairGroups.push({ afterMessage: pair.afterMessage, pendingRows: [pair.pendingRow] });
+  }
+  const consumedPendingRows: RemoteMessage[] = [];
+  for (const group of pairGroups) {
+    const groupedRows = next.filter((message) => group.pendingRows.some((row) => (
+      messageIdentityMatches(message, row.message)
+    )));
+    if (groupedRows.length === 0) continue;
+    const withoutPending = next.filter((message) => !group.pendingRows.some((row) => (
+      messageIdentityMatches(message, row.message)
+    )));
     const anchorIndex = withoutPending.findIndex((message) => (
-      messageIdentityMatches(message, pair.afterMessage)
+      messageIdentityMatches(message, group.afterMessage)
     ));
-    if (anchorIndex >= 0) {
-      next = [
-        ...withoutPending.slice(0, anchorIndex + 1),
-        pendingRow,
-        ...withoutPending.slice(anchorIndex + 1),
-      ];
-      consumedPendingRows.push(pendingRow);
-    }
+    if (anchorIndex < 0) continue;
+    next = [
+      ...withoutPending.slice(0, anchorIndex + 1),
+      ...groupedRows,
+      ...withoutPending.slice(anchorIndex + 1),
+    ];
+    consumedPendingRows.push(...groupedRows);
   }
   if (options.consumePending !== false) {
     if (afterMessages.length > 0) {
@@ -1417,9 +1520,13 @@ function reanchorPendingLiveAssistantRows(
         pendingIds.delete(pendingRow.id);
         pendingIds.delete(pendingRow.clientId);
       }
-      if (pendingIds.size === 0) pendingHostAnchorLiveAssistantClientIds.delete(sessionId);
+      if (pendingIds.size === 0) {
+        pendingHostAnchorLiveAssistantClientIds.delete(sessionId);
+        pendingHostAnchorDeviceIds.delete(sessionId);
+      }
     } else {
       pendingHostAnchorLiveAssistantClientIds.delete(sessionId);
+      pendingHostAnchorDeviceIds.delete(sessionId);
     }
   }
   if (remoteMessageListsEqual(existing, next)) return false;
@@ -1495,11 +1602,18 @@ function migrateGeneratedStreamingClientId(sessionId: string, generatedClientId:
   const neededHostAnchor = pendingHostAnchorLiveAssistantClientIds
     .get(sessionId)
     ?.has(generatedClientId) === true;
-  const hostAnchorSendAt = pendingHostAnchorSendAt(sessionId, generatedClientId);
+  const hostAnchorIdentity = pendingHostAnchorIdentity(sessionId, generatedClientId);
+  const hostAnchorDeviceId = pendingHostAnchorDeviceIds.get(sessionId);
   forgetPendingLiveAssistantClientId(sessionId, generatedClientId);
   if (hadPendingLiveId) rememberPendingLiveAssistantClientId(sessionId, persistId);
-  if (neededHostAnchor) {
-    rememberPendingHostAnchorLiveAssistantClientId(sessionId, persistId, hostAnchorSendAt ?? null);
+  if (neededHostAnchor && hostAnchorIdentity) {
+    rememberPendingHostAnchorLiveAssistantClientId(
+      sessionId,
+      persistId,
+      hostAnchorIdentity.sendAt,
+      hostAnchorIdentity.bindOnMetadata,
+      hostAnchorDeviceId,
+    );
   }
 
   const existing = messages.get(sessionId);
@@ -1600,6 +1714,7 @@ function applyRemoteTextEvent(
   sessionId: string,
   event: Record<string, unknown>,
   persistId?: string,
+  deviceId?: string,
 ): boolean {
   const data = isRecord(event.data) ? event.data : null;
   const text = typeof data?.text === 'string' ? data.text : '';
@@ -1634,7 +1749,13 @@ function applyRemoteTextEvent(
     if (changed) {
       rememberPendingLiveAssistantClientId(sessionId, clientId);
       if (hostCreatedAtAnchor.provisional) {
-        rememberPendingHostAnchorLiveAssistantClientId(sessionId, clientId);
+        rememberPendingHostAnchorLiveAssistantClientId(
+          sessionId,
+          clientId,
+          undefined,
+          true,
+          deviceId,
+        );
       }
     }
     return changed || clientIdResolution.changed;
@@ -1665,9 +1786,9 @@ function applyRemoteTextEvent(
       Boolean(id) && pendingHostAnchorLiveAssistantClientIds.get(sessionId)?.has(id) === true
     ))
     : hostCreatedAtAnchor?.provisional === true;
-  const hostAnchorSendAt = existing
-    ? pendingHostAnchorSendAt(sessionId, existing.id, existing.clientId, clientId)
-    : latestUserSendAt(sessionId) ?? null;
+  const hostAnchorIdentity = existing
+    ? pendingHostAnchorIdentity(sessionId, existing.id, existing.clientId, clientId)
+    : undefined;
   const changed = upsertMessage(sessionId, {
     id: existing?.id ?? clientId,
     clientId,
@@ -1690,7 +1811,13 @@ function applyRemoteTextEvent(
     // replaces an assistant row. A live delta/final is not host-authoritative, so
     // carry the provisional anchor forward until metadata or a persisted row lands.
     if (needsHostAnchor) {
-      rememberPendingHostAnchorLiveAssistantClientId(sessionId, clientId, hostAnchorSendAt ?? null);
+      rememberPendingHostAnchorLiveAssistantClientId(
+        sessionId,
+        clientId,
+        hostAnchorIdentity?.sendAt ?? latestUserSendAt(sessionId) ?? null,
+        hostAnchorIdentity?.bindOnMetadata ?? true,
+        deviceId,
+      );
     }
   }
   return changed || clientIdResolution.changed;
@@ -1706,6 +1833,7 @@ function enqueueRemoteTextDelta(
   sessionId: string,
   event: Record<string, unknown>,
   persistId?: string,
+  deviceId?: string,
 ): boolean {
   const data = isRecord(event.data) ? event.data : null;
   const text = typeof data?.text === 'string' ? data.text : '';
@@ -1721,6 +1849,7 @@ function enqueueRemoteTextDelta(
   pendingTextDeltaBatches.set(sessionId, {
     text: `${current?.text ?? ''}${text}`,
     persistId: current?.persistId ?? persistId,
+    deviceId: current?.deviceId ?? deviceId,
     agentMeta: incomingMeta
       ? { ...(current?.agentMeta ?? {}), ...incomingMeta }
       : current?.agentMeta ?? null,
@@ -1742,6 +1871,7 @@ function flushPendingTextDelta(sessionId: string): boolean {
       ...(batch.agentMeta ? { agentMeta: batch.agentMeta } : {}),
     },
     batch.persistId,
+    batch.deviceId,
   );
 }
 
@@ -2959,11 +3089,11 @@ export const remoteSessionStore = {
    * 单条 maker:event push payload 的消费(逐帧与微批拆包**共用**唯一实现——
    * 两条路径若各自解析,批的语义就会随逐帧演进而漂移)。
    */
-  applyMakerEventPush(payload: Record<string, unknown>): void {
+  applyMakerEventPush(payload: Record<string, unknown>, deviceId?: string): void {
     const sessionId = readString(payload, 'sessionId');
     const event = isRecord(payload.event) ? payload.event : null;
     const persistId = readString(payload, 'persistId') ?? undefined;
-    if (sessionId && event) this.applyMakerEvent(sessionId, event, persistId);
+    if (sessionId && event) this.applyMakerEvent(sessionId, event, persistId, deviceId);
   },
 
   applyRemotePush(deviceId: string, channel: string, payload: unknown): void {
@@ -3063,7 +3193,7 @@ export const remoteSessionStore = {
       return;
     }
     if (channel === 'maker:event' && isRecord(payload)) {
-      this.applyMakerEventPush(payload);
+      this.applyMakerEventPush(payload, deviceId);
       return;
     }
     // 微批帧:被控端把同一会话的连续 maker:event 合并成一帧(能力协商见
@@ -3075,7 +3205,7 @@ export const remoteSessionStore = {
       // 同一份,见 expandMakerEventBatchPayload 注释)。
       for (const event of expandMakerEventBatchPayload(payload)) {
         if (!isRecord(event)) continue;
-        this.applyMakerEventPush(event);
+        this.applyMakerEventPush(event, deviceId);
       }
       return;
     }
@@ -3280,7 +3410,12 @@ export const remoteSessionStore = {
     if (changed) emit();
   },
 
-  applyMakerEvent(sessionId: string, event: Record<string, unknown>, persistId?: string): void {
+  applyMakerEvent(
+    sessionId: string,
+    event: Record<string, unknown>,
+    persistId?: string,
+    deviceId?: string,
+  ): void {
     markSessionMakerActivity(sessionId);
     const type = readString(event, 'type');
     const reconnectCleared = type !== null && type !== 'error' && type !== 'done'
@@ -3293,11 +3428,11 @@ export const remoteSessionStore = {
         return;
       }
       if (isRemoteTextDeltaEvent(event)) {
-        if (enqueueRemoteTextDelta(sessionId, event, persistId) || reconnectCleared) emit();
+        if (enqueueRemoteTextDelta(sessionId, event, persistId, deviceId) || reconnectCleared) emit();
         return;
       }
       let changed = flushPendingTextDelta(sessionId);
-      changed = applyRemoteTextEvent(sessionId, event, persistId) || changed;
+      changed = applyRemoteTextEvent(sessionId, event, persistId, deviceId) || changed;
       changed = reconnectCleared || changed;
       if (changed) emit();
       return;
@@ -3595,6 +3730,16 @@ export const remoteSessionStore = {
    */
   markDeviceOffline(deviceId: string): void {
     let changed = false;
+    // A first text delta can still be waiting in the 32ms batch before any session
+    // metadata/index exists. Flush batches from this transport first so they create a
+    // device-owned host anchor, then freeze that identity before reconnect metadata can
+    // bind it to a newer send round.
+    for (const [sessionId, batch] of [...pendingTextDeltaBatches]) {
+      if (batch.deviceId !== deviceId) continue;
+      changed = flushAndFinalizeRemoteStreamingMessages(sessionId) || changed;
+      changed = streamingAssistantClientIds.delete(sessionId) || changed;
+      changed = freezeUnboundPendingHostAnchorsForOffline(sessionId) || changed;
+    }
     for (const [sessionId, indexedDeviceId] of sessionDeviceIndex) {
       if (indexedDeviceId !== deviceId) continue;
       changed = sessionMessageSyncMarkers.delete(sessionId) || changed;
@@ -3617,8 +3762,13 @@ export const remoteSessionStore = {
       // reconciliation, and the other lets a reconnecting authoritative user row
       // restore question → reply order. Persisted reconciliation, explicit window
       // invalidation, or actual device removal will retire them.
+      changed = freezeUnboundPendingHostAnchorsForOffline(sessionId) || changed;
       changed = writeMakerTurnRunning(sessionId, false) || changed;
       changed = writeSessionRunStatus(sessionId, EMPTY_SESSION_RUN_STATUS) || changed;
+    }
+    for (const [sessionId, pendingDeviceId] of pendingHostAnchorDeviceIds) {
+      if (pendingDeviceId !== deviceId) continue;
+      changed = freezeUnboundPendingHostAnchorsForOffline(sessionId) || changed;
     }
     if (changed) emit();
   },
@@ -3654,6 +3804,7 @@ export const remoteSessionStore = {
         discardPendingTextDelta(sessionId);
         pendingLiveAssistantClientIds.delete(sessionId);
         pendingHostAnchorLiveAssistantClientIds.delete(sessionId);
+        pendingHostAnchorDeviceIds.delete(sessionId);
         sessionMakerTurnRunning.delete(sessionId);
         sessionParkedTaskUpdates.delete(sessionId);
         sessionMessageLifecycle.forget(sessionId);
@@ -3707,6 +3858,7 @@ export const remoteSessionStore = {
     streamingAssistantClientIds.clear();
     pendingLiveAssistantClientIds.clear();
     pendingHostAnchorLiveAssistantClientIds.clear();
+    pendingHostAnchorDeviceIds.clear();
     pendingTextDeltaBatches.clear();
     clearTextDeltaFlushTimer();
     sessionMakerTurnRunning.clear();

--- a/apps/mobile/src/session/remoteSessionStore.ts
+++ b/apps/mobile/src/session/remoteSessionStore.ts
@@ -830,8 +830,8 @@ function userMessageCanConsumePendingLiveReply(
   if (message.role !== 'user') return false;
   const userSendAt = latestUserSendAt(sessionId);
   // Before session metadata arrives, preserve the existing realtime ordering semantics.
-  // Once a send marker exists, an older delayed push may only provide a provisional
-  // host-time anchor; it must not claim the current reply's pending identity.
+  // Once a send marker exists, an older delayed push belongs to a previous round.
+  // It must not move, retimestamp, or claim the current reply's pending identity.
   return !userSendAt || message.createdAt.localeCompare(userSendAt) >= 0;
 }
 
@@ -2193,16 +2193,22 @@ export const remoteSessionStore = {
     // tied to the same host timestamp. Other authoritative tail rows keep the
     // existing live-before-persisted arrival order when their timestamps tie.
     const latestTailMessage = latestWindow[latestWindow.length - 1];
-    const reanchorAfterMerge = latestTailMessage.role === 'user';
+    const latestTailIsUser = latestTailMessage.role === 'user';
+    const latestSendAt = latestUserSendAt(sessionId);
+    const latestTailMatchesSend = userMessageMatchesLatestSend(sessionId, latestTailMessage);
+    const latestTailIsKnownStaleUser = latestTailIsUser
+      && latestSendAt !== undefined
+      && !latestTailMatchesSend;
+    const reanchorAfterMerge = latestTailIsUser && !latestTailIsKnownStaleUser;
     // A latest-window request may have started before the current send. Only a user tail
-    // at/after the session's send marker can finish this pending identity; older user tails
-    // may temporarily position the live row but must leave it eligible for the realtime push.
-    const consumeReanchorAfterMerge = reanchorAfterMerge
-      && userMessageMatchesLatestSend(sessionId, latestTailMessage);
+    // at/after the session's send marker may move or finish this pending identity; an older
+    // user tail belongs to a previous round and leaves the current reply untouched.
+    const consumeReanchorAfterMerge = reanchorAfterMerge && latestTailMatchesSend;
     const reanchorAfterMessages = consumeReanchorAfterMerge
       ? latestWindow.filter((message) => message.role === 'user')
       : undefined;
     const liveRowsReanchoredBeforeMerge = !reanchorAfterMerge
+      && !latestTailIsKnownStaleUser
       && reanchorPendingLiveAssistantRows(
         sessionId,
         latestNewestCreatedAt,
@@ -2442,6 +2448,8 @@ export const remoteSessionStore = {
     if (!messageWriteAllowed(sessionId, options.authority)) return;
     let changed = flushPendingTextDelta(sessionId);
     const reanchorAfterMessage = options.hostTimeAuthoritative !== false && message.role === 'user';
+    const userCanReanchorPendingLiveReply = reanchorAfterMessage
+      && userMessageCanConsumePendingLiveReply(sessionId, message);
     if (
       options.hostTimeAuthoritative !== false
       && !reanchorAfterMessage
@@ -2456,13 +2464,13 @@ export const remoteSessionStore = {
     }
     changed = upsertMessage(sessionId, overlayLivePlanSnapshot(sessionId, message)) || changed;
     if (
-      reanchorAfterMessage
+      userCanReanchorPendingLiveReply
       && reanchorPendingLiveAssistantRows(
         sessionId,
         message.createdAt,
         {
           afterMessage: message,
-          consumePending: userMessageCanConsumePendingLiveReply(sessionId, message),
+          consumePending: true,
           pairPendingFromEnd: latestUserSendAt(sessionId) !== undefined,
         },
       )
@@ -3530,11 +3538,11 @@ export const remoteSessionStore = {
       changed = sessionMakerActivityEpochs.delete(sessionId) || changed;
       changed = flushAndFinalizeRemoteStreamingMessages(sessionId) || changed;
       changed = streamingAssistantClientIds.delete(sessionId) || changed;
-      changed = pendingLiveAssistantClientIds.delete(sessionId) || changed;
-      // The message window survives a soft offline transition, so its provisional
-      // host-time identity must survive too. A reconnecting authoritative user row
-      // may still need it to restore question → reply order; persisted reconciliation,
-      // explicit window invalidation, or actual device removal will retire it.
+      // The message window survives a soft offline transition, so both pending
+      // identities must survive too: one protects the live row during latest-window
+      // reconciliation, and the other lets a reconnecting authoritative user row
+      // restore question → reply order. Persisted reconciliation, explicit window
+      // invalidation, or actual device removal will retire them.
       changed = writeMakerTurnRunning(sessionId, false) || changed;
       changed = writeSessionRunStatus(sessionId, EMPTY_SESSION_RUN_STATUS) || changed;
     }

--- a/apps/mobile/src/session/remoteSessionStore.ts
+++ b/apps/mobile/src/session/remoteSessionStore.ts
@@ -1555,6 +1555,8 @@ function reanchorPendingLiveAssistantRows(
     afterMessage?: RemoteMessage;
     /** 权威窗口可一次带回多轮 user；从窗口尾部向前与 pending 回复按序一对一配对。 */
     afterMessages?: readonly RemoteMessage[];
+    /** 权威窗口已覆盖到会话起点；否则最旧 user 可能已被窗口上沿截断。 */
+    afterMessagesStartIsComplete?: boolean;
     /** 已知本轮发送标记时，实时 user push 也只认领最新的 pending 回复。 */
     pairPendingFromEnd?: boolean;
   } = {},
@@ -1658,7 +1660,10 @@ function reanchorPendingLiveAssistantRows(
     // A reconnect window can deliver several delayed users in one authoritative page.
     // Pair only when that page accounts for every offline cohort; a truncated latest
     // suffix cannot prove whether its first user belongs to the oldest pending round.
-    if (reconnectWindowUsers.length === orderedOfflineUnboundRoundGroups.length) {
+    if (
+      options.afterMessagesStartIsComplete === true
+      && reconnectWindowUsers.length === orderedOfflineUnboundRoundGroups.length
+    ) {
       const pairedUsers = reconnectWindowUsers;
       for (let index = 0; index < orderedOfflineUnboundRoundGroups.length; index += 1) {
         for (const pendingRow of orderedOfflineUnboundRoundGroups[index]) {
@@ -1930,7 +1935,11 @@ function streamingClientIdFor(sessionId: string, persistId: string | undefined):
   return { clientId: generated, changed: false };
 }
 
-function upsertMessage(sessionId: string, message: RemoteMessage): boolean {
+function upsertMessage(
+  sessionId: string,
+  message: RemoteMessage,
+  options: { retirePendingAssistantIdentityOnEqual?: boolean } = {},
+): boolean {
   const existing = messages.get(sessionId) ?? [];
   const index = existing.findIndex((item) => messageIdentityMatches(item, message));
   let fallbackIndex = -1;
@@ -1961,7 +1970,29 @@ function upsertMessage(sessionId: string, message: RemoteMessage): boolean {
     return true;
   }
   const replacement = preferCompleteMessage(existing[index], message);
-  if (remoteMessageEqual(existing[index], replacement)) return false;
+  if (remoteMessageEqual(existing[index], replacement)) {
+    if (
+      message.role !== 'assistant'
+      || options.retirePendingAssistantIdentityOnEqual !== true
+    ) return false;
+    const hadPendingIdentity = isPendingLiveAssistantMessage(sessionId, existing[index])
+      || pendingHostAnchorIdentity(
+        sessionId,
+        existing[index].id,
+        existing[index].clientId,
+        message.id,
+        message.clientId,
+      ) !== undefined;
+    forgetPendingLiveAssistantMessageIdentity(
+      sessionId,
+      existing[index].id,
+      existing[index].clientId,
+      message.id,
+      message.clientId,
+    );
+    if (isPersistedAssistantMessage(message)) retireGeneratedStreamingFallback(sessionId);
+    return hadPendingIdentity;
+  }
   const next = existing.slice();
   next[index] = replacement;
   messages.set(sessionId, normalizeMessages(next));
@@ -2913,6 +2944,7 @@ export const remoteSessionStore = {
           {
             afterMessage: consumeReanchorAfterMerge ? undefined : latestTailMessage,
             afterMessages: reanchorAfterMessages,
+            afterMessagesStartIsComplete: options.moreBeyondWindow !== true,
             consumePending: consumeReanchorAfterMerge,
           },
         );
@@ -2928,6 +2960,7 @@ export const remoteSessionStore = {
         {
           afterMessage: consumeReanchorAfterMerge ? undefined : latestTailMessage,
           afterMessages: reanchorAfterMessages,
+          afterMessagesStartIsComplete: options.moreBeyondWindow !== true,
           consumePending: consumeReanchorAfterMerge,
         },
       );
@@ -3044,7 +3077,11 @@ export const remoteSessionStore = {
       bumpMessageVersion();
       changed = true;
     }
-    changed = upsertMessage(sessionId, overlayLivePlanSnapshot(sessionId, message)) || changed;
+    changed = upsertMessage(
+      sessionId,
+      overlayLivePlanSnapshot(sessionId, message),
+      { retirePendingAssistantIdentityOnEqual: options.hostTimeAuthoritative !== false },
+    ) || changed;
     if (
       userCanReanchorPendingLiveReply
       && reanchorPendingLiveAssistantRows(

--- a/apps/mobile/src/session/remoteSessionStore.ts
+++ b/apps/mobile/src/session/remoteSessionStore.ts
@@ -525,7 +525,10 @@ const streamingAssistantClientIds = new Map<string, string>();
 const pendingLiveAssistantClientIds = new Map<string, Set<string>>();
 // 首个 live 行可能早于 getSession / listMessages 到达。此时只能暂用手机时间，待第一份
 // 主机时间水位到达后重锚；否则快手机时钟会让短且无 persistId 的旧 live 行长期占据尾部。
-const pendingHostAnchorLiveAssistantClientIds = new Map<string, Set<string>>();
+// value 记录这条 provisional 回复首次关联到的 userSendAt；重连期间 desktop 若已推进到
+// 下一轮，旧回复不能被新轮 user 行认领。null 表示 live 行早于任何 session 元数据到达，
+// 首份 userSendAt 会在 recomputeSessions 中完成一次性绑定，之后不再随新轮次前移。
+const pendingHostAnchorLiveAssistantClientIds = new Map<string, Map<string, string | null>>();
 let streamingFallbackSequence = 0;
 const GENERATED_FALLBACK_MIN_PREFIX_LENGTH = 12;
 const TEXT_DELTA_BATCH_INTERVAL_MS = 32;
@@ -917,6 +920,7 @@ function recomputeSessions(): void {
   mergedSessions = sameElementRefs(mergedSessions, next) ? mergedSessions : next;
   let liveRowsReanchored = false;
   for (const session of mergedSessions) {
+    bindPendingHostAnchorSendAt(session.id, session.userSendAt);
     liveRowsReanchored = reanchorPendingLiveAssistantRows(
       session.id,
       session.userSendAt ?? session.updatedAt ?? session.createdAt,
@@ -1228,11 +1232,34 @@ function rememberPendingLiveAssistantClientId(sessionId: string, clientId: strin
 function rememberPendingHostAnchorLiveAssistantClientId(
   sessionId: string,
   clientId: string | null | undefined,
+  sendAt: string | null = latestUserSendAt(sessionId) ?? null,
 ): void {
   if (!clientId) return;
-  const existing = pendingHostAnchorLiveAssistantClientIds.get(sessionId) ?? new Set<string>();
-  existing.add(clientId);
+  const existing = pendingHostAnchorLiveAssistantClientIds.get(sessionId)
+    ?? new Map<string, string | null>();
+  if (!existing.has(clientId)) existing.set(clientId, sendAt);
   pendingHostAnchorLiveAssistantClientIds.set(sessionId, existing);
+}
+
+function pendingHostAnchorSendAt(
+  sessionId: string,
+  ...ids: Array<string | null | undefined>
+): string | null | undefined {
+  const existing = pendingHostAnchorLiveAssistantClientIds.get(sessionId);
+  if (!existing) return undefined;
+  for (const id of ids) {
+    if (id && existing.has(id)) return existing.get(id);
+  }
+  return undefined;
+}
+
+function bindPendingHostAnchorSendAt(sessionId: string, sendAt: string | null | undefined): void {
+  if (!sendAt) return;
+  const existing = pendingHostAnchorLiveAssistantClientIds.get(sessionId);
+  if (!existing) return;
+  for (const [id, pendingSendAt] of existing) {
+    if (pendingSendAt === null) existing.set(id, sendAt);
+  }
 }
 
 function forgetPendingLiveAssistantClientId(sessionId: string, clientId: string | null | undefined): void {
@@ -1283,31 +1310,64 @@ function reanchorPendingLiveAssistantRows(
   if (!pendingIds || pendingIds.size === 0) return false;
   const existing = messages.get(sessionId);
   if (!existing) return false;
-  const pendingRows: RemoteMessage[] = [];
-  for (const pendingId of pendingIds) {
+  const pendingRows: Array<{ message: RemoteMessage; sendAt: string | null }> = [];
+  for (const [pendingId, sendAt] of pendingIds) {
     const match = existing.find((message) => (
       message.role === 'assistant'
       && (message.id === pendingId || message.clientId === pendingId)
     ));
-    if (match && !pendingRows.includes(match)) pendingRows.push(match);
+    if (match && !pendingRows.some((row) => row.message === match)) {
+      pendingRows.push({ message: match, sendAt });
+    }
   }
   const afterMessages = options.afterMessages
     ?? (options.afterMessage ? [options.afterMessage] : []);
   const pairsPendingFromEnd = options.afterMessages !== undefined
     || options.pairPendingFromEnd === true;
-  const pairCount = Math.min(pendingRows.length, afterMessages.length);
+  const latestSendAt = latestUserSendAt(sessionId);
+  const knownSendAts = [...new Set([
+    ...pendingRows.map((row) => row.sendAt).filter((sendAt): sendAt is string => sendAt !== null),
+    ...(latestSendAt ? [latestSendAt] : []),
+  ])].sort((left, right) => left.localeCompare(right));
+  const pendingRowCanPairMessage = (
+    row: (typeof pendingRows)[number],
+    message: RemoteMessage,
+  ): boolean => {
+    if (!row.sendAt || !latestSendAt || row.sendAt.localeCompare(latestSendAt) >= 0) return true;
+    const rowSendAt = row.sendAt;
+    const nextSendAt = knownSendAts.find((sendAt) => sendAt.localeCompare(rowSendAt) > 0);
+    return message.createdAt.localeCompare(rowSendAt) >= 0
+      && (!nextSendAt || message.createdAt.localeCompare(nextSendAt) < 0);
+  };
+  const pairs: Array<{
+    pendingRow: (typeof pendingRows)[number];
+    afterMessage: RemoteMessage;
+  }> = [];
   // A bounded latest window represents the newest user rows, so pair it with the
   // newest pending replies. Realtime pushes do the same once the latest send marker
   // is known; before metadata arrives they preserve front-to-back arrival order.
-  const pairedRowStart = pairsPendingFromEnd
-    ? pendingRows.length - pairCount
-    : 0;
-  const pairedRows = pendingRows.slice(pairedRowStart, pairedRowStart + pairCount);
-  const pairedAfterMessages = afterMessages.slice(afterMessages.length - pairCount);
+  if (pairsPendingFromEnd) {
+    let afterIndex = afterMessages.length - 1;
+    for (let rowIndex = pendingRows.length - 1; rowIndex >= 0 && afterIndex >= 0; rowIndex -= 1) {
+      const pendingRow = pendingRows[rowIndex];
+      while (
+        afterIndex >= 0
+        && !pendingRowCanPairMessage(pendingRow, afterMessages[afterIndex])
+      ) afterIndex -= 1;
+      if (afterIndex < 0) break;
+      pairs.unshift({ pendingRow, afterMessage: afterMessages[afterIndex] });
+      afterIndex -= 1;
+    }
+  } else {
+    const pairCount = Math.min(pendingRows.length, afterMessages.length);
+    for (let index = 0; index < pairCount; index += 1) {
+      pairs.push({ pendingRow: pendingRows[index], afterMessage: afterMessages[index] });
+    }
+  }
   const pairedCreatedAtById = new Map<string, string>();
-  for (let index = 0; index < pairCount; index += 1) {
-    const pendingRow = pairedRows[index];
-    const createdAt = pairedAfterMessages[index].createdAt;
+  for (const pair of pairs) {
+    const pendingRow = pair.pendingRow.message;
+    const createdAt = pair.afterMessage.createdAt;
     pairedCreatedAtById.set(pendingRow.id, createdAt);
     pairedCreatedAtById.set(pendingRow.clientId, createdAt);
   }
@@ -1319,20 +1379,28 @@ function reanchorPendingLiveAssistantRows(
     const pairedCreatedAt = pairedCreatedAtById.get(message.id)
       ?? pairedCreatedAtById.get(message.clientId);
     if (pairsPendingFromEnd && pairedCreatedAt === undefined) return message;
+    const pendingSendAt = pendingHostAnchorSendAt(sessionId, message.id, message.clientId);
+    if (
+      pairedCreatedAt === undefined
+      && pendingSendAt
+      && latestSendAt
+      && pendingSendAt.localeCompare(latestSendAt) < 0
+      && hostCreatedAtWatermark.localeCompare(latestSendAt) >= 0
+    ) return message;
     const createdAt = pairedCreatedAt ?? hostCreatedAtWatermark;
     return message.createdAt === createdAt ? message : { ...message, createdAt };
   });
   let next = normalizeMessages(reanchored);
   const consumedPendingRows: RemoteMessage[] = [];
-  for (let index = 0; index < pairCount; index += 1) {
+  for (const pair of pairs) {
     const pendingRowIndex = next.findIndex((message) => (
-      messageIdentityMatches(message, pairedRows[index])
+      messageIdentityMatches(message, pair.pendingRow.message)
     ));
     if (pendingRowIndex < 0) continue;
     const pendingRow = next[pendingRowIndex];
     const withoutPending = next.filter((_, messageIndex) => messageIndex !== pendingRowIndex);
     const anchorIndex = withoutPending.findIndex((message) => (
-      messageIdentityMatches(message, pairedAfterMessages[index])
+      messageIdentityMatches(message, pair.afterMessage)
     ));
     if (anchorIndex >= 0) {
       next = [
@@ -1427,9 +1495,12 @@ function migrateGeneratedStreamingClientId(sessionId: string, generatedClientId:
   const neededHostAnchor = pendingHostAnchorLiveAssistantClientIds
     .get(sessionId)
     ?.has(generatedClientId) === true;
+  const hostAnchorSendAt = pendingHostAnchorSendAt(sessionId, generatedClientId);
   forgetPendingLiveAssistantClientId(sessionId, generatedClientId);
   if (hadPendingLiveId) rememberPendingLiveAssistantClientId(sessionId, persistId);
-  if (neededHostAnchor) rememberPendingHostAnchorLiveAssistantClientId(sessionId, persistId);
+  if (neededHostAnchor) {
+    rememberPendingHostAnchorLiveAssistantClientId(sessionId, persistId, hostAnchorSendAt ?? null);
+  }
 
   const existing = messages.get(sessionId);
   if (!existing) return false;
@@ -1594,6 +1665,9 @@ function applyRemoteTextEvent(
       Boolean(id) && pendingHostAnchorLiveAssistantClientIds.get(sessionId)?.has(id) === true
     ))
     : hostCreatedAtAnchor?.provisional === true;
+  const hostAnchorSendAt = existing
+    ? pendingHostAnchorSendAt(sessionId, existing.id, existing.clientId, clientId)
+    : latestUserSendAt(sessionId) ?? null;
   const changed = upsertMessage(sessionId, {
     id: existing?.id ?? clientId,
     clientId,
@@ -1616,7 +1690,7 @@ function applyRemoteTextEvent(
     // replaces an assistant row. A live delta/final is not host-authoritative, so
     // carry the provisional anchor forward until metadata or a persisted row lands.
     if (needsHostAnchor) {
-      rememberPendingHostAnchorLiveAssistantClientId(sessionId, clientId);
+      rememberPendingHostAnchorLiveAssistantClientId(sessionId, clientId, hostAnchorSendAt ?? null);
     }
   }
   return changed || clientIdResolution.changed;

--- a/apps/mobile/src/session/remoteSessionStore.ts
+++ b/apps/mobile/src/session/remoteSessionStore.ts
@@ -2065,9 +2065,15 @@ export const remoteSessionStore = {
       return;
     }
 
-    const existing = messages.get(sessionId) ?? [];
     const latestOldestCreatedAt = latestWindow[0].createdAt;
     const latestNewestCreatedAt = latestWindow[latestWindow.length - 1].createdAt;
+    // A triggering user row must be inserted before its live assistant reply is
+    // tied to the same host timestamp. Other authoritative tail rows keep the
+    // existing live-before-persisted arrival order when their timestamps tie.
+    const reanchorAfterMerge = latestWindow[latestWindow.length - 1].role === 'user';
+    const liveRowsReanchoredBeforeMerge = !reanchorAfterMerge
+      && reanchorPendingLiveAssistantRows(sessionId, latestNewestCreatedAt);
+    const existing = messages.get(sessionId) ?? [];
     const existingIdentityIndex = buildMessageIdentityIndex(existing);
     const hasOverlap = latestWindow.some((item) => messageIdentityIndexHas(existingIdentityIndex, item));
     const byKey = new Map<string, RemoteMessage>();
@@ -2177,10 +2183,14 @@ export const remoteSessionStore = {
     // "窗口内容有没有变"无关。被早退跳过时这次权威响应就白来了(#1210 review)。
     coverLatestPage(sessionId, latestOldestCreatedAt, latestNewestCreatedAt, joinedCoverage);
     if (remoteMessageListsEqual(existing, next)) {
-      if (textFlushed) emit();
+      if (liveRowsReanchoredBeforeMerge) bumpMessageVersion();
+      if (textFlushed || liveRowsReanchoredBeforeMerge) emit();
       return;
     }
     messages.set(sessionId, next);
+    if (reanchorAfterMerge) {
+      reanchorPendingLiveAssistantRows(sessionId, latestNewestCreatedAt);
+    }
     applyMessageWriteRetention(sessionId);
     bumpMessageVersion();
     emit();
@@ -2278,14 +2288,23 @@ export const remoteSessionStore = {
   ): void {
     if (!messageWriteAllowed(sessionId, options.authority)) return;
     let changed = flushPendingTextDelta(sessionId);
+    const reanchorAfterMessage = options.hostTimeAuthoritative !== false && message.role === 'user';
     if (
       options.hostTimeAuthoritative !== false
+      && !reanchorAfterMessage
       && reanchorPendingLiveAssistantRows(sessionId, message.createdAt)
     ) {
       bumpMessageVersion();
       changed = true;
     }
     changed = upsertMessage(sessionId, overlayLivePlanSnapshot(sessionId, message)) || changed;
+    if (
+      reanchorAfterMessage
+      && reanchorPendingLiveAssistantRows(sessionId, message.createdAt)
+    ) {
+      bumpMessageVersion();
+      changed = true;
+    }
     // 订阅内到达的实时行可以把覆盖区间的上界往后推;断流后收到的不行(见 liveTailTrusted)。
     coverLiveRow(sessionId, message);
     if (changed) {

--- a/apps/mobile/src/session/remoteSessionStore.ts
+++ b/apps/mobile/src/session/remoteSessionStore.ts
@@ -777,7 +777,13 @@ let mergedSessions: RemoteSession[] = [];
 let messageVersion = 0;
 let storeVersion = 0;
 
-function liveRowCreatedAtWatermark(sessionId: string): string | undefined {
+type LiveRowCreatedAtAnchor = {
+  createdAt: string | undefined;
+  /** 会话列表快照可能早于本次发送，只能临时钳制；消息水位才可完成重锚。 */
+  provisional: boolean;
+};
+
+function liveRowCreatedAtAnchor(sessionId: string): LiveRowCreatedAtAnchor {
   const pendingHostAnchorIds = pendingHostAnchorLiveAssistantClientIds.get(sessionId);
   const messageWatermark = newestCreatedAt((messages.get(sessionId) ?? []).filter((message) => {
     const isPendingHostAnchor = pendingHostAnchorIds?.has(message.id) === true
@@ -786,9 +792,12 @@ function liveRowCreatedAtWatermark(sessionId: string): string | undefined {
       && (message.id.startsWith('mobile-system-') || message.clientId.startsWith('mobile-system-'));
     return !isPendingHostAnchor && !isLocalSystemCard;
   }));
-  if (messageWatermark) return messageWatermark;
+  if (messageWatermark) return { createdAt: messageWatermark, provisional: false };
   const session = mergedSessions.find((item) => item.id === sessionId);
-  return session?.userSendAt ?? session?.updatedAt ?? session?.createdAt;
+  return {
+    createdAt: session?.userSendAt ?? session?.updatedAt ?? session?.createdAt,
+    provisional: true,
+  };
 }
 
 // 当前权威设备列表(由首页从设备列表 API reconcile 后注入)。每次重算会话时基于它 + 当前 shards(stale 侧)
@@ -876,6 +885,7 @@ function recomputeSessions(): void {
     liveRowsReanchored = reanchorPendingLiveAssistantRows(
       session.id,
       session.userSendAt ?? session.updatedAt ?? session.createdAt,
+      { consumePending: false },
     ) || liveRowsReanchored;
     const nextRetention = classifySessionRetention(session);
     if (nextRetention !== 'schedule' || previousRetention.get(session.id) === 'schedule') continue;
@@ -1222,25 +1232,53 @@ function forgetGeneratedPendingLiveAssistantClientIds(sessionId: string): void {
 function reanchorPendingLiveAssistantRows(
   sessionId: string,
   hostCreatedAtWatermark: string | undefined,
+  options: {
+    /** 会话列表快照可旧于本次发送，只有消息/窗口水位可以消费待重锚身份。 */
+    consumePending?: boolean;
+    /** user 行与 live 回复同戳时，明确把回复放在触发它的 user 行之后。 */
+    afterMessage?: RemoteMessage;
+  } = {},
 ): boolean {
   if (!hostCreatedAtWatermark) return false;
   const pendingIds = pendingHostAnchorLiveAssistantClientIds.get(sessionId);
   if (!pendingIds || pendingIds.size === 0) return false;
-  pendingHostAnchorLiveAssistantClientIds.delete(sessionId);
   const existing = messages.get(sessionId);
   if (!existing) return false;
-  let changed = false;
-  const next = existing.map((message) => {
+  const reanchored = existing.map((message) => {
     if (
       message.role !== 'assistant'
       || (!pendingIds.has(message.id) && !pendingIds.has(message.clientId))
       || message.createdAt === hostCreatedAtWatermark
     ) return message;
-    changed = true;
     return { ...message, createdAt: hostCreatedAtWatermark };
   });
-  if (!changed) return false;
-  messages.set(sessionId, normalizeMessages(next));
+  let next = normalizeMessages(reanchored);
+  let afterMessageFound = options.afterMessage === undefined;
+  const afterMessage = options.afterMessage;
+  if (afterMessage) {
+    const pendingRows = next.filter((message) => (
+      message.role === 'assistant'
+      && (pendingIds.has(message.id) || pendingIds.has(message.clientId))
+    ));
+    const pendingRowSet = new Set(pendingRows);
+    const withoutPending = next.filter((message) => !pendingRowSet.has(message));
+    const anchorIndex = withoutPending.findIndex((message) => (
+      messageIdentityMatches(message, afterMessage)
+    ));
+    if (anchorIndex >= 0) {
+      afterMessageFound = true;
+      next = [
+        ...withoutPending.slice(0, anchorIndex + 1),
+        ...pendingRows,
+        ...withoutPending.slice(anchorIndex + 1),
+      ];
+    }
+  }
+  if (options.consumePending !== false && afterMessageFound) {
+    pendingHostAnchorLiveAssistantClientIds.delete(sessionId);
+  }
+  if (remoteMessageListsEqual(existing, next)) return false;
+  messages.set(sessionId, next);
   return true;
 }
 
@@ -1430,10 +1468,10 @@ function applyRemoteTextEvent(
     // Device-clock stamp on a brand-new live row: anchor it to the newest known message,
     // or to host-domain session activity when the message window is still empty. Otherwise
     // an ahead device clock can dominate the first later host-persisted row.
-    const hostCreatedAtWatermark = liveRowCreatedAtWatermark(sessionId);
+    const hostCreatedAtAnchor = liveRowCreatedAtAnchor(sessionId);
     const createdAt = clampLiveRowCreatedAt(
       new Date().toISOString(),
-      hostCreatedAtWatermark,
+      hostCreatedAtAnchor.createdAt,
     );
     const changed = upsertMessage(sessionId, {
       id: clientId,
@@ -1447,7 +1485,7 @@ function applyRemoteTextEvent(
     });
     if (changed) {
       rememberPendingLiveAssistantClientId(sessionId, clientId);
-      if (!hostCreatedAtWatermark) {
+      if (hostCreatedAtAnchor.provisional) {
         rememberPendingHostAnchorLiveAssistantClientId(sessionId, clientId);
       }
     }
@@ -1473,12 +1511,12 @@ function applyRemoteTextEvent(
     : streamingMeta(isRecord(event.agentMeta)
       ? { ...(existing?.agentMeta ?? {}), ...event.agentMeta }
       : existing?.agentMeta);
-  const hostCreatedAtWatermark = existing ? undefined : liveRowCreatedAtWatermark(sessionId);
+  const hostCreatedAtAnchor = existing ? undefined : liveRowCreatedAtAnchor(sessionId);
   const needsHostAnchor = existing
     ? [existing.id, existing.clientId, clientId].some((id) => (
       Boolean(id) && pendingHostAnchorLiveAssistantClientIds.get(sessionId)?.has(id) === true
     ))
-    : !hostCreatedAtWatermark;
+    : hostCreatedAtAnchor?.provisional === true;
   const changed = upsertMessage(sessionId, {
     id: existing?.id ?? clientId,
     clientId,
@@ -1492,7 +1530,7 @@ function applyRemoteTextEvent(
     // needs the clamp — see clampLiveRowCreatedAt doc comment in messagePaging.ts.
     createdAt: existing?.createdAt ?? clampLiveRowCreatedAt(
       new Date().toISOString(),
-      hostCreatedAtWatermark,
+      hostCreatedAtAnchor?.createdAt,
     ),
   });
   if (changed) {
@@ -2190,13 +2228,23 @@ export const remoteSessionStore = {
     // "窗口内容有没有变"无关。被早退跳过时这次权威响应就白来了(#1210 review)。
     coverLatestPage(sessionId, latestOldestCreatedAt, latestNewestCreatedAt, joinedCoverage);
     if (remoteMessageListsEqual(existing, next)) {
-      if (liveRowsReanchoredBeforeMerge) bumpMessageVersion();
-      if (textFlushed || liveRowsReanchoredBeforeMerge) emit();
+      const liveRowsReanchoredAfterMerge = reanchorAfterMerge
+        && reanchorPendingLiveAssistantRows(
+          sessionId,
+          latestNewestCreatedAt,
+          { afterMessage: latestWindow[latestWindow.length - 1] },
+        );
+      if (liveRowsReanchoredBeforeMerge || liveRowsReanchoredAfterMerge) bumpMessageVersion();
+      if (textFlushed || liveRowsReanchoredBeforeMerge || liveRowsReanchoredAfterMerge) emit();
       return;
     }
     messages.set(sessionId, next);
     if (reanchorAfterMerge) {
-      reanchorPendingLiveAssistantRows(sessionId, latestNewestCreatedAt);
+      reanchorPendingLiveAssistantRows(
+        sessionId,
+        latestNewestCreatedAt,
+        { afterMessage: latestWindow[latestWindow.length - 1] },
+      );
     }
     applyMessageWriteRetention(sessionId);
     bumpMessageVersion();
@@ -2307,7 +2355,11 @@ export const remoteSessionStore = {
     changed = upsertMessage(sessionId, overlayLivePlanSnapshot(sessionId, message)) || changed;
     if (
       reanchorAfterMessage
-      && reanchorPendingLiveAssistantRows(sessionId, message.createdAt)
+      && reanchorPendingLiveAssistantRows(
+        sessionId,
+        message.createdAt,
+        { afterMessage: message },
+      )
     ) {
       bumpMessageVersion();
       changed = true;

--- a/apps/mobile/src/session/remoteSessionStore.ts
+++ b/apps/mobile/src/session/remoteSessionStore.ts
@@ -1233,7 +1233,7 @@ function reanchorPendingLiveAssistantRows(
   sessionId: string,
   hostCreatedAtWatermark: string | undefined,
   options: {
-    /** 会话列表快照可旧于本次发送，只有消息/窗口水位可以消费待重锚身份。 */
+    /** 会话/消息窗口快照都可能旧于本次发送，只有实时消息可消费待重锚身份。 */
     consumePending?: boolean;
     /** user 行与 live 回复同戳时，明确把回复放在触发它的 user 行之后。 */
     afterMessage?: RemoteMessage;
@@ -2117,7 +2117,11 @@ export const remoteSessionStore = {
     // existing live-before-persisted arrival order when their timestamps tie.
     const reanchorAfterMerge = latestWindow[latestWindow.length - 1].role === 'user';
     const liveRowsReanchoredBeforeMerge = !reanchorAfterMerge
-      && reanchorPendingLiveAssistantRows(sessionId, latestNewestCreatedAt);
+      && reanchorPendingLiveAssistantRows(
+        sessionId,
+        latestNewestCreatedAt,
+        { consumePending: false },
+      );
     const existing = messages.get(sessionId) ?? [];
     const existingIdentityIndex = buildMessageIdentityIndex(existing);
     const hasOverlap = latestWindow.some((item) => messageIdentityIndexHas(existingIdentityIndex, item));
@@ -2232,7 +2236,10 @@ export const remoteSessionStore = {
         && reanchorPendingLiveAssistantRows(
           sessionId,
           latestNewestCreatedAt,
-          { afterMessage: latestWindow[latestWindow.length - 1] },
+          {
+            afterMessage: latestWindow[latestWindow.length - 1],
+            consumePending: false,
+          },
         );
       if (liveRowsReanchoredBeforeMerge || liveRowsReanchoredAfterMerge) bumpMessageVersion();
       if (textFlushed || liveRowsReanchoredBeforeMerge || liveRowsReanchoredAfterMerge) emit();
@@ -2243,7 +2250,10 @@ export const remoteSessionStore = {
       reanchorPendingLiveAssistantRows(
         sessionId,
         latestNewestCreatedAt,
-        { afterMessage: latestWindow[latestWindow.length - 1] },
+        {
+          afterMessage: latestWindow[latestWindow.length - 1],
+          consumePending: false,
+        },
       );
     }
     applyMessageWriteRetention(sessionId);

--- a/apps/mobile/src/session/remoteSessionStore.ts
+++ b/apps/mobile/src/session/remoteSessionStore.ts
@@ -143,6 +143,8 @@ export interface SetLatestMessageWindowOptions {
 
 export interface SessionMessageWriteOptions {
   authority?: SessionMessageAuthority;
+  /** 本行是否携带主机时间域的 createdAt；本地临时卡必须显式关闭。 */
+  hostTimeAuthoritative?: boolean;
 }
 
 interface LivePlanSnapshot {
@@ -521,6 +523,9 @@ const sessionTaskUpdates = new Map<string, ReadonlyMap<string, AgentTaskUpdate>>
 // clientId/persistId when the database push arrives.
 const streamingAssistantClientIds = new Map<string, string>();
 const pendingLiveAssistantClientIds = new Map<string, Set<string>>();
+// 首个 live 行可能早于 getSession / listMessages 到达。此时只能暂用手机时间，待第一份
+// 主机时间水位到达后重锚；否则快手机时钟会让短且无 persistId 的旧 live 行长期占据尾部。
+const pendingHostAnchorLiveAssistantClientIds = new Map<string, Set<string>>();
 let streamingFallbackSequence = 0;
 const GENERATED_FALLBACK_MIN_PREFIX_LENGTH = 12;
 const TEXT_DELTA_BATCH_INTERVAL_MS = 32;
@@ -670,6 +675,7 @@ function invalidateSessionMessageWindowState(
   changed = sessionMessageSyncMarkers.delete(sessionId) || changed;
   changed = streamingAssistantClientIds.delete(sessionId) || changed;
   changed = pendingLiveAssistantClientIds.delete(sessionId) || changed;
+  changed = pendingHostAnchorLiveAssistantClientIds.delete(sessionId) || changed;
   if (pendingTextDeltaBatches.has(sessionId)) {
     discardPendingTextDelta(sessionId);
     changed = true;
@@ -858,7 +864,12 @@ function recomputeSessions(): void {
   // 数组级同样调和:全部元素引用与序都未变时保留旧数组引用——useRemoteSessions 的
   // useSyncExternalStore 快照经 Object.is 即可短路,消费屏对无关 emit 零重渲染。
   mergedSessions = sameElementRefs(mergedSessions, next) ? mergedSessions : next;
+  let liveRowsReanchored = false;
   for (const session of mergedSessions) {
+    liveRowsReanchored = reanchorPendingLiveAssistantRows(
+      session.id,
+      session.userSendAt ?? session.updatedAt ?? session.createdAt,
+    ) || liveRowsReanchored;
     const nextRetention = classifySessionRetention(session);
     if (nextRetention !== 'schedule' || previousRetention.get(session.id) === 'schedule') continue;
     // source 晚到后立即切断旧缓存路径。旧 hydrate / debounce 回调还会在提交前
@@ -877,6 +888,7 @@ function recomputeSessions(): void {
       sessionMessageLifecycle.leave(session.id, 'session-switch');
     }
   }
+  if (liveRowsReanchored) bumpMessageVersion();
   emit();
 }
 
@@ -1161,12 +1173,28 @@ function rememberPendingLiveAssistantClientId(sessionId: string, clientId: strin
   pendingLiveAssistantClientIds.set(sessionId, existing);
 }
 
+function rememberPendingHostAnchorLiveAssistantClientId(
+  sessionId: string,
+  clientId: string | null | undefined,
+): void {
+  if (!clientId) return;
+  const existing = pendingHostAnchorLiveAssistantClientIds.get(sessionId) ?? new Set<string>();
+  existing.add(clientId);
+  pendingHostAnchorLiveAssistantClientIds.set(sessionId, existing);
+}
+
 function forgetPendingLiveAssistantClientId(sessionId: string, clientId: string | null | undefined): void {
   if (!clientId) return;
   const existing = pendingLiveAssistantClientIds.get(sessionId);
-  if (!existing) return;
-  existing.delete(clientId);
-  if (existing.size === 0) pendingLiveAssistantClientIds.delete(sessionId);
+  if (existing) {
+    existing.delete(clientId);
+    if (existing.size === 0) pendingLiveAssistantClientIds.delete(sessionId);
+  }
+  const pendingHostAnchorIds = pendingHostAnchorLiveAssistantClientIds.get(sessionId);
+  if (pendingHostAnchorIds) {
+    pendingHostAnchorIds.delete(clientId);
+    if (pendingHostAnchorIds.size === 0) pendingHostAnchorLiveAssistantClientIds.delete(sessionId);
+  }
 }
 
 function forgetPendingLiveAssistantMessageIdentity(
@@ -1180,9 +1208,33 @@ function forgetGeneratedPendingLiveAssistantClientIds(sessionId: string): void {
   const existing = pendingLiveAssistantClientIds.get(sessionId);
   if (!existing) return;
   for (const id of [...existing]) {
-    if (isGeneratedStreamingClientId(id)) existing.delete(id);
+    if (isGeneratedStreamingClientId(id)) forgetPendingLiveAssistantClientId(sessionId, id);
   }
-  if (existing.size === 0) pendingLiveAssistantClientIds.delete(sessionId);
+}
+
+function reanchorPendingLiveAssistantRows(
+  sessionId: string,
+  hostCreatedAtWatermark: string | undefined,
+): boolean {
+  if (!hostCreatedAtWatermark) return false;
+  const pendingIds = pendingHostAnchorLiveAssistantClientIds.get(sessionId);
+  if (!pendingIds || pendingIds.size === 0) return false;
+  pendingHostAnchorLiveAssistantClientIds.delete(sessionId);
+  const existing = messages.get(sessionId);
+  if (!existing) return false;
+  let changed = false;
+  const next = existing.map((message) => {
+    if (
+      message.role !== 'assistant'
+      || (!pendingIds.has(message.id) && !pendingIds.has(message.clientId))
+      || message.createdAt === hostCreatedAtWatermark
+    ) return message;
+    changed = true;
+    return { ...message, createdAt: hostCreatedAtWatermark };
+  });
+  if (!changed) return false;
+  messages.set(sessionId, normalizeMessages(next));
+  return true;
 }
 
 function retireGeneratedStreamingFallback(sessionId: string): void {
@@ -1250,8 +1302,12 @@ function migrateGeneratedStreamingClientId(sessionId: string, generatedClientId:
   streamingAssistantClientIds.set(sessionId, persistId);
 
   const hadPendingLiveId = pendingLiveAssistantClientIds.get(sessionId)?.has(generatedClientId) === true;
+  const neededHostAnchor = pendingHostAnchorLiveAssistantClientIds
+    .get(sessionId)
+    ?.has(generatedClientId) === true;
   forgetPendingLiveAssistantClientId(sessionId, generatedClientId);
   if (hadPendingLiveId) rememberPendingLiveAssistantClientId(sessionId, persistId);
+  if (neededHostAnchor) rememberPendingHostAnchorLiveAssistantClientId(sessionId, persistId);
 
   const existing = messages.get(sessionId);
   if (!existing) return false;
@@ -1367,9 +1423,10 @@ function applyRemoteTextEvent(
     // Device-clock stamp on a brand-new live row: anchor it to the newest known message,
     // or to host-domain session activity when the message window is still empty. Otherwise
     // an ahead device clock can dominate the first later host-persisted row.
+    const hostCreatedAtWatermark = liveRowCreatedAtWatermark(sessionId);
     const createdAt = clampLiveRowCreatedAt(
       new Date().toISOString(),
-      liveRowCreatedAtWatermark(sessionId),
+      hostCreatedAtWatermark,
     );
     const changed = upsertMessage(sessionId, {
       id: clientId,
@@ -1381,7 +1438,12 @@ function applyRemoteTextEvent(
       agentMeta: isRecord(event.agentMeta) ? event.agentMeta : null,
       createdAt,
     });
-    if (changed) rememberPendingLiveAssistantClientId(sessionId, clientId);
+    if (changed) {
+      rememberPendingLiveAssistantClientId(sessionId, clientId);
+      if (!hostCreatedAtWatermark) {
+        rememberPendingHostAnchorLiveAssistantClientId(sessionId, clientId);
+      }
+    }
     return changed || clientIdResolution.changed;
   }
 
@@ -1404,6 +1466,12 @@ function applyRemoteTextEvent(
     : streamingMeta(isRecord(event.agentMeta)
       ? { ...(existing?.agentMeta ?? {}), ...event.agentMeta }
       : existing?.agentMeta);
+  const hostCreatedAtWatermark = existing ? undefined : liveRowCreatedAtWatermark(sessionId);
+  const needsHostAnchor = existing
+    ? [existing.id, existing.clientId, clientId].some((id) => (
+      Boolean(id) && pendingHostAnchorLiveAssistantClientIds.get(sessionId)?.has(id) === true
+    ))
+    : !hostCreatedAtWatermark;
   const changed = upsertMessage(sessionId, {
     id: existing?.id ?? clientId,
     clientId,
@@ -1417,10 +1485,18 @@ function applyRemoteTextEvent(
     // needs the clamp — see clampLiveRowCreatedAt doc comment in messagePaging.ts.
     createdAt: existing?.createdAt ?? clampLiveRowCreatedAt(
       new Date().toISOString(),
-      liveRowCreatedAtWatermark(sessionId),
+      hostCreatedAtWatermark,
     ),
   });
-  if (changed) rememberPendingLiveAssistantClientId(sessionId, clientId);
+  if (changed) {
+    rememberPendingLiveAssistantClientId(sessionId, clientId);
+    // upsertMessage intentionally clears pending reconciliation identities when it
+    // replaces an assistant row. A live delta/final is not host-authoritative, so
+    // carry the provisional anchor forward until metadata or a persisted row lands.
+    if (needsHostAnchor) {
+      rememberPendingHostAnchorLiveAssistantClientId(sessionId, clientId);
+    }
+  }
   return changed || clientIdResolution.changed;
 }
 
@@ -2202,6 +2278,13 @@ export const remoteSessionStore = {
   ): void {
     if (!messageWriteAllowed(sessionId, options.authority)) return;
     let changed = flushPendingTextDelta(sessionId);
+    if (
+      options.hostTimeAuthoritative !== false
+      && reanchorPendingLiveAssistantRows(sessionId, message.createdAt)
+    ) {
+      bumpMessageVersion();
+      changed = true;
+    }
     changed = upsertMessage(sessionId, overlayLivePlanSnapshot(sessionId, message)) || changed;
     // 订阅内到达的实时行可以把覆盖区间的上界往后推;断流后收到的不行(见 liveTailTrusted)。
     coverLiveRow(sessionId, message);
@@ -2322,7 +2405,7 @@ export const remoteSessionStore = {
       createdAt: createdAt.toISOString(),
       systemCardType: cardType,
       systemCardData: data,
-    });
+    }, { hostTimeAuthoritative: false });
     return clientId;
   },
 
@@ -3264,6 +3347,7 @@ export const remoteSessionStore = {
       changed = flushAndFinalizeRemoteStreamingMessages(sessionId) || changed;
       changed = streamingAssistantClientIds.delete(sessionId) || changed;
       changed = pendingLiveAssistantClientIds.delete(sessionId) || changed;
+      changed = pendingHostAnchorLiveAssistantClientIds.delete(sessionId) || changed;
       changed = writeMakerTurnRunning(sessionId, false) || changed;
       changed = writeSessionRunStatus(sessionId, EMPTY_SESSION_RUN_STATUS) || changed;
     }
@@ -3300,6 +3384,7 @@ export const remoteSessionStore = {
         streamingAssistantClientIds.delete(sessionId);
         discardPendingTextDelta(sessionId);
         pendingLiveAssistantClientIds.delete(sessionId);
+        pendingHostAnchorLiveAssistantClientIds.delete(sessionId);
         sessionMakerTurnRunning.delete(sessionId);
         sessionParkedTaskUpdates.delete(sessionId);
         sessionMessageLifecycle.forget(sessionId);
@@ -3352,6 +3437,7 @@ export const remoteSessionStore = {
     sessionTaskUpdates.clear();
     streamingAssistantClientIds.clear();
     pendingLiveAssistantClientIds.clear();
+    pendingHostAnchorLiveAssistantClientIds.clear();
     pendingTextDeltaBatches.clear();
     clearTextDeltaFlushTimer();
     sessionMakerTurnRunning.clear();

--- a/apps/mobile/src/session/remoteSessionStore.ts
+++ b/apps/mobile/src/session/remoteSessionStore.ts
@@ -3531,7 +3531,10 @@ export const remoteSessionStore = {
       changed = flushAndFinalizeRemoteStreamingMessages(sessionId) || changed;
       changed = streamingAssistantClientIds.delete(sessionId) || changed;
       changed = pendingLiveAssistantClientIds.delete(sessionId) || changed;
-      changed = pendingHostAnchorLiveAssistantClientIds.delete(sessionId) || changed;
+      // The message window survives a soft offline transition, so its provisional
+      // host-time identity must survive too. A reconnecting authoritative user row
+      // may still need it to restore question → reply order; persisted reconciliation,
+      // explicit window invalidation, or actual device removal will retire it.
       changed = writeMakerTurnRunning(sessionId, false) || changed;
       changed = writeSessionRunStatus(sessionId, EMPTY_SESSION_RUN_STATUS) || changed;
     }

--- a/apps/mobile/src/session/remoteSessionStore.ts
+++ b/apps/mobile/src/session/remoteSessionStore.ts
@@ -813,6 +813,12 @@ function liveRowCreatedAtAnchor(sessionId: string): LiveRowCreatedAtAnchor {
   };
 }
 
+function userMessageMatchesLatestSend(sessionId: string, message: RemoteMessage): boolean {
+  if (message.role !== 'user') return false;
+  const userSendAt = mergedSessions.find((item) => item.id === sessionId)?.userSendAt;
+  return Boolean(userSendAt && message.createdAt.localeCompare(userSendAt) >= 0);
+}
+
 // 当前权威设备列表(由首页从设备列表 API reconcile 后注入)。每次重算会话时基于它 + 当前 shards(stale 侧)
 // 重建身份索引,用于给会话算展示用 canonicalDeviceId(把 re-link 后残留 stale shard 认领回当前设备);
 // 为 null 时不归一,安全退化。
@@ -2143,7 +2149,13 @@ export const remoteSessionStore = {
     // A triggering user row must be inserted before its live assistant reply is
     // tied to the same host timestamp. Other authoritative tail rows keep the
     // existing live-before-persisted arrival order when their timestamps tie.
-    const reanchorAfterMerge = latestWindow[latestWindow.length - 1].role === 'user';
+    const latestTailMessage = latestWindow[latestWindow.length - 1];
+    const reanchorAfterMerge = latestTailMessage.role === 'user';
+    // A latest-window request may have started before the current send. Only a user tail
+    // at/after the session's send marker can finish this pending identity; older user tails
+    // may temporarily position the live row but must leave it eligible for the realtime push.
+    const consumeReanchorAfterMerge = reanchorAfterMerge
+      && userMessageMatchesLatestSend(sessionId, latestTailMessage);
     const liveRowsReanchoredBeforeMerge = !reanchorAfterMerge
       && reanchorPendingLiveAssistantRows(
         sessionId,
@@ -2265,8 +2277,8 @@ export const remoteSessionStore = {
           sessionId,
           latestNewestCreatedAt,
           {
-            afterMessage: latestWindow[latestWindow.length - 1],
-            consumePending: false,
+            afterMessage: latestTailMessage,
+            consumePending: consumeReanchorAfterMerge,
           },
         );
       if (liveRowsReanchoredBeforeMerge || liveRowsReanchoredAfterMerge) bumpMessageVersion();
@@ -2279,8 +2291,8 @@ export const remoteSessionStore = {
         sessionId,
         latestNewestCreatedAt,
         {
-          afterMessage: latestWindow[latestWindow.length - 1],
-          consumePending: false,
+          afterMessage: latestTailMessage,
+          consumePending: consumeReanchorAfterMerge,
         },
       );
     }
@@ -2385,7 +2397,11 @@ export const remoteSessionStore = {
     if (
       options.hostTimeAuthoritative !== false
       && !reanchorAfterMessage
-      && reanchorPendingLiveAssistantRows(sessionId, message.createdAt)
+      && reanchorPendingLiveAssistantRows(
+        sessionId,
+        message.createdAt,
+        { consumePending: false },
+      )
     ) {
       bumpMessageVersion();
       changed = true;

--- a/apps/mobile/src/session/remoteSessionStore.ts
+++ b/apps/mobile/src/session/remoteSessionStore.ts
@@ -531,6 +531,14 @@ const pendingLiveAssistantClientIds = new Map<string, Set<string>>();
 // null 身份先经历软离线，则禁止用重连后的“首份”元数据绑定，因为它可能已经是下一轮。
 type PendingHostAnchorIdentity = {
   bindOnMetadata: boolean;
+  /**
+   * Local maker-turn cohort used only while host session metadata is unavailable.
+   * Distinct assistant rows emitted by one running turn share this id, so the first
+   * authoritative user row can consume the whole reply block without claiming rows
+   * from a later turn. Once sendAt is known it remains as the stronger pre-metadata
+   * grouping key; identities created with host metadata use sendAt directly.
+   */
+  unboundRoundId: number | null;
   sendAt: string | null;
 };
 const pendingHostAnchorLiveAssistantClientIds = new Map<
@@ -541,6 +549,8 @@ const pendingHostAnchorLiveAssistantClientIds = new Map<
 // transport device alongside the pending anchor so markDeviceOffline can still freeze an
 // unbound identity without relying on sessionDeviceIndex.
 const pendingHostAnchorDeviceIds = new Map<string, string>();
+const activePendingHostAnchorRoundIds = new Map<string, number>();
+let nextPendingHostAnchorRoundId = 0;
 let streamingFallbackSequence = 0;
 const GENERATED_FALLBACK_MIN_PREFIX_LENGTH = 12;
 const TEXT_DELTA_BATCH_INTERVAL_MS = 32;
@@ -693,6 +703,7 @@ function invalidateSessionMessageWindowState(
   changed = pendingLiveAssistantClientIds.delete(sessionId) || changed;
   changed = pendingHostAnchorLiveAssistantClientIds.delete(sessionId) || changed;
   changed = pendingHostAnchorDeviceIds.delete(sessionId) || changed;
+  changed = activePendingHostAnchorRoundIds.delete(sessionId) || changed;
   if (pendingTextDeltaBatches.has(sessionId)) {
     discardPendingTextDelta(sessionId);
     changed = true;
@@ -708,6 +719,69 @@ function invalidateSessionMessageWindowState(
     changed = pendingRefreshSessions.delete(sessionId) || changed;
   }
   return changed;
+}
+
+function removeSessionRuntimeState(sessionId: string): void {
+  invalidateSessionMessageWindowState(sessionId, false);
+  pendingInteractions.delete(sessionId);
+  pendingInteractionsAuthoritative.delete(sessionId);
+  inputProjections.delete(sessionId);
+  bumpInputProjectionAuthorityEpoch(sessionId);
+  sessionLiveActivity.delete(sessionId);
+  sessionRunning.delete(sessionId);
+  sessionRunStatus.delete(sessionId);
+  sessionMakerActivityEpochs.delete(sessionId);
+  sessionMakerTurnRunning.delete(sessionId);
+  sessionMessageLifecycle.forget(sessionId);
+  sessionDeviceIndex.delete(sessionId);
+  dropPendingTitlePreview(sessionId);
+  // revision 下限按会话回收:它不参与单轮快照回收(那会把覆盖权还给晚到的
+  // 旧快照),所以只能在会话本身消失时清,保持有界。
+  const sessionPrefix = interactionResolveKey(sessionId, '');
+  for (const key of interactionRevisionFloors.keys()) {
+    if (key.startsWith(sessionPrefix)) interactionRevisionFloors.delete(key);
+  }
+}
+
+function discardTransportOwnedPendingSessionState(
+  sessionId: string,
+  deviceId: string,
+): boolean {
+  let changed = false;
+  const batch = pendingTextDeltaBatches.get(sessionId);
+  if (batch?.deviceId === deviceId) {
+    discardPendingTextDelta(sessionId);
+    changed = true;
+  }
+  if (pendingHostAnchorDeviceIds.get(sessionId) !== deviceId) return changed;
+
+  const pendingAnchorIds = new Set(
+    pendingHostAnchorLiveAssistantClientIds.get(sessionId)?.keys() ?? [],
+  );
+  const existingMessages = messages.get(sessionId);
+  if (existingMessages && pendingAnchorIds.size > 0) {
+    const nextMessages = existingMessages.filter((message) => (
+      !pendingAnchorIds.has(message.id) && !pendingAnchorIds.has(message.clientId)
+    ));
+    if (nextMessages.length !== existingMessages.length) {
+      if (nextMessages.length > 0) messages.set(sessionId, nextMessages);
+      else messages.delete(sessionId);
+      changed = true;
+    }
+  }
+  const pendingLiveIds = pendingLiveAssistantClientIds.get(sessionId);
+  if (pendingLiveIds) {
+    for (const id of pendingAnchorIds) pendingLiveIds.delete(id);
+    if (pendingLiveIds.size === 0) pendingLiveAssistantClientIds.delete(sessionId);
+  }
+  const streamingClientId = streamingAssistantClientIds.get(sessionId);
+  if (streamingClientId && pendingAnchorIds.has(streamingClientId)) {
+    streamingAssistantClientIds.delete(sessionId);
+  }
+  pendingHostAnchorLiveAssistantClientIds.delete(sessionId);
+  pendingHostAnchorDeviceIds.delete(sessionId);
+  activePendingHostAnchorRoundIds.delete(sessionId);
+  return true;
 }
 
 function releaseSessionDetailProjections(sessionId: string): boolean {
@@ -1253,11 +1327,30 @@ function rememberPendingHostAnchorLiveAssistantClientId(
   sendAt: string | null = latestUserSendAt(sessionId) ?? null,
   bindOnMetadata = true,
   deviceId?: string,
+  unboundRoundId?: number | null,
 ): void {
   if (!clientId) return;
   const existing = pendingHostAnchorLiveAssistantClientIds.get(sessionId)
     ?? new Map<string, PendingHostAnchorIdentity>();
-  if (!existing.has(clientId)) existing.set(clientId, { bindOnMetadata, sendAt });
+  if (!existing.has(clientId)) {
+    let resolvedRoundId = unboundRoundId;
+    if (resolvedRoundId === undefined) {
+      if (sendAt !== null) {
+        resolvedRoundId = null;
+      } else if (sessionMakerTurnRunning.get(sessionId) === true) {
+        resolvedRoundId = activePendingHostAnchorRoundIds.get(sessionId);
+        if (resolvedRoundId === undefined) {
+          resolvedRoundId = ++nextPendingHostAnchorRoundId;
+          activePendingHostAnchorRoundIds.set(sessionId, resolvedRoundId);
+        }
+      } else {
+        // Older producers may omit maker status boundaries. Preserve their historical
+        // one-row-per-user fallback instead of grouping unrelated unbound replies.
+        resolvedRoundId = ++nextPendingHostAnchorRoundId;
+      }
+    }
+    existing.set(clientId, { bindOnMetadata, sendAt, unboundRoundId: resolvedRoundId });
+  }
   pendingHostAnchorLiveAssistantClientIds.set(sessionId, existing);
   if (deviceId) pendingHostAnchorDeviceIds.set(sessionId, deviceId);
 }
@@ -1438,11 +1531,13 @@ function reanchorPendingLiveAssistantRows(
   // assistant blocks carrying that non-null send marker belong after the same user;
   // move them as one ordered block instead of consuming only the last block.
   if (afterMessages.length === 1 && pairs.length === 1) {
-    const groupedSendAt = pairs[0].pendingRow.identity.sendAt;
-    if (groupedSendAt) {
+    const groupedIdentity = pairs[0].pendingRow.identity;
+    if (groupedIdentity.unboundRoundId !== null || groupedIdentity.sendAt !== null) {
       const afterMessage = afterMessages[0];
       const groupedRows = pendingRows.filter((row) => (
-        row.identity.sendAt === groupedSendAt
+        (groupedIdentity.unboundRoundId !== null
+          ? row.identity.unboundRoundId === groupedIdentity.unboundRoundId
+          : row.identity.sendAt === groupedIdentity.sendAt)
         && pendingRowCanPairMessage(row, afterMessage)
       ));
       pairs.splice(0, pairs.length, ...groupedRows.map((pendingRow) => ({
@@ -1613,6 +1708,7 @@ function migrateGeneratedStreamingClientId(sessionId: string, generatedClientId:
       hostAnchorIdentity.sendAt,
       hostAnchorIdentity.bindOnMetadata,
       hostAnchorDeviceId,
+      hostAnchorIdentity.unboundRoundId,
     );
   }
 
@@ -1817,6 +1913,7 @@ function applyRemoteTextEvent(
         hostAnchorIdentity?.sendAt ?? latestUserSendAt(sessionId) ?? null,
         hostAnchorIdentity?.bindOnMetadata ?? true,
         deviceId,
+        hostAnchorIdentity?.unboundRoundId,
       );
     }
   }
@@ -3777,49 +3874,46 @@ export const remoteSessionStore = {
     const hadShard = shards.delete(deviceId);
     const hadWorktreePreference = newMakerWorktreePreferences.delete(deviceId);
     const hadWorktreeBranchPreferences = newMakerWorktreeBranchPreferences.delete(deviceId);
-    // Sweep per-session maps for this device regardless of whether the shard still exists, and
-    // drop the index entries too — otherwise sessionDeviceIndex (and any maps it points at)
-    // leak orphans when the shard was already pruned.
-    let removedSession = false;
+    // A maker event may precede the session list, so transport-owned batches and host anchors
+    // are also authoritative ownership evidence. Sweep their sessions even when no shard or
+    // sessionDeviceIndex entry exists yet; otherwise the 32ms timer can recreate messages after
+    // hard removal, or an already-flushed provisional row can survive re-authorization.
+    const indexedDeviceSessionIds = new Set<string>();
+    const transportOwnedSessionIds = new Set<string>();
     for (const [sessionId, indexedDeviceId] of sessionDeviceIndex) {
-      if (indexedDeviceId === deviceId) {
-        messages.delete(sessionId);
-        livePlanSnapshots.delete(sessionId);
-        pendingInteractions.delete(sessionId);
-        pendingInteractionsAuthoritative.delete(sessionId);
-        inputProjections.delete(sessionId);
-        bumpInputProjectionAuthorityEpoch(sessionId);
-        sessionLiveActivity.delete(sessionId);
-        sessionRunning.delete(sessionId);
-        sessionRunStatus.delete(sessionId);
-        sessionMakerActivityEpochs.delete(sessionId);
-        sessionMessageSyncMarkers.delete(sessionId);
-        // 连续性结论随窗口一起失效:rewind 可能删掉中间的行,清空/回收更是整窗重来。
-        // 重置为未知,下一次最新窗口同步会重建(见 sessionWindowCoverage)。
-        forgetWindowCoverage(sessionId);
-        // 会话镜像整体回收:它的 `session:<id>` 订阅也随之消失,ACK 记录不能留着给后面的页背书。
-        sessionLiveStreamAcked.delete(sessionId);
-        sessionTaskUpdates.delete(sessionId);
-        streamingAssistantClientIds.delete(sessionId);
-        discardPendingTextDelta(sessionId);
-        pendingLiveAssistantClientIds.delete(sessionId);
-        pendingHostAnchorLiveAssistantClientIds.delete(sessionId);
-        pendingHostAnchorDeviceIds.delete(sessionId);
-        sessionMakerTurnRunning.delete(sessionId);
-        sessionParkedTaskUpdates.delete(sessionId);
-        sessionMessageLifecycle.forget(sessionId);
-        sessionLastAccessOrder.delete(sessionId);
-        sessionDeviceIndex.delete(sessionId);
-        dropPendingTitlePreview(sessionId);
-        // revision 下限按会话回收:它不参与单轮快照回收(那会把覆盖权还给晚到的
-        // 旧快照),所以只能在会话本身消失时清,保持有界。
-        const sessionPrefix = interactionResolveKey(sessionId, '');
-        for (const key of interactionRevisionFloors.keys()) {
-          if (key.startsWith(sessionPrefix)) interactionRevisionFloors.delete(key);
-        }
-        removedSession = true;
-      }
+      if (indexedDeviceId === deviceId) indexedDeviceSessionIds.add(sessionId);
     }
+    for (const [sessionId, batch] of pendingTextDeltaBatches) {
+      if (batch.deviceId === deviceId) transportOwnedSessionIds.add(sessionId);
+    }
+    for (const [sessionId, pendingDeviceId] of pendingHostAnchorDeviceIds) {
+      if (pendingDeviceId === deviceId) transportOwnedSessionIds.add(sessionId);
+    }
+    for (const sessionId of indexedDeviceSessionIds) {
+      // Keep the authority reset explicit in this hard-remove boundary: consumers must
+      // never interpret the now-empty interaction list as an authoritative snapshot.
+      pendingInteractionsAuthoritative.delete(sessionId);
+      removeSessionRuntimeState(sessionId);
+    }
+    let removedTransportState = false;
+    for (const sessionId of transportOwnedSessionIds) {
+      if (indexedDeviceSessionIds.has(sessionId)) continue;
+      const indexedDeviceId = sessionDeviceIndex.get(sessionId);
+      if (!indexedDeviceId) {
+        pendingInteractionsAuthoritative.delete(sessionId);
+        removeSessionRuntimeState(sessionId);
+        removedTransportState = true;
+        continue;
+      }
+      // A re-linked current shard may already own the same session id. In that case
+      // remove only the stale transport's provisional rows/batch and keep the current
+      // device's authoritative window and runtime projections intact.
+      removedTransportState = discardTransportOwnedPendingSessionState(
+        sessionId,
+        deviceId,
+      ) || removedTransportState;
+    }
+    const removedSession = indexedDeviceSessionIds.size > 0 || removedTransportState;
     if (
       !hadShard
       && !removedSession
@@ -3859,6 +3953,8 @@ export const remoteSessionStore = {
     pendingLiveAssistantClientIds.clear();
     pendingHostAnchorLiveAssistantClientIds.clear();
     pendingHostAnchorDeviceIds.clear();
+    activePendingHostAnchorRoundIds.clear();
+    nextPendingHostAnchorRoundId = 0;
     pendingTextDeltaBatches.clear();
     clearTextDeltaFlushTimer();
     sessionMakerTurnRunning.clear();
@@ -4189,6 +4285,7 @@ function clearLiveGenerationOnWideRunStart(
 
 function writeMakerTurnRunning(sessionId: string, running: boolean): boolean {
   const prev = sessionMakerTurnRunning.get(sessionId) === true;
+  if (!running) activePendingHostAnchorRoundIds.delete(sessionId);
   if (running === prev) return false;
   if (running) sessionMakerTurnRunning.set(sessionId, true);
   else {


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Mobile 会话屏在发送消息后列表不停留在最新消息、反而停在旧消息位置的问题。两个根因：(1) 发送后的贴底滚动只发一次 `scrollToEnd` 且不校验是否真的到达内容底部——命令可能被始终开启的 `maintainVisibleContentPosition` 吸收，或按尚未测量完成的旧 metrics 计算落点，静默停在旧消息上；原有的校验/补滚循环只在会话冷启动锚定时运行一次。(2) 流式 assistant 行用手机时钟打 `createdAt`，与主机时钟落库行混排；手机时钟偏快时，刚发送的消息会被排序到旧的流式行之前，列表尾部被旧行占住。

修复：把冷启动的有界校验/补滚复用到发送跟随（`followLatestRequestKey`）与内容增长补滚（`handleContentSize`）两条路径；显式跟随会清除已被发送动作取代的历史浏览意图。新增纯函数 `clampLiveRowCreatedAt`：会话已有主机域 watermark 时，把临时 live 行固定到该 watermark；既避免慢设备时钟把 live 行插到已知行之前，也避免快设备时钟压过随后到达的主机持久化行。进一步补齐空消息窗场景：没有消息 watermark 时改用会话的主机域活动时间，避免短 live 行残留在首个持久化行之后；用户手动向下滚回底部时也会清除旧的历史浏览意图，后续内容增长可重新触发贴底校验。进一步修复 review 发现的边界：死区内轻拖没有真正解除贴底时，校验继续以 nearBottom 实态运行；首个 live 行早于会话元数据或消息窗口时先标记为 provisional，首个主机元数据或持久化消息到达后重锚，且多帧 delta/final 不会丢失该标记。权威最新消息窗口现在也能作为首个主机时间来源触发重锚；当首个权威行是 user 时先插入再重锚，保持问题在 live 回复之前，而 assistant 持久化尾行仍保留在临时 live 行之后。主机时间水位还会排除仍待重锚的 provisional live 行和本地 system card，确保多条 distinct live 行都在首个权威水位到达后一起收口。旧会话列表快照以及既有 assistant/tool 尾行现在只提供临时时间锚，直到当前轮 user 或其他权威消息到达才完成重锚；user 行到达时会显式保持问题在对应 live 回复之前。连续多轮 provisional live 回复会按 user push 顺序一对一逐条重锚，保持 `U1 → A1 → U2 → A2`。若尾部虽是 user，但会话 `userSendAt` 已前进，则将它识别为上一轮 user，当前 live 行仍保持 provisional，直到本轮 user push 到达。最新 review 进一步收紧 pending 身份生命周期：延迟的 assistant/tool push 只提供临时时间水位，不再批量消费待重锚回复；最新 user 窗口只有在尾行时间不早于会话 `userSendAt` 时才完成配对，避免旧回复被下一轮 user 重复认领。权威窗口一次带回多轮 user 时，会让窗口内最新 user 后缀与最新 pending 回复后缀按顺序一对一配对；实时 user push 也只在不早于会话 userSendAt 时消费当前 pending 身份，已有本轮发送标记时只认领最新 pending 回复；动画贴底则等待既有 1400ms settle 窗口结束后再启动无动画校验补滚，避免平滑滚动被两帧后的 retry 打断成瞬移。短暂离线时同时保留 live-window 保护身份与 host-anchor 身份，避免重连窗口在权威 assistant 回声前丢失回复，并让权威 user 行恢复问题 → 回复顺序；已知早于 `userSendAt` 的旧 user push / 窗口不再改写当前回复的时间锚或位置。最新反馈继续补齐两条边界：pending host-anchor 身份记录首次绑定的 `userSendAt`，重连时只与对应发送窗口内的 user 行配对，旧轮回复不会被新轮问题认领；LegendList 的普通 data append 与流式 size 变化会记录短 mVCP settle 安静窗，两套贴底 verifier 在窗口内使用独立 wait 预算，不再约 200ms 内耗尽 retry。本轮 review 继续补齐：软离线前尚无会话元数据或仍停在 32ms 微批中的 live 回复会按 transport device 冻结空 sendAt 身份，重连后的新轮 user 不会认领旧回复，而迟到的旧轮 user 仍可恢复原顺序；同一 userSendAt 下的多条 live assistant 行会按原顺序整体移动到对应 user 之后；截断持久化回声在保留完整 live 内容时也会吸收权威 createdAt。新 head 继续处理两条有效反馈：设备 hard remove 会同时依据 session 索引与 maker transport ownership 回收元数据前的 32ms 文本批次、provisional 行和 host-anchor 身份；若同一 session ID 已由 re-link 后的 current shard 接管，则只清旧 transport 的临时状态，不误删新设备窗口。元数据前同一 Maker turn 的多条 live block 会共享本地轮次 cohort，首个权威 user 行按原序整体消费，而缺少 turn 边界的旧 producer 仍保留逐条配对兼容语义。本轮新 review 进一步修复三条边界：权威窗口中的 user 行也参与 sendAt 区间分隔，避免中间轮次身份已消费后旧回复跨轮；pending host-anchor 的 transport ownership 改为逐 identity 记录并支持共享 ownership，hard remove 只清理被移除 transport 独占的 provisional 行且在无剩余 owner 时完整回收 runtime；多个离线未绑定 cohort 的实时 user 回补按最小 unboundRoundId 顺序消费，避免 A2→U1 反向配对。本次进一步在 32ms 文本微批内把 transport device 作为硬边界：deviceId 切换时先 flush 旧 batch，避免 stale/current transport 的 delta 串批、错误归属或在移除设备时误删当前回复。当两个 transport 的 batch 都已 flush 时，同一 persistId 的 streaming assembly 也会在 deviceId 切换时重置旧 live 文本，避免 current 回复继续拼接 stale 内容。

最新修复将 streaming transport ownership 按 session 内 identity 独立记录，避免交错的 persistId 相互覆盖；soft-offline / finalization 仅清 active pointer，保留身份 ownership 直到权威调和或精确回收；stale indexed shard hard remove 在 current transport 已先到但 session list 尚未到达时只清 stale transport 状态；已持久化 assistant 行的相同 final 重放不会被误标为 provisional transport ownership。

本次继续修复权威重连窗口与 transport ownership 的边界：多个离线未绑定 cohort 仅在窗口 user 数量与 cohort 数量精确一致时按轮次顺序配对，截断或多出 user 的窗口保持 pending，避免把回复挂到错误轮次；stale transport 在权威 current transport 已拥有 pending assembly 时会在 clientId 迁移前被拒绝，且 ownership 跨 done 边界保留，避免重放改写临时 identity、覆盖 current 内容或插入重复回复；已持久化 assistant 行同样拒绝非权威重放。

本次新反馈继续收紧两处调和边界：多个离线未绑定 cohort 只有在最新窗口明确覆盖到会话起点时才允许按位置配对，头部截断但 user 数量恰好相等的窗口仍保持 pending；权威 persisted assistant echo 即使与 live 行逐字段相同，也会清理 pending reconciliation identity，而实时 transport replay 不会提前退休该身份。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Mobile 发送消息后列表跳到旧消息位置、看不到刚发的消息
- 本 PR 包含：发送/补滚路径的有界贴底校验重试（复用现有 `evaluateMobileAnchorVerify`，卸载/切会话可取消）；显式跟随重置已过期的历史浏览意图；流式行时间戳锚定纯函数及接线；空消息窗 provisional live 行及元数据/持久化消息重锚；多帧流式标记保持；权威最新窗口重锚及 user/assistant 同戳顺序；多条 provisional live 行与本地 system card 的水位隔离；旧会话快照和 assistant/tool 尾行保持 provisional 直到当前轮权威消息重锚；连续多轮 provisional reply 与 user push 一对一按序配对；延迟的非 user push 不消费无关 pending 身份，匹配本轮 `userSendAt` 的 user 最新窗口才完成配对，实时 user push 同样排除较旧轮次，权威多轮/截断窗口只让最新 pending 后缀匹配窗口内 user 后缀；动画贴底等待 settle 后再校验补滚；用更新的会话 `userSendAt` 识别旧 user 尾行并等待本轮 user push；短暂离线后同时保留 provisional 回复的窗口保护与 host-anchor 身份直到权威重锚、持久化调和或会话回收；已知旧轮次 user push / 窗口不改写当前回复锚点；死区轻拖后的贴底校验；手动回到底部时清除旧历史浏览意图；pending host-anchor 按首次 `userSendAt` 绑定并按发送窗口配对，阻止离线旧回复跨轮认领；普通 data/size 变化驱动 mVCP settle 安静窗，贴底校验在窗口内等待；软离线前无元数据或尚在微批中的 live 回复按 transport device 冻结未绑定身份，同一发送轮次的多条 assistant 行保序整体落到对应 user 之后，截断持久化回声保留完整内容时仍吸收权威 createdAt；hard remove 按 transport ownership 清理未索引 batch / provisional 行 / host-anchor，并保护已由 current shard 接管的同 session 窗口；元数据前同一 Maker turn 的多条 live block 共享轮次 cohort 并由首个 user 行整体消费；权威窗口 user 行参与 sendAt 边界分隔；pending identity 逐行记录 transport ownership 并精确回收 stale transport；多个离线未绑定 cohort 按轮次到达顺序恢复；跨 transport 的 32ms text-delta batch 在 deviceId 切换时先 flush，且同一 persistId 的已落地 streaming assembly 会按 transport 重置；权威重连窗口仅在 user/cohort 数量精确一致时按离线轮次顺序配对，截断或多出 user 时保守保持 pending；canonical current transport 的 pending assembly 在 clientId 迁移前及 done 边界后都拒绝 stale replay，已持久化 assistant 行也不被非权威 transport 改写或认领；对应回归测试
- 本次 review 补充：多 cohort 重连配对要求窗口上沿完整；相同内容的权威 persisted assistant echo 仍完成身份调和，实时 replay 保持 pending；对应回归测试
- 明确不包含：`compareMessageOrder` 排序规则本身；重开 resync 的窗口替换策略
- 用户可见变化：发送消息后列表可靠停在最新消息；无布局、样式或文案变化
- 是否存在 breaking change：无

### UI 变化

不涉及：无视觉样式、布局或文案变化；仅修复既有"发送后贴底跟随"交互未按预期生效的缺陷，恢复原设计行为，因此无新界面效果可截图。

- 引用的设计规范：不涉及：未改变 UI 布局、样式、交互规则或文案，仅修复滚动锚定与消息排序的时序缺陷

## 怎么验证的

### 自动验证

```text
Mobile focused tests
结果：4 个文件、320/320 通过

pnpm --filter mobile run --if-present typecheck
结果：通过

pnpm --dir apps/mobile test
结果：312 个文件、3752/3752 通过

pnpm --dir apps/mobile test:scope
结果：通过

pnpm --dir apps/mobile test:smoke
结果：2/2 通过

Node 22.22.0（通过 pnpm dlx 固定）+ TMPDIR=/private/tmp + TZ=UTC pnpm test:unit
结果：全部 workspace 通过

pnpm check:dco
结果：24 个 commit 均通过 DCO

git diff --check
结果：通过
```

### 手工验证

不涉及视觉变化；未做真机录屏。滚动校验逻辑与排序钳制均以确定性单元测试覆盖。

### 未执行的验证

`apps/mobile` 无 ESLint 配置与 `lint` 脚本（仓库既有状态，非本 PR 引入），故未跑 ESLint。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：Mobile 消息列表滚动时序与消息排序

### 影响与回滚

- 影响范围：仅 Mobile 会话屏的贴底跟随（发送后、内容增长补滚、断路器清账三处补校验）与流式 live 行的 provisional `createdAt` 打点及按轮次有序重锚、离线 pending 身份的发送轮次与 transport device 绑定、同轮多 assistant 的保序成组重锚、截断回声的权威时间吸收、hard remove 的 transport-owned 临时状态回收、stale/current 同 session 隔离、同一 persistId 的 streaming assembly transport 隔离、per-identity ownership、soft-offline ownership 保留、stale indexed replacement transport 保护与持久化 replay ownership 隔离、权威重连窗口的多 cohort 顺序与歧义保护、canonical current/stale replay 的 clientId 迁移前与 done 后 ownership 保护，以及常开 mVCP 的 settle 感知；持久化数据、协议、Desktop 均不受影响
- 本次反馈风险控制：截断窗口在无法证明覆盖会话起点时保守不消费 pending identity；仅权威 host 消息可在内容相同时退休身份，实时 transport replay 不改变生命周期
- 断线恢复故障半径：触发条件是单个受控设备的短暂离线；修复动作仅保留该设备会话尚未落盘 / 待重锚回复的本地身份，并忽略已知旧轮次 user 对当前回复的重锚，不改变 relay 连接、重试、重放或任何 peer 的链路状态，因此无跨 peer 恢复动作
- 防回归护栏：校验循环沿用冷启动同款有界重试/放弃语义，尊重防振荡断路器与用户上翻解锁，卸载与切会话时取消；普通 data/size 变化只延长 120ms 安静窗且总等待仍受 2.5s 上限约束，不会重新引入 2026-07 的 onScroll 洪泛问题
- 回滚 / 降级方式：回退本 commit 即恢复原行为；两处修复相互独立，可单独回退

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)