### PR TITLE
fix(desktop): 显示已保存的自定义请求头状态

### DIFF
--- a/apps/desktop/src/renderer/components/settings/CustomProviderDialog.tsx
+++ b/apps/desktop/src/renderer/components/settings/CustomProviderDialog.tsx
@@ -1718,11 +1718,20 @@ export function CustomProviderDialog({
   ]);
 
   const activeSavedBaseline = savedBaselineFor(activeTab);
-  const activeKeyCanRemainSaved =
-    hasKey[activeTab] &&
+  // 共享判据：当前表单的端点相对已存基线是否未变。密钥与请求头都只在
+  // 端点未变时继续有效——main 侧改端点后会清掉已存头，renderer 的徽标
+  // 必须同步消失，否则继续宣称「已配置」会误导用户。
+  const activeSavedEndpointUnchanged =
     activeSavedBaseline != null &&
     f.baseUrl.trim() === activeSavedBaseline.baseUrl.trim() &&
     f.modelsUrl.trim() === activeSavedBaseline.modelsUrl.trim();
+  const activeKeyCanRemainSaved = hasKey[activeTab] && activeSavedEndpointUnchanged;
+  // 已存密文头徽标的判据：端点未变 + 仍是 apiKey 鉴权（none 模式会剥凭证头）
+  // + 确实配置过头。headersState 是不可变初值，端点一变就必须隐藏。
+  const activeHeadersCanRemainSaved =
+    initial?.runtimes[activeTab]?.headersState === 'configured' &&
+    authMode === 'apiKey' &&
+    activeSavedEndpointUnchanged;
   const keyPlaceholder = activeKeyCanRemainSaved
     ? t('settings.providers.custom.fields.apiKeyEditPlaceholder')
     : t('settings.providers.custom.fields.apiKeyPlaceholder');
