### PR TITLE
fix(desktop): SuperGrok 重置后缺百分比按 0% 刷新，不再卡在剩余 0

### DIFF
--- a/apps/desktop/src/main/__tests__/usageBroadcasterXaiSubscription.test.ts
+++ b/apps/desktop/src/main/__tests__/usageBroadcasterXaiSubscription.test.ts
@@ -112,4 +112,25 @@ describe('xai subscription snapshot hydration', () => {
       accountFingerprint: 'bbbb',
     });
   });
+
+  it('lets a reset to 0% overwrite a previously exhausted weekly percent', async () => {
+    const broadcaster = await import('../usageBroadcaster');
+    mocks.queryOne.mockResolvedValue(null);
+    await broadcaster.recordXaiSubscriptionUsageSnapshot({
+      planLabel: 'SuperGrok Heavy',
+      creditUsagePercent: 100,
+      accountFingerprint: 'bbbb',
+      updatedAt: 2,
+    });
+    await broadcaster.recordXaiSubscriptionUsageSnapshot({
+      planLabel: 'SuperGrok Heavy',
+      creditUsagePercent: 0,
+      accountFingerprint: 'bbbb',
+      updatedAt: 3,
+    });
+    await expect(broadcaster.readXaiSubscriptionUsageSnapshot()).resolves.toMatchObject({
+      creditUsagePercent: 0,
+      updatedAt: 3,
+    });
+  });
 });

--- a/apps/desktop/src/main/usage/__tests__/xaiSubscriptionUsage.test.ts
+++ b/apps/desktop/src/main/usage/__tests__/xaiSubscriptionUsage.test.ts
@@ -104,7 +104,7 @@ describe('fetchXaiSubscriptionUsageSnapshot', () => {
     })).resolves.toBeNull();
   });
 
