### PR TITLE
fix(mobile): 同意隐私政策前禁止发起携带 eas-client-id 的 OTA 更新检查

### DIFF
--- a/apps/mobile/app/settings.tsx
+++ b/apps/mobile/app/settings.tsx
@@ -32,6 +32,7 @@ import {
   subscribeAnalyticsConsent,
 } from '@/analytics/analyticsConsentStore';
 import { initMobileTapdb, setTapdbUser, stopMobileTapdbReporting } from '@/analytics/mobileTapdb';
+import { hasPrivacyConsent } from '@/update/updateConsentGate';
 import { SUPPORTED_LOCALES, type LocalePreference } from '@/i18n';
 import { useLocale } from '@/i18n/useLocale';
 import { goBackGuarded } from '@/utils/backGuard';
@@ -322,9 +323,11 @@ export default function SettingsScreen() {
     try {
       const outcome = await runManualUpdateCheck({
         checkBundleUpdate: bundleCheckEnabled ? checkBundleUpdate : undefined,
-        // OTA 检查会携带 eas-client-id,须经隐私同意闸门(企业 SSO 豁免协议门,
-        // 可能未同意);整包 /latest 为匿名请求,不在此列,仍按 bundleCheckEnabled 放行。
-        otaEnabled: updatesEnabled && getAnalyticsConsentState().consent,
+        otaEnabled: updatesEnabled,
+        // OTA 检查会携带 eas-client-id,须经隐私同意闸门(企业 SSO 豁免协议门,可能未
+        // 同意;且检查进行中登出会撤销同意)。整包 /latest 为匿名请求,不在此列。动态
+        // 判定而非调用瞬间快照,manifest 请求前与资源下载前各问一次。
+        isConsented: hasPrivacyConsent,
         checkOtaUpdate: () => Updates.checkForUpdateAsync(),
         fetchOtaUpdate: () => Updates.fetchUpdateAsync(),
         reload: () => Updates.reloadAsync(),

--- a/apps/mobile/app/settings.tsx
+++ b/apps/mobile/app/settings.tsx
@@ -322,7 +322,9 @@ export default function SettingsScreen() {
     try {
       const outcome = await runManualUpdateCheck({
         checkBundleUpdate: bundleCheckEnabled ? checkBundleUpdate : undefined,
-        otaEnabled: updatesEnabled,
+        // OTA 检查会携带 eas-client-id,须经隐私同意闸门(企业 SSO 豁免协议门,
+        // 可能未同意);整包 /latest 为匿名请求,不在此列,仍按 bundleCheckEnabled 放行。
+        otaEnabled: updatesEnabled && getAnalyticsConsentState().consent,
         checkOtaUpdate: () => Updates.checkForUpdateAsync(),
         fetchOtaUpdate: () => Updates.fetchUpdateAsync(),
         reload: () => Updates.reloadAsync(),

--- a/apps/mobile/src/update/manualUpdateCheck.test.ts
+++ b/apps/mobile/src/update/manualUpdateCheck.test.ts
@@ -88,6 +88,30 @@ describe('runManualUpdateCheck', () => {
     expect(input.checkOtaUpdate).not.toHaveBeenCalled();
   });
 
+  it('skips OTA when consent is false at manifest time, before any request', async () => {
+    const input = deps({
+      checkBundleUpdate: bundleCheck('up-to-date'),
+      isConsented: () => false,
+    });
+    await expect(runManualUpdateCheck(input)).resolves.toEqual({ kind: 'ota-unavailable' });
+    expect(input.checkOtaUpdate).not.toHaveBeenCalled();
+  });
+
+  it('re-checks consent before downloading after the manifest resolves', async () => {
+    // manifest 请求期间用户登出撤销同意:下载前再问一次,不得继续拉取带标识的 bundle。
+    let consented = true;
+    const input = deps({
+      isConsented: () => consented,
+      checkOtaUpdate: vi.fn(async () => {
+        consented = false;
+        return { isAvailable: true };
+      }),
+    });
+    await expect(runManualUpdateCheck(input)).resolves.toEqual({ kind: 'ota-unavailable' });
+    expect(input.checkOtaUpdate).toHaveBeenCalledOnce();
+    expect(input.fetchOtaUpdate).not.toHaveBeenCalled();
+  });
+
   // emergency launch(没有 launchedUpdate)时 reloadAsync 会被原生层拒绝,但 bundle 已落盘:
   // 这不是一次失败的检查,必须导向"重开 App 生效",否则用户只看到一条无从下手的红字报错。
   it('asks for a manual restart when an emergency launch blocks reloading the downloaded bundle', async () => {

--- a/apps/mobile/src/update/manualUpdateCheck.ts
+++ b/apps/mobile/src/update/manualUpdateCheck.ts
@@ -27,6 +27,12 @@ export interface ManualUpdateCheckDeps {
   /** 自建线传入整包检查;EAS 线省略后直接检查 OTA。 */
   checkBundleUpdate?: () => Promise<BundleUpdateCheckOutcome>;
   otaEnabled: boolean;
+  /**
+   * 隐私同意闸门(动态判定,非调用瞬间快照):manifest 请求前与资源下载前分别重查。
+   * 用户点击「检查更新」后、请求尚未完成时登出撤销同意,这里必须停止继续携带
+   * eas-client-id 的请求。缺省(未提供)视为不启用该闸门。
+   */
+  isConsented?: () => boolean;
   checkOtaUpdate: () => Promise<{ isAvailable: boolean }>;
   /** isNew 表示确实落盘了一个新 bundle(reload 失败时用它区分"已下载待重启"与"什么都没拿到")。 */
   fetchOtaUpdate: () => Promise<{ isNew: boolean }>;
@@ -46,6 +52,7 @@ export interface ManualUpdateCheckDeps {
 export async function runManualUpdateCheck({
   checkBundleUpdate,
   otaEnabled,
+  isConsented,
   checkOtaUpdate,
   fetchOtaUpdate,
   reload,
@@ -67,11 +74,17 @@ export async function runManualUpdateCheck({
   }
 
   if (!otaEnabled) return { kind: 'ota-unavailable' };
+  // 整包检查是匿名请求,不受同意门约束;只有 OTA manifest/资源会携带 eas-client-id,
+  // 在发起 manifest 请求前先问一次同意(处理「点击检查时未同意」的快照与实况不一致)。
+  if (isConsented && !isConsented()) return { kind: 'ota-unavailable' };
 
   let fetchedNewBundle = false;
   try {
     const ota = await checkOtaUpdate();
     if (!ota.isAvailable) return { kind: 'up-to-date' };
+    // manifest 请求期间用户可能登出撤销同意:下载资源前再问一次,不得在撤销后继续
+    // 拉取带标识的 bundle。
+    if (isConsented && !isConsented()) return { kind: 'ota-unavailable' };
     onPhase('downloading');
     const fetched = await fetchOtaUpdate();
     fetchedNewBundle = fetched.isNew;

--- a/apps/mobile/src/update/resumeUpdateCheck.test.ts
+++ b/apps/mobile/src/update/resumeUpdateCheck.test.ts
@@ -110,6 +110,22 @@ describe('createResumeUpdateChecker OTA 静默路径', () => {
     expect(deps.checkForUpdateAsync).not.toHaveBeenCalled();
   });
 
+  it('isConsented=false → OTA skipped,整包检查仍按 bundleCheckEnabled 放行', async () => {
+    // 未同意隐私政策时不得发起带 eas-client-id 的 manifest 请求;整包 /latest 匿名不受影响。
+    const deps = makeDeps({ isConsented: () => false });
+    const { ota, bundle } = await runOnce(deps);
+    expect(ota).toBe('skipped');
+    expect(deps.checkForUpdateAsync).not.toHaveBeenCalled();
+    expect(bundle).toBe('up-to-date');
+  });
+
+  it('isConsented=true → 走正常 OTA 检查', async () => {
+    const deps = makeDeps({ isConsented: () => true });
+    const { ota } = await runOnce(deps);
+    expect(ota).toBe('up-to-date');
+    expect(deps.checkForUpdateAsync).toHaveBeenCalledOnce();
+  });
+
   it('无可用更新 → up-to-date,不 fetch', async () => {
     const deps = makeDeps();
     const { ota } = await runOnce(deps);

--- a/apps/mobile/src/update/resumeUpdateCheck.test.ts
+++ b/apps/mobile/src/update/resumeUpdateCheck.test.ts
@@ -126,6 +126,22 @@ describe('createResumeUpdateChecker OTA 静默路径', () => {
     expect(deps.checkForUpdateAsync).toHaveBeenCalledOnce();
   });
 
+  it('check 期间撤销同意 → 下载前跳过,不 fetch', async () => {
+    // check 返回后、fetch 前同意被撤回:必须再问一次,不能继续下载带标识的资源。
+    let consented = true;
+    const deps = makeDeps({
+      isConsented: () => consented,
+      checkForUpdateAsync: vi.fn(async () => {
+        consented = false; // check 进行中用户登出,同意被清
+        return { isAvailable: true };
+      }),
+    });
+    const { ota } = await runOnce(deps);
+    expect(ota).toBe('skipped');
+    expect(deps.checkForUpdateAsync).toHaveBeenCalledOnce();
+    expect(deps.fetchUpdateAsync).not.toHaveBeenCalled();
+  });
+
   it('无可用更新 → up-to-date,不 fetch', async () => {
     const deps = makeDeps();
     const { ota } = await runOnce(deps);

--- a/apps/mobile/src/update/resumeUpdateCheck.ts
+++ b/apps/mobile/src/update/resumeUpdateCheck.ts
@@ -30,6 +30,12 @@ export interface ResumeUpdateOutcome {
 export interface ResumeUpdateCheckDeps {
   /** JS OTA 是否启用(自建变体 + 非 dev + expo-updates 可用),与启动热更门同一 gate。 */
   otaEnabled: boolean;
+  /**
+   * 隐私同意闸门(运行时动态判定,非挂载期快照):用户同意《隐私政策》前不得发起
+   * 带 eas-client-id 的 manifest / OTA 资源请求。缺省视为「未同意」与否由调用方决定;
+   * 这里只在调用方提供了判定函数时生效,纯逻辑层不引入 analytics 依赖。
+   */
+  isConsented?: () => boolean;
   checkForUpdateAsync: () => Promise<{ isAvailable: boolean }>;
   fetchUpdateAsync: () => Promise<{ isNew: boolean }>;
   /** 整包检查是否启用(自建变体),与 useBundleUpdatePrompt 同一 gate。 */
@@ -94,7 +100,9 @@ export function createResumeUpdateChecker(
   let inFlight = false;
 
   async function runOtaCheck(): Promise<ResumeOtaOutcome> {
-    if (!deps.otaEnabled) return 'skipped';
+    // 整包 /latest 是匿名请求(无稳定标识),不在此列;只有 OTA 的 manifest/资源
+    // 会携带 eas-client-id,必须经隐私同意闸门。
+    if (!deps.otaEnabled || (deps.isConsented && !deps.isConsented())) return 'skipped';
     try {
       const check = await withTimeout(deps.checkForUpdateAsync(), checkTimeoutMs);
       if (deps.isCurrent && !deps.isCurrent()) return 'skipped';

--- a/apps/mobile/src/update/resumeUpdateCheck.ts
+++ b/apps/mobile/src/update/resumeUpdateCheck.ts
@@ -107,6 +107,9 @@ export function createResumeUpdateChecker(
       const check = await withTimeout(deps.checkForUpdateAsync(), checkTimeoutMs);
       if (deps.isCurrent && !deps.isCurrent()) return 'skipped';
       if (!check.isAvailable) return 'up-to-date';
+      // check 期间用户可能已登出撤销同意(clearAnalyticsConsent 把 consent 翻 false):
+      // 下载前再问一次,避免同意被撤回后仍发起带 eas-client-id 的资源请求。
+      if (deps.isConsented && !deps.isConsented()) return 'skipped';
       const fetched = await withTimeout(deps.fetchUpdateAsync(), fetchTimeoutMs);
       if (deps.isCurrent && !deps.isCurrent()) return 'skipped';
       // 静默路径到此为止:不 reload,新 bundle 下次冷启动生效。

--- a/apps/mobile/src/update/updateConsentGate.ts
+++ b/apps/mobile/src/update/updateConsentGate.ts
@@ -1,0 +1,27 @@
+// 隐私同意闸门(更新链路复用版)。
+//
+// 更新检查(manifest / OTA 资源)在用户同意《隐私政策》前不得联网:expo-updates
+// 原生层会在每次请求里携带稳定的 eas-client-id(可关联安装标识),属于「未经同意
+// 收集、传输个人信息」的隐私合规风险。同意状态的本机真相就是 analyticsConsentStore
+// 的 consent 字段(「用户是否明示同意过《隐私政策》」),这里只做语义别名,不新增
+// 存储、不重复维护第二份同意标记——同一台设备不该出现「统计已同意、更新却未同意」
+// 或反向的不一致。
+//
+// 原生层已通过 checkAutomatically:'NEVER' 关闭自动联网,唯一的 /manifest 泄漏源是
+// JS 手动 checkForUpdateAsync();在 JS 层用本闸门前置拦截即可根治,无需动原生配置。
+
+import {
+  getAnalyticsConsentState,
+  hydrateAnalyticsConsent,
+} from '@/analytics/analyticsConsentStore';
+
+/** 冷启动 hydrate 一次,返回是否已同意。读取失败一律 fail-closed 到 false。 */
+export async function hydratePrivacyConsent(): Promise<boolean> {
+  await hydrateAnalyticsConsent();
+  return getAnalyticsConsentState().consent;
+}
+
+/** hydrate 之后可同步读;未 hydrate 时按未同意(fail-closed)。 */
+export function hasPrivacyConsent(): boolean {
+  return getAnalyticsConsentState().consent;
+}

--- a/apps/mobile/src/update/updateConsentGate.ts
+++ b/apps/mobile/src/update/updateConsentGate.ts
@@ -13,6 +13,7 @@
 import {
   getAnalyticsConsentState,
   hydrateAnalyticsConsent,
+  subscribeAnalyticsConsent,
 } from '@/analytics/analyticsConsentStore';
 
 /** 冷启动 hydrate 一次,返回是否已同意。读取失败一律 fail-closed 到 false。 */
@@ -24,4 +25,13 @@ export async function hydratePrivacyConsent(): Promise<boolean> {
 /** hydrate 之后可同步读;未 hydrate 时按未同意(fail-closed)。 */
 export function hasPrivacyConsent(): boolean {
   return getAnalyticsConsentState().consent;
+}
+
+/**
+ * 订阅同意状态变化(登录页 acceptPrivacyConsent 翻 true、登出 clearAnalyticsConsent
+ * 翻 false 都会触发)。自建线「首启未同意 → 进程内同意」时,调用方需要据此补配置
+ * OTA URL,否则设置页手动检查 / resume 静默检查会拿动态 true 却仍打占位地址。
+ */
+export function subscribePrivacyConsent(listener: () => void): () => void {
+  return subscribeAnalyticsConsent(listener);
 }

--- a/apps/mobile/src/update/useResumeUpdateCheck.ts
+++ b/apps/mobile/src/update/useResumeUpdateCheck.ts
@@ -19,6 +19,7 @@ import { fetchLatestRelease } from './fetchLatestRelease';
 import { createResumeUpdateChecker } from './resumeUpdateCheck';
 import { promptBundleUpdate } from './useBundleUpdatePrompt';
 import { resolveUpdateChannelForDevice } from './canaryChannelStore';
+import { hasPrivacyConsent } from './updateConsentGate';
 import type { UpdateChannel } from '@cindy/maker-shared/update-channel';
 
 export function useResumeUpdateCheck(
@@ -37,6 +38,7 @@ export function useResumeUpdateCheck(
     let current = true;
     const checker = createResumeUpdateChecker({
       otaEnabled: IS_OTA_SELFHOST && !__DEV__ && Updates.isEnabled,
+      isConsented: hasPrivacyConsent,
       checkForUpdateAsync: () => Updates.checkForUpdateAsync(),
       fetchUpdateAsync: () => Updates.fetchUpdateAsync(),
       bundleCheckEnabled,

--- a/apps/mobile/src/update/useStartupOtaGate.ts
+++ b/apps/mobile/src/update/useStartupOtaGate.ts
@@ -11,6 +11,7 @@ import {
   type StartupOtaOutcome,
 } from './startupOtaUpdate';
 import { updateChannelRequestHeaders } from './canaryChannelStore';
+import { hasPrivacyConsent, hydratePrivacyConsent } from './updateConsentGate';
 import type { UpdateChannel } from '@cindy/maker-shared/update-channel';
 import {
   clearOtaReloadGuardIfLaunched,
@@ -57,8 +58,11 @@ export function useStartupOtaGate(channel: UpdateChannel = 'release'): boolean {
   // build-time 配置,不受此字段控制,边界见 maker-shared clientEndpoints 的
   // CLIENT_ENDPOINT_REVIEW_KEY)。REVIEW_MODE 是 live binding,本 hook 挂载在
   // 端点闸门 ready 之后,读到的必是清单匹配结果。
-  const enabled = IS_OTA_SELFHOST && !__DEV__ && Updates.isEnabled && !REVIEW_MODE;
-  const [ready, setReady] = useState(!enabled);
+  const baseEnabled = IS_OTA_SELFHOST && !__DEV__ && Updates.isEnabled && !REVIEW_MODE;
+  // 隐私同意状态三态:null = 尚未 hydrate;false = 未同意(不联网);true = 已同意。
+  // baseEnabled 为 false 时不需要读同意状态,直接置 false 走「非自建放行」路径。
+  const [consent, setConsent] = useState<boolean | null>(baseEnabled ? null : false);
+  const [ready, setReady] = useState(!baseEnabled);
   const started = useRef(false);
   const configuredChannelRef = useRef<UpdateChannel | null>(null);
 
@@ -73,26 +77,49 @@ export function useStartupOtaGate(channel: UpdateChannel = 'release'): boolean {
     configuredChannelRef.current = channel;
   }, [channel]);
 
+  // 冷启动先 hydrate 隐私同意状态;未同意前不联网、不配置 expo-updates 目标。
+  // 读失败 fail-closed 到 false(与 analyticsConsentStore 同口径)。
+  useEffect(() => {
+    if (!baseEnabled) return;
+    let cancelled = false;
+    hydratePrivacyConsent().then(
+      (ok) => { if (!cancelled) setConsent(ok); },
+      () => { if (!cancelled) setConsent(false); },
+    );
+    return () => { cancelled = true; };
+  }, [baseEnabled]);
+
   // feature-flags 在登录/切账号后可能更新 channel；启动检查只跑一次，但
   // expo-updates 仍必须马上切换 request header，否则本进程会把下一个账号
   // 的请求发到上一个账号的 canary/stable 指针。stable 的空 header 也会
-  // 覆盖掉之前的 canary header。
+  // 覆盖掉之前的 canary header。仅在已同意后同步——未同意前不触碰联网目标。
   useEffect(() => {
-    if (!enabled || configuredChannelRef.current === channel) return;
+    if (!baseEnabled || consent !== true || configuredChannelRef.current === channel) return;
     try {
       configureUpdateUrl();
     } catch {
       // 真正的启动检查会把配置异常按 fail-open 处理；这里仅提前同步配置，
       // 失败不能阻断主界面或后续重试。
     }
-  }, [configureUpdateUrl, enabled, channel]);
+  }, [configureUpdateUrl, baseEnabled, consent, channel]);
 
   useEffect(() => {
-    if (!enabled || started.current) return;
+    // 非自建变体:ready 初值已是 true,无需处理。
+    if (!baseEnabled) return;
+    // 同意状态尚未决出:保持 ready=false,继续挡住业务树,避免「先挂出旧 UI、
+    // 待同意读回后再 reload」的闪帧,以及同意前误发 /manifest 请求。
+    if (consent === null) return;
+    // 未同意:直接放行,不发起任何更新检查(manifest / OTA 资源都不碰)。
+    if (consent === false) {
+      setReady(true);
+      return;
+    }
+    // 已同意:走既有启动 OTA 流程。
+    if (started.current) return;
     started.current = true; // 只冷启一次(不随 resume 重跑)
     let cancelled = false;
     const otaDeps = {
-      enabled,
+      enabled: true,
       configureUpdateUrl,
       checkForUpdateAsync: () => Updates.checkForUpdateAsync(),
       fetchUpdateAsync: () => Updates.fetchUpdateAsync(),
@@ -122,7 +149,7 @@ export function useStartupOtaGate(channel: UpdateChannel = 'release'): boolean {
       if (!cancelled) setReady(true);
     });
     return () => { cancelled = true; };
-  }, [configureUpdateUrl, enabled]);
+  }, [baseEnabled, consent, configureUpdateUrl]);
 
   return ready;
 }

--- a/apps/mobile/src/update/useStartupOtaGate.ts
+++ b/apps/mobile/src/update/useStartupOtaGate.ts
@@ -11,7 +11,11 @@ import {
   type StartupOtaOutcome,
 } from './startupOtaUpdate';
 import { updateChannelRequestHeaders } from './canaryChannelStore';
-import { hasPrivacyConsent, hydratePrivacyConsent } from './updateConsentGate';
+import {
+  hasPrivacyConsent,
+  hydratePrivacyConsent,
+  subscribePrivacyConsent,
+} from './updateConsentGate';
 import type { UpdateChannel } from '@cindy/maker-shared/update-channel';
 import {
   clearOtaReloadGuardIfLaunched,
@@ -78,7 +82,10 @@ export function useStartupOtaGate(channel: UpdateChannel = 'release'): boolean {
   }, [channel]);
 
   // 冷启动先 hydrate 隐私同意状态;未同意前不联网、不配置 expo-updates 目标。
-  // 读失败 fail-closed 到 false(与 analyticsConsentStore 同口径)。
+  // 读失败 fail-closed 到 false(与 analyticsConsentStore 同口径)。同时订阅后续
+  // 同意变化:登录页 acceptPrivacyConsent 会在**本进程内**把 consent 翻 true,若这里
+  // 只保留一次性快照,设置页手动检查 / resume 检查(动态读 hasPrivacyConsent)会拿到
+  // true 却仍指向未覆写的占位 URL,更新检查失败且 canary/beta 通道 header 不生效。
   useEffect(() => {
     if (!baseEnabled) return;
     let cancelled = false;
@@ -86,7 +93,14 @@ export function useStartupOtaGate(channel: UpdateChannel = 'release'): boolean {
       (ok) => { if (!cancelled) setConsent(ok); },
       () => { if (!cancelled) setConsent(false); },
     );
-    return () => { cancelled = true; };
+    const unsubscribe = subscribePrivacyConsent(() => {
+      if (cancelled) return;
+      setConsent((prev) => {
+        const ok = hasPrivacyConsent();
+        return prev === ok ? prev : ok;
+      });
+    });
+    return () => { cancelled = true; unsubscribe(); };
   }, [baseEnabled]);
 
   // feature-flags 在登录/切账号后可能更新 channel；启动检查只跑一次，但
@@ -111,6 +125,10 @@ export function useStartupOtaGate(channel: UpdateChannel = 'release'): boolean {
     if (consent === null) return;
     // 未同意:直接放行,不发起任何更新检查(manifest / OTA 资源都不碰)。
     if (consent === false) {
+      // 标记「启动检查已决定跳过」:此后即使用户在本进程内同意(consent 翻 true),
+      // 也只由 configureUpdateUrl effect 补配置 URL,绝不补跑一次 check→fetch→reload,
+      // 否则会把已进入登录页的会话闪屏重启。
+      started.current = true;
       setReady(true);
       return;
     }


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Android/iOS 隐私合规问题：cn 自建分发线 App 在用户同意《隐私政策》**之前**，冷启动就触发 expo-updates 的 `/manifest` 检查，请求里携带稳定的 `eas-client-id`（可关联安装实例标识），属于未经同意的个人信息收集/传输。

根治方式是把「隐私同意闸门」前移到 expo-updates 联网之前。原生层 `checkAutomatically: 'NEVER'` 已关闭自动检查，唯一的泄漏源是 JS 手动 `checkForUpdateAsync()`，因此纯 JS 即可根治，指纹中性、不触发冷更。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：隐私合规整改（eas-client-id 同意前发送）
- **覆盖范围**：cn 自建分发线（Android + iOS，即 `EXPO_PUBLIC_XDT_OTA_SELFHOST=1`）。实现平台无关：`IS_OTA_SELFHOST` 门控启动 / resume / 手动三条更新链路，consent 闸门挂在其下，自建安卓与自建 iOS 一并生效。
- **明确不覆盖**：EAS / TestFlight 线（含 EAS iOS 的原生自动更新检查）。产品已确认该范围不在本次整改内。
- 本 PR 包含：
  - 新增 `updateConsentGate`（复用 `analyticsConsentStore.consent`，不新增存储）
  - `useStartupOtaGate` 加 consent 三态判定，同意前不联网、不配置 expo-updates 目标
  - resume 静默 OTA 增加 `isConsented` 动态闸门（纯逻辑层不引入 analytics 依赖）
  - 设置页手动 OTA 检查加 `isConsented` 动态闸门（覆盖企业 SSO 豁免协议门的边缘）
- 明确不包含：不删 `eas-client-id` header（原生层下次 check 仍会带上，删 header 不成立）；不动 `/endpoint.json`、`/latest` 整包检查（两者为匿名请求、无稳定标识）；不动原生配置。
- 用户可见变化：未同意隐私政策前不再发起 OTA 更新检查（同意后行为不变）。
- 是否存在 breaking change：无

### UI 变化

不涉及：无任何视觉/交互/文案变化，纯启动链路与网络请求门控。

- 引用的设计规范：不涉及：纯逻辑/网络门控改动，settings.tsx 仅新增一个布尔判定函数入参，无视觉、交互或文案变化。

## 怎么验证的

### 自动验证

```text
pnpm --filter mobile run typecheck
结果：通过

pnpm --filter mobile exec vitest run src/update/resumeUpdateCheck.test.ts src/update/startupOtaUpdate.test.ts src/update/manualUpdateCheck.test.ts
结果：通过（resumeUpdateCheck 22、startupOtaUpdate 32、manualUpdateCheck 14）

pnpm test:unit:related
结果：apps/mobile unit 通过；apps/desktop 有 1 个与本次无关的既有失败（plugin-publisher/orchestrator.test.ts 竞态用例，本次未触碰 desktop）
```

### 手工验证

不涉及：真实设备抓包验证（同意前无 eas-client-id 请求）需在全新安装的 APK/IPA 上进行，留待发布链路执行。

### 未执行的验证

真实设备/模拟器抓包验收（Issue 验收标准场景一~四）未执行——需要全新签名 APK/IPA，属发布流程。

## 风险

### 风险分类

- [x] 权限 / 安全 / 用户数据（隐私同意闸门）
- [ ] 原生层 / fingerprint / OTA（**不触发**：纯 JS 改动，指纹输入不含 `src/**`）

### 影响与回滚

- 影响范围：cn 自建分发线（Android + iOS）的启动/静默/手动 OTA 检查；EAS/TestFlight 线无变化。
- 回滚 / 降级方式：revert 本提交即可恢复原行为。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已注明（不涉及）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
