### PR TITLE
fix(maker-core): Codex exec yield 后产品 turn 不再假完成

### DIFF
--- a/docs/dev-rules/maker-core-and-agent-behavior.md
+++ b/docs/dev-rules/maker-core-and-agent-behavior.md
@@ -81,6 +81,9 @@ timeout 不得触发自动换窗或 replay。Codex 当前没有与 Claude `AutoC
   判据；cell 跨 turn 存活性未证实前，续段失败必须诚实报 lost-handle，不得 replay 原请求
   或重跑已执行命令。续段 claim 一旦挡住产品结束，所有非重试终态错误路径（不限
   transport）都必须同步结算它，不能只推 Done 而让 `isTurnRunning()` 仍为 true。
+  续段 `turn/start` 已被服务端接受后若本地取消，必须先凭响应里的 turn id 落墓碑并
+  best-effort interrupt，再抛/返回取消；`wait` 仍输出 running marker 视为 cell
+  存活证据，重试预算内继续等，不得当空续段报 lost-handle。
   Claude wake continuation 与 Codex yield continuation 先分账，不抽公共模块。
 
 ## 3. 守住四项核心数据指标

--- a/docs/dev-rules/maker-core-and-agent-behavior.md
+++ b/docs/dev-rules/maker-core-and-agent-behavior.md
@@ -85,8 +85,8 @@ timeout 不得触发自动换窗或 replay。Codex 当前没有与 Claude `AutoC
   best-effort interrupt，再抛/返回取消；`wait` 仍输出 running marker 视为 cell
   存活证据，重试预算内继续等，不得当空续段报 lost-handle。
   claim 只归属于铸造它的 origin turn 及其续段 turn；迟到的外族终态（含成功
-  `completed`）不得结算、取消、lost-handle 当前 claim，也不得发出未认领的
-  产品 `done`。同一产品 turn 上的
+  `completed`）不得结算、取消、lost-handle 当前 claim，不得发出未认领的
+  产品 `done`，也不得结算当前续段的 generation／usage。同一产品 turn 上的
   ask_user／plan 内部续段必须等 yield 空闲后再 `turn/start`，不得并发；Stop／
   close 取消 yield 时，排队中的内部续段必须退出而不是被当成正常空闲继续发送。
   只有 cell 真正结算的成功空闲才能唤醒排队续段；lost-handle、重试耗尽、

--- a/docs/dev-rules/maker-core-and-agent-behavior.md
+++ b/docs/dev-rules/maker-core-and-agent-behavior.md
@@ -75,7 +75,9 @@ timeout 不得触发自动换窗或 replay。Codex 当前没有与 Claude `AutoC
   结算 usage；只有原子挂在该终态边界上的显式 continuation claim 才能挡住产品结束。
   Codex `functions.exec` yield 没有协议级 execution handle（cell / wait 活在
   `codex-rs` daemon），近期检测只能是 adapter 内、用真实 rollout fixture 锁死的启发式，
-  用来铸造有界 claim，再由宿主确定性开续段让模型 wait 同一 cell。同 turn 或续段里
+  用来铸造有界 claim，再由宿主确定性开续段让模型 wait 同一 cell。无 `id`／`call_id`
+  的 item 只认 `itemCompleted` 快照：`itemUpdated` 不得入账，无 yield marker 的完成
+  必须清掉匿名桶，不得给匿名条目发明身份。同 turn 或续段里
   后续 `wait` 输出 `Script completed` / `Script terminated` 后视为该 cell 已结算，不得
   再铸 claim，也不得报 lost-handle。禁止把 `last_agent_message == null` 或开场白当结算
   判据；cell 跨 turn 存活性未证实前，续段失败必须诚实报 lost-handle，不得 replay 原请求

--- a/docs/dev-rules/maker-core-and-agent-behavior.md
+++ b/docs/dev-rules/maker-core-and-agent-behavior.md
@@ -85,7 +85,8 @@ timeout 不得触发自动换窗或 replay。Codex 当前没有与 Claude `AutoC
   best-effort interrupt，再抛/返回取消；`wait` 仍输出 running marker 视为 cell
   存活证据，重试预算内继续等，不得当空续段报 lost-handle。
   claim 只归属于铸造它的 origin turn 及其续段 turn；迟到的外族终态（含成功
-  `completed`）不得结算、取消或 lost-handle 当前 claim。同一产品 turn 上的
+  `completed`）不得结算、取消、lost-handle 当前 claim，也不得发出未认领的
+  产品 `done`。同一产品 turn 上的
   ask_user／plan 内部续段必须等 yield 空闲后再 `turn/start`，不得并发；Stop／
   close 取消 yield 时，排队中的内部续段必须退出而不是被当成正常空闲继续发送。
   Claude wake continuation 与 Codex yield continuation 先分账，不抽公共模块。

--- a/docs/dev-rules/maker-core-and-agent-behavior.md
+++ b/docs/dev-rules/maker-core-and-agent-behavior.md
@@ -79,8 +79,9 @@ timeout 不得触发自动换窗或 replay。Codex 当前没有与 Claude `AutoC
   后续 `wait` 输出 `Script completed` / `Script terminated` 后视为该 cell 已结算，不得
   再铸 claim，也不得报 lost-handle。禁止把 `last_agent_message == null` 或开场白当结算
   判据；cell 跨 turn 存活性未证实前，续段失败必须诚实报 lost-handle，不得 replay 原请求
-  或重跑已执行命令。Claude wake continuation 与 Codex yield continuation 先分账，不抽
-  公共模块。
+  或重跑已执行命令。续段 claim 一旦挡住产品结束，所有非重试终态错误路径（不限
+  transport）都必须同步结算它，不能只推 Done 而让 `isTurnRunning()` 仍为 true。
+  Claude wake continuation 与 Codex yield continuation 先分账，不抽公共模块。
 
 ## 3. 守住四项核心数据指标
 

--- a/docs/dev-rules/maker-core-and-agent-behavior.md
+++ b/docs/dev-rules/maker-core-and-agent-behavior.md
@@ -77,9 +77,12 @@ timeout 不得触发自动换窗或 replay。Codex 当前没有与 Claude `AutoC
   `codex-rs` daemon），近期检测只能是 adapter 内、用真实 rollout fixture 锁死的启发式，
   用来铸造有界 claim，再由宿主确定性开续段让模型 wait 同一 cell。无 `id`／`call_id`
   的 item 只认 `itemCompleted` 快照：`itemUpdated` 不得入账，无 yield marker 的完成
-  必须清掉匿名桶，不得给匿名条目发明身份。同 turn 或续段里
+  必须清掉匿名桶，不得给匿名条目发明身份。匿名 `wait` 若按 `cell_id` 结算了其中一个
+  cell，只从匿名桶拿掉该 cell，不得清空仍在跑的其它匿名 cell。同 turn 或续段里
   后续 `wait` 输出 `Script completed` / `Script terminated` 后视为该 cell 已结算，不得
-  再铸 claim，也不得报 lost-handle。禁止把 `last_agent_message == null` 或开场白当结算
+  再铸 claim，也不得报 lost-handle。Plan Mode 审批只在产品终态跑：存在 awaiting
+  yield claim 时不得把空计划当循环结束，也不得在 SDK `turn/completed` 上提前挂审批；
+  origin 已产出的计划挂在 claim 上，续段结算后再审。禁止把 `last_agent_message == null` 或开场白当结算
   判据；cell 跨 turn 存活性未证实前，续段失败必须诚实报 lost-handle，不得 replay 原请求
   或重跑已执行命令。续段 claim 一旦挡住产品结束，所有非重试终态错误路径（不限
   transport）都必须同步结算它，不能只推 Done 而让 `isTurnRunning()` 仍为 true。

--- a/docs/dev-rules/maker-core-and-agent-behavior.md
+++ b/docs/dev-rules/maker-core-and-agent-behavior.md
@@ -99,9 +99,10 @@ timeout 不得触发自动换窗或 replay。Codex 当前没有与 Claude `AutoC
   `waitForYieldContinuationIdle()`，同时收掉未完成的 ask_user／plan 卡，不得在用户
   已看到失败后再开 ask_user／plan turn。续段启动失败的产品终态只由续段层
   发送一次（`yield-continuation-start-failed`），`handle.send` 不得再发一组
-  通用终态。continuation 的 `turn/start` 已被服务端接受后若本地 Stop，即使
-  `turnStarted` 已激活、随后 `interrupted` 被墓碑吞掉，也必须发出一条未认领的
-  cancelled `done`，避免 Session 仍握着 `currentTurnAttemptToken`。
+  通用终态。continuation 的 `turn/start` 已被服务端接受、但 RPC 仍 pending 时若
+  本地 Stop，墓碑会吞掉随后的 `interrupted`，必须补一条未认领 cancelled `done`，
+  避免 Session 仍握着 `currentTurnAttemptToken`。RPC 已返回后由 provider
+  `interrupted` 发唯一产品 Done，abort 不得再合成一条。
   续段必须继承铸造 claim 时的 origin 上下文：`turnPermissionPolicy`、
   capability selection 与 auto-review intent。不得把无人值守只读边界重置成普通
   Auto，也不得用固定 wait 提示覆盖原请求的能力选择或审查意图。

--- a/docs/dev-rules/maker-core-and-agent-behavior.md
+++ b/docs/dev-rules/maker-core-and-agent-behavior.md
@@ -76,8 +76,8 @@ timeout 不得触发自动换窗或 replay。Codex 当前没有与 Claude `AutoC
   Codex `functions.exec` yield 没有协议级 execution handle（cell / wait 活在
   `codex-rs` daemon），近期检测只能是 adapter 内、用真实 rollout fixture 锁死的启发式，
   用来铸造有界 claim，再由宿主确定性开续段让模型 wait 同一 cell。无 `id`／`call_id`
-  的 item 只认 `itemCompleted` 快照：`itemUpdated` 不得入账，无 yield marker 的完成
-  必须清掉匿名桶，不得给匿名条目发明身份。匿名 `wait` 若按 `cell_id` 结算了其中一个
+  的 item 只认 `itemCompleted` 快照：`itemUpdated` 不得入账，不得给匿名条目发明身份。
+  无 yield marker 的 nameless 完成不得清匿名桶；匿名 `wait` 若按 `cell_id` 结算了其中一个
   cell，只从匿名桶拿掉该 cell，不得清空仍在跑的其它匿名 cell。同 turn 或续段里
   后续 `wait` 输出 `Script completed` / `Script terminated` 后视为该 cell 已结算，不得
   再铸 claim，也不得报 lost-handle。Plan Mode 审批只在产品终态跑：存在 awaiting

--- a/docs/dev-rules/maker-core-and-agent-behavior.md
+++ b/docs/dev-rules/maker-core-and-agent-behavior.md
@@ -89,6 +89,11 @@ timeout 不得触发自动换窗或 replay。Codex 当前没有与 Claude `AutoC
   产品 `done`。同一产品 turn 上的
   ask_user／plan 内部续段必须等 yield 空闲后再 `turn/start`，不得并发；Stop／
   close 取消 yield 时，排队中的内部续段必须退出而不是被当成正常空闲继续发送。
+  只有 cell 真正结算的成功空闲才能唤醒排队续段；lost-handle、重试耗尽、
+  续段 `turn/start` 失败等产品失败必须以 cancelled 释放 waiter，不得在用户
+  已看到失败后再开 ask_user／plan turn。续段启动失败的产品终态只由续段层
+  发送一次（`yield-continuation-start-failed`），`handle.send` 不得再发一组
+  通用终态。
   续段必须继承铸造 claim 时的 `turnPermissionPolicy`，不得把无人值守只读边界
   重置成普通 Auto。
   Claude wake continuation 与 Codex yield continuation 先分账，不抽公共模块。

--- a/docs/dev-rules/maker-core-and-agent-behavior.md
+++ b/docs/dev-rules/maker-core-and-agent-behavior.md
@@ -84,6 +84,9 @@ timeout 不得触发自动换窗或 replay。Codex 当前没有与 Claude `AutoC
   续段 `turn/start` 已被服务端接受后若本地取消，必须先凭响应里的 turn id 落墓碑并
   best-effort interrupt，再抛/返回取消；`wait` 仍输出 running marker 视为 cell
   存活证据，重试预算内继续等，不得当空续段报 lost-handle。
+  claim 只归属于铸造它的 origin turn 及其续段 turn；迟到的外族 `failed`／
+  `interrupted` 不得取消当前 claim。同一产品 turn 上的 ask_user／plan 内部续段
+  必须等 yield 空闲后再 `turn/start`，不得并发。
   Claude wake continuation 与 Codex yield continuation 先分账，不抽公共模块。
 
 ## 3. 守住四项核心数据指标

--- a/docs/dev-rules/maker-core-and-agent-behavior.md
+++ b/docs/dev-rules/maker-core-and-agent-behavior.md
@@ -84,9 +84,10 @@ timeout 不得触发自动换窗或 replay。Codex 当前没有与 Claude `AutoC
   续段 `turn/start` 已被服务端接受后若本地取消，必须先凭响应里的 turn id 落墓碑并
   best-effort interrupt，再抛/返回取消；`wait` 仍输出 running marker 视为 cell
   存活证据，重试预算内继续等，不得当空续段报 lost-handle。
-  claim 只归属于铸造它的 origin turn 及其续段 turn；迟到的外族 `failed`／
-  `interrupted` 不得取消当前 claim。同一产品 turn 上的 ask_user／plan 内部续段
-  必须等 yield 空闲后再 `turn/start`，不得并发。
+  claim 只归属于铸造它的 origin turn 及其续段 turn；迟到的外族终态（含成功
+  `completed`）不得结算、取消或 lost-handle 当前 claim。同一产品 turn 上的
+  ask_user／plan 内部续段必须等 yield 空闲后再 `turn/start`，不得并发；Stop／
+  close 取消 yield 时，排队中的内部续段必须退出而不是被当成正常空闲继续发送。
   Claude wake continuation 与 Codex yield continuation 先分账，不抽公共模块。
 
 ## 3. 守住四项核心数据指标

--- a/docs/dev-rules/maker-core-and-agent-behavior.md
+++ b/docs/dev-rules/maker-core-and-agent-behavior.md
@@ -89,6 +89,8 @@ timeout 不得触发自动换窗或 replay。Codex 当前没有与 Claude `AutoC
   产品 `done`。同一产品 turn 上的
   ask_user／plan 内部续段必须等 yield 空闲后再 `turn/start`，不得并发；Stop／
   close 取消 yield 时，排队中的内部续段必须退出而不是被当成正常空闲继续发送。
+  续段必须继承铸造 claim 时的 `turnPermissionPolicy`，不得把无人值守只读边界
+  重置成普通 Auto。
   Claude wake continuation 与 Codex yield continuation 先分账，不抽公共模块。
 
 ## 3. 守住四项核心数据指标

--- a/docs/dev-rules/maker-core-and-agent-behavior.md
+++ b/docs/dev-rules/maker-core-and-agent-behavior.md
@@ -102,8 +102,9 @@ timeout 不得触发自动换窗或 replay。Codex 当前没有与 Claude `AutoC
   通用终态。continuation 的 `turn/start` 已被服务端接受后若本地 Stop，即使
   `turnStarted` 已激活、随后 `interrupted` 被墓碑吞掉，也必须发出一条未认领的
   cancelled `done`，避免 Session 仍握着 `currentTurnAttemptToken`。
-  续段必须继承铸造 claim 时的 `turnPermissionPolicy`，不得把无人值守只读边界
-  重置成普通 Auto。
+  续段必须继承铸造 claim 时的 origin 上下文：`turnPermissionPolicy`、
+  capability selection 与 auto-review intent。不得把无人值守只读边界重置成普通
+  Auto，也不得用固定 wait 提示覆盖原请求的能力选择或审查意图。
   Claude wake continuation 与 Codex yield continuation 先分账，不抽公共模块。
 
 ## 3. 守住四项核心数据指标

--- a/docs/dev-rules/maker-core-and-agent-behavior.md
+++ b/docs/dev-rules/maker-core-and-agent-behavior.md
@@ -92,10 +92,13 @@ timeout 不得触发自动换窗或 replay。Codex 当前没有与 Claude `AutoC
   ask_user／plan 内部续段必须等 yield 空闲后再 `turn/start`，不得并发；Stop／
   close 取消 yield 时，排队中的内部续段必须退出而不是被当成正常空闲继续发送。
   只有 cell 真正结算的成功空闲才能唤醒排队续段；lost-handle、重试耗尽、
-  续段 `turn/start` 失败等产品失败必须以 cancelled 释放 waiter，不得在用户
+  续段 `turn/start` 失败等产品失败必须以 cancelled 释放 waiter，并闩住后续
+  `waitForYieldContinuationIdle()`，同时收掉未完成的 ask_user／plan 卡，不得在用户
   已看到失败后再开 ask_user／plan turn。续段启动失败的产品终态只由续段层
   发送一次（`yield-continuation-start-failed`），`handle.send` 不得再发一组
-  通用终态。
+  通用终态。continuation 的 `turn/start` 已被服务端接受后若本地 Stop，即使
+  `turnStarted` 已激活、随后 `interrupted` 被墓碑吞掉，也必须发出一条未认领的
+  cancelled `done`，避免 Session 仍握着 `currentTurnAttemptToken`。
   续段必须继承铸造 claim 时的 `turnPermissionPolicy`，不得把无人值守只读边界
   重置成普通 Auto。
   Claude wake continuation 与 Codex yield continuation 先分账，不抽公共模块。