-  it('does not replace cache when billing 200 only has a reset time', async () => {
+  it('treats a still-open weekly window without percent as 0% used after reset', async () => {
     const fetchFn = vi.fn(async (url: string) => {
       if (url.includes('/settings')) {
         return jsonResponse(200, { subscription_tier_display: 'SuperGrok Heavy' });
@@ -118,6 +118,29 @@ describe('fetchXaiSubscriptionUsageSnapshot', () => {
     await expect(fetchXaiSubscriptionUsageSnapshot({
       accessToken: 'tok',
       fetchFn: fetchFn as unknown as typeof fetch,
+      now: 1_700_000_000_000,
+    })).resolves.toMatchObject({
+      planLabel: 'SuperGrok Heavy',
+      creditUsagePercent: 0,
+      resetsAt: 1_800_000_000,
+    });
+  });
+
+  it('does not replace cache when the reset time is already in the past and percent is missing', async () => {
+    const fetchFn = vi.fn(async (url: string) => {
+      if (url.includes('/settings')) {
+        return jsonResponse(200, { subscription_tier_display: 'SuperGrok Heavy' });
+      }
+      if (url.includes('format=credits')) {
+        return jsonResponse(200, { config: { currentPeriod: { end: 1_600_000_000 } } });
+      }
+      if (url.includes('/user?') || url.includes('/userinfo')) return jsonResponse(200, {});
+      return jsonResponse(404, {});
+    });
+    await expect(fetchXaiSubscriptionUsageSnapshot({
+      accessToken: 'tok',
+      fetchFn: fetchFn as unknown as typeof fetch,
+      now: 1_700_000_000_000,
     })).resolves.toBeNull();
   });
 

--- a/apps/desktop/src/main/usage/__tests__/xaiSubscriptionUsage.test.ts
+++ b/apps/desktop/src/main/usage/__tests__/xaiSubscriptionUsage.test.ts
@@ -130,6 +130,29 @@ describe('fetchXaiSubscriptionUsageSnapshot', () => {
     });
   });
 
+  it('does not replace cache when weekly percent is present but unparseable', async () => {
+    const fetchFn = vi.fn(async (url: string) => {
+      if (url.includes('/settings')) {
+        return jsonResponse(200, { subscription_tier_display: 'SuperGrok Heavy' });
+      }
+      if (url.includes('format=credits')) {
+        return jsonResponse(200, {
+          config: {
+            currentPeriod: { type: 'USAGE_PERIOD_TYPE_WEEKLY', end: 1_800_000_000 },
+            creditUsagePercent: 'nope',
+          },
+        });
+      }
+      if (url.includes('/user?') || url.includes('/userinfo')) return jsonResponse(200, {});
+      return jsonResponse(404, {});
+    });
+    await expect(fetchXaiSubscriptionUsageSnapshot({
+      accessToken: 'tok',
+      fetchFn: fetchFn as unknown as typeof fetch,
+      now: 1_700_000_000_000,
+    })).resolves.toBeNull();
+  });
+
   it('does not replace cache when only a future billingPeriodEnd is present', async () => {
     const fetchFn = vi.fn(async (url: string) => {
       if (url.includes('/settings')) {

--- a/apps/desktop/src/main/usage/__tests__/xaiSubscriptionUsage.test.ts
+++ b/apps/desktop/src/main/usage/__tests__/xaiSubscriptionUsage.test.ts
@@ -110,7 +110,11 @@ describe('fetchXaiSubscriptionUsageSnapshot', () => {
         return jsonResponse(200, { subscription_tier_display: 'SuperGrok Heavy' });
       }
       if (url.includes('format=credits')) {
-        return jsonResponse(200, { config: { currentPeriod: { end: 1_800_000_000 } } });
+        return jsonResponse(200, {
+          config: {
+            currentPeriod: { type: 'USAGE_PERIOD_TYPE_WEEKLY', end: 1_800_000_000 },
+          },
+        });
       }
       if (url.includes('/user?') || url.includes('/userinfo')) return jsonResponse(200, {});
       return jsonResponse(404, {});
@@ -124,6 +128,24 @@ describe('fetchXaiSubscriptionUsageSnapshot', () => {
       creditUsagePercent: 0,
       resetsAt: 1_800_000_000,
     });
+  });
+
+  it('does not replace cache when only a future billingPeriodEnd is present', async () => {
+    const fetchFn = vi.fn(async (url: string) => {
+      if (url.includes('/settings')) {
+        return jsonResponse(200, { subscription_tier_display: 'SuperGrok Heavy' });
+      }
+      if (url.includes('format=credits')) {
+        return jsonResponse(200, { config: { billingPeriodEnd: 1_800_000_000 } });
+      }
+      if (url.includes('/user?') || url.includes('/userinfo')) return jsonResponse(200, {});
+      return jsonResponse(404, {});
+    });
+    await expect(fetchXaiSubscriptionUsageSnapshot({
+      accessToken: 'tok',
+      fetchFn: fetchFn as unknown as typeof fetch,
+      now: 1_700_000_000_000,
+    })).resolves.toBeNull();
   });
 
   it('does not replace cache when the reset time is already in the past and percent is missing', async () => {

--- a/apps/desktop/src/main/usage/xaiSubscriptionUsage.ts
+++ b/apps/desktop/src/main/usage/xaiSubscriptionUsage.ts
@@ -6,7 +6,8 @@
  *
  * 请求头与模型发现共用 buildXaiCliProxyHeaders。邮箱/姓名/完整响应当场丢弃。
  * settings/billing 的 401/403/429 才控制配额可用性;5xx / 半成功无字段返回 null 保缓存。
- * 未结束周窗口省略 creditUsagePercent 视为 0%(重置后常见),不能当残缺 200 保打满缓存。
+ * 仅当 currentPeriod.type=USAGE_PERIOD_TYPE_WEEKLY 且窗口未结束时,
+ * 省略 creditUsagePercent 视为 0%(重置后常见),不能当残缺 200 保打满缓存。
  */
 
 import { createHash } from 'node:crypto';
@@ -173,8 +174,8 @@ export async function fetchXaiSubscriptionUsageSnapshot(opts: {
       || !parsedCredits
       || typeof parsedCredits.creditUsagePercent !== 'number'
     ) {
-      // 权威端点失败,或 200 但连未结束窗口也推不出周百分比:残缺快照不能盖掉缓存。
-      // 未结束窗口省略 creditUsagePercent 已在 parse 里当成 0%,不会走进这里。
+      // 权威端点失败,或 200 但没有仍开放的 weekly currentPeriod 可推出百分比:
+      // 残缺快照不能盖掉缓存。明确的未结束周窗口省略该字段已在 parse 里当成 0%。
       return null;
     }
     const snapshot = buildXaiSubscriptionUsageSnapshot({

--- a/apps/desktop/src/main/usage/xaiSubscriptionUsage.ts
+++ b/apps/desktop/src/main/usage/xaiSubscriptionUsage.ts
@@ -6,8 +6,9 @@
  *
  * 请求头与模型发现共用 buildXaiCliProxyHeaders。邮箱/姓名/完整响应当场丢弃。
  * settings/billing 的 401/403/429 才控制配额可用性;5xx / 半成功无字段返回 null 保缓存。
- * 仅当 currentPeriod.type=USAGE_PERIOD_TYPE_WEEKLY 且窗口未结束时,
- * 省略 creditUsagePercent 视为 0%(重置后常见),不能当残缺 200 保打满缓存。
+ * 仅当 currentPeriod.type=USAGE_PERIOD_TYPE_WEEKLY、窗口未结束、
+ * 且响应里没有 creditUsagePercent 键时,视为 0%(重置后常见)。
+ * 字段在但解不出数,仍当残缺 200 保缓存。
  */
 
 import { createHash } from 'node:crypto';

--- a/apps/desktop/src/main/usage/xaiSubscriptionUsage.ts
+++ b/apps/desktop/src/main/usage/xaiSubscriptionUsage.ts
@@ -6,6 +6,7 @@
  *
  * 请求头与模型发现共用 buildXaiCliProxyHeaders。邮箱/姓名/完整响应当场丢弃。
  * settings/billing 的 401/403/429 才控制配额可用性;5xx / 半成功无字段返回 null 保缓存。
+ * 未结束周窗口省略 creditUsagePercent 视为 0%(重置后常见),不能当残缺 200 保打满缓存。
  */
 
 import { createHash } from 'node:crypto';
@@ -164,7 +165,7 @@ export async function fetchXaiSubscriptionUsageSnapshot(opts: {
     void userIdFromAccountUser(accountUser);
 
     const planLabel = parseXaiSettingsPlanLabel(settings.data);
-    const parsedCredits = parseXaiBillingCreditsConfig(credits.data);
+    const parsedCredits = parseXaiBillingCreditsConfig(credits.data, now);
     const subject = subjectFromUserinfo(userinfo);
     if (
       !settings.ok
@@ -172,7 +173,8 @@ export async function fetchXaiSubscriptionUsageSnapshot(opts: {
       || !parsedCredits
       || typeof parsedCredits.creditUsagePercent !== 'number'
     ) {
-      // 权威端点失败,或 200 但缺周用量百分比:残缺快照不能盖掉缓存。
+      // 权威端点失败,或 200 但连未结束窗口也推不出周百分比:残缺快照不能盖掉缓存。
+      // 未结束窗口省略 creditUsagePercent 已在 parse 里当成 0%,不会走进这里。
       return null;
     }
     const snapshot = buildXaiSubscriptionUsageSnapshot({

--- a/apps/desktop/src/shared/__tests__/xaiSubscriptionUsage.test.ts
+++ b/apps/desktop/src/shared/__tests__/xaiSubscriptionUsage.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   buildXaiSubscriptionUsageSnapshot,
   formatXaiProductLabel,
+  inferXaiWeeklyUsagePercent,
   isXaiSubscriptionAlerting,
   isXaiWeeklyUsageCurrent,
   parseXaiBillingCreditsConfig,
@@ -64,6 +65,32 @@ describe('parseXaiBillingCreditsConfig', () => {
   it('returns null when neither percent nor reset exists', () => {
     expect(parseXaiBillingCreditsConfig({ config: { prepaidBalance: { val: 0 } } })).toBeNull();
     expect(parseXaiBillingCreditsConfig(null)).toBeNull();
+  });
+
+  it('treats an omitted percent as 0% while the weekly window is still open', () => {
+    const nowMs = Date.parse('2026-08-15T00:00:00.000Z');
+    const parsed = parseXaiBillingCreditsConfig({
+      config: {
+        currentPeriod: {
+          type: 'USAGE_PERIOD_TYPE_WEEKLY',
+          end: '2026-08-18T09:53:45.527500+00:00',
+        },
+      },
+    }, nowMs);
+    expect(parsed?.creditUsagePercent).toBe(0);
+    expect(parsed?.resetsAt).toBe(Math.floor(Date.parse('2026-08-18T09:53:45.527500+00:00') / 1000));
+  });
+
+  it('does not invent 0% after the weekly window has already ended', () => {
+    const nowMs = Date.parse('2026-08-19T00:00:00.000Z');
+    const parsed = parseXaiBillingCreditsConfig({
+      config: {
+        currentPeriod: { end: '2026-08-18T09:53:45.527500+00:00' },
+      },
+    }, nowMs);
+    expect(parsed?.creditUsagePercent).toBeNull();
+    expect(inferXaiWeeklyUsagePercent(null, 1_800_000_000, 1_800_000_000 * 1000)).toBeNull();
+    expect(inferXaiWeeklyUsagePercent(null, 1_800_000_000, 1_800_000_000 * 1000 - 1)).toBe(0);
   });
 
   it('skips malformed product rows', () => {

--- a/apps/desktop/src/shared/__tests__/xaiSubscriptionUsage.test.ts
+++ b/apps/desktop/src/shared/__tests__/xaiSubscriptionUsage.test.ts
@@ -85,12 +85,35 @@ describe('parseXaiBillingCreditsConfig', () => {
     const nowMs = Date.parse('2026-08-19T00:00:00.000Z');
     const parsed = parseXaiBillingCreditsConfig({
       config: {
-        currentPeriod: { end: '2026-08-18T09:53:45.527500+00:00' },
+        currentPeriod: {
+          type: 'USAGE_PERIOD_TYPE_WEEKLY',
+          end: '2026-08-18T09:53:45.527500+00:00',
+        },
       },
     }, nowMs);
     expect(parsed?.creditUsagePercent).toBeNull();
     expect(inferXaiWeeklyUsagePercent(null, 1_800_000_000, 1_800_000_000 * 1000)).toBeNull();
     expect(inferXaiWeeklyUsagePercent(null, 1_800_000_000, 1_800_000_000 * 1000 - 1)).toBe(0);
+  });
+
+  it('does not invent 0% from a future billingPeriodEnd or non-weekly period', () => {
+    const nowMs = Date.parse('2026-08-15T00:00:00.000Z');
+    expect(parseXaiBillingCreditsConfig({
+      config: { billingPeriodEnd: '2026-09-18T00:00:00.000Z' },
+    }, nowMs)?.creditUsagePercent).toBeNull();
+    expect(parseXaiBillingCreditsConfig({
+      config: {
+        currentPeriod: {
+          type: 'USAGE_PERIOD_TYPE_MONTHLY',
+          end: '2026-09-18T00:00:00.000Z',
+        },
+      },
+    }, nowMs)?.creditUsagePercent).toBeNull();
+    expect(parseXaiBillingCreditsConfig({
+      config: {
+        currentPeriod: { end: '2026-09-18T00:00:00.000Z' },
+      },
+    }, nowMs)?.creditUsagePercent).toBeNull();
   });
 
   it('skips malformed product rows', () => {

--- a/apps/desktop/src/shared/__tests__/xaiSubscriptionUsage.test.ts
+++ b/apps/desktop/src/shared/__tests__/xaiSubscriptionUsage.test.ts
@@ -92,8 +92,26 @@ describe('parseXaiBillingCreditsConfig', () => {
       },
     }, nowMs);
     expect(parsed?.creditUsagePercent).toBeNull();
-    expect(inferXaiWeeklyUsagePercent(null, 1_800_000_000, 1_800_000_000 * 1000)).toBeNull();
-    expect(inferXaiWeeklyUsagePercent(null, 1_800_000_000, 1_800_000_000 * 1000 - 1)).toBe(0);
+    expect(inferXaiWeeklyUsagePercent(null, 1_800_000_000, 1_800_000_000 * 1000, true)).toBeNull();
+    expect(inferXaiWeeklyUsagePercent(null, 1_800_000_000, 1_800_000_000 * 1000 - 1, true)).toBe(0);
+    expect(inferXaiWeeklyUsagePercent(null, 1_800_000_000, 1_800_000_000 * 1000 - 1, false)).toBeNull();
+  });
+
+  it('does not invent 0% when creditUsagePercent is present but unparseable', () => {
+    const nowMs = Date.parse('2026-08-15T00:00:00.000Z');
+    const weekly = {
+      type: 'USAGE_PERIOD_TYPE_WEEKLY',
+      end: '2026-08-18T09:53:45.527500+00:00',
+    };
+    expect(parseXaiBillingCreditsConfig({
+      config: { currentPeriod: weekly, creditUsagePercent: 'nope' },
+    }, nowMs)?.creditUsagePercent).toBeNull();
+    expect(parseXaiBillingCreditsConfig({
+      config: { currentPeriod: weekly, creditUsagePercent: { val: 2 } },
+    }, nowMs)?.creditUsagePercent).toBeNull();
+    expect(parseXaiBillingCreditsConfig({
+      config: { currentPeriod: weekly, creditUsagePercent: null },
+    }, nowMs)?.creditUsagePercent).toBeNull();
   });
 
   it('does not invent 0% from a future billingPeriodEnd or non-weekly period', () => {

--- a/apps/desktop/src/shared/xaiSubscriptionUsage.ts
+++ b/apps/desktop/src/shared/xaiSubscriptionUsage.ts
@@ -8,8 +8,9 @@
  *
  * 这是账号级「每周包含限额」,不是单次任务配额,也不是 api.x.ai 的 RPM/TPM 限流。
  * 解析必须 fail-safe:字段缺失 / 形状不符就跳过,绝不从 token 数反推百分比。
- * 例外:未结束的周窗口若省略 creditUsagePercent,按 proto3 默认值当成 0% ——
- * 手动重置 / 新窗口刚开始时上游经常不发这个字段,缺了不能继续沿用打满时的缓存。
+ * 例外:仅当 currentPeriod.type 明确是 USAGE_PERIOD_TYPE_WEEKLY、窗口尚未结束、
+ * 且省略 creditUsagePercent 时,按 proto3 默认值当成 0%。只有未来的 billingPeriodEnd、
+ * 或非周窗口,都不能推断 0%,否则会把打满缓存盖成剩余 100%。
  */
 
 /** 分产品周用量(页面「Grok Build 2%」)。 */
@@ -94,21 +95,31 @@ function parseProductUsage(raw: unknown): XaiProductUsage[] {
   return out;
 }
 
+const XAI_WEEKLY_PERIOD_TYPE = 'USAGE_PERIOD_TYPE_WEEKLY';
+
+/** 只有上游标明的周窗口才能用来推断省略的 creditUsagePercent。 */
+export function isXaiWeeklyUsagePeriod(period: unknown): period is Record<string, unknown> {
+  if (!isPlainObject(period)) return false;
+  const type = toOptionalString(period.type);
+  return type === XAI_WEEKLY_PERIOD_TYPE;
+}
+
 /**
  * 未结束的周窗口里,省略的 creditUsagePercent 就是 0%。
- * 已过期窗口缺百分比则保持 null,让 fetch 保缓存,避免把打满快照改成 0。
+ * weeklyResetsAt 必须来自 USAGE_PERIOD_TYPE_WEEKLY 的 currentPeriod.end;
+ * 月度 billingPeriodEnd / 非周窗口 / 已过期窗口缺百分比都保持 null,让 fetch 保缓存。
  */
 export function inferXaiWeeklyUsagePercent(
   creditUsagePercent: number | null,
-  resetsAt: number | null,
+  weeklyResetsAt: number | null,
   nowMs: number,
 ): number | null {
   if (creditUsagePercent !== null) return clampPercent(creditUsagePercent);
   if (
-    typeof resetsAt === 'number'
-    && Number.isFinite(resetsAt)
-    && resetsAt > 0
-    && nowMs < resetsAt * 1000
+    typeof weeklyResetsAt === 'number'
+    && Number.isFinite(weeklyResetsAt)
+    && weeklyResetsAt > 0
+    && nowMs < weeklyResetsAt * 1000
   ) {
     return 0;
   }
@@ -132,13 +143,17 @@ export function parseXaiBillingCreditsConfig(
   const config = isPlainObject(data.config) ? data.config : data;
   const creditUsagePercent = toFiniteNumber(config.creditUsagePercent);
   const period = isPlainObject(config.currentPeriod) ? config.currentPeriod : null;
+  const weeklyResetsAt = isXaiWeeklyUsagePeriod(period)
+    ? toXaiUsageEpochSeconds(period.end)
+    : null;
   const resetsAt =
-    toXaiUsageEpochSeconds(period?.end)
+    weeklyResetsAt
+    ?? toXaiUsageEpochSeconds(period?.end)
     ?? toXaiUsageEpochSeconds(config.billingPeriodEnd);
   const prepaidBalance = toFiniteNumber(unwrapVal(config.prepaidBalance));
   if (creditUsagePercent === null && resetsAt === null) return null;
   return {
-    creditUsagePercent: inferXaiWeeklyUsagePercent(creditUsagePercent, resetsAt, nowMs),
+    creditUsagePercent: inferXaiWeeklyUsagePercent(creditUsagePercent, weeklyResetsAt, nowMs),
     resetsAt,
     productUsage: parseProductUsage(config.productUsage),
     prepaidBalance,

--- a/apps/desktop/src/shared/xaiSubscriptionUsage.ts
+++ b/apps/desktop/src/shared/xaiSubscriptionUsage.ts
@@ -8,6 +8,8 @@
  *
  * 这是账号级「每周包含限额」,不是单次任务配额,也不是 api.x.ai 的 RPM/TPM 限流。
  * 解析必须 fail-safe:字段缺失 / 形状不符就跳过,绝不从 token 数反推百分比。
+ * 例外:未结束的周窗口若省略 creditUsagePercent,按 proto3 默认值当成 0% ——
+ * 手动重置 / 新窗口刚开始时上游经常不发这个字段,缺了不能继续沿用打满时的缓存。
  */
 
 /** 分产品周用量(页面「Grok Build 2%」)。 */
@@ -93,10 +95,34 @@ function parseProductUsage(raw: unknown): XaiProductUsage[] {
 }
 
 /**
+ * 未结束的周窗口里,省略的 creditUsagePercent 就是 0%。
+ * 已过期窗口缺百分比则保持 null,让 fetch 保缓存,避免把打满快照改成 0。
+ */
+export function inferXaiWeeklyUsagePercent(
+  creditUsagePercent: number | null,
+  resetsAt: number | null,
+  nowMs: number,
+): number | null {
+  if (creditUsagePercent !== null) return clampPercent(creditUsagePercent);
+  if (
+    typeof resetsAt === 'number'
+    && Number.isFinite(resetsAt)
+    && resetsAt > 0
+    && nowMs < resetsAt * 1000
+  ) {
+    return 0;
+  }
+  return null;
+}
+
+/**
  * 解析 billing?format=credits 的 config。
  * 至少要有 creditUsagePercent 或重置时间,否则返回 null。
  */
-export function parseXaiBillingCreditsConfig(data: unknown): {
+export function parseXaiBillingCreditsConfig(
+  data: unknown,
+  nowMs: number = Date.now(),
+): {
   creditUsagePercent: number | null;
   resetsAt: number | null;
   productUsage: XaiProductUsage[];
@@ -112,7 +138,7 @@ export function parseXaiBillingCreditsConfig(data: unknown): {
   const prepaidBalance = toFiniteNumber(unwrapVal(config.prepaidBalance));
   if (creditUsagePercent === null && resetsAt === null) return null;
   return {
-    creditUsagePercent: creditUsagePercent === null ? null : clampPercent(creditUsagePercent),
+    creditUsagePercent: inferXaiWeeklyUsagePercent(creditUsagePercent, resetsAt, nowMs),
     resetsAt,
     productUsage: parseProductUsage(config.productUsage),
     prepaidBalance,

--- a/apps/desktop/src/shared/xaiSubscriptionUsage.ts
+++ b/apps/desktop/src/shared/xaiSubscriptionUsage.ts
@@ -9,8 +9,8 @@
  * 这是账号级「每周包含限额」,不是单次任务配额,也不是 api.x.ai 的 RPM/TPM 限流。
  * 解析必须 fail-safe:字段缺失 / 形状不符就跳过,绝不从 token 数反推百分比。
  * 例外:仅当 currentPeriod.type 明确是 USAGE_PERIOD_TYPE_WEEKLY、窗口尚未结束、
- * 且省略 creditUsagePercent 时,按 proto3 默认值当成 0%。只有未来的 billingPeriodEnd、
- * 或非周窗口,都不能推断 0%,否则会把打满缓存盖成剩余 100%。
+ * 且响应里根本没有 creditUsagePercent 键时,按 proto3 默认值当成 0%。
+ * 字段在但解不出数、只有未来 billingPeriodEnd、或非周窗口,都不能推断 0%。
  */
 
 /** 分产品周用量(页面「Grok Build 2%」)。 */
@@ -107,14 +107,17 @@ export function isXaiWeeklyUsagePeriod(period: unknown): period is Record<string
 /**
  * 未结束的周窗口里,省略的 creditUsagePercent 就是 0%。
  * weeklyResetsAt 必须来自 USAGE_PERIOD_TYPE_WEEKLY 的 currentPeriod.end;
- * 月度 billingPeriodEnd / 非周窗口 / 已过期窗口缺百分比都保持 null,让 fetch 保缓存。
+ * fieldOmitted 必须是键不存在。字段在但解不出、月度 billingPeriodEnd、
+ * 非周窗口、已过期窗口都保持 null,让 fetch 保缓存。
  */
 export function inferXaiWeeklyUsagePercent(
   creditUsagePercent: number | null,
   weeklyResetsAt: number | null,
   nowMs: number,
+  fieldOmitted = false,
 ): number | null {
   if (creditUsagePercent !== null) return clampPercent(creditUsagePercent);
+  if (!fieldOmitted) return null;
   if (
     typeof weeklyResetsAt === 'number'
     && Number.isFinite(weeklyResetsAt)
@@ -141,6 +144,7 @@ export function parseXaiBillingCreditsConfig(
 } | null {
   if (!isPlainObject(data)) return null;
   const config = isPlainObject(data.config) ? data.config : data;
+  const percentOmitted = !Object.prototype.hasOwnProperty.call(config, 'creditUsagePercent');
   const creditUsagePercent = toFiniteNumber(config.creditUsagePercent);
   const period = isPlainObject(config.currentPeriod) ? config.currentPeriod : null;
   const weeklyResetsAt = isXaiWeeklyUsagePeriod(period)
@@ -153,7 +157,12 @@ export function parseXaiBillingCreditsConfig(
   const prepaidBalance = toFiniteNumber(unwrapVal(config.prepaidBalance));
   if (creditUsagePercent === null && resetsAt === null) return null;
   return {
-    creditUsagePercent: inferXaiWeeklyUsagePercent(creditUsagePercent, weeklyResetsAt, nowMs),
+    creditUsagePercent: inferXaiWeeklyUsagePercent(
+      creditUsagePercent,
+      weeklyResetsAt,
+      nowMs,
+      percentOmitted,
+    ),
     resetsAt,
     productUsage: parseProductUsage(config.productUsage),
     prepaidBalance,


### PR DESCRIPTION
## 这次改了什么

### 摘要

Grok 授权订阅在 grok.com 上手动重置后已经能继续对话，但 Cindy 里周额度仍显示剩余 0%。原因是重置后的 billing 响应常常省略 `creditUsagePercent`（proto3 把 0 当默认值不发），我们却把缺字段当成残缺 200，继续沿用打满前的缓存。现在：未结束的周窗口缺百分比就按 0% 已用刷新。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：SuperGrok 周用量解析把「未结束窗口省略百分比」视为 0%；过期窗口缺百分比仍保缓存
- 明确不包含：on-demand / prepaid 额外点数展示、落盘 hydration 启动竞态
- 用户可见变化：重置后设置页和用量 chip 会从剩余 0% 恢复为剩余 100%（0% 已使用）
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：不涉及：只改周额度数字的数据解析，不改 chip / 设置页布局、文案或交互

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：PASS apps/desktop unit

pnpm --filter desktop run --if-present typecheck
结果：EXIT 0
```

### 手工验证

不涉及。当前运行中的 App 不会加载本 worktree；重置后的实机刷新需发版或本地用本分支启动后再看设置 → xAI 与右下角用量 chip。

### 未执行的验证

未连真实 grok.com billing 做实机重置回归（依赖账号周额度打满再重置）。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围：Desktop SuperGrok 周用量解析与缓存覆盖
- 回滚 / 降级方式：revert 本 PR

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因