### PR TITLE
fix(codex): 修复切换 Provider 后复用错配线程

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/codexCredentialSwitch.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codexCredentialSwitch.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  isCodexThreadModelProviderIdentityMismatch,
   prepareLocalSessionCredentialModeSwitch,
   prepareLocalCodexCredentialModeSwitch,
   shouldCloseSessionForCredentialSwitch,
@@ -72,7 +73,7 @@ describe('shouldCloseSessionForCredentialSwitch codex mode', () => {
   it('closes when the live thread is still OpenAI even if the provider store already says DeepSeek', () => {
     // 现场回归:provider store 已被选择器提前写成新来源,仅比较 current/next 会误判为
     // 同一家族；thread/start 的实际响应仍是 cindy_openai,必须以它为准重建。
-    expect(shouldCloseSessionForCredentialSwitch({
+    const input = {
       agentKind: 'codex',
       currentProviderId: 'deepseek',
       nextProviderId: 'deepseek',
@@ -80,11 +81,13 @@ describe('shouldCloseSessionForCredentialSwitch codex mode', () => {
       nextModel: 'deepseek/deepseek-v4-pro',
       currentCodexProxyActive: true,
       currentCodexThreadModelProviderId: 'cindy_openai',
-    })).toBe(true);
+    } as const;
+    expect(isCodexThreadModelProviderIdentityMismatch(input)).toBe(true);
+    expect(shouldCloseSessionForCredentialSwitch(input)).toBe(true);
   });
 
   it('keeps a matching gateway thread when the provider store already says DeepSeek', () => {
-    expect(shouldCloseSessionForCredentialSwitch({
+    const input = {
       agentKind: 'codex',
       currentProviderId: 'deepseek',
       nextProviderId: 'deepseek',
@@ -92,7 +95,9 @@ describe('shouldCloseSessionForCredentialSwitch codex mode', () => {
       nextModel: 'deepseek/deepseek-v4-pro',
       currentCodexProxyActive: true,
       currentCodexThreadModelProviderId: 'cindy_gateway',
-    })).toBe(false);
+    } as const;
+    expect(isCodexThreadModelProviderIdentityMismatch(input)).toBe(false);
+    expect(shouldCloseSessionForCredentialSwitch(input)).toBe(false);
   });
 
   it('still closes a gateway Codex session when switching to OAuth on a proxy-active host', () => {

--- a/apps/desktop/src/main/maker-host/__tests__/codexCredentialSwitch.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codexCredentialSwitch.test.ts
@@ -69,6 +69,32 @@ describe('shouldCloseSessionForCredentialSwitch codex mode', () => {
     })).toBe(false);
   });
 
+  it('closes when the live thread is still OpenAI even if the provider store already says DeepSeek', () => {
+    // 现场回归:provider store 已被选择器提前写成新来源,仅比较 current/next 会误判为
+    // 同一家族；thread/start 的实际响应仍是 cindy_openai,必须以它为准重建。
+    expect(shouldCloseSessionForCredentialSwitch({
+      agentKind: 'codex',
+      currentProviderId: 'deepseek',
+      nextProviderId: 'deepseek',
+      currentModel: 'deepseek/deepseek-v4-pro',
+      nextModel: 'deepseek/deepseek-v4-pro',
+      currentCodexProxyActive: true,
+      currentCodexThreadModelProviderId: 'cindy_openai',
+    })).toBe(true);
+  });
+
+  it('keeps a matching gateway thread when the provider store already says DeepSeek', () => {
+    expect(shouldCloseSessionForCredentialSwitch({
+      agentKind: 'codex',
+      currentProviderId: 'deepseek',
+      nextProviderId: 'deepseek',
+      currentModel: 'deepseek/deepseek-v4-pro',
+      nextModel: 'deepseek/deepseek-v4-pro',
+      currentCodexProxyActive: true,
+      currentCodexThreadModelProviderId: 'cindy_gateway',
+    })).toBe(false);
+  });
+
   it('still closes a gateway Codex session when switching to OAuth on a proxy-active host', () => {
     expect(shouldCloseSessionForCredentialSwitch({
       agentKind: 'codex',

--- a/apps/desktop/src/main/maker-host/codex-credential-switch.ts
+++ b/apps/desktop/src/main/maker-host/codex-credential-switch.ts
@@ -135,6 +135,51 @@ function normalizeProviderId(providerId: string | null | undefined): string | nu
   return trimmed || null;
 }
 
+/**
+ * app-server 已确认的 Codex thread provider 是否与指定路由期望的身份冲突。
+ *
+ * 调用方可把「下一目标路由」传进来判断是否需要重建，也可把「当前 provider store
+ * 路由」传进来区分 store/thread 已经错配，避免把仅需关闭单个 thread 的修复扩大成
+ * shared-host 凭证切换。
+ */
+export function isCodexThreadModelProviderIdentityMismatch(
+  input: ShouldCloseSessionForCredentialSwitchInput,
+): boolean {
+  if (
+    input.remoteHostId ||
+    input.agentKind !== 'codex' ||
+    input.currentCodexProxyActive !== true
+  ) {
+    return false;
+  }
+
+  const nextProviderId = normalizeProviderId(input.nextProviderId);
+  const nextMode = resolveAgentCredentialMode({
+    agentKind: input.agentKind,
+    providerId: nextProviderId,
+    model: input.nextModel,
+  });
+  const effectiveNextMode = nextMode ?? credentialFamilyFromAuthInjection(input.codexAuthInjection);
+  const expectedThreadModelProviderId =
+    effectiveNextMode === 'oauth-bearer'
+      ? CODEX_OPENAI_COMPACT_PROVIDER_ID
+      : effectiveNextMode !== undefined
+        ? CODEX_GATEWAY_PROVIDER_ID
+        : null;
+  const actualThreadModelProviderId = normalizeProviderId(
+    input.currentCodexThreadModelProviderId,
+  );
+  const actualThreadIdentityKnown =
+    actualThreadModelProviderId === CODEX_OPENAI_COMPACT_PROVIDER_ID ||
+    actualThreadModelProviderId === CODEX_GATEWAY_PROVIDER_ID;
+
+  return (
+    actualThreadIdentityKnown &&
+    expectedThreadModelProviderId !== null &&
+    actualThreadModelProviderId !== expectedThreadModelProviderId
+  );
+}
+
 function isLocalSession(session: LocalAgentSession): boolean {
   return !session.remoteHostId;
 }
@@ -211,27 +256,11 @@ export function shouldCloseSessionForCredentialSwitch(
     const fallbackFamily = credentialFamilyFromAuthInjection(input.codexAuthInjection);
     const effCurrent = currentMode ?? fallbackFamily;
     const effNext = nextMode ?? fallbackFamily;
-    const actualThreadModelProviderId = normalizeProviderId(
-      input.currentCodexThreadModelProviderId,
-    );
-    const expectedNextThreadModelProviderId =
-      effNext === 'oauth-bearer'
-        ? CODEX_OPENAI_COMPACT_PROVIDER_ID
-        : effNext !== undefined
-          ? CODEX_GATEWAY_PROVIDER_ID
-          : null;
-    const actualThreadIdentityKnown =
-      actualThreadModelProviderId === CODEX_OPENAI_COMPACT_PROVIDER_ID ||
-      actualThreadModelProviderId === CODEX_GATEWAY_PROVIDER_ID;
 
     // provider store 可能先于运行时切换被 UI/持久层覆盖。此时仅比较 currentMode/nextMode
     // 会把两边误判为同一家族，并在仍绑定 cindy_openai 的 thread 上热切 DeepSeek/xAI/XD。
     // start/resume 响应才是 thread 身份的事实源；与目标身份不一致就必须 close + resume。
-    if (
-      actualThreadIdentityKnown &&
-      expectedNextThreadModelProviderId !== null &&
-      actualThreadModelProviderId !== expectedNextThreadModelProviderId
-    ) {
+    if (isCodexThreadModelProviderIdentityMismatch(input)) {
       return true;
     }
     const mayTouchRemoteCompaction =

--- a/apps/desktop/src/main/maker-host/codex-credential-switch.ts
+++ b/apps/desktop/src/main/maker-host/codex-credential-switch.ts
@@ -7,6 +7,10 @@ import {
 } from '@cindy/maker-core';
 
 import { claudeToolSearchMode } from './claude-behavior-flags.js';
+import {
+  CODEX_GATEWAY_PROVIDER_ID,
+  CODEX_OPENAI_COMPACT_PROVIDER_ID,
+} from './codex-gateway-config.js';
 import type { CodexProxyAuthInjection } from './codex-proxy-host.js';
 import { withRehydrateCloseSuppressed } from './rehydrateCloseSuppression.js';
 
@@ -22,6 +26,11 @@ export interface ShouldCloseSessionForCredentialSwitchInput {
    * provider-oauth 依赖 proxy 做供应商 OAuth 注入和 model rewrite；未知状态按 false 处理。
    */
   currentCodexProxyActive?: boolean | null;
+  /**
+   * 当前 Codex thread 由 app-server 的 start/resume 响应确认的 model provider。
+   * 它是 thread 级冻结身份，不能用可能已被 UI 提前覆盖的 provider store 代替。
+   */
+  currentCodexThreadModelProviderId?: string | null;
   /**
    * 当前本地 Codex app-server spawn 的鉴权注入形态(getCodexProxyAuthInjectionState())。
    * 用于把隐式来源(resolveAgentCredentialMode 解析出 undefined)落到实际凭证家族,
@@ -202,6 +211,29 @@ export function shouldCloseSessionForCredentialSwitch(
     const fallbackFamily = credentialFamilyFromAuthInjection(input.codexAuthInjection);
     const effCurrent = currentMode ?? fallbackFamily;
     const effNext = nextMode ?? fallbackFamily;
+    const actualThreadModelProviderId = normalizeProviderId(
+      input.currentCodexThreadModelProviderId,
+    );
+    const expectedNextThreadModelProviderId =
+      effNext === 'oauth-bearer'
+        ? CODEX_OPENAI_COMPACT_PROVIDER_ID
+        : effNext !== undefined
+          ? CODEX_GATEWAY_PROVIDER_ID
+          : null;
+    const actualThreadIdentityKnown =
+      actualThreadModelProviderId === CODEX_OPENAI_COMPACT_PROVIDER_ID ||
+      actualThreadModelProviderId === CODEX_GATEWAY_PROVIDER_ID;
+
+    // provider store 可能先于运行时切换被 UI/持久层覆盖。此时仅比较 currentMode/nextMode
+    // 会把两边误判为同一家族，并在仍绑定 cindy_openai 的 thread 上热切 DeepSeek/xAI/XD。
+    // start/resume 响应才是 thread 身份的事实源；与目标身份不一致就必须 close + resume。
+    if (
+      actualThreadIdentityKnown &&
+      expectedNextThreadModelProviderId !== null &&
+      actualThreadModelProviderId !== expectedNextThreadModelProviderId
+    ) {
+      return true;
+    }
     const mayTouchRemoteCompaction =
       effCurrent === 'oauth-bearer' || effNext === 'oauth-bearer' ||
       effCurrent === undefined || effNext === undefined;

--- a/apps/desktop/src/main/maker-ipc/__tests__/runtimeSetModel.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/runtimeSetModel.test.ts
@@ -365,6 +365,42 @@ describe('applyRuntimeSetModelChange', () => {
     expect(getSessionProvider(sessionId)).toBe('xd');
   });
 
+  it('closes an idle OpenAI thread when the provider store was already overwritten with DeepSeek', async () => {
+    const sessionId = rememberSession('runtime-set-model-stale-openai-thread-to-deepseek');
+    setSessionProvider(sessionId, 'deepseek');
+    const setModel = vi.fn(async () => {});
+    const closeSession = vi.fn(async () => {});
+    const maker: RuntimeSetModelMaker = {
+      getSession: () => ({
+        agentKind: 'codex',
+        remoteHostId: null,
+        codexProxyActive: true,
+        codexThreadModelProviderId: 'cindy_openai',
+        model: 'deepseek/deepseek-v4-pro',
+        setModel,
+      }),
+      listActiveSessions: () => [{
+        id: sessionId,
+        agentKind: 'codex',
+        remoteHostId: null,
+        isTurnRunning: () => false,
+      }],
+      closeSession,
+    };
+
+    const result = await applyRuntimeSetModelChange({
+      maker,
+      sessionId,
+      model: 'deepseek/deepseek-v4-pro',
+      providerId: 'deepseek',
+    });
+
+    expect(result).toEqual({ status: 'applied' });
+    expect(closeSession).toHaveBeenCalledWith(sessionId);
+    expect(setModel).not.toHaveBeenCalled();
+    expect(getSessionProvider(sessionId)).toBe('deepseek');
+  });
+
   it('defers a busy subscription-to-XD Codex switch to the turn boundary (远端压缩身份边界)', async () => {
     const sessionId = rememberSession('runtime-set-model-busy-superset-no-channel');
     setSessionProvider(sessionId, 'openai');

--- a/apps/desktop/src/main/maker-ipc/runtimeSetModel.ts
+++ b/apps/desktop/src/main/maker-ipc/runtimeSetModel.ts
@@ -20,6 +20,7 @@ interface RuntimeSetModelSession {
   agentKind: AgentKind;
   remoteHostId?: string | null;
   codexProxyActive?: boolean | null;
+  codexThreadModelProviderId?: string | null;
   model: string;
   setModel: (model: string, opts?: { providerId?: string | null; effort?: Effort }) => Promise<void>;
 }
@@ -139,6 +140,7 @@ export async function applyRuntimeSetModelChange(
         currentModel: sess.model,
         nextModel: model,
         currentCodexProxyActive: sess.codexProxyActive,
+        currentCodexThreadModelProviderId: sess.codexThreadModelProviderId,
         codexAuthInjection: input.codexAuthInjection,
       })
     : false;

--- a/apps/desktop/src/main/scheduler-host/__tests__/runnerModelSelection.test.ts
+++ b/apps/desktop/src/main/scheduler-host/__tests__/runnerModelSelection.test.ts
@@ -1256,6 +1256,54 @@ describe('MakerScheduleRunner model selection', () => {
       );
     });
 
+    it('heartbeat 修复 Codex thread/store 错配时只关闭目标会话，不受其它忙会话阻塞', async () => {
+      mocks.getSessionRowSnapshot.mockResolvedValue({
+        status: 'active',
+        providerId: 'deepseek',
+      });
+      mocks.getSessionProvider.mockReturnValue('deepseek');
+      const h = createSessionHarness();
+      Object.defineProperties(h.session, {
+        agentKind: { value: 'codex' },
+        model: { value: 'deepseek/deepseek-v4-pro', writable: true },
+        codexProxyActive: { value: true },
+        codexThreadModelProviderId: { value: 'cindy_openai' },
+      });
+      const unrelatedBusyCodex = {
+        id: 'unrelated-busy-codex',
+        agentKind: 'codex',
+        remoteHostId: null,
+        isTurnRunning: () => true,
+      } as unknown as Session;
+      const harness = createRunnerHarness(
+        h,
+        {
+          model: 'deepseek/deepseek-v4-pro',
+          workDir: '/work',
+          sdkSessionId: 'sdk-1',
+        },
+        { sessionAlive: true, activeSessions: [h.session, unrelatedBusyCodex] },
+      );
+
+      await fireToCompletion(
+        harness,
+        h,
+        baseSchedule({
+          agentKind: 'codex',
+          model: 'deepseek/deepseek-v4-pro',
+          providerId: 'deepseek',
+          targetSessionId: 'scheduler-session',
+        }),
+      );
+
+      expect(harness.closeSession).toHaveBeenCalledTimes(1);
+      expect(harness.closeSession).toHaveBeenCalledWith('scheduler-session');
+      expect(harness.closeSession).not.toHaveBeenCalledWith('unrelated-busy-codex');
+      expect(harness.closeSession.mock.invocationCallOrder[0]).toBeLessThan(
+        harness.createSession.mock.invocationCallOrder[0],
+      );
+    });
+
     it('heartbeat 复用本地 Codex 且其它本地 Codex 正忙 → 顺延且不关闭任何会话', async () => {
       mocks.getSessionRowSnapshot.mockResolvedValue({ status: 'active', providerId: 'xd' });
       const h = createSessionHarness();

--- a/apps/desktop/src/main/scheduler-host/__tests__/runnerQueuedDispatch.test.ts
+++ b/apps/desktop/src/main/scheduler-host/__tests__/runnerQueuedDispatch.test.ts
@@ -705,6 +705,46 @@ describe('MakerScheduleRunner queued dispatch (busy bound session)', () => {
     expect(mocks.setSessionProvider).not.toHaveBeenCalled();
   });
 
+  it('排队 Codex 的 thread/store 身份错配时在 vendor dispatch 前 fail-closed', async () => {
+    mocks.getSessionRowSnapshot.mockResolvedValue({
+      status: 'active',
+      userSendAt: null,
+      providerId: 'deepseek',
+    });
+    mocks.getSessionProvider.mockReturnValue('deepseek');
+    const harness = createSessionHarness(async () => ({ accepted: true }));
+    Object.defineProperties(harness.session, {
+      agentKind: { value: 'codex' },
+      model: { value: 'deepseek/deepseek-v4-pro', writable: true },
+      codexProxyActive: { value: true },
+      codexThreadModelProviderId: { value: 'cindy_openai' },
+    });
+    const queue = createQueueHarness({ busy: true });
+    const { runner } = createRunnerHarness(harness.session, queue.deps, {
+      metaModel: 'deepseek/deepseek-v4-pro',
+    });
+
+    const firePromise = runner.fire(
+      heartbeatSchedule({
+        agentKind: 'codex',
+        model: 'deepseek/deepseek-v4-pro',
+        providerId: 'deepseek',
+      }),
+      createFireContext(),
+    );
+    const fireRejected = expect(firePromise).rejects.toThrow(
+      'queued heartbeat Codex thread provider identity does not match the current session route',
+    );
+    await vi.waitFor(() => expect(queue.enqueueCalls.length).toBe(1));
+    await queue.accept();
+
+    await fireRejected;
+    expect(harness.session.abort).toHaveBeenCalled();
+    expect(harness.setModel).not.toHaveBeenCalled();
+    expect(harness.setEffort).not.toHaveBeenCalled();
+    expect(mocks.setSessionProvider).not.toHaveBeenCalled();
+  });
+
   it('排队 Pi 每次派发都写 Fast=false，清掉复用会话的旧 bridge 状态', async () => {
     const harness = createSessionHarness(async () => ({ accepted: true }));
     (harness.session as { agentKind: string }).agentKind = 'pi';

--- a/apps/desktop/src/main/scheduler-host/runner.ts
+++ b/apps/desktop/src/main/scheduler-host/runner.ts
@@ -921,6 +921,7 @@ export class MakerScheduleRunner implements ScheduleRunner {
           currentModel: liveSession.model,
           nextModel: model,
           currentCodexProxyActive: liveSession.codexProxyActive,
+          currentCodexThreadModelProviderId: liveSession.codexThreadModelProviderId,
         })
       ) {
         if (isHeartbeat && isSessionInTurn(sessionId)) {
@@ -1323,6 +1324,7 @@ export class MakerScheduleRunner implements ScheduleRunner {
               currentModel: runtimeModel,
               nextModel: runtimeModel,
               currentCodexProxyActive: session.codexProxyActive,
+              currentCodexThreadModelProviderId: session.codexThreadModelProviderId,
             })
           ) {
             throw new Error(
@@ -2093,6 +2095,7 @@ export class MakerScheduleRunner implements ScheduleRunner {
         currentModel: live.model,
         nextModel: targetModel,
         currentCodexProxyActive: live.codexProxyActive,
+        currentCodexThreadModelProviderId: live.codexThreadModelProviderId,
       })
     ) {
       // 早退 = 本轮沿用 live 当前路由派发:这条保留路由自己也要过停用裁决 ——

--- a/apps/desktop/src/main/scheduler-host/runner.ts
+++ b/apps/desktop/src/main/scheduler-host/runner.ts
@@ -65,6 +65,7 @@ import {
 import { setSessionFastMode } from '../maker-host/session-effort-store.js';
 import {
   CredentialModeSwitchBusyError,
+  isCodexThreadModelProviderIdentityMismatch,
   prepareLocalCodexCredentialModeSwitch,
   prepareLocalSessionCredentialModeSwitch,
   shouldCloseSessionForCredentialSwitch,
@@ -288,6 +289,9 @@ class QueuedRouteDisabledError extends Error {}
 
 /** Pi 原生路由热切失败；继续派发会把任务发给旧 provider，必须在 vendor 前站下。 */
 class QueuedPiRouteSyncError extends Error {}
+
+/** 当前 Codex provider store 与 live thread 身份错配；继续派发会把模型送到错误上游。 */
+class QueuedCodexThreadIdentityMismatchError extends Error {}
 
 /**
  * 排队等派发超过 QUEUED_DISPATCH_MAX_WAIT_MS。用独立类型让 dispatchGate 的 catch
@@ -911,25 +915,39 @@ export class MakerScheduleRunner implements ScheduleRunner {
         reroutedProviderId ??
         materializedDefaultProviderId ??
         currentProviderId;
+      const credentialSwitchInput = liveSession
+        ? {
+            agentKind: liveSession.agentKind,
+            remoteHostId: liveSession.remoteHostId,
+            currentProviderId,
+            nextProviderId,
+            currentModel: liveSession.model,
+            nextModel: model,
+            currentCodexProxyActive: liveSession.codexProxyActive,
+            currentCodexThreadModelProviderId: liveSession.codexThreadModelProviderId,
+          }
+        : null;
       if (
         liveSession &&
-        shouldCloseSessionForCredentialSwitch({
-          agentKind: liveSession.agentKind,
-          remoteHostId: liveSession.remoteHostId,
-          currentProviderId,
-          nextProviderId,
-          currentModel: liveSession.model,
-          nextModel: model,
-          currentCodexProxyActive: liveSession.codexProxyActive,
-          currentCodexThreadModelProviderId: liveSession.codexThreadModelProviderId,
-        })
+        credentialSwitchInput &&
+        shouldCloseSessionForCredentialSwitch(credentialSwitchInput)
       ) {
+        // provider store 可能已先于 runtime 被覆盖。若 live thread 连「当前已登记路由」
+        // 都不匹配，这是单 thread 陈旧，不是 shared host 凭证切换；只关目标会话，
+        // 避免无关 Codex 会话被关闭或因其中一个正忙而阻塞修复。
+        const currentThreadRouteMismatch =
+          liveSession.agentKind === 'codex' &&
+          isCodexThreadModelProviderIdentityMismatch({
+            ...credentialSwitchInput,
+            nextProviderId: currentProviderId,
+            nextModel: liveSession.model,
+          });
         if (isHeartbeat && isSessionInTurn(sessionId)) {
           return this.failOrDeferSessionRunning(schedule, ctx, sessionId, true);
         }
         try {
           throwIfFireAborted(ctx.signal, 'credential mode switch');
-          if (liveSession.agentKind === 'codex') {
+          if (liveSession.agentKind === 'codex' && !currentThreadRouteMismatch) {
             await prepareLocalCodexCredentialModeSwitch({
               maker: this.deps.maker,
               isSessionInTurn,
@@ -958,6 +976,7 @@ export class MakerScheduleRunner implements ScheduleRunner {
           nextProviderId,
           fromModel: liveSession.model,
           toModel: model,
+          closeScope: currentThreadRouteMismatch ? 'session' : 'all-local-codex',
         });
       }
     }
@@ -1807,20 +1826,28 @@ export class MakerScheduleRunner implements ScheduleRunner {
         // 任务编辑器里选的 model/effort/来源在排队派发时刻热同步到会话(此回调
         // 运行于 vendor dispatch 之前,setModel 对本 turn 生效)—— 对齐直发路径
         // 的 4.4.1/4.4.2 语义,不让"任务改了模型且每轮都撞忙"的用户被静默忽略
-        // (PR #972 review P2)。凭证形态需要切换的场景无法热切,跳过并留日志。
+        // (PR #972 review P2)。凭证形态需要切换的场景无法热切；当前路由仍一致时
+        // 跳过并留日志，thread/store 已错配时 fail-closed。
         try {
           await this.applyQueuedHeartbeatRouting(schedule, live, routingBaseline);
         } catch (err) {
-          if (err instanceof QueuedRouteDisabledError || err instanceof QueuedPiRouteSyncError) {
-            // 停用轴准入拒绝(PR #744 review 第六轮):这次排队心跳是新的付费调用,
-            // 目标路由已被停用时不能"保持 live 路由继续派发"。此刻仍在 vendor
-            // dispatch 之前 —— 取消这次派发(同 late-dispatch 路径),run 以明确错误
-            // 失败收口(不含 abort 字样 ⇒ 引擎按 failed 记录)。
+          if (
+            err instanceof QueuedRouteDisabledError ||
+            err instanceof QueuedPiRouteSyncError ||
+            err instanceof QueuedCodexThreadIdentityMismatchError
+          ) {
+            // 停用轴拒绝、Pi 原生同步失败、Codex thread/store 错配都不能放行这次
+            // 新付费调用。此刻仍在 vendor dispatch 之前 —— 取消派发并让 run 以
+            // 明确错误失败收口(不含 abort 字样 ⇒ 引擎按 failed 记录)。
             failAfterAccept(err);
             failDispatch(err);
             blockAcceptedDispatch(
               live,
-              err instanceof QueuedPiRouteSyncError ? 'Pi route sync failed' : 'route disabled',
+              err instanceof QueuedPiRouteSyncError
+                ? 'Pi route sync failed'
+                : err instanceof QueuedCodexThreadIdentityMismatchError
+                  ? 'Codex thread provider identity mismatch'
+                  : 'route disabled',
             );
             return;
           }
@@ -2038,7 +2065,8 @@ export class MakerScheduleRunner implements ScheduleRunner {
    * 排队派发时刻的路由热同步:schedule 显式设置的 model / effort / 来源(供应商)
    * 优先于绑定会话当前值(与直发路径 4.4.1/4.4.2 同语义);留空沿用会话当前值。
    * 凭证形态需要关会话重建的组合(shouldCloseSessionForCredentialSwitch)无法在
-   * 派发时刻热切 —— 跳过本轮同步,沿用会话当前路由,下次空闲直发照常收敛。
+   * 派发时刻热切 —— 当前 thread 与当前 provider store 一致时跳过本轮同步、沿用
+   * 当前路由；两者已经错配时必须在 vendor dispatch 前失败，不能把新模型送到旧身份。
    * setModel / setEffort 成功才落库 meta,失败保留旧值让下轮重试(与直发路径的
    * 复用会话语义一致)。
    */
@@ -2086,6 +2114,22 @@ export class MakerScheduleRunner implements ScheduleRunner {
       }
     }
     const nextProviderId = applyProviderId ?? currentProviderId;
+    if (
+      isCodexThreadModelProviderIdentityMismatch({
+        agentKind: live.agentKind,
+        remoteHostId: live.remoteHostId,
+        currentProviderId,
+        nextProviderId: currentProviderId,
+        currentModel: live.model,
+        nextModel: live.model,
+        currentCodexProxyActive: live.codexProxyActive,
+        currentCodexThreadModelProviderId: live.codexThreadModelProviderId,
+      })
+    ) {
+      throw new QueuedCodexThreadIdentityMismatchError(
+        `queued heartbeat Codex thread provider identity does not match the current session route (session "${live.id}")`,
+      );
+    }
     if (
       shouldCloseSessionForCredentialSwitch({
         agentKind: live.agentKind,

--- a/packages/maker-core/src/agents/base-agent.ts
+++ b/packages/maker-core/src/agents/base-agent.ts
@@ -1588,6 +1588,11 @@ export interface AgentSessionHandle {
   /** Codex-only: 当前会话绑定的 app-server host 是否经 loopback proxy 出口。 */
   readonly codexProxyActive?: boolean;
   /**
+   * Codex-only: thread/start 或 thread/resume 响应确认的实际 model provider。
+   * 这是 thread 级冻结身份，不随 thread/settings/update 的模型切换改变。
+   */
+  readonly codexThreadModelProviderId?: string;
+  /**
    * Codex-only: start/resume 成功后,产品 prompt 这一次到底有没有进入
    * codex thread history。Maker 用这个事实更新 host 持久化 bit,避免再从
    * 全局 proxy 状态反推。其它 agent 不设置。

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -3515,6 +3515,51 @@ describe('CodexAgent.refreshLocalModels', () => {
 });
 
 describe('CodexAgent.startSession developerInstructions', () => {
+  it.each([
+    { action: 'start', resumeSessionId: undefined, expectedProvider: 'cindy_gateway' },
+    {
+      action: 'resume',
+      resumeSessionId: '11111111-1111-1111-1111-111111111111',
+      expectedProvider: 'cindy_openai',
+    },
+  ])('exposes the actual thread model provider returned by $action', async ({
+    resumeSessionId,
+    expectedProvider,
+  }) => {
+    const agent = new CodexAgent(createDeps());
+    installFakeHost(agent, (method) => {
+      if (method === Method.ThreadStart) {
+        return {
+          thread: { id: 'start-thread-id' },
+          model: 'gpt-5.4',
+          modelProvider: 'cindy_gateway',
+          cwd: '/repo',
+        };
+      }
+      if (method === Method.ThreadResume) {
+        return {
+          thread: { id: 'resume-thread-id' },
+          model: 'gpt-5.4',
+          modelProvider: 'cindy_openai',
+          cwd: '/repo',
+          approvalPolicy: 'never',
+          sandbox: { type: 'dangerFullAccess' },
+        };
+      }
+      return undefined;
+    });
+
+    const handle = await agent.startSession({
+      sessionId: `session-provider-response-${expectedProvider}`,
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+      ...(resumeSessionId ? { resumeSessionId } : {}),
+    });
+
+    expect(handle.codexThreadModelProviderId).toBe(expectedProvider);
+    await handle.close();
+  });
+
   it('rejects session creation when thread/start fails', async () => {
     const workingDir = path.join('workspace', 'repo');
     const agent = new CodexAgent(createDeps());

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -4993,6 +4993,7 @@ export class CodexAgent extends BaseAgent {
     });
     const useProxyChannel = isCodexProxyChannelReady();
     let threadId: string;
+    let codexThreadModelProviderId: string | undefined;
     let codexProductPromptDelivery: AgentSessionHandle['codexProductPromptDelivery'];
 
     /**
@@ -5088,6 +5089,7 @@ export class CodexAgent extends BaseAgent {
           mutableCatalogModel = resp.model;
         }
         threadId = resp.thread.id;
+        codexThreadModelProviderId = resp.modelProvider?.trim() || undefined;
         refreshCodexAutoReviewerRoute(threadId);
         if (hostUsesCodexProxy) {
           registerCodexDeveloperInstructions(threadId, developerInstructions);
@@ -5109,7 +5111,12 @@ export class CodexAgent extends BaseAgent {
         // the persisted thread last used Plan Mode. Inject the official Default
         // marker once; markCollaborationModeAccepted() suppresses repeats.
         planModeDefaultMarkerNeeded = true;
-        log.info('thread/resume ok', { threadId, model: resp.model, serviceTier: mutableServiceTier ?? null });
+        log.info('thread/resume ok', {
+          threadId,
+          model: resp.model,
+          modelProvider: codexThreadModelProviderId ?? null,
+          serviceTier: mutableServiceTier ?? null,
+        });
       } catch (e) {
         releaseHostBindingLeaseIfNeeded();
         log.error('thread/resume failed', { error: String(e), resumeSessionId: opts.resumeSessionId });
@@ -5162,6 +5169,7 @@ export class CodexAgent extends BaseAgent {
           mutableCatalogModel = resp.model;
         }
         threadId = resp.thread.id;
+        codexThreadModelProviderId = resp.modelProvider?.trim() || undefined;
         refreshCodexAutoReviewerRoute(threadId);
         if (hostUsesCodexProxy) {
           registerCodexDeveloperInstructions(threadId, developerInstructions);
@@ -5174,7 +5182,12 @@ export class CodexAgent extends BaseAgent {
         sdkSessionId = threadId;
         readonlyReferencesProfileActive = shouldUseReadonlyReferencesProfile();
         threadMayHaveRollout = false;
-        log.info('thread/start ok', { threadId, model: resp.model, serviceTier: mutableServiceTier ?? null });
+        log.info('thread/start ok', {
+          threadId,
+          model: resp.model,
+          modelProvider: codexThreadModelProviderId ?? null,
+          serviceTier: mutableServiceTier ?? null,
+        });
       } catch (e) {
         releaseHostBindingLeaseIfNeeded();
         log.error('thread/start failed', { error: String(e) });
@@ -5312,6 +5325,7 @@ export class CodexAgent extends BaseAgent {
         ) {
           mutableServiceTier = normalizeServiceTier(resp.serviceTier) ?? null;
         }
+        codexThreadModelProviderId = resp.modelProvider?.trim() || undefined;
         if (nextThreadId !== previousThreadId) {
           const released = await releaseCurrentThreadSubscription(
             'unused profile replacement release',
@@ -5412,6 +5426,7 @@ export class CodexAgent extends BaseAgent {
         } else if (resumeServiceTierGeneration !== serviceTierMutationGeneration) {
           void pushThreadSettings({ serviceTier: mutableServiceTier ?? null });
         }
+        codexThreadModelProviderId = resp.modelProvider?.trim() || undefined;
         readonlyReferencesProfileActive = 'permissions' in resumeThreadWorkspaceConfig;
         threadMayHaveRollout = true;
         log.debug('read-only reference profile restored before turn/start', {
@@ -10253,6 +10268,7 @@ export class CodexAgent extends BaseAgent {
       agentKind: 'codex',
       get model() { return mutableModel; },
       get codexProxyActive() { return hostUsesCodexProxy; },
+      get codexThreadModelProviderId() { return codexThreadModelProviderId; },
       get codexProductPromptDelivery() { return codexProductPromptDelivery; },
 
       validateSendOptions(sendOpts: SendOptions) {

--- a/packages/maker-core/src/session.ts
+++ b/packages/maker-core/src/session.ts
@@ -1145,6 +1145,11 @@ export class Session {
     return this.handle.codexProxyActive;
   }
 
+  /** Codex-only: app-server 确认的 thread 级 model provider 身份。 */
+  get codexThreadModelProviderId(): string | undefined {
+    return this.handle.codexThreadModelProviderId;
+  }
+
   /** Snapshot used by temporary host overrides to avoid undoing a newer user change. */
   get permissionModeState(): PermissionModeState {
     return { ...this.permissionModeStateValue };


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Codex 会话在 Provider 配置已切换、但存活 thread 仍冻结在旧 model provider 身份时被错误复用的问题。此前这类错配会让 XD / DeepSeek 等网关模型继续通过 ChatGPT/OpenAI thread 发送，最终返回“不支持使用 Codex + ChatGPT account”的 400。

本次以 app-server 的 `thread/start` / `thread/resume` 响应作为 thread 身份事实源；当它与下一目标路由期望的身份不一致时，只关闭当前会话并在下一次发送时按正确 Provider 重建，不重启共享 Codex host。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：现场报错 `deepseek/deepseek-v4-pro is not supported when using Codex with a ChatGPT account`
- 本 PR 包含：记录 Codex thread 的实际 model provider；在运行时切模型和调度任务复用判定中检查该身份；补充回归测试
- 明确不包含：数据库 schema / migration、本地数据库字段、Provider 配置格式、UI、服务端改动
- 用户可见变化：切换到与存活 thread 身份不一致的 Provider 后，下一条消息会重建正确 thread，不再沿用旧 ChatGPT/OpenAI thread 请求网关模型
- 是否存在 breaking change：无

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：通过（rebase 前完整执行）

pnpm --filter desktop exec vitest run src/main/maker-host/__tests__/codexCredentialSwitch.test.ts src/main/maker-ipc/__tests__/runtimeSetModel.test.ts
结果：通过，2 个文件、48 项测试

pnpm --filter @cindy/maker-core exec vitest run src/agents/codex/index.test.ts
结果：通过，1 个文件、509 项测试

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --filter @cindy/maker-core run --if-present typecheck
结果：通过（该包无 typecheck script，按仓库门禁跳过）

pnpm check:dco
结果：通过，origin/main..HEAD 共 1 个提交，DCO 已签名
```

### 手工验证

- 在 dev 隔离沙盒注入“Provider store 已切到 XD/DeepSeek，但 live thread 仍为 `cindy_openai`”的受控错配状态。
- 基线版本复现同一 400；修复版本会关闭旧 thread，以 `cindy_gateway` 身份重建后成功发送。
- 复核普通同身份切模仍复用会话，不扩大 host 重启范围。

### 未执行的验证

- 未在真实问题用户的原始运行现场复验：本机只有事后导入副本，无法保留对方机器上的 live thread；已用受控夹具注入等价错配状态覆盖。
- rebase 后再次运行完整 `pnpm test:unit:related` 时，本机残留的上一轮测试进程导致调度超时；清理后改为执行上述 557 项直接相关测试与 typecheck，均通过。rebase 前完整 related 门禁已通过。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：Codex 运行时会话重建时机

### 影响与回滚

- 影响范围：仅 Codex + loopback proxy 活跃、且 app-server 已确认的 thread provider 与下一目标路由身份不一致的会话。此时会增加一次当前会话 close/resume；共享 host 不重启。数据库、协议和持久配置不变。
- 回滚 / 降级方式：revert 本 PR 的单个提交即可恢复原复用判定；不会涉及数据回滚。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI，已注明）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次不改变公开配置或协议，无额外文档变更）
- [x] 已确认测试结果或说明未执行原因