### PR TITLE
fix(desktop): Orca worker done 确认被同 turn 收尾拒绝后在 terminal 边界补收口 (#3153)

### DIFF
--- a/apps/desktop/src/main/__tests__/makerSendToSessionOrdering.test.ts
+++ b/apps/desktop/src/main/__tests__/makerSendToSessionOrdering.test.ts
@@ -736,7 +736,7 @@ describe('sendToSession ordering', () => {
   it('marks worker idle and clears auto-bridge state before aborting worker sessions', () => {
     const serviceIdleBlock = extractBetween(
       orcaTeamServiceSource,
-      "async function idleWorker(params: { callerLeadSessionId: string; workerId: string; expectedStatus?: 'done' }): Promise<OrcaOkResult> {",
+      'async function idleWorker(',
       'async function archiveWorker',
     );
     const serviceDepsBlock = extractBetween(

--- a/apps/desktop/src/main/maker-ipc/__tests__/orcaTeamService.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/orcaTeamService.test.ts
@@ -1296,6 +1296,44 @@ describe('OrcaTeamService', () => {
     );
   });
 
+  // terminal 补收口重试若被 active-turn 守卫拒绝,守卫不得把 worker 重新登记——
+  // 否则 fire-once 被打破,且该 terminal 边界之后未必还有下一个 terminal 事件,
+  // worker 会带着悬置登记卡回 done(本机制要修的状态复发)。
+  it('does not re-register a deferred acknowledgement when the terminal retry itself hits the active-turn guard', async () => {
+    const { deps, getWorker, service, setWorker } = createDeps({
+      getLiveSession: vi.fn(() => ({ isTurnRunning: () => true })),
+    });
+    setWorker(createWorker({ status: 'done' }));
+
+    await expect(service.idleWorker({
+      callerLeadSessionId: 'lead-1',
+      workerId: 'worker-1',
+      expectedStatus: 'done',
+    })).resolves.toMatchObject({ ok: false, errorCode: 'WORKER_STATE_CHANGED' });
+
+    // terminal 边界:live session 仍报 running,重试被拒——但不得重新登记。
+    await service.handleWorkerTerminalTurn({
+      sessionId: 'worker-session-1',
+      status: 'done',
+      finalText: 'finished',
+    });
+    expect(getWorker().status).toBe('done');
+    expect(deps.markWorkerIdleIfStatus).not.toHaveBeenCalled();
+    expect(deps.log.info).toHaveBeenCalledWith(
+      'orca deferred done acknowledgement skipped',
+      expect.objectContaining({ workerId: 'worker-1', errorCode: 'WORKER_STATE_CHANGED' }),
+    );
+
+    // 后续再来的 terminal 事件(无新登记来源)也不得触发重试:fire-once 契约成立。
+    await service.handleWorkerTerminalTurn({
+      sessionId: 'worker-session-1',
+      status: 'done',
+      finalText: 'finished',
+    });
+    expect(deps.markWorkerIdleIfStatus).not.toHaveBeenCalled();
+    expect(deps.log.info).toHaveBeenCalledTimes(1);
+  });
+
   it('does not close a direct send that wins the atomic idle-close reservation after the CAS', async () => {
     const { calls, deps, getWorker, service, setWorker } = createDeps({
       getLiveSession: vi.fn(() => ({ isTurnRunning: () => false })),

--- a/apps/desktop/src/main/maker-ipc/__tests__/orcaTeamService.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/orcaTeamService.test.ts
@@ -1182,6 +1182,120 @@ describe('OrcaTeamService', () => {
     expect(calls).toEqual([]);
   });
 
+  // (#3153) 回报 settle 先落库、worker 自己的 turn 还在收尾时,renderer 的
+  // 「看到 done 即 ack」会被 active-turn 守卫拒绝;terminal 边界必须补一次收口,
+  // 否则 worker 永久停在 done(runtime/attention 悬置)。
+  it('retries a skipped done acknowledgement at the worker terminal boundary', async () => {
+    let turnRunning = true;
+    const { calls, getWorker, service, setWorker } = createDeps({
+      getLiveSession: vi.fn(() => ({ isTurnRunning: () => turnRunning })),
+    });
+    setWorker(createWorker({ status: 'done' }));
+
+    await expect(service.idleWorker({
+      callerLeadSessionId: 'lead-1',
+      workerId: 'worker-1',
+      expectedStatus: 'done',
+    })).resolves.toEqual({
+      ok: false,
+      errorCode: 'WORKER_STATE_CHANGED',
+      message: 'worker worker-1 has an active turn',
+    });
+    expect(getWorker().status).toBe('done');
+
+    // worker 的 turn 终止:此时补确认应当成功。
+    turnRunning = false;
+    await service.handleWorkerTerminalTurn({
+      sessionId: 'worker-session-1',
+      status: 'done',
+      finalText: 'finished',
+    });
+
+    expect(getWorker().status).toBe('idle');
+    expect(calls).toEqual([
+      'markWorkerIdleIfStatus',
+      'closeWorkerSessionIfIdle:worker-session-1',
+      'broadcastOrcaWorkerChanged',
+    ]);
+  });
+
+  it('does not auto-acknowledge a done worker at the terminal boundary without a skipped attempt', async () => {
+    const { calls, getWorker, service, setWorker } = createDeps();
+    setWorker(createWorker({ status: 'done' }));
+
+    await service.handleWorkerTerminalTurn({
+      sessionId: 'worker-session-1',
+      status: 'done',
+      finalText: 'finished',
+    });
+
+    // done 的语义是「保持到用户看到为止」:用户从未确认过的 done 不能被 terminal 收口。
+    expect(getWorker().status).toBe('done');
+    expect(calls).toEqual([]);
+  });
+
+  it('does not retry a deferred acknowledgement after a new turn started and re-finished', async () => {
+    let turnRunning = true;
+    const { calls, getWorker, service, setWorker } = createDeps({
+      getLiveSession: vi.fn(() => ({ isTurnRunning: () => turnRunning })),
+    });
+    setWorker(createWorker({ status: 'done' }));
+
+    await expect(service.idleWorker({
+      callerLeadSessionId: 'lead-1',
+      workerId: 'worker-1',
+      expectedStatus: 'done',
+    })).resolves.toMatchObject({ ok: false, errorCode: 'WORKER_STATE_CHANGED' });
+
+    // 新 turn 开始:旧 done 被取代,悬置的补确认必须作废。
+    await service.handleWorkerTurnStarted('worker-session-1');
+    expect(getWorker().status).toBe('running');
+
+    // 新 turn 结束且再次 settle 为 done(模拟下一次 send_to_lead):不应触发旧补确认。
+    turnRunning = false;
+    setWorker(createWorker({ status: 'done' }));
+    await service.handleWorkerTerminalTurn({
+      sessionId: 'worker-session-1',
+      status: 'done',
+      finalText: 'finished',
+    });
+
+    expect(getWorker().status).toBe('done');
+    expect(calls).toEqual(['updateWorkerStatus:running', 'broadcastOrcaWorkerChanged']);
+  });
+
+  it('consumes a deferred acknowledgement even when the terminal retry is rejected', async () => {
+    let turnRunning = true;
+    let queuedInput = false;
+    const { deps, getWorker, service, setWorker } = createDeps({
+      getLiveSession: vi.fn(() => ({ isTurnRunning: () => turnRunning })),
+      hasPendingWorkerInput: vi.fn(async () => queuedInput),
+    });
+    setWorker(createWorker({ status: 'done' }));
+
+    await expect(service.idleWorker({
+      callerLeadSessionId: 'lead-1',
+      workerId: 'worker-1',
+      expectedStatus: 'done',
+    })).resolves.toMatchObject({ ok: false, errorCode: 'WORKER_STATE_CHANGED' });
+
+    // terminal 边界重试时已有新排队输入:确认被拒(fire-once,不重登记),worker 保持 done。
+    turnRunning = false;
+    queuedInput = true;
+    await service.handleWorkerTerminalTurn({
+      sessionId: 'worker-session-1',
+      status: 'done',
+      finalText: 'finished',
+    });
+
+    expect(getWorker().status).toBe('done');
+    expect(deps.markWorkerIdleIfStatus).not.toHaveBeenCalled();
+    expect(deps.log.info).toHaveBeenCalledWith(
+      'orca deferred done acknowledgement skipped',
+      expect.objectContaining({ workerId: 'worker-1', errorCode: 'WORKER_STATE_CHANGED' }),
+    );
+  });
+
   it('does not close a direct send that wins the atomic idle-close reservation after the CAS', async () => {
     const { calls, deps, getWorker, service, setWorker } = createDeps({
       getLiveSession: vi.fn(() => ({ isTurnRunning: () => false })),

--- a/apps/desktop/src/main/maker-ipc/__tests__/orcaTeamService.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/orcaTeamService.test.ts
@@ -1299,6 +1299,53 @@ describe('OrcaTeamService', () => {
   // terminal 补收口重试若被 active-turn 守卫拒绝,守卫不得把 worker 重新登记——
   // 否则 fire-once 被打破,且该 terminal 边界之后未必还有下一个 terminal 事件,
   // worker 会带着悬置登记卡回 done(本机制要修的状态复发)。
+  // turn-start 的登记作废必须在 running 提交之后:旧 done 的 ack 若与
+  // turn-start 并发(它在 transition 队列上排队,轮到时观察到旧 done + 新
+  // active turn),守卫拒绝后的登记会残留;running 提交后的清理必须把它清掉,
+  // 否则脏 entry 存活到新 turn 的 terminal 边界被消费,绕过用户可见性语义。
+  it('invalidates a deferred acknowledgement re-registered after the turn-start transition commits', async () => {
+    let turnRunning = false;
+    let startedRunning = false;
+    const { getWorker, service, setWorker } = createDeps({
+      getLiveSession: vi.fn(() => ({ isTurnRunning: () => turnRunning })),
+      listWorkersByLead: vi.fn(async (leadSessionId: string) => {
+        if (startedRunning) {
+          // turn-start 已提交 running(测试 mock 状态已推进):此刻与 turn-start
+          // 并发排队的旧 done ack 开始执行——它读到的 worker 行若是 done(mock
+          // 已是 running,这里临时换回 done 模拟其读到旧快照),守卫拒绝并登记。
+          const saved = getWorker().status;
+          setWorker(createWorker({ status: 'done' }));
+          const result = await service.idleWorker({
+            callerLeadSessionId: leadSessionId,
+            workerId: 'worker-1',
+            expectedStatus: 'done',
+          });
+          setWorker(createWorker({ status: saved }));
+          expect(result).toMatchObject({ ok: false, errorCode: 'WORKER_STATE_CHANGED' });
+          startedRunning = false;
+        }
+        return [getWorker()];
+      }),
+    });
+    setWorker(createWorker({ status: 'done' }));
+
+    turnRunning = true;
+    await service.handleWorkerTurnStarted('worker-session-1');
+    // turn-start 完成:状态 running,且其后临界区外插队的登记已被清理。
+    expect(getWorker().status).toBe('running');
+
+    // 新 turn 结束 settle 为 done:terminal 边界不得消费插队登记(用户从未见过)。
+    turnRunning = false;
+    setWorker(createWorker({ status: 'done' }));
+    await service.handleWorkerTerminalTurn({
+      sessionId: 'worker-session-1',
+      status: 'done',
+      finalText: 'finished',
+    });
+
+    expect(getWorker().status).toBe('done');
+  });
+
   it('does not re-register a deferred acknowledgement when the terminal retry itself hits the active-turn guard', async () => {
     const { deps, getWorker, service, setWorker } = createDeps({
       getLiveSession: vi.fn(() => ({ isTurnRunning: () => true })),

--- a/apps/desktop/src/main/maker-ipc/orcaTeamService.ts
+++ b/apps/desktop/src/main/maker-ipc/orcaTeamService.ts
@@ -321,6 +321,13 @@ export function createOrcaTeamService(deps: OrcaTeamServiceDeps): OrcaTeamServic
   const workerTransitionTails = new Map<string, Promise<void>>();
   /** Active dispatch count stays positive from pre-resume reservation through host dispatch settlement. */
   const activeWorkerDispatches = new Map<string, number>();
+  /**
+   * (#3153) done 确认被「同 turn 仍在收尾」拒绝(active turn / send in progress)时登记,
+   * 在该 turn 的 terminal 边界重试一次。fire-once:重试前即消费,不因重试失败重登记——
+   * 下一次 done 广播仍会走 renderer 的可见性 ack 路径。done 的产品语义是
+   * 「保持到用户看到为止」,所以只在 renderer 已尝试过确认时补收口,不做无条件自动 ack。
+   */
+  const deferredDoneAcknowledgements = new Set<string>();
 
   async function withWorkerTransition<T>(workerId: string, operation: () => Promise<T>): Promise<T> {
     const previous = workerTransitionTails.get(workerId) ?? Promise.resolve();
@@ -742,6 +749,8 @@ export function createOrcaTeamService(deps: OrcaTeamServiceDeps): OrcaTeamServic
         return { ok: false, errorCode: 'ALREADY_IDLE', message: `worker ${params.workerId} is already idle` };
       }
       if (params.expectedStatus && deps.getLiveSession(worker.sessionId)?.isTurnRunning()) {
+        // 回报 settle 先落库、worker 自己的 turn 还在收尾:登记后由 terminal 边界重试(#3153)。
+        if (params.expectedStatus === 'done') deferredDoneAcknowledgements.add(worker.id);
         return {
           ok: false,
           errorCode: 'WORKER_STATE_CHANGED',
@@ -749,6 +758,7 @@ export function createOrcaTeamService(deps: OrcaTeamServiceDeps): OrcaTeamServic
         };
       }
       if (params.expectedStatus && deps.hasSendToSessionLock(worker.sessionId)) {
+        if (params.expectedStatus === 'done') deferredDoneAcknowledgements.add(worker.id);
         return {
           ok: false,
           errorCode: 'WORKER_STATE_CHANGED',
@@ -802,6 +812,7 @@ export function createOrcaTeamService(deps: OrcaTeamServiceDeps): OrcaTeamServic
       if (!params.expectedStatus) {
         await closeWorkerSessionBestEffort(worker.sessionId, 'idleWorker');
       }
+      deferredDoneAcknowledgements.delete(worker.id);
       deps.broadcastOrcaWorkerChanged(link.leadSessionId);
       return { ok: true, workerId: worker.id };
     };
@@ -829,6 +840,7 @@ export function createOrcaTeamService(deps: OrcaTeamServiceDeps): OrcaTeamServic
 
     clearRuntimeState(worker.sessionId);
     deps.forgetWorkerSession?.(worker.sessionId);
+    deferredDoneAcknowledgements.delete(worker.id);
     await deps.cancelWorkerSessionOperations(worker.sessionId);
     await closeWorkerSessionBestEffort(worker.sessionId, 'archiveWorker');
     await deps.archiveWorkerSession(worker.sessionId);
@@ -1015,6 +1027,8 @@ export function createOrcaTeamService(deps: OrcaTeamServiceDeps): OrcaTeamServic
     async handleWorkerTurnStarted(sessionId) {
       const link = await deps.getWorkerLinkBySessionId(sessionId);
       if (!link) return;
+      // 新 turn 开始意味着旧 done 状态已被取代,悬置的补确认不再有意义(#3153)。
+      deferredDoneAcknowledgements.delete(link.workerId);
 
       const workers = await deps.listWorkersByLead(link.leadSessionId);
       const worker = workers.find((item) => item.id === link.workerId);
@@ -1030,6 +1044,7 @@ export function createOrcaTeamService(deps: OrcaTeamServiceDeps): OrcaTeamServic
       const workers = await deps.listWorkersByLead(link.leadSessionId);
       const worker = workers.find((item) => item.id === link.workerId);
       if (!worker) {
+        deferredDoneAcknowledgements.delete(link.workerId);
         clearRuntimeState(params.sessionId);
         return;
       }
@@ -1044,7 +1059,28 @@ export function createOrcaTeamService(deps: OrcaTeamServiceDeps): OrcaTeamServic
           });
           return;
         }
+        // (#3153) done 的回报 settle 会先于本 turn 终止落库,renderer「看到 done
+        // 即 ack」在 active-turn 守卫处被拒后没有重试闭环,worker 会永久停在 done
+        // (runtime/attention 悬置)。这里在该 turn 的 terminal 边界补一次收口;
+        // 没登记过被拒确认的 done 保持原样(维持「done 保持到用户看到为止」语义)。
+        const retryAcknowledgeDone =
+          worker.status === 'done' && deferredDoneAcknowledgements.delete(link.workerId);
         clearRuntimeState(params.sessionId);
+        if (!retryAcknowledgeDone) return;
+        const acknowledged = await idleWorker({
+          callerLeadSessionId: link.leadSessionId,
+          workerId: link.workerId,
+          expectedStatus: 'done',
+        });
+        if (!acknowledged.ok) {
+          deps.log.info('orca deferred done acknowledgement skipped', {
+            workerId: link.workerId,
+            leadSessionId: link.leadSessionId,
+            sessionId: params.sessionId,
+            errorCode: acknowledged.errorCode,
+            message: acknowledged.message,
+          });
+        }
         return;
       }
 

--- a/apps/desktop/src/main/maker-ipc/orcaTeamService.ts
+++ b/apps/desktop/src/main/maker-ipc/orcaTeamService.ts
@@ -730,7 +730,16 @@ export function createOrcaTeamService(deps: OrcaTeamServiceDeps): OrcaTeamServic
     };
   }
 
-  async function idleWorker(params: { callerLeadSessionId: string; workerId: string; expectedStatus?: 'done' }): Promise<OrcaOkResult> {
+  async function idleWorker(
+    params: { callerLeadSessionId: string; workerId: string; expectedStatus?: 'done' },
+    /**
+     * (#3153) 内部参数,不走 IPC 边界:terminal 边界的补收口重试必须带
+     * deferredRetry=true——重试再被 active-turn / send 锁守卫拒绝时**不得重新登记**,
+     * 否则 fire-once 契约被打破,且该 terminal 边界之后未必还有下一个 terminal
+     * 事件来消费,worker 会带着悬置登记卡回 done(正是本机制要修的状态)。
+     */
+    opts?: { deferredRetry?: boolean },
+  ): Promise<OrcaOkResult> {
     const found = await resolveWorkerRef(params.callerLeadSessionId, params.workerId);
     if (!found.ok) return workerRefFailureForControl(params.workerId, found);
 
@@ -750,7 +759,10 @@ export function createOrcaTeamService(deps: OrcaTeamServiceDeps): OrcaTeamServic
       }
       if (params.expectedStatus && deps.getLiveSession(worker.sessionId)?.isTurnRunning()) {
         // 回报 settle 先落库、worker 自己的 turn 还在收尾:登记后由 terminal 边界重试(#3153)。
-        if (params.expectedStatus === 'done') deferredDoneAcknowledgements.add(worker.id);
+        // terminal 重试自身被拒时不登记(见 idleWorker 的 opts 注释)。
+        if (params.expectedStatus === 'done' && !opts?.deferredRetry) {
+          deferredDoneAcknowledgements.add(worker.id);
+        }
         return {
           ok: false,
           errorCode: 'WORKER_STATE_CHANGED',
@@ -758,7 +770,9 @@ export function createOrcaTeamService(deps: OrcaTeamServiceDeps): OrcaTeamServic
         };
       }
       if (params.expectedStatus && deps.hasSendToSessionLock(worker.sessionId)) {
-        if (params.expectedStatus === 'done') deferredDoneAcknowledgements.add(worker.id);
+        if (params.expectedStatus === 'done' && !opts?.deferredRetry) {
+          deferredDoneAcknowledgements.add(worker.id);
+        }
         return {
           ok: false,
           errorCode: 'WORKER_STATE_CHANGED',
@@ -1067,11 +1081,15 @@ export function createOrcaTeamService(deps: OrcaTeamServiceDeps): OrcaTeamServic
           worker.status === 'done' && deferredDoneAcknowledgements.delete(link.workerId);
         clearRuntimeState(params.sessionId);
         if (!retryAcknowledgeDone) return;
-        const acknowledged = await idleWorker({
-          callerLeadSessionId: link.leadSessionId,
-          workerId: link.workerId,
-          expectedStatus: 'done',
-        });
+        const acknowledged = await idleWorker(
+          {
+            callerLeadSessionId: link.leadSessionId,
+            workerId: link.workerId,
+            expectedStatus: 'done',
+          },
+          // 补收口重试被拒时不得重新登记,保证 fire-once(见 idleWorker 的 opts 注释)。
+          { deferredRetry: true },
+        );
         if (!acknowledged.ok) {
           deps.log.info('orca deferred done acknowledgement skipped', {
             workerId: link.workerId,

--- a/apps/desktop/src/main/maker-ipc/orcaTeamService.ts
+++ b/apps/desktop/src/main/maker-ipc/orcaTeamService.ts
@@ -1041,15 +1041,23 @@ export function createOrcaTeamService(deps: OrcaTeamServiceDeps): OrcaTeamServic
     async handleWorkerTurnStarted(sessionId) {
       const link = await deps.getWorkerLinkBySessionId(sessionId);
       if (!link) return;
+
       // 新 turn 开始意味着旧 done 状态已被取代,悬置的补确认不再有意义(#3153)。
+      // 作废必须放在 transition 临界区内、running 提交之后:ack 的登记同样发生在
+      // 临界区内,若在临界区外提前 delete,旧 done 的 ack 可以插队在 delete 之后、
+      // running 提交之前重新登记(active-turn 守卫只看 live session,不看持久化
+      // status 是否已推进),脏 entry 会存活到新 turn 的 terminal 边界被消费,
+      // 绕过「done 保持到用户看到为止」的可见性语义直接 idle。
+      await withWorkerTransition(link.workerId, async () => {
+        const workers = await deps.listWorkersByLead(link.leadSessionId);
+        const worker = workers.find((item) => item.id === link.workerId);
+        if (!worker || worker.status === 'running') return;
+
+        await deps.updateWorkerStatus(link.workerId, 'running');
+        deps.broadcastOrcaWorkerChanged(link.leadSessionId);
+      });
+      // running 提交后旧 entry 已不可能被重新登记,此时清理才是可靠的。
       deferredDoneAcknowledgements.delete(link.workerId);
-
-      const workers = await deps.listWorkersByLead(link.leadSessionId);
-      const worker = workers.find((item) => item.id === link.workerId);
-      if (!worker || worker.status === 'running') return;
-
-      await deps.updateWorkerStatus(link.workerId, 'running');
-      deps.broadcastOrcaWorkerChanged(link.leadSessionId);
     },
     async handleWorkerTerminalTurn(params) {
       const link = await deps.getWorkerLinkBySessionId(params.sessionId);

--- a/docs/dev-rules/orca-team-architecture.md
+++ b/docs/dev-rules/orca-team-architecture.md
@@ -282,6 +282,9 @@ Worktree 现状：Orca 与普通 session 对齐，worktree 是可选项，不强
 7. **重启后 Lead↔Worker 互访 / resume 不随开启路径变化（状态：不变量）**
    无论协同通过 `enableTeam` 自动创建首个 worker、MCP `start_team` + `create_worker`，还是 renderer 的协同按钮开启；也无论重启发生在对话中途，还是初始化完毕但 worker 尚未接过真实任务，maker 重启后 Lead 与 Worker 都必须能继续互访。`send_to_worker`、`send_to_lead`、`switch_focus` / idle resume 不能因为内存态丢失、worker link 懒登记缺失或空 worker rollout 缺失而失败。实现指针：`CCAgentSessionView.tsx` 的 `requestEnableCollab`、`packages/lizi-mcps/src/orca/server.ts` 的 `start_team` / `create_worker` 顶层注册、`xdt-helper/start_team.ts` / `create_worker.ts`、`orcaLifecycleService.ts` 的 `startTeam` / `createWorker` / `enableTeam`、`register.ts` 的 `synthesizeOrcaVendorOptionsFromDb` / `resumeOrcaWorkerSessionIfMissing`、`orcaTeamService.ts` 的 `sendToWorker`、`orca-bridge-mcp.ts` 的 worker `send_to_lead` handler。
 
+8. **被同 turn 收尾拒绝的 done 确认必须在 terminal 边界补收口（状态：不变量）**
+   worker 的回报 settle（`send_to_lead` 被接受/入队）会先把持久化状态置 `done`，而 worker 自己的 turn 可能还在收尾；renderer「看到 done 即 ack」此时会被 active-turn / send 锁守卫以 `WORKER_STATE_CHANGED` 拒绝。被这两类守卫拒绝的确认必须登记下来，在该 turn 的 `handleWorkerTerminalTurn` done 分支重试一次（fire-once，重试失败不重登记）；新 turn 开始（`handleWorkerTurnStarted`）必须作废登记。没有登记过的 done 不得在 terminal 边界自动收口——`done` 的产品语义是「保持到用户看到为止」。实现指针：`orcaTeamService.ts` 的 `deferredDoneAcknowledgements`、`idleWorker`、`handleWorkerTurnStarted`、`handleWorkerTerminalTurn`。
+
 ### 测试与回归清单
 
 当前文档要求保留以下回归方向：


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 #3153 中 worker 的 `send_to_lead` 回报已被接受、持久化状态先进入 `done`，但当前 turn 尚未结束时，renderer 对 `done` 的确认被 active-turn 或 send-in-progress 守卫拒绝后没有重试闭环的问题。此前 worker 会永久停留在 `done`，导致 runtime/attention 收口悬置，需重新聚焦或重新派活才能恢复。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#3153
- 本 PR 包含：对被 active-turn / send-in-progress 守卫拒绝的 `done` 确认登记；在对应 turn 的 terminal `done` 边界 fire-once 重试；新 turn 开始、成功 ack、archive 或 worker 行缺失时清理登记；补充回归测试与 Orca 架构说明。
- 明确不包含：不无条件在 terminal 边界自动将 worker 从 `done` 收口到 `idle`；不处理 issue 中可能独立存在的 lead dispatcher 队列 drain 问题。
- 用户可见变化：worker 回报完成后不再因同 turn 收尾竞争而卡在 `done`；无登记的 `done` 仍保持到用户看到为止。
- 是否存在 breaking change：无。

### UI 变化

- 不涉及。
- 引用的设计规范：不涉及：仅修改 desktop main 侧 worker 生命周期与测试、架构文档，不命中 UI 路径。

## 怎么验证的

### 自动验证

```text
vitest run src/main/maker-ipc/__tests__/orcaTeamService.test.ts
结果：75/75 通过；新增 terminal 补收口成功、无登记不自动收口、新 turn 作废登记、重试被拒 fire-once 并记录日志等用例。

orcaWorkerControlHandlers / makerSendToSessionOrdering / workerTurnStartSequencer
结果：43/43 通过。

pnpm --filter desktop run typecheck
结果：通过。

vitest related（全量相关测试）
结果：本改动相关测试全部通过；localDb 的 orcaTeamStore / sessionAutoTitlePersist 21 个失败可在干净 upstream main 基线复现，与本改动无代码交集。
```

### 手工验证

不涉及：本次以 main 进程 worker 生命周期单元测试覆盖 active turn、terminal 边界与新 turn 并发时序。

### 未执行的验证

未执行完整手工桌面端流程；原因是变更不涉及 renderer/UI，关键竞争时序已由单元测试覆盖。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：worker 生命周期并发收口。

### 影响与回滚

- 影响范围：desktop main 进程的 Orca worker `done` 确认与 turn terminal 收口。现有 transition 队列、CAS、pending 输入与失败回滚护栏保持不变；terminal 重试失败不会重新登记，维持 fire-once。
- 回滚 / 降级方式：回滚本 PR 的提交即可恢复原有行为；不涉及数据迁移、协议或持久化格式变更。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [ ] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因