### PR TITLE
fix(mobile): 只在消息 key 变化时续 mVCP 安静窗

### DIFF
--- a/apps/mobile/src/__tests__/messageListVirtualization.test.ts
+++ b/apps/mobile/src/__tests__/messageListVirtualization.test.ts
@@ -60,6 +60,9 @@ describe('mobile message list container', () => {
     // 两套 verifier 都不能再只依赖 readingOlderRef 判断是否等待。
     expect(source).toContain('mvcpSettleAtRef.current = mobileMvcpSettleDeadline(');
     expect(source).toContain('markMobileMvcpSettle();');
+    expect(source).toContain('mobileMessageListKeysSignature(itemKeys)');
+    expect(source).toContain('[itemKeysSignature, markMobileMvcpSettle]');
+    expect(source).not.toContain('[itemKeys, markMobileMvcpSettle]');
     expect(source.match(/isMobileMvcpSettling\(Date\.now\(\), mvcpSettleAtRef\.current\)/g))
       .toHaveLength(2);
   });

--- a/apps/mobile/src/__tests__/messageScroll.test.ts
+++ b/apps/mobile/src/__tests__/messageScroll.test.ts
@@ -18,6 +18,7 @@ import {
   isNearMessageListTop,
   isMobileMvcpSettling,
   mobileFollowVerifyStartDelayMs,
+  mobileMessageListKeysSignature,
   mobileMvcpSettleDeadline,
   MOBILE_ANCHOR_VERIFY_MAX_ATTEMPTS,
   MOBILE_ANCHOR_VERIFY_MAX_WAIT_ROUNDS,
@@ -746,6 +747,15 @@ describe('mobile mVCP settle quiet window', () => {
     const firstDeadline = mobileMvcpSettleDeadline(0, 1_000);
     const extendedDeadline = mobileMvcpSettleDeadline(firstDeadline, 1_080);
     expect(extendedDeadline).toBe(1_080 + MOBILE_MVCP_SETTLE_QUIET_MS);
+  });
+
+  it('treats reused keys as the same list identity even when the items array is new', () => {
+    expect(mobileMessageListKeysSignature(['u1', 'a1'])).toBe(
+      mobileMessageListKeysSignature(['u1', 'a1']),
+    );
+    expect(mobileMessageListKeysSignature(['u1', 'a1'])).not.toBe(
+      mobileMessageListKeysSignature(['u1', 'a1', 'a2']),
+    );
   });
 });
 

--- a/apps/mobile/src/session/MessageRenderer.tsx
+++ b/apps/mobile/src/session/MessageRenderer.tsx
@@ -304,6 +304,7 @@ import {
   evaluateMobileFollowEndContentSizePin,
   isMobileMvcpSettling,
   mobileFollowVerifyStartDelayMs,
+  mobileMessageListKeysSignature,
   mobileMvcpSettleDeadline,
   mobileMessageListTopPadding,
   MOBILE_FOLLOW_END_PIN_SUPPRESS_MS,
@@ -918,9 +919,14 @@ export function MessageRenderer({
     prevListLengthRef.current = listData.length;
   }
   const itemKeys = useMemo(() => listData.map((item) => item.key), [listData]);
+  const itemKeysSignature = useMemo(
+    () => mobileMessageListKeysSignature(itemKeys),
+    [itemKeys],
+  );
+  // 只认行身份（追加 / 换行 / 重排）。流式改内容会换 items 引用，但不能续安静窗。
   useEffect(() => {
     markMobileMvcpSettle();
-  }, [itemKeys, markMobileMvcpSettle]);
+  }, [itemKeysSignature, markMobileMvcpSettle]);
   const firstItemKey = itemKeys[0] ?? null;
   // 本地缩略兜底映射版本:collect 内部对 cindy-oss-attach:// 附件读全局 store 做 overlay,
   // hydrate / 新注册后 gallery 需要重建,否则点开气泡本地图时 initialUrl 对不上图集条目。

--- a/apps/mobile/src/session/messageScroll.ts
+++ b/apps/mobile/src/session/messageScroll.ts
@@ -309,6 +309,14 @@ export function isMobileMvcpSettling(now: number, settleAt: number): boolean {
   return now < settleAt;
 }
 
+/**
+ * 只在行身份变化时续 mVCP 安静窗。流式更新会反复换 `items` 数组引用、但 key 不变；
+ * 若按数组引用续窗，verifier 会在整轮生成期间一直 wait，直到 2.5s 预算耗尽。
+ */
+export function mobileMessageListKeysSignature(keys: readonly string[]): string {
+  return keys.join('\0');
+}
+
 export interface MobileFollowVerifyStartDelayInput {
   animatedScrollInFlight: boolean;
   now: number;


### PR DESCRIPTION
## 这次改了什么

### 摘要

#3192 合入后，发送后的贴底校验仍可能在整轮流式输出期间跟不住。原因是 120ms mVCP 安静窗绑在 `items` 数组引用上：流式每个字都会换新数组，窗被一直续上，校验只 wait 直到 2.5s 预算耗尽。

这次改为只在消息 key 真变（追加 / 换行 / 重排）时续窗。高度变化仍走原来的 `handleContentSize`。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：#3192 合入后的跟进
- 本 PR 包含：`mobileMessageListKeysSignature`，以及 MessageRenderer 安静窗只依赖 key 签名
- 明确不包含：时钟对齐、重连配对、#3192 已合入的发送跟随本身
- 用户可见变化：发送后马上开始流式时，列表应继续停在最新消息
- 是否存在 breaking change：无

### UI 变化

不涉及：无布局、样式或文案变化；只修正发送后贴底校验的等待条件。

- 引用的设计规范：不涉及：未改变 UI 布局、样式、交互规则或文案，仅修复滚动锚定时序

## 怎么验证的

### 自动验证

```text
pnpm --filter mobile exec vitest run src/__tests__/messageScroll.test.ts src/__tests__/messageListVirtualization.test.ts
结果：70 passed

pnpm --filter mobile run typecheck
结果：通过

pnpm test:unit:related
结果：PASS apps/mobile unit

bash .../run-unit-gate.sh <worktree>
结果：本 PR 相关 mobile 通过；全量 desktop unit 另有 2 条失败（ghostInstallReceipt.test.ts），与本 diff 无关，交给 CI
```

### 手工验证

未做真机。建议发送后马上进入长流式（>3s），确认列表仍跟在最新消息。

### 未执行的验证

真机 / 模拟器发送后贴底目检未跑。

## 风险

### 风险分类

- [x] 其他：Mobile 发送后贴底校验的等待条件

### 影响与回滚

- 影响范围：仅 Mobile 会话列表的 mVCP 安静窗触发条件；不改协议、schema、原生指纹
- 回滚 / 降级方式：revert 本 PR
- 存量插件影响：无

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
