### PR TITLE
fix(desktop): 显示可读的本机设备名称

### DIFF
--- a/apps/desktop/src/renderer/__tests__/mobileDownloadDialog.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/mobileDownloadDialog.test.tsx
@@ -202,7 +202,7 @@ describe('resolveMobileRemotePresentation', () => {
       remoteEnabled: false,
       linkedMobileCount: 0,
       otherDeviceCount: 0,
-      selfDeviceId: 'desktop-device-1',
+      selfDeviceName: 'Studio Mac',
     });
     expect(
       resolveMobileRemotePresentation({
@@ -242,7 +242,7 @@ describe('resolveMobileRemotePresentation', () => {
       remoteEnabled: true,
       linkedMobileCount: 1,
       otherDeviceCount: 1,
-      selfDeviceId: 'desktop-device-1',
+      selfDeviceName: 'Studio Mac',
       linkedMobileName: 'My iPhone',
     });
   });
@@ -279,7 +279,7 @@ describe('resolveMobileRemotePresentation', () => {
     ).toMatchObject({
       layout: 'checking',
       remoteEnabled: true,
-      selfDeviceId: null,
+      selfDeviceName: null,
     });
   });
 });
@@ -425,7 +425,8 @@ describe('MobileDownloadDialog', () => {
 
     expect(await screen.findByText('sidebar.mobileDownload.myDevices')).toBeTruthy();
     expect(screen.getByText('My iPhone')).toBeTruthy();
-    expect(screen.getByText('sidebar.mobileDownload.deviceId')).toBeTruthy();
+    expect(screen.getByTitle('Studio Mac')).toBeTruthy();
+    expect(screen.getByText('sidebar.mobileDownload.deviceName')).toBeTruthy();
     expect(screen.getByTestId('mobile-download-qr-card').dataset.compact).toBe('true');
     fireEvent.click(screen.getByRole('button', { name: /sidebar\.mobileDownload\.myDevices/ }));
     expect(onOpenDevices).toHaveBeenCalledTimes(1);

--- a/apps/desktop/src/renderer/components/sidebar/MobileDownloadDialog.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/MobileDownloadDialog.tsx
@@ -33,7 +33,7 @@ export interface MobileRemotePresentation {
   remoteEnabled: boolean;
   linkedMobileCount: number;
   otherDeviceCount: number;
-  selfDeviceId: string | null;
+  selfDeviceName: string | null;
   linkedMobileName: string | null;
   previewDevices: DeviceLinkDeviceView[];
 }
@@ -56,7 +56,7 @@ export function resolveMobileRemotePresentation(
       remoteEnabled: snapshot.enabled,
       linkedMobileCount: 0,
       otherDeviceCount: 0,
-      selfDeviceId: null,
+      selfDeviceName: null,
       linkedMobileName: null,
       previewDevices: [],
     };
@@ -81,7 +81,7 @@ export function resolveMobileRemotePresentation(
     remoteEnabled: snapshot.enabled,
     linkedMobileCount: linkedMobileDevices.length,
     otherDeviceCount: otherDevices.length,
-    selfDeviceId: selfDevice?.deviceId ?? null,
+    selfDeviceName: selfDevice?.name ?? null,
     linkedMobileName: linkedMobileDevices[0]?.name ?? null,
     previewDevices,
   };
@@ -593,13 +593,13 @@ export function MobileDownloadDialog({
                   <span className="text-13 font-medium leading-[1.385] text-[var(--confirm-title)]">
                     {t('sidebar.mobileDownload.allowControl')}
                   </span>
-                  {remotePresentation?.selfDeviceId ? (
+                  {remotePresentation?.selfDeviceName ? (
                     <span
-                      className="mt-0.5 truncate font-mono text-10 leading-[1.4] text-[var(--confirm-desc)]"
-                      title={remotePresentation.selfDeviceId}
+                      className="mt-0.5 truncate text-11 leading-[1.4] text-[var(--confirm-desc)]"
+                      title={remotePresentation.selfDeviceName}
                     >
-                      {t('sidebar.mobileDownload.deviceId', {
-                        id: remotePresentation.selfDeviceId,
+                      {t('sidebar.mobileDownload.deviceName', {
+                        name: remotePresentation.selfDeviceName,
                       })}
                     </span>
                   ) : null}

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -6310,7 +6310,7 @@
       "myDevices": "My Devices",
       "deviceOffline": "Offline",
       "allowControl": "Allow same-account devices to control this machine",
-      "deviceId": "This device · {{id}}",
+      "deviceName": "This device · {{name}}",
       "remoteAction": {
         "checking": "Checking…",
         "unavailable": "Unavailable",

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -6308,7 +6308,7 @@
       "myDevices": "自分のデバイス",
       "deviceOffline": "オフライン",
       "allowControl": "同じアカウントのデバイスによるこのマシンの操作を許可",
-      "deviceId": "このデバイス · {{id}}",
+      "deviceName": "このデバイス · {{name}}",
       "remoteAction": {
         "checking": "確認中…",
         "unavailable": "利用できません",

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -6308,7 +6308,7 @@
       "myDevices": "내 기기",
       "deviceOffline": "오프라인",
       "allowControl": "동일 계정 기기에서 이 컴퓨터를 제어하도록 허용",
-      "deviceId": "이 기기 · {{id}}",
+      "deviceName": "이 기기 · {{name}}",
       "remoteAction": {
         "checking": "확인 중…",
         "unavailable": "사용할 수 없음",

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -6308,7 +6308,7 @@
       "myDevices": "我的设备",
       "deviceOffline": "离线",
       "allowControl": "允许同账号设备控制本机",
-      "deviceId": "本机 · {{id}}",
+      "deviceName": "本机 · {{name}}",
       "remoteAction": {
         "checking": "正在检查…",
         "unavailable": "暂不可用",

--- a/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
@@ -6308,7 +6308,7 @@
       "myDevices": "我的裝置",
       "deviceOffline": "離線",
       "allowControl": "允許同帳號裝置控制本機",
-      "deviceId": "本機 · {{id}}",
+      "deviceName": "本機 · {{name}}",
       "remoteAction": {
         "checking": "正在檢查…",
         "unavailable": "暫不可用",


### PR DESCRIPTION
## 这次改了什么

### 摘要

下载手机版弹窗原来把本机内部 `deviceId` 作为“本机 · …”展示，用户看到的是不可读的设备 UUID。现在改为复用远程连接设置页同一份设备列表中的可读 `self.name`，并同步更新五种语言的 i18n key。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护

### 范围

- 关联 Issue / 需求：用户反馈下载手机版弹窗显示本机 UUID，不易理解。
- 本 PR 包含：Desktop 下载手机版弹窗的本机设备名称展示、五语 i18n key、相关渲染测试。
- 明确不包含：device-link 协议、IPC、设备命名服务端逻辑、Mobile 原生代码。
- 用户可见变化：底部设置卡片显示“本机 · 可读设备名”，不再显示 UUID。
- 是否存在 breaking change：无。

### UI 变化

- 引用的设计规范：`docs/design-rules/DESIGN.md` §3 Typography Rules（等宽字体只用于代码内容，设备名使用普通 UI 字体）；§4 Dialog & Modal（沿用现有弹窗容器与间距）；§10 Light / Dark Dual-Mode Delivery Gate（继续使用语义颜色 token，亮色与暗色布局共用）。
- 截图：未附，本次沿用现有弹窗布局，仅替换设备标识字段与字体语义。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/renderer/__tests__/mobileDownloadDialog.test.tsx
结果：通过，26/26。

pnpm --filter desktop typecheck
结果：通过。

pnpm check:i18n
结果：通过，5 种语言 8145 个 key 一致；仅有仓库既有警告。

pnpm check:i18n-glossary
结果：通过；仅有仓库既有 proposed 术语警告。

pnpm check:dco
结果：通过，1 个 commit 已签名。

bash /Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh /Users/dash/Code/Cindy/cindy-readable-local-device-name
结果：未全绿。Desktop 2125 个测试文件中 2124 个通过，2 条失败均来自未改动的 `src/main/cindy-brain/__tests__/ghostInstallReceipt.test.ts`；失败断言为既有 receipt 校验返回 `state: invalid`。Mobile 与其它 packages 通过。
```

### 手工验证

未执行 Desktop 实机启动；已通过 jsdom 渲染测试覆盖设备名展示。

### 未执行的验证

未在 macOS / Windows 实机分别目检弹窗；改动只使用现有语义 token 与布局，不涉及平台特有代码。

## 风险

### 风险分类

- [x] 无已知功能风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：本地统一 unit gate 被未改动的 GhostInstallReceipt 基线测试阻塞，详见验证结果。

### 影响与回滚

- 影响范围：Desktop 侧栏“下载 Cindy 移动端”弹窗中的本机信息副标题。
- 回滚 / 降级方式：回退本 PR commit 即恢复原展示逻辑；不涉及数据迁移或协议变化。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
