### PR TITLE
fix(desktop): preserve custom OAuth route on first Claude turn

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/claudeSessionRouteObservation.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/claudeSessionRouteObservation.test.ts
@@ -159,7 +159,6 @@ describe('claude session route observation (routing transform ② 段)', () => {
     expect(decision).toEqual({
       upstreamOverride: 'https://api.kimi.com/coding',
       headerOverride: { authorization: 'Bearer kimi-token' },
-      headerDelete: ['x-cindy-cc-session-id', 'x-cindy-cc-session-token'],
     });
     expect(routeMocks.resolveSessionRouteDecision).toHaveBeenCalledWith(
       'sess-fresh-kimi',
@@ -180,11 +179,47 @@ describe('claude session route observation (routing transform ② 段)', () => {
     );
     const writeHead = vi.fn();
     const end = vi.fn();
-    await decision?.localHandler?.({ res: { writeHead, end } } as never);
+    const resolvedDecision = await Promise.resolve(decision);
+    await resolvedDecision?.localHandler?.({ res: { writeHead, end } } as never);
     expect(writeHead).toHaveBeenCalledWith(401, expect.any(Object));
     expect(JSON.parse(end.mock.calls[0][0])).toMatchObject({
       error: { code: 'invalid_cc_session_token' },
     });
+  });
+
+  it('revokes a replaced or disposed session-instance attestation', async () => {
+    const oldAuth = getClaudeProxySessionAuth('sess-fresh-kimi', 'instance-old')!;
+    const currentAuth = getClaudeProxySessionAuth('sess-fresh-kimi', 'instance-current')!;
+    const transform = createModelRoutingTransform();
+
+    const oldDecision = await Promise.resolve(transform(
+      { model: 'k3' },
+      ctxWith({
+        'x-cindy-cc-session-id': oldAuth.sessionId,
+        'x-cindy-cc-session-token': oldAuth.token,
+      }),
+    ));
+    expect(oldDecision?.localHandler).toBeTypeOf('function');
+
+    oldAuth.dispose();
+    const activeDecision = await Promise.resolve(transform(
+      { model: 'k3' },
+      ctxWith({
+        'x-cindy-cc-session-id': currentAuth.sessionId,
+        'x-cindy-cc-session-token': currentAuth.token,
+      }),
+    ));
+    expect(activeDecision?.localHandler).not.toBeTypeOf('function');
+
+    currentAuth.dispose();
+    const disposedDecision = await Promise.resolve(transform(
+      { model: 'k3' },
+      ctxWith({
+        'x-cindy-cc-session-id': currentAuth.sessionId,
+        'x-cindy-cc-session-token': currentAuth.token,
+      }),
+    ));
+    expect(disposedDecision?.localHandler).toBeTypeOf('function');
   });
 
   it('records gateway for an explicitly selected XD passthrough with a frozen child key', () => {

--- a/apps/desktop/src/main/maker-host/__tests__/claudeSessionRouteObservation.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/claudeSessionRouteObservation.test.ts
@@ -48,6 +48,7 @@ vi.mock('../provider-route', () => ({
 import {
   createModelRoutingTransform,
   setClaudeProxyGatewayKeyReader,
+  getClaudeProxySessionAuth,
   setClaudeProxySessionIdResolver,
 } from '../anthropic-compat-proxy-host';
 import { setSessionProvider, clearSessionProvider } from '../session-provider-store';
@@ -136,6 +137,54 @@ describe('claude session route observation (routing transform ② 段)', () => {
       ),
     ).toEqual({ upstreamOverride: 'https://api.anthropic.com' });
     expect(takeClaudeRequestRoute(22)).toEqual({ sessionId: 'sess-1', route: 'subscription' });
+  });
+
+  it('routes a fresh session through its authenticated host header before the SDK id is known (#3279)', () => {
+    setSessionProvider('sess-fresh-kimi', 'kimi-code');
+    const auth = getClaudeProxySessionAuth('sess-fresh-kimi');
+    routeMocks.resolveSessionRouteDecision.mockReturnValueOnce({
+      upstreamOverride: 'https://api.kimi.com/coding',
+      headerOverride: { authorization: 'Bearer kimi-token' },
+    });
+
+    const decision = createModelRoutingTransform()(
+      { model: 'k3' },
+      ctxWith({
+        authorization: 'Bearer stale-claude-token',
+        'x-cindy-cc-session-id': auth!.sessionId,
+        'x-cindy-cc-session-token': auth!.token,
+      }, 25),
+    );
+
+    expect(decision).toEqual({
+      upstreamOverride: 'https://api.kimi.com/coding',
+      headerOverride: { authorization: 'Bearer kimi-token' },
+      headerDelete: ['x-cindy-cc-session-id', 'x-cindy-cc-session-token'],
+    });
+    expect(routeMocks.resolveSessionRouteDecision).toHaveBeenCalledWith(
+      'sess-fresh-kimi',
+      'claude-code',
+      null,
+      'k3',
+    );
+    clearSessionProvider('sess-fresh-kimi');
+  });
+
+  it('rejects an invalid host route token instead of falling back to the default provider', async () => {
+    const decision = createModelRoutingTransform()(
+      { model: 'k3' },
+      ctxWith({
+        'x-cindy-cc-session-id': 'sess-fresh-kimi',
+        'x-cindy-cc-session-token': 'forged',
+      }, 26),
+    );
+    const writeHead = vi.fn();
+    const end = vi.fn();
+    await decision?.localHandler?.({ res: { writeHead, end } } as never);
+    expect(writeHead).toHaveBeenCalledWith(401, expect.any(Object));
+    expect(JSON.parse(end.mock.calls[0][0])).toMatchObject({
+      error: { code: 'invalid_cc_session_token' },
+    });
   });
 
   it('records gateway for an explicitly selected XD passthrough with a frozen child key', () => {

--- a/apps/desktop/src/main/maker-host/anthropic-compat-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/anthropic-compat-proxy-host.ts
@@ -119,18 +119,34 @@ let _initialized = false;
 const CC_PROXY_SESSION_ID_HEADER = 'x-cindy-cc-session-id';
 const CC_PROXY_SESSION_TOKEN_HEADER = 'x-cindy-cc-session-token';
 const CC_PROXY_INTERNAL_HEADERS = [CC_PROXY_SESSION_ID_HEADER, CC_PROXY_SESSION_TOKEN_HEADER];
-const ccProxySessionTokens = new Map<string, string>();
+interface ClaudeProxySessionRegistration {
+  sessionInstanceId?: string;
+  token: string;
+}
+
+const ccProxySessionTokens = new Map<string, ClaudeProxySessionRegistration>();
 
 /** Mint the per-process proof that lets a fresh CC request select its Cindy session route. */
-export function getClaudeProxySessionAuth(sessionId: string): { sessionId: string; token: string } | null {
+export function getClaudeProxySessionAuth(
+  sessionId: string,
+  sessionInstanceId?: string,
+): { sessionId: string; token: string; dispose: () => void } | null {
   const id = sessionId.trim();
   if (!id) return null;
-  let token = ccProxySessionTokens.get(id);
-  if (!token) {
-    token = randomBytes(32).toString('base64url');
-    ccProxySessionTokens.set(id, token);
-  }
-  return { sessionId: id, token };
+  const registration: ClaudeProxySessionRegistration = {
+    ...(sessionInstanceId?.trim() ? { sessionInstanceId: sessionInstanceId.trim() } : {}),
+    token: randomBytes(32).toString('base64url'),
+  };
+  // One business session can be reopened with a new instance. Replacing the
+  // registration immediately revokes a delayed process from the old instance.
+  ccProxySessionTokens.set(id, registration);
+  return {
+    sessionId: id,
+    token: registration.token,
+    dispose: () => {
+      if (ccProxySessionTokens.get(id) === registration) ccProxySessionTokens.delete(id);
+    },
+  };
 }
 
 /** Internal proxy headers are only safe when this process owns the loopback hop. */
@@ -140,7 +156,8 @@ export function isAnthropicCompatProxyReady(): boolean {
 
 function authenticateClaudeProxySession(sessionId: string | null, token: string | null): string | null {
   if (!sessionId || !token) return null;
-  const expected = ccProxySessionTokens.get(sessionId);
+  const registration = ccProxySessionTokens.get(sessionId);
+  const expected = registration?.token;
   if (!expected || expected.length !== token.length) return null;
   return timingSafeEqual(Buffer.from(expected), Buffer.from(token)) ? sessionId : null;
 }
@@ -550,15 +567,11 @@ export function createModelRoutingTransform(): RoutingTransform {
       headerValue(ctx.headers, 'x-cindy-pi-session-id') !== null
       || headerValue(ctx.headers, 'x-cindy-pi-session-token') !== null
       || headerValue(ctx.headers, 'x-cindy-pi-provider-id') !== null;
-    const hasInternalCcHeader =
-      headerValue(ctx.headers, CC_PROXY_SESSION_ID_HEADER) !== null
-      || headerValue(ctx.headers, CC_PROXY_SESSION_TOKEN_HEADER) !== null;
-    if (!hasInternalPiHeader && !hasInternalCcHeader) return decision;
+    if (!hasInternalPiHeader) return decision;
     const internalHeadersToDelete = [
       ...(hasInternalPiHeader
         ? ['x-cindy-pi-session-id', 'x-cindy-pi-session-token', 'x-cindy-pi-provider-id']
         : []),
-      ...(hasInternalCcHeader ? CC_PROXY_INTERNAL_HEADERS : []),
     ];
     const stripInternalHeaders = (
       resolved: RoutingDecision | null,
@@ -598,6 +611,10 @@ export async function ensureAnthropicCompatProxyReady(): Promise<void> {
       // 'oauth' 模式按 model 分流(claude-* → api.anthropic.com 走订阅;其余 → gateway 换 key)。
       // 'gateway' 模式恒返 null,字节级行为与扩展前一致。
       routingTransform: createModelRoutingTransform(),
+      // These attestations are meaningful only on the loopback hop. Keeping
+      // stripping in the proxy forwarding layer covers multipart/non-JSON
+      // requests, which intentionally bypass body routing transforms.
+      forwardHeaderDelete: CC_PROXY_INTERNAL_HEADERS,
       // 只读响应观察器(组合三个,互不感知):
       //   - fast mode 链路核验:tee SSE 抽上游 usage.speed(debug-gated);
       //   - 订阅余量旁路:读 anthropic-ratelimit-unified-* headers(仅订阅直连响应,

--- a/apps/desktop/src/main/maker-host/anthropic-compat-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/anthropic-compat-proxy-host.ts
@@ -41,6 +41,7 @@ import {
   type RoutingDecision,
   type RoutingTransform,
 } from '@cindy/anthropic-compat-proxy';
+import { randomBytes, timingSafeEqual } from 'node:crypto';
 import { buildVisionBridgeProxyTransform } from '../vision-bridge/vision-bridge-controller.js';
 
 import { ANTHROPIC_DIRECT_UPSTREAM, CLAUDE_PROVIDER_AUTH_PLACEHOLDER_KEY, anthropicCatalogModelIds, isAnthropicWireModel } from './claude-gateway-config.js';
@@ -114,6 +115,35 @@ const log = createMakerLogger('cc-proxy');
 
 let _handle: ProxyHandle | null = null;
 let _initialized = false;
+
+const CC_PROXY_SESSION_ID_HEADER = 'x-cindy-cc-session-id';
+const CC_PROXY_SESSION_TOKEN_HEADER = 'x-cindy-cc-session-token';
+const CC_PROXY_INTERNAL_HEADERS = [CC_PROXY_SESSION_ID_HEADER, CC_PROXY_SESSION_TOKEN_HEADER];
+const ccProxySessionTokens = new Map<string, string>();
+
+/** Mint the per-process proof that lets a fresh CC request select its Cindy session route. */
+export function getClaudeProxySessionAuth(sessionId: string): { sessionId: string; token: string } | null {
+  const id = sessionId.trim();
+  if (!id) return null;
+  let token = ccProxySessionTokens.get(id);
+  if (!token) {
+    token = randomBytes(32).toString('base64url');
+    ccProxySessionTokens.set(id, token);
+  }
+  return { sessionId: id, token };
+}
+
+/** Internal proxy headers are only safe when this process owns the loopback hop. */
+export function isAnthropicCompatProxyReady(): boolean {
+  return _handle !== null;
+}
+
+function authenticateClaudeProxySession(sessionId: string | null, token: string | null): string | null {
+  if (!sessionId || !token) return null;
+  const expected = ccProxySessionTokens.get(sessionId);
+  if (!expected || expected.length !== token.length) return null;
+  return timingSafeEqual(Buffer.from(expected), Buffer.from(token)) ? sessionId : null;
+}
 
 // gateway api key reader —— 由 host 注入(readClaudeApiKey),避免 proxy-host 直接 import
 // auth-adapters(重模块)。oauth-spawn 下走网关的请求(默认 / 选 XD)要把鉴权头换成它。
@@ -317,11 +347,25 @@ export function createModelRoutingTransform(): RoutingTransform {
     // 都记一笔活动时刻。routingTransform 会处理无 body 控制面请求与 JSON 请求；
     // 非 JSON 的 POST/PUT/PATCH 不经过这里,由响应侧 observer 兜底观察活动。
     // 开销 = 一次 header 读 + 一次活跃会话表反解 + Map.set,非 per-token 路径。
+    const claimedCcSessionId = headerValue(ctx.headers, CC_PROXY_SESSION_ID_HEADER);
+    const claimedCcSessionToken = headerValue(ctx.headers, CC_PROXY_SESSION_TOKEN_HEADER);
+    const authenticatedCcSessionId = authenticateClaudeProxySession(
+      claimedCcSessionId,
+      claimedCcSessionToken,
+    );
+    if ((claimedCcSessionId !== null || claimedCcSessionToken !== null) && !authenticatedCcSessionId) {
+      return {
+        localHandler: async ({ res }) => {
+          res.writeHead(401, { 'content-type': 'application/json; charset=utf-8', 'cache-control': 'no-store' });
+          res.end(JSON.stringify({ type: 'error', error: { type: 'authentication_error', code: 'invalid_cc_session_token', message: 'Invalid Claude Code proxy session token.' } }));
+        },
+      };
+    }
     const sdkSessionId = ctx.headers['x-claude-code-session-id'];
     const ccSessionId = sdkSessionId && _resolveCcSessionId
       ? _resolveCcSessionId(sdkSessionId)
       : null;
-    const sessionId = piSessionId ?? ccSessionId;
+    const sessionId = piSessionId ?? authenticatedCcSessionId ?? ccSessionId;
     if (sdkSessionId) {
       recordClaudeApiActivity(
         sdkSessionId,
@@ -506,8 +550,17 @@ export function createModelRoutingTransform(): RoutingTransform {
       headerValue(ctx.headers, 'x-cindy-pi-session-id') !== null
       || headerValue(ctx.headers, 'x-cindy-pi-session-token') !== null
       || headerValue(ctx.headers, 'x-cindy-pi-provider-id') !== null;
-    if (!hasInternalPiHeader) return decision;
-    const stripInternalPiHeaders = (
+    const hasInternalCcHeader =
+      headerValue(ctx.headers, CC_PROXY_SESSION_ID_HEADER) !== null
+      || headerValue(ctx.headers, CC_PROXY_SESSION_TOKEN_HEADER) !== null;
+    if (!hasInternalPiHeader && !hasInternalCcHeader) return decision;
+    const internalHeadersToDelete = [
+      ...(hasInternalPiHeader
+        ? ['x-cindy-pi-session-id', 'x-cindy-pi-session-token', 'x-cindy-pi-provider-id']
+        : []),
+      ...(hasInternalCcHeader ? CC_PROXY_INTERNAL_HEADERS : []),
+    ];
+    const stripInternalHeaders = (
       resolved: RoutingDecision | null,
     ): RoutingDecision | null => {
       if (resolved?.localHandler) return resolved;
@@ -516,16 +569,14 @@ export function createModelRoutingTransform(): RoutingTransform {
         headerDelete: [
           ...new Set([
             ...(resolved?.headerDelete ?? []),
-            'x-cindy-pi-session-id',
-            'x-cindy-pi-session-token',
-            'x-cindy-pi-provider-id',
+            ...internalHeadersToDelete,
           ]),
         ],
       };
     };
     return decision instanceof Promise
-      ? decision.then(stripInternalPiHeaders)
-      : stripInternalPiHeaders(decision);
+      ? decision.then(stripInternalHeaders)
+      : stripInternalHeaders(decision);
   };
 }
 

--- a/apps/desktop/src/main/maker-host/index.ts
+++ b/apps/desktop/src/main/maker-host/index.ts
@@ -946,8 +946,10 @@ export function getMaker(): Maker {
       runtimeConfig: buildDesktopClaudeRuntimeConfig(getClaudeEndpoint),
       binaryPath: claudePath,
       logger: desktopMakerLogger,
-      getClaudeProxySessionAuth: (sessionId) =>
-        isAnthropicCompatProxyReady() ? getClaudeProxySessionAuth(sessionId) : null,
+      getClaudeProxySessionAuth: (sessionId, sessionInstanceId) =>
+        isAnthropicCompatProxyReady()
+          ? getClaudeProxySessionAuth(sessionId, sessionInstanceId)
+          : null,
       turnChangeCapture: {
         beforeKnownFileWrite: captureKnownFileBefore,
         noteOpaqueWrite: noteOpaqueTurnChange,

--- a/apps/desktop/src/main/maker-host/index.ts
+++ b/apps/desktop/src/main/maker-host/index.ts
@@ -129,6 +129,8 @@ import {
 } from './runtime-configs.js';
 import {
   getClaudeEndpoint,
+  getClaudeProxySessionAuth,
+  isAnthropicCompatProxyReady,
   setClaudeProxyGatewayKeyReader,
   setClaudeProxyOAuthSpawnChecker,
 } from './anthropic-compat-proxy-host.js';
@@ -944,6 +946,8 @@ export function getMaker(): Maker {
       runtimeConfig: buildDesktopClaudeRuntimeConfig(getClaudeEndpoint),
       binaryPath: claudePath,
       logger: desktopMakerLogger,
+      getClaudeProxySessionAuth: (sessionId) =>
+        isAnthropicCompatProxyReady() ? getClaudeProxySessionAuth(sessionId) : null,
       turnChangeCapture: {
         beforeKnownFileWrite: captureKnownFileBefore,
         noteOpaqueWrite: noteOpaqueTurnChange,

--- a/packages/anthropic-compat-proxy/src/server.test.ts
+++ b/packages/anthropic-compat-proxy/src/server.test.ts
@@ -833,6 +833,33 @@ async function postWithAuth(url: string, body: unknown, authorization: string): 
 }
 
 describe('anthropic-compat-proxy routingTransform', () => {
+  it('strips loopback-only headers from non-JSON forwards', async () => {
+    const upstream = await startFakeUpstream((_idx, _body, res) => {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end('{}');
+    });
+    upstreamClose = upstream.close;
+    proxy = await createAnthropicCompatProxy({
+      upstream: upstream.url,
+      transformRequest: [],
+      forwardHeaderDelete: ['x-cindy-cc-session-id', 'x-cindy-cc-session-token'],
+    });
+
+    const response = await fetch(`${proxy.url}/v1/files`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/octet-stream',
+        'x-cindy-cc-session-id': 'session-1',
+        'x-cindy-cc-session-token': 'secret',
+      },
+      body: 'raw-upload',
+    });
+
+    expect(response.status).toBe(200);
+    expect(upstream.headers.at(-1)?.['x-cindy-cc-session-id']).toBeUndefined();
+    expect(upstream.headers.at(-1)?.['x-cindy-cc-session-token']).toBeUndefined();
+  });
+
   it('routes an explicit upstream override without resolving an unavailable default upstream', async () => {
     const custom = await startFakeUpstream((_i, _b, res) => {
       res.writeHead(200, { 'content-type': 'application/json' });

--- a/packages/anthropic-compat-proxy/src/server.ts
+++ b/packages/anthropic-compat-proxy/src/server.ts
@@ -1532,7 +1532,10 @@ export async function createAnthropicCompatProxy(opts: ProxyOptions): Promise<Pr
       target,
       overrideTarget,
       headerOverride: decision?.headerOverride,
-      headerDelete: decision?.headerDelete,
+      headerDelete: [
+        ...(opts.forwardHeaderDelete ?? []),
+        ...(decision?.headerDelete ?? []),
+      ],
       pathOverride,
     };
   };
@@ -2047,13 +2050,18 @@ export async function createAnthropicCompatProxy(opts: ProxyOptions): Promise<Pr
       // transfer-encoding …), 对普通转发是对的 —— 但 **WebSocket 握手必须带
       // `Connection: Upgrade`**(RFC 6455), 缺了上游不会回 101。所以这里显式补回
       // 握手必需的两个头; Sec-WebSocket-* 不属于 hop-by-hop, 已在 headers 里。
+      const upstreamHeaders = { ...headers };
+      const forwardHeaderDelete = new Set((opts.forwardHeaderDelete ?? []).map((header) => header.toLowerCase()));
+      for (const header of Object.keys(upstreamHeaders)) {
+        if (forwardHeaderDelete.has(header.toLowerCase())) delete upstreamHeaders[header];
+      }
       const upstreamReq = reqFn({
         hostname: target.hostname,
         port: target.port,
         method: req.method ?? 'GET',
         path: upstreamPath,
         headers: {
-          ...headers,
+          ...upstreamHeaders,
           host: formatHostHeader(target.hostname, target.port, target.protocol),
           connection: 'Upgrade',
           upgrade: 'websocket',

--- a/packages/anthropic-compat-proxy/src/types.ts
+++ b/packages/anthropic-compat-proxy/src/types.ts
@@ -230,6 +230,13 @@ export interface ProxyOptions {
    */
   routingTransform?: RoutingTransform;
   /**
+   * Always remove these headers before forwarding to an upstream, including
+   * non-JSON requests that do not run `routingTransform`. Header matching is
+   * case-insensitive. Use this for loopback-only control headers that must
+   * never leave the local proxy process.
+   */
+  forwardHeaderDelete?: readonly string[];
+  /**
    * 可选响应观察器。默认关闭;开启后只能 tee 响应 chunk 做轻量 metadata 解析,
    * 不能改写响应或阻塞流式 pipe。
    */

--- a/packages/maker-core/src/agents/base-agent.ts
+++ b/packages/maker-core/src/agents/base-agent.ts
@@ -476,6 +476,12 @@ export interface PiExtensionUiStrings {
 }
 
 export interface AgentDeps {
+  /**
+   * Attests a local Claude Code session to the Desktop loopback proxy before
+   * the SDK has emitted its own session id. The token is host-owned and never
+   * reaches an upstream provider.
+   */
+  getClaudeProxySessionAuth?: (sessionId: string) => { sessionId: string; token: string } | null;
   /** Optional low-I/O, provider-neutral turn change recorder supplied by the host. */
   turnChangeCapture?: TurnChangeCaptureHooks;
   auth: AuthAdapter;

--- a/packages/maker-core/src/agents/base-agent.ts
+++ b/packages/maker-core/src/agents/base-agent.ts
@@ -481,7 +481,10 @@ export interface AgentDeps {
    * the SDK has emitted its own session id. The token is host-owned and never
    * reaches an upstream provider.
    */
-  getClaudeProxySessionAuth?: (sessionId: string) => { sessionId: string; token: string } | null;
+  getClaudeProxySessionAuth?: (
+    sessionId: string,
+    sessionInstanceId?: string,
+  ) => { sessionId: string; token: string; dispose: () => void } | null;
   /** Optional low-I/O, provider-neutral turn change recorder supplied by the host. */
   turnChangeCapture?: TurnChangeCaptureHooks;
   auth: AuthAdapter;

--- a/packages/maker-core/src/agents/claude-code/__tests__/env-builder.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/env-builder.test.ts
@@ -73,6 +73,23 @@ describe('buildClaudeEnv', () => {
     expect(env.ANTHROPIC_API_KEY).toBe('key');
   });
 
+  it('appends host-managed proxy headers after auth headers without allowing duplicates', async () => {
+    const env = await buildClaudeEnv(
+      createAuthAdapter({ ANTHROPIC_CUSTOM_HEADERS: 'x-tenant: acme\nx-cindy-cc-session-id: stale' }),
+      {},
+      {
+        proxyHeaders: {
+          'x-cindy-cc-session-id': 'session-1',
+          'x-cindy-cc-session-token': 'token-1',
+        },
+      },
+    );
+
+    expect(env.ANTHROPIC_CUSTOM_HEADERS).toBe(
+      'x-tenant: acme\nx-cindy-cc-session-id: session-1\nx-cindy-cc-session-token: token-1',
+    );
+  });
+
   it('evaluates function-form behaviorFlags with the spawn route context', async () => {
     const behaviorFlags = vi.fn(() => ({ CLAUDE_CODE_ATTRIBUTION_HEADER: '0' }));
 

--- a/packages/maker-core/src/agents/claude-code/__tests__/forward-loop-crash-teardown.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/forward-loop-crash-teardown.test.ts
@@ -212,6 +212,32 @@ afterEach(async () => {
 });
 
 describe('ClaudeCodeAgent forward loop crash teardown', () => {
+  it('revokes proxy auth when query construction fails before a handle is returned', async () => {
+    const configDir = await makeTempDir();
+    process.env.CLAUDE_CONFIG_DIR = configDir;
+    const workingDir = await makeTempDir();
+    const disposeProxySession = vi.fn();
+    sdkMock.query.mockImplementation(() => {
+      throw new Error('query startup failed');
+    });
+    const agent = new ClaudeCodeAgent(createDeps({
+      getClaudeProxySessionAuth: () => ({
+        sessionId: 'session-startup-failure',
+        token: 'proxy-token',
+        dispose: disposeProxySession,
+      }),
+    }));
+
+    await expect(agent.startSession({
+      sessionId: 'session-startup-failure',
+      model: 'claude-opus-4-6',
+      workingDir,
+      permissionMode: 'acceptEdits',
+    })).rejects.toThrow('query startup failed');
+
+    expect(disposeProxySession).toHaveBeenCalledTimes(1);
+  });
+
   it('mid-turn stream crash tears the handle down with a full failure tail', async () => {
     const disposeProxySession = vi.fn();
     const { handle, stream, events, collected } = await startCrashableSession({

--- a/packages/maker-core/src/agents/claude-code/__tests__/forward-loop-crash-teardown.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/forward-loop-crash-teardown.test.ts
@@ -55,7 +55,7 @@ function createNoopLogger(): Logger {
   return logger;
 }
 
-function createDeps(): AgentDeps {
+function createDeps(overrides: Partial<AgentDeps> = {}): AgentDeps {
   const auth: AuthAdapter = {
     async getState() {
       return { authenticated: true };
@@ -74,6 +74,7 @@ function createDeps(): AgentDeps {
     runtimeConfig: {},
     binaryPath: process.execPath,
     logger: createNoopLogger(),
+    ...overrides,
   };
 }
 
@@ -147,7 +148,7 @@ async function makeTempDir(): Promise<string> {
   return dir;
 }
 
-async function startCrashableSession() {
+async function startCrashableSession(depOverrides: Partial<AgentDeps> = {}) {
   const configDir = await makeTempDir();
   process.env.CLAUDE_CONFIG_DIR = configDir;
   const workingDir = await makeTempDir();
@@ -170,7 +171,7 @@ async function startCrashableSession() {
     return fakeQuery;
   });
 
-  const agent = new ClaudeCodeAgent(createDeps());
+  const agent = new ClaudeCodeAgent(createDeps(depOverrides));
   const handle = await agent.startSession({
     sessionId: 'session-crash',
     model: 'claude-opus-4-6',
@@ -212,7 +213,14 @@ afterEach(async () => {
 
 describe('ClaudeCodeAgent forward loop crash teardown', () => {
   it('mid-turn stream crash tears the handle down with a full failure tail', async () => {
-    const { handle, stream, events, collected } = await startCrashableSession();
+    const disposeProxySession = vi.fn();
+    const { handle, stream, events, collected } = await startCrashableSession({
+      getClaudeProxySessionAuth: () => ({
+        sessionId: 'session-crash',
+        token: 'proxy-token',
+        dispose: disposeProxySession,
+      }),
+    });
 
     await handle.send({ type: 'user', content: 'hello' });
     expect(handle.isTurnRunning?.()).toBe(true);
@@ -239,6 +247,7 @@ describe('ClaudeCodeAgent forward loop crash teardown', () => {
 
     // handle 死透: turn 不再 in-flight, 后续 send 立刻失败而不是进黑洞排队。
     expect(handle.isTurnRunning?.()).toBe(false);
+    expect(disposeProxySession).toHaveBeenCalledTimes(1);
     await expect(handle.send({ type: 'user', content: 'are you there?' })).rejects.toThrow(
       /input queue is closed/i,
     );

--- a/packages/maker-core/src/agents/claude-code/env-builder.ts
+++ b/packages/maker-core/src/agents/claude-code/env-builder.ts
@@ -21,6 +21,8 @@ interface ModelContextWindowSource {
 }
 
 interface ClaudeEnvBuildOptions {
+  /** Host-managed headers for the local loopback proxy. They are not forwarded upstream. */
+  proxyHeaders?: Readonly<Record<string, string>>;
   /**
    * Host-provided model context windows for provider-routed models.
    *
@@ -52,6 +54,23 @@ interface ClaudeEnvBuildOptions {
    *     subagentModelForRoute 时按 sessionProviderId/credentialMode 走路由感知入口)。
    */
   subagentModel?: string | null;
+}
+
+function appendProxyHeaders(env: Record<string, string>, headers: Readonly<Record<string, string>> | undefined): void {
+  if (!headers || Object.keys(headers).length === 0) return;
+  const managedNames = new Set(Object.keys(headers).map((name) => name.toLowerCase()));
+  const existing = (env.ANTHROPIC_CUSTOM_HEADERS ?? '')
+    .split('\n')
+    .filter((line) => {
+      const separator = line.indexOf(':');
+      return separator < 0 || !managedNames.has(line.slice(0, separator).trim().toLowerCase());
+    })
+    .filter(Boolean);
+  for (const [name, value] of Object.entries(headers)) {
+    if (!/^[A-Za-z0-9-]+$/.test(name) || /[\r\n]/.test(value)) continue;
+    existing.push(`${name}: ${value}`);
+  }
+  if (existing.length > 0) env.ANTHROPIC_CUSTOM_HEADERS = existing.join('\n');
 }
 
 function serializeModelContextWindows(
@@ -322,6 +341,7 @@ export async function buildClaudeEnv(
     delete authEnv.CLAUDE_CONFIG_DIR;
   }
   Object.assign(env, authEnv);
+  appendProxyHeaders(env, options.proxyHeaders);
 
   // Claude Code's documented child-agent model override.
   //

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -1091,6 +1091,7 @@ export class ClaudeCodeAgent extends BaseAgent {
       ? this.deps.getClaudeProxySessionAuth?.(opts.sessionId, opts.sessionInstanceId) ?? null
       : null;
 
+    try {
     // 箭头别名捕获 this —— 下方 replayRuntimeDrift(普通 function)与 handle 对象
     // 字面量方法里没有类实例 this,统一经它取 wire 串。
     const sdkModelFor = (model: string): string => this.sdkModelFor(model);
@@ -1102,26 +1103,20 @@ export class ClaudeCodeAgent extends BaseAgent {
     const providerRoutedModels = this.capabilities.availableModels.filter((model) =>
       isProviderRoutedModel(model.id),
     );
-    let env: Record<string, string>;
-    try {
-      env = await buildClaudeEnv(this.deps.auth, this.deps.runtimeConfig, {
-        credentialMode,
-        sessionProviderId: opts.providerId ?? null,
-        proxyHeaders: proxySessionAuth
-          ? {
-              'x-cindy-cc-session-id': proxySessionAuth.sessionId,
-              'x-cindy-cc-session-token': proxySessionAuth.token,
-            }
-          : undefined,
-        modelContextWindows: providerRoutedModels,
-        // 先按「不设」建好 env(顺带删掉可能从 process.env 继承来的残留),真正的判定在下面
-        // 拿到这份 env 之后做 —— 扫描需要 env 里的 CLAUDE_CONFIG_DIR 才能找对目录。
-        subagentModel: null,
-      });
-    } catch (error) {
-      proxySessionAuth?.dispose();
-      throw error;
-    }
+    const env = await buildClaudeEnv(this.deps.auth, this.deps.runtimeConfig, {
+      credentialMode,
+      sessionProviderId: opts.providerId ?? null,
+      proxyHeaders: proxySessionAuth
+        ? {
+            'x-cindy-cc-session-id': proxySessionAuth.sessionId,
+            'x-cindy-cc-session-token': proxySessionAuth.token,
+          }
+        : undefined,
+      modelContextWindows: providerRoutedModels,
+      // 先按「不设」建好 env(顺带删掉可能从 process.env 继承来的残留),真正的判定在下面
+      // 拿到这份 env 之后做 —— 扫描需要 env 里的 CLAUDE_CONFIG_DIR 才能找对目录。
+      subagentModel: null,
+    });
 
     // 「Subagent 模型」设置的默认值语义(见 subagent-model-default.ts):
     // 平台的 CLAUDE_CODE_SUBAGENT_MODEL 是最高优先级**强制覆盖**,会静默盖掉用户手写
@@ -6526,6 +6521,11 @@ export class ClaudeCodeAgent extends BaseAgent {
     };
 
     return handle;
+    } catch (error) {
+      // No handle escapes a failed startup, so this is its only lifecycle owner.
+      proxySessionAuth?.dispose();
+      throw error;
+    }
   }
 
   // ── Memory 实现 ────────────────────────────────────────────────────────

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -1087,6 +1087,9 @@ export class ClaudeCodeAgent extends BaseAgent {
       credentialMode,
       authState.authSource,
     );
+    const proxySessionAuth = !opts.remoteHostId && opts.sessionId
+      ? this.deps.getClaudeProxySessionAuth?.(opts.sessionId) ?? null
+      : null;
 
     // 箭头别名捕获 this —— 下方 replayRuntimeDrift(普通 function)与 handle 对象
     // 字面量方法里没有类实例 this,统一经它取 wire 串。
@@ -1102,6 +1105,12 @@ export class ClaudeCodeAgent extends BaseAgent {
     const env = await buildClaudeEnv(this.deps.auth, this.deps.runtimeConfig, {
       credentialMode,
       sessionProviderId: opts.providerId ?? null,
+      proxyHeaders: proxySessionAuth
+        ? {
+            'x-cindy-cc-session-id': proxySessionAuth.sessionId,
+            'x-cindy-cc-session-token': proxySessionAuth.token,
+          }
+        : undefined,
       modelContextWindows: providerRoutedModels,
       // 先按「不设」建好 env(顺带删掉可能从 process.env 继承来的残留),真正的判定在下面
       // 拿到这份 env 之后做 —— 扫描需要 env 里的 CLAUDE_CONFIG_DIR 才能找对目录。

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -1088,7 +1088,7 @@ export class ClaudeCodeAgent extends BaseAgent {
       authState.authSource,
     );
     const proxySessionAuth = !opts.remoteHostId && opts.sessionId
-      ? this.deps.getClaudeProxySessionAuth?.(opts.sessionId) ?? null
+      ? this.deps.getClaudeProxySessionAuth?.(opts.sessionId, opts.sessionInstanceId) ?? null
       : null;
 
     // 箭头别名捕获 this —— 下方 replayRuntimeDrift(普通 function)与 handle 对象
@@ -1102,20 +1102,26 @@ export class ClaudeCodeAgent extends BaseAgent {
     const providerRoutedModels = this.capabilities.availableModels.filter((model) =>
       isProviderRoutedModel(model.id),
     );
-    const env = await buildClaudeEnv(this.deps.auth, this.deps.runtimeConfig, {
-      credentialMode,
-      sessionProviderId: opts.providerId ?? null,
-      proxyHeaders: proxySessionAuth
-        ? {
-            'x-cindy-cc-session-id': proxySessionAuth.sessionId,
-            'x-cindy-cc-session-token': proxySessionAuth.token,
-          }
-        : undefined,
-      modelContextWindows: providerRoutedModels,
-      // 先按「不设」建好 env(顺带删掉可能从 process.env 继承来的残留),真正的判定在下面
-      // 拿到这份 env 之后做 —— 扫描需要 env 里的 CLAUDE_CONFIG_DIR 才能找对目录。
-      subagentModel: null,
-    });
+    let env: NodeJS.ProcessEnv;
+    try {
+      env = await buildClaudeEnv(this.deps.auth, this.deps.runtimeConfig, {
+        credentialMode,
+        sessionProviderId: opts.providerId ?? null,
+        proxyHeaders: proxySessionAuth
+          ? {
+              'x-cindy-cc-session-id': proxySessionAuth.sessionId,
+              'x-cindy-cc-session-token': proxySessionAuth.token,
+            }
+          : undefined,
+        modelContextWindows: providerRoutedModels,
+        // 先按「不设」建好 env(顺带删掉可能从 process.env 继承来的残留),真正的判定在下面
+        // 拿到这份 env 之后做 —— 扫描需要 env 里的 CLAUDE_CONFIG_DIR 才能找对目录。
+        subagentModel: null,
+      });
+    } catch (error) {
+      proxySessionAuth?.dispose();
+      throw error;
+    }
 
     // 「Subagent 模型」设置的默认值语义(见 subagent-model-default.ts):
     // 平台的 CLAUDE_CODE_SUBAGENT_MODEL 是最高优先级**强制覆盖**,会静默盖掉用户手写
@@ -6000,6 +6006,7 @@ export class ClaudeCodeAgent extends BaseAgent {
         turnInFlight = false;
         clearBridgeState();
         closed = true;
+        proxySessionAuth?.dispose();
         try {
           // 任何挂着的 interaction 强制 deny + emit dismissed, 防止 host 卡住等永远不会来的回应
           dismissAllPending('session_closed', 'deny');

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -1102,7 +1102,7 @@ export class ClaudeCodeAgent extends BaseAgent {
     const providerRoutedModels = this.capabilities.availableModels.filter((model) =>
       isProviderRoutedModel(model.id),
     );
-    let env: NodeJS.ProcessEnv;
+    let env: Record<string, string>;
     try {
       env = await buildClaudeEnv(this.deps.auth, this.deps.runtimeConfig, {
         credentialMode,
@@ -3493,6 +3493,7 @@ export class ClaudeCodeAgent extends BaseAgent {
       runningBackgroundTasks.clear();
       terminalBackgroundTaskIds.clear();
       closed = true;
+      proxySessionAuth?.dispose();
       try { dismissAllPending('session_closed', 'deny'); } catch (e) {
         log.warn(`${logLabel}: dismissAllPending threw`, { error: String(e) });
       }


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Claude Code 新会话首个 turn 尚未产生 SDK session id 时，显式选择的自定义 OAuth 供应商可能回落到 XD 网关的问题。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：#3279
- 本 PR 包含：为本地 Claude Code 会话注入主进程签发的短期路由证明；代理验证该证明后直接使用 Cindy session 的 provider 路由；所有请求在出站前移除内部 headers。
- 明确不包含：OAuth 刷新策略、标题 one-shot 路由及远端 Claude Code 会话。
- 用户可见变化：自定义 OAuth 供应商的首个 Claude Code turn 不再错误发送到 XD。
- 是否存在 breaking change：无。

### UI 变化

- 引用的设计规范：不涉及：仅修改 Desktop main、代理和 Agent 环境组装，没有 UI 变化。

## 怎么验证的

### 自动验证

```text
pnpm --filter @cindy/maker-core exec vitest run src/agents/claude-code/__tests__/env-builder.test.ts
结果：34 passed

pnpm --filter desktop exec vitest run src/main/maker-host/__tests__/claudeSessionRouteObservation.test.ts
结果：10 passed

pnpm --filter desktop typecheck
结果：passed

pnpm test:unit:related
结果：passed

pnpm check:dco
结果：passed
```

### 手工验证

不涉及：需要真实 Kimi OAuth 的 Windows 环境，已用代理路由回归覆盖首轮无 SDK id 的时序。

### 未执行的验证

Windows + Kimi Code OAuth 真实请求未执行；该环境需要用户账号与系统代理。

## 风险

### 风险分类

- [x] 权限 / 安全 / 用户数据
- [x] 跨平台差异

### 影响与回滚

- 影响范围：本地 Claude Code 会话请求的内部路由 header；仅当本地兼容代理已就绪才注入，且代理在转发前剥离。
- 回滚 / 降级方式：回滚本 PR 后恢复原有 SDK session id 反查路径；代理不可用时本 PR 保持既有直连降级，不注入 header。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因