### PR TITLE
fix(mobile): show desktop-only confirmation status remotely

### DIFF
--- a/apps/desktop/src/main/__tests__/deviceLinkDispatch.test.ts
+++ b/apps/desktop/src/main/__tests__/deviceLinkDispatch.test.ts
@@ -43,6 +43,7 @@ import {
   isDeviceLinkInvoke,
 } from '../device-link/invoke-context';
 import * as subscriptions from '../device-link/subscriptions';
+import { createDesktopOnlyConfirmationRequestId } from '../cindy-brain/desktopOnlyConfirmationProjection';
 
 beforeEach(() => {
   remoteControlEnabled = true;
@@ -2483,9 +2484,10 @@ describe('被控端订阅 registry + topic 转发', () => {
     wireInboundDispatch(client);
     feed(subFrame('ctrl-a', SUB, ['session:s1']));
 
+    const sourceRequestId = createDesktopOnlyConfirmationRequestId();
     tapWindowBroadcast(MAKER_PUSH.INTERACTION_REQUEST, {
       sessionId: 's1',
-      request: { kind: 'issue_confirm', requestId: 'private-request-id', draft: { title: 'private' } },
+      request: { kind: 'issue_confirm', requestId: sourceRequestId, draft: { title: 'private' } },
     });
     const remoteRequestId = (calls.push[0].payload as {
       request: { requestId: string };
@@ -2493,7 +2495,7 @@ describe('被控端订阅 registry + topic 转发', () => {
 
     tapWindowBroadcast(MAKER_PUSH.INTERACTION_DISMISSED, {
       sessionId: 's1',
-      requestId: 'private-request-id',
+      requestId: sourceRequestId,
       reason: 'resolved',
     });
 
@@ -2502,7 +2504,7 @@ describe('被控端订阅 registry + topic 转发', () => {
       channel: MAKER_PUSH.INTERACTION_DISMISSED,
       payload: { sessionId: 's1', requestId: remoteRequestId, reason: 'resolved' },
     });
-    expect(JSON.stringify(calls.push[1].payload)).not.toContain('private-request-id');
+    expect(JSON.stringify(calls.push[1].payload)).not.toContain(sourceRequestId);
   });
 
   it('explicit unsubscribe removes the final remembered topic and stops the tap', () => {

--- a/apps/desktop/src/main/__tests__/deviceLinkDispatch.test.ts
+++ b/apps/desktop/src/main/__tests__/deviceLinkDispatch.test.ts
@@ -2448,7 +2448,7 @@ describe('被控端订阅 registry + topic 转发', () => {
     'issue_confirm',
     'rename_sessions_confirm',
     'ghost_grant_confirm',
-  ])('device-link does not forward Desktop-only %s live pushes', (kind) => {
+  ])('device-link forwards a redacted Desktop-only %s live status', (kind) => {
     remoteControlEnabled = true;
     const { client, calls, feed } = makeFakeClient();
     wireInboundDispatch(client);
@@ -2464,7 +2464,45 @@ describe('被控端订阅 registry + topic 转发', () => {
       },
     });
 
-    expect(calls.push).toEqual([]);
+    expect(calls.push).toHaveLength(1);
+    expect(calls.push[0]).toMatchObject({
+      dst: 'ctrl-a',
+      channel: MAKER_PUSH.INTERACTION_REQUEST,
+      payload: {
+        sessionId: 's1',
+        request: { kind, requestId: expect.stringMatching(/^desktop-confirm-/) },
+      },
+    });
+    expect(JSON.stringify(calls.push[0].payload)).not.toContain('private');
+    expect(JSON.stringify(calls.push[0].payload)).not.toContain(`${kind}-1`);
+  });
+
+  it('device-link dismisses a Desktop-only status with its opaque request id', () => {
+    remoteControlEnabled = true;
+    const { client, calls, feed } = makeFakeClient();
+    wireInboundDispatch(client);
+    feed(subFrame('ctrl-a', SUB, ['session:s1']));
+
+    tapWindowBroadcast(MAKER_PUSH.INTERACTION_REQUEST, {
+      sessionId: 's1',
+      request: { kind: 'issue_confirm', requestId: 'private-request-id', draft: { title: 'private' } },
+    });
+    const remoteRequestId = (calls.push[0].payload as {
+      request: { requestId: string };
+    }).request.requestId;
+
+    tapWindowBroadcast(MAKER_PUSH.INTERACTION_DISMISSED, {
+      sessionId: 's1',
+      requestId: 'private-request-id',
+      reason: 'resolved',
+    });
+
+    expect(calls.push[1]).toMatchObject({
+      dst: 'ctrl-a',
+      channel: MAKER_PUSH.INTERACTION_DISMISSED,
+      payload: { sessionId: 's1', requestId: remoteRequestId, reason: 'resolved' },
+    });
+    expect(JSON.stringify(calls.push[1].payload)).not.toContain('private-request-id');
   });
 
   it('explicit unsubscribe removes the final remembered topic and stops the tap', () => {

--- a/apps/desktop/src/main/cindy-brain/__tests__/ghostGrantConfirmBridge.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/ghostGrantConfirmBridge.test.ts
@@ -55,7 +55,9 @@ describe('GhostGrantConfirmBridge', () => {
         items: PAYLOAD.items,
       },
     });
-    expect((payload as { request: { requestId: string } }).request.requestId).toBeTruthy();
+    expect((payload as { request: { requestId: string } }).request.requestId).toMatch(
+      /^desktop-confirm-source-/,
+    );
     expect(bridge.pendingSnapshots('other-session')).toEqual([]);
     expect(bridge.pendingSnapshots('sess-1')).toEqual([
       { sessionId: 'sess-1', request: (payload as { request: unknown }).request },

--- a/apps/desktop/src/main/cindy-brain/__tests__/ghostSetupInteractionBridge.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/ghostSetupInteractionBridge.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { MAKER_PUSH } from '../../maker-ipc/channels';
 import {
+  projectInteractionDismissedForRemote,
   GhostSetupInteractionBridge,
   parseGhostSetupInlineSubmit,
   parseGhostSetupInlineSubmitRequest,
   parseGhostSetupInteractionCommand,
+  projectInteractionRequestForRemote,
   projectPendingInteractionsForRemote,
   sanitizeGhostSetupRequestForRemote,
   sanitizeGhostSetupSnapshotForRemote,
@@ -392,16 +394,40 @@ describe('sanitizeGhostSetupSnapshotForRemote', () => {
 
     const remote = projectPendingInteractionsForRemote(pending, true);
     expect(remote).not.toBe(pending);
-    expect(remote).toHaveLength(3);
+    expect(remote).toHaveLength(6);
     expect(JSON.stringify(remote[0])).not.toContain('desktop-only.example');
     expect(remote[1].request).toBe(permission.request);
     expect(remote[2].request).toBe(future.request);
     expect(JSON.stringify(remote)).not.toContain('private');
     expect(JSON.stringify(remote)).not.toContain('/Users/me/private.png');
+    for (const entry of remote.slice(3)) {
+      expect(entry.request).toEqual({
+        kind: expect.any(String),
+        requestId: expect.stringMatching(/^desktop-confirm-/),
+      });
+      expect(entry.request.requestId).not.toMatch(/issue-1|rename-1|grant-1/);
+    }
     expect(localSetup.request.steps[0].action.form.fields[0].externalLink).toEqual({
       url: 'https://desktop-only.example/keys',
     });
     expect(local).toEqual(pending);
+  });
+
+  it('maps a desktop-only confirmation dismissal to its opaque remote request id', () => {
+    const sourceRequest = { kind: 'issue_confirm', requestId: 'private-request-id', draft: { title: 'private' } };
+    const projected = projectInteractionRequestForRemote(sourceRequest)!;
+    const dismissed = projectInteractionDismissedForRemote({
+      sessionId: 'session-1',
+      requestId: sourceRequest.requestId,
+      reason: 'resolved',
+    });
+
+    expect(dismissed).toEqual({
+      sessionId: 'session-1',
+      requestId: projected.requestId,
+      reason: 'resolved',
+    });
+    expect(JSON.stringify(dismissed)).not.toContain('private-request-id');
   });
 });
 

--- a/apps/desktop/src/main/cindy-brain/__tests__/ghostSetupInteractionBridge.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/ghostSetupInteractionBridge.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { MAKER_PUSH } from '../../maker-ipc/channels';
 import {
+  rememberDesktopOnlyConfirmation,
   projectInteractionDismissedForRemote,
   GhostSetupInteractionBridge,
   parseGhostSetupInlineSubmit,
@@ -428,6 +429,37 @@ describe('sanitizeGhostSetupSnapshotForRemote', () => {
       reason: 'resolved',
     });
     expect(JSON.stringify(dismissed)).not.toContain('private-request-id');
+  });
+
+  it('maps a dismissal when the desktop-only confirmation predates Device Link activation', () => {
+    const requestId = 'preexisting-private-request-id';
+    rememberDesktopOnlyConfirmation(requestId);
+
+    const dismissed = projectInteractionDismissedForRemote({
+      sessionId: 'session-1',
+      requestId,
+      reason: 'resolved',
+    });
+
+    expect(dismissed).toMatchObject({
+      sessionId: 'session-1',
+      requestId: expect.stringMatching(/^desktop-confirm-/),
+      reason: 'resolved',
+    });
+    expect(JSON.stringify(dismissed)).not.toContain(requestId);
+  });
+
+  it('drops a dismissal after its desktop-only confirmation projection expires', () => {
+    vi.useFakeTimers();
+    try {
+      const requestId = 'expired-private-request-id';
+      rememberDesktopOnlyConfirmation(requestId);
+      vi.advanceTimersByTime(9 * 60 * 1000);
+
+      expect(projectInteractionDismissedForRemote({ requestId })).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/apps/desktop/src/main/cindy-brain/__tests__/ghostSetupInteractionBridge.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/ghostSetupInteractionBridge.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import { MAKER_PUSH } from '../../maker-ipc/channels';
+import { createDesktopOnlyConfirmationRequestId } from '../desktopOnlyConfirmationProjection';
 import {
-  rememberDesktopOnlyConfirmation,
   projectInteractionDismissedForRemote,
   GhostSetupInteractionBridge,
   parseGhostSetupInlineSubmit,
@@ -415,7 +415,11 @@ describe('sanitizeGhostSetupSnapshotForRemote', () => {
   });
 
   it('maps a desktop-only confirmation dismissal to its opaque remote request id', () => {
-    const sourceRequest = { kind: 'issue_confirm', requestId: 'private-request-id', draft: { title: 'private' } };
+    const sourceRequest = {
+      kind: 'issue_confirm',
+      requestId: createDesktopOnlyConfirmationRequestId(),
+      draft: { title: 'private' },
+    };
     const projected = projectInteractionRequestForRemote(sourceRequest)!;
     const dismissed = projectInteractionDismissedForRemote({
       sessionId: 'session-1',
@@ -428,12 +432,11 @@ describe('sanitizeGhostSetupSnapshotForRemote', () => {
       requestId: projected.requestId,
       reason: 'resolved',
     });
-    expect(JSON.stringify(dismissed)).not.toContain('private-request-id');
+    expect(JSON.stringify(dismissed)).not.toContain(sourceRequest.requestId);
   });
 
   it('maps a dismissal when the desktop-only confirmation predates Device Link activation', () => {
-    const requestId = 'preexisting-private-request-id';
-    rememberDesktopOnlyConfirmation(requestId);
+    const requestId = createDesktopOnlyConfirmationRequestId();
 
     const dismissed = projectInteractionDismissedForRemote({
       sessionId: 'session-1',
@@ -449,16 +452,38 @@ describe('sanitizeGhostSetupSnapshotForRemote', () => {
     expect(JSON.stringify(dismissed)).not.toContain(requestId);
   });
 
-  it('drops a dismissal after its desktop-only confirmation projection expires', () => {
+  it('keeps the opaque dismissal id stable after the Host confirmation timeout', () => {
     vi.useFakeTimers();
     try {
-      const requestId = 'expired-private-request-id';
-      rememberDesktopOnlyConfirmation(requestId);
+      const requestId = createDesktopOnlyConfirmationRequestId();
+      const projected = projectInteractionRequestForRemote({
+        kind: 'issue_confirm',
+        requestId,
+      })!;
       vi.advanceTimersByTime(9 * 60 * 1000);
 
-      expect(projectInteractionDismissedForRemote({ requestId })).toBeNull();
+      expect(projectInteractionDismissedForRemote({ requestId })).toEqual({
+        requestId: projected.requestId,
+      });
     } finally {
       vi.useRealTimers();
+    }
+  });
+
+  it('projects more than 128 concurrent confirmations without evicting source ids', () => {
+    const sourceRequestIds = Array.from(
+      { length: 256 },
+      () => createDesktopOnlyConfirmationRequestId(),
+    );
+
+    for (const requestId of sourceRequestIds) {
+      const projected = projectInteractionRequestForRemote({
+        kind: 'ghost_grant_confirm',
+        requestId,
+      })!;
+      const dismissed = projectInteractionDismissedForRemote({ requestId });
+      expect(dismissed).toEqual({ requestId: projected.requestId });
+      expect(JSON.stringify(dismissed)).not.toContain(requestId);
     }
   });
 });

--- a/apps/desktop/src/main/cindy-brain/desktopOnlyConfirmationProjection.ts
+++ b/apps/desktop/src/main/cindy-brain/desktopOnlyConfirmationProjection.ts
@@ -1,0 +1,21 @@
+import { createHmac, randomBytes, randomUUID } from 'node:crypto';
+
+const DESKTOP_ONLY_CONFIRMATION_SOURCE_PREFIX = 'desktop-confirm-source-';
+const desktopOnlyConfirmationProjectionKey = randomBytes(32);
+
+/** Creates a Host-only capability id that can be recognized without retaining request state. */
+export function createDesktopOnlyConfirmationRequestId(): string {
+  return `${DESKTOP_ONLY_CONFIRMATION_SOURCE_PREFIX}${randomUUID()}`;
+}
+
+export function isDesktopOnlyConfirmationRequestId(requestId: string): boolean {
+  return requestId.startsWith(DESKTOP_ONLY_CONFIRMATION_SOURCE_PREFIX);
+}
+
+/** Produces the stable opaque id exposed to Device Link for request/dismissal correlation. */
+export function projectDesktopOnlyConfirmationRequestId(requestId: string): string {
+  const digest = createHmac('sha256', desktopOnlyConfirmationProjectionKey)
+    .update(requestId)
+    .digest('hex');
+  return `desktop-confirm-${digest}`;
+}

--- a/apps/desktop/src/main/cindy-brain/ghostGrantConfirmBridge.ts
+++ b/apps/desktop/src/main/cindy-brain/ghostGrantConfirmBridge.ts
@@ -113,6 +113,7 @@ export class GhostGrantConfirmBridge {
         this.settle(requestId, { confirmed: false, reason: 'timeout' }, 'timeout');
       }, timeoutMs);
       this.pending.set(requestId, { sessionId, request, resolve, timeoutId });
+      rememberDesktopOnlyConfirmation(requestId);
       this.deps.broadcast(MAKER_PUSH.INTERACTION_REQUEST, {
         sessionId,
         request,

--- a/apps/desktop/src/main/cindy-brain/ghostGrantConfirmBridge.ts
+++ b/apps/desktop/src/main/cindy-brain/ghostGrantConfirmBridge.ts
@@ -19,10 +19,9 @@
  * 本模块保持 electron-free(broadcast 由 register.ts 注入),单测直接 new。
  */
 
-import { randomUUID } from 'node:crypto';
-
 import { MAKER_PUSH } from '../maker-ipc/channels';
 import { HOST_CONFIRM_TIMEOUT_MS } from '../maker-ipc/hostConfirmTiming.js';
+import { createDesktopOnlyConfirmationRequestId } from './desktopOnlyConfirmationProjection.js';
 
 /**
  * 过户通道:attachments = 媒体文件进总仓;dir = 上行读票据;save_dir = 下行
@@ -101,7 +100,7 @@ export class GhostGrantConfirmBridge {
     sessionId: string,
     payload: GhostGrantConfirmPayload,
   ): Promise<GhostGrantConfirmDecision> {
-    const requestId = randomUUID();
+    const requestId = createDesktopOnlyConfirmationRequestId();
     const request: GhostGrantConfirmInteractionSnapshot = {
       kind: 'ghost_grant_confirm',
       requestId,
@@ -113,7 +112,6 @@ export class GhostGrantConfirmBridge {
         this.settle(requestId, { confirmed: false, reason: 'timeout' }, 'timeout');
       }, timeoutMs);
       this.pending.set(requestId, { sessionId, request, resolve, timeoutId });
-      rememberDesktopOnlyConfirmation(requestId);
       this.deps.broadcast(MAKER_PUSH.INTERACTION_REQUEST, {
         sessionId,
         request,

--- a/apps/desktop/src/main/cindy-brain/ghostSetupInteractionBridge.ts
+++ b/apps/desktop/src/main/cindy-brain/ghostSetupInteractionBridge.ts
@@ -11,6 +11,7 @@ import type {
   GhostSetupErrorCode,
   GhostSetupStepPhase,
 } from '../../shared/ghost.js';
+import { randomUUID } from 'node:crypto';
 import { GHOST_SECRET_VALUE_MAX_CHARS, isGhostSetupErrorCode } from '../../shared/ghost.js';
 import { MAKER_PUSH } from '../maker-ipc/channels.js';
 
@@ -367,6 +368,29 @@ function isDesktopOnlyConfirmationRequest(request: unknown): boolean {
   );
 }
 
+interface DesktopOnlyConfirmationProjection {
+  remoteRequestId: string;
+}
+
+// Device Link must not receive a host confirmation's real request id: it is the
+// capability checked by the trusted Desktop resolver. Keep the opaque id only
+// long enough to translate the paired dismissal event for remote read-only UI.
+const desktopOnlyConfirmationProjections = new Map<string, DesktopOnlyConfirmationProjection>();
+
+function projectDesktopOnlyConfirmation(request: Record<string, unknown>): Record<string, unknown> | null {
+  const requestId = request.requestId;
+  if (typeof requestId !== 'string' || requestId.length === 0) return null;
+  let projection = desktopOnlyConfirmationProjections.get(requestId);
+  if (!projection) {
+    projection = { remoteRequestId: `desktop-confirm-${randomUUID()}` };
+    desktopOnlyConfirmationProjections.set(requestId, projection);
+  }
+  // Preserve only the known kind so mobile can render its existing read-only
+  // guidance. Drafts, file paths, previews, identities, and the real id stay
+  // on the controlled Desktop.
+  return { kind: request.kind, requestId: projection.remoteRequestId };
+}
+
 /**
  * Host-owned confirmations stay on the trusted Desktop. This keeps their
  * request ids and local payload details (for example file paths and previews)
@@ -374,8 +398,21 @@ function isDesktopOnlyConfirmationRequest(request: unknown): boolean {
  * projection used for remote status/cancellation.
  */
 export function projectInteractionRequestForRemote<T>(request: T): T | null {
-  if (isDesktopOnlyConfirmationRequest(request)) return null;
+  if (isDesktopOnlyConfirmationRequest(request)) {
+    return projectDesktopOnlyConfirmation(request as Record<string, unknown>) as T | null;
+  }
   return sanitizeGhostSetupRequestForRemote(request);
+}
+
+/** Rewrites the paired dismissal to the opaque id exposed by the request projection. */
+export function projectInteractionDismissedForRemote<T>(payload: T): T {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return payload;
+  const requestId = (payload as { requestId?: unknown }).requestId;
+  if (typeof requestId !== 'string') return payload;
+  const projection = desktopOnlyConfirmationProjections.get(requestId);
+  if (!projection) return payload;
+  desktopOnlyConfirmationProjections.delete(requestId);
+  return { ...(payload as Record<string, unknown>), requestId: projection.remoteRequestId } as T;
 }
 
 export function projectPendingInteractionsForRemote<T extends { request: unknown }>(

--- a/apps/desktop/src/main/cindy-brain/ghostSetupInteractionBridge.ts
+++ b/apps/desktop/src/main/cindy-brain/ghostSetupInteractionBridge.ts
@@ -14,6 +14,7 @@ import type {
 import { randomUUID } from 'node:crypto';
 import { GHOST_SECRET_VALUE_MAX_CHARS, isGhostSetupErrorCode } from '../../shared/ghost.js';
 import { MAKER_PUSH } from '../maker-ipc/channels.js';
+import { HOST_CONFIRM_TIMEOUT_MS } from '../maker-ipc/hostConfirmTiming.js';
 
 export interface GhostSetupInteractionStep {
   id: string;
@@ -370,25 +371,50 @@ function isDesktopOnlyConfirmationRequest(request: unknown): boolean {
 
 interface DesktopOnlyConfirmationProjection {
   remoteRequestId: string;
+  expiresAt: number;
 }
 
 // Device Link must not receive a host confirmation's real request id: it is the
 // capability checked by the trusted Desktop resolver. Keep the opaque id only
 // long enough to translate the paired dismissal event for remote read-only UI.
 const desktopOnlyConfirmationProjections = new Map<string, DesktopOnlyConfirmationProjection>();
+const MAX_DESKTOP_CONFIRMATION_PROJECTIONS = 128;
+
+function pruneDesktopOnlyConfirmationProjections(now = Date.now()): void {
+  for (const [requestId, projection] of desktopOnlyConfirmationProjections) {
+    if (projection.expiresAt <= now) desktopOnlyConfirmationProjections.delete(requestId);
+  }
+  while (desktopOnlyConfirmationProjections.size >= MAX_DESKTOP_CONFIRMATION_PROJECTIONS) {
+    const oldest = desktopOnlyConfirmationProjections.keys().next().value;
+    if (oldest === undefined) break;
+    desktopOnlyConfirmationProjections.delete(oldest);
+  }
+}
 
 function projectDesktopOnlyConfirmation(request: Record<string, unknown>): Record<string, unknown> | null {
   const requestId = request.requestId;
   if (typeof requestId !== 'string' || requestId.length === 0) return null;
+  pruneDesktopOnlyConfirmationProjections();
   let projection = desktopOnlyConfirmationProjections.get(requestId);
   if (!projection) {
-    projection = { remoteRequestId: `desktop-confirm-${randomUUID()}` };
+    projection = { remoteRequestId: `desktop-confirm-${randomUUID()}`, expiresAt: Date.now() + HOST_CONFIRM_TIMEOUT_MS };
     desktopOnlyConfirmationProjections.set(requestId, projection);
   }
   // Preserve only the known kind so mobile can render its existing read-only
   // guidance. Drafts, file paths, previews, identities, and the real id stay
   // on the controlled Desktop.
   return { kind: request.kind, requestId: projection.remoteRequestId };
+}
+
+/** Register before broadcast so a later Device Link activation cannot leak the source id on dismissal. */
+export function rememberDesktopOnlyConfirmation(requestId: string): void {
+  pruneDesktopOnlyConfirmationProjections();
+  if (!desktopOnlyConfirmationProjections.has(requestId)) {
+    desktopOnlyConfirmationProjections.set(requestId, {
+      remoteRequestId: `desktop-confirm-${randomUUID()}`,
+      expiresAt: Date.now() + HOST_CONFIRM_TIMEOUT_MS,
+    });
+  }
 }
 
 /**
@@ -405,11 +431,15 @@ export function projectInteractionRequestForRemote<T>(request: T): T | null {
 }
 
 /** Rewrites the paired dismissal to the opaque id exposed by the request projection. */
-export function projectInteractionDismissedForRemote<T>(payload: T): T {
+export function projectInteractionDismissedForRemote<T>(payload: T): T | null {
   if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return payload;
   const requestId = (payload as { requestId?: unknown }).requestId;
   if (typeof requestId !== 'string') return payload;
   const projection = desktopOnlyConfirmationProjections.get(requestId);
+  if (projection && projection.expiresAt <= Date.now()) {
+    desktopOnlyConfirmationProjections.delete(requestId);
+    return null;
+  }
   if (!projection) return payload;
   desktopOnlyConfirmationProjections.delete(requestId);
   return { ...(payload as Record<string, unknown>), requestId: projection.remoteRequestId } as T;

--- a/apps/desktop/src/main/cindy-brain/ghostSetupInteractionBridge.ts
+++ b/apps/desktop/src/main/cindy-brain/ghostSetupInteractionBridge.ts
@@ -14,7 +14,10 @@ import type {
 import { randomUUID } from 'node:crypto';
 import { GHOST_SECRET_VALUE_MAX_CHARS, isGhostSetupErrorCode } from '../../shared/ghost.js';
 import { MAKER_PUSH } from '../maker-ipc/channels.js';
-import { HOST_CONFIRM_TIMEOUT_MS } from '../maker-ipc/hostConfirmTiming.js';
+import {
+  isDesktopOnlyConfirmationRequestId,
+  projectDesktopOnlyConfirmationRequestId,
+} from './desktopOnlyConfirmationProjection.js';
 
 export interface GhostSetupInteractionStep {
   id: string;
@@ -369,52 +372,17 @@ function isDesktopOnlyConfirmationRequest(request: unknown): boolean {
   );
 }
 
-interface DesktopOnlyConfirmationProjection {
-  remoteRequestId: string;
-  expiresAt: number;
-}
-
 // Device Link must not receive a host confirmation's real request id: it is the
-// capability checked by the trusted Desktop resolver. Keep the opaque id only
-// long enough to translate the paired dismissal event for remote read-only UI.
-const desktopOnlyConfirmationProjections = new Map<string, DesktopOnlyConfirmationProjection>();
-const MAX_DESKTOP_CONFIRMATION_PROJECTIONS = 128;
-
-function pruneDesktopOnlyConfirmationProjections(now = Date.now()): void {
-  for (const [requestId, projection] of desktopOnlyConfirmationProjections) {
-    if (projection.expiresAt <= now) desktopOnlyConfirmationProjections.delete(requestId);
-  }
-  while (desktopOnlyConfirmationProjections.size >= MAX_DESKTOP_CONFIRMATION_PROJECTIONS) {
-    const oldest = desktopOnlyConfirmationProjections.keys().next().value;
-    if (oldest === undefined) break;
-    desktopOnlyConfirmationProjections.delete(oldest);
-  }
-}
+// capability checked by the trusted Desktop resolver. A process-keyed HMAC
+// keeps request/dismissal correlation stable without retaining source ids.
 
 function projectDesktopOnlyConfirmation(request: Record<string, unknown>): Record<string, unknown> | null {
   const requestId = request.requestId;
   if (typeof requestId !== 'string' || requestId.length === 0) return null;
-  pruneDesktopOnlyConfirmationProjections();
-  let projection = desktopOnlyConfirmationProjections.get(requestId);
-  if (!projection) {
-    projection = { remoteRequestId: `desktop-confirm-${randomUUID()}`, expiresAt: Date.now() + HOST_CONFIRM_TIMEOUT_MS };
-    desktopOnlyConfirmationProjections.set(requestId, projection);
-  }
   // Preserve only the known kind so mobile can render its existing read-only
   // guidance. Drafts, file paths, previews, identities, and the real id stay
   // on the controlled Desktop.
-  return { kind: request.kind, requestId: projection.remoteRequestId };
-}
-
-/** Register before broadcast so a later Device Link activation cannot leak the source id on dismissal. */
-export function rememberDesktopOnlyConfirmation(requestId: string): void {
-  pruneDesktopOnlyConfirmationProjections();
-  if (!desktopOnlyConfirmationProjections.has(requestId)) {
-    desktopOnlyConfirmationProjections.set(requestId, {
-      remoteRequestId: `desktop-confirm-${randomUUID()}`,
-      expiresAt: Date.now() + HOST_CONFIRM_TIMEOUT_MS,
-    });
-  }
+  return { kind: request.kind, requestId: projectDesktopOnlyConfirmationRequestId(requestId) };
 }
 
 /**
@@ -430,19 +398,16 @@ export function projectInteractionRequestForRemote<T>(request: T): T | null {
   return sanitizeGhostSetupRequestForRemote(request);
 }
 
-/** Rewrites the paired dismissal to the opaque id exposed by the request projection. */
-export function projectInteractionDismissedForRemote<T>(payload: T): T | null {
+/** Rewrites a Host-only dismissal to the same opaque id exposed by its request projection. */
+export function projectInteractionDismissedForRemote<T>(payload: T): T {
   if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return payload;
   const requestId = (payload as { requestId?: unknown }).requestId;
   if (typeof requestId !== 'string') return payload;
-  const projection = desktopOnlyConfirmationProjections.get(requestId);
-  if (projection && projection.expiresAt <= Date.now()) {
-    desktopOnlyConfirmationProjections.delete(requestId);
-    return null;
-  }
-  if (!projection) return payload;
-  desktopOnlyConfirmationProjections.delete(requestId);
-  return { ...(payload as Record<string, unknown>), requestId: projection.remoteRequestId } as T;
+  if (!isDesktopOnlyConfirmationRequestId(requestId)) return payload;
+  return {
+    ...(payload as Record<string, unknown>),
+    requestId: projectDesktopOnlyConfirmationRequestId(requestId),
+  } as T;
 }
 
 export function projectPendingInteractionsForRemote<T extends { request: unknown }>(

--- a/apps/desktop/src/main/device-link/dispatch.ts
+++ b/apps/desktop/src/main/device-link/dispatch.ts
@@ -83,7 +83,10 @@ import * as subscriptions from './subscriptions';
 import { LEGACY_TOPIC, type ActiveController } from './subscriptions';
 import { MAKER_PUSH } from '../maker-ipc/channels.js';
 import { RECOVERY_CHECKPOINT_MARKER } from '../maker-ipc/recoveryCoordinator.js';
-import { projectInteractionRequestForRemote } from '../cindy-brain/ghostSetupInteractionBridge.js';
+import {
+  projectInteractionDismissedForRemote,
+  projectInteractionRequestForRemote,
+} from '../cindy-brain/ghostSetupInteractionBridge.js';
 import {
   remoteWorkingDirRejectionToIpcError,
   type RemoteWorkingDirCheckResult,
@@ -1277,6 +1280,9 @@ function forwardPush(channel: string, payload: unknown, ownerStamp?: PushOwnerSt
     );
     if (request === null) return;
     remotePayload = { ...payload, request };
+  }
+  if (channel === MAKER_PUSH.INTERACTION_DISMISSED) {
+    remotePayload = projectInteractionDismissedForRemote(remotePayload);
   }
   const dsts = subscriptions.getControllersForTopic(topic);
   // The active registry describes peer topic intent, not whether this host can

--- a/apps/desktop/src/main/device-link/dispatch.ts
+++ b/apps/desktop/src/main/device-link/dispatch.ts
@@ -1282,9 +1282,7 @@ function forwardPush(channel: string, payload: unknown, ownerStamp?: PushOwnerSt
     remotePayload = { ...payload, request };
   }
   if (channel === MAKER_PUSH.INTERACTION_DISMISSED) {
-    const dismissed = projectInteractionDismissedForRemote(remotePayload);
-    if (dismissed === null) return;
-    remotePayload = dismissed;
+    remotePayload = projectInteractionDismissedForRemote(remotePayload);
   }
   const dsts = subscriptions.getControllersForTopic(topic);
   // The active registry describes peer topic intent, not whether this host can

--- a/apps/desktop/src/main/device-link/dispatch.ts
+++ b/apps/desktop/src/main/device-link/dispatch.ts
@@ -1282,7 +1282,9 @@ function forwardPush(channel: string, payload: unknown, ownerStamp?: PushOwnerSt
     remotePayload = { ...payload, request };
   }
   if (channel === MAKER_PUSH.INTERACTION_DISMISSED) {
-    remotePayload = projectInteractionDismissedForRemote(remotePayload);
+    const dismissed = projectInteractionDismissedForRemote(remotePayload);
+    if (dismissed === null) return;
+    remotePayload = dismissed;
   }
   const dsts = subscriptions.getControllersForTopic(topic);
   // The active registry describes peer topic intent, not whether this host can

--- a/apps/desktop/src/main/github-issue/__tests__/issueConfirmBridge.test.ts
+++ b/apps/desktop/src/main/github-issue/__tests__/issueConfirmBridge.test.ts
@@ -57,7 +57,9 @@ describe('IssueConfirmBridge', () => {
         githubUserIdentity: GITHUB_IDENTITY,
       },
     });
-    expect((payload as { request: { requestId: string } }).request.requestId).toBeTruthy();
+    expect((payload as { request: { requestId: string } }).request.requestId).toMatch(
+      /^desktop-confirm-source-/,
+    );
     expect(bridge.pendingSnapshots('other-session')).toEqual([]);
     expect(bridge.pendingSnapshots('sess-1')).toEqual([
       { sessionId: 'sess-1', request: (payload as { request: unknown }).request },

--- a/apps/desktop/src/main/github-issue/issueConfirmBridge.ts
+++ b/apps/desktop/src/main/github-issue/issueConfirmBridge.ts
@@ -17,12 +17,10 @@
  * 本模块保持 electron-free(broadcast 由调用方注入),单测直接 new。
  */
 
-import { randomUUID } from 'node:crypto';
-
 import type { CindyRegion } from '@cindy/maker-shared/brand-identity';
 
 import { normalizeIssuePublicName } from '../../shared/issuePublicName.js';
-import { rememberDesktopOnlyConfirmation } from '../cindy-brain/ghostSetupInteractionBridge.js';
+import { createDesktopOnlyConfirmationRequestId } from '../cindy-brain/desktopOnlyConfirmationProjection.js';
 import { MAKER_PUSH } from '../maker-ipc/channels';
 import { HOST_CONFIRM_TIMEOUT_MS } from '../maker-ipc/hostConfirmTiming.js';
 
@@ -121,7 +119,7 @@ export class IssueConfirmBridge {
     submissionChoices: IssueSubmissionChoices,
     suggestedPublicName?: string,
   ): Promise<IssueConfirmDecision> {
-    const requestId = randomUUID();
+    const requestId = createDesktopOnlyConfirmationRequestId();
     const request: IssueConfirmInteractionSnapshot = {
       kind: 'issue_confirm',
       requestId,
@@ -143,7 +141,6 @@ export class IssueConfirmBridge {
         resolve,
         timeoutId,
       });
-      rememberDesktopOnlyConfirmation(requestId);
       this.deps.broadcast(MAKER_PUSH.INTERACTION_REQUEST, {
         sessionId,
         request,

--- a/apps/desktop/src/main/github-issue/issueConfirmBridge.ts
+++ b/apps/desktop/src/main/github-issue/issueConfirmBridge.ts
@@ -22,6 +22,7 @@ import { randomUUID } from 'node:crypto';
 import type { CindyRegion } from '@cindy/maker-shared/brand-identity';
 
 import { normalizeIssuePublicName } from '../../shared/issuePublicName.js';
+import { rememberDesktopOnlyConfirmation } from '../cindy-brain/ghostSetupInteractionBridge.js';
 import { MAKER_PUSH } from '../maker-ipc/channels';
 import { HOST_CONFIRM_TIMEOUT_MS } from '../maker-ipc/hostConfirmTiming.js';
 
@@ -142,6 +143,7 @@ export class IssueConfirmBridge {
         resolve,
         timeoutId,
       });
+      rememberDesktopOnlyConfirmation(requestId);
       this.deps.broadcast(MAKER_PUSH.INTERACTION_REQUEST, {
         sessionId,
         request,

--- a/apps/desktop/src/main/session-title-rename/__tests__/renameSessionsConfirmBridge.test.ts
+++ b/apps/desktop/src/main/session-title-rename/__tests__/renameSessionsConfirmBridge.test.ts
@@ -45,7 +45,9 @@ describe('RenameSessionsConfirmBridge', () => {
       sessionId: 'sess-1',
       request: { kind: 'rename_sessions_confirm', changes: CHANGES },
     });
-    expect((payload as { request: { requestId: string } }).request.requestId).toBeTruthy();
+    expect((payload as { request: { requestId: string } }).request.requestId).toMatch(
+      /^desktop-confirm-source-/,
+    );
     expect(bridge.pendingSnapshots('other-session')).toEqual([]);
     expect(bridge.pendingSnapshots('sess-1')).toEqual([
       { sessionId: 'sess-1', request: (payload as { request: unknown }).request },

--- a/apps/desktop/src/main/session-title-rename/renameSessionsConfirmBridge.ts
+++ b/apps/desktop/src/main/session-title-rename/renameSessionsConfirmBridge.ts
@@ -9,6 +9,7 @@
 
 import { randomUUID } from 'node:crypto';
 
+import { rememberDesktopOnlyConfirmation } from '../cindy-brain/ghostSetupInteractionBridge.js';
 import { MAKER_PUSH } from '../maker-ipc/channels';
 import { HOST_CONFIRM_TIMEOUT_MS } from '../maker-ipc/hostConfirmTiming.js';
 
@@ -71,6 +72,7 @@ export class RenameSessionsConfirmBridge {
         this.settle(requestId, { confirmed: false, reason: 'timeout' }, 'timeout');
       }, timeoutMs);
       this.pending.set(requestId, { sessionId, request, resolve, timeoutId });
+      rememberDesktopOnlyConfirmation(requestId);
       this.deps.broadcast(MAKER_PUSH.INTERACTION_REQUEST, {
         sessionId,
         request,

--- a/apps/desktop/src/main/session-title-rename/renameSessionsConfirmBridge.ts
+++ b/apps/desktop/src/main/session-title-rename/renameSessionsConfirmBridge.ts
@@ -7,9 +7,7 @@
  * 在 confirmed 后继续。
  */
 
-import { randomUUID } from 'node:crypto';
-
-import { rememberDesktopOnlyConfirmation } from '../cindy-brain/ghostSetupInteractionBridge.js';
+import { createDesktopOnlyConfirmationRequestId } from '../cindy-brain/desktopOnlyConfirmationProjection.js';
 import { MAKER_PUSH } from '../maker-ipc/channels';
 import { HOST_CONFIRM_TIMEOUT_MS } from '../maker-ipc/hostConfirmTiming.js';
 
@@ -60,7 +58,7 @@ export class RenameSessionsConfirmBridge {
     sessionId: string,
     changes: RenameSessionsConfirmItem[],
   ): Promise<RenameSessionsConfirmDecision> {
-    const requestId = randomUUID();
+    const requestId = createDesktopOnlyConfirmationRequestId();
     const request: RenameSessionsConfirmInteractionSnapshot = {
       kind: 'rename_sessions_confirm',
       requestId,
@@ -72,7 +70,6 @@ export class RenameSessionsConfirmBridge {
         this.settle(requestId, { confirmed: false, reason: 'timeout' }, 'timeout');
       }, timeoutMs);
       this.pending.set(requestId, { sessionId, request, resolve, timeoutId });
-      rememberDesktopOnlyConfirmation(requestId);
       this.deps.broadcast(MAKER_PUSH.INTERACTION_REQUEST, {
         sessionId,
         request,

--- a/apps/desktop/src/renderer/__tests__/deviceLinkInteractionScenarios.test.ts
+++ b/apps/desktop/src/renderer/__tests__/deviceLinkInteractionScenarios.test.ts
@@ -367,17 +367,59 @@ describe('device-link Desktop-only 确认 — 控制端只读投影', () => {
     expect(makerChatStore.getSnapshot(s).pendingIssueConfirm).toBeNull();
   });
 
-  it('重连快照可重建只读状态，后续权威空快照将其收口', async () => {
+  it('并发确认按到达顺序排队，关闭任一项都不会丢失其余确认', async () => {
+    const s = openRemoteSession();
+    host.hostInteraction(s, { kind: 'issue_confirm', requestId: 'opaque-a' });
+    host.hostInteraction(s, { kind: 'ghost_grant_confirm', requestId: 'opaque-b' });
+    await flush();
+
+    expect(makerChatStore.getSnapshot(s).pendingRemoteDesktopConfirmation).toEqual({
+      kind: 'issue_confirm',
+      requestId: 'opaque-a',
+    });
+
+    host.hostDismiss(s, 'opaque-b', 'resolved');
+    await flush();
+    expect(makerChatStore.getSnapshot(s).pendingRemoteDesktopConfirmation?.requestId).toBe(
+      'opaque-a',
+    );
+
+    host.hostInteraction(s, { kind: 'ghost_grant_confirm', requestId: 'opaque-b' });
+    await flush();
+    host.hostDismiss(s, 'opaque-a', 'resolved');
+    await flush();
+    expect(makerChatStore.getSnapshot(s).pendingRemoteDesktopConfirmation).toEqual({
+      kind: 'ghost_grant_confirm',
+      requestId: 'opaque-b',
+    });
+  });
+
+  it('重连快照可重建多个只读状态，后续权威快照将其逐项收口', async () => {
     const s = openRemoteSession();
     host.seedPending(s, {
       kind: 'issue_confirm',
-      requestId: 'opaque-snapshot',
+      requestId: 'opaque-snapshot-a',
+    });
+    host.seedPending(s, {
+      kind: 'rename_sessions_confirm',
+      requestId: 'opaque-snapshot-b',
     });
 
     await makerChatStore.reconcilePendingInteractions(s);
     expect(makerChatStore.getSnapshot(s).pendingRemoteDesktopConfirmation).toEqual({
       kind: 'issue_confirm',
-      requestId: 'opaque-snapshot',
+      requestId: 'opaque-snapshot-a',
+    });
+
+    host.clearPending(s);
+    host.seedPending(s, {
+      kind: 'rename_sessions_confirm',
+      requestId: 'opaque-snapshot-b',
+    });
+    await makerChatStore.reconcilePendingInteractions(s);
+    expect(makerChatStore.getSnapshot(s).pendingRemoteDesktopConfirmation).toEqual({
+      kind: 'rename_sessions_confirm',
+      requestId: 'opaque-snapshot-b',
     });
 
     host.clearPending(s);

--- a/apps/desktop/src/renderer/__tests__/deviceLinkInteractionScenarios.test.ts
+++ b/apps/desktop/src/renderer/__tests__/deviceLinkInteractionScenarios.test.ts
@@ -105,6 +105,9 @@ function makeFakeHost(deviceId: string) {
       arr.push({ request, persistId });
       pending.set(sessionId, arr);
     },
+    clearPending(sessionId: string): void {
+      pending.delete(sessionId);
+    },
     registerPush(cb: (p: RemotePush) => void): () => void {
       pushCb = (push) => cb({ ...push, ownerStamp: push.ownerStamp ?? TEST_OWNER_STAMP });
       return () => {
@@ -319,71 +322,67 @@ describe('device-link 远程交互往返 — plan_review', () => {
   });
 });
 
-describe('device-link 远程交互往返 — issue_confirm draft', () => {
-  const issueRequest = {
-    kind: 'issue_confirm',
-    requestId: 'issue-draft-1',
-    draft: { title: '原始标题', body: '原始正文', type: 'bug' },
-    env: {
-      appVersion: '0.1.18',
-      platform: 'darwin',
-      arch: 'arm64',
-      osVersion: '15.0',
+describe('device-link Desktop-only 确认 — 控制端只读投影', () => {
+  it.each(['issue_confirm', 'rename_sessions_confirm', 'ghost_grant_confirm'] as const)(
+    '%s live push 只建立不可操作状态，dismissal 后清除',
+    async (kind) => {
+      const s = openRemoteSession();
+      const requestId = `opaque-${kind}`;
+
+      host.hostInteraction(s, {
+        kind,
+        requestId,
+      });
+      await flush();
+
+      const state = makerChatStore.getSnapshot(s);
+      expect(state.pendingRemoteDesktopConfirmation).toEqual({ kind, requestId });
+      expect(state.pendingIssueConfirm).toBeNull();
+      expect(state.pendingRenameSessionsConfirm).toBeNull();
+      expect(state.pendingGhostGrantConfirm).toBeNull();
+      expect(host.resolved).toHaveLength(0);
+      expect(local.localResolveInteraction).not.toHaveBeenCalled();
+
+      host.hostDismiss(s, requestId, 'resolved');
+      await flush();
+      expect(makerChatStore.getSnapshot(s).pendingRemoteDesktopConfirmation).toBeNull();
     },
-    submissionIdentity: { kind: 'platform', login: 'cindy-issue' },
-    suggestedPublicName: '当前昵称',
-  };
+  );
 
-  it('逐键保存不通知 makerChatStore 全局订阅,响应后清除草稿', async () => {
+  it('远程来源即使误带完整 payload 也不能获得可操作确认能力', async () => {
     const s = openRemoteSession();
-    host.hostInteraction(s, issueRequest);
+    host.hostInteraction(s, {
+      kind: 'issue_confirm',
+      requestId: 'opaque-full-payload',
+      draft: { title: '敏感标题', body: '敏感正文', type: 'bug' },
+      env: { appVersion: '1', platform: 'darwin', arch: 'arm64', osVersion: '1' },
+      submissionIdentity: { kind: 'platform', login: 'private' },
+    });
     await flush();
-    expect(makerChatStore.getSnapshot(s).pendingIssueConfirm?.requestId).toBe('issue-draft-1');
-    expect(makerChatStore.getSnapshot(s).pendingIssueConfirm).toMatchObject({
-      submissionIdentity: { kind: 'platform', login: 'cindy-issue' },
-      suggestedPublicName: '当前昵称',
-    });
 
-    const globalListener = vi.fn();
-    const unsubscribe = makerChatStore.subscribeAll(globalListener);
-    saveIssueConfirmDraft(s, 'issue-draft-1', {
-      title: '编辑后的标题',
-      body: '编辑后的正文',
-      type: 'feature',
-      publicName: '匿名',
+    expect(makerChatStore.getSnapshot(s).pendingRemoteDesktopConfirmation).toEqual({
+      kind: 'issue_confirm',
+      requestId: 'opaque-full-payload',
     });
-
-    expect(getIssueConfirmDraft(s, 'issue-draft-1')).toMatchObject({
-      title: '编辑后的标题',
-      body: '编辑后的正文',
-      type: 'feature',
-      publicName: '匿名',
-    });
-    expect(globalListener).not.toHaveBeenCalled();
-
-    makerChatStore.respondToIssueConfirm(s, { confirmed: false });
-    await flush();
-    expect(getIssueConfirmDraft(s, 'issue-draft-1')).toBeUndefined();
     expect(makerChatStore.getSnapshot(s).pendingIssueConfirm).toBeNull();
-    unsubscribe();
-    makerChatStore.purgeSession(s);
   });
 
-  it('interaction dismissed 时清除对应草稿', async () => {
+  it('重连快照可重建只读状态，后续权威空快照将其收口', async () => {
     const s = openRemoteSession();
-    host.hostInteraction(s, issueRequest);
-    await flush();
-    saveIssueConfirmDraft(s, 'issue-draft-1', {
-      title: '未提交标题',
-      body: '未提交正文',
-      type: 'bug',
+    host.seedPending(s, {
+      kind: 'issue_confirm',
+      requestId: 'opaque-snapshot',
     });
 
-    host.hostDismiss(s, 'issue-draft-1', 'timeout');
-    await flush();
-    expect(getIssueConfirmDraft(s, 'issue-draft-1')).toBeUndefined();
-    expect(makerChatStore.getSnapshot(s).pendingIssueConfirm).toBeNull();
-    makerChatStore.purgeSession(s);
+    await makerChatStore.reconcilePendingInteractions(s);
+    expect(makerChatStore.getSnapshot(s).pendingRemoteDesktopConfirmation).toEqual({
+      kind: 'issue_confirm',
+      requestId: 'opaque-snapshot',
+    });
+
+    host.clearPending(s);
+    await makerChatStore.reconcilePendingInteractions(s);
+    expect(makerChatStore.getSnapshot(s).pendingRemoteDesktopConfirmation).toBeNull();
   });
 });
 

--- a/apps/desktop/src/renderer/__tests__/deviceLinkInteractionScenarios.test.ts
+++ b/apps/desktop/src/renderer/__tests__/deviceLinkInteractionScenarios.test.ts
@@ -323,6 +323,20 @@ describe('device-link 远程交互往返 — plan_review', () => {
 });
 
 describe('device-link Desktop-only 确认 — 控制端只读投影', () => {
+  it('只读提示展示期间保留 ChatInput，不把控制端锁死', () => {
+    const src = readFileSync(
+      resolve(__dirname, '..', 'features', 'cc-agent', 'CCAgentSessionView.tsx'),
+      'utf8',
+    );
+    const branchStart = src.indexOf('/* 互斥:控制端能终结的 pending interaction');
+    const chatInput = src.indexOf('<ChatInput', branchStart);
+    expect(branchStart).toBeGreaterThan(-1);
+    expect(chatInput).toBeGreaterThan(branchStart);
+    expect(src.slice(branchStart, chatInput)).not.toContain(
+      'pendingRemoteDesktopConfirmation',
+    );
+  });
+
   it.each(['issue_confirm', 'rename_sessions_confirm', 'ghost_grant_confirm'] as const)(
     '%s live push 只建立不可操作状态，dismissal 后清除',
     async (kind) => {

--- a/apps/desktop/src/renderer/__tests__/makerQueueState.test.ts
+++ b/apps/desktop/src/renderer/__tests__/makerQueueState.test.ts
@@ -122,6 +122,8 @@ const state = (overrides: Partial<SessionChatState> = {}): SessionChatState => (
   lastAgentMeta: null,
   ...overrides,
   pendingRemoteDesktopConfirmation: overrides.pendingRemoteDesktopConfirmation ?? null,
+  pendingRemoteDesktopConfirmationQueue:
+    overrides.pendingRemoteDesktopConfirmationQueue ?? [],
 });
 
 describe('makerQueueState', () => {

--- a/apps/desktop/src/renderer/__tests__/makerQueueState.test.ts
+++ b/apps/desktop/src/renderer/__tests__/makerQueueState.test.ts
@@ -121,6 +121,7 @@ const state = (overrides: Partial<SessionChatState> = {}): SessionChatState => (
   turnStoppedByUser: false,
   lastAgentMeta: null,
   ...overrides,
+  pendingRemoteDesktopConfirmation: overrides.pendingRemoteDesktopConfirmation ?? null,
 });
 
 describe('makerQueueState', () => {

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
@@ -4643,9 +4643,9 @@ export function CCAgentSessionView({
               </InteractionPromptHost>
               {/* 会话内 /goal 进行中状态条(composer 上方);无 goal 时返回 null 不占位。 */}
               <GoalIndicator sessionId={sessionId} />
-              {/* 互斥:有任意 pending interaction 时,下方 takeover/overlay/ChatInput
-                 全部静默 — 跟改造前 ternary 链 (Plan ? : Perm ? : Ask ? :
-                 Takeover ? : ChatInput) 的语义一致。
+              {/* 互斥:控制端能终结的 pending interaction 会接管 composer；
+                 Desktop-only 只读确认只能提示等待，必须保留 ChatInput，避免控制端
+                 既处理不了确认又无法继续发送或排队消息。
                  优先级 (高 → 低):
                    1. attached (远程接管中)  → TakeoverMask  (90px)
                    2. worktreePreparing      → WorktreeCreatingOverlay (90px, 视觉同款)
@@ -4659,8 +4659,7 @@ export function CCAgentSessionView({
               pendingPluginSetup ||
               pendingIssueConfirm ||
               pendingRenameSessionsConfirm ||
-              pendingGhostGrantConfirm ||
-              pendingRemoteDesktopConfirmation ? null : sessionBinding.attached && sessionId ? (
+              pendingGhostGrantConfirm ? null : sessionBinding.attached && sessionId ? (
                 <TakeoverMask
                   sessionId={sessionId}
                   channel={sessionBinding.identity?.channel ?? 'feishu'}

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
@@ -66,6 +66,7 @@ import { PermissionPrompt } from '@/components/new-chat/PermissionPrompt';
 import { IssueConfirmCard } from './IssueConfirmCard';
 import { RenameSessionsConfirmCard } from './RenameSessionsConfirmCard';
 import { GhostGrantConfirmCard } from './GhostGrantConfirmCard';
+import { RemoteDesktopConfirmationNotice } from './RemoteDesktopConfirmationNotice';
 import { AskUserQuestionPrompt } from '@/components/new-chat/AskUserQuestionPrompt';
 import { PluginSetupPrompt } from '@/components/new-chat/PluginSetupPrompt';
 import { PlanViewerCard } from '@/components/new-chat/PlanViewerCard';
@@ -1560,6 +1561,7 @@ export function CCAgentSessionView({
     pendingRenameSessionsConfirm,
     respondToRenameSessionsConfirm,
     pendingGhostGrantConfirm,
+    pendingRemoteDesktopConfirmation,
     respondToGhostGrantConfirm,
     lastExpandedPlanViewerState,
     updatePlanContent,
@@ -4015,7 +4017,8 @@ export function CCAgentSessionView({
       pendingPluginSetup ||
       pendingIssueConfirm ||
       pendingRenameSessionsConfirm ||
-      pendingGhostGrantConfirm,
+      pendingGhostGrantConfirm ||
+      pendingRemoteDesktopConfirmation,
     );
   useEffect(() => {
     if (shareSelectionActive && shareSelectionBlocked) shareSelectionStore.exit();
@@ -4374,7 +4377,8 @@ export function CCAgentSessionView({
                       pendingPluginSetup ||
                       pendingIssueConfirm ||
                       pendingRenameSessionsConfirm ||
-                      pendingGhostGrantConfirm
+                      pendingGhostGrantConfirm ||
+                      pendingRemoteDesktopConfirmation
                     )
                   }
                   className="mb-0"
@@ -4563,7 +4567,8 @@ export function CCAgentSessionView({
                     pendingPluginSetup ||
                     pendingIssueConfirm ||
                     pendingRenameSessionsConfirm ||
-                    pendingGhostGrantConfirm
+                    pendingGhostGrantConfirm ||
+                    pendingRemoteDesktopConfirmation
                   )
                 }
                 placeholder={
@@ -4630,6 +4635,10 @@ export function CCAgentSessionView({
                     pending={pendingGhostGrantConfirm}
                     onRespond={respondToGhostGrantConfirm}
                   />
+                ) : pendingRemoteDesktopConfirmation ? (
+                  <RemoteDesktopConfirmationNotice
+                    key={pendingRemoteDesktopConfirmation.requestId}
+                  />
                 ) : null}
               </InteractionPromptHost>
               {/* 会话内 /goal 进行中状态条(composer 上方);无 goal 时返回 null 不占位。 */}
@@ -4650,7 +4659,8 @@ export function CCAgentSessionView({
               pendingPluginSetup ||
               pendingIssueConfirm ||
               pendingRenameSessionsConfirm ||
-              pendingGhostGrantConfirm ? null : sessionBinding.attached && sessionId ? (
+              pendingGhostGrantConfirm ||
+              pendingRemoteDesktopConfirmation ? null : sessionBinding.attached && sessionId ? (
                 <TakeoverMask
                   sessionId={sessionId}
                   channel={sessionBinding.identity?.channel ?? 'feishu'}

--- a/apps/desktop/src/renderer/features/cc-agent/RemoteDesktopConfirmationNotice.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/RemoteDesktopConfirmationNotice.tsx
@@ -1,0 +1,29 @@
+import { MonitorSmartphone } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+/** Read-only projection for confirmations that can only be resolved on the Host Desktop. */
+export function RemoteDesktopConfirmationNotice() {
+  const { t } = useTranslation();
+
+  return (
+    <div
+      className="flex w-full max-w-[914px] items-start gap-3 rounded-[8px] border border-[var(--chat-input-border)] bg-[var(--chat-input-bg)] px-4 py-3"
+      data-testid="remote-desktop-confirmation-notice"
+      role="status"
+    >
+      <MonitorSmartphone
+        aria-hidden="true"
+        className="mt-0.5 shrink-0 text-[var(--status-bar-meta)]"
+        size={18}
+      />
+      <div className="min-w-0">
+        <p className="text-14 font-semibold leading-tight text-[var(--chat-input-text)]">
+          {t('ccAgent.remoteDesktopConfirmation.title')}
+        </p>
+        <p className="mt-1 text-12 leading-relaxed text-[var(--status-bar-meta)]">
+          {t('ccAgent.remoteDesktopConfirmation.description')}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/features/cc-agent/RemoteDesktopConfirmationNotice.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/RemoteDesktopConfirmationNotice.tsx
@@ -7,7 +7,7 @@ export function RemoteDesktopConfirmationNotice() {
 
   return (
     <div
-      className="flex w-full max-w-[914px] items-start gap-3 rounded-[8px] border border-[var(--chat-input-border)] bg-[var(--chat-input-bg)] px-4 py-3"
+      className="flex w-full max-w-[914px] items-start gap-3 rounded-[12px] border border-[var(--chat-input-border)] bg-[var(--chat-input-bg)] px-4 py-3"
       data-testid="remote-desktop-confirmation-notice"
       role="status"
     >

--- a/apps/desktop/src/renderer/features/cc-agent/__tests__/RemoteDesktopConfirmationNotice.test.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/__tests__/RemoteDesktopConfirmationNotice.test.tsx
@@ -15,10 +15,13 @@ describe('RemoteDesktopConfirmationNotice', () => {
   it('renders a read-only status without confirmation actions', () => {
     render(<RemoteDesktopConfirmationNotice />);
 
-    expect(screen.getByRole('status').textContent).toContain(
+    const status = screen.getByRole('status');
+
+    expect(status.className).toContain('rounded-[12px]');
+    expect(status.textContent).toContain(
       'ccAgent.remoteDesktopConfirmation.title',
     );
-    expect(screen.getByRole('status').textContent).toContain(
+    expect(status.textContent).toContain(
       'ccAgent.remoteDesktopConfirmation.description',
     );
     expect(screen.queryByRole('button')).toBeNull();

--- a/apps/desktop/src/renderer/features/cc-agent/__tests__/RemoteDesktopConfirmationNotice.test.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/__tests__/RemoteDesktopConfirmationNotice.test.tsx
@@ -1,0 +1,26 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { RemoteDesktopConfirmationNotice } from '../RemoteDesktopConfirmationNotice';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+afterEach(cleanup);
+
+describe('RemoteDesktopConfirmationNotice', () => {
+  it('renders a read-only status without confirmation actions', () => {
+    render(<RemoteDesktopConfirmationNotice />);
+
+    expect(screen.getByRole('status').textContent).toContain(
+      'ccAgent.remoteDesktopConfirmation.title',
+    );
+    expect(screen.getByRole('status').textContent).toContain(
+      'ccAgent.remoteDesktopConfirmation.description',
+    );
+    expect(screen.queryByRole('button')).toBeNull();
+  });
+});

--- a/apps/desktop/src/renderer/hooks/useCCAgentChat.ts
+++ b/apps/desktop/src/renderer/hooks/useCCAgentChat.ts
@@ -44,6 +44,7 @@ import {
   type PendingIssueConfirm,
   type PendingRenameSessionsConfirm,
   type PendingGhostGrantConfirm,
+  type PendingRemoteDesktopConfirmation,
   type PendingPlanReview,
   type PlanViewerState,
   type QueuedMessage,
@@ -255,6 +256,8 @@ interface UseCCAgentChatReturn {
   respondToRenameSessionsConfirm: (result: { confirmed: true } | { confirmed: false }) => void;
   /** ghost_grant_confirm: Currently pending ghost file-grant confirm card */
   pendingGhostGrantConfirm: PendingGhostGrantConfirm | null;
+  /** Device Link Desktop controller: read-only host confirmation status. */
+  pendingRemoteDesktopConfirmation: PendingRemoteDesktopConfirmation | null;
   /** ghost_grant_confirm: Respond to the pending ghost file-grant confirm card */
   respondToGhostGrantConfirm: (
     result: { confirmed: true; allowDirs?: boolean } | { confirmed: false },
@@ -885,6 +888,7 @@ export function useCCAgentChat(
     pendingRenameSessionsConfirm: lightState.pendingRenameSessionsConfirm,
     respondToRenameSessionsConfirm,
     pendingGhostGrantConfirm: lightState.pendingGhostGrantConfirm,
+    pendingRemoteDesktopConfirmation: lightState.pendingRemoteDesktopConfirmation,
     respondToGhostGrantConfirm,
     planViewerState: lightState.planViewerState,
     setPlanViewerState,

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -7807,6 +7807,10 @@
       "waitForReply": "Waiting for your reply in the document area…",
       "modelSwitchedFastModeOff": "Model switched, Fast Mode disabled"
     },
+    "remoteDesktopConfirmation": {
+      "title": "Confirmation required on the controlled computer",
+      "description": "Open Cindy on the controlled computer to review and respond."
+    },
     "handoff": {
       "card": {
         "lastActive": {

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -7795,6 +7795,10 @@
       "waitForReply": "ドキュメント領域での返信を待っています…",
       "modelSwitchedFastModeOff": "モデルを切り替えました。Fast Mode は無効になりました"
     },
+    "remoteDesktopConfirmation": {
+      "title": "制御対象のコンピューターで確認が必要です",
+      "description": "制御対象のコンピューターで Cindy を開き、内容を確認して応答してください。"
+    },
     "handoff": {
       "card": {
         "lastActive": {

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -7795,6 +7795,10 @@
       "waitForReply": "문서 영역에서 회신을 기다리는 중…",
       "modelSwitchedFastModeOff": "모델이 전환되었으며 Fast Mode가 비활성화되었습니다"
     },
+    "remoteDesktopConfirmation": {
+      "title": "제어 대상 컴퓨터에서 확인이 필요합니다",
+      "description": "제어 대상 컴퓨터에서 Cindy를 열어 내용을 검토하고 응답하세요."
+    },
     "handoff": {
       "card": {
         "lastActive": {

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -7795,6 +7795,10 @@
       "waitForReply": "等待你在文档区回复…",
       "modelSwitchedFastModeOff": "已切换模型，Fast Mode 已关闭"
     },
+    "remoteDesktopConfirmation": {
+      "title": "需要在被控电脑上确认",
+      "description": "请在被控电脑上打开 Cindy，查看并处理这项确认。"
+    },
     "handoff": {
       "card": {
         "lastActive": {

--- a/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
@@ -7795,6 +7795,10 @@
       "waitForReply": "等待你在文件區回覆…",
       "modelSwitchedFastModeOff": "已切換模型，Fast Mode 已關閉"
     },
+    "remoteDesktopConfirmation": {
+      "title": "需要在受控電腦上確認",
+      "description": "請在受控電腦上開啟 Cindy，查看並處理這項確認。"
+    },
     "handoff": {
       "card": {
         "lastActive": {

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -830,6 +830,17 @@ export interface PendingRenameSessionsConfirm {
   }>;
 }
 
+/**
+ * Device Link 控制端对 Desktop-only 确认的只读投影。
+ *
+ * 真实 requestId 与确认内容只留在被控 Desktop；控制端只持有不可用于 resolve 的
+ * opaque id，以便显示等待状态并和 INTERACTION_DISMISSED 收敛。
+ */
+export interface PendingRemoteDesktopConfirmation {
+  requestId: string;
+  kind: 'issue_confirm' | 'rename_sessions_confirm' | 'ghost_grant_confirm';
+}
+
 /** FP-3: Plan Viewer Card display state. */
 export type PlanViewerState = 'expanded' | 'half' | 'minimized' | 'edit';
 
@@ -2462,6 +2473,8 @@ export interface SessionChatState {
   pendingRenameSessionsConfirm: PendingRenameSessionsConfirm | null;
   /** ghost_grant_confirm: ghost_call 过户 workdir 外文件的确认卡片; null when none. */
   pendingGhostGrantConfirm: PendingGhostGrantConfirm | null;
+  /** Device Link 控制端上的 Desktop-only 只读确认提示; null when none. */
+  pendingRemoteDesktopConfirmation: PendingRemoteDesktopConfirmation | null;
   /** FP-3: Plan Viewer Card display state (only meaningful when pendingPlanReview != null). */
   planViewerState: PlanViewerState;
   /** FP-3: Last non-minimized state — used to restore from minimized via the "+" button. */
@@ -2663,6 +2676,7 @@ export type SessionChatLightState = Pick<
   | 'pendingIssueConfirm'
   | 'pendingRenameSessionsConfirm'
   | 'pendingGhostGrantConfirm'
+  | 'pendingRemoteDesktopConfirmation'
   | 'planViewerState'
   | 'lastExpandedPlanViewerState'
   | 'pendingQueue'
@@ -2724,6 +2738,7 @@ function createInitialState(): SessionChatState {
     pendingIssueConfirm: null,
     pendingRenameSessionsConfirm: null,
     pendingGhostGrantConfirm: null,
+    pendingRemoteDesktopConfirmation: null,
     planViewerState: 'expanded',
     lastExpandedPlanViewerState: 'expanded',
     oldestMessageId: null,
@@ -2800,6 +2815,7 @@ export const EMPTY_SESSION_STATE: SessionChatState = Object.freeze({
   pendingIssueConfirm: null,
   pendingRenameSessionsConfirm: null,
   pendingGhostGrantConfirm: null,
+  pendingRemoteDesktopConfirmation: null,
   planViewerState: 'expanded',
   lastExpandedPlanViewerState: 'expanded',
   pendingQueue: [],
@@ -3399,7 +3415,8 @@ function _isSessionBusy(sessionId: string, s: SessionChatState): boolean {
     s.pendingPlanReview ||
     s.pendingIssueConfirm ||
     s.pendingRenameSessionsConfirm ||
-    s.pendingGhostGrantConfirm
+    s.pendingGhostGrantConfirm ||
+    s.pendingRemoteDesktopConfirmation
   );
 }
 
@@ -5288,6 +5305,7 @@ export function handleStreamEvent(
         pendingIssueConfirm: null,
         pendingRenameSessionsConfirm: null,
         pendingGhostGrantConfirm: null,
+        pendingRemoteDesktopConfirmation: null,
         // agent-meta: turn 结束清空，下一 turn 重新累积。
         lastAgentMeta: null,
         queueAbortPending: false,
@@ -5495,6 +5513,7 @@ export function handleStreamEvent(
         pendingIssueConfirm: null,
         pendingRenameSessionsConfirm: null,
         pendingGhostGrantConfirm: null,
+        pendingRemoteDesktopConfirmation: null,
         // agent-meta: turn 异常结束也清空。
         lastAgentMeta: null,
         // 出错也是 turn 终结：清掉 isRunning，否则 RunningStatusBar 会一直停在
@@ -5581,6 +5600,9 @@ export function handleStreamEvent(
       if (state.pendingGhostGrantConfirm?.requestId === data.requestId) {
         // ghost 过户确认卡被 main 兜底关闭(超时/会话清理),ephemeral 无落库,直接清。
         return { ...state, pendingGhostGrantConfirm: null };
+      }
+      if (state.pendingRemoteDesktopConfirmation?.requestId === data.requestId) {
+        return { ...state, pendingRemoteDesktopConfirmation: null };
       }
       if (state.pendingAskUser?.requestId === data.requestId) {
         // resolved + answers → 翻成 answered 并填答案(与答题端 answerUserQuestion 同款 reply / answers,
@@ -5872,6 +5894,7 @@ function forceFinalizeOnSessionClosed(state: SessionChatState): SessionChatState
     !state.pendingIssueConfirm &&
     !state.pendingRenameSessionsConfirm &&
     !state.pendingGhostGrantConfirm &&
+    !state.pendingRemoteDesktopConfirmation &&
     !state.messages.some((m) => m.isStreaming) &&
     !state.queueAbortPending &&
     state.steeringQueueClientIds.length === 0 &&
@@ -5925,6 +5948,7 @@ function forceFinalizeOnSessionClosed(state: SessionChatState): SessionChatState
     pendingIssueConfirm: null,
     pendingRenameSessionsConfirm: null,
     pendingGhostGrantConfirm: null,
+    pendingRemoteDesktopConfirmation: null,
     queueAbortPending: false,
     steeringQueueClientIds: [],
     continuationTurnClientId: null,
@@ -7105,7 +7129,11 @@ function initGlobalListeners(options: GlobalListenerOptions = {}): void {
   );
 
   // ── Maker interaction request: permission/ask/plan 三合一,按 kind 分发 ──
-  const handleInteractionRequestRaw = (raw: unknown, ingress: LiveIngressContext = {}) => {
+  const handleInteractionRequestRaw = (
+    raw: unknown,
+    ingress: LiveIngressContext = {},
+    remoteSnapshotDeviceId?: string,
+  ) => {
     if (!isCurrentLiveIngress(ingress)) return;
     const payload = raw as {
       sessionId?: string;
@@ -7133,6 +7161,25 @@ function initGlobalListeners(options: GlobalListenerOptions = {}): void {
     // F1-a Phase 5: ask_user / plan_review 消息由 main 落库并下发 persistId,renderer
     // 用它当气泡 clientId(permission 无此字段)。
     const persistId = payload.persistId;
+
+    if (
+      (ingress.remoteDeviceId || remoteSnapshotDeviceId) &&
+      (kind === 'issue_confirm' ||
+        kind === 'rename_sessions_confirm' ||
+        kind === 'ghost_grant_confirm')
+    ) {
+      setState(sessionId, (s) => ({
+        ...s,
+        pendingIssueConfirm: null,
+        pendingRenameSessionsConfirm: null,
+        pendingGhostGrantConfirm: null,
+        pendingRemoteDesktopConfirmation: {
+          kind,
+          requestId: request.requestId,
+        },
+      }));
+      return;
+    }
 
     if (request.kind === 'permission') {
       const metadata = request.metadata as Record<string, unknown> | undefined;
@@ -7253,6 +7300,7 @@ function initGlobalListeners(options: GlobalListenerOptions = {}): void {
           githubUserIdentity,
           suggestedPublicName,
         },
+        pendingRemoteDesktopConfirmation: null,
       }));
       return;
     }
@@ -7268,6 +7316,7 @@ function initGlobalListeners(options: GlobalListenerOptions = {}): void {
       setState(sessionId, (s) => ({
         ...s,
         pendingRenameSessionsConfirm: { requestId: request.requestId, changes },
+        pendingRemoteDesktopConfirmation: null,
       }));
       return;
     }
@@ -7276,7 +7325,11 @@ function initGlobalListeners(options: GlobalListenerOptions = {}): void {
       // ephemeral 卡片(同 permission 语义,无 persistId 不落库),直接写 state。
       const parsed = parseGhostGrantConfirmRequest(request);
       if (!parsed) return;
-      setState(sessionId, (s) => ({ ...s, pendingGhostGrantConfirm: parsed }));
+      setState(sessionId, (s) => ({
+        ...s,
+        pendingGhostGrantConfirm: parsed,
+        pendingRemoteDesktopConfirmation: null,
+      }));
       return;
     }
   };
@@ -7308,7 +7361,8 @@ function initGlobalListeners(options: GlobalListenerOptions = {}): void {
   );
   // 模块级桥接:供 reconcilePendingInteractions(打开/重连会话时的快照重建)复用同一套
   // 按 kind 分发逻辑。handler 只依赖模块级 setState/handleStreamEvent,无闭包局部状态,引用安全。
-  applyInteractionRequestRef = handleInteractionRequestRaw;
+  applyInteractionRequestRef = (raw, source) =>
+    handleInteractionRequestRaw(raw, {}, source?.remoteDeviceId);
 
   // ── Maker interaction dismissed: setPermissionMode 切换 / close 时关掉对话框 ──
   const handleInteractionDismissedRaw = (raw: unknown, ingress: LiveIngressContext = {}) => {
@@ -8309,6 +8363,7 @@ function selectLightState(state: SessionChatState): SessionChatLightState {
     pendingIssueConfirm: state.pendingIssueConfirm,
     pendingRenameSessionsConfirm: state.pendingRenameSessionsConfirm,
     pendingGhostGrantConfirm: state.pendingGhostGrantConfirm,
+    pendingRemoteDesktopConfirmation: state.pendingRemoteDesktopConfirmation,
     planViewerState: state.planViewerState,
     lastExpandedPlanViewerState: state.lastExpandedPlanViewerState,
     pendingQueue: state.pendingQueue,
@@ -8353,6 +8408,7 @@ function lightStateEquals(a: SessionChatLightState, b: SessionChatLightState): b
     a.pendingIssueConfirm === b.pendingIssueConfirm &&
     a.pendingRenameSessionsConfirm === b.pendingRenameSessionsConfirm &&
     a.pendingGhostGrantConfirm === b.pendingGhostGrantConfirm &&
+    a.pendingRemoteDesktopConfirmation === b.pendingRemoteDesktopConfirmation &&
     a.planViewerState === b.planViewerState &&
     a.lastExpandedPlanViewerState === b.lastExpandedPlanViewerState &&
     a.pendingQueue === b.pendingQueue &&
@@ -8726,7 +8782,8 @@ function setTitleUpdateCallback(sessionId: string, cb: (() => void) | undefined)
  * initGlobalListeners 注入的「interaction-request 分发」引用,供 reconcilePendingInteractions
  * 复用(打开/重连会话时把当前挂起交互重建成可操作面板)。handler 无闭包局部依赖。
  */
-let applyInteractionRequestRef: ((raw: unknown) => void) | null = null;
+let applyInteractionRequestRef:
+  ((raw: unknown, source?: { remoteDeviceId?: string }) => void) | null = null;
 
 /**
  * 快照重建:拉取某会话当前挂起的交互(permission/ask/plan)并重建可操作面板。
@@ -8787,6 +8844,7 @@ function reconcilePendingInteractions(
       // a Device Link reconnect cannot leave cards that the Host already closed.
       // Other interaction kinds keep their existing replay semantics.
       const authoritativePluginSetupIds = new Set<string>();
+      const authoritativeRemoteDesktopConfirmationIds = new Set<string>();
       for (const item of list) {
         const request = item?.request;
         if (
@@ -8795,6 +8853,15 @@ function reconcilePendingInteractions(
           request.requestId.length > 0
         ) {
           authoritativePluginSetupIds.add(request.requestId);
+        }
+        if (
+          (request?.kind === 'issue_confirm' ||
+            request?.kind === 'rename_sessions_confirm' ||
+            request?.kind === 'ghost_grant_confirm') &&
+          typeof request.requestId === 'string' &&
+          request.requestId.length > 0
+        ) {
+          authoritativeRemoteDesktopConfirmationIds.add(request.requestId);
         }
       }
       if (!isCurrentInteractionReconcile()) return 0;
@@ -8819,8 +8886,22 @@ function reconcilePendingInteractions(
           authoritativePluginSetupIds.has(state.pluginSetupCommandInFlight.requestId)
             ? state.pluginSetupCommandInFlight
             : null;
+        const nextRemoteDesktopConfirmation =
+          stickyDeviceAtStart || interactionOriginAtStart
+            ? state.pendingRemoteDesktopConfirmation &&
+              authoritativeRemoteDesktopConfirmationIds.has(
+                state.pendingRemoteDesktopConfirmation.requestId,
+              )
+              ? state.pendingRemoteDesktopConfirmation
+              : null
+            : state.pendingRemoteDesktopConfirmation;
 
-        if (!currentChanged && !queueChanged && nextCommand === state.pluginSetupCommandInFlight) {
+        if (
+          !currentChanged &&
+          !queueChanged &&
+          nextCommand === state.pluginSetupCommandInFlight &&
+          nextRemoteDesktopConfirmation === state.pendingRemoteDesktopConfirmation
+        ) {
           return state;
         }
         return {
@@ -8829,15 +8910,21 @@ function reconcilePendingInteractions(
           pendingPluginSetupQueue: survivingQueue,
           pluginSetupViewerState: currentChanged ? 'expanded' : state.pluginSetupViewerState,
           pluginSetupCommandInFlight: nextCommand,
+          pendingRemoteDesktopConfirmation: nextRemoteDesktopConfirmation,
         };
       });
       for (const item of list) {
         if (!isCurrentInteractionReconcile()) return 0;
-        applyInteractionRequestRef?.({
-          sessionId,
-          request: item.request,
-          persistId: item.persistId,
-        });
+        applyInteractionRequestRef?.(
+          {
+            sessionId,
+            request: item.request,
+            persistId: item.persistId,
+          },
+          {
+            remoteDeviceId: stickyDeviceAtStart ?? interactionOriginAtStart ?? undefined,
+          },
+        );
       }
       return list.length;
     });
@@ -13400,6 +13487,7 @@ async function clearSessionAfterGuardImpl(sessionId: string, clearedAt: string):
       askUserDraft: null,
       pendingPlanReview: null,
       pendingIssueConfirm: null,
+      pendingRemoteDesktopConfirmation: null,
       pendingQueue: s.pendingQueue.filter((item) =>
         postClearOptimisticClientIds.has(item.clientId),
       ),

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -2475,6 +2475,8 @@ export interface SessionChatState {
   pendingGhostGrantConfirm: PendingGhostGrantConfirm | null;
   /** Device Link 控制端上的 Desktop-only 只读确认提示; null when none. */
   pendingRemoteDesktopConfirmation: PendingRemoteDesktopConfirmation | null;
+  /** 同一会话内其余 Desktop-only 只读确认，按首次收到顺序等待展示。 */
+  pendingRemoteDesktopConfirmationQueue: PendingRemoteDesktopConfirmation[];
   /** FP-3: Plan Viewer Card display state (only meaningful when pendingPlanReview != null). */
   planViewerState: PlanViewerState;
   /** FP-3: Last non-minimized state — used to restore from minimized via the "+" button. */
@@ -2739,6 +2741,7 @@ function createInitialState(): SessionChatState {
     pendingRenameSessionsConfirm: null,
     pendingGhostGrantConfirm: null,
     pendingRemoteDesktopConfirmation: null,
+    pendingRemoteDesktopConfirmationQueue: [],
     planViewerState: 'expanded',
     lastExpandedPlanViewerState: 'expanded',
     oldestMessageId: null,
@@ -2816,6 +2819,7 @@ export const EMPTY_SESSION_STATE: SessionChatState = Object.freeze({
   pendingRenameSessionsConfirm: null,
   pendingGhostGrantConfirm: null,
   pendingRemoteDesktopConfirmation: null,
+  pendingRemoteDesktopConfirmationQueue: [],
   planViewerState: 'expanded',
   lastExpandedPlanViewerState: 'expanded',
   pendingQueue: [],
@@ -3416,7 +3420,8 @@ function _isSessionBusy(sessionId: string, s: SessionChatState): boolean {
     s.pendingIssueConfirm ||
     s.pendingRenameSessionsConfirm ||
     s.pendingGhostGrantConfirm ||
-    s.pendingRemoteDesktopConfirmation
+    s.pendingRemoteDesktopConfirmation ||
+    s.pendingRemoteDesktopConfirmationQueue.length > 0
   );
 }
 
@@ -5306,6 +5311,7 @@ export function handleStreamEvent(
         pendingRenameSessionsConfirm: null,
         pendingGhostGrantConfirm: null,
         pendingRemoteDesktopConfirmation: null,
+        pendingRemoteDesktopConfirmationQueue: [],
         // agent-meta: turn 结束清空，下一 turn 重新累积。
         lastAgentMeta: null,
         queueAbortPending: false,
@@ -5514,6 +5520,7 @@ export function handleStreamEvent(
         pendingRenameSessionsConfirm: null,
         pendingGhostGrantConfirm: null,
         pendingRemoteDesktopConfirmation: null,
+        pendingRemoteDesktopConfirmationQueue: [],
         // agent-meta: turn 异常结束也清空。
         lastAgentMeta: null,
         // 出错也是 turn 终结：清掉 isRunning，否则 RunningStatusBar 会一直停在
@@ -5602,7 +5609,25 @@ export function handleStreamEvent(
         return { ...state, pendingGhostGrantConfirm: null };
       }
       if (state.pendingRemoteDesktopConfirmation?.requestId === data.requestId) {
-        return { ...state, pendingRemoteDesktopConfirmation: null };
+        const [next = null, ...remaining] = state.pendingRemoteDesktopConfirmationQueue;
+        return {
+          ...state,
+          pendingRemoteDesktopConfirmation: next,
+          pendingRemoteDesktopConfirmationQueue: remaining,
+        };
+      }
+      if (
+        state.pendingRemoteDesktopConfirmationQueue.some(
+          (confirmation) => confirmation.requestId === data.requestId,
+        )
+      ) {
+        return {
+          ...state,
+          pendingRemoteDesktopConfirmationQueue:
+            state.pendingRemoteDesktopConfirmationQueue.filter(
+              (confirmation) => confirmation.requestId !== data.requestId,
+            ),
+        };
       }
       if (state.pendingAskUser?.requestId === data.requestId) {
         // resolved + answers → 翻成 answered 并填答案(与答题端 answerUserQuestion 同款 reply / answers,
@@ -5895,6 +5920,7 @@ function forceFinalizeOnSessionClosed(state: SessionChatState): SessionChatState
     !state.pendingRenameSessionsConfirm &&
     !state.pendingGhostGrantConfirm &&
     !state.pendingRemoteDesktopConfirmation &&
+    state.pendingRemoteDesktopConfirmationQueue.length === 0 &&
     !state.messages.some((m) => m.isStreaming) &&
     !state.queueAbortPending &&
     state.steeringQueueClientIds.length === 0 &&
@@ -5949,6 +5975,7 @@ function forceFinalizeOnSessionClosed(state: SessionChatState): SessionChatState
     pendingRenameSessionsConfirm: null,
     pendingGhostGrantConfirm: null,
     pendingRemoteDesktopConfirmation: null,
+    pendingRemoteDesktopConfirmationQueue: [],
     queueAbortPending: false,
     steeringQueueClientIds: [],
     continuationTurnClientId: null,
@@ -7168,16 +7195,40 @@ function initGlobalListeners(options: GlobalListenerOptions = {}): void {
         kind === 'rename_sessions_confirm' ||
         kind === 'ghost_grant_confirm')
     ) {
-      setState(sessionId, (s) => ({
-        ...s,
-        pendingIssueConfirm: null,
-        pendingRenameSessionsConfirm: null,
-        pendingGhostGrantConfirm: null,
-        pendingRemoteDesktopConfirmation: {
+      setState(sessionId, (s) => {
+        const confirmation: PendingRemoteDesktopConfirmation = {
           kind,
           requestId: request.requestId,
-        },
-      }));
+        };
+        const current = s.pendingRemoteDesktopConfirmation;
+        if (!current) {
+          return {
+            ...s,
+            pendingIssueConfirm: null,
+            pendingRenameSessionsConfirm: null,
+            pendingGhostGrantConfirm: null,
+            pendingRemoteDesktopConfirmation: confirmation,
+          };
+        }
+        if (current.requestId === confirmation.requestId) {
+          return { ...s, pendingRemoteDesktopConfirmation: confirmation };
+        }
+        const queuedIndex = s.pendingRemoteDesktopConfirmationQueue.findIndex(
+          (queued) => queued.requestId === confirmation.requestId,
+        );
+        if (queuedIndex >= 0) {
+          const nextQueue = s.pendingRemoteDesktopConfirmationQueue.slice();
+          nextQueue[queuedIndex] = confirmation;
+          return { ...s, pendingRemoteDesktopConfirmationQueue: nextQueue };
+        }
+        return {
+          ...s,
+          pendingRemoteDesktopConfirmationQueue: [
+            ...s.pendingRemoteDesktopConfirmationQueue,
+            confirmation,
+          ],
+        };
+      });
       return;
     }
 
@@ -7301,6 +7352,7 @@ function initGlobalListeners(options: GlobalListenerOptions = {}): void {
           suggestedPublicName,
         },
         pendingRemoteDesktopConfirmation: null,
+        pendingRemoteDesktopConfirmationQueue: [],
       }));
       return;
     }
@@ -7317,6 +7369,7 @@ function initGlobalListeners(options: GlobalListenerOptions = {}): void {
         ...s,
         pendingRenameSessionsConfirm: { requestId: request.requestId, changes },
         pendingRemoteDesktopConfirmation: null,
+        pendingRemoteDesktopConfirmationQueue: [],
       }));
       return;
     }
@@ -7329,6 +7382,7 @@ function initGlobalListeners(options: GlobalListenerOptions = {}): void {
         ...s,
         pendingGhostGrantConfirm: parsed,
         pendingRemoteDesktopConfirmation: null,
+        pendingRemoteDesktopConfirmationQueue: [],
       }));
       return;
     }
@@ -8895,12 +8949,30 @@ function reconcilePendingInteractions(
               ? state.pendingRemoteDesktopConfirmation
               : null
             : state.pendingRemoteDesktopConfirmation;
+        const nextRemoteDesktopConfirmationQueue =
+          stickyDeviceAtStart || interactionOriginAtStart
+            ? state.pendingRemoteDesktopConfirmationQueue.filter((confirmation) =>
+                authoritativeRemoteDesktopConfirmationIds.has(confirmation.requestId),
+              )
+            : state.pendingRemoteDesktopConfirmationQueue;
+        const [promotedRemoteDesktopConfirmation = null, ...remainingRemoteConfirmations] =
+          nextRemoteDesktopConfirmation
+            ? [nextRemoteDesktopConfirmation, ...nextRemoteDesktopConfirmationQueue]
+            : nextRemoteDesktopConfirmationQueue;
+        const remoteQueueChanged =
+          remainingRemoteConfirmations.length !==
+            state.pendingRemoteDesktopConfirmationQueue.length ||
+          remainingRemoteConfirmations.some(
+            (confirmation, index) =>
+              confirmation !== state.pendingRemoteDesktopConfirmationQueue[index],
+          );
 
         if (
           !currentChanged &&
           !queueChanged &&
           nextCommand === state.pluginSetupCommandInFlight &&
-          nextRemoteDesktopConfirmation === state.pendingRemoteDesktopConfirmation
+          promotedRemoteDesktopConfirmation === state.pendingRemoteDesktopConfirmation &&
+          !remoteQueueChanged
         ) {
           return state;
         }
@@ -8910,7 +8982,8 @@ function reconcilePendingInteractions(
           pendingPluginSetupQueue: survivingQueue,
           pluginSetupViewerState: currentChanged ? 'expanded' : state.pluginSetupViewerState,
           pluginSetupCommandInFlight: nextCommand,
-          pendingRemoteDesktopConfirmation: nextRemoteDesktopConfirmation,
+          pendingRemoteDesktopConfirmation: promotedRemoteDesktopConfirmation,
+          pendingRemoteDesktopConfirmationQueue: remainingRemoteConfirmations,
         };
       });
       for (const item of list) {
@@ -13488,6 +13561,7 @@ async function clearSessionAfterGuardImpl(sessionId: string, clearedAt: string):
       pendingPlanReview: null,
       pendingIssueConfirm: null,
       pendingRemoteDesktopConfirmation: null,
+      pendingRemoteDesktopConfirmationQueue: [],
       pendingQueue: s.pendingQueue.filter((item) =>
         postClearOptimisticClientIds.has(item.clientId),
       ),

--- a/apps/mobile/src/__tests__/interactionModel.test.ts
+++ b/apps/mobile/src/__tests__/interactionModel.test.ts
@@ -242,14 +242,16 @@ describe('interactionModel', () => {
     expect(interactionPanelSource).not.toContain('optionCheckboxMark');
   });
 
-  it('keeps issue confirmation unsupported in the mobile adapter and panel', () => {
+  it('keeps every Host-owned confirmation read-only in the mobile adapter and panel', () => {
     const interactionPanelSource = readFileSync(resolve(process.cwd(), 'src/session/InteractionPanel.tsx'), 'utf8');
 
     expect('buildIssueConfirmReviewPresentation' in mobileInteractionModel).toBe(false);
     expect('buildIssueConfirmDecision' in mobileInteractionModel).toBe(false);
     expect('normalizeIssueConfirm' in mobileInteractionModel).toBe(false);
-    expect(interactionPanelSource).toContain("if (kind === 'issue_confirm')");
-    expect(interactionPanelSource).toContain("t('interaction.panel.issueConfirmUnsupported')");
+    expect(interactionPanelSource).toContain(
+      "kind === 'issue_confirm' || kind === 'rename_sessions_confirm' || kind === 'ghost_grant_confirm'",
+    );
+    expect(interactionPanelSource).toContain("t('interaction.panel.desktopConfirmUnsupported')");
     expect(interactionPanelSource).not.toContain('buildIssueConfirmReviewPresentation');
   });
 

--- a/apps/mobile/src/i18n/locales/en/interaction.json
+++ b/apps/mobile/src/i18n/locales/en/interaction.json
@@ -38,6 +38,7 @@
     "composerBlockedByPending": "Handle the pending request from your computer before typing again.",
     "missingRequestId": "This remote interaction has no requestId, so the decision can't be sent back.",
     "issueConfirmUnsupported": "Issue submission is confirmed only on your computer. Go back to the desktop app to confirm or cancel.",
+    "desktopConfirmUnsupported": "This confirmation is handled only on the controlled computer. Go back to the desktop app to continue.",
     "unsupportedType": "This remote interaction type isn't supported on mobile yet.",
     "unsupportedKind": "Unsupported",
     "desktopOnlyKind": "On Computer",

--- a/apps/mobile/src/i18n/locales/en/interaction.json
+++ b/apps/mobile/src/i18n/locales/en/interaction.json
@@ -37,7 +37,6 @@
     "queuePositionNth": "no. {{index}}",
     "composerBlockedByPending": "Handle the pending request from your computer before typing again.",
     "missingRequestId": "This remote interaction has no requestId, so the decision can't be sent back.",
-    "issueConfirmUnsupported": "Issue submission is confirmed only on your computer. Go back to the desktop app to confirm or cancel.",
     "desktopConfirmUnsupported": "This confirmation is handled only on the controlled computer. Go back to the desktop app to continue.",
     "unsupportedType": "This remote interaction type isn't supported on mobile yet.",
     "unsupportedKind": "Unsupported",
@@ -107,6 +106,14 @@
     "issue_confirm": {
       "title": "Issue Needs Confirmation",
       "label": "Issue"
+    },
+    "rename_sessions_confirm": {
+      "title": "Session Names Need Confirmation",
+      "label": "Rename"
+    },
+    "ghost_grant_confirm": {
+      "title": "File Access Needs Confirmation",
+      "label": "File Access"
     },
     "plugin_setup": {
       "title": "Plugin Setup Needed on Your Computer",

--- a/apps/mobile/src/i18n/locales/ja/interaction.json
+++ b/apps/mobile/src/i18n/locales/ja/interaction.json
@@ -37,7 +37,6 @@
     "queuePositionNth": "{{index}} 番目",
     "composerBlockedByPending": "パソコンからの保留中のリクエストを処理してから入力を続けてください。",
     "missingRequestId": "このリモート操作には requestId がないため、決定を返信できません。",
-    "issueConfirmUnsupported": "Issue の送信確認はパソコンでのみ行えます。デスクトップアプリに戻って確認またはキャンセルしてください。",
     "desktopConfirmUnsupported": "この確認は操作対象のパソコンでのみ処理できます。デスクトップアプリに戻って続けてください。",
     "unsupportedType": "このリモート操作タイプはモバイルではまだ対応していません。",
     "unsupportedKind": "未対応",
@@ -107,6 +106,14 @@
     "issue_confirm": {
       "title": "Issue の内容を確認してください",
       "label": "Issue"
+    },
+    "rename_sessions_confirm": {
+      "title": "セッション名の変更を確認してください",
+      "label": "名前変更"
+    },
+    "ghost_grant_confirm": {
+      "title": "ファイルアクセスを確認してください",
+      "label": "ファイルアクセス"
     },
     "plugin_setup": {
       "title": "パソコンでプラグインの設定が必要です",

--- a/apps/mobile/src/i18n/locales/ja/interaction.json
+++ b/apps/mobile/src/i18n/locales/ja/interaction.json
@@ -38,6 +38,7 @@
     "composerBlockedByPending": "パソコンからの保留中のリクエストを処理してから入力を続けてください。",
     "missingRequestId": "このリモート操作には requestId がないため、決定を返信できません。",
     "issueConfirmUnsupported": "Issue の送信確認はパソコンでのみ行えます。デスクトップアプリに戻って確認またはキャンセルしてください。",
+    "desktopConfirmUnsupported": "この確認は操作対象のパソコンでのみ処理できます。デスクトップアプリに戻って続けてください。",
     "unsupportedType": "このリモート操作タイプはモバイルではまだ対応していません。",
     "unsupportedKind": "未対応",
     "desktopOnlyKind": "パソコンで処理",

--- a/apps/mobile/src/i18n/locales/ko/interaction.json
+++ b/apps/mobile/src/i18n/locales/ko/interaction.json
@@ -38,6 +38,7 @@
     "composerBlockedByPending": "컴퓨터의 대기 중인 요청을 처리한 뒤 계속 입력할 수 있습니다.",
     "missingRequestId": "이 원격 상호작용에는 requestId가 없어 결정을 돌려보낼 수 없습니다.",
     "issueConfirmUnsupported": "Issue 제출 확인은 컴퓨터에서만 처리됩니다. 데스크톱 앱으로 돌아가 확인하거나 취소하세요.",
+    "desktopConfirmUnsupported": "이 확인은 제어 중인 컴퓨터에서만 처리할 수 있습니다. 데스크톱 앱으로 돌아가 계속하세요.",
     "unsupportedType": "이 원격 상호작용 유형은 모바일에서 아직 지원되지 않습니다.",
     "unsupportedKind": "미지원",
     "desktopOnlyKind": "컴퓨터에서 처리",

--- a/apps/mobile/src/i18n/locales/ko/interaction.json
+++ b/apps/mobile/src/i18n/locales/ko/interaction.json
@@ -37,7 +37,6 @@
     "queuePositionNth": "{{index}}번째",
     "composerBlockedByPending": "컴퓨터의 대기 중인 요청을 처리한 뒤 계속 입력할 수 있습니다.",
     "missingRequestId": "이 원격 상호작용에는 requestId가 없어 결정을 돌려보낼 수 없습니다.",
-    "issueConfirmUnsupported": "Issue 제출 확인은 컴퓨터에서만 처리됩니다. 데스크톱 앱으로 돌아가 확인하거나 취소하세요.",
     "desktopConfirmUnsupported": "이 확인은 제어 중인 컴퓨터에서만 처리할 수 있습니다. 데스크톱 앱으로 돌아가 계속하세요.",
     "unsupportedType": "이 원격 상호작용 유형은 모바일에서 아직 지원되지 않습니다.",
     "unsupportedKind": "미지원",
@@ -107,6 +106,14 @@
     "issue_confirm": {
       "title": "이슈 내용을 확인해 주세요",
       "label": "이슈"
+    },
+    "rename_sessions_confirm": {
+      "title": "세션 이름 변경을 확인해 주세요",
+      "label": "이름 변경"
+    },
+    "ghost_grant_confirm": {
+      "title": "파일 접근을 확인해 주세요",
+      "label": "파일 접근"
     },
     "plugin_setup": {
       "title": "컴퓨터에서 플러그인 설정이 필요합니다",

--- a/apps/mobile/src/i18n/locales/zh-CN/interaction.json
+++ b/apps/mobile/src/i18n/locales/zh-CN/interaction.json
@@ -38,6 +38,7 @@
     "composerBlockedByPending": "先处理电脑端的待处理请求后才能继续输入。",
     "missingRequestId": "这个远程交互缺少 requestId，无法回传决定。",
     "issueConfirmUnsupported": "Issue 提交确认只在电脑端处理。请回到桌面端确认或取消提交。",
+    "desktopConfirmUnsupported": "此确认只能在被控电脑处理。请回到桌面端继续。",
     "unsupportedType": "手机版暂不支持这个远程交互类型。",
     "unsupportedKind": "暂不支持",
     "desktopOnlyKind": "电脑端处理",

--- a/apps/mobile/src/i18n/locales/zh-CN/interaction.json
+++ b/apps/mobile/src/i18n/locales/zh-CN/interaction.json
@@ -37,7 +37,6 @@
     "queuePositionNth": "第 {{index}}",
     "composerBlockedByPending": "先处理电脑端的待处理请求后才能继续输入。",
     "missingRequestId": "这个远程交互缺少 requestId，无法回传决定。",
-    "issueConfirmUnsupported": "Issue 提交确认只在电脑端处理。请回到桌面端确认或取消提交。",
     "desktopConfirmUnsupported": "此确认只能在被控电脑处理。请回到桌面端继续。",
     "unsupportedType": "手机版暂不支持这个远程交互类型。",
     "unsupportedKind": "暂不支持",
@@ -107,6 +106,14 @@
     "issue_confirm": {
       "title": "需要确认 Issue 内容",
       "label": "Issue"
+    },
+    "rename_sessions_confirm": {
+      "title": "需要确认任务名称变更",
+      "label": "重命名"
+    },
+    "ghost_grant_confirm": {
+      "title": "需要确认文件访问权限",
+      "label": "文件访问"
     },
     "plugin_setup": {
       "title": "需要在电脑端配置插件",

--- a/apps/mobile/src/i18n/locales/zh-TW/interaction.json
+++ b/apps/mobile/src/i18n/locales/zh-TW/interaction.json
@@ -38,6 +38,7 @@
     "composerBlockedByPending": "先處理電腦端的待處理請求後才能繼續輸入。",
     "missingRequestId": "這個遠端互動缺少 requestId，無法回傳決定。",
     "issueConfirmUnsupported": "Issue 提交確認只在電腦端處理。請回到桌面端確認或取消提交。",
+    "desktopConfirmUnsupported": "此確認只能在被控電腦處理。請回到桌面端繼續。",
     "unsupportedType": "手機版暫不支援這個遠端互動型別。",
     "unsupportedKind": "暫不支援",
     "desktopOnlyKind": "電腦端處理",

--- a/apps/mobile/src/i18n/locales/zh-TW/interaction.json
+++ b/apps/mobile/src/i18n/locales/zh-TW/interaction.json
@@ -37,7 +37,6 @@
     "queuePositionNth": "第 {{index}}",
     "composerBlockedByPending": "先處理電腦端的待處理請求後才能繼續輸入。",
     "missingRequestId": "這個遠端互動缺少 requestId，無法回傳決定。",
-    "issueConfirmUnsupported": "Issue 提交確認只在電腦端處理。請回到桌面端確認或取消提交。",
     "desktopConfirmUnsupported": "此確認只能在被控電腦處理。請回到桌面端繼續。",
     "unsupportedType": "手機版暫不支援這個遠端互動型別。",
     "unsupportedKind": "暫不支援",
@@ -107,6 +106,14 @@
     "issue_confirm": {
       "title": "需要確認 Issue 內容",
       "label": "Issue"
+    },
+    "rename_sessions_confirm": {
+      "title": "需要確認任務名稱變更",
+      "label": "重新命名"
+    },
+    "ghost_grant_confirm": {
+      "title": "需要確認檔案存取權限",
+      "label": "檔案存取"
     },
     "plugin_setup": {
       "title": "需要在電腦端配置插件",

--- a/apps/mobile/src/session/InteractionPanel.tsx
+++ b/apps/mobile/src/session/InteractionPanel.tsx
@@ -93,6 +93,8 @@ const LOCALIZED_INTERACTION_KINDS = new Set([
   'ask_user_question',
   'plan_review',
   'issue_confirm',
+  'rename_sessions_confirm',
+  'ghost_grant_confirm',
   'plugin_setup',
 ]);
 
@@ -538,10 +540,10 @@ function InteractionItem({
       />
     );
   }
-  if (kind === 'issue_confirm') {
+  if (kind === 'issue_confirm' || kind === 'rename_sessions_confirm' || kind === 'ghost_grant_confirm') {
     return (
       <UnsupportedCard
-        message={t('interaction.panel.issueConfirmUnsupported')}
+        message={t('interaction.panel.desktopConfirmUnsupported')}
         request={item.request}
         touchLayout={touchLayout}
       />


### PR DESCRIPTION
## 这次改了什么

### 摘要

手机远程控制会话触发桌面专属确认时，之前被控端会完全过滤该交互，手机只看到工具持续执行。现在复用现有 interaction 推送传递只读状态，让手机显示既有的“请回到桌面端确认”提示；确认正文、路径、身份信息和真实 requestId 均不离开被控桌面。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：#2965
- 本 PR 包含：桌面专属确认的脱敏实时推送、重连快照投影，以及使用同一 opaque id 的关闭事件。
- 明确不包含：不开放手机端确认、编辑或提交 Issue；不修改 Desktop 端权限校验。
- 用户可见变化：手机端会明确提示确认应在被控电脑完成，不再只显示持续执行。
- 是否存在 breaking change：无。

### UI 变化

- 平台：Mobile，Light / Dark。
- 改动后效果：当远程会话等待 `issue_confirm`、`rename_sessions_confirm` 或 `ghost_grant_confirm` 时，手机端复用现有只读卡片，显示“此确认只能在被控电脑处理。请回到桌面端继续。”；不提供确认、拒绝或编辑按钮。
- 引用的设计规范：
  - `docs/design-rules/DESIGN.md` §Mobile：移动端布局遵循 Mobile 设计规范。
  - `apps/mobile/docs/mobile-design-guide.md` §1、§2、§5：复用现有卡片结构；颜色使用 Light/Dark semantic tokens；保持零阴影、12px container 圆角和既有间距阶梯。

#### 改动后界面效果

```html
<div style="width:360px;padding:16px;background:#f8f8f6;font-family:system-ui;color:#262626">
  <div style="padding:16px;border:1px solid #d7d7d4;border-radius:12px;background:#fff">
    <div style="font-size:12px;color:#737373;margin-bottom:8px">暂不支持</div>
    <div style="font-size:16px;line-height:22px;font-weight:500">
      此确认只能在被控电脑处理。请回到桌面端继续。
    </div>
  </div>
</div>
```

说明：这是只读提示卡，无移动端确认、拒绝或编辑入口。
### 多端适配

- Device Link：已适配。沿用已有 `maker:interaction-request` / `maker:interaction-dismissed` 白名单和 session topic，不新增 relay kind。
- 手机：已适配。复用已有 `issue_confirm` 的只读提示，不提供确认动作。
- SSH：不涉及：确认仍由被控 Desktop 持有，未读取或执行工作目录。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/cindy-brain/__tests__/ghostSetupInteractionBridge.test.ts src/main/__tests__/deviceLinkDispatch.test.ts
结果：122/122 通过

pnpm --filter desktop typecheck
结果：通过

pnpm --filter desktop lint
结果：通过

pnpm test:unit:related
结果：已执行；该命令因工作区依赖关系退回完整 unit，调用环境未返回最终汇总。

pnpm check:dco
结果：通过
```

### 手工验证

未执行：当前 worktree 未启动已登录的 Desktop 与手机设备链路。

### 未执行的验证

未执行真机 Device Link 回归；自动测试覆盖实时推送、重连快照和关闭事件的 opaque id 对账。

## 风险

### 风险分类

- [x] 协议兼容
- [x] 权限 / 安全 / 用户数据

### 影响与回滚

- 影响范围：仅订阅目标会话的远程控制端。新增内容是既有推送中保留原 kind、替换为随机 opaque requestId 的只读投影；旧控制端按原有 unknown/只读交互路径安全降级。
- 回滚 / 降级方式：回滚本提交即可恢复原先完全不投影的行为；不会改变 Desktop 端真实 requestId、确认 payload 或 resolver 权限。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] 未提交凭证、令牌或授权文件
- [x] 已确认测试结果或说明未执行原因