### PR TITLE
feat(desktop): 让 Markdown 复制工具栏跟随滚动

### DIFF
--- a/apps/desktop/src/renderer/__tests__/markdownFloatingToolbar.test.ts
+++ b/apps/desktop/src/renderer/__tests__/markdownFloatingToolbar.test.ts
@@ -38,12 +38,16 @@ describe('Markdown block floating toolbars', () => {
     expect(source.indexOf('pointer-events-none sticky top-0')).toBeLessThan(
       source.indexOf('ref={preRef}'),
     );
+    expect(source).toContain('<div className="-mt-9">');
+    expect(source).not.toContain("'-mt-9 rounded-[12px]'");
   });
 
   it('keeps the copy-as-image toolbar outside its horizontal overflow node', () => {
     const source = sources.copyableBlock;
     expect(source).toContain("cn('group relative flex flex-col', className)");
-    expect(source).toContain("cn('-mt-9', contentClassName)");
+    expect(source).toContain('<div className="-mt-9">');
+    expect(source).toContain('ref={contentRef} className={contentClassName}');
+    expect(source).not.toContain("cn('-mt-9', contentClassName)");
     expect(source).toContain('pointer-events-none order-first sticky top-0');
   });
 
@@ -51,6 +55,6 @@ describe('Markdown block floating toolbars', () => {
     const source = sources.mermaid;
     expect(source).toContain('group relative my-3 flex flex-col');
     expect(source).toContain('pointer-events-none order-first sticky top-0');
-    expect(source.match(/'-mt-9 overflow-x-auto rounded-\[12px\]'/g)).toHaveLength(3);
+    expect(source.match(/<div className="-mt-9">/g)).toHaveLength(1);
   });
 });

