### PR TITLE
fix(desktop): broadcast session status changes to all windows

### DIFF
--- a/apps/desktop/src/main/localDb/ipc/__tests__/sessionsUpdate.test.ts
+++ b/apps/desktop/src/main/localDb/ipc/__tests__/sessionsUpdate.test.ts
@@ -8,6 +8,10 @@
  *
  * 通过 mock electron ipcMain 捕获真实 handler + 内存 sqlite 全列 sessions 表做集成断言。
  */
+import { mkdtempSync, rmSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
 import Database from 'better-sqlite3';
 import { drizzle } from 'drizzle-orm/better-sqlite3';
 import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from 'vitest';
@@ -31,6 +35,7 @@ const h = vi.hoisted(() => ({
   routeLock: vi.fn(async <T>(_sessionId: string, task: () => Promise<T>): Promise<T> =>
     task(),
   ) as SessionRouteLockMock,
+  userDataDir: null as string | null,
 }));
 
 vi.mock('electron', () => ({
@@ -40,8 +45,11 @@ vi.mock('electron', () => ({
     }),
   },
   BrowserWindow: { getAllWindows: () => [] },
-  // status 写路径会经 removeHookAttachmentDir 调 app.getPath('userData')，需提供桩。
-  app: { getPath: () => '/tmp/cindy-test-user-data' },
+  // status 写路径(removeHookAttachmentDir / removeTurnChangeSetsForSession)会调
+  // app.getPath('userData') 并对真实文件系统做 fire-and-forget fs.rm。这里返回每次
+  // 测试用 mkdtemp 生成的独立目录，避免并发 worktree 共享同一字面量路径互相删 fixture，
+  // 也避免 Windows 把 POSIX 字面量解析成盘符根相对路径。
+  app: { getPath: () => h.userDataDir },
 }));
 vi.mock('../../../logger', () => ({
   createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
@@ -170,6 +178,7 @@ beforeEach(() => {
   h.relocate.mockImplementation(async () => ({ persistedSdkSessionId: null }));
   h.routeLock.mockImplementation(async (_sessionId, task) => task());
   h.handlers.clear();
+  h.userDataDir = mkdtempSync(path.join(os.tmpdir(), 'cindy-sessions-update-'));
   createDb();
   setSessionRouteLockImplementation(h.routeLock);
   registerSessionIpc();
@@ -177,6 +186,11 @@ beforeEach(() => {
 
 afterEach(() => {
   setSessionRouteLockImplementation(null);
+  const dir = h.userDataDir;
+  if (dir) {
+    rmSync(dir, { recursive: true, force: true });
+    h.userDataDir = null;
+  }
 });
 
 describe('local-db:sessions:update handler wiring', () => {

--- a/apps/desktop/src/main/localDb/ipc/__tests__/sessionsUpdate.test.ts
+++ b/apps/desktop/src/main/localDb/ipc/__tests__/sessionsUpdate.test.ts
@@ -40,6 +40,8 @@ vi.mock('electron', () => ({
     }),
   },
   BrowserWindow: { getAllWindows: () => [] },
+  // status 写路径会经 removeHookAttachmentDir 调 app.getPath('userData')，需提供桩。
+  app: { getPath: () => '/tmp/cindy-test-user-data' },
 }));
 vi.mock('../../../logger', () => ({
   createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
@@ -229,6 +231,24 @@ describe('local-db:sessions:update handler wiring', () => {
       expect.objectContaining({
         sessionId: 'codex-local',
         patch: { permissionMode: 'ask' },
+      }),
+    );
+  });
+
+  it('broadcasts status-only patches so secondary windows converge on delete', async () => {
+    await invokeUpdate('cc-local', { status: 'deleted' });
+
+    const persisted = h
+      .sqlite!.prepare('SELECT status FROM sessions WHERE id = ?')
+      .get('cc-local') as { status: string };
+    expect(persisted.status).toBe('deleted');
+    // #3175 回归:纯 status 变化(无 title / settings / project / pinnedAt)也必须广播
+    // sessions:patched,否则「在新窗口打开」的副窗口收不到删除,仍停留在旧视图。
+    expect(h.tapWindowBroadcast).toHaveBeenCalledWith(
+      'local-db:sessions:patched',
+      expect.objectContaining({
+        sessionId: 'cc-local',
+        patch: { status: 'deleted' },
       }),
     );
   });

--- a/apps/desktop/src/main/localDb/ipc/sessions.ts
+++ b/apps/desktop/src/main/localDb/ipc/sessions.ts
@@ -1498,6 +1498,9 @@ export function registerSessionIpc(
     const projectTargetChanged = p.workspaceKind !== undefined || p.workingDir !== undefined;
     const settingsChanged = Object.keys(p).some((key) => REMOTE_PERSIST_FIELDS.has(key));
     const titleChanged = p.title !== undefined;
+    // 归档/删除这类纯 status 变化也要广播:本机多窗口收敛靠 sessions:patched,
+    // 否则「在新窗口打开」的副窗口无从得知会话已被移除,仍停留在旧视图(#3175)。
+    const statusChanged = p.status !== undefined;
     if (
       projectTargetChanged &&
       row.workspaceKind === 'project' &&
@@ -1506,7 +1509,13 @@ export function registerSessionIpc(
     ) {
       await upsertRecentWorkdir(row.workingDir, Date.now());
     }
-    if (projectTargetChanged || settingsChanged || titleChanged || p.pinnedAt !== undefined) {
+    if (
+      projectTargetChanged ||
+      settingsChanged ||
+      titleChanged ||
+      statusChanged ||
+      p.pinnedAt !== undefined
+    ) {
       if (isOwnerScopeCurrent(ownerScope)) {
         broadcastSessionPatched(sid, broadcastPatch, ownerScope);
       }


### PR DESCRIPTION
## 这次改了什么

### 摘要

在「在新窗口打开」的副窗口中打开某个会话后，如果回到主窗口删除该会话，副窗口仍停留在已删除的会话里（#3175）。

根因在 `apps/desktop/src/main/localDb/ipc/sessions.ts` 的 `local-db:sessions:update`：它只在 title / settings / project / pinnedAt 变化时广播 `local-db:sessions:patched`，纯 `status` 变化（删除、恢复归档）从不广播，副窗口因此收不到权威状态。renderer 端其实已经具备收敛逻辑（`CCAgentSessionView` 订阅 `sessions:patched`，收到 `status: deleted` 会主动退出该视图），只差这条广播。

本 PR 让 status 变化也进入广播条件，复用现有广播与收敛链路，不新增任何副窗口检测/禁止逻辑。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：`#3175`
- 本 PR 包含：`local-db:sessions:update` 在纯 status 变化时广播 `sessions:patched`
- 明确不包含：归档后「查看并发送自动恢复」的既有语义不变；不新增副窗口检测/禁止归档逻辑
- 用户可见变化：副窗口打开的会话被删除后，该窗口会退出该会话视图；归档后副窗口状态正确收敛
- 是否存在 breaking change：无

### UI 变化

不涉及：仅 main 进程 IPC 广播条件变更，无 UI 代码路径改动。

## 怎么验证的

### 自动验证

```text
未在本地执行（原因见「未执行的验证」），依赖 GitHub CI 的 client-ci 跑 typecheck 与单测。
```

### 手工验证

不涉及。

### 未执行的验证

本地 `pnpm install` 因网络受限（github.com:443 无法连接、electron 二进制下载不动）未能完成，
因此 `pnpm test:unit:related` 与 `pnpm --filter desktop typecheck` 未在本地执行。改动为单条件
追加、复用既有 `broadcastSessionPatched` 与 renderer 收敛链路，逻辑与批量 `setStatus` 路径
（该路径已广播 `{ status }`）保持一致。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围：本机多窗口之间的会话状态收敛（删除/归档/恢复时向所有窗口广播状态）
- 回滚 / 降级方式：去掉广播条件中新增的 `statusChanged` 即可恢复原行为

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在「UI 变化」注明（不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
EOF
## 这次改了什么

### 摘要

在「在新窗口打开」的副窗口中打开某个会话后，如果回到主窗口删除该会话，副窗口仍停留在已删除的会话里（#3175）。

根因在 `apps/desktop/src/main/localDb/ipc/sessions.ts` 的 `local-db:sessions:update`：它只在 title / settings / project / pinnedAt 变化时广播 `local-db:sessions:patched`，纯 `status` 变化（删除、恢复归档）从不广播，副窗口因此收不到权威状态。renderer 端其实已经具备收敛逻辑（`CCAgentSessionView` 订阅 `sessions:patched`，收到 `status: deleted` 会主动退出该视图），只差这条广播。

本 PR 让 status 变化也进入广播条件，复用现有广播与收敛链路，不新增任何副窗口检测/禁止逻辑。