### PR TITLE
Auto 档下 find -delete 不再被内置只读集静默放行

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,6 +170,7 @@ config/log-upload.json
 # 本地跑 visual-baseline-check 时会自动生成。
 apps/mobile/e2e/visual-baselines/
 .cindy-worktrees/
+.worktrees/
 # 品牌迁移前已创建的 worktree 仍需保持 ignored。
 .xdt-worktrees/
 .xdtworktreeinclude

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -128,7 +128,7 @@ import {
   resolveAutoReviewDecision,
   type AutoReviewDecision,
 } from '../shared/auto-review-decision.js';
-import type { ReviewableAction } from '../shared/auto-review.js';
+import { bashHasDestructiveFind, type ReviewableAction } from '../shared/auto-review.js';
 import {
   resolveAgentCredentialMode,
   resolveEffectiveCredentialModeFromAuthSource,
@@ -1471,6 +1471,27 @@ export class ClaudeCodeAgent extends BaseAgent {
       }
       return { continue: true };
     };
+    // SDK 2.1.219 把 `find` 放进内置只读集:builtin readonly 先于 canUseTool、也不评
+    // deny glob,所以 `find … -delete` 会静默下发。PreToolUse 无条件先于权限判定,
+    // hook deny 能在只读放行之前拦住破坏性 find,只读 `find -print` 不碰。
+    const destructiveFindHook: HookCallback = async (input) => {
+      if (input.hook_event_name !== 'PreToolUse') return { continue: true };
+      const pre = input as PreToolUseHookInput;
+      if (pre.tool_name !== 'Bash') return { continue: true };
+      const command = (pre.tool_input as { command?: unknown } | undefined)?.command;
+      if (typeof command !== 'string' || !bashHasDestructiveFind(command)) {
+        return { continue: true };
+      }
+      return {
+        continue: true,
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          permissionDecision: 'deny',
+          permissionDecisionReason:
+            'find -delete/-exec is destructive; Cindy blocks it before the SDK builtin-readonly allowlist.',
+        },
+      };
+    };
     const reviewReadOnlyHook: HookCallback = async (input) => {
       if (input.hook_event_name !== 'PreToolUse') return { continue: true };
       const pre = input as PreToolUseHookInput;
@@ -1519,7 +1540,7 @@ export class ClaudeCodeAgent extends BaseAgent {
             () => nonHarnessMcpServerNames,
           ),
           {
-            PreToolUse: [{ hooks: [turnChangeCaptureHook] }],
+            PreToolUse: [{ hooks: [destructiveFindHook, turnChangeCaptureHook] }],
             PostToolUse: [{ hooks: [turnChangeCaptureHook] }],
             PostToolUseFailure: [{ hooks: [turnChangeCaptureHook] }],
           },

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -1474,8 +1474,13 @@ export class ClaudeCodeAgent extends BaseAgent {
     // SDK 2.1.219 把 `find` 放进内置只读集:builtin readonly 先于 canUseTool、也不评
     // deny glob,所以 `find … -delete` 会静默下发。PreToolUse 无条件先于权限判定,
     // hook deny 能在只读放行之前拦住破坏性 find,只读 `find -print` 不碰。
+    // 声明必须在 destructiveFindHook 之前,否则闭包创建时撞 TDZ。
+    let mutablePermissionMode: PermissionMode = reviewMode ? 'ask' : opts.permissionMode ?? 'default';
     const destructiveFindHook: HookCallback = async (input) => {
       if (input.hook_event_name !== 'PreToolUse') return { continue: true };
+      // hook deny 先于权限管线,Ask/Full 下硬拦会让用户换档也做不了 find -delete。
+      // 只在 Auto 档补 SDK builtin-readonly 缺口;其它档走原权限链。
+      if (mutablePermissionMode !== 'auto') return { continue: true };
       const pre = input as PreToolUseHookInput;
       if (pre.tool_name !== 'Bash') return { continue: true };
       const command = (pre.tool_input as { command?: unknown } | undefined)?.command;
@@ -2197,7 +2202,6 @@ export class ClaudeCodeAgent extends BaseAgent {
       ? new ToolLoopGuard()
       : null;
     let mutableEffort: Effort = opts.effort ?? 'high';
-    let mutablePermissionMode: PermissionMode = reviewMode ? 'ask' : opts.permissionMode ?? 'default';
     // 计划模式(与 permissionMode 正交, **一次性选择**): mutablePlanMode 是 UI 勾选的
     // "武装"态 —— send 消耗它并立即 emit plan_mode_changed(false) 让勾选熄灭;
     // 本轮 plan turn 由 planTurnActive 承载(SDK 保持 plan 档): ExitPlanMode 批准

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -1545,7 +1545,7 @@ export class ClaudeCodeAgent extends BaseAgent {
             () => nonHarnessMcpServerNames,
           ),
           {
-            PreToolUse: [{ hooks: [destructiveFindHook, turnChangeCaptureHook] }],
+            PreToolUse: [{ hooks: [turnChangeCaptureHook, destructiveFindHook] }],
             PostToolUse: [{ hooks: [turnChangeCaptureHook] }],
             PostToolUseFailure: [{ hooks: [turnChangeCaptureHook] }],
           },

--- a/packages/maker-core/src/agents/shared/auto-review.test.ts
+++ b/packages/maker-core/src/agents/shared/auto-review.test.ts
@@ -4466,4 +4466,11 @@ describe('bashHasDestructiveFind — PreToolUse 拦在 SDK 只读放行之前', 
     expect(bashHasDestructiveFind("find . -ex'ec' rm {} \\;")).toBe(true);
     expect(bashHasDestructiveFind("find . '-exec' rm {} \\;")).toBe(true);
   });
+  it('分段与路径名不误伤: 后段 -delete / -name echo / find echo -delete', () => {
+    expect(bashHasDestructiveFind('find . -print; true -delete')).toBe(false);
+    expect(bashHasDestructiveFind('find . -print && echo -delete')).toBe(false);
+    expect(bashHasDestructiveFind('find . -name echo -print')).toBe(false);
+    expect(bashHasDestructiveFind('find echo -delete')).toBe(true);
+    expect(bashHasDestructiveFind('find . -name echo -delete')).toBe(true);
+  });
 });

--- a/packages/maker-core/src/agents/shared/auto-review.test.ts
+++ b/packages/maker-core/src/agents/shared/auto-review.test.ts
@@ -4491,5 +4491,7 @@ describe('bashHasDestructiveFind — PreToolUse 拦在 SDK 只读放行之前', 
     expect(bashHasDestructiveFind('find . -name -delete')).toBe(false);
     expect(bashHasDestructiveFind('find . -name echo -delete')).toBe(true);
     expect(bashHasDestructiveFind("find . -name '*-delete' -delete")).toBe(true);
+    expect(bashHasDestructiveFind('find . -nouser -delete')).toBe(true);
+    expect(bashHasDestructiveFind('find . -nogroup -exec echo {} \\;')).toBe(true);
   });
 });

