### PR TITLE
fix(desktop): 跳过登录时停止 Device Link 缓存令牌补读

### DIFF
--- a/apps/desktop/src/renderer/__tests__/deviceLinkRemoteProjectsAuth.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/deviceLinkRemoteProjectsAuth.test.tsx
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const authState = vi.hoisted(() => ({
+  isAuthenticated: false,
+  deviceId: 'self-device',
+  dataOwnerId: 'local-v1' as string | null,
+}));
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => authState,
+}));
+
+import { useDeviceLinkRemoteProjects } from '@/features/device-link/useDeviceLinkRemoteProjects';
+
+const getSessionList = vi.fn(async () => {
+  throw new Error('[PERMISSION_DENIED] Device Link requires a Cindy account.');
+});
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  authState.isAuthenticated = false;
+  authState.deviceId = 'self-device';
+  authState.dataOwnerId = 'local-v1';
+  getSessionList.mockClear();
+  Object.defineProperty(window, 'electronAPI', {
+    configurable: true,
+    value: {
+      deviceLink: {
+        mirrorCache: { getSessionList },
+      },
+    } as unknown as Window['electronAPI'],
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  Reflect.deleteProperty(window, 'electronAPI');
+  vi.useRealTimers();
+});
+
+describe('Device Link remote projects auth gate', () => {
+  it('跳过登录进入 local mode 时不启动 session-list owner token 补读', async () => {
+    const { unmount } = renderHook(() => useDeviceLinkRemoteProjects());
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000);
+    });
+
+    expect(getSessionList).not.toHaveBeenCalled();
+    unmount();
+  });
+});

--- a/apps/desktop/src/renderer/features/device-link/useDeviceLinkRemoteProjects.ts
+++ b/apps/desktop/src/renderer/features/device-link/useDeviceLinkRemoteProjects.ts
@@ -268,9 +268,11 @@ export function useDeviceLinkRemoteProjects(): void {
     //  2. 补读可能因待清队列 / owner 边界复核 / 瞬时 IPC 错误失败,失败后**重试**直到锚点
     //     就位 —— 否则订阅仍持续排程 undefined 写入,冷缓存停写到重挂载(本线程)。
     // 账号在重试期间再次变化时,effect 重跑清掉定时器,旧账号的重试不再继续。
-    if (!dataOwnerId) return;
+    // local mode 也有 `local-v1` data owner,但没有 Device Link capability;只看 dataOwnerId
+    // 会让跳过登录的客户端无限重试一个必然被 main 以 PERMISSION_DENIED 拒绝的 IPC。
+    if (!isAuthenticated || !dataOwnerId) return;
     return startSessionListTokenRefresh();
-  }, [ownerBoundaryGeneration]);
+  }, [ownerBoundaryGeneration, isAuthenticated]);
 
   useEffect(() => {
     if (!isAuthenticated || !selfDeviceId) {


### PR DESCRIPTION
## 这次改了什么

### 摘要

跳过 Cindy 登录进入本地模式时，Renderer 仍会因为本地数据 owner 存在而启动 Device Link 镜像缓存令牌补读；Main 会按权限边界拒绝这些请求，形成持续的 `PERMISSION_DENIED` 日志。

本 PR 将补读循环同时受 Cindy 登录态和数据 owner 约束。本地模式不再启动该循环，登录或切换 Cindy 账号后仍会按账号边界重新启动。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：用户反馈跳过登录后持续输出 Device Link 权限错误日志。
- 本 PR 包含：镜像缓存 owner 令牌补读的登录态门禁；本地模式回归测试。
- 明确不包含：Main 授权边界、Device Link wire protocol、Mobile 入口或 UI。
- 用户可见变化：跳过登录后不再持续输出该缓存读取权限错误；界面无变化。
- 是否存在 breaking change：无。

### UI 变化

- 引用的设计规范：不涉及。仅调整后台 effect 的启停条件并补测试，无视觉、交互或文案变化。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/renderer/__tests__/deviceLinkRemoteProjectsAuth.test.tsx src/renderer/__tests__/deviceLinkRemoteProjects.test.ts
结果：通过，2 个测试文件、13 个测试。

pnpm test:unit:related
结果：通过，Desktop 相关单测门禁通过。

pnpm --filter desktop typecheck
结果：通过。

pnpm --filter desktop exec eslint src/renderer/__tests__/deviceLinkRemoteProjectsAuth.test.tsx
结果：通过。

pnpm check:dco
结果：通过，1 个提交已签署 DCO。

pnpm test:unit
结果：未全部通过；28,676 个通过、71 个跳过、2 个失败。失败均位于本 PR 未修改且与 origin/main 一致的 src/main/plugin-publisher/__tests__/orchestrator.test.ts，表现为确认失败状态的 waitFor 超时；本 PR 新增测试在全量运行中通过，其余 workspace 均通过。

pnpm --filter desktop exec vitest run src/main/plugin-publisher/__tests__/orchestrator.test.ts -t "releases pending-confirmation capacity after a confirmation is rejected"
结果：单独复跑通过。

pnpm --filter desktop exec vitest run src/main/plugin-publisher/__tests__/orchestrator.test.ts -t "releases pending-confirmation capacity after a confirmation is failed"
结果：单独复跑仍失败，确认是 origin/main 已有基线失败，非本 PR 引入。
```

补充：对两个改动文件执行 ESLint 时，源文件命中 origin/main 已存在的未使用导入 `requestRemoteSessionStatus`；未在本 PR 中扩大范围处理。新增测试文件单独 ESLint 已通过。

### 手工验证

未执行 Desktop 实机复现：当前会话位于独立 worktree，运行中的宿主不会加载该 worktree 改动。

### 未执行的验证

- 未执行 Desktop 实机 Light / Dark 目检：本 PR 不涉及 UI。
- 未执行 Mobile 本地验证：本 PR 不修改 Mobile 或共享运行时代码。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：Device Link Renderer 缓存补读的启停条件。

### 影响与回滚

- 影响范围：Desktop Renderer 的远程会话镜像缓存令牌补读；仅 Cindy 云账号启用，本地模式保持停用。
- 回滚 / 降级方式：回滚本 PR 提交即可恢复原行为。
- 移动端冷更判断：不会触发。仅修改 Desktop Renderer 与 Desktop 测试，未修改 Mobile 原生配置、原生依赖、config plugin、原生模块或 runtime fingerprint 输入。
- 多端适配：SSH 远程工作区不涉及；没有新增或修改 IPC channel、push 或 wire protocol；Mobile 不需要入口或交互调整。
- 故障半径：触发条件是本地模式 Renderer 发起单请求级、必然被拒绝的缓存补读；恢复动作仅是不启动当前 Renderer 的令牌补读循环，不拆 peer link、不重连 relay，也不重放共享流量；未触及多 peer 共享链路，因此多 peer 零影响用例不适用。
- 跨平台：改动是平台无关的 React 登录态门禁，macOS 与 Windows 行为一致；Windows 已完成自动验证，macOS 未实机验证。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [ ] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（不涉及：无需新增文档，回归由自动测试约束）
- [x] 已确认测试结果或说明未执行原因