--- a/docs/dev-rules/maker-core-and-agent-behavior.md
+++ b/docs/dev-rules/maker-core-and-agent-behavior.md
@@ -71,6 +71,16 @@ timeout 不得触发自动换窗或 replay。Codex 当前没有与 Claude `AutoC
 - 打算用 prompt 解决某个问题前先自问：这件事用代码能不能做？能就用代码。
 - 把本应由代码保证的确定性逻辑（格式校验、字段抽取、流程跳转、是否调用某个工具等）
   交给模型自由发挥，会引入不可复现的行为漂移，属于本规则明确禁止的做法。
+- **产品 turn 未结算不得结束。** provider `turn/completed` 可以立刻给 SDK turn 落墓碑并
+  结算 usage；只有原子挂在该终态边界上的显式 continuation claim 才能挡住产品结束。
+  Codex `functions.exec` yield 没有协议级 execution handle（cell / wait 活在
+  `codex-rs` daemon），近期检测只能是 adapter 内、用真实 rollout fixture 锁死的启发式，
+  用来铸造有界 claim，再由宿主确定性开续段让模型 wait 同一 cell。同 turn 或续段里
+  后续 `wait` 输出 `Script completed` / `Script terminated` 后视为该 cell 已结算，不得
+  再铸 claim，也不得报 lost-handle。禁止把 `last_agent_message == null` 或开场白当结算
+  判据；cell 跨 turn 存活性未证实前，续段失败必须诚实报 lost-handle，不得 replay 原请求
+  或重跑已执行命令。Claude wake continuation 与 Codex yield continuation 先分账，不抽
+  公共模块。
 
 ## 3. 守住四项核心数据指标
 

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -18206,6 +18206,57 @@ describe('CodexAgent yield continuation', () => {
     await handle.close();
   });
 
+  it('does not mint a claim from a nameless itemUpdated yield that later completes without a marker', async () => {
+    const agent = new CodexAgent(createDeps());
+    const host = installFakeHost(agent, (method) => {
+      if (method === Method.TurnStart) return { turn: { id: 'turn-1' } };
+      return undefined;
+    });
+    const handle = await agent.startSession({
+      sessionId: 'session-yield-nameless-updated-then-finished',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+    });
+    const handlers = host.getThreadHandlers();
+    if (!handlers?.itemUpdated || !handlers.itemCompleted || !handlers.turnCompleted) {
+      throw new Error('expected item and turn handlers');
+    }
+    const events = await collectYieldEvents(handle);
+    await handle.send({ type: 'user', content: 'run typecheck' });
+    handlers.itemUpdated({
+      threadId: 'start-thread-id',
+      turnId: 'turn-1',
+      item: {
+        type: 'commandExecution',
+        command: 'pnpm --filter desktop run typecheck',
+        status: 'inProgress',
+        aggregatedOutput: 'Script running with cell ID 226',
+      },
+    });
+    handlers.itemCompleted({
+      threadId: 'start-thread-id',
+      turnId: 'turn-1',
+      item: {
+        type: 'commandExecution',
+        command: 'pnpm --filter desktop run typecheck',
+        status: 'completed',
+        aggregatedOutput: 'Exit 0',
+        exitCode: 0,
+      },
+    });
+    handlers.turnCompleted({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-1', status: 'completed' },
+    });
+    await waitForExpectation(() => {
+      expect(events.some((event) => event.type === 'done')).toBe(true);
+    });
+    expect(events.find((event) => event.type === 'done')?.turnContinuationId).toBeUndefined();
+    expect(yieldTurnStartCalls(host)).toHaveLength(0);
+    expect(handle.isTurnRunning?.()).toBe(false);
+    await handle.close();
+  });
+
   it('emits a terminal error when a later continuation start is rejected without throwing', async () => {
     const agent = new CodexAgent(createDeps());
     let turnStarts = 0;

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -17472,6 +17472,114 @@ describe('CodexAgent yield continuation', () => {
     await handle.close();
   });
 
+  it('inherits origin capability selection and auto-review intent on the yield continuation turn', async () => {
+    const seenIntents: string[] = [];
+    const reviewAutoPermissionAction = vi.fn<AutoReviewDelegate>(async (request) => {
+      seenIntents.push(request.userIntent);
+      return { verdict: 'allow' as const };
+    });
+    const agent = new CodexAgent(createDeps({}, {
+      capabilityRouting: {
+        overrides: [{
+          capabilityId: 'feishu',
+          source: {
+            kind: 'harness-plugin',
+            harness: 'codex',
+            surface: 'mcp',
+            id: 'cindy-routed-feishu-delegate',
+            artifactId: 'feishu-delegate',
+            containerId: 'feishu-delegate@personal',
+          },
+          invocation: 'explicit-only',
+          explicitSelectors: [
+            '$feishu-delegate:message-feishu-coworkers',
+            '/feishu-delegate:message-feishu-coworkers',
+          ],
+          replacement: { kind: 'cindy-plugin', id: 'xd-feishu' },
+        }],
+      },
+      getMcpToolApprovalPolicy: () => 'auto-approve',
+      reviewAutoPermissionAction,
+    }));
+    let turnSeq = 0;
+    const host = installFakeHost(agent, (method) => {
+      if (method === Method.TurnStart) {
+        turnSeq += 1;
+        return { turn: { id: `turn-${turnSeq}` } };
+      }
+      return undefined;
+    }, { userAgent: 'mock-codex/0.145.0' });
+    const handle = await agent.startSession({
+      sessionId: 'session-yield-origin-context',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+      permissionMode: 'auto',
+    });
+    const handlers = host.getThreadHandlers();
+    if (!handlers?.itemCompleted || !handlers.turnCompleted || !handlers.mcpServerElicitation || !handlers.commandExecutionApproval) {
+      throw new Error('expected item, turn, elicitation, and approval handlers');
+    }
+    await handle.send({
+      type: 'user',
+      content: '用 $feishu-delegate:message-feishu-coworkers 查消息并跑 typecheck',
+    });
+    handlers.itemCompleted({
+      threadId: 'start-thread-id',
+      turnId: 'turn-1',
+      item: {
+        id: 'item-exec-origin-context',
+        type: 'commandExecution',
+        command: 'pnpm --filter desktop run typecheck',
+        status: 'completed',
+        aggregatedOutput: 'Script running with cell ID 226',
+      },
+    });
+    handlers.turnCompleted({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-1', status: 'completed' },
+    });
+    await vi.waitFor(() => {
+      expect(yieldTurnStartCalls(host)).toHaveLength(1);
+    });
+    handlers.turnStarted?.({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-2', status: 'inProgress' },
+    });
+    handlers.itemStarted?.({
+      threadId: 'start-thread-id',
+      turnId: 'turn-2',
+      item: {
+        id: 'item-routed-feishu-yield',
+        type: 'mcpToolCall',
+        server: 'cindy-routed-feishu-delegate',
+        tool: 'feishu_read_messages',
+        pluginId: 'feishu-delegate@personal',
+      },
+    });
+    await expect(handlers.mcpServerElicitation({
+      threadId: 'start-thread-id',
+      turnId: 'turn-2',
+      serverName: 'cindy-routed-feishu-delegate',
+      mode: 'form',
+      _meta: {
+        codex_approval_kind: 'mcp_tool_call',
+        tool_name: 'feishu_read_messages',
+      },
+      message: 'Allow tool call',
+      requestedSchema: {},
+    })).resolves.toEqual({ action: 'accept', content: null, _meta: null });
+    await expect(handlers.commandExecutionApproval({
+      threadId: 'start-thread-id',
+      turnId: 'turn-2',
+      itemId: 'item-exec-origin-context-review',
+      command: 'pnpm --filter desktop run typecheck',
+      cwd: '/repo',
+    })).resolves.toEqual({ decision: 'accept' });
+    expect(seenIntents.some((intent) => intent.includes('查消息并跑 typecheck'))).toBe(true);
+    expect(seenIntents.some((intent) => intent.includes('foreground exec cell'))).toBe(false);
+    await handle.close();
+  });
+
   it('detects Responses/proxy function_call(exec_command) yield output', async () => {
     const agent = new CodexAgent(createDeps());
     let turnSeq = 0;

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -18569,6 +18569,8 @@ describe('CodexAgent yield continuation', () => {
       threadId: 'start-thread-id',
       turn: { id: 'old-foreign-turn', status: 'failed', error: { message: 'stale turn failed' } },
     });
+    expect(events.filter((event) => event.type === 'done')).toHaveLength(1);
+    expect(events.find((event) => event.type === 'done' && event.turnContinuationId == null)).toBeUndefined();
     expect(handle.beginTurnContinuationWait?.(claimedDone?.turnContinuationId)).toBe('active');
     expect(handle.isTurnRunning?.()).toBe(true);
     await handle.close();
@@ -18626,6 +18628,8 @@ describe('CodexAgent yield continuation', () => {
       event.type === 'error'
       && String((event.data as { reason?: string }).reason ?? '') === 'yield-continuation-lost-handle'
     ))).toBe(false);
+    expect(events.filter((event) => event.type === 'done')).toHaveLength(1);
+    expect(events.find((event) => event.type === 'done' && event.turnContinuationId == null)).toBeUndefined();
     expect(handle.beginTurnContinuationWait?.(claimedDone?.turnContinuationId)).toBe('active');
     expect(handle.isTurnRunning?.()).toBe(true);
     await handle.close();

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -17471,6 +17471,67 @@ describe('CodexAgent yield continuation', () => {
     await handle.close();
   });
 
+  it('keeps a nameless yielded exec_command when a later nameless wait completes', async () => {
+    const agent = new CodexAgent(createDeps());
+    let turnSeq = 0;
+    const host = installFakeHost(agent, (method) => {
+      if (method === Method.TurnStart) {
+        turnSeq += 1;
+        return { turn: { id: `turn-${turnSeq}` } };
+      }
+      return undefined;
+    });
+    const handle = await agent.startSession({
+      sessionId: 'session-yield-nameless-function-call',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+    });
+    const handlers = host.getThreadHandlers();
+    if (!handlers?.itemCompleted || !handlers.turnCompleted) {
+      throw new Error('expected item and turn handlers');
+    }
+    const events = await collectYieldEvents(handle);
+    await handle.send({ type: 'user', content: 'run typecheck' });
+    handlers.itemCompleted({
+      threadId: 'start-thread-id',
+      turnId: 'turn-1',
+      item: {
+        type: 'function_call',
+        name: 'exec_command',
+        arguments: JSON.stringify({
+          cmd: 'pnpm --filter desktop run typecheck',
+          yield_time_ms: 10_000,
+        }),
+        content: [{ type: 'output_text', text: 'Script running with cell ID 229' }],
+      },
+    });
+    handlers.itemCompleted({
+      threadId: 'start-thread-id',
+      turnId: 'turn-1',
+      item: {
+        type: 'function_call',
+        name: 'wait',
+        arguments: JSON.stringify({ cell_id: '11', yield_time_ms: 1000 }),
+        content: [{ type: 'output_text', text: 'Script running with cell ID 11\nWall time 1.0 seconds\nOutput:\n' }],
+      },
+    });
+    handlers.turnCompleted({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-1', status: 'completed' },
+    });
+    await waitForExpectation(() => {
+      expect(events.some((event) => event.type === 'done' && event.turnContinuationId != null)).toBe(true);
+    });
+    await vi.waitFor(() => {
+      expect(yieldTurnStartCalls(host)).toHaveLength(1);
+    });
+    const [, params] = yieldTurnStartCalls(host)[0] as [string, {
+      input: Array<{ text?: string }>;
+    }];
+    expect(params.input[0]?.text).toContain('Wait for cell ID 229');
+    await handle.close();
+  });
+
   it('does not mint a claim after wait settles the yielded cell in the same turn', async () => {
     const agent = new CodexAgent(createDeps());
     const host = installFakeHost(agent, (method) => {

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -17589,6 +17589,76 @@ describe('CodexAgent yield continuation', () => {
     await handle.close();
   });
 
+  it('keeps other nameless yielded cells when a nameless wait settles one cell', async () => {
+    const agent = new CodexAgent(createDeps());
+    let turnSeq = 0;
+    const host = installFakeHost(agent, (method) => {
+      if (method === Method.TurnStart) {
+        turnSeq += 1;
+        return { turn: { id: `turn-${turnSeq}` } };
+      }
+      return undefined;
+    });
+    const handle = await agent.startSession({
+      sessionId: 'session-yield-nameless-two-cells-one-settled',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+    });
+    const handlers = host.getThreadHandlers();
+    if (!handlers?.itemCompleted || !handlers.turnCompleted) {
+      throw new Error('expected item and turn handlers');
+    }
+    const events = await collectYieldEvents(handle);
+    await handle.send({ type: 'user', content: 'run typecheck' });
+    handlers.itemCompleted({
+      threadId: 'start-thread-id',
+      turnId: 'turn-1',
+      item: {
+        type: 'function_call',
+        name: 'exec_command',
+        arguments: JSON.stringify({ cmd: 'pnpm typecheck', yield_time_ms: 10_000 }),
+        content: [{ type: 'output_text', text: 'Script running with cell ID 226' }],
+      },
+    });
+    handlers.itemCompleted({
+      threadId: 'start-thread-id',
+      turnId: 'turn-1',
+      item: {
+        type: 'function_call',
+        name: 'exec_command',
+        arguments: JSON.stringify({ cmd: 'pnpm lint', yield_time_ms: 10_000 }),
+        content: [{ type: 'output_text', text: 'Script running with cell ID 229' }],
+      },
+    });
+    handlers.itemCompleted({
+      threadId: 'start-thread-id',
+      turnId: 'turn-1',
+      item: {
+        type: 'function_call',
+        name: 'wait',
+        arguments: JSON.stringify({ cell_id: '226', yield_time_ms: 1000 }),
+        content: [{ type: 'output_text', text: 'Script completed\nWall time 1.0 seconds\nOutput:\n' }],
+      },
+    });
+    handlers.turnCompleted({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-1', status: 'completed' },
+    });
+    await waitForExpectation(() => {
+      expect(events.some((event) => event.type === 'done' && event.turnContinuationId != null)).toBe(true);
+    });
+    await vi.waitFor(() => {
+      expect(yieldTurnStartCalls(host)).toHaveLength(1);
+    });
+    const [, params] = yieldTurnStartCalls(host)[0] as [string, {
+      input: Array<{ text?: string }>;
+    }];
+    const prompt = params.input[0]?.text ?? '';
+    expect(prompt).toContain('cell ID 229');
+    expect(prompt).not.toContain('cell ID 226');
+    await handle.close();
+  });
+
   it('does not mint a claim after wait settles the yielded cell in the same turn', async () => {
     const agent = new CodexAgent(createDeps());
     const host = installFakeHost(agent, (method) => {
@@ -19150,6 +19220,166 @@ describe('CodexAgent yield continuation', () => {
       && String((event.data as { message?: string }).message ?? '').includes('ask_user continuation turn failed to start')
     ))).toBe(false);
     expect(handle.isTurnRunning?.()).toBe(false);
+    await handle.close();
+  });
+
+  it('defers plan review until the yield product terminal after an empty plan turn', async () => {
+    const agent = new CodexAgent(createDeps());
+    let turnSeq = 0;
+    const host = installFakeHost(agent, (method) => {
+      if (method === Method.TurnStart) {
+        turnSeq += 1;
+        return { turn: { id: `turn-${turnSeq}` } };
+      }
+      return undefined;
+    });
+    const handle = await agent.startSession({
+      sessionId: 'session-yield-plan-review-after-product-terminal',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+      planMode: true,
+    });
+    const handlers = host.getThreadHandlers();
+    if (!handlers?.itemCompleted || !handlers.turnCompleted || !handlers.turnStarted) {
+      throw new Error('expected item and turn handlers');
+    }
+    const seen: unknown[] = [];
+    handle.setInteractionResolver(async (req) => {
+      seen.push(req);
+      return { kind: 'plan_review', behavior: 'deny' };
+    });
+    const events = await collectYieldEvents(handle);
+    await handle.send({ type: 'user', content: 'make a plan' }, { planMode: true });
+    handlers.itemCompleted({
+      threadId: 'start-thread-id',
+      turnId: 'turn-1',
+      item: {
+        id: 'item-exec-plan-yield',
+        type: 'commandExecution',
+        command: 'pnpm --filter desktop run typecheck',
+        status: 'completed',
+        aggregatedOutput: 'Script running with cell ID 226',
+      },
+    });
+    handlers.turnCompleted({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-1', status: 'completed' },
+    });
+    await vi.waitFor(() => {
+      expect(yieldTurnStartCalls(host)).toHaveLength(1);
+    });
+    expect(seen).toHaveLength(0);
+    const [, continuationParams] = yieldTurnStartCalls(host)[0] as [string, {
+      collaborationMode?: { mode: string };
+    }];
+    expect(continuationParams.collaborationMode?.mode).toBe('plan');
+    handlers.turnStarted({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-2', status: 'inProgress' },
+    });
+    handlers.itemCompleted({
+      threadId: 'start-thread-id',
+      turnId: 'turn-2',
+      item: { type: 'plan', id: 'turn-2-plan', text: '1. inspect\n2. edit' },
+    } as never);
+    handlers.itemCompleted({
+      threadId: 'start-thread-id',
+      turnId: 'turn-2',
+      item: {
+        id: 'item-wait-plan-yield',
+        type: 'function_call',
+        name: 'wait',
+        arguments: JSON.stringify({ cell_id: '226', max_tokens: 1000 }),
+        content: [{ type: 'output_text', text: 'Script completed\nWall time 0.1 seconds\nOutput:\n' }],
+      },
+    });
+    handlers.turnCompleted({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-2', status: 'completed' },
+    });
+    await vi.waitFor(() => {
+      expect(seen.length).toBeGreaterThan(0);
+    });
+    expect(seen[0]).toMatchObject({ kind: 'plan_review', plan: '1. inspect\n2. edit' });
+    await waitForExpectation(() => {
+      expect(events.filter((event) => event.type === 'done' && event.turnContinuationId == null)).toHaveLength(1);
+    });
+    await handle.close();
+  });
+
+  it('reviews a plan produced before yield on the product terminal, not the SDK turn boundary', async () => {
+    const agent = new CodexAgent(createDeps());
+    let turnSeq = 0;
+    const host = installFakeHost(agent, (method) => {
+      if (method === Method.TurnStart) {
+        turnSeq += 1;
+        return { turn: { id: `turn-${turnSeq}` } };
+      }
+      return undefined;
+    });
+    const handle = await agent.startSession({
+      sessionId: 'session-yield-plan-before-yield-reviews-at-product-terminal',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+      planMode: true,
+    });
+    const handlers = host.getThreadHandlers();
+    if (!handlers?.itemCompleted || !handlers.turnCompleted || !handlers.turnStarted) {
+      throw new Error('expected item and turn handlers');
+    }
+    const seen: unknown[] = [];
+    handle.setInteractionResolver(async (req) => {
+      seen.push(req);
+      return { kind: 'plan_review', behavior: 'deny' };
+    });
+    await handle.send({ type: 'user', content: 'make a plan' }, { planMode: true });
+    handlers.itemCompleted({
+      threadId: 'start-thread-id',
+      turnId: 'turn-1',
+      item: { type: 'plan', id: 'turn-1-plan', text: '1. do X\n2. do Y' },
+    } as never);
+    handlers.itemCompleted({
+      threadId: 'start-thread-id',
+      turnId: 'turn-1',
+      item: {
+        id: 'item-exec-plan-before-yield',
+        type: 'commandExecution',
+        command: 'pnpm --filter desktop run typecheck',
+        status: 'completed',
+        aggregatedOutput: 'Script running with cell ID 226',
+      },
+    });
+    handlers.turnCompleted({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-1', status: 'completed' },
+    });
+    await vi.waitFor(() => {
+      expect(yieldTurnStartCalls(host)).toHaveLength(1);
+    });
+    expect(seen).toHaveLength(0);
+    handlers.turnStarted({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-2', status: 'inProgress' },
+    });
+    handlers.itemCompleted({
+      threadId: 'start-thread-id',
+      turnId: 'turn-2',
+      item: {
+        id: 'item-wait-plan-before-yield',
+        type: 'function_call',
+        name: 'wait',
+        arguments: JSON.stringify({ cell_id: '226', max_tokens: 1000 }),
+        content: [{ type: 'output_text', text: 'Script completed\nWall time 0.1 seconds\nOutput:\n' }],
+      },
+    });
+    handlers.turnCompleted({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-2', status: 'completed' },
+    });
+    await vi.waitFor(() => {
+      expect(seen.length).toBeGreaterThan(0);
+    });
+    expect(seen[0]).toMatchObject({ kind: 'plan_review', plan: '1. do X\n2. do Y' });
     await handle.close();
   });
 });

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -17974,11 +17974,17 @@ describe('CodexAgent yield continuation', () => {
       turn: { id: 'turn-1', status: 'completed' },
     });
     await waitForExpectation(() => {
-      expect(events.some((event) => (
+      expect(events.filter((event) => (
         event.type === 'error'
-        && String((event.data as { reason?: string }).reason ?? '').includes('yield-continuation-start-failed')
-      ))).toBe(true);
+        && (event.data as { isTerminal?: boolean }).isTerminal === true
+      ))).toHaveLength(1);
     });
+    const terminalErrors = events.filter((event) => (
+      event.type === 'error'
+      && (event.data as { isTerminal?: boolean }).isTerminal === true
+    ));
+    expect(String((terminalErrors[0]?.data as { reason?: string }).reason ?? ''))
+      .toBe('yield-continuation-start-failed');
     expect(handle.isTurnRunning?.()).toBe(false);
     await handle.close();
   });
@@ -18238,11 +18244,21 @@ describe('CodexAgent yield continuation', () => {
       turn: { id: 'turn-1', status: 'completed' },
     });
     await waitForExpectation(() => {
-      expect(events.some((event) => (
+      expect(events.filter((event) => (
         event.type === 'error'
-        && String((event.data as { reason?: string }).reason ?? '').includes('yield-continuation-start-failed')
-      ))).toBe(true);
+        && (event.data as { isTerminal?: boolean }).isTerminal === true
+      ))).toHaveLength(1);
     });
+    const terminalErrors = events.filter((event) => (
+      event.type === 'error'
+      && (event.data as { isTerminal?: boolean }).isTerminal === true
+    ));
+    expect(String((terminalErrors[0]?.data as { reason?: string }).reason ?? ''))
+      .toBe('yield-continuation-start-failed');
+    expect(events.some((event) => (
+      event.type === 'error'
+      && /^turn\/start failed:/.test(String((event.data as { message?: string }).message ?? ''))
+    ))).toBe(false);
     expect(handle.isTurnRunning?.()).toBe(false);
     await handle.close();
   });
@@ -18758,6 +18774,90 @@ describe('CodexAgent yield continuation', () => {
       event.type === 'error'
       && String((event.data as { message?: string }).message ?? '').includes('ask_user continuation turn failed to start')
     ))).toBe(false);
+    await handle.close();
+  });
+
+  it('does not start a queued ask_user continuation after lost-handle', async () => {
+    const agent = new CodexAgent(createDeps());
+    let turnSeq = 0;
+    const host = installFakeHost(agent, (method) => {
+      if (method === Method.TurnStart) {
+        turnSeq += 1;
+        return { turn: { id: `turn-${turnSeq}` } };
+      }
+      return undefined;
+    });
+    const handle = await agent.startSession({
+      sessionId: 'session-yield-lost-handle-drops-ask-user',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+    });
+    const handlers = host.getThreadHandlers();
+    if (!handlers?.itemCompleted || !handlers.turnCompleted || !handlers.requestUserInput) {
+      throw new Error('expected item, turn, and user-input handlers');
+    }
+    const ownerDecision = deferred<InteractionDecision>();
+    handle.setInteractionResolver(async () => ownerDecision.promise);
+    const events = await collectYieldEvents(handle);
+    await handle.send({ type: 'user', content: 'run typecheck' });
+    void handlers.requestUserInput({
+      threadId: 'start-thread-id',
+      turnId: 'turn-1',
+      itemId: 'item-ask-lost',
+      questions: [{
+        id: 'native-q1',
+        header: 'Question',
+        question: 'Pick one',
+        isOther: false,
+        isSecret: false,
+        options: [{ label: 'A', description: null }],
+      }],
+    }, { requestId: 'req-ask-lost' });
+    handlers.itemCompleted({
+      threadId: 'start-thread-id',
+      turnId: 'turn-1',
+      item: {
+        id: 'item-exec-ask-lost',
+        type: 'commandExecution',
+        command: 'pnpm --filter desktop run typecheck',
+        status: 'completed',
+        aggregatedOutput: 'Script running with cell ID 226',
+      },
+    });
+    handlers.turnCompleted({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-1', status: 'completed' },
+    });
+    await vi.waitFor(() => {
+      expect(yieldTurnStartCalls(host)).toHaveLength(1);
+    });
+    ownerDecision.resolve({
+      kind: 'ask_user_question',
+      answers: { 'Pick one': 'A' },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(host.request.mock.calls.filter(([method]) => method === Method.TurnStart)).toHaveLength(2);
+    handlers.turnStarted?.({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-2', status: 'inProgress' },
+    });
+    handlers.turnCompleted({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-2', status: 'completed' },
+    });
+    await waitForExpectation(() => {
+      expect(events.some((event) => (
+        event.type === 'error'
+        && String((event.data as { reason?: string }).reason ?? '') === 'yield-continuation-lost-handle'
+      ))).toBe(true);
+    });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(host.request.mock.calls.filter(([method]) => method === Method.TurnStart)).toHaveLength(2);
+    expect(events.some((event) => (
+      event.type === 'error'
+      && String((event.data as { message?: string }).message ?? '').includes('ask_user continuation turn failed to start')
+    ))).toBe(false);
+    expect(handle.isTurnRunning?.()).toBe(false);
     await handle.close();
   });
 });

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -18573,6 +18573,134 @@ describe('CodexAgent yield continuation', () => {
     expect(handle.isTurnRunning?.()).toBe(true);
     await handle.close();
   });
+
+  it('does not settle an active yield claim for a late foreign completed turn', async () => {
+    const agent = new CodexAgent(createDeps());
+    let turnSeq = 0;
+    const host = installFakeHost(agent, (method) => {
+      if (method === Method.TurnStart) {
+        turnSeq += 1;
+        return { turn: { id: `turn-${turnSeq}` } };
+      }
+      return undefined;
+    });
+    const handle = await agent.startSession({
+      sessionId: 'session-yield-foreign-completed-turn',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+    });
+    const handlers = host.getThreadHandlers();
+    if (!handlers?.itemCompleted || !handlers.turnCompleted) {
+      throw new Error('expected item and turn handlers');
+    }
+    const events = await collectYieldEvents(handle);
+    await handle.send({ type: 'user', content: 'run typecheck' });
+    handlers.itemCompleted({
+      threadId: 'start-thread-id',
+      turnId: 'turn-1',
+      item: {
+        id: 'item-exec-foreign-complete',
+        type: 'commandExecution',
+        command: 'pnpm --filter desktop run typecheck',
+        status: 'completed',
+        aggregatedOutput: 'Script running with cell ID 226',
+      },
+    });
+    handlers.turnCompleted({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-1', status: 'completed' },
+    });
+    await waitForExpectation(() => {
+      expect(events.some((event) => event.type === 'done' && event.turnContinuationId != null)).toBe(true);
+    });
+    await vi.waitFor(() => {
+      expect(yieldTurnStartCalls(host)).toHaveLength(1);
+    });
+    const claimedDone = events.find((event) => event.type === 'done' && event.turnContinuationId != null);
+    expect(handle.beginTurnContinuationWait?.(claimedDone?.turnContinuationId)).toBe('active');
+    handlers.turnCompleted({
+      threadId: 'start-thread-id',
+      turn: { id: 'old-foreign-turn', status: 'completed' },
+    });
+    expect(events.some((event) => (
+      event.type === 'error'
+      && String((event.data as { reason?: string }).reason ?? '') === 'yield-continuation-lost-handle'
+    ))).toBe(false);
+    expect(handle.beginTurnContinuationWait?.(claimedDone?.turnContinuationId)).toBe('active');
+    expect(handle.isTurnRunning?.()).toBe(true);
+    await handle.close();
+  });
+
+  it('does not start a queued ask_user continuation after Stop cancels yield', async () => {
+    const agent = new CodexAgent(createDeps());
+    let turnSeq = 0;
+    const host = installFakeHost(agent, (method) => {
+      if (method === Method.TurnStart) {
+        turnSeq += 1;
+        return { turn: { id: `turn-${turnSeq}` } };
+      }
+      if (method === Method.TurnInterrupt) return {};
+      return undefined;
+    });
+    const handle = await agent.startSession({
+      sessionId: 'session-yield-stop-drops-ask-user',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+    });
+    const handlers = host.getThreadHandlers();
+    if (!handlers?.itemCompleted || !handlers.turnCompleted || !handlers.requestUserInput) {
+      throw new Error('expected item, turn, and user-input handlers');
+    }
+    const ownerDecision = deferred<InteractionDecision>();
+    handle.setInteractionResolver(async () => ownerDecision.promise);
+    const events = await collectYieldEvents(handle);
+    await handle.send({ type: 'user', content: 'run typecheck' });
+    void handlers.requestUserInput({
+      threadId: 'start-thread-id',
+      turnId: 'turn-1',
+      itemId: 'item-ask-stop',
+      questions: [{
+        id: 'native-q1',
+        header: 'Question',
+        question: 'Pick one',
+        isOther: false,
+        isSecret: false,
+        options: [{ label: 'A', description: null }],
+      }],
+    }, { requestId: 'req-ask-stop' });
+    handlers.itemCompleted({
+      threadId: 'start-thread-id',
+      turnId: 'turn-1',
+      item: {
+        id: 'item-exec-ask-stop',
+        type: 'commandExecution',
+        command: 'pnpm --filter desktop run typecheck',
+        status: 'completed',
+        aggregatedOutput: 'Script running with cell ID 226',
+      },
+    });
+    handlers.turnCompleted({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-1', status: 'completed' },
+    });
+    await vi.waitFor(() => {
+      expect(yieldTurnStartCalls(host)).toHaveLength(1);
+    });
+    ownerDecision.resolve({
+      kind: 'ask_user_question',
+      answers: { 'Pick one': 'A' },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(host.request.mock.calls.filter(([method]) => method === Method.TurnStart)).toHaveLength(2);
+    await handle.abort();
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(host.request.mock.calls.filter(([method]) => method === Method.TurnStart)).toHaveLength(2);
+    expect(events.some((event) => (
+      event.type === 'error'
+      && String((event.data as { message?: string }).message ?? '').includes('ask_user continuation turn failed to start')
+    ))).toBe(false);
+    await handle.close();
+  });
 });
 
 describe('CodexAgent steer', () => {

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -18608,8 +18608,8 @@ describe('CodexAgent yield continuation', () => {
       workingDir: '/repo',
     });
     const handlers = host.getThreadHandlers();
-    if (!handlers?.itemCompleted || !handlers.turnCompleted) {
-      throw new Error('expected item and turn handlers');
+    if (!handlers?.itemCompleted || !handlers.turnCompleted || !handlers.turnStarted || !handlers.tokenUsageUpdated) {
+      throw new Error('expected item, turn, started, and usage handlers');
     }
     const events = await collectYieldEvents(handle);
     await handle.send({ type: 'user', content: 'run typecheck' });
@@ -18636,6 +18636,18 @@ describe('CodexAgent yield continuation', () => {
     });
     const claimedDone = events.find((event) => event.type === 'done' && event.turnContinuationId != null);
     expect(handle.beginTurnContinuationWait?.(claimedDone?.turnContinuationId)).toBe('active');
+    handlers.turnStarted({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-2', status: 'inProgress' },
+    });
+    handlers.tokenUsageUpdated({
+      threadId: 'start-thread-id',
+      turnId: 'turn-2',
+      tokenUsage: {
+        total: { totalTokens: 42, inputTokens: 30, outputTokens: 12, cachedInputTokens: 0 },
+        last: { totalTokens: 42, inputTokens: 30, outputTokens: 12, cachedInputTokens: 0 },
+      },
+    });
     handlers.turnCompleted({
       threadId: 'start-thread-id',
       turn: { id: 'old-foreign-turn', status: 'failed', error: { message: 'stale turn failed' } },
@@ -18644,6 +18656,30 @@ describe('CodexAgent yield continuation', () => {
     expect(events.find((event) => event.type === 'done' && event.turnContinuationId == null)).toBeUndefined();
     expect(handle.beginTurnContinuationWait?.(claimedDone?.turnContinuationId)).toBe('active');
     expect(handle.isTurnRunning?.()).toBe(true);
+    handlers.itemCompleted({
+      threadId: 'start-thread-id',
+      turnId: 'turn-2',
+      item: {
+        id: 'item-wait-after-foreign-fail',
+        type: 'function_call',
+        name: 'wait',
+        arguments: JSON.stringify({ cell_id: '226', max_tokens: 1000 }),
+        content: [{ type: 'output_text', text: 'Script completed\nWall time 0.1 seconds\nOutput:\n' }],
+      },
+    });
+    handlers.turnCompleted({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-2', status: 'completed' },
+    });
+    await waitForExpectation(() => {
+      expect(events.filter((event) => event.type === 'done')).toHaveLength(2);
+    });
+    const productDone = events.find((event) => event.type === 'done' && event.turnContinuationId == null);
+    expect((productDone?.data as { usage?: { promptTokens?: number; completionTokens?: number } }).usage).toMatchObject({
+      promptTokens: 30,
+      completionTokens: 12,
+    });
+    expect(handle.isTurnRunning?.()).toBe(false);
     await handle.close();
   });
 
@@ -18663,8 +18699,8 @@ describe('CodexAgent yield continuation', () => {
       workingDir: '/repo',
     });
     const handlers = host.getThreadHandlers();
-    if (!handlers?.itemCompleted || !handlers.turnCompleted) {
-      throw new Error('expected item and turn handlers');
+    if (!handlers?.itemCompleted || !handlers.turnCompleted || !handlers.turnStarted || !handlers.tokenUsageUpdated) {
+      throw new Error('expected item, turn, started, and usage handlers');
     }
     const events = await collectYieldEvents(handle);
     await handle.send({ type: 'user', content: 'run typecheck' });
@@ -18691,6 +18727,18 @@ describe('CodexAgent yield continuation', () => {
     });
     const claimedDone = events.find((event) => event.type === 'done' && event.turnContinuationId != null);
     expect(handle.beginTurnContinuationWait?.(claimedDone?.turnContinuationId)).toBe('active');
+    handlers.turnStarted({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-2', status: 'inProgress' },
+    });
+    handlers.tokenUsageUpdated({
+      threadId: 'start-thread-id',
+      turnId: 'turn-2',
+      tokenUsage: {
+        total: { totalTokens: 42, inputTokens: 30, outputTokens: 12, cachedInputTokens: 0 },
+        last: { totalTokens: 42, inputTokens: 30, outputTokens: 12, cachedInputTokens: 0 },
+      },
+    });
     handlers.turnCompleted({
       threadId: 'start-thread-id',
       turn: { id: 'old-foreign-turn', status: 'completed' },
@@ -18703,6 +18751,30 @@ describe('CodexAgent yield continuation', () => {
     expect(events.find((event) => event.type === 'done' && event.turnContinuationId == null)).toBeUndefined();
     expect(handle.beginTurnContinuationWait?.(claimedDone?.turnContinuationId)).toBe('active');
     expect(handle.isTurnRunning?.()).toBe(true);
+    handlers.itemCompleted({
+      threadId: 'start-thread-id',
+      turnId: 'turn-2',
+      item: {
+        id: 'item-wait-after-foreign',
+        type: 'function_call',
+        name: 'wait',
+        arguments: JSON.stringify({ cell_id: '226', max_tokens: 1000 }),
+        content: [{ type: 'output_text', text: 'Script completed\nWall time 0.1 seconds\nOutput:\n' }],
+      },
+    });
+    handlers.turnCompleted({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-2', status: 'completed' },
+    });
+    await waitForExpectation(() => {
+      expect(events.filter((event) => event.type === 'done')).toHaveLength(2);
+    });
+    const productDone = events.find((event) => event.type === 'done' && event.turnContinuationId == null);
+    expect((productDone?.data as { usage?: { promptTokens?: number; completionTokens?: number } }).usage).toMatchObject({
+      promptTokens: 30,
+      completionTokens: 12,
+    });
+    expect(handle.isTurnRunning?.()).toBe(false);
     await handle.close();
   });
 

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -18314,6 +18314,63 @@ describe('CodexAgent yield continuation', () => {
     });
     await handle.close();
   });
+
+  it('releases a yield claim on a non-transport terminal error so the session is not permanently busy', async () => {
+    const agent = new CodexAgent(createDeps());
+    let turnSeq = 0;
+    const host = installFakeHost(agent, (method) => {
+      if (method === Method.TurnStart) {
+        turnSeq += 1;
+        return { turn: { id: `turn-${turnSeq}` } };
+      }
+      return undefined;
+    });
+    const handle = await agent.startSession({
+      sessionId: 'session-yield-terminal-error',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+    });
+    const handlers = host.getThreadHandlers();
+    if (!handlers?.itemCompleted || !handlers.turnCompleted || !handlers.error) {
+      throw new Error('expected item, turn, and error handlers');
+    }
+    const events = await collectYieldEvents(handle);
+    await handle.send({ type: 'user', content: 'run typecheck' });
+    handlers.itemCompleted({
+      threadId: 'start-thread-id',
+      turnId: 'turn-1',
+      item: {
+        id: 'item-exec-terminal',
+        type: 'commandExecution',
+        command: 'pnpm --filter desktop run typecheck',
+        status: 'completed',
+        aggregatedOutput: 'Script running with cell ID 226',
+      },
+    });
+    handlers.turnCompleted({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-1', status: 'completed' },
+    });
+    await waitForExpectation(() => {
+      expect(events.some((event) => event.type === 'done' && event.turnContinuationId != null)).toBe(true);
+    });
+    await vi.waitFor(() => {
+      expect(yieldTurnStartCalls(host)).toHaveLength(1);
+    });
+    expect(handle.isTurnRunning?.()).toBe(true);
+    // 原 turn 已落墓碑: 非 transport 的 turn-1 error 会被 stale guard 丢掉。
+    // 必须打到续段 turn, 才能覆盖「只在 transport 路径结算 claim」的旧修法。
+    handlers.error({
+      threadId: 'start-thread-id',
+      turnId: 'turn-2',
+      willRetry: false,
+      error: { message: 'model request failed' },
+    });
+    await waitForExpectation(() => {
+      expect(handle.isTurnRunning?.()).toBe(false);
+    });
+    await handle.close();
+  });
 });
 
 describe('CodexAgent steer', () => {

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -18111,6 +18111,89 @@ describe('CodexAgent yield continuation', () => {
     expect(handle.getCurrentTurnId?.()).not.toBe('turn-2');
     const state = handle.beginTurnContinuationWait?.(claimedDone?.turnContinuationId);
     expect(state === 'cancelled' || state === null).toBe(true);
+    expect(events.some((event) => (
+      event.type === 'done'
+      && event.turnContinuationId == null
+      && (event.data as { cancelled?: boolean }).cancelled === true
+    ))).toBe(true);
+    await handle.close();
+  });
+
+  it('emits an unclaimed cancelled done when Stop races a pending continuation after turnStarted', async () => {
+    const agent = new CodexAgent(createDeps());
+    let turnStarts = 0;
+    const continuationStart = deferred<{ turn: { id: string } }>();
+    const host = installFakeHost(agent, (method) => {
+      if (method === Method.TurnStart) {
+        turnStarts += 1;
+        if (turnStarts === 1) return { turn: { id: 'turn-1' } };
+        return continuationStart.promise;
+      }
+      if (method === Method.TurnInterrupt) return {};
+      return undefined;
+    });
+    const handle = await agent.startSession({
+      sessionId: 'session-yield-cancel-after-started-pending-rpc',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+    });
+    const handlers = host.getThreadHandlers();
+    if (!handlers?.itemCompleted || !handlers.turnCompleted || !handlers.turnStarted) {
+      throw new Error('expected item, turn, and started handlers');
+    }
+    const events = await collectYieldEvents(handle);
+    await handle.send({ type: 'user', content: 'run typecheck' });
+    handlers.itemCompleted({
+      threadId: 'start-thread-id',
+      turnId: 'turn-1',
+      item: {
+        id: 'item-exec-cancel-after-started',
+        type: 'commandExecution',
+        command: 'pnpm --filter desktop run typecheck',
+        status: 'completed',
+        aggregatedOutput: 'Script running with cell ID 226',
+      },
+    });
+    handlers.turnCompleted({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-1', status: 'completed' },
+    });
+    await waitForExpectation(() => {
+      expect(events.some((event) => event.type === 'done' && event.turnContinuationId != null)).toBe(true);
+    });
+    await vi.waitFor(() => {
+      expect(turnStarts).toBe(2);
+    });
+    handlers.turnStarted({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-2', status: 'inProgress' },
+    });
+    expect(handle.getCurrentTurnId?.()).toBe('turn-2');
+    await handle.abort();
+    await waitForExpectation(() => {
+      expect(events.filter((event) => (
+        event.type === 'done'
+        && event.turnContinuationId == null
+        && (event.data as { cancelled?: boolean }).cancelled === true
+      ))).toHaveLength(1);
+    });
+    continuationStart.resolve({ turn: { id: 'turn-2' } });
+    await waitForExpectation(() => {
+      expect(host.request).toHaveBeenCalledWith(Method.TurnInterrupt, {
+        threadId: 'start-thread-id',
+        turnId: 'turn-2',
+      });
+    });
+    handlers.turnCompleted({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-2', status: 'interrupted' },
+    });
+    expect(events.filter((event) => (
+      event.type === 'done'
+      && event.turnContinuationId == null
+      && (event.data as { cancelled?: boolean }).cancelled === true
+    ))).toHaveLength(1);
+    expect(handle.isTurnRunning?.()).toBe(false);
     await handle.close();
   });
 
@@ -18973,6 +19056,92 @@ describe('CodexAgent yield continuation', () => {
         event.type === 'error'
         && String((event.data as { reason?: string }).reason ?? '') === 'yield-continuation-lost-handle'
       ))).toBe(true);
+    });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(host.request.mock.calls.filter(([method]) => method === Method.TurnStart)).toHaveLength(2);
+    expect(events.some((event) => (
+      event.type === 'error'
+      && String((event.data as { message?: string }).message ?? '').includes('ask_user continuation turn failed to start')
+    ))).toBe(false);
+    expect(handle.isTurnRunning?.()).toBe(false);
+    await handle.close();
+  });
+
+  it('does not start ask_user after lost-handle if the user answers later', async () => {
+    const agent = new CodexAgent(createDeps());
+    let turnSeq = 0;
+    const host = installFakeHost(agent, (method) => {
+      if (method === Method.TurnStart) {
+        turnSeq += 1;
+        return { turn: { id: `turn-${turnSeq}` } };
+      }
+      return undefined;
+    });
+    const handle = await agent.startSession({
+      sessionId: 'session-yield-lost-handle-then-late-ask-user',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+    });
+    const handlers = host.getThreadHandlers();
+    if (!handlers?.itemCompleted || !handlers.turnCompleted || !handlers.requestUserInput) {
+      throw new Error('expected item, turn, and user-input handlers');
+    }
+    const ownerDecision = deferred<InteractionDecision>();
+    handle.setInteractionResolver(async () => ownerDecision.promise);
+    const events = await collectYieldEvents(handle);
+    await handle.send({ type: 'user', content: 'run typecheck' });
+    void handlers.requestUserInput({
+      threadId: 'start-thread-id',
+      turnId: 'turn-1',
+      itemId: 'item-ask-late',
+      questions: [{
+        id: 'native-q1',
+        header: 'Question',
+        question: 'Pick one',
+        isOther: false,
+        isSecret: false,
+        options: [{ label: 'A', description: null }],
+      }],
+    }, { requestId: 'req-ask-late' });
+    handlers.itemCompleted({
+      threadId: 'start-thread-id',
+      turnId: 'turn-1',
+      item: {
+        id: 'item-exec-ask-late',
+        type: 'commandExecution',
+        command: 'pnpm --filter desktop run typecheck',
+        status: 'completed',
+        aggregatedOutput: 'Script running with cell ID 226',
+      },
+    });
+    handlers.turnCompleted({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-1', status: 'completed' },
+    });
+    await vi.waitFor(() => {
+      expect(yieldTurnStartCalls(host)).toHaveLength(1);
+    });
+    handlers.turnStarted?.({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-2', status: 'inProgress' },
+    });
+    handlers.turnCompleted({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-2', status: 'completed' },
+    });
+    await waitForExpectation(() => {
+      expect(events.some((event) => (
+        event.type === 'error'
+        && String((event.data as { reason?: string }).reason ?? '') === 'yield-continuation-lost-handle'
+      ))).toBe(true);
+    });
+    expect(events.some((event) => (
+      event.type === 'interaction_dismissed'
+      && (event.data as { requestId?: string }).requestId === 'req-ask-late'
+    ))).toBe(true);
+    ownerDecision.resolve({
+      kind: 'ask_user_question',
+      answers: { 'Pick one': 'A' },
     });
     await new Promise((resolve) => setTimeout(resolve, 20));
     expect(host.request.mock.calls.filter(([method]) => method === Method.TurnStart)).toHaveLength(2);

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -17528,7 +17528,9 @@ describe('CodexAgent yield continuation', () => {
     const [, params] = yieldTurnStartCalls(host)[0] as [string, {
       input: Array<{ text?: string }>;
     }];
-    expect(params.input[0]?.text).toContain('Wait for cell ID 229');
+    const prompt = params.input[0]?.text ?? '';
+    expect(prompt).toContain('cell ID 229');
+    expect(prompt).toContain('cell ID 11');
     await handle.close();
   });
 
@@ -17637,6 +17639,71 @@ describe('CodexAgent yield continuation', () => {
     await vi.waitFor(() => {
       expect(yieldTurnStartCalls(host)).toHaveLength(1);
     });
+    expect(handle.isTurnRunning?.()).toBe(true);
+    await handle.close();
+  });
+
+  it('retries a continuation when wait still reports the cell running', async () => {
+    const agent = new CodexAgent(createDeps());
+    let turnSeq = 0;
+    const host = installFakeHost(agent, (method) => {
+      if (method === Method.TurnStart) {
+        turnSeq += 1;
+        return { turn: { id: `turn-${turnSeq}` } };
+      }
+      return undefined;
+    });
+    const handle = await agent.startSession({
+      sessionId: 'session-yield-wait-alive-retry',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+    });
+    const handlers = host.getThreadHandlers();
+    if (!handlers?.itemCompleted || !handlers.turnCompleted) {
+      throw new Error('expected item and turn handlers');
+    }
+    const events = await collectYieldEvents(handle);
+    await handle.send({ type: 'user', content: 'run typecheck' });
+    handlers.itemCompleted({
+      threadId: 'start-thread-id',
+      turnId: 'turn-1',
+      item: {
+        id: 'item-exec-alive-retry',
+        type: 'commandExecution',
+        command: 'pnpm --filter desktop run typecheck',
+        status: 'completed',
+        aggregatedOutput: 'Script running with cell ID 226',
+      },
+    });
+    handlers.turnCompleted({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-1', status: 'completed' },
+    });
+    await vi.waitFor(() => {
+      expect(yieldTurnStartCalls(host)).toHaveLength(1);
+    });
+    handlers.itemCompleted({
+      threadId: 'start-thread-id',
+      turnId: 'turn-2',
+      item: {
+        id: 'item-wait-alive-retry',
+        type: 'function_call',
+        name: 'wait',
+        arguments: JSON.stringify({ cell_id: '226', yield_time_ms: 1000 }),
+        content: [{ type: 'output_text', text: 'Script running with cell ID 226\nWall time 1.0 seconds\nOutput:\n' }],
+      },
+    });
+    handlers.turnCompleted({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-2', status: 'completed' },
+    });
+    await vi.waitFor(() => {
+      expect(yieldTurnStartCalls(host)).toHaveLength(2);
+    });
+    expect(events.some((event) => (
+      event.type === 'error'
+      && String((event.data as { reason?: string }).reason ?? '') === 'yield-continuation-lost-handle'
+    ))).toBe(false);
     expect(handle.isTurnRunning?.()).toBe(true);
     await handle.close();
   });
@@ -17901,6 +17968,70 @@ describe('CodexAgent yield continuation', () => {
       threadId: 'start-thread-id',
       turnId: 'turn-2',
     });
+    await handle.close();
+  });
+
+  it('isolates a cancelled yield continuation before the turn/start response can activate it', async () => {
+    const agent = new CodexAgent(createDeps());
+    let turnStarts = 0;
+    const continuationStart = deferred<{ turn: { id: string } }>();
+    const host = installFakeHost(agent, (method) => {
+      if (method === Method.TurnStart) {
+        turnStarts += 1;
+        if (turnStarts === 1) return { turn: { id: 'turn-1' } };
+        return continuationStart.promise;
+      }
+      if (method === Method.TurnInterrupt) return {};
+      return undefined;
+    });
+    const handle = await agent.startSession({
+      sessionId: 'session-yield-cancel-before-start-resp',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+    });
+    const handlers = host.getThreadHandlers();
+    if (!handlers?.itemCompleted || !handlers.turnCompleted || !handlers.turnStarted) {
+      throw new Error('expected item, turn, and started handlers');
+    }
+    const events = await collectYieldEvents(handle);
+    await handle.send({ type: 'user', content: 'run typecheck' });
+    handlers.itemCompleted({
+      threadId: 'start-thread-id',
+      turnId: 'turn-1',
+      item: {
+        id: 'item-exec-cancel-before-resp',
+        type: 'commandExecution',
+        command: 'pnpm --filter desktop run typecheck',
+        status: 'completed',
+        aggregatedOutput: 'Script running with cell ID 226',
+      },
+    });
+    handlers.turnCompleted({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-1', status: 'completed' },
+    });
+    await waitForExpectation(() => {
+      expect(events.some((event) => event.type === 'done' && event.turnContinuationId != null)).toBe(true);
+    });
+    await vi.waitFor(() => {
+      expect(turnStarts).toBe(2);
+    });
+    const claimedDone = events.find((event) => event.type === 'done' && event.turnContinuationId != null);
+    await handle.abort();
+    continuationStart.resolve({ turn: { id: 'turn-2' } });
+    await waitForExpectation(() => {
+      expect(host.request).toHaveBeenCalledWith(Method.TurnInterrupt, {
+        threadId: 'start-thread-id',
+        turnId: 'turn-2',
+      });
+    });
+    handlers.turnStarted({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-2', status: 'inProgress' },
+    });
+    expect(handle.getCurrentTurnId?.()).not.toBe('turn-2');
+    const state = handle.beginTurnContinuationWait?.(claimedDone?.turnContinuationId);
+    expect(state === 'cancelled' || state === null).toBe(true);
     await handle.close();
   });
 

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -17336,6 +17336,855 @@ describe('CodexAgent MCP thread context hooks', () => {
   });
 });
 
+describe('CodexAgent yield continuation', () => {
+  async function collectYieldEvents(handle: AgentSessionHandle): Promise<AgentEvent[]> {
+    const events: AgentEvent[] = [];
+    void (async () => {
+      for await (const event of handle.events()) {
+        events.push(event);
+      }
+    })();
+    return events;
+  }
+
+  function yieldTurnStartCalls(host: ReturnType<typeof installFakeHost>) {
+    return host.request.mock.calls.filter(([method, params]) => (
+      method === Method.TurnStart
+      && String((params as { input?: Array<{ text?: string }> }).input?.[0]?.text ?? '')
+        .includes('A foreground exec cell is still running')
+    ));
+  }
+
+  it('keeps the product turn open and waits the yielded cell after commandExecution completes', async () => {
+    const agent = new CodexAgent(createDeps());
+    let turnSeq = 0;
+    const host = installFakeHost(agent, (method) => {
+      if (method === Method.TurnStart) {
+        turnSeq += 1;
+        return { turn: { id: `turn-${turnSeq}` } };
+      }
+      return undefined;
+    });
+    const handle = await agent.startSession({
+      sessionId: 'session-yield-command-execution',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+    });
+    const handlers = host.getThreadHandlers();
+    if (!handlers?.itemCompleted || !handlers.turnCompleted) {
+      throw new Error('expected item and turn handlers');
+    }
+    const events = await collectYieldEvents(handle);
+    await handle.send({ type: 'user', content: 'run typecheck' });
+
+    handlers.itemCompleted({
+      threadId: 'start-thread-id',
+      turnId: 'turn-1',
+      item: {
+        id: 'item-exec-1',
+        type: 'commandExecution',
+        command: 'pnpm --filter desktop run typecheck',
+        status: 'completed',
+        aggregatedOutput: 'Script running with cell ID 226\nWall time 11.0 seconds\nOutput:\n',
+      },
+    });
+    handlers.turnCompleted({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-1', status: 'completed' },
+    });
+
+    await waitForExpectation(() => {
+      const done = events.filter((event) => event.type === 'done');
+      expect(done).toHaveLength(1);
+      expect(done[0]?.turnContinuationId).toEqual(expect.any(Number));
+      expect(events.some((event) => (
+        event.type === 'status'
+        && (event.data as { isRunning?: boolean }).isRunning === false
+        && event.turnContinuationId === done[0]?.turnContinuationId
+      ))).toBe(true);
+    });
+    expect(handle.isTurnRunning?.()).toBe(true);
+    expect(handle.beginTurnContinuationWait?.(events.find((event) => event.type === 'done')?.turnContinuationId))
+      .toBe('active');
+    await vi.waitFor(() => {
+      expect(yieldTurnStartCalls(host)).toHaveLength(1);
+    });
+    const [, params] = yieldTurnStartCalls(host)[0] as [string, {
+      input: Array<{ text?: string }>;
+    }];
+    expect(params.input[0]?.text).toContain('Wait for cell ID 226');
+    expect(params.input[0]?.text).not.toContain('run typecheck');
+    await handle.close();
+  });
+
+  it('detects Responses/proxy function_call(exec_command) yield output', async () => {
+    const agent = new CodexAgent(createDeps());
+    let turnSeq = 0;
+    const host = installFakeHost(agent, (method) => {
+      if (method === Method.TurnStart) {
+        turnSeq += 1;
+        return { turn: { id: `turn-${turnSeq}` } };
+      }
+      return undefined;
+    });
+    const handle = await agent.startSession({
+      sessionId: 'session-yield-function-call',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+    });
+    const handlers = host.getThreadHandlers();
+    if (!handlers?.itemCompleted || !handlers.turnCompleted) {
+      throw new Error('expected item and turn handlers');
+    }
+    const events = await collectYieldEvents(handle);
+    await handle.send({ type: 'user', content: 'run typecheck' });
+
+    handlers.itemCompleted({
+      threadId: 'start-thread-id',
+      turnId: 'turn-1',
+      item: {
+        id: 'item-exec-call',
+        type: 'function_call',
+        name: 'exec_command',
+        arguments: JSON.stringify({
+          cmd: 'pnpm --filter desktop run typecheck',
+          yield_time_ms: 10_000,
+        }),
+        content: [{ type: 'output_text', text: 'Script running with cell ID 229' }],
+      },
+    });
+    handlers.turnCompleted({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-1', status: 'completed' },
+    });
+
+    await waitForExpectation(() => {
+      expect(events.some((event) => event.type === 'done' && event.turnContinuationId != null)).toBe(true);
+    });
+    await vi.waitFor(() => {
+      expect(yieldTurnStartCalls(host)).toHaveLength(1);
+    });
+    const [, params] = yieldTurnStartCalls(host)[0] as [string, {
+      input: Array<{ text?: string }>;
+    }];
+    expect(params.input[0]?.text).toContain('Wait for cell ID 229');
+    await handle.close();
+  });
+
+  it('does not mint a claim after wait settles the yielded cell in the same turn', async () => {
+    const agent = new CodexAgent(createDeps());
+    const host = installFakeHost(agent, (method) => {
+      if (method === Method.TurnStart) return { turn: { id: 'turn-1' } };
+      return undefined;
+    });
+    const handle = await agent.startSession({
+      sessionId: 'session-yield-then-wait-settled',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+    });
+    const handlers = host.getThreadHandlers();
+    if (!handlers?.itemCompleted || !handlers.turnCompleted) {
+      throw new Error('expected item and turn handlers');
+    }
+    const events = await collectYieldEvents(handle);
+    await handle.send({ type: 'user', content: 'run typecheck' });
+    handlers.itemCompleted({
+      threadId: 'start-thread-id',
+      turnId: 'turn-1',
+      item: {
+        id: 'item-exec-yield',
+        type: 'commandExecution',
+        command: 'pnpm --filter desktop run typecheck',
+        status: 'completed',
+        aggregatedOutput: 'Script running with cell ID 226\nWall time 11.0 seconds\nOutput:\n',
+      },
+    });
+    handlers.itemCompleted({
+      threadId: 'start-thread-id',
+      turnId: 'turn-1',
+      item: {
+        id: 'item-wait-226',
+        type: 'function_call',
+        name: 'wait',
+        arguments: JSON.stringify({ cell_id: '226', max_tokens: 1000 }),
+        content: [{ type: 'output_text', text: 'Script completed\nWall time 4.2 seconds\nOutput:\n' }],
+      },
+    });
+    handlers.turnCompleted({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-1', status: 'completed' },
+    });
+    await waitForExpectation(() => {
+      expect(events.some((event) => event.type === 'done')).toBe(true);
+    });
+    expect(events.find((event) => event.type === 'done')?.turnContinuationId).toBeUndefined();
+    expect(yieldTurnStartCalls(host)).toHaveLength(0);
+    expect(handle.isTurnRunning?.()).toBe(false);
+    await handle.close();
+  });
+
+  it('keeps the claim when wait still yields the same cell', async () => {
+    const agent = new CodexAgent(createDeps());
+    let turnSeq = 0;
+    const host = installFakeHost(agent, (method) => {
+      if (method === Method.TurnStart) {
+        turnSeq += 1;
+        return { turn: { id: `turn-${turnSeq}` } };
+      }
+      return undefined;
+    });
+    const handle = await agent.startSession({
+      sessionId: 'session-yield-wait-still-running',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+    });
+    const handlers = host.getThreadHandlers();
+    if (!handlers?.itemCompleted || !handlers.turnCompleted) {
+      throw new Error('expected item and turn handlers');
+    }
+    const events = await collectYieldEvents(handle);
+    await handle.send({ type: 'user', content: 'run typecheck' });
+    handlers.itemCompleted({
+      threadId: 'start-thread-id',
+      turnId: 'turn-1',
+      item: {
+        id: 'item-exec-still-running',
+        type: 'commandExecution',
+        command: 'pnpm --filter desktop run typecheck',
+        status: 'completed',
+        aggregatedOutput: 'Script running with cell ID 226\nWall time 11.0 seconds\nOutput:\n',
+      },
+    });
+    handlers.itemCompleted({
+      threadId: 'start-thread-id',
+      turnId: 'turn-1',
+      item: {
+        id: 'item-wait-still-running',
+        type: 'function_call',
+        name: 'wait',
+        arguments: JSON.stringify({ cell_id: '226', yield_time_ms: 1000 }),
+        content: [{ type: 'output_text', text: 'Script running with cell ID 226\nWall time 1.0 seconds\nOutput:\n' }],
+      },
+    });
+    handlers.turnCompleted({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-1', status: 'completed' },
+    });
+    await waitForExpectation(() => {
+      expect(events.some((event) => event.type === 'done' && event.turnContinuationId != null)).toBe(true);
+    });
+    await vi.waitFor(() => {
+      expect(yieldTurnStartCalls(host)).toHaveLength(1);
+    });
+    expect(handle.isTurnRunning?.()).toBe(true);
+    await handle.close();
+  });
+
+  it('does not mint a claim for a finished command without a yield marker', async () => {
+    const agent = new CodexAgent(createDeps());
+    const host = installFakeHost(agent, (method) => {
+      if (method === Method.TurnStart) return { turn: { id: 'turn-1' } };
+      return undefined;
+    });
+    const handle = await agent.startSession({
+      sessionId: 'session-yield-finished-command',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+    });
+    const handlers = host.getThreadHandlers();
+    if (!handlers?.itemCompleted || !handlers.turnCompleted) {
+      throw new Error('expected item and turn handlers');
+    }
+    const events = await collectYieldEvents(handle);
+    await handle.send({ type: 'user', content: 'run typecheck' });
+    handlers.itemCompleted({
+      threadId: 'start-thread-id',
+      turnId: 'turn-1',
+      item: {
+        id: 'item-exec-done',
+        type: 'commandExecution',
+        command: 'pnpm --filter desktop run typecheck',
+        status: 'completed',
+        aggregatedOutput: 'Exit 0',
+        exitCode: 0,
+      },
+    });
+    handlers.turnCompleted({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-1', status: 'completed' },
+    });
+    await waitForExpectation(() => {
+      expect(events.some((event) => event.type === 'done')).toBe(true);
+    });
+    expect(events.find((event) => event.type === 'done')?.turnContinuationId).toBeUndefined();
+    expect(handle.isTurnRunning?.()).toBe(false);
+    expect(yieldTurnStartCalls(host)).toHaveLength(0);
+    await handle.close();
+  });
+
+  it('does not mint a claim from a late item after turn/completed', async () => {
+    const agent = new CodexAgent(createDeps());
+    const host = installFakeHost(agent, (method) => {
+      if (method === Method.TurnStart) return { turn: { id: 'turn-1' } };
+      return undefined;
+    });
+    const handle = await agent.startSession({
+      sessionId: 'session-yield-late-item',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+    });
+    const handlers = host.getThreadHandlers();
+    if (!handlers?.itemCompleted || !handlers.turnCompleted) {
+      throw new Error('expected item and turn handlers');
+    }
+    const events = await collectYieldEvents(handle);
+    await handle.send({ type: 'user', content: 'run typecheck' });
+    handlers.turnCompleted({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-1', status: 'completed' },
+    });
+    await waitForExpectation(() => {
+      expect(events.some((event) => event.type === 'done')).toBe(true);
+    });
+    handlers.itemCompleted({
+      threadId: 'start-thread-id',
+      turnId: 'turn-1',
+      item: {
+        id: 'item-late',
+        type: 'commandExecution',
+        command: 'pnpm --filter desktop run typecheck',
+        status: 'completed',
+        aggregatedOutput: 'Script running with cell ID 226',
+      },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(events.filter((event) => event.type === 'done')).toHaveLength(1);
+    expect(events.find((event) => event.type === 'done')?.turnContinuationId).toBeUndefined();
+    expect(yieldTurnStartCalls(host)).toHaveLength(0);
+    expect(handle.isTurnRunning?.()).toBe(false);
+    await handle.close();
+  });
+
+  it('emits a terminal error when the yield continuation cannot start', async () => {
+    const agent = new CodexAgent(createDeps());
+    let turnStarts = 0;
+    const host = installFakeHost(agent, (method) => {
+      if (method === Method.TurnStart) {
+        turnStarts += 1;
+        if (turnStarts === 1) return { turn: { id: 'turn-1' } };
+        throw new Error('Codex send cannot be accepted: stale host before turn/start');
+      }
+      return undefined;
+    });
+    const handle = await agent.startSession({
+      sessionId: 'session-yield-start-fails',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+    });
+    const handlers = host.getThreadHandlers();
+    if (!handlers?.itemCompleted || !handlers.turnCompleted) {
+      throw new Error('expected item and turn handlers');
+    }
+    const events = await collectYieldEvents(handle);
+    await handle.send({ type: 'user', content: 'run typecheck' });
+    handlers.itemCompleted({
+      threadId: 'start-thread-id',
+      turnId: 'turn-1',
+      item: {
+        id: 'item-exec-fail-start',
+        type: 'commandExecution',
+        command: 'pnpm --filter desktop run typecheck',
+        status: 'completed',
+        aggregatedOutput: 'Script running with cell ID 226',
+      },
+    });
+    handlers.turnCompleted({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-1', status: 'completed' },
+    });
+    await waitForExpectation(() => {
+      expect(events.some((event) => (
+        event.type === 'error'
+        && String((event.data as { reason?: string }).reason ?? '').includes('yield-continuation-start-failed')
+      ))).toBe(true);
+    });
+    expect(handle.isTurnRunning?.()).toBe(false);
+    await handle.close();
+  });
+
+  it('cancels an awaiting yield continuation on Stop without replaying the original request', async () => {
+    const agent = new CodexAgent(createDeps());
+    let turnStarts = 0;
+    const host = installFakeHost(agent, (method) => {
+      if (method === Method.TurnStart) {
+        turnStarts += 1;
+        return { turn: { id: `turn-${turnStarts}` } };
+      }
+      if (method === Method.TurnInterrupt) return {};
+      return undefined;
+    });
+    const handle = await agent.startSession({
+      sessionId: 'session-yield-stop',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+    });
+    const handlers = host.getThreadHandlers();
+    if (!handlers?.itemCompleted || !handlers.turnCompleted) {
+      throw new Error('expected item and turn handlers');
+    }
+    const events = await collectYieldEvents(handle);
+    await handle.send({ type: 'user', content: 'run typecheck' });
+    handlers.itemCompleted({
+      threadId: 'start-thread-id',
+      turnId: 'turn-1',
+      item: {
+        id: 'item-exec-stop',
+        type: 'commandExecution',
+        command: 'pnpm --filter desktop run typecheck',
+        status: 'completed',
+        aggregatedOutput: 'Script running with cell ID 226',
+      },
+    });
+    handlers.turnStarted?.({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-1', status: 'inProgress' },
+    });
+    handlers.turnCompleted({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-1', status: 'completed' },
+    });
+    await waitForExpectation(() => {
+      expect(events.some((event) => event.type === 'done' && event.turnContinuationId != null)).toBe(true);
+    });
+    await vi.waitFor(() => {
+      expect(yieldTurnStartCalls(host)).toHaveLength(1);
+    });
+    const claimedDone = events.find((event) => event.type === 'done' && event.turnContinuationId != null);
+    expect(claimedDone?.turnContinuationId).toEqual(expect.any(Number));
+    await handle.abort();
+    await waitForExpectation(() => {
+      const state = handle.beginTurnContinuationWait?.(claimedDone?.turnContinuationId);
+      expect(state === 'cancelled' || state === null).toBe(true);
+    });
+    expect(host.request).toHaveBeenCalledWith(Method.TurnInterrupt, {
+      threadId: 'start-thread-id',
+      turnId: 'turn-2',
+    });
+    await handle.close();
+  });
+
+  it('does not mint a claim from an agentMessage quoting a yield marker', async () => {
+    const agent = new CodexAgent(createDeps());
+    const host = installFakeHost(agent, (method) => {
+      if (method === Method.TurnStart) return { turn: { id: 'turn-1' } };
+      return undefined;
+    });
+    const handle = await agent.startSession({
+      sessionId: 'session-yield-quoted-message',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+    });
+    const handlers = host.getThreadHandlers();
+    if (!handlers?.itemCompleted || !handlers.turnCompleted) {
+      throw new Error('expected item and turn handlers');
+    }
+    const events = await collectYieldEvents(handle);
+    await handle.send({ type: 'user', content: 'run typecheck' });
+    handlers.itemCompleted({
+      threadId: 'start-thread-id',
+      turnId: 'turn-1',
+      item: {
+        id: 'item-quoted',
+        type: 'agentMessage',
+        text: 'I will wait. Script running with cell ID 777',
+      },
+    });
+    handlers.turnCompleted({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-1', status: 'completed' },
+    });
+    await waitForExpectation(() => {
+      expect(events.some((event) => event.type === 'done')).toBe(true);
+    });
+    expect(events.find((event) => event.type === 'done')?.turnContinuationId).toBeUndefined();
+    expect(yieldTurnStartCalls(host)).toHaveLength(0);
+    expect(handle.isTurnRunning?.()).toBe(false);
+    await handle.close();
+  });
+
+  it('forgets an itemUpdated yield snapshot when the completed item has no marker', async () => {
+    const agent = new CodexAgent(createDeps());
+    const host = installFakeHost(agent, (method) => {
+      if (method === Method.TurnStart) return { turn: { id: 'turn-1' } };
+      return undefined;
+    });
+    const handle = await agent.startSession({
+      sessionId: 'session-yield-updated-then-finished',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+    });
+    const handlers = host.getThreadHandlers();
+    if (!handlers?.itemUpdated || !handlers.itemCompleted || !handlers.turnCompleted) {
+      throw new Error('expected item and turn handlers');
+    }
+    const events = await collectYieldEvents(handle);
+    await handle.send({ type: 'user', content: 'run typecheck' });
+    handlers.itemUpdated({
+      threadId: 'start-thread-id',
+      turnId: 'turn-1',
+      item: {
+        id: 'item-exec-updated',
+        type: 'commandExecution',
+        command: 'pnpm --filter desktop run typecheck',
+        status: 'inProgress',
+        aggregatedOutput: 'Script running with cell ID 226',
+      },
+    });
+    handlers.itemCompleted({
+      threadId: 'start-thread-id',
+      turnId: 'turn-1',
+      item: {
+        id: 'item-exec-updated',
+        type: 'commandExecution',
+        command: 'pnpm --filter desktop run typecheck',
+        status: 'completed',
+        aggregatedOutput: 'Exit 0',
+        exitCode: 0,
+      },
+    });
+    handlers.turnCompleted({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-1', status: 'completed' },
+    });
+    await waitForExpectation(() => {
+      expect(events.some((event) => event.type === 'done')).toBe(true);
+    });
+    expect(events.find((event) => event.type === 'done')?.turnContinuationId).toBeUndefined();
+    expect(yieldTurnStartCalls(host)).toHaveLength(0);
+    expect(handle.isTurnRunning?.()).toBe(false);
+    await handle.close();
+  });
+
+  it('emits a terminal error when a later continuation start is rejected without throwing', async () => {
+    const agent = new CodexAgent(createDeps());
+    let turnStarts = 0;
+    const host = installFakeHost(agent, (method) => {
+      if (method === Method.TurnStart) {
+        turnStarts += 1;
+        if (turnStarts === 1) return { turn: { id: 'turn-1' } };
+        throw new Error('turn/start failed: timeout');
+      }
+      return undefined;
+    });
+    const handle = await agent.startSession({
+      sessionId: 'session-yield-ordinary-start-fail',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+    });
+    const handlers = host.getThreadHandlers();
+    if (!handlers?.itemCompleted || !handlers.turnCompleted) {
+      throw new Error('expected item and turn handlers');
+    }
+    const events = await collectYieldEvents(handle);
+    await handle.send({ type: 'user', content: 'run typecheck' });
+    handlers.itemCompleted({
+      threadId: 'start-thread-id',
+      turnId: 'turn-1',
+      item: {
+        id: 'item-exec-timeout',
+        type: 'commandExecution',
+        command: 'pnpm --filter desktop run typecheck',
+        status: 'completed',
+        aggregatedOutput: 'Script running with cell ID 226',
+      },
+    });
+    handlers.turnCompleted({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-1', status: 'completed' },
+    });
+    await waitForExpectation(() => {
+      expect(events.some((event) => (
+        event.type === 'error'
+        && String((event.data as { reason?: string }).reason ?? '').includes('yield-continuation-start-failed')
+      ))).toBe(true);
+    });
+    expect(handle.isTurnRunning?.()).toBe(false);
+    await handle.close();
+  });
+
+  it('settles the product turn after the continuation waits the yielded cell', async () => {
+    const agent = new CodexAgent(createDeps());
+    let turnSeq = 0;
+    const host = installFakeHost(agent, (method) => {
+      if (method === Method.TurnStart) {
+        turnSeq += 1;
+        return { turn: { id: `turn-${turnSeq}` } };
+      }
+      return undefined;
+    });
+    const handle = await agent.startSession({
+      sessionId: 'session-yield-continuation-wait-settled',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+    });
+    const handlers = host.getThreadHandlers();
+    if (!handlers?.itemCompleted || !handlers.turnCompleted) {
+      throw new Error('expected item and turn handlers');
+    }
+    const events = await collectYieldEvents(handle);
+    await handle.send({ type: 'user', content: 'run typecheck' });
+    handlers.itemCompleted({
+      threadId: 'start-thread-id',
+      turnId: 'turn-1',
+      item: {
+        id: 'item-exec-cross-turn',
+        type: 'commandExecution',
+        command: 'pnpm --filter desktop run typecheck',
+        status: 'completed',
+        aggregatedOutput: 'Script running with cell ID 226\nWall time 11.0 seconds\nOutput:\n',
+      },
+    });
+    handlers.turnCompleted({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-1', status: 'completed' },
+    });
+    await vi.waitFor(() => {
+      expect(yieldTurnStartCalls(host)).toHaveLength(1);
+    });
+    handlers.turnStarted?.({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-2', status: 'inProgress' },
+    });
+    handlers.itemCompleted({
+      threadId: 'start-thread-id',
+      turnId: 'turn-2',
+      item: {
+        id: 'item-wait-cross-turn',
+        type: 'function_call',
+        name: 'wait',
+        arguments: JSON.stringify({ cell_id: '226', max_tokens: 1000 }),
+        content: [{ type: 'output_text', text: 'Script completed\nWall time 4.2 seconds\nOutput:\n' }],
+      },
+    });
+    handlers.turnCompleted({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-2', status: 'completed' },
+    });
+    await waitForExpectation(() => {
+      expect(events.filter((event) => event.type === 'done')).toHaveLength(2);
+    });
+    expect(events.some((event) => (
+      event.type === 'error'
+      && String((event.data as { reason?: string }).reason ?? '') === 'yield-continuation-lost-handle'
+    ))).toBe(false);
+    const dones = events.filter((event) => event.type === 'done');
+    expect(dones[0]?.turnContinuationId).toEqual(expect.any(Number));
+    expect(dones[1]?.turnContinuationId).toBeUndefined();
+    expect(handle.isTurnRunning?.()).toBe(false);
+    await handle.close();
+  });
+
+  it('emits lost-handle without a later successful done after an empty continuation', async () => {
+    const agent = new CodexAgent(createDeps());
+    let turnSeq = 0;
+    const host = installFakeHost(agent, (method) => {
+      if (method === Method.TurnStart) {
+        turnSeq += 1;
+        return { turn: { id: `turn-${turnSeq}` } };
+      }
+      return undefined;
+    });
+    const handle = await agent.startSession({
+      sessionId: 'session-yield-empty-continuation',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+    });
+    const handlers = host.getThreadHandlers();
+    if (!handlers?.itemCompleted || !handlers.turnCompleted) {
+      throw new Error('expected item and turn handlers');
+    }
+    const events = await collectYieldEvents(handle);
+    await handle.send({ type: 'user', content: 'run typecheck' });
+    handlers.itemCompleted({
+      threadId: 'start-thread-id',
+      turnId: 'turn-1',
+      item: {
+        id: 'item-exec-empty',
+        type: 'commandExecution',
+        command: 'pnpm --filter desktop run typecheck',
+        status: 'completed',
+        aggregatedOutput: 'Script running with cell ID 226',
+      },
+    });
+    handlers.turnCompleted({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-1', status: 'completed' },
+    });
+    await vi.waitFor(() => {
+      expect(yieldTurnStartCalls(host)).toHaveLength(1);
+    });
+    handlers.turnStarted?.({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-2', status: 'inProgress' },
+    });
+    handlers.turnCompleted({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-2', status: 'completed' },
+    });
+    await waitForExpectation(() => {
+      expect(events.filter((event) => (
+        event.type === 'error'
+        && String((event.data as { reason?: string }).reason ?? '') === 'yield-continuation-lost-handle'
+      ))).toHaveLength(1);
+    });
+    const claimedDone = events.find((event) => event.type === 'done' && event.turnContinuationId != null);
+    expect(claimedDone).toBeDefined();
+    expect(events.filter((event) => event.type === 'done' && event.turnContinuationId == null)).toHaveLength(0);
+    expect(handle.isTurnRunning?.()).toBe(false);
+    await handle.close();
+  });
+
+  it('does not append a successful done after exhausting yield retries', async () => {
+    const agent = new CodexAgent(createDeps());
+    let turnSeq = 0;
+    const host = installFakeHost(agent, (method) => {
+      if (method === Method.TurnStart) {
+        turnSeq += 1;
+        return { turn: { id: `turn-${turnSeq}` } };
+      }
+      return undefined;
+    });
+    const handle = await agent.startSession({
+      sessionId: 'session-yield-retry-exhausted',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+    });
+    const handlers = host.getThreadHandlers();
+    if (!handlers?.itemCompleted || !handlers.turnCompleted) {
+      throw new Error('expected item and turn handlers');
+    }
+    const events = await collectYieldEvents(handle);
+    await handle.send({ type: 'user', content: 'run typecheck' });
+    handlers.itemCompleted({
+      threadId: 'start-thread-id',
+      turnId: 'turn-1',
+      item: {
+        id: 'item-exec-retry-1',
+        type: 'commandExecution',
+        command: 'pnpm --filter desktop run typecheck',
+        status: 'completed',
+        aggregatedOutput: 'Script running with cell ID 226',
+      },
+    });
+    handlers.turnCompleted({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-1', status: 'completed' },
+    });
+    await vi.waitFor(() => {
+      expect(yieldTurnStartCalls(host)).toHaveLength(1);
+    });
+    handlers.turnStarted?.({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-2', status: 'inProgress' },
+    });
+    handlers.itemCompleted({
+      threadId: 'start-thread-id',
+      turnId: 'turn-2',
+      item: {
+        id: 'item-exec-retry-2',
+        type: 'commandExecution',
+        command: 'pnpm --filter desktop run typecheck',
+        status: 'completed',
+        aggregatedOutput: 'Script running with cell ID 226',
+      },
+    });
+    handlers.turnCompleted({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-2', status: 'completed' },
+    });
+    await vi.waitFor(() => {
+      expect(yieldTurnStartCalls(host)).toHaveLength(2);
+    });
+    handlers.turnStarted?.({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-3', status: 'inProgress' },
+    });
+    handlers.itemCompleted({
+      threadId: 'start-thread-id',
+      turnId: 'turn-3',
+      item: {
+        id: 'item-exec-retry-3',
+        type: 'commandExecution',
+        command: 'pnpm --filter desktop run typecheck',
+        status: 'completed',
+        aggregatedOutput: 'Script running with cell ID 226',
+      },
+    });
+    handlers.turnCompleted({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-3', status: 'completed' },
+    });
+    await waitForExpectation(() => {
+      expect(events.filter((event) => (
+        event.type === 'error'
+        && String((event.data as { reason?: string }).reason ?? '') === 'yield-continuation-lost-handle'
+      ))).toHaveLength(1);
+    });
+    expect(events.filter((event) => event.type === 'done' && event.turnContinuationId == null)).toHaveLength(0);
+    expect(handle.isTurnRunning?.()).toBe(false);
+    await handle.close();
+  });
+
+  it('releases a yield claim on transport error so the session is not permanently busy', async () => {
+    const agent = new CodexAgent(createDeps());
+    const host = installFakeHost(agent, (method) => {
+      if (method === Method.TurnStart) return { turn: { id: 'turn-1' } };
+      return undefined;
+    });
+    const handle = await agent.startSession({
+      sessionId: 'session-yield-transport-error',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+    });
+    const handlers = host.getThreadHandlers();
+    if (!handlers?.itemCompleted || !handlers.turnCompleted || !handlers.error) {
+      throw new Error('expected item, turn, and error handlers');
+    }
+    const events = await collectYieldEvents(handle);
+    await handle.send({ type: 'user', content: 'run typecheck' });
+    handlers.itemCompleted({
+      threadId: 'start-thread-id',
+      turnId: 'turn-1',
+      item: {
+        id: 'item-exec-transport',
+        type: 'commandExecution',
+        command: 'pnpm --filter desktop run typecheck',
+        status: 'completed',
+        aggregatedOutput: 'Script running with cell ID 226',
+      },
+    });
+    handlers.turnCompleted({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-1', status: 'completed' },
+    });
+    await waitForExpectation(() => {
+      expect(events.some((event) => event.type === 'done' && event.turnContinuationId != null)).toBe(true);
+    });
+    expect(handle.isTurnRunning?.()).toBe(true);
+    handlers.error({
+      threadId: 'start-thread-id',
+      turnId: 'turn-1',
+      scope: 'transport',
+      willRetry: false,
+      error: { message: 'app-server disconnected' },
+    });
+    await waitForExpectation(() => {
+      expect(handle.isTurnRunning?.()).toBe(false);
+    });
+    await handle.close();
+  });
+});
+
 describe('CodexAgent steer', () => {
   it('rejects when the session is already closed before steering', async () => {
     const agent = new CodexAgent(createDeps());

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -17767,6 +17767,68 @@ describe('CodexAgent yield continuation', () => {
     await handle.close();
   });
 
+  it('keeps a nameless yielded exec_command when a later nameless exec completes without a marker', async () => {
+    const agent = new CodexAgent(createDeps());
+    let turnSeq = 0;
+    const host = installFakeHost(agent, (method) => {
+      if (method === Method.TurnStart) {
+        turnSeq += 1;
+        return { turn: { id: `turn-${turnSeq}` } };
+      }
+      return undefined;
+    });
+    const handle = await agent.startSession({
+      sessionId: 'session-yield-nameless-sibling-exit',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+    });
+    const handlers = host.getThreadHandlers();
+    if (!handlers?.itemCompleted || !handlers.turnCompleted) {
+      throw new Error('expected item and turn handlers');
+    }
+    const events = await collectYieldEvents(handle);
+    await handle.send({ type: 'user', content: 'run typecheck' });
+    handlers.itemCompleted({
+      threadId: 'start-thread-id',
+      turnId: 'turn-1',
+      item: {
+        type: 'function_call',
+        name: 'exec_command',
+        arguments: JSON.stringify({
+          cmd: 'pnpm --filter desktop run typecheck',
+          yield_time_ms: 10_000,
+        }),
+        content: [{ type: 'output_text', text: 'Script running with cell ID 229' }],
+      },
+    });
+    handlers.itemCompleted({
+      threadId: 'start-thread-id',
+      turnId: 'turn-1',
+      item: {
+        type: 'function_call',
+        name: 'exec_command',
+        arguments: JSON.stringify({ cmd: 'echo done' }),
+        content: [{ type: 'output_text', text: 'Exit 0' }],
+        exitCode: 0,
+      },
+    });
+    handlers.turnCompleted({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-1', status: 'completed' },
+    });
+    await waitForExpectation(() => {
+      expect(events.some((event) => event.type === 'done' && event.turnContinuationId != null)).toBe(true);
+    });
+    await vi.waitFor(() => {
+      expect(yieldTurnStartCalls(host)).toHaveLength(1);
+    });
+    const [, params] = yieldTurnStartCalls(host)[0] as [string, {
+      input: Array<{ text?: string }>;
+    }];
+    expect(params.input[0]?.text).toContain('Wait for cell ID 229');
+    await handle.close();
+  });
+
   it('does not mint a claim after wait settles the yielded cell in the same turn', async () => {
     const agent = new CodexAgent(createDeps());
     const host = installFakeHost(agent, (method) => {

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -17726,6 +17726,76 @@ describe('CodexAgent yield continuation', () => {
     await handle.close();
   });
 
+  it('does not cancel a yield claim when ask_user continuation starts', async () => {
+    const agent = new CodexAgent(createDeps());
+    let turnSeq = 0;
+    const host = installFakeHost(agent, (method) => {
+      if (method === Method.TurnStart) {
+        turnSeq += 1;
+        return { turn: { id: `turn-${turnSeq}` } };
+      }
+      return undefined;
+    });
+    const handle = await agent.startSession({
+      sessionId: 'session-yield-ask-user-internal',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+    });
+    const handlers = host.getThreadHandlers();
+    if (!handlers?.itemCompleted || !handlers.turnCompleted || !handlers.requestUserInput) {
+      throw new Error('expected item, turn, and user-input handlers');
+    }
+    const ownerDecision = deferred<InteractionDecision>();
+    handle.setInteractionResolver(async () => ownerDecision.promise);
+    const events = await collectYieldEvents(handle);
+    await handle.send({ type: 'user', content: 'run typecheck' });
+    void handlers.requestUserInput({
+      threadId: 'start-thread-id',
+      turnId: 'turn-1',
+      itemId: 'item-ask',
+      questions: [{
+        id: 'native-q1',
+        header: 'Question',
+        question: 'Pick one',
+        isOther: false,
+        isSecret: false,
+        options: [{ label: 'A', description: null }],
+      }],
+    }, { requestId: 'req-ask' });
+    handlers.itemCompleted({
+      threadId: 'start-thread-id',
+      turnId: 'turn-1',
+      item: {
+        id: 'item-exec-ask',
+        type: 'commandExecution',
+        command: 'pnpm --filter desktop run typecheck',
+        status: 'completed',
+        aggregatedOutput: 'Script running with cell ID 226',
+      },
+    });
+    handlers.turnCompleted({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-1', status: 'completed' },
+    });
+    await waitForExpectation(() => {
+      expect(events.some((event) => event.type === 'done' && event.turnContinuationId != null)).toBe(true);
+    });
+    await vi.waitFor(() => {
+      expect(yieldTurnStartCalls(host)).toHaveLength(1);
+    });
+    ownerDecision.resolve({
+      kind: 'ask_user_question',
+      answers: { 'Pick one': 'A' },
+    });
+    await vi.waitFor(() => {
+      expect(host.request.mock.calls.filter(([method]) => method === Method.TurnStart)).toHaveLength(3);
+    });
+    const claimedDone = events.find((event) => event.type === 'done' && event.turnContinuationId != null);
+    expect(handle.beginTurnContinuationWait?.(claimedDone?.turnContinuationId)).toBe('active');
+    expect(handle.isTurnRunning?.()).toBe(true);
+    await handle.close();
+  });
+
   it('emits a terminal error when the yield continuation cannot start', async () => {
     const agent = new CodexAgent(createDeps());
     let turnStarts = 0;

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -17854,12 +17854,30 @@ describe('CodexAgent yield continuation', () => {
       kind: 'ask_user_question',
       answers: { 'Pick one': 'A' },
     });
-    await vi.waitFor(() => {
-      expect(host.request.mock.calls.filter(([method]) => method === Method.TurnStart)).toHaveLength(3);
-    });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(host.request.mock.calls.filter(([method]) => method === Method.TurnStart)).toHaveLength(2);
     const claimedDone = events.find((event) => event.type === 'done' && event.turnContinuationId != null);
     expect(handle.beginTurnContinuationWait?.(claimedDone?.turnContinuationId)).toBe('active');
     expect(handle.isTurnRunning?.()).toBe(true);
+    handlers.itemCompleted({
+      threadId: 'start-thread-id',
+      turnId: 'turn-2',
+      item: {
+        id: 'item-wait-ask-serial',
+        type: 'function_call',
+        name: 'wait',
+        arguments: JSON.stringify({ cell_id: '226', max_tokens: 1000 }),
+        content: [{ type: 'output_text', text: 'Script completed\nWall time 0.1 seconds\nOutput:\n' }],
+      },
+    });
+    handlers.turnCompleted({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-2', status: 'completed' },
+    });
+    await vi.waitFor(() => {
+      expect(host.request.mock.calls.filter(([method]) => method === Method.TurnStart)).toHaveLength(3);
+    });
+    expect(handle.beginTurnContinuationWait?.(claimedDone?.turnContinuationId)).toBeNull();
     await handle.close();
   });
 
@@ -18500,6 +18518,59 @@ describe('CodexAgent yield continuation', () => {
     await waitForExpectation(() => {
       expect(handle.isTurnRunning?.()).toBe(false);
     });
+    await handle.close();
+  });
+
+  it('does not cancel an active yield claim for a late foreign failed turn', async () => {
+    const agent = new CodexAgent(createDeps());
+    let turnSeq = 0;
+    const host = installFakeHost(agent, (method) => {
+      if (method === Method.TurnStart) {
+        turnSeq += 1;
+        return { turn: { id: `turn-${turnSeq}` } };
+      }
+      return undefined;
+    });
+    const handle = await agent.startSession({
+      sessionId: 'session-yield-foreign-failed-turn',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+    });
+    const handlers = host.getThreadHandlers();
+    if (!handlers?.itemCompleted || !handlers.turnCompleted) {
+      throw new Error('expected item and turn handlers');
+    }
+    const events = await collectYieldEvents(handle);
+    await handle.send({ type: 'user', content: 'run typecheck' });
+    handlers.itemCompleted({
+      threadId: 'start-thread-id',
+      turnId: 'turn-1',
+      item: {
+        id: 'item-exec-foreign-fail',
+        type: 'commandExecution',
+        command: 'pnpm --filter desktop run typecheck',
+        status: 'completed',
+        aggregatedOutput: 'Script running with cell ID 226',
+      },
+    });
+    handlers.turnCompleted({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-1', status: 'completed' },
+    });
+    await waitForExpectation(() => {
+      expect(events.some((event) => event.type === 'done' && event.turnContinuationId != null)).toBe(true);
+    });
+    await vi.waitFor(() => {
+      expect(yieldTurnStartCalls(host)).toHaveLength(1);
+    });
+    const claimedDone = events.find((event) => event.type === 'done' && event.turnContinuationId != null);
+    expect(handle.beginTurnContinuationWait?.(claimedDone?.turnContinuationId)).toBe('active');
+    handlers.turnCompleted({
+      threadId: 'start-thread-id',
+      turn: { id: 'old-foreign-turn', status: 'failed', error: { message: 'stale turn failed' } },
+    });
+    expect(handle.beginTurnContinuationWait?.(claimedDone?.turnContinuationId)).toBe('active');
+    expect(handle.isTurnRunning?.()).toBe(true);
     await handle.close();
   });
 });

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -17417,6 +17417,61 @@ describe('CodexAgent yield continuation', () => {
     await handle.close();
   });
 
+  it('inherits the origin turnPermissionPolicy on the yield continuation turn', async () => {
+    const agent = new CodexAgent(createDeps());
+    let turnSeq = 0;
+    const host = installFakeHost(agent, (method) => {
+      if (method === Method.TurnStart) {
+        turnSeq += 1;
+        return { turn: { id: `turn-${turnSeq}` } };
+      }
+      return undefined;
+    });
+    const handle = await agent.startSession({
+      sessionId: 'session-yield-permission-policy',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+      permissionMode: 'auto',
+    });
+    const handlers = host.getThreadHandlers();
+    if (!handlers?.itemCompleted || !handlers.turnCompleted) {
+      throw new Error('expected item and turn handlers');
+    }
+    const events = await collectYieldEvents(handle);
+    const policy: TurnPermissionPolicy = {
+      origin: { kind: 'im', channel: 'wechat', taskId: 'task-yield' },
+      confirmationSurface: 'desktop',
+      forceConfirmToolCall: (_toolName, input) => JSON.stringify(input).includes('rm -rf'),
+    };
+    await handle.send({ type: 'user', content: 'run typecheck' }, { turnPermissionPolicy: policy });
+    handlers.itemCompleted({
+      threadId: 'start-thread-id',
+      turnId: 'turn-1',
+      item: {
+        id: 'item-exec-policy',
+        type: 'commandExecution',
+        command: 'pnpm --filter desktop run typecheck',
+        status: 'completed',
+        aggregatedOutput: 'Script running with cell ID 226',
+      },
+    });
+    handlers.turnCompleted({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-1', status: 'completed' },
+    });
+    await vi.waitFor(() => {
+      expect(yieldTurnStartCalls(host)).toHaveLength(1);
+    });
+    const [, continuationParams] = yieldTurnStartCalls(host)[0] as [string, Record<string, unknown>];
+    expect(continuationParams).toMatchObject({
+      approvalPolicy: 'untrusted',
+      sandboxPolicy: { type: 'readOnly' },
+    });
+    expect(continuationParams).not.toHaveProperty('approvalsReviewer');
+    expect(events.some((event) => event.type === 'done' && event.turnContinuationId != null)).toBe(true);
+    await handle.close();
+  });
+
   it('detects Responses/proxy function_call(exec_command) yield output', async () => {
     const agent = new CodexAgent(createDeps());
     let turnSeq = 0;

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -18375,6 +18375,78 @@ describe('CodexAgent yield continuation', () => {
     await handle.close();
   });
 
+  it('lets provider interrupted emit the only unclaimed cancelled done after TurnStart returns', async () => {
+    const agent = new CodexAgent(createDeps());
+    let turnSeq = 0;
+    const host = installFakeHost(agent, (method) => {
+      if (method === Method.TurnStart) {
+        turnSeq += 1;
+        return { turn: { id: `turn-${turnSeq}` } };
+      }
+      if (method === Method.TurnInterrupt) return {};
+      return undefined;
+    });
+    const handle = await agent.startSession({
+      sessionId: 'session-yield-stop-after-start-resp',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+    });
+    const handlers = host.getThreadHandlers();
+    if (!handlers?.itemCompleted || !handlers.turnCompleted || !handlers.turnStarted) {
+      throw new Error('expected item, turn, and started handlers');
+    }
+    const events = await collectYieldEvents(handle);
+    await handle.send({ type: 'user', content: 'run typecheck' });
+    handlers.itemCompleted({
+      threadId: 'start-thread-id',
+      turnId: 'turn-1',
+      item: {
+        id: 'item-exec-stop-after-resp',
+        type: 'commandExecution',
+        command: 'pnpm --filter desktop run typecheck',
+        status: 'completed',
+        aggregatedOutput: 'Script running with cell ID 226',
+      },
+    });
+    handlers.turnCompleted({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-1', status: 'completed' },
+    });
+    await vi.waitFor(() => {
+      expect(yieldTurnStartCalls(host)).toHaveLength(1);
+    });
+    handlers.turnStarted({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-2', status: 'inProgress' },
+    });
+    expect(handle.getCurrentTurnId?.()).toBe('turn-2');
+    await handle.abort();
+    await waitForExpectation(() => {
+      expect(host.request).toHaveBeenCalledWith(Method.TurnInterrupt, {
+        threadId: 'start-thread-id',
+        turnId: 'turn-2',
+      });
+    });
+    expect(events.filter((event) => (
+      event.type === 'done'
+      && event.turnContinuationId == null
+      && (event.data as { cancelled?: boolean }).cancelled === true
+    ))).toHaveLength(0);
+    handlers.turnCompleted({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-2', status: 'interrupted' },
+    });
+    await waitForExpectation(() => {
+      expect(events.filter((event) => (
+        event.type === 'done'
+        && event.turnContinuationId == null
+        && (event.data as { cancelled?: boolean }).cancelled === true
+      ))).toHaveLength(1);
+    });
+    expect(handle.isTurnRunning?.()).toBe(false);
+    await handle.close();
+  });
+
   it('does not mint a claim from an agentMessage quoting a yield marker', async () => {
     const agent = new CodexAgent(createDeps());
     const host = installFakeHost(agent, (method) => {

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -3349,6 +3349,9 @@ export class CodexAgent extends BaseAgent {
         data: { status: 'Done', ...usageTracker.snapshot(), isRunning: false },
         source: 'codex',
       });
+      // Failure is a product terminal. Queued ask_user / plan waiters must exit
+      // rather than treat this as idle success and start another turn.
+      flushYieldContinuationIdleWaiters(true);
     };
     const emitYieldContinuationStartFailure = (error: unknown, cells: YieldedExecCell[]): void => {
       emitYieldContinuationFailure({
@@ -9035,7 +9038,6 @@ export class CodexAgent extends BaseAgent {
             yieldedCells.length === 0 ? 'empty_completion' : 'retry_exhausted',
           );
           suppressSuccessfulYieldBoundary = true;
-          flushYieldContinuationIdleWaiters();
         } else {
           yieldClaim = mintYieldContinuationClaim(outstandingCells, turn.id, retryCount);
         }
@@ -11021,16 +11023,20 @@ export class CodexAgent extends BaseAgent {
           rejectIfCancelled(sendOpts, 'send');
           const message = `Failed to restore Codex read-only reference permissions: ${String(e)}`;
           log.error('read-only reference profile refresh failed', { error: String(e), threadId });
-          eventQueue.push({
-            type: 'error',
-            data: { message, isTerminal: true },
-            source: 'codex',
-          });
-          eventQueue.push({
-            type: 'status',
-            data: { status: 'Done', ...usageTracker.snapshot(), isRunning: false },
-            source: 'codex',
-          });
+          // Yield continuation owns its product terminal. Emitting here would
+          // duplicate the later yield-continuation-start-failed events.
+          if (yieldAttempt == null) {
+            eventQueue.push({
+              type: 'error',
+              data: { message, isTerminal: true },
+              source: 'codex',
+            });
+            eventQueue.push({
+              type: 'status',
+              data: { status: 'Done', ...usageTracker.snapshot(), isRunning: false },
+              source: 'codex',
+            });
+          }
           if (sendOpts?.throwOnStartFailure) throw new Error(message);
           return;
         }
@@ -11635,7 +11641,7 @@ export class CodexAgent extends BaseAgent {
             log.info('turn/start failure suppressed — this send was already settled by cancel', {
               threadId,
             });
-          } else {
+          } else if (yieldAttempt == null) {
             eventQueue.push({
               type: 'error',
               data: { message: `turn/start failed: ${String(finalErr)}`, isTerminal: true },

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -1184,6 +1184,8 @@ type YieldContinuationClaim = {
   originTurnId: string;
   continuationTurnId: string | null;
   permissionPolicy: TurnPermissionPolicy | null;
+  capabilitySelectionText: string;
+  autoReviewIntent: string;
   deferredPlanText: string | null;
   deferredPlanTurnId: string | null;
   deferredPlanCapabilitySelectionText: string;
@@ -3264,6 +3266,8 @@ export class CodexAgent extends BaseAgent {
         originTurnId,
         continuationTurnId: null,
         permissionPolicy: activeTurnPermissionPolicy,
+        capabilitySelectionText: '',
+        autoReviewIntent: '',
         deferredPlanText: null,
         deferredPlanTurnId: null,
         deferredPlanCapabilitySelectionText: '',
@@ -3429,6 +3433,12 @@ export class CodexAgent extends BaseAgent {
         signal: abort.signal,
         ...(claim.permissionPolicy
           ? { turnPermissionPolicy: claim.permissionPolicy }
+          : {}),
+        ...(claim.capabilitySelectionText
+          ? { [CODEX_INHERITED_CAPABILITY_SELECTION]: claim.capabilitySelectionText }
+          : {}),
+        ...(claim.autoReviewIntent
+          ? { [CODEX_AUTO_REVIEW_INTENT]: claim.autoReviewIntent }
           : {}),
       };
       try {
@@ -9061,6 +9071,12 @@ export class CodexAgent extends BaseAgent {
         if (yieldedCells.length > 0) {
           yieldClaim.cells = dedupeCells([...yieldClaim.cells, ...yieldedCells]);
         }
+        if (!yieldClaim.capabilitySelectionText && completedCapabilitySelectionText) {
+          yieldClaim.capabilitySelectionText = completedCapabilitySelectionText;
+        }
+        if (!yieldClaim.autoReviewIntent && currentAutoReviewIntent) {
+          yieldClaim.autoReviewIntent = currentAutoReviewIntent;
+        }
       } else if (existingYieldClaim?.state === 'active') {
         existingYieldClaim.settled = true;
         activeYieldContinuationId = null;
@@ -9083,6 +9099,9 @@ export class CodexAgent extends BaseAgent {
           suppressSuccessfulYieldBoundary = true;
         } else {
           yieldClaim = mintYieldContinuationClaim(outstandingCells, turn.id, retryCount);
+          yieldClaim.permissionPolicy = existingYieldClaim.permissionPolicy;
+          yieldClaim.capabilitySelectionText = existingYieldClaim.capabilitySelectionText;
+          yieldClaim.autoReviewIntent = existingYieldClaim.autoReviewIntent;
           yieldClaim.deferredPlanText = existingYieldClaim.deferredPlanText;
           yieldClaim.deferredPlanTurnId = existingYieldClaim.deferredPlanTurnId;
           yieldClaim.deferredPlanCapabilitySelectionText =
@@ -9090,6 +9109,10 @@ export class CodexAgent extends BaseAgent {
         }
       } else if (yieldedCells.length > 0) {
         yieldClaim = mintYieldContinuationClaim(yieldedCells, turn.id, 0);
+        // turn/completed already deleted the origin turn's selection map. Use the
+        // snapshot taken before that delete, plus the still-live review intent.
+        yieldClaim.capabilitySelectionText = completedCapabilitySelectionText;
+        yieldClaim.autoReviewIntent = currentAutoReviewIntent;
       }
       if (!suppressSuccessfulYieldBoundary) {
         const idleStatusEvent: AgentEvent = {

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -1164,11 +1164,13 @@ const CODEX_INHERITED_CAPABILITY_SELECTION = Symbol('codexInheritedCapabilitySel
 // 直接拿它当 review intent 会让灰区 reviewer 完全看不到用户原始请求与获批计划(codex 报)。
 const CODEX_AUTO_REVIEW_INTENT = Symbol('codexAutoReviewIntent');
 const CODEX_YIELD_CONTINUATION = Symbol('codexYieldContinuation');
+const CODEX_INTERNAL_CONTINUATION = Symbol('codexInternalContinuation');
 const YIELD_CONTINUATION_MAX_ATTEMPTS = 2;
 type CodexInternalSendOptions = SendOptions & {
   [CODEX_INHERITED_CAPABILITY_SELECTION]?: string;
   [CODEX_AUTO_REVIEW_INTENT]?: string;
   [CODEX_YIELD_CONTINUATION]?: number;
+  [CODEX_INTERNAL_CONTINUATION]?: true;
 };
 type YieldContinuationClaim = {
   id: number;
@@ -3335,6 +3337,7 @@ export class CodexAgent extends BaseAgent {
       yieldContinuationAbort = abort;
       const sendOptions: CodexInternalSendOptions = {
         [CODEX_YIELD_CONTINUATION]: claim.retryCount + 1,
+        [CODEX_INTERNAL_CONTINUATION]: true,
         throwOnStartFailure: true,
         signal: abort.signal,
       };
@@ -5898,6 +5901,7 @@ export class CodexAgent extends BaseAgent {
           .filter(Boolean)
           .join('\n'),
         ...(autoReviewIntent ? { [CODEX_AUTO_REVIEW_INTENT]: autoReviewIntent } : {}),
+        [CODEX_INTERNAL_CONTINUATION]: true,
       });
       const emitPlanFollowUpStartFailure = (kind: 'implementation' | 'revision', error: unknown): void => {
         log.warn(`plan ${kind} turn failed to start`, { error: String(error) });
@@ -6287,6 +6291,7 @@ export class CodexAgent extends BaseAgent {
           ? { [CODEX_INHERITED_CAPABILITY_SELECTION]: live.capabilitySelectionText }
           : {}),
         ...(autoReviewIntent ? { [CODEX_AUTO_REVIEW_INTENT]: autoReviewIntent } : {}),
+        [CODEX_INTERNAL_CONTINUATION]: true,
       };
       try {
         await handle.send({ type: 'user', content: message }, sendOptions);
@@ -10841,8 +10846,9 @@ export class CodexAgent extends BaseAgent {
         if (rejectClosedOrCancelledSend(sendOpts, 'before start')) {
           return;
         }
-        const yieldAttempt = (sendOpts as CodexInternalSendOptions | undefined)?.[CODEX_YIELD_CONTINUATION];
-        if (yieldAttempt == null) {
+        const internalOpts = sendOpts as CodexInternalSendOptions | undefined;
+        const yieldAttempt = internalOpts?.[CODEX_YIELD_CONTINUATION];
+        if (yieldAttempt == null && internalOpts?.[CODEX_INTERNAL_CONTINUATION] !== true) {
           cancelActiveYieldContinuation('new send');
         }
         // 用户开启新 turn = 旧重连序列作废；deadline 不得跨 turn 误伤新请求。

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -3137,6 +3137,7 @@ export class CodexAgent extends BaseAgent {
     let yieldContinuationInFlight = false;
     let yieldContinuationAbort: AbortController | null = null;
     let yieldContinuationIdleWaiters: Array<(cancelled: boolean) => void> = [];
+    let yieldContinuationProductFailed = false;
     const emitYieldContinuationState = (
       continuationId: number,
       state: 'awaiting' | 'active' | 'cancelled',
@@ -3259,6 +3260,7 @@ export class CodexAgent extends BaseAgent {
       };
       yieldContinuationClaims.set(claim.id, claim);
       activeYieldContinuationId = claim.id;
+      yieldContinuationProductFailed = false;
       log.info('yield continuation claim created', {
         continuationId: claim.id,
         originTurnId,
@@ -3283,9 +3285,25 @@ export class CodexAgent extends BaseAgent {
       for (const resolve of waiters) resolve(cancelled);
     };
     const waitForYieldContinuationIdle = async (): Promise<boolean> => {
+      if (yieldContinuationProductFailed) return true;
       if (activeYieldContinuationClaim() == null && !yieldContinuationInFlight) return false;
       return await new Promise<boolean>((resolve) => {
         yieldContinuationIdleWaiters.push(resolve);
+      });
+    };
+    const emitCancelledYieldProductDone = (): void => {
+      eventQueue.push({
+        type: 'done',
+        data: {
+          type: 'codex/event/task_complete',
+          cancelled: true,
+        },
+        source: 'codex',
+      });
+      eventQueue.push({
+        type: 'status',
+        data: { status: 'Done', ...usageTracker.snapshot(), isRunning: false },
+        source: 'codex',
       });
     };
     const cancelActiveYieldContinuation = (reason: string): YieldContinuationClaim | null => {
@@ -3357,9 +3375,15 @@ export class CodexAgent extends BaseAgent {
         data: { status: 'Done', ...usageTracker.snapshot(), isRunning: false },
         source: 'codex',
       });
-      // Failure is a product terminal. Queued ask_user / plan waiters must exit
-      // rather than treat this as idle success and start another turn.
+      // Failure is a product terminal. Latch so later ask_user / plan answers
+      // cannot treat idle as permission to start another turn, and dismiss
+      // unfinished cards from the failed product turn.
+      yieldContinuationProductFailed = true;
       flushYieldContinuationIdleWaiters(true);
+      planCycleActive = false;
+      proposedPlanText = null;
+      dismissAllPending(opts.reason, 'deny');
+      dismissAllPendingUserInput(opts.reason);
     };
     const emitYieldContinuationStartFailure = (error: unknown, cells: YieldedExecCell[]): void => {
       emitYieldContinuationFailure({
@@ -10948,6 +10972,7 @@ export class CodexAgent extends BaseAgent {
         const yieldAttempt = internalOpts?.[CODEX_YIELD_CONTINUATION];
         if (yieldAttempt == null && internalOpts?.[CODEX_INTERNAL_CONTINUATION] !== true) {
           cancelActiveYieldContinuation('new send');
+          yieldContinuationProductFailed = false;
         }
         // 用户开启新 turn = 旧重连序列作废；deadline 不得跨 turn 误伤新请求。
         clearReconnectStall();
@@ -11930,20 +11955,12 @@ export class CodexAgent extends BaseAgent {
 
       async abort() {
         const cancelledYield = cancelActiveYieldContinuation('aborted');
-        if (cancelledYield && !currentTurnId) {
-          eventQueue.push({
-            type: 'done',
-            data: {
-              type: 'codex/event/task_complete',
-              cancelled: true,
-            },
-            source: 'codex',
-          });
-          eventQueue.push({
-            type: 'status',
-            data: { status: 'Done', ...usageTracker.snapshot(), isRunning: false },
-            source: 'codex',
-          });
+        // isolateCancelledTurnStart tombstones the accepted turn and swallows
+        // interrupted turn/completed. Emit the unclaimed cancelled done here so
+        // Session releases currentTurnAttemptToken even if turnStarted already
+        // activated the continuation and the RPC is still pending.
+        if (cancelledYield) {
+          emitCancelledYieldProductDone();
         }
         clearReconnectStall();
         // 用户点 Stop = 明确不想继续这一轮，挂起的过载重投必须一起撤掉。

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -3207,12 +3207,20 @@ export class CodexAgent extends BaseAgent {
       ]);
       const existing = yieldedExecCellsByTurnId.get(turnId) ?? new Map<string, YieldedExecCell[]>();
       if (cells.length === 0) {
-        if (phase === 'completed' && itemId) existing.delete(itemId);
+        if (phase === 'completed') {
+          // Named completions drop that item. Nameless completions cannot match
+          // a prior updated snapshot, so they clear the anonymous bucket rather
+          // than invent a synthetic identity.
+          if (itemId) existing.delete(itemId);
+          else existing.delete('');
+        }
       } else if (itemId) {
         existing.set(itemId, cells);
-      } else {
+      } else if (phase === 'completed') {
         // Nameless exec and wait share the same anonymous bucket. A later wait
         // that is still running must accumulate, not replace the yielded exec.
+        // Only completed snapshots are authoritative; nameless itemUpdated
+        // cannot later be forgotten without an id.
         const anonymous = existing.get('') ?? [];
         existing.set('', dedupeCells([...anonymous, ...cells]));
       }

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -3135,7 +3135,7 @@ export class CodexAgent extends BaseAgent {
     let activeYieldContinuationId: number | null = null;
     let yieldContinuationInFlight = false;
     let yieldContinuationAbort: AbortController | null = null;
-    let yieldContinuationIdleWaiters: Array<() => void> = [];
+    let yieldContinuationIdleWaiters: Array<(cancelled: boolean) => void> = [];
     const emitYieldContinuationState = (
       continuationId: number,
       state: 'awaiting' | 'active' | 'cancelled',
@@ -3266,15 +3266,15 @@ export class CodexAgent extends BaseAgent {
       if (!claim || claim.settled || claim.continuationTurnId) return;
       claim.continuationTurnId = turnId;
     };
-    const flushYieldContinuationIdleWaiters = (): void => {
-      if (activeYieldContinuationClaim() != null || yieldContinuationInFlight) return;
+    const flushYieldContinuationIdleWaiters = (cancelled = false): void => {
+      if (!cancelled && (activeYieldContinuationClaim() != null || yieldContinuationInFlight)) return;
       const waiters = yieldContinuationIdleWaiters;
       yieldContinuationIdleWaiters = [];
-      for (const resolve of waiters) resolve();
+      for (const resolve of waiters) resolve(cancelled);
     };
-    const waitForYieldContinuationIdle = async (): Promise<void> => {
-      if (activeYieldContinuationClaim() == null && !yieldContinuationInFlight) return;
-      await new Promise<void>((resolve) => {
+    const waitForYieldContinuationIdle = async (): Promise<boolean> => {
+      if (activeYieldContinuationClaim() == null && !yieldContinuationInFlight) return false;
+      return await new Promise<boolean>((resolve) => {
         yieldContinuationIdleWaiters.push(resolve);
       });
     };
@@ -3289,7 +3289,7 @@ export class CodexAgent extends BaseAgent {
       log.info('yield continuation cancelled', { reason, continuationId: claim.id });
       emitYieldContinuationState(claim.id, 'cancelled');
       releaseSettledYieldContinuationClaim(claim);
-      flushYieldContinuationIdleWaiters();
+      flushYieldContinuationIdleWaiters(true);
       return claim;
     };
     const discardYieldContinuationClaims = (reason: string): void => {
@@ -3308,7 +3308,7 @@ export class CodexAgent extends BaseAgent {
         releaseSettledYieldContinuationClaim(claim);
       }
       yieldContinuationClaims.clear();
-      flushYieldContinuationIdleWaiters();
+      flushYieldContinuationIdleWaiters(true);
     };
     const releaseYieldContinuationEvent = (event: AgentEvent): void => {
       if (event.turnContinuationId === undefined) return;
@@ -5987,7 +5987,7 @@ export class CodexAgent extends BaseAgent {
         );
         log.debug('plan review ◀ approved — starting implementation turn', { turnId, edited: Boolean(edited && edited !== plan.trim()) });
         try {
-          await waitForYieldContinuationIdle();
+          if (await waitForYieldContinuationIdle()) return;
           if (closed) return;
           await handle.send(
             { type: 'user', content: message },
@@ -6017,7 +6017,7 @@ export class CodexAgent extends BaseAgent {
       }
       log.debug('plan review ◀ revision requested — starting plan revision turn', { turnId });
       try {
-        await waitForYieldContinuationIdle();
+        if (await waitForYieldContinuationIdle()) return;
         if (closed) return;
         await handle.send(
           { type: 'user', content: feedback },
@@ -6324,7 +6324,7 @@ export class CodexAgent extends BaseAgent {
       autoReviewIntent?: string,
     ): Promise<void> {
       if (closed) return;
-      await waitForYieldContinuationIdle();
+      if (await waitForYieldContinuationIdle()) return;
       if (closed) return;
       const message = formatAskUserContinuationMessage(live.questions, answers);
       const sendOptions: CodexInternalSendOptions = {
@@ -8993,7 +8993,9 @@ export class CodexAgent extends BaseAgent {
       yieldedExecCellsByTurnId.delete(turn.id);
       let yieldClaim: YieldContinuationClaim | null = null;
       let suppressSuccessfulYieldBoundary = false;
-      if (existingYieldClaim?.state === 'awaiting') {
+      if (existingYieldClaim && !claimOwnsTurn(existingYieldClaim, turn.id)) {
+        // A late foreign completed must not settle or retry the active claim.
+      } else if (existingYieldClaim?.state === 'awaiting') {
         yieldClaim = existingYieldClaim;
         if (yieldedCells.length > 0) {
           yieldClaim.cells = dedupeCells([...yieldClaim.cells, ...yieldedCells]);

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -1183,6 +1183,7 @@ type YieldContinuationClaim = {
   retryCount: number;
   originTurnId: string;
   continuationTurnId: string | null;
+  permissionPolicy: TurnPermissionPolicy | null;
 };
 const SYSTEM_PLAN_REVIEW_DISMISSAL_REASONS = new Set([
   'no_listener_attached',
@@ -3246,6 +3247,7 @@ export class CodexAgent extends BaseAgent {
         retryCount,
         originTurnId,
         continuationTurnId: null,
+        permissionPolicy: activeTurnPermissionPolicy,
       };
       yieldContinuationClaims.set(claim.id, claim);
       activeYieldContinuationId = claim.id;
@@ -3376,6 +3378,9 @@ export class CodexAgent extends BaseAgent {
         [CODEX_INTERNAL_CONTINUATION]: true,
         throwOnStartFailure: true,
         signal: abort.signal,
+        ...(claim.permissionPolicy
+          ? { turnPermissionPolicy: claim.permissionPolicy }
+          : {}),
       };
       try {
         await handle.send(

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -3150,6 +3150,14 @@ export class CodexAgent extends BaseAgent {
       if (!claim.settled || claim.pendingBoundaryEvents > 0) return;
       yieldContinuationClaims.delete(claim.id);
     };
+    const yieldItemLedgerKey = (record: Record<string, unknown> | null): string => {
+      if (!record) return '';
+      for (const key of ['id', 'call_id', 'callId'] as const) {
+        const value = record[key];
+        if (typeof value === 'string' && value.trim()) return value;
+      }
+      return '';
+    };
     const abortYieldContinuationSend = (): void => {
       const pending = yieldContinuationAbort;
       yieldContinuationAbort = null;
@@ -3185,15 +3193,16 @@ export class CodexAgent extends BaseAgent {
       const record = item && typeof item === 'object' && !Array.isArray(item)
         ? item as Record<string, unknown>
         : null;
-      const itemId = typeof record?.id === 'string' && record.id
-        ? record.id
-        : '';
+      const itemId = yieldItemLedgerKey(record);
       const cells = extractYieldedExecCellsFromCodexItem(item);
       const existing = yieldedExecCellsByTurnId.get(turnId) ?? new Map<string, YieldedExecCell[]>();
       if (cells.length === 0) {
-        if (phase === 'completed') existing.delete(itemId);
-      } else {
+        if (phase === 'completed' && itemId) existing.delete(itemId);
+      } else if (itemId) {
         existing.set(itemId, cells);
+      } else {
+        const anonymous = existing.get('') ?? [];
+        existing.set('', dedupeCells([...anonymous, ...cells]));
       }
       if (existing.size === 0) yieldedExecCellsByTurnId.delete(turnId);
       else yieldedExecCellsByTurnId.set(turnId, existing);

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -12019,11 +12019,13 @@ export class CodexAgent extends BaseAgent {
 
       async abort() {
         const cancelledYield = cancelActiveYieldContinuation('aborted');
-        // isolateCancelledTurnStart tombstones the accepted turn and swallows
-        // interrupted turn/completed. Emit the unclaimed cancelled done here so
-        // Session releases currentTurnAttemptToken even if turnStarted already
-        // activated the continuation and the RPC is still pending.
-        if (cancelledYield) {
+        // isolateCancelledTurnStart tombstones an accepted turn whose TurnStart
+        // RPC is still pending, and that tombstone swallows interrupted
+        // turn/completed. Only then emit an unclaimed cancelled done so Session
+        // releases currentTurnAttemptToken. After the RPC has returned,
+        // provider interrupted already emits one product Done — synthesizing
+        // another here would settle the next attempt.
+        if (cancelledYield && isTurnStartPending) {
           emitCancelledYieldProductDone();
         }
         clearReconnectStall();

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -8944,6 +8944,12 @@ export class CodexAgent extends BaseAgent {
       }
 
       if (turn.status === 'failed' || turn.status === 'interrupted') {
+        const claim = activeYieldContinuationClaim();
+        if (claim && !claimOwnsTurn(claim, turn.id)) {
+          latestPlanByTurn.delete(turn.id);
+          flushDeferredTerminalTurnCompletionsIfIdle();
+          return;
+        }
         // 失败 / 中断的 plan turn 不发审批 — 半截计划没有审批意义, 循环就此结束。
         proposedPlanText = null;
         planCycleActive = false;
@@ -8994,7 +9000,11 @@ export class CodexAgent extends BaseAgent {
       let yieldClaim: YieldContinuationClaim | null = null;
       let suppressSuccessfulYieldBoundary = false;
       if (existingYieldClaim && !claimOwnsTurn(existingYieldClaim, turn.id)) {
-        // A late foreign completed must not settle or retry the active claim.
+        // A late foreign completed must not settle the claim or emit an
+        // unclaimed product Done while the continuation is still running.
+        latestPlanByTurn.delete(turn.id);
+        flushDeferredTerminalTurnCompletionsIfIdle();
+        return;
       } else if (existingYieldClaim?.state === 'awaiting') {
         yieldClaim = existingYieldClaim;
         if (yieldedCells.length > 0) {

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -10736,6 +10736,10 @@ export class CodexAgent extends BaseAgent {
         // 没接管(预算耗尽 / 已有产出 / 非容量错误)且这一轮确实在跑 → 下面推 Done 收口。
         // 同上: 收口即撤销重投资格, 否则延后标记会在别的 start settle 时补排。
         revokeOverloadRetryOnTerminalSettle('terminal error notification');
+        // yield claim 让 isTurnRunning() 在 SDK turn 结束后仍为 true。transport
+        // 路径在订阅作废时已经结算；非 transport 的终态 error 同样会推 Done,
+        // 若不在这里同步取消, UI 已失败而后续 send 仍被 SESSION_RUNNING 拒绝。
+        cancelActiveYieldContinuation('terminal error');
         eventQueue.push({
           type: 'status',
           data: { status: 'Done', ...usageTracker.snapshot(), isRunning: false },

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -1184,6 +1184,9 @@ type YieldContinuationClaim = {
   originTurnId: string;
   continuationTurnId: string | null;
   permissionPolicy: TurnPermissionPolicy | null;
+  deferredPlanText: string | null;
+  deferredPlanTurnId: string | null;
+  deferredPlanCapabilitySelectionText: string;
 };
 const SYSTEM_PLAN_REVIEW_DISMISSAL_REASONS = new Set([
   'no_listener_attached',
@@ -3211,9 +3214,13 @@ export class CodexAgent extends BaseAgent {
         if (phase === 'completed') {
           // Named completions drop that item. Nameless completions cannot match
           // a prior updated snapshot, so they clear the anonymous bucket rather
-          // than invent a synthetic identity.
+          // than invent a synthetic identity — unless this is a wait that settled
+          // one cell_id. That wait shares the anonymous bucket with other yielded
+          // execs; wiping '' would drop still-running cells and skip their claim.
           if (itemId) existing.delete(itemId);
-          else existing.delete('');
+          else if (extractSettledYieldCellIdsFromCodexItem(item).length === 0) {
+            existing.delete('');
+          }
         }
       } else if (itemId) {
         existing.set(itemId, cells);
@@ -3257,6 +3264,9 @@ export class CodexAgent extends BaseAgent {
         originTurnId,
         continuationTurnId: null,
         permissionPolicy: activeTurnPermissionPolicy,
+        deferredPlanText: null,
+        deferredPlanTurnId: null,
+        deferredPlanCapabilitySelectionText: '',
       };
       yieldContinuationClaims.set(claim.id, claim);
       activeYieldContinuationId = claim.id;
@@ -3318,6 +3328,10 @@ export class CodexAgent extends BaseAgent {
       emitYieldContinuationState(claim.id, 'cancelled');
       releaseSettledYieldContinuationClaim(claim);
       flushYieldContinuationIdleWaiters(true);
+      // Cancel is a product terminal. Do not leak a deferred plan cycle into the
+      // next user send after Stop / owned-turn failure / replacement send.
+      planCycleActive = false;
+      proposedPlanText = null;
       return claim;
     };
     const discardYieldContinuationClaims = (reason: string): void => {
@@ -9069,6 +9083,10 @@ export class CodexAgent extends BaseAgent {
           suppressSuccessfulYieldBoundary = true;
         } else {
           yieldClaim = mintYieldContinuationClaim(outstandingCells, turn.id, retryCount);
+          yieldClaim.deferredPlanText = existingYieldClaim.deferredPlanText;
+          yieldClaim.deferredPlanTurnId = existingYieldClaim.deferredPlanTurnId;
+          yieldClaim.deferredPlanCapabilitySelectionText =
+            existingYieldClaim.deferredPlanCapabilitySelectionText;
         }
       } else if (yieldedCells.length > 0) {
         yieldClaim = mintYieldContinuationClaim(yieldedCells, turn.id, 0);
@@ -9118,24 +9136,47 @@ export class CodexAgent extends BaseAgent {
       }
       latestPlanByTurn.delete(turn.id);
       if (yieldClaim?.state === 'awaiting') {
+        if (completedTurnWasPlanMode && planCycleActive) {
+          const livePlan = proposedPlanText?.trim() || null;
+          if (livePlan) {
+            yieldClaim.deferredPlanText = livePlan;
+            yieldClaim.deferredPlanTurnId = turn.id;
+            yieldClaim.deferredPlanCapabilitySelectionText = completedCapabilitySelectionText;
+          } else if (!yieldClaim.deferredPlanText) {
+            yieldClaim.deferredPlanTurnId = turn.id;
+            yieldClaim.deferredPlanCapabilitySelectionText = completedCapabilitySelectionText;
+          }
+        }
+        proposedPlanText = null;
         void startYieldContinuation(yieldClaim);
-      }
-      // 计划模式: plan turn 正常收尾且产出了 proposed plan → 发起审批闭环。
-      // 放在 done 之后 (AsyncQueue FIFO), renderer 先做完 turn 收尾再挂 plan 卡片。
-      // 空跑(模型没产出 <proposed_plan>, 例如直接回答了问题) → 循环结束,
-      // 下一 turn 经 threadTouchedPlanMode 复位 default。
-      const planForReview = proposedPlanText?.trim();
-      proposedPlanText = null;
-      if (completedTurnWasPlanMode && planCycleActive) {
-        if (planForReview) {
-          void runPlanReviewFlow(
-            planForReview,
-            turn.id,
-            completedCapabilitySelectionText,
-          );
-        } else {
-          log.debug('plan turn produced no proposed plan — plan cycle ends', { turnId: turn.id });
-          planCycleActive = false;
+      } else {
+        // 计划模式: 只在产品终态审批。awaiting yield claim 时 SDK turn 边界不是
+        // 产品结束 —— 空跑不得把 planCycleActive 关掉，已有计划也等续段结算后再挂卡。
+        // 放在 done 之后 (AsyncQueue FIFO), renderer 先做完 turn 收尾再挂 plan 卡片。
+        // 空跑(模型没产出 <proposed_plan>, 例如直接回答了问题) → 循环结束,
+        // 下一 turn 经 threadTouchedPlanMode 复位 default。
+        const livePlan = proposedPlanText?.trim() || null;
+        proposedPlanText = null;
+        const deferredPlan = existingYieldClaim?.deferredPlanText?.trim() || null;
+        const planForReview = livePlan ?? deferredPlan;
+        const planReviewTurnId = livePlan
+          ? turn.id
+          : (existingYieldClaim?.deferredPlanTurnId ?? turn.id);
+        const planCapabilitySelection = livePlan
+          ? completedCapabilitySelectionText
+          : (existingYieldClaim?.deferredPlanCapabilitySelectionText
+            || completedCapabilitySelectionText);
+        if (planCycleActive && (completedTurnWasPlanMode || deferredPlan)) {
+          if (planForReview) {
+            void runPlanReviewFlow(
+              planForReview,
+              planReviewTurnId,
+              planCapabilitySelection,
+            );
+          } else {
+            log.debug('plan turn produced no proposed plan — plan cycle ends', { turnId: turn.id });
+            planCycleActive = false;
+          }
         }
       }
       flushDeferredTerminalTurnCompletionsIfIdle();

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -8831,6 +8831,15 @@ export class CodexAgent extends BaseAgent {
       clearActiveToolContextsForTurn(turn.id);
       const overlapsActiveTurn = suppressTerminalUi && currentTurnId !== null && currentTurnId !== turn.id;
       if (overlapsActiveTurn) return;
+      const activeYieldClaim = activeYieldContinuationClaim();
+      if (activeYieldClaim && !claimOwnsTurn(activeYieldClaim, turn.id)) {
+        // Foreign terminals must not settle the live continuation's usage,
+        // generation timing, claim, or product Done. Tombstone the foreign
+        // turn above, then leave the owned continuation untouched.
+        latestPlanByTurn.delete(turn.id);
+        flushDeferredTerminalTurnCompletionsIfIdle();
+        return;
+      }
       const completedTurnWasPlanMode = currentTurnPlanModeActive;
       if (currentTurnId === turn.id || currentTurnId === null) {
         isTurnInFlight = false;
@@ -8952,12 +8961,6 @@ export class CodexAgent extends BaseAgent {
       }
 
       if (turn.status === 'failed' || turn.status === 'interrupted') {
-        const claim = activeYieldContinuationClaim();
-        if (claim && !claimOwnsTurn(claim, turn.id)) {
-          latestPlanByTurn.delete(turn.id);
-          flushDeferredTerminalTurnCompletionsIfIdle();
-          return;
-        }
         // 失败 / 中断的 plan turn 不发审批 — 半截计划没有审批意义, 循环就此结束。
         proposedPlanText = null;
         planCycleActive = false;
@@ -9007,13 +9010,7 @@ export class CodexAgent extends BaseAgent {
       yieldedExecCellsByTurnId.delete(turn.id);
       let yieldClaim: YieldContinuationClaim | null = null;
       let suppressSuccessfulYieldBoundary = false;
-      if (existingYieldClaim && !claimOwnsTurn(existingYieldClaim, turn.id)) {
-        // A late foreign completed must not settle the claim or emit an
-        // unclaimed product Done while the continuation is still running.
-        latestPlanByTurn.delete(turn.id);
-        flushDeferredTerminalTurnCompletionsIfIdle();
-        return;
-      } else if (existingYieldClaim?.state === 'awaiting') {
+      if (existingYieldClaim?.state === 'awaiting') {
         yieldClaim = existingYieldClaim;
         if (yieldedCells.length > 0) {
           yieldClaim.cells = dedupeCells([...yieldClaim.cells, ...yieldedCells]);

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -3213,16 +3213,12 @@ export class CodexAgent extends BaseAgent {
       ]);
       const existing = yieldedExecCellsByTurnId.get(turnId) ?? new Map<string, YieldedExecCell[]>();
       if (cells.length === 0) {
-        if (phase === 'completed') {
-          // Named completions drop that item. Nameless completions cannot match
-          // a prior updated snapshot, so they clear the anonymous bucket rather
-          // than invent a synthetic identity — unless this is a wait that settled
-          // one cell_id. That wait shares the anonymous bucket with other yielded
-          // execs; wiping '' would drop still-running cells and skip their claim.
-          if (itemId) existing.delete(itemId);
-          else if (extractSettledYieldCellIdsFromCodexItem(item).length === 0) {
-            existing.delete('');
-          }
+        if (phase === 'completed' && itemId) {
+          // Named completions drop that item. Nameless completions share the
+          // anonymous bucket; an unmarked sibling (short exec Exit 0) must not
+          // wipe still-running cells. Settled waits drop one cell_id via
+          // forgetSettledYieldCells below — never delete('').
+          existing.delete(itemId);
         }
       } else if (itemId) {
         existing.set(itemId, cells);

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -1181,6 +1181,8 @@ type YieldContinuationClaim = {
   pendingBoundaryEvents: number;
   settled: boolean;
   retryCount: number;
+  originTurnId: string;
+  continuationTurnId: string | null;
 };
 const SYSTEM_PLAN_REVIEW_DISMISSAL_REASONS = new Set([
   'no_listener_attached',
@@ -3133,6 +3135,7 @@ export class CodexAgent extends BaseAgent {
     let activeYieldContinuationId: number | null = null;
     let yieldContinuationInFlight = false;
     let yieldContinuationAbort: AbortController | null = null;
+    let yieldContinuationIdleWaiters: Array<() => void> = [];
     const emitYieldContinuationState = (
       continuationId: number,
       state: 'awaiting' | 'active' | 'cancelled',
@@ -3230,6 +3233,7 @@ export class CodexAgent extends BaseAgent {
     };
     const mintYieldContinuationClaim = (
       cells: YieldedExecCell[],
+      originTurnId: string,
       retryCount: number,
     ): YieldContinuationClaim => {
       const claim: YieldContinuationClaim = {
@@ -3240,15 +3244,39 @@ export class CodexAgent extends BaseAgent {
         pendingBoundaryEvents: 0,
         settled: false,
         retryCount,
+        originTurnId,
+        continuationTurnId: null,
       };
       yieldContinuationClaims.set(claim.id, claim);
       activeYieldContinuationId = claim.id;
       log.info('yield continuation claim created', {
         continuationId: claim.id,
+        originTurnId,
         cellIds: cells.map((cell) => cell.cellId),
         retryCount,
       });
       return claim;
+    };
+    const claimOwnsTurn = (claim: YieldContinuationClaim, turnId: string | null | undefined): boolean => {
+      if (!turnId) return false;
+      return claim.originTurnId === turnId || claim.continuationTurnId === turnId;
+    };
+    const bindYieldContinuationTurn = (turnId: string): void => {
+      const claim = activeYieldContinuationClaim();
+      if (!claim || claim.settled || claim.continuationTurnId) return;
+      claim.continuationTurnId = turnId;
+    };
+    const flushYieldContinuationIdleWaiters = (): void => {
+      if (activeYieldContinuationClaim() != null || yieldContinuationInFlight) return;
+      const waiters = yieldContinuationIdleWaiters;
+      yieldContinuationIdleWaiters = [];
+      for (const resolve of waiters) resolve();
+    };
+    const waitForYieldContinuationIdle = async (): Promise<void> => {
+      if (activeYieldContinuationClaim() == null && !yieldContinuationInFlight) return;
+      await new Promise<void>((resolve) => {
+        yieldContinuationIdleWaiters.push(resolve);
+      });
     };
     const cancelActiveYieldContinuation = (reason: string): YieldContinuationClaim | null => {
       const claim = activeYieldContinuationClaim();
@@ -3261,6 +3289,7 @@ export class CodexAgent extends BaseAgent {
       log.info('yield continuation cancelled', { reason, continuationId: claim.id });
       emitYieldContinuationState(claim.id, 'cancelled');
       releaseSettledYieldContinuationClaim(claim);
+      flushYieldContinuationIdleWaiters();
       return claim;
     };
     const discardYieldContinuationClaims = (reason: string): void => {
@@ -3279,6 +3308,7 @@ export class CodexAgent extends BaseAgent {
         releaseSettledYieldContinuationClaim(claim);
       }
       yieldContinuationClaims.clear();
+      flushYieldContinuationIdleWaiters();
     };
     const releaseYieldContinuationEvent = (event: AgentEvent): void => {
       if (event.turnContinuationId === undefined) return;
@@ -5957,6 +5987,8 @@ export class CodexAgent extends BaseAgent {
         );
         log.debug('plan review ◀ approved — starting implementation turn', { turnId, edited: Boolean(edited && edited !== plan.trim()) });
         try {
+          await waitForYieldContinuationIdle();
+          if (closed) return;
           await handle.send(
             { type: 'user', content: message },
             planFollowUpSendOptions(
@@ -5985,6 +6017,8 @@ export class CodexAgent extends BaseAgent {
       }
       log.debug('plan review ◀ revision requested — starting plan revision turn', { turnId });
       try {
+        await waitForYieldContinuationIdle();
+        if (closed) return;
         await handle.send(
           { type: 'user', content: feedback },
           // 修订轮同样带上原始审查意图快照:否则 send 会把 auto-review intent 覆盖成这条修改意见,
@@ -6290,6 +6324,8 @@ export class CodexAgent extends BaseAgent {
       autoReviewIntent?: string,
     ): Promise<void> {
       if (closed) return;
+      await waitForYieldContinuationIdle();
+      if (closed) return;
       const message = formatAskUserContinuationMessage(live.questions, answers);
       const sendOptions: CodexInternalSendOptions = {
         ...(live.permissionPolicy ? { turnPermissionPolicy: live.permissionPolicy } : {}),
@@ -6483,6 +6519,7 @@ export class CodexAgent extends BaseAgent {
       const isNewTurn = currentTurnId !== turnId;
       currentTurnId = turnId;
       isTurnInFlight = true;
+      bindYieldContinuationTurn(turnId);
       if (!isNewTurn) return;
 
       resetCodexGenerationTiming(translatorRt);
@@ -8778,7 +8815,10 @@ export class CodexAgent extends BaseAgent {
       } else {
         dismissPendingUserInputForTurn(turn.id, `turn_${turn.status}`);
         yieldedExecCellsByTurnId.delete(turn.id);
-        cancelActiveYieldContinuation(`turn_${turn.status}`);
+        const claim = activeYieldContinuationClaim();
+        if (claim && claimOwnsTurn(claim, turn.id)) {
+          cancelActiveYieldContinuation(`turn_${turn.status}`);
+        }
       }
       clearActiveToolContextsForTurn(turn.id);
       const overlapsActiveTurn = suppressTerminalUi && currentTurnId !== null && currentTurnId !== turn.id;
@@ -8971,17 +9011,19 @@ export class CodexAgent extends BaseAgent {
         if (outstandingCells.length === 0) {
           // Continuation waited the claimed cell(s) to completion. This is the
           // product terminal, not a lost handle.
+          flushYieldContinuationIdleWaiters();
         } else if (yieldedCells.length === 0 || retryCount >= YIELD_CONTINUATION_MAX_ATTEMPTS) {
           emitYieldContinuationLostHandle(
             outstandingCells,
             yieldedCells.length === 0 ? 'empty_completion' : 'retry_exhausted',
           );
           suppressSuccessfulYieldBoundary = true;
+          flushYieldContinuationIdleWaiters();
         } else {
-          yieldClaim = mintYieldContinuationClaim(outstandingCells, retryCount);
+          yieldClaim = mintYieldContinuationClaim(outstandingCells, turn.id, retryCount);
         }
       } else if (yieldedCells.length > 0) {
-        yieldClaim = mintYieldContinuationClaim(yieldedCells, 0);
+        yieldClaim = mintYieldContinuationClaim(yieldedCells, turn.id, 0);
       }
       if (!suppressSuccessfulYieldBoundary) {
         const idleStatusEvent: AgentEvent = {

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -120,6 +120,7 @@ import { scanCodexCustomizations } from './customization-scanner.js';
 import { commandExecutionDisplayInput } from './command-display.js';
 import {
   dedupeCells,
+  extractAliveYieldCellsFromCodexItem,
   extractSettledYieldCellIdsFromCodexItem,
   extractYieldedExecCellsFromCodexItem,
   formatYieldContinuationPrompt,
@@ -3196,13 +3197,18 @@ export class CodexAgent extends BaseAgent {
         ? item as Record<string, unknown>
         : null;
       const itemId = yieldItemLedgerKey(record);
-      const cells = extractYieldedExecCellsFromCodexItem(item);
+      const cells = dedupeCells([
+        ...extractYieldedExecCellsFromCodexItem(item),
+        ...extractAliveYieldCellsFromCodexItem(item),
+      ]);
       const existing = yieldedExecCellsByTurnId.get(turnId) ?? new Map<string, YieldedExecCell[]>();
       if (cells.length === 0) {
         if (phase === 'completed' && itemId) existing.delete(itemId);
       } else if (itemId) {
         existing.set(itemId, cells);
       } else {
+        // Nameless exec and wait share the same anonymous bucket. A later wait
+        // that is still running must accumulate, not replace the yielded exec.
         const anonymous = existing.get('') ?? [];
         existing.set('', dedupeCells([...anonymous, ...cells]));
       }
@@ -8049,6 +8055,28 @@ export class CodexAgent extends BaseAgent {
       return true;
     }
 
+    function isolateCancelledTurnStart(
+      resp: TurnStartResponse | undefined,
+      sendOpts: SendOptions | undefined,
+      stage: string,
+    ): void {
+      if (!closed && sendOpts?.signal?.aborted !== true) return;
+      abandonBufferedTurns(`send cancelled ${stage}`);
+      const staleTurnId = resp?.turn?.id;
+      if (!staleTurnId) return;
+      terminalErroredTurnIds.add(staleTurnId);
+      if (!threadId) return;
+      host
+        .request(Method.TurnInterrupt, { threadId, turnId: staleTurnId })
+        .catch((error: unknown) => {
+          log.warn('cancelled turn/start interrupt failed (best-effort)', {
+            turnId: staleTurnId,
+            stage,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        });
+    }
+
     function isLocalAcceptBoundaryError(err: unknown): boolean {
       const text = err instanceof Error ? err.message : String(err);
       return /Codex send (?:cancelled|cannot be accepted)/i.test(text);
@@ -11368,24 +11396,11 @@ export class CodexAgent extends BaseAgent {
           });
           markTurnConfigAccepted();
           adoptUnidentifiedDeadTurn(resp, initialStartSeq);
+          // yield continuation 带 throwOnStartFailure + AbortSignal: 取消检查会
+          // 抛, 不能把墓碑/interrupt 写在 return 后面。先隔离已被 server 接受
+          // 的 turn, 再让取消检查抛/返回, 迟到的 turnStarted 才会撞墓碑。
+          isolateCancelledTurnStart(resp, sendOpts, 'after turn/start');
           if (rejectClosedOrCancelledSend(sendOpts, 'after turn/start')) {
-            // 本地取消边界直接 return: 挂起的 buffered 请求没有 settle 者
-            // (codex R17 P2), 统一释放。
-            abandonBufferedTurns('send cancelled after turn/start');
-            const staleTurnId = resp.turn?.id;
-            if (staleTurnId) {
-              terminalErroredTurnIds.add(staleTurnId);
-              if (threadId) {
-                host
-                  .request(Method.TurnInterrupt, { threadId, turnId: staleTurnId })
-                  .catch((error: unknown) => {
-                    log.warn('cancelled yield continuation interrupt failed (best-effort)', {
-                      turnId: staleTurnId,
-                      error: error instanceof Error ? error.message : String(error),
-                    });
-                  });
-              }
-            }
             return;
           }
           handleTurnStartResp(resp, initialStartSeq);
@@ -11479,8 +11494,8 @@ export class CodexAgent extends BaseAgent {
               });
               markTurnConfigAccepted();
               adoptUnidentifiedDeadTurn(resp, initialStartSeq);
+              isolateCancelledTurnStart(resp, sendOpts, 'after turn/start retry');
               if (rejectClosedOrCancelledSend(sendOpts, 'after turn/start retry')) {
-                abandonBufferedTurns('send cancelled after turn/start retry');
                 return;
               }
               handleTurnStartResp(resp, initialStartSeq);

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -119,6 +119,13 @@ import {
 import { scanCodexCustomizations } from './customization-scanner.js';
 import { commandExecutionDisplayInput } from './command-display.js';
 import {
+  dedupeCells,
+  extractSettledYieldCellIdsFromCodexItem,
+  extractYieldedExecCellsFromCodexItem,
+  formatYieldContinuationPrompt,
+  type YieldedExecCell,
+} from './yielded-exec-cell.js';
+import {
   newCodexRuntimeState,
   isAuthRelatedErrorMessage,
   translateErrorNotification,
@@ -1156,9 +1163,21 @@ const CODEX_INHERITED_CAPABILITY_SELECTION = Symbol('codexInheritedCapabilitySel
 // 计划实施/修订 turn 的**审查意图**:这些 turn 的 message 是固定内部串('Implement the plan.'),
 // 直接拿它当 review intent 会让灰区 reviewer 完全看不到用户原始请求与获批计划(codex 报)。
 const CODEX_AUTO_REVIEW_INTENT = Symbol('codexAutoReviewIntent');
+const CODEX_YIELD_CONTINUATION = Symbol('codexYieldContinuation');
+const YIELD_CONTINUATION_MAX_ATTEMPTS = 2;
 type CodexInternalSendOptions = SendOptions & {
   [CODEX_INHERITED_CAPABILITY_SELECTION]?: string;
   [CODEX_AUTO_REVIEW_INTENT]?: string;
+  [CODEX_YIELD_CONTINUATION]?: number;
+};
+type YieldContinuationClaim = {
+  id: number;
+  state: 'awaiting' | 'active' | 'cancelled';
+  cells: YieldedExecCell[];
+  settledCellIds: Set<string>;
+  pendingBoundaryEvents: number;
+  settled: boolean;
+  retryCount: number;
 };
 const SYSTEM_PLAN_REVIEW_DISMISSAL_REASONS = new Set([
   'no_listener_attached',
@@ -3101,6 +3120,238 @@ export class CodexAgent extends BaseAgent {
       });
     };
     let isTurnInFlight = false;
+    const yieldedExecCellsByTurnId = new Map<string, Map<string, YieldedExecCell[]>>();
+    const yieldContinuationClaims = new Map<number, YieldContinuationClaim>();
+    const yieldContinuationListeners = new Set<(
+      continuationId: number,
+      state: 'awaiting' | 'active' | 'cancelled',
+    ) => void>();
+    let nextYieldContinuationId = 1;
+    let activeYieldContinuationId: number | null = null;
+    let yieldContinuationInFlight = false;
+    let yieldContinuationAbort: AbortController | null = null;
+    const emitYieldContinuationState = (
+      continuationId: number,
+      state: 'awaiting' | 'active' | 'cancelled',
+    ): void => {
+      for (const listener of [...yieldContinuationListeners]) {
+        try {
+          listener(continuationId, state);
+        } catch (e) {
+          log.warn('yield continuation listener threw', { error: String(e) });
+        }
+      }
+    };
+    const activeYieldContinuationClaim = (): YieldContinuationClaim | null =>
+      activeYieldContinuationId === null
+        ? null
+        : yieldContinuationClaims.get(activeYieldContinuationId) ?? null;
+    const releaseSettledYieldContinuationClaim = (claim: YieldContinuationClaim): void => {
+      if (!claim.settled || claim.pendingBoundaryEvents > 0) return;
+      yieldContinuationClaims.delete(claim.id);
+    };
+    const abortYieldContinuationSend = (): void => {
+      const pending = yieldContinuationAbort;
+      yieldContinuationAbort = null;
+      try {
+        pending?.abort();
+      } catch (error) {
+        log.debug('yield continuation abort controller threw', { error: String(error) });
+      }
+    };
+    const forgetSettledYieldCells = (turnId: string, item: unknown): void => {
+      const settledIds = extractSettledYieldCellIdsFromCodexItem(item);
+      if (settledIds.length === 0) return;
+      const existing = yieldedExecCellsByTurnId.get(turnId);
+      if (existing) {
+        for (const [itemId, cells] of [...existing.entries()]) {
+          const remaining = cells.filter((cell) => !settledIds.includes(cell.cellId));
+          if (remaining.length === 0) existing.delete(itemId);
+          else existing.set(itemId, remaining);
+        }
+        if (existing.size === 0) yieldedExecCellsByTurnId.delete(turnId);
+      }
+      const claim = activeYieldContinuationClaim();
+      if (!claim) return;
+      for (const cellId of settledIds) claim.settledCellIds.add(cellId);
+    };
+    const rememberYieldedExecCells = (
+      turnId: string | undefined,
+      item: unknown,
+      phase: 'updated' | 'completed',
+    ): void => {
+      if (!turnId) return;
+      if (completedTurnIds.has(turnId) || terminalErroredTurnIds.has(turnId)) return;
+      const record = item && typeof item === 'object' && !Array.isArray(item)
+        ? item as Record<string, unknown>
+        : null;
+      const itemId = typeof record?.id === 'string' && record.id
+        ? record.id
+        : '';
+      const cells = extractYieldedExecCellsFromCodexItem(item);
+      const existing = yieldedExecCellsByTurnId.get(turnId) ?? new Map<string, YieldedExecCell[]>();
+      if (cells.length === 0) {
+        if (phase === 'completed') existing.delete(itemId);
+      } else {
+        existing.set(itemId, cells);
+      }
+      if (existing.size === 0) yieldedExecCellsByTurnId.delete(turnId);
+      else yieldedExecCellsByTurnId.set(turnId, existing);
+      forgetSettledYieldCells(turnId, item);
+    };
+    const cellsForCompletedTurn = (turnId: string): YieldedExecCell[] => {
+      const byItem = yieldedExecCellsByTurnId.get(turnId);
+      if (!byItem) return [];
+      return dedupeCells([...byItem.values()].flat());
+    };
+    const attachYieldContinuationClaim = (
+      event: AgentEvent,
+      claim: YieldContinuationClaim,
+    ): void => {
+      event.turnContinuationId = claim.id;
+      claim.pendingBoundaryEvents += 1;
+    };
+    const mintYieldContinuationClaim = (
+      cells: YieldedExecCell[],
+      retryCount: number,
+    ): YieldContinuationClaim => {
+      const claim: YieldContinuationClaim = {
+        id: nextYieldContinuationId++,
+        state: 'awaiting',
+        cells,
+        settledCellIds: new Set(),
+        pendingBoundaryEvents: 0,
+        settled: false,
+        retryCount,
+      };
+      yieldContinuationClaims.set(claim.id, claim);
+      activeYieldContinuationId = claim.id;
+      log.info('yield continuation claim created', {
+        continuationId: claim.id,
+        cellIds: cells.map((cell) => cell.cellId),
+        retryCount,
+      });
+      return claim;
+    };
+    const cancelActiveYieldContinuation = (reason: string): YieldContinuationClaim | null => {
+      const claim = activeYieldContinuationClaim();
+      abortYieldContinuationSend();
+      if (!claim || claim.settled) return null;
+      claim.state = 'cancelled';
+      claim.settled = true;
+      activeYieldContinuationId = null;
+      yieldContinuationInFlight = false;
+      log.info('yield continuation cancelled', { reason, continuationId: claim.id });
+      emitYieldContinuationState(claim.id, 'cancelled');
+      releaseSettledYieldContinuationClaim(claim);
+      return claim;
+    };
+    const discardYieldContinuationClaims = (reason: string): void => {
+      abortYieldContinuationSend();
+      if (yieldContinuationClaims.size > 0) {
+        log.debug('discarding yield continuation claims', {
+          reason,
+          continuationIds: [...yieldContinuationClaims.keys()],
+        });
+      }
+      activeYieldContinuationId = null;
+      yieldContinuationInFlight = false;
+      yieldedExecCellsByTurnId.clear();
+      for (const claim of yieldContinuationClaims.values()) {
+        claim.settled = true;
+        releaseSettledYieldContinuationClaim(claim);
+      }
+      yieldContinuationClaims.clear();
+    };
+    const releaseYieldContinuationEvent = (event: AgentEvent): void => {
+      if (event.turnContinuationId === undefined) return;
+      const claim = yieldContinuationClaims.get(event.turnContinuationId);
+      if (!claim) return;
+      claim.pendingBoundaryEvents = Math.max(0, claim.pendingBoundaryEvents - 1);
+      releaseSettledYieldContinuationClaim(claim);
+    };
+    const emitYieldContinuationFailure = (opts: {
+      reason: 'yield-continuation-start-failed' | 'yield-continuation-lost-handle';
+      message: string;
+      cells: YieldedExecCell[];
+      detail?: string;
+    }): void => {
+      log.warn(
+        opts.reason === 'yield-continuation-start-failed'
+          ? 'yield continuation turn failed to start'
+          : 'yield continuation lost exec cell',
+        {
+          reason: opts.reason,
+          ...(opts.detail ? { detail: opts.detail } : {}),
+          cellIds: opts.cells.map((cell) => cell.cellId),
+        },
+      );
+      eventQueue.push({
+        type: 'error',
+        data: {
+          message: opts.message,
+          isTerminal: true,
+          reason: opts.reason,
+        },
+        source: 'codex',
+      });
+      eventQueue.push({
+        type: 'status',
+        data: { status: 'Done', ...usageTracker.snapshot(), isRunning: false },
+        source: 'codex',
+      });
+    };
+    const emitYieldContinuationStartFailure = (error: unknown, cells: YieldedExecCell[]): void => {
+      emitYieldContinuationFailure({
+        reason: 'yield-continuation-start-failed',
+        message: `yield continuation turn failed to start: ${String(error)}`,
+        cells,
+        detail: String(error),
+      });
+    };
+    const emitYieldContinuationLostHandle = (cells: YieldedExecCell[], reason: string): void => {
+      emitYieldContinuationFailure({
+        reason: 'yield-continuation-lost-handle',
+        message: `Foreground exec cell ${cells.map((cell) => cell.cellId).join(', ')} was lost after the previous turn completed.`,
+        cells,
+        detail: reason,
+      });
+    };
+    async function startYieldContinuation(claim: YieldContinuationClaim): Promise<void> {
+      if (closed || yieldContinuationInFlight || claim.state !== 'awaiting' || claim.settled) return;
+      yieldContinuationInFlight = true;
+      claim.state = 'active';
+      emitYieldContinuationState(claim.id, 'active');
+      const abort = new AbortController();
+      yieldContinuationAbort = abort;
+      const sendOptions: CodexInternalSendOptions = {
+        [CODEX_YIELD_CONTINUATION]: claim.retryCount + 1,
+        throwOnStartFailure: true,
+        signal: abort.signal,
+      };
+      try {
+        await handle.send(
+          { type: 'user', content: formatYieldContinuationPrompt(claim.cells) },
+          sendOptions,
+        );
+      } catch (error) {
+        const alreadySettled = claim.settled || abort.signal.aborted;
+        if (activeYieldContinuationId === claim.id) activeYieldContinuationId = null;
+        yieldContinuationInFlight = false;
+        if (alreadySettled) {
+          releaseSettledYieldContinuationClaim(claim);
+          return;
+        }
+        claim.settled = true;
+        emitYieldContinuationStartFailure(error, claim.cells);
+        releaseSettledYieldContinuationClaim(claim);
+      } finally {
+        if (yieldContinuationAbort === abort) yieldContinuationAbort = null;
+        if (claim.settled || activeYieldContinuationId !== claim.id) {
+          yieldContinuationInFlight = false;
+        }
+      }
+    }
     /**
      * 本 handle 上「起过多少个 turn」的单调计数器,每个新 turn 首次被置活时 +1。
      *
@@ -6247,7 +6498,7 @@ export class CodexAgent extends BaseAgent {
       clearUpstreamIdle();
       if (upstreamIdleTimeoutMs <= 0) return;
       if (closed || !isTurnInFlight) return;
-      // 工具执行 / 等审批期间 ball 不在上游,不计 idle 配额。
+      // 工具执行 / 等审批 / yield cell 等待期间 ball 不在上游,不计 idle 配额。
       if (pendingToolItemIds.size > 0) return;
       upstreamIdleRemainingMs = upstreamIdleTimeoutMs;
       armUpstreamIdleSlice();
@@ -6697,7 +6948,9 @@ export class CodexAgent extends BaseAgent {
         armUpstreamIdle();
         observeReconnectStallEvent(ev);
       }
-      return rawEventQueuePush(ev);
+      const accepted = rawEventQueuePush(ev);
+      if (!accepted) releaseYieldContinuationEvent(ev);
+      return accepted;
     };
 
     // ── ServerRequest handlers (Phase 2 approval, Phase 5 dismiss-on-mode-change) ──
@@ -8482,6 +8735,8 @@ export class CodexAgent extends BaseAgent {
         detachPendingAskUserForSuccessfulTurn(turn.id);
       } else {
         dismissPendingUserInputForTurn(turn.id, `turn_${turn.status}`);
+        yieldedExecCellsByTurnId.delete(turn.id);
+        cancelActiveYieldContinuation(`turn_${turn.status}`);
       }
       clearActiveToolContextsForTurn(turn.id);
       const overlapsActiveTurn = suppressTerminalUi && currentTurnId !== null && currentTurnId !== turn.id;
@@ -8651,42 +8906,88 @@ export class CodexAgent extends BaseAgent {
         return;
       }
 
-      eventQueue.push({
-        type: 'status',
-        data: {
-          status: 'Done',
-          ...attachLiveGeneration(endSnap, {
-            outputTokens: realTurnUsage.output,
-            closedDurationMs: translatorRt.generationDurationMs,
-            openStartedAt: null,
-            reliable: translatorRt.generationTimingReliable,
-          }),
-          isRunning: false,
-        },
-        source: 'codex',
-      });
-      // 真实 per-turn 用量 (host 的 today chip / daily_model_usage 记账消费):
-      //   promptTokens     = 本 turn 未命中缓存的输入 (不再是 contextTokens 上下文快照)
-      //   completionTokens = 本 turn outputTokens（已包含 reasoning 子集，不重复相加）
-      //   reasoningTokens  = reasoning 明细子集，仅展示/诊断，不再参与总量求和
-      //   cachedTokens     = 本 turn 命中缓存的输入
-      //   segments         = 每次 total cursor 前进对应的请求级 usage；定价方必须
-      //                      逐段选长上下文档位后再求和，不能拿 turn aggregate 选档
-      // 契约: 本 payload **永远是 per-turn 增量语义**, 消费方 (today chip /
-      // daily_model_usage 记账) 直接累加, 不做任何 delta 化。整个 turn 没收到
-      // tokenUsage/updated 时就是全 0 (该 turn 不记账) — 不退回 contextTokens:
-      // 在直接累加的消费方手里, 上下文快照会被当成一笔巨额输入, 高估远糟于漏记。
-      eventQueue.push({
-        type: 'done',
-        data: {
-          type: 'codex/event/task_complete',
-          usage: codexDoneUsage,
-          raw: turn,
-          plan: latestPlanByTurn.get(turn.id) ?? null,
-        },
-        source: 'codex',
-      });
+      const existingYieldClaim = activeYieldContinuationClaim();
+      const yieldedCells = cellsForCompletedTurn(turn.id);
+      yieldedExecCellsByTurnId.delete(turn.id);
+      let yieldClaim: YieldContinuationClaim | null = null;
+      let suppressSuccessfulYieldBoundary = false;
+      if (existingYieldClaim?.state === 'awaiting') {
+        yieldClaim = existingYieldClaim;
+        if (yieldedCells.length > 0) {
+          yieldClaim.cells = dedupeCells([...yieldClaim.cells, ...yieldedCells]);
+        }
+      } else if (existingYieldClaim?.state === 'active') {
+        existingYieldClaim.settled = true;
+        activeYieldContinuationId = null;
+        yieldContinuationInFlight = false;
+        releaseSettledYieldContinuationClaim(existingYieldClaim);
+        const outstandingCells = dedupeCells([
+          ...existingYieldClaim.cells,
+          ...yieldedCells,
+        ]).filter((cell) => !existingYieldClaim.settledCellIds.has(cell.cellId));
+        const retryCount = existingYieldClaim.retryCount + 1;
+        if (outstandingCells.length === 0) {
+          // Continuation waited the claimed cell(s) to completion. This is the
+          // product terminal, not a lost handle.
+        } else if (yieldedCells.length === 0 || retryCount >= YIELD_CONTINUATION_MAX_ATTEMPTS) {
+          emitYieldContinuationLostHandle(
+            outstandingCells,
+            yieldedCells.length === 0 ? 'empty_completion' : 'retry_exhausted',
+          );
+          suppressSuccessfulYieldBoundary = true;
+        } else {
+          yieldClaim = mintYieldContinuationClaim(outstandingCells, retryCount);
+        }
+      } else if (yieldedCells.length > 0) {
+        yieldClaim = mintYieldContinuationClaim(yieldedCells, 0);
+      }
+      if (!suppressSuccessfulYieldBoundary) {
+        const idleStatusEvent: AgentEvent = {
+          type: 'status',
+          data: {
+            status: 'Done',
+            ...attachLiveGeneration(endSnap, {
+              outputTokens: realTurnUsage.output,
+              closedDurationMs: translatorRt.generationDurationMs,
+              openStartedAt: null,
+              reliable: translatorRt.generationTimingReliable,
+            }),
+            isRunning: false,
+          },
+          source: 'codex',
+        };
+        const doneEvent: AgentEvent = {
+          type: 'done',
+          data: {
+            type: 'codex/event/task_complete',
+            usage: codexDoneUsage,
+            raw: turn,
+            plan: latestPlanByTurn.get(turn.id) ?? null,
+          },
+          source: 'codex',
+        };
+        if (yieldClaim?.state === 'awaiting') {
+          attachYieldContinuationClaim(idleStatusEvent, yieldClaim);
+          attachYieldContinuationClaim(doneEvent, yieldClaim);
+        }
+        eventQueue.push(idleStatusEvent);
+        // 真实 per-turn 用量 (host 的 today chip / daily_model_usage 记账消费):
+        //   promptTokens     = 本 turn 未命中缓存的输入 (不再是 contextTokens 上下文快照)
+        //   completionTokens = 本 turn outputTokens（已包含 reasoning 子集，不重复相加）
+        //   reasoningTokens  = reasoning 明细子集，仅展示/诊断，不再参与总量求和
+        //   cachedTokens     = 本 turn 命中缓存的输入
+        //   segments         = 每次 total cursor 前进对应的请求级 usage；定价方必须
+        //                      逐段选长上下文档位后再求和，不能拿 turn aggregate 选档
+        // 契约: 本 payload **永远是 per-turn 增量语义**, 消费方 (today chip /
+        // daily_model_usage 记账) 直接累加, 不做任何 delta 化。整个 turn 没收到
+        // tokenUsage/updated 时就是全 0 (该 turn 不记账) — 不退回 contextTokens:
+        // 在直接累加的消费方手里, 上下文快照会被当成一笔巨额输入, 高估远糟于漏记。
+        eventQueue.push(doneEvent);
+      }
       latestPlanByTurn.delete(turn.id);
+      if (yieldClaim?.state === 'awaiting') {
+        void startYieldContinuation(yieldClaim);
+      }
       // 计划模式: plan turn 正常收尾且产出了 proposed plan → 发起审批闭环。
       // 放在 done 之后 (AsyncQueue FIFO), renderer 先做完 turn 收尾再挂 plan 卡片。
       // 空跑(模型没产出 <proposed_plan>, 例如直接回答了问题) → 循环结束,
@@ -9448,12 +9749,15 @@ export class CodexAgent extends BaseAgent {
         const hadPendingWork =
           isTurnInFlight
           || isTurnStartPending
-          || overloadRetryPending();
+          || overloadRetryPending()
+          || yieldContinuationInFlight
+          || activeYieldContinuationClaim() != null;
         if (!hadPendingWork) {
           log.info('idle Codex session invalidated by forced host retirement', { threadId });
           eventQueue.end();
           return;
         }
+        discardYieldContinuationClaims('app-server force-retired');
 
         // turn/start 可能尚未返回 id。先把所有在途请求标为已收口并隔离，随后 RPC
         // reject/迟到 resolve 时复用既有 finally/墓碑路径，不再发第二组终态。
@@ -9919,6 +10223,7 @@ export class CodexAgent extends BaseAgent {
           producedOutputTurnIds.add(params.turnId);
         }
         noteActiveToolContext(params.item, params.turnId);
+        rememberYieldedExecCells(params.turnId, params.item, 'updated');
         // updated 也要登记映射,顺序与 started / completed 一致(先登记 → 翻译 → 后发重放帧)。
         // V1 的 spawn 是长跑 item(started → updated* → completed):started 那帧若没到我们手里
         // (turn 缓冲、stale turn 丢弃、上游省略),映射就要一直等到 completed 才建立 —— 期间
@@ -9982,6 +10287,7 @@ export class CodexAgent extends BaseAgent {
           producedOutputTurnIds.add(params.turnId);
         }
         completeActiveToolContext(params.item, params.turnId);
+        rememberYieldedExecCells(params.turnId, params.item, 'completed');
         // This late item belongs to an already-terminal parent. The parent
         // cleanup already cleared its pending tools; touching the shared
         // lifecycle set here would re-arm the currently active turn's idle
@@ -10147,7 +10453,6 @@ export class CodexAgent extends BaseAgent {
         // codex R12 P1): 合法 → 激活后重放走正常终端路径收口 send; 孤儿 →
         // 丢弃, 不得让孤儿 error 终结合法 send。
         if (enqueueIfBufferedTurn(params.turnId, () => handlers.error?.(params))) return;
-        if (shouldIgnoreStaleTurnEvent(params.turnId)) return;
         let effectiveParams = params;
         let isTerminalError = params.willRetry !== true;
         const isTransportError = params.scope === 'transport';
@@ -10169,7 +10474,9 @@ export class CodexAgent extends BaseAgent {
           terminalDescendantTurnIds.clear();
           submittedUserInputByTurn.clear();
           clearAllPendingUserInputInteractions();
+          cancelActiveYieldContinuation('transport error');
         }
+        if (!isTransportError && shouldIgnoreStaleTurnEvent(params.turnId)) return;
         const targetsPendingTurn = isTurnStartPending && currentTurnId === null && Boolean(params.turnId);
         // 空 turnId 的容量拒绝: 过载重投的 RPC 还在飞、而它的 turnStarted 尚未到达时,
         // currentTurnId 是 null 且 isTurnInFlight 是 false —— 上面两条既有判据都不成立,
@@ -10336,7 +10643,11 @@ export class CodexAgent extends BaseAgent {
             }
           }
         }
-        const wasTurnRunning = isTurnInFlight || targetsPendingTurn;
+        const wasTurnRunning =
+          isTurnInFlight
+          || targetsPendingTurn
+          || yieldContinuationInFlight
+          || activeYieldContinuationClaim() != null;
         if (isTerminalError && targetsCurrentTurn && !isTransportError) {
           const recoveryTurnId = effectiveParams.turnId || currentTurnId || '';
           // error notification 只登记恢复意图并保持 logical turn 运行；
@@ -10464,6 +10775,7 @@ export class CodexAgent extends BaseAgent {
       // close 时 buffer 里可能还有等对账的挂起请求 (codex R17 P2):
       // 统一按拒绝释放, 否则 handler 永远悬挂, dispatchServerRequest
       // 永不返回, server 侧请求卡死。
+      discardYieldContinuationClaims('session closed');
       abandonBufferedTurns('session closed');
       abandonPendingCapabilitySteers();
       // 把挂起的 approval 强制 deny + emit interaction_dismissed (UI 关 dialog),
@@ -10519,6 +10831,10 @@ export class CodexAgent extends BaseAgent {
       async send(message: UserMessage, sendOpts?: SendOptions) {
         if (rejectClosedOrCancelledSend(sendOpts, 'before start')) {
           return;
+        }
+        const yieldAttempt = (sendOpts as CodexInternalSendOptions | undefined)?.[CODEX_YIELD_CONTINUATION];
+        if (yieldAttempt == null) {
+          cancelActiveYieldContinuation('new send');
         }
         // 用户开启新 turn = 旧重连序列作废；deadline 不得跨 turn 误伤新请求。
         clearReconnectStall();
@@ -11037,6 +11353,20 @@ export class CodexAgent extends BaseAgent {
             // 本地取消边界直接 return: 挂起的 buffered 请求没有 settle 者
             // (codex R17 P2), 统一释放。
             abandonBufferedTurns('send cancelled after turn/start');
+            const staleTurnId = resp.turn?.id;
+            if (staleTurnId) {
+              terminalErroredTurnIds.add(staleTurnId);
+              if (threadId) {
+                host
+                  .request(Method.TurnInterrupt, { threadId, turnId: staleTurnId })
+                  .catch((error: unknown) => {
+                    log.warn('cancelled yield continuation interrupt failed (best-effort)', {
+                      turnId: staleTurnId,
+                      error: error instanceof Error ? error.message : String(error),
+                    });
+                  });
+              }
+            }
             return;
           }
           handleTurnStartResp(resp, initialStartSeq);
@@ -11495,6 +11825,22 @@ export class CodexAgent extends BaseAgent {
       },
 
       async abort() {
+        const cancelledYield = cancelActiveYieldContinuation('aborted');
+        if (cancelledYield && !currentTurnId) {
+          eventQueue.push({
+            type: 'done',
+            data: {
+              type: 'codex/event/task_complete',
+              cancelled: true,
+            },
+            source: 'codex',
+          });
+          eventQueue.push({
+            type: 'status',
+            data: { status: 'Done', ...usageTracker.snapshot(), isRunning: false },
+            source: 'codex',
+          });
+        }
         clearReconnectStall();
         // 用户点 Stop = 明确不想继续这一轮，挂起的过载重投必须一起撤掉。
         // 放在 currentTurnId 判空之前：重投等待期间 turn 已死、currentTurnId 为
@@ -11537,7 +11883,16 @@ export class CodexAgent extends BaseAgent {
       },
 
       events(): AsyncIterable<AgentEvent> {
-        return eventQueue;
+        const consumedEventStream = async function* (): AsyncGenerator<AgentEvent> {
+          for await (const event of eventQueue) {
+            try {
+              yield event;
+            } finally {
+              releaseYieldContinuationEvent(event);
+            }
+          }
+        };
+        return consumedEventStream();
       },
 
       getUsageSnapshot(): UsageSnapshot {
@@ -11824,7 +12179,23 @@ export class CodexAgent extends BaseAgent {
         // idle 语义——终态先于 turn/start 响应到达时（协议允许的乱序），
         // coordinator 要看到 idle 才能收口，否则 send 挂死（既有用例
         // "accepts terminal error before TurnStartResponse…" 锁的就是这条）。
-        return isTurnInFlight || overloadRetryPending();
+        //
+        // yield continuation claim 把 provider turn/completed 与产品结束拆开:
+        // 等 cell / 续段尚未启动时 isTurnInFlight 已是 false, 但仍是同一产品请求。
+        return isTurnInFlight
+          || overloadRetryPending()
+          || yieldContinuationInFlight
+          || activeYieldContinuationClaim() != null;
+      },
+
+      beginTurnContinuationWait(continuationId?: number) {
+        if (continuationId === undefined) return null;
+        return yieldContinuationClaims.get(continuationId)?.state ?? null;
+      },
+
+      onTurnContinuationChange(listener) {
+        yieldContinuationListeners.add(listener);
+        return () => yieldContinuationListeners.delete(listener);
       },
     };
 

--- a/packages/maker-core/src/agents/codex/yielded-exec-cell.test.ts
+++ b/packages/maker-core/src/agents/codex/yielded-exec-cell.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  extractSettledYieldCellIdsFromCodexItem,
+  extractYieldedExecCellIds,
+  extractYieldedExecCellsFromCodexItem,
+  formatYieldContinuationPrompt,
+} from './yielded-exec-cell.js';
+
+describe('extractYieldedExecCellIds', () => {
+  it('locks the #3179 rollout yield shape', () => {
+    expect(extractYieldedExecCellIds(
+      'Script running with cell ID 226\nWall time 11.0 seconds\nOutput:\n',
+    )).toEqual(['226']);
+  });
+
+  it('keeps later cells in order and dedupes repeats', () => {
+    expect(extractYieldedExecCellIds([
+      'Script running with cell ID 226',
+      'Script running with cell ID 229 Wall time 11.0 seconds Output:',
+      'Script running with cell ID 226',
+    ].join('\n'))).toEqual(['226', '229']);
+  });
+
+  it('ignores finished command output without a yield marker', () => {
+    expect(extractYieldedExecCellIds('Exit 0\n\n> tsc --noEmit\n')).toEqual([]);
+  });
+});
+
+describe('extractYieldedExecCellsFromCodexItem', () => {
+  it('reads commandExecution.aggregatedOutput', () => {
+    expect(extractYieldedExecCellsFromCodexItem({
+      type: 'commandExecution',
+      id: 'item-1',
+      command: 'pnpm --filter desktop run typecheck',
+      status: 'completed',
+      aggregatedOutput: 'Script running with cell ID 226 Wall time 11.0 seconds Output:',
+    })).toEqual([{
+      cellId: '226',
+      command: 'pnpm --filter desktop run typecheck',
+    }]);
+  });
+
+  it('reads Responses/proxy function_call(exec_command) output text', () => {
+    expect(extractYieldedExecCellsFromCodexItem({
+      type: 'function_call',
+      name: 'exec_command',
+      arguments: JSON.stringify({
+        cmd: 'pnpm --filter desktop run typecheck',
+        workdir: '/repo',
+        yield_time_ms: 10_000,
+      }),
+      content: [{ type: 'output_text', text: 'Script running with cell ID 229' }],
+    })).toEqual([{
+      cellId: '229',
+      command: 'pnpm --filter desktop run typecheck',
+    }]);
+  });
+
+  it('does not treat a finished exec item as a yielded cell', () => {
+    expect(extractYieldedExecCellsFromCodexItem({
+      type: 'commandExecution',
+      id: 'item-2',
+      command: 'pnpm --filter desktop run typecheck',
+      status: 'completed',
+      aggregatedOutput: 'Exit 0',
+      exitCode: 0,
+    })).toEqual([]);
+  });
+
+  it('ignores yield text quoted by an agentMessage', () => {
+    expect(extractYieldedExecCellsFromCodexItem({
+      type: 'agentMessage',
+      text: 'I will wait. Script running with cell ID 777',
+    })).toEqual([]);
+  });
+
+  it('still finds a yield marker near the end of a long exec output', () => {
+    const padding = 'x'.repeat(20_000);
+    expect(extractYieldedExecCellsFromCodexItem({
+      type: 'commandExecution',
+      id: 'item-late-marker',
+      command: 'pnpm --filter desktop run typecheck',
+      aggregatedOutput: `${padding}\nScript running with cell ID 226`,
+    })).toEqual([{
+      cellId: '226',
+      command: 'pnpm --filter desktop run typecheck',
+    }]);
+  });
+});
+
+describe('extractSettledYieldCellIdsFromCodexItem', () => {
+  it('clears a cell after wait reports Script completed', () => {
+    expect(extractSettledYieldCellIdsFromCodexItem({
+      type: 'function_call',
+      name: 'wait',
+      arguments: JSON.stringify({ cell_id: '11', max_tokens: 1000 }),
+      content: [{ type: 'output_text', text: 'Script completed\nWall time 0.1 seconds\nOutput:\n' }],
+    })).toEqual(['11']);
+  });
+
+  it('keeps a cell outstanding when wait still yields the same cell', () => {
+    expect(extractSettledYieldCellIdsFromCodexItem({
+      type: 'function_call',
+      name: 'wait',
+      arguments: JSON.stringify({ cell_id: '11', yield_time_ms: 1000 }),
+      content: [{ type: 'output_text', text: 'Script running with cell ID 11\nWall time 1.0 seconds\nOutput:\n' }],
+    })).toEqual([]);
+  });
+
+  it('does not settle on a wait adapter error', () => {
+    expect(extractSettledYieldCellIdsFromCodexItem({
+      type: 'function_call',
+      name: 'wait',
+      arguments: JSON.stringify({ cell_id: '11' }),
+      content: [{ type: 'output_text', text: 'unexpected adapter error' }],
+    })).toEqual([]);
+  });
+
+  it('does not settle cell 11 from a running marker for a different cell', () => {
+    expect(extractSettledYieldCellIdsFromCodexItem({
+      type: 'function_call',
+      name: 'wait',
+      arguments: JSON.stringify({ cell_id: '11' }),
+      content: [{ type: 'output_text', text: 'Script running with cell ID 12' }],
+    })).toEqual([]);
+  });
+});
+
+describe('formatYieldContinuationPrompt', () => {
+  it('asks the next provider turn to wait the same cells', () => {
+    const prompt = formatYieldContinuationPrompt([
+      { cellId: '226', command: 'pnpm --filter desktop run typecheck' },
+    ]);
+    expect(prompt).toContain('Wait for cell ID 226');
+    expect(prompt).toContain('Do not start a new task');
+    expect(prompt).toContain('report that it was lost');
+    expect(prompt).not.toContain('pnpm --filter desktop run typecheck'.repeat(2));
+  });
+});

--- a/packages/maker-core/src/agents/codex/yielded-exec-cell.test.ts
+++ b/packages/maker-core/src/agents/codex/yielded-exec-cell.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  extractAliveYieldCellsFromCodexItem,
   extractSettledYieldCellIdsFromCodexItem,
   extractYieldedExecCellIds,
   extractYieldedExecCellsFromCodexItem,
@@ -123,6 +124,26 @@ describe('extractSettledYieldCellIdsFromCodexItem', () => {
       name: 'wait',
       arguments: JSON.stringify({ cell_id: '11' }),
       content: [{ type: 'output_text', text: 'Script running with cell ID 12' }],
+    })).toEqual([]);
+  });
+});
+
+describe('extractAliveYieldCellsFromCodexItem', () => {
+  it('treats a wait still printing the running marker as proof the cell is alive', () => {
+    expect(extractAliveYieldCellsFromCodexItem({
+      type: 'function_call',
+      name: 'wait',
+      arguments: JSON.stringify({ cell_id: '226', yield_time_ms: 1000 }),
+      content: [{ type: 'output_text', text: 'Script running with cell ID 226\nWall time 1.0 seconds\nOutput:\n' }],
+    })).toEqual([{ cellId: '226' }]);
+  });
+
+  it('does not treat a completed wait as an alive cell', () => {
+    expect(extractAliveYieldCellsFromCodexItem({
+      type: 'function_call',
+      name: 'wait',
+      arguments: JSON.stringify({ cell_id: '226', max_tokens: 1000 }),
+      content: [{ type: 'output_text', text: 'Script completed\nWall time 0.1 seconds\nOutput:\n' }],
     })).toEqual([]);
   });
 });

--- a/packages/maker-core/src/agents/codex/yielded-exec-cell.ts
+++ b/packages/maker-core/src/agents/codex/yielded-exec-cell.ts
@@ -61,6 +61,22 @@ export function extractSettledYieldCellIdsFromCodexItem(item: unknown): string[]
   return [cellId];
 }
 
+/**
+ * A wait that still prints the running marker proves the claimed cell is alive.
+ * The original exec item keeps the yield marker forever, so this is the only
+ * evidence a later empty continuation can use to retry instead of lost-handle.
+ */
+export function extractAliveYieldCellsFromCodexItem(item: unknown): YieldedExecCell[] {
+  const record = asRecord(item);
+  if (!record || !isWaitItem(record)) return [];
+  const args = parseJsonObject(record.arguments) ?? asRecord(record.input);
+  const cellId = firstString(args, ['cell_id', 'cellId']);
+  if (!cellId) return [];
+  const output = collectItemText(record);
+  if (!extractYieldedExecCellIds(output).includes(cellId)) return [];
+  return [{ cellId }];
+}
+
 export function formatYieldContinuationPrompt(cells: readonly YieldedExecCell[]): string {
   const unique = dedupeCells(cells);
   const cellList = unique.map((cell) => {

--- a/packages/maker-core/src/agents/codex/yielded-exec-cell.ts
+++ b/packages/maker-core/src/agents/codex/yielded-exec-cell.ts
@@ -1,0 +1,180 @@
+/**
+ * Codex adapter-local detector for `functions.exec` yield.
+ *
+ * app-server 不暴露 cell 状态或 wait RPC。yield 的权威产物目前只活在工具输出文案里
+ * （#3179 rollout: "Script running with cell ID 226"）。本模块把那条文案降格为
+ * **检测启发式**：只用来铸造有界 continuation claim，不参与产品「是否交付完」判断。
+ *
+ * 协议级 executionHandle 是跨仓长期项；在那之前，漏判等于今天的假完成，误判只是
+ * 多跑一轮有界续段。
+ */
+
+export interface YieldedExecCell {
+  cellId: string;
+  command?: string;
+}
+
+/** Locked to the #3179 Codex rollout shape. Do not loosen without a new fixture. */
+export const YIELDED_EXEC_CELL_RE = /Script running with cell ID[ \t]+(\d+)/gi;
+
+const MAX_SCAN_CHARS = 16_384;
+
+export function extractYieldedExecCellIds(text: string | null | undefined): string[] {
+  if (!text) return [];
+  const sample = textForScan(text);
+  const ids: string[] = [];
+  const seen = new Set<string>();
+  YIELDED_EXEC_CELL_RE.lastIndex = 0;
+  for (const match of sample.matchAll(YIELDED_EXEC_CELL_RE)) {
+    const cellId = match[1];
+    if (!cellId || seen.has(cellId)) continue;
+    seen.add(cellId);
+    ids.push(cellId);
+  }
+  return ids;
+}
+
+export function extractYieldedExecCellsFromCodexItem(item: unknown): YieldedExecCell[] {
+  const record = asRecord(item);
+  if (!record || !isApprovedYieldItem(record)) return [];
+  const command = commandFromCodexItem(record);
+  const ids = extractYieldedExecCellIds(collectItemText(record));
+  return ids.map((cellId) => (
+    command ? { cellId, command } : { cellId }
+  ));
+}
+
+/**
+ * Healthy Codex turns yield an exec cell, then call `wait` until that cell
+ * finishes. The original exec item still contains the yield marker, so the
+ * wait result is the only signal that the cell is no longer outstanding.
+ */
+export function extractSettledYieldCellIdsFromCodexItem(item: unknown): string[] {
+  const record = asRecord(item);
+  if (!record || !isWaitItem(record)) return [];
+  const args = parseJsonObject(record.arguments) ?? asRecord(record.input);
+  const cellId = firstString(args, ['cell_id', 'cellId']);
+  if (!cellId) return [];
+  const output = collectItemText(record);
+  if (!WAIT_SETTLED_RE.test(output)) return [];
+  if (extractYieldedExecCellIds(output).includes(cellId)) return [];
+  return [cellId];
+}
+
+export function formatYieldContinuationPrompt(cells: readonly YieldedExecCell[]): string {
+  const unique = dedupeCells(cells);
+  const cellList = unique.map((cell) => {
+    const command = cell.command?.trim();
+    return command
+      ? `- cell ID ${cell.cellId} (\`${truncateCommand(command)}\`)`
+      : `- cell ID ${cell.cellId}`;
+  }).join('\n');
+  return [
+    'A foreground exec cell is still running after the previous turn completed.',
+    'Wait for every listed cell and finish the original user request. Do not start a new task.',
+    'If a cell is gone, report that it was lost instead of rerunning the command.',
+    unique.length === 1 ? `Wait for cell ID ${unique[0]!.cellId}.` : 'Wait for:',
+    ...(unique.length > 1 ? [cellList] : []),
+  ].join('\n');
+}
+
+const WAIT_SETTLED_RE = /Script (?:completed|terminated)/i;
+
+function isApprovedYieldItem(record: Record<string, unknown>): boolean {
+  if (record.type === 'commandExecution') return true;
+  return record.type === 'function_call' && record.name === 'exec_command';
+}
+
+function isWaitItem(record: Record<string, unknown>): boolean {
+  return record.type === 'function_call' && record.name === 'wait';
+}
+
+function textForScan(text: string): string {
+  if (text.length <= MAX_SCAN_CHARS) return text;
+  return `${text.slice(0, MAX_SCAN_CHARS)}\n${text.slice(-MAX_SCAN_CHARS)}`;
+}
+
+export function dedupeCells(cells: readonly YieldedExecCell[]): YieldedExecCell[] {
+  const seen = new Set<string>();
+  const out: YieldedExecCell[] = [];
+  for (const cell of cells) {
+    if (seen.has(cell.cellId)) continue;
+    seen.add(cell.cellId);
+    out.push(cell);
+  }
+  return out;
+}
+
+function truncateCommand(command: string): string {
+  const compact = command.replace(/\s+/g, ' ').trim();
+  return compact.length > 160 ? `${compact.slice(0, 157)}...` : compact;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function commandFromCodexItem(record: Record<string, unknown>): string | undefined {
+  if (typeof record.command === 'string' && record.command.trim()) return record.command;
+  if (record.type === 'function_call' && record.name === 'exec_command') {
+    const args = parseJsonObject(record.arguments);
+    const command = firstString(args, ['cmd', 'command']);
+    if (command) return command;
+  }
+  const nestedArgs = asRecord(record.arguments) ?? asRecord(record.input);
+  return firstString(nestedArgs, ['cmd', 'command']);
+}
+
+function collectItemText(record: Record<string, unknown>): string {
+  const parts: string[] = [];
+  pushText(parts, record.aggregatedOutput);
+  pushText(parts, record.output);
+  pushText(parts, record.result);
+  pushText(parts, record.text);
+  if (Array.isArray(record.content)) {
+    for (const entry of record.content) {
+      if (typeof entry === 'string') pushText(parts, entry);
+      const nested = asRecord(entry);
+      if (!nested) continue;
+      pushText(parts, nested.text);
+      pushText(parts, nested.output);
+    }
+  } else {
+    pushText(parts, record.content);
+  }
+  if (Array.isArray(record.contentItems)) {
+    for (const entry of record.contentItems) {
+      const nested = asRecord(entry);
+      if (!nested) continue;
+      pushText(parts, nested.text);
+    }
+  }
+  return parts.join('\n');
+}
+
+function pushText(parts: string[], value: unknown): void {
+  if (typeof value === 'string' && value) parts.push(value);
+}
+
+function parseJsonObject(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== 'string') return asRecord(value);
+  try {
+    return asRecord(JSON.parse(value));
+  } catch {
+    return null;
+  }
+}
+
+function firstString(
+  record: Record<string, unknown> | null,
+  keys: readonly string[],
+): string | undefined {
+  if (!record) return undefined;
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === 'string' && value.trim()) return value;
+  }
+  return undefined;
+}


