### PR TITLE
fix(desktop): 修复流式文字中间透明空洞

### DIFF
--- a/apps/desktop/src/renderer/components/chat/MarkdownRenderer.tsx
+++ b/apps/desktop/src/renderer/components/chat/MarkdownRenderer.tsx
@@ -11,7 +11,7 @@
  *   into Markdown image nodes before HTML filtering.
  */
 
-import { createElement, memo, useCallback, useEffect, useLayoutEffect, useRef, useState, useMemo, isValidElement, type AnimationEvent as ReactAnimationEvent, type HTMLAttributes, type ReactNode } from 'react';
+import { createElement, memo, useCallback, useEffect, useLayoutEffect, useRef, useState, useMemo, isValidElement, type HTMLAttributes, type ReactNode } from 'react';
 import ReactMarkdown, { defaultUrlTransform } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import remarkCjkFriendly from 'remark-cjk-friendly';
@@ -36,10 +36,10 @@ import {
   commitWordFadeCandidate,
   createWordFadeCandidate,
   getOrCreateWordFadeState,
-  markSettledFromAnimationEnd,
   releaseWordFadeState,
   rehypeStreamWordFade,
 } from './rehypeStreamWordFade';
+import { StreamFadeSpan } from './StreamFadeSpan';
 import { repairStreamingMarkdown } from './repairStreamingMarkdown';
 import { useReducedMotion } from '@/hooks/useReducedMotion';
 import { useStreamFadeEnabled } from '@/hooks/useStreamFadePreference';
@@ -1692,11 +1692,6 @@ export const MarkdownRenderer = memo(function MarkdownRenderer({
     }
   }, [wordFadeState, wordFade]);
   const rehypePlugins = wordFade?.plugins ?? REHYPE_PLUGINS;
-  const handleWordFadeAnimationEnd = useMemo(() => {
-    if (!wordFadeState) return undefined;
-    return (event: ReactAnimationEvent<HTMLDivElement>) =>
-      markSettledFromAnimationEnd(wordFadeState, event.nativeEvent);
-  }, [wordFadeState]);
   const [lightboxSrc, setLightboxSrc] = useState<string | null>(null);
   // 远程入方向:远程会话里 markdown 的图片/音频 URL 指向远端机器,按来源改写到
   // cindy-remote-media://(device 经 OSS 中转、ssh 经 file-service 落盘缓存)。本地
