### PR TITLE
fix(desktop): 远程未读绿点不再跟灵动岛 TTL 一起消失

### DIFF
--- a/apps/desktop/src/main/agent-island/__tests__/service.test.ts
+++ b/apps/desktop/src/main/agent-island/__tests__/service.test.ts
@@ -883,6 +883,165 @@ describe('AgentIslandService native publishing', () => {
     );
   });
 
+  it('hides unread completion from the island at TTL while remote attention stays until ack even when island UI is off', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+    try {
+      const { AgentIslandService } = await import('../service.js');
+      const { AGENT_ISLAND_UNREAD_TRANSIENT_TTL_MS } = await import('../state.js');
+      const publish = vi.fn((state: AgentIslandDisplayState) => {
+        void state;
+        return true;
+      });
+      const service = new AgentIslandService({
+        getMainWindow: () => null,
+        nativeHost: { failed: false, headless: true, publish, suspend: () => undefined },
+      });
+
+      service.setEnabled(false);
+      service.handleUserPrompt({ sessionId: 's1', agentKind: 'codex' }, 'run tests');
+      service.handleAgentEvent({ sessionId: 's1', agentKind: 'codex' }, doneEvent());
+      const sessions = (
+        service as unknown as { state: { sessions: Map<string, unknown>; remoteUnreadTerminals: Map<string, unknown> } }
+      ).state;
+      expect(sessions.sessions.has('s1')).toBe(true);
+      mocks.tapWindowBroadcast.mockClear();
+
+      await vi.advanceTimersByTimeAsync(AGENT_ISLAND_UNREAD_TRANSIENT_TTL_MS + 50);
+      expect(sessions.sessions.has('s1')).toBe(false);
+      expect(sessions.remoteUnreadTerminals.has('s1')).toBe(true);
+      expect(mocks.tapWindowBroadcast).toHaveBeenCalledWith(
+        SESSION_ACTIVITY_CHANNEL,
+        expect.objectContaining({ sessionId: 's1', phase: 'completed', attention: true }),
+      );
+
+      mocks.tapWindowBroadcast.mockClear();
+      mocks.getSessionRowSnapshot.mockClear();
+      service.handleSessionAttentionCleared('s1', 'passive');
+      expect(mocks.tapWindowBroadcast).toHaveBeenCalledWith(
+        SESSION_ACTIVITY_CHANNEL,
+        expect.objectContaining({ sessionId: 's1', attention: false }),
+      );
+      expect(mocks.getSessionRowSnapshot).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('hides unread completion from the island at TTL while remote attention stays until ack', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+    try {
+      const { AgentIslandService } = await import('../service.js');
+      const { AGENT_ISLAND_UNREAD_TRANSIENT_TTL_MS } = await import('../state.js');
+      const publish = vi.fn((state: AgentIslandDisplayState) => {
+        void state;
+        return true;
+      });
+      const service = new AgentIslandService({
+        getMainWindow: () => null,
+        nativeHost: { failed: false, publish, suspend: () => undefined },
+      });
+
+      service.setEnabled(true);
+      service.handleUserPrompt({ sessionId: 's1', agentKind: 'codex' }, 'run tests');
+      service.handleAgentEvent({ sessionId: 's1', agentKind: 'codex' }, doneEvent());
+      expect(publish.mock.calls.at(-1)?.[0]).toMatchObject({
+        totalCount: 1,
+        sessions: [expect.objectContaining({ sessionId: 's1', phase: 'completed' })],
+      });
+      mocks.tapWindowBroadcast.mockClear();
+
+      await vi.advanceTimersByTimeAsync(AGENT_ISLAND_UNREAD_TRANSIENT_TTL_MS + 50);
+      expect(publish.mock.calls.at(-1)?.[0]).toMatchObject({ totalCount: 0 });
+      expect(mocks.tapWindowBroadcast).toHaveBeenCalledWith(
+        SESSION_ACTIVITY_CHANNEL,
+        expect.objectContaining({ sessionId: 's1', phase: 'completed', attention: true }),
+      );
+
+      mocks.tapWindowBroadcast.mockClear();
+      mocks.getSessionRowSnapshot.mockClear();
+      service.handleSessionAttentionCleared('s1', 'passive');
+      expect(mocks.tapWindowBroadcast).toHaveBeenCalledWith(
+        SESSION_ACTIVITY_CHANNEL,
+        expect.objectContaining({ sessionId: 's1', attention: false }),
+      );
+      expect(mocks.getSessionRowSnapshot).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not let a stale not-found receipt clear a newer unread completion', async () => {
+    const { AgentIslandService } = await import('../service.js');
+    let releaseSnapshot: ((row: { status: string; title: string | null; userSendAt: number | null; workingDir: string | null; workspaceKind: string | null } | null) => void) | undefined;
+    mocks.getSessionRowSnapshot.mockImplementationOnce(
+      () => new Promise((resolve) => {
+        releaseSnapshot = resolve;
+      }),
+    );
+    const service = new AgentIslandService({
+      getMainWindow: () => null,
+      nativeHost: { failed: false, headless: true, publish: () => true, suspend: () => undefined },
+    });
+    service.setEnabled(false);
+
+    service.handleSessionAttentionCleared('s1', 'passive');
+    service.handleUserPrompt({ sessionId: 's1', agentKind: 'codex' }, 'run tests');
+    service.handleAgentEvent({ sessionId: 's1', agentKind: 'codex' }, doneEvent());
+    mocks.tapWindowBroadcast.mockClear();
+
+    releaseSnapshot?.({
+      status: 'active',
+      title: 'new',
+      userSendAt: null,
+      workingDir: '/tmp/x',
+      workspaceKind: null,
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mocks.tapWindowBroadcast).not.toHaveBeenCalledWith(
+      SESSION_ACTIVITY_CHANNEL,
+      expect.objectContaining({ sessionId: 's1', attention: false }),
+    );
+  });
+
+  it('does not let a stale not-found receipt clear a newer unread error', async () => {
+    const { AgentIslandService } = await import('../service.js');
+    let releaseSnapshot: ((row: { status: string; title: string | null; userSendAt: number | null; workingDir: string | null; workspaceKind: string | null } | null) => void) | undefined;
+    mocks.getSessionRowSnapshot.mockImplementationOnce(
+      () => new Promise((resolve) => {
+        releaseSnapshot = resolve;
+      }),
+    );
+    const service = new AgentIslandService({
+      getMainWindow: () => null,
+      nativeHost: { failed: false, headless: true, publish: () => true, suspend: () => undefined },
+    });
+    service.setEnabled(false);
+
+    service.handleSessionAttentionCleared('s1', 'passive');
+    service.handleUserPrompt({ sessionId: 's1', agentKind: 'codex' }, 'run tests');
+    service.handleAgentEvent({ sessionId: 's1', agentKind: 'codex' }, terminalErrorEvent('boom'));
+    mocks.tapWindowBroadcast.mockClear();
+
+    releaseSnapshot?.({
+      status: 'active',
+      title: 'new-err',
+      userSendAt: null,
+      workingDir: '/tmp/x',
+      workspaceKind: null,
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mocks.tapWindowBroadcast).not.toHaveBeenCalledWith(
+      SESSION_ACTIVITY_CHANNEL,
+      expect.objectContaining({ sessionId: 's1', attention: false }),
+    );
+  });
+
   it('broadcasts a terminal clear when a read receipt clears unread completion attention', async () => {
     const { AgentIslandService } = await import('../service.js');
     const service = new AgentIslandService({
@@ -5550,5 +5709,93 @@ describe('会话关闭原因决定条目去留', () => {
 
     service.handleSessionClosed('plain', { reason: 'process-closed' });
     expect(sessions.has('plain')).toBe(false);
+  });
+
+  it('TTL prune 后再 process-close 仍保留远程未读,直到真正 ack', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+    try {
+      const { AgentIslandService } = await import('../service.js');
+      const { AGENT_ISLAND_UNREAD_TRANSIENT_TTL_MS } = await import('../state.js');
+      const publish = vi.fn(() => true);
+      const service = new AgentIslandService({
+        getMainWindow: () => null,
+        nativeHost: { failed: false, headless: true, publish, suspend: () => undefined },
+      });
+      service.setEnabled(false);
+      service.handleUserPrompt({ sessionId: 's1', agentKind: 'codex' }, 'run tests');
+      service.handleAgentEvent({ sessionId: 's1', agentKind: 'codex' }, doneEvent());
+      await vi.advanceTimersByTimeAsync(AGENT_ISLAND_UNREAD_TRANSIENT_TTL_MS + 50);
+      const islandState = (
+        service as unknown as { state: { sessions: Map<string, unknown>; remoteUnreadTerminals: Map<string, unknown> } }
+      ).state;
+      expect(islandState.sessions.has('s1')).toBe(false);
+      expect(islandState.remoteUnreadTerminals.has('s1')).toBe(true);
+
+      mocks.tapWindowBroadcast.mockClear();
+      service.handleSessionClosed('s1', { reason: 'process-closed' });
+      expect(islandState.remoteUnreadTerminals.has('s1')).toBe(true);
+      expect(mocks.tapWindowBroadcast).not.toHaveBeenCalledWith(
+        SESSION_ACTIVITY_CHANNEL,
+        expect.objectContaining({ sessionId: 's1', attention: false }),
+      );
+
+      mocks.tapWindowBroadcast.mockClear();
+      service.handleSessionAttentionCleared('s1', 'passive');
+      expect(islandState.remoteUnreadTerminals.has('s1')).toBe(false);
+      expect(mocks.tapWindowBroadcast).toHaveBeenCalledWith(
+        SESSION_ACTIVITY_CHANNEL,
+        expect.objectContaining({ sessionId: 's1', attention: false }),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('ledger-only error 在新一轮 running 被 App badge 镜像后,passive 仍免疫', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+    const { markSessionNeedsAttention, clearAllSessionAttention } = await import('../../appBadgeService.js');
+    try {
+      const { AgentIslandService } = await import('../service.js');
+      const { AGENT_ISLAND_UNREAD_TRANSIENT_TTL_MS } = await import('../state.js');
+      const publish = vi.fn(() => true);
+      const service = new AgentIslandService({
+        getMainWindow: () => null,
+        nativeHost: { failed: false, headless: true, publish, suspend: () => undefined },
+      });
+      service.setEnabled(false);
+      service.handleUserPrompt({ sessionId: 's-err', agentKind: 'codex' }, 'run tests');
+      service.handleAgentEvent({ sessionId: 's-err', agentKind: 'codex' }, terminalErrorEvent('boom'));
+      markSessionNeedsAttention('s-err');
+      await vi.advanceTimersByTimeAsync(AGENT_ISLAND_UNREAD_TRANSIENT_TTL_MS + 50);
+      const islandState = (
+        service as unknown as { state: { sessions: Map<string, { phase: string; unread: boolean }>; remoteUnreadTerminals: Map<string, { phase: string }> } }
+      ).state;
+      expect(islandState.sessions.has('s-err')).toBe(false);
+      expect(islandState.remoteUnreadTerminals.get('s-err')?.phase).toBe('error');
+
+      service.handleUserPrompt({ sessionId: 's-err', agentKind: 'codex' }, 'retry');
+      expect(islandState.sessions.get('s-err')?.phase).toBe('running');
+      expect(islandState.sessions.get('s-err')?.unread).toBe(true);
+      expect(islandState.remoteUnreadTerminals.get('s-err')?.phase).toBe('error');
+
+      mocks.tapWindowBroadcast.mockClear();
+      service.handleSessionAttentionCleared('s-err', 'passive');
+      expect(islandState.remoteUnreadTerminals.get('s-err')?.phase).toBe('error');
+      expect(islandState.sessions.get('s-err')?.unread).toBe(true);
+      expect(mocks.tapWindowBroadcast).not.toHaveBeenCalledWith(
+        SESSION_ACTIVITY_CHANNEL,
+        expect.objectContaining({ sessionId: 's-err', attention: false }),
+      );
+
+      mocks.tapWindowBroadcast.mockClear();
+      service.handleSessionAttentionCleared('s-err', 'explicit');
+      expect(islandState.remoteUnreadTerminals.has('s-err')).toBe(false);
+      expect(islandState.sessions.get('s-err')?.unread).toBe(false);
+    } finally {
+      clearAllSessionAttention();
+      vi.useRealTimers();
+    }
   });
 });

--- a/apps/desktop/src/main/agent-island/__tests__/service.test.ts
+++ b/apps/desktop/src/main/agent-island/__tests__/service.test.ts
@@ -5766,6 +5766,39 @@ describe('会话关闭原因决定条目去留', () => {
     expect(generations.has('gone')).toBe(false);
   });
 
+  it('TTL prune 后再 Stop 会清账本并立刻给远端发收尾包', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+    try {
+      const { AgentIslandService } = await import('../service.js');
+      const { AGENT_ISLAND_UNREAD_TRANSIENT_TTL_MS } = await import('../state.js');
+      const publish = vi.fn(() => true);
+      const service = new AgentIslandService({
+        getMainWindow: () => null,
+        nativeHost: { failed: false, headless: true, publish, suspend: () => undefined },
+      });
+      service.setEnabled(false);
+      service.handleUserPrompt({ sessionId: 's1', agentKind: 'codex' }, 'run tests');
+      service.handleAgentEvent({ sessionId: 's1', agentKind: 'codex' }, doneEvent());
+      await vi.advanceTimersByTimeAsync(AGENT_ISLAND_UNREAD_TRANSIENT_TTL_MS + 50);
+      const islandState = (
+        service as unknown as { state: { sessions: Map<string, unknown>; remoteUnreadTerminals: Map<string, unknown> } }
+      ).state;
+      expect(islandState.sessions.has('s1')).toBe(false);
+      expect(islandState.remoteUnreadTerminals.has('s1')).toBe(true);
+
+      mocks.tapWindowBroadcast.mockClear();
+      service.handleSessionStopped('s1');
+      expect(islandState.remoteUnreadTerminals.has('s1')).toBe(false);
+      expect(mocks.tapWindowBroadcast).toHaveBeenCalledWith(
+        SESSION_ACTIVITY_CHANNEL,
+        expect.objectContaining({ sessionId: 's1', attention: false }),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('TTL prune 后再 process-close 仍保留远程未读,直到真正 ack', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));

--- a/apps/desktop/src/main/agent-island/__tests__/service.test.ts
+++ b/apps/desktop/src/main/agent-island/__tests__/service.test.ts
@@ -1042,6 +1042,42 @@ describe('AgentIslandService native publishing', () => {
     );
   });
 
+  it('does not let a retrying error bump generation and drop a stale not-found clear', async () => {
+    const { AgentIslandService } = await import('../service.js');
+    let releaseSnapshot: ((row: { status: string; title: string | null; userSendAt: number | null; workingDir: string | null; workspaceKind: string | null } | null) => void) | undefined;
+    mocks.getSessionRowSnapshot.mockImplementationOnce(
+      () => new Promise((resolve) => {
+        releaseSnapshot = resolve;
+      }),
+    );
+    const service = new AgentIslandService({
+      getMainWindow: () => null,
+      nativeHost: { failed: false, headless: true, publish: () => true, suspend: () => undefined },
+    });
+    service.setEnabled(false);
+
+    service.handleSessionAttentionCleared('s1', 'passive');
+    // 重启后内存空、只有异步 not-found 查询在飞。可恢复 error 会建一条
+    // running:false 的临时条目并立刻被 prune,不得因此 bump generation 把旧收尾包作废。
+    service.handleAgentEvent({ sessionId: 's1', agentKind: 'codex' }, recoverableErrorEvent('retrying'));
+    mocks.tapWindowBroadcast.mockClear();
+
+    releaseSnapshot?.({
+      status: 'active',
+      title: 'stale',
+      userSendAt: null,
+      workingDir: '/tmp/x',
+      workspaceKind: null,
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mocks.tapWindowBroadcast).toHaveBeenCalledWith(
+      SESSION_ACTIVITY_CHANNEL,
+      expect.objectContaining({ sessionId: 's1', attention: false }),
+    );
+  });
+
   it('broadcasts a terminal clear when a read receipt clears unread completion attention', async () => {
     const { AgentIslandService } = await import('../service.js');
     const service = new AgentIslandService({
@@ -5709,6 +5745,25 @@ describe('会话关闭原因决定条目去留', () => {
 
     service.handleSessionClosed('plain', { reason: 'process-closed' });
     expect(sessions.has('plain')).toBe(false);
+  });
+
+  it('drops unread generation when a session is discarded without leftover attention', async () => {
+    const { AgentIslandService } = await import('../service.js');
+    const publish = vi.fn(() => true);
+    const service = new AgentIslandService({
+      getMainWindow: () => null,
+      nativeHost: { failed: false, headless: true, publish, suspend: () => undefined },
+    });
+    service.setEnabled(false);
+    service.handleUserPrompt({ sessionId: 'gone', agentKind: 'codex' }, 'run tests');
+    service.handleAgentEvent({ sessionId: 'gone', agentKind: 'codex' }, doneEvent());
+    const generations = (
+      service as unknown as { unreadAttentionGenerationBySession: Map<string, number> }
+    ).unreadAttentionGenerationBySession;
+    expect(generations.has('gone')).toBe(true);
+
+    service.handleSessionClosed('gone');
+    expect(generations.has('gone')).toBe(false);
   });
 
   it('TTL prune 后再 process-close 仍保留远程未读,直到真正 ack', async () => {

--- a/apps/desktop/src/main/agent-island/__tests__/sessionActivityRelay.test.ts
+++ b/apps/desktop/src/main/agent-island/__tests__/sessionActivityRelay.test.ts
@@ -238,8 +238,7 @@ describe('SessionActivityRelay', () => {
     const relay = new SessionActivityRelay(emit, { minIntervalMs: 1_500 });
 
     // entry 存在(此处是 live running 帧)说明与远端有活跃同步流:ensure 不得
-    // 插手 —— 发收尾包会把远端的 running / needs-interaction 指示误清成"已完成"
-    // (needs-interaction 是稳定态,没有后续事件能补回)。
+    // 插手 —— 发收尾包会把远端的 running / needs-interaction 指示误清成"已完成"。
     relay.publish([activity('s1', 'Thinking')]);
     emit.mockClear();
 
@@ -255,6 +254,47 @@ describe('SessionActivityRelay', () => {
       phase: 'completed',
       attention: false,
     }));
+  });
+
+  it('does not clear a leftover unread completed entry either — publish/ledger owns that', () => {
+    const emit = vi.fn();
+    const relay = new SessionActivityRelay(emit, { minIntervalMs: 1_500 });
+
+    // 异步 not-found 回执可能在查询窗口内碰上新一轮 completed。ensure 若因
+    // 「entries 是终态」就 clear,会把新绿点误清。未读由独立账本 + publish 收敛。
+    relay.publish([activity('s1', 'run tests', { phase: 'completed', attention: true })]);
+    emit.mockClear();
+
+    relay.ensureSessionTerminalClear('s1');
+
+    expect(emit).not.toHaveBeenCalled();
+  });
+
+  it('does not clear a leftover unread error entry either', () => {
+    const emit = vi.fn();
+    const relay = new SessionActivityRelay(emit, { minIntervalMs: 1_500 });
+
+    relay.publish([activity('s1', 'boom', { phase: 'error', attention: true })]);
+    emit.mockClear();
+
+    relay.ensureSessionTerminalClear('s1');
+
+    expect(emit).not.toHaveBeenCalled();
+  });
+
+  it('leaves a live needs-interaction entry intact', () => {
+    const emit = vi.fn();
+    const relay = new SessionActivityRelay(emit, { minIntervalMs: 1_500 });
+
+    relay.publish([activity('s1', '等待权限确认', {
+      phase: 'needs-interaction',
+      interactionKind: 'permission',
+    })]);
+    emit.mockClear();
+
+    relay.ensureSessionTerminalClear('s1');
+
+    expect(emit).not.toHaveBeenCalled();
   });
 
   it('drops pending throttled activity when the latest snapshot returns to the last sent state', () => {

--- a/apps/desktop/src/main/agent-island/__tests__/state.test.ts
+++ b/apps/desktop/src/main/agent-island/__tests__/state.test.ts
@@ -2090,6 +2090,11 @@ describe('Agent Island error read semantics (已读以 App 内真实展示为准
     expect(acknowledgeAgentIslandSessionRead(state, 'err', 3_100, { source: 'passive' })).toBe('error-immune');
     expect(state.remoteUnreadTerminals.get('err')).toMatchObject({ phase: 'error' });
     expect(state.sessions.get('err')?.phase).toBe('running');
+    // 远程侧栏同一 session 只能挂一帧:新一轮 running 是当前活档,绿/红点让位给转圈。
+    // 账本仍在,所以 passive 清不掉旧 error;下一轮终态或 explicit ack 再收敛。
+    expect(buildAllSessionActivitySnapshots(state)).toEqual([
+      expect.objectContaining({ sessionId: 'err', phase: 'running' }),
+    ]);
 
     expect(acknowledgeAgentIslandSessionRead(state, 'err', 3_200, { source: 'explicit' })).toBe('cleared');
     expect(state.remoteUnreadTerminals.has('err')).toBe(false);
@@ -2109,6 +2114,9 @@ describe('Agent Island error read semantics (已读以 App 内真实展示为准
     expect(state.sessions.get('err')?.phase).toBe('running');
     expect(state.sessions.get('err')?.unread).toBe(true);
     expect(state.remoteUnreadTerminals.get('err')).toMatchObject({ phase: 'error' });
+    expect(buildAllSessionActivitySnapshots(state)).toEqual([
+      expect.objectContaining({ sessionId: 'err', phase: 'running' }),
+    ]);
     expect(acknowledgeAgentIslandSessionRead(state, 'err', afterExpiryAt + 20, { source: 'passive' })).toBe('error-immune');
     expect(state.remoteUnreadTerminals.get('err')).toMatchObject({ phase: 'error' });
 

--- a/apps/desktop/src/main/agent-island/__tests__/state.test.ts
+++ b/apps/desktop/src/main/agent-island/__tests__/state.test.ts
@@ -2394,6 +2394,33 @@ describe('会话进程关闭不该抹掉正在展示的通知', () => {
     expect(buildAgentIslandDisplayState(state, 1_300).totalCount).toBe(0);
   });
 
+  it('进程关闭丢掉失效审批卡时,仍保留尚未看过的旧 error 账本', () => {
+    const state = createAgentIslandState();
+    applyAgentIslandEvent(state, { sessionId: 'err', title: 'Err' }, terminalErrorEvent('boom'), 1_000);
+    applyAgentIslandUserPrompt(state, { sessionId: 'err', title: 'Err' }, 'retry', 2_000);
+    applyAgentIslandInteractionRequest(
+      state,
+      { sessionId: 'err', title: 'Err' },
+      {
+        kind: 'permission',
+        requestId: 'r1',
+        toolName: 'Bash',
+        input: { command: 'rm -rf dist' },
+      },
+      2_100,
+    );
+    expect(state.remoteUnreadTerminals.get('err')).toMatchObject({ phase: 'error' });
+
+    closeAgentIslandSessionPreservingUnread(state, 'err', 2_200);
+
+    expect(state.sessions.has('err')).toBe(false);
+    expect(state.remoteUnreadTerminals.get('err')).toMatchObject({ phase: 'error' });
+    expect(acknowledgeAgentIslandSessionRead(state, 'err', 2_300, { source: 'passive' })).toBe('error-immune');
+    expect(buildAllSessionActivitySnapshots(state)).toEqual([
+      expect.objectContaining({ sessionId: 'err', phase: 'error', attention: true, activityLines: [] }),
+    ]);
+  });
+
   it('已经没有展示需求的会话,进程关闭时照常删除', () => {
     const state = createAgentIslandState();
     applyAgentIslandEvent(state, { sessionId: 'read', title: '已读' }, doneEvent(), 2_000);

--- a/apps/desktop/src/main/agent-island/__tests__/state.test.ts
+++ b/apps/desktop/src/main/agent-island/__tests__/state.test.ts
@@ -15,6 +15,7 @@ import {
   AGENT_ISLAND_MESSAGE_PREVIEW_MIN_DWELL_MS,
   AGENT_ISLAND_UNREAD_TRANSIENT_TTL_MS,
   buildAgentIslandDisplayState,
+  buildAllSessionActivitySnapshots,
   closeAgentIslandSessionPreservingUnread,
   createAgentIslandState,
   dismissAgentIslandActiveReveal,
@@ -2080,6 +2081,42 @@ describe('Agent Island error read semantics (已读以 App 内真实展示为准
     expect(display.totalCount).toBe(0);
   });
 
+  it('keeps a prior unread error immune to passive ack after a new running turn starts', () => {
+    const state = createAgentIslandState();
+    applyAgentIslandEvent(state, { sessionId: 'err', title: 'Err' }, terminalErrorEvent('boom'), 2_000);
+    applyAgentIslandUserPrompt(state, { sessionId: 'err', title: 'Err' }, 'retry', 3_000);
+
+    expect(state.remoteUnreadTerminals.get('err')).toMatchObject({ phase: 'error' });
+    expect(acknowledgeAgentIslandSessionRead(state, 'err', 3_100, { source: 'passive' })).toBe('error-immune');
+    expect(state.remoteUnreadTerminals.get('err')).toMatchObject({ phase: 'error' });
+    expect(state.sessions.get('err')?.phase).toBe('running');
+
+    expect(acknowledgeAgentIslandSessionRead(state, 'err', 3_200, { source: 'explicit' })).toBe('cleared');
+    expect(state.remoteUnreadTerminals.has('err')).toBe(false);
+    expect(state.sessions.get('err')?.unread).toBe(false);
+  });
+
+  it('keeps a ledger-only unread error through a fresh running turn and App badge mirror', () => {
+    const state = createAgentIslandState();
+    applyAgentIslandEvent(state, { sessionId: 'err', title: 'Err' }, terminalErrorEvent('boom'), 2_000);
+    const afterExpiryAt = 2_000 + AGENT_ISLAND_UNREAD_TRANSIENT_TTL_MS + 1_000;
+    buildAgentIslandDisplayState(state, afterExpiryAt);
+    expect(state.sessions.has('err')).toBe(false);
+    expect(state.remoteUnreadTerminals.get('err')).toMatchObject({ phase: 'error' });
+
+    applyAgentIslandUserPrompt(state, { sessionId: 'err', title: 'Err' }, 'retry', afterExpiryAt + 10);
+    expect(markAgentIslandSessionAttention(state, 'err')).toBe(true);
+    expect(state.sessions.get('err')?.phase).toBe('running');
+    expect(state.sessions.get('err')?.unread).toBe(true);
+    expect(state.remoteUnreadTerminals.get('err')).toMatchObject({ phase: 'error' });
+    expect(acknowledgeAgentIslandSessionRead(state, 'err', afterExpiryAt + 20, { source: 'passive' })).toBe('error-immune');
+    expect(state.remoteUnreadTerminals.get('err')).toMatchObject({ phase: 'error' });
+
+    expect(acknowledgeAgentIslandSessionRead(state, 'err', afterExpiryAt + 30, { source: 'explicit' })).toBe('cleared');
+    expect(state.remoteUnreadTerminals.has('err')).toBe(false);
+    expect(state.sessions.get('err')?.unread).toBe(false);
+  });
+
   it('preserves error unread when a pending interaction is dismissed after the terminal error', () => {
     const state = createAgentIslandState();
     applyAgentIslandInteractionRequest(state, { sessionId: 'err', title: 'Err' }, permissionRequest('r1'), 1_000);
@@ -2202,25 +2239,37 @@ describe('Agent Island 未读驻留 TTL(避免几小时前完成的任务无限�
     const beforeExpiry = buildAgentIslandDisplayState(state, 2_000 + AGENT_ISLAND_UNREAD_TRANSIENT_TTL_MS - 1_000);
     expect(beforeExpiry.totalCount).toBe(1);
     expect(beforeExpiry.sessions[0]).toMatchObject({ sessionId: 'done', phase: 'completed' });
+    // dwell / reveal 走完后,下一次 publish 必须排到岛面 TTL,否则 4h 到点不会自己隐藏。
+    const afterDwell = 2_000 + AGENT_ISLAND_COMPLETION_REVEAL_DWELL_MS + 1;
+    expect(getNextAgentIslandTimerAt(state, afterDwell)).toBe(2_000 + AGENT_ISLAND_UNREAD_TRANSIENT_TTL_MS);
   });
 
-  it('unread completed 条目超过 TTL 后从灵动岛列表 prune 掉', () => {
+  it('unread completed 超过 TTL 后离开岛面,独立账本仍在,远程快照继续带 attention', () => {
     const state = createAgentIslandState();
     applyAgentIslandEvent(state, { sessionId: 'done', title: 'Schedule' }, doneEvent(), 2_000);
 
-    // TTL 边界后 1 秒:即使还没被 ack,也不再让它占展开列表。
-    const afterExpiry = buildAgentIslandDisplayState(state, 2_000 + AGENT_ISLAND_UNREAD_TRANSIENT_TTL_MS + 1_000);
+    const afterExpiryAt = 2_000 + AGENT_ISLAND_UNREAD_TRANSIENT_TTL_MS + 1_000;
+    const afterExpiry = buildAgentIslandDisplayState(state, afterExpiryAt);
     expect(afterExpiry.totalCount).toBe(0);
+    expect(state.sessions.has('done')).toBe(false);
+    expect(buildAllSessionActivitySnapshots(state)).toEqual([
+      expect.objectContaining({ sessionId: 'done', phase: 'completed', attention: true, activityLines: [] }),
+    ]);
+    expect(acknowledgeAgentIslandSessionRead(state, 'done', afterExpiryAt, { source: 'passive' })).toBe('cleared');
+    expect(buildAllSessionActivitySnapshots(state)).toEqual([]);
   });
 
-  it('unread error 条目超过 TTL 后也从灵动岛列表 prune 掉', () => {
+  it('unread error 超过 TTL 后也离开岛面,账本仍在且 passive 仍免疫', () => {
     const state = createAgentIslandState();
     applyAgentIslandEvent(state, { sessionId: 'err', title: 'Err' }, terminalErrorEvent('boom'), 2_000);
 
-    // TTL 边界前:未读 error 仍然驻留(既有 60s 后仍可见的用例覆盖了 TTL 内区间,这里
-    // 只再验证 TTL 边界后被 prune 掉,防止长时间遗留报错霸占展开视图)。
-    const afterExpiry = buildAgentIslandDisplayState(state, 2_000 + AGENT_ISLAND_UNREAD_TRANSIENT_TTL_MS + 1_000);
+    const afterExpiryAt = 2_000 + AGENT_ISLAND_UNREAD_TRANSIENT_TTL_MS + 1_000;
+    const afterExpiry = buildAgentIslandDisplayState(state, afterExpiryAt);
     expect(afterExpiry.totalCount).toBe(0);
+    expect(state.sessions.has('err')).toBe(false);
+    expect(acknowledgeAgentIslandSessionRead(state, 'err', afterExpiryAt, { source: 'passive' })).toBe('error-immune');
+    expect(acknowledgeAgentIslandSessionRead(state, 'err', afterExpiryAt, { source: 'explicit' })).toBe('cleared');
+    expect(buildAllSessionActivitySnapshots(state)).toEqual([]);
   });
 
   it('TTL 过期后悬停展开也不应复活 unread completed 条目(preserveExpiredTransient 不绕过 TTL)', () => {
@@ -2231,9 +2280,13 @@ describe('Agent Island 未读驻留 TTL(避免几小时前完成的任务无限�
     const afterExpiry = 2_000 + AGENT_ISLAND_UNREAD_TRANSIENT_TTL_MS + 5_000;
     setAgentIslandHovered(state, true, afterExpiry);
 
-    // preserveExpiredTransient=true 时也不应把 TTL 过期的 unread 条目捞回来
+    // preserveExpiredTransient=true 时也不应把 TTL 过期的 unread 条目捞回岛面
     const display = buildAgentIslandDisplayState(state, afterExpiry);
     expect(display.totalCount).toBe(0);
+    expect(state.sessions.has('done')).toBe(false);
+    expect(buildAllSessionActivitySnapshots(state)).toEqual([
+      expect.objectContaining({ sessionId: 'done', phase: 'completed', attention: true, activityLines: [] }),
+    ]);
   });
 
   it('TTL 过期后悬停展开也不应复活 unread error 条目', () => {
@@ -2245,6 +2298,39 @@ describe('Agent Island 未读驻留 TTL(避免几小时前完成的任务无限�
 
     const display = buildAgentIslandDisplayState(state, afterExpiry);
     expect(display.totalCount).toBe(0);
+    expect(state.sessions.has('err')).toBe(false);
+    expect(buildAllSessionActivitySnapshots(state)).toEqual([
+      expect.objectContaining({ sessionId: 'err', phase: 'error', attention: true, activityLines: [] }),
+    ]);
+  });
+
+  it('TTL prune 后再 process-close 不得清掉独立未读账本', () => {
+    const state = createAgentIslandState();
+    applyAgentIslandEvent(state, { sessionId: 'done', title: 'Schedule' }, doneEvent(), 2_000);
+    const afterExpiryAt = 2_000 + AGENT_ISLAND_UNREAD_TRANSIENT_TTL_MS + 1_000;
+    buildAgentIslandDisplayState(state, afterExpiryAt);
+    expect(state.sessions.has('done')).toBe(false);
+
+    closeAgentIslandSessionPreservingUnread(state, 'done', afterExpiryAt + 10);
+
+    expect(buildAllSessionActivitySnapshots(state)).toEqual([
+      expect.objectContaining({ sessionId: 'done', phase: 'completed', attention: true, activityLines: [] }),
+    ]);
+  });
+
+  it('仅 ledger 存在时 process-close 也不得清掉未读账本', () => {
+    const state = createAgentIslandState();
+    applyAgentIslandEvent(state, { sessionId: 'err', title: 'Err' }, terminalErrorEvent('boom'), 2_000);
+    const afterExpiryAt = 2_000 + AGENT_ISLAND_UNREAD_TRANSIENT_TTL_MS + 1_000;
+    buildAgentIslandDisplayState(state, afterExpiryAt);
+    expect(state.sessions.has('err')).toBe(false);
+
+    closeAgentIslandSessionPreservingUnread(state, 'err', afterExpiryAt + 10);
+
+    expect(acknowledgeAgentIslandSessionRead(state, 'err', afterExpiryAt + 20, { source: 'passive' })).toBe('error-immune');
+    expect(buildAllSessionActivitySnapshots(state)).toEqual([
+      expect.objectContaining({ sessionId: 'err', phase: 'error', attention: true, activityLines: [] }),
+    ]);
   });
 });
 

--- a/apps/desktop/src/main/agent-island/service.ts
+++ b/apps/desktop/src/main/agent-island/service.ts
@@ -1141,8 +1141,9 @@ export class AgentIslandService {
     this.clearDeferredRemoteAuthError(sessionId);
     this.deletePermissionRequestsForSession(sessionId);
     const hadSession = this.state.sessions.has(sessionId);
+    const hadUnread = this.state.remoteUnreadTerminals.has(sessionId);
     removeAgentIslandSession(this.state, sessionId);
-    if (hadSession) this.publish();
+    if (hadSession || hadUnread) this.publish();
   }
 
   private advanceInteractionEpoch(sessionId: string): number {

--- a/apps/desktop/src/main/agent-island/service.ts
+++ b/apps/desktop/src/main/agent-island/service.ts
@@ -319,6 +319,11 @@ export class AgentIslandService {
   private readonly stoppedProviderTurnIdBySession = new Map<string, string>();
   private readonly interactionEpochBySession = new Map<string, number>();
   private interactionEpochSequence = 0;
+  /**
+   * 每条会话的未读代。新一轮 completed/error 未读会自增;异步 not-found 回执带着
+   * 入队时的代,回来后对不上就作废,避免清掉后来才挂上的绿点/红点。
+   */
+  private unreadAttentionGenerationBySession = new Map<string, number>();
   private readonly sessionHadAttentionAtRunStart = new Map<string, boolean>();
   private readonly userPromptRollbackTokens = new Map<string, {
     state: AgentIslandUserPromptRollbackToken;
@@ -582,8 +587,9 @@ export class AgentIslandService {
     this.hiddenPublished = false;
     if (!wasSynced && !enabled) {
       this.mutedCompletionSoundSessionIds.clear();
-      this.clearPublishTimer();
       this.hiddenPublished = true;
+      // Windows / headless 永远走这条:岛 UI 关着,但远程未读 TTL 仍要自己触发。
+      this.publish();
       return;
     }
     if (enabled) {
@@ -643,6 +649,7 @@ export class AgentIslandService {
     this.stoppedProviderTurnIdBySession.clear();
     this.interactionEpochBySession.clear();
     this.sessionHadAttentionAtRunStart.clear();
+    this.unreadAttentionGenerationBySession.clear();
     this.userPromptRollbackTokens.clear();
     this.deferredCompletions.clear();
     for (const sessionId of this.deferredRemoteAuthErrors.keys()) {
@@ -788,6 +795,9 @@ export class AgentIslandService {
       this.scheduleSilencedRunClearForSession(hydrated.sessionId, SILENCED_COMPLETION_CLEAR_MS);
     }
     if (!changed) return;
+    if (event.type === 'done' || event.type === 'error') {
+      this.bumpUnreadAttentionGeneration(hydrated.sessionId);
+    }
     this.ensureMetadata(hydrated.sessionId);
     if (!suppressCompletionAttention) {
       this.syncSessionAttention(hydrated.sessionId);
@@ -817,6 +827,7 @@ export class AgentIslandService {
           preserveAttention: hadPreviousAttention,
         })
         : false;
+      if (event.sessionId && hadPreviousAttention) this.bumpUnreadAttentionGeneration(event.sessionId);
       if (event.sessionId) this.sessionHadAttentionAtRunStart.delete(event.sessionId);
       // 若该会话有延后完成事件(之前因队列非空被推迟),标记为应压制注意力,
       // 防止队列排空后 notifyQueueEmptied 重放时 silencedSessionRunIds 已被清除、
@@ -1154,26 +1165,22 @@ export class AgentIslandService {
    */
   handleSessionAttentionCleared(sessionId: string, source: 'explicit' | 'passive' = 'passive'): void {
     const ack = acknowledgeAgentIslandSessionRead(this.state, sessionId, Date.now(), { source });
-    // 未读 error 对 passive 免疫:state 未动,也**不能**给远端发收尾包 —— 否则手机
-    // 列表行的 error 红点会被导航级被动信号清掉,破坏「未处置就不消失」。
+    // 未读 error 对 passive 免疫:state / 独立账本都未动,也**不能**给远端发收尾包。
     if (ack === 'error-immune') return;
     if (ack === 'not-found') {
-      // not-found(典型:重启后 state / relay 条目丢失,远端仍挂着旧未读)只对
-      // **本机拥有**的会话补收尾包(localDb 有行 = 本机是 owner)。本机只是控制端
-      // 时(查看别台设备的会话),该会话不在本机 localDb —— 不得替 owner 设备向
-      // 本机 sessions topic 广播否定帧,否则同时订阅本机的第三方控制端会误删
-      // owner 正在发布的 live / 未读条目;远程收敛由 renderer 的隧道回执直达
-      // owner 设备负责。异步查行期间若会话恢复活跃,ensure 的「entries 有条目
-      // 即不插手」语义天然防误清。
-      //
-      // passive 与 explicit 同权放行:重启后 error kind 的记忆(state / 角标)已
-      // 丢失,owner 侧无从做 kind 级免疫;而到达这里的 passive 回执几乎只来自
-      // 远程控制端,发起侧(sessionAttentionStore.flushPendingRemoteReceipt)已
-      // 做过 error 免疫——error 未读时 passive 回执按下不发,镜像缺失时还有消息层
-      // 终止错误探针兜底。若这里再扣发,桌面控制端的正常阅读路径(passive)将
-      // 永远清不掉 owner 重启前留下的完成绿点,恰是本兜底要修的挂死场景。
+      // 内存账本没有这条:典型是进程重启。只对**本机拥有**的会话补收尾包。
+      // 查询是异步的,必须带入队时代;回来时若已有新一轮未读或 live 条目,旧回执作废。
+      const generation = this.unreadAttentionGenerationBySession.get(sessionId) ?? 0;
       void getSessionRowSnapshot(sessionId)
         .then((row) => {
+          if ((this.unreadAttentionGenerationBySession.get(sessionId) ?? 0) !== generation) {
+            log.debug(`session read ack: session=${sessionId} source=${source} state=not-found; superseded`);
+            return;
+          }
+          if (this.state.sessions.has(sessionId) || this.state.remoteUnreadTerminals.has(sessionId)) {
+            log.debug(`session read ack: session=${sessionId} source=${source} state=not-found; live-or-unread returned, withheld`);
+            return;
+          }
           if (!row) {
             log.debug(`session read ack: session=${sessionId} source=${source} state=not-found; no local row, withheld`);
             return;
@@ -1187,12 +1194,9 @@ export class AgentIslandService {
     if (this.sessionHadAttentionAtRunStart.has(sessionId)) {
       this.sessionHadAttentionAtRunStart.set(sessionId, false);
     }
-    // 收尾包兜底必须在 publish() **之前**:桌面重启(state / relay 条目丢失)或
-    // 收尾包推送丢失后,远端列表行可能仍挂着 attention=true 的旧条目,而 relay
-    // entries 已无记录,publish() 的隐式收敛不会为它发出任何帧,绿点永久挂死 ——
-    // ensure 在 entries 无条目时补发一帧可重放的收尾包。entries 有条目(live 会话
-    // 或活跃未读)时 ensure 不插手,由紧随的 publish() 正常收敛:live 帧继续、
-    // 已读的未读终态走 clear 发收尾包,不产生误清与重复帧。
+    this.unreadAttentionGenerationBySession.delete(sessionId);
+    // 收尾包兜底必须在 publish() **之前**。ensure 只在 relay 没有该会话条目时补发;
+    // 已有 entry(live 或刚发出的未读终态)不动,由 publish() 把账本投影出去。
     this.sessionActivityRelay.ensureSessionTerminalClear(sessionId);
     if (ack === 'cleared') this.publish();
     log.debug(`session read ack: session=${sessionId} source=${source} state=${ack}`);
@@ -1451,15 +1455,18 @@ export class AgentIslandService {
     }
   }
 
+  private bumpUnreadAttentionGeneration(sessionId: string): void {
+    const next = (this.unreadAttentionGenerationBySession.get(sessionId) ?? 0) + 1;
+    this.unreadAttentionGenerationBySession.set(sessionId, next);
+  }
+
   /**
    * 把 per-session 活动快照(轻量子集)广播给 renderer,供侧栏置顶卡片/列表显示
    * 任务执行中的逐步活动 + 等待交互态。与原生灵动岛同源数据,enabled/disabled 都发。
    *
-   * 数据取 state.sessions **全集**(buildAllSessionActivitySnapshots),不是灵动岛展示面
-   * displayState.sessions —— 后者在展示 transient 完成/错误卡时会过滤掉运行中/等待中的
-   * 会话,而 renderer store 是整体替换,用子集会把这些会话从活动 map 丢掉、卡片回退陈旧
-   * summary(PR #246 review)。两个调用方均在 buildAgentIslandDisplayState(已裁剪过期
-   * session)之后调用本方法。
+   * 数据取 live sessions ∪ 独立未读账本(buildAllSessionActivitySnapshots),不是
+   * 灵动岛展示面 displayState.sessions。过了岛面 TTL 的完成/出错未读仍从账本带
+   * attention=true 投给远程侧栏,直到真正已读。
    */
   private buildSessionActivityPayload(): AgentIslandSessionActivity[] {
     return buildAllSessionActivitySnapshots(this.state).map((s) => ({
@@ -1574,7 +1581,9 @@ export class AgentIslandService {
       );
       // 侧栏卡片的逐步活动不依赖灵动岛开关:即便岛 UI 关闭,状态机仍累积,照常广播给 renderer。
       this.emitSessionActivityToRenderer();
-      this.clearPublishTimer();
+      // Windows / headless / 用户关掉岛面时,仍要按 TTL 把完整会话迁到轻量未读账本。
+      // 不排 timer 的话,终态后再无事件,活动文本会无限留在 state.sessions。
+      this.scheduleNextPublish(now);
       if (!this.hiddenPublished) {
         if (this.nativeHost.suspend) {
           this.nativeHost.suspend();

--- a/apps/desktop/src/main/agent-island/service.ts
+++ b/apps/desktop/src/main/agent-island/service.ts
@@ -795,12 +795,12 @@ export class AgentIslandService {
       this.scheduleSilencedRunClearForSession(hydrated.sessionId, SILENCED_COMPLETION_CLEAR_MS);
     }
     if (!changed) return;
-    if (event.type === 'done' || event.type === 'error') {
-      this.bumpUnreadAttentionGeneration(hydrated.sessionId);
-    }
     this.ensureMetadata(hydrated.sessionId);
     if (!suppressCompletionAttention) {
       this.syncSessionAttention(hydrated.sessionId);
+    }
+    if (this.state.remoteUnreadTerminals.has(hydrated.sessionId)) {
+      this.bumpUnreadAttentionGeneration(hydrated.sessionId);
     }
     if (isStreamingPreviewEvent(event)) {
       this.scheduleStreamingPreviewPublish();
@@ -1108,6 +1108,7 @@ export class AgentIslandService {
     if (options.reason === 'process-closed') {
       closeAgentIslandSessionPreservingUnread(this.state, sessionId, Date.now());
     } else {
+      this.unreadAttentionGenerationBySession.delete(sessionId);
       removeAgentIslandSession(this.state, sessionId);
     }
     this.deletePermissionRequestsForSession(sessionId);
@@ -1130,6 +1131,7 @@ export class AgentIslandService {
     this.replacementTurnDispatchingSessionIds.delete(sessionId);
     this.clearSilencedRunForSession(sessionId);
     this.sessionHadAttentionAtRunStart.delete(sessionId);
+    this.unreadAttentionGenerationBySession.delete(sessionId);
     for (const key of this.userPromptRollbackTokens.keys()) {
       if (key.startsWith(`${sessionId}:`)) {
         this.userPromptRollbackTokens.delete(key);

--- a/apps/desktop/src/main/agent-island/sessionActivityRelay.ts
+++ b/apps/desktop/src/main/agent-island/sessionActivityRelay.ts
@@ -80,16 +80,15 @@ export class SessionActivityRelay {
    * 远端删除不存在的条目是 no-op)并记入 terminal replay(重连 replay 时补发,
    * 推送当下丢失也能收敛)。
    *
-   * 为什么需要:publish() 的隐式收敛(clear 不在 list 里的 entry / attention 翻
-   * false 的 entry)依赖 entries 里还留着该会话 —— 桌面重启(entries 清零)或
-   * 收尾包推送丢失后,远端列表行可能仍挂着 attention=true 的旧条目,而 entries
-   * 已无记录,任何后续 publish 都不会再为它发出任何帧,绿/红点永久挂死。
+   * 为什么需要:publish() 的隐式收敛依赖 list 里还留着该会话。桌面重启(entries
+   * 清零)或收尾包推送丢失后,远端列表行可能仍挂着 attention=true 的旧条目,而
+   * entries 已无记录,任何后续 publish 都不会再为它发出任何帧。
    *
    * 为什么 entries 有条目时必须不动:条目存在说明本进程与远端就该会话有活跃
-   * 同步流 —— 它可能是 running / needs-interaction 的 live 帧(此刻发收尾包会把
-   * 远端正在展示的运行 / 等待授权指示误清成"已完成",needs-interaction 是稳定态,
-   * 没有后续事件能补回),也可能是刚发出的未读终态;两者都由紧随的 publish()
-   * 正常路径收敛(live 继续、已读走 clear 发收尾包),这里插手只会产生误清或重复帧。
+   * 同步流 —— 可能是 running / needs-interaction,也可能是刚发出的未读终态。
+   * 异步 not-found 回执若在查询窗口内碰上新一轮 completed/error,动手清掉会把
+   * 新绿点/红点误清,并绕过 error 的 passive 免疫。live 与未读终态都由紧随的
+   * publish() / 独立未读账本收敛。
    */
   ensureSessionTerminalClear(sessionId: string): void {
     if (this.entries.has(sessionId)) return;

--- a/apps/desktop/src/main/agent-island/state.ts
+++ b/apps/desktop/src/main/agent-island/state.ts
@@ -1006,9 +1006,13 @@ export function closeAgentIslandSessionPreservingUnread(
   session.currentToolUseId = null;
   session.toolDetailUntil = null;
   // pending 交互随进程一起失效(service 侧同时会 deletePermissionRequestsForSession)。
-  // 留着会让用户对着一张永远不会被响应的审批卡片点按钮,所以这类条目整条删掉 —— 要保的
-  // 只是「已经发生完、还没被看到」的终态通知。
+  // 留着会让用户对着一张永远不会被响应的审批卡片点按钮。岛条目可以丢,但旧的
+  // completed/error 账本不是这次审批,进程关闭不等于已读。
   if (session.pendingInteractionIds.size > 0) {
+    if (state.remoteUnreadTerminals.has(sessionId)) {
+      forgetAgentIslandSession(state, sessionId);
+      return;
+    }
     removeAgentIslandSession(state, sessionId);
     return;
   }

--- a/apps/desktop/src/main/agent-island/state.ts
+++ b/apps/desktop/src/main/agent-island/state.ts
@@ -51,9 +51,9 @@ export const AGENT_ISLAND_HOVER_SHORT_COOLDOWN_MS = 300;
 export const AGENT_ISLAND_TOOL_DETAIL_LINGER_MS = 2_000;
 export const AGENT_ISLAND_MESSAGE_PREVIEW_MIN_DWELL_MS = 1_600;
 export const AGENT_ISLAND_FOCUS_VERIFY_TIMEOUT_MS = 1_500;
-// 未读的 completed / error 条目在灵动岛列表里驻留的上限;超过后即便用户没 ack,
-// 也从灵动岛列表 prune 掉,避免几小时前完成的 schedule / 后台任务无限期霸占展开视图。
-// 会话本身在侧栏的未读状态不受影响。
+// 未读的 completed / error 在**灵动岛浮窗**里驻留的上限;超过后即便用户没 ack,
+// 也不再占用展开列表。岛 state 会按 TTL prune;远程绿/红点改订独立的
+// remoteUnreadTerminals 账本,不跟完整会话(含活动文本)一起留下。
 export const AGENT_ISLAND_UNREAD_TRANSIENT_TTL_MS = 4 * 60 * 60 * 1_000;
 const AGENT_ISLAND_COMPACT_CURRENT_MIN_DWELL_MS = 1_200;
 const AGENT_ISLAND_MEASURED_HEIGHT_MAX = 2_000;
@@ -193,6 +193,18 @@ export interface AgentIslandState {
   strings: AgentIslandStrings;
   /** 工具状态文案的措辞实现:默认共享包中文表,service 注入本地化版(lazy t())。 */
   toolWording: ToolRowWording;
+  /**
+   * 远程侧栏绿/红点的未读账本。岛面 TTL 只决定浮窗还显不显,不删这里。
+   * 条目只保留 phase / lastActivityAt,不含活动文本;resetRuntimeState 会清掉
+   * (进程重启后靠 localDb 兜底补发收尾包)。
+   */
+  remoteUnreadTerminals: Map<string, AgentIslandRemoteUnreadTerminal>;
+}
+
+export interface AgentIslandRemoteUnreadTerminal {
+  sessionId: string;
+  phase: 'completed' | 'error';
+  lastActivityAt: number;
 }
 
 export function createAgentIslandState(): AgentIslandState {
@@ -225,6 +237,7 @@ export function createAgentIslandState(): AgentIslandState {
     compactCurrentUntil: null,
     strings: { ...DEFAULT_AGENT_ISLAND_STRINGS },
     toolWording: DEFAULT_TOOL_ROW_WORDING,
+    remoteUnreadTerminals: new Map(),
   };
 }
 
@@ -257,6 +270,7 @@ export function resetAgentIslandState(state: AgentIslandState): void {
   state.compactCurrentSessionId = fresh.compactCurrentSessionId;
   state.compactCurrentUntil = fresh.compactCurrentUntil;
   state.strings = fresh.strings;
+  state.remoteUnreadTerminals = fresh.remoteUnreadTerminals;
   // toolWording 是注入的配置(非会话状态),reset 时保留,避免退回默认中文表。
 }
 
@@ -708,6 +722,7 @@ export function applyAgentIslandEvent(
     // 用户真的看到了报错内容。unread 只能由显式已读 ack(renderer 确认报错 UI
     // 真实展示给用户)清除,否则条目会在 errorUntil 过期后被 prune 静默删除。
     requestAttentionReveal(state, session, now, AGENT_ISLAND_ERROR_REVEAL_DWELL_MS, { forceUnread: true });
+    syncRemoteUnreadTerminal(state, session);
     return true;
   }
 
@@ -828,7 +843,7 @@ function dismissPendingInteraction(
     session.phase = 'error';
     return;
   }
-  // errorUntil 已过期但未读的 error 仍然可见(isSessionVisible),不能删。
+  // errorUntil 已过期但未读的 error 账本仍在,不能删 —— 岛面 TTL 只影响展示。
   if (preserveErrorUnread) return;
   state.sessions.delete(session.sessionId);
 }
@@ -852,12 +867,20 @@ export function acknowledgeAgentIslandSessionRead(
   options: { source?: 'passive' | 'explicit' } = {},
 ): AgentIslandSessionReadAckResult {
   const session = state.sessions.get(sessionId);
-  if (!session) return 'not-found';
-
-  // passive = 「会话路由可见 / 窗口聚焦」这类被动信号。它不能证明用户真的看到了
-  // 报错内容(切回窗口的瞬间就会触发),所以未读的 error 会话对被动 ack 免疫,
-  // 只接受显式 ack(renderer 确认报错 UI 真实展示后经 badge 桥接过来)。
-  if (options.source === 'passive' && session.phase === 'error' && session.unread) return 'error-immune';
+  const unread = state.remoteUnreadTerminals.get(sessionId);
+  // 未读 error 订账本,不订当前 live phase。新一轮 running 时 session.phase 已不是
+  // error,但用户仍可能没看过那次报错;passive 必须先看账本,否则聚焦/路由可见会把
+  // 旧红点清掉。
+  if (options.source === 'passive' && (
+    unread?.phase === 'error' || (session?.phase === 'error' && session.unread)
+  )) {
+    return 'error-immune';
+  }
+  if (!session) {
+    if (!unread) return 'not-found';
+    clearRemoteUnreadTerminal(state, sessionId);
+    return 'cleared';
+  }
 
   const wasUnread = session.unread;
   const hadDeferredReveal = session.deferredReveal;
@@ -866,6 +889,7 @@ export function acknowledgeAgentIslandSessionRead(
   const hadErrorDwell = session.errorUntil !== null;
 
   session.unread = false;
+  clearRemoteUnreadTerminal(state, sessionId);
   session.deferredReveal = false;
   session.deferredRevealReason = null;
   session.revealUntil = null;
@@ -906,6 +930,7 @@ export function completeAgentIslandSessionWithoutAttention(
   });
 
   if (!isSessionVisible(session, now)) {
+    if (isUnreadTerminalLedger(session)) syncRemoteUnreadTerminal(state, session);
     state.sessions.delete(sessionId);
     removeQueuedTransientReveal(state, sessionId);
   }
@@ -919,6 +944,7 @@ export function markAgentIslandSessionAttention(
   const session = state.sessions.get(sessionId);
   if (!session || session.unread) return false;
   session.unread = true;
+  syncRemoteUnreadTerminal(state, session);
   return true;
 }
 
@@ -926,11 +952,12 @@ export function hasAgentIslandSessionAttention(
   state: AgentIslandState,
   sessionId: string,
 ): boolean {
+  if (state.remoteUnreadTerminals.has(sessionId)) return true;
   const session = state.sessions.get(sessionId);
   return session ? session.unread || isAttentionSession(session) : false;
 }
 
-export function removeAgentIslandSession(state: AgentIslandState, sessionId: string): void {
+function forgetAgentIslandSession(state: AgentIslandState, sessionId: string): void {
   state.sessions.delete(sessionId);
   if (state.visibleSessionIds.delete(sessionId) && state.visibleSessionId === sessionId) {
     state.visibleSessionId = state.visibleSessionIds.values().next().value ?? null;
@@ -942,6 +969,11 @@ export function removeAgentIslandSession(state: AgentIslandState, sessionId: str
   }
 }
 
+export function removeAgentIslandSession(state: AgentIslandState, sessionId: string): void {
+  clearRemoteUnreadTerminal(state, sessionId);
+  forgetAgentIslandSession(state, sessionId);
+}
+
 /**
  * 会话**进程**关闭:落下运行态,但保留仍需展示的通知条目。
  *
@@ -951,8 +983,10 @@ export function removeAgentIslandSession(state: AgentIslandState, sessionId: str
  * 没了,用户看到的就是「弹了一下就收起」。通知是**已发生事件的记录**,生命周期不该绑在
  * agent session 句柄上。
  *
- * 判据复用 `isSessionVisible`:仍需展示(未读终态未过 TTL / dwell 未走完 / 有 pending
- * 交互)就留着,由既有 lifecycle 到期或用户 ack 收掉;否则照常删除。
+ * 判据复用 `isSessionVisible`:仍需在岛上展示(TTL 内的未读终态 / dwell 未走完 /
+ * 有 pending 交互)就留着。过了岛面 TTL 的未读终态会先写入独立账本再删岛 state;
+ * 若岛条目已经不在(TTL 已 prune / 仅剩账本),close 不得再清账本 —— 远程绿/红点
+ * 要等到真正已读。
  *
  * 会话被归档 / 删除、或 Orca worker 被策略清除时**不走这里** —— 那些语义是「这条记录
  * 不该再存在」,继续用 `removeAgentIslandSession` 硬删。
@@ -964,7 +998,7 @@ export function closeAgentIslandSessionPreservingUnread(
 ): void {
   const session = state.sessions.get(sessionId);
   if (!session) {
-    removeAgentIslandSession(state, sessionId);
+    // 岛面已 prune,独立账本仍可能挂着未读。进程关闭不等于已读。
     return;
   }
   // 进程已经没了,运行态必须落下来,否则 pill 会一直转着 working 动画。
@@ -979,6 +1013,15 @@ export function closeAgentIslandSessionPreservingUnread(
     return;
   }
   if (isSessionVisible(session, now)) return;
+  if (isUnreadTerminalLedger(session)) {
+    syncRemoteUnreadTerminal(state, session);
+    forgetAgentIslandSession(state, sessionId);
+    return;
+  }
+  if (state.remoteUnreadTerminals.has(sessionId)) {
+    forgetAgentIslandSession(state, sessionId);
+    return;
+  }
   removeAgentIslandSession(state, sessionId);
 }
 
@@ -1068,6 +1111,9 @@ export function pruneAgentIslandSessions(state: AgentIslandState, now: number): 
   const preserveExpiredTransient = isPointerInsideIsland(state) || state.hoverExpanded || isCollapsePending(state, now);
   for (const [sessionId, session] of state.sessions.entries()) {
     if (isSessionVisible(session, now, preserveExpiredTransient)) continue;
+    // 过了岛面 TTL 的未读终态先写入独立账本,再删岛 state。远程绿/红点订账本,
+    // 不再跟完整 AgentIslandSessionState(含活动文本)绑在一起。
+    if (isUnreadTerminalLedger(session)) syncRemoteUnreadTerminal(state, session);
     state.sessions.delete(sessionId);
     removeQueuedTransientReveal(state, sessionId);
   }
@@ -1146,12 +1192,19 @@ export function buildAgentIslandDisplayState(
  * (PR #246 review)。侧栏卡片按 sessionId 各取所需,故这里取 state.sessions 全集。
  *
  * 仅做读取映射;session 的增删与过期裁剪由 buildAgentIslandDisplayState 负责,调用方
- * 应在其后调用本函数(此时 state.sessions 已裁剪)。
+ * 应在其后调用本函数(此时 state.sessions 已裁剪)。过了岛面 TTL 的未读终态已迁到
+ * remoteUnreadTerminals,这里把账本补进快照,远程侧栏才能继续看到绿/红点。
  */
 export function buildAllSessionActivitySnapshots(
   state: AgentIslandState,
 ): AgentIslandSessionSnapshot[] {
-  return Array.from(state.sessions.values()).map((session) => toSnapshot(session));
+  const snapshots = Array.from(state.sessions.values()).map((session) => toSnapshot(session));
+  const seen = new Set(snapshots.map((snapshot) => snapshot.sessionId));
+  for (const unread of state.remoteUnreadTerminals.values()) {
+    if (seen.has(unread.sessionId)) continue;
+    snapshots.push(toRemoteUnreadSnapshot(unread));
+  }
+  return snapshots;
 }
 
 export function getNextAgentIslandTimerAt(state: AgentIslandState, now: number): number | null {
@@ -1175,6 +1228,7 @@ export function getNextAgentIslandTimerAt(state: AgentIslandState, now: number):
       session.visibleInteractionSuppressedUntil,
       session.toolDetailUntil,
       session.messagePreview?.until,
+      unreadIslandTtlAt(session),
     ]) {
       if (value && value > now && (next === null || value < next)) {
         next = value;
@@ -1343,6 +1397,7 @@ function completeAgentIslandSession(
     session.deferredRevealReason = null;
     session.queuedRevealDwellMs = null;
     session.unread = options.preserveAttention;
+    syncRemoteUnreadTerminal(state, session);
     removeQueuedTransientReveal(state, session.sessionId);
     if (state.activeTransientSessionId === session.sessionId) {
       state.activeTransientSessionId = null;
@@ -1352,6 +1407,7 @@ function completeAgentIslandSession(
 
   session.completedUntil = now + AGENT_ISLAND_COMPLETION_DWELL_MS;
   requestAttentionReveal(state, session, now, completionRevealDwellMs(session, now));
+  syncRemoteUnreadTerminal(state, session);
 }
 
 function requestAttentionReveal(
@@ -2204,14 +2260,69 @@ function shouldDisplaySession(
     && !isVisibleInteractionSuppressed(state, session, now);
 }
 
+function isUnreadTerminalLedger(
+  session: AgentIslandSessionState,
+): session is AgentIslandSessionState & { phase: 'completed' | 'error' } {
+  return session.unread && (session.phase === 'completed' || session.phase === 'error');
+}
+
+function syncRemoteUnreadTerminal(state: AgentIslandState, session: AgentIslandSessionState): void {
+  if (isUnreadTerminalLedger(session)) {
+    state.remoteUnreadTerminals.set(session.sessionId, {
+      sessionId: session.sessionId,
+      phase: session.phase,
+      lastActivityAt: session.lastActivityAt,
+    });
+    return;
+  }
+  // 新一轮 running / 等待交互不是已读。App badge 镜像会给 live session 打 unread,
+  // 但不能据此把还没被看到的旧 completed/error 账本清掉。真正变成新的终态时,
+  // 再按当前 unread 覆盖或清除。
+  if (session.running || session.phase === 'needs-interaction' || session.pendingInteractionIds.size > 0) {
+    return;
+  }
+  clearRemoteUnreadTerminal(state, session.sessionId);
+}
+
+function clearRemoteUnreadTerminal(state: AgentIslandState, sessionId: string): void {
+  state.remoteUnreadTerminals.delete(sessionId);
+}
+
+function unreadIslandTtlAt(session: AgentIslandSessionState): number | null {
+  if (!isUnreadTerminalLedger(session)) return null;
+  return session.lastActivityAt + AGENT_ISLAND_UNREAD_TRANSIENT_TTL_MS;
+}
+
+function toRemoteUnreadSnapshot(unread: AgentIslandRemoteUnreadTerminal): AgentIslandSessionSnapshot {
+  return {
+    sessionId: unread.sessionId,
+    title: unread.sessionId.slice(0, 8),
+    projectName: null,
+    detail: '',
+    compactDetail: '',
+    messagePreview: null,
+    phase: unread.phase,
+    agentKind: 'claude-code',
+    interactionKind: undefined,
+    permissionAction: null,
+    attention: true,
+    activityLines: [],
+    startedAt: unread.lastActivityAt,
+    lastActivityAt: unread.lastActivityAt,
+  };
+}
+
+function isUnreadTerminalWithinIslandTtl(session: AgentIslandSessionState, now: number): boolean {
+  return isUnreadTerminalLedger(session)
+    && now - session.lastActivityAt < AGENT_ISLAND_UNREAD_TRANSIENT_TTL_MS;
+}
+
 function isSessionVisible(session: AgentIslandSessionState, now: number, preserveExpiredTransient = false): boolean {
   if (session.pendingInteractionIds.size > 0) return true;
   if (session.running) return true;
-  if (session.unread && (session.phase === 'completed' || session.phase === 'error')) {
-    // 未读的完成/错误只在 TTL 内保留;过了 TTL 即使用户没 ack,也不再让它占据灵动岛
-    // 列表 —— 会话本身在侧栏的未读状态仍由 renderer 侧维护,不受影响。
-    if (now - session.lastActivityAt < AGENT_ISLAND_UNREAD_TRANSIENT_TTL_MS) return true;
-  }
+  // 岛面只在 TTL 内展示未读终态;过了 TTL prune 会把岛 state 删掉,未读迁到
+  // remoteUnreadTerminals 给远程侧栏 / 已读回执。
+  if (isUnreadTerminalWithinIslandTtl(session, now)) return true;
   if (session.completedUntil && session.completedUntil > now) return true;
   if (session.errorUntil && session.errorUntil > now) return true;
   // 不复活已过 TTL 的 unread 条目：preserveExpiredTransient 仅用于短 dwell 窗口内到期的
@@ -2219,7 +2330,7 @@ function isSessionVisible(session: AgentIslandSessionState, now: number, preserv
   if (
     preserveExpiredTransient &&
     (session.phase === 'completed' || session.phase === 'error') &&
-    !(session.unread && now - session.lastActivityAt >= AGENT_ISLAND_UNREAD_TRANSIENT_TTL_MS)
+    !isUnreadTerminalLedger(session)
   )
     return true;
   return false;
@@ -2259,12 +2370,12 @@ function isWaitingSession(session: AgentIslandSessionState, now: number): boolea
   return (
     session.pendingInteractionIds.size > 0
     || session.phase === 'needs-interaction'
-    || (session.phase === 'error' && (session.unread || (session.errorUntil !== null && session.errorUntil > now)))
+    || (session.phase === 'error' && (isUnreadTerminalWithinIslandTtl(session, now) || (session.errorUntil !== null && session.errorUntil > now)))
   );
 }
 
 function isUnreadCompletedSession(session: AgentIslandSessionState, now: number): boolean {
-  return session.phase === 'completed' && (session.unread || (session.completedUntil !== null && session.completedUntil > now));
+  return session.phase === 'completed' && (isUnreadTerminalWithinIslandTtl(session, now) || (session.completedUntil !== null && session.completedUntil > now));
 }
 
 function isTransientlyPinnedSession(


### PR DESCRIPTION
## 这次改了什么

### 摘要

远程控制端侧栏的完成绿点，会在被控端灵动岛把 4 小时未读卡片藏起来之后卡住：被控端内存里已经没有这条会话，但发给控制端的活动流还停在 `completed + attention=true`，之后也不会再发收尾包。控制端点绿点发出的已读回执，还会撞上另一条保护——「本地还有这条会话就不发收尾」——于是绿点只能等到你在被控端自己点开任务才消失。

这次把远程未读从灵动岛浮窗生命周期里拆出来：岛面照旧 4 小时后隐藏完整活动卡片；远程绿/红点改记一份只含 `phase / lastActivityAt` 的轻量账本，直到真正已读。Windows / 关掉岛面时也走同一套定时器。异步旧回执、进程关闭、以及「旧报错还没看、新一轮又跑起来了」都按账本收敛，不会误清。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无独立 issue；来自远程控制端完成绿点点不掉、直到被控端本地点开才消失。
- 本 PR 包含：
  - Agent Island 独立 `remoteUnreadTerminals` 账本，远程侧栏绿/红点订账本而不是订岛面 TTL
  - 岛面 4h TTL 仍会 prune 完整会话；Windows / headless / 关闭岛面也会排这个定时器
  - 异步 not-found 已读回执带 generation，旧查询不能清新一轮未读
  - `ensureSessionTerminalClear` 在 relay 已有条目时不再插手
  - process-closed 保留账本；passive 已读对未读 error 免疫，包括账本-only 后新一轮 running / App badge 镜像
- 明确不包含：侧栏折叠项目/自动化组红点（另一条线）；不改 device-link wire 协议形状
- 用户可见变化：远程控制端的完成绿点，在被控端灵动岛卡片消失后仍可点掉；未处置的出错红点不会被切任务/聚焦清掉
- 是否存在 breaking change：无

### UI 变化

不涉及：main 进程状态机与远程活动快照，没有 renderer / 视觉 / 交互 / 文案改动。

- 引用的设计规范：不涉及

### 远程与手机适配

1. SSH 远程工作区：不涉及。本改动不读 workdir 文件、不改远端执行位置。
2. 设备互联 / 手机：已一并适配。控制端侧栏绿/红点走既有 `sessions` topic 的 `SessionActivityPayload`（`phase` / `attention`），没有新 IPC / 新 payload 字段；被控端在岛面 TTL、headless、Windows 上都继续发布 attention，直到 ack。
3. 手机版入口：不涉及新入口。手机作为控制端继续消费同一条 sessions 活动流。

故障半径（本 PR 未改 device-link 重试／超时／断链恢复，但活动收尾会经共享 relay 广播）：

1. 故障层级：单条会话的未读终态投影丢失，不是 peer link / 整条 relay 连接故障。
2. 动作层级：只补该 session 的终端 clear / attention 帧；不拆连接、不重放全量。
3. 多 peer：收尾包仍是既有幂等 `attention=false` 广播，其它控制端删除不存在的条目是 no-op。未改 teardown / 重连半径。

## 怎么验证的

### 自动验证

```text
cd /Users/dash/Code/Cindy/cindy-fix-remote-done-dot-ack
pnpm --filter desktop exec vitest run \
  src/main/agent-island/__tests__/state.test.ts \
  src/main/agent-island/__tests__/service.test.ts \
  src/main/agent-island/__tests__/sessionActivityRelay.test.ts
结果：3 files / 256 tests passed

pnpm test:unit:related
结果：PASS apps/desktop unit (related 6 files)

pnpm --filter desktop run typecheck
结果：通过
```

`bash .../run-unit-gate.sh` 全量 desktop unit 在 `ghostInstallReceipt.test.ts` 两例失败；同一失败在干净 `origin/main`（`57ea39795`）上复现，与本 diff 无关，未混入修复。

### 手工验证

未在本机再走一遍远程控制端点绿点。根因与修复由日志复盘 + 上述交错单测覆盖：TTL 后 attention 仍在、headless 定时器、异步旧回执、process-close、ledger-only error + App badge 镜像后的 passive 免疫。

### 未执行的验证

- 实机：Windows 被控端 + 手机/另一台桌面控制端，完成绿点在岛面 4h 后仍可点掉
- 实机：未处置 error 红点在切任务 / 聚焦后仍在，显式看过报错后才消失
- 双模式目检：不涉及 UI

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [x] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：被控端 Agent Island 状态机及其投影到 device-link `sessions` topic 的活动快照；Windows / 关闭岛面与 macOS 开岛走同一套未读账本。payload 字段未变。
- 回滚 / 降级方式：revert 本 PR。旧控制端仍能消费 `phase` / `attention`；新被控端对旧控制端也只是多保留未读 attention，直到 ack。
- 存量插件影响：无

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
