### PR TITLE
fix(desktop): 自动任务失败红点可处理，系统中止不再粘红

### DIFF
--- a/apps/desktop/src/main/__tests__/interruptedContinuationContract.test.ts
+++ b/apps/desktop/src/main/__tests__/interruptedContinuationContract.test.ts
@@ -298,11 +298,12 @@ describe('interrupted continuation enqueue contract', () => {
     expect(sessionViewSource).toMatch(
       /if \(syntheticContinuationPending && sessionInterruptAcked\) \{\s*setSessionInterruptAcked\(false\);\s*\}/,
     );
-    // 恰好两处消费点(error-tail banner 与 interrupted banner 的互斥渲染条件),
-    // 多一处就要回来审视是否绕过了「抑制交给排队/在飞状态」这条契约。
+    // 恰好三处消费点(error-tail / interrupted / unread-failed-schedule banner
+    // 的互斥渲染条件),多一处就要回来审视是否绕过了「抑制交给排队/在飞状态」
+    // 这条契约。
     // 注:PR #879 加的「挂起状态落回 false 的边沿 → 重算告警红点」effect 走的是
     // 早退写法(`if (!was || syntheticContinuationPending) return;`),不消费这个
     // 否定形式,故计数不变。
-    expect(matchIndexes(sessionViewSource, /!syntheticContinuationPending/)).toHaveLength(2);
+    expect(matchIndexes(sessionViewSource, /!syntheticContinuationPending/)).toHaveLength(3);
   });
 });

--- a/apps/desktop/src/main/scheduler-host/storage.ts
+++ b/apps/desktop/src/main/scheduler-host/storage.ts
@@ -54,6 +54,7 @@ export interface ScheduleSidebarIndexRun {
   sessionId?: string;
   status: ScheduleRun['status'];
   readAt?: number;
+  firedAt?: number;
 }
 
 export interface ScheduleCostSummary {
@@ -600,6 +601,7 @@ export class DrizzleScheduleStorage implements ScheduleStorage {
         sessionId: scheduleRuns.sessionId,
         status: scheduleRuns.status,
         readAt: scheduleRuns.readAt,
+        firedAt: scheduleRuns.firedAt,
       })
       .from(scheduleRuns)
       .innerJoin(schedules, eq(scheduleRuns.scheduleId, schedules.id))
