### PR TITLE
fix(desktop): 隔离 Windows 进程扫描失败

### DIFF
--- a/apps/desktop/forge.config.ts
+++ b/apps/desktop/forge.config.ts
@@ -1542,6 +1542,13 @@ const config: ForgeConfig = {
           target: 'preload',
         },
         {
+          entry: 'src/main/process-monitor/windowsProcessScanWorker.ts',
+          config: 'vite.process-scan-worker.config.ts',
+          // Windows PowerShell 的进程管道偶发 ENOTCONN；一次性 worker 隔离后
+          // 只降级资源用量快照，不能再变成 Electron main 的 uncaughtException。
+          target: 'preload',
+        },
+        {
           entry: 'src/main/mcp-integrations/forgeIconConversionProcess.ts',
           config: 'vite.forge-icon-conversion-process.config.ts',
           // Sharp/libvips 转换在一次性 utility process 中执行；超时可 kill，

--- a/apps/desktop/src/main/bootstrap-electron.ts
+++ b/apps/desktop/src/main/bootstrap-electron.ts
@@ -379,6 +379,7 @@ import {
 import { reapClaudeOrphansSync } from './claude-orphan-reaper';
 import { startAgentProcessPriorityWatcher } from './agent-process-priority';
 import { registerProcessMonitorIpc } from './process-monitor/ipc.js';
+import { disposeWindowsProcessScanWorkers } from './process-monitor/windowsProcessScanWorkerClient.js';
 import { initAppBadgeService, clearAllSessionAttention } from './appBadgeService';
 import { initNotificationService } from './notificationService';
 import { initWecomGroupNotificationIpc } from './wecomGroupNotification';
@@ -8113,6 +8114,7 @@ onQuit(
   'sync',
 );
 onQuit('auth-manager', () => authManager.dispose(), 'sync');
+onQuit('windows-process-scan-workers', disposeWindowsProcessScanWorkers, 'sync');
 onQuit('resource-usage-window', () => resourceUsageWindowController.dispose(), 'sync');
 onQuit('rsb-window', () => rsbWindowController.dispose(), 'sync');
 onQuit('ghost-panel-windows', () => ghostPanelWindowsController.dispose(), 'sync');

--- a/apps/desktop/src/main/process-monitor/__tests__/agent-scan.test.ts
+++ b/apps/desktop/src/main/process-monitor/__tests__/agent-scan.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { allUserDataDirNames } from '@cindy/maker-shared/brand-identity';
 
@@ -9,6 +9,7 @@ import {
   buildPosixProcessScanEnv,
   classifyMonitoredAgentCommandLine,
   collectDescendantPids,
+  createWindowsProcessScanner,
   parsePosixProcessTable,
   parseWindowsProcessTable,
   registerPiUserDataMarkers,
@@ -72,6 +73,28 @@ describe('parseWindowsProcessTable', () => {
 
   it('有输出但全不可解析时返回空(格式漂移由上层日志暴露)', () => {
     expect(parseWindowsProcessTable('ProcessId ParentProcessId\n123 456')).toEqual([]);
+  });
+});
+
+describe('createWindowsProcessScanner', () => {
+  it('失败后熔断 30s，期间返回空快照且不重复拉起 worker', async () => {
+    let nowMs = 1_000;
+    const runWorker = vi
+      .fn<() => Promise<string>>()
+      .mockRejectedValueOnce(Object.assign(new Error('read ENOTCONN'), { code: 'ENOTCONN' }))
+      .mockResolvedValue('4321|100|1024|0|638901092960000000|C:\\bin\\claude.exe');
+    const scan = createWindowsProcessScanner({ runWorker, now: () => nowMs });
+
+    await expect(scan()).rejects.toMatchObject({ code: 'ENOTCONN' });
+    expect(runWorker).toHaveBeenCalledOnce();
+
+    nowMs += 29_999;
+    await expect(scan()).resolves.toEqual({ rows: [], childrenByParent: new Map() });
+    expect(runWorker).toHaveBeenCalledOnce();
+
+    nowMs += 1;
+    await expect(scan()).resolves.toMatchObject({ rows: [expect.objectContaining({ pid: 4321 })] });
+    expect(runWorker).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/apps/desktop/src/main/process-monitor/__tests__/sampler.test.ts
+++ b/apps/desktop/src/main/process-monitor/__tests__/sampler.test.ts
@@ -286,4 +286,30 @@ describe('createProcessMonitorSampler', () => {
       expect.objectContaining({ error: 'ps blew up' }),
     );
   });
+
+  it('Windows 预热首帧不等待 OS 扫描，完成后由下一 tick 补齐 agent', async () => {
+    let resolveScan!: (snapshot: OsProcessSnapshot) => void;
+    const pendingScan = new Promise<OsProcessSnapshot>((resolve) => {
+      resolveScan = resolve;
+    });
+    const { sampler } = makeHarness({
+      metrics: [metric({ pid: 100, type: 'Browser' })],
+      deps: {
+        deferOsScan: true,
+        scanOsProcesses: () => pendingScan,
+      },
+    });
+
+    const first = await sampler.sample();
+    expect(first.entries).toHaveLength(1);
+    expect(entryByPid(first, 100)?.kind).toBe('main');
+
+    resolveScan(
+      snapshotOf([osRow({ pid: 501, ppid: SELF_PID, cmdLineLower: 'x claude-marker y' })]),
+    );
+    await pendingScan;
+    await Promise.resolve();
+
+    expect(entryByPid(await sampler.sample(), 501)?.kind).toBe('agent-claude');
+  });
 });

--- a/apps/desktop/src/main/process-monitor/__tests__/windowsProcessScanWorkerClient.test.ts
+++ b/apps/desktop/src/main/process-monitor/__tests__/windowsProcessScanWorkerClient.test.ts
@@ -1,0 +1,47 @@
+import { EventEmitter } from 'node:events';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  runWindowsProcessScanWorker,
+  type WindowsProcessScanWorkerHandle,
+} from '../windowsProcessScanWorkerClient.js';
+
+class FakeWorker extends EventEmitter implements WindowsProcessScanWorkerHandle {
+  terminate = vi.fn(async () => 0);
+}
+
+describe('runWindowsProcessScanWorker', () => {
+  it('返回 worker 的 PowerShell 输出并回收一次性线程', async () => {
+    const worker = new FakeWorker();
+    const result = runWindowsProcessScanWorker({ createWorker: () => worker });
+
+    worker.emit('message', { ok: true, stdout: '1|0|1024|0||cindy.exe' });
+
+    await expect(result).resolves.toBe('1|0|1024|0||cindy.exe');
+    expect(worker.terminate).toHaveBeenCalledOnce();
+  });
+
+  it('worker 内 child_process 的 ENOTCONN 只拒绝本次扫描', async () => {
+    const worker = new FakeWorker();
+    const result = runWindowsProcessScanWorker({ createWorker: () => worker });
+    const error = Object.assign(new Error('read ENOTCONN'), {
+      code: 'ENOTCONN',
+      syscall: 'read',
+    });
+
+    worker.emit('error', error);
+
+    await expect(result).rejects.toMatchObject({ code: 'ENOTCONN', syscall: 'read' });
+    expect(worker.terminate).toHaveBeenCalledOnce();
+  });
+
+  it('worker 未返回消息就退出时失败并回收', async () => {
+    const worker = new FakeWorker();
+    const result = runWindowsProcessScanWorker({ createWorker: () => worker });
+
+    worker.emit('exit', 1);
+
+    await expect(result).rejects.toThrow('exited before response (1)');
+    expect(worker.terminate).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/desktop/src/main/process-monitor/__tests__/windowsProcessScanWorkerClient.test.ts
+++ b/apps/desktop/src/main/process-monitor/__tests__/windowsProcessScanWorkerClient.test.ts
@@ -1,41 +1,99 @@
+import { execFileSync, spawn, type ChildProcess } from 'node:child_process';
 import { EventEmitter } from 'node:events';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  disposeWindowsProcessScanWorkers,
   runWindowsProcessScanWorker,
   type WindowsProcessScanWorkerHandle,
 } from '../windowsProcessScanWorkerClient.js';
 
 class FakeWorker extends EventEmitter implements WindowsProcessScanWorkerHandle {
+  postMessage = vi.fn();
+  unref = vi.fn();
   terminate = vi.fn(async () => 0);
 }
 
-describe('runWindowsProcessScanWorker', () => {
-  it('返回 worker 的 PowerShell 输出并回收一次性线程', async () => {
-    const worker = new FakeWorker();
-    const result = runWindowsProcessScanWorker({ createWorker: () => worker });
+afterEach(() => {
+  disposeWindowsProcessScanWorkers();
+});
 
-    worker.emit('message', { ok: true, stdout: '1|0|1024|0||cindy.exe' });
+describe('runWindowsProcessScanWorker', () => {
+  it('returns PowerShell output and releases the one-shot worker', async () => {
+    const worker = new FakeWorker();
+    const terminateProcessTree = vi.fn();
+    const result = runWindowsProcessScanWorker({
+      createWorker: () => worker,
+      terminateProcessTree,
+    });
+
+    worker.emit('message', { type: 'started', pid: 1234 });
+    worker.emit('message', {
+      type: 'result',
+      response: { ok: true, stdout: '1|0|1024|0||cindy.exe' },
+    });
 
     await expect(result).resolves.toBe('1|0|1024|0||cindy.exe');
+    expect(terminateProcessTree).not.toHaveBeenCalled();
+    expect(worker.unref).toHaveBeenCalledOnce();
     expect(worker.terminate).toHaveBeenCalledOnce();
   });
 
-  it('worker 内 child_process 的 ENOTCONN 只拒绝本次扫描', async () => {
+  it('kills the announced PowerShell process when the worker emits ENOTCONN', async () => {
     const worker = new FakeWorker();
-    const result = runWindowsProcessScanWorker({ createWorker: () => worker });
+    const terminateProcessTree = vi.fn();
+    const result = runWindowsProcessScanWorker({
+      createWorker: () => worker,
+      terminateProcessTree,
+    });
     const error = Object.assign(new Error('read ENOTCONN'), {
       code: 'ENOTCONN',
       syscall: 'read',
     });
 
+    worker.emit('message', { type: 'started', pid: 4321 });
     worker.emit('error', error);
 
     await expect(result).rejects.toMatchObject({ code: 'ENOTCONN', syscall: 'read' });
+    expect(worker.postMessage).toHaveBeenCalledWith({ type: 'cancel' });
+    expect(terminateProcessTree).toHaveBeenCalledWith(4321);
     expect(worker.terminate).toHaveBeenCalledOnce();
   });
 
-  it('worker 未返回消息就退出时失败并回收', async () => {
+  it('kills the announced PowerShell process when the worker times out', async () => {
+    const worker = new FakeWorker();
+    const terminateProcessTree = vi.fn();
+    const result = runWindowsProcessScanWorker({
+      createWorker: () => worker,
+      timeoutMs: 5,
+      terminateProcessTree,
+    });
+
+    worker.emit('message', { type: 'started', pid: 5678 });
+
+    await expect(result).rejects.toMatchObject({ code: 'ETIMEDOUT' });
+    expect(terminateProcessTree).toHaveBeenCalledWith(5678);
+    expect(worker.terminate).toHaveBeenCalledOnce();
+  });
+
+  it('kills active PowerShell processes during application disposal', async () => {
+    const worker = new FakeWorker();
+    const terminateProcessTree = vi.fn();
+    const result = runWindowsProcessScanWorker({
+      createWorker: () => worker,
+      terminateProcessTree,
+    });
+
+    worker.emit('message', { type: 'started', pid: 6789 });
+    disposeWindowsProcessScanWorkers();
+
+    expect(terminateProcessTree).toHaveBeenCalledWith(6789);
+    expect(worker.terminate).toHaveBeenCalledOnce();
+    worker.emit('exit', 1);
+    await expect(result).rejects.toThrow('exited before response (1)');
+  });
+
+  it('fails and releases the worker when it exits before responding', async () => {
     const worker = new FakeWorker();
     const result = runWindowsProcessScanWorker({ createWorker: () => worker });
 
@@ -44,4 +102,108 @@ describe('runWindowsProcessScanWorker', () => {
     await expect(result).rejects.toThrow('exited before response (1)');
     expect(worker.terminate).toHaveBeenCalledOnce();
   });
+
+  it.runIf(process.platform === 'win32')(
+    'does not leave PowerShell alive after a worker crash',
+    async () => {
+      const child = spawnSleepingPowerShell();
+      const pid = requirePid(child);
+      try {
+        const worker = new FakeWorker();
+        const result = runWindowsProcessScanWorker({ createWorker: () => worker });
+
+        worker.emit('message', { type: 'started', pid });
+        expect(isProcessAlive(pid)).toBe(true);
+        worker.emit('error', Object.assign(new Error('read ENOTCONN'), { code: 'ENOTCONN' }));
+
+        await expect(result).rejects.toMatchObject({ code: 'ENOTCONN' });
+        expect(isProcessAlive(pid)).toBe(false);
+      } finally {
+        forceKillProcessTree(pid);
+      }
+    },
+  );
+
+  it.runIf(process.platform === 'win32')(
+    'does not leave PowerShell alive after the outer timeout',
+    async () => {
+      const child = spawnSleepingPowerShell();
+      const pid = requirePid(child);
+      try {
+        const worker = new FakeWorker();
+        const result = runWindowsProcessScanWorker({
+          createWorker: () => worker,
+          timeoutMs: 10,
+        });
+
+        worker.emit('message', { type: 'started', pid });
+        expect(isProcessAlive(pid)).toBe(true);
+
+        await expect(result).rejects.toMatchObject({ code: 'ETIMEDOUT' });
+        expect(isProcessAlive(pid)).toBe(false);
+      } finally {
+        forceKillProcessTree(pid);
+      }
+    },
+  );
+
+  it.runIf(process.platform === 'win32')(
+    'does not leave PowerShell alive during application disposal',
+    async () => {
+      const child = spawnSleepingPowerShell();
+      const pid = requirePid(child);
+      try {
+        const worker = new FakeWorker();
+        const result = runWindowsProcessScanWorker({ createWorker: () => worker });
+
+        worker.emit('message', { type: 'started', pid });
+        expect(isProcessAlive(pid)).toBe(true);
+        disposeWindowsProcessScanWorkers();
+
+        expect(isProcessAlive(pid)).toBe(false);
+        worker.emit('exit', 1);
+        await expect(result).rejects.toThrow('exited before response (1)');
+      } finally {
+        forceKillProcessTree(pid);
+      }
+    },
+  );
 });
+
+function spawnSleepingPowerShell(): ChildProcess {
+  return spawn(
+    'powershell.exe',
+    ['-NoProfile', '-NonInteractive', '-Command', 'Start-Sleep -Seconds 30'],
+    {
+      windowsHide: true,
+      stdio: 'ignore',
+    },
+  );
+}
+
+function requirePid(child: ChildProcess): number {
+  if (typeof child.pid !== 'number') throw new Error('PowerShell did not expose a PID');
+  return child.pid;
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code !== 'ESRCH';
+  }
+}
+
+function forceKillProcessTree(pid: number): void {
+  if (!isProcessAlive(pid)) return;
+  try {
+    execFileSync('taskkill', ['/T', '/F', '/PID', String(pid)], {
+      timeout: 2_000,
+      windowsHide: true,
+      stdio: 'ignore',
+    });
+  } catch {
+    // The assertion reports cleanup failure; this is only a best-effort test teardown.
+  }
+}

--- a/apps/desktop/src/main/process-monitor/agent-scan.ts
+++ b/apps/desktop/src/main/process-monitor/agent-scan.ts
@@ -22,6 +22,8 @@ import { allUserDataDirNames } from '@cindy/maker-shared/brand-identity';
 
 import { CURRENT_CINDY_REGION } from '../../shared/brandRegion.js';
 import { classifyAgentCommandLine } from '../agent-process-priority.js';
+import { WINDOWS_PROCESS_SCAN_SCRIPT } from './windowsProcessScanProtocol.js';
+import { runWindowsProcessScanWorker } from './windowsProcessScanWorkerClient.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -114,15 +116,6 @@ const POSIX_PS_ROW_RE =
   /^(\d+)\s+(\d+)\s+(\S+)\s+([\d.]+)\s+(\d+)\s+(\S+\s+\S+\s+\d{1,2}\s+\d{2}:\d{2}:\d{2}\s+\d{4})\s+(.+)$/;
 
 const POSIX_PS_ARGS = ['-Aww', '-o', 'pid=,ppid=,stat=,%cpu=,rss=,lstart=,command='];
-
-const WINDOWS_PROCESS_SCAN_SCRIPT = [
-  'Get-CimInstance Win32_Process |',
-  'ForEach-Object {',
-  '  $cmd = ([string]$_.CommandLine) -replace "`r|`n", " "',
-  '  $created = if ($null -eq $_.CreationDate) { "" } else { $_.CreationDate.ToUniversalTime().Ticks }',
-  '  Write-Output ("{0}|{1}|{2}|{3}|{4}|{5}" -f $_.ProcessId, $_.ParentProcessId, $_.WorkingSetSize, ($_.UserModeTime + $_.KernelModeTime), $created, $cmd)',
-  '}',
-].join('\n');
 
 /** lstart 不携带时区；固定 UTC，避免 DST 回拨时一小时内出现重复出生字符串。 */
 export function buildPosixProcessScanEnv(baseEnv: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
@@ -228,18 +221,38 @@ async function scanPosix(): Promise<OsProcessSnapshot> {
   return { rows, childrenByParent: buildChildrenByParent(rows) };
 }
 
-async function scanWindows(): Promise<OsProcessSnapshot> {
-  // 全表(无 Name filter):agent 树里的 bash/node 子孙也要计入聚合。
-  // 行尾管道符不可省 —— 否则两条语句独立执行、parse 恒 0 行
-  // (claude-orphan-reaper 2026-07-14 实锤的坑)。
-  const { stdout } = await execFileAsync(
-    'powershell.exe',
-    ['-NoProfile', '-NonInteractive', '-Command', WINDOWS_PROCESS_SCAN_SCRIPT],
-    { encoding: 'utf8', timeout: 10_000, windowsHide: true, maxBuffer: 8 * 1024 * 1024 },
-  );
-  const rows = parseWindowsProcessTable(stdout);
-  return { rows, childrenByParent: buildChildrenByParent(rows) };
+export const WINDOWS_PROCESS_SCAN_FAILURE_BACKOFF_MS = 30_000;
+
+interface WindowsProcessScannerOptions {
+  runWorker(): Promise<string>;
+  now?: () => number;
+  failureBackoffMs?: number;
 }
+
+export function createWindowsProcessScanner(
+  options: WindowsProcessScannerOptions,
+): () => Promise<OsProcessSnapshot> {
+  const now = options.now ?? Date.now;
+  const failureBackoffMs = options.failureBackoffMs ?? WINDOWS_PROCESS_SCAN_FAILURE_BACKOFF_MS;
+  let retryAfterMs = Number.NEGATIVE_INFINITY;
+
+  return async () => {
+    if (now() < retryAfterMs) return { rows: [], childrenByParent: new Map() };
+    try {
+      // 全表(无 Name filter):agent 树里的 bash/node 子孙也要计入聚合。PowerShell
+      // 管道放进一次性 worker，ENOTCONN / 崩溃 / 超时只让本轮快照降级。
+      const stdout = await options.runWorker();
+      retryAfterMs = Number.NEGATIVE_INFINITY;
+      const rows = parseWindowsProcessTable(stdout);
+      return { rows, childrenByParent: buildChildrenByParent(rows) };
+    } catch (error) {
+      retryAfterMs = now() + failureBackoffMs;
+      throw error;
+    }
+  };
+}
+
+const scanWindows = createWindowsProcessScanner({ runWorker: runWindowsProcessScanWorker });
 
 /** 生产扫描入口(sampler / terminate 校验共用)。 */
 export function scanOsProcesses(): Promise<OsProcessSnapshot> {

--- a/apps/desktop/src/main/process-monitor/ipc.ts
+++ b/apps/desktop/src/main/process-monitor/ipc.ts
@@ -126,6 +126,9 @@ export function registerProcessMonitorIpc(opts: ProcessMonitorIpcOptions = {}): 
       resolveAgentProcessRegistration: resolveAgentRegistration,
       selfPid,
       log,
+      // Windows 冷启 PowerShell 可达秒级；隐藏窗口预热首帧只等 app.getAppMetrics，
+      // Worker 扫描完成后由下一次 2s tick 补齐 agent 树。
+      deferOsScan: platform === 'win32',
     });
 
   const subscribers = new Set<WebContents>();

--- a/apps/desktop/src/main/process-monitor/sampler.ts
+++ b/apps/desktop/src/main/process-monitor/sampler.ts
@@ -56,6 +56,8 @@ export interface ProcessMonitorSamplerDeps {
   log: SamplerLogger;
   /** OS 扫描的最小间隔;快 tick 之间复用缓存。 */
   osScanIntervalMs?: number;
+  /** Windows 首帧先返回 Chromium 指标，OS 扫描在后台刷新后由下一 tick 合并。 */
+  deferOsScan?: boolean;
   /** 注入时钟(测试用;生产缺省 Date.now)。 */
   now?: () => number;
 }
@@ -240,7 +242,9 @@ export function createProcessMonitorSampler(
 
   return {
     async sample(): Promise<ProcessMonitorSample> {
-      await refreshSnapshotIfStale();
+      const refresh = refreshSnapshotIfStale();
+      if (deps.deferOsScan) void refresh;
+      else await refresh;
       const atMs = now();
       const agentEntries = collectAgentEntries();
       const agentPids = new Set<number>();

--- a/apps/desktop/src/main/process-monitor/windowsProcessScanProtocol.ts
+++ b/apps/desktop/src/main/process-monitor/windowsProcessScanProtocol.ts
@@ -18,6 +18,9 @@ export type WindowsProcessScanWorkerResponse =
       };
     };
 
+export type WindowsProcessScanWorkerMessage =
+  { type: 'started'; pid: number } | { type: 'result'; response: WindowsProcessScanWorkerResponse };
+
 export function isWindowsProcessScanWorkerResponse(
   value: unknown,
 ): value is WindowsProcessScanWorkerResponse {
@@ -34,4 +37,15 @@ export function isWindowsProcessScanWorkerResponse(
     (response.error.code === undefined || typeof response.error.code === 'string') &&
     (response.error.syscall === undefined || typeof response.error.syscall === 'string')
   );
+}
+
+export function isWindowsProcessScanWorkerMessage(
+  value: unknown,
+): value is WindowsProcessScanWorkerMessage {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const message = value as { type?: unknown; pid?: unknown; response?: unknown };
+  if (message.type === 'started') {
+    return Number.isSafeInteger(message.pid) && Number(message.pid) > 0;
+  }
+  return message.type === 'result' && isWindowsProcessScanWorkerResponse(message.response);
 }

--- a/apps/desktop/src/main/process-monitor/windowsProcessScanProtocol.ts
+++ b/apps/desktop/src/main/process-monitor/windowsProcessScanProtocol.ts
@@ -1,0 +1,37 @@
+export const WINDOWS_PROCESS_SCAN_SCRIPT = [
+  'Get-CimInstance Win32_Process |',
+  'ForEach-Object {',
+  '  $cmd = ([string]$_.CommandLine) -replace "`r|`n", " "',
+  '  $created = if ($null -eq $_.CreationDate) { "" } else { $_.CreationDate.ToUniversalTime().Ticks }',
+  '  Write-Output ("{0}|{1}|{2}|{3}|{4}|{5}" -f $_.ProcessId, $_.ParentProcessId, $_.WorkingSetSize, ($_.UserModeTime + $_.KernelModeTime), $created, $cmd)',
+  '}',
+].join('\n');
+
+export type WindowsProcessScanWorkerResponse =
+  | { ok: true; stdout: string }
+  | {
+      ok: false;
+      error: {
+        message: string;
+        code?: string;
+        syscall?: string;
+      };
+    };
+
+export function isWindowsProcessScanWorkerResponse(
+  value: unknown,
+): value is WindowsProcessScanWorkerResponse {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const response = value as {
+    ok?: unknown;
+    stdout?: unknown;
+    error?: { message?: unknown; code?: unknown; syscall?: unknown };
+  };
+  if (response.ok === true) return typeof response.stdout === 'string';
+  if (response.ok !== false || !response.error || typeof response.error !== 'object') return false;
+  return (
+    typeof response.error.message === 'string' &&
+    (response.error.code === undefined || typeof response.error.code === 'string') &&
+    (response.error.syscall === undefined || typeof response.error.syscall === 'string')
+  );
+}

--- a/apps/desktop/src/main/process-monitor/windowsProcessScanWorker.ts
+++ b/apps/desktop/src/main/process-monitor/windowsProcessScanWorker.ts
@@ -1,44 +1,144 @@
-import { execFile } from 'node:child_process';
+import { spawn, type ChildProcess } from 'node:child_process';
 // eslint-disable-next-line no-restricted-imports -- child-process pipe failures are isolated from Electron Main.
 import { parentPort } from 'node:worker_threads';
-import { promisify } from 'node:util';
 
 import {
   WINDOWS_PROCESS_SCAN_SCRIPT,
+  type WindowsProcessScanWorkerMessage,
   type WindowsProcessScanWorkerResponse,
 } from './windowsProcessScanProtocol.js';
 
-const execFileAsync = promisify(execFile);
+const CHILD_TIMEOUT_MS = 10_000;
+const MAX_STDOUT_BYTES = 8 * 1024 * 1024;
+const MAX_STDERR_BYTES = 64 * 1024;
+
+if (!parentPort) throw new Error('Windows process scan must run in a worker thread');
 const workerPort = parentPort;
 
-if (!workerPort) throw new Error('Windows process scan must run in a worker thread');
+runWindowsProcessTable();
 
-void scanWindowsProcessTable().then(
-  (stdout) =>
-    workerPort.postMessage({ ok: true, stdout } satisfies WindowsProcessScanWorkerResponse),
-  (error: unknown) => {
-    const errno = error as NodeJS.ErrnoException;
-    workerPort.postMessage({
-      ok: false,
-      error: {
-        message: error instanceof Error ? error.message : String(error),
-        ...(typeof errno?.code === 'string' ? { code: errno.code } : {}),
-        ...(typeof errno?.syscall === 'string' ? { syscall: errno.syscall } : {}),
+function runWindowsProcessTable(): void {
+  let child: ChildProcess;
+  try {
+    child = spawn(
+      'powershell.exe',
+      ['-NoProfile', '-NonInteractive', '-Command', WINDOWS_PROCESS_SCAN_SCRIPT],
+      {
+        windowsHide: true,
+        stdio: ['ignore', 'pipe', 'pipe'],
       },
-    } satisfies WindowsProcessScanWorkerResponse);
-  },
-);
+    );
+  } catch (error) {
+    workerPort.postMessage({
+      type: 'result',
+      response: workerFailure(error),
+    } satisfies WindowsProcessScanWorkerMessage);
+    workerPort.close();
+    return;
+  }
 
-async function scanWindowsProcessTable(): Promise<string> {
-  const { stdout } = await execFileAsync(
-    'powershell.exe',
-    ['-NoProfile', '-NonInteractive', '-Command', WINDOWS_PROCESS_SCAN_SCRIPT],
-    {
-      encoding: 'utf8',
-      timeout: 10_000,
-      windowsHide: true,
-      maxBuffer: 8 * 1024 * 1024,
+  let stdout = '';
+  let stdoutBytes = 0;
+  let stderr = '';
+  let stderrBytes = 0;
+  let pendingFailure: NodeJS.ErrnoException | null = null;
+  let finished = false;
+  const timeout = setTimeout(() => {
+    failChild(workerError('Windows process scan PowerShell timed out', 'ETIMEDOUT'));
+  }, CHILD_TIMEOUT_MS);
+  timeout.unref?.();
+
+  child.unref();
+  child.stdout?.setEncoding('utf8');
+  child.stderr?.setEncoding('utf8');
+
+  const pid = child.pid;
+  if (typeof pid === 'number' && pid > 0) {
+    workerPort.postMessage({ type: 'started', pid } satisfies WindowsProcessScanWorkerMessage);
+  }
+
+  child.once('error', failChild);
+  child.stdout?.on('error', failChild);
+  child.stderr?.on('error', failChild);
+  child.stdout?.on('data', (chunk: string) => {
+    if (pendingFailure) return;
+    stdoutBytes += Buffer.byteLength(chunk);
+    if (stdoutBytes > MAX_STDOUT_BYTES) {
+      failChild(workerError('Windows process scan stdout exceeded maxBuffer', 'ENOBUFS'));
+      return;
+    }
+    stdout += chunk;
+  });
+  child.stderr?.on('data', (chunk: string) => {
+    if (stderrBytes >= MAX_STDERR_BYTES) return;
+    const remaining = MAX_STDERR_BYTES - stderrBytes;
+    const slice = Buffer.from(chunk).subarray(0, remaining).toString('utf8');
+    stderr += slice;
+    stderrBytes += Buffer.byteLength(slice);
+  });
+  child.once('close', (code, signal) => {
+    if (finished) return;
+    clearTimeout(timeout);
+    if (pendingFailure) {
+      postResult(workerFailure(pendingFailure));
+      return;
+    }
+    if (code === 0) {
+      postResult({ ok: true, stdout });
+      return;
+    }
+    postResult(
+      workerFailure(
+        workerError(
+          stderr.trim() ||
+            `Windows process scan PowerShell exited (${code ?? signal ?? 'unknown'})`,
+          'ECHILD',
+        ),
+      ),
+    );
+  });
+  workerPort.once('message', (value: unknown) => {
+    if ((value as { type?: unknown } | null)?.type === 'cancel') {
+      failChild(workerError('Windows process scan cancelled', 'ECANCELED'));
+    }
+  });
+
+  function failChild(error: unknown): void {
+    if (finished || pendingFailure) return;
+    pendingFailure = normalizeError(error);
+    try {
+      child.kill('SIGKILL');
+    } catch {
+      // Parent owns the announced PID and performs a taskkill fallback.
+    }
+  }
+
+  function postResult(response: WindowsProcessScanWorkerResponse): void {
+    if (finished) return;
+    finished = true;
+    clearTimeout(timeout);
+    workerPort.removeAllListeners('message');
+    workerPort.postMessage({ type: 'result', response } satisfies WindowsProcessScanWorkerMessage);
+    workerPort.close();
+  }
+}
+
+function workerFailure(error: unknown): WindowsProcessScanWorkerResponse {
+  const errno = normalizeError(error);
+  return {
+    ok: false,
+    error: {
+      message: errno.message,
+      ...(typeof errno.code === 'string' ? { code: errno.code } : {}),
+      ...(typeof errno.syscall === 'string' ? { syscall: errno.syscall } : {}),
     },
-  );
-  return stdout;
+  };
+}
+
+function normalizeError(error: unknown): NodeJS.ErrnoException {
+  return error instanceof Error ? error : new Error(String(error));
+}
+
+function workerError(message: string, code: string): NodeJS.ErrnoException {
+  return Object.assign(new Error(message), { code });
 }

--- a/apps/desktop/src/main/process-monitor/windowsProcessScanWorker.ts
+++ b/apps/desktop/src/main/process-monitor/windowsProcessScanWorker.ts
@@ -1,0 +1,44 @@
+import { execFile } from 'node:child_process';
+// eslint-disable-next-line no-restricted-imports -- child-process pipe failures are isolated from Electron Main.
+import { parentPort } from 'node:worker_threads';
+import { promisify } from 'node:util';
+
+import {
+  WINDOWS_PROCESS_SCAN_SCRIPT,
+  type WindowsProcessScanWorkerResponse,
+} from './windowsProcessScanProtocol.js';
+
+const execFileAsync = promisify(execFile);
+const workerPort = parentPort;
+
+if (!workerPort) throw new Error('Windows process scan must run in a worker thread');
+
+void scanWindowsProcessTable().then(
+  (stdout) =>
+    workerPort.postMessage({ ok: true, stdout } satisfies WindowsProcessScanWorkerResponse),
+  (error: unknown) => {
+    const errno = error as NodeJS.ErrnoException;
+    workerPort.postMessage({
+      ok: false,
+      error: {
+        message: error instanceof Error ? error.message : String(error),
+        ...(typeof errno?.code === 'string' ? { code: errno.code } : {}),
+        ...(typeof errno?.syscall === 'string' ? { syscall: errno.syscall } : {}),
+      },
+    } satisfies WindowsProcessScanWorkerResponse);
+  },
+);
+
+async function scanWindowsProcessTable(): Promise<string> {
+  const { stdout } = await execFileAsync(
+    'powershell.exe',
+    ['-NoProfile', '-NonInteractive', '-Command', WINDOWS_PROCESS_SCAN_SCRIPT],
+    {
+      encoding: 'utf8',
+      timeout: 10_000,
+      windowsHide: true,
+      maxBuffer: 8 * 1024 * 1024,
+    },
+  );
+  return stdout;
+}

--- a/apps/desktop/src/main/process-monitor/windowsProcessScanWorkerClient.ts
+++ b/apps/desktop/src/main/process-monitor/windowsProcessScanWorkerClient.ts
@@ -1,36 +1,69 @@
+import { execFileSync } from 'node:child_process';
 import path from 'node:path';
 // eslint-disable-next-line no-restricted-imports -- Windows child-process pipes must be isolated from Electron Main.
 import { Worker } from 'node:worker_threads';
 
-import { isWindowsProcessScanWorkerResponse } from './windowsProcessScanProtocol.js';
+import { isWindowsProcessScanWorkerMessage } from './windowsProcessScanProtocol.js';
 
 export const WINDOWS_PROCESS_SCAN_WORKER_TIMEOUT_MS = 12_000;
 
 export interface WindowsProcessScanWorkerHandle {
-  once(event: 'message', listener: (value: unknown) => void): this;
+  on(event: 'message', listener: (value: unknown) => void): this;
   once(event: 'error', listener: (error: Error) => void): this;
   once(event: 'exit', listener: (code: number) => void): this;
+  postMessage(value: unknown): void;
+  unref(): void;
   terminate(): Promise<number>;
 }
 
 interface WindowsProcessScanWorkerOptions {
   createWorker?: () => WindowsProcessScanWorkerHandle;
   timeoutMs?: number;
+  terminateProcessTree?: (pid: number) => void;
 }
+
+interface ActiveWindowsProcessScan {
+  worker: WindowsProcessScanWorkerHandle;
+  childPid: number | null;
+  childClosed: boolean;
+  cleaning: boolean;
+  cleanupPromise: Promise<void> | null;
+  terminateProcessTree: (pid: number) => void;
+}
+
+const activeWindowsProcessScans = new Set<ActiveWindowsProcessScan>();
 
 export async function runWindowsProcessScanWorker(
   options: WindowsProcessScanWorkerOptions = {},
 ): Promise<string> {
   const worker =
     options.createWorker?.() ?? new Worker(path.join(__dirname, 'windowsProcessScanWorker.js'));
+  const scan: ActiveWindowsProcessScan = {
+    worker,
+    childPid: null,
+    childClosed: false,
+    cleaning: false,
+    cleanupPromise: null,
+    terminateProcessTree: options.terminateProcessTree ?? terminateWindowsProcessTree,
+  };
+  worker.unref();
+  activeWindowsProcessScans.add(scan);
   try {
-    return await waitForWorker(worker, options.timeoutMs ?? WINDOWS_PROCESS_SCAN_WORKER_TIMEOUT_MS);
+    return await waitForWorker(scan, options.timeoutMs ?? WINDOWS_PROCESS_SCAN_WORKER_TIMEOUT_MS);
   } finally {
-    await worker.terminate().catch(() => void 0);
+    await cleanupWindowsProcessScan(scan);
+    activeWindowsProcessScans.delete(scan);
   }
 }
 
-function waitForWorker(worker: WindowsProcessScanWorkerHandle, timeoutMs: number): Promise<string> {
+export function disposeWindowsProcessScanWorkers(): void {
+  for (const scan of activeWindowsProcessScans) {
+    void cleanupWindowsProcessScan(scan);
+  }
+}
+
+function waitForWorker(scan: ActiveWindowsProcessScan, timeoutMs: number): Promise<string> {
+  const { worker } = scan;
   return new Promise((resolve, reject) => {
     let settled = false;
     const finish = (operation: () => void): void => {
@@ -45,16 +78,34 @@ function waitForWorker(worker: WindowsProcessScanWorkerHandle, timeoutMs: number
     );
     timer.unref?.();
 
-    worker.once('message', (value) => {
-      if (!isWindowsProcessScanWorkerResponse(value)) {
+    worker.on('message', (value) => {
+      if (!isWindowsProcessScanWorkerMessage(value)) {
         finish(() => reject(new Error('invalid Windows process scan worker response')));
         return;
       }
-      if (value.ok) {
-        finish(() => resolve(value.stdout));
+      if (value.type === 'started') {
+        if (scan.childPid !== null && scan.childPid !== value.pid) {
+          finish(() => reject(new Error('Windows process scan worker reported multiple PIDs')));
+          return;
+        }
+        if (scan.cleaning) {
+          terminatePowerShell(scan, value.pid);
+          return;
+        }
+        scan.childPid = value.pid;
         return;
       }
-      finish(() => reject(workerError(value.error.message, value.error.code, value.error.syscall)));
+
+      scan.childClosed = true;
+      scan.childPid = null;
+      const { response } = value;
+      if (response.ok) {
+        const { stdout } = response;
+        finish(() => resolve(stdout));
+        return;
+      }
+      const { error } = response;
+      finish(() => reject(workerError(error.message, error.code, error.syscall)));
     });
     worker.once('error', (error) => finish(() => reject(error)));
     worker.once('exit', (code) =>
@@ -63,6 +114,62 @@ function waitForWorker(worker: WindowsProcessScanWorkerHandle, timeoutMs: number
       ),
     );
   });
+}
+
+function cleanupWindowsProcessScan(scan: ActiveWindowsProcessScan): Promise<void> {
+  if (scan.cleanupPromise) return scan.cleanupPromise;
+
+  scan.cleaning = true;
+  if (!scan.childClosed) {
+    try {
+      scan.worker.postMessage({ type: 'cancel' });
+    } catch {
+      // A crashed worker can no longer receive cancellation; the PID fallback remains available.
+    }
+  }
+  terminateTrackedPowerShell(scan);
+
+  const termination = scan.worker.terminate().catch(() => void 0);
+  scan.cleanupPromise = termination.then(() => {
+    // Catch a late "started" message delivered while terminate() was in flight.
+    terminateTrackedPowerShell(scan);
+  });
+  return scan.cleanupPromise;
+}
+
+function terminateTrackedPowerShell(scan: ActiveWindowsProcessScan): void {
+  const pid = scan.childPid;
+  scan.childPid = null;
+  if (pid === null) return;
+  terminatePowerShell(scan, pid);
+}
+
+function terminatePowerShell(scan: ActiveWindowsProcessScan, pid: number): void {
+  try {
+    scan.terminateProcessTree(pid);
+  } catch {
+    // Cleanup must not mask the worker's original scan failure.
+  }
+}
+
+function terminateWindowsProcessTree(pid: number): void {
+  if (process.platform === 'win32') {
+    try {
+      execFileSync('taskkill', ['/T', '/F', '/PID', String(pid)], {
+        timeout: 2_000,
+        windowsHide: true,
+        stdio: 'ignore',
+      });
+      return;
+    } catch {
+      // The process may already have exited; retain a direct-kill fallback below.
+    }
+  }
+  try {
+    process.kill(pid, 'SIGKILL');
+  } catch {
+    // The process is already gone or inaccessible.
+  }
 }
 
 function workerError(message: string, code?: string, syscall?: string): NodeJS.ErrnoException {

--- a/apps/desktop/src/main/process-monitor/windowsProcessScanWorkerClient.ts
+++ b/apps/desktop/src/main/process-monitor/windowsProcessScanWorkerClient.ts
@@ -1,0 +1,73 @@
+import path from 'node:path';
+// eslint-disable-next-line no-restricted-imports -- Windows child-process pipes must be isolated from Electron Main.
+import { Worker } from 'node:worker_threads';
+
+import { isWindowsProcessScanWorkerResponse } from './windowsProcessScanProtocol.js';
+
+export const WINDOWS_PROCESS_SCAN_WORKER_TIMEOUT_MS = 12_000;
+
+export interface WindowsProcessScanWorkerHandle {
+  once(event: 'message', listener: (value: unknown) => void): this;
+  once(event: 'error', listener: (error: Error) => void): this;
+  once(event: 'exit', listener: (code: number) => void): this;
+  terminate(): Promise<number>;
+}
+
+interface WindowsProcessScanWorkerOptions {
+  createWorker?: () => WindowsProcessScanWorkerHandle;
+  timeoutMs?: number;
+}
+
+export async function runWindowsProcessScanWorker(
+  options: WindowsProcessScanWorkerOptions = {},
+): Promise<string> {
+  const worker =
+    options.createWorker?.() ?? new Worker(path.join(__dirname, 'windowsProcessScanWorker.js'));
+  try {
+    return await waitForWorker(worker, options.timeoutMs ?? WINDOWS_PROCESS_SCAN_WORKER_TIMEOUT_MS);
+  } finally {
+    await worker.terminate().catch(() => void 0);
+  }
+}
+
+function waitForWorker(worker: WindowsProcessScanWorkerHandle, timeoutMs: number): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const finish = (operation: () => void): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      operation();
+    };
+    const timer = setTimeout(
+      () => finish(() => reject(workerError('Windows process scan worker timed out', 'ETIMEDOUT'))),
+      timeoutMs,
+    );
+    timer.unref?.();
+
+    worker.once('message', (value) => {
+      if (!isWindowsProcessScanWorkerResponse(value)) {
+        finish(() => reject(new Error('invalid Windows process scan worker response')));
+        return;
+      }
+      if (value.ok) {
+        finish(() => resolve(value.stdout));
+        return;
+      }
+      finish(() => reject(workerError(value.error.message, value.error.code, value.error.syscall)));
+    });
+    worker.once('error', (error) => finish(() => reject(error)));
+    worker.once('exit', (code) =>
+      finish(() =>
+        reject(new Error(`Windows process scan worker exited before response (${code})`)),
+      ),
+    );
+  });
+}
+
+function workerError(message: string, code?: string, syscall?: string): NodeJS.ErrnoException {
+  return Object.assign(new Error(message), {
+    ...(code ? { code } : {}),
+    ...(syscall ? { syscall } : {}),
+  });
+}

--- a/apps/desktop/vite.process-scan-worker.config.ts
+++ b/apps/desktop/vite.process-scan-worker.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  resolve: {
+    conditions: ['node'],
+    mainFields: ['module', 'jsnext:main', 'jsnext'],
+  },
+  build: {
+    rollupOptions: {
+      output: {
+        inlineDynamicImports: true,
+      },
+    },
+  },
+});


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Windows 启动期资源监视器预热时，PowerShell 进程扫描管道偶发 `ENOTCONN` 可能升级为 Electron 主进程未捕获异常并导致应用退出的问题。

Windows 进程扫描现在运行在一次性 Worker 中；扫描异常只会让本轮 Agent 快照降级为空，并在 30 秒内停止重复拉起 Worker。资源监视器仍会预热，但首帧先返回 Chromium 指标，后台扫描完成后再补齐 Agent 数据。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Windows 用户安装后启动闪退，主日志出现 `read ENOTCONN`
- 本 PR 包含：Windows PowerShell 进程扫描 Worker、Worker 构建入口、失败退避、资源监视器首帧非阻塞降级及对应测试
- 明确不包含：全局异常白名单、资源监视器 UI 改动、macOS/Linux 扫描逻辑改动
- 用户可见变化：Windows 启动不再因该扫描异常退出；资源监视器预热首帧可能先显示应用进程，随后补齐 Agent 进程
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：不涉及；未修改 UI、交互或文案

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：通过，apps/desktop 相关单测通过

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --filter desktop exec eslint <本次 process-monitor 改动文件>
结果：通过

pnpm test:unit
结果：通过，Desktop、Mobile 及所有可收集单测的 packages 均通过

pnpm check:dco
结果：通过，1 个提交已签名
```

另使用 Vite 实际编译 `windowsProcessScanWorker.js` 并在 Windows 上运行，PowerShell 扫描成功返回进程快照。

### 手工验证

- Windows 11、Global remote dev、命名隔离沙盒 `cheerful-morse-89c6f8`
- `pnpm restart:desktop:remote --region=global -- --isolated=@worktree` 返回 `DESKTOP_DEV_VERDICT=ready`
- 确认隐藏的资源监视器预热窗口已加载，并包含主进程与 Codex Agent 首份快照
- 打开资源监视器后连续收到 3 份约 2 秒间隔的快照，每份均包含 Codex Agent
- 当天主日志中 `ENOTCONN`、未捕获异常和进程扫描 Worker 失败匹配数均为 0，主进程持续响应

### 未执行的验证

- 未构建并安装完整 Windows 安装包；本次已覆盖 dev 打包产物、实际 Worker 运行及隔离沙盒启动链路
- 未在原反馈用户机器复现，因为无法访问其运行环境

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Windows 的进程资源扫描与资源监视器预热时序；macOS/Linux 继续使用原有 `ps` 扫描路径
- 回滚 / 降级方式：回退本 PR 后恢复主进程直接执行 PowerShell 扫描；Worker 扫描失败时当前实现会降级为空快照并在 30 秒后重试
- 移动端冷更判断：不触发。未修改 `apps/mobile`、移动端原生配置、原生依赖、config plugin 或 runtime fingerprint 输入
- 存量插件影响：无

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次不需要新增文档）
- [x] 已确认测试结果或说明未执行原因