--- a/packages/maker-core/src/agents/shared/auto-review.test.ts
+++ b/packages/maker-core/src/agents/shared/auto-review.test.ts
@@ -4473,4 +4473,16 @@ describe('bashHasDestructiveFind — PreToolUse 拦在 SDK 只读放行之前', 
     expect(bashHasDestructiveFind('find echo -delete')).toBe(true);
     expect(bashHasDestructiveFind('find . -name echo -delete')).toBe(true);
   });
+  it('前导赋值 / 关键字 / command 前缀仍看见 find: FOO=1 / then / command', () => {
+    expect(bashHasDestructiveFind('FOO=1 find . -delete')).toBe(true);
+    expect(bashHasDestructiveFind('FOO=1 BAR=2 find . -exec echo {} \\;')).toBe(true);
+    expect(bashHasDestructiveFind('if true; then find . -delete; fi')).toBe(true);
+    expect(bashHasDestructiveFind('while true; do find . -delete; done')).toBe(true);
+    expect(bashHasDestructiveFind('command find . -delete')).toBe(true);
+    expect(bashHasDestructiveFind('command -p find . -delete')).toBe(true);
+    expect(bashHasDestructiveFind('env find . -delete')).toBe(true);
+    expect(bashHasDestructiveFind('FOO=1 echo -delete')).toBe(false);
+    expect(bashHasDestructiveFind('if true; then echo x; fi')).toBe(false);
+    expect(bashHasDestructiveFind('command echo -delete')).toBe(false);
+  });
 });

