### PR TITLE
fix(desktop): 广播持久化后的会话 status,挡住写读间隙的并发回滚 (#3175 增量)

### DIFF
--- a/apps/desktop/src/main/localDb/ipc/__tests__/sessionsUpdate.test.ts
+++ b/apps/desktop/src/main/localDb/ipc/__tests__/sessionsUpdate.test.ts
@@ -527,6 +527,31 @@ describe('local-db:sessions:update handler wiring', () => {
     });
   });
 
+  // 竞态收敛(review on #3225):写入与查询不在同一串行区间,归档写入后、查询前
+  // 另一窗口可能已把行推进到 deleted。广播必须携带持久化后的 updated.status,
+  // 否则副窗/控制端镜像会被请求值回滚成旧 UI 状态(已删除任务复活)。
+  // routeLock 是测试注入的实现:在锁内写库完成后、handler 继续查询前,模拟
+  // 另一窗口的删除落库。
+  it('broadcasts the persisted status when a concurrent window deletes between write and read', async () => {
+    h.routeLock.mockImplementation(async (_sessionId, task) => {
+      await task();
+      h.sqlite!.prepare("UPDATE sessions SET status = 'deleted' WHERE id = ?").run('codex-local');
+    });
+
+    await invokeUpdate('codex-local', { status: 'archived' });
+    await vi.dynamicImportSettled();
+
+    expect(h.tapWindowBroadcast).toHaveBeenCalledWith('local-db:sessions:patched', {
+      sessionId: 'codex-local',
+      patch: { status: 'deleted' },
+    });
+    // 不再出现携带请求值的回滚广播
+    const statusPatches = h.tapWindowBroadcast.mock.calls
+      .filter(([channel]) => channel === 'local-db:sessions:patched')
+      .map(([, payload]) => (payload as { patch: { status?: string } }).patch.status);
+    expect(statusPatches).toEqual(['deleted']);
+  });
+
   it('broadcasts pin and unpin patches to device-link subscribers', async () => {
     const pinnedAt = '2026-08-03T04:08:26.000Z';
     await invokeUpdate('codex-local', { pinnedAt });

--- a/apps/desktop/src/main/localDb/ipc/__tests__/sessionsUpdate.test.ts
+++ b/apps/desktop/src/main/localDb/ipc/__tests__/sessionsUpdate.test.ts
@@ -100,6 +100,14 @@ vi.mock('../../../maker-host/claude-transcript-relocation.js', () => ({
 vi.mock('../../../maker-host/index.js', () => ({
   getMakerIfReady: h.getMakerIfReady,
 }));
+// delete 路径的 removeHookAttachmentDir 会真删 turn change-set;归档路径动态
+// import cindy-brain(重副作用模块)。两者都 mock 掉,本文件只断言广播行为。
+vi.mock('../../../turn-change-set/store.js', () => ({
+  removeTurnChangeSetsForSession: vi.fn(async () => undefined),
+}));
+vi.mock('../../../cindy-brain/index.js', () => ({
+  notifyGhostSessionEvent: vi.fn(),
+}));
 
 import { registerSessionIpc, resumeDeletedPiSubagentCleanup } from '../sessions';
 import { retireDeletedPiSubagentState } from '../piSubagentDeletion';
@@ -484,6 +492,39 @@ describe('local-db:sessions:update handler wiring', () => {
         patch: { status: 'deleted' },
       }),
     );
+  });
+
+  it('broadcasts local unarchive status patches to every window (#3175)', async () => {
+    h.sqlite!.prepare("UPDATE sessions SET status = 'archived' WHERE id = ?").run('codex-local');
+
+    await invokeUpdate('codex-local', { status: 'active' });
+    await vi.dynamicImportSettled();
+
+    const persisted = h
+      .sqlite!.prepare('SELECT status FROM sessions WHERE id = ?')
+      .get('codex-local') as { status: string };
+    expect(persisted.status).toBe('active');
+    expect(h.tapWindowBroadcast).toHaveBeenCalledWith('local-db:sessions:patched', {
+      sessionId: 'codex-local',
+      patch: { status: 'active' },
+    });
+  });
+
+  // setStatus 的归档形是 { status, pinnedAt: null }:广播沿用置顶合并逻辑,
+  // 归档一并清 pin 与摘要(归档列表不该保留 pin 标记)。
+  it('broadcasts local archive status patches with the unpin merge (#3175)', async () => {
+    await invokeUpdate('codex-local', { status: 'archived', pinnedAt: null });
+    await vi.dynamicImportSettled();
+
+    const persisted = h
+      .sqlite!.prepare('SELECT status, pinned_at AS pinnedAt FROM sessions WHERE id = ?')
+      .get('codex-local') as { status: string; pinnedAt: number | null };
+    expect(persisted.status).toBe('archived');
+    expect(persisted.pinnedAt).toBeNull();
+    expect(h.tapWindowBroadcast).toHaveBeenCalledWith('local-db:sessions:patched', {
+      sessionId: 'codex-local',
+      patch: { status: 'archived', pinnedAt: null, summary: null },
+    });
   });
 
   it('broadcasts pin and unpin patches to device-link subscribers', async () => {

--- a/apps/desktop/src/main/localDb/ipc/__tests__/sessionsUpdate.test.ts
+++ b/apps/desktop/src/main/localDb/ipc/__tests__/sessionsUpdate.test.ts
@@ -40,6 +40,7 @@ const h = vi.hoisted(() => ({
     closeSession: (id: string) => Promise<void>;
   } | null => null),
   setPinnedSectionCardMode: vi.fn(),
+  upsertRecentWorkdir: vi.fn(async () => undefined),
   routeLock: vi.fn(async <T>(_sessionId: string, task: () => Promise<T>): Promise<T> =>
     task(),
   ) as SessionRouteLockMock,
@@ -77,7 +78,7 @@ vi.mock('../../../git-context/prRefsStore', () => ({
   recomputePrRefsForSession: vi.fn(async () => undefined),
 }));
 vi.mock('../../../imageCacheStore', () => ({ removeSession: vi.fn(async () => undefined) }));
-vi.mock('../recentWorkdirs', () => ({ upsertRecentWorkdir: vi.fn(async () => undefined) }));
+vi.mock('../recentWorkdirs', () => ({ upsertRecentWorkdir: h.upsertRecentWorkdir }));
 vi.mock('../../../device-link/broadcast-tap.js', () => ({
   getSafeDataOwnerPushStamp: vi.fn(() => undefined),
   tapWindowBroadcast: h.tapWindowBroadcast,
@@ -546,6 +547,29 @@ describe('local-db:sessions:update handler wiring', () => {
       patch: { status: 'deleted' },
     });
     // 不再出现携带请求值的回滚广播
+    const statusPatches = h.tapWindowBroadcast.mock.calls
+      .filter(([channel]) => channel === 'local-db:sessions:patched')
+      .map(([, payload]) => (payload as { patch: { status?: string } }).patch.status);
+    expect(statusPatches).toEqual(['deleted']);
+  });
+
+  // 竞态收敛(review on #3225 第二轮):读行与广播之间还有 await(摘要清理 /
+  // recent-workdir / 转录迁移),期间另一窗口可删除并先广播 deleted;本 handler
+  // 恢复后若用旧快照广播 archived,该广播是最后一条,镜像不会自愈——已删任务
+  // 持久复活。upsertRecentWorkdir 是已 mock 的依赖:在其 await 期间模拟删除落库,
+  // 断言广播前重读了状态。
+  it('re-reads status before broadcasting when an await intervenes after the row read', async () => {
+    h.upsertRecentWorkdir.mockImplementationOnce(async () => {
+      h.sqlite!.prepare("UPDATE sessions SET status = 'deleted' WHERE id = ?").run('cc-local');
+    });
+
+    await invokeUpdate('cc-local', { status: 'archived', workspaceKind: 'project' });
+    await vi.dynamicImportSettled();
+
+    expect(h.tapWindowBroadcast).toHaveBeenCalledWith('local-db:sessions:patched', {
+      sessionId: 'cc-local',
+      patch: expect.objectContaining({ status: 'deleted' }),
+    });
     const statusPatches = h.tapWindowBroadcast.mock.calls
       .filter(([channel]) => channel === 'local-db:sessions:patched')
       .map(([, payload]) => (payload as { patch: { status?: string } }).patch.status);

--- a/apps/desktop/src/main/localDb/ipc/sessions.ts
+++ b/apps/desktop/src/main/localDb/ipc/sessions.ts
@@ -1494,13 +1494,23 @@ export function registerSessionIpc(
       row.summary = null;
     }
     const updated = sessionToCamel(row);
+    // status 广播必须用**持久化后的 updated.status**,不能带请求值 p.status:写入
+    // (withStatusWriteLock)与这里的查询不在同一串行区间,两个窗口对同一任务并发
+    // 操作时,本请求写入后、查询前可能被另一窗口推进到更晚的终态(如归档写入后
+    // 被删除)。广播请求值会把镜像回滚成旧 UI 状态(已删除任务在副窗/控制端复活);
+    // 广播持久化真值则天然收敛——即使请求 archived 而行已 deleted,广播 deleted
+    // 与另一窗口的广播幂等重合。置顶合并沿用 updated 值同理。
     const broadcastPatch =
-      p.pinnedAt === undefined
+      p.pinnedAt === undefined && p.status === undefined
         ? p
         : {
             ...p,
-            pinnedAt: updated.pinnedAt,
-            ...(updated.pinnedAt === null ? { summary: null } : { status: updated.status }),
+            ...(p.pinnedAt !== undefined ? { pinnedAt: updated.pinnedAt } : {}),
+            ...(p.status !== undefined ? { status: updated.status } : {}),
+            ...(p.pinnedAt !== undefined && updated.pinnedAt === null ? { summary: null } : {}),
+            ...(p.pinnedAt !== undefined && updated.pinnedAt !== null
+              ? { status: updated.status }
+              : {}),
           };
     const projectTargetChanged = p.workspaceKind !== undefined || p.workingDir !== undefined;
     const settingsChanged = Object.keys(p).some((key) => REMOTE_PERSIST_FIELDS.has(key));

--- a/apps/desktop/src/main/localDb/ipc/sessions.ts
+++ b/apps/desktop/src/main/localDb/ipc/sessions.ts
@@ -1494,24 +1494,6 @@ export function registerSessionIpc(
       row.summary = null;
     }
     const updated = sessionToCamel(row);
-    // status 广播必须用**持久化后的 updated.status**,不能带请求值 p.status:写入
-    // (withStatusWriteLock)与这里的查询不在同一串行区间,两个窗口对同一任务并发
-    // 操作时,本请求写入后、查询前可能被另一窗口推进到更晚的终态(如归档写入后
-    // 被删除)。广播请求值会把镜像回滚成旧 UI 状态(已删除任务在副窗/控制端复活);
-    // 广播持久化真值则天然收敛——即使请求 archived 而行已 deleted,广播 deleted
-    // 与另一窗口的广播幂等重合。置顶合并沿用 updated 值同理。
-    const broadcastPatch =
-      p.pinnedAt === undefined && p.status === undefined
-        ? p
-        : {
-            ...p,
-            ...(p.pinnedAt !== undefined ? { pinnedAt: updated.pinnedAt } : {}),
-            ...(p.status !== undefined ? { status: updated.status } : {}),
-            ...(p.pinnedAt !== undefined && updated.pinnedAt === null ? { summary: null } : {}),
-            ...(p.pinnedAt !== undefined && updated.pinnedAt !== null
-              ? { status: updated.status }
-              : {}),
-          };
     const projectTargetChanged = p.workspaceKind !== undefined || p.workingDir !== undefined;
     const settingsChanged = Object.keys(p).some((key) => REMOTE_PERSIST_FIELDS.has(key));
     const titleChanged = p.title !== undefined;
@@ -1526,6 +1508,37 @@ export function registerSessionIpc(
     ) {
       await upsertRecentWorkdir(row.workingDir, Date.now());
     }
+    // status 广播必须用**广播时刻的持久化真值**,不能带请求值 p.status,也不能用
+    // 上方读行的快照:写入(withStatusWriteLock)与广播不在同一串行区间,且读行
+    // 之后、广播之前还有 await(摘要清理 / recent-workdir / 转录迁移),两个窗口
+    // 对同一任务并发操作时,本请求可能在此期间被另一窗口推进到更晚的终态(如
+    // 归档写入后被删除)。用过期值广播会把镜像回滚成旧 UI 状态(已删除任务在
+    // 副窗/控制端复活),且若本广播是最后一条,镜像不会自愈。
+    //
+    // 因此含 status 的 patch 在广播前(所有 await 之后)**重读一次**:重读与广播
+    // 之间无 await,同进程单事件循环下不可能再插入并发写;即便并发删除的广播
+    // 晚于本广播到达,镜像最终也收敛到 deleted。
+    let broadcastStatus = updated.status;
+    if (p.status !== undefined) {
+      const [currentRow] = await db
+        .select({ status: sessions.status })
+        .from(sessions)
+        .where(eq(sessions.id, sid))
+        .limit(1);
+      if (currentRow) broadcastStatus = currentRow.status;
+    }
+    const broadcastPatch =
+      p.pinnedAt === undefined && p.status === undefined
+        ? p
+        : {
+            ...p,
+            ...(p.pinnedAt !== undefined ? { pinnedAt: updated.pinnedAt } : {}),
+            ...(p.status !== undefined ? { status: broadcastStatus } : {}),
+            ...(p.pinnedAt !== undefined && updated.pinnedAt === null ? { summary: null } : {}),
+            ...(p.pinnedAt !== undefined && updated.pinnedAt !== null
+              ? { status: broadcastStatus }
+              : {}),
+          };
     if (
       projectTargetChanged ||
       settingsChanged ||

--- a/apps/desktop/src/renderer/features/cc-agent/hooks/useSessionLifecycleActions.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/hooks/useSessionLifecycleActions.ts
@@ -170,9 +170,9 @@ export function useSessionLifecycleActions(options?: { includeArchived?: ListSta
       // 为什么必须全桶、不能只刷当前桶(codex review):归档时 patchLocal 会 drop
       // 目标桶(archived,本地没有这条的完整 row)并立刻重拉,而那次重拉发生在
       // setStatus 写库**之前**,拿回来的是「还没归档」的快照。本机
-      // local-db:sessions:update 又只在 title / settings / project 变化时才广播
-      // sessions:patched(status 不在其中),archived 桶再没有别的修正机会 —— 用户
-      // 切到「已归档」筛选会看不到刚归档的这条,直到某次无关刷新。
+      // local-db:sessions:update 对 status 变化也会广播 sessions:patched(#3175,
+      // 副窗与控制端靠它收敛),但广播只修单个字段、不触发各桶重拉 ——
+      // 已归档桶仍需要这里的 emitRefresh 才能看到刚归档的这条,直到某次无关刷新。
       // 与 unarchiveSession 末尾的 emitRefresh 同口径。
       emitRefresh();
       // 远程会话从侧边栏消失由被控端 sessions:patched{status} 回流(applyPatch 移出分片)驱动,


### PR DESCRIPTION
## 这次改了什么

> **更新（rebase 后）**：#3175 的基础修复（status 变化进广播条件）已由 #3206 合入 main。本 PR rebase 后聚焦**增量**：写读间隙并发竞态的广播收敛 + 补齐测试覆盖。原 a54230f 的功能主体被 main 吸收，不再重复。

### 摘要

review 指出的真竞态（P2）：`withStatusWriteLock` 只包住写入，释放锁后才查询，而广播 patch 携带**请求值** `p.status`。两个窗口对同一任务并发操作时（如归档写入后、查询前另一窗口删除），归档请求会查到已删除的行却仍广播 `archived`，把副窗与 device-link 镜像回滚成旧 UI 状态——已删除任务复活。

修复：`broadcastPatch` 在 patch 含 status 时改为携带 `selectSessionWithCount` 读回的 `updated.status`（持久化真值）。即使请求与持久化结果不一致，广播的也是数据库真值，与另一窗口的广播幂等重合，天然收敛。置顶合并原本就用 updated 值，同口径。

测试增量（`sessionsUpdate.test.ts`）：
- 并发竞态回归：用可注入的 routeLock 在写库后、查询前模拟另一窗口删除，断言 status 广播只有 `deleted`、无请求值回滚
- unarchive（`{status:'active'}`）广播覆盖——此前同样不命中广播条件
- setStatus 归档形（`{status:'archived', pinnedAt:null}`）的置顶合并广播覆盖

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联：#3175（基础修复已由 #3206 合入，本 PR 补竞态收敛与测试）；review 讨论见本 PR conversation
- 明确不包含：归档产品语义、窗口生命周期重构
- 用户可见变化：并发删除/归档交叠时副窗与控制端不再短暂复活已删任务
- 是否存在 breaking change：无

## 怎么验证的

### 自动验证

```text
pnpm vitest run src/main/localDb/ipc/__tests__/sessionsUpdate.test.ts → 28 passed
pnpm --filter desktop run typecheck → 通过
desktop 全量单测（--pool=forks）→ 28065 passed；2 个失败为 ghostInstallReceipt.test.ts，在 upstream/main 干净基线上同样失败（既有问题，与本 PR 无关）
```

### 未执行的验证

双窗口实机并发操作未手工复现（行为由注入 routeLock 的竞态回归测试覆盖）。

## 风险

- 广播持久化真值在语义上只会更保守：请求与持久化不一致时，镜像收到的是 DB 实际状态
- 无新 IPC channel、无协议变更

### 多端适配说明（remote-and-mobile-adaptation PR 门禁）

1. 本 PR 已一并适配：并发场景下控制端收到的 status patch 携带持久化真值，与被控端 DB 收敛
2. 不新增 IPC channel / 推送事件 / allowlist 条目
3. 手机版无需新入口

## 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] 未提交凭证、令牌或授权文件
- [x] 已确认测试结果或说明未执行原因


## UI 变化

- 引用的设计规范：不涉及——`useSessionLifecycleActions.ts` 仅修正一条过时的代码注释（status 广播行为说明），无任何视觉 / 交互 / 文案变化，也不触发渲染路径改动
