### PR TITLE
fix(desktop): 避免 macOS 启动时恢复全屏侧边栏

### DIFF
--- a/apps/desktop/src/main/right-sidebar-window/__tests__/windowState.test.ts
+++ b/apps/desktop/src/main/right-sidebar-window/__tests__/windowState.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  manage: vi.fn(),
+  windowStateKeeper: vi.fn(),
+}));
+
+vi.mock('electron-window-state', () => ({ default: mocks.windowStateKeeper }));
+vi.mock('../../logger.js', () => ({
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+vi.mock('../../windowFocusClassifier.js', () => ({ markAppContentWindow: vi.fn() }));
+vi.mock('../../window-behavior-settings-store.js', () => ({
+  readWindowBehaviorSettings: () => ({ swallowActivationClick: true }),
+}));
+vi.mock('../../secondary-windows.js', () => ({ installExternalLinkGuards: vi.fn() }));
+vi.mock('../../selection-context-menu.js', () => ({ installSelectionContextMenu: vi.fn() }));
+vi.mock('../../appearance-settings-ipc.js', () => ({ applyAppearanceToWindow: vi.fn() }));
+vi.mock('../registry.js', () => ({ markRsbWindowWebContentsId: vi.fn() }));
+
+import { createRightSidebarWindow } from '../window';
+
+describe('createRightSidebarWindow window state', () => {
+  beforeEach(() => {
+    mocks.windowStateKeeper.mockReturnValue({
+      x: 100,
+      y: 120,
+      width: 520,
+      height: 860,
+      manage: mocks.manage,
+    });
+    vi.stubGlobal('MAIN_WINDOW_VITE_DEV_SERVER_URL', undefined);
+    vi.stubGlobal('MAIN_WINDOW_VITE_NAME', 'main_window');
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('restores geometry without restoring modes that can reveal the hidden prewarm window', () => {
+    const win = createRightSidebarWindow();
+
+    expect(mocks.windowStateKeeper).toHaveBeenCalledWith({
+      defaultWidth: 520,
+      defaultHeight: 860,
+      file: 'right-sidebar-window-state.json',
+      maximize: false,
+      fullScreen: false,
+    });
+    expect(mocks.manage).toHaveBeenCalledWith(win);
+  });
+});

--- a/apps/desktop/src/main/right-sidebar-window/window.ts
+++ b/apps/desktop/src/main/right-sidebar-window/window.ts
@@ -39,6 +39,10 @@ export function createRightSidebarWindow(): BrowserWindow {
     defaultWidth: 520,
     defaultHeight: 860,
     file: 'right-sidebar-window-state.json',
+    // The window is prewarmed while hidden on every launch. Restoring either
+    // presentation mode can make Electron show it before the controller opens it.
+    maximize: false,
+    fullScreen: false,
   });
 
   const win = new BrowserWindow({


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 macOS 冷启动 Cindy 时，预热的独立右侧栏恢复历史全屏或最大化状态、导致侧边栏覆盖主界面的问题。右侧栏仍会恢复上次的位置和尺寸，但不再跨启动恢复全屏或最大化状态，并补充单元测试锁定配置。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：独立右侧栏 BrowserWindow 状态恢复策略及对应单元测试
- 明确不包含：Renderer 布局、侧边栏停靠逻辑和其他辅助窗口
- 用户可见变化：macOS 冷启动时不再自动出现全屏独立右侧栏
- 是否存在 breaking change：无

### UI 变化

不涉及视觉、样式或文案变化；仅修正独立 BrowserWindow 的启动状态恢复行为。

- 引用的设计规范：不涉及；未修改 Renderer UI、视觉 token 或交互控件

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：通过，apps/desktop 相关单测通过

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm check:dco
结果：通过，1 个提交已签名
```

### 手工验证

macOS、Global Dev 隔离沙盒 `merry-edison-76f8a1`：不手动打开右侧栏，冷启动后仅出现主窗口；主窗口为 1280 × 800，系统辅助功能状态 `AXFullScreen=false`，未出现独立全屏右侧栏。用户已验收通过。

### 未执行的验证

未在 Windows 实机验证；本次修改只禁止辅助窗口跨启动恢复最大化/全屏状态，位置和尺寸恢复保持不变。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅独立右侧栏窗口；位置和尺寸仍会恢复，但最大化与全屏状态不再跨启动恢复
- 回滚 / 降级方式：回滚本 PR 即恢复原有窗口状态恢复行为

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次无需文档变更）
- [x] 已确认测试结果或说明未执行原因