### PR TITLE
fix(desktop): 优化推荐提示词发送与 Tab 交互

### DIFF
--- a/apps/desktop/src/renderer/__tests__/chatInputSteerShortcut.test.ts
+++ b/apps/desktop/src/renderer/__tests__/chatInputSteerShortcut.test.ts
@@ -50,12 +50,12 @@ describe('ChatInput steer shortcut contract', () => {
     );
     expect(windowKeydownBlock).toContain("(enterIntent === 'queue' || enterIntent === 'steer')");
     expect(windowKeydownBlock).toContain("currentState !== 'listening'");
-    expect(windowKeydownBlock).toContain('void dispatchSendRef.current(enterIntent);');
+    expect(windowKeydownBlock).toContain('void voiceInputStopAndSendRef.current(enterIntent);');
     const paletteGuard = windowComposerCaptureBlock.indexOf(
       'panelBridgeRef.current?.captureKey(event)',
     );
     const modifiedSend = windowComposerCaptureBlock.indexOf(
-      'void dispatchSendRef.current(enterIntent);',
+      'void voiceInputStopAndSendRef.current(enterIntent);',
     );
     expect(paletteGuard).toBeGreaterThan(-1);
     expect(paletteGuard).toBeLessThan(modifiedSend);
@@ -69,7 +69,7 @@ describe('ChatInput steer shortcut contract', () => {
     expect(editorEnterBlock).toContain('platform: window.electronAPI?.platform');
     expect(editorEnterBlock).toContain("if (enterIntent === 'native') return false;");
     expect(editorEnterBlock).toContain("if (enterIntent === 'ignore')");
-    expect(editorEnterBlock).toContain('void dispatchSendRef.current(enterIntent);');
+    expect(editorEnterBlock).toContain('void voiceInputStopAndSendRef.current(enterIntent);');
     // Tiptap's document is current before React's send-button effect updates
     // composerCanSubmitRef. The resolver must not use that lagging UI mirror.
     expect(windowComposerCaptureBlock).not.toContain('composerCanSubmitRef.current');

--- a/apps/desktop/src/renderer/__tests__/deviceLinkInteractionScenarios.test.ts
+++ b/apps/desktop/src/renderer/__tests__/deviceLinkInteractionScenarios.test.ts
@@ -332,9 +332,7 @@ describe('device-link Desktop-only 确认 — 控制端只读投影', () => {
     const chatInput = src.indexOf('<ChatInput', branchStart);
     expect(branchStart).toBeGreaterThan(-1);
     expect(chatInput).toBeGreaterThan(branchStart);
-    expect(src.slice(branchStart, chatInput)).not.toContain(
-      'pendingRemoteDesktopConfirmation',
-    );
+    expect(src.slice(branchStart, chatInput)).not.toContain('pendingRemoteDesktopConfirmation');
   });
 
   it.each(['issue_confirm', 'rename_sessions_confirm', 'ghost_grant_confirm'] as const)(
@@ -1014,8 +1012,10 @@ describe('远程交互接线不变式', () => {
     expect(syncEnd).toBeGreaterThan(syncStart);
     const syncBody = chatInputSrc.slice(syncStart, syncEnd);
     expect(syncBody).toContain('patchVendorPrefsPreservingModelChoice');
-    expect(syncBody).toContain('markModelChoice ? patchVendorPrefs : patchVendorPrefsPreservingModelChoice');
-    expect(syncBody).toContain("opts.markModelChoice === true");
+    expect(syncBody).toMatch(
+      /markModelChoice\s*\?\s*patchVendorPrefs\s*:\s*patchVendorPrefsPreservingModelChoice/,
+    );
+    expect(syncBody).toContain('opts.markModelChoice === true');
     expect(syncBody).toContain('markModelChoice');
     expect(syncBody).toContain('{ model: modelId, providerId: activeProviderId ?? null }');
     expect(syncBody).not.toContain(': { model: modelId }');
@@ -1032,7 +1032,7 @@ describe('远程交互接线不变式', () => {
       'markModelChoice === false ? patchVendorPrefsPreservingModelChoice : patchVendorPrefs',
     );
     expect(appSrc).toContain('model: modelId');
-    expect(appSrc).not.toContain("markModelChoice === false ? {} : { model: modelId }");
+    expect(appSrc).not.toContain('markModelChoice === false ? {} : { model: modelId }');
 
     const draftSrc = read('state/newMakerDraft.ts');
     expect(draftSrc).toContain('if (!opts.markModelChoice && modelChosen[vendor] === true)');
@@ -1183,9 +1183,7 @@ describe('远程交互接线不变式', () => {
     );
     expect(activeEffort).toBeGreaterThan(-1);
     // 没有显式目标(既有的 effort / fast 编辑入口)时仍回落当前 dlSel / seed 的档。
-    expect(body).toMatch(
-      /dlSel\?\.effort \?\? deviceLinkInitial\?\.effort/,
-    );
+    expect(body).toMatch(/dlSel\?\.effort \?\? deviceLinkInitial\?\.effort/);
     expect(payloadEffort).toBeGreaterThan(activeEffort);
   });
 
@@ -1203,7 +1201,9 @@ describe('远程交互接线不变式', () => {
     expect(pushStart).toBeGreaterThan(-1);
     const pushBody = src.slice(pushStart, pushEnd);
     expect(pushBody).toContain('target?: {');
-    expect(pushBody).toContain("const model = target?.modelId ?? dlSel?.model ?? deviceLinkInitial?.model;");
+    expect(pushBody).toContain(
+      'const model = target?.modelId ?? dlSel?.model ?? deviceLinkInitial?.model;',
+    );
     expect(pushBody).toContain('agent: target?.agent ?? capabilityAgentKind');
     expect(pushBody).toMatch(/providerId: target\s*\r?\n?\s*\?\s*\(target\.providerId \?\? ''\)/);
     // 给了目标就**只**认目标的档 —— 不许再回落到上一个模型的 dlSel.effort。

--- a/apps/desktop/src/renderer/__tests__/promptRecommendationBadge.test.ts
+++ b/apps/desktop/src/renderer/__tests__/promptRecommendationBadge.test.ts
@@ -15,13 +15,13 @@ describe('prompt recommendation shortcut badge', () => {
     );
     expect(chatInputSource).toContain('className="min-w-0 truncate"');
     expect(chatInputSource).toContain(
-      "'pointer-events-auto ml-1 inline-flex h-4 min-w-[22px] shrink-0 cursor-pointer items-center justify-center rounded-[3px] border border-current'",
+      "'pointer-events-auto ml-1 inline-flex h-4 min-w-[22px] shrink-0 cursor-pointer items-center justify-center rounded-lg border border-current'",
     );
     expect(chatInputSource).toContain(
       "'bg-transparent px-0.5 text-11 font-normal leading-none text-inherit'",
     );
     expect(chatInputSource).toContain(
-      "'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-current'",
+      "'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)]'",
     );
     expect(chatInputSource).toContain('onMouseDown={(event) => event.preventDefault()}');
     expect(chatInputSource).toContain('onClick={acceptPromptRecommendation}');

--- a/apps/desktop/src/renderer/__tests__/promptRecommendationBadge.test.ts
+++ b/apps/desktop/src/renderer/__tests__/promptRecommendationBadge.test.ts
@@ -9,11 +9,22 @@ const chatInputSource = readFileSync(
 );
 
 describe('prompt recommendation shortcut badge', () => {
-  it('keeps the prompt shrinkable while reserving space for a pill badge', () => {
-    expect(chatInputSource).toContain('className="min-w-0 flex-1 truncate"');
+  it('keeps a keycap badge beside the prompt while allowing long text to truncate', () => {
     expect(chatInputSource).toContain(
-      "'ml-1.5 inline-flex shrink-0 items-center rounded-full border'",
+      "'pointer-events-none absolute left-0 top-0 inline-flex max-w-full min-w-0 items-center py-[3px]'",
     );
+    expect(chatInputSource).toContain('className="min-w-0 truncate"');
+    expect(chatInputSource).toContain(
+      "'pointer-events-auto ml-1 inline-flex h-[18px] min-w-[24px] shrink-0 cursor-pointer items-center justify-center rounded-[4px] border border-current'",
+    );
+    expect(chatInputSource).toContain(
+      "'bg-transparent px-1 text-11 font-normal leading-none text-inherit'",
+    );
+    expect(chatInputSource).toContain(
+      "'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-current'",
+    );
+    expect(chatInputSource).toContain('onMouseDown={(event) => event.preventDefault()}');
+    expect(chatInputSource).toContain('onClick={acceptPromptRecommendation}');
   });
 
   it('uses the complete locale catalog for the visible key label', () => {

--- a/apps/desktop/src/renderer/__tests__/promptRecommendationBadge.test.ts
+++ b/apps/desktop/src/renderer/__tests__/promptRecommendationBadge.test.ts
@@ -15,10 +15,10 @@ describe('prompt recommendation shortcut badge', () => {
     );
     expect(chatInputSource).toContain('className="min-w-0 truncate"');
     expect(chatInputSource).toContain(
-      "'pointer-events-auto ml-1 inline-flex h-[18px] min-w-[24px] shrink-0 cursor-pointer items-center justify-center rounded-[4px] border border-current'",
+      "'pointer-events-auto ml-1 inline-flex h-4 min-w-[22px] shrink-0 cursor-pointer items-center justify-center rounded-[3px] border border-current'",
     );
     expect(chatInputSource).toContain(
-      "'bg-transparent px-1 text-11 font-normal leading-none text-inherit'",
+      "'bg-transparent px-0.5 text-11 font-normal leading-none text-inherit'",
     );
     expect(chatInputSource).toContain(
       "'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-current'",

--- a/apps/desktop/src/renderer/__tests__/sessionAgentSwitchRemoteRouting.test.ts
+++ b/apps/desktop/src/renderer/__tests__/sessionAgentSwitchRemoteRouting.test.ts
@@ -159,26 +159,28 @@ describe('isAgentSwitchResponseFresh（远程意图读回的新鲜度守卫）',
   };
 
   it('在途期间无人改动 → 应用读回结果', async () => {
-    const { isAgentSwitchResponseFresh } = await import('@/components/new-chat/agentSwitchConfirmation');
+    const { isAgentSwitchResponseFresh } =
+      await import('@/components/new-chat/agentSwitchConfirmation');
     expect(isAgentSwitchResponseFresh(base)).toBe(true);
   });
 
   it('effect 已清理(切走会话)→ 丢弃', async () => {
-    const { isAgentSwitchResponseFresh } = await import('@/components/new-chat/agentSwitchConfirmation');
+    const { isAgentSwitchResponseFresh } =
+      await import('@/components/new-chat/agentSwitchConfirmation');
     expect(isAgentSwitchResponseFresh({ ...base, cancelled: true })).toBe(false);
   });
 
   it('本端 ABA:点选登记后又撤销 → 写序号已变,丢弃', async () => {
-    const { isAgentSwitchResponseFresh } = await import('@/components/new-chat/agentSwitchConfirmation');
+    const { isAgentSwitchResponseFresh } =
+      await import('@/components/new-chat/agentSwitchConfirmation');
     expect(isAgentSwitchResponseFresh({ ...base, writeSeqNow: 5 })).toBe(false);
   });
 
   it('外部 ABA:另一窗口 / 被控端把意图改成非空又清回 null → 修订号已变,丢弃', async () => {
-    const { isAgentSwitchResponseFresh } = await import('@/components/new-chat/agentSwitchConfirmation');
+    const { isAgentSwitchResponseFresh } =
+      await import('@/components/new-chat/agentSwitchConfirmation');
     // 外部回流不经本端点选,writeSeq 不动;值也回到发起时的 null —— 只有修订号能识别。
-    expect(
-      isAgentSwitchResponseFresh({ ...base, writeSeqNow: 3, intentRevNow: 9 }),
-    ).toBe(false);
+    expect(isAgentSwitchResponseFresh({ ...base, writeSeqNow: 3, intentRevNow: 9 })).toBe(false);
   });
 });
 
@@ -481,7 +483,7 @@ describe('agentSwitchCoordinator（串行链与写序号按 session，跨组件�
     mod.__resetAgentSwitchCoordinatorForTests();
     return mod;
   };
-  const deferred = <T,>() => {
+  const deferred = <T>() => {
     let resolve!: (v: T) => void;
     const promise = new Promise<T>((r) => {
       resolve = r;
@@ -654,11 +656,8 @@ describe('agentSwitchCoordinator（串行链与写序号按 session，跨组件�
   });
 
   it('发送检查与登记原子化:切换在途时拒绝,外层准备 token 与共享发送边界可嵌套', async () => {
-    const {
-      beginAgentSwitchOperation,
-      hasPendingAgentSendDispatch,
-      tryBeginAgentSendDispatch,
-    } = await load();
+    const { beginAgentSwitchOperation, hasPendingAgentSendDispatch, tryBeginAgentSendDispatch } =
+      await load();
     const finishSwitch = beginAgentSwitchOperation('s1');
     expect(tryBeginAgentSendDispatch('s1')).toBeNull();
     expect(hasPendingAgentSendDispatch('s1')).toBe(false);
@@ -762,9 +761,12 @@ describe('makerChatStore 共享发送边界', () => {
     const coordinator = await import('@/lib/agentSwitchCoordinator');
     coordinator.__resetAgentSwitchCoordinatorForTests();
     let rejectRetry!: (reason: Error) => void;
-    const retryLastError = vi.fn(() => new Promise<never>((_resolve, reject) => {
-      rejectRetry = reject;
-    }));
+    const retryLastError = vi.fn(
+      () =>
+        new Promise<never>((_resolve, reject) => {
+          rejectRetry = reject;
+        }),
+    );
     vi.stubGlobal('window', {
       electronAPI: { maker: { input: { retryLastError } } },
     });
@@ -785,9 +787,12 @@ describe('makerChatStore 共享发送边界', () => {
     const coordinator = await import('@/lib/agentSwitchCoordinator');
     coordinator.__resetAgentSwitchCoordinatorForTests();
     let rejectCompact!: (reason: Error) => void;
-    const compact = vi.fn(() => new Promise<never>((_resolve, reject) => {
-      rejectCompact = reject;
-    }));
+    const compact = vi.fn(
+      () =>
+        new Promise<never>((_resolve, reject) => {
+          rejectCompact = reject;
+        }),
+    );
     vi.stubGlobal('window', { electronAPI: { maker: { input: { compact } } } });
     const { makerChatStore } = await import('@/lib/makerChatStore');
 
@@ -990,10 +995,7 @@ describe('ChatInput 的入口门控与调用路由', () => {
       compactSession,
     );
     const resumeQueue = storeSource.indexOf('function resumeQueue(');
-    const resumeBegin = storeSource.indexOf(
-      'runAgentDispatchProjectionOperation(',
-      resumeQueue,
-    );
+    const resumeBegin = storeSource.indexOf('runAgentDispatchProjectionOperation(', resumeQueue);
     const steerMessage = storeSource.indexOf('function steerMessage(');
     const steerBegin = storeSource.indexOf('return withAgentSendDispatch(', steerMessage);
     const steerQueuedMessage = storeSource.indexOf('function steerQueuedMessage(');
@@ -1095,7 +1097,10 @@ describe('ChatInput 的入口门控与调用路由', () => {
   it('切换事务返回真实结果:失败 / 被拒返 false,登记成功才返 true', () => {
     const start = source.indexOf('const performAgentSwitch = useCallback(');
     expect(start).toBeGreaterThan(-1);
-    const body = source.slice(start, source.indexOf('const performAgentSwitchRef = useRef(', start));
+    const body = source.slice(
+      start,
+      source.indexOf('const performAgentSwitchRef = useRef(', start),
+    );
     // 签名显式声明 Promise<boolean> —— 返回值是契约的一部分,不靠推断。
     expect(body).toContain('): Promise<boolean> => {');
     // 「没落地」的四个出口:无会话 / pending send 拒绝 / 会话已切走 / ack 被超车。
@@ -1156,9 +1161,15 @@ describe('ChatInput 的入口门控与调用路由', () => {
     // ★ 偏好同步同族(2026-08-19 review P2):回声已匹配时 syncSessionDraftModelPrefs 也必须
     // 用权威快照的 effort/fastMode/providerId —— 覆盖 effort-only / Fast-only / 两者均改 /
     // provider 归一化四种场景;权威快照缺某字段时该维不写,不回落本端旧值。
-    expect(source).toContain('const authoritative = registeredIntentMatchesCurrent ? registeredIntent : null;');
-    expect(source).toContain('const syncedEffort = authoritative ? authoritative.effort : newEffort;');
-    expect(source).toContain('const syncedFast = authoritative ? authoritative.fastMode : targetFast;');
+    expect(source).toContain(
+      'const authoritative = registeredIntentMatchesCurrent ? registeredIntent : null;',
+    );
+    expect(source).toContain(
+      'const syncedEffort = authoritative ? authoritative.effort : newEffort;',
+    );
+    expect(source).toContain(
+      'const syncedFast = authoritative ? authoritative.fastMode : targetFast;',
+    );
     expect(source).toContain(
       'const syncedProviderId = authoritative ? authoritative.providerId : providerId;',
     );
@@ -1182,8 +1193,7 @@ describe('ChatInput 的入口门控与调用路由', () => {
       resolve(process.cwd(), 'src/renderer/components/new-chat/ModelSelector.tsx'),
       'utf8',
     ).replace(/\r\n/g, '\n');
-    const matches =
-      selectorSource.match(/open=\{open \|\| keepOpenForAgentConfirmation\}/g) ?? [];
+    const matches = selectorSource.match(/open=\{open \|\| keepOpenForAgentConfirmation\}/g) ?? [];
     expect(matches).toHaveLength(2);
     expect(selectorSource).not.toContain('(open || keepOpenForAgentConfirmation) && !disabled');
     expect(selectorSource).not.toContain('(open && !disabled) || keepOpenForAgentConfirmation');
@@ -1193,9 +1203,7 @@ describe('ChatInput 的入口门控与调用路由', () => {
   });
 
   it('换引擎确认只认任务真实引擎,不认挂着的意图', () => {
-    expect(source).toContain(
-      'runtimeAgentKind != null && runtimeAgentKind === targetAgent',
-    );
+    expect(source).toMatch(/runtimeAgentKind != null\s*&&\s*runtimeAgentKind === targetAgent/);
     expect(source).not.toContain(
       'makerChatStore.getAgentSwitchIntent(sessionId)?.target === targetAgent',
     );
@@ -1235,8 +1243,6 @@ describe('ChatInput 的入口门控与调用路由', () => {
     expect(ensure).toContain('computeSelectedRowScrollTop');
   });
 });
-
-
 
 describe('CCAgentSessionView 上下文环压缩入口按 agent 能力分流(#1927)', () => {
   const viewSource = readFileSync(

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -2369,24 +2369,6 @@ export function ChatInput({
           return true;
         }
 
-        // Enter — 推荐可见时等同点击发送按钮：先填入推荐词，再走完整发送链。
-        // 放在 palette 之后，避免 Enter 抢走候选项确认；仅接管裸 Enter，保留
-        // Shift/Alt+Enter 换行、Cmd/Ctrl+Enter 快捷键与 IME 输入。
-        if (
-          event.key === 'Enter' &&
-          !event.shiftKey &&
-          !event.metaKey &&
-          !event.ctrlKey &&
-          !event.altKey &&
-          !event.repeat &&
-          !event.isComposing &&
-          showRecommendationRef.current
-        ) {
-          event.preventDefault();
-          void voiceInputStopAndSendRef.current();
-          return true;
-        }
-
         // Tab — 填入推荐提示词(编辑器为空 + 推荐激活 + 无修饰键)。
         // 放在 captureKey 之后:palette 打开时 Tab 归 palette。
         // 放在 cycle-permission-mode 之前:裸 Tab 不会误触 Shift+Tab 权限轮切。
@@ -2592,7 +2574,7 @@ export function ChatInput({
             void voiceInputStopAndSendRef.current(enterIntent);
             return true;
           }
-          void dispatchSendRef.current(enterIntent);
+          void voiceInputStopAndSendRef.current(enterIntent);
           return true;
         }
         return false;
@@ -3258,7 +3240,7 @@ export function ChatInput({
         if (panelBridgeRef.current?.captureKey(event)) return;
         clearPressTimer();
         voiceShortcutPressRef.current = null;
-        void dispatchSendRef.current(enterIntent);
+        void voiceInputStopAndSendRef.current(enterIntent);
         return;
       }
 
@@ -8021,8 +8003,8 @@ export function ChatInput({
                       type="button"
                       aria-label={`${t('newChat.chatInput.recommendationShortcut')}: ${recommendedPrompt ?? ''}`}
                       className={cn(
-                        'pointer-events-auto ml-1 inline-flex h-[18px] min-w-[24px] shrink-0 cursor-pointer items-center justify-center rounded-[4px] border border-current',
-                        'bg-transparent px-1 text-11 font-normal leading-none text-inherit',
+                        'pointer-events-auto ml-1 inline-flex h-4 min-w-[22px] shrink-0 cursor-pointer items-center justify-center rounded-[3px] border border-current',
+                        'bg-transparent px-0.5 text-11 font-normal leading-none text-inherit',
                         'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-current',
                       )}
                       onMouseDown={(event) => event.preventDefault()}

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -2369,6 +2369,24 @@ export function ChatInput({
           return true;
         }
 
+        // Enter — 推荐可见时等同点击发送按钮：先填入推荐词，再走完整发送链。
+        // 放在 palette 之后，避免 Enter 抢走候选项确认；仅接管裸 Enter，保留
+        // Shift/Alt+Enter 换行、Cmd/Ctrl+Enter 快捷键与 IME 输入。
+        if (
+          event.key === 'Enter' &&
+          !event.shiftKey &&
+          !event.metaKey &&
+          !event.ctrlKey &&
+          !event.altKey &&
+          !event.repeat &&
+          !event.isComposing &&
+          showRecommendationRef.current
+        ) {
+          event.preventDefault();
+          void voiceInputStopAndSendRef.current();
+          return true;
+        }
+
         // Tab — 填入推荐提示词(编辑器为空 + 推荐激活 + 无修饰键)。
         // 放在 captureKey 之后:palette 打开时 Tab 归 palette。
         // 放在 cycle-permission-mode 之前:裸 Tab 不会误触 Shift+Tab 权限轮切。

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -1121,6 +1121,7 @@ export function ChatInput({
   const recommendationRef = useRef(recommendation);
   recommendationRef.current = recommendation;
   const showRecommendationRef = useRef(false);
+  const acceptPromptRecommendationRef = useRef<() => boolean>(() => false);
   // session 切换时 ChatInput/Editor 会复用；推荐资格必须等目标草稿完成水合后再判断。
   const [composerHydrationGeneration, setComposerHydrationGeneration] = useState(0);
   // 完整输入框空判断:不仅检查 ProseMirror 文档是否为空,还检查附件、浏览器评论和语音稿。
@@ -2379,23 +2380,10 @@ export function ChatInput({
           !event.altKey &&
           !event.repeat &&
           !event.isComposing &&
-          showRecommendationRef.current &&
-          recommendedPromptRef.current &&
-          !composerMutationLockedRef.current
+          acceptPromptRecommendationRef.current()
         ) {
-          if (composerFullyEmptyRef.current()) {
-            const prompt = recommendedPromptRef.current;
-            if (!prompt) return false;
-            event.preventDefault();
-            const activeRecommendation = recommendationRef.current;
-            // 先消费 Store 条目(overlay 与正文同位置,不先撤会有一帧重叠),再插入文本。
-            showRecommendationRef.current = false;
-            if (sessionId && activeRecommendation) {
-              dismissPromptRecommendation(sessionId, activeRecommendation.revision);
-            }
-            view.dispatch(view.state.tr.insertText(prompt));
-            return true;
-          }
+          event.preventDefault();
+          return true;
         }
 
         // cycle-permission-mode (registry 默认 Shift+Tab, 用户可改绑) —— 输入框
@@ -5625,6 +5613,31 @@ export function ChatInput({
     [onQueueSteer],
   );
 
+  const acceptPromptRecommendation = useCallback((): boolean => {
+    if (
+      !editor ||
+      editor.isDestroyed ||
+      !showRecommendationRef.current ||
+      !recommendedPromptRef.current ||
+      !composerFullyEmptyRef.current() ||
+      composerMutationLockedRef.current
+    ) {
+      return false;
+    }
+    const prompt = recommendedPromptRef.current;
+    const activeRecommendation = recommendationRef.current;
+    // 与 Tab 接受保持同一消费顺序：先撤 overlay，再同步写入正文，让本次点击
+    // 复用完整发送链；若后续预检失败，推荐词仍作为普通草稿留在输入框供重试。
+    showRecommendationRef.current = false;
+    if (sessionId && activeRecommendation) {
+      dismissPromptRecommendation(sessionId, activeRecommendation.revision);
+    }
+    editor.view.dispatch(editor.state.tr.insertText(prompt));
+    editor.commands.focus('end');
+    return true;
+  }, [editor, sessionId]);
+  acceptPromptRecommendationRef.current = acceptPromptRecommendation;
+
   const handleClickSend = useCallback(
     async (deliveryMode: MessageDeliveryMode = 'queue') => {
       if (voiceBusyOnCurrentComposer) {
@@ -5654,9 +5667,11 @@ export function ChatInput({
         await stopAndSend;
         return;
       }
+      acceptPromptRecommendation();
       await dispatchSend(deliveryMode);
     },
     [
+      acceptPromptRecommendation,
       dispatchSend,
       editor,
       handleVoiceInputStop,
@@ -5826,7 +5841,9 @@ export function ChatInput({
       const markModelChoice = opts.markModelChoice === true;
       if (!remoteDeviceId) {
         const vendor = agentKind === 'codex' ? 'codex' : agentKind === 'pi' ? 'pi' : 'cc';
-        const persistPrefs = markModelChoice ? patchVendorPrefs : patchVendorPrefsPreservingModelChoice;
+        const persistPrefs = markModelChoice
+          ? patchVendorPrefs
+          : patchVendorPrefsPreservingModelChoice;
         persistPrefs(vendor, {
           // 换模才带配对并打标记。本机只改思考档 / Fast 不写回活动模型,
           // 避免未打标用户把区域默认改成当前任务模型。
@@ -6035,7 +6052,8 @@ export function ChatInput({
         hasSwitchIntent:
           !!sessionId &&
           !!targetAgent &&
-          runtimeAgentKind != null && runtimeAgentKind === targetAgent,
+          runtimeAgentKind != null &&
+          runtimeAgentKind === targetAgent,
         confirm: confirmDialog,
         copy: {
           title: t('newChat.chatInput.agentSwitch.confirmation.title'),
@@ -6612,10 +6630,7 @@ export function ChatInput({
 
       // model-only 不改变当前生效来源；effort 能力也必须按该来源精确解析，避免同 id 的
       // 内置模型档位穿进 BYOM。恢复优先级:模型预设 > 旧 per-model 记忆 > 沿用当前 > 模型默认。
-      const { efforts, defaultEffort } = resolveModelEfforts(
-        newModelId,
-        effectiveSourceId,
-      );
+      const { efforts, defaultEffort } = resolveModelEfforts(newModelId, effectiveSourceId);
       const providerEffort =
         modelMemory && currentModelAgentKind && effectiveSourceId
           ? modelMemory.getEffort(currentModelAgentKind, effectiveSourceId, newModelId)
@@ -7491,7 +7506,7 @@ export function ChatInput({
 
   const hasMessage = !isEditorEmpty(editor);
   renderSnapshotRef.current = composerRenderSnapshot(trigger, hasMessage);
-  const canSend = hasMessage || hasAttachments || browserComments.length > 0;
+  const hasComposerPayload = hasMessage || hasAttachments || browserComments.length > 0;
   const hasVoiceDraftText = voiceBusyOnCurrentComposer && voiceInput.draftText.trim().length > 0;
   // 推荐 overlay 的可见判据:开关开启 + 有推荐词 + 输入框空 + 无附件/浏览器评论/语音草稿 + 输入框未锁定。
   // composerMutationLocked 涵盖 disabled、sendDispatchInFlight、当前输入框所属语音及远程只读/锁定状态。
@@ -7510,6 +7525,8 @@ export function ChatInput({
   });
   // handleKeyDown 的稳定闭包只按真实可见性接受 Tab，避免隐藏推荐被误填入。
   showRecommendationRef.current = showRecommendationOverlay;
+  // 可见推荐本身就是一次可发送输入：按钮点击时会先把它同步写入正文，再走现有发送链。
+  const canSend = hasComposerPayload || showRecommendationOverlay;
   const [voiceReleaseToSendActive, setVoiceReleaseToSendActive] = useState(false);
   const sendButtonDisabled = Boolean(
     disabled ||
@@ -7974,23 +7991,27 @@ export function ChatInput({
                 {showRecommendationOverlay && (
                   <div
                     className={cn(
-                      'pointer-events-none absolute left-0 top-0 flex w-full min-w-0 items-center truncate py-[3px]',
+                      'pointer-events-none absolute left-0 top-0 inline-flex max-w-full min-w-0 items-center py-[3px]',
                       'text-15 leading-[1.467] font-normal',
                       'text-[var(--chat-input-placeholder-subtle)]',
                     )}
-                    aria-hidden="true"
                   >
-                    <span className="min-w-0 flex-1 truncate">{recommendedPrompt}</span>
-                    <kbd
+                    <span className="min-w-0 truncate" aria-hidden="true">
+                      {recommendedPrompt}
+                    </span>
+                    <button
+                      type="button"
+                      aria-label={`${t('newChat.chatInput.recommendationShortcut')}: ${recommendedPrompt ?? ''}`}
                       className={cn(
-                        'ml-1.5 inline-flex shrink-0 items-center rounded-full border',
-                        'border-[var(--chat-input-border)] bg-[var(--perm-code-bg)]',
-                        'px-1 py-[1px] text-11 font-normal',
-                        'text-[var(--status-bar-meta)]',
+                        'pointer-events-auto ml-1 inline-flex h-[18px] min-w-[24px] shrink-0 cursor-pointer items-center justify-center rounded-[4px] border border-current',
+                        'bg-transparent px-1 text-11 font-normal leading-none text-inherit',
+                        'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-current',
                       )}
+                      onMouseDown={(event) => event.preventDefault()}
+                      onClick={acceptPromptRecommendation}
                     >
                       {t('newChat.chatInput.recommendationShortcut')}
-                    </kbd>
+                    </button>
                   </div>
                 )}
               </div>

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -8003,9 +8003,9 @@ export function ChatInput({
                       type="button"
                       aria-label={`${t('newChat.chatInput.recommendationShortcut')}: ${recommendedPrompt ?? ''}`}
                       className={cn(
-                        'pointer-events-auto ml-1 inline-flex h-4 min-w-[22px] shrink-0 cursor-pointer items-center justify-center rounded-[3px] border border-current',
+                        'pointer-events-auto ml-1 inline-flex h-4 min-w-[22px] shrink-0 cursor-pointer items-center justify-center rounded-lg border border-current',
                         'bg-transparent px-0.5 text-11 font-normal leading-none text-inherit',
-                        'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-current',
+                        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)]',
                       )}
                       onMouseDown={(event) => event.preventDefault()}
                       onClick={acceptPromptRecommendation}

--- a/apps/desktop/src/renderer/components/new-chat/__tests__/composerPromptRecommendation.test.ts
+++ b/apps/desktop/src/renderer/components/new-chat/__tests__/composerPromptRecommendation.test.ts
@@ -88,6 +88,25 @@ describe('shouldShowComposerPromptRecommendation', () => {
     expect(CHAT_INPUT_SOURCE).toContain('onClick={acceptPromptRecommendation}');
   });
 
+  it('推荐可见时裸 Enter 与点击发送按钮走同一条发送链', () => {
+    const paletteAt = CHAT_INPUT_SOURCE.indexOf('if (bridge?.captureKey(event))');
+    const enterAt = CHAT_INPUT_SOURCE.indexOf("event.key === 'Enter'", paletteAt);
+    const tabAt = CHAT_INPUT_SOURCE.indexOf("event.key === 'Tab'", paletteAt);
+    const enterBlock = CHAT_INPUT_SOURCE.slice(enterAt, tabAt);
+
+    expect(paletteAt).toBeGreaterThanOrEqual(0);
+    expect(enterAt).toBeGreaterThan(paletteAt);
+    expect(tabAt).toBeGreaterThan(enterAt);
+    expect(enterBlock).toContain('!event.shiftKey');
+    expect(enterBlock).toContain('!event.metaKey');
+    expect(enterBlock).toContain('!event.ctrlKey');
+    expect(enterBlock).toContain('!event.altKey');
+    expect(enterBlock).toContain('!event.repeat');
+    expect(enterBlock).toContain('!event.isComposing');
+    expect(enterBlock).toContain('showRecommendationRef.current');
+    expect(enterBlock).toContain('void voiceInputStopAndSendRef.current();');
+  });
+
   it('等待目标 session 草稿水合后才判断 candidate 是否为空输入', () => {
     expect(CHAT_INPUT_SOURCE).toContain('storageKeyForDraftRef.current !== storageKey');
     expect(CHAT_INPUT_SOURCE).toContain(

--- a/apps/desktop/src/renderer/components/new-chat/__tests__/composerPromptRecommendation.test.ts
+++ b/apps/desktop/src/renderer/components/new-chat/__tests__/composerPromptRecommendation.test.ts
@@ -47,6 +47,47 @@ describe('shouldShowComposerPromptRecommendation', () => {
     expect(dismissAt).toBeLessThan(clearContentAt);
   });
 
+  it('推荐可见时启用发送，并在点击后直接作为正文发送', () => {
+    expect(CHAT_INPUT_SOURCE).toContain(
+      'const canSend = hasComposerPayload || showRecommendationOverlay;',
+    );
+
+    const acceptStart = CHAT_INPUT_SOURCE.indexOf('const acceptPromptRecommendation = useCallback');
+    const acceptEnd = CHAT_INPUT_SOURCE.indexOf('const handleClickSend = useCallback', acceptStart);
+    const acceptBlock = CHAT_INPUT_SOURCE.slice(acceptStart, acceptEnd);
+    expect(acceptStart).toBeGreaterThanOrEqual(0);
+    expect(acceptBlock).toContain('!showRecommendationRef.current');
+    expect(acceptBlock).toContain('!composerFullyEmptyRef.current()');
+    expect(acceptBlock).toContain('composerMutationLockedRef.current');
+    expect(acceptBlock).toContain('showRecommendationRef.current = false;');
+    expect(acceptBlock).toContain(
+      'dismissPromptRecommendation(sessionId, activeRecommendation.revision)',
+    );
+    expect(acceptBlock).toContain('editor.view.dispatch(editor.state.tr.insertText(prompt));');
+    expect(acceptBlock).toContain("editor.commands.focus('end');");
+    expect(acceptBlock).toContain(
+      'acceptPromptRecommendationRef.current = acceptPromptRecommendation;',
+    );
+
+    const clickStart = acceptEnd;
+    const clickEnd = CHAT_INPUT_SOURCE.indexOf(
+      'voiceInputStopAndSendRef.current = handleClickSend;',
+      clickStart,
+    );
+    const clickBlock = CHAT_INPUT_SOURCE.slice(clickStart, clickEnd);
+    expect(clickBlock.lastIndexOf('acceptPromptRecommendation();')).toBeLessThan(
+      clickBlock.lastIndexOf('await dispatchSend(deliveryMode);'),
+    );
+  });
+
+  it('键盘 Tab 与可点击 keycap 共用同一个推荐接受动作', () => {
+    expect(CHAT_INPUT_SOURCE).toContain(
+      'const acceptPromptRecommendationRef = useRef<() => boolean>(() => false);',
+    );
+    expect(CHAT_INPUT_SOURCE).toContain('acceptPromptRecommendationRef.current()');
+    expect(CHAT_INPUT_SOURCE).toContain('onClick={acceptPromptRecommendation}');
+  });
+
   it('等待目标 session 草稿水合后才判断 candidate 是否为空输入', () => {
     expect(CHAT_INPUT_SOURCE).toContain('storageKeyForDraftRef.current !== storageKey');
     expect(CHAT_INPUT_SOURCE).toContain(

--- a/apps/desktop/src/renderer/components/new-chat/__tests__/composerPromptRecommendation.test.ts
+++ b/apps/desktop/src/renderer/components/new-chat/__tests__/composerPromptRecommendation.test.ts
@@ -88,23 +88,30 @@ describe('shouldShowComposerPromptRecommendation', () => {
     expect(CHAT_INPUT_SOURCE).toContain('onClick={acceptPromptRecommendation}');
   });
 
-  it('推荐可见时裸 Enter 与点击发送按钮走同一条发送链', () => {
-    const paletteAt = CHAT_INPUT_SOURCE.indexOf('if (bridge?.captureKey(event))');
-    const enterAt = CHAT_INPUT_SOURCE.indexOf("event.key === 'Enter'", paletteAt);
-    const tabAt = CHAT_INPUT_SOURCE.indexOf("event.key === 'Tab'", paletteAt);
-    const enterBlock = CHAT_INPUT_SOURCE.slice(enterAt, tabAt);
+  it('所有配置为发送的 Enter 快捷键都与点击按钮走同一条发送链', () => {
+    const editorEnterStart = CHAT_INPUT_SOURCE.indexOf(
+      '// Resolve the configurable send shortcut after structured list handling.',
+    );
+    const editorEnterEnd = CHAT_INPUT_SOURCE.indexOf('return false;\n      },', editorEnterStart);
+    const editorEnterBlock = CHAT_INPUT_SOURCE.slice(editorEnterStart, editorEnterEnd);
+    const windowEnterStart = CHAT_INPUT_SOURCE.indexOf(
+      'const enterIntent = resolveComposerEnterIntent(',
+      editorEnterEnd,
+    );
+    const windowEnterEnd = CHAT_INPUT_SOURCE.indexOf(
+      "if (\n        currentState === 'listening'",
+      windowEnterStart,
+    );
+    const windowEnterBlock = CHAT_INPUT_SOURCE.slice(windowEnterStart, windowEnterEnd);
 
-    expect(paletteAt).toBeGreaterThanOrEqual(0);
-    expect(enterAt).toBeGreaterThan(paletteAt);
-    expect(tabAt).toBeGreaterThan(enterAt);
-    expect(enterBlock).toContain('!event.shiftKey');
-    expect(enterBlock).toContain('!event.metaKey');
-    expect(enterBlock).toContain('!event.ctrlKey');
-    expect(enterBlock).toContain('!event.altKey');
-    expect(enterBlock).toContain('!event.repeat');
-    expect(enterBlock).toContain('!event.isComposing');
-    expect(enterBlock).toContain('showRecommendationRef.current');
-    expect(enterBlock).toContain('void voiceInputStopAndSendRef.current();');
+    expect(editorEnterStart).toBeGreaterThanOrEqual(0);
+    expect(editorEnterBlock).toContain("if (enterIntent === 'native') return false;");
+    expect(editorEnterBlock).toContain('void voiceInputStopAndSendRef.current(enterIntent);');
+    expect(editorEnterBlock).not.toContain('void dispatchSendRef.current(enterIntent);');
+    expect(windowEnterStart).toBeGreaterThan(editorEnterEnd);
+    expect(windowEnterBlock).toContain('panelBridgeRef.current?.captureKey(event)');
+    expect(windowEnterBlock).toContain('void voiceInputStopAndSendRef.current(enterIntent);');
+    expect(windowEnterBlock).not.toContain('void dispatchSendRef.current(enterIntent);');
   });
 
   it('等待目标 session 草稿水合后才判断 candidate 是否为空输入', () => {

--- a/apps/desktop/src/renderer/lib/__tests__/providerModelEfforts.test.ts
+++ b/apps/desktop/src/renderer/lib/__tests__/providerModelEfforts.test.ts
@@ -146,7 +146,7 @@ describe('resolveProviderModelEfforts', () => {
       'resolveModelEfforts(\n          newModelId,\n          providerId,\n          targetAgentKind,\n        )',
     );
     expect(source.slice(modelChangeStart, modelChangeEnd)).toMatch(
-      /resolveModelEfforts\(\s*newModelId,\s*effectiveSourceId,\s*\)/,
+      /resolveModelEfforts\(\s*newModelId,\s*effectiveSourceId,?\s*\)/,
     );
     expect(source.slice(providerChangeStart, providerChangeEnd)).toContain(
       '{ effort: eff, fastMode: restoredFast }',


### PR DESCRIPTION
## 这次改了什么

### 摘要

优化 Desktop 输入框里的推荐提示词交互：推荐词可见时发送按钮保持可用，点击发送会直接消费并发送该推荐词；当前配置判定为发送的 Enter 快捷键也复用发送按钮的完整路径。选择 `modifier-enter` 时，裸 Enter 仍保持原生换行。

Tab 提示改为紧跟推荐文字的可点击键帽，点击或按物理 Tab 都只填入完整推荐词而不发送；键帽进一步缩小为更轻量的键盘按键造型，颜色继续与提示文字一致；圆角使用已登记的 8px inner-control 层级，键盘焦点使用主题无关的 Focus Blue。

同时将 3 条读取 `ChatInput.tsx` 源码的测试断言改为忽略 Prettier 造成的空白与换行差异，不放宽原有语义检查。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：用户反馈，无关联 Issue
- 本 PR 包含：Desktop Renderer 推荐提示词的按钮/Enter 发送、Tab 接受、Tab 按钮布局与样式，以及相关单测
- 明确不包含：Mobile、服务端、推荐提示词生成策略
- 用户可见变化：推荐词可通过发送按钮或当前发送快捷键直接发送；Tab 键帽紧跟推荐文字并可点击填入，尺寸更小
- 是否存在 breaking change：无

### UI 变化

- macOS Global 隔离开发版已完成前两轮交互的手工确认；最新 Tab 尺寸、Enter 收口与规范化焦点态未重新手工目检。
- 引用的设计规范：
  - `docs/design-rules/DESIGN.md` §2 Color System：键帽聚焦时使用 `--focus-ring` 的主题无关 Focus Blue。
  - `docs/design-rules/DESIGN.md` §3 Typography：沿用 `text-11` 字号 token，不新增任意字号。
  - `docs/design-rules/DESIGN.md` §4 Inputs：推荐文字继续使用输入框的弱提示层级，避免误读为已输入正文。
  - `docs/design-rules/DESIGN.md` §5 Border Radius：键帽使用已登记的 `rounded-lg`（8px inner-control）层级，不使用任意圆角。
  - `docs/design-rules/DESIGN.md` §10 Theme System & Token Reference：颜色使用现有语义 token，并通过 `text-inherit` / `border-current` 与推荐文字保持一致，自动适配 Light / Dark 主题。

## 怎么验证的

### 自动验证

```text
pnpm --dir apps/desktop exec vitest run --pool=threads --maxWorkers=1 \
  src/renderer/__tests__/promptRecommendationBadge.test.ts \
  src/renderer/components/new-chat/__tests__/composerPromptRecommendation.test.ts \
  src/renderer/__tests__/deviceLinkInteractionScenarios.test.ts \
  src/renderer/__tests__/sessionAgentSwitchRemoteRouting.test.ts \
  src/renderer/lib/__tests__/providerModelEfforts.test.ts
结果：5 个文件、155 项测试通过

pnpm --dir apps/desktop exec vitest run --pool=threads --maxWorkers=1 \
  src/renderer/components/new-chat/__tests__/composerPromptRecommendation.test.ts \
  src/renderer/__tests__/promptRecommendationBadge.test.ts \
  src/renderer/__tests__/chatInputSteerShortcut.test.ts \
  src/renderer/__tests__/voiceInputEnterToSend.test.ts \
  src/renderer/__tests__/chatInputListContinuation.test.ts
结果：5 个文件、38 项测试通过；覆盖发送快捷键、modifier-enter 裸 Enter 换行、IME、长按重复、palette 与列表换行边界

pnpm --dir apps/desktop exec vitest run --pool=threads --maxWorkers=1 \
  src/renderer/__tests__/promptRecommendationBadge.test.ts \
  src/renderer/components/new-chat/__tests__/composerPromptRecommendation.test.ts
结果：2 个文件、17 项测试通过；覆盖键帽圆角、Focus Blue 焦点环与推荐词显示/接受路径

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm test:unit:related
结果：通过，apps/desktop unit 通过

pnpm exec prettier --check <本 PR 修改的 7 个文件>
结果：通过

pnpm check:dco
结果：通过，4 个提交均已签名

bash /Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh \
  /Users/dash/Code/Cindy/cindy-send-suggested-prompt
结果：此前完整门禁 2124/2125 个测试文件通过、28481 项测试通过；仅
src/main/cindy-brain/__tests__/ghostInstallReceipt.test.ts 的 2 项既有失败。
同样的 2 项失败已在干净 origin/main（67afe491）上定向复现，与本 PR 无关。
```

### 手工验证

- 环境：macOS、Global、隔离开发版 `send-suggested-prompt-e1ac09`，启动结果 `DESKTOP_DEV_VERDICT=ready`
- 已验证推荐词可见时发送按钮可点击，点击后直接发送推荐词
- 已验证上一版 Tab 键帽位置、方形键盘造型与文字同色
- 已验证点击 Tab 只填入完整推荐词、不发送，并保持输入框焦点
- 用户已确认此前发送按钮与 Tab 的视觉、点击效果

### 未执行的验证

- 未单独切换到另一套 Light / Dark 模式做实机目检；实现仅使用现有语义 token 与继承色，未新增硬编码颜色。
- 最新缩小并对齐设计规范后的 Tab 键帽，以及 Enter 快捷键复用发送路径与 `modifier-enter` 裸 Enter 换行，已完成自动验证，尚未在开发版中重新手工操作确认。
- 最新提交未重新跑完整单测门禁；相关单测门禁已通过。此前完整门禁仅剩上文已在干净 `origin/main` 复现的 2 项基线失败，等待 CI 在当前环境复核。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Desktop Renderer 的输入框推荐提示词交互与对应测试
- 回滚 / 降级方式：revert 本 PR 的 4 个提交即可恢复原行为

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因


