### PR TITLE
fix(desktop): 资源用量窗口标题栏关闭按钮走专用关闭通道 (#3183)

### DIFF
--- a/apps/desktop/src/renderer/components/resource-usage/ResourceUsageWindowLayout.tsx
+++ b/apps/desktop/src/renderer/components/resource-usage/ResourceUsageWindowLayout.tsx
@@ -120,10 +120,18 @@ export function ResourceUsageWindowLayout() {
     report();
   }, []);
 
-  useAppShortcut('close-tab-or-window', () => {
+  const closeWindow = useCallback(() => {
+    // 走资源窗口专用关闭通道(controller.close → hideWindow + 焦点回归主窗口),
+    // 与快捷键一致;不用通用 windowClose() —— 后者在某些子窗口状态下可能落入主窗口
+    // 关闭流程。#3183:之前鼠标点标题栏 X 与快捷键走两条路径,关闭后焦点回不到主窗口,
+    // 用户感知为"打开用量后无法回去"。
     void window.electronAPI.resourceUsageWindow.close().catch((err) => {
-      log.warn('close window via shortcut failed', err);
+      log.warn('close window failed', err);
     });
+  }, []);
+
+  useAppShortcut('close-tab-or-window', () => {
+    closeWindow();
     return true;
   });
 
@@ -146,7 +154,7 @@ export function ResourceUsageWindowLayout() {
             className="flex h-full shrink-0 items-center"
             style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
           >
-            <WindowControls key={windowChromeRevision} />
+            <WindowControls key={windowChromeRevision} onClose={closeWindow} />
           </div>
         )}
       </div>

--- a/apps/desktop/src/renderer/components/resource-usage/__tests__/ResourceUsageWindowLayout.test.tsx
+++ b/apps/desktop/src/renderer/components/resource-usage/__tests__/ResourceUsageWindowLayout.test.tsx
@@ -16,7 +16,10 @@ vi.mock('@/features/right-sidebar/plugins/resource-usage/ResourceUsageBody', () 
 }));
 
 vi.mock('@/components/title-bar/WindowControls', () => ({
-  WindowControls: () => <button data-testid="window-controls" />,
+  // #3183: 暴露 onClose 触发,验证标题栏 X 走资源窗口专用关闭通道
+  WindowControls: ({ onClose }: { onClose?: () => void }) => (
+    <button data-testid="window-controls" onClick={onClose} />
+  ),
 }));
 
 vi.mock('@/hooks/useTheme', () => ({ ThemeProvider: ({ children }: React.PropsWithChildren) => children }));
@@ -44,6 +47,7 @@ afterEach(() => {
 describe('ResourceUsageWindowRoot prewarm lifecycle', () => {
   const rendererReady = vi.fn(() => Promise.resolve());
   const presentationReady = vi.fn(() => Promise.resolve());
+  const resourceClose = vi.fn(() => Promise.resolve());
   let samplingListener: ((active: boolean) => void) | null = null;
   let localeListener: ((locale: 'zh-CN' | 'en') => void) | null = null;
 
@@ -54,12 +58,13 @@ describe('ResourceUsageWindowRoot prewarm lifecycle', () => {
     setLocale.mockClear();
     rendererReady.mockClear();
     presentationReady.mockClear();
+    resourceClose.mockClear();
     Object.defineProperty(window, 'electronAPI', {
       configurable: true,
       value: {
         platform: 'win32',
         resourceUsageWindow: {
-          close: vi.fn(() => Promise.resolve()),
+          close: resourceClose,
           rendererReady,
           presentationReady,
           onSamplingActiveChanged: (cb: (active: boolean) => void) => {
@@ -132,6 +137,18 @@ describe('ResourceUsageWindowRoot prewarm lifecycle', () => {
     });
 
     expect(presentationReady).toHaveBeenCalledOnce();
+  });
+
+  it('closes the resource window via the dedicated close channel when the title-bar X is clicked (#3183)', () => {
+    render(<ResourceUsageWindowRoot />);
+
+    act(() => {
+      screen.getByTestId('window-controls').click();
+    });
+
+    // 必须走 resourceUsageWindow.close(controller 隐藏窗口 + 焦点回归主窗口),
+    // 而不是通用 windowClose,否则用户点 X 后看起来"回不去"。
+    expect(resourceClose).toHaveBeenCalledOnce();
   });
 
   it('retries a transient presentation-ready IPC failure', async () => {


### PR DESCRIPTION
## 问题
#3183:打开资源用量(进程监视器)窗口后,无法回到主页面。

## 根因
`ResourceUsageWindowLayout` 的标题栏 `WindowControls` 没传 `onClose`,鼠标点 X 走通用 `windowClose()` IPC;而 ⌘W/Ctrl+W 快捷键走 `resourceUsageWindow.close()` 专用通道,两条路径不一致。在子窗口(parent/模态)状态下通用 windowClose 可能被主窗口关闭流程拦截,或关闭后不把焦点交回主窗口,用户感知为'打开用量后无法回去'。

## 修复
向 `WindowControls` 传 `onClose`,鼠标点 X 与快捷键统一调 `resourceUsageWindow.close()`(controller.close → hideWindow + focusOwnerWindow),确保关闭后焦点回到主窗口。

## UI 变化

- 引用的设计规范:不涉及视觉/交互/文案变化 —— 本次仅把标题栏关闭按钮的点击处理从通用 IPC 切到资源窗口专用关闭通道,按钮外观、位置、chrome 布局均不变;关闭后由既有 controller 负责隐藏窗口并聚焦主窗口。

## 怎么验证的

### 自动验证
```text
pnpm --filter desktop exec vitest run src/renderer/components/resource-usage/__tests__/ResourceUsageWindowLayout.test.tsx --pool=forks
结果:8 tests passed
pnpm --filter desktop typecheck
结果:通过
```

### 手工验证
不涉及(行为变化为关闭路径统一,无新增 UI 元素)。

### 未执行的验证
无。

## 风险
低。仅影响资源用量窗口的关闭按钮点击路径,快捷键路径本就走同一专用通道。