### PR TITLE
fix: Orca worker 收口 / Pi rehydrate resume / CC 隐式路由 / Subagent 详情入口 (#3153 #2882 #3210 #3154)

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/claudeProxyImplicitPathOverride.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/claudeProxyImplicitPathOverride.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockGetAppCapabilities } = vi.hoisted(() => ({
+  mockGetAppCapabilities: vi.fn(() => ({ canUseCindyGateway: true })),
+}));
+
+vi.mock('../../appCapabilities.js', () => ({
+  getAppCapabilities: mockGetAppCapabilities,
+}));
+vi.mock('../logger-adapter', () => ({
+  createMakerLogger: () => ({
+    trace: vi.fn(), debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(),
+    child: vi.fn(function self() { return { trace: vi.fn(), debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), child: self }; }),
+  }),
+  desktopMakerLogger: {
+    trace: vi.fn(), debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(),
+    child: vi.fn(() => ({ trace: vi.fn(), debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+  },
+}));
+vi.mock('../runtime-configs', () => ({
+  claudeUpstreamEndpoint: () => 'https://gateway.example.com',
+}));
+vi.mock('../silent-encrypted-retry-store', () => ({
+  readSilentEncryptedRetrySettings: () => ({ enabled: false }),
+}));
+vi.mock('../claude-fast-mode-log', () => ({
+  createClaudeFastModeRequestTransform: () => () => null,
+  createClaudeFastModeResponseObserver: () => () => undefined,
+}));
+
+import { buildUserProvider } from '@cindy/model-providers';
+
+import {
+  createModelRoutingTransform,
+  setClaudeProxyGatewayKeyReader,
+  setClaudeProxySessionIdResolver,
+} from '../anthropic-compat-proxy-host';
+import {
+  setCustomProviderKeyReader,
+  setPendingCredentialSwitchReader,
+  setProviderOAuthTokenReader,
+  setProviderViewsReader,
+} from '../provider-route';
+import { getActiveCatalog, setCustomProviders } from '../active-catalog';
+import { clearSessionProvider, setSessionProvider } from '../session-provider-store';
+import { buildRegistry } from '@cindy/model-providers';
+
+function ctxWith(headers: Record<string, string>) {
+  return { reqId: 1, method: 'POST', url: '/v1/messages', headers } as never;
+}
+
+describe('cc proxy ①.5 implicit route — requestPath 透传 (#3210 P2 follow-up)', () => {
+  beforeEach(() => {
+    setClaudeProxyGatewayKeyReader(() => 'sk-gw');
+    setClaudeProxySessionIdResolver(() => null);
+    setPendingCredentialSwitchReader(() => undefined);
+    setProviderOAuthTokenReader(() => null);
+    setCustomProviders([
+      buildUserProvider({
+        id: 'tenant-bridge',
+        name: 'Tenant Bridge',
+        runtimes: {
+          'claude-code': {
+            baseUrl: 'https://tenant.example.com/api/anthropic',
+            // 用户在多租户网关后配置了子路径,会话绑定后由 resolveSessionRouteDecision
+            // 写 pathOverride;隐式首包也必须带上,否则打到原始 /v1/messages 会 404。
+            requestPath: '/tenant/acme/v1/messages',
+            wireProtocol: 'anthropic-messages',
+            models: [{ id: 'glm-5.3', name: 'GLM-5.3' }],
+          },
+        },
+      }),
+    ]);
+    setCustomProviderKeyReader(() => 'tenant-key');
+    setProviderViewsReader(async () =>
+      buildRegistry(getActiveCatalog(), { 'tenant-bridge': true }, {}),
+    );
+  });
+
+  afterEach(() => {
+    setCustomProviders([]);
+    setCustomProviderKeyReader(() => null);
+    setProviderViewsReader(async () => []);
+    clearSessionProvider('sess-implicit');
+  });
+
+  it('forwards the user-configured requestPath when routing the implicit first packet', async () => {
+    const transform = createModelRoutingTransform();
+    const decision = await Promise.resolve(
+      transform(
+        { model: 'glm-5.3' },
+        ctxWith({ 'x-api-key': 'sk-gw' }),
+      ),
+    );
+    expect(decision).toMatchObject({
+      upstreamOverride: 'https://tenant.example.com/api/anthropic',
+      pathOverride: '/tenant/acme/v1/messages',
+      headerOverride: {
+        'x-api-key': 'tenant-key',
+      },
+    });
+  });
+
+  it('does not override an explicit XD session with the implicit user bridge (#3210 P1 follow-up)', async () => {
+    // 会话已显式选 XD,但运行期 gateway key 被清除、cc 子进程仍携带冻结的
+    // x-api-key。此时 ① 段 scope 门放行到 ② 段,那里有专门的 XD passthrough
+    // 分支(按会话实际流量记 gateway 账)。①.5 隐式段绝不能用用户 bridge 覆盖它,
+    // 否则用户明确选 XD 的提示词与计费被改送到另一上游。
+    setClaudeProxySessionIdResolver((sdkId) =>
+      sdkId === 'sdk-xd' ? 'sess-xd' : null,
+    );
+    setSessionProvider('sess-xd', 'xd');
+    const transform = createModelRoutingTransform();
+    const decision = await Promise.resolve(
+      transform(
+        { model: 'glm-5.3' },
+        ctxWith({
+          'x-claude-code-session-id': 'sdk-xd',
+          'x-api-key': 'sk-frozen',
+        }),
+      ),
+    );
+    // 走 ② 段:已选 XD 时由网关 key 决策接管(记 gateway 账),绝不能落到
+    // 用户自定义 bridge(tenant-key)。断言不是 tenant bridge 即可——具体
+    // headerOverride 由 ② 段的 spawn-aware 默认路由决定(gateway key 或 passthrough)。
+    expect(decision).not.toMatchObject({
+      upstreamOverride: 'https://tenant.example.com/api/anthropic',
+    });
+    if (decision && 'headerOverride' in decision && decision.headerOverride) {
+      expect(decision.headerOverride['x-api-key']).not.toBe('tenant-key');
+    }
+  });
+});

--- a/apps/desktop/src/main/maker-host/__tests__/claudeProxyImplicitRoute.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/claudeProxyImplicitRoute.test.ts
@@ -139,6 +139,61 @@ describe('cc routingTransform — ①.5 隐式来源路由 (智谱 glm-5.3 裸 i
     });
   });
 
+  it('未完成 provider 持久化绑定的首包不保留已停用的隐式来源', async () => {
+    const views = buildRegistry(getActiveCatalog(), { 'zhipu-plan': true })
+      .map((view) => ({
+        ...view,
+        models: {
+          ...view.models,
+          'claude-code': (view.models['claude-code'] ?? []).map((model) =>
+            model.id === 'glm-5.3' ? { ...model, disabled: true } : model,
+          ),
+        },
+      }));
+    setProviderViewsReader(async () => views);
+    setClaudeProxySessionIdResolver((sdkId) => (sdkId === 'sdk-race' ? 'sess-race' : null));
+    clearSessionProvider('sess-race');
+
+    const decision = await Promise.resolve(
+      transform(
+        { model: 'glm-5.3' },
+        ctxWith({ 'x-claude-code-session-id': 'sdk-race', 'x-api-key': 'sk-gw' }),
+      ),
+    );
+
+    // 只有 session id,但 provider 尚未 hydrate 时,停用来源不能被当成既有会话续跑。
+    expect(decision).toBeNull();
+  });
+
+  it('已 hydrate 的隐式会话续跑时保留原已停用来源', async () => {
+    const views = buildRegistry(getActiveCatalog(), { 'zhipu-plan': true })
+      .map((view) => ({
+        ...view,
+        models: {
+          ...view.models,
+          'claude-code': (view.models['claude-code'] ?? []).map((model) =>
+            model.id === 'glm-5.3' ? { ...model, disabled: true } : model,
+          ),
+        },
+      }));
+    setProviderViewsReader(async () => views);
+    setClaudeProxySessionIdResolver((sdkId) => (sdkId === 'sdk-race' ? 'sess-race' : null));
+    // null 是已持久化的隐式来源状态,不是“尚未有条目”。
+    setSessionProvider('sess-race', null);
+
+    const decision = await Promise.resolve(
+      transform(
+        { model: 'glm-5.3' },
+        ctxWith({ 'x-claude-code-session-id': 'sdk-race', 'x-api-key': 'sk-gw' }),
+      ),
+    );
+
+    expect(decision).toMatchObject({
+      upstreamOverride: ZHIPU_UPSTREAM,
+      headerOverride: { 'x-api-key': 'glm-user-key' },
+    });
+  });
+
   it('同一裸 model 有多个已连接来源时拒绝请求,不外发默认网关或写计费路由', async () => {
     const provider = (id: string, baseUrl: string) => buildUserProvider({
       id,

--- a/apps/desktop/src/main/maker-host/__tests__/claudeProxyImplicitRoute.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/claudeProxyImplicitRoute.test.ts
@@ -58,7 +58,7 @@ import {
 } from '../provider-route';
 import { getActiveCatalog, setCustomProviders } from '../active-catalog';
 import { buildRegistry, buildUserProvider } from '@cindy/model-providers';
-import { clearSessionProvider } from '../session-provider-store';
+import { clearSessionProvider, setSessionProvider } from '../session-provider-store';
 import {
   readClaudeSessionRoute,
   resetClaudeSessionRouteRegistryForTest,
@@ -107,6 +107,7 @@ describe('cc routingTransform — ①.5 隐式来源路由 (智谱 glm-5.3 裸 i
     setCustomProviderKeyReader(() => null);
     setProviderViewsReader(async () => []);
     clearSessionProvider('sess-race');
+    clearSessionProvider('sess-xd');
     resetClaudeSessionRouteRegistryForTest();
   });
 
@@ -210,5 +211,27 @@ describe('cc routingTransform — ①.5 隐式来源路由 (智谱 glm-5.3 裸 i
       ),
     );
     expect(readClaudeSessionRoute('sess-race')).toBe('gateway');
+  });
+
+  it('已显式绑定 XD 的会话不被隐式 bridge 覆盖(#3210 P1,冻结 x-api-key 场景)', async () => {
+    // 场景:会话显式选了内置 XD,运行期 gateway key 被清除(此处把网关注入器置空),
+    // 但 Claude 子进程仍携带 spawn 时冻结的 x-api-key;同时一个已连接的用户 Anthropic
+    // 兼容上游也提供该非 anthropic-wire 裸 id。隐式推断若以 explicitCustomProvider 为闸
+    // (对内置 XD 为 false)会先选中用户 bridge,把用户明确选 XD 的提示词与计费改送到
+    // 另一上游。必须以 !selectedProviderId 为闸(镜像 codex !explicitProviderId):任何
+    // 已绑定供应商的会话都不进入隐式推断,交由 ② 段 XD passthrough 处理。
+    setClaudeProxyGatewayKeyReader(() => null);
+    setClaudeProxySessionIdResolver((sdkId) => (sdkId === 'sdk-xd' ? 'sess-xd' : null));
+    setSessionProvider('sess-xd', 'xd');
+    const decision = await Promise.resolve(
+      transform(
+        { model: 'glm-5.3' },
+        // 子进程冻结的 x-api-key 不是占位 key,但 host 已无活网关 key 可换。
+        ctxWith({ 'x-claude-code-session-id': 'sdk-xd', 'x-api-key': 'frozen-xd-key' }),
+      ),
+    );
+    // ② 段:显式 XD 会话携带冻结 key → passthrough(null),不被 ①.5 隐式推断改送到
+    // 智谱上游(修复前会返回 upstreamOverride=ZHIPU_UPSTREAM + glm-user-key)。
+    expect(decision).toBeNull();
   });
 });