--- a/packages/maker-core/src/agents/shared/auto-review.test.ts
+++ b/packages/maker-core/src/agents/shared/auto-review.test.ts
@@ -9,6 +9,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  bashHasDestructiveFind,
   classifyShellCommand,
   isProtectedSystemPath,
   reviewAction,
@@ -4447,5 +4448,16 @@ describe('删除也是写通道:普通 rm / mv 源 / cmd del(第四十八批评�
     ]) {
       expect(classifyShellCommand(c, roots), c).not.toBe('prompt-each-time');
     }
+  });
+});
+
+describe('bashHasDestructiveFind — PreToolUse 拦在 SDK 只读放行之前', () => {
+  it('最简 find -delete 与 -exec 命中;只读 find 与管道放行', () => {
+    expect(bashHasDestructiveFind('find /tmp/no-such -delete')).toBe(true);
+    expect(bashHasDestructiveFind('find . -delete')).toBe(true);
+    expect(bashHasDestructiveFind('find . -exec echo {} \\;')).toBe(true);
+    expect(bashHasDestructiveFind("cd /repo && find . -path ./.git -prune -o -name '*.md' -print | sort | head")).toBe(false);
+    expect(bashHasDestructiveFind("find . -path ./.git -prune -o -name '*.md' -print")).toBe(false);
+    expect(bashHasDestructiveFind("echo 'find . -delete'")).toBe(false);
   });
 });

--- a/packages/maker-core/src/agents/shared/auto-review.test.ts
+++ b/packages/maker-core/src/agents/shared/auto-review.test.ts
@@ -4493,5 +4493,7 @@ describe('bashHasDestructiveFind — PreToolUse 拦在 SDK 只读放行之前', 
     expect(bashHasDestructiveFind("find . -name '*-delete' -delete")).toBe(true);
     expect(bashHasDestructiveFind('find . -nouser -delete')).toBe(true);
     expect(bashHasDestructiveFind('find . -nogroup -exec echo {} \\;')).toBe(true);
+    expect(bashHasDestructiveFind('find victim 2>&1 -delete')).toBe(true);
+    expect(bashHasDestructiveFind('find victim >&2 -delete')).toBe(true);
   });
 });

--- a/packages/maker-core/src/agents/shared/auto-review.test.ts
+++ b/packages/maker-core/src/agents/shared/auto-review.test.ts
@@ -4460,4 +4460,10 @@ describe('bashHasDestructiveFind — PreToolUse 拦在 SDK 只读放行之前', 
     expect(bashHasDestructiveFind("find . -path ./.git -prune -o -name '*.md' -print")).toBe(false);
     expect(bashHasDestructiveFind("echo 'find . -delete'")).toBe(false);
   });
+  it('引号包着的 flag 仍是 argv: find . \'-delete\' / -ex\'ec\' 命中', () => {
+    expect(bashHasDestructiveFind("find . '-delete'")).toBe(true);
+    expect(bashHasDestructiveFind('find . "-delete"')).toBe(true);
+    expect(bashHasDestructiveFind("find . -ex'ec' rm {} \\;")).toBe(true);
+    expect(bashHasDestructiveFind("find . '-exec' rm {} \\;")).toBe(true);
+  });
 });

--- a/packages/maker-core/src/agents/shared/auto-review.test.ts
+++ b/packages/maker-core/src/agents/shared/auto-review.test.ts
@@ -4485,4 +4485,11 @@ describe('bashHasDestructiveFind — PreToolUse 拦在 SDK 只读放行之前', 
     expect(bashHasDestructiveFind('if true; then echo x; fi')).toBe(false);
     expect(bashHasDestructiveFind('command echo -delete')).toBe(false);
   });
