### PR TITLE
fix(codex): 修复 OAuth WebSocket 断网恢复

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
@@ -2399,6 +2399,7 @@ describe('codex proxy host', () => {
         // [encrypted activeStrip, image generation activeStrip, provider-aware Guardian reviewer, locked Subagent route, instructions 注入, locked Subagent exec guard, Gateway 原生 web_search, 跨来源压缩块兼容, xAI ModelInput activeStrip, strict gateway history 兼容, xAI ModelInput sanitize, DeepSeek V4 custom tool 兼容, xAI Responses 兼容, XD Gateway Grok 兼容, ByteDance Seed tool 兼容, MiniMax effort 兼容, provider model rewrite, 视觉桥(controller 未注入 → 短路透传), stripNonAnthropicFields]
         transformRequest: [expect.any(Function), expect.any(Function), expect.any(Function), expect.any(Function), expect.any(Function), expect.any(Function), expect.any(Function), expect.any(Function), expect.any(Function), expect.any(Function), expect.any(Function), expect.any(Function), expect.any(Function), expect.any(Function), expect.any(Function), expect.any(Function), expect.any(Function), expect.any(Function), mockState.stripNonAnthropicFields],
         routingTransform: expect.any(Function),
+        retryProvenWebSocketUpgrades: true,
         recoveryRules: expect.arrayContaining([
           expect.objectContaining({ id: 'encrypted_content' }),
           expect.objectContaining({ id: 'image_generation_id' }),
@@ -2436,6 +2437,27 @@ describe('codex proxy host', () => {
     expect(proxyOpts.resolveWebSocketUpstream(ctx)).toBe(
       'https://chatgpt.com/backend-api/codex',
     );
+  });
+
+  it('forgets only the closing session websocket proofs before a provider-route resume', async () => {
+    const host = await freshCodexProxyHost();
+    const forgetWebSocketStateForThread = vi.fn(() => 1);
+    mockState.createAnthropicCompatProxy.mockResolvedValueOnce({
+      url: 'http://127.0.0.1:43210',
+      forgetWebSocketStateForThread,
+      dispose: vi.fn(async () => undefined),
+    });
+    await host.ensureCodexProxyReady();
+    host.registerComposed('session-switching', 'thread-switching', 'PRODUCT_PROMPT');
+    host.registerChildThread('thread-switching', 'thread-switching-child');
+    host.registerComposed('session-untouched', 'thread-untouched', 'PRODUCT_PROMPT');
+
+    host.unregister('session-switching');
+
+    expect(forgetWebSocketStateForThread).toHaveBeenCalledTimes(2);
+    expect(forgetWebSocketStateForThread).toHaveBeenCalledWith('thread-switching');
+    expect(forgetWebSocketStateForThread).toHaveBeenCalledWith('thread-switching-child');
+    expect(forgetWebSocketStateForThread).not.toHaveBeenCalledWith('thread-untouched');
   });
 
   it('declines the next websocket upgrade after a body recovery error is armed', async () => {

--- a/apps/desktop/src/main/maker-host/codex-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/codex-proxy-host.ts
@@ -2785,6 +2785,9 @@ function createCodexProxyHandle(
     recoveryRules: [...CODEX_BODY_RECOVERY_RULES],
     logger: log,
     resolveOutboundProxy: resolveDesktopOutboundProxy,
+    // 仅 resolveWebSocketUpstream 真正返回 OAuth 上游时生效。已成功走过 WS 的单个 thread
+    // 在瞬时断网后由 Cindy 原地回探，不让 Codex 因握手失败把该 session 固定到 HTTP。
+    retryProvenWebSocketUpgrades: true,
     /**
      * WS upgrade 的上游固定为 ChatGPT 订阅后端。
      *
@@ -3074,6 +3077,10 @@ function clearSessionThreads(sessionId: string): string[] {
   reviewerModelBySession.delete(sessionId);
   for (const threadId of threadIds) {
     if (threadToSession.get(threadId) === sessionId) {
+      // Session 关闭既可能是普通释放，也可能是 OAuth ↔ 第三方模型的 route 切换。
+      // 两种情况都必须撤销旧 thread 的 WS 成功证明：第三方恢复使用 cindy_gateway/HTTP，
+      // 迟到的旧 upgrade 不能命中本次新增的 Cindy 侧 WS 保活；其他 thread 不受影响。
+      _handle?.forgetWebSocketStateForThread?.(threadId);
       threadToSession.delete(threadId);
       registry.delete(threadId);
       subagentRouteByParentThread.delete(threadId);

--- a/packages/anthropic-compat-proxy/src/server-websocket.test.ts
+++ b/packages/anthropic-compat-proxy/src/server-websocket.test.ts
@@ -39,7 +39,7 @@ function upgradeRequest(
     `Host: ${host}`,
     'Connection: Upgrade',
     'Upgrade: websocket',
-    'Sec-WebSocket-Key: dGVzdC13ZWJzb2NrZXQta2V5',
+    'Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==',
     'Sec-WebSocket-Version: 13',
     ...extraHeaders,
     '',
@@ -89,8 +89,12 @@ function openUpgrade(
   });
 }
 
-async function readUpgradeFailure(proxyUrl: string, path = '/v1/responses'): Promise<string> {
-  const { socket, head, rest } = await openUpgrade(proxyUrl, path);
+async function readUpgradeFailure(
+  proxyUrl: string,
+  path = '/v1/responses',
+  extraHeaders: readonly string[] = [],
+): Promise<string> {
+  const { socket, head, rest } = await openUpgrade(proxyUrl, path, Buffer.alloc(0), extraHeaders);
   const chunks = [rest];
   await new Promise<void>((resolve, reject) => {
     const timeout = setTimeout(() => {
@@ -135,6 +139,8 @@ function waitForSocketText(socket: Socket, initial: Buffer, expected: string): P
 
 function startUpgradeUpstream(opts: { handshakeDelayMs?: number } = {}): Promise<{
   url: string;
+  port: number;
+  server: ReturnType<typeof createServer>;
   requests: IncomingMessage[];
   received: string[];
   connections: Duplex[];
@@ -169,7 +175,7 @@ function startUpgradeUpstream(opts: { handshakeDelayMs?: number } = {}): Promise
   });
   return listenOnAvailableLoopbackPort(server).then((port) => {
     cleanups.push(() => new Promise<void>((resolve) => server.close(() => resolve())));
-    return { url: `http://127.0.0.1:${port}`, requests, received, connections };
+    return { url: `http://127.0.0.1:${port}`, port, server, requests, received, connections };
   });
 }
 
@@ -251,6 +257,249 @@ describe('anthropic-compat-proxy websocket upgrades', () => {
     expect(response).toBe(
       'HTTP/1.1 426 Upgrade Required\r\nConnection: close\r\n\r\n',
     );
+  });
+
+  it('holds only a proven thread reconnect until its websocket upstream recovers', async () => {
+    const upstream = await startUpgradeUpstream();
+    proxy = await createAnthropicCompatProxy({
+      upstream: 'http://unused.invalid',
+      transformRequest: [],
+      resolveWebSocketUpstream: () => upstream.url,
+      retryProvenWebSocketUpgrades: true,
+    });
+    const handshakeHeaders = [
+      'Thread-Id: thread-proven',
+      'Sec-WebSocket-Extensions: permessage-deflate',
+    ];
+
+    const first = await openUpgrade(
+      proxy.url,
+      '/v1/responses',
+      Buffer.alloc(0),
+      handshakeHeaders,
+    );
+    expect(first.head).toContain('HTTP/1.1 101 Switching Protocols');
+    expect(upstream.requests).toHaveLength(1);
+
+    // Drop the established path and stop accepting new upstream connections, matching a network cut.
+    first.socket.destroy();
+    for (const connection of upstream.connections) connection.destroy();
+    await new Promise<void>((resolve) => upstream.server.close(() => resolve()));
+
+    const reconnect = await openUpgrade(
+      proxy.url,
+      '/v1/responses',
+      Buffer.alloc(0),
+      handshakeHeaders,
+    );
+    expect(reconnect.head).toContain('HTTP/1.1 101 Switching Protocols');
+    expect(reconnect.head.toLowerCase()).toContain(
+      'sec-websocket-extensions: permessage-deflate',
+    );
+    expect(reconnect.head).toContain(
+      'Sec-WebSocket-Accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo=',
+    );
+    expect(upstream.requests).toHaveLength(1);
+
+    // A different thread has no successful-101 proof and must not be captured by this recovery path.
+    const otherThread = await readUpgradeFailure(
+      proxy.url,
+      '/v1/responses',
+      ['Thread-Id: thread-other'],
+    );
+    expect(otherThread).toBe(
+      'HTTP/1.1 502 Bad Gateway\r\nConnection: close\r\n\r\n',
+    );
+
+    // Write while offline. The proxy pauses reads instead of accumulating an unbounded user-space queue.
+    reconnect.socket.write('PING_AFTER_RECONNECT');
+    await new Promise<void>((resolve, reject) => {
+      const onError = (error: Error): void => reject(error);
+      upstream.server.once('error', onError);
+      upstream.server.listen(upstream.port, '127.0.0.1', () => {
+        upstream.server.off('error', onError);
+        resolve();
+      });
+    });
+
+    await expect(
+      waitForSocketText(reconnect.socket, reconnect.rest, 'PONG'),
+    ).resolves.toContain('PONG');
+    expect(upstream.requests).toHaveLength(2);
+    expect(upstream.received.join('')).toContain('PING_AFTER_RECONNECT');
+  });
+
+  it('forgets one thread proof so a provider switch cannot reuse its websocket recovery', async () => {
+    const upstream = await startUpgradeUpstream();
+    proxy = await createAnthropicCompatProxy({
+      upstream: 'http://unused.invalid',
+      transformRequest: [],
+      resolveWebSocketUpstream: () => upstream.url,
+      retryProvenWebSocketUpgrades: true,
+    });
+    const threadHeaders = ['Thread-Id: thread-provider-switch'];
+    const first = await openUpgrade(
+      proxy.url,
+      '/v1/responses',
+      Buffer.alloc(0),
+      threadHeaders,
+    );
+    expect(first.head).toContain('HTTP/1.1 101 Switching Protocols');
+
+    const firstClosed = new Promise<void>((resolve) => first.socket.once('close', () => resolve()));
+    expect(proxy.forgetWebSocketStateForThread?.('thread-provider-switch')).toBe(1);
+    await firstClosed;
+    for (const connection of upstream.connections) connection.destroy();
+    await new Promise<void>((resolve) => upstream.server.close(() => resolve()));
+
+    const response = await readUpgradeFailure(
+      proxy.url,
+      '/v1/responses',
+      threadHeaders,
+    );
+    expect(response).toBe(
+      'HTTP/1.1 502 Bad Gateway\r\nConnection: close\r\n\r\n',
+    );
+  });
+
+  it('stops holding a proven thread when the real upstream returns an HTTP refusal', async () => {
+    let acceptUpgrade = true;
+    const upstream = createServer();
+    upstream.on('upgrade', (_req, socket) => {
+      sockets.add(socket);
+      if (!acceptUpgrade) {
+        socket.end([
+          'HTTP/1.1 503 Service Unavailable',
+          'Content-Length: 4',
+          'Connection: close',
+          '',
+          'down',
+        ].join('\r\n'));
+        return;
+      }
+      socket.write([
+        'HTTP/1.1 101 Switching Protocols',
+        'Connection: Upgrade',
+        'Upgrade: websocket',
+        '',
+        '',
+      ].join('\r\n'));
+    });
+    const port = await listenOnAvailableLoopbackPort(upstream);
+    cleanups.push(() => new Promise<void>((resolve) => upstream.close(() => resolve())));
+    proxy = await createAnthropicCompatProxy({
+      upstream: 'http://unused.invalid',
+      transformRequest: [],
+      resolveWebSocketUpstream: () => `http://127.0.0.1:${port}`,
+      retryProvenWebSocketUpgrades: true,
+    });
+    const threadHeaders = ['Thread-Id: thread-refused'];
+    const first = await openUpgrade(
+      proxy.url,
+      '/v1/responses',
+      Buffer.alloc(0),
+      threadHeaders,
+    );
+    first.socket.destroy();
+    acceptUpgrade = false;
+
+    const held = await openUpgrade(
+      proxy.url,
+      '/v1/responses',
+      Buffer.alloc(0),
+      threadHeaders,
+    );
+    expect(held.head).toContain('HTTP/1.1 101 Switching Protocols');
+    await new Promise<void>((resolve) => held.socket.once('close', () => resolve()));
+
+    const refusal = await readUpgradeFailure(proxy.url, '/v1/responses', threadHeaders);
+    expect(refusal).toContain('HTTP/1.1 503 Service Unavailable');
+    expect(refusal).toContain('down');
+  });
+
+  it('returns 500 instead of falling back when the websocket resolver throws', async () => {
+    proxy = await createAnthropicCompatProxy({
+      upstream: 'http://unused.invalid',
+      transformRequest: [],
+      resolveWebSocketUpstream: () => {
+        throw new Error('resolver failed');
+      },
+    });
+
+    const response = await readUpgradeFailure(proxy.url);
+    expect(response).toBe(
+      'HTTP/1.1 500 Internal Server Error\r\nConnection: close\r\n\r\n',
+    );
+  });
+
+  it('returns 500 instead of falling back for an unusable websocket upstream url', async () => {
+    proxy = await createAnthropicCompatProxy({
+      upstream: 'http://unused.invalid',
+      transformRequest: [],
+      resolveWebSocketUpstream: () => 'ws://upstream.invalid/backend-api/codex',
+    });
+
+    const response = await readUpgradeFailure(proxy.url);
+    expect(response).toBe(
+      'HTTP/1.1 500 Internal Server Error\r\nConnection: close\r\n\r\n',
+    );
+  });
+
+  it('returns 502 instead of falling back on pre-handshake network errors', async () => {
+    // A closed loopback port deterministically produces ECONNREFUSED. DNS ENOTFOUND,
+    // ECONNRESET and TLS failures enter the same ClientRequest error branch.
+    const unavailable = createServer();
+    const port = await listenOnAvailableLoopbackPort(unavailable);
+    await new Promise<void>((resolve) => unavailable.close(() => resolve()));
+
+    proxy = await createAnthropicCompatProxy({
+      upstream: 'http://unused.invalid',
+      transformRequest: [],
+      resolveWebSocketUpstream: () => `http://127.0.0.1:${port}`,
+    });
+
+    const response = await readUpgradeFailure(proxy.url);
+    expect(response).toBe(
+      'HTTP/1.1 502 Bad Gateway\r\nConnection: close\r\n\r\n',
+    );
+  });
+
+  it('returns 504 instead of falling back when the websocket handshake times out', async () => {
+    const upstream = createServer();
+    upstream.on('upgrade', (_req, socket) => {
+      sockets.add(socket);
+      // Intentionally leave the handshake pending. The ClientRequest timeout spy below
+      // fires the production timeout callback without making this test wait 15 seconds.
+    });
+    const port = await listenOnAvailableLoopbackPort(upstream);
+    cleanups.push(() => new Promise<void>((resolve) => {
+      upstream.closeAllConnections();
+      upstream.close(() => resolve());
+    }));
+    const setTimeoutSpy = vi.spyOn(ClientRequest.prototype, 'setTimeout');
+    setTimeoutSpy.mockImplementation(function (
+      this: ClientRequest,
+      msecs: number,
+      callback?: () => void,
+    ): ClientRequest {
+      if (msecs === 15_000 && callback) queueMicrotask(callback);
+      return this;
+    });
+
+    try {
+      proxy = await createAnthropicCompatProxy({
+        upstream: 'http://unused.invalid',
+        transformRequest: [],
+        resolveWebSocketUpstream: () => `http://127.0.0.1:${port}`,
+      });
+
+      const response = await readUpgradeFailure(proxy.url);
+      expect(response).toBe(
+        'HTTP/1.1 504 Gateway Timeout\r\nConnection: close\r\n\r\n',
+      );
+    } finally {
+      setTimeoutSpy.mockRestore();
+    }
   });
 
   it('handles an asynchronous socket error while writing an early 426 response', async () => {
@@ -533,7 +782,7 @@ describe('anthropic-compat-proxy websocket upgrades', () => {
     await expect(waitForSocketText(other.socket, other.rest, 'PONG')).resolves.toContain('PONG');
   });
 
-  it('routes an https websocket upstream through the configured HTTP CONNECT proxy', async () => {
+  it('returns 502 when an HTTP CONNECT proxy cannot reach the websocket upstream', async () => {
     const connects: string[] = [];
     const outbound = createServer();
     outbound.on('connect', (req, clientSocket) => {
@@ -551,7 +800,7 @@ describe('anthropic-compat-proxy websocket upgrades', () => {
     });
 
     const response = await readUpgradeFailure(proxy.url);
-    expect(response).toContain('HTTP/1.1 426 Upgrade Required');
+    expect(response).toContain('HTTP/1.1 502 Bad Gateway');
     expect(connects).toEqual(['upstream.invalid:443']);
   });
 

--- a/packages/anthropic-compat-proxy/src/server.ts
+++ b/packages/anthropic-compat-proxy/src/server.ts
@@ -13,6 +13,7 @@
  *      详见 dispose() 内注释。
  */
 
+import { createHash } from 'node:crypto';
 import { createServer, request as httpRequest, type ClientRequest, type IncomingMessage, type RequestOptions, type Server, type ServerResponse } from 'node:http';
 import { request as httpsRequest } from 'node:https';
 import type { Socket, TcpSocketConnectOpts } from 'node:net';
@@ -64,8 +65,17 @@ const REQUEST_TOO_LARGE_DRAIN_TIMEOUT_MS = 10 * 1000;
 const UPSTREAM_SOCKET_TIMEOUT_MS = 10 * 60 * 1000;
 
 // WebSocket 这里只等 HTTP 101 握手，不应沿用允许长时间生成的 10 分钟超时。
-// 中间代理静默丢弃 Upgrade 时尽快回 426，让 Codex 原生 transport 降到 HTTP。
+// 中间代理静默丢弃 Upgrade 时尽快回 504，让 Codex 把它当临时失败继续原生重试；
+// 不能伪装成 426，否则会把当前 Codex session 永久固定到 HTTP transport。
 const WEBSOCKET_UPGRADE_TIMEOUT_MS = 15 * 1000;
+
+// 已经由真实上游 101 证明可用的 thread，重连时由 loopback proxy 先接住客户端，随后在
+// Cindy 内部回探上游。这样瞬时断网不会把 Codex 的 session 级 transport 固定到 HTTP。
+// 回探没有总时限：生命周期由该条客户端 socket / proxy dispose 精确约束；退避上限避免
+// 长时间离线时制造高频出网请求。
+const WEBSOCKET_RECONNECT_INITIAL_DELAY_MS = 250;
+const WEBSOCKET_RECONNECT_MAX_DELAY_MS = 5_000;
+const WEBSOCKET_ACCEPT_GUID = '258EAFA5-E914-47DA-95CA-C5AB0DC85B11';
 
 // Happy Eyeballs 单地址连接尝试超时。Node 20+ 默认开启 autoSelectFamily(双栈并竞),
 // 但每个地址的 TCP 握手默认只给 250ms(net.getDefaultAutoSelectFamilyAttemptTimeout());
@@ -118,6 +128,98 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 // loopback 不暴露外部,属防御性上限)。
 const MAX_CACHED_THREADS = 1024;
 const MAX_IDS_PER_THREAD = 8192;
+
+interface ProvenWebSocketHandshake {
+  readonly upstreamUrl: string;
+  readonly inboundUrl: string;
+  readonly requestSignature: string;
+  readonly responseProtocol: string;
+  readonly responseExtensions: string;
+}
+
+function webSocketRequestSignature(headers: Readonly<Record<string, string>>): string {
+  return [
+    headers['sec-websocket-version'] ?? '',
+    headers['sec-websocket-protocol'] ?? '',
+    headers['sec-websocket-extensions'] ?? '',
+    headers['openai-beta'] ?? '',
+  ].join('\n');
+}
+
+function createProvenWebSocketHandshake(
+  upstreamUrl: string,
+  inboundUrl: string,
+  requestHeaders: Readonly<Record<string, string>>,
+  response: IncomingMessage,
+): ProvenWebSocketHandshake {
+  return {
+    upstreamUrl,
+    inboundUrl,
+    requestSignature: webSocketRequestSignature(requestHeaders),
+    responseProtocol: String(response.headers['sec-websocket-protocol'] ?? ''),
+    responseExtensions: String(response.headers['sec-websocket-extensions'] ?? ''),
+  };
+}
+
+function rememberProvenWebSocketHandshake(
+  cache: Map<string, ProvenWebSocketHandshake>,
+  threadId: string,
+  proof: ProvenWebSocketHandshake,
+): void {
+  if (!threadId) return;
+  cache.delete(threadId);
+  cache.set(threadId, proof);
+  while (cache.size > MAX_CACHED_THREADS) {
+    const oldest = cache.keys().next().value as string | undefined;
+    if (oldest === undefined) break;
+    cache.delete(oldest);
+  }
+}
+
+function provenWebSocketHandshakeMatchesRequest(
+  proof: ProvenWebSocketHandshake,
+  upstreamUrl: string,
+  inboundUrl: string,
+  headers: Readonly<Record<string, string>>,
+): boolean {
+  return proof.upstreamUrl === upstreamUrl
+    && proof.inboundUrl === inboundUrl
+    && proof.requestSignature === webSocketRequestSignature(headers);
+}
+
+function provenWebSocketHandshakeMatchesResponse(
+  proof: ProvenWebSocketHandshake,
+  response: IncomingMessage,
+): boolean {
+  return proof.responseProtocol === String(response.headers['sec-websocket-protocol'] ?? '')
+    && proof.responseExtensions === String(response.headers['sec-websocket-extensions'] ?? '');
+}
+
+/**
+ * 为已证明可用的 WS thread 生成本地 101。只复用协议/扩展协商结果；Accept 必须按本次
+ * Sec-WebSocket-Key 重新计算，不能复用上一条连接的值。
+ */
+function serializeProvenWebSocketHandshake(
+  headers: Readonly<Record<string, string>>,
+  proof: ProvenWebSocketHandshake,
+): string | null {
+  const key = headers['sec-websocket-key']?.trim();
+  if (!key) return null;
+  const accept = createHash('sha1').update(`${key}${WEBSOCKET_ACCEPT_GUID}`).digest('base64');
+  const lines = [
+    'HTTP/1.1 101 Switching Protocols',
+    'Connection: Upgrade',
+    'Upgrade: websocket',
+    `Sec-WebSocket-Accept: ${accept}`,
+  ];
+  if (proof.responseProtocol) {
+    lines.push(`Sec-WebSocket-Protocol: ${proof.responseProtocol}`);
+  }
+  if (proof.responseExtensions) {
+    lines.push(`Sec-WebSocket-Extensions: ${proof.responseExtensions}`);
+  }
+  return `${lines.join('\r\n')}\r\n\r\n`;
+}
 
 /**
  * 往 per-thread 已见 id 缓存写入一条(id 去重)。有界:线程数超限 FIFO 淘汰最老
@@ -318,6 +420,7 @@ function respondRoutingFailure(
  * 状态码语义(调用方按场景选):
  *  - **426**: 让 codex 优雅退回 HTTP transport。这是它唯一认作降级信号的状态码,
  *    用于宿主主动把某个会话导回 HTTP(见 ProxyOptions.resolveWebSocketUpstream)。
+ *  - 500: resolver 配置或本地 upgrade handler 失败。
  *  - 501: 本 proxy 不支持这种 upgrade(非 websocket 协议)。
  *  - 502 / 503 / 504: 上游或本地转发失败。
  */
@@ -1804,7 +1907,7 @@ export async function createAnthropicCompatProxy(opts: ProxyOptions): Promise<Pr
     // review: Treat Kimi Code k3 as a Kimi stream)。
     const isKimiRequest =
       isRecord(parsedForRewrite) && typeof parsedForRewrite.model === 'string'
-        ? /(^|[\/_-])(kimi|k3)([\/_-]|$)/i.test(parsedForRewrite.model)
+        ? /(^|[/_-])(kimi|k3)([/_-]|$)/i.test(parsedForRewrite.model)
         : false;
 
     // per-thread 已见 id 缓存(跨请求并入 usedIds):rewind / 中断 / CLI 压缩会让
@@ -1889,6 +1992,7 @@ export async function createAnthropicCompatProxy(opts: ProxyOptions): Promise<Pr
     closeForHostFallback(): void;
   }
   const liveWebSocketConnections = new Set<LiveWebSocket>();
+  const provenWebSocketHandshakes = new Map<string, ProvenWebSocketHandshake>();
 
   /**
    * WebSocket upgrade 透传。
@@ -1896,7 +2000,8 @@ export async function createAnthropicCompatProxy(opts: ProxyOptions): Promise<Pr
    * **为什么需要**: bundled codex 的 Responses transport 自己负责 startup prewarm、
    * 连接复用、重试与 HTTP fallback。proxy 不支持 upgrade 时只能给 provider 设
    * supports_websockets=false,Cindy 就无法使用与同版本 Codex 相同的原生传输。
-   * 本层只做透明隧道,不自行解释或改写 at-capacity / 重连语义。
+   * 正常路径只做透明隧道,不解释或改写 at-capacity；宿主显式开启时，仅对已有真实 101
+   * 证明的单 thread 重连在本地保活并回探同一上游，避免瞬时断网被误判成 HTTP fallback。
    *
    * **刻意只做 socket 级透传, 不解析 WS 帧**: requestTransform / routingTransform 的
    * body 改写、recoveryRules、responseObserver 全部依赖读写一次性请求体, 而 WS 帧里
@@ -1930,12 +2035,12 @@ export async function createAnthropicCompatProxy(opts: ProxyOptions): Promise<Pr
     try {
       upstreamUrl = resolveWsUpstream({ url, headers });
     } catch (err) {
-      logger.warn?.('resolveWebSocketUpstream threw — falling back to HTTP', {
+      logger.error?.('resolveWebSocketUpstream threw', {
         reqId,
         url,
         err: String(err),
       });
-      writeUpgradeFailure(clientSocket, 426, 'Upgrade Required');
+      writeUpgradeFailure(clientSocket, 500, 'Internal Server Error');
       return;
     }
     if (!upstreamUrl) {
@@ -1947,16 +2052,17 @@ export async function createAnthropicCompatProxy(opts: ProxyOptions): Promise<Pr
       writeUpgradeFailure(clientSocket, 426, 'Upgrade Required');
       return;
     }
+    const resolvedWebSocketUpstream = upstreamUrl;
 
     let target: UpstreamTarget;
     try {
-      target = parseUpstream(upstreamUrl);
+      target = parseUpstream(resolvedWebSocketUpstream);
     } catch (err) {
-      logger.error?.('resolveWebSocketUpstream returned an unusable url — falling back to HTTP', {
+      logger.error?.('resolveWebSocketUpstream returned an unusable url', {
         reqId,
         err: String(err),
       });
-      writeUpgradeFailure(clientSocket, 426, 'Upgrade Required');
+      writeUpgradeFailure(clientSocket, 500, 'Internal Server Error');
       return;
     }
 
@@ -1966,10 +2072,25 @@ export async function createAnthropicCompatProxy(opts: ProxyOptions): Promise<Pr
     let established = false;
     let settled = false;
     let upstreamReqForEarlyClose: ClientRequest | null = null;
+    let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+    let upstreamAttempt = 0;
     // bundled Codex 0.145.0 的 startup-prewarm / reconnect 都带稳定 thread-id。
     // 真正无 scope 的非 Codex / 通用 socket 仍保留空值隔离；不能把泛用的
     // x-client-request-id 当作稳定 recovery key，误逐出其它 thread 的连接。
     const threadId = selectedHeaderValue(headers, STABLE_THREAD_ID_HEADERS);
+    const provenHandshake = opts.retryProvenWebSocketUpgrades && threadId
+      ? provenWebSocketHandshakes.get(threadId)
+      : undefined;
+    const localHandshake = provenHandshake
+      && provenWebSocketHandshakeMatchesRequest(
+        provenHandshake,
+        resolvedWebSocketUpstream,
+        url,
+        headers,
+      )
+      ? serializeProvenWebSocketHandshake(headers, provenHandshake)
+      : null;
+    const locallyAcceptedForReconnect = localHandshake !== null;
     const connection: LiveWebSocket = {
       threadId,
       clientSocket,
@@ -1984,6 +2105,10 @@ export async function createAnthropicCompatProxy(opts: ProxyOptions): Promise<Pr
     const settle = (why: string, err?: Error): void => {
       if (settled) return;
       settled = true;
+      if (reconnectTimer !== null) {
+        clearTimeout(reconnectTimer);
+        reconnectTimer = null;
+      }
       liveWebSockets -= 1;
       liveWebSocketConnections.delete(connection);
       logger.info?.('◀ websocket closed', {
@@ -2019,9 +2144,52 @@ export async function createAnthropicCompatProxy(opts: ProxyOptions): Promise<Pr
       upstreamReqForEarlyClose?.destroy();
     });
 
-    void (async () => {
-      const outbound = await resolveOutboundForTarget(target, reqId);
-      if (settled || clientSocket.destroyed) return;
+    if (locallyAcceptedForReconnect) {
+      // 暂停读取会把客户端后续 WS 帧留在有界的 socket/TCP 缓冲中；上游恢复并完成真实 101
+      // 后再 resume。不能让用户态数组无限积累离线期间的数据。
+      clientSocket.pause();
+      try {
+        clientSocket.write(localHandshake);
+        logger.info?.('websocket reconnect held by local proxy', {
+          reqId,
+          threadId,
+        });
+      } catch (err) {
+        settle('local-reconnect-handshake-error', err instanceof Error ? err : undefined);
+        clientSocket.destroy();
+        return;
+      }
+    }
+
+    const scheduleReconnectAttempt = (why: string, err?: Error): void => {
+      if (!locallyAcceptedForReconnect || settled || clientSocket.destroyed) return;
+      upstreamReqForEarlyClose = null;
+      const exponent = Math.max(0, Math.min(upstreamAttempt - 1, 8));
+      const delayMs = Math.min(
+        WEBSOCKET_RECONNECT_INITIAL_DELAY_MS * (2 ** exponent),
+        WEBSOCKET_RECONNECT_MAX_DELAY_MS,
+      );
+      logger.warn?.('websocket reconnect upstream unavailable; retrying in proxy', {
+        reqId,
+        threadId,
+        attempt: upstreamAttempt,
+        delayMs,
+        why,
+        err: err ? String(err) : undefined,
+      });
+      reconnectTimer = setTimeout(() => {
+        reconnectTimer = null;
+        startUpstreamAttempt();
+      }, delayMs);
+      reconnectTimer.unref?.();
+    };
+
+    function startUpstreamAttempt(): void {
+      upstreamAttempt += 1;
+      void (async () => {
+        const outbound = await resolveOutboundForTarget(target, reqId);
+        if (settled || clientSocket.destroyed) return;
+        let attemptSettled = false;
 
       // codex 构造 WS URL 的规则是 `base_url + "/responses"`。宿主给 codex 的 base_url
       // 常带 `/v1` 前缀(OpenAI 兼容风格), 而真上游(如 chatgpt.com/backend-api/codex)
@@ -2062,18 +2230,37 @@ export async function createAnthropicCompatProxy(opts: ProxyOptions): Promise<Pr
       });
       upstreamReqForEarlyClose = upstreamReq;
 
+      const failTransientAttempt = (
+        why: 'handshake-timeout' | 'upstream-error',
+        status: 502 | 504,
+        message: 'Bad Gateway' | 'Gateway Timeout',
+        err?: Error,
+      ): void => {
+        if (attemptSettled || established || settled) return;
+        attemptSettled = true;
+        if (locallyAcceptedForReconnect) {
+          scheduleReconnectAttempt(why, err);
+          return;
+        }
+        settle(why, err);
+        writeUpgradeFailure(clientSocket, status, message);
+      };
+
       // 握手阶段必须有独立的秒级上限(上游可能既不回 101 也不回响应)。
       // **建立成功后立刻解除**，避免任何握手 timer 误杀正常长连接。
       upstreamReq.setTimeout(WEBSOCKET_UPGRADE_TIMEOUT_MS, () => {
         logger.warn?.('upgrade handshake timed out', { reqId, path: upstreamPath });
-        if (!established && !settled) {
-          settle('handshake-timeout');
-          writeUpgradeFailure(clientSocket, 426, 'Upgrade Required');
-        }
+        failTransientAttempt('handshake-timeout', 504, 'Gateway Timeout');
         upstreamReq.destroy();
       });
 
       upstreamReq.on('upgrade', (upstreamRes, upstreamSocket: Socket, upstreamHead: Buffer) => {
+        if (attemptSettled) {
+          upstreamSocket.destroy();
+          return;
+        }
+        attemptSettled = true;
+        upstreamReqForEarlyClose = null;
         // 解除握手超时(长连接不能被它杀掉)。
         upstreamReq.setTimeout(0);
         upstreamSocket.setTimeout(0);
@@ -2087,8 +2274,34 @@ export async function createAnthropicCompatProxy(opts: ProxyOptions): Promise<Pr
           return;
         }
 
+        if (
+          locallyAcceptedForReconnect
+          && provenHandshake
+          && !provenWebSocketHandshakeMatchesResponse(provenHandshake, upstreamRes)
+        ) {
+          // 本地已经按旧协商结果回复过 101，真实上游若给出不同子协议/扩展，继续裸 pipe 会
+          // 破坏帧语义。清掉证明并断开；Codex 下一次连接回到完整透明握手。
+          provenWebSocketHandshakes.delete(threadId);
+          settle('reconnect-negotiation-changed');
+          upstreamSocket.destroy();
+          clientSocket.destroy();
+          return;
+        }
+
         established = true;
         connection.upstreamSocket = upstreamSocket;
+        if (opts.retryProvenWebSocketUpgrades) {
+          rememberProvenWebSocketHandshake(
+            provenWebSocketHandshakes,
+            threadId,
+            createProvenWebSocketHandshake(
+              resolvedWebSocketUpstream,
+              url,
+              headers,
+              upstreamRes,
+            ),
+          );
+        }
 
         // **正常关闭只记账, 绝不 destroy 对端**。
         // pipe 的默认 end:true 已经负责把 FIN 传下去, 并且会先冲完缓冲里未写出的数据;
@@ -2111,7 +2324,9 @@ export async function createAnthropicCompatProxy(opts: ProxyOptions): Promise<Pr
         upstreamSocket.on('error', abort('upstream-error'));
 
         try {
-          clientSocket.write(serializeResponseHead(upstreamRes));
+          if (!locallyAcceptedForReconnect) {
+            clientSocket.write(serializeResponseHead(upstreamRes));
+          }
           // 双向把握手时已缓冲的首包补上, 再对接。
           if (upstreamHead?.length) clientSocket.write(upstreamHead);
           if (head?.length) upstreamSocket.write(head);
@@ -2127,6 +2342,7 @@ export async function createAnthropicCompatProxy(opts: ProxyOptions): Promise<Pr
 
         upstreamSocket.pipe(clientSocket);
         clientSocket.pipe(upstreamSocket);
+        if (locallyAcceptedForReconnect) clientSocket.resume();
         logger.info?.('◀ websocket established', {
           reqId, status: upstreamRes.statusCode, live: liveWebSockets,
           upstreamHeadBytes: upstreamHead?.length ?? 0,
@@ -2138,6 +2354,12 @@ export async function createAnthropicCompatProxy(opts: ProxyOptions): Promise<Pr
       // 只写状态行会丢掉 body 里的错误详情, 排查时无从下手; 而 426 更必须准确透传 ——
       // 它是 codex 退回 HTTP transport 的信号。
       upstreamReq.on('response', (upstreamRes) => {
+        if (attemptSettled) {
+          upstreamRes.resume();
+          return;
+        }
+        attemptSettled = true;
+        upstreamReqForEarlyClose = null;
         settle('upstream-refused');
         const status = upstreamRes.statusCode ?? 502;
         logger.warn?.('upstream refused websocket upgrade', {
@@ -2146,6 +2368,15 @@ export async function createAnthropicCompatProxy(opts: ProxyOptions): Promise<Pr
           path: upstreamPath,
         });
         upstreamReq.setTimeout(0);
+        if (locallyAcceptedForReconnect) {
+          // 真实 HTTP 状态不是瞬时建连错误。由于本地已经回复 101，当前 socket 无法再补写
+          // HTTP 状态；撤销该 thread 的握手证明并断开，下一次重连走透明路径并保留原状态。
+          provenWebSocketHandshakes.delete(threadId);
+          upstreamRes.once('error', () => {});
+          upstreamRes.resume();
+          clientSocket.destroy();
+          return;
+        }
         if (shouldFallbackToHttpAfterUpgradeResponse(status)) {
           logger.info?.('websocket upgrade unsupported on current path — falling back to HTTP', {
             reqId,
@@ -2216,26 +2447,29 @@ export async function createAnthropicCompatProxy(opts: ProxyOptions): Promise<Pr
       });
 
       upstreamReq.on('error', (err) => {
-        logger.warn?.('upgrade upstream request failed — falling back to HTTP', {
+        logger.warn?.('upgrade upstream request failed', {
           reqId,
           err: String(err),
         });
-        if (!established && !settled) {
-          settle('upstream-error', err);
-          writeUpgradeFailure(clientSocket, 426, 'Upgrade Required');
-        }
+        failTransientAttempt('upstream-error', 502, 'Bad Gateway', err);
       });
 
       upstreamReq.end();
-    })().catch((err: unknown) => {
-      // 与 respondRoutingFailure 同款理由: 不让 async handler 的 rejection 漂成
-      // process-level unhandledRejection。
-      logger.error?.('websocket upgrade handler threw', { reqId, err: String(err) });
-      if (!established && !settled) {
-        settle('handler-error', err instanceof Error ? err : new Error(String(err)));
-        writeUpgradeFailure(clientSocket, 426, 'Upgrade Required');
-      }
-    });
+      })().catch((err: unknown) => {
+        // 与 respondRoutingFailure 同款理由: 不让 async handler 的 rejection 漂成
+        // process-level unhandledRejection。
+        logger.error?.('websocket upgrade handler threw', { reqId, err: String(err) });
+        if (established || settled) return;
+        const error = err instanceof Error ? err : new Error(String(err));
+        if (locallyAcceptedForReconnect) {
+          scheduleReconnectAttempt('handler-error', error);
+          return;
+        }
+        settle('handler-error', error);
+        writeUpgradeFailure(clientSocket, 500, 'Internal Server Error');
+      });
+    }
+    startUpstreamAttempt();
   });
 
   // 跟踪所有底层 socket,dispose 时强制 destroy
@@ -2250,15 +2484,25 @@ export async function createAnthropicCompatProxy(opts: ProxyOptions): Promise<Pr
 
   logger.debug?.('anthropic-compat-proxy listening', { url, upstream: opts.upstream });
 
+  const disconnectWebSocketsForThread = (threadId: string): number => {
+    const normalized = threadId.trim();
+    if (!normalized) return 0;
+    const matches = Array.from(liveWebSocketConnections)
+      .filter((connection) => connection.threadId === normalized);
+    for (const connection of matches) connection.closeForHostFallback();
+    return matches.length;
+  };
+
   return {
     url,
     disconnectWebSocketsForThread(threadId) {
+      return disconnectWebSocketsForThread(threadId);
+    },
+    forgetWebSocketStateForThread(threadId) {
       const normalized = threadId.trim();
       if (!normalized) return 0;
-      const matches = Array.from(liveWebSocketConnections)
-        .filter((connection) => connection.threadId === normalized);
-      for (const connection of matches) connection.closeForHostFallback();
-      return matches.length;
+      provenWebSocketHandshakes.delete(normalized);
+      return disconnectWebSocketsForThread(normalized);
     },
     async dispose() {
       logger.debug?.('anthropic-compat-proxy disposing', { inflight });

--- a/packages/anthropic-compat-proxy/src/types.ts
+++ b/packages/anthropic-compat-proxy/src/types.ts
@@ -271,6 +271,8 @@ export interface ProxyOptions {
    * `StatusCode::UPGRADE_REQUIRED` 分支; 其余错误一律 Err 抛出 = 用户吃报错)。
    * 而 codex 侧的降级是 **session 级**的(一个 turn 触发后同 session 后续 turn
    * 都走 HTTP), 所以一次 426 即稳定, 不会在两种传输之间抖动。
+   * resolver 抛错、返回非法 URL、上游连接失败或握手超时都属于失败而非主动降级，
+   * proxy 会返回对应 5xx，让客户端按自己的瞬时错误策略处理，不会把它们改写成 426。
    *
    * 因此 null 的语义不是"拒绝服务", 而是"这个会话走 HTTP 更合适" —— 宿主可以据此
    * 把需要 body 级能力(recoveryRules / responseObserver)的会话导回 HTTP 路径,
@@ -289,6 +291,15 @@ export interface ProxyOptions {
     readonly url: string;
     readonly headers: Readonly<Record<string, string>>;
   }) => string | null;
+  /**
+   * 对带稳定 thread id、且此前已真实完成过上游 101 的 WebSocket 重连启用 Cindy 侧保活。
+   * proxy 会先用已证明一致的协商参数接住该条客户端 socket，再以有界退避回探上游；只要
+   * 客户端仍在，就不会把瞬时网络故障暴露成会触发 session 级 HTTP 降级的握手失败。
+   *
+   * 默认关闭。Codex OAuth 宿主按需开启；首次握手、无 thread id、协商参数变化、宿主主动
+   * 返回 null 以及真实上游 HTTP 拒绝都不走这条路径。
+   */
+  retryProvenWebSocketUpgrades?: boolean;
   /**
    * 可选: debug 级别下是否 dump 入站请求 body(截断到 64KiB)。默认 false ——
    * dev 的日志级别默认 trace,若默认 dump,agent 高并发场景(code-review 扇出 +
@@ -315,6 +326,12 @@ export interface ProxyHandle {
    * 否则下一次请求会复用旧 WS，无法通过新的 upgrade 响应触发 transport fallback。
    */
   disconnectWebSocketsForThread?(threadId: string): number;
+  /**
+   * 断开指定 thread 的 WS，并清除它曾成功完成上游 101 的证明。
+   * 用于 session 关闭或切换到 HTTP-only provider；后续即使同 id 出现迟到重连，也必须先
+   * 重新走一次真实上游握手，不能继承旧路由的 Cindy 侧保活资格。
+   */
+  forgetWebSocketStateForThread?(threadId: string): number;
   /** 优雅关闭 —— close listener + 等待 in-flight 请求结束(2s 超时强关) */
   dispose(): Promise<void>;
 }


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 OAuth Codex 会话在 WebSocket 已成功可用后遇到瞬时断网，被错误降级并长期固定到 HTTP/SSE，网络恢复后仍无法回到 WebSocket、只能重启 Cindy 的问题。

代理现在按 Codex thread 记录经过真实上游 101 握手验证的 WebSocket 状态。相同 thread 在瞬时断网重连时，由 Cindy 保持本地 WebSocket 并以有界指数退避回连上游，避免向 Codex 发送会触发永久 HTTP 降级的错误信号；上游恢复后继续原连接。若上游明确以 HTTP 拒绝 WebSocket，则清除证明并恢复原有 HTTP/SSE 兼容路径。

### 变更类型

- [ ] feat 新功能
- [x] fix 缺陷修复
- [ ] refactor / perf 重构或性能优化
- [ ] docs / test / chore 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：OAuth Codex 断网恢复可靠性
- 本 PR 包含：Desktop Codex 代理启用已验证 WebSocket 的 thread 级重连；会话关闭或模型提供方切换时只清理当前会话的 WebSocket 证明和连接；补充断网恢复、真实 HTTP 拒绝、跨 thread 隔离及清理测试
- 明确不包含：不修改 Codex 二进制内部 disable_websockets；不将 OpenAI provider 永久设为 WS-only；不引入会话重建框架
- 用户可见变化：OAuth Codex 会话在网络恢复后可继续原任务，不再要求重启 Cindy；无 UI 变化
- 是否存在 breaking change：无

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

- pnpm test:unit:related
  - 结果：通过；Desktop 相关单测通过，anthropic-compat-proxy 相关单测通过
- pnpm --filter desktop run --if-present typecheck
  - 结果：通过
- pnpm --filter @cindy/anthropic-compat-proxy run --if-present typecheck
  - 结果：通过
- pnpm check:dco
  - 结果：通过；1 个提交已签名

### 手工验证

- Windows Global 隔离沙盒中，先让 OAuth Codex 会话成功建立 WebSocket，再切断网络使 WebSocket 与 HTTP 均不可用；恢复网络后，同一会话自动恢复 WebSocket 并继续执行，无需重启 Cindy。用户验收通过。

### 未执行的验证

无。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [x] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Desktop Codex 代理显式启用此能力；状态按 thread 隔离并设有 1024 条上限。未成功验证过 WebSocket 的 thread、非 OAuth 的 cindy_gateway 第三方模型以及其它代理调用不进入该恢复路径。模型提供方跨 OAuth/第三方切换时只清理当前会话状态，不影响其它会话。合法 HTTP/SSE 降级仍保留。
- 回滚 / 降级方式：回滚本 PR 即恢复旧代理行为；也可关闭 Desktop Codex 代理的 retryProvenWebSocketUpgrades 选项停用该路径。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（git commit -s，见 DCO）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次无需新增用户文档）
- [x] 已确认测试结果或说明未执行原因