### PR TITLE
feat(desktop): Linux agent 二进制改为 CDN manifest 优先,官方源兜底

### DIFF
--- a/apps/desktop/src/main/__tests__/agentBinaryLinuxPrepare.test.ts
+++ b/apps/desktop/src/main/__tests__/agentBinaryLinuxPrepare.test.ts
@@ -204,6 +204,17 @@ describe('packaged Linux agent binary prepare', () => {
     expect(manifestService.fetchManifest).toHaveBeenCalledTimes(2);
   });
 
+  it('skips the CDN leg when the round peek probe failed and goes straight to fallback', async () => {
+    // peek 失败 → 本轮 prepare 跳过 CDN 腿,直接 fallback(离线 + 本地已有
+    // runtime 的首启不再为两个 vendor 白等 2×30s manifest 拉取)。
+    manifestService.fetchManifest.mockRejectedValue(new Error('offline'));
+    await expect(binaries.peekNeedsDownload('codex')).resolves.toBe(true);
+    const result = await binaries.prepare('claude-code');
+    expect(result.ready).toBe(true);
+    expect(cdndProvisioner.prepare).not.toHaveBeenCalled();
+    expect(prepareLinuxRuntimeFallback).toHaveBeenCalled();
+  });
+
   it('peek delegates to the CDN check when the manifest publishes a linux asset', async () => {
     manifestService.getCachedManifest.mockReturnValue({
       app: { version: '0.1.59' },

--- a/apps/desktop/src/main/__tests__/agentBinaryLinuxPrepare.test.ts
+++ b/apps/desktop/src/main/__tests__/agentBinaryLinuxPrepare.test.ts
@@ -181,29 +181,27 @@ describe('packaged Linux agent binary prepare', () => {
     expect(cdndProvisioner.peekNeedsDownload).not.toHaveBeenCalled();
   });
 
-  it('peek probes the manifest once across vendors (negative-cached single flight)', async () => {
-    // 探测失败 → 负缓存:第二个 vendor 的 peek 不再发第二次请求,直接 fs 快查。
+  it('peek probes the manifest once per splash round across vendors (single flight)', async () => {
+    // 同轮内:两个 vendor 的 peek 共享一次探测(第二个 peek 命中 memo)。
+    manifestService.fetchManifest.mockRejectedValue(new Error('offline'));
     await expect(binaries.peekNeedsDownload('claude-code')).resolves.toBe(true);
     await expect(binaries.peekNeedsDownload('codex')).resolves.toBe(true);
     expect(manifestService.fetchManifest).toHaveBeenCalledTimes(1);
     expect(findCachedLinuxRuntimeFallbackBinary).toHaveBeenCalledTimes(2);
   });
 
-  it('negative cache expires after 60s and the next round re-probes the manifest', async () => {
-    vi.useFakeTimers();
-    try {
-      manifestService.fetchManifest.mockRejectedValue(new Error('offline'));
-      await expect(binaries.peekNeedsDownload('codex')).resolves.toBe(true);
-      // 同轮内:负缓存命中,不再重试。
-      await expect(binaries.peekNeedsDownload('claude-code')).resolves.toBe(true);
-      expect(manifestService.fetchManifest).toHaveBeenCalledTimes(1);
-      // TTL 过期:下一轮重试允许重新探测(网络恢复后进度标签与 prepare 对齐)。
-      vi.advanceTimersByTime(61_000);
-      await expect(binaries.peekNeedsDownload('claude-code')).resolves.toBe(true);
-      expect(manifestService.fetchManifest).toHaveBeenCalledTimes(2);
-    } finally {
-      vi.useRealTimers();
-    }
+  it('prepare clears the probe memo so the next retry round re-probes the manifest', async () => {
+    // 模拟真实 retry 流程:peek(Phase 0)→ prepare(Phase 1)清 memo →
+    // 下一轮 peek 重新探测(网络恢复后进度标签与 prepare 行为对齐)。
+    manifestService.fetchManifest.mockRejectedValue(new Error('offline'));
+    await expect(binaries.peekNeedsDownload('codex')).resolves.toBe(true);
+    await expect(binaries.peekNeedsDownload('claude-code')).resolves.toBe(true);
+    expect(manifestService.fetchManifest).toHaveBeenCalledTimes(1);
+    // 本轮 prepare(默认 mock:CDN 失败 → fallback 成功)。
+    await expect(binaries.prepare('claude-code')).resolves.toMatchObject({ ready: true });
+    // 下一轮 peek:重新探测。
+    await expect(binaries.peekNeedsDownload('claude-code')).resolves.toBe(true);
+    expect(manifestService.fetchManifest).toHaveBeenCalledTimes(2);
   });
 
   it('peek delegates to the CDN check when the manifest publishes a linux asset', async () => {

--- a/apps/desktop/src/main/__tests__/agentBinaryLinuxPrepare.test.ts
+++ b/apps/desktop/src/main/__tests__/agentBinaryLinuxPrepare.test.ts
@@ -1,16 +1,28 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
+// getBase() 按 kind 缓存 provisioner 实例:全部测试共享同一个 cdndProvisioner,
+// 每测试重配它的行为(而不是 mockReturnValueOnce 换实例——缓存会让新实例永远不被使用)。
 const {
   appMock,
+  cdndProvisioner,
   createBinaryProvisioner,
   findCachedLinuxRuntimeFallbackBinary,
   prepareLinuxRuntimeFallback,
-} = vi.hoisted(() => ({
-  appMock: { isPackaged: true, getPath: vi.fn(() => '/tmp/xdt-userdata') },
-  createBinaryProvisioner: vi.fn(),
-  findCachedLinuxRuntimeFallbackBinary: vi.fn((): string | null => null),
-  prepareLinuxRuntimeFallback: vi.fn(),
-}));
+} = vi.hoisted(() => {
+  const cdndProvisioner = {
+    prepare: vi.fn(),
+    peekNeedsDownload: vi.fn(),
+    getState: vi.fn(async () => ({ status: 'not_installed' })),
+    cleanup: vi.fn(),
+  };
+  return {
+    appMock: { isPackaged: true, getPath: vi.fn(() => '/tmp/xdt-userdata') },
+    cdndProvisioner,
+    createBinaryProvisioner: vi.fn(() => cdndProvisioner),
+    findCachedLinuxRuntimeFallbackBinary: vi.fn((): string | null => null),
+    prepareLinuxRuntimeFallback: vi.fn(),
+  };
+});
 
 vi.mock('electron', () => ({
   app: appMock,
@@ -22,7 +34,11 @@ vi.mock('../agent-binaries/linux-runtime-fallback.js', () => ({
   findCachedLinuxRuntimeFallbackBinary,
   prepareLinuxRuntimeFallback,
 }));
-vi.mock('../manifestService.js', () => ({ getPlatformKey: () => 'linux-x64' }));
+// CDN manifest 缺省不可用(无缓存)。CDN 命中用例单独 stub getCachedManifest。
+vi.mock('../manifestService.js', () => ({
+  getPlatformKey: () => 'linux-x64',
+  getCachedManifest: vi.fn((): unknown => null),
+}));
 vi.mock('../updateProgressNormalizer.js', () => ({
   ProgressNormalizer: class {
     handle(): void {}
@@ -33,15 +49,20 @@ vi.mock('../updateProgressNormalizer.js', () => ({
 
 const originalPlatform = process.platform;
 let binaries: typeof import('../agent-binaries/index');
+let manifestService: { getCachedManifest: ReturnType<typeof vi.fn> };
 
 beforeAll(async () => {
   Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+  manifestService = (await import('../manifestService.js')) as never;
   binaries = await import('../agent-binaries/index');
 });
 
 beforeEach(() => {
   vi.clearAllMocks();
   appMock.isPackaged = true;
+  // 默认:CDN 链失败(asset_missing)→ 回落 fallback;fallback 命中私有安装。
+  cdndProvisioner.prepare.mockReset().mockResolvedValue({ ready: false, binaryPath: '', error: 'asset_missing' });
+  cdndProvisioner.peekNeedsDownload.mockReset().mockResolvedValue(true);
   findCachedLinuxRuntimeFallbackBinary.mockReturnValue(null);
   prepareLinuxRuntimeFallback.mockResolvedValue({
     ready: true,
@@ -64,7 +85,7 @@ describe('packaged Linux agent binary prepare', () => {
     expect(findCachedLinuxRuntimeFallbackBinary).toHaveBeenCalledWith('codex');
   });
 
-  it('reuses an existing runtime binary without private install or CDN work', async () => {
+  it('falls back to the runtime chain when the CDN chain reports asset_missing', async () => {
     prepareLinuxRuntimeFallback.mockResolvedValueOnce({
       ready: true,
       binaryPath: '/usr/local/bin/claude',
@@ -79,14 +100,15 @@ describe('packaged Linux agent binary prepare', () => {
       path: '/usr/local/bin/claude',
       downloaded: false,
     });
+    // CDN 链先试(manifest 无段 → asset_missing),失败后静默落到 fallback。
+    expect(cdndProvisioner.prepare).toHaveBeenCalled();
     expect(prepareLinuxRuntimeFallback).toHaveBeenCalledWith('claude-code', {
       signal: undefined,
       onProgress: expect.any(Function),
     });
-    expect(createBinaryProvisioner).not.toHaveBeenCalled();
   });
 
-  it('goes directly to the runtime fallback without creating or probing the CDN provisioner', async () => {
+  it('propagates signal and returns fallback install result when CDN misses', async () => {
     const controller = new AbortController();
     const result = await binaries.prepare('claude-code');
 
@@ -104,13 +126,60 @@ describe('packaged Linux agent binary prepare', () => {
       signal: controller.signal,
       onProgress: expect.any(Function),
     });
-    expect(createBinaryProvisioner).not.toHaveBeenCalled();
   });
 
-  it('reports a local miss as a private install need without fetching a manifest', async () => {
+  it('prefers the CDN chain when the manifest publishes a linux asset, without touching the fallback', async () => {
+    manifestService.getCachedManifest.mockReturnValue({
+      app: { version: '0.1.59' },
+      claudeCode: {
+        version: '2.1.219',
+        file: 'claude-code/2.1.219/linux-x64/claude.gz',
+        sha256: 'a'.repeat(64),
+        size: 1234,
+      },
+    });
+    cdndProvisioner.prepare.mockResolvedValueOnce({
+      ready: true,
+      binaryPath: '/tmp/xdt-userdata/claude-code/2.1.219/claude',
+    });
+
+    const result = await binaries.prepare('claude-code');
+
+    expect(result.ready).toBe(true);
+    expect(result.path).toBe('/tmp/xdt-userdata/claude-code/2.1.219/claude');
+    expect(prepareLinuxRuntimeFallback).not.toHaveBeenCalled();
+  });
+
+  it('survives a throwing CDN chain and still resolves via the fallback', async () => {
+    cdndProvisioner.prepare.mockReset().mockRejectedValue(new Error('disk exploded'));
+
+    const result = await binaries.prepare('claude-code');
+
+    expect(result.ready).toBe(true);
+    expect(result.path).toBe('/tmp/xdt-userdata/agent-runtime/claude-code/bin/claude');
+    expect(prepareLinuxRuntimeFallback).toHaveBeenCalled();
+  });
+
+  it('peek reports a local miss as a need without fetching a manifest', async () => {
     await expect(binaries.peekNeedsDownload('codex')).resolves.toBe(true);
     expect(findCachedLinuxRuntimeFallbackBinary).toHaveBeenCalledWith('codex');
-    expect(createBinaryProvisioner).not.toHaveBeenCalled();
+    expect(cdndProvisioner.peekNeedsDownload).not.toHaveBeenCalled();
+  });
+
+  it('peek delegates to the CDN check when the manifest publishes a linux asset', async () => {
+    manifestService.getCachedManifest.mockReturnValue({
+      app: { version: '0.1.59' },
+      codex: {
+        version: '0.144.6',
+        file: 'codex/0.144.6/linux-x64/codex.gz',
+        sha256: 'b'.repeat(64),
+        size: 5678,
+      },
+    });
+
+    await expect(binaries.peekNeedsDownload('codex')).resolves.toBe(true);
+    expect(cdndProvisioner.peekNeedsDownload).toHaveBeenCalled();
+    expect(findCachedLinuxRuntimeFallbackBinary).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/desktop/src/main/__tests__/agentBinaryLinuxPrepare.test.ts
+++ b/apps/desktop/src/main/__tests__/agentBinaryLinuxPrepare.test.ts
@@ -189,6 +189,23 @@ describe('packaged Linux agent binary prepare', () => {
     expect(findCachedLinuxRuntimeFallbackBinary).toHaveBeenCalledTimes(2);
   });
 
+  it('negative cache expires after 60s and the next round re-probes the manifest', async () => {
+    vi.useFakeTimers();
+    try {
+      manifestService.fetchManifest.mockRejectedValue(new Error('offline'));
+      await expect(binaries.peekNeedsDownload('codex')).resolves.toBe(true);
+      // 同轮内:负缓存命中,不再重试。
+      await expect(binaries.peekNeedsDownload('claude-code')).resolves.toBe(true);
+      expect(manifestService.fetchManifest).toHaveBeenCalledTimes(1);
+      // TTL 过期:下一轮重试允许重新探测(网络恢复后进度标签与 prepare 对齐)。
+      vi.advanceTimersByTime(61_000);
+      await expect(binaries.peekNeedsDownload('claude-code')).resolves.toBe(true);
+      expect(manifestService.fetchManifest).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('peek delegates to the CDN check when the manifest publishes a linux asset', async () => {
     manifestService.getCachedManifest.mockReturnValue({
       app: { version: '0.1.59' },

--- a/apps/desktop/src/main/__tests__/agentBinaryLinuxPrepare.test.ts
+++ b/apps/desktop/src/main/__tests__/agentBinaryLinuxPrepare.test.ts
@@ -34,10 +34,11 @@ vi.mock('../agent-binaries/linux-runtime-fallback.js', () => ({
   findCachedLinuxRuntimeFallbackBinary,
   prepareLinuxRuntimeFallback,
 }));
-// CDN manifest 缺省不可用(无缓存)。CDN 命中用例单独 stub getCachedManifest。
+// CDN manifest 缺省不可用(无缓存、拉取也拿不到)。CDN 命中用例单独 stub。
 vi.mock('../manifestService.js', () => ({
   getPlatformKey: () => 'linux-x64',
   getCachedManifest: vi.fn((): unknown => null),
+  fetchManifest: vi.fn(async (): Promise<unknown> => null),
 }));
 vi.mock('../updateProgressNormalizer.js', () => ({
   ProgressNormalizer: class {
@@ -63,6 +64,9 @@ beforeEach(() => {
   // 默认:CDN 链失败(asset_missing)→ 回落 fallback;fallback 命中私有安装。
   cdndProvisioner.prepare.mockReset().mockResolvedValue({ ready: false, binaryPath: '', error: 'asset_missing' });
   cdndProvisioner.peekNeedsDownload.mockReset().mockResolvedValue(true);
+  // manifest 默认无缓存、拉取也拿不到(每个测试独立重置,防上一用例的 stub 泄漏)。
+  manifestService.getCachedManifest.mockReset();
+  (manifestService as unknown as { fetchManifest: ReturnType<typeof vi.fn> }).fetchManifest.mockReset();
   findCachedLinuxRuntimeFallbackBinary.mockReturnValue(null);
   prepareLinuxRuntimeFallback.mockResolvedValue({
     ready: true,
@@ -160,8 +164,11 @@ describe('packaged Linux agent binary prepare', () => {
     expect(prepareLinuxRuntimeFallback).toHaveBeenCalled();
   });
 
-  it('peek reports a local miss as a need without fetching a manifest', async () => {
+  it('peek pulls a manifest when none is cached and falls back to the fs check on a miss', async () => {
+    // 无缓存 → peek 拉一次 manifest(与 prepare 同判据);拉取失败/null → fs 快查。
     await expect(binaries.peekNeedsDownload('codex')).resolves.toBe(true);
+    expect((manifestService as unknown as { fetchManifest: ReturnType<typeof vi.fn> }).fetchManifest)
+      .toHaveBeenCalled();
     expect(findCachedLinuxRuntimeFallbackBinary).toHaveBeenCalledWith('codex');
     expect(cdndProvisioner.peekNeedsDownload).not.toHaveBeenCalled();
   });
@@ -180,6 +187,26 @@ describe('packaged Linux agent binary prepare', () => {
     await expect(binaries.peekNeedsDownload('codex')).resolves.toBe(true);
     expect(cdndProvisioner.peekNeedsDownload).toHaveBeenCalled();
     expect(findCachedLinuxRuntimeFallbackBinary).not.toHaveBeenCalled();
+  });
+
+  it('gives the CDN leg its own signal and preserves the original one for the fallback', async () => {
+    const controller = new AbortController();
+    // CDN 腿失败(模拟拖满自身预算),fallback 必须收到原始未中止的 signal,
+    // 否则官方源兜底会在共享 deadline 被耗尽时名存实亡。
+    cdndProvisioner.prepare.mockReset().mockRejectedValue(new Error('cdn leg timed out'));
+
+    const result = await binaries.prepare('claude-code', { signal: controller.signal });
+
+    expect(result.ready).toBe(true);
+    // CDN 腿收到的是包装后的独立 signal,不是调用方原始 signal。
+    const cdnArgs = cdndProvisioner.prepare.mock.calls[0][0];
+    expect(cdnArgs.signal).toBeInstanceOf(AbortSignal);
+    expect(cdnArgs.signal).not.toBe(controller.signal);
+    // fallback 收到的是原始 signal(未被 CDN 腿污染)。
+    expect(prepareLinuxRuntimeFallback).toHaveBeenCalledWith(
+      'claude-code',
+      expect.objectContaining({ signal: controller.signal }),
+    );
   });
 });
 

--- a/apps/desktop/src/main/__tests__/agentBinaryLinuxPrepare.test.ts
+++ b/apps/desktop/src/main/__tests__/agentBinaryLinuxPrepare.test.ts
@@ -50,23 +50,32 @@ vi.mock('../updateProgressNormalizer.js', () => ({
 
 const originalPlatform = process.platform;
 let binaries: typeof import('../agent-binaries/index');
-let manifestService: { getCachedManifest: ReturnType<typeof vi.fn> };
+let manifestService: { getCachedManifest: ReturnType<typeof vi.fn>; fetchManifest: ReturnType<typeof vi.fn> };
 
 beforeAll(async () => {
   Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
-  manifestService = (await import('../manifestService.js')) as never;
-  binaries = await import('../agent-binaries/index');
 });
 
-beforeEach(() => {
+// peek 的 manifest 探测是模块级 single-flight + 负缓存:每测试 resetModules +
+// 重新 import,否则前一个用例的探测结果(memo)会泄漏进下一个用例。
+async function reloadBinaries(): Promise<void> {
+  vi.resetModules();
+  manifestService = (await import('../manifestService.js')) as never;
+  binaries = await import('../agent-binaries/index');
+}
+
+beforeEach(async () => {
+  await reloadBinaries();
   vi.clearAllMocks();
   appMock.isPackaged = true;
   // 默认:CDN 链失败(asset_missing)→ 回落 fallback;fallback 命中私有安装。
   cdndProvisioner.prepare.mockReset().mockResolvedValue({ ready: false, binaryPath: '', error: 'asset_missing' });
   cdndProvisioner.peekNeedsDownload.mockReset().mockResolvedValue(true);
-  // manifest 默认无缓存、拉取也拿不到(每个测试独立重置,防上一用例的 stub 泄漏)。
-  manifestService.getCachedManifest.mockReset();
-  (manifestService as unknown as { fetchManifest: ReturnType<typeof vi.fn> }).fetchManifest.mockReset();
+  // manifestService 是 reloadBinaries 刚重建的 mock(工厂默认实现仍在):
+  // getCachedManifest → null / fetchManifest → Promise<null>。用例里覆盖时用
+  // mockReturnValue/mockResolvedValue,别 mockReset(会连默认实现一起清掉)。
+  manifestService.getCachedManifest.mockReturnValue(null);
+  manifestService.fetchManifest.mockResolvedValue(null);
   findCachedLinuxRuntimeFallbackBinary.mockReturnValue(null);
   prepareLinuxRuntimeFallback.mockResolvedValue({
     ready: true,
@@ -167,10 +176,17 @@ describe('packaged Linux agent binary prepare', () => {
   it('peek pulls a manifest when none is cached and falls back to the fs check on a miss', async () => {
     // 无缓存 → peek 拉一次 manifest(与 prepare 同判据);拉取失败/null → fs 快查。
     await expect(binaries.peekNeedsDownload('codex')).resolves.toBe(true);
-    expect((manifestService as unknown as { fetchManifest: ReturnType<typeof vi.fn> }).fetchManifest)
-      .toHaveBeenCalled();
+    expect(manifestService.fetchManifest).toHaveBeenCalled();
     expect(findCachedLinuxRuntimeFallbackBinary).toHaveBeenCalledWith('codex');
     expect(cdndProvisioner.peekNeedsDownload).not.toHaveBeenCalled();
+  });
+
+  it('peek probes the manifest once across vendors (negative-cached single flight)', async () => {
+    // 探测失败 → 负缓存:第二个 vendor 的 peek 不再发第二次请求,直接 fs 快查。
+    await expect(binaries.peekNeedsDownload('claude-code')).resolves.toBe(true);
+    await expect(binaries.peekNeedsDownload('codex')).resolves.toBe(true);
+    expect(manifestService.fetchManifest).toHaveBeenCalledTimes(1);
+    expect(findCachedLinuxRuntimeFallbackBinary).toHaveBeenCalledTimes(2);
   });
 
   it('peek delegates to the CDN check when the manifest publishes a linux asset', async () => {

--- a/apps/desktop/src/main/agent-binaries/index.ts
+++ b/apps/desktop/src/main/agent-binaries/index.ts
@@ -79,7 +79,8 @@ let peekManifestProbe: Promise<Manifest | null> | null = null;
  */
 let skipCdnUntilNextProbeSuccess = false;
 
-/** 本轮首个 peek 探测的发起点(用于 CDN 预算的轮次起点,含 Phase 0 探测耗时)。 */
+/** 本轮(最新一次)首个 peek 探测的发起点:prepare 开始时会消费进
+ *  per-signal 记录并清零,下一轮 peek 未探测(命中缓存)时自然为 0。 */
 let lastPeekProbeStartMs = 0;
 
 function probeManifestForPeek(): Promise<Manifest | null> {
@@ -124,9 +125,9 @@ function linuxCdnBudgetForSignal(sharedSignal: AbortSignal | undefined): number 
   const now = Date.now();
   let roundStart = linuxRoundStartBySignal.get(sharedSignal);
   if (roundStart === undefined) {
-    // 优先用本轮首个 peek 探测的发起点(含 Phase 0 探测耗时,比 prepare
-    // 起点更接近 signal 创建时刻);没有 peek(直接 prepare 的路径)才用 now。
-    roundStart = lastPeekProbeStartMs > 0 ? lastPeekProbeStartMs : now;
+    // 轮次起点由 prepare 在入口消费本轮 peek 探测起点写入;直接 prepare
+    // (无 peek)或入口未写入时退回 now。
+    roundStart = now;
     linuxRoundStartBySignal.set(sharedSignal, roundStart);
   }
   const elapsedMs = now - roundStart;
@@ -340,6 +341,14 @@ export async function prepare(
   // pi 例外:没有官方 CLI fallback 链,Linux 也走下方通用 manifest 路径
   // (manifest 缺 pi 字段 → asset_missing 快速失败,由调用方降级)。
   if (process.platform === 'linux' && app.isPackaged && kind !== 'pi') {
+    // 本轮轮次起点:优先消费本轮 peek 探测的发起点(含 Phase 0 探测耗时,
+    // 比 prepare 起点更接近 signal 创建时刻);本轮 peek 命中缓存未探测时
+    // lastPeekProbeStartMs 为 0,退回 now。消费后清零,防跨轮残留
+    // (下一轮 peek 未探测时,预算不能拿上一轮的旧起点计算)。
+    if (opts.signal && !linuxRoundStartBySignal.has(opts.signal)) {
+      linuxRoundStartBySignal.set(opts.signal, lastPeekProbeStartMs > 0 ? lastPeekProbeStartMs : Date.now());
+    }
+    lastPeekProbeStartMs = 0;
     // 新一轮 check-environment 开始(Phase 0 peek 已全部完成):清空 peek
     // 探测 memo,下一轮重试的 peek 会重新探测 manifest。
     resetPeekManifestProbe();

--- a/apps/desktop/src/main/agent-binaries/index.ts
+++ b/apps/desktop/src/main/agent-binaries/index.ts
@@ -46,31 +46,46 @@ import {
 import { ProgressNormalizer } from '../updateProgressNormalizer.js';
 import { createLogger } from '../logger.js';
 
-/** CDN 腿预算(毫秒):manifest 拉取 30s + 下载重试 10s × 5,90s 内必分出结果。 */
-const LINUX_CDN_LEG_TIMEOUT_MS = 90_000;
+/**
+ * CDN 腿预算(毫秒)。有进展的慢速下载给 3 分钟窗口(百 MB 级资产在慢网
+ * 也能下完),无进展(stall)由 downloader 自带 connect 10s / idle 30s 兜底;
+ * 共享 5 分钟启动预算给 fallback 留 2 分钟作最终判决。
+ */
+const LINUX_CDN_LEG_TIMEOUT_MS = 180_000;
 
 /** peek 的 manifest 探测超时(毫秒):离线首启时不能为「猜进度标签」白等 30s×2。 */
 const LINUX_PEEK_MANIFEST_PROBE_TIMEOUT_MS = 3_000;
 
+/** 探测失败的负缓存 TTL:同轮 splash 内不再重试,跨轮重试(>60s)自然恢复。 */
+const LINUX_PEEK_MANIFEST_NEGATIVE_CACHE_TTL_MS = 60_000;
+
 /**
- * peek 阶段跨 vendor 的单次 manifest 探测(single-flight + 结果 memo)。
- * 两个 vendor 的 peek 串行调用只发一次短超时请求;失败 memo 住(负缓存),
- * 本轮 splash 内不再重试——offline 首启因此只损失一个 3s 探测,而不是
- * 2 × 30s。真正需要 manifest 的 prepare 会用自己的信号与超时再拉。
+ * peek 阶段跨 vendor 的单次 manifest 探测(single-flight + 失败负缓存)。
+ * 两个 vendor 的 peek 串行调用只发一次短超时请求;失败负缓存 60s——同轮
+ * splash 不再重试(offline 首启只损失一个 3s 探测,而不是 2 × 30s),网络
+ * 恢复后的下一轮重试(TTL 过期)会重新探测,进度标签与 prepare 行为对齐。
  */
 let peekManifestProbe: Promise<Manifest | null> | null = null;
-let peekManifestProbeFailed = false;
+let peekManifestProbeFailedAtMs = 0;
 
 function probeManifestForPeek(): Promise<Manifest | null> {
-  if (peekManifestProbeFailed) return Promise.resolve(null);
+  if (peekManifestProbeFailedAtMs) {
+    const elapsed = Date.now() - peekManifestProbeFailedAtMs;
+    if (elapsed < LINUX_PEEK_MANIFEST_NEGATIVE_CACHE_TTL_MS) {
+      return Promise.resolve(null); // 负缓存命中:同轮 splash 不再重试
+    }
+    peekManifestProbeFailedAtMs = 0; // TTL 过期:下一轮重试允许重新探测
+  }
   if (peekManifestProbe) return peekManifestProbe;
   const probe = fetchManifest(LINUX_PEEK_MANIFEST_PROBE_TIMEOUT_MS).then(
     (manifest) => {
-      if (!manifest) peekManifestProbeFailed = true; // 负缓存:本轮不再重试
+      peekManifestProbe = null; // 探测已结束,下一轮可重发
+      if (!manifest) peekManifestProbeFailedAtMs = Date.now();
       return manifest;
     },
     () => {
-      peekManifestProbeFailed = true;
+      peekManifestProbe = null;
+      peekManifestProbeFailedAtMs = Date.now();
       return null;
     },
   );
@@ -283,15 +298,18 @@ export async function prepare(
   // pi 例外:没有官方 CLI fallback 链,Linux 也走下方通用 manifest 路径
   // (manifest 缺 pi 字段 → asset_missing 快速失败,由调用方降级)。
   if (process.platform === 'linux' && app.isPackaged && kind !== 'pi') {
-    // CDN 腿用独立更短预算:共享的启动 deadline(opts.signal)要留给 fallback
-    // 作最终判决。若 CDN 拖满共享信号,fallback 会拿到已 abort 的 signal
-    // 立即失败,官方源兜底名存实亡。CDN 预算覆盖 manifest 拉取(30s)+
-    // 下载重试(10s 超时 × 5 次),90s 内必分出结果。
-    const cdnSignal = opts.signal
-      ? AbortSignal.any([opts.signal, AbortSignal.timeout(LINUX_CDN_LEG_TIMEOUT_MS)])
-      : AbortSignal.timeout(LINUX_CDN_LEG_TIMEOUT_MS);
+    // CDN 腿用独立预算,不接共享启动 deadline(opts.signal):
+    // - 共享 deadline 全部留给 fallback 作最终判决(它才是慢路径,官方源
+    //   下载可能要几分钟)
+    // - CDN 腿若挂在共享信号上,前一 vendor 的慢 fallback 耗尽 deadline 后,
+    //   本 vendor 的 CDN 腿会带着已中止的信号立即失败,再传已中止信号给
+    //   fallback → 必然 install cancelled;独立预算下 CDN 腿仍可在自己
+    //   的 180s 窗口内完成慢速但有进展的下载
+    // - 每段仍独立有界(CDN 180s / fallback 共享 deadline / fallback 内部
+    //   5min),不存在无界增长
     // CDN 链任何异常(含磁盘错误级)都是降级第一环的信号:吞掉走 fallback,
     // 绝不让 CDN 尝试本身变成 splash 失败原因。
+    const cdnSignal = AbortSignal.timeout(LINUX_CDN_LEG_TIMEOUT_MS);
     let cdnResult: PrepareResult;
     try {
       cdnResult = await prepareViaCdn(kind, { ...opts, signal: cdnSignal }, {

--- a/apps/desktop/src/main/agent-binaries/index.ts
+++ b/apps/desktop/src/main/agent-binaries/index.ts
@@ -47,11 +47,17 @@ import { ProgressNormalizer } from '../updateProgressNormalizer.js';
 import { createLogger } from '../logger.js';
 
 /**
- * CDN 腿预算(毫秒)。有进展的慢速下载给 3 分钟窗口(百 MB 级资产在慢网
+ * CDN 腿预算上限(毫秒)。有进展的慢速下载给 3 分钟窗口(百 MB 级资产在慢网
  * 也能下完),无进展(stall)由 downloader 自带 connect 10s / idle 30s 兜底;
- * 共享 5 分钟启动预算给 fallback 留 2 分钟作最终判决。
+ * 共享 5 分钟启动预算给 fallback 留 1 分钟作最终判决。
  */
 const LINUX_CDN_LEG_TIMEOUT_MS = 180_000;
+
+/** 与 bootstrap-electron.ts 的 LINUX_AGENT_INSTALL_STARTUP_DEADLINE_MS 保持一致。 */
+const LINUX_SHARED_STARTUP_DEADLINE_MS = 5 * 60_000;
+
+/** 每个 CDN 腿开始前,共享 deadline 里必须给 fallback 预留的最小预算。 */
+const LINUX_FALLBACK_RESERVE_MS = 60_000;
 
 /** peek 的 manifest 探测超时(毫秒):离线首启时不能为「猜进度标签」白等 30s×2。 */
 const LINUX_PEEK_MANIFEST_PROBE_TIMEOUT_MS = 3_000;
@@ -59,7 +65,7 @@ const LINUX_PEEK_MANIFEST_PROBE_TIMEOUT_MS = 3_000;
 /**
  * peek 阶段跨 vendor 的单次 manifest 探测(single-flight,每轮 splash 一次)。
  * 两个 vendor 的 peek 串行调用共享同一探测(3s 短超时);prepare 开始时
- * 清空 memo——用户在同一进程内重试(新一轮 check-environment)会重新探测,
+ * 消费并清空——用户在同一进程内重试(新一轮 check-environment)会重新探测,
  * 不会因旧的失败 memo 把 vendor 排除出下载清单(进度标签与 prepare 行为
  * 对齐)。单轮离线成本上界 = 3s(两个 vendor 共享一次探测)。
  */
@@ -78,6 +84,33 @@ function probeManifestForPeek(): Promise<Manifest | null> {
 /** 新一轮 check-environment 开始时清空 peek 探测 memo(peek 先于 prepare)。 */
 function resetPeekManifestProbe(): void {
   peekManifestProbe = null;
+}
+
+/**
+ * 共享 signal → 该轮首个 prepare 的启动时刻。WeakMap 以 signal 对象为键:
+ * bootstrap 每次 check-environment 新建一个 AbortSignal.timeout,新一轮自然
+ * 拿到新键、老键随 signal 回收——无跨轮状态泄漏,也无需显式 reset。
+ */
+const linuxRoundStartBySignal = new WeakMap<object, number>();
+
+/**
+ * 计算本 vendor 的 CDN 腿预算:min(180s 上限, 共享 deadline 剩余 − 1 分钟
+ * fallback 预留)。前一 vendor 的慢 fallback 已消耗共享预算时,本 vendor 的
+ * CDN 腿相应缩短;剩余不足预留时返回 0(调用方跳过 CDN 腿,把剩余时间全部
+ * 留给 fallback 作最终判决)。
+ */
+function linuxCdnBudgetForSignal(sharedSignal: AbortSignal | undefined): number {
+  if (!sharedSignal) return LINUX_CDN_LEG_TIMEOUT_MS;
+  const now = Date.now();
+  let roundStart = linuxRoundStartBySignal.get(sharedSignal);
+  if (roundStart === undefined) {
+    linuxRoundStartBySignal.set(sharedSignal, now);
+    roundStart = now;
+  }
+  const elapsedMs = now - roundStart;
+  const remainingMs = LINUX_SHARED_STARTUP_DEADLINE_MS - elapsedMs;
+  if (remainingMs <= LINUX_FALLBACK_RESERVE_MS) return 0;
+  return Math.min(LINUX_CDN_LEG_TIMEOUT_MS, remainingMs - LINUX_FALLBACK_RESERVE_MS);
 }
 
 const log = createLogger('agent-binaries');
@@ -410,16 +443,27 @@ async function prepareViaCdn(
   // 创建起算,排队期间预算就在流逝,排到队首时可能已耗尽 → 没试 CDN 就被迫
   // 回落官方源。factory 只在传输层首个 progress 事件才发 'downloading',
   // 用它作为预算计时起点。mac/win 不启用(没有 runtime fallback,不能让
-  // 180s 预算中止它们的传输)。
+  // 预算中止它们的传输)。
+  // 预算长度 = min(180s 上限, 共享 deadline 剩余 − 1 分钟 fallback 预留);
+  // 剩余不足预留时跳过 CDN 腿(早退),把剩余时间全部留给 fallback 作最终
+  // 判决——不能先空跑一段 CDN 再把它烧掉。
+  let cdnBudgetMs = LINUX_CDN_LEG_TIMEOUT_MS;
+  if (linuxCdnBudget) {
+    const budgetMs = linuxCdnBudgetForSignal(opts.signal);
+    if (budgetMs <= 0) {
+      return { ready: false, error: 'cdn_budget_exhausted', downloaded: false };
+    }
+    cdnBudgetMs = budgetMs;
+  }
   const cdnBudget = linuxCdnBudget ? new AbortController() : null;
   let budgetTimer: ReturnType<typeof setTimeout> | null = null;
   const startCdnBudget = (): void => {
     if (!cdnBudget || budgetTimer) return;
-    budgetTimer = setTimeout(() => cdnBudget.abort(), LINUX_CDN_LEG_TIMEOUT_MS);
+    budgetTimer = setTimeout(() => cdnBudget.abort(), cdnBudgetMs);
   };
   // 共享启动 deadline(opts.signal)与 CDN 预算(Linux only)任一触发即中止:
   // 共享 deadline 保证整段启动仍严格受 5 分钟预算约束;CDN 预算保证单段
-  // CDN 传输不吞掉全部共享预算(留 ≥2 分钟给 fallback 作最终判决)。
+  // CDN 传输不吞掉全部共享预算(每段开始前重新计算,始终预留 1 分钟)。
   const effectiveSignal = cdnBudget
     ? opts.signal
       ? AbortSignal.any([opts.signal, cdnBudget.signal])

--- a/apps/desktop/src/main/agent-binaries/index.ts
+++ b/apps/desktop/src/main/agent-binaries/index.ts
@@ -79,8 +79,14 @@ let peekManifestProbe: Promise<Manifest | null> | null = null;
  */
 let skipCdnUntilNextProbeSuccess = false;
 
+/** 本轮首个 peek 探测的发起点(用于 CDN 预算的轮次起点,含 Phase 0 探测耗时)。 */
+let lastPeekProbeStartMs = 0;
+
 function probeManifestForPeek(): Promise<Manifest | null> {
   if (peekManifestProbe) return peekManifestProbe;
+  // 新一轮的首个探测:记录轮次起点(共享 deadline 从 bootstrap 创建 signal
+  // 起就在流逝,peek 起点比 prepare 起点更接近 signal 创建时刻)。
+  lastPeekProbeStartMs = Date.now();
   const probe = fetchManifest(LINUX_PEEK_MANIFEST_PROBE_TIMEOUT_MS).then(
     (manifest) => {
       skipCdnUntilNextProbeSuccess = manifest === null;
@@ -118,8 +124,10 @@ function linuxCdnBudgetForSignal(sharedSignal: AbortSignal | undefined): number 
   const now = Date.now();
   let roundStart = linuxRoundStartBySignal.get(sharedSignal);
   if (roundStart === undefined) {
-    linuxRoundStartBySignal.set(sharedSignal, now);
-    roundStart = now;
+    // 优先用本轮首个 peek 探测的发起点(含 Phase 0 探测耗时,比 prepare
+    // 起点更接近 signal 创建时刻);没有 peek(直接 prepare 的路径)才用 now。
+    roundStart = lastPeekProbeStartMs > 0 ? lastPeekProbeStartMs : now;
+    linuxRoundStartBySignal.set(sharedSignal, roundStart);
   }
   const elapsedMs = now - roundStart;
   const remainingMs = LINUX_SHARED_STARTUP_DEADLINE_MS - elapsedMs;
@@ -338,6 +346,9 @@ export async function prepare(
     // 本轮 peek 探测失败(离线 / endpoint 不可达)→ 跳过 CDN 腿,直接
     // fallback:离线且本地已有 runtime 的首启不再为两个 vendor 白等
     // 2×30s 的 manifest 拉取。下一轮 peek 成功自动恢复 CDN 腿。
+    // 例外:peek 与 prepare 之间缓存里已出现 manifest(并发启动 updater
+    // 可能已拉取并缓存)→ 清标记走 CDN,CDN 资产可用时不该被旧标记跳过。
+    if (getCachedManifest()) skipCdnUntilNextProbeSuccess = false;
     const cdnSkipped = skipCdnUntilNextProbeSuccess;
     // CDN 腿的信号与预算在 prepareViaCdn 内构造(预算从传输真正开始计起,
     // 排队等待不计入,见该函数注释)。CDN 链任何异常(含磁盘错误级)都是降级
@@ -584,7 +595,13 @@ export async function peekNeedsDownload(kind: AgentBinaryKind): Promise<boolean>
   // pi 各平台统一走 manifest peek(可选资产:manifest 缺字段 → false)。
   if (process.platform === 'linux' && kind !== 'pi') {
     let manifest = getCachedManifest();
-    if (!manifest) manifest = await probeManifestForPeek();
+    if (manifest) {
+      // 缓存里已有 manifest(如并发启动 updater 已拉取并缓存):探测失败
+      // 标记立即作废——CDN 资产已可用,不能让 prepare 因旧标记跳过 CDN 腿。
+      skipCdnUntilNextProbeSuccess = false;
+    } else {
+      manifest = await probeManifestForPeek();
+    }
     if (manifest && getVendorAsset(manifest, CONFIG[kind].manifestField)) {
       return getBase(kind).peekNeedsDownload();
     }

--- a/apps/desktop/src/main/agent-binaries/index.ts
+++ b/apps/desktop/src/main/agent-binaries/index.ts
@@ -37,12 +37,46 @@ import {
   prepareLinuxRuntimeFallback,
 } from './linux-runtime-fallback.js';
 import { getVendorAsset } from './manifest.js';
-import { fetchManifest, getCachedManifest, getPlatformKey } from '../manifestService.js';
+import {
+  fetchManifest,
+  getCachedManifest,
+  getPlatformKey,
+  type Manifest,
+} from '../manifestService.js';
 import { ProgressNormalizer } from '../updateProgressNormalizer.js';
 import { createLogger } from '../logger.js';
 
 /** CDN 腿预算(毫秒):manifest 拉取 30s + 下载重试 10s × 5,90s 内必分出结果。 */
 const LINUX_CDN_LEG_TIMEOUT_MS = 90_000;
+
+/** peek 的 manifest 探测超时(毫秒):离线首启时不能为「猜进度标签」白等 30s×2。 */
+const LINUX_PEEK_MANIFEST_PROBE_TIMEOUT_MS = 3_000;
+
+/**
+ * peek 阶段跨 vendor 的单次 manifest 探测(single-flight + 结果 memo)。
+ * 两个 vendor 的 peek 串行调用只发一次短超时请求;失败 memo 住(负缓存),
+ * 本轮 splash 内不再重试——offline 首启因此只损失一个 3s 探测,而不是
+ * 2 × 30s。真正需要 manifest 的 prepare 会用自己的信号与超时再拉。
+ */
+let peekManifestProbe: Promise<Manifest | null> | null = null;
+let peekManifestProbeFailed = false;
+
+function probeManifestForPeek(): Promise<Manifest | null> {
+  if (peekManifestProbeFailed) return Promise.resolve(null);
+  if (peekManifestProbe) return peekManifestProbe;
+  const probe = fetchManifest(LINUX_PEEK_MANIFEST_PROBE_TIMEOUT_MS).then(
+    (manifest) => {
+      if (!manifest) peekManifestProbeFailed = true; // 负缓存:本轮不再重试
+      return manifest;
+    },
+    () => {
+      peekManifestProbeFailed = true;
+      return null;
+    },
+  );
+  peekManifestProbe = probe;
+  return probe;
+}
 
 const log = createLogger('agent-binaries');
 
@@ -442,20 +476,14 @@ export async function peekNeedsDownload(kind: AgentBinaryKind): Promise<boolean>
   if (!app.isPackaged) return false;
   // Linux(cc/codex):manifest 有段 → 走通用 CDN peek(与 mac/win 同口径);
   // 无段(旧 canary / 首发渠道)→ 只看私有 fallback 是否已就位(fs 快查)。
-  // peek 时 manifest 未缓存则拉一次(与 prepare 同判据,避免 peek 判「无需
-  // 下载」而 prepare 随后发现 CDN 资产、进度事件漏 step/totalSteps 标签);
-  // 拉取失败按无段处理,落到 fs 快查,不阻塞 splash。PATH 与版本探测统一
-  // 留给可取消的 async prepare。
+  // peek 时 manifest 未缓存则做一次跨 vendor 的短超时探测(3s,single-flight +
+  // 失败负缓存),与 prepare 判据对齐又不拖慢离线首启:两个 vendor 的 peek
+  // 串行调用共享同一探测,offline 首启只损失 3s 而非 2×30s。
+  // PATH 与版本探测统一留给可取消的 async prepare。
   // pi 各平台统一走 manifest peek(可选资产:manifest 缺字段 → false)。
   if (process.platform === 'linux' && kind !== 'pi') {
     let manifest = getCachedManifest();
-    if (!manifest) {
-      try {
-        manifest = await fetchManifest(undefined, undefined);
-      } catch {
-        manifest = null; // 拉取失败按无段处理,落到 fs 快查
-      }
-    }
+    if (!manifest) manifest = await probeManifestForPeek();
     if (manifest && getVendorAsset(manifest, CONFIG[kind].manifestField)) {
       return getBase(kind).peekNeedsDownload();
     }

--- a/apps/desktop/src/main/agent-binaries/index.ts
+++ b/apps/desktop/src/main/agent-binaries/index.ts
@@ -298,20 +298,12 @@ export async function prepare(
   // pi 例外:没有官方 CLI fallback 链,Linux 也走下方通用 manifest 路径
   // (manifest 缺 pi 字段 → asset_missing 快速失败,由调用方降级)。
   if (process.platform === 'linux' && app.isPackaged && kind !== 'pi') {
-    // CDN 腿的信号 = 调用方共享 deadline + 自身 180s 上限,两者任一触发即中止:
-    // - 自身 180s 上限保证 CDN 腿单段不会耗尽 5 分钟共享预算(留 ≥2 分钟给
-    //   fallback 作最终判决),有进展的慢速下载也有 3 分钟窗口;
-    // - 调用方共享 deadline 保证前一 vendor 的慢 fallback 若已耗尽启动预算,
-    //   本 vendor 的 CDN 腿立即中止、不越过共享 deadline 再拖 3 分钟——
-    //   check-environment 仍严格受 5 分钟共享预算约束。
-    // CDN 链任何异常(含磁盘错误级)都是降级第一环的信号:吞掉走 fallback,
-    // 绝不让 CDN 尝试本身变成 splash 失败原因。
-    const cdnSignal = opts.signal
-      ? AbortSignal.any([opts.signal, AbortSignal.timeout(LINUX_CDN_LEG_TIMEOUT_MS)])
-      : AbortSignal.timeout(LINUX_CDN_LEG_TIMEOUT_MS);
+    // CDN 腿的信号与预算在 prepareViaCdn 内构造(预算从传输真正开始计起,
+    // 排队等待不计入,见该函数注释)。CDN 链任何异常(含磁盘错误级)都是降级
+    // 第一环的信号:吞掉走 fallback,绝不让 CDN 尝试本身变成 splash 失败原因。
     let cdnResult: PrepareResult;
     try {
-      cdnResult = await prepareViaCdn(kind, { ...opts, signal: cdnSignal }, {
+      cdnResult = await prepareViaCdn(kind, opts, {
         broadcastProgress,
         broadcastFailure: false,
       });
@@ -413,6 +405,23 @@ async function prepareViaCdn(
   let lastSpeed: string | undefined;
   let didDownload = false;
 
+  // CDN 腿预算从「传输真正开始」计起,排队等待不计入:单槽 FIFO 下载器可能被
+  // 启动期 app 更新(.deb,百 MB 级)占住,若预算从信号创建起算,排队期间预算就
+  // 在流逝,排到队首时可能已耗尽 → 没试 CDN 就被迫回落官方源。factory 只在
+  // 传输层首个 progress 事件才发 'downloading',用它作为预算计时起点。
+  const cdnBudget = new AbortController();
+  let budgetTimer: ReturnType<typeof setTimeout> | null = null;
+  const startCdnBudget = (): void => {
+    if (budgetTimer) return;
+    budgetTimer = setTimeout(() => cdnBudget.abort(), LINUX_CDN_LEG_TIMEOUT_MS);
+  };
+  // 共享启动 deadline(opts.signal)与 CDN 预算任一触发即中止:共享 deadline
+  // 保证整段启动仍严格受 5 分钟预算约束;CDN 预算保证单段 CDN 传输不吞掉
+  // 全部共享预算(留 ≥2 分钟给 fallback 作最终判决)。
+  const effectiveSignal = opts.signal
+    ? AbortSignal.any([opts.signal, cdnBudget.signal])
+    : cdnBudget.signal;
+
   const normalizer = new ProgressNormalizer({
     onIpc: (progress) => {
       broadcastBinaryDownloadProgress({
@@ -427,63 +436,70 @@ async function prepareViaCdn(
     },
   });
 
-  const result = await base.prepare({
-    signal: opts.signal,
-    onProgress: (p: VendorRuntimeState) => {
-      if (p.status === 'downloading') didDownload = true;
-      if (p.downloadProgress) {
-        lastReceived = p.downloadProgress.received;
-        lastTotal = p.downloadProgress.total;
-        lastSpeed = p.downloadProgress.speedBps > 0
-          ? `${formatBytes(p.downloadProgress.speedBps)}/s`
-          : undefined;
-        normalizer.handle({
-          loaded: lastReceived,
-          total: lastTotal > 0 ? lastTotal : null,
-          percent: lastTotal > 0 ? (lastReceived / lastTotal) * 100 : null,
-          speedBps: p.downloadProgress.speedBps,
-        });
-      }
-      // 初始 0% 广播 (首次进入 downloading 状态时, lastReceived 还是 0)
-      if (p.status === 'downloading' && lastReceived === 0) {
+  try {
+    const result = await base.prepare({
+      signal: effectiveSignal,
+      onProgress: (p: VendorRuntimeState) => {
+        if (p.status === 'downloading') {
+          didDownload = true;
+          startCdnBudget();
+        }
+        if (p.downloadProgress) {
+          lastReceived = p.downloadProgress.received;
+          lastTotal = p.downloadProgress.total;
+          lastSpeed = p.downloadProgress.speedBps > 0
+            ? `${formatBytes(p.downloadProgress.speedBps)}/s`
+            : undefined;
+          normalizer.handle({
+            loaded: lastReceived,
+            total: lastTotal > 0 ? lastTotal : null,
+            percent: lastTotal > 0 ? (lastReceived / lastTotal) * 100 : null,
+            speedBps: p.downloadProgress.speedBps,
+          });
+        }
+        // 初始 0% 广播 (首次进入 downloading 状态时, lastReceived 还是 0)
+        if (p.status === 'downloading' && lastReceived === 0) {
+          broadcastBinaryDownloadProgress({
+            progress: 0,
+            total: lastTotal > 0 ? formatBytes(lastTotal) : undefined,
+            step,
+            totalSteps,
+            vendor: cfg.vendorTag,
+          });
+        }
+      },
+    });
+
+    if (result.ready) {
+      if (didDownload) {
+        normalizer.flush();
         broadcastBinaryDownloadProgress({
-          progress: 0,
+          progress: 100,
+          downloaded: lastReceived > 0 ? formatBytes(lastReceived) : undefined,
           total: lastTotal > 0 ? formatBytes(lastTotal) : undefined,
           step,
           totalSteps,
           vendor: cfg.vendorTag,
         });
       }
-    },
-  });
+      lastReadyPath.set(kind, result.binaryPath);
+      return { ready: true, path: result.binaryPath, downloaded: didDownload };
+    }
 
-  if (result.ready) {
-    if (didDownload) {
-      normalizer.flush();
+    if (broadcastFailure) {
       broadcastBinaryDownloadProgress({
-        progress: 100,
-        downloaded: lastReceived > 0 ? formatBytes(lastReceived) : undefined,
-        total: lastTotal > 0 ? formatBytes(lastTotal) : undefined,
+        progress: normalizer.getCurrent(),
+        failed: true,
+        error: result.error ?? 'unknown',
         step,
         totalSteps,
         vendor: cfg.vendorTag,
       });
     }
-    lastReadyPath.set(kind, result.binaryPath);
-    return { ready: true, path: result.binaryPath, downloaded: didDownload };
+    return { ready: false, error: result.error ?? 'unknown', downloaded: didDownload };
+  } finally {
+    if (budgetTimer) clearTimeout(budgetTimer);
   }
-
-  if (broadcastFailure) {
-    broadcastBinaryDownloadProgress({
-      progress: normalizer.getCurrent(),
-      failed: true,
-      error: result.error ?? 'unknown',
-      step,
-      totalSteps,
-      vendor: cfg.vendorTag,
-    });
-  }
-  return { ready: false, error: result.error ?? 'unknown', downloaded: didDownload };
 }
 
 // ── splash 顺序检查 helpers ──────────────────────────────────────────────────

--- a/apps/desktop/src/main/agent-binaries/index.ts
+++ b/apps/desktop/src/main/agent-binaries/index.ts
@@ -306,6 +306,7 @@ export async function prepare(
       cdnResult = await prepareViaCdn(kind, opts, {
         broadcastProgress,
         broadcastFailure: false,
+        linuxCdnBudget: true,
       });
     } catch (err) {
       log.warn(`CDN chain failed, falling back to linux runtime fallback: ${String((err as Error)?.message ?? err)}`);
@@ -371,19 +372,28 @@ export async function prepare(
     }
   }
 
-  return prepareViaCdn(kind, opts, { broadcastProgress, broadcastFailure });
+  return prepareViaCdn(kind, opts, { broadcastProgress, broadcastFailure, linuxCdnBudget: false });
 }
 
 /**
  * 通用 CDN 供给链(与 mac/win 同链):读 manifest 段 → 下载 → SHA-256 校验。
  * Linux 上也作为首选链调用;失败由调用方决定是否回落 runtime fallback。
  * broadcastFailure 允许调用方关掉失败广播(降级链的第一环不该让 splash
- * 短暂闪烁失败态)。
+ * 短暂闪烁失败态)。linuxCdnBudget 只在 packaged Linux 分支传 true——
+ * mac/win 没有 runtime fallback,不能让 180s 惰性预算中止它们的传输。
  */
 async function prepareViaCdn(
   kind: AgentBinaryKind,
   opts: PrepareOpts,
-  { broadcastProgress, broadcastFailure }: { broadcastProgress: boolean; broadcastFailure: boolean },
+  {
+    broadcastProgress,
+    broadcastFailure,
+    linuxCdnBudget,
+  }: {
+    broadcastProgress: boolean;
+    broadcastFailure: boolean;
+    linuxCdnBudget: boolean;
+  },
 ): Promise<PrepareResult> {
   const cfg = CONFIG[kind];
   const { step, totalSteps } = opts;
@@ -405,22 +415,26 @@ async function prepareViaCdn(
   let lastSpeed: string | undefined;
   let didDownload = false;
 
-  // CDN 腿预算从「传输真正开始」计起,排队等待不计入:单槽 FIFO 下载器可能被
-  // 启动期 app 更新(.deb,百 MB 级)占住,若预算从信号创建起算,排队期间预算就
-  // 在流逝,排到队首时可能已耗尽 → 没试 CDN 就被迫回落官方源。factory 只在
-  // 传输层首个 progress 事件才发 'downloading',用它作为预算计时起点。
-  const cdnBudget = new AbortController();
+  // CDN 腿预算(仅 packaged Linux)从「传输真正开始」计起,排队等待不计入:
+  // 单槽 FIFO 下载器可能被启动期 app 更新(.deb,百 MB 级)占住,若预算从信号
+  // 创建起算,排队期间预算就在流逝,排到队首时可能已耗尽 → 没试 CDN 就被迫
+  // 回落官方源。factory 只在传输层首个 progress 事件才发 'downloading',
+  // 用它作为预算计时起点。mac/win 不启用(没有 runtime fallback,不能让
+  // 180s 预算中止它们的传输)。
+  const cdnBudget = linuxCdnBudget ? new AbortController() : null;
   let budgetTimer: ReturnType<typeof setTimeout> | null = null;
   const startCdnBudget = (): void => {
-    if (budgetTimer) return;
+    if (!cdnBudget || budgetTimer) return;
     budgetTimer = setTimeout(() => cdnBudget.abort(), LINUX_CDN_LEG_TIMEOUT_MS);
   };
-  // 共享启动 deadline(opts.signal)与 CDN 预算任一触发即中止:共享 deadline
-  // 保证整段启动仍严格受 5 分钟预算约束;CDN 预算保证单段 CDN 传输不吞掉
-  // 全部共享预算(留 ≥2 分钟给 fallback 作最终判决)。
-  const effectiveSignal = opts.signal
-    ? AbortSignal.any([opts.signal, cdnBudget.signal])
-    : cdnBudget.signal;
+  // 共享启动 deadline(opts.signal)与 CDN 预算(Linux only)任一触发即中止:
+  // 共享 deadline 保证整段启动仍严格受 5 分钟预算约束;CDN 预算保证单段
+  // CDN 传输不吞掉全部共享预算(留 ≥2 分钟给 fallback 作最终判决)。
+  const effectiveSignal = cdnBudget
+    ? opts.signal
+      ? AbortSignal.any([opts.signal, cdnBudget.signal])
+      : cdnBudget.signal
+    : opts.signal;
 
   const normalizer = new ProgressNormalizer({
     onIpc: (progress) => {

--- a/apps/desktop/src/main/agent-binaries/index.ts
+++ b/apps/desktop/src/main/agent-binaries/index.ts
@@ -37,8 +37,15 @@ import {
   prepareLinuxRuntimeFallback,
 } from './linux-runtime-fallback.js';
 import { getVendorAsset } from './manifest.js';
-import { getCachedManifest, getPlatformKey } from '../manifestService.js';
+import { fetchManifest, getCachedManifest, getPlatformKey } from '../manifestService.js';
 import { ProgressNormalizer } from '../updateProgressNormalizer.js';
+import { createLogger } from '../logger.js';
+
+/** CDN 腿预算(毫秒):manifest 拉取 30s + 下载重试 10s × 5,90s 内必分出结果。 */
+const LINUX_CDN_LEG_TIMEOUT_MS = 90_000;
+
+const log = createLogger('agent-binaries');
+
 import type {
   BinaryProvisioner,
   BinaryDownloadProgressPayload,
@@ -242,19 +249,23 @@ export async function prepare(
   // pi 例外:没有官方 CLI fallback 链,Linux 也走下方通用 manifest 路径
   // (manifest 缺 pi 字段 → asset_missing 快速失败,由调用方降级)。
   if (process.platform === 'linux' && app.isPackaged && kind !== 'pi') {
+    // CDN 腿用独立更短预算:共享的启动 deadline(opts.signal)要留给 fallback
+    // 作最终判决。若 CDN 拖满共享信号,fallback 会拿到已 abort 的 signal
+    // 立即失败,官方源兜底名存实亡。CDN 预算覆盖 manifest 拉取(30s)+
+    // 下载重试(10s 超时 × 5 次),90s 内必分出结果。
+    const cdnSignal = opts.signal
+      ? AbortSignal.any([opts.signal, AbortSignal.timeout(LINUX_CDN_LEG_TIMEOUT_MS)])
+      : AbortSignal.timeout(LINUX_CDN_LEG_TIMEOUT_MS);
     // CDN 链任何异常(含磁盘错误级)都是降级第一环的信号:吞掉走 fallback,
     // 绝不让 CDN 尝试本身变成 splash 失败原因。
     let cdnResult: PrepareResult;
     try {
-      cdnResult = await prepareViaCdn(kind, opts, {
+      cdnResult = await prepareViaCdn(kind, { ...opts, signal: cdnSignal }, {
         broadcastProgress,
         broadcastFailure: false,
       });
     } catch (err) {
-      console.warn(
-        `[agent-binaries/${kind}] CDN chain failed, falling back to linux runtime fallback:`,
-        err,
-      );
+      log.warn(`CDN chain failed, falling back to linux runtime fallback: ${String((err as Error)?.message ?? err)}`);
       cdnResult = { ready: false, error: 'cdn_chain_error', downloaded: false };
     }
     if (cdnResult.ready) return cdnResult;
@@ -430,12 +441,22 @@ export async function peekNeedsDownload(kind: AgentBinaryKind): Promise<boolean>
   // dev 模式永不下载 (findDevBinary 命中 / 缺失都不走 OSS)
   if (!app.isPackaged) return false;
   // Linux(cc/codex):manifest 有段 → 走通用 CDN peek(与 mac/win 同口径);
-  // 无段(旧 canary / 首发渠道)→ 只看私有 fallback 是否已就位(纯内存/fs 快查,
-  // 不发网络;PATH 与版本探测统一留给可取消的 async prepare,避免 splash 前阻塞)。
+  // 无段(旧 canary / 首发渠道)→ 只看私有 fallback 是否已就位(fs 快查)。
+  // peek 时 manifest 未缓存则拉一次(与 prepare 同判据,避免 peek 判「无需
+  // 下载」而 prepare 随后发现 CDN 资产、进度事件漏 step/totalSteps 标签);
+  // 拉取失败按无段处理,落到 fs 快查,不阻塞 splash。PATH 与版本探测统一
+  // 留给可取消的 async prepare。
   // pi 各平台统一走 manifest peek(可选资产:manifest 缺字段 → false)。
   if (process.platform === 'linux' && kind !== 'pi') {
-    const cached = getCachedManifest();
-    if (cached && getVendorAsset(cached, CONFIG[kind].manifestField)) {
+    let manifest = getCachedManifest();
+    if (!manifest) {
+      try {
+        manifest = await fetchManifest(undefined, undefined);
+      } catch {
+        manifest = null; // 拉取失败按无段处理,落到 fs 快查
+      }
+    }
+    if (manifest && getVendorAsset(manifest, CONFIG[kind].manifestField)) {
       return getBase(kind).peekNeedsDownload();
     }
     return findCachedLinuxRuntimeFallbackBinary(kind) === null;

--- a/apps/desktop/src/main/agent-binaries/index.ts
+++ b/apps/desktop/src/main/agent-binaries/index.ts
@@ -298,18 +298,17 @@ export async function prepare(
   // pi 例外:没有官方 CLI fallback 链,Linux 也走下方通用 manifest 路径
   // (manifest 缺 pi 字段 → asset_missing 快速失败,由调用方降级)。
   if (process.platform === 'linux' && app.isPackaged && kind !== 'pi') {
-    // CDN 腿用独立预算,不接共享启动 deadline(opts.signal):
-    // - 共享 deadline 全部留给 fallback 作最终判决(它才是慢路径,官方源
-    //   下载可能要几分钟)
-    // - CDN 腿若挂在共享信号上,前一 vendor 的慢 fallback 耗尽 deadline 后,
-    //   本 vendor 的 CDN 腿会带着已中止的信号立即失败,再传已中止信号给
-    //   fallback → 必然 install cancelled;独立预算下 CDN 腿仍可在自己
-    //   的 180s 窗口内完成慢速但有进展的下载
-    // - 每段仍独立有界(CDN 180s / fallback 共享 deadline / fallback 内部
-    //   5min),不存在无界增长
+    // CDN 腿的信号 = 调用方共享 deadline + 自身 180s 上限,两者任一触发即中止:
+    // - 自身 180s 上限保证 CDN 腿单段不会耗尽 5 分钟共享预算(留 ≥2 分钟给
+    //   fallback 作最终判决),有进展的慢速下载也有 3 分钟窗口;
+    // - 调用方共享 deadline 保证前一 vendor 的慢 fallback 若已耗尽启动预算,
+    //   本 vendor 的 CDN 腿立即中止、不越过共享 deadline 再拖 3 分钟——
+    //   check-environment 仍严格受 5 分钟共享预算约束。
     // CDN 链任何异常(含磁盘错误级)都是降级第一环的信号:吞掉走 fallback,
     // 绝不让 CDN 尝试本身变成 splash 失败原因。
-    const cdnSignal = AbortSignal.timeout(LINUX_CDN_LEG_TIMEOUT_MS);
+    const cdnSignal = opts.signal
+      ? AbortSignal.any([opts.signal, AbortSignal.timeout(LINUX_CDN_LEG_TIMEOUT_MS)])
+      : AbortSignal.timeout(LINUX_CDN_LEG_TIMEOUT_MS);
     let cdnResult: PrepareResult;
     try {
       cdnResult = await prepareViaCdn(kind, { ...opts, signal: cdnSignal }, {

--- a/apps/desktop/src/main/agent-binaries/index.ts
+++ b/apps/desktop/src/main/agent-binaries/index.ts
@@ -484,22 +484,24 @@ async function prepareViaCdn(
   // 回落官方源。factory 只在传输层首个 progress 事件才发 'downloading',
   // 用它作为预算计时起点。mac/win 不启用(没有 runtime fallback,不能让
   // 预算中止它们的传输)。
-  // 预算长度 = min(180s 上限, 共享 deadline 剩余 − 1 分钟 fallback 预留);
-  // 剩余不足预留时跳过 CDN 腿(早退),把剩余时间全部留给 fallback 作最终
-  // 判决——不能先空跑一段 CDN 再把它烧掉。
-  let cdnBudgetMs = LINUX_CDN_LEG_TIMEOUT_MS;
-  if (linuxCdnBudget) {
-    const budgetMs = linuxCdnBudgetForSignal(opts.signal);
-    if (budgetMs <= 0) {
-      return { ready: false, error: 'cdn_budget_exhausted', downloaded: false };
-    }
-    cdnBudgetMs = budgetMs;
+  // 入口早退:此刻共享 deadline 剩余已不足预留 → 跳过 CDN 腿,把剩余时间
+  // 全部留给 fallback 作最终判决(不能先空跑一段 CDN 再把它烧掉)。
+  if (linuxCdnBudget && linuxCdnBudgetForSignal(opts.signal) <= 0) {
+    return { ready: false, error: 'cdn_budget_exhausted', downloaded: false };
   }
   const cdnBudget = linuxCdnBudget ? new AbortController() : null;
   let budgetTimer: ReturnType<typeof setTimeout> | null = null;
   const startCdnBudget = (): void => {
     if (!cdnBudget || budgetTimer) return;
-    budgetTimer = setTimeout(() => cdnBudget.abort(), cdnBudgetMs);
+    // 传输真正开始的时刻重新按共享 deadline 剩余计算:manifest 拉取与
+    // FIFO 排队期间共享 deadline 已在流逝,入口时的预算值已陈旧,固定值
+    // 会让 CDN 吃掉本应留给 fallback 的预留。剩余不足预留 → 立即中止。
+    const budgetMs = linuxCdnBudgetForSignal(opts.signal);
+    if (budgetMs <= 0) {
+      cdnBudget.abort();
+      return;
+    }
+    budgetTimer = setTimeout(() => cdnBudget.abort(), budgetMs);
   };
   // 共享启动 deadline(opts.signal)与 CDN 预算(Linux only)任一触发即中止:
   // 共享 deadline 保证整段启动仍严格受 5 分钟预算约束;CDN 预算保证单段

--- a/apps/desktop/src/main/agent-binaries/index.ts
+++ b/apps/desktop/src/main/agent-binaries/index.ts
@@ -56,41 +56,28 @@ const LINUX_CDN_LEG_TIMEOUT_MS = 180_000;
 /** peek 的 manifest 探测超时(毫秒):离线首启时不能为「猜进度标签」白等 30s×2。 */
 const LINUX_PEEK_MANIFEST_PROBE_TIMEOUT_MS = 3_000;
 
-/** 探测失败的负缓存 TTL:同轮 splash 内不再重试,跨轮重试(>60s)自然恢复。 */
-const LINUX_PEEK_MANIFEST_NEGATIVE_CACHE_TTL_MS = 60_000;
-
 /**
- * peek 阶段跨 vendor 的单次 manifest 探测(single-flight + 失败负缓存)。
- * 两个 vendor 的 peek 串行调用只发一次短超时请求;失败负缓存 60s——同轮
- * splash 不再重试(offline 首启只损失一个 3s 探测,而不是 2 × 30s),网络
- * 恢复后的下一轮重试(TTL 过期)会重新探测,进度标签与 prepare 行为对齐。
+ * peek 阶段跨 vendor 的单次 manifest 探测(single-flight,每轮 splash 一次)。
+ * 两个 vendor 的 peek 串行调用共享同一探测(3s 短超时);prepare 开始时
+ * 清空 memo——用户在同一进程内重试(新一轮 check-environment)会重新探测,
+ * 不会因旧的失败 memo 把 vendor 排除出下载清单(进度标签与 prepare 行为
+ * 对齐)。单轮离线成本上界 = 3s(两个 vendor 共享一次探测)。
  */
 let peekManifestProbe: Promise<Manifest | null> | null = null;
-let peekManifestProbeFailedAtMs = 0;
 
 function probeManifestForPeek(): Promise<Manifest | null> {
-  if (peekManifestProbeFailedAtMs) {
-    const elapsed = Date.now() - peekManifestProbeFailedAtMs;
-    if (elapsed < LINUX_PEEK_MANIFEST_NEGATIVE_CACHE_TTL_MS) {
-      return Promise.resolve(null); // 负缓存命中:同轮 splash 不再重试
-    }
-    peekManifestProbeFailedAtMs = 0; // TTL 过期:下一轮重试允许重新探测
-  }
   if (peekManifestProbe) return peekManifestProbe;
   const probe = fetchManifest(LINUX_PEEK_MANIFEST_PROBE_TIMEOUT_MS).then(
-    (manifest) => {
-      peekManifestProbe = null; // 探测已结束,下一轮可重发
-      if (!manifest) peekManifestProbeFailedAtMs = Date.now();
-      return manifest;
-    },
-    () => {
-      peekManifestProbe = null;
-      peekManifestProbeFailedAtMs = Date.now();
-      return null;
-    },
+    (manifest) => manifest,
+    () => null,
   );
   peekManifestProbe = probe;
   return probe;
+}
+
+/** 新一轮 check-environment 开始时清空 peek 探测 memo(peek 先于 prepare)。 */
+function resetPeekManifestProbe(): void {
+  peekManifestProbe = null;
 }
 
 const log = createLogger('agent-binaries');
@@ -298,6 +285,9 @@ export async function prepare(
   // pi 例外:没有官方 CLI fallback 链,Linux 也走下方通用 manifest 路径
   // (manifest 缺 pi 字段 → asset_missing 快速失败,由调用方降级)。
   if (process.platform === 'linux' && app.isPackaged && kind !== 'pi') {
+    // 新一轮 check-environment 开始(Phase 0 peek 已全部完成):清空 peek
+    // 探测 memo,下一轮重试的 peek 会重新探测 manifest。
+    resetPeekManifestProbe();
     // CDN 腿的信号与预算在 prepareViaCdn 内构造(预算从传输真正开始计起,
     // 排队等待不计入,见该函数注释)。CDN 链任何异常(含磁盘错误级)都是降级
     // 第一环的信号:吞掉走 fallback,绝不让 CDN 尝试本身变成 splash 失败原因。

--- a/apps/desktop/src/main/agent-binaries/index.ts
+++ b/apps/desktop/src/main/agent-binaries/index.ts
@@ -19,8 +19,9 @@
  *   - 基础 BinaryProvisioner 实例懒加载 + 缓存 (createBinaryProvisioner 是工厂, 复用同一份 cached manifest)。
  *   - prepare(kind) 内部:
  *       dev: findDevBinary 短路, 缺失硬错 (开发者必须 git lfs pull / pnpm update:codex)
- *       Linux packaged: PC 已装 CLI / 旧缓存 / userData 私有安装优先; miss 后
- *         直接下载带上游 SHA-256 的官方 pin 资产（不依赖系统 npm/curl/tar）
+ *       Linux packaged: CDN manifest 段优先 (与 mac/win 同链, 国内可达); 资产缺失 /
+ *         拉取 / 下载失败时静默回落 runtime fallback (PC 已装 CLI / 旧缓存 / userData
+ *         私有安装 / 带上游 SHA-256 的官方 pin 资产, 不依赖系统 npm/curl/tar)
  *       other prod: createBinaryProvisioner.prepare() + ProgressNormalizer 节流 + 'binary-download-progress' IPC 广播
  *     opts.broadcastProgress=false 时不接 IPC (lazy 调用路径, 当前 desktop 全是 splash 路径所以默认 true)。
  */
@@ -35,7 +36,8 @@ import {
   findCachedLinuxRuntimeFallbackBinary,
   prepareLinuxRuntimeFallback,
 } from './linux-runtime-fallback.js';
-import { getPlatformKey } from '../manifestService.js';
+import { getVendorAsset } from './manifest.js';
+import { getCachedManifest, getPlatformKey } from '../manifestService.js';
 import { ProgressNormalizer } from '../updateProgressNormalizer.js';
 import type {
   BinaryProvisioner,
@@ -231,13 +233,32 @@ export async function prepare(
     return { ready: false, error: `${kind} dev binary not found for ${getPlatformKey()}`, downloaded: false };
   }
 
-  // ── packaged Linux runtime: 私有安装 / 旧缓存 / PC 已装 / 官方下载 ───────
-  // Linux release manifest 明确不发布 Claude/Codex 资产。这里直接走 runtime
-  // fallback，不能先调 base.prepare()/manifest：离线首装会让 peek + prepare
-  // 重复等待 CDN 超时，fallback 尚未开始 splash 就已经卡住。
+  // ── packaged Linux: CDN manifest 段优先,失败静默回落 runtime fallback ─────
+  // 2026-08 起 Linux 与 mac/win 同链:scripts 侧发版把 claude/codex 资产上传
+  // 区域 CDN 并写进 manifest 段(国内可达)。CDN 链失败(manifest 无段——旧
+  // canary / 首发渠道、拉取失败、下载失败)是预期内的降级第一环,不向 splash
+  // 广播 failed,静默落到 runtime fallback(私有安装 / 旧缓存 / 系统 CLI /
+  // 官方下载)——fallback 才是最终判决。
   // pi 例外:没有官方 CLI fallback 链,Linux 也走下方通用 manifest 路径
   // (manifest 缺 pi 字段 → asset_missing 快速失败,由调用方降级)。
   if (process.platform === 'linux' && app.isPackaged && kind !== 'pi') {
+    // CDN 链任何异常(含磁盘错误级)都是降级第一环的信号:吞掉走 fallback,
+    // 绝不让 CDN 尝试本身变成 splash 失败原因。
+    let cdnResult: PrepareResult;
+    try {
+      cdnResult = await prepareViaCdn(kind, opts, {
+        broadcastProgress,
+        broadcastFailure: false,
+      });
+    } catch (err) {
+      console.warn(
+        `[agent-binaries/${kind}] CDN chain failed, falling back to linux runtime fallback:`,
+        err,
+      );
+      cdnResult = { ready: false, error: 'cdn_chain_error', downloaded: false };
+    }
+    if (cdnResult.ready) return cdnResult;
+
     if (broadcastProgress) {
       broadcastBinaryDownloadProgress({
         progress: 0,
@@ -296,6 +317,22 @@ export async function prepare(
     }
   }
 
+  return prepareViaCdn(kind, opts, { broadcastProgress, broadcastFailure });
+}
+
+/**
+ * 通用 CDN 供给链(与 mac/win 同链):读 manifest 段 → 下载 → SHA-256 校验。
+ * Linux 上也作为首选链调用;失败由调用方决定是否回落 runtime fallback。
+ * broadcastFailure 允许调用方关掉失败广播(降级链的第一环不该让 splash
+ * 短暂闪烁失败态)。
+ */
+async function prepareViaCdn(
+  kind: AgentBinaryKind,
+  opts: PrepareOpts,
+  { broadcastProgress, broadcastFailure }: { broadcastProgress: boolean; broadcastFailure: boolean },
+): Promise<PrepareResult> {
+  const cfg = CONFIG[kind];
+  const { step, totalSteps } = opts;
   const base = getBase(kind);
 
   // ── 不广播 IPC 路径 (lazy 调用, 当前 desktop 不走) ────────────────────────
@@ -392,10 +429,15 @@ export async function prepare(
 export async function peekNeedsDownload(kind: AgentBinaryKind): Promise<boolean> {
   // dev 模式永不下载 (findDevBinary 命中 / 缺失都不走 OSS)
   if (!app.isPackaged) return false;
-  // Linux release 不发布 cc/codex manifest 资产。peek 只做已知私有路径的 fs 快查，
-  // PATH 与版本探测统一留给可取消的 async prepare，避免 splash 前同步阻塞。
+  // Linux(cc/codex):manifest 有段 → 走通用 CDN peek(与 mac/win 同口径);
+  // 无段(旧 canary / 首发渠道)→ 只看私有 fallback 是否已就位(纯内存/fs 快查,
+  // 不发网络;PATH 与版本探测统一留给可取消的 async prepare,避免 splash 前阻塞)。
   // pi 各平台统一走 manifest peek(可选资产:manifest 缺字段 → false)。
   if (process.platform === 'linux' && kind !== 'pi') {
+    const cached = getCachedManifest();
+    if (cached && getVendorAsset(cached, CONFIG[kind].manifestField)) {
+      return getBase(kind).peekNeedsDownload();
+    }
     return findCachedLinuxRuntimeFallbackBinary(kind) === null;
   }
   return getBase(kind).peekNeedsDownload();

--- a/apps/desktop/src/main/agent-binaries/index.ts
+++ b/apps/desktop/src/main/agent-binaries/index.ts
@@ -71,11 +71,25 @@ const LINUX_PEEK_MANIFEST_PROBE_TIMEOUT_MS = 3_000;
  */
 let peekManifestProbe: Promise<Manifest | null> | null = null;
 
+/**
+ * 本轮 peek 探测是否已失败(轮级信号,module 级)。探测失败(离线 / endpoint
+ * 不可达)→ true:本轮的 prepare 跳过 CDN 腿,直接走 fallback——离线且本地
+ * 已有 runtime 的首启不再为两个 vendor 白等 2×30s 的 manifest 拉取。
+ * 下一轮 peek 成功会置回 false,CDN 腿自动恢复。
+ */
+let skipCdnUntilNextProbeSuccess = false;
+
 function probeManifestForPeek(): Promise<Manifest | null> {
   if (peekManifestProbe) return peekManifestProbe;
   const probe = fetchManifest(LINUX_PEEK_MANIFEST_PROBE_TIMEOUT_MS).then(
-    (manifest) => manifest,
-    () => null,
+    (manifest) => {
+      skipCdnUntilNextProbeSuccess = manifest === null;
+      return manifest;
+    },
+    () => {
+      skipCdnUntilNextProbeSuccess = true;
+      return null;
+    },
   );
   peekManifestProbe = probe;
   return probe;
@@ -321,19 +335,25 @@ export async function prepare(
     // 新一轮 check-environment 开始(Phase 0 peek 已全部完成):清空 peek
     // 探测 memo,下一轮重试的 peek 会重新探测 manifest。
     resetPeekManifestProbe();
+    // 本轮 peek 探测失败(离线 / endpoint 不可达)→ 跳过 CDN 腿,直接
+    // fallback:离线且本地已有 runtime 的首启不再为两个 vendor 白等
+    // 2×30s 的 manifest 拉取。下一轮 peek 成功自动恢复 CDN 腿。
+    const cdnSkipped = skipCdnUntilNextProbeSuccess;
     // CDN 腿的信号与预算在 prepareViaCdn 内构造(预算从传输真正开始计起,
     // 排队等待不计入,见该函数注释)。CDN 链任何异常(含磁盘错误级)都是降级
     // 第一环的信号:吞掉走 fallback,绝不让 CDN 尝试本身变成 splash 失败原因。
-    let cdnResult: PrepareResult;
-    try {
-      cdnResult = await prepareViaCdn(kind, opts, {
-        broadcastProgress,
-        broadcastFailure: false,
-        linuxCdnBudget: true,
-      });
-    } catch (err) {
-      log.warn(`CDN chain failed, falling back to linux runtime fallback: ${String((err as Error)?.message ?? err)}`);
-      cdnResult = { ready: false, error: 'cdn_chain_error', downloaded: false };
+    let cdnResult: PrepareResult = { ready: false, error: 'cdn_skipped_probe_failed', downloaded: false };
+    if (!cdnSkipped) {
+      try {
+        cdnResult = await prepareViaCdn(kind, opts, {
+          broadcastProgress,
+          broadcastFailure: false,
+          linuxCdnBudget: true,
+        });
+      } catch (err) {
+        log.warn(`CDN chain failed, falling back to linux runtime fallback: ${String((err as Error)?.message ?? err)}`);
+        cdnResult = { ready: false, error: 'cdn_chain_error', downloaded: false };
+      }
     }
     if (cdnResult.ready) return cdnResult;
 


### PR DESCRIPTION
## 这次改了什么

### 摘要

Linux 桌面包有意不进 claude/codex 二进制,首启由 runtime fallback 直接下载官方资产(downloads.claude.ai / GitHub releases)。CN 网络下官方源 connect 超时,二进制 provision 卡到 startup deadline,splash 无法完成 → 首启白屏约 4 分钟 + maker IPC(注册在 splash 门禁后)全部报 No handler,用户观感就是「装完起不来」。

本 PR 让 Linux 与 mac/win 同链:发版侧(scripts 仓配套 PR)把 claude/codex 资产上传区域 CDN 并写进 manifest 段,客户端 provision 改为 CDN 优先、官方源兜底——国内用户从自家 CDN 拿二进制,不再依赖官方源连通性。

### 变更类型

- [x] `feat` 新功能

### 范围

- 关联 Issue / 需求:无(内部发布链路问题)
- 本 PR 包含:`agent-binaries/index.ts` 的 packaged Linux provision 链改造 + 对应单测重写
- 明确不包含:发布侧(publish-desktop.mjs / job 脚本)改动在 cindy-build-scripts 仓配套分支 `feat/linux-agent-cdn-publish`;Linux 安装包内容不变(二进制仍不进 .deb)
- 用户可见变化:Linux 首启从区域 CDN 下载 agent 二进制,不再白屏卡死;manifest 无段时行为与旧版完全一致
- 是否存在 breaking change:无

### UI 变化

不涉及:纯 main 进程二进制供给逻辑,无界面改动。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop run typecheck
结果:通过

pnpm --dir apps/desktop exec vitest run --pool=threads src/main/__tests__/agentBinaryLinuxPrepare.test.ts
结果:7/7 通过(CDN 命中 / asset_missing 回落 / CDN 链 throw 回落 / signal 透传 / peek 分派)

pnpm --dir apps/desktop exec vitest related --run --pool=threads --maxWorkers=8 --passWithNoTests <本改动相关文件>
结果:3740 passed / 1 skipped,全绿(直接跑同命令两次均通过)
```

已知环境问题(与本改动无关,已做对照实验):
- 本机 `pnpm test:unit:related` 编排层跑 desktop 全量时 vitest 进程在收尾阶段 SIGSEGV;stash 本改动、仅加一行无关改动(logger.ts)跑门禁同样 SIGSEGV,确认是环境问题。CI 将跑完整 `pnpm test:unit`。
- `plugin-publisher/orchestrator.test.ts` 存在基线 flaky(单独跑 3 轮挂 1),与本改动无关。

### 手工验证

不涉及(发布侧配合后才能真机验证,见下)。

### 未执行的验证

Linux 真机首启验证未做:需要 scripts 仓配套分支合并后重打一轮 canary(manifest 才带 agent 段),然后在 cindy-ubuntu 打包机或目标 Ubuntu 上安装 .deb 验证首启走 CDN。待两仓合并后排期验证。

## 风险

### 风险分类

- [x] 协议兼容
- [x] 跨平台差异

### 影响与回滚

- 影响范围:仅 packaged Linux 的 claude/codex provision 路径;mac/win/pi 路径与 manifest 读取语义不变。manifest 新增 claudeCode/codex 段是 append-only 兼容变更——mac/win 客户端与发布脚本早已消费同一字段集,旧 Linux 客户端不读 agent 段、自动忽略,旧端降级行为不变。
- 回滚 / 降级方式:CDN 链失败(manifest 无段/拉取失败/下载失败)静默回落原 runtime fallback,fallback 才是最终判决,行为与旧版完全一致;最坏情况下等于回退到旧行为,无需客户端降级。发布侧若断言拦住首发 Linux 渠道(缺资产 fail closed),可暂以旧 manifest(无 agent 段)继续走纯 fallback。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`)
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节(不涉及 UI 则跳过)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档(代码注释与 PR 说明;README 口径在 scripts 仓配套 PR)
- [x] 已确认测试结果或说明未执行原因
