### PR TITLE
fix(desktop): 避免步骤胶囊与底部导航重叠

### DIFF
--- a/apps/desktop/src/renderer/__tests__/controlledBannerPlacement.test.ts
+++ b/apps/desktop/src/renderer/__tests__/controlledBannerPlacement.test.ts
@@ -109,6 +109,12 @@ describe('controlled banner placement', () => {
     );
     expect(todoListSource).toContain('data-plan-pill-anchor="true"');
     expect(todoListSource).toContain('data-plan-flyout-positioner="composer"');
+    expect(sessionViewSource).toContain(
+      'const mutationObserver = new MutationObserver(syncResizeTargetsAndMeasure);',
+    );
+    expect(sessionViewSource).toContain(
+      'mutationObserver.observe(overlayEl, { childList: true, subtree: true });',
+    );
     expect(sessionViewSource).not.toContain('fitContent=');
     expect(pinnedPlanSource).not.toContain('fitContent');
     expect(todoListSource).not.toContain('fitContent');

--- a/apps/desktop/src/renderer/components/chat/MessageStream.tsx
+++ b/apps/desktop/src/renderer/components/chat/MessageStream.tsx
@@ -375,8 +375,8 @@ interface MessageStreamProps {
   historyWindowHasIsland?: boolean;
   /** Dynamic bottom padding (px) to reserve space for the input overlay */
   bottomPadding?: number;
-  /** Distance from the chat viewport bottom to the visible composer stack top. */
-  composerStackTopOffset?: number;
+  /** Distance from the chat viewport bottom to the topmost occupied bottom-center layer. */
+  bottomCenterClearanceOffset?: number;
   /** Content width — shared with the input overlay so chat stream + input
    *  box stay horizontally aligned (same width, same center, symmetric
    *  padding when the main area is compressed). */
@@ -2957,7 +2957,7 @@ export function MessageStream({
   hasMoreMessages,
   historyWindowHasIsland = false,
   bottomPadding,
-  composerStackTopOffset,
+  bottomCenterClearanceOffset,
   contentWidth,
   getContentWidth,
   focusMessageClientId,
@@ -5658,12 +5658,12 @@ export function MessageStream({
     previousLocalFileRefsRef.current = localFileRefs;
   }, [localFileRefs]);
 
-  // chip 垂直位置：优先使用父层实测的输入框卡片顶边，避免 RunningStatusBar
-  // 出现 / 收起改变 overlay 总高度后，把按钮带进输入框。旧调用方保留历史兜底。
+  // chip 垂直位置：优先使用父层实测的底部中央避让边界。普通状态行不占中央槽，
+  // 步骤 / 接管胶囊在场时则把按钮抬到它们上方；旧调用方保留历史兜底。
   const resolvedBottomPadding = bottomPadding ?? 200;
   const indicatorBottomOffset = resolveMessageStreamIndicatorBottomOffset({
     bottomPadding,
-    composerStackTopOffset,
+    bottomCenterClearanceOffset,
   });
 
   const latestInlinePlanRendered = Boolean(

--- a/apps/desktop/src/renderer/components/chat/__tests__/messageStreamIndicatorPosition.test.ts
+++ b/apps/desktop/src/renderer/components/chat/__tests__/messageStreamIndicatorPosition.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import {
-  measureComposerStackTopOffset,
+  getMessageStreamIndicatorResizeTargets,
+  measureMessageStreamIndicatorClearanceOffset,
   resolveMessageStreamIndicatorBottomOffset,
 } from '../messageStreamIndicatorPosition';
 
@@ -10,13 +11,13 @@ describe('resolveMessageStreamIndicatorBottomOffset', () => {
     expect(
       resolveMessageStreamIndicatorBottomOffset({
         bottomPadding: 174,
-        composerStackTopOffset: 142,
+        bottomCenterClearanceOffset: 142,
       }),
     ).toBe(148);
     expect(
       resolveMessageStreamIndicatorBottomOffset({
         bottomPadding: 206,
-        composerStackTopOffset: 142,
+        bottomCenterClearanceOffset: 142,
       }),
     ).toBe(148);
   });
@@ -26,19 +27,73 @@ describe('resolveMessageStreamIndicatorBottomOffset', () => {
     expect(resolveMessageStreamIndicatorBottomOffset({ bottomPadding: 40 })).toBe(12);
   });
 
-  it('measures from the outer composer stack so goal and plan indicators stay above the button', () => {
+  it('uses the composer stack when the center lane is empty', () => {
     const composerStack = {
       getBoundingClientRect: () => ({ top: 620 }),
     } as HTMLElement;
-    const querySelector = vi.fn((selector: string) =>
-      selector === '[data-chat-composer-stack]' ? composerStack : null,
-    );
+    const centerGroup = {
+      childElementCount: 0,
+      getBoundingClientRect: () => ({ top: 580, height: 0 }),
+    } as HTMLElement;
+    const querySelector = vi.fn((selector: string) => {
+      if (selector === '[data-chat-composer-stack]') return composerStack;
+      if (selector === '[data-composer-center-group]') return centerGroup;
+      return null;
+    });
     const overlay = {
       querySelector,
       getBoundingClientRect: () => ({ bottom: 800 }),
     } as unknown as HTMLElement;
 
-    expect(measureComposerStackTopOffset(overlay)).toBe(180);
+    expect(measureMessageStreamIndicatorClearanceOffset(overlay)).toBe(180);
     expect(querySelector).toHaveBeenCalledWith('[data-chat-composer-stack]');
+    expect(querySelector).toHaveBeenCalledWith('[data-composer-center-group]');
+  });
+
+  it('stacks the indicator above an occupied composer center group', () => {
+    const composerStack = {
+      getBoundingClientRect: () => ({ top: 620 }),
+    } as HTMLElement;
+    const centerGroup = {
+      childElementCount: 1,
+      getBoundingClientRect: () => ({ top: 580, height: 32 }),
+    } as HTMLElement;
+    const overlay = {
+      querySelector: (selector: string) =>
+        selector === '[data-chat-composer-stack]'
+          ? composerStack
+          : selector === '[data-composer-center-group]'
+            ? centerGroup
+            : null,
+      getBoundingClientRect: () => ({ bottom: 800 }),
+    } as unknown as HTMLElement;
+
+    const clearanceOffset = measureMessageStreamIndicatorClearanceOffset(overlay);
+    expect(clearanceOffset).toBe(220);
+    const indicatorBottomOffset = resolveMessageStreamIndicatorBottomOffset({
+      bottomPadding: 206,
+      bottomCenterClearanceOffset: clearanceOffset,
+    });
+    expect(indicatorBottomOffset).toBe(226);
+    expect(580 - (800 - indicatorBottomOffset)).toBe(6);
+  });
+
+  it('observes the inner center lane because it can resize without changing the overlay', () => {
+    const composerStack = {} as HTMLElement;
+    const centerGroup = {} as HTMLElement;
+    const overlay = {
+      querySelector: (selector: string) =>
+        selector === '[data-chat-composer-stack]'
+          ? composerStack
+          : selector === '[data-composer-center-group]'
+            ? centerGroup
+            : null,
+    } as unknown as HTMLElement;
+
+    expect(getMessageStreamIndicatorResizeTargets(overlay)).toEqual([
+      overlay,
+      composerStack,
+      centerGroup,
+    ]);
   });
 });

--- a/apps/desktop/src/renderer/components/chat/__tests__/messageStreamIndicatorPosition.test.ts
+++ b/apps/desktop/src/renderer/components/chat/__tests__/messageStreamIndicatorPosition.test.ts
@@ -78,22 +78,59 @@ describe('resolveMessageStreamIndicatorBottomOffset', () => {
     expect(580 - (800 - indicatorBottomOffset)).toBe(6);
   });
 
-  it('observes the inner center lane because it can resize without changing the overlay', () => {
-    const composerStack = {} as HTMLElement;
-    const centerGroup = {} as HTMLElement;
+  it('stacks the indicator above an expanded plan flyout', () => {
+    const composerStack = {
+      getBoundingClientRect: () => ({ top: 620 }),
+    } as HTMLElement;
+    const centerGroup = {
+      childElementCount: 1,
+      getBoundingClientRect: () => ({ top: 580, height: 32 }),
+    } as HTMLElement;
+    const planFlyout = {
+      getBoundingClientRect: () => ({ top: 300, height: 272 }),
+    } as HTMLElement;
     const overlay = {
       querySelector: (selector: string) =>
         selector === '[data-chat-composer-stack]'
           ? composerStack
           : selector === '[data-composer-center-group]'
             ? centerGroup
-            : null,
+            : selector === '[data-plan-flyout-positioner="composer"]'
+              ? planFlyout
+              : null,
+      getBoundingClientRect: () => ({ bottom: 800 }),
+    } as unknown as HTMLElement;
+
+    const clearanceOffset = measureMessageStreamIndicatorClearanceOffset(overlay);
+    expect(clearanceOffset).toBe(500);
+    const indicatorBottomOffset = resolveMessageStreamIndicatorBottomOffset({
+      bottomPadding: 206,
+      bottomCenterClearanceOffset: clearanceOffset,
+    });
+    expect(indicatorBottomOffset).toBe(506);
+    expect(300 - (800 - indicatorBottomOffset)).toBe(6);
+  });
+
+  it('observes the inner center lane because it can resize without changing the overlay', () => {
+    const composerStack = {} as HTMLElement;
+    const centerGroup = {} as HTMLElement;
+    const planFlyout = {} as HTMLElement;
+    const overlay = {
+      querySelector: (selector: string) =>
+        selector === '[data-chat-composer-stack]'
+          ? composerStack
+          : selector === '[data-composer-center-group]'
+            ? centerGroup
+            : selector === '[data-plan-flyout-positioner="composer"]'
+              ? planFlyout
+              : null,
     } as unknown as HTMLElement;
 
     expect(getMessageStreamIndicatorResizeTargets(overlay)).toEqual([
       overlay,
       composerStack,
       centerGroup,
+      planFlyout,
     ]);
   });
 });

--- a/apps/desktop/src/renderer/components/chat/messageStreamIndicatorPosition.ts
+++ b/apps/desktop/src/renderer/components/chat/messageStreamIndicatorPosition.ts
@@ -3,22 +3,56 @@ const LEGACY_STATUS_ROW_OFFSET_PX = 56;
 const MIN_BOTTOM_OFFSET_PX = 12;
 const COMPOSER_GAP_PX = 6;
 
+const COMPOSER_STACK_SELECTOR = '[data-chat-composer-stack]';
+const COMPOSER_CENTER_GROUP_SELECTOR = '[data-composer-center-group]';
+
 export function resolveMessageStreamIndicatorBottomOffset({
   bottomPadding,
-  composerStackTopOffset,
+  bottomCenterClearanceOffset,
 }: {
   bottomPadding?: number;
-  composerStackTopOffset?: number;
+  bottomCenterClearanceOffset?: number;
 }): number {
-  if (composerStackTopOffset != null) return composerStackTopOffset + COMPOSER_GAP_PX;
+  if (bottomCenterClearanceOffset != null) return bottomCenterClearanceOffset + COMPOSER_GAP_PX;
 
   const resolvedBottomPadding = bottomPadding ?? DEFAULT_BOTTOM_PADDING_PX;
   return Math.max(resolvedBottomPadding - LEGACY_STATUS_ROW_OFFSET_PX, MIN_BOTTOM_OFFSET_PX);
 }
 
-export function measureComposerStackTopOffset(overlayEl: HTMLElement): number | undefined {
-  const composerStack = overlayEl.querySelector<HTMLElement>('[data-chat-composer-stack]');
+/**
+ * Measure the topmost occupied layer in the composer's bottom-center lane.
+ *
+ * The running-status row deliberately does not move message navigation: its
+ * left/right text leaves the center lane free. Pinned plans and the expanded
+ * controlled banner do occupy that lane, so the jump/new-message pill must
+ * stack above them instead of sharing their 32px band.
+ */
+export function measureMessageStreamIndicatorClearanceOffset(
+  overlayEl: HTMLElement,
+): number | undefined {
+  const composerStack = overlayEl.querySelector<HTMLElement>(COMPOSER_STACK_SELECTOR);
   if (!composerStack) return undefined;
 
-  return overlayEl.getBoundingClientRect().bottom - composerStack.getBoundingClientRect().top;
+  let clearanceTop = composerStack.getBoundingClientRect().top;
+  const centerGroup = overlayEl.querySelector<HTMLElement>(COMPOSER_CENTER_GROUP_SELECTOR);
+  if (centerGroup && centerGroup.childElementCount > 0) {
+    const centerGroupRect = centerGroup.getBoundingClientRect();
+    if (centerGroupRect.height > 0) clearanceTop = Math.min(clearanceTop, centerGroupRect.top);
+  }
+
+  return overlayEl.getBoundingClientRect().bottom - clearanceTop;
+}
+
+/**
+ * The center group can gain or lose a plan while the outer overlay keeps the
+ * same height (the running-status row already owns that grid row). Observe the
+ * inner geometry as well so the clearance is refreshed in that case.
+ */
+export function getMessageStreamIndicatorResizeTargets(overlayEl: HTMLElement): HTMLElement[] {
+  const targets = [overlayEl];
+  const composerStack = overlayEl.querySelector<HTMLElement>(COMPOSER_STACK_SELECTOR);
+  const centerGroup = overlayEl.querySelector<HTMLElement>(COMPOSER_CENTER_GROUP_SELECTOR);
+  if (composerStack) targets.push(composerStack);
+  if (centerGroup) targets.push(centerGroup);
+  return targets;
 }

--- a/apps/desktop/src/renderer/components/chat/messageStreamIndicatorPosition.ts
+++ b/apps/desktop/src/renderer/components/chat/messageStreamIndicatorPosition.ts
@@ -5,6 +5,7 @@ const COMPOSER_GAP_PX = 6;
 
 const COMPOSER_STACK_SELECTOR = '[data-chat-composer-stack]';
 const COMPOSER_CENTER_GROUP_SELECTOR = '[data-composer-center-group]';
+const PLAN_FLYOUT_SELECTOR = '[data-plan-flyout-positioner="composer"]';
 
 export function resolveMessageStreamIndicatorBottomOffset({
   bottomPadding,
@@ -39,20 +40,27 @@ export function measureMessageStreamIndicatorClearanceOffset(
     const centerGroupRect = centerGroup.getBoundingClientRect();
     if (centerGroupRect.height > 0) clearanceTop = Math.min(clearanceTop, centerGroupRect.top);
   }
+  const planFlyout = overlayEl.querySelector<HTMLElement>(PLAN_FLYOUT_SELECTOR);
+  if (planFlyout) {
+    const planFlyoutRect = planFlyout.getBoundingClientRect();
+    if (planFlyoutRect.height > 0) clearanceTop = Math.min(clearanceTop, planFlyoutRect.top);
+  }
 
   return overlayEl.getBoundingClientRect().bottom - clearanceTop;
 }
 
 /**
  * The center group can gain or lose a plan while the outer overlay keeps the
- * same height (the running-status row already owns that grid row). Observe the
- * inner geometry as well so the clearance is refreshed in that case.
+ * same height (the running-status row already owns that grid row). The plan
+ * flyout is absolutely positioned, so observe it directly after it mounts.
  */
 export function getMessageStreamIndicatorResizeTargets(overlayEl: HTMLElement): HTMLElement[] {
   const targets = [overlayEl];
   const composerStack = overlayEl.querySelector<HTMLElement>(COMPOSER_STACK_SELECTOR);
   const centerGroup = overlayEl.querySelector<HTMLElement>(COMPOSER_CENTER_GROUP_SELECTOR);
+  const planFlyout = overlayEl.querySelector<HTMLElement>(PLAN_FLYOUT_SELECTOR);
   if (composerStack) targets.push(composerStack);
   if (centerGroup) targets.push(centerGroup);
+  if (planFlyout) targets.push(planFlyout);
   return targets;
 }

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
@@ -77,7 +77,10 @@ import {
   readSendFollowCancelGeneration,
   tryRequestFollowLatest,
 } from '@/components/chat/autoFollowIntent';
-import { measureComposerStackTopOffset } from '@/components/chat/messageStreamIndicatorPosition';
+import {
+  getMessageStreamIndicatorResizeTargets,
+  measureMessageStreamIndicatorClearanceOffset,
+} from '@/components/chat/messageStreamIndicatorPosition';
 import { ShareSelectionBar } from '@/components/chat/ShareSelectionBar';
 import {
   shareSelectionStore,
@@ -1274,9 +1277,9 @@ export function CCAgentSessionView({
     setOverlayEl(node);
   }, []);
   const [overlayHeight, setOverlayHeight] = useState(200);
-  const [composerStackTopOffset, setComposerStackTopOffset] = useState<number | undefined>(
-    undefined,
-  );
+  const [bottomCenterClearanceOffset, setBottomCenterClearanceOffset] = useState<
+    number | undefined
+  >(undefined);
   const [inlinePlanVisibilityState, setInlinePlanVisibilityState] = useState<{
     sessionId: string | undefined;
     value: InlinePlanVisibility | null;
@@ -1305,17 +1308,17 @@ export function CCAgentSessionView({
   useEffect(() => {
     if (!overlayEl) return;
     const measureOverlay = () => {
-      // 状态行会动态出现 / 收起，overlay 总高度不等于 composer 栈顶边。
-      // 直接量完整 composer 栈（含计划模式提示）到 overlay 底边的距离，
-      // 让消息流悬浮按钮不受状态行或输入框内部状态高度影响。
+      // 状态行会动态出现 / 收起，overlay 总高度不等于底部中央控件的避让边界。
+      // 空中央行仍以 composer 栈为锚；步骤 / 接管胶囊在场时改取中央组顶边，
+      // 让消息流悬浮按钮与它们纵向成栈，而不是共享同一块 32px 区域。
       setOverlayHeight(overlayEl.offsetHeight);
-      setComposerStackTopOffset(measureComposerStackTopOffset(overlayEl));
+      setBottomCenterClearanceOffset(measureMessageStreamIndicatorClearanceOffset(overlayEl));
     };
     // Seed with the current height so the first paint after remount uses the
     // real value (not the stale state from the previous mount).
     measureOverlay();
     const ro = new ResizeObserver(measureOverlay);
-    ro.observe(overlayEl);
+    for (const target of getMessageStreamIndicatorResizeTargets(overlayEl)) ro.observe(target);
     return () => ro.disconnect();
   }, [overlayEl]);
 
@@ -4055,7 +4058,7 @@ export function CCAgentSessionView({
       hasMoreMessages={hasMoreMessages}
       historyWindowHasIsland={historyWindowHasIsland}
       bottomPadding={overlayHeight}
-      composerStackTopOffset={composerStackTopOffset}
+      bottomCenterClearanceOffset={bottomCenterClearanceOffset}
       contentWidth={messageWidth}
       getContentWidth={getMessageWidth}
       focusMessageClientId={focusedMessageTarget?.clientId ?? null}

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
@@ -1314,12 +1314,31 @@ export function CCAgentSessionView({
       setOverlayHeight(overlayEl.offsetHeight);
       setBottomCenterClearanceOffset(measureMessageStreamIndicatorClearanceOffset(overlayEl));
     };
-    // Seed with the current height so the first paint after remount uses the
-    // real value (not the stale state from the previous mount).
-    measureOverlay();
     const ro = new ResizeObserver(measureOverlay);
-    for (const target of getMessageStreamIndicatorResizeTargets(overlayEl)) ro.observe(target);
-    return () => ro.disconnect();
+    let observedTargets = new Set<HTMLElement>();
+    const syncResizeTargetsAndMeasure = () => {
+      const nextTargets = new Set(getMessageStreamIndicatorResizeTargets(overlayEl));
+      for (const target of observedTargets) {
+        if (!nextTargets.has(target)) ro.unobserve(target);
+      }
+      for (const target of nextTargets) {
+        if (!observedTargets.has(target)) ro.observe(target);
+      }
+      observedTargets = nextTargets;
+      measureOverlay();
+    };
+
+    // Seed with the current geometry so the first paint after remount does not
+    // reuse stale state. The plan flyout is absolutely positioned and mounts
+    // only on hover/click, so its insertion does not resize the center group;
+    // resync observed targets whenever that subtree changes.
+    syncResizeTargetsAndMeasure();
+    const mutationObserver = new MutationObserver(syncResizeTargetsAndMeasure);
+    mutationObserver.observe(overlayEl, { childList: true, subtree: true });
+    return () => {
+      mutationObserver.disconnect();
+      ro.disconnect();
+    };
   }, [overlayEl]);
 
   // F-FP-5: 点击 workingDir → 在系统文件管理器里直接打开目录(复用 shell:open-path IPC)。


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复任务执行期间，composer 上方的步骤胶囊会与“跳到底部”或新消息提示重叠的问题。

原实现只按输入框栈顶计算底部导航位置，没有把动态出现的中央步骤/接管胶囊算进避让边界；同时中央行内容变化不一定改变外层 overlay 高度，原 ResizeObserver 也可能收不到更新。本次改为测量底部中央区域最上方的实际占用层，并同时观察中央胶囊行与输入框栈，使底部导航始终叠放在它们上方。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：用户反馈的 Desktop 底部步骤胶囊重叠问题
- 本 PR 包含：底部中央避让边界测量、动态尺寸监听、步骤胶囊共存回归测试
- 明确不包含：步骤胶囊、新消息提示或“跳到底部”本身的视觉重设计；Mobile 改动
- 用户可见变化：步骤胶囊出现时，“跳到底部”/新消息提示会上移，并与步骤胶囊保持 6px 间距
- 是否存在 breaking change：无

### UI 变化

- Desktop / Windows：修复底部中央两个 32px 胶囊的纵向堆叠；不改变颜色、字号、圆角或交互语义。
- Draft 阶段未上传截图；已在 Global 隔离 Dev 中完成本地目检和边界测量：导航胶囊底边 616px，步骤胶囊顶边 622px，间距 6px，无重叠。
- 引用的设计规范：
  - `docs/design-rules/DESIGN.md` §5 Spacing System：使用现有 6px 间距尺度。
  - `docs/design-rules/DESIGN.md` §8 Desktop Window：聊天流与 composer 随窗口布局动态重排，控件尺寸不缩减。
  - `docs/design-rules/DESIGN.md` §10 Light / Dark Dual-Mode Delivery Gate：本次仅调整几何定位，不增加颜色或单主题条件分支，继续复用现有语义 token；实际目检完成 Light，Dark 未单独目检。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/renderer/components/chat/__tests__/messageStreamIndicatorPosition.test.ts src/renderer/__tests__/controlledBannerPlacement.test.ts
结果：通过，2 个测试文件、11 个测试全部通过。

pnpm --filter desktop run --if-present typecheck
结果：通过。

pnpm test:unit:related
结果：通过，apps/desktop 关联单测通过。

pnpm --filter desktop exec eslint src/renderer/components/chat/MessageStream.tsx src/renderer/components/chat/messageStreamIndicatorPosition.ts src/renderer/components/chat/__tests__/messageStreamIndicatorPosition.test.ts src/renderer/features/cc-agent/CCAgentSessionView.tsx
结果：通过。

pnpm check:dco
结果：通过，1 个提交已签名。

pnpm --filter desktop run --if-present lint
结果：未通过；全量扫描命中未改文件中的 412 个 error / 5 个 warning，本 PR 的 4 个改动文件未出现在错误列表，且上述定向 lint 通过。
```

### 手工验证

- Windows，Global 隔离沙盒：`pnpm restart:desktop:remote --region=global -- --isolated=@worktree`，得到 `DESKTOP_DEV_VERDICT=ready`。
- 在登录页实际点击“跳过登录”，同意协议后进入 `#/cc-agent`，侧栏显示“未登录”。
- 创建 5 步测试计划并使第 4 步保持进行中；步骤胶囊真实由计划状态生成。为稳定复现共存状态，运行时夹具仅强制显示已有的“跳到底部”组件，定位偏移仍由生产代码计算。
- 实测“跳到底部”底边 616px、步骤胶囊顶边 622px，间距 6px，`overlap=false`；Light 模式截图已本地目检。

### 未执行的验证

- Dark 模式未单独实机目检；本次未改颜色和主题分支，几何逻辑不区分主题。
- 未等待 GitHub CI；Draft PR 创建后由 CI 执行完整门禁。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop Renderer 的消息流底部导航定位；只有中央步骤/接管胶囊占位时改变偏移。
- 回滚 / 降级方式：回退本提交即可恢复原有定位；不涉及数据、配置、协议或迁移。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在“UI 变化”注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要测试；本改动无需额外用户文档
- [x] 已确认测试结果或说明未执行原因