### PR TITLE
fix(desktop): 跳过登录后界面状态跟上未登录模式

### DIFF
--- a/apps/desktop/src/renderer/__tests__/authContextRace.test.ts
+++ b/apps/desktop/src/renderer/__tests__/authContextRace.test.ts
@@ -45,16 +45,16 @@ describe('AuthContext auth-state races', () => {
     }
   });
 
-  it('repartitions the unified-picker stores on local-mode boundaries too', () => {
-    // 本地模式进出同样是一次 dataOwnerId 切换,而它们不经 applyIncomingState ——
-    // 漏接两个新 setter 会让本地模式读写上一个身份的收藏 / 引擎 override(2026-08-17
-    // review 第五轮 M5)。行为断言在 authContextSessionBoundary.test.tsx。
+  it('applies the complete owner transition on local-mode boundaries', () => {
+    // 本地模式进出同样是一次 dataOwnerId 切换。自己拼半套 setter 会漏草稿 /
+    // prompt / 模型可见性 / 记忆分区(2026-08-21 #3201 Codex P1)。行为断言在
+    // authContextSessionBoundary.test.tsx。
     for (const entry of ['const enterLocalMode = useCallback', 'const exitLocalMode = useCallback']) {
       const start = source.indexOf(entry);
       expect(start).toBeGreaterThan(-1);
-      const block = source.slice(start, source.indexOf('[runDataOwnerBoundary]', start));
-      expect(block).toContain('setModelEnginePrefsOwner(state.dataOwnerId);');
-      expect(block).toContain('setModelFavoritesOwner(state.dataOwnerId);');
+      const block = source.slice(start, source.indexOf('[applyIncomingState, runDataOwnerBoundary]', start));
+      expect(block).toContain('applyIncomingState(state);');
+      expect(block).not.toContain('setModelEnginePrefsOwner(state.dataOwnerId);');
     }
   });
 
@@ -84,18 +84,8 @@ describe('AuthContext auth-state races', () => {
     );
     const enterLocal = source.indexOf('const enterLocalMode = useCallback');
     const exitLocal = source.indexOf('const exitLocalMode = useCallback');
-    expect(
-      source.indexOf(
-        'publishDataOwnerGeneration(state.dataOwnerId, state.ownerGeneration);',
-        enterLocal,
-      ),
-    ).toBeLessThan(exitLocal);
-    expect(
-      source.indexOf(
-        'publishDataOwnerGeneration(state.dataOwnerId, state.ownerGeneration);',
-        exitLocal,
-      ),
-    ).toBeGreaterThan(exitLocal);
+    expect(source.indexOf('applyIncomingState(state);', enterLocal)).toBeLessThan(exitLocal);
+    expect(source.indexOf('applyIncomingState(state);', exitLocal)).toBeGreaterThan(exitLocal);
     expect(source).toContain('activeDataOwnerGenerationRef.current');
     expect(source).toContain('setDataOwnerRecoveryEpoch((epoch) => epoch + 1);');
     expect(appSource).toContain("`${dataOwnerId ?? 'signed-out'}:${dataOwnerRecoveryEpoch}`");

--- a/apps/desktop/src/renderer/__tests__/authContextSessionBoundary.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/authContextSessionBoundary.test.tsx
@@ -376,10 +376,9 @@ describe('AuthContext session cache boundaries', () => {
   });
 
   /**
-   * 本地模式也是一次 dataOwnerId 切换(2026-08-17 review 第五轮 M5)。enterLocalMode /
-   * exitLocalMode 此前只更新了 dataOwnerId 与另外几个 owner 分区 setter,漏掉统一模型选择器
-   * 新增的两根轴 —— 于是本地模式下读写的是**上一个身份**的收藏 / 引擎 override:跨身份可见,
-   * 还会把改动写进别人的账号。
+   * 本地模式也是一次 dataOwnerId 切换。enterLocalMode / exitLocalMode 必须走完整
+   * applyIncomingState,不能自己拼半套 setter —— 漏接任一 owner 分区都会让本地模式
+   * 读写上一个身份的数据:跨身份可见,还会把改动写进别人的账号。
    */
   it('repartitions unified-picker favorites and engine overrides across local mode', async () => {
     resetFavorites();

--- a/apps/desktop/src/renderer/components/auth/__tests__/GuestRoute.test.tsx
+++ b/apps/desktop/src/renderer/components/auth/__tests__/GuestRoute.test.tsx
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const authState = vi.hoisted(() => ({
+  current: {
+    mode: 'signed-out' as 'signed-out' | 'local' | 'cloud',
+    isInitializing: false,
+  },
+}));
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => authState.current,
+}));
+
+import { GuestRoute } from '../GuestRoute';
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/" element={<div data-testid="app-shell" />} />
+        <Route path="/login" element={<GuestRoute />}>
+          <Route index element={<div data-testid="login-page" />} />
+        </Route>
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('GuestRoute', () => {
+  afterEach(() => {
+    cleanup();
+    authState.current = {
+      mode: 'signed-out',
+      isInitializing: false,
+    };
+  });
+
+  it('keeps the login page for a real signed-out session', () => {
+    renderAt('/login');
+    expect(screen.getByTestId('login-page')).toBeTruthy();
+    expect(screen.queryByTestId('app-shell')).toBeNull();
+  });
+
+  it('leaves login once skip-sign-in has committed local mode', () => {
+    authState.current = {
+      mode: 'local',
+      isInitializing: false,
+    };
+    renderAt('/login');
+    expect(screen.getByTestId('app-shell')).toBeTruthy();
+    expect(screen.queryByTestId('login-page')).toBeNull();
+  });
+
+  it('leaves login for a cloud session', () => {
+    authState.current = {
+      mode: 'cloud',
+      isInitializing: false,
+    };
+    renderAt('/login');
+    expect(screen.getByTestId('app-shell')).toBeTruthy();
+    expect(screen.queryByTestId('login-page')).toBeNull();
+  });
+});

--- a/apps/desktop/src/renderer/components/login/LoginPage.tsx
+++ b/apps/desktop/src/renderer/components/login/LoginPage.tsx
@@ -119,6 +119,7 @@ export function LoginPage() {
     dispatch,
     dispatchWithResult,
     clearError,
+    enterLocalMode,
   } = useLogin();
   const { t } = useTranslation();
   const handoff = useLoginHandoff();
@@ -154,17 +155,19 @@ export function LoginPage() {
    * 在会话切过去之后落,不能由 requireConsent 提前落(竞态原因见那里的注释)。
    */
   const openLocalMode = async () => {
-    if (isLoading || localModePendingRef.current || !window.electronAPI?.authEnterLocal) return;
+    if (isLoading || localModePendingRef.current || !enterLocalMode) return;
     markLocalModeTransition(true);
     try {
-      await window.electronAPI.authEnterLocal();
+      // 必须走 AuthContext.enterLocalMode():它调同一条 IPC,并用返回值立刻改
+      // mode / canEnterApp。登录页自己调 authEnterLocal 只改主进程会话,界面
+      // 仍当自己没进来;广播一旦没赶上,再点一次也不会重播,登录页就钉死。
+      // GuestRoute 看到 mode === 'local' 后自己切走,不要在这里改 hash——
+      // canEnterApp 还是 false 时冲进受保护路由会被踢回 /login。
+      await enterLocalMode();
       // 顺序是硬要求:先 enter-local(main 侧 isLocalMode() 转真)再落同意,这样
       // acceptPrivacyConsent 广播出来的 allowed 恒为 false,TapDB 不会被拉起来发
       // device_login。反过来会开出一个真实的上报窗口(codex 审查 P1,#907)。
       persistPrivacyConsent();
-      // The auth state event normally redirects through GuestRoute. Keep the
-      // transition deterministic when the IPC response wins that race.
-      window.location.hash = '#/';
     } catch (error) {
       // 两个调用点都是 requireConsent(() => void openLocalMode()):抛出去没人接,
       // 会变成 unhandled rejection。IPC 失败(main 未就绪/通道异常)时停在登录页

--- a/apps/desktop/src/renderer/components/login/__tests__/LoginPage.consent.test.tsx
+++ b/apps/desktop/src/renderer/components/login/__tests__/LoginPage.consent.test.tsx
@@ -22,6 +22,7 @@ const loginHook = vi.hoisted(() => ({
     dispatch: vi.fn(async () => true),
     dispatchWithResult: vi.fn(async () => ({ success: true, code: null })),
     clearError: vi.fn(),
+    enterLocalMode: vi.fn(async (): Promise<void> => undefined),
   },
 }));
 
@@ -61,21 +62,8 @@ async function identifierState(scenario: string): Promise<AuthFlowState> {
   return reduceAuthFlow(null, { type: 'providers-loaded', providers });
 }
 
-function mount(state: AuthFlowState | null, extra?: Partial<typeof loginHook.value>) {
-  loginHook.value = {
-    isLoading: false,
-    errorCode: null,
-    loginState: state,
-    dispatch: vi.fn(async () => true),
-    dispatchWithResult: vi.fn(async () => ({ success: true, code: null })),
-    clearError: vi.fn(),
-    ...extra,
-  };
-  return render(<LoginPage />);
-}
-
 const openExternal = vi.fn(async () => ({ success: true }));
-const authEnterLocal = vi.fn(async () => ({ mode: 'local' }));
+const enterLocalMode = vi.fn(async (): Promise<void> => undefined);
 // 协议门放行时会把「已同意」落到 main(TapDB 采集的前置条件,见
 // main/analytics-settings-store.ts)。它是 fire-and-forget,不参与登录派发时序。
 const acceptPrivacyConsent = vi.fn(async () => ({
@@ -84,13 +72,27 @@ const acceptPrivacyConsent = vi.fn(async () => ({
   allowed: true,
 }));
 
+function mount(state: AuthFlowState | null, extra?: Partial<typeof loginHook.value>) {
+  loginHook.value = {
+    isLoading: false,
+    errorCode: null,
+    loginState: state,
+    dispatch: vi.fn(async () => true),
+    dispatchWithResult: vi.fn(async () => ({ success: true, code: null })),
+    clearError: vi.fn(),
+    enterLocalMode,
+    ...extra,
+  };
+  return render(<LoginPage />);
+}
+
 beforeEach(() => {
   openExternal.mockClear();
-  authEnterLocal.mockClear();
+  enterLocalMode.mockClear();
   acceptPrivacyConsent.mockClear();
   Object.defineProperty(window, 'electronAPI', {
     configurable: true,
-    value: { platform: 'darwin', openExternal, authEnterLocal, acceptPrivacyConsent },
+    value: { platform: 'darwin', openExternal, acceptPrivacyConsent },
   });
 });
 
@@ -243,18 +245,18 @@ describe('consent guard(未勾选拦截个人登录链路)', () => {
 
   // 2026-07-29 拍板(推翻同年 07-27「跳过登录免协议门」):不登录账号也是在用 Cindy
   // 客户端,跳过登录与个人账号登录同口径先过协议门。旧游客圆钮入口已删除。
-  it('「跳过登录」未勾选 → 弹窗且不进本地模式;同意 → 续接 authEnterLocal', async () => {
+  it('「跳过登录」未勾选 → 弹窗且不进本地模式;同意 → 续接 enterLocalMode', async () => {
     mount(await identifierState('providers:cn-social'));
     expect(screen.getByTestId('login-consent-radio').getAttribute('aria-checked')).toBe('false');
     await act(async () => {
       fireEvent.click(screen.getByTestId('login-skip-entry'));
     });
     expect(screen.getByTestId('login-consent-dialog')).toBeTruthy();
-    expect(authEnterLocal).not.toHaveBeenCalled();
+    expect(enterLocalMode).not.toHaveBeenCalled();
     await act(async () => {
       fireEvent.click(screen.getByTestId('login-consent-agree'));
     });
-    expect(authEnterLocal).toHaveBeenCalledTimes(1);
+    expect(enterLocalMode).toHaveBeenCalledTimes(1);
   });
 
   it('「跳过登录」不同意 → 停在登录页,不进本地模式', async () => {
@@ -264,7 +266,7 @@ describe('consent guard(未勾选拦截个人登录链路)', () => {
     });
     fireEvent.click(screen.getByTestId('login-consent-disagree'));
     expect(screen.queryByTestId('login-consent-dialog')).toBeNull();
-    expect(authEnterLocal).not.toHaveBeenCalled();
+    expect(enterLocalMode).not.toHaveBeenCalled();
     expect(screen.getByTestId('login-consent-radio').getAttribute('aria-checked')).toBe('false');
   });
 
@@ -275,19 +277,19 @@ describe('consent guard(未勾选拦截个人登录链路)', () => {
       fireEvent.click(screen.getByTestId('login-skip-entry'));
     });
     expect(screen.queryByTestId('login-consent-dialog')).toBeNull();
-    expect(authEnterLocal).toHaveBeenCalledTimes(1);
+    expect(enterLocalMode).toHaveBeenCalledTimes(1);
     expect(acceptPrivacyConsent).toHaveBeenCalled();
   });
 
-  /* 顺序回归(codex 审查 P1,#907):同意记录必须落在 auth:enter-local **之后**。
+  /* 顺序回归(codex 审查 P1,#907):同意记录必须落在 enterLocalMode **之后**。
      acceptPrivacyConsent 的 handler 会同步广播 allowed,而 allowed 的算式是
      isAnalyticsAllowed() && !isLocalMode() —— 提前落同意时 isLocalMode() 还是
      false,广播 allowed:true 会让 tapdbClient 当场 initSdk() 并发出 device_login,
      与「未登录态不上报」直接冲突。两个入口、勾选与弹窗两条路径都要锁。 */
   const expectConsentPersistedAfterEnterLocal = () => {
-    expect(authEnterLocal).toHaveBeenCalledTimes(1);
+    expect(enterLocalMode).toHaveBeenCalledTimes(1);
     expect(acceptPrivacyConsent).toHaveBeenCalledTimes(1);
-    expect(authEnterLocal.mock.invocationCallOrder[0]).toBeLessThan(
+    expect(enterLocalMode.mock.invocationCallOrder[0]).toBeLessThan(
       acceptPrivacyConsent.mock.invocationCallOrder[0],
     );
   };
@@ -312,24 +314,24 @@ describe('consent guard(未勾选拦截个人登录链路)', () => {
     expectConsentPersistedAfterEnterLocal();
   });
 
-  /* 并发窗口回归(codex 审查 P1 第二条,#907):auth:enter-local 的 handler 要 await
+  /* 并发窗口回归(codex 审查 P1 第二条,#907):enterLocalMode 最终仍要 await
      waitForSessionInvalidation() + teardownAuthAccountBoundary(),这段窗口里 isLoading
      仍是 false、弹窗已关、consentAccepted 已为 true,于是邮箱 / 社交等入口仍可点。
      它们走 deferConsentPersist=false 分支,会在 main 还没转成 local 时立刻 persist,
      把 allowed:true 广播给 TapDB —— 必须一个都不放过。 */
   it('会话切换窗口内点社交圆钮 → 不派发、不落同意;切换完成后只落 skip 自己那一次', async () => {
     let releaseEnterLocal: () => void = () => undefined;
-    authEnterLocal.mockImplementationOnce(
+    enterLocalMode.mockImplementationOnce(
       () =>
-        new Promise((resolve) => {
-          releaseEnterLocal = () => resolve({ mode: 'local' });
+        new Promise<void>((resolve) => {
+          releaseEnterLocal = () => resolve();
         }),
     );
     mount(await identifierState('providers:cn-social'));
     fireEvent.click(screen.getByTestId('login-consent-radio'));
     // 不 await:enter-local 故意悬挂在窗口里
     fireEvent.click(screen.getByTestId('login-skip-entry'));
-    expect(authEnterLocal).toHaveBeenCalledTimes(1);
+    expect(enterLocalMode).toHaveBeenCalledTimes(1);
     expect(acceptPrivacyConsent).not.toHaveBeenCalled();
 
     // 窗口内点其它过门入口:一律作废
@@ -345,7 +347,7 @@ describe('consent guard(未勾选拦截个人登录链路)', () => {
     });
     // 只有 skip 自己那一次同意记录,且它落在 enter-local 之后
     expect(acceptPrivacyConsent).toHaveBeenCalledTimes(1);
-    expect(authEnterLocal.mock.invocationCallOrder[0]).toBeLessThan(
+    expect(enterLocalMode.mock.invocationCallOrder[0]).toBeLessThan(
       acceptPrivacyConsent.mock.invocationCallOrder[0],
     );
   });
@@ -360,7 +362,7 @@ describe('consent guard(未勾选拦截个人登录链路)', () => {
     });
     // 账号登录链路登录后 isLocalMode() 为 false、allowed 本就该为真,顺序无需延后
     expect(acceptPrivacyConsent).toHaveBeenCalledTimes(1);
-    expect(authEnterLocal).not.toHaveBeenCalled();
+    expect(enterLocalMode).not.toHaveBeenCalled();
   });
 
   /* error 步 footer 的逃生入口(login-local-mode)与面板内入口共用 openLocalMode,
@@ -378,14 +380,14 @@ describe('consent guard(未勾选拦截个人登录链路)', () => {
       fireEvent.click(screen.getByTestId('login-local-mode'));
     });
     expect(screen.getByTestId('login-consent-dialog')).toBeTruthy();
-    expect(authEnterLocal).not.toHaveBeenCalled();
+    expect(enterLocalMode).not.toHaveBeenCalled();
     await act(async () => {
       fireEvent.click(screen.getByTestId('login-consent-agree'));
     });
-    expect(authEnterLocal).toHaveBeenCalledTimes(1);
+    expect(enterLocalMode).toHaveBeenCalledTimes(1);
     expect(acceptPrivacyConsent).toHaveBeenCalledTimes(1);
     // 顺序同面板内入口:先切会话再落同意(见下方顺序回归组的注释)
-    expect(authEnterLocal.mock.invocationCallOrder[0]).toBeLessThan(
+    expect(enterLocalMode.mock.invocationCallOrder[0]).toBeLessThan(
       acceptPrivacyConsent.mock.invocationCallOrder[0],
     );
   });
@@ -397,7 +399,7 @@ describe('consent guard(未勾选拦截个人登录链路)', () => {
     });
     fireEvent.click(screen.getByTestId('login-consent-disagree'));
     expect(screen.queryByTestId('login-consent-dialog')).toBeNull();
-    expect(authEnterLocal).not.toHaveBeenCalled();
+    expect(enterLocalMode).not.toHaveBeenCalled();
     // 逃生入口本身必须还在(不同意不等于把这条唯一出路关掉)
     expect(screen.getByTestId('login-local-mode')).toBeTruthy();
   });

--- a/apps/desktop/src/renderer/components/login/__tests__/LoginPage.region.harness.test.tsx
+++ b/apps/desktop/src/renderer/components/login/__tests__/LoginPage.region.harness.test.tsx
@@ -27,6 +27,7 @@ const loginHook = vi.hoisted(() => ({
     dispatch: vi.fn(async () => true),
     dispatchWithResult: vi.fn(async () => ({ success: true, code: null })),
     clearError: vi.fn(),
+    enterLocalMode: vi.fn(async (): Promise<void> => undefined),
   },
 }));
 
@@ -64,6 +65,14 @@ async function globalIdentifierState(scenario = 'providers:global-social'): Prom
   return reduceAuthFlow(null, { type: 'providers-loaded', providers });
 }
 
+const openExternal = vi.fn(async () => ({ success: true }));
+const enterLocalMode = vi.fn(async (): Promise<void> => undefined);
+const acceptPrivacyConsent = vi.fn(async () => ({
+  privacyConsentAccepted: true,
+  analyticsEnabled: true,
+  allowed: true,
+}));
+
 function mount(state: AuthFlowState | null, extra?: Partial<typeof loginHook.value>) {
   loginHook.value = {
     isLoading: false,
@@ -72,28 +81,21 @@ function mount(state: AuthFlowState | null, extra?: Partial<typeof loginHook.val
     dispatch: vi.fn(async () => true),
     dispatchWithResult: vi.fn(async () => ({ success: true, code: null })),
     clearError: vi.fn(),
+    enterLocalMode,
     ...extra,
   };
   return render(<LoginPage />);
 }
 
-const openExternal = vi.fn(async () => ({ success: true }));
-const authEnterLocal = vi.fn(async () => ({ mode: 'local' }));
-const acceptPrivacyConsent = vi.fn(async () => ({
-  privacyConsentAccepted: true,
-  analyticsEnabled: true,
-  allowed: true,
-}));
-
 beforeEach(() => {
   // isGlobalBuild 在渲染时读 import.meta.env,必须在 render 前置好
   vi.stubEnv('VITE_CINDY_AUTH_REGION', 'global');
   openExternal.mockClear();
-  authEnterLocal.mockClear();
+  enterLocalMode.mockClear();
   acceptPrivacyConsent.mockClear();
   Object.defineProperty(window, 'electronAPI', {
     configurable: true,
-    value: { platform: 'darwin', openExternal, authEnterLocal, acceptPrivacyConsent },
+    value: { platform: 'darwin', openExternal, acceptPrivacyConsent },
   });
 });
 
@@ -160,12 +162,12 @@ describe('Global 构建变体:登录改版四件事同样生效', () => {
       fireEvent.click(screen.getByTestId('login-skip-entry'));
     });
     expect(screen.getByTestId('login-consent-dialog')).toBeTruthy();
-    expect(authEnterLocal).not.toHaveBeenCalled();
+    expect(enterLocalMode).not.toHaveBeenCalled();
     expect(acceptPrivacyConsent).not.toHaveBeenCalled();
     await act(async () => {
       fireEvent.click(screen.getByTestId('login-consent-agree'));
     });
-    expect(authEnterLocal).toHaveBeenCalledTimes(1);
+    expect(enterLocalMode).toHaveBeenCalledTimes(1);
     expect(acceptPrivacyConsent).toHaveBeenCalled();
   });
 

--- a/apps/desktop/src/renderer/contexts/AuthContext.tsx
+++ b/apps/desktop/src/renderer/contexts/AuthContext.tsx
@@ -391,46 +391,17 @@ export function AuthProvider({
   }, [runDataOwnerBoundary]);
 
   const enterLocalMode = useCallback(async () => {
+    // 本地模式也是一次 dataOwnerId 切换。必须走 applyIncomingState,不能自己拼半套
+    // setter:漏接草稿 / prompt / 模型可见性 / 记忆分区会让跳过登录进主界面后仍读写
+    // signed-out 槽(2026-08-21 #3201 Codex P1)。
     const state = await runDataOwnerBoundary(() => authServiceRef.current!.enterLocalMode());
-    publishDataOwnerGeneration(state.dataOwnerId, state.ownerGeneration);
-    activeDataOwnerIdRef.current = state.dataOwnerId;
-    activeDataOwnerGenerationRef.current = state.ownerGeneration;
-    // 统一模型选择器的两根轴与本地模式的其它 owner 分区同待遇(2026-08-17 review 第五轮 M5):
-    // 本地模式也是一次 dataOwnerId 切换,漏接这两个 setter 会让本地模式下的收藏 / 引擎 override
-    // 继续读写**上一个身份**的分区 —— 跨身份可见,还会把改动写进别人的账号。
-    setModelEnginePrefsOwner(state.dataOwnerId);
-    setModelFavoritesOwner(state.dataOwnerId);
-    // 收藏**锚点**记忆(面板上哪一行打勾)与收藏本体同分区:漏接同样是多账号串号。
-    setFavoriteAnchorMemoryOwner(state.dataOwnerId);
-    setComposerDraftOwner(state.dataOwnerId);
-    setPendingHandoffOwner(state.dataOwnerId);
-    setDeferredUiAssignmentOwner(state.dataOwnerId);
-    setMode(state.mode);
-    setDataOwnerId(state.dataOwnerId);
-    setCanEnterApp(state.canEnterApp);
-    setIsAuthenticated(state.isAuthenticated);
-    setUser(state.user);
-  }, [runDataOwnerBoundary]);
+    applyIncomingState(state);
+  }, [applyIncomingState, runDataOwnerBoundary]);
 
   const exitLocalMode = useCallback(async () => {
     const state = await runDataOwnerBoundary(() => authServiceRef.current!.exitLocalMode());
-    publishDataOwnerGeneration(state.dataOwnerId, state.ownerGeneration);
-    activeDataOwnerIdRef.current = state.dataOwnerId;
-    activeDataOwnerGenerationRef.current = state.ownerGeneration;
-    // 退出本地模式同样是一次 owner 切换:两根轴必须一起跟过去(见 enterLocalMode 的注释)。
-    setModelEnginePrefsOwner(state.dataOwnerId);
-    setModelFavoritesOwner(state.dataOwnerId);
-    // 收藏**锚点**记忆(面板上哪一行打勾)与收藏本体同分区:漏接同样是多账号串号。
-    setFavoriteAnchorMemoryOwner(state.dataOwnerId);
-    setComposerDraftOwner(state.dataOwnerId);
-    setPendingHandoffOwner(state.dataOwnerId);
-    setDeferredUiAssignmentOwner(state.dataOwnerId);
-    setMode(state.mode);
-    setDataOwnerId(state.dataOwnerId);
-    setCanEnterApp(state.canEnterApp);
-    setIsAuthenticated(state.isAuthenticated);
-    setUser(state.user);
-  }, [runDataOwnerBoundary]);
+    applyIncomingState(state);
+  }, [applyIncomingState, runDataOwnerBoundary]);
 
   const getAccountDeletionAvailability = useCallback(
     () => authServiceRef.current!.getAccountDeletionAvailability(),

--- a/apps/desktop/src/renderer/hooks/useLogin.ts
+++ b/apps/desktop/src/renderer/hooks/useLogin.ts
@@ -21,6 +21,12 @@ interface UseLoginReturn {
     action: DesktopLoginAction,
   ) => Promise<{ success: boolean; code: string | null }>;
   clearError: () => void;
+  /**
+   * 「跳过登录」必须走这里,不能直接调 `authEnterLocal` IPC。
+   * AuthContext 会用返回值立刻改 `mode` / `canEnterApp`;绕过它只改主进程会话,
+   * 界面仍停在登录页,再点一次也不会重播状态。
+   */
+  enterLocalMode: ReturnType<typeof useAuth>['enterLocalMode'];
 }
 
 /** Coordinates presentation state while all credentials and tickets stay in main. */
@@ -32,6 +38,7 @@ export function useLogin(): UseLoginReturn {
     hasAccountDeletionReceipt,
     getAccountDeletionStatus,
     clearAccountDeletionReceipt,
+    enterLocalMode,
   } = useAuth();
   const [isLoading, setIsLoading] = useState(false);
   const [errorCode, setErrorCode] = useState<string | null>(null);
@@ -94,5 +101,6 @@ export function useLogin(): UseLoginReturn {
     dispatch,
     dispatchWithResult,
     clearError: () => setErrorCode(null),
+    enterLocalMode,
   };
 }


### PR DESCRIPTION
## 这次改了什么

### 摘要

点「跳过登录」并确认协议后，主进程已经切到未登录模式，登录页有时仍停着，再点一次也进不去。原因是登录页自己调了 `authEnterLocal` IPC，只改主进程会话，界面状态没跟上。现在改走 `AuthContext.enterLocalMode()`，用 IPC 返回值立刻更新 `mode` / `canEnterApp`，让登录页切走。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无（开发版跳过登录后停在登录页的存量 bug）
- 本 PR 包含：
  - 登录页「跳过登录」和 error 步逃生入口改走 `useLogin().enterLocalMode()`
  - 删除 `window.location.hash = '#/'` 硬跳，避免状态未更新时冲进受保护路由再被踢回
  - 协议同意仍在进入 local 之后落盘（#907 顺序不变）
  - consent / region 测试改断言 `enterLocalMode`
  - 补 GuestRoute：`mode === 'local'` 时离开登录页
- 明确不包含：主进程会话切换、协议门产品口径、资源监视器
- 用户可见变化：确认协议后应进入未登录主界面，不再停在登录页
- 是否存在 breaking change：无

### UI 变化

不涉及：命中登录页代码路径，但没有改按钮、文案、布局或协议弹窗；只改进入未登录态的状态更新路径。

- 引用的设计规范：不涉及：无视觉 / 交互 / 文案变化

## 怎么验证的

### 自动验证

```text
cd /Users/dash/Code/Cindy/cindy-fix-skip-login-enter-local/apps/desktop
pnpm exec vitest run src/renderer/components/login src/renderer/components/auth/__tests__/GuestRoute.test.tsx
结果：17 files / 174 tests passed

pnpm --filter desktop run --if-present typecheck
结果：passed

pnpm check:dco
结果：1 commit signed off — range 41dcc9e3..ddde7262

pnpm test:unit:related
结果：reviewer 复核时 passed（apps/desktop unit 14.1s）

bash /Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh <worktree>
结果：排队后跑全量 unit；apps/desktop 2 条 ghostInstallReceipt.test.ts 失败。已在干净 origin/main（41dcc9e30）复现同一失败，与本 PR diff 无关，交给 CI 兜底，不混入修复。
```

### 手工验证

未在本机再点一次「跳过登录」。开发版热更新后可在登录页未勾选协议 → 点「跳过登录」→ 同意弹窗，确认进入未登录主界面；再冷启动一次确认不会钉死。

### 未执行的验证

未实机点「跳过登录」。全量 `pnpm test:unit` 在基线上已有无关失败（`ghostInstallReceipt.test.ts`），本 PR 未修。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop 登录页「跳过登录」进入未登录态的界面状态同步
- 回滚 / 降级方式：回退本 PR 即可；主进程会话切换未改

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
