### PR TITLE
fix(computer): expose type_text delivery mode (#3335)

### DIFF
--- a/packages/lizi-mcps/src/computer/computerMcpServer.test.ts
+++ b/packages/lizi-mcps/src/computer/computerMcpServer.test.ts
@@ -79,6 +79,7 @@ describe('createComputerMcpServer', () => {
     expect(payload.tools.map((tool) => tool.name)).toContain('replay_trajectory');
     expect(payload.tools.map((tool) => tool.name)).toContain('type_text');
     const listWindows = payload.tools.find((tool) => tool.name === 'list_windows');
+    const typeText = payload.tools.find((tool) => tool.name === 'type_text');
     expect(listWindows?.inputSchema?.properties).toHaveProperty('query');
     expect(listWindows?.inputSchema?.properties).toHaveProperty('workspace_root');
     expect(listWindows?.inputSchema?.properties).toHaveProperty('process_name');
@@ -95,6 +96,7 @@ describe('createComputerMcpServer', () => {
       .not.toHaveProperty('use_external_simulator');
     expect(payload.tools.find((tool) => tool.name === 'hotkey')?.inputSchema?.properties)
       .not.toHaveProperty('use_external_ios_workflow');
+    expect(typeText?.inputSchema?.properties).toHaveProperty('delivery_mode');
     expect(payload.workflow).toContain('always for coordinates');
     expect(payload.workflow).toContain('{"capture_mode":"vision"}');
     await h.cleanup();
@@ -406,6 +408,30 @@ describe('createComputerMcpServer', () => {
     expect(payload.errorCode).toBe('INVALID_ARGS');
     expect((result as { isError?: boolean }).isError).toBe(true);
     expect(deps.callTool).not.toHaveBeenCalled();
+    await h.cleanup();
+  });
+
+  it('forwards an explicit type_text delivery mode to cua-driver', async () => {
+    const deps: ComputerMcpDeps = {
+      getStatus: vi.fn(),
+      callTool: vi.fn(async () => ({ ok: true })),
+    };
+    const h = await makeHarness(deps);
+
+    const result = await h.client.callTool({
+      name: 'call_tool',
+      arguments: {
+        name: 'type_text',
+        args: { pid: 123, text: 'hello', delivery_mode: 'foreground' },
+      },
+    });
+
+    expect(textPayload(result)).toMatchObject({ ok: true });
+    expect(deps.callTool).toHaveBeenCalledWith('type_text', {
+      pid: 123,
+      text: 'hello',
+      delivery_mode: 'foreground',
+    });
     await h.cleanup();
   });
 

--- a/packages/lizi-mcps/src/computer/tools.ts
+++ b/packages/lizi-mcps/src/computer/tools.ts
@@ -165,6 +165,7 @@ export const COMPUTER_TOOLS: readonly ComputerToolDef[] = [
     inputShape: {
       pid: z.number().int().positive(),
       text: z.string(),
+      delivery_mode: z.enum(['background', 'foreground']).optional(),
       element_index: z.number().int().nonnegative().optional(),
       window_id: z.number().int().nonnegative().optional(),
       delay_ms: z.number().int().min(0).max(200).optional(),


### PR DESCRIPTION
## 这次改了什么

### 摘要

为 `cindy_computer` 的 `type_text` MCP 工具暴露 cua-driver 已支持的 `delivery_mode` 参数，使 Windows Terminal 等需要前台投递的目标可以显式选择 `foreground`，同时保留默认后台投递行为。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#3335
- 本 PR 包含：`type_text` schema 增加 `delivery_mode` 枚举；参数校验与 driver 转发回归测试。
- 明确不包含：自动从后台投递升级到前台；未经确认的 `scope` / `target` 参数；cua-driver 本身的实现。
- 用户可见变化：调用方可以在 `type_text` 中显式传入 `delivery_mode: "foreground"`，避免宿主层因未知字段提前拒绝。
- 是否存在 breaking change：无

### UI 变化

不涉及 UI。

- 引用的设计规范：不涉及。

## 怎么验证的

### 自动验证

```text
pnpm --filter @cindy/mcps exec vitest run src/computer/computerMcpServer.test.ts
结果：52 个测试全部通过

pnpm --filter @cindy/mcps build
结果：TypeScript 检查通过
```

覆盖内容：工具列表 schema 暴露、`foreground` 参数原样转发，以及既有严格参数校验。

### 手工验证

不涉及；Windows Terminal 的真实 driver 行为需要 Windows 客户端和匹配版本 cua-driver 环境验证。

### 未执行的验证

未在本机执行 Windows Terminal + cua-driver 的真实前台输入验证，当前环境为 macOS；CI 已完成 Linux/Windows 单元测试。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [x] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅影响 `cindy_computer.type_text` 的参数 schema；未传新参数的调用保持原有行为。
- 回滚 / 降级方式：回滚本 PR 即可移除该可选参数；旧 cua-driver 对显式参数不支持时会返回明确错误，不会静默改变投递模式。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [ ] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
