### PR TITLE
feat(mobile): 手机远程任务搜索对齐桌面侧栏

### DIFF
--- a/apps/desktop/src/main/localDb/__tests__/conversationSearchIpc.test.ts
+++ b/apps/desktop/src/main/localDb/__tests__/conversationSearchIpc.test.ts
@@ -43,6 +43,21 @@ beforeEach(() => {
   });
 });
 
+describe('local-db:conversations:search — agentKind=pi', () => {
+  it('accepts filters.agentKind pi so remote Pi search is not rejected', async () => {
+    await handler()(null, {
+      query: 'needle',
+      filters: { agentKind: 'pi' },
+    });
+
+    expect(h.searchConversations).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filters: expect.objectContaining({ agentKind: 'pi' }),
+      }),
+    );
+  });
+});
+
 describe('local-db:conversations:search — workingDirs 透传', () => {
   it('keeps filters.workingDirs so project search is not widened to all sessions', async () => {
     await handler()(null, {

--- a/apps/desktop/src/main/localDb/ipc/search.ts
+++ b/apps/desktop/src/main/localDb/ipc/search.ts
@@ -14,7 +14,7 @@ import { optionalEnum, requireObject, throwIpcError } from '../../utils/ipcValid
 const SORT_VALUES = ['relevance', 'activityDesc', 'activityAsc'] as const;
 const SEMANTIC_MODE_VALUES = ['hybrid', 'keyword'] as const;
 const STATUS_VALUES = ['active', 'archived', 'all'] as const;
-const AGENT_VALUES = ['all', 'cc', 'codex'] as const;
+const AGENT_VALUES = ['all', 'cc', 'codex', 'pi'] as const;
 const LAST_ACTIVITY_VALUES = ['all', '1d', '3d', '7d', '30d'] as const;
 
 export function registerSearchIpc(): void {

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/ConversationSearchBox.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/ConversationSearchBox.tsx
@@ -136,6 +136,7 @@ const AGENT_OPTIONS: ReadonlyArray<Option<ConversationSearchAgentFilter>> = [
   { value: 'all', labelKey: 'ccAgent.sidebar.filterVendor.all' },
   { value: 'cc', labelKey: 'ccAgent.sidebar.filterVendor.cc' },
   { value: 'codex', labelKey: 'ccAgent.sidebar.filterVendor.codex' },
+  { value: 'pi', labelKey: 'ccAgent.sidebar.filterVendor.pi' },
 ];
 
 const LAST_ACTIVITY_OPTIONS: ReadonlyArray<Option<ConversationSearchLastActivityFilter>> = [

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -7899,8 +7899,9 @@
       },
       "filterVendor": {
         "all": "All",
-        "cc": "Claude",
-        "codex": "Codex"
+        "cc": "Claude Code",
+        "codex": "Codex",
+        "pi": "Pi"
       },
       "filterGroupBy": {
         "project": "Group by project",
@@ -8421,7 +8422,7 @@
       },
       "filterAria": "Search filters and sort (Sort: {{sort}}, Status: {{status}}, Agent: {{agent}}, Last activity: {{lastActivity}}, Projects: {{projects}})",
       "filter": {
-        "label": "Filters",
+        "label": "Search criteria",
         "active": "{{count}} filters",
         "reset": "Reset",
         "allProjects": "All projects"

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -7887,8 +7887,9 @@
       },
       "filterVendor": {
         "all": "すべて",
-        "cc": "Claude",
-        "codex": "Codex"
+        "cc": "Claude Code",
+        "codex": "Codex",
+        "pi": "Pi"
       },
       "filterGroupBy": {
         "project": "プロジェクトでグループ化",
@@ -8409,7 +8410,7 @@
       },
       "filterAria": "検索フィルターと並び順（並び順：{{sort}}、状態：{{status}}、エージェント：{{agent}}、最近のアクティビティ：{{lastActivity}}、プロジェクト：{{projects}}）",
       "filter": {
-        "label": "フィルター",
+        "label": "検索条件",
         "active": "フィルター {{count}} 件",
         "reset": "リセット",
         "allProjects": "すべてのプロジェクト"

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -7887,8 +7887,9 @@
       },
       "filterVendor": {
         "all": "전체",
-        "cc": "Claude",
-        "codex": "Codex"
+        "cc": "Claude Code",
+        "codex": "Codex",
+        "pi": "Pi"
       },
       "filterGroupBy": {
         "project": "프로젝트별 그룹",
@@ -8409,7 +8410,7 @@
       },
       "filterAria": "검색 필터 및 정렬(정렬: {{sort}}, 상태: {{status}}, 에이전트: {{agent}}, 최근 활성: {{lastActivity}}, 프로젝트: {{projects}})",
       "filter": {
-        "label": "필터",
+        "label": "검색 조건",
         "active": "필터 {{count}}개",
         "reset": "초기화",
         "allProjects": "모든 프로젝트"

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -7887,8 +7887,9 @@
       },
       "filterVendor": {
         "all": "全部",
-        "cc": "Claude",
-        "codex": "Codex"
+        "cc": "Claude Code",
+        "codex": "Codex",
+        "pi": "Pi"
       },
       "filterGroupBy": {
         "project": "按项目分组",
@@ -8409,7 +8410,7 @@
       },
       "filterAria": "搜索筛选与排序（排序：{{sort}}，状态：{{status}}，Agent：{{agent}}，最近活跃：{{lastActivity}}，项目：{{projects}}）",
       "filter": {
-        "label": "筛选",
+        "label": "搜索条件",
         "active": "筛选 {{count}}",
         "reset": "重置",
         "allProjects": "所有项目"

--- a/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
@@ -7887,8 +7887,9 @@
       },
       "filterVendor": {
         "all": "全部",
-        "cc": "Claude",
-        "codex": "Codex"
+        "cc": "Claude Code",
+        "codex": "Codex",
+        "pi": "Pi"
       },
       "filterGroupBy": {
         "project": "按專案分組",
@@ -8409,7 +8410,7 @@
       },
       "filterAria": "搜尋篩選與排序（排序：{{sort}}，狀態：{{status}}，Agent：{{agent}}，最近活躍：{{lastActivity}}，專案：{{projects}}）",
       "filter": {
-        "label": "篩選",
+        "label": "搜尋條件",
         "active": "篩選 {{count}}",
         "reset": "重置",
         "allProjects": "所有專案"

--- a/apps/mobile/app/devices/[deviceId].tsx
+++ b/apps/mobile/app/devices/[deviceId].tsx
@@ -9,8 +9,8 @@ import {
   View,
   useWindowDimensions,
 } from 'react-native';
-import { Text, TextInput } from '@/components/AppText';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import { Text } from '@/components/AppText';
+import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
 import type { TFunction } from 'i18next';
 import { ConnectionBanner, useShowConnectionBanner } from '@/components/ConnectionBanner';
@@ -60,6 +60,10 @@ import {
   type MobileSessionBulkAction,
 } from '@/session/sessionSelection';
 import { serializeNewSessionDeviceOptions } from '@/session/newSession';
+import { ConversationSearchFilterSheet } from '@/session/ConversationSearchFilterSheet';
+import { HomeSearchBar } from '@/session/HomeSearchBar';
+import { listConversationSearchProjects, shouldReplaceListWithSearchResults } from '@/session/conversationSearch';
+import { useConversationSearch } from '@/session/useConversationSearch';
 import { sessionMatchesProjectDir } from '@/session/mobileHome';
 import { HomeSessionRow } from './index';
 import { RenameSessionModal } from '@/session/RenameSessionModal';
@@ -159,12 +163,45 @@ export default function DeviceDetailScreen() {
   );
   const [filtersOpen, setFiltersOpen] = useState(false);
   const [searchOpen, setSearchOpen] = useState(false);
-  const [searchQuery, setSearchQuery] = useState('');
+  const [searchFilterOpen, setSearchFilterOpen] = useState(false);
+  const insets = useSafeAreaInsets();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   // 熔断 open(电脑端未响应):relay 可能仍 online,可见性与 banner 文案单独入参。
   const unresponsiveDevices = useUnresponsiveDevices();
   const deviceUnresponsive = !!deviceId && unresponsiveDevices.has(deviceId);
+  const searchOrigins = useMemo(() => (deviceId ? [{
+    deviceId,
+    deviceName,
+    reachable: !deviceUnresponsive,
+  }] : []), [deviceId, deviceName, deviceUnresponsive]);
+  const searchProjects = useMemo(
+    () => listConversationSearchProjects(sessions, deviceId ? new Set([deviceId]) : undefined),
+    [deviceId, sessions],
+  );
+  const visibleSearchProjectKeys = useMemo(
+    () => searchProjects.map((project) => project.key),
+    [searchProjects],
+  );
+  const indexedSearch = useConversationSearch({
+    enabled: !automationScopeKey && !!deviceId,
+    lockedWorkingDirs: projectWorkingDir ? [projectWorkingDir] : null,
+    origins: searchOrigins,
+    visibleProjectKeys: visibleSearchProjectKeys,
+  });
+  const searchQuery = indexedSearch.query;
+  const setSearchQuery = indexedSearch.setQuery;
+  const searchFilterA11y = t('devices.list.search.filterAria', {
+    agent: t(`devices.list.search.filter.agent.${indexedSearch.agentFilter}`),
+    lastActivity: t(`devices.list.search.filter.lastActivity.${indexedSearch.lastActivityFilter}`),
+    projects: projectWorkingDir
+      ? (projectName ?? projectWorkingDir)
+      : indexedSearch.projectSelection === 'all'
+        ? t('devices.list.search.filter.allProjects')
+        : t('devices.list.search.filter.selectedProjects', { count: indexedSearch.projectSelection.length }),
+    sort: t(`devices.list.search.filter.sort.${indexedSearch.sortBy}`),
+    status: t(`devices.list.search.filter.status.${indexedSearch.statusFilter}`),
+  });
   // 自动化 / 项目分支视图的条件挂载 banner:普通弱网断线也要有可见信号(防闪延迟后)
   const showConnectionBanner = useShowConnectionBanner(status, error, connectionIssue, deviceUnresponsive);
   const [lastSyncedAt, setLastSyncedAt] = useState<number | null>(null);
@@ -321,16 +358,22 @@ export default function DeviceDetailScreen() {
     }),
     [automationScopeKey, messagePreviewIndex, pendingInteractionIndex, scheduleIndex, searchQuery, sessions, statusFilter, t],
   );
+  const displaySections = useMemo(() => {
+    if (automationScopeKey || !shouldReplaceListWithSearchResults(searchQuery, indexedSearch.status)) {
+      return sections;
+    }
+    return [{ key: 'search', title: '', data: indexedSearch.results }];
+  }, [automationScopeKey, indexedSearch.results, indexedSearch.status, searchQuery, sections]);
   const listContext = useMemo(
     () => buildRemoteSessionListContext({
       overview: filterCounts,
       searchQuery,
-      sections,
+      sections: displaySections,
       statusFilter,
     }),
-    [filterCounts, searchQuery, sections, statusFilter],
+    [displaySections, filterCounts, searchQuery, statusFilter],
   );
-  const visibleSessionIds = useMemo(() => visibleSessionIdsFromSections(sections), [sections]);
+  const visibleSessionIds = useMemo(() => visibleSessionIdsFromSections(displaySections), [displaySections]);
   const selectedSessionIdSet = useMemo(() => new Set(selectedSessionIds), [selectedSessionIds]);
   const selectedSessions = useMemo(() => {
     const selected = new Set(selectedSessionIds);
@@ -516,17 +559,38 @@ export default function DeviceDetailScreen() {
   }, [bulkActionSummaries, t]);
 
   const actionOverlays = (
-    <SessionListActionOverlays
-      actionSheetSession={actionSheetSession}
-      closeRenameSession={closeRenameSession}
-      confirmRenameSession={confirmRenameSession}
-      handleSessionSheetAction={handleSessionSheetAction}
-      handleSessionSheetClosed={handleSessionSheetClosed}
-      renameSessionDraft={renameSessionDraft}
-      renameSessionTarget={renameSessionTarget}
-      setActionSheetSession={setActionSheetSession}
-      setRenameSessionDraft={setRenameSessionDraft}
-    />
+    <>
+      <ConversationSearchFilterSheet
+        activeCount={indexedSearch.activeFilterCount}
+        agentKind={indexedSearch.agentFilter}
+        lastActivity={indexedSearch.lastActivityFilter}
+        lockedProjects={!!projectWorkingDir}
+        onAgentKindChange={indexedSearch.setAgentFilter}
+        onClose={() => setSearchFilterOpen(false)}
+        onLastActivityChange={indexedSearch.setLastActivityFilter}
+        onProjectsChange={indexedSearch.setProjectSelection}
+        onReset={indexedSearch.resetFilters}
+        onSortChange={indexedSearch.setSortBy}
+        onStatusChange={indexedSearch.setStatusFilter}
+        projectSelection={indexedSearch.projectSelection}
+        projects={searchProjects}
+        sortBy={indexedSearch.sortBy}
+        status={indexedSearch.statusFilter}
+        topOffset={insets.top + 56}
+        visible={searchFilterOpen}
+      />
+      <SessionListActionOverlays
+        actionSheetSession={actionSheetSession}
+        closeRenameSession={closeRenameSession}
+        confirmRenameSession={confirmRenameSession}
+        handleSessionSheetAction={handleSessionSheetAction}
+        handleSessionSheetClosed={handleSessionSheetClosed}
+        renameSessionDraft={renameSessionDraft}
+        renameSessionTarget={renameSessionTarget}
+        setActionSheetSession={setActionSheetSession}
+        setRenameSessionDraft={setRenameSessionDraft}
+      />
+    </>
   );
 
   // 自动化任务作用域(从组行「查看全部 N 次运行」进入):干净布局 —— 头部 + 该任务全部运行的
@@ -648,8 +712,41 @@ export default function DeviceDetailScreen() {
             status={status}
           />
         ) : null}
+        <View style={styles.projectSearchChrome}>
+          {searchOpen || !!searchQuery.trim() ? (
+            <HomeSearchBar
+              autoFocus={searchOpen && !searchQuery}
+              filterA11y={searchFilterA11y}
+              filterActive={indexedSearch.activeFilterCount > 0}
+              onChangeQuery={setSearchQuery}
+              onOpenFilter={() => setSearchFilterOpen(true)}
+              padded={false}
+              query={searchQuery}
+              testIDs={{
+                clear: 'deviceDetail.projectSearchCloseButton',
+                filter: 'deviceDetail.projectSearchFilterButton',
+                input: 'deviceDetail.projectSearchInput',
+                row: 'deviceDetail.projectSearchRow',
+              }}
+            />
+          ) : (
+            <MainWindowActionGroup
+              density="compact"
+              secondaryActions={[
+                {
+                  accessibilityLabel: t('devices.detail.search.openA11y'),
+                  active: false,
+                  label: t('devices.detail.search.label'),
+                  onPress: () => setSearchOpen(true),
+                  testID: 'deviceDetail.projectSearchToggleButton',
+                },
+              ]}
+              testID="deviceDetail.projectSearchActions"
+            />
+          )}
+        </View>
         <SectionList
-          sections={sections}
+          sections={displaySections}
           keyExtractor={(item) => item.automationGroup?.key ?? item.session.id}
           refreshControl={<RefreshControl refreshing={loading} onRefresh={loadSessions} />}
           stickySectionHeadersEnabled={false}
@@ -677,14 +774,14 @@ export default function DeviceDetailScreen() {
           ) : (
             <MainWindowEmptyState
               centered
-              copy={t('devices.detail.projectScope.emptyCopy')}
+              copy={searchQuery.trim() ? deviceSessionEmptyState(statusFilter, searchQuery).copy : t('devices.detail.projectScope.emptyCopy')}
               style={{
                 marginTop: spacing.xxl,
                 minHeight: windowLayout.emptyMinHeight,
                 padding: windowLayout.emptyPadding,
               }}
               testID="deviceDetail.projectEmpty"
-              title={t('devices.detail.projectScope.emptyTitle')}
+              title={searchQuery.trim() ? deviceSessionEmptyState(statusFilter, searchQuery).title : t('devices.detail.projectScope.emptyTitle')}
             />
           )}
         />
@@ -837,36 +934,21 @@ export default function DeviceDetailScreen() {
         </View>
 
         {searchOpen || !!searchQuery.trim() ? (
-          <View style={styles.searchRow}>
-            <TextInput
-              accessibilityLabel={t('devices.detail.search.openA11y')}
-              autoCapitalize="none"
-              autoCorrect={false}
-              autoFocus={searchOpen && !searchQuery}
-              onChangeText={setSearchQuery}
-              placeholder={t('devices.detail.search.placeholder')}
-              placeholderTextColor={colors.textTertiary}
-              style={styles.searchInput}
-              testID="deviceDetail.searchInput"
-              value={searchQuery}
-            />
-            <MainWindowActionButton
-              action={{
-                accessibilityLabel: searchQuery.trim() ? t('devices.detail.search.clearA11y') : t('devices.detail.search.closeInputA11y'),
-                label: searchQuery.trim() ? t('devices.detail.search.clear') : t('devices.detail.search.close'),
-                onPress: () => {
-                  if (searchQuery.trim()) {
-                    setSearchQuery('');
-                    return;
-                  }
-                  setSearchOpen(false);
-                },
-                testID: 'deviceDetail.searchCloseButton',
-              }}
-              density="compact"
-              style={styles.searchCloseButton}
-            />
-          </View>
+          <HomeSearchBar
+            autoFocus={searchOpen && !searchQuery}
+            filterA11y={searchFilterA11y}
+            filterActive={indexedSearch.activeFilterCount > 0}
+            onChangeQuery={setSearchQuery}
+            onOpenFilter={() => setSearchFilterOpen(true)}
+            padded={false}
+            query={searchQuery}
+            testIDs={{
+              clear: 'deviceDetail.searchCloseButton',
+              filter: 'deviceDetail.searchFilterButton',
+              input: 'deviceDetail.searchInput',
+              row: 'deviceDetail.searchRow',
+            }}
+          />
         ) : null}
 
         {filtersOpen ? (
@@ -1005,7 +1087,7 @@ export default function DeviceDetailScreen() {
       </View>
 
       <SectionList
-        sections={sections}
+        sections={displaySections}
         keyExtractor={(item) => item.automationGroup?.key ?? item.session.id}
         refreshControl={<RefreshControl refreshing={loading} onRefresh={loadSessions} />}
         stickySectionHeadersEnabled={false}
@@ -1018,7 +1100,7 @@ export default function DeviceDetailScreen() {
         ]}
         testID="deviceDetail.sessionList"
         renderSectionHeader={({ section }) => (
-          <Text style={styles.sectionTitle}>{section.title}</Text>
+          section.title ? <Text style={styles.sectionTitle}>{section.title}</Text> : null
         )}
         ListEmptyComponent={suppressListEmptyState ? (
           <RemoteListSyncingPlaceholder testID="deviceDetail.syncing" />
@@ -1259,6 +1341,10 @@ const makeStyles = (colors: ThemeColors) => StyleSheet.create({
     fontSize: typeScale.caption,
     fontWeight: fontWeight.medium,
     minWidth: 0,
+  },
+  projectSearchChrome: {
+    paddingHorizontal: spacing.lg,
+    paddingTop: spacing.sm,
   },
   searchRow: {
     alignItems: 'center',

--- a/apps/mobile/app/devices/[deviceId].tsx
+++ b/apps/mobile/app/devices/[deviceId].tsx
@@ -179,15 +179,11 @@ export default function DeviceDetailScreen() {
     () => listConversationSearchProjects(sessions, deviceId ? new Set([deviceId]) : undefined),
     [deviceId, sessions],
   );
-  const visibleSearchProjectKeys = useMemo(
-    () => searchProjects.map((project) => project.key),
-    [searchProjects],
-  );
   const indexedSearch = useConversationSearch({
     enabled: !automationScopeKey && !!deviceId,
     lockedWorkingDirs: projectWorkingDir ? [projectWorkingDir] : null,
     origins: searchOrigins,
-    visibleProjectKeys: visibleSearchProjectKeys,
+    projects: searchProjects,
   });
   const searchQuery = indexedSearch.query;
   const setSearchQuery = indexedSearch.setQuery;
@@ -428,7 +424,7 @@ export default function DeviceDetailScreen() {
     setBulkNotice(null);
   }, []);
 
-  const openSession = useCallback((targetSessionId: string) => {
+  const openSession = useCallback((targetSessionId: string, focusClientId?: string) => {
     if (swipeRegistry.closeOpenRow()) return;
     // 打开会话是远端交互,用当前(可达)设备 endpoint = 页面级 deviceId(对被认领会话即 canonical 当前设备,
     // 其物理机就是当前设备、可达)。不用会话物理旧 shard id:re-link 后旧设备不可达会导致会话根本打不开。
@@ -436,7 +432,12 @@ export default function DeviceDetailScreen() {
     // 副本)的本地乐观回显不完美是已知限制,与 Home 页固有一致(见 PR 描述「已知限制」)。
     guardedPush({
       pathname: '/sessions/[sessionId]',
-      params: { sessionId: targetSessionId, deviceId, deviceName },
+      params: {
+        sessionId: targetSessionId,
+        deviceId,
+        deviceName,
+        ...(focusClientId ? { focusClientId } : {}),
+      },
     });
   }, [deviceId, deviceName, guardedPush, swipeRegistry]);
 
@@ -648,7 +649,10 @@ export default function DeviceDetailScreen() {
           renderItem={({ item }) => (
             <DeviceDetailSessionRow
               item={item}
-              onOpenSession={(it) => openSession(it.session.id)}
+              onOpenSession={(it) => openSession(
+                it.session.id,
+                'searchFocusClientId' in it ? (it as { searchFocusClientId?: string }).searchFocusClientId : undefined,
+              )}
               swipe={sessionSwipeControls}
               testID={`deviceDetail.automationRunRow.${item.session.id}`}
             />
@@ -719,6 +723,7 @@ export default function DeviceDetailScreen() {
               filterA11y={searchFilterA11y}
               filterActive={indexedSearch.activeFilterCount > 0}
               onChangeQuery={setSearchQuery}
+              onDismiss={() => setSearchOpen(false)}
               onOpenFilter={() => setSearchFilterOpen(true)}
               padded={false}
               query={searchQuery}
@@ -762,7 +767,10 @@ export default function DeviceDetailScreen() {
               hideDivider={!!section.data[index + 1]?.automationGroup}
               item={item}
               onOpenAutomationGroup={openAutomationGroup}
-              onOpenSession={(it) => openSession(it.session.id)}
+              onOpenSession={(it) => openSession(
+                it.session.id,
+                'searchFocusClientId' in it ? (it as { searchFocusClientId?: string }).searchFocusClientId : undefined,
+              )}
               onToggleAutomationGroup={toggleAutomationGroup}
               suppressBlockTopBorder={!!section.data[index - 1]?.automationGroup}
               swipe={sessionSwipeControls}
@@ -1123,7 +1131,10 @@ export default function DeviceDetailScreen() {
             item={item}
             onLongPress={() => beginSelection(sessionIdsForListItem(item))}
             onOpenAutomationGroup={item.automationGroup ? openAutomationGroup : undefined}
-            onOpenSession={(it) => openSession(it.session.id)}
+            onOpenSession={(it) => openSession(
+                it.session.id,
+                'searchFocusClientId' in it ? (it as { searchFocusClientId?: string }).searchFocusClientId : undefined,
+              )}
             onPressSelection={() => toggleSelection(sessionIdsForListItem(item))}
             onToggleAutomationGroup={toggleAutomationGroup}
             selected={sessionIdsForListItem(item).every((id) => selectedSessionIdSet.has(id))}

--- a/apps/mobile/app/devices/[deviceId].tsx
+++ b/apps/mobile/app/devices/[deviceId].tsx
@@ -62,7 +62,11 @@ import {
 import { serializeNewSessionDeviceOptions } from '@/session/newSession';
 import { ConversationSearchFilterSheet } from '@/session/ConversationSearchFilterSheet';
 import { HomeSearchBar } from '@/session/HomeSearchBar';
-import { listConversationSearchProjects, shouldReplaceListWithSearchResults } from '@/session/conversationSearch';
+import {
+  conversationSearchAllowsLocalWrites,
+  listConversationSearchProjects,
+  shouldReplaceListWithSearchResults,
+} from '@/session/conversationSearch';
 import { useConversationSearch } from '@/session/useConversationSearch';
 import { sessionMatchesProjectDir } from '@/session/mobileHome';
 import { HomeSessionRow } from './index';
@@ -1129,17 +1133,21 @@ export default function DeviceDetailScreen() {
           <DeviceDetailSessionRow
             expandedAutomationGroups={expandedAutomationGroups}
             item={item}
-            onLongPress={() => beginSelection(sessionIdsForListItem(item))}
+            onLongPress={conversationSearchAllowsLocalWrites(item)
+              ? () => beginSelection(sessionIdsForListItem(item))
+              : undefined}
             onOpenAutomationGroup={item.automationGroup ? openAutomationGroup : undefined}
             onOpenSession={(it) => openSession(
                 it.session.id,
                 'searchFocusClientId' in it ? (it as { searchFocusClientId?: string }).searchFocusClientId : undefined,
               )}
-            onPressSelection={() => toggleSelection(sessionIdsForListItem(item))}
+            onPressSelection={conversationSearchAllowsLocalWrites(item)
+              ? () => toggleSelection(sessionIdsForListItem(item))
+              : undefined}
             onToggleAutomationGroup={toggleAutomationGroup}
             selected={sessionIdsForListItem(item).every((id) => selectedSessionIdSet.has(id))}
             selectionMode={selectionMode}
-            swipe={sessionSwipeControls}
+            swipe={conversationSearchAllowsLocalWrites(item) ? sessionSwipeControls : undefined}
             testID="deviceDetail.sessionRow"
           />
         )}

--- a/apps/mobile/app/devices/index.tsx
+++ b/apps/mobile/app/devices/index.tsx
@@ -981,14 +981,10 @@ export default function HomeScreen() {
     ),
     [searchOrigins, sessions],
   );
-  const visibleSearchProjectKeys = useMemo(
-    () => searchProjects.map((project) => project.key),
-    [searchProjects],
-  );
   const indexedSearch = useConversationSearch({
     enabled: true,
     origins: searchOrigins,
-    visibleProjectKeys: visibleSearchProjectKeys,
+    projects: searchProjects,
   });
   const searchQuery = indexedSearch.query;
   const searchFilterA11y = t('devices.list.search.filterAria', {
@@ -1271,12 +1267,16 @@ export default function HomeScreen() {
       setError(t('devices.list.error.sessionDeviceNotFound'));
       return;
     }
+    const focusClientId = 'searchFocusClientId' in item
+      ? (item as { searchFocusClientId?: string }).searchFocusClientId
+      : undefined;
     guardedPush({
       pathname: '/sessions/[sessionId]',
       params: {
         deviceId,
         deviceName: session.deviceLinkDeviceName ?? deviceId,
         sessionId: session.id,
+        ...(focusClientId ? { focusClientId } : {}),
       },
     });
   }, [guardedPush, priorityContext, swipeRegistry, t]);

--- a/apps/mobile/app/devices/index.tsx
+++ b/apps/mobile/app/devices/index.tsx
@@ -95,6 +95,7 @@ import {
 } from '@/scheduler/remoteScheduleEvents';
 import { ConversationSearchFilterSheet } from '@/session/ConversationSearchFilterSheet';
 import {
+  conversationSearchAllowsLocalWrites,
   conversationSearchOriginsFromDeviceModels,
   listConversationSearchProjects,
   shouldReplaceListWithSearchResults,
@@ -968,6 +969,14 @@ export default function HomeScreen() {
     statusDetail: item.statusDetail,
     statusLabel: item.statusLabel,
   })), [deviceRows]);
+  useEffect(() => {
+    remoteSessionStore.setConversationSearchDeviceModels(deviceModels.map((item) => ({
+      canOpen: item.canOpen,
+      deviceId: item.deviceId,
+      name: item.name,
+      state: item.state,
+    })));
+  }, [deviceModels]);
   const searchOrigins = useMemo(() => conversationSearchOriginsFromDeviceModels(
     deviceModels,
     {
@@ -2661,7 +2670,7 @@ function ProjectRow({
             );
             // 与顶层同一条规则:普通会话子行挂滑动,自动化组行不挂(组行语义含混,
             // 其展开子行由 AutomationGroupChildren 内的透传包裹)。
-            if (!swipe || item.automationGroup) {
+            if (!swipe || item.automationGroup || !conversationSearchAllowsLocalWrites(item)) {
               return <Fragment key={item.automationGroup?.key ?? item.session.id}>{row}</Fragment>;
             }
             return (
@@ -2807,7 +2816,7 @@ function HomeListRowInner({
   // 普通会话行(含置顶区)在这里挂滑动操作;自动化组行不挂 —— 组行代表多次运行,
   // 「置顶/归档这一组」语义含混,但其展开的子行经 swipe 透传同样可滑。
   // 项目组子行 / 自动化子行的滑动在各自渲染路径内包裹;选择态不传 swipe。
-  if (item.item.automationGroup) return row;
+  if (item.item.automationGroup || !conversationSearchAllowsLocalWrites(item.item)) return row;
   return (
     <SwipeableSessionRow
       onArchive={onArchive}

--- a/apps/mobile/app/devices/index.tsx
+++ b/apps/mobile/app/devices/index.tsx
@@ -94,7 +94,11 @@ import {
   useRemoteScheduleMirrorInvalidations,
 } from '@/scheduler/remoteScheduleEvents';
 import { ConversationSearchFilterSheet } from '@/session/ConversationSearchFilterSheet';
-import { listConversationSearchProjects, shouldReplaceListWithSearchResults } from '@/session/conversationSearch';
+import {
+  conversationSearchOriginsFromDeviceModels,
+  listConversationSearchProjects,
+  shouldReplaceListWithSearchResults,
+} from '@/session/conversationSearch';
 import { useConversationSearch } from '@/session/useConversationSearch';
 import {
   buildMobileHomePresentation,
@@ -964,16 +968,13 @@ export default function HomeScreen() {
     statusDetail: item.statusDetail,
     statusLabel: item.statusLabel,
   })), [deviceRows]);
-  const searchOrigins = useMemo(() => {
-    const targets = selectedDeviceId
-      ? deviceModels.filter((item) => item.deviceId === selectedDeviceId)
-      : deviceModels.filter((item) => item.canOpen);
-    return targets.map((item) => ({
-      deviceId: item.deviceId,
-      deviceName: item.name,
-      reachable: item.canOpen && !unresponsiveDevices.has(item.deviceId),
-    }));
-  }, [deviceModels, selectedDeviceId, unresponsiveDevices]);
+  const searchOrigins = useMemo(() => conversationSearchOriginsFromDeviceModels(
+    deviceModels,
+    {
+      selectedDeviceId,
+      unresponsiveDeviceIds: unresponsiveDevices,
+    },
+  ), [deviceModels, selectedDeviceId, unresponsiveDevices]);
   const searchProjects = useMemo(
     () => listConversationSearchProjects(
       excludeOrcaWorkerSessions(sessions),

--- a/apps/mobile/app/devices/index.tsx
+++ b/apps/mobile/app/devices/index.tsx
@@ -60,6 +60,7 @@ import { HomeChromeDrawer } from '@/session/HomeChromeDrawer';
 import { HomeChromeFrost } from '@/session/HomeChromeFrost';
 import { HomeGlassMenuPanel, HomeMenuScrim } from '@/session/HomeGlassMenuPanel';
 import { HomeHeaderGlassButton } from '@/session/HomeHeaderGlassButton';
+import { HomeSearchBar } from '@/session/HomeSearchBar';
 import { buildMainWindowLayout } from '@/components/mainWindowLayout';
 import { useScreenEdgePadding } from '@/components/screenEdgeInsets';
 import { isAccessRevokedError } from '@/device-link/accessRevoked';
@@ -92,6 +93,9 @@ import {
   remoteScheduleEventStore,
   useRemoteScheduleMirrorInvalidations,
 } from '@/scheduler/remoteScheduleEvents';
+import { ConversationSearchFilterSheet } from '@/session/ConversationSearchFilterSheet';
+import { listConversationSearchProjects, shouldReplaceListWithSearchResults } from '@/session/conversationSearch';
+import { useConversationSearch } from '@/session/useConversationSearch';
 import {
   buildMobileHomePresentation,
   excludeOrcaWorkerSessions,
@@ -260,6 +264,8 @@ export default function HomeScreen() {
   const [error, setError] = useState<string | null>(null);
   const [lastSyncedAt, setLastSyncedAt] = useState<number | null>(null);
   const [selectedDeviceId, setSelectedDeviceId] = useState<string | null>(null);
+  const [searchOpen, setSearchOpen] = useState(false);
+  const [searchFilterOpen, setSearchFilterOpen] = useState(false);
   // 恢复偏好时暂存的设备名:设备列表尚未同步回来前表头用它兜底,避免显示成占位文案。
   const [restoredDeviceName, setRestoredDeviceName] = useState<string | null>(null);
   // 用户已手动切换过筛选/分组后,迟到的偏好恢复不再覆盖用户操作。
@@ -958,6 +964,42 @@ export default function HomeScreen() {
     statusDetail: item.statusDetail,
     statusLabel: item.statusLabel,
   })), [deviceRows]);
+  const searchOrigins = useMemo(() => {
+    const targets = selectedDeviceId
+      ? deviceModels.filter((item) => item.deviceId === selectedDeviceId)
+      : deviceModels.filter((item) => item.canOpen);
+    return targets.map((item) => ({
+      deviceId: item.deviceId,
+      deviceName: item.name,
+      reachable: item.canOpen && !unresponsiveDevices.has(item.deviceId),
+    }));
+  }, [deviceModels, selectedDeviceId, unresponsiveDevices]);
+  const searchProjects = useMemo(
+    () => listConversationSearchProjects(
+      excludeOrcaWorkerSessions(sessions),
+      new Set(searchOrigins.map((origin) => origin.deviceId)),
+    ),
+    [searchOrigins, sessions],
+  );
+  const visibleSearchProjectKeys = useMemo(
+    () => searchProjects.map((project) => project.key),
+    [searchProjects],
+  );
+  const indexedSearch = useConversationSearch({
+    enabled: true,
+    origins: searchOrigins,
+    visibleProjectKeys: visibleSearchProjectKeys,
+  });
+  const searchQuery = indexedSearch.query;
+  const searchFilterA11y = t('devices.list.search.filterAria', {
+    agent: t(`devices.list.search.filter.agent.${indexedSearch.agentFilter}`),
+    lastActivity: t(`devices.list.search.filter.lastActivity.${indexedSearch.lastActivityFilter}`),
+    projects: indexedSearch.projectSelection === 'all'
+      ? t('devices.list.search.filter.allProjects')
+      : t('devices.list.search.filter.selectedProjects', { count: indexedSearch.projectSelection.length }),
+    sort: t(`devices.list.search.filter.sort.${indexedSearch.sortBy}`),
+    status: t(`devices.list.search.filter.status.${indexedSearch.statusFilter}`),
+  });
   useEffect(() => {
     const ids = deviceModels.filter((item) => item.canOpen).map((item) => item.deviceId);
     if (ids.length === 0) {
@@ -1052,14 +1094,14 @@ export default function HomeScreen() {
       messagePreviewIndex,
       pendingInteractionIndex,
       scheduleIndex,
-      searchQuery: '',
+      searchQuery,
       selectedDeviceId,
       sessions: homeSessions,
       statusFilter,
       // 未起名会话的显示文案:共享层不兜中文串,由这里给已解析的 i18n 值。
       unnamedLabel: t('session.menu.unnamedTitle'),
     }),
-    [deviceModels, liveActivityIndex, messagePreviewIndex, pendingInteractionIndex, scheduleIndex, selectedDeviceId, homeSessions, statusFilter, t],
+    [deviceModels, liveActivityIndex, messagePreviewIndex, pendingInteractionIndex, scheduleIndex, searchQuery, selectedDeviceId, homeSessions, statusFilter, t],
   );
   const runningSessionIds = useMemo(() => {
     const ids = new Set<string>();
@@ -1090,7 +1132,7 @@ export default function HomeScreen() {
   );
   const displayedProjectOrder = displayed.projectOrder;
   const displayedManualProjectOrder = displayed.manualProjectOrder;
-  const sections = useMemo(
+  const homeSections = useMemo(
     () => buildHomeSections(home, groupByProject, pinnedCollapsed, {
       dialogueTitle: t('devices.list.menu.dialogueFolder'),
       groupDialogue,
@@ -1101,6 +1143,22 @@ export default function HomeScreen() {
     }),
     [displayedManualProjectOrder, displayedProjectOrder, groupByProject, groupDialogue, home, pinnedCollapsed, priorityContext, sortBy, t],
   );
+  const sections = useMemo(() => {
+    if (!shouldReplaceListWithSearchResults(searchQuery, indexedSearch.status)) return homeSections;
+    return [{
+      data: indexedSearch.results.map((item) => ({
+        item,
+        key: `search:${(item.session as { deviceLinkDeviceId?: string | null }).deviceLinkDeviceId ?? 'local'}:${item.session.id}`,
+        kind: 'session' as const,
+        source: 'search' as const,
+        sourceLabel: selectedDeviceId
+          ? undefined
+          : ((item.session as { deviceLinkDeviceName?: string | null }).deviceLinkDeviceName ?? undefined),
+      })),
+      key: 'search',
+      title: null,
+    }];
+  }, [homeSections, indexedSearch.results, indexedSearch.status, searchQuery, selectedDeviceId]);
   if (displayedProjectOrder !== 'custom') {
     visualProjectKeysRef.current = sections.flatMap((section) => section.data)
       .filter((row): row is Extract<HomeRow, { kind: 'project' }> => row.kind === 'project')
@@ -1676,6 +1734,17 @@ export default function HomeScreen() {
         )}
         </View>
 
+        {searchOpen || !!searchQuery.trim() ? (
+          <HomeSearchBar
+            autoFocus={searchOpen && !searchQuery}
+            filterA11y={searchFilterA11y}
+            filterActive={indexedSearch.activeFilterCount > 0}
+            onChangeQuery={indexedSearch.setQuery}
+            onOpenFilter={() => setSearchFilterOpen(true)}
+            query={searchQuery}
+          />
+        ) : null}
+
         {showConnectionRow ? (
         <View
           style={[styles.connectionRow, (connectionError || activeConnectionIssue) && styles.connectionRowError]}
@@ -1730,6 +1799,7 @@ export default function HomeScreen() {
         onScrollBeginDrag={() => {
           // 列表开始滚动即收起已滑开的行(iOS 惯例,避免打开态跟着列表滚)。
           swipeRegistry.closeOpenRow();
+          if (!searchQuery.trim()) setSearchOpen(false);
         }}
         testID="devices.list"
         renderSectionHeader={({ section }) => {
@@ -1894,6 +1964,11 @@ export default function HomeScreen() {
           setChromeMenuCloseInstant(false);
           handleChromeMenuClosed();
         }}
+        onOpenSearch={() => {
+          setSearchOpen(true);
+          setChromeMenuCloseInstant(false);
+          setChromeMenuOpen(false);
+        }}
         onOpenSettings={() => {
           pendingMenuActionRef.current = null;
           guardedPush('/settings');
@@ -1902,6 +1977,25 @@ export default function HomeScreen() {
         }}
         open={chromeMenuOpen}
         user={user}
+      />
+      <ConversationSearchFilterSheet
+        activeCount={indexedSearch.activeFilterCount}
+        agentKind={indexedSearch.agentFilter}
+        lastActivity={indexedSearch.lastActivityFilter}
+        lockedProjects={false}
+        onAgentKindChange={indexedSearch.setAgentFilter}
+        onClose={() => setSearchFilterOpen(false)}
+        onLastActivityChange={indexedSearch.setLastActivityFilter}
+        onProjectsChange={indexedSearch.setProjectSelection}
+        onReset={indexedSearch.resetFilters}
+        onSortChange={indexedSearch.setSortBy}
+        onStatusChange={indexedSearch.setStatusFilter}
+        projectSelection={indexedSearch.projectSelection}
+        projects={searchProjects}
+        sortBy={indexedSearch.sortBy}
+        status={indexedSearch.statusFilter}
+        topOffset={chromeHeight}
+        visible={searchFilterOpen}
       />
       <HomeDisplaySettingsModal
         groupByProject={groupByProject}
@@ -2706,7 +2800,7 @@ function HomeListRowInner({
       sourceLabel={item.sourceLabel}
       suppressBlockTopBorder={prevIsBlock}
       swipe={swipe}
-      testID={homeSessionRowTestId(item.source)}
+      testID={item.source === 'search' ? 'home.searchSessionRow' : homeSessionRowTestId(item.source)}
     />
   );
   // 普通会话行(含置顶区)在这里挂滑动操作;自动化组行不挂 —— 组行代表多次运行,
@@ -2720,7 +2814,7 @@ function HomeListRowInner({
       onTogglePin={onTogglePin}
       registry={registry}
       session={item.item.session as RemoteSession}
-      testID={`${homeSessionRowTestId(item.source)}.swipe`}
+      testID={`${item.source === 'search' ? 'home.searchSessionRow' : homeSessionRowTestId(item.source)}.swipe`}
     >
       {row}
     </SwipeableSessionRow>

--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -2584,7 +2584,10 @@ export default function SessionScreen() {
   }, [navigation, sessionListDrawerOverlayMounted]);
   const handleDrawerSelectSession = useCallback((item: RemoteSessionListItem) => {
     const targetSession = item.session as RemoteSession;
-    if (targetSession.id === sessionId) {
+    const focusClientId = 'searchFocusClientId' in item
+      ? (item as { searchFocusClientId?: string }).searchFocusClientId
+      : undefined;
+    if (targetSession.id === sessionId && !focusClientId) {
       closeSessionListDrawer();
       return;
     }
@@ -2612,6 +2615,7 @@ export default function SessionScreen() {
         deviceId: targetDeviceId,
         deviceName: targetSession.deviceLinkDeviceName ?? targetDeviceId,
         sessionId: targetSession.id,
+        ...(focusClientId ? { focusClientId } : {}),
       });
     });
   }, [closeSessionListDrawer, navigation, queueDrawerNavigation, sessionId, t]);

--- a/apps/mobile/src/__tests__/conversationSearch.test.ts
+++ b/apps/mobile/src/__tests__/conversationSearch.test.ts
@@ -401,6 +401,7 @@ describe('helpers', () => {
     const item = toSearchListItem(hit, Date.parse('2026-08-19T00:00:00.000Z'), '未命名任务', cachedSessionForSearchResult(hit, cachedByKey));
     expect(item.searchLocallyCached).toBe(true);
     expect((item.session as RemoteSession).deviceLinkDeviceId).toBe('dev-a');
-    expect(conversationSearchAllowsLocalWrites(item)).toBe(true);
+    expect(conversationSearchAllowsLocalWrites(item)).toBe(false);
+    expect(conversationSearchAllowsLocalWrites({ session: { id: 'plain' } })).toBe(true);
   });
 });

--- a/apps/mobile/src/__tests__/conversationSearch.test.ts
+++ b/apps/mobile/src/__tests__/conversationSearch.test.ts
@@ -1,0 +1,287 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  conversationSearchActiveFilterCount,
+  isConversationSearchChannelNotAllowed,
+  listConversationSearchProjects,
+  nextConversationSearchProjectSelection,
+  reconcileConversationSearchProjectSelection,
+  searchCachedDeviceSessions,
+  searchConversationsAcrossDevices,
+  sessionBelongsToDevice,
+  shouldReplaceListWithSearchResults,
+  toSearchListItem,
+  type ConversationSearchDeviceOrigin,
+  type ConversationSearchInvoke,
+} from '@/session/conversationSearch';
+import type { ConversationSearchResponse } from '@cindy/maker-shared/conversation-search';
+import type { RemoteSession } from '@/session/types';
+
+function session(partial: Partial<RemoteSession> & Pick<RemoteSession, 'id' | 'title'>): RemoteSession {
+  return {
+    userId: 'u',
+    workingDir: '/repo',
+    workspaceKind: 'project',
+    model: 'x',
+    effort: 'medium',
+    permissionMode: 'default',
+    fastMode: false,
+    userSendAt: '2026-08-19T00:00:00.000Z',
+    status: 'active',
+    agentKind: 'cc',
+    createdAt: '2026-08-19T00:00:00.000Z',
+    updatedAt: '2026-08-19T00:00:00.000Z',
+    deviceLinkDeviceId: 'dev-a',
+    deviceLinkDeviceName: 'Studio',
+    ...partial,
+  };
+}
+
+function indexedPage(ids: string[]): ConversationSearchResponse {
+  return {
+    query: 'needle',
+    results: ids.map((id, index) => ({
+      session: {
+        id,
+        title: id,
+        workingDir: '/repo',
+        workspaceKind: 'project',
+        agentKind: 'cc',
+        status: 'active',
+        userSendAt: '2026-08-19T00:00:00.000Z',
+        updatedAt: '2026-08-19T00:00:00.000Z',
+        createdAt: '2026-08-19T00:00:00.000Z',
+        _count: { messages: 1 },
+      },
+      matchKind: 'title' as const,
+      titleMatchIndices: [0],
+      titleScore: 1,
+      contentHit: null,
+      contentHits: [],
+      rankScore: 10 - index,
+    })),
+    vectorUsed: false,
+    vectorSkipReason: null,
+    poolCapped: false,
+  };
+}
+
+const studio: ConversationSearchDeviceOrigin = {
+  deviceId: 'dev-a',
+  deviceName: 'Studio',
+  reachable: true,
+};
+
+describe('searchConversationsAcrossDevices', () => {
+  it('stamps indexed hits and keeps one device failure from wiping the rest', async () => {
+    const invoke = vi.fn(async (deviceId: string, channel: string) => {
+      if (channel !== 'local-db:conversations:search') throw new Error(`unexpected ${channel}`);
+      if (deviceId === 'dev-a') return indexedPage(['hit-a']);
+      throw new Error('[TIMEOUT] boom');
+    }) as ConversationSearchInvoke;
+    const page = await searchConversationsAcrossDevices(
+      [
+        studio,
+        { deviceId: 'dev-b', deviceName: 'Laptop', reachable: true },
+      ],
+      { query: 'needle' },
+      {
+        invoke,
+        getCachedSessions: () => [
+          session({ id: 'cached-b', title: 'Needle laptop', deviceLinkDeviceId: 'dev-b' }),
+        ],
+      },
+    );
+    expect(page.results.map((item) => item.session.id).sort()).toEqual(['cached-b', 'hit-a']);
+    expect(page.results.find((item) => item.session.id === 'hit-a')?.session.deviceLinkDeviceName).toBe('Studio');
+  });
+
+  it('falls back to cached title search when the channel is not allowed', async () => {
+    const invoke = vi.fn(async () => {
+      throw Object.assign(new Error("[CHANNEL_NOT_ALLOWED] channel 'local-db:conversations:search'"), {
+        code: 'DEVICE_LINK_CHANNEL_NOT_ALLOWED',
+      });
+    }) as ConversationSearchInvoke;
+    const page = await searchConversationsAcrossDevices(
+      [studio],
+      { query: 'planning' },
+      {
+        invoke,
+        getCachedSessions: () => [
+          session({ id: 'hit', title: 'Remote planning' }),
+          session({ id: 'worker', title: 'Planning worker', orcaRole: 'worker' }),
+          session({ id: 'other', title: 'Unrelated' }),
+        ],
+      },
+    );
+    expect(page.results.map((item) => item.session.id)).toEqual(['hit']);
+  });
+
+  it('does not invoke a device that is offline or unresponsive', async () => {
+    const invoke = vi.fn();
+    const page = await searchConversationsAcrossDevices(
+      [{ deviceId: 'dev-a', deviceName: 'Studio', reachable: false }],
+      { query: 'planning' },
+      {
+        invoke: invoke as ConversationSearchInvoke,
+        getCachedSessions: () => [session({ id: 'hit', title: 'Remote planning' })],
+        isDeviceUnresponsive: () => false,
+      },
+    );
+    expect(invoke).not.toHaveBeenCalled();
+    expect(page.results.map((item) => item.session.id)).toEqual(['hit']);
+  });
+
+  it('falls back when an old host ignores workingDirs', async () => {
+    const invoke = vi.fn(async () => ({
+      ...indexedPage(['other']),
+      results: indexedPage(['other']).results.map((item) => ({
+        ...item,
+        session: { ...item.session, workingDir: '/other' },
+      })),
+    })) as ConversationSearchInvoke;
+    const page = await searchConversationsAcrossDevices(
+      [studio],
+      { query: 'planning', filters: { workingDirs: ['/repo'] } },
+      {
+        invoke,
+        getCachedSessions: () => [
+          session({ id: 'in-project', title: 'Planning in repo', workingDir: '/repo' }),
+          session({ id: 'out', title: 'Planning elsewhere', workingDir: '/other' }),
+        ],
+      },
+    );
+    expect(page.results.map((item) => item.session.id)).toEqual(['in-project']);
+  });
+
+  it('forwards keyword search filters and sort to the remote channel', async () => {
+    const invoke = vi.fn(async () => indexedPage(['hit-a'])) as ConversationSearchInvoke;
+    await searchConversationsAcrossDevices(
+      [studio],
+      {
+        query: 'needle',
+        sortBy: 'activityDesc',
+        filters: { agentKind: 'cc', lastActivity: '7d', status: 'archived' },
+      },
+      {
+        invoke,
+        getCachedSessions: () => [],
+      },
+    );
+    expect(invoke).toHaveBeenCalledWith(
+      'dev-a',
+      'local-db:conversations:search',
+      [expect.objectContaining({
+        semanticMode: 'keyword',
+        sortBy: 'activityDesc',
+        filters: expect.objectContaining({
+          agentKind: 'cc',
+          lastActivity: '7d',
+          status: 'archived',
+        }),
+      })],
+    );
+  });
+
+  it('forwards agentKind=pi to the host', async () => {
+    const invoke = vi.fn(async () => indexedPage(['pi-hit'])) as ConversationSearchInvoke;
+    await searchConversationsAcrossDevices(
+      [studio],
+      { query: 'needle', filters: { agentKind: 'pi' } },
+      {
+        invoke,
+        getCachedSessions: () => [],
+      },
+    );
+    expect(invoke).toHaveBeenCalledWith(
+      'dev-a',
+      'local-db:conversations:search',
+      [expect.objectContaining({
+        filters: expect.objectContaining({ agentKind: 'pi' }),
+      })],
+    );
+  });
+});
+
+describe('searchCachedDeviceSessions', () => {
+  it('matches the current device only', () => {
+    const page = searchCachedDeviceSessions(
+      studio,
+      { query: 'planning' },
+      [
+        session({ id: 'hit', title: 'Remote planning' }),
+        session({ id: 'other-device', title: 'Remote planning', deviceLinkDeviceId: 'dev-b' }),
+      ],
+    );
+    expect(page.results.map((item) => item.session.id)).toEqual(['hit']);
+  });
+});
+
+describe('helpers', () => {
+  it('classifies CHANNEL_NOT_ALLOWED wrappers', () => {
+    expect(isConversationSearchChannelNotAllowed({
+      code: 'DEVICE_LINK_CHANNEL_NOT_ALLOWED',
+      message: 'nope',
+    })).toBe(true);
+    expect(isConversationSearchChannelNotAllowed(new Error('TIMEOUT'))).toBe(false);
+  });
+
+  it('prefers canonical device id when matching cache rows', () => {
+    expect(sessionBelongsToDevice({
+      canonicalDeviceId: 'dev-a',
+      deviceLinkDeviceId: 'legacy',
+    }, 'dev-a')).toBe(true);
+  });
+
+  it('lists unique projects and toggles multi-select back to all', () => {
+    const projects = listConversationSearchProjects([
+      session({ id: 'a', title: 'A', workingDir: '/Users/dash/repo' }),
+      session({ id: 'b', title: 'B', workingDir: '/Users/dash/repo/' }),
+      session({ id: 'c', title: 'C', workingDir: '/Users/dash/other' }),
+      session({ id: 'd', title: 'Chat', workspaceKind: 'dialogue', workingDir: null }),
+      session({ id: 'w', title: 'Worker', orcaRole: 'worker', workingDir: '/Users/dash/hidden' }),
+    ]);
+    expect(projects.map((project) => project.title)).toEqual(['other', 'repo']);
+    expect(projects.find((project) => project.title === 'repo')?.count).toBe(2);
+    expect(nextConversationSearchProjectSelection('all', 'repo')).toEqual(['repo']);
+    expect(nextConversationSearchProjectSelection(['repo'], 'other')).toEqual(['repo', 'other']);
+    expect(nextConversationSearchProjectSelection(['repo'], 'repo')).toBe('all');
+    expect(reconcileConversationSearchProjectSelection(['gone'], ['repo'])).toBe('all');
+  });
+
+  it('counts search filters like desktop: sort is ignored, locked projects are ignored', () => {
+    expect(conversationSearchActiveFilterCount({
+      agentKind: 'all',
+      lastActivity: 'all',
+      projectSelection: 'all',
+      status: 'all',
+    })).toBe(0);
+    expect(conversationSearchActiveFilterCount({
+      agentKind: 'cc',
+      lastActivity: '7d',
+      projectSelection: ['/repo'],
+      status: 'active',
+    })).toBe(4);
+    expect(conversationSearchActiveFilterCount({
+      lockedWorkingDirs: ['/repo'],
+      projectSelection: ['/repo'],
+      status: 'all',
+    })).toBe(0);
+  });
+
+  it('keeps an empty indexed search visible so filters are not silently dropped', () => {
+    expect(shouldReplaceListWithSearchResults('pi', 'ready')).toBe(true);
+    expect(shouldReplaceListWithSearchResults('pi', 'searching')).toBe(false);
+    expect(shouldReplaceListWithSearchResults('', 'ready')).toBe(false);
+  });
+
+  it('adapts a search hit into a list item', () => {
+    const page = searchCachedDeviceSessions(
+      studio,
+      { query: 'planning' },
+      [session({ id: 'hit', title: 'Remote planning' })],
+    );
+    const item = toSearchListItem(page.results[0], Date.parse('2026-08-19T00:00:00.000Z'), '未命名任务');
+    expect(item.session.id).toBe('hit');
+    expect(item.title).toBe('Remote planning');
+  });
+});

--- a/apps/mobile/src/__tests__/conversationSearch.test.ts
+++ b/apps/mobile/src/__tests__/conversationSearch.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
+  cachedSessionForSearchResult,
   conversationSearchActiveFilterCount,
+  conversationSearchAllowsLocalWrites,
   conversationSearchOriginsFromDeviceModels,
+  conversationSearchSessionCacheKey,
   isConversationSearchChannelNotAllowed,
   listConversationSearchProjects,
   nextConversationSearchProjectSelection,
@@ -362,5 +365,42 @@ describe('helpers', () => {
     const item = toSearchListItem(page.results[0], Date.parse('2026-08-19T00:00:00.000Z'), '未命名任务');
     expect(item.session.id).toBe('hit');
     expect(item.title).toBe('Remote planning');
+    expect(item.searchLocallyCached).toBe(false);
+    expect(conversationSearchAllowsLocalWrites(item)).toBe(false);
+  });
+
+  it('only attaches a cached session from the same device', () => {
+    const hit = searchCachedDeviceSessions(
+      studio,
+      { query: 'planning' },
+      [session({ id: 'shared', title: 'Remote planning' })],
+    ).results[0];
+    const cachedByKey = new Map([
+      [conversationSearchSessionCacheKey(session({
+        id: 'shared',
+        title: 'Laptop planning',
+        deviceLinkDeviceId: 'dev-b',
+        canonicalDeviceId: 'dev-b',
+      })), session({
+        id: 'shared',
+        title: 'Laptop planning',
+        deviceLinkDeviceId: 'dev-b',
+        canonicalDeviceId: 'dev-b',
+      })],
+      [conversationSearchSessionCacheKey(session({
+        id: 'shared',
+        title: 'Studio planning',
+        canonicalDeviceId: 'dev-a',
+      })), session({
+        id: 'shared',
+        title: 'Studio planning',
+        canonicalDeviceId: 'dev-a',
+      })],
+    ]);
+    expect(cachedSessionForSearchResult(hit, cachedByKey)?.deviceLinkDeviceId ?? cachedSessionForSearchResult(hit, cachedByKey)?.canonicalDeviceId).toBe('dev-a');
+    const item = toSearchListItem(hit, Date.parse('2026-08-19T00:00:00.000Z'), '未命名任务', cachedSessionForSearchResult(hit, cachedByKey));
+    expect(item.searchLocallyCached).toBe(true);
+    expect((item.session as RemoteSession).deviceLinkDeviceId).toBe('dev-a');
+    expect(conversationSearchAllowsLocalWrites(item)).toBe(true);
   });
 });

--- a/apps/mobile/src/__tests__/conversationSearch.test.ts
+++ b/apps/mobile/src/__tests__/conversationSearch.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
   conversationSearchActiveFilterCount,
+  conversationSearchOriginsFromDeviceModels,
   isConversationSearchChannelNotAllowed,
   listConversationSearchProjects,
   nextConversationSearchProjectSelection,
@@ -297,6 +298,32 @@ describe('helpers', () => {
       projectSelection: ['/repo'],
       status: 'all',
     })).toBe(0);
+  });
+
+  it('keeps offline devices in the all-tasks search origins and drops hard-cleared peers', () => {
+    const origins = conversationSearchOriginsFromDeviceModels([
+      { canOpen: true, deviceId: 'dev-a', name: 'Studio', state: 'ready' },
+      { canOpen: false, deviceId: 'dev-b', name: 'Laptop', state: 'offline' },
+      { canOpen: false, deviceId: 'dev-c', name: 'Revoked', state: 'access_revoked' },
+      { canOpen: false, deviceId: 'dev-d', name: 'Closed', state: 'remote_disabled' },
+    ], {
+      unresponsiveDeviceIds: new Set(['dev-a']),
+    });
+    expect(origins).toEqual([
+      { deviceId: 'dev-a', deviceName: 'Studio', reachable: false },
+      { deviceId: 'dev-b', deviceName: 'Laptop', reachable: false },
+    ]);
+  });
+
+  it('keeps a selected offline device as an unreachable origin', () => {
+    expect(conversationSearchOriginsFromDeviceModels([
+      { canOpen: true, deviceId: 'dev-a', name: 'Studio', state: 'ready' },
+      { canOpen: false, deviceId: 'dev-b', name: 'Laptop', state: 'offline' },
+    ], {
+      selectedDeviceId: 'dev-b',
+    })).toEqual([
+      { deviceId: 'dev-b', deviceName: 'Laptop', reachable: false },
+    ]);
   });
 
   it('keeps an empty indexed search visible so filters are not silently dropped', () => {

--- a/apps/mobile/src/__tests__/conversationSearch.test.ts
+++ b/apps/mobile/src/__tests__/conversationSearch.test.ts
@@ -216,6 +216,27 @@ describe('searchCachedDeviceSessions', () => {
     );
     expect(page.results.map((item) => item.session.id)).toEqual(['hit']);
   });
+
+  it('matches visible title or cached preview, not list metadata', () => {
+    const page = searchCachedDeviceSessions(
+      studio,
+      { query: 'codex' },
+      [
+        session({ id: 'agent-only', title: 'Unrelated planning', agentKind: 'codex' }),
+        session({ id: 'path-only', title: 'Unrelated planning', workingDir: '/Users/dash/codex' }),
+        session({ id: 'title-hit', title: 'Try Codex later' }),
+        session({
+          id: 'preview-hit',
+          title: 'Unrelated planning',
+          preview: 'switch the task to Codex',
+        }),
+      ],
+    );
+    expect(page.results.map((item) => [item.session.id, item.matchKind])).toEqual([
+      ['title-hit', 'title'],
+      ['preview-hit', 'content'],
+    ]);
+  });
 });
 
 describe('helpers', () => {

--- a/apps/mobile/src/__tests__/conversationSearch.test.ts
+++ b/apps/mobile/src/__tests__/conversationSearch.test.ts
@@ -5,6 +5,7 @@ import {
   listConversationSearchProjects,
   nextConversationSearchProjectSelection,
   reconcileConversationSearchProjectSelection,
+  scopedConversationSearchOrigins,
   searchCachedDeviceSessions,
   searchConversationsAcrossDevices,
   sessionBelongsToDevice,
@@ -240,12 +241,42 @@ describe('helpers', () => {
       session({ id: 'd', title: 'Chat', workspaceKind: 'dialogue', workingDir: null }),
       session({ id: 'w', title: 'Worker', orcaRole: 'worker', workingDir: '/Users/dash/hidden' }),
     ]);
-    expect(projects.map((project) => project.title)).toEqual(['other', 'repo']);
+    expect(projects.map((project) => project.key)).toEqual([
+      'dev-a:/Users/dash/other',
+      'dev-a:/Users/dash/repo',
+    ]);
     expect(projects.find((project) => project.title === 'repo')?.count).toBe(2);
-    expect(nextConversationSearchProjectSelection('all', 'repo')).toEqual(['repo']);
-    expect(nextConversationSearchProjectSelection(['repo'], 'other')).toEqual(['repo', 'other']);
-    expect(nextConversationSearchProjectSelection(['repo'], 'repo')).toBe('all');
-    expect(reconcileConversationSearchProjectSelection(['gone'], ['repo'])).toBe('all');
+    const mixed = listConversationSearchProjects([
+      session({ id: 'a', title: 'A', workingDir: '/Users/dash/repo' }),
+      session({
+        id: 'b',
+        title: 'B',
+        workingDir: '/Users/dash/repo',
+        deviceLinkDeviceId: 'dev-b',
+        deviceLinkDeviceName: 'Laptop',
+      }),
+    ]);
+    expect(mixed.map((project) => project.key)).toEqual([
+      'dev-a:/Users/dash/repo',
+      'dev-b:/Users/dash/repo',
+    ]);
+    const scoped = scopedConversationSearchOrigins(
+      [
+        studio,
+        { deviceId: 'dev-b', deviceName: 'Laptop', reachable: true },
+      ],
+      ['dev-b:/Users/dash/repo'],
+      mixed,
+    );
+    expect(scoped).toEqual([{
+      deviceId: 'dev-b',
+      deviceName: 'Laptop',
+      reachable: true,
+      workingDirs: ['/Users/dash/repo'],
+    }]);
+    expect(nextConversationSearchProjectSelection('all', 'dev-a:/Users/dash/repo')).toEqual(['dev-a:/Users/dash/repo']);
+    expect(nextConversationSearchProjectSelection(['dev-a:/Users/dash/repo'], 'dev-a:/Users/dash/repo')).toBe('all');
+    expect(reconcileConversationSearchProjectSelection(['gone'], ['dev-a:/Users/dash/repo'])).toBe('all');
   });
 
   it('counts search filters like desktop: sort is ignored, locked projects are ignored', () => {

--- a/apps/mobile/src/__tests__/homeDesktopFirst.test.ts
+++ b/apps/mobile/src/__tests__/homeDesktopFirst.test.ts
@@ -182,6 +182,8 @@ describe('mobile home desktop-first surface', () => {
     expect(filterSheet).toContain('devices.list.search.filter.lastActivityHeading');
     expect(filterSheet).toContain('devices.list.search.filter.label');
     expect(filterSheet).toContain("'all', 'cc', 'codex', 'pi'");
+    expect(source).toContain('conversationSearchOriginsFromDeviceModels');
+    expect(source).not.toContain(': deviceModels.filter((item) => item.canOpen);');
   });
 
   it('uses TapTap blue for the online dot treatment', () => {

--- a/apps/mobile/src/__tests__/homeDesktopFirst.test.ts
+++ b/apps/mobile/src/__tests__/homeDesktopFirst.test.ts
@@ -70,7 +70,7 @@ describe('mobile home desktop-first surface', () => {
     expect(source).not.toContain("title: 'Chats'");
     expect(source).not.toContain('placeholder="Search Chats"');
     expect(source).not.toContain('placeholder="搜索会话"');
-    expect(source).not.toContain('home.searchInput');
+    expect(source).not.toContain('testID="home.searchToggleButton"');
     expect(source).not.toContain('styles.bottomBar');
     expect(source).not.toContain('styles.newChatText');
     expect(source).not.toContain('home.projectNewSessionButton');
@@ -121,6 +121,7 @@ describe('mobile home desktop-first surface', () => {
     expect(source).not.toContain("import { BlurView } from 'expo-blur';");
     const chromeDrawer = readSource('src/session/HomeChromeDrawer.tsx');
     expect(chromeDrawer).toContain('testID="devices.settingsButton"');
+    expect(chromeDrawer).toContain('testID="home.chromeDrawer.search"');
     expect(chromeDrawer).toContain('testID="home.chromeDrawer.account"');
     expect(chromeDrawer).toContain('openSettingsImmediately');
     expect(chromeDrawer).toContain('closeInstant');
@@ -161,6 +162,26 @@ describe('mobile home desktop-first surface', () => {
     expect(source).toContain("position: 'absolute'");
     expect(source).toContain('bottom: CINDY_LIST_FAB_BOTTOM');
     expect(source).toContain('right: CINDY_LIST_GUTTER');
+  });
+
+  it('opens desktop-parity search filters from the search sliders, not display settings', () => {
+    const source = readSource('app/devices/index.tsx');
+    const searchBar = readSource('src/session/HomeSearchBar.tsx');
+    const filterSheet = readSource('src/session/ConversationSearchFilterSheet.tsx');
+
+    expect(source).toContain('<HomeSearchBar');
+    expect(source).toContain('onOpenFilter={() => setSearchFilterOpen(true)}');
+    expect(source).not.toContain('onOpenFilter={openDisplaySettings}');
+    expect(source).toContain('<ConversationSearchFilterSheet');
+    expect(searchBar).toContain('testID={testIDs?.filter ?? \'home.searchFilterButton\'}');
+    expect(filterSheet).toContain('testID="home.searchFilter"');
+    expect(filterSheet).toContain('devices.list.search.filter.sortHeading');
+    expect(filterSheet).toContain('devices.list.search.filter.statusHeading');
+    expect(filterSheet).toContain('devices.list.search.filter.projectsHeading');
+    expect(filterSheet).toContain('devices.list.search.filter.agentHeading');
+    expect(filterSheet).toContain('devices.list.search.filter.lastActivityHeading');
+    expect(filterSheet).toContain('devices.list.search.filter.label');
+    expect(filterSheet).toContain("'all', 'cc', 'codex', 'pi'");
   });
 
   it('uses TapTap blue for the online dot treatment', () => {

--- a/apps/mobile/src/__tests__/homeDesktopFirst.test.ts
+++ b/apps/mobile/src/__tests__/homeDesktopFirst.test.ts
@@ -183,6 +183,7 @@ describe('mobile home desktop-first surface', () => {
     expect(filterSheet).toContain('devices.list.search.filter.label');
     expect(filterSheet).toContain("'all', 'cc', 'codex', 'pi'");
     expect(source).toContain('conversationSearchOriginsFromDeviceModels');
+    expect(source).toContain('setConversationSearchDeviceModels');
     expect(source).not.toContain(': deviceModels.filter((item) => item.canOpen);');
   });
 

--- a/apps/mobile/src/__tests__/mobileMakerTransport.test.ts
+++ b/apps/mobile/src/__tests__/mobileMakerTransport.test.ts
@@ -27,6 +27,7 @@ describe('mobile maker transport', () => {
       'maker:get-capabilities',
       'maker:provider:list',
       'local-db:sessions:get',
+      'local-db:conversations:search',
       'local-db:sessions:patch-meta',
       'local-db:messages:dismiss-error',
       'local-db:sessions:ack-interrupted',
@@ -202,6 +203,19 @@ describe('mobile maker transport', () => {
       deviceId: 'dev-1',
       channel: 'maker:create-session',
       args: [opts],
+    }]);
+  });
+
+  it('routes task search through the controlled desktop conversations:search channel', async () => {
+    const { calls, maker } = harness();
+    const request = { query: 'needle', semanticMode: 'keyword' as const };
+
+    await maker.searchConversations(request);
+
+    expect(calls).toEqual([{
+      deviceId: 'dev-1',
+      channel: 'local-db:conversations:search',
+      args: [request],
     }]);
   });
 

--- a/apps/mobile/src/__tests__/sessionHeaderDesktopFirst.test.ts
+++ b/apps/mobile/src/__tests__/sessionHeaderDesktopFirst.test.ts
@@ -104,7 +104,7 @@ describe('mobile session header desktop-first surface', () => {
     expect(source).toContain('if (sessionListDrawerClosingRef.current || pendingDrawerNavigationRef.current) return;');
     expect(source).toContain('sessionListDrawerClosingRef.current = true;\n    pendingDrawerNavigationRef.current = action;');
     expect(source).toContain('const closeSessionListDrawer = useCallback(() => {\n    if (sessionListDrawerClosingRef.current) return;\n    sessionListDrawerClosingRef.current = true;');
-    expect(source).toContain('if (targetSession.id === sessionId) {\n      closeSessionListDrawer();');
+    expect(source).toContain('if (targetSession.id === sessionId && !focusClientId) {\n      closeSessionListDrawer();');
     expect(source).toContain('onClosed={handleSessionListDrawerClosed}');
     expect(source).toContain('const action = pendingDrawerNavigationRef.current;\n    sessionListDrawerClosingRef.current = false;\n    if (!action) returnDrawerFocusAfterCloseRef.current = true;\n    setSessionListDrawerOverlayMounted(false);');
     expect(source).toContain('pendingDrawerNavigationRef.current = null;\n    action();');

--- a/apps/mobile/src/__tests__/sessionListDrawer.test.ts
+++ b/apps/mobile/src/__tests__/sessionListDrawer.test.ts
@@ -79,6 +79,7 @@ describe('mobile session list drawer', () => {
     expect(text).toContain('resolveMobileSessionRightStatus({');
     expect(text).toContain('buildRemoteSessionCardPreview(item, { running })');
     expect(text).toContain('formatRemoteSessionSidebarTime(lastActivityAt)');
+    expect(text).toContain('remoteSessionStore.getDeviceIdentity()');
   });
 
   it('exposes stable testIDs and modal accessibility semantics', () => {

--- a/apps/mobile/src/__tests__/sessionListDrawer.test.ts
+++ b/apps/mobile/src/__tests__/sessionListDrawer.test.ts
@@ -79,6 +79,8 @@ describe('mobile session list drawer', () => {
     expect(text).toContain('resolveMobileSessionRightStatus({');
     expect(text).toContain('buildRemoteSessionCardPreview(item, { running })');
     expect(text).toContain('formatRemoteSessionSidebarTime(lastActivityAt)');
+    expect(text).toContain('conversationSearchOriginsFromDeviceModels');
+    expect(text).toContain('remoteSessionStore.getConversationSearchDeviceModels()');
     expect(text).toContain('remoteSessionStore.getDeviceIdentity()');
   });
 

--- a/apps/mobile/src/device-link/mobileMakerTransport.ts
+++ b/apps/mobile/src/device-link/mobileMakerTransport.ts
@@ -1,4 +1,8 @@
 import type {
+  ConversationSearchRequest,
+  ConversationSearchResponse,
+} from '@cindy/maker-shared/conversation-search';
+import type {
   InputProjection,
   PendingInteraction,
   QueuedRemoteMessage,
@@ -389,6 +393,7 @@ export interface MobileMakerTransport {
     modelVisibilityOverrides?: Record<string, boolean>;
   }>;
   getSession(sessionId: string): Promise<RemoteSession>;
+  searchConversations(request: ConversationSearchRequest): Promise<ConversationSearchResponse>;
   patchSessionMeta(sessionId: string, patch: SessionMetaPatch): Promise<RemoteSession>;
   /**
    * error-tail「忽略」:被控端把该 role='error' 行的 content merge dismissed:true
@@ -660,6 +665,7 @@ export function createMobileMakerTransport({
       capabilities: [CONTROLLER_CAPABILITY_PROVIDER_LOGO_KINDS_V2],
     }]),
     getSession: (sessionId) => call('local-db:sessions:get', [sessionId]),
+    searchConversations: (request) => call('local-db:conversations:search', [request]),
     patchSessionMeta: (sessionId, patch) => call('local-db:sessions:patch-meta', [sessionId, patch]),
     dismissErrorMessage: (sessionId, clientId) =>
       call('local-db:messages:dismiss-error', [sessionId, clientId]),

--- a/apps/mobile/src/i18n/locales/en/devices.json
+++ b/apps/mobile/src/i18n/locales/en/devices.json
@@ -34,6 +34,7 @@
       "openMenu": "Open menu",
       "closeMenu": "Close menu",
       "openDisplaySettings": "Open display settings",
+      "openSearch": "Search",
       "openSettings": "Open settings",
       "syncing": "Syncing",
       "sync": "Sync again",
@@ -63,6 +64,7 @@
       "statusArchived": "Archived",
       "statusAll": "All",
       "dialogueFolder": "Chat",
+      "search": "Search",
       "settings": "Settings",
       "remoteSettings": "Remote connection settings",
       "displaySettings": "Display settings",
@@ -73,6 +75,45 @@
       "projectOrderManual": "Manual",
       "projectOrderManualTip": "Touch and hold a project row, then drag to reorder. Tasks inside still follow the sort above.",
       "statusHeading": "Status"
+    },
+    "search": {
+      "placeholder": "Search titles or content…",
+      "filterA11y": "Search filters",
+      "filterAria": "Search filters and sort (Sort: {{sort}}, Status: {{status}}, Agent: {{agent}}, Last activity: {{lastActivity}}, Projects: {{projects}})",
+      "filter": {
+        "label": "Search criteria",
+        "reset": "Reset",
+        "sortHeading": "Sort by",
+        "statusHeading": "Status",
+        "projectsHeading": "Projects",
+        "agentHeading": "Agent",
+        "lastActivityHeading": "Last activity",
+        "allProjects": "All projects",
+        "selectedProjects": "{{count}} selected",
+        "sort": {
+          "relevance": "Relevance",
+          "activityDesc": "Recently active",
+          "activityAsc": "Oldest active"
+        },
+        "status": {
+          "active": "Active",
+          "archived": "Archived",
+          "all": "All"
+        },
+        "agent": {
+          "all": "All",
+          "cc": "Claude Code",
+          "codex": "Codex",
+          "pi": "Pi"
+        },
+        "lastActivity": {
+          "1d": "1d",
+          "3d": "3d",
+          "7d": "7d",
+          "30d": "30d",
+          "all": "All"
+        }
+      }
     },
     "renameDevice": {
       "title": "Rename Device",
@@ -129,7 +170,7 @@
       "openA11y": "Search remote sessions",
       "closeA11y": "Close remote session search",
       "label": "Search",
-      "placeholder": "Search titles, projects, models, messages",
+      "placeholder": "Search titles or content…",
       "clearA11y": "Clear search",
       "closeInputA11y": "Close search",
       "clear": "Clear",

--- a/apps/mobile/src/i18n/locales/ja/devices.json
+++ b/apps/mobile/src/i18n/locales/ja/devices.json
@@ -34,6 +34,7 @@
       "openMenu": "メニューを開く",
       "closeMenu": "メニューを閉じる",
       "openDisplaySettings": "表示設定を開く",
+      "openSearch": "検索",
       "openSettings": "設定を開く",
       "syncing": "再同期中",
       "sync": "再同期",
@@ -63,6 +64,7 @@
       "statusArchived": "アーカイブ済み",
       "statusAll": "すべて",
       "dialogueFolder": "チャット",
+      "search": "検索",
       "settings": "設定",
       "remoteSettings": "リモート接続設定",
       "displaySettings": "表示設定",
@@ -73,6 +75,45 @@
       "projectOrderManual": "手動",
       "projectOrderManualTip": "プロジェクト行を長押ししてドラッグすると順番を変えられます。グループ内のタスクは上の並び替えに従います。",
       "statusHeading": "ステータス"
+    },
+    "search": {
+      "placeholder": "タイトルまたは内容を検索…",
+      "filterA11y": "検索フィルター",
+      "filterAria": "検索フィルターと並び順（並び順：{{sort}}、状態：{{status}}、Agent：{{agent}}、最近のアクティビティ：{{lastActivity}}、プロジェクト：{{projects}}）",
+      "filter": {
+        "label": "検索条件",
+        "reset": "リセット",
+        "sortHeading": "並び替え",
+        "statusHeading": "ステータス",
+        "projectsHeading": "プロジェクト",
+        "agentHeading": "Agent",
+        "lastActivityHeading": "最近のアクティビティ",
+        "allProjects": "すべてのプロジェクト",
+        "selectedProjects": "{{count}} 件選択",
+        "sort": {
+          "relevance": "関連度",
+          "activityDesc": "最近アクティブ",
+          "activityAsc": "古いアクティブ順"
+        },
+        "status": {
+          "active": "アクティブ",
+          "archived": "アーカイブ済み",
+          "all": "すべて"
+        },
+        "agent": {
+          "all": "すべて",
+          "cc": "Claude Code",
+          "codex": "Codex",
+          "pi": "Pi"
+        },
+        "lastActivity": {
+          "1d": "1日",
+          "3d": "3日",
+          "7d": "7日",
+          "30d": "30日",
+          "all": "すべて"
+        }
+      }
     },
     "renameDevice": {
       "title": "デバイス名を変更",
@@ -129,7 +170,7 @@
       "openA11y": "リモートセッションを検索",
       "closeA11y": "リモートセッションの検索を閉じる",
       "label": "検索",
-      "placeholder": "タイトル、プロジェクト、モデル、メッセージを検索",
+      "placeholder": "タイトルまたは内容を検索…",
       "clearA11y": "検索をクリア",
       "closeInputA11y": "検索を閉じる",
       "clear": "クリア",

--- a/apps/mobile/src/i18n/locales/ko/devices.json
+++ b/apps/mobile/src/i18n/locales/ko/devices.json
@@ -34,6 +34,7 @@
       "openMenu": "메뉴 열기",
       "closeMenu": "메뉴 닫기",
       "openDisplaySettings": "표시 설정 열기",
+      "openSearch": "검색",
       "openSettings": "설정 열기",
       "syncing": "다시 동기화하는 중",
       "sync": "다시 동기화",
@@ -63,6 +64,7 @@
       "statusArchived": "보관됨",
       "statusAll": "전체",
       "dialogueFolder": "채팅",
+      "search": "검색",
       "settings": "설정",
       "remoteSettings": "원격 연결 설정",
       "displaySettings": "표시 설정",
@@ -73,6 +75,45 @@
       "projectOrderManual": "수동",
       "projectOrderManualTip": "프로젝트 행을 길게 누른 뒤 드래그하면 순서를 바꿀 수 있습니다. 그룹 안 작업은 위 정렬을 따릅니다.",
       "statusHeading": "상태"
+    },
+    "search": {
+      "placeholder": "제목 또는 내용 검색…",
+      "filterA11y": "검색 필터",
+      "filterAria": "검색 필터 및 정렬(정렬: {{sort}}, 상태: {{status}}, Agent: {{agent}}, 최근 활성: {{lastActivity}}, 프로젝트: {{projects}})",
+      "filter": {
+        "label": "검색 조건",
+        "reset": "초기화",
+        "sortHeading": "정렬",
+        "statusHeading": "상태",
+        "projectsHeading": "프로젝트",
+        "agentHeading": "Agent",
+        "lastActivityHeading": "최근 활성",
+        "allProjects": "모든 프로젝트",
+        "selectedProjects": "{{count}}개 선택됨",
+        "sort": {
+          "relevance": "관련도",
+          "activityDesc": "최근 활성순",
+          "activityAsc": "오래된 활성순"
+        },
+        "status": {
+          "active": "활성",
+          "archived": "보관됨",
+          "all": "전체"
+        },
+        "agent": {
+          "all": "전체",
+          "cc": "Claude Code",
+          "codex": "Codex",
+          "pi": "Pi"
+        },
+        "lastActivity": {
+          "1d": "1일",
+          "3d": "3일",
+          "7d": "7일",
+          "30d": "30일",
+          "all": "전체"
+        }
+      }
     },
     "renameDevice": {
       "title": "기기 이름 변경",
@@ -129,7 +170,7 @@
       "openA11y": "원격 세션 검색",
       "closeA11y": "원격 세션 검색 닫기",
       "label": "검색",
-      "placeholder": "제목, 프로젝트, 모델, 메시지 검색",
+      "placeholder": "제목 또는 내용 검색…",
       "clearA11y": "검색 지우기",
       "closeInputA11y": "검색 닫기",
       "clear": "지우기",

--- a/apps/mobile/src/i18n/locales/zh-CN/devices.json
+++ b/apps/mobile/src/i18n/locales/zh-CN/devices.json
@@ -34,6 +34,7 @@
       "openMenu": "打开菜单",
       "closeMenu": "关闭菜单",
       "openDisplaySettings": "打开显示设置",
+      "openSearch": "搜索",
       "openSettings": "打开设置",
       "syncing": "正在重新同步",
       "sync": "重新同步",
@@ -63,6 +64,7 @@
       "statusArchived": "已归档",
       "statusAll": "全部",
       "dialogueFolder": "对话",
+      "search": "搜索",
       "settings": "设置",
       "remoteSettings": "远程连接设置",
       "displaySettings": "显示设置",
@@ -73,6 +75,45 @@
       "projectOrderManual": "手动",
       "projectOrderManualTip": "长按项目行拖动调整顺序，组内任务仍按上面的排序",
       "statusHeading": "状态"
+    },
+    "search": {
+      "placeholder": "搜索标题或内容…",
+      "filterA11y": "搜索筛选",
+      "filterAria": "搜索筛选与排序（排序：{{sort}}，状态：{{status}}，Agent：{{agent}}，最近活跃：{{lastActivity}}，项目：{{projects}}）",
+      "filter": {
+        "label": "搜索条件",
+        "reset": "重置",
+        "sortHeading": "排序",
+        "statusHeading": "状态",
+        "projectsHeading": "项目",
+        "agentHeading": "Agent",
+        "lastActivityHeading": "最近活跃",
+        "allProjects": "所有项目",
+        "selectedProjects": "已选 {{count}} 个",
+        "sort": {
+          "relevance": "相关度",
+          "activityDesc": "最近活跃",
+          "activityAsc": "最早活跃"
+        },
+        "status": {
+          "active": "活跃",
+          "archived": "已归档",
+          "all": "全部"
+        },
+        "agent": {
+          "all": "全部",
+          "cc": "Claude Code",
+          "codex": "Codex",
+          "pi": "Pi"
+        },
+        "lastActivity": {
+          "1d": "1 天",
+          "3d": "3 天",
+          "7d": "7 天",
+          "30d": "30 天",
+          "all": "全部"
+        }
+      }
     },
     "renameDevice": {
       "title": "重命名设备",
@@ -129,7 +170,7 @@
       "openA11y": "搜索远程任务",
       "closeA11y": "关闭搜索远程任务",
       "label": "搜索",
-      "placeholder": "搜索标题、项目、模型、消息",
+      "placeholder": "搜索标题或内容…",
       "clearA11y": "清除搜索",
       "closeInputA11y": "关闭搜索",
       "clear": "清除",

--- a/apps/mobile/src/i18n/locales/zh-TW/devices.json
+++ b/apps/mobile/src/i18n/locales/zh-TW/devices.json
@@ -34,6 +34,7 @@
       "openMenu": "打開選單",
       "closeMenu": "關閉選單",
       "openDisplaySettings": "打開顯示設定",
+      "openSearch": "搜尋",
       "openSettings": "開啟設定",
       "syncing": "正在重新同步",
       "sync": "重新同步",
@@ -63,6 +64,7 @@
       "statusArchived": "已歸檔",
       "statusAll": "全部",
       "dialogueFolder": "對話",
+      "search": "搜尋",
       "settings": "設定",
       "remoteSettings": "遠端連線設定",
       "displaySettings": "顯示設定",
@@ -73,6 +75,45 @@
       "projectOrderManual": "手動",
       "projectOrderManualTip": "長按專案行拖動調整順序，組內任務仍按上面的排序",
       "statusHeading": "狀態"
+    },
+    "search": {
+      "placeholder": "搜尋標題或內容…",
+      "filterA11y": "搜尋篩選",
+      "filterAria": "搜尋篩選與排序（排序：{{sort}}，狀態：{{status}}，Agent：{{agent}}，最近活躍：{{lastActivity}}，專案：{{projects}}）",
+      "filter": {
+        "label": "搜尋條件",
+        "reset": "重置",
+        "sortHeading": "排序",
+        "statusHeading": "狀態",
+        "projectsHeading": "專案",
+        "agentHeading": "Agent",
+        "lastActivityHeading": "最近活躍",
+        "allProjects": "所有專案",
+        "selectedProjects": "已選 {{count}} 個",
+        "sort": {
+          "relevance": "相關度",
+          "activityDesc": "最近活躍",
+          "activityAsc": "最早活躍"
+        },
+        "status": {
+          "active": "活躍",
+          "archived": "已歸檔",
+          "all": "全部"
+        },
+        "agent": {
+          "all": "全部",
+          "cc": "Claude Code",
+          "codex": "Codex",
+          "pi": "Pi"
+        },
+        "lastActivity": {
+          "1d": "1 天",
+          "3d": "3 天",
+          "7d": "7 天",
+          "30d": "30 天",
+          "all": "全部"
+        }
+      }
     },
     "renameDevice": {
       "title": "重新命名裝置",
@@ -129,7 +170,7 @@
       "openA11y": "搜尋遠端任務",
       "closeA11y": "關閉搜尋遠端任務",
       "label": "搜尋",
-      "placeholder": "搜尋標題、專案、模型、訊息",
+      "placeholder": "搜尋標題或內容…",
       "clearA11y": "清除搜尋",
       "closeInputA11y": "關閉搜尋",
       "clear": "清除",

--- a/apps/mobile/src/session/ConversationSearchFilterSheet.tsx
+++ b/apps/mobile/src/session/ConversationSearchFilterSheet.tsx
@@ -1,0 +1,294 @@
+/**
+ * 搜索筛选面板。对照桌面 SearchFilterMenu:
+ * 排序 / 状态 / 项目 / Agent / 最近活动。排序不计入红点。
+ */
+import { Check } from 'lucide-react-native';
+import { Pressable, ScrollView, StyleSheet, View, useWindowDimensions } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useTranslation } from 'react-i18next';
+import { Text } from '@/components/AppText';
+import { HomeGlassMenuPanel, HomeMenuScrim } from '@/session/HomeGlassMenuPanel';
+import { useModalFadeLifecycle } from '@/session/useModalFadeLifecycle';
+import {
+  nextConversationSearchProjectSelection,
+  type ConversationSearchProjectOption,
+  type ConversationSearchProjectSelection,
+} from '@/session/conversationSearch';
+import { useTheme, useThemedStyles, type ThemeColors } from '@/theme';
+import { fontWeight, iconSize, iconStroke, lineHeight, radius, spacing, typeScale } from '@/theme/tokens';
+import type {
+  ConversationSearchAgentFilter,
+  ConversationSearchLastActivityFilter,
+  ConversationSearchSortBy,
+  ConversationSearchStatusFilter,
+} from '@cindy/maker-shared/conversation-search';
+
+const SORT_OPTIONS: ConversationSearchSortBy[] = ['relevance', 'activityDesc', 'activityAsc'];
+const STATUS_OPTIONS: ConversationSearchStatusFilter[] = ['active', 'archived', 'all'];
+const AGENT_OPTIONS: ConversationSearchAgentFilter[] = ['all', 'cc', 'codex', 'pi'];
+const LAST_ACTIVITY_OPTIONS: ConversationSearchLastActivityFilter[] = ['1d', '3d', '7d', '30d', 'all'];
+
+export function ConversationSearchFilterSheet({
+  activeCount,
+  agentKind,
+  lastActivity,
+  lockedProjects,
+  onAgentKindChange,
+  onClose,
+  onLastActivityChange,
+  onProjectsChange,
+  onReset,
+  onSortChange,
+  onStatusChange,
+  projects,
+  projectSelection,
+  sortBy,
+  status,
+  topOffset,
+  visible,
+}: {
+  activeCount: number;
+  agentKind: ConversationSearchAgentFilter;
+  lastActivity: ConversationSearchLastActivityFilter;
+  lockedProjects: boolean;
+  onAgentKindChange(value: ConversationSearchAgentFilter): void;
+  onClose(): void;
+  onLastActivityChange(value: ConversationSearchLastActivityFilter): void;
+  onProjectsChange(value: ConversationSearchProjectSelection): void;
+  onReset(): void;
+  onSortChange(value: ConversationSearchSortBy): void;
+  onStatusChange(value: ConversationSearchStatusFilter): void;
+  projects: readonly ConversationSearchProjectOption[];
+  projectSelection: ConversationSearchProjectSelection;
+  sortBy: ConversationSearchSortBy;
+  status: ConversationSearchStatusFilter;
+  topOffset: number;
+  visible: boolean;
+}) {
+  const styles = useThemedStyles(makeStyles);
+  const { t } = useTranslation();
+  const { height: screenHeight } = useWindowDimensions();
+  const insets = useSafeAreaInsets();
+  const scrollMaxHeight = Math.max(200, screenHeight - topOffset - insets.bottom - 24);
+  const { mounted, progress, onShowStartIn } = useModalFadeLifecycle(visible, {
+    inMs: 140,
+    outMs: 110,
+  });
+  const selectedProjects = projectSelection === 'all' ? null : new Set(projectSelection);
+
+  return (
+    <HomeMenuScrim
+      backdropTestID="home.searchFilter.backdrop"
+      onClose={onClose}
+      onShow={onShowStartIn}
+      progress={progress}
+      topOffset={topOffset}
+      visible={mounted}
+    >
+      <HomeGlassMenuPanel style={styles.panel} testID="home.searchFilter">
+        <ScrollView style={[styles.scroll, { maxHeight: scrollMaxHeight }]} showsVerticalScrollIndicator>
+          <View style={styles.header}>
+            <Text style={styles.headerTitle}>{t('devices.list.search.filter.label')}</Text>
+            {activeCount > 0 ? (
+              <Pressable
+                accessibilityLabel={t('devices.list.search.filter.reset')}
+                accessibilityRole="button"
+                hitSlop={6}
+                onPress={onReset}
+                style={({ pressed }) => [styles.resetButton, pressed && styles.pressed]}
+                testID="home.searchFilter.reset"
+              >
+                <Text style={styles.resetText}>{t('devices.list.search.filter.reset')}</Text>
+              </Pressable>
+            ) : null}
+          </View>
+
+          <Text style={styles.sectionLabel}>{t('devices.list.search.filter.sortHeading')}</Text>
+          {SORT_OPTIONS.map((value) => (
+            <FilterMenuItem
+              key={value}
+              label={t(`devices.list.search.filter.sort.${value}`)}
+              onPress={() => onSortChange(value)}
+              selected={sortBy === value}
+              testID={`home.searchFilter.sort.${value}`}
+            />
+          ))}
+
+          <View style={styles.divider} />
+          <Text style={styles.sectionLabel}>{t('devices.list.search.filter.statusHeading')}</Text>
+          {STATUS_OPTIONS.map((value) => (
+            <FilterMenuItem
+              key={value}
+              label={t(`devices.list.search.filter.status.${value}`)}
+              onPress={() => onStatusChange(value)}
+              selected={status === value}
+              testID={`home.searchFilter.status.${value}`}
+            />
+          ))}
+
+          {!lockedProjects && projects.length > 0 ? (
+            <>
+              <View style={styles.divider} />
+              <Text style={styles.sectionLabel}>{t('devices.list.search.filter.projectsHeading')}</Text>
+              <FilterMenuItem
+                label={t('devices.list.search.filter.allProjects')}
+                onPress={() => onProjectsChange('all')}
+                selected={projectSelection === 'all'}
+                testID="home.searchFilter.project.all"
+              />
+              {projects.map((project) => (
+                <FilterMenuItem
+                  key={project.key}
+                  label={project.title}
+                  meta={String(project.count)}
+                  onPress={() => onProjectsChange(nextConversationSearchProjectSelection(projectSelection, project.key))}
+                  selected={selectedProjects?.has(project.key) === true}
+                  testID={`home.searchFilter.project.${sanitizeFilterTestId(project.key)}`}
+                />
+              ))}
+            </>
+          ) : null}
+
+          <View style={styles.divider} />
+          <Text style={styles.sectionLabel}>{t('devices.list.search.filter.agentHeading')}</Text>
+          {AGENT_OPTIONS.map((value) => (
+            <FilterMenuItem
+              key={value}
+              label={t(`devices.list.search.filter.agent.${value}`)}
+              onPress={() => onAgentKindChange(value)}
+              selected={agentKind === value}
+              testID={`home.searchFilter.agent.${value}`}
+            />
+          ))}
+
+          <View style={styles.divider} />
+          <Text style={styles.sectionLabel}>{t('devices.list.search.filter.lastActivityHeading')}</Text>
+          {LAST_ACTIVITY_OPTIONS.map((value) => (
+            <FilterMenuItem
+              key={value}
+              label={t(`devices.list.search.filter.lastActivity.${value}`)}
+              onPress={() => onLastActivityChange(value)}
+              selected={lastActivity === value}
+              testID={`home.searchFilter.lastActivity.${value}`}
+            />
+          ))}
+        </ScrollView>
+      </HomeGlassMenuPanel>
+    </HomeMenuScrim>
+  );
+}
+
+function FilterMenuItem({
+  label,
+  meta,
+  onPress,
+  selected,
+  testID,
+}: {
+  label: string;
+  meta?: string;
+  onPress(): void;
+  selected: boolean;
+  testID: string;
+}) {
+  const styles = useThemedStyles(makeStyles);
+  const { colors } = useTheme();
+  return (
+    <Pressable
+      accessibilityLabel={label}
+      accessibilityRole="button"
+      accessibilityState={{ selected }}
+      onPress={onPress}
+      style={({ pressed }) => [styles.item, pressed && styles.pressed]}
+      testID={testID}
+    >
+      <View style={styles.checkSlot}>
+        {selected ? (
+          <Check color={colors.textPrimary} size={iconSize.md} strokeWidth={iconStroke.medium} />
+        ) : null}
+      </View>
+      <Text numberOfLines={1} style={styles.itemText}>{label}</Text>
+      {meta ? <Text style={styles.itemMeta}>{meta}</Text> : null}
+    </Pressable>
+  );
+}
+
+function sanitizeFilterTestId(value: string): string {
+  return value.replace(/[^A-Za-z0-9_-]/g, '_');
+}
+
+const makeStyles = (colors: ThemeColors) => StyleSheet.create({
+  panel: {
+    alignSelf: 'flex-end',
+  },
+  scroll: {
+    flexGrow: 0,
+  },
+  header: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: spacing.sm,
+    minHeight: 36,
+    paddingHorizontal: spacing.md,
+    paddingTop: spacing.xs,
+  },
+  headerTitle: {
+    color: colors.textTertiary,
+    flex: 1,
+    fontSize: typeScale.caption,
+    fontWeight: fontWeight.medium,
+    lineHeight: lineHeight.caption,
+  },
+  resetButton: {
+    borderRadius: radius.pill,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: spacing.xs,
+  },
+  resetText: {
+    color: colors.textTertiary,
+    fontSize: typeScale.caption,
+    fontWeight: fontWeight.medium,
+  },
+  sectionLabel: {
+    color: colors.textTertiary,
+    fontSize: typeScale.caption,
+    fontWeight: fontWeight.medium,
+    lineHeight: lineHeight.caption,
+    paddingHorizontal: spacing.md,
+    paddingTop: spacing.sm,
+  },
+  item: {
+    alignItems: 'center',
+    borderRadius: radius.container,
+    flexDirection: 'row',
+    gap: spacing.md,
+    minHeight: 48,
+    paddingHorizontal: spacing.md,
+  },
+  checkSlot: {
+    alignItems: 'center',
+    width: iconSize.md,
+  },
+  itemText: {
+    color: colors.textPrimary,
+    flex: 1,
+    fontSize: typeScale.body,
+    fontWeight: fontWeight.medium,
+    lineHeight: lineHeight.body,
+    minWidth: 0,
+  },
+  itemMeta: {
+    color: colors.textTertiary,
+    fontSize: typeScale.caption,
+    fontWeight: fontWeight.medium,
+  },
+  divider: {
+    backgroundColor: colors.border,
+    height: StyleSheet.hairlineWidth,
+    marginHorizontal: spacing.sm,
+    marginVertical: spacing.sm,
+  },
+  pressed: {
+    opacity: 0.72,
+  },
+});

--- a/apps/mobile/src/session/ConversationSearchFilterSheet.tsx
+++ b/apps/mobile/src/session/ConversationSearchFilterSheet.tsx
@@ -75,6 +75,7 @@ export function ConversationSearchFilterSheet({
     outMs: 110,
   });
   const selectedProjects = projectSelection === 'all' ? null : new Set(projectSelection);
+  const showProjectDevice = new Set(projects.map((project) => project.deviceId)).size > 1;
 
   return (
     <HomeMenuScrim
@@ -140,7 +141,9 @@ export function ConversationSearchFilterSheet({
                 <FilterMenuItem
                   key={project.key}
                   label={project.title}
-                  meta={String(project.count)}
+                  meta={showProjectDevice && project.deviceName
+                    ? `${project.deviceName} · ${project.count}`
+                    : String(project.count)}
                   onPress={() => onProjectsChange(nextConversationSearchProjectSelection(projectSelection, project.key))}
                   selected={selectedProjects?.has(project.key) === true}
                   testID={`home.searchFilter.project.${sanitizeFilterTestId(project.key)}`}

--- a/apps/mobile/src/session/HomeChromeDrawer.tsx
+++ b/apps/mobile/src/session/HomeChromeDrawer.tsx
@@ -1,11 +1,11 @@
 /**
  * HomeChromeDrawer —— 首页左上角系统菜单。
  *
- * 从左边滑出,不是下拉卡:现在只有设置一项,以后会往里加入口。
+ * 从左边滑出,不是下拉卡:现在有搜索任务和设置。
  * 树内 overlay(不用 RN Modal),避免和首页其它 Modal 抢 present/dismiss。
  * 动画 / 左滑关闭对齐 SessionListDrawer,遵循 reduce-motion。
  */
-import { Settings } from 'lucide-react-native';
+import { Search, Settings } from 'lucide-react-native';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   AccessibilityInfo,
@@ -51,6 +51,7 @@ export function HomeChromeDrawer({
   closeInstant = false,
   onClose,
   onClosed,
+  onOpenSearch,
   onOpenSettings,
   open,
   user,
@@ -59,6 +60,7 @@ export function HomeChromeDrawer({
   closeInstant?: boolean;
   onClose(): void;
   onClosed?(): void;
+  onOpenSearch(): void;
   onOpenSettings(): void;
   open: boolean;
   user: { avatar: string | null; email: string | null; name: string } | null;
@@ -248,6 +250,17 @@ export function HomeChromeDrawer({
           </Pressable>
 
           <View style={styles.divider} />
+
+          <Pressable
+            accessibilityLabel={t('devices.list.a11y.openSearch')}
+            accessibilityRole="button"
+            onPress={onOpenSearch}
+            style={({ pressed }) => [styles.menuRow, pressed && styles.pressed]}
+            testID="home.chromeDrawer.search"
+          >
+            <Search color={colors.textSecondary} size={iconSize.md} strokeWidth={iconStroke.regular} />
+            <Text numberOfLines={1} style={styles.menuLabel}>{t('devices.list.menu.search')}</Text>
+          </Pressable>
 
           <Pressable
             accessibilityLabel={t('devices.list.a11y.openSettings')}

--- a/apps/mobile/src/session/HomeSearchBar.tsx
+++ b/apps/mobile/src/session/HomeSearchBar.tsx
@@ -14,6 +14,7 @@ export function HomeSearchBar({
   filterA11y,
   filterActive,
   onChangeQuery,
+  onDismiss,
   onOpenFilter,
   padded = true,
   query,
@@ -23,6 +24,7 @@ export function HomeSearchBar({
   filterA11y?: string;
   filterActive: boolean;
   onChangeQuery(value: string): void;
+  onDismiss?: () => void;
   onOpenFilter(): void;
   padded?: boolean;
   query: string;
@@ -57,12 +59,18 @@ export function HomeSearchBar({
           testID={testIDs?.input ?? 'home.searchInput'}
           value={query}
         />
-        {trimmed ? (
+        {trimmed || onDismiss ? (
           <Pressable
-            accessibilityLabel={t('devices.detail.search.clearA11y')}
+            accessibilityLabel={trimmed ? t('devices.detail.search.clearA11y') : t('devices.detail.search.closeInputA11y')}
             accessibilityRole="button"
             hitSlop={6}
-            onPress={() => onChangeQuery('')}
+            onPress={() => {
+              if (trimmed) {
+                onChangeQuery('');
+                return;
+              }
+              onDismiss?.();
+            }}
             style={({ pressed }) => [styles.iconButton, pressed && styles.pressed]}
             testID={testIDs?.clear ?? 'home.searchClearButton'}
           >

--- a/apps/mobile/src/session/HomeSearchBar.tsx
+++ b/apps/mobile/src/session/HomeSearchBar.tsx
@@ -1,0 +1,140 @@
+/**
+ * 首页任务搜索条。对齐桌面 SidebarInlineSearch 展开态:
+ * 圆角 pill、左侧放大镜、占位「搜索标题或内容…」、有字时清空、右侧筛选钮。
+ */
+import { Search, SlidersHorizontal, X } from 'lucide-react-native';
+import { Pressable, StyleSheet, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { TextInput } from '@/components/AppText';
+import { useTheme, useThemedStyles, type ThemeColors } from '@/theme';
+import { iconSize, iconStroke, radius, spacing, typeScale } from '@/theme/tokens';
+
+export function HomeSearchBar({
+  autoFocus,
+  filterA11y,
+  filterActive,
+  onChangeQuery,
+  onOpenFilter,
+  padded = true,
+  query,
+  testIDs,
+}: {
+  autoFocus: boolean;
+  filterA11y?: string;
+  filterActive: boolean;
+  onChangeQuery(value: string): void;
+  onOpenFilter(): void;
+  padded?: boolean;
+  query: string;
+  testIDs?: {
+    clear?: string;
+    filter?: string;
+    input?: string;
+    row?: string;
+  };
+}) {
+  const styles = useThemedStyles(makeStyles);
+  const { colors } = useTheme();
+  const { t } = useTranslation();
+  const trimmed = query.trim();
+  return (
+    <View style={[styles.row, !padded && styles.rowFlush]} testID={testIDs?.row ?? 'home.searchRow'}>
+      <View style={styles.pill}>
+        <Search
+          color={colors.textSecondary}
+          size={iconSize.md}
+          strokeWidth={iconStroke.regular}
+        />
+        <TextInput
+          accessibilityLabel={t('devices.list.search.placeholder')}
+          autoCapitalize="none"
+          autoCorrect={false}
+          autoFocus={autoFocus}
+          onChangeText={onChangeQuery}
+          placeholder={t('devices.list.search.placeholder')}
+          placeholderTextColor={colors.textTertiary}
+          style={styles.input}
+          testID={testIDs?.input ?? 'home.searchInput'}
+          value={query}
+        />
+        {trimmed ? (
+          <Pressable
+            accessibilityLabel={t('devices.detail.search.clearA11y')}
+            accessibilityRole="button"
+            hitSlop={6}
+            onPress={() => onChangeQuery('')}
+            style={({ pressed }) => [styles.iconButton, pressed && styles.pressed]}
+            testID={testIDs?.clear ?? 'home.searchClearButton'}
+          >
+            <X color={colors.textTertiary} size={iconSize.md} strokeWidth={iconStroke.regular} />
+          </Pressable>
+        ) : null}
+        <Pressable
+          accessibilityLabel={filterA11y ?? t('devices.list.search.filterA11y')}
+          accessibilityRole="button"
+          accessibilityState={{ selected: filterActive }}
+          hitSlop={6}
+          onPress={onOpenFilter}
+          style={({ pressed }) => [styles.iconButton, pressed && styles.pressed]}
+          testID={testIDs?.filter ?? 'home.searchFilterButton'}
+        >
+          <SlidersHorizontal
+            color={filterActive ? colors.textPrimary : colors.textSecondary}
+            size={iconSize.md}
+            strokeWidth={iconStroke.regular}
+          />
+          {filterActive ? <View style={styles.filterDot} /> : null}
+        </Pressable>
+      </View>
+    </View>
+  );
+}
+
+const makeStyles = (colors: ThemeColors) => StyleSheet.create({
+  row: {
+    paddingBottom: spacing.sm,
+    paddingHorizontal: spacing.lg,
+  },
+  rowFlush: {
+    paddingBottom: 0,
+    paddingHorizontal: 0,
+  },
+  pill: {
+    alignItems: 'center',
+    backgroundColor: colors.surfaceElevated,
+    borderColor: colors.border,
+    borderRadius: radius.pill,
+    borderWidth: StyleSheet.hairlineWidth,
+    flexDirection: 'row',
+    gap: spacing.sm,
+    minHeight: 44,
+    paddingLeft: spacing.lg,
+    paddingRight: spacing.xs,
+  },
+  input: {
+    color: colors.textPrimary,
+    flex: 1,
+    fontSize: typeScale.body,
+    minWidth: 0,
+    paddingVertical: spacing.sm,
+  },
+  iconButton: {
+    alignItems: 'center',
+    height: 36,
+    justifyContent: 'center',
+    position: 'relative',
+    width: 36,
+  },
+  filterDot: {
+    backgroundColor: colors.statusAccent,
+    borderRadius: radius.pill,
+    height: 6,
+    position: 'absolute',
+    right: 7,
+    top: 7,
+    width: 6,
+  },
+  pressed: {
+    opacity: 0.72,
+  },
+});

--- a/apps/mobile/src/session/SessionListDrawer.tsx
+++ b/apps/mobile/src/session/SessionListDrawer.tsx
@@ -252,6 +252,14 @@ export function SessionListDrawer({
   const storeVersion = useRemoteSessionStoreVersion();
   const messageVersion = useRemoteMessageVersion();
   const searchOrigins = useMemo(() => {
+    const identities = remoteSessionStore.getDeviceIdentity();
+    if (identities.length > 0) {
+      return identities.map((device) => ({
+        deviceId: device.deviceId,
+        deviceName: device.name,
+        reachable: !unresponsiveDevicesStore.has(device.deviceId),
+      }));
+    }
     const byId = new Map<string, ConversationSearchDeviceOrigin>();
     for (const session of sessions) {
       const id = session.canonicalDeviceId ?? session.deviceLinkDeviceId;
@@ -268,14 +276,10 @@ export function SessionListDrawer({
     () => listConversationSearchProjects(excludeOrcaWorkerSessions(sessions)),
     [sessions],
   );
-  const visibleSearchProjectKeys = useMemo(
-    () => searchProjects.map((project) => project.key),
-    [searchProjects],
-  );
   const indexedSearch = useConversationSearch({
     enabled: mounted,
     origins: searchOrigins,
-    visibleProjectKeys: visibleSearchProjectKeys,
+    projects: searchProjects,
   });
   const searchQuery = indexedSearch.query;
   const [searchFilterOpen, setSearchFilterOpen] = useState(false);

--- a/apps/mobile/src/session/SessionListDrawer.tsx
+++ b/apps/mobile/src/session/SessionListDrawer.tsx
@@ -42,12 +42,14 @@ import { Text } from '@/components/AppText';
 import { ConversationSearchFilterSheet } from '@/session/ConversationSearchFilterSheet';
 import { HomeSearchBar } from '@/session/HomeSearchBar';
 import {
+  conversationSearchOriginsFromDeviceModels,
   listConversationSearchProjects,
   shouldReplaceListWithSearchResults,
+  type ConversationSearchDeviceModel,
   type ConversationSearchDeviceOrigin,
 } from '@/session/conversationSearch';
 import { useConversationSearch } from '@/session/useConversationSearch';
-import { unresponsiveDevicesStore } from '@/device-link/unresponsiveDevicesStore';
+import { useUnresponsiveDevices } from '@/device-link/unresponsiveDevicesStore';
 import { Gesture, GestureDetector } from '@/platform/gestureHandler';
 import { useReduceMotionEnabled } from '@/hooks/useReduceMotion';
 import { buildHomeSections, type HomeRow, type HomeSection } from '@/session/homeSections';
@@ -251,13 +253,20 @@ export function SessionListDrawer({
   // 早退,不为收起的抽屉付这份成本。
   const storeVersion = useRemoteSessionStoreVersion();
   const messageVersion = useRemoteMessageVersion();
+  const unresponsiveDevices = useUnresponsiveDevices();
   const searchOrigins = useMemo(() => {
+    const models = remoteSessionStore.getConversationSearchDeviceModels() as ConversationSearchDeviceModel[];
+    if (models.length > 0) {
+      return conversationSearchOriginsFromDeviceModels(models, {
+        unresponsiveDeviceIds: unresponsiveDevices,
+      });
+    }
     const identities = remoteSessionStore.getDeviceIdentity();
     if (identities.length > 0) {
       return identities.map((device) => ({
         deviceId: device.deviceId,
         deviceName: device.name,
-        reachable: !unresponsiveDevicesStore.has(device.deviceId),
+        reachable: false,
       }));
     }
     const byId = new Map<string, ConversationSearchDeviceOrigin>();
@@ -267,11 +276,11 @@ export function SessionListDrawer({
       byId.set(id, {
         deviceId: id,
         deviceName: session.deviceLinkDeviceName ?? id,
-        reachable: !unresponsiveDevicesStore.has(id),
+        reachable: false,
       });
     }
     return [...byId.values()];
-  }, [sessions, storeVersion]);
+  }, [sessions, storeVersion, unresponsiveDevices]);
   const searchProjects = useMemo(
     () => listConversationSearchProjects(excludeOrcaWorkerSessions(sessions)),
     [sessions],

--- a/apps/mobile/src/session/SessionListDrawer.tsx
+++ b/apps/mobile/src/session/SessionListDrawer.tsx
@@ -39,6 +39,15 @@ import Animated, {
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
 import { Text } from '@/components/AppText';
+import { ConversationSearchFilterSheet } from '@/session/ConversationSearchFilterSheet';
+import { HomeSearchBar } from '@/session/HomeSearchBar';
+import {
+  listConversationSearchProjects,
+  shouldReplaceListWithSearchResults,
+  type ConversationSearchDeviceOrigin,
+} from '@/session/conversationSearch';
+import { useConversationSearch } from '@/session/useConversationSearch';
+import { unresponsiveDevicesStore } from '@/device-link/unresponsiveDevicesStore';
 import { Gesture, GestureDetector } from '@/platform/gestureHandler';
 import { useReduceMotionEnabled } from '@/hooks/useReduceMotion';
 import { buildHomeSections, type HomeRow, type HomeSection } from '@/session/homeSections';
@@ -242,6 +251,43 @@ export function SessionListDrawer({
   // 早退,不为收起的抽屉付这份成本。
   const storeVersion = useRemoteSessionStoreVersion();
   const messageVersion = useRemoteMessageVersion();
+  const searchOrigins = useMemo(() => {
+    const byId = new Map<string, ConversationSearchDeviceOrigin>();
+    for (const session of sessions) {
+      const id = session.canonicalDeviceId ?? session.deviceLinkDeviceId;
+      if (!id || byId.has(id)) continue;
+      byId.set(id, {
+        deviceId: id,
+        deviceName: session.deviceLinkDeviceName ?? id,
+        reachable: !unresponsiveDevicesStore.has(id),
+      });
+    }
+    return [...byId.values()];
+  }, [sessions, storeVersion]);
+  const searchProjects = useMemo(
+    () => listConversationSearchProjects(excludeOrcaWorkerSessions(sessions)),
+    [sessions],
+  );
+  const visibleSearchProjectKeys = useMemo(
+    () => searchProjects.map((project) => project.key),
+    [searchProjects],
+  );
+  const indexedSearch = useConversationSearch({
+    enabled: mounted,
+    origins: searchOrigins,
+    visibleProjectKeys: visibleSearchProjectKeys,
+  });
+  const searchQuery = indexedSearch.query;
+  const [searchFilterOpen, setSearchFilterOpen] = useState(false);
+  const searchFilterA11y = t('devices.list.search.filterAria', {
+    agent: t(`devices.list.search.filter.agent.${indexedSearch.agentFilter}`),
+    lastActivity: t(`devices.list.search.filter.lastActivity.${indexedSearch.lastActivityFilter}`),
+    projects: indexedSearch.projectSelection === 'all'
+      ? t('devices.list.search.filter.allProjects')
+      : t('devices.list.search.filter.selectedProjects', { count: indexedSearch.projectSelection.length }),
+    sort: t(`devices.list.search.filter.sort.${indexedSearch.sortBy}`),
+    status: t(`devices.list.search.filter.status.${indexedSearch.statusFilter}`),
+  });
   const sections = useMemo<HomeSection[]>(() => {
     if (!mounted) return [];
     void storeVersion;
@@ -266,6 +312,7 @@ export function SessionListDrawer({
       if (liveActivity) liveActivityEntries.push([session.id, liveActivity]);
     }
     const home = buildMobileHomePresentation({
+      searchQuery,
       // 权威设备身份必须随会话一起进 presentation:canonicalizeSessionDevice 会按传入
       // devices 重算并覆盖 canonicalDeviceId,空列表会把 store 已认领好的规范 id 打回
       // 弱推断(re-link 后点行路由到旧物理设备)。store 身份变化会触发 sessions 重算,
@@ -285,8 +332,20 @@ export function SessionListDrawer({
       // 已解析的 i18n 文案传给共享层(共享层不出中文串;en/ja/ko 不再回退「未命名任务」)。
       unnamedLabel: t('session.menu.unnamedTitle'),
     });
+    if (shouldReplaceListWithSearchResults(searchQuery, indexedSearch.status)) {
+      return [{
+        data: indexedSearch.results.map((item) => ({
+          item,
+          key: `search:${(item.session as { deviceLinkDeviceId?: string | null }).deviceLinkDeviceId ?? 'local'}:${item.session.id}`,
+          kind: 'session' as const,
+          source: 'search' as const,
+        })),
+        key: 'search',
+        title: null,
+      }];
+    }
     return buildHomeSections(home, false, false);
-  }, [messageVersion, mounted, sessions, storeVersion, t]);
+  }, [indexedSearch.results, indexedSearch.status, messageVersion, mounted, searchQuery, sessions, storeVersion, t]);
   const hasRows = useMemo(
     () => sections.some((section) => section.data.length > 0),
     [sections],
@@ -359,6 +418,22 @@ export function SessionListDrawer({
               />
             </Pressable>
           </View>
+          <View style={styles.drawerSearchRow}>
+            <HomeSearchBar
+              autoFocus={false}
+              filterA11y={searchFilterA11y}
+              filterActive={indexedSearch.activeFilterCount > 0}
+              onChangeQuery={indexedSearch.setQuery}
+              onOpenFilter={() => setSearchFilterOpen(true)}
+              padded={false}
+              query={searchQuery}
+              testIDs={{
+                filter: 'sessionDrawer.searchFilterButton',
+                input: 'sessionDrawer.searchInput',
+                row: 'sessionDrawer.searchRow',
+              }}
+            />
+          </View>
           {hasRows ? (
             <SectionList
               contentContainerStyle={styles.listContent}
@@ -399,6 +474,25 @@ export function SessionListDrawer({
           </View>
         </Animated.View>
       </GestureDetector>
+      <ConversationSearchFilterSheet
+        activeCount={indexedSearch.activeFilterCount}
+        agentKind={indexedSearch.agentFilter}
+        lastActivity={indexedSearch.lastActivityFilter}
+        lockedProjects={false}
+        onAgentKindChange={indexedSearch.setAgentFilter}
+        onClose={() => setSearchFilterOpen(false)}
+        onLastActivityChange={indexedSearch.setLastActivityFilter}
+        onProjectsChange={indexedSearch.setProjectSelection}
+        onReset={indexedSearch.resetFilters}
+        onSortChange={indexedSearch.setSortBy}
+        onStatusChange={indexedSearch.setStatusFilter}
+        projectSelection={indexedSearch.projectSelection}
+        projects={searchProjects}
+        sortBy={indexedSearch.sortBy}
+        status={indexedSearch.statusFilter}
+        topOffset={insets.top + spacing.sm}
+        visible={searchFilterOpen}
+      />
     </View>
   );
 }
@@ -559,6 +653,23 @@ const makeStyles = (colors: ThemeColors) =>
       justifyContent: 'space-between',
       paddingHorizontal: spacing.lg,
       paddingVertical: spacing.sm,
+    },
+    drawerSearchRow: {
+      alignItems: 'center',
+      borderBottomColor: colors.border,
+      borderBottomWidth: StyleSheet.hairlineWidth,
+      flexDirection: 'row',
+      gap: spacing.sm,
+      minHeight: 44,
+      paddingHorizontal: spacing.lg,
+      paddingVertical: spacing.xs,
+    },
+    drawerSearchInput: {
+      color: colors.textPrimary,
+      flex: 1,
+      fontSize: typeScale.body,
+      minWidth: 0,
+      paddingVertical: spacing.xs,
     },
     panelTitle: {
       color: colors.textPrimary,

--- a/apps/mobile/src/session/conversationSearch.ts
+++ b/apps/mobile/src/session/conversationSearch.ts
@@ -24,8 +24,10 @@ import {
   toRemoteSessionListItem,
   type RemoteSessionListItem,
 } from '@cindy/maker-shared/session-list';
+import type { DeviceAccessState } from '@cindy/maker-shared/device-list';
 import { collapseWorktreeDirForGrouping } from '@cindy/maker-shared/worktree-paths';
 import { createMobileMakerTransport } from '@/device-link/mobileMakerTransport';
+import { deviceMirrorCleanupDisposition } from '@/device-link/presenceDevices';
 import type { RemoteSession } from '@/session/types';
 
 export const CONVERSATION_SEARCH_LIMIT = 24;
@@ -41,6 +43,38 @@ export interface ConversationSearchDeviceOrigin {
   deviceName: string | null;
   reachable: boolean;
   workingDirs?: string[] | null;
+}
+
+export interface ConversationSearchDeviceModel {
+  canOpen: boolean;
+  deviceId: string;
+  name: string | null;
+  state: DeviceAccessState;
+}
+
+/**
+ * 搜索源与会话镜像清理边界对齐:
+ * - 全部范围:keep / soft(含短暂 offline)进源,hard(撤权 / 关远控)排除;
+ * - 单台范围:只保留选中的那台,即使它暂时 offline;
+ * - reachable 只看当前能否 invoke,离线或熔断都走缓存回退。
+ */
+export function conversationSearchOriginsFromDeviceModels(
+  devices: readonly ConversationSearchDeviceModel[],
+  options: {
+    selectedDeviceId?: string | null;
+    unresponsiveDeviceIds?: ReadonlySet<string>;
+  } = {},
+): ConversationSearchDeviceOrigin[] {
+  const selectedDeviceId = options.selectedDeviceId ?? null;
+  const unresponsiveDeviceIds = options.unresponsiveDeviceIds;
+  const targets = selectedDeviceId
+    ? devices.filter((item) => item.deviceId === selectedDeviceId)
+    : devices.filter((item) => deviceMirrorCleanupDisposition(item.state) !== 'hard');
+  return targets.map((item) => ({
+    deviceId: item.deviceId,
+    deviceName: item.name,
+    reachable: item.canOpen && !unresponsiveDeviceIds?.has(item.deviceId),
+  }));
 }
 
 export interface SearchConversationsAcrossDevicesDeps {

--- a/apps/mobile/src/session/conversationSearch.ts
+++ b/apps/mobile/src/session/conversationSearch.ts
@@ -1,0 +1,345 @@
+/**
+ * 手机任务搜索集成层:按设备 fan-out `local-db:conversations:search`,
+ * 老端 / 离线回落到已缓存会话的 matchesSearchQuery。
+ *
+ * 纯函数 + 注入依赖,不直接碰 React / store。
+ */
+import {
+  emptyConversationSearchResponse,
+  filterResultsByRequestFilters,
+  mergeConversationSearchFanout,
+  remoteIndexedSearchIgnoredWorkingDirs,
+  stampRemoteSearchResponse,
+  type ConversationSearchAgentFilter,
+  type ConversationSearchLastActivityFilter,
+  type ConversationSearchRequest,
+  type ConversationSearchResponse,
+  type ConversationSearchResultItem,
+  type ConversationSearchSessionSummary,
+  type ConversationSearchStatusFilter,
+} from '@cindy/maker-shared/conversation-search';
+import { stripTrailingPathSeparators } from '@cindy/maker-shared/path-text';
+import {
+  matchesSearchQuery,
+  toRemoteSessionListItem,
+  type RemoteSessionListItem,
+} from '@cindy/maker-shared/session-list';
+import { collapseWorktreeDirForGrouping } from '@cindy/maker-shared/worktree-paths';
+import { createMobileMakerTransport } from '@/device-link/mobileMakerTransport';
+import type { RemoteSession } from '@/session/types';
+
+export const CONVERSATION_SEARCH_LIMIT = 24;
+
+export type ConversationSearchInvoke = <T>(
+  deviceId: string,
+  channel: string,
+  args?: unknown[],
+) => Promise<T>;
+
+export interface ConversationSearchDeviceOrigin {
+  deviceId: string;
+  deviceName: string | null;
+  reachable: boolean;
+}
+
+export interface SearchConversationsAcrossDevicesDeps {
+  invoke: ConversationSearchInvoke;
+  getCachedSessions: () => readonly RemoteSession[];
+  isDeviceUnresponsive?: (deviceId: string) => boolean;
+}
+
+export function isConversationSearchChannelNotAllowed(error: unknown): boolean {
+  const code = (error as { code?: unknown } | null | undefined)?.code;
+  const message = error instanceof Error
+    ? error.message
+    : typeof error === 'string'
+      ? error
+      : String(error);
+  return `${typeof code === 'string' ? code : ''} ${message}`.includes('CHANNEL_NOT_ALLOWED');
+}
+
+export function sessionBelongsToDevice(
+  session: Pick<RemoteSession, 'canonicalDeviceId' | 'deviceLinkDeviceId'>,
+  deviceId: string,
+): boolean {
+  return (session.canonicalDeviceId ?? session.deviceLinkDeviceId) === deviceId;
+}
+
+export async function searchConversationsAcrossDevices(
+  origins: readonly ConversationSearchDeviceOrigin[],
+  request: ConversationSearchRequest,
+  deps: SearchConversationsAcrossDevicesDeps,
+): Promise<ConversationSearchResponse> {
+  const query = request.query.trim();
+  if (!query || origins.length === 0) return emptyConversationSearchResponse(query);
+
+  const keywordRequest: ConversationSearchRequest = {
+    ...request,
+    query,
+    limit: request.limit ?? CONVERSATION_SEARCH_LIMIT,
+    semanticMode: 'keyword',
+  };
+
+  const pages = await Promise.all(
+    origins.map((origin) => searchOneDevice(origin, keywordRequest, deps)),
+  );
+  const present = pages.filter((page): page is ConversationSearchResponse => page != null);
+  if (present.length === 0) return emptyConversationSearchResponse(query);
+
+  const merged = mergeConversationSearchFanout(
+    present,
+    keywordRequest.limit ?? CONVERSATION_SEARCH_LIMIT,
+    keywordRequest.sortBy ?? 'relevance',
+  );
+  return filterResultsByRequestFilters(merged, keywordRequest);
+}
+
+async function searchOneDevice(
+  origin: ConversationSearchDeviceOrigin,
+  request: ConversationSearchRequest,
+  deps: SearchConversationsAcrossDevicesDeps,
+): Promise<ConversationSearchResponse | null> {
+  const unresponsive = deps.isDeviceUnresponsive?.(origin.deviceId) === true;
+  if (!origin.reachable || unresponsive) {
+    return searchCachedDeviceSessions(origin, request, deps.getCachedSessions());
+  }
+
+  try {
+    const maker = createMobileMakerTransport({
+      deviceId: origin.deviceId,
+      invoke: deps.invoke,
+    });
+    const raw = await maker.searchConversations(request);
+    if (remoteIndexedSearchIgnoredWorkingDirs(raw, request.filters?.workingDirs)) {
+      return searchCachedDeviceSessions(origin, request, deps.getCachedSessions());
+    }
+    return finalizeRemotePage(raw, origin, request);
+  } catch (error) {
+    return searchCachedDeviceSessions(origin, request, deps.getCachedSessions());
+  }
+}
+
+function finalizeRemotePage(
+  response: ConversationSearchResponse,
+  origin: ConversationSearchDeviceOrigin,
+  request: ConversationSearchRequest,
+): ConversationSearchResponse {
+  return filterResultsByRequestFilters(
+    stampRemoteSearchResponse(response, {
+      deviceId: origin.deviceId,
+      deviceName: origin.deviceName,
+    }),
+    request,
+  );
+}
+
+export function searchCachedDeviceSessions(
+  origin: ConversationSearchDeviceOrigin,
+  request: ConversationSearchRequest,
+  sessions: readonly RemoteSession[],
+): ConversationSearchResponse {
+  const query = request.query.trim().toLowerCase();
+  if (!query) return emptyConversationSearchResponse('');
+
+  const hits: ConversationSearchResultItem[] = [];
+  sessions.forEach((session, index) => {
+    if (session.orcaRole === 'worker') return;
+    if (!sessionBelongsToDevice(session, origin.deviceId)) return;
+    if (!matchesSearchQuery(session, query, { unnamedLabel: request.unnamedLabel })) return;
+    hits.push({
+      session: sessionToSearchSummary(session, origin),
+      matchKind: 'title',
+      titleMatchIndices: [],
+      titleScore: null,
+      contentHit: null,
+      contentHits: [],
+      rankScore: 1_000_000 - index,
+    });
+  });
+
+  return filterResultsByRequestFilters(
+    {
+      query: request.query.trim(),
+      results: hits,
+      vectorUsed: false,
+      vectorSkipReason: null,
+      poolCapped: false,
+    },
+    request,
+  );
+}
+
+function sessionToSearchSummary(
+  session: RemoteSession,
+  origin: ConversationSearchDeviceOrigin,
+): ConversationSearchSessionSummary {
+  return {
+    id: session.id,
+    title: session.title,
+    workingDir: session.workingDir,
+    workspaceKind: session.workspaceKind,
+    agentKind: session.agentKind,
+    status: session.status,
+    source: session.source ?? null,
+    orcaRole: session.orcaRole === 'lead' || session.orcaRole === 'worker' ? session.orcaRole : null,
+    parentSessionId: session.parentSessionId ?? null,
+    userSendAt: session.userSendAt,
+    updatedAt: session.updatedAt,
+    createdAt: session.createdAt,
+    _count: { messages: session._count?.messages ?? 0 },
+    deviceLinkDeviceId: origin.deviceId,
+    deviceLinkDeviceName: origin.deviceName ?? session.deviceLinkDeviceName ?? null,
+  };
+}
+
+export function toSearchListItem(
+  item: ConversationSearchResultItem,
+  now: number,
+  unnamedLabel?: string,
+  cached?: RemoteSession,
+): RemoteSessionListItem {
+  const stamped = cached
+    ? {
+        ...cached,
+        deviceLinkDeviceId: item.session.deviceLinkDeviceId ?? cached.deviceLinkDeviceId,
+        deviceLinkDeviceName: item.session.deviceLinkDeviceName ?? cached.deviceLinkDeviceName,
+      }
+    : {
+        id: item.session.id,
+        title: item.session.title,
+        workingDir: item.session.workingDir,
+        workspaceKind: item.session.workspaceKind,
+        agentKind: item.session.agentKind,
+        status: item.session.status,
+        source: item.session.source ?? null,
+        orcaRole: item.session.orcaRole,
+        userSendAt: item.session.userSendAt,
+        updatedAt: item.session.updatedAt,
+        createdAt: item.session.createdAt,
+        model: '',
+        _count: item.session._count,
+        deviceLinkDeviceId: item.session.deviceLinkDeviceId,
+        deviceLinkDeviceName: item.session.deviceLinkDeviceName,
+      };
+  return toRemoteSessionListItem(
+    stamped,
+    now,
+    undefined,
+    0,
+    item.contentHit?.preview ?? cached?.preview ?? null,
+    null,
+    unnamedLabel,
+  );
+}
+
+export type ConversationSearchProjectSelection = 'all' | string[];
+
+export interface ConversationSearchProjectOption {
+  count: number;
+  key: string;
+  title: string;
+  workingDir: string;
+}
+
+export function shouldReplaceListWithSearchResults(
+  query: string,
+  status: 'idle' | 'searching' | 'ready',
+): boolean {
+  return query.trim().length > 0 && status === 'ready';
+}
+
+export function conversationSearchStatusFilter(
+  status: string | undefined,
+): ConversationSearchStatusFilter {
+  if (status === 'active' || status === 'archived' || status === 'all') return status;
+  return 'all';
+}
+
+export function conversationSearchActiveFilterCount(input: {
+  agentKind?: ConversationSearchAgentFilter;
+  lastActivity?: ConversationSearchLastActivityFilter;
+  lockedWorkingDirs?: string[] | null;
+  projectSelection?: ConversationSearchProjectSelection;
+  status?: ConversationSearchStatusFilter;
+}): number {
+  let count = 0;
+  if ((input.status ?? 'all') !== 'all') count += 1;
+  if ((input.agentKind ?? 'all') !== 'all') count += 1;
+  if ((input.lastActivity ?? 'all') !== 'all') count += 1;
+  if (!input.lockedWorkingDirs?.length && input.projectSelection && input.projectSelection !== 'all') {
+    count += 1;
+  }
+  return count;
+}
+
+export function nextConversationSearchProjectSelection(
+  prev: ConversationSearchProjectSelection,
+  projectKey: string,
+): ConversationSearchProjectSelection {
+  if (prev === 'all') return [projectKey];
+  if (prev.includes(projectKey)) {
+    const next = prev.filter((key) => key !== projectKey);
+    return next.length > 0 ? next : 'all';
+  }
+  return [...prev, projectKey];
+}
+
+export function reconcileConversationSearchProjectSelection(
+  selection: ConversationSearchProjectSelection,
+  visibleKeys: readonly string[],
+): ConversationSearchProjectSelection {
+  if (selection === 'all') return 'all';
+  const visible = new Set(visibleKeys);
+  const next = selection.filter((key) => visible.has(key));
+  return next.length > 0 ? next : 'all';
+}
+
+export function conversationSearchWorkingDirs(input: {
+  lockedWorkingDirs?: string[] | null;
+  projectSelection?: ConversationSearchProjectSelection;
+}): string[] | null {
+  if (input.lockedWorkingDirs?.length) return [...input.lockedWorkingDirs];
+  if (!input.projectSelection || input.projectSelection === 'all') return null;
+  return [...input.projectSelection];
+}
+
+export function listConversationSearchProjects(
+  sessions: readonly Pick<RemoteSession, 'canonicalDeviceId' | 'deviceLinkDeviceId' | 'orcaRole' | 'workingDir' | 'workspaceKind'>[],
+  deviceIds?: ReadonlySet<string>,
+): ConversationSearchProjectOption[] {
+  const byKey = new Map<string, ConversationSearchProjectOption>();
+  for (const session of sessions) {
+    if (session.orcaRole === 'worker') continue;
+    if (deviceIds && !sessionBelongsToSelectedDevice(session, deviceIds)) continue;
+    if (session.workspaceKind === 'dialogue') continue;
+    const workingDir = stripTrailingPathSeparators(session.workingDir?.trim() ?? '');
+    if (!workingDir) continue;
+    const key = collapseWorktreeDirForGrouping(workingDir) ?? workingDir;
+    const existing = byKey.get(key);
+    if (existing) {
+      existing.count += 1;
+      continue;
+    }
+    byKey.set(key, {
+      count: 1,
+      key,
+      title: conversationSearchProjectTitle(workingDir),
+      workingDir,
+    });
+  }
+  return [...byKey.values()].sort((a, b) => a.title.localeCompare(b.title) || a.key.localeCompare(b.key));
+}
+
+function sessionBelongsToSelectedDevice(
+  session: Pick<RemoteSession, 'canonicalDeviceId' | 'deviceLinkDeviceId'>,
+  deviceIds: ReadonlySet<string>,
+): boolean {
+  const id = session.canonicalDeviceId ?? session.deviceLinkDeviceId;
+  return !!id && deviceIds.has(id);
+}
+
+function conversationSearchProjectTitle(workingDir: string): string {
+  const trimmed = stripTrailingPathSeparators(workingDir);
+  const parts = trimmed.split(/[\\/]/).filter(Boolean);
+  return parts[parts.length - 1] || workingDir;
+}

--- a/apps/mobile/src/session/conversationSearch.ts
+++ b/apps/mobile/src/session/conversationSearch.ts
@@ -1,6 +1,6 @@
 /**
  * 手机任务搜索集成层:按设备 fan-out `local-db:conversations:search`,
- * 老端 / 离线回落到已缓存会话的 matchesSearchQuery。
+ * 老端 / 离线回落到已缓存会话的标题与消息预览，不搜列表元数据。
  *
  * 纯函数 + 注入依赖,不直接碰 React / store。
  */
@@ -20,7 +20,8 @@ import {
 } from '@cindy/maker-shared/conversation-search';
 import { stripTrailingPathSeparators } from '@cindy/maker-shared/path-text';
 import {
-  matchesSearchQuery,
+  remoteSessionDisplayTitle,
+  sessionRowMessagePreview,
   toRemoteSessionListItem,
   type RemoteSessionListItem,
 } from '@cindy/maker-shared/session-list';
@@ -181,10 +182,11 @@ export function searchCachedDeviceSessions(
   sessions.forEach((session, index) => {
     if (session.orcaRole === 'worker') return;
     if (!sessionBelongsToDevice(session, origin.deviceId)) return;
-    if (!matchesSearchQuery(session, query, { unnamedLabel: request.unnamedLabel })) return;
+    const match = cachedConversationSearchMatch(session, query, request.unnamedLabel);
+    if (!match) return;
     hits.push({
       session: sessionToSearchSummary(session, origin),
-      matchKind: 'title',
+      matchKind: match.matchKind,
       titleMatchIndices: [],
       titleScore: null,
       contentHit: null,
@@ -203,6 +205,18 @@ export function searchCachedDeviceSessions(
     },
     request,
   );
+}
+
+function cachedConversationSearchMatch(
+  session: RemoteSession,
+  query: string,
+  unnamedLabel?: string,
+): { matchKind: 'title' | 'content' | 'both' } | null {
+  const titleHit = remoteSessionDisplayTitle(session, unnamedLabel).toLowerCase().includes(query);
+  const contentHit = (sessionRowMessagePreview(session) ?? '').toLowerCase().includes(query);
+  if (!titleHit && !contentHit) return null;
+  if (titleHit && contentHit) return { matchKind: 'both' };
+  return { matchKind: titleHit ? 'title' : 'content' };
 }
 
 function sessionToSearchSummary(

--- a/apps/mobile/src/session/conversationSearch.ts
+++ b/apps/mobile/src/session/conversationSearch.ts
@@ -244,7 +244,30 @@ function sessionToSearchSummary(
 
 export type ConversationSearchListItem = RemoteSessionListItem & {
   searchFocusClientId?: string;
+  searchLocallyCached: boolean;
 };
+
+export function conversationSearchSessionCacheKey(
+  session: Pick<RemoteSession, 'id'> & {
+    canonicalDeviceId?: string | null;
+    deviceLinkDeviceId?: string | null;
+  },
+): string {
+  return `${session.canonicalDeviceId ?? session.deviceLinkDeviceId ?? 'local'}:${session.id}`;
+}
+
+export function conversationSearchAllowsLocalWrites(item: object): boolean {
+  return !('searchLocallyCached' in item) || item.searchLocallyCached !== false;
+}
+
+export function cachedSessionForSearchResult(
+  item: ConversationSearchResultItem,
+  sessionsByCacheKey: ReadonlyMap<string, RemoteSession>,
+): RemoteSession | undefined {
+  const deviceId = item.session.deviceLinkDeviceId;
+  if (!deviceId) return undefined;
+  return sessionsByCacheKey.get(`${deviceId}:${item.session.id}`);
+}
 
 export function toSearchListItem(
   item: ConversationSearchResultItem,
@@ -252,10 +275,12 @@ export function toSearchListItem(
   unnamedLabel?: string,
   cached?: RemoteSession,
 ): ConversationSearchListItem {
+  const deviceId = item.session.deviceLinkDeviceId ?? cached?.deviceLinkDeviceId;
   const stamped = cached
     ? {
         ...cached,
-        deviceLinkDeviceId: item.session.deviceLinkDeviceId ?? cached.deviceLinkDeviceId,
+        canonicalDeviceId: deviceId ?? cached.canonicalDeviceId,
+        deviceLinkDeviceId: deviceId,
         deviceLinkDeviceName: item.session.deviceLinkDeviceName ?? cached.deviceLinkDeviceName,
       }
     : {
@@ -285,7 +310,11 @@ export function toSearchListItem(
     unnamedLabel,
   );
   const searchFocusClientId = item.contentHit?.messageClientId?.trim();
-  return searchFocusClientId ? { ...listItem, searchFocusClientId } : listItem;
+  return {
+    ...listItem,
+    searchLocallyCached: !!cached,
+    ...(searchFocusClientId ? { searchFocusClientId } : {}),
+  };
 }
 
 function requestForOrigin(

--- a/apps/mobile/src/session/conversationSearch.ts
+++ b/apps/mobile/src/session/conversationSearch.ts
@@ -256,8 +256,13 @@ export function conversationSearchSessionCacheKey(
   return `${session.canonicalDeviceId ?? session.deviceLinkDeviceId ?? 'local'}:${session.id}`;
 }
 
+/**
+ * 索引搜索行只负责打开任务。重命名 / 置顶 / 归档 / 多选写回留在普通列表:
+ * 搜索结果是一次请求的投影,订阅 store 再同步筛选只会把写操作家族继续放大。
+ * 带 searchLocallyCached 字段 = 搜索命中(无论是否命中本地镜像)。
+ */
 export function conversationSearchAllowsLocalWrites(item: object): boolean {
-  return !('searchLocallyCached' in item) || item.searchLocallyCached !== false;
+  return !('searchLocallyCached' in item);
 }
 
 export function cachedSessionForSearchResult(

--- a/apps/mobile/src/session/conversationSearch.ts
+++ b/apps/mobile/src/session/conversationSearch.ts
@@ -40,6 +40,7 @@ export interface ConversationSearchDeviceOrigin {
   deviceId: string;
   deviceName: string | null;
   reachable: boolean;
+  workingDirs?: string[] | null;
 }
 
 export interface SearchConversationsAcrossDevicesDeps {
@@ -101,7 +102,7 @@ async function searchOneDevice(
 ): Promise<ConversationSearchResponse | null> {
   const unresponsive = deps.isDeviceUnresponsive?.(origin.deviceId) === true;
   if (!origin.reachable || unresponsive) {
-    return searchCachedDeviceSessions(origin, request, deps.getCachedSessions());
+    return searchCachedDeviceSessions(origin, requestForOrigin(origin, request), deps.getCachedSessions());
   }
 
   try {
@@ -109,13 +110,14 @@ async function searchOneDevice(
       deviceId: origin.deviceId,
       invoke: deps.invoke,
     });
-    const raw = await maker.searchConversations(request);
-    if (remoteIndexedSearchIgnoredWorkingDirs(raw, request.filters?.workingDirs)) {
-      return searchCachedDeviceSessions(origin, request, deps.getCachedSessions());
+    const deviceRequest = requestForOrigin(origin, request);
+    const raw = await maker.searchConversations(deviceRequest);
+    if (remoteIndexedSearchIgnoredWorkingDirs(raw, deviceRequest.filters?.workingDirs)) {
+      return searchCachedDeviceSessions(origin, deviceRequest, deps.getCachedSessions());
     }
-    return finalizeRemotePage(raw, origin, request);
+    return finalizeRemotePage(raw, origin, deviceRequest);
   } catch (error) {
-    return searchCachedDeviceSessions(origin, request, deps.getCachedSessions());
+    return searchCachedDeviceSessions(origin, requestForOrigin(origin, request), deps.getCachedSessions());
   }
 }
 
@@ -192,12 +194,16 @@ function sessionToSearchSummary(
   };
 }
 
+export type ConversationSearchListItem = RemoteSessionListItem & {
+  searchFocusClientId?: string;
+};
+
 export function toSearchListItem(
   item: ConversationSearchResultItem,
   now: number,
   unnamedLabel?: string,
   cached?: RemoteSession,
-): RemoteSessionListItem {
+): ConversationSearchListItem {
   const stamped = cached
     ? {
         ...cached,
@@ -221,7 +227,7 @@ export function toSearchListItem(
         deviceLinkDeviceId: item.session.deviceLinkDeviceId,
         deviceLinkDeviceName: item.session.deviceLinkDeviceName,
       };
-  return toRemoteSessionListItem(
+  const listItem = toRemoteSessionListItem(
     stamped,
     now,
     undefined,
@@ -230,12 +236,30 @@ export function toSearchListItem(
     null,
     unnamedLabel,
   );
+  const searchFocusClientId = item.contentHit?.messageClientId?.trim();
+  return searchFocusClientId ? { ...listItem, searchFocusClientId } : listItem;
+}
+
+function requestForOrigin(
+  origin: ConversationSearchDeviceOrigin,
+  request: ConversationSearchRequest,
+): ConversationSearchRequest {
+  if (!origin.workingDirs?.length) return request;
+  return {
+    ...request,
+    filters: {
+      ...request.filters,
+      workingDirs: origin.workingDirs,
+    },
+  };
 }
 
 export type ConversationSearchProjectSelection = 'all' | string[];
 
 export interface ConversationSearchProjectOption {
   count: number;
+  deviceId: string;
+  deviceName: string | null;
   key: string;
   title: string;
   workingDir: string;
@@ -296,15 +320,34 @@ export function reconcileConversationSearchProjectSelection(
 
 export function conversationSearchWorkingDirs(input: {
   lockedWorkingDirs?: string[] | null;
-  projectSelection?: ConversationSearchProjectSelection;
 }): string[] | null {
   if (input.lockedWorkingDirs?.length) return [...input.lockedWorkingDirs];
-  if (!input.projectSelection || input.projectSelection === 'all') return null;
-  return [...input.projectSelection];
+  return null;
+}
+
+export function scopedConversationSearchOrigins(
+  origins: readonly ConversationSearchDeviceOrigin[],
+  selection: ConversationSearchProjectSelection,
+  projects: readonly ConversationSearchProjectOption[],
+): ConversationSearchDeviceOrigin[] {
+  if (selection === 'all') return [...origins];
+  const selected = new Set(selection);
+  const dirsByDevice = new Map<string, string[]>();
+  for (const project of projects) {
+    if (!selected.has(project.key)) continue;
+    const dirs = dirsByDevice.get(project.deviceId) ?? [];
+    if (!dirs.includes(project.workingDir)) dirs.push(project.workingDir);
+    dirsByDevice.set(project.deviceId, dirs);
+  }
+  return origins.flatMap((origin) => {
+    const dirs = dirsByDevice.get(origin.deviceId);
+    if (!dirs?.length) return [];
+    return [{ ...origin, workingDirs: dirs }];
+  });
 }
 
 export function listConversationSearchProjects(
-  sessions: readonly Pick<RemoteSession, 'canonicalDeviceId' | 'deviceLinkDeviceId' | 'orcaRole' | 'workingDir' | 'workspaceKind'>[],
+  sessions: readonly Pick<RemoteSession, 'canonicalDeviceId' | 'deviceLinkDeviceId' | 'deviceLinkDeviceName' | 'orcaRole' | 'workingDir' | 'workspaceKind'>[],
   deviceIds?: ReadonlySet<string>,
 ): ConversationSearchProjectOption[] {
   const byKey = new Map<string, ConversationSearchProjectOption>();
@@ -312,9 +355,12 @@ export function listConversationSearchProjects(
     if (session.orcaRole === 'worker') continue;
     if (deviceIds && !sessionBelongsToSelectedDevice(session, deviceIds)) continue;
     if (session.workspaceKind === 'dialogue') continue;
+    const deviceId = session.canonicalDeviceId ?? session.deviceLinkDeviceId;
+    if (!deviceId) continue;
     const workingDir = stripTrailingPathSeparators(session.workingDir?.trim() ?? '');
     if (!workingDir) continue;
-    const key = collapseWorktreeDirForGrouping(workingDir) ?? workingDir;
+    const dirKey = collapseWorktreeDirForGrouping(workingDir) ?? workingDir;
+    const key = `${deviceId}:${dirKey}`;
     const existing = byKey.get(key);
     if (existing) {
       existing.count += 1;
@@ -322,12 +368,16 @@ export function listConversationSearchProjects(
     }
     byKey.set(key, {
       count: 1,
+      deviceId,
+      deviceName: session.deviceLinkDeviceName ?? null,
       key,
       title: conversationSearchProjectTitle(workingDir),
-      workingDir,
+      workingDir: dirKey,
     });
   }
-  return [...byKey.values()].sort((a, b) => a.title.localeCompare(b.title) || a.key.localeCompare(b.key));
+  return [...byKey.values()].sort((a, b) => (
+    a.title.localeCompare(b.title) || a.deviceId.localeCompare(b.deviceId) || a.key.localeCompare(b.key)
+  ));
 }
 
 function sessionBelongsToSelectedDevice(

--- a/apps/mobile/src/session/homeSections.ts
+++ b/apps/mobile/src/session/homeSections.ts
@@ -22,7 +22,7 @@ export type HomeRow =
       key: string;
       kind: 'session';
       item: RemoteSessionListItem;
-      source: 'chat' | 'pinned' | 'project';
+      source: 'chat' | 'pinned' | 'project' | 'search';
       /** 仅平铺(未按项目分组)的顶层会话行:项目名或「对话」。 */
       sourceLabel?: string;
     };

--- a/apps/mobile/src/session/remoteSessionStore.ts
+++ b/apps/mobile/src/session/remoteSessionStore.ts
@@ -774,6 +774,12 @@ let storeVersion = 0;
 // 重建身份索引,用于给会话算展示用 canonicalDeviceId(把 re-link 后残留 stale shard 认领回当前设备);
 // 为 null 时不归一,安全退化。
 let deviceList: readonly { deviceId: string; name: string }[] | null = null;
+let conversationSearchDeviceModels: readonly {
+  canOpen: boolean;
+  deviceId: string;
+  name: string | null;
+  state: string;
+}[] = [];
 
 function emit(): void {
   storeVersion += 1;
@@ -1612,6 +1618,31 @@ export const remoteSessionStore = {
    */
   getDeviceIdentity(): readonly { deviceId: string; name: string }[] {
     return deviceList ?? [];
+  },
+
+  getConversationSearchDeviceModels(): readonly {
+    canOpen: boolean;
+    deviceId: string;
+    name: string | null;
+    state: string;
+  }[] {
+    return conversationSearchDeviceModels;
+  },
+
+  setConversationSearchDeviceModels(models: readonly {
+    canOpen: boolean;
+    deviceId: string;
+    name: string | null;
+    state: string;
+  }[]): void {
+    if (conversationSearchDeviceModelsEqual(conversationSearchDeviceModels, models)) return;
+    conversationSearchDeviceModels = models.map((item) => ({
+      canOpen: item.canOpen,
+      deviceId: item.deviceId,
+      name: item.name,
+      state: item.state,
+    }));
+    emit();
   },
 
   getSessionRetention(sessionId: string): SessionRetentionKind {
@@ -3565,6 +3596,24 @@ function deviceListsEqual(
   if (!a || a.length !== b.length) return false;
   for (let i = 0; i < a.length; i += 1) {
     if (a[i].deviceId !== b[i].deviceId || a[i].name !== b[i].name) return false;
+  }
+  return true;
+}
+
+function conversationSearchDeviceModelsEqual(
+  a: readonly { canOpen: boolean; deviceId: string; name: string | null; state: string }[],
+  b: readonly { canOpen: boolean; deviceId: string; name: string | null; state: string }[],
+): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i += 1) {
+    if (
+      a[i].deviceId !== b[i].deviceId
+      || a[i].name !== b[i].name
+      || a[i].canOpen !== b[i].canOpen
+      || a[i].state !== b[i].state
+    ) {
+      return false;
+    }
   }
   return true;
 }

--- a/apps/mobile/src/session/sessionDrawerNavigation.ts
+++ b/apps/mobile/src/session/sessionDrawerNavigation.ts
@@ -2,6 +2,7 @@ export interface SessionDrawerRouteTarget {
   deviceId: string;
   deviceName: string;
   sessionId: string;
+  focusClientId?: string;
 }
 
 export interface SessionRouteParamsNavigation {
@@ -25,5 +26,6 @@ export function switchDrawerSessionInPlace(
     deviceId: target.deviceId,
     deviceName: target.deviceName,
     sessionId: target.sessionId,
+    ...(target.focusClientId ? { focusClientId: target.focusClientId } : {}),
   });
 }

--- a/apps/mobile/src/session/useConversationSearch.ts
+++ b/apps/mobile/src/session/useConversationSearch.ts
@@ -1,0 +1,191 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useDeviceLink } from '@/device-link/DeviceLinkContext';
+import { unresponsiveDevicesStore } from '@/device-link/unresponsiveDevicesStore';
+import {
+  CONVERSATION_SEARCH_LIMIT,
+  conversationSearchActiveFilterCount,
+  conversationSearchWorkingDirs,
+  reconcileConversationSearchProjectSelection,
+  searchConversationsAcrossDevices,
+  toSearchListItem,
+  type ConversationSearchDeviceOrigin,
+  type ConversationSearchProjectSelection,
+} from '@/session/conversationSearch';
+import { remoteSessionStore } from '@/session/remoteSessionStore';
+import type {
+  ConversationSearchAgentFilter,
+  ConversationSearchLastActivityFilter,
+  ConversationSearchSortBy,
+  ConversationSearchStatusFilter,
+} from '@cindy/maker-shared/conversation-search';
+import type { RemoteSessionListItem } from '@/session/sessionList';
+
+export const CONVERSATION_SEARCH_DEBOUNCE_MS = 250;
+
+export type ConversationSearchStatus = 'idle' | 'searching' | 'ready';
+
+export function useConversationSearch({
+  origins,
+  enabled,
+  lockedWorkingDirs,
+  visibleProjectKeys,
+}: {
+  origins: readonly ConversationSearchDeviceOrigin[];
+  enabled: boolean;
+  lockedWorkingDirs?: string[] | null;
+  visibleProjectKeys?: readonly string[];
+}): {
+  query: string;
+  setQuery: (value: string) => void;
+  status: ConversationSearchStatus;
+  results: RemoteSessionListItem[];
+  sortBy: ConversationSearchSortBy;
+  setSortBy: (value: ConversationSearchSortBy) => void;
+  statusFilter: ConversationSearchStatusFilter;
+  setStatusFilter: (value: ConversationSearchStatusFilter) => void;
+  agentFilter: ConversationSearchAgentFilter;
+  setAgentFilter: (value: ConversationSearchAgentFilter) => void;
+  lastActivityFilter: ConversationSearchLastActivityFilter;
+  setLastActivityFilter: (value: ConversationSearchLastActivityFilter) => void;
+  projectSelection: ConversationSearchProjectSelection;
+  setProjectSelection: (value: ConversationSearchProjectSelection) => void;
+  lockedWorkingDirs: string[] | null;
+  activeFilterCount: number;
+  resetFilters: () => void;
+} {
+  const { invoke } = useDeviceLink();
+  const { t } = useTranslation();
+  const [query, setQuery] = useState('');
+  const [status, setStatus] = useState<ConversationSearchStatus>('idle');
+  const [results, setResults] = useState<RemoteSessionListItem[]>([]);
+  const [sortBy, setSortBy] = useState<ConversationSearchSortBy>('relevance');
+  const [statusFilter, setStatusFilter] = useState<ConversationSearchStatusFilter>('all');
+  const [agentFilter, setAgentFilter] = useState<ConversationSearchAgentFilter>('all');
+  const [lastActivityFilter, setLastActivityFilter] =
+    useState<ConversationSearchLastActivityFilter>('all');
+  const [projectSelection, setProjectSelection] = useState<ConversationSearchProjectSelection>('all');
+  const requestSeq = useRef(0);
+  const unnamedLabel = t('session.menu.unnamedTitle');
+  const originKey = useMemo(
+    () => origins.map((origin) => `${origin.deviceId}:${origin.reachable ? '1' : '0'}`).join('|'),
+    [origins],
+  );
+  const visibleKey = visibleProjectKeys?.join('|') ?? '';
+  const lockedDirs = useMemo(
+    () => (lockedWorkingDirs?.length ? [...lockedWorkingDirs] : null),
+    [lockedWorkingDirs?.join('|') ?? ''],
+  );
+
+  useEffect(() => {
+    if (!visibleProjectKeys) return;
+    setProjectSelection((current) => reconcileConversationSearchProjectSelection(current, visibleProjectKeys));
+  }, [visibleKey, visibleProjectKeys]);
+
+  const workingDirs = useMemo(
+    () => conversationSearchWorkingDirs({
+      lockedWorkingDirs: lockedDirs,
+      projectSelection,
+    }),
+    [lockedDirs, projectSelection],
+  );
+  const activeFilterCount = conversationSearchActiveFilterCount({
+    agentKind: agentFilter,
+    lastActivity: lastActivityFilter,
+    lockedWorkingDirs: lockedDirs,
+    projectSelection,
+    status: statusFilter,
+  });
+  const resetFilters = useCallback(() => {
+    setStatusFilter('all');
+    setAgentFilter('all');
+    setLastActivityFilter('all');
+    setProjectSelection(lockedDirs ? [...lockedDirs] : 'all');
+  }, [lockedDirs]);
+
+  useEffect(() => {
+    const trimmed = query.trim();
+    if (!enabled || !trimmed) {
+      requestSeq.current += 1;
+      setStatus('idle');
+      setResults([]);
+      return;
+    }
+
+    setStatus('searching');
+    const seq = ++requestSeq.current;
+    const timer = setTimeout(() => {
+      void searchConversationsAcrossDevices(
+        origins,
+        {
+          query: trimmed,
+          limit: CONVERSATION_SEARCH_LIMIT,
+          semanticMode: 'keyword',
+          sortBy,
+          unnamedLabel,
+          filters: {
+            agentKind: agentFilter,
+            lastActivity: lastActivityFilter,
+            status: statusFilter,
+            workingDirs,
+          },
+        },
+        {
+          invoke,
+          getCachedSessions: () => remoteSessionStore.getSessions(),
+          isDeviceUnresponsive: (deviceId) => unresponsiveDevicesStore.has(deviceId),
+        },
+      ).then((page) => {
+        if (seq !== requestSeq.current) return;
+        const now = Date.now();
+        const cachedById = new Map(
+          remoteSessionStore.getSessions().map((session) => [session.id, session]),
+        );
+        setResults(page.results.map((item) => (
+          toSearchListItem(item, now, unnamedLabel, cachedById.get(item.session.id))
+        )));
+        setStatus('ready');
+      }).catch(() => {
+        if (seq !== requestSeq.current) return;
+        setResults([]);
+        setStatus('ready');
+      });
+    }, CONVERSATION_SEARCH_DEBOUNCE_MS);
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [
+    agentFilter,
+    enabled,
+    invoke,
+    lastActivityFilter,
+    originKey,
+    origins,
+    query,
+    sortBy,
+    statusFilter,
+    unnamedLabel,
+    workingDirs,
+  ]);
+
+  return {
+    query,
+    setQuery,
+    status,
+    results,
+    sortBy,
+    setSortBy,
+    statusFilter,
+    setStatusFilter,
+    agentFilter,
+    setAgentFilter,
+    lastActivityFilter,
+    setLastActivityFilter,
+    projectSelection,
+    setProjectSelection,
+    lockedWorkingDirs: lockedDirs,
+    activeFilterCount,
+    resetFilters,
+  };
+}

--- a/apps/mobile/src/session/useConversationSearch.ts
+++ b/apps/mobile/src/session/useConversationSearch.ts
@@ -9,6 +9,8 @@ import {
   reconcileConversationSearchProjectSelection,
   scopedConversationSearchOrigins,
   searchConversationsAcrossDevices,
+  cachedSessionForSearchResult,
+  conversationSearchSessionCacheKey,
   toSearchListItem,
   type ConversationSearchDeviceOrigin,
   type ConversationSearchListItem,
@@ -147,11 +149,14 @@ export function useConversationSearch({
       ).then((page) => {
         if (seq !== requestSeq.current) return;
         const now = Date.now();
-        const cachedById = new Map(
-          remoteSessionStore.getSessions().map((session) => [session.id, session]),
+        const cachedByKey = new Map(
+          remoteSessionStore.getSessions().map((session) => [
+            conversationSearchSessionCacheKey(session),
+            session,
+          ]),
         );
         setResults(page.results.map((item) => (
-          toSearchListItem(item, now, unnamedLabel, cachedById.get(item.session.id))
+          toSearchListItem(item, now, unnamedLabel, cachedSessionForSearchResult(item, cachedByKey))
         )));
         setStatus('ready');
       }).catch(() => {

--- a/apps/mobile/src/session/useConversationSearch.ts
+++ b/apps/mobile/src/session/useConversationSearch.ts
@@ -7,9 +7,12 @@ import {
   conversationSearchActiveFilterCount,
   conversationSearchWorkingDirs,
   reconcileConversationSearchProjectSelection,
+  scopedConversationSearchOrigins,
   searchConversationsAcrossDevices,
   toSearchListItem,
   type ConversationSearchDeviceOrigin,
+  type ConversationSearchListItem,
+  type ConversationSearchProjectOption,
   type ConversationSearchProjectSelection,
 } from '@/session/conversationSearch';
 import { remoteSessionStore } from '@/session/remoteSessionStore';
@@ -19,7 +22,6 @@ import type {
   ConversationSearchSortBy,
   ConversationSearchStatusFilter,
 } from '@cindy/maker-shared/conversation-search';
-import type { RemoteSessionListItem } from '@/session/sessionList';
 
 export const CONVERSATION_SEARCH_DEBOUNCE_MS = 250;
 
@@ -29,17 +31,17 @@ export function useConversationSearch({
   origins,
   enabled,
   lockedWorkingDirs,
-  visibleProjectKeys,
+  projects,
 }: {
   origins: readonly ConversationSearchDeviceOrigin[];
   enabled: boolean;
   lockedWorkingDirs?: string[] | null;
-  visibleProjectKeys?: readonly string[];
+  projects?: readonly ConversationSearchProjectOption[];
 }): {
   query: string;
   setQuery: (value: string) => void;
   status: ConversationSearchStatus;
-  results: RemoteSessionListItem[];
+  results: ConversationSearchListItem[];
   sortBy: ConversationSearchSortBy;
   setSortBy: (value: ConversationSearchSortBy) => void;
   statusFilter: ConversationSearchStatusFilter;
@@ -58,7 +60,7 @@ export function useConversationSearch({
   const { t } = useTranslation();
   const [query, setQuery] = useState('');
   const [status, setStatus] = useState<ConversationSearchStatus>('idle');
-  const [results, setResults] = useState<RemoteSessionListItem[]>([]);
+  const [results, setResults] = useState<ConversationSearchListItem[]>([]);
   const [sortBy, setSortBy] = useState<ConversationSearchSortBy>('relevance');
   const [statusFilter, setStatusFilter] = useState<ConversationSearchStatusFilter>('all');
   const [agentFilter, setAgentFilter] = useState<ConversationSearchAgentFilter>('all');
@@ -67,27 +69,34 @@ export function useConversationSearch({
   const [projectSelection, setProjectSelection] = useState<ConversationSearchProjectSelection>('all');
   const requestSeq = useRef(0);
   const unnamedLabel = t('session.menu.unnamedTitle');
-  const originKey = useMemo(
-    () => origins.map((origin) => `${origin.deviceId}:${origin.reachable ? '1' : '0'}`).join('|'),
-    [origins],
+  const visibleProjectKeys = useMemo(
+    () => (projects ?? []).map((project) => project.key),
+    [projects],
   );
-  const visibleKey = visibleProjectKeys?.join('|') ?? '';
+  const visibleKey = visibleProjectKeys.join('|');
   const lockedDirs = useMemo(
     () => (lockedWorkingDirs?.length ? [...lockedWorkingDirs] : null),
     [lockedWorkingDirs?.join('|') ?? ''],
   );
+  const scopedOrigins = useMemo(
+    () => (lockedDirs ? [...origins] : scopedConversationSearchOrigins(origins, projectSelection, projects ?? [])),
+    [lockedDirs, origins, projectSelection, projects],
+  );
+  const originKey = useMemo(
+    () => scopedOrigins.map((origin) => (
+      `${origin.deviceId}:${origin.reachable ? '1' : '0'}:${(origin.workingDirs ?? []).join(',')}`
+    )).join('|'),
+    [scopedOrigins],
+  );
 
   useEffect(() => {
-    if (!visibleProjectKeys) return;
+    if (!projects) return;
     setProjectSelection((current) => reconcileConversationSearchProjectSelection(current, visibleProjectKeys));
-  }, [visibleKey, visibleProjectKeys]);
+  }, [projects, visibleKey, visibleProjectKeys]);
 
   const workingDirs = useMemo(
-    () => conversationSearchWorkingDirs({
-      lockedWorkingDirs: lockedDirs,
-      projectSelection,
-    }),
-    [lockedDirs, projectSelection],
+    () => conversationSearchWorkingDirs({ lockedWorkingDirs: lockedDirs }),
+    [lockedDirs],
   );
   const activeFilterCount = conversationSearchActiveFilterCount({
     agentKind: agentFilter,
@@ -100,8 +109,8 @@ export function useConversationSearch({
     setStatusFilter('all');
     setAgentFilter('all');
     setLastActivityFilter('all');
-    setProjectSelection(lockedDirs ? [...lockedDirs] : 'all');
-  }, [lockedDirs]);
+    setProjectSelection('all');
+  }, []);
 
   useEffect(() => {
     const trimmed = query.trim();
@@ -116,7 +125,7 @@ export function useConversationSearch({
     const seq = ++requestSeq.current;
     const timer = setTimeout(() => {
       void searchConversationsAcrossDevices(
-        origins,
+        scopedOrigins,
         {
           query: trimmed,
           limit: CONVERSATION_SEARCH_LIMIT,
@@ -161,7 +170,7 @@ export function useConversationSearch({
     invoke,
     lastActivityFilter,
     originKey,
-    origins,
+    scopedOrigins,
     query,
     sortBy,
     statusFilter,

--- a/packages/maker-shared/package.json
+++ b/packages/maker-shared/package.json
@@ -17,6 +17,7 @@
     "./command-display": "./src/commandDisplay.ts",
     "./client-endpoints": "./src/clientEndpoints.ts",
     "./composer-palette": "./src/composerPalette.ts",
+    "./conversation-search": "./src/conversationSearch.ts",
     "./device-list": "./src/deviceList.ts",
     "./device-link-contract": "./src/deviceLinkContract.ts",
     "./device-responsiveness": "./src/deviceResponsiveness.ts",

--- a/packages/maker-shared/src/__tests__/conversationSearch.test.ts
+++ b/packages/maker-shared/src/__tests__/conversationSearch.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from 'vitest';
+import {
+  conversationSearchResultKey,
+  emptyConversationSearchResponse,
+  filterResultsByRequestFilters,
+  filterResultsByWorkingDirs,
+  mergeConversationSearchFanout,
+  remoteIndexedSearchIgnoredWorkingDirs,
+  remoteResultsFromFanoutPages,
+  stampRemoteSearchResponse,
+  type ConversationSearchResponse,
+  type ConversationSearchResultItem,
+} from '../conversationSearch.js';
+
+function result(
+  id: string,
+  rankScore: number,
+  extras: Partial<ConversationSearchResultItem['session']> = {},
+): ConversationSearchResultItem {
+  return {
+    session: {
+      id,
+      title: id,
+      workingDir: '/repo',
+      workspaceKind: 'project',
+      agentKind: 'cc',
+      status: 'active',
+      userSendAt: '2026-08-19T00:00:00.000Z',
+      updatedAt: '2026-08-19T00:00:00.000Z',
+      createdAt: '2026-08-19T00:00:00.000Z',
+      _count: { messages: 1 },
+      ...extras,
+    },
+    matchKind: 'title',
+    titleMatchIndices: [0],
+    titleScore: 1,
+    contentHit: null,
+    contentHits: [],
+    rankScore,
+  };
+}
+
+function response(results: ConversationSearchResultItem[]): ConversationSearchResponse {
+  return {
+    query: 'needle',
+    results,
+    vectorUsed: false,
+    vectorSkipReason: null,
+    poolCapped: false,
+  };
+}
+
+describe('merge and stamp', () => {
+  it('keeps same-id hits from different devices and stamps origin', () => {
+    const remote = stampRemoteSearchResponse(response([result('same', 10)]), {
+      deviceId: 'dev-a',
+      deviceName: 'Studio',
+    });
+    const merged = mergeConversationSearchFanout([response([result('same', 3)]), remote], 24);
+    expect(merged.results.map((item) => conversationSearchResultKey(item)).sort()).toEqual([
+      'dev-a:same',
+      'local:same',
+    ]);
+    expect(
+      merged.results.find((item) => item.session.deviceLinkDeviceId === 'dev-a')?.session
+        .deviceLinkDeviceName,
+    ).toBe('Studio');
+  });
+
+  it('returns an empty page shape', () => {
+    expect(emptyConversationSearchResponse('q')).toEqual({
+      query: 'q',
+      results: [],
+      vectorUsed: false,
+      vectorSkipReason: null,
+      poolCapped: false,
+    });
+  });
+
+  it('keeps remote hits after the merged page is truncated', () => {
+    const locals = Array.from({ length: 24 }, (_, index) => result(`local-${index}`, 100 - index));
+    const pages = [
+      response(locals),
+      response([result('remote-squeezed', 1, { deviceLinkDeviceId: 'dev-a' })]),
+    ];
+    const merged = mergeConversationSearchFanout(pages, 24);
+    expect(merged.results.map((item) => item.session.id)).not.toContain('remote-squeezed');
+    expect(remoteResultsFromFanoutPages(pages).map((item) => item.session.id)).toEqual([
+      'remote-squeezed',
+    ]);
+  });
+});
+
+describe('filterResultsByWorkingDirs', () => {
+  it('drops remote hits that belong to another project', () => {
+    const page = filterResultsByWorkingDirs(
+      response([
+        result('keep', 1, { workingDir: '/repo-remote' }),
+        result('drop', 1, { workingDir: '/other' }),
+      ]),
+      ['/repo-remote'],
+    );
+    expect(page.results.map((item) => item.session.id)).toEqual(['keep']);
+  });
+});
+
+describe('filterResultsByRequestFilters', () => {
+  it('drops remote hits that ignore status, agent, or activity filters', () => {
+    const recent = new Date().toISOString();
+    const page = filterResultsByRequestFilters(
+      response([
+        result('keep', 1, {
+          agentKind: 'codex',
+          status: 'archived',
+          userSendAt: recent,
+        }),
+        result('wrong-agent', 1, {
+          agentKind: 'cc',
+          status: 'archived',
+          userSendAt: recent,
+        }),
+        result('wrong-status', 1, {
+          agentKind: 'codex',
+          status: 'active',
+          userSendAt: recent,
+        }),
+        result('too-old', 1, {
+          agentKind: 'codex',
+          status: 'archived',
+          userSendAt: '2020-01-01T00:00:00.000Z',
+          updatedAt: '2020-01-01T00:00:00.000Z',
+        }),
+        result('worker', 1, {
+          agentKind: 'codex',
+          status: 'archived',
+          userSendAt: recent,
+          orcaRole: 'worker',
+        }),
+      ]),
+      {
+        filters: {
+          status: 'archived',
+          agentKind: 'codex',
+          lastActivity: '7d',
+        },
+      },
+    );
+    expect(page.results.map((item) => item.session.id)).toEqual(['keep']);
+  });
+
+  it('keeps a remote hit when updatedAt is recent but userSendAt is old', () => {
+    const page = filterResultsByRequestFilters(
+      response([
+        result('keep', 1, {
+          userSendAt: '2020-01-01T00:00:00.000Z',
+          updatedAt: new Date().toISOString(),
+        }),
+      ]),
+      { filters: { lastActivity: '7d' } },
+    );
+    expect(page.results.map((item) => item.session.id)).toEqual(['keep']);
+  });
+});
+
+describe('remoteIndexedSearchIgnoredWorkingDirs', () => {
+  it('detects an old host that searched globally and filled the page from other projects', () => {
+    expect(
+      remoteIndexedSearchIgnoredWorkingDirs(
+        response([
+          result('other', 1, { workingDir: '/other' }),
+          result('keep', 1, { workingDir: '/repo-remote' }),
+        ]),
+        ['/repo-remote'],
+      ),
+    ).toBe(true);
+  });
+
+  it('does not treat an in-project page as unsupported', () => {
+    expect(
+      remoteIndexedSearchIgnoredWorkingDirs(
+        response([result('keep', 1, { workingDir: '/repo-remote' })]),
+        ['/repo-remote'],
+      ),
+    ).toBe(false);
+  });
+});

--- a/packages/maker-shared/src/__tests__/deviceLinkContract.test.ts
+++ b/packages/maker-shared/src/__tests__/deviceLinkContract.test.ts
@@ -33,6 +33,7 @@ describe('device-link shared contract', () => {
     expect(MOBILE_REMOTE_INVOKE_CHANNELS).toContain('maker:switch-session-agent');
     expect(MOBILE_REMOTE_INVOKE_CHANNELS).toContain('maker:get-session-agent-switch-intent');
     expect(MOBILE_REMOTE_INVOKE_CHANNELS).toContain('maker:input:compact');
+    expect(MOBILE_REMOTE_INVOKE_CHANNELS).toContain('local-db:conversations:search');
     expect(MOBILE_REMOTE_INVOKE_CHANNELS).toContain('local-db:messages:around-client-id');
     expect(MOBILE_REMOTE_INVOKE_CHANNELS).toContain('maker:message:delete');
     expect(MOBILE_REMOTE_INVOKE_CHANNELS).toContain('maker:get-session-tree');

--- a/packages/maker-shared/src/conversationSearch.ts
+++ b/packages/maker-shared/src/conversationSearch.ts
@@ -1,0 +1,338 @@
+import { projectDraftSessionTitle } from './sessionTitle.js';
+import { collapseWorktreeDirForGrouping } from './worktreePaths.js';
+
+/**
+ * 任务搜索的跨端契约与纯合并函数。
+ *
+ * 请求 / 响应形状对齐桌面 `apps/desktop/src/shared/conversationSearch.ts`
+ * 与 device-link `local-db:conversations:search` 隧道。合并、打标、目录过滤
+ * 对齐桌面 `conversationSearchFanout.ts` 的可移植子集。
+ *
+ * 不包含桌面本机 SQLite、hybrid / 向量搜索、机器切换栏 origin 解析。
+ */
+
+export type ConversationSearchAgentKind = 'cc' | 'codex' | 'pi';
+export type ConversationSearchWorkspaceKind = 'project' | 'dialogue';
+export type ConversationSearchSessionStatus = 'active' | 'archived' | 'deleted';
+export type ConversationSearchOrcaRole = 'lead' | 'worker';
+export type ConversationSearchMessageRole =
+  | 'user'
+  | 'assistant'
+  | 'tool_use'
+  | 'tool_result'
+  | 'ask_user'
+  | 'plan_review'
+  | 'thinking';
+
+export interface ConversationSearchRequest {
+  query: string;
+  limit?: number;
+  sortBy?: ConversationSearchSortBy;
+  semanticMode?: ConversationSearchSemanticMode;
+  filters?: ConversationSearchFilters;
+  includeArchived?: boolean;
+  unnamedLabel?: string;
+}
+
+export type ConversationSearchSortBy = 'relevance' | 'activityDesc' | 'activityAsc';
+export type ConversationSearchSemanticMode = 'hybrid' | 'keyword';
+export type ConversationSearchStatusFilter = 'active' | 'archived' | 'all';
+export type ConversationSearchAgentFilter = 'all' | ConversationSearchAgentKind;
+export type ConversationSearchLastActivityFilter = 'all' | '1d' | '3d' | '7d' | '30d';
+
+export interface ConversationSearchFilters {
+  status?: ConversationSearchStatusFilter;
+  agentKind?: ConversationSearchAgentFilter;
+  lastActivity?: ConversationSearchLastActivityFilter;
+  sessionIds?: string[] | null;
+  workingDirs?: string[] | null;
+}
+
+export type ConversationSearchMatchKind = 'title' | 'content' | 'both';
+
+export interface ConversationSearchSessionSummary {
+  id: string;
+  title: string;
+  workingDir: string | null;
+  workspaceKind: ConversationSearchWorkspaceKind;
+  agentKind: ConversationSearchAgentKind;
+  status: ConversationSearchSessionStatus;
+  source?: string | null;
+  orcaRole?: ConversationSearchOrcaRole | null;
+  parentSessionId?: string | null;
+  userSendAt: string | null;
+  updatedAt: string;
+  createdAt: string;
+  _count: { messages: number };
+  deviceLinkDeviceId?: string | null;
+  deviceLinkDeviceName?: string | null;
+}
+
+export interface ConversationSearchContentHit {
+  messageId: string;
+  messageClientId: string;
+  role: ConversationSearchMessageRole;
+  createdAt: string;
+  snippet: string | null;
+  preview: string;
+  score: number;
+  ftsRank: number | null;
+  vectorRank: number | null;
+}
+
+export interface ConversationSearchResultItem {
+  session: ConversationSearchSessionSummary;
+  matchKind: ConversationSearchMatchKind;
+  titleMatchIndices: number[];
+  titleScore: number | null;
+  contentHit: ConversationSearchContentHit | null;
+  contentHits: ConversationSearchContentHit[];
+  rankScore: number;
+}
+
+export function conversationSearchTitle(title: string, unnamedLabel?: string | null): string {
+  return projectDraftSessionTitle(title, unnamedLabel);
+}
+
+export interface ConversationSearchResponse {
+  query: string;
+  results: ConversationSearchResultItem[];
+  vectorUsed: boolean;
+  vectorSkipReason: string | null;
+  poolCapped: boolean;
+  remoteResults?: ConversationSearchResultItem[];
+}
+
+const LAST_ACTIVITY_DAY_COUNTS: Record<
+  Exclude<ConversationSearchLastActivityFilter, 'all'>,
+  number
+> = {
+  '1d': 1,
+  '3d': 3,
+  '7d': 7,
+  '30d': 30,
+};
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export function emptyConversationSearchResponse(query = ''): ConversationSearchResponse {
+  return {
+    query,
+    results: [],
+    vectorUsed: false,
+    vectorSkipReason: null,
+    poolCapped: false,
+  };
+}
+
+export function stampRemoteSearchResponse(
+  response: ConversationSearchResponse,
+  device: { deviceId: string; deviceName?: string | null },
+): ConversationSearchResponse {
+  const results = Array.isArray(response?.results) ? response.results : [];
+  return {
+    query: response?.query ?? '',
+    vectorUsed: response?.vectorUsed === true,
+    vectorSkipReason: response?.vectorSkipReason ?? null,
+    poolCapped: response?.poolCapped === true,
+    results: results.map((item) => ({
+      ...item,
+      session: {
+        ...item.session,
+        deviceLinkDeviceId: device.deviceId,
+        deviceLinkDeviceName: device.deviceName ?? item.session.deviceLinkDeviceName ?? null,
+      },
+    })),
+  };
+}
+
+export function conversationSearchResultKey(item: ConversationSearchResultItem): string {
+  return `${item.session.deviceLinkDeviceId ?? 'local'}:${item.session.id}`;
+}
+
+export function remoteResultsFromFanoutPages(
+  pages: readonly ConversationSearchResponse[],
+): ConversationSearchResultItem[] {
+  const byKey = new Map<string, ConversationSearchResultItem>();
+  for (const page of pages) {
+    for (const item of page.results) {
+      if (!item.session.deviceLinkDeviceId) continue;
+      const key = conversationSearchResultKey(item);
+      const existing = byKey.get(key);
+      if (!existing || item.rankScore > existing.rankScore) {
+        byKey.set(key, item);
+      }
+    }
+  }
+  return [...byKey.values()];
+}
+
+export function mergeConversationSearchFanout(
+  pages: readonly ConversationSearchResponse[],
+  limit: number,
+  sortBy: ConversationSearchSortBy = 'relevance',
+): ConversationSearchResponse {
+  const byKey = new Map<string, ConversationSearchResultItem>();
+  for (const page of pages) {
+    for (const item of page.results) {
+      const key = conversationSearchResultKey(item);
+      const existing = byKey.get(key);
+      if (!existing || item.rankScore > existing.rankScore) {
+        byKey.set(key, item);
+      }
+    }
+  }
+
+  const results = [...byKey.values()]
+    .sort((a, b) => compareSearchResults(a, b, sortBy))
+    .slice(0, Math.max(1, limit));
+
+  return {
+    query: pages[0]?.query ?? '',
+    results,
+    vectorUsed: pages.some((page) => page.vectorUsed),
+    vectorSkipReason: pages.find((page) => page.vectorSkipReason)?.vectorSkipReason ?? null,
+    poolCapped: pages.some((page) => page.poolCapped),
+  };
+}
+
+export function remoteIndexedSearchIgnoredWorkingDirs(
+  response: ConversationSearchResponse,
+  workingDirs: string[] | null | undefined,
+): boolean {
+  const allowed = normalizeWorkingDirSet(workingDirs);
+  if (allowed == null) return false;
+  const results = Array.isArray(response?.results) ? response.results : [];
+  return results.some((item) => !matchesWorkingDirSet(item.session.workingDir, allowed));
+}
+
+export function filterResultsByWorkingDirs(
+  response: ConversationSearchResponse,
+  workingDirs: string[] | null | undefined,
+): ConversationSearchResponse {
+  return filterResultsByRequestFilters(response, { filters: { workingDirs } });
+}
+
+export function filterResultsByRequestFilters(
+  response: ConversationSearchResponse,
+  request: Pick<ConversationSearchRequest, 'filters'>,
+): ConversationSearchResponse {
+  const filters = request.filters ?? {};
+  const allowedDirs = normalizeWorkingDirSet(filters.workingDirs);
+  const activityCutoff = cutoffForLastActivity(filters.lastActivity ?? 'all');
+  const status = filters.status ?? 'all';
+  const agentKind = filters.agentKind ?? 'all';
+  return {
+    ...response,
+    results: response.results.filter((item) => {
+      if (!matchesWorkingDirSet(item.session.workingDir, allowedDirs)) return false;
+      if (item.session.orcaRole === 'worker') return false;
+      if (!matchesStatus(item.session.status, status)) return false;
+      if (agentKind !== 'all' && item.session.agentKind !== agentKind) return false;
+      if (activityCutoff !== null && sessionActivityMs(item.session) < activityCutoff) {
+        return false;
+      }
+      return true;
+    }),
+  };
+}
+
+function normalizeWorkingDirForGrouping(raw: string | null | undefined): string | null {
+  if (raw == null) return null;
+  const trimmed = String(raw).trim();
+  if (trimmed === '') return null;
+
+  const withoutLongPathPrefix = stripWindowsLongPathPrefix(trimmed);
+  const needsWindowsSeparatorRewrite =
+    isWindowsPathLike(trimmed) || isWindowsPathLike(withoutLongPathPrefix);
+  let out = needsWindowsSeparatorRewrite
+    ? withoutLongPathPrefix.replace(/\\/g, '/')
+    : withoutLongPathPrefix;
+  while (out.length > 1 && out.endsWith('/')) {
+    if (/^[A-Za-z]:\/$/.test(out)) break;
+    out = out.slice(0, -1);
+  }
+  return collapseWorktreeDirForGrouping(out);
+}
+
+function stripWindowsLongPathPrefix(value: string): string {
+  if (value.startsWith('\\\\?\\UNC\\')) return `\\\\${value.slice('\\\\?\\UNC\\'.length)}`;
+  if (value.startsWith('\\\\?\\')) return value.slice('\\\\?\\'.length);
+  return value;
+}
+
+function isWindowsPathLike(value: string): boolean {
+  return /^[A-Za-z]:[\\/]/.test(value) || value.startsWith('\\\\') || value.startsWith('//');
+}
+
+function normalizeWorkingDirSet(value: string[] | null | undefined): Set<string> | null {
+  if (value == null || !Array.isArray(value)) return null;
+  const out = new Set<string>();
+  for (const item of value) {
+    const normalized = normalizeWorkingDirForGrouping(item);
+    if (normalized) out.add(normalized);
+  }
+  return out.size > 0 ? out : null;
+}
+
+function matchesWorkingDirSet(
+  workingDir: string | null | undefined,
+  allowed: Set<string> | null,
+): boolean {
+  if (allowed == null) return true;
+  const key = normalizeWorkingDirForGrouping(workingDir);
+  return key != null && allowed.has(key);
+}
+
+function matchesStatus(
+  status: ConversationSearchSessionStatus | string,
+  filter: ConversationSearchStatusFilter,
+): boolean {
+  if (status === 'deleted') return false;
+  if (filter === 'all') return status === 'active' || status === 'archived';
+  return status === filter;
+}
+
+function cutoffForLastActivity(lastActivity: ConversationSearchLastActivityFilter): number | null {
+  if (lastActivity === 'all') return null;
+  return Date.now() - LAST_ACTIVITY_DAY_COUNTS[lastActivity] * DAY_MS;
+}
+
+function sessionActivityMs(
+  session: Pick<ConversationSearchSessionSummary, 'userSendAt' | 'updatedAt'>,
+): number {
+  return Math.max(parseActivityMs(session.userSendAt), parseActivityMs(session.updatedAt));
+}
+
+function parseActivityMs(value: string | null | undefined): number {
+  if (!value) return 0;
+  const ms = Date.parse(value);
+  return Number.isFinite(ms) ? ms : 0;
+}
+
+function compareSearchResults(
+  a: ConversationSearchResultItem,
+  b: ConversationSearchResultItem,
+  sortBy: ConversationSearchSortBy,
+): number {
+  if (sortBy === 'activityDesc') {
+    return sessionActivityMs(b.session) - sessionActivityMs(a.session) || relevanceCompare(a, b);
+  }
+  if (sortBy === 'activityAsc') {
+    return sessionActivityMs(a.session) - sessionActivityMs(b.session) || relevanceCompare(a, b);
+  }
+  return relevanceCompare(a, b);
+}
+
+function relevanceCompare(
+  a: ConversationSearchResultItem,
+  b: ConversationSearchResultItem,
+): number {
+  const groupA = a.matchKind === 'title' || a.matchKind === 'both' ? 1 : 0;
+  const groupB = b.matchKind === 'title' || b.matchKind === 'both' ? 1 : 0;
+  return (
+    groupB - groupA ||
+    b.rankScore - a.rankScore ||
+    sessionActivityMs(b.session) - sessionActivityMs(a.session) ||
+    a.session.id.localeCompare(b.session.id)
+  );
+}

--- a/packages/maker-shared/src/deviceLinkContract.ts
+++ b/packages/maker-shared/src/deviceLinkContract.ts
@@ -255,6 +255,9 @@ export const MOBILE_REMOTE_INVOKE_CHANNELS = [
   'maker:get-capabilities',
   'maker:provider:list',
   'local-db:sessions:get',
+  // 只读任务搜索(对齐桌面侧栏 / Composer @)。老被控端 CHANNEL_NOT_ALLOWED →
+  // 手机端降级为已缓存会话的本地匹配,不阻断搜索。
+  'local-db:conversations:search',
   'local-db:sessions:patch-meta',
   // error-tail / interrupted 收尾入口(对齐桌面 error-tail banner / InterruptedTurnBanner):
   // 「忽略」错误尾行 → 被控端持久化 merge dismissed:true;「忽略」中断提示 → 被控端写

--- a/packages/maker-shared/src/sessionList.ts
+++ b/packages/maker-shared/src/sessionList.ts
@@ -648,7 +648,7 @@ function matchesStatusFilter(
   return session.status === filter;
 }
 
-function matchesSearchQuery(
+export function matchesSearchQuery(
   session: RemoteSession,
   query: string,
   options: {


### PR DESCRIPTION
## 这次改了什么

### 摘要

把桌面 [#3018](https://github.com/makecindy/cindy/pull/3018) 的远程任务搜索接到手机：有字时按当前选中电脑（或「全部」里每一台）走已有通道 `local-db:conversations:search`，结果能点开；没字时列表不变。搜索条对照桌面侧栏，筛选菜单叫「搜索条件」，含排序、状态、项目、Agent、最近活动。Agent 为 Claude Code / Codex / Pi。被控端搜索 IPC 同步放行 `pi`。老电脑或离线回落到手机已缓存任务，不空白、不报错。

### 变更类型

- [x] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：桌面 #3018 的手机适配；复用同一条搜索通道
- 本 PR 包含：
  - `maker-shared` 可移植搜索类型与跨设备合并
  - 手机 transport / 通道白名单接上 `local-db:conversations:search`
  - 首页抽屉入口、设备详情、项目页、宽屏任务抽屉共用搜索 hook
  - 搜索条件菜单（排序 / 状态 / 项目 / Agent / 最近活动）
  - 桌面搜索菜单文案与 Agent 选项对齐（搜索条件、Claude Code、Pi），IPC 枚举补 `pi`
- 明确不包含：桌面混合/向量搜索、新协议通道、原生指纹改动、自动化运行列表搜索、侧栏显示设置里的 Agent 列表改 Pi
- 用户可见变化：手机能搜被控电脑上的任务标题和内容；搜索条与筛选对照桌面
- 是否存在 breaking change：无
- 远程 / 手机适配：
  1. SSH 远程工作区：不涉及（不读本机 workdir）
  2. device-link IPC：不新开通道；`local-db:conversations:search` 已在 `packages/device-link` 白名单，本 PR 只把手机 invoke 白名单补上
  3. 手机入口：本 PR 已接首页 / 设备详情 / 项目页 / 宽屏抽屉

### UI 变化

手机首页 / 设备详情 / 项目页 / 宽屏抽屉：点「搜索」展开圆角搜索条（放大镜 +「搜索标题或内容…」+ 清空 + 筛选钮）。筛选面板标题为「搜索条件」。桌面侧栏搜索菜单同步该标题，Agent 增加 Pi，Claude 改为 Claude Code。

- 引用的设计规范：
  - `docs/design-rules/DESIGN.md` §1 pill 几何、近单色、交互元素用 pill
  - `docs/design-rules/DESIGN.md` §2 / §10 颜色走语义 token，Light/Dark 共用同一套组件
  - `docs/design-rules/DESIGN.md` §5 圆角只用 control / container / pill
  - `apps/mobile/docs/mobile-design-guide.md` 触控热区、零阴影、token 色
  - `docs/product-rules/task-and-conversation-naming.md` 面向用户称「任务」；抽屉入口按产品要求叫「搜索」

## 怎么验证的

### 自动验证

```text
pnpm --filter mobile run typecheck
结果：通过

pnpm --filter desktop run typecheck
结果：通过

pnpm --filter mobile exec vitest run src/__tests__/conversationSearch.test.ts src/__tests__/homeDesktopFirst.test.ts src/__tests__/sessionListDrawer.test.ts src/__tests__/mobileMakerTransport.test.ts
结果：通过

pnpm --filter desktop exec vitest run src/main/localDb/__tests__/conversationSearchIpc.test.ts src/renderer/features/cc-agent/sidebar/__tests__/conversationSearchSort.test.tsx
结果：通过

pnpm test:unit:related
结果：因改了 packages/maker-shared/package.json 退回全量 workspace 单测。mobile / maker-shared / device-link 通过。
apps/desktop 全量 unit 失败项为 src/main/cindy-brain/__tests__/ghostInstallReceipt.test.ts（2 条），与本 PR 无关。
已在干净基线 cindy@4be8eb2a3（本分支起点、未含本 diff）复现同一失败。
```

### 手工验证

- 平台：iOS Simulator，iPhone 17 Pro，region=global，worktree `/Users/dash/Code/Cindy/cindy-mobile-remote-task-search`
- 路径：首页抽屉 → 搜索 → 输入关键字 → 点开结果；筛选钮打开「搜索条件」；选 Agent Pi（需被控端已含本 PR 的 IPC）
- 桌面侧栏搜索菜单文案与 Pi 选项：需用本分支重启桌面端后目检（提交前未再开一次桌面）

### 未执行的验证

- 老被控端 `CHANNEL_NOT_ALLOWED` 仅有单测，没有旧版桌面真机验
- 搜索条 Light/Dark 双模式未做实机目检（组件走 themed token，不能当成双模式已验证）
- 未跑 `pnpm mobile:sim:whoami` 作为本轮提交证据（更早一轮模拟器已加载过该 worktree）

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [x] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：手机任务列表搜索；桌面搜索 IPC 的 `filters.agentKind` 增补 `pi`（append-only）。未改 `packages/device-link` 白名单，未改 mobile fingerprint 输入。
- 回滚 / 降级方式：回退本 PR。老被控端不认该通道或 `pi` 时，手机会落到已缓存任务搜索，不阻断列表。
- 存量插件影响：无

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