--- a/apps/desktop/src/renderer/__tests__/markdownFloatingToolbar.test.ts
+++ b/apps/desktop/src/renderer/__tests__/markdownFloatingToolbar.test.ts
@@ -1,0 +1,56 @@
+/**
+ * markdownFloatingToolbar.test.ts
+ * ---------------------------------------------------------------------------
+ * Structural regression guard for Markdown block toolbars. The toolbar must
+ * use a full-height sticky row overlapped by the block content so long messages
+ * keep their existing copy / image actions visible without crossing the block.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const componentPaths = {
+  code: resolve(__dirname, '..', 'components', 'chat', 'MarkdownRenderer.tsx'),
+  copyableBlock: resolve(__dirname, '..', 'components', 'chat', 'CopyAsImageBlock.tsx'),
+  mermaid: resolve(__dirname, '..', 'components', 'chat', 'MarkdownMermaidBlock.tsx'),
+} as const;
+
+const sources = Object.fromEntries(
+  Object.entries(componentPaths).map(([name, path]) => [name, readFileSync(path, 'utf8')]),
+) as Record<keyof typeof componentPaths, string>;
+
+describe('Markdown block floating toolbars', () => {
+  it.each(Object.entries(sources))(
+    '%s uses a sticky, layout-neutral toolbar row',
+    (_name, source) => {
+      expect(source).toContain('sticky top-0 z-10 flex h-9 items-end');
+      expect(source).toContain('-mt-9');
+      expect(source).not.toContain('-mb-9');
+      expect(source).toContain('group-hover:opacity-100 focus-within:opacity-100');
+      expect(source).toContain('pointer-events-auto');
+      expect(source).not.toContain('absolute right-2 top-2');
+    },
+  );
+
+  it('places the toolbar before the code block content', () => {
+    const source = sources.code;
+    expect(source.indexOf('pointer-events-none sticky top-0')).toBeLessThan(
+      source.indexOf('ref={preRef}'),
+    );
+  });
+
+  it('keeps the copy-as-image toolbar outside its horizontal overflow node', () => {
+    const source = sources.copyableBlock;
+    expect(source).toContain("cn('group relative flex flex-col', className)");
+    expect(source).toContain("cn('-mt-9', contentClassName)");
+    expect(source).toContain('pointer-events-none order-first sticky top-0');
+  });
+
+  it('orders the Mermaid toolbar before the rendered diagram or source view', () => {
+    const source = sources.mermaid;
+    expect(source).toContain('group relative my-3 flex flex-col');
+    expect(source).toContain('pointer-events-none order-first sticky top-0');
+    expect(source.match(/'-mt-9 overflow-x-auto rounded-\[12px\]'/g)).toHaveLength(3);
+  });
+});

--- a/apps/desktop/src/renderer/components/chat/CopyAsImageBlock.tsx
+++ b/apps/desktop/src/renderer/components/chat/CopyAsImageBlock.tsx
@@ -4,8 +4,8 @@
  * 与 CodeBlockPre / MarkdownMermaidBlock 同一套 hover 工具栏配方(右上角
  * `h-7 w-7` 图标按钮、group-hover 显隐、Check 1.5s 反馈)。内容经
  * `domToPngBlob`(html-to-image foreignObject 序列化)光栅化:
- *   - 外层 `group relative` 只承载定位,内层才是 overflow 容器——工具栏挂在
- *     overflow 容器内会被裁剪并随横向滚动漂移;
+ *   - 外层 `group relative` 承载完整高度的 sticky 工具栏,内层内容用负上边距回叠;
+ *     工具栏挂在 overflow 容器内会被裁剪并随横向滚动漂移;
  *   - 光栅化目标是内层内容节点,`scrollWidth` 取完整内容宽,宽表格不被可视
  *     口截断;
  *   - 标注入口仅在聊天会话上下文出现(useCopyAsImage.canAnnotate)。
@@ -88,13 +88,13 @@ export function CopyAsImageBlock({
   );
 
   return (
-    <div className={cn('group relative', className)}>
-      <div ref={contentRef} className={contentClassName}>
+    <div className={cn('group relative flex flex-col', className)}>
+      <div ref={contentRef} className={cn('-mt-9', contentClassName)}>
         {children}
       </div>
       <div
         className={cn(
-          'absolute right-2 top-2 flex gap-1 select-none',
+          'pointer-events-none order-first sticky top-0 z-10 flex h-9 items-end justify-end gap-1 pr-2 select-none',
           'opacity-0 transition-opacity duration-150',
           'group-hover:opacity-100 focus-within:opacity-100',
         )}
@@ -112,7 +112,7 @@ export function CopyAsImageBlock({
               ? t('chat.markdownRenderer.blockCopied')
               : t('chat.markdownRenderer.copy')
           }
-          className={buttonClass}
+          className={cn(buttonClass, 'pointer-events-auto')}
         >
           {copiedImage ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
         </button>
@@ -122,7 +122,7 @@ export function CopyAsImageBlock({
             onClick={openAnnotate}
             aria-label={t('chat.markdownRenderer.annotateImage')}
             title={t('chat.markdownRenderer.annotateImage')}
-            className={buttonClass}
+            className={cn(buttonClass, 'pointer-events-auto')}
           >
             <Pen className="h-3.5 w-3.5" />
           </button>

--- a/apps/desktop/src/renderer/components/chat/CopyAsImageBlock.tsx
+++ b/apps/desktop/src/renderer/components/chat/CopyAsImageBlock.tsx
@@ -4,8 +4,8 @@
  * 与 CodeBlockPre / MarkdownMermaidBlock 同一套 hover 工具栏配方(右上角
  * `h-7 w-7` 图标按钮、group-hover 显隐、Check 1.5s 反馈)。内容经
  * `domToPngBlob`(html-to-image foreignObject 序列化)光栅化:
- *   - 外层 `group relative` 承载完整高度的 sticky 工具栏,内层内容用负上边距回叠;
- *     工具栏挂在 overflow 容器内会被裁剪并随横向滚动漂移;
+ *   - 外层 `group relative` 承载完整高度的 sticky 工具栏,内容包装层用负上边距回叠;
+ *     导出目标本身不带布局偏移,工具栏也不会因挂在 overflow 容器内被裁剪或随横向滚动漂移;
  *   - 光栅化目标是内层内容节点,`scrollWidth` 取完整内容宽,宽表格不被可视
  *     口截断;
  *   - 标注入口仅在聊天会话上下文出现(useCopyAsImage.canAnnotate)。
@@ -89,8 +89,10 @@ export function CopyAsImageBlock({
 
   return (
     <div className={cn('group relative flex flex-col', className)}>
-      <div ref={contentRef} className={cn('-mt-9', contentClassName)}>
-        {children}
+      <div className="-mt-9">
+        <div ref={contentRef} className={contentClassName}>
+          {children}
+        </div>
       </div>
       <div
         className={cn(

--- a/apps/desktop/src/renderer/components/chat/MarkdownMermaidBlock.tsx
+++ b/apps/desktop/src/renderer/components/chat/MarkdownMermaidBlock.tsx
@@ -204,59 +204,61 @@ export const MarkdownMermaidBlock = memo(function MarkdownMermaidBlock({
 
   return (
     <div ref={blockRef} className="group relative my-3 flex flex-col">
-      {showSourceView ? (
-        <pre
-          className={cn(
-            '-mt-9 overflow-x-auto rounded-[12px]',
-            'border border-[var(--msg-code-block-border)]',
-            'bg-[var(--msg-code-block-bg)]',
-            'p-4 font-mono text-[length:var(--app-code-font-size)] leading-[1.5]',
-            'select-text',
-          )}
-        >
-          <code className="language-mermaid">{raw}</code>
-        </pre>
-      ) : svg != null ? (
-        <div
-          role="button"
-          tabIndex={0}
-          onClick={() => setLightboxOpen(true)}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter' || e.key === ' ') {
-              e.preventDefault();
-              setLightboxOpen(true);
-            }
-          }}
-          aria-label={t('chat.mermaid.clickToZoom')}
-          title={t('chat.mermaid.clickToZoom')}
-          className={cn(
-            '-mt-9 overflow-x-auto rounded-[12px]',
-            'border border-[var(--msg-code-block-border)]',
-            'bg-[var(--msg-code-block-bg)]',
-            'p-4 flex justify-center cursor-zoom-in',
-            // With mermaid's useMaxWidth disabled, SVG carries its intrinsic
-            // width/height. Cap both axes so an oversized diagram shrinks to
-            // fit (preserving aspect ratio via the SVG's viewBox) without
-            // dominating the viewport — fine detail lives in the lightbox.
-            '[&>svg]:!max-w-full [&>svg]:!max-h-[60vh] [&>svg]:!h-auto [&>svg]:!w-auto',
-          )}
-          dangerouslySetInnerHTML={{ __html: svg }}
-        />
-      ) : (
-        // Initial load (mermaid chunk in flight) — show a quiet placeholder
-        // matching the code-block frame so layout doesn't jump.
-        <pre
-          className={cn(
-            '-mt-9 overflow-x-auto rounded-[12px]',
-            'border border-[var(--msg-code-block-border)]',
-            'bg-[var(--msg-code-block-bg)]',
-            'p-4 font-mono text-[length:var(--app-code-font-size)] leading-[1.5]',
-            'select-text opacity-60',
-          )}
-        >
-          <code className="language-mermaid">{raw}</code>
-        </pre>
-      )}
+      <div className="-mt-9">
+        {showSourceView ? (
+          <pre
+            className={cn(
+              'overflow-x-auto rounded-[12px]',
+              'border border-[var(--msg-code-block-border)]',
+              'bg-[var(--msg-code-block-bg)]',
+              'p-4 font-mono text-[length:var(--app-code-font-size)] leading-[1.5]',
+              'select-text',
+            )}
+          >
+            <code className="language-mermaid">{raw}</code>
+          </pre>
+        ) : svg != null ? (
+          <div
+            role="button"
+            tabIndex={0}
+            onClick={() => setLightboxOpen(true)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                setLightboxOpen(true);
+              }
+            }}
+            aria-label={t('chat.mermaid.clickToZoom')}
+            title={t('chat.mermaid.clickToZoom')}
+            className={cn(
+              'overflow-x-auto rounded-[12px]',
+              'border border-[var(--msg-code-block-border)]',
+              'bg-[var(--msg-code-block-bg)]',
+              'p-4 flex justify-center cursor-zoom-in',
+              // With mermaid's useMaxWidth disabled, SVG carries its intrinsic
+              // width/height. Cap both axes so an oversized diagram shrinks to
+              // fit (preserving aspect ratio via the SVG's viewBox) without
+              // dominating the viewport — fine detail lives in the lightbox.
+              '[&>svg]:!max-w-full [&>svg]:!max-h-[60vh] [&>svg]:!h-auto [&>svg]:!w-auto',
+            )}
+            dangerouslySetInnerHTML={{ __html: svg }}
+          />
+        ) : (
+          // Initial load (mermaid chunk in flight) — show a quiet placeholder
+          // matching the code-block frame so layout doesn't jump.
+          <pre
+            className={cn(
+              'overflow-x-auto rounded-[12px]',
+              'border border-[var(--msg-code-block-border)]',
+              'bg-[var(--msg-code-block-bg)]',
+              'p-4 font-mono text-[length:var(--app-code-font-size)] leading-[1.5]',
+              'select-text opacity-60',
+            )}
+          >
+            <code className="language-mermaid">{raw}</code>
+          </pre>
+        )}
+      </div>
 
       {error != null && svg == null ? (
         <div

--- a/apps/desktop/src/renderer/components/chat/MarkdownMermaidBlock.tsx
+++ b/apps/desktop/src/renderer/components/chat/MarkdownMermaidBlock.tsx
@@ -203,11 +203,11 @@ export const MarkdownMermaidBlock = memo(function MarkdownMermaidBlock({
   const showSourceView = showSource || (svg == null && error != null);
 
   return (
-    <div ref={blockRef} className="group relative my-3">
+    <div ref={blockRef} className="group relative my-3 flex flex-col">
       {showSourceView ? (
         <pre
           className={cn(
-            'overflow-x-auto rounded-[12px]',
+            '-mt-9 overflow-x-auto rounded-[12px]',
             'border border-[var(--msg-code-block-border)]',
             'bg-[var(--msg-code-block-bg)]',
             'p-4 font-mono text-[length:var(--app-code-font-size)] leading-[1.5]',
@@ -230,7 +230,7 @@ export const MarkdownMermaidBlock = memo(function MarkdownMermaidBlock({
           aria-label={t('chat.mermaid.clickToZoom')}
           title={t('chat.mermaid.clickToZoom')}
           className={cn(
-            'overflow-x-auto rounded-[12px]',
+            '-mt-9 overflow-x-auto rounded-[12px]',
             'border border-[var(--msg-code-block-border)]',
             'bg-[var(--msg-code-block-bg)]',
             'p-4 flex justify-center cursor-zoom-in',
@@ -247,7 +247,7 @@ export const MarkdownMermaidBlock = memo(function MarkdownMermaidBlock({
         // matching the code-block frame so layout doesn't jump.
         <pre
           className={cn(
-            'overflow-x-auto rounded-[12px]',
+            '-mt-9 overflow-x-auto rounded-[12px]',
             'border border-[var(--msg-code-block-border)]',
             'bg-[var(--msg-code-block-bg)]',
             'p-4 font-mono text-[length:var(--app-code-font-size)] leading-[1.5]',
@@ -272,7 +272,7 @@ export const MarkdownMermaidBlock = memo(function MarkdownMermaidBlock({
 
       <div
         className={cn(
-          'absolute right-2 top-2 flex gap-1',
+          'pointer-events-none order-first sticky top-0 z-10 flex h-9 items-end justify-end gap-1 pr-2 select-none',
           'opacity-0 transition-opacity duration-150',
           'group-hover:opacity-100 focus-within:opacity-100',
         )}
@@ -287,7 +287,7 @@ export const MarkdownMermaidBlock = memo(function MarkdownMermaidBlock({
             aria-label={t('chat.mermaid.zoom')}
             title={t('chat.mermaid.zoom')}
             className={cn(
-              'inline-flex h-7 w-7 items-center justify-center',
+              'pointer-events-auto inline-flex h-7 w-7 items-center justify-center',
               'rounded-md border border-[var(--msg-code-block-border)]',
               'bg-[var(--msg-code-block-bg)] text-[var(--msg-tool-text)]',
               'hover:bg-[var(--cmd-palette-item-hover)] hover:text-[var(--msg-assistant-text)]',
@@ -306,7 +306,7 @@ export const MarkdownMermaidBlock = memo(function MarkdownMermaidBlock({
             aria-label={t('chat.mermaid.annotate')}
             title={t('chat.mermaid.annotate')}
             className={cn(
-              'inline-flex h-7 w-7 items-center justify-center',
+              'pointer-events-auto inline-flex h-7 w-7 items-center justify-center',
               'rounded-md border border-[var(--msg-code-block-border)]',
               'bg-[var(--msg-code-block-bg)] text-[var(--msg-tool-text)]',
               'hover:bg-[var(--cmd-palette-item-hover)] hover:text-[var(--msg-assistant-text)]',
@@ -325,7 +325,7 @@ export const MarkdownMermaidBlock = memo(function MarkdownMermaidBlock({
             aria-label={showSourceView ? t('chat.mermaid.viewDiagram') : t('chat.mermaid.viewSource')}
             title={showSourceView ? t('chat.mermaid.viewDiagram') : t('chat.mermaid.viewSource')}
             className={cn(
-              'inline-flex h-7 w-7 items-center justify-center',
+              'pointer-events-auto inline-flex h-7 w-7 items-center justify-center',
               'rounded-md border border-[var(--msg-code-block-border)]',
               'bg-[var(--msg-code-block-bg)] text-[var(--msg-tool-text)]',
               'hover:bg-[var(--cmd-palette-item-hover)] hover:text-[var(--msg-assistant-text)]',
@@ -346,7 +346,7 @@ export const MarkdownMermaidBlock = memo(function MarkdownMermaidBlock({
           aria-label={copied || copiedImage ? t('chat.mermaid.copied') : t('chat.mermaid.copy')}
           title={copied || copiedImage ? t('chat.mermaid.copied') : t('chat.mermaid.copy')}
           className={cn(
-            'inline-flex h-7 w-7 items-center justify-center',
+            'pointer-events-auto inline-flex h-7 w-7 items-center justify-center',
             'rounded-md border border-[var(--msg-code-block-border)]',
             'bg-[var(--msg-code-block-bg)] text-[var(--msg-tool-text)]',
             'hover:bg-[var(--cmd-palette-item-hover)] hover:text-[var(--msg-assistant-text)]',

--- a/apps/desktop/src/renderer/components/chat/MarkdownRenderer.tsx
+++ b/apps/desktop/src/renderer/components/chat/MarkdownRenderer.tsx
@@ -436,9 +436,9 @@ function useStreamingThrottle(value: string, enabled: boolean, intervalMs = 100)
  * CodeBlockPre — fenced code block with a hover-revealed copy button that
  * sticks to the visible top-right corner while the message scrolls. The
  * button reads `innerText` from the live <pre>, so it always copies the latest
- * text even mid-stream. The content's negative top margin overlaps the full
- * height sticky row, keeping the button inside the block's bottom edge without
- * adding layout space. Group-hover keeps it out of the way until needed.
+ * text even mid-stream. The content wrapper's negative top margin overlaps the
+ * full height sticky row, keeping the button inside the block's bottom edge
+ * without adding layout space. Group-hover keeps it out of the way until needed.
  */
 function CodeBlockPre({ children, ...props }: HTMLAttributes<HTMLPreElement>) {
   const { t } = useTranslation();
@@ -492,21 +492,23 @@ function CodeBlockPre({ children, ...props }: HTMLAttributes<HTMLPreElement>) {
           {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
         </button>
       </div>
-      <pre
-        ref={preRef}
-        className={cn(
-          '-mt-9 rounded-[12px]',
-          'border border-[var(--msg-code-block-border)]',
-          'bg-[var(--msg-code-block-bg)]',
-          'p-4 font-mono text-[length:var(--app-code-font-size)] leading-[1.5]',
-          'select-text',
-          // 取消横向滚动:长行/长 token 自动折行,避免出现横滚条
-          'whitespace-pre-wrap break-all',
-        )}
-        {...props}
-      >
-        {children}
-      </pre>
+      <div className="-mt-9">
+        <pre
+          ref={preRef}
+          className={cn(
+            'rounded-[12px]',
+            'border border-[var(--msg-code-block-border)]',
+            'bg-[var(--msg-code-block-bg)]',
+            'p-4 font-mono text-[length:var(--app-code-font-size)] leading-[1.5]',
+            'select-text',
+            // 取消横向滚动:长行/长 token 自动折行,避免出现横滚条
+            'whitespace-pre-wrap break-all',
+          )}
+          {...props}
+        >
+          {children}
+        </pre>
+      </div>
     </div>
   );
 }

--- a/apps/desktop/src/renderer/components/chat/MarkdownRenderer.tsx
+++ b/apps/desktop/src/renderer/components/chat/MarkdownRenderer.tsx
@@ -433,10 +433,12 @@ function useStreamingThrottle(value: string, enabled: boolean, intervalMs = 100)
 }
 
 /**
- * CodeBlockPre — fenced code block with a hover-revealed copy button at the
- * top-right corner. The button reads `innerText` from the live <pre>, so it
- * always copies the latest text even mid-stream. We use group-hover to keep
- * the chrome out of the way until the user reaches for it.
+ * CodeBlockPre — fenced code block with a hover-revealed copy button that
+ * sticks to the visible top-right corner while the message scrolls. The
+ * button reads `innerText` from the live <pre>, so it always copies the latest
+ * text even mid-stream. The content's negative top margin overlaps the full
+ * height sticky row, keeping the button inside the block's bottom edge without
+ * adding layout space. Group-hover keeps it out of the way until needed.
  */
 function CodeBlockPre({ children, ...props }: HTMLAttributes<HTMLPreElement>) {
   const { t } = useTranslation();
@@ -468,10 +470,32 @@ function CodeBlockPre({ children, ...props }: HTMLAttributes<HTMLPreElement>) {
 
   return (
     <div className="group relative my-3">
+      <div
+        className={cn(
+          'pointer-events-none sticky top-0 z-10 flex h-9 items-end justify-end pr-2 select-none',
+          'opacity-0 transition-opacity duration-150',
+          'group-hover:opacity-100 focus-within:opacity-100',
+        )}
+      >
+        <button
+          type="button"
+          onClick={handleCopy}
+          aria-label={copied ? t('chat.markdownRenderer.codeCopied') : t('chat.markdownRenderer.copyCode')}
+          title={copied ? t('chat.markdownRenderer.codeCopied') : t('chat.markdownRenderer.copy')}
+          className={cn(
+            'pointer-events-auto inline-flex h-7 w-7 items-center justify-center',
+            'rounded-md border border-[var(--msg-code-block-border)]',
+            'bg-[var(--msg-code-block-bg)] text-[var(--msg-tool-text)]',
+            'hover:bg-[var(--cmd-palette-item-hover)] hover:text-[var(--msg-assistant-text)]',
+          )}
+        >
+          {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+        </button>
+      </div>
       <pre
         ref={preRef}
         className={cn(
-          'rounded-[12px]',
+          '-mt-9 rounded-[12px]',
           'border border-[var(--msg-code-block-border)]',
           'bg-[var(--msg-code-block-bg)]',
           'p-4 font-mono text-[length:var(--app-code-font-size)] leading-[1.5]',
@@ -483,22 +507,6 @@ function CodeBlockPre({ children, ...props }: HTMLAttributes<HTMLPreElement>) {
       >
         {children}
       </pre>
-      <button
-        type="button"
-        onClick={handleCopy}
-        aria-label={copied ? t('chat.markdownRenderer.codeCopied') : t('chat.markdownRenderer.copyCode')}
-        title={copied ? t('chat.markdownRenderer.codeCopied') : t('chat.markdownRenderer.copy')}
-        className={cn(
-          'absolute right-2 top-2 inline-flex h-7 w-7 items-center justify-center',
-          'rounded-md border border-[var(--msg-code-block-border)]',
-          'bg-[var(--msg-code-block-bg)] text-[var(--msg-tool-text)]',
-          'opacity-0 transition-opacity duration-150',
-          'group-hover:opacity-100 focus-visible:opacity-100',
-          'hover:bg-[var(--cmd-palette-item-hover)] hover:text-[var(--msg-assistant-text)]',
-        )}
-      >
-        {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
-      </button>
     </div>
   );
 }


### PR DESCRIPTION
## 这次改了什么

### 摘要

Agent 回复里的长 Markdown 内容块原本只在内容块固定右上角提供复制按钮；滚动到内容块中段后，用户需要回到顶部才能复制。本 PR 将已有复制能力的 Markdown 块工具栏改为 sticky：代码块、表格、块级公式和 Mermaid 在消息滚动时，工具栏会停留在当前可视区域右上角，并在内容块离开时随块一起离开。

### 变更类型

- [x] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：普通 fenced code block、表格、块级公式及 Mermaid 的已有复制/标注工具栏 sticky 定位；结构回归测试。
- 明确不包含：不为原本没有复制按钮的 diff 块新增复制能力；不修改移动端、复制内容格式或消息级复制操作。
- 用户可见变化：鼠标悬停长内容块并滚动消息时，已有工具栏保持在该块当前可视区域的右上角。
- 是否存在 breaking change：无。

### UI 变化

- 引用的设计规范：`docs/design-rules/DESIGN.md` §1 Visual Theme & Atmosphere、§3 Typography、§4 Spacing / Radius、§10 Theme System & Token Reference。实现复用现有 Lucide 图标、12px 内容容器、按钮尺寸、hover/复制成功反馈和语义颜色 token；Light/Dark 继续走同一组主题 token，未新增硬编码颜色。sticky 工具栏使用完整高度定位行并让内容负边距回叠，保持原布局尺寸。

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：通过（apps/desktop related unit tests）。

pnpm --filter desktop typecheck
结果：通过。

pnpm --filter desktop exec eslint src/renderer/components/chat/MarkdownRenderer.tsx src/renderer/components/chat/CopyAsImageBlock.tsx src/renderer/components/chat/MarkdownMermaidBlock.tsx src/renderer/__tests__/markdownFloatingToolbar.test.ts
结果：通过。

pnpm --filter desktop exec vitest run src/renderer/__tests__/markdownFloatingToolbar.test.ts src/renderer/__tests__/markdownFencedCodeInline.test.ts src/renderer/__tests__/markdownDiffBlock.test.ts src/renderer/__tests__/markdownMathRendering.test.ts
结果：通过，4 files / 55 tests。

git diff --check
结果：通过。
```

### 手工验证

- Chrome 几何 smoke：初始位置距内容块顶部 8px；滚动到内容块中段后距滚动视口顶部 8px；到达内容块底部时工具栏不越过块底边。
- 验证了普通代码块，以及 `flex + order-first` 结构下的表格/Mermaid。

### 未执行的验证

- 未启动完整 Desktop 应用做 Light/Dark 双模式实机目检；样式沿用现有语义 token，深色几何 smoke 已检查，但不将其视为双模式实机验证。
- 未在 Windows 实机验证；改动仅涉及 Renderer CSS 布局类，不含平台分支。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：CSS sticky 行为依赖消息流现有滚动容器与祖先 overflow 结构。

### 影响与回滚

- 影响范围：Desktop Renderer 的 Markdown fenced code、表格、块级公式和 Mermaid 工具栏布局。
- 回滚 / 降级方式：恢复这些工具栏原有的 `absolute right-2 top-2` 定位，并移除内容回叠类与对应回归测试即可；复制逻辑和数据格式未变化。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