+  it('谓词值不是 action: -name *-delete / -name -delete 放行, 真 -delete 仍拦', () => {
+    expect(bashHasDestructiveFind("find . -name '*-delete' -print")).toBe(false);
+    expect(bashHasDestructiveFind("find . -name 'foo-delete.txt'")).toBe(false);
+    expect(bashHasDestructiveFind('find . -name -delete')).toBe(false);
+    expect(bashHasDestructiveFind('find . -name echo -delete')).toBe(true);
+    expect(bashHasDestructiveFind("find . -name '*-delete' -delete")).toBe(true);
+  });
 });

--- a/packages/maker-core/src/agents/shared/auto-review.ts
+++ b/packages/maker-core/src/agents/shared/auto-review.ts
@@ -161,7 +161,7 @@ const FIND_DESTRUCTIVE_FLAG_RE = /^-(?:exec(?:dir)?|ok(?:dir)?|delete)$/;
 const FIND_VALUE_PREDICATES = new Set([
   '-name', '-iname', '-path', '-ipath', '-wholename', '-iwholename',
   '-regex', '-iregex', '-lname', '-ilname',
-  '-newer', '-anewer', '-cnewer', '-used', '-user', '-group', '-nouser', '-nogroup',
+  '-newer', '-anewer', '-cnewer', '-used', '-user', '-group',
   '-perm', '-type', '-xtype', '-size', '-links', '-inum', '-samefile',
   '-fstype',
 ]);

