### PR TITLE
fix(desktop): 禁用状态统一使用普通指针

### DIFF
--- a/apps/desktop/src/renderer/__tests__/disabledCursorVisualContract.test.ts
+++ b/apps/desktop/src/renderer/__tests__/disabledCursorVisualContract.test.ts
@@ -12,12 +12,21 @@ const makerExperimentalSource = readFileSync(
 
 describe('Desktop disabled cursor visual contract', () => {
   it('uses the ordinary arrow instead of a theme-provided SVG cursor', () => {
+    const disabledCursorRule = globalsSource.match(
+      /\.cursor-not-allowed,[^{}]*\{[^{}]*\}/,
+    )?.[0];
+
     expect(colorsSource).not.toContain('createNotAllowedCursor');
     expect(colorsSource).not.toContain("registerColor('cursor-not-allowed'");
-    expect(globalsSource).toContain('.cursor-not-allowed');
+    expect(disabledCursorRule).toBeDefined();
+    expect(disabledCursorRule).toContain('.cursor-not-allowed');
+    expect(disabledCursorRule).toContain('.disabled\\:cursor-not-allowed:disabled');
+    expect(disabledCursorRule).toContain(
+      '.data-\\[disabled\\]\\:cursor-not-allowed[data-disabled]',
+    );
+    expect(disabledCursorRule).toContain('cursor: default;');
+    expect(disabledCursorRule).not.toContain('var(--cursor-not-allowed');
     expect(globalsSource).not.toContain("html[data-platform='win32'] .cursor-not-allowed");
-    expect(globalsSource).toContain('cursor: default;');
-    expect(globalsSource).not.toContain('var(--cursor-not-allowed');
     expect(makerExperimentalSource).not.toContain('var(--cursor-not-allowed');
     expect(makerExperimentalSource).not.toContain("window.electronAPI.platform === 'win32'");
     expect(makerExperimentalSource).toContain("cursor: m.session ? 'default' : 'pointer'");

--- a/apps/desktop/src/renderer/__tests__/disabledCursorVisualContract.test.ts
+++ b/apps/desktop/src/renderer/__tests__/disabledCursorVisualContract.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const colorsSource = readFileSync(resolve(__dirname, '..', 'themes', 'colors.ts'), 'utf8');
+const globalsSource = readFileSync(resolve(__dirname, '..', 'styles', 'globals.css'), 'utf8');
+const makerExperimentalSource = readFileSync(
+  resolve(__dirname, '..', 'features', 'maker-experimental', 'MakerExperimentalView.tsx'),
+  'utf8',
+);
+
+describe('Desktop disabled cursor visual contract', () => {
+  it('uses the ordinary arrow instead of a theme-provided SVG cursor', () => {
+    expect(colorsSource).not.toContain('createNotAllowedCursor');
+    expect(colorsSource).not.toContain("registerColor('cursor-not-allowed'");
+    expect(globalsSource).toContain('.cursor-not-allowed');
+    expect(globalsSource).not.toContain("html[data-platform='win32'] .cursor-not-allowed");
+    expect(globalsSource).toContain('cursor: default;');
+    expect(globalsSource).not.toContain('var(--cursor-not-allowed');
+    expect(makerExperimentalSource).not.toContain('var(--cursor-not-allowed');
+    expect(makerExperimentalSource).not.toContain("window.electronAPI.platform === 'win32'");
+    expect(makerExperimentalSource).toContain("cursor: m.session ? 'default' : 'pointer'");
+  });
+});

--- a/apps/desktop/src/renderer/features/maker-experimental/MakerExperimentalView.tsx
+++ b/apps/desktop/src/renderer/features/maker-experimental/MakerExperimentalView.tsx
@@ -188,11 +188,7 @@ export function MakerExperimentalView(): ReactElement {
               color: '#d4d4d4',
               border: '1px solid #333',
               borderRadius: 4,
-              cursor: m.session
-                ? window.electronAPI.platform === 'win32'
-                  ? 'var(--cursor-not-allowed, not-allowed)'
-                  : 'not-allowed'
-                : 'pointer',
+              cursor: m.session ? 'default' : 'pointer',
               opacity: m.session ? 0.5 : 1,
             }}
           >

--- a/apps/desktop/src/renderer/styles/globals.css
+++ b/apps/desktop/src/renderer/styles/globals.css
@@ -1989,10 +1989,12 @@ body.resizing-pane [data-ghost-webview] {
     color: var(--sidebar-item-active-foreground);
   }
 
-  html[data-platform='win32'] .cursor-not-allowed,
-  html[data-platform='win32'] .disabled\:cursor-not-allowed:disabled,
-  html[data-platform='win32'] .data-\[disabled\]\:cursor-not-allowed[data-disabled] {
-    cursor: var(--cursor-not-allowed, not-allowed);
+  /* Disabled controls keep the ordinary desktop arrow. Their visual disabled
+     state already comes from opacity/color, so a separate cursor adds noise. */
+  .cursor-not-allowed,
+  .disabled\:cursor-not-allowed:disabled,
+  .data-\[disabled\]\:cursor-not-allowed[data-disabled] {
+    cursor: default;
   }
 }
 

--- a/apps/desktop/src/renderer/themes/colors.ts
+++ b/apps/desktop/src/renderer/themes/colors.ts
@@ -1,13 +1,6 @@
 import { registerColor } from './color-registry';
 import { EFFORT_TIER_COLORS, PRICE_TIER_COLORS } from './effortTierColors';
 
-function createNotAllowedCursor(stroke: string): string {
-  const encodedStroke = stroke.startsWith('#')
-    ? `%23${stroke.slice(1)}`
-    : encodeURIComponent(stroke);
-  return `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='32' height='32' viewBox='0 0 32 32'%3E%3Ccircle cx='16' cy='16' r='10' fill='none' stroke='${encodedStroke}' stroke-width='2.6'/%3E%3Cpath d='M9.2 22.8 22.8 9.2' fill='none' stroke='${encodedStroke}' stroke-width='2.6' stroke-linecap='round'/%3E%3C/svg%3E") 16 16, not-allowed`;
-}
-
 /* === P3.2: Semantic slot tokens === */
 registerColor('surface', {
   light: '#f8f8f6',
@@ -190,10 +183,6 @@ registerColor('text-placeholder', {
   light: '#c4c4c4',
   dark: '#525252',
 }, 'Placeholder 文字 — 必须读着像空(比 tertiary 更淡);统一 slot,各输入面 placeholder alias 均收口于此');
-registerColor('cursor-not-allowed', {
-  light: createNotAllowedCursor('#373737'),
-  dark: createNotAllowedCursor('#d4d4d4'),
-}, 'Windows disabled cursor SVG (完整 cursor 值,可由主题覆盖)');
 registerColor('accent-cta-bg', {
   light: '#262626',
   dark: '#ffffff',


### PR DESCRIPTION
## 这次改了什么

### 摘要

将 Desktop 禁用控件的鼠标指针统一为普通箭头，移除 Windows 专用的禁止符号 SVG cursor，并同步修正 Maker 实验页的内联实现。禁用逻辑、透明度、颜色和 `cursor-wait` 状态均保持不变。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：用户反馈 Windows 与 macOS 的禁止符号指针视觉突兀
- 本 PR 包含：全局 `cursor-not-allowed` 视觉覆盖、旧主题 cursor token 清理、Maker 实验页同步、回归测试
- 明确不包含：不改变控件何时禁用；不修改现有 `cursor-wait` 点位
- 用户可见变化：Windows、macOS 及其他 Desktop 平台的禁用控件均显示普通箭头
- 是否存在 breaking change：无

### UI 变化

- 截图 / 录屏：未附；本次只改变系统鼠标指针形状，静态截图无法有效表达
- 引用的设计规范：`docs/design-rules/DESIGN.md` §10「Light / Dark Dual-Mode Delivery Gate」——同一普通指针规则覆盖 Light 与 Dark；保留现有 disabled 透明度与语义颜色，不新增硬编码颜色或单模式分支

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：通过（Desktop related tests）

pnpm --filter desktop run --if-present typecheck
结果：通过（最终 rebase 后）

pnpm check:dco
结果：通过（1 个提交带 Signed-off-by）

bash /Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh <worktree>
结果：28,149 个测试通过，2 个 ghostInstallReceipt 断言失败。
该失败已在干净、最新的 main（1aa9c68a）用下列命令独立复现，确认与本 PR 无关：
pnpm --dir apps/desktop exec vitest run --pool=threads --maxWorkers=1 src/main/cindy-brain/__tests__/ghostInstallReceipt.test.ts
```

### 手工验证

未执行实机目检。

### 未执行的验证

- 未在 Windows / macOS 实机逐一目检鼠标指针；回归测试锁定全局选择器、主题 token 与 Maker 实验页实现

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop Renderer 中所有使用 `cursor-not-allowed` 的禁用控件，以及 Maker 实验页的禁用目录选择按钮
- 回滚 / 降级方式：恢复 Windows cursor token、平台限定选择器及 Maker 页原有平台分支

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
