### PR TITLE
fix(codex): hide app-server console on Windows

### DIFF
--- a/packages/maker-core/src/agents/codex/app-server/stdioTransport.test.ts
+++ b/packages/maker-core/src/agents/codex/app-server/stdioTransport.test.ts
@@ -56,6 +56,22 @@ beforeEach(() => {
 });
 
 describe('createStdioTransport process observer', () => {
+  it('starts the app-server without a visible Windows console', () => {
+    mocks.spawn.mockReturnValue(makeChild());
+
+    createStdioTransport({ binaryPath: '/codex', cwd: '/workspace' });
+
+    expect(mocks.spawn).toHaveBeenCalledWith(
+      '/codex',
+      ['app-server'],
+      expect.objectContaining({
+        cwd: '/workspace',
+        shell: false,
+        windowsHide: true,
+      }),
+    );
+  });
+
   it('spawn 时登记一次，主动 close 时只清理一次', async () => {
     const child = makeChild();
     mocks.spawn.mockReturnValue(child);

--- a/packages/maker-core/src/agents/codex/app-server/stdioTransport.ts
+++ b/packages/maker-core/src/agents/codex/app-server/stdioTransport.ts
@@ -61,6 +61,8 @@ export function createStdioTransport(opts: StdioTransportOptions): Transport {
     // Windows: 不开 shell, 直接走 binary; 走 shell 会带来 env injection 风险
     // 且 stdio piping 行为不可控。
     shell: false,
+    // Windows 上 app-server 及其控制台句柄不应打断桌面端 UI。
+    windowsHide: true,
     // Linux/macOS: 跟父进程同 process group, 父进程退出时一并被收割。
     detached: false,
   });


### PR DESCRIPTION
## 这次改了什么

修复 Windows 下本地 Codex app-server 启动时弹出可见控制台窗口的问题，在 spawn 配置中启用 windowsHide: true。

同时新增回归测试，验证 spawn 的二进制、参数、工作目录、shell 模式和隐藏窗口配置均保持正确。

关联 Issue：Closes #3229

## 怎么验证的

已通过：

- pnpm --filter @cindy/maker-core exec vitest run src/agents/codex/app-server/stdioTransport.test.ts
- git diff --check

工作区全量 TypeScript 构建和 lint 仍可能报告其它测试/源码文件中的既有问题，本次改动涉及的定向测试已通过。

## 风险

- 影响范围：仅 Windows 下本地 Codex app-server 的窗口显示方式。
- 不改变进程参数、stdio、shell 模式、生命周期或错误处理。
- macOS、Linux 和 Windows 下的进程功能不受影响。
- 不涉及：没有视觉、交互或文案变化，仅隐藏后台进程控制台窗口。
- 回滚方式：回滚本 PR 即可恢复原有窗口行为。