### PR TITLE
fix(desktop): 修复 Claude 官方订阅下 Fable 模型周限不显示 (#3244)

### DIFF
--- a/apps/desktop/src/main/usage/__tests__/claudeSubscriptionUsage.test.ts
+++ b/apps/desktop/src/main/usage/__tests__/claudeSubscriptionUsage.test.ts
@@ -89,6 +89,27 @@ describe('parseClaudeOAuthUsageResponse', () => {
     ]);
   });
 
+  it('parses legacy seven_day_fable top-level key into a Fable scoped window (#3244)', () => {
+    // 旧 schema 兜底原先只列了 Opus/Sonnet,漏了 Fable,导致走旧端点或降级
+    // 快照时 Fable 周限不显示(同环境 Opus/Sonnet 正常)。
+    const snapshot = parseClaudeOAuthUsageResponse({
+      five_hour: { utilization: 10, resets_at: '2026-04-11T07:00:00Z' },
+      seven_day: { utilization: 13, resets_at: '2026-04-14T07:00:00Z' },
+      seven_day_opus: { utilization: 5, resets_at: '2026-04-14T07:00:00Z' },
+      seven_day_sonnet: { utilization: 1, resets_at: '2026-04-14T07:00:00Z' },
+      seven_day_fable: { utilization: 87, resets_at: '2026-04-14T07:00:00Z' },
+    }, NOW);
+    expect(snapshot?.scoped).toEqual([
+      expect.objectContaining({ modelDisplayName: 'Opus', utilization: 5 }),
+      expect.objectContaining({ modelDisplayName: 'Sonnet', utilization: 1 }),
+      expect.objectContaining({ modelDisplayName: 'Fable', utilization: 87 }),
+    ]);
+    // 匹配器也能命中这个 legacy Fable 窗口
+    expect(
+      matchScopedWindowForModel(snapshot?.scoped, 'claude-fable-5')?.utilization,
+    ).toBe(87);
+  });
+
   it('parses enabled extra usage', () => {
     const snapshot = parseClaudeOAuthUsageResponse({
       five_hour: { utilization: 10 },
@@ -247,6 +268,20 @@ describe('claudeModelFamily / matchScopedWindowForModel', () => {
     expect(matchScopedWindowForModel(scoped, 'claude-opus-4-8')?.utilization).toBe(5);
     expect(matchScopedWindowForModel(scoped, 'claude-sonnet-4-6')).toBeNull();
     expect(matchScopedWindowForModel(undefined, 'claude-fable-5')).toBeNull();
+  });
+
+  it('matches Fable scoped window across display_name variants (#3244)', () => {
+    // 端点对 display_name 的口径历史上有 "Fable" / "Claude Fable" / "Fable 5"
+    // 等形态;精确等于会把变体漏掉,导致 Fable 周限不显示而 Opus/Sonnet 正常。
+    const scoped = [
+      { utilization: 30, modelDisplayName: 'Claude Fable' },
+      { utilization: 5, modelDisplayName: 'Opus' },
+    ];
+    expect(matchScopedWindowForModel(scoped, 'claude-fable-5')?.utilization).toBe(30);
+    const scoped2 = [
+      { utilization: 41, modelDisplayName: 'Fable 5' },
+    ];
+    expect(matchScopedWindowForModel(scoped2, 'claude-fable-5-20250101')?.utilization).toBe(41);
   });
 });
 

--- a/apps/desktop/src/main/usage/__tests__/claudeSubscriptionUsage.test.ts
+++ b/apps/desktop/src/main/usage/__tests__/claudeSubscriptionUsage.test.ts
@@ -110,6 +110,53 @@ describe('parseClaudeOAuthUsageResponse', () => {
     ).toBe(87);
   });
 
+  it('merges legacy per-family fallback when limits[] only covers some families (#3244 Codex P1)', () => {
+    // 混合/降级响应:limits[] 的 weekly_scoped 只给了 Opus,Fable 仅通过顶层
+    // seven_day_fable 下发。旧逻辑用 `scoped.length === 0` 整体门控,有 Opus 时整个
+    // legacy 兜底被跳过,Fable 周限丢失。修复后按家族补(归属判定走共享 helper):
+    // Opus 以 limits[] 为准(utilization 5、保留 severity),缺失的 Fable 从顶层键补入。
+    const snapshot = parseClaudeOAuthUsageResponse({
+      five_hour: { utilization: 10, resets_at: '2026-04-11T07:00:00Z' },
+      seven_day: { utilization: 13, resets_at: '2026-04-14T07:00:00Z' },
+      seven_day_fable: { utilization: 87, resets_at: '2026-04-14T07:00:00Z' },
+      seven_day_opus: { utilization: 5, resets_at: '2026-04-14T07:00:00Z' },
+      limits: [
+        {
+          kind: 'weekly_scoped', percent: 5, severity: 'normal',
+          resets_at: '2026-04-14T07:00:00Z',
+          scope: { model: { id: null, display_name: 'Opus' } },
+        },
+      ],
+    }, NOW);
+    expect(snapshot?.scoped).toEqual([
+      expect.objectContaining({ modelDisplayName: 'Opus', utilization: 5, severity: 'normal' }),
+      expect.objectContaining({ modelDisplayName: 'Fable', utilization: 87 }),
+    ]);
+    expect(
+      matchScopedWindowForModel(snapshot?.scoped, 'claude-fable-5')?.utilization,
+    ).toBe(87);
+  });
+
+  it('does not let a same-family legacy window override the limits[] scoped window', () => {
+    // 去重以家族为单位:limits[] 已给 Fable(带 severity)时,顶层 seven_day_fable
+    // 即使存在也不覆盖——limits[] 是权威全集。这里 Fable 的 limits[] 值 22、legacy 87,
+    // 解析后必须保留 22 且只有一个 Fable 窗口。
+    const snapshot = parseClaudeOAuthUsageResponse({
+      five_hour: { utilization: 10, resets_at: '2026-04-11T07:00:00Z' },
+      seven_day_fable: { utilization: 87, resets_at: '2026-04-14T07:00:00Z' },
+      limits: [
+        {
+          kind: 'weekly_scoped', percent: 22, severity: 'warning',
+          resets_at: '2026-04-14T07:00:00Z',
+          scope: { model: { id: null, display_name: 'Claude Fable' } },
+        },
+      ],
+    }, NOW);
+    expect(snapshot?.scoped).toEqual([
+      expect.objectContaining({ modelDisplayName: 'Claude Fable', utilization: 22, severity: 'warning' }),
+    ]);
+  });
+
   it('parses enabled extra usage', () => {
     const snapshot = parseClaudeOAuthUsageResponse({
       five_hour: { utilization: 10 },
@@ -282,6 +329,33 @@ describe('claudeModelFamily / matchScopedWindowForModel', () => {
       { utilization: 41, modelDisplayName: 'Fable 5' },
     ];
     expect(matchScopedWindowForModel(scoped2, 'claude-fable-5-20250101')?.utilization).toBe(41);
+  });
+
+  it('classifies a scoped window by its modelId when present (authoritative over displayName)', () => {
+    // window.modelId 能经 claudeModelFamily 归类时优先用它:即使 displayName 不含家族名
+    // 也能命中。
+    const scoped = [
+      { utilization: 30, modelDisplayName: 'Internal Label', modelId: 'claude-fable-5-20250101' },
+    ];
+    expect(matchScopedWindowForModel(scoped, 'claude-fable-5')?.utilization).toBe(30);
+    // modelId 指向另一家族时以 modelId 为准,不回退 displayName(即使后者含子串也不跨家族误命中)
+    const cross = [
+      { utilization: 99, modelDisplayName: 'Fable-ish', modelId: 'claude-opus-4-8' },
+    ];
+    expect(matchScopedWindowForModel(cross, 'claude-fable-5')).toBeNull();
+  });
+
+  it('falls back to displayName variant matching when modelId is null or unrecognized', () => {
+    // modelId 为 null → 回退 displayName 变体包含
+    const noId = [
+      { utilization: 30, modelDisplayName: 'Claude Fable', modelId: null },
+    ];
+    expect(matchScopedWindowForModel(noId, 'claude-fable-5')?.utilization).toBe(30);
+    // modelId 存在但无法归类(不在已知家族表)→ 同样回退 displayName 变体
+    const unknownId = [
+      { utilization: 41, modelDisplayName: 'Fable 5', modelId: 'internal-fable-foo' },
+    ];
+    expect(matchScopedWindowForModel(unknownId, 'claude-fable-5')?.utilization).toBe(41);
   });
 });
 

--- a/apps/desktop/src/shared/claudeSubscriptionUsage.ts
+++ b/apps/desktop/src/shared/claudeSubscriptionUsage.ts
@@ -6,7 +6,8 @@
  *   1. `oauth-endpoint` — GET api.anthropic.com/api/oauth/usage(未文档化端点,Claude Code
  *      自己的 /usage 命令同源)。utilization 为 0-100;新 schema 以 `limits[]` 数组为准
  *      (kind: session / weekly_all / weekly_scoped,scoped 带 scope.model),旧 schema 的
- *      `five_hour` / `seven_day` / `seven_day_opus` / `seven_day_sonnet` 顶层键做兜底。
+ *      `five_hour` / `seven_day` / `seven_day_opus` / `seven_day_sonnet` /
+ *      `seven_day_fable` 顶层键做兜底。
  *      仅端点源有分模型周窗口(Fable / Opus / Sonnet 各自独立)与 extra usage。
  *   2. `unified-headers` — 订阅直连响应上的 `anthropic-ratelimit-unified-*` headers
  *      (每次 API call 都带,由本地 proxy 旁路读取)。utilization 为 0.0-1.0 分数,
@@ -188,9 +189,14 @@ export function parseClaudeOAuthUsageResponse(
   if (!fiveHour) fiveHour = parseLegacyWindow(data.five_hour);
   if (!sevenDay) sevenDay = parseLegacyWindow(data.seven_day);
   if (scoped.length === 0) {
+    // 旧 schema 兜底:limits[] 没给 weekly_scoped 时,从顶层 seven_day_<model> 键取。
+    // Fable 是较新加的家族,旧兜底原先只列了 Opus/Sonnet,导致走旧端点或降级快照
+    // 时 Fable 周限丢失(会话信息栏不显示,issue #3244)。补齐 Fable;Mythos/Haiku
+    // 端点目前不下发分模型周窗口,如未来新增在此追加。
     const legacyScoped: Array<[unknown, string]> = [
       [data.seven_day_opus, 'Opus'],
       [data.seven_day_sonnet, 'Sonnet'],
+      [(data as { seven_day_fable?: unknown }).seven_day_fable, 'Fable'],
     ];
     for (const [raw, displayName] of legacyScoped) {
       const window = parseLegacyWindow(raw);
@@ -341,8 +347,11 @@ export function claudeModelFamily(modelId: string | null | undefined): string | 
 
 /**
  * 找当前会话模型对应的分模型周窗口(chip 方案 B:第二栏跟随当前模型)。
- * 匹配口径:scoped.modelDisplayName 小写 == 模型家族名。找不到 → null,调用方回退
- * sevenDay 总周限(绝不臆造)。
+ * 匹配口径:scoped.modelDisplayName 小写后**包含**模型家族名(而非精确相等)——
+ * 端点对 display_name 的口径历史上有 "Fable" / "Claude Fable" / "Fable 5" 等
+ * 形态,精确等于会把变体漏掉(issue #3244:Fable 周限不显示,Opus/Sonnet 正常)。
+ * 家族名互斥出现在 model id 里(claudeModelFamily 已保证),不会跨家族误命中。
+ * 找不到 → null,调用方回退 sevenDay 总周限(绝不臆造)。
  */
 export function matchScopedWindowForModel(
   scoped: ClaudeScopedUsageWindow[] | null | undefined,
@@ -351,7 +360,9 @@ export function matchScopedWindowForModel(
   if (!scoped || scoped.length === 0) return null;
   const family = claudeModelFamily(modelId);
   if (!family) return null;
-  return scoped.find((w) => w.modelDisplayName.trim().toLowerCase() === family) ?? null;
+  return (
+    scoped.find((w) => w.modelDisplayName.trim().toLowerCase().includes(family)) ?? null
+  );
 }
 
 // ── 告警判定(chip 变红的口径;tooltip 另有 status 分流,见 TodaySpendChip) ───

--- a/apps/desktop/src/shared/claudeSubscriptionUsage.ts
+++ b/apps/desktop/src/shared/claudeSubscriptionUsage.ts
@@ -188,20 +188,24 @@ export function parseClaudeOAuthUsageResponse(
   // 旧 schema 兜底:limits[] 没给的窗口再看顶层键。
   if (!fiveHour) fiveHour = parseLegacyWindow(data.five_hour);
   if (!sevenDay) sevenDay = parseLegacyWindow(data.seven_day);
-  if (scoped.length === 0) {
-    // 旧 schema 兜底:limits[] 没给 weekly_scoped 时,从顶层 seven_day_<model> 键取。
-    // Fable 是较新加的家族,旧兜底原先只列了 Opus/Sonnet,导致走旧端点或降级快照
-    // 时 Fable 周限丢失(会话信息栏不显示,issue #3244)。补齐 Fable;Mythos/Haiku
-    // 端点目前不下发分模型周窗口,如未来新增在此追加。
-    const legacyScoped: Array<[unknown, string]> = [
-      [data.seven_day_opus, 'Opus'],
-      [data.seven_day_sonnet, 'Sonnet'],
-      [(data as { seven_day_fable?: unknown }).seven_day_fable, 'Fable'],
-    ];
-    for (const [raw, displayName] of legacyScoped) {
-      const window = parseLegacyWindow(raw);
-      if (window) scoped.push({ ...window, modelDisplayName: displayName });
-    }
+  // 旧 schema 分模型周窗口兜底:按家族补 limits[] 没给 weekly_scoped 的家族,从顶层
+  // seven_day_<model> 键取。不能用 `scoped.length === 0` 整体门控——混合/降级响应里
+  // limits[] 可能只给了部分家族(如只有 Opus),其余家族(Fable)只通过顶层键下发;某家族
+  // 的 weekly_scoped 畸形被跳过时同理。已由 limits[] 给出的家族以 limits[] 为准,不被
+  // legacy 覆盖。家族归属统一走 scopedWindowBelongsToFamily,与 matchScopedWindowForModel
+  // 同一份口径,避免两份 includes 规则漂移。Fable 是较新加的家族,旧兜底原先只列
+  // Opus/Sonnet,走旧端点或降级快照时 Fable 周限丢失(issue #3244);Mythos/Haiku 端点
+  // 目前不下发分模型周窗口,如未来新增在此追加。
+  const legacyScoped: Array<[unknown, string]> = [
+    [data.seven_day_opus, 'Opus'],
+    [data.seven_day_sonnet, 'Sonnet'],
+    [(data as { seven_day_fable?: unknown }).seven_day_fable, 'Fable'],
+  ];
+  for (const [raw, displayName] of legacyScoped) {
+    const family = displayName.toLowerCase();
+    if (scoped.some((w) => scopedWindowBelongsToFamily(w, family))) continue;
+    const window = parseLegacyWindow(raw);
+    if (window) scoped.push({ ...window, modelDisplayName: displayName });
   }
 
   if (!fiveHour && !sevenDay && scoped.length === 0) return null;
@@ -346,12 +350,29 @@ export function claudeModelFamily(modelId: string | null | undefined): string | 
 }
 
 /**
+ * 判断一个分模型周窗口是否属于指定家族。
+ *
+ * 优先用窗口自带的 `modelId` 经 `claudeModelFamily` 归类(权威、精确);`modelId`
+ * 缺失或无法归类(端点常为 null,或 id 形态不在识别表里)时,回退用 `modelDisplayName`
+ * 的变体包含匹配——端点对 display_name 的口径历史上有 "Fable" / "Claude Fable" /
+ * "Fable 5" 等形态,精确等于会漏掉变体(issue #3244)。家族名互斥,不会跨家族误命中。
+ *
+ * matcher(`matchScopedWindowForModel`)与 legacy 兜底去重共用这一份口径,避免两份
+ * includes 规则漂移。
+ */
+function scopedWindowBelongsToFamily(
+  window: ClaudeScopedUsageWindow,
+  family: string,
+): boolean {
+  const fromId = claudeModelFamily(window.modelId);
+  if (fromId) return fromId === family;
+  return window.modelDisplayName.trim().toLowerCase().includes(family);
+}
+
+/**
  * 找当前会话模型对应的分模型周窗口(chip 方案 B:第二栏跟随当前模型)。
- * 匹配口径:scoped.modelDisplayName 小写后**包含**模型家族名(而非精确相等)——
- * 端点对 display_name 的口径历史上有 "Fable" / "Claude Fable" / "Fable 5" 等
- * 形态,精确等于会把变体漏掉(issue #3244:Fable 周限不显示,Opus/Sonnet 正常)。
- * 家族名互斥出现在 model id 里(claudeModelFamily 已保证),不会跨家族误命中。
- * 找不到 → null,调用方回退 sevenDay 总周限(绝不臆造)。
+ * 找不到 → null,调用方回退 sevenDay 总周限(绝不臆造)。家族归属口径见
+ * scopedWindowBelongsToFamily。
  */
 export function matchScopedWindowForModel(
   scoped: ClaudeScopedUsageWindow[] | null | undefined,
@@ -360,9 +381,7 @@ export function matchScopedWindowForModel(
   if (!scoped || scoped.length === 0) return null;
   const family = claudeModelFamily(modelId);
   if (!family) return null;
-  return (
-    scoped.find((w) => w.modelDisplayName.trim().toLowerCase().includes(family)) ?? null
-  );
+  return scoped.find((w) => scopedWindowBelongsToFamily(w, family)) ?? null;
 }
 
 // ── 告警判定(chip 变红的口径;tooltip 另有 status 分流,见 TodaySpendChip) ───


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Claude 官方订阅下会话信息栏 Fable 模型周限不显示的问题（#3244，必现；同环境 Opus/Sonnet 正常）。

根因有两处：

1. `matchScopedWindowForModel` 用 `modelDisplayName.toLowerCase() === family` 精确匹配，但端点对 display_name 的口径存在 `Fable` / `Claude Fable` / `Fable 5` 等变体，精确等于会漏掉变体（Opus/Sonnet 碰巧都是短名才没暴露）。
2. 旧 schema 兜底（`parseClaudeOAuthUsageResponse` 的 `seven_day_*` 顶层键）只列了 Opus/Sonnet，漏了 Fable，走旧端点或降级快照时 Fable 周限直接丢失。

修复：匹配改为 `includes(family)`（家族名互斥，不会跨家族误命中）；旧 schema 兜底补 `seven_day_fable`；文件头注释同步。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#3244
- 本 PR 包含：`apps/desktop/src/shared/claudeSubscriptionUsage.ts` 匹配与 legacy 兜底修复；`apps/desktop/src/main/usage/__tests__/claudeSubscriptionUsage.test.ts` 两个回归用例
- 明确不包含：UI 组件/样式改动；其他模型家族（Mythos/Haiku 端点目前不下发分模型周窗口）
- 用户可见变化：Claude 官方订阅、当前会话模型为 Fable 时，会话信息栏第二栏重新显示 Fable 周限
- 是否存在 breaking change：无

### UI 变化

不涉及：本次仅修正 usage 数据解析与匹配逻辑，未改动任何 UI 组件、样式或文案；展示路径（TodaySpendChip 等）不变，原本拿到数据就能显示。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop test -- claudeSubscriptionUsage
结果：claudeSubscriptionUsage.test.ts 全部通过（含新增 2 个回归用例：
display_name 变体 "Claude Fable" / "Fable 5" 匹配；legacy seven_day_fable 解析为 Fable scoped 窗口）

pnpm --filter desktop run typecheck
结果：通过
```

CI：client-ci（Linux/Windows unit tests、verify、Desktop Git integration）、DCO、pr-design-basis、Greptile Review 均为 SUCCESS。

### 手工验证

不涉及：缺陷为纯数据解析/匹配逻辑，已由针对性回归测试覆盖 display_name 变体与 legacy schema 两条触发路径；无 UI 视觉或交互变化需要目检。

### 未执行的验证

无。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Desktop Claude 官方订阅 usage 解析。匹配放宽为 `includes` 后，由于 `claudeModelFamily` 返回的家族名（fable/opus/sonnet）互斥且不会作为子串出现在彼此的 display_name 中，不会跨家族误命中；Opus/Sonnet 现有行为不变。legacy 兜底仅在 `seven_day_fable` 存在时新增一个 Fable 窗口，缺字段时行为与之前一致。
- 回滚 / 降级方式：revert 本 PR 即可，无数据迁移或持久化变更。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
