### PR TITLE
fix(usage): 按请求 segment 修正 AI 用量计价

### DIFF
--- a/apps/desktop/src/main/__tests__/makerEventHotPathOrdering.test.ts
+++ b/apps/desktop/src/main/__tests__/makerEventHotPathOrdering.test.ts
@@ -854,20 +854,27 @@ describe('maker:event hot path ordering', () => {
     expect(codexDoneSource).toContain('? getReferenceModelPricing()');
     expect(codexDoneSource).toContain('? await getGatewayModelPricingForModel()');
     expect(codexDoneSource).toContain('price ?? undefined');
-    expect(codexDoneSource).toContain(
-      "if (!isSubscriptionValue && money && price?.source === 'gateway')",
+    expect(codexDoneSource).toMatch(
+      /u\.segments !== undefined && codexSegmentsReliable\s*\? codexUsageSegments\s*:\s*\[\]/,
     );
+    expect(codexDoneSource).toContain(
+      "if (money && (isSubscriptionValue || price?.source === 'gateway'))",
+    );
+    expect(codexDoneSource).toContain(
+      "const isActualApiCost = !isSubscriptionValue && price?.source === 'gateway';",
+    );
+    expect(codexDoneSource).toContain('if (isActualApiCost)');
     expect(codexDoneSource).toContain('void recordTurnSpend(money);');
     expect(codexDoneSource).toContain('void recordSessionTurnSpend(session.id, money);');
     expect(codexDoneSource).toMatch(
-      /await recordModelTurnUsage\(\{\s*agentKind: 'codex',\s*model: modelUsageKey,\s*inputTokensDelta: promptTokens,\s*outputTokensDelta: completionTokens,\s*cacheReadTokensDelta: cachedTokens,\s*cacheCreateTokensDelta: 0,\s*\}\)\.finally\(\(\) => rebroadcastCodexTodayUsage\(\)\);[\s\S]*?const pricing = isSubscriptionValue/,
+      /await recordModelTurnUsage\(\{\s*agentKind: 'codex',\s*model: modelUsageKey,\s*money: isSubscriptionValue \? unpricedSubscriptionValueMarker\(\) : undefined,\s*inputTokensDelta: promptTokens,\s*outputTokensDelta: completionTokens,\s*cacheReadTokensDelta: cachedTokens,\s*cacheCreateTokensDelta: 0,\s*\}\)\.finally\(\(\) => rebroadcastCodexTodayUsage\(\)\);[\s\S]*?const pricing = isSubscriptionValue/,
     );
     expect(codexDoneSource).toMatch(
       /await recordModelTurnUsage\(\{\s*agentKind: 'codex',\s*model: modelUsageKey,\s*money,\s*inputTokensDelta: 0,\s*outputTokensDelta: 0,\s*cacheReadTokensDelta: 0,\s*cacheCreateTokensDelta: 0,\s*\}\);/,
     );
     const costRecordIndex = codexDoneSource.indexOf('void recordTurnSpend(money);');
     const modelCostRecordIndex = codexDoneSource.indexOf(
-      "if (!isSubscriptionValue && money && price?.source === 'gateway')",
+      "if (money && (isSubscriptionValue || price?.source === 'gateway'))",
     );
     const schedulerCostRecordIndex = codexDoneSource.indexOf('await recordSchedulerTurnCost({');
     expect(costRecordIndex).toBeGreaterThanOrEqual(0);
@@ -887,7 +894,7 @@ describe('maker:event hot path ordering', () => {
     expect(codexDoneSource).not.toContain('isEstimate: true');
   });
 
-  it('claude-code 费用走 HYBRID 定价 (gateway 重算 + total_cost_usd 窄兜底) after EVENT broadcast', () => {
+  it('claude-code 费用按完整请求段定价，累计 cost 首帧只建基线', () => {
     const wireSessionSource = extractWireSessionSource();
     const claudeDoneIndex = wireSessionSource.indexOf("event.type === 'done' && event.source === 'claude-code'");
     const codexDoneIndex = wireSessionSource.indexOf("event.type === 'done' && event.source === 'codex'");
@@ -906,15 +913,17 @@ describe('maker:event hot path ordering', () => {
     );
     expect(claudeDoneSource).toContain('providerId: sessionProviderForBilling');
     expect(claudeDoneSource).toContain('billingRoute,');
+    expect(claudeDoneSource).toContain(
+      'const claudeUsageSegments = normalizeTurnUsageSegments(doneData?.usageSegments);',
+    );
     expect(claudeDoneSource).toContain('recordTurnSpend(turnMoney);');
     expect(claudeDoneSource).toContain('recordSessionTurnSpend(session.id, turnMoney);');
-    expect(claudeDoneSource).toContain(
-      "money: m.money?.kind === 'actual-cost' ? m.money : null,",
-    );
+    expect(claudeDoneSource).toContain('subscriptionEstimate ?? unpricedSubscriptionValueMarker()');
+    expect(claudeDoneSource).toContain('money: modelRowMoney,');
     // 订阅轮 (Claude Anthropic 订阅或 bridge 订阅直连) 打 #billing=subscription 标记,
     // 仪表盘按订阅估算价折算; 其余轮仍写归一化裸 id。
     expect(claudeDoneSource).toMatch(
-      /model:\s*isClaudeSubscriptionValueRow\s*\?\s*claudeSubscriptionUsageModelKey\(m\.model\)\s*:\s*m\.model,/,
+      /model:\s*isClaudeSubscriptionValueRow \|\| isBridgeSubscriptionRow\s*\?\s*claudeSubscriptionUsageModelKey\(m\.model\)\s*:\s*m\.model,/,
     );
     expect(claudeDoneSource).toContain(
       "isClaudeSubscriptionSession && !m.money && isAnthropicModel(m.model)",
@@ -922,8 +931,9 @@ describe('maker:event hot path ordering', () => {
     expect(claudeDoneSource).toContain(
       "m.source === 'subscription' && isSubscriptionDirectRoute(m.model)",
     );
+    expect(claudeDoneSource).toContain('const subscriptionTurnEstimates: RegionalMoney[] = [];');
     expect(claudeDoneSource).toMatch(
-      /estimateClaudeSubscriptionTurnValue\(\s*perModel,\s*currentLedgerCurrency\(\),\s*pricing,\s*\)/,
+      /computePriceQuoteTurnMoney\(\s*m\.deltas,\s*getSubscriptionValuePriceFor\('claude-code', m\.model, pricing\),\s*currentLedgerCurrency\(\),\s*m\.segments,\s*\)/,
     );
     // 订阅判定对齐 proxy 路由: 显式选 Anthropic, 或默认路由优先按 observed route, 未观察再回落无网关 key 启发式
     expect(claudeDoneSource).toContain("sessionProviderForBilling === 'anthropic'");
@@ -941,8 +951,17 @@ describe('maker:event hot path ordering', () => {
     );
     // 保留 #216 的 tooltip token/cache 明细。
     expect(claudeDoneSource).toContain('buildClaudeTurnUsageDetails(');
-    // 窄兜底: modelUsage 缺失时仍用 total_cost_usd delta 记总额, 别漏整轮 (review #4)。
-    expect(claudeDoneSource).toContain('const rawDelta = Math.max(0, cumulative - prevReportedCost);');
+    // 窄兜底: total_cost_usd 是进程累计；首次只建基线，且累计 usage 不得冒充本轮 token。
+    expect(claudeDoneSource).toMatch(
+      /const rawDelta\s*=\s*prevReportedCost === undefined\s*\? 0\s*:\s*Math\.max\(0, cumulative - prevReportedCost\);/,
+    );
+    const claudeCostFallback = claudeDoneSource.slice(
+      claudeDoneSource.indexOf("} else if (typeof cumulative === 'number' && cumulative >= 0)"),
+    );
+    expect(claudeCostFallback).toMatch(
+      /buildClaudeTurnUsageDetails\(\s*undefined,\s*undefined,\s*resolvedModel,/,
+    );
+    expect(claudeCostFallback).toContain("if (route !== 'provider-api')");
   });
 
   it('pi subscription turns estimate value from the shared reference-price helper', () => {
@@ -950,11 +969,27 @@ describe('maker:event hot path ordering', () => {
     const piDoneIndex = wireSessionSource.indexOf("event.type === 'done' && event.source === 'pi'");
     expect(piDoneIndex).toBeGreaterThanOrEqual(0);
     const piDoneSource = wireSessionSource.slice(piDoneIndex);
-    expect(piDoneSource).toContain('const pricing = isCustomProviderRoute');
-    expect(piDoneSource).toContain('? getReferenceModelPricing()');
-    expect(piDoneSource).toContain("getSubscriptionValuePriceFor('pi', pricingModel, pricing)");
-    expect(piDoneSource).not.toMatch(/getModelPriceQuote\(\s*null\s*,\s*effectiveProvider/);
-    expect(piDoneSource).toContain('if (!isSubscriptionValue)');
+    expect(piDoneSource).toContain(
+      '(turnPiFastModeBySession.get(session.id) ?? getSessionFastMode(session.id))',
+    );
+    expect(piDoneSource).toContain('turnPiFastModeBySession.delete(session.id);');
+    expect(piDoneSource).toContain(
+      "segment.priceVariant ?? (segment.id?.startsWith('pi:') ? piPriceVariant : 'standard'),",
+    );
+    expect(piDoneSource).toMatch(/const pricing\s*=\s*billingRoute === 'xd-gateway'/);
+    expect(piDoneSource).toContain(': getReferenceModelPricing();');
+    expect(piDoneSource).toContain("getSubscriptionValuePriceFor('pi', model, pricing)");
+    expect(piDoneSource).toContain(
+      'const pricingSegments = piSegmentsReliable ? group.segments : [];',
+    );
+    expect(piDoneSource).toContain('money = resolveTurnCost({');
+    expect(piDoneSource).toContain('segments: pricingSegments,');
+    expect(piDoneSource).toContain(
+      "billingRoute === 'provider-api' ? undefined : group.sdkCostUsd",
+    );
+    expect(piDoneSource).toContain('money ?? unpricedSubscriptionValueMarker()');
+    expect(piDoneSource).toContain('money: modelRowMoney,');
+    expect(piDoneSource).toContain('if (actualMoney)');
     expect(piDoneSource).toContain('await recordSchedulerTurnCost({');
   });
 

--- a/apps/desktop/src/main/localDb/dailyModelUsage.ts
+++ b/apps/desktop/src/main/localDb/dailyModelUsage.ts
@@ -128,14 +128,20 @@ export async function getModelUsageSince(sinceDayKey: string): Promise<DailyMode
     .where(sql`${dailyModelUsage.day} >= ${sinceDayKey}`)
     .all();
   return rows.map((row) => {
+    const isSubscriptionValue = row.model.endsWith('#billing=subscription');
+    const isExplicitUnpricedSubscription =
+      isSubscriptionValue && row.costAmount === 0 && Boolean(row.costIsApproximate);
     const legacy = legacyUsdMoney(row.costUsd);
     const current =
-      row.costCurrency && row.costAmount > 0
+      row.costCurrency && (row.costAmount > 0 || isExplicitUnpricedSubscription)
         ? normalizeRegionalMoney({
             amount: row.costAmount,
             currency: row.costCurrency,
-            approximate: row.costIsApproximate,
-            kind: 'actual-cost',
+            approximate: isSubscriptionValue || row.costIsApproximate,
+            kind: isSubscriptionValue ? 'value-estimate' : 'actual-cost',
+            ...(isSubscriptionValue
+              ? { estimateReasons: ['subscription-value', 'reference-price'] }
+              : {}),
           })
         : undefined;
     return {

--- a/apps/desktop/src/main/maker-host/index.ts
+++ b/apps/desktop/src/main/maker-host/index.ts
@@ -79,6 +79,7 @@ import { resolveVisionBackendRoute, setVisionGatewayKeyReader } from './provider
 import { resolveSessionCcDebugFile } from '../logger.js';
 import { resetProviderModelAutoRefreshCooldowns } from './provider-model-auto-refresh.js';
 import { getThinkingEnabledFromMemory } from './newMakerDefaultsCache.js';
+import { getSessionFastMode } from './session-effort-store.js';
 import { createSshDaemonTransport } from './codex-remote-transport.js';
 import { getRemoteSshPool, broadcastSilentInstallStatus } from '../remote-ssh/index.js';
 import {
@@ -2081,6 +2082,9 @@ export function getMaker(): Maker {
               opts.model,
             );
             if (thinkingEnabled !== undefined) opts.thinkingEnabled = thinkingEnabled;
+          }
+          if (opts.agentKind === 'pi') {
+            opts.getPriceVariant = () => (getSessionFastMode(sessionId) ? 'priority' : 'standard');
           }
           if (opts.agentKind === 'codex') {
             const disabledPluginIds = getPluginRegistry().getDisabledRuntimePluginIds(

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -4573,6 +4573,7 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
               modelUsage?: Record<string, unknown>;
               usageSegments?: unknown;
               usageSegmentsComplete?: unknown;
+              modelUsageCumulativeStartsAtZero?: unknown;
               assistant_message_id?: unknown;
               is_error?: unknown;
             }
@@ -4615,6 +4616,9 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
             lastReportedModelUsageBySession.get(session.id),
             modelUsage,
             observedByModel,
+            {
+              cumulativeStartsAtZero: doneData?.modelUsageCumulativeStartsAtZero === true,
+            },
           );
           lastReportedModelUsageBySession.set(session.id, next);
           modelUsageDeltas = deltas;

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -509,10 +509,12 @@ import {
   billingRouteForExplicitProvider,
   buildClaudeTurnUsageDetails,
   computePriceQuoteTurnMoney,
-  estimateClaudeSubscriptionTurnValue,
   isAnthropicModel,
+  normalizeTurnUsageSegments,
   normalizeModelIdForPricing,
+  resolveTurnCost,
   resolveClaudeTurnCostSinks,
+  sumTurnUsageSegments,
   type BillingRoute,
 } from '../usage/turnCostCalculator.js';
 import {
@@ -804,7 +806,11 @@ import {
   storeCustomProviderHeaders,
   storeCustomProviderKey,
 } from '../secrets/providerSecretStore.js';
-import { setSessionEffort, setSessionFastMode } from '../maker-host/session-effort-store.js';
+import {
+  getSessionFastMode,
+  setSessionEffort,
+  setSessionFastMode,
+} from '../maker-host/session-effort-store.js';
 import {
   getModelVisibilityMirrorSnapshot,
   syncModelVisibilityMirrorForOwner,
@@ -1625,13 +1631,11 @@ interface OrcaCollabService {
         message: string;
       }
   >;
-  getSessionRuntime: (params: { targetSessionId: string }) => Promise<
+  getSessionRuntime: (params: {
+    targetSessionId: string;
+  }) => Promise<
     | { ok: true; runtime: Awaited<ReturnType<typeof readCanonicalSessionActivity>> }
-    | {
-        ok: false;
-        errorCode: 'NOT_FOUND' | 'HOST_NOT_READY' | 'INTERNAL';
-        message: string;
-      }
+    | { ok: false; errorCode: 'NOT_FOUND' | 'HOST_NOT_READY' | 'INTERNAL'; message: string }
   >;
   sendToSession: (params: {
     /** 省略 → create 新 session;提供 → jump 到该既有 session。 */
@@ -1668,12 +1672,7 @@ interface OrcaCollabService {
     leadSessionId: string;
     workerPermissionMode?: OrcaWorkerPermissionMode;
   }) => Promise<
-    | {
-        ok: true;
-        teamId: string;
-        workerPermissionMode: OrcaWorkerPermissionMode;
-        reused?: boolean;
-      }
+    | { ok: true; teamId: string; workerPermissionMode: OrcaWorkerPermissionMode; reused?: boolean }
     | { ok: false; errorCode: string; message: string }
   >;
   createWorker: (params: {
@@ -1735,11 +1734,7 @@ interface OrcaCollabService {
   getWorkspaceInfo: (params: { leadSessionId: string }) => Promise<
     | {
         ok: true;
-        workflow: {
-          workflow_id: string;
-          lead_session_id: string;
-          status: string;
-        } | null;
+        workflow: { workflow_id: string; lead_session_id: string; status: string } | null;
         ui_capacity: number;
         worker_count: number;
         workers: Array<{
@@ -2571,6 +2566,23 @@ async function readSessionModelForUsage(sessionId: string): Promise<string> {
  * 只在第一次 isRunning:true 时写入,避免后续 progress status 在用户切模型后覆盖本轮归因。
  */
 const turnModelPromiseBySession = new Map<string, Promise<string>>();
+/** Pi request pricing variant captured at product-turn start. */
+const turnPiFastModeBySession = new Map<string, boolean>();
+
+/**
+ * Zero-value marker for a future subscription turn that was deliberately not
+ * priceable. daily_model_usage has no money-kind column, so approximate=true
+ * distinguishes this from legacy zero rows that history may still estimate.
+ */
+function unpricedSubscriptionValueMarker(): RegionalMoney {
+  return {
+    amount: 0,
+    currency: currentLedgerCurrency(),
+    approximate: true,
+    kind: 'value-estimate',
+    estimateReasons: ['subscription-value', 'reference-price'],
+  };
+}
 /**
  * claude/codex 失败 turn 的记账交接: is_error 收尾时 terminal error 事件先到,
  * 边界块在 error 上就 consume 掉本轮 assistant persistId;配对的 done 稍后才进
@@ -2647,12 +2659,7 @@ let agentInputCoordinatorHolder: AgentInputCoordinator | null = null;
 let contextOverflowRolloverHolder: ReturnType<typeof createContextOverflowRollover> | null = null;
 const overflowSuppressedBroadcasts = new Map<
   string,
-  {
-    sessionId: string;
-    event: AgentEvent;
-    persistId?: string;
-    resolvedContent?: unknown;
-  }
+  { sessionId: string; event: AgentEvent; persistId?: string; resolvedContent?: unknown }
 >();
 
 function getWiredSessionCloseReason(session: WiredSession) {
@@ -2720,10 +2727,7 @@ let pendingAgentSwitchApplyHolder:
 let cancelPendingAgentSwitchHolder: ((sessionId: string) => void) | null = null;
 let gitSnapshotCoordinator: GitSnapshotCoordinator | null = null;
 const sessionTurnActivityTracker = new SessionTurnActivityTracker();
-const reviewRunOwner: ReviewRunOwner = {
-  instanceId: randomUUID(),
-  processId: process.pid,
-};
+const reviewRunOwner: ReviewRunOwner = { instanceId: randomUUID(), processId: process.pid };
 configureTempAttachmentOwner(reviewRunOwner);
 const ensureReviewOwnerLivenessReady = createRetryableReviewStartup(async () => {
   const handle = await startReviewOwnerLiveness();
@@ -3117,10 +3121,7 @@ function surfaceSuppressedAutoResumeErrorInAgentIsland(
     const meta = wired ? sessionMetaForIsland(wired) : { sessionId };
     service.handleAgentEvent(
       meta,
-      redactEventForRenderer({
-        type: 'error',
-        data: { ...detail, isTerminal: true },
-      }),
+      redactEventForRenderer({ type: 'error', data: { ...detail, isTerminal: true } }),
     );
   } catch (error) {
     log.warn('Agent Island suppressed auto-resume error restore failed', {
@@ -3310,8 +3311,6 @@ function rollbackAgentIslandUserPrompt(
     });
   }
 }
-
-
 
 /**
  * 当前是否有任意一个 session 正在跑 turn。
@@ -3786,10 +3785,7 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
             event.data && typeof event.data === 'object' && !Array.isArray(event.data)
               ? (event.data as Record<string, unknown>)
               : {};
-          attributedEvent = {
-            ...event,
-            data: { ...eventData, reason },
-          };
+          attributedEvent = { ...event, data: { ...eventData, reason } };
           log.warn('Claude Opus plan error normalized for renderer', {
             sessionId: session.id,
             model: session.model,
@@ -3915,6 +3911,9 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
           ) {
             turnModelPromiseBySession.set(session.id, readSessionModelForUsage(session.id));
           }
+          if (event.source === 'pi' && !turnPiFastModeBySession.has(session.id)) {
+            turnPiFastModeBySession.set(session.id, getSessionFastMode(session.id));
+          }
         } else if (
           data.isRunning === false &&
           !isContinuationBoundary &&
@@ -4023,6 +4022,7 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
         shouldMarkTurnTerminalIdleAfterBroadcast = true;
         if (event.source === 'claude-code' || event.source === 'codex' || event.source === 'pi') {
           turnModelPromiseBySession.delete(session.id);
+          if (event.source === 'pi') turnPiFastModeBySession.delete(session.id);
         }
         const errData =
           attributedEvent.type === 'error'
@@ -4437,12 +4437,7 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
           persistCodexPlanOnDone(
             session.id,
             event.data as
-              | {
-                  plan?: unknown;
-                  raw?: { id?: unknown; status?: unknown };
-                }
-              | null
-              | undefined,
+              { plan?: unknown; raw?: { id?: unknown; status?: unknown } } | null | undefined,
           );
         }
         if (!isContinuationBoundary) {
@@ -4511,7 +4506,10 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
                     doneData?.sdkError,
                     doneData?.reason,
                     doneData?.error?.message,
-                  ].find((value): value is string => typeof value === 'string' && value.trim().length > 0)
+                  ].find(
+                    (value): value is string =>
+                      typeof value === 'string' && value.trim().length > 0,
+                  )
                 : undefined;
               await workerTurnStartSequencer.waitForStart(session.id);
               await orcaTeamServiceForEvents?.handleWorkerTerminalTurn({
@@ -4573,20 +4571,50 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
                 cache_creation_input_tokens?: number;
               };
               modelUsage?: Record<string, unknown>;
+              usageSegments?: unknown;
+              usageSegmentsComplete?: unknown;
               assistant_message_id?: unknown;
               is_error?: unknown;
             }
           | undefined;
         const cumulative = doneData?.total_cost_usd;
         const modelUsage = doneData?.modelUsage;
+        // Missing request boundaries are an explicit pricing failure, including
+        // older remote payloads. Flat aggregate arithmetic may look safe, but
+        // the request's Fast/Batch variant is also unknown.
+        const claudeUsageSegments = normalizeTurnUsageSegments(doneData?.usageSegments);
+        const claudeUsageSegmentsComplete =
+          doneData?.usageSegmentsComplete === true && (claudeUsageSegments?.length ?? 0) > 0;
         const claudeTurnDurationMs =
           completedTurnWallClockMs ??
           (typeof doneData?.duration_ms === 'number' ? doneData.duration_ms : undefined);
         let modelUsageDeltas: ModelUsageDeltaEntry[] | undefined;
         if (modelUsage && typeof modelUsage === 'object') {
+          const observedByModel = claudeUsageSegmentsComplete
+            ? (() => {
+                const grouped = new Map<string, ReturnType<typeof sumTurnUsageSegments>>();
+                for (const segment of claudeUsageSegments ?? []) {
+                  const model = normalizeModelIdForPricing(segment.model);
+                  const previous = grouped.get(model) ?? {
+                    inputTokens: 0,
+                    outputTokens: 0,
+                    cacheReadTokens: 0,
+                    cacheCreateTokens: 0,
+                  };
+                  grouped.set(model, {
+                    inputTokens: previous.inputTokens + segment.inputTokens,
+                    outputTokens: previous.outputTokens + segment.outputTokens,
+                    cacheReadTokens: previous.cacheReadTokens + segment.cacheReadTokens,
+                    cacheCreateTokens: previous.cacheCreateTokens + segment.cacheCreateTokens,
+                  });
+                }
+                return grouped;
+              })()
+            : undefined;
           const { next, deltas } = computeModelUsageDeltas(
             lastReportedModelUsageBySession.get(session.id),
             modelUsage,
+            observedByModel,
           );
           lastReportedModelUsageBySession.set(session.id, next);
           modelUsageDeltas = deltas;
@@ -4607,7 +4635,7 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
             : undefined;
         // total_cost_usd 累计基线: 主路径不靠它算钱, 但仍跟住, 以便万一某轮缺 modelUsage
         // 走兜底时累计差才准。先取"更新前"基线给兜底用, 再写入本轮累计。
-        const prevReportedCost = lastReportedCostUsdBySession.get(session.id) ?? 0;
+        const prevReportedCost = lastReportedCostUsdBySession.get(session.id);
         if (typeof cumulative === 'number' && cumulative >= 0) {
           lastReportedCostUsdBySession.set(session.id, cumulative);
         }
@@ -4650,10 +4678,13 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
               /* 模型解析失败:跳过降级检测,非致命 */
             });
         }
-        if (modelUsageDeltas && modelUsageDeltas.length > 0) {
+        if (
+          (modelUsageDeltas && modelUsageDeltas.length > 0) ||
+          (claudeUsageSegments?.length ?? 0) > 0
+        ) {
           // 主路径: 逐模型 HYBRID 定价 (Anthropic→SDK, 非 Anthropic→gateway), 四个 sink
           // 由同一份解析结果驱动。价格表走 main 端内存 + 磁盘缓存, stale 快返并后台刷新。
-          const deltas = modelUsageDeltas;
+          const deltas = modelUsageDeltas ?? [];
           void (async () => {
             const sessionProviderForBilling = getSessionProvider(session.id);
             const observedClaudeRoute =
@@ -4686,34 +4717,61 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
             const { turnMoney, estimatedTurnMoney, perModel } = resolveClaudeTurnCostSinks(
               deltas,
               pricing,
-              {
-                providerId: sessionProviderForBilling,
-                billingRoute,
-                region: CURRENT_CINDY_REGION,
-              },
+              { providerId: sessionProviderForBilling, billingRoute, region: CURRENT_CINDY_REGION },
+              claudeUsageSegments,
+              claudeUsageSegmentsComplete,
             );
-            // 按模型记账 (首页仪表盘"按模型拆分"): 写归一化裸 id, 与 codex 行 / 价格表对齐。
+            const resolvedUsageDeltas: ModelUsageDeltaEntry[] = perModel.map((item) => ({
+              model: item.model,
+              costUsdDelta: item.money?.kind === 'actual-cost' ? item.money.amount : 0,
+              inputTokensDelta: item.deltas.inputTokens,
+              outputTokensDelta: item.deltas.outputTokens,
+              cacheReadTokensDelta: item.deltas.cacheReadTokens,
+              cacheCreateTokensDelta: item.deltas.cacheCreateTokens,
+            }));
+            // 按模型记账 (首页仪表盘"按模型拆分"): 保留 provider/SKU 前缀，
+            // `codex/` 等预算路由必须精确命中自己的报价，不能回落到裸模型的另一折扣。
             // 订阅轮打 #billing=subscription 标记(Claude 订阅:Anthropic 模型 + cost=0),
             // 或 bridge 订阅轮(chatgpt// xai/ 前缀,source==='subscription');两类均需触发
             // rebroadcastTodaySpend 刷新首页仪表盘。
             const modelUsageWrites: Promise<unknown>[] = [];
+            const subscriptionTurnEstimates: RegionalMoney[] = [];
             let hasSubscriptionValueRow = false;
             for (const m of perModel) {
               const isClaudeSubscriptionValueRow =
                 isClaudeSubscriptionSession && !m.money && isAnthropicModel(m.model);
               const isBridgeSubscriptionRow =
                 m.source === 'subscription' && isSubscriptionDirectRoute(m.model);
+              const subscriptionEstimate =
+                isClaudeSubscriptionValueRow || isBridgeSubscriptionRow
+                  ? computePriceQuoteTurnMoney(
+                      m.deltas,
+                      getSubscriptionValuePriceFor('claude-code', m.model, pricing),
+                      currentLedgerCurrency(),
+                      m.segments,
+                    )
+                  : null;
+              if (subscriptionEstimate?.amount) {
+                subscriptionTurnEstimates.push(subscriptionEstimate);
+              }
               if (isClaudeSubscriptionValueRow || isBridgeSubscriptionRow)
                 hasSubscriptionValueRow = true;
+              const modelRowMoney =
+                m.money?.kind === 'actual-cost'
+                  ? m.money
+                  : isClaudeSubscriptionValueRow || isBridgeSubscriptionRow
+                    ? (subscriptionEstimate ?? unpricedSubscriptionValueMarker())
+                    : null;
               modelUsageWrites.push(
                 recordModelTurnUsage({
                   agentKind: 'claude-code',
-                  model: isClaudeSubscriptionValueRow
-                    ? claudeSubscriptionUsageModelKey(m.model)
-                    : m.model,
-                  // daily_model_usage does not persist RegionalMoney.kind. Keep reference estimates
-                  // out of this actual-cost row so they cannot be reconstructed as real API spend.
-                  money: m.money?.kind === 'actual-cost' ? m.money : null,
+                  model:
+                    isClaudeSubscriptionValueRow || isBridgeSubscriptionRow
+                      ? claudeSubscriptionUsageModelKey(m.model)
+                      : m.model,
+                  // The subscription suffix lets the existing schema reconstruct this amount as
+                  // value-estimate, keeping it out of daily_spend and actual API totals.
+                  money: modelRowMoney,
                   inputTokensDelta: m.deltas.inputTokens,
                   outputTokensDelta: m.deltas.outputTokens,
                   cacheReadTokensDelta: m.deltas.cacheReadTokens,
@@ -4733,7 +4791,7 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
               // 传 perModel → 落「按模型成本明细」(含 subagent 跑的模型, 如 Haiku)。
               const turnUsageDetails = buildClaudeTurnUsageDetails(
                 doneData?.usage,
-                deltas,
+                resolvedUsageDeltas,
                 'unknown',
                 perModel,
                 claudeGenerationDurationMs,
@@ -4764,29 +4822,12 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
               const estimatedValues: RegionalMoney[] = estimatedTurnMoney
                 ? [estimatedTurnMoney]
                 : [];
-              for (const m of perModel) {
-                if (m.source !== 'subscription') continue;
-                const quote = getSubscriptionDirectValuePrice(m.model, 'claude-code', pricing);
-                const value = computePriceQuoteTurnMoney(
-                  m.deltas,
-                  quote ?? undefined,
-                  currentLedgerCurrency(),
-                );
-                if (value?.amount) estimatedValues.push(value);
-              }
-              if (isClaudeSubscriptionSession) {
-                const claudeEstimated = estimateClaudeSubscriptionTurnValue(
-                  perModel,
-                  currentLedgerCurrency(),
-                  pricing,
-                );
-                if (claudeEstimated?.amount) estimatedValues.push(claudeEstimated);
-              }
+              estimatedValues.push(...subscriptionTurnEstimates);
               const turnEstimatedValue =
                 estimatedValues.length > 0 ? addRegionalMoney(estimatedValues) : null;
               const turnUsageDetails = buildClaudeTurnUsageDetails(
                 doneData?.usage,
-                deltas,
+                resolvedUsageDeltas,
                 'unknown',
                 perModel,
                 claudeGenerationDurationMs,
@@ -4813,9 +4854,13 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
             }
           })();
         } else if (typeof cumulative === 'number' && cumulative >= 0) {
-          // 窄兜底: 罕见地 done 只带 total_cost_usd、没 modelUsage —— 拆不了 daily_model_usage,
-          // 但至少用累计差把总额 / session / message 记上, 别漏整轮 (review #4)。
-          const rawDelta = Math.max(0, cumulative - prevReportedCost);
+          // 窄兜底: 罕见地 done 只带 total_cost_usd、没 modelUsage / request segments ——
+          // 拆不了 daily_model_usage, 只在已有累计基线后用 cost delta 记总额。
+          // The first cumulative snapshot after restart/reattach may contain
+          // the whole provider process lifetime. With neither modelUsage nor
+          // request segments, only establish the baseline.
+          const rawDelta =
+            prevReportedCost === undefined ? 0 : Math.max(0, cumulative - prevReportedCost);
           void (async () => {
             let resolvedModel = 'unknown';
             try {
@@ -4824,17 +4869,19 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
             } catch {
               /* non-fatal: 保留 SDK 原始 cost */
             }
+            // `doneData.usage` can be the same process-lifetime cumulative snapshot as
+            // `total_cost_usd`. Without model deltas or request segments it is not a reliable
+            // per-turn token fact, so retain only model/timing metadata in this fallback.
             const turnUsageDetails = buildClaudeTurnUsageDetails(
-              doneData?.usage,
+              undefined,
               undefined,
               resolvedModel,
               undefined,
               claudeGenerationDurationMs,
               claudeTurnDurationMs,
             );
-            // 本分支有三个"记不了钱"的出口(本轮 cost 未增长 / 订阅直连 / 订阅与网关路由),
-            // 账本口径一个字不改,但都把本轮 token 明细落下来 —— 钱算不出来不代表用量
-            // 算不出来,UI 那一格据此退回显示 token 而不是空着。
+            // 本分支有三个"记不了钱"的出口(本轮 cost 未增长 / 订阅直连 / 非明确
+            // provider-api 路由)。只保留可证明的模型与时长；进程累计 usage 不能冒充本轮 token。
             const recordUsageOnly = async () => {
               if (!turnAssistantPersistId) return;
               await recordTurnUsageOnMessage({
@@ -4870,7 +4917,10 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
               await recordUsageOnly();
               return;
             }
-            if (route === 'subscription' || route === 'xd-gateway') {
+            // A cumulative SDK dollar value is authoritative only for an
+            // explicitly selected provider API. Remote/unknown routing cannot
+            // be attributed to this local account and must stay usage-only.
+            if (route !== 'provider-api') {
               await recordUsageOnly();
               return;
             }
@@ -4924,8 +4974,9 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
         const usage = (event.data as { usage?: unknown } | undefined)?.usage;
         if (usage) recordCodexTurnUsage(usage);
         // 按模型记账: codex done.data.usage 是 **per-turn 增量语义** (maker-core
-        // codexDoneUsage 契约: promptTokens=本 turn 未命中输入, completionTokens=输出+推理
-        // 合并, cachedTokens=命中缓存; 整 turn 没收到 tokenUsage/updated 时全 0)。
+        // codexDoneUsage 契约: promptTokens=本 turn 未命中输入, completionTokens=完整输出
+        // (reasoningTokens 只是其中的诊断子集), cachedTokens=命中缓存;
+        // 整 turn 没收到 tokenUsage/updated 时全 0。
         // 直接入库, 不做 delta 化 —— 历史上 promptTokens 曾是 contextTokens 快照、这里
         // 做过 per-session delta 化, 语义改为 per-turn 后那套逻辑会把后小于前的 turn 记 0。
         if (usage && typeof usage === 'object') {
@@ -4934,12 +4985,20 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
             completionTokens?: number;
             reasoningTokens?: number;
             cachedTokens?: number;
+            segments?: unknown;
             durationMs?: number;
             turnDurationMs?: number;
           };
           const promptTokens = Number(u.promptTokens) || 0;
           const completionTokens = Number(u.completionTokens) || 0;
           const cachedTokens = Number(u.cachedTokens) || 0;
+          const codexUsageSegments = normalizeTurnUsageSegments(u.segments);
+          const codexSegmentTotals = sumTurnUsageSegments(codexUsageSegments);
+          const codexSegmentsReliable =
+            codexUsageSegments.length > 0 &&
+            codexSegmentTotals.inputTokens === promptTokens &&
+            codexSegmentTotals.outputTokens === completionTokens &&
+            codexSegmentTotals.cacheReadTokens === cachedTokens;
           void recordSessionTurnTokens(session.id, promptTokens + completionTokens + cachedTokens);
           // 先落 daily_model_usage token 行, 再等价格表补 API cost。首页 usage push 会在
           // ~2s 后刷新, 不能让冷价格表 / 离线 fetch 把模型 token 行延后到刷新之后。
@@ -4949,8 +5008,8 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
             let turnModel = 'unknown';
             try {
               turnModel = await modelPromise;
-              // 价格查表用归一化裸 id, 与 daily_model_usage 的 key 一致
-              // (codex 当前不带 [1m], 归一化防御未来变体后缀导致查表 miss)。
+              // 只剥上下文后缀，保留 provider/SKU 前缀；`codex/gpt-*` 与裸
+              // `gpt-*` 是不同售价和折扣，不能互相回落。
               pricingModel = normalizeModelIdForPricing(turnModel);
             } catch {
               // 模型读取失败时仍记录 token, 聚合 UI 会归到 unknown。
@@ -5001,6 +5060,7 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
             await recordModelTurnUsage({
               agentKind: 'codex',
               model: modelUsageKey,
+              money: isSubscriptionValue ? unpricedSubscriptionValueMarker() : undefined,
               inputTokensDelta: promptTokens,
               outputTokensDelta: completionTokens,
               cacheReadTokensDelta: cachedTokens,
@@ -5064,11 +5124,12 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
                 codexUsageToTokens(u),
                 price ?? undefined,
                 currentLedgerCurrency(),
+                u.segments !== undefined && codexSegmentsReliable ? codexUsageSegments : [],
               );
               // Only Gateway sale prices are actual API spend. Third-party/user reference quotes
               // are value estimates and daily_model_usage cannot preserve RegionalMoney.kind, so
               // writing them into #billing=api would later reconstruct an estimate as actual cost.
-              if (!isSubscriptionValue && money && price?.source === 'gateway') {
+              if (money && (isSubscriptionValue || price?.source === 'gateway')) {
                 await recordModelTurnUsage({
                   agentKind: 'codex',
                   model: modelUsageKey,
@@ -5138,6 +5199,14 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
       // usage 事实无论价格是否可解析都持久化，保证新模型也能看到 cache 命中明细。
       if (event.type === 'done' && event.source === 'pi') {
         const sessionProvider = getSessionProvider(session.id);
+        // Pi's responses bridge receives Fast through host-side session prefs,
+        // not through the Pi RPC payload. Capture the request tariff at the
+        // synchronous done boundary before any later setting change can race it.
+        const piPriceVariant =
+          (turnPiFastModeBySession.get(session.id) ?? getSessionFastMode(session.id))
+            ? 'priority'
+            : 'standard';
+        turnPiFastModeBySession.delete(session.id);
         const modelPromise =
           turnModelPromiseBySession.get(session.id) ?? readSessionModelForUsage(session.id);
         turnModelPromiseBySession.delete(session.id);
@@ -5151,6 +5220,24 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
               cacheCreationTokens?: number;
             },
           );
+          const piUsageSegments = normalizeTurnUsageSegments(
+            (rawUsage as { segments?: unknown }).segments,
+          ).map((segment) => ({
+            ...segment,
+            // Parent requests use this session's bridge preference. Delegated
+            // child requests have an independent process and are standard
+            // unless their own payload explicitly reports another variant.
+            priceVariant:
+              segment.priceVariant ?? (segment.id?.startsWith('pi:') ? piPriceVariant : 'standard'),
+          }));
+          const piSegmentTotals = sumTurnUsageSegments(piUsageSegments);
+          const piSegmentsReliable =
+            (rawUsage as { segmentsComplete?: unknown }).segmentsComplete === true &&
+            piUsageSegments.length > 0 &&
+            piSegmentTotals.inputTokens === tokens.inputTokens &&
+            piSegmentTotals.outputTokens === tokens.outputTokens &&
+            piSegmentTotals.cacheReadTokens === tokens.cacheReadTokens &&
+            piSegmentTotals.cacheCreateTokens === tokens.cacheCreateTokens;
           const totalTokens =
             tokens.inputTokens +
             tokens.outputTokens +
@@ -5178,76 +5265,152 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
               effectiveProvider === 'anthropic' ||
               effectiveProvider === 'xai' ||
               (!isCustomProviderRoute && isSubscriptionDirectRoute(pricingModel));
-            const turnUsageDetails = buildTurnUsageDetails({
-              ...tokens,
-              model: turnModel,
-              durationMs:
-                typeof (rawUsage as { durationMs?: unknown }).durationMs === 'number'
-                  ? (rawUsage as { durationMs: number }).durationMs
-                  : undefined,
-              turnDurationMs:
-                typeof (rawUsage as { turnDurationMs?: unknown }).turnDurationMs === 'number'
-                  ? (rawUsage as { turnDurationMs: number }).turnDurationMs
-                  : undefined,
-            });
+            const billingRoute: BillingRoute = isCustomProviderRoute
+              ? 'provider-api'
+              : isSubscriptionValue
+                ? 'subscription'
+                : 'xd-gateway';
+            const effectiveSegments = piSegmentsReliable ? piUsageSegments : [];
+            const groupedSegments = new Map<
+              string,
+              { segments: typeof effectiveSegments; tokens: typeof tokens; sdkCostUsd: number }
+            >();
+            for (const segment of effectiveSegments) {
+              const model = normalizeModelIdForPricing(segment.model ?? turnModel);
+              const group = groupedSegments.get(model) ?? {
+                segments: [],
+                tokens: {
+                  inputTokens: 0,
+                  outputTokens: 0,
+                  cacheReadTokens: 0,
+                  cacheCreateTokens: 0,
+                },
+                sdkCostUsd: 0,
+              };
+              group.segments.push(segment);
+              group.tokens.inputTokens += segment.inputTokens;
+              group.tokens.outputTokens += segment.outputTokens;
+              group.tokens.cacheReadTokens += segment.cacheReadTokens;
+              group.tokens.cacheCreateTokens += segment.cacheCreateTokens;
+              group.sdkCostUsd += segment.costUsd ?? 0;
+              groupedSegments.set(model, group);
+            }
+            // An explicitly incomplete segment payload must not be collapsed
+            // into one synthetic request for pricing. Keep the aggregate token
+            // fact under the selected model while leaving money unavailable.
+            if (groupedSegments.size === 0) {
+              groupedSegments.set(pricingModel, { segments: [], tokens, sdkCostUsd: 0 });
+            }
 
-            // Pi 也必须进 daily_model_usage，否则首页仪表盘会把 Pi 的
-            // token/cache 全部漏掉。先落 usage 事实，价格解析失败也不影响。
-            const modelUsageKey = isSubscriptionValue
-              ? piSubscriptionUsageModelKey(pricingModel)
-              : pricingModel;
-            await recordModelTurnUsage({
-              agentKind: 'pi',
-              model: modelUsageKey,
-              inputTokensDelta: tokens.inputTokens,
-              outputTokensDelta: tokens.outputTokens,
-              cacheReadTokensDelta: tokens.cacheReadTokens,
-              cacheCreateTokensDelta: tokens.cacheCreateTokens,
+            const durationMs =
+              typeof (rawUsage as { durationMs?: unknown }).durationMs === 'number'
+                ? (rawUsage as { durationMs: number }).durationMs
+                : undefined;
+            const turnDurationMs =
+              typeof (rawUsage as { turnDurationMs?: unknown }).turnDurationMs === 'number'
+                ? (rawUsage as { turnDurationMs: number }).turnDurationMs
+                : undefined;
+            const usageOnlyDetails = buildTurnUsageDetails({
+              ...tokens,
+              model: groupedSegments.size === 1 ? [...groupedSegments.keys()][0] : undefined,
+              models: [...groupedSegments.keys()],
+              durationMs,
+              turnDurationMs,
             });
-            void rebroadcastTodaySpend();
 
             try {
-              // 自定义(source:'user')provider——本地 Ollama / 用户自付费兼容端点——即便
-              // 模型 id 与 XD 目录重名,也不能套用 XD 网关定价当作 Cindy 消费入账;只记 token
-              // (上方已入库),不写 money(codex review)。仅 xd / 默认网关与订阅路由计费。
-              // 订阅估值必须走参考价目录 + getSubscriptionValuePriceFor,与仪表盘同口径:
-              // 裸 grok-4.6 会先映射到 xai/grok-4.6。旧实现把 catalog 置 null 再
-              // getModelPriceQuote(null, 'xai', 'grok-4.6'),报价永远 miss,消息上就只剩用量。
-              const pricing = isCustomProviderRoute
-                ? null
-                : isSubscriptionValue
-                  ? getReferenceModelPricing()
-                  : await getGatewayModelPricingForModel();
-              const price = isCustomProviderRoute
-                ? null
-                : isSubscriptionValue
-                  ? getSubscriptionValuePriceFor('pi', pricingModel, pricing)
-                  : getModelPriceQuote(pricing, 'xd', pricingModel);
-              const money = computePriceQuoteTurnMoney(
-                tokens,
-                price ?? undefined,
-                currentLedgerCurrency(),
-              );
-              if (money && money.amount > 0) {
-                if (!isSubscriptionValue) {
-                  // token 已在上方入库；这里只补真实 API/gateway 费用，
-                  // 避免重复累加 token。订阅价值挂到消息(value-estimate),不进 daily_spend。
-                  await recordModelTurnUsage({
+              const pricing =
+                billingRoute === 'xd-gateway'
+                  ? await getGatewayModelPricingForModel()
+                  : getReferenceModelPricing();
+              const actualMonies: RegionalMoney[] = [];
+              const estimatedMonies: RegionalMoney[] = [];
+              const perModelCost: Array<{ model: string; money: RegionalMoney }> = [];
+              const modelWrites: Promise<unknown>[] = [];
+              for (const [model, group] of groupedSegments) {
+                // Missing/incomplete request boundaries are explicitly unpriceable. A provider-
+                // reported request cost may still win in resolveTurnCost; token × quote must not
+                // collapse the whole turn into one synthetic long-context request.
+                const pricingSegments = piSegmentsReliable ? group.segments : [];
+                let money: RegionalMoney | null = null;
+                if (billingRoute === 'subscription') {
+                  const quote = getSubscriptionValuePriceFor('pi', model, pricing);
+                  money = computePriceQuoteTurnMoney(
+                    group.tokens,
+                    quote ?? undefined,
+                    currentLedgerCurrency(),
+                    pricingSegments,
+                  );
+                } else {
+                  money = resolveTurnCost({
+                    rawModel: model,
+                    tokens: group.tokens,
+                    // Pi computes usage.cost from its local model catalog. For
+                    // BYOM/provider-api routes that is a reference estimate,
+                    // not a provider invoice. Let the provider quote path mark
+                    // it as value-estimate instead of recording it as actual.
+                    sdkCostDelta: billingRoute === 'provider-api' ? undefined : group.sdkCostUsd,
+                    pricing,
+                    context: {
+                      providerId: sessionProvider,
+                      billingRoute,
+                      region: CURRENT_CINDY_REGION,
+                    },
+                    segments: pricingSegments,
+                  }).money;
+                }
+                if (money?.amount) {
+                  perModelCost.push({ model, money });
+                  (money.kind === 'actual-cost' ? actualMonies : estimatedMonies).push(money);
+                }
+                const modelUsageKey = isSubscriptionValue
+                  ? piSubscriptionUsageModelKey(model)
+                  : model;
+                const modelRowMoney =
+                  money?.kind === 'actual-cost'
+                    ? money
+                    : isSubscriptionValue
+                      ? (money ?? unpricedSubscriptionValueMarker())
+                      : null;
+                modelWrites.push(
+                  recordModelTurnUsage({
                     agentKind: 'pi',
                     model: modelUsageKey,
-                    money,
-                    inputTokensDelta: 0,
-                    outputTokensDelta: 0,
-                    cacheReadTokensDelta: 0,
-                    cacheCreateTokensDelta: 0,
-                  });
-                  void recordTurnSpend(money);
-                  void recordSessionTurnSpend(session.id, money);
-                }
+                    // daily_model_usage has no money-kind column. Subscription
+                    // rows recover value-estimate from their suffix; other
+                    // reference estimates must stay message-only or they would
+                    // be reconstructed later as actual spend.
+                    money: modelRowMoney,
+                    inputTokensDelta: group.tokens.inputTokens,
+                    outputTokensDelta: group.tokens.outputTokens,
+                    cacheReadTokensDelta: group.tokens.cacheReadTokens,
+                    cacheCreateTokensDelta: group.tokens.cacheCreateTokens,
+                  }),
+                );
+              }
+              await Promise.allSettled(modelWrites);
+              void rebroadcastTodaySpend();
+              const actualMoney = actualMonies.length > 0 ? addRegionalMoney(actualMonies) : null;
+              const estimatedMoney =
+                estimatedMonies.length > 0 ? addRegionalMoney(estimatedMonies) : null;
+              const messageMoney = actualMoney ?? estimatedMoney;
+              const turnUsageDetails = buildTurnUsageDetails({
+                ...tokens,
+                model: groupedSegments.size === 1 ? [...groupedSegments.keys()][0] : undefined,
+                models: [...groupedSegments.keys()],
+                perModelCost,
+                durationMs,
+                turnDurationMs,
+              });
+              if (actualMoney) {
+                void recordTurnSpend(actualMoney);
+                void recordSessionTurnSpend(session.id, actualMoney);
+              }
+              if (messageMoney) {
                 const changedScheduleId = await recordSchedulerTurnCost({
                   sessionId: session.id,
                   clientId: turnAssistantPersistId,
-                  money,
+                  money: messageMoney,
                   turnUsageDetails,
                   turnOrigin: event.turnOrigin,
                 });
@@ -5260,12 +5423,25 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
                 });
               }
             } catch {
-              // 价格读取失败不能连带丢失 token/cache 事实。
-              if (turnAssistantPersistId && turnUsageDetails) {
+              // Price/catalog failure must not lose token/cache facts.
+              const writes = [...groupedSegments].map(([model, group]) =>
+                recordModelTurnUsage({
+                  agentKind: 'pi',
+                  model: isSubscriptionValue ? piSubscriptionUsageModelKey(model) : model,
+                  money: isSubscriptionValue ? unpricedSubscriptionValueMarker() : undefined,
+                  inputTokensDelta: group.tokens.inputTokens,
+                  outputTokensDelta: group.tokens.outputTokens,
+                  cacheReadTokensDelta: group.tokens.cacheReadTokens,
+                  cacheCreateTokensDelta: group.tokens.cacheCreateTokens,
+                }),
+              );
+              await Promise.allSettled(writes);
+              void rebroadcastTodaySpend();
+              if (turnAssistantPersistId && usageOnlyDetails) {
                 await recordTurnUsageOnMessage({
                   sessionId: session.id,
                   clientId: turnAssistantPersistId,
-                  turnUsageDetails,
+                  turnUsageDetails: usageOnlyDetails,
                 });
               }
             }
@@ -5351,6 +5527,7 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
           lastReportedCostUsdBySession.delete(session.id);
           lastReportedModelUsageBySession.delete(session.id);
           turnModelPromiseBySession.delete(session.id);
+          turnPiFastModeBySession.delete(session.id);
           productTurnWallClockTracker.clear(session.id);
           productTurnUsageTargetTracker.clear(session.id);
           claudeOutputLagTimingGuard.clear(session.id);
@@ -5520,9 +5697,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
   gitSnapshotCoordinator = createGitSnapshotCoordinator(maker);
   // 接上 DB 改名通知(用户手动改名后自动起名收手)与拦截意识探针(装了
   // will-user-message 钩子时不把用户原话送去标题模型)。
-  registerSessionAutoTitleHooks({
-    isUserMessageScreeningActive: hasEnabledUserMessageHookGhost,
-  });
+  registerSessionAutoTitleHooks({ isUserMessageScreeningActive: hasEnabledUserMessageHookGhost });
 
   // device-link busy presence:把「本机是否有 turn 在跑」探针注入 device-link host,
   // 它每 5s 取一次、翻转才上报,让控制端设备列表显示 busy 三态(规则 2:回调注入解耦)。
@@ -5600,9 +5775,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
     workerPermissionMode: OrcaWorkerPermissionMode,
   ): void => {
     setWorkerCreationPrefsCache({ workerPermissionMode });
-    broadcastToAllWindows(MAKER_PUSH.WORKER_CREATION_PREFS_APPLY, {
-      workerPermissionMode,
-    });
+    broadcastToAllWindows(MAKER_PUSH.WORKER_CREATION_PREFS_APPLY, { workerPermissionMode });
   };
 
   // device-link:被控端 providerModelMemory(草稿列表行的真实读源)全量镜像给 main。旧的
@@ -5793,8 +5966,8 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
     const agentHome = path.join(app.getPath('userData'), 'pi-agent-home');
     const runRoot = piSubagentRunRoot(agentHome, body.sessionId);
     const runs = await listPiSubagentRuns(runRoot);
-    const run = runs.find((candidate) =>
-      candidate.taskId === body.taskId || candidate.runId === body.taskId,
+    const run = runs.find(
+      (candidate) => candidate.taskId === body.taskId || candidate.runId === body.taskId,
     );
     if (!run) throwIpcError('NOT_FOUND', 'PI Subagent run not found');
     if (body.childId !== undefined && (typeof body.childId !== 'string' || !body.childId)) {
@@ -5808,7 +5981,10 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
     if (body.action === 'resume') {
       const live = maker.getSession(body.sessionId);
       if (!terminal || live?.agentKind !== 'pi') {
-        throwIpcError('UNSUPPORTED_CAPABILITY', 'Resume requires a loaded parent PI task and a terminal run.');
+        throwIpcError(
+          'UNSUPPORTED_CAPABILITY',
+          'Resume requires a loaded parent PI task and a terminal run.',
+        );
       }
       await live.resumeBackgroundTask(run.taskId, body.message as string, childId);
       return { ok: true, controlled: 1 };
@@ -6202,10 +6378,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
         oauth,
         {
           onProgress: (progress) =>
-            broadcastToAllWindows(MAKER_PUSH.PROVIDER_OAUTH_PROGRESS, {
-              providerId,
-              ...progress,
-            }),
+            broadcastToAllWindows(MAKER_PUSH.PROVIDER_OAUTH_PROGRESS, { providerId, ...progress }),
           onCredentialPersisted: (rollback) => {
             rollbackCredentials = rollback;
           },
@@ -6282,10 +6455,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
         }
         if (isCurrent()) broadcastToAllWindows(MAKER_PUSH.PROVIDER_CHANGED, {});
       }
-      return {
-        ...result,
-        ...(rollbackCredentials ? { rollbackCredentials } : {}),
-      };
+      return { ...result, ...(rollbackCredentials ? { rollbackCredentials } : {}) };
     },
     readCustomProviderKeyForMutation,
     storeCustomProviderKey,
@@ -6390,10 +6560,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
     }
     // senderWebContentsId 由 main 从 event.sender 填入(覆盖 renderer 传入的任何值),
     // 供需要"只回发起窗口"的命令(/issue)做定向 send。
-    const c = {
-      ...((ctx ?? {}) as DesktopCommandContext),
-      senderWebContentsId: e.sender.id,
-    };
+    const c = { ...((ctx ?? {}) as DesktopCommandContext), senderWebContentsId: e.sender.id };
     await getDesktopCommandRegistry().execute(name, c);
   });
 
@@ -6674,11 +6841,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
           projectAgents,
           resourceParams.cap,
         );
-        return {
-          success: true,
-          items: merged.items,
-          truncated: result.truncated || merged.capped,
-        };
+        return { success: true, items: merged.items, truncated: result.truncated || merged.capped };
       } catch (err) {
         return {
           success: false,
@@ -8315,11 +8478,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
     supersedePendingCredentialSwitch: clearPendingCredentialSwitchForSession,
     insertBoundaryMessage: async (sessionId, content) => {
       const clientId = `agent-switch:${createId()}`;
-      await createDbMessage(sessionId, {
-        clientId,
-        role: 'agent_switch',
-        content,
-      });
+      await createDbMessage(sessionId, { clientId, role: 'agent_switch', content });
       return clientId;
     },
     applyResumeFallbackAtomically: applyAgentSwitchResumeFallbackAtomically,
@@ -8408,12 +8567,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
         clientIds: deletedClientIds,
       });
       for (const runId of subagentRunIds) {
-        broadcastSubagentRunsChanged({
-          sessionId,
-          runId,
-          created: false,
-          firstForSession: false,
-        });
+        broadcastSubagentRunsChanged({ sessionId, runId, created: false, firstForSession: false });
       }
       // 不带 _count:可见消息数不是列表的权威口径,拿它 patch 的错值会被 shallow merge 一直
       // 留住;权威口径受删除影响只有 0 或 +1,交给 sessions:list / reseed 收敛就够。
@@ -8627,11 +8781,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
       explicitOrigin: origin,
     });
     if (!message) {
-      return {
-        ok: false,
-        errorCode: 'INVALID_ARGS',
-        message: 'message required',
-      };
+      return { ok: false, errorCode: 'INVALID_ARGS', message: 'message required' };
     }
 
     if (targetSessionId) {
@@ -8751,10 +8901,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
                 message: resolvedExecution.message,
               };
             }
-            inherited = {
-              ...inheritedBase,
-              ...resolvedExecution.config,
-            };
+            inherited = { ...inheritedBase, ...resolvedExecution.config };
           } else {
             inherited = inheritedBase;
           }
@@ -8908,11 +9055,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
             .catch(() => undefined);
         }
         if (isSessionRunningError(err)) {
-          return {
-            ok: false,
-            errorCode: 'BUSY',
-            message: 'new session has a turn in progress',
-          };
+          return { ok: false, errorCode: 'BUSY', message: 'new session has a turn in progress' };
         }
         return {
           ok: false,
@@ -9061,10 +9204,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
               } catch (err) {
                 log.warn(
                   'sendToSession: detach after drift rebootstrap failed, falling through to lazy-resume',
-                  {
-                    targetSessionId,
-                    err: err instanceof Error ? err.message : String(err),
-                  },
+                  { targetSessionId, err: err instanceof Error ? err.message : String(err) },
                 );
               }
               live = undefined;
@@ -9086,10 +9226,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
           } catch (err) {
             log.warn(
               'sendToSession: detach stale remote CC session failed, falling through to lazy-resume',
-              {
-                targetSessionId,
-                err: err instanceof Error ? err.message : String(err),
-              },
+              { targetSessionId, err: err instanceof Error ? err.message : String(err) },
             );
           }
           // detach 后不得继续 live 直发 (session 已 closed) — 置空落入
@@ -9377,11 +9514,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
       persistedContent: request.persistedContent,
     });
     if (!sent.ok) return sent;
-    return {
-      ok: true,
-      sessionId: forkedSessionId,
-      disposition: 'forked',
-    };
+    return { ok: true, sessionId: forkedSessionId, disposition: 'forked' };
   });
   setGhostSessionRevealer((sessionId) => openMainWindowSession(sessionId));
 
@@ -9777,11 +9910,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
         }
       }
       return orcaUiAssignmentDispatchClaims.runOnce(
-        {
-          leadSessionId,
-          workerSessionId,
-          snapshotBeforeMs,
-        },
+        { leadSessionId, workerSessionId, snapshotBeforeMs },
         async () => {
           const result = await orcaTeamService.sendToWorker({
             callerLeadSessionId: leadSessionId,
@@ -10136,10 +10265,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
         onAcceptedRollback,
       });
       if (!result.ok) {
-        return {
-          ok: false,
-          dispatchOutcome: result.dispatchOutcome,
-        };
+        return { ok: false, dispatchOutcome: result.dispatchOutcome };
       }
       return {
         ok: true,
@@ -10299,12 +10425,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
         orcaWorkflowId: teamId,
         orcaLeadSessionId: leadSessionId,
         ...(workerId && workerSessionId
-          ? {
-              initialWorker: {
-                workerId,
-                sessionId: workerSessionId,
-              },
-            }
+          ? { initialWorker: { workerId, sessionId: workerSessionId } }
           : {}),
       });
     },
@@ -10461,11 +10582,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
         persistedContent: message,
         clientId: queuedMessageId,
         meta,
-        origin: {
-          kind: 'session',
-          senderSessionId: callerSessionId,
-          displayText: message,
-        },
+        origin: { kind: 'session', senderSessionId: callerSessionId, displayText: message },
       });
     },
     steerQueuedMessage: async (sessionId, item, expectedTurn) => {
@@ -10520,10 +10637,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
             message: `queue restore incomplete for ${sessionId}`,
           };
         }
-        return {
-          ok: true,
-          messages: inputCoordinator.getQueueInspection(sessionId),
-        };
+        return { ok: true, messages: inputCoordinator.getQueueInspection(sessionId) };
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         return {
@@ -10560,11 +10674,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
     // MCP worker 派活必须经 OrcaTeamService，确保 running、resume idle、广播和
     // 公开错误码映射都与 IPC handler WORKER_SEND_TO 保持同一套状态机。
     sendToWorker: ({ callerLeadSessionId, targetSessionId, message }) =>
-      orcaTeamService.sendToWorker({
-        callerLeadSessionId,
-        targetSessionId,
-        message,
-      }),
+      orcaTeamService.sendToWorker({ callerLeadSessionId, targetSessionId, message }),
     // 排队消息控制统一走 OrcaTeamService,复用 resolveWorkerRef 归属校验与
     // coordinator 的 remove/replace 原语(cancel 经 remove 触发 discard settle)。
     listWorkerQueuedMessages: (params) => orcaTeamService.listWorkerQueuedMessages(params),
@@ -10861,13 +10971,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
           message.agentMeta.transcriptParentUuid.length > 0;
         const enrichedMessage =
           transcriptParentUuid && !hasTranscriptParent
-            ? {
-                ...message,
-                agentMeta: {
-                  ...message.agentMeta,
-                  transcriptParentUuid,
-                },
-              }
+            ? { ...message, agentMeta: { ...message.agentMeta, transcriptParentUuid } }
             : message;
         // session-agent-switch:user 行逐行 stamp 当前引擎(见 messages.agent_kind 注释)。
         const agentKind = getSessionDbAgentKind(sessionId);
@@ -10987,18 +11091,13 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
       );
       if (!snapshot) return null;
       if (snapshot.state === 'sealed') {
-        return {
-          note: buildCompletedPlanGuardNote(),
-          sealedTurnId: snapshot.turnId,
-        };
+        return { note: buildCompletedPlanGuardNote(), sealedTurnId: snapshot.turnId };
       }
       const openSteps = snapshot.plan
         .filter((item) => item.status !== 'completed')
         .map((item) => item.step);
       if (openSteps.length === 0 && snapshot.state !== 'interrupted') return null;
-      return {
-        note: buildPlanReconcileNote({ openSteps, totalSteps: snapshot.plan.length }),
-      };
+      return { note: buildPlanReconcileNote({ openSteps, totalSteps: snapshot.plan.length }) };
     },
     consumeSealedPlanReconcileNote: (sessionId, turnId) =>
       enqueueDurableWrite(`plan-seal-consume:${sessionId}:${turnId}`, () =>
@@ -11076,12 +11175,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
         role: 'assistant',
         content: '',
         agentKind: cardAgentKind,
-        agentMeta: {
-          contextRebuild: {
-            reason: meta.reason,
-            handoff,
-          },
-        } as AgentMeta,
+        agentMeta: { contextRebuild: { reason: meta.reason, handoff } } as AgentMeta,
       });
     },
     setPendingHandoff: (sessionId, handoff, expectedGeneration) =>
@@ -11786,13 +11880,9 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
       options: { surfaceError: boolean; owner: SuppressedTurnErrorOwner },
     ) => {
       if (options.surfaceError) {
-        autoResumeBookkeeping.surfaceSuppressedError(sessionId, {
-          deferredOwner: options.owner,
-        });
+        autoResumeBookkeeping.surfaceSuppressedError(sessionId, { deferredOwner: options.owner });
       } else {
-        autoResumeBookkeeping.flushSuppressedError(sessionId, {
-          deferredOwner: options.owner,
-        });
+        autoResumeBookkeeping.flushSuppressedError(sessionId, { deferredOwner: options.owner });
       }
     },
     onResumableTurnError: (
@@ -12083,11 +12173,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
     },
     previewQueuedUserTurn: (sessionId, item) => {
       notifyAgentIslandUserPrompt(
-        {
-          id: sessionId,
-          agentKind: item.createOpts?.agentKind,
-          workDir: item.workingDir,
-        },
+        { id: sessionId, agentKind: item.createOpts?.agentKind, workDir: item.workingDir },
         item.text || item.persistedContent,
         { source: 'enqueue', clientId: item.clientId },
       );
@@ -12619,10 +12705,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
     return normalized;
   };
 
-  ipcMain.handle(DL_SESSION_REFERENCE_CAPABILITY_CHANNEL, () => ({
-    supported: true,
-    version: 1,
-  }));
+  ipcMain.handle(DL_SESSION_REFERENCE_CAPABILITY_CHANNEL, () => ({ supported: true, version: 1 }));
 
   /**
    * device-link 远控输入的自动起名(入队 / 插话共用)。
@@ -14686,9 +14769,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
     });
   });
 
-  registerProjectPluginPolicyHandlers(createElectronIpcHandlerRegistry(), {
-    getPluginRegistry,
-  });
+  registerProjectPluginPolicyHandlers(createElectronIpcHandlerRegistry(), { getPluginRegistry });
 
   // ── Android automation (Settings →「电脑使用」) ──────────────────────────
   registerAndroidAutomationHandlers(createElectronIpcHandlerRegistry());
@@ -14819,24 +14900,14 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
 
   ipcMain.on(
     MAKER_SEND.COMPUTER_PERMISSION_APP_DRAG_START,
-    (
-      _event,
-      payload?: {
-        iconDataUrl?: unknown;
-      },
-    ) => {
+    (_event, payload?: { iconDataUrl?: unknown }) => {
       startComputerPermissionAppDrag(_event.sender, payload?.iconDataUrl);
     },
   );
 
   ipcMain.handle(
     MAKER_INVOKE.COMPUTER_PERMISSION_APP_DRAG_END,
-    async (
-      _event,
-      payload?: {
-        didCopy?: unknown;
-      },
-    ) => {
+    async (_event, payload?: { didCopy?: unknown }) => {
       return finishComputerPermissionAppDrag(_event.sender, payload?.didCopy);
     },
   );
@@ -14936,30 +15007,19 @@ async function broadcastCodexImageAsToolResult(
       type: 'tool_use',
       source: 'codex',
       agentMeta: event.agentMeta,
-      data: {
-        toolUseId,
-        toolName: 'imagegen',
-        input: toolInput,
-      },
+      data: { toolUseId, toolName: 'imagegen', input: toolInput },
     } satisfies AgentEvent);
     broadcastSyntheticToolEvent(sessionId, {
       type: 'tool_result_full',
       source: 'codex',
       agentMeta: event.agentMeta,
-      data: {
-        toolUseId,
-        fullText,
-        isError: false,
-      },
+      data: { toolUseId, fullText, isError: false },
     } satisfies AgentEvent);
     broadcastSyntheticToolEvent(sessionId, {
       type: 'tool_result',
       source: 'codex',
       agentMeta: event.agentMeta,
-      data: {
-        summary: 'image generated',
-        toolUseIds: [toolUseId],
-      },
+      data: { summary: 'image generated', toolUseIds: [toolUseId] },
     } satisfies AgentEvent);
   } catch (err) {
     log.warn('failed to materialize codex image event', {
@@ -15143,11 +15203,7 @@ function emitWorkDirMissingError(
   });
   broadcastToAllWindows(MAKER_PUSH.EVENT, {
     sessionId,
-    event: {
-      type: 'error',
-      data: { message },
-      source: agentSource,
-    } satisfies AgentEvent,
+    event: { type: 'error', data: { message }, source: agentSource } satisfies AgentEvent,
   });
 }
 

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -5203,9 +5203,9 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
       // usage 事实无论价格是否可解析都持久化，保证新模型也能看到 cache 命中明细。
       if (event.type === 'done' && event.source === 'pi') {
         const sessionProvider = getSessionProvider(session.id);
-        // Pi's responses bridge receives Fast through host-side session prefs,
-        // not through the Pi RPC payload. Capture the request tariff at the
-        // synchronous done boundary before any later setting change can race it.
+        // New Pi payloads carry the tariff on every request segment. Keep the
+        // turn-start snapshot only as a compatibility fallback for older or
+        // incomplete payloads that have no explicit priceVariant.
         const piPriceVariant =
           (turnPiFastModeBySession.get(session.id) ?? getSessionFastMode(session.id))
             ? 'priority'

--- a/apps/desktop/src/main/turnCostBroadcaster.ts
+++ b/apps/desktop/src/main/turnCostBroadcaster.ts
@@ -432,7 +432,7 @@ export async function recordSchedulerTurnCost(
 
 /**
  * Codex done.data.usage → computeGatewayTurnCost 的 TurnTokenDeltas 入参映射。
- * Codex translator 已把 reasoning 合并进 completionTokens, 这里不再重复相加。
+ * Provider 的 completionTokens 已包含 reasoning 子集，这里不再重复相加。
  * Codex 无 cache 写入概念, cacheCreateTokens 恒 0。
  */
 export function codexUsageToTokens(usage: {

--- a/apps/desktop/src/main/usage/__tests__/modelUsageDelta.test.ts
+++ b/apps/desktop/src/main/usage/__tests__/modelUsageDelta.test.ts
@@ -39,6 +39,33 @@ describe('computeModelUsageDeltas', () => {
     }));
   });
 
+  it('accepts the first cumulative report when the SDK query explicitly started at zero', () => {
+    const { deltas } = computeModelUsageDeltas(
+      undefined,
+      {
+        'claude-opus-4-8': {
+          costUSD: 0.5,
+          inputTokens: 100,
+          outputTokens: 200,
+          cacheReadInputTokens: 3000,
+          cacheCreationInputTokens: 400,
+        },
+      },
+      undefined,
+      { cumulativeStartsAtZero: true },
+    );
+    expect(deltas).toEqual([
+      {
+        model: 'claude-opus-4-8',
+        costUsdDelta: 0.5,
+        inputTokensDelta: 100,
+        outputTokensDelta: 200,
+        cacheReadTokensDelta: 3000,
+        cacheCreateTokensDelta: 400,
+      },
+    ]);
+  });
+
   it('first report uses independently observed request usage and accepts cost only on an exact match', () => {
     const observed = new Map([
       [

--- a/apps/desktop/src/main/usage/__tests__/modelUsageDelta.test.ts
+++ b/apps/desktop/src/main/usage/__tests__/modelUsageDelta.test.ts
@@ -19,7 +19,7 @@ function snap(over: Partial<ModelUsageCumulative> = {}): ModelUsageCumulative {
 }
 
 describe('computeModelUsageDeltas', () => {
-  it('first report: full cumulative becomes the delta', () => {
+  it('first report without observed request usage only establishes a baseline', () => {
     const { next, deltas } = computeModelUsageDeltas(undefined, {
       'claude-opus-4-8': {
         costUSD: 0.5,
@@ -29,6 +29,36 @@ describe('computeModelUsageDeltas', () => {
         cacheCreationInputTokens: 400,
       },
     });
+    expect(deltas).toEqual([]);
+    expect(next.get('claude-opus-4-8')).toEqual(snap({
+      costUSD: 0.5,
+      inputTokens: 100,
+      outputTokens: 200,
+      cacheReadInputTokens: 3000,
+      cacheCreationInputTokens: 400,
+    }));
+  });
+
+  it('first report uses independently observed request usage and accepts cost only on an exact match', () => {
+    const observed = new Map([
+      [
+        'claude-opus-4-8',
+        { inputTokens: 100, outputTokens: 200, cacheReadTokens: 3000, cacheCreateTokens: 400 },
+      ],
+    ]);
+    const { deltas } = computeModelUsageDeltas(
+      undefined,
+      {
+        'claude-opus-4-8': {
+          costUSD: 0.5,
+          inputTokens: 100,
+          outputTokens: 200,
+          cacheReadInputTokens: 3000,
+          cacheCreationInputTokens: 400,
+        },
+      },
+      observed,
+    );
     expect(deltas).toEqual([
       {
         model: 'claude-opus-4-8',
@@ -39,13 +69,6 @@ describe('computeModelUsageDeltas', () => {
         cacheCreateTokensDelta: 400,
       },
     ]);
-    expect(next.get('claude-opus-4-8')).toEqual(snap({
-      costUSD: 0.5,
-      inputTokens: 100,
-      outputTokens: 200,
-      cacheReadInputTokens: 3000,
-      cacheCreationInputTokens: 400,
-    }));
   });
 
   it('monotonic increase: delta = cumulative - last', () => {
@@ -65,23 +88,43 @@ describe('computeModelUsageDeltas', () => {
     ]);
   });
 
-  it('cumulative reset (subprocess respawn): rebase from zero, no negative delta', () => {
+  it('cumulative reset without observed request usage rebases without charging the session total', () => {
     const prev = new Map([['m', snap({ costUSD: 2, inputTokens: 1000, outputTokens: 500 })]]);
     const { next, deltas } = computeModelUsageDeltas(prev, {
       m: { costUSD: 0.1, inputTokens: 50, outputTokens: 30, cacheReadInputTokens: 0, cacheCreationInputTokens: 0 },
     });
-    // 归零后整体 rebase: 本次累计全额计入 (而不是部分字段钳 0 的混合口径)
+    expect(deltas).toEqual([]);
+    expect(next.get('m')!.costUSD).toBe(0.1);
+  });
+
+  it('cumulative reset uses observed turn tokens but withholds unmatched cumulative cost', () => {
+    const prev = new Map([['m', snap({ costUSD: 2, inputTokens: 1000, outputTokens: 500 })]]);
+    const observed = new Map([
+      ['m', { inputTokens: 40, outputTokens: 20, cacheReadTokens: 0, cacheCreateTokens: 0 }],
+    ]);
+    const { deltas } = computeModelUsageDeltas(
+      prev,
+      {
+        m: {
+          costUSD: 0.1,
+          inputTokens: 50,
+          outputTokens: 30,
+          cacheReadInputTokens: 0,
+          cacheCreationInputTokens: 0,
+        },
+      },
+      observed,
+    );
     expect(deltas).toEqual([
       {
         model: 'm',
-        costUsdDelta: 0.1,
-        inputTokensDelta: 50,
-        outputTokensDelta: 30,
+        costUsdDelta: 0,
+        inputTokensDelta: 40,
+        outputTokensDelta: 20,
         cacheReadTokensDelta: 0,
         cacheCreateTokensDelta: 0,
       },
     ]);
-    expect(next.get('m')!.costUSD).toBe(0.1);
   });
 
   it('multi-model: independent deltas, unchanged model omitted', () => {
@@ -96,12 +139,12 @@ describe('computeModelUsageDeltas', () => {
     expect(deltas.map((d) => d.model)).toEqual(['a']);
   });
 
-  it('model absent from current report keeps its previous snapshot', () => {
+  it('model absent from current report keeps its previous snapshot and baselines unseen models', () => {
     const prev = new Map([['stale', snap({ costUSD: 3 })]]);
     const { next, deltas } = computeModelUsageDeltas(prev, {
       fresh: { costUSD: 0.2, inputTokens: 1, outputTokens: 1, cacheReadInputTokens: 0, cacheCreationInputTokens: 0 },
     });
-    expect(deltas.map((d) => d.model)).toEqual(['fresh']);
+    expect(deltas).toEqual([]);
     expect(next.get('stale')).toEqual(snap({ costUSD: 3 }));
   });
 

--- a/apps/desktop/src/main/usage/__tests__/turnCostCalculator.test.ts
+++ b/apps/desktop/src/main/usage/__tests__/turnCostCalculator.test.ts
@@ -1,19 +1,17 @@
 import { describe, expect, it } from 'vitest';
 
 import type { ModelUsageDeltaEntry } from '../modelUsageDelta';
-import {
-  LEDGER_CURRENCY_FALLBACK,
-  __resetActiveLedgerCurrencyForTesting,
-  setActiveLedgerCurrency,
-} from '../ledgerCurrency';
+import { __resetActiveLedgerCurrencyForTesting, setActiveLedgerCurrency } from '../ledgerCurrency';
 import {
   billingRouteForExplicitProvider,
   buildClaudeTurnUsageDetails,
   computePriceQuoteTurnMoney,
+  computeGatewaySegmentedTurnCost,
   computeGatewayTurnCost,
   estimateClaudeSubscriptionTurnValue,
   isAnthropicModel,
   normalizeModelIdForPricing,
+  normalizeTurnUsageSegments,
   resolveClaudeTurnCostSinks,
   resolveTurnCost,
   type ResolvedModelCost,
@@ -137,10 +135,26 @@ describe('model id and route helpers', () => {
     expect(isAnthropicModel('sonnet')).toBe(true);
     expect(isAnthropicModel('gpt-5.5')).toBe(false);
   });
+
+  it('keeps provider-reported cost-only segments', () => {
+    expect(
+      normalizeTurnUsageSegments([
+        {
+          inputTokens: 0,
+          outputTokens: 0,
+          cacheReadTokens: 0,
+          cacheCreateTokens: 0,
+          costUsd: 0.25,
+        },
+      ]),
+    ).toEqual([
+      { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreateTokens: 0, costUsd: 0.25 },
+    ]);
+  });
 });
 
 describe('computeGatewayTurnCost', () => {
-  it('returns null without a quote and uses input price for missing cache tiers', () => {
+  it('returns null without a quote or a price for every used token bucket', () => {
     const tokens = {
       inputTokens: 1_000_000,
       outputTokens: 1_000_000,
@@ -148,7 +162,7 @@ describe('computeGatewayTurnCost', () => {
       cacheCreateTokens: 1_000_000,
     };
     expect(computeGatewayTurnCost(tokens, undefined)).toBeNull();
-    expect(computeGatewayTurnCost(tokens, quote('m', 2, 8))).toBe(14);
+    expect(computeGatewayTurnCost(tokens, quote('m', 2, 8))).toBeNull();
   });
 
   it('uses explicit cache read/write prices when present', () => {
@@ -160,10 +174,7 @@ describe('computeGatewayTurnCost', () => {
           cacheReadTokens: 1_000_000,
           cacheCreateTokens: 1_000_000,
         },
-        quote('m', 2, 8, {
-          cacheReadPerMtok: 0.2,
-          cacheCreatePerMtok: 2.5,
-        }),
+        quote('m', 2, 8, { cacheReadPerMtok: 0.2, cacheCreatePerMtok: 2.5 }),
       ),
     ).toBeCloseTo(12.7);
   });
@@ -200,37 +211,90 @@ describe('computeGatewayTurnCost', () => {
       source: 'provider-reference',
       approximate: true,
       inputTokenPriceBands: [
-        {
-          minInputTokens: 0,
-          maxInputTokens: 200_000,
-          inputPerMtok: 0.2,
-          outputPerMtok: 1.5,
-        },
+        { minInputTokens: 0, maxInputTokens: 200_000, inputPerMtok: 0.2, outputPerMtok: 1.5 },
       ],
     });
 
     expect(
       computeGatewayTurnCost(
-        {
-          inputTokens: 199_999,
-          outputTokens: 1,
-          cacheReadTokens: 0,
-          cacheCreateTokens: 0,
-        },
+        { inputTokens: 199_999, outputTokens: 1, cacheReadTokens: 0, cacheCreateTokens: 0 },
         boundedReference,
       ),
     ).not.toBeNull();
     expect(
       computeGatewayTurnCost(
-        {
-          inputTokens: 200_000,
-          outputTokens: 1,
-          cacheReadTokens: 0,
-          cacheCreateTokens: 0,
-        },
+        { inputTokens: 200_000, outputTokens: 1, cacheReadTokens: 0, cacheCreateTokens: 0 },
         boundedReference,
       ),
     ).toBeNull();
+  });
+
+  it('selects long-context bands per request instead of from the turn aggregate', () => {
+    const price = quote('m', 5, 30, {
+      cacheReadPerMtok: 0.5,
+      inputTokenPriceBands: [
+        { minInputTokens: 272_001, inputPerMtok: 10, outputPerMtok: 45, cacheReadPerMtok: 1 },
+      ],
+    });
+    const tenRequests = Array.from({ length: 10 }, (_, index) => ({
+      id: `request-${index}`,
+      inputTokens: 50_000,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+      cacheCreateTokens: 0,
+    }));
+    expect(computeGatewaySegmentedTurnCost(tenRequests, price)).toBe(2.5);
+    expect(
+      computeGatewaySegmentedTurnCost(
+        [{ inputTokens: 500_000, outputTokens: 0, cacheReadTokens: 0, cacheCreateTokens: 0 }],
+        price,
+      ),
+    ).toBe(5);
+  });
+
+  it('replays the audited Codex turn as 92 baseline requests for $1.3124601', () => {
+    const price = quote('codex/gpt-5.6-sol', 5, 30, {
+      cacheReadPerMtok: 0.5,
+      costDiscount: 0.85,
+      inputTokenPriceBands: [
+        { minInputTokens: 272_001, inputPerMtok: 10, outputPerMtok: 45, cacheReadPerMtok: 1 },
+      ],
+    });
+    const segments = Array.from({ length: 92 }, (_, index) => ({
+      inputTokens: 7_987 + (index < 68 ? 1 : 0),
+      cacheReadTokens: 86_234 + (index < 40 ? 1 : 0),
+      outputTokens: 401 + (index < 61 ? 1 : 0),
+      cacheCreateTokens: 0,
+    }));
+    const money = computePriceQuoteTurnMoney(
+      {
+        inputTokens: 734_872,
+        cacheReadTokens: 7_933_568,
+        outputTokens: 36_953,
+        cacheCreateTokens: 0,
+      },
+      price,
+      'USD',
+      segments,
+    );
+    expect(money?.amount).toBeCloseTo(1.3124601, 9);
+  });
+
+  it('uses priority prices for Fast requests and refuses unsupported batch pricing', () => {
+    const price = quote('m', 5, 30, {
+      cacheReadPerMtok: 0.5,
+      cacheCreatePerMtok: 6.25,
+      priority: { inputPerMtok: 10, outputPerMtok: 60, cacheReadPerMtok: 1 },
+    });
+    const tokens = {
+      inputTokens: 1_000_000,
+      outputTokens: 1_000_000,
+      cacheReadTokens: 1_000_000,
+      cacheCreateTokens: 1_000_000,
+    };
+    expect(computeGatewayTurnCost(tokens, price, 'priority')).toBe(77.25);
+    expect(computeGatewayTurnCost(tokens, price, 'fast')).toBe(77.25);
+    expect(computeGatewayTurnCost(tokens, price, 'batch')).toBeNull();
   });
 });
 
@@ -246,10 +310,7 @@ describe('computePriceQuoteTurnMoney', () => {
     expect(
       computePriceQuoteTurnMoney(
         tokens,
-        quote('subscription-model', 2, 10, {
-          source: 'subscription-reference',
-          approximate: true,
-        }),
+        quote('subscription-model', 2, 10, { source: 'subscription-reference', approximate: true }),
         'USD',
       )?.estimateReasons,
     ).toEqual(['subscription-value', 'reference-price']);
@@ -264,8 +325,7 @@ describe('computePriceQuoteTurnMoney', () => {
     }
   });
 
-  it('estimates SuperGrok token value from xAI reference prices including cache reads',
-    () => {
+  it('estimates SuperGrok token value from xAI reference prices including cache reads', () => {
     const money = computePriceQuoteTurnMoney(
       {
         inputTokens: 179_300,
@@ -309,12 +369,7 @@ describe('resolveTurnCost', () => {
     });
     const claude = resolveTurnCost({
       rawModel: 'claude-opus-4-8[1m]',
-      tokens: {
-        inputTokens: 1_000_000,
-        outputTokens: 0,
-        cacheReadTokens: 0,
-        cacheCreateTokens: 0,
-      },
+      tokens: { inputTokens: 1_000_000, outputTokens: 0, cacheReadTokens: 0, cacheCreateTokens: 0 },
       sdkCostDelta: 99,
       pricing,
       context: XD_GATEWAY,
@@ -326,56 +381,51 @@ describe('resolveTurnCost', () => {
     expect(claude.money?.amount).toBe(5);
   });
 
-  it('falls back to USD for the SDK amount when the ledger currency is unknown — never the build region', () => {
-    // 没有活动账本币种(冷启动、目录还没同步下来)时按 ledgerCurrency.ts 的回退链
-    // 落到 USD,绝不按构建区域猜(#1302:按区域回落会让同一账号的账本币种反复翻转,
-    // 覆盖当天累计)。SDK 的 costDelta 本来就是 USD 口径,与兜底币种同口径,因此
-    // 无论 cn / global 构建,这一轮都按 USD 原值兜底记账,断言两种构建下同形。
+  it('does not fall back from a missing codex budget SKU to the bare model price', () => {
+    const result = resolveTurnCost({
+      rawModel: 'codex/gpt-5.6-sol',
+      tokens: { inputTokens: 1_000_000, outputTokens: 0, cacheReadTokens: 0, cacheCreateTokens: 0 },
+      pricing: catalog(quote('gpt-5.6-sol', 5, 30, { costDiscount: 0.4 })),
+      context: XD_GATEWAY,
+    });
+    expect(result.source).toBe('sdk-fallback');
+    expect(result.money).toBeNull();
+  });
+
+  it('does not present an unquoted Gateway SDK estimate as actual spend', () => {
     __resetActiveLedgerCurrencyForTesting();
     const result = resolveTurnCost({
       rawModel: 'unknown-model',
-      tokens: {
-        inputTokens: 1_000,
-        outputTokens: 100,
-        cacheReadTokens: 0,
-        cacheCreateTokens: 0,
-      },
+      tokens: { inputTokens: 1_000, outputTokens: 100, cacheReadTokens: 0, cacheCreateTokens: 0 },
       sdkCostDelta: 1.23,
       pricing: {},
       context: XD_GATEWAY,
     });
     expect(result.source).toBe('sdk-fallback');
-    expect(LEDGER_CURRENCY_FALLBACK).toBe('USD');
-    expect(result.money).toEqual({
-      amount: 1.23,
-      currency: 'USD',
-      approximate: false,
-      kind: 'actual-cost',
-    });
+    expect(result.money).toBeNull();
   });
 
-  it('falls back to the SDK USD amount for a USD-settled account on a CN build', () => {
-    // 结算币种由目录里其它 xd 报价声明,不看构建区域、也不按租户判断。
-    // 以 USD 结算的账号在某个模型缺报价时同样要记账,不能漏计。
+  it('does not present SDK cost from an unknown route as local actual spend', () => {
+    const result = resolveTurnCost({
+      rawModel: 'unknown-model',
+      tokens: { inputTokens: 1_000, outputTokens: 100, cacheReadTokens: 0, cacheCreateTokens: 0 },
+      sdkCostDelta: 1.23,
+      pricing: null,
+      context: { providerId: null, billingRoute: 'unknown', region: 'global' },
+    });
+    expect(result).toMatchObject({ source: 'sdk-fallback', money: null });
+  });
+
+  it('keeps an unquoted Gateway model unavailable even on a USD ledger', () => {
     const result = resolveTurnCost({
       rawModel: 'unquoted-model',
-      tokens: {
-        inputTokens: 1_000,
-        outputTokens: 100,
-        cacheReadTokens: 0,
-        cacheCreateTokens: 0,
-      },
+      tokens: { inputTokens: 1_000, outputTokens: 100, cacheReadTokens: 0, cacheCreateTokens: 0 },
       sdkCostDelta: 1.23,
       pricing: catalog(quote('some-other-model', 3, 15)),
       context: XD_GATEWAY_CN,
     });
     expect(result.source).toBe('sdk-fallback');
-    expect(result.money).toEqual({
-      amount: 1.23,
-      currency: 'USD',
-      approximate: false,
-      kind: 'actual-cost',
-    });
+    expect(result.money).toBeNull();
   });
 
   it('projects non-gateway costs to the ledger currency, not the build region', () => {
@@ -408,12 +458,7 @@ describe('resolveTurnCost', () => {
     // 折算进去只会误记，这一轮宁可不记。
     const result = resolveTurnCost({
       rawModel: 'unquoted-model',
-      tokens: {
-        inputTokens: 1_000,
-        outputTokens: 100,
-        cacheReadTokens: 0,
-        cacheCreateTokens: 0,
-      },
+      tokens: { inputTokens: 1_000, outputTokens: 100, cacheReadTokens: 0, cacheCreateTokens: 0 },
       sdkCostDelta: 1.23,
       pricing: catalog(quote('some-other-model', 3, 15, { currency: 'CNY' })),
       context: XD_GATEWAY_CN,
@@ -422,7 +467,7 @@ describe('resolveTurnCost', () => {
     expect(result.money).toBeNull();
   });
 
-  it('uses the active ledger currency when the pricing catalog is entirely empty', () => {
+  it('does not use the active ledger currency to legitimize a missing Gateway quote', () => {
     try {
       setActiveLedgerCurrency('USD');
       const result = resolveTurnCost({
@@ -432,7 +477,7 @@ describe('resolveTurnCost', () => {
         pricing: {},
         context: XD_GATEWAY_CN,
       });
-      expect(result.money).toMatchObject({ amount: 1.23, currency: 'USD' });
+      expect(result.money).toBeNull();
     } finally {
       __resetActiveLedgerCurrencyForTesting();
     }
@@ -441,26 +486,12 @@ describe('resolveTurnCost', () => {
   it('applies an ordinary Gateway model costDiscount exactly once', () => {
     const result = resolveTurnCost({
       rawModel: 'discounted-model',
-      tokens: {
-        inputTokens: 1_000_000,
-        outputTokens: 0,
-        cacheReadTokens: 0,
-        cacheCreateTokens: 0,
-      },
+      tokens: { inputTokens: 1_000_000, outputTokens: 0, cacheReadTokens: 0, cacheCreateTokens: 0 },
       sdkCostDelta: 99,
-      pricing: catalog(
-        quote('discounted-model', 2, 8, {
-          currency: 'CNY',
-          costDiscount: 0.75,
-        }),
-      ),
+      pricing: catalog(quote('discounted-model', 2, 8, { currency: 'CNY', costDiscount: 0.75 })),
       context: XD_GATEWAY_CN,
     });
-    expect(result.money).toMatchObject({
-      amount: 0.5,
-      currency: 'CNY',
-      approximate: false,
-    });
+    expect(result.money).toMatchObject({ amount: 0.5, currency: 'CNY', approximate: false });
   });
 
   it('keeps a USD Gateway quote unconverted on a CN build (XD enterprise settles in USD)', () => {
@@ -469,12 +500,7 @@ describe('resolveTurnCost', () => {
     // turn 若被换算就会在同一行出现 $ / ¥ 混排,且金额差一个汇率倍数、无法与账单核对。
     const result = resolveTurnCost({
       rawModel: 'gpt-5.5',
-      tokens: {
-        inputTokens: 1_000_000,
-        outputTokens: 0,
-        cacheReadTokens: 0,
-        cacheCreateTokens: 0,
-      },
+      tokens: { inputTokens: 1_000_000, outputTokens: 0, cacheReadTokens: 0, cacheCreateTokens: 0 },
       pricing: catalog(quote('gpt-5.5', 3, 15)),
       context: XD_GATEWAY_CN,
     });
@@ -490,12 +516,7 @@ describe('resolveTurnCost', () => {
   it('XD missing price with no SDK cost still resolves to null money', () => {
     const result = resolveTurnCost({
       rawModel: 'unknown-model',
-      tokens: {
-        inputTokens: 1_000,
-        outputTokens: 100,
-        cacheReadTokens: 0,
-        cacheCreateTokens: 0,
-      },
+      tokens: { inputTokens: 1_000, outputTokens: 100, cacheReadTokens: 0, cacheCreateTokens: 0 },
       pricing: {},
       context: XD_GATEWAY,
     });
@@ -506,12 +527,7 @@ describe('resolveTurnCost', () => {
   it('provider API route keeps the SDK USD fact exact — no regional conversion', () => {
     const result = resolveTurnCost({
       rawModel: 'claude-opus-4-8',
-      tokens: {
-        inputTokens: 0,
-        outputTokens: 0,
-        cacheReadTokens: 0,
-        cacheCreateTokens: 0,
-      },
+      tokens: { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreateTokens: 0 },
       sdkCostDelta: 3,
       pricing: catalog(quote('claude-opus-4-8', 99, 99)),
       context: PROVIDER_API,
@@ -550,11 +566,7 @@ describe('resolveTurnCost', () => {
     expect(result).toMatchObject({
       model: 'deepseek-v4-pro',
       source: 'reference',
-      money: {
-        currency: 'USD',
-        approximate: true,
-        kind: 'value-estimate',
-      },
+      money: { currency: 'USD', approximate: true, kind: 'value-estimate' },
     });
     expect(result.money?.amount).toBeCloseTo(0.00173275, 10);
   });
@@ -562,12 +574,7 @@ describe('resolveTurnCost', () => {
   it('keeps the DeepSeek SDK cost when token deltas are unavailable', () => {
     const result = resolveTurnCost({
       rawModel: 'deepseek-v4-pro',
-      tokens: {
-        inputTokens: 0,
-        outputTokens: 0,
-        cacheReadTokens: 0,
-        cacheCreateTokens: 0,
-      },
+      tokens: { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreateTokens: 0 },
       sdkCostDelta: 0.052635,
       pricing: catalog(
         quote('deepseek-v4-pro', 0.435, 0.87, {
@@ -583,13 +590,32 @@ describe('resolveTurnCost', () => {
     expect(result).toEqual({
       model: 'deepseek-v4-pro',
       source: 'sdk',
-      money: {
-        amount: 0.052635,
-        currency: 'USD',
-        approximate: false,
-        kind: 'actual-cost',
-      },
+      money: { amount: 0.052635, currency: 'USD', approximate: false, kind: 'actual-cost' },
     });
+  });
+
+  it('does not fall back to the DeepSeek SDK estimate when request segments are incomplete', () => {
+    const result = resolveTurnCost({
+      rawModel: 'deepseek-v4-pro',
+      tokens: {
+        inputTokens: 2_000,
+        outputTokens: 500,
+        cacheReadTokens: 118_000,
+        cacheCreateTokens: 0,
+      },
+      sdkCostDelta: 0.052635,
+      pricing: catalog(
+        quote('deepseek-v4-pro', 0.435, 0.87, {
+          providerId: 'deepseek',
+          cacheReadPerMtok: 0.003625,
+          source: 'provider-reference',
+          approximate: true,
+        }),
+      ),
+      context: { providerId: 'deepseek', billingRoute: 'provider-api', region: 'global' },
+      segments: [],
+    });
+    expect(result).toEqual({ model: 'deepseek-v4-pro', source: 'reference', money: null });
   });
 
   it('uses a provider reference or user override estimate when the SDK reports no cost', () => {
@@ -627,12 +653,7 @@ describe('resolveTurnCost', () => {
       setActiveLedgerCurrency('USD');
       const result = resolveTurnCost({
         rawModel: 'codex/gpt-5.5',
-        tokens: {
-          inputTokens: 0,
-          outputTokens: 0,
-          cacheReadTokens: 0,
-          cacheCreateTokens: 0,
-        },
+        tokens: { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreateTokens: 0 },
         sdkCostDelta: 10,
         pricing: null,
         context: PROVIDER_API,
@@ -646,24 +667,14 @@ describe('resolveTurnCost', () => {
   it('subscription routes and inferred subscription model prefixes never become actual cost', () => {
     const byRoute = resolveTurnCost({
       rawModel: 'claude-opus-4-8',
-      tokens: {
-        inputTokens: 1_000_000,
-        outputTokens: 0,
-        cacheReadTokens: 0,
-        cacheCreateTokens: 0,
-      },
+      tokens: { inputTokens: 1_000_000, outputTokens: 0, cacheReadTokens: 0, cacheCreateTokens: 0 },
       sdkCostDelta: 5,
       pricing: null,
       context: SUBSCRIPTION,
     });
     const byPrefix = resolveTurnCost({
       rawModel: 'chatgpt/gpt-5.5',
-      tokens: {
-        inputTokens: 1_000_000,
-        outputTokens: 0,
-        cacheReadTokens: 0,
-        cacheCreateTokens: 0,
-      },
+      tokens: { inputTokens: 1_000_000, outputTokens: 0, cacheReadTokens: 0, cacheCreateTokens: 0 },
       sdkCostDelta: 5,
       pricing: null,
       context: { providerId: null, billingRoute: 'unknown', region: 'global' },
@@ -714,11 +725,7 @@ describe('resolveTurnCost', () => {
           approximate: true,
         }),
       ),
-      context: {
-        providerId: 'vercel-ai-gateway',
-        billingRoute: 'provider-api',
-        region: 'global',
-      },
+      context: { providerId: 'vercel-ai-gateway', billingRoute: 'provider-api', region: 'global' },
     });
 
     expect(result.source).toBe('reference');
@@ -758,16 +765,110 @@ describe('resolveClaudeTurnCostSinks', () => {
       pricing,
       XD_GATEWAY_CN,
     );
-    expect(result.turnMoney).toMatchObject({
-      amount: 5,
-      currency: 'CNY',
-      kind: 'actual-cost',
-    });
+    expect(result.turnMoney).toMatchObject({ amount: 5, currency: 'CNY', kind: 'actual-cost' });
     expect(result.perModel.map((item) => item.money)).toEqual([
       expect.objectContaining({ currency: 'CNY', amount: 5 }),
       null,
     ]);
     expect(result.perModel.map((item) => item.source)).toEqual(['gateway', 'sdk-fallback']);
+  });
+
+  it('does not price a Claude turn whose request segment payload is incomplete', () => {
+    const pricing = catalog(
+      quote('gpt-5.5', 5, 30, {
+        cacheReadPerMtok: 0.5,
+        inputTokenPriceBands: [{ minInputTokens: 272_001, inputPerMtok: 10 }],
+      }),
+    );
+    const result = resolveClaudeTurnCostSinks(
+      [delta('gpt-5.5', { inputTokensDelta: 500_000 })],
+      pricing,
+      XD_GATEWAY,
+      [],
+      false,
+    );
+    expect(result.turnMoney).toBeNull();
+    expect(result.perModel[0]?.segments).toEqual([]);
+  });
+
+  it('keeps observed Claude tokens when the first cumulative snapshot is unpriceable', () => {
+    const result = resolveClaudeTurnCostSinks(
+      [],
+      catalog(quote('gpt-5.5', 5, 30, { cacheReadPerMtok: 0.5 })),
+      XD_GATEWAY,
+      [
+        {
+          model: 'gpt-5.5',
+          inputTokens: 100,
+          outputTokens: 25,
+          cacheReadTokens: 0,
+          cacheCreateTokens: 0,
+        },
+      ],
+      false,
+    );
+    expect(result.turnMoney).toBeNull();
+    expect(result.perModel).toMatchObject([
+      {
+        model: 'gpt-5.5',
+        money: null,
+        deltas: { inputTokens: 100, outputTokens: 25, cacheReadTokens: 0, cacheCreateTokens: 0 },
+        segments: [],
+      },
+    ]);
+  });
+
+  it('prices completed Claude request segments while leaving only the residual unpriced', () => {
+    const pricing = catalog(
+      quote('gpt-5.5', 5, 30, {
+        cacheReadPerMtok: 0.5,
+        inputTokenPriceBands: [{ minInputTokens: 272_001, inputPerMtok: 10 }],
+      }),
+    );
+    const result = resolveClaudeTurnCostSinks(
+      [
+        delta('gpt-5.5', {
+          inputTokensDelta: 600_000,
+          outputTokensDelta: 20_000,
+        }),
+      ],
+      pricing,
+      XD_GATEWAY,
+      [
+        {
+          id: 'completed-request',
+          model: 'gpt-5.5',
+          inputTokens: 100_000,
+          outputTokens: 10_000,
+          cacheReadTokens: 0,
+          cacheCreateTokens: 0,
+          complete: true,
+        },
+        {
+          id: 'unfinished-request',
+          model: 'gpt-5.5',
+          inputTokens: 500_000,
+          outputTokens: 10_000,
+          cacheReadTokens: 0,
+          cacheCreateTokens: 0,
+          complete: false,
+        },
+      ],
+      false,
+    );
+
+    expect(result.turnMoney).toMatchObject({ amount: 0.8, kind: 'actual-cost' });
+    expect(result.perModel).toHaveLength(2);
+    expect(result.perModel[0]).toMatchObject({
+      money: { amount: 0.8, kind: 'actual-cost' },
+      deltas: { inputTokens: 100_000, outputTokens: 10_000 },
+      segments: [{ id: 'completed-request', complete: true }],
+    });
+    expect(result.perModel[1]).toMatchObject({
+      money: null,
+      deltas: { inputTokens: 500_000, outputTokens: 10_000 },
+      segments: [],
+    });
   });
 
   it('returns null total when the route is subscription-only', () => {
@@ -778,10 +879,7 @@ describe('resolveClaudeTurnCostSinks', () => {
     );
     expect(result.turnMoney).toBeNull();
     expect(result.estimatedTurnMoney).toBeNull();
-    expect(result.perModel[0]).toMatchObject({
-      source: 'subscription',
-      money: null,
-    });
+    expect(result.perModel[0]).toMatchObject({ source: 'subscription', money: null });
   });
 
   it('keeps provider reference estimates out of actual spend', () => {
@@ -796,10 +894,7 @@ describe('resolveClaudeTurnCostSinks', () => {
       PROVIDER_API,
     );
     expect(result.turnMoney).toBeNull();
-    expect(result.estimatedTurnMoney).toMatchObject({
-      amount: 5,
-      kind: 'value-estimate',
-    });
+    expect(result.estimatedTurnMoney).toMatchObject({ amount: 5, kind: 'value-estimate' });
   });
 
   it('does not mix a reference estimate into an actual SDK cost total', () => {
@@ -835,12 +930,7 @@ describe('subscription value and usage details', () => {
       }),
     );
     const value = estimateClaudeSubscriptionTurnValue(
-      [
-        resolvedModel('claude-opus-4-8', {
-          inputTokens: 1_000_000,
-          outputTokens: 200_000,
-        }),
-      ],
+      [resolvedModel('claude-opus-4-8', { inputTokens: 1_000_000, outputTokens: 200_000 })],
       'USD',
       pricing,
     );
@@ -894,10 +984,7 @@ describe('subscription value and usage details', () => {
       approximate: true,
     });
     const pricing = {
-      anthropic: {
-        [canonical]: reference,
-        [`${canonical}\u0000claude-code`]: override,
-      },
+      anthropic: { [canonical]: reference, [`${canonical}\u0000claude-code`]: override },
     };
 
     expect(

--- a/apps/desktop/src/main/usage/__tests__/usageHistory.test.ts
+++ b/apps/desktop/src/main/usage/__tests__/usageHistory.test.ts
@@ -309,6 +309,14 @@ describe('getSubscriptionValuePriceFor', () => {
       cacheReadPerMtok: 0.5,
     });
   });
+
+  it('routes Claude bridge subscription ids through their direct quote', () => {
+    expect(getSubscriptionValuePriceFor('claude-code', 'xai/grok-4.3', null)).toMatchObject({
+      providerId: 'xai',
+      modelId: 'xai/grok-4.3',
+      source: 'subscription-reference',
+    });
+  });
 });
 
 describe('readUsageHistoryWith', () => {
@@ -410,6 +418,93 @@ describe('readUsageHistoryWith', () => {
     ]);
     expect(result.models[0].estimatedMoney?.amount).toBeCloseTo(regionalUsdAmount(5));
     expect(result.totals.last30DaysEstimatedValue.amount).toBeCloseTo(regionalUsdAmount(5));
+  });
+
+  it('uses the request-priced subscription value stored at write time', async () => {
+    const stored: RegionalMoney = {
+      amount: regionalUsdAmount(1.25),
+      currency: DEFAULT_USAGE_CURRENCY,
+      approximate: true,
+      kind: 'value-estimate',
+      estimateReasons: ['subscription-value', 'reference-price'],
+    };
+    const result = await readUsageHistoryWith(
+      makeDeps({
+        getModelUsageSince: async () => [
+          modelRow(TODAY, 'codex', codexSubscriptionUsageModelKey('gpt-5.5'), stored, {
+            inputTokens: 1_000_000,
+          }),
+        ],
+        getReferenceModelPricing: () => ({
+          openai: {
+            // A later catalog price would produce 9. The frozen request-level
+            // estimate must win instead of repricing the day aggregate.
+            'gpt-5.5': subscriptionQuote('openai', 'gpt-5.5', 9, 20),
+          },
+        }),
+      }),
+    );
+    expect(result.models[0].estimatedMoney?.amount).toBeCloseTo(stored.amount);
+    expect(result.modelDaily[0].subscriptionEstimateMoney.amount).toBeCloseTo(stored.amount);
+  });
+
+  it('does not reprice an explicitly unpriceable future subscription row', async () => {
+    const unavailable: RegionalMoney = {
+      amount: 0,
+      currency: DEFAULT_USAGE_CURRENCY,
+      approximate: true,
+      kind: 'value-estimate',
+      estimateReasons: ['subscription-value', 'reference-price'],
+    };
+    const result = await readUsageHistoryWith(
+      makeDeps({
+        getModelUsageSince: async () => [
+          modelRow(TODAY, 'codex', codexSubscriptionUsageModelKey('gpt-5.5'), unavailable, {
+            inputTokens: 1_000_000,
+          }),
+        ],
+        getReferenceModelPricing: () => ({
+          openai: { 'gpt-5.5': subscriptionQuote('openai', 'gpt-5.5', 9, 20) },
+        }),
+        isModelPricingRefreshInFlight: () => true,
+      }),
+    );
+    expect(result.estimatesPending).toBe(false);
+    expect(result.models[0].estimatedMoney).toBeNull();
+    expect(result.modelDaily[0].subscriptionEstimateMoney.amount).toBe(0);
+  });
+
+  it('does not reprice a value estimate after projecting it into another ledger currency', async () => {
+    const historicalCurrency = DEFAULT_USAGE_CURRENCY === 'CNY' ? 'USD' : 'CNY';
+    const stored: RegionalMoney = {
+      amount: 4,
+      currency: historicalCurrency,
+      approximate: true,
+      kind: 'value-estimate',
+      estimateReasons: ['subscription-value', 'reference-price'],
+    };
+    const result = await readUsageHistoryWith(
+      makeDeps({
+        getModelUsageSince: async () => [
+          modelRow(TODAY, 'codex', codexSubscriptionUsageModelKey('gpt-5.5'), stored, {
+            inputTokens: 1_000_000,
+          }),
+        ],
+        getReferenceModelPricing: () => ({
+          openai: { 'gpt-5.5': subscriptionQuote('openai', 'gpt-5.5', 99, 199) },
+        }),
+      }),
+    );
+
+    expect(result.estimatesPending).toBe(false);
+    expect(result.models[0].estimatedMoney).toBeNull();
+    expect(result.modelDaily[0]).toMatchObject({
+      subscriptionEstimateMoney: {
+        amount: 0,
+        currency: DEFAULT_USAGE_CURRENCY,
+        kind: 'value-estimate',
+      },
+    });
   });
 
   it('keeps active-ledger subscription estimates when history uses another currency', async () => {
@@ -556,7 +651,7 @@ describe('readUsageHistoryWith', () => {
     expect(result.models[0].estimatedMoney?.amount).toBe(expected);
   });
 
-  it('keeps Pi cache usage as a distinct subscription row', async () => {
+  it('keeps Pi cache usage token-only when the quote omits a cache-read price', async () => {
     const result = await readUsageHistoryWith(makeDeps({
       getModelUsageSince: async () => [
         modelRow(
@@ -575,7 +670,7 @@ describe('readUsageHistoryWith', () => {
       inputTokens: 100_000,
       cacheReadTokens: 900_000,
     });
-    expect(result.models[0].estimatedMoney?.amount).toBeGreaterThan(0);
+    expect(result.models[0].estimatedMoney).toBeNull();
     expect(result.totals.todayTokens).toBe(1_002_000);
   });
 

--- a/apps/desktop/src/main/usage/modelPricing.ts
+++ b/apps/desktop/src/main/usage/modelPricing.ts
@@ -202,6 +202,20 @@ function validateQuote(
   if (isNonNegativeFinite(quote.cacheCreatePerMtok)) {
     next.cacheCreatePerMtok = quote.cacheCreatePerMtok;
   }
+  if (quote.priority && typeof quote.priority === 'object') {
+    const priority: NonNullable<ModelPriceQuote['priority']> = {};
+    for (const field of [
+      'inputPerMtok',
+      'outputPerMtok',
+      'cacheReadPerMtok',
+      'cacheCreatePerMtok',
+    ] as const) {
+      if (isNonNegativeFinite(quote.priority[field])) priority[field] = quote.priority[field];
+    }
+    const bands = validateInputTokenPriceBands(quote.priority.inputTokenPriceBands);
+    if (bands) priority.inputTokenPriceBands = bands;
+    if (Object.keys(priority).length > 0) next.priority = priority;
+  }
   const inputTokenPriceBands = validateInputTokenPriceBands(quote.inputTokenPriceBands);
   if (inputTokenPriceBands) {
     next.inputTokenPriceBands = inputTokenPriceBands;

--- a/apps/desktop/src/main/usage/modelUsageDelta.ts
+++ b/apps/desktop/src/main/usage/modelUsageDelta.ts
@@ -79,6 +79,7 @@ export function computeModelUsageDeltas(
   prev: Map<string, ModelUsageCumulative> | undefined,
   current: Record<string, unknown>,
   observedTurnUsage?: ReadonlyMap<string, ObservedModelTurnUsage>,
+  options: { cumulativeStartsAtZero?: boolean } = {},
 ): { next: Map<string, ModelUsageCumulative>; deltas: ModelUsageDeltaEntry[] } {
   const next = new Map<string, ModelUsageCumulative>();
   const deltas: ModelUsageDeltaEntry[] = [];
@@ -98,6 +99,7 @@ export function computeModelUsageDeltas(
         cum.cacheReadInputTokens < last.cacheReadInputTokens ||
         cum.cacheCreationInputTokens < last.cacheCreationInputTokens);
     const unbaselined = reset || last === undefined;
+    const cumulativeStartsAtZero = options.cumulativeStartsAtZero === true;
     const observed =
       observedTurnUsage?.get(model) ?? observedTurnUsage?.get(model.replace(/\[[^\]]*\]\s*$/, ''));
     const observedMatchesCumulative =
@@ -106,7 +108,17 @@ export function computeModelUsageDeltas(
       cum.outputTokens === observed.outputTokens &&
       cum.cacheReadInputTokens === observed.cacheReadTokens &&
       cum.cacheCreationInputTokens === observed.cacheCreateTokens;
-    const base = unbaselined ? cum : last;
+    const base = unbaselined
+      ? cumulativeStartsAtZero
+        ? {
+            costUSD: 0,
+            inputTokens: 0,
+            outputTokens: 0,
+            cacheReadInputTokens: 0,
+            cacheCreationInputTokens: 0,
+          }
+        : cum
+      : last;
 
     const entry: ModelUsageDeltaEntry = {
       model,
@@ -114,24 +126,24 @@ export function computeModelUsageDeltas(
       // provider session. Only treat its cumulative cost as this turn when the
       // independently observed request segments prove the token totals match.
       costUsdDelta: unbaselined
-        ? observedMatchesCumulative
+        ? cumulativeStartsAtZero || observedMatchesCumulative
           ? cum.costUSD
           : 0
         : Math.max(0, cum.costUSD - base.costUSD),
       inputTokensDelta:
-        observed && unbaselined
+        observed && unbaselined && !cumulativeStartsAtZero
           ? observed.inputTokens
           : Math.max(0, cum.inputTokens - base.inputTokens),
       outputTokensDelta:
-        observed && unbaselined
+        observed && unbaselined && !cumulativeStartsAtZero
           ? observed.outputTokens
           : Math.max(0, cum.outputTokens - base.outputTokens),
       cacheReadTokensDelta:
-        observed && unbaselined
+        observed && unbaselined && !cumulativeStartsAtZero
           ? observed.cacheReadTokens
           : Math.max(0, cum.cacheReadInputTokens - base.cacheReadInputTokens),
       cacheCreateTokensDelta:
-        observed && unbaselined
+        observed && unbaselined && !cumulativeStartsAtZero
           ? observed.cacheCreateTokens
           : Math.max(0, cum.cacheCreationInputTokens - base.cacheCreationInputTokens),
     };

--- a/apps/desktop/src/main/usage/modelUsageDelta.ts
+++ b/apps/desktop/src/main/usage/modelUsageDelta.ts
@@ -6,8 +6,9 @@
  * daily_model_usage 表必须 cumulative - lastReported (与 register.ts 的
  * lastReportedCostUsdBySession 同款手法)。
  *
- * 钳制: 子进程重 spawn (resume / 崩溃重启) 后累计值归零, delta 会算出负数 —
- * 一律 Math.max(0, ...) 钳到 0 (接受少记一个 turn 的取舍, 与 total_cost_usd 一致)。
+ * 基线: 首次快照或子进程重 spawn 后的回退快照不能直接当成本轮增量。
+ * 先把累计值设为新基线；若独立观察到的完整 request segments 与该快照逐桶一致，
+ * 才保留这轮 token/cost。其余情况宁可只保留可证明的 segment token，也不吞入历史累计。
  *
  * ## 已知上游行为: output 归属可能滞后一轮
  *
@@ -43,6 +44,13 @@ export interface ModelUsageDeltaEntry {
   cacheCreateTokensDelta: number;
 }
 
+export interface ObservedModelTurnUsage {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheCreateTokens: number;
+}
+
 function num(v: unknown): number {
   return typeof v === 'number' && Number.isFinite(v) && v >= 0 ? v : 0;
 }
@@ -70,6 +78,7 @@ function sanitize(raw: unknown): ModelUsageCumulative {
 export function computeModelUsageDeltas(
   prev: Map<string, ModelUsageCumulative> | undefined,
   current: Record<string, unknown>,
+  observedTurnUsage?: ReadonlyMap<string, ObservedModelTurnUsage>,
 ): { next: Map<string, ModelUsageCumulative>; deltas: ModelUsageDeltaEntry[] } {
   const next = new Map<string, ModelUsageCumulative>();
   const deltas: ModelUsageDeltaEntry[] = [];
@@ -88,17 +97,43 @@ export function computeModelUsageDeltas(
         cum.outputTokens < last.outputTokens ||
         cum.cacheReadInputTokens < last.cacheReadInputTokens ||
         cum.cacheCreationInputTokens < last.cacheCreationInputTokens);
-    const base = reset || last === undefined
-      ? { costUSD: 0, inputTokens: 0, outputTokens: 0, cacheReadInputTokens: 0, cacheCreationInputTokens: 0 }
-      : last;
+    const unbaselined = reset || last === undefined;
+    const observed =
+      observedTurnUsage?.get(model) ?? observedTurnUsage?.get(model.replace(/\[[^\]]*\]\s*$/, ''));
+    const observedMatchesCumulative =
+      observed !== undefined &&
+      cum.inputTokens === observed.inputTokens &&
+      cum.outputTokens === observed.outputTokens &&
+      cum.cacheReadInputTokens === observed.cacheReadTokens &&
+      cum.cacheCreationInputTokens === observed.cacheCreateTokens;
+    const base = unbaselined ? cum : last;
 
     const entry: ModelUsageDeltaEntry = {
       model,
-      costUsdDelta: Math.max(0, cum.costUSD - base.costUSD),
-      inputTokensDelta: Math.max(0, cum.inputTokens - base.inputTokens),
-      outputTokensDelta: Math.max(0, cum.outputTokens - base.outputTokens),
-      cacheReadTokensDelta: Math.max(0, cum.cacheReadInputTokens - base.cacheReadInputTokens),
-      cacheCreateTokensDelta: Math.max(0, cum.cacheCreationInputTokens - base.cacheCreationInputTokens),
+      // A first snapshot after desktop restart/reattach may contain the whole
+      // provider session. Only treat its cumulative cost as this turn when the
+      // independently observed request segments prove the token totals match.
+      costUsdDelta: unbaselined
+        ? observedMatchesCumulative
+          ? cum.costUSD
+          : 0
+        : Math.max(0, cum.costUSD - base.costUSD),
+      inputTokensDelta:
+        observed && unbaselined
+          ? observed.inputTokens
+          : Math.max(0, cum.inputTokens - base.inputTokens),
+      outputTokensDelta:
+        observed && unbaselined
+          ? observed.outputTokens
+          : Math.max(0, cum.outputTokens - base.outputTokens),
+      cacheReadTokensDelta:
+        observed && unbaselined
+          ? observed.cacheReadTokens
+          : Math.max(0, cum.cacheReadInputTokens - base.cacheReadInputTokens),
+      cacheCreateTokensDelta:
+        observed && unbaselined
+          ? observed.cacheCreateTokens
+          : Math.max(0, cum.cacheCreationInputTokens - base.cacheCreationInputTokens),
     };
     next.set(model, cum);
     if (

--- a/apps/desktop/src/main/usage/turnCostCalculator.ts
+++ b/apps/desktop/src/main/usage/turnCostCalculator.ts
@@ -4,19 +4,16 @@
 
 import type { CindyRegion } from '@cindy/maker-shared/brand-identity';
 
-import {
-  gatewayLedgerCurrency,
-  getModelPriceQuote,
-} from '../../shared/modelPriceQuote.js';
+import { gatewayLedgerCurrency, getModelPriceQuote } from '../../shared/modelPriceQuote.js';
 import {
   addRegionalMoney,
   toLedgerCurrency,
-  usdMoney,
   usdToLedgerCurrency,
   type ModelPriceQuote,
   type ModelPricingCatalog,
   type MoneyCurrency,
   type MoneyEstimateReason,
+  type PriceVariant,
   type RegionalMoney,
 } from '../../shared/regionalMoney.js';
 import { buildTurnUsageDetails, type TurnUsageDetails } from '../../shared/turnUsageDetails.js';
@@ -29,6 +26,68 @@ export interface TurnTokenDeltas {
   outputTokens: number;
   cacheReadTokens: number;
   cacheCreateTokens: number;
+}
+
+export interface TurnUsageSegment extends TurnTokenDeltas {
+  id?: string;
+  model?: string;
+  priceVariant?: PriceVariant;
+  costUsd?: number;
+  complete?: boolean;
+}
+
+function finiteNonNegative(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : 0;
+}
+
+export function normalizeTurnUsageSegments(value: unknown): TurnUsageSegment[] {
+  if (!Array.isArray(value)) return [];
+  const segments: TurnUsageSegment[] = [];
+  for (const item of value) {
+    if (!item || typeof item !== 'object' || Array.isArray(item)) continue;
+    const raw = item as Record<string, unknown>;
+    const segment: TurnUsageSegment = {
+      inputTokens: finiteNonNegative(raw.inputTokens),
+      outputTokens: finiteNonNegative(raw.outputTokens),
+      cacheReadTokens: finiteNonNegative(raw.cacheReadTokens),
+      cacheCreateTokens: finiteNonNegative(raw.cacheCreateTokens),
+    };
+    const costUsd = finiteNonNegative(raw.costUsd);
+    if (
+      segment.inputTokens === 0 &&
+      segment.outputTokens === 0 &&
+      segment.cacheReadTokens === 0 &&
+      segment.cacheCreateTokens === 0 &&
+      costUsd === 0
+    )
+      continue;
+    if (typeof raw.id === 'string' && raw.id) segment.id = raw.id;
+    if (typeof raw.model === 'string' && raw.model.trim()) segment.model = raw.model.trim();
+    if (
+      raw.priceVariant === 'standard' ||
+      raw.priceVariant === 'priority' ||
+      raw.priceVariant === 'fast' ||
+      raw.priceVariant === 'batch'
+    ) {
+      segment.priceVariant = raw.priceVariant;
+    }
+    if (costUsd > 0) segment.costUsd = costUsd;
+    if (raw.complete === true || raw.complete === false) segment.complete = raw.complete;
+    segments.push(segment);
+  }
+  return segments;
+}
+
+export function sumTurnUsageSegments(segments: readonly TurnUsageSegment[]): TurnTokenDeltas {
+  return segments.reduce(
+    (sum, segment) => ({
+      inputTokens: sum.inputTokens + segment.inputTokens,
+      outputTokens: sum.outputTokens + segment.outputTokens,
+      cacheReadTokens: sum.cacheReadTokens + segment.cacheReadTokens,
+      cacheCreateTokens: sum.cacheCreateTokens + segment.cacheCreateTokens,
+    }),
+    { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreateTokens: 0 },
+  );
 }
 
 export type BillingRoute = 'xd-gateway' | 'provider-api' | 'subscription' | 'unknown';
@@ -79,22 +138,23 @@ export function isAnthropicModel(normalizedModel: string): boolean {
   );
 }
 
-/**
- * token × quote → quote 币种金额。cache 价缺失时按输入价计，和详情文案一致。
- */
+/** token × quote → quote 币种金额。缺少实际使用桶的价格时拒绝猜价。 */
 export function computeGatewayTurnCost(
   tokens: TurnTokenDeltas,
   price: ModelPriceQuote | undefined,
+  variant: PriceVariant = 'standard',
 ): number | null {
   if (!price) return null;
-  const totalInputTokens =
-    tokens.inputTokens + tokens.cacheReadTokens + tokens.cacheCreateTokens;
-  const band = price.inputTokenPriceBands
+  if (variant === 'batch') return null;
+  const priority = variant === 'priority' || variant === 'fast';
+  const tariff = priority ? price.priority : price;
+  if (!tariff) return null;
+  const totalInputTokens = tokens.inputTokens + tokens.cacheReadTokens + tokens.cacheCreateTokens;
+  const band = tariff.inputTokenPriceBands
     ?.filter(
       (candidate) =>
         totalInputTokens >= candidate.minInputTokens &&
-        (candidate.maxInputTokens === undefined ||
-          totalInputTokens < candidate.maxInputTokens),
+        (candidate.maxInputTokens === undefined || totalInputTokens < candidate.maxInputTokens),
     )
     .sort((a, b) => b.minInputTokens - a.minInputTokens)[0];
   // Provider reference bands describe the complete set of ranges for which the
@@ -102,22 +162,50 @@ export function computeGatewayTurnCost(
   // would silently extend a bounded quote (for example <200k) to the model's
   // whole context window. Gateway bands remain overlays because its legacy
   // threshold fields intentionally omit the baseline range.
-  if (price.inputTokenPriceBands?.length && !band && price.source !== 'gateway') {
+  if (tariff.inputTokenPriceBands?.length && !band && price.source !== 'gateway') {
     return null;
   }
-  const inputPrice = band?.inputPerMtok ?? price.inputPerMtok;
-  const outputPrice = band?.outputPerMtok ?? price.outputPerMtok;
-  const cacheReadPrice =
-    band?.cacheReadPerMtok ?? price.cacheReadPerMtok ?? inputPrice;
+  const inputPrice = band?.inputPerMtok ?? tariff.inputPerMtok;
+  const outputPrice = band?.outputPerMtok ?? tariff.outputPerMtok;
+  const cacheReadPrice = band?.cacheReadPerMtok ?? tariff.cacheReadPerMtok;
+  // Gateway currently publishes no dedicated Priority cache-write field. Its
+  // contract keeps cache creation on the standard tariff while Fast changes
+  // input/output/cache-read prices. Do not turn every cached Claude Fast
+  // request into an unpriceable turn merely because that redundant field is
+  // absent from the Priority overlay.
   const cacheCreatePrice =
-    band?.cacheCreatePerMtok ?? price.cacheCreatePerMtok ?? inputPrice;
+    band?.cacheCreatePerMtok ??
+    tariff.cacheCreatePerMtok ??
+    (priority ? price.cacheCreatePerMtok : undefined);
+  if (
+    (tokens.inputTokens > 0 && inputPrice === undefined) ||
+    (tokens.outputTokens > 0 && outputPrice === undefined) ||
+    (tokens.cacheReadTokens > 0 && cacheReadPrice === undefined) ||
+    (tokens.cacheCreateTokens > 0 && cacheCreatePrice === undefined)
+  ) {
+    return null;
+  }
   return (
-    (tokens.inputTokens * inputPrice +
-      tokens.outputTokens * outputPrice +
-      tokens.cacheReadTokens * cacheReadPrice +
-      tokens.cacheCreateTokens * cacheCreatePrice) /
+    (tokens.inputTokens * (inputPrice ?? 0) +
+      tokens.outputTokens * (outputPrice ?? 0) +
+      tokens.cacheReadTokens * (cacheReadPrice ?? 0) +
+      tokens.cacheCreateTokens * (cacheCreatePrice ?? 0)) /
     1_000_000
   );
+}
+
+export function computeGatewaySegmentedTurnCost(
+  segments: readonly TurnUsageSegment[],
+  price: ModelPriceQuote | undefined,
+): number | null {
+  if (!price || segments.length === 0) return null;
+  let total = 0;
+  for (const segment of segments) {
+    const amount = computeGatewayTurnCost(segment, price, segment.priceVariant ?? 'standard');
+    if (amount == null) return null;
+    total += amount;
+  }
+  return total;
 }
 
 /**
@@ -129,9 +217,13 @@ export function computePriceQuoteTurnMoney(
   tokens: TurnTokenDeltas,
   price: ModelPriceQuote | undefined,
   ledgerCurrency: MoneyCurrency,
+  segments?: readonly TurnUsageSegment[],
 ): RegionalMoney | null {
   if (!price) return null;
-  const standardAmount = computeGatewayTurnCost(tokens, price);
+  const standardAmount =
+    segments !== undefined
+      ? computeGatewaySegmentedTurnCost(segments, price)
+      : computeGatewayTurnCost(tokens, price);
   if (standardAmount == null) return null;
   const discount =
     price.source === 'gateway' &&
@@ -184,8 +276,9 @@ export function resolveTurnCost(args: {
   sdkCostDelta?: number;
   pricing: ModelPricingCatalog | null | undefined;
   context: TurnPricingContext;
+  segments?: readonly TurnUsageSegment[];
 }): TurnCostResolution {
-  const { rawModel, tokens, sdkCostDelta, pricing, context } = args;
+  const { rawModel, tokens, sdkCostDelta, pricing, context, segments } = args;
   const model = normalizeModelIdForPricing(rawModel);
 
   // An explicit provider API route is authoritative. User-defined providers may legitimately
@@ -211,21 +304,11 @@ export function resolveTurnCost(args: {
     // 窗口，不代表这一轮真的超过阈值）。
     const quote = getModelPriceQuote(pricing, 'xd', model);
     if (!quote) {
-      // 该模型没有报价(上游未登记,或目录还没同步下来)。SDK 的 costDelta 是 USD,
-      // 只有账本币种同为 USD 时才能直接兜底记账 —— 这样以 USD 结算的账号不会漏记。
-      //
-      // 币种不同(CNY 账本)仍然不兜底:SDK 值既不是该账号的报价口径、也不含 costDiscount,
-      // 折算进去只会误记,宁可这一轮不记。
-      const fallbackUsd = Math.max(0, sdkCostDelta ?? 0);
-      return {
-        model,
-        money: ledgerCurrency === 'USD' && fallbackUsd > 0 ? usdMoney(fallbackUsd) : null,
-        source: 'sdk-fallback',
-      };
+      return { model, money: null, source: 'sdk-fallback' };
     }
     return {
       model,
-      money: computePriceQuoteTurnMoney(tokens, quote, ledgerCurrency),
+      money: computePriceQuoteTurnMoney(tokens, quote, ledgerCurrency, segments),
       source: 'gateway',
     };
   }
@@ -245,29 +328,31 @@ export function resolveTurnCost(args: {
   // 分桶重算并保留 value-estimate 标记；只有 cost 增量或目录价格不覆盖本轮时仍退回
   // SDK，避免把有费用但无 token 明细的轮次误算成 $0。
   if (context.providerId === 'deepseek' && providerQuote && hasTokenDeltas) {
-    const referenceMoney = computePriceQuoteTurnMoney(tokens, providerQuote, ledgerCurrency);
+    const referenceMoney = computePriceQuoteTurnMoney(
+      tokens,
+      providerQuote,
+      ledgerCurrency,
+      segments,
+    );
     if (referenceMoney) {
-      return {
-        model,
-        money: referenceMoney,
-        source: 'reference',
-      };
+      return { model, money: referenceMoney, source: 'reference' };
+    }
+    if (segments !== undefined) {
+      return { model, money: null, source: 'reference' };
     }
   }
 
   // 其它第三方供应商 / 未知路由:SDK 值是 USD 口径,投影到账本币种而不是构建区域,
   // 否则 USD 结算账号上这些花费会变成 CNY 并被账本守卫丢弃。
   const sdkAmount = Math.max(0, sdkCostDelta ?? 0);
-  if (sdkAmount > 0) {
-    return {
-      model,
-      money: usdToLedgerCurrency(sdkAmount, ledgerCurrency),
-      source: context.billingRoute === 'provider-api' ? 'sdk' : 'sdk-fallback',
-    };
+  if (context.billingRoute === 'provider-api' && sdkAmount > 0) {
+    return { model, money: usdToLedgerCurrency(sdkAmount, ledgerCurrency), source: 'sdk' };
   }
   return {
     model,
-    money: providerQuote ? computePriceQuoteTurnMoney(tokens, providerQuote, ledgerCurrency) : null,
+    money: providerQuote
+      ? computePriceQuoteTurnMoney(tokens, providerQuote, ledgerCurrency, segments)
+      : null,
     source: context.billingRoute === 'provider-api' ? 'reference' : 'sdk-fallback',
   };
 }
@@ -277,6 +362,7 @@ export interface ResolvedModelCost {
   money: RegionalMoney | null;
   source: TurnCostSource;
   deltas: TurnTokenDeltas;
+  segments?: TurnUsageSegment[];
 }
 
 export interface ClaudeTurnCostResolution {
@@ -291,11 +377,105 @@ export function resolveClaudeTurnCostSinks(
   modelDeltas: ModelUsageDeltaEntry[],
   pricing: ModelPricingCatalog | null | undefined,
   context: TurnPricingContext,
+  usageSegments?: readonly TurnUsageSegment[],
+  usageSegmentsComplete = false,
 ): ClaudeTurnCostResolution {
+  type DeltaWithSegments = ModelUsageDeltaEntry & { segments?: TurnUsageSegment[] };
+  const effectiveDeltas: DeltaWithSegments[] =
+    usageSegments === undefined
+      ? modelDeltas
+      : (() => {
+          const observedByModel = new Map<
+            string,
+            { all: TurnUsageSegment[]; priceable: TurnUsageSegment[] }
+          >();
+          for (const segment of usageSegments) {
+            const model = normalizeModelIdForPricing(segment.model);
+            const group = observedByModel.get(model) ?? { all: [], priceable: [] };
+            const copy = { ...segment };
+            group.all.push(copy);
+            if (usageSegmentsComplete || segment.complete === true) {
+              group.priceable.push(copy);
+            }
+            observedByModel.set(model, group);
+          }
+          const cumulativeByModel = new Map(
+            modelDeltas.map((delta) => [normalizeModelIdForPricing(delta.model), delta]),
+          );
+          const models = new Set([...observedByModel.keys(), ...cumulativeByModel.keys()]);
+          const values: DeltaWithSegments[] = [];
+          for (const model of models) {
+            const observed = observedByModel.get(model);
+            const cumulative = cumulativeByModel.get(model);
+            const observedTotals = sumTurnUsageSegments(observed?.all ?? []);
+            const priceableSegments = observed?.priceable ?? [];
+            const priceableTotals = sumTurnUsageSegments(priceableSegments);
+            const target: TurnTokenDeltas = {
+              inputTokens: Math.max(observedTotals.inputTokens, cumulative?.inputTokensDelta ?? 0),
+              outputTokens: Math.max(
+                observedTotals.outputTokens,
+                cumulative?.outputTokensDelta ?? 0,
+              ),
+              cacheReadTokens: Math.max(
+                observedTotals.cacheReadTokens,
+                cumulative?.cacheReadTokensDelta ?? 0,
+              ),
+              cacheCreateTokens: Math.max(
+                observedTotals.cacheCreateTokens,
+                cumulative?.cacheCreateTokensDelta ?? 0,
+              ),
+            };
+            let remainingCost = cumulative?.costUsdDelta ?? 0;
+            if (priceableSegments.length > 0) {
+              values.push({
+                model,
+                costUsdDelta: remainingCost,
+                inputTokensDelta: priceableTotals.inputTokens,
+                outputTokensDelta: priceableTotals.outputTokens,
+                cacheReadTokensDelta: priceableTotals.cacheReadTokens,
+                cacheCreateTokensDelta: priceableTotals.cacheCreateTokens,
+                segments: priceableSegments,
+              });
+              // Provider-reported cost is already represented once. The
+              // unpriceable residual below carries token facts only.
+              remainingCost = 0;
+            }
+            const residual = {
+              inputTokensDelta: Math.max(0, target.inputTokens - priceableTotals.inputTokens),
+              outputTokensDelta: Math.max(0, target.outputTokens - priceableTotals.outputTokens),
+              cacheReadTokensDelta: Math.max(
+                0,
+                target.cacheReadTokens - priceableTotals.cacheReadTokens,
+              ),
+              cacheCreateTokensDelta: Math.max(
+                0,
+                target.cacheCreateTokens - priceableTotals.cacheCreateTokens,
+              ),
+            };
+            if (
+              remainingCost > 0 ||
+              residual.inputTokensDelta > 0 ||
+              residual.outputTokensDelta > 0 ||
+              residual.cacheReadTokensDelta > 0 ||
+              residual.cacheCreateTokensDelta > 0
+            ) {
+              values.push({
+                model,
+                costUsdDelta: remainingCost,
+                ...residual,
+                // Never collapse an unmatched aggregate or unfinished request
+                // into one synthetic provider call. Only explicitly completed
+                // request segments above are eligible for token pricing.
+                segments: [],
+              });
+            }
+          }
+          return values;
+        })();
   const perModel: ResolvedModelCost[] = [];
   const actualMoney: RegionalMoney[] = [];
   const estimatedMoney: RegionalMoney[] = [];
-  for (const delta of modelDeltas) {
+  for (const delta of effectiveDeltas) {
     const tokens: TurnTokenDeltas = {
       inputTokens: delta.inputTokensDelta,
       outputTokens: delta.outputTokensDelta,
@@ -308,12 +488,14 @@ export function resolveClaudeTurnCostSinks(
       sdkCostDelta: delta.costUsdDelta,
       pricing,
       context,
+      segments: delta.segments,
     });
     perModel.push({
       model: resolved.model,
       money: resolved.money,
       source: resolved.source,
       deltas: tokens,
+      ...(delta.segments ? { segments: delta.segments } : {}),
     });
     if (resolved.money && resolved.money.amount > 0) {
       (resolved.money.kind === 'actual-cost' ? actualMoney : estimatedMoney).push(resolved.money);
@@ -321,8 +503,7 @@ export function resolveClaudeTurnCostSinks(
   }
   return {
     turnMoney: actualMoney.length > 0 ? addRegionalMoney(actualMoney) : null,
-    estimatedTurnMoney:
-      estimatedMoney.length > 0 ? addRegionalMoney(estimatedMoney) : null,
+    estimatedTurnMoney: estimatedMoney.length > 0 ? addRegionalMoney(estimatedMoney) : null,
     perModel,
   };
 }

--- a/apps/desktop/src/main/usage/usageHistory.ts
+++ b/apps/desktop/src/main/usage/usageHistory.ts
@@ -390,7 +390,10 @@ export function getSubscriptionValuePriceFor(
       getClaudeSubscriptionValuePrice(model, pricing, at, overrides)
     );
   }
-  return getClaudeSubscriptionValuePrice(model, pricing, at, overrides);
+  return (
+    getSubscriptionDirectValuePrice(model, 'claude-code', pricing, at, overrides) ??
+    getClaudeSubscriptionValuePrice(model, pricing, at, overrides)
+  );
 }
 
 async function hydrateFromDisk(expectedOptsKey: string): Promise<UsageHistoryPayload | null> {
@@ -547,7 +550,9 @@ export async function readUsageHistoryWith(
     estimateReasons: ['subscription-value'],
   });
   const keepCompatibleMoney = (money: RegionalMoney): RegionalMoney =>
-    money.currency === ledgerCurrency ? money : zeroActual();
+    money.currency === ledgerCurrency
+      ? money
+      : { ...money, amount: 0, currency: ledgerCurrency };
   const addOrZero = (
     values: RegionalMoney[],
     kind: 'actual-cost' | 'value-estimate' = 'actual-cost',
@@ -606,6 +611,7 @@ export async function readUsageHistoryWith(
   const priceOverrides = deps.getModelPriceOverridesSnapshot();
   const hasMissingPendingSubscriptionPrice = modelRows.some((r) =>
     isSubscriptionUsageModel(r.model) &&
+    r.money.kind !== 'value-estimate' &&
     !getSubscriptionValuePriceFor(
       r.agentKind === 'codex' ? 'codex' : r.agentKind === 'pi' ? 'pi' : 'claude-code',
       displayModelName(r.model),
@@ -647,7 +653,7 @@ export async function readUsageHistoryWith(
       };
       byKey.set(key, agg);
     }
-    if (row.money.amount > 0) {
+    if (row.money.amount > 0 && row.money.kind === 'actual-cost') {
       agg.money =
         agg.money.amount > 0
           ? (addCompatibleRegionalMoney([agg.money, row.money], ledgerCurrency) ?? row.money)
@@ -657,12 +663,17 @@ export async function readUsageHistoryWith(
     agg.outputTokens += row.outputTokens;
     agg.cacheReadTokens += row.cacheReadTokens;
     agg.cacheCreateTokens += row.cacheCreateTokens;
-    if (row.money.amount === 0 && isSubscriptionUsageModel(row.model)) {
-      const estimate = computePriceQuoteTurnMoney(
-        row,
-        getSubscriptionValuePriceFor(agentKind, model, pricing, row.day, priceOverrides),
-        ledgerCurrency,
-      );
+    if (isSubscriptionUsageModel(row.model)) {
+      const estimate =
+        row.money.kind === 'value-estimate' && row.money.amount > 0
+          ? row.money
+          : row.money.kind !== 'value-estimate' && row.money.amount === 0
+            ? computePriceQuoteTurnMoney(
+                row,
+                getSubscriptionValuePriceFor(agentKind, model, pricing, row.day, priceOverrides),
+                ledgerCurrency,
+              )
+            : null;
       if (estimate?.amount) {
         const estimates = subscriptionEstimatesByKey.get(key) ?? [];
         estimates.push(estimate);
@@ -689,17 +700,19 @@ export async function readUsageHistoryWith(
         ? ('pi' as const)
         : ('claude-code' as const);
     const model = displayModelName(row.model);
-    const apiMoney = row.money;
-    const subscriptionEstimateMoney =
-      apiMoney.amount === 0 && isSubscriptionUsageModel(row.model)
-        ? (computePriceQuoteTurnMoney(
-            row,
-            getSubscriptionValuePriceFor(agentKind, model, pricing, row.day, priceOverrides),
-            ledgerCurrency,
-          ) ?? zeroEstimate())
-        : zeroEstimate();
-    const money =
-      apiMoney.amount > 0 ? apiMoney : subscriptionEstimateMoney;
+    const apiMoney = row.money.kind === 'actual-cost' ? row.money : zeroActual();
+    const subscriptionEstimateMoney = isSubscriptionUsageModel(row.model)
+      ? row.money.kind === 'value-estimate' && row.money.amount > 0
+        ? row.money
+        : row.money.kind !== 'value-estimate'
+          ? (computePriceQuoteTurnMoney(
+              row,
+              getSubscriptionValuePriceFor(agentKind, model, pricing, row.day, priceOverrides),
+              ledgerCurrency,
+            ) ?? zeroEstimate())
+          : zeroEstimate()
+      : zeroEstimate();
+    const money = apiMoney.amount > 0 ? apiMoney : subscriptionEstimateMoney;
     return {
       day: row.day,
       agentKind,

--- a/apps/desktop/src/renderer/vite-env.d.ts
+++ b/apps/desktop/src/renderer/vite-env.d.ts
@@ -669,7 +669,7 @@ interface CodexUsageSnapshot {
   completionTokens: number;
   reasoningTokens: number;
   cachedTokens: number;
-  /** = prompt + completion + reasoning + cached */
+  /** = prompt + completion + cached; reasoning is a diagnostic subset of completion */
   total: number;
 }
 

--- a/apps/desktop/src/shared/__tests__/modelPriceQuote.test.ts
+++ b/apps/desktop/src/shared/__tests__/modelPriceQuote.test.ts
@@ -87,6 +87,31 @@ describe('gatewayPricingCatalog', () => {
       costDiscount: 0.4,
     });
   });
+
+  it('preserves Fast/Priority baseline and long-context prices', () => {
+    const catalog = gatewayPricingCatalog(
+      [
+        model('fast-model', {
+          inputCostPerTokenPriority: 0.00001,
+          outputCostPerTokenPriority: 0.00006,
+          cacheReadInputTokenCostPriority: 0.000001,
+          inputCostPerTokenAbove272kTokensPriority: 0.00002,
+          outputCostPerTokenAbove272kTokensPriority: 0.00009,
+          cacheReadInputTokenCostAbove272kTokensPriority: 0.000002,
+        }),
+      ],
+      'USD',
+    );
+
+    expect(catalog.xd['fast-model']?.priority).toMatchObject({
+      inputPerMtok: 10,
+      outputPerMtok: 60,
+      cacheReadPerMtok: 1,
+      inputTokenPriceBands: [
+        { minInputTokens: 272_001, inputPerMtok: 20, outputPerMtok: 90, cacheReadPerMtok: 2 },
+      ],
+    });
+  });
 });
 
 describe('registryPricingCatalog', () => {

--- a/apps/desktop/src/shared/modelPriceQuote.ts
+++ b/apps/desktop/src/shared/modelPriceQuote.ts
@@ -81,6 +81,31 @@ function gatewayInputTokenPriceBands(
   return thresholdBands.length > 0 ? thresholdBands : undefined;
 }
 
+function gatewayPriorityInputTokenPriceBands(
+  model: ModelAccessGatewayModel,
+): ModelPriceQuote['inputTokenPriceBands'] {
+  const thresholdBands = [
+    {
+      minInputTokens: 200_001,
+      inputPerMtok: perMtok(model.inputCostPerTokenAbove200kTokensPriority),
+      outputPerMtok: perMtok(model.outputCostPerTokenAbove200kTokensPriority),
+      cacheReadPerMtok: perMtok(model.cacheReadInputTokenCostAbove200kTokensPriority),
+    },
+    {
+      minInputTokens: 272_001,
+      inputPerMtok: perMtok(model.inputCostPerTokenAbove272kTokensPriority),
+      outputPerMtok: perMtok(model.outputCostPerTokenAbove272kTokensPriority),
+      cacheReadPerMtok: perMtok(model.cacheReadInputTokenCostAbove272kTokensPriority),
+    },
+  ].filter(
+    (tier) =>
+      tier.inputPerMtok !== undefined ||
+      tier.outputPerMtok !== undefined ||
+      tier.cacheReadPerMtok !== undefined,
+  );
+  return thresholdBands.length > 0 ? thresholdBands : undefined;
+}
+
 /** 该条目是否会产生报价(与币种无关;目录币种裁决与覆盖率统计共用此判定)。 */
 export function isPricedGatewayModel(model: ModelAccessGatewayModel): boolean {
   // 币种不影响“是否有价格”的判断，随便传一个具体币种即可。
@@ -106,6 +131,10 @@ export function gatewayModelPriceQuote(
   }
   const cacheReadPerMtok = perMtok(model.cacheReadInputTokenCost);
   const cacheCreatePerMtok = perMtok(model.cacheCreationInputTokenCost);
+  const priorityInputPerMtok = perMtok(model.inputCostPerTokenPriority);
+  const priorityOutputPerMtok = perMtok(model.outputCostPerTokenPriority);
+  const priorityCacheReadPerMtok = perMtok(model.cacheReadInputTokenCostPriority);
+  const priorityInputTokenPriceBands = gatewayPriorityInputTokenPriceBands(model);
   if (
     inputPerMtok === 0 &&
     outputPerMtok === 0 &&
@@ -129,6 +158,25 @@ export function gatewayModelPriceQuote(
     outputPerMtok,
     ...(cacheReadPerMtok !== undefined ? { cacheReadPerMtok } : {}),
     ...(cacheCreatePerMtok !== undefined ? { cacheCreatePerMtok } : {}),
+    ...(priorityInputPerMtok !== undefined ||
+    priorityOutputPerMtok !== undefined ||
+    priorityCacheReadPerMtok !== undefined ||
+    priorityInputTokenPriceBands
+      ? {
+          priority: {
+            ...(priorityInputPerMtok !== undefined ? { inputPerMtok: priorityInputPerMtok } : {}),
+            ...(priorityOutputPerMtok !== undefined
+              ? { outputPerMtok: priorityOutputPerMtok }
+              : {}),
+            ...(priorityCacheReadPerMtok !== undefined
+              ? { cacheReadPerMtok: priorityCacheReadPerMtok }
+              : {}),
+            ...(priorityInputTokenPriceBands
+              ? { inputTokenPriceBands: priorityInputTokenPriceBands }
+              : {}),
+          },
+        }
+      : {}),
     ...(inputTokenPriceBands ? { inputTokenPriceBands } : {}),
     ...(costDiscount !== undefined ? { costDiscount } : {}),
     ...(!declaredCurrency && fallbackIsInferred ? { currencyInferred: true } : {}),

--- a/apps/desktop/src/shared/regionalMoney.ts
+++ b/apps/desktop/src/shared/regionalMoney.ts
@@ -4,6 +4,7 @@ import { CURRENT_CINDY_REGION } from './brandRegion.js';
 
 export type MoneyCurrency = 'CNY' | 'USD';
 export type MoneyKind = 'actual-cost' | 'value-estimate';
+export type PriceVariant = 'standard' | 'priority' | 'fast' | 'batch';
 export type MoneyEstimateReason =
   'fixed-fx' | 'legacy-usd' | 'subscription-value' | 'reference-price' | 'inferred-currency';
 
@@ -35,6 +36,14 @@ export interface ModelPriceQuote {
   outputPerMtok: number;
   cacheReadPerMtok?: number;
   cacheCreatePerMtok?: number;
+  /** Gateway fast/priority tariff. Missing fields make that request unpriceable. */
+  priority?: {
+    inputPerMtok?: number;
+    outputPerMtok?: number;
+    cacheReadPerMtok?: number;
+    cacheCreatePerMtok?: number;
+    inputTokenPriceBands?: ModelPriceQuote['inputTokenPriceBands'];
+  };
   /**
    * Context-length pricing bands. minInputTokens is inclusive and maxInputTokens
    * is exclusive; omitted prices inherit the quote's baseline field.

--- a/packages/anthropic-responses-bridge/src/__tests__/handler.test.ts
+++ b/packages/anthropic-responses-bridge/src/__tests__/handler.test.ts
@@ -104,6 +104,7 @@ describe('createResponsesHandler', () => {
     expect(r.status).toBe(200);
     expect(r.text).toContain('message_start');
     expect(r.text).toContain('"chatgpt/gpt-5.5"'); // message_start 回显带前缀 model(记账判据)
+    expect(r.text).toContain('"service_tier":"priority"');
     expect(r.text).toContain('message_stop');
     expect(seen).toHaveLength(1);
     expect(seen[0].url).toBe('https://upstream.example/responses');
@@ -113,8 +114,9 @@ describe('createResponsesHandler', () => {
 
     // fast=false / provider 无 fastServiceTier → 不发 service_tier。
     seen.length = 0;
-    await invoke(handler, { model: 'chatgpt/gpt-5.5', messages: [], stream: true }, { prefs: { fast: false } });
+    const standard = await invoke(handler, { model: 'chatgpt/gpt-5.5', messages: [], stream: true }, { prefs: { fast: false } });
     expect(seen[0].body.service_tier).toBeUndefined();
+    expect(standard.text).toContain('"service_tier":"default"');
   });
 
   it('上游 200 但整流零事件(非 SSE 正文)→ 合成带正文前缀的 error 事件而非空 200,并留 warn(#941)', async () => {

--- a/packages/anthropic-responses-bridge/src/handler.ts
+++ b/packages/anthropic-responses-bridge/src/handler.ts
@@ -400,7 +400,7 @@ export function createResponsesHandler(opts: ResponsesHandlerOptions): Responses
     // 完整的 Anthropic Message JSON。上游恒回 SSE(只接受流式),所以这里缓冲整流后组装;
     // 同时兼容个别上游直接给 Responses JSON 的情况。
     if (!downstreamStreaming) {
-      const translator = new SseTranslator(wireModel);
+      const translator = new SseTranslator(wireModel, serviceTier ?? 'default');
       const collector = new AnthropicMessageCollector();
       const collect = (event: AnthropicSseEvent): void => collector.push(event);
       try {
@@ -457,7 +457,7 @@ export function createResponsesHandler(opts: ResponsesHandlerOptions): Responses
 
     // 用 wireModel(带前缀,如 chatgpt/gpt-5.5)而非 realModel 构造 —— message_start 回显带前缀 id,
     // CC 的 modelUsage 据此记账,下游 usage 可按前缀区分订阅轮,不与真网关同名裸模型混淆。
-    const translator = new SseTranslator(wireModel);
+    const translator = new SseTranslator(wireModel, serviceTier ?? 'default');
     const reader = upstream.body.getReader();
     const decoder = new TextDecoder();
     let buf = '';

--- a/packages/anthropic-responses-bridge/src/translate-sse.ts
+++ b/packages/anthropic-responses-bridge/src/translate-sse.ts
@@ -91,6 +91,8 @@ export class SseTranslator {
   /** 当前打开的 Anthropic 块所属 item 的 output_index;null = 没有块打开(单开块不变量)。 */
   private openOutputIndex: number | null = null;
   private model: string;
+  /** Host-selected tier for this concrete provider request; carried in usage so Pi can latch it. */
+  private readonly serviceTier?: string;
   /** 构造时传入非空 model 即 pin —— message_start 固定用它,不被上游回显的裸 model 覆盖。 */
   private readonly modelPinned: boolean;
   /**
@@ -100,8 +102,9 @@ export class SseTranslator {
    */
   private readonly signaturePrefix: string;
 
-  constructor(model: string) {
+  constructor(model: string, serviceTier?: string) {
     this.model = model;
+    this.serviceTier = serviceTier;
     this.modelPinned = model.length > 0;
     const slash = model.indexOf('/');
     this.signaturePrefix = slash > 0 ? model.slice(0, slash + 1) : '';
@@ -329,7 +332,13 @@ export class SseTranslator {
           content: [],
           stop_reason: null,
           stop_sequence: null,
-          usage: { input_tokens: 0, output_tokens: 0, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 },
+          usage: {
+            input_tokens: 0,
+            output_tokens: 0,
+            cache_read_input_tokens: 0,
+            cache_creation_input_tokens: 0,
+            ...(this.serviceTier !== undefined ? { service_tier: this.serviceTier } : {}),
+          },
         },
       },
     });
@@ -583,6 +592,7 @@ export class SseTranslator {
           output_tokens: usage.output_tokens,
           cache_read_input_tokens: usage.cache_read_input_tokens,
           cache_creation_input_tokens: usage.cache_creation_input_tokens,
+          ...(this.serviceTier !== undefined ? { service_tier: this.serviceTier } : {}),
         },
       },
     });

--- a/packages/maker-core/src/agents/base-agent.ts
+++ b/packages/maker-core/src/agents/base-agent.ts
@@ -1361,6 +1361,12 @@ export interface StartSessionOptions {
    * Undefined means do not override the agent/server default.
    */
   fastMode?: boolean;
+  /**
+   * Host-owned live pricing variant for request-level usage segments.
+   * Pi reads this at each provider request boundary so a mid-turn Fast toggle
+   * prices already-started requests with the tariff they actually used.
+   */
+  getPriceVariant?: () => 'standard' | 'priority';
   /** Pi + thinking-toggle 模型：false 时启动即关思考。缺省保持模型默认（开）。 */
   thinkingEnabled?: boolean;
   /**

--- a/packages/maker-core/src/agents/claude-code/__tests__/invalid-resume-recovery.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/invalid-resume-recovery.test.ts
@@ -283,6 +283,11 @@ describe('Claude invalid-resume recovery', () => {
     expect(clear).toHaveBeenCalledTimes(1);
     expect(h.events.filter((event) => event.type === 'error')).toHaveLength(0);
     expect(h.events).toContainEqual({ type: 'session_id', data: 'sdk-fresh', source: 'claude-code' });
+    expect(
+      (h.events.find((event) => event.type === 'done')?.data as {
+        modelUsageCumulativeStartsAtZero?: boolean;
+      }).modelUsageCumulativeStartsAtZero,
+    ).toBe(true);
     await vi.waitFor(() => expect(h.consumedInputs[1]?.length).toBe(1));
 
     await h.handle.close();

--- a/packages/maker-core/src/agents/claude-code/generation-timing.test.ts
+++ b/packages/maker-core/src/agents/claude-code/generation-timing.test.ts
@@ -66,6 +66,7 @@ function createTurnState(): TurnState {
     generation: 0,
     interruptGeneration: 0,
     lastAssistantMsgHadSubstance: true,
+    nextRequestPriceVariant: 'standard',
   };
 }
 
@@ -370,6 +371,82 @@ describe('claude generation pause boundaries', () => {
         },
       ],
     });
+  });
+
+  it('keeps a Claude request on its accepted price variant across a pre-response Fast toggle', () => {
+    let fastMode = false;
+    const ctx = {
+      ...createTranslatorCtx(),
+      getFastMode: () => fastMode,
+    };
+    const queue = createAsyncQueue<AgentEvent>();
+    // The first request was accepted on standard before its message_start
+    // arrived; the user toggles Fast while that response is still in flight.
+    ctx.turn.nextRequestPriceVariant = 'standard';
+    fastMode = true;
+    translateSdkMessage(
+      {
+        type: 'stream_event',
+        event: {
+          type: 'message_start',
+          message: { model: 'claude-sonnet-4.5', usage: { input_tokens: 100 } },
+        },
+      },
+      queue,
+      ctx,
+    );
+    translateSdkMessage(
+      {
+        type: 'stream_event',
+        event: {
+          type: 'message_delta',
+          usage: {
+            input_tokens: 100,
+            output_tokens: 25,
+            cache_read_input_tokens: 0,
+            cache_creation_input_tokens: 0,
+          },
+        },
+      },
+      queue,
+      ctx,
+    );
+
+    // The next provider request is accepted after Fast is enabled and gets
+    // its own priority segment.
+    translateSdkMessage(
+      {
+        type: 'stream_event',
+        event: {
+          type: 'message_start',
+          message: { model: 'claude-sonnet-4.5', usage: { input_tokens: 200 } },
+        },
+      },
+      queue,
+      ctx,
+    );
+    translateSdkMessage(
+      {
+        type: 'stream_event',
+        event: {
+          type: 'message_delta',
+          usage: {
+            input_tokens: 200,
+            output_tokens: 10,
+            cache_read_input_tokens: 0,
+            cache_creation_input_tokens: 0,
+          },
+        },
+      },
+      queue,
+      ctx,
+    );
+
+    expect(ctx.tracker.getTurnUsageSegments()).toEqual([
+      expect.objectContaining({ inputTokens: 100, outputTokens: 25, priceVariant: 'standard' }),
+      expect.objectContaining({ inputTokens: 200, outputTokens: 10, priceVariant: 'priority' }),
+    ]);
+    queue.end();
   });
 
   it('fails closed when a resumed result aggregate cannot prove streamed segment completeness', async () => {

--- a/packages/maker-core/src/agents/claude-code/generation-timing.test.ts
+++ b/packages/maker-core/src/agents/claude-code/generation-timing.test.ts
@@ -11,11 +11,7 @@ import {
   resetClaudeGenerationTiming,
   resumeClaudeGeneration,
 } from './generation-timing.js';
-import {
-  newRuntimeState,
-  translateSdkMessage,
-  type TurnState,
-} from './translator.js';
+import { newRuntimeState, translateSdkMessage, type TurnState } from './translator.js';
 
 describe('claude generation timing', () => {
   afterEach(() => {
@@ -193,7 +189,14 @@ describe('claude generation pause boundaries', () => {
       {
         type: 'assistant',
         message: {
-          content: [{ type: 'tool_use', id: 'toolu_2', name: 'Read', input: { file_path: '/tmp/a' } }],
+          content: [
+            {
+              type: 'tool_use',
+              id: 'toolu_2',
+              name: 'Read',
+              input: { file_path: '/tmp/a' },
+            },
+          ],
         },
       },
       queue,
@@ -216,7 +219,14 @@ describe('claude generation pause boundaries', () => {
       {
         type: 'assistant',
         message: {
-          content: [{ type: 'tool_use', id: 'toolu_3', name: 'Read', input: { file_path: '/tmp/a' } }],
+          content: [
+            {
+              type: 'tool_use',
+              id: 'toolu_3',
+              name: 'Read',
+              input: { file_path: '/tmp/a' },
+            },
+          ],
         },
       },
       queue,
@@ -282,6 +292,145 @@ describe('claude generation pause boundaries', () => {
     vi.useRealTimers();
   });
 
+  it('merges message_start and message_delta usage into one request segment', async () => {
+    const ctx = createTranslatorCtx();
+    const queue = createAsyncQueue<AgentEvent>();
+    translateSdkMessage(
+      {
+        type: 'stream_event',
+        event: {
+          type: 'message_start',
+          message: {
+            model: 'claude-sonnet-4.5',
+            usage: {
+              input_tokens: 100,
+              cache_read_input_tokens: 900,
+              cache_creation_input_tokens: 50,
+            },
+          },
+        },
+      },
+      queue,
+      ctx,
+    );
+    translateSdkMessage(
+      {
+        type: 'stream_event',
+        event: {
+          type: 'message_delta',
+          usage: {
+            input_tokens: 100,
+            output_tokens: 25,
+            cache_read_input_tokens: 900,
+            cache_creation_input_tokens: 50,
+          },
+        },
+      },
+      queue,
+      ctx,
+    );
+    expect(ctx.tracker.getTurnUsage()).toEqual({
+      input: 100,
+      output: 25,
+      cacheRead: 900,
+      cacheCreate: 50,
+    });
+    expect(ctx.tracker.getTurnUsageSegments()).toHaveLength(1);
+
+    translateSdkMessage(
+      {
+        type: 'result',
+        stop_reason: 'end_turn',
+        total_cost_usd: 0,
+        num_turns: 1,
+        usage: {
+          input_tokens: 100,
+          output_tokens: 25,
+          cache_read_input_tokens: 900,
+          cache_creation_input_tokens: 50,
+        },
+      },
+      queue,
+      ctx,
+    );
+    queue.end();
+    const events: AgentEvent[] = [];
+    for await (const event of queue) events.push(event);
+    const done = events.find((event) => event.type === 'done');
+    expect(done?.data).toMatchObject({
+      usageSegmentsComplete: true,
+      usageSegments: [
+        {
+          model: 'claude-sonnet-4.5',
+          inputTokens: 100,
+          outputTokens: 25,
+          cacheReadTokens: 900,
+          cacheCreateTokens: 50,
+          complete: true,
+        },
+      ],
+    });
+  });
+
+  it('fails closed when a resumed result aggregate cannot prove streamed segment completeness', async () => {
+    const ctx = createTranslatorCtx();
+    const queue = createAsyncQueue<AgentEvent>();
+    translateSdkMessage(
+      {
+        type: 'stream_event',
+        event: {
+          type: 'message_start',
+          message: { model: 'claude-sonnet-4.5', usage: { input_tokens: 100 } },
+        },
+      },
+      queue,
+      ctx,
+    );
+    translateSdkMessage(
+      {
+        type: 'stream_event',
+        event: { type: 'message_delta', usage: { output_tokens: 25 } },
+      },
+      queue,
+      ctx,
+    );
+    translateSdkMessage(
+      {
+        type: 'result',
+        stop_reason: 'end_turn',
+        total_cost_usd: 2,
+        num_turns: 1,
+        usage: {
+          // First result after resume can include historical usage, and some
+          // providers only reveal cache tokens here. Request count alone must
+          // not turn the streamed subset into an exact priced total.
+          input_tokens: 1_100,
+          output_tokens: 225,
+          cache_read_input_tokens: 500,
+        },
+      },
+      queue,
+      ctx,
+    );
+    queue.end();
+    const events: AgentEvent[] = [];
+    for await (const event of queue) events.push(event);
+    const done = events.find((event) => event.type === 'done');
+    expect(done?.data).toMatchObject({
+      usageSegmentsComplete: false,
+      usageSegments: [
+        {
+          model: 'claude-sonnet-4.5',
+          inputTokens: 100,
+          outputTokens: 25,
+          cacheReadTokens: 0,
+          cacheCreateTokens: 0,
+          complete: false,
+        },
+      ],
+    });
+  });
+
   it('marks timing unreliable for a complete subagent assistant without message_delta', () => {
     vi.useFakeTimers();
     vi.setSystemTime(1_000);
@@ -314,5 +463,3 @@ describe('claude generation pause boundaries', () => {
     vi.useRealTimers();
   });
 });
-
-

--- a/packages/maker-core/src/agents/claude-code/generation-timing.test.ts
+++ b/packages/maker-core/src/agents/claude-code/generation-timing.test.ts
@@ -373,7 +373,7 @@ describe('claude generation pause boundaries', () => {
     });
   });
 
-  it('keeps a Claude request on its accepted price variant across a pre-response Fast toggle', () => {
+  it('freezes the current request and captures the next tool-loop request variant at the tool boundary', () => {
     let fastMode = false;
     const ctx = {
       ...createTranslatorCtx(),
@@ -412,7 +412,33 @@ describe('claude generation pause boundaries', () => {
       ctx,
     );
 
-    // The next provider request is accepted after Fast is enabled and gets
+    // The first response requests a tool. Fast is toggled while the tool is
+    // running, and the SDK's tool-result echo is the boundary at which the
+    // next provider request's variant is captured.
+    fastMode = false;
+    translateSdkMessage(
+      {
+        type: 'assistant',
+        message: {
+          content: [{ type: 'tool_use', id: 'toolu_1', name: 'Read', input: {} }],
+        },
+      },
+      queue,
+      ctx,
+    );
+    fastMode = true;
+    translateSdkMessage(
+      {
+        type: 'user',
+        message: {
+          content: [{ type: 'tool_result', tool_use_id: 'toolu_1', content: 'done' }],
+        },
+      },
+      queue,
+      ctx,
+    );
+
+    // The next provider request is dispatched after the tool result and gets
     // its own priority segment.
     translateSdkMessage(
       {

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -2420,6 +2420,11 @@ export class ClaudeCodeAgent extends BaseAgent {
     const bridgeStateActive = (): boolean =>
       queuedBridgeTurns > 0 || activeBridgeKind !== null || activeBridgeRewindResumeAt !== undefined;
     let q: Query;
+    // Query-scoped lifecycle fact: modelUsage is cumulative within the SDK
+    // process. A query created without a resume id starts that counter at zero;
+    // resumed queries may include prior transcript usage and must establish a
+    // baseline unless request segments prove the delta independently.
+    const modelUsageStartsAtZeroQueries = new WeakSet<Query>();
     function restoreBridgeAutoCompactSnapshot(reason: string): void {
       const snapshot = bridgeCompactUsageSnapshot;
       bridgeCompactUsageSnapshot = null;
@@ -2742,6 +2747,7 @@ export class ClaudeCodeAgent extends BaseAgent {
       // resume 优先用当前的 sdkSessionId (rewind 重启时它指向上一轮 SDK 给的 id);
       // 缺省回到 startSession 入参的 resumeSessionId (新会话首次起 query 时用)。
       let resumeSdkSid = sdkSessionId ?? configuredResumeSessionId;
+      const modelUsageCumulativeStartsAtZero = !resumeSdkSid;
 
       // ── 远端 cc 分支 (Phase 4.3) ──
       // session 标了 remoteHostId 且 host 注入了 remoteCcQueryFactory → 走远端
@@ -3254,6 +3260,7 @@ export class ClaudeCodeAgent extends BaseAgent {
         })().catch(() => undefined);
 
         if (finalRemotePermissionMode === 'auto') nativeAutoQueries.add(remoteQuery);
+        if (modelUsageCumulativeStartsAtZero) modelUsageStartsAtZeroQueries.add(remoteQuery);
         return remoteQuery;
       }
 
@@ -3455,6 +3462,7 @@ export class ClaudeCodeAgent extends BaseAgent {
         },
       });
       if (sdkStartPermissionMode === 'auto') nativeAutoQueries.add(query);
+      if (modelUsageCumulativeStartsAtZero) modelUsageStartsAtZeroQueries.add(query);
       return query;
     };
 
@@ -4523,6 +4531,8 @@ export class ClaudeCodeAgent extends BaseAgent {
               getPermissionMode: () => mutablePermissionMode,
               getFastMode: () => mutableFastMode,
               getSdkSessionId: () => sdkSessionId,
+              modelUsageCumulativeStartsAtZero: () =>
+                modelUsageStartsAtZeroQueries.has(currentQ),
               getLogTitle: () => lastSendTitle,
               tracker: usageTracker,
               onSessionId: (sid) => {

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -2747,7 +2747,7 @@ export class ClaudeCodeAgent extends BaseAgent {
       // resume 优先用当前的 sdkSessionId (rewind 重启时它指向上一轮 SDK 给的 id);
       // 缺省回到 startSession 入参的 resumeSessionId (新会话首次起 query 时用)。
       let resumeSdkSid = sdkSessionId ?? configuredResumeSessionId;
-      const modelUsageCumulativeStartsAtZero = !resumeSdkSid;
+      let modelUsageCumulativeStartsAtZero = !resumeSdkSid;
 
       // ── 远端 cc 分支 (Phase 4.3) ──
       // session 标了 remoteHostId 且 host 注入了 remoteCcQueryFactory → 走远端
@@ -3326,6 +3326,7 @@ export class ClaudeCodeAgent extends BaseAgent {
               resumeRecoveryAttempted = false;
               freshSessionValidationPending = true;
               resumeSdkSid = undefined;
+              modelUsageCumulativeStartsAtZero = true;
             } else {
               log.warn('resume transcript not found in any project dir (CLI resume may fail)', {
                 resumeSdkSid,

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -2352,6 +2352,7 @@ export class ClaudeCodeAgent extends BaseAgent {
       // 开始时清掉，避免上一轮 abnormal/abort 没走 result 时污染下一轮状态。
       usageTracker.beginTurn();
       resetClaudeGenerationTiming(runtimeState.generation);
+      runtimeState.activeUsageSegmentByParent.clear();
       turnState.text = '';
       turnState.toolUses = 0;
       turnState.apiCalls = 0;
@@ -4520,6 +4521,7 @@ export class ClaudeCodeAgent extends BaseAgent {
               getModelContextWindow: () => resolveModelContextWindow(mutableModel),
               getEffort: () => mutableEffort,
               getPermissionMode: () => mutablePermissionMode,
+              getFastMode: () => mutableFastMode,
               getSdkSessionId: () => sdkSessionId,
               getLogTitle: () => lastSendTitle,
               tracker: usageTracker,

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -2345,14 +2345,18 @@ export class ClaudeCodeAgent extends BaseAgent {
       generation: 0,
       interruptGeneration: 0,
       lastAssistantMsgHadSubstance: true,
+      nextRequestPriceVariant: 'standard',
     };
     const runtimeState: RuntimeState = newRuntimeState();
-    const beginNewTurn = (): void => {
+    const beginNewTurn = (priceVariant: 'standard' | 'priority' = mutableFastMode ? 'priority' : 'standard'): void => {
       // usageTracker.beginTurn() 只清 usage 桶；translator 的 turnState 也要在新 turn
       // 开始时清掉，避免上一轮 abnormal/abort 没走 result 时污染下一轮状态。
       usageTracker.beginTurn();
       resetClaudeGenerationTiming(runtimeState.generation);
       runtimeState.activeUsageSegmentByParent.clear();
+      runtimeState.activeUsagePriceVariantByParent.clear();
+      runtimeState.pendingUsagePriceVariantByParent.clear();
+      turnState.nextRequestPriceVariant = priceVariant;
       turnState.text = '';
       turnState.toolUses = 0;
       turnState.apiCalls = 0;
@@ -2637,7 +2641,7 @@ export class ClaudeCodeAgent extends BaseAgent {
         contextWindow: snapshot?.contextWindow,
         sdkSessionId,
       });
-      beginNewTurn();
+      beginNewTurn(mutableFastMode ? 'priority' : 'standard');
       resetToolLoopGuards();
       turnInFlight = true;
       if (origin === 'idle') hostAutoCompactInFlight = true;
@@ -4512,7 +4516,7 @@ export class ClaudeCodeAgent extends BaseAgent {
                 rawType,
                 sdkSessionId,
               });
-              beginNewTurn();
+              beginNewTurn(mutableFastMode ? 'priority' : 'standard');
               resetToolLoopGuards();
               turnInFlight = true;
             }
@@ -4937,7 +4941,7 @@ export class ClaudeCodeAgent extends BaseAgent {
       // turnInFlight,否则 isTurnRunning() 会在没有 turn 运行时误报为忙。无 replay 的
       // 全新 query + startForwardLoop 等价于 startSession 首次起 q 的空闲态。
       if (replayInput) {
-        beginNewTurn();
+        beginNewTurn(runtimeSnapshot.fastMode ? 'priority' : 'standard');
         resetToolLoopGuards();
         turnInFlight = true;
       }
@@ -5474,7 +5478,7 @@ export class ClaudeCodeAgent extends BaseAgent {
 
         // 兜底重置 currentTurn —— 上一 turn 异常 / abort 时 endTurn 可能没跑,
         // 防止 currentTurn 残留累加到下一 turn (lastApi / contextWindow / cost 跨 turn 保留)
-        beginNewTurn();
+        beginNewTurn(mutableFastMode ? 'priority' : 'standard');
         resetToolLoopGuards();
         // 标记 turn 进入 in-flight 态 (translator.onTurnEnd 在 result 事件回调时清);
         // rewind preview/commit 守卫读 isTurnRunning() 决定能否操作。

--- a/packages/maker-core/src/agents/claude-code/translator.ts
+++ b/packages/maker-core/src/agents/claude-code/translator.ts
@@ -119,6 +119,13 @@ export interface TurnState {
    */
   lastAssistantMsgHadSubstance: boolean;
   /**
+   * The price variant captured when the current turn's next provider request
+   * was accepted. The SDK may deliver message_start after a runtime Fast-mode
+   * toggle, so usage translation must not read the mutable session setting for
+   * that already-dispatched request.
+   */
+  nextRequestPriceVariant?: 'standard' | 'priority';
+  /**
    * 本 turn 最近一条 assistant API message id。Vertex 路由用 `msg_vrtx_`
    * 前缀作为输出 token 延迟结算的确定性证据；result 本身不携带该 id，
    * 因此必须在 assistant 消息到达时按 turn 暂存，再随 done 交给 host。
@@ -171,6 +178,10 @@ export interface RuntimeState {
   streamStopTokenByKey: Map<string, StandaloneStopTokenHold>;
   /** Per-parent active provider request used to merge message_start + message_delta usage. */
   activeUsageSegmentByParent: Map<string, string>;
+  /** Price variant frozen for the active request of each parent stream. */
+  activeUsagePriceVariantByParent: Map<string, 'standard' | 'priority'>;
+  /** Price variant captured for the next request before its message_start arrives. */
+  pendingUsagePriceVariantByParent: Map<string, 'standard' | 'priority'>;
   usageSegmentSeq: number;
   generation: ClaudeGenerationState;
 }
@@ -190,6 +201,8 @@ export function newRuntimeState(): RuntimeState {
     lastResultUsageAggregate: null,
     streamStopTokenByKey: new Map(),
     activeUsageSegmentByParent: new Map(),
+    activeUsagePriceVariantByParent: new Map(),
+    pendingUsagePriceVariantByParent: new Map(),
     usageSegmentSeq: 0,
     generation: newClaudeGenerationState(),
   };
@@ -1546,6 +1559,11 @@ function handleStreamEvent(
         ctx.rt.activeUsageSegmentByParent.get(parentStreamKey) ??
         `claude:${++ctx.rt.usageSegmentSeq}:${parentStreamKey}`;
       ctx.rt.activeUsageSegmentByParent.set(parentStreamKey, segmentId);
+      const priceVariant =
+        ctx.rt.activeUsagePriceVariantByParent.get(parentStreamKey) ??
+        ctx.rt.pendingUsagePriceVariantByParent.get(parentStreamKey) ??
+        ctx.turn.nextRequestPriceVariant ??
+        (ctx.getFastMode?.() ? 'priority' : 'standard');
       const hasCompleteUsageSnapshot = [
         'input_tokens',
         'output_tokens',
@@ -1555,13 +1573,20 @@ function handleStreamEvent(
       ctx.tracker.upsertApiCallUsage(segmentId, {
         id: segmentId,
         model: streamModel ?? ctx.getModel(),
-        priceVariant: ctx.getFastMode?.() ? 'priority' : 'standard',
+        priceVariant,
         inputTokens: dIn,
         outputTokens: dOut,
         cacheReadTokens: dCacheRead,
         cacheCreateTokens: dCacheCreate,
         complete: hasCompleteUsageSnapshot,
       });
+      // A completed message is the acceptance boundary for the next Claude
+      // request. Capture the then-current setting for that next request, but
+      // keep the active segment's variant immutable until its final frame.
+      ctx.rt.pendingUsagePriceVariantByParent.set(
+        parentStreamKey,
+        ctx.getFastMode?.() ? 'priority' : 'standard',
+      );
       if (parentToolUseId && dOut > 0) markClaudeGenerationUnreliable(ctx.rt.generation);
       // 每次 API 回合的 token 增量打一行 —— 一个 turn 可能多个 message_delta(工具循环),
       // 让人看日志能直观看到 token 是怎么涨上去的, 而不是只在 turn end 看到一个总数。
@@ -1595,6 +1620,12 @@ function handleStreamEvent(
     ctx.turn.apiCalls += 1;
     const segmentId = `claude:${++ctx.rt.usageSegmentSeq}:${parentStreamKey}`;
     ctx.rt.activeUsageSegmentByParent.set(parentStreamKey, segmentId);
+    const priceVariant =
+      ctx.rt.pendingUsagePriceVariantByParent.get(parentStreamKey) ??
+      ctx.turn.nextRequestPriceVariant ??
+      (ctx.getFastMode?.() ? 'priority' : 'standard');
+    ctx.rt.pendingUsagePriceVariantByParent.delete(parentStreamKey);
+    ctx.rt.activeUsagePriceVariantByParent.set(parentStreamKey, priceVariant);
 
     // 第三方 proxy(如 litellm)或官方端点通常在 message_start 给出 input_tokens
     const usage = event.message?.usage as Record<string, number> | undefined;
@@ -1606,7 +1637,7 @@ function handleStreamEvent(
         ctx.tracker.upsertApiCallUsage(segmentId, {
           id: segmentId,
           model: event.message?.model ?? streamModel ?? ctx.getModel(),
-          priceVariant: ctx.getFastMode?.() ? 'priority' : 'standard',
+          priceVariant,
           inputTokens: dIn,
           outputTokens: 0,
           cacheReadTokens: dCacheRead,

--- a/packages/maker-core/src/agents/claude-code/translator.ts
+++ b/packages/maker-core/src/agents/claude-code/translator.ts
@@ -734,6 +734,16 @@ export function translateSdkMessage(
         resumeClaudeGeneration(ctx.rt.generation, toolUseId);
         ctx.rt.toolUseIdToName.delete(toolUseId);
       }
+      if (completedToolUseIds.size > 0) {
+        // The SDK emits the tool-result echo immediately before it dispatches
+        // the next provider request. Capture the mutable Fast setting here,
+        // after tool execution has completed, rather than at the previous
+        // message_delta (which can be much earlier than the next request).
+        ctx.rt.pendingUsagePriceVariantByParent.set(
+          parentToolUseId ?? '__main__',
+          ctx.getFastMode?.() ? 'priority' : 'standard',
+        );
+      }
       return;
     }
 
@@ -1580,13 +1590,6 @@ function handleStreamEvent(
         cacheCreateTokens: dCacheCreate,
         complete: hasCompleteUsageSnapshot,
       });
-      // A completed message is the acceptance boundary for the next Claude
-      // request. Capture the then-current setting for that next request, but
-      // keep the active segment's variant immutable until its final frame.
-      ctx.rt.pendingUsagePriceVariantByParent.set(
-        parentStreamKey,
-        ctx.getFastMode?.() ? 'priority' : 'standard',
-      );
       if (parentToolUseId && dOut > 0) markClaudeGenerationUnreliable(ctx.rt.generation);
       // 每次 API 回合的 token 增量打一行 —— 一个 turn 可能多个 message_delta(工具循环),
       // 让人看日志能直观看到 token 是怎么涨上去的, 而不是只在 turn end 看到一个总数。

--- a/packages/maker-core/src/agents/claude-code/translator.ts
+++ b/packages/maker-core/src/agents/claude-code/translator.ts
@@ -169,6 +169,9 @@ export interface RuntimeState {
    * 发出可见正文，不能看整轮 `uiEmittedText`，也不能跨 text block 复用。
    */
   streamStopTokenByKey: Map<string, StandaloneStopTokenHold>;
+  /** Per-parent active provider request used to merge message_start + message_delta usage. */
+  activeUsageSegmentByParent: Map<string, string>;
+  usageSegmentSeq: number;
   generation: ClaudeGenerationState;
 }
 
@@ -186,6 +189,8 @@ export function newRuntimeState(): RuntimeState {
     lastAssistantMeta: null,
     lastResultUsageAggregate: null,
     streamStopTokenByKey: new Map(),
+    activeUsageSegmentByParent: new Map(),
+    usageSegmentSeq: 0,
     generation: newClaudeGenerationState(),
   };
 }
@@ -519,6 +524,7 @@ interface TranslateContext {
   getModelContextWindow?: () => number | undefined;
   getEffort: () => string;
   getPermissionMode: () => string;
+  getFastMode?: () => boolean;
   /** SDK session_id 第一次出现时的回调, agent 用来回填 sdkSessionId */
   onSessionId: (sdkSessionId: string | undefined) => void;
   /**
@@ -1534,11 +1540,25 @@ function handleStreamEvent(
       const dCacheCreate = usage.cache_creation_input_tokens ?? 0;
       // 累加进 tracker (跨多个 message_delta 会一直涨 —— 对标老 agentManager.ts:2362-2365
       // 的 session.currentTurn{Input,Output,CacheRead,CacheCreate}Tokens += dX)
-      ctx.tracker.ingestApiCallUsage({
+      const segmentId =
+        ctx.rt.activeUsageSegmentByParent.get(parentStreamKey) ??
+        `claude:${++ctx.rt.usageSegmentSeq}:${parentStreamKey}`;
+      ctx.rt.activeUsageSegmentByParent.set(parentStreamKey, segmentId);
+      const hasCompleteUsageSnapshot = [
+        'input_tokens',
+        'output_tokens',
+        'cache_read_input_tokens',
+        'cache_creation_input_tokens',
+      ].every((field) => Object.prototype.hasOwnProperty.call(usage, field));
+      ctx.tracker.upsertApiCallUsage(segmentId, {
+        id: segmentId,
+        model: streamModel ?? ctx.getModel(),
+        priceVariant: ctx.getFastMode?.() ? 'priority' : 'standard',
         inputTokens: dIn,
         outputTokens: dOut,
         cacheReadTokens: dCacheRead,
         cacheCreateTokens: dCacheCreate,
+        complete: hasCompleteUsageSnapshot,
       });
       if (parentToolUseId && dOut > 0) markClaudeGenerationUnreliable(ctx.rt.generation);
       // 每次 API 回合的 token 增量打一行 —— 一个 turn 可能多个 message_delta(工具循环),
@@ -1571,6 +1591,8 @@ function handleStreamEvent(
       model: event.message?.model ?? ctx.getModel(),
     });
     ctx.turn.apiCalls += 1;
+    const segmentId = `claude:${++ctx.rt.usageSegmentSeq}:${parentStreamKey}`;
+    ctx.rt.activeUsageSegmentByParent.set(parentStreamKey, segmentId);
 
     // 第三方 proxy(如 litellm)或官方端点通常在 message_start 给出 input_tokens
     const usage = event.message?.usage as Record<string, number> | undefined;
@@ -1579,11 +1601,15 @@ function handleStreamEvent(
       const dCacheRead = usage.cache_read_input_tokens ?? 0;
       const dCacheCreate = usage.cache_creation_input_tokens ?? 0;
       if (dIn > 0 || dCacheRead > 0 || dCacheCreate > 0) {
-        ctx.tracker.ingestApiCallUsage({
+        ctx.tracker.upsertApiCallUsage(segmentId, {
+          id: segmentId,
+          model: event.message?.model ?? streamModel ?? ctx.getModel(),
+          priceVariant: ctx.getFastMode?.() ? 'priority' : 'standard',
           inputTokens: dIn,
           outputTokens: 0,
           cacheReadTokens: dCacheRead,
           cacheCreateTokens: dCacheCreate,
+          complete: false,
         });
       }
     }
@@ -1823,6 +1849,34 @@ function handleResult(
 
   // turn 桶快照 — endTurn 会清掉 turn 桶, 必须在调用之前先取出来给后面日志用
   const preTurnEndCacheStats = ctx.tracker.getCacheStats();
+  const turnUsageSegments = ctx.tracker.getTurnUsageSegments();
+  const segmentTotals = turnUsageSegments.reduce<{
+    inputTokens: number;
+    outputTokens: number;
+    cacheReadTokens: number;
+    cacheCreateTokens: number;
+  }>(
+    (sum, segment) => ({
+      inputTokens: sum.inputTokens + segment.inputTokens,
+      outputTokens: sum.outputTokens + segment.outputTokens,
+      cacheReadTokens: sum.cacheReadTokens + (segment.cacheReadTokens ?? 0),
+      cacheCreateTokens: sum.cacheCreateTokens + (segment.cacheCreateTokens ?? 0),
+    }),
+    { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreateTokens: 0 },
+  );
+  const segmentsMatchResult = resultUsage
+    ? segmentTotals.inputTokens === resultUsage.inputTokens &&
+      segmentTotals.outputTokens === resultUsage.outputTokens &&
+      segmentTotals.cacheReadTokens === (resultUsage.cacheReadTokens ?? 0) &&
+      segmentTotals.cacheCreateTokens === (resultUsage.cacheCreateTokens ?? 0)
+    : false;
+  // Only declare request segments complete when an independent turn delta
+  // proves that they cover every token bucket. A matching request count is not
+  // enough: some providers report cache usage only in the terminal aggregate.
+  // On the first result after resume that aggregate may still include history,
+  // so a mismatch must fail closed to token-only accounting rather than price
+  // an incomplete set of requests.
+  const usageSegmentsComplete = segmentsMatchResult;
   const finalTextForLogs = msg.is_error ? redactSensitiveText(finalText) : finalText;
 
   // turn end usage 锁定: Claude Code result.usage 是 session aggregate,
@@ -2087,9 +2141,14 @@ function handleResult(
     msg.is_error && typeof msg.result === 'string'
       ? { ...msg, result: redactSensitiveText(msg.result) }
       : msg;
+  const resultWithUsageSegments = {
+    ...safeResult,
+    usageSegments: turnUsageSegments,
+    usageSegmentsComplete,
+  };
   const resultWithAssistantMessageId = ctx.turn.lastAssistantRequestId
-    ? { ...safeResult, assistant_message_id: ctx.turn.lastAssistantRequestId }
-    : safeResult;
+    ? { ...resultWithUsageSegments, assistant_message_id: ctx.turn.lastAssistantRequestId }
+    : resultWithUsageSegments;
   queue.push({
     type: 'done',
     data:
@@ -2100,6 +2159,7 @@ function handleResult(
   });
   // reset turn 累积 (tracker 内部已经在 endTurn 里 reset 了 currentTurn,这里只清非 usage 状态)
   resetTurnState(ctx.turn);
+  ctx.rt.activeUsageSegmentByParent.clear();
   resetClaudeGenerationTiming(ctx.rt.generation);
   // turn 结束钩子 — agent 用来清 turnInFlight 标记 (rewind preview/commit 前置守卫读它)
   ctx.onTurnEnd?.();

--- a/packages/maker-core/src/agents/claude-code/translator.ts
+++ b/packages/maker-core/src/agents/claude-code/translator.ts
@@ -532,6 +532,8 @@ interface TranslateContext {
    * 仅诊断日志用, getter 形式确保读到的是最新值 (system init 那一步会回填)。
    */
   getSdkSessionId: () => string | undefined;
+  /** Whether the current SDK query starts its cumulative modelUsage at zero. */
+  modelUsageCumulativeStartsAtZero?: () => boolean;
   /**
    * 当前 session 的展示 title —— 由调用方 (register.ts) 每次 send 时透传进来,
    * 同样仅用于诊断日志, 不参与业务。允许 undefined / 跨 turn 变化。
@@ -2145,6 +2147,7 @@ function handleResult(
     ...safeResult,
     usageSegments: turnUsageSegments,
     usageSegmentsComplete,
+    modelUsageCumulativeStartsAtZero: ctx.modelUsageCumulativeStartsAtZero?.() === true,
   };
   const resultWithAssistantMessageId = ctx.turn.lastAssistantRequestId
     ? { ...resultWithUsageSegments, assistant_message_id: ctx.turn.lastAssistantRequestId }

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -4586,6 +4586,60 @@ describe('CodexAgent fast mode service tier', () => {
     expect(handle.getFastMode?.()).toBe(true);
     await handle.close();
   });
+
+  it('keeps a Codex turn on its accepted service tier across a mid-start Fast toggle', async () => {
+    const agent = new CodexAgent(createDeps());
+    const turnStartGate = deferred<{ turn: { id: string }; serviceTier: 'default' }>();
+    const host = installFakeHost(agent, (method) => {
+      if (method === Method.TurnStart) return turnStartGate.promise;
+      if (method === Method.ThreadSettingsUpdate) return {};
+      return undefined;
+    });
+    const handle = await agent.startSession({
+      sessionId: 'session-tier-lock',
+      model: 'gpt-5.4',
+      fastMode: false,
+      workingDir: '/repo',
+    });
+    const handlers = host.getThreadHandlers();
+    if (!handlers?.turnStarted || !handlers.tokenUsageUpdated || !handlers.turnCompleted) {
+      throw new Error('expected usage handlers');
+    }
+    const events: AgentEvent[] = [];
+    void (async () => {
+      for await (const event of handle.events()) events.push(event);
+    })();
+
+    const sendPromise = handle.send({ type: 'user', content: 'tier lock' });
+    await waitForExpectation(() => {
+      expect(host.request.mock.calls.some(([method]) => method === Method.TurnStart)).toBe(true);
+    });
+    // The turn/start request was already sent with the standard tier. Changing
+    // the session setting must not re-price the usage that follows it.
+    await handle.setFastMode?.(true);
+    turnStartGate.resolve({ turn: { id: 'turn-tier-lock' }, serviceTier: 'default' });
+    handlers.turnStarted({ threadId: 'start-thread-id', turn: { id: 'turn-tier-lock' } });
+    handlers.tokenUsageUpdated({
+      threadId: 'start-thread-id',
+      turnId: 'turn-tier-lock',
+      tokenUsage: {
+        total: { totalTokens: 30, inputTokens: 20, outputTokens: 10, cachedInputTokens: 0 },
+        last: { totalTokens: 30, inputTokens: 20, outputTokens: 10, cachedInputTokens: 0 },
+      },
+    });
+    handlers.turnCompleted({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-tier-lock', status: 'completed' },
+    });
+    await sendPromise;
+    await waitForExpectation(() => expect(events.some((event) => event.type === 'done')).toBe(true));
+
+    const done = events.find((event): event is Extract<AgentEvent, { type: 'done' }> => event.type === 'done');
+    expect((done?.data as { usage?: { segments?: unknown[] } }).usage?.segments).toEqual([
+      expect.objectContaining({ inputTokens: 20, outputTokens: 10, priceVariant: 'standard' }),
+    ]);
+    await handle.close();
+  });
 });
 
 describe('CodexAgent thread/settings/update channel', () => {

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -4640,6 +4640,81 @@ describe('CodexAgent fast mode service tier', () => {
     ]);
     await handle.close();
   });
+
+  it('calibrates the accepted tier before replaying buffered usage notifications', async () => {
+    const agent = new CodexAgent(createDeps());
+    const firstStart = deferred<unknown>();
+    const secondStart = deferred<{ turn: { id: string }; serviceTier: 'default' }>();
+    let attempt = 0;
+    const host = installFakeHost(agent, (method) => {
+      if (method === Method.TurnStart) {
+        attempt += 1;
+        return attempt === 1 ? firstStart.promise : secondStart.promise;
+      }
+      return undefined;
+    });
+    const handle = await agent.startSession({
+      sessionId: 'session-tier-buffer-replay',
+      model: 'gpt-5.4',
+      fastMode: true,
+      workingDir: '/repo',
+    });
+    const handlers = host.getThreadHandlers();
+    if (!handlers?.turnStarted || !handlers.tokenUsageUpdated || !handlers.turnCompleted) {
+      throw new Error('expected usage handlers');
+    }
+    const iterator = handle.events()[Symbol.asyncIterator]();
+
+    const firstSend = handle.send({ type: 'user', content: 'first' });
+    await waitForExpectation(() => {
+      expect(host.request.mock.calls.some(([method]) => method === Method.TurnStart)).toBe(true);
+    });
+    firstStart.reject(new Error('codex app-server turn/start timed out after 60000ms'));
+    await firstSend;
+    expect(await iterator.next()).toMatchObject({ value: { type: 'status', data: { isRunning: true } } });
+    expect(await iterator.next()).toMatchObject({ value: { type: 'error', data: { isTerminal: true } } });
+    expect(await iterator.next()).toMatchObject({ value: { type: 'status', data: { status: 'Done', isRunning: false } } });
+
+    const events: AgentEvent[] = [];
+    const secondSend = handle.send({ type: 'user', content: 'buffered tier' });
+    await waitForExpectation(() => {
+      expect(host.request.mock.calls.filter(([method]) => method === Method.TurnStart)).toHaveLength(2);
+    });
+
+    // All three notifications arrive before turn/start responds.  They must
+    // replay only after the response's authoritative default tier is applied.
+    handlers.turnStarted({ threadId: 'start-thread-id', turn: { id: 'turn-buffer-tier' } });
+    handlers.tokenUsageUpdated({
+      threadId: 'start-thread-id',
+      turnId: 'turn-buffer-tier',
+      tokenUsage: {
+        total: { totalTokens: 30, inputTokens: 20, outputTokens: 10, cachedInputTokens: 0 },
+        last: { totalTokens: 30, inputTokens: 20, outputTokens: 10, cachedInputTokens: 0 },
+      },
+    });
+    handlers.turnCompleted({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-buffer-tier', status: 'completed' },
+    });
+
+    secondStart.resolve({ turn: { id: 'turn-buffer-tier' }, serviceTier: 'default' });
+    await secondSend;
+    for (;;) {
+      const next = await iterator.next();
+      if (next.done) break;
+      events.push(next.value);
+      if (next.value.type === 'done') break;
+    }
+    await waitForExpectation(() => expect(events.some((event) => event.type === 'done')).toBe(true));
+
+    const done = events.find((event) => event.type === 'done') as
+      | { type: 'done'; data: { usage?: { segments?: unknown[] } } }
+      | undefined;
+    expect((done?.data as { usage?: { segments?: unknown[] } }).usage?.segments).toEqual([
+      expect.objectContaining({ inputTokens: 20, outputTokens: 10, priceVariant: 'standard' }),
+    ]);
+    await handle.close();
+  });
 });
 
 describe('CodexAgent thread/settings/update channel', () => {

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -3192,6 +3192,78 @@ describe('CodexAgent reference directories', () => {
     await handle.close();
   });
 
+  it('accepts lower usage totals after stale-daemon resume starts a new execution generation', async () => {
+    const agent = new CodexAgent(createDeps());
+    let turnStartCount = 0;
+    let activeTurnId = '';
+    const host = installFakeHost(agent, (method) => {
+      if (method !== Method.TurnStart) return undefined;
+      turnStartCount += 1;
+      if (turnStartCount === 2) throw new Error('thread not found');
+      activeTurnId = `turn-${turnStartCount}`;
+      return { turn: { id: activeTurnId } };
+    });
+    const handle = await agent.startSession({
+      sessionId: 'session-usage-after-stale-daemon',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+    });
+    const handlers = host.getThreadHandlers();
+    if (!handlers?.turnStarted || !handlers.tokenUsageUpdated || !handlers.turnCompleted) {
+      throw new Error('expected usage handlers');
+    }
+    const events: AgentEvent[] = [];
+    void (async () => {
+      for await (const event of handle.events()) events.push(event);
+    })();
+
+    await handle.send({ type: 'user', content: 'first turn' });
+    handlers.turnStarted({ threadId: 'start-thread-id', turn: { id: activeTurnId } });
+    handlers.tokenUsageUpdated({
+      threadId: 'start-thread-id',
+      turnId: activeTurnId,
+      tokenUsage: {
+        total: { totalTokens: 100, inputTokens: 80, outputTokens: 20, cachedInputTokens: 0 },
+        last: { totalTokens: 100, inputTokens: 80, outputTokens: 20, cachedInputTokens: 0 },
+      },
+    });
+    handlers.turnCompleted({
+      threadId: 'start-thread-id',
+      turn: { id: activeTurnId, status: 'completed' },
+    });
+    await waitForExpectation(() =>
+      expect(events.filter((event) => event.type === 'done')).toHaveLength(1),
+    );
+
+    await handle.send({ type: 'user', content: 'after daemon restart' });
+    handlers.turnStarted({ threadId: 'start-thread-id', turn: { id: activeTurnId } });
+    handlers.tokenUsageUpdated({
+      threadId: 'start-thread-id',
+      turnId: activeTurnId,
+      tokenUsage: {
+        total: { totalTokens: 10, inputTokens: 8, outputTokens: 2, cachedInputTokens: 0 },
+        last: { totalTokens: 10, inputTokens: 8, outputTokens: 2, cachedInputTokens: 0 },
+      },
+    });
+    handlers.turnCompleted({
+      threadId: 'start-thread-id',
+      turn: { id: activeTurnId, status: 'completed' },
+    });
+    await waitForExpectation(() =>
+      expect(events.filter((event) => event.type === 'done')).toHaveLength(2),
+    );
+
+    const doneEvents = events.filter((event): event is Extract<AgentEvent, { type: 'done' }> =>
+      event.type === 'done',
+    );
+    expect((doneEvents[0]?.data as { usage?: { segments?: unknown[] } }).usage?.segments).toHaveLength(1);
+    expect((doneEvents[1]?.data as { usage?: { segments?: Array<{ inputTokens: number; outputTokens: number }> } }).usage?.segments).toEqual([
+      expect.objectContaining({ inputTokens: 8, outputTokens: 2 }),
+    ]);
+
+    await handle.close();
+  });
+
   it('retries a stale reference turn with its frozen permission profile', async () => {
     const agent = new CodexAgent(createDeps());
     const firstTurnGate = deferred<never>();

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -15641,6 +15641,7 @@ describe('CodexAgent MCP thread context hooks', () => {
         threadId: 'start-thread-id',
         turnId: 'turn-fast',
         tokenUsage: {
+          total: { totalTokens: 50, inputTokens: 10, outputTokens: 40, cachedInputTokens: 0 },
           last: { inputTokens: 10, outputTokens: 40, cachedInputTokens: 0 },
         },
       });
@@ -15674,6 +15675,220 @@ describe('CodexAgent MCP thread context hooks', () => {
     } finally {
       nowSpy.mockRestore();
     }
+  });
+
+  it('emits only monotonic request segments and keeps reasoning as a non-additive detail', async () => {
+    const agent = new CodexAgent(createDeps());
+    const host = installFakeHost(agent);
+    const handle = await agent.startSession({
+      sessionId: 'session-usage-segments',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+    });
+    const handlers = host.getThreadHandlers();
+    if (!handlers?.turnStarted || !handlers.tokenUsageUpdated || !handlers.turnCompleted) {
+      throw new Error('expected usage segment handlers');
+    }
+    const events: AgentEvent[] = [];
+    void (async () => {
+      for await (const event of handle.events()) events.push(event);
+    })();
+
+    handlers.turnStarted({ threadId: 'start-thread-id', turn: { id: 'turn-segments' } });
+    const first = {
+      threadId: 'start-thread-id',
+      turnId: 'turn-segments',
+      tokenUsage: {
+        total: {
+          totalTokens: 60_007,
+          inputTokens: 60_000,
+          cachedInputTokens: 10_000,
+          outputTokens: 7,
+          reasoningOutputTokens: 3,
+        },
+        last: {
+          totalTokens: 60_007,
+          inputTokens: 60_000,
+          cachedInputTokens: 10_000,
+          outputTokens: 7,
+          reasoningOutputTokens: 3,
+        },
+      },
+    };
+    handlers.tokenUsageUpdated(first);
+    // Exact replay plus an older frame must not create billable segments.
+    handlers.tokenUsageUpdated(first);
+    handlers.tokenUsageUpdated({
+      ...first,
+      tokenUsage: {
+        ...first.tokenUsage,
+        total: { ...first.tokenUsage.total, totalTokens: 59_000 },
+      },
+    });
+    handlers.tokenUsageUpdated({
+      threadId: 'start-thread-id',
+      turnId: 'turn-segments',
+      tokenUsage: {
+        total: {
+          totalTokens: 115_011,
+          inputTokens: 115_000,
+          cachedInputTokens: 15_000,
+          outputTokens: 11,
+          reasoningOutputTokens: 5,
+        },
+        last: {
+          totalTokens: 55_004,
+          inputTokens: 55_000,
+          cachedInputTokens: 5_000,
+          outputTokens: 4,
+          reasoningOutputTokens: 2,
+        },
+      },
+    });
+    handlers.turnCompleted({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-segments', status: 'completed' },
+    });
+    await waitForExpectation(() =>
+      expect(events.some((event) => event.type === 'done')).toBe(true),
+    );
+
+    const done = events.find((event) => event.type === 'done');
+    expect((done?.data as { usage?: unknown }).usage).toMatchObject({
+      promptTokens: 100_000,
+      completionTokens: 11,
+      reasoningTokens: 5,
+      cachedTokens: 15_000,
+      segments: [
+        {
+          inputTokens: 50_000,
+          outputTokens: 7,
+          cacheReadTokens: 10_000,
+          cacheCreateTokens: 0,
+          reasoningTokens: 3,
+        },
+        {
+          inputTokens: 50_000,
+          outputTokens: 4,
+          cacheReadTokens: 5_000,
+          cacheCreateTokens: 0,
+          reasoningTokens: 2,
+        },
+      ],
+    });
+    await handle.close();
+  });
+
+  it('replays 108 audited usage notifications as 92 billable request segments', async () => {
+    const agent = new CodexAgent(createDeps());
+    const host = installFakeHost(agent);
+    const handle = await agent.startSession({
+      sessionId: 'session-audited-usage-fixture',
+      model: 'codex/gpt-5.6-sol',
+      workingDir: '/repo',
+    });
+    const handlers = host.getThreadHandlers();
+    if (!handlers?.turnStarted || !handlers.tokenUsageUpdated || !handlers.turnCompleted) {
+      throw new Error('expected usage handlers');
+    }
+    const events: AgentEvent[] = [];
+    void (async () => {
+      for await (const event of handle.events()) events.push(event);
+    })();
+
+    const turnId = 'turn-audited-usage-fixture';
+    handlers.turnStarted({ threadId: 'start-thread-id', turn: { id: turnId } });
+    let cumulativeInput = 0;
+    let cumulativeOutput = 0;
+    let notificationCount = 0;
+    for (let index = 0; index < 92; index += 1) {
+      const uncachedInput = 7_987 + (index < 68 ? 1 : 0);
+      const cachedInput = 86_234 + (index < 40 ? 1 : 0);
+      const output = 401 + (index < 61 ? 1 : 0);
+      const input = uncachedInput + cachedInput;
+      cumulativeInput += input;
+      cumulativeOutput += output;
+      const notification = {
+        threadId: 'start-thread-id',
+        turnId,
+        tokenUsage: {
+          total: {
+            totalTokens: cumulativeInput + cumulativeOutput,
+            inputTokens: cumulativeInput,
+            cachedInputTokens:
+              index < 40 ? (index + 1) * 86_235 : 40 * 86_235 + (index - 39) * 86_234,
+            outputTokens: cumulativeOutput,
+            reasoningOutputTokens: 0,
+          },
+          last: {
+            totalTokens: input + output,
+            inputTokens: input,
+            cachedInputTokens: cachedInput,
+            outputTokens: output,
+            reasoningOutputTokens: 0,
+          },
+        },
+      };
+      handlers.tokenUsageUpdated(notification);
+      notificationCount += 1;
+      if (index < 15) {
+        handlers.tokenUsageUpdated(notification);
+        notificationCount += 1;
+      }
+    }
+    const finalTotal = {
+      totalTokens: cumulativeInput + cumulativeOutput,
+      inputTokens: cumulativeInput,
+      cachedInputTokens: 7_933_568,
+      outputTokens: cumulativeOutput,
+      reasoningOutputTokens: 0,
+    };
+    handlers.tokenUsageUpdated({
+      threadId: 'start-thread-id',
+      turnId,
+      tokenUsage: {
+        total: finalTotal,
+        last: {
+          totalTokens: 18_694,
+          inputTokens: 0,
+          cachedInputTokens: 0,
+          outputTokens: 0,
+          reasoningOutputTokens: 0,
+        },
+      },
+    });
+    notificationCount += 1;
+    expect(notificationCount).toBe(108);
+
+    handlers.turnCompleted({
+      threadId: 'start-thread-id',
+      turn: { id: turnId, status: 'completed' },
+    });
+    await waitForExpectation(() =>
+      expect(events.some((event) => event.type === 'done')).toBe(true),
+    );
+    const usage = (
+      events.find((event) => event.type === 'done')?.data as {
+        usage?: {
+          promptTokens: number;
+          completionTokens: number;
+          cachedTokens: number;
+          segments: Array<{ inputTokens: number; cacheReadTokens: number }>;
+        };
+      }
+    ).usage;
+    expect(usage).toMatchObject({
+      promptTokens: 734_872,
+      cachedTokens: 7_933_568,
+      completionTokens: 36_953,
+    });
+    expect(usage?.segments).toHaveLength(92);
+    expect(
+      Math.max(
+        ...(usage?.segments ?? []).map((segment) => segment.inputTokens + segment.cacheReadTokens),
+      ),
+    ).toBeLessThan(272_001);
+    await handle.close();
   });
 
   it('keeps descendant approval waits out of the root generation timer', async () => {
@@ -19374,7 +19589,7 @@ describe('CodexAgent turn lifecycle', () => {
         modelContextWindow: 272000,
       },
     });
-    expect(handle.getUsageSnapshot().tokenUsage).toBe(71);
+    expect(handle.getUsageSnapshot().tokenUsage).toBe(67);
     handlers.error?.({
       threadId: 'start-thread-id',
       turnId: 'turn-a',
@@ -19400,10 +19615,10 @@ describe('CodexAgent turn lifecycle', () => {
       turnId: 'turn-b',
       tokenUsage: {
         total: {
-          totalTokens: 52,
-          inputTokens: 50,
-          cachedInputTokens: 10,
-          outputTokens: 2,
+          totalTokens: 143,
+          inputTokens: 130,
+          cachedInputTokens: 30,
+          outputTokens: 9,
           reasoningOutputTokens: 0,
         },
         last: {
@@ -19522,7 +19737,7 @@ describe('CodexAgent turn lifecycle', () => {
         modelContextWindow: 272000,
       },
     });
-    expect(handle.getUsageSnapshot().tokenUsage).toBe(71);
+    expect(handle.getUsageSnapshot().tokenUsage).toBe(67);
     handlers.error?.({
       threadId: 'start-thread-id',
       turnId: 'turn-a',
@@ -19624,10 +19839,10 @@ describe('CodexAgent turn lifecycle', () => {
       turnId: 'turn-b',
       tokenUsage: {
         total: {
-          totalTokens: 52,
-          inputTokens: 50,
-          cachedInputTokens: 10,
-          outputTokens: 2,
+          totalTokens: 143,
+          inputTokens: 130,
+          cachedInputTokens: 30,
+          outputTokens: 9,
           reasoningOutputTokens: 0,
         },
         last: {
@@ -25089,7 +25304,12 @@ describe('CodexAgent compaction storm escalation', () => {
       turnId,
       tokenUsage: {
         // total 是累加值,与 last 不同量级 —— 不把两者设成相同,否则测不出字段映射。
-        total: { inputTokens: usageTotal, cachedInputTokens: 0, outputTokens: 0 },
+        total: {
+          totalTokens: usageTotal,
+          inputTokens: usageTotal,
+          cachedInputTokens: 0,
+          outputTokens: 0,
+        },
         last: { inputTokens, cachedInputTokens: 0, outputTokens: 0 },
         // 上游的 bug:切模型后仍报旧模型的 258400。
         modelContextWindow: 258_400,

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -3207,8 +3207,21 @@ export class CodexAgent extends BaseAgent {
     let lastModelContextWindow: number | null = null;
     // tokenUsage.total 是 thread 生命周期内的单调累计 cursor。app-server 会重放
     // 相同快照（包括 compaction 的零帧），也可能让旧通知乱序晚到；只有 total
-    // 真正前进时，last 才代表一条新的可计费用量 segment。
-    const acceptedUsageTotalByThread = new Map<string, TokenUsageBreakdown>();
+    // 真正前进时，last 才代表一条新的可计费用量 segment。daemon 重启后
+    // thread/resume 会开启新的累计代次；旧代次的高水位不能继续挡住新进程的真实用量。
+    let usageExecutionGeneration = 0;
+    const acceptedUsageTotalByThread = new Map<
+      string,
+      { generation: number; total: TokenUsageBreakdown }
+    >();
+    const resetAcceptedUsageCursors = (reason: string): void => {
+      usageExecutionGeneration += 1;
+      acceptedUsageTotalByThread.clear();
+      log.info('resetting Codex usage cursors for a new app-server execution generation', {
+        generation: usageExecutionGeneration,
+        reason,
+      });
+    };
     /**
      * 已产出过模型内容(item 或 reasoning 增量)的 turn id。
      *
@@ -9482,7 +9495,9 @@ export class CodexAgent extends BaseAgent {
         const uncachedInput = Math.max(0, totalInput - cached);
         const cumulativeTotal = params.tokenUsage?.total;
         if (!cumulativeTotal) return;
-        const previousTotal = acceptedUsageTotalByThread.get(params.threadId);
+        const previousCursor = acceptedUsageTotalByThread.get(params.threadId);
+        const previousTotal =
+          previousCursor?.generation === usageExecutionGeneration ? previousCursor.total : undefined;
         const hasBillableLast =
           last.inputTokens > 0 ||
           last.cachedInputTokens > 0 ||
@@ -9499,7 +9514,10 @@ export class CodexAgent extends BaseAgent {
           cumulativeTotal.totalTokens > 0 &&
           (previousTotal === undefined || cumulativeTotal.totalTokens > previousTotal.totalTokens);
         if (isNewUsageSegment) {
-          acceptedUsageTotalByThread.set(params.threadId, { ...cumulativeTotal });
+          acceptedUsageTotalByThread.set(params.threadId, {
+            generation: usageExecutionGeneration,
+            total: { ...cumulativeTotal },
+          });
           usageTracker.ingestApiCallUsage({
             inputTokens: uncachedInput,
             // outputTokens already includes the reasoning subset. Adding
@@ -10910,6 +10928,11 @@ export class CodexAgent extends BaseAgent {
               }
               readonlyReferencesProfileActive = 'permissions' in turnThreadWorkspaceConfig;
               threadMayHaveRollout = true;
+              // The stale-daemon path has crossed an explicit app-server
+              // execution boundary. Reset all thread cursors before the retry;
+              // every thread on the daemon shares the same process-level
+              // cumulative usage source.
+              resetAcceptedUsageCursors('thread/resume after stale daemon');
               if (collaborationMode?.mode === 'default') {
                 planModeDefaultMarkerNeeded = true;
                 if (turnParams.collaborationMode?.mode === 'default') {

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -3205,6 +3205,10 @@ export class CodexAgent extends BaseAgent {
     // 缓存供 turn end 日志读取 (协议本身不在 turn/completed 里带 usage)。
     let lastTurnTokenUsage: TokenUsageBreakdown | null = null;
     let lastModelContextWindow: number | null = null;
+    // tokenUsage.total 是 thread 生命周期内的单调累计 cursor。app-server 会重放
+    // 相同快照（包括 compaction 的零帧），也可能让旧通知乱序晚到；只有 total
+    // 真正前进时，last 才代表一条新的可计费用量 segment。
+    const acceptedUsageTotalByThread = new Map<string, TokenUsageBreakdown>();
     /**
      * 已产出过模型内容(item 或 reasoning 增量)的 turn id。
      *
@@ -8329,7 +8333,23 @@ export class CodexAgent extends BaseAgent {
       // usage 用它, 不用 contextTokens 降级值 (那是整个上下文快照, 不是本 turn 增量)。
       // 必须在 endTurn 之前取: endTurn 会用降级 aggregate 覆盖后 reset。
       const realTurnUsage = usageTracker.getTurnUsage();
+      const realTurnUsageSegments = usageTracker.getTurnUsageSegments();
       finalizeCodexGenerationTurn(translatorRt, turn.id);
+      const generationDurationMs = codexGenerationDurationMs(translatorRt);
+      const codexDoneUsage = {
+        promptTokens: realTurnUsage.input,
+        completionTokens: realTurnUsage.output,
+        reasoningTokens: realTurnUsageSegments.reduce(
+          (sum, segment) => sum + (segment.reasoningTokens ?? 0),
+          0,
+        ),
+        cachedTokens: realTurnUsage.cacheRead,
+        segments: realTurnUsageSegments,
+        ...(generationDurationMs !== undefined ? { durationMs: generationDurationMs } : {}),
+        ...(typeof turn.durationMs === 'number' && Number.isFinite(turn.durationMs)
+          ? { turnDurationMs: turn.durationMs }
+          : {}),
+      };
       usageTracker.endTurn({
         inputTokens: lastSnap.contextTokens ?? 0,
         outputTokens: 0,
@@ -8448,7 +8468,12 @@ export class CodexAgent extends BaseAgent {
         }
         eventQueue.push({
           type: 'done',
-          data: { type: 'codex/event/task_complete', cancelled: turn.status === 'interrupted', raw: turn },
+          data: {
+            type: 'codex/event/task_complete',
+            cancelled: turn.status === 'interrupted',
+            usage: codexDoneUsage,
+            raw: turn,
+          },
           source: 'codex',
         });
         latestPlanByTurn.delete(turn.id);
@@ -8472,24 +8497,15 @@ export class CodexAgent extends BaseAgent {
       });
       // 真实 per-turn 用量 (host 的 today chip / daily_model_usage 记账消费):
       //   promptTokens     = 本 turn 未命中缓存的输入 (不再是 contextTokens 上下文快照)
-      //   completionTokens = 本 turn 输出+推理合并 (ingest 时已合并, 拆不回, 总量正确)
-      //   reasoningTokens  = 0 (已并入 completionTokens, 消费方求和口径不变)
+      //   completionTokens = 本 turn outputTokens（已包含 reasoning 子集，不重复相加）
+      //   reasoningTokens  = reasoning 明细子集，仅展示/诊断，不再参与总量求和
       //   cachedTokens     = 本 turn 命中缓存的输入
+      //   segments         = 每次 total cursor 前进对应的请求级 usage；定价方必须
+      //                      逐段选长上下文档位后再求和，不能拿 turn aggregate 选档
       // 契约: 本 payload **永远是 per-turn 增量语义**, 消费方 (today chip /
       // daily_model_usage 记账) 直接累加, 不做任何 delta 化。整个 turn 没收到
       // tokenUsage/updated 时就是全 0 (该 turn 不记账) — 不退回 contextTokens:
       // 在直接累加的消费方手里, 上下文快照会被当成一笔巨额输入, 高估远糟于漏记。
-      const generationDurationMs = codexGenerationDurationMs(translatorRt);
-      const codexDoneUsage = {
-        promptTokens: realTurnUsage.input,
-        completionTokens: realTurnUsage.output,
-        reasoningTokens: 0,
-        cachedTokens: realTurnUsage.cacheRead,
-        ...(generationDurationMs !== undefined ? { durationMs: generationDurationMs } : {}),
-        ...(typeof turn.durationMs === 'number' && Number.isFinite(turn.durationMs)
-          ? { turnDurationMs: turn.durationMs }
-          : {}),
-      };
       eventQueue.push({
         type: 'done',
         data: {
@@ -9456,26 +9472,58 @@ export class CodexAgent extends BaseAgent {
       tokenUsageUpdated: (params) => {
         if (enqueueIfBufferedTurn(params.turnId, () => handlers.tokenUsageUpdated?.(params))) return;
         if (shouldIgnoreStaleTurnEvent(params.turnId)) return;
+        lastModelContextWindow = capContextWindow(params.tokenUsage?.modelContextWindow ?? null);
+        usageTracker.setContextWindow(lastModelContextWindow ?? 0);
         const last = params.tokenUsage?.last;
         if (!last) return;
         lastTurnTokenUsage = last;
-        lastModelContextWindow = capContextWindow(params.tokenUsage?.modelContextWindow ?? null);
-        usageTracker.setContextWindow(lastModelContextWindow ?? 0);
         const cached = last.cachedInputTokens ?? 0;
         const totalInput = last.inputTokens ?? 0;
         const uncachedInput = Math.max(0, totalInput - cached);
-        const totalOutput = (last.outputTokens ?? 0) + (last.reasoningOutputTokens ?? 0);
-        usageTracker.ingestApiCallUsage({
-          inputTokens: uncachedInput,
-          outputTokens: totalOutput,
-          cacheReadTokens: cached,
-          cacheCreateTokens: 0,
-        });
-        maybePushUsageRefresh();
-        // Maker Memory flush 观察 (A 轻版: 只打日志). makerMemoryEnabled 关时 controller 为 null。
-        if (memoryFlushController) {
-          const snap = usageTracker.snapshot();
-          memoryFlushController.onUsageUpdate(snap.contextTokens, snap.contextWindow);
+        const cumulativeTotal = params.tokenUsage?.total;
+        if (!cumulativeTotal) return;
+        const previousTotal = acceptedUsageTotalByThread.get(params.threadId);
+        const hasBillableLast =
+          last.inputTokens > 0 ||
+          last.cachedInputTokens > 0 ||
+          last.outputTokens > 0 ||
+          last.reasoningOutputTokens > 0;
+        // A lower cursor can be an out-of-order frame, so it is not sufficient
+        // evidence of a new execution generation. A genuinely new thread gets
+        // a distinct threadId and therefore a fresh map entry. Same-thread
+        // resets need an explicit host/process generation before they can be
+        // accepted safely; guessing here would double-charge delayed frames.
+        const isNewUsageSegment =
+          hasBillableLast &&
+          Number.isFinite(cumulativeTotal.totalTokens) &&
+          cumulativeTotal.totalTokens > 0 &&
+          (previousTotal === undefined || cumulativeTotal.totalTokens > previousTotal.totalTokens);
+        if (isNewUsageSegment) {
+          acceptedUsageTotalByThread.set(params.threadId, { ...cumulativeTotal });
+          usageTracker.ingestApiCallUsage({
+            inputTokens: uncachedInput,
+            // outputTokens already includes the reasoning subset. Adding
+            // reasoningOutputTokens again double-counts completion usage.
+            outputTokens: last.outputTokens ?? 0,
+            cacheReadTokens: cached,
+            cacheCreateTokens: 0,
+            reasoningTokens: last.reasoningOutputTokens ?? 0,
+            model: turnOriginByTurnId.get(params.turnId)?.model ?? activeTurnModel ?? mutableModel,
+            priceVariant: isFastServiceTier(mutableServiceTier) ? 'priority' : 'standard',
+          });
+          maybePushUsageRefresh();
+          // Maker Memory flush 观察 (A 轻版: 只打日志). makerMemoryEnabled 关时 controller 为 null。
+          if (memoryFlushController) {
+            const snap = usageTracker.snapshot();
+            memoryFlushController.onUsageUpdate(snap.contextTokens, snap.contextWindow);
+          }
+        } else {
+          log.debug('ignoring duplicate or out-of-order Codex usage snapshot', {
+            threadId: params.threadId,
+            turnId: params.turnId,
+            previousTotal: previousTotal?.totalTokens ?? null,
+            cumulativeTotal: cumulativeTotal.totalTokens,
+          });
         }
         // 压缩风暴熔断 (见 compaction-storm.ts)。喂**上报的 input 总量**而不是
         // usageTracker 快照: 判据比的是「压缩前后同一口径的水位」, 而 tracker 的

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -3279,6 +3279,8 @@ export class CodexAgent extends BaseAgent {
        * 不算收紧，会把延迟中断标记清掉，而冻结的 Full access 仍然更宽）。
        */
       launchedPermissionMode: PermissionMode;
+      /** Service tier frozen for the logical send and any safe retry. */
+      serviceTier?: ServiceTier | null;
       /**
        * 在途 RPC 期间又收到容量失败 → 那条错误被延后处理（既没排计时器也没收口）。
        * RPC settle 且新 turn 没能激活时，必须凭这个标记补排一次，否则逻辑 send
@@ -3310,6 +3312,8 @@ export class CodexAgent extends BaseAgent {
       capabilitySelectionText: string;
       /** Catalog model frozen for this turn/start request. */
       model?: string;
+      /** Service tier frozen for this turn/start request. */
+      serviceTier?: ServiceTier | null;
       sendGen: number;
       startedAtMs: number;
     }>();
@@ -3329,6 +3333,7 @@ export class CodexAgent extends BaseAgent {
     const beginTurnStart = (
       ownerSendGen: number,
       capabilitySelectionText: string,
+      serviceTier?: ServiceTier | null,
     ): number => {
       const seq = ++turnStartSeq;
       inFlightStarts.set(seq, {
@@ -3336,6 +3341,7 @@ export class CodexAgent extends BaseAgent {
         terminalSettled: false,
         capabilitySelectionText,
         ...(activeTurnModel ? { model: activeTurnModel } : {}),
+        ...(serviceTier !== undefined ? { serviceTier } : {}),
         sendGen: ownerSendGen,
         startedAtMs: Date.now(),
       });
@@ -3387,6 +3393,8 @@ export class CodexAgent extends BaseAgent {
       startedAtMs: number;
       /** Catalog model accepted for this turn; spawn cards freeze inheritance from this value. */
       model?: string;
+      /** Service tier accepted for this turn; usage segments must read this, not mutable session state. */
+      serviceTier?: ServiceTier | null;
     }>();
 
     const hasOtherInFlightStart = (seq: number): boolean => {
@@ -9426,6 +9434,10 @@ export class CodexAgent extends BaseAgent {
           : undefined;
         const existingTurnOrigin = turnOriginByTurnId.get(params.turn.id);
         const turnModel = startedOwner?.[1].model ?? existingTurnOrigin?.model ?? activeTurnModel;
+        const startedServiceTier = startedOwner?.[1].serviceTier;
+        const turnServiceTier = startedServiceTier !== undefined
+          ? startedServiceTier
+          : existingTurnOrigin?.serviceTier;
         turnOriginByTurnId.set(params.turn.id, {
           startSeq: startedOwner?.[0] ?? null,
           sendGen: startedOwner?.[1].sendGen ?? sendGeneration,
@@ -9435,6 +9447,7 @@ export class CodexAgent extends BaseAgent {
               ? existingTurnOrigin.startedAtMs
               : (startedOwnerEntries.length === 0 ? Date.now() : 0)),
           ...(turnModel ? { model: turnModel } : {}),
+          ...(turnServiceTier !== undefined ? { serviceTier: turnServiceTier } : {}),
         });
         // Notifications may arrive before the turn/start RPC response. Bind the
         // selector at the same unique-owner boundary as turnOrigin so an early
@@ -9514,6 +9527,7 @@ export class CodexAgent extends BaseAgent {
           cumulativeTotal.totalTokens > 0 &&
           (previousTotal === undefined || cumulativeTotal.totalTokens > previousTotal.totalTokens);
         if (isNewUsageSegment) {
+          const turnServiceTier = turnOriginByTurnId.get(params.turnId)?.serviceTier;
           acceptedUsageTotalByThread.set(params.threadId, {
             generation: usageExecutionGeneration,
             total: { ...cumulativeTotal },
@@ -9527,7 +9541,11 @@ export class CodexAgent extends BaseAgent {
             cacheCreateTokens: 0,
             reasoningTokens: last.reasoningOutputTokens ?? 0,
             model: turnOriginByTurnId.get(params.turnId)?.model ?? activeTurnModel ?? mutableModel,
-            priceVariant: isFastServiceTier(mutableServiceTier) ? 'priority' : 'standard',
+            priceVariant: isFastServiceTier(
+              turnServiceTier !== undefined ? turnServiceTier : mutableServiceTier,
+            )
+              ? 'priority'
+              : 'standard',
           });
           maybePushUsageRefresh();
           // Maker Memory flush 观察 (A 轻版: 只打日志). makerMemoryEnabled 关时 controller 为 null。
@@ -10558,6 +10576,7 @@ export class CodexAgent extends BaseAgent {
                 sendGen: startEntry.sendGen,
                 startedAtMs: startEntry.startedAtMs,
                 ...(startEntry.model ? { model: startEntry.model } : {}),
+                ...(startEntry.serviceTier !== undefined ? { serviceTier: startEntry.serviceTier } : {}),
               });
             }
             // 缓冲的歧义 started 对账 (codex R9 P2): 本响应确立在飞 RPC 的
@@ -10641,6 +10660,9 @@ export class CodexAgent extends BaseAgent {
               );
               // 权威归属: 这个 turn 由本次 start 生出, 属于本轮 send。
               const turnModel = startEntry?.model ?? activeTurnModel;
+              const turnServiceTier = startEntry?.serviceTier !== undefined
+                ? startEntry.serviceTier
+                : turnOriginByTurnId.get(resp.turn.id)?.serviceTier;
               turnOriginByTurnId.set(resp.turn.id, {
                 startSeq: ownerSeq,
                 sendGen: mySendGen,
@@ -10649,6 +10671,7 @@ export class CodexAgent extends BaseAgent {
                   ?? turnOriginByTurnId.get(resp.turn.id)?.startedAtMs
                   ?? Date.now(),
                 ...(turnModel ? { model: turnModel } : {}),
+                ...(turnServiceTier !== undefined ? { serviceTier: turnServiceTier } : {}),
               });
               activateRootTurn(resp.turn.id);
               currentTurnPlanModeActive = turnStartsInPlanMode;
@@ -10687,7 +10710,16 @@ export class CodexAgent extends BaseAgent {
             }
           }
           if (Object.hasOwn(resp, 'serviceTier')) {
-            mutableServiceTier = normalizeServiceTier(resp.serviceTier) ?? null;
+            const acceptedServiceTier = normalizeServiceTier(resp.serviceTier) ?? null;
+            const startEntry = inFlightStarts.get(ownerSeq);
+            if (startEntry) startEntry.serviceTier = acceptedServiceTier;
+            if (resp.turn?.id) {
+              const origin = turnOriginByTurnId.get(resp.turn.id);
+              if (origin) {
+                origin.serviceTier = acceptedServiceTier;
+              }
+            }
+            mutableServiceTier = acceptedServiceTier;
             log.debug('turn/start response serviceTier', {
               turnId: resp.turn?.id ?? null,
               serviceTier: mutableServiceTier,
@@ -10711,6 +10743,7 @@ export class CodexAgent extends BaseAgent {
           inFlight: false,
           isCancelled: () => sendOpts?.signal?.aborted === true,
           launchedPermissionMode: mutablePermissionMode,
+          ...(turnParams.serviceTier !== undefined ? { serviceTier: turnParams.serviceTier } : {}),
           sendGen: mySendGen,
           deferredCapacityFailure: null,
           disposeSignalWatch: null,
@@ -10732,6 +10765,7 @@ export class CodexAgent extends BaseAgent {
             const retryStartSeq = beginTurnStart(
               state.sendGen,
               capabilitySelectionText,
+              state.serviceTier,
             );
             // RPC 是否走完了成功路径。补排延后的容量失败**只能**在成功路径上做:
             // finally 先于外层 state.retry().catch 执行, 若 RPC 已经 reject 却在这里
@@ -10838,6 +10872,7 @@ export class CodexAgent extends BaseAgent {
         const initialStartSeq = beginTurnStart(
           mySendGen,
           capabilitySelectionText,
+          turnParams.serviceTier,
         );
         let initialStartSettledOk = false;
         /** 本次请求是否已被 Stop / 撤单收口过(条目会在 finally 里删掉, 所以先取出来)。 */

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -10645,6 +10645,25 @@ export class CodexAgent extends BaseAgent {
             // 墓碑: 该 turn 的终态已抢在本响应之前到达 (典型: 收紧补中断后
             // turnCompleted(interrupted) 先回), 不得重新置活, 否则会话卡 running。
             const alreadyCompleted = turnsCompletedBeforeStartResp.has(resp.turn.id);
+            // The app-server's response is the first authoritative proof of the
+            // tier it accepted.  Calibrate the per-turn origin before replaying
+            // any notifications that arrived while turn/start was in flight;
+            // otherwise a buffered tokenUsageUpdated can be priced with the
+            // requested Fast tier even when the server downgraded the turn.
+            if (Object.hasOwn(resp, 'serviceTier')) {
+              const acceptedServiceTier = normalizeServiceTier(resp.serviceTier) ?? null;
+              const startEntry = inFlightStarts.get(ownerSeq);
+              if (startEntry) startEntry.serviceTier = acceptedServiceTier;
+              const origin = turnOriginByTurnId.get(resp.turn.id);
+              if (origin) origin.serviceTier = acceptedServiceTier;
+              mutableServiceTier = acceptedServiceTier;
+              log.debug('turn/start response serviceTier', {
+                turnId: resp.turn.id,
+                serviceTier: mutableServiceTier,
+                fastMode: isFastServiceTier(mutableServiceTier),
+                note: 'serviceTier calibrated before buffered turn replay',
+              });
+            }
             // 强退守卫 (Greptile P1 on #1720): hostForcedRetire 已把本会话终态收口
             // (eventQueue.end), 迟到的 turn/start 成功响应不得重新激活。正常流程里
             // client.close() 会 reject 挂起 RPC 且 quarantine 已在 adoptUnidentifiedDeadTurn
@@ -10708,24 +10727,6 @@ export class CodexAgent extends BaseAgent {
               pendingTightenInterrupt = false;
               if (!alreadyCompleted) void interruptTurnForPermissionTighten(resp.turn.id);
             }
-          }
-          if (Object.hasOwn(resp, 'serviceTier')) {
-            const acceptedServiceTier = normalizeServiceTier(resp.serviceTier) ?? null;
-            const startEntry = inFlightStarts.get(ownerSeq);
-            if (startEntry) startEntry.serviceTier = acceptedServiceTier;
-            if (resp.turn?.id) {
-              const origin = turnOriginByTurnId.get(resp.turn.id);
-              if (origin) {
-                origin.serviceTier = acceptedServiceTier;
-              }
-            }
-            mutableServiceTier = acceptedServiceTier;
-            log.debug('turn/start response serviceTier', {
-              turnId: resp.turn?.id ?? null,
-              serviceTier: mutableServiceTier,
-              fastMode: isFastServiceTier(mutableServiceTier),
-              note: 'serviceTier returned by app-server turn/start response',
-            });
           }
         };
         // 登记本轮的过载重投器。闭包持有 turnParams 与本轮的响应处理逻辑，因此

--- a/packages/maker-core/src/agents/pi/__tests__/cindySubagentSource.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/cindySubagentSource.test.ts
@@ -349,6 +349,15 @@ describe('cindy-subagent extension source', () => {
     for (const field of ['input', 'output', 'cacheRead', 'cacheWrite', 'cost']) {
       expect(CINDY_SUBAGENT_EXTENSION_SOURCE).toContain(field + ': totals.usage.' + field + ',');
     }
+    // Request boundaries come from the durable runner status. Dropping them in
+    // the generated extension would force the parent back to an unpriceable
+    // turn aggregate even though the child recorded each provider request.
+    expect(CINDY_SUBAGENT_EXTENSION_SOURCE).toContain(
+      'usageSegments: Array.isArray(task.usageSegments) ? task.usageSegments : [],',
+    );
+    expect(CINDY_SUBAGENT_EXTENSION_SOURCE).toContain(
+      'usageSegments: totals.usageSegments.map(function (segment)',
+    );
   });
 
 

--- a/packages/maker-core/src/agents/pi/__tests__/pi-translator.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/pi-translator.test.ts
@@ -970,14 +970,18 @@ describe('pi translator', () => {
     expect(events.filter((event) => event.type === 'done')).toHaveLength(1);
   });
 
-  it('locks the Pi price variant at each provider request boundary', () => {
+  it('locks the Pi price variant from bridge usage metadata at each provider request boundary', () => {
     const ctx = createPiTranslateContext(noopLogger);
     let fast = false;
     ctx.getPriceVariant = () => (fast ? 'priority' : 'standard');
     const { queue, events } = makeQueue();
 
     translatePiEvent(ev({ type: 'agent_start' }), queue, ctx);
-    translatePiEvent(ev({ type: 'message_start' }), queue, ctx);
+    translatePiEvent(
+      ev({ type: 'message_start', message: { usage: { service_tier: 'default' } } }),
+      queue,
+      ctx,
+    );
     fast = true;
     translatePiEvent(
       ev({
@@ -986,14 +990,18 @@ describe('pi translator', () => {
           role: 'assistant',
           model: 'gpt-5.6-sol',
           content: [{ type: 'text', text: 'standard request' }],
-          usage: { input: 10, output: 2 },
+          usage: { input: 10, output: 2, service_tier: 'default' },
         },
       }),
       queue,
       ctx,
     );
 
-    translatePiEvent(ev({ type: 'message_start' }), queue, ctx);
+    translatePiEvent(
+      ev({ type: 'message_start', message: { usage: { service_tier: 'priority' } } }),
+      queue,
+      ctx,
+    );
     translatePiEvent(
       ev({
         type: 'message_end',
@@ -1001,7 +1009,7 @@ describe('pi translator', () => {
           role: 'assistant',
           model: 'gpt-5.6-sol',
           content: [{ type: 'text', text: 'priority request' }],
-          usage: { input: 20, output: 3 },
+          usage: { input: 20, output: 3, service_tier: 'priority' },
         },
       }),
       queue,

--- a/packages/maker-core/src/agents/pi/__tests__/pi-translator.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/pi-translator.test.ts
@@ -937,11 +937,20 @@ describe('pi translator', () => {
 
     const done = events.find((e) => e.type === 'done');
     expect(done).toBeDefined();
-    const usage = (done!.data as { usage: Record<string, number> }).usage;
+    const usage = (done!.data as { usage: Record<string, unknown> }).usage;
     expect(usage.inputTokens).toBe(100);
     expect(usage.outputTokens).toBe(20);
     expect(usage.cacheReadTokens).toBe(5);
     expect(usage.cacheCreationTokens).toBe(3);
+    expect(usage.segmentsComplete).toBe(true);
+    expect(usage.segments).toEqual([
+      expect.objectContaining({
+        inputTokens: 100,
+        outputTokens: 20,
+        cacheReadTokens: 5,
+        cacheCreateTokens: 3,
+      }),
+    ]);
     expect(usage.durationMs).toBeGreaterThanOrEqual(1_200);
     expect(usage.turnDurationMs).toBeGreaterThanOrEqual(0);
     // 快照累计 input+output。
@@ -957,6 +966,8 @@ describe('pi translator', () => {
       type: 'status',
       data: expect.objectContaining({ status: 'Done', isRunning: false }),
     }));
+    translatePiEvent(ev({ type: 'agent_settled' }), queue, ctx);
+    expect(events.filter((event) => event.type === 'done')).toHaveLength(1);
   });
 
   it('marks generation active on message_start so the UI can tick live TPS', () => {
@@ -1424,6 +1435,88 @@ describe('pi translator', () => {
       expect(ctx.turnOutput).toBe(40);
       expect(ctx.turnTokens).toBe(290);
       expect(ctx.costUsd).toBeCloseTo(0.03, 10);
+    });
+
+    it('deduplicates child request segments across cumulative progress frames', () => {
+      const ctx = createPiTranslateContext(noopLogger);
+      const { queue, events } = makeQueue();
+      translatePiEvent(ev({ type: 'agent_start' }), queue, ctx);
+      const segments = [
+        {
+          id: 'r1',
+          model: 'gpt-5.5',
+          input: 100,
+          output: 10,
+          cacheRead: 5,
+          cacheWrite: 0,
+          cost: 0.01,
+        },
+        {
+          id: 'r2',
+          model: 'gpt-5.5',
+          input: 200,
+          output: 20,
+          cacheRead: 15,
+          cacheWrite: 0,
+          cost: 0.02,
+        },
+      ];
+      translatePiEvent(
+        progressEvent(
+          'sa-1',
+          { input: 300, output: 30, cacheRead: 20, cost: 0.03 },
+          { usageSegments: segments },
+        ),
+        queue,
+        ctx,
+      );
+      translatePiEvent(
+        progressEvent(
+          'sa-1',
+          { input: 300, output: 30, cacheRead: 20, cost: 0.03 },
+          { usageSegments: segments },
+        ),
+        queue,
+        ctx,
+      );
+      translatePiEvent(ev({ type: 'agent_settled' }), queue, ctx);
+
+      expect(ctx.turnInput).toBe(300);
+      expect(ctx.turnOutput).toBe(30);
+      expect(ctx.costUsd).toBeCloseTo(0.03, 10);
+      const usage = (
+        events.find((event) => event.type === 'done')!.data as { usage: Record<string, unknown> }
+      ).usage;
+      expect(usage.segmentsComplete).toBe(true);
+      expect(usage.segments).toHaveLength(2);
+    });
+
+    it('falls back to token-only accounting when child segments do not cover the cumulative total', () => {
+      const ctx = createPiTranslateContext(noopLogger);
+      const { queue, events } = makeQueue();
+      translatePiEvent(ev({ type: 'agent_start' }), queue, ctx);
+      translatePiEvent(
+        progressEvent(
+          'sa-1',
+          { input: 300, output: 30, cacheRead: 20, cost: 0.03 },
+          {
+            usageSegments: [
+              { id: 'r1', model: 'gpt-5.5', input: 100, output: 10, cacheRead: 5, cost: 0.01 },
+            ],
+          },
+        ),
+        queue,
+        ctx,
+      );
+      translatePiEvent(ev({ type: 'agent_settled' }), queue, ctx);
+
+      expect(ctx.turnInput).toBe(300);
+      expect(ctx.turnOutput).toBe(30);
+      const usage = (
+        events.find((event) => event.type === 'done')!.data as { usage: Record<string, unknown> }
+      ).usage;
+      expect(usage.segmentsComplete).toBe(false);
+      expect(usage.segments).toEqual([]);
     });
 
     it('accumulates parallel delegations independently and never goes negative', () => {

--- a/packages/maker-core/src/agents/pi/__tests__/pi-translator.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/pi-translator.test.ts
@@ -970,6 +970,54 @@ describe('pi translator', () => {
     expect(events.filter((event) => event.type === 'done')).toHaveLength(1);
   });
 
+  it('locks the Pi price variant at each provider request boundary', () => {
+    const ctx = createPiTranslateContext(noopLogger);
+    let fast = false;
+    ctx.getPriceVariant = () => (fast ? 'priority' : 'standard');
+    const { queue, events } = makeQueue();
+
+    translatePiEvent(ev({ type: 'agent_start' }), queue, ctx);
+    translatePiEvent(ev({ type: 'message_start' }), queue, ctx);
+    fast = true;
+    translatePiEvent(
+      ev({
+        type: 'message_end',
+        message: {
+          role: 'assistant',
+          model: 'gpt-5.6-sol',
+          content: [{ type: 'text', text: 'standard request' }],
+          usage: { input: 10, output: 2 },
+        },
+      }),
+      queue,
+      ctx,
+    );
+
+    translatePiEvent(ev({ type: 'message_start' }), queue, ctx);
+    translatePiEvent(
+      ev({
+        type: 'message_end',
+        message: {
+          role: 'assistant',
+          model: 'gpt-5.6-sol',
+          content: [{ type: 'text', text: 'priority request' }],
+          usage: { input: 20, output: 3 },
+        },
+      }),
+      queue,
+      ctx,
+    );
+    translatePiEvent(ev({ type: 'agent_settled' }), queue, ctx);
+
+    const usage = (events.find((event) => event.type === 'done')!.data as {
+      usage: { segments: Array<{ priceVariant?: string }> };
+    }).usage;
+    expect(usage.segments.map((segment) => segment.priceVariant)).toEqual([
+      'standard',
+      'priority',
+    ]);
+  });
+
   it('marks generation active on message_start so the UI can tick live TPS', () => {
     const ctx = createPiTranslateContext(noopLogger);
     const { queue, events } = makeQueue();

--- a/packages/maker-core/src/agents/pi/cindy-subagent-runner-source.ts
+++ b/packages/maker-core/src/agents/pi/cindy-subagent-runner-source.ts
@@ -274,6 +274,7 @@ function main() {
       scheduled: false,
       toolUses: 0,
       usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0 },
+      usageSegments: [],
       output: '',
       outputTruncated: false,
       error: undefined,
@@ -317,6 +318,7 @@ function main() {
       addUsage(usage, task.usage);
       toolUses += task.toolUses;
     }
+    const usageSegments = tasks.flatMap(function (task) { return task.usageSegments; });
     return {
       version: STATUS_VERSION,
       runId: config.runId,
@@ -343,6 +345,7 @@ function main() {
       toolUses: toolUses,
       totalTokens: usage.input + usage.output + usage.cacheRead + usage.cacheWrite,
       usage: usage,
+      usageSegments: usageSegments,
       transcriptPath: transcriptPath,
       resultPath: state.resultWritten ? resultPath : undefined,
       tasks: tasks.map(function (task) {
@@ -358,6 +361,7 @@ function main() {
           thinking: task.thinking,
           toolUses: task.toolUses,
           usage: task.usage,
+          usageSegments: task.usageSegments,
           // message_end is already a complete generation result even if Pi
           // keeps the RPC process alive for follow-up. Publish it immediately
           // so the host can hide late Steer before writing a doomed control.
@@ -886,7 +890,19 @@ function main() {
             task.output = bounded.value;
             task.outputTruncated = bounded.truncated;
           }
-          addUsage(task.usage, usageOf(event.message));
+          const requestUsage = usageOf(event.message);
+          addUsage(task.usage, requestUsage);
+          task.usageSegments.push({
+            id: task.childId + ':' + String(task.usageSegments.length + 1),
+            model: typeof event.message.model === 'string' && event.message.model
+              ? event.message.model
+              : (task.displayModel || task.model),
+            input: requestUsage.input,
+            output: requestUsage.output,
+            cacheRead: requestUsage.cacheRead,
+            cacheWrite: requestUsage.cacheWrite,
+            cost: requestUsage.cost,
+          });
           scheduleStatus();
           return;
         }
@@ -1131,6 +1147,7 @@ function main() {
           outputTruncated: task.outputTruncated || undefined,
           error: task.error,
           usage: task.usage,
+          usageSegments: task.usageSegments,
           toolUses: task.toolUses,
         };
       }),

--- a/packages/maker-core/src/agents/pi/cindy-subagent-source.ts
+++ b/packages/maker-core/src/agents/pi/cindy-subagent-source.ts
@@ -1240,8 +1240,10 @@ export default async function cindySubagent(pi: any) {
       const startedAt = Date.now();
       const label = tasks.map(function (t) { return t.agent; }).join(', ');
       const taskId = String(toolCallId || 'subagent');
-      const totals = { toolUses: 0, tokens: 0, usage: emptyUsage() };
-      const perTask = tasks.map(function () { return { toolUses: 0, tokens: 0, usage: emptyUsage() }; });
+      const totals = { toolUses: 0, tokens: 0, usage: emptyUsage(), usageSegments: [] as any[] };
+      const perTask = tasks.map(function () {
+        return { toolUses: 0, tokens: 0, usage: emptyUsage(), usageSegments: [] as any[] };
+      });
 
       const report = function (status: string, summary?: string) {
         if (typeof onUpdate !== 'function') return;
@@ -1263,6 +1265,9 @@ export default async function cindySubagent(pi: any) {
             cacheWrite: totals.usage.cacheWrite,
             cost: totals.usage.cost,
           },
+          usageSegments: totals.usageSegments.map(function (segment) {
+            return Object.assign({}, segment);
+          }),
         };
         details[MARKER] = 1;
         if (summary) details.summary = summary;
@@ -1278,14 +1283,19 @@ export default async function cindySubagent(pi: any) {
         let toolUses = 0;
         let tokens = 0;
         const usage = emptyUsage();
+        const usageSegments: any[] = [];
         for (const entry of perTask) {
           toolUses += entry.toolUses;
           tokens += entry.tokens;
           mergeUsage(usage, entry.usage);
+          if (Array.isArray(entry.usageSegments)) {
+            usageSegments.push.apply(usageSegments, entry.usageSegments);
+          }
         }
         totals.toolUses = toolUses;
         totals.tokens = tokens;
         totals.usage = usage;
+        totals.usageSegments = usageSegments;
       };
 
       // 两道**派发前**的失败关闭闸。注意它们排在 report 定义**之后**、report('running')
@@ -1352,6 +1362,7 @@ export default async function cindySubagent(pi: any) {
               + Number(task.usage.cacheWrite || 0)
             )),
             usage: task.usage || emptyUsage(),
+            usageSegments: Array.isArray(task.usageSegments) ? task.usageSegments : [],
           };
         });
         recompute();
@@ -1369,10 +1380,16 @@ export default async function cindySubagent(pi: any) {
             + Number(task.usage.cacheWrite || 0)
           )),
           usage: task.usage || emptyUsage(),
+          usageSegments: Array.isArray(task.usageSegments) ? task.usageSegments : [],
         };
       });
       results.forEach(function (result, index) {
-        perTask[index] = { toolUses: result.toolUses, tokens: result.tokens, usage: result.usage };
+        perTask[index] = {
+          toolUses: result.toolUses,
+          tokens: result.tokens,
+          usage: result.usage,
+          usageSegments: result.usageSegments,
+        };
       });
       recompute();
 

--- a/packages/maker-core/src/agents/pi/index.ts
+++ b/packages/maker-core/src/agents/pi/index.ts
@@ -2441,6 +2441,7 @@ export class PiAgent extends BaseAgent {
 
     const queue: AsyncQueue<AgentEvent> = createAsyncQueue<AgentEvent>();
     const ctx: PiTranslateContext = createPiTranslateContext(this.deps.logger);
+    ctx.getPriceVariant = opts.getPriceVariant;
     const contextModeRoot = findContextModePackageRoot(managedPackageResources.packageRoots);
     ctx.rewriteToolResultText = (text) => rewriteContextModeDoctorPath(text, contextModeRoot);
     let interactionResolver: InteractionResolver | null = null;

--- a/packages/maker-core/src/agents/pi/subagent-progress.ts
+++ b/packages/maker-core/src/agents/pi/subagent-progress.ts
@@ -43,6 +43,11 @@ export interface PiSubagentUsage {
   cost: number;
 }
 
+export interface PiSubagentUsageSegment extends PiSubagentUsage {
+  id: string;
+  model?: string;
+}
+
 /**
  * parse 结果:卡片更新 + 可选的委派用量。
  *
@@ -54,6 +59,8 @@ export interface PiSubagentProgress {
   update: AgentTaskUpdateEventData;
   /** 累计值,不是增量。调用方按 taskId 记住上次值再作差。 */
   delegatedUsage?: PiSubagentUsage;
+  /** Request snapshots; preferred over delegatedUsage for request-scoped pricing. */
+  delegatedUsageSegments?: PiSubagentUsageSegment[];
 }
 
 function readUsage(value: unknown): PiSubagentUsage | undefined {
@@ -75,6 +82,21 @@ function readUsage(value: unknown): PiSubagentUsage | undefined {
     return undefined;
   }
   return usage;
+}
+
+function readUsageSegments(value: unknown): PiSubagentUsageSegment[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const segments: PiSubagentUsageSegment[] = [];
+  for (const item of value) {
+    if (!item || typeof item !== 'object' || Array.isArray(item)) continue;
+    const raw = item as Record<string, unknown>;
+    const id = typeof raw.id === 'string' ? raw.id.trim() : '';
+    const usage = readUsage(raw);
+    if (!id || !usage) continue;
+    const model = readString(raw.model, 200);
+    segments.push({ id, ...usage, ...(model ? { model } : {}) });
+  }
+  return segments.length > 0 ? segments : undefined;
 }
 
 function readString(value: unknown, max = MAX_TEXT): string | undefined {
@@ -128,6 +150,7 @@ export function parsePiSubagentProgress(partialResult: unknown): PiSubagentProgr
   const model = readString(raw.model, 200);
 
   const delegatedUsage = readUsage(raw.usage);
+  const delegatedUsageSegments = readUsageSegments(raw.usageSegments);
 
   return {
     update: {
@@ -147,6 +170,7 @@ export function parsePiSubagentProgress(partialResult: unknown): PiSubagentProgr
       ...(usage ? { usage } : {}),
     },
     ...(delegatedUsage ? { delegatedUsage } : {}),
+    ...(delegatedUsageSegments ? { delegatedUsageSegments } : {}),
   };
 }
 

--- a/packages/maker-core/src/agents/pi/translator.ts
+++ b/packages/maker-core/src/agents/pi/translator.ts
@@ -88,6 +88,8 @@ interface PiThinkingBlock {
 
 export interface PiTranslateContext {
   logger: Logger;
+  /** Host-owned live tariff selector, sampled at request boundaries. */
+  getPriceVariant?: () => 'standard' | 'priority';
   /** get_state 拿到的 contextWindow(模型切换时更新)。 */
   contextWindow: number;
   /** turn 内累计 input+output;turn 结束 reset。 */
@@ -100,6 +102,8 @@ export interface PiTranslateContext {
   turnUsageSegments: UsageSegment[];
   turnUsageSegmentsComplete: boolean;
   turnUsageSegmentSeq: number;
+  /** Price variants latched by message_start until their matching message_end. */
+  pendingPriceVariants: Array<'standard' | 'priority'>;
   turnSettled: boolean;
   /** 最后一次 API call 的 context 占用(input + cacheRead + cacheWrite)。 */
   contextTokens: number;
@@ -170,6 +174,7 @@ export interface PiTranslateContext {
 export function createPiTranslateContext(logger: Logger): PiTranslateContext {
   return {
     logger,
+    getPriceVariant: undefined,
     contextWindow: 0,
     turnTokens: 0,
     turnInput: 0,
@@ -179,6 +184,7 @@ export function createPiTranslateContext(logger: Logger): PiTranslateContext {
     turnUsageSegments: [],
     turnUsageSegmentsComplete: true,
     turnUsageSegmentSeq: 0,
+    pendingPriceVariants: [],
     turnSettled: false,
     contextTokens: 0,
     costUsd: 0,
@@ -301,7 +307,12 @@ function takeCompactTurnScope(
   return idleCompactScope(ctx);
 }
 
-function applyUsage(ctx: PiTranslateContext, usage: PiUsage | undefined, model?: string): void {
+function applyUsage(
+  ctx: PiTranslateContext,
+  usage: PiUsage | undefined,
+  model?: string,
+  priceVariant?: 'standard' | 'priority',
+): void {
   if (!usage) return;
   const input = usage.input ?? 0;
   const output = usage.output ?? 0;
@@ -323,6 +334,7 @@ function applyUsage(ctx: PiTranslateContext, usage: PiUsage | undefined, model?:
     cacheReadTokens: cacheRead,
     cacheCreateTokens: cacheWrite,
     ...(typeof cost === 'number' && Number.isFinite(cost) ? { costUsd: cost } : {}),
+    ...(priceVariant ? { priceVariant } : {}),
   });
 }
 
@@ -534,6 +546,7 @@ export function translatePiEvent(
       ctx.turnUsageSegments = [];
       ctx.turnUsageSegmentsComplete = true;
       ctx.turnUsageSegmentSeq = 0;
+      ctx.pendingPriceVariants = [];
       ctx.turnSettled = false;
       ctx.finalAssistantText = '';
       ctx.pendingAssistantError = null;
@@ -559,6 +572,7 @@ export function translatePiEvent(
     case 'message_start': {
       ctx.thinkingBlocks.clear();
       ctx.streamStopTokenByIndex.clear();
+      ctx.pendingPriceVariants.push(ctx.getPriceVariant?.() ?? 'standard');
       startPiGenerationHeartbeat(ctx);
       // Tell the UI generation is active so it can tick the TPS denominator
       // locally between sparse message_end usage reports.
@@ -576,7 +590,9 @@ export function translatePiEvent(
     case 'message_end': {
       const message = event.message as PiAssistantMessage | undefined;
       if (!message || message.role !== 'assistant') return;
-      applyUsage(ctx, message.usage, message.model);
+      const priceVariant =
+        ctx.pendingPriceVariants.shift() ?? ctx.getPriceVariant?.() ?? 'standard';
+      applyUsage(ctx, message.usage, message.model, priceVariant);
       const hadGenerationHeartbeat = ctx.generationHeartbeatAt > 0;
       samplePiGenerationHeartbeat(ctx);
       const messageDurationMs =
@@ -777,6 +793,7 @@ export function translatePiEvent(
       if (ctx.turnSettled) return;
       ctx.turnSettled = true;
       ctx.isStreaming = false;
+      ctx.pendingPriceVariants = [];
       stopPiGenerationHeartbeat(ctx);
       const pendingAssistantError = ctx.pendingAssistantError;
       ctx.pendingAssistantError = null;
@@ -827,6 +844,10 @@ export function translatePiEvent(
     }
 
     case 'auto_retry_start': {
+      // A provider retry may begin without a matching message_end for the
+      // failed request. Drop any stale latch so the next request samples its
+      // own tariff at message_start.
+      ctx.pendingPriceVariants = [];
       // 走 CC/Codex 同一套 `(auto-retry N/M)` 跨 agent 协议。这个后缀在 mobile /
       // Telegram 投影里**只表示过载**，不能拿去编码未分类 5xx —— 否则手机会把普通
       // 供应商故障显示成「模型服务繁忙」。

--- a/packages/maker-core/src/agents/pi/translator.ts
+++ b/packages/maker-core/src/agents/pi/translator.ts
@@ -57,6 +57,8 @@ interface PiUsage {
   cacheRead?: number;
   cacheWrite?: number;
   cost?: { total?: number };
+  /** Anthropic bridge metadata: the tier accepted for this concrete request. */
+  service_tier?: string;
 }
 
 interface PiAssistantMessage {
@@ -88,7 +90,7 @@ interface PiThinkingBlock {
 
 export interface PiTranslateContext {
   logger: Logger;
-  /** Host-owned live tariff selector, sampled at request boundaries. */
+  /** Host-owned live tariff selector fallback when the provider response has no accepted tier. */
   getPriceVariant?: () => 'standard' | 'priority';
   /** get_state 拿到的 contextWindow(模型切换时更新)。 */
   contextWindow: number;
@@ -338,6 +340,12 @@ function applyUsage(
   });
 }
 
+function priceVariantFromServiceTier(value: unknown): 'standard' | 'priority' | undefined {
+  if (value === 'priority') return 'priority';
+  if (value === 'default' || value === 'standard') return 'standard';
+  return undefined;
+}
+
 /**
  * 把子代理(委派)的用量并进本 turn 的记账。
  *
@@ -572,7 +580,9 @@ export function translatePiEvent(
     case 'message_start': {
       ctx.thinkingBlocks.clear();
       ctx.streamStopTokenByIndex.clear();
-      ctx.pendingPriceVariants.push(ctx.getPriceVariant?.() ?? 'standard');
+      const message = event.message as { usage?: PiUsage } | undefined;
+      const bridgedPriceVariant = priceVariantFromServiceTier(message?.usage?.service_tier);
+      ctx.pendingPriceVariants.push(bridgedPriceVariant ?? ctx.getPriceVariant?.() ?? 'standard');
       startPiGenerationHeartbeat(ctx);
       // Tell the UI generation is active so it can tick the TPS denominator
       // locally between sparse message_end usage reports.
@@ -590,8 +600,10 @@ export function translatePiEvent(
     case 'message_end': {
       const message = event.message as PiAssistantMessage | undefined;
       if (!message || message.role !== 'assistant') return;
+      const pendingPriceVariant = ctx.pendingPriceVariants.shift();
+      const reportedPriceVariant = priceVariantFromServiceTier(message.usage?.service_tier);
       const priceVariant =
-        ctx.pendingPriceVariants.shift() ?? ctx.getPriceVariant?.() ?? 'standard';
+        pendingPriceVariant ?? reportedPriceVariant ?? ctx.getPriceVariant?.() ?? 'standard';
       applyUsage(ctx, message.usage, message.model, priceVariant);
       const hadGenerationHeartbeat = ctx.generationHeartbeatAt > 0;
       samplePiGenerationHeartbeat(ctx);

--- a/packages/maker-core/src/agents/pi/translator.ts
+++ b/packages/maker-core/src/agents/pi/translator.ts
@@ -29,6 +29,7 @@ import {
 import type { AgentEvent, AgentTaskUpdateEventData, UsageSnapshot } from '../../types/index.js';
 import type { AsyncQueue } from '../shared/async-queue.js';
 import { attachLiveGeneration } from '../shared/live-generation-snapshot.js';
+import type { UsageSegment } from '../shared/usage-tracker.js';
 import {
   UPSTREAM_OVERLOAD_REASON,
   formatOverloadRetryMessage,
@@ -44,7 +45,11 @@ import {
 } from '../shared/stream-interrupt-error.js';
 import { isContextModeDoctorToolName } from './context-mode-doctor-path.js';
 import type { PiRpcEvent } from './rpc-client.js';
-import { parsePiSubagentProgress, type PiSubagentUsage } from './subagent-progress.js';
+import {
+  parsePiSubagentProgress,
+  type PiSubagentUsage,
+  type PiSubagentUsageSegment,
+} from './subagent-progress.js';
 
 interface PiUsage {
   input?: number;
@@ -92,6 +97,10 @@ export interface PiTranslateContext {
   turnOutput: number;
   turnCacheRead: number;
   turnCacheWrite: number;
+  turnUsageSegments: UsageSegment[];
+  turnUsageSegmentsComplete: boolean;
+  turnUsageSegmentSeq: number;
+  turnSettled: boolean;
   /** 最后一次 API call 的 context 占用(input + cacheRead + cacheWrite)。 */
   contextTokens: number;
   /** 跨 turn 累计成本。 */
@@ -134,6 +143,8 @@ export interface PiTranslateContext {
    * 用来算增量,避免同一批用量被反复加进 turn 记账。与其它 turn 计数器同点(agent_start)清空。
    */
   delegatedUsage: Map<string, PiSubagentUsage>;
+  delegatedUsageSegmentIds: Set<string>;
+  delegatedUsageIncompleteTaskIds: Set<string>;
   /**
    * Tool calls explicitly identified as Cindy's PI Subagent extension.
    *
@@ -165,6 +176,10 @@ export function createPiTranslateContext(logger: Logger): PiTranslateContext {
     turnOutput: 0,
     turnCacheRead: 0,
     turnCacheWrite: 0,
+    turnUsageSegments: [],
+    turnUsageSegmentsComplete: true,
+    turnUsageSegmentSeq: 0,
+    turnSettled: false,
     contextTokens: 0,
     costUsd: 0,
     isStreaming: false,
@@ -180,6 +195,8 @@ export function createPiTranslateContext(logger: Logger): PiTranslateContext {
     generationHeartbeatTimer: null,
     generationHeartbeatReliable: true,
     delegatedUsage: new Map(),
+    delegatedUsageSegmentIds: new Set(),
+    delegatedUsageIncompleteTaskIds: new Set(),
     subagentToolCalls: new Map(),
     toolNamesByCallId: new Map(),
     pendingAssistantError: null,
@@ -284,7 +301,7 @@ function takeCompactTurnScope(
   return idleCompactScope(ctx);
 }
 
-function applyUsage(ctx: PiTranslateContext, usage: PiUsage | undefined): void {
+function applyUsage(ctx: PiTranslateContext, usage: PiUsage | undefined, model?: string): void {
   if (!usage) return;
   const input = usage.input ?? 0;
   const output = usage.output ?? 0;
@@ -298,6 +315,15 @@ function applyUsage(ctx: PiTranslateContext, usage: PiUsage | undefined): void {
   ctx.contextTokens = input + cacheRead + cacheWrite;
   const cost = usage.cost?.total;
   if (typeof cost === 'number' && Number.isFinite(cost)) ctx.costUsd += cost;
+  ctx.turnUsageSegments.push({
+    id: `pi:${++ctx.turnUsageSegmentSeq}`,
+    ...(model ? { model } : {}),
+    inputTokens: input,
+    outputTokens: output,
+    cacheReadTokens: cacheRead,
+    cacheCreateTokens: cacheWrite,
+    ...(typeof cost === 'number' && Number.isFinite(cost) ? { costUsd: cost } : {}),
+  });
 }
 
 /**
@@ -313,8 +339,64 @@ function applyDelegatedUsage(
   ctx: PiTranslateContext,
   taskId: string,
   cumulative: PiSubagentUsage | undefined,
+  segments: PiSubagentUsageSegment[] | undefined,
 ): void {
-  if (!cumulative || !taskId) return;
+  if (!taskId) return;
+  const segmentTotals = segments?.reduce<PiSubagentUsage>(
+    (sum, segment) => ({
+      input: sum.input + segment.input,
+      output: sum.output + segment.output,
+      cacheRead: sum.cacheRead + segment.cacheRead,
+      cacheWrite: sum.cacheWrite + segment.cacheWrite,
+      cost: sum.cost + segment.cost,
+    }),
+    { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0 },
+  );
+  const segmentsMatchCumulative =
+    cumulative === undefined ||
+    (segmentTotals !== undefined &&
+      segmentTotals.input === cumulative.input &&
+      segmentTotals.output === cumulative.output &&
+      segmentTotals.cacheRead === cumulative.cacheRead &&
+      segmentTotals.cacheWrite === cumulative.cacheWrite &&
+      Math.abs(segmentTotals.cost - cumulative.cost) < 1e-9);
+  if (
+    segments?.length &&
+    segmentsMatchCumulative &&
+    !ctx.delegatedUsageIncompleteTaskIds.has(taskId)
+  ) {
+    for (const segment of segments) {
+      const identity = `${taskId}:${segment.id}`;
+      if (ctx.delegatedUsageSegmentIds.has(identity)) continue;
+      ctx.delegatedUsageSegmentIds.add(identity);
+      ctx.turnTokens += segment.input + segment.output;
+      ctx.turnInput += segment.input;
+      ctx.turnOutput += segment.output;
+      ctx.turnCacheRead += segment.cacheRead;
+      ctx.turnCacheWrite += segment.cacheWrite;
+      ctx.costUsd += segment.cost;
+      ctx.turnUsageSegments.push({
+        id: `pi-child:${identity}`,
+        ...(segment.model ? { model: segment.model } : {}),
+        inputTokens: segment.input,
+        outputTokens: segment.output,
+        cacheReadTokens: segment.cacheRead,
+        cacheCreateTokens: segment.cacheWrite,
+        ...(segment.cost > 0 ? { costUsd: segment.cost } : {}),
+      });
+      if (segment.output > 0) ctx.generationTimingReliable = false;
+    }
+    if (cumulative) ctx.delegatedUsage.set(taskId, cumulative);
+    return;
+  }
+  if (segments?.length && !segmentsMatchCumulative) {
+    // A partial segment list cannot safely price the unassigned residual. Once
+    // this task falls back to its cumulative total, keep it unpriceable for the
+    // rest of the turn so a later full snapshot cannot double-count usage.
+    ctx.delegatedUsageIncompleteTaskIds.add(taskId);
+    ctx.turnUsageSegmentsComplete = false;
+  }
+  if (!cumulative) return;
   const previous = ctx.delegatedUsage.get(taskId);
   const delta = {
     input: Math.max(0, cumulative.input - (previous?.input ?? 0)),
@@ -330,6 +412,11 @@ function applyDelegatedUsage(
   ctx.turnCacheRead += delta.cacheRead;
   ctx.turnCacheWrite += delta.cacheWrite;
   ctx.costUsd += delta.cost;
+  if (delta.input || delta.output || delta.cacheRead || delta.cacheWrite || delta.cost) {
+    // Older runner payloads expose only a cumulative task total. Preserve token
+    // accounting, but do not pretend that this delta is one provider request.
+    ctx.turnUsageSegmentsComplete = false;
+  }
   // Child progress exposes wall-clock card duration, not generation-only time.
   // Once child output joins the numerator, parent-only timing cannot produce a
   // compatible TPS denominator, so retain usage but omit speed for this turn.
@@ -444,6 +531,10 @@ export function translatePiEvent(
       ctx.turnOutput = 0;
       ctx.turnCacheRead = 0;
       ctx.turnCacheWrite = 0;
+      ctx.turnUsageSegments = [];
+      ctx.turnUsageSegmentsComplete = true;
+      ctx.turnUsageSegmentSeq = 0;
+      ctx.turnSettled = false;
       ctx.finalAssistantText = '';
       ctx.pendingAssistantError = null;
       ctx.turnWallClockStartedAt = Date.now();
@@ -453,6 +544,8 @@ export function translatePiEvent(
       // 与其它 turn 计数器同点清:新 turn 的委派用量不该跟上一 turn 的累计值作差,
       // 也避免长会话里 taskId 条目无界堆积。
       ctx.delegatedUsage.clear();
+      ctx.delegatedUsageSegmentIds.clear();
+      ctx.delegatedUsageIncompleteTaskIds.clear();
       ctx.subagentToolCalls.clear();
       ctx.toolNamesByCallId.clear();
       ctx.streamStopTokenByIndex.clear();
@@ -483,7 +576,7 @@ export function translatePiEvent(
     case 'message_end': {
       const message = event.message as PiAssistantMessage | undefined;
       if (!message || message.role !== 'assistant') return;
-      applyUsage(ctx, message.usage);
+      applyUsage(ctx, message.usage, message.model);
       const hadGenerationHeartbeat = ctx.generationHeartbeatAt > 0;
       samplePiGenerationHeartbeat(ctx);
       const messageDurationMs =
@@ -605,7 +698,12 @@ export function translatePiEvent(
         // 委派用量并进本 turn 的记账。子代理是独立 pi 进程,它的请求不走父进程的 usage 流,
         // 不在这里显式并进来,done.data.usage 与 register.ts 持久化的 session token/cost
         // 就会漏掉全部子代理花费(review)。
-        applyDelegatedUsage(ctx, progress.update.taskId, progress.delegatedUsage);
+        applyDelegatedUsage(
+          ctx,
+          progress.update.taskId,
+          progress.delegatedUsage,
+          progress.delegatedUsageSegments,
+        );
         queue.push({ type: 'agent_task_update', data: progress.update, source: 'pi' });
       }
       return;
@@ -676,6 +774,8 @@ export function translatePiEvent(
       return;
 
     case 'agent_settled': {
+      if (ctx.turnSettled) return;
+      ctx.turnSettled = true;
       ctx.isStreaming = false;
       stopPiGenerationHeartbeat(ctx);
       const pendingAssistantError = ctx.pendingAssistantError;
@@ -705,6 +805,8 @@ export function translatePiEvent(
             outputTokens: ctx.turnOutput,
             cacheReadTokens: ctx.turnCacheRead,
             cacheCreationTokens: ctx.turnCacheWrite,
+            segments: ctx.turnUsageSegments.map((segment) => ({ ...segment })),
+            segmentsComplete: ctx.turnUsageSegmentsComplete,
             // durationMs is deliberately generation-only. If Pi does not report a
             // per-assistant generation duration, omit it instead of charging tool
             // execution / user waits to TPS.

--- a/packages/maker-core/src/agents/shared/usage-tracker.test.ts
+++ b/packages/maker-core/src/agents/shared/usage-tracker.test.ts
@@ -45,6 +45,120 @@ describe('UsageTracker.getTurnUsage', () => {
     expect(tracker.getTurnUsage()).toEqual({ input: 0, output: 0, cacheRead: 0, cacheCreate: 0 });
   });
 
+  it('preserves request boundaries for request-scoped pricing', () => {
+    const tracker = new UsageTracker();
+    tracker.ingestApiCallUsage({
+      inputTokens: 40_000,
+      outputTokens: 500,
+      cacheReadTokens: 10_000,
+      cacheCreateTokens: 0,
+      reasoningTokens: 100,
+    });
+    tracker.ingestApiCallUsage({
+      inputTokens: 45_000,
+      outputTokens: 700,
+      cacheReadTokens: 5_000,
+      cacheCreateTokens: 0,
+      reasoningTokens: 200,
+    });
+
+    const segments = tracker.getTurnUsageSegments();
+    expect(segments).toEqual([
+      {
+        inputTokens: 40_000,
+        outputTokens: 500,
+        cacheReadTokens: 10_000,
+        cacheCreateTokens: 0,
+        reasoningTokens: 100,
+      },
+      {
+        inputTokens: 45_000,
+        outputTokens: 700,
+        cacheReadTokens: 5_000,
+        cacheCreateTokens: 0,
+        reasoningTokens: 200,
+      },
+    ]);
+
+    segments[0]!.inputTokens = 999_999;
+    expect(tracker.getTurnUsageSegments()[0]?.inputTokens).toBe(40_000);
+  });
+
+  it('merges split frames for one request without double-counting repeated input/cache', () => {
+    const tracker = new UsageTracker();
+    tracker.upsertApiCallUsage('request-1', {
+      inputTokens: 100,
+      outputTokens: 0,
+      cacheReadTokens: 900,
+      cacheCreateTokens: 50,
+      complete: false,
+    });
+    tracker.upsertApiCallUsage('request-1', {
+      inputTokens: 100,
+      outputTokens: 25,
+      cacheReadTokens: 900,
+      cacheCreateTokens: 50,
+      complete: true,
+    });
+
+    expect(tracker.getTurnUsage()).toEqual({
+      input: 100,
+      output: 25,
+      cacheRead: 900,
+      cacheCreate: 50,
+    });
+    expect(tracker.getTurnUsageSegments()).toEqual([
+      {
+        id: 'request-1',
+        inputTokens: 100,
+        outputTokens: 25,
+        cacheReadTokens: 900,
+        cacheCreateTokens: 50,
+        reasoningTokens: 0,
+        costUsd: 0,
+        complete: true,
+      },
+    ]);
+  });
+
+  it('keeps the request model and price variant captured by the first frame', () => {
+    const tracker = new UsageTracker();
+    tracker.upsertApiCallUsage('request-1', {
+      model: 'claude-opus-4-8',
+      priceVariant: 'priority',
+      inputTokens: 100,
+      outputTokens: 0,
+    });
+    tracker.upsertApiCallUsage('request-1', {
+      model: 'claude-sonnet-4-8',
+      priceVariant: 'standard',
+      inputTokens: 100,
+      outputTokens: 25,
+    });
+
+    expect(tracker.getTurnUsageSegments()[0]).toMatchObject({
+      model: 'claude-opus-4-8',
+      priceVariant: 'priority',
+      inputTokens: 100,
+      outputTokens: 25,
+    });
+  });
+
+  it('clears request segments at both beginTurn and endTurn boundaries', () => {
+    const tracker = new UsageTracker();
+    tracker.ingestApiCallUsage({ inputTokens: 10, outputTokens: 1 });
+    tracker.beginTurn();
+    expect(tracker.getTurnUsageSegments()).toEqual([]);
+
+    tracker.ingestApiCallUsage({ inputTokens: 20, outputTokens: 2 });
+    const captured = tracker.getTurnUsageSegments();
+    tracker.endTurn({ inputTokens: 20, outputTokens: 2 });
+    expect(captured).toEqual([
+      { inputTokens: 20, outputTokens: 2, cacheReadTokens: 0, cacheCreateTokens: 0 },
+    ]);
+    expect(tracker.getTurnUsageSegments()).toEqual([]);
+  });
+
   it('adds result-only cache tokens to cache stats without double counting prior usage', () => {
     const tracker = new UsageTracker();
     tracker.ingestApiCallUsage({ inputTokens: 10, outputTokens: 0 });

--- a/packages/maker-core/src/agents/shared/usage-tracker.ts
+++ b/packages/maker-core/src/agents/shared/usage-tracker.ts
@@ -24,7 +24,20 @@
 
 import type { UsageSnapshot } from '../../types/events.js';
 
-interface ApiCallUsage {
+/**
+ * One provider request (or the narrowest reliable upstream usage boundary).
+ *
+ * Pricing consumers must price each segment independently before summing a
+ * turn. In particular, long-context bands are request-scoped: selecting a
+ * band from the turn aggregate overcharges turns made of many smaller calls.
+ */
+export interface UsageSegment {
+  /** Stable only within the owning turn; used to merge split provider frames. */
+  id?: string;
+  /** Actual model for this request when the provider exposes it. */
+  model?: string;
+  /** Request price variant. Fast maps to the gateway priority tariff. */
+  priceVariant?: 'standard' | 'priority' | 'fast' | 'batch';
   /** 输入 token (不含 cache) */
   inputTokens: number;
   outputTokens: number;
@@ -32,6 +45,12 @@ interface ApiCallUsage {
   cacheReadTokens?: number;
   /** 写入缓存的 token (Anthropic cache_creation_input_tokens) */
   cacheCreateTokens?: number;
+  /** Provider diagnostic subset; never add this to outputTokens again. */
+  reasoningTokens?: number;
+  /** Provider-reported request cost, used only on routes where that value is authoritative. */
+  costUsd?: number;
+  /** Upstream emitted a terminal request usage frame covering every token bucket. */
+  complete?: boolean;
 }
 
 export class UsageTracker {
@@ -39,6 +58,11 @@ export class UsageTracker {
   // 每次 ingestApiCallUsage 累加, endTurn 后由 resetCurrentTurn 清零。
   // 老链路对标: agentManager.ts:2362-2365 currentTurn{Input,Output,CacheRead,CacheCreate}Tokens
   private currentTurn = { input: 0, output: 0, cacheRead: 0, cacheCreate: 0 };
+
+  // Request/segment boundaries for request-scoped pricing. This list follows
+  // the same turn lifecycle as currentTurn and is copied before exposure.
+  private currentTurnSegments: UsageSegment[] = [];
+  private currentTurnSegmentIndex = new Map<string, number>();
 
   // ── 最后一次 API call 快照 ─────────────────────────────────────────────────
   // 用于 contextTokens (圆环): 反映"自动压缩后真实 context 占用",而非整 turn 累计。
@@ -82,12 +106,99 @@ export class UsageTracker {
    * codex: 在 turn.completed 或类似事件提取后映射)。
    * 同时累加 currentTurn + 覆盖 lastApi。
    */
-  ingestApiCallUsage(usage: ApiCallUsage): void {
+  ingestApiCallUsage(usage: UsageSegment): void {
+    this.appendUsageSegment(usage);
+  }
+
+  /**
+   * Merge split frames for one provider request. Claude commonly reports the
+   * input/cache side at message_start and output at message_delta; some
+   * compatible endpoints repeat input/cache on both frames. Field-wise max
+   * preserves the final request snapshot without double counting repeats.
+   */
+  upsertApiCallUsage(segmentId: string, usage: UsageSegment): void {
+    if (!segmentId) {
+      this.appendUsageSegment(usage);
+      return;
+    }
+    const existingIndex = this.currentTurnSegmentIndex.get(segmentId);
+    if (existingIndex === undefined) {
+      this.appendUsageSegment({ ...usage, id: segmentId });
+      return;
+    }
+    const existing = this.currentTurnSegments[existingIndex]!;
+    const merged: UsageSegment = {
+      ...existing,
+      ...usage,
+      id: segmentId,
+      // Request identity is fixed by the first frame. Runtime settings may
+      // change before a terminal frame arrives, but that must not re-price an
+      // already-dispatched request.
+      model: existing.model ?? usage.model,
+      priceVariant: existing.priceVariant ?? usage.priceVariant,
+      inputTokens: Math.max(existing.inputTokens, usage.inputTokens),
+      outputTokens: Math.max(existing.outputTokens, usage.outputTokens),
+      cacheReadTokens: Math.max(existing.cacheReadTokens ?? 0, usage.cacheReadTokens ?? 0),
+      cacheCreateTokens: Math.max(existing.cacheCreateTokens ?? 0, usage.cacheCreateTokens ?? 0),
+      reasoningTokens: Math.max(existing.reasoningTokens ?? 0, usage.reasoningTokens ?? 0),
+      costUsd: Math.max(existing.costUsd ?? 0, usage.costUsd ?? 0),
+      ...(existing.complete !== undefined || usage.complete !== undefined
+        ? { complete: existing.complete === true || usage.complete === true }
+        : {}),
+    };
+    this.currentTurnSegments[existingIndex] = merged;
+    this.applyUsageDelta(
+      {
+        inputTokens: merged.inputTokens - existing.inputTokens,
+        outputTokens: merged.outputTokens - existing.outputTokens,
+        cacheReadTokens: (merged.cacheReadTokens ?? 0) - (existing.cacheReadTokens ?? 0),
+        cacheCreateTokens: (merged.cacheCreateTokens ?? 0) - (existing.cacheCreateTokens ?? 0),
+      },
+      false,
+    );
+    if (
+      merged.inputTokens > 0 ||
+      (merged.cacheReadTokens ?? 0) > 0 ||
+      (merged.cacheCreateTokens ?? 0) > 0
+    ) {
+      this.lastApi = {
+        input: merged.inputTokens,
+        cacheRead: merged.cacheReadTokens ?? 0,
+        cacheCreate: merged.cacheCreateTokens ?? 0,
+      };
+    }
+  }
+
+  private appendUsageSegment(usage: UsageSegment): void {
+    const normalized: UsageSegment = {
+      ...usage,
+      inputTokens: Math.max(0, usage.inputTokens),
+      outputTokens: Math.max(0, usage.outputTokens),
+      cacheReadTokens: Math.max(0, usage.cacheReadTokens ?? 0),
+      cacheCreateTokens: Math.max(0, usage.cacheCreateTokens ?? 0),
+      ...(usage.reasoningTokens !== undefined
+        ? { reasoningTokens: Math.max(0, usage.reasoningTokens) }
+        : {}),
+      ...(usage.costUsd !== undefined ? { costUsd: Math.max(0, usage.costUsd) } : {}),
+    };
+    if (normalized.id)
+      this.currentTurnSegmentIndex.set(normalized.id, this.currentTurnSegments.length);
+    this.currentTurnSegments.push(normalized);
+    this.applyUsageDelta(normalized, true);
+  }
+
+  private applyUsageDelta(
+    usage: Pick<
+      UsageSegment,
+      'inputTokens' | 'outputTokens' | 'cacheReadTokens' | 'cacheCreateTokens'
+    >,
+    isNewApiCall: boolean,
+  ): void {
     const cr = usage.cacheReadTokens ?? 0;
     const cc = usage.cacheCreateTokens ?? 0;
 
     // lastApi: 覆盖, 反映"最后一次 API call" (如果入参全 0 则不覆盖，防止被没有 input_tokens 的 delta 冲掉)
-    if (usage.inputTokens > 0 || cr > 0 || cc > 0) {
+    if (isNewApiCall && (usage.inputTokens > 0 || cr > 0 || cc > 0)) {
       this.lastApi.input = usage.inputTokens;
       this.lastApi.cacheRead = cr;
       this.lastApi.cacheCreate = cc;
@@ -105,11 +216,11 @@ export class UsageTracker {
     this.turnCache.read += cr;
     this.turnCache.create += cc;
     this.turnCache.uncachedInput += usage.inputTokens;
-    this.turnCache.apiCalls += 1;
+    if (isNewApiCall) this.turnCache.apiCalls += 1;
     this.sessionCache.read += cr;
     this.sessionCache.create += cc;
     this.sessionCache.uncachedInput += usage.inputTokens;
-    this.sessionCache.apiCalls += 1;
+    if (isNewApiCall) this.sessionCache.apiCalls += 1;
   }
 
   /**
@@ -187,10 +298,21 @@ export class UsageTracker {
    * input/output 再 reset — Codex 链路的调用方只有 contextTokens 可给 (降级值),
    * 所以 done 事件要在 endTurn 之前用本方法取走真实 per-turn 累计
    * (来自每次 tokenUsage/updated 的 ingestApiCallUsage 累加)。
-   * 语义: input = 未命中缓存输入, output = 输出+推理合并, cacheRead = 命中缓存。
+   * 语义: input = 未命中缓存输入, output = provider 的计费 output（reasoning 若为
+   * 子集不重复相加）, cacheRead = 命中缓存。
    */
-  getTurnUsage(): { input: number; output: number; cacheRead: number; cacheCreate: number } {
+  getTurnUsage(): {
+    input: number;
+    output: number;
+    cacheRead: number;
+    cacheCreate: number;
+  } {
     return { ...this.currentTurn };
+  }
+
+  /** Current turn's provider request boundaries, returned as defensive copies. */
+  getTurnUsageSegments(): UsageSegment[] {
+    return this.currentTurnSegments.map((segment) => ({ ...segment }));
   }
 
   /**
@@ -239,6 +361,8 @@ export class UsageTracker {
     const snap = this.snapshot();
     // reset currentTurn for next turn (lastApi / contextWindow / cost 跨 turn 保留)
     this.currentTurn = { input: 0, output: 0, cacheRead: 0, cacheCreate: 0 };
+    this.currentTurnSegments = [];
+    this.currentTurnSegmentIndex.clear();
     // turnCache 同步清零, sessionCache 跨 turn 累计保留
     this.turnCache = { read: 0, create: 0, uncachedInput: 0, apiCalls: 0 };
     return snap;
@@ -251,6 +375,8 @@ export class UsageTracker {
    */
   beginTurn(): void {
     this.currentTurn = { input: 0, output: 0, cacheRead: 0, cacheCreate: 0 };
+    this.currentTurnSegments = [];
+    this.currentTurnSegmentIndex.clear();
     // 兜底清 turnCache, 防止上一 turn 异常 / abort 没走到 endTurn 留下脏数据;
     // 与 currentTurn 同语义。
     this.turnCache = { read: 0, create: 0, uncachedInput: 0, apiCalls: 0 };
@@ -292,8 +418,20 @@ export class UsageTracker {
    *   (1-2 次的 hitRate 不能代表 session 长期表现)。
    */
   getCacheStats(): {
-    turn: { read: number; create: number; uncachedInput: number; apiCalls: number; hitRate: number | null };
-    session: { read: number; create: number; uncachedInput: number; apiCalls: number; hitRate: number | null };
+    turn: {
+      read: number;
+      create: number;
+      uncachedInput: number;
+      apiCalls: number;
+      hitRate: number | null;
+    };
+    session: {
+      read: number;
+      create: number;
+      uncachedInput: number;
+      apiCalls: number;
+      hitRate: number | null;
+    };
   } {
     const calc = (b: { read: number; create: number; uncachedInput: number }): number | null => {
       const denom = b.read + b.create + b.uncachedInput;


### PR DESCRIPTION
## 这次改了什么

### 摘要

修正 AI 用量计价链：按每次 provider usage segment 单独选择价格档位并汇总，避免重复 usage 快照、reasoning token 双计，以及把整轮累计 token 错误套用高价档。同步收紧报价缺失、估算金额和订阅估值的语义，避免把本地估算冒充实际扣款。

### 变更类型

- [x] `fix` 缺陷修复
- [x] `refactor` / `perf` 重构或性能优化

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：Codex、Claude、Pi 的 segment 级 usage 计价；Codex 快照幂等去重；Claude 不完整 segment 的 token residual；Fast/Priority 报价；估算与实际金额分离；币种切换估值保护；相关测试契约更新。
- 明确不包含：历史账单修复、已有 `daily_*` 数据回写、usage ledger / migration / outbox、`.xdtshare` 格式变更。
- 用户可见变化：新产生的消息、任务和今日用量金额不再因重复通知或整轮累计 token 而被高估；无法可靠计价时保留 token 或估值语义，不显示为精确实付。
- 是否存在 breaking change：无

### UI 变化

- 不涉及：仅修改 usage 计量、计价和投影数据，不改变界面布局、样式或文案。
- 引用的设计规范：不涉及：纯逻辑重构，无视觉/交互/文案变化。

## 怎么验证的

### 自动验证

```text
@cindy/maker-core affected tests: 627/627 通过
desktop affected pricing tests: 121/121 通过
pnpm --filter desktop run --if-present typecheck: 通过
pnpm --filter desktop db:validate: 通过
git diff --check: 通过
pnpm check:dco: 通过
Codex fixture: 108 notifications → 92 segments → NZ$1.3124601，重复快照和 compaction 零帧不计费
```

### 手工验证

不涉及 UI 或设备手工验证。

### 未执行的验证

统一 unit gate 已执行，但全量结果包含两个与本 PR 无关的既有失败：

- `apps/desktop/src/main/cindy-brain/__tests__/ghostInstallReceipt.test.ts`
- 两条 setup receipt reader 断言失败

其余结果：2102 个测试文件中 28264 个测试通过、5 个跳过。相关计价测试和类型检查均通过；上述失败未触及本 PR 修改路径，留给 CI/基线问题单独处理。

## 风险

### 风险分类

- [x] 跨平台差异
- [x] 其他：usage 计量与金额投影语义变化

### 影响与回滚

- 影响范围：未来新产生的 Codex、Claude、Pi usage 计量和金额投影；不主动修改历史账。
- 回滚 / 降级方式：回滚本 PR commit 即恢复旧计价路径；已产生的旧历史金额不会被本 PR 自动重写。

已知少记方向：Codex 当前 cache-write token 仍由上游适配器报告为 0 时不会凭空猜价；报价缺失或不完整时按保守 token-only / unavailable 处理。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] 未提交凭证、令牌或授权文件
- [x] 已确认测试结果或说明未执行原因

审查：Orca Worker `reviewer-2` 复审结论为 approve，无新的 P0/P1；原生 subagents 亦完成 Codex、Claude/Pi 和投影链复核。
