### PR TITLE
fix(desktop): 提问导航条预览改为最终回答

### DIFF
--- a/apps/desktop/src/renderer/__tests__/messageNavRailModel.test.ts
+++ b/apps/desktop/src/renderer/__tests__/messageNavRailModel.test.ts
@@ -192,6 +192,30 @@ describe('deriveNavRailEntries', () => {
     expect(deriveNavRailEntries(messages)[0].answerExcerpt).toBe('真正的回答');
   });
 
+  it('合成续跑之后的回答不再盖到上一根可见刻度', () => {
+    const messages = [
+      msg({ clientId: 'u1', role: 'user', content: '这个点不到吧' }),
+      msg({
+        clientId: 'a1',
+        role: 'assistant',
+        content: '对，那个 0 尺寸节点本身点不到。入口是定时器按钮的右键。',
+        turnCompleted: true,
+      }),
+      msg({ clientId: 'syn', role: 'user', content: '继续', isSyntheticTrigger: true }),
+      msg({
+        clientId: 'a2',
+        role: 'assistant',
+        content: '续跑后的另一轮结论,不该出现在上一问预览里。',
+        turnCompleted: true,
+      }),
+    ];
+    const entries = deriveNavRailEntries(messages);
+    expect(entries.map((e) => e.id)).toEqual(['u1']);
+    expect(entries[0].answerExcerpt).toBe(
+      '对，那个 0 尺寸节点本身点不到。入口是定时器按钮的右键。',
+    );
+  });
+
   it('提问之前的 assistant 消息不会挂到任何条目上', () => {
     const messages = [
       msg({ clientId: 'a0', role: 'assistant', content: '开场白' }),

--- a/apps/desktop/src/renderer/__tests__/messageNavRailModel.test.ts
+++ b/apps/desktop/src/renderer/__tests__/messageNavRailModel.test.ts
@@ -116,18 +116,80 @@ describe('deriveNavRailEntries', () => {
     expect(entries[0].attachmentsOnly).toBe(1);
   });
 
-  it('回答摘要取该轮第一条非空 assistant 正文,跳过 thinking / tool 行', () => {
+  it('回答摘要取该轮最后一条非空 assistant 正文,跳过 thinking / tool 行', () => {
     const messages = [
       msg({ clientId: 'u1', role: 'user', content: '第一问' }),
       msg({ clientId: 'th1', role: 'thinking', content: '推理过程' }),
       msg({ clientId: 't1', role: 'tool_use', content: '{"cmd":"ls"}' }),
       msg({ clientId: 'a1', role: 'assistant', content: '  我先看下\n项目结构  ' }),
-      msg({ clientId: 'a2', role: 'assistant', content: '后续补充,不该覆盖首条' }),
+      msg({ clientId: 'a2', role: 'assistant', content: '结论:入口在右键,不在 0 尺寸节点。' }),
       msg({ clientId: 'u2', role: 'user', content: '第二问(流式中,尚无回答)' }),
     ];
     const entries = deriveNavRailEntries(messages);
-    expect(entries[0].answerExcerpt).toBe('我先看下 项目结构');
+    expect(entries[0].answerExcerpt).toBe('结论:入口在右键,不在 0 尺寸节点。');
     expect(entries[1].answerExcerpt).toBeUndefined();
+  });
+
+  it('开工叙述会被同轮最终回答覆盖', () => {
+    const messages = [
+      msg({ clientId: 'u1', role: 'user', content: '这个点不到吧' }),
+      msg({
+        clientId: 'a1',
+        role: 'assistant',
+        content: '对，那个 0 尺寸节点不是给人点的，只是拿来锚菜单。我先核对它会不会一打开就被 Radix 关掉。',
+      }),
+      msg({
+        clientId: 'a2',
+        role: 'assistant',
+        content: '对，那个 0 尺寸节点本身点不到。\n\n它不是入口。入口是定时器按钮的右键。',
+      }),
+    ];
+    expect(deriveNavRailEntries(messages)[0].answerExcerpt).toBe(
+      '对，那个 0 尺寸节点本身点不到。 它不是入口。入口是定时器按钮的右键。',
+    );
+  });
+
+  it('已收尾的最终回答不会被后续开工叙述盖回去', () => {
+    const messages = [
+      msg({ clientId: 'u1', role: 'user', content: '这个点不到吧' }),
+      msg({
+        clientId: 'a1',
+        role: 'assistant',
+        content: '对，那个 0 尺寸节点本身点不到。入口是定时器按钮的右键。',
+        turnCompleted: true,
+      }),
+      msg({
+        clientId: 'a2',
+        role: 'assistant',
+        content: '我先核对展开态菜单会不会一打开就被关掉。',
+      }),
+    ];
+    expect(deriveNavRailEntries(messages)[0].answerExcerpt).toBe(
+      '对，那个 0 尺寸节点本身点不到。入口是定时器按钮的右键。',
+    );
+  });
+
+  it('同轮后一条收尾正文覆盖前一条收尾正文', () => {
+    const messages = [
+      msg({ clientId: 'u1', role: 'user', content: '继续' }),
+      msg({ clientId: 'a1', role: 'assistant', content: '先交了 PR。', turnCompleted: true }),
+      msg({ clientId: 'a2', role: 'assistant', content: '菜单已经改到组头右键。', turnCompleted: true }),
+    ];
+    expect(deriveNavRailEntries(messages)[0].answerExcerpt).toBe('菜单已经改到组头右键。');
+  });
+
+  it('系统卡不占用回答摘要', () => {
+    const messages = [
+      msg({ clientId: 'u1', role: 'user', content: '第一问' }),
+      msg({ clientId: 'a1', role: 'assistant', content: '真正的回答', turnCompleted: true }),
+      msg({
+        clientId: 'a2',
+        role: 'assistant',
+        content: '本轮费用 $0.12',
+        systemCardType: 'cost',
+      }),
+    ];
+    expect(deriveNavRailEntries(messages)[0].answerExcerpt).toBe('真正的回答');
   });
 
   it('提问之前的 assistant 消息不会挂到任何条目上', () => {

--- a/apps/desktop/src/renderer/__tests__/messageNavRailModel.test.ts
+++ b/apps/desktop/src/renderer/__tests__/messageNavRailModel.test.ts
@@ -262,6 +262,16 @@ describe('deriveNavRailEntries', () => {
     expect(deriveNavRailEntries(messages)[0].answerExcerpt).toBe('真正的回答');
   });
 
+  it('空正文收尾标记仍封轮,未收尾进度不能盖掉已有摘要', () => {
+    const messages = [
+      msg({ clientId: 'u1', role: 'user', content: '第一问' }),
+      msg({ clientId: 'a1', role: 'assistant', content: '真正的回答' }),
+      msg({ clientId: 'a2', role: 'assistant', content: '', turnCompleted: true }),
+      msg({ clientId: 'a3', role: 'assistant', content: '我先核对下一处入口。' }),
+    ];
+    expect(deriveNavRailEntries(messages)[0].answerExcerpt).toBe('真正的回答');
+  });
+
   it('hook 消息(带 userText):预览取干净原文,不取 content 里的 agent prompt', () => {
     const messages = [
       msg({

--- a/apps/desktop/src/renderer/__tests__/messageNavRailModel.test.ts
+++ b/apps/desktop/src/renderer/__tests__/messageNavRailModel.test.ts
@@ -242,6 +242,26 @@ describe('deriveNavRailEntries', () => {
     expect(deriveNavRailEntries(messages)[0].answerExcerpt).toBe('真正的回答');
   });
 
+  it('收尾正文规范化为空仍封轮,未收尾进度不能盖掉已有摘要', () => {
+    const messages = [
+      msg({ clientId: 'u1', role: 'user', content: '第一问' }),
+      msg({
+        clientId: 'a1',
+        role: 'assistant',
+        content: '真正的回答',
+        turnCompleted: true,
+      }),
+      msg({
+        clientId: 'a2',
+        role: 'assistant',
+        content: '<!-- hidden -->',
+        turnCompleted: true,
+      }),
+      msg({ clientId: 'a3', role: 'assistant', content: '我先核对下一处入口。' }),
+    ];
+    expect(deriveNavRailEntries(messages)[0].answerExcerpt).toBe('真正的回答');
+  });
+
   it('hook 消息(带 userText):预览取干净原文,不取 content 里的 agent prompt', () => {
     const messages = [
       msg({

--- a/apps/desktop/src/renderer/__tests__/messageNavRailModel.test.ts
+++ b/apps/desktop/src/renderer/__tests__/messageNavRailModel.test.ts
@@ -233,6 +233,15 @@ describe('deriveNavRailEntries', () => {
     expect(deriveNavRailEntries(messages)[0].answerExcerpt).toBe('真正的回答');
   });
 
+  it('规范化后为空的尾条不冲掉已有有效摘要', () => {
+    const messages = [
+      msg({ clientId: 'u1', role: 'user', content: '第一问' }),
+      msg({ clientId: 'a1', role: 'assistant', content: '真正的回答' }),
+      msg({ clientId: 'a2', role: 'assistant', content: '<!-- hidden -->\n`**`' }),
+    ];
+    expect(deriveNavRailEntries(messages)[0].answerExcerpt).toBe('真正的回答');
+  });
+
   it('hook 消息(带 userText):预览取干净原文,不取 content 里的 agent prompt', () => {
     const messages = [
       msg({

--- a/apps/desktop/src/renderer/__tests__/messageNavRailModel.test.ts
+++ b/apps/desktop/src/renderer/__tests__/messageNavRailModel.test.ts
@@ -272,6 +272,16 @@ describe('deriveNavRailEntries', () => {
     expect(deriveNavRailEntries(messages)[0].answerExcerpt).toBe('真正的回答');
   });
 
+  it('封轮后的下一 SDK turn 在再次封轮时提交新摘要', () => {
+    const messages = [
+      msg({ clientId: 'u1', role: 'user', content: '第一问' }),
+      msg({ clientId: 'a1', role: 'assistant', content: '第一轮结论。', turnCompleted: true }),
+      msg({ clientId: 'a2', role: 'assistant', content: '第二轮真正的结论。' }),
+      msg({ clientId: 'a3', role: 'assistant', content: '', turnCompleted: true }),
+    ];
+    expect(deriveNavRailEntries(messages)[0].answerExcerpt).toBe('第二轮真正的结论。');
+  });
+
   it('hook 消息(带 userText):预览取干净原文,不取 content 里的 agent prompt', () => {
     const messages = [
       msg({

--- a/apps/desktop/src/renderer/__tests__/messageNavRailModel.test.ts
+++ b/apps/desktop/src/renderer/__tests__/messageNavRailModel.test.ts
@@ -282,6 +282,21 @@ describe('deriveNavRailEntries', () => {
     expect(deriveNavRailEntries(messages)[0].answerExcerpt).toBe('第二轮真正的结论。');
   });
 
+  it('显式失败收尾不能靠费用把进度提交成最终摘要', () => {
+    const messages = [
+      msg({ clientId: 'u1', role: 'user', content: '第一问' }),
+      msg({ clientId: 'a1', role: 'assistant', content: '成功结论。', turnCompleted: true }),
+      msg({
+        clientId: 'a2',
+        role: 'assistant',
+        content: '失败前的进度。',
+        turnCompleted: false,
+        turnCostUsd: 0.12,
+      }),
+    ];
+    expect(deriveNavRailEntries(messages)[0].answerExcerpt).toBe('成功结论。');
+  });
+
   it('hook 消息(带 userText):预览取干净原文,不取 content 里的 agent prompt', () => {
     const messages = [
       msg({

--- a/apps/desktop/src/renderer/components/chat/messageNavRailModel.ts
+++ b/apps/desktop/src/renderer/components/chat/messageNavRailModel.ts
@@ -129,8 +129,8 @@ export const NAV_RAIL_MIN_AVAIL_HEIGHT_PX = NAV_RAIL_MIN_ENTRIES * NAV_RAIL_TICK
  * 回答不再盖到上一问(旧的 first-wins 碰巧挡住了这条;改 last-wins 后必须显式切)。
  * steer 插话不是边界,回答仍归上一问。
  *
- * 候选只在「可能成为本轮摘要」时才规范化;规范化后为空则丢掉,保留上一条
- * 有效摘要。避免流式每次重算都对整段历史跑一遍 normalizeExcerpt。
+ * 本轮只收集候选原文,收尾时从后往前规范化到第一条非空摘要。收尾标记
+ * 即使正文规范化为空也封轮,避免后续未收尾进度盖掉已有摘要。
  *
  * 注意输入是全量已加载 messages 而非 visibleRenderItems —— 导航条要覆盖
  * 整段已加载历史,渲染窗口外的目标由跳转侧扩窗解决(见 MessageStream 的
@@ -141,12 +141,20 @@ export function deriveNavRailEntries(messages: readonly ChatMessage[]): NavRailE
   const entries: NavRailEntry[] = [];
   let lastOwnsAnswers = false;
   let lastExcerptSealed = false;
-  let pendingExcerpt: string | null = null;
+  let pendingAnswers: ChatMessage[] = [];
 
   const flushPendingAnswer = () => {
     const last = entries[entries.length - 1];
-    if (last && pendingExcerpt) last.answerExcerpt = pendingExcerpt;
-    pendingExcerpt = null;
+    if (last) {
+      for (let i = pendingAnswers.length - 1; i >= 0; i--) {
+        const excerpt = normalizeExcerpt(pendingAnswers[i].content);
+        if (excerpt) {
+          last.answerExcerpt = excerpt;
+          break;
+        }
+      }
+    }
+    pendingAnswers = [];
   };
 
   const closeAnswerTurn = () => {
@@ -202,10 +210,8 @@ export function deriveNavRailEntries(messages: readonly ChatMessage[]): NavRailE
     if (!lastOwnsAnswers || !isNavRailAnswerCandidate(m)) continue;
     const sealed = isSealedAssistantAnswer(m);
     if (sealed || !lastExcerptSealed) {
-      const excerpt = normalizeExcerpt(m.content);
-      if (!excerpt) continue;
-      pendingExcerpt = excerpt;
-      lastExcerptSealed = sealed;
+      pendingAnswers.push(m);
+      if (sealed) lastExcerptSealed = true;
     }
   }
   flushPendingAnswer();

--- a/apps/desktop/src/renderer/components/chat/messageNavRailModel.ts
+++ b/apps/desktop/src/renderer/components/chat/messageNavRailModel.ts
@@ -130,7 +130,7 @@ export const NAV_RAIL_MIN_AVAIL_HEIGHT_PX = NAV_RAIL_MIN_ENTRIES * NAV_RAIL_TICK
  * steer 插话不是边界,回答仍归上一问。
  *
  * 本轮只收集候选原文,收尾时从后往前规范化到第一条非空摘要。收尾标记
- * 即使正文规范化为空也封轮,避免后续未收尾进度盖掉已有摘要。
+ * 即使正文为空或规范化后为空也封轮,避免后续未收尾进度盖掉已有摘要。
  *
  * 注意输入是全量已加载 messages 而非 visibleRenderItems —— 导航条要覆盖
  * 整段已加载历史,渲染窗口外的目标由跳转侧扩窗解决(见 MessageStream 的
@@ -207,23 +207,16 @@ export function deriveNavRailEntries(messages: readonly ChatMessage[]): NavRailE
       }
       continue;
     }
-    if (!lastOwnsAnswers || !isNavRailAnswerCandidate(m)) continue;
+    if (!lastOwnsAnswers) continue;
+    if (m.role !== 'assistant' || m.systemCardType) continue;
     const sealed = isSealedAssistantAnswer(m);
-    if (sealed || !lastExcerptSealed) {
-      pendingAnswers.push(m);
-      if (sealed) lastExcerptSealed = true;
-    }
+    const accept = sealed || !lastExcerptSealed;
+    if (sealed) lastExcerptSealed = true;
+    if (!accept || m.content.trim().length === 0) continue;
+    pendingAnswers.push(m);
   }
   flushPendingAnswer();
   return entries;
-}
-
-function isNavRailAnswerCandidate(message: ChatMessage): boolean {
-  return (
-    message.role === 'assistant' &&
-    !message.systemCardType &&
-    message.content.trim().length > 0
-  );
 }
 
 /** 与消息流 action bar 的收尾判定同口径:done 边界 / 费用 / 用量。 */

--- a/apps/desktop/src/renderer/components/chat/messageNavRailModel.ts
+++ b/apps/desktop/src/renderer/components/chat/messageNavRailModel.ts
@@ -124,13 +124,10 @@ export const NAV_RAIL_MIN_AVAIL_HEIGHT_PX = NAV_RAIL_MIN_ENTRIES * NAV_RAIL_TICK
  * - isSyntheticTrigger:合成指令行渲染 null,没有可滚动的锚点;
  * - systemCardType:user 位次上的系统卡(compact / learn …),不是用户提问。
  *
- * 回答摘要只属于最近一根可见刻度,且只在该刻度仍「拥有」后续回答时更新。
- * 合成续跑 / 系统卡 user 行不画刻度,但会结束上一根刻度的归属 —— 其后的
- * 回答不再盖到上一问(旧的 first-wins 碰巧挡住了这条;改 last-wins 后必须显式切)。
- * steer 插话不是边界,回答仍归上一问。
- *
- * 本轮只收集候选原文,收尾时从后往前规范化到第一条非空摘要。收尾标记
- * 即使正文为空或规范化后为空也封轮,避免后续未收尾进度盖掉已有摘要。
+ * 回答摘要只属于最近一根可见刻度。一根刻度下可以有多个 SDK turn:
+ * 封轮(turnCompleted / 费用 / 用量,含空 wrap-up)提交当前候选;封轮后的
+ * 未收尾进度只暂存,要等下一次封轮才提交。合成续跑 / 系统卡 user 行结束
+ * 整根刻度归属;steer 插话不是边界。
  *
  * 注意输入是全量已加载 messages 而非 visibleRenderItems —— 导航条要覆盖
  * 整段已加载历史,渲染窗口外的目标由跳转侧扩窗解决(见 MessageStream 的
@@ -142,23 +139,35 @@ export function deriveNavRailEntries(messages: readonly ChatMessage[]): NavRailE
   let lastOwnsAnswers = false;
   let lastExcerptSealed = false;
   let pendingAnswers: ChatMessage[] = [];
+  let committedExcerpt: string | null = null;
 
-  const flushPendingAnswer = () => {
-    const last = entries[entries.length - 1];
-    if (last) {
-      for (let i = pendingAnswers.length - 1; i >= 0; i--) {
-        const excerpt = normalizeExcerpt(pendingAnswers[i].content);
-        if (excerpt) {
-          last.answerExcerpt = excerpt;
-          break;
-        }
-      }
+  const excerptFromPending = (): string | null => {
+    for (let i = pendingAnswers.length - 1; i >= 0; i--) {
+      const excerpt = normalizeExcerpt(pendingAnswers[i].content);
+      if (excerpt) return excerpt;
     }
+    return null;
+  };
+
+  const commitPendingIfAny = () => {
+    const excerpt = excerptFromPending();
+    if (excerpt) committedExcerpt = excerpt;
     pendingAnswers = [];
   };
 
+  const applyToLastEntry = () => {
+    const last = entries[entries.length - 1];
+    if (last) {
+      const live = lastExcerptSealed ? null : excerptFromPending();
+      const excerpt = live ?? committedExcerpt;
+      if (excerpt) last.answerExcerpt = excerpt;
+    }
+    pendingAnswers = [];
+    committedExcerpt = null;
+  };
+
   const closeAnswerTurn = () => {
-    flushPendingAnswer();
+    applyToLastEntry();
     lastOwnsAnswers = false;
     lastExcerptSealed = false;
   };
@@ -210,12 +219,13 @@ export function deriveNavRailEntries(messages: readonly ChatMessage[]): NavRailE
     if (!lastOwnsAnswers) continue;
     if (m.role !== 'assistant' || m.systemCardType) continue;
     const sealed = isSealedAssistantAnswer(m);
-    const accept = sealed || !lastExcerptSealed;
-    if (sealed) lastExcerptSealed = true;
-    if (!accept || m.content.trim().length === 0) continue;
-    pendingAnswers.push(m);
+    if (m.content.trim().length > 0) pendingAnswers.push(m);
+    if (sealed) {
+      commitPendingIfAny();
+      lastExcerptSealed = true;
+    }
   }
-  flushPendingAnswer();
+  applyToLastEntry();
   return entries;
 }
 

--- a/apps/desktop/src/renderer/components/chat/messageNavRailModel.ts
+++ b/apps/desktop/src/renderer/components/chat/messageNavRailModel.ts
@@ -34,9 +34,10 @@ export interface NavRailEntry {
    */
   attachmentsOnly?: number;
   /**
-   * 该轮回答开头的摘要(已压平空白、截断)。agent 对话里大量提问是
+   * 该轮最终回答的摘要(已压平空白、截断)。agent 对话里大量提问是
    * "继续 / 不对,重来"这类不含识别信息的短指令,回答摘要才是用户认出
    * "这根刻度是哪一轮"的主载体 — 它是识别的必需品,不是装饰。
+   * 取本轮最后一条非空 assistant 正文:前面的开工叙述会随最终回答覆盖。
    * 回答尚未产生(流式中 / 被打断)时为 undefined,预览卡只显示提问行。
    */
   answerExcerpt?: string;
@@ -123,9 +124,10 @@ export const NAV_RAIL_MIN_AVAIL_HEIGHT_PX = NAV_RAIL_MIN_ENTRIES * NAV_RAIL_TICK
  * - isSyntheticTrigger:合成指令行渲染 null,没有可滚动的锚点;
  * - systemCardType:user 位次上的系统卡(compact / learn …),不是用户提问。
  *
- * 回答摘要取该提问之后第一条非空 assistant 正文的开头(thinking / tool 行
- * 不算正文):它可能是开工叙述而非最终结论,但作为"这一轮在干什么"的识别
- * 线索足够,且流式期间就有值。
+ * 回答摘要取该提问之后的最终 assistant 正文(thinking / tool / 系统卡不算):
+ * 有收尾标记(turnCompleted / 费用 / 用量)时用最后一条收尾正文,没有则用
+ * 最后一条非空正文。一轮里先写开工叙述、再写结论时预览卡必须显示结论;
+ * 流式中途只有叙述时先用叙述,结论到达后覆盖,后续未收尾的过程句不再回盖。
  *
  * 注意输入是全量已加载 messages 而非 visibleRenderItems —— 导航条要覆盖
  * 整段已加载历史,渲染窗口外的目标由跳转侧扩窗解决(见 MessageStream 的
@@ -134,6 +136,7 @@ export const NAV_RAIL_MIN_AVAIL_HEIGHT_PX = NAV_RAIL_MIN_ENTRIES * NAV_RAIL_TICK
  */
 export function deriveNavRailEntries(messages: readonly ChatMessage[]): NavRailEntry[] {
   const entries: NavRailEntry[] = [];
+  let lastExcerptSealed = false;
   for (const m of messages) {
     if (m.role === 'user') {
       if (m.isSyntheticTrigger) continue;
@@ -157,6 +160,7 @@ export function deriveNavRailEntries(messages: readonly ChatMessage[]): NavRailE
       const attachmentCount = (m.images?.length ?? 0) + (m.files?.length ?? 0);
       if (preview) {
         entries.push({ id: m.clientId, preview, isAutomation: Boolean(m.automationOrigin) });
+        lastExcerptSealed = false;
       } else if (attachmentCount > 0) {
         // 有附件但一个名字都取不到(粘贴截图):仍是真实提问,保留刻度,
         // 预览文案由组件按 attachmentsOnly 用 i18n 兜底。
@@ -166,17 +170,41 @@ export function deriveNavRailEntries(messages: readonly ChatMessage[]): NavRailE
           attachmentsOnly: attachmentCount,
           isAutomation: Boolean(m.automationOrigin),
         });
+        lastExcerptSealed = false;
       }
       // 无文本、无附件 → 无法识别的空刻度,不当成提问(PR #830 review)。
       continue;
     }
-    if (m.role !== 'assistant') continue;
+    if (!isNavRailAnswerCandidate(m)) continue;
     const last = entries[entries.length - 1];
-    if (!last || last.answerExcerpt !== undefined) continue;
+    if (!last) continue;
     const excerpt = normalizeExcerpt(m.content);
-    if (excerpt) last.answerExcerpt = excerpt;
+    if (!excerpt) continue;
+    const sealed = isSealedAssistantAnswer(m);
+    if (sealed || !lastExcerptSealed) {
+      last.answerExcerpt = excerpt;
+      lastExcerptSealed = sealed;
+    }
   }
   return entries;
+}
+
+function isNavRailAnswerCandidate(message: ChatMessage): boolean {
+  return (
+    message.role === 'assistant' &&
+    !message.systemCardType &&
+    message.content.trim().length > 0
+  );
+}
+
+/** 与消息流 action bar 的收尾判定同口径:done 边界 / 费用 / 用量。 */
+function isSealedAssistantAnswer(message: ChatMessage): boolean {
+  return (
+    message.turnCompleted === true ||
+    (message.turnMoney?.amount ?? 0) > 0 ||
+    (typeof message.turnCostUsd === 'number' && message.turnCostUsd > 0) ||
+    message.turnUsageDetails !== undefined
+  );
 }
 
 /**

--- a/apps/desktop/src/renderer/components/chat/messageNavRailModel.ts
+++ b/apps/desktop/src/renderer/components/chat/messageNavRailModel.ts
@@ -129,8 +129,8 @@ export const NAV_RAIL_MIN_AVAIL_HEIGHT_PX = NAV_RAIL_MIN_ENTRIES * NAV_RAIL_TICK
  * 回答不再盖到上一问(旧的 first-wins 碰巧挡住了这条;改 last-wins 后必须显式切)。
  * steer 插话不是边界,回答仍归上一问。
  *
- * 每根刻度只规范化一条候选正文(最后一条收尾,没有则最后一条非空),避免流式
- * 每次重算都对整段历史跑一遍 normalizeExcerpt。
+ * 候选只在「可能成为本轮摘要」时才规范化;规范化后为空则丢掉,保留上一条
+ * 有效摘要。避免流式每次重算都对整段历史跑一遍 normalizeExcerpt。
  *
  * 注意输入是全量已加载 messages 而非 visibleRenderItems —— 导航条要覆盖
  * 整段已加载历史,渲染窗口外的目标由跳转侧扩窗解决(见 MessageStream 的
@@ -141,16 +141,12 @@ export function deriveNavRailEntries(messages: readonly ChatMessage[]): NavRailE
   const entries: NavRailEntry[] = [];
   let lastOwnsAnswers = false;
   let lastExcerptSealed = false;
-  let pendingAnswer: ChatMessage | null = null;
+  let pendingExcerpt: string | null = null;
 
   const flushPendingAnswer = () => {
-    if (!pendingAnswer) return;
     const last = entries[entries.length - 1];
-    if (last) {
-      const excerpt = normalizeExcerpt(pendingAnswer.content);
-      if (excerpt) last.answerExcerpt = excerpt;
-    }
-    pendingAnswer = null;
+    if (last && pendingExcerpt) last.answerExcerpt = pendingExcerpt;
+    pendingExcerpt = null;
   };
 
   const closeAnswerTurn = () => {
@@ -206,7 +202,9 @@ export function deriveNavRailEntries(messages: readonly ChatMessage[]): NavRailE
     if (!lastOwnsAnswers || !isNavRailAnswerCandidate(m)) continue;
     const sealed = isSealedAssistantAnswer(m);
     if (sealed || !lastExcerptSealed) {
-      pendingAnswer = m;
+      const excerpt = normalizeExcerpt(m.content);
+      if (!excerpt) continue;
+      pendingExcerpt = excerpt;
       lastExcerptSealed = sealed;
     }
   }

--- a/apps/desktop/src/renderer/components/chat/messageNavRailModel.ts
+++ b/apps/desktop/src/renderer/components/chat/messageNavRailModel.ts
@@ -229,10 +229,14 @@ export function deriveNavRailEntries(messages: readonly ChatMessage[]): NavRailE
   return entries;
 }
 
-/** 与消息流 action bar 的收尾判定同口径:done 边界 / 费用 / 用量。 */
+/**
+ * 与 latestMessageText.logic.isTitleTurnCompleted 同口径:
+ * 显式 turnCompleted=false 是失败,不能被费用/用量兜底当成封轮。
+ */
 function isSealedAssistantAnswer(message: ChatMessage): boolean {
+  if (message.turnCompleted === false) return false;
+  if (message.turnCompleted === true) return true;
   return (
-    message.turnCompleted === true ||
     (message.turnMoney?.amount ?? 0) > 0 ||
     (typeof message.turnCostUsd === 'number' && message.turnCostUsd > 0) ||
     message.turnUsageDetails !== undefined

--- a/apps/desktop/src/renderer/components/chat/messageNavRailModel.ts
+++ b/apps/desktop/src/renderer/components/chat/messageNavRailModel.ts
@@ -124,10 +124,13 @@ export const NAV_RAIL_MIN_AVAIL_HEIGHT_PX = NAV_RAIL_MIN_ENTRIES * NAV_RAIL_TICK
  * - isSyntheticTrigger:合成指令行渲染 null,没有可滚动的锚点;
  * - systemCardType:user 位次上的系统卡(compact / learn …),不是用户提问。
  *
- * 回答摘要取该提问之后的最终 assistant 正文(thinking / tool / 系统卡不算):
- * 有收尾标记(turnCompleted / 费用 / 用量)时用最后一条收尾正文,没有则用
- * 最后一条非空正文。一轮里先写开工叙述、再写结论时预览卡必须显示结论;
- * 流式中途只有叙述时先用叙述,结论到达后覆盖,后续未收尾的过程句不再回盖。
+ * 回答摘要只属于最近一根可见刻度,且只在该刻度仍「拥有」后续回答时更新。
+ * 合成续跑 / 系统卡 user 行不画刻度,但会结束上一根刻度的归属 —— 其后的
+ * 回答不再盖到上一问(旧的 first-wins 碰巧挡住了这条;改 last-wins 后必须显式切)。
+ * steer 插话不是边界,回答仍归上一问。
+ *
+ * 每根刻度只规范化一条候选正文(最后一条收尾,没有则最后一条非空),避免流式
+ * 每次重算都对整段历史跑一遍 normalizeExcerpt。
  *
  * 注意输入是全量已加载 messages 而非 visibleRenderItems —— 导航条要覆盖
  * 整段已加载历史,渲染窗口外的目标由跳转侧扩窗解决(见 MessageStream 的
@@ -136,14 +139,35 @@ export const NAV_RAIL_MIN_AVAIL_HEIGHT_PX = NAV_RAIL_MIN_ENTRIES * NAV_RAIL_TICK
  */
 export function deriveNavRailEntries(messages: readonly ChatMessage[]): NavRailEntry[] {
   const entries: NavRailEntry[] = [];
+  let lastOwnsAnswers = false;
   let lastExcerptSealed = false;
+  let pendingAnswer: ChatMessage | null = null;
+
+  const flushPendingAnswer = () => {
+    if (!pendingAnswer) return;
+    const last = entries[entries.length - 1];
+    if (last) {
+      const excerpt = normalizeExcerpt(pendingAnswer.content);
+      if (excerpt) last.answerExcerpt = excerpt;
+    }
+    pendingAnswer = null;
+  };
+
+  const closeAnswerTurn = () => {
+    flushPendingAnswer();
+    lastOwnsAnswers = false;
+    lastExcerptSealed = false;
+  };
+
   for (const m of messages) {
     if (m.role === 'user') {
-      if (m.isSyntheticTrigger) continue;
-      if (m.systemCardType) continue;
       // 运行中插话(steer)不是新一轮问答:MessageStream 的轮次语义也不把
       // 它当边界,算成刻度会把进行中的回答错挂到插话名下(PR #830 review)。
       if (m.delivery === 'steer') continue;
+      if (m.isSyntheticTrigger || m.systemCardType) {
+        closeAnswerTurn();
+        continue;
+      }
       // 预览来源按序:显示文本(hook 消息取 userText / 剥 <thread_context>,
       // Orca 通信行解包 JSON,与 UserMessage 气泡正文同源,见
       // userMessageDisplayText.ts;PR #830 review)→ ChatMessage 顶层
@@ -159,33 +183,34 @@ export function deriveNavRailEntries(messages: readonly ChatMessage[]): NavRailE
       if (!preview) preview = attachmentNames.join(' · ');
       const attachmentCount = (m.images?.length ?? 0) + (m.files?.length ?? 0);
       if (preview) {
+        closeAnswerTurn();
         entries.push({ id: m.clientId, preview, isAutomation: Boolean(m.automationOrigin) });
-        lastExcerptSealed = false;
+        lastOwnsAnswers = true;
       } else if (attachmentCount > 0) {
         // 有附件但一个名字都取不到(粘贴截图):仍是真实提问,保留刻度,
         // 预览文案由组件按 attachmentsOnly 用 i18n 兜底。
+        closeAnswerTurn();
         entries.push({
           id: m.clientId,
           preview: '',
           attachmentsOnly: attachmentCount,
           isAutomation: Boolean(m.automationOrigin),
         });
-        lastExcerptSealed = false;
+        lastOwnsAnswers = true;
+      } else {
+        // 无文本、无附件 → 无法识别的空刻度,不当成提问(PR #830 review)。
+        closeAnswerTurn();
       }
-      // 无文本、无附件 → 无法识别的空刻度,不当成提问(PR #830 review)。
       continue;
     }
-    if (!isNavRailAnswerCandidate(m)) continue;
-    const last = entries[entries.length - 1];
-    if (!last) continue;
-    const excerpt = normalizeExcerpt(m.content);
-    if (!excerpt) continue;
+    if (!lastOwnsAnswers || !isNavRailAnswerCandidate(m)) continue;
     const sealed = isSealedAssistantAnswer(m);
     if (sealed || !lastExcerptSealed) {
-      last.answerExcerpt = excerpt;
+      pendingAnswer = m;
       lastExcerptSealed = sealed;
     }
   }
+  flushPendingAnswer();
   return entries;
 }
 


### PR DESCRIPTION
## 这次改了什么

### 摘要

对话左侧提问导航条的预览卡，以前取本轮第一条助手正文。一轮里先说「我先核对……」、再给出结论时，刻度上会停在开工句。现在改为以该轮最终回答为准：有收尾标记用最后一条收尾正文，没有则用最后一条非空正文；结论之后未收尾的过程句不再盖回去。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：提问导航条 `answerExcerpt` 改为最终回答
- 明确不包含：侧栏任务列表 preview / summary、消息流折叠规则
- 用户可见变化：刻度预览卡第二行显示该轮结论，而不是开工叙述
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：`docs/design-rules/DESIGN.md` §1 Extreme content restraint — each surface presents one clear idea。预览卡是内容预览，必须展示该轮可识别的最终回答。未改版式、颜色、间距、token 或交互，只改取哪一段助手正文。

## 怎么验证的

### 自动验证

```text
cd /Users/dash/Code/Cindy/cindy-sidebar-preview-final-answer
pnpm test:unit:related
结果：PASS apps/desktop unit（related 2 个文件）

pnpm --filter desktop run typecheck
结果：通过

pnpm --filter desktop exec vitest run src/renderer/__tests__/messageNavRailModel.test.ts src/renderer/components/chat/__tests__/MessageNavRail.test.tsx
结果：68 passed

bash /Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh <worktree>
结果：apps/desktop 全量 2 failed / 28333 passed
失败项：src/main/cindy-brain/__tests__/ghostInstallReceipt.test.ts
与本 PR diff 无关。在干净 main checkout 复现同一文件同样失败，属基线问题，交给 CI 给权威结论。
```

### 手工验证

未在本机重启开发版目检。当前运行中的 Cindy 不会热更到此 worktree。

### 未执行的验证

未做 Light / Dark 实机目检（只改取文逻辑，版式未动）。未跑 mobile。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop 对话区左侧提问导航条预览文案
- 回滚 / 降级方式：revert 本提交即可

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