### PR DESCRIPTION
## 这次改了什么

### 摘要

Codex `functions.exec` 大约 11 秒会先 yield 一个 cell，再由模型 `wait`。Grok 等模型常在 yield 后立刻空 `task_complete`，Cindy 把产品 turn 标完成，长命令其实还没跑完。

这次在 Codex adapter 里用真实 rollout 锁死的启发式铸造 continuation claim：成功 `status(isRunning:false)` 与 `done` 共用同一 `turnContinuationId`，宿主再开续段让模型 wait 同一 cell。同 turn 或续段里 wait 输出 `Script completed` / `Script terminated` 后正常收口；空续段或重试耗尽报 lost-handle，不 replay 原请求、不重跑已执行命令。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#3179 会话提前结束的根因之一（exec yield 后空 `task_complete`）
- 本 PR 包含：Codex yield continuation claim、wait 结算、有界续段、lost-handle、相关单测与 maker-core 规则补充
- 明确不包含：Claude wake continuation 公共模块、#3290 ask_user continuation 迁移、协议级 executionHandle、Codex compact/rollover
- 用户可见变化：Codex 长命令 yield 后任务不再立刻显示完成；续段失败时会报 cell 丢失，而不是假装成功
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：不涉及：只改 maker-core Codex adapter 与规则文档，无界面、交互或文案改动

