### PR TITLE
fix(desktop): preserve plan mode composer drafts

### DIFF
--- a/apps/desktop/src/renderer/__tests__/planModeComposerCommand.test.ts
+++ b/apps/desktop/src/renderer/__tests__/planModeComposerCommand.test.ts
@@ -6,6 +6,7 @@ import {
   addPlanModeComposerCommand,
   consumePlanModeComposerCommand,
   isPlanModeComposerCommandText,
+  planModeComposerDraftText,
   shouldPreservePlanModeComposerDraft,
 } from '../components/new-chat/planModeComposerCommand';
 import type { UnifiedCommand } from '../lib/slashCommands';
@@ -83,5 +84,20 @@ describe('/plan composer command', () => {
     expect(shouldPreservePlanModeComposerDraft(1, 0)).toBe(true);
     expect(shouldPreservePlanModeComposerDraft(0, 1)).toBe(true);
     expect(shouldPreservePlanModeComposerDraft(0, 0)).toBe(false);
+  });
+
+  it('captures editor text before the plan command clears the editor', () => {
+    const editorText = {
+      type: 'doc',
+      content: [{ type: 'paragraph', content: [{ type: 'text', text: 'keep me' }] }],
+    };
+    const storedText = {
+      type: 'doc',
+      content: [{ type: 'paragraph', content: [{ type: 'text', text: 'stored' }] }],
+    };
+
+    expect(planModeComposerDraftText(true, editorText, storedText)).toBe(editorText);
+    expect(planModeComposerDraftText(false, null, storedText)).toBe(storedText);
+    expect(planModeComposerDraftText(true, null, storedText)).toBeNull();
   });
 });

--- a/apps/desktop/src/renderer/__tests__/planModeComposerCommand.test.ts
+++ b/apps/desktop/src/renderer/__tests__/planModeComposerCommand.test.ts
@@ -100,4 +100,10 @@ describe('/plan composer command', () => {
     expect(planModeComposerDraftText(false, null, storedText)).toBe(storedText);
     expect(planModeComposerDraftText(true, null, storedText)).toBeNull();
   });
+
+  it('does not persist the consumed /plan command as draft text', () => {
+    const editorText = { type: 'doc', content: [{ type: 'paragraph', content: [{ type: 'text', text: '/plan' }] }] };
+    expect(planModeComposerDraftText(true, editorText, null, true)).toBeNull();
+    expect(planModeComposerDraftText(false, null, editorText, true)).toBeNull();
+  });
 });

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -5049,6 +5049,7 @@ export function ChatInput({
             editorOwnsSource,
             editorOwnsSource ? editor.getJSON() : null,
             existingDraft?.text,
+            true,
           );
           if (editorOwnsSource) {
             planModeEntry?.onToggle(!planModeEntry.enabled);

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -158,6 +158,7 @@ import {
   addPlanModeComposerCommand,
   consumePlanModeComposerCommand,
   isPlanModeComposerCommandText,
+  planModeComposerDraftText,
   shouldPreservePlanModeComposerDraft,
 } from './planModeComposerCommand';
 import { PendingQueuePanel } from './PendingQueuePanel';
@@ -5042,6 +5043,13 @@ export function ChatInput({
             editorStorageKey: storageKeyForDraftRef.current,
             sourceStorageKey,
           });
+          const existingDraft = sourceStorageKey ? getComposerDraft(sourceStorageKey) : undefined;
+          // Capture this before consuming `/plan`, which clears the live editor.
+          const draftText = planModeComposerDraftText(
+            editorOwnsSource,
+            editorOwnsSource ? editor.getJSON() : null,
+            existingDraft?.text,
+          );
           if (editorOwnsSource) {
             planModeEntry?.onToggle(!planModeEntry.enabled);
             isRestoringRef.current = true;
@@ -5058,11 +5066,10 @@ export function ChatInput({
             if (
               shouldPreservePlanModeComposerDraft(attachmentsForSend.length, commentsForSend.length)
             ) {
-              const existingDraft = getComposerDraft(sourceStorageKey);
               saveComposerDraft(
                 sourceStorageKey,
                 {
-                  text: editorOwnsSource ? editor.getJSON() : (existingDraft?.text ?? null),
+                  text: draftText,
                   attachments: attachmentsForSend,
                   quotes: existingDraft?.quotes ?? [],
                   browserComments: commentsForSend,

--- a/apps/desktop/src/renderer/components/new-chat/planModeComposerCommand.ts
+++ b/apps/desktop/src/renderer/components/new-chat/planModeComposerCommand.ts
@@ -1,4 +1,5 @@
 import type { Transaction } from '@tiptap/pm/state';
+import type { JSONContent } from '@tiptap/core';
 
 import type { UnifiedCommand } from '@/lib/slashCommands';
 
@@ -55,4 +56,13 @@ export function shouldPreservePlanModeComposerDraft(
   browserCommentCount: number,
 ): boolean {
   return attachmentCount > 0 || browserCommentCount > 0;
+}
+
+/** Capture text before consuming `/plan` clears the live editor. */
+export function planModeComposerDraftText(
+  editorOwnsSource: boolean,
+  editorText: JSONContent | null | undefined,
+  storedText: JSONContent | null | undefined,
+): JSONContent | null {
+  return (editorOwnsSource ? editorText : storedText) ?? null;
 }

--- a/apps/desktop/src/renderer/components/new-chat/planModeComposerCommand.ts
+++ b/apps/desktop/src/renderer/components/new-chat/planModeComposerCommand.ts
@@ -63,6 +63,8 @@ export function planModeComposerDraftText(
   editorOwnsSource: boolean,
   editorText: JSONContent | null | undefined,
   storedText: JSONContent | null | undefined,
+  consumedCommand = false,
 ): JSONContent | null {
+  if (consumedCommand) return null;
   return (editorOwnsSource ? editorText : storedText) ?? null;
 }


### PR DESCRIPTION
## 这次改了什么

### 摘要
修复独立 `/plan` 命令消费时先清空编辑器、再保存草稿导致正文丢失的问题。

### 范围
- 关联 Issue：#3095
- 本 PR 包含：保存 `/plan` 消费前的正文快照，并保留现有附件/浏览器评论语义。
- 明确不包含：计划模式产品行为或视觉调整。

### UI 变化
- 引用的设计规范：不涉及：仅修复 composer 草稿持久化时序，没有视觉、交互或文案变化。

## 怎么验证的

### 自动验证
```text
pnpm --filter desktop exec vitest run src/renderer/__tests__/planModeComposerCommand.test.ts
结果：6 tests passed

pnpm --filter desktop exec eslint src/renderer/components/new-chat/planModeComposerCommand.ts src/renderer/__tests__/planModeComposerCommand.test.ts
结果：通过

git diff --check
结果：通过
```

### 手工验证
不涉及。

### 未执行的验证
未执行完整 Desktop typecheck；仓库当前存在与本改动无关的既有类型错误。

## 风险

### 风险分类
- [x] 无已知风险

### 影响与回滚
- 影响范围：仅 `/plan` 消费且同时保留附件或浏览器评论的草稿保存。
- 回滚 / 降级方式：回滚本 PR 即恢复原逻辑。

Closes #3095