### PR TITLE
fix(desktop): drain queued input after a stale idle turn

### DIFF
--- a/apps/desktop/src/main/__tests__/makerEventHotPathOrdering.test.ts
+++ b/apps/desktop/src/main/__tests__/makerEventHotPathOrdering.test.ts
@@ -147,7 +147,7 @@ describe('maker:event hot path ordering', () => {
     const observerHelperStart = source.indexOf('function notifyGoalIdleAfterTurnSettled(');
     const observerHelperEnd = source.indexOf('\n}\n', observerHelperStart) + 2;
     const observerHelperSource = source.slice(observerHelperStart, observerHelperEnd);
-    const reconcileStart = source.indexOf('const reconcileSessionTurnIdle =');
+    const reconcileStart = source.indexOf('const sealLostTerminalPersistState =');
     const reconcileEnd = source.indexOf('\n\n  const readDirectAbortTurnId =', reconcileStart);
     const reconcileSource = source.slice(reconcileStart, reconcileEnd);
     const directAbortStart = source.indexOf('ipcMain.handle(MAKER_INVOKE.ABORT_SESSION');
@@ -170,20 +170,27 @@ describe('maker:event hot path ordering', () => {
 
     expect(reconcileStart).toBeGreaterThanOrEqual(0);
     expect(reconcileEnd).toBeGreaterThan(reconcileStart);
-    expectOrder(
-      reconcileSource,
+    const liveIdleStart = reconcileSource.indexOf(
       'sessionTurnActivityTracker.setSessionInTurn(sessionId, false);',
-      'notifyGoalIdleAfterTurnSettled(sessionId);',
     );
+    expect(liveIdleStart).toBeGreaterThanOrEqual(0);
+    expect(
+      reconcileSource.indexOf('notifyGoalIdleAfterTurnSettled(sessionId);', liveIdleStart),
+    ).toBeGreaterThan(liveIdleStart);
     expectOrder(
       reconcileSource,
-      'markTurnEndedAfterPersistDrain(sessionId);',
-      'clearCodexPlanRowsForSession(sessionId);',
+      'flushAssistantBlock(sessionId, null);',
+      'consumeLastAssistantPersistId(sessionId);',
     );
     expectOrder(
       reconcileSource,
       'clearCodexPlanRowsForSession(sessionId);',
       'resetTurnPersistState(sessionId);',
+    );
+    expectOrder(
+      reconcileSource,
+      'sealLostTerminalPersistState(sessionId);',
+      'sessionTurnActivityTracker.deleteSession(sessionId);',
     );
 
     // ABORT_SESSION reconciles from finally, so vendor abort rejection still reaches the
@@ -703,7 +710,7 @@ describe('maker:event hot path ordering', () => {
     const stableLookupStart = source.indexOf('const lookupStableSessionForTurnBoundary =');
     const stableLookupEnd = source.indexOf('\n  const getStableSessionForTurnBoundary =', stableLookupStart);
     const stableLookupSource = source.slice(stableLookupStart, stableLookupEnd);
-    const reconcileStart = source.indexOf('\n  const reconcileSessionTurnIdle =');
+    const reconcileStart = source.indexOf('const sealLostTerminalPersistState =');
     const reconcileEnd = source.indexOf('\n\n  const inputCoordinator:', reconcileStart);
     const reconcileSource = source.slice(reconcileStart, reconcileEnd);
 
@@ -728,8 +735,8 @@ describe('maker:event hot path ordering', () => {
     expectOrder(reconcileSource, 'flushAssistantBlock(sessionId, null);', 'consumeLastAssistantPersistId(sessionId);');
     expectOrder(reconcileSource, 'consumeLastAssistantPersistId(sessionId);', 'consumeLastTopLevelAssistantPersistId(sessionId);');
     expectOrder(reconcileSource, 'consumeLastTopLevelAssistantPersistId(sessionId);', 'markAssistantTurnFailed(sessionId, abortedBoundaryAssistantPersistId)');
-    expectOrder(reconcileSource, 'markAssistantTurnFailed(sessionId, abortedBoundaryAssistantPersistId)', 'markTurnEndedAfterPersistDrain(sessionId);');
-    expectOrder(reconcileSource, 'markTurnEndedAfterPersistDrain(sessionId);', 'resetTurnPersistState(sessionId);');
+    expectOrder(reconcileSource, 'sealLostTerminalPersistState(sessionId);', 'sessionTurnActivityTracker.deleteSession(sessionId);');
+    expectOrder(reconcileSource, 'clearCodexPlanRowsForSession(sessionId);', 'resetTurnPersistState(sessionId);');
   });
 
   it('keeps direct abort reconciliation fail-closed across owner replacement and new turns', () => {

--- a/apps/desktop/src/main/__tests__/makerEventHotPathOrdering.test.ts
+++ b/apps/desktop/src/main/__tests__/makerEventHotPathOrdering.test.ts
@@ -67,12 +67,17 @@ describe('maker:event hot path ordering', () => {
     const wireSessionSource = extractWireSessionSource();
     expectOrder(
       wireSessionSource,
-      'isFencedStaleTerminal(session.id, {',
+      'isFencedStaleSessionTerminal(session.id, event)',
+      'ghostSessionTap.handleEvent(',
+    );
+    expectOrder(
+      wireSessionSource,
+      'isFencedStaleSessionTerminal(session.id, event)',
       'finalizeTurnChangeSet(',
     );
     expectOrder(
       wireSessionSource,
-      'isFencedStaleTerminal(session.id, {',
+      'isFencedStaleSessionTerminal(session.id, event)',
       'shouldMarkTurnStatusIdleAfterBroadcast = true',
     );
   });

--- a/apps/desktop/src/main/__tests__/makerEventHotPathOrdering.test.ts
+++ b/apps/desktop/src/main/__tests__/makerEventHotPathOrdering.test.ts
@@ -202,10 +202,12 @@ describe('maker:event hot path ordering', () => {
       "return reconcileSessionTurnIdle(sessionId, 'authoritative-idle');",
     );
     expect(coordinatorSource).toContain('isLiveTurnRunning: (sessionId) =>');
+    expect(coordinatorSource).toContain('isLiveSessionPresent: (sessionId) =>');
     expect(source).toContain('lookupStableSessionForTurnBoundary');
     expect(source).toContain("status: 'unavailable'");
     expect(coordinatorSource).toContain("if (lookup.status === 'unavailable') return undefined;");
     expect(coordinatorSource).toContain("if (lookup.status === 'missing') return false;");
+    expect(coordinatorSource).toContain("return lookup.status === 'found';");
   });
 
   it('does not latch product-turn bookkeeping on background status events', () => {

--- a/apps/desktop/src/main/__tests__/makerEventHotPathOrdering.test.ts
+++ b/apps/desktop/src/main/__tests__/makerEventHotPathOrdering.test.ts
@@ -73,6 +73,11 @@ describe('maker:event hot path ordering', () => {
     expectOrder(
       wireSessionSource,
       'isFencedStaleSessionTerminal(session.id, event)',
+      'consumeClaudeOpusPlanMismatch(',
+    );
+    expectOrder(
+      wireSessionSource,
+      'isFencedStaleSessionTerminal(session.id, event)',
       'finalizeTurnChangeSet(',
     );
     expectOrder(

--- a/apps/desktop/src/main/__tests__/makerEventHotPathOrdering.test.ts
+++ b/apps/desktop/src/main/__tests__/makerEventHotPathOrdering.test.ts
@@ -202,7 +202,10 @@ describe('maker:event hot path ordering', () => {
       "return reconcileSessionTurnIdle(sessionId, 'authoritative-idle');",
     );
     expect(coordinatorSource).toContain('isLiveTurnRunning: (sessionId) =>');
-    expect(coordinatorSource).toContain('if (!sess) return false;');
+    expect(source).toContain('lookupStableSessionForTurnBoundary');
+    expect(source).toContain("status: 'unavailable'");
+    expect(coordinatorSource).toContain("if (lookup.status === 'unavailable') return undefined;");
+    expect(coordinatorSource).toContain("if (lookup.status === 'missing') return false;");
   });
 
   it('does not latch product-turn bookkeeping on background status events', () => {
@@ -695,18 +698,25 @@ describe('maker:event hot path ordering', () => {
   });
 
   it('uses the wired Session snapshot while reconciling owner-boundary aborts', () => {
-    const stableLookupStart = source.indexOf('const getStableSessionForTurnBoundary =');
-    const stableLookupEnd = source.indexOf('\n  const reconcileSessionTurnIdle =', stableLookupStart);
+    const stableLookupStart = source.indexOf('const lookupStableSessionForTurnBoundary =');
+    const stableLookupEnd = source.indexOf('\n  const getStableSessionForTurnBoundary =', stableLookupStart);
     const stableLookupSource = source.slice(stableLookupStart, stableLookupEnd);
-    const reconcileStart = stableLookupEnd;
+    const reconcileStart = source.indexOf('\n  const reconcileSessionTurnIdle =');
     const reconcileEnd = source.indexOf('\n\n  const inputCoordinator:', reconcileStart);
     const reconcileSource = source.slice(reconcileStart, reconcileEnd);
 
     expect(stableLookupStart).toBeGreaterThanOrEqual(0);
     expect(stableLookupEnd).toBeGreaterThan(stableLookupStart);
     expect(stableLookupSource).toContain('wiredSessionsById.get(sessionId)?.session');
-    expectOrder(stableLookupSource, 'if (wired) return wired;', 'return maker.getSession(sessionId) ?? null;');
-    expect(stableLookupSource).toContain('return null;');
+    expectOrder(
+      stableLookupSource,
+      'if (wired) return { status: \'found\', session: wired };',
+      'return sess ? { status: \'found\', session: sess } : { status: \'missing\' };',
+    );
+    expect(stableLookupSource).toContain("return { status: 'unavailable' };");
+    expect(source).toContain(
+      "return lookup.status === 'found' ? lookup.session : null;",
+    );
 
     expect(reconcileStart).toBeGreaterThanOrEqual(0);
     expect(reconcileEnd).toBeGreaterThan(reconcileStart);

--- a/apps/desktop/src/main/__tests__/makerEventHotPathOrdering.test.ts
+++ b/apps/desktop/src/main/__tests__/makerEventHotPathOrdering.test.ts
@@ -202,7 +202,7 @@ describe('maker:event hot path ordering', () => {
       "return reconcileSessionTurnIdle(sessionId, 'authoritative-idle');",
     );
     expect(coordinatorSource).toContain('isLiveTurnRunning: (sessionId) =>');
-    expect(coordinatorSource).toContain('if (!sess) return undefined;');
+    expect(coordinatorSource).toContain('if (!sess) return false;');
   });
 
   it('does not latch product-turn bookkeeping on background status events', () => {

--- a/apps/desktop/src/main/__tests__/makerEventHotPathOrdering.test.ts
+++ b/apps/desktop/src/main/__tests__/makerEventHotPathOrdering.test.ts
@@ -61,6 +61,22 @@ describe('maker:event hot path ordering', () => {
     expect(wireSessionSource).toContain('installInteractionLifecycleObserver(session, null);');
   });
 
+  it('rejects a fenced leftover terminal before register-side turn effects', () => {
+    expect(source).toContain('delete rendererEvent.sessionTurnGeneration');
+    expect(source).toContain('delete rendererEvent.sessionInstanceId');
+    const wireSessionSource = extractWireSessionSource();
+    expectOrder(
+      wireSessionSource,
+      'isFencedStaleTerminal(session.id, {',
+      'finalizeTurnChangeSet(',
+    );
+    expectOrder(
+      wireSessionSource,
+      'isFencedStaleTerminal(session.id, {',
+      'shouldMarkTurnStatusIdleAfterBroadcast = true',
+    );
+  });
+
   it('broadcasts EVENT before usage/context/island/idle side effects', () => {
     const wireSessionSource = extractWireSessionSource();
 

--- a/apps/desktop/src/main/__tests__/messagePersistBroadcaster.test.ts
+++ b/apps/desktop/src/main/__tests__/messagePersistBroadcaster.test.ts
@@ -2202,6 +2202,40 @@ describe('consumeLastAssistantPersistId(per-turn 费用挂载的目标消息追�
     expect(consumeLastAssistantPersistId(SESSION)).toBeUndefined();
   });
 
+  it('missing-session lost-terminal seal does not concatenate the next turn onto leftover stream text', async () => {
+    const deadId = onAssistantTextEvent(
+      SESSION,
+      { text: 'dead-turn-fragment', isFinal: false },
+      null,
+    );
+    expect(deadId).toEqual(expect.any(String));
+
+    // Same persist boundary as reconcileSessionTurnIdle's missing lookup.
+    flushAssistantBlock(SESSION, null);
+    consumeLastAssistantPersistId(SESSION);
+    consumeLastTopLevelAssistantPersistId(SESSION);
+    resetTurnPersistState(SESSION);
+
+    const nextId = onAssistantTextEvent(
+      SESSION,
+      { text: 'next-turn-only', isFinal: false },
+      null,
+    );
+    expect(nextId).not.toBe(deadId);
+    flushAssistantBlock(SESSION, null);
+    await flushWrites();
+
+    const assistantCreates = (createMessage as unknown as { mock: { calls: unknown[][] } }).mock.calls
+      .filter((c) => (c[1] as { role?: string }).role === 'assistant');
+    expect(assistantCreates).toHaveLength(2);
+    expect(assistantCreates[0]?.[1]).toEqual(
+      expect.objectContaining({ clientId: deadId, content: 'dead-turn-fragment' }),
+    );
+    expect(assistantCreates[1]?.[1]).toEqual(
+      expect.objectContaining({ clientId: nextId, content: 'next-turn-only' }),
+    );
+  });
+
   it('clearSessionPersistState 清理追踪(session 关闭防泄漏)', () => {
     onAssistantTextEvent(SESSION, { text: 'gone', isFinal: true }, null);
     clearSessionPersistState(SESSION);

--- a/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
@@ -171,6 +171,7 @@ function createHarness(opts?: {
 }) {
   let running = false;
   let liveRunningOverride: boolean | null | 'unknown' = null;
+  let liveSessionPresentOverride: boolean | null | 'unknown' = null;
   let turnGeneration = 0;
   let turnSessionIdentity: object = {};
   let pendingInteraction = false;
@@ -299,6 +300,12 @@ function createHarness(opts?: {
       if (liveRunningOverride === 'unknown') return undefined;
       return liveRunningOverride === null ? running : liveRunningOverride;
     },
+    isLiveSessionPresent: () => {
+      if (liveSessionPresentOverride === 'unknown') return undefined;
+      if (liveSessionPresentOverride !== null) return liveSessionPresentOverride;
+      if (liveRunningOverride === 'unknown') return undefined;
+      return true;
+    },
     getTurnGeneration: () => turnGeneration,
     getTurnSessionIdentity: () => turnSessionIdentity,
     reconcileTurnIdle,
@@ -379,6 +386,9 @@ function createHarness(opts?: {
     },
     setLiveRunning(value: boolean | null | 'unknown') {
       liveRunningOverride = value;
+    },
+    setLiveSessionPresent(value: boolean | null | 'unknown') {
+      liveSessionPresentOverride = value;
     },
     setTurnGeneration(value: number) {
       turnGeneration = value;
@@ -6201,11 +6211,11 @@ describe('AgentInputCoordinator steer transaction', () => {
     expect(latestProjection(h.projections).pendingQueue.map((q) => q.clientId)).toEqual(['q-1']);
   });
 
-  it('clears a leftover activeTurn when the live Session is idle and drains the next head', async () => {
+  it('does not timeout-clear leftover activeTurn while a live Session is still present', async () => {
     vi.useFakeTimers();
     try {
       const h = createHarness();
-      const sid = 'drain-zombie-active-turn';
+      const sid = 'drain-live-present-active-turn';
       const first = makeItem('q-1', 'first');
       const second = makeItem('q-2', 'queued-after-idle');
 
@@ -6214,38 +6224,60 @@ describe('AgentInputCoordinator steer transaction', () => {
       expect(h.sendToAgent).toHaveBeenCalledTimes(1);
 
       h.setLiveRunning(false);
+      h.setLiveSessionPresent(true);
       h.setRunning(true);
-      h.reconcileTurnIdle.mockImplementation(() => {
-        h.setRunning(false);
-        h.setLiveRunning(false);
-        return true;
-      });
       h.coordinator.enqueue(sid, second);
       await flush();
-      expect(h.sendToAgent).toHaveBeenCalledTimes(1);
       expect(latestProjection(h.projections).pendingQueue.map((q) => q.clientId)).toEqual(['q-2']);
 
-      await vi.advanceTimersByTimeAsync(250);
+      await vi.advanceTimersByTimeAsync(5_000);
       await flush();
+
       expect(h.reconcileTurnIdle).not.toHaveBeenCalled();
       expect(h.sendToAgent).toHaveBeenCalledTimes(1);
-
-      await vi.advanceTimersByTimeAsync(4_750);
-      await flush();
-
-      expect(h.reconcileTurnIdle).toHaveBeenCalledWith(sid);
-      expect(h.sendToAgent).toHaveBeenCalledTimes(2);
-      expect(h.sendToAgent.mock.calls[1]?.[1]).toEqual({
-        type: 'user',
-        content: 'queued-after-idle',
-      });
-      expect(latestProjection(h.projections).pendingQueue).toEqual([]);
+      expect(latestProjection(h.projections).pendingQueue.map((q) => q.clientId)).toEqual(['q-2']);
     } finally {
       vi.useRealTimers();
     }
   });
 
-  it('drains queued work after an unloaded Session leaves only a leftover activeTurn', async () => {
+  it('does not timeout-clear a pre-dispatch activeTurn even after the Session unloads', async () => {
+    vi.useFakeTimers();
+    try {
+      const h = createHarness();
+      const sid = 'drain-pre-dispatch-active-turn';
+      let finishFirst: ((value: AgentInputSendResult) => void) | undefined;
+      h.sendToAgent.mockImplementationOnce(
+        () =>
+          new Promise<AgentInputSendResult>((resolve) => {
+            finishFirst = resolve;
+          }),
+      );
+
+      h.coordinator.enqueue(sid, makeItem('q-1', 'first'));
+      await flush();
+      expect(h.sendToAgent).toHaveBeenCalledTimes(1);
+
+      h.setLiveRunning(false);
+      h.setLiveSessionPresent(false);
+      h.setRunning(false);
+      h.coordinator.enqueue(sid, makeItem('q-2', 'second'));
+      await flush();
+
+      await vi.advanceTimersByTimeAsync(5_000);
+      await flush();
+      expect(h.sendToAgent).toHaveBeenCalledTimes(1);
+      expect(latestProjection(h.projections).pendingQueue.map((q) => q.clientId)).toEqual(['q-2']);
+
+      finishFirst?.(sendSuccess());
+      await flush();
+      expect(h.sendToAgent).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('reclaims a dispatched leftover activeTurn only after the Session is gone', async () => {
     vi.useFakeTimers();
     try {
       const h = createHarness();
@@ -6257,18 +6289,14 @@ describe('AgentInputCoordinator steer transaction', () => {
       await flush();
       expect(h.sendToAgent).toHaveBeenCalledTimes(1);
 
-      // Process gone: live probe is idle (false), tracker already released.
       h.setLiveRunning(false);
+      h.setLiveSessionPresent(false);
       h.setRunning(false);
       h.coordinator.enqueue(sid, second);
       await flush();
       expect(h.sendToAgent).toHaveBeenCalledTimes(1);
 
       await vi.advanceTimersByTimeAsync(250);
-      await flush();
-      expect(h.sendToAgent).toHaveBeenCalledTimes(1);
-
-      await vi.advanceTimersByTimeAsync(4_750);
       await flush();
 
       expect(h.reconcileTurnIdle).not.toHaveBeenCalled();

--- a/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
@@ -6279,6 +6279,48 @@ describe('AgentInputCoordinator steer transaction', () => {
     }
   });
 
+  it('ignores a late terminal from a reclaimed leftover turn after the next turn starts', async () => {
+    vi.useFakeTimers();
+    try {
+      const h = createHarness();
+      const sid = 'drain-fence-late-terminal';
+      h.setTurnGeneration(4);
+
+      h.coordinator.enqueue(sid, makeItem('q-1', 'first'));
+      await flush();
+      expect(h.sendToAgent).toHaveBeenCalledTimes(1);
+
+      h.setLiveRunning(false);
+      h.setLiveSessionPresent(true);
+      h.setRunning(true);
+      h.reconcileTurnIdle.mockImplementation(() => {
+        h.setRunning(false);
+        return true;
+      });
+      h.coordinator.enqueue(sid, makeItem('q-2', 'second'));
+      await flush();
+      await vi.advanceTimersByTimeAsync(250);
+      await flush();
+      expect(h.sendToAgent).toHaveBeenCalledTimes(2);
+
+      h.coordinator.onTurnEvent(sid, 'error', 'old turn died late', undefined, {
+        sessionTurnGeneration: 4,
+      });
+      await flush();
+      expect(latestProjection(h.projections).error).toBeNull();
+      expect(h.sendToAgent).toHaveBeenCalledTimes(2);
+
+      h.coordinator.onTurnEvent(sid, 'done', undefined, undefined, {
+        sessionTurnGeneration: 4,
+      });
+      await flush();
+      expect(latestProjection(h.projections).pendingQueue).toEqual([]);
+      expect(h.sendToAgent).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('does not timeout-clear a pre-dispatch activeTurn even after the Session unloads', async () => {
     vi.useFakeTimers();
     try {

--- a/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
@@ -6211,11 +6211,11 @@ describe('AgentInputCoordinator steer transaction', () => {
     expect(latestProjection(h.projections).pendingQueue.map((q) => q.clientId)).toEqual(['q-1']);
   });
 
-  it('does not timeout-clear leftover activeTurn while a live Session is still present', async () => {
+  it('does not reclaim leftover activeTurn in the post-send agent_start gap', async () => {
     vi.useFakeTimers();
     try {
       const h = createHarness();
-      const sid = 'drain-live-present-active-turn';
+      const sid = 'drain-agent-start-gap';
       const first = makeItem('q-1', 'first');
       const second = makeItem('q-2', 'queued-after-idle');
 
@@ -6223,9 +6223,10 @@ describe('AgentInputCoordinator steer transaction', () => {
       await flush();
       expect(h.sendToAgent).toHaveBeenCalledTimes(1);
 
+      // sendReservation already released, handle not streaming yet, tracker idle.
       h.setLiveRunning(false);
       h.setLiveSessionPresent(true);
-      h.setRunning(true);
+      h.setRunning(false);
       h.coordinator.enqueue(sid, second);
       await flush();
       expect(latestProjection(h.projections).pendingQueue.map((q) => q.clientId)).toEqual(['q-2']);
@@ -6236,6 +6237,43 @@ describe('AgentInputCoordinator steer transaction', () => {
       expect(h.reconcileTurnIdle).not.toHaveBeenCalled();
       expect(h.sendToAgent).toHaveBeenCalledTimes(1);
       expect(latestProjection(h.projections).pendingQueue.map((q) => q.clientId)).toEqual(['q-2']);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('reclaims a dispatched leftover activeTurn when the live Session is idle but tracker stays busy', async () => {
+    vi.useFakeTimers();
+    try {
+      const h = createHarness();
+      const sid = 'drain-lost-terminal-live-idle';
+      const first = makeItem('q-1', 'first');
+      const second = makeItem('q-2', 'queued-after-idle');
+
+      h.coordinator.enqueue(sid, first);
+      await flush();
+      expect(h.sendToAgent).toHaveBeenCalledTimes(1);
+
+      h.setLiveRunning(false);
+      h.setLiveSessionPresent(true);
+      h.setRunning(true);
+      h.reconcileTurnIdle.mockImplementation(() => {
+        h.setRunning(false);
+        return true;
+      });
+      h.coordinator.enqueue(sid, second);
+      await flush();
+      expect(h.sendToAgent).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(250);
+      await flush();
+
+      expect(h.reconcileTurnIdle).toHaveBeenCalledWith(sid);
+      expect(h.sendToAgent).toHaveBeenCalledTimes(2);
+      expect(h.sendToAgent.mock.calls[1]?.[1]).toEqual({
+        type: 'user',
+        content: 'queued-after-idle',
+      });
     } finally {
       vi.useRealTimers();
     }

--- a/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
@@ -6117,7 +6117,8 @@ describe('AgentInputCoordinator steer transaction', () => {
       await flush();
       expect(h.sendToAgent).toHaveBeenCalledTimes(1);
 
-      h.setLiveRunning(false);
+      // Session.send reservation keeps live busy before agent_start.
+      h.setLiveRunning(true);
       h.setRunning(true);
       h.coordinator.enqueue(sid, second);
       await flush();
@@ -6193,6 +6194,104 @@ describe('AgentInputCoordinator steer transaction', () => {
     expect(h.reconcileTurnIdle).not.toHaveBeenCalled();
     expect(h.sendToAgent).not.toHaveBeenCalled();
     expect(latestProjection(h.projections).pendingQueue.map((q) => q.clientId)).toEqual(['q-1']);
+  });
+
+  it('clears a leftover activeTurn when the live Session is idle and drains the next head', async () => {
+    vi.useFakeTimers();
+    try {
+      const h = createHarness();
+      const sid = 'drain-zombie-active-turn';
+      const first = makeItem('q-1', 'first');
+      const second = makeItem('q-2', 'queued-after-idle');
+
+      h.coordinator.enqueue(sid, first);
+      await flush();
+      expect(h.sendToAgent).toHaveBeenCalledTimes(1);
+
+      h.setLiveRunning(false);
+      h.setRunning(true);
+      h.reconcileTurnIdle.mockImplementation(() => {
+        h.setRunning(false);
+        h.setLiveRunning(false);
+        return true;
+      });
+      h.coordinator.enqueue(sid, second);
+      await flush();
+      expect(h.sendToAgent).toHaveBeenCalledTimes(1);
+      expect(latestProjection(h.projections).pendingQueue.map((q) => q.clientId)).toEqual(['q-2']);
+
+      await vi.advanceTimersByTimeAsync(250);
+      await flush();
+
+      expect(h.reconcileTurnIdle).toHaveBeenCalledWith(sid);
+      expect(h.sendToAgent).toHaveBeenCalledTimes(2);
+      expect(h.sendToAgent.mock.calls[1]?.[1]).toEqual({
+        type: 'user',
+        content: 'queued-after-idle',
+      });
+      expect(latestProjection(h.projections).pendingQueue).toEqual([]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('drains queued work after an unloaded Session leaves only a leftover activeTurn', async () => {
+    vi.useFakeTimers();
+    try {
+      const h = createHarness();
+      const sid = 'drain-unloaded-active-turn';
+      const first = makeItem('q-1', 'first');
+      const second = makeItem('q-2', 'queued-after-unload');
+
+      h.coordinator.enqueue(sid, first);
+      await flush();
+      expect(h.sendToAgent).toHaveBeenCalledTimes(1);
+
+      // Process gone: live probe is idle (false), tracker already released.
+      h.setLiveRunning(false);
+      h.setRunning(false);
+      h.coordinator.enqueue(sid, second);
+      await flush();
+      expect(h.sendToAgent).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(250);
+      await flush();
+
+      expect(h.reconcileTurnIdle).not.toHaveBeenCalled();
+      expect(h.sendToAgent).toHaveBeenCalledTimes(2);
+      expect(h.sendToAgent.mock.calls[1]?.[1]).toEqual({
+        type: 'user',
+        content: 'queued-after-unload',
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('reconciles a stale tracker after the live Session process is gone', async () => {
+    vi.useFakeTimers();
+    try {
+      const h = createHarness();
+      const sid = 'drain-unloaded-tracker';
+      h.setRunning(true);
+      h.setLiveRunning(false);
+      h.reconcileTurnIdle.mockImplementation(() => {
+        h.setRunning(false);
+        return true;
+      });
+
+      h.coordinator.enqueue(sid, makeItem('q-1', 'queued-after-unload'));
+      await flush();
+      expect(h.sendToAgent).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(250);
+      await flush();
+
+      expect(h.reconcileTurnIdle).toHaveBeenCalledWith(sid);
+      expect(h.sendToAgent).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('recovers from a zombie turn: NO_ACTIVE_TURN reconciles stale busy state and dispatches the fallback', async () => {

--- a/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
@@ -6362,6 +6362,54 @@ describe('AgentInputCoordinator steer transaction', () => {
     }
   });
 
+  it('keeps the leftover terminal fence across clearSession', async () => {
+    vi.useFakeTimers();
+    try {
+      const h = createHarness();
+      const sid = 'drain-fence-survives-clear';
+      h.setTurnGeneration(4);
+
+      h.coordinator.enqueue(sid, makeItem('q-1', 'first'));
+      await flush();
+      expect(h.sendToAgent).toHaveBeenCalledTimes(1);
+
+      h.setLiveRunning(false);
+      h.setLiveSessionPresent(true);
+      h.setRunning(true);
+      h.reconcileTurnIdle.mockImplementation(() => {
+        h.setRunning(false);
+        return true;
+      });
+      h.coordinator.enqueue(sid, makeItem('q-2', 'second'));
+      await flush();
+      await vi.advanceTimersByTimeAsync(250);
+      await flush();
+      expect(h.sendToAgent).toHaveBeenCalledTimes(2);
+
+      h.coordinator.clearSession(sid);
+      expect(
+        h.coordinator.isFencedStaleTerminal(sid, {
+          sessionTurnGeneration: 4,
+          sessionInstanceId: 'harness-session',
+        }),
+      ).toBe(true);
+
+      h.setRunning(false);
+      h.setLiveRunning(false);
+      h.coordinator.enqueue(sid, makeItem('q-3', 'after-clear'));
+      await flush();
+      h.coordinator.onTurnEvent(sid, 'done', undefined, undefined, {
+        sessionTurnGeneration: 4,
+        sessionInstanceId: 'harness-session',
+      });
+      await flush();
+      expect(latestProjection(h.projections).error).toBeNull();
+      expect(h.sendToAgent).toHaveBeenCalledTimes(3);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('does not fence a replacement Session terminal that reuses the same generation number', async () => {
     vi.useFakeTimers();
     try {

--- a/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
@@ -173,7 +173,7 @@ function createHarness(opts?: {
   let liveRunningOverride: boolean | null | 'unknown' = null;
   let liveSessionPresentOverride: boolean | null | 'unknown' = null;
   let turnGeneration = 0;
-  let turnSessionIdentity: object = {};
+  let turnSessionIdentity: object = { instanceId: 'harness-session' };
   let pendingInteraction = false;
   let agentKind: AgentInputCreateOpts['agentKind'] | null = 'claude-code';
   const projections: AgentInputProjection[] = [];
@@ -6303,8 +6303,15 @@ describe('AgentInputCoordinator steer transaction', () => {
       await flush();
       expect(h.sendToAgent).toHaveBeenCalledTimes(2);
 
+      expect(
+        h.coordinator.isFencedStaleTerminal(sid, {
+          sessionTurnGeneration: 0,
+          sessionInstanceId: 'harness-session',
+        }),
+      ).toBe(true);
       h.coordinator.onTurnEvent(sid, 'error', 'old turn died late', undefined, {
-        sessionTurnGeneration: 4,
+        sessionTurnGeneration: 0,
+        sessionInstanceId: 'harness-session',
       });
       await flush();
       expect(latestProjection(h.projections).error).toBeNull();
@@ -6312,10 +6319,52 @@ describe('AgentInputCoordinator steer transaction', () => {
 
       h.coordinator.onTurnEvent(sid, 'done', undefined, undefined, {
         sessionTurnGeneration: 4,
+        sessionInstanceId: 'harness-session',
       });
       await flush();
       expect(latestProjection(h.projections).pendingQueue).toEqual([]);
       expect(h.sendToAgent).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not fence a replacement Session terminal that reuses the same generation number', async () => {
+    vi.useFakeTimers();
+    try {
+      const h = createHarness();
+      const sid = 'drain-fence-session-identity';
+      h.setTurnGeneration(1);
+
+      h.coordinator.enqueue(sid, makeItem('q-1', 'first'));
+      await flush();
+      h.setLiveRunning(false);
+      h.setLiveSessionPresent(true);
+      h.setRunning(true);
+      h.reconcileTurnIdle.mockImplementation(() => {
+        h.setRunning(false);
+        return true;
+      });
+      h.coordinator.enqueue(sid, makeItem('q-2', 'second'));
+      await flush();
+      await vi.advanceTimersByTimeAsync(250);
+      await flush();
+      expect(h.sendToAgent).toHaveBeenCalledTimes(2);
+
+      h.setTurnSessionIdentity({ instanceId: 'replacement-session' });
+      h.coordinator.onTurnEvent(sid, 'done', undefined, undefined, {
+        sessionTurnGeneration: 1,
+        sessionInstanceId: 'replacement-session',
+      });
+      h.setRunning(false);
+      await flush();
+      h.coordinator.enqueue(sid, makeItem('q-3', 'third'));
+      await flush();
+      expect(h.sendToAgent).toHaveBeenCalledTimes(3);
+      expect(h.sendToAgent.mock.calls[2]?.[1]).toEqual({
+        type: 'user',
+        content: 'third',
+      });
     } finally {
       vi.useRealTimers();
     }

--- a/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
@@ -6330,6 +6330,7 @@ describe('AgentInputCoordinator steer transaction', () => {
       h.setLiveRunning(false);
       h.setLiveSessionPresent(false);
       h.setRunning(false);
+      h.reconcileTurnIdle.mockReturnValue(true);
       h.coordinator.enqueue(sid, second);
       await flush();
       expect(h.sendToAgent).toHaveBeenCalledTimes(1);
@@ -6337,7 +6338,7 @@ describe('AgentInputCoordinator steer transaction', () => {
       await vi.advanceTimersByTimeAsync(250);
       await flush();
 
-      expect(h.reconcileTurnIdle).not.toHaveBeenCalled();
+      expect(h.reconcileTurnIdle).toHaveBeenCalledWith(sid);
       expect(h.sendToAgent).toHaveBeenCalledTimes(2);
       expect(h.sendToAgent.mock.calls[1]?.[1]).toEqual({
         type: 'user',

--- a/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
@@ -6279,6 +6279,33 @@ describe('AgentInputCoordinator steer transaction', () => {
     }
   });
 
+  it('does not reclaim leftover activeTurn when idle reconcile fails', async () => {
+    vi.useFakeTimers();
+    try {
+      const h = createHarness();
+      const sid = 'drain-reconcile-fail-keeps-boundary';
+
+      h.coordinator.enqueue(sid, makeItem('q-1', 'first'));
+      await flush();
+      expect(h.sendToAgent).toHaveBeenCalledTimes(1);
+
+      h.setLiveRunning(false);
+      h.setLiveSessionPresent(true);
+      h.setRunning(true);
+      h.reconcileTurnIdle.mockImplementation(() => false);
+      h.coordinator.enqueue(sid, makeItem('q-2', 'queued-after-idle'));
+      await flush();
+      await vi.advanceTimersByTimeAsync(250);
+      await flush();
+
+      expect(h.reconcileTurnIdle).toHaveBeenCalledWith(sid);
+      expect(h.sendToAgent).toHaveBeenCalledTimes(1);
+      expect(latestProjection(h.projections).pendingQueue.map((q) => q.clientId)).toEqual(['q-2']);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('ignores a late terminal from a reclaimed leftover turn after the next turn starts', async () => {
     vi.useFakeTimers();
     try {

--- a/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
@@ -6124,6 +6124,11 @@ describe('AgentInputCoordinator steer transaction', () => {
       await flush();
       await vi.advanceTimersByTimeAsync(250);
       await flush();
+      expect(h.reconcileTurnIdle).not.toHaveBeenCalled();
+      expect(h.sendToAgent).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(5_000);
+      await flush();
 
       expect(h.reconcileTurnIdle).not.toHaveBeenCalled();
       expect(h.sendToAgent).toHaveBeenCalledTimes(1);
@@ -6222,6 +6227,11 @@ describe('AgentInputCoordinator steer transaction', () => {
 
       await vi.advanceTimersByTimeAsync(250);
       await flush();
+      expect(h.reconcileTurnIdle).not.toHaveBeenCalled();
+      expect(h.sendToAgent).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(4_750);
+      await flush();
 
       expect(h.reconcileTurnIdle).toHaveBeenCalledWith(sid);
       expect(h.sendToAgent).toHaveBeenCalledTimes(2);
@@ -6255,6 +6265,10 @@ describe('AgentInputCoordinator steer transaction', () => {
       expect(h.sendToAgent).toHaveBeenCalledTimes(1);
 
       await vi.advanceTimersByTimeAsync(250);
+      await flush();
+      expect(h.sendToAgent).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(4_750);
       await flush();
 
       expect(h.reconcileTurnIdle).not.toHaveBeenCalled();

--- a/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
@@ -6309,6 +6309,12 @@ describe('AgentInputCoordinator steer transaction', () => {
           sessionInstanceId: 'harness-session',
         }),
       ).toBe(true);
+      expect(
+        h.coordinator.isFencedStaleTerminal(sid, {
+          sessionTurnGeneration: 5,
+          sessionInstanceId: 'harness-session',
+        }),
+      ).toBe(false);
       h.coordinator.onTurnEvent(sid, 'error', 'old turn died late', undefined, {
         sessionTurnGeneration: 0,
         sessionInstanceId: 'harness-session',

--- a/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
+++ b/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
@@ -643,6 +643,8 @@ interface SessionInputState {
    * flips idle; reconcile only after SESSION_RUNNING_RETRY_DELAY_MS.
    */
   staleLiveIdleSinceMs: number | null;
+  /** Vendor Session.turnGeneration fenced when a leftover dispatched turn was reclaimed. */
+  fencedSessionTurnGeneration: number | null;
   /**
    * 发送撞上 CREDENTIAL_SWITCH_BUSY 后的可见等待态:队首保留,挡路会话 turn 结束
    * (onExternalTurnSettled)或兜底定时器触发自动重发。clientId 绑定等待中的那条
@@ -707,6 +709,7 @@ function createInitialInputState(
     sessionRunningRetryDelayMs: null,
     sessionRunningRetryToken: null,
     staleLiveIdleSinceMs: null,
+    fencedSessionTurnGeneration: null,
     credentialSwitchWait: null,
     credentialSwitchRetryTimer: null,
     credentialSwitchRetryGeneration: null,
@@ -2958,8 +2961,21 @@ export class AgentInputCoordinator {
     type: 'done' | 'error',
     message?: string,
     signals?: Omit<InterruptedTurnErrorSignals, 'message'>,
+    meta?: { sessionTurnGeneration?: number },
   ): void {
     const state = this.getState(sessionId);
+    const eventGeneration = meta?.sessionTurnGeneration;
+    if (
+      typeof eventGeneration === 'number' &&
+      state.fencedSessionTurnGeneration === eventGeneration
+    ) {
+      log.debug('ignored stale terminal after leftover turn reclaim', {
+        sessionId,
+        type,
+        eventGeneration,
+      });
+      return;
+    }
     const active = state.activeTurn;
     state.staleLiveIdleSinceMs = null;
     this.clearAbortReconcileRetry(state);
@@ -3488,10 +3504,15 @@ export class AgentInputCoordinator {
       if (!reconciled && !reclaimLeftover) return false;
     }
     if (reclaimLeftover) {
+      const vendorGeneration = this.deps.getTurnGeneration?.(sessionId);
+      if (typeof vendorGeneration === 'number') {
+        state.fencedSessionTurnGeneration = vendorGeneration;
+      }
       log.warn('reconciling leftover dispatched activeTurn after vendor idle', {
         sessionId,
         clientId: state.activeTurn?.item?.clientId ?? null,
         dispatchLifecycle: state.activeTurn?.dispatchLifecycle ?? null,
+        fencedSessionTurnGeneration: state.fencedSessionTurnGeneration,
       });
       state.activeTurn = null;
     }

--- a/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
+++ b/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
@@ -643,8 +643,8 @@ interface SessionInputState {
    * flips idle; reconcile only after SESSION_RUNNING_RETRY_DELAY_MS.
    */
   staleLiveIdleSinceMs: number | null;
-  /** Vendor Session.turnGeneration fenced when a leftover dispatched turn was reclaimed. */
-  fencedSessionTurnGeneration: number | null;
+  /** Leftover terminal fence: Session incarnation + the generation that was reclaimed. */
+  fencedStaleTerminal: { instanceId: string; generation: number } | null;
   /**
    * 发送撞上 CREDENTIAL_SWITCH_BUSY 后的可见等待态:队首保留,挡路会话 turn 结束
    * (onExternalTurnSettled)或兜底定时器触发自动重发。clientId 绑定等待中的那条
@@ -709,7 +709,7 @@ function createInitialInputState(
     sessionRunningRetryDelayMs: null,
     sessionRunningRetryToken: null,
     staleLiveIdleSinceMs: null,
-    fencedSessionTurnGeneration: null,
+    fencedStaleTerminal: null,
     credentialSwitchWait: null,
     credentialSwitchRetryTimer: null,
     credentialSwitchRetryGeneration: null,
@@ -717,6 +717,25 @@ function createInitialInputState(
     generation,
     clearBoundaryMs,
   };
+}
+
+function readSessionInstanceId(identity: object | null | undefined): string | null {
+  if (!identity || typeof identity !== 'object') return null;
+  const id = (identity as { instanceId?: unknown }).instanceId;
+  return typeof id === 'string' && id.length > 0 ? id : null;
+}
+
+export function isMatchingFencedStaleTerminal(
+  fence: { instanceId: string; generation: number } | null | undefined,
+  meta?: { sessionTurnGeneration?: number; sessionInstanceId?: string },
+): boolean {
+  if (!fence) return false;
+  return (
+    typeof meta?.sessionTurnGeneration === 'number' &&
+    typeof meta.sessionInstanceId === 'string' &&
+    meta.sessionInstanceId === fence.instanceId &&
+    meta.sessionTurnGeneration <= fence.generation
+  );
 }
 /**
  * 首次进入 main 队列边界时冻结原始合成指令意图。IPC payload 属不可信输入，
@@ -2956,23 +2975,27 @@ export class AgentInputCoordinator {
    * coordinator 里做那个判断——它是「这条错误是什么」的领域知识，属于 host 侧的
    * interruptedTurnAutoResume；coordinator 只负责回答「有没有可续跑的目标」。
    */
+  isFencedStaleTerminal(
+    sessionId: string,
+    meta?: { sessionTurnGeneration?: number; sessionInstanceId?: string },
+  ): boolean {
+    return isMatchingFencedStaleTerminal(this.getState(sessionId).fencedStaleTerminal, meta);
+  }
+
   onTurnEvent(
     sessionId: string,
     type: 'done' | 'error',
     message?: string,
     signals?: Omit<InterruptedTurnErrorSignals, 'message'>,
-    meta?: { sessionTurnGeneration?: number },
+    meta?: { sessionTurnGeneration?: number; sessionInstanceId?: string },
   ): void {
     const state = this.getState(sessionId);
-    const eventGeneration = meta?.sessionTurnGeneration;
-    if (
-      typeof eventGeneration === 'number' &&
-      state.fencedSessionTurnGeneration === eventGeneration
-    ) {
+    if (this.isFencedStaleTerminal(sessionId, meta)) {
       log.debug('ignored stale terminal after leftover turn reclaim', {
         sessionId,
         type,
-        eventGeneration,
+        eventGeneration: meta?.sessionTurnGeneration ?? null,
+        sessionInstanceId: meta?.sessionInstanceId ?? null,
       });
       return;
     }
@@ -3505,14 +3528,15 @@ export class AgentInputCoordinator {
     }
     if (reclaimLeftover) {
       const vendorGeneration = this.deps.getTurnGeneration?.(sessionId);
-      if (typeof vendorGeneration === 'number') {
-        state.fencedSessionTurnGeneration = vendorGeneration;
+      const instanceId = readSessionInstanceId(this.deps.getTurnSessionIdentity?.(sessionId));
+      if (typeof vendorGeneration === 'number' && instanceId) {
+        state.fencedStaleTerminal = { instanceId, generation: vendorGeneration };
       }
       log.warn('reconciling leftover dispatched activeTurn after vendor idle', {
         sessionId,
         clientId: state.activeTurn?.item?.clientId ?? null,
         dispatchLifecycle: state.activeTurn?.dispatchLifecycle ?? null,
-        fencedSessionTurnGeneration: state.fencedSessionTurnGeneration,
+        fencedStaleTerminal: state.fencedStaleTerminal,
       });
       state.activeTurn = null;
     }

--- a/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
+++ b/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
@@ -3483,7 +3483,7 @@ export class AgentInputCoordinator {
       return false;
     }
 
-    if (trackerBusy) {
+    if (trackerBusy || reclaimLeftover) {
       const reconciled = this.deps.reconcileTurnIdle?.(sessionId) === true;
       if (!reconciled && !reclaimLeftover) return false;
     }

--- a/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
+++ b/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
@@ -3426,15 +3426,20 @@ export class AgentInputCoordinator {
    * Do not call this while a send is in flight, a permission card is up, or
    * abort/steer already owns the boundary.
    *
-   * Leftover `activeTurn` is only reclaimed when the turn is already dispatched
-   * and the live Session is gone. A present Session that looks idle may still
-   * be in pre-dispatch awaits or waiting for Pi `agent_start`; a timeout must
-   * not drop that owner. Probe unavailable stays fail-closed.
+   * Leftover `activeTurn` is reclaimed only when it is already dispatched and
+   * we can prove the vendor turn is gone: the Session object is missing, or the
+   * live Session is idle while the desktop tracker is still latched. A present
+   * Session with an idle tracker may still be in the Pi gap after handle.send
+   * (reservation released, agent_start not yet observed). Pre-dispatch owners
+   * and unavailable probes stay fail-closed.
    */
   private canReclaimLeftoverActiveTurn(sessionId: string, state: SessionInputState): boolean {
     const active = state.activeTurn;
     if (!active || !isActiveTurnDispatched(active)) return false;
-    return this.deps.isLiveSessionPresent?.(sessionId) === false;
+    const present = this.deps.isLiveSessionPresent?.(sessionId);
+    if (present === false) return true;
+    if (present !== true) return false;
+    return this.deps.isTurnRunning(sessionId) === true;
   }
 
   private tryReconcileStaleDispatchBoundary(
@@ -3483,7 +3488,7 @@ export class AgentInputCoordinator {
       if (!reconciled && !reclaimLeftover) return false;
     }
     if (reclaimLeftover) {
-      log.warn('reconciling leftover dispatched activeTurn after session unload', {
+      log.warn('reconciling leftover dispatched activeTurn after vendor idle', {
         sessionId,
         clientId: state.activeTurn?.item?.clientId ?? null,
         dispatchLifecycle: state.activeTurn?.dispatchLifecycle ?? null,

--- a/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
+++ b/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
@@ -73,6 +73,14 @@ import {
 const log = createLogger('maker-input-coordinator');
 const SESSION_RUNNING_RETRY_DELAY_MS = 250;
 /**
+ * Leftover `activeTurn` plus live-idle is either a lost terminal or the Pi
+ * window after `handle.send` resolves (reservation released) but before
+ * `agent_start` flips `isStreaming`. 250ms is enough for a queued status/done;
+ * it is not enough for that independent start event. Keep the corpse only for
+ * this longer grace, then treat it as a zombie so queued input can drain.
+ */
+const LEFTOVER_ACTIVE_TURN_IDLE_GRACE_MS = 5_000;
+/**
  * Codex 的 reconnect-stalled 清理要等两次 turn/interrupt ACK，每次最多 10s。
  * 自动续跑仍只允许 3 次 SESSION_RUNNING 派发尝试，但退避必须覆盖这段有界
  * cleanup 窗口；终态事件先到时 scheduleDrain 仍会立即放行，不会强制等满该间隔。
@@ -3420,10 +3428,10 @@ export class AgentInputCoordinator {
    * Do not call this while a send is in flight, a permission card is up, or
    * abort/steer already owns the boundary.
    *
-   * Live `isTurnRunning()` already covers Session.send reservations, so a
-   * leftover `activeTurn` plus live-idle after the 250ms grace is a zombie
-   * (done never reached the coordinator, or the process already unloaded).
-   * Missing live probe (`undefined`) stays fail-closed.
+   * Tracker-only stale busy uses the 250ms grace (status/done still in Session).
+   * Leftover `activeTurn` waits longer: Pi may have released sendReservation
+   * after prompt RPC while `agent_start` is still in flight. Probe unavailable
+   * (`undefined`, including owner-boundary lookup failure) stays fail-closed.
    */
   private tryReconcileStaleDispatchBoundary(
     sessionId: string,
@@ -3453,12 +3461,13 @@ export class AgentInputCoordinator {
       return false;
     }
 
-    // Handle may already be idle while status/done is still queued in Session.
-    // Extra drains in this window must not confirm; wait the existing 250ms retry.
+    const graceMs = leftoverActiveTurn
+      ? LEFTOVER_ACTIVE_TURN_IDLE_GRACE_MS
+      : SESSION_RUNNING_RETRY_DELAY_MS;
     if (state.staleLiveIdleSinceMs == null) {
       state.staleLiveIdleSinceMs = Date.now();
     }
-    if (Date.now() - state.staleLiveIdleSinceMs < SESSION_RUNNING_RETRY_DELAY_MS) {
+    if (Date.now() - state.staleLiveIdleSinceMs < graceMs) {
       return false;
     }
 
@@ -4161,6 +4170,12 @@ export class AgentInputCoordinator {
       return { ownerKey: 'compact', delayMs: SESSION_RUNNING_RETRY_DELAY_MS };
     }
     const head = state.pendingQueue[0];
+    if (state.activeTurn !== null) {
+      return {
+        ownerKey: head ? `queue:${head.clientId}` : 'leftover-active-turn',
+        delayMs: LEFTOVER_ACTIVE_TURN_IDLE_GRACE_MS,
+      };
+    }
     return {
       ownerKey: head ? `queue:${head.clientId}` : null,
       delayMs: head?.autoResume

--- a/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
+++ b/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
@@ -677,6 +677,7 @@ interface PendingAutoResumeRecovery {
 function createInitialInputState(
   generation = 0,
   clearBoundaryMs: number | null = null,
+  fencedStaleTerminal: { instanceId: string; generation: number } | null = null,
 ): SessionInputState {
   return {
     pendingQueue: [],
@@ -709,7 +710,7 @@ function createInitialInputState(
     sessionRunningRetryDelayMs: null,
     sessionRunningRetryToken: null,
     staleLiveIdleSinceMs: null,
-    fencedStaleTerminal: null,
+    fencedStaleTerminal,
     credentialSwitchWait: null,
     credentialSwitchRetryTimer: null,
     credentialSwitchRetryGeneration: null,
@@ -2964,7 +2965,10 @@ export class AgentInputCoordinator {
     // 显式清上下文:强制开启持久化闸门,让 emit 写出空快照(删行),
     // 即使此前该会话从未触发恢复(否则旧快照残留,下次打开会诈尸)。
     this.restoredQueueSessions.add(sessionId);
-    this.states.set(sessionId, createInitialInputState(prev.generation + 1, clearBoundaryMs));
+    this.states.set(
+      sessionId,
+      createInitialInputState(prev.generation + 1, clearBoundaryMs, prev.fencedStaleTerminal),
+    );
     this.emit(sessionId);
     return this.getProjection(sessionId);
   }

--- a/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
+++ b/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
@@ -3524,7 +3524,7 @@ export class AgentInputCoordinator {
 
     if (trackerBusy || reclaimLeftover) {
       const reconciled = this.deps.reconcileTurnIdle?.(sessionId) === true;
-      if (!reconciled && !reclaimLeftover) return false;
+      if (!reconciled) return false;
     }
     if (reclaimLeftover) {
       const vendorGeneration = this.deps.getTurnGeneration?.(sessionId);

--- a/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
+++ b/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
@@ -73,14 +73,6 @@ import {
 const log = createLogger('maker-input-coordinator');
 const SESSION_RUNNING_RETRY_DELAY_MS = 250;
 /**
- * Leftover `activeTurn` plus live-idle is either a lost terminal or the Pi
- * window after `handle.send` resolves (reservation released) but before
- * `agent_start` flips `isStreaming`. 250ms is enough for a queued status/done;
- * it is not enough for that independent start event. Keep the corpse only for
- * this longer grace, then treat it as a zombie so queued input can drain.
- */
-const LEFTOVER_ACTIVE_TURN_IDLE_GRACE_MS = 5_000;
-/**
  * Codex 的 reconnect-stalled 清理要等两次 turn/interrupt ACK，每次最多 10s。
  * 自动续跑仍只允许 3 次 SESSION_RUNNING 派发尝试，但退避必须覆盖这段有界
  * cleanup 窗口；终态事件先到时 scheduleDrain 仍会立即放行，不会强制等满该间隔。
@@ -278,6 +270,12 @@ export interface AgentInputCoordinatorDeps {
   isTurnRunning: (sessionId: string) => boolean;
   /** Live Session only — must not OR the desktop tracker. undefined = probe unavailable. */
   isLiveTurnRunning?: (sessionId: string) => boolean | undefined;
+  /**
+   * Whether a live Session object exists. Distinct from isLiveTurnRunning:
+   * found+idle is present=true/running=false; process gone is present=false;
+   * owner-boundary lookup failure is undefined and must stay fail-closed.
+   */
+  isLiveSessionPresent?: (sessionId: string) => boolean | undefined;
   /** maker-core turn 代号；steer 跨 await 后据此验证仍属于开始时的同一 vendor turn。 */
   getTurnGeneration?: (sessionId: string) => number | null;
   /** maker-core Session object identity; control-plane steer uses it to reject session reuse. */
@@ -3423,16 +3421,22 @@ export class AgentInputCoordinator {
   }
 
   /**
-   * Live Session idle + host tracker / leftover activeTurn still busy is an
-   * invariant break. Reconcile so queued input can drain without Stop / steer.
+   * Live Session idle + host tracker still busy is an invariant break.
+   * Reconcile so queued input can drain without Stop / steer.
    * Do not call this while a send is in flight, a permission card is up, or
    * abort/steer already owns the boundary.
    *
-   * Tracker-only stale busy uses the 250ms grace (status/done still in Session).
-   * Leftover `activeTurn` waits longer: Pi may have released sendReservation
-   * after prompt RPC while `agent_start` is still in flight. Probe unavailable
-   * (`undefined`, including owner-boundary lookup failure) stays fail-closed.
+   * Leftover `activeTurn` is only reclaimed when the turn is already dispatched
+   * and the live Session is gone. A present Session that looks idle may still
+   * be in pre-dispatch awaits or waiting for Pi `agent_start`; a timeout must
+   * not drop that owner. Probe unavailable stays fail-closed.
    */
+  private canReclaimLeftoverActiveTurn(sessionId: string, state: SessionInputState): boolean {
+    const active = state.activeTurn;
+    if (!active || !isActiveTurnDispatched(active)) return false;
+    return this.deps.isLiveSessionPresent?.(sessionId) === false;
+  }
+
   private tryReconcileStaleDispatchBoundary(
     sessionId: string,
     state: SessionInputState,
@@ -3456,27 +3460,30 @@ export class AgentInputCoordinator {
 
     const leftoverActiveTurn = state.activeTurn !== null;
     const trackerBusy = this.deps.isTurnRunning(sessionId);
-    if (!trackerBusy && !leftoverActiveTurn) {
+    const reclaimLeftover = leftoverActiveTurn && this.canReclaimLeftoverActiveTurn(sessionId, state);
+    if (leftoverActiveTurn && !reclaimLeftover) {
+      state.staleLiveIdleSinceMs = null;
+      return false;
+    }
+    if (!trackerBusy && !reclaimLeftover) {
       state.staleLiveIdleSinceMs = null;
       return false;
     }
 
-    const graceMs = leftoverActiveTurn
-      ? LEFTOVER_ACTIVE_TURN_IDLE_GRACE_MS
-      : SESSION_RUNNING_RETRY_DELAY_MS;
+    // Handle may already be idle while status/done is still queued in Session.
     if (state.staleLiveIdleSinceMs == null) {
       state.staleLiveIdleSinceMs = Date.now();
     }
-    if (Date.now() - state.staleLiveIdleSinceMs < graceMs) {
+    if (Date.now() - state.staleLiveIdleSinceMs < SESSION_RUNNING_RETRY_DELAY_MS) {
       return false;
     }
 
     if (trackerBusy) {
       const reconciled = this.deps.reconcileTurnIdle?.(sessionId) === true;
-      if (!reconciled && !leftoverActiveTurn) return false;
+      if (!reconciled && !reclaimLeftover) return false;
     }
-    if (leftoverActiveTurn) {
-      log.warn('reconciling leftover activeTurn while live session idle', {
+    if (reclaimLeftover) {
+      log.warn('reconciling leftover dispatched activeTurn after session unload', {
         sessionId,
         clientId: state.activeTurn?.item?.clientId ?? null,
         dispatchLifecycle: state.activeTurn?.dispatchLifecycle ?? null,
@@ -4170,12 +4177,6 @@ export class AgentInputCoordinator {
       return { ownerKey: 'compact', delayMs: SESSION_RUNNING_RETRY_DELAY_MS };
     }
     const head = state.pendingQueue[0];
-    if (state.activeTurn !== null) {
-      return {
-        ownerKey: head ? `queue:${head.clientId}` : 'leftover-active-turn',
-        delayMs: LEFTOVER_ACTIVE_TURN_IDLE_GRACE_MS,
-      };
-    }
     return {
       ownerKey: head ? `queue:${head.clientId}` : null,
       delayMs: head?.autoResume

--- a/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
+++ b/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
@@ -3415,12 +3415,15 @@ export class AgentInputCoordinator {
   }
 
   /**
-   * Live Session idle + host tracker still busy is an invariant break.
-   * Reconcile the tracker so queued input can drain without a user Stop / steer.
-   * Do not call this while a send is in flight, an activeTurn still owns the
-   * generation, a permission card is up, or abort/steer already owns the boundary.
-   * Dispatched-but-not-started turns (Pi may accept a prompt before agent_start)
-   * must wait for real lifecycle events — do not synthesize done.
+   * Live Session idle + host tracker / leftover activeTurn still busy is an
+   * invariant break. Reconcile so queued input can drain without Stop / steer.
+   * Do not call this while a send is in flight, a permission card is up, or
+   * abort/steer already owns the boundary.
+   *
+   * Live `isTurnRunning()` already covers Session.send reservations, so a
+   * leftover `activeTurn` plus live-idle after the 250ms grace is a zombie
+   * (done never reached the coordinator, or the process already unloaded).
+   * Missing live probe (`undefined`) stays fail-closed.
    */
   private tryReconcileStaleDispatchBoundary(
     sessionId: string,
@@ -3432,8 +3435,7 @@ export class AgentInputCoordinator {
       state.queueInteractionLocks.length > 0 ||
       state.steeringQueueClientIds.length > 0 ||
       state.pendingExternalTerminalDone ||
-      this.deps.hasPendingInteraction(sessionId) ||
-      state.activeTurn !== null
+      this.deps.hasPendingInteraction(sessionId)
     ) {
       state.staleLiveIdleSinceMs = null;
       return false;
@@ -3444,7 +3446,9 @@ export class AgentInputCoordinator {
       return false;
     }
 
-    if (!this.deps.isTurnRunning(sessionId)) {
+    const leftoverActiveTurn = state.activeTurn !== null;
+    const trackerBusy = this.deps.isTurnRunning(sessionId);
+    if (!trackerBusy && !leftoverActiveTurn) {
       state.staleLiveIdleSinceMs = null;
       return false;
     }
@@ -3458,8 +3462,18 @@ export class AgentInputCoordinator {
       return false;
     }
 
-    const reconciled = this.deps.reconcileTurnIdle?.(sessionId) === true;
-    if (!reconciled) return false;
+    if (trackerBusy) {
+      const reconciled = this.deps.reconcileTurnIdle?.(sessionId) === true;
+      if (!reconciled && !leftoverActiveTurn) return false;
+    }
+    if (leftoverActiveTurn) {
+      log.warn('reconciling leftover activeTurn while live session idle', {
+        sessionId,
+        clientId: state.activeTurn?.item?.clientId ?? null,
+        dispatchLifecycle: state.activeTurn?.dispatchLifecycle ?? null,
+      });
+      state.activeTurn = null;
+    }
     state.staleLiveIdleSinceMs = null;
     return true;
   }

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -3977,7 +3977,9 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
           // 兜底: 有些 vendor 的 done 不必先发 status:isRunning=false。
           // 但 idle 恢复不能挡在 EVENT broadcast 前，否则隐藏窗口可能在 done
           // 还没进入 renderer 时就重新被 Chromium 节流。
-          agentInputCoordinatorHolder?.onTurnEvent(session.id, 'done');
+          agentInputCoordinatorHolder?.onTurnEvent(session.id, 'done', undefined, undefined, {
+            sessionTurnGeneration: event.sessionTurnGeneration,
+          });
         } else {
           // silent-stop 自动续跑:translator 判定本 turn 被上游空内容消息静默收尾时在
           // done.data 附加 silentStop 标记(见 maker-core translator)。延迟一拍再决策,
@@ -4060,6 +4062,7 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
                 ? { errorStatus: errData.errorStatus }
                 : {}),
             },
+            { sessionTurnGeneration: event.sessionTurnGeneration },
           );
         }
       }

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -3673,6 +3673,22 @@ function isFencedStaleProductTerminal(event: AgentEvent): boolean {
   return data?.isRunning === false;
 }
 
+function isFencedStaleSessionTerminal(
+  sessionId: string,
+  event: AgentEvent,
+): boolean {
+  if (isTurnContinuationBoundaryEvent(event) || event.turnScope === 'background') {
+    return false;
+  }
+  return (
+    isFencedStaleProductTerminal(event) &&
+    agentInputCoordinatorHolder?.isFencedStaleTerminal(sessionId, {
+      sessionTurnGeneration: event.sessionTurnGeneration,
+      sessionInstanceId: event.sessionInstanceId,
+    }) === true
+  );
+}
+
 export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void {
   if (!session) return;
   const existing = wiredSessionsById.get(session.id);
@@ -3754,6 +3770,7 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
   });
   registration.disposers.push(
     session.onEvent((event: AgentEvent) => {
+      if (isFencedStaleSessionTerminal(session.id, event)) return;
       noteTurnDiffEvent(session.id, event, session.remoteHostId !== null);
       ghostSessionTap.handleEvent(
         event as { type: string; data?: unknown; source?: string; turnOrigin?: { kind?: string } },
@@ -3856,15 +3873,7 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
       let shouldMarkTurnTerminalIdleAfterBroadcast = false;
       let completedTurnWallClockMs: number | undefined;
       const isContinuationBoundary = isTurnContinuationBoundaryEvent(event);
-      if (
-        !isContinuationBoundary &&
-        event.turnScope !== 'background' &&
-        isFencedStaleProductTerminal(event) &&
-        agentInputCoordinatorHolder?.isFencedStaleTerminal(session.id, {
-          sessionTurnGeneration: event.sessionTurnGeneration,
-          sessionInstanceId: event.sessionInstanceId,
-        })
-      ) {
+      if (!isContinuationBoundary && isFencedStaleSessionTerminal(session.id, event)) {
         log.debug('ignored stale terminal after leftover turn reclaim', {
           sessionId: session.id,
           eventType: event.type,

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -3665,6 +3665,14 @@ async function handleSilentStopTurnEnd(
   }
 }
 
+function isFencedStaleProductTerminal(event: AgentEvent): boolean {
+  if (event.type === 'done') return true;
+  if (isTerminalTurnErrorEvent(event)) return true;
+  if (event.type !== 'status') return false;
+  const data = event.data as { isRunning?: unknown } | null | undefined;
+  return data?.isRunning === false;
+}
+
 export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void {
   if (!session) return;
   const existing = wiredSessionsById.get(session.id);
@@ -3848,6 +3856,23 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
       let shouldMarkTurnTerminalIdleAfterBroadcast = false;
       let completedTurnWallClockMs: number | undefined;
       const isContinuationBoundary = isTurnContinuationBoundaryEvent(event);
+      if (
+        !isContinuationBoundary &&
+        event.turnScope !== 'background' &&
+        isFencedStaleProductTerminal(event) &&
+        agentInputCoordinatorHolder?.isFencedStaleTerminal(session.id, {
+          sessionTurnGeneration: event.sessionTurnGeneration,
+          sessionInstanceId: event.sessionInstanceId,
+        })
+      ) {
+        log.debug('ignored stale terminal after leftover turn reclaim', {
+          sessionId: session.id,
+          eventType: event.type,
+          sessionTurnGeneration: event.sessionTurnGeneration ?? null,
+          sessionInstanceId: event.sessionInstanceId ?? null,
+        });
+        return;
+      }
       // 探针:continuation 边界命中会跳过 status idle / ended 写 / tracker idle,
       // 若 claim 悬挂会导致 UI 永久「正在生成」。区分「claim 悬挂」与「done 未到达」。
       if (isContinuationBoundary && (event.type === 'done' || event.type === 'status')) {
@@ -3979,6 +4004,7 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
           // 还没进入 renderer 时就重新被 Chromium 节流。
           agentInputCoordinatorHolder?.onTurnEvent(session.id, 'done', undefined, undefined, {
             sessionTurnGeneration: event.sessionTurnGeneration,
+            sessionInstanceId: event.sessionInstanceId,
           });
         } else {
           // silent-stop 自动续跑:translator 判定本 turn 被上游空内容消息静默收尾时在
@@ -4062,7 +4088,10 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
                 ? { errorStatus: errData.errorStatus }
                 : {}),
             },
-            { sessionTurnGeneration: event.sessionTurnGeneration },
+            {
+              sessionTurnGeneration: event.sessionTurnGeneration,
+              sessionInstanceId: event.sessionInstanceId,
+            },
           );
         }
       }
@@ -15204,6 +15233,8 @@ function redactEventForRenderer(event: AgentEvent): AgentEvent {
   const rendererEvent = { ...event };
   delete rendererEvent.turnAttemptToken;
   delete rendererEvent.backgroundTurnStartedAt;
+  delete rendererEvent.sessionTurnGeneration;
+  delete rendererEvent.sessionInstanceId;
   if (!event.data || typeof event.data !== 'object') return rendererEvent;
 
   const data = event.data as Record<string, unknown>;

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -11434,6 +11434,23 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
     return true;
   };
 
+  const sealLostTerminalPersistState = (sessionId: string): void => {
+    // Same persist boundary as a lost-terminal live-idle reconcile. The next
+    // turn on this sessionId must not append to a half-open streaming block.
+    flushAssistantBlock(sessionId, null);
+    const abortedAssistantPersistId = consumeLastAssistantPersistId(sessionId);
+    const abortedBoundaryAssistantPersistId = consumeLastTopLevelAssistantPersistId(sessionId);
+    flushOrphanToolResults(sessionId, null);
+    if (abortedAssistantPersistId) {
+      pendingFailedTurnAssistantPersistId.set(sessionId, abortedAssistantPersistId);
+    }
+    if (abortedBoundaryAssistantPersistId) {
+      void markAssistantTurnFailed(sessionId, abortedBoundaryAssistantPersistId);
+    }
+    clearCodexPlanRowsForSession(sessionId);
+    resetTurnPersistState(sessionId);
+  };
+
   const reconcileSessionTurnIdle = (sessionId: string, source: string): boolean => {
     const lookup = lookupStableSessionForTurnBoundary(sessionId);
     if (lookup.status === 'unavailable') return false;
@@ -11441,12 +11458,30 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
       const trackerStale =
         sessionTurnActivityTracker.isSessionInTurn(sessionId) ||
         sessionTurnActivityTracker.isSessionTurnDispatchBoundaryBusy(sessionId);
-      if (!trackerStale) return false;
-      log.warn('reconciling stale session turn boundary after session unload', {
-        sessionId,
-        source,
-      });
+      sealLostTerminalPersistState(sessionId);
+      if (trackerStale) {
+        log.warn('reconciling stale session turn boundary after session unload', {
+          sessionId,
+          source,
+        });
+      }
       sessionTurnActivityTracker.deleteSession(sessionId);
+      void sessionTurnLeaseTracker.markTurnEnded(sessionId);
+      notifyGoalIdleAfterTurnSettled(sessionId);
+      try {
+        markTurnEndedAfterPersistDrain(sessionId);
+        noteClaudeSessionTurnState(sessionId, false);
+        settlePendingCredentialSwitch(sessionId, `reconcile:${source}`);
+        deferredCodexRestartHolder?.onSessionSettled();
+        agentInputCoordinatorHolder?.onExternalTurnSettled(sessionId);
+        refreshRemoteCodexMcpOnTurnSettledHolder?.(sessionId);
+      } catch (err) {
+        log.warn('stale session turn side-effect cleanup failed', {
+          sessionId,
+          source,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
       return true;
     }
     const sess = lookup.session;
@@ -11463,20 +11498,10 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
     }
     if (!liveSessionIdle) return false;
     // The vendor is authoritative that this turn is over, but no terminal event
-    // reached the host. Flush and fail-seal the latest top-level Assistant before
-    // releasing the boundary; otherwise its last progress line is later treated
-    // as a legacy final answer by title regeneration. Preserve the last Assistant
-    // id for a rare late paired done so usage attribution still has a target.
-    flushAssistantBlock(sessionId, null);
-    const abortedAssistantPersistId = consumeLastAssistantPersistId(sessionId);
-    const abortedBoundaryAssistantPersistId = consumeLastTopLevelAssistantPersistId(sessionId);
-    flushOrphanToolResults(sessionId, null);
-    if (abortedAssistantPersistId) {
-      pendingFailedTurnAssistantPersistId.set(sessionId, abortedAssistantPersistId);
-    }
-    if (abortedBoundaryAssistantPersistId) {
-      void markAssistantTurnFailed(sessionId, abortedBoundaryAssistantPersistId);
-    }
+    // reached the host. Seal persist state before releasing the boundary;
+    // otherwise its last progress line is later treated as a legacy final
+    // answer by title regeneration.
+    sealLostTerminalPersistState(sessionId);
     const trackerStale =
       sessionTurnActivityTracker.isSessionInTurn(sessionId) ||
       sessionTurnActivityTracker.isSessionTurnDispatchBoundaryBusy(sessionId);
@@ -11508,11 +11533,6 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
       // The marker write is best-effort and ordered behind pending message
       // persistence. It may retry/settle after an owner boundary is available.
       markTurnEndedAfterPersistDrain(sessionId);
-      // This is a logical turn boundary even though the vendor terminal event
-      // was lost. Drop the cross-segment plan ownership here so a later turn's
-      // id-less terminal error cannot fail-stamp an older plan.
-      clearCodexPlanRowsForSession(sessionId);
-      resetTurnPersistState(sessionId);
       noteClaudeSessionTurnState(sessionId, false);
       settlePendingCredentialSwitch(sessionId, `reconcile:${source}`);
       deferredCodexRestartHolder?.onSessionSettled();

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -11384,22 +11384,32 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
    * whether work is still running; the desktop tracker is only an event-driven
    * view and can remain stale across owner-boundary teardown.
    */
-  const getStableSessionForTurnBoundary = (sessionId: string): WiredSession | null => {
+  type StableSessionLookup =
+    | { status: 'found'; session: WiredSession }
+    | { status: 'missing' }
+    | { status: 'unavailable' };
+
+  const lookupStableSessionForTurnBoundary = (sessionId: string): StableSessionLookup => {
     const wired = wiredSessionsById.get(sessionId)?.session;
-    if (wired) return wired;
+    if (wired) return { status: 'found', session: wired };
     try {
-      return maker.getSession(sessionId) ?? null;
+      const sess = maker.getSession(sessionId);
+      return sess ? { status: 'found', session: sess } : { status: 'missing' };
     } catch (err) {
-      // Dynamic Maker intentionally fails closed while an account owner is
-      // being replaced. A missing stable wiring snapshot means we cannot
-      // authoritatively reconcile this session yet; callers must retain their
-      // boundary and wait for the normal close/settle path.
+      // Dynamic Maker throws PRECONDITION_FAILED while an account owner is
+      // being replaced. Callers that need fail-closed must not treat this as
+      // "session process gone".
       log.warn('session lookup unavailable during turn-boundary reconciliation', {
         sessionId,
         error: err instanceof Error ? err.message : String(err),
       });
-      return null;
+      return { status: 'unavailable' };
     }
+  };
+
+  const getStableSessionForTurnBoundary = (sessionId: string): WiredSession | null => {
+    const lookup = lookupStableSessionForTurnBoundary(sessionId);
+    return lookup.status === 'found' ? lookup.session : null;
   };
 
   /**
@@ -11425,8 +11435,9 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
   };
 
   const reconcileSessionTurnIdle = (sessionId: string, source: string): boolean => {
-    const sess = getStableSessionForTurnBoundary(sessionId);
-    if (!sess) {
+    const lookup = lookupStableSessionForTurnBoundary(sessionId);
+    if (lookup.status === 'unavailable') return false;
+    if (lookup.status === 'missing') {
       const trackerStale =
         sessionTurnActivityTracker.isSessionInTurn(sessionId) ||
         sessionTurnActivityTracker.isSessionTurnDispatchBoundaryBusy(sessionId);
@@ -11438,6 +11449,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
       sessionTurnActivityTracker.deleteSession(sessionId);
       return true;
     }
+    const sess = lookup.session;
     let liveSessionIdle = false;
     try {
       liveSessionIdle = !sess.isTurnRunning();
@@ -11944,12 +11956,11 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
       return isSessionTurnDispatchBoundaryBusy(sessionTurnActivityTracker, sessionId, sess);
     },
     isLiveTurnRunning: (sessionId) => {
+      const lookup = lookupStableSessionForTurnBoundary(sessionId);
+      if (lookup.status === 'unavailable') return undefined;
+      if (lookup.status === 'missing') return false;
       try {
-        const sess = getStableSessionForTurnBoundary(sessionId);
-        // No live Session means the process is gone, so it is not running.
-        // Only a lookup exception is "probe unavailable" (owner-boundary).
-        if (!sess) return false;
-        return sess.isTurnRunning();
+        return lookup.session.isTurnRunning();
       } catch {
         return undefined;
       }

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -11426,7 +11426,18 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
 
   const reconcileSessionTurnIdle = (sessionId: string, source: string): boolean => {
     const sess = getStableSessionForTurnBoundary(sessionId);
-    if (!sess) return false;
+    if (!sess) {
+      const trackerStale =
+        sessionTurnActivityTracker.isSessionInTurn(sessionId) ||
+        sessionTurnActivityTracker.isSessionTurnDispatchBoundaryBusy(sessionId);
+      if (!trackerStale) return false;
+      log.warn('reconciling stale session turn boundary after session unload', {
+        sessionId,
+        source,
+      });
+      sessionTurnActivityTracker.deleteSession(sessionId);
+      return true;
+    }
     let liveSessionIdle = false;
     try {
       liveSessionIdle = !sess.isTurnRunning();
@@ -11935,7 +11946,9 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
     isLiveTurnRunning: (sessionId) => {
       try {
         const sess = getStableSessionForTurnBoundary(sessionId);
-        if (!sess) return undefined;
+        // No live Session means the process is gone, so it is not running.
+        // Only a lookup exception is "probe unavailable" (owner-boundary).
+        if (!sess) return false;
         return sess.isTurnRunning();
       } catch {
         return undefined;

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -3793,6 +3793,15 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
       ) {
         return;
       }
+      if (isFencedStaleSessionTerminal(session.id, event)) {
+        log.debug('ignored stale terminal after leftover turn reclaim', {
+          sessionId: session.id,
+          eventType: event.type,
+          sessionTurnGeneration: event.sessionTurnGeneration ?? null,
+          sessionInstanceId: event.sessionInstanceId ?? null,
+        });
+        return;
+      }
       // 自动续跑的 pending 不能只靠 status(isRunning=true) 清理：Pi/Claude 的
       // terminal-only 路径可能首个事件就是 error。Session 已把 host-owned token
       // 盖到事件上，首个匹配 token 的事件即视为 provider accepted。
@@ -3873,15 +3882,6 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
       let shouldMarkTurnTerminalIdleAfterBroadcast = false;
       let completedTurnWallClockMs: number | undefined;
       const isContinuationBoundary = isTurnContinuationBoundaryEvent(event);
-      if (!isContinuationBoundary && isFencedStaleSessionTerminal(session.id, event)) {
-        log.debug('ignored stale terminal after leftover turn reclaim', {
-          sessionId: session.id,
-          eventType: event.type,
-          sessionTurnGeneration: event.sessionTurnGeneration ?? null,
-          sessionInstanceId: event.sessionInstanceId ?? null,
-        });
-        return;
-      }
       // 探针:continuation 边界命中会跳过 status idle / ended 写 / tracker idle,
       // 若 claim 悬挂会导致 UI 永久「正在生成」。区分「claim 悬挂」与「done 未到达」。
       if (isContinuationBoundary && (event.type === 'done' || event.type === 'status')) {

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -11965,6 +11965,11 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
         return undefined;
       }
     },
+    isLiveSessionPresent: (sessionId) => {
+      const lookup = lookupStableSessionForTurnBoundary(sessionId);
+      if (lookup.status === 'unavailable') return undefined;
+      return lookup.status === 'found';
+    },
     getTurnGeneration: (sessionId) =>
       getStableSessionForTurnBoundary(sessionId)?.getTurnGeneration() ?? null,
     getTurnSessionIdentity: (sessionId) => getStableSessionForTurnBoundary(sessionId) ?? null,

--- a/packages/maker-core/src/session.origin.test.ts
+++ b/packages/maker-core/src/session.origin.test.ts
@@ -408,16 +408,14 @@ describe('Session per-turn origin 打标', () => {
     const second = session.send('second');
     await new Promise((resolve) => setTimeout(resolve, 0));
     await new Promise((resolve) => setTimeout(resolve, 0));
-    await emit({
-      type: 'error',
-      data: { message: 'first late failure', isTerminal: true },
-      source: 'codex',
-    });
+    await emit({ type: 'status', data: { isRunning: false }, source: 'codex' });
+    await emit({ type: 'done', data: {}, source: 'codex' });
 
-    const late = seen.find((event) =>
-      event.type === 'error' && (event.data as { message?: string }).message === 'first late failure');
-    expect(late?.sessionTurnGeneration).toBe(1);
-    expect(late?.sessionInstanceId).toBe(session.instanceId);
+    const idle = seen.find((event) => event.type === 'status');
+    const done = seen.find((event) => event.type === 'done');
+    expect(idle?.sessionTurnGeneration).toBe(1);
+    expect(done?.sessionTurnGeneration).toBe(1);
+    expect(done?.sessionInstanceId).toBe(session.instanceId);
     releaseDispatch();
     await second;
     await session.close();

--- a/packages/maker-core/src/session.origin.test.ts
+++ b/packages/maker-core/src/session.origin.test.ts
@@ -528,7 +528,7 @@ describe('Session per-turn origin 打标', () => {
     await session.close();
   });
 
-  it('keeps leftover idle+done on the prior generation after new-turn tokens', async () => {
+  it('does not let a leftover idle-only tail claim the new turn done after tokens', async () => {
     const { handle, emit, setTurnRunning, releaseDispatch } = createControllableHandle({
       holdDispatch: true,
       holdOnSend: 2,
@@ -544,10 +544,10 @@ describe('Session per-turn origin 打标', () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
     await emit({ type: 'status', data: { isRunning: false }, source: 'codex' });
     await emit({ type: 'text', data: { text: 'second progress', isFinal: false } });
-    await emit({ type: 'done', data: { reason: 'old-tail' }, source: 'codex' });
+    await emit({ type: 'done', data: { reason: 'new-turn' }, source: 'codex' });
 
-    const leftoverDone = seen.find((event) => event.type === 'done');
-    expect(leftoverDone?.sessionTurnGeneration).toBe(1);
+    const done = seen.find((event) => event.type === 'done');
+    expect(done?.sessionTurnGeneration).toBe(2);
     releaseDispatch();
     await second;
     await session.close();

--- a/packages/maker-core/src/session.origin.test.ts
+++ b/packages/maker-core/src/session.origin.test.ts
@@ -445,6 +445,30 @@ describe('Session per-turn origin 打标', () => {
     await session.close();
   });
 
+  it('stamps a silent-stop done as the new generation even without progress tokens', async () => {
+    const { handle, emit, setTurnRunning, releaseDispatch } = createControllableHandle({
+      holdDispatch: true,
+      holdOnSend: 2,
+    });
+    const session = makeSession(handle);
+    const seen: AgentEvent[] = [];
+    session.onEvent((event) => seen.push({ ...event }));
+
+    await session.send('first');
+    await emit({ type: 'text', data: { text: 'first progress', isFinal: false } });
+    setTurnRunning(false);
+    const second = session.send('second');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await emit({ type: 'status', data: { isRunning: true }, source: 'claude-code' });
+    await emit({ type: 'done', data: { silentStop: true }, source: 'claude-code' });
+
+    const silentStop = seen.find((event) => event.type === 'done');
+    expect(silentStop?.sessionTurnGeneration).toBe(2);
+    releaseDispatch();
+    await second;
+    await session.close();
+  });
+
   it('keeps a leftover terminal error on the prior generation after handle.send yields', async () => {
     const { handle, emit, setTurnRunning, releaseDispatch } = createControllableHandle({
       holdDispatch: true,

--- a/packages/maker-core/src/session.origin.test.ts
+++ b/packages/maker-core/src/session.origin.test.ts
@@ -474,6 +474,61 @@ describe('Session per-turn origin 打标', () => {
     await session.close();
   });
 
+  it('does not let a leftover terminal clear the live turn origin', async () => {
+    const { handle, emit, setTurnRunning, releaseDispatch } = createControllableHandle({
+      holdDispatch: true,
+      holdOnSend: 2,
+    });
+    const session = makeSession(handle);
+    const seen: AgentEvent[] = [];
+    session.onEvent((event) => seen.push({ ...event }));
+
+    await session.send('first');
+    await emit({ type: 'text', data: { text: 'first progress', isFinal: false } });
+    setTurnRunning(false);
+    const second = session.send('second', { origin: SCHED_ORIGIN });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await emit({ type: 'status', data: { isRunning: true }, source: 'codex' });
+    await emit({ type: 'done', data: { reason: 'old-tail' }, source: 'codex' });
+    await emit({ type: 'text', data: { text: 'second progress', isFinal: false } });
+
+    const leftoverDone = seen.find((event) => event.type === 'done');
+    const secondText = seen.find((event) =>
+      event.type === 'text' && (event.data as { text?: string }).text === 'second progress');
+    expect(leftoverDone?.sessionTurnGeneration).toBe(1);
+    expect(leftoverDone?.turnOrigin).toBeUndefined();
+    expect(secondText?.sessionTurnGeneration).toBe(2);
+    expect(secondText?.turnOrigin).toEqual(SCHED_ORIGIN);
+    releaseDispatch();
+    await second;
+    await session.close();
+  });
+
+  it('keeps leftover idle+done on the prior generation after new-turn tokens', async () => {
+    const { handle, emit, setTurnRunning, releaseDispatch } = createControllableHandle({
+      holdDispatch: true,
+      holdOnSend: 2,
+    });
+    const session = makeSession(handle);
+    const seen: AgentEvent[] = [];
+    session.onEvent((event) => seen.push({ ...event }));
+
+    await session.send('first');
+    await emit({ type: 'text', data: { text: 'first progress', isFinal: false } });
+    setTurnRunning(false);
+    const second = session.send('second');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await emit({ type: 'status', data: { isRunning: false }, source: 'codex' });
+    await emit({ type: 'text', data: { text: 'second progress', isFinal: false } });
+    await emit({ type: 'done', data: { reason: 'old-tail' }, source: 'codex' });
+
+    const leftoverDone = seen.find((event) => event.type === 'done');
+    expect(leftoverDone?.sessionTurnGeneration).toBe(1);
+    releaseDispatch();
+    await second;
+    await session.close();
+  });
+
   it('排队中的旧 Codex terminal error 不能冒领随后 dispatch 的 attempt token', async () => {
     const { handle, emit, queue, setTurnRunning, releaseDispatch } = createControllableHandle({
       dispatchEvent: {

--- a/packages/maker-core/src/session.origin.test.ts
+++ b/packages/maker-core/src/session.origin.test.ts
@@ -355,9 +355,41 @@ describe('Session per-turn origin 打标', () => {
       type: 'error',
       turnOrigin: SCHED_ORIGIN,
       turnAttemptToken: 9,
+      sessionTurnGeneration: 1,
+      sessionInstanceId: session.instanceId,
     }));
     releaseDispatch();
     await send;
+    await session.close();
+  });
+
+  it('prior-turn next() still stamps an in-flight Codex start-failure as the new generation', async () => {
+    const { handle, emit, setTurnRunning, releaseDispatch } = createControllableHandle({
+      dispatchEvent: {
+        type: 'error',
+        data: { message: 'second failed', isTerminal: true },
+        source: 'codex',
+      },
+      dispatchOnSend: 2,
+      holdDispatch: true,
+      holdOnSend: 2,
+    });
+    const session = makeSession(handle);
+    const seen: AgentEvent[] = [];
+    session.onEvent((event) => seen.push({ ...event }));
+
+    await session.send('first');
+    await emit({ type: 'text', data: { text: 'first progress', isFinal: false } });
+    setTurnRunning(false);
+    const second = session.send('second');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const startFail = seen.find((event) =>
+      event.type === 'error' && (event.data as { message?: string }).message === 'second failed');
+    expect(startFail?.sessionTurnGeneration).toBe(2);
+    expect(startFail?.sessionInstanceId).toBe(session.instanceId);
+    releaseDispatch();
+    await second;
     await session.close();
   });
 
@@ -394,6 +426,7 @@ describe('Session per-turn origin 打标', () => {
       event.type === 'error' && (event.data as { message?: string }).message === 'first late failure');
     expect(late?.turnAttemptToken).toBeUndefined();
     expect(late?.turnOrigin).toBeUndefined();
+    expect(late?.sessionInstanceId).toBe(session.instanceId);
     releaseDispatch();
     await second;
     await session.close();

--- a/packages/maker-core/src/session.origin.test.ts
+++ b/packages/maker-core/src/session.origin.test.ts
@@ -445,6 +445,32 @@ describe('Session per-turn origin 打标', () => {
     await session.close();
   });
 
+  it('does not stamp a zero-output done as leftover after a completed prior turn', async () => {
+    const { handle, emit, setTurnRunning, releaseDispatch } = createControllableHandle({
+      holdDispatch: true,
+      holdOnSend: 2,
+    });
+    const session = makeSession(handle);
+    const seen: AgentEvent[] = [];
+    session.onEvent((event) => seen.push({ ...event }));
+
+    await session.send('first');
+    await emit({ type: 'text', data: { text: 'first progress', isFinal: false } });
+    await emit({ type: 'done', data: {}, source: 'codex' });
+    setTurnRunning(false);
+    const second = session.send('second');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await emit({ type: 'status', data: { isRunning: true }, source: 'codex' });
+    await emit({ type: 'done', data: {}, source: 'codex' });
+
+    const dones = seen.filter((event) => event.type === 'done');
+    expect(dones[0]?.sessionTurnGeneration).toBe(1);
+    expect(dones[1]?.sessionTurnGeneration).toBe(2);
+    releaseDispatch();
+    await second;
+    await session.close();
+  });
+
   it('stamps a silent-stop done as the new generation even without progress tokens', async () => {
     const { handle, emit, setTurnRunning, releaseDispatch } = createControllableHandle({
       holdDispatch: true,

--- a/packages/maker-core/src/session.origin.test.ts
+++ b/packages/maker-core/src/session.origin.test.ts
@@ -393,6 +393,36 @@ describe('Session per-turn origin 打标', () => {
     await session.close();
   });
 
+  it('keeps a leftover terminal on queued generation after handle.send yields', async () => {
+    const { handle, emit, setTurnRunning, releaseDispatch } = createControllableHandle({
+      holdDispatch: true,
+      holdOnSend: 2,
+    });
+    const session = makeSession(handle);
+    const seen: AgentEvent[] = [];
+    session.onEvent((event) => seen.push({ ...event }));
+
+    await session.send('first');
+    await emit({ type: 'text', data: { text: 'first progress', isFinal: false } });
+    setTurnRunning(false);
+    const second = session.send('second');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await emit({
+      type: 'error',
+      data: { message: 'first late failure', isTerminal: true },
+      source: 'codex',
+    });
+
+    const late = seen.find((event) =>
+      event.type === 'error' && (event.data as { message?: string }).message === 'first late failure');
+    expect(late?.sessionTurnGeneration).toBe(1);
+    expect(late?.sessionInstanceId).toBe(session.instanceId);
+    releaseDispatch();
+    await second;
+    await session.close();
+  });
+
   it('排队中的旧 Codex terminal error 不能冒领随后 dispatch 的 attempt token', async () => {
     const { handle, emit, queue, setTurnRunning, releaseDispatch } = createControllableHandle({
       dispatchEvent: {

--- a/packages/maker-core/src/session.origin.test.ts
+++ b/packages/maker-core/src/session.origin.test.ts
@@ -410,12 +410,11 @@ describe('Session per-turn origin 打标', () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
     await emit({ type: 'status', data: { isRunning: false }, source: 'codex' });
     await emit({ type: 'done', data: {}, source: 'codex' });
+    await emit({ type: 'text', data: { text: 'second progress', isFinal: false } });
 
-    const idle = seen.find((event) => event.type === 'status');
-    const done = seen.find((event) => event.type === 'done');
-    expect(idle?.sessionTurnGeneration).toBe(1);
-    expect(done?.sessionTurnGeneration).toBe(1);
-    expect(done?.sessionInstanceId).toBe(session.instanceId);
+    expect(seen.some((event) => event.type === 'status' || event.type === 'done')).toBe(false);
+    const secondText = seen.find((event) => event.type === 'text' && (event.data as { text?: string }).text === 'second progress');
+    expect(secondText?.sessionTurnGeneration).toBe(2);
     releaseDispatch();
     await second;
     await session.close();
@@ -437,9 +436,10 @@ describe('Session per-turn origin 打标', () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
     await emit({ type: 'status', data: { isRunning: true }, source: 'codex' });
     await emit({ type: 'done', data: { reason: 'old-tail' }, source: 'codex' });
+    await emit({ type: 'text', data: { text: 'second progress', isFinal: false } });
 
-    const leftoverDone = seen.find((event) => event.type === 'done');
-    expect(leftoverDone?.sessionTurnGeneration).toBe(1);
+    expect(seen.some((event) => event.type === 'done')).toBe(false);
+    expect(seen.find((event) => event.type === 'text' && (event.data as { text?: string }).text === 'second progress')?.sessionTurnGeneration).toBe(2);
     releaseDispatch();
     await second;
     await session.close();
@@ -516,9 +516,8 @@ describe('Session per-turn origin 打标', () => {
       source: 'codex',
     });
 
-    const late = seen.find((event) =>
-      event.type === 'error' && (event.data as { message?: string }).message === 'first late failure');
-    expect(late?.sessionTurnGeneration).toBe(1);
+    expect(seen.some((event) =>
+      event.type === 'error' && (event.data as { message?: string }).message === 'first late failure')).toBe(false);
     releaseDispatch();
     await second;
     await session.close();
@@ -571,11 +570,9 @@ describe('Session per-turn origin 打标', () => {
     await emit({ type: 'done', data: { reason: 'old-tail' }, source: 'codex' });
     await emit({ type: 'text', data: { text: 'second progress', isFinal: false } });
 
-    const leftoverDone = seen.find((event) => event.type === 'done');
+    expect(seen.some((event) => event.type === 'done')).toBe(false);
     const secondText = seen.find((event) =>
       event.type === 'text' && (event.data as { text?: string }).text === 'second progress');
-    expect(leftoverDone?.sessionTurnGeneration).toBe(1);
-    expect(leftoverDone?.turnOrigin).toBeUndefined();
     expect(secondText?.sessionTurnGeneration).toBe(2);
     expect(secondText?.turnOrigin).toEqual(SCHED_ORIGIN);
     releaseDispatch();
@@ -630,9 +627,10 @@ describe('Session per-turn origin 打标', () => {
       turnScope: 'background',
     });
     await emit({ type: 'done', data: { reason: 'old-tail' }, source: 'codex' });
+    await emit({ type: 'text', data: { text: 'second progress', isFinal: false } });
 
-    const leftoverDone = seen.find((event) => event.type === 'done');
-    expect(leftoverDone?.sessionTurnGeneration).toBe(1);
+    expect(seen.some((event) => event.type === 'done')).toBe(false);
+    expect(seen.find((event) => event.type === 'text' && (event.data as { text?: string }).text === 'second progress')?.sessionTurnGeneration).toBe(2);
     releaseDispatch();
     await second;
     await session.close();
@@ -661,9 +659,10 @@ describe('Session per-turn origin 打标', () => {
     const second = session.send('second');
     await new Promise((resolve) => setTimeout(resolve, 0));
     await emit({ type: 'done', data: { reason: 'old-tail' }, source: 'codex' });
+    await emit({ type: 'text', data: { text: 'second progress', isFinal: false } });
 
-    const leftoverDone = seen.find((event) => event.type === 'done');
-    expect(leftoverDone?.sessionTurnGeneration).toBe(1);
+    expect(seen.some((event) => event.type === 'done')).toBe(false);
+    expect(seen.find((event) => event.type === 'text' && (event.data as { text?: string }).text === 'second progress')?.sessionTurnGeneration).toBe(2);
     releaseDispatch();
     await second;
     await session.close();
@@ -731,7 +730,6 @@ describe('Session per-turn origin 打标', () => {
       event.type === 'error' && (event.data as { message?: string }).message === 'first late failure');
     expect(late?.turnAttemptToken).toBeUndefined();
     expect(late?.turnOrigin).toBeUndefined();
-    expect(late?.sessionInstanceId).toBe(session.instanceId);
     releaseDispatch();
     await second;
     await session.close();

--- a/packages/maker-core/src/session.origin.test.ts
+++ b/packages/maker-core/src/session.origin.test.ts
@@ -638,6 +638,37 @@ describe('Session per-turn origin 打标', () => {
     await session.close();
   });
 
+  it('keeps leftover done on the unresolved generation after a cancelled reservation', async () => {
+    const { handle, emit, setTurnRunning, releaseDispatch } = createControllableHandle({
+      holdDispatch: true,
+      holdOnSend: 2,
+    });
+    const session = makeSession(handle);
+    const seen: AgentEvent[] = [];
+    session.onEvent((event) => seen.push({ ...event }));
+
+    await session.send('first');
+    await emit({ type: 'text', data: { text: 'first progress', isFinal: false } });
+    setTurnRunning(false);
+    const controller = new AbortController();
+    await expect(session.send('cancelled', {
+      signal: controller.signal,
+      afterTurnReserved: () => controller.abort(),
+    })).resolves.toEqual({
+      accepted: false,
+      reason: 'cancelled-before-dispatch',
+    });
+    const second = session.send('second');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await emit({ type: 'done', data: { reason: 'old-tail' }, source: 'codex' });
+
+    const leftoverDone = seen.find((event) => event.type === 'done');
+    expect(leftoverDone?.sessionTurnGeneration).toBe(1);
+    releaseDispatch();
+    await second;
+    await session.close();
+  });
+
   it('treats a standalone image as new-turn progress before leftover done', async () => {
     const { handle, emit, setTurnRunning, releaseDispatch } = createControllableHandle({
       holdDispatch: true,

--- a/packages/maker-core/src/session.origin.test.ts
+++ b/packages/maker-core/src/session.origin.test.ts
@@ -608,6 +608,36 @@ describe('Session per-turn origin 打标', () => {
     await session.close();
   });
 
+  it('does not treat a background tool result as new-turn progress', async () => {
+    const { handle, emit, setTurnRunning, releaseDispatch } = createControllableHandle({
+      holdDispatch: true,
+      holdOnSend: 2,
+    });
+    const session = makeSession(handle);
+    const seen: AgentEvent[] = [];
+    session.onEvent((event) => seen.push({ ...event }));
+
+    await session.send('first');
+    await emit({ type: 'text', data: { text: 'first progress', isFinal: false } });
+    setTurnRunning(false);
+    const second = session.send('second');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await emit({ type: 'status', data: { isRunning: false }, source: 'codex' });
+    await emit({
+      type: 'tool_result_full',
+      data: { toolUseId: 'collab-1', result: 'old collab' },
+      source: 'codex',
+      turnScope: 'background',
+    });
+    await emit({ type: 'done', data: { reason: 'old-tail' }, source: 'codex' });
+
+    const leftoverDone = seen.find((event) => event.type === 'done');
+    expect(leftoverDone?.sessionTurnGeneration).toBe(1);
+    releaseDispatch();
+    await second;
+    await session.close();
+  });
+
   it('treats a standalone image as new-turn progress before leftover done', async () => {
     const { handle, emit, setTurnRunning, releaseDispatch } = createControllableHandle({
       holdDispatch: true,

--- a/packages/maker-core/src/session.origin.test.ts
+++ b/packages/maker-core/src/session.origin.test.ts
@@ -608,6 +608,35 @@ describe('Session per-turn origin 打标', () => {
     await session.close();
   });
 
+  it('treats a standalone image as new-turn progress before leftover done', async () => {
+    const { handle, emit, setTurnRunning, releaseDispatch } = createControllableHandle({
+      holdDispatch: true,
+      holdOnSend: 2,
+    });
+    const session = makeSession(handle);
+    const seen: AgentEvent[] = [];
+    session.onEvent((event) => seen.push({ ...event }));
+
+    await session.send('first');
+    await emit({ type: 'text', data: { text: 'first progress', isFinal: false } });
+    setTurnRunning(false);
+    const second = session.send('second');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await emit({ type: 'status', data: { isRunning: false }, source: 'codex' });
+    await emit({
+      type: 'image',
+      data: { kind: 'imageGeneration', result: 'data:image/png;base64,xx' },
+      source: 'codex',
+    });
+    await emit({ type: 'done', data: { reason: 'new-turn' }, source: 'codex' });
+
+    const done = seen.find((event) => event.type === 'done');
+    expect(done?.sessionTurnGeneration).toBe(2);
+    releaseDispatch();
+    await second;
+    await session.close();
+  });
+
   it('排队中的旧 Codex terminal error 不能冒领随后 dispatch 的 attempt token', async () => {
     const { handle, emit, queue, setTurnRunning, releaseDispatch } = createControllableHandle({
       dispatchEvent: {

--- a/packages/maker-core/src/session.origin.test.ts
+++ b/packages/maker-core/src/session.origin.test.ts
@@ -421,6 +421,59 @@ describe('Session per-turn origin 打标', () => {
     await session.close();
   });
 
+  it('keeps leftover done on the prior generation after a new-turn running status', async () => {
+    const { handle, emit, setTurnRunning, releaseDispatch } = createControllableHandle({
+      holdDispatch: true,
+      holdOnSend: 2,
+    });
+    const session = makeSession(handle);
+    const seen: AgentEvent[] = [];
+    session.onEvent((event) => seen.push({ ...event }));
+
+    await session.send('first');
+    await emit({ type: 'text', data: { text: 'first progress', isFinal: false } });
+    setTurnRunning(false);
+    const second = session.send('second');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await emit({ type: 'status', data: { isRunning: true }, source: 'codex' });
+    await emit({ type: 'done', data: { reason: 'old-tail' }, source: 'codex' });
+
+    const leftoverDone = seen.find((event) => event.type === 'done');
+    expect(leftoverDone?.sessionTurnGeneration).toBe(1);
+    releaseDispatch();
+    await second;
+    await session.close();
+  });
+
+  it('keeps a leftover terminal error on the prior generation after handle.send yields', async () => {
+    const { handle, emit, setTurnRunning, releaseDispatch } = createControllableHandle({
+      holdDispatch: true,
+      holdOnSend: 2,
+    });
+    const session = makeSession(handle);
+    const seen: AgentEvent[] = [];
+    session.onEvent((event) => seen.push({ ...event }));
+
+    await session.send('first');
+    await emit({ type: 'text', data: { text: 'first progress', isFinal: false } });
+    setTurnRunning(false);
+    const second = session.send('second');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await emit({ type: 'status', data: { isRunning: true }, source: 'codex' });
+    await emit({
+      type: 'error',
+      data: { message: 'first late failure', isTerminal: true },
+      source: 'codex',
+    });
+
+    const late = seen.find((event) =>
+      event.type === 'error' && (event.data as { message?: string }).message === 'first late failure');
+    expect(late?.sessionTurnGeneration).toBe(1);
+    releaseDispatch();
+    await second;
+    await session.close();
+  });
+
   it('排队中的旧 Codex terminal error 不能冒领随后 dispatch 的 attempt token', async () => {
     const { handle, emit, queue, setTurnRunning, releaseDispatch } = createControllableHandle({
       dispatchEvent: {

--- a/packages/maker-core/src/session.origin.test.ts
+++ b/packages/maker-core/src/session.origin.test.ts
@@ -495,7 +495,36 @@ describe('Session per-turn origin 打标', () => {
     await session.close();
   });
 
-  it('keeps a leftover terminal error on the prior generation after handle.send yields', async () => {
+  it('keeps a leftover terminal error on the prior generation after leftover idle', async () => {
+    const { handle, emit, setTurnRunning, releaseDispatch } = createControllableHandle({
+      holdDispatch: true,
+      holdOnSend: 2,
+    });
+    const session = makeSession(handle);
+    const seen: AgentEvent[] = [];
+    session.onEvent((event) => seen.push({ ...event }));
+
+    await session.send('first');
+    await emit({ type: 'text', data: { text: 'first progress', isFinal: false } });
+    setTurnRunning(false);
+    const second = session.send('second');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await emit({ type: 'status', data: { isRunning: false }, source: 'codex' });
+    await emit({
+      type: 'error',
+      data: { message: 'first late failure', isTerminal: true },
+      source: 'codex',
+    });
+
+    const late = seen.find((event) =>
+      event.type === 'error' && (event.data as { message?: string }).message === 'first late failure');
+    expect(late?.sessionTurnGeneration).toBe(1);
+    releaseDispatch();
+    await second;
+    await session.close();
+  });
+
+  it('stamps an immediate new-turn 401 after running as the live generation', async () => {
     const { handle, emit, setTurnRunning, releaseDispatch } = createControllableHandle({
       holdDispatch: true,
       holdOnSend: 2,
@@ -512,13 +541,13 @@ describe('Session per-turn origin 打标', () => {
     await emit({ type: 'status', data: { isRunning: true }, source: 'codex' });
     await emit({
       type: 'error',
-      data: { message: 'first late failure', isTerminal: true },
+      data: { message: 'quota exceeded', isTerminal: true },
       source: 'codex',
     });
 
-    const late = seen.find((event) =>
-      event.type === 'error' && (event.data as { message?: string }).message === 'first late failure');
-    expect(late?.sessionTurnGeneration).toBe(1);
+    const fail = seen.find((event) =>
+      event.type === 'error' && (event.data as { message?: string }).message === 'quota exceeded');
+    expect(fail?.sessionTurnGeneration).toBe(2);
     releaseDispatch();
     await second;
     await session.close();

--- a/packages/maker-core/src/session.origin.test.ts
+++ b/packages/maker-core/src/session.origin.test.ts
@@ -735,6 +735,34 @@ describe('Session per-turn origin 打标', () => {
     await session.close();
   });
 
+  it('clears leftover prior after an in-flight terminal so the live done can settle', async () => {
+    const { handle, emit, queue, setTurnRunning, releaseDispatch } = createControllableHandle({
+      holdDispatch: true,
+      holdOnSend: 2,
+    });
+    const session = makeSession(handle);
+    const seen: AgentEvent[] = [];
+    session.onEvent((event) => seen.push({ ...event }));
+
+    await session.send('first');
+    await emit({ type: 'text', data: { text: 'first progress', isFinal: false } });
+    setTurnRunning(false);
+    queue({
+      type: 'error',
+      data: { message: 'first late failure', isTerminal: true },
+      source: 'codex',
+    });
+    const second = session.send('second');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await emit({ type: 'done', data: { reason: 'new-turn' }, source: 'codex' });
+
+    const liveDone = seen.find((event) => event.type === 'done');
+    expect(liveDone?.sessionTurnGeneration).toBe(2);
+    releaseDispatch();
+    await second;
+    await session.close();
+  });
+
   it('terminal error 后先排空尾部，再允许新 attempt', async () => {
     const { handle, emit } = createControllableHandle();
     const session = makeSession(handle);

--- a/packages/maker-core/src/session.ts
+++ b/packages/maker-core/src/session.ts
@@ -1870,7 +1870,11 @@ export class Session {
     if (belongsToInFlightSend) {
       this.inFlightSendOwnsBlockedWait = false;
       this.staleTerminalQueuedGeneration = null;
-      if (this.isNewTurnProgressEvent(event)) {
+      if (
+        this.isNewTurnProgressEvent(event) ||
+        event.type === 'done' ||
+        isTerminalAgentErrorEvent(event)
+      ) {
         this.pendingPriorGeneration = null;
       }
       return inFlightGeneration;

--- a/packages/maker-core/src/session.ts
+++ b/packages/maker-core/src/session.ts
@@ -743,16 +743,26 @@ export class Session {
       //     turn 的剩余事件(含 done)继续带正确 origin。若这里强行清 null,正在跑的
       //     turn 的 done 会丢 origin → IM 转播收不到 done → 转播卡永不 finalize、残留
       //     state 污染下一轮(见 PR #129 review)。
-      if (originInstalled && !turnDispatched) {
-        this.currentTurnOrigin = previousTurnOrigin;
-        this.currentTurnAttemptToken = previousTurnAttemptToken;
+      if (!turnDispatched) {
+        if (originInstalled) {
+          this.currentTurnOrigin = previousTurnOrigin;
+          this.currentTurnAttemptToken = previousTurnAttemptToken;
+          originInstalled = false;
+          // Confirmed provider rejection cannot produce a turn tail, so it may
+          // immediately reuse the rolled-back generation. Other failures retain
+          // the bounded tail fence before another turn can enter.
+          if (!dispatchConfirmedUndispatched) {
+            this.armTerminalErrorDrain(previousTurnGeneration);
+          }
+        }
         this.turnGeneration = previousTurnGeneration;
-        this.pendingPriorGeneration = null;
-        // Confirmed provider rejection cannot produce a turn tail, so it may
-        // immediately reuse the rolled-back generation. Other failures retain
-        // the bounded tail fence before another turn can enter.
-        if (!dispatchConfirmedUndispatched) {
-          this.armTerminalErrorDrain(previousTurnGeneration);
+        if (
+          previousTurnGeneration > 0 &&
+          this.terminalEventObservedGeneration !== previousTurnGeneration
+        ) {
+          this.pendingPriorGeneration = previousTurnGeneration;
+        } else {
+          this.pendingPriorGeneration = null;
         }
       }
       if (turnLifecyclePrepared && !turnDispatched) {

--- a/packages/maker-core/src/session.ts
+++ b/packages/maker-core/src/session.ts
@@ -1863,11 +1863,6 @@ export class Session {
       }
       return inFlightGeneration;
     }
-    if (prior !== null && isTerminalAgentErrorEvent(event) && waitStartGeneration !== 0) {
-      this.pendingPriorGeneration = null;
-      this.staleTerminalQueuedGeneration = null;
-      return prior;
-    }
     if (waitStartGeneration === 0 && this.turnGeneration > 0) {
       this.staleTerminalQueuedGeneration = null;
       return this.turnGeneration;

--- a/packages/maker-core/src/session.ts
+++ b/packages/maker-core/src/session.ts
@@ -580,8 +580,13 @@ export class Session {
     // 卡死的 turn"，避免误杀宽限期内新起的健康 turn。
     const previousTurnGeneration = this.turnGeneration;
     this.turnGeneration += 1;
-    if (previousTurnGeneration > 0) {
+    if (
+      previousTurnGeneration > 0 &&
+      this.terminalEventObservedGeneration !== previousTurnGeneration
+    ) {
       this.pendingPriorGeneration = previousTurnGeneration;
+    } else {
+      this.pendingPriorGeneration = null;
     }
     const reservedTurnGeneration = this.turnGeneration;
     const reservation = createSendReservation(reservedTurnGeneration);

--- a/packages/maker-core/src/session.ts
+++ b/packages/maker-core/src/session.ts
@@ -1798,6 +1798,7 @@ export class Session {
   }
 
   private isNewTurnProgressEvent(event: AgentEvent): boolean {
+    if (event.turnScope === 'background') return false;
     return (
       event.type === 'text' ||
       event.type === 'thinking' ||

--- a/packages/maker-core/src/session.ts
+++ b/packages/maker-core/src/session.ts
@@ -432,6 +432,8 @@ export class Session {
   private insideProviderSendSync = false;
   /** Keep a leftover status/done tail on the generation that started it. */
   private staleTerminalQueuedGeneration: number | null = null;
+  /** Previous turn generation, kept until leftover tail or new-turn progress. */
+  private pendingPriorGeneration: number | null = null;
   /**
    * 当前进行中 turn 的发起来源(来自 send 的 opts.origin)。事件 fan-out 前打到
    * AgentEvent.turnOrigin 上,turn 终止(isTerminalTurnEvent)后清空 — 共享
@@ -578,6 +580,9 @@ export class Session {
     // 卡死的 turn"，避免误杀宽限期内新起的健康 turn。
     const previousTurnGeneration = this.turnGeneration;
     this.turnGeneration += 1;
+    if (previousTurnGeneration > 0) {
+      this.pendingPriorGeneration = previousTurnGeneration;
+    }
     const reservedTurnGeneration = this.turnGeneration;
     const reservation = createSendReservation(reservedTurnGeneration);
     this.sendReservation = reservation;
@@ -712,6 +717,7 @@ export class Session {
           this.currentTurnOrigin = previousTurnOrigin;
           this.currentTurnAttemptToken = previousTurnAttemptToken;
           this.turnGeneration = previousTurnGeneration;
+          this.pendingPriorGeneration = null;
           originInstalled = false;
         }
         await this.close();
@@ -736,6 +742,7 @@ export class Session {
         this.currentTurnOrigin = previousTurnOrigin;
         this.currentTurnAttemptToken = previousTurnAttemptToken;
         this.turnGeneration = previousTurnGeneration;
+        this.pendingPriorGeneration = null;
         // Confirmed provider rejection cannot produce a turn tail, so it may
         // immediately reuse the rolled-back generation. Other failures retain
         // the bounded tail fence before another turn can enter.
@@ -1779,6 +1786,16 @@ export class Session {
     );
   }
 
+  private isNewTurnProgressEvent(event: AgentEvent): boolean {
+    return (
+      event.type === 'text' ||
+      event.type === 'thinking' ||
+      event.type === 'tool_use' ||
+      event.type === 'tool_result' ||
+      event.type === 'tool_result_full'
+    );
+  }
+
   private resolveSessionTurnGeneration(
     waitStartGeneration: number,
     observedGeneration: number,
@@ -1787,6 +1804,17 @@ export class Session {
     if (observedGeneration > waitStartGeneration) {
       this.staleTerminalQueuedGeneration = null;
       return observedGeneration;
+    }
+    const prior = this.pendingPriorGeneration;
+    const leftoverDoneOrIdle = event.type === 'done' || this.isIdleStatusEvent(event);
+    if (prior !== null && leftoverDoneOrIdle && waitStartGeneration !== 0) {
+      if (event.type === 'done') {
+        this.pendingPriorGeneration = null;
+        this.staleTerminalQueuedGeneration = null;
+      } else {
+        this.staleTerminalQueuedGeneration = prior;
+      }
+      return prior;
     }
     const leftoverTail = this.isLeftoverTailEvent(event);
     if (leftoverTail && this.staleTerminalQueuedGeneration !== null) {
@@ -1816,11 +1844,19 @@ export class Session {
       this.staleTerminalQueuedGeneration = null;
       return inFlightGeneration;
     }
+    if (prior !== null && isTerminalAgentErrorEvent(event) && waitStartGeneration !== 0) {
+      this.pendingPriorGeneration = null;
+      this.staleTerminalQueuedGeneration = null;
+      return prior;
+    }
     if (waitStartGeneration === 0 && this.turnGeneration > 0) {
       this.staleTerminalQueuedGeneration = null;
       return this.turnGeneration;
     }
-    this.staleTerminalQueuedGeneration = null;
+    if (this.isNewTurnProgressEvent(event)) {
+      this.pendingPriorGeneration = null;
+      this.staleTerminalQueuedGeneration = null;
+    }
     return waitStartGeneration;
   }
 

--- a/packages/maker-core/src/session.ts
+++ b/packages/maker-core/src/session.ts
@@ -1854,8 +1854,10 @@ export class Session {
       return this.turnGeneration;
     }
     if (this.isNewTurnProgressEvent(event)) {
+      // New-turn tokens prove this generation owns later product terminals.
+      // Keep a leftover idle/error tail on its queued generation so a late
+      // done after first tokens still matches the register fence.
       this.pendingPriorGeneration = null;
-      this.staleTerminalQueuedGeneration = null;
     }
     return waitStartGeneration;
   }
@@ -1868,7 +1870,6 @@ export class Session {
     const isBackgroundEvent = event.turnScope === 'background';
     if (!isBackgroundEvent) this.lastEventAt = Date.now();
     this.lastEventType = event.type;
-    const isCurrentGeneration = observedGeneration === this.turnGeneration;
     if (event.sessionInstanceId === undefined) {
       event.sessionInstanceId = this.instanceId;
     }
@@ -1879,7 +1880,15 @@ export class Session {
         event,
       );
     }
-    this.observeTurnControl(event, observedGeneration);
+    const resolvedGeneration = event.sessionTurnGeneration ?? observedGeneration;
+    // Both the source stamp and the dequeued wait must name this turn.
+    // A leftover tail can be stamped N while next() recaptures N+1, or the
+    // reverse when an in-flight start-failure adopts the new generation from
+    // an older wait. Current-turn cleanup requires agreement.
+    const isCurrentGeneration =
+      resolvedGeneration === this.turnGeneration &&
+      observedGeneration === this.turnGeneration;
+    this.observeTurnControl(event, resolvedGeneration);
     // fan-out 前打 turn origin(所有 listener 拿到同一份);事件对象由 translator
     // 每次新建、看门狗每次合成,不会串台。=== undefined 守卫:不覆盖 agent 自带的。
     if (!isBackgroundEvent && isCurrentGeneration && this.currentTurnOrigin && event.turnOrigin === undefined) {
@@ -1934,26 +1943,26 @@ export class Session {
     }
     const listenerEvent = redactEventForListeners(event);
     if (isCurrentGeneration && isTerminal && !isBackgroundEvent) {
-      this.clearTurnControl(observedGeneration);
+      this.clearTurnControl(resolvedGeneration);
     }
     if (isTerminal && !isBackgroundEvent) {
       try {
         const pending = this.turnLifecycleObserver?.onTerminal({
-          turnGeneration: observedGeneration,
+          turnGeneration: resolvedGeneration,
           event: listenerEvent,
           isCurrentGeneration,
         });
         if (pending) {
           void Promise.resolve(pending).catch((error) => {
             this.logger.warn('turn lifecycle terminal cleanup failed', {
-              turnGeneration: observedGeneration,
+              turnGeneration: resolvedGeneration,
               error: String(error),
             });
           });
         }
       } catch (error) {
         this.logger.warn('turn lifecycle terminal cleanup failed', {
-          turnGeneration: observedGeneration,
+          turnGeneration: resolvedGeneration,
           error: String(error),
         });
       }

--- a/packages/maker-core/src/session.ts
+++ b/packages/maker-core/src/session.ts
@@ -1972,7 +1972,11 @@ export class Session {
     if (isCurrentGeneration && isTerminal && !isBackgroundEvent) {
       this.clearTurnControl(resolvedGeneration);
     }
-    if (isTerminal && !isBackgroundEvent) {
+    const isLeftoverProductTerminal =
+      !isBackgroundEvent &&
+      resolvedGeneration < this.turnGeneration &&
+      (isTerminal || this.isIdleStatusEvent(event));
+    if (isTerminal && !isBackgroundEvent && !isLeftoverProductTerminal) {
       try {
         const pending = this.turnLifecycleObserver?.onTerminal({
           turnGeneration: resolvedGeneration,
@@ -1994,8 +1998,10 @@ export class Session {
         });
       }
     }
-    for (const listener of this.eventListeners) {
-      try { listener(listenerEvent); } catch (e) { this.logger.error('event listener threw', { error: String(e) }); }
+    if (!isLeftoverProductTerminal) {
+      for (const listener of this.eventListeners) {
+        try { listener(listenerEvent); } catch (e) { this.logger.error('event listener threw', { error: String(e) }); }
+      }
     }
     // A late child update belongs to the completed parent turn. It remains
     // visible to listeners, but must not clear/adopt the current turn or keep

--- a/packages/maker-core/src/session.ts
+++ b/packages/maker-core/src/session.ts
@@ -424,6 +424,10 @@ export class Session {
   private terminalErrorDrainGeneration: number | null = null;
   private terminalErrorDrainTimer: ReturnType<typeof setTimeout> | null = null;
   private sendReservation: SendReservation | null = null;
+  /** True while runEventLoop is blocked in iterator.next(). */
+  private eventLoopAwaiting = false;
+  /** The blocked next() that was pending when the current send entered handle.send. */
+  private inFlightSendOwnsBlockedWait = false;
   /**
    * 当前进行中 turn 的发起来源(来自 send 的 opts.origin)。事件 fan-out 前打到
    * AgentEvent.turnOrigin 上,turn 终止(isTerminalTurnEvent)后清空 — 共享
@@ -1603,6 +1607,7 @@ export class Session {
       gracefulStopState: 'none',
       gracefulStopPromise: null,
     };
+    this.inFlightSendOwnsBlockedWait = this.eventLoopAwaiting;
   }
 
   private clearTurnControl(generation: number): void {
@@ -1751,6 +1756,24 @@ export class Session {
    * 并像用户插话一样暂停 goal,scheduler 的 IM 转播则直接忽略,卡片永不 finalize
    * (review #944 第二轮)。
    */
+  private resolveSessionTurnGeneration(queuedGeneration: number): number {
+    const inFlightGeneration = this.sendReservation?.generation;
+    const belongsToInFlightSend =
+      this.inFlightSendOwnsBlockedWait &&
+      typeof inFlightGeneration === 'number' &&
+      inFlightGeneration === this.turnGeneration &&
+      this.turnControlState?.generation === inFlightGeneration;
+    if (belongsToInFlightSend) {
+      this.inFlightSendOwnsBlockedWait = false;
+      return inFlightGeneration;
+    }
+    // The constructor wait starts at generation 0. The first send owns that wait.
+    if (queuedGeneration === 0 && this.turnGeneration > 0) {
+      return this.turnGeneration;
+    }
+    return queuedGeneration;
+  }
+
   private fanOutEvent(
     event: AgentEvent,
     observedGeneration = this.turnGeneration,
@@ -1764,10 +1787,9 @@ export class Session {
       event.sessionInstanceId = this.instanceId;
     }
     if (event.sessionTurnGeneration === undefined) {
-      // Stamp the generation that owned this next() wait, not an adopted later
-      // generation. A leftover terminal dequeued after the next send must keep
-      // the older value so host can fence it.
-      event.sessionTurnGeneration = queuedGeneration;
+      event.sessionTurnGeneration = this.resolveSessionTurnGeneration(
+        queuedGeneration,
+      );
     }
     this.observeTurnControl(event, observedGeneration);
     // fan-out 前打 turn origin(所有 listener 拿到同一份);事件对象由 translator
@@ -2131,7 +2153,13 @@ export class Session {
         const awaitingCanAdoptNextGeneration =
           awaitingGeneration === 0 ||
           this.terminalEventObservedGeneration === awaitingGeneration;
-        const result = await iterator.next();
+        this.eventLoopAwaiting = true;
+        let result: IteratorResult<AgentEvent>;
+        try {
+          result = await iterator.next();
+        } finally {
+          this.eventLoopAwaiting = false;
+        }
         if (result.done) break;
         const event = result.value;
         this.releaseSendReservationIfObserved();

--- a/packages/maker-core/src/session.ts
+++ b/packages/maker-core/src/session.ts
@@ -1778,9 +1778,15 @@ export class Session {
     return data?.isRunning === false;
   }
 
+  private isSilentStopDoneEvent(event: AgentEvent): boolean {
+    if (event.type !== 'done') return false;
+    const data = event.data as { silentStop?: unknown } | null | undefined;
+    return data?.silentStop === true;
+  }
+
   private isLeftoverTailEvent(event: AgentEvent): boolean {
     return (
-      event.type === 'done' ||
+      (event.type === 'done' && !this.isSilentStopDoneEvent(event)) ||
       this.isIdleStatusEvent(event) ||
       (isTerminalAgentErrorEvent(event) && this.staleTerminalQueuedGeneration !== null)
     );
@@ -1806,7 +1812,9 @@ export class Session {
       return observedGeneration;
     }
     const prior = this.pendingPriorGeneration;
-    const leftoverDoneOrIdle = event.type === 'done' || this.isIdleStatusEvent(event);
+    const leftoverDoneOrIdle =
+      (event.type === 'done' && !this.isSilentStopDoneEvent(event)) ||
+      this.isIdleStatusEvent(event);
     if (prior !== null && leftoverDoneOrIdle && waitStartGeneration !== 0) {
       if (event.type === 'done') {
         this.pendingPriorGeneration = null;

--- a/packages/maker-core/src/session.ts
+++ b/packages/maker-core/src/session.ts
@@ -1801,6 +1801,7 @@ export class Session {
     return (
       event.type === 'text' ||
       event.type === 'thinking' ||
+      event.type === 'image' ||
       event.type === 'tool_use' ||
       event.type === 'tool_result' ||
       event.type === 'tool_result_full'

--- a/packages/maker-core/src/session.ts
+++ b/packages/maker-core/src/session.ts
@@ -428,6 +428,8 @@ export class Session {
   private eventLoopAwaiting = false;
   /** The blocked next() that was pending when the current send entered handle.send. */
   private inFlightSendOwnsBlockedWait = false;
+  /** True only for the synchronous body of handle.send plus its first microtask. */
+  private insideProviderSendSync = false;
   /**
    * 当前进行中 turn 的发起来源(来自 send 的 opts.origin)。事件 fan-out 前打到
    * AgentEvent.turnOrigin 上,turn 终止(isTerminalTurnEvent)后清空 — 共享
@@ -656,10 +658,21 @@ export class Session {
       try {
         this.beginTurnControl(reservedTurnGeneration);
         onDispatching?.();
-        await this.handle.send(msg, {
-          ...handleOpts,
-          signal: reservation.abortController.signal,
-        });
+        this.insideProviderSendSync = true;
+        let sendPromise: Promise<void>;
+        try {
+          sendPromise = this.handle.send(msg, {
+            ...handleOpts,
+            signal: reservation.abortController.signal,
+          });
+        } catch (error) {
+          this.insideProviderSendSync = false;
+          throw error;
+        }
+        setTimeout(() => {
+          this.insideProviderSendSync = false;
+        }, 0);
+        await sendPromise;
       } catch (e) {
         if (e instanceof TurnDispatchRejectedError) {
           // The provider returned a trustworthy rejection before accepting any
@@ -1759,6 +1772,7 @@ export class Session {
   private resolveSessionTurnGeneration(queuedGeneration: number): number {
     const inFlightGeneration = this.sendReservation?.generation;
     const belongsToInFlightSend =
+      this.insideProviderSendSync &&
       this.inFlightSendOwnsBlockedWait &&
       typeof inFlightGeneration === 'number' &&
       inFlightGeneration === this.turnGeneration &&

--- a/packages/maker-core/src/session.ts
+++ b/packages/maker-core/src/session.ts
@@ -428,8 +428,10 @@ export class Session {
   private eventLoopAwaiting = false;
   /** The blocked next() that was pending when the current send entered handle.send. */
   private inFlightSendOwnsBlockedWait = false;
-  /** True only for the synchronous body of handle.send plus its first microtask. */
+  /** True from handle.send() start until that send settles. */
   private insideProviderSendSync = false;
+  /** Keep a leftover status/done tail on the generation that started it. */
+  private staleTerminalQueuedGeneration: number | null = null;
   /**
    * 当前进行中 turn 的发起来源(来自 send 的 opts.origin)。事件 fan-out 前打到
    * AgentEvent.turnOrigin 上,turn 终止(isTerminalTurnEvent)后清空 — 共享
@@ -659,20 +661,14 @@ export class Session {
         this.beginTurnControl(reservedTurnGeneration);
         onDispatching?.();
         this.insideProviderSendSync = true;
-        let sendPromise: Promise<void>;
         try {
-          sendPromise = this.handle.send(msg, {
+          await this.handle.send(msg, {
             ...handleOpts,
             signal: reservation.abortController.signal,
           });
-        } catch (error) {
+        } finally {
           this.insideProviderSendSync = false;
-          throw error;
         }
-        setTimeout(() => {
-          this.insideProviderSendSync = false;
-        }, 0);
-        await sendPromise;
       } catch (e) {
         if (e instanceof TurnDispatchRejectedError) {
           // The provider returned a trustworthy rejection before accepting any
@@ -1769,7 +1765,45 @@ export class Session {
    * 并像用户插话一样暂停 goal,scheduler 的 IM 转播则直接忽略,卡片永不 finalize
    * (review #944 第二轮)。
    */
-  private resolveSessionTurnGeneration(queuedGeneration: number): number {
+  private isIdleStatusEvent(event: AgentEvent): boolean {
+    if (event.type !== 'status') return false;
+    const data = event.data as { isRunning?: unknown } | null | undefined;
+    return data?.isRunning === false;
+  }
+
+  private isLeftoverTailEvent(event: AgentEvent): boolean {
+    return (
+      event.type === 'done' ||
+      this.isIdleStatusEvent(event) ||
+      (isTerminalAgentErrorEvent(event) && this.staleTerminalQueuedGeneration !== null)
+    );
+  }
+
+  private resolveSessionTurnGeneration(
+    waitStartGeneration: number,
+    observedGeneration: number,
+    event: AgentEvent,
+  ): number {
+    if (observedGeneration > waitStartGeneration) {
+      this.staleTerminalQueuedGeneration = null;
+      return observedGeneration;
+    }
+    const leftoverTail = this.isLeftoverTailEvent(event);
+    if (leftoverTail && this.staleTerminalQueuedGeneration !== null) {
+      const stamped = this.staleTerminalQueuedGeneration;
+      if (event.type === 'done' || isTerminalAgentErrorEvent(event)) {
+        this.staleTerminalQueuedGeneration = null;
+      }
+      return stamped;
+    }
+    if (leftoverTail && waitStartGeneration > 0 && waitStartGeneration < this.turnGeneration) {
+      if (event.type === 'done' || isTerminalAgentErrorEvent(event)) {
+        this.staleTerminalQueuedGeneration = null;
+      } else {
+        this.staleTerminalQueuedGeneration = waitStartGeneration;
+      }
+      return waitStartGeneration;
+    }
     const inFlightGeneration = this.sendReservation?.generation;
     const belongsToInFlightSend =
       this.insideProviderSendSync &&
@@ -1779,13 +1813,15 @@ export class Session {
       this.turnControlState?.generation === inFlightGeneration;
     if (belongsToInFlightSend) {
       this.inFlightSendOwnsBlockedWait = false;
+      this.staleTerminalQueuedGeneration = null;
       return inFlightGeneration;
     }
-    // The constructor wait starts at generation 0. The first send owns that wait.
-    if (queuedGeneration === 0 && this.turnGeneration > 0) {
+    if (waitStartGeneration === 0 && this.turnGeneration > 0) {
+      this.staleTerminalQueuedGeneration = null;
       return this.turnGeneration;
     }
-    return queuedGeneration;
+    this.staleTerminalQueuedGeneration = null;
+    return waitStartGeneration;
   }
 
   private fanOutEvent(
@@ -1803,6 +1839,8 @@ export class Session {
     if (event.sessionTurnGeneration === undefined) {
       event.sessionTurnGeneration = this.resolveSessionTurnGeneration(
         queuedGeneration,
+        observedGeneration,
+        event,
       );
     }
     this.observeTurnControl(event, observedGeneration);

--- a/packages/maker-core/src/session.ts
+++ b/packages/maker-core/src/session.ts
@@ -1751,13 +1751,23 @@ export class Session {
    * 并像用户插话一样暂停 goal,scheduler 的 IM 转播则直接忽略,卡片永不 finalize
    * (review #944 第二轮)。
    */
-  private fanOutEvent(event: AgentEvent, observedGeneration = this.turnGeneration): void {
+  private fanOutEvent(
+    event: AgentEvent,
+    observedGeneration = this.turnGeneration,
+    queuedGeneration = observedGeneration,
+  ): void {
     const isBackgroundEvent = event.turnScope === 'background';
     if (!isBackgroundEvent) this.lastEventAt = Date.now();
     this.lastEventType = event.type;
     const isCurrentGeneration = observedGeneration === this.turnGeneration;
+    if (event.sessionInstanceId === undefined) {
+      event.sessionInstanceId = this.instanceId;
+    }
     if (event.sessionTurnGeneration === undefined) {
-      event.sessionTurnGeneration = observedGeneration;
+      // Stamp the generation that owned this next() wait, not an adopted later
+      // generation. A leftover terminal dequeued after the next send must keep
+      // the older value so host can fence it.
+      event.sessionTurnGeneration = queuedGeneration;
     }
     this.observeTurnControl(event, observedGeneration);
     // fan-out 前打 turn origin(所有 listener 拿到同一份);事件对象由 translator
@@ -2140,7 +2150,7 @@ export class Session {
         if (this.terminationStarted) continue;
         // origin 打标与终态清理都收在 fanOutEvent 里（看门狗合成的事件共用同一语义，
         // 见那里的注释）。关闭门一旦占住，旧 handle 的迟到事件不得再改写业务状态。
-        this.fanOutEvent(event, observedGeneration);
+        this.fanOutEvent(event, observedGeneration, awaitingGeneration);
       }
     } catch (e) {
       this.logger.error('event loop crashed', { error: String(e) });

--- a/packages/maker-core/src/session.ts
+++ b/packages/maker-core/src/session.ts
@@ -1756,6 +1756,9 @@ export class Session {
     if (!isBackgroundEvent) this.lastEventAt = Date.now();
     this.lastEventType = event.type;
     const isCurrentGeneration = observedGeneration === this.turnGeneration;
+    if (event.sessionTurnGeneration === undefined) {
+      event.sessionTurnGeneration = observedGeneration;
+    }
     this.observeTurnControl(event, observedGeneration);
     // fan-out 前打 turn origin(所有 listener 拿到同一份);事件对象由 translator
     // 每次新建、看门狗每次合成,不会串台。=== undefined 守卫:不覆盖 agent 自带的。

--- a/packages/maker-core/src/session.ts
+++ b/packages/maker-core/src/session.ts
@@ -1809,6 +1809,9 @@ export class Session {
   ): number {
     if (observedGeneration > waitStartGeneration) {
       this.staleTerminalQueuedGeneration = null;
+      if (this.isNewTurnProgressEvent(event)) {
+        this.pendingPriorGeneration = null;
+      }
       return observedGeneration;
     }
     const prior = this.pendingPriorGeneration;
@@ -1850,6 +1853,9 @@ export class Session {
     if (belongsToInFlightSend) {
       this.inFlightSendOwnsBlockedWait = false;
       this.staleTerminalQueuedGeneration = null;
+      if (this.isNewTurnProgressEvent(event)) {
+        this.pendingPriorGeneration = null;
+      }
       return inFlightGeneration;
     }
     if (prior !== null && isTerminalAgentErrorEvent(event) && waitStartGeneration !== 0) {
@@ -1863,9 +1869,10 @@ export class Session {
     }
     if (this.isNewTurnProgressEvent(event)) {
       // New-turn tokens prove this generation owns later product terminals.
-      // Keep a leftover idle/error tail on its queued generation so a late
-      // done after first tokens still matches the register fence.
+      // Drop a leftover idle-only tail too: if that old done is lost, the
+      // live done must not inherit staleQueued and get fenced.
       this.pendingPriorGeneration = null;
+      this.staleTerminalQueuedGeneration = null;
     }
     return waitStartGeneration;
   }

--- a/packages/maker-core/src/session.turn-stall.test.ts
+++ b/packages/maker-core/src/session.turn-stall.test.ts
@@ -260,6 +260,32 @@ describe('Session turn stall watchdog', () => {
     }
   });
 
+  it('stamps dequeued terminals with the queued generation and Session instance', async () => {
+    vi.useFakeTimers();
+    try {
+      const stub = createStubHandle();
+      const session = createSession(stub);
+      const seen: AgentEvent[] = [];
+      session.onEvent((ev) => seen.push(ev));
+
+      await session.send('first');
+      expect(session.getTurnGeneration()).toBe(1);
+      stub.endTurn();
+      await session.send('second');
+      expect(session.getTurnGeneration()).toBe(2);
+      stub.endTurn();
+      stub.pushEvent({ type: 'done', data: {}, source: 'claude-code' } as AgentEvent);
+      await vi.advanceTimersByTimeAsync(0);
+
+      const done = seen.find((ev) => ev.type === 'done');
+      // next() started at construction (generation 0) and stayed pending across both sends.
+      expect(done?.sessionTurnGeneration).toBe(0);
+      expect(done?.sessionInstanceId).toBe(session.instanceId);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('合成的超时 error 带 turnOrigin,并在 fan-out 后清空(review 第二轮)', async () => {
     // 不带 origin 的话:goal-host 把它归类成 origin:'other' 并像用户插话一样暂停 goal,
     // scheduler 的 IM 转播则直接忽略这条终态,卡片永不 finalize。

--- a/packages/maker-core/src/session.turn-stall.test.ts
+++ b/packages/maker-core/src/session.turn-stall.test.ts
@@ -278,8 +278,9 @@ describe('Session turn stall watchdog', () => {
       await vi.advanceTimersByTimeAsync(0);
 
       const done = seen.find((ev) => ev.type === 'done');
-      // next() started at construction (generation 0) and stayed pending across both sends.
-      expect(done?.sessionTurnGeneration).toBe(0);
+      // The constructor wait starts at generation 0; the send that is current
+      // when that wait finally dequeues owns the event.
+      expect(done?.sessionTurnGeneration).toBe(2);
       expect(done?.sessionInstanceId).toBe(session.instanceId);
     } finally {
       vi.useRealTimers();

--- a/packages/maker-core/src/types/events.ts
+++ b/packages/maker-core/src/types/events.ts
@@ -168,11 +168,13 @@ export interface AgentEvent {
   /** Host-owned per-turn correlation for lifecycle bookkeeping; never comes from vendor metadata. */
   turnAttemptToken?: number;
   /**
-   * Session.turnGeneration observed when this event was dequeued. Late terminals
-   * from a previous attempt keep the older value so host can ignore them after
-   * reclaiming a leftover turn. Host-only; never vendor metadata.
+   * Session.turnGeneration captured when runEventLoop started the next() that
+   * dequeued this event. Adoption of a later generation must not overwrite it,
+   * so a leftover terminal keeps the older value after the next send. Host-only.
    */
   sessionTurnGeneration?: number;
+  /** Session.instanceId of the incarnation that dequeued this event. Host-only. */
+  sessionInstanceId?: string;
   /**
    * Provider-owned claim attached synchronously to a `done` boundary when that
    * boundary has an automatic continuation. Consumers pass it back to the

--- a/packages/maker-core/src/types/events.ts
+++ b/packages/maker-core/src/types/events.ts
@@ -168,6 +168,12 @@ export interface AgentEvent {
   /** Host-owned per-turn correlation for lifecycle bookkeeping; never comes from vendor metadata. */
   turnAttemptToken?: number;
   /**
+   * Session.turnGeneration observed when this event was dequeued. Late terminals
+   * from a previous attempt keep the older value so host can ignore them after
+   * reclaiming a leftover turn. Host-only; never vendor metadata.
+   */
+  sessionTurnGeneration?: number;
+  /**
    * Provider-owned claim attached synchronously to a `done` boundary when that
    * boundary has an automatic continuation. Consumers pass it back to the
    * session lifecycle API; unlike a live task-map sample it cannot race later


### PR DESCRIPTION
## 这次改了什么

### 摘要

任务已经结束、侧栏也不再转圈时，新消息仍可能被 desktop 当成「目标正忙」塞进输入队列，然后永远不跑。常见于 Pi：产品 turn 已经闲着，或进程已经卸掉，但 coordinator 还留着上一轮 `activeTurn`，或 tracker 的 dispatch boundary 没放。

本 PR 修这条假忙门，并给迟到终态加代次归属，避免旧 `done` / idle / leftover error 结算下一轮。活 session 已 idle、或 live probe 明确返回「没有进程」时，走现有 250ms grace 后收口边界并 drain。owner-boundary 查询失败仍然 fail-closed。

这不是 desktop-only。`packages/maker-core` 的 `resolveSessionTurnGeneration` / `fanOutEvent` 会给每条前台事件打 `sessionTurnGeneration`，并用 `isLeftoverProductTerminal` 在扇出前丢掉 leftover 终态。所有 `Session.onEvent` 听众都会吃到这个门，包括 desktop persist / coordinator、goal-host、scheduler-host、IM turnRunner、learn-host、hook-control。故意放在 Session 里：旧终态不能再触发下一轮的 persist、tracker、goal 收口或 IM 卡片。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：假忙 dispatch boundary 收口；maker-core 事件代次归属与 leftover 终态扇出门；相关回归测试
- 明确不包含：Pi translator 事件顺序、崩溃恢复暂停队列、用户 Stop / recovery 语义、MCP session 协议、右侧栏 pin、解挂任何现存卡住的 session
- 用户可见变化：已结束的任务再收到新消息时，应在约 250ms 内自动开跑，而不是只进队不跑。旧轮迟到终态不再结算新轮。
- 是否存在 breaking change：无。`sessionTurnGeneration` / `sessionInstanceId` 是 host-only，renderer 侧已脱敏。

### UI 变化

- 引用的设计规范：不涉及。无 renderer、样式或文案变化。

### maker-core §3.4

- (a) 指标：3.2 热路径、3.3 事件归属。不改 translator 顺序，不改 prompt / cache。
- (b) 方法：代码抽查 `resolveSessionTurnGeneration` 公共路径是整数比较 + `event.type` 判断，无同步 IO、无正则、无深拷贝、不在 `handle.send` 上加网络。事件流覆盖 leftover idle/done、N+1 401、silent-stop、image、background `tool_result_full`、预派发取消回滚。
- (c) 结论：`session.origin.test.ts` + `session.turn-stall.test.ts` + `maker.test.ts` 149 个测试约 2.0s（含 setup）。stamp 是 O(1) 比较，没有可测的吞吐 / 延迟回退。

## 怎么验证的

### 自动验证

```text
pnpm --filter @cindy/maker-core exec vitest run \
  src/session.origin.test.ts src/session.turn-stall.test.ts src/maker.test.ts
结果：3 files / 149 tests passed

pnpm --filter desktop exec vitest run \
  src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts \
  src/main/__tests__/makerEventHotPathOrdering.test.ts
结果：通过

pnpm --filter desktop run typecheck
pnpm --filter @cindy/maker-core run typecheck
结果：通过
```

### 手工验证

不涉及。本机正在跑的 Cindy 包不会热更到本分支。

### 未执行的验证

实机：下一版里对已完成的 Pi 任务再丢一条消息，确认不再只进队不跑。用户可执行。

## 风险

### 风险分类

- [x] 其他：可能把「Session.send 已受理、agent_start 尚未到达」的窗口误收口。缓解：live `isTurnRunning()` 覆盖 send reservation；仍保留 250ms grace；probe throw 继续 fail-closed。
- leftover 终态不再扇出给 goal / scheduler / IM / hook-control。只拦 `resolvedGeneration < turnGeneration` 的产品终态；当前轮 401 / silent-stop / 合法 `done` 仍会广播。

### 影响与回滚

- 影响范围：desktop 输入队列 drain / send_to_session 撞忙入队；maker-core `Session.onEvent` 扇出（goal-host / scheduler-host / IM turnRunner / learn-host / hook-control / persist / coordinator）。CC / Codex / Pi 共用。
- 回滚 / 降级方式：revert 本分支。
- 远程 / 手机：不改 workdir 读写、不新增 IPC / push、不改 device-link 重试。手机和远程控制仍走同一条 coordinator drain；假忙解开后，它们排队的消息也会被派发。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