@@ -625,6 +627,7 @@ export class DrizzleScheduleStorage implements ScheduleStorage {
       sessionId: row.sessionId ?? undefined,
       status: row.status,
       readAt: row.readAt ?? undefined,
+      firedAt: row.firedAt ?? undefined,
     }));
 
     const linkedSessionIds = new Set(

--- a/apps/desktop/src/renderer/__tests__/automationGeneratedSessions.test.ts
+++ b/apps/desktop/src/renderer/__tests__/automationGeneratedSessions.test.ts
@@ -1180,6 +1180,10 @@ describe('automation-generated sessions', () => {
     expect(sidebarSource).toContain('knownSessionIds: group.sessions.map((session) => session.id)');
     expect(sidebarSource).toContain("if (action === 'mark-read')");
     expect(sidebarSource).toContain('unreadSuccessScheduleRunIds(info)');
+    expect(sidebarSource).toContain("t('ccAgent.layout.markedAsRead', { count: processed.length })");
+    expect(sidebarSource).not.toContain(
+      "t('ccAgent.layout.markedAsRead', { count: unreadRunIds.length })",
+    );
     expect(schedulerPageSource).toContain('getFocusedScheduleStatusFilter(schedules, focusId)');
     expect(schedulerPageSource).toContain('setEditing(focused)');
     expect(schedulerPageSource).toContain('setFormOpen(true)');

--- a/apps/desktop/src/renderer/__tests__/automationGeneratedSessions.test.ts
+++ b/apps/desktop/src/renderer/__tests__/automationGeneratedSessions.test.ts
@@ -26,6 +26,7 @@ import {
   getAutomationGroupPrimarySession,
   getVisibleAutomationGroupSessions,
   groupAutomationSidebarEntries,
+  unreadSuccessScheduleRunIds,
   type AutomationScheduleSessionInfo,
 } from '@/features/cc-agent/lib/automationSidebarGrouping';
 import { groupSessions } from '@/features/cc-agent/lib/projectGrouping';
@@ -36,7 +37,10 @@ import {
   isScheduledSession,
 } from '@/features/cc-agent/lib/scheduledSessionGrouping';
 import { getFocusedScheduleStatusFilter } from '@/features/scheduler/SchedulerPage';
-import { isUnreadScheduleRun } from '@/features/scheduler/lib/runUnread';
+import {
+  isUnreadFailedScheduleRun,
+  isUnreadScheduleRun,
+} from '@/features/scheduler/lib/runUnread';
 import { formatUsd } from '@/features/scheduler/lib/formatters';
 
 // Windows checkout(core.autocrlf)下源码是 CRLF;统一归一成 LF,含 \n 的多行片段断言才跨平台成立。
@@ -90,6 +94,7 @@ const makeScheduleSessionInfo = (
   scheduleId: 'sched-1',
   scheduleName: 'Schedule',
   unreadRunIds: [],
+  unreadFailedRunIds: [],
   hasUnreadRun: false,
   hasUnreadFailedRun: false,
   ...partial,
@@ -493,8 +498,40 @@ describe('automation-generated sessions', () => {
   it('keeps schedule run unread semantics shared with the run history badge', () => {
     expect(isUnreadScheduleRun({ status: 'success', readAt: undefined })).toBe(true);
     expect(isUnreadScheduleRun({ status: 'failed', readAt: undefined })).toBe(true);
+    expect(isUnreadScheduleRun({ status: 'interrupted', readAt: undefined })).toBe(true);
+    expect(isUnreadScheduleRun({ status: 'aborted', readAt: undefined })).toBe(false);
     expect(isUnreadScheduleRun({ status: 'running', readAt: undefined })).toBe(false);
     expect(isUnreadScheduleRun({ status: 'success', readAt: 1 })).toBe(false);
+    expect(isUnreadFailedScheduleRun({ status: 'failed', readAt: undefined })).toBe(true);
+    expect(isUnreadFailedScheduleRun({ status: 'interrupted', readAt: undefined })).toBe(true);
+    expect(isUnreadFailedScheduleRun({ status: 'aborted', readAt: undefined })).toBe(false);
+    expect(isUnreadFailedScheduleRun({ status: 'success', readAt: undefined })).toBe(false);
+    expect(
+      unreadSuccessScheduleRunIds({
+        unreadRunIds: ['ok', 'bad'],
+        unreadFailedRunIds: ['bad'],
+      }),
+    ).toEqual(['ok']);
+  });
+
+  it('surfaces unread failed schedule runs as an in-session mark-as-read banner', () => {
+    const sessionViewSource = readTextLf(
+      new URL('../features/cc-agent/CCAgentSessionView.tsx', import.meta.url),
+      'utf8',
+    );
+    const bannerSource = readTextLf(
+      new URL('../components/chat/InterruptedTurnBanner.tsx', import.meta.url),
+      'utf8',
+    );
+    const zh = JSON.parse(
+      readTextLf(new URL('../i18n/locales/zh-CN/common.json', import.meta.url), 'utf8'),
+    );
+
+    expect(sessionViewSource).toContain('<UnreadFailedScheduleBanner');
+    expect(sessionViewSource).toContain('unreadFailedScheduleRunIds.length > 0');
+    expect(bannerSource).toContain("t('chat.unreadFailedScheduleBanner.text')");
+    expect(zh.chat.unreadFailedScheduleBanner.text).toBe('这次自动任务没有完成。');
+    expect(zh.chat.unreadFailedScheduleBanner.markAsRead).toBe('标为已读');
   });
 
   it('maps a focused schedule to the status bucket that can reveal it', () => {
@@ -824,24 +861,30 @@ describe('automation-generated sessions', () => {
     expect(source).toContain('{hasVisibleChildren && (');
     // 侧栏侧保留「立即运行」直点,低频的编辑 / 暂停恢复 / 删除收回 More 菜单。
     expect(source).toContain("onScheduleAction(group, 'run')");
+    expect(source).toContain('const canMarkRead = collapsedAttention.tone != null');
+    expect(source).toContain('{canMarkRead && (');
+    expect(source).toContain("onScheduleAction(group, 'mark-read')");
     expect(source).toContain("onScheduleAction(group, 'edit')");
     expect(source).toContain("onScheduleAction(group, 'toggle-pause')");
     expect(source).toContain("onScheduleAction(group, 'delete')");
     expect(source).toContain('EllipsisVertical');
     expect(source).toContain('setMenuOpen');
-    expect(source).not.toContain('handleGroupContextMenu');
+    expect(source).toContain('onContextMenu={(event) => {');
+    expect(source).toContain('setMenuOpen(true)');
     // Run / More 图标(lucide Play / EllipsisVertical)必须都在,按钮尺寸与普通会话行对齐。
     expect(source).toMatch(/<Play size=\{14\}/);
     expect(source).toMatch(/<EllipsisVertical size=\{14\}/);
     expect(source).toContain('ccAgent.sidebar.automationGroup.menu.runNow');
     expect(source).toContain('ccAgent.sidebar.automationGroup.menu.more');
+    expect(source).toContain('ccAgent.sidebar.automationGroup.menu.markAllAsRead');
     expect(source).toContain('ccAgent.sidebar.automationGroup.menu.edit');
     expect(source).toContain('ccAgent.sidebar.automationGroup.menu.pause');
     expect(source).toContain('ccAgent.sidebar.automationGroup.menu.resume');
     expect(source).toContain('ccAgent.sidebar.automationGroup.menu.delete');
     expect(source).toContain('scheduleFocusPath(group.scheduleId)');
-    // 组头点击打开组内「最新一条」运行(需求:点折叠组头打开最新 session),不再走 primary。
-    expect(source).toContain('onSessionClick(latestSession.id)');
+    // 组头点击:展开打开最新一条;收起且整组是红时打开贡献红点的那条。
+    expect(source).toContain('resolveCollapsedGroupHeaderSessionId({');
+    expect(source).toContain('onSessionClick(targetId)');
     expect(source).toContain('getAutomationGroupLatestSession(group)');
     expect(source).toContain('visibleSessionIds: visibleSessions.map((session) => session.id)');
     // 自动任务只是展示分组，展开后的每条运行仍须保留普通会话行的移动菜单与搜索高亮。
@@ -1135,6 +1178,8 @@ describe('automation-generated sessions', () => {
     expect(sidebarSource).toContain('useDeleteScheduleWithSessions');
     expect(sidebarSource).toContain('requestDeleteSchedule({');
     expect(sidebarSource).toContain('knownSessionIds: group.sessions.map((session) => session.id)');
+    expect(sidebarSource).toContain("if (action === 'mark-read')");
+    expect(sidebarSource).toContain('unreadSuccessScheduleRunIds(info)');
     expect(schedulerPageSource).toContain('getFocusedScheduleStatusFilter(schedules, focusId)');
     expect(schedulerPageSource).toContain('setEditing(focused)');
     expect(schedulerPageSource).toContain('setFormOpen(true)');

--- a/apps/desktop/src/renderer/__tests__/automationGeneratedSessions.test.ts
+++ b/apps/desktop/src/renderer/__tests__/automationGeneratedSessions.test.ts
@@ -531,7 +531,11 @@ describe('automation-generated sessions', () => {
     expect(sessionViewSource).toContain('unreadFailedScheduleRunIds.length > 0');
     expect(sessionViewSource).toContain('useAutomationScheduleSessionInfo(sessionId)');
     expect(sessionViewSource).not.toContain('useAutomationScheduleSessionIndex()');
-    expect(sessionViewSource).toContain('markUnreadFailedScheduleRunsRead()');
+    expect(sessionViewSource).toContain('latestUnreadFailedRunId');
+    expect(sessionViewSource).toContain('markScheduleRunsReadAndSync([currentUnreadFailedRunId])');
+    expect(sessionViewSource).not.toContain(
+      'void markScheduleRunsReadAndSync(unreadFailedScheduleRunIds)',
+    );
     expect(bannerSource).toContain("t('chat.unreadFailedScheduleBanner.text')");
     expect(zh.chat.unreadFailedScheduleBanner.text).toBe('这次定时任务没有完成。');
     expect(zh.chat.unreadFailedScheduleBanner.markAsRead).toBe('标为已读');

--- a/apps/desktop/src/renderer/__tests__/automationGeneratedSessions.test.ts
+++ b/apps/desktop/src/renderer/__tests__/automationGeneratedSessions.test.ts
@@ -530,7 +530,7 @@ describe('automation-generated sessions', () => {
     expect(sessionViewSource).toContain('<UnreadFailedScheduleBanner');
     expect(sessionViewSource).toContain('unreadFailedScheduleRunIds.length > 0');
     expect(bannerSource).toContain("t('chat.unreadFailedScheduleBanner.text')");
-    expect(zh.chat.unreadFailedScheduleBanner.text).toBe('这次自动任务没有完成。');
+    expect(zh.chat.unreadFailedScheduleBanner.text).toBe('这次定时任务没有完成。');
     expect(zh.chat.unreadFailedScheduleBanner.markAsRead).toBe('标为已读');
   });
 

--- a/apps/desktop/src/renderer/__tests__/automationGeneratedSessions.test.ts
+++ b/apps/desktop/src/renderer/__tests__/automationGeneratedSessions.test.ts
@@ -529,6 +529,9 @@ describe('automation-generated sessions', () => {
 
     expect(sessionViewSource).toContain('<UnreadFailedScheduleBanner');
     expect(sessionViewSource).toContain('unreadFailedScheduleRunIds.length > 0');
+    expect(sessionViewSource).toContain('useAutomationScheduleSessionInfo(sessionId)');
+    expect(sessionViewSource).not.toContain('useAutomationScheduleSessionIndex()');
+    expect(sessionViewSource).toContain('markUnreadFailedScheduleRunsRead()');
     expect(bannerSource).toContain("t('chat.unreadFailedScheduleBanner.text')");
     expect(zh.chat.unreadFailedScheduleBanner.text).toBe('这次定时任务没有完成。');
     expect(zh.chat.unreadFailedScheduleBanner.markAsRead).toBe('标为已读');

--- a/apps/desktop/src/renderer/__tests__/mainListModel.test.ts
+++ b/apps/desktop/src/renderer/__tests__/mainListModel.test.ts
@@ -154,6 +154,7 @@ describe('buildMainListEntries — 混排(recency)', () => {
       unreadRunIds: [],
       hasUnreadRun: false,
       hasUnreadFailedRun: false,
+      unreadFailedRunIds: [],
     };
 
     const entries = buildMainListEntries({
@@ -201,6 +202,7 @@ describe('buildMainListEntries — 混排(recency)', () => {
       unreadRunIds: [],
       hasUnreadRun: false,
       hasUnreadFailedRun: false,
+      unreadFailedRunIds: [],
     };
 
     const entries = buildMainListEntries({
@@ -254,6 +256,7 @@ describe('buildMainListEntries — 混排(recency)', () => {
       unreadRunIds: [],
       hasUnreadRun: false,
       hasUnreadFailedRun: false,
+      unreadFailedRunIds: [],
     };
 
     const entries = buildMainListEntries({
@@ -303,6 +306,7 @@ describe('buildMainListEntries — 混排(recency)', () => {
           scheduleId: 'shared-schedule-id',
           scheduleName: '远程自动检查',
           unreadRunIds: [],
+          unreadFailedRunIds: [],
           hasUnreadRun: false,
           hasUnreadFailedRun: false,
         },

--- a/apps/desktop/src/renderer/__tests__/projectCollapsedAttention.test.ts
+++ b/apps/desktop/src/renderer/__tests__/projectCollapsedAttention.test.ts
@@ -7,6 +7,7 @@ import type { AttentionKind } from '@/lib/sessionAttentionStore';
 import type { RemoteSessionActivityPhase } from '@/features/device-link/remoteSessionActivityStore';
 import {
   resolveCollapsedAttention,
+  resolveCollapsedGroupHeaderSessionId,
   resolveCollapsedGroupRightStatus,
   resolveCollapsedProjectAttentionTone,
 } from '../features/cc-agent/sidebar/projectCollapsedAttention';
@@ -235,6 +236,7 @@ describe('collapsed project attention wiring', () => {
     // 展开后哪一行都没有」。
     expect(automationGroupSource).toContain('resolveCollapsedAttention({');
     expect(automationGroupSource).toContain('resolveCollapsedGroupRightStatus({');
+    expect(automationGroupSource).toContain('resolveCollapsedGroupHeaderSessionId({');
     expect(automationGroupSource).toMatch(/tone:\s*collapsedAttention\.tone/);
     expect(automationGroupSource).toMatch(/new Set\(collapsedAttention\.errorSessionIds\)/);
     expect(automationGroupSource).toContain('alertSessionIds,');
@@ -252,6 +254,31 @@ describe('collapsed project attention wiring', () => {
     expect(automationGroupSource).toMatch(/useSessionsAttentionKindMap\(groupSessionIds\)/);
     expect(automationGroupSource).toMatch(/useSessionsAttentionUrgencyIdSet\(groupSessionIds\)/);
     expect(automationGroupSource).toMatch(/useRemoteSessionsPhaseMap\(groupSessionIds\)/);
+  });
+
+  it('opens the unread-failed session from a collapsed red group header', () => {
+    const attention = { tone: 'error' as const, errorSessionIds: ['run-old'] };
+    expect(
+      resolveCollapsedGroupHeaderSessionId({
+        collapsed: true,
+        latestSessionId: 'run-new',
+        attention,
+      }),
+    ).toBe('run-old');
+    expect(
+      resolveCollapsedGroupHeaderSessionId({
+        collapsed: false,
+        latestSessionId: 'run-new',
+        attention,
+      }),
+    ).toBe('run-new');
+    expect(
+      resolveCollapsedGroupHeaderSessionId({
+        collapsed: true,
+        latestSessionId: 'run-new',
+        attention: { tone: 'done', errorSessionIds: [] },
+      }),
+    ).toBe('run-new');
   });
 
   it('feeds both regular and pinned project rows from their displayed children', () => {

--- a/apps/desktop/src/renderer/components/chat/InterruptedTurnBanner.tsx
+++ b/apps/desktop/src/renderer/components/chat/InterruptedTurnBanner.tsx
@@ -31,7 +31,7 @@
  */
 
 import { useMemo, useState } from 'react';
-import { CirclePause, Play, X } from 'lucide-react';
+import { AlertCircle, CirclePause, Play, X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { cn } from '@/lib/utils';
 import { extractUsageLimitRecoveryHint } from '@/lib/usageLimitRecovery';
@@ -102,6 +102,49 @@ export function InterruptedTurnBanner({
         title={t('chat.interruptedBanner.dismissTitle')}
       >
         <X size={14} />
+      </button>
+    </div>
+  );
+}
+
+/** 定时任务失败/中断未读:只有「标为已读」,没有继续。继续走已有的 error/中断横幅。 */
+export function UnreadFailedScheduleBanner({
+  onDismiss,
+  className,
+  style,
+}: {
+  onDismiss: () => void;
+  className?: string;
+  style?: React.CSSProperties;
+}) {
+  const { t } = useTranslation();
+
+  return (
+    <div
+      className={cn(
+        'mx-auto flex select-none items-start gap-2 rounded-md px-3 py-2',
+        'border bg-[var(--error-bg)] border-[var(--error-border)]',
+        className,
+      )}
+      style={style}
+      data-testid="unread-failed-schedule-banner"
+      data-banner-kind="unread-failed-schedule"
+    >
+      <AlertCircle size={14} className="shrink-0 mt-[2px] text-[var(--error-fg)]" />
+      <span className="flex-1 min-w-0 text-xs break-all text-[var(--error-fg)]">
+        {t('chat.unreadFailedScheduleBanner.text')}
+      </span>
+      <button
+        type="button"
+        onClick={onDismiss}
+        className={cn(
+          'shrink-0 text-xs font-medium',
+          'text-[var(--error-fg-strong)]',
+          'hover:opacity-70 transition-opacity',
+        )}
+        title={t('chat.unreadFailedScheduleBanner.markAsReadTitle')}
+      >
+        {t('chat.unreadFailedScheduleBanner.markAsRead')}
       </button>
     </div>
   );

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
@@ -87,7 +87,10 @@ import { ErrorBanner } from '@/components/chat/ErrorBanner';
 import {
   ErrorTailErrorBanner,
   InterruptedTurnBanner,
+  UnreadFailedScheduleBanner,
 } from '@/components/chat/InterruptedTurnBanner';
+import { useAutomationScheduleSessionIndex } from './hooks/useAutomationScheduleSessionIndex';
+import { markScheduleRunsReadAndSync } from '../scheduler/lib/scheduleRunReadSync';
 import { useBackgroundBashTasks } from '@/hooks/useBackgroundBashTasks';
 import { useSessionBackgroundActivity } from '@/hooks/useSessionBackgroundActivity';
 import { workflowAgentVisualState } from '@/features/right-sidebar/plugins/background-tasks/workflowProgressModel';
@@ -578,6 +581,8 @@ function summarizeRunningWorkflow(taskUpdates: ReadonlyMap<string, AgentTaskUpda
     total: agents.length,
   };
 }
+
+const EMPTY_UNREAD_FAILED_RUN_IDS: string[] = [];
 
 export function CCAgentSessionView({
   sessionIdProp,
@@ -1777,6 +1782,15 @@ export function CCAgentSessionView({
   //     →「重试/关闭」
   // 后面有新消息 = 任务已被推进,判定自然不命中。此时消息流内不重复渲染该行
   // (MessageStream 对尾部未忽略 error 行返回 null,由本条独家承载)。
+  const scheduleSessionIndex = useAutomationScheduleSessionIndex();
+  const unreadFailedScheduleRunIds = useMemo(() => {
+    if (!sessionId) return EMPTY_UNREAD_FAILED_RUN_IDS;
+    return scheduleSessionIndex.get(sessionId)?.unreadFailedRunIds ?? EMPTY_UNREAD_FAILED_RUN_IDS;
+  }, [scheduleSessionIndex, sessionId]);
+  const handleUnreadFailedScheduleDismiss = useCallback(() => {
+    if (unreadFailedScheduleRunIds.length === 0) return;
+    void markScheduleRunsReadAndSync(unreadFailedScheduleRunIds);
+  }, [unreadFailedScheduleRunIds]);
   const errorTailMsg = useMemo(() => {
     const last = messages.length > 0 ? messages[messages.length - 1] : undefined;
     return last && last.role === 'error' && !last.errorDismissed ? last : null;
@@ -4476,6 +4490,22 @@ export function CCAgentSessionView({
                 <InterruptedTurnBanner
                   onContinue={handleSessionInterruptContinue}
                   onDismiss={handleSessionInterruptDismiss}
+                  style={{ width: inputWidth }}
+                  className="py-1"
+                />
+              )}
+
+            {!errorTailMsg &&
+              !interruptedFromSession &&
+              unreadFailedScheduleRunIds.length > 0 &&
+              !syntheticContinuationPending &&
+              !error &&
+              !credentialSwitchWait &&
+              !isStreaming &&
+              !agentStatus.isRunning &&
+              sessionId && (
+                <UnreadFailedScheduleBanner
+                  onDismiss={handleUnreadFailedScheduleDismiss}
                   style={{ width: inputWidth }}
                   className="py-1"
                 />

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
@@ -1785,13 +1785,22 @@ export function CCAgentSessionView({
   const scheduleSessionInfo = useAutomationScheduleSessionInfo(sessionId);
   const unreadFailedScheduleRunIds =
     scheduleSessionInfo?.unreadFailedRunIds ?? EMPTY_UNREAD_FAILED_RUN_IDS;
-  const markUnreadFailedScheduleRunsRead = useCallback(() => {
-    if (unreadFailedScheduleRunIds.length === 0) return;
-    void markScheduleRunsReadAndSync(unreadFailedScheduleRunIds);
-  }, [unreadFailedScheduleRunIds]);
+  const currentUnreadFailedRunId =
+    scheduleSessionInfo?.latestUnreadFailedRunId ?? unreadFailedScheduleRunIds[0];
+  const markCurrentUnreadFailedScheduleRun = useCallback(async (): Promise<boolean> => {
+    if (!currentUnreadFailedRunId) return true;
+    const { failed, firstError } = await markScheduleRunsReadAndSync([currentUnreadFailedRunId]);
+    if (failed.length === 0) return true;
+    toast.error(
+      t('ccAgent.layout.markAllReadFailed', {
+        error: firstError ?? failed[0],
+      }),
+    );
+    return false;
+  }, [currentUnreadFailedRunId, t]);
   const handleUnreadFailedScheduleDismiss = useCallback(() => {
-    markUnreadFailedScheduleRunsRead();
-  }, [markUnreadFailedScheduleRunsRead]);
+    void markCurrentUnreadFailedScheduleRun();
+  }, [markCurrentUnreadFailedScheduleRun]);
   const errorTailMsg = useMemo(() => {
     const last = messages.length > 0 ? messages[messages.length - 1] : undefined;
     return last && last.role === 'error' && !last.errorDismissed ? last : null;
@@ -1886,9 +1895,8 @@ export function CCAgentSessionView({
       // 本机会话才清:远程会话的红点靠隧道回执清被控端,而本机库里没有它的行,
       // 重算恢复不了 —— 那条腿延后到 pending 落回 false 且横幅确实消失后再 ack。
       if (!remoteDeviceId) ackErrorAlertHandled(sessionId);
-      // 中断/失败横幅优先于未读失败 schedule 横幅。用户已经处置这一次事故,
-      // 不要再立刻换成第二条「标为已读」。
-      markUnreadFailedScheduleRunsRead();
+      // 只清当前这次失败 run。整组历史仍走组菜单。
+      await markCurrentUnreadFailedScheduleRun();
     } catch (err) {
       setErrorTailBannerHiddenFor(null);
       toast.error(err instanceof Error ? err.message : String(err));
@@ -1896,30 +1904,32 @@ export function CCAgentSessionView({
   }, [
     errorTailKind,
     errorTailMsg,
-    markUnreadFailedScheduleRunsRead,
+    markCurrentUnreadFailedScheduleRun,
     rebuildClaudeSubscriptionSessionBeforeRetry,
     sessionId,
   ]);
   const handleErrorTailDismiss = useCallback(() => {
     if (!sessionId || !errorTailMsg) return;
-    // store 乐观置 errorDismissed(banner 即刻熄灭、切会话回来不复现)+ 持久化
-    // (main 侧 merge dismissed:true,不丢 sdkError 等原字段)。落库失败会回滚乐观态。
-    // 必须**等落库完成**再重算:dismiss 落库无广播,而告警查询是纯 DB 读,
-    // 抢在写入前读会仍判定告警存在 —— 横幅已熄灭、红点却卡住。
-    void makerChatStore
-      .dismissErrorTailMessage(sessionId, errorTailMsg.clientId)
-      .then((persisted) => {
-        // device-link 远程会话:dismiss 经隧道写到**被控端** DB,控制端本机库里没有
-        // 这个会话的行,派生腿查不到、也从未认领它 —— 必须显式 ack(explicit 清本机
-        // 角标 + 隧道回执清被控端未读)。删掉展示型 ack 后这是唯一的清除路径。
-        // **只在落库成功时 ack**:隧道写失败时 store 已回滚乐观态、横幅重新出现,
-        // 此时清红点会再造成「横幅在、红点没」(PR #879 review P1)。
-        // 本机会话由下面的重算收敛,不重复 ack。
-        if (persisted && remoteDeviceId) ackErrorAlertHandled(sessionId);
-        if (persisted) markUnreadFailedScheduleRunsRead();
-        return refreshPendingAlerts();
-      });
-  }, [errorTailMsg, markUnreadFailedScheduleRunsRead, remoteDeviceId, sessionId]);
+    void markCurrentUnreadFailedScheduleRun().then((marked) => {
+      if (!marked) return;
+      // store 乐观置 errorDismissed(banner 即刻熄灭、切会话回来不复现)+ 持久化
+      // (main 侧 merge dismissed:true,不丢 sdkError 等原字段)。落库失败会回滚乐观态。
+      // 必须**等落库完成**再重算:dismiss 落库无广播,而告警查询是纯 DB 读,
+      // 抢在写入前读会仍判定告警存在 —— 横幅已熄灭、红点却卡住。
+      return makerChatStore.dismissErrorTailMessage(sessionId, errorTailMsg.clientId).then(
+        (persisted) => {
+          // device-link 远程会话:dismiss 经隧道写到**被控端** DB,控制端本机库里没有
+          // 这个会话的行,派生腿查不到、也从未认领它 —— 必须显式 ack(explicit 清本机
+          // 角标 + 隧道回执清被控端未读)。删掉展示型 ack 后这是唯一的清除路径。
+          // **只在落库成功时 ack**:隧道写失败时 store 已回滚乐观态、横幅重新出现,
+          // 此时清红点会再造成「横幅在、红点没」(PR #879 review P1)。
+          // 本机会话由下面的重算收敛,不重复 ack。
+          if (persisted && remoteDeviceId) ackErrorAlertHandled(sessionId);
+          return refreshPendingAlerts();
+        },
+      );
+    });
+  }, [errorTailMsg, markCurrentUnreadFailedScheduleRun, remoteDeviceId, sessionId]);
   // interrupted-turn-resume(简化版):「疑似中断」由 session 行的双时间戳驱动
   // (startedAt > endedAt 且未被 /clear 越过,见 sessionActiveTurn.ts 文件头),
   // 不再依赖持久化中断消息行。判定是打开会话时的一次性快照:本窗口 turn 一旦
@@ -2010,31 +2020,33 @@ export function CCAgentSessionView({
       // dispatch 成功,而横幅已隐藏 —— 先临时清点保持一致,排队被取消时由 pending
       // 落回 false 的 effect 重算恢复。远程会话同样延后(见那里的说明)。
       if (!remoteDeviceId) ackErrorAlertHandled(sessionId);
-      markUnreadFailedScheduleRunsRead();
+      await markCurrentUnreadFailedScheduleRun();
     } catch (err) {
       setSessionInterruptAcked(false);
       toast.error(err instanceof Error ? err.message : String(err));
     }
-  }, [markUnreadFailedScheduleRunsRead, remoteDeviceId, sessionId]);
+  }, [markCurrentUnreadFailedScheduleRun, remoteDeviceId, sessionId]);
   const handleSessionInterruptDismiss = useCallback(() => {
     if (!sessionId) return;
-    setSessionInterruptAcked(true);
-    void ackInterruptedTurnFor(sessionId)
-      .then(() => {
-        // 远程会话同 handleErrorTailDismiss:ack 落的是被控端 DB,控制端本机库里没有
-        // 这个会话,派生腿管不到它的红点 —— 显式 ack。本机会话靠 ended 落库广播的
-        // sessions:patched(lastTurnEndedAt)收敛,不重复 ack。
-        if (remoteDeviceId) ackErrorAlertHandled(sessionId);
-        markUnreadFailedScheduleRunsRead();
-      })
-      .catch((err) => {
-        // 落库失败(典型:device-link 断连时忽略远程中断)必须复位闩锁 —— 否则横幅
-        // 永久隐藏而中断并未被确认,红点还挂着,用户不离开再重进就没法重试
-        // (PR #879 review P1)。与 handleSessionInterruptContinue 的失败处理一致。
-        setSessionInterruptAcked(false);
-        toast.error(err instanceof Error ? err.message : String(err));
-      });
-  }, [markUnreadFailedScheduleRunsRead, remoteDeviceId, sessionId]);
+    void markCurrentUnreadFailedScheduleRun().then((marked) => {
+      if (!marked) return;
+      setSessionInterruptAcked(true);
+      return ackInterruptedTurnFor(sessionId)
+        .then(() => {
+          // 远程会话同 handleErrorTailDismiss:ack 落的是被控端 DB,控制端本机库里没有
+          // 这个会话,派生腿管不到它的红点 —— 显式 ack。本机会话靠 ended 落库广播的
+          // sessions:patched(lastTurnEndedAt)收敛,不重复 ack。
+          if (remoteDeviceId) ackErrorAlertHandled(sessionId);
+        })
+        .catch((err) => {
+          // 落库失败(典型:device-link 断连时忽略远程中断)必须复位闩锁 —— 否则横幅
+          // 永久隐藏而中断并未被确认,红点还挂着,用户不离开再重进就没法重试
+          // (PR #879 review P1)。与 handleSessionInterruptContinue 的失败处理一致。
+          setSessionInterruptAcked(false);
+          toast.error(err instanceof Error ? err.message : String(err));
+        });
+    });
+  }, [markCurrentUnreadFailedScheduleRun, remoteDeviceId, sessionId]);
   // device-link 远程会话首屏:历史/元数据经隧道往返(网络),慢网下 historyLoaded=false
   // 期间消息区空白。仅远程 + 延迟防闪后给「正在从被控端加载」提示(本机会话恒 false)。
   // 冷缓存已经把最近一页画出来时(messages 非空)不再显示覆盖层 —— 它会盖住可读内容。

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
@@ -89,7 +89,7 @@ import {
   InterruptedTurnBanner,
   UnreadFailedScheduleBanner,
 } from '@/components/chat/InterruptedTurnBanner';
-import { useAutomationScheduleSessionIndex } from './hooks/useAutomationScheduleSessionIndex';
+import { useAutomationScheduleSessionInfo } from './hooks/useAutomationScheduleSessionIndex';
 import { markScheduleRunsReadAndSync } from '../scheduler/lib/scheduleRunReadSync';
 import { useBackgroundBashTasks } from '@/hooks/useBackgroundBashTasks';
 import { useSessionBackgroundActivity } from '@/hooks/useSessionBackgroundActivity';
@@ -1782,15 +1782,16 @@ export function CCAgentSessionView({
   //     →「重试/关闭」
   // 后面有新消息 = 任务已被推进,判定自然不命中。此时消息流内不重复渲染该行
   // (MessageStream 对尾部未忽略 error 行返回 null,由本条独家承载)。
-  const scheduleSessionIndex = useAutomationScheduleSessionIndex();
-  const unreadFailedScheduleRunIds = useMemo(() => {
-    if (!sessionId) return EMPTY_UNREAD_FAILED_RUN_IDS;
-    return scheduleSessionIndex.get(sessionId)?.unreadFailedRunIds ?? EMPTY_UNREAD_FAILED_RUN_IDS;
-  }, [scheduleSessionIndex, sessionId]);
-  const handleUnreadFailedScheduleDismiss = useCallback(() => {
+  const scheduleSessionInfo = useAutomationScheduleSessionInfo(sessionId);
+  const unreadFailedScheduleRunIds =
+    scheduleSessionInfo?.unreadFailedRunIds ?? EMPTY_UNREAD_FAILED_RUN_IDS;
+  const markUnreadFailedScheduleRunsRead = useCallback(() => {
     if (unreadFailedScheduleRunIds.length === 0) return;
     void markScheduleRunsReadAndSync(unreadFailedScheduleRunIds);
   }, [unreadFailedScheduleRunIds]);
+  const handleUnreadFailedScheduleDismiss = useCallback(() => {
+    markUnreadFailedScheduleRunsRead();
+  }, [markUnreadFailedScheduleRunsRead]);
   const errorTailMsg = useMemo(() => {
     const last = messages.length > 0 ? messages[messages.length - 1] : undefined;
     return last && last.role === 'error' && !last.errorDismissed ? last : null;
@@ -1885,11 +1886,20 @@ export function CCAgentSessionView({
       // 本机会话才清:远程会话的红点靠隧道回执清被控端,而本机库里没有它的行,
       // 重算恢复不了 —— 那条腿延后到 pending 落回 false 且横幅确实消失后再 ack。
       if (!remoteDeviceId) ackErrorAlertHandled(sessionId);
+      // 中断/失败横幅优先于未读失败 schedule 横幅。用户已经处置这一次事故,
+      // 不要再立刻换成第二条「标为已读」。
+      markUnreadFailedScheduleRunsRead();
     } catch (err) {
       setErrorTailBannerHiddenFor(null);
       toast.error(err instanceof Error ? err.message : String(err));
     }
-  }, [errorTailKind, errorTailMsg, rebuildClaudeSubscriptionSessionBeforeRetry, sessionId]);
+  }, [
+    errorTailKind,
+    errorTailMsg,
+    markUnreadFailedScheduleRunsRead,
+    rebuildClaudeSubscriptionSessionBeforeRetry,
+    sessionId,
+  ]);
   const handleErrorTailDismiss = useCallback(() => {
     if (!sessionId || !errorTailMsg) return;
     // store 乐观置 errorDismissed(banner 即刻熄灭、切会话回来不复现)+ 持久化
@@ -1906,9 +1916,10 @@ export function CCAgentSessionView({
         // 此时清红点会再造成「横幅在、红点没」(PR #879 review P1)。
         // 本机会话由下面的重算收敛,不重复 ack。
         if (persisted && remoteDeviceId) ackErrorAlertHandled(sessionId);
+        if (persisted) markUnreadFailedScheduleRunsRead();
         return refreshPendingAlerts();
       });
-  }, [errorTailMsg, remoteDeviceId, sessionId]);
+  }, [errorTailMsg, markUnreadFailedScheduleRunsRead, remoteDeviceId, sessionId]);
   // interrupted-turn-resume(简化版):「疑似中断」由 session 行的双时间戳驱动
   // (startedAt > endedAt 且未被 /clear 越过,见 sessionActiveTurn.ts 文件头),
   // 不再依赖持久化中断消息行。判定是打开会话时的一次性快照:本窗口 turn 一旦
@@ -1999,11 +2010,12 @@ export function CCAgentSessionView({
       // dispatch 成功,而横幅已隐藏 —— 先临时清点保持一致,排队被取消时由 pending
       // 落回 false 的 effect 重算恢复。远程会话同样延后(见那里的说明)。
       if (!remoteDeviceId) ackErrorAlertHandled(sessionId);
+      markUnreadFailedScheduleRunsRead();
     } catch (err) {
       setSessionInterruptAcked(false);
       toast.error(err instanceof Error ? err.message : String(err));
     }
-  }, [sessionId]);
+  }, [markUnreadFailedScheduleRunsRead, remoteDeviceId, sessionId]);
   const handleSessionInterruptDismiss = useCallback(() => {
     if (!sessionId) return;
     setSessionInterruptAcked(true);
@@ -2013,6 +2025,7 @@ export function CCAgentSessionView({
         // 这个会话,派生腿管不到它的红点 —— 显式 ack。本机会话靠 ended 落库广播的
         // sessions:patched(lastTurnEndedAt)收敛,不重复 ack。
         if (remoteDeviceId) ackErrorAlertHandled(sessionId);
+        markUnreadFailedScheduleRunsRead();
       })
       .catch((err) => {
         // 落库失败(典型:device-link 断连时忽略远程中断)必须复位闩锁 —— 否则横幅
@@ -2021,7 +2034,7 @@ export function CCAgentSessionView({
         setSessionInterruptAcked(false);
         toast.error(err instanceof Error ? err.message : String(err));
       });
-  }, [remoteDeviceId, sessionId]);
+  }, [markUnreadFailedScheduleRunsRead, remoteDeviceId, sessionId]);
   // device-link 远程会话首屏:历史/元数据经隧道往返(网络),慢网下 historyLoaded=false
   // 期间消息区空白。仅远程 + 延迟防闪后给「正在从被控端加载」提示(本机会话恒 false)。
   // 冷缓存已经把最近一页画出来时(messages 非空)不再显示覆盖层 —— 它会盖住可读内容。

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSidebarUpper.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSidebarUpper.tsx
@@ -897,17 +897,18 @@ function ExpandedView({
         const unreadRunIds = sessionIds.flatMap(
           (sessionId) => scheduleSessionIndex.get(sessionId)?.unreadRunIds ?? [],
         );
-        try {
-          if (unreadRunIds.length > 0) {
-            await markScheduleRunsReadAndSync(unreadRunIds);
-            toast.success(t('ccAgent.layout.markedAsRead', { count: unreadRunIds.length }));
+        if (unreadRunIds.length > 0) {
+          const { processed, failed, firstError } = await markScheduleRunsReadAndSync(unreadRunIds);
+          if (processed.length > 0) {
+            toast.success(t('ccAgent.layout.markedAsRead', { count: processed.length }));
           }
-        } catch (e) {
-          toast.error(
-            t('ccAgent.layout.markAllReadFailed', {
-              error: e instanceof Error ? e.message : String(e),
-            }),
-          );
+          if (failed.length > 0) {
+            toast.error(
+              t('ccAgent.layout.markAllReadFailed', {
+                error: firstError ?? String(failed.length),
+              }),
+            );
+          }
         }
         return;
       }

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSidebarUpper.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSidebarUpper.tsx
@@ -120,10 +120,7 @@ import { useCollapsedProjects } from './hooks/useCollapsedProjects';
 import { useOrcaLeadWorkerMap } from './hooks/useOrcaLeadWorkerMap';
 import { useOrcaWorkerAttentionWatcher } from './hooks/useOrcaWorkerAttentionWatcher';
 import { useAutomationScheduleSessionIndex } from './hooks/useAutomationScheduleSessionIndex';
-import {
-  markAllScheduleRunsReadAndSync,
-  markScheduleRunsReadAndSync,
-} from '../scheduler/lib/scheduleRunReadSync';
+import { markScheduleRunsReadAndSync } from '../scheduler/lib/scheduleRunReadSync';
 import { useSessionLifecycleActions } from './hooks/useSessionLifecycleActions';
 import { useSidebarFilter, type UseSidebarFilterReturn } from './hooks/useSidebarFilter';
 import { useHiddenProjects, type UseHiddenProjectsReturn } from './hooks/useHiddenProjects';
@@ -168,17 +165,17 @@ import { PinnedSection, type PinnedSidebarEntry } from './sidebar/sections/Pinne
 import { ProjectNode as ProjectNodeView } from './sidebar/sections/ProjectNode';
 import { compareDialogueSessions, type DialogueSortBy } from './sidebar/sections/DialogueSection';
 import { holdSidebarViewedPriority, ProjectsSection } from './sidebar/sections/ProjectsSection';
-import { isAutomationGeneratedSession } from './lib/scheduledSessionGrouping';
 import { toStoredSessionTitle } from './lib/sessionDisplayTitle';
 import {
   getVisibleSidebarSessionIds,
   pickSessionIdAfterRemoval,
 } from './lib/sessionRemovalNavigation';
 import { onRequestSessionSwitch, pickAdjacentSessionId } from './lib/sessionSwitchCommands';
-import type {
-  AutomationScheduleAction,
-  AutomationScheduleSessionInfo,
-  AutomationSessionGroup,
+import {
+  unreadSuccessScheduleRunIds,
+  type AutomationScheduleAction,
+  type AutomationScheduleSessionInfo,
+  type AutomationSessionGroup,
 } from './lib/automationSidebarGrouping';
 import { getSessionDeviceId } from '@/features/device-link/remoteProjectsStore';
 import {
@@ -487,68 +484,6 @@ export function CCAgentSidebarUpper() {
     return next;
   }, [scheduleSessionIndex]);
   const navigate = useNavigate();
-  const automationAttentionSessionIds = useMemo(
-    () =>
-      allSessionsForAttention
-        .filter(
-          (s) =>
-            isAutomationGeneratedSession(s) &&
-            (attentionNotifications.has(s.id) ||
-              scheduleSessionIndex.get(s.id)?.hasUnreadRun === true),
-        )
-        .map((s) => s.id),
-    [allSessionsForAttention, attentionNotifications, scheduleSessionIndex],
-  );
-  // automationAttentionSessionIds 仅供下方「全部标为已读」右键菜单使用;导航栏 /
-  // rail 的自动化入口不再显示未读 dot(未读 / 运行状态改由各 schedule 组头承载)。
-
-  // Automations 按钮右键菜单：复用 TaskListCell 的 "controlled DropdownMenu + 不可见 trigger 跟坐标"模式，
-  // state 提到 root —— 折叠/展开两个视图都用同一个 button 概念,菜单只渲染一次,避免两份重复 state。
-  const [automationsMenuPos, setAutomationsMenuPos] = useState<{ x: number; y: number } | null>(
-    null,
-  );
-  const handleAutomationsContextMenu = useCallback((e: React.MouseEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
-    setAutomationsMenuPos({ x: e.clientX, y: e.clientY });
-  }, []);
-  const handleMarkAllAutomationsRead = useCallback(async () => {
-    setAutomationsMenuPos(null);
-    // 先清 done / awaiting(passive,store 对 error 免疫):这部分是纯未读标记,
-    // 展示过就算已读,不需要落库处置。
-    clearSessionAttentionMany(automationAttentionSessionIds);
-    // error 红点是未处理告警的派生投影,**必须先落库处置再清点**:此前是乐观先清、
-    // 失败只记日志,一旦 dismissPendingAlerts 拒绝或只处理了部分会话,横幅仍在库里
-    // 而红点已经消失(还连带发了 explicit 桥接 / 远程回执),正是本 PR 要消灭的割裂。
-    // 现在成功才 explicit 清,失败则重算把仍存在的告警点恢复回来。
-    try {
-      const { processed, failed } = await window.electronAPI.localDb.sessions.dismissPendingAlerts(
-        automationAttentionSessionIds,
-      );
-      // 只清 main 侧**确切回报处置成功**的会话。不能用「不在 failed 里」推断成功:
-      // 请求集合里可能有本 IPC 根本不处理的告警来源(如 WorktreeRestoreBanner 打的
-      // 红点),那些会话既不成功也不失败,误清后重算也恢复不了(worktree 告警不进
-      // 那条查询)。
-      clearSessionAttentionMany(processed, { intent: 'explicit' });
-      if (failed.length > 0) log.warn('some pending alerts were not dismissed', failed);
-    } catch (e) {
-      log.warn('dismiss pending alerts failed', e);
-    }
-    // 成功与失败都重算一次:成功路径收敛掉残留,失败路径把红点恢复成库里的真实告警。
-    void refreshPendingAlerts();
-    try {
-      const updated = await markAllScheduleRunsReadAndSync();
-      if (updated > 0) {
-        toast.success(t('ccAgent.layout.markedAsRead', { count: updated }));
-      }
-    } catch (e) {
-      toast.error(
-        t('ccAgent.layout.markAllReadFailed', {
-          error: e instanceof Error ? e.message : String(e),
-        }),
-      );
-    }
-  }, [automationAttentionSessionIds, t]);
 
   // Sidebar is rendered outside the :sessionId route, so useParams won't work.
   // Use useMatch to extract the active session id from the URL.
@@ -815,7 +750,6 @@ export function CCAgentSidebarUpper() {
           >
             <CollapsedView
               navigate={navigate}
-              onAutomationsContextMenu={handleAutomationsContextMenu}
               allSearchProjects={visibleSearchProjects}
               searchableSessionIds={visibleSearchSessionIds}
               hiddenProjectKeys={hiddenProjectKeys}
@@ -826,45 +760,6 @@ export function CCAgentSidebarUpper() {
               onReorderPinned={handleRailPinnedReorder}
             />
           </div>
-
-          {/* Automations 按钮右键菜单 —— 折叠/展开两份按钮共用此渲染。trigger 跟着 click 坐标定位。 */}
-          <DropdownMenu
-            open={automationsMenuPos !== null}
-            onOpenChange={(open) => {
-              if (!open) setAutomationsMenuPos(null);
-            }}
-          >
-            <DropdownMenuTrigger asChild>
-              <span
-                aria-hidden
-                style={{
-                  position: 'fixed',
-                  left: automationsMenuPos?.x ?? 0,
-                  top: automationsMenuPos?.y ?? 0,
-                  width: 0,
-                  height: 0,
-                  pointerEvents: 'none',
-                }}
-              />
-            </DropdownMenuTrigger>
-            <DropdownMenuContent
-              align="start"
-              sideOffset={2}
-              className={cn(
-                'min-w-[180px] rounded-xl p-1 overflow-hidden',
-                'bg-[var(--cmd-palette-bg)]',
-                'border border-[var(--cmd-palette-border)]',
-                'shadow-[var(--shadow-menu)]',
-              )}
-            >
-              <DropdownMenuItem
-                onSelect={() => void handleMarkAllAutomationsRead()}
-                className="cursor-pointer text-sm text-[var(--msg-assistant-text)] hover:bg-[var(--cmd-palette-item-hover)]"
-              >
-                {t('ccAgent.layout.markAllAsRead')}
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
         </div>
       </SessionAttentionUrgencyProvider>
     </Tooltip.Provider>
@@ -986,6 +881,37 @@ function ExpandedView({
 
   const handleScheduleAction = useCallback(
     async (group: AutomationSessionGroup, action: AutomationScheduleAction) => {
+      if (action === 'mark-read') {
+        const sessionIds = group.sessions.map((session) => session.id);
+        clearSessionAttentionMany(sessionIds);
+        try {
+          const { processed, failed } = await window.electronAPI.localDb.sessions.dismissPendingAlerts(
+            sessionIds,
+          );
+          clearSessionAttentionMany(processed, { intent: 'explicit' });
+          if (failed.length > 0) log.warn('some pending alerts were not dismissed', failed);
+        } catch (e) {
+          log.warn('dismiss pending alerts failed', e);
+        }
+        void refreshPendingAlerts();
+        const unreadRunIds = sessionIds.flatMap(
+          (sessionId) => scheduleSessionIndex.get(sessionId)?.unreadRunIds ?? [],
+        );
+        try {
+          if (unreadRunIds.length > 0) {
+            await markScheduleRunsReadAndSync(unreadRunIds);
+            toast.success(t('ccAgent.layout.markedAsRead', { count: unreadRunIds.length }));
+          }
+        } catch (e) {
+          toast.error(
+            t('ccAgent.layout.markAllReadFailed', {
+              error: e instanceof Error ? e.message : String(e),
+            }),
+          );
+        }
+        return;
+      }
+
       if (!group.scheduleId) return;
       const scheduleId = group.scheduleId;
       const scheduleName = group.title;
@@ -1101,7 +1027,7 @@ function ExpandedView({
         knownSessionIds: group.sessions.map((session) => session.id),
       });
     },
-    [confirmDialog, navigate, requestDeleteSchedule, t],
+    [confirmDialog, navigate, requestDeleteSchedule, scheduleSessionIndex, t],
   );
 
   const [confirm, setConfirm] = useState<ConfirmState>(CONFIRM_INITIAL);
@@ -1198,11 +1124,14 @@ function ExpandedView({
   const markAutomationSessionRunsRead = useCallback(
     (sessionId: string) => {
       const info = scheduleSessionIndex.get(sessionId);
-      if (!info?.unreadRunIds.length) return;
+      // 成功未读可以看过即已读;失败未读必须等横幅或组菜单显式「标为已读」,
+      // 否则点进去横幅立刻消失,红点又没有可处置入口。
+      const successUnreadRunIds = info ? unreadSuccessScheduleRunIds(info) : [];
+      if (successUnreadRunIds.length === 0) return;
       // …AndSync:settle 后无条件触发 renderer 本地刷新。跨实例场景下这些 runId
       // 可能在 DB 里早已被另一实例标为已读(main no-op 且不广播),没有本地刷新
       // 通道的话,这里的过期未读快照永远等不到事件、红点无法自愈。
-      void markScheduleRunsReadAndSync(info.unreadRunIds);
+      void markScheduleRunsReadAndSync(successUnreadRunIds);
     },
     [scheduleSessionIndex],
   );
@@ -3820,7 +3749,6 @@ function ExpandedView({
 
 interface CollapsedProps {
   navigate: ReturnType<typeof useNavigate>;
-  onAutomationsContextMenu: (e: React.MouseEvent) => void;
   /** 全量项目(供 rail 搜索图标钮的 ConversationSearchBox 用)。 */
   allSearchProjects: ProjectNode[];
   searchableSessionIds: string[];
@@ -3844,7 +3772,6 @@ interface CollapsedProps {
  */
 function CollapsedView({
   navigate,
-  onAutomationsContextMenu,
   allSearchProjects,
   searchableSessionIds,
   hiddenProjectKeys,
@@ -3945,7 +3872,6 @@ function CollapsedView({
         variant="rail"
         active={Boolean(onScheduleMatch)}
         onClick={handleNavScheduled}
-        onContextMenu={onAutomationsContextMenu}
       />
       {/* 插件 rail 入口 —— 未读绿点与展开态 SidebarTopNav 对称(同一聚合语义:
           任一插件有未读就点亮,静态不呼吸)。 */}

--- a/apps/desktop/src/renderer/features/cc-agent/contexts/SessionAttentionUrgencyContext.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/contexts/SessionAttentionUrgencyContext.tsx
@@ -4,7 +4,7 @@
  * sessionAttentionStore 已经承担了主流程 attention 语义(kind: done / awaiting / error),
  * 由 useSessionRunningStatus 边缘触发写入。但有些 urgent 信号不属于 attention store 的
  * 生命周期,又不适合直接跨 store 写入(会污染 dock badge 与 auto-clear 语义),典型例子:
- * "定时任务未读且失败/中断/aborted"的 session —— 该信号来自 useAutomationScheduleSessionIndex
+ * "定时任务未读且失败/中断"的 session —— 该信号来自 useAutomationScheduleSessionIndex
  * 的 hasUnreadFailedRun,只想让侧栏右侧涂红,不想触发系统级 attention 广播。
  *
  * 本 context 由 CCAgentSidebarUpper 在其子树顶部 provide,SessionItem 用

--- a/apps/desktop/src/renderer/features/cc-agent/hooks/useAutomationScheduleSessionIndex.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/hooks/useAutomationScheduleSessionIndex.ts
@@ -117,6 +117,7 @@ export function useAutomationScheduleSessionIndex(): ReadonlyMap<string, Automat
       }
 
       const next = new Map<string, AutomationScheduleSessionInfo>();
+      const latestFailedFiredAt = new Map<string, number>();
       for (const run of runs) {
         if (!run.sessionId) continue;
         const existing = next.get(run.sessionId);
@@ -128,7 +129,15 @@ export function useAutomationScheduleSessionIndex(): ReadonlyMap<string, Automat
         // 未读 run 拉高本 session 的 urgency 让侧栏涂红而不是涂绿。
         const isRunUnread = isUnreadScheduleRun(run);
         if (isRunUnread) unreadRunIds.push(run.runId);
-        if (isUnreadFailedScheduleRun(run)) unreadFailedRunIds.push(run.runId);
+        let latestUnreadFailedRunId = existing?.latestUnreadFailedRunId;
+        if (isUnreadFailedScheduleRun(run)) {
+          unreadFailedRunIds.push(run.runId);
+          const firedAt = run.firedAt ?? 0;
+          if (firedAt >= (latestFailedFiredAt.get(run.sessionId) ?? Number.NEGATIVE_INFINITY)) {
+            latestFailedFiredAt.set(run.sessionId, firedAt);
+            latestUnreadFailedRunId = run.runId;
+          }
+        }
         next.set(run.sessionId, {
           scheduleId: run.scheduleId,
           scheduleName: run.scheduleName,
@@ -139,6 +148,7 @@ export function useAutomationScheduleSessionIndex(): ReadonlyMap<string, Automat
           projectConfigId: run.projectConfigId,
           unreadRunIds,
           unreadFailedRunIds,
+          latestUnreadFailedRunId,
           hasUnreadRun: unreadRunIds.length > 0,
           hasUnreadFailedRun: unreadFailedRunIds.length > 0,
         });

--- a/apps/desktop/src/renderer/features/cc-agent/hooks/useAutomationScheduleSessionIndex.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/hooks/useAutomationScheduleSessionIndex.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from 'react';
 import type { SchedulerEvent } from '@cindy/maker-scheduler';
 
 import { isDataOwnerPushCurrent } from '@/contexts/dataOwnerGeneration';
@@ -29,6 +29,32 @@ import { loadScheduleSidebarIndexSnapshot } from '../../scheduler/lib/scheduleSi
 import { subscribeScheduleRunReadSync } from '../../scheduler/lib/scheduleRunReadSync';
 
 const log = createLogger('AutomationScheduleSessionIndex');
+
+/** 侧栏 hook 写入、会话视图只读。避免每个聊天窗再跑一遍全量 listSidebarIndexRuns。 */
+let publishedIndex: ReadonlyMap<string, AutomationScheduleSessionInfo> = new Map();
+const publishedIndexListeners = new Set<() => void>();
+
+function publishIndex(next: ReadonlyMap<string, AutomationScheduleSessionInfo>): void {
+  publishedIndex = next;
+  for (const listener of publishedIndexListeners) listener();
+}
+
+function subscribePublishedIndex(listener: () => void): () => void {
+  publishedIndexListeners.add(listener);
+  return () => {
+    publishedIndexListeners.delete(listener);
+  };
+}
+
+export function useAutomationScheduleSessionInfo(
+  sessionId: string | undefined,
+): AutomationScheduleSessionInfo | undefined {
+  return useSyncExternalStore(
+    subscribePublishedIndex,
+    () => (sessionId ? publishedIndex.get(sessionId) : undefined),
+    () => (sessionId ? publishedIndex.get(sessionId) : undefined),
+  );
+}
 
 /**
  * refresh 失败后的退避重试节奏。这次拉取同时承担抑制标记的对账(见 refresh 内注释),
@@ -118,6 +144,7 @@ export function useAutomationScheduleSessionIndex(): ReadonlyMap<string, Automat
         });
       }
       setIndex(next);
+      publishIndex(next);
       retryAttemptRef.current = 0;
     } catch (error) {
       log.warn('failed to build automation schedule session index', {

--- a/apps/desktop/src/renderer/features/cc-agent/hooks/useAutomationScheduleSessionIndex.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/hooks/useAutomationScheduleSessionIndex.ts
@@ -24,7 +24,7 @@ import {
   scheduleClearSilencedRun,
 } from '@/lib/silencedSessionDoneStore';
 import type { AutomationScheduleSessionInfo } from '../lib/automationSidebarGrouping';
-import { isUnreadScheduleRun } from '../../scheduler/lib/runUnread';
+import { isUnreadFailedScheduleRun, isUnreadScheduleRun } from '../../scheduler/lib/runUnread';
 import { loadScheduleSidebarIndexSnapshot } from '../../scheduler/lib/scheduleSidebarIndexRuns';
 import { subscribeScheduleRunReadSync } from '../../scheduler/lib/scheduleRunReadSync';
 
@@ -95,14 +95,14 @@ export function useAutomationScheduleSessionIndex(): ReadonlyMap<string, Automat
         if (!run.sessionId) continue;
         const existing = next.get(run.sessionId);
         const unreadRunIds = existing?.unreadRunIds ? [...existing.unreadRunIds] : [];
-        // 只对未读 run 累加(与 isUnreadScheduleRun 对齐)。failed/aborted/interrupted
-        // 三种未读 run 视为"未成功",拉高本 session 的 urgency 让侧栏涂红而不是涂绿。
+        const unreadFailedRunIds = existing?.unreadFailedRunIds
+          ? [...existing.unreadFailedRunIds]
+          : [];
+        // 只对未读 run 累加(与 isUnreadScheduleRun 对齐)。failed / interrupted
+        // 未读 run 拉高本 session 的 urgency 让侧栏涂红而不是涂绿。
         const isRunUnread = isUnreadScheduleRun(run);
         if (isRunUnread) unreadRunIds.push(run.runId);
-        const runFailedUnread =
-          isRunUnread &&
-          (run.status === 'failed' || run.status === 'aborted' || run.status === 'interrupted');
-        const hasUnreadFailedRun = (existing?.hasUnreadFailedRun ?? false) || runFailedUnread;
+        if (isUnreadFailedScheduleRun(run)) unreadFailedRunIds.push(run.runId);
         next.set(run.sessionId, {
           scheduleId: run.scheduleId,
           scheduleName: run.scheduleName,
@@ -112,8 +112,9 @@ export function useAutomationScheduleSessionIndex(): ReadonlyMap<string, Automat
           workingDir: run.workingDir,
           projectConfigId: run.projectConfigId,
           unreadRunIds,
+          unreadFailedRunIds,
           hasUnreadRun: unreadRunIds.length > 0,
-          hasUnreadFailedRun,
+          hasUnreadFailedRun: unreadFailedRunIds.length > 0,
         });
       }
       setIndex(next);

--- a/apps/desktop/src/renderer/features/cc-agent/lib/automationSidebarGrouping.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/lib/automationSidebarGrouping.ts
@@ -28,6 +28,11 @@ export interface AutomationScheduleSessionInfo {
    */
   unreadFailedRunIds: string[];
   /**
+   * 该 session 上最近一次未读失败/中断 run。会话内横幅只清这一条;
+   * 清整组仍走组菜单。
+   */
+  latestUnreadFailedRunId?: string;
+  /**
    * 是否至少有一个未读失败 run —— 侧栏右侧据此涂红,而不是和成功完成一样涂绿。
    */
   hasUnreadFailedRun: boolean;

--- a/apps/desktop/src/renderer/features/cc-agent/lib/automationSidebarGrouping.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/lib/automationSidebarGrouping.ts
@@ -23,11 +23,22 @@ export interface AutomationScheduleSessionInfo {
   unreadRunIds: string[];
   hasUnreadRun: boolean;
   /**
-   * unreadRunIds 里是否至少有一个非成功结局(`failed` / `aborted` / `interrupted`)
-   * 的 run —— 侧栏右侧状态指示器据此把 failed schedule 涂成红点(urgent),
-   * 而不是和成功完成一样涂绿。
+   * unreadRunIds 里未成功结局(`failed` / `interrupted`)的子集。
+   * `aborted` 生而已读,不算未读失败。
+   */
+  unreadFailedRunIds: string[];
+  /**
+   * 是否至少有一个未读失败 run —— 侧栏右侧据此涂红,而不是和成功完成一样涂绿。
    */
   hasUnreadFailedRun: boolean;
+}
+
+export function unreadSuccessScheduleRunIds(
+  info: Pick<AutomationScheduleSessionInfo, 'unreadRunIds' | 'unreadFailedRunIds'>,
+): string[] {
+  if (info.unreadFailedRunIds.length === 0) return info.unreadRunIds;
+  const failed = new Set(info.unreadFailedRunIds);
+  return info.unreadRunIds.filter((id) => !failed.has(id));
 }
 
 export interface AutomationSessionGroup {
@@ -58,7 +69,7 @@ export function getEntryActivityMs(entry: SidebarSessionEntry): number {
   return entry.group.sessions.reduce((max, s) => Math.max(max, sessionActivityMs(s)), 0);
 }
 
-export type AutomationScheduleAction = 'run' | 'edit' | 'toggle-pause' | 'delete';
+export type AutomationScheduleAction = 'run' | 'edit' | 'toggle-pause' | 'delete' | 'mark-read';
 
 interface ScopedAutomationGroupKey {
   key: string;

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/AutomationSessionGroupItem.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/AutomationSessionGroupItem.tsx
@@ -43,6 +43,7 @@ import {
 } from './sidebarRightStatus';
 import {
   resolveCollapsedAttention,
+  resolveCollapsedGroupHeaderSessionId,
   resolveCollapsedGroupRightStatus,
 } from './projectCollapsedAttention';
 import { AutomationTimerIcon } from './AutomationTimerIcon';
@@ -187,6 +188,8 @@ export function AutomationSessionGroupItem({
     () => new Set(collapsedAttention.errorSessionIds),
     [collapsedAttention],
   );
+  // 与组头红/绿未读点同源:没有未读就不提供「标为已读」,避免空操作占菜单。
+  const canMarkRead = collapsedAttention.tone != null;
   // childView 的 24h 豁免依赖实时 now,必须每次渲染直接算,不能进 useMemo —— 否则依赖项
   // 不变时时间窗口会被冻结,跨过 24h 阈值的运行不会及时移出豁免。与普通对话列表
   // SessionEntryList 一致(它也是 render 内直接算 getSessionListCollapseView、不 memo);
@@ -401,14 +404,18 @@ export function AutomationSessionGroupItem({
     [countdownText, runCountText, stoppedText],
   );
 
-  // 点击空白行区域 = 点击标题,统一打开组内「最新一条」运行(需求:「点击这条自动化
-  // 折叠也打开最新的 session」)。行内可交互控件(chevron toggle / Timer logo / Run /
-  // More)在自己的 handler 里 stopPropagation,不会误触发。
+  // 点击空白行区域 = 点击标题。展开态打开最新一条;收起且整组是红时打开
+  // 贡献红点的那条。行内控件各自 stopPropagation,不会误触发。
   const openLatestSession = () => {
-    if (!latestSession) return;
+    const targetId = resolveCollapsedGroupHeaderSessionId({
+      collapsed,
+      latestSessionId,
+      attention: collapsedAttention,
+    });
+    if (!targetId) return;
     // 仅在展开 + 前 5 条态下冻结当前布局;收起态无子项可冻结。
-    if (!collapsed && !showAll) freezeCurrentLayout(latestSession.id);
-    onSessionClick(latestSession.id);
+    if (!collapsed && !showAll) freezeCurrentLayout(targetId);
+    onSessionClick(targetId);
   };
 
   return (
@@ -433,6 +440,14 @@ export function AutomationSessionGroupItem({
             标题 <button>(Tab focus + Enter/Space)天然提供。 */}
         <div
           onClick={openLatestSession}
+          onContextMenu={(event) => {
+            // 整行右键 = 打开「更多操作」同一份菜单(不再另做一份隐形锚点菜单)。
+            event.preventDefault();
+            event.stopPropagation();
+            if (!scheduleId) return;
+            setRowTooltipOpen(false);
+            setMenuOpen(true);
+          }}
           onPointerOver={(event) => {
             setRowTooltipOpen(!isAutomationGroupInlineAction(event.target));
           }}
@@ -721,6 +736,14 @@ export function AutomationSessionGroupItem({
                         onClick={(event) => event.stopPropagation()}
                         className={cn(MENU_CONTENT_CLASS, 'min-w-36 overflow-hidden')}
                       >
+                        {canMarkRead && (
+                          <DropdownMenuItem
+                            onSelect={() => onScheduleAction(group, 'mark-read')}
+                            className={MENU_ITEM_CLASS}
+                          >
+                            {t('ccAgent.sidebar.automationGroup.menu.markAllAsRead')}
+                          </DropdownMenuItem>
+                        )}
                         <DropdownMenuItem
                           onSelect={() => onScheduleAction(group, 'edit')}
                           className={MENU_ITEM_CLASS}

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/automationGroupCollapsedAlerts.test.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/automationGroupCollapsedAlerts.test.tsx
@@ -112,11 +112,13 @@ function GroupHarness({
   notifications,
   urgentSessionIds,
   initialCollapsed,
+  onSessionClick = noop,
 }: {
   sessions: Session[];
   notifications: string[];
   urgentSessionIds: ReadonlySet<string>;
   initialCollapsed: boolean;
+  onSessionClick?: (sessionId: string) => void;
 }) {
   const [collapsed, setCollapsed] = useState(initialCollapsed);
   return createElement(SessionAttentionUrgencyProvider, {
@@ -135,7 +137,7 @@ function GroupHarness({
       notifications: new Set(notifications),
       collapsed,
       onCollapsedChange: setCollapsed,
-      onSessionClick: noop,
+      onSessionClick,
       onAction: noop,
       onRename: noop,
       onTogglePin: noop,
@@ -149,11 +151,13 @@ function renderGroup({
   notifications = [],
   urgentSessionIds = new Set<string>(),
   collapsed = true,
+  onSessionClick,
 }: {
   sessions?: Session[];
   notifications?: string[];
   urgentSessionIds?: ReadonlySet<string>;
   collapsed?: boolean;
+  onSessionClick?: (sessionId: string) => void;
 } = {}) {
   return render(
     createElement(GroupHarness, {
@@ -161,6 +165,7 @@ function renderGroup({
       notifications,
       urgentSessionIds,
       initialCollapsed: collapsed,
+      onSessionClick,
     }),
   );
 }
@@ -213,6 +218,18 @@ describe('AutomationSessionGroupItem — 收起态的未处理告警', () => {
     expect(screen.getByLabelText('Completed — click to view')).toBeTruthy();
     expect(screen.queryByLabelText('Failed — click to view')).toBeNull();
     expect(childRunIds(container)).toEqual([]);
+  });
+
+  it('收起且整组是红时,点组头打开告警那条而不是最新一条', () => {
+    const onSessionClick = vi.fn();
+    renderGroup({
+      urgentSessionIds: new Set(['run-3']),
+      onSessionClick,
+    });
+
+    fireEvent.click(screen.getByText('产品决策巡检'));
+    expect(onSessionClick).toHaveBeenCalledWith('run-3');
+    expect(onSessionClick).not.toHaveBeenCalledWith('run-0');
   });
 
   it('等待回复(蓝)不升格成组头状态,也不提行', () => {

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/projectCollapsedAttention.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/projectCollapsedAttention.ts
@@ -112,3 +112,22 @@ export function resolveCollapsedGroupRightStatus({
   if (tone === 'done' && latestKind === 'time') return 'done';
   return latestKind;
 }
+
+/**
+ * 组头点击打开哪一条。展开态仍打开最新一条;收起且整组是红时,
+ * 打开贡献红点的那条,避免点红进到后来成功的巡检。
+ */
+export function resolveCollapsedGroupHeaderSessionId({
+  collapsed,
+  latestSessionId,
+  attention,
+}: {
+  collapsed: boolean;
+  latestSessionId: string | undefined;
+  attention: Pick<CollapsedAttentionSummary, 'tone' | 'errorSessionIds'>;
+}): string | undefined {
+  if (collapsed && attention.tone === 'error' && attention.errorSessionIds[0]) {
+    return attention.errorSessionIds[0];
+  }
+  return latestSessionId;
+}

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/sidebarRightStatus.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/sidebarRightStatus.ts
@@ -28,7 +28,7 @@ export interface SidebarRightStatusInput {
    * 定时任务未读(attentionKind 缺失)语义等同 'done'。
    */
   attentionKind: AttentionKind | undefined;
-  /** 定时任务未读且非成功结局(failed/aborted/interrupted)—— 语义等同 error。 */
+  /** 定时任务未读且失败/中断(failed/interrupted)—— 语义等同 error。 */
   isUrgentFromContext: boolean;
   isRunning: boolean;
   hasAttentionNotification: boolean;

--- a/apps/desktop/src/renderer/features/scheduler/lib/__tests__/scheduleRunReadSync.test.ts
+++ b/apps/desktop/src/renderer/features/scheduler/lib/__tests__/scheduleRunReadSync.test.ts
@@ -59,7 +59,11 @@ describe('scheduleRunReadSync', () => {
     const listener = vi.fn();
     const off = subscribeScheduleRunReadSync(listener);
     try {
-      await expect(markScheduleRunsReadAndSync(['run-1', 'run-2'])).resolves.toBeUndefined();
+      await expect(markScheduleRunsReadAndSync(['run-1', 'run-2'])).resolves.toEqual({
+        processed: ['run-2'],
+        failed: ['run-1'],
+        firstError: 'already read (no-op)',
+      });
       expect(markRunRead).toHaveBeenCalledTimes(2);
       expect(listener).toHaveBeenCalledTimes(1);
     } finally {

--- a/apps/desktop/src/renderer/features/scheduler/lib/runUnread.ts
+++ b/apps/desktop/src/renderer/features/scheduler/lib/runUnread.ts
@@ -2,12 +2,13 @@ import type { ScheduleRun } from '@cindy/maker-scheduler';
 
 type RunUnreadFields = Pick<ScheduleRun, 'readAt' | 'status'>;
 
+export function isUnreadFailedScheduleRun(run: RunUnreadFields): boolean {
+  return !run.readAt && (run.status === 'failed' || run.status === 'interrupted');
+}
+
 export function isUnreadScheduleRun(run: RunUnreadFields): boolean {
   return (
     !run.readAt &&
-    (run.status === 'success' ||
-      run.status === 'failed' ||
-      run.status === 'aborted' ||
-      run.status === 'interrupted')
+    (run.status === 'success' || run.status === 'failed' || run.status === 'interrupted')
   );
 }

--- a/apps/desktop/src/renderer/features/scheduler/lib/scheduleRunReadSync.ts
+++ b/apps/desktop/src/renderer/features/scheduler/lib/scheduleRunReadSync.ts
@@ -32,18 +32,43 @@ function emit(): void {
   for (const listener of [...listeners]) listener();
 }
 
+export interface MarkScheduleRunsReadResult {
+  processed: string[];
+  failed: string[];
+  firstError?: string;
+}
+
 /**
  * 批量标记 run 已读,settle 后无条件触发本地刷新。
  * 单条失败不阻塞其余(allSettled);IPC 全挂时也照样 emit——刷新只是重查 DB,
  * 让 UI 至少回到与 DB 一致的状态。
+ * 返回实际成功 / 失败的 runId,调用方按真实结果出 toast,不要用请求数当成功数。
  */
-export async function markScheduleRunsReadAndSync(runIds: readonly string[]): Promise<void> {
+export async function markScheduleRunsReadAndSync(
+  runIds: readonly string[],
+): Promise<MarkScheduleRunsReadResult> {
+  const processed: string[] = [];
+  const failed: string[] = [];
+  let firstError: string | undefined;
   if (runIds.length > 0) {
-    await Promise.allSettled(
+    const results = await Promise.allSettled(
       runIds.map((runId) => window.electronAPI.maker.schedule.markRunRead(runId)),
     );
+    results.forEach((result, index) => {
+      const runId = runIds[index];
+      if (runId === undefined) return;
+      if (result.status === 'fulfilled') {
+        processed.push(runId);
+        return;
+      }
+      failed.push(runId);
+      if (firstError === undefined) {
+        firstError = result.reason instanceof Error ? result.reason.message : String(result.reason);
+      }
+    });
   }
   emit();
+  return firstError === undefined ? { processed, failed } : { processed, failed, firstError };
 }
 
 /** 单条版本(run 历史卡片用)。 */

--- a/apps/desktop/src/renderer/features/scheduler/lib/scheduleSidebarIndexRuns.ts
+++ b/apps/desktop/src/renderer/features/scheduler/lib/scheduleSidebarIndexRuns.ts
@@ -13,6 +13,7 @@ export interface ScheduleSidebarIndexRun {
   sessionId?: string;
   status: ScheduleRun['status'];
   readAt?: number;
+  firedAt?: number;
 }
 
 /**

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -7162,6 +7162,11 @@
       "continueTitle": "Continue from where the task left off (completed steps will not be repeated)",
       "dismissTitle": "Dismiss this interruption notice"
     },
+    "unreadFailedScheduleBanner": {
+      "text": "This scheduled run did not finish.",
+      "markAsRead": "Mark as read",
+      "markAsReadTitle": "Clear this failed unread state"
+    },
     "worktreeRestoreBanner": {
       "text": "This session's worktree has been cleaned up (directory missing).",
       "textPendingSnapshot": "This session has an unapplied change snapshot.",
@@ -8105,6 +8110,7 @@
         "menu": {
           "runNow": "Run now",
           "more": "More actions",
+          "markAllAsRead": "Mark as read",
           "edit": "Edit",
           "pause": "Pause",
           "resume": "Resume",

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -7159,6 +7159,11 @@
       "continueTitle": "中断した箇所からタスクを続行します（完了済みのステップは繰り返しません）",
       "dismissTitle": "この中断通知を閉じる"
     },
+    "unreadFailedScheduleBanner": {
+      "text": "この自動タスクは完了しませんでした。",
+      "markAsRead": "既読にする",
+      "markAsReadTitle": "この失敗の未読を消す"
+    },
     "worktreeRestoreBanner": {
       "text": "このセッションのワークツリーは回収されました（ディレクトリが存在しません）。",
       "textPendingSnapshot": "このセッションには未適用の変更スナップショットがあります。",
@@ -8093,6 +8098,7 @@
         "menu": {
           "runNow": "今すぐ実行",
           "more": "その他の操作",
+          "markAllAsRead": "既読にする",
           "edit": "編集",
           "pause": "一時停止",
           "resume": "再開",

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -7160,7 +7160,7 @@
       "dismissTitle": "この中断通知を閉じる"
     },
     "unreadFailedScheduleBanner": {
-      "text": "この自動タスクは完了しませんでした。",
+      "text": "このスケジュール実行は完了しませんでした。",
       "markAsRead": "既読にする",
       "markAsReadTitle": "この失敗の未読を消す"
     },

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -7159,6 +7159,11 @@
       "continueTitle": "중단된 지점부터 작업을 계속합니다(완료된 단계는 반복하지 않습니다)",
       "dismissTitle": "이 중단 알림 닫기"
     },
+    "unreadFailedScheduleBanner": {
+      "text": "이 자동 작업이 완료되지 않았습니다.",
+      "markAsRead": "읽음으로 표시",
+      "markAsReadTitle": "이 실패 읽지 않음 표시를 지웁니다"
+    },
     "worktreeRestoreBanner": {
       "text": "이 세션의 워크트리가 정리되었습니다(디렉터리가 존재하지 않음).",
       "textPendingSnapshot": "이 세션에 적용되지 않은 변경 스냅샷이 있습니다.",
@@ -8093,6 +8098,7 @@
         "menu": {
           "runNow": "지금 실행",
           "more": "추가 작업",
+          "markAllAsRead": "읽음으로 표시",
           "edit": "편집",
           "pause": "일시중지",
           "resume": "재개",

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -7160,7 +7160,7 @@
       "dismissTitle": "이 중단 알림 닫기"
     },
     "unreadFailedScheduleBanner": {
-      "text": "이 자동 작업이 완료되지 않았습니다.",
+      "text": "이 예약 작업이 완료되지 않았습니다.",
       "markAsRead": "읽음으로 표시",
       "markAsReadTitle": "이 실패 읽지 않음 표시를 지웁니다"
     },

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -7160,7 +7160,7 @@
       "dismissTitle": "关闭此中断提示"
     },
     "unreadFailedScheduleBanner": {
-      "text": "这次自动任务没有完成。",
+      "text": "这次定时任务没有完成。",
       "markAsRead": "标为已读",
       "markAsReadTitle": "清除这条失败未读"
     },

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -7159,6 +7159,11 @@
       "continueTitle": "从中断处继续完成任务（不会重复已完成的步骤）",
       "dismissTitle": "关闭此中断提示"
     },
+    "unreadFailedScheduleBanner": {
+      "text": "这次自动任务没有完成。",
+      "markAsRead": "标为已读",
+      "markAsReadTitle": "清除这条失败未读"
+    },
     "worktreeRestoreBanner": {
       "text": "该任务的 worktree 已被回收（目录不存在）。",
       "textPendingSnapshot": "该任务有一份未应用的更改快照。",
@@ -8093,6 +8098,7 @@
         "menu": {
           "runNow": "立即运行",
           "more": "更多操作",
+          "markAllAsRead": "标为已读",
           "edit": "编辑",
           "pause": "暂停",
           "resume": "恢复",

--- a/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
@@ -7158,6 +7158,11 @@
       "continueTitle": "從中斷處繼續完成任務（不會重複已完成的步驟）",
       "dismissTitle": "關閉此中斷提示"
     },
+    "unreadFailedScheduleBanner": {
+      "text": "這次自動任務沒有完成。",
+      "markAsRead": "標為已讀",
+      "markAsReadTitle": "清除這條失敗未讀"
+    },
     "worktreeRestoreBanner": {
       "text": "該任務的 worktree 已被回收（目錄不存在）。",
       "textPendingSnapshot": "該任務有一份未應用的更改快照。",
@@ -8093,6 +8098,7 @@
         "menu": {
           "runNow": "立即執行",
           "more": "更多操作",
+          "markAllAsRead": "標為已讀",
           "edit": "編輯",
           "pause": "暫停",
           "resume": "恢復",

--- a/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
@@ -7159,7 +7159,7 @@
       "dismissTitle": "關閉此中斷提示"
     },
     "unreadFailedScheduleBanner": {
-      "text": "這次自動任務沒有完成。",
+      "text": "這次定時任務沒有完成。",
       "markAsRead": "標為已讀",
       "markAsReadTitle": "清除這條失敗未讀"
     },

--- a/packages/maker-scheduler/src/__tests__/scheduler.test.ts
+++ b/packages/maker-scheduler/src/__tests__/scheduler.test.ts
@@ -1340,6 +1340,7 @@ describe('Scheduler', () => {
     expect(runs).toHaveLength(1);
     expect(runs[0].status).toBe('aborted');
     expect(runs[0].errorMsg).toMatch(/cancelled by user/);
+    expect(runs[0].readAt).toBe(runs[0].finishedAt);
   });
 
   it('pause aborts in-flight run, keeps schedule with status=paused', async () => {
@@ -1365,6 +1366,7 @@ describe('Scheduler', () => {
     const runs = await local.scheduler.listRuns(sch.id);
     expect(runs).toHaveLength(1);
     expect(runs[0].status).toBe('aborted');
+    expect(runs[0].readAt).toBe(runs[0].finishedAt);
     expect(local.scheduler.getInflightCount(sch.id)).toBe(0);
   });
 

--- a/packages/maker-scheduler/src/engine/scheduler.ts
+++ b/packages/maker-scheduler/src/engine/scheduler.ts
@@ -870,6 +870,8 @@ export class Scheduler extends EventEmitter {
           status: 'aborted',
           finishedAt,
           errorMsg: 'cancelled by user (schedule deleted or paused)',
+          // 系统/用户主动收口,不是要处理的失败;生而已读,侧栏不涂红。
+          readAt: finishedAt,
         });
         this.emitEvent({
           type: 'failed',
@@ -1153,6 +1155,7 @@ export class Scheduler extends EventEmitter {
         status: 'aborted',
         finishedAt,
         errorMsg: 'cancelled by user (schedule deleted or paused)',
+        readAt: finishedAt,
       });
       this.emitEvent({ type: 'failed', scheduleId: schedule.id, runId, error: 'aborted' });
     } else if (runError !== undefined) {

--- a/packages/maker-scheduler/src/types.ts
+++ b/packages/maker-scheduler/src/types.ts
@@ -107,6 +107,8 @@ export interface ScriptExecutionConfig {
   capabilities: ScriptCapability[];
 }
 /**
+ * 'aborted': 用户暂停/删除计划，或调度器 stop（切账号/退出）主动中断。
+ * 视为终态；落库时自带 readAt（不是用户要处理的失败，不产生未读红点）。
  * 'interrupted': app 关闭/崩溃时残留为 'running' 的 run，下次启动时由
  * Scheduler.start() 统一改写为本状态，区别于用户主动 abort。视为终态。
  * 'skipped': 前置检查脚本（preRunHook）exit 2 拦截，本轮未启动 agent。


### PR DESCRIPTION
## 这次改了什么

### 摘要

自动任务侧栏红点有两套逻辑：失败未读会涂红，但点进任务后往往没有可忽略的横幅；组头点击还一律打开最新一次运行。账号切换或暂停计划把进行中的 run 掐成 `aborted` 时，红点会一直粘着。

这次把「标为已读」放到自动任务组头的更多菜单（有未读才出现），失败/中断打开后给出横幅；系统主动中止的 `aborted` 生而已读，不再当失败未读。

### 变更类型

- [x] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：
  - 组头 `⋯` / 整行右键提供「标为已读」，只清这一组
  - `failed` / `interrupted` 未读打开后出现「这次自动任务没有完成」横幅，点「标为已读」才消红
  - 成功未读仍可看过即已读；失败未读不再被打开任务偷偷清掉
  - 收起且整组是红时，点组头打开贡献红点的那条，不再打开后来成功的巡检
  - 暂停 / 删除 / 调度器 stop 写成 `aborted` 时带上 `readAt`；存量未读 `aborted` 也不再涂红
- 明确不包含：
  - 不伪造 error 消息行
  - 不把失败未读写进 `sessionAttentionStore`（避免污染 Dock）
  - 不做全库「全部自动任务标已读」的导航栏隐形菜单
- 用户可见变化：自动任务组菜单多一项「标为已读」；真失败点进去有横幅；系统掐断不再留下消不掉的红点
- 是否存在 breaking change：无

### UI 变化

Desktop 侧栏自动任务组头菜单，以及任务输入框上方的失败未读横幅。未附截图。

- 引用的设计规范：
  - `docs/design-rules/DESIGN.md` §2 Semantic & Accent：横幅复用已有 error token（`--error-bg` / `--error-border` / `--error-fg` / `--error-fg-strong`），与中断横幅同组，不新增语义色
  - `docs/design-rules/DESIGN.md` §10 Theme System：颜色只走 token，Light / Dark 随主题切换
  - `docs/design-rules/DESIGN.md` §1 Extreme content restraint：失败横幅只有一句说明 + 一个「标为已读」，没有「继续」
  - 组菜单复用既有 `DropdownMenu` 与组头 pill 行，不再用 0 尺寸隐形 trigger

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop run typecheck
结果：通过

pnpm --filter @cindy/maker-scheduler exec vitest run
结果：6 files / 208 tests 通过

pnpm --filter desktop exec vitest run \
  src/main/__tests__/interruptedContinuationContract.test.ts \
  src/renderer/__tests__/automationGeneratedSessions.test.ts \
  src/renderer/__tests__/mainListModel.test.ts \
  src/renderer/__tests__/projectCollapsedAttention.test.ts \
  src/renderer/features/cc-agent/sidebar/__tests__/automationGroupCollapsedAlerts.test.tsx
结果：通过

pnpm check:i18n-glossary
结果：无新增违规

bash /Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh <worktree>
结果：maker-scheduler 等 workspace 通过；desktop 仅 ghostInstallReceipt.test.ts 2 例失败。
该失败在当前 origin/main 干净基线同样复现，与本 PR diff 无关，交给 CI 给权威结论。
```

### 手工验证

不涉及。未启动 Desktop 实机点选组菜单 / 横幅（worktree 改动不会热更到正在跑的实例）。

### 未执行的验证

Desktop Light / Dark 实机目检未做。横幅与菜单复用已有 themed 组件和 error token，双模式实现已落地，但未目检。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop 自动任务侧栏红点、组菜单、任务内横幅；scheduler `aborted` 落库带 `readAt`
- 回滚 / 降级方式：revert 本 PR。已写出的 `aborted.readAt` 只让那些 run 保持已读，不影响后续失败未读

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
