### PR TITLE
feat(composer): add styled Tab shortcut badge to recommendation overlay

### DIFF
--- a/apps/desktop/src/renderer/__tests__/promptRecommendationBadge.test.ts
+++ b/apps/desktop/src/renderer/__tests__/promptRecommendationBadge.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const rendererRoot = resolve(__dirname, '..');
+const chatInputSource = readFileSync(
+  resolve(rendererRoot, 'components', 'new-chat', 'ChatInput.tsx'),
+  'utf8',
+);
+
+describe('prompt recommendation shortcut badge', () => {
+  it('keeps the prompt shrinkable while reserving space for a pill badge', () => {
+    expect(chatInputSource).toContain('className="min-w-0 flex-1 truncate"');
+    expect(chatInputSource).toContain(
+      "'ml-1.5 inline-flex shrink-0 items-center rounded-full border'",
+    );
+  });
+
+  it('uses the complete locale catalog for the visible key label', () => {
+    expect(chatInputSource).toContain("t('newChat.chatInput.recommendationShortcut')");
+    for (const locale of ['en', 'ja', 'ko', 'zh-CN', 'zh-TW']) {
+      const catalog = JSON.parse(
+        readFileSync(resolve(rendererRoot, 'i18n', 'locales', locale, 'common.json'), 'utf8'),
+      ) as { newChat?: { chatInput?: { recommendationShortcut?: string } } };
+      expect(catalog.newChat?.chatInput?.recommendationShortcut).toBe('Tab');
+    }
+  });
+});

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -7962,13 +7962,23 @@ export function ChatInput({
                 {showRecommendationOverlay && (
                   <div
                     className={cn(
-                      'pointer-events-none absolute left-0 top-0 w-full truncate py-[3px]',
+                      'pointer-events-none absolute left-0 top-0 flex w-full min-w-0 items-center truncate py-[3px]',
                       'text-15 leading-[1.467] font-normal',
                       'text-[var(--chat-input-placeholder-subtle)]',
                     )}
                     aria-hidden="true"
                   >
-                    {recommendedPrompt}
+                    <span className="min-w-0 truncate">{recommendedPrompt}</span>
+                    <kbd
+                      className={cn(
+                        'ml-1.5 inline-flex shrink-0 items-center rounded border',
+                        'border-[var(--chat-input-border)] bg-[var(--perm-code-bg)]',
+                        'px-1 py-[1px] text-11 font-normal',
+                        'text-[var(--status-bar-meta)]',
+                      )}
+                    >
+                      {t('Tab', 'Tab')}
+                    </kbd>
                   </div>
                 )}
               </div>

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -7968,16 +7968,16 @@ export function ChatInput({
                     )}
                     aria-hidden="true"
                   >
-                    <span className="min-w-0 truncate">{recommendedPrompt}</span>
+                    <span className="min-w-0 flex-1 truncate">{recommendedPrompt}</span>
                     <kbd
                       className={cn(
-                        'ml-1.5 inline-flex shrink-0 items-center rounded border',
+                        'ml-1.5 inline-flex shrink-0 items-center rounded-full border',
                         'border-[var(--chat-input-border)] bg-[var(--perm-code-bg)]',
                         'px-1 py-[1px] text-11 font-normal',
                         'text-[var(--status-bar-meta)]',
                       )}
                     >
-                      {t('Tab', 'Tab')}
+                      {t('newChat.chatInput.recommendationShortcut')}
                     </kbd>
                   </div>
                 )}

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -6624,6 +6624,7 @@
     "chatInput": {
       "defaultPlaceholder": "What shall we work on today~",
       "createAgentPlaceholder": "Hi {{appName}}!",
+      "recommendationShortcut": "Tab",
       "voiceInput": {
         "start": "Start voice input",
         "stop": "Stop voice input",

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -6622,6 +6622,7 @@
     "chatInput": {
       "defaultPlaceholder": "今日は何をしましょうか〜",
       "createAgentPlaceholder": "{{appName}}さん、こんにちは！",
+      "recommendationShortcut": "Tab",
       "voiceInput": {
         "start": "音声入力を開始",
         "stop": "音声入力を停止",

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -6622,6 +6622,7 @@
     "chatInput": {
       "defaultPlaceholder": "오늘은 무엇을 할까요~",
       "createAgentPlaceholder": "안녕하세요, {{appName}}!",
+      "recommendationShortcut": "Tab",
       "voiceInput": {
         "start": "음성 입력 시작",
         "stop": "음성 입력 중지",

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -6622,6 +6622,7 @@
     "chatInput": {
       "defaultPlaceholder": "今天我们做点什么呢~",
       "createAgentPlaceholder": "你好，{{appName}}！",
+      "recommendationShortcut": "Tab",
       "voiceInput": {
         "start": "开始语音输入",
         "stop": "停止语音输入",

--- a/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
@@ -6622,6 +6622,7 @@
     "chatInput": {
       "defaultPlaceholder": "今天我們做點什麼呢~",
       "createAgentPlaceholder": "你好，{{appName}}！",
+      "recommendationShortcut": "Tab",
       "voiceInput": {
         "start": "開始語音輸入",
         "stop": "停止語音輸入",


### PR DESCRIPTION
## 这次改了什么

### 摘要

Adds a keyboard-style Tab badge next to the composer recommendation overlay so the insertion shortcut is immediately discoverable.

### 变更类型

- [x] feat 新功能

### 范围

- 关联 Issue / 需求：#3180
- 本 PR 包含：推荐文本 flex 布局、Tab 键帽、本地化资源与回归测试
- 用户可见变化：推荐提示词右侧显示 Tab 键帽

### UI 变化

推荐文本在窄输入框中可收缩并省略，Tab 键帽保持可见；键帽使用设计系统规定的 pill 圆角。

- 引用的设计规范：docs/design-rules/DESIGN.md badge 圆角规范——键帽使用 pill 档 rounded-full；Light / Dark 颜色复用语义 token。

## 怎么验证的

### 自动验证

- corepack pnpm --filter desktop exec vitest run src/renderer/__tests__/promptRecommendationBadge.test.ts：通过（2 tests）
- corepack pnpm test:unit:related：通过
- corepack pnpm --filter desktop run --if-present typecheck：通过
- corepack pnpm check:i18n：通过
- corepack pnpm check:i18n-glossary：通过

### 手工验证

未启动 Desktop 实例；窄宽度、pill 圆角和五语资源契约由回归测试覆盖。

### 未执行的验证

- 未做 Light / Dark 实机目检。

## 风险

### 风险分类

- [x] 低风险：仅调整推荐浮层中的提示布局与键帽文案

### 影响与回滚

- 影响范围：composer 推荐提示浮层
- 回滚方式：回滚本 PR 的推荐键帽改动

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] UI 改动已注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已确认测试结果