### PR TITLE
fix(scheduler): append actionable hint to MCP utility-model errors

### DIFF
--- a/packages/lizi-mcps/src/scheduler/errors.test.ts
+++ b/packages/lizi-mcps/src/scheduler/errors.test.ts
@@ -13,6 +13,23 @@ describe('classifySchedulerError utility model diagnostics', () => {
       new Error(`[${code}] safe diagnostic`),
     );
 
-    expect(result).toEqual({ code, message: `[${code}] safe diagnostic` });
+    expect(result.code).toBe(code);
+    // Message must contain the original diagnostic
+    expect(result.message).toContain(`[${code}] safe diagnostic`);
+  });
+
+  it.each([
+    'UTILITY_MODEL_NO_CANDIDATE',
+    'UTILITY_MODEL_ALL_CANDIDATES_FAILED',
+    'UTILITY_MODEL_EMPTY_RESPONSE',
+    'UTILITY_MODEL_TIMEOUT',
+  ] as const)('appends actionable hint for %s so agents can suggest passing script', (code) => {
+    const result = classifySchedulerError(
+      new Error(`[${code}] all candidates failed`),
+    );
+
+    // Must hint that passing "script" bypasses generation (#3317)
+    expect(result.message).toContain('script');
+    expect(result.message).toContain('bypass');
   });
 });

--- a/packages/lizi-mcps/src/scheduler/errors.ts
+++ b/packages/lizi-mcps/src/scheduler/errors.ts
@@ -35,7 +35,21 @@ export function classifySchedulerError(err: unknown): SchedulerToolError {
   const utilityCode = /^\[(UTILITY_MODEL_(?:NO_CANDIDATE|ALL_CANDIDATES_FAILED|EMPTY_RESPONSE|TIMEOUT))\]/
     .exec(message)?.[1];
   if (utilityCode) {
-    return { code: utilityCode as SchedulerToolErrorCode, message };
+    // Append actionable hint so the MCP caller (agent) can suggest a workaround
+    // instead of silently retrying the same failing utility-model chain.
+    // See #3317.
+    const hints: Record<string, string> = {
+      UTILITY_MODEL_ALL_CANDIDATES_FAILED:
+        ' All utility-model candidates failed. You can bypass generation by passing the "script" parameter directly with a hand-written check script.',
+      UTILITY_MODEL_NO_CANDIDATE:
+        ' No utility-model candidate is configured. You can bypass generation by passing the "script" parameter directly.',
+      UTILITY_MODEL_TIMEOUT:
+        ' The utility-model call timed out. You can bypass generation by passing the "script" parameter directly.',
+      UTILITY_MODEL_EMPTY_RESPONSE:
+        ' The utility-model returned an empty response. You can bypass generation by passing the "script" parameter directly.',
+    };
+    const hint = hints[utilityCode] ?? '';
+    return { code: utilityCode as SchedulerToolErrorCode, message: message + hint };
   }
   if (/scheduler not started/i.test(message)) {
     return { code: 'SCHEDULER_NOT_READY', message };


### PR DESCRIPTION
## 这次改了什么

当 `schedule_set_pre_run_hook` 因为所有 utility-model 候选全部失败时，原始错误信息直接返回给 MCP 调用方，没有任何操作指引。Agent 无法知道可以通过直接传 `script` 参数绕过失败的生成链。

本修复为 4 种 utility-model 错误码追加可操作提示，明确建议传 `script` 绕过生成，解决 **#3317**。

### 变更类型

- [ ] feat 新功能
- [x] fix 缺陷修复
- [ ] refactor / perf 重构或性能优化
- [ ] docs / test / chore 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue：#3317
- 本 PR 包含：
  - `packages/lizi-mcps/src/scheduler/errors.ts`：为 4 种 utility-model 错误码追加可操作提示
  - `packages/lizi-mcps/src/scheduler/errors.test.ts`：更新已有测试 + 新增提示验证测试
- 明确不包含：不修改错误分类逻辑；不修改 scheduler 核心流程

## 怎么验证的

1. 运行 `npx vitest run packages/lizi-mcps/src/scheduler/errors.test.ts`，8/8 测试通过
2. 验证每种错误码（`ALL_CANDIDATES_FAILED`、`NO_CANDIDATE`、`TIMEOUT`、`EMPTY_RESPONSE`）的错误消息都包含 "passing the `script` parameter" 提示
3. 验证原始错误信息仍然保留在提示之后

## 风险

风险极低——仅向现有错误消息追加文本，无控制流变更，无 breaking change。