### PR TITLE
fix(mobile): 让 --takeover 能清掉孤儿 Metro 和脏 worktree

### DIFF
--- a/apps/mobile/scripts/lib/sim-whoami.mjs
+++ b/apps/mobile/scripts/lib/sim-whoami.mjs
@@ -120,6 +120,102 @@ export function classifySimMetroListener({ cwd, source, targetWorktree }) {
   };
 }
 
+/**
+ * Decide whether sim:start should reuse, restart, or refuse the occupant on 8081.
+ *
+ * `--takeover` may stop a confirmed Cindy Metro (cwd ends with /apps/mobile and
+ * the process has an injected source token). It does not require the occupying
+ * worktree's live git fingerprint to still match the running Metro. A missing
+ * worktree is an orphan Metro and is also eligible. Unknown occupants stay
+ * fail-closed even with `--takeover`.
+ */
+export function resolveSimMetroHandoff({
+  port = 8081,
+  cwd = null,
+  takeover = false,
+  envChanged = false,
+  currentSource,
+  runningSource,
+  listener,
+  listenerWorktreeExists = false,
+} = {}) {
+  const occupant = cwd || '(未知进程)';
+
+  if (!listener?.confirmed) {
+    return {
+      action: 'refuse',
+      code: 'occupied-unknown',
+      lines: [
+        `✗ 端口 ${port} 被其他进程占用:${occupant}`,
+        '  不是可确认的 Cindy Metro(需要 .../apps/mobile 工作目录 + 注入的源码指纹)。',
+        '  未知进程即使传 `--takeover` 也不会停。',
+      ],
+    };
+  }
+
+  if (listener.isTarget) {
+    if (runningSource === currentSource) {
+      if (envChanged && !takeover) {
+        return {
+          action: 'refuse',
+          code: 'target-env-stale',
+          lines: [
+            `✗ 已补/改 apps/mobile/.env,但 ${port} 上的 Metro 是用旧 env 启动的(env 在 bundle 时注入)。`,
+            '  需要刷新 env 时传 `--takeover` 重起,新 env 才会生效。',
+          ],
+        };
+      }
+      if (envChanged && takeover) {
+        return { action: 'restart', code: 'target-env', lines: [] };
+      }
+      return {
+        action: 'reuse',
+        code: 'target-fresh',
+        lines: [
+          `✓ Metro 已在 ${port} 运行(本 worktree,源码指纹 ${currentSource})。改 JS 直接 Fast Refresh,无需重开。`,
+        ],
+      };
+    }
+    if (!takeover) {
+      return {
+        action: 'refuse',
+        code: 'target-stale',
+        lines: [
+          `✗ ${port} 上是本 worktree 的 Metro,但源码指纹已过期(运行中=${runningSource || '(无)'} ≠ 当前=${currentSource})。`,
+          '  这通常表示 Metro 启动后又 amend/rebase/reset/改过文件。需要接管时传 `--takeover` 重起。',
+        ],
+      };
+    }
+    return { action: 'restart', code: 'target-stale', lines: [] };
+  }
+
+  if (!listenerWorktreeExists) {
+    if (!takeover) {
+      return {
+        action: 'refuse',
+        code: 'occupied-orphan',
+        lines: [
+          `✗ 端口 ${port} 被已删除 worktree 的孤儿 Metro 占用:${occupant}`,
+          '  该目录已不存在,进程还占着端口。确认可以清掉时传 `--takeover`。',
+        ],
+      };
+    }
+    return { action: 'restart', code: 'occupied-orphan', lines: [] };
+  }
+
+  if (!takeover) {
+    return {
+      action: 'refuse',
+      code: 'occupied-foreign',
+      lines: [
+        `✗ 端口 ${port} 被其他 Cindy worktree 的 Metro 占用:${occupant}`,
+        '  当前版本需要这块端口。确认可以切换时传 `--takeover`。',
+      ],
+    };
+  }
+  return { action: 'restart', code: 'occupied-foreign', lines: [] };
+}
+
 /** Parse the machine-readable output switch for mobile:sim:whoami. */
 export function extractSimJsonArgs(args) {
   let json = false;

--- a/apps/mobile/scripts/sim-start.mjs
+++ b/apps/mobile/scripts/sim-start.mjs
@@ -11,8 +11,10 @@
 // 8083、app 还连 8081,反而制造"看着像新版、其实是旧 bundle"的坑(正是本工具要消灭的)。
 //   - 8081 空闲 → 起在 8081。
 //   - 8081 已被**本 worktree** 占 → 说明 Metro 已在跑,直接 Fast Refresh 即可,不重开。
-//   - 8081 被**别的 worktree** 占 → 默认明确报错;传 `--takeover` 时仅在确认占用者是 Metro、
-//     且能读取它的 worktree 时为本次用户授权的切换停止它,然后重新启动当前版本。
+//   - 8081 被**别的 worktree** 占 → 默认明确报错;传 `--takeover` 时仅在确认占用者是
+//     Cindy Metro(cwd 以 /apps/mobile 结尾 + 注入了源码指纹)后停止它。不要求对方
+//     磁盘上的 git 指纹仍与启动时一致;对方目录已删则视为孤儿 Metro,同样可接管。
+//     未知进程 / 非 Metro 即使带 `--takeover` 也 fail closed。
 //     确实要换端口请 `--port <p>` 显式指定(你需自行把模拟器里的 app 指过去,如 dev menu)。
 //
 // 用法(仓库根):
@@ -22,6 +24,7 @@
 //   pnpm mobile:sim:start -- --port 8082   # 显式换端口(透传给 expo;需自行把 app 指过去)
 
 import { execFileSync, spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { mobileClientBundleEnv } from '../../../scripts/shared/client-endpoint-build-env.mjs';
@@ -34,6 +37,7 @@ import {
   classifySimMetroListener,
   extractSimMetroPortArgs,
   extractSimTakeoverArgs,
+  resolveSimMetroHandoff,
 } from './lib/sim-whoami.mjs';
 import {
   ensureMobileLocalRegionConfig,
@@ -94,39 +98,23 @@ if (portArgs.port === DEFAULT_PORT) {
       source: runningSource,
       targetWorktree: worktreeRoot,
     });
-    let listenerSourceIdentity = null;
-    if (listener.confirmed) {
-      try {
-        listenerSourceIdentity = gitSourceIdentity(listener.worktree);
-      } catch {
-        listenerSourceIdentity = null;
-      }
+    const listenerWorktreeExists = Boolean(listener.worktree && existsSync(listener.worktree));
+    const decision = resolveSimMetroHandoff({
+      port: DEFAULT_PORT,
+      cwd,
+      takeover,
+      envChanged,
+      currentSource: sourceIdentity,
+      runningSource,
+      listener,
+      listenerWorktreeExists,
+    });
+    if (decision.action === 'reuse') {
+      for (const line of decision.lines) console.log(line);
+      process.exit(0);
     }
-    const listenerConfirmed = listener.confirmed && listenerSourceIdentity === runningSource;
-    const canTakeOverListener = listener.isTarget ? listener.confirmed : listenerConfirmed;
-
-    if (listenerConfirmed && listener.isTarget) {
-      // 是本 worktree 的 Metro —— 但还要确认它注入了**当前分支**的 git env,否则 build label branch
-      // 会是旧值/unknown(如手动 `expo start` 起的、或起好后切过分支),"已在跑"就成了假证据。
-      if (runningSource === sourceIdentity) {
-        if (envChanged && !takeover) {
-          console.error('✗ 已补/改 apps/mobile/.env,但 8081 上的 Metro 是用旧 env 启动的(env 在 bundle 时注入)。');
-          console.error('  需要刷新 env 时传 `--takeover` 重起,新 env 才会生效。');
-          process.exit(1);
-        }
-        if (!envChanged) {
-          console.log(`✓ Metro 已在 ${DEFAULT_PORT} 运行(本 worktree,源码指纹 ${sourceIdentity})。改 JS 直接 Fast Refresh,无需重开。`);
-          process.exit(0);
-        }
-      } else if (!takeover) {
-        console.error(`✗ ${DEFAULT_PORT} 上是本 worktree 的 Metro,但源码指纹已过期(运行中=${runningSource || '(无)'} ≠ 当前=${sourceIdentity})。`);
-        console.error('  这通常表示 Metro 启动后又 amend/rebase/reset/改过文件。需要接管时传 `--takeover` 重起。');
-        process.exit(1);
-      }
-    } else if (!(takeover && canTakeOverListener)) {
-      console.error(`✗ 端口 ${DEFAULT_PORT} 被其他进程占用:${cwd || '(未知进程)'}`);
-      console.error(`  本 app 无 expo-dev-client、只会连默认 ${DEFAULT_PORT};默认不会自动接管。`);
-      console.error('  只有确认它是本 Cindy worktree 的 Metro 后，传 `--takeover` 才能安全切换。');
+    if (decision.action === 'refuse') {
+      for (const line of decision.lines) console.error(line);
       process.exit(1);
     }
 
@@ -139,7 +127,9 @@ if (portArgs.port === DEFAULT_PORT) {
       console.error(`✗ 无法在限定时间内停止旧 Metro(pid=${pid}),拒绝继续。`);
       process.exit(1);
     }
-    if (listener.isTarget) {
+    if (decision.code === 'occupied-orphan') {
+      console.log(`✓ 已停止已删除 worktree 的孤儿 Metro(pid=${pid}, cwd=${cwd})。`);
+    } else if (listener.isTarget) {
       console.log(`✓ 已重启当前 worktree 的 Metro(pid=${pid}, cwd=${cwd})。`);
     } else {
       console.log(`✓ 已接管其他 Cindy worktree 的 Metro(pid=${pid}, cwd=${cwd})。`);

--- a/apps/mobile/src/__tests__/mobileSimWhoami.test.ts
+++ b/apps/mobile/src/__tests__/mobileSimWhoami.test.ts
@@ -9,6 +9,7 @@ import {
   extractSimWhoamiUdidArgs,
   getSimulatorAppContainer,
   resolveMobileSimulatorBundleId,
+  resolveSimMetroHandoff,
 } from '../../scripts/lib/sim-whoami.mjs';
 
 const SIMULATOR_UDID = 'A1B2C3D4-E5F6-47A8-9B0C-D1E2F3A4B5C6';
@@ -76,6 +77,93 @@ describe('mobile:sim takeover and JSON arguments', () => {
       source: 'branch@commit',
       targetWorktree: '/repo/',
     })).toEqual({ confirmed: true, worktree: '/repo', isTarget: true });
+  });
+});
+
+describe('mobile:sim Metro handoff', () => {
+  const foreign = {
+    confirmed: true,
+    worktree: '/other',
+    isTarget: false,
+  };
+  const target = {
+    confirmed: true,
+    worktree: '/repo',
+    isTarget: true,
+  };
+
+  it('lets --takeover stop a foreign Metro even if that worktree is dirty', () => {
+    expect(resolveSimMetroHandoff({
+      cwd: '/other/apps/mobile',
+      takeover: true,
+      currentSource: 'here@aaa',
+      runningSource: 'there@bbb',
+      listener: foreign,
+      listenerWorktreeExists: true,
+    })).toMatchObject({ action: 'restart', code: 'occupied-foreign' });
+  });
+
+  it('lets --takeover stop an orphan Metro whose worktree is gone', () => {
+    expect(resolveSimMetroHandoff({
+      cwd: '/gone/apps/mobile',
+      takeover: true,
+      currentSource: 'here@aaa',
+      runningSource: 'gone@ccc',
+      listener: foreign,
+      listenerWorktreeExists: false,
+    })).toMatchObject({ action: 'restart', code: 'occupied-orphan' });
+  });
+
+  it('refuses a dirty or orphan foreign Metro without --takeover', () => {
+    expect(resolveSimMetroHandoff({
+      cwd: '/other/apps/mobile',
+      currentSource: 'here@aaa',
+      runningSource: 'there@bbb',
+      listener: foreign,
+      listenerWorktreeExists: true,
+    })).toMatchObject({ action: 'refuse', code: 'occupied-foreign' });
+    expect(resolveSimMetroHandoff({
+      cwd: '/gone/apps/mobile',
+      currentSource: 'here@aaa',
+      runningSource: 'gone@ccc',
+      listener: foreign,
+      listenerWorktreeExists: false,
+    })).toMatchObject({ action: 'refuse', code: 'occupied-orphan' });
+  });
+
+  it('keeps unknown occupants fail-closed even with --takeover', () => {
+    expect(resolveSimMetroHandoff({
+      cwd: '/random',
+      takeover: true,
+      currentSource: 'here@aaa',
+      runningSource: null,
+      listener: { confirmed: false, worktree: null },
+    })).toMatchObject({ action: 'refuse', code: 'occupied-unknown' });
+  });
+
+  it('reuses a fresh Metro on this worktree and restarts a stale one only with --takeover', () => {
+    expect(resolveSimMetroHandoff({
+      cwd: '/repo/apps/mobile',
+      currentSource: 'here@aaa',
+      runningSource: 'here@aaa',
+      listener: target,
+      listenerWorktreeExists: true,
+    })).toMatchObject({ action: 'reuse', code: 'target-fresh' });
+    expect(resolveSimMetroHandoff({
+      cwd: '/repo/apps/mobile',
+      currentSource: 'here@aaa',
+      runningSource: 'here@old',
+      listener: target,
+      listenerWorktreeExists: true,
+    })).toMatchObject({ action: 'refuse', code: 'target-stale' });
+    expect(resolveSimMetroHandoff({
+      cwd: '/repo/apps/mobile',
+      takeover: true,
+      currentSource: 'here@aaa',
+      runningSource: 'here@old',
+      listener: target,
+      listenerWorktreeExists: true,
+    })).toMatchObject({ action: 'restart', code: 'target-stale' });
   });
 });
 


### PR DESCRIPTION
## 这次改了什么

### 摘要

`pnpm mobile:sim:start -- --takeover` 原先要求「对方 worktree 磁盘上的 git 指纹必须仍等于 Metro 启动时注入的值」。对方目录已经删掉（孤儿进程），或启动后又改过文件时，脚本会误判成未知占用并拒绝接管，8081 被占死。现在只要确认占用者是 Cindy Metro（cwd 以 `/apps/mobile` 结尾 + 注入了源码指纹），`--takeover` 就可以停掉它；未知进程 / 非 Metro 仍然 fail closed。报错会写明是别的 worktree、孤儿进程还是未知占用。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：
  - 抽出 `resolveSimMetroHandoff` 纯函数，统一 reuse / restart / refuse
  - `--takeover` 允许接管指纹已漂的其他 Cindy worktree
  - `--takeover` 允许清掉目录已删的孤儿 Metro
  - 按原因拆开拒绝文案
  - 单测覆盖脏 worktree、孤儿、未知占用、本 worktree 复用/过期
- 明确不包含：
  - 不放宽未知进程 / 非 Metro 的 fail-closed
  - 不改 `mobile:sim:rebuild` 的启动前警告
  - 不改模拟器选设备或 App 启动
- 用户可见变化：开发者跑 `mobile:sim:start -- --takeover` 时，上述两类占用可以接管；报错更准确
- 是否存在 breaking change：无

### UI 变化

不涉及

- 引用的设计规范：不涉及：本地模拟器启动脚本，无界面改动

远程与手机适配三问：不涉及。这是本机 `mobile:sim:*` 开发脚本，不改产品功能、不改 device-link 协议、不改手机 App 运行时。

## 怎么验证的

### 自动验证

```text
pnpm --filter mobile exec vitest run \
  src/__tests__/mobileSimWhoami.test.ts \
  src/__tests__/mobileSimSource.test.ts
结果：2 files / 35 tests passed

pnpm --filter mobile run typecheck
结果：通过
```

### 手工验证

不涉及。这次是开发脚本判定，没有改 App UI；孤儿 Metro 的现场已用单测固定，没有再占一次 8081 做真机接管。

### 未执行的验证

- 未在真机上再制造一个已删 worktree 的孤儿 Metro 做端到端接管
- 未跑全仓 `pnpm test:unit`（改动只触及 mobile 模拟器脚本与对应单测）

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：本地 `pnpm mobile:sim:start -- --takeover` 的占用判定与报错
- 回滚 / 降级方式：回退本 PR 后恢复旧闸门（脏 worktree / 孤儿进程再次无法接管）
- 存量插件影响：无
- 冷更：无。只改仓库根脚本与测试，不改 `apps/mobile/package.json` / 原生输入

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