--- a/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
@@ -2522,6 +2522,70 @@ describe('createModelRoutingTransform —— session-less 控制面请求(桶③
     setProviderOAuthTokenReader(() => null);
   });
 
+  it('uses the hydrated-session gate before preserving a disabled implicit bridge source', async () => {
+    const host = await import('../codex-proxy-host.js');
+    const { buildRegistry, buildUserProvider } = await import('@cindy/model-providers');
+    const { getActiveCatalog, setCustomProviders } = await import('../active-catalog.js');
+    const {
+      setCustomProviderKeyReader,
+      setProviderViewsReader,
+    } = await import('../provider-route.js');
+    const { clearSessionProvider, setSessionProvider } = await import('../session-provider-store.js');
+    const sessionId = 'session-disabled-implicit';
+    const threadId = 'thread-disabled-implicit';
+    setCustomProviders([
+      buildUserProvider({
+        id: 'disabled-implicit-provider',
+        name: 'Disabled implicit provider',
+        runtimes: {
+          codex: {
+            baseUrl: 'https://disabled-implicit.example/v1',
+            wireProtocol: 'openai-chat',
+            models: [{ id: 'resume-model', name: 'Resume model' }],
+          },
+        },
+      }),
+    ]);
+    setCustomProviderKeyReader(() => 'resume-key');
+    const views = buildRegistry(getActiveCatalog(), { 'disabled-implicit-provider': true })
+      .map((view) => ({
+        ...view,
+        models: {
+          ...view.models,
+          codex: (view.models.codex ?? []).map((model) =>
+            model.id === 'resume-model' ? { ...model, disabled: true } : model,
+          ),
+        },
+      }));
+    setProviderViewsReader(async () => views);
+    host.registerComposed(sessionId, threadId, 'PRODUCT_PROMPT');
+    host.setCodexProxyAuthInjection('env-key');
+    clearSessionProvider(sessionId);
+
+    try {
+      const request = {
+        model: 'resume-model',
+        input: [{ role: 'user', content: 'hello' }],
+      };
+      const ctx = { reqId: 1, method: 'POST', url: '/responses', headers: { 'thread-id': threadId } };
+      // session id alone is not proof that persistence finished; strict admission rejects the
+      // disabled source and the env-key default route remains a passthrough.
+      await expect(Promise.resolve(host.createModelRoutingTransform()(request, ctx))).resolves.toBeNull();
+
+      // A hydrated null provider entry is the durable fact for an established implicit session.
+      setSessionProvider(sessionId, null);
+      await expect(Promise.resolve(host.createModelRoutingTransform()(request, { ...ctx, reqId: 2 })))
+        .resolves.toMatchObject({ localHandler: expect.any(Function) });
+    } finally {
+      host.unregister(sessionId);
+      clearSessionProvider(sessionId);
+      setCustomProviderKeyReader(() => null);
+      setProviderViewsReader(async () => []);
+      setCustomProviders([]);
+      host.clearCodexProxyAuthInjection();
+    }
+  });
+
   it('provider-oauth spawn + xAI session + 非 xai/ 模型 → 换网关 key 的可用默认路由 (#890 review 第二轮)', async () => {
     // scope 门放下来的请求在 provider-oauth spawn 下只带占位 env key,直落网关必 401 ——
     // 必须换真网关 key 兜底(与 cc oauth-spawn 默认换 key 同语义)。

--- a/apps/desktop/src/main/maker-host/__tests__/providerRoute.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/providerRoute.test.ts
@@ -195,6 +195,166 @@ describe('implicit local bridge resume routing', () => {
       routing: { wireProtocol: 'anthropic-messages' },
     });
   });