@@ -2416,7 +2425,7 @@ export function CustomProviderDialog({
                   <div className="flex items-center gap-2">
                     <FieldLabel>{t('settings.providers.custom.fields.headers')}</FieldLabel>
                     {/* 已存密文头时给明确徽标 —— 明文不回读进 renderer,无徽标会让人误以为没存上。 */}
-                    {initial?.runtimes[activeTab]?.headersState === 'configured' && (
+                    {activeHeadersCanRemainSaved && (
                       <span
                         className="flex items-center gap-1 rounded-full px-2 py-0.5 text-11 font-medium"
                         style={{

--- a/apps/desktop/src/renderer/components/settings/CustomProviderDialog.tsx
+++ b/apps/desktop/src/renderer/components/settings/CustomProviderDialog.tsx
@@ -2413,7 +2413,22 @@ export function CustomProviderDialog({
 
                 {/* 请求头（可选） */}
                 <div className="flex flex-col gap-2">
-                  <FieldLabel>{t('settings.providers.custom.fields.headers')}</FieldLabel>
+                  <div className="flex items-center gap-2">
+                    <FieldLabel>{t('settings.providers.custom.fields.headers')}</FieldLabel>
+                    {/* 已存密文头时给明确徽标 —— 明文不回读进 renderer,无徽标会让人误以为没存上。 */}
+                    {initial?.runtimes[activeTab]?.headersState === 'configured' && (
+                      <span
+                        className="flex items-center gap-1 rounded-full px-2 py-0.5 text-11 font-medium"
+                        style={{
+                          backgroundColor: 'var(--settings-btn-secondary-bg)',
+                          color: 'var(--settings-section-desc)',
+                        }}
+                      >
+                        <Check size={11} strokeWidth={2.5} />
+                        {t('settings.providers.custom.runtimeFill.values.configured')}
+                      </span>
+                    )}
+                  </div>
                   {f.headers.map((h, i) => (
                     <div key={i} className="flex items-center gap-2">
                       <div className="flex-1">

--- a/apps/desktop/src/renderer/components/settings/__tests__/CustomProviderDialogAccessibility.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/__tests__/CustomProviderDialogAccessibility.test.tsx
@@ -475,13 +475,38 @@ describe('CustomProviderDialog accessibility', () => {
     };
     customProviderMocks.readCustomProviderKey.mockResolvedValue(null);
 
+    const user = userEvent.setup();
     render(<CustomProviderDialog initial={initial} onSaved={vi.fn()} onClose={vi.fn()} />);
     await waitFor(() => expect(customProviderMocks.readCustomProviderKey).toHaveBeenCalled());
 
-    expect(
-      screen.queryByText('settings.providers.custom.runtimeFill.values.configured', { exact: true }),
-    ).not.toBeNull();
+    const configuredBadge = () =>
+      screen.queryByText('settings.providers.custom.runtimeFill.values.configured', {
+        exact: true,
+      });
+
+    // 初始：端点未变，徽标显示。
+    expect(configuredBadge()).not.toBeNull();
     // 明文头值绝不允许出现在 renderer。
+    expect(document.body.textContent).not.toContain('configured-header-secret');
+
+    const baseUrl = screen.getByPlaceholderText(
+      'settings.providers.custom.fields.baseUrlPlaceholder',
+    );
+    await waitForInitialDialogFocus();
+    // 改端点：main 会清掉已存头，徽标必须同步隐藏。
+    await user.clear(baseUrl);
+    await user.type(baseUrl, 'https://changed.example.test/v1');
+    await waitFor(() => expect(configuredBadge()).toBeNull());
+    expect(document.body.textContent).not.toContain('configured-header-secret');
+
+    // 改回原端点：徽标可以重新出现。
+    await user.clear(baseUrl);
+    await user.type(baseUrl, 'https://configured.example.test/v1');
+    await waitFor(() => expect(configuredBadge()).not.toBeNull());
+
+    // 切到无鉴权：none 模式剥凭证头，已存头不再有效，徽标隐藏。
+    await user.click(screen.getByRole('button', { name: 'settings.providers.custom.authMode.none' }));
+    await waitFor(() => expect(configuredBadge()).toBeNull());
     expect(document.body.textContent).not.toContain('configured-header-secret');
   });
 });

--- a/apps/desktop/src/renderer/components/settings/__tests__/CustomProviderDialogAccessibility.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/__tests__/CustomProviderDialogAccessibility.test.tsx
@@ -459,4 +459,29 @@ describe('CustomProviderDialog accessibility', () => {
       codex: 'replacement-secret',
     });
   });
+
+  it('shows a configured-headers badge and never reveals plaintext for the active runtime', async () => {
+    const initial: CustomProviderConfig = {
+      id: 'configured-headers-provider',
+      name: 'Configured headers provider',
+      auth: { method: 'apiKey' },
+      runtimes: {
+        codex: {
+          baseUrl: 'https://configured.example.test/v1',
+          models: [{ id: 'test-model', name: 'Test Model' }],
+          headersState: 'configured',
+        },
+      },
+    };
+    customProviderMocks.readCustomProviderKey.mockResolvedValue(null);
+
+    render(<CustomProviderDialog initial={initial} onSaved={vi.fn()} onClose={vi.fn()} />);
+    await waitFor(() => expect(customProviderMocks.readCustomProviderKey).toHaveBeenCalled());
+
+    expect(
+      screen.queryByText('settings.providers.custom.runtimeFill.values.configured', { exact: true }),
+    ).not.toBeNull();
+    // 明文头值绝不允许出现在 renderer。
+    expect(document.body.textContent).not.toContain('configured-header-secret');
+  });
 });


### PR DESCRIPTION
## 这次改了什么

### 摘要

- Fixes #2846。
- 改动内容：Custom Provider 编辑对话框在 `headersState` 已配置且已存请求头仍可保留时显示“已配置”徽标。
  - 已存储的 headers 仍然生效,行为不变。
  - 更改 Base URL / Models URL 或切换到无鉴权后，徽标会立即隐藏，与 main 侧清理旧 headers 的语义一致。
  - 明文 header 值始终不会暴露给 renderer。
  - 持久化语义不变。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：Fixes #2846
- 本 PR 包含：desktop custom provider 对话框及对应无障碍测试。
- 明确不包含：读取或展示请求头明文、修改请求头持久化语义。
- 用户可见变化：编辑已配置请求头的自定义 Provider 时显示本地化“已配置”状态。
- 是否存在 breaking change：无。

### UI 变化

- 未截屏；可见语义由自动化 accessible-name 测试覆盖。
- 引用的设计规范：docs/design-rules/DESIGN.md §3（Micro Label）与 §5（Pill）：复用既有 settings 状态 pill / 对勾（✓）模式，沿用现有设置语义 token。

## 怎么验证的

### 自动验证

1. 实现前红测试：`CustomProviderDialogAccessibility` 新增回归用例因找不到请求头已配置状态而失败（1 failed，11 passed）。
2. 实现后目标测试：12/12 通过；覆盖初始显示、端点变化后隐藏、恢复端点后重现、切换无鉴权后隐藏，以及明文不进入 renderer。
3. `pnpm check:i18n`：五种语言的 8012 个 key 全部一致。
4. desktop typecheck 通过。
5. `git diff --check` 通过。
6. 最终修订后执行 `pnpm test:unit:related`：Desktop 与其余 workspace 通过；`packages/maker-core` 为 118/119 文件通过、3329 个测试通过、3 个失败、3 个跳过。3 个失败全部来自与本次 2 文件 diff 无关的 `pi-rpc-resource-discovery.integration.test.ts`，定向复现结果相同。
7. DCO 本地检查通过；GitHub 上两个提交均使用 `fico-hub <fico@xd.com>` 的 Signed-off-by。

### 手工验证

未运行。

### 未执行的验证

未执行桌面端手工截图验证；自动化无障碍测试已覆盖状态文案。

## 风险

### 风险分类

- [x] 权限 / 安全 / 用户数据

### 影响与回滚

- 影响范围：仅新增已保存 header 的状态徽标；无明文暴露、无持久化语义变更。
- 回滚 / 降级方式：revert 该 commit 即可。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] UI 改动已注明引用的设计规范
- [x] 未提交凭证、令牌或授权文件
- [x] 已复用现有完整本地化文案并补充测试
- [x] 已确认并如实披露测试结果