--- a/packages/maker-core/src/agents/shared/auto-review.ts
+++ b/packages/maker-core/src/agents/shared/auto-review.ts
@@ -152,6 +152,43 @@ export function reviewAction(
 // 包裹器仍会剥壳按内层命令判定(见 COMMAND_WRAPPERS);裸 `env` 剥壳后为空段→fail-closed 升级。
 // `cat`/`grep`/`base64` 等能读文件的仍在列,但读**凭证文件**由 ALWAYS_ASK_PATTERNS 先行拦成
 // prompt-each-time(在 classifyShellCommand 里先于分段判定),读普通文件才放行。
+/**
+ * Bash 里的 find 是否带破坏性 flag。给 PreToolUse hook 用:
+ * SDK 内置只读集把 `find` 整命令放行,deny glob 对 builtin readonly 不评,
+ * 必须在 canUseTool / 只读放行之前用 hook deny 把 -delete/-exec 拦下。
+ */
+const FIND_DESTRUCTIVE_FLAG_RE = /-(?:exec(?:dir)?|ok(?:dir)?|delete)\b/;
+
+function outsideQuotes(command: string): string {
+  let out = '';
+  let quote: "'" | '"' | null = null;
+  for (let i = 0; i < command.length; i++) {
+    const ch = command[i];
+    if (quote) {
+      if (ch === quote) quote = null;
+      continue;
+    }
+    if (ch === "'" || ch === '"') {
+      quote = ch;
+      continue;
+    }
+    if (ch === '\\' && i + 1 < command.length) {
+      out += command[i + 1];
+      i++;
+      continue;
+    }
+    out += ch;
+  }
+  return out;
+}
+
+export function bashHasDestructiveFind(command: string): boolean {
+  if (typeof command !== 'string' || command.trim() === '') return false;
+  const visible = outsideQuotes(command);
+  if (!/\bfind\b/i.test(visible)) return false;
+  return FIND_DESTRUCTIVE_FLAG_RE.test(visible);
+}
+
 const SAFE_READONLY_BINS: ReadonlySet<string> = new Set([
   'ls', 'pwd', 'echo', 'cat', 'head', 'tail', 'wc', 'stat', 'file', 'which',
   'type', 'date', 'whoami', 'hostname', 'uname', 'basename', 'dirname',

--- a/packages/maker-core/src/agents/shared/auto-review.ts
+++ b/packages/maker-core/src/agents/shared/auto-review.ts
@@ -227,7 +227,14 @@ function shellWords(command: string): string[] {
       if (command[i + 1] === '&') {
         pushOp('&&');
         i++;
-      } else pushOp('&');
+        continue;
+      }
+      // `2>&1` / `>&2` 是重定向，不是后台分隔符。
+      if (inWord && (cur.endsWith('>') || cur.endsWith('<'))) {
+        cur += ch;
+        continue;
+      }
+      pushOp('&');
       continue;
     }
     if (/\s/.test(ch)) {

--- a/packages/maker-core/src/agents/shared/auto-review.ts
+++ b/packages/maker-core/src/agents/shared/auto-review.ts
@@ -175,6 +175,10 @@ function shellWords(command: string): string[] {
     cur = '';
     inWord = false;
   };
+  const pushOp = (op: string): void => {
+    flush();
+    words.push(op);
+  };
   for (let i = 0; i < command.length; i++) {
     const ch = command[i];
     if (quote === "'") {
@@ -201,7 +205,25 @@ function shellWords(command: string): string[] {
       i++;
       continue;
     }
-    if (/\s/.test(ch) || ch === '|' || ch === '&' || ch === ';' || ch === '\n') {
+    if (ch === '\n' || ch === ';') {
+      pushOp(';');
+      continue;
+    }
+    if (ch === '|') {
+      if (command[i + 1] === '|') {
+        pushOp('||');
+        i++;
+      } else pushOp('|');
+      continue;
+    }
+    if (ch === '&') {
+      if (command[i + 1] === '&') {
+        pushOp('&&');
+        i++;
+      } else pushOp('&');
+      continue;
+    }
+    if (/\s/.test(ch)) {
       flush();
       continue;
     }
@@ -212,26 +234,29 @@ function shellWords(command: string): string[] {
   return words;
 }
 
+const SHELL_OP = new Set(['|', '||', '&&', ';', '&']);
+
+function commandBasename(token: string): string {
+  return token.replace(/.*\//, '').toLowerCase();
+}
+
 export function bashHasDestructiveFind(command: string): boolean {
   if (typeof command !== 'string' || command.trim() === '') return false;
   const words = shellWords(command);
   let i = 0;
   while (i < words.length) {
-    const bin = words[i]?.replace(/.*\//, '').toLowerCase();
-    if (bin === 'find') {
-      const rest: string[] = [];
+    if (SHELL_OP.has(words[i])) {
       i += 1;
-      while (i < words.length) {
-        const w = words[i];
-        const b = w.replace(/.*\//, '').toLowerCase();
-        if (b === 'find' || b === 'echo' || b === 'printf') break;
-        rest.push(w);
-        i += 1;
-      }
-      if (rest.some((w) => FIND_DESTRUCTIVE_FLAG_RE.test(w))) return true;
       continue;
     }
+    const bin = commandBasename(words[i] ?? '');
+    const rest: string[] = [];
     i += 1;
+    while (i < words.length && !SHELL_OP.has(words[i])) {
+      rest.push(words[i]);
+      i += 1;
+    }
+    if (bin === 'find' && rest.some((w) => FIND_DESTRUCTIVE_FLAG_RE.test(w))) return true;
   }
   return false;
 }

--- a/packages/maker-core/src/agents/shared/auto-review.ts
+++ b/packages/maker-core/src/agents/shared/auto-review.ts
@@ -157,7 +157,14 @@ export function reviewAction(
  * SDK 内置只读集把 `find` 整命令放行,deny glob 对 builtin readonly 不评,
  * 必须在 canUseTool / 只读放行之前用 hook deny 把 -delete/-exec 拦下。
  */
-const FIND_DESTRUCTIVE_FLAG_RE = /-(?:exec(?:dir)?|ok(?:dir)?|delete)\b/;
+const FIND_DESTRUCTIVE_FLAG_RE = /^-(?:exec(?:dir)?|ok(?:dir)?|delete)$/;
+const FIND_VALUE_PREDICATES = new Set([
+  '-name', '-iname', '-path', '-ipath', '-wholename', '-iwholename',
+  '-regex', '-iregex', '-lname', '-ilname',
+  '-newer', '-anewer', '-cnewer', '-used', '-user', '-group', '-nouser', '-nogroup',
+  '-perm', '-type', '-xtype', '-size', '-links', '-inum', '-samefile',
+  '-fstype',
+]);
 
 /**
  * 还原 shell 词(去引号、拼相邻片段、解开 \' / \\),保留引号内的 flag 字面量。
@@ -280,8 +287,16 @@ export function bashHasDestructiveFind(command: string): boolean {
     }
     const unwrapped = skipFindCommandPrefixes(segment);
     const bin = commandBasename(unwrapped[0] ?? '');
+    if (bin !== 'find') continue;
     const rest = unwrapped.slice(1);
-    if (bin === 'find' && rest.some((w) => FIND_DESTRUCTIVE_FLAG_RE.test(w))) return true;
+    for (let j = 0; j < rest.length; j++) {
+      const w = rest[j];
+      if (FIND_VALUE_PREDICATES.has(w.toLowerCase())) {
+        j += 1;
+        continue;
+      }
+      if (FIND_DESTRUCTIVE_FLAG_RE.test(w)) return true;
+    }
   }
   return false;
 }

--- a/packages/maker-core/src/agents/shared/auto-review.ts
+++ b/packages/maker-core/src/agents/shared/auto-review.ts
@@ -240,6 +240,30 @@ function commandBasename(token: string): string {
   return token.replace(/.*\//, '').toLowerCase();
 }
 
+const FIND_PREFIX_KEYWORDS = new Set([
+  'then', 'do', 'else', 'elif', 'if', 'while', 'until', 'fi', 'done',
+]);
+const FIND_PREFIX_BUILTINS = new Set(['command', 'builtin', 'exec', 'env']);
+
+/** 只剥本 gate 需要的前缀：NAME=val、then/do、command/env/exec。不走 unwrapWrappers。 */
+function skipFindCommandPrefixes(tokens: string[]): string[] {
+  let i = 0;
+  while (i < tokens.length) {
+    const tok = tokens[i];
+    if (/^[A-Za-z_][A-Za-z0-9_]*=/.test(tok) || FIND_PREFIX_KEYWORDS.has(tok.toLowerCase())) {
+      i += 1;
+      continue;
+    }
+    if (FIND_PREFIX_BUILTINS.has(commandBasename(tok))) {
+      i += 1;
+      while (i < tokens.length && tokens[i].startsWith('-')) i += 1;
+      continue;
+    }
+    break;
+  }
+  return tokens.slice(i);
+}
+
 export function bashHasDestructiveFind(command: string): boolean {
   if (typeof command !== 'string' || command.trim() === '') return false;
   const words = shellWords(command);
@@ -254,9 +278,7 @@ export function bashHasDestructiveFind(command: string): boolean {
       segment.push(words[i]);
       i += 1;
     }
-    // 前导 NAME=val / then|do|else / command|env|exec 不是命令名。
-    // 复用 unwrapWrappers，与 classify 同一套剥壳，避免 FOO=1 find 漏拦。
-    const unwrapped = unwrapWrappers(segment);
+    const unwrapped = skipFindCommandPrefixes(segment);
     const bin = commandBasename(unwrapped[0] ?? '');
     const rest = unwrapped.slice(1);
     if (bin === 'find' && rest.some((w) => FIND_DESTRUCTIVE_FLAG_RE.test(w))) return true;

--- a/packages/maker-core/src/agents/shared/auto-review.ts
+++ b/packages/maker-core/src/agents/shared/auto-review.ts
@@ -249,13 +249,16 @@ export function bashHasDestructiveFind(command: string): boolean {
       i += 1;
       continue;
     }
-    const bin = commandBasename(words[i] ?? '');
-    const rest: string[] = [];
-    i += 1;
+    const segment: string[] = [];
     while (i < words.length && !SHELL_OP.has(words[i])) {
-      rest.push(words[i]);
+      segment.push(words[i]);
       i += 1;
     }
+    // 前导 NAME=val / then|do|else / command|env|exec 不是命令名。
+    // 复用 unwrapWrappers，与 classify 同一套剥壳，避免 FOO=1 find 漏拦。
+    const unwrapped = unwrapWrappers(segment);
+    const bin = commandBasename(unwrapped[0] ?? '');
+    const rest = unwrapped.slice(1);
     if (bin === 'find' && rest.some((w) => FIND_DESTRUCTIVE_FLAG_RE.test(w))) return true;
   }
   return false;

--- a/packages/maker-core/src/agents/shared/auto-review.ts
+++ b/packages/maker-core/src/agents/shared/auto-review.ts
@@ -159,34 +159,81 @@ export function reviewAction(
  */
 const FIND_DESTRUCTIVE_FLAG_RE = /-(?:exec(?:dir)?|ok(?:dir)?|delete)\b/;
 
-function outsideQuotes(command: string): string {
-  let out = '';
+/**
+ * 还原 shell 词(去引号、拼相邻片段、解开 \' / \\),保留引号内的 flag 字面量。
+ * `find . '-delete'` 与 `find . -ex'ec'` 必须仍看见 -delete/-exec;
+ * `echo 'find . -delete'` 的 find 落在 echo 的数据词里,命令位不是 find。
+ */
+function shellWords(command: string): string[] {
+  const words: string[] = [];
+  let cur = '';
+  let inWord = false;
   let quote: "'" | '"' | null = null;
+  const flush = (): void => {
+    if (!inWord) return;
+    words.push(cur);
+    cur = '';
+    inWord = false;
+  };
   for (let i = 0; i < command.length; i++) {
     const ch = command[i];
-    if (quote) {
-      if (ch === quote) quote = null;
+    if (quote === "'") {
+      if (ch === "'") quote = null;
+      else cur += ch;
+      continue;
+    }
+    if (quote === '"') {
+      if (ch === '"') quote = null;
+      else if (ch === '\\' && i + 1 < command.length) {
+        cur += command[i + 1];
+        i++;
+      } else cur += ch;
       continue;
     }
     if (ch === "'" || ch === '"') {
       quote = ch;
+      inWord = true;
       continue;
     }
     if (ch === '\\' && i + 1 < command.length) {
-      out += command[i + 1];
+      cur += command[i + 1];
+      inWord = true;
       i++;
       continue;
     }
-    out += ch;
+    if (/\s/.test(ch) || ch === '|' || ch === '&' || ch === ';' || ch === '\n') {
+      flush();
+      continue;
+    }
+    cur += ch;
+    inWord = true;
   }
-  return out;
+  flush();
+  return words;
 }
 
 export function bashHasDestructiveFind(command: string): boolean {
   if (typeof command !== 'string' || command.trim() === '') return false;
-  const visible = outsideQuotes(command);
-  if (!/\bfind\b/i.test(visible)) return false;
-  return FIND_DESTRUCTIVE_FLAG_RE.test(visible);
+  const words = shellWords(command);
+  let i = 0;
+  while (i < words.length) {
+    const bin = words[i]?.replace(/.*\//, '').toLowerCase();
+    if (bin === 'find') {
+      const rest: string[] = [];
+      i += 1;
+      while (i < words.length) {
+        const w = words[i];
+        const b = w.replace(/.*\//, '').toLowerCase();
+        if (b === 'find' || b === 'echo' || b === 'printf') break;
+        rest.push(w);
+        i += 1;
+      }
+      if (rest.some((w) => FIND_DESTRUCTIVE_FLAG_RE.test(w))) return true;
+      continue;
+    }
+    i += 1;
+  }
+  return false;
 }
 
 const SAFE_READONLY_BINS: ReadonlySet<string> = new Set([


### PR DESCRIPTION
## 用户能做什么
Auto-review 会话里 \`find … -delete\` / \`-exec\` 会被拦在 SDK 内置只读放行之前，不再「Bash completed with no output」静默成功。只读 \`find -print\` 不受影响。

## 改动
- PreToolUse hook 在 canUseTool / builtin readonly 之前 deny 破坏性 find
- bashHasDestructiveFind 只看引号外的命令位，echo 'find . -delete' 不误伤
- 未加 Bash(find:*) 宽前缀

## 验证
- vitest auto-review.test.ts + auto-review-policy.test.ts：323 passed
- size-gate PASS（63 counted）
- DCO Signed-off-by 与 author 一致

## 风险
hook deny 是硬拒绝，不是弹窗。用户在 Auto 档下如果真要 find -delete，需要换命令或降到 Ask。这是诊断会话的既定口径。