### PR TITLE
fix(desktop): 按 owner 隔离插件 WebView partition

### DIFF
--- a/apps/desktop/src/main/__tests__/appSessionBoundary.test.ts
+++ b/apps/desktop/src/main/__tests__/appSessionBoundary.test.ts
@@ -26,6 +26,7 @@ vi.mock('../authBoundaryQuarantine.js', () => ({
 import {
   beginAppSessionBoundary,
   isAppSessionBoundaryPending,
+  waitForAppSessionBoundarySettlement,
 } from '../appSessionState.js';
 
 describe('application session boundary isolation', () => {
@@ -39,5 +40,24 @@ describe('application session boundary isolation', () => {
     expect(isAppSessionBoundaryPending()).toBe(true);
     release();
     expect(isAppSessionBoundaryPending()).toBe(false);
+  });
+
+  it('settles only after the outermost nested owner boundary releases', async () => {
+    const releaseOuter = beginAppSessionBoundary();
+    const releaseInner = beginAppSessionBoundary();
+    let settled = false;
+    const settlement = waitForAppSessionBoundarySettlement().then(() => {
+      settled = true;
+    });
+
+    releaseInner();
+    await Promise.resolve();
+    expect(isAppSessionBoundaryPending()).toBe(true);
+    expect(settled).toBe(false);
+
+    releaseOuter();
+    await settlement;
+    expect(isAppSessionBoundaryPending()).toBe(false);
+    expect(settled).toBe(true);
   });
 });

--- a/apps/desktop/src/main/__tests__/ghostAccountBoundaryOrdering.test.ts
+++ b/apps/desktop/src/main/__tests__/ghostAccountBoundaryOrdering.test.ts
@@ -4,26 +4,33 @@ import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 describe('Ghost account-boundary teardown ordering', () => {
-  const bootstrap = readFileSync(
-    resolve(__dirname, '../bootstrap-electron.ts'),
-    'utf8',
-  ).replace(/\r\n?/g, '\n');
-  const ghostIndex = readFileSync(
-    resolve(__dirname, '../cindy-brain/index.ts'),
-    'utf8',
-  ).replace(/\r\n?/g, '\n');
+  const bootstrap = readFileSync(resolve(__dirname, '../bootstrap-electron.ts'), 'utf8').replace(
+    /\r\n?/g,
+    '\n',
+  );
+  const ghostIndex = readFileSync(resolve(__dirname, '../cindy-brain/index.ts'), 'utf8').replace(
+    /\r\n?/g,
+    '\n',
+  );
+  const authManager = readFileSync(resolve(__dirname, '../authManager.ts'), 'utf8').replace(
+    /\r\n?/g,
+    '\n',
+  );
 
-  it('interrupts long setup, grant, and pipe waits before draining owner leases', () => {
+  it('destroys owner-scoped panel windows before draining plugin work', () => {
     const start = bootstrap.indexOf(
       'async function teardownGhostProjectionBoundary(reason: string): Promise<void> {',
     );
     const end = bootstrap.indexOf('\n}\n', start);
     const body = bootstrap.slice(start, end);
 
+    const resetPanelWindows = body.indexOf('ghostPanelWindowsController.destroyForOwnerBoundary();');
     const interrupt = body.indexOf('interruptGhostCallsForAccountBoundary));');
     const wait = body.indexOf('waitForGhostMutations));');
     const suspend = body.indexOf('suspendAllGhosts);');
 
+    expect(resetPanelWindows).toBeGreaterThan(-1);
+    expect(resetPanelWindows).toBeLessThan(interrupt);
     expect(interrupt).toBeGreaterThan(-1);
     expect(interrupt).toBeLessThan(wait);
     expect(wait).toBeLessThan(suspend);
@@ -40,5 +47,46 @@ describe('Ghost account-boundary teardown ordering', () => {
     expect(helper).toContain('broker.destroyAll();');
     expect(helper).toContain('nodeRuntimeBrokerSingleton = null;');
     expect(ghostIndex).toContain('resetNodeRuntimeBrokerForAccountBoundary();');
+  });
+
+  it('aborts admitted WebView requests and destroys their producers before draining', () => {
+    const start = ghostIndex.indexOf(
+      'export async function interruptGhostCallsForAccountBoundary(): Promise<void> {',
+    );
+    const end = ghostIndex.indexOf('\n}', start);
+    const body = ghostIndex.slice(start, end);
+
+    const abortExternalLink = body.indexOf(
+      'abortGhostExternalLinkNavigationsForAccountBoundary();',
+    );
+    const abortProtocol = body.indexOf('abortGhostProtocolRequestsForAccountBoundary();');
+    const drainProtocol = body.indexOf('await waitForGhostProtocolRequests();');
+    const destroyRuntime = body.indexOf('runtimeSingleton?.destroyAll();');
+    expect(abortExternalLink).toBeGreaterThan(-1);
+    expect(abortExternalLink).toBeLessThan(abortProtocol);
+    expect(abortProtocol).toBeGreaterThan(-1);
+    expect(abortProtocol).toBeLessThan(destroyRuntime);
+    expect(drainProtocol).toBeGreaterThan(-1);
+    expect(destroyRuntime).toBeLessThan(drainProtocol);
+  });
+
+  it('restores detached windows after the whole owner boundary settles, including prepareCommit failure', () => {
+    const cloudStart = authManager.indexOf('async function withCloudOwnerCommit');
+    const cloudEnd = authManager.indexOf('\n}\n\n/**', cloudStart);
+    const cloudBody = authManager.slice(cloudStart, cloudEnd);
+    const accountFreeStart = authManager.indexOf('async function withAccountFreeOwnerCommit');
+    const accountFreeEnd = authManager.indexOf('\n}\n\nasync function recoverAccountFreeOwnerAtStartup', accountFreeStart);
+    const accountFreeBody = authManager.slice(accountFreeStart, accountFreeEnd);
+
+    for (const body of [cloudBody, accountFreeBody]) {
+      const finallyStart = body.lastIndexOf('} finally {');
+      const release = body.indexOf('release?.();', finallyStart);
+      const settled = body.indexOf('scheduleOwnerBoundarySettledTask();', finallyStart);
+      expect(finallyStart).toBeGreaterThan(-1);
+      expect(release).toBeGreaterThan(finallyStart);
+      expect(settled).toBeGreaterThan(release);
+    }
+    expect(bootstrap).toContain('authManager.setOwnerBoundarySettledTask(() => {');
+    expect(bootstrap).toContain('ghostPanelWindowsController.restoreOpenWindowsForCurrentOwner();');
   });
 });

--- a/apps/desktop/src/main/__tests__/lifecycle.test.ts
+++ b/apps/desktop/src/main/__tests__/lifecycle.test.ts
@@ -50,6 +50,12 @@ vi.mock('../ghost-panel-window/registry.js', () => ({
     ghostPanelWebContentsIds.has(webContentsId),
 }));
 
+// lifecycle 只消费这个查询函数；不要把 Electron session、插件协议和 owner
+// 存储整条运行时依赖链带进退出编排单测。
+vi.mock('../cindy-brain/runtime/electronSandboxAdapter', () => ({
+  isGhostSandboxWebContentsId: () => false,
+}));
+
 const mocks = vi.hoisted(() => ({
   logger: {
     info: vi.fn(),

--- a/apps/desktop/src/main/__tests__/webview-security.test.ts
+++ b/apps/desktop/src/main/__tests__/webview-security.test.ts
@@ -49,6 +49,7 @@ import {
   applyGhostWebviewHardening,
   applyLoginCaptchaWebviewHardening,
   applyWebviewHardening,
+  authorizeGhostWebviewAttach,
   hardenLoginCaptchaSession,
   installGhostGuestNavigationHandlers,
   installBrowserGuestHandlers,
@@ -292,7 +293,7 @@ describe('applyGhostWebviewHardening(意识面板 webview)', () => {
     };
     const params: Record<string, string> = {
       src: 'cindy-ghost://art/panel.html',
-      partition: 'cindy-ghost-art',
+      partition: 'cindy-ghost-owner:cloud:0123456789abcdefabcd:art',
       disablewebsecurity: 'true',
       webpreferences: 'nodeIntegration=1',
       allowpopups: 'true',
@@ -311,10 +312,58 @@ describe('applyGhostWebviewHardening(意识面板 webview)', () => {
     expect(webPreferences.plugins).toBe(false);
     expect('preload' in webPreferences).toBe(false);
     // 与浏览器路径的两点差异:分区保留、popup 掐死
-    expect(params.partition).toBe('cindy-ghost-art');
+    expect(params.partition).toBe('cindy-ghost-owner:cloud:0123456789abcdefabcd:art');
     expect('allowpopups' in params).toBe(false);
     expect('disablewebsecurity' in params).toBe(false);
     expect('webpreferences' in params).toBe(false);
+  });
+
+  it('把 Renderer claim 覆盖为 Main 核准的 owner partition', () => {
+    // Electron 在 will-attach-webview 前会把 renderer claim 复制到这里，真实
+    // guest 创建时使用的是 webPreferences.partition，而不是后续的 params。
+    const webPreferences: Record<string, unknown> = {
+      nodeIntegration: true,
+      partition: 'cindy-ghost-same-ghost',
+    };
+    const params: Record<string, string> = {
+      src: 'cindy-ghost://same-ghost/panel.html',
+      partition: 'cindy-ghost-same-ghost',
+      allowpopups: 'true',
+    };
+    const resolver = vi.fn(() => ({
+      ghost: { manifest: { id: 'same-ghost' } },
+      partition: 'cindy-ghost-owner:cloud:opaque-owner-a:same-ghost',
+      owner: { mode: 'cloud', dataOwnerId: 'owner-a' },
+    })) as never;
+
+    expect(authorizeGhostWebviewAttach(webPreferences, params, resolver)).toEqual({
+      id: 'same-ghost',
+      owner: { mode: 'cloud', dataOwnerId: 'owner-a' },
+    });
+    expect(resolver).toHaveBeenCalledWith(
+      'cindy-ghost-same-ghost',
+      'cindy-ghost://same-ghost/panel.html',
+    );
+    expect(params.partition).toBe('cindy-ghost-owner:cloud:opaque-owner-a:same-ghost');
+    expect(webPreferences.partition).toBe(
+      'cindy-ghost-owner:cloud:opaque-owner-a:same-ghost',
+    );
+    expect(webPreferences.nodeIntegration).toBe(false);
+    expect('allowpopups' in params).toBe(false);
+  });
+
+  it('Main 解析或协议注册异常时不核准 attach', () => {
+    const params: Record<string, string> = {
+      src: 'cindy-ghost://same-ghost/panel.html',
+      partition: 'cindy-ghost-same-ghost',
+    };
+
+    expect(
+      authorizeGhostWebviewAttach({}, params, (() => {
+        throw new Error('protocol registration failed');
+      }) as never),
+    ).toBeNull();
+    expect(params.partition).toBe('cindy-ghost-same-ghost');
   });
 });
 
@@ -490,13 +539,28 @@ describe('installGhostGuestNavigationHandlers(Ghost settingsHtml / panel 共用�
       openHandler = handler;
     });
     const host = { id: 10 } as unknown as WebContents;
+    let ownerActive = true;
+    const gesture = vi.fn();
     const preview = vi.fn();
     const external = vi.fn();
-    installGhostGuestNavigationHandlers(host, guest as unknown as WebContents, 'xd-sites', {
+    installGhostGuestNavigationHandlers(
+      host,
+      guest as unknown as WebContents,
+      'xd-sites',
+      () => ownerActive,
+      { gesture, preview, external },
+    );
+    return {
+      guest,
+      host,
+      gesture,
       preview,
       external,
-    });
-    return { guest, host, preview, external, getOpenHandler: () => openHandler };
+      setOwnerActive: (active: boolean) => {
+        ownerActive = active;
+      },
+      getOpenHandler: () => openHandler,
+    };
   }
 
   it('普通 HTTPS <a> 的 will-navigate 被拦下并带真实 host/guest 交给外链处理', () => {
@@ -511,6 +575,7 @@ describe('installGhostGuestNavigationHandlers(Ghost settingsHtml / panel 共用�
       'https://workers.xd.team/workspace/published',
       harness.host,
       harness.guest,
+      expect.any(Function),
     );
     expect(harness.preview).not.toHaveBeenCalled();
   });
@@ -544,6 +609,24 @@ describe('installGhostGuestNavigationHandlers(Ghost settingsHtml / panel 共用�
 
     expect(harness.guest.setWindowOpenHandler).toHaveBeenCalledOnce();
     expect(harness.getOpenHandler()?.()).toEqual({ action: 'deny' });
+    expect(harness.external).not.toHaveBeenCalled();
+  });
+
+  it('owner 切换后旧 guest 的手势和导航全部被 Main 拒绝', () => {
+    const harness = makeHarness();
+    harness.setOwnerActive(false);
+    const externalEvent = { preventDefault: vi.fn() };
+    const sameOriginEvent = { preventDefault: vi.fn() };
+
+    harness.guest.emit('before-mouse-event', {}, { type: 'mouseDown' });
+    harness.guest.emit('before-input-event', {}, { type: 'keyDown' });
+    harness.guest.emit('will-navigate', externalEvent, 'https://workers.xd.team/owner-a-data');
+    harness.guest.emit('will-navigate', sameOriginEvent, 'cindy-ghost://xd-sites/panel.html');
+
+    expect(harness.gesture).not.toHaveBeenCalled();
+    expect(externalEvent.preventDefault).toHaveBeenCalledOnce();
+    expect(sameOriginEvent.preventDefault).toHaveBeenCalledOnce();
+    expect(harness.preview).not.toHaveBeenCalled();
     expect(harness.external).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/main/appSessionState.ts
+++ b/apps/desktop/src/main/appSessionState.ts
@@ -80,6 +80,8 @@ const store = createOverrideSettingsFile<PersistedAppSessionSettings>({
 
 let active: ActiveAppSession | null = null;
 let boundaryDepth = 0;
+let boundarySettledPromise: Promise<void> | null = null;
+let resolveBoundarySettled: (() => void) | null = null;
 
 function ensureLoaded(): ActiveAppSession {
   if (active) return active;
@@ -138,11 +140,28 @@ export function beginAppSessionBoundary(): () => void {
     if (released) return;
     released = true;
     boundaryDepth = Math.max(0, boundaryDepth - 1);
+    if (boundaryDepth === 0) {
+      const resolve = resolveBoundarySettled;
+      boundarySettledPromise = null;
+      resolveBoundarySettled = null;
+      resolve?.();
+    }
   };
 }
 
 export function isAppSessionBoundaryPending(): boolean {
   return boundaryDepth > 0;
+}
+
+/** Resolves only after every nested/ref-counted process-local owner boundary releases. */
+export function waitForAppSessionBoundarySettlement(): Promise<void> {
+  if (boundaryDepth === 0) return Promise.resolve();
+  if (!boundarySettledPromise) {
+    boundarySettledPromise = new Promise<void>((resolve) => {
+      resolveBoundarySettled = resolve;
+    });
+  }
+  return boundarySettledPromise;
 }
 
 /** Backward-compatible alias for the process-local application transition. */

--- a/apps/desktop/src/main/authManager.ts
+++ b/apps/desktop/src/main/authManager.ts
@@ -109,6 +109,7 @@ import {
   getActiveDataOwnerPushStamp,
   isAppSessionBoundaryPending,
   LOCAL_DATA_OWNER_ID,
+  waitForAppSessionBoundarySettlement,
   type AppSessionMode,
 } from './appSessionState.js';
 import {
@@ -257,10 +258,29 @@ type AccountSwitchTeardown = (context: {
 /** Releases every account-scoped runtime before terminal local sign-out. */
 type AuthSessionTeardown = (reason: string) => void | Promise<void>;
 type ProjectionRepairTeardown = (reason: string) => void | Promise<void>;
+type OwnerBoundarySettledTask = () => void;
 
 let accountSwitchTeardown: AccountSwitchTeardown | null = null;
 let authSessionTeardown: AuthSessionTeardown | null = null;
 let projectionRepairTeardown: ProjectionRepairTeardown | null = null;
+let ownerBoundarySettledTask: OwnerBoundarySettledTask | null = null;
+let ownerBoundarySettledEpoch = 0;
+
+function scheduleOwnerBoundarySettledTask(): void {
+  const epoch = ++ownerBoundarySettledEpoch;
+  void (async () => {
+    do {
+      await waitForAppSessionBoundarySettlement();
+    } while (isAppSessionBoundaryPending());
+    if (epoch !== ownerBoundarySettledEpoch) return;
+    try {
+      ownerBoundarySettledTask?.();
+    } catch (error) {
+      // Window restoration must never replace the real auth commit outcome.
+      log.warn('owner boundary settled task failed', error);
+    }
+  })();
+}
 
 const stableOwnerPostCommitCoordinator = new StableOwnerPostCommitCoordinator({
   snapshot: () => {
@@ -927,6 +947,7 @@ async function withCloudOwnerCommit<T>(opts: {
     release?.();
     if (heldOwnerChangeShell) leaveOwnerChangeShellPending();
     if (release) notifyRenderer();
+    if (release) scheduleOwnerBoundarySettledTask();
   }
   if (committed) requestStableOwnerPostCommit('owner-commit');
   return result;
@@ -1064,6 +1085,7 @@ async function withAccountFreeOwnerCommit(opts: {
     release?.();
     if (heldOwnerChangeShell) leaveOwnerChangeShellPending();
     if (release && notify) notifyRenderer();
+    if (release) scheduleOwnerBoundarySettledTask();
   }
 
   requestStableOwnerPostCommit('owner-commit');
@@ -1121,6 +1143,11 @@ export function setAuthSessionTeardown(teardown: AuthSessionTeardown | null): vo
 
 export function setProjectionRepairTeardown(teardown: ProjectionRepairTeardown | null): void {
   projectionRepairTeardown = teardown;
+}
+
+/** Runs after every locally-owned boundary releases, whether commit succeeded or rolled back. */
+export function setOwnerBoundarySettledTask(task: OwnerBoundarySettledTask | null): void {
+  ownerBoundarySettledTask = task;
 }
 
 /** Register the owner-scoped work that must settle after the durable boundary is stable. */

--- a/apps/desktop/src/main/bootstrap-electron.ts
+++ b/apps/desktop/src/main/bootstrap-electron.ts
@@ -1283,6 +1283,7 @@ async function teardownGhostProjectionBoundary(reason: string): Promise<void> {
     }
   };
 
+  ghostPanelWindowsController.destroyForOwnerBoundary();
   await run('interruptGhostCallsForAccountBoundary', () => withAuthBoundaryTimeout('interrupt Ghost calls', interruptGhostCallsForAccountBoundary));
   await run('waitForGhostMutations', () => withAuthBoundaryTimeout('wait for Ghost mutations', waitForGhostMutations));
   await run('suspendAllGhosts', suspendAllGhosts);
@@ -1772,11 +1773,13 @@ async function teardownAuthAccountBoundary(reason: string): Promise<void> {
   clearAccountBoundaryAbortMark();
 }
 
-authManager.setAccountSwitchTeardown(async () => {
-  await teardownAuthAccountBoundary('runtime-replacement-account-switch');
-});
+authManager.setAccountSwitchTeardown(() =>
+  teardownAuthAccountBoundary('runtime-replacement-account-switch'));
 authManager.setAuthSessionTeardown(teardownAuthAccountBoundary);
 authManager.setProjectionRepairTeardown(teardownGhostProjectionBoundary);
+authManager.setOwnerBoundarySettledTask(() => {
+  ghostPanelWindowsController.restoreOpenWindowsForCurrentOwner();
+});
 
 // A launch fence left by the host we just replaced (or by one that crashed
 // mid-relaunch) would otherwise refuse this instance's Subagent launches for as

--- a/apps/desktop/src/main/cindy-brain/__tests__/ghostExternalLinkNavigation.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/ghostExternalLinkNavigation.test.ts
@@ -57,6 +57,8 @@ function makeHarness(options: {
   const openExternal = vi.fn<(url: string) => Promise<void>>(async () => undefined);
   const debug = vi.fn();
   const warn = vi.fn();
+  let ownerActive = true;
+  const boundaryController = new AbortController();
   const translate = vi.fn((key: string) => {
     const labels: Record<string, string> = {
       'ghostPanel.externalLinkConfirm.title': '是否要 Cindy 打开外部网站',
@@ -78,6 +80,10 @@ function makeHarness(options: {
     destroyOwner: () => {
       ownerDestroyed = true;
     },
+    setOwnerActive: (active: boolean) => {
+      ownerActive = active;
+    },
+    boundaryController,
     deps: {
       gate,
       resolveOwner,
@@ -85,6 +91,8 @@ function makeHarness(options: {
       openExternal,
       translate,
       logger: { debug, warn },
+      isOwnerActive: () => ownerActive,
+      signal: boundaryController.signal,
     },
   };
 }
@@ -152,6 +160,7 @@ describe('runGhostExternalLinkNavigation', () => {
       defaultId: 0,
       cancelId: 1,
       noLink: true,
+      signal: harness.boundaryController.signal,
     } satisfies MessageBoxOptions);
     expect(harness.openExternal).not.toHaveBeenCalled();
   });
@@ -180,6 +189,8 @@ describe('runGhostExternalLinkNavigation', () => {
       openExternal,
       translate: (key: string) => key,
       logger: { debug: vi.fn(), warn: vi.fn() },
+      isOwnerActive: () => true,
+      signal: new AbortController().signal,
     };
 
     for (const { surface, contents, owner } of entries) {
@@ -285,6 +296,37 @@ describe('runGhostExternalLinkNavigation', () => {
     );
 
     expect(harness.showMessageBox).toHaveBeenCalledTimes(2);
+  });
+
+  it('owner 在确认期间切换后，即使旧确认返回打开也不执行', async () => {
+    const contents = makeContents();
+    const harness = makeHarness({});
+    let finishDialog!: (value: { response: number }) => void;
+    harness.showMessageBox.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finishDialog = resolve;
+        }),
+    );
+
+    const pending = runGhostExternalLinkNavigation(
+      {
+        ghostId: 'xd-sites',
+        url: 'https://example.com/owner-a-data',
+        hostContents: contents.host,
+        guestContents: contents.guest,
+      },
+      harness.deps,
+    );
+    await vi.waitFor(() => expect(harness.showMessageBox).toHaveBeenCalledOnce());
+
+    harness.setOwnerActive(false);
+    harness.boundaryController.abort();
+    finishDialog({ response: 0 });
+    await pending;
+
+    expect(harness.openExternal).not.toHaveBeenCalled();
+    expect(harness.warn).not.toHaveBeenCalled();
   });
 
   it('guest 已脱离原宿主时不弹窗也不打开', async () => {

--- a/apps/desktop/src/main/cindy-brain/__tests__/ghostPreviewNavigation.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/ghostPreviewNavigation.test.ts
@@ -1,0 +1,46 @@
+import type { WebContents } from 'electron';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { GhostPreviewOutcome } from '../previewGate';
+import { runGhostPreviewNavigation } from '../ghostPreviewNavigation';
+
+describe('runGhostPreviewNavigation', () => {
+  it('owner 在账本查询期间切换后不向新 owner 的 renderer 推送旧预览', async () => {
+    let ownerActive = true;
+    let finishRequest!: (outcome: GhostPreviewOutcome) => void;
+    const request = vi.fn(
+      () =>
+        new Promise<GhostPreviewOutcome>((resolve) => {
+          finishRequest = resolve;
+        }),
+    );
+    const send = vi.fn();
+    const hostContents = { isDestroyed: () => false } as unknown as WebContents;
+    const guestContents = {
+      isDestroyed: () => false,
+      isFocused: () => true,
+    } as unknown as WebContents;
+
+    const pending = runGhostPreviewNavigation(
+      {
+        ghostId: 'same-ghost',
+        url: `cindy-ghost://same-ghost/preview/${'a'.repeat(64)}.png`,
+        hostContents,
+        guestContents,
+      },
+      {
+        request,
+        isOwnerActive: () => ownerActive,
+        send,
+        logger: { debug: vi.fn(), warn: vi.fn() },
+      },
+    );
+    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+
+    ownerActive = false;
+    finishRequest({ ok: true, src: 'cindy-media://blob/owner-a.png', kind: 'image' });
+    await pending;
+
+    expect(send).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/main/cindy-brain/__tests__/ghostProtocolDialogParent.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/ghostProtocolDialogParent.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const harness = vi.hoisted(() => ({
+  focused: null as FakeWindow | null,
+  windows: [] as FakeWindow[],
+}));
+
+interface FakeWindow {
+  trusted: boolean;
+  visible: boolean;
+  url: string;
+  isVisible(): boolean;
+  webContents: { getURL(): string };
+}
+
+function fakeWindow(args: { trusted?: boolean; visible?: boolean; url?: string } = {}): FakeWindow {
+  const window = {
+    trusted: args.trusted ?? true,
+    visible: args.visible ?? true,
+    url: args.url ?? 'file:///app/index.html',
+  } as FakeWindow;
+  window.isVisible = () => window.visible;
+  window.webContents = { getURL: () => window.url };
+  return window;
+}
+
+vi.mock('electron', () => ({
+  BrowserWindow: {
+    getFocusedWindow: () => harness.focused,
+    getAllWindows: () => harness.windows,
+  },
+}));
+
+vi.mock('../../security/trustedAppRenderer.js', () => ({
+  isTrustedAppRendererWindow: (window: FakeWindow | null) => Boolean(window?.trusted),
+}));
+
+vi.mock('../scheduleSlot.js', () => ({
+  isMainShellWindowUrl: (url: string) => !url.includes('ghostPanelWindow='),
+}));
+
+import { resolveGhostProtocolDialogParent } from '../ghostProtocolDialogParent.js';
+
+beforeEach(() => {
+  harness.focused = null;
+  harness.windows = [];
+});
+
+describe('resolveGhostProtocolDialogParent', () => {
+  it('uses a focused trusted detached panel even when the main shell is hidden', () => {
+    const panel = fakeWindow({ url: 'file:///app/index.html?ghostPanelWindow=art' });
+    const hiddenMain = fakeWindow({ visible: false });
+    harness.focused = panel;
+    harness.windows = [hiddenMain, panel];
+
+    expect(resolveGhostProtocolDialogParent()).toBe(panel);
+  });
+
+  it('does not attach a confirmation sheet to a hidden main shell', () => {
+    harness.windows = [fakeWindow({ visible: false })];
+
+    expect(resolveGhostProtocolDialogParent()).toBeNull();
+  });
+
+  it('falls back to a visible trusted main shell when focus is unavailable', () => {
+    const visibleMain = fakeWindow();
+    harness.windows = [fakeWindow({ trusted: false }), visibleMain];
+
+    expect(resolveGhostProtocolDialogParent()).toBe(visibleMain);
+  });
+});

--- a/apps/desktop/src/main/cindy-brain/__tests__/ghostWebviewPartition.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/ghostWebviewPartition.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../appSessionState', () => ({
+  dataOwnerStorageKey: (ownerId: string) => `opaque-${ownerId}`,
+}));
+
+import { ghostPartition } from '../../../shared/ghost';
+import {
+  ownerScopedGhostPartition,
+  resolveGhostWebviewPartitionClaim,
+} from '../ghostWebviewPartition';
+
+describe('ghost WebView Main partition', () => {
+  const ownerA = { mode: 'cloud' as const, dataOwnerId: 'owner-a' };
+  const ownerB = { mode: 'cloud' as const, dataOwnerId: 'owner-b' };
+
+  it('同 owner + ghost 稳定，不同 owner + 同 ghost 使用不同 session', () => {
+    const partitionA = ownerScopedGhostPartition('same-ghost', ownerA);
+    const partitionB = ownerScopedGhostPartition('same-ghost', ownerB);
+
+    expect(partitionA).toBe('cindy-ghost-owner:cloud:opaque-owner-a:same-ghost');
+    expect(ownerScopedGhostPartition('same-ghost', ownerA)).toBe(partitionA);
+    expect(partitionB).not.toBe(partitionA);
+  });
+
+  it('把 Renderer claim 解析为 Main 当前 owner 的权威 partition', () => {
+    const claim = ghostPartition('same-ghost');
+
+    expect(resolveGhostWebviewPartitionClaim(claim, ownerA)).toEqual({
+      ghostId: 'same-ghost',
+      partition: 'cindy-ghost-owner:cloud:opaque-owner-a:same-ghost',
+    });
+    expect(resolveGhostWebviewPartitionClaim(claim, ownerB)?.partition).toBe(
+      'cindy-ghost-owner:cloud:opaque-owner-b:same-ghost',
+    );
+  });
+
+  it('无 owner、非法 claim 和伪造的真实 partition 都 fail closed', () => {
+    expect(
+      resolveGhostWebviewPartitionClaim(ghostPartition('same-ghost'), {
+        mode: 'signed-out',
+        dataOwnerId: null,
+      }),
+    ).toBeNull();
+    expect(resolveGhostWebviewPartitionClaim('cindy-ghost-BAD_ID', ownerA)).toBeNull();
+    expect(
+      resolveGhostWebviewPartitionClaim(
+        'cindy-ghost-owner:cloud:opaque-owner-b:same-ghost',
+        ownerA,
+      ),
+    ).toBeNull();
+    expect(resolveGhostWebviewPartitionClaim(undefined, ownerA)).toBeNull();
+  });
+});

--- a/apps/desktop/src/main/cindy-brain/ghostExternalLinkNavigation.ts
+++ b/apps/desktop/src/main/cindy-brain/ghostExternalLinkNavigation.ts
@@ -14,6 +14,10 @@ export interface GhostExternalLinkNavigationDeps {
   openExternal(url: string): Promise<void>;
   translate(key: string): string;
   logger: GhostExternalLinkNavigationLogger;
+  /** Captured attach owner is still the committed active owner. */
+  isOwnerActive(): boolean;
+  /** Owner boundary closes a visible native confirmation sheet. */
+  signal: AbortSignal;
 }
 
 export interface GhostExternalLinkNavigationParams {
@@ -39,6 +43,7 @@ async function openExternalBestEffort(
   url: string,
   deps: GhostExternalLinkNavigationDeps,
 ): Promise<void> {
+  if (deps.signal.aborted || !deps.isOwnerActive()) return;
   try {
     await deps.openExternal(url);
   } catch (error) {
@@ -61,6 +66,7 @@ export async function runGhostExternalLinkNavigation(
   params: GhostExternalLinkNavigationParams,
   deps: GhostExternalLinkNavigationDeps,
 ): Promise<void> {
+  if (deps.signal.aborted || !deps.isOwnerActive()) return;
   const outcome = deps.gate.request({
     ghostId: params.ghostId,
     url: params.url,
@@ -82,6 +88,7 @@ export async function runGhostExternalLinkNavigation(
   const confirmedUrl = outcome.url;
   let shouldOpen = false;
   try {
+    if (deps.signal.aborted || !deps.isOwnerActive()) return;
     if (!guestStillBelongsToHost(params.guestContents, params.hostContents)) return;
     const owner = deps.resolveOwner(params.hostContents);
     if (!owner || owner.isDestroyed()) return;
@@ -100,8 +107,10 @@ export async function runGhostExternalLinkNavigation(
         defaultId: 0,
         cancelId: 1,
         noLink: true,
+        signal: deps.signal,
       }));
     } catch (error) {
+      if (deps.signal.aborted || !deps.isOwnerActive()) return;
       deps.logger.warn('ghost external link confirmation failed', {
         ghostId: params.ghostId,
         error: errorMessage(error),
@@ -109,6 +118,7 @@ export async function runGhostExternalLinkNavigation(
       return;
     }
     if (response !== 0) return;
+    if (deps.signal.aborted || !deps.isOwnerActive()) return;
     if (!guestStillBelongsToHost(params.guestContents, params.hostContents)) return;
     if (owner.isDestroyed()) return;
     if (!deps.gate.isGhostAvailable(params.ghostId)) return;

--- a/apps/desktop/src/main/cindy-brain/ghostPreviewNavigation.ts
+++ b/apps/desktop/src/main/cindy-brain/ghostPreviewNavigation.ts
@@ -1,0 +1,60 @@
+import type { WebContents } from 'electron';
+
+import type { GhostPreviewGate, GhostPreviewOutcome } from './previewGate.js';
+
+export interface GhostPreviewNavigationLogger {
+  debug(message: string, meta: Record<string, unknown>): void;
+  warn(message: string, meta: Record<string, unknown>): void;
+}
+
+export interface GhostPreviewNavigationParams {
+  ghostId: string;
+  url: string;
+  hostContents: WebContents;
+  guestContents: WebContents;
+}
+
+export interface GhostPreviewNavigationDeps {
+  request: GhostPreviewGate['request'];
+  isOwnerActive(): boolean;
+  send(outcome: Extract<GhostPreviewOutcome, { ok: true }>): void;
+  logger: GhostPreviewNavigationLogger;
+}
+
+/**
+ * Owner-aware preview continuation. The ledger lookup may finish after an
+ * account commit, so the captured owner is checked both before and after it.
+ */
+export async function runGhostPreviewNavigation(
+  params: GhostPreviewNavigationParams,
+  deps: GhostPreviewNavigationDeps,
+): Promise<void> {
+  if (!deps.isOwnerActive()) return;
+  try {
+    const outcome = await deps.request({
+      ghostId: params.ghostId,
+      url: params.url,
+      isPanelFocused: () =>
+        deps.isOwnerActive() &&
+        !params.guestContents.isDestroyed() &&
+        params.guestContents.isFocused(),
+    });
+    if (!deps.isOwnerActive()) return;
+    if (!outcome.ok) {
+      deps.logger.debug('ghost preview rejected', {
+        ghostId: params.ghostId,
+        reason: outcome.reason,
+      });
+      return;
+    }
+    if (params.hostContents.isDestroyed()) return;
+    if (!deps.isOwnerActive()) return;
+    deps.send(outcome);
+  } catch (error) {
+    if (!deps.isOwnerActive()) return;
+    deps.logger.warn('ghost preview failed', {
+      ghostId: params.ghostId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}

--- a/apps/desktop/src/main/cindy-brain/ghostProtocolDialogParent.ts
+++ b/apps/desktop/src/main/cindy-brain/ghostProtocolDialogParent.ts
@@ -1,0 +1,21 @@
+import { BrowserWindow } from 'electron';
+
+import { isTrustedAppRendererWindow } from '../security/trustedAppRenderer.js';
+import { isMainShellWindowUrl } from './scheduleSlot.js';
+
+/**
+ * Native plugin confirmations must have a visible trusted parent on macOS so an
+ * AbortSignal can close the sheet during an owner boundary.
+ */
+export function resolveGhostProtocolDialogParent(): BrowserWindow | null {
+  const focused = BrowserWindow.getFocusedWindow();
+  if (isTrustedAppRendererWindow(focused)) return focused;
+  return (
+    BrowserWindow.getAllWindows().find(
+      (window) =>
+        isTrustedAppRendererWindow(window) &&
+        window.isVisible() &&
+        isMainShellWindowUrl(window.webContents.getURL()),
+    ) ?? null
+  );
+}

--- a/apps/desktop/src/main/cindy-brain/ghostWebviewPartition.ts
+++ b/apps/desktop/src/main/cindy-brain/ghostWebviewPartition.ts
@@ -1,0 +1,33 @@
+import { GHOST_PARTITION_PREFIX, isValidGhostId, parseGhostPartition } from '../../shared/ghost.js';
+import { dataOwnerStorageKey, type ActiveAppSession } from '../appSessionState.js';
+
+const GHOST_OWNER_PARTITION_PREFIX = `${GHOST_PARTITION_PREFIX}owner:`;
+
+export interface ResolvedGhostWebviewPartition {
+  ghostId: string;
+  partition: string;
+}
+
+/** Main 持有的真实 owner → 不透明、稳定的插件 Electron session 分区。 */
+export function ownerScopedGhostPartition(
+  ghostId: string,
+  owner: Pick<ActiveAppSession, 'mode' | 'dataOwnerId'>,
+): string | null {
+  if (!isValidGhostId(ghostId) || owner.mode === 'signed-out' || !owner.dataOwnerId) return null;
+  return `${GHOST_OWNER_PARTITION_PREFIX}${owner.mode}:${dataOwnerStorageKey(owner.dataOwnerId)}:${ghostId}`;
+}
+
+/**
+ * Main 侧 WebView attach 的 owner 决策原语。
+ * Renderer 的 ghost-only partition 只是 attach claim；实际 partition 由 Main
+ * 根据当前已提交 owner 生成，Renderer 无法挑选另一个 owner 的 session。
+ */
+export function resolveGhostWebviewPartitionClaim(
+  partitionClaim: unknown,
+  activeOwner: Pick<ActiveAppSession, 'mode' | 'dataOwnerId'>,
+): ResolvedGhostWebviewPartition | null {
+  const ghostId = parseGhostPartition(partitionClaim);
+  if (!ghostId) return null;
+  const partition = ownerScopedGhostPartition(ghostId, activeOwner);
+  return partition ? { ghostId, partition } : null;
+}

--- a/apps/desktop/src/main/cindy-brain/index.ts
+++ b/apps/desktop/src/main/cindy-brain/index.ts
@@ -67,6 +67,7 @@ import {
   isAppSessionBoundaryPending,
   ownerScopedUserDataPath,
   type ActiveAppSession,
+  type AppSessionMode,
 } from '../appSessionState.js';
 import { getLayoutStore } from '../layout/index.js';
 import {
@@ -115,6 +116,7 @@ import {
 import { takePendingCindyInstall } from './openFileInstall.js';
 import { GhostRuntime } from './runtime/GhostRuntime.js';
 import {
+  abortGhostProtocolRequestsForAccountBoundary,
   electronSandboxAdapter,
   ensureGhostProtocolRegistered,
   ghostIdForLogicWebContents,
@@ -127,6 +129,7 @@ import {
   setGhostSandboxDevToolsDisabled,
   setGhostSecretsHandler,
   setGhostWakeHandler,
+  waitForGhostProtocolRequests,
 } from './runtime/electronSandboxAdapter.js';
 import { CURRENT_CINDY_REGION } from '../../shared/brandRegion.js';
 import { createGhostKvStore, removeGhostKvBestEffort, type GhostKvStore } from './ghostKvStore.js';
@@ -204,11 +207,13 @@ import {
   readLegacyEncryptedValue,
   type LegacyMigrationRead,
 } from './legacyMigrationRead.js';
-import { GHOST_SCHEME, ghostExternalLinkUrls, parseGhostPartition } from '../../shared/ghost.js';
+import { GHOST_SCHEME, ghostExternalLinkUrls } from '../../shared/ghost.js';
 import { GhostPipeDispatcher } from './pipeDispatcher.js';
 import { GhostCardService, parseCardHeightReport } from './cardService.js';
 import { GhostCardActionDispatcher } from './cardActionDispatch.js';
 import { GhostSessionActivityTracker } from './ghostSessionActivity.js';
+import { resolveGhostWebviewPartitionClaim } from './ghostWebviewPartition.js';
+import { resolveGhostProtocolDialogParent } from './ghostProtocolDialogParent.js';
 import { sanitizeGhostCardHtml } from './cardSanitizer.js';
 import {
   getGhostCard,
@@ -327,6 +332,7 @@ import {
 } from './subscriptionGateway.js';
 import { GhostExternalLinkGate, GhostPreviewGate, resolveGhostPanelMedia } from './previewGate.js';
 import { runGhostExternalLinkNavigation } from './ghostExternalLinkNavigation.js';
+import { runGhostPreviewNavigation } from './ghostPreviewNavigation.js';
 import {
   ghostSecretSaved,
   readGhostSecret,
@@ -975,8 +981,14 @@ export async function interruptGhostCallsForAccountBoundary(): Promise<void> {
   getGhostSetupInteractionBridge()?.cleanupAll('session_aborted');
   getGhostGrantConfirmBridge()?.cleanupAll('session_aborted');
   getGhostConfirmDialogBridge()?.cancelAll();
+  abortGhostExternalLinkNavigationsForAccountBoundary();
+  // 外层 owner boundary 已禁止新请求；主动打断不受信 body、系统确认框和
+  // library 媒体流，再销毁其余生产者，避免插件靠悬挂请求阻断切号。
+  abortGhostProtocolRequestsForAccountBoundary();
   runtimeSingleton?.destroyAll();
   resetNodeRuntimeBrokerForAccountBoundary();
+  // 请求租约由 handler 自己释放；取消后仍等真正退出，不能提前提交新 owner。
+  await waitForGhostProtocolRequests();
   // Library 会话一并作废:关 db worker + 作废 handle——在途写入已在串行链上
   // 归属原 owner 完成或随 vault.invalidate 作废,新 owner 解析到全新根。
   await getGhostLibrarySlot().disposeAll();
@@ -6073,7 +6085,8 @@ export function registerGhostIpc(): void {
   // 旧快照);login-email 派生凭证没有收单动作,不在键集内。保险库真身 =
   // providerSecretStore(safeStorage 键名与官方别名同一套)。卸下后的残留
   // 请求查无此意识,统一 404。
-  setGhostSecretsHandler(async ({ ghostId, method, pathname, readBodyText }) => {
+  setGhostSecretsHandler(async ({ ghostId, method, pathname, readBodyText, assertActive }) => {
+    assertActive();
     const ghost = findAvailableGhost(ghostId);
     if (!ghost) return { status: 404 };
     const networkSecretDecls = ghost.manifest.network?.secrets ?? [];
@@ -6116,6 +6129,7 @@ export function registerGhostIpc(): void {
       ghCliSecretDecls.length > 0
         ? await getSharedGhCliTokenSource().probeAvailability()
         : false;
+    assertActive();
     return handleGhostSecretsRequest({
       method,
       pathname,
@@ -6158,7 +6172,8 @@ export function registerGhostIpc(): void {
   // /oauth 通道(source:'oauth' 凭证的设置页动作面,FORGE_GUIDE §4.7):
   // client 凭证只写入库、连接/断开/默认账号由主机代办。同 /secrets 模式
   // 现查在装清单(意识更新立即以新声明为准);卸下后残留请求统一 404。
-  setGhostOauthHandler(async ({ ghostId, method, pathname, readBodyText }) => {
+  setGhostOauthHandler(async ({ ghostId, method, pathname, readBodyText, assertActive }) => {
+    assertActive();
     const ghost = findAvailableGhost(ghostId);
     if (!ghost) return { status: 404 };
     const runtimeManifest = withRuntimeFiloGoogleClient(ghost.manifest);
@@ -6189,57 +6204,70 @@ export function registerGhostIpc(): void {
   // 关键闸:**新增地址必须过 main 侧受信确认弹窗**——意识设置页是意识自绘
   // 的不可信界面,动态白名单扩张必须由主机模态拿到用户点头(规则 9:用代码
   // 保证,不靠意识自觉)。
-  setGhostConnectionsHandler(async ({ ghostId, method, pathname, readBodyText }) => {
-    const ghost = findAvailableGhost(ghostId);
-    if (!ghost) return { status: 404 };
-    const connectionDecls = ghost.manifest.network?.connections ?? [];
-    const decls = new Map<string, { label: string; maxConnections: number }>();
-    for (const c of connectionDecls) {
-      decls.set(c.key, {
-        label: c.label,
-        maxConnections: c.maxConnections ?? GHOST_NETWORK_MAX_CONNECTIONS_PER_DECL,
-      });
-    }
-    return handleGhostConnectionsRequest({
-      method,
-      pathname,
-      readBodyText,
-      decls,
-      manager: getGhostConnectionManager(),
-      ghostId,
-      // 受信确认:main 侧系统模态(对照 bootstrap 的 moveToApplications 弹窗
-      // 用法),默认落在「取消」上防误触;意识名从在装清单现查。
-      confirmAddHost: async (declLabel, host) => {
-        const ghostName = findAvailableGhost(ghostId)?.manifest.name ?? ghostId;
-        // main 迷你 i18n 只内置 {{appName}} 插值,其余变量按其约定在调用点
-        // 自行 replace(对照 bootstrap 菜单的用法)。
-        const { response } = await dialog.showMessageBox({
-          type: 'question',
-          title: t('settings.ghosts.connections.confirmTitle'),
-          message: t('settings.ghosts.connections.confirmMessage')
-            .replaceAll('{{name}}', ghostName)
-            .replaceAll('{{host}}', host),
-          detail: t('settings.ghosts.connections.confirmDetail').replaceAll('{{label}}', declLabel),
-          buttons: [
-            t('settings.ghosts.connections.confirmAllow'),
-            t('settings.ghosts.connections.confirmCancel'),
-          ],
-          defaultId: 1,
-          cancelId: 1,
+  setGhostConnectionsHandler(
+    async ({ ghostId, method, pathname, readBodyText, signal, assertActive }) => {
+      assertActive();
+      const ghost = findAvailableGhost(ghostId);
+      if (!ghost) return { status: 404 };
+      const connectionDecls = ghost.manifest.network?.connections ?? [];
+      const decls = new Map<string, { label: string; maxConnections: number }>();
+      for (const c of connectionDecls) {
+        decls.set(c.key, {
+          label: c.label,
+          maxConnections: c.maxConnections ?? GHOST_NETWORK_MAX_CONNECTIONS_PER_DECL,
         });
-        return response === 0;
-      },
-      onChanged: (declKey) => {
-        getGhostSetupChangeBus().emit(ghostId, { source: 'connection', ref: declKey });
-      },
-      // 新连接添加成功 → 主机代言 tips(带意识身份头;与 secretSaved 同接法)。
-      onAdded: (declKey) => {
-        const label = connectionDecls.find((c) => c.key === declKey)?.label ?? declKey;
-        broadcastGhostHostNotice(ghostId, { textKey: 'connectionAdded', textArgs: { label } });
-      },
-      log,
-    });
-  });
+      }
+      return handleGhostConnectionsRequest({
+        method,
+        pathname,
+        readBodyText,
+        decls,
+        manager: getGhostConnectionManager(),
+        ghostId,
+        // 受信确认:main 侧系统模态(对照 bootstrap 的 moveToApplications 弹窗
+        // 用法),默认落在「取消」上防误触;意识名从在装清单现查。
+        confirmAddHost: async (declLabel, host) => {
+          assertActive();
+          const ghostName = findAvailableGhost(ghostId)?.manifest.name ?? ghostId;
+          // macOS 的 signal 只有带 parent 的 message box 才能异步取消；没有
+          // 可见的受信宿主窗口时无法可靠拿到用户确认，直接按拒绝收口。
+          const parent = resolveGhostProtocolDialogParent();
+          if (!parent) return false;
+          // main 迷你 i18n 只内置 {{appName}} 插值,其余变量按其约定在调用点
+          // 自行 replace(对照 bootstrap 菜单的用法)。
+          const { response } = await dialog.showMessageBox(parent, {
+            type: 'question',
+            title: t('settings.ghosts.connections.confirmTitle'),
+            message: t('settings.ghosts.connections.confirmMessage')
+              .replaceAll('{{name}}', ghostName)
+              .replaceAll('{{host}}', host),
+            detail: t('settings.ghosts.connections.confirmDetail').replaceAll(
+              '{{label}}',
+              declLabel,
+            ),
+            buttons: [
+              t('settings.ghosts.connections.confirmAllow'),
+              t('settings.ghosts.connections.confirmCancel'),
+            ],
+            defaultId: 1,
+            cancelId: 1,
+            signal,
+          });
+          assertActive();
+          return response === 0;
+        },
+        onChanged: (declKey) => {
+          getGhostSetupChangeBus().emit(ghostId, { source: 'connection', ref: declKey });
+        },
+        // 新连接添加成功 → 主机代言 tips(带意识身份头;与 secretSaved 同接法)。
+        onAdded: (declKey) => {
+          const label = connectionDecls.find((c) => c.key === declKey)?.label ?? declKey;
+          broadcastGhostHostNotice(ghostId, { textKey: 'connectionAdded', textArgs: { label } });
+        },
+        log,
+      });
+    },
+  );
   // 主机正常退出:逐个销毁沙箱(docs/dev-rules/plugin-security-and-authoring.md 的"关完才走";
   // 主进程被强杀时 Chromium 会级联回收渲染子进程,无孤儿)。
   app.on('before-quit', () => {
@@ -7612,34 +7640,33 @@ export function handleGhostPreviewNavigation(
   url: string,
   hostContents: WebContents,
   guestContents: WebContents,
+  isOwnerActive: () => boolean,
 ): void {
-  void getGhostPreviewGate()
-    .request({
-      ghostId,
-      url,
-      isPanelFocused: () => !guestContents.isDestroyed() && guestContents.isFocused(),
-    })
-    .then((outcome) => {
-      if (!outcome.ok) {
-        log.debug('ghost preview rejected', { ghostId, reason: outcome.reason });
-        return;
-      }
-      if (hostContents.isDestroyed()) return;
-      sendGhostContentsPush(hostContents, GHOST_PREVIEW_MEDIA_CHANNEL, {
-        ghostId,
-        src: outcome.src,
-        kind: outcome.kind,
-      });
-    })
-    .catch((err) => {
-      log.warn('ghost preview failed', {
-        ghostId,
-        error: err instanceof Error ? err.message : String(err),
-      });
-    });
+  void runGhostPreviewNavigation(
+    { ghostId, url, hostContents, guestContents },
+    {
+      request: (request) => getGhostPreviewGate().request(request),
+      isOwnerActive,
+      send: (outcome) => {
+        sendGhostContentsPush(hostContents, GHOST_PREVIEW_MEDIA_CHANNEL, {
+          ghostId,
+          src: outcome.src,
+          kind: outcome.kind,
+        });
+      },
+      logger: log,
+    },
+  );
 }
 
 let externalLinkGateSingleton: GhostExternalLinkGate | null = null;
+const activeGhostExternalLinkNavigations = new Set<AbortController>();
+
+function abortGhostExternalLinkNavigationsForAccountBoundary(): void {
+  for (const controller of [...activeGhostExternalLinkNavigations]) {
+    controller.abort(new Error('ghost external link owner boundary started'));
+  }
+}
 
 function getGhostExternalLinkGate(): GhostExternalLinkGate {
   if (!externalLinkGateSingleton) {
@@ -7664,7 +7691,10 @@ export function handleGhostExternalLinkNavigation(
   url: string,
   hostContents: WebContents,
   guestContents: WebContents,
+  isOwnerActive: () => boolean,
 ): void {
+  const controller = new AbortController();
+  activeGhostExternalLinkNavigations.add(controller);
   void runGhostExternalLinkNavigation(
     { ghostId, url, hostContents, guestContents },
     {
@@ -7674,8 +7704,12 @@ export function handleGhostExternalLinkNavigation(
       openExternal: (targetUrl) => shell.openExternal(targetUrl),
       translate: t,
       logger: log,
+      isOwnerActive,
+      signal: controller.signal,
     },
-  );
+  ).finally(() => {
+    activeGhostExternalLinkNavigations.delete(controller);
+  });
 }
 
 /**
@@ -7687,10 +7721,19 @@ export function handleGhostExternalLinkNavigation(
  * 把协议 handler 挂好(必须先于 webview 首次加载)。任何一条不满足返回
  * null(闸口拒附加)。
  */
-export function resolveGhostWebviewAttach(partition: unknown, src: unknown): InstalledGhost | null {
-  const id = parseGhostPartition(partition);
-  if (!id || typeof src !== 'string') return null;
-  const ghost = findAvailableGhost(id);
+export function resolveGhostWebviewAttach(
+  partitionClaim: unknown,
+  src: unknown,
+): {
+  ghost: InstalledGhost;
+  partition: string;
+  owner: { mode: AppSessionMode; dataOwnerId: string };
+} | null {
+  if (isAppSessionBoundaryPending() || typeof src !== 'string') return null;
+  const owner = getActiveAppSession();
+  const resolvedPartition = resolveGhostWebviewPartitionClaim(partitionClaim, owner);
+  if (!resolvedPartition) return null;
+  const ghost = findAvailableGhost(resolvedPartition.ghostId);
   if (!ghost || !ghost.enabled) return null;
   const allowedPaths = ghostWebviewEntryPaths(ghost.manifest);
   if (allowedPaths.length === 0) return null;
@@ -7700,10 +7743,14 @@ export function resolveGhostWebviewAttach(partition: unknown, src: unknown): Ins
   } catch {
     return null;
   }
-  if (url.protocol !== `${GHOST_SCHEME}:` || url.host !== id) return null;
+  if (url.protocol !== `${GHOST_SCHEME}:` || url.host !== resolvedPartition.ghostId) return null;
   if (!allowedPaths.includes(url.pathname)) return null;
-  ensureGhostProtocolRegistered(ghost);
-  return ghost;
+  ensureGhostProtocolRegistered(ghost, owner);
+  return {
+    ghost,
+    partition: resolvedPartition.partition,
+    owner: { mode: owner.mode, dataOwnerId: owner.dataOwnerId! },
+  };
 }
 
 /** 播种进行中提示广播(renderer 显示/收起非阻塞胶囊;与退出 overlay 同款视觉)。 */

--- a/apps/desktop/src/main/cindy-brain/runtime/__tests__/electronSandboxAdapter.partition.test.ts
+++ b/apps/desktop/src/main/cindy-brain/runtime/__tests__/electronSandboxAdapter.partition.test.ts
@@ -1,0 +1,510 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Readable } from 'node:stream';
+
+const harness = vi.hoisted(() => {
+  let nextWebContentsId = 1;
+  type RegisteredSession = {
+    permissionRequest: ReturnType<typeof vi.fn>;
+    permissionCheck: ReturnType<typeof vi.fn>;
+    on: ReturnType<typeof vi.fn>;
+    beforeRequest: ReturnType<typeof vi.fn>;
+    protocolHandle: ReturnType<typeof vi.fn>;
+    beforeRequestHandler?: (
+      details: { url: string },
+      callback: (result: { cancel: boolean }) => void,
+    ) => void;
+    protocolHandler?: (request: Request) => Promise<Response>;
+    downloadHandler?: (event: { preventDefault(): void }) => void;
+  };
+  const sessions = new Map<string, RegisteredSession>();
+  return {
+    activeOwner: {
+      mode: 'cloud' as 'signed-out' | 'local' | 'cloud',
+      dataOwnerId: 'owner-a' as string | null,
+      generation: 1,
+    },
+    boundaryPending: false,
+    sessions,
+    fromPartition: vi.fn((partition: string) => {
+      const existing = sessions.get(partition);
+      if (existing) return existing;
+      const created: RegisteredSession = {
+        permissionRequest: vi.fn(),
+        permissionCheck: vi.fn(),
+        on: vi.fn((event: string, handler: (event: { preventDefault(): void }) => void) => {
+          if (event === 'will-download') created.downloadHandler = handler;
+        }),
+        beforeRequest: vi.fn((handler) => {
+          created.beforeRequestHandler = handler;
+        }),
+        protocolHandle: vi.fn(
+          (_scheme: string, handler: (request: Request) => Promise<Response>) => {
+            created.protocolHandler = handler;
+          },
+        ),
+      };
+      sessions.set(partition, created);
+      return {
+        setPermissionRequestHandler: created.permissionRequest,
+        setPermissionCheckHandler: created.permissionCheck,
+        on: created.on,
+        webRequest: { onBeforeRequest: created.beforeRequest },
+        protocol: { handle: created.protocolHandle },
+      };
+    }),
+    browserWindowOptions: [] as Array<Record<string, unknown>>,
+    createReadStream: vi.fn(),
+    readFile: vi.fn(),
+    stat: vi.fn().mockResolvedValue({ isFile: () => true, size: 1024 }),
+    BrowserWindow: vi.fn(function BrowserWindow(options: Record<string, unknown>) {
+      harness.browserWindowOptions.push(options);
+      const webContents = {
+        id: nextWebContentsId++,
+        on: vi.fn(),
+        isDestroyed: vi.fn(() => false),
+        forcefullyCrashRenderer: vi.fn(),
+      };
+      return {
+        webContents,
+        loadURL: vi.fn().mockResolvedValue(undefined),
+        isDestroyed: vi.fn(() => false),
+        destroy: vi.fn(),
+      };
+    }),
+  };
+});
+
+vi.mock('electron', () => ({
+  BrowserWindow: harness.BrowserWindow,
+  session: { fromPartition: harness.fromPartition },
+  webContents: { fromId: vi.fn(() => null) },
+}));
+
+vi.mock('node:fs', () => ({
+  createReadStream: harness.createReadStream,
+}));
+
+vi.mock('node:fs/promises', () => ({
+  default: {
+    readFile: harness.readFile,
+    stat: harness.stat,
+  },
+}));
+
+vi.mock('../../../appSessionState', () => ({
+  dataOwnerStorageKey: (ownerId: string) => `opaque-${ownerId}`,
+  getActiveAppSession: () => ({ ...harness.activeOwner }),
+  isAppSessionBoundaryPending: () => harness.boundaryPending,
+}));
+
+vi.mock('../../../logger', () => ({
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+
+vi.mock('../../../cindy-media/blobStore', () => ({
+  readBlob: vi.fn(),
+  resolveHashRef: vi.fn(),
+}));
+
+vi.mock('../../../cindy-media/ledger', () => ({
+  ghostCanRead: vi.fn(),
+  listGhostGallery: vi.fn().mockResolvedValue([]),
+}));
+
+import type { InstalledGhost } from '../../../../shared/ghost';
+import {
+  electronSandboxAdapter,
+  abortGhostProtocolRequestsForAccountBoundary,
+  ensureGhostProtocolRegistered,
+  setGhostConnectionsHandler,
+  setGhostLibraryFileResolver,
+  setGhostKvStore,
+  waitForGhostProtocolRequests,
+} from '../electronSandboxAdapter';
+
+function ghost(id: string): InstalledGhost {
+  return {
+    dir: `/plugins/${id}`,
+    enabled: true,
+    approval: { state: 'approved', revision: '00000000-0000-4000-8000-000000000001' },
+    manifest: {
+      schemaVersion: 2,
+      id,
+      name: id,
+      version: '1.0.0',
+      kind: 'chip',
+      entry: 'main.js',
+      slots: ['panel'],
+      panel: { html: 'panel.html' },
+    },
+  };
+}
+
+beforeEach(() => {
+  harness.activeOwner = { mode: 'cloud', dataOwnerId: 'owner-a', generation: 1 };
+  harness.boundaryPending = false;
+  harness.fromPartition.mockClear();
+  harness.BrowserWindow.mockClear();
+  harness.browserWindowOptions.length = 0;
+  harness.createReadStream.mockReset();
+  harness.readFile.mockReset();
+  setGhostLibraryFileResolver(null);
+});
+
+describe('electronSandboxAdapter owner partition', () => {
+  it('同 ghostId 的不同 owner 注册不同 session，且每个 session 都显式拒绝权限和下载', () => {
+    const installed = ghost('same-ghost');
+    ensureGhostProtocolRegistered(installed, {
+      mode: 'cloud',
+      dataOwnerId: 'owner-a',
+      generation: 1,
+    });
+    ensureGhostProtocolRegistered(installed, {
+      mode: 'cloud',
+      dataOwnerId: 'owner-b',
+      generation: 2,
+    });
+
+    const partitionA = 'cindy-ghost-owner:cloud:opaque-owner-a:same-ghost';
+    const partitionB = 'cindy-ghost-owner:cloud:opaque-owner-b:same-ghost';
+    const sessionA = harness.sessions.get(partitionA);
+    const sessionB = harness.sessions.get(partitionB);
+    expect(sessionA).toBeDefined();
+    expect(sessionB).toBeDefined();
+
+    for (const registered of [sessionA, sessionB]) {
+      expect(registered?.permissionRequest).toHaveBeenCalledOnce();
+      expect(registered?.permissionCheck).toHaveBeenCalledOnce();
+      expect(registered?.on).toHaveBeenCalledWith('will-download', expect.any(Function));
+
+      const permissionCallback = vi.fn();
+      registered?.permissionRequest.mock.calls[0]?.[0](null, 'camera', permissionCallback);
+      expect(permissionCallback).toHaveBeenCalledWith(false);
+      expect(registered?.permissionCheck.mock.calls[0]?.[0]()).toBe(false);
+
+      const downloadEvent = { preventDefault: vi.fn() };
+      registered?.downloadHandler?.(downloadEvent);
+      expect(downloadEvent.preventDefault).toHaveBeenCalledOnce();
+    }
+  });
+
+  it('协议和网络 handler 在 owner 变化或切换边界中 fail closed', async () => {
+    const installed = ghost('owner-fence');
+    ensureGhostProtocolRegistered(installed, {
+      mode: 'cloud',
+      dataOwnerId: 'owner-a',
+      generation: 1,
+    });
+    const registered = harness.sessions.get('cindy-ghost-owner:cloud:opaque-owner-a:owner-fence');
+    expect(registered?.protocolHandler).toBeDefined();
+    expect(registered?.beforeRequestHandler).toBeDefined();
+
+    harness.activeOwner = { mode: 'cloud', dataOwnerId: 'owner-b', generation: 2 };
+    const response = await registered?.protocolHandler?.(
+      new Request('cindy-ghost://owner-fence/panel.html'),
+    );
+    expect(response?.status).toBe(403);
+
+    const networkResult = vi.fn();
+    registered?.beforeRequestHandler?.(
+      { url: 'cindy-ghost://owner-fence/panel.html' },
+      networkResult,
+    );
+    expect(networkResult).toHaveBeenCalledWith({ cancel: true });
+
+    harness.activeOwner = { mode: 'cloud', dataOwnerId: 'owner-a', generation: 1 };
+    harness.boundaryPending = true;
+    const boundaryResponse = await registered?.protocolHandler?.(
+      new Request('cindy-ghost://owner-fence/panel.html'),
+    );
+    expect(boundaryResponse?.status).toBe(403);
+  });
+
+  it('同 owner generation 变化后既有 WebView 无需重新 attach 仍可访问', async () => {
+    const installed = ghost('generation-refresh');
+    ensureGhostProtocolRegistered(installed, {
+      mode: 'cloud',
+      dataOwnerId: 'owner-a',
+      generation: 1,
+    });
+    harness.activeOwner.generation = 2;
+
+    const registered = harness.sessions.get(
+      'cindy-ghost-owner:cloud:opaque-owner-a:generation-refresh',
+    );
+    const response = await registered?.protocolHandler?.(
+      new Request('cindy-ghost://generation-refresh/'),
+    );
+    expect(response?.status).toBe(200);
+  });
+
+  it('边界会等待已入闸的 KV 请求在旧 owner 下完成，再允许提交新 owner', async () => {
+    const installed = ghost('inflight-kv');
+    ensureGhostProtocolRegistered(installed, {
+      mode: 'cloud',
+      dataOwnerId: 'owner-a',
+      generation: 1,
+    });
+    const writes: string[] = [];
+    setGhostKvStore({
+      read: () => ({}),
+      write: () => {
+        writes.push(`${harness.activeOwner.dataOwnerId}:${harness.activeOwner.generation}`);
+      },
+    });
+
+    let resolveFirstRead!: (value: { done: false; value: Uint8Array }) => void;
+    let readCount = 0;
+    const read = vi.fn(() => {
+      if (readCount++ === 0) {
+        return new Promise<{ done: false; value: Uint8Array }>((resolve) => {
+          resolveFirstRead = resolve;
+        });
+      }
+      return Promise.resolve({ done: true as const });
+    });
+    const request = {
+      url: 'cindy-ghost://inflight-kv/kv',
+      method: 'PUT',
+      headers: new Headers(),
+      body: { getReader: () => ({ read, cancel: vi.fn().mockResolvedValue(undefined) }) },
+    } as unknown as Request;
+    const registered = harness.sessions.get(
+      'cindy-ghost-owner:cloud:opaque-owner-a:inflight-kv',
+    );
+    const responsePromise = registered!.protocolHandler!(request);
+    await vi.waitFor(() => expect(read).toHaveBeenCalledOnce());
+
+    harness.boundaryPending = true;
+    let drained = false;
+    const drainPromise = waitForGhostProtocolRequests().then(() => {
+      drained = true;
+    });
+    await Promise.resolve();
+    expect(drained).toBe(false);
+
+    resolveFirstRead({
+      done: false,
+      value: new TextEncoder().encode('{"owner":"a"}'),
+    });
+    expect((await responsePromise).status).toBe(204);
+    await drainPromise;
+    expect(writes).toEqual(['owner-a:1']);
+
+    harness.activeOwner = { mode: 'cloud', dataOwnerId: 'owner-b', generation: 2 };
+  });
+
+  it('请求体等待期间 owner 若意外变化，旧请求按 403 收口且不写新 owner', async () => {
+    const installed = ghost('stale-kv');
+    ensureGhostProtocolRegistered(installed, {
+      mode: 'cloud',
+      dataOwnerId: 'owner-a',
+      generation: 1,
+    });
+    const write = vi.fn();
+    setGhostKvStore({ read: () => ({}), write });
+
+    let resolveFirstRead!: (value: { done: false; value: Uint8Array }) => void;
+    let readCount = 0;
+    const read = vi.fn(() => {
+      if (readCount++ === 0) {
+        return new Promise<{ done: false; value: Uint8Array }>((resolve) => {
+          resolveFirstRead = resolve;
+        });
+      }
+      return Promise.resolve({ done: true as const });
+    });
+    const request = {
+      url: 'cindy-ghost://stale-kv/kv',
+      method: 'PUT',
+      headers: new Headers(),
+      body: { getReader: () => ({ read, cancel: vi.fn().mockResolvedValue(undefined) }) },
+    } as unknown as Request;
+    const registered = harness.sessions.get(
+      'cindy-ghost-owner:cloud:opaque-owner-a:stale-kv',
+    );
+    const responsePromise = registered!.protocolHandler!(request);
+    await vi.waitFor(() => expect(read).toHaveBeenCalledOnce());
+
+    harness.activeOwner = { mode: 'cloud', dataOwnerId: 'owner-b', generation: 2 };
+    resolveFirstRead({
+      done: false,
+      value: new TextEncoder().encode('{"owner":"stale"}'),
+    });
+
+    expect((await responsePromise).status).toBe(403);
+    expect(write).not.toHaveBeenCalled();
+    await waitForGhostProtocolRequests();
+  });
+
+  it('账号边界会取消永不结束的请求体，drain 不被插件阻塞', async () => {
+    const installed = ghost('hanging-kv');
+    ensureGhostProtocolRegistered(installed, {
+      mode: 'cloud',
+      dataOwnerId: 'owner-a',
+      generation: 1,
+    });
+    const write = vi.fn();
+    setGhostKvStore({ read: () => ({}), write });
+
+    const cancel = vi.fn(() => new Promise<never>(() => {}));
+    const read = vi.fn(() => new Promise<never>(() => {}));
+    const request = {
+      url: 'cindy-ghost://hanging-kv/kv',
+      method: 'PUT',
+      headers: new Headers(),
+      body: { getReader: () => ({ read, cancel }) },
+    } as unknown as Request;
+    const registered = harness.sessions.get(
+      'cindy-ghost-owner:cloud:opaque-owner-a:hanging-kv',
+    );
+    const responsePromise = registered!.protocolHandler!(request);
+    await vi.waitFor(() => expect(read).toHaveBeenCalledOnce());
+
+    harness.boundaryPending = true;
+    abortGhostProtocolRequestsForAccountBoundary();
+
+    expect((await responsePromise).status).toBe(403);
+    await waitForGhostProtocolRequests();
+    expect(cancel).toHaveBeenCalled();
+    expect(write).not.toHaveBeenCalled();
+  });
+
+  it('Response 已返回但未读完的 library 流会在账号边界被销毁', async () => {
+    const installed = ghost('streaming-library');
+    ensureGhostProtocolRegistered(installed, {
+      mode: 'cloud',
+      dataOwnerId: 'owner-a',
+      generation: 1,
+    });
+    setGhostLibraryFileResolver(async () => '/owner-a/library/video.mp4');
+    const stream = new Readable({ read: () => {} });
+    const destroy = vi.spyOn(stream, 'destroy');
+    harness.createReadStream.mockReturnValue(stream);
+
+    const registered = harness.sessions.get(
+      'cindy-ghost-owner:cloud:opaque-owner-a:streaming-library',
+    );
+    const response = await registered!.protocolHandler!(
+      new Request('cindy-ghost://streaming-library/library/video.mp4'),
+    );
+    expect(response.status).toBe(200);
+    expect(destroy).not.toHaveBeenCalled();
+
+    harness.boundaryPending = true;
+    abortGhostProtocolRequestsForAccountBoundary();
+
+    expect(destroy).toHaveBeenCalledOnce();
+  });
+
+  it('library resolver 等待期间开始边界，恢复后不会再创建漏网文件流', async () => {
+    const installed = ghost('pending-library');
+    ensureGhostProtocolRegistered(installed, {
+      mode: 'cloud',
+      dataOwnerId: 'owner-a',
+      generation: 1,
+    });
+    let resolveLibrary!: (path: string) => void;
+    const resolver = vi.fn(
+      () =>
+        new Promise<string>((resolve) => {
+          resolveLibrary = resolve;
+        }),
+    );
+    setGhostLibraryFileResolver(resolver);
+    const registered = harness.sessions.get(
+      'cindy-ghost-owner:cloud:opaque-owner-a:pending-library',
+    );
+    const responsePromise = registered!.protocolHandler!(
+      new Request('cindy-ghost://pending-library/library/video.mp4'),
+    );
+    await vi.waitFor(() => expect(resolver).toHaveBeenCalledOnce());
+
+    harness.boundaryPending = true;
+    abortGhostProtocolRequestsForAccountBoundary();
+    resolveLibrary('/owner-a/library/video.mp4');
+
+    expect((await responsePromise).status).toBe(403);
+    expect(harness.createReadStream).not.toHaveBeenCalled();
+    await waitForGhostProtocolRequests();
+  });
+
+  it('静态插件文件读取被账号边界取消时按 403 收口', async () => {
+    const installed = ghost('pending-static');
+    ensureGhostProtocolRegistered(installed, {
+      mode: 'cloud',
+      dataOwnerId: 'owner-a',
+      generation: 1,
+    });
+    harness.readFile.mockImplementation(
+      (_path: string, options: { signal: AbortSignal }) =>
+        new Promise((_resolve, reject) => {
+          options.signal.addEventListener(
+            'abort',
+            () => reject(Object.assign(new Error('aborted'), { name: 'AbortError' })),
+            { once: true },
+          );
+        }),
+    );
+    const registered = harness.sessions.get(
+      'cindy-ghost-owner:cloud:opaque-owner-a:pending-static',
+    );
+    const responsePromise = registered!.protocolHandler!(
+      new Request('cindy-ghost://pending-static/panel.html'),
+    );
+    await vi.waitFor(() => expect(harness.readFile).toHaveBeenCalledOnce());
+
+    harness.boundaryPending = true;
+    abortGhostProtocolRequestsForAccountBoundary();
+
+    expect((await responsePromise).status).toBe(403);
+    await waitForGhostProtocolRequests();
+  });
+
+  it('账号边界把取消信号传给等待主机确认的协议 handler', async () => {
+    const installed = ghost('pending-confirmation');
+    ensureGhostProtocolRegistered(installed, {
+      mode: 'cloud',
+      dataOwnerId: 'owner-a',
+      generation: 1,
+    });
+    const observedAbort = vi.fn();
+    setGhostConnectionsHandler(
+      ({ signal }) =>
+        new Promise((resolve) => {
+          signal.addEventListener(
+            'abort',
+            () => {
+              observedAbort();
+              resolve({ status: 200 });
+            },
+            { once: true },
+          );
+        }),
+    );
+
+    const registered = harness.sessions.get(
+      'cindy-ghost-owner:cloud:opaque-owner-a:pending-confirmation',
+    );
+    const responsePromise = registered!.protocolHandler!(
+      new Request('cindy-ghost://pending-confirmation/connections'),
+    );
+    harness.boundaryPending = true;
+    abortGhostProtocolRequestsForAccountBoundary();
+
+    expect((await responsePromise).status).toBe(403);
+    expect(observedAbort).toHaveBeenCalledOnce();
+    await waitForGhostProtocolRequests();
+  });
+
+  it('隐藏逻辑页使用与可见 WebView 相同的 owner-scoped partition', () => {
+    const handle = electronSandboxAdapter.create(ghost('logic-page'));
+
+    expect(harness.browserWindowOptions[0]).toMatchObject({
+      webPreferences: {
+        partition: 'cindy-ghost-owner:cloud:opaque-owner-a:logic-page',
+      },
+    });
+    handle.destroy();
+  });
+});

--- a/apps/desktop/src/main/cindy-brain/runtime/electronSandboxAdapter.ts
+++ b/apps/desktop/src/main/cindy-brain/runtime/electronSandboxAdapter.ts
@@ -1,19 +1,23 @@
 import { BrowserWindow, session, webContents, type CustomScheme } from 'electron';
 import fs from 'node:fs/promises';
 import * as nodeFs from 'node:fs';
-import { Readable } from 'node:stream';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { createLogger } from '../../logger.js';
 import {
+  getActiveAppSession,
+  isAppSessionBoundaryPending,
+  type ActiveAppSession,
+} from '../../appSessionState.js';
+import {
   GHOST_SCHEME,
-  ghostPartition,
   type GhostAppContextResult,
   type GhostMediaModelsResult,
   type GhostMediaModelType,
   type InstalledGhost,
 } from '../../../shared/ghost.js';
+import { ownerScopedGhostPartition } from '../ghostWebviewPartition.js';
 import { GHOST_BOOT_PATH, ghostBootHtml, ghostFileMime, resolveGhostFilePath } from './ghostFiles.js';
 import { handleGhostKvRequest, readBoundedBodyText } from './ghostKvEndpoint.js';
 import { resolveHashRef as resolveBlobHashRef } from '../../cindy-media/blobStore.js';
@@ -23,6 +27,7 @@ import {
   listGhostGallery as listGhostGalleryFromLedger,
 } from '../../cindy-media/ledger.js';
 import type { SandboxHandle, SandboxHostAdapter } from './GhostRuntime.js';
+import { GhostMutationCoordinator } from '../ghostMutationCoordinator.js';
 
 /**
  * Electron 沙箱宿主(docs/dev-rules/plugin-security-and-authoring.md):
@@ -176,6 +181,8 @@ type GhostSecretsProtocolHandler = (args: {
   method: string;
   pathname: string;
   readBodyText: () => Promise<string>;
+  signal: AbortSignal;
+  assertActive: () => void;
 }) => Promise<{ status: number; body?: string }>;
 
 let ghostSecretsHandler: GhostSecretsProtocolHandler | null = null;
@@ -194,6 +201,8 @@ type GhostOauthProtocolHandler = (args: {
   method: string;
   pathname: string;
   readBodyText: () => Promise<string>;
+  signal: AbortSignal;
+  assertActive: () => void;
 }) => Promise<{ status: number; body?: string }>;
 
 let ghostOauthHandler: GhostOauthProtocolHandler | null = null;
@@ -213,6 +222,8 @@ type GhostConnectionsProtocolHandler = (args: {
   method: string;
   pathname: string;
   readBodyText: () => Promise<string>;
+  signal: AbortSignal;
+  assertActive: () => void;
 }) => Promise<{ status: number; body?: string }>;
 
 let ghostConnectionsHandler: GhostConnectionsProtocolHandler | null = null;
@@ -224,14 +235,53 @@ export function setGhostConnectionsHandler(handler: GhostConnectionsProtocolHand
 /** 该分区是否已挂过协议 handler(session 分区随 app 生命周期,挂一次即可)。 */
 const partitionRegistered = new Set<string>();
 const partitionGhost = new Map<string, { dir: string; entry: string }>();
+const partitionOwner = new Map<string, ActiveAppSession>();
+const ghostProtocolRequestCoordinator = new GhostMutationCoordinator();
+const activeGhostProtocolRequests = new Set<AbortController>();
+
+interface ActiveGhostProtocolStream {
+  abort(): void;
+}
+
+const activeGhostProtocolStreams = new Set<ActiveGhostProtocolStream>();
+
+class GhostProtocolOwnerChangedError extends Error {}
+
+function throwIfGhostProtocolAborted(signal: AbortSignal): void {
+  if (!signal.aborted) return;
+  throw signal.reason instanceof Error
+    ? signal.reason
+    : new GhostProtocolOwnerChangedError('ghost protocol request aborted');
+}
+
+/**
+ * 账号边界先主动取消不受信请求体、确认框与媒体流，避免插件靠悬挂输入
+ * 阻塞切号；coordinator 租约仍由 handler 自己释放，不能提前伪造 drain。
+ */
+export function abortGhostProtocolRequestsForAccountBoundary(): void {
+  for (const controller of [...activeGhostProtocolRequests]) {
+    controller.abort(new GhostProtocolOwnerChangedError('ghost protocol owner boundary started'));
+  }
+  for (const stream of [...activeGhostProtocolStreams]) stream.abort();
+}
+
+/** 账号边界在提交新 owner 前等待已经入闸的协议请求真正退出。 */
+export function waitForGhostProtocolRequests(): Promise<void> {
+  return ghostProtocolRequestCoordinator.waitForIdle();
+}
 
 /**
  * 确保某意识分区上的 cindy-ghost:// 协议 handler 就位(幂等)。
  * 两个调用方:离屏沙箱窗口(create)与面板 webview 附加闸(webview-security
  * 放行前调用——handler 必须先于 webview 首次加载挂好)。
  */
-export function ensureGhostProtocolRegistered(ghost: InstalledGhost): void {
-  registerGhostProtocol(ghostPartition(ghost.manifest.id), ghost);
+export function ensureGhostProtocolRegistered(
+  ghost: InstalledGhost,
+  owner: ActiveAppSession = getActiveAppSession(),
+): void {
+  const partition = ownerScopedGhostPartition(ghost.manifest.id, owner);
+  if (!partition) throw new Error('ghost protocol requires an active data owner');
+  registerGhostProtocol(partition, ghost, owner);
 }
 
 /**
@@ -242,27 +292,81 @@ export function ensureGhostProtocolRegistered(ghost: InstalledGhost): void {
 const GHOST_HTML_CSP =
   "default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; media-src 'self' data: blob:";
 
-function registerGhostProtocol(partition: string, ghost: InstalledGhost): void {
+function isGhostProtocolOwnerActive(
+  owner: ActiveAppSession,
+  allowPendingBoundary = false,
+): boolean {
+  if (!allowPendingBoundary && isAppSessionBoundaryPending()) return false;
+  const current = getActiveAppSession();
+  return (
+    current.mode === owner.mode &&
+    current.dataOwnerId === owner.dataOwnerId
+  );
+}
+
+function registerGhostProtocol(
+  partition: string,
+  ghost: InstalledGhost,
+  owner: ActiveAppSession,
+): void {
   partitionGhost.set(partition, {
     dir: ghost.dir,
     entry: ghost.manifest.entry,
   });
+  // partition 按 owner 身份稳定复用；generation 是异步任务栅栏，不是 storage
+  // 身份。同 owner 修复会递增 generation，但既有可见 WebView 无需因此失效。
+  partitionOwner.set(partition, { ...owner });
   if (partitionRegistered.has(partition)) return;
   // 注意:登记发生在全部挂载成功之后(函数末尾)——session.fromPartition 在
   // app ready 前会 throw,若先登记后挂载,失败分区会被永久标记"已注册"而
   // 实际无 handler,面板与电子脑一起哑火(review P0 的中毒模式)。
   const ses = session.fromPartition(partition);
   const ghostId = ghost.manifest.id;
+  // 不受信插件页面没有直接申请设备权限或发起下载的资格；每个新 owner
+  // session 都显式 fail closed，不能依赖 Electron 默认值。
+  ses.setPermissionRequestHandler((_webContents, _permission, callback) => callback(false));
+  ses.setPermissionCheckHandler(() => false);
+  ses.on('will-download', (event) => event.preventDefault());
   // 分区级断网(docs/dev-rules/plugin-security-and-authoring.md 的"网络永远不直连"):本分区发出的一切
   // 请求,只放行自己协议同 id 下的资源;http(s) / ws / 其它协议一律掐断。
   // 进程沙箱不管网络,这里才是"零网络"承诺的真正闸门;外部数据未来走
   // 主机代发(管子服务),不走这里。devtools 前端跑在自己的进程,不受影响。
   const selfPrefix = `${SCHEME}://${ghostId}/`;
   ses.webRequest.onBeforeRequest((details, callback) => {
-    callback({ cancel: !details.url.startsWith(selfPrefix) });
+    const activeOwner = partitionOwner.get(partition);
+    callback({
+      cancel:
+        !activeOwner ||
+        !isGhostProtocolOwnerActive(activeOwner) ||
+        !details.url.startsWith(selfPrefix),
+    });
   });
   ses.protocol.handle(SCHEME, async (request) => {
+    const requestOwner = partitionOwner.get(partition);
+    if (!requestOwner || !isGhostProtocolOwnerActive(requestOwner)) {
+      return new Response(null, { status: 403 });
+    }
+    const requestAbort = new AbortController();
+    activeGhostProtocolRequests.add(requestAbort);
+    const releaseRequest = ghostProtocolRequestCoordinator.acquire();
     try {
+      const assertRequestOwner = (): void => {
+        throwIfGhostProtocolAborted(requestAbort.signal);
+        // 已入闸请求允许在 pending 边界中用旧 owner 做同步收尾，但 owner
+        // 身份不能变化；边界会先 abort，再等待 coordinator 归零。
+        if (!isGhostProtocolOwnerActive(requestOwner, true)) {
+          throw new GhostProtocolOwnerChangedError(
+            'ghost protocol owner changed while request was pending',
+          );
+        }
+      };
+      assertRequestOwner();
+      const awaitForRequestOwner = async <T>(pending: Promise<T>): Promise<T> => {
+        assertRequestOwner();
+        const result = await pending;
+        assertRequestOwner();
+        return result;
+      };
       const url = new URL(request.url);
       // 分区专属通道只认自己的 id,其它 host 一律 403(结构隔离的最后一道断言)。
       if (url.host !== ghostId) return new Response(null, { status: 403 });
@@ -271,19 +375,36 @@ function registerGhostProtocol(partition: string, ghost: InstalledGhost): void {
       // 账本验归属(出生自本意识或挂本意识画廊),通过才从字节仓读——
       // 查无此账与不属于你统一 404,不给沙箱探测面。
       if (url.pathname.startsWith('/media/')) {
-        return serveGhostMedia(ghostId, url.pathname.slice('/media/'.length), request.headers.get('range'));
+        const response = await awaitForRequestOwner(
+          serveGhostMedia(
+            ghostId,
+            url.pathname.slice('/media/'.length),
+            request.headers.get('range'),
+            requestAbort.signal,
+          ),
+        );
+        return response;
       }
       // /library/<相对路径>:面板只读投影本意识的持久作品库文件(图片/视频/
       // 导出物)。解析器由 cindy-brain/index 注入(binding 根 + vault 路径纪律,
       // 与电子脑 read 同源校验);内容可变,Cache-Control 走 no-cache(与
       // 内容寻址的 /media 长缓存不同)。失败统一折叠 404。
       if (url.pathname.startsWith('/library/')) {
-        return serveGhostLibraryFile(ghostId, decodeURIComponent(url.pathname.slice('/library/'.length)), request.headers.get('range'));
+        const response = await awaitForRequestOwner(
+          serveGhostLibraryFile(
+            ghostId,
+            decodeURIComponent(url.pathname.slice('/library/'.length)),
+            request.headers.get('range'),
+            requestAbort.signal,
+          ),
+        );
+        return response;
       }
       // /gallery:本意识画廊清单(重启回放)。分区专属通道天然只答自己的账;
       // 内容只有指纹地址与备注字符串,零文件字节。
       if (url.pathname === '/gallery') {
-        return serveGhostGallery(ghostId);
+        const response = await awaitForRequestOwner(serveGhostGallery(ghostId));
+        return response;
       }
       // /wake:面板叫醒自己的电子脑(§4"确实有活才开门"的面板侧入口)。
       // spawn 幂等(已在跑立即返回);沉睡/熔断由注入的 handler 拒绝。
@@ -291,7 +412,7 @@ function registerGhostProtocol(partition: string, ghost: InstalledGhost): void {
       // 只回状态字符串,不回任何细节。
       if (url.pathname === '/wake') {
         if (!ghostWakeHandler) return new Response(null, { status: 503 });
-        const wake = await ghostWakeHandler(ghostId);
+        const wake = await awaitForRequestOwner(ghostWakeHandler(ghostId));
         return new Response(JSON.stringify(wake), {
           status: 200,
           headers: { 'Content-Type': 'application/json; charset=utf-8', 'Cache-Control': 'no-cache' },
@@ -325,7 +446,7 @@ function registerGhostProtocol(partition: string, ghost: InstalledGhost): void {
           return new Response(null, { status: 400 });
         }
         if (!ghostMediaModelsProvider) return new Response(null, { status: 503 });
-        const result = await ghostMediaModelsProvider(ghostId, type);
+        const result = await awaitForRequestOwner(ghostMediaModelsProvider(ghostId, type));
         return new Response(JSON.stringify(result), {
           status: result.ok ? 200 : result.errorCode === 'PERMISSION_DENIED' ? 403 : 503,
           headers: {
@@ -339,15 +460,16 @@ function registerGhostProtocol(partition: string, ghost: InstalledGhost): void {
       // (ghostKvEndpoint,已单测),这里只做 Response 包装。
       if (url.pathname === '/kv') {
         if (!ghostKvStore) return new Response(null, { status: 503 });
-        const out = await handleGhostKvRequest({
+        const out = await awaitForRequestOwner(handleGhostKvRequest({
           method: request.method,
           // 有界读取(readBoundedBodyText):content-length 预检 + 流式限额,
           // 不受信 body 永不全量进主进程内存——沙箱允许死,主机不能被 OOM。
-          readBodyText: () => readBoundedBodyText(request),
+          readBodyText: () =>
+            awaitForRequestOwner(readBoundedBodyText(request, requestAbort.signal)),
           store: ghostKvStore,
           ghostId,
           log,
-        });
+        }));
         return new Response(out.body ?? null, {
           status: out.status,
           headers: {
@@ -362,12 +484,15 @@ function registerGhostProtocol(partition: string, ghost: InstalledGhost): void {
       // 明文单向进保险库,无任何读回动作;分区专属通道天然只碰自己的账。
       if (url.pathname === '/secrets' || url.pathname.startsWith('/secrets/')) {
         if (!ghostSecretsHandler) return new Response(null, { status: 503 });
-        const out = await ghostSecretsHandler({
+        const out = await awaitForRequestOwner(ghostSecretsHandler({
           ghostId,
           method: request.method,
           pathname: url.pathname,
-          readBodyText: () => readBoundedBodyText(request),
-        });
+          readBodyText: () =>
+            awaitForRequestOwner(readBoundedBodyText(request, requestAbort.signal)),
+          signal: requestAbort.signal,
+          assertActive: assertRequestOwner,
+        }));
         return new Response(out.body ?? null, {
           status: out.status,
           headers: {
@@ -383,12 +508,15 @@ function registerGhostProtocol(partition: string, ghost: InstalledGhost): void {
       // 动作;分区专属通道天然只碰自己的账。
       if (url.pathname === '/oauth' || url.pathname.startsWith('/oauth/')) {
         if (!ghostOauthHandler) return new Response(null, { status: 503 });
-        const out = await ghostOauthHandler({
+        const out = await awaitForRequestOwner(ghostOauthHandler({
           ghostId,
           method: request.method,
           pathname: url.pathname,
-          readBodyText: () => readBoundedBodyText(request),
-        });
+          readBodyText: () =>
+            awaitForRequestOwner(readBoundedBodyText(request, requestAbort.signal)),
+          signal: requestAbort.signal,
+          assertActive: assertRequestOwner,
+        }));
         return new Response(out.body ?? null, {
           status: out.status,
           headers: {
@@ -404,12 +532,15 @@ function registerGhostProtocol(partition: string, ghost: InstalledGhost): void {
       // 与尾 4 位指纹;分区专属通道天然只碰自己的账。
       if (url.pathname === '/connections' || url.pathname.startsWith('/connections/')) {
         if (!ghostConnectionsHandler) return new Response(null, { status: 503 });
-        const out = await ghostConnectionsHandler({
+        const out = await awaitForRequestOwner(ghostConnectionsHandler({
           ghostId,
           method: request.method,
           pathname: url.pathname,
-          readBodyText: () => readBoundedBodyText(request),
-        });
+          readBodyText: () =>
+            awaitForRequestOwner(readBoundedBodyText(request, requestAbort.signal)),
+          signal: requestAbort.signal,
+          assertActive: assertRequestOwner,
+        }));
         return new Response(out.body ?? null, {
           status: out.status,
           headers: {
@@ -436,7 +567,7 @@ function registerGhostProtocol(partition: string, ghost: InstalledGhost): void {
       if (!installDir) return new Response(null, { status: 404 });
       const filePath = resolveGhostFilePath(installDir, url.pathname);
       if (!filePath) return new Response(null, { status: 403 });
-      const data = await fs.readFile(filePath);
+      const data = await awaitForRequestOwner(fs.readFile(filePath, { signal: requestAbort.signal }));
       const mime = ghostFileMime(filePath);
       return new Response(new Uint8Array(data), {
         status: 200,
@@ -447,10 +578,16 @@ function registerGhostProtocol(partition: string, ghost: InstalledGhost): void {
         },
       });
     } catch (err) {
+      if (requestAbort.signal.aborted || err instanceof GhostProtocolOwnerChangedError) {
+        return new Response(null, { status: 403 });
+      }
       const code = (err as NodeJS.ErrnoException)?.code;
       if (code === 'ENOENT' || code === 'EISDIR') return new Response(null, { status: 404 });
       log.error('cindy-ghost protocol error', { error: err instanceof Error ? err.message : String(err) });
       return new Response(null, { status: 500 });
+    } finally {
+      activeGhostProtocolRequests.delete(requestAbort);
+      releaseRequest();
     }
   });
   partitionRegistered.add(partition); // 全部挂载成功,才算注册完成
@@ -465,6 +602,7 @@ async function serveGhostMedia(
   ghostId: string,
   fileRef: string,
   rangeHeader: string | null,
+  signal: AbortSignal,
 ): Promise<Response> {
   const dotIdx = fileRef.lastIndexOf('.');
   if (dotIdx <= 0) return new Response(null, { status: 404 });
@@ -478,7 +616,7 @@ async function serveGhostMedia(
   }
   if (!(await ghostCanReadMedia(hash, ghostId))) return new Response(null, { status: 404 });
   try {
-    const data = await fs.readFile(resolved.absPath);
+    const data = await fs.readFile(resolved.absPath, { signal });
     // Range/206:面板 <video> 靠分片与 seek;图片无 Range 头走 200 不变。
     // 内容寻址:同地址内容永不变,面板画廊可长缓存。
     return buildRangedMediaResponse({
@@ -488,6 +626,7 @@ async function serveGhostMedia(
       cacheControl: 'public, max-age=31536000, immutable',
     });
   } catch (err) {
+    throwIfGhostProtocolAborted(signal);
     const code = (err as NodeJS.ErrnoException)?.code;
     if (code === 'ENOENT' || code === 'EISDIR') return new Response(null, { status: 404 });
     log.error('ghost media serve error', { error: err instanceof Error ? err.message : String(err) });
@@ -507,14 +646,79 @@ export function setGhostLibraryFileResolver(resolver: GhostLibraryFileResolver |
 }
 
 /**
+ * Response 返回后协议 handler 已结束，但 Node 流仍可能继续读 owner 私有文件。
+ * 单独登记这些流，账号边界直接 destroy；不把整个视频播放期算作 mutation，
+ * 否则正常长视频也会把切号无限拖住。
+ */
+function trackGhostProtocolStream(
+  stream: nodeFs.ReadStream,
+  signal: AbortSignal,
+): ReadableStream {
+  let settled = false;
+  let webController: ReadableStreamDefaultController<Uint8Array> | null = null;
+  const cleanup = (): void => {
+    if (settled) return;
+    settled = true;
+    signal.removeEventListener('abort', onAbort);
+    activeGhostProtocolStreams.delete(operation);
+  };
+  const stop = (error?: Error): void => {
+    if (settled) return;
+    stream.destroy();
+    if (error) webController?.error(error);
+    cleanup();
+  };
+  const operation: ActiveGhostProtocolStream = {
+    abort: () => stop(new GhostProtocolOwnerChangedError('ghost protocol stream aborted')),
+  };
+  const onAbort = (): void => operation.abort();
+  activeGhostProtocolStreams.add(operation);
+  const iterator = stream[Symbol.asyncIterator]();
+  const webStream = new ReadableStream<Uint8Array>(
+    {
+      start: (controller) => {
+        webController = controller;
+      },
+      pull: async (controller) => {
+        try {
+          const chunk = await iterator.next();
+          if (settled) return;
+          if (chunk.done) {
+            controller.close();
+            cleanup();
+            return;
+          }
+          controller.enqueue(new Uint8Array(chunk.value));
+        } catch (error) {
+          if (settled) return;
+          controller.error(error);
+          cleanup();
+        }
+      },
+      cancel: () => stop(),
+    },
+    { highWaterMark: 0 },
+  );
+  signal.addEventListener('abort', onAbort, { once: true });
+  if (signal.aborted) onAbort();
+  return webStream;
+}
+
+/**
  * library 只读投影:注入解析器校验路径与归属后**流式**回字节。Range 用
  * createReadStream(多 GB 视频不整文件读进内存,review:面板路由整文件
  * 物化);仅支持单段 bytes=a-b / bytes=a-(多段与非法头按不支持处理,回
  * 200 全量或 416)。与 /media 不同:library 文件内容可变,不缓存。
  */
-async function serveGhostLibraryFile(ghostId: string, relPath: string, rangeHeader: string | null): Promise<Response> {
+async function serveGhostLibraryFile(
+  ghostId: string,
+  relPath: string,
+  rangeHeader: string | null,
+  signal: AbortSignal,
+): Promise<Response> {
   if (!ghostLibraryFileResolver) return new Response(null, { status: 404 });
   const absPath = await ghostLibraryFileResolver(ghostId, relPath);
+  throwIfGhostProtocolAborted(signal);
   if (!absPath) return new Response(null, { status: 404 });
   const mimeType = mediaTypeForLibraryPath(relPath);
   const headers: Record<string, string> = {
@@ -524,6 +728,7 @@ async function serveGhostLibraryFile(ghostId: string, relPath: string, rangeHead
   };
   try {
     const st = await fs.stat(absPath);
+    throwIfGhostProtocolAborted(signal);
     if (!st.isFile()) return new Response(null, { status: 404 });
     const total = st.size;
     if (rangeHeader !== null && rangeHeader !== undefined && rangeHeader !== '') {
@@ -542,8 +747,8 @@ async function serveGhostLibraryFile(ghostId: string, relPath: string, rangeHead
           return new Response(null, { status: 416, headers: { 'Content-Range': `bytes */${total}` } });
         }
         end = Math.min(end, total - 1);
-        const stream = nodeFs.createReadStream(absPath, { start, end });
-        return new Response(Readable.toWeb(stream) as ReadableStream, {
+        const stream = nodeFs.createReadStream(absPath, { start, end, signal });
+        return new Response(trackGhostProtocolStream(stream, signal), {
           status: 206,
           headers: {
             ...headers,
@@ -553,15 +758,19 @@ async function serveGhostLibraryFile(ghostId: string, relPath: string, rangeHead
         });
       }
     }
-    const stream = nodeFs.createReadStream(absPath);
-    return new Response(Readable.toWeb(stream) as ReadableStream, {
+    const stream = nodeFs.createReadStream(absPath, { signal });
+    return new Response(trackGhostProtocolStream(stream, signal), {
       status: 200,
       headers: { ...headers, 'Content-Length': String(total) },
     });
   } catch (err) {
+    throwIfGhostProtocolAborted(signal);
     const code = (err as NodeJS.ErrnoException)?.code;
     if (code === 'ENOENT' || code === 'EISDIR') return new Response(null, { status: 404 });
-    log.error('ghost library serve error', { ghostId, error: err instanceof Error ? err.message : String(err) });
+    log.error('ghost library serve error', {
+      ghostId,
+      error: err instanceof Error ? err.message : String(err),
+    });
     return new Response(null, { status: 500 });
   }
 }
@@ -615,8 +824,10 @@ class ElectronSandboxHandle implements SandboxHandle {
   private destroyed = false;
 
   constructor(private readonly ghost: InstalledGhost) {
-    const partition = ghostPartition(ghost.manifest.id);
-    registerGhostProtocol(partition, ghost);
+    const owner = getActiveAppSession();
+    const partition = ownerScopedGhostPartition(ghost.manifest.id, owner);
+    if (!partition) throw new Error('ghost sandbox requires an active data owner');
+    registerGhostProtocol(partition, ghost, owner);
     this.win = new BrowserWindow({
       show: false,
       // 逻辑页是恒隐藏的离屏工作台;可见面板由独立 webview 嵌入布局。

--- a/apps/desktop/src/main/cindy-brain/runtime/ghostKvEndpoint.ts
+++ b/apps/desktop/src/main/cindy-brain/runtime/ghostKvEndpoint.ts
@@ -41,7 +41,17 @@ interface BoundedBodySource {
  *   ——恶意方最多让主进程持有 64KB+一个 chunk,不是整个 body。
  * 抛出的 TOO_LARGE 由 handleGhostKvRequest 折叠成 413。
  */
-export async function readBoundedBodyText(request: BoundedBodySource): Promise<string> {
+function throwBodyReadAbort(signal: AbortSignal): never {
+  throw signal.reason instanceof Error
+    ? signal.reason
+    : new Error('ghost protocol request body read aborted');
+}
+
+export async function readBoundedBodyText(
+  request: BoundedBodySource,
+  signal?: AbortSignal,
+): Promise<string> {
+  if (signal?.aborted) throwBodyReadAbort(signal);
   const declared = Number(request.headers.get('content-length') ?? Number.NaN);
   if (Number.isFinite(declared) && declared > GHOST_KV_MAX_BYTES) {
     throw new GhostKvError('TOO_LARGE', 'content-length 声明超限');
@@ -54,7 +64,34 @@ export async function readBoundedBodyText(request: BoundedBodySource): Promise<s
   let text = '';
   try {
     for (;;) {
-      const { done, value } = await reader.read();
+      const { done, value } = signal
+        ? await new Promise<{ done: boolean; value?: Uint8Array }>((resolve, reject) => {
+            const onAbort = (): void => {
+              signal.removeEventListener('abort', onAbort);
+              void reader.cancel().catch(() => {});
+              reject(
+                signal.reason instanceof Error
+                  ? signal.reason
+                  : new Error('ghost protocol request body read aborted'),
+              );
+            };
+            signal.addEventListener('abort', onAbort, { once: true });
+            if (signal.aborted) {
+              onAbort();
+              return;
+            }
+            void reader.read().then(
+              (chunk) => {
+                signal.removeEventListener('abort', onAbort);
+                resolve(chunk);
+              },
+              (error: unknown) => {
+                signal.removeEventListener('abort', onAbort);
+                reject(error);
+              },
+            );
+          })
+        : await reader.read();
       if (done) break;
       if (!value) continue;
       bytes += value.byteLength;
@@ -67,7 +104,9 @@ export async function readBoundedBodyText(request: BoundedBodySource): Promise<s
     return text;
   } finally {
     // 超限断流时取消余下的流(释放上游);正常读完 cancel 是 no-op。
-    await reader.cancel().catch(() => {});
+    const cancellation = reader.cancel().catch(() => {});
+    // owner 边界必须立即退出，不能再信任插件侧 cancel 回调会兑现 Promise。
+    if (!signal?.aborted) await cancellation;
   }
 }
 

--- a/apps/desktop/src/main/ghost-panel-window/__tests__/controller.test.ts
+++ b/apps/desktop/src/main/ghost-panel-window/__tests__/controller.test.ts
@@ -266,6 +266,47 @@ describe('prewarm / open / close (hide-reuse)', () => {
   });
 });
 
+describe('owner boundary', () => {
+  it('destroys the outgoing owner WebView and restores it only as a new window', () => {
+    const h = makeHarness(new Set(['same-ghost']));
+    h.controller.open('same-ghost');
+    const ownerAWindow = h.created[0].win;
+
+    h.controller.destroyForOwnerBoundary();
+
+    expect(ownerAWindow.destroy).toHaveBeenCalledOnce();
+    expect(h.entries()).toEqual({
+      'same-ghost': { detached: true, lastOpen: true },
+    });
+    expect(h.controller.getState()['same-ghost']?.open).toBe(false);
+
+    // 旧 renderer 排队中的 IPC 不能在边界 pending 期间复活窗口或改偏好。
+    h.controller.open('same-ghost');
+    h.controller.setDetached('same-ghost', false);
+    expect(h.created).toHaveLength(1);
+    expect(h.entries()).toEqual({
+      'same-ghost': { detached: true, lastOpen: true },
+    });
+
+    h.controller.restoreOpenWindowsForCurrentOwner();
+    expect(h.created).toHaveLength(2);
+    expect(h.created[1].win).not.toBe(ownerAWindow);
+  });
+
+  it('broadcasts the incoming owner empty state instead of retaining outgoing detached flags', () => {
+    const h = makeHarness(new Set(['same-ghost']));
+    h.controller.open('same-ghost');
+    h.controller.destroyForOwnerBoundary();
+
+    // settings-store 在 owner 提交后会切到 B 的独立 map；B 没有分离偏好。
+    h.setEntries({});
+    h.controller.restoreOpenWindowsForCurrentOwner();
+
+    expect(h.created).toHaveLength(1);
+    expect(h.broadcasts.at(-1)).toEqual({});
+  });
+});
+
 describe('renderer navigation lifecycle', () => {
   it('ignores same-document main-frame navigation such as hash routing', () => {
     const h = makeHarness(new Set(['a']));

--- a/apps/desktop/src/main/ghost-panel-window/__tests__/settings-store.test.ts
+++ b/apps/desktop/src/main/ghost-panel-window/__tests__/settings-store.test.ts
@@ -5,6 +5,11 @@ import os from 'node:os';
 import path from 'node:path';
 
 const tmpUserData = fs.mkdtempSync(path.join(os.tmpdir(), 'cindy-ghost-panel-window-settings-'));
+const activeOwner = vi.hoisted(() => ({
+  mode: 'cloud' as 'signed-out' | 'local' | 'cloud',
+  dataOwnerId: 'owner-a' as string | null,
+  generation: 1,
+}));
 
 vi.mock('electron', () => ({
   app: {
@@ -21,6 +26,10 @@ vi.mock('../../maker-host/logger-adapter.js', () => ({
   },
 }));
 
+vi.mock('../../appSessionState.js', () => ({
+  getActiveAppSession: () => ({ ...activeOwner }),
+}));
+
 import {
   normalizeGhostPanelWindowsSettings,
   patchGhostPanelWindowEntry,
@@ -31,6 +40,9 @@ import {
 const settingsFile = path.join(tmpUserData, 'ghost-panel-windows-settings.json');
 
 beforeEach(() => {
+  activeOwner.mode = 'cloud';
+  activeOwner.dataOwnerId = 'owner-a';
+  activeOwner.generation = 1;
   if (fs.existsSync(settingsFile)) fs.unlinkSync(settingsFile);
   resetGhostPanelWindowSettingsForStartup();
 });
@@ -77,6 +89,19 @@ describe('runtime state', () => {
       windows: { 'cindy-art': { detached: true, lastOpen: true } },
     });
     expect(fs.existsSync(settingsFile)).toBe(false);
+  });
+
+  it('同 ghostId 的不同 owner 使用各自的进程内分离状态', () => {
+    patchGhostPanelWindowEntry('cindy-art', { detached: true, lastOpen: true });
+
+    activeOwner.dataOwnerId = 'owner-b';
+    expect(readGhostPanelWindowsSettings()).toEqual({ windows: {} });
+    patchGhostPanelWindowEntry('cindy-art', { detached: false, lastOpen: false });
+
+    activeOwner.dataOwnerId = 'owner-a';
+    expect(readGhostPanelWindowsSettings()).toEqual({
+      windows: { 'cindy-art': { detached: true, lastOpen: true } },
+    });
   });
 
   it('startup 清空所有插件分离态并删除旧版本偏好文件', () => {

--- a/apps/desktop/src/main/ghost-panel-window/controller.ts
+++ b/apps/desktop/src/main/ghost-panel-window/controller.ts
@@ -74,6 +74,7 @@ interface WindowSlot {
 export class GhostPanelWindowsController {
   private readonly slots = new Map<string, WindowSlot>();
   private disposed = false;
+  private ownerBoundaryFrozen = false;
   private locale: SupportedLocale | null = null;
 
   constructor(private readonly deps: GhostPanelWindowsControllerDeps) {}
@@ -99,7 +100,7 @@ export class GhostPanelWindowsController {
    * 可在当前运行期提前为即将打开的插件面板准备 renderer。
    */
   prewarm(ghostId: string): void {
-    if (this.disposed) return;
+    if (this.disposed || this.ownerBoundaryFrozen) return;
     if (!this.deps.isGhostDetachable(ghostId)) return;
     this.ensureSlot(ghostId);
   }
@@ -121,7 +122,7 @@ export class GhostPanelWindowsController {
    * 资格不符则清条目防陈年状态复活。
    */
   open(ghostId: string): void {
-    if (this.disposed) return;
+    if (this.disposed || this.ownerBoundaryFrozen) return;
     if (!this.deps.isGhostDetachable(ghostId)) {
       this.deps.log.warn('ghost not detachable, pruning entry', { ghostId });
       const staleSlot = this.slots.get(ghostId);
@@ -166,6 +167,7 @@ export class GhostPanelWindowsController {
 
   /** 普通关窗只隐藏(保留 renderer,供下次瞬时恢复)。偏好保持 detached:true。 */
   close(ghostId: string): void {
+    if (this.disposed || this.ownerBoundaryFrozen) return;
     const slot = this.slots.get(ghostId);
     if (!slot) {
       // 窗口不存在,但仍需落盘 lastOpen=false
@@ -178,6 +180,7 @@ export class GhostPanelWindowsController {
 
   /** 写偏好;true 开窗,false 真正销毁窗口(= 回停靠)。 */
   setDetached(ghostId: string, next: boolean): GhostPanelWindowsState {
+    if (this.disposed || this.ownerBoundaryFrozen) return this.getState();
     if (next) {
       this.open(ghostId);
     } else {
@@ -249,6 +252,7 @@ export class GhostPanelWindowsController {
   // ── reconcile ──────────────────────────────────────────────────────
 
   reconcile(ghosts: InstalledGhost[]): void {
+    if (this.disposed || this.ownerBoundaryFrozen) return;
     const byId = new Map(ghosts.map((g) => [g.manifest.id, g]));
     const knownIds = new Set([
       ...Object.keys(this.deps.settings.read().windows),
@@ -293,6 +297,30 @@ export class GhostPanelWindowsController {
     this.slots.clear();
   }
 
+  /**
+   * 账号边界落定前销毁旧 owner 的独立 WebView。分离状态由 settings-store
+   * 按 owner 暂存；切换成功或失败都只会据对应 owner 状态创建全新 renderer。
+   */
+  destroyForOwnerBoundary(): void {
+    this.ownerBoundaryFrozen = true;
+    this.destroyAllWindows();
+    this.broadcast();
+  }
+
+  /** owner 已稳定后，用该 owner 自己的进程内状态创建全新的 WebView。 */
+  restoreOpenWindowsForCurrentOwner(): void {
+    if (this.disposed) return;
+    const wasFrozen = this.ownerBoundaryFrozen;
+    this.ownerBoundaryFrozen = false;
+    if (wasFrozen) {
+      for (const [ghostId, entry] of Object.entries(this.deps.settings.read().windows)) {
+        if (entry.detached && entry.lastOpen) this.open(ghostId);
+      }
+    }
+    // 新 owner 可能没有任何条目；也必须用空快照覆盖 renderer 留下的旧 owner 状态。
+    this.broadcast();
+  }
+
   /** 应用退出时永久停止并同步销毁所有缓存窗口。 */
   dispose(): void {
     if (this.disposed) return;
@@ -305,6 +333,7 @@ export class GhostPanelWindowsController {
   // ══════════════════════════════════════════════════════════════════════
 
   private ensureSlot(ghostId: string): WindowSlot | null {
+    if (this.disposed || this.ownerBoundaryFrozen) return null;
     const existing = this.slots.get(ghostId);
     if (existing && !existing.win.isDestroyed()) return existing;
 

--- a/apps/desktop/src/main/ghost-panel-window/settings-store.ts
+++ b/apps/desktop/src/main/ghost-panel-window/settings-store.ts
@@ -1,8 +1,9 @@
 /**
  * ghost-panel-window 进程内状态。
  *
- * 每个 ghostId 的 detached / lastOpen 只服务当前客户端进程，用于窗口状态机和隐藏复用；
- * 客户端重启后所有插件面板一律回到主窗口。启动时还会删除旧版本留下的分离偏好文件。
+ * 每个 owner + ghostId 的 detached / lastOpen 只服务当前客户端进程，用于窗口状态机
+ * 和隐藏复用；客户端重启后所有插件面板一律回到主窗口。启动时还会删除旧版本留下的
+ * 分离偏好文件。
  * 窗口尺寸与位置由独立的 window-state 文件管理，不受这里影响。
  */
 
@@ -11,6 +12,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 import { isValidGhostId } from '../../shared/ghost.js';
+import { getActiveAppSession } from '../appSessionState.js';
 import { desktopMakerLogger } from '../maker-host/logger-adapter.js';
 
 const log = desktopMakerLogger.child('ghost-panel-window-settings-store');
@@ -24,7 +26,16 @@ export interface GhostPanelWindowsSettings {
   windows: Record<string, GhostPanelWindowEntrySettings>;
 }
 
-let runtimeSettings: GhostPanelWindowsSettings = { windows: {} };
+const runtimeSettingsByOwner = new Map<string, GhostPanelWindowsSettings>();
+
+function activeOwnerKey(): string {
+  const owner = getActiveAppSession();
+  return `${owner.mode}:${owner.dataOwnerId ?? 'none'}`;
+}
+
+function currentRuntimeSettings(): GhostPanelWindowsSettings {
+  return runtimeSettingsByOwner.get(activeOwnerKey()) ?? { windows: {} };
+}
 
 function settingsFilePath(): string {
   return path.join(app.getPath('userData'), 'ghost-panel-windows-settings.json');
@@ -47,7 +58,7 @@ export function normalizeGhostPanelWindowsSettings(raw: unknown): GhostPanelWind
 }
 
 export function readGhostPanelWindowsSettings(): GhostPanelWindowsSettings {
-  return { windows: { ...runtimeSettings.windows } };
+  return { windows: { ...currentRuntimeSettings().windows } };
 }
 
 /** 单条 patch:writePatch 是浅合并,windows map 必须整体读改写。 */
@@ -55,23 +66,27 @@ export function patchGhostPanelWindowEntry(
   ghostId: string,
   patch: Partial<GhostPanelWindowEntrySettings>,
 ): void {
-  const current = runtimeSettings.windows;
+  const ownerKey = activeOwnerKey();
+  const current = currentRuntimeSettings().windows;
   const entry = current[ghostId] ?? { detached: false, lastOpen: false };
-  runtimeSettings = { windows: { ...current, [ghostId]: { ...entry, ...patch } } };
+  runtimeSettingsByOwner.set(ownerKey, {
+    windows: { ...current, [ghostId]: { ...entry, ...patch } },
+  });
 }
 
 /** 删条目(卸载清理):不存在时为 no-op。 */
 export function removeGhostPanelWindowEntry(ghostId: string): void {
-  const current = runtimeSettings.windows;
+  const ownerKey = activeOwnerKey();
+  const current = currentRuntimeSettings().windows;
   if (!(ghostId in current)) return;
   const next = { ...current };
   delete next[ghostId];
-  runtimeSettings = { windows: next };
+  runtimeSettingsByOwner.set(ownerKey, { windows: next });
 }
 
 /** 新进程重置全部插件面板的分离状态，并清理旧版本遗留的持久化偏好。 */
 export function resetGhostPanelWindowSettingsForStartup(): void {
-  runtimeSettings = { windows: {} };
+  runtimeSettingsByOwner.clear();
   const legacyFile = settingsFilePath();
   try {
     fs.rmSync(legacyFile, { force: true });

--- a/apps/desktop/src/main/webview-security.ts
+++ b/apps/desktop/src/main/webview-security.ts
@@ -34,6 +34,11 @@ import {
 } from '../shared/webviewPartition';
 import { GHOST_PARTITION_PREFIX } from '../shared/ghost';
 import {
+  getActiveAppSession,
+  isAppSessionBoundaryPending,
+  type AppSessionMode,
+} from './appSessionState.js';
+import {
   matchesElectronInput,
   type AppShortcutCombo,
   type AppShortcutId,
@@ -164,6 +169,34 @@ export function applyGhostWebviewHardening(
   webPreferences.webviewTag = false;
   webPreferences.plugins = false;
   delete webPreferences.preload;
+}
+
+type GhostWebviewAttachResolver = typeof resolveGhostWebviewAttach;
+
+/**
+ * 把 Renderer 的 ghost-only claim 换成 Main 已核准的 owner partition，并同步
+ * 应用插件 WebView 安全锁。返回 null 时调用方必须拒绝 attach。
+ */
+export function authorizeGhostWebviewAttach(
+  webPreferences: Record<string, unknown>,
+  params: Record<string, string>,
+  resolver: GhostWebviewAttachResolver = resolveGhostWebviewAttach,
+): { id: string; owner: { mode: AppSessionMode; dataOwnerId: string } } | null {
+  let resolved: ReturnType<GhostWebviewAttachResolver> = null;
+  try {
+    resolved = resolver(params.partition, params.src);
+  } catch {
+    // session/protocol 注册失败也必须 fail closed。
+  }
+  if (!resolved) return null;
+
+  // Electron 在触发 will-attach-webview 前已经把 params.partition 复制进
+  // webPreferences.partition，之后创建 guest 时读取的是后者。两边都必须由
+  // Main 的核准结果覆盖，否则只改 attribute dict 不会改变真实 session。
+  params.partition = resolved.partition;
+  webPreferences.partition = resolved.partition;
+  applyGhostWebviewHardening(webPreferences, params);
+  return { id: resolved.ghost.manifest.id, owner: resolved.owner };
 }
 
 /**
@@ -776,8 +809,20 @@ export function installBrowserGuestHandlers(
 }
 
 interface GhostGuestNavigationHandlers {
+  gesture?: typeof noteGhostUserGesture;
   preview: typeof handleGhostPreviewNavigation;
   external: typeof handleGhostExternalLinkNavigation;
+}
+
+interface GhostGuestOwnerIdentity {
+  mode: AppSessionMode;
+  dataOwnerId: string;
+}
+
+function isGhostGuestOwnerActive(owner: GhostGuestOwnerIdentity): boolean {
+  if (isAppSessionBoundaryPending()) return false;
+  const activeOwner = getActiveAppSession();
+  return activeOwner.mode === owner.mode && activeOwner.dataOwnerId === owner.dataOwnerId;
 }
 
 /**
@@ -789,13 +834,17 @@ export function installGhostGuestNavigationHandlers(
   hostContents: WebContents,
   guestContents: WebContents,
   ghostId: string,
+  isOwnerActive: () => boolean,
   handlers: GhostGuestNavigationHandlers = {
     preview: handleGhostPreviewNavigation,
     external: handleGhostExternalLinkNavigation,
   },
 ): void {
   guestContents.setWindowOpenHandler(() => ({ action: 'deny' }));
-  const noteGesture = () => noteGhostUserGesture(ghostId);
+  const noteGesture = () => {
+    if (!isOwnerActive()) return;
+    (handlers.gesture ?? noteGhostUserGesture)(ghostId);
+  };
   guestContents.on('before-mouse-event', (_event, mouse) => {
     if (mouse.type === 'mouseDown') noteGesture();
   });
@@ -803,13 +852,19 @@ export function installGhostGuestNavigationHandlers(
     if (input.type === 'keyDown') noteGesture();
   });
   guestContents.on('will-navigate', (event, url) => {
+    // owner commit 后、Renderer 卸载旧 guest 前仍可能收到导航事件。旧页
+    // 不能借新 owner 的同名插件声明或授权代开外链。
+    if (!isOwnerActive()) {
+      event.preventDefault();
+      return;
+    }
     const nav = classifyGhostPanelNavigation(url, ghostId);
     if (nav === 'allow') return;
     event.preventDefault();
     if (nav === 'preview') {
-      handlers.preview(ghostId, url, hostContents, guestContents);
+      handlers.preview(ghostId, url, hostContents, guestContents, isOwnerActive);
     } else if (nav === 'external') {
-      handlers.external(ghostId, url, hostContents, guestContents);
+      handlers.external(ghostId, url, hostContents, guestContents, isOwnerActive);
     }
   });
 }
@@ -819,7 +874,7 @@ export function installWebviewHardener(): void {
     // will-attach → did-attach 对同一个 guest 同步成对触发;用闭包变量把
     // will 阶段的意识/captcha 判定带给 did 阶段(这两类 guest 走独立接线,
     // 不装浏览器的 popup 路由与快捷键转发)。
-    let pendingGhostAttach: { id: string } | null = null;
+    let pendingGhostAttach: ReturnType<typeof authorizeGhostWebviewAttach> = null;
     let pendingCaptchaAttach = false;
     contents.on('will-attach-webview', (e, webPreferences, params) => {
       pendingCaptchaAttach = false;
@@ -827,14 +882,16 @@ export function installWebviewHardener(): void {
       // 分区/地址/已装清单三对齐才放行并保留专属分区;验证失败直接拒附加
       // (绝不回落到浏览器分区,那会让 cindy-ghost:// 内容跑进错误 session)。
       if (typeof params.partition === 'string' && params.partition.startsWith(GHOST_PARTITION_PREFIX)) {
-        const ghost = resolveGhostWebviewAttach(params.partition, params.src);
-        if (!ghost) {
+        const authorized = authorizeGhostWebviewAttach(
+          webPreferences as unknown as Record<string, unknown>,
+          params,
+        );
+        if (!authorized) {
           e.preventDefault();
           pendingGhostAttach = null;
           return;
         }
-        applyGhostWebviewHardening(webPreferences as unknown as Record<string, unknown>, params);
-        pendingGhostAttach = { id: ghost.manifest.id };
+        pendingGhostAttach = authorized;
         return;
       }
       pendingGhostAttach = null;
@@ -879,7 +936,8 @@ export function installWebviewHardener(): void {
         return;
       }
       if (pendingGhostAttach) {
-        const ghostId = pendingGhostAttach.id;
+        const authorized = pendingGhostAttach;
+        const ghostId = authorized.id;
         pendingGhostAttach = null;
         // 崩溃豁免登记(lifecycle 的全局 render-process-gone 守卫据此放行,
         // 面板错误接管态负责用户侧收尾)。
@@ -888,7 +946,12 @@ export function installWebviewHardener(): void {
         // 两个声明式例外(都是拦下导航、主机代办,面板侧依旧零桥):
         //   - /preview/ 预览链接 → 主窗口弹 lightbox(cindy-brain/previewGate.ts);
         //   - https 外链 → 外链闸(声明/授信直开,其余二次确认)转系统浏览器。
-        installGhostGuestNavigationHandlers(contents, guestContents, ghostId);
+        installGhostGuestNavigationHandlers(
+          contents,
+          guestContents,
+          ghostId,
+          () => isGhostGuestOwnerActive(authorized.owner),
+        );
         return;
       }
       installBrowserGuestHandlers(contents, guestContents);

--- a/apps/desktop/src/renderer/cindy-brain/GhostSettingsWebview.tsx
+++ b/apps/desktop/src/renderer/cindy-brain/GhostSettingsWebview.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { CircleAlert, LayoutGrid, MoonStar } from 'lucide-react';
 import type { WebviewTag } from 'electron';
 
+import { useAuth } from '@/contexts/AuthContext';
 import { cn } from '@/lib/utils';
 import { GHOST_SCHEME, ghostPartition, type InstalledGhost } from '../../shared/ghost';
 import {
@@ -159,14 +160,17 @@ function CrashedHint({
 function SettingsWebviewBody({
   ghost,
   appearance,
+  dataOwnerId,
 }: {
   ghost: InstalledGhost;
   appearance: 'settings' | 'plugin';
+  dataOwnerId: string | null;
 }): ReactNode {
   const [crashed, setCrashed] = useState(false);
   const [generation, setGeneration] = useState(0);
   const hostRef = useRef<HTMLDivElement | null>(null);
   const { manifest } = ghost;
+  const partitionClaim = ghostPartition(manifest.id);
   const settingsHtml = manifest.settingsHtml;
   const fixedHeight = manifest.settingsHeight;
   const buildSettingsThemeCss =
@@ -174,7 +178,7 @@ function SettingsWebviewBody({
   // 首帧贴的快照(仅 mount 时决定一次;版本/主题/DPR 现场比对,宽度等布局后
   // 由下方 layout effect 补验)。失配 = null,走透明占位 + 淡入的老路径。
   const [snapshot, setSnapshot] = useState<GhostSettingsSnapshot | null>(() => {
-    const snap = loadGhostSettingsSnapshot(manifest.id);
+    const snap = loadGhostSettingsSnapshot(dataOwnerId, manifest.id);
     if (!snap) return null;
     const ctx = {
       version: manifest.version,
@@ -187,9 +191,9 @@ function SettingsWebviewBody({
   // 版本——换版后界面可能全变,旧高度不可信;主题/DPR 不影响布局高,不卡)
   // → 占位高。前两级命中时首帧即终态,零跳变。固定高度声明时本状态不参与。
   const [autoHeight, setAutoHeight] = useState(() => {
-    const cached = lastMeasuredHeights.get(manifest.id);
+    const cached = lastMeasuredHeights.get(`${dataOwnerId ?? ''}:${manifest.id}`);
     if (cached !== undefined) return cached;
-    const snap = loadGhostSettingsSnapshot(manifest.id);
+    const snap = loadGhostSettingsSnapshot(dataOwnerId, manifest.id);
     return snap && snap.version === manifest.version ? snap.height : AUTO_HEIGHT_PLACEHOLDER;
   });
 
@@ -211,7 +215,7 @@ function SettingsWebviewBody({
     const host = hostRef.current;
     if (!host) return;
     const webview = document.createElement('webview') as WebviewTag;
-    webview.setAttribute('partition', ghostPartition(manifest.id));
+    webview.setAttribute('partition', partitionClaim);
     webview.setAttribute('src', `${GHOST_SCHEME}://${manifest.id}/${settingsHtml}`);
     // 先透明占位:guest 装载与主题注入完成前不露面(一次性淡入,非常驻动画)。
     // 有快照时快照图盖在上层,这段透明期用户看到的就是"成品画面"。
@@ -262,7 +266,7 @@ function SettingsWebviewBody({
             if (disposed) return;
             const rect = host.getBoundingClientRect();
             if (rect.width <= 0 || rect.height <= 0) return;
-            saveGhostSettingsSnapshot(manifest.id, {
+            saveGhostSettingsSnapshot(dataOwnerId, manifest.id, {
               dataUrl: image.toDataURL(),
               width: rect.width,
               height: rect.height,
@@ -314,7 +318,7 @@ function SettingsWebviewBody({
         .then((h: unknown) => {
           if (disposed || typeof h !== 'number' || !Number.isFinite(h)) return;
           const clamped = Math.max(AUTO_HEIGHT_MIN, Math.min(AUTO_HEIGHT_MAX, Math.ceil(h)));
-          lastMeasuredHeights.set(manifest.id, clamped);
+          lastMeasuredHeights.set(`${dataOwnerId ?? ''}:${manifest.id}`, clamped);
           setAutoHeight((cur) => (cur === clamped ? cur : clamped));
         })
         .catch(() => {})
@@ -404,6 +408,8 @@ function SettingsWebviewBody({
     manifest.resolvedLocale,
     settingsHtml,
     fixedHeight,
+    dataOwnerId,
+    partitionClaim,
   ]);
 
   if (crashed) {
@@ -455,6 +461,8 @@ export function GhostSettingsWebview({
   appearance?: 'settings' | 'plugin';
 }): ReactNode {
   const { t } = useTranslation();
+  const { mode, dataOwnerId } = useAuth();
+  const ownerKey = `${mode}:${dataOwnerId ?? ''}`;
   const { manifest } = ghost;
   if (!manifest.settingsHtml) return null;
   return (
@@ -478,7 +486,12 @@ export function GhostSettingsWebview({
         </p>
       </div>
       {ghost.enabled ? (
-        <SettingsWebviewBody ghost={ghost} appearance={appearance} />
+        <SettingsWebviewBody
+          key={ownerKey}
+          ghost={ghost}
+          appearance={appearance}
+          dataOwnerId={dataOwnerId}
+        />
       ) : (
         <AsleepHint appearance={appearance} />
       )}

--- a/apps/desktop/src/renderer/cindy-brain/__tests__/GhostSettingsWebview.test.tsx
+++ b/apps/desktop/src/renderer/cindy-brain/__tests__/GhostSettingsWebview.test.tsx
@@ -5,7 +5,12 @@
  */
 
 import { render, waitFor } from '@testing-library/react';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const authState = vi.hoisted(() => ({
+  mode: 'cloud' as 'signed-out' | 'local' | 'cloud',
+  dataOwnerId: 'owner-a' as string | null,
+}));
 
 import type { InstalledGhost } from '../../../shared/ghost';
 import { GhostSettingsWebview } from '../GhostSettingsWebview';
@@ -13,6 +18,15 @@ import { GhostSettingsWebview } from '../GhostSettingsWebview';
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key }),
 }));
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => authState,
+}));
+
+beforeEach(() => {
+  authState.mode = 'cloud';
+  authState.dataOwnerId = 'owner-a';
+});
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -42,7 +56,7 @@ function renderSettings(settingsHeight?: number) {
     enabled: true,
     dir: '/tmp/example',
     manifest: {
-      id: 'example.settings-layout',
+      id: 'example-settings-layout',
       name: 'Example',
       version: '1.0.0',
       settingsHtml: 'settings.html',
@@ -58,7 +72,7 @@ function renderSettings(settingsHeight?: number) {
   const host = view.container.querySelector<HTMLElement>('[data-ghost-webview]');
   if (!host) throw new Error('Expected settings webview host');
 
-  return { executeJavaScript, host };
+  return { executeJavaScript, ghost, host, view, webview };
 }
 
 describe('GhostSettingsWebview layout ownership', () => {
@@ -89,5 +103,16 @@ describe('GhostSettingsWebview layout ownership', () => {
     expect(responsiveScript).toContain('min-width:0!important');
     expect(responsiveScript).toContain('max-width:100%!important');
     expect(host.classList.contains('overflow-hidden')).toBe(true);
+  });
+
+  it('recreates settings WebView when owner changes for the same ghostId', () => {
+    const { ghost, view, webview: ownerAWebview } = renderSettings();
+
+    authState.dataOwnerId = 'owner-b';
+    view.rerender(<GhostSettingsWebview ghost={ghost} />);
+
+    const ownerBWebview = view.container.querySelector('webview');
+    expect(ownerBWebview).not.toBeNull();
+    expect(ownerBWebview).not.toBe(ownerAWebview);
   });
 });

--- a/apps/desktop/src/renderer/cindy-brain/__tests__/ghostSettingsSnapshot.test.ts
+++ b/apps/desktop/src/renderer/cindy-brain/__tests__/ghostSettingsSnapshot.test.ts
@@ -39,33 +39,50 @@ beforeEach(() => {
 describe('存取往返', () => {
   it('save 后 load 返回同一内容,且写进了 localStorage', () => {
     const snap = makeSnapshot();
-    saveGhostSettingsSnapshot('g1', snap);
+    saveGhostSettingsSnapshot('owner-a', 'g1', snap);
     __resetGhostSettingsSnapshotCacheForTest();
-    expect(loadGhostSettingsSnapshot('g1')).toEqual(snap);
-    expect(localStorage.getItem('ghostSettings.snapshot.g1')).toBeTruthy();
+    expect(loadGhostSettingsSnapshot('owner-a', 'g1')).toEqual(snap);
+    expect(localStorage.getItem('ghostSettings.snapshot.v2.owner-a:g1')).toBeTruthy();
   });
 
   it('不同意识 id 互不串台', () => {
-    saveGhostSettingsSnapshot('g1', makeSnapshot({ version: '1.0.0' }));
-    saveGhostSettingsSnapshot('g2', makeSnapshot({ version: '2.0.0' }));
-    expect(loadGhostSettingsSnapshot('g1')?.version).toBe('1.0.0');
-    expect(loadGhostSettingsSnapshot('g2')?.version).toBe('2.0.0');
+    saveGhostSettingsSnapshot('owner-a', 'g1', makeSnapshot({ version: '1.0.0' }));
+    saveGhostSettingsSnapshot('owner-a', 'g2', makeSnapshot({ version: '2.0.0' }));
+    expect(loadGhostSettingsSnapshot('owner-a', 'g1')?.version).toBe('1.0.0');
+    expect(loadGhostSettingsSnapshot('owner-a', 'g2')?.version).toBe('2.0.0');
+  });
+
+  it('不同 owner 的同 ghostId 互不读取，旧的无 owner 快照不自动认领', () => {
+    const ownerASnapshot = makeSnapshot({ version: 'owner-a-version' });
+    saveGhostSettingsSnapshot('owner-a', 'shared-ghost', ownerASnapshot);
+    localStorage.setItem(
+      'ghostSettings.snapshot.shared-ghost',
+      JSON.stringify(makeSnapshot({ version: 'legacy-unowned' })),
+    );
+
+    expect(loadGhostSettingsSnapshot('owner-a', 'shared-ghost')).toEqual(ownerASnapshot);
+    expect(loadGhostSettingsSnapshot('owner-b', 'shared-ghost')).toBeNull();
+
+    const ownerBSnapshot = makeSnapshot({ version: 'owner-b-version' });
+    saveGhostSettingsSnapshot('owner-b', 'shared-ghost', ownerBSnapshot);
+    expect(loadGhostSettingsSnapshot('owner-b', 'shared-ghost')).toEqual(ownerBSnapshot);
+    expect(loadGhostSettingsSnapshot('owner-a', 'shared-ghost')).toEqual(ownerASnapshot);
   });
 
   it('没有存量时返回 null', () => {
-    expect(loadGhostSettingsSnapshot('nope')).toBeNull();
+    expect(loadGhostSettingsSnapshot('owner-a', 'nope')).toBeNull();
   });
 });
 
 describe('容错', () => {
   it('localStorage 里是坏 JSON 时按没有处理', () => {
-    localStorage.setItem('ghostSettings.snapshot.g1', '{oops');
-    expect(loadGhostSettingsSnapshot('g1')).toBeNull();
+    localStorage.setItem('ghostSettings.snapshot.v2.owner-a:g1', '{oops');
+    expect(loadGhostSettingsSnapshot('owner-a', 'g1')).toBeNull();
   });
 
   it('形不对(缺字段 / 类型错 / 非图片 dataUrl)按没有处理', () => {
     localStorage.setItem(
-      'ghostSettings.snapshot.g1',
+      'ghostSettings.snapshot.v2.owner-a:g1',
       JSON.stringify({
         dataUrl: 'javascript:alert(1)',
         width: 1,
@@ -76,25 +93,25 @@ describe('容错', () => {
         capturedAt: Date.now(),
       }),
     );
-    expect(loadGhostSettingsSnapshot('g1')).toBeNull();
+    expect(loadGhostSettingsSnapshot('owner-a', 'g1')).toBeNull();
     __resetGhostSettingsSnapshotCacheForTest();
     localStorage.setItem(
-      'ghostSettings.snapshot.g1',
+      'ghostSettings.snapshot.v2.owner-a:g1',
       JSON.stringify({ ...makeSnapshot(), width: 'wide' }),
     );
-    expect(loadGhostSettingsSnapshot('g1')).toBeNull();
+    expect(loadGhostSettingsSnapshot('owner-a', 'g1')).toBeNull();
     __resetGhostSettingsSnapshotCacheForTest();
     // 老格式(缺 capturedAt)同样作废。
     const legacy: Partial<GhostSettingsSnapshot> = { ...makeSnapshot() };
     delete legacy.capturedAt;
-    localStorage.setItem('ghostSettings.snapshot.g1', JSON.stringify(legacy));
-    expect(loadGhostSettingsSnapshot('g1')).toBeNull();
+    localStorage.setItem('ghostSettings.snapshot.v2.owner-a:g1', JSON.stringify(legacy));
+    expect(loadGhostSettingsSnapshot('owner-a', 'g1')).toBeNull();
 
     __resetGhostSettingsSnapshotCacheForTest();
     const preLayoutRevision: Partial<GhostSettingsSnapshot> = { ...makeSnapshot() };
     delete preLayoutRevision.layoutRevision;
-    localStorage.setItem('ghostSettings.snapshot.g1', JSON.stringify(preLayoutRevision));
-    expect(loadGhostSettingsSnapshot('g1')).toBeNull();
+    localStorage.setItem('ghostSettings.snapshot.v2.owner-a:g1', JSON.stringify(preLayoutRevision));
+    expect(loadGhostSettingsSnapshot('owner-a', 'g1')).toBeNull();
   });
 
   it('localStorage 写失败(配额满)时静默降级为仅内存缓存', () => {
@@ -103,9 +120,9 @@ describe('容错', () => {
     });
     try {
       const snap = makeSnapshot();
-      expect(() => saveGhostSettingsSnapshot('g1', snap)).not.toThrow();
+      expect(() => saveGhostSettingsSnapshot('owner-a', 'g1', snap)).not.toThrow();
       // 本会话内存缓存仍可读。
-      expect(loadGhostSettingsSnapshot('g1')).toEqual(snap);
+      expect(loadGhostSettingsSnapshot('owner-a', 'g1')).toEqual(snap);
     } finally {
       spy.mockRestore();
     }
@@ -114,47 +131,57 @@ describe('容错', () => {
 
 describe('存储预算', () => {
   it('单条超大位图只存内存不落 localStorage,并清掉同 id 旧持久快照', () => {
-    saveGhostSettingsSnapshot('g1', makeSnapshot());
-    expect(localStorage.getItem('ghostSettings.snapshot.g1')).toBeTruthy();
+    saveGhostSettingsSnapshot('owner-a', 'g1', makeSnapshot());
+    expect(localStorage.getItem('ghostSettings.snapshot.v2.owner-a:g1')).toBeTruthy();
     const snap = makeSnapshot({ dataUrl: `data:image/png;base64,${'a'.repeat(500_000)}` });
-    saveGhostSettingsSnapshot('g1', snap);
-    expect(localStorage.getItem('ghostSettings.snapshot.g1')).toBeNull();
-    expect(loadGhostSettingsSnapshot('g1')).toEqual(snap);
+    saveGhostSettingsSnapshot('owner-a', 'g1', snap);
+    expect(localStorage.getItem('ghostSettings.snapshot.v2.owner-a:g1')).toBeNull();
+    expect(loadGhostSettingsSnapshot('owner-a', 'g1')).toEqual(snap);
   });
 
   it('总量超预算时按拍摄时间淘汰最旧的其它快照', () => {
     const big = (tag: string) => `data:image/png;base64,${tag.repeat(390_000)}`;
     // 5 条 ~390k 快照(总预算 2M):写第 6 条时应从最旧开始腾位。
     for (let i = 0; i < 5; i++) {
-      saveGhostSettingsSnapshot(`g${i}`, makeSnapshot({ dataUrl: big('a'), capturedAt: 1000 + i }));
+      saveGhostSettingsSnapshot('owner-a', `g${i}`, makeSnapshot({ dataUrl: big('a'), capturedAt: 1000 + i }));
     }
-    saveGhostSettingsSnapshot('gNew', makeSnapshot({ dataUrl: big('b'), capturedAt: 9999 }));
+    saveGhostSettingsSnapshot('owner-a', 'gNew', makeSnapshot({ dataUrl: big('b'), capturedAt: 9999 }));
     // 最新的必须在;最旧的 g0(至少)被淘汰;总量回到预算内。
-    expect(localStorage.getItem('ghostSettings.snapshot.gNew')).toBeTruthy();
-    expect(localStorage.getItem('ghostSettings.snapshot.g0')).toBeNull();
+    expect(localStorage.getItem('ghostSettings.snapshot.v2.owner-a:gNew')).toBeTruthy();
+    expect(localStorage.getItem('ghostSettings.snapshot.v2.owner-a:g0')).toBeNull();
     let total = 0;
     for (let i = 0; i < localStorage.length; i++) {
       const key = localStorage.key(i)!;
-      if (key.startsWith('ghostSettings.snapshot.')) total += localStorage.getItem(key)!.length;
+      if (key.startsWith('ghostSettings.snapshot.v2.owner-a:')) total += localStorage.getItem(key)!.length;
     }
     expect(total).toBeLessThanOrEqual(2_000_000);
   });
 
   it('TTL 过期的快照按没有处理并顺手清盘', () => {
     const stale = makeSnapshot({ capturedAt: Date.now() - 15 * 24 * 60 * 60 * 1000 });
-    localStorage.setItem('ghostSettings.snapshot.g1', JSON.stringify(stale));
-    expect(loadGhostSettingsSnapshot('g1')).toBeNull();
-    expect(localStorage.getItem('ghostSettings.snapshot.g1')).toBeNull();
+    localStorage.setItem('ghostSettings.snapshot.v2.owner-a:g1', JSON.stringify(stale));
+    expect(loadGhostSettingsSnapshot('owner-a', 'g1')).toBeNull();
+    expect(localStorage.getItem('ghostSettings.snapshot.v2.owner-a:g1')).toBeNull();
   });
 
   it('prune 按已装清单清孤儿(含内存缓存),在装的不动', () => {
-    saveGhostSettingsSnapshot('keep', makeSnapshot());
-    saveGhostSettingsSnapshot('orphan', makeSnapshot());
-    pruneGhostSettingsSnapshots(['keep', 'not-yet-snapshotted']);
-    expect(localStorage.getItem('ghostSettings.snapshot.keep')).toBeTruthy();
-    expect(localStorage.getItem('ghostSettings.snapshot.orphan')).toBeNull();
-    expect(loadGhostSettingsSnapshot('orphan')).toBeNull();
-    expect(loadGhostSettingsSnapshot('keep')).toBeTruthy();
+    saveGhostSettingsSnapshot('owner-a', 'keep', makeSnapshot());
+    saveGhostSettingsSnapshot('owner-a', 'orphan', makeSnapshot());
+    pruneGhostSettingsSnapshots('owner-a', ['keep', 'not-yet-snapshotted']);
+    expect(localStorage.getItem('ghostSettings.snapshot.v2.owner-a:keep')).toBeTruthy();
+    expect(localStorage.getItem('ghostSettings.snapshot.v2.owner-a:orphan')).toBeNull();
+    expect(loadGhostSettingsSnapshot('owner-a', 'orphan')).toBeNull();
+    expect(loadGhostSettingsSnapshot('owner-a', 'keep')).toBeTruthy();
+  });
+
+  it('prune 只清当前 owner，不触碰其他 owner 的同名快照', () => {
+    saveGhostSettingsSnapshot('owner-a', 'orphan', makeSnapshot({ version: 'a' }));
+    saveGhostSettingsSnapshot('owner-b', 'orphan', makeSnapshot({ version: 'b' }));
+
+    pruneGhostSettingsSnapshots('owner-a', []);
+
+    expect(loadGhostSettingsSnapshot('owner-a', 'orphan')).toBeNull();
+    expect(loadGhostSettingsSnapshot('owner-b', 'orphan')?.version).toBe('b');
   });
 });
 

--- a/apps/desktop/src/renderer/cindy-brain/ghostPanels.tsx
+++ b/apps/desktop/src/renderer/cindy-brain/ghostPanels.tsx
@@ -19,6 +19,7 @@ import { GhostChipPanelBody, GhostPanelError } from './ghostPanelBody';
 import { ghostInstallErrorKey } from './installErrorKey';
 import { pruneGhostSettingsSnapshots } from './ghostSettingsSnapshot';
 import { useGhostRuntimeState } from './runtimeStates';
+import { getDataOwnerGeneration } from '../contexts/dataOwnerGeneration';
 
 /**
  * 意识面板接入布局引擎。
@@ -173,7 +174,10 @@ export function syncGhostPanelRegistrations(ghosts: InstalledGhost[]): void {
   // 顺手清设置区快照缓存的孤儿(卸载的意识不该在 localStorage 留位图);
   // 本函数是"已装清单"的唯一同步点(启动 + ghosts:changed),挂这里最省。
   // 注意用全量清单(含沉睡)——沉睡只是不注册面板,快照仍然有效。
-  pruneGhostSettingsSnapshots(ghosts.map((g) => g.manifest.id));
+  pruneGhostSettingsSnapshots(
+    getDataOwnerGeneration().dataOwnerId,
+    ghosts.map((g) => g.manifest.id),
+  );
   // 气泡状态对齐(与快照 prune 不同:停用/失格的要强制还原,不只清卸载)——
   // 气泡是"面板不可见 + 唯一恢复入口",失格后必须回停靠,不留死角。
   reconcileGhostPanelBubbles(ghosts);

--- a/apps/desktop/src/renderer/cindy-brain/ghostSettingsSnapshot.ts
+++ b/apps/desktop/src/renderer/cindy-brain/ghostSettingsSnapshot.ts
@@ -42,7 +42,8 @@ export interface GhostSettingsSnapshotContext {
   dpr: number;
 }
 
-const STORAGE_PREFIX = 'ghostSettings.snapshot.';
+// v1 只有 ghostId，无法证明快照属于哪个 owner；保留但永不读取/迁移。
+const STORAGE_PREFIX = 'ghostSettings.snapshot.v2.';
 
 /** 宿主设置 guest 的布局契约版本;布局注入改变时递增以主动淘汰旧快照。 */
 export const GHOST_SETTINGS_LAYOUT_REVISION = 3;
@@ -86,27 +87,50 @@ function isValidSnapshot(value: unknown): value is GhostSettingsSnapshot {
   );
 }
 
-/** 静默删一条持久化快照(localStorage 不可用时忽略)。 */
-function removePersisted(ghostId: string): void {
+function snapshotKey(dataOwnerId: string, ghostId: string): string {
+  return `${encodeURIComponent(dataOwnerId)}:${ghostId}`;
+}
+
+function parseSnapshotKey(key: string): { dataOwnerId: string; ghostId: string } | null {
+  const separator = key.lastIndexOf(':');
+  if (separator <= 0 || separator === key.length - 1) return null;
   try {
-    localStorage.removeItem(STORAGE_PREFIX + ghostId);
+    const dataOwnerId = decodeURIComponent(key.slice(0, separator));
+    const ghostId = key.slice(separator + 1);
+    if (!dataOwnerId || !ghostId) return null;
+    return { dataOwnerId, ghostId };
+  } catch {
+    return null;
+  }
+}
+
+/** 静默删一条持久化快照(localStorage 不可用时忽略)。 */
+function removePersisted(dataOwnerId: string, ghostId: string): void {
+  const key = snapshotKey(dataOwnerId, ghostId);
+  try {
+    localStorage.removeItem(STORAGE_PREFIX + key);
   } catch {
     // ignore
   }
 }
 
 /** 读取某意识的存量快照(内存 → localStorage;损坏/缺失/过期返回 null)。 */
-export function loadGhostSettingsSnapshot(ghostId: string): GhostSettingsSnapshot | null {
-  const cached = memoryCache.get(ghostId);
+export function loadGhostSettingsSnapshot(
+  dataOwnerId: string | null,
+  ghostId: string,
+): GhostSettingsSnapshot | null {
+  if (!dataOwnerId) return null;
+  const key = snapshotKey(dataOwnerId, ghostId);
+  const cached = memoryCache.get(key);
   if (cached !== undefined) return cached;
   let snapshot: GhostSettingsSnapshot | null = null;
   try {
-    const raw = localStorage.getItem(STORAGE_PREFIX + ghostId);
+    const raw = localStorage.getItem(STORAGE_PREFIX + key);
     if (raw) {
       const parsed: unknown = JSON.parse(raw);
       if (isValidSnapshot(parsed)) {
         if (Date.now() - parsed.capturedAt > SNAPSHOT_TTL_MS) {
-          removePersisted(ghostId);
+          removePersisted(dataOwnerId, ghostId);
         } else {
           snapshot = parsed;
         }
@@ -115,12 +139,14 @@ export function loadGhostSettingsSnapshot(ghostId: string): GhostSettingsSnapsho
   } catch {
     // localStorage 不可用或 JSON 损坏:视同没有快照,走老的淡入路径。
   }
-  memoryCache.set(ghostId, snapshot);
+  memoryCache.set(key, snapshot);
   return snapshot;
 }
 
-/** 遍历所有持久化快照键,回调收到意识 id 与原始串(解析失败的键直接跳过)。 */
-function forEachPersisted(fn: (ghostId: string, raw: string) => void): void {
+/** 遍历所有新版持久快照键；旧的无 owner 快照不会进入回调。 */
+function forEachPersisted(
+  fn: (identity: { key: string; dataOwnerId: string; ghostId: string }, raw: string) => void,
+): void {
   try {
     const keys: string[] = [];
     for (let i = 0; i < localStorage.length; i++) {
@@ -129,7 +155,9 @@ function forEachPersisted(fn: (ghostId: string, raw: string) => void): void {
     }
     for (const key of keys) {
       const raw = localStorage.getItem(key);
-      if (raw !== null) fn(key.slice(STORAGE_PREFIX.length), raw);
+      const scopedKey = key.slice(STORAGE_PREFIX.length);
+      const identity = parseSnapshotKey(scopedKey);
+      if (raw !== null && identity) fn({ key: scopedKey, ...identity }, raw);
     }
   } catch {
     // localStorage 不可用:静默(持久化本就是 best-effort)。
@@ -140,19 +168,25 @@ function forEachPersisted(fn: (ghostId: string, raw: string) => void): void {
  * 存快照(内存必存;持久化 best-effort):单条超限只留内存;写入前按
  * capturedAt 淘汰最旧的其它快照直到总量回到预算内;写失败静默降级仅内存。
  */
-export function saveGhostSettingsSnapshot(ghostId: string, snapshot: GhostSettingsSnapshot): void {
-  memoryCache.set(ghostId, snapshot);
+export function saveGhostSettingsSnapshot(
+  dataOwnerId: string | null,
+  ghostId: string,
+  snapshot: GhostSettingsSnapshot,
+): void {
+  if (!dataOwnerId) return;
+  const key = snapshotKey(dataOwnerId, ghostId);
+  memoryCache.set(key, snapshot);
   if (snapshot.dataUrl.length > MAX_PERSIST_CHARS) {
     // 单条超限只留内存;同 id 更早的持久快照顺手清掉——它已确认过时,
     // 重启后贴一张旧画面不如诚实走淡入。
-    removePersisted(ghostId);
+    removePersisted(dataOwnerId, ghostId);
     return;
   }
   const serialized = JSON.stringify(snapshot);
   // 总量预算:收集其它快照的体积与拍摄时间,超预算从最旧开始腾位。
   const others: Array<{ id: string; size: number; capturedAt: number }> = [];
-  forEachPersisted((id, raw) => {
-    if (id === ghostId) return;
+  forEachPersisted((identity, raw) => {
+    if (identity.key === key) return;
     let capturedAt = 0;
     try {
       const parsed: unknown = JSON.parse(raw);
@@ -160,20 +194,21 @@ export function saveGhostSettingsSnapshot(ghostId: string, snapshot: GhostSettin
     } catch {
       // 坏数据当最旧(capturedAt 0),优先被淘汰。
     }
-    others.push({ id, size: raw.length, capturedAt });
+    others.push({ id: identity.key, size: raw.length, capturedAt });
   });
   let total = serialized.length + others.reduce((sum, o) => sum + o.size, 0);
   if (total > TOTAL_PERSIST_BUDGET_CHARS) {
     others.sort((a, b) => a.capturedAt - b.capturedAt);
     for (const victim of others) {
       if (total <= TOTAL_PERSIST_BUDGET_CHARS) break;
-      removePersisted(victim.id);
+      const identity = parseSnapshotKey(victim.id);
+      if (identity) removePersisted(identity.dataOwnerId, identity.ghostId);
       memoryCache.delete(victim.id);
       total -= victim.size;
     }
   }
   try {
-    localStorage.setItem(STORAGE_PREFIX + ghostId, serialized);
+    localStorage.setItem(STORAGE_PREFIX + key, serialized);
   } catch {
     // 配额满等写失败:内存缓存仍生效(本会话内复用),不影响功能。
   }
@@ -183,18 +218,28 @@ export function saveGhostSettingsSnapshot(ghostId: string, snapshot: GhostSettin
  * 按"当前已装意识清单"清理孤儿快照(卸载后的快照没有存在理由)。
  * 由意识清单同步点(启动 + ghosts:changed)顺手调用,幂等。
  */
-export function pruneGhostSettingsSnapshots(installedGhostIds: Iterable<string>): void {
+export function pruneGhostSettingsSnapshots(
+  dataOwnerId: string | null,
+  installedGhostIds: Iterable<string>,
+): void {
+  if (!dataOwnerId) return;
   const keep = new Set(installedGhostIds);
   const orphanIds: string[] = [];
-  forEachPersisted((id) => {
-    if (!keep.has(id)) orphanIds.push(id);
+  forEachPersisted((identity) => {
+    if (identity.dataOwnerId === dataOwnerId && !keep.has(identity.ghostId)) {
+      orphanIds.push(identity.ghostId);
+    }
   });
   for (const id of orphanIds) {
-    removePersisted(id);
-    memoryCache.delete(id);
+    removePersisted(dataOwnerId, id);
+    const key = snapshotKey(dataOwnerId, id);
+    memoryCache.delete(key);
   }
-  for (const id of [...memoryCache.keys()]) {
-    if (!keep.has(id)) memoryCache.delete(id);
+  for (const key of [...memoryCache.keys()]) {
+    const identity = parseSnapshotKey(key);
+    if (identity?.dataOwnerId === dataOwnerId && !keep.has(identity.ghostId)) {
+      memoryCache.delete(key);
+    }
   }
 }
 

--- a/apps/desktop/src/shared/__tests__/ghost.test.ts
+++ b/apps/desktop/src/shared/__tests__/ghost.test.ts
@@ -139,7 +139,7 @@ describe('ghost · id 规则', () => {
     expect(bare.ok && ghostContentKeys(bare.manifest)).toEqual(['code', 'slotTool']);
   });
 
-  it('沙箱分区名:拼接与解析互逆,非意识分区/非法 id 解析为 null', () => {
+  it('沙箱分区 claim:拼接与解析互逆,非意识分区/非法 id 解析为 null', () => {
     expect(ghostPartition('art')).toBe('cindy-ghost-art');
     expect(parseGhostPartition('cindy-ghost-art')).toBe('art');
     expect(parseGhostPartition('persist:xdmaker-browser-app')).toBeNull();

--- a/apps/desktop/src/shared/ghost.ts
+++ b/apps/desktop/src/shared/ghost.ts
@@ -56,16 +56,17 @@ export const GHOST_SCHEME = 'cindy-ghost';
 
 /**
  * 意识沙箱的 session 分区前缀。无 `persist:` 前缀 = 纯内存分区,熄灯即蒸发。
- * 面板 webview 与离屏沙箱窗口共用同一分区规则(同一意识 = 同一间房)。
+ * Renderer 只用它声明待附加的意识 id；Main 验明当前 owner 后会覆盖成真正的
+ * owner-scoped partition，不能把这里的 claim 当成最终 Electron session 边界。
  */
 export const GHOST_PARTITION_PREFIX = 'cindy-ghost-';
 
-/** 某段意识的 session 分区名。 */
+/** Renderer 的意识 WebView attach claim；Main 放行前会覆盖成 owner 分区。 */
 export function ghostPartition(id: string): string {
   return `${GHOST_PARTITION_PREFIX}${id}`;
 }
 
-/** 从分区名解析意识 id;不是意识分区(或 id 非法)返回 null。 */
+/** 从 Renderer claim 解析意识 id；不是合法 claim 返回 null。 */
 export function parseGhostPartition(partition: unknown): string | null {
   if (typeof partition !== 'string' || !partition.startsWith(GHOST_PARTITION_PREFIX)) return null;
   const id = partition.slice(GHOST_PARTITION_PREFIX.length);


### PR DESCRIPTION
## 改动说明

- 由 Main 根据当前 owner、运行模式和 ghostId 派生插件 WebView 的非持久 partition；Renderer 只提交 ghostId claim，不能指定 owner 范围。
- 在 will-attach 时同时覆盖 params.partition 与 webPreferences.partition，并把裁决后的 owner 绑定到实际 guest，避免旧 owner 的 guest、导航和协议请求在新 owner 下继续获得权限。
- owner 切换时先冻结并销毁独立 panel，取消并排空在途协议请求、请求体、library 流、系统确认和外链确认，再按新 owner 恢复 panel、settings 与 main-view。
- settings 快照、高度缓存和主视图挂载键按 owner 隔离；同一 owner 的 generation 更新继续复用同一 partition。
- 增加 owner 切换、同 ghostId 不同 owner、attach 校验、协议在途取消及 panel/settings 生命周期测试。

## 范围与兼容性

- 影响范围：Desktop 插件 WebView 的 panel、settings、main-view，以及 Main attach/协议注册链路。
- 不修改插件 manifest、receipt、批准/启停状态、Secret、OAuth、KV、插件配置、作者 API 或持久化数据根。
- 存量插件影响：无。旧 ghostId-only partition 是非持久内存会话，不做 owner 归属迁移；升级后已安装、已批准、已启用的插件和既有凭证/偏好继续可用，不需要重装、重批或重配。
- 作者手册：无需同步。本次只调整宿主内部 partition 与权限裁决，不改变 manifest、pipe、端点或作者可见协议。
- 插件基座白名单确认：合并前仍需指定放行人在 PR 中明确 Approve。

## 用户可见变化

账号/数据 owner 切换后，插件一级视图会使用新 owner 的独立 WebView 会话，不再继承旧 owner 的 cookie、storage 或 session 状态。没有视觉、文案或布局变化。

### UI 变化

- 引用的设计规范：不涉及：本次没有修改视觉、交互文案或样式；只在 owner 变化时重建既有 WebView，继续复用 docs/design-rules/DESIGN.md 的语义 token 与 Light/Dark 主题注入路径。

## 验证

- pnpm test:unit:related：通过（788 个测试文件，14,302 项通过，2 项跳过）
- 13 个相关定向测试文件：通过（347 项）
- pnpm --filter desktop run --if-present typecheck：通过
- 新增文件及本次改动相关 ESLint：通过
- git diff --check：通过
- pnpm check:dco：通过

### 真实 Electron E2E

- macOS 26.4.1 / Electron 41.10.3 / 国内版 cn / shared passive：冷启动复用登录态通过，无需重新登录。
- settings WebView attach、cindy-ghost:// 静态资源、GET /app-context、同 owner 关闭重开、Light/Dark、存量批准/启停/setup-status：通过。
- E2E 未发现可归因于本 diff 的 FAIL；Tester 另跑 16 个相关测试文件，206/206 通过。
- 现场无 mainView 插件、合规 enabled+approved panel 和第二 owner，真实 main-view、独立 panel、跨 owner 隔离、切换时在途取消及失败回滚为 BLOCKED，不能视为完整 E2E 放行。
- 测试全程未读取或保存 Cookie、Token、Secret、OAuth、个人信息或 userData 路径；结束后开发实例正常退出，正式版仍在运行。

完整 changed-file ESLint 仍会报告 origin/main 已存在的 20 个问题，集中在 lifecycle、bootstrap、cindy-brain 与 panel controller 的旧代码行；本次新增或修改行未引入 lint 问题，因此没有顺手扩大范围修复。

## 未验证与风险

- 已在真实 Electron 中验证共享登录态冷启动、settings WebView 和同 owner 重挂载；因现场缺少 mainView、合规 panel 与第二 owner，仍未实测多个 WebView 交错 attach、完整账号切换及失败回滚。
- shared passive 模式可验证共享数据兼容性，但绕过完整生产 owner boundary，不能替代 primary 模式的跨 owner E2E。
- 未逐条为 OAuth、media/gallery/wake/media-models 等所有协议路由补 owner 切换在途用例；这些路径由共用入口和 owner boundary 栅栏保护。
- 未使用旧版本真实用户目录做升级端到端验证；本次不迁移持久数据。
- 未验证 Windows 实机；CI 的 WebView 相关检查通过，当前 Windows 失败来自未被本 PR 修改的 maker-pi-manager 1ms 时间边界测试。

## 回滚

回滚该提交即可恢复旧行为，不涉及数据 migration；但会重新引入不同 owner 共享 ghostId-only WebView partition 的安全问题。

## Reviewer

Orca Reviewer Worker 已对 git diff origin/main 和全部 untracked 文件完成对抗性审查，结论：无 P0/P1。