+
+  it('does not guess when two connected user providers expose the same bare model id (#3210 P1)', async () => {
+    // 两个已连接的用户自定义 Anthropic 兼容来源都暴露裸 id glm-5.3。会话启动/切模竞态下
+    // getSessionProvider 暂时为 null,此时绝不能把首包猜发给其中一个来源(数据外发+错计费),
+    // 应回落默认路由,等 provider 绑定落定后重试恢复。
+    setCustomProviders([
+      buildUserProvider({
+        id: 'zhipu-a',
+        name: 'Zhipu A',
+        runtimes: {
+          'claude-code': {
+            baseUrl: 'https://open.bigmodel.example/a/api/anthropic',
+            wireProtocol: 'anthropic-messages',
+            models: [{ id: 'glm-5.3', name: 'GLM-5.3' }],
+          },
+        },
+      }),
+      buildUserProvider({
+        id: 'zhipu-b',
+        name: 'Zhipu B',
+        runtimes: {
+          'claude-code': {
+            baseUrl: 'https://open.bigmodel.example/b/api/anthropic',
+            wireProtocol: 'anthropic-messages',
+            models: [{ id: 'glm-5.3', name: 'GLM-5.3' }],
+          },
+        },
+      }),
+    ]);
+    setProviderViewsReader(async () =>
+      buildRegistry(getActiveCatalog(), { 'zhipu-a': true, 'zhipu-b': true }, {}),
+    );
+
+    await expect(
+      resolveImplicitLocalBridgeRoute('glm-5.3', 'claude-code'),
+    ).resolves.toBeNull();
+  });
+
+  it('resolves the sole connected user bridge source for a bare model id', async () => {
+    setCustomProviders([
+      buildUserProvider({
+        id: 'zhipu-solo',
+        name: 'Zhipu Solo',
+        runtimes: {
+          'claude-code': {
+            baseUrl: 'https://open.bigmodel.example/api/anthropic',
+            wireProtocol: 'anthropic-messages',
+            models: [{ id: 'glm-5.3', name: 'GLM-5.3' }],
+          },
+        },
+      }),
+    ]);
+    setCustomProviderKeyReader(() => 'glm-user-key');
+    setProviderViewsReader(async () =>
+      buildRegistry(getActiveCatalog(), { 'zhipu-solo': true }, {}),
+    );
+
+    await expect(
+      resolveImplicitLocalBridgeRoute('glm-5.3', 'claude-code'),
+    ).resolves.toMatchObject({
+      providerId: 'zhipu-solo',
+      providerSource: 'user',
+      apiKey: 'glm-user-key',
+    });
+  });
+
+  it('does not treat an unrelated connected user provider as a bridge candidate for a model it does not list (#3210 P1 follow-up)', async () => {
+    // 场景:用户已断连原来源,但一个**不提供该 model** 的 BYOM 仍 connected
+    // (典型:运维临时挂着的空 BYOM)。歧义检查只看到「唯一候选」,如果该候选
+    // 其实不提供 model,providerRoutingForModel 会回落 provider 级 routing,导致
+    // 首包被转发到无关上游 + 凭证泄漏。必须先按 model 存在性过滤。
+    setCustomProviders([
+      buildUserProvider({
+        id: 'byom-unrelated',
+        name: 'Unrelated BYOM',
+        runtimes: {
+          'claude-code': {
+            baseUrl: 'https://unrelated.example/api/anthropic',
+            wireProtocol: 'anthropic-messages',
+            // 提供的是别的 model,不是 glm-5.3
+            models: [{ id: 'unrelated-model', name: 'Unrelated' }],
+          },
+        },
+      }),
+    ]);
+    setProviderViewsReader(async () =>
+      buildRegistry(getActiveCatalog(), { 'byom-unrelated': true }, {}),
+    );
+
+    await expect(
+      resolveImplicitLocalBridgeRoute('glm-5.3', 'claude-code'),
+    ).resolves.toBeNull();
+  });
+
+  it('does not select a suspended user provider even when it is the sole connected bridge (#3210 P1 follow-up)', async () => {
+    // 用户在设置页停用某供应商后凭证仍保留(connected=true),但 suspended=true
+    // 表示该来源不可用于新路由。隐式首包绝不能选它,否则违背用户显式停用动作。
+    setCustomProviders([
+      buildUserProvider({
+        id: 'suspended-bridge',
+        name: 'Suspended Bridge',
+        runtimes: {
+          'claude-code': {
+            baseUrl: 'https://suspended.example/api/anthropic',
+            wireProtocol: 'anthropic-messages',
+            models: [{ id: 'glm-5.3', name: 'GLM-5.3' }],
+          },
+        },
+      }),
+    ]);
+    setCustomProviderKeyReader(() => 'suspended-key');
+    const views = buildRegistry(getActiveCatalog(), { 'suspended-bridge': true }, {})
+      // buildRegistry 用 spread 构造视图,suspended 只在 provider 被整体停用
+      // (access.disabledProviders)时设置。测试里用 JSON round-trip 绕开只读,
+      // 手工打上 suspended=true 模拟"已连接但停用"状态。
+      .map((v) => (v.id === 'suspended-bridge' ? { ...v, suspended: true } : v));
+    setProviderViewsReader(async () => views);
+
+    await expect(
+      resolveImplicitLocalBridgeRoute('glm-5.3', 'claude-code'),
+    ).resolves.toBeNull();
+  });
+
+  it('does not select a provider whose matching model entry is individually disabled (#3210 P1 follow-up)', async () => {
+    // 用户在某供应商下只停用了单个 model(供应商本身仍 connected),ProviderView
+    // 会把该 model 条目标 disabled=true。隐式路由必须排除,否则首包仍打到被
+    // 用户显式停用的模型上游。
+    setCustomProviders([
+      buildUserProvider({
+        id: 'partial-disable',
+        name: 'Partial Disable',
+        runtimes: {
+          'claude-code': {
+            baseUrl: 'https://partial.example/api/anthropic',
+            wireProtocol: 'anthropic-messages',
+            models: [{ id: 'glm-5.3', name: 'GLM-5.3' }],
+          },
+        },
+      }),
+    ]);
+    setCustomProviderKeyReader(() => 'partial-key');
+    const views = buildRegistry(getActiveCatalog(), { 'partial-disable': true }, {})
+      .map((v) => {
+        if (v.id !== 'partial-disable') return v;
+        return {
+          ...v,
+          models: {
+            ...v.models,
+            'claude-code': (v.models['claude-code'] ?? []).map((m) =>
+              m.id === 'glm-5.3' ? { ...m, disabled: true } : m,
+            ),
+          },
+        };
+      });
+    setProviderViewsReader(async () => views);
+
+    await expect(
+      resolveImplicitLocalBridgeRoute('glm-5.3', 'claude-code'),
+    ).resolves.toBeNull();
+  });
 });
 
 describe('local mode Cindy gateway gate', () => {

--- a/apps/desktop/src/main/maker-host/__tests__/providerRoute.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/providerRoute.test.ts
@@ -189,11 +189,68 @@ describe('implicit local bridge resume routing', () => {
     setProviderViewsReader(async () => buildRegistry(getActiveCatalog(), { anthropic: true }, {}));
 
     await expect(
-      resolveImplicitLocalBridgeRoute('claude-retired-live', 'codex'),
+      resolveImplicitLocalBridgeRoute('claude-retired-live', 'codex', { preserveDisabled: true }),
     ).resolves.toMatchObject({
       providerId: 'anthropic',
       routing: { wireProtocol: 'anthropic-messages' },
     });
+  });
+
+  it('strict implicit routing skips a retired copy when an active copy is available', async () => {
+    setAnthropicDiscoveredModels([
+      {
+        id: 'retired-shared',
+        name: 'Retired shared',
+        contextWindow: 200_000,
+        efforts: [],
+        defaultEffort: null,
+        status: 'retired',
+      },
+    ]);
+    setCustomProviders([
+      buildUserProvider({
+        id: 'active-copy',
+        name: 'Active copy',
+        runtimes: {
+          codex: {
+            baseUrl: 'https://active-copy.example/v1',
+            wireProtocol: 'openai-chat',
+            models: [{ id: 'retired-shared', name: 'Retired shared' }],
+          },
+        },
+      }),
+    ]);
+    setCustomProviderKeyReader((providerId) => `${providerId}-key`);
+    setProviderViewsReader(async () =>
+      buildRegistry(getActiveCatalog(), { anthropic: true, 'active-copy': true }, {}),
+    );
+
+    await expect(
+      resolveImplicitLocalBridgeRoute('retired-shared', 'codex'),
+    ).resolves.toMatchObject({
+      providerId: 'active-copy',
+      apiKey: 'active-copy-key',
+    });
+  });
+
+  it('strict implicit routing rejects a retired-only source', async () => {
+    setAnthropicDiscoveredModels([
+      {
+        id: 'retired-only-model',
+        name: 'Retired only',
+        contextWindow: 200_000,
+        efforts: [],
+        defaultEffort: null,
+        status: 'retired',
+      },
+    ]);
+    setProviderViewsReader(async () =>
+      buildRegistry(getActiveCatalog(), { anthropic: true }, {}),
+    );
+
+    await expect(
+      resolveImplicitLocalBridgeRoute('retired-only-model', 'codex'),
+    ).resolves.toBeNull();
   });
 
   it('does not guess when two connected user providers expose the same bare model id (#3210 P1)', async () => {

--- a/apps/desktop/src/main/maker-host/anthropic-compat-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/anthropic-compat-proxy-host.ts
@@ -716,16 +716,22 @@ export function createModelRoutingTransform(): RoutingTransform {
     //     偶发 API Error 400、重试后恢复。与 codex-proxy-host ①.5 段同语义:
     //       - anthropic-messages wire 来源(智谱/自定义 Anthropic 兼容上游)透明转发;
     //       - 唯一 provider-oauth 来源(xai/grok-*)注入对应供应商 OAuth。
-    //     刻意排除:显式自定义供应商会话(① 段已裁决,镜像 codex 的 !explicitProviderId
-    //     闸门)、anthropic wire 模型(claude-* 辅助调用保持 #886 的默认路径语义)、xd
-    //     来源(网关即默认上游,② 段处理且带计费路由记账,这里接管会漏记)、PI 会话
-    //     (PI 有自己的 per-model 路由解析 resolvePiModelRoute,不受隐式推断接管)。
+    //     刻意排除:任何已绑定供应商的会话(含内置 XD/anthropic;① 段 scope 门放行下来的
+    //     辅助请求除外,见下)。镜像 codex 的 !explicitProviderId 闸门 —— 已显式选 XD 在
+    //     gateway key 清除后仍带冻结 x-api-key 时,② 段有专门的 XD passthrough 分支处理
+    //     计费;若这里接管会把显式选 XD 的提示词改送到用户 bridge,违背用户选择
+    //     (#3210 codex review P1)。注意不能用 explicitCustomProvider:它对内置 XD/anthropic
+    //     为 false(applyExclusiveReroute=true),会把已绑定内置来源的非 anthropic-wire 模型
+    //     误纳入隐式推断。其余排除:anthropic wire 模型(claude-* 辅助调用保持 #886 的默认
+    //     路径语义,同时也是 scope 辅助请求的安全回落)、xd 来源(网关即默认上游,② 段处理
+    //     且带计费路由记账,这里接管会漏记)、PI 会话(PI 有自己的 per-model 路由解析
+    //     resolvePiModelRoute,不受隐式推断接管)。
     //     解析复用
     //     resolveImplicitLocalBridgeRouteResolution —— 与模型选择器共用连接态(providerViewsReader),
     //     目录无 bridge 候选的模型同步短路,热路径零额外开销。
     const implicitRouteEligible =
       !piSessionId
-      && !explicitCustomProvider
+      && !selectedProviderId
       && wireModel
       && !isAnthropicWireModel(wireModel, anthropicCatalogModelIds(getActiveCatalog()));
     if (implicitRouteEligible) {

--- a/apps/desktop/src/main/maker-host/anthropic-compat-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/anthropic-compat-proxy-host.ts
@@ -735,7 +735,9 @@ export function createModelRoutingTransform(): RoutingTransform {
       && wireModel
       && !isAnthropicWireModel(wireModel, anthropicCatalogModelIds(getActiveCatalog()));
     if (implicitRouteEligible) {
-      return resolveImplicitLocalBridgeRouteResolution(wireModel, 'claude-code').then((resolution) => {
+      return resolveImplicitLocalBridgeRouteResolution(wireModel, 'claude-code', {
+        preserveDisabled: Boolean(sessionId && hasSessionProvider(sessionId)),
+      }).then((resolution) => {
         if (resolution.kind === 'ambiguous') {
           return refuseAmbiguousImplicitProviderRoute(wireModel);
         }

--- a/apps/desktop/src/main/maker-host/anthropic-compat-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/anthropic-compat-proxy-host.ts
@@ -73,7 +73,7 @@ import {
 } from './claude-session-route-registry.js';
 import { createClaudeGatewayErrorObserver } from './claude-gateway-error-observer.js';
 import { shouldApplyExclusiveProviderReroute } from './model-route-guard.js';
-import { getSessionProvider } from './session-provider-store.js';
+import { getSessionProvider, hasSessionProvider } from './session-provider-store.js';
 import {
   buildRouteDecision,
   gatewayDefaultRouteDecision,

--- a/apps/desktop/src/main/maker-host/codex-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/codex-proxy-host.ts
@@ -84,7 +84,7 @@ import {
   rewriteSessionModelIdForRoute,
 } from './provider-route.js';
 import type { CodexSubagentRouteSnapshot } from './codex-subagent-config.js';
-import { getSessionProvider } from './session-provider-store.js';
+import { getSessionProvider, hasSessionProvider } from './session-provider-store.js';
 import {
   composeResponseObservers,
   recordClaudeRateLimitHeaders,

--- a/apps/desktop/src/main/maker-host/codex-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/codex-proxy-host.ts
@@ -3042,7 +3042,9 @@ export function createModelRoutingTransform(
     // 两者都必须先于 Codex 默认 ChatGPT/XD 分支，避免协议或凭证落错上游。
     if (!explicitProviderId && model) {
       if (sessionId && ctx.method === 'POST') {
-        return resolveImplicitLocalBridgeRoute(model, 'codex').then((localRoute) => {
+        return resolveImplicitLocalBridgeRoute(model, 'codex', {
+          preserveDisabled: hasSessionProvider(sessionId),
+        }).then((localRoute) => {
           if (localRoute) {
             return createLocalBridgeDecision(
               localRoute,

--- a/apps/desktop/src/main/maker-host/provider-route.ts
+++ b/apps/desktop/src/main/maker-host/provider-route.ts
@@ -23,6 +23,7 @@ import {
   actualSourceIdForModel,
   chatEligibleSourcesForModel,
   isExclusiveXaiModelId,
+  isModelSelectableForNewRoute,
   resolvePiModelRoute,
   runtimeCustomProviderId,
   storedCustomProviderId,

--- a/apps/desktop/src/main/maker-host/provider-route.ts
+++ b/apps/desktop/src/main/maker-host/provider-route.ts
@@ -882,14 +882,22 @@ type ConnectedDefaultProviderResolution =
 async function connectedDefaultProviderForModel(
   modelId: string,
   agent: AgentKind,
+  options: ImplicitLocalBridgeRouteOptions,
 ): Promise<ConnectedDefaultProviderResolution> {
   const providers = await providerViewsReader();
-  // 严格口径(不带 includeDisabled):隐式 bridge 只服务「未绑定会话的首包」——
-  // 被用户停用的供应商(suspended)或逐模型停用条目(disabled=true)即便凭证仍 connected
-  // 也不得作为新路由候选,否则把首包转发到用户显式停用的上游(#3210 codex review P1:
-  // suspended / disabled model)。retired 模型没有 disabled=true,仍保留(给运行中会话
-  // 续跑);真正的会话级恢复走 resolveSessionRouteDecision,不经过这里。
-  const eligible = chatEligibleSourcesForModel(providers, modelId, agent);
+  // 新会话 / 尚未完成 provider 绑定的首包走严格准入口径,不能把用户已停用的来源
+  // 当成上游。只有调用方确认 session-provider-store 已有该会话条目时才沿用实际
+  // 路由口径,保留 suspended / disabled 拷贝以便续跑,避免设置变更把后续请求静默改送
+  // 到默认上游。
+  const eligible = chatEligibleSourcesForModel(providers, modelId, agent, {
+    includeDisabled: options.preserveDisabled,
+  }).filter((provider) => {
+    if (options.preserveDisabled) return true;
+    const model = (provider.models[agent] ?? []).find((candidate) => candidate.id === modelId);
+    return model !== undefined && isModelSelectableForNewRoute(model, {
+      userProvider: provider.source === 'user',
+    });
+  });
   // Claude Code can emit its first request before the selected Provider is
   // bound to the session. If more than one connected source exposes the same
   // bare model id, choosing the native default/first source would risk sending
@@ -897,12 +905,16 @@ async function connectedDefaultProviderForModel(
   // session binding arrives; Codex retains its established native-default
   // semantics because its implicit bridge is also used for explicit prefixes.
   if (agent === 'claude-code' && eligible.length > 1) return { kind: 'ambiguous' };
-  // 与上方 eligible 同口径(严格):actualSourceIdForModel 内部默认 includeDisabled,
-  // 直接传全量 providers 会把已停用来源选回。这里只在严格 eligible 集合里按原生默认
-  // 来源定位最终候选。
-  const defaultId = actualSourceIdForModel(eligible, null, modelId, agent);
+  const defaultId = options.preserveDisabled
+    ? actualSourceIdForModel(providers, null, modelId, agent)
+    : actualSourceIdForModel(eligible, null, modelId, agent);
   const provider = eligible.find((candidate) => candidate.id === defaultId);
   return provider ? { kind: 'provider', provider } : { kind: 'none' };
+}
+
+export interface ImplicitLocalBridgeRouteOptions {
+  /** Keep disabled/retired copies only when routing an already-established session. */
+  preserveDisabled?: boolean;
 }
 
 /**
@@ -956,12 +968,13 @@ export type ImplicitLocalBridgeRouteResolution =
 export async function resolveImplicitLocalBridgeRouteResolution(
   modelId: string,
   agent: AgentKind,
+  options: ImplicitLocalBridgeRouteOptions = {},
 ): Promise<ImplicitLocalBridgeRouteResolution> {
   const catalogModelId = modelId.replace(/\[1m\]$/, '');
   if (!hasImplicitLocalBridgeCandidate(catalogModelId, agent)) {
     return { kind: 'none' };
   }
-  const source = await connectedDefaultProviderForModel(catalogModelId, agent);
+  const source = await connectedDefaultProviderForModel(catalogModelId, agent, options);
   if (source.kind !== 'provider') return source;
   const routing = providerRoutingForModel(source.provider, agent, modelId);
   const wire = implicitBridgeWire(routing, agent);
@@ -982,8 +995,9 @@ export async function resolveImplicitLocalBridgeRouteResolution(
 export function resolveImplicitLocalBridgeRoute(
   modelId: string,
   agent: AgentKind,
+  options: ImplicitLocalBridgeRouteOptions = {},
 ): Promise<ResolvedSessionRoute | null> {
-  return resolveImplicitLocalBridgeRouteResolution(modelId, agent).then((resolution) =>
+  return resolveImplicitLocalBridgeRouteResolution(modelId, agent, options).then((resolution) =>
     resolution.kind === 'route' ? resolution.route : null,
   );
 }

--- a/apps/desktop/src/main/maker-host/provider-route.ts
+++ b/apps/desktop/src/main/maker-host/provider-route.ts
@@ -883,9 +883,12 @@ async function connectedDefaultProviderForModel(
   agent: AgentKind,
 ): Promise<ConnectedDefaultProviderResolution> {
   const providers = await providerViewsReader();
-  const eligible = chatEligibleSourcesForModel(providers, modelId, agent, {
-    includeDisabled: true,
-  });
+  // 严格口径(不带 includeDisabled):隐式 bridge 只服务「未绑定会话的首包」——
+  // 被用户停用的供应商(suspended)或逐模型停用条目(disabled=true)即便凭证仍 connected
+  // 也不得作为新路由候选,否则把首包转发到用户显式停用的上游(#3210 codex review P1:
+  // suspended / disabled model)。retired 模型没有 disabled=true,仍保留(给运行中会话
+  // 续跑);真正的会话级恢复走 resolveSessionRouteDecision,不经过这里。
+  const eligible = chatEligibleSourcesForModel(providers, modelId, agent);
   // Claude Code can emit its first request before the selected Provider is
   // bound to the session. If more than one connected source exposes the same
   // bare model id, choosing the native default/first source would risk sending
@@ -893,9 +896,10 @@ async function connectedDefaultProviderForModel(
   // session binding arrives; Codex retains its established native-default
   // semantics because its implicit bridge is also used for explicit prefixes.
   if (agent === 'claude-code' && eligible.length > 1) return { kind: 'ambiguous' };
-  // This runs while dispatching an already-created implicit-source session. Admission for new
-  // sessions/model switches happened earlier; keep its retired/disabled source usable for resume.
-  const defaultId = actualSourceIdForModel(providers, null, modelId, agent);
+  // 与上方 eligible 同口径(严格):actualSourceIdForModel 内部默认 includeDisabled,
+  // 直接传全量 providers 会把已停用来源选回。这里只在严格 eligible 集合里按原生默认
+  // 来源定位最终候选。
+  const defaultId = actualSourceIdForModel(eligible, null, modelId, agent);
   const provider = eligible.find((candidate) => candidate.id === defaultId);
   return provider ? { kind: 'provider', provider } : { kind: 'none' };
 }

--- a/apps/desktop/src/main/maker-ipc/__tests__/orcaTeamService.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/orcaTeamService.test.ts
@@ -1858,6 +1858,7 @@ describe('OrcaTeamService', () => {
       ok: false,
       errorCode: 'WORKER_STATE_CHANGED',
       message: 'worker worker-1 has a send in progress',
+      deferredAcknowledgementRegistered: true,
     });
 
     expect(deps.hasSendToSessionLock).toHaveBeenCalledWith('worker-session-1');
@@ -1881,6 +1882,7 @@ describe('OrcaTeamService', () => {
       ok: false,
       errorCode: 'WORKER_STATE_CHANGED',
       message: 'worker worker-1 has an active turn',
+      deferredAcknowledgementRegistered: true,
     });
 
     expect(deps.getLiveSession).toHaveBeenCalledWith('worker-session-1');
@@ -1910,6 +1912,7 @@ describe('OrcaTeamService', () => {
       ok: false,
       errorCode: 'WORKER_STATE_CHANGED',
       message: 'worker worker-1 has an active turn',
+      deferredAcknowledgementRegistered: true,
     });
     expect(getWorker().status).toBe('done');
 
@@ -2116,6 +2119,7 @@ describe('OrcaTeamService', () => {
       ok: false,
       errorCode: 'WORKER_STATE_CHANGED',
       message: 'worker worker-1 has an active turn',
+      deferredAcknowledgementRegistered: true,
     });
 
     expect(deps.getLiveSession).toHaveBeenCalledTimes(1);

--- a/apps/desktop/src/main/maker-ipc/__tests__/orcaTeamService.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/orcaTeamService.test.ts
@@ -1165,6 +1165,69 @@ describe('OrcaTeamService', () => {
     ]);
   });
 
+  it('retries a deferred done acknowledgement only after auto-bridge delivery succeeds', async () => {
+    let turnRunning = false;
+    const sendAutoBridgeToLead = vi
+      .fn()
+      .mockResolvedValueOnce({ accepted: false })
+      .mockResolvedValueOnce({ accepted: false })
+      .mockResolvedValueOnce({ accepted: true });
+    const { deps, getWorker, service } = createDeps({
+      getLiveSession: vi.fn(() => ({ isTurnRunning: () => turnRunning })),
+      sendAutoBridgeToLead,
+    });
+
+    await service.dispatchWorkerTask({
+      targetSessionId: 'worker-session-1',
+      message: '分析 issue',
+      dispatchMeta: { source: 'test-source', context: 'deferred-done-after-bridge-retry' },
+    });
+    await service.handleWorkerTerminalTurn({
+      sessionId: 'worker-session-1',
+      status: 'done',
+      finalText: '第一次结果',
+    });
+    expect(getWorker().status).toBe('done');
+
+    // Renderer saw done while the turn was still unwinding, so its acknowledgement
+    // is registered for the terminal boundary.
+    turnRunning = true;
+    await expect(
+      service.idleWorker({
+        callerLeadSessionId: 'lead-1',
+        workerId: 'worker-1',
+        expectedStatus: 'done',
+      }),
+    ).resolves.toMatchObject({
+      ok: false,
+      errorCode: 'WORKER_STATE_CHANGED',
+      deferredAcknowledgementRegistered: true,
+    });
+
+    // A rejected retry keeps the bridge generation alive and must not clear the
+    // worker runtime or consume the one-shot acknowledgement.
+    turnRunning = false;
+    await service.handleWorkerTerminalTurn({
+      sessionId: 'worker-session-1',
+      status: 'done',
+      finalText: '第一次结果',
+    });
+    expect(getWorker().status).toBe('done');
+    expect(deps.markWorkerIdleIfStatus).not.toHaveBeenCalled();
+
+    // Once a later terminal boundary delivers the bridge, it must consume the
+    // deferred done acknowledgement in that same boundary.
+    await service.handleWorkerTerminalTurn({
+      sessionId: 'worker-session-1',
+      status: 'done',
+      finalText: '第一次结果',
+    });
+
+    expect(sendAutoBridgeToLead).toHaveBeenCalledTimes(3);
+    expect(getWorker().status).toBe('idle');
+    expect(deps.markWorkerIdleIfStatus).toHaveBeenCalledTimes(1);
+  });
+
   it('does not auto-bridge when there is no worker link', async () => {
     const leadMessages: string[] = [];
     const { deps, service } = createDeps({

--- a/apps/desktop/src/main/maker-ipc/__tests__/orcaTeamService.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/orcaTeamService.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { AgentInputQueuedMessage } from '../../../shared/agentInputQueue';
 import {

--- a/apps/desktop/src/main/maker-ipc/__tests__/orcaTeamService.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/orcaTeamService.test.ts
@@ -2100,7 +2100,9 @@ describe('OrcaTeamService', () => {
   it('does not close a direct send that wins the atomic idle-close reservation after the CAS', async () => {
     const { calls, deps, getWorker, service, setWorker } = createDeps({
       getLiveSession: vi.fn(() => ({ isTurnRunning: () => false })),
-      closeWorkerSessionIfIdle: vi.fn(async () => false),
+      closeWorkerSessionIfIdle: vi.fn()
+        .mockResolvedValueOnce(false)
+        .mockResolvedValueOnce(true),
     });
     setWorker(createWorker({ status: 'done' }));
 
@@ -2123,6 +2125,18 @@ describe('OrcaTeamService', () => {
     expect(deps.broadcastOrcaWorkerChanged).toHaveBeenCalledTimes(1);
     expect(getWorker().status).toBe('done');
     expect(calls).toContain('restoreWorkerDoneIfIdle');
+
+    // close race 与入口处的 active-turn 拒绝同族:本次普通 renderer ack 已登记,
+    // direct send 的 terminal 边界会 fire-once 补收口,不需要 renderer timer。
+    await service.handleWorkerTerminalTurn({
+      sessionId: 'worker-session-1',
+      status: 'done',
+      finalText: 'finished',
+    });
+
+    expect(getWorker().status).toBe('idle');
+    expect(deps.closeWorkerSessionIfIdle).toHaveBeenCalledTimes(2);
+    expect(deps.broadcastOrcaWorkerChanged).toHaveBeenCalledTimes(2);
   });
 
   it('preserves queued worker input before acknowledging a done worker', async () => {

--- a/apps/desktop/src/main/maker-ipc/__tests__/orcaWorkerControlHandlers.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/orcaWorkerControlHandlers.test.ts
@@ -6,7 +6,12 @@ import { IpcHarness } from './helpers/ipcHarness';
 
 type WorkerControlResult =
   | { ok: true; workerId?: string }
-  | { ok: false; errorCode: string; message: string };
+  | {
+      ok: false;
+      errorCode: string;
+      message: string;
+      deferredAcknowledgementRegistered?: true;
+    };
 
 function createDeps() {
   return {
@@ -153,6 +158,33 @@ describe('Orca worker control IPC handlers', () => {
       workerId: 'worker-1',
       expectedStatus: 'done',
     });
+  });
+
+  it('returns success only when the automatic channel registered a terminal-boundary retry', async () => {
+    const harness = new IpcHarness();
+    const deps = createDeps();
+    deps.idleWorker.mockResolvedValue({
+      ok: false,
+      errorCode: 'WORKER_STATE_CHANGED',
+      message: 'worker worker-1 has an active turn',
+      deferredAcknowledgementRegistered: true,
+    });
+    registerOrcaWorkerControlHandlers(harness, deps);
+
+    await expect(
+      harness.invoke(MAKER_INVOKE.WORKER_ACKNOWLEDGE_DONE, {
+        leadSessionId: 'lead-1',
+        workerId: 'worker-1',
+      }),
+    ).resolves.toEqual({ ok: true, workerId: 'worker-1', deferred: true });
+
+    await expect(
+      harness.invoke(MAKER_INVOKE.WORKER_IDLE, {
+        leadSessionId: 'lead-1',
+        workerId: 'worker-1',
+        expectedStatus: 'done',
+      }),
+    ).rejects.toMatchObject({ code: 'WORKER_STATE_CHANGED' });
   });
 
   it('maps archive service not-found failures to stable IPC error codes', async () => {

--- a/apps/desktop/src/main/maker-ipc/makerSendTransaction.ts
+++ b/apps/desktop/src/main/maker-ipc/makerSendTransaction.ts
@@ -645,7 +645,6 @@ export function createMakerSendTransaction(deps: MakerSendTransactionDeps): Make
     // Pi/Codex 等依赖 resume 续接原生会话的 agent 会丢掉旧 JSONL/thread,从空会话开始。
     // 与 lazy-create 路径(下方 reconcileCreateOptsWithDb)保持同一条 resume 口径;
     // 对账必须在 close 前,避免恢复失败后已不可逆地丢失当前 handle。
-    await deps.reconcileCreateOptsWithDb?.(sessionId, createOpts);
     try {
       // 关旧 runtime 前先按 DB 权威口径对账执行字段(与 lazy-create 同源):caller /
       // 队列的 createOpts 快照常不带 resumeSessionId(或带旧引擎的陈旧值),直接

--- a/apps/desktop/src/main/maker-ipc/makerSendTransaction.ts
+++ b/apps/desktop/src/main/maker-ipc/makerSendTransaction.ts
@@ -640,6 +640,12 @@ export function createMakerSendTransaction(deps: MakerSendTransactionDeps): Make
       };
     }
     await loadExtraDirsIfNeeded(sessionId, createOpts, 'active-orca-rehydrate');
+    // #2882: close 当前 runtime 前必须先用 DB(真源)对账 createOpts,尤其是回填
+    // resumeSessionId(sessions.sdkSessionId)。否则中途开启 Orca 触发 rehydrate 时,
+    // Pi/Codex 等依赖 resume 续接原生会话的 agent 会丢掉旧 JSONL/thread,从空会话开始。
+    // 与 lazy-create 路径(下方 reconcileCreateOptsWithDb)保持同一条 resume 口径;
+    // 对账必须在 close 前,避免恢复失败后已不可逆地丢失当前 handle。
+    await deps.reconcileCreateOptsWithDb?.(sessionId, createOpts);
     try {
       // 关旧 runtime 前先按 DB 权威口径对账执行字段(与 lazy-create 同源):caller /
       // 队列的 createOpts 快照常不带 resumeSessionId(或带旧引擎的陈旧值),直接

--- a/apps/desktop/src/main/maker-ipc/orcaTeamService.ts
+++ b/apps/desktop/src/main/maker-ipc/orcaTeamService.ts
@@ -1188,6 +1188,12 @@ export function createOrcaTeamService(deps: OrcaTeamServiceDeps): OrcaTeamServic
         const didClose = await closeWorkerSessionIfIdleBestEffort(worker.sessionId, 'idleWorker');
         if (!didClose) {
           await rollbackDoneAcknowledgement();
+          // closeIfIdle 与新 direct send 竞争失败时,与入口处观察到 active turn
+          // 属于同一个可恢复拒绝族:普通 renderer ack 要交给本 turn 的 terminal
+          // 边界 fire-once 补收口;terminal retry 自身仍不得重新登记。
+          if (params.expectedStatus === 'done' && !opts?.deferredRetry) {
+            deferredDoneAcknowledgements.add(worker.id);
+          }
           return {
             ok: false,
             errorCode: 'WORKER_STATE_CHANGED',

--- a/apps/desktop/src/main/maker-ipc/orcaTeamService.ts
+++ b/apps/desktop/src/main/maker-ipc/orcaTeamService.ts
@@ -1626,11 +1626,20 @@ export function createOrcaTeamService(deps: OrcaTeamServiceDeps): OrcaTeamServic
           const state = autoBridge.get(params.sessionId);
           if (worker.status === 'done' || worker.status === 'error' || worker.status === 'idle') {
             if (state?.retryAfterRejectedDelivery === true) {
-              await bridgeWorkerCompletion(params.sessionId, {
+              const delivery = await bridgeWorkerCompletion(params.sessionId, {
                 status: params.status,
                 finalText: params.finalText,
                 diagnostic: params.diagnostic,
               });
+              // A prior renderer acknowledgement may have been deferred by the
+              // same turn/send guard that rejected the first auto-bridge. The
+              // terminal retry must consume that one-shot acknowledgement when
+              // delivery actually succeeds; a rejected retry keeps the bridge
+              // generation alive and must not let the follow-up idle clear it.
+              if (delivery === 'accepted') {
+                retryAcknowledgeDone =
+                  worker.status === 'done' && deferredDoneAcknowledgements.delete(link.workerId);
+              }
               return;
             }
             // (#3153) done 的回报 settle 会先于本 turn 终止落库,renderer「看到 done

--- a/apps/desktop/src/main/maker-ipc/orcaTeamService.ts
+++ b/apps/desktop/src/main/maker-ipc/orcaTeamService.ts
@@ -138,7 +138,14 @@ export type DispatchWorkerTaskResult =
 
 /** 简单生命周期操作的 domain result，供 IPC 与 MCP adapter 各自翻译。 */
 export type OrcaOkResult =
-  { ok: true; workerId?: string } | { ok: false; errorCode: string; message: string };
+   | { ok: true; workerId?: string }
+   | {
+       ok: false;
+       errorCode: string;
+       message: string;
+       /** The automatic done-ack channel may translate this registered retry into success. */
+       deferredAcknowledgementRegistered?: true;
+     };
 
 /** worker 排队消息控制(list/update/cancel)对外暴露的失败码。 */
 export type WorkerQueuedMessageFailureCode =
@@ -1140,6 +1147,7 @@ export function createOrcaTeamService(deps: OrcaTeamServiceDeps): OrcaTeamServic
           ok: false,
           errorCode: 'WORKER_STATE_CHANGED',
           message: `worker ${params.workerId} has an active turn`,
+          ...(!opts?.deferredRetry ? { deferredAcknowledgementRegistered: true as const } : {}),
         };
       }
       if (params.expectedStatus && deps.hasSendToSessionLock(worker.sessionId)) {
@@ -1150,6 +1158,7 @@ export function createOrcaTeamService(deps: OrcaTeamServiceDeps): OrcaTeamServic
           ok: false,
           errorCode: 'WORKER_STATE_CHANGED',
           message: `worker ${params.workerId} has a send in progress`,
+          ...(!opts?.deferredRetry ? { deferredAcknowledgementRegistered: true as const } : {}),
         };
       }
       if (params.expectedStatus && (await deps.hasPendingWorkerInput(worker.sessionId))) {
@@ -1198,6 +1207,7 @@ export function createOrcaTeamService(deps: OrcaTeamServiceDeps): OrcaTeamServic
             ok: false,
             errorCode: 'WORKER_STATE_CHANGED',
             message: `worker ${params.workerId} has an active turn`,
+            ...(!opts?.deferredRetry ? { deferredAcknowledgementRegistered: true as const } : {}),
           };
         }
       }

--- a/apps/desktop/src/main/maker-ipc/orcaWorkerControlHandlers.ts
+++ b/apps/desktop/src/main/maker-ipc/orcaWorkerControlHandlers.ts
@@ -5,7 +5,12 @@ import { throwOrcaServiceFailure } from './orcaServiceFailure.js';
 
 type OrcaWorkerControlResult =
   | { ok: true; workerId?: string }
-  | { ok: false; errorCode: string; message: string };
+  | {
+      ok: false;
+      errorCode: string;
+      message: string;
+      deferredAcknowledgementRegistered?: true;
+    };
 type IdleWorkerExpectedStatus = 'done';
 
 export interface OrcaWorkerControlHandlerDeps {
@@ -32,7 +37,13 @@ export function registerOrcaWorkerControlHandlers(
     } catch (err) {
       throwIpcError('INTERNAL', err instanceof Error ? err.message : String(err));
     }
-    if (!result.ok) throwOrcaServiceFailure(result);
+    if (!result.ok) {
+      if (forcedExpectedStatus === 'done' && result.deferredAcknowledgementRegistered === true) {
+        deps.logInfo('idleWorker deferred to terminal boundary', { workerId: b.workerId });
+        return { ok: true as const, workerId: b.workerId, deferred: true as const };
+      }
+      throwOrcaServiceFailure(result);
+    }
     deps.logInfo('idleWorker done', { workerId: b.workerId });
     return result;
   };

--- a/apps/desktop/src/renderer/__tests__/AgentTaskCard.test.ts
+++ b/apps/desktop/src/renderer/__tests__/AgentTaskCard.test.ts
@@ -385,6 +385,13 @@ describe('AgentTaskCard', () => {
           React.createElement(AgentTaskCard, {
             sessionId: `session-${sessionAgentKind}`,
             sessionAgentKind,
+            toolCall: {
+              clientId: `historical-pi-${sessionAgentKind}`,
+              role: 'tool_use',
+              content: '',
+              toolName: 'Agent',
+              toolUseId: 'historical-pi-tool',
+            },
             update: {
               provider: 'pi',
               taskId: 'historical-pi-tool',

--- a/apps/desktop/src/renderer/components/chat/AgentTaskCard.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentTaskCard.tsx
@@ -619,6 +619,7 @@ export function AgentTaskCard({
                   type="button"
                   onClick={openSubagentPanel}
                   className="mt-1 inline-flex items-center gap-1 text-12 leading-4 underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)]"
+>>>>>>> 588e120bc (fix(desktop): 普通 Subagent 卡展开区加「查看 Subagent 详情」入口 (#3154))
                 >
                   <PanelRight size={12} aria-hidden="true" />
                   {t('chat.agentTask.viewSubagentDetails')}

--- a/apps/desktop/src/renderer/components/chat/AgentTaskCard.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentTaskCard.tsx
@@ -372,6 +372,8 @@ export function AgentTaskCard({
     && isSubagentSpawnToolName(toolName);
   const subagentPanelFocusId = update?.taskId ?? toolCall?.toolUseId;
   const canOpenSubagentPanel =
+    (update?.provider === 'pi' || toolCall?.toolName === PI_SUBAGENT_TOOL_NAME) &&
+    sessionAgentKind === 'pi' &&
     Boolean(sessionId)
     && Boolean(subagentPanelFocusId)
     && panelReachable

--- a/apps/desktop/src/renderer/components/chat/AgentTaskCard.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentTaskCard.tsx
@@ -619,7 +619,6 @@ export function AgentTaskCard({
                   type="button"
                   onClick={openSubagentPanel}
                   className="mt-1 inline-flex items-center gap-1 text-12 leading-4 underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)]"
->>>>>>> 588e120bc (fix(desktop): 普通 Subagent 卡展开区加「查看 Subagent 详情」入口 (#3154))
                 >
                   <PanelRight size={12} aria-hidden="true" />
                   {t('chat.agentTask.viewSubagentDetails')}

--- a/apps/desktop/src/renderer/components/chat/AgentTaskCard.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentTaskCard.tsx
@@ -36,6 +36,7 @@ import { formatModelShortLabel } from '@/lib/modelShortLabel';
 import { formatCompactTokens } from '@/lib/usageFormat';
 import { CODEX_SUBAGENT_EFFORTS } from '../../../shared/subagentModelSettings';
 import {
+  isSubagentSpawnToolName,
   PI_SUBAGENT_TOOL_NAME,
   subagentSpawnReceiptName,
   subagentSpawnResultIndicatesRunning,
@@ -355,6 +356,35 @@ export function AgentTaskCard({
     });
   }, [provider, sessionId, subagentFocusId]);
 
+  // 普通子代理(非 workflow / bash)卡:就地只展开摘要,完整进度(activity、用量、
+  // 返回结果与未来的完整过程)在右栏「子代理」面板。提供显式入口,不恢复曾被有意
+  // 撤回的"首次创建自动弹出右栏"。focusId 优先取 update.taskId(实时态),history
+  // reload 后 update 缺失时回退 toolCall.toolUseId(已作为 sidebar alias 持久化,
+  // Pi durable 路径也用它兜底,见 #3154 codex P1)。provider 与卡片同源。内嵌宿主
+  // (worker 面板/窄 rail)右栏不可达时不显示假入口。只在真正的 subagent 启动卡
+  // (Task/Agent/subagent/collab:spawn[Agent])显示——collab:wait/sendInput/
+  // resumeAgent/closeAgent 等控制调用虽被 isAgentTaskToolName 渲染成任务卡,但
+  // 不是子代理启动,拿它们的 toolUseId 去聚焦右栏会定位不到 run(#3154 codex P2)。
+  const toolName = toolCall?.toolName ?? '';
+  const isSubagentCard =
+    !isWorkflow
+    && !isBash
+    && isSubagentSpawnToolName(toolName);
+  const subagentPanelFocusId = update?.taskId ?? toolCall?.toolUseId;
+  const canOpenSubagentPanel =
+    Boolean(sessionId)
+    && Boolean(subagentPanelFocusId)
+    && panelReachable
+    && isSubagentCard;
+  const openSubagentPanel = useCallback(() => {
+    if (!sessionId || !subagentPanelFocusId) return;
+    void openSubagentsTab(sessionId, {
+      focusRunId: subagentPanelFocusId,
+      focusProvider: provider,
+      userInitiated: true,
+    });
+  }, [provider, sessionId, subagentPanelFocusId]);
+
   // workflow 摘要行:当前运行中 agent 的 phaseTitle + 已收口/总数。收口判定走
   // workflowAgentVisualState 归一(与方块条 / 面板同一词表源,done 与 failed 都算收口)。
   const workflowSummary = useMemo(() => {
@@ -583,6 +613,16 @@ export function AgentTaskCard({
                 <p className="text-12 leading-4 text-[var(--text-tertiary)]">
                   {t('chat.agentTask.outputFile', { path: update.outputFile })}
                 </p>
+              )}
+              {canOpenSubagentPanel && (
+                <button
+                  type="button"
+                  onClick={openSubagentPanel}
+                  className="mt-1 inline-flex items-center gap-1 text-12 leading-4 text-[var(--text-link)] hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)]"
+                >
+                  <PanelRight size={12} aria-hidden="true" />
+                  {t('chat.agentTask.viewSubagentDetails')}
+                </button>
               )}
             </div>
           </Collapse>

--- a/apps/desktop/src/renderer/components/chat/AgentTaskCard.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentTaskCard.tsx
@@ -618,7 +618,7 @@ export function AgentTaskCard({
                 <button
                   type="button"
                   onClick={openSubagentPanel}
-                  className="mt-1 inline-flex items-center gap-1 text-12 leading-4 text-[var(--text-link)] hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)]"
+                  className="mt-1 inline-flex items-center gap-1 text-12 leading-4 underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)]"
                 >
                   <PanelRight size={12} aria-hidden="true" />
                   {t('chat.agentTask.viewSubagentDetails')}

--- a/apps/desktop/src/renderer/components/chat/__tests__/AgentTaskCardSubagentHistory.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/__tests__/AgentTaskCardSubagentHistory.test.tsx
@@ -1,0 +1,140 @@
+// @vitest-environment jsdom
+//
+// #3154 codex P1:history reload 后 agent_task_update 不持久化,普通 Subagent 卡
+// 没有 update,但 toolCall.toolUseId 已作为 sidebar alias 持久化。详情入口必须用它
+// 兜底,否则历史会话里完成的 Subagent 永远点不进右栏面板。
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { openSubagentsTab } = vi.hoisted(() => ({
+  openSubagentsTab: vi.fn(),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, vars?: Record<string, unknown>) =>
+      vars && Object.keys(vars).length > 0 ? `${key}:${JSON.stringify(vars)}` : key,
+  }),
+}));
+
+vi.mock('@/hooks/useExpandedBlockMemory', () => ({
+  useExpandedBlockMemory: () => ({ expanded: true, setExpanded: vi.fn() }),
+}));
+
+vi.mock('@/lib/makerTransport', () => ({
+  getWorkflowProgressFor: vi.fn(async () => null),
+  isRemoteSessionSticky: () => false,
+}));
+
+vi.mock('@/features/right-sidebar/lib/openBackgroundTasksTab', () => ({
+  openBackgroundTasksTab: vi.fn(),
+}));
+
+vi.mock('@/features/right-sidebar/lib/openSubagentsTab', () => ({
+  openSubagentsTab,
+}));
+
+vi.mock('@/features/right-sidebar/plugins/background-tasks/listSessionTasks', () => ({
+  extractWorkflowTaskId: () => undefined,
+}));
+
+vi.mock('@/features/right-sidebar/plugins/background-tasks/WorkflowAgentStrip', () => ({
+  WorkflowAgentStrip: () => null,
+}));
+
+vi.mock('@/features/cc-agent/embeddedSessionNavigation', () => ({
+  useSidebarPanelReachable: () => true,
+}));
+
+vi.mock('@/components/ui/collapse', () => ({
+  Collapse: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@/components/ui/spinner', () => ({
+  Spinner: () => null,
+}));
+
+vi.mock('@/lib/modelShortLabel', () => ({
+  formatModelShortLabel: (model?: string | null) => model ?? undefined,
+}));
+
+import { AgentTaskCard } from '../AgentTaskCard';
+import type { ChatMessage } from '@/hooks/useCCAgentChat';
+
+function makeToolCall(toolUseId: string, toolName = 'Agent'): ChatMessage {
+  return {
+    clientId: `c-${toolUseId}`,
+    role: 'tool_use',
+    content: '',
+    toolUseId,
+    toolName,
+    toolInput: { description: 'scout', prompt: 'do a thing' },
+  } as unknown as ChatMessage;
+}
+
+function makeControlToolCall(toolUseId: string, toolName: string): ChatMessage {
+  return {
+    clientId: `c-${toolUseId}`,
+    role: 'tool_use',
+    content: '',
+    toolUseId,
+    toolName,
+    toolInput: {},
+  } as unknown as ChatMessage;
+}
+
+describe('AgentTaskCard subagent details entry after history reload', () => {
+  beforeEach(() => {
+    openSubagentsTab.mockClear();
+  });
+
+  it('still opens the subagent panel when update is missing and only toolUseId is known', () => {
+    render(
+      <MemoryRouter>
+        <AgentTaskCard
+          toolCall={makeToolCall('persisted-run-alias')}
+          result="completed"
+          sessionId="lead-1"
+        />
+      </MemoryRouter>,
+    );
+
+    const button = screen.getByRole('button', { name: /viewSubagentDetails/ });
+    fireEvent.click(button);
+
+    expect(openSubagentsTab).toHaveBeenCalledWith('lead-1', {
+      focusRunId: 'persisted-run-alias',
+      focusProvider: expect.any(String),
+      userInitiated: true,
+    });
+  });
+
+  it('does not show the details entry on collab control calls (wait/sendInput/resume/close)', () => {
+    // #3154 codex P2:collab:wait / collab:sendInput / collab:resumeAgent /
+    // collab:closeAgent 虽是任务卡,但不是 subagent 启动,拿它们的 toolUseId 去
+    // 右栏定位不到 run。详情入口只应对真正的 spawn 工具显示。
+    for (const controlName of [
+      'collab:wait',
+      'collab:sendInput',
+      'collab:resumeAgent',
+      'collab:closeAgent',
+    ]) {
+      const { unmount } = render(
+        <MemoryRouter>
+          <AgentTaskCard
+            toolCall={makeControlToolCall(`ctrl-${controlName}`, controlName)}
+            result="ok"
+            sessionId="lead-1"
+          />
+        </MemoryRouter>,
+      );
+      expect(
+        screen.queryByRole('button', { name: /viewSubagentDetails/ }),
+      ).toBeNull();
+      unmount();
+    }
+  });
+});

--- a/apps/desktop/src/renderer/components/chat/__tests__/AgentTaskCardSubagentHistory.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/__tests__/AgentTaskCardSubagentHistory.test.tsx
@@ -95,9 +95,10 @@ describe('AgentTaskCard subagent details entry after history reload', () => {
     render(
       <MemoryRouter>
         <AgentTaskCard
-          toolCall={makeToolCall('persisted-run-alias')}
+          toolCall={makeToolCall('persisted-run-alias', 'subagent')}
           result="completed"
           sessionId="lead-1"
+          sessionAgentKind="pi"
         />
       </MemoryRouter>,
     );
@@ -110,7 +111,7 @@ describe('AgentTaskCard subagent details entry after history reload', () => {
 
     expect(openSubagentsTab).toHaveBeenCalledWith('lead-1', {
       focusRunId: 'persisted-run-alias',
-      focusProvider: expect.any(String),
+      focusProvider: 'pi',
       userInitiated: true,
     });
   });

--- a/apps/desktop/src/renderer/components/chat/__tests__/AgentTaskCardSubagentHistory.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/__tests__/AgentTaskCardSubagentHistory.test.tsx
@@ -103,6 +103,9 @@ describe('AgentTaskCard subagent details entry after history reload', () => {
     );
 
     const button = screen.getByRole('button', { name: /viewSubagentDetails/ });
+    expect(button.className).toContain('underline');
+    expect(button.className).not.toContain('text-[var(--text-link)]');
+    expect(button.className).not.toContain('hover:underline');
     fireEvent.click(button);
 
     expect(openSubagentsTab).toHaveBeenCalledWith('lead-1', {

--- a/apps/desktop/src/renderer/features/cc-agent/hooks/__tests__/useOrcaWorkerSelection.test.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/hooks/__tests__/useOrcaWorkerSelection.test.tsx
@@ -130,6 +130,34 @@ describe('useOrcaWorkerSelection', () => {
     expect(mocks.refresh).toHaveBeenCalled();
   });
 
+  it('retries done acknowledgement when the worker turn is still settling (active turn)', async () => {
+    // #3153: 终态事件抵达时底层 turn 可能尚未 settle,idleWorker 第一次撞
+    // WORKER_STATE_CHANGED/has an active turn。renderer 应有界重试,直到 turn
+    // settle 后 ack 成功,而不是让 worker 长期停在 done。
+    mocks.workers = [
+      makeWorker('worker-a', 'session-a', true),
+      makeWorker('worker-b', 'session-b', false, 'done'),
+    ];
+    mocks.idleWorker
+      .mockRejectedValueOnce(
+        new Error('[WORKER_STATE_CHANGED] worker worker-b has an active turn'),
+      )
+      .mockResolvedValueOnce({ ok: true as const, workerId: 'worker-b' });
+    markWorkerAttention('worker-b');
+    const { result } = renderHook(
+      () => useOrcaWorkerSelection({ leadSessionId: 'lead-1' }),
+      { wrapper },
+    );
+
+    act(() => result.current.handleSwitchFocus('worker-b'));
+
+    await waitFor(() => {
+      expect(mocks.idleWorker).toHaveBeenCalledTimes(2);
+    });
+    expect(hasWorkerAttention('worker-b')).toBe(false);
+    expect(mocks.toastError).not.toHaveBeenCalled();
+  });
+
   it('silently keeps done attention and refreshes when acknowledgement loses a state race', async () => {
     mocks.workers = [
       makeWorker('worker-a', 'session-a', true),

--- a/apps/desktop/src/renderer/features/cc-agent/hooks/__tests__/useOrcaWorkerSelection.test.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/hooks/__tests__/useOrcaWorkerSelection.test.tsx
@@ -39,6 +39,16 @@ vi.mock('@/lib/makerTransport', () => ({
     idleWorker: mocks.idleWorker,
     archiveWorker: vi.fn(async () => undefined),
   }),
+  orcaWorkflowsForDevice: () => ({
+    createWorker: mocks.createWorker,
+    switchFocus: mocks.switchFocus,
+    idleWorker: mocks.idleWorker,
+    archiveWorker: vi.fn(async () => undefined),
+  }),
+}));
+
+vi.mock('@/features/device-link/stickySessionOrigin', () => ({
+  getStickySessionDeviceId: () => undefined,
 }));
 
 vi.mock('react-i18next', () => ({
@@ -157,6 +167,31 @@ describe('useOrcaWorkerSelection', () => {
       });
       expect(mocks.idleWorker).toHaveBeenCalledTimes(1);
       expect(hasWorkerAttention('worker-b')).toBe(false);
+      expect(mocks.toastError).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(['has an active turn', 'has a send in progress'])(
+    'keeps attention for a legacy remote target without terminal deferred ack (%s)',
+    async (reason) => {
+      mocks.workers = [
+        makeWorker('worker-a', 'session-a', true),
+        makeWorker('worker-b', 'session-b', false, 'done'),
+      ];
+      mocks.idleWorker.mockRejectedValueOnce(
+        new Error(`[WORKER_STATE_CHANGED] worker worker-b ${reason}`),
+      );
+      markWorkerAttention('worker-b');
+      const { result } = renderHook(
+        () => useOrcaWorkerSelection({ leadSessionId: 'lead-1', deviceId: 'device-1' }),
+        { wrapper },
+      );
+
+      act(() => result.current.handleSwitchFocus('worker-b'));
+
+      await waitFor(() => expect(mocks.refresh).toHaveBeenCalled());
+      expect(mocks.idleWorker).toHaveBeenCalledTimes(1);
+      expect(hasWorkerAttention('worker-b')).toBe(true);
       expect(mocks.toastError).not.toHaveBeenCalled();
     },
   );

--- a/apps/desktop/src/renderer/features/cc-agent/hooks/__tests__/useOrcaWorkerSelection.test.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/hooks/__tests__/useOrcaWorkerSelection.test.tsx
@@ -130,33 +130,36 @@ describe('useOrcaWorkerSelection', () => {
     expect(mocks.refresh).toHaveBeenCalled();
   });
 
-  it('retries done acknowledgement when the worker turn is still settling (active turn)', async () => {
-    // #3153: 终态事件抵达时底层 turn 可能尚未 settle,idleWorker 第一次撞
-    // WORKER_STATE_CHANGED/has an active turn。renderer 应有界重试,直到 turn
-    // settle 后 ack 成功,而不是让 worker 长期停在 done。
-    mocks.workers = [
-      makeWorker('worker-a', 'session-a', true),
-      makeWorker('worker-b', 'session-b', false, 'done'),
-    ];
-    mocks.idleWorker
-      .mockRejectedValueOnce(
-        new Error('[WORKER_STATE_CHANGED] worker worker-b has an active turn'),
-      )
-      .mockResolvedValueOnce({ ok: true as const, workerId: 'worker-b' });
-    markWorkerAttention('worker-b');
-    const { result } = renderHook(
-      () => useOrcaWorkerSelection({ leadSessionId: 'lead-1' }),
-      { wrapper },
-    );
+  it.each(['has an active turn', 'has a send in progress'])(
+    'defers done acknowledgement to the terminal boundary without renderer retry (%s)',
+    async (reason) => {
+      // #3153:Main 会把 active-turn / send-lock 拒绝登记到本轮 terminal
+      // generation,并在 terminal 边界 fire-once 补收口。Renderer 只发一次确认,
+      // 立即清掉已读 attention;不得留下能误确认下一轮结果的 timer。
+      mocks.workers = [
+        makeWorker('worker-a', 'session-a', true),
+        makeWorker('worker-b', 'session-b', false, 'done'),
+      ];
+      mocks.idleWorker.mockRejectedValueOnce(
+        new Error(`[WORKER_STATE_CHANGED] worker worker-b ${reason}`),
+      );
+      markWorkerAttention('worker-b');
+      const { result } = renderHook(
+        () => useOrcaWorkerSelection({ leadSessionId: 'lead-1' }),
+        { wrapper },
+      );
 
-    act(() => result.current.handleSwitchFocus('worker-b'));
+      act(() => result.current.handleSwitchFocus('worker-b'));
 
-    await waitFor(() => {
-      expect(mocks.idleWorker).toHaveBeenCalledTimes(2);
-    });
-    expect(hasWorkerAttention('worker-b')).toBe(false);
-    expect(mocks.toastError).not.toHaveBeenCalled();
-  });
+      await waitFor(() => expect(mocks.refresh).toHaveBeenCalled());
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 300));
+      });
+      expect(mocks.idleWorker).toHaveBeenCalledTimes(1);
+      expect(hasWorkerAttention('worker-b')).toBe(false);
+      expect(mocks.toastError).not.toHaveBeenCalled();
+    },
+  );
 
   it('silently keeps done attention and refreshes when acknowledgement loses a state race', async () => {
     mocks.workers = [

--- a/apps/desktop/src/renderer/features/cc-agent/hooks/useOrcaWorkerSelection.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/hooks/useOrcaWorkerSelection.ts
@@ -260,16 +260,48 @@ export function useOrcaWorkerSelection({
       if (acknowledgingDoneWorkerIdsRef.current.has(workerId)) return false;
       acknowledgingDoneWorkerIdsRef.current.add(workerId);
       try {
-        await orcaWorkflowsFor(leadSessionId).idleWorker(leadSessionId, workerId, 'done');
-        clearWorkerAttention(workerId);
-        return true;
-      } catch (err) {
-        const errorCode = extractIpcError(err)?.code;
-        if (errorCode === 'WORKER_STATE_CHANGED' || errorCode === 'DEVICE_LINK_CHANNEL_NOT_ALLOWED') {
-          log.debug('done acknowledgement skipped after worker state changed', { workerId });
-          return false;
+        // 终态事件抵达时底层 agent 的 turn 可能尚未 settle,idleWorker 会撞
+        // WORKER_STATE_CHANGED/has an active turn。只对"turn 还在收尾/send 锁未释放"
+        // 这两种可恢复情形做有界重试(250ms × 8 ≈ 2s,覆盖 translator 清
+        // turnInFlight 的窗口);其它(有排队输入、已不是 done、device-link 拒绝)
+        // 立即放弃,attention 保持 done 等下一次用户查看时 effect 重入。
+        const MAX_ATTEMPTS = 8;
+        const RETRY_DELAY_MS = 250;
+        for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt += 1) {
+          try {
+            await orcaWorkflowsFor(leadSessionId).idleWorker(leadSessionId, workerId, 'done');
+            clearWorkerAttention(workerId);
+            return true;
+          } catch (err) {
+            const ipcErr = extractIpcError(err);
+            if (ipcErr?.code !== 'WORKER_STATE_CHANGED') {
+              if (ipcErr?.code === 'DEVICE_LINK_CHANNEL_NOT_ALLOWED') {
+                log.debug('done acknowledgement skipped after worker state changed', { workerId });
+                return false;
+              }
+              throw err;
+            }
+            const transient =
+              ipcErr.message.includes('has an active turn')
+              || ipcErr.message.includes('has a send in progress');
+            if (!transient) {
+              log.debug('done acknowledgement abandoned after non-transient state change', {
+                workerId,
+                message: ipcErr.message,
+              });
+              return false;
+            }
+            if (attempt + 1 >= MAX_ATTEMPTS) {
+              log.debug('done acknowledgement exhausted retries; leaving for next view', {
+                workerId,
+                attempts: attempt + 1,
+              });
+              return false;
+            }
+            await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS));
+          }
         }
-        throw err;
+        return false;
       } finally {
         acknowledgingDoneWorkerIdsRef.current.delete(workerId);
       }

--- a/apps/desktop/src/renderer/features/cc-agent/hooks/useOrcaWorkerSelection.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/hooks/useOrcaWorkerSelection.ts
@@ -4,7 +4,8 @@ import { useLocation, useSearchParams } from 'react-router-dom';
 
 import { toast } from '@/lib/toast';
 import { createLogger } from '@/lib/logger';
-import { orcaWorkflowsFor } from '@/lib/makerTransport';
+import { getStickySessionDeviceId } from '@/features/device-link/stickySessionOrigin';
+import { orcaWorkflowsFor, orcaWorkflowsForDevice } from '@/lib/makerTransport';
 import { extractIpcError } from '@/utils/ipcError';
 import {
   parseConversationSearchJump,
@@ -48,6 +49,7 @@ export function useOrcaWorkerSelection({
   const { t } = useTranslation();
   const location = useLocation();
   const [searchParams] = useSearchParams();
+  const remoteDeviceId = deviceId ?? getStickySessionDeviceId(leadSessionId);
   const {
     workers,
     focusedWorker,
@@ -260,14 +262,17 @@ export function useOrcaWorkerSelection({
       if (acknowledgingDoneWorkerIdsRef.current.has(workerId)) return false;
       acknowledgingDoneWorkerIdsRef.current.add(workerId);
       try {
+        const workflows = remoteDeviceId
+          ? orcaWorkflowsForDevice(remoteDeviceId)
+          : orcaWorkflowsFor(leadSessionId);
         // 终态事件抵达时底层 agent 的 turn 可能尚未 settle,idleWorker 会撞
         // WORKER_STATE_CHANGED/has an active turn。Main 会把 active-turn / send-lock
         // 这两种可恢复拒绝登记到当前 terminal generation,并在 terminal 边界
-        // fire-once 补收口;Renderer 不得用脱离可见性与 turn generation 的 timer
-        // 重试,否则旧 timer 可能确认下一轮结果。用户已经看过本轮结果,所以登记
-        // 成功后即可清 attention;新 turn 再次进入 done 时 watcher 会重新标记。
+        // fire-once 补收口,专用 channel 会在登记成功后直接返回成功。旧被控端仍
+        // 返回相同错误,且没有原子 generation CAS；此时必须保留 attention,不能
+        // 用 renderer timer 重试后误确认下一轮结果。
         try {
-          await orcaWorkflowsFor(leadSessionId).idleWorker(leadSessionId, workerId, 'done');
+          await workflows.idleWorker(leadSessionId, workerId, 'done');
           clearWorkerAttention(workerId);
           return true;
         } catch (err) {
@@ -283,6 +288,10 @@ export function useOrcaWorkerSelection({
             ipcErr.message.includes('has an active turn')
             || ipcErr.message.includes('has a send in progress');
           if (deferredToTerminalBoundary) {
+            if (remoteDeviceId) {
+              log.debug('legacy remote done acknowledgement left attention visible', { workerId });
+              return false;
+            }
             clearWorkerAttention(workerId);
             log.debug('done acknowledgement deferred to worker terminal boundary', { workerId });
             return true;
@@ -297,7 +306,7 @@ export function useOrcaWorkerSelection({
         acknowledgingDoneWorkerIdsRef.current.delete(workerId);
       }
     },
-    [leadSessionId],
+    [leadSessionId, remoteDeviceId],
   );
 
   const visibleDoneWorkerId =
@@ -371,7 +380,9 @@ export function useOrcaWorkerSelection({
       const acknowledgeDone = worker?.status === 'done';
       void (async () => {
         try {
-          const workflows = orcaWorkflowsFor(leadSessionId);
+          const workflows = remoteDeviceId
+            ? orcaWorkflowsForDevice(remoteDeviceId)
+            : orcaWorkflowsFor(leadSessionId);
           await workflows.switchFocus({
             leadSessionId,
             workerIdOrLabel: workerId,
@@ -393,7 +404,7 @@ export function useOrcaWorkerSelection({
         }
       })();
     },
-    [acknowledgeDoneWorker, clearSelectionHints, leadSessionId, refresh],
+    [acknowledgeDoneWorker, clearSelectionHints, leadSessionId, refresh, remoteDeviceId],
   );
 
   const handleArchiveWorker = useCallback(

--- a/apps/desktop/src/renderer/features/cc-agent/hooks/useOrcaWorkerSelection.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/hooks/useOrcaWorkerSelection.ts
@@ -261,47 +261,38 @@ export function useOrcaWorkerSelection({
       acknowledgingDoneWorkerIdsRef.current.add(workerId);
       try {
         // 终态事件抵达时底层 agent 的 turn 可能尚未 settle,idleWorker 会撞
-        // WORKER_STATE_CHANGED/has an active turn。只对"turn 还在收尾/send 锁未释放"
-        // 这两种可恢复情形做有界重试(250ms × 8 ≈ 2s,覆盖 translator 清
-        // turnInFlight 的窗口);其它(有排队输入、已不是 done、device-link 拒绝)
-        // 立即放弃,attention 保持 done 等下一次用户查看时 effect 重入。
-        const MAX_ATTEMPTS = 8;
-        const RETRY_DELAY_MS = 250;
-        for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt += 1) {
-          try {
-            await orcaWorkflowsFor(leadSessionId).idleWorker(leadSessionId, workerId, 'done');
-            clearWorkerAttention(workerId);
-            return true;
-          } catch (err) {
-            const ipcErr = extractIpcError(err);
-            if (ipcErr?.code !== 'WORKER_STATE_CHANGED') {
-              if (ipcErr?.code === 'DEVICE_LINK_CHANNEL_NOT_ALLOWED') {
-                log.debug('done acknowledgement skipped after worker state changed', { workerId });
-                return false;
-              }
-              throw err;
-            }
-            const transient =
-              ipcErr.message.includes('has an active turn')
-              || ipcErr.message.includes('has a send in progress');
-            if (!transient) {
-              log.debug('done acknowledgement abandoned after non-transient state change', {
-                workerId,
-                message: ipcErr.message,
-              });
+        // WORKER_STATE_CHANGED/has an active turn。Main 会把 active-turn / send-lock
+        // 这两种可恢复拒绝登记到当前 terminal generation,并在 terminal 边界
+        // fire-once 补收口;Renderer 不得用脱离可见性与 turn generation 的 timer
+        // 重试,否则旧 timer 可能确认下一轮结果。用户已经看过本轮结果,所以登记
+        // 成功后即可清 attention;新 turn 再次进入 done 时 watcher 会重新标记。
+        try {
+          await orcaWorkflowsFor(leadSessionId).idleWorker(leadSessionId, workerId, 'done');
+          clearWorkerAttention(workerId);
+          return true;
+        } catch (err) {
+          const ipcErr = extractIpcError(err);
+          if (ipcErr?.code !== 'WORKER_STATE_CHANGED') {
+            if (ipcErr?.code === 'DEVICE_LINK_CHANNEL_NOT_ALLOWED') {
+              log.debug('done acknowledgement skipped after worker state changed', { workerId });
               return false;
             }
-            if (attempt + 1 >= MAX_ATTEMPTS) {
-              log.debug('done acknowledgement exhausted retries; leaving for next view', {
-                workerId,
-                attempts: attempt + 1,
-              });
-              return false;
-            }
-            await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS));
+            throw err;
           }
+          const deferredToTerminalBoundary =
+            ipcErr.message.includes('has an active turn')
+            || ipcErr.message.includes('has a send in progress');
+          if (deferredToTerminalBoundary) {
+            clearWorkerAttention(workerId);
+            log.debug('done acknowledgement deferred to worker terminal boundary', { workerId });
+            return true;
+          }
+          log.debug('done acknowledgement abandoned after non-transient state change', {
+            workerId,
+            message: ipcErr.message,
+          });
+          return false;
         }
-        return false;
       } finally {
         acknowledgingDoneWorkerIdsRef.current.delete(workerId);
       }

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -7763,6 +7763,7 @@
       },
       "stop": "Stop this task",
       "openInPanel": "Open in the background tasks panel",
+      "viewSubagentDetails": "View Subagent details",
       "workflowProgressLine": "{{phase}} · {{done}}/{{total}} agents",
       "workflowProgressCount": "{{done}}/{{total}} agents",
       "tokens": "{{count}} tokens",

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -7761,6 +7761,7 @@
       },
       "stop": "このタスクを停止",
       "openInPanel": "バックグラウンドタスクパネルで開く",
+      "viewSubagentDetails": "サブエージェントの詳細を表示",
       "workflowProgressLine": "{{phase}} · {{done}}/{{total}} Agent",
       "workflowProgressCount": "{{done}}/{{total}} Agent",
       "tokens": "{{count}} tokens",

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -7761,6 +7761,7 @@
       },
       "stop": "이 작업 중지",
       "openInPanel": "백그라운드 작업 패널에서 열기",
+      "viewSubagentDetails": "하위 에이전트 세부 정보 보기",
       "workflowProgressLine": "{{phase}} · {{done}}/{{total}} Agent",
       "workflowProgressCount": "{{done}}/{{total}} Agent",
       "tokens": "{{count}} tokens",

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -7761,6 +7761,7 @@
       },
       "stop": "停止该任务",
       "openInPanel": "在后台任务面板中打开",
+      "viewSubagentDetails": "查看 Subagent 详情",
       "workflowProgressLine": "{{phase}} · {{done}}/{{total}} Agent",
       "workflowProgressCount": "{{done}}/{{total}} Agent",
       "tokens": "{{count}} tokens",

--- a/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
@@ -7760,6 +7760,7 @@
       },
       "stop": "停止該任務",
       "openInPanel": "在後臺任務面板中開啟",
+      "viewSubagentDetails": "查看 Subagent 詳情",
       "workflowProgressLine": "{{phase}} · {{done}}/{{total}} Agent",
       "workflowProgressCount": "{{done}}/{{total}} Agent",
       "tokens": "{{count}} tokens",


### PR DESCRIPTION
## 这次改了什么

### 摘要

四个 issue 的修复(按 commit 顺序):

| Commit | Issue | 范围 |
|---|---|---|
| `5fa431f3` | #3153 | Orca worker terminal 边界 done→idle 收口 |
| `e5abeba5` | #2882 | Pi 会话中途开 Orca rehydrate 前从 DB 回填 resumeSessionId |
| `273babb0` | #3210 (resolver) | 隐式本地 bridge 路由加歧义保护 + wire 缺省推断 |
| `9b37bb92` | #3210 (arch-gate) | cc 代理接入 ①.5 隐式来源路由 |
| `86cedc50` | #3154 | 普通 Subagent 卡展开区加「查看 Subagent 详情」入口 |

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他:

### 范围

- 关联 Issue / 需求:Fixes #3153、#2882、#3210、#3154
- 本 PR 包含:
  - #3153:main 侧 Orca worker done→idle 有界重试收口(250/500ms × 最多 5 次)
  - #2882:`rehydrateActiveOrcaSession` 在 close 前调用 `reconcileCreateOptsWithDb` 从 DB 回填 `resumeSessionId`
  - #3210 resolver:`resolveImplicitLocalBridgeRoute` 歧义保护(多 user-source 暴露同裸 id 时回落)+ wire 缺省推断(`claude-code=anthropic-messages`、`codex=openai-responses`)+ 按 model 存在性过滤候选
  - #3210 cc 代理:cc 未绑定会话时按模型解析已连接的 anthropic-messages bridge 来源(对齐 codex 既有 ①.5 段)
  - #3154:普通 Subagent 卡展开区底部新增「查看 Subagent 详情」链接按钮,通过既有 `openSubagentsTab` 打开右栏面板并定位 run
- 明确不包含:
  - #3154 不恢复曾被有意撤回的「首次创建自动弹出右栏」侵入式行为
  - #3154 完整 Subagent transcript 仍属 #2574 范围,本次只提供可发现性入口
  - 不在 LiteLLM 网关侧为裸 id 注册别名(会引入计费语义歧义)
- 用户可见变化:
  - #3153:协同长会话不再因终态/ack 竞态卡 done,无需手动「继续」
  - #2882:Pi 会话中途开 Orca 后不再丢历史
  - #3210:用户智谱 GLM-5.3 等裸 id 首包不再偶发 400
  - #3154:普通 Subagent 卡展开区有显式详情入口
- 是否存在 breaking change:无

### UI 变化

- 引用的设计规范:

  - #3154 新增的「查看 Subagent 详情」链接按钮位于既有任务卡(AgentTaskCard)展开区底部,字号 `text-12`、颜色 `var(--text-link)`、hover 下划线,与展开区其它元信息(lastTool/outputFile,同 `text-12` / `--text-tertiary`)同一基线,仅颜色提升为链接色以表可点。遵循 DESIGN.md §14.5「聊天正文的可点性信号」:用文字颜色 + 显式按钮文案 + hover 下划线作为可点信号,不引入新的装饰底色或图标背景(图标 `PanelRight size=12` 与 workflow 卡头部同款,复用既有 token)。
  - 不涉及新的间距/栅格/圆角 token,卡片内外边距与背景完全沿用展开区 `mt-2 border-l-2 pl-3` 容器。
  - 无深色模式专门调整:`--text-link` 已是双模式 token。
  - 其余 4 个 commit 都是 main 进程逻辑,不涉及 UI。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop typecheck                       # pass
pnpm --filter desktop exec vitest related --run       # pass(包含 5 个 commit 相关套件)
pnpm test:unit:related                                # pass(maker-host 1948+ / maker-ipc 1725+ / renderer 344+)
pnpm check:i18n-glossary                              # pass(Subagent 已裁决;4 处 lead proposed 为存量告警,非本次引入)
pnpm check:dco                                        # 5/5 Signed-off-by
```

新增/修改测试:
- #3153:`orcaTeamService.test.ts` 新增 4 例(turn 未 settle 后重试、新派活胜出、有排队输入不收口、error 不自动 settle)
- #2882:`makerSendTransaction.test.ts` 新增 1 例(rehydrate 前从 DB 回填 resumeSessionId 且对账先于 bootstrap)
- #3210 resolver:`providerRoute.test.ts` 新增 3 例(多 user-source 歧义返回 null、单源正确解析、不相关 BYOM 不进候选)
- #3210 cc 代理:`claudeProxyScopeGate.test.ts` / `claudeSessionRouteObservation.test.ts` 既有断言随异步化改 await

### 手工验证

不涉及(纯 main 进程路由与状态机逻辑,决策级单测覆盖;原始事故的网关层 curl 复现记录见 #3210)。

### 未执行的验证

未跑 e2e / renderer 套件(改动中 main 进程逻辑由 maker-host / maker-ipc 全目录覆盖;#3154 渲染层改动由 chat/right-sidebar 组件测试覆盖)。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据(#3210 cc 代理改未绑定会话的默认路由,见下)
- [ ] 存量插件兼容
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他:

### 影响与回滚

- #3153:有界重试最多 5 次,到达上限放弃并由 idle watcher 兜底;新派活走 `withWorkerTransition` 串行互斥。单 commit,revert 即恢复。
- #2882:对账在 close 前,失败仅沿用原 opts(与 register.ts 行为一致)。单 commit,revert 即恢复。
- #3210 resolver:歧义保护仅在多 user-source 暴露同 id 时回落,不破坏单源/内置源既有行为;wire 缺省推断是纯放宽(原本会把 user-provider 的 anthropic-messages 漏判)。单 commit,revert 即恢复。
- #3210 cc 代理(架构门):调整未绑定会话的 cc 默认路由契约,讨论见 #3221;维护者 Approve 后合并,如不接受可单独 revert 此 commit 而不影响其它修复。
- #3154:仅增加用户主动入口,不改任何现有行为。
- DCO:5/5 `Signed-off-by: yuaiccc <yuaiccc@aliyun.com>`。