@@ -1723,6 +1718,15 @@ export const MarkdownRenderer = memo(function MarkdownRenderer({
   } | null>(null);
   // model-local chip/link click → in-app 3D preview (ModelLightbox, local mode).
   const [modelLightboxPath, setModelLightboxPath] = useState<string | null>(null);
+  const streamFadeComponents = useMemo<Components>(
+    () =>
+      wordFadeState
+        ? {
+            span: (props) => <StreamFadeSpan {...props} wordFadeState={wordFadeState} />,
+          }
+        : {},
+    [wordFadeState],
+  );
 
   // workingDir and localFileRefs are stable within a session lifecycle — they
   // only change on session switch or when the message list gains a new user
@@ -1731,6 +1735,7 @@ export const MarkdownRenderer = memo(function MarkdownRenderer({
   const components = useMemo<Components>(
     () => ({
       ...baseComponents,
+      ...streamFadeComponents,
       // doc-mode anchor: emitSourceLines=true 时把 baseComponents 里的 block
       // renderer 整体替换成带 data-source-line 注入的版本。chat 调用方不传 prop
       // → 默认 false → 整段是 falsy 短路, components 对象与之前完全一致。
@@ -1885,11 +1890,12 @@ export const MarkdownRenderer = memo(function MarkdownRenderer({
       currentSessionTitle,
       allowPrivilegedLinks,
       remoteMediaOrigin,
+      streamFadeComponents,
     ],
   );
 
   return (
-    <div className="msg-markdown select-text" onAnimationEnd={handleWordFadeAnimationEnd}>
+    <div className="msg-markdown select-text">
       <ReactMarkdown
         remarkPlugins={allowPrivilegedLinks ? REMARK_PLUGINS_PRIVILEGED : REMARK_PLUGINS}
         rehypePlugins={rehypePlugins}

--- a/apps/desktop/src/renderer/components/chat/StreamFadeSpan.tsx
+++ b/apps/desktop/src/renderer/components/chat/StreamFadeSpan.tsx
@@ -1,0 +1,50 @@
+import type {
+  AnimationEvent as ReactAnimationEvent,
+  ComponentPropsWithoutRef,
+} from 'react';
+import type { Element } from 'hast';
+
+import { markWordFadeSettled, type WordFadeState } from './rehypeStreamWordFade';
+
+interface StreamFadeSpanProps extends ComponentPropsWithoutRef<'span'> {
+  node?: Element;
+  wordFadeState: WordFadeState | null;
+}
+
+/**
+ * ReactMarkdown 给自定义 renderer 的外层 key 是位置型 span-N。这里再用逻辑 key
+ * 标识真实 DOM span:位置被复用给别的段时会 remount,旧动画不能污染新段。
+ */
+export function StreamFadeSpan({
+  children,
+  node,
+  onAnimationEnd,
+  wordFadeState,
+  ...props
+}: StreamFadeSpanProps) {
+  const rawWordFadeKey = node?.properties?.dataWfKey;
+  const wordFadeKey = typeof rawWordFadeKey === 'string' ? rawWordFadeKey : undefined;
+  const handleAnimationEnd = (event: ReactAnimationEvent<HTMLSpanElement>) => {
+    onAnimationEnd?.(event);
+    if (
+      !wordFadeState ||
+      !wordFadeKey ||
+      event.target !== event.currentTarget ||
+      event.animationName !== 'stream-word-in'
+    ) {
+      return;
+    }
+    markWordFadeSettled(wordFadeState, wordFadeKey);
+  };
+
+  return (
+    <span
+      key={wordFadeKey}
+      {...props}
+      data-wf-key={wordFadeKey}
+      onAnimationEnd={handleAnimationEnd}
+    >
+      {children}
+    </span>
+  );
+}

--- a/apps/desktop/src/renderer/components/chat/__tests__/StreamFadeSpan.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/__tests__/StreamFadeSpan.test.tsx
@@ -1,0 +1,145 @@
+// @vitest-environment jsdom
+
+import { useLayoutEffect, useMemo, type AnimationEvent as ReactAnimationEvent } from 'react';
+import { cleanup, fireEvent, render } from '@testing-library/react';
+import ReactMarkdown, { type Components } from 'react-markdown';
+import type { PluggableList } from 'unified';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { StreamFadeSpan } from '../StreamFadeSpan';
+import {
+  commitWordFadeCandidate,
+  createWordFadeCandidate,
+  createWordFadeState,
+  rehypeStreamWordFade,
+  type WordFadeState,
+} from '../rehypeStreamWordFade';
+
+afterEach(cleanup);
+
+function fireAnimationEnd(element: Element, animationName = 'stream-word-in'): void {
+  // jsdom 没有 AnimationEvent,React 会选择 WebKit 前缀事件名。
+  const event = new Event('webkitAnimationEnd', { bubbles: true });
+  Object.defineProperty(event, 'animationName', { value: animationName });
+  fireEvent(element, event);
+}
+
+function StreamingMarkdownHarness({
+  content,
+  state,
+}: {
+  content: string;
+  state: WordFadeState;
+}) {
+  const candidate = useMemo(() => createWordFadeCandidate(state), [content, state]);
+  const rehypePlugins = useMemo(
+    () => [[rehypeStreamWordFade, candidate]] as PluggableList,
+    [candidate],
+  );
+  const components = useMemo<Components>(
+    () => ({
+      span: (props) => <StreamFadeSpan {...props} wordFadeState={state} />,
+    }),
+    [state],
+  );
+
+  useLayoutEffect(() => {
+    commitWordFadeCandidate(state, candidate);
+  }, [candidate, state]);
+
+  return (
+    <ReactMarkdown rehypePlugins={rehypePlugins} components={components}>
+      {content}
+    </ReactMarkdown>
+  );
+}
+
+describe('StreamFadeSpan', () => {
+  it('动画结束使用 render 时捕获的 key,不读取后来变化的 dataset', () => {
+    const state = createWordFadeState();
+    let forwardedTargetMatched = false;
+    const forwardedAnimationEnd = vi.fn((event: ReactAnimationEvent<HTMLSpanElement>) => {
+      forwardedTargetMatched = event.target === event.currentTarget;
+    });
+    const { container } = render(
+      <StreamFadeSpan
+        className="stream-word"
+        node={{
+          type: 'element',
+          tagName: 'span',
+          properties: { dataWfKey: 'wf-original' },
+          children: [],
+        }}
+        onAnimationEnd={forwardedAnimationEnd}
+        wordFadeState={state}
+      >
+        word
+      </StreamFadeSpan>,
+    );
+    const span = container.querySelector<HTMLSpanElement>('.stream-word');
+    expect(span).not.toBeNull();
+    expect(span!.dataset.wfKey).toBe('wf-original');
+
+    span!.dataset.wfKey = 'wf-reused';
+    fireAnimationEnd(span!);
+
+    expect(forwardedAnimationEnd).toHaveBeenCalledOnce();
+    expect(forwardedAnimationEnd.mock.calls[0][0].animationName).toBe('stream-word-in');
+    expect(forwardedTargetMatched).toBe(true);
+    expect(state.settled.has('wf-original')).toBe(true);
+    expect(state.settled.has('wf-reused')).toBe(false);
+  });
+
+  it('忽略子节点冒泡和其它动画名', () => {
+    const state = createWordFadeState();
+    const { container } = render(
+      <StreamFadeSpan
+        className="stream-word"
+        node={{
+          type: 'element',
+          tagName: 'span',
+          properties: { dataWfKey: 'wf-atom' },
+          children: [],
+        }}
+        wordFadeState={state}
+      >
+        <code>atom</code>
+      </StreamFadeSpan>,
+    );
+    const span = container.querySelector<HTMLSpanElement>('.stream-word')!;
+
+    fireAnimationEnd(span.querySelector('code')!);
+    fireAnimationEnd(span, 'spinner-rotate');
+
+    expect(state.settled.size).toBe(0);
+  });
+
+  it('settled 前缀拆除导致位置 key 前移时重建真实 span,旧节点不能结算新段', () => {
+    const state = createWordFadeState();
+    state.nowFn = () => 0;
+    const view = render(<StreamingMarkdownHarness content="one two three" state={state} />);
+    const firstFrame = Array.from(
+      view.container.querySelectorAll<HTMLSpanElement>('.stream-word'),
+    );
+    const oldFirst = firstFrame[0];
+    const oldSecond = firstFrame[1];
+    const secondKey = oldSecond.dataset.wfKey!;
+
+    fireAnimationEnd(oldFirst);
+    view.rerender(<StreamingMarkdownHarness content="one two three four" state={state} />);
+
+    const secondFrame = Array.from(
+      view.container.querySelectorAll<HTMLSpanElement>('.stream-word'),
+    );
+    expect(secondFrame.map((span) => span.textContent)).toEqual(['two ', 'three ', 'four']);
+    expect(secondFrame[0].dataset.wfKey).toBe(secondKey);
+    expect(secondFrame[0]).not.toBe(oldFirst);
+    expect(oldSecond.isConnected).toBe(false);
+
+    fireAnimationEnd(oldSecond);
+    expect(state.settled.has(secondKey)).toBe(false);
+
+    fireAnimationEnd(secondFrame[0]);
+    expect(state.settled.has(secondKey)).toBe(true);
+  });
+});

--- a/apps/desktop/src/renderer/components/chat/__tests__/rehypeStreamWordFade.test.ts
+++ b/apps/desktop/src/renderer/components/chat/__tests__/rehypeStreamWordFade.test.ts
@@ -17,7 +17,6 @@ import {
   createWordFadeCandidate,
   createWordFadeState,
   getOrCreateWordFadeState,
-  markSettledFromAnimationEnd,
   releaseWordFadeState,
   rehypeStreamWordFade,
   splitWords,
@@ -99,7 +98,7 @@ describe('splitWords', () => {
 });
 
 describe('rehypeStreamWordFade', () => {
-  it('同一条流式消息 remount 后沿用原时间线，已有词不从头重播', () => {
+  it('同一条流式消息 remount 超过动画时长后把旧词兜底落袋', () => {
     const cacheKey = 'session-1\u0000message-1';
     const firstMount = getOrCreateWordFadeState(cacheKey);
     const tree1 = root(el('p', [textNode('one two')]));
@@ -112,9 +111,9 @@ describe('rehypeStreamWordFade', () => {
     const words = collectWords(tree2);
 
     expect(remount).toBe(firstMount);
-    expect(words.slice(0, 2).map((word) => word.key)).toEqual(firstKeys);
-    expect(words.slice(0, 2).every((word) => word.delay < -150)).toBe(true);
-    expect(words[2].delay).toBe(0);
+    expect(firstKeys.every((key) => remount.settled.has(key))).toBe(true);
+    expect(words.map((word) => word.text)).toEqual(['three']);
+    expect(words[0].delay).toBe(0);
   });
 
   it('消息进入终态后释放 remount 状态', () => {
@@ -170,7 +169,8 @@ describe('rehypeStreamWordFade', () => {
     const tree2 = root(el('p', [textNode('a b x y z')]));
     run(tree2, state, 5000);
     const words = collectWords(tree2);
-    expect(words.slice(2).map((w) => w.delay)).toEqual([0, 0, 0]);
+    expect(words.map((w) => w.text)).toEqual(['x ', 'y ', 'z']);
+    expect(words.map((w) => w.delay)).toEqual([0, 0, 0]);
   });
 
   it('chunk 边界半个词长成整词:前缀延续复用同一 key', () => {
@@ -407,13 +407,12 @@ describe('rehypeStreamWordFade', () => {
     const tree2 = root(el('p', [textNode('one two three four')]));
     run(tree2, state, 500);
     const words2 = collectWords(tree2);
-    expect(words2.map((w) => w.text)).toEqual(['two ', 'three ', 'four']);
+    expect(words2.map((w) => w.text)).toEqual(['four']);
     const p = tree2.children[0] as Element;
-    expect(p.children[0]).toEqual(textNode('one '));
-    // 活动词仍保住原 key,负 delay 继续提供 remount 免疫；新词立即开始。
-    expect(words2[0].key).toBe(words1[1].key);
-    expect(words2[1].key).toBe(words1[2].key);
-    expect(words2[1].delay).toBe(-500);
+    expect(p.children[0]).toEqual(textNode('one two three '));
+    // 即使 remount 丢了 animationend,超过 150ms 的旧词也会按开播时刻自动落袋。
+    expect(words1.every((word) => state.settled.has(word.key))).toBe(true);
+    expect(words2[0].delay).toBe(0);
   });
 
   it('长 settled 前缀只保留一个原生文本节点', () => {
@@ -427,28 +426,8 @@ describe('rehypeStreamWordFade', () => {
     const tree2 = root(el('p', [textNode(`${prefix} tail next`)]));
     run(tree2, state, 500);
     const p = tree2.children[0] as Element;
-    expect(p.children[0]).toEqual(textNode(`${prefix} `));
-    expect(collectWords(tree2).map((w) => w.text)).toEqual(['tail ', 'next']);
-  });
-});
-
-describe('markSettledFromAnimationEnd', () => {
-  function fadeEndEvent(wfKey: string | undefined, animationName = 'stream-word-in') {
-    const target = (wfKey === undefined ? {} : { dataset: { wfKey } }) as unknown as EventTarget;
-    return { animationName, target };
-  }
-
-  it('stream-word-in 播完的词 key 进 settled', () => {
-    const state = createWordFadeState();
-    markSettledFromAnimationEnd(state, fadeEndEvent('wf-3'));
-    expect(state.settled.has('wf-3')).toBe(true);
-  });
-
-  it('其它动画名 / 非 stream-word 目标都不落袋', () => {
-    const state = createWordFadeState();
-    markSettledFromAnimationEnd(state, fadeEndEvent('wf-1', 'spinner-rotate'));
-    markSettledFromAnimationEnd(state, fadeEndEvent(undefined));
-    expect(state.settled.size).toBe(0);
+    expect(p.children[0]).toEqual(textNode(`${prefix} tail `));
+    expect(collectWords(tree2).map((w) => w.text)).toEqual(['next']);
   });
 });
 

--- a/apps/desktop/src/renderer/components/chat/rehypeStreamWordFade.ts
+++ b/apps/desktop/src/renderer/components/chat/rehypeStreamWordFade.ts
@@ -17,9 +17,10 @@
  *     没有才发新 key。markdown 结构变化(列表标记吃掉 "2. "、加粗闭合劈开文本
  *     节点、Segmenter 对 chunk 尾部的切分变化)只会让**词序号**漂移,key 不漂 ——
  *     漂移序号曾让已稳定的整片前文被当新词重淡(2026-08-08 实测)。
- *   - **settled 落袋 + settled 前缀还原纯文本**:span 带 data-wf-key,
- *     MarkdownRenderer 根节点监听冒泡的 animationend(markSettledFromAnimationEnd),
- *     播完的 key 进 state.settled;settled 词从槽位中还原为合并后的原生文本,
+ *   - **settled 落袋 + settled 前缀还原纯文本**:span 带 data-wf-key,作为 HAST
+ *     到 React renderer 的逻辑身份通道;StreamFadeSpan 用该 key 控制真实 DOM
+ *     remount,并由每个 span 的 animationend 闭包把自身 key 放进 state.settled。
+ *     settled 词从槽位中还原为合并后的原生文本,
  *     settled inline code 则恢复原始 code 节点,
  *     只保留仍在播放的尾部 span——流式长文档的元素数因此回落到与无动效渲染
  *     同阶,react-markdown 每 tick 的重建 + diff 不随已播完的前文线性涨
@@ -95,6 +96,9 @@ export interface WordFadeState {
   nowFn?: () => number;
 }
 
+/** 与 globals.css 的 --motion-fast 保持一致,用于 animationend 丢失时的到期兜底。 */
+const FADE_DURATION_MS = 150;
+
 export function createWordFadeState(): WordFadeState {
   return {
     nextId: 0,
@@ -163,19 +167,9 @@ export function _resetWordFadeStateCacheForTests(): void {
   wordFadeStateCache.clear();
 }
 
-/**
- * animationend 落袋入口:MarkdownRenderer 根节点上监听冒泡的 animationend,
- * 把播完 stream-word-in 的段 key 记进 state.settled。按动画名过滤 —— 同一子树里
- * 其它动画(代码高亮、chip 等)的 animationend 不误伤。
- */
-export function markSettledFromAnimationEnd(
-  state: WordFadeState,
-  event: { animationName: string; target: EventTarget | null },
-): void {
-  if (event.animationName !== 'stream-word-in') return;
-  const target = event.target as { dataset?: { wfKey?: string } } | null;
-  const key = target?.dataset?.wfKey;
-  if (key) state.settled.add(key);
+/** animationend 闭包的落袋入口;身份来自 render 时捕获的 key,不读取可变 DOM dataset。 */
+export function markWordFadeSettled(state: WordFadeState, key: string): void {
+  state.settled.add(key);
 }
 
 /** 整棵子树跳过(不进入):块级代码、非正文节点与公式内部结构。 */
@@ -503,6 +497,14 @@ export const rehypeStreamWordFade: Plugin<[WordFadeState], Root> = (state) => {
     // pass 3:回填 span。同 tick 新段全部 0ms 开始,旧段按绝对开播时刻续播。
     // 槽位从后往前 splice,前面槽位的 index 不受影响。
     const nowMs = (state.nowFn ?? (() => performance.now()))();
+    // 结构变化会让活动 span remount,旧节点因此可能收不到 animationend。超过动画
+    // 时长的已开播段直接落袋,避免它永久保留活动包装。
+    for (const key of keys) {
+      const startAt = state.startAtByKey.get(key);
+      if (startAt !== undefined && nowMs - startAt >= FADE_DURATION_MS) {
+        state.settled.add(key);
+      }
+    }
     const nodesBySlot = slots.map((slot) => {
       // 全 settled 槽位不改树(性能核心,见 isSlotFullySettled 注释)。
       if (isSlotFullySettled(slot, keys, state)) return null;


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复流式 Markdown 在 settled 前缀收缩后复用错误 DOM 节点，导致中间文字仍透明、后续文字提前显示的问题。流式段现在由 React 组件闭包绑定自身逻辑 key，并在节点身份变化时重建真实 span；同时增加动画结束事件丢失时的到期结算。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：流式文字淡入期间出现中间透明空洞
- 本 PR 包含：流式 span 的 React 身份护栏、闭包结算、150ms 到期兜底及真实 ReactMarkdown 重渲染测试
- 明确不包含：流式动画节奏、分段延迟、Markdown 解析架构调整
- 用户可见变化：流式输出不再出现中间文字透明、后续文字先显示的空洞
- 是否存在 breaking change：无

### UI 变化

不涉及视觉样式、颜色、布局或文案变化；仅修复已有流式淡入动效的节点身份错误。

- 引用的设计规范：`docs/design-rules/DESIGN.md` §14.4；保持 150ms opacity 淡入、稳定分段身份、动画不重播与 reduced-motion 现有行为。

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：通过，Desktop related 5。

pnpm --filter desktop run --if-present typecheck
结果：通过。

pnpm --filter desktop exec vitest run src/renderer/components/chat/__tests__/rehypeStreamWordFade.test.ts src/renderer/components/chat/__tests__/StreamFadeSpan.test.tsx
结果：通过，31 项测试。

pnpm --filter desktop exec eslint src/renderer/components/chat/MarkdownRenderer.tsx src/renderer/components/chat/rehypeStreamWordFade.ts src/renderer/components/chat/StreamFadeSpan.tsx src/renderer/components/chat/__tests__/rehypeStreamWordFade.test.ts src/renderer/components/chat/__tests__/StreamFadeSpan.test.tsx
结果：通过。

pnpm check:dco
结果：通过，1 个 commit 已签名。
```

### 手工验证

Windows Global 隔离开发沙盒中复现流式长文本输出，确认中间透明空洞消失；用户验收通过。

### 未执行的验证

- 未运行全仓 `pnpm test:unit`，按仓库流程由 GitHub CI 执行完整单测。
- 未单独执行 macOS 实机目检；改动仅涉及 React DOM 身份与事件结算，不包含平台分支。
- 未分别执行 Light / Dark 目检；改动未调整样式、颜色或主题 token。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop 流式 Markdown 淡入启用时的文本与行内代码段；静态 Markdown 路径不注册额外 span renderer。
- 回滚 / 降级方式：回退本 PR；用户也可通过现有“流式动效”设置关闭该动效。
- 移动端冷更判断：不触发。本 PR 仅修改 `apps/desktop` Renderer TypeScript 与测试，不涉及 `apps/mobile`、原生依赖、config plugin 或 runtime fingerprint 输入。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因