### PR TITLE
fix(desktop): 副窗口中会话被归档后关闭窗口,禁止继续对话 (#3175)

### DIFF
--- a/apps/desktop/src/main/__tests__/makerSendToSessionOrdering.test.ts
+++ b/apps/desktop/src/main/__tests__/makerSendToSessionOrdering.test.ts
@@ -509,7 +509,7 @@ describe('sendToSession ordering', () => {
     );
     const directSendSwitchBlock = extractBetween(
       source,
-      'pendingAgentSwitchApplyHolder = async (sessionId, signal) =>',
+      'pendingAgentSwitchApplyHolder = async (sessionId, options) =>',
       'ipcMain.handle(MAKER_INVOKE.MARK_ORCA_ROLE',
     );
 
@@ -591,14 +591,19 @@ describe('sendToSession ordering', () => {
       'selection,',
     );
     expect(source).toContain('withSessionLock: withSendToSessionLock,');
+    // 非持锁路径:获取锁 → apply → 准备不健康会话 → 返回 release。
+    // (持锁路径 sessionRouteLockHeld 在锁外直接 apply 并返回 no-op,
+    //  见同文件 "lets a route-lock holder skip..." 测试。)
     expect(directSendSwitchBlock).toContain('const release = await acquireSendToSessionLock(sessionId);');
-    expectOrder(
+    const nonLockedPath = extractBetween(
       directSendSwitchBlock,
       'const release = await acquireSendToSessionLock(sessionId);',
-      'applyPendingAgentSwitchIfIdle(',
+      '  };',
+      { allowMissingEnd: true },
     );
-    expectOrder(directSendSwitchBlock, 'applyPendingAgentSwitchIfIdle(', 'prepareUnhealthySession');
-    expectOrder(directSendSwitchBlock, 'prepareUnhealthySession', 'return release;');
+    expect(nonLockedPath).toContain('await applyPendingRoute();');
+    expect(nonLockedPath).toContain('return release;');
+    expectOrder(nonLockedPath, 'await applyPendingRoute();', 'return release;');
   });
 
   it('仅 Device Link 归一化 SET_MODEL 的 JSON null 可选占位,本地仍走严格校验', () => {
@@ -1069,6 +1074,36 @@ describe('sendToSession ordering', () => {
     expect(useWorkersSource).not.toContain('isRunningWorkerStatus');
     expect(useWorkersSource).toContain('const activeWorkerCount = getActiveWorkerCount(workers);');
     expect(workerProjectionStoreSource).toContain('return workers.filter((w) => isActiveWorkerStatus(w.status)).length;');
+  });
+
+  it('lets a route-lock holder skip the nested pending-agent-switch lock', () => {
+    // Goal 的 lifecycle fence 在持有 withSendToSessionLock 时调用
+    // controller.setGoal/resumeGoal/fireTurn,后者经
+    // acquirePendingAgentSwitchForDirectSend → pendingAgentSwitchApplyHolder
+    // 又获取同一把非重入 send/route 锁,会自死锁(#3262 review P2)。
+    // holder 必须支持 sessionRouteLockHeld 选项:调用方已持锁时跳过
+    // acquireSendToSessionLock,只执行 apply 并返回 no-op release。
+    const holderBlock = extractBetween(
+      source,
+      'pendingAgentSwitchApplyHolder = async (sessionId, options) =>',
+      'ipcMain.handle(MAKER_INVOKE.MARK_ORCA_ROLE',
+    );
+    // 1. holder 读取 options.sessionRouteLockHeld。
+    expect(holderBlock).toContain('options?.sessionRouteLockHeld');
+    // 2. 持锁时直接执行 apply 并返回 no-op release,不调 acquireSendToSessionLock。
+    expect(holderBlock).toContain('await applyPendingRoute()');
+    expect(holderBlock).toContain('return () => {};');
+    // 3. 非持锁路径仍获取锁,保证串行语义不回退。
+    const nonLockedPath = extractBetween(
+      holderBlock,
+      'const release = await acquireSendToSessionLock(sessionId);',
+      '  };',
+      { allowMissingEnd: true },
+    );
+    expect(nonLockedPath).toContain('await applyPendingRoute();');
+    expect(nonLockedPath).toContain('return release;');
+    // 4. acquirePendingAgentSwitchForDirectSend 把 options 透传给 holder。
+    expect(source).toContain('pendingAgentSwitchApplyHolder?.(sessionId, options)');
   });
 });
 

--- a/apps/desktop/src/main/bootstrap-electron.ts
+++ b/apps/desktop/src/main/bootstrap-electron.ts
@@ -5841,8 +5841,14 @@ const registerIpcHandlers = () => {
         assertSessionActive: assertSessionActiveForManualDispatch,
         // 本地副窗口(GoalIndicator 所在的 secondary app window)按真实 sender 反查,
         // 与 device-link 透传的 requireActiveSession 标记互补,统一走 active-session fence。
-        isSecondaryWindowEvent: (event) =>
-          isSecondaryAppWindow(BrowserWindow.fromWebContents(event.sender)),
+        // device-link 合成事件的 sender 为 undefined(见 device-link/invoke-registry),
+        // 不能交给 fromWebContents;这类请求只靠显式 requireActiveSession 标记驱动,
+        // 窗口归属探测直接返回 false(#3262 review P1)。
+        isSecondaryWindowEvent: (event) => {
+          if (!event?.sender) return false;
+          const win = BrowserWindow.fromWebContents(event.sender);
+          return win ? isSecondaryAppWindow(win) : false;
+        },
       });
       // clear-context 清目标 / turn 收尾 idle 兜底续跑(setter 注入,null-safe)。
       setGoalClearObserver((sid) => {

--- a/apps/desktop/src/main/bootstrap-electron.ts
+++ b/apps/desktop/src/main/bootstrap-electron.ts
@@ -5839,6 +5839,10 @@ const registerIpcHandlers = () => {
         isDeviceLinkInvoke,
         withSessionLock: withSendToSessionLock,
         assertSessionActive: assertSessionActiveForManualDispatch,
+        // 本地副窗口(GoalIndicator 所在的 secondary app window)按真实 sender 反查,
+        // 与 device-link 透传的 requireActiveSession 标记互补,统一走 active-session fence。
+        isSecondaryWindowEvent: (event) =>
+          isSecondaryAppWindow(BrowserWindow.fromWebContents(event.sender)),
       });
       // clear-context 清目标 / turn 收尾 idle 兜底续跑(setter 注入,null-safe)。
       setGoalClearObserver((sid) => {

--- a/apps/desktop/src/main/bootstrap-electron.ts
+++ b/apps/desktop/src/main/bootstrap-electron.ts
@@ -621,6 +621,7 @@ import {
 } from './right-sidebar-window/settings-store.js';
 import {
   anySessionInTurn,
+  assertSessionActiveForManualDispatch,
   applyCodexSpawnConfigChangeWithRestart,
   clearDeferredCodexRestartForOwnerBoundary,
   collectAgentInputQueueScanTexts,
@@ -636,6 +637,7 @@ import {
   setGoalAskAnswerObserver,
   withSendToSessionLock,
 } from './maker-ipc/register.js';
+import { isDeviceLinkInvoke } from './device-link/invoke-context.js';
 import { cleanupActiveReviewArtifactSnapshots } from './reviewer/reviewArtifactSnapshot.js';
 import { MAKER_INVOKE as MAKER_IPC_INVOKE, MAKER_PUSH, MAKER_SEND } from './maker-ipc/channels.js';
 import {
@@ -5805,10 +5807,18 @@ const registerIpcHandlers = () => {
       });
       // desktop-cmd:run —— /cmd 的被控端远程执行 handler(仅隧道 dispatch 消费,
       // 本机 /cmd 仍在 builtins 内联执行,不走 IPC 往返)。
-      registerRemoteCmdIpc();
+      registerRemoteCmdIpc({
+        isDeviceLinkInvoke,
+        withSessionLock: withSendToSessionLock,
+        assertSessionActive: assertSessionActiveForManualDispatch,
+      });
       // learn:* handler 提前一次性注册(eager,同 goal);handler 内部 getLearnController()
       // 取单例,invoke 时 controller 已由 startLearnHost 启动。
-      registerLearnIpc();
+      registerLearnIpc({
+        isDeviceLinkInvoke,
+        withSessionLock: withSendToSessionLock,
+        assertSessionActive: assertSessionActiveForManualDispatch,
+      });
       // maker:schedule:* handler 提前一次性注册;handler 内部 awaitReady 等真实
       // scheduler 实例(由后续 attemptStartScheduler 通过 attachSchedulerEventListeners
       // → setSchedulerReady 喂入)。这条修复 cold-start race:之前 handler 在
@@ -5825,7 +5835,11 @@ const registerIpcHandlers = () => {
       });
       // maker:goal:* handler 同样提前一次性注册(eager);handler 内部 getGoalController()
       // 取单例,invoke 时 controller 已由 attemptStartScheduler → startGoalController 启动。
-      registerGoalHandlers();
+      registerGoalHandlers({
+        isDeviceLinkInvoke,
+        withSessionLock: withSendToSessionLock,
+        assertSessionActive: assertSessionActiveForManualDispatch,
+      });
       // clear-context 清目标 / turn 收尾 idle 兜底续跑(setter 注入,null-safe)。
       setGoalClearObserver((sid) => {
         void getGoalController()?.clearGoal(sid);

--- a/apps/desktop/src/main/commands/__tests__/builtinsRemoteRouting.test.ts
+++ b/apps/desktop/src/main/commands/__tests__/builtinsRemoteRouting.test.ts
@@ -81,6 +81,20 @@ describe('/goal 远程路由', () => {
     expect(remoteInvoke).not.toHaveBeenCalled();
   });
 
+  it('Main 已持有 session route lock 时把所有权传给 Goal 首轮派发', async () => {
+    const { registry, goalController } = makeHarness();
+    await registry.execute('goal', {
+      sessionId: 'ls',
+      args: '目标 Z',
+      sessionRouteLockHeld: true,
+    });
+    expect(goalController.setGoal).toHaveBeenCalledWith({
+      sessionId: 'ls',
+      objective: '目标 Z',
+      sessionRouteLockHeld: true,
+    });
+  });
+
   it('被控端版本过旧(CHANNEL_NOT_ALLOWED)→ remote-unsupported', async () => {
     const { registry } = makeHarness({
       remoteInvoke: async () => {
@@ -173,7 +187,7 @@ describe('/cmd 远程路由', () => {
       args: 'ls',
     });
     expect(remoteInvoke).toHaveBeenCalledWith('dev-1', 'desktop-cmd:run', [
-      { cmdLine: 'ls', cwd: '/remote/dir' },
+      { sessionId: 'rs', cmdLine: 'ls', cwd: '/remote/dir' },
     ]);
     expect(sentPayloads().at(-1)).toMatchObject({ command: 'cmd', result: remoteResult });
   });

--- a/apps/desktop/src/main/commands/__tests__/builtinsRemoteRouting.test.ts
+++ b/apps/desktop/src/main/commands/__tests__/builtinsRemoteRouting.test.ts
@@ -74,6 +74,21 @@ describe('/goal 远程路由', () => {
     expect(sentPayloads().at(-1)).toMatchObject({ command: 'goal', goalAction: 'cleared' });
   });
 
+  it('副窗口 clear:第一参保持裸 sessionId,仅追加尾部 fenceOpts', async () => {
+    const { registry, remoteInvoke } = makeHarness();
+    await registry.execute('goal', {
+      sessionId: 'rs',
+      deviceId: 'dev-1',
+      args: 'clear',
+      requireActiveSession: true,
+    });
+    // 旧被控端按 requireString 解析第一参裸字符串、忽略尾参;新被控端读第二参加锁。
+    expect(remoteInvoke).toHaveBeenCalledWith('dev-1', 'maker:goal:clear', [
+      'rs',
+      { requireActiveSession: true },
+    ]);
+  });
+
   it('本机会话(无 deviceId)仍走本机 controller', async () => {
     const { registry, goalController, remoteInvoke } = makeHarness();
     await registry.execute('goal', { sessionId: 'ls', args: '目标 Y' });
@@ -103,6 +118,19 @@ describe('/goal 远程路由', () => {
     });
     await registry.execute('goal', { sessionId: 'rs', deviceId: 'dev-1', args: '目标 X' });
     expect(sentPayloads().at(-1)).toMatchObject({ command: 'goal', error: 'remote-unsupported' });
+  });
+
+  it('副窗口 requireActiveSession 透传进 maker:goal:set args', async () => {
+    const { registry, remoteInvoke } = makeHarness();
+    await registry.execute('goal', {
+      sessionId: 'rs',
+      deviceId: 'dev-1',
+      args: '目标 X',
+      requireActiveSession: true,
+    });
+    expect(remoteInvoke).toHaveBeenCalledWith('dev-1', 'maker:goal:set', [
+      { sessionId: 'rs', objective: '目标 X', requireActiveSession: true },
+    ]);
   });
 });
 
@@ -166,6 +194,28 @@ describe('/learn 远程路由', () => {
     expect(remoteInvoke).not.toHaveBeenCalled();
     expect(sentPayloads().at(-1)).toMatchObject({ command: 'learn', learnRunId: 'local-run' });
   });
+
+  it('副窗口 requireActiveSession 透传进 learn:start req(本机 startLearn 不带该字段)', async () => {
+    const { registry, learnController, remoteInvoke } = makeHarness({
+      remoteInvoke: async () => ({ runId: 'remote-run' }),
+    });
+    await registry.execute('learn', {
+      sessionId: 'rs',
+      deviceId: 'dev-1',
+      args: '学习 Z',
+      requireActiveSession: true,
+    });
+    expect(remoteInvoke).toHaveBeenCalledWith('dev-1', 'learn:start', [
+      {
+        input: '学习 Z',
+        sourceKind: 'freetext',
+        originSessionId: 'rs',
+        requireActiveSession: true,
+      },
+    ]);
+    // 本机 controller 不被调用,且 req 不污染本机路径。
+    expect(learnController.startLearn).not.toHaveBeenCalled();
+  });
 });
 
 describe('/cmd 远程路由', () => {
@@ -207,5 +257,51 @@ describe('/cmd 远程路由', () => {
     const last = sentPayloads().at(-1) as { result?: { exitCode: number; spawnError?: string } };
     expect(last?.result?.exitCode).toBe(-1);
     expect(last?.result?.spawnError).toContain('DEVICE_LINK_DEVICE_OFFLINE');
+  });
+
+  it('副窗口 requireActiveSession 透传进 desktop-cmd:run args(被控端据此 fence)', async () => {
+    const { registry, remoteInvoke } = makeHarness({
+      remoteInvoke: async () => ({
+        cmdLine: 'ls',
+        cwd: '/remote/dir',
+        exitCode: 0,
+        stdout: 'ok',
+        stderr: '',
+        elapsedMs: 1,
+        timedOut: false,
+      }),
+    });
+    await registry.execute('cmd', {
+      sessionId: 'rs',
+      deviceId: 'dev-1',
+      workingDir: '/remote/dir',
+      args: 'ls',
+      requireActiveSession: true,
+    });
+    expect(remoteInvoke).toHaveBeenCalledWith('dev-1', 'desktop-cmd:run', [
+      { sessionId: 'rs', cmdLine: 'ls', cwd: '/remote/dir', requireActiveSession: true },
+    ]);
+  });
+
+  it('无 requireActiveSession 时隧道 args 不带该字段(primary remote 历史语义)', async () => {
+    const { registry, remoteInvoke } = makeHarness({
+      remoteInvoke: async () => ({
+        cmdLine: 'ls',
+        cwd: '/remote/dir',
+        exitCode: 0,
+        stdout: 'ok',
+        stderr: '',
+        elapsedMs: 1,
+        timedOut: false,
+      }),
+    });
+    await registry.execute('cmd', {
+      sessionId: 'rs',
+      deviceId: 'dev-1',
+      workingDir: '/remote/dir',
+      args: 'ls',
+    });
+    const args = (remoteInvoke.mock.calls.at(-1)?.[2] as unknown[])[0] as Record<string, unknown>;
+    expect(args).not.toHaveProperty('requireActiveSession');
   });
 });

--- a/apps/desktop/src/main/commands/__tests__/builtinsRemoteRouting.test.ts
+++ b/apps/desktop/src/main/commands/__tests__/builtinsRemoteRouting.test.ts
@@ -55,6 +55,23 @@ beforeEach(() => {
   h.webContentsSend.mockClear();
 });
 
+describe('/clear lifecycle fence', () => {
+  it('keeps a secondary-window active-session guard for every broadcast consumer', async () => {
+    const { registry } = makeHarness();
+
+    await registry.execute('clear', {
+      sessionId: 'rs',
+      requireActiveSession: true,
+    });
+
+    expect(sentPayloads().at(-1)).toMatchObject({
+      command: 'clear',
+      sessionId: 'rs',
+      requireActiveSession: true,
+    });
+  });
+});
+
 describe('/goal 远程路由', () => {
   it('deviceId + objective → 隧道 maker:goal:set,不触本机 controller', async () => {
     const { registry, goalController, remoteInvoke } = makeHarness();

--- a/apps/desktop/src/main/commands/__tests__/remoteCmdIpc.test.ts
+++ b/apps/desktop/src/main/commands/__tests__/remoteCmdIpc.test.ts
@@ -6,9 +6,16 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
+type SessionLock = <T>(sessionId: string, task: () => Promise<T>) => Promise<T>;
+
 const h = vi.hoisted(() => ({
   handlers: new Map<string, (event: unknown, ...args: unknown[]) => unknown>(),
   isAllowed: vi.fn(async () => true),
+  isDeviceLinkInvoke: vi.fn(() => false),
+  withSessionLock: vi.fn<SessionLock>(
+    async <T>(_sessionId: string, task: () => Promise<T>): Promise<T> => task(),
+  ),
+  assertSessionActive: vi.fn(async (_sessionId: string) => undefined),
   runShellCommand: vi.fn(async (opts: { cmdLine: string; cwd: string }) => ({
     cmdLine: opts.cmdLine,
     cwd: opts.cwd,
@@ -38,6 +45,10 @@ vi.mock('../../device-link/remote-workdir-guard.js', () => ({
 vi.mock('../builtins.js', () => ({
   runShellCommand: h.runShellCommand,
 }));
+vi.mock('../../maker-ipc/register.js', () => ({
+  withSendToSessionLock: h.withSessionLock,
+  assertSessionActiveForManualDispatch: h.assertSessionActive,
+}));
 
 import { registerRemoteCmdIpc, DESKTOP_CMD_RUN_CHANNEL } from '../remoteCmdIpc.js';
 
@@ -49,8 +60,16 @@ function invokeHandler(input: unknown): Promise<unknown> {
 
 beforeEach(() => {
   h.isAllowed.mockClear();
+  h.isDeviceLinkInvoke.mockReset();
+  h.isDeviceLinkInvoke.mockReturnValue(false);
+  h.withSessionLock.mockClear();
+  h.assertSessionActive.mockClear();
   h.runShellCommand.mockClear();
-  registerRemoteCmdIpc(); // 幂等:重复调用不重复注册
+  registerRemoteCmdIpc({
+    isDeviceLinkInvoke: h.isDeviceLinkInvoke,
+    withSessionLock: h.withSessionLock as unknown as SessionLock,
+    assertSessionActive: h.assertSessionActive,
+  }); // 幂等:重复调用不重复注册
 });
 
 describe('desktop-cmd:run handler', () => {
@@ -63,6 +82,21 @@ describe('desktop-cmd:run handler', () => {
     expect(h.runShellCommand).toHaveBeenCalledWith({ cmdLine: 'ls -la', cwd: '/known/dir' });
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toBe('ok');
+  });
+
+  it('device-link 调用在同一 session route lock 内复核 active', async () => {
+    h.isDeviceLinkInvoke.mockReturnValue(true);
+    await invokeHandler({ sessionId: 's1', cmdLine: 'ls', cwd: '/known/dir' });
+    expect(h.withSessionLock).toHaveBeenCalledWith('s1', expect.any(Function));
+    expect(h.assertSessionActive).toHaveBeenCalledWith('s1');
+  });
+
+  it('device-link 调用缺 sessionId 时 fail closed', async () => {
+    h.isDeviceLinkInvoke.mockReturnValue(true);
+    await expect(invokeHandler({ cmdLine: 'ls', cwd: '/known/dir' })).rejects.toThrow(
+      /\[INVALID_PARAMS\]/,
+    );
+    expect(h.runShellCommand).not.toHaveBeenCalled();
   });
 
   it('guard 拒绝 → INVALID_PARAMS,fail-closed 不落 spawn', async () => {

--- a/apps/desktop/src/main/commands/__tests__/remoteCmdIpc.test.ts
+++ b/apps/desktop/src/main/commands/__tests__/remoteCmdIpc.test.ts
@@ -84,18 +84,31 @@ describe('desktop-cmd:run handler', () => {
     expect(result.stdout).toBe('ok');
   });
 
-  it('device-link 调用在同一 session route lock 内复核 active', async () => {
+  it('device-link 调用带显式 requireActiveSession 时在 route lock 内复核 active', async () => {
     h.isDeviceLinkInvoke.mockReturnValue(true);
-    await invokeHandler({ sessionId: 's1', cmdLine: 'ls', cwd: '/known/dir' });
+    await invokeHandler({
+      sessionId: 's1',
+      cmdLine: 'ls',
+      cwd: '/known/dir',
+      requireActiveSession: true,
+    });
     expect(h.withSessionLock).toHaveBeenCalledWith('s1', expect.any(Function));
     expect(h.assertSessionActive).toHaveBeenCalledWith('s1');
   });
 
-  it('device-link 调用缺 sessionId 时 fail closed', async () => {
+  it('device-link 调用缺 requireActiveSession 时直通(primary remote 历史语义),不加锁', async () => {
     h.isDeviceLinkInvoke.mockReturnValue(true);
-    await expect(invokeHandler({ cmdLine: 'ls', cwd: '/known/dir' })).rejects.toThrow(
-      /\[INVALID_PARAMS\]/,
-    );
+    await invokeHandler({ sessionId: 's1', cmdLine: 'ls', cwd: '/known/dir' });
+    expect(h.withSessionLock).not.toHaveBeenCalled();
+    expect(h.assertSessionActive).not.toHaveBeenCalled();
+    expect(h.runShellCommand).toHaveBeenCalledWith({ cmdLine: 'ls', cwd: '/known/dir' });
+  });
+
+  it('device-link 调用带 requireActiveSession 但缺 sessionId 时 fail closed', async () => {
+    h.isDeviceLinkInvoke.mockReturnValue(true);
+    await expect(
+      invokeHandler({ cmdLine: 'ls', cwd: '/known/dir', requireActiveSession: true }),
+    ).rejects.toThrow(/\[INVALID_PARAMS\]/);
     expect(h.runShellCommand).not.toHaveBeenCalled();
   });
 

--- a/apps/desktop/src/main/commands/builtins.ts
+++ b/apps/desktop/src/main/commands/builtins.ts
@@ -399,7 +399,14 @@ export function registerBuiltinDesktopCommands(
         let result: CmdExecutionResult;
         try {
           result = (await deps.remoteInvoke(ctx.deviceId, 'desktop-cmd:run', [
-            { sessionId: ctx.sessionId, cmdLine, cwd },
+            {
+              sessionId: ctx.sessionId,
+              cmdLine,
+              cwd,
+              // 控制端 Main 不持有被控端 route lock;把副窗口显式 fence 标记透传给
+              // 被控端,由其在 route lock 内复核持久化 active 状态。
+              ...(ctx.requireActiveSession ? { requireActiveSession: true } : {}),
+            },
           ])) as CmdExecutionResult;
         } catch (err) {
           log.warn('/cmd remote exec failed', err);
@@ -476,9 +483,23 @@ export function registerBuiltinDesktopCommands(
       // renderer 按会话来源路由)。本机路径与远程路径的动作语义一一对应。
       const remoteGoal = ctx.deviceId
         ? {
-            clearGoal: (id: string) => deps.remoteInvoke(ctx.deviceId!, 'maker:goal:clear', [id]),
+            // 第一参保持裸 sessionId(旧被控端按 requireString 解析、忽略尾参);
+            // 仅副窗口显式 fence 时追加第二参 { requireActiveSession },新被控端据此加锁。
+            clearGoal: (id: string) =>
+              deps.remoteInvoke(
+                ctx.deviceId!,
+                'maker:goal:clear',
+                ctx.requireActiveSession ? [id, { requireActiveSession: true }] : [id],
+              ),
             setGoal: (input: { sessionId: string; objective: string }) =>
-              deps.remoteInvoke(ctx.deviceId!, 'maker:goal:set', [input]),
+              deps.remoteInvoke(ctx.deviceId!, 'maker:goal:set', [
+                {
+                  ...input,
+                  // 副窗口显式 fence 标记透传给被控端 Main(append-only 字段,
+                  // 旧被控端忽略);被控端据此在 route lock 内复核持久化 active。
+                  ...(ctx.requireActiveSession ? { requireActiveSession: true } : {}),
+                },
+              ]),
           }
         : null;
       const controller = deps.getGoalController();
@@ -566,8 +587,15 @@ export function registerBuiltinDesktopCommands(
             ...(ctx.sessionId ? { originSessionId: ctx.sessionId } : {}),
           };
       try {
+        // 远程副窗口:把显式 fence 标记经隧道透传给被控端 Main(append-only 字段,
+        // 旧被控端忽略);被控端据此在 route lock 内复核持久化 active 状态。
+        const remoteReq = ctx.deviceId
+          ? { ...req, ...(ctx.requireActiveSession ? { requireActiveSession: true } : {}) }
+          : req;
         const { runId } = ctx.deviceId
-          ? ((await deps.remoteInvoke(ctx.deviceId, 'learn:start', [req])) as { runId: string })
+          ? ((await deps.remoteInvoke(ctx.deviceId, 'learn:start', [remoteReq])) as {
+              runId: string;
+            })
           : await controller!.startLearn(req);
         sendDesktopCommandToSender(ctx, { ...buildPayload('learn', ctx), learnRunId: runId });
       } catch (err) {

--- a/apps/desktop/src/main/commands/builtins.ts
+++ b/apps/desktop/src/main/commands/builtins.ts
@@ -102,7 +102,13 @@ function buildPayload(
     ...(ctx.sessionId ? { sessionId: ctx.sessionId } : {}),
     ...(ctx.workingDir ? { workingDir: ctx.workingDir } : {}),
     ...(ctx.args ? { args: ctx.args } : {}),
-    ...(ctx.sessionRouteLockHeld ? { requireActiveSession: true } : {}),
+    // Secondary-window dispatches carry an explicit lifecycle fence because
+    // their route lock lives on the source window.  Keep that fence when this
+    // command is broadcast to every window: otherwise a sibling primary
+    // window can replay /clear without the archived-session guard.
+    ...(ctx.sessionRouteLockHeld || ctx.requireActiveSession
+      ? { requireActiveSession: true }
+      : {}),
   };
 }
 

--- a/apps/desktop/src/main/commands/builtins.ts
+++ b/apps/desktop/src/main/commands/builtins.ts
@@ -46,6 +46,8 @@ export interface DesktopCommandTriggeredPayload {
   goalAction?: 'set' | 'cleared' | 'open-dialog';
   /** /learn 专用 —— 启动成功时的 runId(renderer 据此关联 learn:event 状态流)。 */
   learnRunId?: string;
+  /** Main-owned lifecycle fence propagated to every renderer in a broadcast. */
+  requireActiveSession?: boolean;
 }
 
 export interface CmdExecutionResult {
@@ -100,6 +102,7 @@ function buildPayload(
     ...(ctx.sessionId ? { sessionId: ctx.sessionId } : {}),
     ...(ctx.workingDir ? { workingDir: ctx.workingDir } : {}),
     ...(ctx.args ? { args: ctx.args } : {}),
+    ...(ctx.sessionRouteLockHeld ? { requireActiveSession: true } : {}),
   };
 }
 
@@ -396,7 +399,7 @@ export function registerBuiltinDesktopCommands(
         let result: CmdExecutionResult;
         try {
           result = (await deps.remoteInvoke(ctx.deviceId, 'desktop-cmd:run', [
-            { cmdLine, cwd },
+            { sessionId: ctx.sessionId, cmdLine, cwd },
           ])) as CmdExecutionResult;
         } catch (err) {
           log.warn('/cmd remote exec failed', err);
@@ -506,8 +509,15 @@ export function registerBuiltinDesktopCommands(
       }
       // /goal <objective> → 直接设/编辑目标并续跑。
       try {
-        if (remoteGoal) await remoteGoal.setGoal({ sessionId, objective: arg });
-        else await controller!.setGoal({ sessionId, objective: arg });
+        if (remoteGoal) {
+          await remoteGoal.setGoal({ sessionId, objective: arg });
+        } else {
+          await controller!.setGoal({
+            sessionId,
+            objective: arg,
+            ...(ctx.sessionRouteLockHeld ? { sessionRouteLockHeld: true } : {}),
+          });
+        }
         broadcastDesktopCommand({ ...buildPayload('goal', ctx), goalAction: 'set' });
       } catch (err) {
         log.warn('/goal setGoal failed', err);

--- a/apps/desktop/src/main/commands/registry.ts
+++ b/apps/desktop/src/main/commands/registry.ts
@@ -38,6 +38,12 @@ export interface DesktopCommandContext {
    */
   senderWebContentsId?: number;
   /**
+   * Main-owned lifecycle marker. A secondary-window command sets this only
+   * after it has acquired the source session route lock and rechecked the
+   * persisted session status. Renderer input with the same field is ignored.
+   */
+  sessionRouteLockHeld?: boolean;
+  /**
    * device-link 远程会话的归属设备 id(renderer 从 remoteProjectsStore 注册表填入,
    * 本机会话缺省)。业务语义在"会话归属设备"的命令(/goal /learn /cmd)据此把
    * 执行经隧道路由到被控端;纯控制端 UI 命令(/help /clear 等)忽略它。

--- a/apps/desktop/src/main/commands/registry.ts
+++ b/apps/desktop/src/main/commands/registry.ts
@@ -45,6 +45,12 @@ export interface DesktopCommandContext {
    * channel,权威校验在被控端三道 gate(remoteControlEnabled + 撤销黑名单 + allowlist)。
    */
   deviceId?: string;
+  /**
+   * Secondary windows set this for a local task command. It asks the Main
+   * process to reject dispatch when the task was archived after renderer-side
+   * command reconciliation; it never grants access on its own.
+   */
+  requireActiveSession?: boolean;
 }
 
 /**

--- a/apps/desktop/src/main/commands/remoteCmdIpc.ts
+++ b/apps/desktop/src/main/commands/remoteCmdIpc.ts
@@ -30,10 +30,19 @@ const log = createLogger('desktop-commands:remote-cmd');
 /** desktop-cmd:run channel 常量(allowlist / 控制端 builtins 同名字符串消费)。 */
 export const DESKTOP_CMD_RUN_CHANNEL = 'desktop-cmd:run';
 
+export interface RemoteCmdIpcDeps {
+  /** Trusted source marker from the device-link async context. */
+  isDeviceLinkInvoke(): boolean;
+  /** Serialize the remote command with archive/close for this session. */
+  withSessionLock<T>(sessionId: string, task: () => Promise<T>): Promise<T>;
+  /** Re-read the persisted session lifecycle while the lock is held. */
+  assertSessionActive(sessionId: string): Promise<void>;
+}
+
 /** 幂等保护:与 registerLearnIpc 同款 —— 可重试注册块内二次执行不 throw。 */
 let _registered = false;
 
-export function registerRemoteCmdIpc(): void {
+export function registerRemoteCmdIpc(deps: RemoteCmdIpcDeps): void {
   if (_registered) return;
   _registered = true;
   ipcMain.handle(
@@ -42,21 +51,31 @@ export function registerRemoteCmdIpc(): void {
       const obj = requireObject(input, 'input');
       const cmdLine = requireString(obj.cmdLine, 'cmdLine').trim();
       const cwd = requireString(obj.cwd, 'cwd');
+      const sessionId = typeof obj.sessionId === 'string' ? obj.sessionId.trim() : '';
       if (!cmdLine) throwIpcError('INVALID_PARAMS', 'cmdLine must not be empty');
-      if (!(await isRemoteWorkingDirAllowed(cwd))) {
-        throwIpcError('INVALID_PARAMS', `working directory not allowed: ${cwd}`);
-      }
-      log.info('remote /cmd exec ▶', { cmdLine, cwd });
-      const result = await runShellCommand({ cmdLine, cwd });
-      log.info('remote /cmd exec ◀', {
-        cmdLine,
-        cwd,
-        exitCode: result.exitCode,
-        elapsedMs: result.elapsedMs,
-        timedOut: result.timedOut,
-        spawnError: result.spawnError ?? null,
+      const run = async (): Promise<CmdExecutionResult> => {
+        if (!(await isRemoteWorkingDirAllowed(cwd))) {
+          throwIpcError('INVALID_PARAMS', `working directory not allowed: ${cwd}`);
+        }
+        log.info('remote /cmd exec ▶', { cmdLine, cwd, sessionId: sessionId || undefined });
+        const result = await runShellCommand({ cmdLine, cwd });
+        log.info('remote /cmd exec ◀', {
+          cmdLine,
+          cwd,
+          sessionId: sessionId || undefined,
+          exitCode: result.exitCode,
+          elapsedMs: result.elapsedMs,
+          timedOut: result.timedOut,
+          spawnError: result.spawnError ?? null,
+        });
+        return result;
+      };
+      if (!deps.isDeviceLinkInvoke()) return run();
+      if (!sessionId) throwIpcError('INVALID_PARAMS', 'sessionId required for remote /cmd');
+      return deps.withSessionLock(sessionId, async () => {
+        await deps.assertSessionActive(sessionId);
+        return run();
       });
-      return result;
     },
   );
   log.info('remote cmd IPC handler registered');

--- a/apps/desktop/src/main/commands/remoteCmdIpc.ts
+++ b/apps/desktop/src/main/commands/remoteCmdIpc.ts
@@ -52,6 +52,10 @@ export function registerRemoteCmdIpc(deps: RemoteCmdIpcDeps): void {
       const cmdLine = requireString(obj.cmdLine, 'cmdLine').trim();
       const cwd = requireString(obj.cwd, 'cwd');
       const sessionId = typeof obj.sessionId === 'string' ? obj.sessionId.trim() : '';
+      // Main-owned fence marker:device-link 合成 event 的 sender 为空,无法用窗口归属
+      // 判定 secondary;只有原始 renderer(控制端副窗口)显式请求时才 fence。primary
+      // remote task(主窗口)不带此标记,保持"向已归档任务发 /cmd 可恢复任务"的历史语义。
+      const requireActiveSession = obj.requireActiveSession === true;
       if (!cmdLine) throwIpcError('INVALID_PARAMS', 'cmdLine must not be empty');
       const run = async (): Promise<CmdExecutionResult> => {
         if (!(await isRemoteWorkingDirAllowed(cwd))) {
@@ -70,7 +74,9 @@ export function registerRemoteCmdIpc(deps: RemoteCmdIpcDeps): void {
         });
         return result;
       };
-      if (!deps.isDeviceLinkInvoke()) return run();
+      // 仅显式请求 active-session fence 的 device-link 调用走 route lock + 持久化复核;
+      // 本机 handler 调用(isDeviceLinkInvoke false)与未带标记的 primary remote 直通。
+      if (!deps.isDeviceLinkInvoke() || !requireActiveSession) return run();
       if (!sessionId) throwIpcError('INVALID_PARAMS', 'sessionId required for remote /cmd');
       return deps.withSessionLock(sessionId, async () => {
         await deps.assertSessionActive(sessionId);

--- a/apps/desktop/src/main/goal-host/__tests__/controller.test.ts
+++ b/apps/desktop/src/main/goal-host/__tests__/controller.test.ts
@@ -3060,6 +3060,50 @@ describe('GoalController', () => {
     await Promise.resolve();
   });
 
+  it('waits for a caller-held route lock before detaching resume-on-open dispatch', async () => {
+    let markDispatchStarted!: () => void;
+    let releaseDispatch!: (result: SessionSendResult) => void;
+    const dispatchStarted = new Promise<void>((resolve) => {
+      markDispatchStarted = resolve;
+    });
+    const pendingDispatch = new Promise<SessionSendResult>((resolve) => {
+      releaseDispatch = resolve;
+    });
+    const acquirePendingAgentSwitch = vi.fn(async () => () => {});
+    const local = makeController({ acquirePendingAgentSwitch });
+    vi.spyOn(local.session, 'send').mockImplementation(async (
+      message: Parameters<FakeSession['send']>[0],
+      opts: Parameters<FakeSession['send']>[1],
+    ): Promise<SessionSendResult> => {
+      const content = typeof message === 'string' ? message : message.content;
+      local.session.sends.push({ content, originKind: opts?.origin?.kind });
+      opts?.onDispatching?.();
+      markDispatchStarted();
+      return pendingDispatch;
+    });
+    await local.storage.set(seededGoal({ status: 'active', objective: 'hold the route' }));
+
+    let settled = false;
+    const resumePromise = local.controller.resumeOnOpen('s1', {
+      waitForDispatch: false,
+      sessionRouteLockHeld: true,
+    });
+    resumePromise.then(() => {
+      settled = true;
+    });
+    await dispatchStarted;
+    await Promise.resolve();
+
+    expect(settled).toBe(false);
+    expect(acquirePendingAgentSwitch).toHaveBeenCalledWith('s1', {
+      sessionRouteLockHeld: true,
+    });
+
+    releaseDispatch({ accepted: true });
+    await resumePromise;
+    expect(settled).toBe(true);
+  });
+
   it('converges a detached resume-on-open dispatch failure to blocked', async () => {
     let markDispatchStarted!: () => void;
     let releaseDispatch!: () => void;

--- a/apps/desktop/src/main/goal-host/__tests__/controller.test.ts
+++ b/apps/desktop/src/main/goal-host/__tests__/controller.test.ts
@@ -620,6 +620,22 @@ describe('GoalController', () => {
     expect(releaseAgentSwitchLock).toHaveBeenCalledTimes(1);
   });
 
+  it('reuses a caller-held session route lock for the first Goal dispatch', async () => {
+    const acquirePendingAgentSwitch = vi.fn(async () => () => {});
+    const local = makeController({ acquirePendingAgentSwitch });
+
+    await local.controller.setGoal({
+      sessionId: 's1',
+      objective: 'continue under the accepted route',
+      sessionRouteLockHeld: true,
+    });
+
+    expect(acquirePendingAgentSwitch).toHaveBeenCalledWith('s1', {
+      sessionRouteLockHeld: true,
+    });
+    expect(local.session.sends).toHaveLength(1);
+  });
+
   it('migrates the Goal listener to the switched session so the new engine turn can finalize (reviewer P1)', async () => {
     const oldSession = new FakeSession('s1', 'claude-code');
     const switchedSession = new FakeSession('s1', 'codex');

--- a/apps/desktop/src/main/goal-host/controller.ts
+++ b/apps/desktop/src/main/goal-host/controller.ts
@@ -651,7 +651,10 @@ export class GoalController {
         this.attachListener(sessionId);
         this.emit(updated);
         if (this.turns.get(sessionId) === activeBoundary) {
-          await this.fireTurn(sessionId, { throwOnRestoreFailure: true });
+          await this.fireTurn(sessionId, {
+            throwOnRestoreFailure: true,
+            sessionRouteLockHeld: input.sessionRouteLockHeld,
+          });
         }
       } catch (error) {
         if (this.turns.get(sessionId) === editBoundary) {
@@ -731,7 +734,10 @@ export class GoalController {
       this.attachListener(sessionId);
       this.emit(state);
       if (this.turns.get(sessionId) === activeBoundary) {
-        await this.fireTurn(sessionId, { throwOnRestoreFailure: true });
+        await this.fireTurn(sessionId, {
+          throwOnRestoreFailure: true,
+          sessionRouteLockHeld: input.sessionRouteLockHeld,
+        });
       }
     } catch (error) {
       if (this.turns.get(sessionId) === createBoundary) this.turns.delete(sessionId);
@@ -2295,6 +2301,7 @@ export class GoalController {
     opts?: {
       throwOnRestoreFailure?: boolean;
       throwOnUnpersistedRestoreFailure?: boolean;
+      sessionRouteLockHeld?: boolean;
     },
   ): Promise<void> {
     if (this.disposed) return;
@@ -2401,7 +2408,11 @@ export class GoalController {
       // apply、重新读取 live session 和 Session.send；否则并发 SET_MODEL 能在 fresh
       // session 创建后、send 前再次换 route，让本轮落到 UI 未显示的来源。
       releaseAgentSwitchLock =
-        (await this.deps.acquirePendingAgentSwitch?.(sessionId)) ?? (() => {});
+        (await (opts?.sessionRouteLockHeld
+          ? this.deps.acquirePendingAgentSwitch?.(sessionId, {
+              sessionRouteLockHeld: true,
+            })
+          : this.deps.acquirePendingAgentSwitch?.(sessionId))) ?? (() => {});
       if (!isCurrentLifecycle()) return;
       const session = await this.deps.ensureSession(sessionId);
       if (!isCurrentLifecycle()) return;

--- a/apps/desktop/src/main/goal-host/controller.ts
+++ b/apps/desktop/src/main/goal-host/controller.ts
@@ -1514,8 +1514,13 @@ export class GoalController {
     if (!this.isBusy(sessionId)) {
       const dispatch = this.fireTurn(sessionId, {
         throwOnUnpersistedRestoreFailure: true,
+        ...(opts?.sessionRouteLockHeld ? { sessionRouteLockHeld: true } : {}),
       });
-      if (opts?.waitForDispatch === false) {
+      // A caller-held route lock protects the entire lifecycle boundary. Do
+      // not detach the dispatch while that lock is still owned by the caller,
+      // otherwise the lock can be released before Session.send reaches the
+      // accepted side effect.
+      if (opts?.waitForDispatch === false && !opts?.sessionRouteLockHeld) {
         void dispatch.catch((error) => {
           this.deps.logger.warn('[goal] detached resume-on-open fire failed', {
             sessionId,

--- a/apps/desktop/src/main/goal-host/controller.ts
+++ b/apps/desktop/src/main/goal-host/controller.ts
@@ -748,7 +748,11 @@ export class GoalController {
     return (await this.deps.storage.get(sessionId)) ?? createdState;
   }
 
-  async updateGoal(sessionId: string, patch: GoalUpdatePatch): Promise<GoalState | null> {
+  async updateGoal(
+    sessionId: string,
+    patch: GoalUpdatePatch,
+    opts?: { sessionRouteLockHeld?: boolean },
+  ): Promise<GoalState | null> {
     if (this.disposed || this.disposing) return null;
     const normalized = normalizeGoalUpdatePatch(patch);
     const existingBoundary = this.turns.get(sessionId);
@@ -962,7 +966,11 @@ export class GoalController {
         objectiveChanged &&
         (changed.status === 'paused' || changed.status === 'blocked' || changed.status === 'usageLimited')
       ) {
-        await this.resumeGoal(sessionId);
+        // fence 已持有 route 锁时透传,避免 resumeGoal→fireTurn 二次加锁自死锁(#3262)。
+        await this.resumeGoal(
+          sessionId,
+          opts?.sessionRouteLockHeld ? { sessionRouteLockHeld: true } : undefined,
+        );
         return reconcileLifecycleChange();
       }
       this.emit(next);

--- a/apps/desktop/src/main/goal-host/controller.ts
+++ b/apps/desktop/src/main/goal-host/controller.ts
@@ -1178,7 +1178,10 @@ export class GoalController {
    * (与 setGoal 全清零相反),重挂 listener,空闲则立即续一轮。终态(complete/budgetLimited)
    * /已 active 不处理。
    */
-  async resumeGoal(sessionId: string, opts?: { auto?: boolean }): Promise<void> {
+  async resumeGoal(
+    sessionId: string,
+    opts?: { auto?: boolean; sessionRouteLockHeld?: boolean },
+  ): Promise<void> {
     if (this.disposed || this.disposing) return;
     let existingBoundary = this.turns.get(sessionId);
     let state: GoalState | null | undefined;
@@ -1325,7 +1328,13 @@ export class GoalController {
     this.attachListener(sessionId);
     this.emit(updated);
     if (!this.isBusy(sessionId)) {
-      await this.fireTurn(sessionId, { throwOnRestoreFailure: !opts?.auto });
+      await this.fireTurn(sessionId, {
+        throwOnRestoreFailure: !opts?.auto,
+        // 调用方(goal fence)已持有 session route lock:让 fireTurn 内的
+        // pending-agent-switch 走 holder 的 sessionRouteLockHeld 分支,
+        // 不再二次获取同一把非重入锁,避免自死锁(#3262 P2)。
+        ...(opts?.sessionRouteLockHeld ? { sessionRouteLockHeld: true } : {}),
+      });
     }
   }
 
@@ -1400,7 +1409,7 @@ export class GoalController {
    */
   async resumeOnOpen(
     sessionId: string,
-    opts?: { waitForDispatch?: boolean },
+    opts?: { waitForDispatch?: boolean; sessionRouteLockHeld?: boolean },
   ): Promise<void> {
     if (this.disposed || this.disposing) return;
     const pendingFailure = this.unpersistedDispatchFailures.get(sessionId);
@@ -1440,7 +1449,11 @@ export class GoalController {
     let restoreError: unknown;
     try {
       releaseAgentSwitchLock =
-        (await this.deps.acquirePendingAgentSwitch?.(sessionId)) ?? (() => {});
+        (await this.deps.acquirePendingAgentSwitch?.(
+          sessionId,
+          // goal fence 已持有 route lock 时透传标记,让 holder 跳过二次加锁(#3262 P2)。
+          opts?.sessionRouteLockHeld ? { sessionRouteLockHeld: true } : undefined,
+        )) ?? (() => {});
       if (this.disposed) return;
       if (this.turns.get(sessionId) !== lifecycleBoundary) return;
       session = await this.deps.ensureSession(sessionId);

--- a/apps/desktop/src/main/goal-host/types.ts
+++ b/apps/desktop/src/main/goal-host/types.ts
@@ -84,6 +84,8 @@ export interface GoalState {
 export interface SetGoalInput {
   sessionId: string;
   objective: string;
+  /** Internal Main marker: the caller already owns this session's route lock. */
+  sessionRouteLockHeld?: boolean;
   /** 留空则由 controller 从活动会话(SessionLike.agentKind)解析。 */
   agentKind?: AgentKind;
   /** 新建时的上限(GUI 新建弹窗的高级设置)。留空 → 走系统默认(getDefaults)。仅新建路径用;编辑改 objective 不动上限。 */
@@ -183,7 +185,10 @@ export interface GoalControllerDeps {
    * 锁住本 session、落实 deferred agent switch 并 bootstrap 新 live session。
    * 调用方在重新读取 live session 且 Session.send 返回后执行 release。
    */
-  acquirePendingAgentSwitch?: (sessionId: string) => Promise<() => void>;
+  acquirePendingAgentSwitch?: (
+    sessionId: string,
+    options?: { sessionRouteLockHeld?: boolean },
+  ) => Promise<() => void>;
   /** ← maker-ipc/register.isSessionInTurn(main 侧 turn 活跃跟踪)。 */
   isSessionInTurn(sessionId: string): boolean;
   /**

--- a/apps/desktop/src/main/learn-host/__tests__/registerIpc.test.ts
+++ b/apps/desktop/src/main/learn-host/__tests__/registerIpc.test.ts
@@ -1,0 +1,99 @@
+/**
+ * registerIpc.test.ts —— learn:start 的远程 lifecycle fence。
+ *
+ * device-link 合成 event 的 sender 为空,不能按窗口归属判定 secondary;fence 只在
+ * 原始 renderer(经隧道 req)显式带 requireActiveSession 时触发。primary remote
+ * task 不带该标记,保持历史语义。
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  handlers: new Map<string, (...args: unknown[]) => unknown>(),
+  startLearn: vi.fn(async (_req: unknown) => ({ runId: 'run-1' })),
+}));
+
+vi.mock('electron', () => ({
+  BrowserWindow: { getAllWindows: () => [] },
+  ipcMain: {
+    handle: (channel: string, handler: (...args: unknown[]) => unknown) => {
+      mocks.handlers.set(channel, handler);
+    },
+  },
+}));
+
+vi.mock('../../logger.js', () => ({
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() }),
+}));
+
+vi.mock('../../device-link/broadcast-tap.js', () => ({
+  tapWindowBroadcast: vi.fn(),
+}));
+
+vi.mock('../index.js', () => ({
+  getLearnController: () => ({ startLearn: mocks.startLearn }),
+}));
+
+import { LEARN_CHANNELS, registerLearnIpc, type LearnIpcLifecycleDeps } from '../registerIpc.js';
+
+function invoke(req: unknown): Promise<unknown> {
+  const handler = mocks.handlers.get(LEARN_CHANNELS.START);
+  if (!handler) throw new Error('learn:start handler not registered');
+  return Promise.resolve(handler({}, req));
+}
+
+describe('learn:start remote lifecycle fence', () => {
+  type SessionLock = <T>(sessionId: string, task: () => Promise<T>) => Promise<T>;
+  const isDeviceLinkInvoke = vi.fn(() => true);
+  const withSessionLock = vi.fn<SessionLock>(async (_sessionId, task) => task());
+  const assertSessionActive = vi.fn(async (_sessionId: string) => undefined);
+
+  // registerLearnIpc 有模块级幂等 guard,整文件只注册一次;lifecycle deps 是
+  // vi.fn,beforeEach clear 后仍可逐用例断言调用次数。
+  registerLearnIpc({
+    isDeviceLinkInvoke,
+    withSessionLock: withSessionLock as unknown as LearnIpcLifecycleDeps['withSessionLock'],
+    assertSessionActive,
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    isDeviceLinkInvoke.mockReturnValue(true);
+  });
+
+  it('fences a device-link learn:start only when requireActiveSession is explicitly requested', async () => {
+    await invoke({
+      input: '学习 X',
+      sourceKind: 'freetext',
+      originSessionId: 'rs',
+      requireActiveSession: true,
+    });
+
+    expect(withSessionLock).toHaveBeenCalledWith('rs', expect.any(Function));
+    expect(assertSessionActive).toHaveBeenCalledWith('rs');
+    // fence 已在锁内完成;requireActiveSession 是 dispatch-only 标记,必须在 IPC
+    // 边界剥离,不能流进 LearnController 的 run 记录 / 证据打包。
+    expect(mocks.startLearn).toHaveBeenCalledTimes(1);
+    const passedReq = mocks.startLearn.mock.calls[0]![0] as Record<string, unknown>;
+    expect(passedReq).not.toHaveProperty('requireActiveSession');
+    expect(passedReq).toMatchObject({
+      input: '学习 X',
+      sourceKind: 'freetext',
+      originSessionId: 'rs',
+    });
+  });
+
+  it('does not fence a primary remote learn:start without requireActiveSession', async () => {
+    await invoke({ input: '学习 Y', sourceKind: 'freetext', originSessionId: 'rs' });
+
+    expect(withSessionLock).not.toHaveBeenCalled();
+    expect(assertSessionActive).not.toHaveBeenCalled();
+    expect(mocks.startLearn).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fence when originSessionId is missing even with the marker', async () => {
+    await invoke({ input: 'hub:skill', sourceKind: 'hub', hubSlug: 'skill', requireActiveSession: true });
+
+    expect(withSessionLock).not.toHaveBeenCalled();
+    expect(mocks.startLearn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/desktop/src/main/learn-host/registerIpc.ts
+++ b/apps/desktop/src/main/learn-host/registerIpc.ts
@@ -23,6 +23,18 @@ import { LearnError } from './controller';
 
 const log = createLogger('learn-host:ipc');
 
+export interface LearnIpcLifecycleDeps {
+  isDeviceLinkInvoke(): boolean;
+  withSessionLock<T>(sessionId: string, task: () => Promise<T>): Promise<T>;
+  assertSessionActive(sessionId: string): Promise<void>;
+}
+
+const NOOP_LEARN_LIFECYCLE_DEPS: LearnIpcLifecycleDeps = {
+  isDeviceLinkInvoke: () => false,
+  withSessionLock: async (_sessionId, task) => task(),
+  assertSessionActive: async (_sessionId) => undefined,
+};
+
 /** learn:* channel 常量 —— preload 与 renderer 按同名字符串消费。 */
 export const LEARN_CHANNELS = {
   START: 'learn:start',
@@ -70,12 +82,20 @@ export function broadcastLearnEvent(payload: LearnEventPayload): void {
  *  二次注册直接 throw,反而让重试永远无法恢复(Greptile review,含复现)。 */
 let _learnIpcRegistered = false;
 
-export function registerLearnIpc(): void {
+export function registerLearnIpc(
+  lifecycle: LearnIpcLifecycleDeps = NOOP_LEARN_LIFECYCLE_DEPS,
+): void {
   if (_learnIpcRegistered) return;
   _learnIpcRegistered = true;
   ipcMain.handle(LEARN_CHANNELS.START, async (_event, req: LearnStartRequest) => {
     try {
-      return await mustController().startLearn(req);
+      const start = () => mustController().startLearn(req);
+      const sourceSessionId = req.originSessionId?.trim();
+      if (!lifecycle.isDeviceLinkInvoke() || !sourceSessionId) return await start();
+      return await lifecycle.withSessionLock(sourceSessionId, async () => {
+        await lifecycle.assertSessionActive(sourceSessionId);
+        return start();
+      });
     } catch (err) {
       rethrow(err);
     }

--- a/apps/desktop/src/main/learn-host/registerIpc.ts
+++ b/apps/desktop/src/main/learn-host/registerIpc.ts
@@ -89,9 +89,17 @@ export function registerLearnIpc(
   _learnIpcRegistered = true;
   ipcMain.handle(LEARN_CHANNELS.START, async (_event, req: LearnStartRequest) => {
     try {
-      const start = () => mustController().startLearn(req);
       const sourceSessionId = req.originSessionId?.trim();
-      if (!lifecycle.isDeviceLinkInvoke() || !sourceSessionId) return await start();
+      // device-link 合成 event sender 为空,不能按窗口归属判定 secondary;只在原始
+      // renderer(经隧道 req 透传)显式请求时 fence,primary remote task 保持历史语义。
+      const requireActiveSession = req.requireActiveSession === true;
+      // requireActiveSession 是 IPC dispatch-only 标记,不进入 LearnController:
+      // 剥离后再传,避免污染 controller 的 run 记录 / 证据打包。
+      const { requireActiveSession: _omit, ...controllerReq } = req;
+      void _omit;
+      const start = () => mustController().startLearn(controllerReq);
+      if (!lifecycle.isDeviceLinkInvoke() || !requireActiveSession || !sourceSessionId)
+        return await start();
       return await lifecycle.withSessionLock(sourceSessionId, async () => {
         await lifecycle.assertSessionActive(sourceSessionId);
         return start();

--- a/apps/desktop/src/main/localDb/__tests__/orcaTeamStore.test.ts
+++ b/apps/desktop/src/main/localDb/__tests__/orcaTeamStore.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { DbClient } from '../client/DbClient.js';
 import { clearCurrentDbClient, setCurrentDbClient } from '../client/current.js';
+import { setSessionRouteLockImplementation } from '../sessionRouteLock.js';
 import { tx as runInprocTx } from '../worker/opHandlers/tx.js';
 import { setSessionRouteLockImplementation } from '../sessionRouteLock.js';
 import { setSessionRuntimeCleanup } from '../sessionRuntimeCleanup.js';
@@ -157,6 +158,130 @@ describe('orcaTeamStore', () => {
     expect(h.compactSessionToolResultsBestEffort).toHaveBeenCalledTimes(1);
   });
 
+  it('rejects worker links that arrive after team shutdown begins', async () => {
+    const { archiveWorkersByTeam } = await import('../orcaTeamStore.js');
+    const client = createTestDbClient();
+    setCurrentDbClient(client, 'test-user');
+    await seedOrcaWorkers(client);
+    await client.exec('UPDATE orca_teams SET status = ? WHERE id = ?', ['completed', 'team-1']);
+
+    let releaseFirstLock!: () => void;
+    const firstLockGate = new Promise<void>((resolve) => {
+      releaseFirstLock = resolve;
+    });
+    const lockedSessionIds: string[] = [];
+    setSessionRouteLockImplementation(async (sessionId, task) => {
+      lockedSessionIds.push(sessionId);
+      if (sessionId === 'worker-session-1') await firstLockGate;
+      return task();
+    });
+
+    const archive = archiveWorkersByTeam('team-1');
+    await vi.waitFor(() => expect(lockedSessionIds).toEqual(['worker-session-1']));
+    await seedAdditionalWorkerSession(client, 'worker-session-3');
+    await expect(
+      client.tx('orca.upsertWorker', {
+        id: 'worker-3',
+        teamId: 'team-1',
+        sessionId: 'worker-session-3',
+        status: 'idle',
+        now: Date.now(),
+      }),
+    ).rejects.toThrow('Orca team team-1 is not active');
+
+    releaseFirstLock();
+    await expect(archive).resolves.toEqual(['worker-session-1', 'worker-session-2']);
+    expect(lockedSessionIds).toEqual(['worker-session-1', 'worker-session-2']);
+    await expect(
+      client.query<{ id: string; status: string }>(
+        'SELECT id, status FROM sessions WHERE id LIKE ? ORDER BY id',
+        ['worker-session-%'],
+      ),
+    ).resolves.toEqual([
+      { id: 'worker-session-1', status: 'archived' },
+      { id: 'worker-session-2', status: 'archived' },
+      { id: 'worker-session-3', status: 'active' },
+    ]);
+    await expect(
+      client.queryOne('SELECT id FROM orca_workers WHERE id = ?', ['worker-3']),
+    ).resolves.toBeUndefined();
+  });
+
+  it('serializes single-worker archival with the shared session route lock', async () => {
+    const { archiveSingleWorkerSession } = await import('../orcaTeamStore.js');
+    const client = createTestDbClient();
+    setCurrentDbClient(client, 'test-user');
+    await seedOrcaWorkers(client);
+
+    let releaseLock!: () => void;
+    const lockGate = new Promise<void>((resolve) => {
+      releaseLock = resolve;
+    });
+    const enteredLock = vi.fn();
+    setSessionRouteLockImplementation(async (sessionId, task) => {
+      enteredLock(sessionId);
+      await lockGate;
+      return task();
+    });
+
+    const archive = archiveSingleWorkerSession('worker-session-1');
+    await vi.waitFor(() => expect(enteredLock).toHaveBeenCalledWith('worker-session-1'));
+    await expect(
+      client.queryOne<{ status: string }>('SELECT status FROM sessions WHERE id = ?', [
+        'worker-session-1',
+      ]),
+    ).resolves.toEqual({ status: 'active' });
+
+    releaseLock();
+    await expect(archive).resolves.toBeUndefined();
+    await expect(
+      client.queryOne<{ status: string }>('SELECT status FROM sessions WHERE id = ?', [
+        'worker-session-1',
+      ]),
+    ).resolves.toEqual({ status: 'archived' });
+  });
+
+  it('keeps worker removal and session archival behind the worker route lock', async () => {
+    const { removeWorker } = await import('../orcaTeamStore.js');
+    const client = createTestDbClient();
+    setCurrentDbClient(client, 'test-user');
+    await seedOrcaWorkers(client);
+
+    let releaseLock!: () => void;
+    const lockGate = new Promise<void>((resolve) => {
+      releaseLock = resolve;
+    });
+    const enteredLock = vi.fn();
+    setSessionRouteLockImplementation(async (sessionId, task) => {
+      enteredLock(sessionId);
+      await lockGate;
+      return task();
+    });
+
+    const remove = removeWorker('worker-1');
+    await vi.waitFor(() => expect(enteredLock).toHaveBeenCalledWith('worker-session-1'));
+    await expect(
+      client.queryOne('SELECT id FROM orca_workers WHERE id = ?', ['worker-1']),
+    ).resolves.toEqual({ id: 'worker-1' });
+    await expect(
+      client.queryOne<{ status: string }>('SELECT status FROM sessions WHERE id = ?', [
+        'worker-session-1',
+      ]),
+    ).resolves.toEqual({ status: 'active' });
+
+    releaseLock();
+    await expect(remove).resolves.toBeUndefined();
+    await expect(
+      client.queryOne('SELECT id FROM orca_workers WHERE id = ?', ['worker-1']),
+    ).resolves.toBeUndefined();
+    await expect(
+      client.queryOne<{ status: string; orcaRole: string | null }>(
+        'SELECT status, orca_role AS orcaRole FROM sessions WHERE id = ?',
+        ['worker-session-1'],
+      ),
+    ).resolves.toEqual({ status: 'archived', orcaRole: null });
+  });
+
   it('reconciles only still-active workers from inactive teams', async () => {
     const { reconcileInactiveTeamWorkersForLead } = await import('../orcaTeamStore.js');
     const client = createTestDbClient();
@@ -257,6 +382,57 @@ describe('orcaTeamStore', () => {
       client,
       sessionId: 'worker-session-1',
     });
+  });
+
+  it('rejects worker links that arrive while inactive-team reconciliation is locked', async () => {
+    const { reconcileInactiveTeamWorkersForLead } = await import('../orcaTeamStore.js');
+    const client = createTestDbClient();
+    setCurrentDbClient(client, 'test-user');
+    await seedOrcaWorkers(client);
+    await client.exec('UPDATE orca_teams SET status = ? WHERE id = ?', ['completed', 'team-1']);
+
+    let releaseFirstLock!: () => void;
+    const firstLockGate = new Promise<void>((resolve) => {
+      releaseFirstLock = resolve;
+    });
+    const lockedSessionIds: string[] = [];
+    setSessionRouteLockImplementation(async (sessionId, task) => {
+      lockedSessionIds.push(sessionId);
+      if (sessionId === 'worker-session-1') await firstLockGate;
+      return task();
+    });
+
+    const reconcile = reconcileInactiveTeamWorkersForLead('lead-session-1');
+    await vi.waitFor(() => expect(lockedSessionIds).toEqual(['worker-session-1']));
+    await seedAdditionalWorkerSession(client, 'worker-session-3');
+    await expect(
+      client.tx('orca.upsertWorker', {
+        id: 'worker-3',
+        teamId: 'team-1',
+        sessionId: 'worker-session-3',
+        status: 'idle',
+        now: Date.now(),
+      }),
+    ).rejects.toThrow('Orca team team-1 is not active');
+
+    releaseFirstLock();
+    await expect(reconcile).resolves.toEqual(['worker-session-1', 'worker-session-2']);
+    expect(lockedSessionIds).toEqual(['worker-session-1', 'worker-session-2']);
+    await expect(
+      client.query<{ id: string; status: string }>(
+        'SELECT id, status FROM sessions WHERE id LIKE ? ORDER BY id',
+        ['worker-session-%'],
+      ),
+    ).resolves.toEqual([
+      { id: 'worker-session-1', status: 'archived' },
+      { id: 'worker-session-2', status: 'archived' },
+      { id: 'worker-session-3', status: 'active' },
+    ]);
+    await expect(
+      client.queryOne<{ status: string }>('SELECT status FROM orca_workers WHERE id = ?', [
+        'worker-3',
+      ]),
+    ).resolves.toBeUndefined();
   });
 
   it('preserves Pi worker identity in Orca projections', async () => {
@@ -498,5 +674,13 @@ async function seedOrcaWorkers(client: DbClient): Promise<void> {
   await client.exec(
     'INSERT INTO orca_workers (id, team_id, session_id, created_at, updated_at) VALUES (?, ?, ?, ?, ?)',
     ['worker-2', 'team-1', 'worker-session-2', now, now],
+  );
+}
+
+async function seedAdditionalWorkerSession(client: DbClient, sessionId: string): Promise<void> {
+  const now = Date.now();
+  await client.exec(
+    'INSERT INTO sessions (id, title, agent_kind, orca_role, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)',
+    [sessionId, sessionId, 'codex', 'worker', now, now],
   );
 }

--- a/apps/desktop/src/main/localDb/__tests__/orcaTeamStore.test.ts
+++ b/apps/desktop/src/main/localDb/__tests__/orcaTeamStore.test.ts
@@ -6,7 +6,6 @@ import type { DbClient } from '../client/DbClient.js';
 import { clearCurrentDbClient, setCurrentDbClient } from '../client/current.js';
 import { setSessionRouteLockImplementation } from '../sessionRouteLock.js';
 import { tx as runInprocTx } from '../worker/opHandlers/tx.js';
-import { setSessionRouteLockImplementation } from '../sessionRouteLock.js';
 import { setSessionRuntimeCleanup } from '../sessionRuntimeCleanup.js';
 import * as schema from '../schema.js';
 

--- a/apps/desktop/src/main/localDb/client/WorkerThreadTransport.ts
+++ b/apps/desktop/src/main/localDb/client/WorkerThreadTransport.ts
@@ -1067,16 +1067,21 @@ function orcaSetWorkerFocus(readyDb, args) {
 function orcaRemoveWorker(readyDb, args) {
   const payload = asRecord(args, 'orca.removeWorker args');
   const workerId = expectString(payload.workerId, 'workerId');
+  const sessionId = expectString(payload.sessionId, 'sessionId');
   const now = expectNumber(payload.now, 'now');
-  const selectWorker = readyDb.prepare('SELECT session_id AS sessionId FROM orca_workers WHERE id = ? LIMIT 1');
-  const deleteWorker = readyDb.prepare('DELETE FROM orca_workers WHERE id = ?');
+  const selectWorker = readyDb.prepare('SELECT 1 FROM orca_workers WHERE id = ? AND session_id = ? LIMIT 1');
+  const deleteWorker = readyDb.prepare('DELETE FROM orca_workers WHERE id = ? AND session_id = ?');
   const archiveSession = readyDb.prepare("UPDATE sessions SET status = 'archived', orca_role = NULL, updated_at = ? WHERE id = ? AND status != 'deleted'");
   return readyDb.transaction(() => {
-    const row = selectWorker.get(workerId);
-    if (!row) return null;
-    deleteWorker.run(workerId);
-    const archived = archiveSession.run(now, row.sessionId);
-    return archived.changes > 0 ? row.sessionId : null;
+    if (!selectWorker.get(workerId, sessionId)) {
+      return { removed: false, archivedSessionId: null };
+    }
+    deleteWorker.run(workerId, sessionId);
+    const archived = archiveSession.run(now, sessionId);
+    return {
+      removed: true,
+      archivedSessionId: archived.changes > 0 ? sessionId : null,
+    };
   })();
 }
 
@@ -1117,17 +1122,21 @@ function orcaReconcileInactiveTeamWorkersForLead(readyDb, args) {
     expectString(value, 'sessionIds[' + index + ']'),
   );
   const now = expectNumber(payload.now, 'now');
+  const selectCandidate = readyDb.prepare(
+    "SELECT 1 FROM orca_workers INNER JOIN orca_teams ON orca_workers.team_id = orca_teams.id WHERE orca_teams.lead_session_id = ? AND orca_teams.status != 'active' AND orca_workers.session_id = ? LIMIT 1",
+  );
   const finishWorkers = readyDb.prepare(
-    "UPDATE orca_workers SET status = 'done', updated_at = ? WHERE team_id IN (SELECT id FROM orca_teams WHERE lead_session_id = ? AND status != 'active')",
+    "UPDATE orca_workers SET status = 'done', updated_at = ? WHERE team_id IN (SELECT id FROM orca_teams WHERE lead_session_id = ? AND status != 'active') AND session_id = ?",
   );
   const archiveSession = readyDb.prepare(
     "UPDATE sessions SET status = 'archived', updated_at = ? WHERE id = ? AND status = 'active' AND EXISTS (SELECT 1 FROM orca_workers INNER JOIN orca_teams ON orca_workers.team_id = orca_teams.id WHERE orca_workers.session_id = sessions.id AND orca_teams.lead_session_id = ? AND orca_teams.status != 'active')",
   );
   return readyDb.transaction(() => {
-    finishWorkers.run(now, leadSessionId);
     const updatedIds = [];
-    for (const id of sessionIds) {
-      if (archiveSession.run(now, id, leadSessionId).changes > 0) updatedIds.push(id);
+    for (const sessionId of sessionIds) {
+      if (!selectCandidate.get(leadSessionId, sessionId)) continue;
+      finishWorkers.run(now, leadSessionId, sessionId);
+      if (archiveSession.run(now, sessionId, leadSessionId).changes > 0) updatedIds.push(sessionId);
     }
     return updatedIds;
   })();
@@ -1140,11 +1149,14 @@ function orcaUpsertWorker(readyDb, args) {
   const sessionId = expectString(payload.sessionId, 'sessionId');
   const now = expectNumber(payload.now, 'now');
   readyDb.transaction(() => {
+    // Keep final persistence atomic with team shutdown. The no-op write obtains
+    // SQLite's writer lock before checking status, so a late worker cannot be
+    // linked to a team that has already entered a terminal state.
     const activeTeam = readyDb.prepare(
-      "SELECT 1 FROM orca_teams WHERE id = ? AND status = 'active' LIMIT 1",
-    ).get(teamId);
-    if (!activeTeam) {
-      throw new Error('Orca team ' + teamId + ' is no longer active');
+      "UPDATE orca_teams SET updated_at = updated_at WHERE id = ? AND status = 'active'",
+    ).run(teamId);
+    if (activeTeam.changes !== 1) {
+      throw new Error('Orca team ' + teamId + ' is not active');
     }
     if (payload.focused === true) {
       readyDb.prepare('UPDATE orca_workers SET focused = 0, updated_at = ? WHERE team_id = ? AND focused = 1').run(now, teamId);

--- a/apps/desktop/src/main/localDb/client/WorkerThreadTransport.ts
+++ b/apps/desktop/src/main/localDb/client/WorkerThreadTransport.ts
@@ -1156,7 +1156,13 @@ function orcaUpsertWorker(readyDb, args) {
       "UPDATE orca_teams SET updated_at = updated_at WHERE id = ? AND status = 'active'",
     ).run(teamId);
     if (activeTeam.changes !== 1) {
-      throw new Error('Orca team ' + teamId + ' is not active');
+      const team = readyDb.prepare(
+        'SELECT status, completed_at FROM orca_teams WHERE id = ? LIMIT 1',
+      ).get(teamId);
+      const ended = team && team.completed_at != null;
+      throw new Error(
+        'Orca team ' + teamId + ' is ' + (ended ? 'no longer active' : 'not active'),
+      );
     }
     if (payload.focused === true) {
       readyDb.prepare('UPDATE orca_workers SET focused = 0, updated_at = ? WHERE team_id = ? AND focused = 1').run(now, teamId);

--- a/apps/desktop/src/main/localDb/client/__tests__/tx.test.ts
+++ b/apps/desktop/src/main/localDb/client/__tests__/tx.test.ts
@@ -2658,17 +2658,19 @@ describe('db worker tx handlers', () => {
         ['worker-1', 'team-1', 'worker', 'idle', 1, 1],
       );
 
-      const archivedSessionId = await client.tx<string | null>('orca.removeWorker', {
+      const removed = await client.tx('orca.removeWorker', {
         workerId: 'worker-1',
+        sessionId: 'worker',
         now: 999,
       });
-      const missingSessionId = await client.tx<string | null>('orca.removeWorker', {
+      const missing = await client.tx('orca.removeWorker', {
         workerId: 'missing',
+        sessionId: 'worker',
         now: 1000,
       });
 
-      expect(archivedSessionId).toBe('worker');
-      expect(missingSessionId).toBeNull();
+      expect(removed).toEqual({ removed: true, archivedSessionId: 'worker' });
+      expect(missing).toEqual({ removed: false, archivedSessionId: null });
       await expect(
         client.queryOne('SELECT id FROM orca_workers WHERE id = ?', ['worker-1']),
       ).resolves.toBeUndefined();
@@ -2682,6 +2684,35 @@ describe('db worker tx handlers', () => {
         updated_at: 999,
       });
     });
+  });
+
+  it.each([
+    { label: 'bundled worker', useInlineWorker: false },
+    { label: 'inline worker', useInlineWorker: true },
+  ])('orca.upsertWorker rejects an inactive team through the $label tx path', async ({ useInlineWorker }) => {
+    await withClient(
+      async (client) => {
+        await seedSession(client, 'lead');
+        await seedSession(client, 'late-worker', { orcaRole: 'worker' });
+        await client.exec(
+          'INSERT INTO orca_teams (id, lead_session_id, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?)',
+          ['team-1', 'lead', 'completed', 1, 1],
+        );
+
+        await expect(
+          client.tx('orca.upsertWorker', {
+            id: 'worker-1',
+            teamId: 'team-1',
+            sessionId: 'late-worker',
+            status: 'idle',
+            label: 'late',
+            now: 100,
+          }),
+        ).rejects.toThrow('Orca team team-1 is not active');
+        await expect(client.query('SELECT id FROM orca_workers')).resolves.toEqual([]);
+      },
+      { useInlineWorker },
+    );
   });
 
   it.each([
@@ -2724,7 +2755,7 @@ describe('db worker tx handlers', () => {
         await expect(
           client.tx('orca.archiveWorkersByTeam', {
             teamId: 'active-team',
-            sessionIds: ['active-worker'],
+            sessionIds: ['active-worker', 'archived-worker', 'deleted-worker'],
             now: 100,
           }),
         ).resolves.toEqual(['active-worker']);

--- a/apps/desktop/src/main/localDb/client/tx/types.ts
+++ b/apps/desktop/src/main/localDb/client/tx/types.ts
@@ -253,7 +253,13 @@ export interface OrcaSetWorkerFocusArgs {
 /** F-COLLAB: create_worker 派发失败时移除 worker link，并归档对应 session。 */
 export interface OrcaRemoveWorkerArgs {
   workerId: string;
+  sessionId: string;
   now: number;
+}
+
+export interface OrcaRemoveWorkerResult {
+  removed: boolean;
+  archivedSessionId: string | null;
 }
 
 /**
@@ -872,7 +878,7 @@ export type DbTxResultByName = {
   'orca.releaseWorkerCreationReservation': undefined;
   'orca.upsertWorker': undefined;
   'orca.setWorkerFocus': undefined;
-  'orca.removeWorker': string | null;
+  'orca.removeWorker': OrcaRemoveWorkerResult;
   'orca.cancelStaleTeams': undefined;
   'orca.archiveWorkersByTeam': string[];
   'orca.reconcileInactiveTeamWorkersForLead': string[];

--- a/apps/desktop/src/main/localDb/orcaTeamStore.ts
+++ b/apps/desktop/src/main/localDb/orcaTeamStore.ts
@@ -551,13 +551,27 @@ export async function restoreWorkerDoneIfIdle(workerId: string): Promise<boolean
  */
 export async function removeWorker(workerId: string): Promise<void> {
   const client = getDbClient();
-  const removedSessionId = await client.tx('orca.removeWorker', {
-    workerId,
-    now: Date.now(),
-  });
-  if (removedSessionId) {
-    broadcastSessionPatch(removedSessionId, { status: 'archived', orcaRole: null });
-    void compactSessionToolResultsBestEffort({ client, sessionId: removedSessionId });
+  for (;;) {
+    const [worker] = await client.drizzle
+      .select({ sessionId: orcaWorkers.sessionId })
+      .from(orcaWorkers)
+      .where(eq(orcaWorkers.id, workerId))
+      .limit(1);
+    if (!worker) return;
+
+    const result = await withSessionRouteLock(worker.sessionId, () =>
+      client.tx('orca.removeWorker', {
+        workerId,
+        sessionId: worker.sessionId,
+        now: Date.now(),
+      }),
+    );
+    if (!result.removed) continue;
+    if (result.archivedSessionId) {
+      broadcastSessionPatch(result.archivedSessionId, { status: 'archived', orcaRole: null });
+      void compactSessionToolResultsBestEffort({ client, sessionId: result.archivedSessionId });
+    }
+    return;
   }
 }
 

--- a/apps/desktop/src/main/localDb/worker/opHandlers/tx.ts
+++ b/apps/desktop/src/main/localDb/worker/opHandlers/tx.ts
@@ -1945,7 +1945,11 @@ function orcaUpsertWorker(db: Database.Database, args: unknown): void {
       "UPDATE orca_teams SET updated_at = updated_at WHERE id = ? AND status = 'active'",
     ).run(teamId);
     if (activeTeam.changes !== 1) {
-      throw new Error(`Orca team ${teamId} is not active`);
+      const team = db.prepare(
+        'SELECT status, completed_at FROM orca_teams WHERE id = ? LIMIT 1',
+      ).get(teamId) as { status?: unknown; completed_at?: unknown } | undefined;
+      const ended = team?.completed_at != null;
+      throw new Error(`Orca team ${teamId} is ${ended ? 'no longer active' : 'not active'}`);
     }
     if (payload.focused === true) {
       db.prepare('UPDATE orca_workers SET focused = 0, updated_at = ? WHERE team_id = ? AND focused = 1').run(now, teamId);

--- a/apps/desktop/src/main/localDb/worker/opHandlers/tx.ts
+++ b/apps/desktop/src/main/localDb/worker/opHandlers/tx.ts
@@ -1811,21 +1811,33 @@ function orcaSetWorkerFocus(db: Database.Database, args: unknown): void {
   })();
 }
 
-function orcaRemoveWorker(db: Database.Database, args: unknown): string | null {
+function orcaRemoveWorker(
+  db: Database.Database,
+  args: unknown,
+): { removed: boolean; archivedSessionId: string | null } {
   const payload = asRecord(args, 'orca.removeWorker args');
   const workerId = expectString(payload.workerId, 'workerId');
+  const sessionId = expectString(payload.sessionId, 'sessionId');
   const now = expectNumber(payload.now, 'now');
-  const selectWorker = db.prepare('SELECT session_id AS sessionId FROM orca_workers WHERE id = ? LIMIT 1');
-  const deleteWorker = db.prepare('DELETE FROM orca_workers WHERE id = ?');
-  const archiveSession = db.prepare("UPDATE sessions SET status = 'archived', orca_role = NULL, updated_at = ? WHERE id = ? AND status != 'deleted'");
+  const selectWorker = db.prepare(
+    'SELECT 1 FROM orca_workers WHERE id = ? AND session_id = ? LIMIT 1',
+  );
+  const deleteWorker = db.prepare('DELETE FROM orca_workers WHERE id = ? AND session_id = ?');
+  const archiveSession = db.prepare(
+    "UPDATE sessions SET status = 'archived', orca_role = NULL, updated_at = ? WHERE id = ? AND status != 'deleted'",
+  );
   const transaction = db.transaction(() => {
-    const row = selectWorker.get(workerId) as { sessionId: string } | undefined;
-    if (!row) return null;
-    deleteWorker.run(workerId);
-    const archived = archiveSession.run(now, row.sessionId);
-    return archived.changes > 0 ? row.sessionId : null;
+    if (!selectWorker.get(workerId, sessionId)) {
+      return { removed: false, archivedSessionId: null };
+    }
+    deleteWorker.run(workerId, sessionId);
+    const archived = archiveSession.run(now, sessionId);
+    return {
+      removed: true,
+      archivedSessionId: archived.changes > 0 ? sessionId : null,
+    };
   });
-  return transaction() as string | null;
+  return transaction() as { removed: boolean; archivedSessionId: string | null };
 }
 
 function orcaCancelStaleTeams(db: Database.Database, args: unknown): void {
@@ -1876,13 +1888,22 @@ function orcaReconcileInactiveTeamWorkersForLead(
     expectString(value, `sessionIds[${index}]`),
   );
   const now = expectNumber(payload.now, 'now');
+  const selectCandidate = db.prepare(
+    `SELECT 1
+       FROM orca_workers
+       INNER JOIN orca_teams ON orca_workers.team_id = orca_teams.id
+      WHERE orca_teams.lead_session_id = ?
+        AND orca_teams.status != 'active'
+        AND orca_workers.session_id = ?
+      LIMIT 1`,
+  );
   const finishWorkers = db.prepare(
     `UPDATE orca_workers
         SET status = 'done', updated_at = ?
       WHERE team_id IN (
         SELECT id FROM orca_teams
          WHERE lead_session_id = ? AND status != 'active'
-      )`,
+      ) AND session_id = ?`,
   );
   const archiveSession = db.prepare(
     `UPDATE sessions
@@ -1898,10 +1919,11 @@ function orcaReconcileInactiveTeamWorkersForLead(
         )`,
   );
   const transaction = db.transaction(() => {
-    finishWorkers.run(now, leadSessionId);
     const updatedIds: string[] = [];
-    for (const id of sessionIds) {
-      if (archiveSession.run(now, id, leadSessionId).changes > 0) updatedIds.push(id);
+    for (const sessionId of sessionIds) {
+      if (!selectCandidate.get(leadSessionId, sessionId)) continue;
+      finishWorkers.run(now, leadSessionId, sessionId);
+      if (archiveSession.run(now, sessionId, leadSessionId).changes > 0) updatedIds.push(sessionId);
     }
     return updatedIds;
   });
@@ -1915,11 +1937,15 @@ function orcaUpsertWorker(db: Database.Database, args: unknown): void {
   const sessionId = expectString(payload.sessionId, 'sessionId');
   const now = expectNumber(payload.now, 'now');
   db.transaction(() => {
+    // A no-op write acquires SQLite's writer lock before the active-team check.
+    // This serializes final worker persistence with markTeamEnded: either the
+    // worker commits first and the subsequent archive snapshot includes it, or
+    // the team ends first and this upsert fails without creating an orphan link.
     const activeTeam = db.prepare(
-      "SELECT 1 FROM orca_teams WHERE id = ? AND status = 'active' LIMIT 1",
-    ).get(teamId);
-    if (!activeTeam) {
-      throw new Error(`Orca team ${teamId} is no longer active`);
+      "UPDATE orca_teams SET updated_at = updated_at WHERE id = ? AND status = 'active'",
+    ).run(teamId);
+    if (activeTeam.changes !== 1) {
+      throw new Error(`Orca team ${teamId} is not active`);
     }
     if (payload.focused === true) {
       db.prepare('UPDATE orca_workers SET focused = 0, updated_at = ? WHERE team_id = ? AND focused = 1').run(now, teamId);

--- a/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
@@ -614,7 +614,7 @@ function createHarness(opts?: {
     sessionId: string,
     userClientId: string,
   ) => Promise<RecoveryContextSnapshot>;
-  isSessionActiveForRetry?: (sessionId: string) => Promise<boolean>;
+  isSessionActiveForManualDispatch?: (sessionId: string) => Promise<boolean>;
 }) {
   let running = false;
   let liveRunningOverride: boolean | null | 'unknown' = null;
@@ -784,8 +784,8 @@ function createHarness(opts?: {
     ...(opts?.getRecoveryContextSnapshot
       ? { getRecoveryContextSnapshot: opts.getRecoveryContextSnapshot }
       : {}),
-    ...(opts?.isSessionActiveForRetry
-      ? { isSessionActiveForRetry: opts.isSessionActiveForRetry }
+    ...(opts?.isSessionActiveForManualDispatch
+      ? { isSessionActiveForManualDispatch: opts.isSessionActiveForManualDispatch }
       : {}),
     beforeDispatchUserTurn,
     onUndispatchedUserTurn,
@@ -1910,6 +1910,31 @@ describe('AgentInputCoordinator send transaction', () => {
     }
   });
 
+  it('keeps an archived secondary-window queue paused when resume reaches main', async () => {
+    const isSessionActiveForManualDispatch = vi.fn(async () => false);
+    const h = createHarness({ isSessionActiveForManualDispatch });
+    const sid = 'resume-archived-secondary-window';
+    const first = makeItem('q-1', 'first');
+
+    h.setRunning(true);
+    h.coordinator.enqueue(sid, first);
+    await flush();
+    h.coordinator.stop(sid, { keepQueue: true, pauseQueue: true });
+    h.setRunning(false);
+    await flush();
+
+    await h.coordinator.resume(sid, { requireActiveSession: true });
+    await flush();
+
+    expect(isSessionActiveForManualDispatch).toHaveBeenCalledOnce();
+    expect(isSessionActiveForManualDispatch).toHaveBeenCalledWith(sid);
+    expect(h.sendToAgent).not.toHaveBeenCalled();
+    expect(latestProjection(h.projections)).toMatchObject({
+      queuePaused: true,
+      pendingQueue: [first],
+    });
+  });
+
   it('retries an interaction-unlocked queue when an external live reservation clears without a terminal event', async () => {
     vi.useFakeTimers();
     try {
@@ -2929,7 +2954,7 @@ describe('AgentInputCoordinator send transaction', () => {
     const progressRead = deferred<boolean>();
     let sessionActive = true;
     const isSessionActiveForRetry = vi.fn(async () => sessionActive);
-    const h = createHarness({ isSessionActiveForRetry });
+    const h = createHarness({ isSessionActiveForManualDispatch: isSessionActiveForRetry });
     const sid = 'retry-archived-during-history-read';
     h.setHasAssistantProgressAfter(async () => progressRead.promise);
 
@@ -2958,7 +2983,7 @@ describe('AgentInputCoordinator send transaction', () => {
 
   it('keeps main-window retry compatible with archived tasks when no lifecycle fence is requested', async () => {
     const isSessionActiveForRetry = vi.fn(async () => false);
-    const h = createHarness({ isSessionActiveForRetry });
+    const h = createHarness({ isSessionActiveForManualDispatch: isSessionActiveForRetry });
     const sid = 'retry-archived-main-window';
     h.setHasAssistantProgressAfter(async () => false);
 

--- a/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
@@ -5770,6 +5770,35 @@ describe('AgentInputCoordinator steer transaction', () => {
     expect(latestProjection(h.projections).steeringQueueClientIds).toEqual([]);
   });
 
+  it('clears the steer marker without fallback when the final lifecycle fence sees an archived task', async () => {
+    const h = createHarness();
+    const sid = 'inspection-secondary-steer-archived-race';
+    const queued = makeItem('q-archived', 'still here');
+    h.setRunning(true);
+    h.coordinator.enqueue(sid, makeItem('q-running', 'running'));
+    h.coordinator.enqueue(sid, queued);
+    h.steerToAgent.mockRejectedValueOnce(
+      new Error('SESSION_NOT_ACTIVE: Session is no longer active'),
+    );
+
+    await expect(
+      h.coordinator.steer(sid, queued, {
+        removeFromQueue: true,
+        requireActiveSession: true,
+      }),
+    ).resolves.toBe(false);
+
+    expect(h.steerToAgent).toHaveBeenCalledWith(
+      sid,
+      { type: 'user', content: 'still here' },
+      expect.objectContaining({ requireActiveSession: true }),
+    );
+    const projection = latestProjection(h.projections);
+    expect(projection.pendingQueue.map((item) => item.clientId)).toContain('q-archived');
+    expect(projection.steeringQueueClientIds).toEqual([]);
+    expect(projection.error).toBeNull();
+  });
+
   it('does not report a policy-blocked control steer as delivered', async () => {
     const h = createHarness();
     h.setScreenUserMessage(

--- a/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
@@ -2941,7 +2941,7 @@ describe('AgentInputCoordinator send transaction', () => {
     await flush();
     expect(latestProjection(h.projections).recovery?.kind).toBe('active-turn');
 
-    const retryPromise = h.coordinator.retryLastError(sid);
+    const retryPromise = h.coordinator.retryLastError(sid, { requireActiveSession: true });
     await flush();
     expect(isSessionActiveForRetry).not.toHaveBeenCalled();
 
@@ -2954,6 +2954,25 @@ describe('AgentInputCoordinator send transaction', () => {
     expect(isSessionActiveForRetry).toHaveBeenCalledWith(sid);
     expect(h.sendToAgent).toHaveBeenCalledTimes(1);
     expect(latestProjection(h.projections).recovery?.kind).toBe('active-turn');
+  });
+
+  it('keeps main-window retry compatible with archived tasks when no lifecycle fence is requested', async () => {
+    const isSessionActiveForRetry = vi.fn(async () => false);
+    const h = createHarness({ isSessionActiveForRetry });
+    const sid = 'retry-archived-main-window';
+    h.setHasAssistantProgressAfter(async () => false);
+
+    h.coordinator.enqueue(sid, makeItem('q-first', 'original task'));
+    await flush();
+    h.setRunning(false);
+    h.coordinator.onTurnEvent(sid, 'error', 'turn failed');
+    await flush();
+
+    await h.coordinator.retryLastError(sid);
+    await flush();
+
+    expect(isSessionActiveForRetry).not.toHaveBeenCalled();
+    expect(h.sendToAgent).toHaveBeenCalledTimes(2);
   });
 
   it('active-turn retry falls back to resending the original text when the turn produced nothing', async () => {

--- a/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
@@ -610,7 +610,11 @@ function unsupportedChatBridgeImageError(feature = "input content part 'input_im
 }
 
 function createHarness(opts?: {
-  getRecoveryContextSnapshot?: (sessionId: string, userClientId: string) => Promise<RecoveryContextSnapshot>;
+  getRecoveryContextSnapshot?: (
+    sessionId: string,
+    userClientId: string,
+  ) => Promise<RecoveryContextSnapshot>;
+  isSessionActiveForRetry?: (sessionId: string) => Promise<boolean>;
 }) {
   let running = false;
   let liveRunningOverride: boolean | null | 'unknown' = null;
@@ -779,6 +783,9 @@ function createHarness(opts?: {
         : Promise.resolve(false),
     ...(opts?.getRecoveryContextSnapshot
       ? { getRecoveryContextSnapshot: opts.getRecoveryContextSnapshot }
+      : {}),
+    ...(opts?.isSessionActiveForRetry
+      ? { isSessionActiveForRetry: opts.isSessionActiveForRetry }
       : {}),
     beforeDispatchUserTurn,
     onUndispatchedUserTurn,
@@ -2916,6 +2923,37 @@ describe('AgentInputCoordinator send transaction', () => {
     await flush();
     // The retry was superseded — no second dispatch occurred.
     expect(h.sendToAgent).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not enqueue a retry when the session is archived during the history read', async () => {
+    const progressRead = deferred<boolean>();
+    let sessionActive = true;
+    const isSessionActiveForRetry = vi.fn(async () => sessionActive);
+    const h = createHarness({ isSessionActiveForRetry });
+    const sid = 'retry-archived-during-history-read';
+    h.setHasAssistantProgressAfter(async () => progressRead.promise);
+
+    h.coordinator.enqueue(sid, makeItem('q-first', 'original task'));
+    await flush();
+
+    h.setRunning(false);
+    h.coordinator.onTurnEvent(sid, 'error', 'turn failed');
+    await flush();
+    expect(latestProjection(h.projections).recovery?.kind).toBe('active-turn');
+
+    const retryPromise = h.coordinator.retryLastError(sid);
+    await flush();
+    expect(isSessionActiveForRetry).not.toHaveBeenCalled();
+
+    sessionActive = false;
+    progressRead.resolve(false);
+    await retryPromise;
+    await flush();
+
+    expect(isSessionActiveForRetry).toHaveBeenCalledOnce();
+    expect(isSessionActiveForRetry).toHaveBeenCalledWith(sid);
+    expect(h.sendToAgent).toHaveBeenCalledTimes(1);
+    expect(latestProjection(h.projections).recovery?.kind).toBe('active-turn');
   });
 
   it('active-turn retry falls back to resending the original text when the turn produced nothing', async () => {

--- a/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
@@ -1935,6 +1935,28 @@ describe('AgentInputCoordinator send transaction', () => {
     });
   });
 
+  it('fences every queued item when a secondary window resumes a paused batch', async () => {
+    const h = createHarness({ isSessionActiveForManualDispatch: async () => true });
+    const sid = 'resume-secondary-window-batch-fence';
+    h.setRunning(true);
+    h.coordinator.enqueue(sid, makeItem('q-1', 'first'));
+    h.coordinator.enqueue(sid, makeItem('q-2', 'second'));
+    await flush();
+    h.coordinator.stop(sid, { keepQueue: true, pauseQueue: true });
+
+    await h.coordinator.resume(sid, { requireActiveSession: true });
+    await flush();
+
+    expect(h.coordinator.getQueueControlSnapshot(sid).pendingQueue).toEqual([
+      expect.objectContaining({ clientId: 'q-1', requireActiveSession: true }),
+      expect.objectContaining({ clientId: 'q-2', requireActiveSession: true }),
+    ]);
+    expect(h.coordinator.getProjection(sid).pendingQueue).toEqual([
+      expect.not.objectContaining({ requireActiveSession: expect.anything() }),
+      expect.not.objectContaining({ requireActiveSession: expect.anything() }),
+    ]);
+  });
+
   it('retries an interaction-unlocked queue when an external live reservation clears without a terminal event', async () => {
     vi.useFakeTimers();
     try {
@@ -2998,6 +3020,26 @@ describe('AgentInputCoordinator send transaction', () => {
 
     expect(isSessionActiveForRetry).not.toHaveBeenCalled();
     expect(h.sendToAgent).toHaveBeenCalledTimes(2);
+  });
+
+  it('carries a secondary-window retry fence into the replacement queue item', async () => {
+    const h = createHarness({ isSessionActiveForManualDispatch: async () => true });
+    const sid = 'retry-secondary-window-final-fence';
+    h.setHasAssistantProgressAfter(async () => false);
+
+    h.coordinator.enqueue(sid, makeItem('q-first', 'original task'));
+    await flush();
+    h.setRunning(false);
+    h.coordinator.onTurnEvent(sid, 'error', 'turn failed');
+    await flush();
+
+    await h.coordinator.retryLastError(sid, { requireActiveSession: true });
+    await flush();
+
+    expect(h.sendToAgent).toHaveBeenCalledTimes(2);
+    expect(h.sendToAgent.mock.calls[1]?.[3]).toEqual(
+      expect.objectContaining({ requireActiveSession: true }),
+    );
   });
 
   it('active-turn retry falls back to resending the original text when the turn produced nothing', async () => {
@@ -5797,6 +5839,79 @@ describe('AgentInputCoordinator steer transaction', () => {
     expect(projection.pendingQueue.map((item) => item.clientId)).toContain('q-archived');
     expect(projection.steeringQueueClientIds).toEqual([]);
     expect(projection.error).toBeNull();
+  });
+
+  it('keeps the lifecycle fence when a secondary-window steer falls back to a queued turn', async () => {
+    const gate = deferred<{ action: 'allow' }>();
+    const h = createHarness();
+    const sid = 'secondary-window-steer-fallback-archived-race';
+    const queued = makeItem('q-fallback-archived', 'do not revive');
+    h.setScreenUserMessage(async () => gate.promise);
+    h.sendToAgent.mockRejectedValueOnce(
+      new Error('SESSION_NOT_ACTIVE: Session is no longer active'),
+    );
+
+    await expect(
+      h.coordinator.steer(sid, queued, { requireActiveSession: true }),
+    ).resolves.toBe(true);
+    await flush();
+    expect(h.sendToAgent).not.toHaveBeenCalled();
+
+    gate.resolve({ action: 'allow' });
+    await flush();
+
+    expect(h.sendToAgent).toHaveBeenCalledWith(
+      sid,
+      { type: 'user', content: 'do not revive' },
+      queued.createOpts,
+      expect.objectContaining({ requireActiveSession: true }),
+    );
+    expect(h.onDiscardedQueuedMessage).toHaveBeenCalledWith(
+      sid,
+      expect.objectContaining({
+        clientId: queued.clientId,
+        requireActiveSession: true,
+      }),
+    );
+    expect(latestProjection(h.projections)).toMatchObject({
+      pendingQueue: [],
+      error: null,
+      recovery: null,
+    });
+  });
+
+  it('drops a queued secondary-window input when the final lifecycle fence sees an archived task', async () => {
+    const gate = deferred<{ action: 'allow' }>();
+    const h = createHarness();
+    const sid = 'secondary-window-queued-archived-race';
+    const queued = makeItem('q-archived', 'do not revive');
+    h.setScreenUserMessage(async () => gate.promise);
+    h.sendToAgent.mockRejectedValueOnce(
+      new Error('SESSION_NOT_ACTIVE: Session is no longer active'),
+    );
+
+    h.coordinator.enqueue(sid, queued, { requireActiveSession: true });
+    await flush();
+    expect(h.sendToAgent).not.toHaveBeenCalled();
+
+    gate.resolve({ action: 'allow' });
+    await flush();
+
+    expect(h.sendToAgent).toHaveBeenCalledWith(
+      sid,
+      { type: 'user', content: 'do not revive' },
+      queued.createOpts,
+      expect.objectContaining({ requireActiveSession: true }),
+    );
+    expect(h.onDiscardedQueuedMessage).toHaveBeenCalledWith(
+      sid,
+      expect.objectContaining({ clientId: queued.clientId, requireActiveSession: true }),
+    );
+    expect(latestProjection(h.projections)).toMatchObject({
+      pendingQueue: [],
+      error: null,
+      recovery: null,
+    });
   });
 
   it('does not report a policy-blocked control steer as delivered', async () => {
@@ -9126,6 +9241,26 @@ describe('AgentInputCoordinator crash-recovery queue snapshots (issue #761)', ()
       .toEqual(expect.objectContaining({ clientId: restored.clientId, text: command }));
   });
 
+  it('keeps a lifecycle fence in the crash snapshot but omits it from projections', async () => {
+    const h = createHarness();
+    const sid = 'snapshot-secondary-window-lifecycle-fence';
+    await h.coordinator.ensureQueueRestored(sid);
+    h.setRunning(true);
+
+    h.coordinator.enqueue(sid, makeItem('q-1', 'queued'), { requireActiveSession: true });
+    await flush();
+
+    expect(h.coordinator.getProjection(sid).pendingQueue[0]?.requireActiveSession).toBeUndefined();
+    expect(h.coordinator.getQueueControlSnapshot(sid).pendingQueue[0]).toMatchObject({
+      clientId: 'q-1',
+      requireActiveSession: true,
+    });
+    expect(h.persistQueueSnapshot.mock.calls.at(-1)?.[1][0]).toMatchObject({
+      clientId: 'q-1',
+      requireActiveSession: true,
+    });
+  });
+
   it('persists the queue after restore and shrinks the snapshot once the head crosses the DB boundary', async () => {
     const h = createHarness();
     const sid = 'snapshot-persist';
@@ -10537,6 +10672,22 @@ describe('AgentInputCoordinator scheduler 排队心跳(review 反馈回归)', ()
 });
 
 describe('AgentInputCoordinator replaceQueuedMessage(Orca lead 排队消息修改)', () => {
+  it('preserves a Main-owned lifecycle fence across full-row replacement', async () => {
+    const h = createHarness();
+    const sid = 'replace-secondary-window-lifecycle-fence';
+    h.setRunning(true);
+    h.coordinator.enqueue(sid, makeItem('q-1', 'before'), { requireActiveSession: true });
+    await flush();
+
+    expect(h.coordinator.replaceQueuedMessage(sid, 'q-1', makeItem('q-1', 'after'))).toBe(true);
+
+    expect(h.coordinator.getQueueControlSnapshot(sid).pendingQueue[0]).toMatchObject({
+      clientId: 'q-1',
+      text: 'after',
+      requireActiveSession: true,
+    });
+  });
+
   it('原位整条替换 pending 条目:位置不变、投影与崩溃快照同步新内容', async () => {
     const h = createHarness();
     const sid = 'replace-pending';

--- a/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
@@ -3042,6 +3042,36 @@ describe('AgentInputCoordinator send transaction', () => {
     );
   });
 
+  it('restores a secondary-window retry recovery when the final lifecycle fence wins', async () => {
+    const h = createHarness({ isSessionActiveForManualDispatch: async () => true });
+    const sid = 'retry-secondary-window-fence-wins-after-retry';
+    h.setHasAssistantProgressAfter(async () => false);
+
+    h.coordinator.enqueue(sid, makeItem('q-first', 'original task'));
+    await flush();
+    h.setRunning(false);
+    h.coordinator.onTurnEvent(sid, 'error', 'original retry failure');
+    await flush();
+    h.persistTerminalSendError.mockClear();
+    h.sendToAgent.mockRejectedValueOnce(
+      new Error('[SESSION_NOT_ACTIVE] Session was archived before dispatch'),
+    );
+
+    await h.coordinator.retryLastError(sid, { requireActiveSession: true });
+    await flush();
+
+    const projection = latestProjection(h.projections);
+    expect(projection).toMatchObject({
+      error: 'original retry failure',
+      recovery: { kind: 'active-turn' },
+    });
+    expect(h.persistTerminalSendError).toHaveBeenCalledWith(sid, 'original retry failure');
+    expect(h.onDiscardedQueuedMessage).toHaveBeenCalledWith(
+      sid,
+      expect.objectContaining({ requireActiveSession: true }),
+    );
+  });
+
   it('active-turn retry falls back to resending the original text when the turn produced nothing', async () => {
     const h = createHarness();
     const sid = 'retry-continue-no-progress';

--- a/apps/desktop/src/main/maker-ipc/__tests__/goalHandlers.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/goalHandlers.test.ts
@@ -326,7 +326,7 @@ describe('goal remote lifecycle fence', () => {
 
     expect(withSessionLock).toHaveBeenCalledWith('rs', expect.any(Function));
     expect(assertSessionActive).toHaveBeenCalledWith('rs');
-    expect(mocks.updateGoal).toHaveBeenCalledWith('rs', { objective: 'updated objective' });
+    expect(mocks.updateGoal).toHaveBeenCalledWith('rs', { objective: 'updated objective' }, { sessionRouteLockHeld: true });
   });
 
   it('does not fence a primary remote GOAL_UPDATE without requireActiveSession', async () => {
@@ -465,7 +465,7 @@ describe('goal local secondary-window lifecycle fence', () => {
     expect(assertSessionActive).toHaveBeenCalledWith('s1');
     expect(mocks.updateGoal).toHaveBeenCalledWith('s1', {
       objective: 'edited in secondary window',
-    });
+    }, { sessionRouteLockHeld: true });
   });
 
   it('fences a local secondary-window GOAL_CLEAR even with a bare sessionId', async () => {

--- a/apps/desktop/src/main/maker-ipc/__tests__/goalHandlers.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/goalHandlers.test.ts
@@ -295,4 +295,76 @@ describe('goal remote lifecycle fence', () => {
     expect(assertSessionActive).toHaveBeenCalledWith('rs');
     expect(mocks.clearGoal).toHaveBeenCalledWith('rs');
   });
+
+  it('does not fence GOAL_RESUME for a bare sessionId string (old wire shape, primary remote)', async () => {
+    const resumeHandler = mocks.handlers.get(MAKER_INVOKE.GOAL_RESUME)!;
+    await resumeHandler({}, 'rs');
+
+    expect(withSessionLock).not.toHaveBeenCalled();
+    expect(assertSessionActive).not.toHaveBeenCalled();
+    expect(mocks.resumeGoal).toHaveBeenCalledWith('rs');
+  });
+
+  it('fences GOAL_RESUME only when the trailing fenceOpts.requireActiveSession is true', async () => {
+    const resumeHandler = mocks.handlers.get(MAKER_INVOKE.GOAL_RESUME)!;
+    await resumeHandler({}, 'rs', { requireActiveSession: true });
+
+    expect(withSessionLock).toHaveBeenCalledWith('rs', expect.any(Function));
+    expect(assertSessionActive).toHaveBeenCalledWith('rs');
+    expect(mocks.resumeGoal).toHaveBeenCalledWith('rs');
+  });
+
+  it('fences a device-link GOAL_UPDATE only when requireActiveSession is explicitly requested', async () => {
+    mocks.updateGoal.mockResolvedValueOnce({ sessionId: 'rs' });
+    const updateHandler = mocks.handlers.get(MAKER_INVOKE.GOAL_UPDATE)!;
+    await updateHandler({}, {
+      sessionId: 'rs',
+      patch: { objective: 'updated objective' },
+      requireActiveSession: true,
+    });
+
+    expect(withSessionLock).toHaveBeenCalledWith('rs', expect.any(Function));
+    expect(assertSessionActive).toHaveBeenCalledWith('rs');
+    expect(mocks.updateGoal).toHaveBeenCalledWith('rs', { objective: 'updated objective' });
+  });
+
+  it('does not fence a primary remote GOAL_UPDATE without requireActiveSession', async () => {
+    mocks.updateGoal.mockResolvedValueOnce({ sessionId: 'rs' });
+    const updateHandler = mocks.handlers.get(MAKER_INVOKE.GOAL_UPDATE)!;
+    await updateHandler({}, {
+      sessionId: 'rs',
+      patch: { objective: 'updated objective' },
+    });
+
+    expect(withSessionLock).not.toHaveBeenCalled();
+    expect(assertSessionActive).not.toHaveBeenCalled();
+    expect(mocks.updateGoal).toHaveBeenCalledWith('rs', { objective: 'updated objective' });
+  });
+
+  it('blocks GOAL_RESUME for an archived session when the active-session assertion rejects', async () => {
+    assertSessionActive.mockRejectedValueOnce(new Error('session is archived'));
+    const resumeHandler = mocks.handlers.get(MAKER_INVOKE.GOAL_RESUME)!;
+
+    await expect(resumeHandler({}, 'rs', { requireActiveSession: true })).rejects.toThrow(
+      'session is archived',
+    );
+    expect(withSessionLock).toHaveBeenCalledWith('rs', expect.any(Function));
+    expect(mocks.resumeGoal).not.toHaveBeenCalled();
+  });
+
+  it('blocks GOAL_UPDATE for an archived session when the active-session assertion rejects', async () => {
+    assertSessionActive.mockRejectedValueOnce(new Error('session is archived'));
+    mocks.updateGoal.mockResolvedValueOnce({ sessionId: 'rs' });
+    const updateHandler = mocks.handlers.get(MAKER_INVOKE.GOAL_UPDATE)!;
+
+    await expect(
+      updateHandler({}, {
+        sessionId: 'rs',
+        patch: { objective: 'updated objective' },
+        requireActiveSession: true,
+      }),
+    ).rejects.toThrow('session is archived');
+    expect(withSessionLock).toHaveBeenCalledWith('rs', expect.any(Function));
+    expect(mocks.updateGoal).not.toHaveBeenCalled();
+  });
 });

--- a/apps/desktop/src/main/maker-ipc/__tests__/goalHandlers.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/goalHandlers.test.ts
@@ -311,7 +311,8 @@ describe('goal remote lifecycle fence', () => {
 
     expect(withSessionLock).toHaveBeenCalledWith('rs', expect.any(Function));
     expect(assertSessionActive).toHaveBeenCalledWith('rs');
-    expect(mocks.resumeGoal).toHaveBeenCalledWith('rs');
+    // fence 已持有 route lock:透传 sessionRouteLockHeld,避免 resumeGoal→fireTurn 二次加锁。
+    expect(mocks.resumeGoal).toHaveBeenCalledWith('rs', { sessionRouteLockHeld: true });
   });
 
   it('fences a device-link GOAL_UPDATE only when requireActiveSession is explicitly requested', async () => {
@@ -359,7 +360,10 @@ describe('goal remote lifecycle fence', () => {
 
     expect(withSessionLock).toHaveBeenCalledWith('rs', expect.any(Function));
     expect(assertSessionActive).toHaveBeenCalledWith('rs');
-    expect(mocks.resumeOnOpen).toHaveBeenCalledWith('rs', { waitForDispatch: false });
+    expect(mocks.resumeOnOpen).toHaveBeenCalledWith('rs', {
+      waitForDispatch: false,
+      sessionRouteLockHeld: true,
+    });
   });
 
   it('does not fence GET_STATUS resumeOnOpen for a primary remote without the marker', async () => {
@@ -446,7 +450,7 @@ describe('goal local secondary-window lifecycle fence', () => {
     expect(isSecondaryWindowEvent).toHaveBeenCalledWith(SECONDARY_EVENT);
     expect(withSessionLock).toHaveBeenCalledWith('s1', expect.any(Function));
     expect(assertSessionActive).toHaveBeenCalledWith('s1');
-    expect(mocks.resumeGoal).toHaveBeenCalledWith('s1');
+    expect(mocks.resumeGoal).toHaveBeenCalledWith('s1', { sessionRouteLockHeld: true });
   });
 
   it('fences a local secondary-window GOAL_UPDATE without requireActiveSession', async () => {
@@ -525,7 +529,10 @@ describe('goal local secondary-window lifecycle fence', () => {
     expect(isSecondaryWindowEvent).toHaveBeenCalledWith(SECONDARY_EVENT);
     expect(withSessionLock).toHaveBeenCalledWith('s1', expect.any(Function));
     expect(assertSessionActive).toHaveBeenCalledWith('s1');
-    expect(mocks.resumeOnOpen).toHaveBeenCalledWith('s1', { waitForDispatch: false });
+    expect(mocks.resumeOnOpen).toHaveBeenCalledWith('s1', {
+      waitForDispatch: false,
+      sessionRouteLockHeld: true,
+    });
   });
 
   it('does not fence a primary local main-window GET_STATUS resumeOnOpen', async () => {

--- a/apps/desktop/src/main/maker-ipc/__tests__/goalHandlers.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/goalHandlers.test.ts
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   resumeOnOpen: vi.fn(),
   resumeGoal: vi.fn(),
   updateGoal: vi.fn(),
+  clearGoal: vi.fn(),
 }));
 
 vi.mock('electron', () => ({
@@ -27,6 +28,7 @@ vi.mock('../../goal-host/index.js', () => ({
         resumeOnOpen: mocks.resumeOnOpen,
         resumeGoal: mocks.resumeGoal,
         updateGoal: mocks.updateGoal,
+        clearGoal: mocks.clearGoal,
       }
     : null,
 }));
@@ -45,7 +47,7 @@ import {
   GoalUpdateSupersededError,
 } from '../../goal-host/controller.js';
 import { MAKER_INVOKE } from '../channels.js';
-import { registerGoalHandlers } from '../goal.js';
+import { registerGoalHandlers, type GoalHandlerLifecycleDeps } from '../goal.js';
 
 function handlerFor(channel: string): (...args: unknown[]) => unknown {
   const handler = mocks.handlers.get(channel);
@@ -228,5 +230,69 @@ describe('goal update IPC errors', () => {
     );
 
     await expect(result).rejects.toMatchObject({ code: 'GOAL_NOT_FOUND' });
+  });
+});
+
+describe('goal remote lifecycle fence', () => {
+  type SessionLock = <T>(sessionId: string, task: () => Promise<T>) => Promise<T>;
+  const isDeviceLinkInvoke = vi.fn(() => true);
+  const withSessionLock = vi.fn<SessionLock>(
+    async (_sessionId, task) => task(),
+  );
+  const assertSessionActive = vi.fn(async (_sessionId: string) => undefined);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.handlers.clear();
+    mocks.controllerAvailable = true;
+    isDeviceLinkInvoke.mockReturnValue(true);
+    registerGoalHandlers({
+      isDeviceLinkInvoke,
+      withSessionLock: withSessionLock as unknown as GoalHandlerLifecycleDeps['withSessionLock'],
+      assertSessionActive,
+    });
+  });
+
+  it('fences a device-link GOAL_SET only when requireActiveSession is explicitly requested', async () => {
+    const setHandler = mocks.handlers.get(MAKER_INVOKE.GOAL_SET)!;
+    await setHandler({}, { sessionId: 'rs', objective: '目标', requireActiveSession: true });
+
+    expect(withSessionLock).toHaveBeenCalledWith('rs', expect.any(Function));
+    expect(assertSessionActive).toHaveBeenCalledWith('rs');
+    expect(mocks.setGoal).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionId: 'rs', objective: '目标', sessionRouteLockHeld: true }),
+    );
+  });
+
+  it('does not fence a primary remote GOAL_SET without requireActiveSession', async () => {
+    const setHandler = mocks.handlers.get(MAKER_INVOKE.GOAL_SET)!;
+    await setHandler({}, { sessionId: 'rs', objective: '目标' });
+
+    expect(withSessionLock).not.toHaveBeenCalled();
+    expect(assertSessionActive).not.toHaveBeenCalled();
+    expect(mocks.setGoal).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionId: 'rs', objective: '目标' }),
+    );
+    expect(mocks.setGoal).not.toHaveBeenCalledWith(
+      expect.objectContaining({ sessionRouteLockHeld: true }),
+    );
+  });
+
+  it('does not fence GOAL_CLEAR for a bare sessionId string (old wire shape, primary remote)', async () => {
+    const clearHandler = mocks.handlers.get(MAKER_INVOKE.GOAL_CLEAR)!;
+    await clearHandler({}, 'rs');
+
+    expect(withSessionLock).not.toHaveBeenCalled();
+    expect(assertSessionActive).not.toHaveBeenCalled();
+    expect(mocks.clearGoal).toHaveBeenCalledWith('rs');
+  });
+
+  it('fences GOAL_CLEAR only when the trailing fenceOpts.requireActiveSession is true', async () => {
+    const clearHandler = mocks.handlers.get(MAKER_INVOKE.GOAL_CLEAR)!;
+    await clearHandler({}, 'rs', { requireActiveSession: true });
+
+    expect(withSessionLock).toHaveBeenCalledWith('rs', expect.any(Function));
+    expect(assertSessionActive).toHaveBeenCalledWith('rs');
+    expect(mocks.clearGoal).toHaveBeenCalledWith('rs');
   });
 });

--- a/apps/desktop/src/main/maker-ipc/__tests__/goalHandlers.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/goalHandlers.test.ts
@@ -352,6 +352,46 @@ describe('goal remote lifecycle fence', () => {
     expect(mocks.resumeGoal).not.toHaveBeenCalled();
   });
 
+  it('fences the side-effecting resumeOnOpen inside GET_STATUS when requireActiveSession is set', async () => {
+    mocks.getStatus.mockResolvedValue({ sessionId: 'rs', status: 'active' });
+    const getStatusHandler = mocks.handlers.get(MAKER_INVOKE.GOAL_GET_STATUS)!;
+    await getStatusHandler({}, 'rs', { requireActiveSession: true });
+
+    expect(withSessionLock).toHaveBeenCalledWith('rs', expect.any(Function));
+    expect(assertSessionActive).toHaveBeenCalledWith('rs');
+    expect(mocks.resumeOnOpen).toHaveBeenCalledWith('rs', { waitForDispatch: false });
+  });
+
+  it('does not fence GET_STATUS resumeOnOpen for a primary remote without the marker', async () => {
+    mocks.getStatus
+      .mockResolvedValueOnce({ sessionId: 'rs', status: 'active' })
+      .mockResolvedValueOnce({ sessionId: 'rs', status: 'active' });
+    const getStatusHandler = mocks.handlers.get(MAKER_INVOKE.GOAL_GET_STATUS)!;
+    await getStatusHandler({}, 'rs');
+
+    expect(withSessionLock).not.toHaveBeenCalled();
+    expect(assertSessionActive).not.toHaveBeenCalled();
+    expect(mocks.resumeOnOpen).toHaveBeenCalledWith('rs', { waitForDispatch: false });
+  });
+
+  it('skips resumeOnOpen for GET_STATUS when the fence reports the session archived', async () => {
+    mocks.getStatus.mockResolvedValue({ sessionId: 'rs', status: 'active' });
+    // 真实 assertSessionActiveForManualDispatch 用 throwIpcError 抛 PRECONDITION_FAILED +
+    // SESSION_NOT_ACTIVE 标记;GET_STATUS 据此降级为不 resumeOnOpen、返回恢复前快照。
+    const archived = new Error('SESSION_NOT_ACTIVE: Session rs is no longer active') as Error & {
+      code: string;
+    };
+    archived.code = 'PRECONDITION_FAILED';
+    assertSessionActive.mockRejectedValueOnce(archived);
+    const getStatusHandler = mocks.handlers.get(MAKER_INVOKE.GOAL_GET_STATUS)!;
+    const result = await getStatusHandler({}, 'rs', { requireActiveSession: true });
+
+    expect(withSessionLock).toHaveBeenCalledWith('rs', expect.any(Function));
+    expect(mocks.resumeOnOpen).not.toHaveBeenCalled();
+    // 降级返回恢复前的 active 快照,不把读取变成报错。
+    expect(result).toEqual({ sessionId: 'rs', status: 'active' });
+  });
+
   it('blocks GOAL_UPDATE for an archived session when the active-session assertion rejects', async () => {
     assertSessionActive.mockRejectedValueOnce(new Error('session is archived'));
     mocks.updateGoal.mockResolvedValueOnce({ sessionId: 'rs' });
@@ -474,5 +514,30 @@ describe('goal local secondary-window lifecycle fence', () => {
     expect(withSessionLock).not.toHaveBeenCalled();
     expect(assertSessionActive).not.toHaveBeenCalled();
     expect(mocks.updateGoal).toHaveBeenCalledWith('s1', { objective: 'edited in main window' });
+  });
+
+  it('fences the resumeOnOpen inside a local secondary-window GET_STATUS (no marker needed)', async () => {
+    mocks.getStatus.mockResolvedValue({ sessionId: 's1', status: 'active' });
+    const getStatusHandler = mocks.handlers.get(MAKER_INVOKE.GOAL_GET_STATUS)!;
+    // 裸 sessionId,无 requireActiveSession —— 本地副窗口靠真实 sender 自动 fence。
+    await getStatusHandler(SECONDARY_EVENT, 's1');
+
+    expect(isSecondaryWindowEvent).toHaveBeenCalledWith(SECONDARY_EVENT);
+    expect(withSessionLock).toHaveBeenCalledWith('s1', expect.any(Function));
+    expect(assertSessionActive).toHaveBeenCalledWith('s1');
+    expect(mocks.resumeOnOpen).toHaveBeenCalledWith('s1', { waitForDispatch: false });
+  });
+
+  it('does not fence a primary local main-window GET_STATUS resumeOnOpen', async () => {
+    mocks.getStatus
+      .mockResolvedValueOnce({ sessionId: 's1', status: 'active' })
+      .mockResolvedValueOnce({ sessionId: 's1', status: 'active' });
+    const getStatusHandler = mocks.handlers.get(MAKER_INVOKE.GOAL_GET_STATUS)!;
+    await getStatusHandler(MAIN_EVENT, 's1');
+
+    expect(isSecondaryWindowEvent).toHaveBeenCalledWith(MAIN_EVENT);
+    expect(withSessionLock).not.toHaveBeenCalled();
+    expect(assertSessionActive).not.toHaveBeenCalled();
+    expect(mocks.resumeOnOpen).toHaveBeenCalledWith('s1', { waitForDispatch: false });
   });
 });

--- a/apps/desktop/src/main/maker-ipc/__tests__/goalHandlers.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/goalHandlers.test.ts
@@ -368,3 +368,111 @@ describe('goal remote lifecycle fence', () => {
     expect(mocks.updateGoal).not.toHaveBeenCalled();
   });
 });
+
+// Reviewer P2 (PRRT_kwDOTgdRUs6b0AHd):本地副窗口 GoalIndicator 的 resume/update/clear
+// 走真实 event.sender,此前因既非 device-link、renderer 也不带 requireActiveSession 标记而
+// 绕过 active-session 门禁。这里钉住"按真实 sender 识别本地副窗口 → 一律 fence"。
+describe('goal local secondary-window lifecycle fence', () => {
+  type SessionLock = <T>(sessionId: string, task: () => Promise<T>) => Promise<T>;
+  const isDeviceLinkInvoke = vi.fn(() => false);
+  const withSessionLock = vi.fn<SessionLock>(
+    async (_sessionId, task) => task(),
+  );
+  const assertSessionActive = vi.fn(async (_sessionId: string) => undefined);
+  const isSecondaryWindowEvent = vi.fn((event: unknown) => event === SECONDARY_EVENT);
+
+  // 主窗口事件(sender 不是副窗口);副窗口事件(sender 命中 secondaryWindows)。
+  const MAIN_EVENT = { sender: { id: 1 } };
+  const SECONDARY_EVENT = { sender: { id: 2 } };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.handlers.clear();
+    mocks.controllerAvailable = true;
+    isDeviceLinkInvoke.mockReturnValue(false);
+    isSecondaryWindowEvent.mockImplementation((event: unknown) => event === SECONDARY_EVENT);
+    registerGoalHandlers({
+      isDeviceLinkInvoke,
+      withSessionLock: withSessionLock as unknown as GoalHandlerLifecycleDeps['withSessionLock'],
+      assertSessionActive,
+      isSecondaryWindowEvent,
+    });
+  });
+
+  it('fences a local secondary-window GOAL_RESUME even with a bare sessionId (no marker)', async () => {
+    const resumeHandler = mocks.handlers.get(MAKER_INVOKE.GOAL_RESUME)!;
+    await resumeHandler(SECONDARY_EVENT, 's1');
+
+    expect(isSecondaryWindowEvent).toHaveBeenCalledWith(SECONDARY_EVENT);
+    expect(withSessionLock).toHaveBeenCalledWith('s1', expect.any(Function));
+    expect(assertSessionActive).toHaveBeenCalledWith('s1');
+    expect(mocks.resumeGoal).toHaveBeenCalledWith('s1');
+  });
+
+  it('fences a local secondary-window GOAL_UPDATE without requireActiveSession', async () => {
+    mocks.updateGoal.mockResolvedValueOnce({ sessionId: 's1' });
+    const updateHandler = mocks.handlers.get(MAKER_INVOKE.GOAL_UPDATE)!;
+    await updateHandler(SECONDARY_EVENT, {
+      sessionId: 's1',
+      patch: { objective: 'edited in secondary window' },
+    });
+
+    expect(withSessionLock).toHaveBeenCalledWith('s1', expect.any(Function));
+    expect(assertSessionActive).toHaveBeenCalledWith('s1');
+    expect(mocks.updateGoal).toHaveBeenCalledWith('s1', {
+      objective: 'edited in secondary window',
+    });
+  });
+
+  it('fences a local secondary-window GOAL_CLEAR even with a bare sessionId', async () => {
+    const clearHandler = mocks.handlers.get(MAKER_INVOKE.GOAL_CLEAR)!;
+    await clearHandler(SECONDARY_EVENT, 's1');
+
+    expect(withSessionLock).toHaveBeenCalledWith('s1', expect.any(Function));
+    expect(assertSessionActive).toHaveBeenCalledWith('s1');
+    expect(mocks.clearGoal).toHaveBeenCalledWith('s1');
+  });
+
+  it('fences a local secondary-window GOAL_SET and marks the route lock held', async () => {
+    const setHandler = mocks.handlers.get(MAKER_INVOKE.GOAL_SET)!;
+    await setHandler(SECONDARY_EVENT, { sessionId: 's1', objective: '目标' });
+
+    expect(withSessionLock).toHaveBeenCalledWith('s1', expect.any(Function));
+    expect(assertSessionActive).toHaveBeenCalledWith('s1');
+    expect(mocks.setGoal).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionId: 's1', objective: '目标', sessionRouteLockHeld: true }),
+    );
+  });
+
+  it('blocks a secondary-window GOAL_RESUME for an archived session', async () => {
+    assertSessionActive.mockRejectedValueOnce(new Error('session is archived'));
+    const resumeHandler = mocks.handlers.get(MAKER_INVOKE.GOAL_RESUME)!;
+
+    await expect(resumeHandler(SECONDARY_EVENT, 's1')).rejects.toThrow('session is archived');
+    expect(withSessionLock).toHaveBeenCalledWith('s1', expect.any(Function));
+    expect(mocks.resumeGoal).not.toHaveBeenCalled();
+  });
+
+  it('does not fence a primary local main-window GOAL_RESUME (historical resume semantics)', async () => {
+    const resumeHandler = mocks.handlers.get(MAKER_INVOKE.GOAL_RESUME)!;
+    await resumeHandler(MAIN_EVENT, 's1');
+
+    expect(isSecondaryWindowEvent).toHaveBeenCalledWith(MAIN_EVENT);
+    expect(withSessionLock).not.toHaveBeenCalled();
+    expect(assertSessionActive).not.toHaveBeenCalled();
+    expect(mocks.resumeGoal).toHaveBeenCalledWith('s1');
+  });
+
+  it('does not fence a primary local main-window GOAL_UPDATE', async () => {
+    mocks.updateGoal.mockResolvedValueOnce({ sessionId: 's1' });
+    const updateHandler = mocks.handlers.get(MAKER_INVOKE.GOAL_UPDATE)!;
+    await updateHandler(MAIN_EVENT, {
+      sessionId: 's1',
+      patch: { objective: 'edited in main window' },
+    });
+
+    expect(withSessionLock).not.toHaveBeenCalled();
+    expect(assertSessionActive).not.toHaveBeenCalled();
+    expect(mocks.updateGoal).toHaveBeenCalledWith('s1', { objective: 'edited in main window' });
+  });
+});

--- a/apps/desktop/src/main/maker-ipc/__tests__/makerSendTransaction.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/makerSendTransaction.test.ts
@@ -403,6 +403,29 @@ describe('maker SEND transaction', () => {
       .toBeUndefined();
   });
 
+  it('rechecks the durable active state before a guarded direct send', async () => {
+    const assertSessionActiveForManualDispatch = vi
+      .fn()
+      .mockRejectedValue(
+        Object.assign(new Error('Session is archived'), { code: 'PRECONDITION_FAILED' }),
+      );
+    const { deps, session } = createDeps({ assertSessionActiveForManualDispatch });
+    const transaction = createMakerSendTransaction(deps);
+
+    await expect(
+      transaction.sendToAgentAccepted(
+        'session-1',
+        { type: 'user', content: '[UI_ACTION_TRIGGER]continue' },
+        undefined,
+        { requireActiveSession: true },
+      ),
+    ).rejects.toMatchObject({ code: 'PRECONDITION_FAILED' });
+
+    expect(assertSessionActiveForManualDispatch).toHaveBeenCalledOnce();
+    expect(assertSessionActiveForManualDispatch).toHaveBeenCalledWith('session-1');
+    expect(session.send).not.toHaveBeenCalled();
+  });
+
   it('links attachment messages to the accepted Pi transcript entry only for Pi attachments', async () => {
     const { deps, session } = createDeps();
     session.agentKind = 'pi';

--- a/apps/desktop/src/main/maker-ipc/__tests__/makerSendTransaction.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/makerSendTransaction.test.ts
@@ -409,7 +409,13 @@ describe('maker SEND transaction', () => {
       .mockRejectedValue(
         Object.assign(new Error('Session is archived'), { code: 'PRECONDITION_FAILED' }),
       );
-    const { deps, session } = createDeps({ assertSessionActiveForManualDispatch });
+    const applyPendingAgentSwitch = vi.fn();
+    const prepareUnhealthySession = vi.fn();
+    const { deps, session } = createDeps({
+      assertSessionActiveForManualDispatch,
+      applyPendingAgentSwitch,
+      prepareUnhealthySession,
+    });
     const transaction = createMakerSendTransaction(deps);
 
     await expect(
@@ -423,6 +429,8 @@ describe('maker SEND transaction', () => {
 
     expect(assertSessionActiveForManualDispatch).toHaveBeenCalledOnce();
     expect(assertSessionActiveForManualDispatch).toHaveBeenCalledWith('session-1');
+    expect(applyPendingAgentSwitch).not.toHaveBeenCalled();
+    expect(prepareUnhealthySession).not.toHaveBeenCalled();
     expect(session.send).not.toHaveBeenCalled();
   });
 

--- a/apps/desktop/src/main/maker-ipc/__tests__/reviewStartHandler.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/reviewStartHandler.test.ts
@@ -89,6 +89,7 @@ function makeDeps(
   return {
     assertCaller: vi.fn(),
     waitUntilReady: vi.fn(async () => undefined),
+    acquireSourceSessionLifecycle: vi.fn(async () => () => {}),
     createRunId: vi.fn(() => `run-${++id}`),
     createReviewerSessionId: vi.fn(() => `reviewer-${id}`),
     owner: { instanceId: 'main-instance-1', processId: 123 },
@@ -186,6 +187,26 @@ describe('maker:review:start IPC lifecycle', () => {
     expect(deps.assertCaller).toHaveBeenCalledTimes(2);
     expect(deps.waitUntilReady).not.toHaveBeenCalled();
     expect(deps.prepareRun).not.toHaveBeenCalled();
+  });
+
+  it('runs the source lifecycle fence before preparing any Review side effect', async () => {
+    const harness = new IpcHarness();
+    const reviewer = new FakeReviewer();
+    const acquireSourceSessionLifecycle = vi.fn(async () => {
+      throw new Error('source task archived');
+    });
+    const deps = makeDeps(reviewer, { acquireSourceSessionLifecycle });
+    registerReviewStartHandler(harness, deps);
+
+    await expect(harness.invoke(MAKER_INVOKE.START_REVIEW, reviewRequest())).rejects.toThrow(
+      'source task archived',
+    );
+
+    expect(acquireSourceSessionLifecycle).toHaveBeenCalledWith(expect.anything(), 'source-1');
+    expect(deps.prepareRun).not.toHaveBeenCalled();
+    expect(deps.acquireSourceLease).not.toHaveBeenCalled();
+    expect(deps.createSourceCard).not.toHaveBeenCalled();
+    expect(deps.startReviewer).not.toHaveBeenCalled();
   });
 
   it('runs card, bootstrap, accepted send, and completed result through the real handler', async () => {

--- a/apps/desktop/src/main/maker-ipc/__tests__/reviewStartHandler.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/reviewStartHandler.test.ts
@@ -434,6 +434,60 @@ describe('maker:review:start IPC lifecycle', () => {
     expect(deps.startReviewer).toHaveBeenCalledTimes(1);
   });
 
+  it('reserves the in-process slot before awaiting the lifecycle lock so a concurrent start cannot clobber it', async () => {
+    const harness = new IpcHarness();
+    const reviewer = new FakeReviewer();
+    let releaseLifecycle!: () => void;
+    const lifecyclePending = new Promise<void>((resolve) => {
+      releaseLifecycle = resolve;
+    });
+    const acquireSourceSessionLifecycle = vi
+      .fn<ReviewStartHandlerDeps['acquireSourceSessionLifecycle']>()
+      .mockImplementationOnce(async () => {
+        await lifecyclePending;
+        return () => {};
+      })
+      .mockResolvedValue(() => {});
+    const deps = makeDeps(reviewer, { acquireSourceSessionLifecycle });
+    registerReviewStartHandler(harness, deps);
+
+    // A enters and parks on the lifecycle lock (first await after the slot set).
+    const first = harness.invoke(MAKER_INVOKE.START_REVIEW, reviewRequest());
+    await vi.waitFor(() => expect(acquireSourceSessionLifecycle).toHaveBeenCalledTimes(1));
+
+    // B arrives while A is still awaiting the lock. With the upfront reservation
+    // it must be rejected at has() and never reach acquireSourceSessionLifecycle.
+    await expect(harness.invoke(MAKER_INVOKE.START_REVIEW, reviewRequest())).rejects.toMatchObject({
+      code: 'SESSION_RUNNING',
+    });
+    expect(acquireSourceSessionLifecycle).toHaveBeenCalledTimes(1);
+    expect(deps.prepareRun).not.toHaveBeenCalled();
+
+    releaseLifecycle();
+    await expect(first).resolves.toMatchObject({ ok: true, runId: 'run-1' });
+  });
+
+  it('releases its in-process reservation if acquiring the lifecycle lock fails, allowing a retry', async () => {
+    const harness = new IpcHarness();
+    const reviewer = new FakeReviewer();
+    const acquireSourceSessionLifecycle = vi
+      .fn<ReviewStartHandlerDeps['acquireSourceSessionLifecycle']>()
+      .mockRejectedValueOnce(new Error('source task archived'))
+      .mockResolvedValueOnce(() => {});
+    const deps = makeDeps(reviewer, { acquireSourceSessionLifecycle });
+    registerReviewStartHandler(harness, deps);
+
+    await expect(harness.invoke(MAKER_INVOKE.START_REVIEW, reviewRequest())).rejects.toThrow(
+      'source task archived',
+    );
+    // No leaked reservation → the retry passes has() and succeeds.
+    await expect(harness.invoke(MAKER_INVOKE.START_REVIEW, reviewRequest())).resolves.toMatchObject({
+      ok: true,
+      runId: 'run-2',
+    });
+    expect(acquireSourceSessionLifecycle).toHaveBeenCalledTimes(2);
+  });
+
   it('rejects a provider send failure before dispatch and permits retry', async () => {
     const harness = new IpcHarness();
     const reviewer = new FakeReviewer();

--- a/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
+++ b/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
@@ -730,6 +730,21 @@ interface PendingAutoResumeRecovery {
   attemptToken: number;
 }
 
+/**
+ * Secondary-window Retry clears the visible recovery before its replacement
+ * reaches the final lifecycle fence. Keep that recovery just long enough to
+ * restore it if the task is archived in that last dispatch window.
+ */
+interface PendingManualRetryRecovery {
+  sessionId: string;
+  stateRef: SessionInputState;
+  recovery: NonNullable<AgentInputRecovery>;
+  error: string | null;
+  errorReason: string | null;
+  toolLoop: AgentInputToolLoopDetails | null;
+  stickyError: string | null;
+}
+
 function createInitialInputState(
   generation = 0,
   clearBoundaryMs: number | null = null,
@@ -1054,6 +1069,8 @@ export class AgentInputCoordinator {
    * 并用 stateRef 防止 clearSession 后迟到的旧结果复活新上下文。
    */
   private readonly pendingAutoResumeRecoveries = new Map<string, PendingAutoResumeRecovery>();
+  /** Secondary-window retry checkpoints, keyed by the replacement queue item. */
+  private readonly pendingManualRetryRecoveries = new Map<string, PendingManualRetryRecovery>();
   /** transient busy 期间同一 auto item 已尝试过的派发次数。 */
   private readonly autoResumeDispatchAttempts = new Map<string, number>();
 
@@ -2890,6 +2907,7 @@ export class AgentInputCoordinator {
     const previousErrorReason = state.errorReason;
     const previousToolLoop = state.toolLoop;
     const previousStickyError = state.stickyError;
+    let manualRetryClientId: string | null = null;
     let retryItem = recovery.kind === 'active-turn' ? recovery.item : null;
     if (
       !continueItem &&
@@ -2932,6 +2950,7 @@ export class AgentInputCoordinator {
         };
       }
       item = preserveActiveSessionDispatchFence(item, opts?.requireActiveSession === true);
+      if (!opts?.auto && opts?.requireActiveSession) manualRetryClientId = item.clientId;
       if (opts?.auto && attemptToken !== null) {
         this.pendingAutoResumeRecoveries.set(item.clientId, {
           sessionId,
@@ -2971,7 +2990,19 @@ export class AgentInputCoordinator {
         const nextQueue = [...state.pendingQueue];
         nextQueue[headIndex] = preserveActiveSessionDispatchFence(head, true);
         state.pendingQueue = nextQueue;
+        manualRetryClientId = head.clientId;
       }
+    }
+    if (manualRetryClientId) {
+      this.pendingManualRetryRecoveries.set(manualRetryClientId, {
+        sessionId,
+        stateRef: state,
+        recovery,
+        error: previousError,
+        errorReason: previousErrorReason,
+        toolLoop: previousToolLoop,
+        stickyError: previousStickyError,
+      });
     }
     if (!opts?.auto) this.touchUserSend(sessionId);
     this.emit(sessionId);
@@ -4575,6 +4606,8 @@ export class AgentInputCoordinator {
           latest.activeTurn = null;
           this.clearCredentialSwitchWait(latest);
           this.deps.onDiscardedQueuedMessage?.(sessionId, head);
+          const restoredError = this.restoreManualRetryRecovery(sessionId, head.clientId);
+          if (restoredError) this.persistTerminalSendError(sessionId, restoredError);
           log.info('discarded queued input after final lifecycle fence', {
             sessionId,
             clientId: head.clientId,
@@ -4593,6 +4626,7 @@ export class AgentInputCoordinator {
           );
           return;
         }
+        this.pendingManualRetryRecoveries.delete(head.clientId);
         if (head.autoResume) {
           latest.activeTurn = null;
           this.discardAutoResumeBeforeDispatch(sessionId, head);
@@ -4617,6 +4651,7 @@ export class AgentInputCoordinator {
         this.emit(sessionId);
         return;
       }
+      this.pendingManualRetryRecoveries.delete(head.clientId);
       latest.error = errorMessage(err);
       clearErrorProjectionSignals(latest);
       latest.stickyError = null;
@@ -5201,6 +5236,7 @@ export class AgentInputCoordinator {
   /** 自动续跑项已真正进入 vendor，之后不再需要 pre-vendor 回滚信息。 */
   private commitAutoResumeDispatch(sessionId: string, item: AgentInputQueuedMessage): void {
     this.pendingAutoResumeRecoveries.delete(item.clientId);
+    this.pendingManualRetryRecoveries.delete(item.clientId);
     this.autoResumeDispatchAttempts.delete(item.clientId);
     const attemptToken = item.autoResumeInfo?.sessionTotal;
     const state = this.getState(sessionId);
@@ -5211,6 +5247,21 @@ export class AgentInputCoordinator {
     ) {
       state.autoResumeAttemptToken = null;
     }
+  }
+
+  /** Restore a secondary-window retry only while it still owns this state object. */
+  private restoreManualRetryRecovery(sessionId: string, clientId: string): string | null {
+    const pending = this.pendingManualRetryRecoveries.get(clientId);
+    if (!pending) return null;
+    this.pendingManualRetryRecoveries.delete(clientId);
+    const state = this.states.get(sessionId);
+    if (pending.sessionId !== sessionId || state !== pending.stateRef) return null;
+    state.error = pending.error;
+    state.errorReason = pending.errorReason;
+    state.toolLoop = pending.toolLoop;
+    state.stickyError = pending.stickyError;
+    state.recovery = pending.recovery;
+    return pending.error ?? pending.stickyError;
   }
 
   /**
@@ -5261,6 +5312,12 @@ export class AgentInputCoordinator {
       .filter((item) => item.autoResume)
       .map((item) => item.clientId);
     this.supersedePendingAutoResumeRecoveries(sessionId);
+    // A later user action supersedes the secondary-window retry intent as
+    // well. Session close deliberately does not call this helper: its final
+    // lifecycle fence may still need the checkpoint to restore the retry UI.
+    for (const [clientId, pending] of this.pendingManualRetryRecoveries) {
+      if (pending.sessionId === sessionId) this.pendingManualRetryRecoveries.delete(clientId);
+    }
     for (const clientId of queuedClientIds) this.remove(sessionId, clientId);
 
     const active = state.activeTurn;

--- a/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
+++ b/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
@@ -806,6 +806,30 @@ function captureOriginalSyntheticTrigger(item: AgentInputQueuedMessage): AgentIn
 }
 
 /**
+ * First acceptance overwrites the untrusted wire value; later Main-owned queue
+ * transitions use `preserveActiveSessionDispatchFence` so edits, resume, retry,
+ * and crash recovery cannot weaken an already accepted lifecycle requirement.
+ */
+function stampActiveSessionDispatchFence(
+  item: AgentInputQueuedMessage,
+  requireActiveSession: boolean,
+): AgentInputQueuedMessage {
+  const stamped = { ...item };
+  if (requireActiveSession) stamped.requireActiveSession = true;
+  else delete stamped.requireActiveSession;
+  return stamped;
+}
+
+function preserveActiveSessionDispatchFence(
+  item: AgentInputQueuedMessage,
+  requireActiveSession: boolean,
+): AgentInputQueuedMessage {
+  return item.requireActiveSession || requireActiveSession
+    ? { ...item, requireActiveSession: true }
+    : item;
+}
+
+/**
  * Stamp the acceptance boundary with the controlled host's clock.  Remote
  * renderer timestamps are presentation data and may come from a device with a
  * different wall clock; they must never decide whether a crash-restored item
@@ -1504,11 +1528,15 @@ export class AgentInputCoordinator {
       wasFirst?: boolean;
       sendAtMs?: number;
       resumeRestorePausedQueue?: boolean;
+      requireActiveSession?: boolean;
       onDuplicate?: () => void;
     },
   ): AgentInputProjection {
     const state = this.getState(sessionId);
-    item = captureOriginalSyntheticTrigger(item);
+    item = stampActiveSessionDispatchFence(
+      captureOriginalSyntheticTrigger(item),
+      opts?.requireActiveSession === true,
+    );
     // 幂等去重(弱网重发防线,PR #881):同 clientId 重复投递说明是控制端(手机
     // 断连自动重试 / 用户对 ack 丢失的消息重发)在补发同一条消息,不是新消息。
     // 直接返回当前 projection、不再入队——否则同一条消息双入队、agent 跑两轮。
@@ -1958,6 +1986,12 @@ export class AgentInputCoordinator {
           typeof item.hostAcceptedAtMs === 'number' && Number.isFinite(item.hostAcceptedAtMs);
       }
     }
+    // A same-turn steer can fall back to an ordinary queued turn both before
+    // vendor delivery and after a NO_ACTIVE_TURN race. Stamp the lifecycle
+    // requirement on the Main-owned item before either fallback can retain it;
+    // otherwise that later drain would lose the secondary-window fence even
+    // though direct steer delivery still rechecks it.
+    item = preserveActiveSessionDispatchFence(item, opts?.requireActiveSession === true);
     if (state.steeringQueueClientIds.includes(item.clientId)) {
       log.info('steer ignored: duplicate in-flight clientId (control-side resend)', {
         sessionId,
@@ -2595,6 +2629,11 @@ export class AgentInputCoordinator {
       return this.getProjection(sessionId);
     }
     const state = this.getState(sessionId);
+    if (opts?.requireActiveSession) {
+      state.pendingQueue = state.pendingQueue.map((item) =>
+        preserveActiveSessionDispatchFence(item, true),
+      );
+    }
     const recovery = state.recovery;
     const pausedQueueHeadRecoveryClientId =
       state.queuePaused &&
@@ -2869,6 +2908,7 @@ export class AgentInputCoordinator {
           },
         };
       }
+      item = preserveActiveSessionDispatchFence(item, opts?.requireActiveSession === true);
       if (opts?.auto && attemptToken !== null) {
         this.pendingAutoResumeRecoveries.set(item.clientId, {
           sessionId,
@@ -2899,6 +2939,16 @@ export class AgentInputCoordinator {
         opts?.auto ? 'auto' : 'manual',
         attemptToken ?? undefined,
       );
+    } else if (opts?.requireActiveSession) {
+      const headIndex = state.pendingQueue.findIndex(
+        (item) => item.clientId === recovery.clientId,
+      );
+      const head = headIndex >= 0 ? state.pendingQueue[headIndex] : undefined;
+      if (head) {
+        const nextQueue = [...state.pendingQueue];
+        nextQueue[headIndex] = preserveActiveSessionDispatchFence(head, true);
+        state.pendingQueue = nextQueue;
+      }
     }
     if (!opts?.auto) this.touchUserSend(sessionId);
     this.emit(sessionId);
@@ -3081,6 +3131,8 @@ export class AgentInputCoordinator {
     const replacement = { ...next };
     if (current.hostAcceptedAtMs === undefined) delete replacement.hostAcceptedAtMs;
     else replacement.hostAcceptedAtMs = current.hostAcceptedAtMs;
+    if (current.requireActiveSession === undefined) delete replacement.requireActiveSession;
+    else replacement.requireActiveSession = current.requireActiveSession;
     const nextQueue = [...state.pendingQueue];
     nextQueue[index] = replacement;
     state.pendingQueue = nextQueue;
@@ -3808,6 +3860,7 @@ export class AgentInputCoordinator {
   private toProjectedItem(item: AgentInputQueuedMessage): AgentInputQueuedMessage {
     const projected = { ...item };
     delete projected.hostAcceptedAtMs;
+    delete projected.requireActiveSession;
     delete projected.trustedSessionReferenceContexts;
     delete projected.sessionReferencesRequireTrustedSnapshot;
     delete (projected as Record<string, unknown>)[TRUSTED_DESKTOP_PI_COMMAND_SNAPSHOT];
@@ -4371,6 +4424,7 @@ export class AgentInputCoordinator {
         signal: this.getInputAbortSignal(sessionId, active.generation),
         expectedClearBoundaryMs: active.clearBoundaryMs,
         expectedInputGeneration: active.generation,
+        ...(head.requireActiveSession ? { requireActiveSession: true } : {}),
         ...(head.origin?.kind === 'scheduler' ? { origin: head.origin } : {}),
         // 手机来源透传到 send 事务:drain 已脱离入队时的 async context。
         ...(head.fromMobileClient ? { fromMobileClient: true } : {}),
@@ -4494,6 +4548,18 @@ export class AgentInputCoordinator {
       this.discardDeferredResumableCandidate(sessionId, active);
       const latest = this.getState(sessionId);
       if (!active.persisted) {
+        if (head.requireActiveSession && isSessionNotActiveError(err)) {
+          latest.activeTurn = null;
+          this.clearCredentialSwitchWait(latest);
+          this.deps.onDiscardedQueuedMessage?.(sessionId, head);
+          log.info('discarded queued input after final lifecycle fence', {
+            sessionId,
+            clientId: head.clientId,
+          });
+          this.emit(sessionId);
+          this.scheduleDrain(sessionId, 'session-no-longer-active');
+          return;
+        }
         if (isSessionRunningError(err)) {
           this.deferQueueHeadAfterSessionRunning(
             sessionId,

--- a/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
+++ b/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
@@ -2596,8 +2596,11 @@ export class AgentInputCoordinator {
   }
 
   /** 用户点「重试 / 继续任务」。行为见 performRetryLastError。 */
-  async retryLastError(sessionId: string): Promise<AgentInputProjection> {
-    const { projection } = await this.performRetryLastError(sessionId);
+  async retryLastError(
+    sessionId: string,
+    opts?: { requireActiveSession?: boolean },
+  ): Promise<AgentInputProjection> {
+    const { projection } = await this.performRetryLastError(sessionId, opts);
     return projection;
   }
 
@@ -2633,7 +2636,7 @@ export class AgentInputCoordinator {
    */
   private async performRetryLastError(
     sessionId: string,
-    opts?: { auto?: boolean; attemptToken?: number },
+    opts?: { auto?: boolean; attemptToken?: number; requireActiveSession?: boolean },
   ): Promise<{ projection: AgentInputProjection; outcome: AutoRetryOutcome }> {
     const state = this.getState(sessionId);
     const recovery = state.recovery;
@@ -2787,6 +2790,7 @@ export class AgentInputCoordinator {
     // is not sufficient. Re-read the durable lifecycle state at the actual
     // enqueue boundary; no await occurs between this check and the mutation.
     if (
+      opts?.requireActiveSession &&
       this.deps.isSessionActiveForRetry &&
       !(await this.deps.isSessionActiveForRetry(sessionId))
     ) {

--- a/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
+++ b/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
@@ -324,6 +324,12 @@ export interface AgentInputCoordinatorDeps {
     userClientId: string,
   ) => Promise<RecoveryContextSnapshot>;
   /**
+   * Durable lifecycle fence for retry paths that can await history before they
+   * mutate the queue. Production checks sessions.status; omitted test harnesses
+   * retain the historical behavior.
+   */
+  isSessionActiveForRetry?: (sessionId: string) => Promise<boolean>;
+  /**
    * Durable user-row writer shared with direct maker sends.  The fallback keeps
    * the coordinator usable in narrow unit harnesses, while the registered host
    * injects its FIFO writer so steer and drain persistence share one ordering.
@@ -2774,6 +2780,17 @@ export class AgentInputCoordinator {
         progressKnown,
       });
       return { projection: this.getProjection(sessionId), outcome: 'no-progress' };
+    }
+    // Manual retry can spend multiple awaits reading durable history before it
+    // reaches the queue mutation below. A secondary window may learn that the
+    // task was archived during those awaits, so the renderer's click-time guard
+    // is not sufficient. Re-read the durable lifecycle state at the actual
+    // enqueue boundary; no await occurs between this check and the mutation.
+    if (
+      this.deps.isSessionActiveForRetry &&
+      !(await this.deps.isSessionActiveForRetry(sessionId))
+    ) {
+      return { projection: this.getProjection(sessionId), outcome: 'superseded' };
     }
     const previousError = state.error;
     const previousErrorReason = state.errorReason;

--- a/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
+++ b/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
@@ -1876,6 +1876,10 @@ export class AgentInputCoordinator {
           expectedInputGeneration: active.generation,
           onVendorTurnReserved: (generation) =>
             this.captureReservedVendorGeneration(sessionId, active, generation),
+          // 把 fence 传到最终 send 边界,让 sendToAgent 在持有的
+          // session route lock 内做最后一次 active 复核(与上面的 precheck
+          // 形成闭环,消除 precheck 与 send 之间的归档竞态,#3262 P1)。
+          ...(request.requireActiveSession ? { requireActiveSession: true } : {}),
         },
       );
       if (!this.isActiveTurnCurrent(sessionId, active)) return this.getProjection(sessionId);

--- a/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
+++ b/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
@@ -210,6 +210,8 @@ export interface AgentInputSendOpts {
   expectedClearBoundaryMs?: number | null;
   /** Main-owned input generation captured before async preparation. */
   expectedInputGeneration?: number;
+  /** Recheck the durable task lifecycle at the final manual dispatch boundary. */
+  requireActiveSession?: boolean;
   /** Main-owned Session identity for a control-plane same-turn steer. */
   expectedTurnSession?: object;
   /** Main-owned maker-core turn generation for a control-plane same-turn steer. */
@@ -841,6 +843,11 @@ function isNoActiveTurnError(err: unknown): boolean {
 function isStaleTurnError(err: unknown): boolean {
   const msg = err instanceof Error ? err.message : String(err);
   return /\[STALE_TURN\]/i.test(msg);
+}
+
+function isSessionNotActiveError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  return /\bSESSION_NOT_ACTIVE\b/i.test(msg);
 }
 
 /**
@@ -1899,6 +1906,8 @@ export class AgentInputCoordinator {
       expectedTurnSession?: object;
       /** 控制面初检捕获的 maker-core turn generation。 */
       expectedTurnGeneration?: number;
+      /** 副窗口人工插话在最终 vendor 边界复核持久化任务仍为 active。 */
+      requireActiveSession?: boolean;
     },
   ): Promise<boolean> {
     const matchesExpectedTurn = () =>
@@ -2127,6 +2136,7 @@ export class AgentInputCoordinator {
         signal: AbortSignal.any([inputBoundarySignal, steerAbort.signal]),
         expectedClearBoundaryMs: steerClearBoundaryMs,
         expectedInputGeneration: steerGeneration,
+        ...(opts?.requireActiveSession ? { requireActiveSession: true } : {}),
         ...(opts?.expectedTurnSession !== undefined
           ? { expectedTurnSession: opts.expectedTurnSession }
           : {}),
@@ -2157,6 +2167,14 @@ export class AgentInputCoordinator {
       this.clearSteerAbortController(sessionId, item.clientId, steerAbort);
 
       if (isStaleTurnError(err)) {
+        if (markerStillPresent) {
+          this.clearDirectSteeringItem(latest, item.clientId);
+          this.emit(sessionId);
+        }
+        return finishSteerRequest(false);
+      }
+
+      if (isSessionNotActiveError(err)) {
         if (markerStillPresent) {
           this.clearDirectSteeringItem(latest, item.clientId);
           this.emit(sessionId);

--- a/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
+++ b/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
@@ -324,11 +324,11 @@ export interface AgentInputCoordinatorDeps {
     userClientId: string,
   ) => Promise<RecoveryContextSnapshot>;
   /**
-   * Durable lifecycle fence for retry paths that can await history before they
-   * mutate the queue. Production checks sessions.status; omitted test harnesses
-   * retain the historical behavior.
+   * Durable lifecycle fence for manual dispatch paths that can race an archive
+   * update before they mutate the queue. Production checks sessions.status;
+   * omitted test harnesses retain the historical behavior.
    */
-  isSessionActiveForRetry?: (sessionId: string) => Promise<boolean>;
+  isSessionActiveForManualDispatch?: (sessionId: string) => Promise<boolean>;
   /**
    * Durable user-row writer shared with direct maker sends.  The fallback keeps
    * the coordinator usable in narrow unit harnesses, while the registered host
@@ -2565,7 +2565,17 @@ export class AgentInputCoordinator {
     return this.getProjection(sessionId);
   }
 
-  resume(sessionId: string): AgentInputProjection {
+  async resume(
+    sessionId: string,
+    opts?: { requireActiveSession?: boolean },
+  ): Promise<AgentInputProjection> {
+    if (
+      opts?.requireActiveSession &&
+      this.deps.isSessionActiveForManualDispatch &&
+      !(await this.deps.isSessionActiveForManualDispatch(sessionId))
+    ) {
+      return this.getProjection(sessionId);
+    }
     const state = this.getState(sessionId);
     const recovery = state.recovery;
     const pausedQueueHeadRecoveryClientId =
@@ -2791,8 +2801,8 @@ export class AgentInputCoordinator {
     // enqueue boundary; no await occurs between this check and the mutation.
     if (
       opts?.requireActiveSession &&
-      this.deps.isSessionActiveForRetry &&
-      !(await this.deps.isSessionActiveForRetry(sessionId))
+      this.deps.isSessionActiveForManualDispatch &&
+      !(await this.deps.isSessionActiveForManualDispatch(sessionId))
     ) {
       return { projection: this.getProjection(sessionId), outcome: 'superseded' };
     }

--- a/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
+++ b/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
@@ -578,6 +578,9 @@ interface PendingCompactRequest {
   createOpts: AgentInputCreateOpts;
   userName?: string;
   waitForClientIds: string[];
+  // 副窗口归档后不得压缩:入队时由调用方置位,dispatchCompact 在最终
+  // sendToAgent 前复核会话仍 active,与归档串行(#3262 P2)。
+  requireActiveSession?: boolean;
 }
 
 type ActiveTurnDispatchLifecycle =
@@ -1766,7 +1769,7 @@ export class AgentInputCoordinator {
   async compact(
     sessionId: string,
     createOpts: AgentInputCreateOpts,
-    opts?: { userName?: string },
+    opts?: { userName?: string; requireActiveSession?: boolean },
   ): Promise<AgentInputProjection> {
     const state = this.getState(sessionId);
     // 手动 /compact 是用户接管，与 composer 新消息同语义。先撤掉尚未跨过
@@ -1792,6 +1795,7 @@ export class AgentInputCoordinator {
       createOpts,
       userName: opts?.userName,
       waitForClientIds: state.pendingQueue.map((item) => item.clientId),
+      requireActiveSession: opts?.requireActiveSession === true,
     };
 
     if (
@@ -1843,6 +1847,21 @@ export class AgentInputCoordinator {
     this.emit(sessionId);
 
     try {
+      // 入队到派发之间会话可能被归档(request.requireActiveSession 仅副窗口置位)。
+      // 在最终 send 边界复核持久化 active 状态;非 active 则放弃压缩,不启动
+      // 新 turn(#3262 P2,与普通队列项的 requireActiveSession fence 对齐)。
+      if (
+        request.requireActiveSession &&
+        this.deps.isSessionActiveForManualDispatch &&
+        !(await this.deps.isSessionActiveForManualDispatch(sessionId))
+      ) {
+        if (!this.isActiveTurnCurrent(sessionId, active)) return this.getProjection(sessionId);
+        state.activeTurn = null;
+        this.emit(sessionId);
+        log.info('compact skipped: session no longer active', { sessionId, reason });
+        this.deps.onQueueEmptied?.(sessionId);
+        return this.getProjection(sessionId);
+      }
       active.sendStarted = true;
       active.dispatchLifecycle = 'sending';
       const result = await this.deps.sendToAgent(

--- a/apps/desktop/src/main/maker-ipc/goal.ts
+++ b/apps/desktop/src/main/maker-ipc/goal.ts
@@ -214,16 +214,31 @@ export function registerGoalHandlers(
   });
 
   // 恢复 paused/blocked 目标(GoalIndicator ▶ 按钮 / resume-on-open 确认)。
-  // 保留计数继续;终态/active 是 no-op。
-  ipcMain.handle(MAKER_INVOKE.GOAL_RESUME, async (_e, sessionId: unknown) => {
-    const id = requireString(sessionId, 'sessionId');
-    try {
-      await getGoalController()?.resumeGoal(id);
-    } catch (error) {
-      throwGoalControllerIpcError(error);
-    }
-    return { ok: true };
-  });
+  // 保留计数继续;终态/active 是 no-op。第一个参数保持裸 sessionId 字符串的 wire
+  // 形态(append-only 协议兼容;旧被控端 / 本机按钮发裸字符串,按 requireString 解析,
+  // 多余尾参被忽略);副窗口经隧道时在第二参带 { requireActiveSession: true },此时
+  // 才在 device-link 下走 route lock + 持久化 active 复核(与 GOAL_CLEAR 同口径)。
+  // primary remote 不带标记,保留"向已归档任务发命令可恢复任务"的历史语义。
+  ipcMain.handle(
+    MAKER_INVOKE.GOAL_RESUME,
+    async (_e, sessionId: unknown, fenceOpts?: unknown) => {
+      const id = requireString(sessionId, 'sessionId');
+      const requireActiveSession =
+        fenceOpts !== null &&
+        typeof fenceOpts === 'object' &&
+        (fenceOpts as { requireActiveSession?: boolean }).requireActiveSession === true;
+      try {
+        await runWithLifecycleGuard(
+          id,
+          () => getGoalController()?.resumeGoal(id) ?? Promise.resolve(),
+          requireActiveSession,
+        );
+      } catch (error) {
+        throwGoalControllerIpcError(error);
+      }
+      return { ok: true };
+    },
+  );
 
   ipcMain.handle(MAKER_INVOKE.GOAL_UPDATE, async (_e, input: unknown) => {
     const obj = requireObject(input, 'goal');
@@ -239,7 +254,14 @@ export function registerGoalHandlers(
     const controller = getGoalController();
     if (!controller) throwIpcError('INTERNAL', 'goal controller not started');
     try {
-      const updated = await controller.updateGoal(sessionId, patch);
+      // 与 GOAL_SET 同口径:仅 device-link 调用且原始 renderer 显式带
+      // requireActiveSession 时才加 route lock + 持久化 active 复核;主窗口 / primary
+      // remote 不带标记,保留"编辑已归档任务目标可重新激活任务"的历史语义。
+      const updated = await runWithLifecycleGuard(
+        sessionId,
+        () => controller.updateGoal(sessionId, patch),
+        obj.requireActiveSession === true,
+      );
       if (!updated) throwIpcError('GOAL_NOT_FOUND', 'goal not found');
       return { ok: true };
     } catch (err) {

--- a/apps/desktop/src/main/maker-ipc/goal.ts
+++ b/apps/desktop/src/main/maker-ipc/goal.ts
@@ -336,7 +336,14 @@ export function registerGoalHandlers(
       const updated = await runWithLifecycleGuard(
         sessionId,
         e,
-        () => controller.updateGoal(sessionId, patch),
+        // fence 持锁时透传 sessionRouteLockHeld:updateGoal 改 paused/blocked
+        // 目标的 objective 会内部调 resumeGoal→fireTurn,需跳过二次加锁(#3262)。
+        (fenced) =>
+          controller.updateGoal(
+            sessionId,
+            patch,
+            ...(fenced ? [{ sessionRouteLockHeld: true }] : []),
+          ),
         obj.requireActiveSession === true,
       );
       if (!updated) throwIpcError('GOAL_NOT_FOUND', 'goal not found');

--- a/apps/desktop/src/main/maker-ipc/goal.ts
+++ b/apps/desktop/src/main/maker-ipc/goal.ts
@@ -132,7 +132,10 @@ export function registerGoalHandlers(
   //   2. 本地副窗口(GoalIndicator 所在的 secondary app window)由真实 event.sender 反查,
   //      无需 renderer 自报标记,一律 fence——reviewer P2:此前本地副窗 resume/update 绕过门禁。
   // primary remote task(主窗口)不带标记且 sender 为主窗,保持"向已归档任务发命令可恢复
-  // 任务"的历史语义。返回是否实际加了 fence,供 GOAL_SET 决定是否传 sessionRouteLockHeld。
+  // 任务"的历史语义。fence 持锁期间调 controller 续跑(setGoal→fireTurn、
+  // resumeGoal、resumeOnOpen→acquirePendingAgentSwitch)会再次取同一把非重入
+  // route 锁,因此把 fenced 标志透传给 controller(sessionRouteLockHeld),
+  // 由 holder 跳过二次加锁,避免自死锁(#3262 review P2)。
   const runWithLifecycleGuard = <T>(
     sessionId: string,
     event: IpcMainInvokeEvent,
@@ -176,7 +179,8 @@ export function registerGoalHandlers(
             sessionId,
             objective,
             ...(limits ? { limits } : {}),
-            // 走了 route lock fence 时告诉 controller 锁已持有,避免重复获取 pending-agent-switch 锁。
+            // fence 已持有 route 锁:让 controller 内的 pending-agent-switch
+            // 走 holder 的 sessionRouteLockHeld 分支,不重复加锁(#3262 P2)。
             ...(fenced ? { sessionRouteLockHeld: true } : {}),
           }),
         obj.requireActiveSession === true,
@@ -244,7 +248,12 @@ export function registerGoalHandlers(
           await runWithLifecycleGuard(
             id,
             e,
-            () => controller.resumeOnOpen(id, { waitForDispatch: false }),
+            (fenced) =>
+              controller.resumeOnOpen(id, {
+                waitForDispatch: false,
+                // fence 持锁时透传,跳过 resumeOnOpen 内的二次加锁(#3262 P2)。
+                ...(fenced ? { sessionRouteLockHeld: true } : {}),
+              }),
             requireActiveSession,
           );
         } catch (error) {
@@ -290,7 +299,13 @@ export function registerGoalHandlers(
         await runWithLifecycleGuard(
           id,
           e,
-          () => getGoalController()?.resumeGoal(id) ?? Promise.resolve(),
+          (fenced) =>
+            // fence 持锁时传 sessionRouteLockHeld,让 resumeGoal→fireTurn 跳过
+            // 二次获取同一把 route 锁(#3262 P2);非 fence 路径保持无 opts 裸调用。
+            getGoalController()?.resumeGoal(
+              id,
+              ...(fenced ? [{ sessionRouteLockHeld: true }] : []),
+            ) ?? Promise.resolve(),
           requireActiveSession,
         );
       } catch (error) {

--- a/apps/desktop/src/main/maker-ipc/goal.ts
+++ b/apps/desktop/src/main/maker-ipc/goal.ts
@@ -102,11 +102,15 @@ export function broadcastGoalStatus(update: GoalStatusUpdate): void {
 export function registerGoalHandlers(
   lifecycle: GoalHandlerLifecycleDeps = NOOP_GOAL_LIFECYCLE_DEPS,
 ): void {
+  // 仅当调用方(原始 renderer,经隧道 args 透传)显式请求 active-session fence 时
+  // 才加 route lock + 持久化复核。device-link 合成 event 的 sender 为空,不能用窗口
+  // 归属判定 secondary;primary remote task(主窗口)不带此标记,保持历史恢复语义。
   const runWithLifecycleGuard = <T>(
     sessionId: string,
     task: () => Promise<T>,
+    requireActiveSession?: boolean,
   ): Promise<T> => {
-    if (!lifecycle.isDeviceLinkInvoke()) return task();
+    if (!lifecycle.isDeviceLinkInvoke() || !requireActiveSession) return task();
     return lifecycle.withSessionLock(sessionId, async () => {
       await lifecycle.assertSessionActive(sessionId);
       return task();
@@ -132,13 +136,18 @@ export function registerGoalHandlers(
     const controller = getGoalController();
     if (!controller) throwIpcError('INTERNAL', 'goal controller not started');
     try {
-      await runWithLifecycleGuard(sessionId, () =>
-        controller.setGoal({
-          sessionId,
-          objective,
-          ...(limits ? { limits } : {}),
-          ...(lifecycle.isDeviceLinkInvoke() ? { sessionRouteLockHeld: true } : {}),
-        }),
+      await runWithLifecycleGuard(
+        sessionId,
+        () =>
+          controller.setGoal({
+            sessionId,
+            objective,
+            ...(limits ? { limits } : {}),
+            ...(lifecycle.isDeviceLinkInvoke() && obj.requireActiveSession === true
+              ? { sessionRouteLockHeld: true }
+              : {}),
+          }),
+        obj.requireActiveSession === true,
       );
     } catch (err) {
       throwGoalControllerIpcError(err);
@@ -146,12 +155,27 @@ export function registerGoalHandlers(
     return { ok: true };
   });
 
-  // 用户清除目标(GoalIndicator ✕ 按钮)。
-  ipcMain.handle(MAKER_INVOKE.GOAL_CLEAR, async (_e, sessionId: unknown) => {
-    const id = requireString(sessionId, 'sessionId');
-    await runWithLifecycleGuard(id, () => getGoalController()?.clearGoal(id) ?? Promise.resolve());
-    return { ok: true };
-  });
+  // 用户清除目标(GoalIndicator ✕ 按钮)。第一个参数保持裸 sessionId 字符串的 wire
+  // 形态(append-only 协议兼容;旧被控端 / 本机按钮发裸字符串,按 requireString 解析,
+  // 多余尾参被忽略);副窗口经隧道时在第二参带 { requireActiveSession: true },此时
+  // 才在 device-link 下走 route lock + 持久化 active 复核(与 GOAL_SET 同口径)。
+  // primary remote 不带标记,保留"向已归档任务发命令可恢复任务"的历史语义。
+  ipcMain.handle(
+    MAKER_INVOKE.GOAL_CLEAR,
+    async (_e, sessionId: unknown, fenceOpts?: unknown) => {
+      const id = requireString(sessionId, 'sessionId');
+      const requireActiveSession =
+        fenceOpts !== null &&
+        typeof fenceOpts === 'object' &&
+        (fenceOpts as { requireActiveSession?: boolean }).requireActiveSession === true;
+      await runWithLifecycleGuard(
+        id,
+        () => getGoalController()?.clearGoal(id) ?? Promise.resolve(),
+        requireActiveSession,
+      );
+      return { ok: true };
+    },
+  );
 
   // 取当前状态(useGoalStatus hook 挂载时拉一次 = 用户打开该会话)。无 goal 返回 null。
   ipcMain.handle(MAKER_INVOKE.GOAL_GET_STATUS, async (_e, sessionId: unknown) => {

--- a/apps/desktop/src/main/maker-ipc/goal.ts
+++ b/apps/desktop/src/main/maker-ipc/goal.ts
@@ -29,6 +29,18 @@ import { MAKER_INVOKE, MAKER_PUSH } from './channels.js';
 
 const log = createLogger('maker-ipc:goal');
 
+export interface GoalHandlerLifecycleDeps {
+  isDeviceLinkInvoke(): boolean;
+  withSessionLock<T>(sessionId: string, task: () => Promise<T>): Promise<T>;
+  assertSessionActive(sessionId: string): Promise<void>;
+}
+
+const NOOP_GOAL_LIFECYCLE_DEPS: GoalHandlerLifecycleDeps = {
+  isDeviceLinkInvoke: () => false,
+  withSessionLock: async (_sessionId, task) => task(),
+  assertSessionActive: async (_sessionId) => undefined,
+};
+
 type GoalLimitPatchKey = 'maxTurns' | 'budgetTokens' | 'noProgressLimit';
 
 function throwGoalControllerIpcError(error: unknown): never {
@@ -87,7 +99,20 @@ export function broadcastGoalStatus(update: GoalStatusUpdate): void {
   tapWindowBroadcast(MAKER_PUSH.GOAL_STATUS_CHANGED, update);
 }
 
-export function registerGoalHandlers(): void {
+export function registerGoalHandlers(
+  lifecycle: GoalHandlerLifecycleDeps = NOOP_GOAL_LIFECYCLE_DEPS,
+): void {
+  const runWithLifecycleGuard = <T>(
+    sessionId: string,
+    task: () => Promise<T>,
+  ): Promise<T> => {
+    if (!lifecycle.isDeviceLinkInvoke()) return task();
+    return lifecycle.withSessionLock(sessionId, async () => {
+      await lifecycle.assertSessionActive(sessionId);
+      return task();
+    });
+  };
+
   // 设目标(renderer 备用入口;命令路径走 commands/builtins.ts)。新建/编辑都直接生效并续跑。
   ipcMain.handle(MAKER_INVOKE.GOAL_SET, async (_e, input: unknown) => {
     const obj = requireObject(input, 'goal');
@@ -107,7 +132,14 @@ export function registerGoalHandlers(): void {
     const controller = getGoalController();
     if (!controller) throwIpcError('INTERNAL', 'goal controller not started');
     try {
-      await controller.setGoal({ sessionId, objective, ...(limits ? { limits } : {}) });
+      await runWithLifecycleGuard(sessionId, () =>
+        controller.setGoal({
+          sessionId,
+          objective,
+          ...(limits ? { limits } : {}),
+          ...(lifecycle.isDeviceLinkInvoke() ? { sessionRouteLockHeld: true } : {}),
+        }),
+      );
     } catch (err) {
       throwGoalControllerIpcError(err);
     }
@@ -117,7 +149,7 @@ export function registerGoalHandlers(): void {
   // 用户清除目标(GoalIndicator ✕ 按钮)。
   ipcMain.handle(MAKER_INVOKE.GOAL_CLEAR, async (_e, sessionId: unknown) => {
     const id = requireString(sessionId, 'sessionId');
-    await getGoalController()?.clearGoal(id);
+    await runWithLifecycleGuard(id, () => getGoalController()?.clearGoal(id) ?? Promise.resolve());
     return { ok: true };
   });
 

--- a/apps/desktop/src/main/maker-ipc/goal.ts
+++ b/apps/desktop/src/main/maker-ipc/goal.ts
@@ -50,6 +50,23 @@ const NOOP_GOAL_LIFECYCLE_DEPS: GoalHandlerLifecycleDeps = {
 
 type GoalLimitPatchKey = 'maxTurns' | 'budgetTokens' | 'noProgressLimit';
 
+/**
+ * 识别 lifecycle fence 里 `assertSessionActive` 对已归档/非 active 会话抛出的
+ * PRECONDITION_FAILED(消息以 `SESSION_NOT_ACTIVE:` 开头,见 register.ts)。
+ * GOAL_GET_STATUS 对副窗口遇到这种情况降级为"返回恢复前快照、不 resumeOnOpen",
+ * 而不是把读取变成报错;其它 PRECONDITION_FAILED(目标控制器真实失败)仍向上抛。
+ */
+function isSessionNotActiveError(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    (error as { code?: unknown }).code === 'PRECONDITION_FAILED' &&
+    error instanceof Error &&
+    error.message.includes('SESSION_NOT_ACTIVE')
+  );
+}
+
 function throwGoalControllerIpcError(error: unknown): never {
   if (error instanceof GoalControllerInputError) {
     throwIpcError('INVALID_PARAMS', error.message);
@@ -194,33 +211,59 @@ export function registerGoalHandlers(
   );
 
   // 取当前状态(useGoalStatus hook 挂载时拉一次 = 用户打开该会话)。无 goal 返回 null。
-  ipcMain.handle(MAKER_INVOKE.GOAL_GET_STATUS, async (_e, sessionId: unknown) => {
-    const id = requireString(sessionId, 'sessionId');
-    const controller = getGoalController();
-    if (!controller) throwIpcError('INTERNAL', 'goal controller not started');
-    let status = await readGoalStatusForIpc(controller, id);
-    // Dormant recovery may synchronously converge an apparently active Goal to
-    // blocked. Wait for storage/session recovery and re-read so this invoke
-    // response cannot overwrite the newer status push with a stale active
-    // snapshot. Actual turn dispatch stays detached: PI prompt acceptance may
-    // legitimately wait through long compaction and must not hold a read query.
-    if (status?.status === 'active') {
-      try {
-        await controller.resumeOnOpen(id, { waitForDispatch: false });
-      } catch (error) {
-        if (
-          error instanceof GoalControllerInputError ||
-          error instanceof GoalSessionRestoreError ||
-          error instanceof GoalUpdateSupersededError
-        ) {
-          throwGoalControllerIpcError(error);
+  // 第一参保持裸 sessionId 字符串的 wire 形态(append-only 协议兼容;旧被控端 / 本机
+  // hook 发裸字符串,多余尾参被忽略);副窗口经隧道时在第二参带 { requireActiveSession:
+  // true },此时 resumeOnOpen(有副作用:会重建 Agent session 并可能续跑 dormant goal)
+  // 与 GOAL_RESUME/CLEAR 同口径走 route lock + 持久化 active 复核——reviewer P2:副窗口
+  // 归档后这个"读取"入口此前能把已归档任务重新拉起。本地副窗口由真实 event.sender 自动
+  // fence,无需 renderer 标记;primary remote / 主窗口不带标记,保留 resume-on-open 的
+  // 历史语义(打开主窗口会话本就允许 dormant 恢复)。
+  ipcMain.handle(
+    MAKER_INVOKE.GOAL_GET_STATUS,
+    async (e, sessionId: unknown, fenceOpts?: unknown) => {
+      const id = requireString(sessionId, 'sessionId');
+      const requireActiveSession =
+        fenceOpts !== null &&
+        typeof fenceOpts === 'object' &&
+        (fenceOpts as { requireActiveSession?: boolean }).requireActiveSession === true;
+      const controller = getGoalController();
+      if (!controller) throwIpcError('INTERNAL', 'goal controller not started');
+      let status = await readGoalStatusForIpc(controller, id);
+      // Dormant recovery may synchronously converge an apparently active Goal to
+      // blocked. Wait for storage/session recovery and re-read so this invoke
+      // response cannot overwrite the newer status push with a stale active
+      // snapshot. Actual turn dispatch stays detached: PI prompt acceptance may
+      // legitimately wait through long compaction and must not hold a read query.
+      //
+      // resumeOnOpen 有副作用(重建 Agent session / 续跑 dormant goal),必须在
+      // lifecycle fence 内执行:副窗口 + 已归档任务时 assertSessionActive 失败,
+      // 这里降级为直接返回当前 status(归档任务无 active goal → 通常 null),既不
+      // 重新激活任务,也不把"读取"变成对 renderer 的报错。
+      if (status?.status === 'active') {
+        try {
+          await runWithLifecycleGuard(
+            id,
+            e,
+            () => controller.resumeOnOpen(id, { waitForDispatch: false }),
+            requireActiveSession,
+          );
+        } catch (error) {
+          // 副窗口 fence 判定会话已归档:放弃 resumeOnOpen,返回恢复前快照即可。
+          if (isSessionNotActiveError(error)) return status;
+          if (
+            error instanceof GoalControllerInputError ||
+            error instanceof GoalSessionRestoreError ||
+            error instanceof GoalUpdateSupersededError
+          ) {
+            throwGoalControllerIpcError(error);
+          }
+          throwIpcError('INTERNAL', 'failed to restore goal status');
         }
-        throwIpcError('INTERNAL', 'failed to restore goal status');
+        status = await readGoalStatusForIpc(controller, id);
       }
-      status = await readGoalStatusForIpc(controller, id);
-    }
-    return status;
-  });
+      return status;
+    },
+  );
 
   // 暂停 active 目标(GoalIndicator ⏸ 按钮)。非 active 是 no-op,不报错。
   ipcMain.handle(MAKER_INVOKE.GOAL_PAUSE, async (_e, sessionId: unknown) => {

--- a/apps/desktop/src/main/maker-ipc/goal.ts
+++ b/apps/desktop/src/main/maker-ipc/goal.ts
@@ -12,7 +12,7 @@
  *     controller.setGoal);GOAL_SET IPC 是给 renderer 主动设目标的备用入口。
  */
 
-import { ipcMain, BrowserWindow } from 'electron';
+import { ipcMain, BrowserWindow, type IpcMainInvokeEvent } from 'electron';
 
 import { createLogger } from '../logger.js';
 import { throwIpcError, requireString, requireObject } from '../utils/ipcValidate.js';
@@ -33,6 +33,13 @@ export interface GoalHandlerLifecycleDeps {
   isDeviceLinkInvoke(): boolean;
   withSessionLock<T>(sessionId: string, task: () => Promise<T>): Promise<T>;
   assertSessionActive(sessionId: string): Promise<void>;
+  /**
+   * 根据真实 event.sender 判定调用是否来自本地副窗口(secondary app window)。
+   * 本地副窗口承载的也是完整会话(含 GoalIndicator),其 resume/update/clear 与远程
+   * 副窗口一样必须走 active-session fence,不能信任 renderer 自报的窗口身份。
+   * device-link 合成 event 的 sender 为空,由 requireActiveSession 标记驱动,二者互补。
+   */
+  isSecondaryWindowEvent?(event: IpcMainInvokeEvent): boolean;
 }
 
 const NOOP_GOAL_LIFECYCLE_DEPS: GoalHandlerLifecycleDeps = {
@@ -102,23 +109,31 @@ export function broadcastGoalStatus(update: GoalStatusUpdate): void {
 export function registerGoalHandlers(
   lifecycle: GoalHandlerLifecycleDeps = NOOP_GOAL_LIFECYCLE_DEPS,
 ): void {
-  // 仅当调用方(原始 renderer,经隧道 args 透传)显式请求 active-session fence 时
-  // 才加 route lock + 持久化复核。device-link 合成 event 的 sender 为空,不能用窗口
-  // 归属判定 secondary;primary remote task(主窗口)不带此标记,保持历史恢复语义。
+  // 加 route lock + 持久化 active 复核的两条触发路径(对齐 register.ts 手工派发口径):
+  //   1. device-link 合成 event 的 sender 为空,无法用窗口归属判定,由原始 renderer 经隧道
+  //      args 透传的 requireActiveSession 显式驱动;
+  //   2. 本地副窗口(GoalIndicator 所在的 secondary app window)由真实 event.sender 反查,
+  //      无需 renderer 自报标记,一律 fence——reviewer P2:此前本地副窗 resume/update 绕过门禁。
+  // primary remote task(主窗口)不带标记且 sender 为主窗,保持"向已归档任务发命令可恢复
+  // 任务"的历史语义。返回是否实际加了 fence,供 GOAL_SET 决定是否传 sessionRouteLockHeld。
   const runWithLifecycleGuard = <T>(
     sessionId: string,
-    task: () => Promise<T>,
+    event: IpcMainInvokeEvent,
+    task: (fenced: boolean) => Promise<T>,
     requireActiveSession?: boolean,
   ): Promise<T> => {
-    if (!lifecycle.isDeviceLinkInvoke() || !requireActiveSession) return task();
+    const isSecondaryWindow = lifecycle.isSecondaryWindowEvent?.(event) ?? false;
+    const mustFence =
+      (lifecycle.isDeviceLinkInvoke() && requireActiveSession === true) || isSecondaryWindow;
+    if (!mustFence) return task(false);
     return lifecycle.withSessionLock(sessionId, async () => {
       await lifecycle.assertSessionActive(sessionId);
-      return task();
+      return task(true);
     });
   };
 
   // 设目标(renderer 备用入口;命令路径走 commands/builtins.ts)。新建/编辑都直接生效并续跑。
-  ipcMain.handle(MAKER_INVOKE.GOAL_SET, async (_e, input: unknown) => {
+  ipcMain.handle(MAKER_INVOKE.GOAL_SET, async (e, input: unknown) => {
     const obj = requireObject(input, 'goal');
     const sessionId = requireString(obj.sessionId, 'sessionId');
     const objective = requireString(obj.objective, 'objective');
@@ -138,14 +153,14 @@ export function registerGoalHandlers(
     try {
       await runWithLifecycleGuard(
         sessionId,
-        () =>
+        e,
+        (fenced) =>
           controller.setGoal({
             sessionId,
             objective,
             ...(limits ? { limits } : {}),
-            ...(lifecycle.isDeviceLinkInvoke() && obj.requireActiveSession === true
-              ? { sessionRouteLockHeld: true }
-              : {}),
+            // 走了 route lock fence 时告诉 controller 锁已持有,避免重复获取 pending-agent-switch 锁。
+            ...(fenced ? { sessionRouteLockHeld: true } : {}),
           }),
         obj.requireActiveSession === true,
       );
@@ -162,7 +177,7 @@ export function registerGoalHandlers(
   // primary remote 不带标记,保留"向已归档任务发命令可恢复任务"的历史语义。
   ipcMain.handle(
     MAKER_INVOKE.GOAL_CLEAR,
-    async (_e, sessionId: unknown, fenceOpts?: unknown) => {
+    async (e, sessionId: unknown, fenceOpts?: unknown) => {
       const id = requireString(sessionId, 'sessionId');
       const requireActiveSession =
         fenceOpts !== null &&
@@ -170,6 +185,7 @@ export function registerGoalHandlers(
         (fenceOpts as { requireActiveSession?: boolean }).requireActiveSession === true;
       await runWithLifecycleGuard(
         id,
+        e,
         () => getGoalController()?.clearGoal(id) ?? Promise.resolve(),
         requireActiveSession,
       );
@@ -221,7 +237,7 @@ export function registerGoalHandlers(
   // primary remote 不带标记,保留"向已归档任务发命令可恢复任务"的历史语义。
   ipcMain.handle(
     MAKER_INVOKE.GOAL_RESUME,
-    async (_e, sessionId: unknown, fenceOpts?: unknown) => {
+    async (e, sessionId: unknown, fenceOpts?: unknown) => {
       const id = requireString(sessionId, 'sessionId');
       const requireActiveSession =
         fenceOpts !== null &&
@@ -230,6 +246,7 @@ export function registerGoalHandlers(
       try {
         await runWithLifecycleGuard(
           id,
+          e,
           () => getGoalController()?.resumeGoal(id) ?? Promise.resolve(),
           requireActiveSession,
         );
@@ -240,7 +257,7 @@ export function registerGoalHandlers(
     },
   );
 
-  ipcMain.handle(MAKER_INVOKE.GOAL_UPDATE, async (_e, input: unknown) => {
+  ipcMain.handle(MAKER_INVOKE.GOAL_UPDATE, async (e, input: unknown) => {
     const obj = requireObject(input, 'goal');
     const sessionId = requireString(obj.sessionId, 'sessionId');
     const rawPatch = requireObject(obj.patch, 'patch');
@@ -254,11 +271,13 @@ export function registerGoalHandlers(
     const controller = getGoalController();
     if (!controller) throwIpcError('INTERNAL', 'goal controller not started');
     try {
-      // 与 GOAL_SET 同口径:仅 device-link 调用且原始 renderer 显式带
-      // requireActiveSession 时才加 route lock + 持久化 active 复核;主窗口 / primary
-      // remote 不带标记,保留"编辑已归档任务目标可重新激活任务"的历史语义。
+      // 与 GOAL_SET 同口径:device-link 显式带 requireActiveSession,或真实 sender 是本地
+      // 副窗口(reviewer P2:本地副窗 GoalIndicator resume/update 此前绕过门禁)时,加 route
+      // lock + 持久化 active 复核;主窗口 / primary remote 不带标记且非副窗,保留"编辑已归档
+      // 任务目标可重新激活任务"的历史语义。
       const updated = await runWithLifecycleGuard(
         sessionId,
+        e,
         () => controller.updateGoal(sessionId, patch),
         obj.requireActiveSession === true,
       );

--- a/apps/desktop/src/main/maker-ipc/makerSendTransaction.ts
+++ b/apps/desktop/src/main/maker-ipc/makerSendTransaction.ts
@@ -17,6 +17,7 @@ import {
   toDesktopSessionDispatchOutcome,
 } from '../maker-host/send-outcome.js';
 import { isCredentialModeSwitchBusyError } from '../maker-host/codex-credential-switch.js';
+import { requiresActiveSessionForDispatch } from '../../shared/agentInputQueue.js';
 import { throwIpcError } from '../utils/ipcValidate.js';
 import {
   extractPlainText,
@@ -354,6 +355,8 @@ export interface MakerSendTransactionDeps {
   /** 把 Pi 原生 user entry id 补到已落库的 Cindy user 行，供会话树恢复附件。 */
   linkPiUserEntry?(sessionId: string, clientId: string, piEntryId: string): Promise<boolean | void>;
   beforeDispatchDirectUserTurn?: (sessionId: string) => void | Promise<void>;
+  /** Re-read the durable session row immediately before a guarded direct send. */
+  assertSessionActiveForManualDispatch?: (sessionId: string) => void | Promise<void>;
   /** Synchronous final fence immediately before Session.send enters vendor code. */
   assertBeforeVendorDispatch?: (sessionId: string, sendOpts: unknown) => void;
   onUndispatchedDirectUserTurn?: (sessionId: string) => void;
@@ -1132,6 +1135,9 @@ export function createMakerSendTransaction(deps: MakerSendTransactionDeps): Make
         if (directPreDispatchHook) {
           await directPreDispatchHook(sessionId);
           directPreDispatchHookStarted = true;
+        }
+        if (requiresActiveSessionForDispatch(finalFenceSendOpts)) {
+          await deps.assertSessionActiveForManualDispatch?.(sessionId);
         }
         // Capture on the executor immediately before vendor code. sess.send may
         // synchronously publish the continuation's new started marker before it

--- a/apps/desktop/src/main/maker-ipc/makerSendTransaction.ts
+++ b/apps/desktop/src/main/maker-ipc/makerSendTransaction.ts
@@ -791,6 +791,12 @@ export function createMakerSendTransaction(deps: MakerSendTransactionDeps): Make
       sendOpts,
     ): Promise<DesktopMakerSendResult> {
       if (typeof sessionId !== 'string') throwIpcError('INVALID_PARAMS', 'sessionId required');
+      // A secondary-window queued send may race an archive after renderer-side
+      // reconciliation.  Fence before any route switch, recovery, or lazy
+      // bootstrap so an already-archived task cannot recreate an Agent runtime.
+      if (requiresActiveSessionForDispatch(sendOpts)) {
+        await deps.assertSessionActiveForManualDispatch?.(sessionId);
+      }
       // session-agent-switch:pending 切换在发送时刻生效(用户语义:「消息真正发出
       // 去时才切」)。必须在 getSession 之前——apply 会 close 旧引擎的 live session,
       // 让下方走 lazy-create 按 DB 新值 spawn 新引擎。

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -2466,6 +2466,19 @@ function isPendingDesktopOnlyConfirmation(requestId: string): boolean {
   );
 }
 
+function findPendingInteractionSessionId(requestId: string): string | undefined {
+  const agentEntry = pendingInteractionResolvers.get(requestId);
+  if (agentEntry) return agentEntry.sessionId;
+  const bridgeEntries = [
+    ...issueConfirmBridge.pendingSnapshots(),
+    ...renameSessionsConfirmBridge.pendingSnapshots(),
+    ...orcaWorkerPermissionConfirmBridge.pendingSnapshots(),
+    ...ghostGrantConfirmBridge.pendingSnapshots(),
+    ...ghostSetupInteractionBridge.pendingSnapshots(),
+  ];
+  return bridgeEntries.find(({ request }) => request.requestId === requestId)?.sessionId;
+}
+
 function dismissRendererInteraction(
   entry: PendingInteractionEntry,
   requestId: string,
@@ -7369,7 +7382,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
   });
 
   const isSecondarySessionWindowEvent = (event: IpcMainInvokeEvent): boolean =>
-    isSecondaryAppWindow(BrowserWindow.fromWebContents(event.sender));
+    Boolean(event?.sender) && isSecondaryAppWindow(BrowserWindow.fromWebContents(event.sender));
 
   // 会话移动转录迁移:活跃会话桥(查内存 sdkSessionId + 关闭 handle)。
   // rewind fork 后 SDK 换新 id,消息落库前 DB 仍是旧值,迁移必须能看到内存里的最新 id;
@@ -15777,14 +15790,6 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
       // 挂起 turn。按 requestId 找到所属会话,把"复核 active"与"resolve 副作用"
       // 放进同一把 session route lock,与归档串行——否则检查通过后归档仍可在
       // resolver 执行前提交(#3262 P2)。
-      const pendingEntry = pendingInteractionResolvers.get(requestId);
-      let accepted = false;
-      if (pendingEntry?.sessionId) {
-        await withSendToSessionLock(pendingEntry.sessionId, async () => {
-          await assertSessionActiveForManualDispatch(pendingEntry.sessionId);
-          accepted = resolvePendingInteraction(requestId, decision as InteractionDecision);
-        });
-      }
       let pluginSetupResponseTarget: GhostSetupInteractionResponseTarget | undefined;
       if (isPluginSetupInteractionDecision(decision) && !isDeviceLinkInvoke()) {
         assertTrustedAppRendererEvent(event);
@@ -15794,8 +15799,39 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
           pluginSetupResponseTarget = event.sender;
         }
       }
+      const pendingSessionId = findPendingInteractionSessionId(requestId);
+      let accepted = false;
+      let resolutionAttemptedUnderLock = false;
+      if (pendingSessionId) {
+        await withSendToSessionLock(pendingSessionId, async () => {
+          await assertSessionActiveForManualDispatch(pendingSessionId);
+          resolutionAttemptedUnderLock = true;
+          accepted =
+            resolvePendingInteraction(requestId, decision as InteractionDecision) ||
+            issueConfirmBridge.resolve(requestId, decision) ||
+            renameSessionsConfirmBridge.resolve(requestId, decision) ||
+            orcaWorkerPermissionConfirmBridge.resolveFromIpc(requestId, decision, {
+              isDeviceLink: isDeviceLinkInvoke(),
+              assertTrustedSender: () => assertTrustedAppRendererEvent(event),
+            }) ||
+            ghostGrantConfirmBridge.resolve(requestId, decision) ||
+            ghostSetupInteractionBridge.resolve(requestId, decision, pluginSetupResponseTarget);
+        });
+      }
       if (accepted) {
         return { accepted: true };
+      }
+      // If the request was found under the lock but disappeared before the
+      // resolver ran, do not retry it outside the lock and reintroduce the
+      // archive/resolve race.
+      if (resolutionAttemptedUnderLock) {
+        if (isPermissionInteractionDecision(decision)) {
+          handleAgentIslandInteractionDismissedByRequestId(requestId);
+        }
+        log.warn('resolve-interaction: no pending resolver (likely already dismissed/timed out)', {
+          requestId,
+        });
+        return { accepted: false };
       }
       if (isPermissionInteractionDecision(decision)) {
         handleAgentIslandInteractionDismissedByRequestId(requestId);

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -17417,23 +17417,31 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
         (!isDeviceLinkInvoke() &&
           event?.sender &&
           isSecondaryAppWindow(BrowserWindow.fromWebContents(event.sender)));
+      // 复核 active 与执行 compact 必须在同一把 route lock 内,否则检查通过后、
+      // compactSession 启动 turn 前归档仍可提交(#3262 P1)。主窗口(无 fence)
+      // 保持历史语义,直接执行。
+      const runCompact = async (): Promise<unknown> => {
+        const sess = maker.getSession(sessionId);
+        if (!sess) {
+          log.debug('compact-session: session not found, no-op', { sessionId });
+          return null;
+        }
+        if (!sess.capabilities.manualCompact?.supported) {
+          log.debug('compact-session: agent does not support manual compact, no-op', {
+            sessionId,
+            agentKind: sess.agentKind,
+          });
+          return null;
+        }
+        return sess.compactSession(instructions);
+      };
       if (requireActiveSession) {
-        await assertSessionActiveForManualDispatch(sessionId);
-      }
-      const sess = maker.getSession(sessionId);
-      if (!sess) {
-        log.debug('compact-session: session not found, no-op', { sessionId });
-        return null;
-      }
-      if (!sess.capabilities.manualCompact?.supported) {
-        // 调用方应先按 capabilities 隐藏入口,这里兜底 no-op。
-        log.debug('compact-session: agent does not support manual compact, no-op', {
-          sessionId,
-          agentKind: sess.agentKind,
+        return withSendToSessionLock(sessionId, async () => {
+          await assertSessionActiveForManualDispatch(sessionId);
+          return runCompact();
         });
-        return null;
       }
-      return sess.compactSession(instructions);
+      return runCompact();
     },
   );
 

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -10909,23 +10909,25 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
         }
       }
       // Lead 可能在 renderer 缓存检查通过后、派单前被另一窗口归档。仅靠前端状态
-      // 不够:在串行 claim 内复核 lead 持久化状态仍 active,避免 Worker 在已归档
-      // 任务下开始执行(#3262 P2)。
+      // 不够:复核 + sendToWorker 必须在 Lead 的 route lock 内原子完成,与归档
+      // 串行,否则检查通过后归档仍可在派发前提交(#3262 P2)。
       return orcaUiAssignmentDispatchClaims.runOnce(
         { leadSessionId, workerSessionId, snapshotBeforeMs },
         async () => {
-          await assertSessionActiveForManualDispatch(leadSessionId);
-          const result = await orcaTeamService.sendToWorker({
-            callerLeadSessionId: leadSessionId,
-            targetSessionId: workerSessionId,
-            message: buildUiAssignmentInitialTask({
-              leadSessionId,
-              initialTask: initialTask.trim(),
-              snapshotBeforeMs,
-            }),
+          return withSendToSessionLock(leadSessionId, async () => {
+            await assertSessionActiveForManualDispatch(leadSessionId);
+            const result = await orcaTeamService.sendToWorker({
+              callerLeadSessionId: leadSessionId,
+              targetSessionId: workerSessionId,
+              message: buildUiAssignmentInitialTask({
+                leadSessionId,
+                initialTask: initialTask.trim(),
+                snapshotBeforeMs,
+              }),
+            });
+            if (!result.ok) throwOrcaServiceFailure(result);
+            return result;
           });
-          if (!result.ok) throwOrcaServiceFailure(result);
-          return result;
         },
       );
     },
@@ -15094,7 +15096,9 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
       return inputCoordinator.compact(
         sid,
         typedCreateOpts,
-        opts && typeof opts === 'object' ? (opts as { userName?: string }) : undefined,
+        // 透传 userName + requireActiveSession(后者在 dispatchCompact 最终 send
+        // 边界二次复核,覆盖 compact 入队后才归档的竞态,#3262 P2)。
+        compactOpts as { userName?: string; requireActiveSession?: boolean } | undefined,
       );
     },
   );
@@ -15770,10 +15774,16 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
       assertResolveInteractionOrigin(decision, isPendingDesktopOnlyConfirmation(requestId));
       // 归档竞态:会话在权限/AskUser/Plan Review 等待期间被另一窗口归档、脏文件
       // 预检又取消了自动关窗时,pending 交互可能残留。批准/回答会放行已归档任务的
-      // 挂起 turn。解析前按 requestId 找到所属会话,在锁内复核仍 active(#3262 P2)。
+      // 挂起 turn。按 requestId 找到所属会话,把"复核 active"与"resolve 副作用"
+      // 放进同一把 session route lock,与归档串行——否则检查通过后归档仍可在
+      // resolver 执行前提交(#3262 P2)。
       const pendingEntry = pendingInteractionResolvers.get(requestId);
+      let accepted = false;
       if (pendingEntry?.sessionId) {
-        await assertSessionActiveForManualDispatch(pendingEntry.sessionId);
+        await withSendToSessionLock(pendingEntry.sessionId, async () => {
+          await assertSessionActiveForManualDispatch(pendingEntry.sessionId);
+          accepted = resolvePendingInteraction(requestId, decision as InteractionDecision);
+        });
       }
       let pluginSetupResponseTarget: GhostSetupInteractionResponseTarget | undefined;
       if (isPluginSetupInteractionDecision(decision) && !isDeviceLinkInvoke()) {
@@ -15784,7 +15794,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
           pluginSetupResponseTarget = event.sender;
         }
       }
-      if (resolvePendingInteraction(requestId, decision as InteractionDecision)) {
+      if (accepted) {
         return { accepted: true };
       }
       if (isPermissionInteractionDecision(decision)) {

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -13810,6 +13810,14 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
       await drainPersistQueue();
       return getRecoveryContextSnapshot(sessionId, userClientId);
     },
+    isSessionActiveForRetry: async (sessionId) => {
+      const [row] = await getDbClient()
+        .drizzle.select({ status: sessions.status })
+        .from(sessions)
+        .where(eq(sessions.id, sessionId))
+        .limit(1);
+      return row?.status === 'active';
+    },
     // retry-supersede:零产出重试的克隆行落库并派发成功后,软删被取代的旧 user 行
     // 与其后的 error 行(实现与守卫见 localDb/ipc/messages.supersedeRetriedUserTurn)。
     // 只发 messages:deleted、不额外发 sessions:patched:软删既不改变会话列表的

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -78,6 +78,7 @@ import {
   type AgentInputClearBoundaryOpts,
   type AgentInputCreateOpts,
   type AgentInputQueuedMessage,
+  type AgentInputResumeOpts,
   type AgentInputRetryOpts,
   type AgentInputSessionRef,
   type AgentInputSessionReferenceContext,
@@ -13811,7 +13812,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
       await drainPersistQueue();
       return getRecoveryContextSnapshot(sessionId, userClientId);
     },
-    isSessionActiveForRetry: async (sessionId) => {
+    isSessionActiveForManualDispatch: async (sessionId) => {
       const [row] = await getDbClient()
         .drizzle.select({ status: sessions.status })
         .from(sessions)
@@ -15214,7 +15215,10 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
   ipcMain.handle(MAKER_INVOKE.INPUT_RESUME, async (_e, sessionId: unknown, opts?: unknown) => {
     const sid = requireSessionId(sessionId);
     await assertRemoteInputControlBoundary(sid, isDeviceLinkInvoke(), opts);
-    return inputCoordinator.resume(sid);
+    const resumeOpts = opts && typeof opts === 'object' ? (opts as AgentInputResumeOpts) : undefined;
+    return inputCoordinator.resume(sid, {
+      requireActiveSession: resumeOpts?.requireActiveSession === true,
+    });
   });
 
   ipcMain.handle(

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -10908,9 +10908,13 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
           );
         }
       }
+      // Lead 可能在 renderer 缓存检查通过后、派单前被另一窗口归档。仅靠前端状态
+      // 不够:在串行 claim 内复核 lead 持久化状态仍 active,避免 Worker 在已归档
+      // 任务下开始执行(#3262 P2)。
       return orcaUiAssignmentDispatchClaims.runOnce(
         { leadSessionId, workerSessionId, snapshotBeforeMs },
         async () => {
+          await assertSessionActiveForManualDispatch(leadSessionId);
           const result = await orcaTeamService.sendToWorker({
             callerLeadSessionId: leadSessionId,
             targetSessionId: workerSessionId,
@@ -15058,9 +15062,24 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
 
   ipcMain.handle(
     MAKER_INVOKE.INPUT_COMPACT,
-    async (_e, sessionId: unknown, createOpts: unknown, opts?: unknown) => {
+    async (event, sessionId: unknown, createOpts: unknown, opts?: unknown) => {
       const sid = requireSessionId(sessionId);
       const remote = isDeviceLinkInvoke();
+      // 副窗口归档后不得压缩(压缩会启动新 turn,绕过 active-session fence,
+      // #3262 P2)。device-link 显式传 requireActiveSession;本机副窗口按真实
+      // sender 判定。主窗口保持历史语义。
+      const compactOpts =
+        opts && typeof opts === 'object' && !Array.isArray(opts)
+          ? (opts as Record<string, unknown>)
+          : undefined;
+      const requireActiveSession =
+        compactOpts?.requireActiveSession === true ||
+        (!remote &&
+          event?.sender &&
+          isSecondaryAppWindow(BrowserWindow.fromWebContents(event.sender)));
+      if (requireActiveSession) {
+        await assertSessionActiveForManualDispatch(sid);
+      }
       await assertRemoteInputControlBoundary(sid, remote, opts);
       if (!remote) await observeLocalInputClearBoundary(sid);
       await inputCoordinator.ensureQueueRestored(sid).catch(() => undefined);
@@ -15737,7 +15756,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
 
   ipcMain.handle(
     MAKER_INVOKE.RESOLVE_INTERACTION,
-    (event, requestId: unknown, decision: unknown) => {
+    async (event, requestId: unknown, decision: unknown) => {
       if (typeof requestId !== 'string') throwIpcError('INVALID_PARAMS', 'requestId required');
       if (
         isPluginSetupInteractionDecision(decision) &&
@@ -15749,6 +15768,13 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
       // resolvable. Host-owned setup side effects and Desktop-only confirmations
       // may only originate from the trusted local Desktop.
       assertResolveInteractionOrigin(decision, isPendingDesktopOnlyConfirmation(requestId));
+      // 归档竞态:会话在权限/AskUser/Plan Review 等待期间被另一窗口归档、脏文件
+      // 预检又取消了自动关窗时,pending 交互可能残留。批准/回答会放行已归档任务的
+      // 挂起 turn。解析前按 requestId 找到所属会话,在锁内复核仍 active(#3262 P2)。
+      const pendingEntry = pendingInteractionResolvers.get(requestId);
+      if (pendingEntry?.sessionId) {
+        await assertSessionActiveForManualDispatch(pendingEntry.sessionId);
+      }
       let pluginSetupResponseTarget: GhostSetupInteractionResponseTarget | undefined;
       if (isPluginSetupInteractionDecision(decision) && !isDeviceLinkInvoke()) {
         assertTrustedAppRendererEvent(event);
@@ -17358,7 +17384,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
 
   ipcMain.handle(
     MAKER_INVOKE.COMPACT_SESSION,
-    async (event, sessionId: unknown, instructions: unknown) => {
+    async (event, sessionId: unknown, instructions: unknown, fenceOpts?: unknown) => {
       // 会启动 Agent turn、产生模型费用:非 device-link 的本机调用必须来自受信顶层页面,
       // 不能让辅助窗口 / WebView / 子 frame 经隐藏入口触发(codex review)。device-link
       // 走独立鉴权通道,按既有 dual 模式放行。
@@ -17370,6 +17396,19 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
       }
       if (instructions !== undefined && typeof instructions !== 'string') {
         throwIpcError('INVALID_PARAMS', 'instructions must be a string when provided');
+      }
+      // 副窗口(device-link 显式 requireActiveSession,或本地副窗口由 sender 判定)
+      // 已归档/非 active 时不得压缩——压缩会启动新 turn,绕过 active-session fence
+      // (#3262 P2)。本机主窗口保持历史语义(允许对任意存在的会话压缩)。
+      const requireActiveSession =
+        (fenceOpts !== null &&
+          typeof fenceOpts === 'object' &&
+          (fenceOpts as { requireActiveSession?: boolean }).requireActiveSession === true) ||
+        (!isDeviceLinkInvoke() &&
+          event?.sender &&
+          isSecondaryAppWindow(BrowserWindow.fromWebContents(event.sender)));
+      if (requireActiveSession) {
+        await assertSessionActiveForManualDispatch(sessionId);
       }
       const sess = maker.getSession(sessionId);
       if (!sess) {

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -130,6 +130,7 @@ import {
   assertTrustedAppRendererEvent,
   isTrustedAppRendererEvent,
 } from '../security/trustedAppRenderer.js';
+import { isSecondaryAppWindow } from '../secondary-windows.js';
 import {
   initRenameSessionsConfirm,
   RenameSessionsConfirmBridge,
@@ -2837,6 +2838,29 @@ const pendingFailedTurnAssistantPersistId = new Map<string, string>();
 const sendToSessionLocks = new Map<string, Promise<unknown>>();
 
 /**
+ * Read the persisted session lifecycle at the same boundary used by manual
+ * dispatches. Device-link and secondary-window callers must not trust the
+ * renderer's cached status because an archive can land between reconciliation
+ * and the side effect.
+ */
+export async function isSessionActiveForManualDispatch(sessionId: string): Promise<boolean> {
+  const [row] = await getDbClient()
+    .drizzle.select({ status: sessions.status })
+    .from(sessions)
+    .where(eq(sessions.id, sessionId))
+    .limit(1);
+  return row?.status === 'active';
+}
+
+export async function assertSessionActiveForManualDispatch(sessionId: string): Promise<void> {
+  if (await isSessionActiveForManualDispatch(sessionId)) return;
+  throwIpcError(
+    'PRECONDITION_FAILED',
+    `SESSION_NOT_ACTIVE: Session ${sessionId} is no longer active`,
+  );
+}
+
+/**
  * Acquire the per-session send/route lock until the returned release callback runs.
  *
  * Direct-send callers need this lease form because applying a deferred agent switch,
@@ -3196,7 +3220,11 @@ function settlePendingCredentialSwitch(sessionId: string, source: string): void 
 let refreshRemoteCodexMcpOnTurnSettledHolder: ((sessionId: string) => void) | null = null;
 let deferredCodexRestartHolder: DeferredCodexRestartService | null = null;
 let pendingAgentSwitchApplyHolder:
-  ((sessionId: string, signal?: AbortSignal) => Promise<() => void>) | null = null;
+  | ((
+      sessionId: string,
+      options?: { signal?: AbortSignal; sessionRouteLockHeld?: boolean },
+    ) => Promise<() => void>)
+  | null = null;
 let cancelPendingAgentSwitchHolder: ((sessionId: string) => void) | null = null;
 let gitSnapshotCoordinator: GitSnapshotCoordinator | null = null;
 const sessionTurnActivityTracker = new SessionTurnActivityTracker();
@@ -3346,9 +3374,9 @@ export function clearDeferredCodexRestartForOwnerBoundary(): void {
  */
 export async function acquirePendingAgentSwitchForDirectSend(
   sessionId: string,
-  signal?: AbortSignal,
+  options?: { signal?: AbortSignal; sessionRouteLockHeld?: boolean },
 ): Promise<() => void> {
-  return pendingAgentSwitchApplyHolder?.(sessionId, signal) ?? (() => {});
+  return pendingAgentSwitchApplyHolder?.(sessionId, options) ?? (() => {});
 }
 
 /** 直发路径在 createSession / 重读 live session 之前关掉不健康原生会话。 */
@@ -7340,6 +7368,9 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
     }
   });
 
+  const isSecondarySessionWindowEvent = (event: IpcMainInvokeEvent): boolean =>
+    isSecondaryAppWindow(BrowserWindow.fromWebContents(event.sender));
+
   // 会话移动转录迁移:活跃会话桥(查内存 sdkSessionId + 关闭 handle)。
   // rewind fork 后 SDK 换新 id,消息落库前 DB 仍是旧值,迁移必须能看到内存里的最新 id;
   // 移动时还要关闭活跃 handle,否则旧 cwd 的 CLI 进程继续追加旧目录 jsonl 造成分叉。
@@ -7364,22 +7395,39 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
     if (typeof name !== 'string' || name.length === 0) {
       throwIpcError('INVALID_PARAMS', 'name required');
     }
+    const rawContext =
+      ctx !== null && typeof ctx === 'object' && !Array.isArray(ctx)
+        ? (ctx as DesktopCommandContext)
+        : {};
+    if (rawContext.sessionId !== undefined && typeof rawContext.sessionId !== 'string') {
+      throwIpcError('INVALID_PARAMS', 'sessionId must be a string');
+    }
     // senderWebContentsId 由 main 从 event.sender 填入(覆盖 renderer 传入的任何值),
     // 供需要"只回发起窗口"的命令(/issue)做定向 send。
-    const rawContext = ctx !== null && typeof ctx === 'object' && !Array.isArray(ctx)
-      ? (ctx as DesktopCommandContext)
-      : {};
     const c = {
       ...rawContext,
       senderWebContentsId: e.sender.id,
+      sessionRouteLockHeld: false,
     };
-    if (c.requireActiveSession === true) {
-      if (typeof c.sessionId !== 'string' || c.sessionId.length === 0) {
-        throwIpcError('INVALID_PARAMS', 'sessionId required when requireActiveSession is true');
-      }
-      await assertSessionActiveForManualDispatch(c.sessionId);
+    const sessionId = rawContext.sessionId;
+    if (rawContext.requireActiveSession === true && !sessionId) {
+      throwIpcError('INVALID_PARAMS', 'sessionId required when requireActiveSession is true');
     }
-    await getDesktopCommandRegistry().execute(name, c);
+    const mustFenceActiveSession =
+      Boolean(sessionId) &&
+      !rawContext.deviceId &&
+      (rawContext.requireActiveSession === true || isSecondarySessionWindowEvent(e));
+    if (!sessionId || !mustFenceActiveSession) {
+      await getDesktopCommandRegistry().execute(name, c);
+      return;
+    }
+    await withSendToSessionLock(sessionId, async () => {
+      await assertSessionActiveForManualDispatch(sessionId);
+      await getDesktopCommandRegistry().execute(name, {
+        ...c,
+        sessionRouteLockHeld: true,
+      });
+    });
   });
 
   ipcMain.handle(
@@ -8733,6 +8781,18 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
       // A live or ambiguous peer remains protected by the DB-backed gate.
       await reconcileReviewForSource(sourceSessionId);
     },
+    acquireSourceSessionLifecycle: async (event, sourceSessionId) => {
+      const ipcEvent = event as IpcMainInvokeEvent;
+      if (!isSecondarySessionWindowEvent(ipcEvent)) return () => {};
+      const release = await acquireSendToSessionLock(sourceSessionId);
+      try {
+        await assertSessionActiveForManualDispatch(sourceSessionId);
+        return release;
+      } catch (error) {
+        release();
+        throw error;
+      }
+    },
     createRunId: randomUUID,
     createReviewerSessionId: randomUUID,
     owner: reviewRunOwner,
@@ -9482,14 +9542,21 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
     withCloseSuppressed: withRehydrateCloseSuppressed,
     log,
   });
-  pendingAgentSwitchApplyHolder = async (sessionId, signal) => {
-    const release = await acquireSendToSessionLock(sessionId);
-    try {
+  pendingAgentSwitchApplyHolder = async (sessionId, options) => {
+    const applyPendingRoute = async (): Promise<void> => {
       await applyPendingAgentSwitchIfIdle(agentSwitchDeps, sessionId, {
         bootstrapAfterSwitch: true,
-        signal,
+        signal: options?.signal,
       });
       await contextOverflowRolloverHolder?.prepareUnhealthySession(sessionId);
+    };
+    if (options?.sessionRouteLockHeld) {
+      await applyPendingRoute();
+      return () => {};
+    }
+    const release = await acquireSendToSessionLock(sessionId);
+    try {
+      await applyPendingRoute();
       return release;
     } catch (err) {
       release();
@@ -12444,22 +12511,6 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
       releasePendingOutcomeOnFailure();
       throw err;
     }
-  };
-
-  const isSessionActiveForManualDispatch = async (sessionId: string): Promise<boolean> => {
-    const [row] = await getDbClient()
-      .drizzle.select({ status: sessions.status })
-      .from(sessions)
-      .where(eq(sessions.id, sessionId))
-      .limit(1);
-    return row?.status === 'active';
-  };
-  const assertSessionActiveForManualDispatch = async (sessionId: string): Promise<void> => {
-    if (await isSessionActiveForManualDispatch(sessionId)) return;
-    throwIpcError(
-      'PRECONDITION_FAILED',
-      `SESSION_NOT_ACTIVE: Session ${sessionId} is no longer active`,
-    );
   };
 
   const { sendToAgentAccepted: sendToAgentAcceptedUnlocked } = createMakerSendTransaction({
@@ -15503,7 +15554,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
 
   ipcMain.handle(
     MAKER_INVOKE.INPUT_CLEAR_SESSION,
-    async (_e, sessionId: unknown, clearedAt: unknown) => {
+    async (e, sessionId: unknown, clearedAt: unknown, opts?: unknown) => {
       if (
         clearedAt !== undefined &&
         (typeof clearedAt !== 'string' || !Number.isFinite(new Date(clearedAt).getTime()))
@@ -15511,59 +15562,68 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
         throwIpcError('INVALID_PARAMS', 'clearedAt must be an ISO timestamp');
       }
       const sid = requireSessionId(sessionId);
-      await assertReviewExternalInputAllowed(sid);
-      // Fence remote content-bearing controls for the whole clear lifecycle,
-      // including the DB await below.  Local clear is gated too so a remote
-      // controller cannot enter the same sealing window through another peer.
-      beginRemoteInputClearGate(sid);
-      try {
-        const remoteInvoke = isDeviceLinkInvoke();
-        const clearBoundary = resolveClearSessionBoundary({
-          clearedAt: typeof clearedAt === 'string' ? clearedAt : undefined,
-          isRemoteInvoke: remoteInvoke,
-        });
-        const projection = inputCoordinator.clearSession(sid, clearBoundary);
-        resetAutomaticRecoveryForExplicitStop(sid);
-        // 丢弃缓存的待注入交接 / fork 来源标记:它们是按 clear 之前的历史算出来的,
-        // DB 侧的 cleared_at 抑制拦不住已经落进 registry 内存的那一份(首发被拒后
-        // 缓存仍在),下次 send 会把旧血缘灌进用户刚显式清空的上下文。
-        //
-        // 用 invalidate(留 null 墓碑)而不是 clear(删条目):删条目会让后续 send 回落到
-        // DB 重建,把旧交接捞回来再缓存住。墓碑同步生效,窗口内的 send 立刻拿到 null;
-        // clear 纪元则要等下面 cleared_at 落库之后才推进。
-        agentHandoffPending.invalidate(sid);
-        getAgentIslandService()?.notifyQueueEmptied(sid);
-        // 清上下文后,active 目标失去其依据(objective 引用的内容已被抹掉)→ 一并清除目标。
-        goalClearObserver?.(sid);
-        // cleared_at 在 handler 内**同步**落库,本地与远程同一口径。
-        //
-        // 过去本地路径只靠 renderer 事后 fire-and-forget 写这一列,于是 handler 返回到那次
-        // 写入落库之间有个窗口:此刻启动的引擎切换 / 消息删除会读到**尚未标记 clear**的
-        // DB 历史,却又拿到 clear 之后的纪元——纪元校验因此形同虚设,基于已清空历史算出的
-        // 交接会盖掉刚立的墓碑。在这里同步写掉,那个窗口就不存在了;renderer 之后若再写一次
-        // 也是同值幂等。
-        const clearBoundaryMs =
-          typeof clearBoundary === 'number' ? clearBoundary : new Date(clearBoundary).getTime();
+      const runClear = async () => {
+        await assertReviewExternalInputAllowed(sid);
+        // Fence remote content-bearing controls for the whole clear lifecycle,
+        // including the DB await below.  Local clear is gated too so a remote
+        // controller cannot enter the same sealing window through another peer.
+        beginRemoteInputClearGate(sid);
         try {
-          await clearSessionContextInDb(sid, clearBoundaryMs);
-        } catch (err) {
-          // The in-memory fence is still authoritative for this process. Keep
-          // /clear remains a local cleanup action even when persistence fails;
-          // surface the failure in logs, and
-          // let the next input/projection boundary retry the durable token.
-          log.error('clear session context persist failed', {
-            sessionId: sid,
-            remoteInvoke,
-            err: err instanceof Error ? err.message : String(err),
+          const remoteInvoke = isDeviceLinkInvoke();
+          const clearBoundary = resolveClearSessionBoundary({
+            clearedAt: typeof clearedAt === 'string' ? clearedAt : undefined,
+            isRemoteInvoke: remoteInvoke,
           });
+          const projection = inputCoordinator.clearSession(sid, clearBoundary);
+          resetAutomaticRecoveryForExplicitStop(sid);
+          // 丢弃缓存的待注入交接 / fork 来源标记:它们是按 clear 之前的历史算出来的,
+          // DB 侧的 cleared_at 抑制拦不住已经落进 registry 内存的那一份(首发被拒后
+          // 缓存仍在),下次 send 会把旧血缘灌进用户刚显式清空的上下文。
+          //
+          // 用 invalidate(留 null 墓碑)而不是 clear(删条目):删条目会让后续 send 回落到
+          // DB 重建,把旧交接捞回来再缓存住。墓碑同步生效,窗口内的 send 立刻拿到 null;
+          // clear 纪元则要等下面 cleared_at 落库之后才推进。
+          agentHandoffPending.invalidate(sid);
+          getAgentIslandService()?.notifyQueueEmptied(sid);
+          // 清上下文后,active 目标失去其依据(objective 引用的内容已被抹掉)→ 一并清除目标。
+          goalClearObserver?.(sid);
+          // cleared_at 在 handler 内**同步**落库,本地与远程同一口径。
+          //
+          // 过去本地路径只靠 renderer 事后 fire-and-forget 写这一列,于是 handler 返回到那次
+          // 写入落库之间有个窗口:此刻启动的引擎切换 / 消息删除会读到**尚未标记 clear**的
+          // DB 历史,却又拿到 clear 之后的纪元——纪元校验因此形同虚设,基于已清空历史算出的
+          // 交接会盖掉刚立的墓碑。在这里同步写掉,那个窗口就不存在了;renderer 之后若再写一次
+          // 也是同值幂等。
+          const clearBoundaryMs =
+            typeof clearBoundary === 'number' ? clearBoundary : new Date(clearBoundary).getTime();
+          try {
+            await clearSessionContextInDb(sid, clearBoundaryMs);
+          } catch (err) {
+            // The in-memory fence is still authoritative for this process. Keep
+            // /clear remains a local cleanup action even when persistence fails;
+            // surface the failure in logs, and
+            // let the next input/projection boundary retry the durable token.
+            log.error('clear session context persist failed', {
+              sessionId: sid,
+              remoteInvoke,
+              err: err instanceof Error ? err.message : String(err),
+            });
+          }
+          return projection;
+        } finally {
+          // 落库尝试结束后封边界:重立墓碑(清掉这段 await 里用 clear 前纪元挤进来的那份)
+          // + 推进纪元(挡住后面才写回的那批)。顺序不可颠倒,理由见 sealClearBoundary 注释。
+          agentHandoffPending.sealClearBoundary(sid);
+          endRemoteInputClearGate(sid);
         }
-        return projection;
-      } finally {
-        // 落库尝试结束后封边界:重立墓碑(清掉这段 await 里用 clear 前纪元挤进来的那份)
-        // + 推进纪元(挡住后面才写回的那批)。顺序不可颠倒,理由见 sealClearBoundary 注释。
-        agentHandoffPending.sealClearBoundary(sid);
-        endRemoteInputClearGate(sid);
+      };
+      if (isSecondarySessionWindowEvent(e) || requiresActiveSessionForDispatch(opts)) {
+        return withSendToSessionLock(sid, async () => {
+          await assertSessionActiveForManualDispatch(sid);
+          return runClear();
+        });
       }
+      return runClear();
     },
   );
 

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -12949,23 +12949,25 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
       ? prependNoteToWireUserMessage(normalized as HandoffWireMessage, steerNote)
       : normalized;
     try {
-      const remote = isDeviceLinkInvoke();
-      assertRemoteInputClearNotInFlight(sessionId, remote);
-      const precondition = readRemoteInputClearBoundaryPrecondition(sendOpts);
-      if (precondition.present) {
-        assertCurrentInputClearBoundary(sessionId, precondition.expected);
-      }
-      assertCurrentInputGeneration(sessionId, readExpectedInputGeneration(sendOpts));
-      if (so.requireActiveSession) {
-        await assertSessionActiveForManualDispatch(sessionId);
-      }
-      sess = readCurrentSteerSession();
-      await sess.steer(steerPayload as never, {
-        logTitle: meta?.title,
-        messageUuid: so.messageUuid,
-        userName: so.userName,
-        signal: so.signal,
-        [MAIN_OWNED_SEND_CONTEXT]: so[MAIN_OWNED_SEND_CONTEXT],
+      await withSendToSessionLock(sessionId, async () => {
+        const remote = isDeviceLinkInvoke();
+        assertRemoteInputClearNotInFlight(sessionId, remote);
+        const precondition = readRemoteInputClearBoundaryPrecondition(sendOpts);
+        if (precondition.present) {
+          assertCurrentInputClearBoundary(sessionId, precondition.expected);
+        }
+        assertCurrentInputGeneration(sessionId, readExpectedInputGeneration(sendOpts));
+        if (so.requireActiveSession) {
+          await assertSessionActiveForManualDispatch(sessionId);
+        }
+        sess = readCurrentSteerSession();
+        await sess.steer(steerPayload as never, {
+          logTitle: meta?.title,
+          messageUuid: so.messageUuid,
+          userName: so.userName,
+          signal: so.signal,
+          [MAIN_OWNED_SEND_CONTEXT]: so[MAIN_OWNED_SEND_CONTEXT],
+        });
       });
       log.info('steer: delivered', { sessionId, agentKind: sess.agentKind });
     } catch (err) {

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -14505,6 +14505,10 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
       throwIpcError('INVALID_PARAMS', 'queued.createOpts.agentKind invalid');
     }
     const normalized: AgentInputQueuedMessage = { ...msg };
+    // Lifecycle fences are Main-owned. Renderer/device-link payloads may ask
+    // for one through the validated opts object, but may not forge it on a
+    // queue row that can survive beyond the current IPC invocation.
+    delete normalized.requireActiveSession;
     const refs = requireSessionRefs(normalized.sessionRefs);
     if (!isDeviceLinkInvoke()) {
       // preload/renderer 不属于可信边界，不能直接注入历史正文。
@@ -14923,6 +14927,9 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
         let duplicate = false;
         const projection = inputCoordinator.enqueue(sid, queued, {
           ...(enqueueOpts?.sendAtMs !== undefined ? { sendAtMs: enqueueOpts.sendAtMs } : {}),
+          ...(requiresActiveSessionForDispatch(enqueueOpts)
+            ? { requireActiveSession: true }
+            : {}),
           // INPUT_ENQUEUE 只承载显式用户输入(composer 发送 / UI trigger / device-link
           // 被控端转投的用户消息):崩溃恢复出的暂停队列遇到显式输入即放行,解开
           // 「继续任务/新消息全部排队直到重启」的死锁。Orca 自动投递走 main 侧直调

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -13143,92 +13143,103 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
 
   ipcMain.handle(
     MAKER_INVOKE.GET_CONTEXT_USAGE,
-    async (_e, sessionId: unknown, createOpts?: unknown): Promise<ContextUsageData> => {
+    async (e, sessionId: unknown, createOpts?: unknown): Promise<ContextUsageData> => {
       if (typeof sessionId !== 'string' || sessionId.length === 0) {
         throwIpcError('INVALID_PARAMS', 'sessionId required');
       }
-      let sess = maker.getSession(sessionId);
-      if (!sess) {
-        if (!createOpts) {
-          throwIpcError('NOT_FOUND', `Session ${sessionId} is not running`);
-        }
-        const co = buildCreateOptsWithStderr({ ...(createOpts as CreateOpts), id: sessionId });
-        // session-agent-switch:先按 DB 行校正再判 claude-only——否则切到 codex 后
-        // 残留的 claude createOpts 会在这里 spawn 出旧引擎的 live session 并被后续
-        // send 复用(会话被劫持回旧引擎,2026-07-20 审计实锤)。
-        await reconcileCreateOptsAgainstDb(sessionId, co);
-        if (co.agentKind !== 'claude-code') {
-          throwIpcError(
-            'UNSUPPORTED_CAPABILITY',
-            `Agent ${co.agentKind} does not support context usage`,
+      // 副窗口对已归档任务的 `/context` 必须走 durable fence:lazy-bootstrap 分支
+      // 会为该任务重建 agent 进程,不能让渲染端的缓存归档判断独自守门。主窗口的历史
+      // 语义(/context 可重新激活已归档任务)保持不变。
+      const fromSecondary = isSecondarySessionWindowEvent(e);
+      const run = async (): Promise<ContextUsageData> => {
+        let sess = maker.getSession(sessionId);
+        if (!sess) {
+          if (!createOpts) {
+            throwIpcError('NOT_FOUND', `Session ${sessionId} is not running`);
+          }
+          const co = buildCreateOptsWithStderr({ ...(createOpts as CreateOpts), id: sessionId });
+          // session-agent-switch:先按 DB 行校正再判 claude-only——否则切到 codex 后
+          // 残留的 claude createOpts 会在这里 spawn 出旧引擎的 live session 并被后续
+          // send 复用(会话被劫持回旧引擎,2026-07-20 审计实锤)。
+          await reconcileCreateOptsAgainstDb(sessionId, co);
+          if (co.agentKind !== 'claude-code') {
+            throwIpcError(
+              'UNSUPPORTED_CAPABILITY',
+              `Agent ${co.agentKind} does not support context usage`,
+            );
+          }
+          const okLazy = await checkWorkDirExists(
+            sessionId,
+            co.workingDir,
+            co.agentKind,
+            co.remoteHostId,
           );
-        }
-        const okLazy = await checkWorkDirExists(
-          sessionId,
-          co.workingDir,
-          co.agentKind,
-          co.remoteHostId,
-        );
-        if (!okLazy) {
-          throwIpcError('NOT_FOUND', `Working directory is missing for session ${sessionId}`);
-        }
-        await synthesizeOrcaVendorOptionsFromDb(sessionId, co);
-        if (co.extraDirs === undefined) {
+          if (!okLazy) {
+            throwIpcError('NOT_FOUND', `Working directory is missing for session ${sessionId}`);
+          }
+          await synthesizeOrcaVendorOptionsFromDb(sessionId, co);
+          if (co.extraDirs === undefined) {
+            try {
+              const row = await readSessionExtraDirsFromDb(sessionId);
+              if (row.length > 0) co.extraDirs = extraDirsForRuntime(row);
+            } catch (err) {
+              log.warn('context-usage lazy-create: read extra_dirs from DB failed (non-fatal)', {
+                sessionId,
+                err: err instanceof Error ? err.message : String(err),
+              });
+            }
+          }
+          if (co.writableDirs === undefined) {
+            const row = await readSessionWritableDirsFromDb(sessionId).catch(() => []);
+            if (row.length > 0) co.writableDirs = row;
+          }
           try {
-            const row = await readSessionExtraDirsFromDb(sessionId);
-            if (row.length > 0) co.extraDirs = extraDirsForRuntime(row);
-          } catch (err) {
-            log.warn('context-usage lazy-create: read extra_dirs from DB failed (non-fatal)', {
+            await ensureRemoteReadyForSessionStart({ createOpts: co });
+            const {
+              session: lazySess,
+              didInjectOrcaInstructions,
+              didInjectProjectContext,
+            } = await bootstrapSession(co);
+            await markOrcaRoleIfNeeded(lazySess.id, co.orcaRole);
+            log.info('context-usage: lazy create-session', {
               sessionId,
-              err: err instanceof Error ? err.message : String(err),
+              agentKind: co.agentKind,
+              model: co.model,
+              usedOrcaInstructions: didInjectOrcaInstructions,
+              usedProjectContext: didInjectProjectContext,
+              extraDirsCount: co.extraDirs?.length ?? 0,
             });
+            sess = lazySess;
+          } catch (err) {
+            throwIpcError(
+              'INTERNAL',
+              err instanceof Error ? err.message : 'context usage lazy create failed',
+            );
           }
         }
-        if (co.writableDirs === undefined) {
-          const row = await readSessionWritableDirsFromDb(sessionId).catch(() => []);
-          if (row.length > 0) co.writableDirs = row;
-        }
-        try {
-          await ensureRemoteReadyForSessionStart({ createOpts: co });
-          const {
-            session: lazySess,
-            didInjectOrcaInstructions,
-            didInjectProjectContext,
-          } = await bootstrapSession(co);
-          await markOrcaRoleIfNeeded(lazySess.id, co.orcaRole);
-          log.info('context-usage: lazy create-session', {
-            sessionId,
-            agentKind: co.agentKind,
-            model: co.model,
-            usedOrcaInstructions: didInjectOrcaInstructions,
-            usedProjectContext: didInjectProjectContext,
-            extraDirsCount: co.extraDirs?.length ?? 0,
-          });
-          sess = lazySess;
-        } catch (err) {
+        if (sess.agentKind !== 'claude-code' && sess.agentKind !== 'pi') {
           throwIpcError(
-            'INTERNAL',
-            err instanceof Error ? err.message : 'context usage lazy create failed',
+            'UNSUPPORTED_CAPABILITY',
+            `Agent ${sess.agentKind} does not support context usage`,
           );
         }
-      }
-      if (sess.agentKind !== 'claude-code' && sess.agentKind !== 'pi') {
-        throwIpcError(
-          'UNSUPPORTED_CAPABILITY',
-          `Agent ${sess.agentKind} does not support context usage`,
-        );
-      }
-      try {
-        return await sess.getContextUsage();
-      } catch (err) {
-        if (err instanceof Error && err.name === 'NotSupportedError') {
-          throwIpcError('UNSUPPORTED_CAPABILITY', err.message);
+        try {
+          return await sess.getContextUsage();
+        } catch (err) {
+          if (err instanceof Error && err.name === 'NotSupportedError') {
+            throwIpcError('UNSUPPORTED_CAPABILITY', err.message);
+          }
+          throwIpcError(
+            'INTERNAL',
+            err instanceof Error ? err.message : 'context usage query failed',
+          );
         }
-        throwIpcError(
-          'INTERNAL',
-          err instanceof Error ? err.message : 'context usage query failed',
-        );
-      }
+      };
+      if (!fromSecondary) return run();
+      return withSendToSessionLock(sessionId, async () => {
+        await assertSessionActiveForManualDispatch(sessionId);
+        return run();
+      });
     },
   );
 

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -78,6 +78,7 @@ import {
   type AgentInputClearBoundaryOpts,
   type AgentInputCreateOpts,
   type AgentInputQueuedMessage,
+  type AgentInputRetryOpts,
   type AgentInputSessionRef,
   type AgentInputSessionReferenceContext,
 } from '../../shared/agentInputQueue.js';
@@ -15221,7 +15222,10 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
     async (_e, sessionId: unknown, opts?: unknown) => {
       const sid = requireSessionId(sessionId);
       await assertRemoteInputControlBoundary(sid, isDeviceLinkInvoke(), opts);
-      return inputCoordinator.retryLastError(sid);
+      const retryOpts = opts && typeof opts === 'object' ? (opts as AgentInputRetryOpts) : undefined;
+      return inputCoordinator.retryLastError(sid, {
+        requireActiveSession: retryOpts?.requireActiveSession === true,
+      });
     },
   );
 

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -74,14 +74,17 @@ import {
   getAgentFacingText,
   normalizeAgentInputClearBoundaryMs,
   parseAgentInputToolLoopDetails,
+  requiresActiveSessionForDispatch,
   serializeSessionReferencePayload,
   type AgentInputClearBoundaryOpts,
   type AgentInputCreateOpts,
+  type AgentInputEnqueueOpts,
   type AgentInputQueuedMessage,
   type AgentInputResumeOpts,
   type AgentInputRetryOpts,
   type AgentInputSessionRef,
   type AgentInputSessionReferenceContext,
+  type AgentInputSteerOpts,
 } from '../../shared/agentInputQueue.js';
 import { getManagedWorktreeBasePath } from '../../shared/managedWorktreePaths.js';
 import { normalizeWorkingDirForProjectSettings } from '../../shared/workingDir.js';
@@ -12430,6 +12433,22 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
     }
   };
 
+  const isSessionActiveForManualDispatch = async (sessionId: string): Promise<boolean> => {
+    const [row] = await getDbClient()
+      .drizzle.select({ status: sessions.status })
+      .from(sessions)
+      .where(eq(sessions.id, sessionId))
+      .limit(1);
+    return row?.status === 'active';
+  };
+  const assertSessionActiveForManualDispatch = async (sessionId: string): Promise<void> => {
+    if (await isSessionActiveForManualDispatch(sessionId)) return;
+    throwIpcError(
+      'PRECONDITION_FAILED',
+      `SESSION_NOT_ACTIVE: Session ${sessionId} is no longer active`,
+    );
+  };
+
   const { sendToAgentAccepted: sendToAgentAcceptedUnlocked } = createMakerSendTransaction({
     getSession: (sessionId) => maker.getSession(sessionId),
     closeSession: (sessionId) => maker.closeSession(sessionId),
@@ -12472,6 +12491,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
         patchMessageAgentMeta(sessionId, clientId, { piEntryId }),
       ),
     beforeDispatchDirectUserTurn: (sessionId) => gitSnapshotCoordinator?.onTurnStart(sessionId),
+    assertSessionActiveForManualDispatch,
     assertBeforeVendorDispatch: (sessionId, sendOpts) => {
       const remote = isDeviceLinkInvoke();
       assertRemoteInputClearNotInFlight(sessionId, remote);
@@ -12855,6 +12875,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
       fromMobileClient?: boolean;
       expectedClearBoundaryMs?: number | null;
       expectedInputGeneration?: number;
+      requireActiveSession?: boolean;
       expectedTurnSession?: object;
       expectedTurnGeneration?: number;
       readonly [MAIN_OWNED_SEND_CONTEXT]?: MainOwnedSendContext;
@@ -12935,6 +12956,9 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
         assertCurrentInputClearBoundary(sessionId, precondition.expected);
       }
       assertCurrentInputGeneration(sessionId, readExpectedInputGeneration(sendOpts));
+      if (so.requireActiveSession) {
+        await assertSessionActiveForManualDispatch(sessionId);
+      }
       sess = readCurrentSteerSession();
       await sess.steer(steerPayload as never, {
         logTitle: meta?.title,
@@ -13812,14 +13836,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
       await drainPersistQueue();
       return getRecoveryContextSnapshot(sessionId, userClientId);
     },
-    isSessionActiveForManualDispatch: async (sessionId) => {
-      const [row] = await getDbClient()
-        .drizzle.select({ status: sessions.status })
-        .from(sessions)
-        .where(eq(sessions.id, sessionId))
-        .limit(1);
-      return row?.status === 'active';
-    },
+    isSessionActiveForManualDispatch,
     // retry-supersede:零产出重试的克隆行落库并派发成功后,软删被取代的旧 user 行
     // 与其后的 error 行(实现与守卫见 localDb/ipc/messages.supersedeRetriedUserTurn)。
     // 只发 messages:deleted、不额外发 sessions:patched:软删既不改变会话列表的
@@ -14811,6 +14828,10 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
       await assertReviewExternalInputAllowed(sid);
       const deviceLinkInvoke = isDeviceLinkInvoke();
       if (!deviceLinkInvoke) assertTrustedAppRendererEvent(event);
+      const enqueueOpts =
+        opts && typeof opts === 'object' && !Array.isArray(opts)
+          ? (opts as AgentInputEnqueueOpts)
+          : undefined;
       const parsed = requireQueuedMessage(item);
       assertRemoteInputClearNotInFlight(sid, deviceLinkInvoke);
       const clearBoundaryPrecondition = readRemoteInputClearBoundaryPrecondition(opts);
@@ -14896,9 +14917,12 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
         // 「继续任务」durable ack 延后到 vendor dispatch 成功（onDispatchedUserTurn）：
         // 排队可取消时旧中断提示必须能恢复；accepted 但仍可能 cancelled-before-dispatch
         // 时也不能提前 ack。续跑项本身由 coordinator 插到队首（普通输入仍 FIFO）。
+        if (requiresActiveSessionForDispatch(enqueueOpts)) {
+          await assertSessionActiveForManualDispatch(sid);
+        }
         let duplicate = false;
         const projection = inputCoordinator.enqueue(sid, queued, {
-          ...(opts && typeof opts === 'object' ? (opts as { sendAtMs?: number }) : undefined),
+          ...(enqueueOpts?.sendAtMs !== undefined ? { sendAtMs: enqueueOpts.sendAtMs } : {}),
           // INPUT_ENQUEUE 只承载显式用户输入(composer 发送 / UI trigger / device-link
           // 被控端转投的用户消息):崩溃恢复出的暂停队列遇到显式输入即放行,解开
           // 「继续任务/新消息全部排队直到重启」的死锁。Orca 自动投递走 main 侧直调
@@ -14966,11 +14990,8 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
       const deviceLinkInvoke = isDeviceLinkInvoke();
       if (!deviceLinkInvoke) assertTrustedAppRendererEvent(event);
       const steerOpts =
-        opts && typeof opts === 'object'
-          ? (opts as {
-              removeFromQueue?: boolean;
-              touchUserSend?: boolean;
-            } & AgentInputClearBoundaryOpts)
+        opts && typeof opts === 'object' && !Array.isArray(opts)
+          ? (opts as AgentInputSteerOpts)
           : undefined;
       const parsed = requireQueuedMessage(item, {
         // A device-link projection intentionally omits the trusted snapshot;
@@ -15115,6 +15136,9 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
           }
           return true;
         }
+        if (requiresActiveSessionForDispatch(steerOpts)) {
+          await assertSessionActiveForManualDispatch(sid);
+        }
         // steer 与 enqueue 不同:它会因同会话已有在飞 steer / Stop 边界 / 输入锁而
         // 返回 false。必须等它落定、受理了才改名 —— 被拒的文本改掉默认名 / 合成占位 /
         // fork 占位就是凭空改名(review P1)。
@@ -15125,7 +15149,14 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
             attachmentOwnerId,
           );
         }
-        const runSteer = () => inputCoordinator.steer(sid, queued, steerOpts);
+        const coordinatorSteerOpts = steerOpts
+          ? {
+              ...(steerOpts.removeFromQueue ? { removeFromQueue: true } : {}),
+              ...(steerOpts.touchUserSend ? { touchUserSend: true } : {}),
+              ...(steerOpts.requireActiveSession ? { requireActiveSession: true } : {}),
+            }
+          : undefined;
+        const runSteer = () => inputCoordinator.steer(sid, queued, coordinatorSteerOpts);
         const accepted = await (deviceLinkInvoke
           ? runSteer()
           : trustedDesktopSteerText.run(queued.text, runSteer));

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -13143,14 +13143,28 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
 
   ipcMain.handle(
     MAKER_INVOKE.GET_CONTEXT_USAGE,
-    async (e, sessionId: unknown, createOpts?: unknown): Promise<ContextUsageData> => {
+    async (
+      e,
+      sessionId: unknown,
+      createOpts?: unknown,
+      fenceOpts?: unknown,
+    ): Promise<ContextUsageData> => {
       if (typeof sessionId !== 'string' || sessionId.length === 0) {
         throwIpcError('INVALID_PARAMS', 'sessionId required');
       }
       // 副窗口对已归档任务的 `/context` 必须走 durable fence:lazy-bootstrap 分支
       // 会为该任务重建 agent 进程,不能让渲染端的缓存归档判断独自守门。主窗口的历史
       // 语义(/context 可重新激活已归档任务)保持不变。
-      const fromSecondary = isSecondarySessionWindowEvent(e);
+      //
+      // device-link 远程派发经 dispatchLocalInvoke 传入合成 event(sender 为空),
+      // isSecondarySessionWindowEvent 无法识别——此时由原始 renderer 显式带入的
+      // requireActiveSession(Main-owned,不采信窗口归属)驱动 fence;本机副窗口仍由
+      // sender 判定,两条路都覆盖。
+      const requireActiveFence =
+        isSecondarySessionWindowEvent(e) ||
+        (fenceOpts !== null &&
+          typeof fenceOpts === 'object' &&
+          (fenceOpts as { requireActiveSession?: boolean }).requireActiveSession === true);
       const run = async (): Promise<ContextUsageData> => {
         let sess = maker.getSession(sessionId);
         if (!sess) {
@@ -13235,7 +13249,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
           );
         }
       };
-      if (!fromSecondary) return run();
+      if (!requireActiveFence) return run();
       return withSendToSessionLock(sessionId, async () => {
         await assertSessionActiveForManualDispatch(sessionId);
         return run();

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -7360,12 +7360,25 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
   });
 
   ipcMain.handle(MAKER_INVOKE.EXECUTE_DESKTOP_COMMAND, async (e, name: unknown, ctx: unknown) => {
+    assertTrustedAppRendererEvent(e);
     if (typeof name !== 'string' || name.length === 0) {
       throwIpcError('INVALID_PARAMS', 'name required');
     }
     // senderWebContentsId 由 main 从 event.sender 填入(覆盖 renderer 传入的任何值),
     // 供需要"只回发起窗口"的命令(/issue)做定向 send。
-    const c = { ...((ctx ?? {}) as DesktopCommandContext), senderWebContentsId: e.sender.id };
+    const rawContext = ctx !== null && typeof ctx === 'object' && !Array.isArray(ctx)
+      ? (ctx as DesktopCommandContext)
+      : {};
+    const c = {
+      ...rawContext,
+      senderWebContentsId: e.sender.id,
+    };
+    if (c.requireActiveSession === true) {
+      if (typeof c.sessionId !== 'string' || c.sessionId.length === 0) {
+        throwIpcError('INVALID_PARAMS', 'sessionId required when requireActiveSession is true');
+      }
+      await assertSessionActiveForManualDispatch(c.sessionId);
+    }
     await getDesktopCommandRegistry().execute(name, c);
   });
 

--- a/apps/desktop/src/main/maker-ipc/reviewStartHandler.ts
+++ b/apps/desktop/src/main/maker-ipc/reviewStartHandler.ts
@@ -173,6 +173,10 @@ export interface ReviewCardWrite {
 export interface ReviewStartHandlerDeps {
   assertCaller(event: unknown): void;
   waitUntilReady(sourceSessionId: string): Promise<void>;
+  acquireSourceSessionLifecycle(
+    event: unknown,
+    sourceSessionId: string,
+  ): Promise<() => void>;
   createRunId(): string;
   createReviewerSessionId(): string;
   owner: ReviewRunOwner;
@@ -274,6 +278,10 @@ export function registerReviewStartHandler(
     const runId = deps.createRunId();
     const reviewerSessionId = deps.createReviewerSessionId();
     const sourceCardClientId = `review:${runId}`;
+    const releaseSourceSessionLifecycle = await deps.acquireSourceSessionLifecycle(
+      event,
+      request.sourceSessionId,
+    );
     activeReviewsBySource.set(request.sourceSessionId, { runId, reviewerSessionId });
 
     let disposeReviewEvents: (() => void) | null = null;
@@ -685,6 +693,8 @@ export function registerReviewStartHandler(
         throwIpcError('PRECONDITION_FAILED', error.message);
       }
       throw error;
+    } finally {
+      releaseSourceSessionLifecycle();
     }
   });
 

--- a/apps/desktop/src/main/maker-ipc/reviewStartHandler.ts
+++ b/apps/desktop/src/main/maker-ipc/reviewStartHandler.ts
@@ -278,11 +278,30 @@ export function registerReviewStartHandler(
     const runId = deps.createRunId();
     const reviewerSessionId = deps.createReviewerSessionId();
     const sourceCardClientId = `review:${runId}`;
-    const releaseSourceSessionLifecycle = await deps.acquireSourceSessionLifecycle(
-      event,
-      request.sourceSessionId,
-    );
+    // Reserve the in-process slot BEFORE awaiting the lifecycle lock. has()+set()
+    // run synchronously with no await between them, so under the single-threaded
+    // event loop this check-and-set is atomic: a second caller cannot also pass
+    // has() and overwrite this entry. The durable acquireSourceLease below remains
+    // the cross-process gate; reserving here only keeps an in-process loser from
+    // clobbering the winner's map entry, which would otherwise let the winner's
+    // failure path skip its runId match and leak the durable lease.
     activeReviewsBySource.set(request.sourceSessionId, { runId, reviewerSessionId });
+    let releaseSourceSessionLifecycle: () => void = () => {};
+    try {
+      releaseSourceSessionLifecycle = await deps.acquireSourceSessionLifecycle(
+        event,
+        request.sourceSessionId,
+      );
+    } catch (error) {
+      // acquireSourceSessionLifecycle can yield (secondary-window route lock).
+      // If it fails, release only our own reservation — never a slot another
+      // caller may have taken (it cannot, with the upfront set, but stay
+      // fail-closed in case a future path force-clears entries).
+      if (activeReviewsBySource.get(request.sourceSessionId)?.runId === runId) {
+        activeReviewsBySource.delete(request.sourceSessionId);
+      }
+      throw error;
+    }
 
     let disposeReviewEvents: (() => void) | null = null;
     let disposeReviewStatus: (() => void) | null = null;

--- a/apps/desktop/src/main/scheduler-host/index.ts
+++ b/apps/desktop/src/main/scheduler-host/index.ts
@@ -107,7 +107,8 @@ async function startSchedulerInternal(deps: StartSchedulerDeps): Promise<Schedul
     logger: deps.logger,
     beforeDispatchUserTurn: deps.beforeDispatchUserTurn,
     onUndispatchedUserTurn: deps.onUndispatchedUserTurn,
-    acquirePendingAgentSwitch: acquirePendingAgentSwitchForDirectSend,
+    acquirePendingAgentSwitch: (sessionId, signal) =>
+      acquirePendingAgentSwitchForDirectSend(sessionId, { signal }),
     onSessionCreated: broadcastSessionCreated,
     // 停用轴裁决:每次 fire 前判保存路由是否已被用户停用(见 runner deps 注释)。
     checkModelRoute: verdictForModelRoute,

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -6694,7 +6694,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
         ipcRenderer.invoke('maker:input:stop', sessionId, opts),
       resume: (
         sessionId: string,
-        opts?: { expectedClearBoundaryMs?: number | null },
+        opts?: import('../shared/agentInputQueue').AgentInputResumeOpts,
       ): Promise<import('../shared/agentInputQueue').AgentInputProjection> =>
         ipcRenderer.invoke('maker:input:resume', sessionId, opts),
       retryLastError: (

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -6130,8 +6130,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
         remoteHostId?: string;
         resumeSessionId?: string;
       },
+      fenceOpts?: { requireActiveSession?: boolean },
     ): Promise<import('@cindy/maker-core').ContextUsageData> =>
-      ipcRenderer.invoke('maker:get-context-usage', sessionId, createOpts),
+      ipcRenderer.invoke('maker:get-context-usage', sessionId, createOpts, fenceOpts),
 
     abortSession: (sessionId: string): Promise<void> =>
       ipcRenderer.invoke('maker:abort-session', sessionId),

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -6665,7 +6665,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
       enqueue: (
         sessionId: string,
         item: import('../shared/agentInputQueue').AgentInputQueuedMessage,
-        opts?: { sendAtMs?: number; expectedClearBoundaryMs?: number | null },
+        opts?: import('../shared/agentInputQueue').AgentInputEnqueueOpts,
       ): Promise<import('../shared/agentInputQueue').AgentInputProjection> =>
         ipcRenderer.invoke('maker:input:enqueue', sessionId, item, opts),
       compact: (
@@ -6677,11 +6677,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
       steer: (
         sessionId: string,
         item: import('../shared/agentInputQueue').AgentInputQueuedMessage,
-        opts?: {
-          removeFromQueue?: boolean;
-          touchUserSend?: boolean;
-          expectedClearBoundaryMs?: number | null;
-        },
+        opts?: import('../shared/agentInputQueue').AgentInputSteerOpts,
       ): Promise<boolean> => ipcRenderer.invoke('maker:input:steer', sessionId, item, opts),
       stop: (
         sessionId: string,

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -5772,7 +5772,13 @@ contextBridge.exposeInMainWorld('electronAPI', {
     executeDesktopCommand: (
       name: string,
       // deviceId:device-link 远程会话的归属设备(main 侧 /goal /learn /cmd 据此隧道路由)。
-      ctx: { sessionId?: string; workingDir?: string; args?: string; deviceId?: string },
+      ctx: {
+        sessionId?: string;
+        workingDir?: string;
+        args?: string;
+        deviceId?: string;
+        requireActiveSession?: boolean;
+      },
     ): Promise<{ success: boolean; error?: string }> =>
       ipcRenderer.invoke('maker:execute-desktop-command', name, ctx),
 

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -6699,7 +6699,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
         ipcRenderer.invoke('maker:input:resume', sessionId, opts),
       retryLastError: (
         sessionId: string,
-        opts?: { expectedClearBoundaryMs?: number | null },
+        opts?: import('../shared/agentInputQueue').AgentInputRetryOpts,
       ): Promise<import('../shared/agentInputQueue').AgentInputProjection> =>
         ipcRenderer.invoke('maker:input:retry-last-error', sessionId, opts),
       clearError: (

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -5862,6 +5862,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
         };
         error?: string;
         goalAction?: 'set' | 'cleared' | 'open-dialog';
+        requireActiveSession?: boolean;
       }) => void,
     ): (() => void) => {
       const channel = 'maker:desktop-command-triggered';
@@ -6773,8 +6774,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
       clearSession: (
         sessionId: string,
         clearedAt?: string,
+        opts?: import('../shared/agentInputQueue').AgentInputRequireActiveSessionOpts,
       ): Promise<import('../shared/agentInputQueue').AgentInputProjection> =>
-        ipcRenderer.invoke('maker:input:clear-session', sessionId, clearedAt),
+        opts === undefined
+          ? ipcRenderer.invoke('maker:input:clear-session', sessionId, clearedAt)
+          : ipcRenderer.invoke('maker:input:clear-session', sessionId, clearedAt, opts),
     },
 
     // Stage 2 C1: chat utility (前身 cc-agent:generate-title / cc-agent:plan-file-write)

--- a/apps/desktop/src/renderer/__tests__/archivedSecondaryWindowOwnership.test.ts
+++ b/apps/desktop/src/renderer/__tests__/archivedSecondaryWindowOwnership.test.ts
@@ -216,6 +216,9 @@ describe('archived secondary-window ownership', () => {
     );
 
     expect(resumeHandler).toContain('isArchivedSecondaryWindowInputBlocked()');
+    expect(resumeHandler).toContain(
+      'resumeQueue({ requireActiveSession: isSecondaryWindow() })',
+    );
     expect(steerHandler).toContain('isArchivedSecondaryWindowInputBlocked()');
     expect(chatInput).toContain('blocksArchivedSecondaryWindowInput');
     expect(chatInput).toContain(': handleArchivedSafeQueueResume');

--- a/apps/desktop/src/renderer/__tests__/archivedSecondaryWindowOwnership.test.ts
+++ b/apps/desktop/src/renderer/__tests__/archivedSecondaryWindowOwnership.test.ts
@@ -34,7 +34,7 @@ const makerChatStoreSource = readFileSync(
 const registerSource = readFileSync(
   resolve(__dirname, '..', '..', 'main', 'maker-ipc', 'register.ts'),
   'utf8',
-);
+).replace(/\r\n/g, '\n');
 const makerSendTransactionSource = readFileSync(
   resolve(__dirname, '..', '..', 'main', 'maker-ipc', 'makerSendTransaction.ts'),
   'utf8',
@@ -347,5 +347,31 @@ describe('archived secondary-window ownership', () => {
     );
     expect(registerSource).toContain('delete normalized.requireActiveSession;');
     expect(enqueueBody).toContain('{ requireActiveSession: true }');
+  });
+
+  it('fences desktop slash-command effects before their Main dispatch boundary', () => {
+    const helperStart = sessionViewSource.indexOf('const maybeDispatchDesktopSlashCommand = useCallback(');
+    const helperEnd = sessionViewSource.indexOf('const handleWorkingDirChange = useCallback(', helperStart);
+    const helperBody = sessionViewSource.slice(helperStart, helperEnd);
+    const reviewFence = helperBody.indexOf(
+      'await options.beforeDesktopDispatch()',
+      helperBody.indexOf("hit.name === 'review'"),
+    );
+    const reviewDispatch = helperBody.indexOf('window.electronAPI.maker.startReview', reviewFence);
+    const commandFence = helperBody.indexOf('await options.beforeDesktopDispatch()', reviewDispatch);
+    const commandDispatch = helperBody.indexOf('await dispatchCommand(hit, {', commandFence);
+    const mainFence = registerSource.indexOf('await assertSessionActiveForManualDispatch(c.sessionId);');
+    const mainDispatch = registerSource.indexOf('getDesktopCommandRegistry().execute(name, c);', mainFence);
+
+    expect(reviewFence).toBeGreaterThan(-1);
+    expect(reviewDispatch).toBeGreaterThan(reviewFence);
+    expect(commandFence).toBeGreaterThan(reviewDispatch);
+    expect(commandDispatch).toBeGreaterThan(commandFence);
+    expect(mainFence).toBeGreaterThan(-1);
+    expect(mainDispatch).toBeGreaterThan(mainFence);
+    expect(sessionViewSource).toContain(
+      'beforeDesktopDispatch: allowArchivedSecondaryWindowEnqueue',
+    );
+    expect(helperBody).toContain('requireActiveSession: true');
   });
 });

--- a/apps/desktop/src/renderer/__tests__/archivedSecondaryWindowOwnership.test.ts
+++ b/apps/desktop/src/renderer/__tests__/archivedSecondaryWindowOwnership.test.ts
@@ -107,23 +107,57 @@ describe('archived secondary-window ownership', () => {
     ).toHaveLength(2);
   });
 
-  it('blocks both the composer and send path for archived secondary-window sessions', () => {
+  it('uses a synchronous archive fence for the composer and every send path', () => {
     const guardDeclaration = sessionViewSource.indexOf(
       'const blocksArchivedSecondaryWindowInput =',
     );
-    const sendGuard = sessionViewSource.indexOf(
-      'if (blocksArchivedSecondaryWindowInput) return false;',
+    const refDeclaration = sessionViewSource.indexOf(
+      'const archivedSecondaryWindowInputBlockedRef = useRef(',
       guardDeclaration,
     );
-    const composerDisabled = sessionViewSource.indexOf('disabled={', sendGuard);
+    const pushFence = sessionViewSource.indexOf(
+      'archivedSecondaryWindowInputBlockedRef.current = {',
+      refDeclaration + 1,
+    );
+    const handleSend = sessionViewSource.indexOf('const handleSend = useCallback(', pushFence);
+    const initialSendGuard = sessionViewSource.indexOf(
+      'if (isArchivedSecondaryWindowInputBlocked()) return false;',
+      handleSend,
+    );
+    const steerDispatch = sessionViewSource.indexOf(
+      'const accepted = await steerMessage(',
+      initialSendGuard,
+    );
+    const steerGuard = sessionViewSource.lastIndexOf(
+      'if (isArchivedSecondaryWindowInputBlocked()) return false;',
+      steerDispatch,
+    );
+    const sendDispatch = sessionViewSource.indexOf(
+      'const accepted = await sendMessage(',
+      steerDispatch,
+    );
+    const sendGuard = sessionViewSource.lastIndexOf(
+      'if (isArchivedSecondaryWindowInputBlocked()) return false;',
+      sendDispatch,
+    );
+    const composerDisabled = sessionViewSource.indexOf('disabled={', sendDispatch);
     const composerGuard = sessionViewSource.indexOf(
       'blocksArchivedSecondaryWindowInput',
       composerDisabled,
     );
 
     expect(guardDeclaration).toBeGreaterThan(-1);
-    expect(sendGuard).toBeGreaterThan(guardDeclaration);
-    expect(composerDisabled).toBeGreaterThan(sendGuard);
+    expect(refDeclaration).toBeGreaterThan(guardDeclaration);
+    expect(pushFence).toBeGreaterThan(refDeclaration);
+    expect(initialSendGuard).toBeGreaterThan(handleSend);
+    expect(steerGuard).toBeGreaterThan(initialSendGuard);
+    expect(steerDispatch).toBeGreaterThan(steerGuard);
+    expect(sendGuard).toBeGreaterThan(steerDispatch);
+    expect(sendDispatch).toBeGreaterThan(sendGuard);
+    expect(composerDisabled).toBeGreaterThan(sendDispatch);
     expect(composerGuard).toBeGreaterThan(composerDisabled);
+    expect(
+      sessionViewSource.match(/if \(isArchivedSecondaryWindowInputBlocked\(\)\) return/g),
+    ).toHaveLength(16);
   });
 });

--- a/apps/desktop/src/renderer/__tests__/archivedSecondaryWindowOwnership.test.ts
+++ b/apps/desktop/src/renderer/__tests__/archivedSecondaryWindowOwnership.test.ts
@@ -431,17 +431,23 @@ describe('archived secondary-window ownership', () => {
     );
     const handlerBody = registerSource.slice(handlerStart, handlerEnd);
 
-    // 副窗口判定必须在任何 session 查找 / lazy-bootstrap 之前。
-    const secondaryProbe = handlerBody.indexOf('isSecondarySessionWindowEvent(');
+    // fence 判定必须在任何 session 查找 / lazy-bootstrap 之前,且同时认两路信号:
+    // 本机副窗口按 sender(isSecondarySessionWindowEvent)、device-link 远程副窗口
+    // sender 为空,靠显式 fenceOpts.requireActiveSession 驱动。
+    const secondaryProbe = handlerBody.indexOf('isSecondarySessionWindowEvent(e)');
     expect(secondaryProbe).toBeGreaterThan(-1);
+    const explicitMarkerProbe = handlerBody.indexOf('requireActiveSession === true');
+    expect(explicitMarkerProbe).toBeGreaterThan(-1);
+    expect(handlerBody).toContain('const requireActiveFence =');
+    const fenceAssigned = handlerBody.indexOf('const requireActiveFence =');
     const sessionLookup = handlerBody.indexOf('maker.getSession(sessionId)');
-    expect(sessionLookup).toBeGreaterThan(secondaryProbe);
+    expect(sessionLookup).toBeGreaterThan(fenceAssigned);
 
-    // 副窗口路径走与 send/steer 同一条 route lock + durable active 复核。
-    expect(handlerBody).toContain('if (!fromSecondary) return run();');
+    // 触发 fence 的路径走与 send/steer 同一条 route lock + durable active 复核。
+    expect(handlerBody).toContain('if (!requireActiveFence) return run();');
     const lockStart = handlerBody.indexOf(
       'return withSendToSessionLock(sessionId, async () => {',
-      secondaryProbe,
+      fenceAssigned,
     );
     expect(lockStart).toBeGreaterThan(-1);
     const activeCheck = handlerBody.indexOf(
@@ -452,19 +458,18 @@ describe('archived secondary-window ownership', () => {
     const runInsideLock = handlerBody.indexOf('return run();', activeCheck);
     expect(runInsideLock).toBeGreaterThan(activeCheck);
 
-    // lazy-bootstrap(会重建 agent 进程)被包在 run() 内,所以副窗口在已归档任务上
-    // 会在拿到锁后被 active 复核拦截,bootstrapSession 不可能执行。
+    // lazy-bootstrap(会重建 agent 进程)被包在 run() 内,所以 fence 命中时会在拿到
+    // 锁后被 active 复核拦截,bootstrapSession 不可能执行。
     expect(handlerBody.indexOf('await bootstrapSession(co)')).toBeGreaterThan(sessionLookup);
     expect(handlerBody.indexOf('await reconcileCreateOptsAgainstDb(sessionId, co)')).toBeGreaterThan(
       sessionLookup,
     );
 
-    // 主窗口 / device-link 路径不被新 fence 包裹,保留历史 /context 可重新激活会话的语义。
-    // 具体表现:`if (!fromSecondary) return run();` 是主窗口唯一出口,且主窗口路径没有
-    // 进入 withSendToSessionLock 分支。
-    const nonSecondaryReturn = handlerBody.indexOf('if (!fromSecondary) return run();');
-    expect(nonSecondaryReturn).toBeGreaterThan(-1);
-    expect(nonSecondaryReturn).toBeLessThan(lockStart);
+    // 主窗口与未带标记的 primary remote 路径不被 fence 包裹,保留历史 /context 可重新
+    // 激活会话的语义。
+    const nonFenceReturn = handlerBody.indexOf('if (!requireActiveFence) return run();');
+    expect(nonFenceReturn).toBeGreaterThan(-1);
+    expect(nonFenceReturn).toBeLessThan(lockStart);
   });
 
 });

--- a/apps/desktop/src/renderer/__tests__/archivedSecondaryWindowOwnership.test.ts
+++ b/apps/desktop/src/renderer/__tests__/archivedSecondaryWindowOwnership.test.ts
@@ -15,6 +15,18 @@ const workdirBrowseRouteSource = readFileSync(
   resolve(__dirname, '..', 'features', 'cc-agent', 'workdir-browse', 'WorkdirBrowseRoute.tsx'),
   'utf8',
 );
+const dirtyPreflightSource = readFileSync(
+  resolve(
+    __dirname,
+    '..',
+    'features',
+    'cc-agent',
+    'workdir-browse',
+    'hooks',
+    'useConfirmSwitchAwayIfDirty.ts',
+  ),
+  'utf8',
+);
 
 describe('archived secondary-window ownership', () => {
   it('removes embedded split panes without letting them close the route-owning window', () => {
@@ -46,7 +58,7 @@ describe('archived secondary-window ownership', () => {
     expect(cancelGate).toBeGreaterThan(closePreflight);
     expect(closeWindow).toBeGreaterThan(cancelGate);
     expect(sessionViewSource).toMatch(
-      /\}, \[\s*session\?\.status,\s*sessionId,\s*ownsWindowRoute,\s*onBeforeSecondaryWindowClose,\s*secondaryWindowArchiveOwner,\s*\]\);/,
+      /\}, \[\s*session\?\.status,\s*sessionId,\s*ownsWindowRoute,\s*onBeforeSecondaryWindowClose,\s*confirmCloseActiveFileIfDirty,\s*secondaryWindowArchiveOwner,\s*\]\);/,
     );
   });
 
@@ -107,7 +119,16 @@ describe('archived secondary-window ownership', () => {
     ).toHaveLength(2);
   });
 
-  it('uses a synchronous archive fence for the composer and every send path', () => {
+  it('uses the active editor dirty-file preflight when an ordinary task route closes', () => {
+    expect(sessionViewSource).toContain(': await confirmCloseActiveFileIfDirty();');
+    expect(dirtyPreflightSource).toContain('export function useConfirmCloseActiveFileIfDirty()');
+    expect(dirtyPreflightSource).toContain('const handle = getActiveFileBodyHandle();');
+    expect(dirtyPreflightSource).toContain('if (!handle || !handle.isDirty()) return true;');
+    expect(dirtyPreflightSource).toContain("if (choice === 'cancel') return false;");
+    expect(dirtyPreflightSource).toContain('return await handle.save();');
+  });
+
+  it('uses a synchronous archive guard plus enqueue-time fences for every send path', () => {
     const guardDeclaration = sessionViewSource.indexOf(
       'const blocksArchivedSecondaryWindowInput =',
     );
@@ -156,8 +177,67 @@ describe('archived secondary-window ownership', () => {
     expect(sendDispatch).toBeGreaterThan(sendGuard);
     expect(composerDisabled).toBeGreaterThan(sendDispatch);
     expect(composerGuard).toBeGreaterThan(composerDisabled);
+
+    const workingDirChange = sessionViewSource.slice(
+      sessionViewSource.indexOf('const handleWorkingDirChange = useCallback('),
+      sessionViewSource.indexOf('const maybeShowContextUsage = useCallback('),
+    );
+    const recoverableFirstMessage = sessionViewSource.slice(
+      sessionViewSource.indexOf('const restoreRecoverableHandoff = useCallback('),
+      sessionViewSource.indexOf('const pendingGoalConsumedRef = useRef(false);'),
+    );
+    const ordinarySend = sessionViewSource.slice(
+      sessionViewSource.indexOf('const handleSend = useCallback('),
+      sessionViewSource.indexOf('const handleStopSession = useCallback('),
+    );
+
+    for (const source of [workingDirChange, recoverableFirstMessage, ordinarySend]) {
+      expect(source).toContain('beforeEnqueue: allowArchivedSecondaryWindowEnqueue');
+    }
+  });
+
+  it('blocks every retry and continuation entry after its task is archived', () => {
+    const handlers = [
+      ['const handleErrorTailContinue = useCallback(', 'const handleErrorTailDismiss = useCallback('],
+      [
+        'const handleSessionInterruptContinue = useCallback(',
+        'const handleSessionInterruptDismiss = useCallback(',
+      ],
+      ['const handleRetry = useCallback(', 'const handleSwitchToClaudeSubscription = useCallback('],
+      [
+        'const handleSwitchToClaudeSubscription = useCallback(',
+        'const handleSilentStopContinue = useCallback(',
+      ],
+      [
+        'const handleSilentStopContinue = useCallback(',
+        'const handleContinueAfterUsageReset = useCallback(',
+      ],
+    ] as const;
+
+    for (const [start, end] of handlers) {
+      const source = sessionViewSource.slice(
+        sessionViewSource.indexOf(start),
+        sessionViewSource.indexOf(end),
+      );
+      expect(source).toContain('isArchivedSecondaryWindowInputBlocked()');
+    }
     expect(
-      sessionViewSource.match(/if \(isArchivedSecondaryWindowInputBlocked\(\)\) return/g),
-    ).toHaveLength(16);
+      sessionViewSource.slice(
+        sessionViewSource.indexOf('const handleErrorTailContinue = useCallback('),
+        sessionViewSource.indexOf('const handleErrorTailDismiss = useCallback('),
+      ),
+    ).toContain('beforeEnqueue: allowArchivedSecondaryWindowEnqueue');
+    expect(
+      sessionViewSource.slice(
+        sessionViewSource.indexOf('const handleSessionInterruptContinue = useCallback('),
+        sessionViewSource.indexOf('const handleSessionInterruptDismiss = useCallback('),
+      ),
+    ).toContain('beforeEnqueue: allowArchivedSecondaryWindowEnqueue');
+    expect(
+      sessionViewSource.slice(
+        sessionViewSource.indexOf('const handleSilentStopContinue = useCallback('),
+        sessionViewSource.indexOf('const handleContinueAfterUsageReset = useCallback('),
+      ),
+    ).toContain('beforeEnqueue: allowArchivedSecondaryWindowEnqueue');
   });
 });

--- a/apps/desktop/src/renderer/__tests__/archivedSecondaryWindowOwnership.test.ts
+++ b/apps/desktop/src/renderer/__tests__/archivedSecondaryWindowOwnership.test.ts
@@ -27,15 +27,27 @@ const dirtyPreflightSource = readFileSync(
   ),
   'utf8',
 );
+const makerChatStoreSource = readFileSync(
+  resolve(__dirname, '..', 'lib', 'makerChatStore.ts'),
+  'utf8',
+);
+const registerSource = readFileSync(
+  resolve(__dirname, '..', '..', 'main', 'maker-ipc', 'register.ts'),
+  'utf8',
+);
+const makerSendTransactionSource = readFileSync(
+  resolve(__dirname, '..', '..', 'main', 'maker-ipc', 'makerSendTransaction.ts'),
+  'utf8',
+);
 
 describe('archived secondary-window ownership', () => {
   it('removes embedded split panes without letting them close the route-owning window', () => {
     const archivedEffect = sessionViewSource.indexOf("if (session?.status !== 'archived') return;");
+    const ownerGate = sessionViewSource.indexOf('if (!ownsWindowRoute) {', archivedEffect);
     const removePane = sessionViewSource.indexOf(
       'splitGroupStore.removeSession(sessionId);',
-      archivedEffect,
+      ownerGate,
     );
-    const ownerGate = sessionViewSource.indexOf('if (!ownsWindowRoute) {', removePane);
     const ownerGateEnd = sessionViewSource.indexOf('\n    }', ownerGate);
     const closePreflight = sessionViewSource.indexOf(
       'await onBeforeSecondaryWindowClose()',
@@ -51,8 +63,9 @@ describe('archived secondary-window ownership', () => {
     );
 
     expect(archivedEffect).toBeGreaterThan(-1);
-    expect(removePane).toBeGreaterThan(archivedEffect);
-    expect(ownerGate).toBeGreaterThan(removePane);
+    expect(ownerGate).toBeGreaterThan(archivedEffect);
+    expect(removePane).toBeGreaterThan(ownerGate);
+    expect(removePane).toBeLessThan(ownerGateEnd);
     expect(ownerGateEnd).toBeGreaterThan(ownerGate);
     expect(closePreflight).toBeGreaterThan(ownerGateEnd);
     expect(cancelGate).toBeGreaterThan(closePreflight);
@@ -220,6 +233,9 @@ describe('archived secondary-window ownership', () => {
       'resumeQueue({ requireActiveSession: isSecondaryWindow() })',
     );
     expect(steerHandler).toContain('isArchivedSecondaryWindowInputBlocked()');
+    expect(steerHandler).toContain(
+      'steerQueuedMessage(clientId, { requireActiveSession: isSecondaryWindow() })',
+    );
     expect(chatInput).toContain('blocksArchivedSecondaryWindowInput');
     expect(chatInput).toContain(': handleArchivedSafeQueueResume');
     expect(chatInput).toContain(': handleArchivedSafeQueueSteer');
@@ -270,6 +286,54 @@ describe('archived secondary-window ownership', () => {
     ).toContain('beforeEnqueue: allowArchivedSecondaryWindowEnqueue');
     expect(sessionViewSource).toContain(
       'retryLastError({ requireActiveSession: isSecondaryWindow() })',
+    );
+  });
+
+  it('rechecks the durable active state at every Main dispatch boundary', () => {
+    const enqueueStart = registerSource.indexOf('MAKER_INVOKE.INPUT_ENQUEUE');
+    const enqueueEnd = registerSource.indexOf('MAKER_INVOKE.INPUT_COMPACT', enqueueStart);
+    const enqueueBody = registerSource.slice(enqueueStart, enqueueEnd);
+    const enqueueFence = enqueueBody.indexOf('await assertSessionActiveForManualDispatch(sid);');
+    const enqueueDispatch = enqueueBody.indexOf('inputCoordinator.enqueue(sid, queued');
+
+    const steerStart = registerSource.indexOf('MAKER_INVOKE.INPUT_STEER');
+    const steerEnd = registerSource.indexOf('MAKER_INVOKE.INPUT_STOP', steerStart);
+    const steerBody = registerSource.slice(steerStart, steerEnd);
+    const steerFence = steerBody.indexOf('await assertSessionActiveForManualDispatch(sid);');
+    const steerDispatch = steerBody.indexOf('inputCoordinator.steer(');
+
+    const directFence = makerSendTransactionSource.indexOf(
+      'await deps.assertSessionActiveForManualDispatch?.(sessionId);',
+    );
+    const directDispatch = makerSendTransactionSource.indexOf(
+      'const sendResult = await sess.send(',
+    );
+    const acceptedSteerStart = registerSource.indexOf('const steerToAgentAccepted = async');
+    const steerMetadataRead = registerSource.indexOf(
+      'const meta = await maker.getSessionMeta(sessionId).catch(() => null);',
+      acceptedSteerStart,
+    );
+    const finalSteerFence = registerSource.indexOf(
+      'await assertSessionActiveForManualDispatch(sessionId);',
+      steerMetadataRead,
+    );
+    const vendorSteer = registerSource.indexOf(
+      'await sess.steer(steerPayload as never,',
+      finalSteerFence,
+    );
+
+    expect(enqueueFence).toBeGreaterThan(-1);
+    expect(enqueueDispatch).toBeGreaterThan(enqueueFence);
+    expect(steerFence).toBeGreaterThan(-1);
+    expect(steerDispatch).toBeGreaterThan(steerFence);
+    expect(directFence).toBeGreaterThan(-1);
+    expect(directDispatch).toBeGreaterThan(directFence);
+    expect(acceptedSteerStart).toBeGreaterThan(-1);
+    expect(steerMetadataRead).toBeGreaterThan(-1);
+    expect(finalSteerFence).toBeGreaterThan(steerMetadataRead);
+    expect(vendorSteer).toBeGreaterThan(finalSteerFence);
+    expect(makerChatStoreSource).toContain(
+      '...(opts?.requireActiveSession ? { requireActiveSession: true } : {})',
     );
   });
 });

--- a/apps/desktop/src/renderer/__tests__/archivedSecondaryWindowOwnership.test.ts
+++ b/apps/desktop/src/renderer/__tests__/archivedSecondaryWindowOwnership.test.ts
@@ -45,8 +45,8 @@ describe('archived secondary-window ownership', () => {
     expect(closePreflight).toBeGreaterThan(ownerGateEnd);
     expect(cancelGate).toBeGreaterThan(closePreflight);
     expect(closeWindow).toBeGreaterThan(cancelGate);
-    expect(sessionViewSource).toContain(
-      '}, [session?.status, sessionId, ownsWindowRoute, onBeforeSecondaryWindowClose]);',
+    expect(sessionViewSource).toMatch(
+      /\}, \[\s*session\?\.status,\s*sessionId,\s*ownsWindowRoute,\s*onBeforeSecondaryWindowClose,\s*secondaryWindowArchiveOwner,\s*\]\);/,
     );
   });
 
@@ -66,12 +66,40 @@ describe('archived secondary-window ownership', () => {
     expect(orcaSplitViewSource).toContain(
       'onBeforeSecondaryWindowClose={onBeforeSecondaryWindowClose}',
     );
+    expect(orcaSplitViewSource).toContain('secondaryWindowArchiveOwner="host"');
+  });
+
+  it('keeps the Orca host subscribed to archived leads and closes after the dirty-file preflight', () => {
+    expect(orcaSplitViewSource).toContain("useCCSessions({ includeArchived: 'all' })");
+    const archivedLeadGuard = orcaSplitViewSource.indexOf(
+      "if (leadSession?.status !== 'archived') return;",
+    );
+    const secondaryWindowGuard = orcaSplitViewSource.indexOf(
+      'if (!isSecondaryWindow()) return;',
+      archivedLeadGuard,
+    );
+    const closePreflight = orcaSplitViewSource.indexOf(
+      'await onBeforeSecondaryWindowClose()',
+      secondaryWindowGuard,
+    );
+    const cancelGate = orcaSplitViewSource.indexOf(
+      'if (!allowClose || cancelled) return;',
+      closePreflight,
+    );
+    const closeWindow = orcaSplitViewSource.indexOf(
+      'window.electronAPI?.windowCloseSelf();',
+      cancelGate,
+    );
+
+    expect(archivedLeadGuard).toBeGreaterThan(-1);
+    expect(secondaryWindowGuard).toBeGreaterThan(archivedLeadGuard);
+    expect(closePreflight).toBeGreaterThan(secondaryWindowGuard);
+    expect(cancelGate).toBeGreaterThan(closePreflight);
+    expect(closeWindow).toBeGreaterThan(cancelGate);
   });
 
   it('lets the workdir route protect dirty files before either route-owning chat closes', () => {
-    expect(workdirBrowseRouteSource).toContain(
-      '() => confirmSwitchAway(selectedPath, null)',
-    );
+    expect(workdirBrowseRouteSource).toContain('() => confirmSwitchAway(selectedPath, null)');
     expect(
       workdirBrowseRouteSource.match(
         /onBeforeSecondaryWindowClose=\{confirmSecondaryWindowClose\}/g,

--- a/apps/desktop/src/renderer/__tests__/archivedSecondaryWindowOwnership.test.ts
+++ b/apps/desktop/src/renderer/__tests__/archivedSecondaryWindowOwnership.test.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const sessionViewSource = readFileSync(
+  resolve(__dirname, '..', 'features', 'cc-agent', 'CCAgentSessionView.tsx'),
+  'utf8',
+);
+
+describe('archived secondary-window ownership', () => {
+  it('removes embedded split panes without letting them close the route-owning window', () => {
+    const archivedEffect = sessionViewSource.indexOf("if (session?.status !== 'archived') return;");
+    const removePane = sessionViewSource.indexOf(
+      'splitGroupStore.removeSession(sessionId);',
+      archivedEffect,
+    );
+    const ownerGate = sessionViewSource.indexOf('if (!ownsWindowRoute) {', removePane);
+    const ownerGateEnd = sessionViewSource.indexOf('\n    }', ownerGate);
+    const closeWindow = sessionViewSource.indexOf(
+      'window.electronAPI?.windowClose();',
+      ownerGateEnd,
+    );
+
+    expect(archivedEffect).toBeGreaterThan(-1);
+    expect(removePane).toBeGreaterThan(archivedEffect);
+    expect(ownerGate).toBeGreaterThan(removePane);
+    expect(ownerGateEnd).toBeGreaterThan(ownerGate);
+    expect(closeWindow).toBeGreaterThan(ownerGateEnd);
+    expect(sessionViewSource).toContain('}, [session?.status, sessionId, ownsWindowRoute]);');
+  });
+});

--- a/apps/desktop/src/renderer/__tests__/archivedSecondaryWindowOwnership.test.ts
+++ b/apps/desktop/src/renderer/__tests__/archivedSecondaryWindowOwnership.test.ts
@@ -335,5 +335,7 @@ describe('archived secondary-window ownership', () => {
     expect(makerChatStoreSource).toContain(
       '...(opts?.requireActiveSession ? { requireActiveSession: true } : {})',
     );
+    expect(registerSource).toContain('delete normalized.requireActiveSession;');
+    expect(enqueueBody).toContain('{ requireActiveSession: true }');
   });
 });

--- a/apps/desktop/src/renderer/__tests__/archivedSecondaryWindowOwnership.test.ts
+++ b/apps/desktop/src/renderer/__tests__/archivedSecondaryWindowOwnership.test.ts
@@ -317,9 +317,17 @@ describe('archived secondary-window ownership', () => {
       'await assertSessionActiveForManualDispatch(sessionId);',
       steerMetadataRead,
     );
+    const finalSteerLock = registerSource.indexOf(
+      'await withSendToSessionLock(sessionId, async () => {',
+      steerMetadataRead,
+    );
     const vendorSteer = registerSource.indexOf(
       'await sess.steer(steerPayload as never,',
       finalSteerFence,
+    );
+    const finalSteerLockEnd = registerSource.indexOf(
+      "\n      });\n      log.info('steer: delivered'",
+      vendorSteer,
     );
 
     expect(enqueueFence).toBeGreaterThan(-1);
@@ -330,8 +338,10 @@ describe('archived secondary-window ownership', () => {
     expect(directDispatch).toBeGreaterThan(directFence);
     expect(acceptedSteerStart).toBeGreaterThan(-1);
     expect(steerMetadataRead).toBeGreaterThan(-1);
-    expect(finalSteerFence).toBeGreaterThan(steerMetadataRead);
+    expect(finalSteerLock).toBeGreaterThan(steerMetadataRead);
+    expect(finalSteerFence).toBeGreaterThan(finalSteerLock);
     expect(vendorSteer).toBeGreaterThan(finalSteerFence);
+    expect(finalSteerLockEnd).toBeGreaterThan(vendorSteer);
     expect(makerChatStoreSource).toContain(
       '...(opts?.requireActiveSession ? { requireActiveSession: true } : {})',
     );

--- a/apps/desktop/src/renderer/__tests__/archivedSecondaryWindowOwnership.test.ts
+++ b/apps/desktop/src/renderer/__tests__/archivedSecondaryWindowOwnership.test.ts
@@ -7,6 +7,14 @@ const sessionViewSource = readFileSync(
   resolve(__dirname, '..', 'features', 'cc-agent', 'CCAgentSessionView.tsx'),
   'utf8',
 );
+const orcaSplitViewSource = readFileSync(
+  resolve(__dirname, '..', 'features', 'cc-agent', 'OrcaSplitView.tsx'),
+  'utf8',
+);
+const workdirBrowseRouteSource = readFileSync(
+  resolve(__dirname, '..', 'features', 'cc-agent', 'workdir-browse', 'WorkdirBrowseRoute.tsx'),
+  'utf8',
+);
 
 describe('archived secondary-window ownership', () => {
   it('removes embedded split panes without letting them close the route-owning window', () => {
@@ -17,16 +25,77 @@ describe('archived secondary-window ownership', () => {
     );
     const ownerGate = sessionViewSource.indexOf('if (!ownsWindowRoute) {', removePane);
     const ownerGateEnd = sessionViewSource.indexOf('\n    }', ownerGate);
-    const closeWindow = sessionViewSource.indexOf(
-      'window.electronAPI?.windowClose();',
+    const closePreflight = sessionViewSource.indexOf(
+      'await onBeforeSecondaryWindowClose()',
       ownerGateEnd,
+    );
+    const cancelGate = sessionViewSource.indexOf(
+      'if (!allowClose || cancelled) return;',
+      closePreflight,
+    );
+    const closeWindow = sessionViewSource.indexOf(
+      'window.electronAPI?.windowCloseSelf();',
+      cancelGate,
     );
 
     expect(archivedEffect).toBeGreaterThan(-1);
     expect(removePane).toBeGreaterThan(archivedEffect);
     expect(ownerGate).toBeGreaterThan(removePane);
     expect(ownerGateEnd).toBeGreaterThan(ownerGate);
-    expect(closeWindow).toBeGreaterThan(ownerGateEnd);
-    expect(sessionViewSource).toContain('}, [session?.status, sessionId, ownsWindowRoute]);');
+    expect(closePreflight).toBeGreaterThan(ownerGateEnd);
+    expect(cancelGate).toBeGreaterThan(closePreflight);
+    expect(closeWindow).toBeGreaterThan(cancelGate);
+    expect(sessionViewSource).toContain(
+      '}, [session?.status, sessionId, ownsWindowRoute, onBeforeSecondaryWindowClose]);',
+    );
+  });
+
+  it('marks the Orca lead as route owner and the worker as embedded', () => {
+    const leadView = orcaSplitViewSource.indexOf('sessionIdProp={leadSessionId}');
+    const leadOwner = orcaSplitViewSource.indexOf('navigationMode="route-owner"', leadView);
+    const workerView = orcaSplitViewSource.indexOf('sessionIdProp={workerSession.id}', leadOwner);
+    const workerEmbedded = orcaSplitViewSource.indexOf(
+      'navigationMode="sidebar-embedded"',
+      workerView,
+    );
+
+    expect(leadView).toBeGreaterThan(-1);
+    expect(leadOwner).toBeGreaterThan(leadView);
+    expect(workerView).toBeGreaterThan(leadOwner);
+    expect(workerEmbedded).toBeGreaterThan(workerView);
+    expect(orcaSplitViewSource).toContain(
+      'onBeforeSecondaryWindowClose={onBeforeSecondaryWindowClose}',
+    );
+  });
+
+  it('lets the workdir route protect dirty files before either route-owning chat closes', () => {
+    expect(workdirBrowseRouteSource).toContain(
+      '() => confirmSwitchAway(selectedPath, null)',
+    );
+    expect(
+      workdirBrowseRouteSource.match(
+        /onBeforeSecondaryWindowClose=\{confirmSecondaryWindowClose\}/g,
+      ),
+    ).toHaveLength(2);
+  });
+
+  it('blocks both the composer and send path for archived secondary-window sessions', () => {
+    const guardDeclaration = sessionViewSource.indexOf(
+      'const blocksArchivedSecondaryWindowInput =',
+    );
+    const sendGuard = sessionViewSource.indexOf(
+      'if (blocksArchivedSecondaryWindowInput) return false;',
+      guardDeclaration,
+    );
+    const composerDisabled = sessionViewSource.indexOf('disabled={', sendGuard);
+    const composerGuard = sessionViewSource.indexOf(
+      'blocksArchivedSecondaryWindowInput',
+      composerDisabled,
+    );
+
+    expect(guardDeclaration).toBeGreaterThan(-1);
+    expect(sendGuard).toBeGreaterThan(guardDeclaration);
+    expect(composerDisabled).toBeGreaterThan(sendGuard);
+    expect(composerGuard).toBeGreaterThan(composerDisabled);
   });
 });

--- a/apps/desktop/src/renderer/__tests__/archivedSecondaryWindowOwnership.test.ts
+++ b/apps/desktop/src/renderer/__tests__/archivedSecondaryWindowOwnership.test.ts
@@ -210,6 +210,79 @@ describe('archived secondary-window ownership', () => {
     }
   });
 
+  it('rechecks the archive lifecycle after slash reconciliation and before every desktop side effect', () => {
+    const slashDispatch = sessionViewSource.slice(
+      sessionViewSource.indexOf('const maybeDispatchDesktopSlashCommand = useCallback('),
+      sessionViewSource.indexOf('const handleWorkingDirChange = useCallback('),
+    );
+    const reconciliation = slashDispatch.indexOf('const reconciled =');
+    const lifecycleFence = slashDispatch.indexOf('await options.beforeDesktopDispatch()');
+    const startReview = slashDispatch.indexOf('await window.electronAPI.maker.startReview({');
+    const executeDesktopCommand = slashDispatch.indexOf(
+      'const dispatchResult = await dispatchCommand(hit',
+    );
+
+    expect(reconciliation).toBeGreaterThan(-1);
+    expect(lifecycleFence).toBeGreaterThan(reconciliation);
+    expect(startReview).toBeGreaterThan(lifecycleFence);
+    expect(executeDesktopCommand).toBeGreaterThan(startReview);
+    expect(slashDispatch).toContain("if (dispatchResult === 'rejected')");
+    expect(slashDispatch).toContain('requireActiveSession: true');
+
+    for (const source of [
+      sessionViewSource.slice(
+        sessionViewSource.indexOf('const handleWorkingDirChange = useCallback('),
+        sessionViewSource.indexOf('const maybeShowContextUsage = useCallback('),
+      ),
+      sessionViewSource.slice(
+        sessionViewSource.indexOf('const handleSend = useCallback('),
+        sessionViewSource.indexOf('const handleStopSession = useCallback('),
+      ),
+      sessionViewSource.slice(
+        sessionViewSource.indexOf('const restoreRecoverableHandoff = useCallback('),
+        sessionViewSource.indexOf('const pendingGoalConsumedRef = useRef(false);'),
+      ),
+    ]) {
+      expect(source).toContain('beforeDesktopDispatch: allowArchivedSecondaryWindowEnqueue');
+    }
+  });
+
+  it('serializes secondary-window desktop commands, Review, and clear against archival in Main', () => {
+    const desktopHandler = registerSource.slice(
+      registerSource.indexOf('MAKER_INVOKE.EXECUTE_DESKTOP_COMMAND'),
+      registerSource.indexOf('MAKER_INVOKE.LIST_AGENT_COMMANDS'),
+    );
+    const reviewRegistration = registerSource.slice(
+      registerSource.indexOf('registerReviewStartHandler(makerSessionRegistry'),
+      registerSource.indexOf(
+        'registerPrecreatedWorktreeDiscardHandler',
+        registerSource.indexOf('registerReviewStartHandler(makerSessionRegistry'),
+      ),
+    );
+    const clearHandler = registerSource.slice(
+      registerSource.indexOf('MAKER_INVOKE.INPUT_CLEAR_SESSION'),
+      registerSource.indexOf('MAKER_INVOKE.ABORT_SESSION'),
+    );
+
+    expect(desktopHandler).toContain('assertTrustedAppRendererEvent(e)');
+    expect(desktopHandler).toContain('isSecondarySessionWindowEvent(e)');
+    expect(desktopHandler).toContain('const mustFenceActiveSession =');
+    expect(desktopHandler).toContain('await withSendToSessionLock(sessionId, async () => {');
+    expect(desktopHandler).toContain('await assertSessionActiveForManualDispatch(sessionId)');
+    expect(desktopHandler).toContain('sessionRouteLockHeld: true');
+    expect(desktopHandler).toContain('rawContext.requireActiveSession === true');
+    expect(reviewRegistration).toContain('acquireSourceSessionLifecycle: async');
+    expect(reviewRegistration).toContain(
+      'if (!isSecondarySessionWindowEvent(ipcEvent)) return () => {}',
+    );
+    expect(reviewRegistration).toContain('await acquireSendToSessionLock(sourceSessionId)');
+    expect(clearHandler).toContain(
+      'isSecondarySessionWindowEvent(e) || requiresActiveSessionForDispatch(opts)',
+    );
+    expect(clearHandler).toContain('await assertSessionActiveForManualDispatch(sid)');
+    expect(registerSource).toContain('if (options?.sessionRouteLockHeld) {');
+  });
+
   it('removes queue resume and steer dispatchers while an archived secondary window stays open', () => {
     const resumeHandler = sessionViewSource.slice(
       sessionViewSource.indexOf('const handleArchivedSafeQueueResume = useCallback('),
@@ -349,29 +422,4 @@ describe('archived secondary-window ownership', () => {
     expect(enqueueBody).toContain('{ requireActiveSession: true }');
   });
 
-  it('fences desktop slash-command effects before their Main dispatch boundary', () => {
-    const helperStart = sessionViewSource.indexOf('const maybeDispatchDesktopSlashCommand = useCallback(');
-    const helperEnd = sessionViewSource.indexOf('const handleWorkingDirChange = useCallback(', helperStart);
-    const helperBody = sessionViewSource.slice(helperStart, helperEnd);
-    const reviewFence = helperBody.indexOf(
-      'await options.beforeDesktopDispatch()',
-      helperBody.indexOf("hit.name === 'review'"),
-    );
-    const reviewDispatch = helperBody.indexOf('window.electronAPI.maker.startReview', reviewFence);
-    const commandFence = helperBody.indexOf('await options.beforeDesktopDispatch()', reviewDispatch);
-    const commandDispatch = helperBody.indexOf('await dispatchCommand(hit, {', commandFence);
-    const mainFence = registerSource.indexOf('await assertSessionActiveForManualDispatch(c.sessionId);');
-    const mainDispatch = registerSource.indexOf('getDesktopCommandRegistry().execute(name, c);', mainFence);
-
-    expect(reviewFence).toBeGreaterThan(-1);
-    expect(reviewDispatch).toBeGreaterThan(reviewFence);
-    expect(commandFence).toBeGreaterThan(reviewDispatch);
-    expect(commandDispatch).toBeGreaterThan(commandFence);
-    expect(mainFence).toBeGreaterThan(-1);
-    expect(mainDispatch).toBeGreaterThan(mainFence);
-    expect(sessionViewSource).toContain(
-      'beforeDesktopDispatch: allowArchivedSecondaryWindowEnqueue',
-    );
-    expect(helperBody).toContain('requireActiveSession: true');
-  });
 });

--- a/apps/desktop/src/renderer/__tests__/archivedSecondaryWindowOwnership.test.ts
+++ b/apps/desktop/src/renderer/__tests__/archivedSecondaryWindowOwnership.test.ts
@@ -422,4 +422,49 @@ describe('archived secondary-window ownership', () => {
     expect(enqueueBody).toContain('{ requireActiveSession: true }');
   });
 
+  it('fences secondary-window /context at the Main dispatch boundary without changing primary semantics', () => {
+    const handlerStart = registerSource.indexOf('MAKER_INVOKE.GET_CONTEXT_USAGE');
+    expect(handlerStart).toBeGreaterThan(-1);
+    const handlerEnd = registerSource.indexOf(
+      'ipcMain.handle(',
+      handlerStart + 'MAKER_INVOKE.GET_CONTEXT_USAGE'.length,
+    );
+    const handlerBody = registerSource.slice(handlerStart, handlerEnd);
+
+    // 副窗口判定必须在任何 session 查找 / lazy-bootstrap 之前。
+    const secondaryProbe = handlerBody.indexOf('isSecondarySessionWindowEvent(');
+    expect(secondaryProbe).toBeGreaterThan(-1);
+    const sessionLookup = handlerBody.indexOf('maker.getSession(sessionId)');
+    expect(sessionLookup).toBeGreaterThan(secondaryProbe);
+
+    // 副窗口路径走与 send/steer 同一条 route lock + durable active 复核。
+    expect(handlerBody).toContain('if (!fromSecondary) return run();');
+    const lockStart = handlerBody.indexOf(
+      'return withSendToSessionLock(sessionId, async () => {',
+      secondaryProbe,
+    );
+    expect(lockStart).toBeGreaterThan(-1);
+    const activeCheck = handlerBody.indexOf(
+      'await assertSessionActiveForManualDispatch(sessionId);',
+      lockStart,
+    );
+    expect(activeCheck).toBeGreaterThan(lockStart);
+    const runInsideLock = handlerBody.indexOf('return run();', activeCheck);
+    expect(runInsideLock).toBeGreaterThan(activeCheck);
+
+    // lazy-bootstrap(会重建 agent 进程)被包在 run() 内,所以副窗口在已归档任务上
+    // 会在拿到锁后被 active 复核拦截,bootstrapSession 不可能执行。
+    expect(handlerBody.indexOf('await bootstrapSession(co)')).toBeGreaterThan(sessionLookup);
+    expect(handlerBody.indexOf('await reconcileCreateOptsAgainstDb(sessionId, co)')).toBeGreaterThan(
+      sessionLookup,
+    );
+
+    // 主窗口 / device-link 路径不被新 fence 包裹,保留历史 /context 可重新激活会话的语义。
+    // 具体表现:`if (!fromSecondary) return run();` 是主窗口唯一出口,且主窗口路径没有
+    // 进入 withSendToSessionLock 分支。
+    const nonSecondaryReturn = handlerBody.indexOf('if (!fromSecondary) return run();');
+    expect(nonSecondaryReturn).toBeGreaterThan(-1);
+    expect(nonSecondaryReturn).toBeLessThan(lockStart);
+  });
+
 });

--- a/apps/desktop/src/renderer/__tests__/archivedSecondaryWindowOwnership.test.ts
+++ b/apps/desktop/src/renderer/__tests__/archivedSecondaryWindowOwnership.test.ts
@@ -193,7 +193,33 @@ describe('archived secondary-window ownership', () => {
 
     for (const source of [workingDirChange, recoverableFirstMessage, ordinarySend]) {
       expect(source).toContain('beforeEnqueue: allowArchivedSecondaryWindowEnqueue');
+      expect(source).toContain('beforeDispatch: allowArchivedSecondaryWindowEnqueue');
     }
+  });
+
+  it('removes queue resume and steer dispatchers while an archived secondary window stays open', () => {
+    const resumeHandler = sessionViewSource.slice(
+      sessionViewSource.indexOf('const handleArchivedSafeQueueResume = useCallback('),
+      sessionViewSource.indexOf('const handleArchivedSafeQueueSteer = useCallback('),
+    );
+    const steerHandler = sessionViewSource.slice(
+      sessionViewSource.indexOf('const handleArchivedSafeQueueSteer = useCallback('),
+      sessionViewSource.indexOf(
+        'useEffect(() => {',
+        sessionViewSource.indexOf('const handleArchivedSafeQueueSteer = useCallback('),
+      ),
+    );
+    const chatInputStart = sessionViewSource.indexOf('<ChatInput');
+    const chatInput = sessionViewSource.slice(
+      chatInputStart,
+      sessionViewSource.indexOf('/>', chatInputStart),
+    );
+
+    expect(resumeHandler).toContain('isArchivedSecondaryWindowInputBlocked()');
+    expect(steerHandler).toContain('isArchivedSecondaryWindowInputBlocked()');
+    expect(chatInput).toContain('blocksArchivedSecondaryWindowInput');
+    expect(chatInput).toContain(': handleArchivedSafeQueueResume');
+    expect(chatInput).toContain(': handleArchivedSafeQueueSteer');
   });
 
   it('blocks every retry and continuation entry after its task is archived', () => {
@@ -239,5 +265,8 @@ describe('archived secondary-window ownership', () => {
         sessionViewSource.indexOf('const handleContinueAfterUsageReset = useCallback('),
       ),
     ).toContain('beforeEnqueue: allowArchivedSecondaryWindowEnqueue');
+    expect(sessionViewSource).toContain(
+      'retryLastError({ requireActiveSession: isSecondaryWindow() })',
+    );
   });
 });

--- a/apps/desktop/src/renderer/__tests__/makerChatStoreTextDeltaBatching.test.ts
+++ b/apps/desktop/src/renderer/__tests__/makerChatStoreTextDeltaBatching.test.ts
@@ -7100,6 +7100,92 @@ describe('makerChatStore text delta batching', () => {
     ).rejects.toThrow(/workdir-missing/);
   });
 
+  it('does not dispatch a UI trigger when its enqueue-time preflight rejects', async () => {
+    vi.mocked(sessionService.get).mockResolvedValueOnce({
+      agentKind: 'codex',
+      remoteHostId: null,
+      sdkSessionId: null,
+      fastMode: false,
+      contextTokens: 0,
+      contextWindow: 0,
+      totalCostUsd: 0,
+      workingDir: WORKING_DIR,
+      model: MODEL,
+      effort: EFFORT,
+      permissionMode: PERMISSION_MODE,
+    } as unknown as Awaited<ReturnType<typeof sessionService.get>>);
+    const beforeEnqueue = vi.fn(async () => false);
+
+    await expect(
+      makerChatStore.sendUiTrigger(SESSION_ID, CONTINUE_AFTER_APP_EXIT_PROMPT, {
+        beforeEnqueue,
+      }),
+    ).resolves.toBe(false);
+
+    expect(beforeEnqueue).toHaveBeenCalledTimes(1);
+    expect(input.enqueue).not.toHaveBeenCalled();
+    expect(window.electronAPI.maker.send).not.toHaveBeenCalled();
+  });
+
+  it('rechecks a local send after attachment materialization before enqueueing it', async () => {
+    let resolveMaterialize!: (value: {
+      url: string;
+      name: string;
+      ext: string;
+      mimeType: string;
+      size: number;
+    }) => void;
+    vi.mocked(window.electronAPI.cacheMediaForSession).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveMaterialize = resolve;
+        }),
+    );
+    const attachment: AttachedFile = {
+      id: 'archive-race-annotation',
+      name: 'archive-race.png',
+      path: '',
+      ext: '.png',
+      size: 1,
+      category: 'image',
+      mimeType: 'image/png',
+      url: 'xdt-image://source/archive-race.png',
+      cacheUrlShared: true,
+    };
+    let archived = false;
+    const beforeEnqueue = vi.fn(async () => !archived);
+
+    const send = makerChatStore.sendMessage(
+      SESSION_ID,
+      'annotated send',
+      MODEL,
+      EFFORT,
+      PERMISSION_MODE,
+      WORKING_DIR,
+      [attachment],
+      undefined,
+      { beforeEnqueue },
+    );
+    await flushPromises();
+    expect(beforeEnqueue).not.toHaveBeenCalled();
+    expect(input.enqueue).not.toHaveBeenCalled();
+
+    archived = true;
+    resolveMaterialize({
+      url: 'xdt-image://text-delta-batching/archive-race-private.png',
+      name: 'archive-race-private.png',
+      ext: '.png',
+      mimeType: 'image/png',
+      size: 1,
+    });
+
+    await expect(send).resolves.toBe(false);
+    expect(beforeEnqueue).toHaveBeenCalledOnce();
+    expect(input.enqueue).not.toHaveBeenCalled();
+    expect(makerChatStore.getSnapshot(SESSION_ID).messages).toHaveLength(0);
+    expect(makerChatStore.getSnapshot(SESSION_ID).pendingQueue).toHaveLength(0);
+  });
+
   it('requests executor-side interrupted-turn ack for a direct-send continue fallback', async () => {
     const api = window.electronAPI.maker;
     const ackInterrupted = window.electronAPI.localDb.sessions.ackInterrupted;

--- a/apps/desktop/src/renderer/__tests__/makerChatStoreTextDeltaBatching.test.ts
+++ b/apps/desktop/src/renderer/__tests__/makerChatStoreTextDeltaBatching.test.ts
@@ -2106,6 +2106,14 @@ describe('makerChatStore text delta batching', () => {
     expect(makerChatStore.getSnapshot(SESSION_ID).messages).toEqual([]);
   });
 
+  it('forwards the secondary-window active-session fence to the final local clear boundary', async () => {
+    await makerChatStore.clearSession(SESSION_ID, { requireActiveSession: true });
+
+    expect(input.clearSession).toHaveBeenCalledWith(SESSION_ID, expect.any(String), {
+      requireActiveSession: true,
+    });
+  });
+
   it('continues clearing local state when the clear guard hangs', async () => {
     input.clearSession.mockReturnValueOnce(new Promise<AgentInputProjection>(() => {}));
 

--- a/apps/desktop/src/renderer/__tests__/makerChatStoreTextDeltaBatching.test.ts
+++ b/apps/desktop/src/renderer/__tests__/makerChatStoreTextDeltaBatching.test.ts
@@ -2178,6 +2178,33 @@ describe('makerChatStore text delta batching', () => {
     expect(window.electronAPI.maker.closeSession).not.toHaveBeenCalled();
   });
 
+  it('waits for a fenced clear guard instead of clearing after timeout', async () => {
+    let settleClear!: (error: Error) => void;
+    input.clearSession.mockReturnValueOnce(
+      new Promise<AgentInputProjection>((_resolve, reject) => {
+        settleClear = reject;
+      }),
+    );
+
+    emitTextDelta('preserve until the guard settles');
+    vi.advanceTimersByTime(32);
+    const clear = makerChatStore.clearSession(SESSION_ID, { requireActiveSession: true });
+    await flushPromises();
+
+    vi.advanceTimersByTime(500);
+    await flushPromises();
+    expect(makerChatStore.getSnapshot(SESSION_ID).messages).toEqual([
+      expect.objectContaining({ content: 'preserve until the guard settles' }),
+    ]);
+    expect(sessionService.update).not.toHaveBeenCalled();
+
+    settleClear(new Error('SESSION_NOT_ACTIVE: session is archived'));
+    await clear;
+    expect(makerChatStore.getSnapshot(SESSION_ID).messages).toEqual([
+      expect.objectContaining({ content: 'preserve until the guard settles' }),
+    ]);
+  });
+
   it('continues clearing local state when the clear guard hangs', async () => {
     input.clearSession.mockReturnValueOnce(new Promise<AgentInputProjection>(() => {}));
 

--- a/apps/desktop/src/renderer/__tests__/makerChatStoreTextDeltaBatching.test.ts
+++ b/apps/desktop/src/renderer/__tests__/makerChatStoreTextDeltaBatching.test.ts
@@ -113,6 +113,7 @@ import {
 import { CONTINUE_AFTER_APP_EXIT_PROMPT } from '../../shared/interruptedTurn';
 
 const SESSION_ID = 'text-delta-batching';
+const SHARED_TARGET_PEER_SESSION_ID = `${SESSION_ID}-shared-target-peer`;
 const MODEL = 'gpt-5';
 const EFFORT = 'medium';
 const PERMISSION_MODE = 'default';
@@ -518,6 +519,7 @@ describe('makerChatStore text delta batching', () => {
     vi.clearAllMocks();
     makerChatStore.__teardownGlobalListeners();
     makerChatStore.purgeSession(SESSION_ID);
+    makerChatStore.purgeSession(SHARED_TARGET_PEER_SESSION_ID);
     makerChatStore.__resetRemoteTerminalTombstonesForTest();
     remoteProjectsStore.clear();
     remoteProjectsStore.__resetPinnedOriginsForTest();
@@ -533,6 +535,7 @@ describe('makerChatStore text delta batching', () => {
   afterEach(() => {
     makerChatStore.__teardownGlobalListeners();
     makerChatStore.purgeSession(SESSION_ID);
+    makerChatStore.purgeSession(SHARED_TARGET_PEER_SESSION_ID);
     makerChatStore.__resetRemoteTerminalTombstonesForTest();
     remoteProjectsStore.clear();
     remoteProjectsStore.__resetPinnedOriginsForTest();
@@ -6235,6 +6238,80 @@ describe('makerChatStore text delta batching', () => {
     expect(beforeDispatch).toHaveBeenCalledOnce();
     expect(enqueueCalls).toBe(0);
     expect(restore).toHaveBeenCalledOnce();
+    expect(makerChatStore.getSnapshot(SESSION_ID).messages).toHaveLength(0);
+  });
+
+  it('keeps another in-flight request on the shared controlled endpoint isolated from a rejected lifecycle fence', async () => {
+    remoteProjectsStore.pinSessionOrigin('device-1', SESSION_ID);
+    remoteProjectsStore.pinSessionOrigin('device-1', SHARED_TARGET_PEER_SESSION_ID);
+    let online = false;
+    const dispatched: Array<{ sessionId: string; text: string }> = [];
+    const rejectedRestore = vi.fn();
+    const peerRestore = vi.fn();
+    deviceLinkInvoke.mockImplementation(async (_deviceId, channel, args) => {
+      const sessionId = args[0] as string;
+      if (channel === 'maker:input:get-projection') {
+        if (!online) throw new Error('[DEVICE_LINK_NOT_CONNECTED] relay offline');
+        return projection(sessionId);
+      }
+      if (channel === 'maker:input:enqueue') {
+        const item = args[1] as AgentInputQueuedMessage;
+        dispatched.push({ sessionId, text: item.text });
+        return projection(sessionId, { pendingQueue: [item] });
+      }
+      throw new Error(`unexpected remote channel: ${channel}`);
+    });
+
+    await expect(
+      makerChatStore.sendMessage(
+        SESSION_ID,
+        'archived peer request',
+        MODEL,
+        EFFORT,
+        PERMISSION_MODE,
+        WORKING_DIR,
+        undefined,
+        undefined,
+        {
+          beforeEnqueue: async () => true,
+          beforeDispatch: async () => false,
+          onRemoteOptimisticFailure: rejectedRestore,
+        },
+      ),
+    ).resolves.toBe(true);
+    await expect(
+      makerChatStore.sendMessage(
+        SHARED_TARGET_PEER_SESSION_ID,
+        'healthy peer request',
+        MODEL,
+        EFFORT,
+        PERMISSION_MODE,
+        WORKING_DIR,
+        undefined,
+        undefined,
+        {
+          beforeEnqueue: async () => true,
+          beforeDispatch: async () => true,
+          onRemoteOptimisticFailure: peerRestore,
+        },
+      ),
+    ).resolves.toBe(true);
+    expect(dispatched).toEqual([]);
+
+    // Both controller intents share the same controlled endpoint and reconnect
+    // edge. Rejecting one record is request-scoped: it must not tear down the
+    // shared link or suppress the other in-flight record.
+    online = true;
+    onPresenceChanged?.({ deviceId: 'device-1', online: true });
+    await flushPromises();
+    await flushPromises();
+    await flushPromises();
+
+    expect(rejectedRestore).toHaveBeenCalledOnce();
+    expect(peerRestore).not.toHaveBeenCalled();
+    expect(dispatched).toEqual([
+      { sessionId: SHARED_TARGET_PEER_SESSION_ID, text: 'healthy peer request' },
+    ]);
     expect(makerChatStore.getSnapshot(SESSION_ID).messages).toHaveLength(0);
   });
 

--- a/apps/desktop/src/renderer/__tests__/makerChatStoreTextDeltaBatching.test.ts
+++ b/apps/desktop/src/renderer/__tests__/makerChatStoreTextDeltaBatching.test.ts
@@ -2133,6 +2133,51 @@ describe('makerChatStore text delta batching', () => {
     expect(sessionService.update).not.toHaveBeenCalled();
   });
 
+  it('preserves a remote optimistic send when a fenced clear is rejected', async () => {
+    remoteProjectsStore.pinSessionOrigin('device-1', SESSION_ID);
+    let rejectClear!: (error: Error) => void;
+    deviceLinkInvoke.mockImplementation(async (_deviceId, channel) => {
+      if (channel === 'maker:input:clear-session') {
+        return new Promise<AgentInputProjection>((_resolve, reject) => {
+          rejectClear = reject;
+        });
+      }
+      throw new Error(`unexpected remote channel: ${channel}`);
+    });
+
+    const clear = makerChatStore.clearSession(SESSION_ID, { requireActiveSession: true });
+    await flushPromises();
+    expect(rejectClear).toBeDefined();
+
+    await expect(
+      makerChatStore.sendMessage(
+        SESSION_ID,
+        'preserve this remote optimistic send',
+        MODEL,
+        EFFORT,
+        PERMISSION_MODE,
+        WORKING_DIR,
+      ),
+    ).resolves.toBe(true);
+    expect(makerChatStore.getSnapshot(SESSION_ID).messages).toEqual([
+      expect.objectContaining({
+        content: 'preserve this remote optimistic send',
+        isPendingPersist: true,
+      }),
+    ]);
+
+    rejectClear(new Error('SESSION_NOT_ACTIVE: session is archived'));
+    await clear;
+
+    expect(makerChatStore.getSnapshot(SESSION_ID).messages).toEqual([
+      expect.objectContaining({
+        content: 'preserve this remote optimistic send',
+        isPendingPersist: true,
+      }),
+    ]);
+    expect(window.electronAPI.maker.closeSession).not.toHaveBeenCalled();
+  });
+
   it('continues clearing local state when the clear guard hangs', async () => {
     input.clearSession.mockReturnValueOnce(new Promise<AgentInputProjection>(() => {}));
 

--- a/apps/desktop/src/renderer/__tests__/makerChatStoreTextDeltaBatching.test.ts
+++ b/apps/desktop/src/renderer/__tests__/makerChatStoreTextDeltaBatching.test.ts
@@ -6189,6 +6189,55 @@ describe('makerChatStore text delta batching', () => {
     expect(sentTexts).toEqual(['wait for preflight']);
   });
 
+  it('reruns the lifecycle fence before a deferred remote dispatch after reconnect', async () => {
+    remoteProjectsStore.pinSessionOrigin('device-1', SESSION_ID);
+    let online = false;
+    let archived = false;
+    let enqueueCalls = 0;
+    const beforeEnqueue = vi.fn(async () => true);
+    const beforeDispatch = vi.fn(async () => !archived);
+    const restore = vi.fn();
+    deviceLinkInvoke.mockImplementation(async (_deviceId, channel, args) => {
+      if (channel === 'maker:input:get-projection') {
+        if (!online) throw new Error('[DEVICE_LINK_NOT_CONNECTED] relay offline');
+        return projection(SESSION_ID);
+      }
+      if (channel === 'maker:input:enqueue') {
+        enqueueCalls += 1;
+        return projection(SESSION_ID, { pendingQueue: [args[1] as AgentInputQueuedMessage] });
+      }
+      throw new Error(`unexpected remote channel: ${channel}`);
+    });
+
+    await expect(
+      makerChatStore.sendMessage(
+        SESSION_ID,
+        'wait for lifecycle fence',
+        MODEL,
+        EFFORT,
+        PERMISSION_MODE,
+        WORKING_DIR,
+        undefined,
+        undefined,
+        { beforeEnqueue, beforeDispatch, onRemoteOptimisticFailure: restore },
+      ),
+    ).resolves.toBe(true);
+    expect(beforeEnqueue).toHaveBeenCalledOnce();
+    expect(beforeDispatch).not.toHaveBeenCalled();
+
+    archived = true;
+    online = true;
+    onPresenceChanged?.({ deviceId: 'device-1', online: true });
+    await flushPromises();
+    await flushPromises();
+
+    expect(beforeEnqueue).toHaveBeenCalledOnce();
+    expect(beforeDispatch).toHaveBeenCalledOnce();
+    expect(enqueueCalls).toBe(0);
+    expect(restore).toHaveBeenCalledOnce();
+    expect(makerChatStore.getSnapshot(SESSION_ID).messages).toHaveLength(0);
+  });
+
   it('hydrates existing runtime messages with authoritative DB-created timestamps', () => {
     vi.setSystemTime(new Date('2026-06-15T00:00:30.000Z'));
     emitTextDelta('draft');

--- a/apps/desktop/src/renderer/__tests__/makerChatStoreTextDeltaBatching.test.ts
+++ b/apps/desktop/src/renderer/__tests__/makerChatStoreTextDeltaBatching.test.ts
@@ -2114,6 +2114,25 @@ describe('makerChatStore text delta batching', () => {
     });
   });
 
+  it('does not clear local state when a fenced clear is rejected for an archived session', async () => {
+    input.clearSession.mockRejectedValueOnce(
+      new Error('SESSION_NOT_ACTIVE: session is archived'),
+    );
+
+    emitTextDelta('preserve me');
+    vi.advanceTimersByTime(32);
+    expect(makerChatStore.getSnapshot(SESSION_ID).messages).toHaveLength(1);
+
+    await makerChatStore.clearSession(SESSION_ID, { requireActiveSession: true });
+
+    expect(input.clearSession).toHaveBeenCalledWith(SESSION_ID, expect.any(String), {
+      requireActiveSession: true,
+    });
+    expect(makerChatStore.getSnapshot(SESSION_ID).messages).toHaveLength(1);
+    expect(window.electronAPI.maker.closeSession).not.toHaveBeenCalled();
+    expect(sessionService.update).not.toHaveBeenCalled();
+  });
+
   it('continues clearing local state when the clear guard hangs', async () => {
     input.clearSession.mockReturnValueOnce(new Promise<AgentInputProjection>(() => {}));
 

--- a/apps/desktop/src/renderer/__tests__/newMakerOrcaCreateOrder.test.ts
+++ b/apps/desktop/src/renderer/__tests__/newMakerOrcaCreateOrder.test.ts
@@ -137,8 +137,8 @@ describe('NewMakerDraftRoute Orca worker create order', () => {
     );
     expect(sessionViewSource).toContain('if (sessionHandoffPreparing) return false;');
     expect(sessionViewSource).not.toContain('if (worktreePreparing) return false;');
-    expect(sessionViewSource).toContain(
-      "disabled={remoteHandoffPreparing || session?.source === 'review'}",
+    expect(sessionViewSource).toMatch(
+      /disabled=\{\s*remoteHandoffPreparing \|\|\s*session\?\.source === 'review' \|\|\s*blocksArchivedSecondaryWindowInput\s*\}/,
     );
   });
 

--- a/apps/desktop/src/renderer/__tests__/remoteSessionSyncInvariants.test.ts
+++ b/apps/desktop/src/renderer/__tests__/remoteSessionSyncInvariants.test.ts
@@ -88,8 +88,8 @@ describe('CCAgentSessionView 接线不变式', () => {
     expect(sessionViewSrc).not.toContain('beforeEnqueue: checkVendorReady');
     // device-link 远程交接期间仍要禁用(见 remoteHandoffPreparing):那几段 await
     // 可能数十秒,不禁用的话用户补发的消息会插到草稿提交的首条之前。
-    expect(sessionViewSrc).toContain(
-      "disabled={remoteHandoffPreparing || session?.source === 'review'}",
+    expect(sessionViewSrc).toMatch(
+      /disabled=\{\s*remoteHandoffPreparing \|\|\s*session\?\.source === 'review' \|\|\s*blocksArchivedSecondaryWindowInput\s*\}/,
     );
   });
   it('补选目录后的续发保持 delivery mode，并按本地/远端策略清理原 composer', () => {

--- a/apps/desktop/src/renderer/__tests__/reviewCommandDispatch.test.ts
+++ b/apps/desktop/src/renderer/__tests__/reviewCommandDispatch.test.ts
@@ -22,10 +22,11 @@ describe('/review command dispatch', () => {
     expect(dispatchSource).toContain('await window.electronAPI.maker.startReview({');
     expect(dispatchSource).toContain('return { handled: true, accepted: true, message }');
     expect(dispatchSource).toContain('return { handled: true, accepted: false, message }');
+    expect(dispatchSource).toContain('const dispatchResult = await dispatchCommand(hit');
     expect(sessionViewSource).toContain('if (slashDispatch.handled) {');
     expect(sessionViewSource).toContain('waitForLeadHistory: false');
     expect(dispatchSource.indexOf('.startReview({')).toBeLessThan(
-      dispatchSource.indexOf('void dispatchCommand(hit'),
+      dispatchSource.indexOf('const dispatchResult = await dispatchCommand(hit'),
     );
   });
 

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
@@ -1792,7 +1792,7 @@ export function CCAgentSessionView({
   } = useCCAgentChat(sessionId, handleTitleUpdate, { chatRealtime });
   const handleArchivedSafeQueueResume = useCallback(() => {
     if (isArchivedSecondaryWindowInputBlocked()) return;
-    resumeQueue();
+    resumeQueue({ requireActiveSession: isSecondaryWindow() });
   }, [isArchivedSecondaryWindowInputBlocked, resumeQueue]);
   const handleArchivedSafeQueueSteer = useCallback(
     (clientId: string) => {

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
@@ -457,6 +457,8 @@ interface CCAgentSessionViewProps {
   disableAutofocus?: boolean;
   /** 副窗口因当前任务被归档而自动关闭前，由路由宿主保护尚未保存的界面状态。 */
   onBeforeSecondaryWindowClose?: () => Promise<boolean>;
+  /** Orca 等常驻路由宿主接管归档关窗时，视图本身只负责收敛 pane 与禁用输入。 */
+  secondaryWindowArchiveOwner?: 'self' | 'host';
 }
 
 /**
@@ -703,6 +705,7 @@ export function CCAgentSessionView({
   sidebarTargetSessionId,
   disableAutofocus = false,
   onBeforeSecondaryWindowClose,
+  secondaryWindowArchiveOwner = 'self',
 }: CCAgentSessionViewProps = {}) {
   const { t } = useTranslation();
   const { sessionId: paramSessionId } = useParams<{ sessionId: string }>();
@@ -1239,6 +1242,10 @@ export function CCAgentSessionView({
       log.info('archived session removed from embedded secondary-window pane', { sessionId });
       return;
     }
+    if (secondaryWindowArchiveOwner === 'host') {
+      log.info('archived route-owning session delegated to secondary-window host', { sessionId });
+      return;
+    }
     let cancelled = false;
     void (async () => {
       let allowClose = true;
@@ -1257,7 +1264,13 @@ export function CCAgentSessionView({
     return () => {
       cancelled = true;
     };
-  }, [session?.status, sessionId, ownsWindowRoute, onBeforeSecondaryWindowClose]);
+  }, [
+    session?.status,
+    sessionId,
+    ownsWindowRoute,
+    onBeforeSecondaryWindowClose,
+    secondaryWindowArchiveOwner,
+  ]);
 
   const vendorAuthGate = useVendorAuthGate();
 

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
@@ -55,6 +55,7 @@ import {
 import { cn, basename } from '@/lib/utils';
 import { Spinner } from '@/components/ui/spinner';
 import { setRemoteReceiptDisplayReady } from '@/lib/sessionAttentionStore';
+import { isSecondaryWindow } from '@/lib/secondaryWindow';
 import { shortSessionId } from '@/lib/sessionId';
 import { ChatInput } from '@/components/new-chat/ChatInput';
 import { GoalIndicator } from '@/components/new-chat/GoalIndicator';
@@ -1219,6 +1220,20 @@ export function CCAgentSessionView({
       navigate('/cc-agent', { replace: true });
     }
   }, [session?.status, sessionId, navigate, ownsWindowRoute]);
+
+  // 副窗口("在新窗口打开")里的会话被主窗口归档后,副窗不能继续停留在该会话上
+  // 发消息(那会把已归档会话自动恢复成 active,绕过归档语义)。主窗口里归档保持可
+  // 浏览 + 发消息自动恢复的既有行为;只有副窗归档后直接关窗,回到主窗口。
+  // 见 #3175。deleted 已在上方 effect 处理(导航回 /cc-agent),这里只管 archived。
+  useEffect(() => {
+    if (!sessionId) return;
+    if (session?.status !== 'archived') return;
+    if (!isSecondaryWindow()) return;
+    log.info('archived session in secondary window, closing window', { sessionId });
+    splitGroupStore.removeSession(sessionId);
+    window.electronAPI?.windowClose();
+  }, [session?.status, sessionId]);
+
   const vendorAuthGate = useVendorAuthGate();
 
   useEffect(() => {

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
@@ -2459,12 +2459,15 @@ export function CCAgentSessionView({
   useEffect(() => {
     const unsub = window.electronAPI.maker.onDesktopCommandTriggered((payload) => {
       if (payload.sessionId && payload.sessionId !== sessionId) return;
+      if (isArchivedSecondaryWindowInputBlocked()) return;
       if (payload.command === 'help') {
         void insertHelpCard();
         return;
       }
       if (payload.command === 'clear') {
-        clearSession();
+        clearSession({
+          requireActiveSession: payload.requireActiveSession === true || isSecondaryWindow(),
+        });
         return;
       }
       if (payload.command === 'cmd') {
@@ -2521,7 +2524,14 @@ export function CCAgentSessionView({
       // 'issue' 命令由下方独立 effect 处理(需要 handleSend,其声明在本 effect 之后)。
     });
     return unsub;
-  }, [insertHelpCard, clearSession, insertSystemCard, sessionId, t]);
+  }, [
+    insertHelpCard,
+    clearSession,
+    insertSystemCard,
+    isArchivedSecondaryWindowInputBlocked,
+    sessionId,
+    t,
+  ]);
 
   // F-COLLAB: 协同模式真实状态。enabled 来自 session.orcaRole === 'lead';
   // worker(显示用)从 active workflow 的 Worker session 列表查到 agentKind。
@@ -3114,6 +3124,9 @@ export function CCAgentSessionView({
       // Desktop commands stay `^/` only. A whitespace-prefixed `/help` is not a dispatch.
       if (!slashMatch) return { handled: false, accepted: false, message };
       if (!allowDesktopDispatch) return { handled: false, accepted: false, message };
+      if (options?.beforeDesktopDispatch && !(await options.beforeDesktopDispatch())) {
+        return { handled: true, accepted: false, message };
+      }
       // Review is handed to Main immediately with this invocation's serialized
       // attachments. It must not depend on this React view remaining mounted,
       // nor share a mutable attachment ref with a later command.
@@ -3126,9 +3139,6 @@ export function CCAgentSessionView({
           return { handled: true, accepted: false, message };
         }
         const attachments = files?.length ? serializeAttachedFiles(files) : undefined;
-        if (options?.beforeDesktopDispatch && !(await options.beforeDesktopDispatch())) {
-          return { handled: true, accepted: false, message };
-        }
         try {
           await window.electronAPI.maker.startReview({
             sourceSessionId: sessionId,
@@ -3148,9 +3158,6 @@ export function CCAgentSessionView({
           return { handled: true, accepted: false, message };
         }
       }
-      if (options?.beforeDesktopDispatch && !(await options.beforeDesktopDispatch())) {
-        return { handled: true, accepted: false, message };
-      }
       // 仅 /issue 需要携带附件:snapshot 到 ref,DESKTOP_COMMAND_TRIGGERED 回流时消费。
       // 其它 desktop 命令(/help /clear /cmd ...)不涉及附件,不写 ref。
       if (hit.name === 'issue') {
@@ -3160,13 +3167,17 @@ export function CCAgentSessionView({
       // 经隧道路由到被控端执行(纯 UI 命令忽略该字段)。用视图的粘滞 remoteDeviceId
       // 而非现读快照:origin 注入 / 重连窗口内快照为 undefined,会误走本机路径
       // (/cmd 拿被控端路径本机 spawn、/goal /learn 在本机产生副作用;Codex review #548)。
-      await dispatchCommand(hit, {
+      const dispatchResult = await dispatchCommand(hit, {
         ...(sessionId ? { sessionId } : {}),
         ...(workingDir ? { workingDir } : {}),
         ...(args ? { args } : {}),
         ...(remoteDeviceId ? { deviceId: remoteDeviceId } : {}),
         ...(!remoteDeviceId && isSecondaryWindow() ? { requireActiveSession: true } : {}),
       });
+      if (dispatchResult === 'rejected') {
+        if (hit.name === 'issue') pendingIssueFilesRef.current = undefined;
+        return { handled: true, accepted: false, message };
+      }
       return { handled: true, accepted: true, message };
     },
     [
@@ -3714,6 +3725,7 @@ export function CCAgentSessionView({
     const unsub = window.electronAPI.maker.onDesktopCommandTriggered((payload) => {
       if (payload.command !== 'issue') return;
       if (!payload.sessionId || payload.sessionId !== sessionId || !session) return;
+      if (isArchivedSecondaryWindowInputBlocked()) return;
       const details = payload.args?.trim()
         ? t('issueAgent.command.detailsPrefix', { details: payload.args.trim() })
         : '';
@@ -3730,7 +3742,7 @@ export function CCAgentSessionView({
       );
     });
     return unsub;
-  }, [sessionId, session, handleSend, t]);
+  }, [sessionId, session, handleSend, isArchivedSecondaryWindowInputBlocked, t]);
 
   const { confirm: confirmDialog } = useConfirmDialog();
   // 防双击重入:ConfirmDialogProvider 是队列语义,弹窗 mount 前的连续点击会入队

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
@@ -3172,7 +3172,9 @@ export function CCAgentSessionView({
         ...(workingDir ? { workingDir } : {}),
         ...(args ? { args } : {}),
         ...(remoteDeviceId ? { deviceId: remoteDeviceId } : {}),
-        ...(!remoteDeviceId && isSecondaryWindow() ? { requireActiveSession: true } : {}),
+        // 副窗口无论本机还是远程都要 fence:本机由 Main 按 sender 判定,远程则把此
+        // 显式标记经隧道传到被控端 Main(sender 为空,无法按窗口归属判定)。
+        ...(isSecondaryWindow() ? { requireActiveSession: true } : {}),
       });
       if (dispatchResult === 'rejected') {
         if (hit.name === 'issue') pendingIssueFilesRef.current = undefined;
@@ -3406,8 +3408,12 @@ export function CCAgentSessionView({
         : undefined;
       const cardClientId = insertSystemCard('context', { usage: undefined });
       if (!cardClientId) return true;
+      // 副窗口(含 device-link 远程)对已归档任务的 /context 必须 fence:本机副窗口
+      // Main 按 sender 判定,远程副窗口 sender 为空,靠此显式 requireActiveSession
+      // 经隧道传到被控端 Main 复核;主窗口不传,保留历史恢复语义。
+      const fenceOpts = isSecondaryWindow() ? { requireActiveSession: true } : undefined;
       void makerApiFor(sessionId)
-        .getContextUsage(sessionId, createOpts)
+        .getContextUsage(sessionId, createOpts, fenceOpts)
         .then((usage) => {
           updateSystemCardData(cardClientId, { usage });
         })

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
@@ -1263,8 +1263,8 @@ export function CCAgentSessionView({
     if (!sessionId) return;
     if (session?.status !== 'archived') return;
     if (!isSecondaryWindow()) return;
-    splitGroupStore.removeSession(sessionId);
     if (!ownsWindowRoute) {
+      splitGroupStore.removeSession(sessionId);
       log.info('archived session removed from embedded secondary-window pane', { sessionId });
       return;
     }
@@ -1797,7 +1797,7 @@ export function CCAgentSessionView({
   const handleArchivedSafeQueueSteer = useCallback(
     (clientId: string) => {
       if (isArchivedSecondaryWindowInputBlocked()) return Promise.resolve(false);
-      return steerQueuedMessage(clientId);
+      return steerQueuedMessage(clientId, { requireActiveSession: isSecondaryWindow() });
     },
     [isArchivedSecondaryWindowInputBlocked, steerQueuedMessage],
   );
@@ -2123,7 +2123,10 @@ export function CCAgentSessionView({
         errorTailKind === 'interrupted'
           ? CONTINUE_AFTER_APP_EXIT_PROMPT
           : CONTINUE_AFTER_ERROR_PROMPT,
-        { beforeEnqueue: allowArchivedSecondaryWindowEnqueue },
+        {
+          beforeEnqueue: allowArchivedSecondaryWindowEnqueue,
+          requireActiveSession: isSecondaryWindow(),
+        },
       );
       if (!accepted) {
         setErrorTailBannerHiddenFor(null);
@@ -2264,6 +2267,7 @@ export function CCAgentSessionView({
         CONTINUE_AFTER_APP_EXIT_PROMPT,
         {
           beforeEnqueue: allowArchivedSecondaryWindowEnqueue,
+          requireActiveSession: isSecondaryWindow(),
         },
       );
       if (!accepted) {
@@ -3286,6 +3290,7 @@ export function CCAgentSessionView({
                     ? {
                         beforeEnqueue: allowArchivedSecondaryWindowEnqueue,
                         beforeDispatch: allowArchivedSecondaryWindowEnqueue,
+                        requireActiveSession: true,
                       }
                     : {}),
                   ...(pending.vendorOptions ? { vendorOptions: pending.vendorOptions } : {}),
@@ -3595,6 +3600,7 @@ export function CCAgentSessionView({
           ? {
               beforeEnqueue: allowArchivedSecondaryWindowEnqueue,
               beforeDispatch: allowArchivedSecondaryWindowEnqueue,
+              requireActiveSession: true,
             }
           : {}),
         ...(opts?.quotesEncoded ? { quotesEncoded: true } : {}),
@@ -3954,7 +3960,10 @@ export function CCAgentSessionView({
 
   const handleSilentStopContinue = useCallback(() => {
     if (isArchivedSecondaryWindowInputBlocked()) return;
-    continueAfterSilentStop({ beforeEnqueue: allowArchivedSecondaryWindowEnqueue });
+    continueAfterSilentStop({
+      beforeEnqueue: allowArchivedSecondaryWindowEnqueue,
+      requireActiveSession: isSecondaryWindow(),
+    });
   }, [
     allowArchivedSecondaryWindowEnqueue,
     continueAfterSilentStop,
@@ -4233,6 +4242,7 @@ export function CCAgentSessionView({
                     ? {
                         beforeEnqueue: allowArchivedSecondaryWindowEnqueue,
                         beforeDispatch: allowArchivedSecondaryWindowEnqueue,
+                        requireActiveSession: true,
                       }
                     : {}),
                   ...(pending.vendorOptions ? { vendorOptions: pending.vendorOptions } : {}),

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
@@ -907,6 +907,20 @@ export function CCAgentSessionView({
   const isOrcaLeadSessionView = session?.orcaRole === 'lead';
   const blocksArchivedSecondaryWindowInput =
     isSecondaryWindow() && session?.status === 'archived';
+  const archivedSecondaryWindowInputBlockedRef = useRef({
+    sessionId: sessionId ?? null,
+    blocked: blocksArchivedSecondaryWindowInput,
+  });
+  useLayoutEffect(() => {
+    archivedSecondaryWindowInputBlockedRef.current = {
+      sessionId: sessionId ?? null,
+      blocked: blocksArchivedSecondaryWindowInput,
+    };
+  }, [blocksArchivedSecondaryWindowInput, sessionId]);
+  const isArchivedSecondaryWindowInputBlocked = useCallback(() => {
+    const current = archivedSecondaryWindowInputBlockedRef.current;
+    return current.sessionId === sessionId && current.blocked;
+  }, [sessionId]);
 
   // worktree-parallel-sessions:订阅当前 session 的 worktree 创建态(creating/failed)。
   // 触发源:NewMakerDraftRoute 的 worktree 异步创建路径。
@@ -1186,6 +1200,12 @@ export function CCAgentSessionView({
     const unsub = sessionsPush.onPatched(({ sessionId: patchedId, patch }, ownerStamp) => {
       if (!isDataOwnerPushCurrent(ownerStamp)) return;
       if (patchedId !== sessionId || !refreshSequence.isCurrentSession(patchedId)) return;
+      if (patch.status !== undefined) {
+        archivedSecondaryWindowInputBlockedRef.current = {
+          sessionId: patchedId,
+          blocked: isSecondaryWindow() && patch.status === 'archived',
+        };
+      }
       const patchBuffer = sessionSnapshotPatchBufferRef.current;
       patchBuffer.stage(patchedId, patch);
       const fullSnapshot = currentServerSessionRef.current;
@@ -3114,8 +3134,10 @@ export function CCAgentSessionView({
       const pending = pendingSendRef.current;
       if (!newDir || !pending) return;
       pendingSendRef.current = null;
+      if (isArchivedSecondaryWindowInputBlocked()) return;
       void (async () => {
         try {
+          if (isArchivedSecondaryWindowInputBlocked()) return;
           const slashDispatch = await maybeDispatchDesktopSlashCommand(
             pending.message,
             pending.files,
@@ -3151,6 +3173,7 @@ export function CCAgentSessionView({
               },
             },
           );
+          if (isArchivedSecondaryWindowInputBlocked()) return;
           if (slashDispatch.handled) {
             if (slashDispatch.accepted) {
               pending.onDeferredAccepted?.();
@@ -3193,6 +3216,7 @@ export function CCAgentSessionView({
                   slashDispatch.message,
                 )
               : undefined;
+          if (isArchivedSecondaryWindowInputBlocked()) return;
           const dispatch = pending.deliveryMode === 'steer' ? steerMessage : sendMessage;
           const followStartGeneration = readSendFollowCancelGeneration(sessionId);
           requestFollowLatest(sessionId, followStartGeneration);
@@ -3252,6 +3276,7 @@ export function CCAgentSessionView({
     },
     [
       maybeDispatchDesktopSlashCommand,
+      isArchivedSecondaryWindowInputBlocked,
       refreshServerSession,
       remoteDeviceId,
       session?.agentKind,
@@ -3336,7 +3361,7 @@ export function CCAgentSessionView({
         onDeferredAccepted?: () => void;
       },
     ) => {
-      if (blocksArchivedSecondaryWindowInput) return false;
+      if (isArchivedSecondaryWindowInputBlocked()) return false;
       const deliveryMode = opts?.deliveryMode ?? 'queue';
       const navigationRequestVersion =
         deliveryMode !== 'steer' && matchNavigationCommandName(message)
@@ -3357,10 +3382,12 @@ export function CCAgentSessionView({
       ) {
         return;
       }
+      if (isArchivedSecondaryWindowInputBlocked()) return false;
 
       if (deliveryMode !== 'steer' && (await maybeShowContextUsage(message))) {
         return;
       }
+      if (isArchivedSecondaryWindowInputBlocked()) return false;
 
       // ── Slash command dispatch (palette refactor) ──
       // 三源 palette 命中:
@@ -3379,6 +3406,7 @@ export function CCAgentSessionView({
           : await maybeDispatchDesktopSlashCommand(message, files, {
               piRuntimeRetryDelaysMs: PI_RUNTIME_SKILL_RETRY_DELAYS_MS,
             });
+      if (isArchivedSecondaryWindowInputBlocked()) return false;
       if (slashDispatch.handled) {
         if (slashDispatch.accepted) {
           // Desktop commands can wait in Main long enough for draft hydration to
@@ -3443,6 +3471,7 @@ export function CCAgentSessionView({
           existingSessionRoute: true,
         });
         if (!proceed) return false;
+        if (isArchivedSecondaryWindowInputBlocked()) return false;
       }
 
       // Popover open → prevent re-entry
@@ -3450,6 +3479,7 @@ export function CCAgentSessionView({
       // 会话交接尚未完成(建 worktree / 远程开协同)时不放行:否则新输入会插到
       // 草稿提交的首条之前,顺序倒置。
       if (sessionHandoffPreparing) return false;
+      if (isArchivedSecondaryWindowInputBlocked()) return false;
 
       const orcaLeadVendorOptions =
         sessionId && session !== null && isOrcaLeadSession(session)
@@ -3520,6 +3550,7 @@ export function CCAgentSessionView({
         ...(opts?.onDeferredAccepted ? { onDeferredAccepted: opts.onDeferredAccepted } : {}),
       };
       if (deliveryMode === 'steer') {
+        if (isArchivedSecondaryWindowInputBlocked()) return false;
         const followStartGeneration = readSendFollowCancelGeneration(sessionId);
         if (sessionId) requestFollowLatest(sessionId, followStartGeneration);
         const accepted = await steerMessage(
@@ -3540,6 +3571,7 @@ export function CCAgentSessionView({
         }
         return accepted;
       }
+      if (isArchivedSecondaryWindowInputBlocked()) return false;
       const followStartGeneration = readSendFollowCancelGeneration(sessionId);
       if (sessionId) requestFollowLatest(sessionId, followStartGeneration);
       const accepted = await sendMessage(
@@ -3579,7 +3611,7 @@ export function CCAgentSessionView({
       vendorAuthGate,
       remoteDeviceId,
       sessionHandoffPreparing,
-      blocksArchivedSecondaryWindowInput,
+      isArchivedSecondaryWindowInputBlocked,
     ],
   );
 
@@ -4006,6 +4038,7 @@ export function CCAgentSessionView({
       const holdComposer = !!pending.remoteCollab;
       if (holdComposer) setRemoteHandoffPreparing(true);
       try {
+        if (isArchivedSecondaryWindowInputBlocked()) return;
         if (pending.remoteCollab) {
           const remoteCollab = await consumePendingRemoteCollab(pending.remoteCollab, {
             leadSessionId: sessionId,
@@ -4027,6 +4060,7 @@ export function CCAgentSessionView({
             });
           }
         }
+        if (isArchivedSecondaryWindowInputBlocked()) return;
         // 三处交接统一走 deliverRecoverableHandoff:交付成功才丢副本,
         // resolve false / 抛错都保留(见该函数注释)。
         let pendingText = pending.text;
@@ -4034,6 +4068,7 @@ export function CCAgentSessionView({
           piRuntimeRetryDelaysMs: PI_RUNTIME_SKILL_RETRY_DELAYS_MS,
         });
         pendingText = slashDispatch.message;
+        if (isArchivedSecondaryWindowInputBlocked()) return;
         if (slashDispatch.handled) {
           if (!slashDispatch.accepted) {
             // NewMaker 已把源草稿移交并清空；Main 没受理 `/review` 时，把正文和附件
@@ -4087,6 +4122,7 @@ export function CCAgentSessionView({
             : undefined;
         // 必须 await:sendMessage 在设备离线 / 访问被撤销 / 远端 enqueue 拒绝时不抛错,
         // 而是 resolve false —— 不等它就丢副本,正文会从界面和磁盘上一起消失(codex P1)。
+        if (isArchivedSecondaryWindowInputBlocked()) return;
         const followStartGeneration = readSendFollowCancelGeneration(sessionId);
         requestFollowLatest(sessionId, followStartGeneration);
         const delivered = await deliverRecoverableHandoff(sessionId, () =>
@@ -4133,6 +4169,7 @@ export function CCAgentSessionView({
     })();
   }, [
     historyLoaded,
+    isArchivedSecondaryWindowInputBlocked,
     maybeDispatchDesktopSlashCommand,
     restoreRecoverableHandoff,
     requestFollowLatest,

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
@@ -1790,6 +1790,17 @@ export function CCAgentSessionView({
     updateQueueItem,
     chatDisplaySnapshot,
   } = useCCAgentChat(sessionId, handleTitleUpdate, { chatRealtime });
+  const handleArchivedSafeQueueResume = useCallback(() => {
+    if (isArchivedSecondaryWindowInputBlocked()) return;
+    resumeQueue();
+  }, [isArchivedSecondaryWindowInputBlocked, resumeQueue]);
+  const handleArchivedSafeQueueSteer = useCallback(
+    (clientId: string) => {
+      if (isArchivedSecondaryWindowInputBlocked()) return Promise.resolve(false);
+      return steerQueuedMessage(clientId);
+    },
+    [isArchivedSecondaryWindowInputBlocked, steerQueuedMessage],
+  );
   useEffect(() => {
     if (!sessionId || !isOrcaLeadSessionView || !historyLoaded) return;
     const recoveredAssignment = getRecoverableDeferredUiAssignment({
@@ -3272,7 +3283,10 @@ export function CCAgentSessionView({
               isSecondaryWindow()
               ? {
                   ...(isSecondaryWindow()
-                    ? { beforeEnqueue: allowArchivedSecondaryWindowEnqueue }
+                    ? {
+                        beforeEnqueue: allowArchivedSecondaryWindowEnqueue,
+                        beforeDispatch: allowArchivedSecondaryWindowEnqueue,
+                      }
                     : {}),
                   ...(pending.vendorOptions ? { vendorOptions: pending.vendorOptions } : {}),
                   ...(pending.quotesEncoded ? { quotesEncoded: true } : {}),
@@ -3578,7 +3592,10 @@ export function CCAgentSessionView({
       const sendOptions = {
         ...orcaLeadVendorOptions,
         ...(isSecondaryWindow()
-          ? { beforeEnqueue: allowArchivedSecondaryWindowEnqueue }
+          ? {
+              beforeEnqueue: allowArchivedSecondaryWindowEnqueue,
+              beforeDispatch: allowArchivedSecondaryWindowEnqueue,
+            }
           : {}),
         ...(opts?.quotesEncoded ? { quotesEncoded: true } : {}),
         ...(opts?.agentReferences?.length ? { agentReferences: opts.agentReferences } : {}),
@@ -3842,7 +3859,7 @@ export function CCAgentSessionView({
     void rebuildClaudeSubscriptionSessionBeforeRetry(errorReason)
       .then(() => {
         if (isArchivedSecondaryWindowInputBlocked()) return;
-        return retryLastError();
+        return retryLastError({ requireActiveSession: isSecondaryWindow() });
       })
       .catch((error) => {
         log.warn('retryLastError failed', error);
@@ -3922,7 +3939,7 @@ export function CCAgentSessionView({
 
     await refreshServerSession();
     if (isArchivedSecondaryWindowInputBlocked()) return;
-    await retryLastError();
+    await retryLastError({ requireActiveSession: isSecondaryWindow() });
   }, [
     canSwitchToClaudeSubscription,
     confirmDialog,
@@ -4213,7 +4230,10 @@ export function CCAgentSessionView({
               isSecondaryWindow()
               ? {
                   ...(isSecondaryWindow()
-                    ? { beforeEnqueue: allowArchivedSecondaryWindowEnqueue }
+                    ? {
+                        beforeEnqueue: allowArchivedSecondaryWindowEnqueue,
+                        beforeDispatch: allowArchivedSecondaryWindowEnqueue,
+                      }
                     : {}),
                   ...(pending.vendorOptions ? { vendorOptions: pending.vendorOptions } : {}),
                   ...(pending.quotesEncoded ? { quotesEncoded: true } : {}),
@@ -5168,10 +5188,18 @@ export function CCAgentSessionView({
                   queuePaused={queuePaused}
                   queueExpanded={queueExpanded}
                   onQueueExpandedChange={setQueueExpanded}
-                  onQueueResume={resumeQueue}
+                  onQueueResume={
+                    blocksArchivedSecondaryWindowInput
+                      ? undefined
+                      : handleArchivedSafeQueueResume
+                  }
                   onQueueRemove={removeFromQueue}
                   onQueueEdit={updateQueueItem}
-                  onQueueSteer={steerQueuedMessage}
+                  onQueueSteer={
+                    blocksArchivedSecondaryWindowInput
+                      ? undefined
+                      : handleArchivedSafeQueueSteer
+                  }
                   onQueueReorder={moveQueueItem}
                   onQueueInteractionLock={setQueueInteractionLock}
                   onQueueEditLock={setQueueEditLock}

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
@@ -126,6 +126,7 @@ import { useCCAgentChat } from '@/hooks/useCCAgentChat';
 import { ackErrorAlertHandled } from '@/lib/errorAlertAck';
 import { useAttachments } from '@/hooks/useAttachments';
 import { useCCSessions } from '@/hooks/useCCSessions';
+import { useConfirmCloseActiveFileIfDirty } from './workdir-browse/hooks/useConfirmSwitchAwayIfDirty';
 import { SessionContentHeaderRegistration } from './SessionContentHeader';
 import { useSessionBinding } from '@/hooks/useSessionBinding';
 import { useVendorAuthGate } from '@/hooks/useVendorAuthGate';
@@ -921,6 +922,11 @@ export function CCAgentSessionView({
     const current = archivedSecondaryWindowInputBlockedRef.current;
     return current.sessionId === sessionId && current.blocked;
   }, [sessionId]);
+  const allowArchivedSecondaryWindowEnqueue = useCallback(
+    async () => !isArchivedSecondaryWindowInputBlocked(),
+    [isArchivedSecondaryWindowInputBlocked],
+  );
+  const confirmCloseActiveFileIfDirty = useConfirmCloseActiveFileIfDirty();
 
   // worktree-parallel-sessions:订阅当前 session 的 worktree 创建态(creating/failed)。
   // 触发源:NewMakerDraftRoute 的 worktree 异步创建路径。
@@ -1272,7 +1278,7 @@ export function CCAgentSessionView({
       try {
         allowClose = onBeforeSecondaryWindowClose
           ? await onBeforeSecondaryWindowClose()
-          : true;
+          : await confirmCloseActiveFileIfDirty();
       } catch (err) {
         log.error('secondary-window close preflight failed', err);
         return;
@@ -1289,6 +1295,7 @@ export function CCAgentSessionView({
     sessionId,
     ownsWindowRoute,
     onBeforeSecondaryWindowClose,
+    confirmCloseActiveFileIfDirty,
     secondaryWindowArchiveOwner,
   ]);
 
@@ -2087,7 +2094,7 @@ export function CCAgentSessionView({
     }
   }, [syntheticContinuationPending, errorTailBannerHiddenFor]);
   const handleErrorTailContinue = useCallback(async () => {
-    if (!sessionId || !errorTailMsg) return;
+    if (!sessionId || !errorTailMsg || isArchivedSecondaryWindowInputBlocked()) return;
     setErrorTailBannerHiddenFor(errorTailMsg.clientId);
     try {
       // 隐藏的英文续跑指令([UI_ACTION_TRIGGER] 前缀,消息流不渲染)——用户视角
@@ -2096,12 +2103,21 @@ export function CCAgentSessionView({
       await rebuildClaudeSubscriptionSessionBeforeRetry(
         errorTailKind === 'error' ? errorTailMsg.errorReason : null,
       );
-      await makerChatStore.sendUiTrigger(
+      if (isArchivedSecondaryWindowInputBlocked()) {
+        setErrorTailBannerHiddenFor(null);
+        return;
+      }
+      const accepted = await makerChatStore.sendUiTrigger(
         sessionId,
         errorTailKind === 'interrupted'
           ? CONTINUE_AFTER_APP_EXIT_PROMPT
           : CONTINUE_AFTER_ERROR_PROMPT,
+        { beforeEnqueue: allowArchivedSecondaryWindowEnqueue },
       );
+      if (!accepted) {
+        setErrorTailBannerHiddenFor(null);
+        return;
+      }
       // sendUiTrigger 在 enqueue 成功后就 resolve,续跑消息**还没落库** —— 此刻重算
       // 仍会把原 error 行判为尾行并保留红点,而 syntheticContinuationPending 已经把
       // 横幅隐藏了(排队被暂停 / 阻塞时可能持续很久)。所以先临时清点让两者一致;
@@ -2117,8 +2133,10 @@ export function CCAgentSessionView({
       toast.error(err instanceof Error ? err.message : String(err));
     }
   }, [
+    allowArchivedSecondaryWindowEnqueue,
     errorTailKind,
     errorTailMsg,
+    isArchivedSecondaryWindowInputBlocked,
     markCurrentUnreadFailedScheduleRun,
     rebuildClaudeSubscriptionSessionBeforeRetry,
     sessionId,
@@ -2223,14 +2241,24 @@ export function CCAgentSessionView({
     void refreshPendingAlerts();
   }, [syntheticContinuationPending, remoteDeviceId, sessionId]);
   const handleSessionInterruptContinue = useCallback(async () => {
-    if (!sessionId) return;
+    if (!sessionId || isArchivedSecondaryWindowInputBlocked()) return;
     setSessionInterruptAcked(true);
     try {
       // main 侧把续跑项插到队首；durable ack 延后到 vendor dispatch 成功后，
       // 避免排队取消 / cancelled-before-dispatch 时旧中断提示被提前抹掉。
       // 续跑 turn 真正启动时会写更新的 started；若再次被 app 退出打断，仍会产生新提示。
       // 本视图先靠内存 acked 即时熄灭，peer 视图靠 dispatch 后的 ack 广播收敛。
-      await makerChatStore.sendUiTrigger(sessionId, CONTINUE_AFTER_APP_EXIT_PROMPT);
+      const accepted = await makerChatStore.sendUiTrigger(
+        sessionId,
+        CONTINUE_AFTER_APP_EXIT_PROMPT,
+        {
+          beforeEnqueue: allowArchivedSecondaryWindowEnqueue,
+        },
+      );
+      if (!accepted) {
+        setSessionInterruptAcked(false);
+        return;
+      }
       // 同 handleErrorTailContinue:enqueue 成功但续跑还没落库、durable ack 也要等
       // dispatch 成功,而横幅已隐藏 —— 先临时清点保持一致,排队被取消时由 pending
       // 落回 false 的 effect 重算恢复。远程会话同样延后(见那里的说明)。
@@ -2240,7 +2268,13 @@ export function CCAgentSessionView({
       setSessionInterruptAcked(false);
       toast.error(err instanceof Error ? err.message : String(err));
     }
-  }, [markCurrentUnreadFailedScheduleRun, remoteDeviceId, sessionId]);
+  }, [
+    allowArchivedSecondaryWindowEnqueue,
+    isArchivedSecondaryWindowInputBlocked,
+    markCurrentUnreadFailedScheduleRun,
+    remoteDeviceId,
+    sessionId,
+  ]);
   const handleSessionInterruptDismiss = useCallback(() => {
     if (!sessionId) return;
     void markCurrentUnreadFailedScheduleRun().then((marked) => {
@@ -3234,8 +3268,12 @@ export function CCAgentSessionView({
               pendingPastedTextRanges?.length ||
               pendingSlashCommandRanges !== undefined ||
               pending.onRemoteOptimisticFailure !== undefined ||
-              pending.onDeferredAccepted !== undefined
+              pending.onDeferredAccepted !== undefined ||
+              isSecondaryWindow()
               ? {
+                  ...(isSecondaryWindow()
+                    ? { beforeEnqueue: allowArchivedSecondaryWindowEnqueue }
+                    : {}),
                   ...(pending.vendorOptions ? { vendorOptions: pending.vendorOptions } : {}),
                   ...(pending.quotesEncoded ? { quotesEncoded: true } : {}),
                   ...(pendingAgentReferences?.length
@@ -3275,6 +3313,7 @@ export function CCAgentSessionView({
       })();
     },
     [
+      allowArchivedSecondaryWindowEnqueue,
       maybeDispatchDesktopSlashCommand,
       isArchivedSecondaryWindowInputBlocked,
       refreshServerSession,
@@ -3538,6 +3577,9 @@ export function CCAgentSessionView({
       // ④ Execute send — effort + permissionMode came straight from ChatInput (fresh value)
       const sendOptions = {
         ...orcaLeadVendorOptions,
+        ...(isSecondaryWindow()
+          ? { beforeEnqueue: allowArchivedSecondaryWindowEnqueue }
+          : {}),
         ...(opts?.quotesEncoded ? { quotesEncoded: true } : {}),
         ...(opts?.agentReferences?.length ? { agentReferences: opts.agentReferences } : {}),
         ...(opts?.pastedTextRanges?.length ? { pastedTextRanges: opts.pastedTextRanges } : {}),
@@ -3611,6 +3653,7 @@ export function CCAgentSessionView({
       vendorAuthGate,
       remoteDeviceId,
       sessionHandoffPreparing,
+      allowArchivedSecondaryWindowEnqueue,
       isArchivedSecondaryWindowInputBlocked,
     ],
   );
@@ -3795,15 +3838,30 @@ export function CCAgentSessionView({
   // useSessionRunningStatus 在 running 上升沿把 orphan 的 error 角标 explicit 清掉。
   // 失败路径则天然保留红点,与仍在展示的横幅一致。
   const handleRetry = useCallback(() => {
+    if (isArchivedSecondaryWindowInputBlocked()) return;
     void rebuildClaudeSubscriptionSessionBeforeRetry(errorReason)
-      .then(() => retryLastError())
+      .then(() => {
+        if (isArchivedSecondaryWindowInputBlocked()) return;
+        return retryLastError();
+      })
       .catch((error) => {
         log.warn('retryLastError failed', error);
       });
-  }, [errorReason, rebuildClaudeSubscriptionSessionBeforeRetry, retryLastError]);
+  }, [
+    errorReason,
+    isArchivedSecondaryWindowInputBlocked,
+    rebuildClaudeSubscriptionSessionBeforeRetry,
+    retryLastError,
+  ]);
 
   const handleSwitchToClaudeSubscription = useCallback(async (): Promise<void> => {
-    if (!sessionId || !session || !canSwitchToClaudeSubscription) return;
+    if (
+      !sessionId ||
+      !session ||
+      !canSwitchToClaudeSubscription ||
+      isArchivedSecondaryWindowInputBlocked()
+    )
+      return;
     const model = session.model;
     const previousProviderId = session.providerId ?? null;
     const retryEffort =
@@ -3863,15 +3921,28 @@ export function CCAgentSessionView({
     }
 
     await refreshServerSession();
+    if (isArchivedSecondaryWindowInputBlocked()) return;
     await retryLastError();
   }, [
-    canSwitchToClaudeSubscription, confirmDialog, fastMode, refreshServerSession,
-    retryLastError, session, sessionId, t,
+    canSwitchToClaudeSubscription,
+    confirmDialog,
+    fastMode,
+    isArchivedSecondaryWindowInputBlocked,
+    refreshServerSession,
+    retryLastError,
+    session,
+    sessionId,
+    t,
   ]);
 
   const handleSilentStopContinue = useCallback(() => {
-    continueAfterSilentStop();
-  }, [continueAfterSilentStop]);
+    if (isArchivedSecondaryWindowInputBlocked()) return;
+    continueAfterSilentStop({ beforeEnqueue: allowArchivedSecondaryWindowEnqueue });
+  }, [
+    allowArchivedSecondaryWindowEnqueue,
+    continueAfterSilentStop,
+    isArchivedSecondaryWindowInputBlocked,
+  ]);
 
   const handleContinueAfterUsageReset = useCallback(() => {
     if (!sessionId || !usageLimitRecovery || remoteDeviceId) return;
@@ -4138,8 +4209,12 @@ export function CCAgentSessionView({
               pending.quotesEncoded ||
               pendingAgentReferences?.length ||
               pendingPastedTextRanges?.length ||
-              pendingSlashCommandRanges !== undefined
+              pendingSlashCommandRanges !== undefined ||
+              isSecondaryWindow()
               ? {
+                  ...(isSecondaryWindow()
+                    ? { beforeEnqueue: allowArchivedSecondaryWindowEnqueue }
+                    : {}),
                   ...(pending.vendorOptions ? { vendorOptions: pending.vendorOptions } : {}),
                   ...(pending.quotesEncoded ? { quotesEncoded: true } : {}),
                   ...(pendingAgentReferences?.length
@@ -4169,6 +4244,7 @@ export function CCAgentSessionView({
     })();
   }, [
     historyLoaded,
+    allowArchivedSecondaryWindowEnqueue,
     isArchivedSecondaryWindowInputBlocked,
     maybeDispatchDesktopSlashCommand,
     restoreRecoverableHandoff,

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
@@ -1229,10 +1229,14 @@ export function CCAgentSessionView({
     if (!sessionId) return;
     if (session?.status !== 'archived') return;
     if (!isSecondaryWindow()) return;
-    log.info('archived session in secondary window, closing window', { sessionId });
     splitGroupStore.removeSession(sessionId);
+    if (!ownsWindowRoute) {
+      log.info('archived session removed from embedded secondary-window pane', { sessionId });
+      return;
+    }
+    log.info('archived route-owning session in secondary window, closing window', { sessionId });
     window.electronAPI?.windowClose();
-  }, [session?.status, sessionId]);
+  }, [session?.status, sessionId, ownsWindowRoute]);
 
   const vendorAuthGate = useVendorAuthGate();
 

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
@@ -455,6 +455,8 @@ interface CCAgentSessionViewProps {
   sidebarTargetSessionId?: string;
   /** 禁止该常驻视图在挂载时抢占键盘焦点（例如非 owner 的分屏 pane）。 */
   disableAutofocus?: boolean;
+  /** 副窗口因当前任务被归档而自动关闭前，由路由宿主保护尚未保存的界面状态。 */
+  onBeforeSecondaryWindowClose?: () => Promise<boolean>;
 }
 
 /**
@@ -700,6 +702,7 @@ export function CCAgentSessionView({
   onSessionNavigate,
   sidebarTargetSessionId,
   disableAutofocus = false,
+  onBeforeSecondaryWindowClose,
 }: CCAgentSessionViewProps = {}) {
   const { t } = useTranslation();
   const { sessionId: paramSessionId } = useParams<{ sessionId: string }>();
@@ -899,6 +902,8 @@ export function CCAgentSessionView({
       ? sessionSnapshotPatchBufferRef.current.merge(sessionId, sessionBase)
       : null;
   const isOrcaLeadSessionView = session?.orcaRole === 'lead';
+  const blocksArchivedSecondaryWindowInput =
+    isSecondaryWindow() && session?.status === 'archived';
 
   // worktree-parallel-sessions:订阅当前 session 的 worktree 创建态(creating/failed)。
   // 触发源:NewMakerDraftRoute 的 worktree 异步创建路径。
@@ -1234,9 +1239,25 @@ export function CCAgentSessionView({
       log.info('archived session removed from embedded secondary-window pane', { sessionId });
       return;
     }
-    log.info('archived route-owning session in secondary window, closing window', { sessionId });
-    window.electronAPI?.windowClose();
-  }, [session?.status, sessionId, ownsWindowRoute]);
+    let cancelled = false;
+    void (async () => {
+      let allowClose = true;
+      try {
+        allowClose = onBeforeSecondaryWindowClose
+          ? await onBeforeSecondaryWindowClose()
+          : true;
+      } catch (err) {
+        log.error('secondary-window close preflight failed', err);
+        return;
+      }
+      if (!allowClose || cancelled) return;
+      log.info('archived route-owning session in secondary window, closing window', { sessionId });
+      window.electronAPI?.windowCloseSelf();
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [session?.status, sessionId, ownsWindowRoute, onBeforeSecondaryWindowClose]);
 
   const vendorAuthGate = useVendorAuthGate();
 
@@ -3302,6 +3323,7 @@ export function CCAgentSessionView({
         onDeferredAccepted?: () => void;
       },
     ) => {
+      if (blocksArchivedSecondaryWindowInput) return false;
       const deliveryMode = opts?.deliveryMode ?? 'queue';
       const navigationRequestVersion =
         deliveryMode !== 'steer' && matchNavigationCommandName(message)
@@ -3544,6 +3566,7 @@ export function CCAgentSessionView({
       vendorAuthGate,
       remoteDeviceId,
       sessionHandoffPreparing,
+      blocksArchivedSecondaryWindowInput,
     ],
   );
 
@@ -5010,7 +5033,11 @@ export function CCAgentSessionView({
                   isAgentBusy={isAgentBusy}
                   onStop={handleStopSession}
                   pendingQueue={pendingQueue}
-                  disabled={remoteHandoffPreparing || session?.source === 'review'}
+                  disabled={
+                    remoteHandoffPreparing ||
+                    session?.source === 'review' ||
+                    blocksArchivedSecondaryWindowInput
+                  }
                   settingsLocked={session?.source === 'review'}
                   queuePaused={queuePaused}
                   queueExpanded={queueExpanded}

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
@@ -3053,6 +3053,8 @@ export function CCAgentSessionView({
         piRuntimeRetryDelaysMs?: readonly number[];
         workingDirOverride?: string;
         preparePiRuntime?: () => Promise<void>;
+        /** Recheck the owning window's lifecycle immediately before side effects. */
+        beforeDesktopDispatch?: () => Promise<boolean>;
       },
     ): Promise<{ handled: boolean; accepted: boolean; message: string }> => {
       const slashMatch = message.match(/^\/(\S+)(?:\s+(.*))?$/s);
@@ -3124,6 +3126,9 @@ export function CCAgentSessionView({
           return { handled: true, accepted: false, message };
         }
         const attachments = files?.length ? serializeAttachedFiles(files) : undefined;
+        if (options?.beforeDesktopDispatch && !(await options.beforeDesktopDispatch())) {
+          return { handled: true, accepted: false, message };
+        }
         try {
           await window.electronAPI.maker.startReview({
             sourceSessionId: sessionId,
@@ -3143,6 +3148,9 @@ export function CCAgentSessionView({
           return { handled: true, accepted: false, message };
         }
       }
+      if (options?.beforeDesktopDispatch && !(await options.beforeDesktopDispatch())) {
+        return { handled: true, accepted: false, message };
+      }
       // 仅 /issue 需要携带附件:snapshot 到 ref,DESKTOP_COMMAND_TRIGGERED 回流时消费。
       // 其它 desktop 命令(/help /clear /cmd ...)不涉及附件,不写 ref。
       if (hit.name === 'issue') {
@@ -3152,15 +3160,17 @@ export function CCAgentSessionView({
       // 经隧道路由到被控端执行(纯 UI 命令忽略该字段)。用视图的粘滞 remoteDeviceId
       // 而非现读快照:origin 注入 / 重连窗口内快照为 undefined,会误走本机路径
       // (/cmd 拿被控端路径本机 spawn、/goal /learn 在本机产生副作用;Codex review #548)。
-      void dispatchCommand(hit, {
+      await dispatchCommand(hit, {
         ...(sessionId ? { sessionId } : {}),
         ...(workingDir ? { workingDir } : {}),
         ...(args ? { args } : {}),
         ...(remoteDeviceId ? { deviceId: remoteDeviceId } : {}),
+        ...(!remoteDeviceId && isSecondaryWindow() ? { requireActiveSession: true } : {}),
       });
       return { handled: true, accepted: true, message };
     },
     [
+      allowArchivedSecondaryWindowEnqueue,
       getHelpCommandsSnapshot,
       isRemoteSession,
       session?.agentKind,
@@ -3192,6 +3202,7 @@ export function CCAgentSessionView({
             pending.files,
             {
               allowDesktopDispatch: pending.deliveryMode !== 'steer',
+              beforeDesktopDispatch: allowArchivedSecondaryWindowEnqueue,
               piRuntimeRetryDelaysMs: PI_RUNTIME_SKILL_RETRY_DELAYS_MS,
               workingDirOverride: newDir,
               preparePiRuntime: async () => {
@@ -3459,9 +3470,11 @@ export function CCAgentSessionView({
         deliveryMode === 'steer'
           ? await maybeDispatchDesktopSlashCommand(message, files, {
               allowDesktopDispatch: false,
+              beforeDesktopDispatch: allowArchivedSecondaryWindowEnqueue,
               piRuntimeRetryDelaysMs: PI_RUNTIME_SKILL_RETRY_DELAYS_MS,
             })
           : await maybeDispatchDesktopSlashCommand(message, files, {
+              beforeDesktopDispatch: allowArchivedSecondaryWindowEnqueue,
               piRuntimeRetryDelaysMs: PI_RUNTIME_SKILL_RETRY_DELAYS_MS,
             });
       if (isArchivedSecondaryWindowInputBlocked()) return false;
@@ -4162,6 +4175,7 @@ export function CCAgentSessionView({
         // resolve false / 抛错都保留(见该函数注释)。
         let pendingText = pending.text;
         const slashDispatch = await maybeDispatchDesktopSlashCommand(pending.text, pending.files, {
+          beforeDesktopDispatch: allowArchivedSecondaryWindowEnqueue,
           piRuntimeRetryDelaysMs: PI_RUNTIME_SKILL_RETRY_DELAYS_MS,
         });
         pendingText = slashDispatch.message;

--- a/apps/desktop/src/renderer/features/cc-agent/OrcaSplitView.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/OrcaSplitView.tsx
@@ -11,6 +11,8 @@ import { X } from 'lucide-react';
 import { VendorIcon } from '@/components/sidebar/VendorIcon';
 import { useCCSessions } from '@/hooks/useCCSessions';
 import { useRemoteProjectSessions } from '@/features/device-link/remoteProjectsStore';
+import { createLogger } from '@/lib/logger';
+import { isSecondaryWindow } from '@/lib/secondaryWindow';
 import { cn } from '@/lib/utils';
 import { CCAgentSessionView } from './CCAgentSessionView';
 import { isAgentIslandSupported } from '@/hooks/useAgentIslandSettings';
@@ -28,6 +30,8 @@ import { useOrcaWorkerSelection } from './hooks/useOrcaWorkerSelection';
 import { mergeSessionSources } from './lib/mergeSessionSources';
 
 type TogglePane = 'lead' | 'worker';
+
+const log = createLogger('OrcaSplitView');
 
 export interface OrcaSplitViewProps {
   /** Lead session id. 调用方负责保证存在; 找不到时本组件渲染 "lead not found" 占位。 */
@@ -52,10 +56,15 @@ export function OrcaSplitView({
   const { t } = useTranslation();
   const [togglePane, setTogglePane] = useState<TogglePane>('lead');
   const { sessions: localSessions } = useCCSessions();
+  const { sessions: allLocalSessions } = useCCSessions({ includeArchived: 'all' });
   const remoteSessions = useRemoteProjectSessions();
   const sessions = useMemo(
     () => mergeSessionSources(localSessions, remoteSessions),
     [localSessions, remoteSessions],
+  );
+  const allSessions = useMemo(
+    () => mergeSessionSources(allLocalSessions, remoteSessions),
+    [allLocalSessions, remoteSessions],
   );
   const { requestStop: requestStopCollab } = useStopOrcaCollabWithoutNavigation({
     leadSessionId,
@@ -69,13 +78,39 @@ export function OrcaSplitView({
     viewVisible: togglePane === 'worker' && reportAgentIslandVisibility,
   });
   const leadSession = useMemo(
-    () => sessions.find((s) => s.id === leadSessionId) ?? null,
-    [leadSessionId, sessions],
+    () => allSessions.find((s) => s.id === leadSessionId) ?? null,
+    [allSessions, leadSessionId],
   );
   const workerSession = useMemo(
     () => (workerSessionId ? sessions.find((s) => s.id === workerSessionId) ?? null : null),
     [sessions, workerSessionId],
   );
+
+  // Orca 的 Lead view 会随当前 toggle pane 条件挂载，不能让它独占 route lifecycle：
+  // 用户停在 Worker、或 active-only 列表先移除 Lead 时，常驻宿主仍必须观察 Lead 归档，
+  // 先保护文件页未保存编辑，再关闭整个副窗口。
+  useEffect(() => {
+    if (leadSession?.status !== 'archived') return;
+    if (!isSecondaryWindow()) return;
+    let cancelled = false;
+    void (async () => {
+      let allowClose = true;
+      try {
+        allowClose = onBeforeSecondaryWindowClose ? await onBeforeSecondaryWindowClose() : true;
+      } catch (err) {
+        log.error('secondary-window close preflight failed for archived Orca lead', err);
+        return;
+      }
+      if (!allowClose || cancelled) return;
+      log.info('archived Orca lead in secondary window, closing window', {
+        leadSessionId,
+      });
+      window.electronAPI?.windowCloseSelf();
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [leadSession?.status, leadSessionId, onBeforeSecondaryWindowClose]);
 
   const leadAgentKind = normalizeOrcaDisplayAgentKind(leadSession?.agentKind);
   const leadVendor = orcaVendorForAgentKind(leadAgentKind);
@@ -197,6 +232,7 @@ export function OrcaSplitView({
               viewVisible={reportAgentIslandVisibility}
               navigationMode="route-owner"
               onBeforeSecondaryWindowClose={onBeforeSecondaryWindowClose}
+              secondaryWindowArchiveOwner="host"
             />
           ) : (
             <div className="flex h-full w-full items-center justify-center px-6 text-center text-sm text-muted-foreground">

--- a/apps/desktop/src/renderer/features/cc-agent/OrcaSplitView.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/OrcaSplitView.tsx
@@ -39,12 +39,15 @@ export interface OrcaSplitViewProps {
   workerEmptyLabel?: string;
   /** 当前 OrcaSplitView 是否应代表屏幕可见内容上报给 Agent Island。 */
   reportAgentIslandVisibility?: boolean;
+  /** Lead 作为副窗口路由所有者自动关窗前的宿主预检。 */
+  onBeforeSecondaryWindowClose?: () => Promise<boolean>;
 }
 
 export function OrcaSplitView({
   leadSessionId,
   workerEmptyLabel,
   reportAgentIslandVisibility = true,
+  onBeforeSecondaryWindowClose,
 }: OrcaSplitViewProps) {
   const { t } = useTranslation();
   const [togglePane, setTogglePane] = useState<TogglePane>('lead');
@@ -192,6 +195,8 @@ export function OrcaSplitView({
               orcaMode
               showRsbToggle
               viewVisible={reportAgentIslandVisibility}
+              navigationMode="route-owner"
+              onBeforeSecondaryWindowClose={onBeforeSecondaryWindowClose}
             />
           ) : (
             <div className="flex h-full w-full items-center justify-center px-6 text-center text-sm text-muted-foreground">
@@ -206,6 +211,7 @@ export function OrcaSplitView({
             orcaMode
             showRsbToggle
             viewVisible={reportAgentIslandVisibility}
+            navigationMode="sidebar-embedded"
           />
         ) : (
           <div className="flex h-full w-full items-center justify-center px-6 text-center text-sm text-muted-foreground">

--- a/apps/desktop/src/renderer/features/cc-agent/__tests__/modelWindowConfirmation.test.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/__tests__/modelWindowConfirmation.test.ts
@@ -27,8 +27,9 @@ describe('Claude subscription model-window confirmation', () => {
       handler.indexOf('sessionService.update(sessionId'),
     );
     expect(handler.indexOf('sessionService.update(sessionId')).toBeLessThan(
-      handler.indexOf('retryLastError()'),
+      handler.indexOf('retryLastError({'),
     );
+    expect(handler).toContain('requireActiveSession: isSecondaryWindow()');
   });
 
   it('keeps the ordinary route when Main reports no destructive pressure', async () => {

--- a/apps/desktop/src/renderer/features/cc-agent/workdir-browse/FileBodyView.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/workdir-browse/FileBodyView.tsx
@@ -178,6 +178,8 @@ export interface FileBodyViewProps {
  * 内部的 "保存修改?" 二次确认 —— 调用方已经在自己的关闭确认里收过用户意图)。
  */
 export interface FileBodyHandle {
+  /** 当前编辑器对应的 workdir-relative 路径；关闭宿主前的 dirty 预检用于说明目标。 */
+  relPath: string | null;
   /** true = 当前可编辑内容相对原始内容已变化(LF 归一后比对)。 */
   isDirty(): boolean;
   /** 写入磁盘。无 dirty 时直接 resolve(true) 不做任何 IO。返回 false = 写入失败。 */
@@ -506,10 +508,11 @@ export const FileBodyView = forwardRef<FileBodyHandle, FileBodyViewProps>(functi
   useImperativeHandle(
     ref,
     () => ({
+      relPath,
       isDirty: () => allowEdit && editMode && dirty,
       save: () => (allowEdit ? writeToDisk() : Promise.resolve(true)),
     }),
-    [allowEdit, editMode, dirty, writeToDisk],
+    [allowEdit, editMode, dirty, relPath, writeToDisk],
   );
 
   // 同步把当前 FileBodyView 的 handle 注册到 module-level singleton,让
@@ -518,11 +521,12 @@ export const FileBodyView = forwardRef<FileBodyHandle, FileBodyViewProps>(functi
   // editMode/dirty 变化时刷新 store 引用。unmount 时清空。
   useEffect(() => {
     setActiveFileBodyHandle({
+      relPath,
       isDirty: () => allowEdit && editMode && dirty,
       save: () => (allowEdit ? writeToDisk() : Promise.resolve(true)),
     });
     return () => setActiveFileBodyHandle(null);
-  }, [allowEdit, editMode, dirty, writeToDisk]);
+  }, [allowEdit, editMode, dirty, relPath, writeToDisk]);
 
   // ── find-in-page / search-in-project capture ───────────────────────────
   // 组合键定义在 shared/appShortcuts registry (默认 Ctrl/Cmd+F 与

--- a/apps/desktop/src/renderer/features/cc-agent/workdir-browse/WorkdirBrowseRoute.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/workdir-browse/WorkdirBrowseRoute.tsx
@@ -203,6 +203,10 @@ export function WorkdirBrowseRoute() {
   }, [activeSessionIsOrcaLead, syncAgentIslandVisibleSession]);
 
   const confirmSwitchAway = useConfirmSwitchAwayIfDirty();
+  const confirmSecondaryWindowClose = useCallback(
+    () => confirmSwitchAway(selectedPath, null),
+    [confirmSwitchAway, selectedPath],
+  );
 
   // Tab 条点击/关闭后切换 active：写 URL ?file= + 同步 selectedFile / openTabs。
   // 与 Sidebar 的 handleSelectFile 逻辑保持等价，避免单击 tab 仅刷 URL 不写存储
@@ -598,10 +602,16 @@ export function WorkdirBrowseRoute() {
                 <OrcaSplitView
                   leadSessionId={activeSession.id}
                   reportAgentIslandVisibility={!railCollapse.collapsed}
+                  onBeforeSecondaryWindowClose={confirmSecondaryWindowClose}
                 />
               );
             }
-            return <CCAgentSessionView viewVisible={!railCollapse.collapsed} />;
+            return (
+              <CCAgentSessionView
+                viewVisible={!railCollapse.collapsed}
+                onBeforeSecondaryWindowClose={confirmSecondaryWindowClose}
+              />
+            );
           })()}
         </div>
       </div>

--- a/apps/desktop/src/renderer/features/cc-agent/workdir-browse/hooks/useConfirmSwitchAwayIfDirty.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/workdir-browse/hooks/useConfirmSwitchAwayIfDirty.ts
@@ -50,3 +50,31 @@ export function useConfirmSwitchAwayIfDirty() {
     [confirmThree, t],
   );
 }
+
+/**
+ * 副窗口宿主关闭前的统一 dirty 预检。
+ *
+ * 普通任务路由的可编辑文件位于右侧栏，路由宿主拿不到 selectedPath；从当前
+ * FileBodyView handle 读取路径，复用与关 tab 相同的保存／不保存／取消语义。
+ */
+export function useConfirmCloseActiveFileIfDirty() {
+  const { t } = useTranslation();
+  const { confirmThree } = useConfirmDialog();
+
+  return useCallback(async (): Promise<boolean> => {
+    const handle = getActiveFileBodyHandle();
+    if (!handle || !handle.isDirty()) return true;
+    const choice = await confirmThree({
+      title: t('ccAgent.workdirBrowse.confirmSwitchAway.title'),
+      description: t('ccAgent.workdirBrowse.confirmSwitchAway.descriptionCloseTab', {
+        path: handle.relPath ?? '',
+      }),
+      confirmText: t('ccAgent.workdirBrowse.confirmSwitchAway.save'),
+      tertiaryText: t('ccAgent.workdirBrowse.confirmSwitchAway.tertiary'),
+      cancelText: t('ccAgent.workdirBrowse.confirmSwitchAway.cancel'),
+    });
+    if (choice === 'cancel') return false;
+    if (choice === 'tertiary') return true;
+    return await handle.save();
+  }, [confirmThree, t]);
+}

--- a/apps/desktop/src/renderer/hooks/useCCAgentChat.ts
+++ b/apps/desktop/src/renderer/hooks/useCCAgentChat.ts
@@ -170,7 +170,7 @@ interface UseCCAgentChatReturn {
   /** User-initiated stop: aborts the current SDK query and clears streaming state */
   stopSession: () => void;
   /** F-CLEAR-1: Clear conversation — hides old messages, resets SDK context, stays on same session */
-  clearSession: () => void;
+  clearSession: (opts?: { requireActiveSession?: boolean }) => void;
   /** Dismiss the error banner without retrying. */
   clearError: () => void;
   /** Retry the main-owned typed recovery target. */
@@ -524,10 +524,13 @@ export function useCCAgentChat(
     makerChatStore.stopSession(sessionId);
   }, [sessionId]);
 
-  const clearSession = useCallback(() => {
-    if (!sessionId) return;
-    makerChatStore.clearSession(sessionId);
-  }, [sessionId]);
+  const clearSession = useCallback(
+    (opts?: { requireActiveSession?: boolean }) => {
+      if (!sessionId) return;
+      makerChatStore.clearSession(sessionId, opts);
+    },
+    [sessionId],
+  );
 
   const clearError = useCallback(() => {
     if (!sessionId) return;

--- a/apps/desktop/src/renderer/hooks/useCCAgentChat.ts
+++ b/apps/desktop/src/renderer/hooks/useCCAgentChat.ts
@@ -130,6 +130,7 @@ interface UseCCAgentChatReturn {
       pastedTextRanges?: PastedTextRange[];
       slashCommandRanges?: SlashCommandRange[];
       beforeEnqueue?: () => Promise<boolean>;
+      beforeDispatch?: () => Promise<boolean>;
       onRemoteOptimisticFailure?: (clientId: string, error?: unknown) => void;
     },
   ) => Promise<boolean>;
@@ -155,6 +156,7 @@ interface UseCCAgentChatReturn {
       pastedTextRanges?: PastedTextRange[];
       slashCommandRanges?: SlashCommandRange[];
       beforeEnqueue?: () => Promise<boolean>;
+      beforeDispatch?: () => Promise<boolean>;
       onRemoteOptimisticFailure?: (clientId: string, error?: unknown) => void;
     },
   ) => Promise<boolean>;
@@ -166,7 +168,7 @@ interface UseCCAgentChatReturn {
   /** Dismiss the error banner without retrying. */
   clearError: () => void;
   /** Retry the main-owned typed recovery target. */
-  retryLastError: () => Promise<void>;
+  retryLastError: (opts?: { requireActiveSession?: boolean }) => Promise<void>;
   /** silent-stop 耗尽横幅「继续」:清横幅并发隐藏续跑指令(充值守卫额度)。 */
   continueAfterSilentStop: (opts?: { beforeEnqueue?: () => Promise<boolean> }) => void;
   /** F-CMD: Insert a local-only system card */
@@ -531,9 +533,9 @@ export function useCCAgentChat(
     [sessionId],
   );
 
-  const retryLastError = useCallback(() => {
+  const retryLastError = useCallback((opts?: { requireActiveSession?: boolean }) => {
     if (!sessionId) return Promise.resolve();
-    return makerChatStore.retryLastError(sessionId);
+    return makerChatStore.retryLastError(sessionId, opts);
   }, [sessionId]);
 
   const insertSystemCard = useCallback(

--- a/apps/desktop/src/renderer/hooks/useCCAgentChat.ts
+++ b/apps/desktop/src/renderer/hooks/useCCAgentChat.ts
@@ -132,6 +132,7 @@ interface UseCCAgentChatReturn {
       slashCommandRanges?: SlashCommandRange[];
       beforeEnqueue?: () => Promise<boolean>;
       beforeDispatch?: () => Promise<boolean>;
+      requireActiveSession?: boolean;
       onRemoteOptimisticFailure?: (clientId: string, error?: unknown) => void;
     },
   ) => Promise<boolean>;
@@ -158,10 +159,14 @@ interface UseCCAgentChatReturn {
       slashCommandRanges?: SlashCommandRange[];
       beforeEnqueue?: () => Promise<boolean>;
       beforeDispatch?: () => Promise<boolean>;
+      requireActiveSession?: boolean;
       onRemoteOptimisticFailure?: (clientId: string, error?: unknown) => void;
     },
   ) => Promise<boolean>;
-  steerQueuedMessage: (clientId: string) => Promise<boolean>;
+  steerQueuedMessage: (
+    clientId: string,
+    opts?: { requireActiveSession?: boolean },
+  ) => Promise<boolean>;
   /** User-initiated stop: aborts the current SDK query and clears streaming state */
   stopSession: () => void;
   /** F-CLEAR-1: Clear conversation — hides old messages, resets SDK context, stays on same session */
@@ -171,7 +176,10 @@ interface UseCCAgentChatReturn {
   /** Retry the main-owned typed recovery target. */
   retryLastError: (opts?: { requireActiveSession?: boolean }) => Promise<void>;
   /** silent-stop 耗尽横幅「继续」:清横幅并发隐藏续跑指令(充值守卫额度)。 */
-  continueAfterSilentStop: (opts?: { beforeEnqueue?: () => Promise<boolean> }) => void;
+  continueAfterSilentStop: (opts?: {
+    beforeEnqueue?: () => Promise<boolean>;
+    requireActiveSession?: boolean;
+  }) => void;
   /** F-CMD: Insert a local-only system card */
   insertSystemCard: (
     cardType: 'help' | 'cost' | 'context' | 'pwd' | 'status' | 'cmd' | 'learn',
@@ -496,9 +504,9 @@ export function useCCAgentChat(
   );
 
   const steerQueuedMessage = useCallback(
-    (clientId: string) => {
+    (clientId: string, opts?: { requireActiveSession?: boolean }) => {
       if (!sessionId) return Promise.resolve(false);
-      return makerChatStore.steerQueuedMessage(sessionId, clientId);
+      return makerChatStore.steerQueuedMessage(sessionId, clientId, opts);
     },
     [sessionId],
   );
@@ -527,7 +535,7 @@ export function useCCAgentChat(
   }, [sessionId]);
 
   const continueAfterSilentStop = useCallback(
-    (opts?: { beforeEnqueue?: () => Promise<boolean> }) => {
+    (opts?: { beforeEnqueue?: () => Promise<boolean>; requireActiveSession?: boolean }) => {
       if (!sessionId) return;
       makerChatStore.continueAfterSilentStop(sessionId, opts);
     },

--- a/apps/desktop/src/renderer/hooks/useCCAgentChat.ts
+++ b/apps/desktop/src/renderer/hooks/useCCAgentChat.ts
@@ -168,7 +168,7 @@ interface UseCCAgentChatReturn {
   /** Retry the main-owned typed recovery target. */
   retryLastError: () => Promise<void>;
   /** silent-stop 耗尽横幅「继续」:清横幅并发隐藏续跑指令(充值守卫额度)。 */
-  continueAfterSilentStop: () => void;
+  continueAfterSilentStop: (opts?: { beforeEnqueue?: () => Promise<boolean> }) => void;
   /** F-CMD: Insert a local-only system card */
   insertSystemCard: (
     cardType: 'help' | 'cost' | 'context' | 'pwd' | 'status' | 'cmd' | 'learn',
@@ -523,10 +523,13 @@ export function useCCAgentChat(
     makerChatStore.clearError(sessionId);
   }, [sessionId]);
 
-  const continueAfterSilentStop = useCallback(() => {
-    if (!sessionId) return;
-    makerChatStore.continueAfterSilentStop(sessionId);
-  }, [sessionId]);
+  const continueAfterSilentStop = useCallback(
+    (opts?: { beforeEnqueue?: () => Promise<boolean> }) => {
+      if (!sessionId) return;
+      makerChatStore.continueAfterSilentStop(sessionId, opts);
+    },
+    [sessionId],
+  );
 
   const retryLastError = useCallback(() => {
     if (!sessionId) return Promise.resolve();

--- a/apps/desktop/src/renderer/hooks/useCCAgentChat.ts
+++ b/apps/desktop/src/renderer/hooks/useCCAgentChat.ts
@@ -55,6 +55,7 @@ import type { ChatDisplaySnapshot } from '@/components/chat/ChatDisplaySnapshotC
 import type { AttachedFile, MentionedResource } from '@/lib/fileTypes';
 import type { PastedTextRange, SlashCommandRange } from '@/lib/imageRef';
 import type { AgentInputReference } from '@cindy/maker-shared/agent-input-projection';
+import type { AgentInputResumeOpts } from '../../shared/agentInputQueue';
 import { createLogger } from '@/lib/logger';
 import { isRemoteSessionSticky } from '@/lib/makerTransport';
 import type { UsageLimitRecoveryHint } from '@/lib/usageLimitRecovery';
@@ -104,7 +105,7 @@ interface UseCCAgentChatReturn {
   /** F-QUEUE-DEFER: 切换队列面板的展开 / 折叠态，仅影响展示。 */
   setQueueExpanded: (expanded: boolean) => void;
   /** Resume a queue paused by Stop. */
-  resumeQueue: () => void;
+  resumeQueue: (opts?: AgentInputResumeOpts) => void;
   /** Reorder a queued row by moving it to the requested insertion index. */
   moveQueueItem: (clientId: string, targetIndex: number) => void;
   /** Protect the whole queue from auto-drain while row order is being changed. */
@@ -779,10 +780,13 @@ export function useCCAgentChat(
     [sessionId],
   );
 
-  const resumeQueue = useCallback(() => {
-    if (!sessionId) return;
-    makerChatStore.resumeQueue(sessionId);
-  }, [sessionId]);
+  const resumeQueue = useCallback(
+    (opts?: AgentInputResumeOpts) => {
+      if (!sessionId) return;
+      makerChatStore.resumeQueue(sessionId, opts);
+    },
+    [sessionId],
+  );
 
   const moveQueueItem = useCallback(
     (clientId: string, targetIndex: number) => {

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -13757,11 +13757,16 @@ function retryLastError(sessionId: string): Promise<void> {
  * (点击是真实人类动作)。与 retryLastError 不同:耗尽横幅是 main 合成事件,
  * coordinator 无 recovery 状态,retryLastError 会 no-op,必须走本方法。
  */
-function continueAfterSilentStop(sessionId: string): void {
+interface SyntheticTriggerOptions {
+  beforeEnqueue?: () => Promise<boolean>;
+}
+
+function continueAfterSilentStop(sessionId: string, opts?: SyntheticTriggerOptions): void {
   if (!sessionId) return;
-  disposeLiveErrorPersist(sessionId);
-  void sendUiTrigger(sessionId, CONTINUE_AFTER_ERROR_PROMPT).then(
-    () => {
+  void sendUiTrigger(sessionId, CONTINUE_AFTER_ERROR_PROMPT, opts).then(
+    (accepted) => {
+      if (!accepted) return;
+      disposeLiveErrorPersist(sessionId);
       setState(sessionId, (s) => ({
         ...s,
         error: null,
@@ -14900,7 +14905,11 @@ export { UI_ACTION_TRIGGER_PREFIX };
  * error-tail banner) toasts or恢复红条。
  */
 
-function sendUiTriggerCore(sessionId: string, prompt: string): Promise<void> {
+function sendUiTriggerCore(
+  sessionId: string,
+  prompt: string,
+  opts?: SyntheticTriggerOptions,
+): Promise<boolean> {
   const state = getOrCreateState(sessionId);
   // UI triggers can be invoked from an error card while the mirror is being
   // reseeded. Pin every mutation in this attempt to the device that owned the
@@ -14924,7 +14933,8 @@ function sendUiTriggerCore(sessionId: string, prompt: string): Promise<void> {
       log.warn('sendUiTrigger: fetch session for createOpts failed', err);
       return null;
     })
-    .then((session) => {
+    .then(async (session) => {
+      if (opts?.beforeEnqueue && !(await opts.beforeEnqueue())) return false;
       if (!session?.workingDir) {
         // 行缺失兜底:direct send,行为与旧实现一致。
         // 无 pendingQueue 可取消，continue 在直发 accepted 后 durable ack；成功后再 dismiss
@@ -14940,7 +14950,9 @@ function sendUiTriggerCore(sessionId: string, prompt: string): Promise<void> {
                 throw new Error(result.reason ?? 'Maker send was not accepted before dispatch');
               }
             });
-        if (syntheticTriggerKind(prompt) !== 'continue') return sendDirect();
+        if (syntheticTriggerKind(prompt) !== 'continue') {
+          return sendDirect().then(() => true);
+        }
         // 执行端 maker:send 在进入 vendor 前冻结自己的时钟，并仅在 accepted 后
         // durable ack；device-link 控制端不再跨设备传时间戳。老执行端忽略该选项
         // 时安全降级为“不确认旧中断”，不会因时钟偏差抹掉新的中断。
@@ -14948,6 +14960,7 @@ function sendUiTriggerCore(sessionId: string, prompt: string): Promise<void> {
           if (continuedErrorTailClientId) {
             dismissErrorTailMessage(sessionId, continuedErrorTailClientId);
           }
+          return true;
         });
       }
       const queued = buildQueuedMessage(
@@ -14984,6 +14997,7 @@ function sendUiTriggerCore(sessionId: string, prompt: string): Promise<void> {
         .enqueue(sessionId, queued, { sendAtMs: Date.now() })
         .then((projection) => {
           applyInputProjectionOperationResponse(sessionId, operation, projection);
+          return true;
         });
     })
     .catch((err) => {
@@ -14992,12 +15006,16 @@ function sendUiTriggerCore(sessionId: string, prompt: string): Promise<void> {
     });
 }
 
-function sendUiTrigger(sessionId: string, prompt: string): Promise<void> {
+function sendUiTrigger(
+  sessionId: string,
+  prompt: string,
+  opts?: SyntheticTriggerOptions,
+): Promise<boolean> {
   if (!sessionId) return Promise.reject(new Error('sendUiTrigger: empty sessionId'));
   return withAgentSendDispatch(
     sessionId,
     () => Promise.reject(new Error('Agent switch is still in progress')),
-    () => sendUiTriggerCore(sessionId, prompt),
+    () => sendUiTriggerCore(sessionId, prompt, opts),
   );
 }
 

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -13881,24 +13881,32 @@ function dismissErrorTailMessage(sessionId: string, clientId: string): Promise<b
  *   are permanently hidden and the next query starts a fresh conversation
  * - Stays on the same session (no navigation, no new session created)
  */
-function clearSession(sessionId: string): Promise<void> {
+function clearSession(sessionId: string, opts?: { requireActiveSession?: boolean }): Promise<void> {
   if (!sessionId) return Promise.resolve();
   const clearedAt = new Date().toISOString();
 
-  return clearSessionAfterGuard(sessionId, clearedAt);
+  return clearSessionAfterGuard(sessionId, clearedAt, opts);
 }
 
-async function clearSessionAfterGuard(sessionId: string, clearedAt: string): Promise<void> {
+async function clearSessionAfterGuard(
+  sessionId: string,
+  clearedAt: string,
+  opts?: { requireActiveSession?: boolean },
+): Promise<void> {
   if (remoteClearInFlight.has(sessionId)) return;
   remoteClearInFlight.add(sessionId);
   try {
-    await clearSessionAfterGuardImpl(sessionId, clearedAt);
+    await clearSessionAfterGuardImpl(sessionId, clearedAt, opts);
   } finally {
     remoteClearInFlight.delete(sessionId);
   }
 }
 
-async function clearSessionAfterGuardImpl(sessionId: string, clearedAt: string): Promise<void> {
+async function clearSessionAfterGuardImpl(
+  sessionId: string,
+  clearedAt: string,
+  opts?: { requireActiveSession?: boolean },
+): Promise<void> {
   // /clear 清空会话：清掉该 session 的「正在识别图片中」toast，防残留。
   dismissVisionBridgeToast(sessionId);
   // Pin the clear lifecycle to the last known device before any await. The
@@ -13934,9 +13942,13 @@ async function clearSessionAfterGuardImpl(sessionId: string, clearedAt: string):
     | { kind: 'error'; err: unknown }
     | { kind: 'timeout' };
   const clearOperation = beginInputProjectionOperation(sessionId, remoteDeviceId);
+  const clearSessionRequest =
+    opts && !remoteDeviceId
+      ? clearOperation.api.input.clearSession(sessionId, clearedAt, opts)
+      : clearOperation.api.input.clearSession(sessionId, clearedAt);
   try {
     guardResult = await Promise.race([
-      clearOperation.api.input.clearSession(sessionId, clearedAt).then(
+      clearSessionRequest.then(
         (projection) => ({ kind: 'projection' as const, projection }),
         (err) => ({ kind: 'error' as const, err }),
       ),

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -1955,7 +1955,52 @@ function clearRemoteOptimisticSend(sessionId: string, clientId: string): void {
   if (deleted) syncRemoteOptimisticAttachmentUrls();
 }
 
-function clearRemoteOptimisticSendsForSession(sessionId: string): void {
+function clearRemoteOptimisticSendsForSession(
+  sessionId: string,
+  preserveClientIds?: ReadonlySet<string>,
+): void {
+  if (preserveClientIds) {
+    const records = remoteOptimisticSends.get(sessionId);
+    let deleted = false;
+    if (records) {
+      for (const clientId of [...records.keys()]) {
+        if (preserveClientIds.has(clientId)) continue;
+        records.delete(clientId);
+        cancelRemoteOptimisticSettlingRetirement(sessionId, clientId);
+        deleted = true;
+      }
+      if (records.size === 0) remoteOptimisticSends.delete(sessionId);
+    }
+    remoteInputProjectionRequests.delete(sessionId);
+    remoteInputProjectionProbeStateBySession.delete(sessionId);
+    clearRemoteOptimisticRetryTimer(sessionId);
+    remoteOptimisticPumps.delete(sessionId);
+    const timers = remoteOptimisticSettlingTimers.get(sessionId);
+    if (timers) {
+      for (const clientId of [...timers.keys()]) {
+        if (preserveClientIds.has(clientId)) continue;
+        clearTimeout(timers.get(clientId));
+        timers.delete(clientId);
+      }
+      if (timers.size === 0) remoteOptimisticSettlingTimers.delete(sessionId);
+    }
+    for (const key of remoteOptimisticSettlingChecks) {
+      const prefix = `${sessionId}\u0000`;
+      if (key.startsWith(prefix) && !preserveClientIds.has(key.slice(prefix.length))) {
+        remoteOptimisticSettlingChecks.delete(key);
+      }
+    }
+    const removed = remoteOptimisticLocallyRemoved.get(sessionId);
+    if (removed) {
+      for (const clientId of [...removed]) {
+        if (!preserveClientIds.has(clientId)) removed.delete(clientId);
+      }
+      if (removed.size === 0) remoteOptimisticLocallyRemoved.delete(sessionId);
+    }
+    if (deleted) syncRemoteOptimisticAttachmentUrls();
+    return;
+  }
+
   const deleted = remoteOptimisticSends.delete(sessionId);
   remoteInputProjectionRequests.delete(sessionId);
   remoteInputProjectionProbeStateBySession.delete(sessionId);
@@ -13917,34 +13962,20 @@ async function clearSessionAfterGuardImpl(
   clearedAt: string,
   opts?: { requireActiveSession?: boolean },
 ): Promise<void> {
-  // /clear 清空会话：清掉该 session 的「正在识别图片中」toast，防残留。
-  dismissVisionBridgeToast(sessionId);
+  const fencedClear = opts?.requireActiveSession === true;
   // Pin the clear lifecycle to the last known device before any await. The
   // mirror is intentionally cleared below, so live origin lookup is no longer
   // reliable for either clearSession or closeSession.
   const remoteDeviceId = getStickySessionDeviceId(sessionId);
-  noteRendererClearBoundary(sessionId, clearedAt);
-  // Invalidate old history/projection operations before the first network await.
-  // The clear guard itself must be the new authority generation, otherwise an
-  // older projection can win the race and reinsert pre-clear queue state.
-  invalidateMessageHistoryWindow(sessionId);
-  bumpInteractionReconcileEpoch(sessionId);
-  supersedeInputProjectionRequests(sessionId, { supersedeOperations: true });
+  const preGuardRemoteOptimisticClientIds = new Set(
+    remoteOptimisticSendRecords(sessionId)?.keys() ?? [],
+  );
   if (remoteDeviceId) {
     // Arm before the first remote await. New sends made while the invoke is
     // pending are accepted into the local optimistic ledger but cannot cross
     // the host's clear boundary.
     armRemoteClearFence(sessionId, remoteDeviceId, clearedAt);
   }
-  clearRemoteOptimisticMaterializationRecoveriesForSession(sessionId, {
-    preserveComposerTransitions: true,
-    markComposerTransitionsPurged: true,
-  });
-  clearRemoteOptimisticSendsForSession(sessionId);
-  // 远程会话:/clear 之后**不会**再有一次"最新页"拉取(唯一写缓存的那条路径),盘上那份
-  // 仍是清空前的正文 —— 此刻退出 app,下次离线冷启动就把已经被清掉的对话 hydrate 回来
-  // (review: codex P1)。放在守卫之前:无论守卫成功、失败还是超时,缓存都必须消失。
-  invalidateRemoteMessageCache(sessionId, remoteDeviceId);
   // Arm main-side clear guards before closing the CLI and clearing renderer state.
   let guardTimeoutId: ReturnType<typeof setTimeout> | undefined;
   let guardResult:
@@ -13974,8 +14005,9 @@ async function clearSessionAfterGuardImpl(
   } finally {
     if (guardTimeoutId) clearTimeout(guardTimeoutId);
   }
+  let remoteClearResolved: boolean | undefined;
   if (guardResult.kind === 'projection') {
-    let remoteClearResolved = true;
+    remoteClearResolved = true;
     if (remoteDeviceId) {
       remoteClearResolved = resolveRemoteClearFenceFromProjection(
         sessionId,
@@ -13986,10 +14018,6 @@ async function clearSessionAfterGuardImpl(
       );
     }
     applyInputProjectionOperationResponse(sessionId, clearOperation, guardResult.projection);
-    if (remoteDeviceId) {
-      if (remoteClearResolved) pumpRemoteOptimisticSendsAfterCurrent(sessionId);
-      else scheduleRemoteClearRetry(sessionId);
-    }
   } else if (guardResult.kind === 'error') {
     const err = guardResult.err;
     log.warn('maker.input.clearSession failed:', err);
@@ -14003,11 +14031,56 @@ async function clearSessionAfterGuardImpl(
     }
     if (remoteDeviceId) {
       noteRemoteClearDispatchError(sessionId, remoteDeviceId, clearedAt, err);
-      scheduleRemoteClearRetry(sessionId);
     }
   } else {
     log.warn('maker.input.clearSession timed out; continuing local clear', { sessionId });
-    if (remoteDeviceId) scheduleRemoteClearRetry(sessionId);
+  }
+
+  // A fenced clear must not mutate renderer history, optimistic sends, or the
+  // offline mirror until the main-side lifecycle guard has accepted it. If
+  // the guard rejects with SESSION_NOT_ACTIVE, returning above leaves all of
+  // those structures untouched. Sends created while the guard was pending
+  // are post-clear work and are retained below for both local and remote
+  // clears.
+  const postGuardRemoteOptimisticClientIds = new Set(
+    [...(remoteOptimisticSendRecords(sessionId)?.keys() ?? [])].filter(
+      (clientId) => !preGuardRemoteOptimisticClientIds.has(clientId),
+    ),
+  );
+  dismissVisionBridgeToast(sessionId);
+  noteRendererClearBoundary(sessionId, clearedAt);
+  invalidateMessageHistoryWindow(sessionId);
+  bumpInteractionReconcileEpoch(sessionId);
+  supersedeInputProjectionRequests(sessionId, { supersedeOperations: true });
+  clearRemoteOptimisticMaterializationRecoveriesForSession(sessionId, {
+    preserveComposerTransitions: true,
+    markComposerTransitionsPurged: true,
+  });
+  clearRemoteOptimisticSendsForSession(sessionId, postGuardRemoteOptimisticClientIds);
+  for (const clientId of postGuardRemoteOptimisticClientIds) {
+    const record = remoteOptimisticSendRecords(sessionId)?.get(clientId);
+    if (record) {
+      record.clearGeneration = rendererClearGenerationBySession.get(sessionId) ?? 0;
+    }
+  }
+  // 远程会话:/clear 之后**不会**再有一次"最新页"拉取(唯一写缓存的那条路径),盘上那份
+  // 仍是清空前的正文 —— 此刻退出 app,下次离线冷启动就把已经被清掉的对话 hydrate 回来。
+  invalidateRemoteMessageCache(sessionId, remoteDeviceId);
+  if (remoteDeviceId) {
+    // The remote fence was armed before the guard, so its generation predates
+    // the renderer clear boundary we just committed. Advance it only after a
+    // successful/non-terminal clear result; rejected fenced clears returned
+    // above and never reach this mutation.
+    const fence = remoteClearFences.get(sessionId);
+    if (fence) {
+      fence.clearGeneration = rendererClearGenerationBySession.get(sessionId) ?? 0;
+    }
+    if (guardResult.kind === 'projection') {
+      if (remoteClearResolved) pumpRemoteOptimisticSendsAfterCurrent(sessionId);
+      else scheduleRemoteClearRetry(sessionId);
+    } else {
+      scheduleRemoteClearRetry(sessionId);
+    }
   }
 
   _lastViewedAt.delete(sessionId);
@@ -14022,13 +14095,15 @@ async function clearSessionAfterGuardImpl(
   // The remote guard may have been waiting while the user composed another
   // message. Those records belong to the post-clear generation: clear the old
   // transcript, but keep their local optimistic rows until the host accepts
-  // them. Pre-clear records were already removed before the guard invoke.
+  // them. Records from before the guard are removed by the clear below.
   const postClearOptimisticClientIds = new Set(
     [...(remoteOptimisticSendRecords(sessionId)?.values() ?? [])]
       .filter(
         (record) =>
           isDataOwnerGenerationCurrent(record.dataOwner) &&
-          record.clearGeneration === (rendererClearGenerationBySession.get(sessionId) ?? 0),
+          (fencedClear
+            ? !preGuardRemoteOptimisticClientIds.has(record.queued.clientId)
+            : record.clearGeneration === (rendererClearGenerationBySession.get(sessionId) ?? 0)),
       )
       .map((record) => record.queued.clientId),
   );

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -930,6 +930,7 @@ interface RemoteOptimisticSendRecord {
   dispatching: boolean;
   attempt: number;
   beforeEnqueue?: () => Promise<boolean>;
+  beforeDispatch?: () => Promise<boolean>;
   preflightCompleted: boolean;
   /** 标注附件仍在本机烧录；完成前必须挡住本条及后续 FIFO 派发。 */
   materializationPending: boolean;
@@ -1519,6 +1520,7 @@ function registerRemoteOptimisticSend(
     dispatching: false,
     attempt: 0,
     beforeEnqueue: opts?.beforeEnqueue,
+    beforeDispatch: opts?.beforeDispatch,
     preflightCompleted: opts?.beforeEnqueue === undefined,
     materializationPending,
     steerDispatchUncertain: false,
@@ -9857,6 +9859,10 @@ async function dispatchRemoteOptimisticSend(
       if (record.steerDispatchUncertain) {
         return await reconcileUncertainRemoteSteer(sessionId, record, operation);
       }
+      if (record.beforeDispatch && !(await record.beforeDispatch())) {
+        return { kind: 'failed', error: undefined };
+      }
+      if (!isRemoteOptimisticSendRegistered(sessionId, record)) return { kind: 'cancelled' };
       const accepted = await operation.api.input.steer(sessionId, record.queued, {
         touchUserSend: true,
         ...(record.expectedClearBoundaryMs !== undefined
@@ -9869,6 +9875,10 @@ async function dispatchRemoteOptimisticSend(
       void requestInputProjection(sessionId);
       return { kind: 'accepted' };
     }
+    if (record.beforeDispatch && !(await record.beforeDispatch())) {
+      return { kind: 'failed', error: undefined };
+    }
+    if (!isRemoteOptimisticSendRegistered(sessionId, record)) return { kind: 'cancelled' };
     const projection = await operation.api.input.enqueue(sessionId, record.queued, {
       sendAtMs: Date.now(),
       ...(record.expectedClearBoundaryMs !== undefined
@@ -12533,6 +12543,8 @@ type SendMessageOpts = {
   bypassGhostHooks?: boolean;
   /** 远程预检在乐观投影建立后执行；false 时按 clientId 精确回滚。 */
   beforeEnqueue?: () => Promise<boolean>;
+  /** device-link 每次实际派发前重跑的生命周期门禁；重连重试不得复用旧结果。 */
+  beforeDispatch?: () => Promise<boolean>;
   /** 远程乐观发送在稍后确认永久失败时恢复 composer。 */
   onRemoteOptimisticFailure?: (clientId: string, error?: unknown) => void;
 };
@@ -13639,7 +13651,10 @@ function clearError(sessionId: string): void {
   });
 }
 
-function retryLastError(sessionId: string): Promise<void> {
+function retryLastError(
+  sessionId: string,
+  opts?: { requireActiveSession?: boolean },
+): Promise<void> {
   if (!sessionId) return Promise.resolve();
   disposeLiveErrorPersist(sessionId);
   // 续跑语义在 main:coordinator 判定失败 turn 已有 assistant 产出时,用共享英文
@@ -13684,8 +13699,14 @@ function retryLastError(sessionId: string): Promise<void> {
     markLocalSentUserMessage(sessionId, preRetryQueueHeadClientId);
   }
   const boundaryOpts = getRemoteInputClearBoundaryOpts(sessionId);
+  const retryOpts = {
+    ...(boundaryOpts ?? {}),
+    ...(opts?.requireActiveSession ? { requireActiveSession: true } : {}),
+  };
   return runAgentDispatchProjectionOperation(sessionId, (input) =>
-    boundaryOpts ? input.retryLastError(sessionId, boundaryOpts) : input.retryLastError(sessionId),
+    Object.keys(retryOpts).length > 0
+      ? input.retryLastError(sessionId, retryOpts)
+      : input.retryLastError(sessionId),
   ).then(
     ({ projection }) => {
       // 一次性意图的兜底清理：正常路径下 applyInputProjection 已凭意图认领

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -13893,6 +13893,11 @@ function clearSession(sessionId: string, opts?: { requireActiveSession?: boolean
   return clearSessionAfterGuard(sessionId, clearedAt, opts);
 }
 
+function isSessionNotActiveError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /\bSESSION_NOT_ACTIVE\b/i.test(message);
+}
+
 async function clearSessionAfterGuard(
   sessionId: string,
   clearedAt: string,
@@ -13948,7 +13953,7 @@ async function clearSessionAfterGuardImpl(
     | { kind: 'timeout' };
   const clearOperation = beginInputProjectionOperation(sessionId, remoteDeviceId);
   const clearSessionRequest =
-    opts && !remoteDeviceId
+    opts
       ? clearOperation.api.input.clearSession(sessionId, clearedAt, opts)
       : clearOperation.api.input.clearSession(sessionId, clearedAt);
   try {
@@ -13988,6 +13993,14 @@ async function clearSessionAfterGuardImpl(
   } else if (guardResult.kind === 'error') {
     const err = guardResult.err;
     log.warn('maker.input.clearSession failed:', err);
+    if (opts?.requireActiveSession && isSessionNotActiveError(err)) {
+      // A fenced secondary-window clear must not turn an already archived
+      // session into a locally cleared session. The host rejected the
+      // lifecycle before its clear boundary was committed; preserve the
+      // transcript and stop any remote retry loop.
+      if (remoteDeviceId) clearRemoteClearFence(sessionId, { pump: false });
+      return;
+    }
     if (remoteDeviceId) {
       noteRemoteClearDispatchError(sessionId, remoteDeviceId, clearedAt, err);
       scheduleRemoteClearRetry(sessionId);

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -13987,19 +13987,26 @@ async function clearSessionAfterGuardImpl(
     opts
       ? clearOperation.api.input.clearSession(sessionId, clearedAt, opts)
       : clearOperation.api.input.clearSession(sessionId, clearedAt);
+  const clearResult = clearSessionRequest.then(
+    (projection) => ({ kind: 'projection' as const, projection }),
+    (err) => ({ kind: 'error' as const, err }),
+  );
   try {
-    guardResult = await Promise.race([
-      clearSessionRequest.then(
-        (projection) => ({ kind: 'projection' as const, projection }),
-        (err) => ({ kind: 'error' as const, err }),
-      ),
-      new Promise<{ kind: 'timeout' }>((resolve) => {
-        guardTimeoutId = setTimeout(
-          () => resolve({ kind: 'timeout' }),
-          CLEAR_SESSION_GUARD_TIMEOUT_MS,
-        );
-      }),
-    ]);
+    // A fenced clear must wait for the main-side lifecycle decision. Falling
+    // back to a local clear after the timeout would let a later
+    // SESSION_NOT_ACTIVE rejection arrive after the renderer has already
+    // destroyed the archived transcript.
+    guardResult = fencedClear
+      ? await clearResult
+      : await Promise.race([
+          clearResult,
+          new Promise<{ kind: 'timeout' }>((resolve) => {
+            guardTimeoutId = setTimeout(
+              () => resolve({ kind: 'timeout' }),
+              CLEAR_SESSION_GUARD_TIMEOUT_MS,
+            );
+          }),
+        ]);
   } catch (err) {
     guardResult = { kind: 'error', err };
   } finally {

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -68,6 +68,7 @@ import type {
   AgentInputProjection,
   AgentInputQueuedMessage,
   AgentInputRecovery,
+  AgentInputResumeOpts,
   AgentInputSessionRef,
   AgentInputReference,
 } from '../../shared/agentInputQueue';
@@ -12228,7 +12229,7 @@ function setQueueExpanded(sessionId: string, expanded: boolean): void {
   ).catch((err) => log.warn('setQueueExpanded failed:', err));
 }
 
-function resumeQueue(sessionId: string): void {
+function resumeQueue(sessionId: string, opts?: AgentInputResumeOpts): void {
   if (!sessionId) return;
   // #2194 (Codex review P2): 暂停队列的「继续」是本端点击意图——恢复后 drain
   // 派发的队首项落库时会作为新尾部 user 行出现，不登记则门控误判为外部注入，
@@ -12247,8 +12248,14 @@ function resumeQueue(sessionId: string): void {
     markLocalSentUserMessage(sessionId, preResumeHeadClientId);
   }
   const boundaryOpts = getRemoteInputClearBoundaryOpts(sessionId);
+  const resumeOpts: AgentInputResumeOpts = {
+    ...(boundaryOpts ?? {}),
+    ...(opts?.requireActiveSession ? { requireActiveSession: true } : {}),
+  };
   runAgentDispatchProjectionOperation(sessionId, (input) =>
-    boundaryOpts ? input.resume(sessionId, boundaryOpts) : input.resume(sessionId),
+    Object.keys(resumeOpts).length > 0
+      ? input.resume(sessionId, resumeOpts)
+      : input.resume(sessionId),
   )
     .then(({ projection }) => {
       if (

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -932,6 +932,7 @@ interface RemoteOptimisticSendRecord {
   attempt: number;
   beforeEnqueue?: () => Promise<boolean>;
   beforeDispatch?: () => Promise<boolean>;
+  requireActiveSession?: boolean;
   preflightCompleted: boolean;
   /** 标注附件仍在本机烧录；完成前必须挡住本条及后续 FIFO 派发。 */
   materializationPending: boolean;
@@ -1522,6 +1523,7 @@ function registerRemoteOptimisticSend(
     attempt: 0,
     beforeEnqueue: opts?.beforeEnqueue,
     beforeDispatch: opts?.beforeDispatch,
+    requireActiveSession: opts?.requireActiveSession,
     preflightCompleted: opts?.beforeEnqueue === undefined,
     materializationPending,
     steerDispatchUncertain: false,
@@ -9866,6 +9868,7 @@ async function dispatchRemoteOptimisticSend(
       if (!isRemoteOptimisticSendRegistered(sessionId, record)) return { kind: 'cancelled' };
       const accepted = await operation.api.input.steer(sessionId, record.queued, {
         touchUserSend: true,
+        ...(record.requireActiveSession ? { requireActiveSession: true } : {}),
         ...(record.expectedClearBoundaryMs !== undefined
           ? { expectedClearBoundaryMs: record.expectedClearBoundaryMs }
           : {}),
@@ -9882,6 +9885,7 @@ async function dispatchRemoteOptimisticSend(
     if (!isRemoteOptimisticSendRegistered(sessionId, record)) return { kind: 'cancelled' };
     const projection = await operation.api.input.enqueue(sessionId, record.queued, {
       sendAtMs: Date.now(),
+      ...(record.requireActiveSession ? { requireActiveSession: true } : {}),
       ...(record.expectedClearBoundaryMs !== undefined
         ? { expectedClearBoundaryMs: record.expectedClearBoundaryMs }
         : {}),
@@ -12552,6 +12556,8 @@ type SendMessageOpts = {
   beforeEnqueue?: () => Promise<boolean>;
   /** device-link 每次实际派发前重跑的生命周期门禁；重连重试不得复用旧结果。 */
   beforeDispatch?: () => Promise<boolean>;
+  /** Main 在最终入队／插话边界复核持久化任务仍为 active。 */
+  requireActiveSession?: boolean;
   /** 远程乐观发送在稍后确认永久失败时恢复 composer。 */
   onRemoteOptimisticFailure?: (clientId: string, error?: unknown) => void;
 };
@@ -12895,7 +12901,10 @@ async function sendMessageCore(
 
   const operation = beginInputProjectionOperation(sessionId);
   return operation.api.input
-    .enqueue(sessionId, queued, { sendAtMs: Date.now() })
+    .enqueue(sessionId, queued, {
+      sendAtMs: Date.now(),
+      ...(opts?.requireActiveSession ? { requireActiveSession: true } : {}),
+    })
     .then((projection) => {
       if (opts?.authRetryPersistOnProjectionError) {
         setState(sessionId, (s) => ({
@@ -13004,6 +13013,8 @@ function steerMessage(
     pastedTextRanges?: PastedTextRange[];
     slashCommandRanges?: SlashCommandRange[];
     beforeEnqueue?: () => Promise<boolean>;
+    beforeDispatch?: () => Promise<boolean>;
+    requireActiveSession?: boolean;
     onRemoteOptimisticFailure?: (clientId: string, error?: unknown) => void;
   },
 ): Promise<boolean> {
@@ -13150,6 +13161,8 @@ async function steerMessageCore(
     pastedTextRanges?: PastedTextRange[];
     slashCommandRanges?: SlashCommandRange[];
     beforeEnqueue?: () => Promise<boolean>;
+    beforeDispatch?: () => Promise<boolean>;
+    requireActiveSession?: boolean;
     onRemoteOptimisticFailure?: (clientId: string, error?: unknown) => void;
   },
   clearGenerationAtStart = 0,
@@ -13251,7 +13264,10 @@ async function steerMessageCore(
 
   const steerApi = remoteDeviceId ? makerApiForDevice(remoteDeviceId) : makerApiFor(sessionId);
   return steerApi.input
-    .steer(sessionId, queued, { touchUserSend: true })
+    .steer(sessionId, queued, {
+      touchUserSend: true,
+      ...(opts?.requireActiveSession ? { requireActiveSession: true } : {}),
+    })
     .then(async (ok) => {
       if (ok) {
         commitAutoTitle();
@@ -13383,7 +13399,11 @@ async function resendBlockedMessage(
   }
 }
 
-function steerQueuedMessage(sessionId: string, clientId: string): Promise<boolean> {
+function steerQueuedMessage(
+  sessionId: string,
+  clientId: string,
+  opts?: { requireActiveSession?: boolean },
+): Promise<boolean> {
   if (!sessionId || !clientId) return Promise.resolve(false);
   // Capture the target before entering the dispatch coordinator. A relay
   // reconnect may clear remoteProjectsStore while the coordinator is waiting;
@@ -13425,6 +13445,7 @@ function steerQueuedMessage(sessionId: string, clientId: string): Promise<boolea
       return steerApi.input
         .steer(sessionId, queued, {
           removeFromQueue: true,
+          ...(opts?.requireActiveSession ? { requireActiveSession: true } : {}),
           ...getRemoteInputClearBoundaryOpts(sessionId),
         })
         .then((ok) => {
@@ -13787,6 +13808,7 @@ function retryLastError(
  */
 interface SyntheticTriggerOptions {
   beforeEnqueue?: () => Promise<boolean>;
+  requireActiveSession?: boolean;
 }
 
 function continueAfterSilentStop(sessionId: string, opts?: SyntheticTriggerOptions): void {
@@ -14971,6 +14993,7 @@ function sendUiTriggerCore(
           triggerApi
             .send(sessionId, { type: 'user', content: prompt }, undefined, {
               userName: currentUserName ?? undefined,
+              ...(opts?.requireActiveSession ? { requireActiveSession: true } : {}),
               ...(ackInterruptedTurnOnDispatch ? { ackInterruptedTurnOnDispatch: true } : {}),
             })
             .then((result) => {
@@ -15022,7 +15045,10 @@ function sendUiTriggerCore(
       markLocalSentUserMessage(sessionId, queued.clientId);
       const operation = beginInputProjectionOperation(sessionId, remoteDeviceId);
       return operation.api.input
-        .enqueue(sessionId, queued, { sendAtMs: Date.now() })
+        .enqueue(sessionId, queued, {
+          sendAtMs: Date.now(),
+          ...(opts?.requireActiveSession ? { requireActiveSession: true } : {}),
+        })
         .then((projection) => {
           applyInputProjectionOperationResponse(sessionId, operation, projection);
           return true;

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -96,6 +96,7 @@ import type {
 } from '../../shared/ghost';
 import * as messageService from '@/lib/messageService';
 import * as sessionService from '@/lib/sessionService';
+import { isSecondaryWindow } from '@/lib/secondaryWindow';
 // device-link 透明传输:远程(被控设备)会话的操作/读取走隧道,本地会话零变化。
 import {
   makerApiFor,
@@ -12974,11 +12975,15 @@ function compactSession(
   // 不进计划模式、不消耗用户的一次性勾选(false 语义见 SendOptions.planMode)。
   createOpts.planMode = false;
   const boundaryOpts = getRemoteInputClearBoundaryOpts(sessionId);
+  // 副窗口归档后不得压缩(压缩会启动新 turn,绕过 active-session fence,#3262 P2)。
+  // main 侧 INPUT_COMPACT handler 读取此标记并在持锁内复核会话仍 active。
+  const fenceOpts = isSecondaryWindow() ? { requireActiveSession: true } : {};
   return (
     runAgentDispatchProjectionOperation(sessionId, (input) =>
       input.compact(sessionId, createOpts, {
         userName: currentUserName,
         ...(boundaryOpts ?? {}),
+        ...fenceOpts,
       }),
     )
       // RPC 已执行成功时保留既有返回语义；origin 漂移只丢控制端镜像回写。

--- a/apps/desktop/src/renderer/lib/makerTransport.ts
+++ b/apps/desktop/src/renderer/lib/makerTransport.ts
@@ -173,22 +173,19 @@ function remoteMakerApi(deviceId: string): RoutableMaker {
     setExtraDirs: t('maker:set-extra-dirs') as FullMaker['setExtraDirs'],
     setWritableDirs: t('maker:set-writable-dirs') as FullMaker['setWritableDirs'],
     closeSession: t('maker:close-session') as FullMaker['closeSession'],
-    compactSession: ((sessionId, instructions) =>
-      invokeRemote(
-        deviceId,
-        'maker:compact-session',
-        // 副窗口显式透传 requireActiveSession:压缩会启动新 turn,不能在已归档
-        // 任务上执行(#3262 P2)。instructions 后追加 fenceOpts 作为第四参。
-        isSecondaryWindow()
-          ? [
-              sessionId,
-              ...(instructions === undefined ? [] : [instructions]),
-              { requireActiveSession: true },
-            ]
-          : instructions === undefined
-            ? [sessionId]
-            : [sessionId, instructions],
-      )) as FullMaker['compactSession'],
+    compactSession: ((sessionId, instructions) => {
+      // 副窗口显式透传 requireActiveSession:压缩会启动新 turn,不能在已归档
+      // 任务上执行(#3262)。handler 签名是 (event, sessionId, instructions,
+      // fenceOpts),所以副窗口时必须保留 instructions 槽位(即使 undefined),
+      // 再追加 fenceOpts 作为第四参——否则 fence 对象会被当成 instructions
+      // 触发 INVALID_PARAMS(P1)。
+      const args: unknown[] = isSecondaryWindow()
+        ? [sessionId, instructions, { requireActiveSession: true }]
+        : instructions === undefined
+          ? [sessionId]
+          : [sessionId, instructions];
+      return invokeRemote(deviceId, 'maker:compact-session', args);
+    }) as FullMaker['compactSession'],
     enableOrca: t('maker:session:enable-orca') as FullMaker['enableOrca'],
     dispatchOrcaUiAssignment: t(
       'maker:worker:dispatch-ui-assignment',

--- a/apps/desktop/src/renderer/lib/makerTransport.ts
+++ b/apps/desktop/src/renderer/lib/makerTransport.ts
@@ -28,6 +28,7 @@ import {
   sessionCacheInvalidationToken,
 } from '@/features/device-link/mirrorCacheClient';
 import { getStickySessionDeviceId } from '@/features/device-link/stickySessionOrigin';
+import { isSecondaryWindow } from '@/lib/secondaryWindow';
 import type { Message, Session } from '@/lib/ccAgent.types';
 import * as messageService from '@/lib/messageService';
 import * as sessionService from '@/lib/sessionService';
@@ -651,7 +652,16 @@ export function goalApiFor(sessionId: string): RoutableGoal {
         return localApi.updateGoal(sid, patch as Parameters<FullMaker['updateGoal']>[1]);
       return invokeRemote(deviceId, 'maker:goal:update', [{ sessionId: sid, patch }]);
     }) as FullMaker['updateGoal'],
-    getGoalStatus: t('maker:goal:get-status', localApi.getGoalStatus) as FullMaker['getGoalStatus'],
+    getGoalStatus: ((sid: string) => {
+      const deviceId = resolve();
+      if (!deviceId) return localApi.getGoalStatus(sid);
+      // 远程会话:本机会话 main 按真实 event.sender 自动 fence 副窗口,无需标记;
+      // 远程副窗口的合成 event 无 sender,这里显式透传 requireActiveSession,让被控端
+      // 把有副作用的 resumeOnOpen 纳入 active-session 复核(归档后不重新拉起任务)。
+      // 主窗口打开远程会话保持 resume-on-open 历史语义,不带标记。
+      const args: unknown[] = isSecondaryWindow() ? [sid, { requireActiveSession: true }] : [sid];
+      return invokeRemote(deviceId, 'maker:goal:get-status', args);
+    }) as FullMaker['getGoalStatus'],
   };
 }
 

--- a/apps/desktop/src/renderer/lib/makerTransport.ts
+++ b/apps/desktop/src/renderer/lib/makerTransport.ts
@@ -177,7 +177,17 @@ function remoteMakerApi(deviceId: string): RoutableMaker {
       invokeRemote(
         deviceId,
         'maker:compact-session',
-        instructions === undefined ? [sessionId] : [sessionId, instructions],
+        // 副窗口显式透传 requireActiveSession:压缩会启动新 turn,不能在已归档
+        // 任务上执行(#3262 P2)。instructions 后追加 fenceOpts 作为第四参。
+        isSecondaryWindow()
+          ? [
+              sessionId,
+              ...(instructions === undefined ? [] : [instructions]),
+              { requireActiveSession: true },
+            ]
+          : instructions === undefined
+            ? [sessionId]
+            : [sessionId, instructions],
       )) as FullMaker['compactSession'],
     enableOrca: t('maker:session:enable-orca') as FullMaker['enableOrca'],
     dispatchOrcaUiAssignment: t(

--- a/apps/desktop/src/renderer/lib/makerTransport.ts
+++ b/apps/desktop/src/renderer/lib/makerTransport.ts
@@ -633,32 +633,52 @@ export type RoutableGoal = FullGoalMaker;
  */
 export function goalApiFor(sessionId: string): RoutableGoal {
   const resolve = () => getStickySessionDeviceId(sessionId);
-  const t =
-    (channel: string, local: (...args: never[]) => unknown) =>
-    (...args: unknown[]): Promise<unknown> => {
-      const deviceId = resolve();
-      if (!deviceId) return Promise.resolve(local(...(args as never[])));
-      return invokeRemote(deviceId, channel, args);
-    };
   const localApi = window.electronAPI.maker;
+  // 远程副窗口(device-link 会话 + 当前 renderer 是副窗口):合成 event 无 sender,
+  // 被控端 runWithLifecycleGuard 无法按窗口归属识别副窗,因此每个有副作用的 Goal
+  // 操作都显式透传 requireActiveSession,与 GOAL_SET 的 input 标记 / GOAL_CLEAR、
+  // GOAL_RESUME 的第二参 fenceOpts 对齐(reviewer P1:不能只 fence getGoalStatus,
+  // 否则副窗口仍能通过 set/resume/update/clear 重新拉起已归档任务)。
+  // 本机会话 main 按真实 event.sender 自动 fence,主窗口远程会话保持历史语义。
+  const remoteFenceOpts = (): unknown => (isSecondaryWindow() ? { requireActiveSession: true } : undefined);
   return {
-    setGoal: t('maker:goal:set', localApi.setGoal) as FullMaker['setGoal'],
-    clearGoal: t('maker:goal:clear', localApi.clearGoal) as FullMaker['clearGoal'],
-    pauseGoal: t('maker:goal:pause', localApi.pauseGoal) as FullMaker['pauseGoal'],
-    resumeGoal: t('maker:goal:resume', localApi.resumeGoal) as FullMaker['resumeGoal'],
+    setGoal: ((input: unknown) => {
+      const deviceId = resolve();
+      if (!deviceId) return localApi.setGoal(input as Parameters<FullMaker['setGoal']>[0]);
+      const merged = isSecondaryWindow() && input && typeof input === 'object'
+        ? { ...(input as Record<string, unknown>), requireActiveSession: true }
+        : input;
+      return invokeRemote(deviceId, 'maker:goal:set', [merged]);
+    }) as FullMaker['setGoal'],
+    clearGoal: ((sid: string) => {
+      const deviceId = resolve();
+      if (!deviceId) return localApi.clearGoal(sid);
+      return invokeRemote(deviceId, 'maker:goal:clear', [sid, remoteFenceOpts()]);
+    }) as FullMaker['clearGoal'],
+    pauseGoal: ((sid: string) => {
+      const deviceId = resolve();
+      if (!deviceId) return localApi.pauseGoal(sid);
+      // pauseGoal 对 active/paused 是 no-op,不续跑任务,不需要 fence。
+      return invokeRemote(deviceId, 'maker:goal:pause', [sid]);
+    }) as FullMaker['pauseGoal'],
+    resumeGoal: ((sid: string) => {
+      const deviceId = resolve();
+      if (!deviceId) return localApi.resumeGoal(sid);
+      return invokeRemote(deviceId, 'maker:goal:resume', [sid, remoteFenceOpts()]);
+    }) as FullMaker['resumeGoal'],
     updateGoal: ((sid: string, patch: unknown) => {
       const deviceId = resolve();
       if (!deviceId)
         return localApi.updateGoal(sid, patch as Parameters<FullMaker['updateGoal']>[1]);
-      return invokeRemote(deviceId, 'maker:goal:update', [{ sessionId: sid, patch }]);
+      const payload: Record<string, unknown> = { sessionId: sid, patch };
+      if (isSecondaryWindow()) payload.requireActiveSession = true;
+      return invokeRemote(deviceId, 'maker:goal:update', [payload]);
     }) as FullMaker['updateGoal'],
     getGoalStatus: ((sid: string) => {
       const deviceId = resolve();
       if (!deviceId) return localApi.getGoalStatus(sid);
-      // 远程会话:本机会话 main 按真实 event.sender 自动 fence 副窗口,无需标记;
-      // 远程副窗口的合成 event 无 sender,这里显式透传 requireActiveSession,让被控端
-      // 把有副作用的 resumeOnOpen 纳入 active-session 复核(归档后不重新拉起任务)。
-      // 主窗口打开远程会话保持 resume-on-open 历史语义,不带标记。
+      // 远程副窗口显式透传 requireActiveSession,把有副作用的 resumeOnOpen 纳入
+      // active-session 复核(归档后不重新拉起任务);主窗口远程会话保持历史语义。
       const args: unknown[] = isSecondaryWindow() ? [sid, { requireActiveSession: true }] : [sid];
       return invokeRemote(deviceId, 'maker:goal:get-status', args);
     }) as FullMaker['getGoalStatus'],

--- a/apps/desktop/src/renderer/lib/makerTransport.ts
+++ b/apps/desktop/src/renderer/lib/makerTransport.ts
@@ -653,7 +653,11 @@ export function goalApiFor(sessionId: string): RoutableGoal {
     clearGoal: ((sid: string) => {
       const deviceId = resolve();
       if (!deviceId) return localApi.clearGoal(sid);
-      return invokeRemote(deviceId, 'maker:goal:clear', [sid, remoteFenceOpts()]);
+      return invokeRemote(
+        deviceId,
+        'maker:goal:clear',
+        isSecondaryWindow() ? [sid, { requireActiveSession: true }] : [sid],
+      );
     }) as FullMaker['clearGoal'],
     pauseGoal: ((sid: string) => {
       const deviceId = resolve();
@@ -664,7 +668,11 @@ export function goalApiFor(sessionId: string): RoutableGoal {
     resumeGoal: ((sid: string) => {
       const deviceId = resolve();
       if (!deviceId) return localApi.resumeGoal(sid);
-      return invokeRemote(deviceId, 'maker:goal:resume', [sid, remoteFenceOpts()]);
+      return invokeRemote(
+        deviceId,
+        'maker:goal:resume',
+        isSecondaryWindow() ? [sid, { requireActiveSession: true }] : [sid],
+      );
     }) as FullMaker['resumeGoal'],
     updateGoal: ((sid: string, patch: unknown) => {
       const deviceId = resolve();

--- a/apps/desktop/src/renderer/lib/slashCommands.ts
+++ b/apps/desktop/src/renderer/lib/slashCommands.ts
@@ -466,6 +466,8 @@ export interface DispatchContext {
   /** device-link 远程会话的归属设备 id(本机会话缺省)。main 侧 /goal /learn /cmd
    *  据此把业务体经隧道路由到被控端执行。 */
   deviceId?: string;
+  /** Require Main to verify that a local session remains active before dispatch. */
+  requireActiveSession?: boolean;
 }
 
 /**
@@ -490,6 +492,7 @@ export async function dispatchCommand(
         ...(ctx.workingDir ? { workingDir: ctx.workingDir } : {}),
         ...(ctx.args ? { args: ctx.args } : {}),
         ...(ctx.deviceId ? { deviceId: ctx.deviceId } : {}),
+        ...(ctx.requireActiveSession ? { requireActiveSession: true } : {}),
       });
     } catch (err) {
       log.warn(

--- a/apps/desktop/src/renderer/lib/slashCommands.ts
+++ b/apps/desktop/src/renderer/lib/slashCommands.ts
@@ -479,7 +479,7 @@ export interface DispatchContext {
  * 返回 'handled-locally' 表示已处理(调用方应阻止默认 send 行为);
  * 返回 'forward-to-agent' 表示让调用方继续走默认 send 路径。
  */
-export type DispatchResult = 'handled-locally' | 'forward-to-agent';
+export type DispatchResult = 'handled-locally' | 'forward-to-agent' | 'rejected';
 
 export async function dispatchCommand(
   cmd: UnifiedCommand,
@@ -498,6 +498,7 @@ export async function dispatchCommand(
       log.warn(
         `executeDesktopCommand /${cmd.name} failed: ${err instanceof Error ? err.message : String(err)}`,
       );
+      return 'rejected';
     }
     return 'handled-locally';
   }

--- a/apps/desktop/src/renderer/vite-env.d.ts
+++ b/apps/desktop/src/renderer/vite-env.d.ts
@@ -5197,7 +5197,13 @@ interface ElectronAPI {
 
     executeDesktopCommand: (
       name: string,
-      ctx: { sessionId?: string; workingDir?: string; args?: string; deviceId?: string },
+      ctx: {
+        sessionId?: string;
+        workingDir?: string;
+        args?: string;
+        deviceId?: string;
+        requireActiveSession?: boolean;
+      },
     ) => Promise<{ success: boolean; error?: string }>;
 
     startReview: (input: {

--- a/apps/desktop/src/renderer/vite-env.d.ts
+++ b/apps/desktop/src/renderer/vite-env.d.ts
@@ -5540,7 +5540,7 @@ interface ElectronAPI {
       ) => Promise<import('../shared/agentInputQueue').AgentInputProjection>;
       resume: (
         sessionId: string,
-        opts?: { expectedClearBoundaryMs?: number | null },
+        opts?: import('../shared/agentInputQueue').AgentInputResumeOpts,
       ) => Promise<import('../shared/agentInputQueue').AgentInputProjection>;
       retryLastError: (
         sessionId: string,

--- a/apps/desktop/src/renderer/vite-env.d.ts
+++ b/apps/desktop/src/renderer/vite-env.d.ts
@@ -5271,6 +5271,7 @@ interface ElectronAPI {
         goalAction?: 'set' | 'cleared' | 'open-dialog';
         /** /learn 专用:启动成功时的 runId(关联 learn:event 状态流)。 */
         learnRunId?: string;
+        requireActiveSession?: boolean;
       }) => void,
     ) => () => void;
 
@@ -5596,6 +5597,7 @@ interface ElectronAPI {
       clearSession: (
         sessionId: string,
         clearedAt?: string,
+        opts?: import('../shared/agentInputQueue').AgentInputRequireActiveSessionOpts,
       ) => Promise<import('../shared/agentInputQueue').AgentInputProjection>;
     };
 

--- a/apps/desktop/src/renderer/vite-env.d.ts
+++ b/apps/desktop/src/renderer/vite-env.d.ts
@@ -5544,7 +5544,7 @@ interface ElectronAPI {
       ) => Promise<import('../shared/agentInputQueue').AgentInputProjection>;
       retryLastError: (
         sessionId: string,
-        opts?: { expectedClearBoundaryMs?: number | null },
+        opts?: import('../shared/agentInputQueue').AgentInputRetryOpts,
       ) => Promise<import('../shared/agentInputQueue').AgentInputProjection>;
       clearError: (
         sessionId: string,

--- a/apps/desktop/src/renderer/vite-env.d.ts
+++ b/apps/desktop/src/renderer/vite-env.d.ts
@@ -5514,7 +5514,7 @@ interface ElectronAPI {
       enqueue: (
         sessionId: string,
         item: import('../shared/agentInputQueue').AgentInputQueuedMessage,
-        opts?: { sendAtMs?: number; expectedClearBoundaryMs?: number | null },
+        opts?: import('../shared/agentInputQueue').AgentInputEnqueueOpts,
       ) => Promise<import('../shared/agentInputQueue').AgentInputProjection>;
       compact: (
         sessionId: string,
@@ -5524,11 +5524,7 @@ interface ElectronAPI {
       steer: (
         sessionId: string,
         item: import('../shared/agentInputQueue').AgentInputQueuedMessage,
-        opts?: {
-          removeFromQueue?: boolean;
-          touchUserSend?: boolean;
-          expectedClearBoundaryMs?: number | null;
-        },
+        opts?: import('../shared/agentInputQueue').AgentInputSteerOpts,
       ) => Promise<boolean>;
       stop: (
         sessionId: string,

--- a/apps/desktop/src/renderer/vite-env.d.ts
+++ b/apps/desktop/src/renderer/vite-env.d.ts
@@ -5493,6 +5493,7 @@ interface ElectronAPI {
         remoteHostId?: string;
         resumeSessionId?: string;
       },
+      fenceOpts?: { requireActiveSession?: boolean },
     ) => Promise<import('@cindy/maker-core').ContextUsageData>;
 
     abortSession: (sessionId: string) => Promise<void>;

--- a/apps/desktop/src/shared/agentInputQueue.ts
+++ b/apps/desktop/src/shared/agentInputQueue.ts
@@ -167,6 +167,11 @@ export interface AgentInputClearBoundaryOpts {
   expectedClearBoundaryMs?: number | null;
 }
 
+/** Manual retry options; secondary windows can require an active task at dispatch time. */
+export interface AgentInputRetryOpts extends AgentInputClearBoundaryOpts {
+  requireActiveSession?: boolean;
+}
+
 /**
  * 一次自动续跑（中断自愈）的展示信息，main 与 renderer 共用。
  *

--- a/apps/desktop/src/shared/agentInputQueue.ts
+++ b/apps/desktop/src/shared/agentInputQueue.ts
@@ -259,6 +259,13 @@ export interface AgentInputQueuedMessage {
    */
   hostAcceptedAtMs?: number;
   /**
+   * Main-owned lifecycle fence for an input accepted from a secondary window.
+   * It survives queueing and crash recovery so the final vendor boundary can
+   * reject the input if the durable task was archived in the meantime. It is
+   * never trusted from IPC payloads and is omitted from public projections.
+   */
+  requireActiveSession?: boolean;
+  /**
    * Main 在首次入队时从原始 text 冻结的合成指令意图。Ghost rewrite、队列编辑
    * 与 dispatch 前的其它正文变换都不得改写它；执行端用它判断 Continue 的
    * 优先级与 durable ack，避免从已经被改写的 text 反推原始用户动作。

--- a/apps/desktop/src/shared/agentInputQueue.ts
+++ b/apps/desktop/src/shared/agentInputQueue.ts
@@ -167,15 +167,40 @@ export interface AgentInputClearBoundaryOpts {
   expectedClearBoundaryMs?: number | null;
 }
 
-/** Queue resume options; secondary windows can require an active task at dispatch time. */
-export interface AgentInputResumeOpts extends AgentInputClearBoundaryOpts {
+/** Optional Main-side lifecycle fence for manual dispatches from secondary windows. */
+export interface AgentInputRequireActiveSessionOpts {
   requireActiveSession?: boolean;
 }
 
-/** Manual retry options; secondary windows can require an active task at dispatch time. */
-export interface AgentInputRetryOpts extends AgentInputClearBoundaryOpts {
-  requireActiveSession?: boolean;
+export function requiresActiveSessionForDispatch(opts: unknown): boolean {
+  return Boolean(
+    opts &&
+    typeof opts === 'object' &&
+    !Array.isArray(opts) &&
+    (opts as AgentInputRequireActiveSessionOpts).requireActiveSession === true,
+  );
 }
+
+/** Queue enqueue options; secondary windows can require an active task at dispatch time. */
+export interface AgentInputEnqueueOpts
+  extends AgentInputClearBoundaryOpts, AgentInputRequireActiveSessionOpts {
+  sendAtMs?: number;
+}
+
+/** Same-turn steer options, including the secondary-window lifecycle fence. */
+export interface AgentInputSteerOpts
+  extends AgentInputClearBoundaryOpts, AgentInputRequireActiveSessionOpts {
+  removeFromQueue?: boolean;
+  touchUserSend?: boolean;
+}
+
+/** Queue resume options; secondary windows can require an active task at dispatch time. */
+export interface AgentInputResumeOpts
+  extends AgentInputClearBoundaryOpts, AgentInputRequireActiveSessionOpts {}
+
+/** Manual retry options; secondary windows can require an active task at dispatch time. */
+export interface AgentInputRetryOpts
+  extends AgentInputClearBoundaryOpts, AgentInputRequireActiveSessionOpts {}
 
 /**
  * 一次自动续跑（中断自愈）的展示信息，main 与 renderer 共用。

--- a/apps/desktop/src/shared/agentInputQueue.ts
+++ b/apps/desktop/src/shared/agentInputQueue.ts
@@ -167,6 +167,11 @@ export interface AgentInputClearBoundaryOpts {
   expectedClearBoundaryMs?: number | null;
 }
 
+/** Queue resume options; secondary windows can require an active task at dispatch time. */
+export interface AgentInputResumeOpts extends AgentInputClearBoundaryOpts {
+  requireActiveSession?: boolean;
+}
+
 /** Manual retry options; secondary windows can require an active task at dispatch time. */
 export interface AgentInputRetryOpts extends AgentInputClearBoundaryOpts {
   requireActiveSession?: boolean;

--- a/apps/desktop/src/shared/learnTypes.ts
+++ b/apps/desktop/src/shared/learnTypes.ts
@@ -109,6 +109,12 @@ export interface LearnStartRequest {
   hubSlug?: string;
   hubCatalogScope?: 'market' | 'team';
   originSessionId?: string;
+  /**
+   * Main-owned fence marker(仅 IPC dispatch 路径消费,controller 不读):device-link
+   * 合成 event sender 为空,副窗口经隧道发起 /learn 时由原始 renderer 显式置 true,
+   * 被控端据此在 route lock 内复核持久化 active 状态;primary remote task 不带。
+   */
+  requireActiveSession?: boolean;
 }
 
 /** learn:event push payload。 */


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复独立副窗口仍持有已归档任务时可以继续派发输入的问题。副窗口会在观察到任务归档后关闭；即使归档与“继续队列”或远程乐观发送发生竞态，Main 也会在真正恢复派发前按持久化任务状态再次拦截。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：Closes #3175；产品讨论：#3263
- 本 PR 包含：副窗口归档生命周期收口；队列 Resume / Retry 的持久化 active 状态门禁；远程乐观发送失败时的请求级回滚与隔离测试。
- 明确不包含：改变主窗口中“向已归档任务发消息会恢复任务”的既有行为；新增 device-link wire 消息、重连策略或 relay 协议。
- 用户可见变化：任务在主窗口被归档后，仍打开该任务的独立副窗口会关闭，且竞态中的继续/发送操作不会把该任务重新激活。
- 是否存在 breaking change：无。

### UI 变化

- 引用的设计规范：不涉及新增视觉、文案或布局。改动复用既有 `windowClose()` 与分屏树收敛逻辑，属于独立辅助窗口的生命周期与故障隔离修复；对应 `docs/design-rules/DESIGN.md` 的多窗口一致性原则，以及 `docs/dev-rules/electron-security-and-process-boundaries.md` §3.1“独立辅助窗口统一生命周期基线”。

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：通过。

pnpm --filter desktop run --if-present typecheck
结果：通过。

Desktop 相关定向 Vitest（队列 coordinator、副窗口归档门禁、makerChatStore 远程恢复等 5 个文件）
结果：502 tests passed。

pnpm --filter @cindy/device-link exec vitest run src/__tests__/client.test.ts -t '多 peer 拓扑:一个 peer 停止 ACK 被限流,另一个 peer 的投递零感知'
结果：通过。

bash /Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh <worktree>
结果：Desktop 28,262 passed / 5 skipped；仅 ghostInstallReceipt.test.ts 两项失败。相同两项已在 clean origin/main 单独复现，判定为与本 PR 无关的主干基线故障。
```

### 手工验证

未执行；本轮以生命周期、IPC 边界与远程恢复回归测试覆盖。

### 未执行的验证

- macOS / Windows 多窗口手工回归。
- 全仓 unit gate 未达到全绿：被上述已在 clean main 复现的两项基线失败阻断。

## 风险

### 风险分类

- [x] 权限 / 安全 / 用户数据
- [x] 跨平台差异
- [x] 其他：独立窗口与远程派发生命周期竞态

### 影响与回滚

- 影响范围：仅副窗口对已归档任务的输入派发、队列恢复，以及远程乐观发送恢复路径；主窗口既有归档恢复行为保持不变。
- 回滚 / 降级方式：回滚本 PR 即恢复旧行为；未新增 migration、持久化 schema 或 wire 协议。
- 故障半径三问：
  1. 触发层级是单条乐观发送请求或单个任务生命周期在归档边界发生竞态。
  2. 恢复动作保持同半径：只拒绝/回滚对应 outbox 请求，或让对应任务队列继续暂停；不会拆除 peer link、关闭 relay、重连或全量重放。
  3. 多 peer / 共享被控端：新增 Desktop 用例覆盖同一被控端上一个生命周期门禁拒绝不影响另一个在途请求；同时复跑 `packages/device-link` 既有“双 peer 中一个停止 ACK、另一个投递零感知”用例。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在“UI 变化”注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因

