### PR TITLE
fix(desktop): 修复输入框推荐提示词生命周期

### DIFF
--- a/apps/desktop/src/main/maker-ipc/__tests__/predictPromptIpcBoundary.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/predictPromptIpcBoundary.test.ts
@@ -10,11 +10,18 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const h = vi.hoisted(() => ({
   handlers: new Map<string, (...args: unknown[]) => unknown>(),
   trusted: true,
-  predict: vi.fn(async (_params: unknown) => '下一步做什么'),
+  predict: vi.fn(async (params: unknown): Promise<string | null> => {
+    void params;
+    return '下一步做什么';
+  }),
   drainPersistQueue: vi.fn<() => Promise<void>>(async () => undefined),
   /** 模拟 DB 读出的最近 user/assistant 素材(来源:latestMessageText.regenerateTitleMaterial)。 */
   regenerateMaterial: vi.fn(
-    async (_sessionId: string, _limit: number, _latestTurnIsInFlight?: boolean | (() => boolean)) => {
+    async (
+      _sessionId: string,
+      _limit: number,
+      _latestTurnIsInFlight?: boolean | (() => boolean),
+    ) => {
       void _sessionId;
       void _limit;
       void _latestTurnIsInFlight;
@@ -28,9 +35,37 @@ const h = vi.hoisted(() => ({
     },
   ),
   /** 模拟 DB 返回的 session row */
-  sessionRow: { remoteHostId: null, agentKind: null, updatedAt: 1 } as { remoteHostId: string | null; source?: string | null; agentKind: string | null; workingDir?: string | null; status?: string | null; updatedAt?: number } | undefined,
+  sessionRow: {
+    remoteHostId: null,
+    agentKind: null,
+    updatedAt: 1,
+    activeTurnStartedAt: 1,
+    lastTurnEndedAt: 2,
+  } as
+    | {
+        remoteHostId: string | null;
+        source?: string | null;
+        agentKind: string | null;
+        workingDir?: string | null;
+        status?: string | null;
+        updatedAt?: number;
+        activeTurnStartedAt?: number | null;
+        lastTurnEndedAt?: number | null;
+      }
+    | undefined,
   /** 模拟 DB 第二次读取(排空落盘队列之后)返回的 session row;用于「drain 期间被删除」竞态测试。 */
-  sessionRowAfterDrain: undefined as { remoteHostId: string | null; source?: string | null; agentKind: string | null; workingDir?: string | null; status?: string | null; updatedAt?: number } | undefined,
+  sessionRowAfterDrain: undefined as
+    | {
+        remoteHostId: string | null;
+        source?: string | null;
+        agentKind: string | null;
+        workingDir?: string | null;
+        status?: string | null;
+        updatedAt?: number;
+        activeTurnStartedAt?: number | null;
+        lastTurnEndedAt?: number | null;
+      }
+    | undefined,
   /** DB 读取次数计数(区分 drain 前后的两次读取)。 */
   dbReads: 0,
 }));
@@ -51,8 +86,19 @@ vi.mock('electron', () => ({
     getPath: () => '/tmp/xdt-maker-vitest-electron',
     isReady: () => true,
     whenReady: async () => undefined,
-    commandLine: { appendSwitch: () => undefined, appendArgument: () => undefined, hasSwitch: () => false, getSwitchValue: () => '' },
-    dock: { setBadge: () => undefined, bounce: () => 0, cancelBounce: () => undefined, hide: () => undefined, show: async () => undefined },
+    commandLine: {
+      appendSwitch: () => undefined,
+      appendArgument: () => undefined,
+      hasSwitch: () => false,
+      getSwitchValue: () => '',
+    },
+    dock: {
+      setBadge: () => undefined,
+      bounce: () => 0,
+      cancelBounce: () => undefined,
+      hide: () => undefined,
+      show: async () => undefined,
+    },
     getName: () => 'XDMaker Test',
     getVersion: () => '0.0.0-test',
     setName: () => undefined,
@@ -110,17 +156,40 @@ vi.mock('electron', () => ({
   nativeTheme: { shouldUseDarkColors: false, themeSource: 'system' },
   powerMonitor: { getSystemIdleTime: () => 0, getSystemIdleState: () => 'active' },
   screen: {
-    getPrimaryDisplay: () => ({ id: 1, bounds: { x: 0, y: 0, width: 1024, height: 768 }, workArea: { x: 0, y: 0, width: 1024, height: 768 }, scaleFactor: 1 }),
+    getPrimaryDisplay: () => ({
+      id: 1,
+      bounds: { x: 0, y: 0, width: 1024, height: 768 },
+      workArea: { x: 0, y: 0, width: 1024, height: 768 },
+      scaleFactor: 1,
+    }),
     getAllDisplays: () => [],
-    getDisplayNearestPoint: () => ({ id: 1, bounds: { x: 0, y: 0, width: 1024, height: 768 }, workArea: { x: 0, y: 0, width: 1024, height: 768 }, scaleFactor: 1 }),
-    getDisplayMatching: () => ({ id: 1, bounds: { x: 0, y: 0, width: 1024, height: 768 }, workArea: { x: 0, y: 0, width: 1024, height: 768 }, scaleFactor: 1 }),
+    getDisplayNearestPoint: () => ({
+      id: 1,
+      bounds: { x: 0, y: 0, width: 1024, height: 768 },
+      workArea: { x: 0, y: 0, width: 1024, height: 768 },
+      scaleFactor: 1,
+    }),
+    getDisplayMatching: () => ({
+      id: 1,
+      bounds: { x: 0, y: 0, width: 1024, height: 768 },
+      workArea: { x: 0, y: 0, width: 1024, height: 768 },
+      scaleFactor: 1,
+    }),
     getCursorScreenPoint: () => ({ x: 0, y: 0 }),
   },
   BrowserWindow: class {
-    static getAllWindows() { return []; }
-    static getFocusedWindow() { return null; }
-    static fromWebContents() { return null; }
-    static fromId() { return null; }
+    static getAllWindows() {
+      return [];
+    }
+    static getFocusedWindow() {
+      return null;
+    }
+    static fromWebContents() {
+      return null;
+    }
+    static fromId() {
+      return null;
+    }
   },
   session: {
     defaultSession: { protocol: { registerSchemesAsPrivileged: () => undefined } },
@@ -137,9 +206,20 @@ vi.mock('electron', () => ({
     getUserDefault: () => undefined,
     setUserDefault: () => undefined,
   },
-  globalShortcut: { register: () => true, registerAll: () => undefined, isRegistered: () => false, unregister: () => undefined, unregisterAll: () => undefined },
+  globalShortcut: {
+    register: () => true,
+    registerAll: () => undefined,
+    isRegistered: () => false,
+    unregister: () => undefined,
+    unregisterAll: () => undefined,
+  },
   webContents: { fromId: () => null, fromFrame: () => null, getAllWebContents: () => [] },
-  crashReporter: { start: () => undefined, addExtraParameter: () => undefined, removeExtraParameter: () => undefined, getParameters: () => ({}) },
+  crashReporter: {
+    start: () => undefined,
+    addExtraParameter: () => undefined,
+    removeExtraParameter: () => undefined,
+    getParameters: () => ({}),
+  },
   nativeImage: {
     createEmpty: () => nativeImageEmpty(),
     createFromPath: () => nativeImageEmpty(),
@@ -158,7 +238,9 @@ vi.mock('electron', () => ({
     getApplicationMenu: () => null,
   },
   Notification: class {
-    static isSupported() { return true; }
+    static isSupported() {
+      return true;
+    }
     show() {}
     close() {}
   },
@@ -177,7 +259,9 @@ vi.mock('../../localDb/client/current.js', () => ({
               h.dbReads >= 2 && h.sessionRowAfterDrain !== undefined
                 ? h.sessionRowAfterDrain
                 : h.sessionRow;
-            return Promise.resolve([row].filter(Boolean));
+            return Promise.resolve(
+              row ? [{ activeTurnStartedAt: 1, lastTurnEndedAt: 2, ...row }] : [],
+            );
           },
         }),
       }),
@@ -202,7 +286,12 @@ vi.mock('../../security/trustedAppRenderer.js', () => ({
   },
 }));
 
-import { registerMakerTitleIpc } from '../title.js';
+import { _resetPromptPredictionCacheForTests, registerMakerTitleIpc } from '../title.js';
+import {
+  clearPromptPredictionSessionStopped,
+  notePromptPredictionSessionStopped,
+  resetPromptPredictionStopLedgerForTests,
+} from '../promptPredictionStopLedger.js';
 
 const EVENT = {} as Electron.IpcMainInvokeEvent;
 
@@ -212,19 +301,28 @@ function invokePredict(request: unknown): Promise<unknown> {
   return Promise.resolve(handler(EVENT, request));
 }
 
-/** 合法的 predict-prompt payload: sessionId + agentKind + turnGen(素材由 main 从 DB 读取)。 */
+/** 合法 payload：完成 revision 由 renderer live ledger 提供，素材由 main 从 DB 读取。 */
 const VALID_REQUEST = {
   sessionId: 'session-1',
   agentKind: 'claude-code',
   turnGen: 0,
+  completionRevision: 2,
 };
 
 beforeEach(() => {
   vi.clearAllMocks();
   h.handlers.clear();
   h.trusted = true;
-  h.sessionRow = { remoteHostId: null, agentKind: 'cc', updatedAt: 1 };
+  h.sessionRow = {
+    remoteHostId: null,
+    agentKind: 'cc',
+    updatedAt: 1,
+    activeTurnStartedAt: 1,
+    lastTurnEndedAt: 2,
+  };
   h.sessionRowAfterDrain = undefined;
+  _resetPromptPredictionCacheForTests();
+  resetPromptPredictionStopLedgerForTests();
   h.dbReads = 0;
   h.predict.mockResolvedValue('下一步做什么');
   registerMakerTitleIpc();
@@ -262,6 +360,10 @@ describe('maker:predict-prompt — payload 运行期校验', () => {
     ['turnGen 非数字', { sessionId: 's1', agentKind: 'claude-code', turnGen: 'abc' }],
     ['turnGen 负数', { sessionId: 's1', agentKind: 'claude-code', turnGen: -1 }],
     ['turnGen NaN', { sessionId: 's1', agentKind: 'claude-code', turnGen: NaN }],
+    ['缺 completionRevision', { sessionId: 's1', agentKind: 'claude-code', turnGen: 0 }],
+    ['completionRevision 非数字', { ...VALID_REQUEST, completionRevision: 'abc' }],
+    ['completionRevision 非整数', { ...VALID_REQUEST, completionRevision: 1.5 }],
+    ['completionRevision 非正数', { ...VALID_REQUEST, completionRevision: 0 }],
   ])('%s → INVALID_PARAMS 且不调用付费模型', async (_label, payload) => {
     await expect(invokePredict(payload)).rejects.toThrow(/INVALID_PARAMS/);
     expect(h.predict).not.toHaveBeenCalled();
@@ -270,9 +372,8 @@ describe('maker:predict-prompt — payload 运行期校验', () => {
   it('素材从 DB 读取,不采用 renderer 上报的 messages / workingDir', async () => {
     h.sessionRow = { remoteHostId: null, agentKind: 'pi', workingDir: '/db/workdir', updatedAt: 1 };
     await invokePredict({
-      sessionId: 'session-1',
+      ...VALID_REQUEST,
       agentKind: 'pi',
-      turnGen: 0,
       // 受信 renderer 或 stale UI 可能上报其它会话转写 / 伪造 workdir,应被忽略
       messages: [{ role: 'user', content: '外部注入的伪造内容' }],
       workingDir: '/spoofed/path',
@@ -308,6 +409,43 @@ describe('maker:predict-prompt — DB 防御纵深(远程会话拒绝)', () => {
     expect(h.predict).not.toHaveBeenCalled();
   });
 
+  it('completionRevision 与 DB lastTurnEndedAt 不一致时不调用付费模型', async () => {
+    h.sessionRow = {
+      remoteHostId: null,
+      agentKind: 'cc',
+      updatedAt: 1,
+      activeTurnStartedAt: 1,
+      lastTurnEndedAt: 3,
+    };
+
+    await expect(invokePredict(VALID_REQUEST)).resolves.toEqual({ prompt: null });
+    expect(h.predict).not.toHaveBeenCalled();
+  });
+
+  it('完成后同毫秒开始新 turn 时也不返回旧轮推荐', async () => {
+    h.sessionRow = {
+      remoteHostId: null,
+      agentKind: 'cc',
+      updatedAt: 2,
+      activeTurnStartedAt: 2,
+      lastTurnEndedAt: 2,
+    };
+
+    await expect(invokePredict(VALID_REQUEST)).resolves.toEqual({ prompt: null });
+    expect(h.predict).not.toHaveBeenCalled();
+  });
+
+  it('Main 记录显式 Stop 后所有窗口与 Device Link 请求都跳过预测，下一 turn 可清除', async () => {
+    notePromptPredictionSessionStopped('session-1');
+
+    await expect(invokePredict(VALID_REQUEST)).resolves.toEqual({ prompt: null });
+    expect(h.predict).not.toHaveBeenCalled();
+
+    clearPromptPredictionSessionStopped('session-1');
+    await expect(invokePredict(VALID_REQUEST)).resolves.toEqual({ prompt: '下一步做什么' });
+    expect(h.predict).toHaveBeenCalledTimes(1);
+  });
+
   it('本地 session(remoteHostId=null, agentKind 匹配)正常执行预测', async () => {
     h.sessionRow = { remoteHostId: null, agentKind: 'cc', updatedAt: 1 };
 
@@ -334,7 +472,12 @@ describe('maker:predict-prompt — DB 防御纵深(远程会话拒绝)', () => {
     // 第一次读取(drain 前)返回合法本地 session;排空落盘队列后第二次读取返回已删除状态,
     // 覆盖 TOCTOU 竞态:drain 前的 status 检查过期后,必须在素材物化/调用 provider 前重新校验。
     h.sessionRow = { remoteHostId: null, agentKind: 'cc', updatedAt: 1 };
-    h.sessionRowAfterDrain = { remoteHostId: null, agentKind: 'cc', status: 'deleted', updatedAt: 1 };
+    h.sessionRowAfterDrain = {
+      remoteHostId: null,
+      agentKind: 'cc',
+      status: 'deleted',
+      updatedAt: 1,
+    };
 
     await expect(invokePredict(VALID_REQUEST)).resolves.toEqual({ prompt: null });
     expect(h.predict).not.toHaveBeenCalled();
@@ -353,63 +496,115 @@ describe('maker:predict-prompt — DB 防御纵深(远程会话拒绝)', () => {
   });
 });
 
-describe('maker:predict-prompt — 多窗口去重', () => {
-  it('同一 session 同一 updatedAt 并发调用时第二个请求直接返回 null,避免重复付费', async () => {
-    // 让第一次预测暂挂,模拟并发
+describe('maker:predict-prompt — 多窗口同轮幂等', () => {
+  it('同一 session 同一 completion revision 并发时共享 Promise 和结果', async () => {
     let resolveFirst!: (value: string) => void;
     h.predict.mockImplementationOnce(
-      () => new Promise<string>((resolve) => { resolveFirst = resolve; }),
+      () =>
+        new Promise<string>((resolve) => {
+          resolveFirst = resolve;
+        }),
     );
 
-    // 发起两个并发调用(同一 turnGen)
     const first = invokePredict(VALID_REQUEST);
-    // 等第一个进入 handler 并标记 _predictingPromptSessions
     await vi.waitFor(() => expect(h.predict).toHaveBeenCalledTimes(1));
+    const second = invokePredict({ ...VALID_REQUEST, turnGen: 9 });
 
-    const second = invokePredict(VALID_REQUEST);
-    await expect(second).resolves.toEqual({ prompt: null });
-
-    // 第一个完成
     resolveFirst('预测结果');
     await expect(first).resolves.toEqual({ prompt: '预测结果' });
+    await expect(second).resolves.toEqual({ prompt: '预测结果' });
+    expect(h.predict).toHaveBeenCalledTimes(1);
   });
 
-  it('同一 session 新 updatedAt 的请求替换旧请求（旧轮结果终将被 renderer turnGen 校验丢弃）', async () => {
+  it('同一 completion revision 结算后即使 updatedAt 因非轮次字段变化也复用结果', async () => {
+    await expect(invokePredict(VALID_REQUEST)).resolves.toEqual({ prompt: '下一步做什么' });
+    h.sessionRow = {
+      remoteHostId: null,
+      agentKind: 'cc',
+      updatedAt: 9,
+      activeTurnStartedAt: 1,
+      lastTurnEndedAt: 2,
+    };
+    await expect(invokePredict({ ...VALID_REQUEST, turnGen: 3 })).resolves.toEqual({
+      prompt: '下一步做什么',
+    });
+
+    expect(h.predict).toHaveBeenCalledTimes(1);
+  });
+
+  it('同一 completion revision 改过 workingDir 后不复用旧目录上下文', async () => {
+    h.sessionRow = {
+      remoteHostId: null,
+      agentKind: 'cc',
+      workingDir: '/project-a',
+      updatedAt: 1,
+      activeTurnStartedAt: 1,
+      lastTurnEndedAt: 2,
+    };
+    await expect(invokePredict(VALID_REQUEST)).resolves.toEqual({ prompt: '下一步做什么' });
+
+    h.sessionRow = {
+      ...h.sessionRow,
+      workingDir: '/project-b',
+      updatedAt: 2,
+    };
+    await expect(invokePredict({ ...VALID_REQUEST, turnGen: 3 })).resolves.toEqual({
+      prompt: null,
+    });
+    expect(h.predict).toHaveBeenCalledTimes(1);
+  });
+
+  it('新 completion revision 即使 updatedAt 相同也允许新预测，旧结果不覆盖新缓存', async () => {
     let resolveFirst!: (value: string) => void;
     h.predict.mockImplementationOnce(
-      () => new Promise<string>((resolve) => { resolveFirst = resolve; }),
+      () =>
+        new Promise<string>((resolve) => {
+          resolveFirst = resolve;
+        }),
     );
 
-    // 发起 updatedAt=1 的预测并暂挂
     const first = invokePredict(VALID_REQUEST);
     await vi.waitFor(() => expect(h.predict).toHaveBeenCalledTimes(1));
 
-    // 同一 session 发起 updatedAt=2 的新预测（模拟新轮次更新了 session.updatedAt），
-    // 应替换旧条目并允许通过。旧请求结果终将被 renderer 端 turnGen 校验丢弃，不再阻塞新轮。
-    h.sessionRow = { remoteHostId: null, agentKind: 'cc', updatedAt: 2 };
+    h.sessionRow = {
+      remoteHostId: null,
+      agentKind: 'cc',
+      updatedAt: 1,
+      activeTurnStartedAt: 2,
+      lastTurnEndedAt: 3,
+    };
     let resolveSecond!: (value: string) => void;
     h.predict.mockImplementationOnce(
-      () => new Promise<string>((resolve) => { resolveSecond = resolve; }),
+      () =>
+        new Promise<string>((resolve) => {
+          resolveSecond = resolve;
+        }),
     );
     const second = invokePredict({
       ...VALID_REQUEST,
       turnGen: 1,
+      completionRevision: 3,
     });
     await vi.waitFor(() => expect(h.predict).toHaveBeenCalledTimes(2));
 
-    // 旧预测完成，去重条目已被新请求替换
     resolveFirst('旧轮预测');
     await expect(first).resolves.toEqual({ prompt: '旧轮预测' });
-
-    // 新预测完成
     resolveSecond('新轮预测');
     await expect(second).resolves.toEqual({ prompt: '新轮预测' });
+
+    await expect(
+      invokePredict({ ...VALID_REQUEST, turnGen: 2, completionRevision: 3 }),
+    ).resolves.toEqual({ prompt: '新轮预测' });
+    expect(h.predict).toHaveBeenCalledTimes(2);
   });
 
   it('不同 session 可以并发预测', async () => {
     let resolveFirst!: (value: string) => void;
     h.predict.mockImplementationOnce(
-      () => new Promise<string>((resolve) => { resolveFirst = resolve; }),
+      () =>
+        new Promise<string>((resolve) => {
+          resolveFirst = resolve;
+        }),
     );
 
     const first = invokePredict(VALID_REQUEST);
@@ -425,32 +620,14 @@ describe('maker:predict-prompt — 多窗口去重', () => {
     await expect(first).resolves.toEqual({ prompt: '预测结果A' });
   });
 
-  it('同一 session 不同 updatedAt 的请求也允许通过（renderer 端 turnGen 校验兜底）', async () => {
-    let resolveFirst!: (value: string) => void;
-    h.predict.mockImplementationOnce(
-      () => new Promise<string>((resolve) => { resolveFirst = resolve; }),
-    );
+  it('同一 completion revision 的 null 结果也缓存，避免反复付费重试', async () => {
+    h.predict.mockResolvedValueOnce(null);
 
-    // 窗口 A 发起 updatedAt=1 的预测并暂挂
-    const first = invokePredict({ ...VALID_REQUEST, turnGen: 5 });
-    await vi.waitFor(() => expect(h.predict).toHaveBeenCalledTimes(1));
+    await expect(invokePredict(VALID_REQUEST)).resolves.toEqual({ prompt: null });
+    await expect(invokePredict({ ...VALID_REQUEST, turnGen: 8 })).resolves.toEqual({
+      prompt: null,
+    });
 
-    // 窗口 B 发起 updatedAt=2 的预测（新轮次，updatedAt 已更新）。
-    // 不同 updatedAt 允许通过，入口不比对大小；renderer 端 turnGen 校验兜底。
-    h.sessionRow = { remoteHostId: null, agentKind: 'cc', updatedAt: 2 };
-    let resolveSecond!: (value: string) => void;
-    h.predict.mockImplementationOnce(
-      () => new Promise<string>((resolve) => { resolveSecond = resolve; }),
-    );
-    const second = invokePredict({ ...VALID_REQUEST, turnGen: 3 });
-    await vi.waitFor(() => expect(h.predict).toHaveBeenCalledTimes(2));
-
-    // 窗口 A 的预测完成
-    resolveFirst('预测结果A');
-    await expect(first).resolves.toEqual({ prompt: '预测结果A' });
-
-    // 窗口 B 的预测完成
-    resolveSecond('预测结果B');
-    await expect(second).resolves.toEqual({ prompt: '预测结果B' });
+    expect(h.predict).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/desktop/src/main/maker-ipc/__tests__/promptPredictionRevision.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/promptPredictionRevision.test.ts
@@ -1,0 +1,177 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const h = vi.hoisted(() => ({
+  rows: [] as Array<{
+    agentKind: string | null;
+    status: string | null;
+    source: string | null;
+    remoteHostId: string | null;
+    providerId: string | null;
+    workingDir: string | null;
+    updatedAt: number;
+    activeTurnStartedAt: number | null;
+    lastTurnEndedAt: number | null;
+  }>,
+  dbReads: 0,
+  beforeDispatchCalls: 0,
+  providers: [{ id: 'provider-1' }],
+  resolvedProviderId: 'provider-1',
+  afterDispatch: null as null | (() => void),
+}));
+
+vi.mock('../../logger.js', () => ({
+  createLogger: () => ({ debug: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+
+vi.mock('../../i18n.js', () => ({
+  getResolvedMainLocale: () => 'zh-CN',
+}));
+
+vi.mock('../../localDb/client/current.js', () => ({
+  getDbClient: () => ({
+    drizzle: {
+      select: () => ({
+        from: () => ({
+          where: () => ({
+            limit: async () => {
+              const row = h.rows[Math.min(h.dbReads, h.rows.length - 1)];
+              h.dbReads += 1;
+              return row ? [row] : [];
+            },
+          }),
+        }),
+      }),
+    },
+  }),
+}));
+
+vi.mock('../../maker-host/createDesktopProviderService.js', () => ({
+  getDesktopProviderService: () => ({
+    listProviders: async () => h.providers,
+  }),
+}));
+
+vi.mock('@cindy/model-providers', () => ({
+  connectedProvidersForAgent: (providers: unknown[]) => providers,
+  nativeDefaultSourceId: () => 'provider-1',
+}));
+
+vi.mock('../../maker-host/title-one-shot.js', () => ({
+  buildTitleTarget: (providerId: string) =>
+    providerId === 'provider-1' || providerId === 'xd' ? { providerId } : null,
+  generateTitleViaProviderResult: async (
+    request: { sessionId: string; agentKind: string },
+    deps: {
+      beforeDispatch?: (input: {
+        sessionId: string;
+        agentKind: string;
+        providerId: string;
+      }) => Promise<boolean>;
+    },
+  ) => {
+    h.beforeDispatchCalls += 1;
+    const allowed = await deps.beforeDispatch?.({
+      sessionId: request.sessionId,
+      agentKind: request.agentKind,
+      providerId: h.resolvedProviderId,
+    });
+    if (allowed) h.afterDispatch?.();
+    return allowed ? { status: 'ok', title: '继续补测试' } : { status: 'aborted', title: null };
+  },
+}));
+
+import { generatePromptPrediction } from '../promptPrediction.js';
+import {
+  notePromptPredictionSessionStopped,
+  resetPromptPredictionStopLedgerForTests,
+} from '../promptPredictionStopLedger.js';
+
+const VALID_ROW = {
+  agentKind: 'cc',
+  status: 'active',
+  source: null,
+  remoteHostId: null,
+  providerId: 'provider-1',
+  workingDir: 'E:\\project',
+  updatedAt: 10,
+  activeTurnStartedAt: 100,
+  lastTurnEndedAt: 200,
+};
+
+function predict(): Promise<string | null> {
+  return generatePromptPrediction({
+    sessionId: 'session-1',
+    agentKind: 'claude-code',
+    messages: [
+      { role: 'user', content: '实现这个功能' },
+      { role: 'assistant', content: '已经完成实现' },
+    ],
+    workingDir: 'E:\\project',
+    materialDrainUpdatedAt: 10,
+    completionRevision: 200,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.dbReads = 0;
+  h.beforeDispatchCalls = 0;
+  h.providers = [{ id: 'provider-1' }];
+  h.resolvedProviderId = 'provider-1';
+  h.afterDispatch = null;
+  h.rows = [{ ...VALID_ROW }, { ...VALID_ROW }];
+  resetPromptPredictionStopLedgerForTests();
+});
+
+describe('prompt prediction completion revision guard', () => {
+  it('provider 派发紧前两次复核都匹配时允许预测', async () => {
+    await expect(predict()).resolves.toBe('继续补测试');
+    expect(h.beforeDispatchCalls).toBe(1);
+    expect(h.dbReads).toBe(2);
+  });
+
+  it('显式 custom provider 没有 title wire 时允许回落官方 xd', async () => {
+    h.providers = [{ id: 'custom:deepseek' }, { id: 'xd' }];
+    h.resolvedProviderId = 'xd';
+    h.rows = [
+      { ...VALID_ROW, providerId: 'custom:deepseek' },
+      { ...VALID_ROW, providerId: 'custom:deepseek' },
+    ];
+
+    await expect(predict()).resolves.toBe('继续补测试');
+    expect(h.beforeDispatchCalls).toBe(1);
+    expect(h.dbReads).toBe(2);
+  });
+
+  it('provider 派发紧前观察到 Main 显式 Stop 时中止', async () => {
+    notePromptPredictionSessionStopped('session-1');
+
+    await expect(predict()).resolves.toBeNull();
+    expect(h.beforeDispatchCalls).toBe(1);
+    expect(h.dbReads).toBe(1);
+  });
+
+  it('provider 请求已发出后发生 Stop 时丢弃返回值', async () => {
+    h.afterDispatch = () => notePromptPredictionSessionStopped('session-1');
+
+    await expect(predict()).resolves.toBeNull();
+    expect(h.beforeDispatchCalls).toBe(1);
+    expect(h.dbReads).toBe(2);
+  });
+
+  it('首次复核发现 completion revision 已变化时中止付费派发', async () => {
+    h.rows = [{ ...VALID_ROW, lastTurnEndedAt: 201 }];
+
+    await expect(predict()).resolves.toBeNull();
+    expect(h.beforeDispatchCalls).toBe(1);
+    expect(h.dbReads).toBe(1);
+  });
+
+  it('异步 provider 检查期间同毫秒启动新 turn 时，终末复核中止派发', async () => {
+    h.rows = [{ ...VALID_ROW }, { ...VALID_ROW, activeTurnStartedAt: 200 }];
+
+    await expect(predict()).resolves.toBeNull();
+    expect(h.beforeDispatchCalls).toBe(1);
+    expect(h.dbReads).toBe(2);
+  });
+});

--- a/apps/desktop/src/main/maker-ipc/__tests__/promptPredictionStopLedger.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/promptPredictionStopLedger.test.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from 'node:fs';
+
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  clearPromptPredictionSessionStopped,
+  notePromptPredictionSessionStopped,
+  resetPromptPredictionStopLedgerForTests,
+  wasPromptPredictionSessionStopped,
+} from '../promptPredictionStopLedger.js';
+
+const REGISTER_SOURCE = readFileSync(new URL('../register.ts', import.meta.url), 'utf8');
+
+beforeEach(() => {
+  resetPromptPredictionStopLedgerForTests();
+});
+
+describe('prompt prediction explicit Stop ledger', () => {
+  it('记录 Stop 并只由下一真实 turn 清除', () => {
+    notePromptPredictionSessionStopped('session-1');
+    expect(wasPromptPredictionSessionStopped('session-1')).toBe(true);
+
+    clearPromptPredictionSessionStopped('session-1');
+    expect(wasPromptPredictionSessionStopped('session-1')).toBe(false);
+  });
+
+  it('INPUT_STOP 在 abort 前记账，中央 turn-start 边界负责清除', () => {
+    const stopHandlerAt = REGISTER_SOURCE.indexOf('ipcMain.handle(MAKER_INVOKE.INPUT_STOP');
+    const noteAt = REGISTER_SOURCE.indexOf('notePromptPredictionSessionStopped(sid);', stopHandlerAt);
+    const abortAt = REGISTER_SOURCE.indexOf('inputCoordinator.stop(', stopHandlerAt);
+    const clearAt = REGISTER_SOURCE.indexOf('clearPromptPredictionSessionStopped(session.id);');
+    const turnStartAt = REGISTER_SOURCE.indexOf('markSessionTurnStarted(session.id);', clearAt);
+
+    expect(stopHandlerAt).toBeGreaterThanOrEqual(0);
+    expect(noteAt).toBeGreaterThan(stopHandlerAt);
+    expect(noteAt).toBeLessThan(abortAt);
+    expect(clearAt).toBeGreaterThanOrEqual(0);
+    expect(clearAt).toBeLessThan(turnStartAt);
+  });
+});

--- a/apps/desktop/src/main/maker-ipc/promptPrediction.ts
+++ b/apps/desktop/src/main/maker-ipc/promptPrediction.ts
@@ -17,12 +17,20 @@ import type { AgentKind } from '@cindy/maker-core';
 import { dbToMakerAgentKind } from '../../shared/agentKindConversion.js';
 import { getResolvedMainLocale } from '../i18n.js';
 import { getDesktopProviderService } from '../maker-host/createDesktopProviderService.js';
-import { generateTitleViaProviderResult } from '../maker-host/title-one-shot.js';
-import { connectedProvidersForAgent, nativeDefaultSourceId, type ProviderView } from '@cindy/model-providers';
+import {
+  buildTitleTarget,
+  generateTitleViaProviderResult,
+} from '../maker-host/title-one-shot.js';
+import {
+  connectedProvidersForAgent,
+  nativeDefaultSourceId,
+  type ProviderView,
+} from '@cindy/model-providers';
 import { eq } from 'drizzle-orm';
 import { getDbClient } from '../localDb/client/current.js';
 import { sessions } from '../localDb/schema.js';
 import { createLogger } from '../logger.js';
+import { wasPromptPredictionSessionStopped } from './promptPredictionStopLedger.js';
 
 const log = createLogger('maker-ipc/prompt-prediction');
 
@@ -40,13 +48,8 @@ type SlimMessage = { role: string; content: string };
  * 从对话历史里提取最近几轮 user↔assistant 配对,截断后拼接成 prompt 素材。
  * 跳过 tool_use / tool_result / thinking / error / system 等非对话角色。
  */
-function buildConversationContext(
-  messages: SlimMessage[],
-  maxPairs: number,
-): string {
-  const conversational = messages.filter(
-    (m) => m.role === 'user' || m.role === 'assistant',
-  );
+function buildConversationContext(messages: SlimMessage[], maxPairs: number): string {
+  const conversational = messages.filter((m) => m.role === 'user' || m.role === 'assistant');
   // 从末尾往前取 maxPairs*2 条(user+assistant)
   const recent = conversational.slice(-maxPairs * 2);
   if (recent.length === 0) return '';
@@ -61,7 +64,9 @@ function buildConversationContext(
       text.length <= maxChars
         ? text
         : m.role === 'assistant'
-          ? text.slice(0, Math.floor(maxChars * 0.4)) + ' … ' + text.slice(-Math.floor(maxChars * 0.6))
+          ? text.slice(0, Math.floor(maxChars * 0.4)) +
+            ' … ' +
+            text.slice(-Math.floor(maxChars * 0.6))
           : text.slice(0, maxChars);
     if (!truncated) continue;
     lines.push(`${m.role === 'user' ? 'User' : 'Assistant'}: ${truncated}`);
@@ -93,7 +98,9 @@ function buildPredictionPrompt(
     ja: "Match the user's language. The user types in Japanese.",
     ko: "Match the user's language. The user types in Korean.",
   };
-  const wdLine = workingDir ? `Current working directory: ${escapeReferenceData(workingDir)}` : null;
+  const wdLine = workingDir
+    ? `Current working directory: ${escapeReferenceData(workingDir)}`
+    : null;
 
   // 系统指令写入 Anthropic Messages API 顶层 system 字段（非 Anthropic wire 忽略），
   // 不混入 user message，避免被 Anthropic API 拒绝。
@@ -143,9 +150,7 @@ async function readSessionProviderIdFromDb(sessionId: string): Promise<string | 
 }
 
 /** 某 agent 下已连接的供应商视图列表。失败 → []。 */
-async function listConnectedProvidersForAgent(
-  agentKind: AgentKind,
-): Promise<ProviderView[]> {
+async function listConnectedProvidersForAgent(agentKind: AgentKind): Promise<ProviderView[]> {
   try {
     const all = await getDesktopProviderService().listProviders({ allowSideEffects: true });
     return connectedProvidersForAgent(all, agentKind);
@@ -159,6 +164,8 @@ export interface PromptPredictionParams {
   agentKind: AgentKind;
   messages: SlimMessage[];
   workingDir?: string;
+  /** 本次预测对应的 sessions.lastTurnEndedAt，provider 派发紧前再次复核。 */
+  completionRevision: number;
   /** title.ts 中 readMaterial 之后捕获的 session.updatedAt,用于 beforeDispatch 终末复核。
    * 传入此参数后 generatePromptPrediction 不再重新从 DB 读取 drain 时 updatedAt,
    * 避免素材物化后、provider/凭证解析期间新消息落盘导致轮次变化未被检测。 */
@@ -258,6 +265,8 @@ export async function generatePromptPrediction(
               providerId: sessions.providerId,
               workingDir: sessions.workingDir,
               updatedAt: sessions.updatedAt,
+              activeTurnStartedAt: sessions.activeTurnStartedAt,
+              lastTurnEndedAt: sessions.lastTurnEndedAt,
             })
             .from(sessions)
             .where(eq(sessions.id, sessionId))
@@ -267,28 +276,33 @@ export async function generatePromptPrediction(
           if (row.source === 'review') return false;
           if (row.remoteHostId) return false;
           if (dbToMakerAgentKind(row.agentKind) !== agentKind) return false;
-          // 用已解析的 providerId(来自 generateTitleViaProviderResult 的
-          // 凭证解析口径)与当前 DB 的 providerId 比对。此前只比较两次 DB 读,
-          // 会话在 provider 解析后、beforeDispatch 前被切换 provider 时,
-          // 两次 DB 读都返回新值,比对通过,但凭证已用旧 provider 解析,
-          // 导致付费请求路由到过期 provider/账号。
-          if (row.providerId != null) {
-            if (row.providerId !== resolvedProviderId) return false;
-            // 额外复查：显式 provider 是否仍在已连接列表中。用户在凭证解析后
-            // 断开/登出该显式 provider 时，DB providerId 仍等于 resolvedProviderId，
-            // 但 connected-provider rail 已不含该 provider，继续派发会用过期凭证
-            // 外发付费调用。按 fail-closed 中止。
-            const providers = await listConnectedProvidersForAgent(agentKind);
-            if (!providers.some((p) => p.id === resolvedProviderId)) return false;
-          } else {
-            // provider_id 为 null 表示使用默认 provider。若用户在凭证解析后
-            // 断开/切换了默认 provider，resolvedProviderId 仍指向旧 provider，
-            // 继续派发会外发到过期 provider/账号。重新计算当前有效默认 provider
-            // 并与 resolvedProviderId 比对。
-            const providers = await listConnectedProvidersForAgent(agentKind);
-            const defaultProviderId = nativeDefaultSourceId(providers, agentKind);
-            if (!defaultProviderId || defaultProviderId !== resolvedProviderId) return false;
-          }
+          if (row.lastTurnEndedAt !== params.completionRevision) return false;
+          if (
+            row.activeTurnStartedAt != null &&
+            row.activeTurnStartedAt >= params.completionRevision
+          )
+            return false;
+          if (wasPromptPredictionSessionStopped(sessionId)) return false;
+          // 重新按 one-shot 同一口径解析当前有效来源。显式/默认来源若没有 title wire，
+          // generateTitleViaProviderResult 会回落已连接的官方 xd；这里必须比较「解析后的
+          // 实际来源」，不能拿 DB 原始 custom providerId 直接拒绝合法回落。
+          const providers = await listConnectedProvidersForAgent(agentKind);
+          const selectedProviderId =
+            row.providerId ?? nativeDefaultSourceId(providers, agentKind);
+          if (
+            !selectedProviderId ||
+            !providers.some((provider) => provider.id === selectedProviderId)
+          ) return false;
+          const officialFallbackAvailable =
+            providers.some((provider) => provider.id === 'xd') &&
+            buildTitleTarget('xd') != null;
+          const expectedResolvedProviderId =
+            buildTitleTarget(selectedProviderId) != null
+              ? selectedProviderId
+              : officialFallbackAvailable
+                ? 'xd'
+                : selectedProviderId;
+          if (expectedResolvedProviderId !== resolvedProviderId) return false;
           // 紧前复查 workingDir：用户在 provider/凭证解析期间切换了工作目录，
           // 此时 buildPredictionPrompt 已嵌入旧 params.workingDir，继续派发
           // 会向 provider 外发过期本地路径。按 fail-closed 中止。
@@ -306,6 +320,8 @@ export async function generatePromptPrediction(
               providerId: sessions.providerId,
               workingDir: sessions.workingDir,
               updatedAt: sessions.updatedAt,
+              activeTurnStartedAt: sessions.activeTurnStartedAt,
+              lastTurnEndedAt: sessions.lastTurnEndedAt,
             })
             .from(sessions)
             .where(eq(sessions.id, sessionId))
@@ -315,12 +331,16 @@ export async function generatePromptPrediction(
           if (finalRow.source === 'review') return false;
           if (finalRow.remoteHostId) return false;
           if (dbToMakerAgentKind(finalRow.agentKind) !== agentKind) return false;
-          if (finalRow.providerId != null && finalRow.providerId !== resolvedProviderId) return false;
-          // 会话在检查期间从显式 provider 切换到默认 provider（finalRow.providerId
-          // 为 null 但 row.providerId 非 null），resolvedProviderId 仍指向旧显式
-          // provider。此时无法再做异步 provider 解析（TOCTOU 最小化），按 fail-closed
-          // 中止，避免用旧 provider 凭证外发付费调用。
-          if (finalRow.providerId == null && row.providerId != null) return false;
+          if (finalRow.lastTurnEndedAt !== params.completionRevision) return false;
+          if (
+            finalRow.activeTurnStartedAt != null &&
+            finalRow.activeTurnStartedAt >= params.completionRevision
+          )
+            return false;
+          if (wasPromptPredictionSessionStopped(sessionId)) return false;
+          // provider/凭证 rail 已在上方按 fallback 口径复核；最后一个 await 后只需确认
+          // DB 原始选择没有再变化（含 explicit ↔ default），避免重开异步解析窗口。
+          if (finalRow.providerId !== row.providerId) return false;
           if (finalRow.workingDir !== (params.workingDir ?? null)) return false;
           // 终末复核消息轮次：与 drain 时的 updatedAt（provider/凭证解析之前捕获）比较。
           // 仅与 row.updatedAt（beforeDispatch 内首次 DB 读）比较无法检测到
@@ -342,5 +362,8 @@ export async function generatePromptPrediction(
       maxVisualChars: 140,
     },
   );
+  // HTTP 已经发出后仍可能收到其它窗口 / Device Link 的 Stop。费用无法撤回，但返回值
+  // 必须丢弃，不能在用户明确停止后把推荐重新显示到输入框。
+  if (wasPromptPredictionSessionStopped(params.sessionId)) return null;
   return result.status === 'ok' ? result.title : null;
 }

--- a/apps/desktop/src/main/maker-ipc/promptPredictionStopLedger.ts
+++ b/apps/desktop/src/main/maker-ipc/promptPredictionStopLedger.ts
@@ -1,0 +1,24 @@
+/**
+ * Main-owned explicit Stop ledger for prompt prediction.
+ *
+ * Every local/Device Link `maker:input:stop` passes through the same IPC handler, so this
+ * set is the cross-window authority. A real next turn clears the marker at the central
+ * maker-core turn-start boundary. Nothing is persisted across app restarts.
+ */
+const explicitlyStoppedSessions = new Set<string>();
+
+export function notePromptPredictionSessionStopped(sessionId: string): void {
+  if (sessionId) explicitlyStoppedSessions.add(sessionId);
+}
+
+export function clearPromptPredictionSessionStopped(sessionId: string): void {
+  explicitlyStoppedSessions.delete(sessionId);
+}
+
+export function wasPromptPredictionSessionStopped(sessionId: string): boolean {
+  return explicitlyStoppedSessions.has(sessionId);
+}
+
+export function resetPromptPredictionStopLedgerForTests(): void {
+  explicitlyStoppedSessions.clear();
+}

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -557,6 +557,10 @@ import { dbToMakerAgentKind, makerToDbAgentKind } from '../../shared/agentKindCo
 import { readWorkflowProgressForSession } from '../workflow-progress/reader.js';
 import { AgentInputCoordinator } from './agent-input-coordinator.js';
 import {
+  clearPromptPredictionSessionStopped,
+  notePromptPredictionSessionStopped,
+} from './promptPredictionStopLedger.js';
+import {
   estimateReferenceTokens,
   MAX_REFERENCE_MESSAGES,
   MAX_REFERENCE_TOKENS,
@@ -3891,6 +3895,7 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
             // 「疑似中断」纯读判定(设计总述见 localDb/sessionActiveTurn.ts 文件头)。
             // SSH remote 会话同样记录:session 行在本地 DB、事件流走本进程,只是
             // agent 跑在远端;device-link 被控会话不进本进程 maker-core,天然不经过。
+            clearPromptPredictionSessionStopped(session.id);
             markSessionTurnStarted(session.id);
           }
           if (
@@ -13154,6 +13159,9 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
   ipcMain.handle(MAKER_INVOKE.INPUT_STOP, async (_e, sessionId: unknown, opts?: unknown) => {
     const sid = requireSessionId(sessionId);
     await assertRemoteInputControlBoundary(sid, isDeviceLinkInvoke(), opts);
+    // Main 是本机窗口与 Device Link 控制端的 Stop 汇合点；先记账再触发 abort，
+    // 任何 renderer 后续请求推荐都会从同一 ledger fail-closed。
+    notePromptPredictionSessionStopped(sid);
     // 这三类续跑撤销都是同步操作，必须早于 goal/DB await；
     // 否则退避 timer 能在用户已点 Stop 后抢先发出下一轮。
     resetAutomaticRecoveryForExplicitStop(sid);

--- a/apps/desktop/src/main/maker-ipc/title.ts
+++ b/apps/desktop/src/main/maker-ipc/title.ts
@@ -51,6 +51,7 @@ import {
   type SessionAutoTitleResult,
 } from './sessionAutoTitle.js';
 import { generatePromptPrediction } from './promptPrediction.js';
+import { wasPromptPredictionSessionStopped } from './promptPredictionStopLedger.js';
 
 const log = createLogger('maker-ipc/title');
 
@@ -345,27 +346,30 @@ function parseAutoTitleRequest(raw: unknown): SessionAutoTitleRequest {
 /** 预测素材窗口:从 DB 读最近几条 user/assistant 消息(与 promptPrediction 的最近 3 轮配对对齐)。 */
 const PREDICTION_RECENT_MESSAGE_LIMIT = 6;
 
-/** 预测请求:仅 sessionId + agentKind + turnGen。素材(messages / workingDir)一律由 main 从 DB 读取,
- * 不信任 renderer 上报内容——受信 renderer 或 stale UI 可能携带其它会话转写 / 伪造 workdir,
- * 把非本会话内容送到本地 provider 触发付费调用。turnGen 仅用于 renderer 端结果校验
- * (丢弃旧轮过期结果),主进程级去重改用 DB 的 session.updatedAt(跨窗口一致)。 */
+/** 预测请求:素材(messages / workingDir)一律由 main 从 DB 读取，不信任 renderer 上报内容。
+ * completionRevision 来自本次运行期真实收到的 lastTurnEndedAt push，main 再与 DB 权威值
+ * 复核并作为跨窗口幂等键；turnGen 仅保留 renderer 侧请求代次。 */
 interface PredictPromptRequest {
   sessionId: string;
   agentKind: AgentKind;
   turnGen: number;
+  completionRevision: number;
 }
 
-/** 主进程级去重:同一 session 同一去重键同时只能有一笔预测在途,
- * 避免多窗口重复付费调用。使用 DB session.updatedAt + renderer turnGen 联合去重:
- * updatedAt 排队场景下相邻轮次可能相同,但 turnGen 逐轮递增,联合后可区分真重复与
- * 不同轮次。Map<sessionId, {updatedAt, turnGen}>——新轮会替换旧条目,不阻塞新轮预测。 */
-const _predictingPromptSessions = new Map<string, { updatedAt: number; turnGen: number }>();
+interface PromptPredictionCacheEntry {
+  revision: number;
+  workingDir: string | null;
+  promise: Promise<string | null>;
+}
+
+/** 每个 session 只保留最新完成轮的一笔 Promise/结果，进程重启自然清空。 */
+const _promptPredictionCache = new Map<string, PromptPredictionCacheEntry>();
 
 function parsePredictPromptRequest(raw: unknown): PredictPromptRequest {
   if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
     throwIpcError('INVALID_PARAMS', 'predict-prompt request must be a non-null object');
   }
-  const { sessionId, agentKind, turnGen } = raw as Record<string, unknown>;
+  const { sessionId, agentKind, turnGen, completionRevision } = raw as Record<string, unknown>;
   if (typeof sessionId !== 'string' || !sessionId || sessionId.length > SESSION_ID_MAX) {
     throwIpcError('INVALID_PARAMS', 'invalid or missing sessionId for predict-prompt');
   }
@@ -373,14 +377,186 @@ function parsePredictPromptRequest(raw: unknown): PredictPromptRequest {
     throwIpcError('INVALID_PARAMS', `invalid agentKind for predict-prompt: ${String(agentKind)}`);
   }
   if (typeof turnGen !== 'number' || !Number.isFinite(turnGen) || turnGen < 0) {
-    throwIpcError('INVALID_PARAMS', `invalid or missing turnGen for predict-prompt: ${String(turnGen)}`);
+    throwIpcError(
+      'INVALID_PARAMS',
+      `invalid or missing turnGen for predict-prompt: ${String(turnGen)}`,
+    );
   }
-  return { sessionId, agentKind: agentKind as AgentKind, turnGen };
+  if (
+    typeof completionRevision !== 'number' ||
+    !Number.isFinite(completionRevision) ||
+    !Number.isInteger(completionRevision) ||
+    completionRevision <= 0
+  ) {
+    throwIpcError(
+      'INVALID_PARAMS',
+      `invalid or missing completionRevision for predict-prompt: ${String(completionRevision)}`,
+    );
+  }
+  return {
+    sessionId,
+    agentKind: agentKind as AgentKind,
+    turnGen,
+    completionRevision,
+  };
+}
+
+/** Test-only reset: settled Promise 会跨 register 调用保留，单测需显式清理。 */
+export function _resetPromptPredictionCacheForTests(): void {
+  _promptPredictionCache.clear();
 }
 
 export interface RegisterMakerTitleIpcOptions {
   /** True from turn dispatch until terminal delivery, including status:false → done. */
   isSessionTurnPendingCompletion?: (sessionId: string) => boolean;
+}
+
+async function predictPromptForCompletedRevision(
+  request: PredictPromptRequest,
+  options: RegisterMakerTitleIpcOptions,
+): Promise<string | null> {
+  const { sessionId, agentKind, completionRevision } = request;
+  // 防御纵深：身份、来源、完成轮次都以 DB 为准。activeTurnStartedAt 不早于完成
+  // revision 表示下一轮已经启动（含同毫秒），即使命中缓存也不能返回上一轮推荐。
+  const [sessionRow] = await getDbClient()
+    .drizzle.select({
+      remoteHostId: sessions.remoteHostId,
+      source: sessions.source,
+      agentKind: sessions.agentKind,
+      workingDir: sessions.workingDir,
+      status: sessions.status,
+      updatedAt: sessions.updatedAt,
+      activeTurnStartedAt: sessions.activeTurnStartedAt,
+      lastTurnEndedAt: sessions.lastTurnEndedAt,
+    })
+    .from(sessions)
+    .where(eq(sessions.id, sessionId));
+  if (
+    !sessionRow ||
+    sessionRow.remoteHostId ||
+    sessionRow.source === 'review' ||
+    sessionRow.status === 'deleted' ||
+    sessionRow.lastTurnEndedAt !== completionRevision ||
+    (sessionRow.activeTurnStartedAt != null &&
+      sessionRow.activeTurnStartedAt >= completionRevision) ||
+    wasPromptPredictionSessionStopped(sessionId) ||
+    options.isSessionTurnPendingCompletion?.(sessionId) === true
+  ) {
+    return null;
+  }
+
+  const dbAgentKind = dbToMakerAgentKind(sessionRow.agentKind);
+  if (dbAgentKind !== agentKind) {
+    log.warn('predict-prompt agentKind mismatch — rejecting', {
+      sessionId,
+      rendererAgentKind: agentKind,
+      dbAgentKind,
+    });
+    return null;
+  }
+
+  const cached = _promptPredictionCache.get(sessionId);
+  if (cached?.revision === completionRevision) {
+    // workingDir 会进入模型 prompt；同轮改过目录后不能复用旧目录上下文的结果。
+    if (cached.workingDir !== (sessionRow.workingDir ?? null)) return null;
+    return cached.promise;
+  }
+  if (cached && cached.revision > completionRevision) {
+    return null;
+  }
+  if (cached) {
+    log.debug('predict-prompt replacing cached older completion', {
+      sessionId,
+      oldRevision: cached.revision,
+      newRevision: completionRevision,
+    });
+  }
+
+  const predictionPromise = (async () => {
+    // 先排空落盘队列，确保完成轮的终末 Assistant 已 durable；等待两侧都复查
+    // pending completion，避免下一轮已启动却把上一轮缓存成当前推荐。
+    const pendingCompletionBeforeDrain =
+      options.isSessionTurnPendingCompletion?.(sessionId) === true;
+    await drainPersistQueue();
+    let pendingCompletionObserved = pendingCompletionBeforeDrain;
+    const latestTurnIsPendingCompletion = (): boolean => {
+      if (!pendingCompletionObserved) {
+        pendingCompletionObserved = options.isSessionTurnPendingCompletion?.(sessionId) === true;
+      }
+      return pendingCompletionObserved;
+    };
+    if (latestTurnIsPendingCompletion()) return null;
+
+    const [latestSessionRow] = await getDbClient()
+      .drizzle.select({
+        remoteHostId: sessions.remoteHostId,
+        source: sessions.source,
+        status: sessions.status,
+        agentKind: sessions.agentKind,
+        workingDir: sessions.workingDir,
+        updatedAt: sessions.updatedAt,
+        activeTurnStartedAt: sessions.activeTurnStartedAt,
+        lastTurnEndedAt: sessions.lastTurnEndedAt,
+      })
+      .from(sessions)
+      .where(eq(sessions.id, sessionId));
+    if (
+      !latestSessionRow ||
+      latestSessionRow.remoteHostId ||
+      latestSessionRow.source === 'review' ||
+      latestSessionRow.status === 'deleted' ||
+      latestSessionRow.lastTurnEndedAt !== completionRevision ||
+      (latestSessionRow.activeTurnStartedAt != null &&
+        latestSessionRow.activeTurnStartedAt >= completionRevision) ||
+      wasPromptPredictionSessionStopped(sessionId)
+    ) {
+      return null;
+    }
+    if (latestSessionRow.updatedAt !== sessionRow.updatedAt) {
+      log.debug('predict-prompt session updated during drain — rejecting', { sessionId });
+      return null;
+    }
+    const latestDbAgentKind = dbToMakerAgentKind(latestSessionRow.agentKind);
+    if (latestDbAgentKind !== agentKind) {
+      log.warn('predict-prompt agentKind changed after drain — rejecting', {
+        sessionId,
+        rendererAgentKind: agentKind,
+        dbAgentKind: latestDbAgentKind,
+      });
+      return null;
+    }
+
+    const material = await regenerateTitleMaterial(
+      sessionId,
+      PREDICTION_RECENT_MESSAGE_LIMIT,
+      latestTurnIsPendingCompletion,
+    );
+    const messages = material.recent.map((message) => ({
+      role: message.role,
+      content: message.text,
+    }));
+    return generatePromptPrediction({
+      sessionId,
+      agentKind,
+      messages,
+      ...(latestSessionRow.workingDir ? { workingDir: latestSessionRow.workingDir } : {}),
+      materialDrainUpdatedAt: latestSessionRow.updatedAt,
+      completionRevision,
+    });
+  })().catch((error: unknown) => {
+    const current = _promptPredictionCache.get(sessionId);
+    if (current?.revision === completionRevision) {
+      _promptPredictionCache.delete(sessionId);
+    }
+    throw error;
+  });
+
+  _promptPredictionCache.set(sessionId, {
+    revision: completionRevision,
+    workingDir: sessionRow.workingDir ?? null,
+    promise: predictionPromise,
+  });
+  return predictionPromise;
 }
 
 export function registerMakerTitleIpc(options: RegisterMakerTitleIpcOptions = {}): void {
@@ -458,139 +634,16 @@ export function registerMakerTitleIpc(options: RegisterMakerTitleIpcOptions = {}
       request: unknown,
     ): Promise<{ prompt: string | null }> => {
       assertTrustedAppRendererEvent(event);
-      const { sessionId, agentKind, turnGen } = parsePredictPromptRequest(request);
+      const parsed = parsePredictPromptRequest(request);
       try {
-      // 防御纵深:即使 renderer 有 UI 守卫,main 侧也需从 DB 确认 session 真实存在且非远程
-      // (SSH / device-link),避免受信 renderer 绕过 UI 守卫携带远程会话内容触发付费调用。
-      // 同时拒绝 review session:reviewer 会话的 composer 被禁用(disabled),不可编辑也不可发送,
-      // 对其做预测是浪费付费调用。也拒绝 soft-deleted session:删除态会话的消息仍保留在 DB,
-      // 但已从用户会话列表移除,对其做预测会外发已删除转写并产生付费调用。
-      const [sessionRow] = await getDbClient()
-        .drizzle.select({ remoteHostId: sessions.remoteHostId, source: sessions.source, agentKind: sessions.agentKind, workingDir: sessions.workingDir, status: sessions.status, updatedAt: sessions.updatedAt })
-        .from(sessions)
-        .where(eq(sessions.id, sessionId));
-      if (!sessionRow || sessionRow.remoteHostId || sessionRow.source === 'review' || sessionRow.status === 'deleted') {
-        return { prompt: null };
-      }
-      // 防御纵深:校验 renderer 上报的 agentKind 与 DB 记录一致,避免受信 renderer 绕过
-      // UI 守卫或 stale UI 状态将 Claude session 的对话内容发送给 Codex provider(反之亦然)。
-      const dbAgentKind = dbToMakerAgentKind(sessionRow.agentKind);
-      if (dbAgentKind !== agentKind) {
-        log.warn('predict-prompt agentKind mismatch — rejecting', {
-          sessionId,
-          rendererAgentKind: agentKind,
-          dbAgentKind,
-        });
-        return { prompt: null };
-      }
-      // 多窗口去重:同一 session 同一 DB 轮次只能有一笔预测在途。
-      // updatedAt 是 DB 权威轮次标识:相同时拒绝(同一真实轮次,跨窗口 turnGen 不同
-      // 也不放行,避免重复付费调用);不同时替换旧条目放行(新轮已开始)。
-      // 注意:排队发送场景下相邻轮次可能共享 updatedAt(入队消息提前推进),此时后一轮
-      // 预测会被拒绝。这是可接受的 tradeoff:避免重复付费调用优先于排队轮次的即时预测。
-      if (_predictingPromptSessions.has(sessionId)) {
-        const existing = _predictingPromptSessions.get(sessionId)!;
-        if (existing.updatedAt === sessionRow.updatedAt) {
-          return { prompt: null };
-        }
-        // 旧轮预测仍在途但新轮已开始,旧结果注定被 renderer 丢弃,放行新请求。
-        log.debug('predict-prompt replacing stale in-flight prediction', {
-          sessionId,
-          oldUpdatedAt: existing.updatedAt,
-          newUpdatedAt: sessionRow.updatedAt,
-        });
-      }
-      _predictingPromptSessions.set(sessionId, { updatedAt: sessionRow.updatedAt, turnGen });
-      try {
-        // 素材只从 DB 读取,不信任 renderer 上报的 messages / workingDir:受信 renderer 或
-        // stale UI 可能携带其它会话转写或伪造 workdir,把非本会话内容送到本地 provider 触发
-        // 付费调用。先排空落盘队列,确保刚结束 turn 的最终回复已持久化,再读最近消息。
-        // 与 REGENERATE_TITLE 对齐:在 drain 前后各拍一次 isSessionTurnPendingCompletion,
-        // 捕获 drain 期间封存的终末消息——避免在 terminal delivery 短窗口内把施工中的
-        // Assistant 行当作完整回复,预测基于不完整上下文落地后 renderer 不会再重试。
-        const pendingCompletionBeforeDrain =
-          options.isSessionTurnPendingCompletion?.(sessionId) === true;
-        await drainPersistQueue();
-        let pendingCompletionObserved = pendingCompletionBeforeDrain;
-        const latestTurnIsPendingCompletion = (): boolean => {
-          if (!pendingCompletionObserved) {
-            pendingCompletionObserved =
-              options.isSessionTurnPendingCompletion?.(sessionId) === true;
-          }
-          return pendingCompletionObserved;
-        };
-        latestTurnIsPendingCompletion();
-        // drainPersistQueue 等待期间 session 可能被软删除或转为远程/review，
-        // 或用户发起新 turn（session.updatedAt 变化）。上方基于 status / source /
-        // remoteHostId 的防御纵深检查会过期（TOCTOU）。此处再从 DB 读取同一行
-        // 的资格字段，并比对 updatedAt：若 session 在 drain 期间被修改（新 turn
-        // 启动），中止预测，避免用旧上下文发起付费调用。
-        const [latestSessionRow] = await getDbClient()
-          .drizzle.select({
-            remoteHostId: sessions.remoteHostId,
-            source: sessions.source,
-            status: sessions.status,
-            agentKind: sessions.agentKind,
-            workingDir: sessions.workingDir,
-            updatedAt: sessions.updatedAt,
-          })
-          .from(sessions)
-          .where(eq(sessions.id, sessionId));
-        if (
-          !latestSessionRow ||
-          latestSessionRow.remoteHostId ||
-          latestSessionRow.source === 'review' ||
-          latestSessionRow.status === 'deleted'
-        ) {
-          return { prompt: null };
-        }
-        // drain 期间 session 被修改（新 turn 启动 / 消息落盘等），中止预测。
-        if (latestSessionRow.updatedAt !== sessionRow.updatedAt) {
-          log.debug('predict-prompt session updated during drain — rejecting', {
-            sessionId,
-          });
-          return { prompt: null };
-        }
-        // drain 期间 session 可能被切换 agent(sessionAgentSwitchHandler 会提交 agentKind 变更):
-        // 上方 drain 前的 agentKind 校验已过期,这里用 drain 后的 DB agentKind 复核,与 renderer
-        // 上报不一致时拒绝,避免把转写路由到切换前的 provider/账号触发付费调用。
-        const latestDbAgentKind = dbToMakerAgentKind(latestSessionRow.agentKind);
-        if (latestDbAgentKind !== agentKind) {
-          log.warn('predict-prompt agentKind changed after drain — rejecting', {
-            sessionId,
-            rendererAgentKind: agentKind,
-            dbAgentKind: latestDbAgentKind,
-          });
-          return { prompt: null };
-        }
-        const material = await regenerateTitleMaterial(
-          sessionId,
-          PREDICTION_RECENT_MESSAGE_LIMIT,
-          latestTurnIsPendingCompletion,
-        );
-        const messages = material.recent.map((m) => ({ role: m.role, content: m.text }));
         return {
-          prompt: await generatePromptPrediction({
-            sessionId,
-            agentKind,
-            messages,
-            ...(latestSessionRow.workingDir ? { workingDir: latestSessionRow.workingDir } : {}),
-            materialDrainUpdatedAt: latestSessionRow.updatedAt,
-          }),
+          prompt: await predictPromptForCompletedRevision(parsed, options),
         };
-      } finally {
-        // 同 session 的预测在上一笔在途时会被拒绝,正常情况下条目始终为请求时刻的
-        // updatedAt + turnGen。此处保留相等性校验作为防御性编程。
-        const current = _predictingPromptSessions.get(sessionId);
-        if (current && current.updatedAt === sessionRow.updatedAt && current.turnGen === turnGen) {
-          _predictingPromptSessions.delete(sessionId);
-        }
-      }
       } catch (error: unknown) {
         // 将数据库不可用、查询失败等意外错误编码为 IPC error，避免 Electron
         // 将原始 Drizzle/SQLite 异常序列化到 Renderer 侧泄露内部细节。
         if (isIpcError(error)) throw error;
-        log.error('predict-prompt handler failed', { sessionId, error });
+        log.error('predict-prompt handler failed', { sessionId: parsed.sessionId, error });
         throwIpcError('INTERNAL', 'Prompt prediction failed');
       }
     },

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -6392,6 +6392,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
       messages: Array<{ role: string; content: string }>;
       workingDir?: string;
       turnGen: number;
+      completionRevision: number;
     }): Promise<{ prompt: string | null }> => ipcRenderer.invoke('maker:predict-prompt', request),
     helpAsk: (
       request: import('../shared/helpTypes').HelpAskRequest,

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -29,6 +29,10 @@ import { ProjectAutomationNotifyBridge } from '@/features/scheduler/components/P
 import { GhostConfirmDialogHost } from '@/cindy-brain/GhostConfirmDialogHost';
 import { PluginMarketPermissionReviewHost } from '@/features/plugin/PluginMarketPermissionReviewHost';
 import { makerChatStore } from '@/lib/makerChatStore';
+import {
+  initializePromptRecommendationStore,
+  setPromptRecommendationOwner,
+} from '@/lib/promptRecommendationStore';
 import { installSystemNetworkErrorToastListener } from '@/lib/systemNetworkErrorToast';
 import { installSilentInstallToastListener } from '@/lib/silentInstallToast';
 import { installProviderUpstreamErrorToastListener } from '@/lib/providerUpstreamErrorToast';
@@ -90,9 +94,14 @@ function LoginHandoffHost({ children }: { children: React.ReactNode }) {
 }
 
 function MakerBootstrap() {
-  const { isAuthenticated, dataOwnerId } = useAuth();
+  const { isAuthenticated, dataOwnerId, dataOwnerRecoveryEpoch } = useAuth();
 
   useResyncAgentIslandSettingsAfterLogin(isAuthenticated);
+
+  useEffect(() => {
+    setPromptRecommendationOwner(`${dataOwnerId ?? 'signed-out'}:${dataOwnerRecoveryEpoch}`);
+    initializePromptRecommendationStore();
+  }, [dataOwnerId, dataOwnerRecoveryEpoch]);
 
   useEffect(() => {
     makerChatStore.syncActiveTurnsFromMain();

--- a/apps/desktop/src/renderer/__tests__/makerChatStorePromptRecommendationStop.test.ts
+++ b/apps/desktop/src/renderer/__tests__/makerChatStorePromptRecommendationStop.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  EMPTY_SESSION_STATE,
+  handleStreamEvent,
+  type SessionChatState,
+} from '@/lib/makerChatStore';
+
+function doneState(
+  turnStoppedByUser: boolean,
+  data: Record<string, unknown>,
+): SessionChatState {
+  const before = {
+    ...EMPTY_SESSION_STATE,
+    turnStoppedByUser,
+    agentStatus: {
+      ...EMPTY_SESSION_STATE.agentStatus,
+      isRunning: true,
+      startedAt: 100,
+    },
+  } as SessionChatState;
+  return handleStreamEvent(before, {
+    sessionId: 'session-1',
+    type: 'done',
+    source: 'claude-code',
+    data,
+  });
+}
+
+describe('prompt recommendation cross-window Stop projection', () => {
+  it('真实或合成的 cancelled terminal 会在所有窗口投影 Stop', () => {
+    expect(doneState(false, { cancelled: true }).turnStoppedByUser).toBe(true);
+    expect(
+      doneState(false, { reason: 'turn_continuation_cancelled' }).turnStoppedByUser,
+    ).toBe(true);
+    expect(
+      doneState(false, { reason: 'user_stop_unconfirmed_wake_tasks' }).turnStoppedByUser,
+    ).toBe(true);
+    expect(doneState(false, {}).turnStoppedByUser).toBe(false);
+    expect(doneState(true, {}).turnStoppedByUser).toBe(true);
+  });
+});

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -267,6 +267,12 @@ import {
   useComposerSendShortcutPreference,
 } from '@/hooks/useComposerSendShortcutPreference';
 import { usePromptRecommendationPreference } from '@/hooks/usePromptRecommendationPreference';
+import {
+  beginPromptRecommendationPrediction,
+  dismissPromptRecommendation,
+  resolvePromptRecommendationPrediction,
+  usePromptRecommendation,
+} from '@/lib/promptRecommendationStore';
 import { createLogger } from '@/lib/logger';
 import { subscribeWorkLouderCodexAction } from '@/lib/workLouderCodexActions';
 import { createComposerDraftSaveScheduler } from '@/lib/composerDraftSaveScheduler';
@@ -275,6 +281,7 @@ import {
   shouldRefreshComposerRender,
   type ComposerRenderSnapshot,
 } from './composerRenderGate';
+import { shouldShowComposerPromptRecommendation } from './composerPromptRecommendation';
 import { createComposerFrameScheduler } from './composerFrameScheduler';
 import {
   serializeEditorContent,
@@ -331,7 +338,6 @@ import {
   isRemoteOptimisticDataOwnerBoundaryError,
   isRemoteOptimisticSessionPurgedError,
   makerChatStore,
-	wasLastStopSideTask,
 } from '@/lib/makerChatStore';
 // 切模型前的上下文容量预检(大窗口 → 小窗口护栏), 纯函数与 main 共用。
 import { assessModelSwitchContext } from '../../../shared/modelSwitchAssessment';
@@ -385,15 +391,6 @@ const ComposerHardBreak = HardBreak.extend({
 // 自然宽度（permission + model + voice + send 等）估，实测可微调。
 const TOOLBAR_DENSE_MAX_WIDTH = 520;
 const TOOLBAR_COMPACT_MAX_WIDTH = 448;
-
-// 预测去重:同一 session 在多个窗口(openSessionInNewWindow)打开时,每个 ChatInput
-// 实例都会独立检测到 turn 结束并触发 predictNextPrompt,导致重复的 provider 调用。
-// 模块级 Map<sessionId, turnGen> 跟踪正在进行的预测(renderer 端辅助跟踪),
-// 主要用于 cleanup 时防止误删其他窗口的条目。主进程级去重(main 侧 title.ts)
-// 使用 DB session.updatedAt 作为跨窗口一致的去重键,才是真正的付费调用防线。
-// 当旧 turn 的预测仍在途时新 turn 触发预测,新 turn 的 turnGen 不同,
-// 会替换旧条目并允许新预测通过(main 侧也通过 updatedAt 变化放行)。
-const _predictingSessions = new Map<string, number>();
 
 function isVoiceInputIdleLike(state: VoiceInputState): boolean {
   return state === 'idle' || state === 'done' || state === 'error';
@@ -1094,13 +1091,20 @@ export function ChatInput({
   // ── 推荐提示词 ────────────────────────────────────────────────────
   // 设置开关:通过 shared hook 订阅,与 TipsSection 同源,切换后立即生效。
   const { enabled: recommendationEnabled } = usePromptRecommendationPreference();
+  // 推荐状态按 sessionId 存在组件外：切换 session 时同步读取各自条目，后台完成与
+  // 分屏也共享同一份结果；App 重启后自然清空，不把一次性推荐持久化成业务真相。
+  const recommendation = usePromptRecommendation(sessionId);
   // 推荐词渲染成一层 overlay 盖在编辑器上(原生 placeholder 由 CSS 隐藏)——
   // Tiptap Placeholder 的文本在 extension 创建时定型,运行期改不动,所以不走它。
-  const [recommendedPrompt, setRecommendedPrompt] = useState<string | null>(null);
-  // handleKeyDown / onUpdate 是稳定闭包,读不到 state,走 ref 取值
+  const recommendedPrompt = recommendation?.phase === 'ready' ? recommendation.prompt : null;
+  // handleKeyDown 是稳定闭包,读不到本轮 render,走 ref 取当前 session 的值。
   const recommendedPromptRef = useRef<string | null>(null);
   recommendedPromptRef.current = recommendedPrompt;
+  const recommendationRef = useRef(recommendation);
+  recommendationRef.current = recommendation;
   const showRecommendationRef = useRef(false);
+  // session 切换时 ChatInput/Editor 会复用；推荐资格必须等目标草稿完成水合后再判断。
+  const [composerHydrationGeneration, setComposerHydrationGeneration] = useState(0);
   // 完整输入框空判断:不仅检查 ProseMirror 文档是否为空,还检查附件、浏览器评论和语音稿。
   // 避免在用户放好了附件/评论/语音稿但正文为空时,仍发起付费的 predictNextPrompt 调用。
   const voiceDraftTextRef = useRef('');
@@ -1184,177 +1188,124 @@ export function ChatInput({
   // ── ESC / history ref bridges for Tiptap handleKeyDown ────────────
   // Tiptap editorProps can't read React state, so we use refs.
   const onStopRef = useRef(onStop);
-  // 用户点击 Stop 时标记 wasTurnStoppedByUserRef,阻止该轮次触发预测。
   onStopRef.current = onStop;
   const handleStop = useCallback(() => {
-    wasTurnStoppedByUserRef.current = true;
     onStop?.();
   }, [onStop]);
   const showStopButtonRef = useRef(showStopButton);
   showStopButtonRef.current = showStopButton;
 
-  const recommendationEnabledRef = useRef(recommendationEnabled);
-  recommendationEnabledRef.current = recommendationEnabled;
-
-  // ── 推荐提示词:turn 结束(showStopButton true→false)→ 调 IPC 预测 ────
-  // messages 在流式期间每个 delta 都变,放进 deps 会让本 effect 反复重跑并把
-  // prevShowStopRef 冲掉,从而永远检测不到那次跳变 —— 所以走 ref 读最新值。
-  const prevShowStopRef = useRef(false);
-  // 用户点击 Stop 或 turn 以错误结束时，不应触发预测。
-  // 该 ref 在 Stop 按钮/快捷键触发时置 true，新 turn 开始时重置。
-  const wasTurnStoppedByUserRef = useRef(false);
-  // turnGen: 每次新 turn 开始递增,预测请求携带代次;落地时检查代次与 sessionId
-  // 是否仍匹配,避免旧请求覆盖新轮推荐或跨 session 残留。
-  // 递增分两层:render 阶段同步检测 showStopButton false→true 跳变,关闭「用户操作
-  // → React render」之间旧 Promise 落地的空窗;useEffect 里照旧做清除推荐 UI 的副作用。
+  // turnGen 继续作为 renderer 侧请求代次；跨 session / 新 turn 的真实归属由
+  // promptRecommendationStore 的 sessionId + completion revision + requestSeq 保证。
   const turnGenRef = useRef(0);
   const prevShowStopRender = useRef(false);
   const prevSessionIdRef = useRef(sessionId);
-  // sessionId 切换时在 render 阶段同步更新预测相关 ref，消除 session 切换与
-  // layout effect 之间的时序窗口。旧代码将 ref 更新放在 useLayoutEffect 中，
-  // 当会话 A 的预测仍在途且切换到会话 B 时，sessionId 已变但 ref 未更新，
-  // 旧 Promise 返回时仍通过 prevSessionIdRef.current === requestSessionId 校验，
-  // 导致会话 A 的推荐词写入会话 B 的输入框。
-  // 修复：在 render 阶段同步更新 ref，旧 session 的预测请求落回时
-  // prevSessionIdRef 已更新为新 sessionId，校验失败后静默丢弃。
-  // React concurrent rendering 下若某次 render 被丢弃，ref 会在实际 commit 的
-  // render 中再次正确更新，不影响最终正确性。
   if (prevSessionIdRef.current !== sessionId) {
     prevSessionIdRef.current = sessionId;
-    prevShowStopRef.current = false;
     turnGenRef.current += 1;
     prevShowStopRender.current = false;
+    // stable key handler 在下一次 render 前也不能接受上一 session 的推荐。
     showRecommendationRef.current = false;
   }
-  // useLayoutEffect 在 React commit 后、浏览器绘制前同步执行，比 useEffect 更接近
-  // render 阶段的时序，同时避免 React concurrent rendering 下 render 被丢弃但 ref
-  // 已被错误修改的风险。防御纵深：发送时已通过 turnGenRef.current += 1 立即失效
-  // 旧预测（见 handleSend），此处作为兜底处理 showStopButton 跳变场景。
   useLayoutEffect(() => {
     const turnStarting = showStopButton && !prevShowStopRender.current;
     prevShowStopRender.current = showStopButton;
     if (turnStarting) {
       turnGenRef.current += 1;
+      showRecommendationRef.current = false;
+      if (sessionId) dismissPromptRecommendation(sessionId);
     }
   });
-  useLayoutEffect(() => {
-    // sessionId 变化时同步清除推荐 UI（用 useLayoutEffect 避免旧推荐跨会话闪现）
-    setRecommendedPrompt(null);
-  }, [sessionId]);
   useEffect(() => {
-    // 用户在 Settings 里关闭推荐提示词后,立即清除当前可见的推荐 UI。
-    if (!recommendationEnabled) {
-      setRecommendedPrompt(null);
+    if (!recommendationEnabled && sessionId) {
+      showRecommendationRef.current = false;
+      dismissPromptRecommendation(sessionId);
     }
-  }, [recommendationEnabled]);
-  // messages 是可选 prop,缺省按空历史处理(空历史不发预测请求)。
+  }, [recommendationEnabled, sessionId]);
+
+  // messages 是可选 prop。只把「是否已有历史」放进 deps，避免流式 delta 让预测 effect
+  // 每个 token 都重跑；真正素材仍由 main 从 DB 读取，renderer payload 不作为信任来源。
   const messagesRef = useRef(messages ?? []);
   messagesRef.current = messages ?? [];
+  const hasPredictionMessages = (messages?.length ?? 0) > 0;
   useEffect(() => {
-    const wasRunning = prevShowStopRef.current;
-    prevShowStopRef.current = showStopButton;
-    // 新 turn 开始 → 清除推荐 UI(代次已在 render 阶段同步递增)
-    if (showStopButton) {
-      showRecommendationRef.current = false;
-      setRecommendedPrompt(null);
-      wasTurnStoppedByUserRef.current = false;
+    if (!sessionId || recommendation?.phase !== 'candidate') return;
+    if (!recommendationEnabled) {
+      dismissPromptRecommendation(sessionId, recommendation.revision);
+      return;
     }
-    // device-link 远程会话 & SSH 远程会话:maker:predict-prompt 不在 allowlist,且远程对话内容
-    // 不应送到控制端本地 provider/凭证 —— 跳过预测。deviceLinkDeviceId 语义（来自
-    // CCAgentSessionView）：
-    //   null = 已确认本地会话 → 允许预测
-    //   undefined = 所有权尚未解析 → 跳过预测（device-link 引导/重连窗口期归属未定，
-    //               远程转写可能被误送到本地 provider，故 fail-closed）
-    //   string = 远程会话 → 被下面 deviceLinkDeviceId === null 拦截
-    if (wasRunning && !showStopButton && recommendationEnabled && sessionId && deviceLinkDeviceId === null && !remoteHostId) {
-      // 当 composer 被禁用时（如 reviewer 任务完成后 read-only），不应触发
-      // 预测：用户无法 Tab 填入或发送，发起 provider 调用是浪费。
-      // 读取 disabled prop 而非 disabledRef：disabledRef 由后续 effect 刷新，
-      // reviewer 任务变为 read-only 的同一次 render 中 ref 可能仍是旧值。
-      if (disabled) return;
-      // 后台 wake 型任务(local_agent / local_workflow)仍在运行时,主 turn 报告
-      // 用户点击 Stop 或 turn 以错误/中止结束时,不应触发预测。
-      // turnStoppedByUser 是 session 级 store 字段(stopSession 置位、新 turn 复位),
-      // 确保同一 session 在多窗口打开时,任一窗口的 Stop 都能阻止其他窗口触发预测。
-      if (makerChatStore.getSnapshot(sessionId)?.turnStoppedByUser) return;
-      // turn 以终端错误结束时，不应触发预测：错误上下文可能包含不完整/损坏的对话，
-      // 避免在错误状态下发起付费 provider 调用。
-      if (makerChatStore.getSnapshot(sessionId)?.error) return;
-      // stopped 但会话仍在工作 —— 跳过预测,避免用不完整上下文发起付费调用。
-      // hasBackgroundAgentWork 已在 _isSessionBusy 里统一折算,这里单独补门禁。
-      if (makerChatStore.hasBackgroundAgentWork(sessionId)) return;
-	      // side-task（skipTurnReset 如 Mivo 侧通道）结束时，store 将 running 翻为
-	      // false 但未产生新的 assistant 回复，不应在对话内容未变时发起付费预测。
-	      if (wasLastStopSideTask(sessionId)) return;
-      // 冷加载帧:runtimeAgentKind 尚未确认时就默认 claude-code,会将其他引擎的会话内容
-      // 发给 Claude Code provider —— 跳过预测,等 agent 身份确认后再恢复。
-      if (runtimeAgentKind == null) return;
-      const latestMessages = messagesRef.current;
-      const ed = editorRef.current;
-      if (
-        latestMessages.length > 0 &&
-        ed &&
-        !ed.isDestroyed &&
-        composerFullyEmptyRef.current()
-      ) {
-        const contextMsgs = latestMessages.slice(-20).map((m) => ({
-          role: m.role,
-          content: m.content,
-        }));
-        // 捕获请求时刻的 sessionId、turnGen 与 workingDir 快照,落地前校验是否仍匹配。
-        const requestSessionId = sessionId;
-        const requestTurnGen = turnGenRef.current;
-        const requestWorkingDir = workingDir;
-        // 去重:同一 session 同一 turnGen 同时只有一次预测调用,避免重复 provider 调用与费用。
-        // 当旧 turn 预测仍在途时新 turn 触发预测,新 turnGen 不同 → 替换旧条目,允许新预测通过。
-        const existingTurnGen = _predictingSessions.get(requestSessionId);
-        if (existingTurnGen === requestTurnGen) return;
-        _predictingSessions.set(requestSessionId, requestTurnGen);
-        window.electronAPI.maker
-          .predictNextPrompt({
-            sessionId,
-            agentKind: runtimeAgentKind,
-            messages: contextMsgs,
-            workingDir: workingDir ?? undefined,
-            turnGen: requestTurnGen,
-          })
-          .then((result) => {
-            if (_predictingSessions.get(requestSessionId) === requestTurnGen) {
-              _predictingSessions.delete(requestSessionId);
-            }
-            // 请求往返期间用户可能已经切换会话、发起新 turn 或开始打字 —— 落地前
-            // 重新确认 sessionId、turnGen、编辑器状态,否则旧上下文的推荐会覆盖当前轮。
-            const cur = editorRef.current;
-            if (
-              result?.prompt &&
-              recommendationEnabledRef.current &&
-              cur &&
-              !cur.isDestroyed &&
-              composerFullyEmptyRef.current() &&
-              !showStopButtonRef.current &&
-              !composerMutationLockedRef.current &&
-              prevSessionIdRef.current === requestSessionId &&
-              turnGenRef.current === requestTurnGen &&
-              workingDirRef.current === requestWorkingDir
-            ) {
-              showRecommendationRef.current = true;
-              setRecommendedPrompt(result.prompt);
-            }
-          })
-          .catch(() => {
-            if (_predictingSessions.get(requestSessionId) === requestTurnGen) {
-              _predictingSessions.delete(requestSessionId);
-            }
-            // 预测失败静默处理:不显示推荐,也不回落任何默认文案。
-          });
-      }
+    // remote / review/read-only 保持原有 fail-closed 语义。deviceLinkDeviceId=undefined
+    // 是归属尚未解析的暂态，先保留 candidate；解析为本地 null 后再继续。
+    if (deviceLinkDeviceId === undefined || runtimeAgentKind == null || !hasPredictionMessages) {
+      return;
     }
-    // 新 turn 开始 → 立即撤掉推荐
-    if (showStopButton) {
-      showRecommendationRef.current = false;
-      setRecommendedPrompt(null);
+    if (deviceLinkDeviceId !== null || remoteHostId || disabled) {
+      dismissPromptRecommendation(sessionId, recommendation.revision);
+      return;
     }
-  }, [showStopButton, sessionId, recommendationEnabled, runtimeAgentKind]);
+    const ed = editorRef.current;
+    if (!ed || ed.isDestroyed) return;
+    // ChatInput/Editor 在 session 间复用。目标 storageKey 的草稿尚未水合时，editor 里仍是
+    // 上一 session 的正文；此时判非空会误删目标 session candidate。等水合代次推进后重试。
+    if (
+      !hasHydratedRef.current ||
+      storageKeyForDraftRef.current !== storageKey ||
+      isRestoringRef.current
+    ) {
+      return;
+    }
+    // candidate 首次进入前台时已有草稿/附件/评论/语音稿，沿用旧逻辑：不发付费调用。
+    if (!composerFullyEmptyRef.current()) {
+      dismissPromptRecommendation(sessionId, recommendation.revision);
+      return;
+    }
+
+    const requestSeq = beginPromptRecommendationPrediction(sessionId, recommendation.revision);
+    if (requestSeq == null) return;
+    const requestSessionId = sessionId;
+    const requestRevision = recommendation.revision;
+    const requestTurnGen = turnGenRef.current;
+    const contextMsgs = messagesRef.current.slice(-20).map((message) => ({
+      role: message.role,
+      content: message.content,
+    }));
+
+    window.electronAPI.maker
+      .predictNextPrompt({
+        sessionId: requestSessionId,
+        agentKind: runtimeAgentKind,
+        messages: contextMsgs,
+        workingDir: workingDirRef.current ?? undefined,
+        turnGen: requestTurnGen,
+        completionRevision: requestRevision,
+      })
+      .then((result) => {
+        // 结果按原 session + completion revision 落入 Store；即使用户已切到其它
+        // session，也只更新原 session，切回时再展示，不污染当前输入框。
+        resolvePromptRecommendationPrediction(
+          requestSessionId,
+          requestRevision,
+          requestSeq,
+          result?.prompt ?? null,
+        );
+      })
+      .catch(() => {
+        resolvePromptRecommendationPrediction(requestSessionId, requestRevision, requestSeq, null);
+        // 预测失败静默处理:不显示推荐,也不回落任何默认文案。
+      });
+  }, [
+    composerHydrationGeneration,
+    deviceLinkDeviceId,
+    disabled,
+    hasPredictionMessages,
+    recommendation?.phase,
+    recommendation?.revision,
+    recommendationEnabled,
+    remoteHostId,
+    runtimeAgentKind,
+    sessionId,
+    storageKey,
+  ]);
 
   // F-QUEUE-DEFER: when the queue panel is expanded, esc collapses it
   // BEFORE falling through to the existing stop / history shortcuts. That
@@ -1539,13 +1490,6 @@ export function ChatInput({
   const internalMentionDragActiveRef = useRef(false);
   const [workingDir, setWorkingDir] = useState<string | null>(initialWorkingDir ?? null);
   const [internalFolderOpen, setInternalFolderOpen] = useState(false);
-
-  // 工作目录变化 → 作废在途推荐并清除已显示推荐,避免旧目录上下文诱导错误操作。
-  useEffect(() => {
-    turnGenRef.current += 1;
-    showRecommendationRef.current = false;
-    setRecommendedPrompt(null);
-  }, [workingDir]);
 
   // Ref bridge for Tiptap handlePaste(粘贴管线):editorProps 闭包只建一次,
   // 读不到最新 state / props / t——粘贴时的 workdir(路径识别范围)、会话来源
@@ -2412,11 +2356,16 @@ export function ChatInput({
           !composerMutationLockedRef.current
         ) {
           if (composerFullyEmptyRef.current()) {
+            const prompt = recommendedPromptRef.current;
+            if (!prompt) return false;
             event.preventDefault();
-            // 先撤推荐(overlay 与正文同位置,不先撤会有一帧重叠),再插入文本。
+            const activeRecommendation = recommendationRef.current;
+            // 先消费 Store 条目(overlay 与正文同位置,不先撤会有一帧重叠),再插入文本。
             showRecommendationRef.current = false;
-            setRecommendedPrompt(null);
-            view.dispatch(view.state.tr.insertText(recommendedPromptRef.current));
+            if (sessionId && activeRecommendation) {
+              dismissPromptRecommendation(sessionId, activeRecommendation.revision);
+            }
+            view.dispatch(view.state.tr.insertText(prompt));
             return true;
           }
         }
@@ -2455,7 +2404,6 @@ export function ChatInput({
           // instead of sending the next one immediately.
           if (showStopButtonRef.current && onStopRef.current) {
             event.preventDefault();
-            wasTurnStoppedByUserRef.current = true;
             onStopRef.current();
             return true;
           }
@@ -2622,12 +2570,9 @@ export function ChatInput({
       if (syntheticRangeEnd !== null && transaction.docChanged) {
         syntheticAtRangeEndRef.current = transaction.mapping.map(syntheticRangeEnd, 1);
       }
-      // 编辑器一旦非空就彻底撤掉推荐(不只是隐藏)。留着 state 的话,发送后正文被
-      // 清空的那一帧 overlay 会重新出现 —— 那就是提交后闪一下推荐词的来源。
-      if (!composerDocIsEmpty(ed.state.doc) && recommendedPromptRef.current) {
-        showRecommendationRef.current = false;
-        setRecommendedPrompt(null);
-      }
+      // 普通输入只通过 showRecommendationOverlay 隐藏 session 级推荐，不销毁它；
+      // 用户把正文重新清空时即可恢复。发送路径会在 clearContent 前同步消费 Store 条目，
+      // 因而不会复活上一轮推荐。
       if (
         !suppressListNormalizationRef.current &&
         !ed.view.composing &&
@@ -3081,22 +3026,29 @@ export function ChatInput({
     editor?.setEditable(!composerMutationLocked);
   }, [composerMutationLocked, editor]);
 
-  // 当推荐因附件/浏览器评论/语音草稿变为不可见时,清除 ref 防止 Tab 填入隐藏内容。
-  // showRecommendationOverlay 的可见判据包含 !hasAttachments / browserComments.length === 0 /
-  // !hasVoiceDraftText,但当这些条件变为 false 时只隐藏 overlay,不清除 ref。
-  // 此时按 Tab 仍会通过 showRecommendationRef.current 检查并插入不可见的推荐词。
-  // voiceInput.isBusy 也需要纳入：用户通过快捷键开始听写时 isBusy 立即为 true，
-  // 但 draftText 可能尚未到达，此时 overlay 已隐藏而 ref 未清除，Tab 仍会插入推荐词。
-  // composerMutationLocked 涵盖 disabled、sendDispatchInFlight、voiceInput.isBusy 及远程只读/锁定状态。
+  // 附件/浏览器评论/语音/锁定保持原有「失效」语义（不同于普通文字输入的暂时隐藏）。
+  // 同步清 ref，避免稳定闭包里的 Tab 在 React 重渲染前填入已隐藏推荐。
   useEffect(() => {
+    const activeRecommendation = recommendationRef.current;
     if (
-      recommendedPromptRef.current &&
-      (attachments.length > 0 || browserComments.length > 0 || composerMutationLocked || voiceInput.draftText.trim().length > 0)
+      sessionId &&
+      activeRecommendation &&
+      (attachments.length > 0 ||
+        browserComments.length > 0 ||
+        composerMutationLocked ||
+        (voiceBusyOnCurrentComposer && voiceInput.draftText.trim().length > 0))
     ) {
       showRecommendationRef.current = false;
-      setRecommendedPrompt(null);
+      dismissPromptRecommendation(sessionId, activeRecommendation.revision);
     }
-  }, [attachments.length, browserComments.length, composerMutationLocked, voiceInput.draftText]);
+  }, [
+    attachments.length,
+    browserComments.length,
+    composerMutationLocked,
+    sessionId,
+    voiceBusyOnCurrentComposer,
+    voiceInput.draftText,
+  ]);
 
   const captureSendFocusForRestore = useComposerSendFocusRestore(
     editor,
@@ -3609,6 +3561,7 @@ export function ChatInput({
       editorDataOwnerRef.current = dataOwnerAtTransition;
       // composer-draft-mount-race 修复 (issue #40):放行后续 onUpdate 写 store。
       hasHydratedRef.current = true;
+      setComposerHydrationGeneration((generation) => generation + 1);
       if (
         focusOnStorageKeyChangeRef.current &&
         !disableAutofocusRef.current &&
@@ -3670,6 +3623,7 @@ export function ChatInput({
       editorDataOwnerRef.current = dataOwnerAtTransition;
       storageKeyTransitionRecoveryRef.current = null;
       hasHydratedRef.current = true;
+      setComposerHydrationGeneration((generation) => generation + 1);
 
       // Reset history-browse bookkeeping when switching sessions —
       // arrow-key history was relative to the previous session.
@@ -4934,10 +4888,11 @@ export function ChatInput({
       if (!finishAgentSendDispatch) return;
       draftSaveSchedulerRef.current?.flush();
       dispatchSendInFlightKeysRef.current.add(sendInFlightKey);
-      // 发送新消息时立即递增 turnGen，让任何还未落地的旧 turn 预测结果失效。
-      // 必须在所有异步操作（resolveSessionMessageReferencesForSend / effort settle）
-      // 之前递增，防止旧预测在 reference 解析等异步等待期间落地到输入框。
+      // 发送新消息时立即递增 turnGen，并在任何 await / clearContent 前消费来源 session
+      // 的推荐：旧 Promise 不能落地，正文程序化清空时也不会闪回上一轮推荐。
       turnGenRef.current += 1;
+      showRecommendationRef.current = false;
+      if (sourceSessionId) dismissPromptRecommendation(sourceSessionId);
       // Local/SSH sends keep the live composer while references and runtime
       // settings settle; remote sends must stay editable after their
       // click-time snapshot is cleared. A background source send after a
@@ -7508,7 +7463,11 @@ export function ChatInput({
         if (sessionId) {
           await sessionService.update(sessionId, { workingDir: folderPath });
         }
-        // Server succeeded → update UI
+        // Server succeeded → update UI。只有真实的同 session 目录修改才作废推荐；
+        // session 切换时 initialWorkingDir 水合不走这里，不能误删目标 session 的缓存。
+        turnGenRef.current += 1;
+        showRecommendationRef.current = false;
+        if (sessionId) dismissPromptRecommendation(sessionId);
         setWorkingDir(folderPath);
         onWorkingDirChange?.(folderPath);
       } catch {
@@ -7525,14 +7484,21 @@ export function ChatInput({
     voiceBusyOnCurrentComposer && voiceInput.draftText.trim().length > 0;
   // 推荐 overlay 的可见判据:开关开启 + 有推荐词 + 输入框空 + 无附件/浏览器评论/语音草稿 + 输入框未锁定。
   // composerMutationLocked 涵盖 disabled、sendDispatchInFlight、当前输入框所属语音及远程只读/锁定状态。
-  const showRecommendationOverlay =
-    recommendationEnabled &&
-    !!recommendedPrompt &&
-    !hasMessage &&
-    !hasAttachments &&
-    browserComments.length === 0 &&
-    !hasVoiceDraftText &&
-    !composerMutationLocked;
+  const showRecommendationOverlay = shouldShowComposerPromptRecommendation({
+    enabled: recommendationEnabled,
+    hydrated:
+      hasHydratedRef.current &&
+      storageKeyForDraftRef.current === storageKey &&
+      !isRestoringRef.current,
+    prompt: recommendedPrompt,
+    hasMessage,
+    hasAttachments,
+    hasBrowserComments: browserComments.length > 0,
+    hasVoiceDraftText,
+    mutationLocked: composerMutationLocked,
+  });
+  // handleKeyDown 的稳定闭包只按真实可见性接受 Tab，避免隐藏推荐被误填入。
+  showRecommendationRef.current = showRecommendationOverlay;
   const [voiceReleaseToSendActive, setVoiceReleaseToSendActive] = useState(false);
   const sendButtonDisabled = Boolean(
     disabled ||

--- a/apps/desktop/src/renderer/components/new-chat/__tests__/composerPromptRecommendation.test.ts
+++ b/apps/desktop/src/renderer/components/new-chat/__tests__/composerPromptRecommendation.test.ts
@@ -1,0 +1,89 @@
+import { readFileSync } from 'node:fs';
+
+import { describe, expect, it } from 'vitest';
+
+import { shouldShowComposerPromptRecommendation } from '../composerPromptRecommendation';
+
+const CHAT_INPUT_SOURCE = readFileSync(new URL('../ChatInput.tsx', import.meta.url), 'utf8');
+
+const BASE = {
+  enabled: true,
+  hydrated: true,
+  prompt: '继续补充测试',
+  hasMessage: false,
+  hasAttachments: false,
+  hasBrowserComments: false,
+  hasVoiceDraftText: false,
+  mutationLocked: false,
+};
+
+describe('shouldShowComposerPromptRecommendation', () => {
+  it('输入文字时只隐藏，重新清空后恢复同一推荐', () => {
+    expect(shouldShowComposerPromptRecommendation(BASE)).toBe(true);
+    expect(
+      shouldShowComposerPromptRecommendation({
+        ...BASE,
+        hasMessage: true,
+      }),
+    ).toBe(false);
+    expect(shouldShowComposerPromptRecommendation(BASE)).toBe(true);
+  });
+
+  it('发送路径在任何 await / clearContent 前同步消费来源 session 的推荐', () => {
+    const sendStart = CHAT_INPUT_SOURCE.indexOf('const dispatchSend = useCallback');
+    const dismissAt = CHAT_INPUT_SOURCE.indexOf(
+      'if (sourceSessionId) dismissPromptRecommendation(sourceSessionId);',
+      sendStart,
+    );
+    const firstAwait = CHAT_INPUT_SOURCE.indexOf(
+      'await resolveSessionMessageReferencesForSend',
+      sendStart,
+    );
+    const clearContentAt = CHAT_INPUT_SOURCE.indexOf('editor.commands.clearContent(', sendStart);
+
+    expect(sendStart).toBeGreaterThanOrEqual(0);
+    expect(dismissAt).toBeGreaterThan(sendStart);
+    expect(dismissAt).toBeLessThan(firstAwait);
+    expect(dismissAt).toBeLessThan(clearContentAt);
+  });
+
+  it('等待目标 session 草稿水合后才判断 candidate 是否为空输入', () => {
+    expect(CHAT_INPUT_SOURCE).toContain('storageKeyForDraftRef.current !== storageKey');
+    expect(CHAT_INPUT_SOURCE).toContain(
+      'setComposerHydrationGeneration((generation) => generation + 1);',
+    );
+  });
+
+  it('只让当前 session 拥有的语音草稿消费推荐', () => {
+    expect(CHAT_INPUT_SOURCE).toContain(
+      '(voiceBusyOnCurrentComposer && voiceInput.draftText.trim().length > 0)',
+    );
+  });
+
+  it('session 切换的 workingDir 水合不会消费目标 session 的缓存推荐', () => {
+    const hydrationAt = CHAT_INPUT_SOURCE.indexOf('setWorkingDir(initialWorkingDir ?? null);');
+    const nextEditorSection = CHAT_INPUT_SOURCE.indexOf('// ── Tiptap editor', hydrationAt);
+    const hydrationEffect = CHAT_INPUT_SOURCE.slice(hydrationAt, nextEditorSection);
+
+    expect(hydrationAt).toBeGreaterThanOrEqual(0);
+    expect(nextEditorSection).toBeGreaterThan(hydrationAt);
+    expect(hydrationEffect).not.toContain('dismissPromptRecommendation');
+  });
+
+  it.each([
+    ['开关关闭', { enabled: false }],
+    ['目标 session 草稿尚未水合', { hydrated: false }],
+    ['没有推荐', { prompt: null }],
+    ['存在附件', { hasAttachments: true }],
+    ['存在浏览器评论', { hasBrowserComments: true }],
+    ['存在语音草稿', { hasVoiceDraftText: true }],
+    ['输入框锁定', { mutationLocked: true }],
+  ])('%s 时不显示，也不会允许隐藏推荐被 Tab 接受', (_label, patch) => {
+    expect(
+      shouldShowComposerPromptRecommendation({
+        ...BASE,
+        ...patch,
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/desktop/src/renderer/components/new-chat/composerPromptRecommendation.ts
+++ b/apps/desktop/src/renderer/components/new-chat/composerPromptRecommendation.ts
@@ -1,0 +1,26 @@
+export interface ComposerPromptRecommendationVisibilityInput {
+  enabled: boolean;
+  hydrated: boolean;
+  prompt: string | null;
+  hasMessage: boolean;
+  hasAttachments: boolean;
+  hasBrowserComments: boolean;
+  hasVoiceDraftText: boolean;
+  mutationLocked: boolean;
+}
+
+/** Overlay 与 Tab 接受共用的唯一可见性判据。 */
+export function shouldShowComposerPromptRecommendation(
+  input: ComposerPromptRecommendationVisibilityInput,
+): boolean {
+  return (
+    input.enabled &&
+    input.hydrated &&
+    !!input.prompt &&
+    !input.hasMessage &&
+    !input.hasAttachments &&
+    !input.hasBrowserComments &&
+    !input.hasVoiceDraftText &&
+    !input.mutationLocked
+  );
+}

--- a/apps/desktop/src/renderer/hooks/__tests__/usePromptRecommendationPreference.test.ts
+++ b/apps/desktop/src/renderer/hooks/__tests__/usePromptRecommendationPreference.test.ts
@@ -1,0 +1,32 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  _resetPromptRecommendationPreferenceForTests,
+  getPromptRecommendationPreference,
+  subscribePromptRecommendationPreference,
+  syncPromptRecommendationPreferenceFromStorageValue,
+} from '../usePromptRecommendationPreference';
+
+beforeEach(() => {
+  _resetPromptRecommendationPreferenceForTests();
+});
+
+describe('prompt recommendation preference runtime sync', () => {
+  it('storage push 会先更新模块级真值，首次 ChatInput render 不会读到旧值', () => {
+    syncPromptRecommendationPreferenceFromStorageValue('true');
+    expect(getPromptRecommendationPreference()).toBe(true);
+
+    syncPromptRecommendationPreferenceFromStorageValue('false');
+    expect(getPromptRecommendationPreference()).toBe(false);
+  });
+
+  it('通知运行期 Store 清理已缓存的推荐', () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribePromptRecommendationPreference(listener);
+
+    syncPromptRecommendationPreferenceFromStorageValue('false');
+
+    expect(listener).toHaveBeenCalledWith(false);
+    unsubscribe();
+  });
+});

--- a/apps/desktop/src/renderer/hooks/usePromptRecommendationPreference.ts
+++ b/apps/desktop/src/renderer/hooks/usePromptRecommendationPreference.ts
@@ -6,6 +6,12 @@ export const PROMPT_RECOMMENDATION_KEY = 'prompt-recommendation-enabled';
 let memoryValue: boolean | null = null;
 
 const listeners = new Set<() => void>();
+const lifecycleListeners = new Set<(enabled: boolean) => void>();
+
+function notifyPreferenceChanged(enabled: boolean): void {
+  listeners.forEach((fn) => fn());
+  lifecycleListeners.forEach((fn) => fn(enabled));
+}
 
 function readFromStorage(): boolean {
   try {
@@ -18,6 +24,15 @@ function readFromStorage(): boolean {
 export function getPromptRecommendationPreference(): boolean {
   if (memoryValue !== null) return memoryValue;
   memoryValue = readFromStorage();
+  return memoryValue;
+}
+
+/** 跨窗口 storage push 同步模块级真值；Store 与 hook 共用，避免首次 render 读旧缓存。 */
+export function syncPromptRecommendationPreferenceFromStorageValue(
+  storageValue: string | null,
+): boolean {
+  memoryValue = storageValue !== 'false';
+  notifyPreferenceChanged(memoryValue);
   return memoryValue;
 }
 
@@ -37,7 +52,7 @@ export function usePromptRecommendationPreference(): {
     } catch {
       // localStorage 不可用 → 静默; 模块级内存值仍在本渲染进程内生效。
     }
-    listeners.forEach((fn) => fn());
+    notifyPreferenceChanged(next);
   }, []);
 
   useEffect(() => {
@@ -52,8 +67,7 @@ export function usePromptRecommendationPreference(): {
     listeners.add(sync);
     const onStorage = (event: StorageEvent) => {
       if (event.key !== PROMPT_RECOMMENDATION_KEY) return;
-      memoryValue = event.newValue !== 'false';
-      sync();
+      syncPromptRecommendationPreferenceFromStorageValue(event.newValue);
     };
     window.addEventListener('storage', onStorage);
     return () => {
@@ -65,8 +79,17 @@ export function usePromptRecommendationPreference(): {
   return { enabled, setEnabled };
 }
 
+/** 运行期消费者订阅偏好变化（推荐状态 Store 用于全局清理）。 */
+export function subscribePromptRecommendationPreference(
+  listener: (enabled: boolean) => void,
+): () => void {
+  lifecycleListeners.add(listener);
+  return () => lifecycleListeners.delete(listener);
+}
+
 /** Test-only reset for the module-level source of truth. */
 export function _resetPromptRecommendationPreferenceForTests(): void {
   memoryValue = null;
   listeners.clear();
+  lifecycleListeners.clear();
 }

--- a/apps/desktop/src/renderer/lib/__tests__/promptRecommendationStore.test.ts
+++ b/apps/desktop/src/renderer/lib/__tests__/promptRecommendationStore.test.ts
@@ -1,0 +1,202 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const h = vi.hoisted(() => ({
+  enabled: true,
+  startedAtBySession: new Map<string, number>(),
+  statusBySession: new Map<
+    string,
+    {
+      turnStoppedByUser: boolean;
+      hasTerminalError: boolean;
+      sideTask: boolean;
+      hasBackgroundAgentWork: boolean;
+      hasAutoDrainingQueue: boolean;
+    }
+  >(),
+}));
+
+vi.mock('@/hooks/usePromptRecommendationPreference', () => ({
+  PROMPT_RECOMMENDATION_KEY: 'prompt-recommendation-enabled',
+  getPromptRecommendationPreference: () => h.enabled,
+  subscribePromptRecommendationPreference: () => () => undefined,
+  syncPromptRecommendationPreferenceFromStorageValue: () => h.enabled,
+}));
+
+vi.mock('@/contexts/dataOwnerGeneration', () => ({
+  isDataOwnerPushCurrent: () => true,
+}));
+
+vi.mock('@/lib/makerChatStore', () => ({
+  makerChatStore: {
+    getRunningSnapshot: () => new Map(),
+    subscribeAll: () => () => undefined,
+    getPromptRecommendationRunStartedAt: (sessionId: string) =>
+      h.startedAtBySession.get(sessionId) ?? null,
+    getPromptRecommendationCompletionStatus: (sessionId: string) =>
+      h.statusBySession.get(sessionId) ?? null,
+  },
+}));
+
+import {
+  __testing,
+  beginPromptRecommendationPrediction,
+  dismissPromptRecommendation,
+  resolvePromptRecommendationPrediction,
+} from '../promptRecommendationStore';
+
+const ELIGIBLE = {
+  turnStoppedByUser: false,
+  hasTerminalError: false,
+  sideTask: false,
+  hasBackgroundAgentWork: false,
+  hasAutoDrainingQueue: false,
+};
+
+function complete(sessionId: string, revision: number): void {
+  h.startedAtBySession.set(sessionId, revision - 1);
+  __testing.applyRunningSnapshot(new Map([[sessionId, { isRunning: true }]]));
+  __testing.noteTurnEnded(sessionId, revision);
+  __testing.applyRunningSnapshot(new Map());
+  __testing.settleCompletion(sessionId);
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  h.enabled = true;
+  h.startedAtBySession.clear();
+  h.statusBySession.clear();
+  __testing.reset();
+});
+
+afterEach(() => {
+  __testing.reset();
+  vi.useRealTimers();
+});
+
+describe('promptRecommendationStore', () => {
+  it('不会为本次运行期间未观察到 running 的历史 session 创建候选', () => {
+    h.statusBySession.set('old-session', ELIGIBLE);
+
+    __testing.noteTurnEnded('old-session', 10);
+    __testing.settleCompletion('old-session');
+
+    expect(__testing.getSessionSnapshot('old-session')).toBeUndefined();
+  });
+
+  it('后台正常完成后按 session 和完成 revision 创建候选', () => {
+    h.statusBySession.set('session-a', ELIGIBLE);
+
+    complete('session-a', 101);
+
+    expect(__testing.getSessionSnapshot('session-a')).toEqual({
+      revision: 101,
+      phase: 'candidate',
+      prompt: null,
+      requestSeq: 0,
+    });
+    expect(__testing.getSessionSnapshot('session-b')).toBeUndefined();
+  });
+
+  it.each([
+    ['用户 Stop', { turnStoppedByUser: true }],
+    ['终端错误', { hasTerminalError: true }],
+    ['side-task', { sideTask: true }],
+    ['仍有后台工作', { hasBackgroundAgentWork: true }],
+    ['队列即将自动续跑', { hasAutoDrainingQueue: true }],
+  ])('%s 的完成不会创建推荐候选', (_label, patch) => {
+    h.statusBySession.set('session-a', { ...ELIGIBLE, ...patch });
+
+    complete('session-a', 102);
+
+    expect(__testing.getSessionSnapshot('session-a')).toBeUndefined();
+  });
+
+  it('开关关闭时耗尽本轮，不在重新打开 session 时补付费预测', () => {
+    h.enabled = false;
+    h.statusBySession.set('session-a', ELIGIBLE);
+
+    complete('session-a', 103);
+
+    expect(__testing.getSessionSnapshot('session-a')).toBeUndefined();
+  });
+
+  it('上一轮迟到的 ended revision 不会被配给下一轮 stopped 边沿', () => {
+    h.statusBySession.set('session-a', ELIGIBLE);
+    h.startedAtBySession.set('session-a', 50);
+    __testing.applyRunningSnapshot(new Map([['session-a', { isRunning: true }]]));
+    __testing.applyRunningSnapshot(new Map());
+
+    // 下一轮与上一轮 ended 落在同一毫秒，旧 revision 也必须被拒绝。
+    h.startedAtBySession.set('session-a', 100);
+    __testing.applyRunningSnapshot(new Map([['session-a', { isRunning: true }]]));
+    __testing.noteTurnEnded('session-a', 100);
+    __testing.applyRunningSnapshot(new Map());
+    __testing.settleCompletion('session-a');
+    expect(__testing.getSessionSnapshot('session-a')).toBeUndefined();
+
+    __testing.noteTurnEnded('session-a', 200);
+    __testing.settleCompletion('session-a');
+    expect(__testing.getSessionSnapshot('session-a')?.revision).toBe(200);
+  });
+
+  it('wake bridge 连续 running 时按底层 startedAt 换代丢弃中间轮 revision', () => {
+    h.statusBySession.set('session-a', ELIGIBLE);
+    h.startedAtBySession.set('session-a', 50);
+    const running = new Map([['session-a', { isRunning: true }]]);
+    __testing.applyRunningSnapshot(running);
+    __testing.noteTurnEnded('session-a', 100);
+
+    // 聚合 running 没有熄灭，但 wake turn 已经用新的 startedAt 启动。
+    h.startedAtBySession.set('session-a', 150);
+    __testing.applyRunningSnapshot(running);
+    __testing.applyRunningSnapshot(new Map());
+    __testing.settleCompletion('session-a');
+    expect(__testing.getSessionSnapshot('session-a')).toBeUndefined();
+
+    __testing.noteTurnEnded('session-a', 200);
+    __testing.settleCompletion('session-a');
+    expect(__testing.getSessionSnapshot('session-a')?.revision).toBe(200);
+  });
+
+  it('A 与 B 的请求和结果互不覆盖', () => {
+    h.statusBySession.set('session-a', ELIGIBLE);
+    h.statusBySession.set('session-b', ELIGIBLE);
+    complete('session-a', 201);
+    complete('session-b', 301);
+
+    const requestA = beginPromptRecommendationPrediction('session-a', 201);
+    const requestB = beginPromptRecommendationPrediction('session-b', 301);
+    expect(requestA).not.toBeNull();
+    expect(requestB).not.toBeNull();
+
+    resolvePromptRecommendationPrediction('session-a', 201, requestA!, 'A 的推荐');
+    resolvePromptRecommendationPrediction('session-b', 301, requestB!, 'B 的推荐');
+
+    expect(__testing.getSessionSnapshot('session-a')?.prompt).toBe('A 的推荐');
+    expect(__testing.getSessionSnapshot('session-b')?.prompt).toBe('B 的推荐');
+  });
+
+  it('新 turn 开始会使旧推荐和旧 Promise 失效', () => {
+    h.statusBySession.set('session-a', ELIGIBLE);
+    complete('session-a', 401);
+    const request = beginPromptRecommendationPrediction('session-a', 401);
+    expect(request).not.toBeNull();
+
+    __testing.applyRunningSnapshot(new Map([['session-a', { isRunning: true }]]));
+    resolvePromptRecommendationPrediction('session-a', 401, request!, '过期推荐');
+
+    expect(__testing.getSessionSnapshot('session-a')).toBeUndefined();
+  });
+
+  it('Tab/发送消费后，同 revision 的迟到结果不能复活', () => {
+    h.statusBySession.set('session-a', ELIGIBLE);
+    complete('session-a', 501);
+    const request = beginPromptRecommendationPrediction('session-a', 501);
+    expect(request).not.toBeNull();
+
+    dismissPromptRecommendation('session-a', 501);
+    resolvePromptRecommendationPrediction('session-a', 501, request!, '不应复活');
+
+    expect(__testing.getSessionSnapshot('session-a')).toBeUndefined();
+  });
+});

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -5194,12 +5194,16 @@ export function handleStreamEvent(
       });
 
       const terminalData = event.data as
-        { cancelled?: unknown; plan?: unknown; raw?: { id?: unknown; status?: unknown } }
+        { cancelled?: unknown; reason?: unknown; plan?: unknown; raw?: { id?: unknown; status?: unknown } }
         | null
         | undefined;
       const terminalTurnId = typeof terminalData?.raw?.id === 'string' ? terminalData.raw.id : null;
       const terminalTurnStatus =
         typeof terminalData?.raw?.status === 'string' ? terminalData.raw.status : null;
+      const terminalCancelled =
+        terminalData?.cancelled === true ||
+        terminalData?.reason === 'turn_continuation_cancelled' ||
+        terminalData?.reason === 'user_stop_unconfirmed_wake_tasks';
       const doneMessages =
         event.source === 'codex'
           ? applyCodexPlanSnapshotOnDone(
@@ -5208,7 +5212,7 @@ export function handleStreamEvent(
               terminalTurnId,
               terminalTurnStatus,
               Date.now(),
-              terminalData?.cancelled === true,
+              terminalCancelled,
             ).messages
           : cleanedMessages;
 
@@ -5241,6 +5245,9 @@ export function handleStreamEvent(
         // agent-meta: turn 结束清空，下一 turn 重新累积。
         lastAgentMeta: null,
         queueAbortPending: false,
+        // cancelled terminal 会广播到同一 session 的所有窗口；把它投影成 session 级
+        // Stop 标记，避免非发起窗口把不完整回复误当正常完成并触发付费推荐。
+        turnStoppedByUser: state.turnStoppedByUser || terminalCancelled,
         agentStatus: {
           ...state.agentStatus,
           isRunning: false,
@@ -8298,6 +8305,39 @@ function getSnapshot(sessionId: string): SessionChatState {
 function hasPausedQueue(sessionId: string): boolean {
   const state = sessions.get(sessionId);
   return state ? isQueuePausedWithPending(state) : false;
+}
+
+/**
+ * 输入框推荐提示词在全局 running→stopped 边沿后读取的终态资格快照。
+ * 必须是 non-creating read：后台会话可能已被 demote / LRU，不能为了补推荐
+ * materialize 空 state 并把 Stop / error 等守卫误读成默认值。
+ */
+export interface PromptRecommendationCompletionStatus {
+  turnStoppedByUser: boolean;
+  hasTerminalError: boolean;
+  sideTask: boolean;
+  hasBackgroundAgentWork: boolean;
+  hasAutoDrainingQueue: boolean;
+}
+
+function getPromptRecommendationRunStartedAt(sessionId: string): number | null {
+  return sessions.get(sessionId)?.agentStatus.startedAt ?? null;
+}
+
+function getPromptRecommendationCompletionStatus(
+  sessionId: string,
+): PromptRecommendationCompletionStatus | null {
+  const state = sessions.get(sessionId);
+  if (!state) return null;
+  return {
+    turnStoppedByUser: state.turnStoppedByUser,
+    hasTerminalError: !!state.error && !state.lastStopWasSideTask,
+    sideTask: state.lastStopWasSideTask,
+    hasBackgroundAgentWork: hasBackgroundAgentWork(sessionId, state),
+    // 与 useCCAgentChat.isAgentBusy 对齐：暂停队列允许当前完成轮展示推荐，
+    // 自动续跑队列则等最终一轮结束后再生成。
+    hasAutoDrainingQueue: state.pendingQueue.length > 0 && !state.queuePaused,
+  };
 }
 
 /**
@@ -14504,6 +14544,10 @@ export const makerChatStore = {
   /** F-SB-7: Authoritative terminal-error read, immune to snapshot-generation races. */
   hasSessionTerminalError,
   wasLastStopSideTask,
+  /** 输入框推荐后台完成配对用的 non-creating turn 起点。 */
+  getPromptRecommendationRunStartedAt,
+  /** 输入框推荐后台完成资格的 non-creating 终态快照。 */
+  getPromptRecommendationCompletionStatus,
   ensureInitialMessages,
   reloadMessages,
   /** 消息菜单:本地移除一次删除动作覆盖的整轮记录。 */

--- a/apps/desktop/src/renderer/lib/promptRecommendationStore.ts
+++ b/apps/desktop/src/renderer/lib/promptRecommendationStore.ts
@@ -1,0 +1,346 @@
+import { useSyncExternalStore } from 'react';
+
+import { isDataOwnerPushCurrent } from '@/contexts/dataOwnerGeneration';
+import {
+  getPromptRecommendationPreference,
+  PROMPT_RECOMMENDATION_KEY,
+  subscribePromptRecommendationPreference,
+  syncPromptRecommendationPreferenceFromStorageValue,
+} from '@/hooks/usePromptRecommendationPreference';
+import { makerChatStore } from '@/lib/makerChatStore';
+
+/**
+ * 输入框推荐提示词的 session 级运行期状态。
+ *
+ * 推荐只活在当前 renderer 生命周期，不落盘：全局监听记录本次运行期间真实发生的
+ * running→stopped + lastTurnEndedAt，ChatInput 只在用户打开对应 session 时调用模型。
+ * 这样后台完成不会漏，历史旧 session 也不会因一次普通打开凭空触发付费预测。
+ */
+export interface PromptRecommendationSnapshot {
+  revision: number;
+  phase: 'candidate' | 'predicting' | 'ready';
+  prompt: string | null;
+  requestSeq: number;
+}
+
+const COMPLETION_SETTLE_MS = 500;
+const entries = new Map<string, PromptRecommendationSnapshot>();
+const sessionListeners = new Map<string, Set<() => void>>();
+const runningSessionIds = new Set<string>();
+const sawRunningSessionIds = new Set<string>();
+/** running 上升沿捕获的 agent startedAt，用于拒绝上一轮迟到的 ended patch。 */
+const runStartedAtBySession = new Map<string, number>();
+const pendingCompletionRevisions = new Map<string, number>();
+const handledCompletionRevisions = new Map<string, number>();
+const settleTimers = new Map<string, ReturnType<typeof setTimeout>>();
+let nextRequestSeq = 0;
+let initialized = false;
+let ownerKey: string | null = null;
+const globalUnsubscribers: Array<() => void> = [];
+
+function emitSession(sessionId: string): void {
+  for (const listener of sessionListeners.get(sessionId) ?? []) listener();
+}
+
+function deleteEntry(sessionId: string): void {
+  if (!entries.delete(sessionId)) return;
+  emitSession(sessionId);
+}
+
+function clearSettleTimer(sessionId: string): void {
+  const timer = settleTimers.get(sessionId);
+  if (!timer) return;
+  clearTimeout(timer);
+  settleTimers.delete(sessionId);
+}
+
+function clearRuntimeState(): void {
+  const changedSessionIds = [...entries.keys()];
+  for (const timer of settleTimers.values()) clearTimeout(timer);
+  entries.clear();
+  runningSessionIds.clear();
+  sawRunningSessionIds.clear();
+  runStartedAtBySession.clear();
+  pendingCompletionRevisions.clear();
+  handledCompletionRevisions.clear();
+  settleTimers.clear();
+  for (const sessionId of changedSessionIds) emitSession(sessionId);
+}
+
+function handlePreferenceChanged(enabled: boolean): void {
+  if (!enabled) {
+    const changedSessionIds = [...entries.keys()];
+    entries.clear();
+    pendingCompletionRevisions.clear();
+    sawRunningSessionIds.clear();
+      runStartedAtBySession.clear();
+    for (const timer of settleTimers.values()) clearTimeout(timer);
+    settleTimers.clear();
+    for (const sessionId of changedSessionIds) emitSession(sessionId);
+    return;
+  }
+  // 与前台原行为对齐：运行中打开开关，本轮正常结束后仍可产生推荐。
+  for (const sessionId of runningSessionIds) {
+    sawRunningSessionIds.add(sessionId);
+    const startedAt = makerChatStore.getPromptRecommendationRunStartedAt(sessionId);
+    if (startedAt != null) runStartedAtBySession.set(sessionId, startedAt);
+  }
+}
+
+function scheduleCompletionSettle(sessionId: string): void {
+  clearSettleTimer(sessionId);
+  const timer = setTimeout(() => {
+    settleTimers.delete(sessionId);
+    settleCompletion(sessionId);
+  }, COMPLETION_SETTLE_MS);
+  settleTimers.set(sessionId, timer);
+}
+
+function settleCompletion(sessionId: string): void {
+  if (runningSessionIds.has(sessionId)) return;
+  const revision = pendingCompletionRevisions.get(sessionId);
+  if (revision == null || !sawRunningSessionIds.has(sessionId)) return;
+
+  pendingCompletionRevisions.delete(sessionId);
+  sawRunningSessionIds.delete(sessionId);
+  runStartedAtBySession.delete(sessionId);
+  const previousHandled = handledCompletionRevisions.get(sessionId) ?? 0;
+  if (revision <= previousHandled) return;
+  handledCompletionRevisions.set(sessionId, revision);
+
+  const status = makerChatStore.getPromptRecommendationCompletionStatus(sessionId);
+  const eligible =
+    getPromptRecommendationPreference() &&
+    status != null &&
+    !status.turnStoppedByUser &&
+    !status.hasTerminalError &&
+    !status.sideTask &&
+    !status.hasBackgroundAgentWork &&
+    !status.hasAutoDrainingQueue;
+
+  if (!eligible) {
+    deleteEntry(sessionId);
+    return;
+  }
+
+  entries.set(sessionId, {
+    revision,
+    phase: 'candidate',
+    prompt: null,
+    requestSeq: 0,
+  });
+  emitSession(sessionId);
+}
+
+function applyRunningSnapshot(snapshot: ReadonlyMap<string, { isRunning: boolean }>): void {
+  const nextRunning = new Set<string>();
+  for (const [sessionId, info] of snapshot) {
+    if (info.isRunning) nextRunning.add(sessionId);
+  }
+
+  for (const sessionId of nextRunning) {
+    const startedAt = makerChatStore.getPromptRecommendationRunStartedAt(sessionId);
+    if (runningSessionIds.has(sessionId)) {
+      // wake bridge 会让聚合 running 在「主 turn → 后台任务 → wake turn」之间一直为 true，
+      // 因而没有新的 false→true 边沿。仍需观察底层 agent startedAt 的换代，清掉主 turn
+      // 的中间 ended revision，等待最终 wake turn 自己的 revision。
+      if (startedAt != null) {
+        const previousStartedAt = runStartedAtBySession.get(sessionId);
+        const pendingRevision = pendingCompletionRevisions.get(sessionId);
+        const underlyingTurnChanged =
+          (previousStartedAt != null && previousStartedAt !== startedAt) ||
+          (previousStartedAt == null && pendingRevision != null && pendingRevision <= startedAt);
+        runStartedAtBySession.set(sessionId, startedAt);
+        if (underlyingTurnChanged) {
+          pendingCompletionRevisions.delete(sessionId);
+          clearSettleTimer(sessionId);
+          deleteEntry(sessionId);
+        }
+      }
+      continue;
+    }
+    runningSessionIds.add(sessionId);
+    sawRunningSessionIds.add(sessionId);
+    if (startedAt != null) runStartedAtBySession.set(sessionId, startedAt);
+    else runStartedAtBySession.delete(sessionId);
+    // 新 turn 开始：旧完成 patch / 推荐 / 在途 renderer Promise 全部作废。
+    pendingCompletionRevisions.delete(sessionId);
+    clearSettleTimer(sessionId);
+    deleteEntry(sessionId);
+  }
+
+  for (const sessionId of [...runningSessionIds]) {
+    if (nextRunning.has(sessionId)) continue;
+    runningSessionIds.delete(sessionId);
+    scheduleCompletionSettle(sessionId);
+  }
+}
+
+function noteTurnEnded(sessionId: string, revision: number): void {
+  if (!Number.isFinite(revision) || revision <= 0) return;
+  if (!sawRunningSessionIds.has(sessionId)) return;
+  // 两条 push 通道没有顺序契约：上一轮 ended patch 可能在下一轮 running 后才到。
+  // ended 时间不晚于本轮 startedAt 时必须忽略，不能把同毫秒的上一轮 patch
+  // 配给下一轮 stopped 边沿。真实模型轮不会在启动同一毫秒内正常完成。
+  const runStartedAt = runStartedAtBySession.get(sessionId);
+  if (runStartedAt != null && revision <= runStartedAt) return;
+  const handled = handledCompletionRevisions.get(sessionId) ?? 0;
+  const pending = pendingCompletionRevisions.get(sessionId) ?? 0;
+  if (revision <= handled || revision <= pending) return;
+  pendingCompletionRevisions.set(sessionId, revision);
+  scheduleCompletionSettle(sessionId);
+}
+
+/** App 级接线：必须在 ChatInput 之外常驻，才能记录后台 session 的完成。 */
+export function initializePromptRecommendationStore(): void {
+  if (initialized || typeof window === 'undefined') return;
+  initialized = true;
+
+  applyRunningSnapshot(makerChatStore.getRunningSnapshot());
+  globalUnsubscribers.push(
+    makerChatStore.subscribeAll(() => {
+      applyRunningSnapshot(makerChatStore.getRunningSnapshot());
+    }),
+  );
+
+  const sessionsPush = window.electronAPI?.localDb?.sessionsPush;
+  if (sessionsPush) {
+    globalUnsubscribers.push(
+      sessionsPush.onPatched(({ sessionId, patch }, ownerStamp) => {
+        if (!isDataOwnerPushCurrent(ownerStamp)) return;
+        if (patch.status === 'deleted') {
+          clearPromptRecommendationSession(sessionId);
+          return;
+        }
+        if (typeof patch.lastTurnEndedAt === 'number') {
+          noteTurnEnded(sessionId, patch.lastTurnEndedAt);
+        }
+      }),
+    );
+  }
+
+  globalUnsubscribers.push(subscribePromptRecommendationPreference(handlePreferenceChanged));
+  const onStorage = (event: StorageEvent) => {
+    if (event.key !== PROMPT_RECOMMENDATION_KEY) return;
+    // 先同步偏好模块的 memoryValue，再由 lifecycle subscription 清理 Store；
+    // 否则首次挂载 ChatInput 的 render 仍可能读到旧 true 并发出付费请求。
+    syncPromptRecommendationPreferenceFromStorageValue(event.newValue);
+  };
+  window.addEventListener('storage', onStorage);
+  globalUnsubscribers.push(() => window.removeEventListener('storage', onStorage));
+}
+
+/** 认证 owner / 恢复代次切换时清空所有运行期推荐，防止跨账号复用。 */
+export function setPromptRecommendationOwner(nextOwnerKey: string): void {
+  if (ownerKey === nextOwnerKey) return;
+  ownerKey = nextOwnerKey;
+  clearRuntimeState();
+}
+
+function subscribeSession(sessionId: string | undefined, listener: () => void): () => void {
+  if (!sessionId) return () => undefined;
+  let listeners = sessionListeners.get(sessionId);
+  if (!listeners) {
+    listeners = new Set();
+    sessionListeners.set(sessionId, listeners);
+  }
+  listeners.add(listener);
+  return () => {
+    listeners?.delete(listener);
+    if (listeners?.size === 0) sessionListeners.delete(sessionId);
+  };
+}
+
+function getSessionSnapshot(
+  sessionId: string | undefined,
+): PromptRecommendationSnapshot | undefined {
+  return sessionId ? entries.get(sessionId) : undefined;
+}
+
+/** 当前 session 的推荐状态；切换 session 时同步读取对应 key，不携带上一 session state。 */
+export function usePromptRecommendation(
+  sessionId: string | undefined,
+): PromptRecommendationSnapshot | undefined {
+  return useSyncExternalStore(
+    (listener) => subscribeSession(sessionId, listener),
+    () => getSessionSnapshot(sessionId),
+    () => getSessionSnapshot(sessionId),
+  );
+}
+
+/** candidate → predicting 的 compare-and-set；同 renderer 的分屏只允许一个请求。 */
+export function beginPromptRecommendationPrediction(
+  sessionId: string,
+  revision: number,
+): number | null {
+  const current = entries.get(sessionId);
+  if (!current || current.revision !== revision || current.phase !== 'candidate') return null;
+  const requestSeq = ++nextRequestSeq;
+  entries.set(sessionId, {
+    ...current,
+    phase: 'predicting',
+    requestSeq,
+  });
+  emitSession(sessionId);
+  return requestSeq;
+}
+
+/** 仅同 session + revision + requestSeq 的 Promise 可落地，旧轮结果静默丢弃。 */
+export function resolvePromptRecommendationPrediction(
+  sessionId: string,
+  revision: number,
+  requestSeq: number,
+  prompt: string | null,
+): void {
+  const current = entries.get(sessionId);
+  if (
+    !current ||
+    current.revision !== revision ||
+    current.requestSeq !== requestSeq ||
+    current.phase !== 'predicting'
+  ) {
+    return;
+  }
+  if (!prompt) {
+    deleteEntry(sessionId);
+    return;
+  }
+  entries.set(sessionId, {
+    ...current,
+    phase: 'ready',
+    prompt,
+  });
+  emitSession(sessionId);
+}
+
+/** Tab / 发送 / workingDir / 附件等消费路径同步作废当前推荐。 */
+export function dismissPromptRecommendation(sessionId: string, revision?: number): void {
+  const current = entries.get(sessionId);
+  if (!current || (revision != null && current.revision !== revision)) return;
+  deleteEntry(sessionId);
+}
+
+export function clearPromptRecommendationSession(sessionId: string): void {
+  clearSettleTimer(sessionId);
+  runningSessionIds.delete(sessionId);
+  sawRunningSessionIds.delete(sessionId);
+  runStartedAtBySession.delete(sessionId);
+  pendingCompletionRevisions.delete(sessionId);
+  handledCompletionRevisions.delete(sessionId);
+  deleteEntry(sessionId);
+}
+
+export const __testing = {
+  applyRunningSnapshot,
+  noteTurnEnded,
+  settleCompletion,
+  getSessionSnapshot,
+  reset(): void {
+    for (const unsubscribe of globalUnsubscribers.splice(0)) unsubscribe();
+    initialized = false;
+    ownerKey = null;
+    nextRequestSeq = 0;
+    clearRuntimeState();
+    sessionListeners.clear();
+  },
+};

--- a/apps/desktop/src/renderer/vite-env.d.ts
+++ b/apps/desktop/src/renderer/vite-env.d.ts
@@ -5743,6 +5743,7 @@ interface ElectronAPI {
       messages: Array<{ role: string; content: string }>;
       workingDir?: string;
       turnGen: number;
+      completionRevision: number;
     }) => Promise<{ prompt: string | null }>;
     helpAsk: (
       request: import('../shared/helpTypes').HelpAskRequest,


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复输入框推荐提示词的生命周期问题：推荐状态改为按任务隔离的运行期状态，后台完成的任务切回前台后可以补预测；输入文字时只隐藏推荐，清空后恢复；Main 按完成轮次复用结果并统一处理本机窗口与 Device Link 的 Stop，避免串任务、旧结果复活或重复付费调用。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：原功能 PR #1965；本次修复后台完成、任务切换和输入清空后的推荐生命周期。
- 本 PR 包含：Desktop Renderer 的任务级推荐状态、完成轮次跟踪、草稿水合与可见性门禁；Main 的完成轮次幂等缓存、显式 Stop ledger、provider dispatch 前后复核；preload 类型与回归测试。
- 明确不包含：不修改推荐 system/user prompt，不修改 provider/model/凭证路由，不新增 UI、文案、样式或设置项，不修改 Mobile UI。
- 用户可见变化：后台完成的任务切回后可显示自己的推荐词；任务间不串推荐；输入字符后清空会恢复推荐；Tab/发送/新一轮/附件/语音/目录变化仍按既有规则消费推荐。
- 是否存在 breaking change：无。

### UI 变化

不涉及视觉变化：未新增或修改布局、颜色、间距、动效、文案；继续复用现有推荐 overlay、Tab 交互和语义样式。

- 引用的设计规范：`docs/design-rules/DESIGN.md` 双模式交付约束；本 PR 没有新增颜色或样式，Light/Dark 继续使用现有实现。

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：通过（apps/desktop related 19）

pnpm --filter desktop run --if-present typecheck
结果：通过

聚焦回归测试：
- promptRecommendationStore
- composerPromptRecommendation
- usePromptRecommendationPreference
- makerChatStorePromptRecommendationStop
- predictPromptIpcBoundary
- promptPredictionRevision
- promptPredictionStopLedger
结果：7 个文件、70 个测试通过

相关文件定向 ESLint
结果：通过

pnpm check:dco
结果：通过，1 个 commit 已签名
```

### 手工验证

未执行实机视觉验证：本 PR 不改变视觉，生命周期、跨任务竞态、草稿水合、Stop 时序、provider 返回竞态和多窗口幂等均由自动化测试覆盖。

### 未执行的验证

- 全量 Desktop lint：仓库当前存在与本 PR 无关的既有 lint 错误；本次涉及的可独立检查文件已定向通过 ESLint。
- 未启动当前 checkout 的 Desktop，避免影响正在运行的宿主；以 typecheck、related unit gate 和聚焦竞态测试作为验证依据。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：Desktop 本地推荐生命周期与付费 one-shot 幂等边界

### 影响与回滚

- 影响范围：仅 Desktop 本地输入框推荐提示词。推荐状态只存在当前 Renderer/Main 运行期，不写 SQLite 或 localStorage；App 重启自然清空。
- 回滚 / 降级方式：回退本 PR 即恢复原组件本地状态与原预测去重方式；设置中的“输入框推荐提示词”开关仍可作为用户侧降级入口。

多端适配结论：

- SSH 远程工作区：保持既有 `remoteHostId` fail-closed，不调用本地推荐 provider；未新增 workdir 文件访问。
- Device Link：预测通道仍不进入远程 allowlist；被控端显式 Stop 经过既有 `maker:input:stop` 汇合到 Main ledger，可阻止 Stop 后推荐结果展示。
- Mobile：没有新增入口或 UI；手机版继续通过既有 Device Link 控制任务，无需同步改动。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在「UI 变化」注明引用的设计规范（本次无视觉变化）
- [x] 未提交凭证、令牌或授权文件
- [x] 已确认本次无需补充产品文档
- [x] 已确认测试结果或说明未执行原因
