### PR TITLE
fix(desktop): 修复暂停回复重复持久化

### DIFF
--- a/apps/desktop/src/main/__tests__/makerEventHotPathOrdering.test.ts
+++ b/apps/desktop/src/main/__tests__/makerEventHotPathOrdering.test.ts
@@ -205,7 +205,7 @@ describe('maker:event hot path ordering', () => {
     ).toBeGreaterThan(liveIdleStart);
     expectOrder(
       reconcileSource,
-      'flushAssistantBlock(sessionId, null);',
+      'sealAssistantBlockForLateFinal(sessionId, null);',
       'consumeLastAssistantPersistId(sessionId);',
     );
     expectOrder(
@@ -758,7 +758,7 @@ describe('maker:event hot path ordering', () => {
     expect(reconcileSource).toContain('if (!liveSessionIdle) return false;');
     expect(reconcileSource).not.toContain('if (!trackerStale && !hadZombieInteraction) return false;');
     expect(reconcileSource).toContain('confirmed live session idle during turn-boundary reconciliation');
-    expectOrder(reconcileSource, 'flushAssistantBlock(sessionId, null);', 'consumeLastAssistantPersistId(sessionId);');
+    expectOrder(reconcileSource, 'sealAssistantBlockForLateFinal(sessionId, null);', 'consumeLastAssistantPersistId(sessionId);');
     expectOrder(reconcileSource, 'consumeLastAssistantPersistId(sessionId);', 'consumeLastTopLevelAssistantPersistId(sessionId);');
     expectOrder(reconcileSource, 'consumeLastTopLevelAssistantPersistId(sessionId);', 'markAssistantTurnFailed(sessionId, abortedBoundaryAssistantPersistId)');
     expectOrder(reconcileSource, 'sealLostTerminalPersistState(sessionId);', 'sessionTurnActivityTracker.deleteSession(sessionId);');

--- a/apps/desktop/src/main/__tests__/messagePersistBroadcaster.test.ts
+++ b/apps/desktop/src/main/__tests__/messagePersistBroadcaster.test.ts
@@ -86,6 +86,7 @@ import {
   onInteractionResolved,
   onThinkingEvent,
   flushAssistantBlock,
+  sealAssistantBlockForLateFinal,
   flushOrphanToolResults,
   isSuccessfulCodexDoneEventData,
   onTurnErrorEvent,
@@ -2019,6 +2020,93 @@ describe('assistant isFinal burst DUP-SKIP(P1:main 对称去重,防重复 isFina
     const r2 = onAssistantTextEvent(SESSION, { text: 'X', isFinal: true }, null);
     expect(r2).not.toBe(r1); // 跨 turn 不复用
     await flushWrites();
+    const assistantCreates = (createMessage as unknown as { mock: { calls: unknown[][] } }).mock.calls
+      .filter((c) => (c[1] as { role?: string }).role === 'assistant');
+    expect(assistantCreates).toHaveLength(2);
+  });
+});
+
+describe('stale-idle assistant late final identity', () => {
+  it('reuses the sealed row for the same SDK request after per-turn reset', async () => {
+    const meta = { requestId: 'req-stale-idle', uuid: 'assistant-stale-idle' };
+    const persistId = onAssistantTextEvent(
+      SESSION,
+      { text: 'Cindy 能够理解多轮对', isFinal: false },
+      meta,
+    );
+    sealAssistantBlockForLateFinal(SESSION, null);
+    expect(consumeLastAssistantPersistId(SESSION)).toBe(persistId);
+    expect(consumeLastTopLevelAssistantPersistId(SESSION)).toBe(persistId);
+    resetTurnPersistState(SESSION);
+
+    const lateFinalId = onAssistantTextEvent(
+      SESSION,
+      { text: 'Cindy 能够理解多轮对', isFinal: true, isFullText: true },
+      { ...meta, uuid: 'assistant-late-snapshot', stopReason: 'stop_sequence' },
+    );
+    expect(lateFinalId).toBe(persistId);
+    // The late final must not restore the consumed turn target: a paired done
+    // still belongs to the stale-idle failure seal rather than a new success.
+    expect(consumeLastAssistantPersistId(SESSION)).toBeUndefined();
+    expect(consumeLastTopLevelAssistantPersistId(SESSION)).toBeUndefined();
+
+    await flushWrites();
+    const assistantCreates = (createMessage as unknown as { mock: { calls: unknown[][] } }).mock.calls
+      .filter((c) => (c[1] as { role?: string }).role === 'assistant');
+    expect(assistantCreates).toHaveLength(1);
+    expect(assistantCreates[0]?.[1]).toEqual(
+      expect.objectContaining({ clientId: persistId, content: 'Cindy 能够理解多轮对' }),
+    );
+    expect(updateMessageContent).not.toHaveBeenCalled();
+    expect(patchMessageAgentMetaWithResult).not.toHaveBeenCalled();
+  });
+
+  it('updates the same row when the matching late final supplies a longer snapshot', async () => {
+    const meta = { requestId: 'req-longer-final', uuid: 'assistant-longer-final' };
+    const persistId = onAssistantTextEvent(
+      SESSION,
+      { text: 'partial', isFinal: false },
+      meta,
+    );
+    sealAssistantBlockForLateFinal(SESSION, null);
+    consumeLastAssistantPersistId(SESSION);
+    consumeLastTopLevelAssistantPersistId(SESSION);
+    resetTurnPersistState(SESSION);
+
+    expect(onAssistantTextEvent(
+      SESSION,
+      { text: 'partial output', isFinal: true, isFullText: true },
+      meta,
+    )).toBe(persistId);
+    await flushWrites();
+
+    const assistantCreates = (createMessage as unknown as { mock: { calls: unknown[][] } }).mock.calls
+      .filter((c) => (c[1] as { role?: string }).role === 'assistant');
+    expect(assistantCreates).toHaveLength(1);
+    expect(updateMessageContent).toHaveBeenCalledWith(SESSION, persistId, 'partial output');
+    expect(patchMessageAgentMetaWithResult).not.toHaveBeenCalled();
+    expect(broadcastMessageRow).toHaveBeenCalled();
+  });
+
+  it('keeps identical text from a different SDK request as a separate message', async () => {
+    const firstId = onAssistantTextEvent(
+      SESSION,
+      { text: 'same text', isFinal: false },
+      { requestId: 'req-first', uuid: 'assistant-first' },
+    );
+    sealAssistantBlockForLateFinal(SESSION, null);
+    consumeLastAssistantPersistId(SESSION);
+    consumeLastTopLevelAssistantPersistId(SESSION);
+    resetTurnPersistState(SESSION);
+
+    const secondId = onAssistantTextEvent(
+      SESSION,
+      { text: 'same text', isFinal: true },
+      { requestId: 'req-second', uuid: 'assistant-second' },
+    );
+    expect(secondId).not.toBe(firstId);
+    await flushWrites();
+
     const assistantCreates = (createMessage as unknown as { mock: { calls: unknown[][] } }).mock.calls
       .filter((c) => (c[1] as { role?: string }).role === 'assistant');
     expect(assistantCreates).toHaveLength(2);

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -442,6 +442,7 @@ import {
   onToolResultFullEvent,
   onToolUseEvent,
   preserveTurnPersistStateForBackground,
+  sealAssistantBlockForLateFinal,
   markAutoResumeOutcome,
   onTurnErrorEvent,
   prepareSyntheticToolEventForBroadcast,
@@ -11631,7 +11632,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
   const sealLostTerminalPersistState = (sessionId: string): void => {
     // Same persist boundary as a lost-terminal live-idle reconcile. The next
     // turn on this sessionId must not append to a half-open streaming block.
-    flushAssistantBlock(sessionId, null);
+    sealAssistantBlockForLateFinal(sessionId, null);
     const abortedAssistantPersistId = consumeLastAssistantPersistId(sessionId);
     const abortedBoundaryAssistantPersistId = consumeLastTopLevelAssistantPersistId(sessionId);
     flushOrphanToolResults(sessionId, null);

--- a/apps/desktop/src/main/messagePersistBroadcaster.ts
+++ b/apps/desktop/src/main/messagePersistBroadcaster.ts
@@ -77,6 +77,35 @@ interface AssistantBlock {
 }
 
 const assistantBlocks = new Map<string, AssistantBlock>();
+interface SealedAssistantLateFinalCandidate {
+  persistId: string;
+  text: string;
+  requestId?: string;
+  uuid?: string;
+}
+
+/**
+ * A stale-idle reconcile may persist a half-open block before the SDK's final
+ * snapshot drains. Keep that exact SDK identity outside per-turn reset state so
+ * the late snapshot can update/reuse the same row instead of creating another.
+ */
+const sealedAssistantLateFinalBySession = new Map<string, SealedAssistantLateFinalCandidate>();
+
+function matchesSealedAssistantIdentity(
+  candidate: SealedAssistantLateFinalCandidate,
+  agentMeta: AgentMeta | null,
+): boolean {
+  if (!agentMeta) return false;
+  if (candidate.requestId !== undefined && agentMeta.requestId !== undefined) {
+    return candidate.requestId === agentMeta.requestId;
+  }
+  return (
+    candidate.uuid !== undefined &&
+    agentMeta.uuid !== undefined &&
+    candidate.uuid === agentMeta.uuid
+  );
+}
+
 const clearBoundaryBySession = new Map<string, number>();
 
 export function noteSessionClearBoundary(sessionId: string, clearedAt: string | number | null | undefined): void {
@@ -89,6 +118,7 @@ export function noteSessionClearBoundary(sessionId: string, clearedAt: string | 
   const current = clearBoundaryBySession.get(sessionId);
   if (current === undefined || parsed > current) {
     clearBoundaryBySession.set(sessionId, parsed);
+    sealedAssistantLateFinalBySession.delete(sessionId);
     // A cleared transcript must not be revived by a late terminal update from an
     // older background task. New tool calls repopulate this linkage after the boundary.
     clearAgentTaskPersistState(sessionId);
@@ -1675,6 +1705,42 @@ export function onAssistantTextEvent(
   const isFullText = data.isFullText === true;
 
   if (isFinal) {
+    const visible = stripInternalWebCitations(rawText);
+    const lateFinalCandidate = sealedAssistantLateFinalBySession.get(sessionId);
+    if (
+      lateFinalCandidate &&
+      visible.length > 0 &&
+      matchesSealedAssistantIdentity(lateFinalCandidate, agentMeta) &&
+      (isFullText ||
+        visible === lateFinalCandidate.text ||
+        visible.startsWith(lateFinalCandidate.text))
+    ) {
+      const contentChanged = visible !== lateFinalCandidate.text;
+      if (contentChanged) {
+        const isCandidateCurrent = () =>
+          sealedAssistantLateFinalBySession.get(sessionId) === lateFinalCandidate;
+        enqueueWrite(
+          `assistant_late_final:${sessionId}:${lateFinalCandidate.persistId}`,
+          async (ownerScope) => {
+            if (!isCandidateCurrent()) return;
+            const updated = await updateDbMessageContent(
+              sessionId,
+              lateFinalCandidate.persistId,
+              visible,
+            );
+            if (updated && isCandidateCurrent()) {
+              lateFinalCandidate.text = visible;
+              broadcastMessageRow(sessionId, updated, ownerScope);
+            }
+          },
+        );
+      }
+      // Do not restore the consumed per-turn Assistant ids here. A paired late
+      // done must keep the stale-idle failure seal instead of changing it to a
+      // successful turn merely because its final text snapshot arrived late.
+      return lateFinalCandidate.persistId;
+    }
+
     const block = assistantBlocks.get(sessionId);
     if (block) {
       // 流式确认:不落库,留给边界 flush。显式 isFullText 表示 SDK 权威全文；
@@ -1691,7 +1757,6 @@ export function onAssistantTextEvent(
       return block.persistId;
     }
     // 非流式 isFinal burst(result 兜底补推也走这):无在飞 block,立即落库。
-    const visible = stripInternalWebCitations(rawText);
     if (visible) {
       // DUP-SKIP(对齐 renderer 老 757-762):若紧邻的上一条已落库消息正是内容完全
       // 相同的 assistant(典型:重复 isFinal / block flush 后又来同内容补推),复用其
@@ -1732,15 +1797,46 @@ export function flushAssistantBlock(
   sessionId: string,
   agentMetaFallback: AgentMeta | null = null,
 ): void {
+  flushAssistantBlockInternal(sessionId, agentMetaFallback);
+}
+
+function flushAssistantBlockInternal(
+  sessionId: string,
+  agentMetaFallback: AgentMeta | null,
+): { persistId: string; text: string; agentMeta: AgentMeta | null } | undefined {
   const block = assistantBlocks.get(sessionId);
-  if (!block) return;
+  if (!block) return undefined;
   assistantBlocks.delete(sessionId);
   const visible = stripInternalWebCitations(block.text);
-  if (!visible) return;
+  if (!visible) return undefined;
   // 三级兜底,对齐 renderer 老逻辑:本 block 自带 meta → 边界事件 meta(tool_use/done
   // 同属或携带这条 assistant 的 meta)→ 会话最近一次非空 meta(interaction 边界靠这级)。
   const meta = block.agentMeta ?? agentMetaFallback ?? lastAgentMetaBySession.get(sessionId) ?? null;
   enqueuePersistAssistant(sessionId, block.persistId, visible, meta, block.createdAt);
+  return { persistId: block.persistId, text: visible, agentMeta: meta };
+}
+
+/**
+ * Flush a lost-terminal streaming block while retaining its SDK identity for a
+ * possible late final snapshot. resetTurnPersistState intentionally leaves this
+ * candidate intact; /clear and full session cleanup invalidate it.
+ */
+export function sealAssistantBlockForLateFinal(
+  sessionId: string,
+  agentMetaFallback: AgentMeta | null = null,
+): void {
+  const flushed = flushAssistantBlockInternal(sessionId, agentMetaFallback);
+  if (!flushed) return;
+  sealedAssistantLateFinalBySession.delete(sessionId);
+  const requestId = flushed.agentMeta?.requestId;
+  const uuid = flushed.agentMeta?.uuid;
+  if (!requestId && !uuid) return;
+  sealedAssistantLateFinalBySession.set(sessionId, {
+    persistId: flushed.persistId,
+    text: flushed.text,
+    ...(requestId ? { requestId } : {}),
+    ...(uuid ? { uuid } : {}),
+  });
 }
 
 /**
@@ -1947,6 +2043,7 @@ export function clearCodexPlanRowsForSession(sessionId: string): void {
 export function clearSessionPersistState(sessionId: string): void {
   clearCodexPlanRowsForSession(sessionId);
   assistantBlocks.delete(sessionId);
+  sealedAssistantLateFinalBySession.delete(sessionId);
   backgroundTurnPersistStatesBySession.delete(sessionId);
   lastAgentMetaBySession.delete(sessionId);
   knownToolUseIdsBySession.delete(sessionId);

--- a/packages/maker-core/src/agents/claude-code/__tests__/translator-subagent-model.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/translator-subagent-model.test.ts
@@ -62,6 +62,55 @@ async function collect(queue: ReturnType<typeof createAsyncQueue<AgentEvent>>): 
 }
 
 describe('Claude Code assistant text streaming contract', () => {
+  it('attributes pre-envelope text deltas to the current message_start request', async () => {
+    const queue = createAsyncQueue<AgentEvent>();
+    const ctx = createCtx();
+    ctx.rt.lastAssistantMeta = {
+      uuid: 'previous-assistant',
+      requestId: 'msg_previous',
+      sdkSessionId: 'sdk-session',
+    };
+
+    translateSdkMessage(
+      {
+        type: 'stream_event',
+        uuid: 'stream-start',
+        session_id: 'sdk-session',
+        parent_tool_use_id: null,
+        event: {
+          type: 'message_start',
+          message: {
+            id: 'msg_current',
+            model: 'claude-opus-4-6',
+            usage: { input_tokens: 1 },
+          },
+        },
+      },
+      queue,
+      ctx,
+    );
+    translateSdkMessage(
+      {
+        type: 'stream_event',
+        uuid: 'stream-delta',
+        session_id: 'sdk-session',
+        parent_tool_use_id: null,
+        event: {
+          type: 'content_block_delta',
+          delta: { type: 'text_delta', text: 'partial reply' },
+        },
+      },
+      queue,
+      ctx,
+    );
+
+    const textEvent = (await collect(queue)).find((event) => event.type === 'text');
+    expect(textEvent?.agentMeta).toMatchObject({
+      requestId: 'msg_current',
+      sdkSessionId: 'sdk-session',
+    });
+  });
+
   it('emits live deltas before the final assistant text block', async () => {
     const queue = createAsyncQueue<AgentEvent>();
     const ctx = createCtx();

--- a/packages/maker-core/src/agents/claude-code/translator.ts
+++ b/packages/maker-core/src/agents/claude-code/translator.ts
@@ -178,6 +178,8 @@ export interface RuntimeState {
    * 发出可见正文，不能看整轮 `uiEmittedText`，也不能跨 text block 复用。
    */
   streamStopTokenByKey: Map<string, StandaloneStopTokenHold>;
+  /** Current message_start.message.id for each parent stream, used before the full envelope arrives. */
+  streamRequestIdByParent: Map<string, string>;
   /** Per-parent active provider request used to merge message_start + message_delta usage. */
   activeUsageSegmentByParent: Map<string, string>;
   /** Price variant frozen for the active request of each parent stream. */
@@ -202,6 +204,7 @@ export function newRuntimeState(): RuntimeState {
     lastAssistantMeta: null,
     lastResultUsageAggregate: null,
     streamStopTokenByKey: new Map(),
+    streamRequestIdByParent: new Map(),
     activeUsageSegmentByParent: new Map(),
     activeUsagePriceVariantByParent: new Map(),
     pendingUsagePriceVariantByParent: new Map(),
@@ -1289,6 +1292,16 @@ function handleAssistant(
   const parentToolUseId = typeof msg.parent_tool_use_id === 'string' && msg.parent_tool_use_id
     ? msg.parent_tool_use_id
     : undefined;
+  const parentStreamKey = parentToolUseId ?? '__main__';
+  const assistantRequestId = typeof assistantMeta.requestId === 'string'
+    ? assistantMeta.requestId
+    : undefined;
+  if (
+    assistantRequestId &&
+    ctx.rt.streamRequestIdByParent.get(parentStreamKey) === assistantRequestId
+  ) {
+    ctx.rt.streamRequestIdByParent.delete(parentStreamKey);
+  }
   // 子代理完整 assistant 没有 message_delta 时，result.usage 仍含其子输出，
   // 而父级 Agent 工具区间已从分母排除。与 message_delta 路径同样 fail-closed。
   if (parentToolUseId) markClaudeGenerationUnreliable(ctx.rt.generation);
@@ -1346,7 +1359,6 @@ function handleAssistant(
   for (const blockRaw of content) {
     const block = blockRaw as { type?: string; text?: string; name?: string; id?: string; input?: unknown; thinking?: string; signature?: string };
     if (block.type === 'text' && typeof block.text === 'string') {
-      const parentStreamKey = parentToolUseId ?? '__main__';
       const prefix = `${parentStreamKey}:`;
       for (const key of ctx.rt.streamStopTokenByKey.keys()) {
         if (key === parentStreamKey || key.startsWith(prefix)) {
@@ -1456,7 +1468,7 @@ function handleStreamEvent(
     index?: number;
     delta?: Record<string, unknown>;
     usage?: Record<string, number>;
-    message?: { model?: string; usage?: Record<string, number> };
+    message?: { id?: string; model?: string; usage?: Record<string, number> };
     content_block?: { type?: string; id?: string; name?: string; input?: unknown };
   } | undefined;
   if (!event) return;
@@ -1494,21 +1506,33 @@ function handleStreamEvent(
   if (typeof eventModel === 'string' && eventModel) {
     ctx.rt.streamModelByParentToolUseId.set(parentStreamKey, eventModel);
   }
+  const eventRequestId = event.message?.id;
+  if (typeof eventRequestId === 'string' && eventRequestId) {
+    ctx.rt.streamRequestIdByParent.set(parentStreamKey, eventRequestId);
+  }
   const streamModel = typeof eventModel === 'string' && eventModel
     ? eventModel
     : ctx.rt.streamModelByParentToolUseId.get(parentStreamKey);
+  const streamRequestId = typeof eventRequestId === 'string' && eventRequestId
+    ? eventRequestId
+    : ctx.rt.streamRequestIdByParent.get(parentStreamKey);
   const fallbackMeta: Record<string, unknown> | undefined = parentToolUseId
     ? {
         parentUuid: parentToolUseId,
         ...(streamModel ? { model: streamModel } : {}),
+        ...(streamRequestId ? { requestId: streamRequestId } : {}),
       }
     : ctx.rt.lastAssistantMeta
       ? {
           ...ctx.rt.lastAssistantMeta,
           ...(streamModel ? { model: streamModel } : {}),
+          ...(streamRequestId ? { requestId: streamRequestId } : {}),
         }
-      : streamModel
-        ? { model: streamModel }
+      : streamModel || streamRequestId
+        ? {
+            ...(streamModel ? { model: streamModel } : {}),
+            ...(streamRequestId ? { requestId: streamRequestId } : {}),
+          }
         : undefined;
 
   if (event.type === 'content_block_delta') {


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复用户暂停流式回复后，同一段 assistant 内容可能被持久化为两条消息的问题。stale-idle 收口现在会保留带 SDK requestId/uuid 的持久化候选；同一请求迟到的终态会复用原消息身份，终态正文更完整时则原地更新。不同请求即使正文相同，仍会分别持久化。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#3332
- 本 PR 包含：Desktop Main 的 assistant 流式持久化收口逻辑，以及覆盖同请求终态、正文扩展和不同请求的回归测试
- 明确不包含：历史重复数据清理、数据库 schema / migration、UI 改动
- 用户可见变化：暂停或停止流式回复后，不再出现两份相同的 assistant 消息
- 是否存在 breaking change：无

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/__tests__/messagePersistBroadcaster.test.ts src/main/__tests__/makerEventHotPathOrdering.test.ts
结果：2 个测试文件、139 个测试通过

pnpm --filter desktop typecheck
结果：通过

pnpm test:unit:related
结果：Desktop 相关单测通过

pnpm check:dco
结果：1 个提交签名检查通过
```

### 手工验证

未执行 Desktop 实机复现；当前工作在 Cindy 内嵌 worktree 中，不能重启正在承载任务的宿主实例。竞态路径已由回归测试复现并锁定。

### 未执行的验证

- `pnpm test:unit`：未执行；本次按相关单测门禁运行 `pnpm test:unit:related`
- macOS 实机验证：未执行；本次为平台无关的内存状态与持久化队列逻辑，已在 Windows 完成自动验证

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅影响 Desktop Main 中 stale-idle 收口后同一 SDK 请求迟到终态的 assistant 消息持久化。现有历史消息不改写，不新增 IPC 或推送事件，不修改数据库结构。SSH 远程工作区继续走既有事件和数据库链路；device-link 与 Mobile 继续接收既有 `messages:created` 行广播，只会看到修正后的单行结果。改动不涉及 Mobile runtime fingerprint，不触发冷更。逻辑不依赖操作系统；Windows 已验证，macOS 未实机验证。
- 回滚 / 降级方式：回滚本 PR 提交即可；没有 migration 或需要反向处理的数据。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次无需文档改动，行为由代码注释与回归测试说明）
- [x] 已确认测试结果或说明未执行原因