### PR TITLE
feat(desktop): 企业微信渠道支持配置新对话工作目录

### DIFF
--- a/apps/desktop/src/main/im/__tests__/accountBoundary.test.ts
+++ b/apps/desktop/src/main/im/__tests__/accountBoundary.test.ts
@@ -4,6 +4,7 @@ import {
   activateImAccountBoundary,
   captureImAccountGeneration,
   deactivateImAccountBoundary,
+  onImAccountBoundaryActivated,
   runInImAccountGeneration,
   waitForImAccountGenerationIdle,
 } from '../accountBoundary';
@@ -54,5 +55,31 @@ describe('IM account boundary', () => {
     await work;
     await draining;
     expect(drained).toBe(true);
+  });
+
+  it('notifies activation listeners only on the closed→open transition', () => {
+    // 激活通知是「账号边界 ready」广播的触发源(renderer 据此重拉渠道设置):
+    // 只在真实转换时触发一次, 重复 activate 不重复通知, 退订后不再触发。
+    deactivateImAccountBoundary();
+    const listener = vi.fn();
+    const unsubscribe = onImAccountBoundaryActivated(listener);
+    try {
+      activateImAccountBoundary();
+      expect(listener).toHaveBeenCalledTimes(1);
+      // 已激活状态下的重复 activate 是 no-op。
+      activateImAccountBoundary();
+      expect(listener).toHaveBeenCalledTimes(1);
+
+      // 换号重连: 再经历一次 关闭→激活 仍要通知。
+      deactivateImAccountBoundary();
+      activateImAccountBoundary();
+      expect(listener).toHaveBeenCalledTimes(2);
+    } finally {
+      unsubscribe();
+    }
+
+    deactivateImAccountBoundary();
+    activateImAccountBoundary();
+    expect(listener).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/desktop/src/main/im/accountBoundary.ts
+++ b/apps/desktop/src/main/im/accountBoundary.ts
@@ -21,10 +21,29 @@ export class ImAccountScopeClosedError extends Error {
   }
 }
 
+/** 边界从关闭走到激活(false→true 转换)时同步触发的监听器。 */
+export type ImAccountBoundaryActivationListener = () => void;
+
+const activationListeners = new Set<ImAccountBoundaryActivationListener>();
+
+/**
+ * 订阅账号边界的下一次(及后续)激活。仅在实际转换时触发 — 已激活状态下的
+ * 重复 activate 是 no-op, 不通知。返回取消订阅函数。
+ */
+export function onImAccountBoundaryActivated(
+  listener: ImAccountBoundaryActivationListener,
+): () => void {
+  activationListeners.add(listener);
+  return () => {
+    activationListeners.delete(listener);
+  };
+}
+
 export function activateImAccountBoundary(): void {
   if (active) return;
   generation += 1;
   active = true;
+  for (const listener of activationListeners) listener();
 }
 
 export function deactivateImAccountBoundary(): void {

--- a/apps/desktop/src/main/im/index.ts
+++ b/apps/desktop/src/main/im/index.ts
@@ -100,7 +100,12 @@ import {
   resetWechatWorkingDir,
   writeWechatWorkingDir,
 } from './wechat/channelSettings';
-import { readWecomChannelSettings, resetWecomWorkingDir, writeWecomWorkingDir } from './wecom/channelSettings';
+import {
+  commitWecomWorkingDir,
+  normalizeWecomSelectedDirectory,
+  readWecomChannelSettings,
+  resetWecomWorkingDir,
+} from './wecom/channelSettings';
 import {
   createWecomWorkingDirIpcHandlers,
   registerWecomWorkingDirIpc,
@@ -254,7 +259,7 @@ export function startImOrchestrators(): void {
       return { ok: true };
     });
   });
-  ipcMain.handle('wechatBot:get-channel-settings', (event) => {
+  ipcMain.handle('wechatBot:get-channel-settings', async (event) => {
     assertTrustedAppRendererEvent(event);
     return readWechatChannelSettings();
   });
@@ -266,12 +271,12 @@ export function startImOrchestrators(): void {
       properties: ['openDirectory', 'createDirectory'],
     });
     if (result.canceled || !result.filePaths[0]) {
-      return { canceled: true as const, state: readWechatChannelSettings() };
+      return { canceled: true as const, state: await readWechatChannelSettings() };
     }
     try {
       return {
         canceled: false as const,
-        state: writeWechatWorkingDir(result.filePaths[0]),
+        state: await writeWechatWorkingDir(result.filePaths[0]),
       };
     } catch (error) {
       log.warn('failed to save user-picked personal WeChat working directory', {
@@ -287,10 +292,10 @@ export function startImOrchestrators(): void {
       throw new Error('WECHAT_WORKING_DIR_UPDATE_FAILED');
     }
   });
-  ipcMain.handle('wechatBot:reset-working-directory', (event) => {
+  ipcMain.handle('wechatBot:reset-working-directory', async (event) => {
     assertTrustedAppRendererEvent(event);
     try {
-      return resetWechatWorkingDir();
+      return await resetWechatWorkingDir();
     } catch {
       throw new Error('WECHAT_WORKING_DIR_UPDATE_FAILED');
     }
@@ -303,7 +308,8 @@ export function startImOrchestrators(): void {
     ipc: ipcMain,
     handlers: createWecomWorkingDirIpcHandlers({
       readSettings: () => readWecomChannelSettings(),
-      writeWorkingDir: (selectedPath) => writeWecomWorkingDir(selectedPath),
+      normalizeSelectedDirectory: (selectedPath) => normalizeWecomSelectedDirectory(selectedPath),
+      commitWorkingDir: (normalizedDir) => commitWecomWorkingDir(normalizedDir),
       resetWorkingDir: () => resetWecomWorkingDir(),
       showDirectoryPicker: async (sender) => {
         const owner = BrowserWindow.fromWebContents(sender as WebContents);
@@ -570,7 +576,19 @@ async function reconcileOwnerScopedImWorkingDirs(): Promise<void> {
         .where(eq(sessions.source, 'wechat'));
       for (const row of rows) {
         if (!row.botContextId) continue;
+        // 与 telegram 同因(review P1): 设置页选的 override 目录是用户显式
+        // 选择, 且已有会话按产品契约保留旧目录直到 /new — 归一只服务
+        // "跨 owner 命名空间迁移的旧托管路径"。ensureWorkingDir 只回稳定
+        // 托管目录, 判定用它的完整尾段(两种命名都覆盖), 不做子串匹配。
         const scoped = wechatAdapter.sessions.ensureWorkingDir(row.botContextId);
+        const managedTail = path.join('im-working-dir', path.basename(scoped));
+        if (
+          row.workingDir &&
+          !row.workingDir.endsWith(`${path.sep}${managedTail}`) &&
+          !row.workingDir.endsWith(`/${managedTail}`)
+        ) {
+          continue;
+        }
         if (row.workingDir === scoped) continue;
         await db.update(sessions).set({ workingDir: scoped }).where(eq(sessions.id, row.id));
       }

--- a/apps/desktop/src/main/im/index.ts
+++ b/apps/desktop/src/main/im/index.ts
@@ -55,7 +55,7 @@
 
 import path from 'node:path';
 
-import { ipcMain, BrowserWindow, dialog, type IpcMainEvent } from 'electron';
+import { ipcMain, BrowserWindow, dialog, type IpcMainEvent, type WebContents } from 'electron';
 import { and, eq, like, ne, sql } from 'drizzle-orm';
 
 import { getDbClient } from '../localDb/client/current';
@@ -100,6 +100,11 @@ import {
   resetWechatWorkingDir,
   writeWechatWorkingDir,
 } from './wechat/channelSettings';
+import { readWecomChannelSettings, resetWecomWorkingDir, writeWecomWorkingDir } from './wecom/channelSettings';
+import {
+  createWecomWorkingDirIpcHandlers,
+  registerWecomWorkingDirIpc,
+} from './wecom/workingDirIpc';
 
 export {
   registerTelegramBotConfigIpc,
@@ -289,6 +294,28 @@ export function startImOrchestrators(): void {
     } catch {
       throw new Error('WECHAT_WORKING_DIR_UPDATE_FAILED');
     }
+  });
+
+  // 企业微信渠道工作目录 — 与个人微信同构:目录只能经 Main 原生选择器进入,
+  // Renderer 不提交路径。业务体与可信 sender 边界的注册都在 wecom/workingDirIpc.ts,
+  // 两者的回归测试(含不可信 sender 拒绝)锁在 workingDirIpc.test.ts。
+  registerWecomWorkingDirIpc({
+    ipc: ipcMain,
+    handlers: createWecomWorkingDirIpcHandlers({
+      readSettings: () => readWecomChannelSettings(),
+      writeWorkingDir: (selectedPath) => writeWecomWorkingDir(selectedPath),
+      resetWorkingDir: () => resetWecomWorkingDir(),
+      showDirectoryPicker: async (sender) => {
+        const owner = BrowserWindow.fromWebContents(sender as WebContents);
+        if (!owner || owner.isDestroyed()) return null;
+        return dialog.showOpenDialog(owner, {
+          properties: ['openDirectory', 'createDirectory'],
+        });
+      },
+      captureGeneration: captureImAccountGeneration,
+      warn: (message, context) => log.warn(message, context),
+    }),
+    assertTrustedEvent: assertTrustedAppRendererEvent,
   });
 
   // bindingStore.preload() 故意不在这里跑 —— 它要 DbClient, 而 localDb 在

--- a/apps/desktop/src/main/im/index.ts
+++ b/apps/desktop/src/main/im/index.ts
@@ -96,20 +96,23 @@ import { getUpdateStatus, isUpdateRelaunchImminent } from '../updateService';
 import { createLogger } from '../logger';
 import { assertTrustedAppRendererEvent } from '../security/trustedAppRenderer';
 import {
+  commitWechatWorkingDir,
+  normalizeWechatSelectedDirectory,
   readWechatChannelSettings,
   resetWechatWorkingDir,
-  writeWechatWorkingDir,
 } from './wechat/channelSettings';
+import { registerWechatWorkingDirIpc } from './wechat/workingDirIpc';
 import {
   commitWecomWorkingDir,
   normalizeWecomSelectedDirectory,
   readWecomChannelSettings,
   resetWecomWorkingDir,
 } from './wecom/channelSettings';
+import { registerWecomWorkingDirIpc } from './wecom/workingDirIpc';
 import {
-  createWecomWorkingDirIpcHandlers,
-  registerWecomWorkingDirIpc,
-} from './wecom/workingDirIpc';
+  createChannelWorkingDirIpcHandlers,
+  type ChannelWorkingDirIpcDeps,
+} from './shared/channelWorkingDirIpc';
 
 export {
   registerTelegramBotConfigIpc,
@@ -125,6 +128,31 @@ export {
 const log = createLogger('main:im');
 
 let wired = false;
+
+/**
+ * 个人微信/企业微信工作目录 IPC 的公共 deps — 目录选择器(可信宿主窗口 +
+ * Main 原生弹窗)、IM account generation 快照与日志出口相同, 渠道 store 的
+ * 四个操作由调用方注入。业务体见 shared/channelWorkingDirIpc。
+ */
+function workingDirIpcDeps(
+  store: Pick<
+    ChannelWorkingDirIpcDeps,
+    'readSettings' | 'normalizeSelectedDirectory' | 'commitWorkingDir' | 'resetWorkingDir'
+  >,
+): ChannelWorkingDirIpcDeps {
+  return {
+    ...store,
+    showDirectoryPicker: async (sender) => {
+      const owner = BrowserWindow.fromWebContents(sender as WebContents);
+      if (!owner || owner.isDestroyed()) return null;
+      return dialog.showOpenDialog(owner, {
+        properties: ['openDirectory', 'createDirectory'],
+      });
+    },
+    captureGeneration: captureImAccountGeneration,
+    warn: (message, context) => log.warn(message, context),
+  };
+}
 
 export interface DesktopCcPrefs {
   model: string;
@@ -259,67 +287,35 @@ export function startImOrchestrators(): void {
       return { ok: true };
     });
   });
-  ipcMain.handle('wechatBot:get-channel-settings', async (event) => {
-    assertTrustedAppRendererEvent(event);
-    return readWechatChannelSettings();
+  // 个人微信 / 企业微信渠道工作目录 — 业务体同工厂(generation 三处校验 +
+  // 两段式提交 + 日志只记错误码, 见 shared/channelWorkingDirIpc), 固定 channel
+  // 注册与可信 sender 校验各渠道各自保留。目录只能经 Main 原生选择器进入,
+  // Renderer 不提交路径。
+  registerWechatWorkingDirIpc({
+    ipc: ipcMain,
+    handlers: createChannelWorkingDirIpcHandlers({
+      updateFailedCode: 'WECHAT_WORKING_DIR_UPDATE_FAILED',
+      channelLabel: 'personal WeChat',
+      deps: workingDirIpcDeps({
+        readSettings: () => readWechatChannelSettings(),
+        normalizeSelectedDirectory: (selectedPath) => normalizeWechatSelectedDirectory(selectedPath),
+        commitWorkingDir: (normalizedDir) => commitWechatWorkingDir(normalizedDir),
+        resetWorkingDir: () => resetWechatWorkingDir(),
+      }),
+    }),
+    assertTrustedEvent: assertTrustedAppRendererEvent,
   });
-  ipcMain.handle('wechatBot:choose-working-directory', async (event) => {
-    assertTrustedAppRendererEvent(event);
-    const owner = BrowserWindow.fromWebContents(event.sender);
-    if (!owner || owner.isDestroyed()) throw new Error('WECHAT_SETTINGS_WINDOW_UNAVAILABLE');
-    const result = await dialog.showOpenDialog(owner, {
-      properties: ['openDirectory', 'createDirectory'],
-    });
-    if (result.canceled || !result.filePaths[0]) {
-      return { canceled: true as const, state: await readWechatChannelSettings() };
-    }
-    try {
-      return {
-        canceled: false as const,
-        state: await writeWechatWorkingDir(result.filePaths[0]),
-      };
-    } catch (error) {
-      log.warn('failed to save user-picked personal WeChat working directory', {
-        errorCode:
-          typeof error === 'object' &&
-          error !== null &&
-          'code' in error &&
-          typeof (error as { code?: unknown }).code === 'string'
-            ? (error as { code: string }).code
-            : 'UNKNOWN',
-        errorMessage: error instanceof Error ? error.message : String(error),
-      });
-      throw new Error('WECHAT_WORKING_DIR_UPDATE_FAILED');
-    }
-  });
-  ipcMain.handle('wechatBot:reset-working-directory', async (event) => {
-    assertTrustedAppRendererEvent(event);
-    try {
-      return await resetWechatWorkingDir();
-    } catch {
-      throw new Error('WECHAT_WORKING_DIR_UPDATE_FAILED');
-    }
-  });
-
-  // 企业微信渠道工作目录 — 与个人微信同构:目录只能经 Main 原生选择器进入,
-  // Renderer 不提交路径。业务体与可信 sender 边界的注册都在 wecom/workingDirIpc.ts,
-  // 两者的回归测试(含不可信 sender 拒绝)锁在 workingDirIpc.test.ts。
   registerWecomWorkingDirIpc({
     ipc: ipcMain,
-    handlers: createWecomWorkingDirIpcHandlers({
-      readSettings: () => readWecomChannelSettings(),
-      normalizeSelectedDirectory: (selectedPath) => normalizeWecomSelectedDirectory(selectedPath),
-      commitWorkingDir: (normalizedDir) => commitWecomWorkingDir(normalizedDir),
-      resetWorkingDir: () => resetWecomWorkingDir(),
-      showDirectoryPicker: async (sender) => {
-        const owner = BrowserWindow.fromWebContents(sender as WebContents);
-        if (!owner || owner.isDestroyed()) return null;
-        return dialog.showOpenDialog(owner, {
-          properties: ['openDirectory', 'createDirectory'],
-        });
-      },
-      captureGeneration: captureImAccountGeneration,
-      warn: (message, context) => log.warn(message, context),
+    handlers: createChannelWorkingDirIpcHandlers({
+      updateFailedCode: 'WECOM_WORKING_DIR_UPDATE_FAILED',
+      channelLabel: 'WeCom',
+      deps: workingDirIpcDeps({
+        readSettings: () => readWecomChannelSettings(),
+        normalizeSelectedDirectory: (selectedPath) => normalizeWecomSelectedDirectory(selectedPath),
+        commitWorkingDir: (normalizedDir) => commitWecomWorkingDir(normalizedDir),
+        resetWorkingDir: () => resetWecomWorkingDir(),
+      }),
     }),
     assertTrustedEvent: assertTrustedAppRendererEvent,
   });

--- a/apps/desktop/src/main/im/index.ts
+++ b/apps/desktop/src/main/im/index.ts
@@ -97,6 +97,7 @@ import { createLogger } from '../logger';
 import { assertTrustedAppRendererEvent } from '../security/trustedAppRenderer';
 import {
   commitWechatWorkingDir,
+  configureWechatChannelProbeExecutor,
   normalizeWechatSelectedDirectory,
   readWechatChannelSettings,
   resetWechatWorkingDir,
@@ -104,6 +105,7 @@ import {
 import { registerWechatWorkingDirIpc } from './wechat/workingDirIpc';
 import {
   commitWecomWorkingDir,
+  configureWecomChannelProbeExecutor,
   normalizeWecomSelectedDirectory,
   readWecomChannelSettings,
   resetWecomWorkingDir,
@@ -113,6 +115,7 @@ import {
   createChannelWorkingDirIpcHandlers,
   type ChannelWorkingDirIpcDeps,
 } from './shared/channelWorkingDirIpc';
+import { createWorkdirProbeHostExecutor } from '../workdir-probe-host/channelProbeExecutor';
 
 export {
   registerTelegramBotConfigIpc,
@@ -290,7 +293,11 @@ export function startImOrchestrators(): void {
   // 个人微信 / 企业微信渠道工作目录 — 业务体同工厂(generation 三处校验 +
   // 两段式提交 + 日志只记错误码, 见 shared/channelWorkingDirIpc), 固定 channel
   // 注册与可信 sender 校验各渠道各自保留。目录只能经 Main 原生选择器进入,
-  // Renderer 不提交路径。
+  // Renderer 不提交路径。用户目录探测接到 utility-process 执行边界: 失联
+  // 网络盘的挂死 IO 被隔离在子进程, 超时即终止回收(workdir-probe-host)。
+  const channelProbeExecutor = createWorkdirProbeHostExecutor();
+  configureWechatChannelProbeExecutor(channelProbeExecutor);
+  configureWecomChannelProbeExecutor(channelProbeExecutor);
   registerWechatWorkingDirIpc({
     ipc: ipcMain,
     handlers: createChannelWorkingDirIpcHandlers({

--- a/apps/desktop/src/main/im/index.ts
+++ b/apps/desktop/src/main/im/index.ts
@@ -84,6 +84,7 @@ import {
   captureImAccountGeneration,
   deactivateImAccountBoundary,
   isImAccountGenerationCurrent,
+  onImAccountBoundaryActivated,
   waitForImAccountGenerationIdle,
 } from './accountBoundary';
 import { configureImAccountScope } from './accountScopeBridge';
@@ -249,6 +250,14 @@ export function startImOrchestrators(): void {
   // Keep the synchronous ingress gate closed until startImConnection reaches
   // the authenticated account's initialized DB boundary.
   deactivateImAccountBoundary();
+  // 边界每次从关闭走到激活(登录/换号后 startImConnection 完成初始化)时广播
+  // 一次: 该窗口里 renderer 的渠道设置首拉(个人微信/企微)会因 generation=null
+  // 被 fail-closed 拒绝, 收到推送即重拉。无 payload — 只表达「可以重试了」,
+  // 数据仍由 renderer 主动拉取, 迟到守卫(Main generation + renderer
+  // ownerEpoch/updateSeq)不因此变化。
+  onImAccountBoundaryActivated(() =>
+    broadcastToAllWindows('im:account-boundary-ready', null),
+  );
 
   ipcMain.on('desktop:cc-prefs-changed', (_e: IpcMainEvent, prefs: unknown) => {
     if (prefs && typeof prefs === 'object') {

--- a/apps/desktop/src/main/im/shared/__tests__/channelWorkingDirIpc.test.ts
+++ b/apps/desktop/src/main/im/shared/__tests__/channelWorkingDirIpc.test.ts
@@ -303,6 +303,33 @@ describe.each(CHANNELS)('channelWorkingDirIpc handlers ($label)', ({ code, label
     await expect(pending).rejects.toMatchObject({ code });
   });
 
+  it('rejects a cancel that crossed an account switch before any settings read', async () => {
+    // A 打开选择器 → 切到 B → 取消: A 发起的 IPC 不得把 B 的配置带回去 —
+    // pick 复检先于取消判断, 且不得发起 readSettings。
+    let resolvePicker!: (result: { canceled: boolean; filePaths: string[] }) => void;
+    let generation = 7;
+    const deps = makeDeps({
+      showDirectoryPicker: vi.fn(
+        () => new Promise<{ canceled: boolean; filePaths: string[] }>((resolve) => {
+          resolvePicker = resolve;
+        }),
+      ),
+      captureGeneration: vi.fn(() => generation),
+    });
+    const handlers = makeHandlers(deps);
+
+    const pending = handlers.chooseWorkingDirectory({});
+    await Promise.resolve();
+    await Promise.resolve();
+    generation = 8;
+    resolvePicker({ canceled: true, filePaths: [] });
+    await expect(pending).rejects.toMatchObject({ code });
+    expect(deps.readSettings).not.toHaveBeenCalled();
+    expect(deps.warn).toHaveBeenCalledWith(
+      `${label} working directory pick crossed an account switch; dropped`,
+    );
+  });
+
   it('never logs the picked absolute path or raw error messages', async () => {
     // 脱敏纪律: 原生 fs 错误的 message 含完整用户目录, warn 上下文只允许
     // errorCode 一个字段。

--- a/apps/desktop/src/main/im/shared/__tests__/channelWorkingDirIpc.test.ts
+++ b/apps/desktop/src/main/im/shared/__tests__/channelWorkingDirIpc.test.ts
@@ -136,12 +136,65 @@ describe.each(CHANNELS)('channelWorkingDirIpc handlers ($label)', ({ code, label
     );
   });
 
-  it('allows the write when the generation stays equal, including both null', async () => {
-    const deps = makeDeps({ captureGeneration: vi.fn((): number | null => null) });
+  it('allows the write when a non-null generation stays equal', async () => {
+    const deps = makeDeps();
     const handlers = makeHandlers(deps);
 
     await expect(handlers.chooseWorkingDirectory({})).resolves.toMatchObject({ canceled: false });
     expect(deps.commitWorkingDir).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects every operation at the entry when the generation is null (no active account boundary)', async () => {
+    // null→null 不构成「稳定账号」: 换号窗口期间配置归属未定义, 一律拒绝,
+    // 且不得触碰任何业务依赖(读配置/弹选择器/重置/提交)。
+    const deps = makeDeps({ captureGeneration: vi.fn((): number | null => null) });
+    const handlers = makeHandlers(deps);
+
+    await expect(handlers.getChannelSettings()).rejects.toMatchObject({ code });
+    await expect(handlers.chooseWorkingDirectory({})).rejects.toMatchObject({ code });
+    await expect(handlers.resetWorkingDir()).rejects.toMatchObject({ code });
+    expect(deps.readSettings).not.toHaveBeenCalled();
+    expect(deps.showDirectoryPicker).not.toHaveBeenCalled();
+    expect(deps.resetWorkingDir).not.toHaveBeenCalled();
+    expect(deps.normalizeSelectedDirectory).not.toHaveBeenCalled();
+    expect(deps.commitWorkingDir).not.toHaveBeenCalled();
+  });
+
+  it('rejects when the generation falls back to null mid-flight (number → null)', async () => {
+    // 弹窗/探测/提交期间 stopImConnection 关闭账号边界 → generation 回落 null:
+    // 与变成另一个数字一样, 都算切号。
+    const generations: Array<number | null> = [7, null];
+    const deps = makeDeps({
+      captureGeneration: vi.fn((): number | null => {
+        const next = generations.shift();
+        return next === undefined ? 7 : next;
+      }),
+    });
+    const handlers = makeHandlers(deps);
+
+    await expect(handlers.chooseWorkingDirectory({})).rejects.toMatchObject({ code });
+    expect(deps.normalizeSelectedDirectory).not.toHaveBeenCalled();
+    expect(deps.commitWorkingDir).not.toHaveBeenCalled();
+    expect(deps.warn).toHaveBeenCalledWith(
+      `${label} working directory pick crossed an account switch; dropped`,
+    );
+  });
+
+  it('rejects a settings read that falls back to null mid-flight', async () => {
+    let resolveRead!: (state: typeof PICKED_STATE) => void;
+    const generations: Array<number | null> = [7];
+    const deps = makeDeps({
+      readSettings: vi.fn(
+        () => new Promise<typeof PICKED_STATE>((resolve) => { resolveRead = resolve; }),
+      ),
+      captureGeneration: vi.fn((): number | null => generations.shift() ?? null),
+    });
+    const handlers = makeHandlers(deps);
+
+    const pending = handlers.getChannelSettings();
+    await Promise.resolve();
+    resolveRead(PICKED_STATE);
+    await expect(pending).rejects.toMatchObject({ code });
   });
 
   it('maps validation failures to the structured IPC error without writing', async () => {

--- a/apps/desktop/src/main/im/shared/__tests__/channelWorkingDirIpc.test.ts
+++ b/apps/desktop/src/main/im/shared/__tests__/channelWorkingDirIpc.test.ts
@@ -1,0 +1,228 @@
+/**
+ * channelWorkingDirIpc.test.ts
+ * ---------------------------------------------------------------------------
+ * 工作目录 IPC 共享工厂的 handler 级测试(依赖全注入, 不拉起 Electron),
+ * 个人微信与企业微信两组参数各跑一遍同一矩阵:
+ *   - 主路径 / 取消 / 窗口失效 / 选择器异常;
+ *   - **generation 三处校验**: 选择器返回后、异步探测返回后(commit 前)、
+ *     本地 commit 返回后 —— 前两处不得 commit, 第三处不得把已落盘状态
+ *     返回给 Renderer(切号期间报错代替);
+ *   - 校验失败 / 落盘失败 / 重置失败全部映射成渠道 UPDATE_FAILED 错误码;
+ *   - **日志脱敏**: warn 上下文只含 errorCode, 不含原始 error.message 与
+ *     用户所选绝对路径。
+ * 固定 channel 注册与可信 sender 校验的测试在各渠道自己的 workingDirIpc.test。
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  createChannelWorkingDirIpcHandlers,
+  type ChannelWorkingDirIpcDeps,
+} from '../channelWorkingDirIpc';
+
+const STATE = { version: 1, workingDir: null, workingDirAvailable: true } as const;
+const PICKED_STATE = { version: 1, workingDir: 'D:/picked', workingDirAvailable: true } as const;
+const NORMALIZED = 'D:/picked';
+const RAW_PICKED = 'D:\\picked';
+
+function makeDeps(overrides: Partial<ChannelWorkingDirIpcDeps> = {}): ChannelWorkingDirIpcDeps {
+  return {
+    readSettings: vi.fn(async () => PICKED_STATE),
+    normalizeSelectedDirectory: vi.fn(async () => NORMALIZED),
+    commitWorkingDir: vi.fn(async () => PICKED_STATE),
+    resetWorkingDir: vi.fn(async () => STATE),
+    showDirectoryPicker: vi.fn(async () => ({ canceled: false, filePaths: [RAW_PICKED] })),
+    captureGeneration: vi.fn((): number | null => 7),
+    warn: vi.fn(),
+    ...overrides,
+  };
+}
+
+const CHANNELS = [
+  { code: 'WECOM_WORKING_DIR_UPDATE_FAILED', label: 'WeCom' },
+  { code: 'WECHAT_WORKING_DIR_UPDATE_FAILED', label: 'personal WeChat' },
+] as const;
+
+describe.each(CHANNELS)('channelWorkingDirIpc handlers ($label)', ({ code, label }) => {
+  function makeHandlers(deps: ChannelWorkingDirIpcDeps) {
+    return createChannelWorkingDirIpcHandlers({ updateFailedCode: code, channelLabel: label, deps });
+  }
+
+  it('saves the picked directory via the two-phase flow and returns the fresh state', async () => {
+    const deps = makeDeps();
+    const handlers = makeHandlers(deps);
+
+    await expect(handlers.chooseWorkingDirectory('wc')).resolves.toEqual({
+      canceled: false,
+      state: PICKED_STATE,
+    });
+    expect(deps.showDirectoryPicker).toHaveBeenCalledWith('wc');
+    expect(deps.normalizeSelectedDirectory).toHaveBeenCalledWith(RAW_PICKED);
+    expect(deps.commitWorkingDir).toHaveBeenCalledWith(NORMALIZED);
+  });
+
+  it('treats a cancelled picker as canceled, not an error, and keeps config', async () => {
+    const deps = makeDeps({
+      showDirectoryPicker: vi.fn(async () => ({ canceled: true, filePaths: [] })),
+    });
+    const handlers = makeHandlers(deps);
+
+    await expect(handlers.chooseWorkingDirectory({})).resolves.toEqual({
+      canceled: true,
+      state: PICKED_STATE,
+    });
+    expect(deps.normalizeSelectedDirectory).not.toHaveBeenCalled();
+    expect(deps.commitWorkingDir).not.toHaveBeenCalled();
+  });
+
+  it('rejects with the structured IPC error when the owner window is gone', async () => {
+    const deps = makeDeps({ showDirectoryPicker: vi.fn(async () => null) });
+    const handlers = makeHandlers(deps);
+
+    await expect(handlers.chooseWorkingDirectory({})).rejects.toMatchObject({ code });
+    expect(deps.commitWorkingDir).not.toHaveBeenCalled();
+  });
+
+  it('maps picker exceptions to the structured IPC error', async () => {
+    const deps = makeDeps({
+      showDirectoryPicker: vi.fn(async () => {
+        throw new Error('dialog exploded');
+      }),
+    });
+    const handlers = makeHandlers(deps);
+
+    await expect(handlers.chooseWorkingDirectory({})).rejects.toMatchObject({ code });
+    expect(deps.warn).toHaveBeenCalled();
+    expect(deps.commitWorkingDir).not.toHaveBeenCalled();
+  });
+
+  it('drops the pick when the account generation changes during the dialog', async () => {
+    const generations = [7, 8];
+    const deps = makeDeps({ captureGeneration: vi.fn(() => generations.shift() ?? null) });
+    const handlers = makeHandlers(deps);
+
+    await expect(handlers.chooseWorkingDirectory({})).rejects.toMatchObject({ code });
+    expect(deps.normalizeSelectedDirectory).not.toHaveBeenCalled();
+    expect(deps.commitWorkingDir).not.toHaveBeenCalled();
+    expect(deps.warn).toHaveBeenCalledWith(
+      `${label} working directory pick crossed an account switch; dropped`,
+    );
+  });
+
+  it('drops the pick when the generation changes while probing the user directory', async () => {
+    const generations = [7, 7, 8];
+    const deps = makeDeps({ captureGeneration: vi.fn(() => generations.shift() ?? null) });
+    const handlers = makeHandlers(deps);
+
+    await expect(handlers.chooseWorkingDirectory({})).rejects.toMatchObject({ code });
+    expect(deps.normalizeSelectedDirectory).toHaveBeenCalledTimes(1);
+    expect(deps.commitWorkingDir).not.toHaveBeenCalled();
+    expect(deps.warn).toHaveBeenCalledWith(
+      `${label} working directory probe crossed an account switch; dropped`,
+    );
+  });
+
+  it('rejects instead of returning the state when the generation changes during commit', async () => {
+    // commit 期间切号: 落盘可能已发生, 但该状态属于上一个账号的语境 —
+    // 报错让界面重新读取, 不把跨账号路径返回给 Renderer。
+    const generations = [7, 7, 7, 8];
+    const deps = makeDeps({ captureGeneration: vi.fn(() => generations.shift() ?? null) });
+    const handlers = makeHandlers(deps);
+
+    await expect(handlers.chooseWorkingDirectory({})).rejects.toMatchObject({ code });
+    expect(deps.commitWorkingDir).toHaveBeenCalledTimes(1);
+    expect(deps.warn).toHaveBeenCalledWith(
+      `${label} working directory commit crossed an account switch; dropped`,
+    );
+  });
+
+  it('allows the write when the generation stays equal, including both null', async () => {
+    const deps = makeDeps({ captureGeneration: vi.fn((): number | null => null) });
+    const handlers = makeHandlers(deps);
+
+    await expect(handlers.chooseWorkingDirectory({})).resolves.toMatchObject({ canceled: false });
+    expect(deps.commitWorkingDir).toHaveBeenCalledTimes(1);
+  });
+
+  it('maps validation failures to the structured IPC error without writing', async () => {
+    const deps = makeDeps({
+      normalizeSelectedDirectory: vi.fn(async () => {
+        throw Object.assign(new Error('WECHAT_WORKING_DIR_NOT_DIRECTORY'), {
+          code: 'WECHAT_WORKING_DIR_NOT_DIRECTORY',
+        });
+      }),
+    });
+    const handlers = makeHandlers(deps);
+
+    await expect(handlers.chooseWorkingDirectory({})).rejects.toMatchObject({ code });
+    expect(deps.commitWorkingDir).not.toHaveBeenCalled();
+  });
+
+  it('maps commit failures to the structured IPC error', async () => {
+    const deps = makeDeps({
+      commitWorkingDir: vi.fn(async () => {
+        throw Object.assign(new Error("ENOENT: no such file or directory 'D:/picked'"), {
+          code: 'ENOENT',
+        });
+      }),
+    });
+    const handlers = makeHandlers(deps);
+
+    await expect(handlers.chooseWorkingDirectory({})).rejects.toMatchObject({ code });
+  });
+
+  it('returns the stored projection and maps reset failures', async () => {
+    const deps = makeDeps();
+    const handlers = makeHandlers(deps);
+
+    await expect(handlers.getChannelSettings()).resolves.toBe(PICKED_STATE);
+    await expect(handlers.resetWorkingDir()).resolves.toBe(STATE);
+
+    const failing = makeHandlers(
+      makeDeps({
+        resetWorkingDir: vi.fn(async () => {
+          throw Object.assign(new Error('EACCES'), { code: 'EACCES' });
+        }),
+      }),
+    );
+    await expect(failing.resetWorkingDir()).rejects.toThrow(`[${code}]`);
+  });
+
+  it('never logs the picked absolute path or raw error messages', async () => {
+    // 脱敏纪律: 原生 fs 错误的 message 含完整用户目录, warn 上下文只允许
+    // errorCode 一个字段。
+    const scenarios: Array<Partial<ChannelWorkingDirIpcDeps>> = [
+      {
+        showDirectoryPicker: vi.fn(async () => {
+          throw new Error(`dialog exploded near ${RAW_PICKED}`);
+        }),
+      },
+      {
+        normalizeSelectedDirectory: vi.fn(async () => {
+          throw Object.assign(new Error(`ENOENT: no such file or directory '${RAW_PICKED}'`), {
+            code: 'ENOENT',
+          });
+        }),
+      },
+      {
+        commitWorkingDir: vi.fn(async () => {
+          throw Object.assign(new Error(`EACCES: permission denied '${RAW_PICKED}'`), {
+            code: 'EACCES',
+          });
+        }),
+      },
+    ];
+    for (const override of scenarios) {
+      const deps = makeDeps(override);
+      const handlers = makeHandlers(deps);
+      await handlers.chooseWorkingDirectory({}).catch(() => undefined);
+      expect(deps.warn).toHaveBeenCalled();
+      for (const call of vi.mocked(deps.warn).mock.calls) {
+        const context = call[1] ?? {};
+        expect(Object.keys(context)).toEqual(['errorCode']);
+        expect(JSON.stringify(context)).not.toContain(RAW_PICKED);
+        expect(JSON.stringify(call[0])).not.toContain(RAW_PICKED);
+      }
+    }
+  });
+});

--- a/apps/desktop/src/main/im/shared/__tests__/channelWorkingDirIpc.test.ts
+++ b/apps/desktop/src/main/im/shared/__tests__/channelWorkingDirIpc.test.ts
@@ -188,6 +188,68 @@ describe.each(CHANNELS)('channelWorkingDirIpc handlers ($label)', ({ code, label
     await expect(failing.resetWorkingDir()).rejects.toThrow(`[${code}]`);
   });
 
+  it('returns settings normally when the generation stays stable across a slow read', async () => {
+    let resolveRead!: (state: typeof PICKED_STATE) => void;
+    const deps = makeDeps({
+      readSettings: vi.fn(
+        () => new Promise<typeof PICKED_STATE>((resolve) => { resolveRead = resolve; }),
+      ),
+    });
+    const handlers = makeHandlers(deps);
+
+    const pending = handlers.getChannelSettings();
+    resolveRead(PICKED_STATE);
+    await expect(pending).resolves.toBe(PICKED_STATE);
+  });
+
+  it('drops a slow settings read that crosses an account switch', async () => {
+    // A 账号的目录在慢速网络盘上: 读取挂起期间切到 B — A 的绝对路径不得
+    // 返回给当前 Renderer(Main 侧守卫, renderer 无法可靠拦截)。
+    const OLD_ACCOUNT_STATE = {
+      version: 1,
+      workingDir: 'D:/owner-a/project',
+      workingDirAvailable: true,
+    } as const;
+    let resolveRead!: (state: typeof PICKED_STATE) => void;
+    let generation = 7;
+    const deps = makeDeps({
+      readSettings: vi.fn(
+        () => new Promise<typeof PICKED_STATE>((resolve) => { resolveRead = resolve; }),
+      ),
+      captureGeneration: vi.fn(() => generation),
+    });
+    const handlers = makeHandlers(deps);
+
+    const pending = handlers.getChannelSettings();
+    generation = 8;
+    resolveRead(OLD_ACCOUNT_STATE as unknown as typeof PICKED_STATE);
+    await expect(pending).rejects.toMatchObject({ code });
+    expect(deps.warn).toHaveBeenCalledWith(
+      `${label} working directory settings read crossed an account switch; dropped`,
+    );
+  });
+
+  it('drops the post-cancel settings read when it crosses an account switch', async () => {
+    let resolveRead!: (state: typeof PICKED_STATE) => void;
+    let generation = 7;
+    const deps = makeDeps({
+      showDirectoryPicker: vi.fn(async () => ({ canceled: true, filePaths: [] })),
+      readSettings: vi.fn(
+        () => new Promise<typeof PICKED_STATE>((resolve) => { resolveRead = resolve; }),
+      ),
+      captureGeneration: vi.fn(() => generation),
+    });
+    const handlers = makeHandlers(deps);
+
+    const pending = handlers.chooseWorkingDirectory({});
+    // 等 handler 走过取消分支、真正发起 readSettings 后再切号。
+    await Promise.resolve();
+    await Promise.resolve();
+    generation = 8;
+    resolveRead(PICKED_STATE);
+    await expect(pending).rejects.toMatchObject({ code });
+  });
+
   it('never logs the picked absolute path or raw error messages', async () => {
     // 脱敏纪律: 原生 fs 错误的 message 含完整用户目录, warn 上下文只允许
     // errorCode 一个字段。

--- a/apps/desktop/src/main/im/shared/__tests__/channelWorkingDirProbe.test.ts
+++ b/apps/desktop/src/main/im/shared/__tests__/channelWorkingDirProbe.test.ts
@@ -25,6 +25,8 @@ const failState = vi.hoisted(() => ({
   tmpWriteEexistNext: false,
   /** 探针写挂起(模拟网络盘失联): 挂起的 promise 由 releaseProbeHang 放行。 */
   probeWriteHang: false,
+  /** realpath 挂起(模拟选目录时网络盘失联): 同上放行。 */
+  realpathHang: false,
   hangResolvers: [] as Array<() => void>,
   rmCalls: [] as string[],
   openCalls: [] as string[],
@@ -35,6 +37,14 @@ vi.mock('node:fs/promises', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:fs/promises')>();
   const isProbe = (target: string) => target.includes('.cindy-workdir-probe-');
   const wrapped = {
+    async realpath(target: string, options?: Parameters<typeof actual.realpath>[1]) {
+      if (failState.realpathHang) {
+        await new Promise<void>((resolve) => {
+          failState.hangResolvers.push(resolve);
+        });
+      }
+      return actual.realpath(target, options);
+    },
     open(...args: Parameters<typeof actual.open>) {
       failState.openCalls.push(String(args[0]));
       return actual.open(...args);
@@ -77,13 +87,15 @@ vi.mock('node:fs/promises', async (importOriginal) => {
 
 import { readFile, mkdtemp, readdir, rm as fspRm, mkdir, writeFile as fspWriteFile } from 'node:fs/promises';
 
-import { __testing } from '../channelWorkingDirSettings';
+import { __testing, createChannelWorkingDirStore } from '../channelWorkingDirSettings';
 import { readWecomChannelSettings, writeWecomWorkingDir } from '../../wecom/channelSettings';
 
 let root = '';
 
-const probeFiles = async (): Promise<string[]> =>
-  (await readdir(root)).filter((n) => n.startsWith('.cindy-workdir-probe-'));
+const probeNames = async (dir: string): Promise<string[]> =>
+  (await readdir(dir)).filter((n) => n.startsWith('.cindy-workdir-probe-'));
+
+const probeFiles = async (): Promise<string[]> => probeNames(root);
 
 /** 放行挂起的探针写并恢复直通。 */
 function releaseProbeHang(): void {
@@ -98,6 +110,7 @@ beforeEach(async () => {
   failState.probeWriteEexistNext = false;
   failState.tmpWriteEexistNext = false;
   failState.probeWriteHang = false;
+  failState.realpathHang = false;
   failState.hangResolvers.length = 0;
   failState.rmCalls.length = 0;
   failState.openCalls.length = 0;
@@ -210,5 +223,87 @@ describe('用户目录 IO 异步化(Main 事件循环不被冻结)', () => {
     expect(state.workingDir).toBeTruthy();
     expect(state.workingDirAvailable).toBe(true);
     expect(await readdir(selected)).toEqual([]);
+  });
+});
+
+describe('用户目录探测 deadline(失联网络盘)', () => {
+  /** 小超时 + TEST 前缀的独立 store — deadline 行为与渠道无关。 */
+  function makeStore(userDirTimeoutMs: number) {
+    return createChannelWorkingDirStore({
+      logTag: 'im/test/channel-settings',
+      fileName: 'test-channel.json',
+      errorCodePrefix: 'TEST',
+      managedDirNameFor: (botId) => `test-${botId}`,
+      userDirTimeoutMs,
+    });
+  }
+
+  it('设置读取在 deadline 内返回不可用, 新对话限时回退托管目录', async () => {
+    const selected = path.join(root, 'project');
+    await mkdir(selected);
+    const store = makeStore(120);
+    await store.writeWorkingDir(selected, root);
+
+    failState.probeWriteHang = true;
+    const startedRead = Date.now();
+    const state = await store.read(root);
+    expect(Date.now() - startedRead).toBeLessThan(2_000);
+    expect(state.workingDir).toBeTruthy();
+    expect(state.workingDirAvailable).toBe(false);
+
+    // 首次对话 / /new 边界同样限时 — 不可用即回退托管目录, 不无限等待。
+    const startedResolve = Date.now();
+    const resolved = await store.resolveWorkingDirForNewConversation('bot-1', root);
+    expect(Date.now() - startedResolve).toBeLessThan(2_000);
+    expect(resolved).toBe(path.join(root, 'im-working-dir', 'test-bot-1'));
+
+    // 迟到的探针写(两次探测各一枚)放行后由各自调用清理, 不留残留。
+    releaseProbeHang();
+    await vi.waitFor(async () => {
+      expect(await probeNames(selected)).toEqual([]);
+    });
+  });
+
+  it('选择新目录探测超时: 不提交配置, 抛结构化超时错误', async () => {
+    const selected = path.join(root, 'project');
+    await mkdir(selected);
+    const store = makeStore(120);
+    await store.writeWorkingDir(selected, root);
+    const configPath = path.join(root, 'test-channel.json');
+    const before = await readFile(configPath, 'utf8');
+
+    // 新目录的 realpath 挂起(失联网络盘), 限时内必须以超时错误收场。
+    const fresh = path.join(root, 'fresh');
+    await mkdir(fresh);
+    failState.realpathHang = true;
+    const started = Date.now();
+    await expect(store.writeWorkingDir(fresh, root)).rejects.toMatchObject({
+      code: 'TEST_WORKING_DIR_PROBE_TIMEOUT',
+    });
+    expect(Date.now() - started).toBeLessThan(2_000);
+    // 未提交: 既有配置原样保留。
+    expect(await readFile(configPath, 'utf8')).toBe(before);
+
+    releaseProbeHang();
+  });
+
+  it('超时后迟到完成的探针只清理自己创建的文件, 不误删用户同前缀文件', async () => {
+    const selected = path.join(root, 'project');
+    await mkdir(selected);
+    const userNote = path.join(selected, '.cindy-workdir-probe-user-note');
+    await fspWriteFile(userNote, 'user data');
+    const store = makeStore(120);
+    await store.writeWorkingDir(selected, root);
+
+    failState.probeWriteHang = true;
+    expect((await store.read(root)).workingDirAvailable).toBe(false);
+
+    // 放行: 迟到的 'wx' 创建最终成功 — 由本次调用的 finally 清理自己那枚;
+    // 未确认创建过任何东西的超时路径绝不触碰用户文件。
+    releaseProbeHang();
+    await vi.waitFor(async () => {
+      expect(await probeNames(selected)).toEqual(['.cindy-workdir-probe-user-note']);
+    });
+    expect(await readFile(userNote, 'utf8')).toBe('user data');
   });
 });

--- a/apps/desktop/src/main/im/shared/__tests__/channelWorkingDirProbe.test.ts
+++ b/apps/desktop/src/main/im/shared/__tests__/channelWorkingDirProbe.test.ts
@@ -1,0 +1,183 @@
+/**
+ * channelWorkingDirProbe.test.ts
+ * ---------------------------------------------------------------------------
+ * 写探针/临时文件的所有权纪律回归(六轮 review 裁决):
+ *   - 只删除**本次调用确认独占创建**的文件 — 'wx' 碰撞(EEXIST)的路径属于
+ *     别人, 竞争文件必须原样保留;
+ *   - 删除失败接受 0 字节 UUID 残留 — 不记住路径跨时间重试(路径可能已被
+ *     其它进程替换, 重试会误删替换文件), 不做前缀扫描;
+ *   - 探测不经 openSync/closeSync 手工描述符生命周期, 无句柄泄漏面。
+ *
+ * node:fs 被包装注入(closeSync / rmSync / writeFileSync 可控), 目录准备与
+ * 残留断言走未被 mock 的 node:fs/promises。
+ */
+
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const failState = vi.hoisted(() => ({
+  closeSyncFails: false,
+  rmSyncFailuresRemaining: 0,
+  probeWriteEexistNext: false,
+  tmpWriteEexistNext: false,
+  rmSyncCalls: [] as string[],
+  openSyncCalls: [] as string[],
+  writeFileSyncCalls: [] as string[],
+}));
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  const wrapped = {
+    ...actual,
+    closeSync(fd: number) {
+      if (failState.closeSyncFails) {
+        const err = Object.assign(new Error('EBADF close'), {
+          code: 'EBADF',
+        }) as NodeJS.ErrnoException;
+        throw err;
+      }
+      return actual.closeSync(fd);
+    },
+    openSync(...args: Parameters<typeof actual.openSync>) {
+      failState.openSyncCalls.push(String(args[0]));
+      return actual.openSync(...args);
+    },
+    writeFileSync(...args: Parameters<typeof actual.writeFileSync>) {
+      const target = String(args[0]);
+      failState.writeFileSyncCalls.push(target);
+      // 模拟「其它进程抢先占住同一路径」: 真实写一份竞争内容, 再按 'wx'
+      // 语义抛 EEXIST。
+      const eexist =
+        (failState.probeWriteEexistNext && target.includes('.cindy-workdir-probe-')) ||
+        (failState.tmpWriteEexistNext && target.endsWith('.tmp'));
+      if (eexist) {
+        failState.probeWriteEexistNext = false;
+        failState.tmpWriteEexistNext = false;
+        actual.writeFileSync(target, 'foreign data');
+        const err = Object.assign(new Error('EEXIST'), {
+          code: 'EEXIST',
+        }) as NodeJS.ErrnoException;
+        throw err;
+      }
+      return actual.writeFileSync(...args);
+    },
+    rmSync(target: string, options: fs.RmOptions) {
+      failState.rmSyncCalls.push(target);
+      if (failState.rmSyncFailuresRemaining > 0) {
+        failState.rmSyncFailuresRemaining -= 1;
+        const err = Object.assign(new Error('EBUSY rm'), {
+          code: 'EBUSY',
+        }) as NodeJS.ErrnoException;
+        throw err;
+      }
+      return actual.rmSync(target, options);
+    },
+  };
+  return { ...actual, default: wrapped };
+});
+
+// factory 经 default import 消费 fs; 类型引用从 mock 模块借一个名字。
+import type * as fs from 'node:fs';
+
+import { __testing } from '../channelWorkingDirSettings';
+import { writeWecomWorkingDir } from '../../wecom/channelSettings';
+
+const fsp = await import('node:fs/promises');
+
+let root = '';
+
+const probeFiles = async (): Promise<string[]> =>
+  (await fsp.readdir(root)).filter((n) => n.startsWith('.cindy-workdir-probe-'));
+
+beforeEach(async () => {
+  root = await fsp.mkdtemp(path.join(os.tmpdir(), 'cindy-workdir-probe-'));
+  failState.closeSyncFails = false;
+  failState.rmSyncFailuresRemaining = 0;
+  failState.probeWriteEexistNext = false;
+  failState.tmpWriteEexistNext = false;
+  failState.rmSyncCalls.length = 0;
+  failState.openSyncCalls.length = 0;
+  failState.writeFileSyncCalls.length = 0;
+});
+
+afterEach(async () => {
+  await fsp.rm(root, { recursive: true, force: true });
+});
+
+describe('isUsableWorkingDirectory 探针生命周期', () => {
+  it('可写目录判定为可用且不留探针残留, 且不经手工 fd 生命周期', async () => {
+    // closeSync 预置为持续抛错: 探测照常成功 = 实现根本不调用 closeSync。
+    failState.closeSyncFails = true;
+
+    expect(__testing.isUsableWorkingDirectory(root)).toBe(true);
+
+    expect(failState.closeSyncFails).toBe(true); // 从未被消耗
+    expect(failState.openSyncCalls).toEqual([]); // 不持 fd
+    expect(failState.writeFileSyncCalls.length).toBe(1); // 单次独占创建
+    expect(failState.rmSyncCalls.length).toBe(1);
+    expect(await fsp.readdir(root)).toEqual([]);
+  });
+
+  it('目录变成文件后判定为不可用, 且不产生任何写入', async () => {
+    const file = path.join(root, 'now-a-file');
+    await fsp.writeFile(file, 'x');
+
+    expect(__testing.isUsableWorkingDirectory(file)).toBe(false);
+    expect(failState.writeFileSyncCalls).toEqual([]);
+  });
+
+  it('独占创建碰撞(EEXIST)时判定不可用, 竞争文件原样保留', async () => {
+    failState.probeWriteEexistNext = true;
+
+    expect(__testing.isUsableWorkingDirectory(root)).toBe(false);
+
+    // 碰撞路径属于别人: finally 绝不删除未由本次调用创建的文件。
+    const collided = failState.writeFileSyncCalls[0]!;
+    expect(await fsp.readFile(collided, 'utf8')).toBe('foreign data');
+    expect(failState.rmSyncCalls).toEqual([]);
+  });
+
+  it('rm 失败接受 0 字节残留; 旧路径(即使被替换)与用户同前缀文件都不再触碰', async () => {
+    const userNote = path.join(root, '.cindy-workdir-probe-user-note');
+    await fsp.writeFile(userNote, 'user data');
+
+    // 探测1: 自己的探针删不掉(锁) → 残留, 但不记住路径。
+    failState.rmSyncFailuresRemaining = 1;
+    expect(__testing.isUsableWorkingDirectory(root)).toBe(true);
+    const residue = (await probeFiles()).find((n) => n !== '.cindy-workdir-probe-user-note')!;
+    expect(residue).toBeTruthy();
+
+    // 旧路径已被「其它进程」替换成有意义内容。
+    await fsp.writeFile(path.join(root, residue), 'replaced by someone else');
+
+    // 探测2(锁解除): 只清理本次自己的探针, 不触碰旧路径, 不触碰用户文件。
+    expect(__testing.isUsableWorkingDirectory(root)).toBe(true);
+    expect(await fsp.readFile(path.join(root, residue), 'utf8')).toBe('replaced by someone else');
+    expect(await fsp.readFile(userNote, 'utf8')).toBe('user data');
+    const names = await probeFiles();
+    expect(names.sort()).toEqual([residue, '.cindy-workdir-probe-user-note'].sort());
+  });
+});
+
+describe('配置临时文件的所有权', () => {
+  it('tmp 独占碰撞(EEXIST)时写入失败, 碰撞文件与既有配置保留', async () => {
+    const selected = path.join(root, 'project');
+    await fsp.mkdir(selected);
+    // 已有一份合法配置, 碰撞不应破坏它。
+    writeWecomWorkingDir(selected, root);
+    const settingsFile = path.join(root, 'wecom-channel.json');
+    const before = await fsp.readFile(settingsFile, 'utf8');
+
+    // 清掉 setup 阶段的记录, 只观察碰撞这一次调用。
+    failState.writeFileSyncCalls.length = 0;
+    failState.tmpWriteEexistNext = true;
+    const other = path.join(root, 'other');
+    await fsp.mkdir(other);
+    expect(() => writeWecomWorkingDir(other, root)).toThrow('EEXIST');
+
+    const collided = failState.writeFileSyncCalls.find((c) => c.endsWith('.tmp'))!;
+    expect(await fsp.readFile(collided, 'utf8')).toBe('foreign data');
+    expect(await fsp.readFile(settingsFile, 'utf8')).toBe(before);
+  });
+});

--- a/apps/desktop/src/main/im/shared/__tests__/channelWorkingDirProbe.test.ts
+++ b/apps/desktop/src/main/im/shared/__tests__/channelWorkingDirProbe.test.ts
@@ -287,6 +287,55 @@ describe('用户目录探测 deadline(失联网络盘)', () => {
     releaseProbeHang();
   });
 
+  it('新选择目录的写探针超时: 不提交, 旧配置原样保留, 迟到探针自清理', async () => {
+    const selected = path.join(root, 'project');
+    await mkdir(selected);
+    const store = makeStore(120);
+    await store.writeWorkingDir(selected, root);
+    const configPath = path.join(root, 'test-channel.json');
+    const before = await readFile(configPath, 'utf8');
+
+    // realpath/stat 正常, 但 'wx' 写探针挂起(慢速网络盘) — 严格校验在 commit
+    // 之前完成, 超时绝不提交。
+    const fresh = path.join(root, 'fresh');
+    await mkdir(fresh);
+    failState.probeWriteHang = true;
+    const started = Date.now();
+    await expect(store.writeWorkingDir(fresh, root)).rejects.toMatchObject({
+      code: 'TEST_WORKING_DIR_PROBE_TIMEOUT',
+    });
+    expect(Date.now() - started).toBeLessThan(2_000);
+    expect(await readFile(configPath, 'utf8')).toBe(before);
+
+    // 迟到的探针写最终成功 — 由本次调用按所有权纪律清理自己那枚。
+    releaseProbeHang();
+    await vi.waitFor(async () => {
+      expect(await probeNames(fresh)).toEqual([]);
+    });
+  });
+
+  it('新选择目录不可写(wx 独占碰撞): 不提交, 碰撞文件原样保留', async () => {
+    const selected = path.join(root, 'project');
+    await mkdir(selected);
+    const store = makeStore(120);
+    await store.writeWorkingDir(selected, root);
+    const configPath = path.join(root, 'test-channel.json');
+    const before = await readFile(configPath, 'utf8');
+
+    const fresh = path.join(root, 'fresh');
+    await mkdir(fresh);
+    failState.probeWriteEexistNext = true;
+    await expect(store.writeWorkingDir(fresh, root)).rejects.toMatchObject({
+      code: 'TEST_WORKING_DIR_NOT_WRITABLE',
+    });
+    expect(await readFile(configPath, 'utf8')).toBe(before);
+
+    // 碰撞路径属于「别人」: 原样保留, 绝不删除。
+    const collided = await probeNames(fresh);
+    expect(collided).toHaveLength(1);
+    expect(await readFile(path.join(fresh, collided[0]!), 'utf8')).toBe('foreign data');
+  });
+
   it('超时后迟到完成的探针只清理自己创建的文件, 不误删用户同前缀文件', async () => {
     const selected = path.join(root, 'project');
     await mkdir(selected);

--- a/apps/desktop/src/main/im/shared/__tests__/channelWorkingDirProbe.test.ts
+++ b/apps/desktop/src/main/im/shared/__tests__/channelWorkingDirProbe.test.ts
@@ -424,4 +424,72 @@ describe('用户目录探测 deadline(失联网络盘)', () => {
     });
     expect(await readFile(userNote, 'utf8')).toBe('user data');
   });
+
+  it('注入执行器: validate 超时不提交且路径进入冷却, 冷却期重选直接超时收口', async () => {
+    const selected = path.join(root, 'project');
+    const fresh = path.join(root, 'fresh');
+    await mkdir(selected);
+    await mkdir(fresh);
+    const validateCalls: string[] = [];
+    let nextValidate: 'ok' | 'timeout' = 'ok';
+    const store = createChannelWorkingDirStore({
+      logTag: 'im/test/channel-settings',
+      fileName: 'test-channel.json',
+      errorCodePrefix: 'TEST',
+      managedDirNameFor: (botId) => `test-${botId}`,
+      probeExecutor: {
+        validate: async (dir) => {
+          validateCalls.push(dir);
+          return nextValidate === 'ok'
+            ? { ok: true, realPath: dir }
+            : { ok: false, code: 'PROBE_TIMEOUT' };
+        },
+        availability: async () => ({ ok: true, usable: true }),
+      },
+    });
+    await store.writeWorkingDir(selected, root);
+    const configPath = path.join(root, 'test-channel.json');
+    const before = await readFile(configPath, 'utf8');
+
+    // 新选择目录在执行边界内超时 → 不提交 + 该路径进入冷却。
+    nextValidate = 'timeout';
+    await expect(store.writeWorkingDir(fresh, root)).rejects.toMatchObject({
+      code: 'TEST_WORKING_DIR_PROBE_TIMEOUT',
+    });
+    expect(await readFile(configPath, 'utf8')).toBe(before);
+
+    // 冷却期内重选同一失联目录: 直接超时收口, 不再触达执行边界。
+    const callsBefore = validateCalls.length;
+    await expect(store.writeWorkingDir(fresh, root)).rejects.toMatchObject({
+      code: 'TEST_WORKING_DIR_PROBE_TIMEOUT',
+    });
+    expect(validateCalls.length).toBe(callsBefore);
+  });
+
+  it('注入执行器: 执行边界不可用时按不可用返回但不记冷却, 恢复后照常探测', async () => {
+    const selected = path.join(root, 'project');
+    await mkdir(selected);
+    const availabilityCalls: string[] = [];
+    const store = createChannelWorkingDirStore({
+      logTag: 'im/test/channel-settings',
+      fileName: 'test-channel.json',
+      errorCodePrefix: 'TEST',
+      managedDirNameFor: (botId) => `test-${botId}`,
+      probeExecutor: {
+        validate: async (dir) => ({ ok: true, realPath: dir }),
+        availability: async (dir) => {
+          availabilityCalls.push(dir);
+          return availabilityCalls.length === 1
+            ? { ok: false, code: 'PROBE_UNAVAILABLE' }
+            : { ok: true, usable: true };
+        },
+      },
+    });
+    await store.writeWorkingDir(selected, root);
+
+    // 宿主故障(队列满/进程异常): 该次按不可用收口…
+    expect((await store.read(root)).workingDirAvailable).toBe(false);
+    // …但不算目录的错 — 不记冷却, 下一次照常探测并恢复可用。
+    expect((await store.read(root)).workingDirAvailable).toBe(true);
+  });
 });

--- a/apps/desktop/src/main/im/shared/__tests__/channelWorkingDirProbe.test.ts
+++ b/apps/desktop/src/main/im/shared/__tests__/channelWorkingDirProbe.test.ts
@@ -6,10 +6,13 @@
  *     别人, 竞争文件必须原样保留;
  *   - 删除失败接受 0 字节 UUID 残留 — 不记住路径跨时间重试(路径可能已被
  *     其它进程替换, 重试会误删替换文件), 不做前缀扫描;
- *   - 探测不经 openSync/closeSync 手工描述符生命周期, 无句柄泄漏面。
+ *   - 探测不经 open 手工描述符生命周期, 无句柄泄漏面。
  *
- * node:fs 被包装注入(closeSync / rmSync / writeFileSync 可控), 目录准备与
- * 残留断言走未被 mock 的 node:fs/promises。
+ * 另有异步化回归: 用户目录(可能在网络盘上)上的 stat/写探针/删除全走
+ * node:fs/promises — 探针挂起时 Main 事件循环必须仍能运转。
+ *
+ * node:fs/promises 被包装注入(writeFile / rm / open 可控), 目录准备与残留
+ * 断言在包装关闭时直接穿过到真实实现。
  */
 
 import os from 'node:os';
@@ -17,144 +20,143 @@ import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const failState = vi.hoisted(() => ({
-  closeSyncFails: false,
-  rmSyncFailuresRemaining: 0,
+  rmFailuresRemaining: 0,
   probeWriteEexistNext: false,
   tmpWriteEexistNext: false,
-  rmSyncCalls: [] as string[],
-  openSyncCalls: [] as string[],
-  writeFileSyncCalls: [] as string[],
+  /** 探针写挂起(模拟网络盘失联): 挂起的 promise 由 releaseProbeHang 放行。 */
+  probeWriteHang: false,
+  hangResolvers: [] as Array<() => void>,
+  rmCalls: [] as string[],
+  openCalls: [] as string[],
+  writeFileCalls: [] as string[],
 }));
 
-vi.mock('node:fs', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('node:fs')>();
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>();
+  const isProbe = (target: string) => target.includes('.cindy-workdir-probe-');
   const wrapped = {
-    ...actual,
-    closeSync(fd: number) {
-      if (failState.closeSyncFails) {
-        const err = Object.assign(new Error('EBADF close'), {
-          code: 'EBADF',
-        }) as NodeJS.ErrnoException;
-        throw err;
+    open(...args: Parameters<typeof actual.open>) {
+      failState.openCalls.push(String(args[0]));
+      return actual.open(...args);
+    },
+    async writeFile(
+      target: Parameters<typeof actual.writeFile>[0],
+      data: Parameters<typeof actual.writeFile>[1],
+      options?: Parameters<typeof actual.writeFile>[2],
+    ) {
+      failState.writeFileCalls.push(String(target));
+      if (failState.probeWriteHang && isProbe(String(target))) {
+        await new Promise<void>((resolve) => {
+          failState.hangResolvers.push(resolve);
+        });
       }
-      return actual.closeSync(fd);
-    },
-    openSync(...args: Parameters<typeof actual.openSync>) {
-      failState.openSyncCalls.push(String(args[0]));
-      return actual.openSync(...args);
-    },
-    writeFileSync(...args: Parameters<typeof actual.writeFileSync>) {
-      const target = String(args[0]);
-      failState.writeFileSyncCalls.push(target);
       // 模拟「其它进程抢先占住同一路径」: 真实写一份竞争内容, 再按 'wx'
       // 语义抛 EEXIST。
       const eexist =
-        (failState.probeWriteEexistNext && target.includes('.cindy-workdir-probe-')) ||
-        (failState.tmpWriteEexistNext && target.endsWith('.tmp'));
+        (failState.probeWriteEexistNext && isProbe(String(target))) ||
+        (failState.tmpWriteEexistNext && String(target).endsWith('.tmp'));
       if (eexist) {
         failState.probeWriteEexistNext = false;
         failState.tmpWriteEexistNext = false;
-        actual.writeFileSync(target, 'foreign data');
-        const err = Object.assign(new Error('EEXIST'), {
-          code: 'EEXIST',
-        }) as NodeJS.ErrnoException;
-        throw err;
+        await actual.writeFile(target, 'foreign data', 'utf8');
+        throw Object.assign(new Error('EEXIST'), { code: 'EEXIST' }) as NodeJS.ErrnoException;
       }
-      return actual.writeFileSync(...args);
+      return actual.writeFile(target, data, options);
     },
-    rmSync(target: string, options: fs.RmOptions) {
-      failState.rmSyncCalls.push(target);
-      if (failState.rmSyncFailuresRemaining > 0) {
-        failState.rmSyncFailuresRemaining -= 1;
-        const err = Object.assign(new Error('EBUSY rm'), {
-          code: 'EBUSY',
-        }) as NodeJS.ErrnoException;
-        throw err;
+    async rm(target: string, options?: import('node:fs').RmOptions) {
+      failState.rmCalls.push(target);
+      if (failState.rmFailuresRemaining > 0) {
+        failState.rmFailuresRemaining -= 1;
+        throw Object.assign(new Error('EBUSY rm'), { code: 'EBUSY' }) as NodeJS.ErrnoException;
       }
-      return actual.rmSync(target, options);
+      return actual.rm(target, options);
     },
   };
-  return { ...actual, default: wrapped };
+  return { ...actual, ...wrapped };
 });
 
-// factory 经 default import 消费 fs; 类型引用从 mock 模块借一个名字。
-import type * as fs from 'node:fs';
+import { readFile, mkdtemp, readdir, rm as fspRm, mkdir, writeFile as fspWriteFile } from 'node:fs/promises';
 
 import { __testing } from '../channelWorkingDirSettings';
-import { writeWecomWorkingDir } from '../../wecom/channelSettings';
-
-const fsp = await import('node:fs/promises');
+import { readWecomChannelSettings, writeWecomWorkingDir } from '../../wecom/channelSettings';
 
 let root = '';
 
 const probeFiles = async (): Promise<string[]> =>
-  (await fsp.readdir(root)).filter((n) => n.startsWith('.cindy-workdir-probe-'));
+  (await readdir(root)).filter((n) => n.startsWith('.cindy-workdir-probe-'));
+
+/** 放行挂起的探针写并恢复直通。 */
+function releaseProbeHang(): void {
+  failState.probeWriteHang = false;
+  const resolvers = failState.hangResolvers.splice(0);
+  for (const resolve of resolvers) resolve();
+}
 
 beforeEach(async () => {
-  root = await fsp.mkdtemp(path.join(os.tmpdir(), 'cindy-workdir-probe-'));
-  failState.closeSyncFails = false;
-  failState.rmSyncFailuresRemaining = 0;
+  root = await mkdtemp(path.join(os.tmpdir(), 'cindy-workdir-probe-'));
+  failState.rmFailuresRemaining = 0;
   failState.probeWriteEexistNext = false;
   failState.tmpWriteEexistNext = false;
-  failState.rmSyncCalls.length = 0;
-  failState.openSyncCalls.length = 0;
-  failState.writeFileSyncCalls.length = 0;
+  failState.probeWriteHang = false;
+  failState.hangResolvers.length = 0;
+  failState.rmCalls.length = 0;
+  failState.openCalls.length = 0;
+  failState.writeFileCalls.length = 0;
 });
 
 afterEach(async () => {
-  await fsp.rm(root, { recursive: true, force: true });
+  releaseProbeHang();
+  await fspRm(root, { recursive: true, force: true });
 });
 
 describe('isUsableWorkingDirectory 探针生命周期', () => {
   it('可写目录判定为可用且不留探针残留, 且不经手工 fd 生命周期', async () => {
-    // closeSync 预置为持续抛错: 探测照常成功 = 实现根本不调用 closeSync。
-    failState.closeSyncFails = true;
+    expect(await __testing.isUsableWorkingDirectory(root)).toBe(true);
 
-    expect(__testing.isUsableWorkingDirectory(root)).toBe(true);
-
-    expect(failState.closeSyncFails).toBe(true); // 从未被消耗
-    expect(failState.openSyncCalls).toEqual([]); // 不持 fd
-    expect(failState.writeFileSyncCalls.length).toBe(1); // 单次独占创建
-    expect(failState.rmSyncCalls.length).toBe(1);
-    expect(await fsp.readdir(root)).toEqual([]);
+    expect(failState.openCalls).toEqual([]); // 不持 fd
+    expect(failState.writeFileCalls.length).toBe(1); // 单次独占创建
+    expect(failState.rmCalls.length).toBe(1);
+    expect(await readdir(root)).toEqual([]);
   });
 
   it('目录变成文件后判定为不可用, 且不产生任何写入', async () => {
     const file = path.join(root, 'now-a-file');
-    await fsp.writeFile(file, 'x');
+    await fspWriteFile(file, 'x');
+    // setup 写入也过 wrapper, 清掉记录只观察探测这一次调用。
+    failState.writeFileCalls.length = 0;
 
-    expect(__testing.isUsableWorkingDirectory(file)).toBe(false);
-    expect(failState.writeFileSyncCalls).toEqual([]);
+    expect(await __testing.isUsableWorkingDirectory(file)).toBe(false);
+    expect(failState.writeFileCalls).toEqual([]);
   });
 
   it('独占创建碰撞(EEXIST)时判定不可用, 竞争文件原样保留', async () => {
     failState.probeWriteEexistNext = true;
 
-    expect(__testing.isUsableWorkingDirectory(root)).toBe(false);
+    expect(await __testing.isUsableWorkingDirectory(root)).toBe(false);
 
     // 碰撞路径属于别人: finally 绝不删除未由本次调用创建的文件。
-    const collided = failState.writeFileSyncCalls[0]!;
-    expect(await fsp.readFile(collided, 'utf8')).toBe('foreign data');
-    expect(failState.rmSyncCalls).toEqual([]);
+    const collided = failState.writeFileCalls[0]!;
+    expect(await readFile(collided, 'utf8')).toBe('foreign data');
+    expect(failState.rmCalls).toEqual([]);
   });
 
   it('rm 失败接受 0 字节残留; 旧路径(即使被替换)与用户同前缀文件都不再触碰', async () => {
     const userNote = path.join(root, '.cindy-workdir-probe-user-note');
-    await fsp.writeFile(userNote, 'user data');
+    await fspWriteFile(userNote, 'user data');
 
     // 探测1: 自己的探针删不掉(锁) → 残留, 但不记住路径。
-    failState.rmSyncFailuresRemaining = 1;
-    expect(__testing.isUsableWorkingDirectory(root)).toBe(true);
+    failState.rmFailuresRemaining = 1;
+    expect(await __testing.isUsableWorkingDirectory(root)).toBe(true);
     const residue = (await probeFiles()).find((n) => n !== '.cindy-workdir-probe-user-note')!;
     expect(residue).toBeTruthy();
 
     // 旧路径已被「其它进程」替换成有意义内容。
-    await fsp.writeFile(path.join(root, residue), 'replaced by someone else');
+    await fspWriteFile(path.join(root, residue), 'replaced by someone else');
 
     // 探测2(锁解除): 只清理本次自己的探针, 不触碰旧路径, 不触碰用户文件。
-    expect(__testing.isUsableWorkingDirectory(root)).toBe(true);
-    expect(await fsp.readFile(path.join(root, residue), 'utf8')).toBe('replaced by someone else');
-    expect(await fsp.readFile(userNote, 'utf8')).toBe('user data');
+    expect(await __testing.isUsableWorkingDirectory(root)).toBe(true);
+    expect(await readFile(path.join(root, residue), 'utf8')).toBe('replaced by someone else');
+    expect(await readFile(userNote, 'utf8')).toBe('user data');
     const names = await probeFiles();
     expect(names.sort()).toEqual([residue, '.cindy-workdir-probe-user-note'].sort());
   });
@@ -163,21 +165,50 @@ describe('isUsableWorkingDirectory 探针生命周期', () => {
 describe('配置临时文件的所有权', () => {
   it('tmp 独占碰撞(EEXIST)时写入失败, 碰撞文件与既有配置保留', async () => {
     const selected = path.join(root, 'project');
-    await fsp.mkdir(selected);
+    await mkdir(selected);
     // 已有一份合法配置, 碰撞不应破坏它。
-    writeWecomWorkingDir(selected, root);
+    await writeWecomWorkingDir(selected, root);
     const settingsFile = path.join(root, 'wecom-channel.json');
-    const before = await fsp.readFile(settingsFile, 'utf8');
+    const before = await readFile(settingsFile, 'utf8');
 
     // 清掉 setup 阶段的记录, 只观察碰撞这一次调用。
-    failState.writeFileSyncCalls.length = 0;
+    failState.writeFileCalls.length = 0;
     failState.tmpWriteEexistNext = true;
     const other = path.join(root, 'other');
-    await fsp.mkdir(other);
-    expect(() => writeWecomWorkingDir(other, root)).toThrow('EEXIST');
+    await mkdir(other);
+    await expect(writeWecomWorkingDir(other, root)).rejects.toThrow('EEXIST');
 
-    const collided = failState.writeFileSyncCalls.find((c) => c.endsWith('.tmp'))!;
-    expect(await fsp.readFile(collided, 'utf8')).toBe('foreign data');
-    expect(await fsp.readFile(settingsFile, 'utf8')).toBe(before);
+    const collided = failState.writeFileCalls.find((c) => c.endsWith('.tmp'))!;
+    expect(await readFile(collided, 'utf8')).toBe('foreign data');
+    expect(await readFile(settingsFile, 'utf8')).toBe(before);
+  });
+});
+
+describe('用户目录 IO 异步化(Main 事件循环不被冻结)', () => {
+  it('配置目录的探针挂起时, 定时器仍能如期触发(同步 statSync/writeFileSync 会阻塞到它返回)', async () => {
+    const selected = path.join(root, 'project');
+    await mkdir(selected);
+    await writeWecomWorkingDir(selected, root);
+
+    // 挂起「配置目录上的探针写」: 模拟网络盘失联 — stat 正常, 写入永不落定。
+    failState.probeWriteHang = true;
+    const pending = readWecomChannelSettings(root);
+
+    let loopAlive = false;
+    await new Promise<void>((resolve) => {
+      setTimeout(() => {
+        loopAlive = true;
+        resolve();
+      }, 20);
+    });
+    expect(loopAlive).toBe(true);
+    expect(failState.hangResolvers.length).toBe(1);
+
+    // 放行后探测照常完成, 不留残留。
+    releaseProbeHang();
+    const state = await pending;
+    expect(state.workingDir).toBeTruthy();
+    expect(state.workingDirAvailable).toBe(true);
+    expect(await readdir(selected)).toEqual([]);
   });
 });

--- a/apps/desktop/src/main/im/shared/__tests__/channelWorkingDirProbe.test.ts
+++ b/apps/desktop/src/main/im/shared/__tests__/channelWorkingDirProbe.test.ts
@@ -106,6 +106,7 @@ function releaseProbeHang(): void {
 
 beforeEach(async () => {
   root = await mkdtemp(path.join(os.tmpdir(), 'cindy-workdir-probe-'));
+  __testing.resetProbeScheduler();
   failState.rmFailuresRemaining = 0;
   failState.probeWriteEexistNext = false;
   failState.tmpWriteEexistNext = false;
@@ -223,6 +224,74 @@ describe('用户目录 IO 异步化(Main 事件循环不被冻结)', () => {
     expect(state.workingDir).toBeTruthy();
     expect(state.workingDirAvailable).toBe(true);
     expect(await readdir(selected)).toEqual([]);
+  });
+});
+
+describe('探针调度(同目录复用 / 超时冷却 / 全局并发上限)', () => {
+  const probeWriteCount = (): number =>
+    failState.writeFileCalls.filter((c) => c.includes('.cindy-workdir-probe-')).length;
+
+  it('相同目录的并发探测复用同一份底层探针, 不叠加占线程', async () => {
+    const dir = path.join(root, 'shared');
+    await mkdir(dir);
+    failState.probeWriteHang = true;
+
+    const first = __testing.isUsableWorkingDirectory(dir, 5_000);
+    const second = __testing.isUsableWorkingDirectory(dir, 5_000);
+    // stat 是异步的, 等底层 'wx' 写真正发出后断言只有一份。
+    await vi.waitFor(() => expect(probeWriteCount()).toBe(1));
+
+    releaseProbeHang();
+    expect(await first).toBe(true);
+    expect(await second).toBe(true);
+    expect(await probeNames(dir)).toEqual([]);
+  });
+
+  it('探测超时进入冷却: 冷却期内的再次探测直接按不可用返回, 不再发起底层写', async () => {
+    const dir = path.join(root, 'cooldown');
+    await mkdir(dir);
+    failState.probeWriteHang = true;
+
+    const startedFirst = Date.now();
+    expect(await __testing.isUsableWorkingDirectory(dir, 120)).toBe(false);
+    expect(Date.now() - startedFirst).toBeLessThan(2_000);
+    await vi.waitFor(() => expect(probeWriteCount()).toBe(1));
+
+    // 冷却期内再探: 立即 false, 且没有第二次底层写(冷却优先于复用 — 不再
+    // 挂到仍在挂起的旧探针上等满自己的 deadline)。
+    failState.probeWriteHang = false;
+    const startedSecond = Date.now();
+    expect(await __testing.isUsableWorkingDirectory(dir, 5_000)).toBe(false);
+    expect(Date.now() - startedSecond).toBeLessThan(2_000);
+    expect(probeWriteCount()).toBe(1);
+
+    releaseProbeHang();
+    await vi.waitFor(async () => {
+      expect(await probeNames(dir)).toEqual([]);
+    });
+  });
+
+  it('在途探针超过全局上限时, 新目录的探测直接拒绝, 不再占用线程', async () => {
+    const max = __testing.probeLimits.maxConcurrent;
+    const dirs: string[] = [];
+    for (let i = 0; i <= max; i += 1) {
+      const dir = path.join(root, `cap-${i}`);
+      await mkdir(dir);
+      dirs.push(dir);
+    }
+    failState.probeWriteHang = true;
+
+    const pending = dirs.slice(0, max).map((dir) => __testing.isUsableWorkingDirectory(dir, 5_000));
+    await vi.waitFor(() => expect(probeWriteCount()).toBe(max));
+
+    // 第 max+1 个不同目录: 超上限 → 立即 false, 底层写数量不变。
+    const started = Date.now();
+    expect(await __testing.isUsableWorkingDirectory(dirs[max]!, 5_000)).toBe(false);
+    expect(Date.now() - started).toBeLessThan(2_000);
+    expect(probeWriteCount()).toBe(max);
+
+    releaseProbeHang();
+    await Promise.all(pending);
   });
 });
 

--- a/apps/desktop/src/main/im/shared/__tests__/sessionRepoResetDefaults.test.ts
+++ b/apps/desktop/src/main/im/shared/__tests__/sessionRepoResetDefaults.test.ts
@@ -1,0 +1,162 @@
+/**
+ * sessionRepoResetDefaults.test.ts
+ * ---------------------------------------------------------------------------
+ * `resetSessionToDefaults`(`/new` 语义)对 workingDir 的真实落库行为:
+ *   - 渠道声明 refreshWorkingDirOnNew(微信/企微) ⇒ 刷到 prepareNewSession
+ *     现解析的目录;
+ *   - 未声明(目录恒定渠道) ⇒ 保留行里已有的目录;
+ *   - prepared.workingDir 为空 ⇒ 不写空值。
+ *
+ * 跑真 SQLite(表结构从生产 schema 现推), 与 sessionRepoWorkspaceKind.test.ts
+ * 同一套 harness —— slashCommands 的参数透传断言证明"传了开关", 这里证明
+ * "开关真的改库"。
+ */
+
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { getTableConfig } from 'drizzle-orm/sqlite-core';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('electron', () => ({
+  BrowserWindow: { getAllWindows: () => [] },
+  app: { getPath: () => '/tmp/never-used-here' },
+}));
+vi.mock('../../../device-link/broadcast-tap', () => ({
+  getSafeDataOwnerPushStamp: vi.fn(() => undefined),
+  tapWindowBroadcast: vi.fn(),
+}));
+vi.mock('../../../logger', () => ({
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+  maskPath: (p: string) => p,
+}));
+vi.mock('../../../maker-host/session-provider-store', () => ({
+  setSessionProvider: vi.fn(),
+}));
+vi.mock('../../defaultSessionSettings', () => ({
+  getImDefaultEffortFor: vi.fn(() => 'high'),
+  resolveImSessionDefaults: vi.fn(async () => ({
+    agentKind: 'claude-code',
+    model: 'claude-opus-4-8',
+    effort: 'high',
+    permissionMode: 'auto',
+    fastMode: false,
+    providerId: null,
+  })),
+}));
+
+let db: ReturnType<typeof drizzle>;
+vi.mock('../../../localDb/client/current', () => ({
+  getDbClient: () => ({ drizzle: db }),
+}));
+
+const { sessions } = await import('../../../localDb/schema');
+const { createImSessionRepo, resetSessionToDefaults } = await import('../sessionRepo');
+import type { ImSessionRow } from '../sessionRepo';
+import type { ImOrchestratorConfig, ImSessionNamespace } from '../types';
+
+const OLD_DIR = '/tmp/im-working-dir/wecom-old';
+const NEW_DIR = 'D:/projects/wecom-new';
+
+const ns = {
+  source: 'wecom',
+  workspaceKind: 'dialogue',
+  sessionIdFor: (bot: string, user: string) => `wecom_${bot}_${user}`,
+  defaultTitle: () => 'WeCom',
+  ensureWorkingDir: () => OLD_DIR,
+  extraInsertColumns: (bot: string, user: string) => ({ imBotContextId: bot, imUserId: user }),
+} as unknown as ImSessionNamespace;
+
+function createTableSql(): string {
+  const config = getTableConfig(sessions);
+  const cols = config.columns.map((col) => {
+    const parts = [`"${col.name}"`, col.getSQLType()];
+    if (col.primary) parts.push('PRIMARY KEY');
+    if (col.notNull) parts.push('NOT NULL');
+    const dflt = col.default;
+    if (dflt !== undefined && typeof dflt !== 'object') {
+      parts.push(`DEFAULT ${typeof dflt === 'string' ? `'${dflt}'` : Number(dflt)}`);
+    }
+    return parts.join(' ');
+  });
+  return `CREATE TABLE "${config.name}" (${cols.join(', ')})`;
+}
+
+async function preparedRow(id: string, workingDir: string): Promise<ImSessionRow> {
+  return {
+    id,
+    agentKind: 'claude-code',
+    workingDir,
+    model: 'claude-opus-4-8',
+    effort: 'high',
+    permissionMode: 'auto',
+    fastMode: false,
+    sdkSessionId: 'sdk-old',
+    providerId: null,
+  };
+}
+
+async function workingDirOf(id: string): Promise<string> {
+  const rows = await db.select().from(sessions);
+  return rows.find((r) => r.id === id)!.workingDir!;
+}
+
+beforeEach(() => {
+  const raw = new Database(':memory:');
+  raw.exec(createTableSql());
+  db = drizzle(raw);
+});
+
+describe('resetSessionToDefaults 的 workingDir 行为', () => {
+  it('refreshWorkingDir=true 时 /new 把行刷到最新解析的渠道目录', async () => {
+    const repo = createImSessionRepo({ agentKind: 'claude-code' } as ImOrchestratorConfig, ns);
+    const created = await repo.createSession('bot1', 'u1');
+    expect(await workingDirOf(created.id)).toBe(OLD_DIR);
+
+    // 用户在设置页改了渠道目录, /new 的 prepared 行带着新目录。
+    await resetSessionToDefaults(
+      created.id,
+      {} as ImOrchestratorConfig,
+      await preparedRow(created.id, NEW_DIR),
+      {
+        channel: 'wecom',
+        refreshWorkingDir: true,
+      },
+    );
+
+    expect(await workingDirOf(created.id)).toBe(NEW_DIR);
+  });
+
+  it('refreshWorkingDir=false 时 /new 不动行里已有的目录', async () => {
+    const repo = createImSessionRepo({ agentKind: 'claude-code' } as ImOrchestratorConfig, ns);
+    const created = await repo.createSession('bot1', 'u1');
+
+    await resetSessionToDefaults(
+      created.id,
+      {} as ImOrchestratorConfig,
+      await preparedRow(created.id, NEW_DIR),
+      {
+        channel: 'feishu',
+        refreshWorkingDir: false,
+      },
+    );
+
+    expect(await workingDirOf(created.id)).toBe(OLD_DIR);
+  });
+
+  it('prepared.workingDir 为空时即便声明了刷新也不写空值', async () => {
+    const repo = createImSessionRepo({ agentKind: 'claude-code' } as ImOrchestratorConfig, ns);
+    const created = await repo.createSession('bot1', 'u1');
+
+    await resetSessionToDefaults(
+      created.id,
+      {} as ImOrchestratorConfig,
+      await preparedRow(created.id, ''),
+      {
+        channel: 'wecom',
+        refreshWorkingDir: true,
+      },
+    );
+
+    expect(await workingDirOf(created.id)).toBe(OLD_DIR);
+  });
+});

--- a/apps/desktop/src/main/im/shared/__tests__/slashCommands.test.ts
+++ b/apps/desktop/src/main/im/shared/__tests__/slashCommands.test.ts
@@ -305,9 +305,37 @@ describe('IM slash commands', () => {
       'feishu-session',
       expect.anything(),
       prepared,
-      'feishu',
+      { channel: 'feishu', refreshWorkingDir: false },
     );
     expect(mocks.sendMarkdownText).toHaveBeenCalledWith('ou_user', ui.slash.new);
+  });
+
+  it('asks /new to refresh the working directory when the channel declares it', async () => {
+    const prepared = { ...defaultRow, agentKind: 'codex' as const, model: 'gpt-5.5' };
+    const repo = makeRepo({ prepareNewSession: vi.fn(async () => prepared) });
+    const { handlers } = makeHarness({
+      repo,
+      adapterOverrides: {
+        channel: 'wecom',
+        sessions: {
+          source: 'wecom',
+          sessionIdFor: () => 'wecom-session',
+          defaultTitle: () => 'WeCom',
+          ensureWorkingDir: () => 'F:\\XDMaker',
+          refreshWorkingDirOnNew: true,
+          extraInsertColumns: () => ({}),
+        },
+      },
+    });
+
+    await handlers.handleSlashCommand('/new', { botContextId: 'bot', userId: 'ou_user' });
+
+    expect(mocks.resetSessionToDefaults).toHaveBeenCalledWith(
+      'feishu-session',
+      expect.anything(),
+      prepared,
+      { channel: 'wecom', refreshWorkingDir: true },
+    );
   });
 
   it('does not send /model picker when creating the target session would fail auth', async () => {

--- a/apps/desktop/src/main/im/shared/channelWorkingDirIpc.ts
+++ b/apps/desktop/src/main/im/shared/channelWorkingDirIpc.ts
@@ -8,10 +8,14 @@
  *
  * 安全不变量(六轮 review 裁决的延续):
  *   - 目录授权只来自 Main 原生选择器, Renderer 不提交路径;
+ *   - **每个操作(get/choose/reset)入口都绑定一个非空 generation**: null =
+ *     IM 账号边界未激活(启动早期/登出/换号窗口), 一律直接拒绝 — null→null
+ *     不构成"稳定账号", 否则换号窗口的慢读取会把 A 的路径交给 B(review P1);
  *   - 选择器与用户目录探测都是异步的: 打开/探测期间登出/换号会推进 IM
- *     account generation, **三个异步边界归来后都必须重校验** —
- *     ① 选择器返回后、② 异步探测返回后(commit 前, 必检)、③ 本地 commit
- *     返回后(切号期间已落盘的状态不返回给 Renderer, 报错代替);
+ *     account generation(或回落 null), **三个异步边界归来后都必须复检仍是
+ *     同一个非空 generation** — ① 选择器返回后、② 异步探测返回后
+ *     (commit 前, 必检)、③ 本地 commit 返回后(切号期间已落盘的状态不返回
+ *     给 Renderer, 报错代替);
  *   - 校验/探测(normalizeSelectedDirectory)与落盘(commitWorkingDir)拆开:
  *     ② 与 ③ 之间只剩一次本地 userData 写入, 敏感窗口收敛到本机盘 IO;
  *   - 取消选择不是错误, 也不改变配置;
@@ -55,19 +59,39 @@ export function createChannelWorkingDirIpcHandlers(options: ChannelWorkingDirIpc
   const { updateFailedCode, channelLabel, deps } = options;
 
   /**
+   * 捕获并**要求非空**的 generation 作为本次操作的绑定代次。null 表示 IM
+   * 账号边界未激活(启动早期/登出/换号窗口) — 期间配置属于哪个账号是未定义
+   * 的, 读配置、弹选择器、重置、提交一律拒绝, 不能把 null→null 当成"稳定
+   * 账号"(review P1: 换号窗口的慢读取会把 A 的路径交给 B)。
+   */
+  function requireStableGeneration(): number {
+    const generation = deps.captureGeneration();
+    if (generation === null) {
+      deps.warn(`${channelLabel} working directory IPC rejected: no active IM account boundary`);
+      throwIpcError(updateFailedCode, 'no active account');
+    }
+    return generation;
+  }
+
+  /** 异步边界归来后复检: 仍是同一个非空 generation 才放行(null 同样算变化)。 */
+  function assertSameGeneration(expected: number, phase: string): void {
+    if (deps.captureGeneration() !== expected) {
+      deps.warn(`${channelLabel} working directory ${phase} crossed an account switch; dropped`);
+      throwIpcError(updateFailedCode, `account changed while ${phase}`);
+    }
+  }
+
+  /**
    * 读取渠道设置并做 generation 守卫: A 账号的目录在慢速网络盘上时,
    * readSettings 可能挂到 deadline 才返回 — 期间切到 B 账号后, A 的绝对
    * 路径不得交给当前 Renderer。读取前捕获、返回前复检, generation 变化
-   * 即丢弃结果并抛渠道 UPDATE_FAILED(renderer 无法可靠拦截跨账号响应,
-   * 守卫必须在 Main 侧)。
+   * (含回落 null)即丢弃结果并抛渠道 UPDATE_FAILED(renderer 无法可靠拦截
+   * 跨账号响应, 守卫必须在 Main 侧)。
    */
   async function readSettingsForCurrentGeneration(): Promise<ChannelWorkingDirSettingsState> {
-    const generationAtRead = deps.captureGeneration();
+    const expected = requireStableGeneration();
     const state = await deps.readSettings();
-    if (deps.captureGeneration() !== generationAtRead) {
-      deps.warn(`${channelLabel} working directory settings read crossed an account switch; dropped`);
-      throwIpcError(updateFailedCode, 'account changed while reading settings');
-    }
+    assertSameGeneration(expected, 'settings read');
     return state;
   }
 
@@ -79,7 +103,7 @@ export function createChannelWorkingDirIpcHandlers(options: ChannelWorkingDirIpc
     async chooseWorkingDirectory(
       sender: unknown,
     ): Promise<{ canceled: boolean; state: ChannelWorkingDirSettingsState }> {
-      const generationAtOpen = deps.captureGeneration();
+      const expected = requireStableGeneration();
 
       let result: { canceled: boolean; filePaths: string[] } | null = null;
       try {
@@ -98,12 +122,7 @@ export function createChannelWorkingDirIpcHandlers(options: ChannelWorkingDirIpc
       if (picked === undefined) {
         return { canceled: true, state: await readSettingsForCurrentGeneration() };
       }
-      if (deps.captureGeneration() !== generationAtOpen) {
-        // ① 弹窗期间登出/换号: 选中的路径属于上一个账号的语境, 不落盘。
-        // 前后代次相等(含双双为 null 的未激活窗口)才允许继续。
-        deps.warn(`${channelLabel} working directory pick crossed an account switch; dropped`);
-        throwIpcError(updateFailedCode, 'account changed while picking');
-      }
+      assertSameGeneration(expected, 'pick');
 
       let normalized: string;
       try {
@@ -115,12 +134,7 @@ export function createChannelWorkingDirIpcHandlers(options: ChannelWorkingDirIpc
         });
         throwIpcError(updateFailedCode, 'failed to save working directory');
       }
-      if (deps.captureGeneration() !== generationAtOpen) {
-        // ② 探测期间登出/换号: 必检。校验通过后的提交只碰本地 userData,
-        // 代次校验到落盘之间不再有用户盘 IO。
-        deps.warn(`${channelLabel} working directory probe crossed an account switch; dropped`);
-        throwIpcError(updateFailedCode, 'account changed while probing');
-      }
+      assertSameGeneration(expected, 'probe');
       let state: ChannelWorkingDirSettingsState;
       try {
         state = await deps.commitWorkingDir(normalized);
@@ -130,19 +144,18 @@ export function createChannelWorkingDirIpcHandlers(options: ChannelWorkingDirIpc
         });
         throwIpcError(updateFailedCode, 'failed to save working directory');
       }
-      if (deps.captureGeneration() !== generationAtOpen) {
-        // ③ commit 期间切号: 已落盘的状态属于上一个账号的语境, 不返回给
-        // Renderer — 报错让界面回落到重新读取, 而不是展示跨账号路径。
-        deps.warn(`${channelLabel} working directory commit crossed an account switch; dropped`);
-        throwIpcError(updateFailedCode, 'account changed while committing');
-      }
+      assertSameGeneration(expected, 'commit');
       return { canceled: false, state };
     },
 
     async resetWorkingDir(): Promise<ChannelWorkingDirSettingsState> {
+      const expected = requireStableGeneration();
       try {
-        return await deps.resetWorkingDir();
+        const state = await deps.resetWorkingDir();
+        assertSameGeneration(expected, 'reset');
+        return state;
       } catch (error) {
+        if ((error as { code?: unknown }).code === updateFailedCode) throw error;
         deps.warn(`failed to reset ${channelLabel} working directory`, {
           errorCode: nodeErrorCodeOf(error),
         });

--- a/apps/desktop/src/main/im/shared/channelWorkingDirIpc.ts
+++ b/apps/desktop/src/main/im/shared/channelWorkingDirIpc.ts
@@ -1,0 +1,147 @@
+/**
+ * 直连 IM 渠道(个人微信/企业微信)「工作目录」IPC 业务体的共享工厂。
+ *
+ * 渠道差异只经两个显式参数注入:`updateFailedCode`(完整 IpcErrorCode,不做
+ * 字符串拼接/强转,保持 throwIpcError 类型安全)与 `channelLabel`(日志文案)。
+ * 固定 IPC channel 注册与可信 sender 校验**不**泛化 —— 各渠道在各自的
+ * workingDirIpc.ts 里保留(避免出现可配置任意 channel 的通用注册器)。
+ *
+ * 安全不变量(六轮 review 裁决的延续):
+ *   - 目录授权只来自 Main 原生选择器, Renderer 不提交路径;
+ *   - 选择器与用户目录探测都是异步的: 打开/探测期间登出/换号会推进 IM
+ *     account generation, **三个异步边界归来后都必须重校验** —
+ *     ① 选择器返回后、② 异步探测返回后(commit 前, 必检)、③ 本地 commit
+ *     返回后(切号期间已落盘的状态不返回给 Renderer, 报错代替);
+ *   - 校验/探测(normalizeSelectedDirectory)与落盘(commitWorkingDir)拆开:
+ *     ② 与 ③ 之间只剩一次本地 userData 写入, 敏感窗口收敛到本机盘 IO;
+ *   - 取消选择不是错误, 也不改变配置;
+ *   - 日志只记 Node 错误码(ENOENT/EACCES/…与渠道校验码), 不记 error.message
+ *     —— 原生文件系统错误的 message 含完整用户目录, 是隐私泄漏。
+ */
+
+import { throwIpcError } from '../../utils/ipcValidate';
+import type { IpcErrorCode } from '../../../shared/ipc-errors';
+import type { ChannelWorkingDirSettingsState } from './channelWorkingDirSettings';
+
+export interface ChannelWorkingDirIpcDeps {
+  readSettings(): Promise<ChannelWorkingDirSettingsState>;
+  /**
+   * 校验并规整用户所选目录 — 异步探测用户盘(可能是网络盘, 挂起只阻塞本
+   * IPC, 不冻结 Main 事件循环), 不落盘。
+   */
+  normalizeSelectedDirectory(selectedPath: string): Promise<string>;
+  /** 落盘已规整目录(只碰本地 userData 配置文件)。 */
+  commitWorkingDir(normalizedDir: string): Promise<ChannelWorkingDirSettingsState>;
+  resetWorkingDir(): Promise<ChannelWorkingDirSettingsState>;
+  /**
+   * 解析可信宿主窗口并打开 Main 原生目录选择器。
+   * 返回 null = 无有效窗口(同步失败, 不弹窗); Promise 拒绝 = 选择器异常。
+   */
+  showDirectoryPicker(sender: unknown): Promise<{ canceled: boolean; filePaths: string[] } | null>;
+  /** IM account generation 快照(accountBoundary);前后不一致 = 期间切号。 */
+  captureGeneration(): number | null;
+  warn(message: string, context?: Record<string, unknown>): void;
+}
+
+export interface ChannelWorkingDirIpcOptions {
+  /** 完整错误码, 如 'WECOM_WORKING_DIR_UPDATE_FAILED'。 */
+  updateFailedCode: IpcErrorCode;
+  /** 日志里的渠道名, 如 'WeCom' / 'personal WeChat'。 */
+  channelLabel: string;
+  deps: ChannelWorkingDirIpcDeps;
+}
+
+export function createChannelWorkingDirIpcHandlers(options: ChannelWorkingDirIpcOptions) {
+  const { updateFailedCode, channelLabel, deps } = options;
+  return {
+    async getChannelSettings(): Promise<ChannelWorkingDirSettingsState> {
+      return deps.readSettings();
+    },
+
+    async chooseWorkingDirectory(
+      sender: unknown,
+    ): Promise<{ canceled: boolean; state: ChannelWorkingDirSettingsState }> {
+      const generationAtOpen = deps.captureGeneration();
+
+      let result: { canceled: boolean; filePaths: string[] } | null = null;
+      try {
+        result = await deps.showDirectoryPicker(sender);
+      } catch (error) {
+        deps.warn(`${channelLabel} working directory picker failed`, {
+          errorCode: nodeErrorCodeOf(error),
+        });
+        throwIpcError(updateFailedCode, 'directory picker failed');
+      }
+      if (!result) {
+        throwIpcError(updateFailedCode, 'settings window unavailable');
+      }
+
+      const picked = result.canceled || !result.filePaths[0] ? undefined : result.filePaths[0];
+      if (picked === undefined) {
+        return { canceled: true, state: await deps.readSettings() };
+      }
+      if (deps.captureGeneration() !== generationAtOpen) {
+        // ① 弹窗期间登出/换号: 选中的路径属于上一个账号的语境, 不落盘。
+        // 前后代次相等(含双双为 null 的未激活窗口)才允许继续。
+        deps.warn(`${channelLabel} working directory pick crossed an account switch; dropped`);
+        throwIpcError(updateFailedCode, 'account changed while picking');
+      }
+
+      let normalized: string;
+      try {
+        // 异步探测用户所选目录(网络盘可能秒级挂起 — 只阻塞本 IPC)。
+        normalized = await deps.normalizeSelectedDirectory(picked);
+      } catch (error) {
+        deps.warn(`failed to validate user-picked ${channelLabel} working directory`, {
+          errorCode: nodeErrorCodeOf(error),
+        });
+        throwIpcError(updateFailedCode, 'failed to save working directory');
+      }
+      if (deps.captureGeneration() !== generationAtOpen) {
+        // ② 探测期间登出/换号: 必检。校验通过后的提交只碰本地 userData,
+        // 代次校验到落盘之间不再有用户盘 IO。
+        deps.warn(`${channelLabel} working directory probe crossed an account switch; dropped`);
+        throwIpcError(updateFailedCode, 'account changed while probing');
+      }
+      let state: ChannelWorkingDirSettingsState;
+      try {
+        state = await deps.commitWorkingDir(normalized);
+      } catch (error) {
+        deps.warn(`failed to save user-picked ${channelLabel} working directory`, {
+          errorCode: nodeErrorCodeOf(error),
+        });
+        throwIpcError(updateFailedCode, 'failed to save working directory');
+      }
+      if (deps.captureGeneration() !== generationAtOpen) {
+        // ③ commit 期间切号: 已落盘的状态属于上一个账号的语境, 不返回给
+        // Renderer — 报错让界面回落到重新读取, 而不是展示跨账号路径。
+        deps.warn(`${channelLabel} working directory commit crossed an account switch; dropped`);
+        throwIpcError(updateFailedCode, 'account changed while committing');
+      }
+      return { canceled: false, state };
+    },
+
+    async resetWorkingDir(): Promise<ChannelWorkingDirSettingsState> {
+      try {
+        return await deps.resetWorkingDir();
+      } catch (error) {
+        deps.warn(`failed to reset ${channelLabel} working directory`, {
+          errorCode: nodeErrorCodeOf(error),
+        });
+        throwIpcError(updateFailedCode, 'failed to reset working directory');
+      }
+    },
+  };
+}
+
+/** 日志用 Node 错误码(ENOENT/EACCES/渠道校验码...);不含路径与原始 message。 */
+export function nodeErrorCodeOf(error: unknown): string {
+  return typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    typeof (error as { code?: unknown }).code === 'string'
+    ? (error as { code: string }).code
+    : 'UNKNOWN';
+}
+
+export type ChannelWorkingDirIpcHandlers = ReturnType<typeof createChannelWorkingDirIpcHandlers>;

--- a/apps/desktop/src/main/im/shared/channelWorkingDirIpc.ts
+++ b/apps/desktop/src/main/im/shared/channelWorkingDirIpc.ts
@@ -53,9 +53,27 @@ export interface ChannelWorkingDirIpcOptions {
 
 export function createChannelWorkingDirIpcHandlers(options: ChannelWorkingDirIpcOptions) {
   const { updateFailedCode, channelLabel, deps } = options;
+
+  /**
+   * 读取渠道设置并做 generation 守卫: A 账号的目录在慢速网络盘上时,
+   * readSettings 可能挂到 deadline 才返回 — 期间切到 B 账号后, A 的绝对
+   * 路径不得交给当前 Renderer。读取前捕获、返回前复检, generation 变化
+   * 即丢弃结果并抛渠道 UPDATE_FAILED(renderer 无法可靠拦截跨账号响应,
+   * 守卫必须在 Main 侧)。
+   */
+  async function readSettingsForCurrentGeneration(): Promise<ChannelWorkingDirSettingsState> {
+    const generationAtRead = deps.captureGeneration();
+    const state = await deps.readSettings();
+    if (deps.captureGeneration() !== generationAtRead) {
+      deps.warn(`${channelLabel} working directory settings read crossed an account switch; dropped`);
+      throwIpcError(updateFailedCode, 'account changed while reading settings');
+    }
+    return state;
+  }
+
   return {
     async getChannelSettings(): Promise<ChannelWorkingDirSettingsState> {
-      return deps.readSettings();
+      return readSettingsForCurrentGeneration();
     },
 
     async chooseWorkingDirectory(
@@ -78,7 +96,7 @@ export function createChannelWorkingDirIpcHandlers(options: ChannelWorkingDirIpc
 
       const picked = result.canceled || !result.filePaths[0] ? undefined : result.filePaths[0];
       if (picked === undefined) {
-        return { canceled: true, state: await deps.readSettings() };
+        return { canceled: true, state: await readSettingsForCurrentGeneration() };
       }
       if (deps.captureGeneration() !== generationAtOpen) {
         // ① 弹窗期间登出/换号: 选中的路径属于上一个账号的语境, 不落盘。

--- a/apps/desktop/src/main/im/shared/channelWorkingDirIpc.ts
+++ b/apps/desktop/src/main/im/shared/channelWorkingDirIpc.ts
@@ -82,14 +82,14 @@ export function createChannelWorkingDirIpcHandlers(options: ChannelWorkingDirIpc
   }
 
   /**
-   * 读取渠道设置并做 generation 守卫: A 账号的目录在慢速网络盘上时,
+   * 按既定 generation 读取渠道设置: A 账号的目录在慢速网络盘上时,
    * readSettings 可能挂到 deadline 才返回 — 期间切到 B 账号后, A 的绝对
-   * 路径不得交给当前 Renderer。读取前捕获、返回前复检, generation 变化
-   * (含回落 null)即丢弃结果并抛渠道 UPDATE_FAILED(renderer 无法可靠拦截
-   * 跨账号响应, 守卫必须在 Main 侧)。
+   * 路径不得交给当前 Renderer。返回前复检仍是同一 generation, 变化(含
+   * 回落 null)即丢弃结果并抛渠道 UPDATE_FAILED(renderer 无法可靠拦截
+   * 跨账号响应, 守卫必须在 Main 侧)。**不重新捕获** — 语义上不得在读取
+   * 边界重新绑定账号。
    */
-  async function readSettingsForCurrentGeneration(): Promise<ChannelWorkingDirSettingsState> {
-    const expected = requireStableGeneration();
+  async function readSettingsForGeneration(expected: number): Promise<ChannelWorkingDirSettingsState> {
     const state = await deps.readSettings();
     assertSameGeneration(expected, 'settings read');
     return state;
@@ -97,7 +97,7 @@ export function createChannelWorkingDirIpcHandlers(options: ChannelWorkingDirIpc
 
   return {
     async getChannelSettings(): Promise<ChannelWorkingDirSettingsState> {
-      return readSettingsForCurrentGeneration();
+      return readSettingsForGeneration(requireStableGeneration());
     },
 
     async chooseWorkingDirectory(
@@ -118,11 +118,14 @@ export function createChannelWorkingDirIpcHandlers(options: ChannelWorkingDirIpc
         throwIpcError(updateFailedCode, 'settings window unavailable');
       }
 
+      // 选择器返回后立即复检 — **取消分支同样不得跨账号返回状态**: 弹窗
+      // 期间 A→B 切号后取消, A 发起的 IPC 不能把 B 的绝对路径带回去
+      // (renderer 的 owner epoch 只是第二道防线, Main 边界不依赖它)。
+      assertSameGeneration(expected, 'pick');
       const picked = result.canceled || !result.filePaths[0] ? undefined : result.filePaths[0];
       if (picked === undefined) {
-        return { canceled: true, state: await readSettingsForCurrentGeneration() };
+        return { canceled: true, state: await readSettingsForGeneration(expected) };
       }
-      assertSameGeneration(expected, 'pick');
 
       let normalized: string;
       try {

--- a/apps/desktop/src/main/im/shared/channelWorkingDirSettings.ts
+++ b/apps/desktop/src/main/im/shared/channelWorkingDirSettings.ts
@@ -7,7 +7,12 @@
  * 渠道差异(配置文件名、错误码前缀、托管目录命名)经工厂参数注入。
  *
  * Main 线程纪律: 用户所选目录可能在网络盘/可移动盘上, stat/realpath/写探针/
- * 删除全部走 node:fs/promises —— 挂起只阻塞当前 IPC/解析, 不冻结事件循环。
+ * 删除全部走 node:fs/promises —— 挂起只阻塞当前 IPC/解析, 不冻结事件循环;
+ * 且整条用户目录链路套 deadline(userDirTimeoutMs, 默认 5s): 失联网络盘下
+ * 设置读取限时返回 workingDirAvailable:false, 新对话解析回退托管目录,
+ * 选择新目录不提交配置并抛结构化超时错误。超时不取消底层操作(Node fs
+ * 无法取消) — 迟到的写探针若最终创建成功, 仍由本次调用的 finally 按
+ * 所有权纪律清理; 清理迟到/失败按既有纪律接受 0 字节残留。
  * 只有 userData(rootPath 测试桩)下的托管目录与配置文件属于本机盘, 同步
  * mkdirSync / 异步落盘均可接受。目录解析拆成两层:
  *   - ensureManagedWorkingDir(): 稳定托管目录, 同步, 供 sessionRepo 等热路径;
@@ -25,6 +30,14 @@ import { createLogger, maskPath } from '../../logger';
 import { ownerScopedImUserDataPath } from '../ownerScopedStorage';
 
 const SETTINGS_VERSION = 1;
+
+/**
+ * 用户目录 IO 的统一 deadline。取值权衡: 太短会把高延迟但活着的网络盘误判
+ * 不可用(/new 会回退托管目录); 太长则设置读取/选目录让用户久等。5s 覆盖
+ * 常规网盘抖动, 超过它按「当前不可用」处理 —— 目录恢复后的下一次设置刷新
+ * 或新对话会重新探测回来。测试经工厂参数 userDirTimeoutMs 缩小。
+ */
+const USER_DIR_IO_TIMEOUT_MS = 5_000;
 
 export interface ChannelWorkingDirSettings {
   version: typeof SETTINGS_VERSION;
@@ -71,10 +84,17 @@ export function createChannelWorkingDirStore(options: {
   errorCodePrefix: string;
   /** botId → 托管目录名。渠道各自的既定命名,存量目录依赖它保持稳定。 */
   managedDirNameFor(botId: string): string;
+  /**
+   * 用户目录 IO(realpath/stat/写探针/清理)的 deadline, 默认 5s — 主要供
+   * 测试缩小。本机盘(userData 配置与托管目录)不受它约束。
+   */
+  userDirTimeoutMs?: number;
 }): ChannelWorkingDirStore {
   const log = createLogger(options.logTag);
   const invalidErrorCode = `${options.errorCodePrefix}_WORKING_DIR_INVALID`;
   const notDirectoryErrorCode = `${options.errorCodePrefix}_WORKING_DIR_NOT_DIRECTORY`;
+  const probeTimeoutErrorCode = `${options.errorCodePrefix}_WORKING_DIR_PROBE_TIMEOUT`;
+  const userDirTimeoutMs = options.userDirTimeoutMs ?? USER_DIR_IO_TIMEOUT_MS;
   const defaults: ChannelWorkingDirSettings = { version: SETTINGS_VERSION, workingDir: null };
 
   function settingsFilePath(rootPath?: string): string {
@@ -99,7 +119,8 @@ export function createChannelWorkingDirStore(options: {
       return {
         ...normalized,
         workingDirAvailable:
-          normalized.workingDir === null || (await isUsableWorkingDirectory(normalized.workingDir)),
+          normalized.workingDir === null ||
+          (await isUsableWorkingDirectory(normalized.workingDir, userDirTimeoutMs)),
       };
     } catch (error) {
       log.warn(`failed to read ${options.logTag} settings; using defaults`, {
@@ -124,14 +145,22 @@ export function createChannelWorkingDirStore(options: {
     if (typeof selectedPath !== 'string' || !path.isAbsolute(selectedPath)) {
       throw Object.assign(new Error(invalidErrorCode), { code: invalidErrorCode });
     }
-    // 用户所选目录可能是网络盘/可移动盘 — realpath/stat 全异步, 挂起不冻结 Main。
-    // fs.promises 没有 realpath.native(那只有同步版), 用标准 fsp.realpath —
-    // 同样解析符号链接, Node 22 实测与 realpathSync.native 结果一致。
-    const realPath = await realpath(selectedPath);
-    if (!(await stat(realPath)).isDirectory()) {
-      throw Object.assign(new Error(notDirectoryErrorCode), { code: notDirectoryErrorCode });
+    // 用户所选目录可能是网络盘/可移动盘 — realpath/stat 全异步且套 deadline:
+    // 挂起不冻结 Main, 超时则不提交配置, 抛结构化超时错误(快速失败的本地
+    // 校验错误照常穿透)。fs.promises 没有 realpath.native(那只有同步版),
+    // 用标准 fsp.realpath — 同样解析符号链接, Node 22 实测与
+    // realpathSync.native 结果一致。
+    const checked = await withUserDirDeadline(async () => {
+      const realPath = await realpath(selectedPath);
+      if (!(await stat(realPath)).isDirectory()) {
+        throw Object.assign(new Error(notDirectoryErrorCode), { code: notDirectoryErrorCode });
+      }
+      return realPath;
+    }, userDirTimeoutMs);
+    if (checked === null) {
+      throw Object.assign(new Error(probeTimeoutErrorCode), { code: probeTimeoutErrorCode });
     }
-    const normalized = normalizeWorkingDirForStorage(realPath);
+    const normalized = normalizeWorkingDirForStorage(checked);
     if (!normalized) {
       throw Object.assign(new Error(invalidErrorCode), { code: invalidErrorCode });
     }
@@ -236,18 +265,30 @@ export function createChannelWorkingDirStore(options: {
  * 只能证明「存在」— 遍历/写权限被收回时它们仍成功(Windows 上 access 对目录
  * 基本恒过), 随后 /new 会拿到一个无法使用的目录而不是回退托管目录。所以用
  * 真写入探测: `writeFile(flag 'wx')` 独占创建并删除一个一次性 0 字节探针 —
- * 全异步, 不经 open/close 手工描述符生命周期, 挂起的网络盘只阻塞本探测。
+ * 全异步, 不经 open/close 手工描述符生命周期; 整条链路套 deadline, 失联
+ * 网络盘在限时内返回「不可用」, 探测本体超时后继续跑完, 迟到创建成功的
+ * 探针仍由本次调用按所有权纪律清理。
  *
  * 删除的所有权纪律(六轮 review 裁决, 两条都不可退让):
  *   - **绝不按文件名前缀扫描删除** — 用户自建的同前缀文件不属于 Cindy。
  *   - **只删除本次调用确认独占创建的探针** — 'wx' 碰撞(EEXIST)说明那个
  *     路径属于别人; 「记住路径跨时间重试」也不行, 路径被其它进程替换后
- *     重试会删掉替换文件。删除失败(锁)接受 0 字节 UUID 残留, 不设任何
- *     延迟重试队列。
+ *     重试会删掉替换文件。删除失败(锁)与「超时后才创建成功但清理迟到」
+ *     都接受 0 字节 UUID 残留, 不设任何延迟重试队列。
  */
 const WORKDIR_PROBE_PREFIX = '.cindy-workdir-probe-';
 
-async function isUsableWorkingDirectory(candidate: string): Promise<boolean> {
+async function isUsableWorkingDirectory(
+  candidate: string,
+  timeoutMs: number = USER_DIR_IO_TIMEOUT_MS,
+): Promise<boolean> {
+  // deadline 只决定「现在能不能信这个目录」; 探测本体超时后继续执行,
+  // 迟到的 'wx' 创建一旦成功, 由 probeUsability 自己的 finally 清理。
+  const verdict = await withUserDirDeadline(() => probeUsability(candidate), timeoutMs);
+  return verdict === true;
+}
+
+async function probeUsability(candidate: string): Promise<boolean> {
   const probe = path.join(candidate, `${WORKDIR_PROBE_PREFIX}${randomUUID()}`);
   let created = false;
   try {
@@ -265,6 +306,23 @@ async function isUsableWorkingDirectory(candidate: string): Promise<boolean> {
         // 删除被锁挡住: 接受 0 字节残留 — 不记住路径, 不重试, 不扫描。
       }
     }
+  }
+}
+
+/**
+ * 用户目录 IO 的 deadline 包装: 超时返回 null(与业务返回值可区分), 不取消
+ * 底层操作(Node fs 无法取消)。run() 的快速失败/校验错误立即穿透, 不吃满
+ * 时限; 超时后 run() 迟到的 settle 由 Promise.race 吸收, 不产生未处理拒绝。
+ */
+async function withUserDirDeadline<T>(run: () => Promise<T>, timeoutMs: number): Promise<T | null> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<null>((resolve) => {
+    timer = setTimeout(() => resolve(null), timeoutMs);
+  });
+  try {
+    return await Promise.race([run(), timeout]);
+  } finally {
+    clearTimeout(timer);
   }
 }
 

--- a/apps/desktop/src/main/im/shared/channelWorkingDirSettings.ts
+++ b/apps/desktop/src/main/im/shared/channelWorkingDirSettings.ts
@@ -5,11 +5,20 @@
  * 原生目录选择器里选中的 override,不保存静态默认值快照(「恢复默认」= 删文件);
  * 配置缺失、损坏或目录暂不可访问时安全回退渠道托管目录,不阻断入站消息。
  * 渠道差异(配置文件名、错误码前缀、托管目录命名)经工厂参数注入。
+ *
+ * Main 线程纪律: 用户所选目录可能在网络盘/可移动盘上, stat/realpath/写探针/
+ * 删除全部走 node:fs/promises —— 挂起只阻塞当前 IPC/解析, 不冻结事件循环。
+ * 只有 userData(rootPath 测试桩)下的托管目录与配置文件属于本机盘, 同步
+ * mkdirSync / 异步落盘均可接受。目录解析拆成两层:
+ *   - ensureManagedWorkingDir(): 稳定托管目录, 同步, 供 sessionRepo 等热路径;
+ *   - resolveWorkingDirForNewConversation(): 异步读配置 + 探测用户目录, 只在
+ *     设置刷新、首次对话与 /new 边界调用。
  */
 
 import fs from 'node:fs';
 import path from 'node:path';
 import { randomUUID } from 'node:crypto';
+import { readFile, realpath, rename, rm, stat, writeFile, mkdir } from 'node:fs/promises';
 
 import { normalizeWorkingDirForStorage } from '../../../shared/workingDir';
 import { createLogger, maskPath } from '../../logger';
@@ -27,11 +36,30 @@ export interface ChannelWorkingDirSettingsState extends ChannelWorkingDirSetting
 }
 
 export interface ChannelWorkingDirStore {
-  read(rootPath?: string): ChannelWorkingDirSettingsState;
-  writeWorkingDir(selectedPath: string, rootPath?: string): ChannelWorkingDirSettingsState;
-  resetWorkingDir(rootPath?: string): ChannelWorkingDirSettingsState;
-  /** 解析 bot 的生效目录;回退托管目录时负责创建它。 */
-  resolveWorkingDir(botId: string, rootPath?: string): string;
+  /** 设置刷新(设置页展开/聚焦 IPC)用: 异步读配置 + 异步探测用户目录可用性。 */
+  read(rootPath?: string): Promise<ChannelWorkingDirSettingsState>;
+  /** 校验并写入用户所选目录(一步到位版): 异步 normalize + 异步落盘。 */
+  writeWorkingDir(selectedPath: string, rootPath?: string): Promise<ChannelWorkingDirSettingsState>;
+  /** 只校验/规整用户所选目录(异步探测用户盘), 不落盘;返回存储形态路径。 */
+  normalizeSelectedDirectory(selectedPath: string): Promise<string>;
+  /**
+   * 落盘已规整的目录: 只碰本地 userData 配置文件。供 IPC 在「用户盘探测完成」
+   * 与「提交」之间二次校验 IM account generation 后调用, 缩短代次校验到写入的
+   * 敏感窗口(探测网络盘可能秒级)。
+   */
+  commitWorkingDir(normalizedDir: string, rootPath?: string): Promise<ChannelWorkingDirSettingsState>;
+  /** 「恢复默认」= 删配置文件(本地 userData)。 */
+  resetWorkingDir(rootPath?: string): Promise<ChannelWorkingDirSettingsState>;
+  /**
+   * 稳定托管目录(userData 本机盘, 同步 mkdir 不会挂起 Main)。会话行的兜底
+   * 目录与归属比较都用它 —— 不读配置、不探测用户盘。
+   */
+  ensureManagedWorkingDir(botId: string, rootPath?: string): string;
+  /** 解析新对话实际目录: 异步读配置 + 探测用户目录, 不可用回退托管目录。 */
+  resolveWorkingDirForNewConversation(
+    botId: string,
+    rootPath?: string,
+  ): Promise<string>;
 }
 
 export function createChannelWorkingDirStore(options: {
@@ -55,15 +83,23 @@ export function createChannelWorkingDirStore(options: {
       : ownerScopedImUserDataPath(options.fileName);
   }
 
-  function read(rootPath?: string): ChannelWorkingDirSettingsState {
+  async function read(rootPath?: string): Promise<ChannelWorkingDirSettingsState> {
     const file = settingsFilePath(rootPath);
     try {
-      if (!fs.existsSync(file)) return { ...defaults, workingDirAvailable: true };
-      const normalized = normalizeSettings(JSON.parse(fs.readFileSync(file, 'utf8')));
+      let raw: string;
+      try {
+        raw = await readFile(file, 'utf8');
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+          return { ...defaults, workingDirAvailable: true };
+        }
+        throw error;
+      }
+      const normalized = normalizeSettings(JSON.parse(raw));
       return {
         ...normalized,
         workingDirAvailable:
-          normalized.workingDir === null || isUsableWorkingDirectory(normalized.workingDir),
+          normalized.workingDir === null || (await isUsableWorkingDirectory(normalized.workingDir)),
       };
     } catch (error) {
       log.warn(`failed to read ${options.logTag} settings; using defaults`, {
@@ -74,19 +110,39 @@ export function createChannelWorkingDirStore(options: {
     }
   }
 
-  function writeWorkingDir(
+  async function writeWorkingDir(
     selectedPath: string,
     rootPath?: string,
-  ): ChannelWorkingDirSettingsState {
-    const workingDir = normalizeSelectedDirectory(selectedPath);
-    writeSettings({ ...defaults, workingDir }, rootPath);
+  ): Promise<ChannelWorkingDirSettingsState> {
+    return commitWorkingDir(await normalizeSelectedDirectory(selectedPath), rootPath);
+  }
+
+  async function normalizeSelectedDirectory(selectedPath: string): Promise<string> {
+    if (typeof selectedPath !== 'string' || !path.isAbsolute(selectedPath)) {
+      throw new Error(invalidErrorCode);
+    }
+    // 用户所选目录可能是网络盘/可移动盘 — realpath/stat 全异步, 挂起不冻结 Main。
+    // fs.promises 没有 realpath.native(那只有同步版), 用标准 fsp.realpath —
+    // 同样解析符号链接, Node 22 实测与 realpathSync.native 结果一致。
+    const realPath = await realpath(selectedPath);
+    if (!(await stat(realPath)).isDirectory()) throw new Error(notDirectoryErrorCode);
+    const normalized = normalizeWorkingDirForStorage(realPath);
+    if (!normalized) throw new Error(invalidErrorCode);
+    return normalized;
+  }
+
+  async function commitWorkingDir(
+    normalizedDir: string,
+    rootPath?: string,
+  ): Promise<ChannelWorkingDirSettingsState> {
+    await writeSettings({ ...defaults, workingDir: normalizedDir }, rootPath);
     return read(rootPath);
   }
 
-  function resetWorkingDir(rootPath?: string): ChannelWorkingDirSettingsState {
+  async function resetWorkingDir(rootPath?: string): Promise<ChannelWorkingDirSettingsState> {
     const file = settingsFilePath(rootPath);
     try {
-      fs.rmSync(file, { force: true });
+      await rm(file, { force: true });
     } catch (error) {
       log.warn(`failed to reset ${options.logTag} settings`, {
         path: maskPath(file),
@@ -97,26 +153,22 @@ export function createChannelWorkingDirStore(options: {
     return { ...defaults, workingDirAvailable: true };
   }
 
-  function resolveWorkingDir(botId: string, rootPath?: string): string {
-    const configured = read(rootPath);
-    if (configured.workingDir && configured.workingDirAvailable) return configured.workingDir;
-
+  function ensureManagedWorkingDir(botId: string, rootPath?: string): string {
     const dir = rootPath
       ? path.join(rootPath, 'im-working-dir', options.managedDirNameFor(botId))
       : ownerScopedImUserDataPath('im-working-dir', options.managedDirNameFor(botId));
+    // 本地 userData 托管目录 — 本机盘, 同步创建不会挂起 Main 事件循环。
     fs.mkdirSync(dir, { recursive: true });
     return dir;
   }
 
-  function normalizeSelectedDirectory(selectedPath: string): string {
-    if (typeof selectedPath !== 'string' || !path.isAbsolute(selectedPath)) {
-      throw new Error(invalidErrorCode);
-    }
-    const realPath = fs.realpathSync.native(selectedPath);
-    if (!fs.statSync(realPath).isDirectory()) throw new Error(notDirectoryErrorCode);
-    const normalized = normalizeWorkingDirForStorage(realPath);
-    if (!normalized) throw new Error(invalidErrorCode);
-    return normalized;
+  async function resolveWorkingDirForNewConversation(
+    botId: string,
+    rootPath?: string,
+  ): Promise<string> {
+    const configured = await read(rootPath);
+    if (configured.workingDir && configured.workingDirAvailable) return configured.workingDir;
+    return ensureManagedWorkingDir(botId, rootPath);
   }
 
   function normalizeSettings(raw: unknown): ChannelWorkingDirSettings {
@@ -137,23 +189,23 @@ export function createChannelWorkingDirStore(options: {
    * tmp 只有在本调用确认独占创建成功后才清理 — 'wx' 碰撞(EEXIST)说明那个
    * 路径属于别人, 无条件 rm 会删掉竞争文件(P0)。
    */
-  function writeSettings(settings: ChannelWorkingDirSettings, rootPath?: string): void {
+  async function writeSettings(settings: ChannelWorkingDirSettings, rootPath?: string): Promise<void> {
     const file = settingsFilePath(rootPath);
     const tmp = `${file}.${randomUUID()}.tmp`;
-    fs.mkdirSync(path.dirname(file), { recursive: true });
+    await mkdir(path.dirname(file), { recursive: true });
     let tmpCreated = false;
     try {
-      fs.writeFileSync(tmp, `${JSON.stringify(settings, null, 2)}\n`, {
+      await writeFile(tmp, `${JSON.stringify(settings, null, 2)}\n`, {
         encoding: 'utf8',
         flag: 'wx',
       });
       tmpCreated = true;
-      fs.renameSync(tmp, file);
+      await rename(tmp, file);
     } finally {
       if (tmpCreated) {
         try {
           // rename 成功后是 ENOENT 幂等 no-op;rename 失败则清掉自己的半成品。
-          fs.rmSync(tmp, { force: true });
+          await rm(tmp, { force: true });
         } catch {
           // 清理被锁挡住: 接受 tmp 残留, 不掩盖真正的写入错误。
         }
@@ -161,15 +213,23 @@ export function createChannelWorkingDirStore(options: {
     }
   }
 
-  return { read, writeWorkingDir, resetWorkingDir, resolveWorkingDir };
+  return {
+    read,
+    writeWorkingDir,
+    normalizeSelectedDirectory,
+    commitWorkingDir,
+    resetWorkingDir,
+    ensureManagedWorkingDir,
+    resolveWorkingDirForNewConversation,
+  };
 }
 
 /**
  * 目录「可用」按工作目录的实际用途判定: agent 要往里写文件。stat/access 都
  * 只能证明「存在」— 遍历/写权限被收回时它们仍成功(Windows 上 access 对目录
  * 基本恒过), 随后 /new 会拿到一个无法使用的目录而不是回退托管目录。所以用
- * 真写入探测: `writeFileSync(flag 'wx')` 独占创建并删除一个一次性 0 字节
- * 探针 — 不经 openSync/closeSync, 探测路径上没有手工描述符生命周期可泄漏。
+ * 真写入探测: `writeFile(flag 'wx')` 独占创建并删除一个一次性 0 字节探针 —
+ * 全异步, 不经 open/close 手工描述符生命周期, 挂起的网络盘只阻塞本探测。
  *
  * 删除的所有权纪律(六轮 review 裁决, 两条都不可退让):
  *   - **绝不按文件名前缀扫描删除** — 用户自建的同前缀文件不属于 Cindy。
@@ -180,12 +240,12 @@ export function createChannelWorkingDirStore(options: {
  */
 const WORKDIR_PROBE_PREFIX = '.cindy-workdir-probe-';
 
-function isUsableWorkingDirectory(candidate: string): boolean {
+async function isUsableWorkingDirectory(candidate: string): Promise<boolean> {
   const probe = path.join(candidate, `${WORKDIR_PROBE_PREFIX}${randomUUID()}`);
   let created = false;
   try {
-    if (!fs.statSync(candidate).isDirectory()) return false;
-    fs.writeFileSync(probe, '', { flag: 'wx' });
+    if (!(await stat(candidate)).isDirectory()) return false;
+    await writeFile(probe, '', { flag: 'wx' });
     created = true;
     return true;
   } catch {
@@ -193,7 +253,7 @@ function isUsableWorkingDirectory(candidate: string): boolean {
   } finally {
     if (created) {
       try {
-        fs.rmSync(probe, { force: true });
+        await rm(probe, { force: true });
       } catch {
         // 删除被锁挡住: 接受 0 字节残留 — 不记住路径, 不重试, 不扫描。
       }

--- a/apps/desktop/src/main/im/shared/channelWorkingDirSettings.ts
+++ b/apps/desktop/src/main/im/shared/channelWorkingDirSettings.ts
@@ -118,16 +118,23 @@ export function createChannelWorkingDirStore(options: {
   }
 
   async function normalizeSelectedDirectory(selectedPath: string): Promise<string> {
+    // 校验错误自带 .code(= 渠道错误码): IPC 层日志只记错误码即可区分
+    // WECOM_WORKING_DIR_INVALID / NOT_DIRECTORY / EACCES..., 不需要
+    // error.message —— 原生 fs 错误的 message 含完整用户目录, 不能进日志。
     if (typeof selectedPath !== 'string' || !path.isAbsolute(selectedPath)) {
-      throw new Error(invalidErrorCode);
+      throw Object.assign(new Error(invalidErrorCode), { code: invalidErrorCode });
     }
     // 用户所选目录可能是网络盘/可移动盘 — realpath/stat 全异步, 挂起不冻结 Main。
     // fs.promises 没有 realpath.native(那只有同步版), 用标准 fsp.realpath —
     // 同样解析符号链接, Node 22 实测与 realpathSync.native 结果一致。
     const realPath = await realpath(selectedPath);
-    if (!(await stat(realPath)).isDirectory()) throw new Error(notDirectoryErrorCode);
+    if (!(await stat(realPath)).isDirectory()) {
+      throw Object.assign(new Error(notDirectoryErrorCode), { code: notDirectoryErrorCode });
+    }
     const normalized = normalizeWorkingDirForStorage(realPath);
-    if (!normalized) throw new Error(invalidErrorCode);
+    if (!normalized) {
+      throw Object.assign(new Error(invalidErrorCode), { code: invalidErrorCode });
+    }
     return normalized;
   }
 

--- a/apps/desktop/src/main/im/shared/channelWorkingDirSettings.ts
+++ b/apps/desktop/src/main/im/shared/channelWorkingDirSettings.ts
@@ -1,0 +1,213 @@
+/**
+ * Owner-scoped, non-secret channel working-directory override store.
+ *
+ * 直连 IM 渠道(个人微信/企业微信)共用的工作目录配置:只持久化用户在 Main
+ * 原生目录选择器里选中的 override,不保存静态默认值快照(「恢复默认」= 删文件);
+ * 配置缺失、损坏或目录暂不可访问时安全回退渠道托管目录,不阻断入站消息。
+ * 渠道差异(配置文件名、错误码前缀、托管目录命名)经工厂参数注入。
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { randomUUID } from 'node:crypto';
+
+import { normalizeWorkingDirForStorage } from '../../../shared/workingDir';
+import { createLogger, maskPath } from '../../logger';
+import { ownerScopedImUserDataPath } from '../ownerScopedStorage';
+
+const SETTINGS_VERSION = 1;
+
+export interface ChannelWorkingDirSettings {
+  version: typeof SETTINGS_VERSION;
+  workingDir: string | null;
+}
+
+export interface ChannelWorkingDirSettingsState extends ChannelWorkingDirSettings {
+  workingDirAvailable: boolean;
+}
+
+export interface ChannelWorkingDirStore {
+  read(rootPath?: string): ChannelWorkingDirSettingsState;
+  writeWorkingDir(selectedPath: string, rootPath?: string): ChannelWorkingDirSettingsState;
+  resetWorkingDir(rootPath?: string): ChannelWorkingDirSettingsState;
+  /** 解析 bot 的生效目录;回退托管目录时负责创建它。 */
+  resolveWorkingDir(botId: string, rootPath?: string): string;
+}
+
+export function createChannelWorkingDirStore(options: {
+  /** 日志 tag,如 'im/wecom/channel-settings'。 */
+  logTag: string;
+  /** owner-scoped 配置文件名,如 'wecom-channel.json'。 */
+  fileName: string;
+  /** 校验错误码前缀,如 'WECOM' → 'WECOM_WORKING_DIR_INVALID'。 */
+  errorCodePrefix: string;
+  /** botId → 托管目录名。渠道各自的既定命名,存量目录依赖它保持稳定。 */
+  managedDirNameFor(botId: string): string;
+}): ChannelWorkingDirStore {
+  const log = createLogger(options.logTag);
+  const invalidErrorCode = `${options.errorCodePrefix}_WORKING_DIR_INVALID`;
+  const notDirectoryErrorCode = `${options.errorCodePrefix}_WORKING_DIR_NOT_DIRECTORY`;
+  const defaults: ChannelWorkingDirSettings = { version: SETTINGS_VERSION, workingDir: null };
+
+  function settingsFilePath(rootPath?: string): string {
+    return rootPath
+      ? path.join(rootPath, options.fileName)
+      : ownerScopedImUserDataPath(options.fileName);
+  }
+
+  function read(rootPath?: string): ChannelWorkingDirSettingsState {
+    const file = settingsFilePath(rootPath);
+    try {
+      if (!fs.existsSync(file)) return { ...defaults, workingDirAvailable: true };
+      const normalized = normalizeSettings(JSON.parse(fs.readFileSync(file, 'utf8')));
+      return {
+        ...normalized,
+        workingDirAvailable:
+          normalized.workingDir === null || isUsableWorkingDirectory(normalized.workingDir),
+      };
+    } catch (error) {
+      log.warn(`failed to read ${options.logTag} settings; using defaults`, {
+        path: maskPath(file),
+        errorCode: nodeErrorCode(error),
+      });
+      return { ...defaults, workingDirAvailable: true };
+    }
+  }
+
+  function writeWorkingDir(
+    selectedPath: string,
+    rootPath?: string,
+  ): ChannelWorkingDirSettingsState {
+    const workingDir = normalizeSelectedDirectory(selectedPath);
+    writeSettings({ ...defaults, workingDir }, rootPath);
+    return read(rootPath);
+  }
+
+  function resetWorkingDir(rootPath?: string): ChannelWorkingDirSettingsState {
+    const file = settingsFilePath(rootPath);
+    try {
+      fs.rmSync(file, { force: true });
+    } catch (error) {
+      log.warn(`failed to reset ${options.logTag} settings`, {
+        path: maskPath(file),
+        errorCode: nodeErrorCode(error),
+      });
+      throw error;
+    }
+    return { ...defaults, workingDirAvailable: true };
+  }
+
+  function resolveWorkingDir(botId: string, rootPath?: string): string {
+    const configured = read(rootPath);
+    if (configured.workingDir && configured.workingDirAvailable) return configured.workingDir;
+
+    const dir = rootPath
+      ? path.join(rootPath, 'im-working-dir', options.managedDirNameFor(botId))
+      : ownerScopedImUserDataPath('im-working-dir', options.managedDirNameFor(botId));
+    fs.mkdirSync(dir, { recursive: true });
+    return dir;
+  }
+
+  function normalizeSelectedDirectory(selectedPath: string): string {
+    if (typeof selectedPath !== 'string' || !path.isAbsolute(selectedPath)) {
+      throw new Error(invalidErrorCode);
+    }
+    const realPath = fs.realpathSync.native(selectedPath);
+    if (!fs.statSync(realPath).isDirectory()) throw new Error(notDirectoryErrorCode);
+    const normalized = normalizeWorkingDirForStorage(realPath);
+    if (!normalized) throw new Error(invalidErrorCode);
+    return normalized;
+  }
+
+  function normalizeSettings(raw: unknown): ChannelWorkingDirSettings {
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return { ...defaults };
+    const input = raw as Record<string, unknown>;
+    const workingDir =
+      typeof input.workingDir === 'string' && path.isAbsolute(input.workingDir)
+        ? normalizeWorkingDirForStorage(input.workingDir)
+        : null;
+    return {
+      version: SETTINGS_VERSION,
+      workingDir,
+    };
+  }
+
+  /**
+   * tmp + rename 原子落盘:崩溃不会留下半份 JSON。
+   * tmp 只有在本调用确认独占创建成功后才清理 — 'wx' 碰撞(EEXIST)说明那个
+   * 路径属于别人, 无条件 rm 会删掉竞争文件(P0)。
+   */
+  function writeSettings(settings: ChannelWorkingDirSettings, rootPath?: string): void {
+    const file = settingsFilePath(rootPath);
+    const tmp = `${file}.${randomUUID()}.tmp`;
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    let tmpCreated = false;
+    try {
+      fs.writeFileSync(tmp, `${JSON.stringify(settings, null, 2)}\n`, {
+        encoding: 'utf8',
+        flag: 'wx',
+      });
+      tmpCreated = true;
+      fs.renameSync(tmp, file);
+    } finally {
+      if (tmpCreated) {
+        try {
+          // rename 成功后是 ENOENT 幂等 no-op;rename 失败则清掉自己的半成品。
+          fs.rmSync(tmp, { force: true });
+        } catch {
+          // 清理被锁挡住: 接受 tmp 残留, 不掩盖真正的写入错误。
+        }
+      }
+    }
+  }
+
+  return { read, writeWorkingDir, resetWorkingDir, resolveWorkingDir };
+}
+
+/**
+ * 目录「可用」按工作目录的实际用途判定: agent 要往里写文件。stat/access 都
+ * 只能证明「存在」— 遍历/写权限被收回时它们仍成功(Windows 上 access 对目录
+ * 基本恒过), 随后 /new 会拿到一个无法使用的目录而不是回退托管目录。所以用
+ * 真写入探测: `writeFileSync(flag 'wx')` 独占创建并删除一个一次性 0 字节
+ * 探针 — 不经 openSync/closeSync, 探测路径上没有手工描述符生命周期可泄漏。
+ *
+ * 删除的所有权纪律(六轮 review 裁决, 两条都不可退让):
+ *   - **绝不按文件名前缀扫描删除** — 用户自建的同前缀文件不属于 Cindy。
+ *   - **只删除本次调用确认独占创建的探针** — 'wx' 碰撞(EEXIST)说明那个
+ *     路径属于别人; 「记住路径跨时间重试」也不行, 路径被其它进程替换后
+ *     重试会删掉替换文件。删除失败(锁)接受 0 字节 UUID 残留, 不设任何
+ *     延迟重试队列。
+ */
+const WORKDIR_PROBE_PREFIX = '.cindy-workdir-probe-';
+
+function isUsableWorkingDirectory(candidate: string): boolean {
+  const probe = path.join(candidate, `${WORKDIR_PROBE_PREFIX}${randomUUID()}`);
+  let created = false;
+  try {
+    if (!fs.statSync(candidate).isDirectory()) return false;
+    fs.writeFileSync(probe, '', { flag: 'wx' });
+    created = true;
+    return true;
+  } catch {
+    return false;
+  } finally {
+    if (created) {
+      try {
+        fs.rmSync(probe, { force: true });
+      } catch {
+        // 删除被锁挡住: 接受 0 字节残留 — 不记住路径, 不重试, 不扫描。
+      }
+    }
+  }
+}
+
+function nodeErrorCode(error: unknown): string {
+  return typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    typeof (error as { code?: unknown }).code === 'string'
+    ? (error as { code: string }).code
+    : 'UNKNOWN';
+}
+
+export const __testing = { isUsableWorkingDirectory };

--- a/apps/desktop/src/main/im/shared/channelWorkingDirSettings.ts
+++ b/apps/desktop/src/main/im/shared/channelWorkingDirSettings.ts
@@ -48,7 +48,59 @@ export interface ChannelWorkingDirSettingsState extends ChannelWorkingDirSetting
   workingDirAvailable: boolean;
 }
 
+/**
+ * 用户目录探测的执行边界。默认实现跑在本进程(单测用它 + fs mock);生产环境
+ * 由 im/index.ts 注入 workdir-probe-host 的 utility-process 执行器 —— Node 的
+ * fs 调用不可取消, 失联网络盘会把挂死 IO 留在 libuv 线程池里, 子进程化后
+ * 超时即终止回收(review P1: 槽位被永久挂起的探针占满会饿死健康目录)。
+ * 同目录 single-flight / 超时冷却 / 并发上限在 store 层保留, 作为减少探测
+ * 次数的优化。
+ */
+export type UserDirValidateOutcome =
+  | { ok: true; realPath: string }
+  /** code: NOT_DIRECTORY / NOT_WRITABLE / PROBE_TIMEOUT / PROBE_UNAVAILABLE / 原生 fs 码 */
+  | { ok: false; code: string };
+export type UserDirAvailabilityOutcome =
+  | { ok: true; usable: boolean }
+  | { ok: false; code: string };
+
+export interface ChannelUserDirProbeExecutor {
+  /** 严格校验新选择目录: realpath → stat → 'wx' 写探针 → 清理。 */
+  validate(selectedPath: string, timeoutMs: number): Promise<UserDirValidateOutcome>;
+  /** 已保存目录可用性: stat → 'wx' 写探针 → 清理(失败宽大降级)。 */
+  availability(candidate: string, timeoutMs: number): Promise<UserDirAvailabilityOutcome>;
+}
+
+/** 进程内默认执行器(单测与兜底); 生产经 setProbeExecutor 换成子进程执行器。 */
+function createInProcessUserDirProbeExecutor(): ChannelUserDirProbeExecutor {
+  return {
+    async validate(selectedPath, timeoutMs) {
+      const checked = await withUserDirDeadline(async () => {
+        const realPath = await realpath(selectedPath);
+        if (!(await stat(realPath)).isDirectory()) {
+          return { ok: false as const, code: 'NOT_DIRECTORY' };
+        }
+        if (!(await probeUsability(realPath))) {
+          return { ok: false as const, code: 'NOT_WRITABLE' };
+        }
+        return { ok: true as const, realPath };
+      }, timeoutMs);
+      return checked ?? { ok: false, code: 'PROBE_TIMEOUT' };
+    },
+    async availability(candidate, timeoutMs) {
+      const verdict = await withUserDirDeadline(() => probeUsability(candidate), timeoutMs);
+      if (verdict === null) return { ok: false, code: 'PROBE_TIMEOUT' };
+      return { ok: true, usable: verdict };
+    },
+  };
+}
+
 export interface ChannelWorkingDirStore {
+  /**
+   * 替换用户目录探测执行边界(im/index.ts 启动时注入 utility-process 执行器)。
+   * 在途请求沿用旧执行器跑完; 只影响后续探测。
+   */
+  setProbeExecutor(executor: ChannelUserDirProbeExecutor): void;
   /** 设置刷新(设置页展开/聚焦 IPC)用: 异步读配置 + 异步探测用户目录可用性。 */
   read(rootPath?: string): Promise<ChannelWorkingDirSettingsState>;
   /** 校验并写入用户所选目录(一步到位版): 异步 normalize + 异步落盘。 */
@@ -94,6 +146,8 @@ export function createChannelWorkingDirStore(options: {
    * 测试缩小。本机盘(userData 配置与托管目录)不受它约束。
    */
   userDirTimeoutMs?: number;
+  /** 用户目录探测执行边界;缺省为进程内执行器(单测), 生产由 im/index.ts 注入。 */
+  probeExecutor?: ChannelUserDirProbeExecutor;
 }): ChannelWorkingDirStore {
   const log = createLogger(options.logTag);
   const invalidErrorCode = `${options.errorCodePrefix}_WORKING_DIR_INVALID`;
@@ -101,7 +155,22 @@ export function createChannelWorkingDirStore(options: {
   const probeTimeoutErrorCode = `${options.errorCodePrefix}_WORKING_DIR_PROBE_TIMEOUT`;
   const notWritableErrorCode = `${options.errorCodePrefix}_WORKING_DIR_NOT_WRITABLE`;
   const userDirTimeoutMs = options.userDirTimeoutMs ?? USER_DIR_IO_TIMEOUT_MS;
+  let probeExecutor: ChannelUserDirProbeExecutor =
+    options.probeExecutor ?? createInProcessUserDirProbeExecutor();
+  const probeScheduler = createProbeScheduler(() => probeExecutor);
   const defaults: ChannelWorkingDirSettings = { version: SETTINGS_VERSION, workingDir: null };
+
+  function setProbeExecutor(executor: ChannelUserDirProbeExecutor): void {
+    probeExecutor = executor;
+  }
+
+  /** 执行器稳定错误码 → 渠道错误码(原生 fs 码原样保留, 只进日志不落文案)。 */
+  function mapValidateCode(code: string): string {
+    if (code === 'NOT_DIRECTORY') return notDirectoryErrorCode;
+    if (code === 'NOT_WRITABLE') return notWritableErrorCode;
+    if (code === 'PROBE_TIMEOUT' || code === 'PROBE_UNAVAILABLE') return probeTimeoutErrorCode;
+    return code;
+  }
 
   function settingsFilePath(rootPath?: string): string {
     return rootPath
@@ -126,7 +195,8 @@ export function createChannelWorkingDirStore(options: {
         ...normalized,
         workingDirAvailable:
           normalized.workingDir === null ||
-          (await isUsableWorkingDirectory(normalized.workingDir, userDirTimeoutMs)),
+          (await probeScheduler.availability(normalized.workingDir, userDirTimeoutMs)) ===
+            'usable',
       };
     } catch (error) {
       log.warn(`failed to read ${options.logTag} settings; using defaults`, {
@@ -151,35 +221,24 @@ export function createChannelWorkingDirStore(options: {
     if (typeof selectedPath !== 'string' || !path.isAbsolute(selectedPath)) {
       throw Object.assign(new Error(invalidErrorCode), { code: invalidErrorCode });
     }
-    // 新选择目录采用「严格校验」: realpath → stat → 'wx' 写探针 → 清理在
-    // 同一个 deadline 内完成, 任一步失败/超时都不进入 commit, 原配置保持
-    // 不变(与「已保存目录宽大保留」相对 — 后者由 read() 降级为不可用)。
-    // 用户所选目录可能是网络盘/可移动盘 — 全异步且套 deadline: 挂起不冻结
-    // Main, 超时抛结构化超时错误; 快速失败的本地校验错误照常穿透。
-    // fs.promises 没有 realpath.native(那只有同步版), 用标准 fsp.realpath —
-    // 同样解析符号链接, Node 22 实测与 realpathSync.native 结果一致。
-    const checked = await withUserDirDeadline(async () => {
-      const realPath = await realpath(selectedPath);
-      if (!(await stat(realPath)).isDirectory()) {
-        throw Object.assign(new Error(notDirectoryErrorCode), { code: notDirectoryErrorCode });
-      }
-      // 写探针走统一调度(同目录复用/冷却/并发上限) — 目录存在但探针写不进
-      // (权限/只读/独占碰撞)绝不提交; 超时或被调度拒绝同样不提交。
-      const probe = await probeWithDiscipline(realPath, userDirTimeoutMs);
-      if (probe === 'unusable') {
-        throw Object.assign(new Error(notWritableErrorCode), { code: notWritableErrorCode });
-      }
-      if (probe !== 'usable') {
-        throw Object.assign(new Error(probeTimeoutErrorCode), { code: probeTimeoutErrorCode });
-      }
-      return realPath;
-    }, userDirTimeoutMs);
-    if (checked === null) {
-      // 链条(realpath/stat)超时: 对该路径进入冷却, 重复选择不再占线程。
-      probeCooldownUntil.set(selectedPath, Date.now() + PROBE_COOLDOWN_MS);
+    // 冷却中的路径直接超时收口, 不再向执行边界排队(重复选择同一失联目录)。
+    if (probeScheduler.inCooldown(selectedPath)) {
       throw Object.assign(new Error(probeTimeoutErrorCode), { code: probeTimeoutErrorCode });
     }
-    const normalized = normalizeWorkingDirForStorage(checked);
+    // 新选择目录采用「严格校验」: realpath → stat → 'wx' 写探针 → 清理整个
+    // 链条跑在探测执行边界内(生产为 utility process, 超时即终止回收), 任一步
+    // 失败/超时都不进入 commit, 原配置保持不变(与「已保存目录宽大保留」相对 —
+    // 后者由 read() 降级为不可用)。
+    const outcome = await probeExecutor.validate(selectedPath, userDirTimeoutMs);
+    if (!outcome.ok) {
+      const code = mapValidateCode(outcome.code);
+      if (code === probeTimeoutErrorCode) {
+        // 探测超时/执行边界不可用: 对该路径进入冷却, 重复选择不再排队。
+        probeScheduler.cooldown(selectedPath);
+      }
+      throw Object.assign(new Error(code), { code });
+    }
+    const normalized = normalizeWorkingDirForStorage(outcome.realPath);
     if (!normalized) {
       throw Object.assign(new Error(invalidErrorCode), { code: invalidErrorCode });
     }
@@ -272,6 +331,7 @@ export function createChannelWorkingDirStore(options: {
   }
 
   return {
+    setProbeExecutor,
     read,
     writeWorkingDir,
     normalizeSelectedDirectory,
@@ -313,49 +373,87 @@ const WORKDIR_PROBE_PREFIX = '.cindy-workdir-probe-';
  */
 const PROBE_COOLDOWN_MS = 30_000;
 const MAX_CONCURRENT_USER_DIR_PROBES = 8;
-const inflightProbes = new Map<string, Promise<boolean>>();
-const probeCooldownUntil = new Map<string, number>();
-let inflightProbeCount = 0;
-
-function acquireProbe(candidate: string): Promise<boolean> | null {
-  // 冷却判定优先于复用: 该目录已经让某次调用等超时了, 不该让后续调用再
-  // 挂在(仍挂起的)旧探针上等满自己的 deadline — 直接拒绝, 立即按不可用
-  // 返回; 旧探针继续自跑自清理。
-  if ((probeCooldownUntil.get(candidate) ?? 0) > Date.now()) return null;
-  const shared = inflightProbes.get(candidate);
-  if (shared) return shared;
-  if (inflightProbeCount >= MAX_CONCURRENT_USER_DIR_PROBES) return null;
-  const attempt = probeUsability(candidate).finally(() => {
-    inflightProbes.delete(candidate);
-    // resetProbeScheduler 清空计数后迟到的释放不得把计数打成负数。
-    inflightProbeCount = Math.max(0, inflightProbeCount - 1);
-  });
-  inflightProbes.set(candidate, attempt);
-  inflightProbeCount += 1;
-  return attempt;
-}
 
 type ProbeVerdict = 'usable' | 'unusable' | 'timeout' | 'skipped';
 
-async function probeWithDiscipline(candidate: string, timeoutMs: number): Promise<ProbeVerdict> {
-  const attempt = acquireProbe(candidate);
-  if (attempt === null) return 'skipped';
-  // deadline 只决定「现在能不能信这个目录」; 底层探针继续执行, 迟到的 'wx'
-  // 创建一旦成功, 仍由 probeUsability 自己的 finally 按所有权纪律清理。
-  const verdict = await withUserDirDeadline(() => attempt, timeoutMs);
-  if (verdict === null) {
-    probeCooldownUntil.set(candidate, Date.now() + PROBE_COOLDOWN_MS);
-    return 'timeout';
-  }
-  return verdict ? 'usable' : 'unusable';
+interface ProbeScheduler {
+  /** 可用性探测(带 single-flight / 冷却 / 并发上限)。 */
+  availability(candidate: string, timeoutMs: number): Promise<ProbeVerdict>;
+  /** 手动记冷却(normalize 链条超时时用)。 */
+  cooldown(candidate: string): void;
+  /** 该目录是否处于冷却期。 */
+  inCooldown(candidate: string): boolean;
+  reset(): void;
 }
+
+function createProbeScheduler(
+  executor: () => ChannelUserDirProbeExecutor,
+): ProbeScheduler {
+  const inflightProbes = new Map<string, Promise<UserDirAvailabilityOutcome>>();
+  const probeCooldownUntil = new Map<string, number>();
+  let inflightProbeCount = 0;
+
+  function acquire(
+    candidate: string,
+    timeoutMs: number,
+  ): Promise<UserDirAvailabilityOutcome> | null {
+    // 冷却判定优先于复用: 该目录已经让某次调用等超时了, 不该让后续调用再
+    // 挂在(仍挂起的)旧探针上等满自己的 deadline — 直接拒绝, 立即按不可用
+    // 返回; 旧探针在执行边界内自跑自清理。
+    if ((probeCooldownUntil.get(candidate) ?? 0) > Date.now()) return null;
+    const shared = inflightProbes.get(candidate);
+    if (shared) return shared;
+    if (inflightProbeCount >= MAX_CONCURRENT_USER_DIR_PROBES) return null;
+    const attempt = executor()
+      .availability(candidate, timeoutMs)
+      .finally(() => {
+        inflightProbes.delete(candidate);
+        // reset 后迟到的释放不得把计数打成负数。
+        inflightProbeCount = Math.max(0, inflightProbeCount - 1);
+      });
+    inflightProbes.set(candidate, attempt);
+    inflightProbeCount += 1;
+    return attempt;
+  }
+
+  return {
+    async availability(candidate, timeoutMs): Promise<ProbeVerdict> {
+      const attempt = acquire(candidate, timeoutMs);
+      if (attempt === null) return 'skipped';
+      // 执行边界保证在 timeoutMs 内 settle(子进程被 kill / 进程内 deadline),
+      // 挂死的底层 IO 不会滞留在 Main 的 libuv 线程池, 槽位必然释放。
+      const outcome = await attempt;
+      if (outcome.ok) return outcome.usable ? 'usable' : 'unusable';
+      if (outcome.code === 'PROBE_UNAVAILABLE') {
+        // 执行边界自身不可用(队列满/宿主故障): 不给目录记冷却, 下次照常尝试。
+        return 'skipped';
+      }
+      probeCooldownUntil.set(candidate, Date.now() + PROBE_COOLDOWN_MS);
+      return 'timeout';
+    },
+    cooldown(candidate) {
+      probeCooldownUntil.set(candidate, Date.now() + PROBE_COOLDOWN_MS);
+    },
+    inCooldown(candidate) {
+      return (probeCooldownUntil.get(candidate) ?? 0) > Date.now();
+    },
+    reset() {
+      inflightProbes.clear();
+      probeCooldownUntil.clear();
+      inflightProbeCount = 0;
+    },
+  };
+}
+
+/** __testing 直测调度行为的默认调度器(默认进程内执行器)。 */
+const defaultProbeScheduler = createProbeScheduler(createInProcessUserDirProbeExecutor);
 
 async function isUsableWorkingDirectory(
   candidate: string,
   timeoutMs: number = USER_DIR_IO_TIMEOUT_MS,
 ): Promise<boolean> {
   // 冷却/超限(skipped)与超时一样按「当前不可用」处理 — 拒绝占用更多线程。
-  return (await probeWithDiscipline(candidate, timeoutMs)) === 'usable';
+  return (await defaultProbeScheduler.availability(candidate, timeoutMs)) === 'usable';
 }
 
 async function probeUsability(candidate: string): Promise<boolean> {
@@ -407,11 +505,9 @@ function nodeErrorCode(error: unknown): string {
 
 export const __testing = {
   isUsableWorkingDirectory,
-  /** 清空探针调度状态(在途表/冷却表/计数) — 测试隔离用。 */
+  /** 清空默认调度器的探针状态(在途表/冷却表/计数) — 测试隔离用。 */
   resetProbeScheduler(): void {
-    inflightProbes.clear();
-    probeCooldownUntil.clear();
-    inflightProbeCount = 0;
+    defaultProbeScheduler.reset();
   },
   probeLimits: {
     maxConcurrent: MAX_CONCURRENT_USER_DIR_PROBES,

--- a/apps/desktop/src/main/im/shared/channelWorkingDirSettings.ts
+++ b/apps/desktop/src/main/im/shared/channelWorkingDirSettings.ts
@@ -163,13 +163,20 @@ export function createChannelWorkingDirStore(options: {
       if (!(await stat(realPath)).isDirectory()) {
         throw Object.assign(new Error(notDirectoryErrorCode), { code: notDirectoryErrorCode });
       }
-      if (!(await probeUsability(realPath))) {
-        // 目录存在但探针写不进(权限/只读/独占碰撞) — 绝不提交。
+      // 写探针走统一调度(同目录复用/冷却/并发上限) — 目录存在但探针写不进
+      // (权限/只读/独占碰撞)绝不提交; 超时或被调度拒绝同样不提交。
+      const probe = await probeWithDiscipline(realPath, userDirTimeoutMs);
+      if (probe === 'unusable') {
         throw Object.assign(new Error(notWritableErrorCode), { code: notWritableErrorCode });
+      }
+      if (probe !== 'usable') {
+        throw Object.assign(new Error(probeTimeoutErrorCode), { code: probeTimeoutErrorCode });
       }
       return realPath;
     }, userDirTimeoutMs);
     if (checked === null) {
+      // 链条(realpath/stat)超时: 对该路径进入冷却, 重复选择不再占线程。
+      probeCooldownUntil.set(selectedPath, Date.now() + PROBE_COOLDOWN_MS);
       throw Object.assign(new Error(probeTimeoutErrorCode), { code: probeTimeoutErrorCode });
     }
     const normalized = normalizeWorkingDirForStorage(checked);
@@ -293,14 +300,62 @@ export function createChannelWorkingDirStore(options: {
  */
 const WORKDIR_PROBE_PREFIX = '.cindy-workdir-probe-';
 
+/**
+ * 探针调度(review P2: deadline 只让调用者提前返回, 底层 fs 调用仍占着
+ * libuv 线程 — 反复聚焦设置页//new 会累积挂起探针, 拖住其它异步文件操作)。
+ * 最低可接受修法, 模块级共享(跨渠道, 同一台机器):
+ *   - **同目录复用**: 相同目录的在途探针只跑一份底层 IO, 并发调用共享结果;
+ *   - **超时冷却**: 某目录探测超时后进入冷却期(PROBE_COOLDOWN_MS), 期间
+ *     不再为它发起底层探针, 直接按不可用/超时返回;
+ *   - **全局并发上限**: 在途用户目录探针超过 MAX_CONCURRENT_USER_DIR_PROBES
+ *     时新请求直接拒绝(不占线程)。真·硬终止需要把探测挪进可杀死的子进程,
+ *     不在本轮范围。
+ */
+const PROBE_COOLDOWN_MS = 30_000;
+const MAX_CONCURRENT_USER_DIR_PROBES = 8;
+const inflightProbes = new Map<string, Promise<boolean>>();
+const probeCooldownUntil = new Map<string, number>();
+let inflightProbeCount = 0;
+
+function acquireProbe(candidate: string): Promise<boolean> | null {
+  // 冷却判定优先于复用: 该目录已经让某次调用等超时了, 不该让后续调用再
+  // 挂在(仍挂起的)旧探针上等满自己的 deadline — 直接拒绝, 立即按不可用
+  // 返回; 旧探针继续自跑自清理。
+  if ((probeCooldownUntil.get(candidate) ?? 0) > Date.now()) return null;
+  const shared = inflightProbes.get(candidate);
+  if (shared) return shared;
+  if (inflightProbeCount >= MAX_CONCURRENT_USER_DIR_PROBES) return null;
+  const attempt = probeUsability(candidate).finally(() => {
+    inflightProbes.delete(candidate);
+    // resetProbeScheduler 清空计数后迟到的释放不得把计数打成负数。
+    inflightProbeCount = Math.max(0, inflightProbeCount - 1);
+  });
+  inflightProbes.set(candidate, attempt);
+  inflightProbeCount += 1;
+  return attempt;
+}
+
+type ProbeVerdict = 'usable' | 'unusable' | 'timeout' | 'skipped';
+
+async function probeWithDiscipline(candidate: string, timeoutMs: number): Promise<ProbeVerdict> {
+  const attempt = acquireProbe(candidate);
+  if (attempt === null) return 'skipped';
+  // deadline 只决定「现在能不能信这个目录」; 底层探针继续执行, 迟到的 'wx'
+  // 创建一旦成功, 仍由 probeUsability 自己的 finally 按所有权纪律清理。
+  const verdict = await withUserDirDeadline(() => attempt, timeoutMs);
+  if (verdict === null) {
+    probeCooldownUntil.set(candidate, Date.now() + PROBE_COOLDOWN_MS);
+    return 'timeout';
+  }
+  return verdict ? 'usable' : 'unusable';
+}
+
 async function isUsableWorkingDirectory(
   candidate: string,
   timeoutMs: number = USER_DIR_IO_TIMEOUT_MS,
 ): Promise<boolean> {
-  // deadline 只决定「现在能不能信这个目录」; 探测本体超时后继续执行,
-  // 迟到的 'wx' 创建一旦成功, 由 probeUsability 自己的 finally 清理。
-  const verdict = await withUserDirDeadline(() => probeUsability(candidate), timeoutMs);
-  return verdict === true;
+  // 冷却/超限(skipped)与超时一样按「当前不可用」处理 — 拒绝占用更多线程。
+  return (await probeWithDiscipline(candidate, timeoutMs)) === 'usable';
 }
 
 async function probeUsability(candidate: string): Promise<boolean> {
@@ -350,4 +405,16 @@ function nodeErrorCode(error: unknown): string {
     : 'UNKNOWN';
 }
 
-export const __testing = { isUsableWorkingDirectory };
+export const __testing = {
+  isUsableWorkingDirectory,
+  /** 清空探针调度状态(在途表/冷却表/计数) — 测试隔离用。 */
+  resetProbeScheduler(): void {
+    inflightProbes.clear();
+    probeCooldownUntil.clear();
+    inflightProbeCount = 0;
+  },
+  probeLimits: {
+    maxConcurrent: MAX_CONCURRENT_USER_DIR_PROBES,
+    cooldownMs: PROBE_COOLDOWN_MS,
+  },
+};

--- a/apps/desktop/src/main/im/shared/channelWorkingDirSettings.ts
+++ b/apps/desktop/src/main/im/shared/channelWorkingDirSettings.ts
@@ -53,12 +53,17 @@ export interface ChannelWorkingDirStore {
   read(rootPath?: string): Promise<ChannelWorkingDirSettingsState>;
   /** 校验并写入用户所选目录(一步到位版): 异步 normalize + 异步落盘。 */
   writeWorkingDir(selectedPath: string, rootPath?: string): Promise<ChannelWorkingDirSettingsState>;
-  /** 只校验/规整用户所选目录(异步探测用户盘), 不落盘;返回存储形态路径。 */
+  /**
+   * 严格校验并规整用户**新选择**的目录(不落盘): realpath → stat → 'wx' 写
+   * 探针 → 清理在同一 deadline 内完成, 任一步失败/超时抛带 .code 的错误,
+   * 调用方不得进入 commit。返回存储形态路径。
+   */
   normalizeSelectedDirectory(selectedPath: string): Promise<string>;
   /**
-   * 落盘已规整的目录: 只碰本地 userData 配置文件。供 IPC 在「用户盘探测完成」
-   * 与「提交」之间二次校验 IM account generation 后调用, 缩短代次校验到写入的
-   * 敏感窗口(探测网络盘可能秒级)。
+   * 落盘已通过严格校验的目录: 只原子写 owner-scoped 本地配置(userData),
+   * 直接返回 workingDirAvailable:true — 边界内不访问用户目录。供 IPC 在
+   * 「用户盘校验完成」与「提交」之间二次校验 IM account generation 后调用,
+   * 校验到写入之间只剩本机盘 IO。
    */
   commitWorkingDir(normalizedDir: string, rootPath?: string): Promise<ChannelWorkingDirSettingsState>;
   /** 「恢复默认」= 删配置文件(本地 userData)。 */
@@ -94,6 +99,7 @@ export function createChannelWorkingDirStore(options: {
   const invalidErrorCode = `${options.errorCodePrefix}_WORKING_DIR_INVALID`;
   const notDirectoryErrorCode = `${options.errorCodePrefix}_WORKING_DIR_NOT_DIRECTORY`;
   const probeTimeoutErrorCode = `${options.errorCodePrefix}_WORKING_DIR_PROBE_TIMEOUT`;
+  const notWritableErrorCode = `${options.errorCodePrefix}_WORKING_DIR_NOT_WRITABLE`;
   const userDirTimeoutMs = options.userDirTimeoutMs ?? USER_DIR_IO_TIMEOUT_MS;
   const defaults: ChannelWorkingDirSettings = { version: SETTINGS_VERSION, workingDir: null };
 
@@ -140,20 +146,26 @@ export function createChannelWorkingDirStore(options: {
 
   async function normalizeSelectedDirectory(selectedPath: string): Promise<string> {
     // 校验错误自带 .code(= 渠道错误码): IPC 层日志只记错误码即可区分
-    // WECOM_WORKING_DIR_INVALID / NOT_DIRECTORY / EACCES..., 不需要
-    // error.message —— 原生 fs 错误的 message 含完整用户目录, 不能进日志。
+    // WECOM_WORKING_DIR_INVALID / NOT_DIRECTORY / NOT_WRITABLE / EACCES...,
+    // 不需要 error.message —— 原生 fs 错误的 message 含完整用户目录, 不能进日志。
     if (typeof selectedPath !== 'string' || !path.isAbsolute(selectedPath)) {
       throw Object.assign(new Error(invalidErrorCode), { code: invalidErrorCode });
     }
-    // 用户所选目录可能是网络盘/可移动盘 — realpath/stat 全异步且套 deadline:
-    // 挂起不冻结 Main, 超时则不提交配置, 抛结构化超时错误(快速失败的本地
-    // 校验错误照常穿透)。fs.promises 没有 realpath.native(那只有同步版),
-    // 用标准 fsp.realpath — 同样解析符号链接, Node 22 实测与
-    // realpathSync.native 结果一致。
+    // 新选择目录采用「严格校验」: realpath → stat → 'wx' 写探针 → 清理在
+    // 同一个 deadline 内完成, 任一步失败/超时都不进入 commit, 原配置保持
+    // 不变(与「已保存目录宽大保留」相对 — 后者由 read() 降级为不可用)。
+    // 用户所选目录可能是网络盘/可移动盘 — 全异步且套 deadline: 挂起不冻结
+    // Main, 超时抛结构化超时错误; 快速失败的本地校验错误照常穿透。
+    // fs.promises 没有 realpath.native(那只有同步版), 用标准 fsp.realpath —
+    // 同样解析符号链接, Node 22 实测与 realpathSync.native 结果一致。
     const checked = await withUserDirDeadline(async () => {
       const realPath = await realpath(selectedPath);
       if (!(await stat(realPath)).isDirectory()) {
         throw Object.assign(new Error(notDirectoryErrorCode), { code: notDirectoryErrorCode });
+      }
+      if (!(await probeUsability(realPath))) {
+        // 目录存在但探针写不进(权限/只读/独占碰撞) — 绝不提交。
+        throw Object.assign(new Error(notWritableErrorCode), { code: notWritableErrorCode });
       }
       return realPath;
     }, userDirTimeoutMs);
@@ -171,8 +183,11 @@ export function createChannelWorkingDirStore(options: {
     normalizedDir: string,
     rootPath?: string,
   ): Promise<ChannelWorkingDirSettingsState> {
+    // 只原子写入 owner-scoped 本地配置, 直接返回 available:true — 严格校验
+    // ('wx' 写探针)已在 normalizeSelectedDirectory 完成, commit 边界内不再
+    // 访问用户目录(超时/不可写时配置早已不被触碰)。
     await writeSettings({ ...defaults, workingDir: normalizedDir }, rootPath);
-    return read(rootPath);
+    return { ...defaults, workingDir: normalizedDir, workingDirAvailable: true };
   }
 
   async function resetWorkingDir(rootPath?: string): Promise<ChannelWorkingDirSettingsState> {

--- a/apps/desktop/src/main/im/shared/sessionRepo.ts
+++ b/apps/desktop/src/main/im/shared/sessionRepo.ts
@@ -63,7 +63,8 @@ export interface ImSessionRow {
    *
    * schema 里 workspaceKind 与路径是解耦的 —— 只比对目录等于不等于渠道托管目录
    * 判不出来(接管一条 desktop 的 dialogue 会话时路径根本不是渠道自己那条)。
-   * 只读路径按需带出, 建会话路径不填(那时归属由 ns.workspaceKind 决定)。
+   * 只读路径按需带出;prepareNewSession 也带出渠道声明值(只读展示用),
+   * 建行落列仍由 ns.workspaceKind 决定。
    */
   workspaceKind?: 'project' | 'dialogue' | null;
 }
@@ -326,12 +327,19 @@ export function createImSessionRepo(
 
     async prepareNewSession(botContextId, userId, scopeKey, providerSnapshot) {
       const id = ns.sessionIdFor(botContextId, userId, scopeKey);
-      const workingDir = ns.ensureWorkingDir(botContextId);
+      // 「首次对话 / /new」边界才解析实际目录: 设置页可改托管目录的渠道
+      // (微信/企微)异步读配置 + 探测用户盘, 其余渠道走同步稳定托管目录。
+      const workingDir =
+        (await ns.resolveWorkingDirForNew?.(botContextId)) ?? ns.ensureWorkingDir(botContextId);
       const row = rowFromDefaults(
         id,
         workingDir,
         await resolveImSessionDefaults(config, providerSnapshot, ns.source),
       );
+      // 只读路径(/settings 无会话行时)也要能报对归属分组: 带出渠道声明值,
+      // 否则「无会话行 + 用户已选目录」会被 workspaceDisplayName 误当项目名。
+      // 建行走 createSession 的 ns.workspaceKind 落列, 不读这里的值。
+      if (ns.workspaceKind) row.workspaceKind = ns.workspaceKind;
       // 渠道可按 userId 覆写新会话权限档(telegram guest lane → 只读探索;
       // feishu 群 lane → 渠道设置「群聊新建任务权限档」)。
       const overridden = ns.permissionModeFor?.(userId) ?? null;

--- a/apps/desktop/src/main/im/shared/sessionRepo.ts
+++ b/apps/desktop/src/main/im/shared/sessionRepo.ts
@@ -499,6 +499,14 @@ export async function clearContext(sessionId: string): Promise<void> {
     .where(eq(sessions.id, sessionId));
 }
 
+/** resetSessionToDefaults 的渠道选项 — 由调用方从 adapter 上取,不再按渠道名硬编码。 */
+export interface ResetSessionToDefaultsOptions {
+  /** 渠道 scope 的 IM 默认设置(见 resolveImSessionDefaults)。 */
+  channel?: ImSessionNamespace['source'];
+  /** 渠道声明 `/new` 边界刷新工作目录(ImSessionNamespace.refreshWorkingDirOnNew)。 */
+  refreshWorkingDir?: boolean;
+}
+
 /**
  * `/new` 语义:保留同一个 IM 会话行,但按当前渠道的 IM 默认重新开始一条新对话。
  *
@@ -510,8 +518,9 @@ export async function resetSessionToDefaults(
   sessionId: string,
   config: ImOrchestratorConfig,
   prepared?: ImSessionRow,
-  channel?: ImSessionNamespace['source'],
+  options: ResetSessionToDefaultsOptions = {},
 ): Promise<void> {
+  const { channel, refreshWorkingDir = false } = options;
   const defaults =
     prepared ??
     rowFromDefaults(sessionId, '', await resolveImSessionDefaults(config, undefined, channel));
@@ -525,10 +534,9 @@ export async function resetSessionToDefaults(
       providerId: defaults.providerId,
       permissionMode: defaults.permissionMode,
       fastMode: defaults.fastMode,
-      // Personal WeChat exposes a user-selected channel working directory.
-      // It applies only at the explicit `/new` boundary; existing context is
-      // never moved silently.
-      ...(channel === 'wechat' && defaults.workingDir ? { workingDir: defaults.workingDir } : {}),
+      // 渠道把托管目录暴露给设置页(个人微信/企业微信,ns.refreshWorkingDirOnNew)
+      // 时,新目录只在 `/new` 这个显式边界生效;已有上下文永不静默移动。
+      ...(refreshWorkingDir && defaults.workingDir ? { workingDir: defaults.workingDir } : {}),
       sdkSessionId: null,
       clearedAt: Date.now(),
       updatedAt: Date.now(),

--- a/apps/desktop/src/main/im/shared/slashCommands.ts
+++ b/apps/desktop/src/main/im/shared/slashCommands.ts
@@ -270,7 +270,10 @@ export function createSlashHandlers(
         const row =
           existing ?? (await repo.createSession(ctx.botContextId, ctx.userId, undefined, prepared));
         if (existing) {
-          await resetSessionToDefaults(row.id, adapter.config, prepared, adapter.channel);
+          await resetSessionToDefaults(row.id, adapter.config, prepared, {
+            channel: adapter.channel,
+            refreshWorkingDir: adapter.sessions.refreshWorkingDirOnNew === true,
+          });
         }
         await turnRunner.disposeOneSession(row.id);
         await safeSendText(ctx, ui.slash.new);

--- a/apps/desktop/src/main/im/shared/types.ts
+++ b/apps/desktop/src/main/im/shared/types.ts
@@ -79,6 +79,14 @@ export interface ImSessionNamespace {
   /** 该渠道 session 的工作目录(必须已创建好)。 */
   ensureWorkingDir(botContextId: string): string;
   /**
+   * 新建会话行实际使用的工作目录(异步)。设置页可改渠道托管目录的渠道
+   * (个人微信/企业微信)声明: 读 owner-scoped 配置并异步探测用户所选目录
+   * (可能在网络盘上, 挂起不冻结 Main), 不可用回退托管目录。
+   * 只在「首次对话 / `/new`」边界(sessionRepo.prepareNewSession)调用;其余
+   * 同步路径一律用 ensureWorkingDir 的稳定托管目录, 不读配置不探测。
+   */
+  resolveWorkingDirForNew?(botContextId: string): Promise<string>;
+  /**
    * `/new` 边界是否把会话行刷到渠道当前解析的工作目录。设置页可改渠道
    * 托管目录的渠道(个人微信/企业微信)声明 true:新目录只在 `/new` 这个
    * 显式边界生效,已有上下文永不静默移动。缺省 false(目录恒定的渠道)。

--- a/apps/desktop/src/main/im/shared/types.ts
+++ b/apps/desktop/src/main/im/shared/types.ts
@@ -78,6 +78,12 @@ export interface ImSessionNamespace {
   workspaceKind?: 'project' | 'dialogue';
   /** 该渠道 session 的工作目录(必须已创建好)。 */
   ensureWorkingDir(botContextId: string): string;
+  /**
+   * `/new` 边界是否把会话行刷到渠道当前解析的工作目录。设置页可改渠道
+   * 托管目录的渠道(个人微信/企业微信)声明 true:新目录只在 `/new` 这个
+   * 显式边界生效,已有上下文永不静默移动。缺省 false(目录恒定的渠道)。
+   */
+  refreshWorkingDirOnNew?: boolean;
   /** 渠道专属列(feishu: feishuBotAppId/feishuOpenId;slack: imBotContextId/imUserId)。 */
   extraInsertColumns(botContextId: string, userId: string): Record<string, unknown>;
   /**

--- a/apps/desktop/src/main/im/wechat/WechatIM.ts
+++ b/apps/desktop/src/main/im/wechat/WechatIM.ts
@@ -26,7 +26,7 @@ import {
 import type { InteractionDecision, InteractionRequest } from '@cindy/maker-core';
 
 import { autoReviewUnavailablePromptLine } from '../shared/autoReviewUnavailablePrompt';
-import type { ImSessionRepo } from '../shared/sessionRepo';
+import type { ImSessionRepo, ImSessionRow } from '../shared/sessionRepo';
 import type { ImOrchestratorConfig } from '../shared/types';
 import type { ImFinalOutput } from '@cindy/im';
 import type { ImTurnRunner } from '../shared/turnRunner';
@@ -1525,10 +1525,7 @@ export class WechatIM extends BaseIM implements RichChannelIM {
     const runtime = this.#turnRuntime;
     if (!runtime) throw new Error('WECHAT_TURN_RUNTIME_NOT_ATTACHED');
     const botId = this.#epoch?.credentials.ilinkBotId ?? 'wechat';
-    const prepared = await runtime.repo.prepareNewSession(botId, message.senderId);
-    const existing = await runtime.repo.findActiveSession(botId, message.senderId);
-    const session =
-      existing ?? (await runtime.repo.createSession(botId, message.senderId, undefined, prepared));
+    const session = await resolveWechatMessageSession(runtime.repo, botId, message.senderId);
     const epoch = await this.#requireStore().getConversationEpoch(bindingEpoch, message.senderId);
     const taskId = randomUUID();
     const staged = await stageWechatTaskMedia({
@@ -1674,6 +1671,21 @@ export const WECHAT_AUTH_BASE_URL = AUTH_BASE_URL;
 export function sessionIdFor(botId: string, peerId: string): string {
   const digest = createHash('sha256').update(`${botId}\0${peerId}`).digest('hex').slice(0, 32);
   return `wechat_${digest}`;
+}
+
+/**
+ * 入站消息的会话解析:先查已有行, 无行才建(createSession 内部只 prepare 一次)。
+ * 刻意**不**提前 prepareNewSession —— 它会解析渠道工作目录(读配置 + 异步探测
+ * 用户所选目录, 网络盘下可达秒级), 已有会话的目录就在行里, 不该为每条消息
+ * 付一次探测延迟。新目录只在首条消息(建行)与 `/new` 边界生效。
+ */
+export async function resolveWechatMessageSession(
+  repo: ImSessionRepo,
+  botId: string,
+  senderId: string,
+): Promise<ImSessionRow> {
+  const existing = await repo.findActiveSession(botId, senderId);
+  return existing ?? (await repo.createSession(botId, senderId));
 }
 
 function parseTaskPayload(raw: string): WechatTaskPayload {

--- a/apps/desktop/src/main/im/wechat/__tests__/WechatIM.test.ts
+++ b/apps/desktop/src/main/im/wechat/__tests__/WechatIM.test.ts
@@ -8,7 +8,14 @@ import {
 } from '@cindy/wechat-ilink';
 
 import type { DbClient } from '../../../localDb/client/DbClient';
-import { __testing, sessionIdFor, WechatIM, type WechatIMDeps } from '../WechatIM';
+import type { ImSessionRepo, ImSessionRow } from '../../shared/sessionRepo';
+import {
+  __testing,
+  resolveWechatMessageSession,
+  sessionIdFor,
+  WechatIM,
+  type WechatIMDeps,
+} from '../WechatIM';
 
 const mediaMocks = vi.hoisted(() => ({
   removeReleasedWechatFiles: vi.fn(async () => undefined),
@@ -20,6 +27,47 @@ vi.mock('../mediaStaging', async (importOriginal) => {
     ...actual,
     removeReleasedWechatFiles: mediaMocks.removeReleasedWechatFiles,
   };
+});
+
+describe('resolveWechatMessageSession(入站消息会话解析)', () => {
+  const row = { id: 'wechat_row1', workingDir: '/tmp/im-working-dir/wechat-bot' } as ImSessionRow;
+
+  function repoWith(existing: ImSessionRow | null) {
+    return {
+      findActiveSession: vi.fn(async () => existing),
+      createSession: vi.fn(async () => ({ ...row, id: 'wechat_new' })),
+      prepareNewSession: vi.fn(async () => ({ ...row, id: 'prepared' })),
+    } as unknown as ImSessionRepo & {
+      findActiveSession: ReturnType<typeof vi.fn>;
+      createSession: ReturnType<typeof vi.fn>;
+      prepareNewSession: ReturnType<typeof vi.fn>;
+    };
+  }
+
+  it('已有会话直接用行里的目录:不 prepareNewSession(不触发工作目录探测), 不建行', async () => {
+    const repo = repoWith(row);
+
+    await expect(resolveWechatMessageSession(repo, 'bot', 'peer')).resolves.toMatchObject({
+      id: 'wechat_row1',
+    });
+
+    expect(repo.findActiveSession).toHaveBeenCalledWith('bot', 'peer');
+    expect(repo.prepareNewSession).not.toHaveBeenCalled();
+    expect(repo.createSession).not.toHaveBeenCalled();
+  });
+
+  it('无会话行时走 createSession(prepared 缺省, 由 repo 内部只 prepare 一次)', async () => {
+    const repo = repoWith(null);
+
+    await expect(resolveWechatMessageSession(repo, 'bot', 'peer')).resolves.toMatchObject({
+      id: 'wechat_new',
+    });
+
+    expect(repo.createSession).toHaveBeenCalledTimes(1);
+    expect(repo.createSession).toHaveBeenCalledWith('bot', 'peer');
+    // 解析函数自身不得额外 prepare —— 一次建行只允许一次工作目录解析。
+    expect(repo.prepareNewSession).not.toHaveBeenCalled();
+  });
 });
 
 describe('WechatIM host boundary', () => {

--- a/apps/desktop/src/main/im/wechat/__tests__/channelSettings.test.ts
+++ b/apps/desktop/src/main/im/wechat/__tests__/channelSettings.test.ts
@@ -5,9 +5,10 @@ import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import {
+  ensureWechatManagedWorkingDir,
   readWechatChannelSettings,
   resetWechatWorkingDir,
-  resolveWechatWorkingDir,
+  resolveWechatWorkingDirForNewConversation,
   writeWechatWorkingDir,
 } from '../channelSettings';
 
@@ -22,28 +23,28 @@ afterEach(() => {
 });
 
 describe('personal WeChat channel settings', () => {
-  it('persists only a directory selected from an absolute existing path', () => {
+  it('persists only a directory selected from an absolute existing path', async () => {
     const selected = path.join(root, 'project');
     const replacement = path.join(root, 'replacement');
     fs.mkdirSync(selected);
     fs.mkdirSync(replacement);
 
-    writeWechatWorkingDir(selected, root);
-    const state = writeWechatWorkingDir(replacement, root);
+    await writeWechatWorkingDir(selected, root);
+    const state = await writeWechatWorkingDir(replacement, root);
 
     expect(state.workingDir).toBe(fs.realpathSync.native(replacement).replace(/\\/g, '/'));
     expect(state.workingDirAvailable).toBe(true);
-    expect(readWechatChannelSettings(root)).toEqual(state);
+    expect(await readWechatChannelSettings(root)).toEqual(state);
   });
 
-  it('falls back to a managed directory when the selected directory disappears', () => {
+  it('falls back to a managed directory when the selected directory disappears', async () => {
     const selected = path.join(root, 'project');
     fs.mkdirSync(selected);
-    writeWechatWorkingDir(selected, root);
+    await writeWechatWorkingDir(selected, root);
     fs.rmSync(selected, { recursive: true });
 
-    expect(readWechatChannelSettings(root).workingDirAvailable).toBe(false);
-    const resolved = resolveWechatWorkingDir('bot-1', root);
+    expect((await readWechatChannelSettings(root)).workingDirAvailable).toBe(false);
+    const resolved = await resolveWechatWorkingDirForNewConversation('bot-1', root);
     expect(resolved).toBe(path.join(root, 'im-working-dir', 'wechat-bot-1'));
     expect(fs.statSync(resolved).isDirectory()).toBe(true);
   });
@@ -53,39 +54,43 @@ describe('personal WeChat channel settings', () => {
     const unsafeIds = ['../../escape', 'nested/bot', 'nested\\bot', 'bot:name'];
 
     for (const botId of unsafeIds) {
-      const first = resolveWechatWorkingDir(botId, root);
-      const second = resolveWechatWorkingDir(botId, root);
+      const first = ensureWechatManagedWorkingDir(botId, root);
+      const second = ensureWechatManagedWorkingDir(botId, root);
       expect(first).toBe(second);
       expect(path.dirname(first)).toBe(managedRoot);
       expect(path.basename(first)).toMatch(/^wechat-external-[a-f0-9]{24}$/);
       expect(fs.statSync(first).isDirectory()).toBe(true);
     }
 
-    expect(resolveWechatWorkingDir('bot-1', root)).toBe(
+    expect(ensureWechatManagedWorkingDir('bot-1', root)).toBe(
       path.join(managedRoot, 'wechat-bot-1'),
     );
     expect(fs.existsSync(path.join(root, 'escape'))).toBe(false);
   });
 
-  it('reset removes the override and restores the managed directory', () => {
+  it('reset removes the override and restores the managed directory', async () => {
     const selected = path.join(root, 'project');
     fs.mkdirSync(selected);
-    writeWechatWorkingDir(selected, root);
+    await writeWechatWorkingDir(selected, root);
 
-    expect(resetWechatWorkingDir(root)).toEqual({
+    expect(await resetWechatWorkingDir(root)).toEqual({
       version: 1,
       workingDir: null,
       workingDirAvailable: true,
     });
-    expect(resolveWechatWorkingDir('bot-2', root)).toBe(
+    expect(await resolveWechatWorkingDirForNewConversation('bot-2', root)).toBe(
       path.join(root, 'im-working-dir', 'wechat-bot-2'),
     );
   });
 
-  it('rejects relative paths and files', () => {
-    expect(() => writeWechatWorkingDir('relative', root)).toThrow('WECHAT_WORKING_DIR_INVALID');
+  it('rejects relative paths and files', async () => {
+    await expect(writeWechatWorkingDir('relative', root)).rejects.toThrow(
+      'WECHAT_WORKING_DIR_INVALID',
+    );
     const file = path.join(root, 'file.txt');
     fs.writeFileSync(file, 'x');
-    expect(() => writeWechatWorkingDir(file, root)).toThrow('WECHAT_WORKING_DIR_NOT_DIRECTORY');
+    await expect(writeWechatWorkingDir(file, root)).rejects.toThrow(
+      'WECHAT_WORKING_DIR_NOT_DIRECTORY',
+    );
   });
 });

--- a/apps/desktop/src/main/im/wechat/__tests__/workingDirIpc.test.ts
+++ b/apps/desktop/src/main/im/wechat/__tests__/workingDirIpc.test.ts
@@ -1,9 +1,9 @@
 /**
- * workingDirIpc.test.ts(企微注册层)
+ * workingDirIpc.test.ts(个人微信注册层)
  * ---------------------------------------------------------------------------
  * 业务体矩阵在 shared/__tests__/channelWorkingDirIpc.test.ts(双渠道同一套)。
- * 这里只锁企微自己的注册面:固定三个 channel、可信 sender 校验**先于一切
- * 业务依赖**、可信事件放行到业务体。channel 名刻意不做参数化。
+ * 这里只锁个人微信自己的注册面:固定三个 channel、可信 sender 校验**先于
+ * 一切业务依赖**、可信事件放行到业务体。channel 名刻意不做参数化。
  */
 
 import { describe, expect, it, vi } from 'vitest';
@@ -12,7 +12,7 @@ import {
   createChannelWorkingDirIpcHandlers,
   type ChannelWorkingDirIpcDeps,
 } from '../../shared/channelWorkingDirIpc';
-import { registerWecomWorkingDirIpc, type IpcHandleSink } from '../workingDirIpc';
+import { registerWechatWorkingDirIpc, type IpcHandleSink } from '../workingDirIpc';
 
 const STATE = { version: 1, workingDir: null, workingDirAvailable: true } as const;
 const PICKED_STATE = { version: 1, workingDir: 'D:/picked', workingDirAvailable: true } as const;
@@ -29,7 +29,7 @@ function makeDeps(): ChannelWorkingDirIpcDeps {
   };
 }
 
-describe('wecomBot working directory IPC 安全边界', () => {
+describe('wechatBot working directory IPC 安全边界', () => {
   type Listener = (event: unknown) => unknown;
   const UNTRUSTED_EVENT = { sender: { id: 1 }, senderFrame: { url: 'https://evil.example' } };
 
@@ -41,11 +41,11 @@ describe('wecomBot working directory IPC 安全边界', () => {
         listeners.set(channel, listener as Listener);
       },
     };
-    registerWecomWorkingDirIpc({
+    registerWechatWorkingDirIpc({
       ipc: sink,
       handlers: createChannelWorkingDirIpcHandlers({
-        updateFailedCode: 'WECOM_WORKING_DIR_UPDATE_FAILED',
-        channelLabel: 'WeCom',
+        updateFailedCode: 'WECHAT_WORKING_DIR_UPDATE_FAILED',
+        channelLabel: 'personal WeChat',
         deps,
       }),
       assertTrustedEvent: (event) => {
@@ -58,9 +58,9 @@ describe('wecomBot working directory IPC 安全边界', () => {
   it('registers exactly the three working-directory channels', () => {
     const { listeners } = registerWith(true);
     expect([...listeners.keys()].sort()).toEqual([
-      'wecomBot:choose-working-directory',
-      'wecomBot:get-channel-settings',
-      'wecomBot:reset-working-directory',
+      'wechatBot:choose-working-directory',
+      'wechatBot:get-channel-settings',
+      'wechatBot:reset-working-directory',
     ]);
   });
 
@@ -68,15 +68,13 @@ describe('wecomBot working directory IPC 安全边界', () => {
     const { deps, listeners } = registerWith(false);
 
     // 安全边界必须先于业务体: 任何一个业务 dep 都不允许被触碰。
-    // (listener 同步抛出 — Electron handle 会把它变成 renderer 侧的 rejected
-    // invocation, 这里按同步抛出断言。)
-    expect(() => listeners.get('wecomBot:get-channel-settings')!(UNTRUSTED_EVENT)).toThrow(
+    expect(() => listeners.get('wechatBot:get-channel-settings')!(UNTRUSTED_EVENT)).toThrow(
       'UNTRUSTED_RENDERER',
     );
-    expect(() => listeners.get('wecomBot:reset-working-directory')!(UNTRUSTED_EVENT)).toThrow(
+    expect(() => listeners.get('wechatBot:reset-working-directory')!(UNTRUSTED_EVENT)).toThrow(
       'UNTRUSTED_RENDERER',
     );
-    expect(() => listeners.get('wecomBot:choose-working-directory')!(UNTRUSTED_EVENT)).toThrow(
+    expect(() => listeners.get('wechatBot:choose-working-directory')!(UNTRUSTED_EVENT)).toThrow(
       'UNTRUSTED_RENDERER',
     );
 
@@ -90,14 +88,14 @@ describe('wecomBot working directory IPC 安全边界', () => {
   it('passes trusted senders through to the business body', async () => {
     const { deps, listeners } = registerWith(true);
 
-    await expect(listeners.get('wecomBot:get-channel-settings')!({ sender: 'wc' })).resolves.toBe(
+    await expect(listeners.get('wechatBot:get-channel-settings')!({ sender: 'wc' })).resolves.toBe(
       PICKED_STATE,
     );
     await expect(
-      listeners.get('wecomBot:reset-working-directory')!({ sender: 'wc' }),
+      listeners.get('wechatBot:reset-working-directory')!({ sender: 'wc' }),
     ).resolves.toBe(STATE);
     await expect(
-      listeners.get('wecomBot:choose-working-directory')!({ sender: 'wc' }),
+      listeners.get('wechatBot:choose-working-directory')!({ sender: 'wc' }),
     ).resolves.toMatchObject({ canceled: false });
 
     expect(deps.readSettings).toHaveBeenCalled();

--- a/apps/desktop/src/main/im/wechat/adapter.ts
+++ b/apps/desktop/src/main/im/wechat/adapter.ts
@@ -1,11 +1,10 @@
 import type { ImChannelAdapter, ImOrchestratorConfig } from '../shared/types';
-import { resolveWechatWorkingDir } from './channelSettings';
+import {
+  ensureWechatManagedWorkingDir,
+  resolveWechatWorkingDirForNewConversation,
+} from './channelSettings';
 import { ui } from './uiText';
 import { sessionIdFor, type WechatIM } from './WechatIM';
-
-function ensureWorkingDir(botId: string): string {
-  return resolveWechatWorkingDir(botId);
-}
 
 export function buildWechatAdapter(
   wechatIm: WechatIM,
@@ -27,7 +26,10 @@ export function buildWechatAdapter(
       defaultTitle: (peerId) => `微信 · ${peerId.slice(-6)}`,
       generatedTitlePrefix: '微信 · ',
       workspaceKind: 'dialogue',
-      ensureWorkingDir,
+      // 同步兜底只回稳定托管目录; 实际目录(读配置+探测用户盘)在首次对话 /
+      // /new 边界经 resolveWorkingDirForNew 异步解析。
+      ensureWorkingDir: ensureWechatManagedWorkingDir,
+      resolveWorkingDirForNew: resolveWechatWorkingDirForNewConversation,
       // 设置页可改渠道托管目录: /new 边界刷新到最新解析结果。
       refreshWorkingDirOnNew: true,
       extraInsertColumns: (botId, peerId) => ({

--- a/apps/desktop/src/main/im/wechat/adapter.ts
+++ b/apps/desktop/src/main/im/wechat/adapter.ts
@@ -28,6 +28,8 @@ export function buildWechatAdapter(
       generatedTitlePrefix: '微信 · ',
       workspaceKind: 'dialogue',
       ensureWorkingDir,
+      // 设置页可改渠道托管目录: /new 边界刷新到最新解析结果。
+      refreshWorkingDirOnNew: true,
       extraInsertColumns: (botId, peerId) => ({
         imBotContextId: botId,
         imUserId: peerId,

--- a/apps/desktop/src/main/im/wechat/channelSettings.ts
+++ b/apps/desktop/src/main/im/wechat/channelSettings.ts
@@ -13,6 +13,7 @@ import { createHash } from 'node:crypto';
 
 import {
   createChannelWorkingDirStore,
+  type ChannelUserDirProbeExecutor,
   type ChannelWorkingDirSettings,
   type ChannelWorkingDirSettingsState,
 } from '../shared/channelWorkingDirSettings';
@@ -35,6 +36,11 @@ const store = createChannelWorkingDirStore({
 
 export function readWechatChannelSettings(rootPath?: string): Promise<WechatChannelSettingsState> {
   return store.read(rootPath);
+}
+
+/** 生产装配(im/index.ts): 用户目录探测切到 utility-process 执行边界。 */
+export function configureWechatChannelProbeExecutor(executor: ChannelUserDirProbeExecutor): void {
+  store.setProbeExecutor(executor);
 }
 
 export function writeWechatWorkingDir(

--- a/apps/desktop/src/main/im/wechat/channelSettings.ts
+++ b/apps/desktop/src/main/im/wechat/channelSettings.ts
@@ -6,6 +6,7 @@
  * to the channel-managed directory instead of breaking inbound messages.
  * 校验与原子保存的实现在 shared/channelWorkingDirSettings 工厂里,这里只注入
  * 微信的文件名、错误码前缀与托管目录命名(存量目录依赖命名保持稳定)。
+ * 用户目录上的 IO 全异步(shared/channelWorkingDirSettings 的 Main 线程纪律)。
  */
 
 import { createHash } from 'node:crypto';
@@ -32,21 +33,30 @@ const store = createChannelWorkingDirStore({
   managedDirNameFor: managedWorkingDirName,
 });
 
-export function readWechatChannelSettings(rootPath?: string): WechatChannelSettingsState {
+export function readWechatChannelSettings(rootPath?: string): Promise<WechatChannelSettingsState> {
   return store.read(rootPath);
 }
 
 export function writeWechatWorkingDir(
   selectedPath: string,
   rootPath?: string,
-): WechatChannelSettingsState {
+): Promise<WechatChannelSettingsState> {
   return store.writeWorkingDir(selectedPath, rootPath);
 }
 
-export function resetWechatWorkingDir(rootPath?: string): WechatChannelSettingsState {
+export function resetWechatWorkingDir(rootPath?: string): Promise<WechatChannelSettingsState> {
   return store.resetWorkingDir(rootPath);
 }
 
-export function resolveWechatWorkingDir(botId: string, rootPath?: string): string {
-  return store.resolveWorkingDir(botId, rootPath);
+/** 稳定托管目录(同步, 本机盘)— 会话行兜底与归属比较用, 不读配置不探测。 */
+export function ensureWechatManagedWorkingDir(botId: string, rootPath?: string): string {
+  return store.ensureManagedWorkingDir(botId, rootPath);
+}
+
+/** 新对话实际目录(异步): 读配置 + 探测用户所选目录, 不可用回退托管目录。 */
+export function resolveWechatWorkingDirForNewConversation(
+  botId: string,
+  rootPath?: string,
+): Promise<string> {
+  return store.resolveWorkingDirForNewConversation(botId, rootPath);
 }

--- a/apps/desktop/src/main/im/wechat/channelSettings.ts
+++ b/apps/desktop/src/main/im/wechat/channelSettings.ts
@@ -4,92 +4,20 @@
  * A working directory can only enter this store after the user selected it in
  * a native directory picker. Missing/inaccessible saved directories fall back
  * to the channel-managed directory instead of breaking inbound messages.
+ * 校验与原子保存的实现在 shared/channelWorkingDirSettings 工厂里,这里只注入
+ * 微信的文件名、错误码前缀与托管目录命名(存量目录依赖命名保持稳定)。
  */
 
-import fs from 'node:fs';
-import path from 'node:path';
-import { createHash, randomUUID } from 'node:crypto';
+import { createHash } from 'node:crypto';
 
-import { normalizeWorkingDirForStorage } from '../../../shared/workingDir';
-import { createLogger, maskPath } from '../../logger';
-import { ownerScopedImUserDataPath } from '../ownerScopedStorage';
+import {
+  createChannelWorkingDirStore,
+  type ChannelWorkingDirSettings,
+  type ChannelWorkingDirSettingsState,
+} from '../shared/channelWorkingDirSettings';
 
-const log = createLogger('im/wechat/channel-settings');
-const SETTINGS_VERSION = 1;
-
-export interface WechatChannelSettings {
-  version: typeof SETTINGS_VERSION;
-  workingDir: string | null;
-}
-
-export interface WechatChannelSettingsState extends WechatChannelSettings {
-  workingDirAvailable: boolean;
-}
-
-const DEFAULTS: WechatChannelSettings = {
-  version: SETTINGS_VERSION,
-  workingDir: null,
-};
-
-function settingsFilePath(rootPath?: string): string {
-  return rootPath
-    ? path.join(rootPath, 'wechat-channel.json')
-    : ownerScopedImUserDataPath('wechat-channel.json');
-}
-
-export function readWechatChannelSettings(rootPath?: string): WechatChannelSettingsState {
-  const file = settingsFilePath(rootPath);
-  try {
-    if (!fs.existsSync(file)) return { ...DEFAULTS, workingDirAvailable: true };
-    const normalized = normalizeSettings(JSON.parse(fs.readFileSync(file, 'utf8')));
-    return {
-      ...normalized,
-      workingDirAvailable:
-        normalized.workingDir === null || isAccessibleDirectory(normalized.workingDir),
-    };
-  } catch (error) {
-    log.warn('failed to read WeChat channel settings; using defaults', {
-      path: maskPath(file),
-      errorCode: nodeErrorCode(error),
-    });
-    return { ...DEFAULTS, workingDirAvailable: true };
-  }
-}
-
-export function writeWechatWorkingDir(
-  selectedPath: string,
-  rootPath?: string,
-): WechatChannelSettingsState {
-  const workingDir = normalizeSelectedDirectory(selectedPath);
-  writeSettings({ ...DEFAULTS, workingDir }, rootPath);
-  return readWechatChannelSettings(rootPath);
-}
-
-export function resetWechatWorkingDir(rootPath?: string): WechatChannelSettingsState {
-  const file = settingsFilePath(rootPath);
-  try {
-    fs.rmSync(file, { force: true });
-  } catch (error) {
-    log.warn('failed to reset WeChat channel settings', {
-      path: maskPath(file),
-      errorCode: nodeErrorCode(error),
-    });
-    throw error;
-  }
-  return { ...DEFAULTS, workingDirAvailable: true };
-}
-
-export function resolveWechatWorkingDir(botId: string, rootPath?: string): string {
-  const configured = readWechatChannelSettings(rootPath);
-  if (configured.workingDir && configured.workingDirAvailable) return configured.workingDir;
-
-  const managedDirName = managedWorkingDirName(botId);
-  const dir = rootPath
-    ? path.join(rootPath, 'im-working-dir', managedDirName)
-    : ownerScopedImUserDataPath('im-working-dir', managedDirName);
-  fs.mkdirSync(dir, { recursive: true });
-  return dir;
-}
+export type WechatChannelSettings = ChannelWorkingDirSettings;
+export type WechatChannelSettingsState = ChannelWorkingDirSettingsState;
 
 function managedWorkingDirName(botId: string): string {
   if (/^[A-Za-z0-9_-]{1,128}$/.test(botId)) return `wechat-${botId}`;
@@ -97,64 +25,28 @@ function managedWorkingDirName(botId: string): string {
   return `wechat-external-${digest}`;
 }
 
-function normalizeSelectedDirectory(selectedPath: string): string {
-  if (typeof selectedPath !== 'string' || !path.isAbsolute(selectedPath)) {
-    throw new Error('WECHAT_WORKING_DIR_INVALID');
-  }
-  const realPath = fs.realpathSync.native(selectedPath);
-  if (!fs.statSync(realPath).isDirectory()) throw new Error('WECHAT_WORKING_DIR_NOT_DIRECTORY');
-  const normalized = normalizeWorkingDirForStorage(realPath);
-  if (!normalized) throw new Error('WECHAT_WORKING_DIR_INVALID');
-  return normalized;
+const store = createChannelWorkingDirStore({
+  logTag: 'im/wechat/channel-settings',
+  fileName: 'wechat-channel.json',
+  errorCodePrefix: 'WECHAT',
+  managedDirNameFor: managedWorkingDirName,
+});
+
+export function readWechatChannelSettings(rootPath?: string): WechatChannelSettingsState {
+  return store.read(rootPath);
 }
 
-function normalizeSettings(raw: unknown): WechatChannelSettings {
-  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return { ...DEFAULTS };
-  const input = raw as Record<string, unknown>;
-  const workingDir =
-    typeof input.workingDir === 'string' && path.isAbsolute(input.workingDir)
-      ? normalizeWorkingDirForStorage(input.workingDir)
-      : null;
-  return {
-    version: SETTINGS_VERSION,
-    workingDir,
-  };
+export function writeWechatWorkingDir(
+  selectedPath: string,
+  rootPath?: string,
+): WechatChannelSettingsState {
+  return store.writeWorkingDir(selectedPath, rootPath);
 }
 
-function isAccessibleDirectory(candidate: string): boolean {
-  try {
-    return fs.statSync(candidate).isDirectory();
-  } catch {
-    return false;
-  }
+export function resetWechatWorkingDir(rootPath?: string): WechatChannelSettingsState {
+  return store.resetWorkingDir(rootPath);
 }
 
-function nodeErrorCode(error: unknown): string {
-  return typeof error === 'object' &&
-    error !== null &&
-    'code' in error &&
-    typeof (error as { code?: unknown }).code === 'string'
-    ? (error as { code: string }).code
-    : 'UNKNOWN';
+export function resolveWechatWorkingDir(botId: string, rootPath?: string): string {
+  return store.resolveWorkingDir(botId, rootPath);
 }
-
-function writeSettings(settings: WechatChannelSettings, rootPath?: string): void {
-  const file = settingsFilePath(rootPath);
-  const tmp = `${file}.${randomUUID()}.tmp`;
-  fs.mkdirSync(path.dirname(file), { recursive: true });
-  try {
-    fs.writeFileSync(tmp, `${JSON.stringify(settings, null, 2)}\n`, {
-      encoding: 'utf8',
-      flag: 'wx',
-    });
-    fs.renameSync(tmp, file);
-  } finally {
-    fs.rmSync(tmp, { force: true });
-  }
-}
-
-export const __testing = {
-  managedWorkingDirName,
-  normalizeSettings,
-  normalizeSelectedDirectory,
-};

--- a/apps/desktop/src/main/im/wechat/channelSettings.ts
+++ b/apps/desktop/src/main/im/wechat/channelSettings.ts
@@ -44,6 +44,19 @@ export function writeWechatWorkingDir(
   return store.writeWorkingDir(selectedPath, rootPath);
 }
 
+/** 只校验/规整用户所选目录(异步探测用户盘), 不落盘 — 供 IPC 两段式提交。 */
+export function normalizeWechatSelectedDirectory(selectedPath: string): Promise<string> {
+  return store.normalizeSelectedDirectory(selectedPath);
+}
+
+/** 落盘已规整目录(只碰本地 userData)— 在 IM account generation 二次校验之后调用。 */
+export function commitWechatWorkingDir(
+  normalizedDir: string,
+  rootPath?: string,
+): Promise<WechatChannelSettingsState> {
+  return store.commitWorkingDir(normalizedDir, rootPath);
+}
+
 export function resetWechatWorkingDir(rootPath?: string): Promise<WechatChannelSettingsState> {
   return store.resetWorkingDir(rootPath);
 }

--- a/apps/desktop/src/main/im/wechat/index.ts
+++ b/apps/desktop/src/main/im/wechat/index.ts
@@ -5,13 +5,18 @@ import { buildWechatAdapter } from './adapter';
 import type { WechatIM } from './WechatIM';
 
 export function wireWechatOrchestrator(wechatIm: WechatIM, config: ImOrchestratorConfig): void {
-  const orchestrator = createImOrchestrator(buildWechatAdapter(wechatIm, config));
+  const adapter = buildWechatAdapter(wechatIm, config);
+  const orchestrator = createImOrchestrator(adapter);
   wechatIm.attachTurnRuntime({
     runner: orchestrator.turnRunner,
     repo: orchestrator.repo,
     config,
+    // WechatIM 自带 /new 流程,与 shared slashCommands 走同一份渠道能力声明。
     resetSessionToDefaults: (sessionId, nextConfig, prepared) =>
-      resetSessionToDefaults(sessionId, nextConfig, prepared, 'wechat'),
+      resetSessionToDefaults(sessionId, nextConfig, prepared, {
+        channel: 'wechat',
+        refreshWorkingDir: adapter.sessions.refreshWorkingDirOnNew === true,
+      }),
   });
 }
 

--- a/apps/desktop/src/main/im/wechat/workingDirIpc.ts
+++ b/apps/desktop/src/main/im/wechat/workingDirIpc.ts
@@ -1,0 +1,38 @@
+/**
+ * wechatBot 工作目录 IPC 的**固定 channel 注册层** — 业务体在
+ * shared/channelWorkingDirIpc 工厂(与企微同构: generation 三处校验、两段式
+ * 提交、日志脱敏), 这里只保留个人微信自己的 channel 名与可信 sender 边界。
+ * channel 刻意不做成可配置: 每个渠道一份注册, 不产生通用注册器。
+ */
+
+import type { ChannelWorkingDirIpcHandlers } from '../shared/channelWorkingDirIpc';
+
+/** ipcMain.handle 的最小投影 — 测试注入 fake, 不拉起 Electron。 */
+export interface IpcHandleSink {
+  handle(channel: string, listener: (event: unknown, ...args: unknown[]) => unknown): unknown;
+}
+
+/**
+ * 注册三个 wechatBot 工作目录 channel。**可信 sender 校验先于一切业务体**
+ * (读设置 / 开弹窗 / 重置) — 与企微同一条安全边界, 不许静默回退。
+ */
+export function registerWechatWorkingDirIpc(options: {
+  ipc: IpcHandleSink;
+  handlers: ChannelWorkingDirIpcHandlers;
+  /** main/im/index.ts 注入 assertTrustedAppRendererEvent。 */
+  assertTrustedEvent(event: unknown): void;
+}): void {
+  const { ipc, handlers, assertTrustedEvent } = options;
+  ipc.handle('wechatBot:get-channel-settings', (event) => {
+    assertTrustedEvent(event);
+    return handlers.getChannelSettings();
+  });
+  ipc.handle('wechatBot:choose-working-directory', (event) => {
+    assertTrustedEvent(event);
+    return handlers.chooseWorkingDirectory((event as { sender: unknown }).sender);
+  });
+  ipc.handle('wechatBot:reset-working-directory', (event) => {
+    assertTrustedEvent(event);
+    return handlers.resetWorkingDir();
+  });
+}

--- a/apps/desktop/src/main/im/wecom/__tests__/channelSettings.test.ts
+++ b/apps/desktop/src/main/im/wecom/__tests__/channelSettings.test.ts
@@ -1,0 +1,227 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  readWecomChannelSettings,
+  resetWecomWorkingDir,
+  resolveWecomWorkingDir,
+  writeWecomWorkingDir,
+} from '../channelSettings';
+
+/** owner 隔离用例的可变 owner 桩 — 经 vi.mock 注入 ownerScopedImUserDataPath。 */
+const ownerState = vi.hoisted(() => ({ key: 'owner-a' }));
+let ownersRoot = '';
+
+vi.mock('../../ownerScopedStorage', () => ({
+  ownerScopedImUserDataPath: (...parts: string[]) =>
+    path.join(ownersRoot, ownerState.key, ...parts),
+}));
+
+let root = '';
+
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'cindy-wecom-channel-settings-'));
+  ownersRoot = path.join(root, 'owners');
+  ownerState.key = 'owner-a';
+});
+
+afterEach(() => {
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+/** 存储契约: normalizeWorkingDirForStorage 统一成正斜杠(逻辑路径, 非宿主表示)。 */
+function storageForm(dir: string): string {
+  return fs.realpathSync.native(dir).replace(/\\/g, '/');
+}
+
+describe('WeCom channel settings', () => {
+  it('persists only a directory selected from an absolute existing path', () => {
+    const selected = path.join(root, 'project');
+    const replacement = path.join(root, 'replacement');
+    fs.mkdirSync(selected);
+    fs.mkdirSync(replacement);
+
+    writeWecomWorkingDir(selected, root);
+    const state = writeWecomWorkingDir(replacement, root);
+
+    expect(state.workingDir).toBe(storageForm(replacement));
+    expect(state.workingDirAvailable).toBe(true);
+    expect(readWecomChannelSettings(root)).toEqual(state);
+    // 原子写入不留 tmp 残留; 可用性探测不留探针残留。
+    expect(fs.readdirSync(root).filter((name) => name.endsWith('.tmp'))).toEqual([]);
+    expect(fs.readdirSync(replacement)).toEqual([]);
+  });
+
+  it('falls back to a managed directory when the selected directory disappears', () => {
+    const selected = path.join(root, 'project');
+    fs.mkdirSync(selected);
+    writeWecomWorkingDir(selected, root);
+    const savedStorageForm = storageForm(selected);
+    fs.rmSync(selected, { recursive: true });
+
+    expect(readWecomChannelSettings(root).workingDirAvailable).toBe(false);
+    // override 保留(不静默清掉用户的显式选择), 新对话回退托管目录。
+    expect(readWecomChannelSettings(root).workingDir).toBe(savedStorageForm);
+    const resolved = resolveWecomWorkingDir('bot-1', root);
+    expect(resolved).toBe(
+      path.join(root, 'im-working-dir', `wecom-${Buffer.from('bot-1').toString('base64url')}`),
+    );
+    expect(fs.statSync(resolved).isDirectory()).toBe(true);
+  });
+
+  it('resolves the configured directory again once it becomes available', () => {
+    const selected = path.join(root, 'project');
+    fs.mkdirSync(selected);
+    writeWecomWorkingDir(selected, root);
+    expect(resolveWecomWorkingDir('bot-1', root)).toBe(storageForm(selected));
+  });
+
+  it('never touches user-created files with a probe-like name in the configured directory', () => {
+    const selected = path.join(root, 'project');
+    fs.mkdirSync(selected);
+    writeWecomWorkingDir(selected, root);
+    fs.writeFileSync(path.join(selected, '.cindy-workdir-probe-user-note'), 'user data');
+
+    expect(readWecomChannelSettings(root).workingDirAvailable).toBe(true);
+    // 只清理 Cindy 自己的 UUID 探针; 用户同前缀文件必须原样保留(P0)。
+    expect(fs.readFileSync(path.join(selected, '.cindy-workdir-probe-user-note'), 'utf8')).toBe(
+      'user data',
+    );
+    expect(fs.readdirSync(selected)).toEqual(['.cindy-workdir-probe-user-note']);
+  });
+
+  it('maps arbitrary bot ids to stable managed directory names', () => {
+    const managedRoot = path.join(root, 'im-working-dir');
+    const ids = ['../../escape', 'nested/bot', 'nested\\bot', 'bot:name', '空间名'];
+
+    for (const botId of ids) {
+      const first = resolveWecomWorkingDir(botId, root);
+      const second = resolveWecomWorkingDir(botId, root);
+      expect(first).toBe(second);
+      expect(path.dirname(first)).toBe(managedRoot);
+      expect(path.basename(first)).toMatch(/^wecom-[A-Za-z0-9_-]{1,96}$/);
+      expect(fs.statSync(first).isDirectory()).toBe(true);
+    }
+
+    expect(fs.existsSync(path.join(root, 'escape'))).toBe(false);
+  });
+
+  it('reset removes the override and restores the managed directory', () => {
+    const selected = path.join(root, 'project');
+    fs.mkdirSync(selected);
+    writeWecomWorkingDir(selected, root);
+
+    expect(resetWecomWorkingDir(root)).toEqual({
+      version: 1,
+      workingDir: null,
+      workingDirAvailable: true,
+    });
+    expect(fs.existsSync(path.join(root, 'wecom-channel.json'))).toBe(false);
+    expect(resolveWecomWorkingDir('bot-2', root)).toBe(
+      path.join(root, 'im-working-dir', `wecom-${Buffer.from('bot-2').toString('base64url')}`),
+    );
+  });
+
+  it('rejects relative paths and files', () => {
+    expect(() => writeWecomWorkingDir('relative', root)).toThrow('WECOM_WORKING_DIR_INVALID');
+    const file = path.join(root, 'file.txt');
+    fs.writeFileSync(file, 'x');
+    expect(() => writeWecomWorkingDir(file, root)).toThrow('WECOM_WORKING_DIR_NOT_DIRECTORY');
+  });
+
+  it('treats corrupted settings JSON as no override', () => {
+    fs.writeFileSync(path.join(root, 'wecom-channel.json'), '{not json', 'utf8');
+
+    expect(readWecomChannelSettings(root)).toEqual({
+      version: 1,
+      workingDir: null,
+      workingDirAvailable: true,
+    });
+    expect(resolveWecomWorkingDir('bot-1', root)).toBe(
+      path.join(root, 'im-working-dir', `wecom-${Buffer.from('bot-1').toString('base64url')}`),
+    );
+  });
+
+  it('ignores a non-absolute workingDir left in the settings file', () => {
+    fs.writeFileSync(
+      path.join(root, 'wecom-channel.json'),
+      JSON.stringify({ version: 1, workingDir: 'relative/path' }),
+      'utf8',
+    );
+
+    const state = readWecomChannelSettings(root);
+    expect(state.workingDir).toBeNull();
+    expect(state.workingDirAvailable).toBe(true);
+  });
+
+  it('marks a configured path that became a file as unavailable and falls back', () => {
+    const file = path.join(root, 'now-a-file');
+    fs.writeFileSync(file, 'x');
+    fs.writeFileSync(
+      path.join(root, 'wecom-channel.json'),
+      JSON.stringify({ version: 1, workingDir: file }),
+      'utf8',
+    );
+
+    const state = readWecomChannelSettings(root);
+    expect(state.workingDir).toBeTruthy();
+    expect(state.workingDirAvailable).toBe(false);
+    expect(resolveWecomWorkingDir('bot-1', root)).toBe(
+      path.join(root, 'im-working-dir', `wecom-${Buffer.from('bot-1').toString('base64url')}`),
+    );
+  });
+
+  it('treats a read-only directory as unavailable (POSIX permission semantics)', () => {
+    // Windows 的 chmod 不对目录构成写保护(§3.2 平台能力差异), 真实权限语义
+    // 只在 POSIX 实跑; stat 层行为已由上面用例覆盖。
+    if (process.platform === 'win32') return;
+    const selected = path.join(root, 'readonly');
+    fs.mkdirSync(selected);
+    try {
+      fs.chmodSync(selected, 0o500);
+      fs.writeFileSync(
+        path.join(root, 'wecom-channel.json'),
+        JSON.stringify({ version: 1, workingDir: selected }),
+        'utf8',
+      );
+
+      const state = readWecomChannelSettings(root);
+      expect(state.workingDir).toBeTruthy();
+      expect(state.workingDirAvailable).toBe(false);
+      expect(resolveWecomWorkingDir('bot-1', root)).toBe(
+        path.join(root, 'im-working-dir', `wecom-${Buffer.from('bot-1').toString('base64url')}`),
+      );
+    } finally {
+      fs.chmodSync(selected, 0o700);
+    }
+  });
+
+  it('scopes the settings file and managed dirs to the active data owner', () => {
+    const selected = path.join(root, 'project');
+    fs.mkdirSync(selected);
+
+    expect(writeWecomWorkingDir(selected).workingDir).toBe(storageForm(selected));
+    expect(fs.existsSync(path.join(ownersRoot, 'owner-a', 'wecom-channel.json'))).toBe(true);
+
+    // 换 owner 后读到的是自己的(尚不存在的)配置, 不跨账号泄漏;托管目录也各自开。
+    ownerState.key = 'owner-b';
+    expect(readWecomChannelSettings()).toEqual({
+      version: 1,
+      workingDir: null,
+      workingDirAvailable: true,
+    });
+    const managedB = resolveWecomWorkingDir('bot-1');
+    expect(managedB).toBe(
+      path.join(
+        ownersRoot,
+        'owner-b',
+        'im-working-dir',
+        `wecom-${Buffer.from('bot-1').toString('base64url')}`,
+      ),
+    );
+    expect(fs.existsSync(path.join(ownersRoot, 'owner-b', 'wecom-channel.json'))).toBe(false);
+  });
+});

--- a/apps/desktop/src/main/im/wecom/__tests__/channelSettings.test.ts
+++ b/apps/desktop/src/main/im/wecom/__tests__/channelSettings.test.ts
@@ -5,9 +5,10 @@ import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  ensureWecomManagedWorkingDir,
   readWecomChannelSettings,
   resetWecomWorkingDir,
-  resolveWecomWorkingDir,
+  resolveWecomWorkingDirForNewConversation,
   writeWecomWorkingDir,
 } from '../channelSettings';
 
@@ -38,54 +39,56 @@ function storageForm(dir: string): string {
 }
 
 describe('WeCom channel settings', () => {
-  it('persists only a directory selected from an absolute existing path', () => {
+  it('persists only a directory selected from an absolute existing path', async () => {
     const selected = path.join(root, 'project');
     const replacement = path.join(root, 'replacement');
     fs.mkdirSync(selected);
     fs.mkdirSync(replacement);
 
-    writeWecomWorkingDir(selected, root);
-    const state = writeWecomWorkingDir(replacement, root);
+    await writeWecomWorkingDir(selected, root);
+    const state = await writeWecomWorkingDir(replacement, root);
 
     expect(state.workingDir).toBe(storageForm(replacement));
     expect(state.workingDirAvailable).toBe(true);
-    expect(readWecomChannelSettings(root)).toEqual(state);
+    expect(await readWecomChannelSettings(root)).toEqual(state);
     // 原子写入不留 tmp 残留; 可用性探测不留探针残留。
     expect(fs.readdirSync(root).filter((name) => name.endsWith('.tmp'))).toEqual([]);
     expect(fs.readdirSync(replacement)).toEqual([]);
   });
 
-  it('falls back to a managed directory when the selected directory disappears', () => {
+  it('falls back to a managed directory when the selected directory disappears', async () => {
     const selected = path.join(root, 'project');
     fs.mkdirSync(selected);
-    writeWecomWorkingDir(selected, root);
+    await writeWecomWorkingDir(selected, root);
     const savedStorageForm = storageForm(selected);
     fs.rmSync(selected, { recursive: true });
 
-    expect(readWecomChannelSettings(root).workingDirAvailable).toBe(false);
+    expect((await readWecomChannelSettings(root)).workingDirAvailable).toBe(false);
     // override 保留(不静默清掉用户的显式选择), 新对话回退托管目录。
-    expect(readWecomChannelSettings(root).workingDir).toBe(savedStorageForm);
-    const resolved = resolveWecomWorkingDir('bot-1', root);
+    expect((await readWecomChannelSettings(root)).workingDir).toBe(savedStorageForm);
+    const resolved = await resolveWecomWorkingDirForNewConversation('bot-1', root);
     expect(resolved).toBe(
       path.join(root, 'im-working-dir', `wecom-${Buffer.from('bot-1').toString('base64url')}`),
     );
     expect(fs.statSync(resolved).isDirectory()).toBe(true);
   });
 
-  it('resolves the configured directory again once it becomes available', () => {
+  it('resolves the configured directory again once it becomes available', async () => {
     const selected = path.join(root, 'project');
     fs.mkdirSync(selected);
-    writeWecomWorkingDir(selected, root);
-    expect(resolveWecomWorkingDir('bot-1', root)).toBe(storageForm(selected));
+    await writeWecomWorkingDir(selected, root);
+    expect(await resolveWecomWorkingDirForNewConversation('bot-1', root)).toBe(
+      storageForm(selected),
+    );
   });
 
-  it('never touches user-created files with a probe-like name in the configured directory', () => {
+  it('never touches user-created files with a probe-like name in the configured directory', async () => {
     const selected = path.join(root, 'project');
     fs.mkdirSync(selected);
-    writeWecomWorkingDir(selected, root);
+    await writeWecomWorkingDir(selected, root);
     fs.writeFileSync(path.join(selected, '.cindy-workdir-probe-user-note'), 'user data');
 
-    expect(readWecomChannelSettings(root).workingDirAvailable).toBe(true);
+    expect((await readWecomChannelSettings(root)).workingDirAvailable).toBe(true);
     // 只清理 Cindy 自己的 UUID 探针; 用户同前缀文件必须原样保留(P0)。
     expect(fs.readFileSync(path.join(selected, '.cindy-workdir-probe-user-note'), 'utf8')).toBe(
       'user data',
@@ -98,8 +101,8 @@ describe('WeCom channel settings', () => {
     const ids = ['../../escape', 'nested/bot', 'nested\\bot', 'bot:name', '空间名'];
 
     for (const botId of ids) {
-      const first = resolveWecomWorkingDir(botId, root);
-      const second = resolveWecomWorkingDir(botId, root);
+      const first = ensureWecomManagedWorkingDir(botId, root);
+      const second = ensureWecomManagedWorkingDir(botId, root);
       expect(first).toBe(second);
       expect(path.dirname(first)).toBe(managedRoot);
       expect(path.basename(first)).toMatch(/^wecom-[A-Za-z0-9_-]{1,96}$/);
@@ -109,55 +112,59 @@ describe('WeCom channel settings', () => {
     expect(fs.existsSync(path.join(root, 'escape'))).toBe(false);
   });
 
-  it('reset removes the override and restores the managed directory', () => {
+  it('reset removes the override and restores the managed directory', async () => {
     const selected = path.join(root, 'project');
     fs.mkdirSync(selected);
-    writeWecomWorkingDir(selected, root);
+    await writeWecomWorkingDir(selected, root);
 
-    expect(resetWecomWorkingDir(root)).toEqual({
+    expect(await resetWecomWorkingDir(root)).toEqual({
       version: 1,
       workingDir: null,
       workingDirAvailable: true,
     });
     expect(fs.existsSync(path.join(root, 'wecom-channel.json'))).toBe(false);
-    expect(resolveWecomWorkingDir('bot-2', root)).toBe(
+    expect(await resolveWecomWorkingDirForNewConversation('bot-2', root)).toBe(
       path.join(root, 'im-working-dir', `wecom-${Buffer.from('bot-2').toString('base64url')}`),
     );
   });
 
-  it('rejects relative paths and files', () => {
-    expect(() => writeWecomWorkingDir('relative', root)).toThrow('WECOM_WORKING_DIR_INVALID');
+  it('rejects relative paths and files', async () => {
+    await expect(writeWecomWorkingDir('relative', root)).rejects.toThrow(
+      'WECOM_WORKING_DIR_INVALID',
+    );
     const file = path.join(root, 'file.txt');
     fs.writeFileSync(file, 'x');
-    expect(() => writeWecomWorkingDir(file, root)).toThrow('WECOM_WORKING_DIR_NOT_DIRECTORY');
+    await expect(writeWecomWorkingDir(file, root)).rejects.toThrow(
+      'WECOM_WORKING_DIR_NOT_DIRECTORY',
+    );
   });
 
-  it('treats corrupted settings JSON as no override', () => {
+  it('treats corrupted settings JSON as no override', async () => {
     fs.writeFileSync(path.join(root, 'wecom-channel.json'), '{not json', 'utf8');
 
-    expect(readWecomChannelSettings(root)).toEqual({
+    expect(await readWecomChannelSettings(root)).toEqual({
       version: 1,
       workingDir: null,
       workingDirAvailable: true,
     });
-    expect(resolveWecomWorkingDir('bot-1', root)).toBe(
+    expect(await resolveWecomWorkingDirForNewConversation('bot-1', root)).toBe(
       path.join(root, 'im-working-dir', `wecom-${Buffer.from('bot-1').toString('base64url')}`),
     );
   });
 
-  it('ignores a non-absolute workingDir left in the settings file', () => {
+  it('ignores a non-absolute workingDir left in the settings file', async () => {
     fs.writeFileSync(
       path.join(root, 'wecom-channel.json'),
       JSON.stringify({ version: 1, workingDir: 'relative/path' }),
       'utf8',
     );
 
-    const state = readWecomChannelSettings(root);
+    const state = await readWecomChannelSettings(root);
     expect(state.workingDir).toBeNull();
     expect(state.workingDirAvailable).toBe(true);
   });
 
-  it('marks a configured path that became a file as unavailable and falls back', () => {
+  it('marks a configured path that became a file as unavailable and falls back', async () => {
     const file = path.join(root, 'now-a-file');
     fs.writeFileSync(file, 'x');
     fs.writeFileSync(
@@ -166,15 +173,15 @@ describe('WeCom channel settings', () => {
       'utf8',
     );
 
-    const state = readWecomChannelSettings(root);
+    const state = await readWecomChannelSettings(root);
     expect(state.workingDir).toBeTruthy();
     expect(state.workingDirAvailable).toBe(false);
-    expect(resolveWecomWorkingDir('bot-1', root)).toBe(
+    expect(await resolveWecomWorkingDirForNewConversation('bot-1', root)).toBe(
       path.join(root, 'im-working-dir', `wecom-${Buffer.from('bot-1').toString('base64url')}`),
     );
   });
 
-  it('treats a read-only directory as unavailable (POSIX permission semantics)', () => {
+  it('treats a read-only directory as unavailable (POSIX permission semantics)', async () => {
     // Windows 的 chmod 不对目录构成写保护(§3.2 平台能力差异), 真实权限语义
     // 只在 POSIX 实跑; stat 层行为已由上面用例覆盖。
     if (process.platform === 'win32') return;
@@ -188,10 +195,10 @@ describe('WeCom channel settings', () => {
         'utf8',
       );
 
-      const state = readWecomChannelSettings(root);
+      const state = await readWecomChannelSettings(root);
       expect(state.workingDir).toBeTruthy();
       expect(state.workingDirAvailable).toBe(false);
-      expect(resolveWecomWorkingDir('bot-1', root)).toBe(
+      expect(await resolveWecomWorkingDirForNewConversation('bot-1', root)).toBe(
         path.join(root, 'im-working-dir', `wecom-${Buffer.from('bot-1').toString('base64url')}`),
       );
     } finally {
@@ -199,21 +206,21 @@ describe('WeCom channel settings', () => {
     }
   });
 
-  it('scopes the settings file and managed dirs to the active data owner', () => {
+  it('scopes the settings file and managed dirs to the active data owner', async () => {
     const selected = path.join(root, 'project');
     fs.mkdirSync(selected);
 
-    expect(writeWecomWorkingDir(selected).workingDir).toBe(storageForm(selected));
+    expect((await writeWecomWorkingDir(selected)).workingDir).toBe(storageForm(selected));
     expect(fs.existsSync(path.join(ownersRoot, 'owner-a', 'wecom-channel.json'))).toBe(true);
 
     // 换 owner 后读到的是自己的(尚不存在的)配置, 不跨账号泄漏;托管目录也各自开。
     ownerState.key = 'owner-b';
-    expect(readWecomChannelSettings()).toEqual({
+    expect(await readWecomChannelSettings()).toEqual({
       version: 1,
       workingDir: null,
       workingDirAvailable: true,
     });
-    const managedB = resolveWecomWorkingDir('bot-1');
+    const managedB = ensureWecomManagedWorkingDir('bot-1');
     expect(managedB).toBe(
       path.join(
         ownersRoot,

--- a/apps/desktop/src/main/im/wecom/__tests__/workingDirIpc.test.ts
+++ b/apps/desktop/src/main/im/wecom/__tests__/workingDirIpc.test.ts
@@ -3,7 +3,8 @@
  * ---------------------------------------------------------------------------
  * wecomBot 工作目录 IPC 的 handler 级测试(依赖全注入, 不拉起 Electron)。
  * 关键路径: 主路径 / 取消 / 窗口失效 / 选择器异常 / **弹窗期间切号不落盘** /
- * 写入与重置失败 —— 全部映射成统一 IPC 错误码, 不把原始异常穿给 Renderer。
+ * **用户目录探测期间切号不落盘** / 写入与重置失败 —— 全部映射成统一 IPC
+ * 错误码, 不把原始异常穿给 Renderer。
  */
 
 import { describe, expect, it, vi } from 'vitest';
@@ -16,13 +17,15 @@ import {
 
 const STATE = { version: 1, workingDir: null, workingDirAvailable: true } as const;
 const PICKED_STATE = { version: 1, workingDir: 'D:/picked', workingDirAvailable: true } as const;
+const NORMALIZED = 'D:/picked';
 const ERROR_CODE = 'WECOM_WORKING_DIR_UPDATE_FAILED';
 
 function makeDeps(overrides: Record<string, unknown> = {}) {
   return {
-    readSettings: vi.fn(() => PICKED_STATE),
-    writeWorkingDir: vi.fn(() => PICKED_STATE),
-    resetWorkingDir: vi.fn(() => STATE),
+    readSettings: vi.fn(async () => PICKED_STATE),
+    normalizeSelectedDirectory: vi.fn(async () => NORMALIZED),
+    commitWorkingDir: vi.fn(async () => PICKED_STATE),
+    resetWorkingDir: vi.fn(async () => STATE),
     showDirectoryPicker: vi.fn(async () => ({ canceled: false, filePaths: ['D:\\picked'] })),
     captureGeneration: vi.fn((): number | null => 7),
     warn: vi.fn(),
@@ -40,7 +43,9 @@ describe('wecomBot working directory IPC handlers', () => {
       state: PICKED_STATE,
     });
     expect(deps.showDirectoryPicker).toHaveBeenCalledWith('wc');
-    expect(deps.writeWorkingDir).toHaveBeenCalledWith('D:\\picked');
+    // 两段式: 先异步校验用户盘, 再(代次校验后)落盘本地配置。
+    expect(deps.normalizeSelectedDirectory).toHaveBeenCalledWith('D:\\picked');
+    expect(deps.commitWorkingDir).toHaveBeenCalledWith(NORMALIZED);
   });
 
   it('treats a cancelled picker as canceled, not an error, and keeps config', async () => {
@@ -53,7 +58,8 @@ describe('wecomBot working directory IPC handlers', () => {
       canceled: true,
       state: PICKED_STATE,
     });
-    expect(deps.writeWorkingDir).not.toHaveBeenCalled();
+    expect(deps.normalizeSelectedDirectory).not.toHaveBeenCalled();
+    expect(deps.commitWorkingDir).not.toHaveBeenCalled();
   });
 
   it('rejects with the structured IPC error when the owner window is gone', async () => {
@@ -63,7 +69,7 @@ describe('wecomBot working directory IPC handlers', () => {
     await expect(handlers.chooseWorkingDirectory({})).rejects.toMatchObject({
       code: ERROR_CODE,
     });
-    expect(deps.writeWorkingDir).not.toHaveBeenCalled();
+    expect(deps.commitWorkingDir).not.toHaveBeenCalled();
   });
 
   it('maps picker exceptions to the structured IPC error', async () => {
@@ -78,7 +84,7 @@ describe('wecomBot working directory IPC handlers', () => {
       code: ERROR_CODE,
     });
     expect(deps.warn).toHaveBeenCalled();
-    expect(deps.writeWorkingDir).not.toHaveBeenCalled();
+    expect(deps.commitWorkingDir).not.toHaveBeenCalled();
   });
 
   it('drops the pick when the IM account generation changes during the dialog', async () => {
@@ -92,9 +98,30 @@ describe('wecomBot working directory IPC handlers', () => {
     await expect(handlers.chooseWorkingDirectory({})).rejects.toMatchObject({
       code: ERROR_CODE,
     });
-    expect(deps.writeWorkingDir).not.toHaveBeenCalled();
+    expect(deps.normalizeSelectedDirectory).not.toHaveBeenCalled();
+    expect(deps.commitWorkingDir).not.toHaveBeenCalled();
     expect(deps.warn).toHaveBeenCalledWith(
       'WeCom working directory pick crossed an account switch; dropped',
+    );
+  });
+
+  it('drops the pick when the generation changes while probing the user directory', async () => {
+    // 用户盘探测是异步的(网络盘可能秒级): 探测归来后必须重校验代次,
+    // 不能沿用「弹窗后校验过一次」的同步假设 — 否则 A 账号选的路径会趁
+    // 探测间隙写进 B 账号的 owner-scoped 配置。
+    const generations = [7, 7, 8];
+    const deps = makeDeps({
+      captureGeneration: vi.fn(() => generations.shift() ?? null),
+    });
+    const handlers = createWecomWorkingDirIpcHandlers(deps);
+
+    await expect(handlers.chooseWorkingDirectory({})).rejects.toMatchObject({
+      code: ERROR_CODE,
+    });
+    expect(deps.normalizeSelectedDirectory).toHaveBeenCalledTimes(1);
+    expect(deps.commitWorkingDir).not.toHaveBeenCalled();
+    expect(deps.warn).toHaveBeenCalledWith(
+      'WeCom working directory probe crossed an account switch; dropped',
     );
   });
 
@@ -105,13 +132,27 @@ describe('wecomBot working directory IPC handlers', () => {
     await expect(handlers.chooseWorkingDirectory({})).resolves.toMatchObject({
       canceled: false,
     });
-    expect(deps.writeWorkingDir).toHaveBeenCalledTimes(1);
+    expect(deps.commitWorkingDir).toHaveBeenCalledTimes(1);
   });
 
-  it('maps write failures to the structured IPC error', async () => {
+  it('maps validation failures to the structured IPC error without writing', async () => {
     const deps = makeDeps({
-      writeWorkingDir: vi.fn(() => {
+      normalizeSelectedDirectory: vi.fn(async () => {
         throw new Error('WECOM_WORKING_DIR_NOT_DIRECTORY');
+      }),
+    });
+    const handlers = createWecomWorkingDirIpcHandlers(deps);
+
+    await expect(handlers.chooseWorkingDirectory({})).rejects.toMatchObject({
+      code: ERROR_CODE,
+    });
+    expect(deps.commitWorkingDir).not.toHaveBeenCalled();
+  });
+
+  it('maps commit failures to the structured IPC error', async () => {
+    const deps = makeDeps({
+      commitWorkingDir: vi.fn(async () => {
+        throw new Error('EACCES');
       }),
     });
     const handlers = createWecomWorkingDirIpcHandlers(deps);
@@ -121,21 +162,23 @@ describe('wecomBot working directory IPC handlers', () => {
     });
   });
 
-  it('returns the stored projection and maps reset failures', () => {
+  it('returns the stored projection and maps reset failures', async () => {
     const deps = makeDeps();
     const handlers = createWecomWorkingDirIpcHandlers(deps);
 
-    expect(handlers.getChannelSettings()).toBe(PICKED_STATE);
-    expect(handlers.resetWorkingDirectory()).toBe(STATE);
+    await expect(handlers.getChannelSettings()).resolves.toBe(PICKED_STATE);
+    await expect(handlers.resetWorkingDirectory()).resolves.toBe(STATE);
 
     const failing = createWecomWorkingDirIpcHandlers(
       makeDeps({
-        resetWorkingDir: vi.fn(() => {
+        resetWorkingDir: vi.fn(async () => {
           throw new Error('EACCES');
         }),
       }),
     );
-    expect(() => failing.resetWorkingDirectory()).toThrow(/\[WECOM_WORKING_DIR_UPDATE_FAILED\]/);
+    await expect(failing.resetWorkingDirectory()).rejects.toThrow(
+      /\[WECOM_WORKING_DIR_UPDATE_FAILED\]/,
+    );
   });
 });
 
@@ -174,8 +217,8 @@ describe('wecomBot working directory IPC 安全边界', () => {
     const { deps, listeners } = registerWith(false);
 
     // 安全边界必须先于业务体: 任何一个业务 dep 都不允许被触碰。
-    // (choose 的 listener 同步抛出 — Electron handle 会把它变成 renderer 侧
-    // 的 rejected invocation, 这里按同步抛出断言。)
+    // (listener 同步抛出 — Electron handle 会把它变成 renderer 侧的 rejected
+    // invocation, 这里按同步抛出断言。)
     expect(() => listeners.get('wecomBot:get-channel-settings')!(UNTRUSTED_EVENT)).toThrow(
       'UNTRUSTED_RENDERER',
     );
@@ -189,14 +232,19 @@ describe('wecomBot working directory IPC 安全边界', () => {
     expect(deps.readSettings).not.toHaveBeenCalled();
     expect(deps.showDirectoryPicker).not.toHaveBeenCalled();
     expect(deps.resetWorkingDir).not.toHaveBeenCalled();
-    expect(deps.writeWorkingDir).not.toHaveBeenCalled();
+    expect(deps.normalizeSelectedDirectory).not.toHaveBeenCalled();
+    expect(deps.commitWorkingDir).not.toHaveBeenCalled();
   });
 
   it('passes trusted senders through to the business body', async () => {
     const { deps, listeners } = registerWith(true);
 
-    expect(listeners.get('wecomBot:get-channel-settings')!({ sender: 'wc' })).toBe(PICKED_STATE);
-    expect(listeners.get('wecomBot:reset-working-directory')!({ sender: 'wc' })).toBe(STATE);
+    await expect(listeners.get('wecomBot:get-channel-settings')!({ sender: 'wc' })).resolves.toBe(
+      PICKED_STATE,
+    );
+    await expect(
+      listeners.get('wecomBot:reset-working-directory')!({ sender: 'wc' }),
+    ).resolves.toBe(STATE);
     await expect(
       listeners.get('wecomBot:choose-working-directory')!({ sender: 'wc' }),
     ).resolves.toMatchObject({ canceled: false });

--- a/apps/desktop/src/main/im/wecom/__tests__/workingDirIpc.test.ts
+++ b/apps/desktop/src/main/im/wecom/__tests__/workingDirIpc.test.ts
@@ -1,0 +1,208 @@
+/**
+ * workingDirIpc.test.ts
+ * ---------------------------------------------------------------------------
+ * wecomBot 工作目录 IPC 的 handler 级测试(依赖全注入, 不拉起 Electron)。
+ * 关键路径: 主路径 / 取消 / 窗口失效 / 选择器异常 / **弹窗期间切号不落盘** /
+ * 写入与重置失败 —— 全部映射成统一 IPC 错误码, 不把原始异常穿给 Renderer。
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  createWecomWorkingDirIpcHandlers,
+  registerWecomWorkingDirIpc,
+  type IpcHandleSink,
+} from '../workingDirIpc';
+
+const STATE = { version: 1, workingDir: null, workingDirAvailable: true } as const;
+const PICKED_STATE = { version: 1, workingDir: 'D:/picked', workingDirAvailable: true } as const;
+const ERROR_CODE = 'WECOM_WORKING_DIR_UPDATE_FAILED';
+
+function makeDeps(overrides: Record<string, unknown> = {}) {
+  return {
+    readSettings: vi.fn(() => PICKED_STATE),
+    writeWorkingDir: vi.fn(() => PICKED_STATE),
+    resetWorkingDir: vi.fn(() => STATE),
+    showDirectoryPicker: vi.fn(async () => ({ canceled: false, filePaths: ['D:\\picked'] })),
+    captureGeneration: vi.fn((): number | null => 7),
+    warn: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('wecomBot working directory IPC handlers', () => {
+  it('saves the picked directory and returns the fresh state', async () => {
+    const deps = makeDeps();
+    const handlers = createWecomWorkingDirIpcHandlers(deps);
+
+    await expect(handlers.chooseWorkingDirectory('wc')).resolves.toEqual({
+      canceled: false,
+      state: PICKED_STATE,
+    });
+    expect(deps.showDirectoryPicker).toHaveBeenCalledWith('wc');
+    expect(deps.writeWorkingDir).toHaveBeenCalledWith('D:\\picked');
+  });
+
+  it('treats a cancelled picker as canceled, not an error, and keeps config', async () => {
+    const deps = makeDeps({
+      showDirectoryPicker: vi.fn(async () => ({ canceled: true, filePaths: [] })),
+    });
+    const handlers = createWecomWorkingDirIpcHandlers(deps);
+
+    await expect(handlers.chooseWorkingDirectory({})).resolves.toEqual({
+      canceled: true,
+      state: PICKED_STATE,
+    });
+    expect(deps.writeWorkingDir).not.toHaveBeenCalled();
+  });
+
+  it('rejects with the structured IPC error when the owner window is gone', async () => {
+    const deps = makeDeps({ showDirectoryPicker: vi.fn(async () => null) });
+    const handlers = createWecomWorkingDirIpcHandlers(deps);
+
+    await expect(handlers.chooseWorkingDirectory({})).rejects.toMatchObject({
+      code: ERROR_CODE,
+    });
+    expect(deps.writeWorkingDir).not.toHaveBeenCalled();
+  });
+
+  it('maps picker exceptions to the structured IPC error', async () => {
+    const deps = makeDeps({
+      showDirectoryPicker: vi.fn(async () => {
+        throw new Error('dialog exploded');
+      }),
+    });
+    const handlers = createWecomWorkingDirIpcHandlers(deps);
+
+    await expect(handlers.chooseWorkingDirectory({})).rejects.toMatchObject({
+      code: ERROR_CODE,
+    });
+    expect(deps.warn).toHaveBeenCalled();
+    expect(deps.writeWorkingDir).not.toHaveBeenCalled();
+  });
+
+  it('drops the pick when the IM account generation changes during the dialog', async () => {
+    // 弹窗期间登出/换号: 代次推进 ⇒ 选中的路径属于上一个账号, 绝不落盘。
+    const generations = [7, 8];
+    const deps = makeDeps({
+      captureGeneration: vi.fn(() => generations.shift() ?? null),
+    });
+    const handlers = createWecomWorkingDirIpcHandlers(deps);
+
+    await expect(handlers.chooseWorkingDirectory({})).rejects.toMatchObject({
+      code: ERROR_CODE,
+    });
+    expect(deps.writeWorkingDir).not.toHaveBeenCalled();
+    expect(deps.warn).toHaveBeenCalledWith(
+      'WeCom working directory pick crossed an account switch; dropped',
+    );
+  });
+
+  it('allows the write when the generation stays equal, including both null', async () => {
+    const deps = makeDeps({ captureGeneration: vi.fn((): number | null => null) });
+    const handlers = createWecomWorkingDirIpcHandlers(deps);
+
+    await expect(handlers.chooseWorkingDirectory({})).resolves.toMatchObject({
+      canceled: false,
+    });
+    expect(deps.writeWorkingDir).toHaveBeenCalledTimes(1);
+  });
+
+  it('maps write failures to the structured IPC error', async () => {
+    const deps = makeDeps({
+      writeWorkingDir: vi.fn(() => {
+        throw new Error('WECOM_WORKING_DIR_NOT_DIRECTORY');
+      }),
+    });
+    const handlers = createWecomWorkingDirIpcHandlers(deps);
+
+    await expect(handlers.chooseWorkingDirectory({})).rejects.toMatchObject({
+      code: ERROR_CODE,
+    });
+  });
+
+  it('returns the stored projection and maps reset failures', () => {
+    const deps = makeDeps();
+    const handlers = createWecomWorkingDirIpcHandlers(deps);
+
+    expect(handlers.getChannelSettings()).toBe(PICKED_STATE);
+    expect(handlers.resetWorkingDirectory()).toBe(STATE);
+
+    const failing = createWecomWorkingDirIpcHandlers(
+      makeDeps({
+        resetWorkingDir: vi.fn(() => {
+          throw new Error('EACCES');
+        }),
+      }),
+    );
+    expect(() => failing.resetWorkingDirectory()).toThrow(/\[WECOM_WORKING_DIR_UPDATE_FAILED\]/);
+  });
+});
+
+describe('wecomBot working directory IPC 安全边界', () => {
+  type Listener = (event: unknown) => unknown;
+  const UNTRUSTED_EVENT = { sender: { id: 1 }, senderFrame: { url: 'https://evil.example' } };
+
+  function registerWith(trusted: boolean) {
+    const deps = makeDeps();
+    const listeners = new Map<string, Listener>();
+    const sink: IpcHandleSink = {
+      handle: (channel, listener) => {
+        listeners.set(channel, listener as Listener);
+      },
+    };
+    registerWecomWorkingDirIpc({
+      ipc: sink,
+      handlers: createWecomWorkingDirIpcHandlers(deps),
+      assertTrustedEvent: (event) => {
+        if (!trusted) throw new Error('UNTRUSTED_RENDERER');
+      },
+    });
+    return { deps, listeners };
+  }
+
+  it('registers exactly the three working-directory channels', () => {
+    const { listeners } = registerWith(true);
+    expect([...listeners.keys()].sort()).toEqual([
+      'wecomBot:choose-working-directory',
+      'wecomBot:get-channel-settings',
+      'wecomBot:reset-working-directory',
+    ]);
+  });
+
+  it('rejects untrusted senders before reading settings, opening the picker, or resetting', () => {
+    const { deps, listeners } = registerWith(false);
+
+    // 安全边界必须先于业务体: 任何一个业务 dep 都不允许被触碰。
+    // (choose 的 listener 同步抛出 — Electron handle 会把它变成 renderer 侧
+    // 的 rejected invocation, 这里按同步抛出断言。)
+    expect(() => listeners.get('wecomBot:get-channel-settings')!(UNTRUSTED_EVENT)).toThrow(
+      'UNTRUSTED_RENDERER',
+    );
+    expect(() => listeners.get('wecomBot:reset-working-directory')!(UNTRUSTED_EVENT)).toThrow(
+      'UNTRUSTED_RENDERER',
+    );
+    expect(() => listeners.get('wecomBot:choose-working-directory')!(UNTRUSTED_EVENT)).toThrow(
+      'UNTRUSTED_RENDERER',
+    );
+
+    expect(deps.readSettings).not.toHaveBeenCalled();
+    expect(deps.showDirectoryPicker).not.toHaveBeenCalled();
+    expect(deps.resetWorkingDir).not.toHaveBeenCalled();
+    expect(deps.writeWorkingDir).not.toHaveBeenCalled();
+  });
+
+  it('passes trusted senders through to the business body', async () => {
+    const { deps, listeners } = registerWith(true);
+
+    expect(listeners.get('wecomBot:get-channel-settings')!({ sender: 'wc' })).toBe(PICKED_STATE);
+    expect(listeners.get('wecomBot:reset-working-directory')!({ sender: 'wc' })).toBe(STATE);
+    await expect(
+      listeners.get('wecomBot:choose-working-directory')!({ sender: 'wc' }),
+    ).resolves.toMatchObject({ canceled: false });
+
+    expect(deps.readSettings).toHaveBeenCalled();
+    expect(deps.showDirectoryPicker).toHaveBeenCalledWith('wc');
+    expect(deps.resetWorkingDir).toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/main/im/wecom/adapter.ts
+++ b/apps/desktop/src/main/im/wecom/adapter.ts
@@ -1,17 +1,12 @@
-import fs from 'node:fs';
-
 import type { WecomIM } from '@cindy/im';
 
 import type { ImChannelAdapter, ImOrchestratorConfig } from '../shared/types';
-import { ownerScopedImUserDataPath } from '../ownerScopedStorage';
+import { resolveWecomWorkingDir } from './channelSettings';
 import { ui } from './uiText';
 import type { WecomTextInteractions } from './textInteractions';
 
 function ensureWorkingDir(botId: string): string {
-  const safeBotId = Buffer.from(botId, 'utf8').toString('base64url').slice(0, 96);
-  const dir = ownerScopedImUserDataPath('im-working-dir', `wecom-${safeBotId}`);
-  fs.mkdirSync(dir, { recursive: true });
-  return dir;
+  return resolveWecomWorkingDir(botId);
 }
 
 function sessionSafeUserId(userId: string): string {
@@ -45,6 +40,8 @@ export function buildWecomAdapter(
       generatedTitlePrefix: '企业微信 · ',
       workspaceKind: 'dialogue',
       ensureWorkingDir,
+      // 设置页可改渠道托管目录: /new 边界刷新到最新解析结果。
+      refreshWorkingDirOnNew: true,
       extraInsertColumns: (botId, userId) => ({
         imBotContextId: botId,
         imUserId: userId,

--- a/apps/desktop/src/main/im/wecom/adapter.ts
+++ b/apps/desktop/src/main/im/wecom/adapter.ts
@@ -1,13 +1,12 @@
 import type { WecomIM } from '@cindy/im';
 
 import type { ImChannelAdapter, ImOrchestratorConfig } from '../shared/types';
-import { resolveWecomWorkingDir } from './channelSettings';
+import {
+  ensureWecomManagedWorkingDir,
+  resolveWecomWorkingDirForNewConversation,
+} from './channelSettings';
 import { ui } from './uiText';
 import type { WecomTextInteractions } from './textInteractions';
-
-function ensureWorkingDir(botId: string): string {
-  return resolveWecomWorkingDir(botId);
-}
 
 function sessionSafeUserId(userId: string): string {
   return Buffer.from(userId, 'utf8').toString('base64url');
@@ -39,7 +38,10 @@ export function buildWecomAdapter(
           : `企业微信 · ${userId.slice(-6)}`,
       generatedTitlePrefix: '企业微信 · ',
       workspaceKind: 'dialogue',
-      ensureWorkingDir,
+      // 同步兜底只回稳定托管目录; 实际目录(读配置+探测用户盘)在首次对话 /
+      // /new 边界经 resolveWorkingDirForNew 异步解析。
+      ensureWorkingDir: ensureWecomManagedWorkingDir,
+      resolveWorkingDirForNew: resolveWecomWorkingDirForNewConversation,
       // 设置页可改渠道托管目录: /new 边界刷新到最新解析结果。
       refreshWorkingDirOnNew: true,
       extraInsertColumns: (botId, userId) => ({

--- a/apps/desktop/src/main/im/wecom/channelSettings.ts
+++ b/apps/desktop/src/main/im/wecom/channelSettings.ts
@@ -1,0 +1,48 @@
+/**
+ * Owner-scoped, non-secret settings for the WeCom channel.
+ *
+ * 与个人微信同构(见 wechat/channelSettings.ts):只持久化用户在 Main 原生
+ * 目录选择器里选中的 override;目录缺失/不可访问时回退渠道托管目录。
+ * 托管目录命名沿用 adapter 既定的 base64url 方案,存量目录保持稳定。
+ */
+
+import {
+  createChannelWorkingDirStore,
+  type ChannelWorkingDirSettings,
+  type ChannelWorkingDirSettingsState,
+} from '../shared/channelWorkingDirSettings';
+
+export type WecomChannelSettings = ChannelWorkingDirSettings;
+export type WecomChannelSettingsState = ChannelWorkingDirSettingsState;
+
+function managedWorkingDirName(botId: string): string {
+  // 与旧 ensureWorkingDir 相同的编码:任意 botId 都映射进安全文件名字符集。
+  const safeBotId = Buffer.from(botId, 'utf8').toString('base64url').slice(0, 96);
+  return `wecom-${safeBotId}`;
+}
+
+const store = createChannelWorkingDirStore({
+  logTag: 'im/wecom/channel-settings',
+  fileName: 'wecom-channel.json',
+  errorCodePrefix: 'WECOM',
+  managedDirNameFor: managedWorkingDirName,
+});
+
+export function readWecomChannelSettings(rootPath?: string): WecomChannelSettingsState {
+  return store.read(rootPath);
+}
+
+export function writeWecomWorkingDir(
+  selectedPath: string,
+  rootPath?: string,
+): WecomChannelSettingsState {
+  return store.writeWorkingDir(selectedPath, rootPath);
+}
+
+export function resetWecomWorkingDir(rootPath?: string): WecomChannelSettingsState {
+  return store.resetWorkingDir(rootPath);
+}
+
+export function resolveWecomWorkingDir(botId: string, rootPath?: string): string {
+  return store.resolveWorkingDir(botId, rootPath);
+}

--- a/apps/desktop/src/main/im/wecom/channelSettings.ts
+++ b/apps/desktop/src/main/im/wecom/channelSettings.ts
@@ -9,6 +9,7 @@
 
 import {
   createChannelWorkingDirStore,
+  type ChannelUserDirProbeExecutor,
   type ChannelWorkingDirSettings,
   type ChannelWorkingDirSettingsState,
 } from '../shared/channelWorkingDirSettings';
@@ -31,6 +32,11 @@ const store = createChannelWorkingDirStore({
 
 export function readWecomChannelSettings(rootPath?: string): Promise<WecomChannelSettingsState> {
   return store.read(rootPath);
+}
+
+/** 生产装配(im/index.ts): 用户目录探测切到 utility-process 执行边界。 */
+export function configureWecomChannelProbeExecutor(executor: ChannelUserDirProbeExecutor): void {
+  store.setProbeExecutor(executor);
 }
 
 export function writeWecomWorkingDir(

--- a/apps/desktop/src/main/im/wecom/channelSettings.ts
+++ b/apps/desktop/src/main/im/wecom/channelSettings.ts
@@ -4,6 +4,7 @@
  * 与个人微信同构(见 wechat/channelSettings.ts):只持久化用户在 Main 原生
  * 目录选择器里选中的 override;目录缺失/不可访问时回退渠道托管目录。
  * 托管目录命名沿用 adapter 既定的 base64url 方案,存量目录保持稳定。
+ * 用户目录上的 IO 全异步(shared/channelWorkingDirSettings 的 Main 线程纪律)。
  */
 
 import {
@@ -28,21 +29,43 @@ const store = createChannelWorkingDirStore({
   managedDirNameFor: managedWorkingDirName,
 });
 
-export function readWecomChannelSettings(rootPath?: string): WecomChannelSettingsState {
+export function readWecomChannelSettings(rootPath?: string): Promise<WecomChannelSettingsState> {
   return store.read(rootPath);
 }
 
 export function writeWecomWorkingDir(
   selectedPath: string,
   rootPath?: string,
-): WecomChannelSettingsState {
+): Promise<WecomChannelSettingsState> {
   return store.writeWorkingDir(selectedPath, rootPath);
 }
 
-export function resetWecomWorkingDir(rootPath?: string): WecomChannelSettingsState {
+/** 只校验/规整用户所选目录(异步探测用户盘), 不落盘 — 供 IPC 两段式提交。 */
+export function normalizeWecomSelectedDirectory(selectedPath: string): Promise<string> {
+  return store.normalizeSelectedDirectory(selectedPath);
+}
+
+/** 落盘已规整目录(只碰本地 userData)— 在 IM account generation 二次校验之后调用。 */
+export function commitWecomWorkingDir(
+  normalizedDir: string,
+  rootPath?: string,
+): Promise<WecomChannelSettingsState> {
+  return store.commitWorkingDir(normalizedDir, rootPath);
+}
+
+export function resetWecomWorkingDir(rootPath?: string): Promise<WecomChannelSettingsState> {
   return store.resetWorkingDir(rootPath);
 }
 
-export function resolveWecomWorkingDir(botId: string, rootPath?: string): string {
-  return store.resolveWorkingDir(botId, rootPath);
+/** 稳定托管目录(同步, 本机盘)— 会话行兜底与归属比较用, 不读配置不探测。 */
+export function ensureWecomManagedWorkingDir(botId: string, rootPath?: string): string {
+  return store.ensureManagedWorkingDir(botId, rootPath);
+}
+
+/** 新对话实际目录(异步): 读配置 + 探测用户所选目录, 不可用回退托管目录。 */
+export function resolveWecomWorkingDirForNewConversation(
+  botId: string,
+  rootPath?: string,
+): Promise<string> {
+  return store.resolveWorkingDirForNewConversation(botId, rootPath);
 }

--- a/apps/desktop/src/main/im/wecom/workingDirIpc.ts
+++ b/apps/desktop/src/main/im/wecom/workingDirIpc.ts
@@ -1,0 +1,131 @@
+/**
+ * wecomBot 工作目录 IPC 的可注入业务体 — im/index.ts 的 ipcMain.handle 只做
+ * Electron adapter(可信 sender 校验 + 事件解包), 业务与错误映射都在这里,
+ * 便于免 Electron 的 handler 级测试(主路径 + 关键错误路径)。
+ *
+ * 安全不变量:
+ *   - 目录授权只来自 Main 原生选择器, Renderer 不提交路径;
+ *   - 原生弹窗是异步的: 打开期间登出/换号会推进 IM account generation,
+ *     await 归来后必须重校验, 否则 A 账号选的绝对路径会写进 B 账号的
+ *     owner-scoped 配置;
+ *   - 取消选择不是错误, 也不改变配置。
+ */
+
+import { throwIpcError } from '../../utils/ipcValidate';
+import type { WecomChannelSettingsState } from './channelSettings';
+
+export interface WecomWorkingDirIpcDeps {
+  readSettings(): WecomChannelSettingsState;
+  writeWorkingDir(selectedPath: string): WecomChannelSettingsState;
+  resetWorkingDir(): WecomChannelSettingsState;
+  /**
+   * 解析可信宿主窗口并打开 Main 原生目录选择器。
+   * 返回 null = 无有效窗口(同步失败, 不弹窗); Promise 拒绝 = 选择器异常。
+   */
+  showDirectoryPicker(sender: unknown): Promise<{ canceled: boolean; filePaths: string[] } | null>;
+  /** IM account generation 快照(accountBoundary); 前后不一致 = 弹窗期间切号。 */
+  captureGeneration(): number | null;
+  warn(message: string, context?: Record<string, unknown>): void;
+}
+
+export function createWecomWorkingDirIpcHandlers(deps: WecomWorkingDirIpcDeps) {
+  return {
+    getChannelSettings(): WecomChannelSettingsState {
+      return deps.readSettings();
+    },
+
+    async chooseWorkingDirectory(
+      sender: unknown,
+    ): Promise<{ canceled: boolean; state: WecomChannelSettingsState }> {
+      const generationAtOpen = deps.captureGeneration();
+
+      let result: { canceled: boolean; filePaths: string[] } | null = null;
+      try {
+        result = await deps.showDirectoryPicker(sender);
+      } catch (error) {
+        deps.warn('WeCom working directory picker failed', {
+          errorCode: nodeErrorCodeOf(error),
+          errorMessage: error instanceof Error ? error.message : String(error),
+        });
+        throwIpcError('WECOM_WORKING_DIR_UPDATE_FAILED', 'directory picker failed');
+      }
+      if (!result) {
+        throwIpcError('WECOM_WORKING_DIR_UPDATE_FAILED', 'settings window unavailable');
+      }
+
+      const picked = result.canceled || !result.filePaths[0] ? undefined : result.filePaths[0];
+      if (picked === undefined) {
+        return { canceled: true, state: deps.readSettings() };
+      }
+      if (deps.captureGeneration() !== generationAtOpen) {
+        // 弹窗期间登出/换号: 选中的路径属于上一个账号的语境, 不落盘。
+        // 前后代次相等(含双双为 null 的未激活窗口)才允许写。
+        deps.warn('WeCom working directory pick crossed an account switch; dropped');
+        throwIpcError('WECOM_WORKING_DIR_UPDATE_FAILED', 'account changed while picking');
+      }
+      try {
+        return { canceled: false, state: deps.writeWorkingDir(picked) };
+      } catch (error) {
+        deps.warn('failed to save user-picked WeCom working directory', {
+          errorCode: nodeErrorCodeOf(error),
+          errorMessage: error instanceof Error ? error.message : String(error),
+        });
+        throwIpcError('WECOM_WORKING_DIR_UPDATE_FAILED', 'failed to save working directory');
+      }
+    },
+
+    resetWorkingDirectory(): WecomChannelSettingsState {
+      try {
+        return deps.resetWorkingDir();
+      } catch (error) {
+        deps.warn('failed to reset WeCom working directory', {
+          errorCode: nodeErrorCodeOf(error),
+        });
+        throwIpcError('WECOM_WORKING_DIR_UPDATE_FAILED', 'failed to reset working directory');
+      }
+    },
+  };
+}
+
+/** 日志用 Node 错误码(ENOENT/EACCES/...);不含路径与堆栈,避免泄漏用户目录。 */
+function nodeErrorCodeOf(error: unknown): string {
+  return typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    typeof (error as { code?: unknown }).code === 'string'
+    ? (error as { code: string }).code
+    : 'UNKNOWN';
+}
+
+/** ipcMain.handle 的最小投影 — 测试注入 fake, 不拉起 Electron。 */
+export interface IpcHandleSink {
+  handle(channel: string, listener: (event: unknown, ...args: unknown[]) => unknown): unknown;
+}
+
+export type WecomWorkingDirIpcHandlers = ReturnType<typeof createWecomWorkingDirIpcHandlers>;
+
+/**
+ * 注册三个 wecomBot 工作目录 channel。**可信 sender 校验先于一切业务体**
+ * (读设置 / 开弹窗 / 重置) — 这条安全边界由 workingDirIpc.test 的回归用例
+ * 锁住, 不许静默回退。
+ */
+export function registerWecomWorkingDirIpc(options: {
+  ipc: IpcHandleSink;
+  handlers: WecomWorkingDirIpcHandlers;
+  /** main/im/index.ts 注入 assertTrustedAppRendererEvent。 */
+  assertTrustedEvent(event: unknown): void;
+}): void {
+  const { ipc, handlers, assertTrustedEvent } = options;
+  ipc.handle('wecomBot:get-channel-settings', (event) => {
+    assertTrustedEvent(event);
+    return handlers.getChannelSettings();
+  });
+  ipc.handle('wecomBot:choose-working-directory', (event) => {
+    assertTrustedEvent(event);
+    return handlers.chooseWorkingDirectory((event as { sender: unknown }).sender);
+  });
+  ipc.handle('wecomBot:reset-working-directory', (event) => {
+    assertTrustedEvent(event);
+    return handlers.resetWorkingDirectory();
+  });
+}

--- a/apps/desktop/src/main/im/wecom/workingDirIpc.ts
+++ b/apps/desktop/src/main/im/wecom/workingDirIpc.ts
@@ -5,9 +5,13 @@
  *
  * 安全不变量:
  *   - 目录授权只来自 Main 原生选择器, Renderer 不提交路径;
- *   - 原生弹窗是异步的: 打开期间登出/换号会推进 IM account generation,
- *     await 归来后必须重校验, 否则 A 账号选的绝对路径会写进 B 账号的
- *     owner-scoped 配置;
+ *   - 原生弹窗与用户目录探测都是异步的: 打开/探测期间登出/换号会推进 IM
+ *     account generation, **每个异步边界归来后都必须重校验** —— 只在弹窗前
+ *     校验一次是同步时代的老假设, 探测网络盘可能秒级, A 账号选的绝对路径
+ *     会趁探测间隙写进 B 账号的 owner-scoped 配置;
+ *   - 校验/探测(normalizeSelectedDirectory)与落盘(commitWorkingDir)拆开:
+ *     代次二次校验夹在两者之间, 校验通过后的写入只碰本地 userData, 窗口
+ *     收敛到一次本机盘 IO;
  *   - 取消选择不是错误, 也不改变配置。
  */
 
@@ -15,9 +19,15 @@ import { throwIpcError } from '../../utils/ipcValidate';
 import type { WecomChannelSettingsState } from './channelSettings';
 
 export interface WecomWorkingDirIpcDeps {
-  readSettings(): WecomChannelSettingsState;
-  writeWorkingDir(selectedPath: string): WecomChannelSettingsState;
-  resetWorkingDir(): WecomChannelSettingsState;
+  readSettings(): Promise<WecomChannelSettingsState>;
+  /**
+   * 校验并规整用户所选目录 — 异步探测用户盘(可能是网络盘, 挂起只阻塞本
+   * IPC, 不冻结 Main 事件循环), 不落盘。
+   */
+  normalizeSelectedDirectory(selectedPath: string): Promise<string>;
+  /** 落盘已规整目录(只碰本地 userData 配置文件)。 */
+  commitWorkingDir(normalizedDir: string): Promise<WecomChannelSettingsState>;
+  resetWorkingDir(): Promise<WecomChannelSettingsState>;
   /**
    * 解析可信宿主窗口并打开 Main 原生目录选择器。
    * 返回 null = 无有效窗口(同步失败, 不弹窗); Promise 拒绝 = 选择器异常。
@@ -30,7 +40,7 @@ export interface WecomWorkingDirIpcDeps {
 
 export function createWecomWorkingDirIpcHandlers(deps: WecomWorkingDirIpcDeps) {
   return {
-    getChannelSettings(): WecomChannelSettingsState {
+    async getChannelSettings(): Promise<WecomChannelSettingsState> {
       return deps.readSettings();
     },
 
@@ -55,16 +65,34 @@ export function createWecomWorkingDirIpcHandlers(deps: WecomWorkingDirIpcDeps) {
 
       const picked = result.canceled || !result.filePaths[0] ? undefined : result.filePaths[0];
       if (picked === undefined) {
-        return { canceled: true, state: deps.readSettings() };
+        return { canceled: true, state: await deps.readSettings() };
       }
       if (deps.captureGeneration() !== generationAtOpen) {
         // 弹窗期间登出/换号: 选中的路径属于上一个账号的语境, 不落盘。
-        // 前后代次相等(含双双为 null 的未激活窗口)才允许写。
+        // 前后代次相等(含双双为 null 的未激活窗口)才允许继续。
         deps.warn('WeCom working directory pick crossed an account switch; dropped');
         throwIpcError('WECOM_WORKING_DIR_UPDATE_FAILED', 'account changed while picking');
       }
+
+      let normalized: string;
       try {
-        return { canceled: false, state: deps.writeWorkingDir(picked) };
+        // 异步探测用户所选目录(网络盘可能秒级挂起 — 只阻塞本 IPC)。
+        normalized = await deps.normalizeSelectedDirectory(picked);
+      } catch (error) {
+        deps.warn('failed to validate user-picked WeCom working directory', {
+          errorCode: nodeErrorCodeOf(error),
+          errorMessage: error instanceof Error ? error.message : String(error),
+        });
+        throwIpcError('WECOM_WORKING_DIR_UPDATE_FAILED', 'failed to save working directory');
+      }
+      if (deps.captureGeneration() !== generationAtOpen) {
+        // 探测期间登出/换号: 二次校验。校验通过后的提交只碰本地 userData,
+        // 代次校验到落盘之间不再有用户盘 IO。
+        deps.warn('WeCom working directory probe crossed an account switch; dropped');
+        throwIpcError('WECOM_WORKING_DIR_UPDATE_FAILED', 'account changed while probing');
+      }
+      try {
+        return { canceled: false, state: await deps.commitWorkingDir(normalized) };
       } catch (error) {
         deps.warn('failed to save user-picked WeCom working directory', {
           errorCode: nodeErrorCodeOf(error),
@@ -74,9 +102,9 @@ export function createWecomWorkingDirIpcHandlers(deps: WecomWorkingDirIpcDeps) {
       }
     },
 
-    resetWorkingDirectory(): WecomChannelSettingsState {
+    async resetWorkingDirectory(): Promise<WecomChannelSettingsState> {
       try {
-        return deps.resetWorkingDir();
+        return await deps.resetWorkingDir();
       } catch (error) {
         deps.warn('failed to reset WeCom working directory', {
           errorCode: nodeErrorCodeOf(error),

--- a/apps/desktop/src/main/im/wecom/workingDirIpc.ts
+++ b/apps/desktop/src/main/im/wecom/workingDirIpc.ts
@@ -1,136 +1,17 @@
 /**
- * wecomBot 工作目录 IPC 的可注入业务体 — im/index.ts 的 ipcMain.handle 只做
- * Electron adapter(可信 sender 校验 + 事件解包), 业务与错误映射都在这里,
- * 便于免 Electron 的 handler 级测试(主路径 + 关键错误路径)。
- *
- * 安全不变量:
- *   - 目录授权只来自 Main 原生选择器, Renderer 不提交路径;
- *   - 原生弹窗与用户目录探测都是异步的: 打开/探测期间登出/换号会推进 IM
- *     account generation, **每个异步边界归来后都必须重校验** —— 只在弹窗前
- *     校验一次是同步时代的老假设, 探测网络盘可能秒级, A 账号选的绝对路径
- *     会趁探测间隙写进 B 账号的 owner-scoped 配置;
- *   - 校验/探测(normalizeSelectedDirectory)与落盘(commitWorkingDir)拆开:
- *     代次二次校验夹在两者之间, 校验通过后的写入只碰本地 userData, 窗口
- *     收敛到一次本机盘 IO;
- *   - 取消选择不是错误, 也不改变配置。
+ * wecomBot 工作目录 IPC 的**固定 channel 注册层** — 业务体在
+ * shared/channelWorkingDirIpc 工厂(渠道差异经 updateFailedCode/channelLabel
+ * 显式注入, generation 三处校验与日志脱敏都在那里), 这里只保留企微自己的
+ * channel 名与可信 sender 边界, 便于免 Electron 的注册级测试。channel 刻意
+ * 不做成可配置: 每个渠道一份注册, 不产生通用注册器。
  */
 
-import { throwIpcError } from '../../utils/ipcValidate';
-import type { WecomChannelSettingsState } from './channelSettings';
-
-export interface WecomWorkingDirIpcDeps {
-  readSettings(): Promise<WecomChannelSettingsState>;
-  /**
-   * 校验并规整用户所选目录 — 异步探测用户盘(可能是网络盘, 挂起只阻塞本
-   * IPC, 不冻结 Main 事件循环), 不落盘。
-   */
-  normalizeSelectedDirectory(selectedPath: string): Promise<string>;
-  /** 落盘已规整目录(只碰本地 userData 配置文件)。 */
-  commitWorkingDir(normalizedDir: string): Promise<WecomChannelSettingsState>;
-  resetWorkingDir(): Promise<WecomChannelSettingsState>;
-  /**
-   * 解析可信宿主窗口并打开 Main 原生目录选择器。
-   * 返回 null = 无有效窗口(同步失败, 不弹窗); Promise 拒绝 = 选择器异常。
-   */
-  showDirectoryPicker(sender: unknown): Promise<{ canceled: boolean; filePaths: string[] } | null>;
-  /** IM account generation 快照(accountBoundary); 前后不一致 = 弹窗期间切号。 */
-  captureGeneration(): number | null;
-  warn(message: string, context?: Record<string, unknown>): void;
-}
-
-export function createWecomWorkingDirIpcHandlers(deps: WecomWorkingDirIpcDeps) {
-  return {
-    async getChannelSettings(): Promise<WecomChannelSettingsState> {
-      return deps.readSettings();
-    },
-
-    async chooseWorkingDirectory(
-      sender: unknown,
-    ): Promise<{ canceled: boolean; state: WecomChannelSettingsState }> {
-      const generationAtOpen = deps.captureGeneration();
-
-      let result: { canceled: boolean; filePaths: string[] } | null = null;
-      try {
-        result = await deps.showDirectoryPicker(sender);
-      } catch (error) {
-        deps.warn('WeCom working directory picker failed', {
-          errorCode: nodeErrorCodeOf(error),
-          errorMessage: error instanceof Error ? error.message : String(error),
-        });
-        throwIpcError('WECOM_WORKING_DIR_UPDATE_FAILED', 'directory picker failed');
-      }
-      if (!result) {
-        throwIpcError('WECOM_WORKING_DIR_UPDATE_FAILED', 'settings window unavailable');
-      }
-
-      const picked = result.canceled || !result.filePaths[0] ? undefined : result.filePaths[0];
-      if (picked === undefined) {
-        return { canceled: true, state: await deps.readSettings() };
-      }
-      if (deps.captureGeneration() !== generationAtOpen) {
-        // 弹窗期间登出/换号: 选中的路径属于上一个账号的语境, 不落盘。
-        // 前后代次相等(含双双为 null 的未激活窗口)才允许继续。
-        deps.warn('WeCom working directory pick crossed an account switch; dropped');
-        throwIpcError('WECOM_WORKING_DIR_UPDATE_FAILED', 'account changed while picking');
-      }
-
-      let normalized: string;
-      try {
-        // 异步探测用户所选目录(网络盘可能秒级挂起 — 只阻塞本 IPC)。
-        normalized = await deps.normalizeSelectedDirectory(picked);
-      } catch (error) {
-        deps.warn('failed to validate user-picked WeCom working directory', {
-          errorCode: nodeErrorCodeOf(error),
-          errorMessage: error instanceof Error ? error.message : String(error),
-        });
-        throwIpcError('WECOM_WORKING_DIR_UPDATE_FAILED', 'failed to save working directory');
-      }
-      if (deps.captureGeneration() !== generationAtOpen) {
-        // 探测期间登出/换号: 二次校验。校验通过后的提交只碰本地 userData,
-        // 代次校验到落盘之间不再有用户盘 IO。
-        deps.warn('WeCom working directory probe crossed an account switch; dropped');
-        throwIpcError('WECOM_WORKING_DIR_UPDATE_FAILED', 'account changed while probing');
-      }
-      try {
-        return { canceled: false, state: await deps.commitWorkingDir(normalized) };
-      } catch (error) {
-        deps.warn('failed to save user-picked WeCom working directory', {
-          errorCode: nodeErrorCodeOf(error),
-          errorMessage: error instanceof Error ? error.message : String(error),
-        });
-        throwIpcError('WECOM_WORKING_DIR_UPDATE_FAILED', 'failed to save working directory');
-      }
-    },
-
-    async resetWorkingDirectory(): Promise<WecomChannelSettingsState> {
-      try {
-        return await deps.resetWorkingDir();
-      } catch (error) {
-        deps.warn('failed to reset WeCom working directory', {
-          errorCode: nodeErrorCodeOf(error),
-        });
-        throwIpcError('WECOM_WORKING_DIR_UPDATE_FAILED', 'failed to reset working directory');
-      }
-    },
-  };
-}
-
-/** 日志用 Node 错误码(ENOENT/EACCES/...);不含路径与堆栈,避免泄漏用户目录。 */
-function nodeErrorCodeOf(error: unknown): string {
-  return typeof error === 'object' &&
-    error !== null &&
-    'code' in error &&
-    typeof (error as { code?: unknown }).code === 'string'
-    ? (error as { code: string }).code
-    : 'UNKNOWN';
-}
+import type { ChannelWorkingDirIpcHandlers } from '../shared/channelWorkingDirIpc';
 
 /** ipcMain.handle 的最小投影 — 测试注入 fake, 不拉起 Electron。 */
 export interface IpcHandleSink {
   handle(channel: string, listener: (event: unknown, ...args: unknown[]) => unknown): unknown;
 }
-
-export type WecomWorkingDirIpcHandlers = ReturnType<typeof createWecomWorkingDirIpcHandlers>;
 
 /**
  * 注册三个 wecomBot 工作目录 channel。**可信 sender 校验先于一切业务体**
@@ -139,7 +20,7 @@ export type WecomWorkingDirIpcHandlers = ReturnType<typeof createWecomWorkingDir
  */
 export function registerWecomWorkingDirIpc(options: {
   ipc: IpcHandleSink;
-  handlers: WecomWorkingDirIpcHandlers;
+  handlers: ChannelWorkingDirIpcHandlers;
   /** main/im/index.ts 注入 assertTrustedAppRendererEvent。 */
   assertTrustedEvent(event: unknown): void;
 }): void {
@@ -154,6 +35,6 @@ export function registerWecomWorkingDirIpc(options: {
   });
   ipc.handle('wecomBot:reset-working-directory', (event) => {
     assertTrustedEvent(event);
-    return handlers.resetWorkingDirectory();
+    return handlers.resetWorkingDir();
   });
 }

--- a/apps/desktop/src/main/workdir-probe-host/WorkdirProbeHostClient.ts
+++ b/apps/desktop/src/main/workdir-probe-host/WorkdirProbeHostClient.ts
@@ -9,10 +9,15 @@
  */
 
 import type {
+  WorkdirAvailabilityResult,
   WorkdirProbeRequest,
   WorkdirProbeResponse,
   WorkdirProbeResult,
+  WorkdirProbeStatResult,
+  WorkdirValidateResult,
 } from './protocol';
+
+type ProbeJobKind = WorkdirProbeRequest['kind'];
 
 export interface WorkdirProbeChildLike {
   postMessage(message: unknown): void;
@@ -52,6 +57,7 @@ export class WorkdirProbeClientError extends Error {
 
 interface ProbeEntry {
   id: number;
+  kind: ProbeJobKind;
   dir: string;
   key: string;
   deadline: number;
@@ -84,7 +90,26 @@ export class WorkdirProbeHostClient {
     this.maxQueued = deps.maxQueued ?? DEFAULT_MAX_QUEUED;
   }
 
-  probe(dir: string, key: string, timeoutMs: number): Promise<WorkdirProbeResult> {
+  probe(dir: string, key: string, timeoutMs: number): Promise<WorkdirProbeStatResult> {
+    return this.request('probe', dir, key, timeoutMs).then(asStatResult);
+  }
+
+  /** validate: realpath → stat → 'wx' 写探针 → 清理(IM 渠道新选择目录严格校验)。 */
+  validate(dir: string, key: string, timeoutMs: number): Promise<WorkdirValidateResult> {
+    return this.request('validate', dir, key, timeoutMs).then(asValidateResult);
+  }
+
+  /** availability: stat → 'wx' 写探针 → 清理(IM 渠道已保存目录可用性探测)。 */
+  availability(dir: string, key: string, timeoutMs: number): Promise<WorkdirAvailabilityResult> {
+    return this.request('availability', dir, key, timeoutMs).then(asAvailabilityResult);
+  }
+
+  private request(
+    kind: ProbeJobKind,
+    dir: string,
+    key: string,
+    timeoutMs: number,
+  ): Promise<WorkdirProbeResult> {
     if (this.disposed) {
       return Promise.reject(
         new WorkdirProbeClientError('WORKDIR_PROBE_UNAVAILABLE', 'probe host is disposed'),
@@ -102,6 +127,7 @@ export class WorkdirProbeHostClient {
     const probe = new Promise<WorkdirProbeResult>((resolve, reject) => {
       entry = {
         id: this.nextId++,
+        kind,
         dir,
         key,
         deadline: Date.now() + timeoutMs,
@@ -221,7 +247,7 @@ export class WorkdirProbeHostClient {
     entry.probeTimer.unref?.();
 
     const request: WorkdirProbeRequest = {
-      kind: 'probe',
+      kind: entry.kind,
       id: entry.id,
       dir: entry.dir,
     };
@@ -315,13 +341,33 @@ export class WorkdirProbeHostClient {
   }
 }
 
+/** 按 job 收窄结果形态;形态不符(协议违例)按执行边界故障 fail-closed。 */
+function asStatResult(result: WorkdirProbeResult): WorkdirProbeStatResult {
+  if (result.ok === false) return result;
+  return 'isDirectory' in result ? result : { ok: false, code: 'WORKDIR_PROBE_UNAVAILABLE' };
+}
+
+function asValidateResult(result: WorkdirProbeResult): WorkdirValidateResult {
+  if (result.ok === false) return result;
+  return 'realPath' in result ? result : { ok: false, code: 'WORKDIR_PROBE_UNAVAILABLE' };
+}
+
+function asAvailabilityResult(result: WorkdirProbeResult): WorkdirAvailabilityResult {
+  if (result.ok === false) return result;
+  return 'usable' in result ? result : { ok: false, code: 'WORKDIR_PROBE_UNAVAILABLE' };
+}
+
 function isProbeResponse(message: unknown): message is WorkdirProbeResponse {
   if (!message || typeof message !== 'object') return false;
   const candidate = message as Partial<WorkdirProbeResponse>;
   if (candidate.kind !== 'result' || typeof candidate.id !== 'number') return false;
   const result = candidate.result as Partial<WorkdirProbeResult> | undefined;
   if (!result || typeof result.ok !== 'boolean') return false;
-  return result.ok
-    ? typeof (result as { isDirectory?: unknown }).isDirectory === 'boolean'
-    : typeof (result as { code?: unknown }).code === 'string';
+  if (!result.ok) return typeof (result as { code?: unknown }).code === 'string';
+  // ok 分支按 job 种类携带 isDirectory / realPath / usable 之一。
+  return (
+    typeof (result as { isDirectory?: unknown }).isDirectory === 'boolean' ||
+    typeof (result as { realPath?: unknown }).realPath === 'string' ||
+    typeof (result as { usable?: unknown }).usable === 'boolean'
+  );
 }

--- a/apps/desktop/src/main/workdir-probe-host/WorkdirProbeHostClient.ts
+++ b/apps/desktop/src/main/workdir-probe-host/WorkdirProbeHostClient.ts
@@ -6,6 +6,18 @@
  * probe kills only its worker, releasing the slot and the worker's libuv state.
  * Queued probes wait for a slot within the same end-to-end deadline instead of
  * being rejected immediately merely because other shares are slow.
+ *
+ * Capacity isolation (queue wait + execution share one deadline, so a starved
+ * slot is a false timeout): settings-class jobs (validate/availability — IM
+ * channel working-dir probes, fail-soft) jointly occupy at most maxWorkers-1
+ * workers, keeping at least one execution slot for kind='probe' (the remote
+ * session-creation safety gate, remote-workdir-guard). Two wedged settings
+ * probes must not exhaust a healthy remote directory's whole budget and turn
+ * it into REMOTE_WORKDIR_UNAVAILABLE. Queue drain prefers 'probe' so a freed
+ * slot cannot be re-taken by an earlier-queued optional settings probe.
+ * Workers awaiting exit confirmation (terminating) count toward the settings
+ * occupancy regardless of their previous job kind — an unconfirmed exit
+ * releases no capacity to optional probes.
  */
 
 import type {
@@ -76,6 +88,15 @@ interface ProbeWorker {
 const DEFAULT_MAX_WORKERS = 2;
 const DEFAULT_MAX_QUEUED = 32;
 
+/**
+ * 设置类 job(IM 渠道工作目录探测): 失败可宽大降级(设置页「不可用」警告/
+ * 选择器报错), 属可选探测。kind='probe' 是远程新建会话的安全闸
+ * (remote-workdir-guard), 其误报直接阻断远程任务创建, 不归入此类。
+ */
+function isSettingsKind(kind: ProbeJobKind): boolean {
+  return kind === 'validate' || kind === 'availability';
+}
+
 export class WorkdirProbeHostClient {
   private readonly maxWorkers: number;
   private readonly maxQueued: number;
@@ -121,11 +142,6 @@ export class WorkdirProbeHostClient {
     const flightKey = `${kind}\0${key}`;
     const existing = this.inFlightByPath.get(flightKey);
     if (existing) return existing;
-    if (this.queue.length >= this.maxQueued) {
-      return Promise.reject(
-        new WorkdirProbeClientError('WORKDIR_PROBE_UNAVAILABLE', 'probe queue is full'),
-      );
-    }
 
     let entry!: ProbeEntry;
     const probe = new Promise<WorkdirProbeResult>((resolve, reject) => {
@@ -172,14 +188,10 @@ export class WorkdirProbeHostClient {
   }
 
   private schedule(entry: ProbeEntry): void {
-    const idle = this.workers.find((worker) => !worker.active && !worker.terminating);
-    if (idle) {
-      this.startProbe(idle, entry);
-      return;
-    }
-    if (this.workers.length < this.maxWorkers) {
+    if (this.hasFreeWorker() && this.withinSettingsCapacity(entry)) {
+      const idle = this.workers.find((worker) => !worker.active && !worker.terminating);
       try {
-        this.startProbe(this.createWorker(), entry);
+        this.startProbe(idle ?? this.createWorker(), entry);
       } catch (error) {
         entry.reject(
           new WorkdirProbeClientError(
@@ -190,7 +202,19 @@ export class WorkdirProbeHostClient {
       }
       return;
     }
+    // 队列上限只拦「确实需要排队」的请求 — 容量隔离下可能存在空闲的保留槽
+    // (设置类占满 + probe 可立即启动), 可立即运行的 job 不得先被 queue-full
+    // 拒绝。对实际排队项仍是硬限制(enqueue 前判定)。
+    if (this.queue.length >= this.maxQueued) {
+      entry.reject(
+        new WorkdirProbeClientError('WORKDIR_PROBE_UNAVAILABLE', 'probe queue is full'),
+      );
+      return;
+    }
+    this.enqueue(entry);
+  }
 
+  private enqueue(entry: ProbeEntry): void {
     this.queue.push(entry);
     const remainingMs = this.remainingMs(entry);
     entry.queueTimer = setTimeout(() => {
@@ -205,6 +229,44 @@ export class WorkdirProbeHostClient {
       );
     }, remainingMs);
     entry.queueTimer.unref?.();
+  }
+
+  /** 空闲执行槽: 存在 idle worker, 或进程数仍在全局硬上限内可新建。 */
+  private hasFreeWorker(): boolean {
+    if (this.workers.some((worker) => !worker.active && !worker.terminating)) return true;
+    return this.workers.length < this.maxWorkers;
+  }
+
+  /**
+   * 设置类容量判定: validate/availability 的「容量占用」= 活跃设置 job 数 +
+   * 全部 terminating worker 数(**不论**其此前的 job 类型)。
+   *   - 活跃设置 job 直接占执行槽;
+   *   - terminating worker 在 exit 确认前仍占 maxWorkers 名额, 它腾出的槽
+   *     并未真正可回收 — 不计入的话, 设置 job 超时挂起的瞬间新设置 job 就会
+   *     吃掉本应留给远程安全 probe 的保留槽(fail-closed: 未确认退出的进程
+   *     不向可选探测释放任何容量, 可选设置不得扩大其故障半径)。
+   * 合计占用 < maxWorkers-1 才放行, 恒为 kind='probe'(远程新建会话安全闸)
+   * 保留至少 1 个执行槽 — 排队与执行共用同一 deadline, 两个设置探针挂死在
+   * 失联网络盘上时, 安全 probe 仍能立即拿到保留槽, 而不是把预算耗在排队上。
+   */
+  private withinSettingsCapacity(entry: ProbeEntry): boolean {
+    if (!isSettingsKind(entry.kind)) return true;
+    return this.settingsOccupancy() < this.settingsWorkerCap();
+  }
+
+  /** 设置类容量占用: 活跃设置 job + 全部未确认退出的 terminating worker。 */
+  private settingsOccupancy(): number {
+    let count = 0;
+    for (const worker of this.workers) {
+      if (worker.terminating) count += 1;
+      else if (worker.active && isSettingsKind(worker.active.kind)) count += 1;
+    }
+    return count;
+  }
+
+  /** maxWorkers=1 时无从保留(测试/极端配置), 退化为共享; 生产行为不变。 */
+  private settingsWorkerCap(): number {
+    return Math.max(1, this.maxWorkers - 1);
   }
 
   private createWorker(): ProbeWorker {
@@ -323,13 +385,19 @@ export class WorkdirProbeHostClient {
   private drainQueue(): void {
     if (this.disposed) return;
     while (this.queue.length > 0) {
+      const index = this.nextRunnableIndex();
+      if (index < 0) return;
       const idle = this.workers.find((worker) => !worker.active && !worker.terminating);
+      if (!idle && this.workers.length >= this.maxWorkers) {
+        // nextRunnableIndex 已同步校验过空闲槽, 此分支不可达 — 保守起见保持
+        // 条目排队而不是突破进程硬上限。
+        return;
+      }
+      const entry = this.queue.splice(index, 1)[0];
       if (idle) {
-        this.startProbe(idle, this.queue.shift()!);
+        this.startProbe(idle, entry);
         continue;
       }
-      if (this.workers.length >= this.maxWorkers) return;
-      const entry = this.queue.shift()!;
       try {
         this.startProbe(this.createWorker(), entry);
       } catch (error) {
@@ -342,6 +410,23 @@ export class WorkdirProbeHostClient {
         );
       }
     }
+  }
+
+  /**
+   * 下一个可启动排队项的下标: kind='probe' 优先于设置类探针 — worker 释放后
+   * 不得先启动排在前面的可选设置探针、再次占掉保留容量。返回 -1 = 当前无可
+   * 启动项(无空闲槽, 或设置类容量已满需把槽留给 probe)。
+   */
+  private nextRunnableIndex(): number {
+    const probeIndex = this.queue.findIndex((queued) => queued.kind === 'probe');
+    if (probeIndex >= 0) {
+      // probe 只看空闲槽; 有 probe 在队而槽不空时, 设置类同样无槽可占。
+      return this.hasFreeWorker() ? probeIndex : -1;
+    }
+    const head = this.queue[0];
+    if (!head) return -1;
+    if (!this.hasFreeWorker() || !this.withinSettingsCapacity(head)) return -1;
+    return 0;
   }
 }
 

--- a/apps/desktop/src/main/workdir-probe-host/WorkdirProbeHostClient.ts
+++ b/apps/desktop/src/main/workdir-probe-host/WorkdirProbeHostClient.ts
@@ -115,7 +115,11 @@ export class WorkdirProbeHostClient {
         new WorkdirProbeClientError('WORKDIR_PROBE_UNAVAILABLE', 'probe host is disposed'),
       );
     }
-    const existing = this.inFlightByPath.get(key);
+    // single-flight 按「job 类型 + 路径」: 三种 job 的结果形态不同
+    // (isDirectory/realPath/usable), 同路径跨类型复用会把成功结果交给错误的
+    // 收窄函数, 变成 WORKDIR_PROBE_UNAVAILABLE 误拒 — 只合并同类型同路径。
+    const flightKey = `${kind}\0${key}`;
+    const existing = this.inFlightByPath.get(flightKey);
     if (existing) return existing;
     if (this.queue.length >= this.maxQueued) {
       return Promise.reject(
@@ -136,11 +140,11 @@ export class WorkdirProbeHostClient {
       };
       this.schedule(entry);
     }).finally(() => {
-      if (this.inFlightByPath.get(key) === probe) {
-        this.inFlightByPath.delete(key);
+      if (this.inFlightByPath.get(flightKey) === probe) {
+        this.inFlightByPath.delete(flightKey);
       }
     });
-    this.inFlightByPath.set(key, probe);
+    this.inFlightByPath.set(flightKey, probe);
     return probe;
   }
 

--- a/apps/desktop/src/main/workdir-probe-host/__tests__/WorkdirProbeHostClient.test.ts
+++ b/apps/desktop/src/main/workdir-probe-host/__tests__/WorkdirProbeHostClient.test.ts
@@ -176,3 +176,88 @@ describe('WorkdirProbeHostClient', () => {
     client.dispose();
   });
 });
+
+describe('WorkdirProbeHostClient validate/availability(IM 渠道探测 job)', () => {
+  it('runs validate through the pool and returns the resolved real path', async () => {
+    const children: FakeChild[] = [];
+    const client = new WorkdirProbeHostClient({
+      fork: () => {
+        const child = new FakeChild();
+        children.push(child);
+        return child;
+      },
+      log: { warn: vi.fn() },
+    });
+
+    const pending = client.validate('/share/pick', '/share/pick', 1_000);
+    const request = children[0].posted[0];
+    expect(request.kind).toBe('validate');
+    children[0].emit('message', {
+      kind: 'result',
+      id: request.id,
+      result: { ok: true, realPath: '/resolved' },
+    });
+    await expect(pending).resolves.toEqual({ ok: true, realPath: '/resolved' });
+    client.dispose();
+  });
+
+  it('kills a hung validate (dead-share realpath) and frees the slot for a healthy probe', async () => {
+    vi.useFakeTimers();
+    const children: FakeChild[] = [];
+    const client = new WorkdirProbeHostClient({
+      fork: () => {
+        const child = new FakeChild();
+        children.push(child);
+        return child;
+      },
+      log: { warn: vi.fn() },
+      maxWorkers: 1,
+    });
+
+    const hung = client.validate('/share/dead', '/share/dead', 100);
+    const hungFailure = hung.catch((error) => error);
+    const healthy = client.validate('/local/ok', '/local/ok', 200);
+
+    expect(children).toHaveLength(1);
+    expect(children[0].posted[0]).toMatchObject({ kind: 'validate', dir: '/share/dead' });
+
+    await vi.advanceTimersByTimeAsync(100);
+    expect(children[0].kill).toHaveBeenCalled();
+    await expect(hungFailure).resolves.toMatchObject({ code: 'WORKDIR_PROBE_TIMEOUT' });
+    children[0].emit('exit', 0);
+
+    // 槽位释放 → 新 worker 承接排队的健康探测(评审场景: 挂死探针不饿死健康目录)。
+    const worker = children[children.length - 1];
+    expect(worker.posted[0]).toMatchObject({ kind: 'validate', dir: '/local/ok' });
+    worker.emit('message', {
+      kind: 'result',
+      id: worker.posted[0].id,
+      result: { ok: true, realPath: '/local/ok' },
+    });
+    await expect(healthy).resolves.toEqual({ ok: true, realPath: '/local/ok' });
+    client.dispose();
+  });
+
+  it('maps availability results and boundary failures', async () => {
+    const children: FakeChild[] = [];
+    const client = new WorkdirProbeHostClient({
+      fork: () => {
+        const child = new FakeChild();
+        children.push(child);
+        return child;
+      },
+      log: { warn: vi.fn() },
+    });
+
+    const pending = client.availability('/share/a', '/share/a', 1_000);
+    const request = children[0].posted[0];
+    expect(request.kind).toBe('availability');
+    children[0].emit('message', {
+      kind: 'result',
+      id: request.id,
+      result: { ok: true, usable: true },
+    });
+    await expect(pending).resolves.toEqual({ ok: true, usable: true });
+    client.dispose();
+  });
+});

--- a/apps/desktop/src/main/workdir-probe-host/__tests__/WorkdirProbeHostClient.test.ts
+++ b/apps/desktop/src/main/workdir-probe-host/__tests__/WorkdirProbeHostClient.test.ts
@@ -309,20 +309,25 @@ describe('WorkdirProbeHostClient single-flight 按 job 类型隔离', () => {
     const validate = client.validate('/share/a', '/share/a', 1_000);
     const avail = client.availability('/share/a', '/share/a', 1_000);
 
-    expect(children).toHaveLength(2);
+    // 设置类容量 = maxWorkers-1: 第二个设置 job 先排队(见容量隔离用例),
+    // 不与第一个并行占满两个 worker。
+    expect(children).toHaveLength(1);
     expect(children[0].posted[0].kind).toBe('validate');
-    expect(children[1].posted[0].kind).toBe('availability');
     children[0].emit('message', {
       kind: 'result',
       id: children[0].posted[0].id,
       result: { ok: true, realPath: '/resolved' },
     });
-    children[1].emit('message', {
+    await expect(validate).resolves.toEqual({ ok: true, realPath: '/resolved' });
+
+    // 槽位归还后, 排队的 availability 在同一 worker 上启动(仍是两次独立执行)。
+    expect(children).toHaveLength(1);
+    expect(children[0].posted[1].kind).toBe('availability');
+    children[0].emit('message', {
       kind: 'result',
-      id: children[1].posted[0].id,
+      id: children[0].posted[1].id,
       result: { ok: true, usable: true },
     });
-    await expect(validate).resolves.toEqual({ ok: true, realPath: '/resolved' });
     await expect(avail).resolves.toEqual({ ok: true, usable: true });
     client.dispose();
   });
@@ -350,6 +355,191 @@ describe('WorkdirProbeHostClient single-flight 按 job 类型隔离', () => {
       { ok: true, realPath: '/resolved' },
       { ok: true, realPath: '/resolved' },
     ]);
+    client.dispose();
+  });
+});
+
+describe('WorkdirProbeHostClient 容量隔离(设置类探针不得挤占安全 probe 保留槽)', () => {
+  function createClient(options: { maxWorkers?: number; maxQueued?: number } = {}) {
+    const children: FakeChild[] = [];
+    const client = new WorkdirProbeHostClient({
+      fork: () => {
+        const child = new FakeChild();
+        children.push(child);
+        return child;
+      },
+      log: { warn: vi.fn() },
+      ...options,
+    });
+    return { client, children };
+  }
+
+  function respond(
+    child: FakeChild,
+    index: number,
+    result: { ok: true; isDirectory: boolean } | { ok: true; realPath: string } | { ok: true; usable: boolean },
+  ): void {
+    child.emit('message', { kind: 'result', id: child.posted[index].id, result });
+  }
+
+  it('两个设置类 job 同时提交: 第二个排队, 不与第一个并行占满 worker', async () => {
+    const { client, children } = createClient();
+
+    const validate = client.validate('/share/a', '/share/a', 5_000);
+    const availability = client.availability('/share/b', '/share/b', 5_000);
+
+    expect(children).toHaveLength(1);
+    expect(children[0].posted[0]).toMatchObject({ kind: 'validate', dir: '/share/a' });
+    respond(children[0], 0, { ok: true, realPath: '/resolved' });
+    await expect(validate).resolves.toEqual({ ok: true, realPath: '/resolved' });
+
+    // 槽位归还后第二个设置 job 才启动(同一 worker 顺序复用)。
+    expect(children).toHaveLength(1);
+    expect(children[0].posted[1]).toMatchObject({ kind: 'availability', dir: '/share/b' });
+    respond(children[0], 1, { ok: true, usable: true });
+    await expect(availability).resolves.toEqual({ ok: true, usable: true });
+    client.dispose();
+  });
+
+  it('设置探针挂死时, 后来的远程安全 probe 立即使用保留槽并成功', async () => {
+    // P2: 两个设置探针最多占 maxWorkers-1=1 个 worker; 即使第一个挂在失联
+    // 网络盘上, 远程新建会话的安全 probe 也不排队, 直接用保留槽 — 不会把
+    // 5s 预算耗在排队上而误报 REMOTE_WORKDIR_UNAVAILABLE。
+    const { client, children } = createClient();
+
+    const hung = client.validate('/share/dead', '/share/dead', 5_000);
+    const hungFailure = hung.catch((error) => error);
+    const queuedSettings = client.availability('/share/dead2', '/share/dead2', 5_000);
+    const queuedFailure = queuedSettings.catch((error) => error);
+    expect(children).toHaveLength(1);
+
+    const safety = client.probe('/remote/healthy', '/remote/healthy', 5_000);
+    expect(children).toHaveLength(2);
+    expect(children[1].posted[0]).toMatchObject({ kind: 'probe', dir: '/remote/healthy' });
+    children[1].respond();
+    await expect(safety).resolves.toEqual({ ok: true, isDirectory: true });
+
+    // 安全 probe 结论到手时, 挂死的设置探针与排队的设置探针均未影响它。
+    expect(children[0].posted).toHaveLength(1);
+    expect(hungFailure).toBeInstanceOf(Promise);
+    expect(queuedFailure).toBeInstanceOf(Promise);
+    client.dispose();
+  });
+
+  it('队列同时有设置类与安全 probe 时, 释放的槽优先服务 probe', async () => {
+    const { client, children } = createClient();
+
+    const settingsA = client.validate('/share/a', '/share/a', 5_000); // worker1, 设置容量占满
+    const busyProbe = client.probe('/share/busy', '/share/busy', 5_000); // worker2
+    expect(children).toHaveLength(2);
+    const queuedSettings = client.availability('/share/b', '/share/b', 5_000); // 容量满 → 排队(在前)
+    const queuedProbe = client.probe('/remote/next', '/remote/next', 5_000); // 无空闲槽 → 排队(在后)
+
+    // worker2 释放: 必须先启动排在后面的 probe, 而不是排在前面的设置探针。
+    respond(children[1], 0, { ok: true, isDirectory: true });
+    await expect(busyProbe).resolves.toEqual({ ok: true, isDirectory: true });
+    expect(children[1].posted[1]).toMatchObject({ kind: 'probe', dir: '/remote/next' });
+    expect(children[0].posted).toHaveLength(1); // 设置探针仍在队列
+
+    // 设置容量释放(worker1 归还)后, 排队的设置探针才启动 — probe 优先不造成
+    // 设置类饥饿。
+    respond(children[0], 0, { ok: true, realPath: '/resolved' });
+    await expect(settingsA).resolves.toEqual({ ok: true, realPath: '/resolved' });
+    expect(children[0].posted[1]).toMatchObject({ kind: 'availability', dir: '/share/b' });
+
+    respond(children[0], 1, { ok: true, usable: true });
+    respond(children[1], 1, { ok: true, isDirectory: true });
+    await expect(queuedSettings).resolves.toEqual({ ok: true, usable: true });
+    await expect(queuedProbe).resolves.toEqual({ ok: true, isDirectory: true });
+    client.dispose();
+  });
+
+  it('设置 job 超时且进程未确认退出时, 保留槽不转移给新设置 job', async () => {
+    // terminating worker 在 exit 前仍占 maxWorkers 名额 — 它若原是设置 job,
+    // 保留容量必须继续被占用: 新设置 job 排队, 不得创建第二个 worker 吃掉
+    // 远程 probe 的保留槽; 直到 exit 确认后设置才可运行。
+    vi.useFakeTimers();
+    const { client, children } = createClient();
+
+    const hung = client.validate('/share/dead', '/share/dead', 100);
+    const hungFailure = hung.catch((error) => error);
+    children[0].killResult = false; // kill 未确认, 进程滞留
+    await vi.advanceTimersByTimeAsync(100);
+    await expect(hungFailure).resolves.toMatchObject({ code: 'WORKDIR_PROBE_TIMEOUT' });
+    expect(children).toHaveLength(1);
+
+    const blockedSettings = client.availability('/share/blocked', '/share/blocked', 5_000);
+    expect(children).toHaveLength(1); // 不为设置类新建第二个 worker
+
+    const safety = client.probe('/remote/healthy', '/remote/healthy', 5_000);
+    expect(children).toHaveLength(2);
+    expect(children[1].posted[0]).toMatchObject({ kind: 'probe', dir: '/remote/healthy' });
+    children[1].respond();
+    await expect(safety).resolves.toEqual({ ok: true, isDirectory: true });
+
+    // 未确认退出期间, 空闲的保留槽也不交给设置类(occupancy 仍含 terminating)。
+    expect(children[1].posted).toHaveLength(1);
+
+    children[0].emit('exit', 0);
+    expect(children[1].posted[1]).toMatchObject({ kind: 'availability', dir: '/share/blocked' });
+    respond(children[1], 1, { ok: true, usable: true });
+    await expect(blockedSettings).resolves.toEqual({ ok: true, usable: true });
+    client.dispose();
+  });
+
+  it('terminating 的 probe worker 同样收紧设置容量(不扩大未确认退出的故障半径)', async () => {
+    // 若只按「terminating 前的 job 类型」计数, 挂死的 probe 留下的空槽会被
+    // 可选设置占走, 后续远程 probe 反而无槽 — 未确认退出的故障半径被设置
+    // 放大。任何 terminating worker 都收紧设置容量。
+    vi.useFakeTimers();
+    const { client, children } = createClient();
+
+    const hungProbe = client.probe('/share/dead', '/share/dead', 100);
+    const hungFailure = hungProbe.catch((error) => error);
+    children[0].killResult = false;
+    await vi.advanceTimersByTimeAsync(100);
+    await expect(hungFailure).resolves.toMatchObject({ code: 'WORKDIR_PROBE_TIMEOUT' });
+
+    const blockedSettings = client.validate('/share/pick', '/share/pick', 5_000);
+    expect(children).toHaveLength(1);
+
+    const safety = client.probe('/remote/healthy', '/remote/healthy', 5_000);
+    expect(children).toHaveLength(2);
+    expect(children[1].posted[0]).toMatchObject({ kind: 'probe', dir: '/remote/healthy' });
+    children[1].respond();
+    await expect(safety).resolves.toEqual({ ok: true, isDirectory: true });
+
+    children[0].emit('exit', 0);
+    expect(children[1].posted[1]).toMatchObject({ kind: 'validate', dir: '/share/pick' });
+    respond(children[1], 1, { ok: true, realPath: '/share/pick' });
+    await expect(blockedSettings).resolves.toEqual({ ok: true, realPath: '/share/pick' });
+    client.dispose();
+  });
+
+  it('队列满时, 可立即运行的 probe 不被 queue-full 拒绝; 新设置 job 仍被硬拒', async () => {
+    // 容量隔离下可能「设置 active + 设置队列满 + 保留槽空闲」: probe 本可
+    // 立即启动, 不得先撞 queue-full; 上限只拦确实需要排队的请求。
+    const { client, children } = createClient({ maxWorkers: 2, maxQueued: 1 });
+
+    const activeSettings = client.validate('/share/a', '/share/a', 5_000);
+    const queuedSettings = client.availability('/share/b', '/share/b', 5_000);
+    expect(children).toHaveLength(1);
+
+    const safety = client.probe('/remote/healthy', '/remote/healthy', 5_000);
+    expect(children).toHaveLength(2);
+    expect(children[1].posted[0]).toMatchObject({ kind: 'probe', dir: '/remote/healthy' });
+    children[1].respond();
+    await expect(safety).resolves.toEqual({ ok: true, isDirectory: true });
+
+    // 队列仍满且设置容量已占: 新设置 job 按原语义被 queue-full 拒绝。
+    const rejected = client.validate('/share/c', '/share/c', 5_000);
+    await expect(rejected).rejects.toMatchObject({ code: 'WORKDIR_PROBE_UNAVAILABLE' });
+
+    respond(children[0], 0, { ok: true, realPath: '/resolved' });
+    await expect(activeSettings).resolves.toEqual({ ok: true, realPath: '/resolved' });
+    expect(children[0].posted[1]).toMatchObject({ kind: 'availability', dir: '/share/b' });
+    respond(children[0], 1, { ok: true, usable: true });
+    await expect(queuedSettings).resolves.toEqual({ ok: true, usable: true });
     client.dispose();
   });
 });

--- a/apps/desktop/src/main/workdir-probe-host/__tests__/WorkdirProbeHostClient.test.ts
+++ b/apps/desktop/src/main/workdir-probe-host/__tests__/WorkdirProbeHostClient.test.ts
@@ -261,3 +261,95 @@ describe('WorkdirProbeHostClient validate/availability(IM 渠道探测 job)', ()
     client.dispose();
   });
 });
+
+describe('WorkdirProbeHostClient single-flight 按 job 类型隔离', () => {
+  it('同路径并发 probe + availability: 各自获得正确形态的结果, 互不复用', async () => {
+    const children: FakeChild[] = [];
+    const client = new WorkdirProbeHostClient({
+      fork: () => {
+        const child = new FakeChild();
+        children.push(child);
+        return child;
+      },
+      log: { warn: vi.fn() },
+    });
+
+    const stat = client.probe('/share/a', '/share/a', 1_000);
+    const avail = client.availability('/share/a', '/share/a', 1_000);
+
+    expect(children).toHaveLength(2);
+    expect(children[0].posted[0].kind).toBe('probe');
+    expect(children[1].posted[0].kind).toBe('availability');
+    children[0].emit('message', {
+      kind: 'result',
+      id: children[0].posted[0].id,
+      result: { ok: true, isDirectory: true },
+    });
+    children[1].emit('message', {
+      kind: 'result',
+      id: children[1].posted[0].id,
+      result: { ok: true, usable: false },
+    });
+    await expect(stat).resolves.toEqual({ ok: true, isDirectory: true });
+    await expect(avail).resolves.toEqual({ ok: true, usable: false });
+    client.dispose();
+  });
+
+  it('同路径并发 validate + availability: 独立执行, 不跨类型复用', async () => {
+    const children: FakeChild[] = [];
+    const client = new WorkdirProbeHostClient({
+      fork: () => {
+        const child = new FakeChild();
+        children.push(child);
+        return child;
+      },
+      log: { warn: vi.fn() },
+    });
+
+    const validate = client.validate('/share/a', '/share/a', 1_000);
+    const avail = client.availability('/share/a', '/share/a', 1_000);
+
+    expect(children).toHaveLength(2);
+    expect(children[0].posted[0].kind).toBe('validate');
+    expect(children[1].posted[0].kind).toBe('availability');
+    children[0].emit('message', {
+      kind: 'result',
+      id: children[0].posted[0].id,
+      result: { ok: true, realPath: '/resolved' },
+    });
+    children[1].emit('message', {
+      kind: 'result',
+      id: children[1].posted[0].id,
+      result: { ok: true, usable: true },
+    });
+    await expect(validate).resolves.toEqual({ ok: true, realPath: '/resolved' });
+    await expect(avail).resolves.toEqual({ ok: true, usable: true });
+    client.dispose();
+  });
+
+  it('同类型同路径仍然复用(不放大探测次数)', async () => {
+    const children: FakeChild[] = [];
+    const client = new WorkdirProbeHostClient({
+      fork: () => {
+        const child = new FakeChild();
+        children.push(child);
+        return child;
+      },
+      log: { warn: vi.fn() },
+    });
+
+    const first = client.validate('/share/a', '/share/a', 1_000);
+    const second = client.validate('/share/a', '/share/a', 1_000);
+    expect(children).toHaveLength(1);
+    children[0].emit('message', {
+      kind: 'result',
+      id: children[0].posted[0].id,
+      result: { ok: true, realPath: '/resolved' },
+    });
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      { ok: true, realPath: '/resolved' },
+      { ok: true, realPath: '/resolved' },
+    ]);
+    client.dispose();
+  });
+});

--- a/apps/desktop/src/main/workdir-probe-host/__tests__/workdirProbeHostProcess.test.ts
+++ b/apps/desktop/src/main/workdir-probe-host/__tests__/workdirProbeHostProcess.test.ts
@@ -65,7 +65,8 @@ describe('validate job(realpath → stat → wx 探针 → 清理)', () => {
   it('可写目录回传解析后的真实路径且不留探针残留', async () => {
     const dir = path.join(root, 'project');
     fs.mkdirSync(dir);
-    await expect(runValidateJob(dir)).resolves.toEqual({ ok: true, realPath: dir });
+    const expectedRealPath = await fs.promises.realpath(dir);
+    await expect(runValidateJob(dir)).resolves.toEqual({ ok: true, realPath: expectedRealPath });
     expect(fs.readdirSync(dir)).toEqual([]);
   });
 
@@ -100,9 +101,7 @@ describe('availability job(stat → wx 探针 → 清理)', () => {
 
     failState.rmFailuresRemaining = 1;
     await expect(runAvailabilityJob(dir)).resolves.toEqual({ ok: true, usable: true });
-    const residue = fs
-      .readdirSync(dir)
-      .find((n) => n.startsWith('.cindy-workdir-probe-'))!;
+    const residue = fs.readdirSync(dir).find((n) => n.startsWith('.cindy-workdir-probe-'))!;
     expect(residue).toBeTruthy(); // 0 字节残留, 不重试不扫描
   });
 

--- a/apps/desktop/src/main/workdir-probe-host/__tests__/workdirProbeHostProcess.test.ts
+++ b/apps/desktop/src/main/workdir-probe-host/__tests__/workdirProbeHostProcess.test.ts
@@ -1,0 +1,119 @@
+/**
+ * workdirProbeHostProcess worker 函数的单测(纯函数直测, 不拉起子进程)。
+ * 'wx' 独占创建/只删本次确认创建的探针/不前缀扫描的所有权纪律与
+ * im/shared 的进程内执行器同源, 这里锁子进程侧的同一套语义。
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const failState = vi.hoisted(() => ({
+  probeWriteEexistNext: false,
+  rmFailuresRemaining: 0,
+  writeFileCalls: [] as string[],
+  rmCalls: [] as string[],
+}));
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>();
+  const isProbe = (target: string) => target.includes('.cindy-workdir-probe-');
+  return {
+    ...actual,
+    async writeFile(
+      target: Parameters<typeof actual.writeFile>[0],
+      data: Parameters<typeof actual.writeFile>[1],
+      options?: Parameters<typeof actual.writeFile>[2],
+    ) {
+      failState.writeFileCalls.push(String(target));
+      if (failState.probeWriteEexistNext && isProbe(String(target))) {
+        failState.probeWriteEexistNext = false;
+        await actual.writeFile(target, 'foreign data', 'utf8');
+        throw Object.assign(new Error('EEXIST'), { code: 'EEXIST' }) as NodeJS.ErrnoException;
+      }
+      return actual.writeFile(target, data, options);
+    },
+    async rm(target: string, options?: import('node:fs').RmOptions) {
+      failState.rmCalls.push(target);
+      if (failState.rmFailuresRemaining > 0) {
+        failState.rmFailuresRemaining -= 1;
+        throw Object.assign(new Error('EBUSY rm'), { code: 'EBUSY' }) as NodeJS.ErrnoException;
+      }
+      return actual.rm(target, options);
+    },
+  };
+});
+
+import { runAvailabilityJob, runValidateJob, runWriteProbe } from '../workdirProbeHostProcess';
+
+let root = '';
+
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'cindy-probe-child-'));
+  failState.probeWriteEexistNext = false;
+  failState.rmFailuresRemaining = 0;
+  failState.writeFileCalls.length = 0;
+  failState.rmCalls.length = 0;
+});
+
+afterEach(() => {
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe('validate job(realpath → stat → wx 探针 → 清理)', () => {
+  it('可写目录回传解析后的真实路径且不留探针残留', async () => {
+    const dir = path.join(root, 'project');
+    fs.mkdirSync(dir);
+    await expect(runValidateJob(dir)).resolves.toEqual({ ok: true, realPath: dir });
+    expect(fs.readdirSync(dir)).toEqual([]);
+  });
+
+  it('文件与不存在的路径分别收口为 NOT_DIRECTORY 与原生码', async () => {
+    const file = path.join(root, 'now-a-file');
+    fs.writeFileSync(file, 'x');
+    await expect(runValidateJob(file)).resolves.toEqual({ ok: false, code: 'NOT_DIRECTORY' });
+    const missing = await runValidateJob(path.join(root, 'missing'));
+    expect(missing).toEqual({ ok: false, code: 'ENOENT' });
+  });
+
+  it('写探针独占碰撞(EEXIST)收口为 NOT_WRITABLE, 碰撞文件原样保留', async () => {
+    const dir = path.join(root, 'project');
+    fs.mkdirSync(dir);
+    failState.probeWriteEexistNext = true;
+    await expect(runValidateJob(dir)).resolves.toEqual({ ok: false, code: 'NOT_WRITABLE' });
+    const collided = failState.writeFileCalls.find((c) => c.includes('.cindy-workdir-probe-'))!;
+    expect(fs.readFileSync(collided, 'utf8')).toBe('foreign data');
+    expect(failState.rmCalls).toEqual([]);
+  });
+});
+
+describe('availability job(stat → wx 探针 → 清理)', () => {
+  it('可写目录 usable, 文件 NOT_DIRECTORY, rm 失败接受残留', async () => {
+    const dir = path.join(root, 'avail');
+    fs.mkdirSync(dir);
+    await expect(runAvailabilityJob(dir)).resolves.toEqual({ ok: true, usable: true });
+
+    const file = path.join(root, 'now-a-file');
+    fs.writeFileSync(file, 'x');
+    await expect(runAvailabilityJob(file)).resolves.toEqual({ ok: false, code: 'NOT_DIRECTORY' });
+
+    failState.rmFailuresRemaining = 1;
+    await expect(runAvailabilityJob(dir)).resolves.toEqual({ ok: true, usable: true });
+    const residue = fs
+      .readdirSync(dir)
+      .find((n) => n.startsWith('.cindy-workdir-probe-'))!;
+    expect(residue).toBeTruthy(); // 0 字节残留, 不重试不扫描
+  });
+
+  it('runWriteProbe 只删除本次确认创建的探针, 用户同前缀文件不触碰', async () => {
+    const dir = path.join(root, 'discipline');
+    fs.mkdirSync(dir);
+    const userNote = path.join(dir, '.cindy-workdir-probe-user-note');
+    fs.writeFileSync(userNote, 'user data');
+
+    expect(await runWriteProbe(dir)).toBe(true);
+    expect(fs.readFileSync(userNote, 'utf8')).toBe('user data');
+    expect(fs.readdirSync(dir)).toEqual(['.cindy-workdir-probe-user-note']);
+  });
+});

--- a/apps/desktop/src/main/workdir-probe-host/channelProbeExecutor.ts
+++ b/apps/desktop/src/main/workdir-probe-host/channelProbeExecutor.ts
@@ -1,0 +1,63 @@
+/**
+ * IM 渠道工作目录探测的 utility-process 执行器。
+ *
+ * 把渠道 store 的用户目录探测(realpath/stat/'wx' 写探针/清理)接到
+ * workdir-probe-host 的 worker 池上: 失联网络盘的挂死 IO 被隔离在子进程,
+ * 超时即终止回收, 不占 Electron main 的 libuv 线程池。仅由 im/index.ts
+ * (Electron main)装配使用; 引入本模块即引入 electron。
+ */
+
+import { WorkdirProbeClientError } from './WorkdirProbeHostClient';
+import { workdirProbeHostClient } from './index';
+import type {
+  ChannelUserDirProbeExecutor,
+  UserDirAvailabilityOutcome,
+  UserDirValidateOutcome,
+} from '../im/shared/channelWorkingDirSettings';
+
+function boundaryErrorCode(error: unknown): string {
+  if (error instanceof WorkdirProbeClientError) {
+    return error.code === 'WORKDIR_PROBE_TIMEOUT' ? 'PROBE_TIMEOUT' : 'PROBE_UNAVAILABLE';
+  }
+  return 'PROBE_UNAVAILABLE';
+}
+
+export function createWorkdirProbeHostExecutor(): ChannelUserDirProbeExecutor {
+  return {
+    async validate(selectedPath: string, timeoutMs: number): Promise<UserDirValidateOutcome> {
+      try {
+        const result = await workdirProbeHostClient.validate(selectedPath, selectedPath, timeoutMs);
+        if (result.ok) {
+          return typeof result.realPath === 'string'
+            ? { ok: true, realPath: result.realPath }
+            : { ok: false, code: 'PROBE_UNAVAILABLE' };
+        }
+        // NOT_DIRECTORY / NOT_WRITABLE / 原生 fs 码原样交给 store 映射渠道码。
+        return { ok: false, code: result.code };
+      } catch (error) {
+        return { ok: false, code: boundaryErrorCode(error) };
+      }
+    },
+    async availability(candidate: string, timeoutMs: number): Promise<UserDirAvailabilityOutcome> {
+      try {
+        const result = await workdirProbeHostClient.availability(
+          candidate,
+          candidate,
+          timeoutMs,
+        );
+        if (result.ok) {
+          return typeof result.usable === 'boolean'
+            ? { ok: true, usable: result.usable }
+            : { ok: false, code: 'PROBE_UNAVAILABLE' };
+        }
+        if (result.code === 'NOT_DIRECTORY') {
+          // 不是目录 = 宽大降级为不可用, 不算执行边界故障。
+          return { ok: true, usable: false };
+        }
+        return { ok: false, code: result.code };
+      } catch (error) {
+        return { ok: false, code: boundaryErrorCode(error) };
+      }
+    },
+  };
+}

--- a/apps/desktop/src/main/workdir-probe-host/protocol.ts
+++ b/apps/desktop/src/main/workdir-probe-host/protocol.ts
@@ -1,20 +1,36 @@
 /**
  * workdir probe host wire format.
  *
- * The utility process only returns a boolean or a stable filesystem error code.
- * It never returns the probed path or the host error message to avoid leaking
- * local filesystem details across the process boundary.
+ * The utility process only returns booleans, a resolved path the parent itself
+ * asked to validate, or a stable filesystem error code. It never returns host
+ * error messages to avoid leaking local filesystem details across the process
+ * boundary.
+ *
+ * Job kinds:
+ *   - probe:        stat(dir) → isDirectory(远程会话创建的目录可用性守卫)
+ *   - validate:     realpath → stat → 'wx' 写探针 → 清理(IM 渠道**新选择**目录
+ *                   的严格校验)。realPath 是父进程自己提交的路径经符号链接
+ *                   解析后的形式, 回传给提交者不构成越权泄漏。
+ *   - availability: stat → 'wx' 写探针 → 清理(IM 渠道**已保存**目录的可用性
+ *                   探测, 失败宽大降级为不可用)。
  */
 
 export interface WorkdirProbeRequest {
-  kind: 'probe';
+  kind: 'probe' | 'validate' | 'availability';
   id: number;
   dir: string;
 }
 
 export type WorkdirProbeResult =
   | { ok: true; isDirectory: boolean }
+  | { ok: true; realPath: string }
+  | { ok: true; usable: boolean }
   | { ok: false; code: string };
+
+/** 各 job 的窄返回形态(客户端按 job 收口, 形态不符按执行边界故障 fail-closed)。 */
+export type WorkdirProbeStatResult = { ok: true; isDirectory: boolean } | { ok: false; code: string };
+export type WorkdirValidateResult = { ok: true; realPath: string } | { ok: false; code: string };
+export type WorkdirAvailabilityResult = { ok: true; usable: boolean } | { ok: false; code: string };
 
 export interface WorkdirProbeResponse {
   kind: 'result';

--- a/apps/desktop/src/main/workdir-probe-host/workdirProbeHostProcess.ts
+++ b/apps/desktop/src/main/workdir-probe-host/workdirProbeHostProcess.ts
@@ -2,11 +2,24 @@
  * Dedicated Electron utility-process entry for directory probes.
  *
  * The main process assigns at most one request at a time to each host. A stuck
- * UNC/SMB stat is cancelled by terminating this process, never by accumulating
- * uncancellable libuv work in Electron's main process.
+ * UNC/SMB stat/realpath/write is cancelled by terminating this process, never
+ * by accumulating uncancellable libuv work in Electron's main process.
+ *
+ * 'validate' / 'availability' carry the IM channel working-directory probe
+ * discipline (six-round review rulings) — the ownership rules travel with the
+ * job into the child:
+ *   - probe file is created exclusively ('wx'); a collision means the path
+ *     belongs to someone else and is left untouched;
+ *   - only a file this invocation confirmed creating is ever removed;
+ *   - no prefix scans, no delayed retries; a killed/late probe accepts 0-byte
+ *     UUID residue.
+ * The worker functions are exported pure so vitest can exercise the discipline
+ * in-process (same pattern as cindy-brain/ghostSnapshotWorkerProcess).
  */
 
-import { stat } from 'node:fs/promises';
+import { realpath, rm, stat, writeFile } from 'node:fs/promises';
+import { randomUUID } from 'node:crypto';
+import path from 'node:path';
 
 import type {
   WorkdirProbeRequest,
@@ -21,35 +34,103 @@ interface ParentPortLike {
 
 const parentPort = (process as unknown as { parentPort?: ParentPortLike }).parentPort;
 
+const WORKDIR_PROBE_PREFIX = '.cindy-workdir-probe-';
+
 function filesystemErrorCode(error: unknown): string {
   return error && typeof error === 'object' && typeof (error as { code?: unknown }).code === 'string'
     ? (error as { code: string }).code
     : 'UNKNOWN';
 }
 
+/**
+ * 'wx' 独占创建 + 删除一次性 0 字节探针 — 只删除本次调用确认创建的文件;
+ * 任何失败按 false 收口(父进程据此判定不可用/不可写)。
+ */
+export async function runWriteProbe(candidate: string): Promise<boolean> {
+  const probe = path.join(candidate, `${WORKDIR_PROBE_PREFIX}${randomUUID()}`);
+  let created = false;
+  try {
+    if (!(await stat(candidate)).isDirectory()) return false;
+    await writeFile(probe, '', { flag: 'wx' });
+    created = true;
+    return true;
+  } catch {
+    return false;
+  } finally {
+    if (created) {
+      try {
+        await rm(probe, { force: true });
+      } catch {
+        // 锁挡住删除: 接受 0 字节残留 — 不记住路径, 不重试, 不扫描。
+      }
+    }
+  }
+}
+
+/** validate: realpath → stat → 'wx' 写探针 → 清理;成功回传解析后的真实路径。 */
+export async function runValidateJob(dir: string): Promise<WorkdirProbeResult> {
+  let realPath: string;
+  try {
+    realPath = await realpath(dir);
+  } catch (error) {
+    return { ok: false, code: filesystemErrorCode(error) };
+  }
+  if (!(await stat(realPath).then((s) => s.isDirectory(), () => false))) {
+    return { ok: false, code: 'NOT_DIRECTORY' };
+  }
+  if (!(await runWriteProbe(realPath))) {
+    return { ok: false, code: 'NOT_WRITABLE' };
+  }
+  return { ok: true, realPath };
+}
+
+/** availability: stat → 'wx' 写探针 → 清理;失败宽大收口为不可用。 */
+export async function runAvailabilityJob(dir: string): Promise<WorkdirProbeResult> {
+  if (!(await stat(dir).then((s) => s.isDirectory(), () => false))) {
+    return { ok: false, code: 'NOT_DIRECTORY' };
+  }
+  return { ok: true, usable: await runWriteProbe(dir) };
+}
+
+export async function runProbeJob(dir: string): Promise<WorkdirProbeResult> {
+  return stat(dir).then<WorkdirProbeResult, WorkdirProbeResult>(
+    (entry) => ({ ok: true, isDirectory: entry.isDirectory() }),
+    (error) => ({ ok: false, code: filesystemErrorCode(error) }),
+  );
+}
+
+export function runRequestJob(request: WorkdirProbeRequest): Promise<WorkdirProbeResult> {
+  switch (request.kind) {
+    case 'probe':
+      return runProbeJob(request.dir);
+    case 'validate':
+      return runValidateJob(request.dir);
+    case 'availability':
+      return runAvailabilityJob(request.dir);
+  }
+}
+
 if (parentPort) {
   parentPort.on('message', (event) => {
-    const request = event.data as Partial<WorkdirProbeRequest>;
+    const message = event.data as Partial<WorkdirProbeRequest>;
     if (
-      request.kind !== 'probe' ||
-      typeof request.id !== 'number' ||
-      typeof request.dir !== 'string' ||
-      request.dir.length === 0
+      (message.kind !== 'probe' &&
+        message.kind !== 'validate' &&
+        message.kind !== 'availability') ||
+      typeof message.id !== 'number' ||
+      typeof message.dir !== 'string' ||
+      message.dir.length === 0
     ) {
       return;
     }
-    void stat(request.dir)
-      .then<WorkdirProbeResult, WorkdirProbeResult>(
-        (entry) => ({ ok: true, isDirectory: entry.isDirectory() }),
-        (error) => ({ ok: false, code: filesystemErrorCode(error) }),
-      )
-      .then((result) => {
-        const response: WorkdirProbeResponse = {
-          kind: 'result',
-          id: request.id!,
-          result,
-        };
-        parentPort.postMessage(response);
-      });
+    const request: WorkdirProbeRequest = { kind: message.kind, id: message.id, dir: message.dir };
+    void runRequestJob(request).then((result) => {
+      const response: WorkdirProbeResponse = {
+        kind: 'result',
+        id: request.id,
+        result,
+      };
+      parentPort.postMessage(response);
+    });
   });
 }

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -535,6 +535,9 @@ const fanOutDingTalkBotOwnerChange = createIpcFanOut('dingtalkBot:owner-change')
 const fanOutWecomBotStatusChange = createIpcFanOut('wecomBot:status-changed');
 // Personal WeChat: main owns auth/polling and broadcasts a credential-free state snapshot.
 const fanOutWechatBotStateChange = createIpcFanOut('wechatBot:state-changed');
+// IM 账号边界激活通知(main 广播, 无 payload): 冷启动/换号窗口里个人微信/企微
+// 渠道设置首拉会因 [IM_NOT_READY] 失败, renderer 收到该推送后重拉。
+const fanOutImAccountBoundaryReady = createIpcFanOut('im:account-boundary-ready');
 const fanOutVoiceInputEvent = createIpcFanOut('voice-input:event');
 const fanOutVoiceInputGlobalShortcutTrigger = createIpcFanOut(
   'voice-input:global-shortcut-trigger',
@@ -1834,6 +1837,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
   }): Promise<{ ok: true }> => ipcRenderer.invoke('profile:update', params),
   onAuthStateChange: fanOutAuthStateChange,
   onAuthSessionExpired: fanOutAuthSessionExpired,
+  /** IM 账号边界激活推送(无 payload)— 渠道设置首拉失败后的重拉信号。 */
+  onImAccountBoundaryReady: fanOutImAccountBoundaryReady,
 
   // ── 使用统计(TapDB)同意闸 ──
   // 真相在 main(<userData>/analytics-settings.json);renderer 只读结论、只提交

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -2132,6 +2132,21 @@ contextBridge.exposeInMainWorld('electronAPI', {
       botId: string | null;
       ownerUserId: string | null;
     }> => ipcRenderer.invoke('wecomBot:disconnect'),
+    // 渠道工作目录只读投影 + Main 原生选择器入口;不提供 setWorkingDirectory(path)。
+    getChannelSettings: (): Promise<{
+      version: 1;
+      workingDir: string | null;
+      workingDirAvailable: boolean;
+    }> => ipcRenderer.invoke('wecomBot:get-channel-settings'),
+    chooseWorkingDirectory: (): Promise<{
+      canceled: boolean;
+      state: { version: 1; workingDir: string | null; workingDirAvailable: boolean };
+    }> => ipcRenderer.invoke('wecomBot:choose-working-directory'),
+    resetWorkingDirectory: (): Promise<{
+      version: 1;
+      workingDir: string | null;
+      workingDirAvailable: boolean;
+    }> => ipcRenderer.invoke('wecomBot:reset-working-directory'),
     onStatusChange: fanOutWecomBotStatusChange,
   },
 

--- a/apps/desktop/src/renderer/components/settings/ImWorkingDirectorySection.tsx
+++ b/apps/desktop/src/renderer/components/settings/ImWorkingDirectorySection.tsx
@@ -1,0 +1,91 @@
+import { FolderOpen } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+import { cn } from '@/lib/utils';
+
+/**
+ * IM 渠道「新对话工作目录」区块 — 个人微信/企业微信共用。
+ *
+ * 目录只能经 Main 原生选择器进入(点击整行触发),Renderer 不提供路径输入;
+ * i18n key 前缀由渠道注入(`settings.wechatBot` / `settings.wecomBot`),组件
+ * 只消费 `<prefix>.workingDir.*` 与渠道各自的提示文案。
+ */
+export function ImWorkingDirectorySection({
+  i18nKeyPrefix,
+  settings,
+  pending,
+  onChoose,
+  onReset,
+}: {
+  i18nKeyPrefix: string;
+  settings: { workingDir: string | null; workingDirAvailable: boolean } | null;
+  pending: boolean;
+  onChoose: () => void;
+  onReset: () => void;
+}) {
+  const { t } = useTranslation();
+  const configured = settings?.workingDir ?? null;
+
+  return (
+    <section className="flex flex-col gap-3" aria-label={t(`${i18nKeyPrefix}.workingDir.title`)}>
+      <div>
+        <h3 className="text-13 font-medium text-[var(--settings-section-title)]">
+          {t(`${i18nKeyPrefix}.workingDir.title`)}
+        </h3>
+        <p className="mt-1 text-12 leading-[1.55] text-[var(--settings-section-desc)]">
+          {t(`${i18nKeyPrefix}.workingDir.hint`)}
+        </p>
+      </div>
+      <div className="flex min-w-0 items-center gap-2">
+        <button
+          type="button"
+          onClick={onChoose}
+          disabled={pending}
+          aria-label={
+            configured
+              ? t(`${i18nKeyPrefix}.workingDir.chooseAriaWithDir`, { dir: configured })
+              : t(`${i18nKeyPrefix}.workingDir.chooseAria`)
+          }
+          className={cn(
+            'flex h-10 min-w-0 flex-1 items-center gap-2 rounded-full px-3 text-left',
+            'border border-[var(--settings-input-border)] bg-[var(--settings-input-bg)]',
+            'text-12 text-[var(--settings-input-text)]',
+            'transition-colors hover:border-[var(--settings-input-border-focus)]',
+            'active:scale-[0.98]',
+            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset',
+            'focus-visible:ring-[var(--focus-ring-soft)]',
+            pending && 'cursor-not-allowed opacity-50',
+          )}
+        >
+          <FolderOpen size={15} className="shrink-0 text-[var(--text-tertiary)]" />
+          <span className="truncate" title={configured ?? undefined} dir="auto">
+            {configured ?? t(`${i18nKeyPrefix}.workingDir.managed`)}
+          </span>
+        </button>
+        {configured && (
+          <button
+            type="button"
+            onClick={onReset}
+            disabled={pending}
+            className={cn(
+              'h-10 shrink-0 rounded-full px-4 text-12 font-medium',
+              'border border-[var(--settings-btn-secondary-border)] bg-[var(--settings-btn-secondary-bg)]',
+              'text-[var(--settings-btn-secondary-text)] transition-colors',
+              'hover:bg-[var(--surface-hover)] active:scale-[0.98]',
+              'focus-visible:outline-none focus-visible:ring-2',
+              'focus-visible:ring-[var(--focus-ring-soft)]',
+              'disabled:cursor-not-allowed disabled:opacity-50',
+            )}
+          >
+            {t(`${i18nKeyPrefix}.workingDir.reset`)}
+          </button>
+        )}
+      </div>
+      {settings && !settings.workingDirAvailable && (
+        <p className="text-12 text-[var(--settings-error-text)]" role="alert">
+          {t(`${i18nKeyPrefix}.workingDir.unavailable`)}
+        </p>
+      )}
+    </section>
+  );
+}

--- a/apps/desktop/src/renderer/components/settings/WechatBotSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/WechatBotSection.tsx
@@ -1,5 +1,5 @@
 import { Check, Loader2, RotateCw, Trash2, Unplug } from 'lucide-react';
-import { useCallback } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useConfirmDialog } from '@/components/ui/confirm-dialog-provider';
@@ -61,8 +61,28 @@ export function WechatBotSection({
     unbind,
     chooseWorkingDirectory,
     resetWorkingDirectory,
+    refreshChannelSettings,
   } = useWechatBot();
   const [routeSummary, setRouteSummary] = useImChannelSettingsSummary('wechat');
+
+  // 展开设置卡 / 窗口重新聚焦时重拉渠道设置(与企微同款): 目录可能在折叠或
+  // 失焦期间被删/拔盘/收回权限, 只在挂载时读一次会让「不可用」警告永远不
+  // 出现。展开首帧由 hook 的挂载请求覆盖, 跳过避免双拉。
+  const firstExpandRun = useRef(true);
+  useEffect(() => {
+    if (firstExpandRun.current) {
+      firstExpandRun.current = false;
+      return;
+    }
+    if (expanded) void refreshChannelSettings();
+  }, [expanded, refreshChannelSettings]);
+  useEffect(() => {
+    const refreshOnFocus = (): void => {
+      void refreshChannelSettings();
+    };
+    window.addEventListener('focus', refreshOnFocus);
+    return () => window.removeEventListener('focus', refreshOnFocus);
+  }, [refreshChannelSettings]);
 
   const authorizationSteps = (
     <ol className="mt-1 grid gap-2 rounded-xl border border-[var(--border-default)] bg-[var(--surface-chip)] px-4 py-3 text-12 leading-[1.55] text-[var(--text-secondary)]">

--- a/apps/desktop/src/renderer/components/settings/WechatBotSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/WechatBotSection.tsx
@@ -1,4 +1,4 @@
-import { Check, FolderOpen, Loader2, RotateCw, Trash2, Unplug } from 'lucide-react';
+import { Check, Loader2, RotateCw, Trash2, Unplug } from 'lucide-react';
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -7,6 +7,7 @@ import { useWechatBot } from '@/hooks/useWechatBot';
 import { cn } from '@/lib/utils';
 import { ImChannelSettingsCard, useImChannelSettingsSummary } from './ImChannelSettingsCard';
 import { ImDefaultSettingsSection } from './ImDefaultSettingsSection';
+import { ImWorkingDirectorySection } from './ImWorkingDirectorySection';
 
 const STATUS_KEYS: Record<WechatBotPhase, string> = {
   disconnected: 'settings.wechatBot.status.disconnected',
@@ -149,7 +150,8 @@ export function WechatBotSection({
 
       <div className="h-px w-full bg-[var(--border-default)]" />
 
-      <WechatWorkingDirectory
+      <ImWorkingDirectorySection
+        i18nKeyPrefix="settings.wechatBot"
         settings={channelSettings}
         pending={isUpdatingWorkingDir}
         onChoose={() => void chooseWorkingDirectory()}
@@ -270,66 +272,5 @@ export function WechatBotSection({
         </div>
       )}
     </ImChannelSettingsCard>
-  );
-}
-
-function WechatWorkingDirectory({
-  settings,
-  pending,
-  onChoose,
-  onReset,
-}: {
-  settings: WechatChannelSettingsState | null;
-  pending: boolean;
-  onChoose: () => void;
-  onReset: () => void;
-}) {
-  const { t } = useTranslation();
-  const configured = settings?.workingDir ?? null;
-
-  return (
-    <section className="flex flex-col gap-3" aria-label={t('settings.wechatBot.workingDir.title')}>
-      <div>
-        <h3 className="text-13 font-medium text-[var(--settings-section-title)]">
-          {t('settings.wechatBot.workingDir.title')}
-        </h3>
-        <p className="mt-1 text-12 leading-[1.55] text-[var(--settings-section-desc)]">
-          {t('settings.wechatBot.workingDir.hint')}
-        </p>
-      </div>
-      <div className="flex min-w-0 items-center gap-2">
-        <button
-          type="button"
-          onClick={onChoose}
-          disabled={pending}
-          className={cn(
-            'flex h-10 min-w-0 flex-1 items-center gap-2 rounded-full px-3 text-left',
-            'border border-[var(--settings-input-border)] bg-[var(--settings-input-bg)]',
-            'text-12 text-[var(--settings-input-text)]',
-            pending && 'cursor-not-allowed opacity-50',
-          )}
-        >
-          <FolderOpen size={15} className="shrink-0 text-[var(--text-tertiary)]" />
-          <span className="truncate" title={configured ?? undefined} dir="auto">
-            {configured ?? t('settings.wechatBot.workingDir.managed')}
-          </span>
-        </button>
-        {configured && (
-          <button
-            type="button"
-            onClick={onReset}
-            disabled={pending}
-            className="h-10 shrink-0 rounded-full border border-[var(--settings-btn-secondary-border)] bg-[var(--settings-btn-secondary-bg)] px-4 text-12 font-medium text-[var(--settings-btn-secondary-text)] disabled:cursor-not-allowed disabled:opacity-50"
-          >
-            {t('settings.wechatBot.workingDir.reset')}
-          </button>
-        )}
-      </div>
-      {settings && !settings.workingDirAvailable && (
-        <p className="text-12 text-[var(--settings-error-text)]" role="alert">
-          {t('settings.wechatBot.workingDir.unavailable')}
-        </p>
-      )}
-    </section>
   );
 }

--- a/apps/desktop/src/renderer/components/settings/WecomBotSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/WecomBotSection.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Check, Eye, EyeOff, Loader2, Send, Trash2 } from 'lucide-react';
 
@@ -10,6 +10,7 @@ import { cn } from '@/lib/utils';
 import { toast } from '@/lib/toast';
 import { ImChannelSettingsCard, useImChannelSettingsSummary } from './ImChannelSettingsCard';
 import { ImDefaultSettingsSection } from './ImDefaultSettingsSection';
+import { ImWorkingDirectorySection } from './ImWorkingDirectorySection';
 
 const STATUS_KEY: Record<WecomBotTransportStatus['kind'], string> = {
   idle: 'settings.wecomBot.status.needsConfig',
@@ -54,14 +55,19 @@ export function WecomBotSection({
     setSecret,
     ownerUserId,
     status,
+    channelSettings,
     validationError,
     isSaving,
     isDisconnecting,
+    isUpdatingWorkingDir,
     canConnect,
     canReconnect,
     connect,
     reconnect,
     disconnect,
+    chooseWorkingDirectory,
+    resetWorkingDirectory,
+    refreshChannelSettings,
   } = useWecomBot();
   const [showSecret, setShowSecret] = useState(false);
   const [routeSummary, setRouteSummary] = useImChannelSettingsSummary('wecom');
@@ -69,6 +75,25 @@ export function WecomBotSection({
   const { t } = useTranslation();
   const wecomGroup = useWecomGroupNotificationSettings();
   const [webhookUrl, setWebhookUrl] = useState('');
+
+  // 展开设置卡 / 窗口重新聚焦时重拉渠道设置: 目录可能在折叠或失焦期间被删/
+  // 拔盘/收回权限, 只在挂载时读一次会让「不可用」警告永远不出现。展开首帧由
+  // hook 的挂载请求覆盖, 跳过避免双拉。
+  const firstExpandRun = useRef(true);
+  useEffect(() => {
+    if (firstExpandRun.current) {
+      firstExpandRun.current = false;
+      return;
+    }
+    if (expanded) void refreshChannelSettings();
+  }, [expanded, refreshChannelSettings]);
+  useEffect(() => {
+    const refreshOnFocus = (): void => {
+      void refreshChannelSettings();
+    };
+    window.addEventListener('focus', refreshOnFocus);
+    return () => window.removeEventListener('focus', refreshOnFocus);
+  }, [refreshChannelSettings]);
 
   const handleDisconnect = useCallback(async () => {
     const approved = await confirm({
@@ -118,6 +143,15 @@ export function WecomBotSection({
       }
     >
       <ImDefaultSettingsSection channel="wecom" embedded onSummaryChange={setRouteSummary} />
+      <div className="h-px w-full bg-[var(--border-default)]" />
+
+      <ImWorkingDirectorySection
+        i18nKeyPrefix="settings.wecomBot"
+        settings={channelSettings}
+        pending={isUpdatingWorkingDir}
+        onChoose={() => void chooseWorkingDirectory()}
+        onReset={() => void resetWorkingDirectory()}
+      />
       <div className="h-px w-full bg-[var(--border-default)]" />
 
       {status.kind === 'connected' ? (

--- a/apps/desktop/src/renderer/components/settings/__tests__/WechatBotSection.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/__tests__/WechatBotSection.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { WechatBotSection } from '../WechatBotSection';
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   unbind: vi.fn(),
   chooseWorkingDirectory: vi.fn(),
   resetWorkingDirectory: vi.fn(),
+  refreshChannelSettings: vi.fn(async () => undefined),
   state: {
     phase: 'disconnected',
     bound: false,
@@ -44,6 +45,7 @@ vi.mock('@/hooks/useWechatBot', () => ({
     unbind: mocks.unbind,
     chooseWorkingDirectory: mocks.chooseWorkingDirectory,
     resetWorkingDirectory: mocks.resetWorkingDirectory,
+    refreshChannelSettings: mocks.refreshChannelSettings,
   }),
 }));
 
@@ -143,5 +145,25 @@ describe('WechatBotSection', () => {
       description: 'settings.wechatBot.unbind.description',
     });
     expect(mocks.unbind).toHaveBeenCalledTimes(1);
+  });
+
+  it('refreshes channel settings when the card expands again', () => {
+    // 目录可能在折叠期间被删/拔盘/收回权限 — 重新展开要重拉, 让「不可用」
+    // 警告及时出现(与企微同款; 首次展开由 hook 挂载请求覆盖, 跳过)。
+    const { rerender } = render(<WechatBotSection expanded={false} onToggle={vi.fn()} />);
+    expect(mocks.refreshChannelSettings).not.toHaveBeenCalled();
+
+    rerender(<WechatBotSection expanded onToggle={vi.fn()} />);
+    expect(mocks.refreshChannelSettings).toHaveBeenCalledTimes(1);
+  });
+
+  it('refreshes channel settings when the window regains focus', () => {
+    render(<WechatBotSection expanded onToggle={vi.fn()} />);
+    expect(mocks.refreshChannelSettings).not.toHaveBeenCalled();
+
+    act(() => {
+      window.dispatchEvent(new Event('focus'));
+    });
+    expect(mocks.refreshChannelSettings).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/desktop/src/renderer/components/settings/__tests__/WecomBotSection.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/__tests__/WecomBotSection.test.tsx
@@ -1,0 +1,148 @@
+// @vitest-environment jsdom
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { WecomBotSection } from '../WecomBotSection';
+
+const mocks = vi.hoisted(() => ({
+  chooseWorkingDirectory: vi.fn(),
+  resetWorkingDirectory: vi.fn(),
+  refreshChannelSettings: vi.fn(async () => undefined),
+  channelSettings: {
+    version: 1,
+    workingDir: null,
+    workingDirAvailable: true,
+  } as WecomChannelSettingsState | null,
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('@/components/ui/confirm-dialog-provider', () => ({
+  useConfirmDialog: () => ({ confirm: vi.fn() }),
+}));
+
+vi.mock('@/components/ui/switch', () => ({
+  Switch: () => <div data-testid="switch" />,
+}));
+
+vi.mock('@/lib/toast', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('@/hooks/useWecomBot', () => ({
+  useWecomBot: () => ({
+    botId: '',
+    setBotId: vi.fn(),
+    secret: '',
+    setSecret: vi.fn(),
+    ownerUserId: '',
+    status: { kind: 'idle' },
+    channelSettings: mocks.channelSettings,
+    validationError: null,
+    isSaving: false,
+    isDisconnecting: false,
+    isUpdatingWorkingDir: false,
+    canConnect: false,
+    canReconnect: false,
+    connect: vi.fn(),
+    reconnect: vi.fn(),
+    disconnect: vi.fn(),
+    chooseWorkingDirectory: mocks.chooseWorkingDirectory,
+    resetWorkingDirectory: mocks.resetWorkingDirectory,
+    refreshChannelSettings: mocks.refreshChannelSettings,
+  }),
+}));
+
+vi.mock('@/hooks/useWecomGroupNotificationSettings', () => ({
+  useWecomGroupNotificationSettings: () => ({
+    configured: false,
+    enabled: false,
+    maskedKey: '',
+    busy: false,
+    setEnabled: vi.fn(async () => true),
+    test: vi.fn(async () => undefined),
+    clear: vi.fn(async () => undefined),
+    saveAndTest: vi.fn(async () => undefined),
+  }),
+}));
+
+vi.mock('../ImDefaultSettingsSection', () => ({
+  ImDefaultSettingsSection: () => <div data-testid="defaults" />,
+}));
+
+vi.mock('../ImChannelSettingsCard', () => ({
+  useImChannelSettingsSummary: () => [null, vi.fn()],
+  ImChannelSettingsCard: ({ children }: { children: React.ReactNode }) => (
+    <section>{children}</section>
+  ),
+}));
+
+describe('WecomBotSection working directory', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.channelSettings = { version: 1, workingDir: null, workingDirAvailable: true };
+  });
+
+  it('shows the managed-directory placeholder and no reset button by default', () => {
+    render(<WecomBotSection expanded onToggle={vi.fn()} />);
+
+    expect(screen.getByText('settings.wecomBot.workingDir.title')).toBeTruthy();
+    expect(screen.getByText('settings.wecomBot.workingDir.managed')).toBeTruthy();
+    // 无障碍名称说明动作而不是只有路径(t 为 identity mock, 返回 key 本身)。
+    expect(
+      screen.getByRole('button', { name: 'settings.wecomBot.workingDir.chooseAria' }),
+    ).toBeTruthy();
+    expect(screen.queryByText('settings.wecomBot.workingDir.reset')).toBeNull();
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
+
+  it('triggers the native picker and reset through the hook actions', () => {
+    mocks.channelSettings = {
+      version: 1,
+      workingDir: 'D:/projects/wecom',
+      workingDirAvailable: true,
+    };
+    render(<WecomBotSection expanded onToggle={vi.fn()} />);
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'settings.wecomBot.workingDir.chooseAriaWithDir' }),
+    );
+    expect(mocks.chooseWorkingDirectory).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole('button', { name: 'settings.wecomBot.workingDir.reset' }));
+    expect(mocks.resetWorkingDirectory).toHaveBeenCalledTimes(1);
+  });
+
+  it('warns when the configured directory is unavailable', () => {
+    mocks.channelSettings = {
+      version: 1,
+      workingDir: 'D:/gone',
+      workingDirAvailable: false,
+    };
+    render(<WecomBotSection expanded onToggle={vi.fn()} />);
+
+    expect(screen.getByRole('alert').textContent).toBe('settings.wecomBot.workingDir.unavailable');
+  });
+
+  it('refreshes channel settings when the card expands again', () => {
+    const { rerender } = render(<WecomBotSection expanded={false} onToggle={vi.fn()} />);
+    expect(mocks.refreshChannelSettings).not.toHaveBeenCalled();
+
+    rerender(<WecomBotSection expanded onToggle={vi.fn()} />);
+    expect(mocks.refreshChannelSettings).toHaveBeenCalledTimes(1);
+  });
+
+  it('refreshes channel settings when the window regains focus', () => {
+    render(<WecomBotSection expanded onToggle={vi.fn()} />);
+    expect(mocks.refreshChannelSettings).not.toHaveBeenCalled();
+
+    act(() => {
+      window.dispatchEvent(new Event('focus'));
+    });
+    expect(mocks.refreshChannelSettings).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/desktop/src/renderer/hooks/__tests__/useWechatBot.test.ts
+++ b/apps/desktop/src/renderer/hooks/__tests__/useWechatBot.test.ts
@@ -45,6 +45,7 @@ function authState(dataOwnerId: string, ownerGeneration = 1): AuthStateChangePay
 function installWechatApi(initial: WechatBotState = disconnectedState()) {
   const listeners = new Set<(state: WechatBotState) => void>();
   const authListeners = new Set<(auth: AuthStateChangePayload) => void>();
+  const boundaryReadyListeners = new Set<() => void>();
   const channelState: WechatChannelSettingsState = {
     version: 1,
     workingDir: null,
@@ -71,6 +72,7 @@ function installWechatApi(initial: WechatBotState = disconnectedState()) {
       electronAPI: {
         wechatBot: typeof api;
         onAuthStateChange: (cb: (auth: AuthStateChangePayload) => void) => () => void;
+        onImAccountBoundaryReady: (cb: () => void) => () => void;
       };
     }
   ).electronAPI = {
@@ -78,6 +80,10 @@ function installWechatApi(initial: WechatBotState = disconnectedState()) {
     onAuthStateChange: vi.fn((callback: (auth: AuthStateChangePayload) => void) => {
       authListeners.add(callback);
       return () => authListeners.delete(callback);
+    }),
+    onImAccountBoundaryReady: vi.fn((callback: () => void) => {
+      boundaryReadyListeners.add(callback);
+      return () => boundaryReadyListeners.delete(callback);
     }),
   };
   return {
@@ -87,6 +93,9 @@ function installWechatApi(initial: WechatBotState = disconnectedState()) {
     },
     pushAuth(auth: AuthStateChangePayload) {
       for (const listener of authListeners) listener(auth);
+    },
+    pushBoundaryReady() {
+      for (const listener of boundaryReadyListeners) listener();
     },
   };
 }
@@ -292,6 +301,187 @@ describe('useWechatBot', () => {
       await Promise.resolve();
     });
     expect(result.current.channelSettings?.workingDir).toBe('D:/owner-b/project');
+  });
+
+  it('re-pulls channel settings after the IM account boundary becomes ready', async () => {
+    // 冷启动/换号窗口: 挂载首拉撞上 IM 账号边界未激活, 被 Main fail-closed
+    // 拒绝 — 设置停在 null; Main 激活边界后广播 ready, 到达即重拉成功,
+    // 不必等 focus/设置卡展开。
+    const harness = installWechatApi();
+    harness.api.getChannelSettings
+      .mockRejectedValueOnce(
+        new Error('[WECHAT_WORKING_DIR_UPDATE_FAILED] no active account'),
+      )
+      .mockResolvedValueOnce({
+        version: 1,
+        workingDir: 'D:/owner-a/project',
+        workingDirAvailable: true,
+      });
+    const { result } = renderHook(() => useWechatBot());
+    await waitFor(() => expect(harness.api.getChannelSettings).toHaveBeenCalledTimes(1));
+    expect(result.current.channelSettings).toBeNull();
+
+    act(() => harness.pushBoundaryReady());
+    await waitFor(() =>
+      expect(result.current.channelSettings?.workingDir).toBe('D:/owner-a/project'),
+    );
+    expect(harness.api.getChannelSettings).toHaveBeenCalledTimes(2);
+  });
+
+  it('drops the ready-triggered read that crosses a Cindy account switch', async () => {
+    // ready 重拉在途期间换号: 该响应按旧 owner 代次丢弃, 不覆盖新账号状态。
+    const harness = installWechatApi();
+    harness.api.getChannelSettings.mockRejectedValueOnce(
+      new Error('[WECHAT_WORKING_DIR_UPDATE_FAILED] no active account'),
+    );
+    const { result } = renderHook(() => useWechatBot());
+    await waitFor(() => expect(harness.api.getChannelSettings).toHaveBeenCalledTimes(1));
+
+    // ready 到达 → 重拉挂起(慢速网络盘探测, 可能仍服务于旧 owner 语境)。
+    let resolveReadyRead!: (state: WechatChannelSettingsState) => void;
+    harness.api.getChannelSettings.mockReturnValueOnce(
+      new Promise<WechatChannelSettingsState>((resolve) => {
+        resolveReadyRead = resolve;
+      }),
+    );
+    act(() => harness.pushBoundaryReady());
+    await waitFor(() => expect(harness.api.getChannelSettings).toHaveBeenCalledTimes(2));
+
+    // 换号: 立即失效 + 新 owner 的拉取先返回。
+    harness.api.getChannelSettings.mockResolvedValueOnce({
+      version: 1,
+      workingDir: 'D:/owner-b/project',
+      workingDirAvailable: true,
+    });
+    act(() => {
+      harness.pushAuth(authState('owner-b'));
+    });
+    expect(result.current.channelSettings).toBeNull();
+    await waitFor(() =>
+      expect(result.current.channelSettings?.workingDir).toBe('D:/owner-b/project'),
+    );
+
+    // ready 重拉(旧 owner 代次)此刻才返回 — 不得落地。
+    await act(async () => {
+      resolveReadyRead({ version: 1, workingDir: 'D:/owner-a/project', workingDirAvailable: true });
+      await Promise.resolve();
+    });
+    expect(result.current.channelSettings?.workingDir).toBe('D:/owner-b/project');
+  });
+
+  it('recovers the committed pick when the Cindy owner epoch advances during the picker', async () => {
+    // 与企微 TOFU 翻转同构的竞态: 弹窗期间 owner 代次推进, Main 已提交但结果
+    // 按旧代次被丢弃; 代次推进触发的提交前读取先落地旧配置 — 最终必须由
+    // 丢弃后的收敛读取把已落盘状态读回来(修复前停在旧配置)。
+    const harness = installWechatApi();
+    const oldState: WechatChannelSettingsState = {
+      version: 1,
+      workingDir: 'D:/old',
+      workingDirAvailable: true,
+    };
+    const committed: WechatChannelSettingsState = {
+      version: 1,
+      workingDir: 'D:/newly-picked',
+      workingDirAvailable: true,
+    };
+    harness.api.getChannelSettings
+      .mockResolvedValueOnce(oldState) // 挂载读取
+      .mockResolvedValueOnce(oldState) // 代次推进触发的读取(提交前, 先落地)
+      .mockResolvedValueOnce(committed); // 丢弃结果后的收敛读取(Main 已提交)
+    const { result } = renderHook(() => useWechatBot());
+    await waitFor(() => expect(result.current.channelSettings?.workingDir).toBe('D:/old'));
+
+    let resolvePick!: (result: {
+      canceled: boolean;
+      state: { version: 1; workingDir: string; workingDirAvailable: boolean };
+    }) => void;
+    harness.api.chooseWorkingDirectory.mockReturnValueOnce(
+      new Promise<{
+        canceled: boolean;
+        state: { version: 1; workingDir: string; workingDirAvailable: boolean };
+      }>((resolve) => {
+        resolvePick = resolve;
+      }),
+    );
+    let chooseDone: Promise<void> | null = null;
+    act(() => {
+      chooseDone = result.current.chooseWorkingDirectory();
+    });
+    act(() => {
+      harness.pushAuth(authState('owner-b'));
+    });
+    expect(result.current.channelSettings).toBeNull();
+    // 代次推进触发的提交前读取先返回并落地 — 修复前它会一直定住 UI。
+    await waitFor(() => expect(result.current.channelSettings?.workingDir).toBe('D:/old'));
+
+    // Main 已提交并返回; 结果按旧代次丢弃 → 收敛读取落地已提交状态。
+    await act(async () => {
+      resolvePick({
+        canceled: false,
+        state: { version: 1, workingDir: 'D:/newly-picked', workingDirAvailable: true },
+      });
+      await chooseDone;
+    });
+    await waitFor(() => expect(result.current.channelSettings?.workingDir).toBe('D:/newly-picked'));
+    expect(harness.api.getChannelSettings).toHaveBeenCalledTimes(3);
+  });
+
+  it('invalidates the pre-reset read and converges when the Cindy owner epoch advances during the reset', async () => {
+    // reset 版竞态另一半: 代次推进触发的提交前读取晚于丢弃返回 — 必须已被
+    // updateSeq 作废, 最终状态收敛到 Main 删除配置后的默认值。
+    const harness = installWechatApi();
+    const oldState: WechatChannelSettingsState = {
+      version: 1,
+      workingDir: 'D:/old',
+      workingDirAvailable: true,
+    };
+    const defaults: WechatChannelSettingsState = {
+      version: 1,
+      workingDir: null,
+      workingDirAvailable: true,
+    };
+    let resolveFlipRead!: (state: WechatChannelSettingsState) => void;
+    harness.api.getChannelSettings
+      .mockResolvedValueOnce(oldState) // 挂载读取
+      .mockReturnValueOnce( // 代次推进触发的读取(提交前, 挂起晚归)
+        new Promise<WechatChannelSettingsState>((resolve) => {
+          resolveFlipRead = resolve;
+        }),
+      )
+      .mockResolvedValueOnce(defaults); // 丢弃结果后的收敛读取(配置已删除)
+    const { result } = renderHook(() => useWechatBot());
+    await waitFor(() => expect(result.current.channelSettings?.workingDir).toBe('D:/old'));
+
+    let resolveReset!: (state: WechatChannelSettingsState) => void;
+    harness.api.resetWorkingDirectory.mockReturnValueOnce(
+      new Promise<WechatChannelSettingsState>((resolve) => {
+        resolveReset = resolve;
+      }),
+    );
+    let resetDone: Promise<void> | null = null;
+    act(() => {
+      resetDone = result.current.resetWorkingDirectory();
+    });
+    // reset 在途时 owner 代次推进(读取挂起中)。
+    act(() => {
+      harness.pushAuth(authState('owner-b'));
+    });
+    expect(result.current.channelSettings).toBeNull();
+
+    // Main 已删除配置并返回; 结果按旧代次丢弃 → 收敛读取落地「已恢复默认」。
+    await act(async () => {
+      resolveReset(defaults);
+      await resetDone;
+    });
+    await waitFor(() => expect(result.current.channelSettings?.workingDir).toBeNull());
+
+    // 代次推进触发的提交前读取此刻才返回 — 已被作废, 不得落地。
+    await act(async () => {
+      resolveFlipRead(oldState);
+      await Promise.resolve();
+    });
+    expect(result.current.channelSettings?.workingDir).toBeNull();
+    expect(harness.api.getChannelSettings).toHaveBeenCalledTimes(3);
   });
 
   it('skips the focus refresh while a working-dir update is in flight', async () => {

--- a/apps/desktop/src/renderer/hooks/__tests__/useWechatBot.test.ts
+++ b/apps/desktop/src/renderer/hooks/__tests__/useWechatBot.test.ts
@@ -155,6 +155,59 @@ describe('useWechatBot', () => {
     expect(result.current.channelSettings?.workingDir).toBeNull();
     expect(api.resetWorkingDirectory).toHaveBeenCalledTimes(1);
   });
+
+  it('drops the stale mount read that returns after a working-dir update (choose)', async () => {
+    // 挂载读取会异步探测已配置目录(网络盘可挂数秒), 可能晚于用户的选择落定 —
+    // 携带提交前旧配置的迟到读取不得覆盖较新的结果。
+    const { api } = installWechatApi();
+    let resolveMountRead!: (state: WechatChannelSettingsState) => void;
+    api.getChannelSettings.mockReturnValueOnce(
+      new Promise<WechatChannelSettingsState>((resolve) => {
+        resolveMountRead = resolve;
+      }),
+    );
+    const { result } = renderHook(() => useWechatBot());
+    api.chooseWorkingDirectory.mockResolvedValueOnce({
+      canceled: false,
+      state: { version: 1, workingDir: 'D:/new-pick', workingDirAvailable: true },
+    });
+    await act(async () => {
+      await result.current.chooseWorkingDirectory();
+    });
+    expect(result.current.channelSettings?.workingDir).toBe('D:/new-pick');
+
+    await act(async () => {
+      resolveMountRead({ version: 1, workingDir: 'D:/old', workingDirAvailable: true });
+      await Promise.resolve();
+    });
+    expect(result.current.channelSettings?.workingDir).toBe('D:/new-pick');
+  });
+
+  it('drops the stale mount read that returns after a working-dir reset', async () => {
+    const { api } = installWechatApi();
+    let resolveMountRead!: (state: WechatChannelSettingsState) => void;
+    api.getChannelSettings.mockReturnValueOnce(
+      new Promise<WechatChannelSettingsState>((resolve) => {
+        resolveMountRead = resolve;
+      }),
+    );
+    const { result } = renderHook(() => useWechatBot());
+    api.resetWorkingDirectory.mockResolvedValueOnce({
+      version: 1,
+      workingDir: null,
+      workingDirAvailable: true,
+    });
+    await act(async () => {
+      await result.current.resetWorkingDirectory();
+    });
+    expect(result.current.channelSettings?.workingDir).toBeNull();
+
+    await act(async () => {
+      resolveMountRead({ version: 1, workingDir: 'D:/old', workingDirAvailable: true });
+      await Promise.resolve();
+    });
+    expect(result.current.channelSettings?.workingDir).toBeNull();
+  });
 });
 
 function disconnectedState(): WechatBotState {

--- a/apps/desktop/src/renderer/hooks/__tests__/useWechatBot.test.ts
+++ b/apps/desktop/src/renderer/hooks/__tests__/useWechatBot.test.ts
@@ -484,6 +484,71 @@ describe('useWechatBot', () => {
     expect(harness.api.getChannelSettings).toHaveBeenCalledTimes(3);
   });
 
+  it('flushes a boundary-ready deferred by an in-flight pick after the update fails', async () => {
+    // P2: 选择器在途时切号 — auth 触发的读取因新账号边界未激活而失败, ready
+    // 又在更新在途中到达(只能挂起), 旧账号的 choose 随后被 Main generation
+    // 守卫拒绝。ready 不得丢: choose 收尾后必须为当前 owner 补拉, 设置不得
+    // 停在 null; 迟到的旧账号挂载读取也不得覆盖。
+    const harness = installWechatApi();
+    let resolveMountRead!: (state: WechatChannelSettingsState) => void;
+    harness.api.getChannelSettings
+      .mockReturnValueOnce( // 挂载读取挂起(慢探测), 携带旧账号语境, 晚归
+        new Promise<WechatChannelSettingsState>((resolve) => {
+          resolveMountRead = resolve;
+        }),
+      )
+      .mockRejectedValueOnce( // auth 切换触发的读取撞上未激活边界
+        new Error('[WECHAT_WORKING_DIR_UPDATE_FAILED] no active account'),
+      )
+      .mockResolvedValueOnce({ // 收尾补拉(边界已激活, 新账号已落盘状态)
+        version: 1,
+        workingDir: 'D:/owner-b/project',
+        workingDirAvailable: true,
+      });
+    const { result } = renderHook(() => useWechatBot());
+    await waitFor(() => expect(harness.api.getChannelSettings).toHaveBeenCalledTimes(1));
+
+    let rejectChoose!: (reason?: unknown) => void;
+    harness.api.chooseWorkingDirectory.mockReturnValueOnce(
+      new Promise<{
+        canceled: boolean;
+        state: { version: 1; workingDir: string; workingDirAvailable: boolean };
+      }>((_resolve, reject) => {
+        rejectChoose = reject;
+      }),
+    );
+    let chooseDone: Promise<void> | null = null;
+    act(() => {
+      chooseDone = result.current.chooseWorkingDirectory();
+    });
+    // 弹窗期间切号: 立即失效 + auth 触发的读取失败(call 2)。
+    act(() => {
+      harness.pushAuth(authState('owner-b'));
+    });
+    expect(result.current.channelSettings).toBeNull();
+    await waitFor(() => expect(harness.api.getChannelSettings).toHaveBeenCalledTimes(2));
+    // ready 在更新在途时到达 — 只记 pending, 不立刻拉。
+    act(() => harness.pushBoundaryReady());
+    expect(harness.api.getChannelSettings).toHaveBeenCalledTimes(2);
+
+    // 旧账号的 choose 被 Main generation 守卫拒绝 → 收尾补拉(call 3)。
+    await act(async () => {
+      rejectChoose(new Error('[WECHAT_WORKING_DIR_UPDATE_FAILED] account changed while pick'));
+      await chooseDone;
+    });
+    await waitFor(() =>
+      expect(result.current.channelSettings?.workingDir).toBe('D:/owner-b/project'),
+    );
+    expect(harness.api.getChannelSettings).toHaveBeenCalledTimes(3);
+
+    // 挂载读取(旧账号代次)此刻才返回 — 不得覆盖。
+    await act(async () => {
+      resolveMountRead({ version: 1, workingDir: 'D:/owner-a/project', workingDirAvailable: true });
+      await Promise.resolve();
+    });
+    expect(result.current.channelSettings?.workingDir).toBe('D:/owner-b/project');
+  });
+
   it('skips the focus refresh while a working-dir update is in flight', async () => {
     const harness = installWechatApi();
     const { result } = renderHook(() => useWechatBot());

--- a/apps/desktop/src/renderer/hooks/__tests__/useWechatBot.test.ts
+++ b/apps/desktop/src/renderer/hooks/__tests__/useWechatBot.test.ts
@@ -122,10 +122,7 @@ describe('useWechatBot', () => {
       await Promise.resolve();
     });
 
-    expect(__testing.getCache()).toEqual({
-      state: null,
-      channelSettings: null,
-    });
+    expect(__testing.getCache()).toEqual({ state: null });
   });
 
   it('starts and cancels authorization through the credential-free bridge', async () => {

--- a/apps/desktop/src/renderer/hooks/__tests__/useWechatBot.test.ts
+++ b/apps/desktop/src/renderer/hooks/__tests__/useWechatBot.test.ts
@@ -27,8 +27,24 @@ vi.mock('@/lib/logger', () => ({
   }),
 }));
 
+function authState(dataOwnerId: string, ownerGeneration = 1): AuthStateChangePayload {
+  return {
+    user: null,
+    mode: 'cloud',
+    dataOwnerId,
+    ownerGeneration,
+    canEnterApp: true,
+    isAuthenticated: true,
+    isCanary: false,
+    deviceId: 'dev-test',
+    hasAccountDeletionReceipt: false,
+    accountDeletionRestored: false,
+  } as AuthStateChangePayload;
+}
+
 function installWechatApi(initial: WechatBotState = disconnectedState()) {
   const listeners = new Set<(state: WechatBotState) => void>();
+  const authListeners = new Set<(auth: AuthStateChangePayload) => void>();
   const channelState: WechatChannelSettingsState = {
     version: 1,
     workingDir: null,
@@ -52,13 +68,25 @@ function installWechatApi(initial: WechatBotState = disconnectedState()) {
   };
   (
     window as unknown as {
-      electronAPI: { wechatBot: typeof api };
+      electronAPI: {
+        wechatBot: typeof api;
+        onAuthStateChange: (cb: (auth: AuthStateChangePayload) => void) => () => void;
+      };
     }
-  ).electronAPI = { wechatBot: api };
+  ).electronAPI = {
+    wechatBot: api,
+    onAuthStateChange: vi.fn((callback: (auth: AuthStateChangePayload) => void) => {
+      authListeners.add(callback);
+      return () => authListeners.delete(callback);
+    }),
+  };
   return {
     api,
     push(state: WechatBotState) {
       for (const listener of listeners) listener(state);
+    },
+    pushAuth(auth: AuthStateChangePayload) {
+      for (const listener of authListeners) listener(auth);
     },
   };
 }
@@ -207,6 +235,97 @@ describe('useWechatBot', () => {
       await Promise.resolve();
     });
     expect(result.current.channelSettings?.workingDir).toBeNull();
+  });
+
+  it('invalidates the displayed path immediately when the Cindy account switches', async () => {
+    // 微信状态推送不含任何 Cindy 身份 — 不订阅 auth 的话旧账号路径会一直
+    // 留在界面上(Main 守卫只拦得住迟到响应, 清不掉已渲染状态)。
+    const harness = installWechatApi();
+    const ownerA: WechatChannelSettingsState = {
+      version: 1,
+      workingDir: 'D:/owner-a/project',
+      workingDirAvailable: true,
+    };
+    const ownerB: WechatChannelSettingsState = {
+      version: 1,
+      workingDir: null,
+      workingDirAvailable: true,
+    };
+    let current = ownerA;
+    harness.api.getChannelSettings.mockImplementation(async () => current);
+    const { result } = renderHook(() => useWechatBot());
+    await waitFor(() => expect(result.current.channelSettings).toEqual(ownerA));
+
+    current = ownerB;
+    act(() => {
+      harness.pushAuth(authState('owner-b'));
+    });
+    expect(result.current.channelSettings).toBeNull();
+    await waitFor(() => expect(result.current.channelSettings).toEqual(ownerB));
+  });
+
+  it('drops a hanging mount read that crosses a Cindy account switch', async () => {
+    const harness = installWechatApi();
+    let resolveMountRead!: (state: WechatChannelSettingsState) => void;
+    harness.api.getChannelSettings.mockReturnValueOnce(
+      new Promise<WechatChannelSettingsState>((resolve) => {
+        resolveMountRead = resolve;
+      }),
+    );
+    const { result } = renderHook(() => useWechatBot());
+    // 挂载读取在途(慢速网络盘探测), Cindy 换号: 失效 + 为新账号重拉。
+    harness.api.getChannelSettings.mockResolvedValue({
+      version: 1,
+      workingDir: 'D:/owner-b/project',
+      workingDirAvailable: true,
+    });
+    act(() => {
+      harness.pushAuth(authState('owner-b'));
+    });
+    await waitFor(() =>
+      expect(result.current.channelSettings?.workingDir).toBe('D:/owner-b/project'),
+    );
+
+    // 旧账号语境的挂载读取此刻才返回 — 不得覆盖。
+    await act(async () => {
+      resolveMountRead({ version: 1, workingDir: 'D:/owner-a/project', workingDirAvailable: true });
+      await Promise.resolve();
+    });
+    expect(result.current.channelSettings?.workingDir).toBe('D:/owner-b/project');
+  });
+
+  it('skips the focus refresh while a working-dir update is in flight', async () => {
+    const harness = installWechatApi();
+    const { result } = renderHook(() => useWechatBot());
+    await waitFor(() => expect(result.current.channelSettings).not.toBeNull());
+    const readsBefore = harness.api.getChannelSettings.mock.calls.length;
+
+    let resolveChoose!: (result: {
+      canceled: boolean;
+      state: { version: 1; workingDir: string; workingDirAvailable: boolean };
+    }) => void;
+    harness.api.chooseWorkingDirectory.mockReturnValueOnce(
+      new Promise<{
+        canceled: boolean;
+        state: { version: 1; workingDir: string; workingDirAvailable: boolean };
+      }>((resolve) => {
+        resolveChoose = resolve;
+      }),
+    );
+    let chooseDone: Promise<void> | null = null;
+    act(() => {
+      chooseDone = result.current.chooseWorkingDirectory();
+    });
+    await act(async () => {
+      await result.current.refreshChannelSettings();
+    });
+    expect(harness.api.getChannelSettings.mock.calls.length).toBe(readsBefore);
+
+    await act(async () => {
+      resolveChoose({ canceled: false, state: { version: 1, workingDir: 'D:/picked', workingDirAvailable: true } });
+      await chooseDone;
+    });
+    expect(result.current.channelSettings?.workingDir).toBe('D:/picked');
   });
 });
 

--- a/apps/desktop/src/renderer/hooks/__tests__/useWecomBot.test.ts
+++ b/apps/desktop/src/renderer/hooks/__tests__/useWecomBot.test.ts
@@ -524,4 +524,99 @@ describe('useWecomBot', () => {
     expect(result.current.channelSettings).toEqual(defaults);
     expect(harness.api.getChannelSettings).toHaveBeenCalledTimes(3);
   });
+
+  it('flushes a boundary-ready deferred by an in-flight reset after the update fails', async () => {
+    // P2(与个人微信 choose 同构的反向矩阵): reset 在途时切 Cindy 账号 —
+    // auth 触发的读取因新账号边界未激活而失败, ready 在更新在途中到达(只能
+    // 挂起), 旧账号的 reset 随后被 Main generation 守卫拒绝。ready 不得丢:
+    // reset 收尾后必须为当前 owner 补拉, 设置不得停在 null; 迟到的旧语境
+    // 挂载读取也不得覆盖。
+    const harness = installWecomApi();
+    let resolveMountRead!: (state: WecomChannelSettingsState) => void;
+    harness.api.getChannelSettings
+      .mockReturnValueOnce( // owner 首次确立的挂载读取(慢探测, 旧语境晚归)
+        new Promise<WecomChannelSettingsState>((resolve) => {
+          resolveMountRead = resolve;
+        }),
+      )
+      .mockRejectedValueOnce( // auth 切换触发的读取撞上未激活边界
+        new Error('[IM_NOT_READY] IM account is not active'),
+      )
+      .mockResolvedValueOnce(settingsFor('B')); // 收尾补拉(边界已激活)
+    const { result } = renderHook(() => useWecomBot());
+    await waitFor(() => expect(harness.api.getChannelSettings).toHaveBeenCalledTimes(1));
+
+    let rejectReset!: (reason?: unknown) => void;
+    harness.api.resetWorkingDirectory.mockReturnValueOnce(
+      new Promise<WecomChannelSettingsState>((_resolve, reject) => {
+        rejectReset = reject;
+      }),
+    );
+    let resetDone: Promise<void> | null = null;
+    act(() => {
+      resetDone = result.current.resetWorkingDirectory();
+    });
+    // reset 在途时切 Cindy 账号: 失效 + auth 触发的读取失败(call 2)。
+    act(() => {
+      harness.pushAuth(authState('owner-b'));
+    });
+    expect(result.current.channelSettings).toBeNull();
+    await waitFor(() => expect(harness.api.getChannelSettings).toHaveBeenCalledTimes(2));
+    // ready 在更新在途时到达 — 只记 pending, 不立刻拉。
+    act(() => harness.pushBoundaryReady());
+    expect(harness.api.getChannelSettings).toHaveBeenCalledTimes(2);
+
+    // 旧账号的 reset 被 Main generation 守卫拒绝 → 收尾补拉(call 3)。
+    await act(async () => {
+      rejectReset(new Error('[WECOM_WORKING_DIR_UPDATE_FAILED] account changed while reset'));
+      await resetDone;
+    });
+    await waitFor(() => expect(result.current.channelSettings).toEqual(settingsFor('B')));
+    expect(harness.api.getChannelSettings).toHaveBeenCalledTimes(3);
+
+    // 挂载读取(旧语境)此刻才返回 — 不得覆盖。
+    await act(async () => {
+      resolveMountRead(settingsFor('A'));
+      await Promise.resolve();
+    });
+    expect(result.current.channelSettings).toEqual(settingsFor('B'));
+  });
+
+  it('does not double-fetch when the owner-flip recovery supersedes a deferred ready', async () => {
+    // 协调: pending ready 与 owner 翻转收敛同时出现 — refetchAfterOwnerFlip
+    // 已在 Main 返回后发起收敛读取, 收尾不得再为同一目标补拉第二次。
+    const harness = installWecomApi();
+    harness.api.getChannelSettings
+      .mockResolvedValueOnce(settingsFor('old')) // 挂载确立 owner('')
+      .mockResolvedValueOnce(settingsFor('old')) // 翻转触发的提交前读取
+      .mockResolvedValueOnce(settingsFor('X')); // 收敛读取(Main 已提交)
+    const { result } = renderHook(() => useWecomBot());
+    await waitFor(() => expect(result.current.channelSettings).toEqual(settingsFor('old')));
+
+    let resolvePick!: (result: { canceled: boolean; state: WecomChannelSettingsState }) => void;
+    harness.api.chooseWorkingDirectory.mockReturnValueOnce(
+      new Promise<{ canceled: boolean; state: WecomChannelSettingsState }>((resolve) => {
+        resolvePick = resolve;
+      }),
+    );
+    let chooseDone: Promise<void> | null = null;
+    act(() => {
+      chooseDone = result.current.chooseWorkingDirectory();
+    });
+    act(() => {
+      harness.push({ status: { kind: 'connected', appId: 'app' }, botId: 'bot', ownerUserId: 'X' });
+    });
+    await waitFor(() => expect(harness.api.getChannelSettings).toHaveBeenCalledTimes(2));
+    // 更新在途时 ready 到达 — 记 pending。
+    act(() => harness.pushBoundaryReady());
+    expect(harness.api.getChannelSettings).toHaveBeenCalledTimes(2);
+
+    // Main 成功返回但 owner 已翻转 → 收敛读取覆盖 pending, 收尾不再补拉。
+    await act(async () => {
+      resolvePick({ canceled: false, state: settingsFor('X') });
+      await chooseDone;
+    });
+    await waitFor(() => expect(result.current.channelSettings).toEqual(settingsFor('X')));
+    expect(harness.api.getChannelSettings).toHaveBeenCalledTimes(3);
+  });
 });

--- a/apps/desktop/src/renderer/hooks/__tests__/useWecomBot.test.ts
+++ b/apps/desktop/src/renderer/hooks/__tests__/useWecomBot.test.ts
@@ -61,6 +61,7 @@ function authState(dataOwnerId: string, ownerGeneration = 1): AuthStateChangePay
 function installWecomApi(initial: StatusPush = IDLE) {
   const listeners = new Set<(update: StatusPush) => void>();
   const authListeners = new Set<(auth: AuthStateChangePayload) => void>();
+  const boundaryReadyListeners = new Set<() => void>();
   const api = {
     getStatus: vi.fn(async () => initial),
     setConfig: vi.fn(async () => ({
@@ -90,6 +91,7 @@ function installWecomApi(initial: StatusPush = IDLE) {
       electronAPI: {
         wecomBot: typeof api;
         onAuthStateChange: (cb: (auth: AuthStateChangePayload) => void) => () => void;
+        onImAccountBoundaryReady: (cb: () => void) => () => void;
       };
     }
   ).electronAPI = {
@@ -97,6 +99,10 @@ function installWecomApi(initial: StatusPush = IDLE) {
     onAuthStateChange: vi.fn((callback: (auth: AuthStateChangePayload) => void) => {
       authListeners.add(callback);
       return () => authListeners.delete(callback);
+    }),
+    onImAccountBoundaryReady: vi.fn((callback: () => void) => {
+      boundaryReadyListeners.add(callback);
+      return () => boundaryReadyListeners.delete(callback);
     }),
   };
   return {
@@ -106,6 +112,9 @@ function installWecomApi(initial: StatusPush = IDLE) {
     },
     pushAuth(auth: AuthStateChangePayload) {
       for (const listener of authListeners) listener(auth);
+    },
+    pushBoundaryReady() {
+      for (const listener of boundaryReadyListeners) listener();
     },
   };
 }
@@ -361,5 +370,158 @@ describe('useWecomBot', () => {
     });
     expect(result.current.channelSettings).toBeNull();
     await waitFor(() => expect(result.current.channelSettings).toEqual(settingsFor('two')));
+  });
+
+  it('re-pulls channel settings after the IM account boundary becomes ready', async () => {
+    // 冷启动(无模块缓存种子): getStatus 先确立 owner(''), 但 IM 边界未激活 →
+    // 首拉被 Main fail-closed 拒绝, 设置停在 null; Main 激活边界后广播
+    // ready → 到达即重拉成功, 不必等设置卡展开。
+    const harness = installWecomApi();
+    harness.api.getChannelSettings
+      .mockRejectedValueOnce(new Error('[IM_NOT_READY] IM account is not active'))
+      .mockResolvedValueOnce(settingsFor('A'));
+    const { result } = renderHook(() => useWecomBot());
+    await waitFor(() => expect(harness.api.getChannelSettings).toHaveBeenCalledTimes(1));
+    expect(result.current.channelSettings).toBeNull();
+
+    act(() => harness.pushBoundaryReady());
+    await waitFor(() => expect(result.current.channelSettings).toEqual(settingsFor('A')));
+    expect(harness.api.getChannelSettings).toHaveBeenCalledTimes(2);
+  });
+
+  it('drops the ready-triggered read that crosses a Cindy account switch', async () => {
+    // ready 重拉在途期间换号: 该响应按旧 owner 代次丢弃, 不覆盖新账号状态。
+    const harness = installWecomApi({
+      status: { kind: 'connected', appId: 'app' },
+      botId: 'bot',
+      ownerUserId: 'A',
+    });
+    harness.api.getChannelSettings.mockRejectedValueOnce(
+      new Error('[IM_NOT_READY] IM account is not active'),
+    );
+    const { result } = renderHook(() => useWecomBot());
+    await waitFor(() => expect(harness.api.getChannelSettings).toHaveBeenCalledTimes(1));
+
+    // ready 到达 → 重拉挂起(慢速网络盘探测, 可能仍服务于旧 owner 语境)。
+    let resolveReadyRead!: (state: WecomChannelSettingsState) => void;
+    harness.api.getChannelSettings.mockReturnValueOnce(
+      new Promise<WecomChannelSettingsState>((resolve) => {
+        resolveReadyRead = resolve;
+      }),
+    );
+    act(() => harness.pushBoundaryReady());
+    await waitFor(() => expect(harness.api.getChannelSettings).toHaveBeenCalledTimes(2));
+
+    // 换号: 立即失效 + 新 owner 的拉取先返回。
+    harness.api.getChannelSettings.mockResolvedValueOnce(settingsFor('B'));
+    act(() => {
+      harness.pushAuth(authState('owner-b'));
+    });
+    expect(result.current.channelSettings).toBeNull();
+    await waitFor(() => expect(result.current.channelSettings).toEqual(settingsFor('B')));
+
+    // ready 重拉(旧 owner 代次)此刻才返回 — 不得落地。
+    await act(async () => {
+      resolveReadyRead(settingsFor('A'));
+      await Promise.resolve();
+    });
+    expect(result.current.channelSettings).toEqual(settingsFor('B'));
+  });
+
+  it('recovers the committed pick when a TOFU owner flip races the directory picker', async () => {
+    // TOFU 首绑定在弹窗期间把 owner 从 '' 翻到 sender: Main 照常提交新目录并
+    // 返回, 结果却按旧代次被丢弃; 翻转触发的读取出发于提交之前、先带着旧配置
+    // 落地 — 最终必须由丢弃后的收敛读取把已落盘状态读回来(修复前停在旧配置)。
+    const harness = installWecomApi();
+    const committed: WecomChannelSettingsState = {
+      version: 1,
+      workingDir: 'D:/newly-picked',
+      workingDirAvailable: true,
+    };
+    harness.api.getChannelSettings
+      .mockResolvedValueOnce(settingsFor('old')) // 挂载确立 owner('') 的读取
+      .mockResolvedValueOnce(settingsFor('old')) // owner 翻转触发的读取(提交前, 先落地)
+      .mockResolvedValueOnce(committed); // 丢弃结果后的收敛读取(Main 已提交)
+    const { result } = renderHook(() => useWecomBot());
+    await waitFor(() => expect(result.current.channelSettings).toEqual(settingsFor('old')));
+
+    let resolvePick!: (result: { canceled: boolean; state: WecomChannelSettingsState }) => void;
+    harness.api.chooseWorkingDirectory.mockReturnValueOnce(
+      new Promise<{ canceled: boolean; state: WecomChannelSettingsState }>((resolve) => {
+        resolvePick = resolve;
+      }),
+    );
+    let chooseDone: Promise<void> | null = null;
+    act(() => {
+      chooseDone = result.current.chooseWorkingDirectory();
+    });
+    // 弹窗期间 TOFU 首条入站消息确立 owner: ''→'X'。
+    act(() => {
+      harness.push({ status: { kind: 'connected', appId: 'app' }, botId: 'bot', ownerUserId: 'X' });
+    });
+    expect(result.current.channelSettings).toBeNull();
+    // 翻转触发的提交前读取先返回并落地 — 修复前它会一直定住 UI。
+    await waitFor(() => expect(result.current.channelSettings).toEqual(settingsFor('old')));
+
+    // Main 已提交并返回; 结果按旧代次丢弃 → 收敛读取落地已提交状态。
+    await act(async () => {
+      resolvePick({ canceled: false, state: committed });
+      await chooseDone;
+    });
+    await waitFor(() => expect(result.current.channelSettings).toEqual(committed));
+    expect(harness.api.getChannelSettings).toHaveBeenCalledTimes(3);
+  });
+
+  it('invalidates the pre-reset read and converges when a TOFU owner flip races the reset', async () => {
+    // reset 版竞态另一半: 翻转触发的提交前读取晚于丢弃返回 — 必须已被
+    // updateSeq 作废, 最终状态收敛到 Main 删除配置后的默认值。
+    const harness = installWecomApi();
+    const defaults: WecomChannelSettingsState = {
+      version: 1,
+      workingDir: null,
+      workingDirAvailable: true,
+    };
+    let resolveFlipRead!: (state: WecomChannelSettingsState) => void;
+    harness.api.getChannelSettings
+      .mockResolvedValueOnce(settingsFor('old')) // 挂载确立 owner('')
+      .mockReturnValueOnce( // owner 翻转触发的读取(提交前, 挂起晚归)
+        new Promise<WecomChannelSettingsState>((resolve) => {
+          resolveFlipRead = resolve;
+        }),
+      )
+      .mockResolvedValueOnce(defaults); // 丢弃结果后的收敛读取(配置已删除)
+    const { result } = renderHook(() => useWecomBot());
+    await waitFor(() => expect(result.current.channelSettings).toEqual(settingsFor('old')));
+
+    let resolveReset!: (state: WecomChannelSettingsState) => void;
+    harness.api.resetWorkingDirectory.mockReturnValueOnce(
+      new Promise<WecomChannelSettingsState>((resolve) => {
+        resolveReset = resolve;
+      }),
+    );
+    let resetDone: Promise<void> | null = null;
+    act(() => {
+      resetDone = result.current.resetWorkingDirectory();
+    });
+    // reset 在途时 TOFU 翻转 owner: ''→'X'(读取挂起中)。
+    act(() => {
+      harness.push({ status: { kind: 'connected', appId: 'app' }, botId: 'bot', ownerUserId: 'X' });
+    });
+    expect(result.current.channelSettings).toBeNull();
+
+    // Main 已删除配置并返回; 结果按旧代次丢弃 → 收敛读取落地「已恢复默认」。
+    await act(async () => {
+      resolveReset(defaults);
+      await resetDone;
+    });
+    await waitFor(() => expect(result.current.channelSettings).toEqual(defaults));
+
+    // 翻转触发的提交前读取此刻才返回 — 已被作废, 不得落地。
+    await act(async () => {
+      resolveFlipRead(settingsFor('old'));
+      await Promise.resolve();
+    });
+    expect(result.current.channelSettings).toEqual(defaults);
+    expect(harness.api.getChannelSettings).toHaveBeenCalledTimes(3);
   });
 });

--- a/apps/desktop/src/renderer/hooks/__tests__/useWecomBot.test.ts
+++ b/apps/desktop/src/renderer/hooks/__tests__/useWecomBot.test.ts
@@ -1,0 +1,221 @@
+// @vitest-environment jsdom
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { __testing, useWecomBot } from '../useWecomBot';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, vars?: Record<string, string>) =>
+      vars?.message ? `${key}:${vars.message}` : key,
+  }),
+}));
+
+vi.mock('@/lib/toast', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  createLogger: () => ({
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+type StatusPush = {
+  status: WecomBotTransportStatus;
+  botId: string | null;
+  ownerUserId: string | null;
+};
+
+function settingsFor(owner: string): WecomChannelSettingsState {
+  return {
+    version: 1,
+    workingDir: `D:/owners/${owner}/project`,
+    workingDirAvailable: true,
+  };
+}
+
+const IDLE: StatusPush = { status: { kind: 'idle' }, botId: null, ownerUserId: null };
+
+function installWecomApi(initial: StatusPush = IDLE) {
+  const listeners = new Set<(update: StatusPush) => void>();
+  const api = {
+    getStatus: vi.fn(async () => initial),
+    setConfig: vi.fn(async () => ({
+      status: { kind: 'connected', appId: 'app' } as WecomBotTransportStatus,
+      botId: 'bot',
+      ownerUserId: 'X',
+    })),
+    reconnect: vi.fn(async () => ({
+      status: { kind: 'connecting' } as WecomBotTransportStatus,
+      botId: 'bot',
+      ownerUserId: null,
+    })),
+    disconnect: vi.fn(async () => IDLE),
+    getChannelSettings: vi.fn(async () => settingsFor('A')),
+    chooseWorkingDirectory: vi.fn(async () => ({
+      canceled: false,
+      state: settingsFor('A'),
+    })),
+    resetWorkingDirectory: vi.fn(async () => settingsFor('A')),
+    onStatusChange: vi.fn((callback: (update: StatusPush) => void) => {
+      listeners.add(callback);
+      return () => listeners.delete(callback);
+    }),
+  };
+  (
+    window as unknown as {
+      electronAPI: { wecomBot: typeof api };
+    }
+  ).electronAPI = { wecomBot: api };
+  return {
+    api,
+    push(update: StatusPush) {
+      for (const listener of listeners) listener(update);
+    },
+  };
+}
+
+describe('useWecomBot', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    __testing.resetCache();
+    delete (window as unknown as { electronAPI?: unknown }).electronAPI;
+  });
+
+  it('loads the transport state and the current owner channel settings on mount', async () => {
+    const harness = installWecomApi({
+      status: { kind: 'connected', appId: 'app' },
+      botId: 'bot',
+      ownerUserId: 'A',
+    });
+    const { result } = renderHook(() => useWecomBot());
+
+    await waitFor(() => expect(result.current.ownerUserId).toBe('A'));
+    await waitFor(() => expect(result.current.channelSettings).toEqual(settingsFor('A')));
+    expect(harness.api.getChannelSettings).toHaveBeenCalledTimes(1);
+  });
+
+  it('invalidates the previous owner path immediately on account switch and refetches', async () => {
+    const harness = installWecomApi({
+      status: { kind: 'connected', appId: 'app' },
+      botId: 'bot',
+      ownerUserId: 'A',
+    });
+    let owner = 'A';
+    harness.api.getChannelSettings.mockImplementation(async () => settingsFor(owner));
+    const { result } = renderHook(() => useWecomBot());
+    await waitFor(() => expect(result.current.channelSettings).toEqual(settingsFor('A')));
+
+    owner = 'B';
+    act(() => {
+      harness.push({ status: { kind: 'connected', appId: 'app' }, botId: 'bot', ownerUserId: 'B' });
+    });
+    // 切号瞬间: 旧 owner 的绝对路径立即失效, 不等新请求返回。
+    expect(result.current.channelSettings).toBeNull();
+    await waitFor(() => expect(result.current.channelSettings).toEqual(settingsFor('B')));
+    expect(result.current.ownerUserId).toBe('B');
+  });
+
+  it('drops a late response from the previous owner instead of overwriting the new owner', async () => {
+    const harness = installWecomApi({
+      status: { kind: 'connected', appId: 'app' },
+      botId: 'bot',
+      ownerUserId: 'A',
+    });
+    // 第一次挂载把 owner A 落进模块缓存(重挂载的种子来源)。
+    const first = renderHook(() => useWecomBot());
+    await waitFor(() => expect(first.result.current.channelSettings).toEqual(settingsFor('A')));
+    first.unmount();
+
+    // 重挂载: 缓存种子 owner A, 挂载即拉 — 该请求挂起(可能仍服务于 A);
+    // 切号触发的新请求(owner B)先返回。
+    let resolveOwnerA!: (state: WecomChannelSettingsState) => void;
+    harness.api.getChannelSettings
+      .mockReturnValueOnce(
+        new Promise<WecomChannelSettingsState>((resolve) => {
+          resolveOwnerA = resolve;
+        }),
+      )
+      .mockImplementationOnce(async () => settingsFor('B'));
+    const { result } = renderHook(() => useWecomBot());
+
+    act(() => {
+      harness.push({ status: { kind: 'connected', appId: 'app' }, botId: 'bot', ownerUserId: 'B' });
+    });
+    await waitFor(() => expect(result.current.channelSettings).toEqual(settingsFor('B')));
+
+    // A 的旧请求此刻才返回 — 不得覆盖 B 的状态(递增 epoch 的写回守卫)。
+    await act(async () => {
+      resolveOwnerA(settingsFor('A'));
+      await Promise.resolve();
+    });
+    expect(result.current.channelSettings).toEqual(settingsFor('B'));
+    expect(result.current.ownerUserId).toBe('B');
+  });
+
+  it('drops the picker result when the account switches while the dialog or probe is pending', async () => {
+    const harness = installWecomApi({
+      status: { kind: 'connected', appId: 'app' },
+      botId: 'bot',
+      ownerUserId: 'A',
+    });
+    const { result } = renderHook(() => useWecomBot());
+    await waitFor(() => expect(result.current.channelSettings).toEqual(settingsFor('A')));
+
+    let resolveChoose!: (result: { canceled: boolean; state: WecomChannelSettingsState }) => void;
+    harness.api.chooseWorkingDirectory.mockReturnValueOnce(
+      new Promise<{ canceled: boolean; state: WecomChannelSettingsState }>((resolve) => {
+        resolveChoose = resolve;
+      }),
+    );
+    let chooseDone: Promise<void> | null = null;
+    act(() => {
+      chooseDone = result.current.chooseWorkingDirectory();
+    });
+    // 原生弹窗 + Main 侧异步探测期间切号: B 的设置先落位。
+    harness.api.getChannelSettings.mockImplementation(async () => settingsFor('B'));
+    act(() => {
+      harness.push({ status: { kind: 'connected', appId: 'app' }, botId: 'bot', ownerUserId: 'B' });
+    });
+    await waitFor(() => expect(result.current.channelSettings).toEqual(settingsFor('B')));
+
+    // A 语境下选完的目录此刻才返回 — 不得写回。
+    await act(async () => {
+      resolveChoose({ canceled: false, state: settingsFor('A') });
+      await chooseDone;
+    });
+    expect(result.current.channelSettings).toEqual(settingsFor('B'));
+    expect(result.current.isUpdatingWorkingDir).toBe(false);
+  });
+
+  it('invalidates in-flight responses on unmount', async () => {
+    const harness = installWecomApi();
+    // 第一次挂载确立 owner 上下文(''), 重挂载才会挂载即拉。
+    const first = renderHook(() => useWecomBot());
+    await waitFor(() => expect(first.result.current.channelSettings).toEqual(settingsFor('A')));
+    first.unmount();
+
+    let resolveSettings!: (state: WecomChannelSettingsState) => void;
+    harness.api.getChannelSettings.mockReturnValueOnce(
+      new Promise<WecomChannelSettingsState>((resolve) => {
+        resolveSettings = resolve;
+      }),
+    );
+    const { unmount } = renderHook(() => useWecomBot());
+
+    unmount();
+    // 卸载作废在途响应 — 迟到 resolve 不再触碰任何状态(也不抛错)。
+    await act(async () => {
+      resolveSettings(settingsFor('B'));
+      await Promise.resolve();
+    });
+    expect(__testing.getCache()).toMatchObject({ ownerUserId: '' });
+  });
+});

--- a/apps/desktop/src/renderer/hooks/__tests__/useWecomBot.test.ts
+++ b/apps/desktop/src/renderer/hooks/__tests__/useWecomBot.test.ts
@@ -195,6 +195,84 @@ describe('useWecomBot', () => {
     expect(result.current.isUpdatingWorkingDir).toBe(false);
   });
 
+  it('applies the picked directory immediately although closing the dialog fires a focus refresh', async () => {
+    // 回归: 原生选择器关窗触发 focus → 设置卡刷新读到提交前的旧配置, 且旧
+    // 实现按「请求代次」丢弃了选择器结果 — 新目录显示不出来, 切页签才刷新。
+    const harness = installWecomApi({
+      status: { kind: 'connected', appId: 'app' },
+      botId: 'bot',
+      ownerUserId: 'A',
+    });
+    const picked: WecomChannelSettingsState = {
+      version: 1,
+      workingDir: 'D:/newly-picked',
+      workingDirAvailable: true,
+    };
+    const { result } = renderHook(() => useWecomBot());
+    await waitFor(() => expect(result.current.channelSettings).toEqual(settingsFor('A')));
+
+    let resolveChoose!: (result: { canceled: boolean; state: WecomChannelSettingsState }) => void;
+    harness.api.chooseWorkingDirectory.mockReturnValueOnce(
+      new Promise<{ canceled: boolean; state: WecomChannelSettingsState }>((resolve) => {
+        resolveChoose = resolve;
+      }),
+    );
+    let chooseDone: Promise<void> | null = null;
+    act(() => {
+      chooseDone = result.current.chooseWorkingDirectory();
+    });
+    // 更新在途时 focus 刷新到达 — 必须被跳过, 不发起读取。
+    await act(async () => {
+      await result.current.refreshChannelSettings();
+    });
+    expect(harness.api.getChannelSettings).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveChoose({ canceled: false, state: picked });
+      await chooseDone;
+    });
+    expect(result.current.channelSettings).toEqual(picked);
+    expect(result.current.isUpdatingWorkingDir).toBe(false);
+  });
+
+  it('drops a stale read that was dispatched before a working-dir update landed', async () => {
+    // 竞态另一半: 读取在更新提交前出发(读到旧配置), 却在更新结果之后返回 —
+    // 按更新落地序号丢弃, 不得把新目录又盖回旧值。
+    const harness = installWecomApi({
+      status: { kind: 'connected', appId: 'app' },
+      botId: 'bot',
+      ownerUserId: 'A',
+    });
+    let resolveStaleRead!: (state: WecomChannelSettingsState) => void;
+    harness.api.getChannelSettings.mockReturnValueOnce(
+      new Promise<WecomChannelSettingsState>((resolve) => {
+        resolveStaleRead = resolve;
+      }),
+    );
+    const picked: WecomChannelSettingsState = {
+      version: 1,
+      workingDir: 'D:/newly-picked',
+      workingDirAvailable: true,
+    };
+    harness.api.chooseWorkingDirectory.mockResolvedValueOnce({ canceled: false, state: picked });
+    const { result } = renderHook(() => useWecomBot());
+    // owner 首次确定触发挂载读取(挂起中, 携带旧配置)。
+    await waitFor(() => expect(result.current.ownerUserId).toBe('A'));
+    expect(result.current.channelSettings).toBeNull();
+
+    await act(async () => {
+      await result.current.chooseWorkingDirectory();
+    });
+    expect(result.current.channelSettings).toEqual(picked);
+
+    // 旧读取此刻才返回(提交前的旧配置) — 不得覆盖已落位的新目录。
+    await act(async () => {
+      resolveStaleRead(settingsFor('A'));
+      await Promise.resolve();
+    });
+    expect(result.current.channelSettings).toEqual(picked);
+  });
+
   it('invalidates in-flight responses on unmount', async () => {
     const harness = installWecomApi();
     // 第一次挂载确立 owner 上下文(''), 重挂载才会挂载即拉。

--- a/apps/desktop/src/renderer/hooks/__tests__/useWecomBot.test.ts
+++ b/apps/desktop/src/renderer/hooks/__tests__/useWecomBot.test.ts
@@ -43,8 +43,24 @@ function settingsFor(owner: string): WecomChannelSettingsState {
 
 const IDLE: StatusPush = { status: { kind: 'idle' }, botId: null, ownerUserId: null };
 
+function authState(dataOwnerId: string, ownerGeneration = 1): AuthStateChangePayload {
+  return {
+    user: null,
+    mode: 'cloud',
+    dataOwnerId,
+    ownerGeneration,
+    canEnterApp: true,
+    isAuthenticated: true,
+    isCanary: false,
+    deviceId: 'dev-test',
+    hasAccountDeletionReceipt: false,
+    accountDeletionRestored: false,
+  } as AuthStateChangePayload;
+}
+
 function installWecomApi(initial: StatusPush = IDLE) {
   const listeners = new Set<(update: StatusPush) => void>();
+  const authListeners = new Set<(auth: AuthStateChangePayload) => void>();
   const api = {
     getStatus: vi.fn(async () => initial),
     setConfig: vi.fn(async () => ({
@@ -71,13 +87,25 @@ function installWecomApi(initial: StatusPush = IDLE) {
   };
   (
     window as unknown as {
-      electronAPI: { wecomBot: typeof api };
+      electronAPI: {
+        wecomBot: typeof api;
+        onAuthStateChange: (cb: (auth: AuthStateChangePayload) => void) => () => void;
+      };
     }
-  ).electronAPI = { wecomBot: api };
+  ).electronAPI = {
+    wecomBot: api,
+    onAuthStateChange: vi.fn((callback: (auth: AuthStateChangePayload) => void) => {
+      authListeners.add(callback);
+      return () => authListeners.delete(callback);
+    }),
+  };
   return {
     api,
     push(update: StatusPush) {
       for (const listener of listeners) listener(update);
+    },
+    pushAuth(auth: AuthStateChangePayload) {
+      for (const listener of authListeners) listener(auth);
     },
   };
 }
@@ -295,5 +323,43 @@ describe('useWecomBot', () => {
       await Promise.resolve();
     });
     expect(__testing.getCache()).toMatchObject({ ownerUserId: '' });
+  });
+
+  it('invalidates immediately when the Cindy account switches but the WeCom ownerUserId stays the same', async () => {
+    // 两个 Cindy 账号绑同一个企微用户: 企微推送维度看不到任何变化, 只有
+    // auth 推送(dataOwnerId/ownerGeneration)区分得了。
+    const harness = installWecomApi({
+      status: { kind: 'connected', appId: 'app' },
+      botId: 'bot',
+      ownerUserId: 'A',
+    });
+    let cindyOwner = 'one';
+    harness.api.getChannelSettings.mockImplementation(async () => settingsFor(cindyOwner));
+    const { result } = renderHook(() => useWecomBot());
+    await waitFor(() => expect(result.current.channelSettings).toEqual(settingsFor('one')));
+
+    cindyOwner = 'two';
+    act(() => {
+      harness.pushAuth(authState('owner-two'));
+    });
+    // 企微 ownerUserId 全程未变, 渠道设置仍立即失效并重拉。
+    expect(result.current.channelSettings).toBeNull();
+    await waitFor(() => expect(result.current.channelSettings).toEqual(settingsFor('two')));
+  });
+
+  it('invalidates on Cindy account switch when neither side configured the WeCom bot (empty ownerUserId)', async () => {
+    // 两边都没配置企微: ownerUserId 同为空串, 换号同样只有 auth 推送可见。
+    const harness = installWecomApi();
+    let cindyOwner = 'one';
+    harness.api.getChannelSettings.mockImplementation(async () => settingsFor(cindyOwner));
+    const { result } = renderHook(() => useWecomBot());
+    await waitFor(() => expect(result.current.channelSettings).toEqual(settingsFor('one')));
+
+    cindyOwner = 'two';
+    act(() => {
+      harness.pushAuth(authState('owner-two'));
+    });
+    expect(result.current.channelSettings).toBeNull();
+    await waitFor(() => expect(result.current.channelSettings).toEqual(settingsFor('two')));
   });
 });

--- a/apps/desktop/src/renderer/hooks/useWechatBot.ts
+++ b/apps/desktop/src/renderer/hooks/useWechatBot.ts
@@ -27,6 +27,7 @@ export interface UseWechatBotReturn {
   unbind: () => Promise<boolean>;
   chooseWorkingDirectory: () => Promise<void>;
   resetWorkingDirectory: () => Promise<void>;
+  refreshChannelSettings: () => Promise<void>;
 }
 
 export function useWechatBot(): UseWechatBotReturn {
@@ -44,6 +45,32 @@ export function useWechatBot(): UseWechatBotReturn {
    * 较新的选择/重置结果(与企微 hook 同款竞态防护)。
    */
   const updateSeqRef = useRef(0);
+  /** Cindy 数据 owner 代次(auth:state-change 的 mode+dataOwnerId+ownerGeneration)。 */
+  const ownerEpochRef = useRef(0);
+  const cindyOwnerRef = useRef<string | null>(null);
+  /** isUpdatingWorkingDir 的 ref 镜像: refreshChannelSettings 的在途守卫用。 */
+  const isUpdatingWorkingDirRef = useRef(false);
+
+  /** 拉取当前账号的渠道设置;owner 代次或更新序号已推进的迟到响应不写回。 */
+  const fetchChannelSettings = useCallback(async (): Promise<void> => {
+    const ownerEpoch = ownerEpochRef.current;
+    const updateSeq = updateSeqRef.current;
+    try {
+      const settings = await window.electronAPI.wechatBot.getChannelSettings();
+      if (ownerEpochRef.current !== ownerEpoch || updateSeqRef.current !== updateSeq) return;
+      setChannelSettings(settings);
+    } catch {
+      log.error('failed to load personal WeChat channel settings');
+    }
+  }, []);
+
+  /** 拉取最新渠道设置 — 设置卡展开/窗口聚焦时刷新, 让「不可用」警告及时出现。 */
+  const refreshChannelSettings = useCallback(async (): Promise<void> => {
+    // 工作目录更新在途时跳过: 原生选择器关窗会触发 focus 刷新, 这次读取
+    // 大概率读到提交前的旧配置; choose/reset 返回的状态才是最新的。
+    if (isUpdatingWorkingDirRef.current) return;
+    await fetchChannelSettings();
+  }, [fetchChannelSettings]);
 
   useEffect(() => {
     let cancelled = false;
@@ -54,7 +81,6 @@ export function useWechatBot(): UseWechatBotReturn {
       setState(next);
     });
     const initialPushVersion = pushVersionRef.current;
-    const initialUpdateSeq = updateSeqRef.current;
     void Promise.all([
       window.electronAPI.wechatBot.getState(),
       window.electronAPI.wechatBot.getChannelSettings(),
@@ -65,7 +91,7 @@ export function useWechatBot(): UseWechatBotReturn {
           cachedState = nextState;
           setState(nextState);
         }
-        if (updateSeqRef.current !== initialUpdateSeq) return;
+        if (updateSeqRef.current !== 0 || ownerEpochRef.current !== 0) return;
         setChannelSettings(nextChannelSettings);
       })
       .catch(() => {
@@ -74,9 +100,25 @@ export function useWechatBot(): UseWechatBotReturn {
       });
     return () => {
       cancelled = true;
+      ownerEpochRef.current += 1;
       unsubscribe();
     };
   }, []);
+
+  useEffect(() => {
+    // Cindy 账号切换(登录/登出/换号)即时失效渠道设置: 微信状态推送不含任何
+    // Cindy 身份, 不订阅 auth 的话旧账号的绝对路径会一直留在界面上; Main
+    // 侧守卫只拦得住迟到响应, 清不掉已渲染状态。
+    const unsubscribe = window.electronAPI.onAuthStateChange((auth) => {
+      const next = `${auth.mode}/${auth.dataOwnerId ?? '-'}/${auth.ownerGeneration}`;
+      if (cindyOwnerRef.current === next) return;
+      cindyOwnerRef.current = next;
+      ownerEpochRef.current += 1;
+      setChannelSettings(null);
+      void fetchChannelSettings();
+    });
+    return unsubscribe;
+  }, [fetchChannelSettings]);
 
   const authorize = useCallback(async (): Promise<boolean> => {
     if (isAuthorizing) return false;
@@ -121,8 +163,12 @@ export function useWechatBot(): UseWechatBotReturn {
   const chooseWorkingDirectory = useCallback(async (): Promise<void> => {
     if (isUpdatingWorkingDir) return;
     setIsUpdatingWorkingDir(true);
+    isUpdatingWorkingDirRef.current = true;
+    const ownerEpoch = ownerEpochRef.current;
     try {
       const result = await window.electronAPI.wechatBot.chooseWorkingDirectory();
+      // 弹窗/探测期间 Cindy 账号切换: 迟到结果不得写回新账号界面。
+      if (ownerEpochRef.current !== ownerEpoch) return;
       updateSeqRef.current += 1;
       setChannelSettings(result.state);
       if (!result.canceled) toast.success(t('settings.wechatBot.toasts.workingDirSaved'));
@@ -130,6 +176,7 @@ export function useWechatBot(): UseWechatBotReturn {
       log.error('failed to choose personal WeChat working directory');
       toast.error(t('settings.wechatBot.toasts.workingDirFailed'));
     } finally {
+      isUpdatingWorkingDirRef.current = false;
       setIsUpdatingWorkingDir(false);
     }
   }, [isUpdatingWorkingDir, t]);
@@ -137,8 +184,11 @@ export function useWechatBot(): UseWechatBotReturn {
   const resetWorkingDirectory = useCallback(async (): Promise<void> => {
     if (isUpdatingWorkingDir) return;
     setIsUpdatingWorkingDir(true);
+    isUpdatingWorkingDirRef.current = true;
+    const ownerEpoch = ownerEpochRef.current;
     try {
       const next = await window.electronAPI.wechatBot.resetWorkingDirectory();
+      if (ownerEpochRef.current !== ownerEpoch) return;
       updateSeqRef.current += 1;
       setChannelSettings(next);
       toast.success(t('settings.wechatBot.toasts.workingDirReset'));
@@ -146,6 +196,7 @@ export function useWechatBot(): UseWechatBotReturn {
       log.error('failed to reset personal WeChat working directory');
       toast.error(t('settings.wechatBot.toasts.workingDirFailed'));
     } finally {
+      isUpdatingWorkingDirRef.current = false;
       setIsUpdatingWorkingDir(false);
     }
   }, [isUpdatingWorkingDir, t]);
@@ -161,6 +212,7 @@ export function useWechatBot(): UseWechatBotReturn {
     unbind,
     chooseWorkingDirectory,
     resetWorkingDirectory,
+    refreshChannelSettings,
   };
 }
 

--- a/apps/desktop/src/renderer/hooks/useWechatBot.ts
+++ b/apps/desktop/src/renderer/hooks/useWechatBot.ts
@@ -37,6 +37,13 @@ export function useWechatBot(): UseWechatBotReturn {
   const [isUnbinding, setIsUnbinding] = useState(false);
   const [isUpdatingWorkingDir, setIsUpdatingWorkingDir] = useState(false);
   const pushVersionRef = useRef(0);
+  /**
+   * 工作目录更新落地序号: choose/reset 结果写回时递增。读取请求出发时捕获,
+   * 返回时序号已变(期间有一次更新落地)则丢弃 — 挂载读取会异步探测已配置
+   * 目录, 网络盘下可能挂数秒, 迟到返回携带的是提交前的旧配置, 不得覆盖
+   * 较新的选择/重置结果(与企微 hook 同款竞态防护)。
+   */
+  const updateSeqRef = useRef(0);
 
   useEffect(() => {
     let cancelled = false;
@@ -47,6 +54,7 @@ export function useWechatBot(): UseWechatBotReturn {
       setState(next);
     });
     const initialPushVersion = pushVersionRef.current;
+    const initialUpdateSeq = updateSeqRef.current;
     void Promise.all([
       window.electronAPI.wechatBot.getState(),
       window.electronAPI.wechatBot.getChannelSettings(),
@@ -57,6 +65,7 @@ export function useWechatBot(): UseWechatBotReturn {
           cachedState = nextState;
           setState(nextState);
         }
+        if (updateSeqRef.current !== initialUpdateSeq) return;
         setChannelSettings(nextChannelSettings);
       })
       .catch(() => {
@@ -114,6 +123,7 @@ export function useWechatBot(): UseWechatBotReturn {
     setIsUpdatingWorkingDir(true);
     try {
       const result = await window.electronAPI.wechatBot.chooseWorkingDirectory();
+      updateSeqRef.current += 1;
       setChannelSettings(result.state);
       if (!result.canceled) toast.success(t('settings.wechatBot.toasts.workingDirSaved'));
     } catch {
@@ -129,6 +139,7 @@ export function useWechatBot(): UseWechatBotReturn {
     setIsUpdatingWorkingDir(true);
     try {
       const next = await window.electronAPI.wechatBot.resetWorkingDirectory();
+      updateSeqRef.current += 1;
       setChannelSettings(next);
       toast.success(t('settings.wechatBot.toasts.workingDirReset'));
     } catch {

--- a/apps/desktop/src/renderer/hooks/useWechatBot.ts
+++ b/apps/desktop/src/renderer/hooks/useWechatBot.ts
@@ -50,6 +50,12 @@ export function useWechatBot(): UseWechatBotReturn {
   const cindyOwnerRef = useRef<string | null>(null);
   /** isUpdatingWorkingDir 的 ref 镜像: refreshChannelSettings 的在途守卫用。 */
   const isUpdatingWorkingDirRef = useRef(false);
+  /**
+   * 更新在途期间到达的 boundary-ready: 此刻拉取会被在途守卫跳过、读到提交前
+   * 旧配置, 只能记下来, 由 choose/reset 收尾(finishWorkingDirUpdate)补拉 —
+   * ready 一轮登录只广播一次, 跳过即永久丢失(切号后设置停在 null)。
+   */
+  const pendingBoundaryReadyRef = useRef(false);
 
   /** 拉取当前账号的渠道设置;owner 代次或更新序号已推进的迟到响应不写回。 */
   const fetchChannelSettings = useCallback(async (): Promise<void> => {
@@ -73,7 +79,23 @@ export function useWechatBot(): UseWechatBotReturn {
    * Main 返回之后发起, 必然读到已提交状态。
    */
   const refetchAfterOwnerFlip = useCallback((): void => {
+    // 这里的收敛读取已覆盖「ready 待补拉」的意图 — 清掉 pending, 防止收尾
+    // 时对同一目标重复拉取。
+    pendingBoundaryReadyRef.current = false;
     updateSeqRef.current += 1;
+    void fetchChannelSettings();
+  }, [fetchChannelSettings]);
+
+  /**
+   * choose/reset 的统一收尾: 先解除更新在途守卫, 再补拉更新期间到达的
+   * boundary-ready(若有)。补拉发生在 choose/reset 完全结束之后, ready 又已
+   * 表示新账号边界激活 — 此时读到的是当前 owner 的已落盘状态; 迟到守卫照常,
+   * ownerEpoch 再推进则丢弃, 由推进方自己的重拉兜底。
+   */
+  const finishWorkingDirUpdate = useCallback((): void => {
+    isUpdatingWorkingDirRef.current = false;
+    if (!pendingBoundaryReadyRef.current) return;
+    pendingBoundaryReadyRef.current = false;
     void fetchChannelSettings();
   }, [fetchChannelSettings]);
 
@@ -138,9 +160,13 @@ export function useWechatBot(): UseWechatBotReturn {
       // 冷启动/换号窗口: 挂载首拉撞上 IM 账号边界未激活会被 Main fail-closed
       // 拒绝([IM_NOT_READY]), 设置停在 null; Main 在边界激活时广播 ready,
       // 到达即重拉, 不必等 focus/设置卡展开。迟到守卫不变 — ownerEpoch/
-      // updateSeq 已推进的响应照旧丢弃, 更新在途时 refreshChannelSettings
-      // 自会跳过(其结果由 choose/reset 落地的新状态取代)。
+      // updateSeq 已推进的响应照旧丢弃。更新在途时不能拉也不能丢: 记入
+      // pending, 由 choose/reset 收尾(finishWorkingDirUpdate)补拉。
       window.electronAPI.onImAccountBoundaryReady(() => {
+        if (isUpdatingWorkingDirRef.current) {
+          pendingBoundaryReadyRef.current = true;
+          return;
+        }
         void refreshChannelSettings();
       }),
     [refreshChannelSettings],
@@ -207,10 +233,10 @@ export function useWechatBot(): UseWechatBotReturn {
       log.error('failed to choose personal WeChat working directory');
       toast.error(t('settings.wechatBot.toasts.workingDirFailed'));
     } finally {
-      isUpdatingWorkingDirRef.current = false;
+      finishWorkingDirUpdate();
       setIsUpdatingWorkingDir(false);
     }
-  }, [isUpdatingWorkingDir, refetchAfterOwnerFlip, t]);
+  }, [finishWorkingDirUpdate, isUpdatingWorkingDir, refetchAfterOwnerFlip, t]);
 
   const resetWorkingDirectory = useCallback(async (): Promise<void> => {
     if (isUpdatingWorkingDir) return;
@@ -231,10 +257,10 @@ export function useWechatBot(): UseWechatBotReturn {
       log.error('failed to reset personal WeChat working directory');
       toast.error(t('settings.wechatBot.toasts.workingDirFailed'));
     } finally {
-      isUpdatingWorkingDirRef.current = false;
+      finishWorkingDirUpdate();
       setIsUpdatingWorkingDir(false);
     }
-  }, [isUpdatingWorkingDir, refetchAfterOwnerFlip, t]);
+  }, [finishWorkingDirUpdate, isUpdatingWorkingDir, refetchAfterOwnerFlip, t]);
 
   return {
     state,

--- a/apps/desktop/src/renderer/hooks/useWechatBot.ts
+++ b/apps/desktop/src/renderer/hooks/useWechatBot.ts
@@ -13,7 +13,8 @@ const EMPTY_STATE: WechatBotState = {
 };
 
 let cachedState: WechatBotState | null = null;
-let cachedChannelSettings: WechatChannelSettingsState | null = null;
+// 渠道设置不做模块级缓存种子(与 useWecomBot 同因): 缓存不按数据 owner 隔离,
+// 切号后重新挂载会把上一账号的绝对路径闪给新账号。挂载时现拉, 数据本地量小。
 
 export interface UseWechatBotReturn {
   state: WechatBotState;
@@ -31,9 +32,7 @@ export interface UseWechatBotReturn {
 export function useWechatBot(): UseWechatBotReturn {
   const { t } = useTranslation();
   const [state, setState] = useState<WechatBotState>(() => cachedState ?? EMPTY_STATE);
-  const [channelSettings, setChannelSettings] = useState<WechatChannelSettingsState | null>(
-    () => cachedChannelSettings,
-  );
+  const [channelSettings, setChannelSettings] = useState<WechatChannelSettingsState | null>(null);
   const [isAuthorizing, setIsAuthorizing] = useState(false);
   const [isUnbinding, setIsUnbinding] = useState(false);
   const [isUpdatingWorkingDir, setIsUpdatingWorkingDir] = useState(false);
@@ -58,7 +57,6 @@ export function useWechatBot(): UseWechatBotReturn {
           cachedState = nextState;
           setState(nextState);
         }
-        cachedChannelSettings = nextChannelSettings;
         setChannelSettings(nextChannelSettings);
       })
       .catch(() => {
@@ -116,7 +114,6 @@ export function useWechatBot(): UseWechatBotReturn {
     setIsUpdatingWorkingDir(true);
     try {
       const result = await window.electronAPI.wechatBot.chooseWorkingDirectory();
-      cachedChannelSettings = result.state;
       setChannelSettings(result.state);
       if (!result.canceled) toast.success(t('settings.wechatBot.toasts.workingDirSaved'));
     } catch {
@@ -132,7 +129,6 @@ export function useWechatBot(): UseWechatBotReturn {
     setIsUpdatingWorkingDir(true);
     try {
       const next = await window.electronAPI.wechatBot.resetWorkingDirectory();
-      cachedChannelSettings = next;
       setChannelSettings(next);
       toast.success(t('settings.wechatBot.toasts.workingDirReset'));
     } catch {
@@ -160,15 +156,8 @@ export function useWechatBot(): UseWechatBotReturn {
 export const __testing = {
   resetCache(): void {
     cachedState = null;
-    cachedChannelSettings = null;
   },
-  getCache(): {
-    state: WechatBotState | null;
-    channelSettings: WechatChannelSettingsState | null;
-  } {
-    return {
-      state: cachedState,
-      channelSettings: cachedChannelSettings,
-    };
+  getCache(): { state: WechatBotState | null } {
+    return { state: cachedState };
   },
 };

--- a/apps/desktop/src/renderer/hooks/useWechatBot.ts
+++ b/apps/desktop/src/renderer/hooks/useWechatBot.ts
@@ -64,6 +64,19 @@ export function useWechatBot(): UseWechatBotReturn {
     }
   }, []);
 
+  /**
+   * choose/reset 结果因 owner 代次推进被丢弃后的收敛(与企微 hook 同款)。
+   * Main 侧可能已把新状态落盘并返回(代次推进未必伴随 IM 账号切换, 如同账号
+   * 重新登录推进 ownerGeneration), 但代次推进触发的渠道设置读取出发于提交
+   * 之前 — 迟到落地会带着提交前的旧配置, 把已落盘的新状态盖掉或停在旧值上。
+   * 先推进 updateSeq 作废这些在途旧读取, 再为当前 owner 重拉一次 — 重拉在
+   * Main 返回之后发起, 必然读到已提交状态。
+   */
+  const refetchAfterOwnerFlip = useCallback((): void => {
+    updateSeqRef.current += 1;
+    void fetchChannelSettings();
+  }, [fetchChannelSettings]);
+
   /** 拉取最新渠道设置 — 设置卡展开/窗口聚焦时刷新, 让「不可用」警告及时出现。 */
   const refreshChannelSettings = useCallback(async (): Promise<void> => {
     // 工作目录更新在途时跳过: 原生选择器关窗会触发 focus 刷新, 这次读取
@@ -120,6 +133,19 @@ export function useWechatBot(): UseWechatBotReturn {
     return unsubscribe;
   }, [fetchChannelSettings]);
 
+  useEffect(
+    () =>
+      // 冷启动/换号窗口: 挂载首拉撞上 IM 账号边界未激活会被 Main fail-closed
+      // 拒绝([IM_NOT_READY]), 设置停在 null; Main 在边界激活时广播 ready,
+      // 到达即重拉, 不必等 focus/设置卡展开。迟到守卫不变 — ownerEpoch/
+      // updateSeq 已推进的响应照旧丢弃, 更新在途时 refreshChannelSettings
+      // 自会跳过(其结果由 choose/reset 落地的新状态取代)。
+      window.electronAPI.onImAccountBoundaryReady(() => {
+        void refreshChannelSettings();
+      }),
+    [refreshChannelSettings],
+  );
+
   const authorize = useCallback(async (): Promise<boolean> => {
     if (isAuthorizing) return false;
     setIsAuthorizing(true);
@@ -168,7 +194,12 @@ export function useWechatBot(): UseWechatBotReturn {
     try {
       const result = await window.electronAPI.wechatBot.chooseWorkingDirectory();
       // 弹窗/探测期间 Cindy 账号切换: 迟到结果不得写回新账号界面。
-      if (ownerEpochRef.current !== ownerEpoch) return;
+      if (ownerEpochRef.current !== ownerEpoch) {
+        // 代次推进丢弃结果, 但 Main 可能已提交 — 收敛到已落盘状态, 不停在
+        // 代次推进触发的提交前旧读取上。
+        refetchAfterOwnerFlip();
+        return;
+      }
       updateSeqRef.current += 1;
       setChannelSettings(result.state);
       if (!result.canceled) toast.success(t('settings.wechatBot.toasts.workingDirSaved'));
@@ -179,7 +210,7 @@ export function useWechatBot(): UseWechatBotReturn {
       isUpdatingWorkingDirRef.current = false;
       setIsUpdatingWorkingDir(false);
     }
-  }, [isUpdatingWorkingDir, t]);
+  }, [isUpdatingWorkingDir, refetchAfterOwnerFlip, t]);
 
   const resetWorkingDirectory = useCallback(async (): Promise<void> => {
     if (isUpdatingWorkingDir) return;
@@ -188,7 +219,11 @@ export function useWechatBot(): UseWechatBotReturn {
     const ownerEpoch = ownerEpochRef.current;
     try {
       const next = await window.electronAPI.wechatBot.resetWorkingDirectory();
-      if (ownerEpochRef.current !== ownerEpoch) return;
+      if (ownerEpochRef.current !== ownerEpoch) {
+        // 代次推进丢弃结果, 但 Main 可能已删除配置 — 收敛到已落盘状态。
+        refetchAfterOwnerFlip();
+        return;
+      }
       updateSeqRef.current += 1;
       setChannelSettings(next);
       toast.success(t('settings.wechatBot.toasts.workingDirReset'));
@@ -199,7 +234,7 @@ export function useWechatBot(): UseWechatBotReturn {
       isUpdatingWorkingDirRef.current = false;
       setIsUpdatingWorkingDir(false);
     }
-  }, [isUpdatingWorkingDir, t]);
+  }, [isUpdatingWorkingDir, refetchAfterOwnerFlip, t]);
 
   return {
     state,

--- a/apps/desktop/src/renderer/hooks/useWecomBot.ts
+++ b/apps/desktop/src/renderer/hooks/useWecomBot.ts
@@ -31,22 +31,32 @@ export function useWecomBot() {
   const [validationError, setValidationError] = useState<string | null>(null);
 
   /**
-   * 渠道设置写回的代次。每次发起新请求(挂载/刷新/选择/重置)递增;切号与卸载
-   * 也递增以作废在途响应。异步结果只有发起时的代次仍是当前代次才允许写回 —
-   * 否则账号 A 的旧请求晚于账号 B 的请求返回时, 会把 A 的绝对路径覆盖给 B。
+   * owner 代次: 仅在 owner 变化(含首次确定)与卸载时递增。所有渠道设置的异步
+   * 写回(读取/选择/重置)只有发起时的 owner 代次仍有效才允许落地 — 迟到的旧
+   * owner 响应不得把上一账号的绝对路径写给新账号。同 owner 内的并发请求**不**
+   * 递增: focus 触发的并发刷新与选择器结果互相竞争时丢弃后者, 会让新选的
+   * 目录显示不出来(实测回归)。
    */
-  const settingsEpochRef = useRef(0);
+  const ownerEpochRef = useRef(0);
+  /**
+   * 工作目录更新落地序号: choose/reset 结果写回时递增。早于一次更新出发的
+   * 读取可能带着提交前的旧配置、在更新结果之后才返回 — 这种读取按序号丢弃。
+   */
+  const updateSeqRef = useRef(0);
+  /** isUpdatingWorkingDir 的 ref 镜像: refreshChannelSettings 的在途守卫用。 */
+  const isUpdatingWorkingDirRef = useRef(false);
   /** null = 尚未确定 owner(冷启动, 无模块缓存种子)。 */
   const ownerRef = useRef<string | null>(cachedState?.ownerUserId ?? null);
   /** 推送代次: 挂载快照归来前已有推送先行到达时, 丢弃过期快照(同 useWechatBot)。 */
   const pushVersionRef = useRef(0);
 
-  /** 拉取当前 owner 的渠道设置;递增代次, 迟到的旧响应不写回。 */
+  /** 拉取当前 owner 的渠道设置;owner 或更新序号已推进的迟到响应不写回。 */
   const fetchChannelSettings = useCallback(async (): Promise<void> => {
-    const epoch = ++settingsEpochRef.current;
+    const ownerEpoch = ownerEpochRef.current;
+    const updateSeq = updateSeqRef.current;
     try {
       const settings = await window.electronAPI.wecomBot.getChannelSettings();
-      if (settingsEpochRef.current !== epoch) return;
+      if (ownerEpochRef.current !== ownerEpoch || updateSeqRef.current !== updateSeq) return;
       setChannelSettings(settings);
     } catch (error) {
       log.error(
@@ -68,7 +78,7 @@ export function useWecomBot() {
       setBotId(next.botId);
       if (ownerRef.current !== next.ownerUserId) {
         ownerRef.current = next.ownerUserId;
-        settingsEpochRef.current += 1;
+        ownerEpochRef.current += 1;
         setChannelSettings(null);
         void fetchChannelSettings();
       }
@@ -102,7 +112,7 @@ export function useWecomBot() {
     return () => {
       cancelled = true;
       // 卸载作废在途响应(比 cancelled 标志多覆盖 fetchChannelSettings 一路)。
-      settingsEpochRef.current += 1;
+      ownerEpochRef.current += 1;
     };
   }, [applyState, fetchChannelSettings]);
 
@@ -203,11 +213,15 @@ export function useWecomBot() {
   const chooseWorkingDirectory = useCallback(async (): Promise<void> => {
     if (isUpdatingWorkingDir) return;
     setIsUpdatingWorkingDir(true);
-    const epoch = ++settingsEpochRef.current;
+    isUpdatingWorkingDirRef.current = true;
+    const ownerEpoch = ownerEpochRef.current;
     try {
       const result = await window.electronAPI.wecomBot.chooseWorkingDirectory();
-      // 原生弹窗 + Main 侧异步探测期间可能切号: 迟到结果不得写回。
-      if (settingsEpochRef.current !== epoch) return;
+      // 原生弹窗 + Main 侧异步探测期间可能切号: 仅 owner 变化才丢弃。
+      // 同 owner 内 focus 触发的并发刷新不构成丢弃理由 — 这里返回的是刚
+      // 落盘的最新状态, 丢弃它会让新目录显示不出来(实测回归)。
+      if (ownerEpochRef.current !== ownerEpoch) return;
+      updateSeqRef.current += 1;
       setChannelSettings(result.state);
       if (!result.canceled) toast.success(t('settings.wecomBot.workingDirSaved'));
     } catch (error) {
@@ -217,6 +231,7 @@ export function useWecomBot() {
       );
       toast.error(t('settings.wecomBot.workingDirFailed'));
     } finally {
+      isUpdatingWorkingDirRef.current = false;
       setIsUpdatingWorkingDir(false);
     }
   }, [isUpdatingWorkingDir, t]);
@@ -224,10 +239,12 @@ export function useWecomBot() {
   const resetWorkingDirectory = useCallback(async (): Promise<void> => {
     if (isUpdatingWorkingDir) return;
     setIsUpdatingWorkingDir(true);
-    const epoch = ++settingsEpochRef.current;
+    isUpdatingWorkingDirRef.current = true;
+    const ownerEpoch = ownerEpochRef.current;
     try {
       const next = await window.electronAPI.wecomBot.resetWorkingDirectory();
-      if (settingsEpochRef.current !== epoch) return;
+      if (ownerEpochRef.current !== ownerEpoch) return;
+      updateSeqRef.current += 1;
       setChannelSettings(next);
       toast.success(t('settings.wecomBot.workingDirReset'));
     } catch (error) {
@@ -237,9 +254,18 @@ export function useWecomBot() {
       );
       toast.error(t('settings.wecomBot.workingDirFailed'));
     } finally {
+      isUpdatingWorkingDirRef.current = false;
       setIsUpdatingWorkingDir(false);
     }
   }, [isUpdatingWorkingDir, t]);
+
+  /** 拉取最新渠道设置 — 设置卡展开时刷新, 让「目录不可用」警告及时出现。 */
+  const refreshChannelSettings = useCallback(async (): Promise<void> => {
+    // 工作目录更新在途时跳过: 原生选择器关窗会触发 focus 刷新, 这次读取
+    // 大概率读到提交前的旧配置; choose/reset 返回的状态才是最新的。
+    if (isUpdatingWorkingDirRef.current) return;
+    await fetchChannelSettings();
+  }, [fetchChannelSettings]);
 
   return {
     botId,
@@ -278,7 +304,7 @@ export function useWecomBot() {
     disconnect,
     chooseWorkingDirectory,
     resetWorkingDirectory,
-    refreshChannelSettings: fetchChannelSettings,
+    refreshChannelSettings,
   };
 }
 

--- a/apps/desktop/src/renderer/hooks/useWecomBot.ts
+++ b/apps/desktop/src/renderer/hooks/useWecomBot.ts
@@ -22,8 +22,12 @@ export function useWecomBot() {
   const [status, setStatus] = useState<WecomBotTransportStatus>(
     () => cachedState?.status ?? { kind: 'idle' },
   );
+  // 渠道设置不做模块级缓存种子: 缓存不按数据 owner 隔离, 切号后会把上一账号
+  // 的绝对路径闪给新账号。挂载/展开时现拉, 数据本地且量小。
+  const [channelSettings, setChannelSettings] = useState<WecomChannelSettingsState | null>(null);
   const [isSaving, setIsSaving] = useState(false);
   const [isDisconnecting, setIsDisconnecting] = useState(false);
+  const [isUpdatingWorkingDir, setIsUpdatingWorkingDir] = useState(false);
   const [validationError, setValidationError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -45,9 +49,33 @@ export function useWecomBot() {
       .catch((error) => {
         log.error('getStatus failed:', error instanceof Error ? error.message : String(error));
       });
+    void window.electronAPI.wecomBot
+      .getChannelSettings()
+      .then((settings) => {
+        if (cancelled) return;
+        setChannelSettings(settings);
+      })
+      .catch((error) => {
+        log.error(
+          'getChannelSettings failed:',
+          error instanceof Error ? error.message : String(error),
+        );
+      });
     return () => {
       cancelled = true;
     };
+  }, []);
+
+  /** 拉取最新渠道设置 — 设置卡展开时刷新, 让「目录不可用」警告及时出现。 */
+  const refreshChannelSettings = useCallback(async (): Promise<void> => {
+    try {
+      setChannelSettings(await window.electronAPI.wecomBot.getChannelSettings());
+    } catch (error) {
+      log.error(
+        'refreshChannelSettings failed:',
+        error instanceof Error ? error.message : String(error),
+      );
+    }
   }, []);
 
   useEffect(
@@ -161,6 +189,42 @@ export function useWecomBot() {
     }
   }, [isDisconnecting, t]);
 
+  const chooseWorkingDirectory = useCallback(async (): Promise<void> => {
+    if (isUpdatingWorkingDir) return;
+    setIsUpdatingWorkingDir(true);
+    try {
+      const result = await window.electronAPI.wecomBot.chooseWorkingDirectory();
+      setChannelSettings(result.state);
+      if (!result.canceled) toast.success(t('settings.wecomBot.workingDirSaved'));
+    } catch (error) {
+      log.error(
+        'chooseWorkingDirectory failed:',
+        error instanceof Error ? error.message : String(error),
+      );
+      toast.error(t('settings.wecomBot.workingDirFailed'));
+    } finally {
+      setIsUpdatingWorkingDir(false);
+    }
+  }, [isUpdatingWorkingDir, t]);
+
+  const resetWorkingDirectory = useCallback(async (): Promise<void> => {
+    if (isUpdatingWorkingDir) return;
+    setIsUpdatingWorkingDir(true);
+    try {
+      const next = await window.electronAPI.wecomBot.resetWorkingDirectory();
+      setChannelSettings(next);
+      toast.success(t('settings.wecomBot.workingDirReset'));
+    } catch (error) {
+      log.error(
+        'resetWorkingDirectory failed:',
+        error instanceof Error ? error.message : String(error),
+      );
+      toast.error(t('settings.wecomBot.workingDirFailed'));
+    } finally {
+      setIsUpdatingWorkingDir(false);
+    }
+  }, [isUpdatingWorkingDir, t]);
+
   return {
     botId,
     setBotId: (value: string) => {
@@ -174,25 +238,30 @@ export function useWecomBot() {
     },
     ownerUserId,
     status,
+    channelSettings,
     validationError,
     isSaving,
     isDisconnecting,
+    isUpdatingWorkingDir,
     canConnect: Boolean(
       botId.trim() &&
-        secret.trim() &&
-        status.kind !== 'connecting' &&
-        !isSaving &&
-        !isDisconnecting,
+      secret.trim() &&
+      status.kind !== 'connecting' &&
+      !isSaving &&
+      !isDisconnecting,
     ),
     canReconnect: Boolean(
       botId.trim() &&
-        !secret.trim() &&
-        status.kind !== 'connecting' &&
-        !isSaving &&
-        !isDisconnecting,
+      !secret.trim() &&
+      status.kind !== 'connecting' &&
+      !isSaving &&
+      !isDisconnecting,
     ),
     connect,
     reconnect,
     disconnect,
+    chooseWorkingDirectory,
+    resetWorkingDirectory,
+    refreshChannelSettings,
   };
 }

--- a/apps/desktop/src/renderer/hooks/useWecomBot.ts
+++ b/apps/desktop/src/renderer/hooks/useWecomBot.ts
@@ -45,6 +45,12 @@ export function useWecomBot() {
   const updateSeqRef = useRef(0);
   /** isUpdatingWorkingDir 的 ref 镜像: refreshChannelSettings 的在途守卫用。 */
   const isUpdatingWorkingDirRef = useRef(false);
+  /**
+   * 更新在途期间到达的 boundary-ready: 此刻拉取会被在途守卫跳过、读到提交前
+   * 旧配置, 只能记下来, 由 choose/reset 收尾(finishWorkingDirUpdate)补拉 —
+   * ready 一轮登录只广播一次, 跳过即永久丢失(切号后设置停在 null)。
+   */
+  const pendingBoundaryReadyRef = useRef(false);
   /** null = 尚未确定 owner(冷启动, 无模块缓存种子)。 */
   const ownerRef = useRef<string | null>(cachedState?.ownerUserId ?? null);
   /** 推送代次: 挂载快照归来前已有推送先行到达时, 丢弃过期快照(同 useWechatBot)。 */
@@ -81,7 +87,23 @@ export function useWecomBot() {
    * 返回之后发起, 必然读到已提交状态。
    */
   const refetchAfterOwnerFlip = useCallback((): void => {
+    // 这里的收敛读取已覆盖「ready 待补拉」的意图 — 清掉 pending, 防止收尾
+    // 时对同一目标重复拉取。
+    pendingBoundaryReadyRef.current = false;
     updateSeqRef.current += 1;
+    void fetchChannelSettings();
+  }, [fetchChannelSettings]);
+
+  /**
+   * choose/reset 的统一收尾: 先解除更新在途守卫, 再补拉更新期间到达的
+   * boundary-ready(若有)。补拉发生在 choose/reset 完全结束之后, ready 又已
+   * 表示新账号边界激活 — 此时读到的是当前 owner 的已落盘状态; 迟到守卫照常,
+   * ownerEpoch 再推进则丢弃, 由推进方自己的重拉兜底。
+   */
+  const finishWorkingDirUpdate = useCallback((): void => {
+    isUpdatingWorkingDirRef.current = false;
+    if (!pendingBoundaryReadyRef.current) return;
+    pendingBoundaryReadyRef.current = false;
     void fetchChannelSettings();
   }, [fetchChannelSettings]);
 
@@ -269,10 +291,10 @@ export function useWecomBot() {
       );
       toast.error(t('settings.wecomBot.workingDirFailed'));
     } finally {
-      isUpdatingWorkingDirRef.current = false;
+      finishWorkingDirUpdate();
       setIsUpdatingWorkingDir(false);
     }
-  }, [isUpdatingWorkingDir, refetchAfterOwnerFlip, t]);
+  }, [finishWorkingDirUpdate, isUpdatingWorkingDir, refetchAfterOwnerFlip, t]);
 
   const resetWorkingDirectory = useCallback(async (): Promise<void> => {
     if (isUpdatingWorkingDir) return;
@@ -296,10 +318,10 @@ export function useWecomBot() {
       );
       toast.error(t('settings.wecomBot.workingDirFailed'));
     } finally {
-      isUpdatingWorkingDirRef.current = false;
+      finishWorkingDirUpdate();
       setIsUpdatingWorkingDir(false);
     }
-  }, [isUpdatingWorkingDir, refetchAfterOwnerFlip, t]);
+  }, [finishWorkingDirUpdate, isUpdatingWorkingDir, refetchAfterOwnerFlip, t]);
 
   /** 拉取最新渠道设置 — 设置卡展开时刷新, 让「目录不可用」警告及时出现。 */
   const refreshChannelSettings = useCallback(async (): Promise<void> => {
@@ -314,9 +336,13 @@ export function useWecomBot() {
       // 冷启动/换号窗口: 首次拉取撞上 IM 账号边界未激活会被 Main fail-closed
       // 拒绝([IM_NOT_READY]), 设置停在 null; Main 在边界激活时广播 ready,
       // 到达即重拉, 不必等设置卡展开。迟到守卫不变 — ownerEpoch/updateSeq
-      // 已推进的响应照旧丢弃, 更新在途时 refreshChannelSettings 自会跳过
-      // (其结果由 choose/reset 落地的新状态取代)。
+      // 已推进的响应照旧丢弃。更新在途时不能拉也不能丢: 记入 pending, 由
+      // choose/reset 收尾(finishWorkingDirUpdate)补拉。
       window.electronAPI.onImAccountBoundaryReady(() => {
+        if (isUpdatingWorkingDirRef.current) {
+          pendingBoundaryReadyRef.current = true;
+          return;
+        }
         void refreshChannelSettings();
       }),
     [refreshChannelSettings],

--- a/apps/desktop/src/renderer/hooks/useWecomBot.ts
+++ b/apps/desktop/src/renderer/hooks/useWecomBot.ts
@@ -73,6 +73,19 @@ export function useWecomBot() {
   }, []);
 
   /**
+   * choose/reset 结果因 owner 翻转被丢弃后的收敛。Main 侧已把新状态落盘并
+   * 返回 — TOFU 首绑定(''→sender)只是渠道维度换 owner, 不动 IM 账号代次,
+   * Main 照常提交; 但 owner 翻转触发的渠道设置读取出发于提交之前, 迟到落地
+   * 会带着提交前的旧配置, 把已落盘的新状态盖掉或停在旧值上。先推进
+   * updateSeq 作废这些在途旧读取, 再为当前 owner 重拉一次 — 重拉在 Main
+   * 返回之后发起, 必然读到已提交状态。
+   */
+  const refetchAfterOwnerFlip = useCallback((): void => {
+    updateSeqRef.current += 1;
+    void fetchChannelSettings();
+  }, [fetchChannelSettings]);
+
+  /**
    * 统一的状态落地。ownerUserId 变化(含首次确定)= 数据主人换了: 立即失效
    * 旧 owner 的渠道设置(绝对路径不得跨账号展示), 作废在途响应, 并重拉新
    * owner 的设置。在途请求无法保证服务于哪个 owner — 宁可多拉一次本地小数据。
@@ -240,7 +253,12 @@ export function useWecomBot() {
       // 原生弹窗 + Main 侧异步探测期间可能切号: 仅 owner 变化才丢弃。
       // 同 owner 内 focus 触发的并发刷新不构成丢弃理由 — 这里返回的是刚
       // 落盘的最新状态, 丢弃它会让新目录显示不出来(实测回归)。
-      if (ownerEpochRef.current !== ownerEpoch) return;
+      if (ownerEpochRef.current !== ownerEpoch) {
+        // owner 翻转丢弃结果, 但 Main 已提交 — 收敛到已落盘状态, 不停在
+        // 翻转触发的提交前旧读取上。
+        refetchAfterOwnerFlip();
+        return;
+      }
       updateSeqRef.current += 1;
       setChannelSettings(result.state);
       if (!result.canceled) toast.success(t('settings.wecomBot.workingDirSaved'));
@@ -254,7 +272,7 @@ export function useWecomBot() {
       isUpdatingWorkingDirRef.current = false;
       setIsUpdatingWorkingDir(false);
     }
-  }, [isUpdatingWorkingDir, t]);
+  }, [isUpdatingWorkingDir, refetchAfterOwnerFlip, t]);
 
   const resetWorkingDirectory = useCallback(async (): Promise<void> => {
     if (isUpdatingWorkingDir) return;
@@ -263,7 +281,11 @@ export function useWecomBot() {
     const ownerEpoch = ownerEpochRef.current;
     try {
       const next = await window.electronAPI.wecomBot.resetWorkingDirectory();
-      if (ownerEpochRef.current !== ownerEpoch) return;
+      if (ownerEpochRef.current !== ownerEpoch) {
+        // owner 翻转丢弃结果, 但 Main 已删除配置 — 收敛到已落盘状态。
+        refetchAfterOwnerFlip();
+        return;
+      }
       updateSeqRef.current += 1;
       setChannelSettings(next);
       toast.success(t('settings.wecomBot.workingDirReset'));
@@ -277,7 +299,7 @@ export function useWecomBot() {
       isUpdatingWorkingDirRef.current = false;
       setIsUpdatingWorkingDir(false);
     }
-  }, [isUpdatingWorkingDir, t]);
+  }, [isUpdatingWorkingDir, refetchAfterOwnerFlip, t]);
 
   /** 拉取最新渠道设置 — 设置卡展开时刷新, 让「目录不可用」警告及时出现。 */
   const refreshChannelSettings = useCallback(async (): Promise<void> => {
@@ -286,6 +308,19 @@ export function useWecomBot() {
     if (isUpdatingWorkingDirRef.current) return;
     await fetchChannelSettings();
   }, [fetchChannelSettings]);
+
+  useEffect(
+    () =>
+      // 冷启动/换号窗口: 首次拉取撞上 IM 账号边界未激活会被 Main fail-closed
+      // 拒绝([IM_NOT_READY]), 设置停在 null; Main 在边界激活时广播 ready,
+      // 到达即重拉, 不必等设置卡展开。迟到守卫不变 — ownerEpoch/updateSeq
+      // 已推进的响应照旧丢弃, 更新在途时 refreshChannelSettings 自会跳过
+      // (其结果由 choose/reset 落地的新状态取代)。
+      window.electronAPI.onImAccountBoundaryReady(() => {
+        void refreshChannelSettings();
+      }),
+    [refreshChannelSettings],
+  );
 
   return {
     botId,

--- a/apps/desktop/src/renderer/hooks/useWecomBot.ts
+++ b/apps/desktop/src/renderer/hooks/useWecomBot.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { createLogger } from '@/lib/logger';
@@ -30,69 +30,93 @@ export function useWecomBot() {
   const [isUpdatingWorkingDir, setIsUpdatingWorkingDir] = useState(false);
   const [validationError, setValidationError] = useState<string | null>(null);
 
-  useEffect(() => {
-    let cancelled = false;
-    void window.electronAPI.wecomBot
-      .getStatus()
-      .then((state) => {
-        if (cancelled) return;
-        const next = {
-          status: state.status,
-          botId: state.botId ?? '',
-          ownerUserId: state.ownerUserId ?? '',
-        };
-        cachedState = next;
-        setStatus(next.status);
-        setBotId(next.botId);
-        setOwnerUserId(next.ownerUserId);
-      })
-      .catch((error) => {
-        log.error('getStatus failed:', error instanceof Error ? error.message : String(error));
-      });
-    void window.electronAPI.wecomBot
-      .getChannelSettings()
-      .then((settings) => {
-        if (cancelled) return;
-        setChannelSettings(settings);
-      })
-      .catch((error) => {
-        log.error(
-          'getChannelSettings failed:',
-          error instanceof Error ? error.message : String(error),
-        );
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
+  /**
+   * 渠道设置写回的代次。每次发起新请求(挂载/刷新/选择/重置)递增;切号与卸载
+   * 也递增以作废在途响应。异步结果只有发起时的代次仍是当前代次才允许写回 —
+   * 否则账号 A 的旧请求晚于账号 B 的请求返回时, 会把 A 的绝对路径覆盖给 B。
+   */
+  const settingsEpochRef = useRef(0);
+  /** null = 尚未确定 owner(冷启动, 无模块缓存种子)。 */
+  const ownerRef = useRef<string | null>(cachedState?.ownerUserId ?? null);
+  /** 推送代次: 挂载快照归来前已有推送先行到达时, 丢弃过期快照(同 useWechatBot)。 */
+  const pushVersionRef = useRef(0);
 
-  /** 拉取最新渠道设置 — 设置卡展开时刷新, 让「目录不可用」警告及时出现。 */
-  const refreshChannelSettings = useCallback(async (): Promise<void> => {
+  /** 拉取当前 owner 的渠道设置;递增代次, 迟到的旧响应不写回。 */
+  const fetchChannelSettings = useCallback(async (): Promise<void> => {
+    const epoch = ++settingsEpochRef.current;
     try {
-      setChannelSettings(await window.electronAPI.wecomBot.getChannelSettings());
+      const settings = await window.electronAPI.wecomBot.getChannelSettings();
+      if (settingsEpochRef.current !== epoch) return;
+      setChannelSettings(settings);
     } catch (error) {
       log.error(
-        'refreshChannelSettings failed:',
+        'getChannelSettings failed:',
         error instanceof Error ? error.message : String(error),
       );
     }
   }, []);
 
+  /**
+   * 统一的状态落地。ownerUserId 变化(含首次确定)= 数据主人换了: 立即失效
+   * 旧 owner 的渠道设置(绝对路径不得跨账号展示), 作废在途响应, 并重拉新
+   * owner 的设置。在途请求无法保证服务于哪个 owner — 宁可多拉一次本地小数据。
+   */
+  const applyState = useCallback(
+    (next: CachedState) => {
+      cachedState = next;
+      setStatus(next.status);
+      setBotId(next.botId);
+      if (ownerRef.current !== next.ownerUserId) {
+        ownerRef.current = next.ownerUserId;
+        settingsEpochRef.current += 1;
+        setChannelSettings(null);
+        void fetchChannelSettings();
+      }
+      setOwnerUserId(next.ownerUserId);
+      if (next.status.kind === 'connected') setSecret('');
+    },
+    [fetchChannelSettings],
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    const initialPushVersion = pushVersionRef.current;
+    void window.electronAPI.wecomBot
+      .getStatus()
+      .then((state) => {
+        if (cancelled) return;
+        if (pushVersionRef.current !== initialPushVersion) return;
+        applyState({
+          status: state.status,
+          botId: state.botId ?? '',
+          ownerUserId: state.ownerUserId ?? '',
+        });
+      })
+      .catch((error) => {
+        log.error('getStatus failed:', error instanceof Error ? error.message : String(error));
+      });
+    // owner 上下文已知(有模块缓存种子, 含已断开的 '' owner)才挂载即拉;完全
+    // 未知(首次冷启动)时由 applyState 首次确定 owner 后再拉 — 拉早了无法
+    // 保证请求服务于哪个 owner。
+    if (cachedState) void fetchChannelSettings();
+    return () => {
+      cancelled = true;
+      // 卸载作废在途响应(比 cancelled 标志多覆盖 fetchChannelSettings 一路)。
+      settingsEpochRef.current += 1;
+    };
+  }, [applyState, fetchChannelSettings]);
+
   useEffect(
     () =>
       window.electronAPI.wecomBot.onStatusChange((state) => {
-        const next = {
+        pushVersionRef.current += 1;
+        applyState({
           status: state.status,
           botId: state.botId ?? cachedState?.botId ?? '',
           ownerUserId: state.ownerUserId ?? '',
-        };
-        cachedState = next;
-        setStatus(next.status);
-        setBotId(next.botId);
-        setOwnerUserId(next.ownerUserId);
-        if (next.status.kind === 'connected') setSecret('');
+        });
       }),
-    [],
+    [applyState],
   );
 
   const connect = useCallback(async () => {
@@ -110,16 +134,11 @@ export function useWecomBot() {
         botId: nextBotId,
         secret: nextSecret,
       });
-      const next = {
+      applyState({
         status: result.status,
         botId: result.botId ?? nextBotId,
         ownerUserId: result.ownerUserId ?? '',
-      };
-      cachedState = next;
-      setStatus(next.status);
-      setBotId(next.botId);
-      setOwnerUserId(next.ownerUserId);
-      if (next.status.kind === 'connected') setSecret('');
+      });
       if (result.saveErrorStatus?.kind === 'error' || result.status.kind === 'error') {
         toast.error(t('settings.wecomBot.connectFailed'));
         return false;
@@ -134,7 +153,7 @@ export function useWecomBot() {
     } finally {
       setIsSaving(false);
     }
-  }, [botId, isSaving, secret, t]);
+  }, [applyState, botId, isSaving, secret, t]);
 
   const reconnect = useCallback(async () => {
     if (isSaving || !botId.trim()) return false;
@@ -142,15 +161,11 @@ export function useWecomBot() {
     setIsSaving(true);
     try {
       const result = await window.electronAPI.wecomBot.reconnect();
-      const next = {
+      applyState({
         status: result.status,
         botId: result.botId ?? botId.trim(),
         ownerUserId: result.ownerUserId ?? '',
-      };
-      cachedState = next;
-      setStatus(next.status);
-      setBotId(next.botId);
-      setOwnerUserId(next.ownerUserId);
+      });
       if (result.status.kind === 'error') {
         toast.error(t('settings.wecomBot.connectFailed'));
         return false;
@@ -165,19 +180,15 @@ export function useWecomBot() {
     } finally {
       setIsSaving(false);
     }
-  }, [botId, isSaving, t]);
+  }, [applyState, botId, isSaving, t]);
 
   const disconnect = useCallback(async () => {
     if (isDisconnecting) return;
     setIsDisconnecting(true);
     try {
       const result = await window.electronAPI.wecomBot.disconnect();
-      const next = { status: result.status, botId: '', ownerUserId: '' };
-      cachedState = next;
-      setStatus(next.status);
-      setBotId('');
+      applyState({ status: result.status, botId: '', ownerUserId: '' });
       setSecret('');
-      setOwnerUserId('');
       setValidationError(null);
       toast.success(t('settings.wecomBot.disconnected'));
     } catch (error) {
@@ -187,13 +198,16 @@ export function useWecomBot() {
     } finally {
       setIsDisconnecting(false);
     }
-  }, [isDisconnecting, t]);
+  }, [applyState, isDisconnecting, t]);
 
   const chooseWorkingDirectory = useCallback(async (): Promise<void> => {
     if (isUpdatingWorkingDir) return;
     setIsUpdatingWorkingDir(true);
+    const epoch = ++settingsEpochRef.current;
     try {
       const result = await window.electronAPI.wecomBot.chooseWorkingDirectory();
+      // 原生弹窗 + Main 侧异步探测期间可能切号: 迟到结果不得写回。
+      if (settingsEpochRef.current !== epoch) return;
       setChannelSettings(result.state);
       if (!result.canceled) toast.success(t('settings.wecomBot.workingDirSaved'));
     } catch (error) {
@@ -210,8 +224,10 @@ export function useWecomBot() {
   const resetWorkingDirectory = useCallback(async (): Promise<void> => {
     if (isUpdatingWorkingDir) return;
     setIsUpdatingWorkingDir(true);
+    const epoch = ++settingsEpochRef.current;
     try {
       const next = await window.electronAPI.wecomBot.resetWorkingDirectory();
+      if (settingsEpochRef.current !== epoch) return;
       setChannelSettings(next);
       toast.success(t('settings.wecomBot.workingDirReset'));
     } catch (error) {
@@ -262,6 +278,15 @@ export function useWecomBot() {
     disconnect,
     chooseWorkingDirectory,
     resetWorkingDirectory,
-    refreshChannelSettings,
+    refreshChannelSettings: fetchChannelSettings,
   };
 }
+
+export const __testing = {
+  resetCache(): void {
+    cachedState = null;
+  },
+  getCache(): CachedState | null {
+    return cachedState;
+  },
+};

--- a/apps/desktop/src/renderer/hooks/useWecomBot.ts
+++ b/apps/desktop/src/renderer/hooks/useWecomBot.ts
@@ -49,6 +49,12 @@ export function useWecomBot() {
   const ownerRef = useRef<string | null>(cachedState?.ownerUserId ?? null);
   /** 推送代次: 挂载快照归来前已有推送先行到达时, 丢弃过期快照(同 useWechatBot)。 */
   const pushVersionRef = useRef(0);
+  /**
+   * Cindy 数据 owner 的真身(mode+dataOwnerId+ownerGeneration)。企微的
+   * ownerUserId 不是身份判据: 两个 Cindy 账号可能绑同一个企微用户, 两边
+   * 都没配置企微时又同为空串 — 这些换号只有 auth 推送区分得了。
+   */
+  const cindyOwnerRef = useRef<string | null>(null);
 
   /** 拉取当前 owner 的渠道设置;owner 或更新序号已推进的迟到响应不写回。 */
   const fetchChannelSettings = useCallback(async (): Promise<void> => {
@@ -128,6 +134,20 @@ export function useWecomBot() {
       }),
     [applyState],
   );
+
+  useEffect(() => {
+    // Cindy 账号切换(登录/登出/换号)即时失效渠道设置: Main 侧守卫只拦得住
+    // 迟到响应, 清不掉已经渲染出来的旧路径 — 失效必须在 renderer 侧做。
+    const unsubscribe = window.electronAPI.onAuthStateChange((auth) => {
+      const next = `${auth.mode}/${auth.dataOwnerId ?? '-'}/${auth.ownerGeneration}`;
+      if (cindyOwnerRef.current === next) return;
+      cindyOwnerRef.current = next;
+      ownerEpochRef.current += 1;
+      setChannelSettings(null);
+      void fetchChannelSettings();
+    });
+    return unsubscribe;
+  }, [fetchChannelSettings]);
 
   const connect = useCallback(async () => {
     if (isSaving) return false;

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -2072,11 +2072,13 @@
         "unbind": "Unbind"
       },
       "workingDir": {
-        "title": "Working directory for new conversations",
+        "title": "Working Directory for New Conversations",
         "hint": "Used for the first WeChat conversation and after /new. Changing it does not move the current context.",
-        "managed": "Use a Cindy-managed directory",
-        "reset": "Restore default",
-        "unavailable": "The selected directory is unavailable. New conversations temporarily use a Cindy-managed directory."
+        "managed": "Use a Cindy-Managed Directory",
+        "reset": "Restore Default",
+        "unavailable": "The selected directory is unavailable. New conversations temporarily use a Cindy-managed directory. Restore access or pick another directory.",
+        "chooseAria": "Choose Working Directory for New Conversations",
+        "chooseAriaWithDir": "Choose Working Directory for New Conversations, Current: {{dir}}"
       },
       "unbind": {
         "title": "Unbind personal WeChat?",
@@ -2198,6 +2200,18 @@
       "saveFailed": "Save failed: {{message}}",
       "disconnected": "WeCom bot unbound",
       "disconnectFailed": "Unbind failed: {{message}}",
+      "workingDir": {
+        "title": "Working Directory for New Conversations",
+        "hint": "Used for the first WeCom conversation and after /new. Changing it does not move the current context.",
+        "managed": "Use a Cindy-Managed Directory",
+        "reset": "Restore Default",
+        "unavailable": "The selected directory is unavailable. New conversations temporarily use a Cindy-managed directory. Restore access or pick another directory.",
+        "chooseAria": "Choose Working Directory for New Conversations",
+        "chooseAriaWithDir": "Choose Working Directory for New Conversations, Current: {{dir}}"
+      },
+      "workingDirSaved": "Working directory for new WeCom conversations updated",
+      "workingDirReset": "New WeCom conversations now use the default directory",
+      "workingDirFailed": "Could not update the working directory. Select it again.",
       "connected": {
         "heading": "WeCom bot connected",
         "awaitingOwner": "Send the bot a direct message from your WeCom account to bind the owner.",

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -2075,7 +2075,9 @@
         "hint": "WeChat の初回会話と /new の後に使用します。変更しても現在のコンテキストは移動しません。",
         "managed": "Cindy 管理の専用ディレクトリを使用",
         "reset": "デフォルトに戻す",
-        "unavailable": "選択したディレクトリにアクセスできません。新しい会話では一時的に Cindy 管理のディレクトリを使用します。"
+        "unavailable": "選択したディレクトリにアクセスできません。新しい会話では一時的に Cindy 管理のディレクトリを使用します。アクセスを回復するか、別のディレクトリを選択してください。",
+        "chooseAria": "新しい会話の作業ディレクトリを選択",
+        "chooseAriaWithDir": "新しい会話の作業ディレクトリを選択（現在：{{dir}}）"
       },
       "unbind": {
         "title": "個人 WeChat の連携を解除しますか？",
@@ -2197,6 +2199,18 @@
       "saveFailed": "保存失敗：{{message}}",
       "disconnected": "WeCom ボットの連携を解除しました",
       "disconnectFailed": "連携解除に失敗しました：{{message}}",
+      "workingDir": {
+        "title": "新しい会話の作業ディレクトリ",
+        "hint": "WeCom の初回会話と /new の後に使用します。変更しても現在のコンテキストは移動しません。",
+        "managed": "Cindy 管理の専用ディレクトリを使用",
+        "reset": "デフォルトに戻す",
+        "unavailable": "選択したディレクトリにアクセスできません。新しい会話では一時的に Cindy 管理のディレクトリを使用します。アクセスを回復するか、別のディレクトリを選択してください。",
+        "chooseAria": "新しい会話の作業ディレクトリを選択",
+        "chooseAriaWithDir": "新しい会話の作業ディレクトリを選択（現在：{{dir}}）"
+      },
+      "workingDirSaved": "WeCom の新しい会話の作業ディレクトリを更新しました",
+      "workingDirReset": "WeCom の新しい会話はデフォルトディレクトリを使用します",
+      "workingDirFailed": "作業ディレクトリを更新できませんでした。もう一度選択してください。",
       "connected": {
         "heading": "WeCom ボット接続済み",
         "awaitingOwner": "WeCom アカウントからボットへ DM を送り、owner を設定してください。",

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -2075,7 +2075,9 @@
         "hint": "WeChat 첫 대화와 /new 이후에 사용합니다. 변경해도 현재 컨텍스트는 이동하지 않습니다.",
         "managed": "Cindy 관리 전용 디렉터리 사용",
         "reset": "기본값 복원",
-        "unavailable": "선택한 디렉터리에 접근할 수 없습니다. 새 대화는 임시로 Cindy 관리 디렉터리를 사용합니다."
+        "unavailable": "선택한 디렉터리에 접근할 수 없습니다. 새 대화는 임시로 Cindy 관리 디렉터리를 사용합니다. 접근을 복원하거나 다른 디렉터리를 선택하세요.",
+        "chooseAria": "새 대화 작업 디렉터리 선택",
+        "chooseAriaWithDir": "새 대화 작업 디렉터리 선택, 현재: {{dir}}"
       },
       "unbind": {
         "title": "개인 WeChat 연동을 해제하시겠습니까?",
@@ -2197,6 +2199,18 @@
       "saveFailed": "저장 실패: {{message}}",
       "disconnected": "WeCom 봇 연결을 해제했습니다",
       "disconnectFailed": "연결 해제 실패: {{message}}",
+      "workingDir": {
+        "title": "새 대화 작업 디렉터리",
+        "hint": "WeCom 첫 대화와 /new 이후에 사용합니다. 변경해도 현재 컨텍스트는 이동하지 않습니다.",
+        "managed": "Cindy 관리 전용 디렉터리 사용",
+        "reset": "기본값 복원",
+        "unavailable": "선택한 디렉터리에 접근할 수 없습니다. 새 대화는 임시로 Cindy 관리 디렉터리를 사용합니다. 접근을 복원하거나 다른 디렉터리를 선택하세요.",
+        "chooseAria": "새 대화 작업 디렉터리 선택",
+        "chooseAriaWithDir": "새 대화 작업 디렉터리 선택, 현재: {{dir}}"
+      },
+      "workingDirSaved": "WeCom 새 대화 작업 디렉터리가 업데이트되었습니다",
+      "workingDirReset": "WeCom 새 대화가 기본 디렉터리를 사용합니다",
+      "workingDirFailed": "작업 디렉터리를 업데이트하지 못했습니다. 다시 선택하세요.",
       "connected": {
         "heading": "WeCom 봇 연결됨",
         "awaitingOwner": "WeCom 계정에서 봇으로 DM을 보내 owner를 연결하세요.",

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -2075,7 +2075,9 @@
         "hint": "微信首次对话或发送 /new 后使用。更改不会移动当前上下文。",
         "managed": "使用 Cindy 管理的专用目录",
         "reset": "恢复默认",
-        "unavailable": "已选目录当前不可访问；新对话将暂时使用 Cindy 管理的专用目录。"
+        "unavailable": "已选目录当前不可访问，新对话将暂时使用 Cindy 管理的专用目录；请恢复访问或重新选择。",
+        "chooseAria": "选择新对话工作目录",
+        "chooseAriaWithDir": "选择新对话工作目录，当前：{{dir}}"
       },
       "unbind": {
         "title": "解绑个人微信？",
@@ -2197,6 +2199,18 @@
       "saveFailed": "保存失败：{{message}}",
       "disconnected": "已解绑企业微信机器人",
       "disconnectFailed": "解绑失败：{{message}}",
+      "workingDir": {
+        "title": "新对话工作目录",
+        "hint": "企业微信首次对话或发送 /new 后使用。更改不会移动当前上下文。",
+        "managed": "使用 Cindy 管理的专用目录",
+        "reset": "恢复默认",
+        "unavailable": "已选目录当前不可访问，新对话将暂时使用 Cindy 管理的专用目录；请恢复访问或重新选择。",
+        "chooseAria": "选择新对话工作目录",
+        "chooseAriaWithDir": "选择新对话工作目录，当前：{{dir}}"
+      },
+      "workingDirSaved": "企业微信新对话工作目录已更新",
+      "workingDirReset": "企业微信新对话已恢复使用默认目录",
+      "workingDirFailed": "更新工作目录失败，请重新选择",
       "connected": {
         "heading": "企业微信机器人已连接",
         "awaitingOwner": "请使用你的企业微信账号向机器人发送一条单聊消息，完成 owner 绑定。",

--- a/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
@@ -2075,7 +2075,9 @@
         "hint": "微信首次對話或傳送 /new 後使用。更改不會移動當前上下文。",
         "managed": "使用 Cindy 管理的專用目錄",
         "reset": "恢復預設",
-        "unavailable": "已選目錄當前不可訪問；新對話將暫時使用 Cindy 管理的專用目錄。"
+        "unavailable": "已選目錄當前不可訪問，新對話將暫時使用 Cindy 管理的專用目錄；請恢復訪問或重新選擇。",
+        "chooseAria": "選擇新對話工作目錄",
+        "chooseAriaWithDir": "選擇新對話工作目錄，當前：{{dir}}"
       },
       "unbind": {
         "title": "解綁個人微信？",
@@ -2197,6 +2199,18 @@
       "saveFailed": "儲存失敗：{{message}}",
       "disconnected": "已解綁企業微信機器人",
       "disconnectFailed": "解綁失敗：{{message}}",
+      "workingDir": {
+        "title": "新對話工作目錄",
+        "hint": "企業微信首次對話或傳送 /new 後使用。更改不會移動當前上下文。",
+        "managed": "使用 Cindy 管理的專用目錄",
+        "reset": "恢復預設",
+        "unavailable": "已選目錄當前不可訪問，新對話將暫時使用 Cindy 管理的專用目錄；請恢復訪問或重新選擇。",
+        "chooseAria": "選擇新對話工作目錄",
+        "chooseAriaWithDir": "選擇新對話工作目錄，當前：{{dir}}"
+      },
+      "workingDirSaved": "企業微信新對話工作目錄已更新",
+      "workingDirReset": "企業微信新對話已恢復使用預設目錄",
+      "workingDirFailed": "更新工作目錄失敗，請重新選擇",
       "connected": {
         "heading": "企業微信機器人已連線",
         "awaitingOwner": "請使用你的企業微信帳號向機器人傳送一條單聊訊息，完成 owner 繫結。",

--- a/apps/desktop/src/renderer/vite-env.d.ts
+++ b/apps/desktop/src/renderer/vite-env.d.ts
@@ -517,6 +517,12 @@ interface WechatChannelSettingsState {
   workingDirAvailable: boolean;
 }
 
+interface WecomChannelSettingsState {
+  version: 1;
+  workingDir: string | null;
+  workingDirAvailable: boolean;
+}
+
 type DiscordBotSessionAuthCheckResult = {
   ok: boolean;
   missing: 'gateway-key' | 'agent-oauth' | 'provider-key' | 'provider-disconnected' | null;
@@ -2229,6 +2235,12 @@ interface ElectronAPI {
       botId: string | null;
       ownerUserId: string | null;
     }>;
+    getChannelSettings: () => Promise<WecomChannelSettingsState>;
+    chooseWorkingDirectory: () => Promise<{
+      canceled: boolean;
+      state: WecomChannelSettingsState;
+    }>;
+    resetWorkingDirectory: () => Promise<WecomChannelSettingsState>;
     onStatusChange: (
       callback: (update: {
         status: WecomBotTransportStatus;

--- a/apps/desktop/src/renderer/vite-env.d.ts
+++ b/apps/desktop/src/renderer/vite-env.d.ts
@@ -2039,6 +2039,11 @@ interface ElectronAPI {
   authConsumeAccountDeletionRestoredNotice: () => Promise<boolean>;
   onAuthStateChange: (callback: (state: AuthStateChangePayload) => void) => () => void;
   onAuthSessionExpired: (callback: (state: AuthSessionExpiredPayload) => void) => () => void;
+  /**
+   * IM 账号边界激活推送(main 广播, 无 payload)。冷启动/换号窗口里个人微信/企微
+   * 渠道设置首拉会因 [IM_NOT_READY] 失败 — 收到该推送即重拉。
+   */
+  onImAccountBoundaryReady: (callback: () => void) => () => void;
 
   // ── 使用统计(TapDB)同意闸 ──
   getAnalyticsSettings: () => Promise<AnalyticsSettingsPayload>;

--- a/apps/desktop/src/shared/ipc-errors.ts
+++ b/apps/desktop/src/shared/ipc-errors.ts
@@ -197,6 +197,8 @@ export type IpcErrorCode =
   | 'DINGTALK_AUTH_FAILED' // Client ID / Client Secret 被钉钉拒绝
   | 'DINGTALK_NETWORK_FAILED' // 钉钉凭证校验接口不可达
   | 'DINGTALK_STREAM_CONNECTION_FAILED' // 凭证有效，但 Stream WebSocket 未建立
+  // 企业微信渠道工作目录(原生选择器结果保存/恢复默认失败)
+  | 'WECOM_WORKING_DIR_UPDATE_FAILED'
   // 个人资料自助修改(settings → 用户卡片;服务端直写)
   | 'PROFILE_AVATAR_UPLOAD_FAILED' // 头像经 oss-server 预签名直传失败(presign 或 PUT 阶段)
   | 'PROFILE_UPDATE_FAILED' // PATCH /api/me/profile 失败(网络 / 服务端拒绝)
@@ -392,6 +394,7 @@ const IPC_ERROR_CODES: ReadonlySet<IpcErrorCode> = new Set<IpcErrorCode>([
   'DINGTALK_AUTH_FAILED',
   'DINGTALK_NETWORK_FAILED',
   'DINGTALK_STREAM_CONNECTION_FAILED',
+  'WECOM_WORKING_DIR_UPDATE_FAILED',
   'PROFILE_AVATAR_UPLOAD_FAILED',
   'PROFILE_UPDATE_FAILED',
   'BROWSER_FILE_INVALID_TARGET',

--- a/apps/desktop/src/shared/ipc-errors.ts
+++ b/apps/desktop/src/shared/ipc-errors.ts
@@ -199,6 +199,8 @@ export type IpcErrorCode =
   | 'DINGTALK_STREAM_CONNECTION_FAILED' // 凭证有效，但 Stream WebSocket 未建立
   // 企业微信渠道工作目录(原生选择器结果保存/恢复默认失败)
   | 'WECOM_WORKING_DIR_UPDATE_FAILED'
+  // 个人微信渠道工作目录(原生选择器结果保存/恢复默认失败)
+  | 'WECHAT_WORKING_DIR_UPDATE_FAILED'
   // 个人资料自助修改(settings → 用户卡片;服务端直写)
   | 'PROFILE_AVATAR_UPLOAD_FAILED' // 头像经 oss-server 预签名直传失败(presign 或 PUT 阶段)
   | 'PROFILE_UPDATE_FAILED' // PATCH /api/me/profile 失败(网络 / 服务端拒绝)
@@ -395,6 +397,7 @@ const IPC_ERROR_CODES: ReadonlySet<IpcErrorCode> = new Set<IpcErrorCode>([
   'DINGTALK_NETWORK_FAILED',
   'DINGTALK_STREAM_CONNECTION_FAILED',
   'WECOM_WORKING_DIR_UPDATE_FAILED',
+  'WECHAT_WORKING_DIR_UPDATE_FAILED',
   'PROFILE_AVATAR_UPLOAD_FAILED',
   'PROFILE_UPDATE_FAILED',
   'BROWSER_FILE_INVALID_TARGET',


### PR DESCRIPTION
## 这次改了什么

### 摘要

2026-09-22 同步主干 `c7186a37`，解决冲突并适配主干已更换的 Main 异步目录探针；保留主干 Telegram `/new` 创建独立任务与事务性 detach 语义。此 PR 的工作目录刷新只应用于个人微信/企业微信。

为企业微信增加 owner 隔离的「新对话工作目录」设置，并把个人微信、企业微信的目录校验、探针、原子写入、不可用回退和账号代次保护收敛到共享实现。

用户只能通过 Desktop Main 原生目录选择器授权目录；首次创建任务时使用该目录；已有任务不会仅因设置变更迁移，只有发送 `/new`、在同一任务内开始新对话时，才会按当前配置刷新工作目录。目录不可用、探针超时或探针宿主过载时，均 fail-closed 回退 Cindy 管理的专用目录。

本 PR 经多轮 review 后补齐了以下竞态与安全边界：

- 目录选择、读探针、提交和取消路径均校验 IM account generation，换号期间不会跨 owner 返回或落盘绝对路径。
- 目录解析与写探针接入主干的 `MainProcessWorkdirProbeClient`，不恢复主干因 Windows 消息失联问题移除的 UtilityProcess。所有操作异步执行，共享端到端 deadline、全局在途/队列上限与同类同路径 single-flight；渠道 store 保留失败冷却。超时只结束等待，底层 I/O 结束前继续占槽、去重，不能物理取消。
- 远程目录探测及恢复操作（`probe / mkdir / realpath / similar`）拥有保留容量和队列优先级。默认全局最多 2 项 I/O，设置类最多占 1 项；所有超时但未完成的 I/O 继续计入占用。队列满只拒绝确需排队的请求，不误拒可立即占用保留容量的远程操作。
- 冷启动或换号期间，渠道设置首拉被 fail-closed 拒绝后，会在 IM 账号边界激活时自动重拉。
- 账号边界 ready 在目录更新期间到达时会被记为 pending，并在选择/重置收尾后为当前 owner 补拉，不会因在途守卫永久丢失。
- 选择/重置目录期间 owner 发生 TOFU 绑定或代次推进时，会作废提交前读取，并在 Main 返回后重新读取，使 UI 收敛到已落盘状态。
- 个人微信已有任务的普通消息不重复探测工作目录，仅新建任务或 `/new` 时解析。

### 变更类型

- [x] `feat` 新功能
- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：企业微信不能设置工作目录（渠道默认目录，第一阶段）
- 本 PR 包含：
  - owner-scoped 企业微信/个人微信渠道配置
  - 共享工作目录配置与探针工厂
  - 基于主干 Main 异步探针调度器的渠道校验、容量隔离、deadline、冷却与 single-flight 纪律
  - 两渠道 `/new` 工作目录刷新
  - 三个固定的 `wecomBot:*` IPC 与 Preload API
  - 设置页共享 `ImWorkingDirectorySection` 及五语文案
  - 账号代次、冷启动重拉与 Renderer 迟到响应守卫
- 明确不包含：任务级目录 override、非 owner 群成员触发、渠道级 system prompt、SSH/device-link/Mobile 远程目录选择
- 用户可见变化：企业微信设置卡新增「新对话工作目录」；个人微信复用同款区块；不可用目录显示警告并回退托管目录
- 是否存在 breaking change：无

### 远程与多端适配结论

- **SSH：不涉及。** 本功能配置的是 Desktop 本地个人微信／企业微信渠道创建的本地任务所使用的工作目录，设置与探针都在本机运行，不进入 `maker-remote-ssh`、`remote-file-service` 或 cc-manager 的 SSH 远程工作区链路；因此本 PR 不提供 SSH 远程目录选择。
- **device-link：不新增远程入口或协议字段，且不登记 allowlist；共享目录探针调度有影响。** 本 PR 新增的 `wecomBot:get-channel-settings`、`wecomBot:choose-working-directory`、`wecomBot:reset-working-directory` 三个 invoke，以及个人微信对应的工作目录能力，都只服务可信本地 Renderer：Main 打开本机原生目录选择器，Renderer 不提交路径，返回的本机绝对路径只在本机设置页消费，远程控制端不应调用这些能力。新增的 `im:account-boundary-ready` push 无 payload，只在 Desktop 本地 IM 账号边界激活后通知本地设置页重拉；远程控制端既不需要这个本地 UI 重拉信号，也不应接收它。因此上述 invoke 与 push 均不登记 device-link allowlist。远程新建/目录恢复仍使用主干共享探针，其优先级与保留容量有回归测试；单次目录 I/O 超时仅结束该请求的等待，不重连 relay、不拆 peer link，不改变连接级恢复策略。
- **Mobile：本阶段不提供入口。** Mobile 是被控 Desktop 的控制端，不能代替 Desktop 用户选择该机的本地目录。若未来支持远程目录选择，需要另行设计产品交互、授权边界与 device-link 协议／allowlist，不在本 PR 范围。

### UI 变化

- 引用的设计规范：
  - `docs/design-rules/DESIGN.md` §4 Buttons / Inputs & Forms：按钮和输入态使用 Settings 语义 token
  - `docs/design-rules/DESIGN.md` §10 Light / Dark：颜色全部走语义 token，无单模式硬编码
  - `docs/design-rules/DESIGN.md` §11.2 Casing & Punctuation：英文标题和按钮使用约定大小写
  - `docs/design-rules/DESIGN.md` §14：保留统一的 hover、press、focus 反馈
  - 产品术语遵循 `i18n/glossary.json`：「工作目录」

#### Light

| 默认目录 | 自定义目录 | 目录不可用 |
| --- | --- | --- |
| ![Light default](https://raw.githubusercontent.com/tsuixl/cindy/pr-assets-3216/pr-assets/3216/light-default.png) | ![Light custom](https://raw.githubusercontent.com/tsuixl/cindy/pr-assets-3216/pr-assets/3216/light-custom.png) | ![Light unavailable](https://raw.githubusercontent.com/tsuixl/cindy/pr-assets-3216/pr-assets/3216/light-unavailable.png) |

#### Dark

| 默认目录 | 自定义目录 | 目录不可用（标注区域） |
| --- | --- | --- |
| ![Dark default](https://raw.githubusercontent.com/tsuixl/cindy/pr-assets-3216/pr-assets/3216/dark-default.png) | ![Dark custom](https://raw.githubusercontent.com/tsuixl/cindy/pr-assets-3216/pr-assets/3216/dark-custom.png) | ![Dark unavailable](https://raw.githubusercontent.com/tsuixl/cindy/pr-assets-3216/pr-assets/3216/dark-unavailable-annotated.png) |

截图资源存放在 fork 的独立 `pr-assets-3216` 分支，不进入本 PR 的代码 diff。

## 怎么验证的

### 自动验证

2026-09-22，在同步主干后的 Windows 工作区完成（合并提交 `c19bba56`）：

```text
pnpm test:unit:related
结果：PASS。由于合并带入主干依赖/调度配置更新，自动退回全量：
test:runner 553 passed / 8 skipped（既有平台条件）；
29 个有单测的 workspace 全部通过，其余 6 个无单测 workspace 按仓库清单 notApplicable。
Desktop 295.1s，Mobile 50.5s，maker-core 208.3s。
执行环境使用本机已有 Node 22.23.2、Git Bash 与 Rust，未更改或跳过门禁。

pnpm --filter desktop run --if-present typecheck
结果：PASS

定向 vitest：workdir-probe-host、remoteWorkdirGuard、deviceLinkDispatch /
deviceLinkHostDispatch、两渠道 store / IPC / Hook / Section、accountBoundary、
sessionRepoResetDefaults、slashCommands、wecomGroupNotification
结果：PASS
覆盖保留容量、队列满、四种远程操作优先级、跨排队/执行的 deadline、
超时后仍占槽与同类去重、迟到 realpath/stat 不再启动写入、
迟到独占写入的清理、dispose、微信/企微账号切换与 ready 补拉、
Telegram /new 独立任务与事务性 detach。

pnpm --filter desktop exec eslint（本轮修改的 4 个探针生产模块）
pnpm check:i18n
pnpm check:i18n-glossary
pnpm check:design-inventory
结果：PASS（i18n 存量非阻塞告警保留）

git diff --check upstream/main
pnpm check:dco
结果：PASS；13 个功能提交均签名，1 个 merge commit 按规则豁免且仍带 Signed-off-by。
```

### 手工验证

以下为作者于 2026-08-23 在合并最新主干前的实机验证记录；本次探针实现迁移后的版本尚未重跑真实 Bot / U 盘操作，不把历史截图等同于新版本端到端验收。

- Windows Desktop 设置页截图覆盖 Light / Dark 两种模式
- 覆盖 Cindy 托管默认目录、自定义目录与目录不可用警告三种状态
- 已检查布局、按钮、路径展示、不可用提示及双模式对比度
- Windows 隔离开发环境（CN，`cindy-450bd0`）已使用真实企业微信 Bot 对话验证：自定义目录 `G:\Dev\Github\cindy` 在 `/new` 后生效；恢复默认目录后再次 `/new`，同一任务开始新对话，工作目录切换到当前 owner 的 `im-working-dir/wecom-*` 托管目录
- 已使用 U 盘 `I:\` 实测可移动目录完整链路：任务可使用 U 盘目录；U 盘断开后，Light / Dark 设置页均正确识别为“当前不可访问”；随后发送 `/new`，同一任务开始新对话，工作目录实际切换到当前 owner 的 `im-working-dir/wecom-*` 托管目录

### 未执行的验证

- 合并主干后的版本尚未重跑真实企业微信、U 盘拔插、账号切换及失联网络盘端到端场景；已用自动化测试覆盖对应的目录校验、超时、回退和竞态边界
- 未在 macOS 实机验证；本轮新增代码无平台分支，跨平台文件行为由既有及新增单测覆盖

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异

### 影响与回滚

- 影响范围：
  - 目录只能由可信 Renderer 触发 Main 原生选择器授权；不存在 `setWorkingDirectory(path)` 一类路径注入 API
  - 配置按 data owner 隔离，账号切换前后的慢读取、选择器和探针结果不会跨 owner 落地或展示
  - 探针文件以 `wx` 独占创建，只删除本次调用确认创建的文件；不会扫描或按前缀删除用户目录
  - Main 文件操作无法物理取消。超时结果立即返回，但底层 I/O 仍占槽；若操作始终不返回，设置类后续校验可能持续超时/不可用，直到 I/O 结束或进程重启。此时保留用户配置、回退托管目录，不绕过权限校验。默认设置类不能独占所有容量；远程操作自身也可能耗尽剩余容量，不能声称远程探测永不超时
  - 在 realpath/stat 迟到返回后，不再启动已过期的写探针；已成功独占创建的文件即使超时仍尝试清理，清理失败接受 0 字节残留，不扫描、不延迟重试
  - 个人微信目录可用性判定随共享写探针收紧：只读目录会判为不可用并回退托管目录
- 回滚 / 降级方式：撤销最终合入主干的本 PR 功能提交；不撤销本次同步进来的既有主干改动。企微新增配置可保留（旧版不消费），个人微信沿用原配置格式，无数据库 schema/migration 耦合
- 存量插件影响：无

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已注明设计规范并提供 Light / Dark 截图
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要测试
- [x] 已确认自动验证结果并如实列出未执行项