## 怎么验证的

### 自动验证

```text
cd /Users/dash/Code/Cindy/cindy-codex-yield-continuation
env -u NODE_DEBUG -u NODE_ENV pnpm --filter @cindy/maker-core exec vitest related --run \
  src/agents/codex/index.ts src/agents/codex/yielded-exec-cell.ts
结果：3 files / 558 tests passed

env -u NODE_DEBUG -u NODE_ENV pnpm --filter @cindy/maker-core exec vitest run \
  src/agents/codex/yielded-exec-cell.test.ts src/agents/codex/index.test.ts \
  -t "CodexAgent yield continuation|extractYieldedExec|extractSettledYield"
结果：27 passed / 523 skipped

pnpm --filter @cindy/maker-core run --if-present typecheck
结果：无 typecheck script，按仓库规则跳过
```

### 手工验证

不涉及。两名 Orca reviewer（Codex / Claude Code）按当前 worktree 独立复审，结论均为通过。

### 未执行的验证

全量 `pnpm test:unit` / `run-unit-gate.sh` 因 `apps/desktop` 的 `ghostInstallReceipt.test.ts` 两条失败未绿。同一失败在主仓 `cindy` checkout 上复现，与本 PR 的 Codex 文件无关；CI 仍会跑完整单测。

未做真实 Codex daemon 上的 cell 跨 turn 存活实验。cell 丢失时走诚实 lost-handle，不自动重跑命令。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [x] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：产品 turn 生命周期；启发式误判会多开有界续段

### 影响与回滚

- 影响范围：Codex 会话在 exec yield 后的产品 turn 收口。续段会向模型发送固定 wait 指令（内部 send，不是用户原请求 replay）。检测锁死 `#3179` rollout 的 `Script running with cell ID <n>`，只认 `commandExecution` 与 `function_call(exec_command)`。
- 回滚 / 降级方式：revert 本 PR 即回到「provider `turn/completed` 立刻结束产品 turn」的旧行为。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
