### PR TITLE
fix: 防止子 Agent 直接弹出用户问答卡

### DIFF
--- a/packages/maker-cc-manager/__tests__/protocol.test.ts
+++ b/packages/maker-cc-manager/__tests__/protocol.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  CC_MGR_BUNDLE_VERSION,
   PROTOCOL_VERSION,
   METHODS,
   NOTIFICATIONS,
@@ -18,8 +19,12 @@ describe('protocol constants', () => {
     expect(PROTOCOL_VERSION).toBeGreaterThan(0);
   });
 
-  it('requires v4 so old daemons cannot ignore subagent model preflight', () => {
-    expect(PROTOCOL_VERSION).toBe(4);
+  it('requires v5 so old daemons cannot reject native root-only guards', () => {
+    expect(PROTOCOL_VERSION).toBe(5);
+  });
+
+  it('bumps the daemon bundle when the wire contract changes', () => {
+    expect(CC_MGR_BUNDLE_VERSION).toBe('0.0.10');
   });
 
   it('METHODS has expected method names', () => {

--- a/packages/maker-cc-manager/__tests__/sdk-handlers.test.ts
+++ b/packages/maker-cc-manager/__tests__/sdk-handlers.test.ts
@@ -427,6 +427,22 @@ describe('sdk-handlers end-to-end', () => {
     expect(latestFactoryOptions?.hooks?.PreToolUse?.[0]?.hooks[0]).toBeDefined();
   });
 
+  it('query/start accepts a root-only guard for the native AskUserQuestion tool', async () => {
+    await ctx!.client.request('query/start', {
+      sessionId: 's-root-only-ask-user-question',
+      cwd: '/a',
+      model: 'm',
+      env: {},
+      toolGuards: [{
+        toolNamePrefix: 'AskUserQuestion',
+        sourceServerId: 'claude-code',
+        invocation: 'root-only',
+      }],
+    });
+    await waitFor(() => ctx!.notifications.length >= 1);
+    expect(latestFactoryOptions?.hooks?.PreToolUse?.[0]?.hooks[0]).toBeDefined();
+  });
+
   it('query/close ends consume loop → session.alive=false + closed notification', async () => {
     await ctx!.client.request('query/start', { sessionId: 's1', cwd: '/a', model: 'm', env: {} });
     await waitFor(() => ctx!.notifications.length >= 1);

--- a/packages/maker-cc-manager/__tests__/session-registry.test.ts
+++ b/packages/maker-cc-manager/__tests__/session-registry.test.ts
@@ -330,6 +330,42 @@ describe('SessionRegistry', () => {
     })).resolves.toEqual({ continue: true });
   });
 
+  it('allows AskUserQuestion for the root and denies it for nested Claude agents', async () => {
+    const { factory: baseFactory } = buildFakeFactory();
+    let captured: SdkQueryFactoryOptions | undefined;
+    const registry = new SessionRegistry({
+      sdkQueryFactory: (opts) => {
+        captured = opts;
+        return baseFactory(opts);
+      },
+    });
+    registry.create({
+      sessionId: 's-ask-user-question-root-only',
+      cwd: '/x',
+      model: 'm',
+      env: {},
+      toolGuards: [{
+        toolNamePrefix: 'AskUserQuestion',
+        sourceServerId: 'claude-code',
+        invocation: 'root-only',
+        denialMessage: 'NATIVE_SUBAGENT_USER_INPUT_NOT_ALLOWED',
+      }],
+    });
+    const preToolUse = captured?.hooks?.PreToolUse?.[0]?.hooks[0];
+    expect(preToolUse).toBeDefined();
+    const call = {
+      hook_event_name: 'PreToolUse',
+      tool_name: 'AskUserQuestion',
+    };
+    await expect(preToolUse!(call)).resolves.toEqual({ continue: true });
+    await expect(preToolUse!({ ...call, agent_id: 'child-1' })).resolves.toMatchObject({
+      hookSpecificOutput: {
+        permissionDecision: 'deny',
+        permissionDecisionReason: 'NATIVE_SUBAGENT_USER_INPUT_NOT_ALLOWED',
+      },
+    });
+  });
+
   it('keeps explicit selection across accepted same-turn steering inputs', async () => {
     let captured: SdkQueryFactoryOptions | undefined;
     const factory: SdkQueryFactory = (opts) => {

--- a/packages/maker-cc-manager/src/protocol.ts
+++ b/packages/maker-cc-manager/src/protocol.ts
@@ -216,7 +216,7 @@ export interface QueryStartParams {
 }
 
 export interface QueryToolGuard {
-  /** Exact SDK tool-name prefix, for example `mcp__plugin_x_server__`. */
+  /** Exact SDK tool name for root-only guards, or a tool-name prefix otherwise. */
   toolNamePrefix: string;
   /** Exact harness-owned MCP server id before Claude normalizes punctuation. */
   sourceServerId?: string;

--- a/packages/maker-cc-manager/src/protocol.ts
+++ b/packages/maker-cc-manager/src/protocol.ts
@@ -30,12 +30,16 @@
  * 之前执行 Agent/Task 实时模型准入预检。旧 daemon 没有该执行边界，
  * 会继续发起无权限请求，因此必须升级协议。
  *
+ * v5: root-only toolGuards now accept the native `AskUserQuestion` tool name.
+ * Older daemons reject that exact guard as an invalid root-only tool and must
+ * be upgraded before remote queries send it.
+ *
  * v1 (redesign): 删除 dead-session drain/archive 握手,对齐 codex 模式。
  * reattach 只接新 events (live-only subscription),不 replay 旧 ring buffer。
  * ring buffer 降级为纯内存 fast-path(同一 daemon 进程生命周期内的 mid-turn 续流)。
  * 断开期间跑完的输出暂不自动补回 chat(follow-up: jsonl recovery 统一 cc + codex)。
  */
-export const PROTOCOL_VERSION = 4 as const;
+export const PROTOCOL_VERSION = 5 as const;
 
 /**
  * cc-mgr bundle 版本号 — 手动 bump。
@@ -44,7 +48,7 @@ export const PROTOCOL_VERSION = 4 as const;
  * 无关依赖变化而变。desktop 用这个（而非 bundle sha256）判断远端 daemon
  * 是否需要 upgrade,避免无关的 pnpm install 触发全量远端重装。
  */
-export const CC_MGR_BUNDLE_VERSION = '0.0.9' as const;
+export const CC_MGR_BUNDLE_VERSION = '0.0.10' as const;
 
 export type RpcId = number;
 

--- a/packages/maker-cc-manager/src/sdk-handlers.ts
+++ b/packages/maker-cc-manager/src/sdk-handlers.ts
@@ -402,7 +402,8 @@ function validateToolGuards(value: unknown): QueryToolGuard[] | undefined {
     const toolNamePrefix = guard.toolNamePrefix.trim();
     const sourceServerId = guard.sourceServerId?.trim();
     const validToolName = guard.invocation === 'root-only'
-      ? /^mcp__[A-Za-z0-9_-]+__[A-Za-z0-9_-]+$/.test(toolNamePrefix)
+      ? toolNamePrefix === 'AskUserQuestion'
+        || /^mcp__[A-Za-z0-9_-]+__[A-Za-z0-9_-]+$/.test(toolNamePrefix)
       : /^mcp__[A-Za-z0-9_-]+__$/.test(toolNamePrefix);
     if (!validToolName) {
       throwInvalid(

--- a/packages/maker-core/src/agents/claude-code/__tests__/capability-routing.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/capability-routing.test.ts
@@ -2,12 +2,16 @@ import { describe, expect, it } from 'vitest';
 
 import type { CapabilityRoutingPolicy } from '../../../types/capability-routing.js';
 import {
+  buildClaudeAskUserQuestionCallerProvenanceHooks,
   buildClaudeOrcaCallerProvenanceHooks,
   buildClaudeRemoteOrcaCallerGuards,
+  buildClaudeRemoteRootOnlyToolGuards,
   buildClaudeLocalToolGuardHooks,
   buildClaudeRemoteToolGuards,
   buildClaudeSkillOverrides,
   mergeClaudeHookSets,
+  CLAUDE_ASK_USER_QUESTION_TOOL_NAME,
+  CLAUDE_SUBAGENT_ASK_USER_QUESTION_DENIAL_REASON,
   ORCA_SEND_TO_LEAD_TOOL_NAME,
 } from '../capability-routing.js';
 
@@ -43,6 +47,41 @@ describe('Claude Orca caller provenance', () => {
       denialMessage: 'NESTED_AGENT_NOT_ALLOWED: nested agent cannot report directly to the lead',
     }]);
     expect(buildClaudeRemoteOrcaCallerGuards(false)).toEqual([]);
+  });
+
+  it('allows the root but denies a native subagent from asking the user', async () => {
+    const hook = buildClaudeAskUserQuestionCallerProvenanceHooks().PreToolUse?.[0]?.hooks[0];
+    if (!hook) throw new Error('expected AskUserQuestion caller provenance hook');
+    const input = {
+      hook_event_name: 'PreToolUse' as const,
+      session_id: 'session-ask-user-question',
+      transcript_path: '/tmp/transcript',
+      cwd: '/repo',
+      tool_name: CLAUDE_ASK_USER_QUESTION_TOOL_NAME,
+      tool_input: { questions: [] },
+      tool_use_id: 'tool-ask-user-question',
+    };
+
+    await expect(hook(input, 'tool-ask-user-question', {
+      signal: new AbortController().signal,
+    })).resolves.toEqual({ continue: true });
+    await expect(hook({ ...input, agent_id: 'native-child-1' }, 'tool-ask-user-question', {
+      signal: new AbortController().signal,
+    })).resolves.toMatchObject({
+      hookSpecificOutput: {
+        permissionDecision: 'deny',
+        permissionDecisionReason: CLAUDE_SUBAGENT_ASK_USER_QUESTION_DENIAL_REASON,
+      },
+    });
+  });
+
+  it('serializes the native AskUserQuestion root-only guard for remote Claude', () => {
+    expect(buildClaudeRemoteRootOnlyToolGuards()).toEqual([{
+      toolNamePrefix: CLAUDE_ASK_USER_QUESTION_TOOL_NAME,
+      sourceServerId: 'claude-code',
+      invocation: 'root-only',
+      denialMessage: CLAUDE_SUBAGENT_ASK_USER_QUESTION_DENIAL_REASON,
+    }]);
   });
 });
 

--- a/packages/maker-core/src/agents/claude-code/__tests__/mcp-approval-policy.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/mcp-approval-policy.test.ts
@@ -1377,6 +1377,13 @@ describe('remote sessions share the same permission semantics', () => {
         denialMessage:
           'This downstream source was not explicitly selected. Use Cindy capability xd-feishu.',
       },
+      {
+        toolNamePrefix: 'AskUserQuestion',
+        sourceServerId: 'claude-code',
+        invocation: 'root-only',
+        denialMessage:
+          'NATIVE_SUBAGENT_USER_INPUT_NOT_ALLOWED: report the question to the parent agent, which can decide whether to ask the user.',
+      },
     ]);
     await expect(
       natural.onApprovalRequest({
@@ -1486,7 +1493,7 @@ describe('remote sessions share the same permission semantics', () => {
       mcpServerNames: [userServerId],
     });
 
-    expect(remote.remoteStartParams?.toolGuards).toHaveLength(1);
+    expect(remote.remoteStartParams?.toolGuards).toHaveLength(2);
     await expect(
       remote.onApprovalRequest({
         requestId: 'r-user-mcp-collision',
@@ -1568,7 +1575,7 @@ describe('remote sessions share the same permission semantics', () => {
       failedInitMcpServerNames: [userServerId],
     });
     await new Promise<void>((resolve) => setTimeout(resolve, 0));
-    expect(failed.remoteStartParams?.toolGuards).toHaveLength(1);
+    expect(failed.remoteStartParams?.toolGuards).toHaveLength(2);
     await expect(
       failed.onApprovalRequest({
         requestId: 'r-failed-settings-mcp-collision',

--- a/packages/maker-core/src/agents/claude-code/capability-routing.ts
+++ b/packages/maker-core/src/agents/claude-code/capability-routing.ts
@@ -20,6 +20,9 @@ import { ORCA_NESTED_REPORT_DENIAL_REASON } from '../shared/orca-report-policy.j
 
 const CLAUDE_CODE_HARNESS_ID = 'claude-code';
 export const ORCA_SEND_TO_LEAD_TOOL_NAME = 'mcp__orca_worker_bridge__send_to_lead';
+export const CLAUDE_ASK_USER_QUESTION_TOOL_NAME = 'AskUserQuestion';
+export const CLAUDE_SUBAGENT_ASK_USER_QUESTION_DENIAL_REASON =
+  'NATIVE_SUBAGENT_USER_INPUT_NOT_ALLOWED: report the question to the parent agent, which can decide whether to ask the user.';
 
 /** Claude root calls have no agent_id; native subagents always carry one. */
 export function buildClaudeOrcaCallerProvenanceHooks(): Partial<Record<HookEvent, HookCallbackMatcher[]>> {
@@ -38,6 +41,25 @@ export function buildClaudeOrcaCallerProvenanceHooks(): Partial<Record<HookEvent
     };
   };
   return { PreToolUse: [{ matcher: ORCA_SEND_TO_LEAD_TOOL_NAME, hooks: [guardTool] }] };
+}
+
+/** Native Claude subagents must report questions to the root agent. */
+export function buildClaudeAskUserQuestionCallerProvenanceHooks(): Partial<Record<HookEvent, HookCallbackMatcher[]>> {
+  const guardTool: HookCallback = async (input) => {
+    if (input.hook_event_name !== 'PreToolUse') return { continue: true };
+    const pre = input as PreToolUseHookInput;
+    if (pre.tool_name !== CLAUDE_ASK_USER_QUESTION_TOOL_NAME) return { continue: true };
+    if (typeof pre.agent_id !== 'string' || pre.agent_id.length === 0) return { continue: true };
+    return {
+      continue: true,
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        permissionDecision: 'deny',
+        permissionDecisionReason: CLAUDE_SUBAGENT_ASK_USER_QUESTION_DENIAL_REASON,
+      },
+    };
+  };
+  return { PreToolUse: [{ matcher: CLAUDE_ASK_USER_QUESTION_TOOL_NAME, hooks: [guardTool] }] };
 }
 
 function isClaudeSkillDirective(directive: CapabilityRouteOverride): boolean {
@@ -93,6 +115,16 @@ export function buildClaudeRemoteOrcaCallerGuards(isOrcaWorker: boolean): Claude
     sourceServerId: 'orca_worker_bridge',
     invocation: 'root-only',
     denialMessage: ORCA_NESTED_REPORT_DENIAL_REASON,
+  }];
+}
+
+/** JSON-safe remote equivalent of the native subagent user-input guard. */
+export function buildClaudeRemoteRootOnlyToolGuards(): ClaudeRemoteToolGuard[] {
+  return [{
+    toolNamePrefix: CLAUDE_ASK_USER_QUESTION_TOOL_NAME,
+    sourceServerId: 'claude-code',
+    invocation: 'root-only',
+    denialMessage: CLAUDE_SUBAGENT_ASK_USER_QUESTION_DENIAL_REASON,
   }];
 }
 

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -113,9 +113,11 @@ import {
 } from './env-builder.js';
 import { buildClaudeFlagSettings } from './flag-settings.js';
 import {
+  buildClaudeAskUserQuestionCallerProvenanceHooks,
   buildClaudeOrcaCallerProvenanceHooks,
   buildClaudeLocalToolGuardHooks,
   buildClaudeRemoteOrcaCallerGuards,
+  buildClaudeRemoteRootOnlyToolGuards,
   buildClaudeRemoteToolGuards,
   mergeClaudeHookSets,
 } from './capability-routing.js';
@@ -1575,6 +1577,7 @@ export class ClaudeCodeAgent extends BaseAgent {
           // rely on their observable order. The exact-match Orca provenance guard
           // still runs for send_to_lead after those hooks and denies descendants.
           buildClaudeOrcaCallerProvenanceHooks(),
+          buildClaudeAskUserQuestionCallerProvenanceHooks(),
           this.deps.claudeHooks,
         );
     const deniedCapabilityRoute = (toolName: string) => {
@@ -2871,6 +2874,7 @@ export class ClaudeCodeAgent extends BaseAgent {
         sdkInPlanMode = remotePermissionMode === 'plan';
         const remoteToolGuards = [
           ...buildClaudeRemoteToolGuards(this.deps.capabilityRouting),
+          ...buildClaudeRemoteRootOnlyToolGuards(),
           ...buildClaudeRemoteOrcaCallerGuards(vo.orcaRole === 'worker'),
         ];
 

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -16469,7 +16469,7 @@ describe('CodexAgent MCP thread context hooks', () => {
       workingDir: '/repo',
     });
     const handlers = host.getThreadHandlers();
-    if (!handlers?.requestUserInput || !handlers.descendantThreadStarted) {
+    if (!handlers?.requestUserInput || !handlers.descendantThreadStarted || !handlers.serverRequestResolved) {
       throw new Error('expected requestUserInput and descendant thread handlers');
     }
     handlers.descendantThreadStarted({
@@ -16478,7 +16478,7 @@ describe('CodexAgent MCP thread context hooks', () => {
     const resolveInteraction = vi.fn();
     handle.setInteractionResolver(resolveInteraction);
 
-    const result = await handlers.requestUserInput({
+    const resultPromise = handlers.requestUserInput({
       threadId: 'child-thread-native-user-input',
       turnId: 'turn-native-descendant',
       itemId: 'native-input-descendant',
@@ -16491,6 +16491,14 @@ describe('CodexAgent MCP thread context hooks', () => {
         options: [],
       }],
     }, { requestId: 'req-native-descendant' });
+
+    // Without item provenance, keep the descendant request fail-closed until
+    // the server resolves it instead of guessing that it is a user question.
+    handlers.serverRequestResolved({
+      threadId: 'child-thread-native-user-input',
+      requestId: 'req-native-descendant',
+    });
+    const result = await resultPromise;
 
     expect(result).toEqual({ answers: {} });
     expect(resolveInteraction).not.toHaveBeenCalled();
@@ -16589,6 +16597,7 @@ describe('CodexAgent MCP thread context hooks', () => {
       }],
     }, { requestId: 'req-permission-descendant-late' });
 
+    await new Promise((resolve) => setTimeout(resolve, 600));
     handlers.descendantNotification('child-thread-permission-input-late', 'item/updated', {
       threadId: 'child-thread-permission-input-late',
       turnId: 'turn-permission-descendant-late',
@@ -19835,6 +19844,7 @@ describe('CodexAgent turn lifecycle', () => {
       || !handlers.mcpServerElicitation
       || !handlers.permissionsApproval
       || !handlers.requestUserInput
+      || !handlers.serverRequestResolved
       || !handlers.dynamicToolCall
     ) {
       throw new Error('expected all descendant server request handlers');
@@ -19899,7 +19909,7 @@ describe('CodexAgent turn lifecycle', () => {
       itemId: 'child-permissions',
       permissions: { network: true },
     })).resolves.toEqual({ permissions: { network: true }, scope: 'turn' });
-    await expect(handlers.requestUserInput({
+    const childInputPromise = handlers.requestUserInput({
       ...child,
       itemId: 'child-input',
       questions: [{
@@ -19910,7 +19920,12 @@ describe('CodexAgent turn lifecycle', () => {
         isSecret: false,
         options: [],
       }],
-    }, { requestId: 'child-input-request' })).resolves.toEqual({
+    }, { requestId: 'child-input-request' });
+    handlers.serverRequestResolved({
+      threadId: child.threadId,
+      requestId: 'child-input-request',
+    });
+    await expect(childInputPromise).resolves.toEqual({
       answers: {},
     });
     await expect(handlers.dynamicToolCall({

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -16469,7 +16469,7 @@ describe('CodexAgent MCP thread context hooks', () => {
       workingDir: '/repo',
     });
     const handlers = host.getThreadHandlers();
-    if (!handlers?.requestUserInput || !handlers.descendantThreadStarted || !handlers.serverRequestResolved) {
+    if (!handlers?.requestUserInput || !handlers.descendantThreadStarted) {
       throw new Error('expected requestUserInput and descendant thread handlers');
     }
     handlers.descendantThreadStarted({
@@ -16478,7 +16478,7 @@ describe('CodexAgent MCP thread context hooks', () => {
     const resolveInteraction = vi.fn();
     handle.setInteractionResolver(resolveInteraction);
 
-    const resultPromise = handlers.requestUserInput({
+    const result = await handlers.requestUserInput({
       threadId: 'child-thread-native-user-input',
       turnId: 'turn-native-descendant',
       itemId: 'native-input-descendant',
@@ -16492,60 +16492,9 @@ describe('CodexAgent MCP thread context hooks', () => {
       }],
     }, { requestId: 'req-native-descendant' });
 
-    // Without item provenance, keep the descendant request fail-closed until
-    // the server resolves it instead of guessing that it is a user question.
-    handlers.serverRequestResolved({
-      threadId: 'child-thread-native-user-input',
-      requestId: 'req-native-descendant',
-    });
-    const result = await resultPromise;
-
     expect(result).toEqual({ answers: {} });
     expect(resolveInteraction).not.toHaveBeenCalled();
     await handle.close();
-  });
-
-  it('rejects an unknown descendant native request after provenance timeout', async () => {
-    vi.useFakeTimers();
-    try {
-      const agent = new CodexAgent(createDeps());
-      const host = installFakeHost(agent);
-      const handle = await agent.startSession({
-        sessionId: 'session-native-user-input-descendant-timeout',
-        model: 'gpt-5.4',
-        workingDir: '/repo',
-      });
-      const handlers = host.getThreadHandlers();
-      if (!handlers?.requestUserInput || !handlers.descendantThreadStarted) {
-        throw new Error('expected requestUserInput and descendant thread handlers');
-      }
-      handlers.descendantThreadStarted({
-        thread: { id: 'child-thread-native-user-input-timeout', parentThreadId: 'start-thread-id' },
-      });
-      const resolveInteraction = vi.fn();
-      handle.setInteractionResolver(resolveInteraction);
-
-      const resultPromise = handlers.requestUserInput({
-        threadId: 'child-thread-native-user-input-timeout',
-        turnId: 'turn-native-descendant-timeout',
-        itemId: 'native-input-descendant-timeout',
-        questions: [{
-          id: 'direction',
-          header: 'Direction',
-          question: 'Choose child direction?',
-          isOther: false,
-          isSecret: false,
-          options: [],
-        }],
-      }, { requestId: 'req-native-descendant-timeout' });
-
-      await vi.advanceTimersByTimeAsync(10_000);
-      await expect(resultPromise).resolves.toEqual({ answers: {} });
-      expect(resolveInteraction).not.toHaveBeenCalled();
-      await handle.close();
-    } finally {
-      vi.useRealTimers();
-    }
   });
 
   it('keeps descendant native permission input requests available', async () => {
@@ -16597,64 +16546,6 @@ describe('CodexAgent MCP thread context hooks', () => {
     }, { requestId: 'req-permission-descendant' });
 
     expect(result).toEqual({ answers: { confirm: { answers: ['Allow'] } } });
-    expect(resolveInteraction).toHaveBeenCalledTimes(1);
-    await handle.close();
-  });
-
-  it('keeps descendant native permission input requests available when item context arrives later', async () => {
-    const agent = new CodexAgent(createDeps());
-    const host = installFakeHost(agent);
-    const handle = await agent.startSession({
-      sessionId: 'session-native-permission-input-descendant-out-of-order',
-      model: 'gpt-5.4',
-      workingDir: '/repo',
-    });
-    const handlers = host.getThreadHandlers();
-    if (!handlers?.requestUserInput || !handlers.descendantThreadStarted || !handlers.descendantNotification) {
-      throw new Error('expected requestUserInput and descendant notification handlers');
-    }
-    handlers.descendantThreadStarted({
-      thread: { id: 'child-thread-permission-input-late', parentThreadId: 'start-thread-id' },
-    });
-    const resolveInteraction = vi.fn(async (request: InteractionRequest): Promise<InteractionDecision> => {
-      expect(request.kind).toBe('permission');
-      expect(request.toolName).toBe('mcp:third_party:needs_confirmation');
-      return { kind: 'permission', behavior: 'allow' };
-    });
-    handle.setInteractionResolver(resolveInteraction);
-
-    const resultPromise = handlers.requestUserInput({
-      threadId: 'child-thread-permission-input-late',
-      turnId: 'turn-permission-descendant-late',
-      itemId: 'child-permission-input-late',
-      questions: [{
-        id: 'confirm',
-        header: 'Confirm',
-        question: 'Allow the child tool?',
-        isOther: false,
-        isSecret: false,
-        options: [
-          { label: 'Deny', description: '' },
-          { label: 'Allow', description: '' },
-        ],
-      }],
-    }, { requestId: 'req-permission-descendant-late' });
-
-    await new Promise((resolve) => setTimeout(resolve, 600));
-    handlers.descendantNotification('child-thread-permission-input-late', 'item/updated', {
-      threadId: 'child-thread-permission-input-late',
-      turnId: 'turn-permission-descendant-late',
-      item: {
-        id: 'child-permission-input-late',
-        type: 'mcpToolCall',
-        server: 'third_party',
-        tool: 'needs_confirmation',
-      },
-    });
-
-    await expect(resultPromise).resolves.toEqual({
-      answers: { confirm: { answers: ['Allow'] } },
-    });
     expect(resolveInteraction).toHaveBeenCalledTimes(1);
     await handle.close();
   });

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -16550,6 +16550,63 @@ describe('CodexAgent MCP thread context hooks', () => {
     await handle.close();
   });
 
+  it('keeps descendant native permission input requests available when item context arrives later', async () => {
+    const agent = new CodexAgent(createDeps());
+    const host = installFakeHost(agent);
+    const handle = await agent.startSession({
+      sessionId: 'session-native-permission-input-descendant-out-of-order',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+    });
+    const handlers = host.getThreadHandlers();
+    if (!handlers?.requestUserInput || !handlers.descendantThreadStarted || !handlers.descendantNotification) {
+      throw new Error('expected requestUserInput and descendant notification handlers');
+    }
+    handlers.descendantThreadStarted({
+      thread: { id: 'child-thread-permission-input-late', parentThreadId: 'start-thread-id' },
+    });
+    const resolveInteraction = vi.fn(async (request: InteractionRequest): Promise<InteractionDecision> => {
+      expect(request.kind).toBe('permission');
+      expect(request.toolName).toBe('mcp:third_party:needs_confirmation');
+      return { kind: 'permission', behavior: 'allow' };
+    });
+    handle.setInteractionResolver(resolveInteraction);
+
+    const resultPromise = handlers.requestUserInput({
+      threadId: 'child-thread-permission-input-late',
+      turnId: 'turn-permission-descendant-late',
+      itemId: 'child-permission-input-late',
+      questions: [{
+        id: 'confirm',
+        header: 'Confirm',
+        question: 'Allow the child tool?',
+        isOther: false,
+        isSecret: false,
+        options: [
+          { label: 'Deny', description: '' },
+          { label: 'Allow', description: '' },
+        ],
+      }],
+    }, { requestId: 'req-permission-descendant-late' });
+
+    handlers.descendantNotification('child-thread-permission-input-late', 'item/updated', {
+      threadId: 'child-thread-permission-input-late',
+      turnId: 'turn-permission-descendant-late',
+      item: {
+        id: 'child-permission-input-late',
+        type: 'mcpToolCall',
+        server: 'third_party',
+        tool: 'needs_confirmation',
+      },
+    });
+
+    await expect(resultPromise).resolves.toEqual({
+      answers: { confirm: { answers: ['Allow'] } },
+    });
+    expect(resolveInteraction).toHaveBeenCalledTimes(1);
+    await handle.close();
+  });
+
   it('preserves submitted answers from different concurrent user input prompts', async () => {
     const agent = new CodexAgent(createDeps());
     const host = installFakeHost(agent);

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -16417,6 +16417,139 @@ describe('CodexAgent MCP thread context hooks', () => {
     await handle.close();
   });
 
+  it('rejects descendant dynamic ask_user_question calls without opening an interaction', async () => {
+    const agent = new CodexAgent(createDeps());
+    const host = installFakeHost(agent);
+    const handle = await agent.startSession({
+      sessionId: 'session-dynamic-user-input-descendant',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+    });
+    const handlers = host.getThreadHandlers();
+    if (!handlers?.dynamicToolCall || !handlers.descendantThreadStarted) {
+      throw new Error('expected dynamic tool and descendant thread handlers');
+    }
+    handlers.descendantThreadStarted({
+      thread: { id: 'child-thread-user-input', parentThreadId: 'start-thread-id' },
+    });
+    const resolveInteraction = vi.fn(async () => ({
+      kind: 'ask_user_question' as const,
+      answers: { 'Should I continue?': 'yes' },
+    }));
+    handle.setInteractionResolver(resolveInteraction);
+
+    const result = await handlers.dynamicToolCall({
+      threadId: 'child-thread-user-input',
+      turnId: 'turn-1',
+      callId: 'dynamic-call-descendant',
+      namespace: null,
+      tool: 'cindy__ask_user_question',
+      arguments: {
+        questions: [{ header: 'Direction', question: 'Should I continue?' }],
+      },
+    }, { requestId: 'req-dynamic-descendant' });
+
+    expect(result).toEqual({
+      contentItems: [{
+        type: 'inputText',
+        text: 'User questions are only available to the root agent. Report the question to the parent agent, which can decide whether to ask the user.',
+      }],
+      success: false,
+    });
+    expect(resolveInteraction).not.toHaveBeenCalled();
+    await handle.close();
+  });
+
+  it('rejects descendant native ask_user_question requests without opening an interaction', async () => {
+    const agent = new CodexAgent(createDeps());
+    const host = installFakeHost(agent);
+    const handle = await agent.startSession({
+      sessionId: 'session-native-user-input-descendant',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+    });
+    const handlers = host.getThreadHandlers();
+    if (!handlers?.requestUserInput || !handlers.descendantThreadStarted) {
+      throw new Error('expected requestUserInput and descendant thread handlers');
+    }
+    handlers.descendantThreadStarted({
+      thread: { id: 'child-thread-native-user-input', parentThreadId: 'start-thread-id' },
+    });
+    const resolveInteraction = vi.fn();
+    handle.setInteractionResolver(resolveInteraction);
+
+    const result = await handlers.requestUserInput({
+      threadId: 'child-thread-native-user-input',
+      turnId: 'turn-native-descendant',
+      itemId: 'native-input-descendant',
+      questions: [{
+        id: 'direction',
+        header: 'Direction',
+        question: 'Choose child direction?',
+        isOther: false,
+        isSecret: false,
+        options: [],
+      }],
+    }, { requestId: 'req-native-descendant' });
+
+    expect(result).toEqual({ answers: {} });
+    expect(resolveInteraction).not.toHaveBeenCalled();
+    await handle.close();
+  });
+
+  it('keeps descendant native permission input requests available', async () => {
+    const agent = new CodexAgent(createDeps());
+    const host = installFakeHost(agent);
+    const handle = await agent.startSession({
+      sessionId: 'session-native-permission-input-descendant',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+    });
+    const handlers = host.getThreadHandlers();
+    if (!handlers?.requestUserInput || !handlers.descendantThreadStarted || !handlers.descendantNotification) {
+      throw new Error('expected requestUserInput and descendant notification handlers');
+    }
+    handlers.descendantThreadStarted({
+      thread: { id: 'child-thread-permission-input', parentThreadId: 'start-thread-id' },
+    });
+    handlers.descendantNotification('child-thread-permission-input', 'item/started', {
+      threadId: 'child-thread-permission-input',
+      turnId: 'turn-permission-descendant',
+      item: {
+        id: 'child-permission-input',
+        type: 'mcpToolCall',
+        server: 'third_party',
+        tool: 'needs_confirmation',
+      },
+    });
+    const resolveInteraction = vi.fn(async (request: InteractionRequest): Promise<InteractionDecision> => {
+      expect(request.kind).toBe('permission');
+      return { kind: 'permission', behavior: 'allow' };
+    });
+    handle.setInteractionResolver(resolveInteraction);
+
+    const result = await handlers.requestUserInput({
+      threadId: 'child-thread-permission-input',
+      turnId: 'turn-permission-descendant',
+      itemId: 'child-permission-input',
+      questions: [{
+        id: 'confirm',
+        header: 'Confirm',
+        question: 'Allow the child tool?',
+        isOther: false,
+        isSecret: false,
+        options: [
+          { label: 'Deny', description: '' },
+          { label: 'Allow', description: '' },
+        ],
+      }],
+    }, { requestId: 'req-permission-descendant' });
+
+    expect(result).toEqual({ answers: { confirm: { answers: ['Allow'] } } });
+    expect(resolveInteraction).toHaveBeenCalledTimes(1);
+    await handle.close();
+  });
+
   it('preserves submitted answers from different concurrent user input prompts', async () => {
     const agent = new CodexAgent(createDeps());
     const host = installFakeHost(agent);
@@ -19721,7 +19854,7 @@ describe('CodexAgent turn lifecycle', () => {
         options: [],
       }],
     }, { requestId: 'child-input-request' })).resolves.toEqual({
-      answers: { continue: { answers: ['Continue'] } },
+      answers: {},
     });
     await expect(handlers.dynamicToolCall({
       ...child,
@@ -19735,11 +19868,17 @@ describe('CodexAgent turn lifecycle', () => {
           question: 'Choose child direction?',
         }],
       },
-    }, { requestId: 'child-dynamic-request' })).resolves.toMatchObject({
-      success: true,
+    }, { requestId: 'child-dynamic-request' })).resolves.toEqual({
+      contentItems: [{
+        type: 'inputText',
+        text: 'User questions are only available to the root agent. Report the question to the parent agent, which can decide whether to ask the user.',
+      }],
+      success: false,
     });
 
-    expect(resolver).toHaveBeenCalledTimes(6);
+    // The root orphan gate remains bypassed for verified descendants, but both
+    // user-question channels are root-owned and therefore do not open UI.
+    expect(resolver).toHaveBeenCalledTimes(4);
     expect(host.request.mock.calls.filter(
       ([method]) => method === Method.TurnInterrupt,
     )).toHaveLength(interruptsBeforeRequests);

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -16505,6 +16505,49 @@ describe('CodexAgent MCP thread context hooks', () => {
     await handle.close();
   });
 
+  it('rejects an unknown descendant native request after provenance timeout', async () => {
+    vi.useFakeTimers();
+    try {
+      const agent = new CodexAgent(createDeps());
+      const host = installFakeHost(agent);
+      const handle = await agent.startSession({
+        sessionId: 'session-native-user-input-descendant-timeout',
+        model: 'gpt-5.4',
+        workingDir: '/repo',
+      });
+      const handlers = host.getThreadHandlers();
+      if (!handlers?.requestUserInput || !handlers.descendantThreadStarted) {
+        throw new Error('expected requestUserInput and descendant thread handlers');
+      }
+      handlers.descendantThreadStarted({
+        thread: { id: 'child-thread-native-user-input-timeout', parentThreadId: 'start-thread-id' },
+      });
+      const resolveInteraction = vi.fn();
+      handle.setInteractionResolver(resolveInteraction);
+
+      const resultPromise = handlers.requestUserInput({
+        threadId: 'child-thread-native-user-input-timeout',
+        turnId: 'turn-native-descendant-timeout',
+        itemId: 'native-input-descendant-timeout',
+        questions: [{
+          id: 'direction',
+          header: 'Direction',
+          question: 'Choose child direction?',
+          isOther: false,
+          isSecret: false,
+          options: [],
+        }],
+      }, { requestId: 'req-native-descendant-timeout' });
+
+      await vi.advanceTimersByTimeAsync(10_000);
+      await expect(resultPromise).resolves.toEqual({ answers: {} });
+      expect(resolveInteraction).not.toHaveBeenCalled();
+      await handle.close();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('keeps descendant native permission input requests available', async () => {
     const agent = new CodexAgent(createDeps());
     const host = installFakeHost(agent);

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -660,12 +660,6 @@ const ASK_USER_DYNAMIC_TOOL_CANONICAL_NAME =
   `${ASK_USER_DYNAMIC_TOOL_NAMESPACE}__${ASK_USER_DYNAMIC_TOOL_NAME}`;
 const CODEX_SUBAGENT_ASK_USER_QUESTION_DENIAL_MESSAGE =
   'User questions are only available to the root agent. Report the question to the parent agent, which can decide whether to ask the user.';
-// Item provenance is normally delivered before the corresponding server
-// request, but an unknown descendant request must still have a bounded,
-// fail-closed path when the app-server never emits provenance or cancellation.
-// This is deliberately much longer than the old 500ms grace period so normal
-// out-of-order permission notifications are not reclassified as user input.
-const DESCENDANT_INPUT_PROVENANCE_TIMEOUT_MS = 10_000;
 const MAX_REQUEST_USER_INPUT_QUESTIONS = 3;
 const MAX_REQUEST_USER_INPUT_OPTIONS = 10;
 const MAX_REQUEST_USER_INPUT_TEXT_CHARS = 1_000;
@@ -742,13 +736,6 @@ interface ActiveToolContext {
   pluginId?: string | null;
   namespace?: string | null;
   tool?: string | null;
-}
-
-type ActiveToolContextWaiter = (context: ActiveToolContext | undefined) => void;
-
-interface UserInputClassification {
-  kind: 'ask_user_question' | 'permission';
-  cancelled: boolean;
 }
 
 function isAskUserDynamicTool(params: Pick<DynamicToolCallParams, 'namespace' | 'tool'>): boolean {
@@ -4654,7 +4641,6 @@ export class CodexAgent extends BaseAgent {
       unregisterDescendantCodexMcpContexts();
       activeToolContexts.clear();
       completedActiveToolTurns.clear();
-      completedActiveToolContexts.clear();
       capabilitySelectionTextByTurnId.clear();
       capabilitySelectionTextByThreadId.clear();
       descendantParentThreadByThreadId.clear();
@@ -5528,9 +5514,7 @@ export class CodexAgent extends BaseAgent {
     const userInputBroker = new CodexInteractionBroker<ToolRequestUserInputResponse>();
     const dynamicToolBroker = new CodexInteractionBroker<DynamicToolCallResponse>();
     const activeToolContexts = new Map<string, ActiveToolContext>();
-    const activeToolContextWaiters = new Map<string, Set<ActiveToolContextWaiter>>();
     const completedActiveToolTurns = new Map<string, string | null | undefined>();
-    const completedActiveToolContexts = new Map<string, ActiveToolContext>();
     // A single model turn can surface the same visible question through both
     // the native requestUserInput request and the dynamic-tool compatibility
     // path. Join an in-flight interaction, then replay its submitted answers
@@ -5548,11 +5532,6 @@ export class CodexAgent extends BaseAgent {
       fingerprint: string;
       pendingForTurn: Map<string, PendingUserInputInteraction>;
       pendingInteraction: PendingUserInputInteraction;
-    }>();
-    const pendingUserInputClassifications = new Map<string, {
-      turnId: string | null | undefined;
-      cancelled: boolean;
-      cancel: () => void;
     }>();
     const liveAskUserByRequestId = new Map<string, LiveAskUserRequest>();
     registerRootCodexMcpContext();
@@ -6060,7 +6039,6 @@ export class CodexAgent extends BaseAgent {
 
     function dismissAllPendingUserInput(reason: string): void {
       dismissPendingUserInput(reason, (meta) => meta.threadId === threadId);
-      for (const pending of [...pendingUserInputClassifications.values()]) pending.cancel();
     }
 
     /**
@@ -7214,11 +7192,6 @@ export class CodexAgent extends BaseAgent {
         && completedActiveToolTurns.get(active.id) === turnId
       ) return;
       activeToolContexts.set(active.id, active.ctx);
-      completedActiveToolContexts.delete(active.id);
-      const waiters = activeToolContextWaiters.get(active.id);
-      if (!waiters) return;
-      activeToolContextWaiters.delete(active.id);
-      for (const resolve of [...waiters]) resolve(active.ctx);
     }
 
     function completeActiveToolContext(item: unknown, turnId?: string | null): void {
@@ -7227,80 +7200,8 @@ export class CodexAgent extends BaseAgent {
         ? (item as Record<string, unknown>).id as string
         : '';
       if (!itemId) return;
-      const context = activeToolContextFromItem(item, turnId)?.ctx
-        ?? activeToolContexts.get(itemId);
       activeToolContexts.delete(itemId);
       completedActiveToolTurns.set(itemId, turnId);
-      if (context) completedActiveToolContexts.set(itemId, context);
-      const waiters = activeToolContextWaiters.get(itemId);
-      if (!waiters) return;
-      activeToolContextWaiters.delete(itemId);
-      for (const resolve of [...waiters]) resolve(context);
-    }
-
-    function toolContextForItem(itemId: string): ActiveToolContext | undefined {
-      return activeToolContexts.get(itemId) ?? completedActiveToolContexts.get(itemId);
-    }
-
-    function waitForActiveToolContext(
-      itemId: string,
-      requestId: string,
-      turnId: string | null | undefined,
-    ): Promise<{ context: ActiveToolContext | undefined; cancelled: boolean }> {
-      // Prefer provenance or lifecycle cancellation. The bounded fallback is
-      // only to keep an unknown descendant request from hanging forever when
-      // neither signal arrives; it remains fail-closed for descendant input.
-      const existing = toolContextForItem(itemId);
-      if (existing) {
-        return Promise.resolve({ context: existing, cancelled: false });
-      }
-      if (completedActiveToolTurns.has(itemId)) {
-        return Promise.resolve({ context: undefined, cancelled: false });
-      }
-      return new Promise((resolve) => {
-        let settled = false;
-        let cancel!: () => void;
-        let timeout: ReturnType<typeof setTimeout>;
-        const pending = {
-          turnId,
-          cancelled: false,
-          cancel: (): void => undefined,
-        };
-        const finish = (context: ActiveToolContext | undefined): void => {
-          if (settled) return;
-          settled = true;
-          clearTimeout(timeout);
-          const waiters = activeToolContextWaiters.get(itemId);
-          waiters?.delete(finish);
-          if (waiters?.size === 0) activeToolContextWaiters.delete(itemId);
-          resolve({ context, cancelled: false });
-        };
-        cancel = (): void => {
-          pending.cancelled = true;
-          if (settled) return;
-          settled = true;
-          clearTimeout(timeout);
-          const waiters = activeToolContextWaiters.get(itemId);
-          waiters?.delete(finish);
-          if (waiters?.size === 0) activeToolContextWaiters.delete(itemId);
-          resolve({ context: undefined, cancelled: true });
-        };
-        pending.cancel = cancel;
-        const waiters = activeToolContextWaiters.get(itemId) ?? new Set<ActiveToolContextWaiter>();
-        waiters.add(finish);
-        activeToolContextWaiters.set(itemId, waiters);
-        pendingUserInputClassifications.set(requestId, pending);
-        timeout = setTimeout(() => {
-          log.warn('descendant requestUserInput provenance timed out; rejecting unknown request', {
-            requestId,
-            threadId,
-            turnId,
-            itemId,
-            timeoutMs: DESCENDANT_INPUT_PROVENANCE_TIMEOUT_MS,
-          });
-          finish(undefined);
-        }, DESCENDANT_INPUT_PROVENANCE_TIMEOUT_MS);
-      });
     }
 
     function activeDynamicToolUseId(params: DynamicToolCallParams): string | undefined {
@@ -7316,17 +7217,11 @@ export class CodexAgent extends BaseAgent {
     }
 
     function clearActiveToolContextsForTurn(turnId: string): void {
-      for (const pending of pendingUserInputClassifications.values()) {
-        if (pending.turnId === turnId) pending.cancel();
-      }
       for (const [itemId, ctx] of activeToolContexts) {
         if (ctx.turnId === turnId) activeToolContexts.delete(itemId);
       }
       for (const [itemId, completedTurnId] of completedActiveToolTurns) {
         if (completedTurnId === turnId) completedActiveToolTurns.delete(itemId);
-      }
-      for (const [itemId, ctx] of completedActiveToolContexts) {
-        if (ctx.turnId === turnId) completedActiveToolContexts.delete(itemId);
       }
       // Lifecycle callers dismiss the broker entries first. Wake joined waiters
       // before dropping the lookup maps so they can observe that their request
@@ -7345,7 +7240,6 @@ export class CodexAgent extends BaseAgent {
     }
 
     function clearAllPendingUserInputInteractions(): void {
-      for (const pending of [...pendingUserInputClassifications.values()]) pending.cancel();
       // Keep the same broker-dismiss-before-wake ordering as the per-turn path.
       for (const pendingForTurn of pendingUserInputByTurn.values()) {
         for (const pendingInteraction of pendingForTurn.values()) {
@@ -7380,20 +7274,6 @@ export class CodexAgent extends BaseAgent {
           : 'permission';
       }
       return 'ask_user_question';
-    }
-
-    function classifyUserInputRequest(
-      params: ToolRequestUserInputParams,
-      requestId: string,
-    ): UserInputClassification | Promise<UserInputClassification> {
-      const ctx = toolContextForItem(params.itemId);
-      if (ctx || params.threadId === threadId) {
-        return { kind: classifyToolContext(ctx), cancelled: false };
-      }
-      return waitForActiveToolContext(params.itemId, requestId, params.turnId).then(({ context, cancelled }) => ({
-        kind: classifyToolContext(context),
-        cancelled,
-      }));
     }
 
     async function askUserViaInteraction(
@@ -7614,21 +7494,12 @@ export class CodexAgent extends BaseAgent {
       if (resolvedWhileBufferedRequestIds.delete(requestId)) return { answers: {} };
       const questions = normalizeRequestUserInputQuestions(params.questions);
       if (questions.length === 0) return { answers: {} };
-      const classifiedKind = classifyUserInputRequest(params, requestId);
-      const classification = classifiedKind instanceof Promise
-        ? await classifiedKind
-        : classifiedKind;
-      const pendingClassification = pendingUserInputClassifications.get(requestId);
-      if (
-        classification.cancelled
-        || pendingClassification?.cancelled === true
-        || resolvedWhileBufferedRequestIds.delete(requestId)
-      ) {
-        pendingUserInputClassifications.delete(requestId);
-        return { answers: {} };
-      }
-      pendingUserInputClassifications.delete(requestId);
-      const kind = classification.kind;
+      // Codex 0.145 emits an MCP tool's item/started notification before it
+      // requests fallback approval through requestUserInput. Therefore an
+      // unknown descendant item is not a permission race: fail closed instead
+      // of adding a timer that can either hang or reject a legitimate request.
+      const activeToolContext = activeToolContexts.get(params.itemId);
+      const kind = classifyToolContext(activeToolContext);
       if (kind === 'ask_user_question' && params.threadId !== threadId) {
         log.warn('native requestUserInput rejected for descendant user question', {
           requestId,
@@ -7639,7 +7510,6 @@ export class CodexAgent extends BaseAgent {
         });
         return { answers: {} };
       }
-      const activeToolContext = toolContextForItem(params.itemId);
       const hasToolGenerationBoundary =
         activeToolContext?.type === 'mcpToolCall'
         || activeToolContext?.type === 'dynamicToolCall';
@@ -7853,8 +7723,6 @@ export class CodexAgent extends BaseAgent {
       const brokerKey = { connectionId, requestId: params.requestId };
       const userInputPending = userInputBroker.has(brokerKey);
       const dynamicPending = dynamicToolBroker.has(brokerKey);
-      const classificationPending = pendingUserInputClassifications.get(requestId);
-      if (classificationPending) classificationPending.cancel();
       if (userInputPending || dynamicPending) {
         // Wake joined duplicates before settling the owner's outer broker
         // response. This keeps them on the cancellation/reassignment path even
@@ -7878,7 +7746,7 @@ export class CodexAgent extends BaseAgent {
           data: { requestId, reason: 'server_request_resolved', resolvedAs: 'deny' },
           source: 'codex',
         });
-      } else if (!classificationPending && bufferedOrphanTurnIds.size > 0) {
+      } else if (bufferedOrphanTurnIds.size > 0) {
         // cancel 未命中且有 buffered turn: 可能是挂起中的请求 (尚未注册到
         // broker) 被服务端取消 (greptile R13 P1) — 记下 requestId, 对账放行
         // 后 handler 自查回空响应, 不上 UI。requestId 是一次性的 (消费即删),
@@ -9629,7 +9497,6 @@ export class CodexAgent extends BaseAgent {
         dismissAllPendingUserInput('transport_error');
         activeToolContexts.clear();
         completedActiveToolTurns.clear();
-        completedActiveToolContexts.clear();
         capabilitySelectionTextByTurnId.clear();
         capabilitySelectionTextByThreadId.clear();
         descendantParentThreadByThreadId.clear();
@@ -10323,7 +10190,6 @@ export class CodexAgent extends BaseAgent {
           dismissAllPendingUserInput('transport_error');
           activeToolContexts.clear();
           completedActiveToolTurns.clear();
-          completedActiveToolContexts.clear();
           capabilitySelectionTextByTurnId.clear();
           capabilitySelectionTextByThreadId.clear();
           descendantParentThreadByThreadId.clear();
@@ -10613,7 +10479,6 @@ export class CodexAgent extends BaseAgent {
       unregisterDescendantCodexMcpContexts();
       activeToolContexts.clear();
       completedActiveToolTurns.clear();
-      completedActiveToolContexts.clear();
       capabilitySelectionTextByTurnId.clear();
       capabilitySelectionTextByThreadId.clear();
       descendantParentThreadByThreadId.clear();

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -660,6 +660,12 @@ const ASK_USER_DYNAMIC_TOOL_CANONICAL_NAME =
   `${ASK_USER_DYNAMIC_TOOL_NAMESPACE}__${ASK_USER_DYNAMIC_TOOL_NAME}`;
 const CODEX_SUBAGENT_ASK_USER_QUESTION_DENIAL_MESSAGE =
   'User questions are only available to the root agent. Report the question to the parent agent, which can decide whether to ask the user.';
+// Item provenance is normally delivered before the corresponding server
+// request, but an unknown descendant request must still have a bounded,
+// fail-closed path when the app-server never emits provenance or cancellation.
+// This is deliberately much longer than the old 500ms grace period so normal
+// out-of-order permission notifications are not reclassified as user input.
+const DESCENDANT_INPUT_PROVENANCE_TIMEOUT_MS = 10_000;
 const MAX_REQUEST_USER_INPUT_QUESTIONS = 3;
 const MAX_REQUEST_USER_INPUT_OPTIONS = 10;
 const MAX_REQUEST_USER_INPUT_TEXT_CHARS = 1_000;
@@ -7241,9 +7247,9 @@ export class CodexAgent extends BaseAgent {
       requestId: string,
       turnId: string | null | undefined,
     ): Promise<{ context: ActiveToolContext | undefined; cancelled: boolean }> {
-      // Item notifications may be delayed well beyond a wall-clock threshold;
-      // resolve from provenance or lifecycle cancellation instead of guessing
-      // that an unknown descendant request is a user question.
+      // Prefer provenance or lifecycle cancellation. The bounded fallback is
+      // only to keep an unknown descendant request from hanging forever when
+      // neither signal arrives; it remains fail-closed for descendant input.
       const existing = toolContextForItem(itemId);
       if (existing) {
         return Promise.resolve({ context: existing, cancelled: false });
@@ -7254,6 +7260,7 @@ export class CodexAgent extends BaseAgent {
       return new Promise((resolve) => {
         let settled = false;
         let cancel!: () => void;
+        let timeout: ReturnType<typeof setTimeout>;
         const pending = {
           turnId,
           cancelled: false,
@@ -7262,6 +7269,7 @@ export class CodexAgent extends BaseAgent {
         const finish = (context: ActiveToolContext | undefined): void => {
           if (settled) return;
           settled = true;
+          clearTimeout(timeout);
           const waiters = activeToolContextWaiters.get(itemId);
           waiters?.delete(finish);
           if (waiters?.size === 0) activeToolContextWaiters.delete(itemId);
@@ -7271,6 +7279,7 @@ export class CodexAgent extends BaseAgent {
           pending.cancelled = true;
           if (settled) return;
           settled = true;
+          clearTimeout(timeout);
           const waiters = activeToolContextWaiters.get(itemId);
           waiters?.delete(finish);
           if (waiters?.size === 0) activeToolContextWaiters.delete(itemId);
@@ -7281,6 +7290,16 @@ export class CodexAgent extends BaseAgent {
         waiters.add(finish);
         activeToolContextWaiters.set(itemId, waiters);
         pendingUserInputClassifications.set(requestId, pending);
+        timeout = setTimeout(() => {
+          log.warn('descendant requestUserInput provenance timed out; rejecting unknown request', {
+            requestId,
+            threadId,
+            turnId,
+            itemId,
+            timeoutMs: DESCENDANT_INPUT_PROVENANCE_TIMEOUT_MS,
+          });
+          finish(undefined);
+        }, DESCENDANT_INPUT_PROVENANCE_TIMEOUT_MS);
       });
     }
 

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -660,6 +660,10 @@ const ASK_USER_DYNAMIC_TOOL_CANONICAL_NAME =
   `${ASK_USER_DYNAMIC_TOOL_NAMESPACE}__${ASK_USER_DYNAMIC_TOOL_NAME}`;
 const CODEX_SUBAGENT_ASK_USER_QUESTION_DENIAL_MESSAGE =
   'User questions are only available to the root agent. Report the question to the parent agent, which can decide whether to ask the user.';
+// Codex may deliver a server request before the matching item notification.
+// Keep the classification race bounded while preserving fail-closed behavior
+// for a descendant whose tool provenance never arrives.
+const CODEX_TOOL_CONTEXT_WAIT_TIMEOUT_MS = 500;
 const MAX_REQUEST_USER_INPUT_QUESTIONS = 3;
 const MAX_REQUEST_USER_INPUT_OPTIONS = 10;
 const MAX_REQUEST_USER_INPUT_TEXT_CHARS = 1_000;
@@ -5514,6 +5518,7 @@ export class CodexAgent extends BaseAgent {
     const userInputBroker = new CodexInteractionBroker<ToolRequestUserInputResponse>();
     const dynamicToolBroker = new CodexInteractionBroker<DynamicToolCallResponse>();
     const activeToolContexts = new Map<string, ActiveToolContext>();
+    const activeToolContextWaiters = new Map<string, Set<() => void>>();
     const completedActiveToolTurns = new Map<string, string | null | undefined>();
     // A single model turn can surface the same visible question through both
     // the native requestUserInput request and the dynamic-tool compatibility
@@ -7192,6 +7197,10 @@ export class CodexAgent extends BaseAgent {
         && completedActiveToolTurns.get(active.id) === turnId
       ) return;
       activeToolContexts.set(active.id, active.ctx);
+      const waiters = activeToolContextWaiters.get(active.id);
+      if (!waiters) return;
+      activeToolContextWaiters.delete(active.id);
+      for (const resolve of [...waiters]) resolve();
     }
 
     function completeActiveToolContext(item: unknown, turnId?: string | null): void {
@@ -7202,6 +7211,34 @@ export class CodexAgent extends BaseAgent {
       if (!itemId) return;
       activeToolContexts.delete(itemId);
       completedActiveToolTurns.set(itemId, turnId);
+      const waiters = activeToolContextWaiters.get(itemId);
+      if (!waiters) return;
+      activeToolContextWaiters.delete(itemId);
+      for (const resolve of [...waiters]) resolve();
+    }
+
+    function waitForActiveToolContext(itemId: string): Promise<void> {
+      if (activeToolContexts.has(itemId) || completedActiveToolTurns.has(itemId)) {
+        return Promise.resolve();
+      }
+      return new Promise((resolve) => {
+        let settled = false;
+        let timer: ReturnType<typeof setTimeout> | undefined;
+        const finish = (): void => {
+          if (settled) return;
+          settled = true;
+          if (timer) clearTimeout(timer);
+          const waiters = activeToolContextWaiters.get(itemId);
+          waiters?.delete(finish);
+          if (waiters?.size === 0) activeToolContextWaiters.delete(itemId);
+          resolve();
+        };
+        timer = setTimeout(finish, CODEX_TOOL_CONTEXT_WAIT_TIMEOUT_MS);
+        timer.unref?.();
+        const waiters = activeToolContextWaiters.get(itemId) ?? new Set<() => void>();
+        waiters.add(finish);
+        activeToolContextWaiters.set(itemId, waiters);
+      });
     }
 
     function activeDynamicToolUseId(params: DynamicToolCallParams): string | undefined {
@@ -7265,8 +7302,7 @@ export class CodexAgent extends BaseAgent {
       }
     }
 
-    function classifyUserInputRequest(params: ToolRequestUserInputParams): 'ask_user_question' | 'permission' {
-      const ctx = activeToolContexts.get(params.itemId);
+    function classifyToolContext(ctx: ActiveToolContext | undefined): 'ask_user_question' | 'permission' {
       if (!ctx) return 'ask_user_question';
       if (ctx.type === 'mcpToolCall') return 'permission';
       if (ctx.type === 'dynamicToolCall') {
@@ -7275,6 +7311,15 @@ export class CodexAgent extends BaseAgent {
           : 'permission';
       }
       return 'ask_user_question';
+    }
+
+    function classifyUserInputRequest(
+      params: ToolRequestUserInputParams,
+    ): 'ask_user_question' | 'permission' | Promise<'ask_user_question' | 'permission'> {
+      const ctx = activeToolContexts.get(params.itemId);
+      if (ctx || params.threadId === threadId) return classifyToolContext(ctx);
+      return waitForActiveToolContext(params.itemId).then(() =>
+        classifyToolContext(activeToolContexts.get(params.itemId)));
     }
 
     async function askUserViaInteraction(
@@ -7495,7 +7540,8 @@ export class CodexAgent extends BaseAgent {
       if (resolvedWhileBufferedRequestIds.delete(requestId)) return { answers: {} };
       const questions = normalizeRequestUserInputQuestions(params.questions);
       if (questions.length === 0) return { answers: {} };
-      const kind = classifyUserInputRequest(params);
+      const classifiedKind = classifyUserInputRequest(params);
+      const kind = typeof classifiedKind === 'string' ? classifiedKind : await classifiedKind;
       if (kind === 'ask_user_question' && params.threadId !== threadId) {
         log.warn('native requestUserInput rejected for descendant user question', {
           requestId,

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -658,6 +658,8 @@ const LEGACY_ASK_USER_DYNAMIC_TOOL_NAMESPACE = 'xdt_maker';
 const ASK_USER_DYNAMIC_TOOL_NAME = 'ask_user_question';
 const ASK_USER_DYNAMIC_TOOL_CANONICAL_NAME =
   `${ASK_USER_DYNAMIC_TOOL_NAMESPACE}__${ASK_USER_DYNAMIC_TOOL_NAME}`;
+const CODEX_SUBAGENT_ASK_USER_QUESTION_DENIAL_MESSAGE =
+  'User questions are only available to the root agent. Report the question to the parent agent, which can decide whether to ask the user.';
 const MAX_REQUEST_USER_INPUT_QUESTIONS = 3;
 const MAX_REQUEST_USER_INPUT_OPTIONS = 10;
 const MAX_REQUEST_USER_INPUT_TEXT_CHARS = 1_000;
@@ -7494,6 +7496,16 @@ export class CodexAgent extends BaseAgent {
       const questions = normalizeRequestUserInputQuestions(params.questions);
       if (questions.length === 0) return { answers: {} };
       const kind = classifyUserInputRequest(params);
+      if (kind === 'ask_user_question' && params.threadId !== threadId) {
+        log.warn('native requestUserInput rejected for descendant user question', {
+          requestId,
+          threadId: params.threadId,
+          rootThreadId: threadId,
+          turnId: params.turnId,
+          itemId: params.itemId,
+        });
+        return { answers: {} };
+      }
       const activeToolContext = activeToolContexts.get(params.itemId);
       const hasToolGenerationBoundary =
         activeToolContext?.type === 'mcpToolCall'
@@ -7570,6 +7582,19 @@ export class CodexAgent extends BaseAgent {
       }
       const toolUseId = activeDynamicToolUseId(params);
       if (isAskUserDynamicTool(params)) {
+        // Codex app-server keeps dynamic tools at the root thread and may make
+        // them callable from descendant threads. User interaction is a
+        // root-owned capability: a native subagent must report the question to
+        // its parent instead of opening a Cindy card of its own.
+        if (params.threadId !== threadId) {
+          return {
+            contentItems: [{
+              type: 'inputText',
+              text: CODEX_SUBAGENT_ASK_USER_QUESTION_DENIAL_MESSAGE,
+            }],
+            success: false,
+          };
+        }
         const requestId = String(meta.requestId);
         // 挂起期间服务端已取消本请求 (greptile R13 P1): 直接回失败响应, 不注册
         // broker 不上 UI (与 resolved 的 cancel 响应同款文案)。

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -660,10 +660,6 @@ const ASK_USER_DYNAMIC_TOOL_CANONICAL_NAME =
   `${ASK_USER_DYNAMIC_TOOL_NAMESPACE}__${ASK_USER_DYNAMIC_TOOL_NAME}`;
 const CODEX_SUBAGENT_ASK_USER_QUESTION_DENIAL_MESSAGE =
   'User questions are only available to the root agent. Report the question to the parent agent, which can decide whether to ask the user.';
-// Codex may deliver a server request before the matching item notification.
-// Keep the classification race bounded while preserving fail-closed behavior
-// for a descendant whose tool provenance never arrives.
-const CODEX_TOOL_CONTEXT_WAIT_TIMEOUT_MS = 500;
 const MAX_REQUEST_USER_INPUT_QUESTIONS = 3;
 const MAX_REQUEST_USER_INPUT_OPTIONS = 10;
 const MAX_REQUEST_USER_INPUT_TEXT_CHARS = 1_000;
@@ -740,6 +736,13 @@ interface ActiveToolContext {
   pluginId?: string | null;
   namespace?: string | null;
   tool?: string | null;
+}
+
+type ActiveToolContextWaiter = (context: ActiveToolContext | undefined) => void;
+
+interface UserInputClassification {
+  kind: 'ask_user_question' | 'permission';
+  cancelled: boolean;
 }
 
 function isAskUserDynamicTool(params: Pick<DynamicToolCallParams, 'namespace' | 'tool'>): boolean {
@@ -4645,6 +4648,7 @@ export class CodexAgent extends BaseAgent {
       unregisterDescendantCodexMcpContexts();
       activeToolContexts.clear();
       completedActiveToolTurns.clear();
+      completedActiveToolContexts.clear();
       capabilitySelectionTextByTurnId.clear();
       capabilitySelectionTextByThreadId.clear();
       descendantParentThreadByThreadId.clear();
@@ -5518,8 +5522,9 @@ export class CodexAgent extends BaseAgent {
     const userInputBroker = new CodexInteractionBroker<ToolRequestUserInputResponse>();
     const dynamicToolBroker = new CodexInteractionBroker<DynamicToolCallResponse>();
     const activeToolContexts = new Map<string, ActiveToolContext>();
-    const activeToolContextWaiters = new Map<string, Set<() => void>>();
+    const activeToolContextWaiters = new Map<string, Set<ActiveToolContextWaiter>>();
     const completedActiveToolTurns = new Map<string, string | null | undefined>();
+    const completedActiveToolContexts = new Map<string, ActiveToolContext>();
     // A single model turn can surface the same visible question through both
     // the native requestUserInput request and the dynamic-tool compatibility
     // path. Join an in-flight interaction, then replay its submitted answers
@@ -5537,6 +5542,11 @@ export class CodexAgent extends BaseAgent {
       fingerprint: string;
       pendingForTurn: Map<string, PendingUserInputInteraction>;
       pendingInteraction: PendingUserInputInteraction;
+    }>();
+    const pendingUserInputClassifications = new Map<string, {
+      turnId: string | null | undefined;
+      cancelled: boolean;
+      cancel: () => void;
     }>();
     const liveAskUserByRequestId = new Map<string, LiveAskUserRequest>();
     registerRootCodexMcpContext();
@@ -6044,6 +6054,7 @@ export class CodexAgent extends BaseAgent {
 
     function dismissAllPendingUserInput(reason: string): void {
       dismissPendingUserInput(reason, (meta) => meta.threadId === threadId);
+      for (const pending of [...pendingUserInputClassifications.values()]) pending.cancel();
     }
 
     /**
@@ -7197,10 +7208,11 @@ export class CodexAgent extends BaseAgent {
         && completedActiveToolTurns.get(active.id) === turnId
       ) return;
       activeToolContexts.set(active.id, active.ctx);
+      completedActiveToolContexts.delete(active.id);
       const waiters = activeToolContextWaiters.get(active.id);
       if (!waiters) return;
       activeToolContextWaiters.delete(active.id);
-      for (const resolve of [...waiters]) resolve();
+      for (const resolve of [...waiters]) resolve(active.ctx);
     }
 
     function completeActiveToolContext(item: unknown, turnId?: string | null): void {
@@ -7209,35 +7221,66 @@ export class CodexAgent extends BaseAgent {
         ? (item as Record<string, unknown>).id as string
         : '';
       if (!itemId) return;
+      const context = activeToolContextFromItem(item, turnId)?.ctx
+        ?? activeToolContexts.get(itemId);
       activeToolContexts.delete(itemId);
       completedActiveToolTurns.set(itemId, turnId);
+      if (context) completedActiveToolContexts.set(itemId, context);
       const waiters = activeToolContextWaiters.get(itemId);
       if (!waiters) return;
       activeToolContextWaiters.delete(itemId);
-      for (const resolve of [...waiters]) resolve();
+      for (const resolve of [...waiters]) resolve(context);
     }
 
-    function waitForActiveToolContext(itemId: string): Promise<void> {
-      if (activeToolContexts.has(itemId) || completedActiveToolTurns.has(itemId)) {
-        return Promise.resolve();
+    function toolContextForItem(itemId: string): ActiveToolContext | undefined {
+      return activeToolContexts.get(itemId) ?? completedActiveToolContexts.get(itemId);
+    }
+
+    function waitForActiveToolContext(
+      itemId: string,
+      requestId: string,
+      turnId: string | null | undefined,
+    ): Promise<{ context: ActiveToolContext | undefined; cancelled: boolean }> {
+      // Item notifications may be delayed well beyond a wall-clock threshold;
+      // resolve from provenance or lifecycle cancellation instead of guessing
+      // that an unknown descendant request is a user question.
+      const existing = toolContextForItem(itemId);
+      if (existing) {
+        return Promise.resolve({ context: existing, cancelled: false });
+      }
+      if (completedActiveToolTurns.has(itemId)) {
+        return Promise.resolve({ context: undefined, cancelled: false });
       }
       return new Promise((resolve) => {
         let settled = false;
-        let timer: ReturnType<typeof setTimeout> | undefined;
-        const finish = (): void => {
+        let cancel!: () => void;
+        const pending = {
+          turnId,
+          cancelled: false,
+          cancel: (): void => undefined,
+        };
+        const finish = (context: ActiveToolContext | undefined): void => {
           if (settled) return;
           settled = true;
-          if (timer) clearTimeout(timer);
           const waiters = activeToolContextWaiters.get(itemId);
           waiters?.delete(finish);
           if (waiters?.size === 0) activeToolContextWaiters.delete(itemId);
-          resolve();
+          resolve({ context, cancelled: false });
         };
-        timer = setTimeout(finish, CODEX_TOOL_CONTEXT_WAIT_TIMEOUT_MS);
-        timer.unref?.();
-        const waiters = activeToolContextWaiters.get(itemId) ?? new Set<() => void>();
+        cancel = (): void => {
+          pending.cancelled = true;
+          if (settled) return;
+          settled = true;
+          const waiters = activeToolContextWaiters.get(itemId);
+          waiters?.delete(finish);
+          if (waiters?.size === 0) activeToolContextWaiters.delete(itemId);
+          resolve({ context: undefined, cancelled: true });
+        };
+        pending.cancel = cancel;
+        const waiters = activeToolContextWaiters.get(itemId) ?? new Set<ActiveToolContextWaiter>();
         waiters.add(finish);
         activeToolContextWaiters.set(itemId, waiters);
+        pendingUserInputClassifications.set(requestId, pending);
       });
     }
 
@@ -7254,11 +7297,17 @@ export class CodexAgent extends BaseAgent {
     }
 
     function clearActiveToolContextsForTurn(turnId: string): void {
+      for (const pending of pendingUserInputClassifications.values()) {
+        if (pending.turnId === turnId) pending.cancel();
+      }
       for (const [itemId, ctx] of activeToolContexts) {
         if (ctx.turnId === turnId) activeToolContexts.delete(itemId);
       }
       for (const [itemId, completedTurnId] of completedActiveToolTurns) {
         if (completedTurnId === turnId) completedActiveToolTurns.delete(itemId);
+      }
+      for (const [itemId, ctx] of completedActiveToolContexts) {
+        if (ctx.turnId === turnId) completedActiveToolContexts.delete(itemId);
       }
       // Lifecycle callers dismiss the broker entries first. Wake joined waiters
       // before dropping the lookup maps so they can observe that their request
@@ -7277,6 +7326,7 @@ export class CodexAgent extends BaseAgent {
     }
 
     function clearAllPendingUserInputInteractions(): void {
+      for (const pending of [...pendingUserInputClassifications.values()]) pending.cancel();
       // Keep the same broker-dismiss-before-wake ordering as the per-turn path.
       for (const pendingForTurn of pendingUserInputByTurn.values()) {
         for (const pendingInteraction of pendingForTurn.values()) {
@@ -7315,11 +7365,16 @@ export class CodexAgent extends BaseAgent {
 
     function classifyUserInputRequest(
       params: ToolRequestUserInputParams,
-    ): 'ask_user_question' | 'permission' | Promise<'ask_user_question' | 'permission'> {
-      const ctx = activeToolContexts.get(params.itemId);
-      if (ctx || params.threadId === threadId) return classifyToolContext(ctx);
-      return waitForActiveToolContext(params.itemId).then(() =>
-        classifyToolContext(activeToolContexts.get(params.itemId)));
+      requestId: string,
+    ): UserInputClassification | Promise<UserInputClassification> {
+      const ctx = toolContextForItem(params.itemId);
+      if (ctx || params.threadId === threadId) {
+        return { kind: classifyToolContext(ctx), cancelled: false };
+      }
+      return waitForActiveToolContext(params.itemId, requestId, params.turnId).then(({ context, cancelled }) => ({
+        kind: classifyToolContext(context),
+        cancelled,
+      }));
     }
 
     async function askUserViaInteraction(
@@ -7540,8 +7595,21 @@ export class CodexAgent extends BaseAgent {
       if (resolvedWhileBufferedRequestIds.delete(requestId)) return { answers: {} };
       const questions = normalizeRequestUserInputQuestions(params.questions);
       if (questions.length === 0) return { answers: {} };
-      const classifiedKind = classifyUserInputRequest(params);
-      const kind = typeof classifiedKind === 'string' ? classifiedKind : await classifiedKind;
+      const classifiedKind = classifyUserInputRequest(params, requestId);
+      const classification = classifiedKind instanceof Promise
+        ? await classifiedKind
+        : classifiedKind;
+      const pendingClassification = pendingUserInputClassifications.get(requestId);
+      if (
+        classification.cancelled
+        || pendingClassification?.cancelled === true
+        || resolvedWhileBufferedRequestIds.delete(requestId)
+      ) {
+        pendingUserInputClassifications.delete(requestId);
+        return { answers: {} };
+      }
+      pendingUserInputClassifications.delete(requestId);
+      const kind = classification.kind;
       if (kind === 'ask_user_question' && params.threadId !== threadId) {
         log.warn('native requestUserInput rejected for descendant user question', {
           requestId,
@@ -7552,7 +7620,7 @@ export class CodexAgent extends BaseAgent {
         });
         return { answers: {} };
       }
-      const activeToolContext = activeToolContexts.get(params.itemId);
+      const activeToolContext = toolContextForItem(params.itemId);
       const hasToolGenerationBoundary =
         activeToolContext?.type === 'mcpToolCall'
         || activeToolContext?.type === 'dynamicToolCall';
@@ -7766,6 +7834,8 @@ export class CodexAgent extends BaseAgent {
       const brokerKey = { connectionId, requestId: params.requestId };
       const userInputPending = userInputBroker.has(brokerKey);
       const dynamicPending = dynamicToolBroker.has(brokerKey);
+      const classificationPending = pendingUserInputClassifications.get(requestId);
+      if (classificationPending) classificationPending.cancel();
       if (userInputPending || dynamicPending) {
         // Wake joined duplicates before settling the owner's outer broker
         // response. This keeps them on the cancellation/reassignment path even
@@ -7789,7 +7859,7 @@ export class CodexAgent extends BaseAgent {
           data: { requestId, reason: 'server_request_resolved', resolvedAs: 'deny' },
           source: 'codex',
         });
-      } else if (bufferedOrphanTurnIds.size > 0) {
+      } else if (!classificationPending && bufferedOrphanTurnIds.size > 0) {
         // cancel 未命中且有 buffered turn: 可能是挂起中的请求 (尚未注册到
         // broker) 被服务端取消 (greptile R13 P1) — 记下 requestId, 对账放行
         // 后 handler 自查回空响应, 不上 UI。requestId 是一次性的 (消费即删),
@@ -9540,6 +9610,7 @@ export class CodexAgent extends BaseAgent {
         dismissAllPendingUserInput('transport_error');
         activeToolContexts.clear();
         completedActiveToolTurns.clear();
+        completedActiveToolContexts.clear();
         capabilitySelectionTextByTurnId.clear();
         capabilitySelectionTextByThreadId.clear();
         descendantParentThreadByThreadId.clear();
@@ -10233,6 +10304,7 @@ export class CodexAgent extends BaseAgent {
           dismissAllPendingUserInput('transport_error');
           activeToolContexts.clear();
           completedActiveToolTurns.clear();
+          completedActiveToolContexts.clear();
           capabilitySelectionTextByTurnId.clear();
           capabilitySelectionTextByThreadId.clear();
           descendantParentThreadByThreadId.clear();
@@ -10522,6 +10594,7 @@ export class CodexAgent extends BaseAgent {
       unregisterDescendantCodexMcpContexts();
       activeToolContexts.clear();
       completedActiveToolTurns.clear();
+      completedActiveToolContexts.clear();
       capabilitySelectionTextByTurnId.clear();
       capabilitySelectionTextByThreadId.clear();
       descendantParentThreadByThreadId.clear();


### PR DESCRIPTION
## 这次改了什么

### 摘要

收口子 Agent 的用户问答能力，避免 native subagent 或 Codex descendant 直接创建用户问答卡，同时保留主 Agent 的正常提问能力和子 Agent 的权限审批能力。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：
  - Codex dynamic `ask_user_question` 和原生 `requestUserInput` 的 descendant 拒绝。
  - Claude 本地 `PreToolUse` 与远程 cc-manager 的 `root-only` 守卫。
  - Codex、Claude、cc-manager 相关单测。
- 明确不包含：
  - Codex per-thread MCP 工具隔离。
  - 其他尚未裁决的 root-only 能力分层。
  - Pi 改动；Pi 已通过显式工具白名单隔离。
- 用户可见变化：子 Agent 不再直接弹出用户问答卡；主 Agent 仍可提问，权限审批不受影响。
- 是否存在 breaking change：无

### UI 变化

- 不涉及：本 PR 只修改 Agent/cc-manager 调用权限与测试，没有 UI 代码或视觉变化。
- 引用的设计规范：不涉及。

## 怎么验证的

### 自动验证

```text
pnpm --filter @cindy/maker-core exec vitest run src/agents/codex/index.test.ts src/agents/claude-code/__tests__/capability-routing.test.ts src/agents/claude-code/__tests__/mcp-approval-policy.test.ts
结果：3 个测试文件、574 个测试全部通过。

pnpm --filter @cindy/maker-cc-manager exec vitest run __tests__/sdk-handlers.test.ts __tests__/session-registry.test.ts
结果：2 个测试文件、40 个测试全部通过。

pnpm --filter @cindy/maker-cc-manager build
结果：通过。

pnpm check:dco
结果：通过，1 个提交带 DCO 签名。

bash /Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh /Users/dash/Code/Cindy/cindy-subagent-tool-visibility
结果：相关 packages 通过；apps/desktop 因隔离 worktree 的 Electron 未正确安装导致大量收集失败，另有 2 个未改动的 ghost receipt 基线断言失败。完整日志已由门禁脚本写入临时日志。
```

### 手工验证

不涉及。

### 未执行的验证

未进行 Desktop 实机手工验证；本 PR 不包含 UI 改动。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [x] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Agent 子调用用户问答的权限边界；Codex descendant 与 Claude native subagent 被拒绝，root 调用和权限审批保持原行为。
- 回滚 / 降级方式：回滚本 PR 提交即可恢复旧行为；不涉及数据迁移。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [ ] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因

