### PR TITLE
fix(shared): 裸 URL 不再把后面的中文标点吃进链接

### DIFF
--- a/apps/desktop/src/renderer/__tests__/remarkTruncateCjkUrls.test.ts
+++ b/apps/desktop/src/renderer/__tests__/remarkTruncateCjkUrls.test.ts
@@ -169,24 +169,31 @@ describe('remarkTruncateCjkUrls', () => {
     expect(para.children).toHaveLength(1);
   });
 
-  it('URL + 直接跟中文文字：https://example.com/path这是说明', () => {
+  it('混合 ASCII/CJK 路径保留：https://example.com/2024年报告', () => {
+    const tree = autolinkTree('https://example.com/2024年报告');
+    transform(tree);
+    const para = tree.children[0] as Paragraph;
+    const link = para.children[0] as Link;
+    expect(link.url).toBe('https://example.com/2024年报告');
+    expect(para.children).toHaveLength(1);
+  });
+
+  it('无标点的汉字跟在 ASCII 词后也保留（IRI，不按脚本猜测）', () => {
     const tree = autolinkTree('https://example.com/path这是说明');
     transform(tree);
     const para = tree.children[0] as Paragraph;
     const link = para.children[0] as Link;
-    const tail = para.children[1] as Text;
-    expect(link.url).toBe('https://example.com/path');
-    expect(tail.value).toBe('这是说明');
+    expect(link.url).toBe('https://example.com/path这是说明');
+    expect(para.children).toHaveLength(1);
   });
 
-  it('URL + 日文假名：https://example.com/fooこんにちは', () => {
+  it('URL + 日文假名路径保留：https://example.com/fooこんにちは', () => {
     const tree = autolinkTree('https://example.com/fooこんにちは');
     transform(tree);
     const para = tree.children[0] as Paragraph;
     const link = para.children[0] as Link;
-    const tail = para.children[1] as Text;
-    expect(link.url).toBe('https://example.com/foo');
-    expect(tail.value).toBe('こんにちは');
+    expect(link.url).toBe('https://example.com/fooこんにちは');
+    expect(para.children).toHaveLength(1);
   });
 
   it('URL + 全角感叹号：https://example.com/path！wow', () => {
@@ -215,15 +222,13 @@ describe('remarkTruncateCjkUrls', () => {
     expect(tail.value).toBe('**(完整');
   });
 
-  it('Markdown 装饰残留仍剥掉 trailing _ 和 ~', () => {
+  it('无标点的 _~ 加汉字视为路径，不按脚本切断', () => {
     const tree = autolinkTree('https://github.com/makecindy/cindy/pull/90_~说明');
     transform(tree);
     const para = tree.children[0] as Paragraph;
     const link = para.children[0] as Link;
-    const tail = para.children[1] as Text;
-    expect(link.url).toBe('https://github.com/makecindy/cindy/pull/90');
-    expect((link.children[0] as Text).value).toBe('https://github.com/makecindy/cindy/pull/90');
-    expect(tail.value).toBe('_~说明');
+    expect(link.url).toBe('https://github.com/makecindy/cindy/pull/90_~说明');
+    expect(para.children).toHaveLength(1);
   });
 
   it('ASCII prose 截断时保留 URL 尾部合法 markdown 字符', () => {
@@ -237,15 +242,13 @@ describe('remarkTruncateCjkUrls', () => {
     expect(tail.value).toBe('(draft');
   });
 
-  it('ASCII prose 截断先于 CJK boundary 时保留 URL 尾部合法 markdown 字符', () => {
+  it('配对括号内的汉字保留：https://example.com/Foo_(draft说明)', () => {
     const tree = autolinkTree('https://example.com/Foo_(draft说明)');
     transform(tree);
     const para = tree.children[0] as Paragraph;
     const link = para.children[0] as Link;
-    const tail = para.children[1] as Text;
-    expect(link.url).toBe('https://example.com/Foo_');
-    expect((link.children[0] as Text).value).toBe('https://example.com/Foo_');
-    expect(tail.value).toBe('(draft说明)');
+    expect(link.url).toBe('https://example.com/Foo_(draft说明)');
+    expect(para.children).toHaveLength(1);
   });
 
   it('ASCII prose 截断时保留 URL 尾部合法多字符 markdown 字符', () => {
@@ -259,24 +262,22 @@ describe('remarkTruncateCjkUrls', () => {
     expect(tail.value).toBe('(draft');
   });
 
-  it('URL 尾部半角句点 + 中文：https://x.com/foo.说明 → 剥掉 .', () => {
+  it('半角句点后的汉字保留在路径里：https://x.com/foo.说明', () => {
     const tree = autolinkTree('https://x.com/foo.说明');
     transform(tree);
     const para = tree.children[0] as Paragraph;
     const link = para.children[0] as Link;
-    const tail = para.children[1] as Text;
-    expect(link.url).toBe('https://x.com/foo');
-    expect(tail.value).toBe('.说明');
+    expect(link.url).toBe('https://x.com/foo.说明');
+    expect(para.children).toHaveLength(1);
   });
 
-  it('URL 尾部半角分号 + 中文：https://x.com/foo;说明 → 剥掉 ;', () => {
+  it('半角分号后的汉字保留在路径里：https://x.com/foo;说明', () => {
     const tree = autolinkTree('https://x.com/foo;说明');
     transform(tree);
     const para = tree.children[0] as Paragraph;
     const link = para.children[0] as Link;
-    const tail = para.children[1] as Text;
-    expect(link.url).toBe('https://x.com/foo');
-    expect(tail.value).toBe(';说明');
+    expect(link.url).toBe('https://x.com/foo;说明');
+    expect(para.children).toHaveLength(1);
   });
 
   it('未配对的 ) 被剥掉：https://x.com/foo)（说明）', () => {
@@ -660,15 +661,12 @@ describe('remarkTruncateCjkUrls', () => {
     expect(tail.value).toBe("'");
   });
 
-  it("有 opening apostrophe 且 URL 后接 CJK 时也剥掉包裹 apostrophe", () => {
+  it("opening apostrophe 后的 path'汉字 视为 IRI，不按脚本切断", () => {
     const tree = apostropheWrappedAutolinkTree("https://example.com/path'说明");
     transform(tree);
     const para = tree.children[0] as Paragraph;
     const link = para.children[1] as Link;
-    const tail = para.children[2] as Text;
-    expect(link.url).toBe('https://example.com/path');
-    expect((link.children[0] as Text).value).toBe('https://example.com/path');
-    expect(tail.value).toBe("'说明");
+    expect(link.url).toBe("https://example.com/path'说明");
   });
 
   it('纯 ASCII autolink 也剥掉尾部分号：https://x.com/foo; next', () => {

--- a/apps/desktop/src/renderer/__tests__/remarkTruncateCjkUrls.test.ts
+++ b/apps/desktop/src/renderer/__tests__/remarkTruncateCjkUrls.test.ts
@@ -160,6 +160,15 @@ describe('remarkTruncateCjkUrls', () => {
     expect(tail.value).toBe('（无 @）');
   });
 
+  it('URL 路径里的汉字保留：https://example.com/路径', () => {
+    const tree = autolinkTree('https://example.com/路径');
+    transform(tree);
+    const para = tree.children[0] as Paragraph;
+    const link = para.children[0] as Link;
+    expect(link.url).toBe('https://example.com/路径');
+    expect(para.children).toHaveLength(1);
+  });
+
   it('URL + 直接跟中文文字：https://example.com/path这是说明', () => {
     const tree = autolinkTree('https://example.com/path这是说明');
     transform(tree);

--- a/apps/desktop/src/renderer/__tests__/remarkTruncateCjkUrls.test.ts
+++ b/apps/desktop/src/renderer/__tests__/remarkTruncateCjkUrls.test.ts
@@ -160,6 +160,15 @@ describe('remarkTruncateCjkUrls', () => {
     expect(tail.value).toBe('（无 @）');
   });
 
+  it('authority 里的 IDN 点号保留：https://例子。测试/path', () => {
+    const tree = autolinkTree('https://例子。测试/path');
+    transform(tree);
+    const para = tree.children[0] as Paragraph;
+    const link = para.children[0] as Link;
+    expect(link.url).toBe('https://例子。测试/path');
+    expect(para.children).toHaveLength(1);
+  });
+
   it('URL 路径里的汉字保留：https://example.com/路径', () => {
     const tree = autolinkTree('https://example.com/路径');
     transform(tree);

--- a/apps/desktop/src/renderer/__tests__/remarkTruncateCjkUrls.test.ts
+++ b/apps/desktop/src/renderer/__tests__/remarkTruncateCjkUrls.test.ts
@@ -143,6 +143,23 @@ describe('remarkTruncateCjkUrls', () => {
     expect(tail.value).toBe('（说明）');
   });
 
+  it('issue comment fragment + 全角说明：…#issuecomment-1（无 @）', () => {
+    const tree = autolinkTree(
+      'https://github.com/example/app/issues/3561#issuecomment-5391602790（无 @）',
+    );
+    transform(tree);
+    const para = tree.children[0] as Paragraph;
+    const link = para.children[0] as Link;
+    const tail = para.children[1] as Text;
+    expect(link.url).toBe(
+      'https://github.com/example/app/issues/3561#issuecomment-5391602790',
+    );
+    expect((link.children[0] as Text).value).toBe(
+      'https://github.com/example/app/issues/3561#issuecomment-5391602790',
+    );
+    expect(tail.value).toBe('（无 @）');
+  });
+
   it('URL + 直接跟中文文字：https://example.com/path这是说明', () => {
     const tree = autolinkTree('https://example.com/path这是说明');
     transform(tree);

--- a/apps/desktop/src/renderer/__tests__/userMessageLinkify.test.ts
+++ b/apps/desktop/src/renderer/__tests__/userMessageLinkify.test.ts
@@ -83,15 +83,18 @@ describe('userMessageLinkify', () => {
     ]);
   });
 
-  it('stops URL matches before ASCII quotes and CJK text', () => {
+  it('stops URL matches before ASCII quotes and CJK punctuation', () => {
     expect(urls('看 "https://example.com/path"然后')).toEqual(['https://example.com/path']);
-    expect(urls('看 https://example.com/path这是说明')).toEqual(['https://example.com/path']);
+    expect(urls('看 https://example.com/path。然后')).toEqual(['https://example.com/path']);
   });
 
   it('keeps Unicode domain and path segments', () => {
     expect(urls('打开 https://example.com/路径 与 https://例子.测试/path')).toEqual([
       'https://example.com/路径',
       'https://例子.测试/path',
+    ]);
+    expect(urls('打开 https://www.例子.com/2024年报告')).toEqual([
+      'https://www.例子.com/2024年报告',
     ]);
   });
 

--- a/apps/desktop/src/renderer/__tests__/userMessageLinkify.test.ts
+++ b/apps/desktop/src/renderer/__tests__/userMessageLinkify.test.ts
@@ -96,6 +96,13 @@ describe('userMessageLinkify', () => {
     expect(urls('打开 https://www.例子.com/2024年报告')).toEqual([
       'https://www.例子.com/2024年报告',
     ]);
+    expect(urls('打开 https://example.com/ＡＢＣ 与 https://example.com/ｶﾀｶﾅ')).toEqual([
+      'https://example.com/ＡＢＣ',
+      'https://example.com/ｶﾀｶﾅ',
+    ]);
+    expect(urls('看 https://example.com/path\u00A0然后')).toEqual([
+      'https://example.com/path',
+    ]);
   });
 
   it('keeps apostrophes inside URL paths and at URL endings', () => {

--- a/apps/desktop/src/renderer/__tests__/userMessageLinkify.test.ts
+++ b/apps/desktop/src/renderer/__tests__/userMessageLinkify.test.ts
@@ -88,6 +88,13 @@ describe('userMessageLinkify', () => {
     expect(urls('看 https://example.com/path这是说明')).toEqual(['https://example.com/path']);
   });
 
+  it('keeps Unicode domain and path segments', () => {
+    expect(urls('打开 https://example.com/路径 与 https://例子.测试/path')).toEqual([
+      'https://example.com/路径',
+      'https://例子.测试/path',
+    ]);
+  });
+
   it('keeps apostrophes inside URL paths and at URL endings', () => {
     expect(urls("看 https://en.wikipedia.org/wiki/Guns_N'_Roses 然后")).toEqual([
       "https://en.wikipedia.org/wiki/Guns_N'_Roses",

--- a/apps/desktop/src/renderer/__tests__/userMessageLinkify.test.ts
+++ b/apps/desktop/src/renderer/__tests__/userMessageLinkify.test.ts
@@ -99,6 +99,9 @@ describe('userMessageLinkify', () => {
     expect(urls('打开 https://例子。测试/path')).toEqual([
       'https://例子。测试/path',
     ]);
+    expect(urls('看 http://localhost:3000。然后')).toEqual([
+      'http://localhost:3000',
+    ]);
     expect(urls('打开 https://example.com/ＡＢＣ 与 https://example.com/ｶﾀｶﾅ')).toEqual([
       'https://example.com/ＡＢＣ',
       'https://example.com/ｶﾀｶﾅ',

--- a/apps/desktop/src/renderer/__tests__/userMessageLinkify.test.ts
+++ b/apps/desktop/src/renderer/__tests__/userMessageLinkify.test.ts
@@ -96,6 +96,9 @@ describe('userMessageLinkify', () => {
     expect(urls('打开 https://www.例子.com/2024年报告')).toEqual([
       'https://www.例子.com/2024年报告',
     ]);
+    expect(urls('打开 https://例子。测试/path')).toEqual([
+      'https://例子。测试/path',
+    ]);
     expect(urls('打开 https://example.com/ＡＢＣ 与 https://example.com/ｶﾀｶﾅ')).toEqual([
       'https://example.com/ＡＢＣ',
       'https://example.com/ｶﾀｶﾅ',

--- a/apps/desktop/src/renderer/components/chat/remarkTruncateCjkUrls.ts
+++ b/apps/desktop/src/renderer/components/chat/remarkTruncateCjkUrls.ts
@@ -12,11 +12,8 @@
  * 在 ast 层后处理一刀：扫描 link 节点，url 命中 CJK / 全角范围就在那里切断，
  * 把切掉的尾巴作为 text 节点放回 link 后面，保持 visible text 与 href 一致。
  *
- * 切断后还要补一次 GFM 风格的「尾部标点剥离」：GFM autolink 在 URL 自然结束
- * （空白/EOF）时会剥掉末尾的 ?!.,:*_~ 等标点，但我们的切点在 CJK 处，原本
- * 粘在 CJK 前面的 ASCII 标点（典型如 `**https://x.com/pr/90**(中文)` 里的
- * `**(`）就会残留在 head 末尾，产生一个点开 404 的脏链接。所以切完再从尾部
- * 把这类标点、悬空的 `(`、未配对的 `)` 一并剥进 tail。
+ * 切边规则在 `@cindy/maker-shared/url-text-boundary`：本插件只负责认出
+ * GFM autolink literal、把尾巴拆回 text，并在 query 后补回被拆开的括号。
  *
  * 仅处理「children 只有一个 text 且 value === url」这种 autolink literal 形态；
  * 显式 `[text](url)` / `<https://...>` 因为 parser 自带闭合括号/尖括号边界，
@@ -28,45 +25,10 @@ import type { Root, Link, Text, PhrasingContent } from 'mdast';
 import { visit, SKIP } from 'unist-util-visit';
 
 import {
-  countUnmatchedOpeningParens,
-  cutBeforeClosingMarkdownWrap,
-  cutBeforePathBracketProse,
-  cutBeforeUnbalancedParenProse,
-  isCodeHostNumericResourcePath,
-  isMarkdownWrapOpenBoundary,
-  MARKDOWN_WRAP_MARKERS,
-  shrinkAutolinkTrailingJunk,
-} from '@/lib/urlTextBoundary';
+  clipBareHttpAutolink,
+  markdownWrapMarkerFromPrefix,
+} from '@cindy/maker-shared/url-text-boundary';
 import { findLinkifyMatches } from './userMessageLinkify';
-
-// Unicode / ASCII 区段，命中即视为 URL 结束边界：
-//   " `:       常见 prose 引号；裸 URL 里不应直接出现，应该 percent-encode
-//               Apostrophe 可以是合法 path 字符 (`Guns_N'_Roses`) 或 URL 尾字
-//               符，只在能看到对应 opening apostrophe 时按包裹引号剥离。
-//   2018-201F: 弯引号 / 类似的 general punctuation
-//   2026:      …
-//   3000-303F: CJK Symbols and Punctuation（、。「」『』【】〈〉《》 等）
-//   3040-30FF: Hiragana + Katakana
-//   3400-4DBF: CJK Extension A
-//   4E00-9FFF: CJK Unified Ideographs
-//   AC00-D7AF: Hangul Syllables
-//   FF00-FFEF: Halfwidth and Fullwidth Forms（（）！？．，；： 等）
-const AUTOLINK_TEXT_BOUNDARY = new RegExp(
-  '[' +
-    '"`' + // ASCII quotes except apostrophe
-    '\\u2018-\\u201F' + // smart quotes
-    '\\u2026' + // …
-    '\\u3000-\\u303F' + // CJK Symbols and Punctuation
-    '\\u3040-\\u30FF' + // Hiragana + Katakana
-    '\\u3400-\\u4DBF' + // CJK Extension A
-    '\\u4E00-\\u9FFF' + // CJK Unified Ideographs
-    '\\uAC00-\\uD7AF' + // Hangul Syllables
-    '\\uFF00-\\uFFEF' + // Halfwidth and Fullwidth Forms
-    ']',
-);
-
-const MARKDOWN_FORMATTING_STRIP_BOUNDARY =
-  /[\u3000-\u303F\u3040-\u30FF\u3400-\u4DBF\u4E00-\u9FFF\uAC00-\uD7AF\uFF00-\uFFEF]/;
 
 function hasSamePosition(a: Link, b: Text): boolean {
   return (
@@ -75,17 +37,6 @@ function hasSamePosition(a: Link, b: Text): boolean {
     b.position?.start.offset === a.position.start.offset &&
     b.position?.end.offset === a.position.end.offset
   );
-}
-
-function getMarkdownWrapMarkerBeforeAutolink(prevText: string | null): string | null {
-  if (!prevText) return null;
-  for (const marker of MARKDOWN_WRAP_MARKERS) {
-    if (!prevText.endsWith(marker)) continue;
-    return isMarkdownWrapOpenBoundary(prevText[prevText.length - marker.length - 1])
-      ? marker
-      : null;
-  }
-  return null;
 }
 
 function textFromPhrasingContent(node: PhrasingContent): string {
@@ -121,36 +72,13 @@ const remarkTruncateCjkUrls: Plugin<[], Root> = () => {
         parent.children as PhrasingContent[],
         index,
       );
-      const match = node.url.match(AUTOLINK_TEXT_BOUNDARY);
-      const boundaryIndex = match?.index;
-
       const prev = parent.children[index - 1];
       const prevText = prev?.type === 'text' ? (prev as Text).value : null;
       const prefixText = textBeforeAutolink(parent.children as PhrasingContent[], index);
-      const hasLeadingApostrophe =
-        prefixText.endsWith("'");
-      const marker = getMarkdownWrapMarkerBeforeAutolink(prevText);
-      const wrappingParenCount = countUnmatchedOpeningParens(prefixText);
-      const boundaryCut = boundaryIndex ?? node.url.length;
-      const markdownCut = cutBeforeClosingMarkdownWrap(node.url, marker);
-      const proseCut = Math.min(
-        boundaryCut,
-        cutBeforeUnbalancedParenProse(node.url, Math.min(boundaryCut, markdownCut), {
-          wrappingParenCount,
-        }),
-        cutBeforePathBracketProse(node.url),
-        markdownCut,
-      );
-      const shouldStripMarkdownFormattingPunct =
-        markdownCut < node.url.length ||
-        hasTrailingMultiCharMarkdownMarkerAfterCodeHostResource(node.url, proseCut) ||
-        (boundaryIndex != null &&
-          proseCut === boundaryCut &&
-          MARKDOWN_FORMATTING_STRIP_BOUNDARY.test(node.url[boundaryIndex]));
-      const cut = shrinkAutolinkTrailingJunk(node.url, proseCut, {
-        stripMarkdownFormattingPunct: shouldStripMarkdownFormattingPunct,
-        stripWrappingApostrophe: hasLeadingApostrophe,
-        stripWrappingParenCount: wrappingParenCount,
+      const cut = clipBareHttpAutolink(node.url, {
+        prefix: prefixText,
+        markdownWrapMarker: markdownWrapMarkerFromPrefix(prevText),
+        stripMarkdownFormattingPunct: 'auto',
       });
       if (cut === node.url.length) return;
       if (cut === 0) return;
@@ -169,15 +97,6 @@ const remarkTruncateCjkUrls: Plugin<[], Root> = () => {
 };
 
 export default remarkTruncateCjkUrls;
-
-function hasTrailingMultiCharMarkdownMarkerAfterCodeHostResource(raw: string, cut: number): boolean {
-  if (cut < 2) return false;
-  return ['**', '__', '~~'].some(
-    (marker) =>
-      raw.slice(cut - marker.length, cut) === marker &&
-      isCodeHostNumericResourcePath(raw.slice(0, cut - marker.length)),
-  );
-}
 
 function linkifyTailUrls(tail: string): PhrasingContent[] {
   const matches = findLinkifyMatches(tail).filter((match) => match.kind === 'url');

--- a/apps/desktop/src/renderer/components/chat/userMessageLinkify.ts
+++ b/apps/desktop/src/renderer/components/chat/userMessageLinkify.ts
@@ -1,12 +1,7 @@
 import {
-  cutBeforeUnbalancedParenProse,
-  cutBeforeClosingMarkdownWrap,
-  cutBeforePathBracketProse,
-  countUnmatchedOpeningParens,
-  isMarkdownWrapOpenBoundary,
-  MARKDOWN_WRAP_MARKERS,
-  shrinkAutolinkTrailingJunk,
-} from '@/lib/urlTextBoundary';
+  BARE_HTTP_URL_RE_SOURCE,
+  clipBareHttpAutolink,
+} from '@cindy/maker-shared/url-text-boundary';
 import {
   SESSION_DEEP_LINK_RE_SOURCE,
   PROJECT_DEEP_LINK_RE_SOURCE,
@@ -29,18 +24,9 @@ import { stripDeepLinkPathPrefix } from '../../../shared/deepLinkSchemes';
  * (png/jpg/jpeg/gif/webp/svg/bmp/ico) and the main-process xdt-file://
  * protocol's IMAGE_EXT_WHITELIST. Keep them in sync.
  */
-// The trailing range in the negation class spans U+0080..U+FFFF, so any
-// non-ASCII char (CJK text, full-width punctuation) terminates the URL —
-// URLs at this layer are ASCII-only, otherwise a Chinese comma right after
-// the URL gets gobbled into the link and breaks the click target.
-//
-// ASCII double quotes / angle brackets are prose boundaries. Apostrophes can be
-// valid path text (`Guns_N'_Roses`) and can also validly end a URL, so a trailing
-// apostrophe is only stripped when the URL is visibly wrapped by a leading
-// apostrophe. Parentheses and square/brace brackets are handled after matching so
-// URL-valid query / fragment punctuation survives while path-level prose is
-// returned to text.
-const URL_RE = /(https?:\/\/[^\s<>"\u0080-\uFFFF]+)/g;
+// 匹配源与切边都来自 maker-shared/url-text-boundary：ASCII-only 匹配，
+// 半角括号/包裹引号/尾部句读由 clipBareHttpAutolink 统一收口。
+const URL_RE = new RegExp(`(${BARE_HTTP_URL_RE_SOURCE})`, 'g');
 const IMG_PATH_RE =
   /([A-Za-z]:[\\/][^\s<>"']*?\.(?:png|jpe?g|gif|webp|svg|bmp|ico)|\/[^\s<>"']*?\.(?:png|jpe?g|gif|webp|svg|bmp|ico))/gi;
 // \u4F1A\u8BDD\u6DF1\u94FE cindy://session/<id>[?message=<clientId>](\u5386\u53F2 xdt-maker:// \u540C):ASCII \u767D\u540D\u5355,CJK /
@@ -82,36 +68,13 @@ export type LinkifyMatch =
   | ({ kind: 'session' } & DeepLinkMatchFields)
   | ({ kind: 'project' } & DeepLinkMatchFields);
 
-function getMarkdownWrapMarkerBeforeUrl(source: string, index: number): string | null {
-  for (const marker of MARKDOWN_WRAP_MARKERS) {
-    if (index < marker.length || source.slice(index - marker.length, index) !== marker) {
-      continue;
-    }
-    return isMarkdownWrapOpenBoundary(source[index - marker.length - 1])
-      ? marker
-      : null;
-  }
-  return null;
-}
-
 function pushUrlMatch(
   matches: LinkifyMatch[],
   source: string,
   index: number,
   raw: string,
 ): number | null {
-  const marker = getMarkdownWrapMarkerBeforeUrl(source, index);
-  const markdownCut = cutBeforeClosingMarkdownWrap(raw, marker);
-  const wrappingParenCount = countUnmatchedOpeningParens(source.slice(0, index));
-  const cut = Math.min(
-    cutBeforeUnbalancedParenProse(raw, markdownCut, { wrappingParenCount }),
-    cutBeforePathBracketProse(raw),
-    markdownCut,
-  );
-  const end = shrinkAutolinkTrailingJunk(raw, cut, {
-    stripWrappingApostrophe: source[index - 1] === "'",
-    stripWrappingParenCount: wrappingParenCount,
-  });
+  const end = clipBareHttpAutolink(raw, { prefix: source.slice(0, index) });
   if (end <= 0) return null;
   const text = raw.slice(0, end);
   matches.push({

--- a/apps/mobile/src/__tests__/messageMarkdown.test.ts
+++ b/apps/mobile/src/__tests__/messageMarkdown.test.ts
@@ -323,6 +323,15 @@ describe('messageMarkdown', () => {
       { type: 'link', text: 'https://例子。测试', url: 'https://例子。测试' },
       { type: 'text', text: '。这是说明' },
     ]);
+    expect(parseMobileMarkdownInlines('打开 https://例子。ファッション/path 看')).toEqual([
+      { type: 'text', text: '打开 ' },
+      {
+        type: 'link',
+        text: 'https://例子。ファッション/path',
+        url: 'https://例子。ファッション/path',
+      },
+      { type: 'text', text: ' 看' },
+    ]);
     expect(parseMobileMarkdownInlines('看 https://example.com。这是说明')).toEqual([
       { type: 'text', text: '看 ' },
       { type: 'link', text: 'https://example.com', url: 'https://example.com' },

--- a/apps/mobile/src/__tests__/messageMarkdown.test.ts
+++ b/apps/mobile/src/__tests__/messageMarkdown.test.ts
@@ -287,6 +287,12 @@ describe('messageMarkdown', () => {
       { type: 'link', text: 'https://example.com/path', url: 'https://example.com/path' },
       { type: 'text', text: ') 收尾' },
     ]);
+    expect(parseMobileMarkdownInlines('打开 https://example.com/路径 与 https://例子.测试/path')).toEqual([
+      { type: 'text', text: '打开 ' },
+      { type: 'link', text: 'https://example.com/路径', url: 'https://example.com/路径' },
+      { type: 'text', text: ' 与 ' },
+      { type: 'link', text: 'https://例子.测试/path', url: 'https://例子.测试/path' },
+    ]);
   });
 
   it('parses common inline formatting tokens', () => {

--- a/apps/mobile/src/__tests__/messageMarkdown.test.ts
+++ b/apps/mobile/src/__tests__/messageMarkdown.test.ts
@@ -295,6 +295,20 @@ describe('messageMarkdown', () => {
         url: 'https://example.com/~alice',
       },
     ]);
+    expect(parseMobileMarkdownInlines('打开 https://example.com/api/[id] 看')).toEqual([
+      { type: 'text', text: '打开 ' },
+      {
+        type: 'link',
+        text: 'https://example.com/api/[id]',
+        url: 'https://example.com/api/[id]',
+      },
+      { type: 'text', text: ' 看' },
+    ]);
+    expect(parseMobileMarkdownInlines('看 https://例子。测试。这是说明')).toEqual([
+      { type: 'text', text: '看 ' },
+      { type: 'link', text: 'https://例子。测试', url: 'https://例子。测试' },
+      { type: 'text', text: '。这是说明' },
+    ]);
     expect(parseMobileMarkdownInlines('看 https://例子。测试。')).toEqual([
       { type: 'text', text: '看 ' },
       { type: 'link', text: 'https://例子。测试', url: 'https://例子。测试' },

--- a/apps/mobile/src/__tests__/messageMarkdown.test.ts
+++ b/apps/mobile/src/__tests__/messageMarkdown.test.ts
@@ -287,6 +287,24 @@ describe('messageMarkdown', () => {
       { type: 'link', text: 'https://example.com/path', url: 'https://example.com/path' },
       { type: 'text', text: ') 收尾' },
     ]);
+    expect(parseMobileMarkdownInlines('~https://example.com/~alice')).toEqual([
+      { type: 'text', text: '~' },
+      {
+        type: 'link',
+        text: 'https://example.com/~alice',
+        url: 'https://example.com/~alice',
+      },
+    ]);
+    expect(parseMobileMarkdownInlines('看 https://例子。测试。')).toEqual([
+      { type: 'text', text: '看 ' },
+      { type: 'link', text: 'https://例子。测试', url: 'https://例子。测试' },
+      { type: 'text', text: '。' },
+    ]);
+    expect(parseMobileMarkdownInlines('看 https://example.com/path・说明')).toEqual([
+      { type: 'text', text: '看 ' },
+      { type: 'link', text: 'https://example.com/path', url: 'https://example.com/path' },
+      { type: 'text', text: '・说明' },
+    ]);
     expect(parseMobileMarkdownInlines('看 http://localhost:3000。然后')).toEqual([
       { type: 'text', text: '看 ' },
       { type: 'link', text: 'http://localhost:3000', url: 'http://localhost:3000' },

--- a/apps/mobile/src/__tests__/messageMarkdown.test.ts
+++ b/apps/mobile/src/__tests__/messageMarkdown.test.ts
@@ -309,10 +309,23 @@ describe('messageMarkdown', () => {
       { type: 'link', text: 'https://子域。例子。测试', url: 'https://子域。例子。测试' },
       { type: 'text', text: ' 看' },
     ]);
-    expect(parseMobileMarkdownInlines('看 https://例子。测试。这是说明')).toEqual([
-      { type: 'text', text: '看 ' },
-      { type: 'link', text: 'https://例子。测试', url: 'https://例子。测试' },
-      { type: 'text', text: '。这是说明' },
+    expect(parseMobileMarkdownInlines('打开 https://пример。онлайн/path 看')).toEqual([
+      { type: 'text', text: '打开 ' },
+      {
+        type: 'link',
+        text: 'https://пример。онлайн/path',
+        url: 'https://пример。онлайн/path',
+      },
+      { type: 'text', text: ' 看' },
+    ]);
+    expect(parseMobileMarkdownInlines('打开 https://子域。四字域名。测试 看')).toEqual([
+      { type: 'text', text: '打开 ' },
+      {
+        type: 'link',
+        text: 'https://子域。四字域名。测试',
+        url: 'https://子域。四字域名。测试',
+      },
+      { type: 'text', text: ' 看' },
     ]);
     expect(parseMobileMarkdownInlines('看 https://例子。测试。')).toEqual([
       { type: 'text', text: '看 ' },

--- a/apps/mobile/src/__tests__/messageMarkdown.test.ts
+++ b/apps/mobile/src/__tests__/messageMarkdown.test.ts
@@ -318,6 +318,16 @@ describe('messageMarkdown', () => {
       },
       { type: 'text', text: ' 看' },
     ]);
+    expect(parseMobileMarkdownInlines('看 https://例子。测试。这是说明')).toEqual([
+      { type: 'text', text: '看 ' },
+      { type: 'link', text: 'https://例子。测试', url: 'https://例子。测试' },
+      { type: 'text', text: '。这是说明' },
+    ]);
+    expect(parseMobileMarkdownInlines('看 https://example.com。这是说明')).toEqual([
+      { type: 'text', text: '看 ' },
+      { type: 'link', text: 'https://example.com', url: 'https://example.com' },
+      { type: 'text', text: '。这是说明' },
+    ]);
     expect(parseMobileMarkdownInlines('打开 https://子域。四字域名。测试 看')).toEqual([
       { type: 'text', text: '打开 ' },
       {

--- a/apps/mobile/src/__tests__/messageMarkdown.test.ts
+++ b/apps/mobile/src/__tests__/messageMarkdown.test.ts
@@ -251,6 +251,44 @@ describe('messageMarkdown', () => {
     ]);
   });
 
+  it('does not swallow fullwidth parentheses or CJK punctuation after a bare URL', () => {
+    expect(parseMobileMarkdownInlines(
+      '诊断已写在 https://github.com/example/app/issues/3561#issuecomment-5391602790（无 @）。',
+    )).toEqual([
+      { type: 'text', text: '诊断已写在 ' },
+      {
+        type: 'link',
+        text: 'https://github.com/example/app/issues/3561#issuecomment-5391602790',
+        url: 'https://github.com/example/app/issues/3561#issuecomment-5391602790',
+      },
+      { type: 'text', text: '（无 @）。' },
+    ]);
+    expect(parseMobileMarkdownInlines('看 https://example.com/path（说明）然后')).toEqual([
+      { type: 'text', text: '看 ' },
+      { type: 'link', text: 'https://example.com/path', url: 'https://example.com/path' },
+      { type: 'text', text: '（说明）然后' },
+    ]);
+    expect(parseMobileMarkdownInlines('看 https://example.com/path。然后')).toEqual([
+      { type: 'text', text: '看 ' },
+      { type: 'link', text: 'https://example.com/path', url: 'https://example.com/path' },
+      { type: 'text', text: '。然后' },
+    ]);
+    expect(parseMobileMarkdownInlines('见 https://en.wikipedia.org/wiki/Foo_(bar) 词条')).toEqual([
+      { type: 'text', text: '见 ' },
+      {
+        type: 'link',
+        text: 'https://en.wikipedia.org/wiki/Foo_(bar)',
+        url: 'https://en.wikipedia.org/wiki/Foo_(bar)',
+      },
+      { type: 'text', text: ' 词条' },
+    ]);
+    expect(parseMobileMarkdownInlines('见 (https://example.com/path) 收尾')).toEqual([
+      { type: 'text', text: '见 (' },
+      { type: 'link', text: 'https://example.com/path', url: 'https://example.com/path' },
+      { type: 'text', text: ') 收尾' },
+    ]);
+  });
+
   it('parses common inline formatting tokens', () => {
     expect(parseMobileMarkdownInlines(
       'Use **bold**, *em*, `code`, ~~gone~~, [docs](https://example.com/docs).',

--- a/apps/mobile/src/__tests__/messageMarkdown.test.ts
+++ b/apps/mobile/src/__tests__/messageMarkdown.test.ts
@@ -293,6 +293,17 @@ describe('messageMarkdown', () => {
       { type: 'text', text: ' 与 ' },
       { type: 'link', text: 'https://例子.测试/path', url: 'https://例子.测试/path' },
     ]);
+    expect(parseMobileMarkdownInlines('打开 https://example.com/ＡＢＣ 与 https://example.com/abc々def')).toEqual([
+      { type: 'text', text: '打开 ' },
+      { type: 'link', text: 'https://example.com/ＡＢＣ', url: 'https://example.com/ＡＢＣ' },
+      { type: 'text', text: ' 与 ' },
+      { type: 'link', text: 'https://example.com/abc々def', url: 'https://example.com/abc々def' },
+    ]);
+    expect(parseMobileMarkdownInlines('看 https://example.com/path\u00A0然后')).toEqual([
+      { type: 'text', text: '看 ' },
+      { type: 'link', text: 'https://example.com/path', url: 'https://example.com/path' },
+      { type: 'text', text: '\u00A0然后' },
+    ]);
   });
 
   it('parses common inline formatting tokens', () => {

--- a/apps/mobile/src/__tests__/messageMarkdown.test.ts
+++ b/apps/mobile/src/__tests__/messageMarkdown.test.ts
@@ -287,6 +287,11 @@ describe('messageMarkdown', () => {
       { type: 'link', text: 'https://example.com/path', url: 'https://example.com/path' },
       { type: 'text', text: ') 收尾' },
     ]);
+    expect(parseMobileMarkdownInlines('看 http://localhost:3000。然后')).toEqual([
+      { type: 'text', text: '看 ' },
+      { type: 'link', text: 'http://localhost:3000', url: 'http://localhost:3000' },
+      { type: 'text', text: '。然后' },
+    ]);
     expect(parseMobileMarkdownInlines('打开 https://例子。测试/path 看')).toEqual([
       { type: 'text', text: '打开 ' },
       { type: 'link', text: 'https://例子。测试/path', url: 'https://例子。测试/path' },

--- a/apps/mobile/src/__tests__/messageMarkdown.test.ts
+++ b/apps/mobile/src/__tests__/messageMarkdown.test.ts
@@ -304,6 +304,11 @@ describe('messageMarkdown', () => {
       },
       { type: 'text', text: ' 看' },
     ]);
+    expect(parseMobileMarkdownInlines('打开 https://子域。例子。测试 看')).toEqual([
+      { type: 'text', text: '打开 ' },
+      { type: 'link', text: 'https://子域。例子。测试', url: 'https://子域。例子。测试' },
+      { type: 'text', text: ' 看' },
+    ]);
     expect(parseMobileMarkdownInlines('看 https://例子。测试。这是说明')).toEqual([
       { type: 'text', text: '看 ' },
       { type: 'link', text: 'https://例子。测试', url: 'https://例子。测试' },

--- a/apps/mobile/src/__tests__/messageMarkdown.test.ts
+++ b/apps/mobile/src/__tests__/messageMarkdown.test.ts
@@ -287,6 +287,11 @@ describe('messageMarkdown', () => {
       { type: 'link', text: 'https://example.com/path', url: 'https://example.com/path' },
       { type: 'text', text: ') 收尾' },
     ]);
+    expect(parseMobileMarkdownInlines('打开 https://例子。测试/path 看')).toEqual([
+      { type: 'text', text: '打开 ' },
+      { type: 'link', text: 'https://例子。测试/path', url: 'https://例子。测试/path' },
+      { type: 'text', text: ' 看' },
+    ]);
     expect(parseMobileMarkdownInlines('打开 https://example.com/路径 与 https://例子.测试/path')).toEqual([
       { type: 'text', text: '打开 ' },
       { type: 'link', text: 'https://example.com/路径', url: 'https://example.com/路径' },

--- a/apps/mobile/src/session/messageMarkdown.ts
+++ b/apps/mobile/src/session/messageMarkdown.ts
@@ -902,6 +902,7 @@ function findNextInlineToken(
                 markdownWrapMarker: mobileMarkdownWrapMarker(
                   input.slice(0, match.index),
                 ),
+                cutPathBrackets: false,
               })
             : trimUrlPunctuation(rawHref);
           return { type: 'link' as const, text: href, url: href };

--- a/apps/mobile/src/session/messageMarkdown.ts
+++ b/apps/mobile/src/session/messageMarkdown.ts
@@ -1,5 +1,9 @@
 import { normalizeMathDelimiters } from '@cindy/maker-shared/math-markdown';
 import {
+  BARE_HTTP_URL_RE_SOURCE,
+  clipBareHttpAutolinkText,
+} from '@cindy/maker-shared/url-text-boundary';
+import {
   classifyChatPathLinkTarget,
   findBareFilePathMatch,
   resolveChatAbsPath,
@@ -868,8 +872,8 @@ function findNextInlineToken(
       type: 'emphasis' as const,
       text: match[2],
     }), 1),
-    // 裸链接:http(s) 通用形态 + 会话/项目深链(ASCII 白名单,CJK / 空白处
-    // 天然收尾;尾部粘连的英文句读由 trimUrlPunctuation 统一剥掉。project
+    // 裸链接:http(s) 走共享 BARE_HTTP_URL_RE_SOURCE + clipBareHttpAutolink
+    // （CJK/全角标点/包裹括号/尾部句读同一套）；会话/项目深链仍是。project
     // 白名单与桌面 PROJECT_DEEP_LINK_RE_SOURCE 同口径,含尾部负向前瞻
     // (白名单 ∪ `'(`):旧编码产出的链接可能含裸 `'` `(`,白名单在此截断
     // 会得到指错项目的前缀匹配——匹配终止处紧跟 `'` / `(` 时整段拒绝;
@@ -880,14 +884,16 @@ function findNextInlineToken(
         input,
         from,
         new RegExp(
-          `(?:https?://[^\\s<>()]+[^\\s<>().,;:!?]|(?:${DEEP_LINK_SCHEME_GROUP})://session/[A-Za-z0-9%~_-]+(?:\\?[A-Za-z0-9%&=~._-]*[A-Za-z0-9%~_-])?|(?:${DEEP_LINK_SCHEME_GROUP})://project/[A-Za-z0-9%~._!*-]+(?![A-Za-z0-9%~._!*('-]))`,
+          `(?:${BARE_HTTP_URL_RE_SOURCE}|(?:${DEEP_LINK_SCHEME_GROUP})://session/[A-Za-z0-9%~_-]+(?:\\?[A-Za-z0-9%&=~._-]*[A-Za-z0-9%~_-])?|(?:${DEEP_LINK_SCHEME_GROUP})://project/[A-Za-z0-9%~._!*-]+(?![A-Za-z0-9%~._!*('-]))`,
           'g',
         ),
-        (match) => ({
-          type: 'link' as const,
-          text: trimUrlPunctuation(match[0]),
-          url: trimUrlPunctuation(match[0]),
-        }),
+        (match) => {
+          const rawHref = match[0];
+          const href = /^https?:\/\//i.test(rawHref)
+            ? clipBareHttpAutolinkText(rawHref, { prefix: input.slice(0, match.index) })
+            : trimUrlPunctuation(rawHref);
+          return { type: 'link' as const, text: href, url: href };
+        },
       );
       // 剥掉的尾部句读要留在正文里:matchRegex 的 end 按未剥原文推进,而
       // project 白名单含 `.`(`!` 同理),`…%2Frepo.` 的句号会被吞掉不再

--- a/apps/mobile/src/session/messageMarkdown.ts
+++ b/apps/mobile/src/session/messageMarkdown.ts
@@ -2,6 +2,7 @@ import { normalizeMathDelimiters } from '@cindy/maker-shared/math-markdown';
 import {
   BARE_HTTP_URL_RE_SOURCE,
   clipBareHttpAutolinkText,
+  markdownWrapMarkerFromPrefix,
 } from '@cindy/maker-shared/url-text-boundary';
 import {
   classifyChatPathLinkTarget,
@@ -808,6 +809,12 @@ export function parseMobileMarkdownInlines(
   return out.length > 0 ? out : [{ type: 'text', text: input }];
 }
 
+/** Mobile 只把 `~~` 当删除线，单个 `~` 是普通字符，不能当 URL 包裹标记。 */
+function mobileMarkdownWrapMarker(prefix: string): string | null {
+  const marker = markdownWrapMarkerFromPrefix(prefix);
+  return marker === '~' ? null : marker;
+}
+
 function findNextInlineToken(
   input: string,
   from: number,
@@ -890,7 +897,12 @@ function findNextInlineToken(
         (match) => {
           const rawHref = match[0];
           const href = /^https?:\/\//i.test(rawHref)
-            ? clipBareHttpAutolinkText(rawHref, { prefix: input.slice(0, match.index) })
+            ? clipBareHttpAutolinkText(rawHref, {
+                prefix: input.slice(0, match.index),
+                markdownWrapMarker: mobileMarkdownWrapMarker(
+                  input.slice(0, match.index),
+                ),
+              })
             : trimUrlPunctuation(rawHref);
           return { type: 'link' as const, text: href, url: href };
         },

--- a/packages/maker-shared/package.json
+++ b/packages/maker-shared/package.json
@@ -68,6 +68,7 @@
     "./turn-continuation": "./src/turnContinuation.ts",
     "./tool-use-descriptor": "./src/toolUseDescriptor.ts",
     "./update-channel": "./src/updateChannel.ts",
+    "./url-text-boundary": "./src/urlTextBoundary.ts",
     "./usage-format": "./src/usageFormat.ts",
     "./work-activity-projection": "./src/workActivityProjection.ts",
     "./worktree-paths": "./src/worktreePaths.ts",

--- a/packages/maker-shared/src/__tests__/urlTextBoundary.test.ts
+++ b/packages/maker-shared/src/__tests__/urlTextBoundary.test.ts
@@ -100,6 +100,12 @@ describe('clipBareHttpAutolinkText', () => {
     expect(clipBareHttpAutolinkText('https://例子。测试。这是说明')).toBe(
       'https://例子。测试',
     );
+    expect(clipBareHttpAutolinkText('https://子域。例子。测试')).toBe(
+      'https://子域。例子。测试',
+    );
+    expect(clipBareHttpAutolinkText('https://www。例子。测试')).toBe(
+      'https://www。例子。测试',
+    );
     expect(clipBareHttpAutolinkText('https://example.com/path・说明')).toBe(
       'https://example.com/path',
     );

--- a/packages/maker-shared/src/__tests__/urlTextBoundary.test.ts
+++ b/packages/maker-shared/src/__tests__/urlTextBoundary.test.ts
@@ -44,10 +44,33 @@ describe('clipBareHttpAutolinkText', () => {
       'https://example.com/path',
     );
   });
+
+  it('keeps Unicode domain and path, but still cuts glued CJK prose', () => {
+    expect(clipBareHttpAutolinkText('https://example.com/路径')).toBe(
+      'https://example.com/路径',
+    );
+    expect(clipBareHttpAutolinkText('https://例子.测试/path')).toBe(
+      'https://例子.测试/path',
+    );
+    expect(clipBareHttpAutolinkText('https://example.com/中文')).toBe(
+      'https://example.com/中文',
+    );
+    expect(clipBareHttpAutolinkText('https://example.com/path这是说明')).toBe(
+      'https://example.com/path',
+    );
+    expect(clipBareHttpAutolinkText('https://x.com/foo.说明')).toBe(
+      'https://x.com/foo',
+    );
+    expect(
+      clipBareHttpAutolinkText('https://github.com/makecindy/cindy/pull/90_~说明', {
+        stripMarkdownFormattingPunct: 'auto',
+      }),
+    ).toBe('https://github.com/makecindy/cindy/pull/90');
+  });
 });
 
 describe('BARE_HTTP_URL_RE_SOURCE', () => {
-  it('stops the match before non-ASCII prose', () => {
+  it('stops the match before fullwidth / CJK punctuation, not before letters', () => {
     expect(
       matchBareHttp(
         '诊断已写在 https://github.com/example/app/issues/3561#issuecomment-5391602790（无 @）。',
@@ -55,6 +78,12 @@ describe('BARE_HTTP_URL_RE_SOURCE', () => {
     ).toBe('https://github.com/example/app/issues/3561#issuecomment-5391602790');
     expect(matchBareHttp('看 https://example.com/path。然后')).toBe(
       'https://example.com/path',
+    );
+    expect(matchBareHttp('打开 https://example.com/路径 看')).toBe(
+      'https://example.com/路径',
+    );
+    expect(matchBareHttp('打开 https://例子.测试/path 看')).toBe(
+      'https://例子.测试/path',
     );
   });
 

--- a/packages/maker-shared/src/__tests__/urlTextBoundary.test.ts
+++ b/packages/maker-shared/src/__tests__/urlTextBoundary.test.ts
@@ -97,14 +97,17 @@ describe('clipBareHttpAutolinkText', () => {
     expect(clipBareHttpAutolinkText('https://例子。测试。')).toBe(
       'https://例子。测试',
     );
-    expect(clipBareHttpAutolinkText('https://例子。测试。这是说明')).toBe(
-      'https://例子。测试',
-    );
     expect(clipBareHttpAutolinkText('https://子域。例子。测试')).toBe(
       'https://子域。例子。测试',
     );
     expect(clipBareHttpAutolinkText('https://www。例子。测试')).toBe(
       'https://www。例子。测试',
+    );
+    expect(clipBareHttpAutolinkText('https://пример。онлайн/path')).toBe(
+      'https://пример。онлайн/path',
+    );
+    expect(clipBareHttpAutolinkText('https://子域。四字域名。测试')).toBe(
+      'https://子域。四字域名。测试',
     );
     expect(clipBareHttpAutolinkText('https://example.com/path・说明')).toBe(
       'https://example.com/path',

--- a/packages/maker-shared/src/__tests__/urlTextBoundary.test.ts
+++ b/packages/maker-shared/src/__tests__/urlTextBoundary.test.ts
@@ -45,27 +45,25 @@ describe('clipBareHttpAutolinkText', () => {
     );
   });
 
-  it('keeps Unicode domain and path, but still cuts glued CJK prose', () => {
+  it('keeps mixed ASCII/CJK domains and paths that URL can parse', () => {
     expect(clipBareHttpAutolinkText('https://example.com/路径')).toBe(
       'https://example.com/路径',
     );
     expect(clipBareHttpAutolinkText('https://例子.测试/path')).toBe(
       'https://例子.测试/path',
     );
-    expect(clipBareHttpAutolinkText('https://example.com/中文')).toBe(
-      'https://example.com/中文',
+    expect(clipBareHttpAutolinkText('https://www.例子.com/path')).toBe(
+      'https://www.例子.com/path',
     );
-    expect(clipBareHttpAutolinkText('https://example.com/path这是说明')).toBe(
-      'https://example.com/path',
+    expect(clipBareHttpAutolinkText('https://example.com/2024年报告')).toBe(
+      'https://example.com/2024年报告',
     );
-    expect(clipBareHttpAutolinkText('https://x.com/foo.说明')).toBe(
-      'https://x.com/foo',
+    expect(clipBareHttpAutolinkText('https://example.com/abc中文')).toBe(
+      'https://example.com/abc中文',
     );
-    expect(
-      clipBareHttpAutolinkText('https://github.com/makecindy/cindy/pull/90_~说明', {
-        stripMarkdownFormattingPunct: 'auto',
-      }),
-    ).toBe('https://github.com/makecindy/cindy/pull/90');
+    expect(clipBareHttpAutolinkText('https://例子123.测试/path')).toBe(
+      'https://例子123.测试/path',
+    );
   });
 });
 

--- a/packages/maker-shared/src/__tests__/urlTextBoundary.test.ts
+++ b/packages/maker-shared/src/__tests__/urlTextBoundary.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import {
+  BARE_HTTP_URL_RE_SOURCE,
+  clipBareHttpAutolinkText,
+} from '../urlTextBoundary.js';
+
+function matchBareHttp(text: string): string | null {
+  const match = new RegExp(BARE_HTTP_URL_RE_SOURCE, 'g').exec(text);
+  return match?.[0] ?? null;
+}
+
+describe('clipBareHttpAutolinkText', () => {
+  it('strips fullwidth parentheses and CJK punctuation glued to a URL', () => {
+    expect(
+      clipBareHttpAutolinkText(
+        'https://github.com/example/app/issues/3561#issuecomment-5391602790（无 @）',
+      ),
+    ).toBe('https://github.com/example/app/issues/3561#issuecomment-5391602790');
+    expect(clipBareHttpAutolinkText('https://example.com/path（说明）')).toBe(
+      'https://example.com/path',
+    );
+    expect(clipBareHttpAutolinkText('https://example.com/path。')).toBe(
+      'https://example.com/path',
+    );
+  });
+
+  it('keeps balanced Wikipedia-style parentheses', () => {
+    expect(
+      clipBareHttpAutolinkText('https://en.wikipedia.org/wiki/Foo_(bar)'),
+    ).toBe('https://en.wikipedia.org/wiki/Foo_(bar)');
+  });
+
+  it('does not swallow a wrapping closer from surrounding prose', () => {
+    expect(
+      clipBareHttpAutolinkText('https://example.com/path)', { prefix: '见 (' }),
+    ).toBe('https://example.com/path');
+  });
+
+  it('strips trailing English sentence punctuation', () => {
+    expect(clipBareHttpAutolinkText('https://example.com/path,')).toBe(
+      'https://example.com/path',
+    );
+    expect(clipBareHttpAutolinkText('https://example.com/path.')).toBe(
+      'https://example.com/path',
+    );
+  });
+});
+
+describe('BARE_HTTP_URL_RE_SOURCE', () => {
+  it('stops the match before non-ASCII prose', () => {
+    expect(
+      matchBareHttp(
+        '诊断已写在 https://github.com/example/app/issues/3561#issuecomment-5391602790（无 @）。',
+      ),
+    ).toBe('https://github.com/example/app/issues/3561#issuecomment-5391602790');
+    expect(matchBareHttp('看 https://example.com/path。然后')).toBe(
+      'https://example.com/path',
+    );
+  });
+
+  it('includes balanced ASCII parentheses for later clip', () => {
+    expect(matchBareHttp('https://en.wikipedia.org/wiki/Foo_(bar) next')).toBe(
+      'https://en.wikipedia.org/wiki/Foo_(bar)',
+    );
+  });
+});

--- a/packages/maker-shared/src/__tests__/urlTextBoundary.test.ts
+++ b/packages/maker-shared/src/__tests__/urlTextBoundary.test.ts
@@ -109,6 +109,12 @@ describe('clipBareHttpAutolinkText', () => {
     expect(clipBareHttpAutolinkText('https://子域。四字域名。测试')).toBe(
       'https://子域。四字域名。测试',
     );
+    expect(clipBareHttpAutolinkText('https://例子。测试。这是说明')).toBe(
+      'https://例子。测试',
+    );
+    expect(clipBareHttpAutolinkText('https://example.com。这是说明')).toBe(
+      'https://example.com',
+    );
     expect(clipBareHttpAutolinkText('https://example.com/path・说明')).toBe(
       'https://example.com/path',
     );

--- a/packages/maker-shared/src/__tests__/urlTextBoundary.test.ts
+++ b/packages/maker-shared/src/__tests__/urlTextBoundary.test.ts
@@ -115,6 +115,9 @@ describe('clipBareHttpAutolinkText', () => {
     expect(clipBareHttpAutolinkText('https://example.com。这是说明')).toBe(
       'https://example.com',
     );
+    expect(clipBareHttpAutolinkText('https://例子。ファッション/path')).toBe(
+      'https://例子。ファッション/path',
+    );
     expect(clipBareHttpAutolinkText('https://example.com/path・说明')).toBe(
       'https://example.com/path',
     );

--- a/packages/maker-shared/src/__tests__/urlTextBoundary.test.ts
+++ b/packages/maker-shared/src/__tests__/urlTextBoundary.test.ts
@@ -73,6 +73,18 @@ describe('clipBareHttpAutolinkText', () => {
     expect(clipBareHttpAutolinkText('https://example.com/abc々def')).toBe(
       'https://example.com/abc々def',
     );
+    expect(clipBareHttpAutolinkText('https://例子。测试/path')).toBe(
+      'https://例子。测试/path',
+    );
+    expect(clipBareHttpAutolinkText('https://例子．测试/path')).toBe(
+      'https://例子．测试/path',
+    );
+    expect(clipBareHttpAutolinkText('https://例子｡测试/path')).toBe(
+      'https://例子｡测试/path',
+    );
+    expect(clipBareHttpAutolinkText('https://example.com/path。然后')).toBe(
+      'https://example.com/path',
+    );
   });
 });
 
@@ -83,8 +95,11 @@ describe('BARE_HTTP_URL_RE_SOURCE', () => {
         '诊断已写在 https://github.com/example/app/issues/3561#issuecomment-5391602790（无 @）。',
       ),
     ).toBe('https://github.com/example/app/issues/3561#issuecomment-5391602790');
+    expect(matchBareHttp('打开 https://例子。测试/path 看')).toBe(
+      'https://例子。测试/path',
+    );
     expect(matchBareHttp('看 https://example.com/path。然后')).toBe(
-      'https://example.com/path',
+      'https://example.com/path。然后',
     );
     expect(matchBareHttp('打开 https://example.com/路径 看')).toBe(
       'https://example.com/路径',

--- a/packages/maker-shared/src/__tests__/urlTextBoundary.test.ts
+++ b/packages/maker-shared/src/__tests__/urlTextBoundary.test.ts
@@ -64,6 +64,15 @@ describe('clipBareHttpAutolinkText', () => {
     expect(clipBareHttpAutolinkText('https://例子123.测试/path')).toBe(
       'https://例子123.测试/path',
     );
+    expect(clipBareHttpAutolinkText('https://example.com/ＡＢＣ')).toBe(
+      'https://example.com/ＡＢＣ',
+    );
+    expect(clipBareHttpAutolinkText('https://example.com/ｶﾀｶﾅ')).toBe(
+      'https://example.com/ｶﾀｶﾅ',
+    );
+    expect(clipBareHttpAutolinkText('https://example.com/abc々def')).toBe(
+      'https://example.com/abc々def',
+    );
   });
 });
 
@@ -82,6 +91,15 @@ describe('BARE_HTTP_URL_RE_SOURCE', () => {
     );
     expect(matchBareHttp('打开 https://例子.测试/path 看')).toBe(
       'https://例子.测试/path',
+    );
+    expect(matchBareHttp('打开 https://example.com/ＡＢＣ 看')).toBe(
+      'https://example.com/ＡＢＣ',
+    );
+    expect(matchBareHttp('看 https://example.com/path\u00A0然后')).toBe(
+      'https://example.com/path',
+    );
+    expect(matchBareHttp('看 https://example.com/path\u202F然后')).toBe(
+      'https://example.com/path',
     );
   });
 

--- a/packages/maker-shared/src/__tests__/urlTextBoundary.test.ts
+++ b/packages/maker-shared/src/__tests__/urlTextBoundary.test.ts
@@ -97,11 +97,20 @@ describe('clipBareHttpAutolinkText', () => {
     expect(clipBareHttpAutolinkText('https://例子。测试。')).toBe(
       'https://例子。测试',
     );
+    expect(clipBareHttpAutolinkText('https://例子。测试。这是说明')).toBe(
+      'https://例子。测试',
+    );
     expect(clipBareHttpAutolinkText('https://example.com/path・说明')).toBe(
       'https://example.com/path',
     );
     expect(clipBareHttpAutolinkText('https://example.com/path—说明')).toBe(
       'https://example.com/path',
+    );
+    expect(
+      clipBareHttpAutolinkText('https://example.com/api/[id]', { cutPathBrackets: false }),
+    ).toBe('https://example.com/api/[id]');
+    expect(clipBareHttpAutolinkText('https://example.com/api/[id]')).toBe(
+      'https://example.com/api/',
     );
   });
 });

--- a/packages/maker-shared/src/__tests__/urlTextBoundary.test.ts
+++ b/packages/maker-shared/src/__tests__/urlTextBoundary.test.ts
@@ -85,6 +85,15 @@ describe('clipBareHttpAutolinkText', () => {
     expect(clipBareHttpAutolinkText('https://example.com/path。然后')).toBe(
       'https://example.com/path',
     );
+    expect(clipBareHttpAutolinkText('http://localhost:3000。然后')).toBe(
+      'http://localhost:3000',
+    );
+    expect(clipBareHttpAutolinkText('https://[::1]:3000。然后')).toBe(
+      'https://[::1]:3000',
+    );
+    expect(clipBareHttpAutolinkText('https://例子。测试:443/path')).toBe(
+      'https://例子。测试:443/path',
+    );
   });
 });
 

--- a/packages/maker-shared/src/__tests__/urlTextBoundary.test.ts
+++ b/packages/maker-shared/src/__tests__/urlTextBoundary.test.ts
@@ -94,6 +94,15 @@ describe('clipBareHttpAutolinkText', () => {
     expect(clipBareHttpAutolinkText('https://例子。测试:443/path')).toBe(
       'https://例子。测试:443/path',
     );
+    expect(clipBareHttpAutolinkText('https://例子。测试。')).toBe(
+      'https://例子。测试',
+    );
+    expect(clipBareHttpAutolinkText('https://example.com/path・说明')).toBe(
+      'https://example.com/path',
+    );
+    expect(clipBareHttpAutolinkText('https://example.com/path—说明')).toBe(
+      'https://example.com/path',
+    );
   });
 });
 

--- a/packages/maker-shared/src/index.ts
+++ b/packages/maker-shared/src/index.ts
@@ -52,5 +52,6 @@ export * from './toolUseDescriptor.js';
 export * from './thinkingText.js';
 export * from './turnContinuation.js';
 export * from './updateChannel.js';
+export * from './urlTextBoundary.js';
 export * from './workActivityProjection.js';
 export * from './worktreePaths.js';

--- a/packages/maker-shared/src/urlTextBoundary.ts
+++ b/packages/maker-shared/src/urlTextBoundary.ts
@@ -361,8 +361,8 @@ function isAutolinkPunctuationBoundary(ch: string): boolean {
 }
 
 /** URL 标准会把这三者归一成 `.` 的域名分隔符。 */
-function isIdnDomainDot(ch: string): boolean {
-  const code = ch.codePointAt(0);
+function isIdnDomainDot(ch: string | undefined): boolean {
+  const code = ch?.codePointAt(0);
   return code === 0x3002 || code === 0xff0e || code === 0xff61;
 }
 
@@ -397,23 +397,46 @@ function isHostLabelChar(ch: string | undefined): boolean {
   return !isAutolinkPunctuationBoundary(ch);
 }
 
+function isCjkLetter(ch: string): boolean {
+  return /[\u3040-\u30FF\u3400-\u4DBF\u4E00-\u9FFF\uAC00-\uD7AF\uF900-\uFAFF]/u.test(ch);
+}
+
+function nextHostLabelEnd(raw: string, from: number, hostEnd: number): number {
+  let index = from;
+  while (index < hostEnd) {
+    const code = raw.codePointAt(index);
+    if (code == null) break;
+    const char = String.fromCodePoint(code);
+    if (isIdnDomainDot(char) || char === '.') break;
+    if (!isHostLabelChar(char)) break;
+    index += char.length;
+  }
+  return index;
+}
+
 function isIdnDotInHostname(
   raw: string,
   index: number,
   hostStart: number,
   hostEnd: number,
 ): boolean {
-  return (
-    index >= hostStart &&
-    index < hostEnd &&
-    isIdnDomainDot(raw[index] ?? '') &&
-    isHostLabelChar(raw[index + 1])
-  );
+  if (index < hostStart || index >= hostEnd) return false;
+  if (!isIdnDomainDot(raw[index] ?? '') || !isHostLabelChar(raw[index + 1])) return false;
+  const labelEnd = nextHostLabelEnd(raw, index + 1, hostEnd);
+  const chars = [...raw.slice(index + 1, labelEnd)];
+  if (chars.length === 0) return false;
+  // 俄文/拉丁等字母脚本是真 IDN 标签，不限长度。
+  if (chars.some((ch) => /^\p{L}$/u.test(ch) && !isCjkLetter(ch))) return true;
+  if (chars.some((ch) => /[A-Za-z0-9]/.test(ch))) return true;
+  // 纯汉字标签：后面还有域名分隔符说明主机还没完（`四字域名。测试`）；
+  // 否则只留 1–3 字的 TLD 形标签，避免 `。这是说明` 并进主机名。
+  const after = raw[labelEnd];
+  if (after === '.' || isIdnDomainDot(after)) return true;
+  return chars.length <= 3;
 }
 
 /**
- * 标点/全角符号是正文边界。hostname 里后面还跟标签的 IDN 点号一律留下
- * （`пример。онлайн`、`子域。四字域名。测试`）。句末单独的 `。` 仍切掉。
+ * 标点是正文边界。hostname 里真 IDN 点号留下；完整主机后的 `。这是说明` 切掉。
  */
 function findAutolinkProseBoundary(raw: string): number {
   const { start: hostStart, end: hostEnd } = hostnameRange(raw);

--- a/packages/maker-shared/src/urlTextBoundary.ts
+++ b/packages/maker-shared/src/urlTextBoundary.ts
@@ -362,38 +362,17 @@ function isAutolinkPunctuationBoundary(ch: string): boolean {
   return false;
 }
 
-function isUrlLetterScript(ch: string): boolean {
-  const code = ch.codePointAt(0);
-  if (code == null) return false;
-  if (code >= 0x3040 && code <= 0x30ff) return true;
-  if (code >= 0x3400 && code <= 0x4dbf) return true;
-  if (code >= 0x4e00 && code <= 0x9fff) return true;
-  if (code >= 0xac00 && code <= 0xd7af) return true;
-  return false;
-}
-
 /**
- * 标点/全角符号永远是正文边界。
- * 汉字假名谚文：跟在 URL 结构符后面算地址（`/路径`、`例子.测试`），
- * 紧贴 ASCII 字母数字则是粘上去的说明（`path这是说明`）。
+ * 只有标点/全角符号是正文边界。汉字假名谚文一律算地址，
+ * 不按「前一个字符是不是 ASCII」猜测（`www.例子.com`、`/2024年报告`
+ * 都是浏览器能打开的 IRI）。无标点的 `path这是说明` 无法和真路径区分，不猜。
  */
-function isAsciiTrailPunct(ch: string | undefined): boolean {
-  return ch != null && ".,;:?!_~'*" .includes(ch);
-}
-
-function isGluedCjkProse(raw: string, index: number): boolean {
-  let cursor = index - 1;
-  while (cursor >= 0 && isAsciiTrailPunct(raw[cursor])) cursor -= 1;
-  return cursor >= 0 && isAsciiAlnum(raw[cursor]);
-}
-
 function findAutolinkProseBoundary(raw: string): number {
   for (let index = 0; index < raw.length; ) {
     const code = raw.codePointAt(index);
     if (code == null) break;
     const char = String.fromCodePoint(code);
     if (isAutolinkPunctuationBoundary(char)) return index;
-    if (isUrlLetterScript(char) && isGluedCjkProse(raw, index)) return index;
     index += char.length;
   }
   return raw.length;

--- a/packages/maker-shared/src/urlTextBoundary.ts
+++ b/packages/maker-shared/src/urlTextBoundary.ts
@@ -375,7 +375,7 @@ function firstAuthDelimiterIndex(text: string, from = 0): number {
 }
 
 /** IDN 点号只在 hostname 内保留；端口和 IPv6 `]` 之后仍是正文边界。 */
-function hostnameEndIndex(raw: string): number {
+function hostnameRange(raw: string): { start: number; end: number } {
   const scheme = raw.match(/^https?:\/\//i);
   let start = scheme ? scheme[0].length : 0;
   const authEnd = firstAuthDelimiterIndex(raw, start);
@@ -383,12 +383,12 @@ function hostnameEndIndex(raw: string): number {
   if (at >= start) start = at + 1;
   if (raw[start] === '[') {
     const close = raw.indexOf(']', start + 1);
-    return close >= 0 && close < authEnd ? close + 1 : authEnd;
+    return { start, end: close >= 0 && close < authEnd ? close + 1 : authEnd };
   }
   for (let index = start; index < authEnd; index += 1) {
-    if (raw[index] === ':') return index;
+    if (raw[index] === ':') return { start, end: index };
   }
-  return authEnd;
+  return { start, end: authEnd };
 }
 
 function isHostLabelChar(ch: string | undefined): boolean {
@@ -397,27 +397,39 @@ function isHostLabelChar(ch: string | undefined): boolean {
   return !isAutolinkPunctuationBoundary(ch);
 }
 
-function isIdnDotInHostname(raw: string, index: number, hostnameEnd: number): boolean {
-  return (
-    index < hostnameEnd &&
-    isIdnDomainDot(raw[index] ?? '') &&
-    isHostLabelChar(raw[index + 1])
-  );
+function hasEarlierIdnDot(raw: string, hostStart: number, index: number): boolean {
+  for (let cursor = hostStart; cursor < index; cursor += 1) {
+    if (isIdnDomainDot(raw[cursor] ?? '')) return true;
+  }
+  return false;
+}
+
+function isIdnDotInHostname(
+  raw: string,
+  index: number,
+  hostStart: number,
+  hostEnd: number,
+): boolean {
+  if (index < hostStart || index >= hostEnd) return false;
+  if (!isIdnDomainDot(raw[index] ?? '') || !isHostLabelChar(raw[index + 1])) return false;
+  if (!hasEarlierIdnDot(raw, hostStart, index)) return true;
+  // 已经有过 IDN 点号后，再出现的 `。这是说明` 当句号；后面还有 path/port 才继续当域名。
+  return hostEnd < raw.length;
 }
 
 /**
- * 标点/全角符号是正文边界；hostname 里的 IDN 点号（`例子。测试`）留下。
- * 端口、IPv6 `]`、路径之后的 `。` 仍当句号切掉。
+ * 标点/全角符号是正文边界；hostname 里第一处 IDN 点号（`例子。测试`）留下。
+ * 端口、IPv6 `]`、路径、以及第二个句末 `。` 之后仍当句号切掉。
  */
 function findAutolinkProseBoundary(raw: string): number {
-  const hostnameEnd = hostnameEndIndex(raw);
+  const { start: hostStart, end: hostEnd } = hostnameRange(raw);
   for (let index = 0; index < raw.length; ) {
     const code = raw.codePointAt(index);
     if (code == null) break;
     const char = String.fromCodePoint(code);
     if (
       isAutolinkPunctuationBoundary(char) &&
-      !isIdnDotInHostname(raw, index, hostnameEnd)
+      !isIdnDotInHostname(raw, index, hostStart, hostEnd)
     ) {
       return index;
     }
@@ -441,6 +453,8 @@ export type ClipBareHttpAutolinkOptions = {
   prefix?: string | null;
   markdownWrapMarker?: string | null;
   stripMarkdownFormattingPunct?: boolean | 'auto';
+  /** Desktop GFM 会把 path 里的 `[]`/`{}` 当说明；Mobile 原匹配器会保留。 */
+  cutPathBrackets?: boolean;
 };
 
 /**
@@ -464,7 +478,7 @@ export function clipBareHttpAutolink(
   const proseCut = Math.min(
     limited,
     cutBeforeUnbalancedParenProse(raw, limited, { wrappingParenCount }),
-    cutBeforePathBracketProse(raw),
+    options.cutPathBrackets === false ? raw.length : cutBeforePathBracketProse(raw),
   );
   const stripMarkdown =
     options.stripMarkdownFormattingPunct === true ||

--- a/packages/maker-shared/src/urlTextBoundary.ts
+++ b/packages/maker-shared/src/urlTextBoundary.ts
@@ -343,11 +343,11 @@ export function shrinkAutolinkTrailingJunk(
 /**
  * 扫描器用的裸 http(s) 源。任意 Unicode 空白 / 尖括号 / 引号 / 省略号 /
  * 真正的 CJK·全角标点处结束。全角字母、半角片假名、々 等字母
- * 留在地址里；半角括号留给 `clipBareHttpAutolink` 按配对处理。
- * 标点范围与 `isAutolinkPunctuationBoundary` 的 P/Z 判定对齐，不是整块 Unicode block。
+ * 留在地址里；U+3002 / U+FF0E / U+FF61 是 IDN 点号，留给 clip 按
+ * authority 决定。半角括号留给 `clipBareHttpAutolink` 按配对处理。
  */
 export const BARE_HTTP_URL_RE_SOURCE =
-  String.raw`https?://[^\s<>"\u2018-\u201F\u2026\u3000-\u3003\u3008-\u3011\u3014-\u301F\u3030\u303D\uFF01-\uFF0F\uFF1A-\uFF20\uFF3B-\uFF40\uFF5B-\uFF65]+`;
+  String.raw`https?://[^\s<>"\u2018-\u201F\u2026\u3000-\u3001\u3003\u3008-\u3011\u3014-\u301F\u3030\u303D\uFF01-\uFF0D\uFF0F\uFF1A-\uFF20\uFF3B-\uFF40\uFF5B-\uFF60\uFF62-\uFF65]+`;
 
 const MARKDOWN_FORMATTING_STRIP_BOUNDARY =
   /[\u3000-\u303F\u3040-\u30FF\u3400-\u4DBF\u4E00-\u9FFF\uAC00-\uD7AF\uFF00-\uFFEF]/;
@@ -365,17 +365,38 @@ function isAutolinkPunctuationBoundary(ch: string): boolean {
   return /^\p{P}$/u.test(ch) || /^\p{Z}$/u.test(ch);
 }
 
+/** URL 标准会把这三者归一成 `.` 的域名分隔符。 */
+function isIdnDomainDot(ch: string): boolean {
+  const code = ch.codePointAt(0);
+  return code === 0x3002 || code === 0xff0e || code === 0xff61;
+}
+
+function authorityEndIndex(raw: string): number {
+  const scheme = raw.match(/^https?:\/\//i);
+  const start = scheme ? scheme[0].length : 0;
+  for (let index = start; index < raw.length; index += 1) {
+    const ch = raw[index];
+    if (ch === '/' || ch === '?' || ch === '#') return index;
+  }
+  return raw.length;
+}
+
 /**
- * 只有标点/全角符号是正文边界。汉字假名谚文一律算地址，
- * 不按「前一个字符是不是 ASCII」猜测（`www.例子.com`、`/2024年报告`
- * 都是浏览器能打开的 IRI）。无标点的 `path这是说明` 无法和真路径区分，不猜。
+ * 标点/全角符号是正文边界；authority 里的 IDN 点号（`例子。测试`）留下。
+ * 路径开始后的 `。` 仍当句号切掉。无标点的 `path这是说明` 不猜。
  */
 function findAutolinkProseBoundary(raw: string): number {
+  const authorityEnd = authorityEndIndex(raw);
   for (let index = 0; index < raw.length; ) {
     const code = raw.codePointAt(index);
     if (code == null) break;
     const char = String.fromCodePoint(code);
-    if (isAutolinkPunctuationBoundary(char)) return index;
+    if (
+      isAutolinkPunctuationBoundary(char) &&
+      !(index < authorityEnd && isIdnDomainDot(char))
+    ) {
+      return index;
+    }
     index += char.length;
   }
   return raw.length;

--- a/packages/maker-shared/src/urlTextBoundary.ts
+++ b/packages/maker-shared/src/urlTextBoundary.ts
@@ -341,29 +341,63 @@ export function shrinkAutolinkTrailingJunk(
 }
 
 /**
- * 扫描器用的裸 http(s) 源。空白 / 尖括号 / ASCII 引号 / 任何非 ASCII
- * （含全角括号与中文）处结束，避免匹配阶段就把说明吃进候选。
+ * 扫描器用的裸 http(s) 源。空白 / 尖括号 / ASCII 引号 / 弯引号 /
+ * CJK 与全角标点处结束。汉字、假名、谚文可以出现在域名和路径里；
  * 半角括号留给 `clipBareHttpAutolink` 按配对/包裹处理。
  */
 export const BARE_HTTP_URL_RE_SOURCE =
-  String.raw`https?://[^\s<>"\u0080-\uFFFF]+`;
-
-const AUTOLINK_PROSE_BOUNDARY = new RegExp(
-  '[' +
-    '"`' +
-    '\\u2018-\\u201F' +
-    '\\u2026' +
-    '\\u3000-\\u303F' +
-    '\\u3040-\\u30FF' +
-    '\\u3400-\\u4DBF' +
-    '\\u4E00-\\u9FFF' +
-    '\\uAC00-\\uD7AF' +
-    '\\uFF00-\\uFFEF' +
-    ']',
-);
+  'https?://[^ \t\r\n<>"\u2018-\u201F\u2026\u3000-\u303F\uFF00-\uFFEF]+';
 
 const MARKDOWN_FORMATTING_STRIP_BOUNDARY =
   /[\u3000-\u303F\u3040-\u30FF\u3400-\u4DBF\u4E00-\u9FFF\uAC00-\uD7AF\uFF00-\uFFEF]/;
+
+function isAutolinkPunctuationBoundary(ch: string): boolean {
+  const code = ch.codePointAt(0);
+  if (code == null) return false;
+  if (ch === '"' || ch === '`') return true;
+  if (code >= 0x2018 && code <= 0x201f) return true;
+  if (code === 0x2026) return true;
+  if (code >= 0x3000 && code <= 0x303f) return true;
+  if (code >= 0xff00 && code <= 0xffef) return true;
+  return false;
+}
+
+function isUrlLetterScript(ch: string): boolean {
+  const code = ch.codePointAt(0);
+  if (code == null) return false;
+  if (code >= 0x3040 && code <= 0x30ff) return true;
+  if (code >= 0x3400 && code <= 0x4dbf) return true;
+  if (code >= 0x4e00 && code <= 0x9fff) return true;
+  if (code >= 0xac00 && code <= 0xd7af) return true;
+  return false;
+}
+
+/**
+ * 标点/全角符号永远是正文边界。
+ * 汉字假名谚文：跟在 URL 结构符后面算地址（`/路径`、`例子.测试`），
+ * 紧贴 ASCII 字母数字则是粘上去的说明（`path这是说明`）。
+ */
+function isAsciiTrailPunct(ch: string | undefined): boolean {
+  return ch != null && ".,;:?!_~'*" .includes(ch);
+}
+
+function isGluedCjkProse(raw: string, index: number): boolean {
+  let cursor = index - 1;
+  while (cursor >= 0 && isAsciiTrailPunct(raw[cursor])) cursor -= 1;
+  return cursor >= 0 && isAsciiAlnum(raw[cursor]);
+}
+
+function findAutolinkProseBoundary(raw: string): number {
+  for (let index = 0; index < raw.length; ) {
+    const code = raw.codePointAt(index);
+    if (code == null) break;
+    const char = String.fromCodePoint(code);
+    if (isAutolinkPunctuationBoundary(char)) return index;
+    if (isUrlLetterScript(char) && isGluedCjkProse(raw, index)) return index;
+    index += char.length;
+  }
+  return raw.length;
+}
 
 export function markdownWrapMarkerFromPrefix(prefix: string | null | undefined): string | null {
   if (!prefix) return null;
@@ -396,8 +430,8 @@ export function clipBareHttpAutolink(
     options.markdownWrapMarker === undefined
       ? markdownWrapMarkerFromPrefix(prefix)
       : options.markdownWrapMarker;
-  const boundaryIndex = raw.search(AUTOLINK_PROSE_BOUNDARY);
-  const boundaryCut = boundaryIndex >= 0 ? boundaryIndex : raw.length;
+  const boundaryIndex = findAutolinkProseBoundary(raw);
+  const boundaryCut = boundaryIndex;
   const markdownCut = cutBeforeClosingMarkdownWrap(raw, marker);
   const limited = Math.min(boundaryCut, markdownCut);
   const proseCut = Math.min(
@@ -410,7 +444,7 @@ export function clipBareHttpAutolink(
     (options.stripMarkdownFormattingPunct === 'auto' &&
       (markdownCut < raw.length ||
         hasTrailingMultiCharMarkdownMarkerAfterCodeHostResource(raw, proseCut) ||
-        (boundaryIndex >= 0 &&
+        (boundaryIndex < raw.length &&
           proseCut === boundaryCut &&
           MARKDOWN_FORMATTING_STRIP_BOUNDARY.test(raw[boundaryIndex]))));
   return shrinkAutolinkTrailingJunk(raw, proseCut, {

--- a/packages/maker-shared/src/urlTextBoundary.ts
+++ b/packages/maker-shared/src/urlTextBoundary.ts
@@ -397,11 +397,25 @@ function isHostLabelChar(ch: string | undefined): boolean {
   return !isAutolinkPunctuationBoundary(ch);
 }
 
-function hasEarlierIdnDot(raw: string, hostStart: number, index: number): boolean {
-  for (let cursor = hostStart; cursor < index; cursor += 1) {
-    if (isIdnDomainDot(raw[cursor] ?? '')) return true;
+function nextHostLabelEnd(raw: string, from: number, hostEnd: number): number {
+  let index = from;
+  while (index < hostEnd) {
+    const code = raw.codePointAt(index);
+    if (code == null) break;
+    const char = String.fromCodePoint(code);
+    if (isIdnDomainDot(char) || char === '.') break;
+    if (!isHostLabelChar(char)) break;
+    index += char.length;
   }
-  return false;
+  return index;
+}
+
+/** ASCII 标签或 1–3 个汉字/假名/谚文，当作域名标签；更长的 CJK 当正文。 */
+function isLikelyIdnHostLabel(raw: string, from: number, to: number): boolean {
+  if (from >= to) return false;
+  const chars = [...raw.slice(from, to)];
+  if (chars.some((ch) => /[A-Za-z0-9]/.test(ch))) return true;
+  return chars.length <= 3 && chars.every((ch) => isHostLabelChar(ch));
 }
 
 function isIdnDotInHostname(
@@ -411,15 +425,16 @@ function isIdnDotInHostname(
   hostEnd: number,
 ): boolean {
   if (index < hostStart || index >= hostEnd) return false;
-  if (!isIdnDomainDot(raw[index] ?? '') || !isHostLabelChar(raw[index + 1])) return false;
-  if (!hasEarlierIdnDot(raw, hostStart, index)) return true;
-  // 已经有过 IDN 点号后，再出现的 `。这是说明` 当句号；后面还有 path/port 才继续当域名。
-  return hostEnd < raw.length;
+  if (!isIdnDomainDot(raw[index] ?? '') || !isHostLabelChar(raw[index + 1])) {
+    return false;
+  }
+  const labelEnd = nextHostLabelEnd(raw, index + 1, hostEnd);
+  return isLikelyIdnHostLabel(raw, index + 1, labelEnd);
 }
 
 /**
- * 标点/全角符号是正文边界；hostname 里第一处 IDN 点号（`例子。测试`）留下。
- * 端口、IPv6 `]`、路径、以及第二个句末 `。` 之后仍当句号切掉。
+ * 标点/全角符号是正文边界。hostname 里后面还像域名标签的 IDN 点号留下
+ * （`子域。例子。测试`）；`。这是说明` 这种长 CJK 仍当句号。
  */
 function findAutolinkProseBoundary(raw: string): number {
   const { start: hostStart, end: hostEnd } = hostnameRange(raw);

--- a/packages/maker-shared/src/urlTextBoundary.ts
+++ b/packages/maker-shared/src/urlTextBoundary.ts
@@ -1,7 +1,13 @@
+/**
+ * 裸 http(s) URL 在聊天正文里的切边权威。
+ *
+ * Desktop 用户消息、Desktop GFM autolink 后处理、Mobile markdown 分词共用这一份，
+ * 避免「URL 后面粘着（说明）」这类尾巴在一端被切掉、另一端点进 404。
+ * 匹配可以按扫描器各自写；href 从哪一刀结束只问 `clipBareHttpAutolink`。
+ */
+
 // 尾部 ASCII 标点集合：GFM spec 会剥掉 ? ! . , : * _ ~，此处额外加了 ;
 // 以便把 `https://x.com/foo; 然后` 这类散文分号也视为 URL 边界。
-// 用在我们自己的 plain-text linkifier 和 remark 后处理里，避免两条渲染链路
-// 对 `https://x.com/foo.` / `https://x.com/foo(base` 这类边界给出不同结果。
 
 const PROSE_TRAILING_PUNCT = new Set(['?', '!', '.', ',', ':', ';']);
 const MARKDOWN_FORMATTING_TRAILING_PUNCT = new Set(['*', '_', '~']);
@@ -332,4 +338,103 @@ export function shrinkAutolinkTrailingJunk(
     break;
   }
   return end;
+}
+
+/**
+ * 扫描器用的裸 http(s) 源。空白 / 尖括号 / ASCII 引号 / 任何非 ASCII
+ * （含全角括号与中文）处结束，避免匹配阶段就把说明吃进候选。
+ * 半角括号留给 `clipBareHttpAutolink` 按配对/包裹处理。
+ */
+export const BARE_HTTP_URL_RE_SOURCE =
+  String.raw`https?://[^\s<>"\u0080-\uFFFF]+`;
+
+const AUTOLINK_PROSE_BOUNDARY = new RegExp(
+  '[' +
+    '"`' +
+    '\\u2018-\\u201F' +
+    '\\u2026' +
+    '\\u3000-\\u303F' +
+    '\\u3040-\\u30FF' +
+    '\\u3400-\\u4DBF' +
+    '\\u4E00-\\u9FFF' +
+    '\\uAC00-\\uD7AF' +
+    '\\uFF00-\\uFFEF' +
+    ']',
+);
+
+const MARKDOWN_FORMATTING_STRIP_BOUNDARY =
+  /[\u3000-\u303F\u3040-\u30FF\u3400-\u4DBF\u4E00-\u9FFF\uAC00-\uD7AF\uFF00-\uFFEF]/;
+
+export function markdownWrapMarkerFromPrefix(prefix: string | null | undefined): string | null {
+  if (!prefix) return null;
+  for (const marker of MARKDOWN_WRAP_MARKERS) {
+    if (!prefix.endsWith(marker)) continue;
+    return isMarkdownWrapOpenBoundary(prefix[prefix.length - marker.length - 1])
+      ? marker
+      : null;
+  }
+  return null;
+}
+
+export type ClipBareHttpAutolinkOptions = {
+  prefix?: string | null;
+  markdownWrapMarker?: string | null;
+  stripMarkdownFormattingPunct?: boolean | 'auto';
+};
+
+/**
+ * 返回 `raw` 里真实 href 的结束下标（不含）。
+ * prefix 是 URL 前面的正文，用来识别包裹括号 / 引号 / markdown 开标记。
+ */
+export function clipBareHttpAutolink(
+  raw: string,
+  options: ClipBareHttpAutolinkOptions = {},
+): number {
+  const prefix = options.prefix ?? '';
+  const wrappingParenCount = countUnmatchedOpeningParens(prefix);
+  const marker =
+    options.markdownWrapMarker === undefined
+      ? markdownWrapMarkerFromPrefix(prefix)
+      : options.markdownWrapMarker;
+  const boundaryIndex = raw.search(AUTOLINK_PROSE_BOUNDARY);
+  const boundaryCut = boundaryIndex >= 0 ? boundaryIndex : raw.length;
+  const markdownCut = cutBeforeClosingMarkdownWrap(raw, marker);
+  const limited = Math.min(boundaryCut, markdownCut);
+  const proseCut = Math.min(
+    limited,
+    cutBeforeUnbalancedParenProse(raw, limited, { wrappingParenCount }),
+    cutBeforePathBracketProse(raw),
+  );
+  const stripMarkdown =
+    options.stripMarkdownFormattingPunct === true ||
+    (options.stripMarkdownFormattingPunct === 'auto' &&
+      (markdownCut < raw.length ||
+        hasTrailingMultiCharMarkdownMarkerAfterCodeHostResource(raw, proseCut) ||
+        (boundaryIndex >= 0 &&
+          proseCut === boundaryCut &&
+          MARKDOWN_FORMATTING_STRIP_BOUNDARY.test(raw[boundaryIndex]))));
+  return shrinkAutolinkTrailingJunk(raw, proseCut, {
+    stripMarkdownFormattingPunct: stripMarkdown,
+    stripWrappingApostrophe: prefix.endsWith("'"),
+    stripWrappingParenCount: wrappingParenCount,
+  });
+}
+
+export function clipBareHttpAutolinkText(
+  raw: string,
+  options: ClipBareHttpAutolinkOptions = {},
+): string {
+  return raw.slice(0, clipBareHttpAutolink(raw, options));
+}
+
+function hasTrailingMultiCharMarkdownMarkerAfterCodeHostResource(
+  raw: string,
+  cut: number,
+): boolean {
+  if (cut < 2) return false;
+  return ['**', '__', '~~'].some(
+    (marker) =>
+      raw.slice(cut - marker.length, cut) === marker &&
+      isCodeHostNumericResourcePath(raw.slice(0, cut - marker.length)),
+  );
 }

--- a/packages/maker-shared/src/urlTextBoundary.ts
+++ b/packages/maker-shared/src/urlTextBoundary.ts
@@ -397,44 +397,23 @@ function isHostLabelChar(ch: string | undefined): boolean {
   return !isAutolinkPunctuationBoundary(ch);
 }
 
-function nextHostLabelEnd(raw: string, from: number, hostEnd: number): number {
-  let index = from;
-  while (index < hostEnd) {
-    const code = raw.codePointAt(index);
-    if (code == null) break;
-    const char = String.fromCodePoint(code);
-    if (isIdnDomainDot(char) || char === '.') break;
-    if (!isHostLabelChar(char)) break;
-    index += char.length;
-  }
-  return index;
-}
-
-/** ASCII 标签或 1–3 个汉字/假名/谚文，当作域名标签；更长的 CJK 当正文。 */
-function isLikelyIdnHostLabel(raw: string, from: number, to: number): boolean {
-  if (from >= to) return false;
-  const chars = [...raw.slice(from, to)];
-  if (chars.some((ch) => /[A-Za-z0-9]/.test(ch))) return true;
-  return chars.length <= 3 && chars.every((ch) => isHostLabelChar(ch));
-}
-
 function isIdnDotInHostname(
   raw: string,
   index: number,
   hostStart: number,
   hostEnd: number,
 ): boolean {
-  if (index < hostStart || index >= hostEnd) return false;
-  if (!isIdnDomainDot(raw[index] ?? '') || !isHostLabelChar(raw[index + 1])) {
-    return false;
-  }
-  const labelEnd = nextHostLabelEnd(raw, index + 1, hostEnd);
-  return isLikelyIdnHostLabel(raw, index + 1, labelEnd);
+  return (
+    index >= hostStart &&
+    index < hostEnd &&
+    isIdnDomainDot(raw[index] ?? '') &&
+    isHostLabelChar(raw[index + 1])
+  );
 }
 
 /**
- * 标点/全角符号是正文边界。hostname 里后面还像域名标签的 IDN 点号留下
- * （`子域。例子。测试`）；`。这是说明` 这种长 CJK 仍当句号。
+ * 标点/全角符号是正文边界。hostname 里后面还跟标签的 IDN 点号一律留下
+ * （`пример。онлайн`、`子域。四字域名。测试`）。句末单独的 `。` 仍切掉。
  */
 function findAutolinkProseBoundary(raw: string): number {
   const { start: hostStart, end: hostEnd } = hostnameRange(raw);

--- a/packages/maker-shared/src/urlTextBoundary.ts
+++ b/packages/maker-shared/src/urlTextBoundary.ts
@@ -428,10 +428,10 @@ function isIdnDotInHostname(
   // 俄文/拉丁等字母脚本是真 IDN 标签，不限长度。
   if (chars.some((ch) => /^\p{L}$/u.test(ch) && !isCjkLetter(ch))) return true;
   if (chars.some((ch) => /[A-Za-z0-9]/.test(ch))) return true;
-  // 纯汉字标签：后面还有域名分隔符说明主机还没完（`四字域名。测试`）；
-  // 否则只留 1–3 字的 TLD 形标签，避免 `。这是说明` 并进主机名。
+  // 纯汉字标签：后面还有域名分隔符，或已有 path/port/query，说明主机还没完。
+  // 无路径的歧义场景才用 1–3 字 TLD 上限，避免 `。这是说明` 并进主机名。
   const after = raw[labelEnd];
-  if (after === '.' || isIdnDomainDot(after)) return true;
+  if (after === '.' || isIdnDomainDot(after) || hostEnd < raw.length) return true;
   return chars.length <= 3;
 }
 

--- a/packages/maker-shared/src/urlTextBoundary.ts
+++ b/packages/maker-shared/src/urlTextBoundary.ts
@@ -347,21 +347,16 @@ export function shrinkAutolinkTrailingJunk(
  * authority 决定。半角括号留给 `clipBareHttpAutolink` 按配对处理。
  */
 export const BARE_HTTP_URL_RE_SOURCE =
-  String.raw`https?://[^\s<>"\u2018-\u201F\u2026\u3000-\u3001\u3003\u3008-\u3011\u3014-\u301F\u3030\u303D\uFF01-\uFF0D\uFF0F\uFF1A-\uFF20\uFF3B-\uFF40\uFF5B-\uFF60\uFF62-\uFF65]+`;
+  String.raw`https?://[^\s<>"\u2013-\u2015\u2018-\u201F\u2022\u2026\u3000-\u3001\u3003\u3008-\u3011\u3014-\u301F\u3030\u303D\u30FB\uFE10-\uFE19\uFF01-\uFF0D\uFF0F\uFF1A-\uFF20\uFF3B-\uFF40\uFF5B-\uFF60\uFF62-\uFF65]+`;
 
 const MARKDOWN_FORMATTING_STRIP_BOUNDARY =
   /[\u3000-\u303F\u3040-\u30FF\u3400-\u4DBF\u4E00-\u9FFF\uAC00-\uD7AF\uFF00-\uFFEF]/;
-
-const CJK_OR_FULLWIDTH_PUNCT_BLOCK =
-  /(?:[\u3000-\u303F\uFF00-\uFFEF])/u;
 
 function isAutolinkPunctuationBoundary(ch: string): boolean {
   const code = ch.codePointAt(0);
   if (code == null) return false;
   if (ch === '"' || ch === '`') return true;
-  if (code >= 0x2018 && code <= 0x201f) return true;
-  if (code === 0x2026) return true;
-  if (!CJK_OR_FULLWIDTH_PUNCT_BLOCK.test(ch)) return false;
+  if (code < 0x80) return false;
   return /^\p{P}$/u.test(ch) || /^\p{Z}$/u.test(ch);
 }
 
@@ -396,8 +391,18 @@ function hostnameEndIndex(raw: string): number {
   return authEnd;
 }
 
+function isHostLabelChar(ch: string | undefined): boolean {
+  if (ch == null || isIdnDomainDot(ch)) return false;
+  if (ch === '/' || ch === '?' || ch === '#' || ch === ':' || ch === '@') return false;
+  return !isAutolinkPunctuationBoundary(ch);
+}
+
 function isIdnDotInHostname(raw: string, index: number, hostnameEnd: number): boolean {
-  return index < hostnameEnd && isIdnDomainDot(raw[index] ?? '');
+  return (
+    index < hostnameEnd &&
+    isIdnDomainDot(raw[index] ?? '') &&
+    isHostLabelChar(raw[index + 1])
+  );
 }
 
 /**

--- a/packages/maker-shared/src/urlTextBoundary.ts
+++ b/packages/maker-shared/src/urlTextBoundary.ts
@@ -371,29 +371,48 @@ function isIdnDomainDot(ch: string): boolean {
   return code === 0x3002 || code === 0xff0e || code === 0xff61;
 }
 
-function authorityEndIndex(raw: string): number {
-  const scheme = raw.match(/^https?:\/\//i);
-  const start = scheme ? scheme[0].length : 0;
-  for (let index = start; index < raw.length; index += 1) {
-    const ch = raw[index];
+function firstAuthDelimiterIndex(text: string, from = 0): number {
+  for (let index = from; index < text.length; index += 1) {
+    const ch = text[index];
     if (ch === '/' || ch === '?' || ch === '#') return index;
   }
-  return raw.length;
+  return text.length;
+}
+
+/** IDN 点号只在 hostname 内保留；端口和 IPv6 `]` 之后仍是正文边界。 */
+function hostnameEndIndex(raw: string): number {
+  const scheme = raw.match(/^https?:\/\//i);
+  let start = scheme ? scheme[0].length : 0;
+  const authEnd = firstAuthDelimiterIndex(raw, start);
+  const at = raw.lastIndexOf('@', authEnd - 1);
+  if (at >= start) start = at + 1;
+  if (raw[start] === '[') {
+    const close = raw.indexOf(']', start + 1);
+    return close >= 0 && close < authEnd ? close + 1 : authEnd;
+  }
+  for (let index = start; index < authEnd; index += 1) {
+    if (raw[index] === ':') return index;
+  }
+  return authEnd;
+}
+
+function isIdnDotInHostname(raw: string, index: number, hostnameEnd: number): boolean {
+  return index < hostnameEnd && isIdnDomainDot(raw[index] ?? '');
 }
 
 /**
- * 标点/全角符号是正文边界；authority 里的 IDN 点号（`例子。测试`）留下。
- * 路径开始后的 `。` 仍当句号切掉。无标点的 `path这是说明` 不猜。
+ * 标点/全角符号是正文边界；hostname 里的 IDN 点号（`例子。测试`）留下。
+ * 端口、IPv6 `]`、路径之后的 `。` 仍当句号切掉。
  */
 function findAutolinkProseBoundary(raw: string): number {
-  const authorityEnd = authorityEndIndex(raw);
+  const hostnameEnd = hostnameEndIndex(raw);
   for (let index = 0; index < raw.length; ) {
     const code = raw.codePointAt(index);
     if (code == null) break;
     const char = String.fromCodePoint(code);
     if (
       isAutolinkPunctuationBoundary(char) &&
-      !(index < authorityEnd && isIdnDomainDot(char))
+      !isIdnDotInHostname(raw, index, hostnameEnd)
     ) {
       return index;
     }

--- a/packages/maker-shared/src/urlTextBoundary.ts
+++ b/packages/maker-shared/src/urlTextBoundary.ts
@@ -341,15 +341,19 @@ export function shrinkAutolinkTrailingJunk(
 }
 
 /**
- * 扫描器用的裸 http(s) 源。空白 / 尖括号 / ASCII 引号 / 弯引号 /
- * CJK 与全角标点处结束。汉字、假名、谚文可以出现在域名和路径里；
- * 半角括号留给 `clipBareHttpAutolink` 按配对/包裹处理。
+ * 扫描器用的裸 http(s) 源。任意 Unicode 空白 / 尖括号 / 引号 / 省略号 /
+ * 真正的 CJK·全角标点处结束。全角字母、半角片假名、々 等字母
+ * 留在地址里；半角括号留给 `clipBareHttpAutolink` 按配对处理。
+ * 标点范围与 `isAutolinkPunctuationBoundary` 的 P/Z 判定对齐，不是整块 Unicode block。
  */
 export const BARE_HTTP_URL_RE_SOURCE =
-  'https?://[^ \t\r\n<>"\u2018-\u201F\u2026\u3000-\u303F\uFF00-\uFFEF]+';
+  String.raw`https?://[^\s<>"\u2018-\u201F\u2026\u3000-\u3003\u3008-\u3011\u3014-\u301F\u3030\u303D\uFF01-\uFF0F\uFF1A-\uFF20\uFF3B-\uFF40\uFF5B-\uFF65]+`;
 
 const MARKDOWN_FORMATTING_STRIP_BOUNDARY =
   /[\u3000-\u303F\u3040-\u30FF\u3400-\u4DBF\u4E00-\u9FFF\uAC00-\uD7AF\uFF00-\uFFEF]/;
+
+const CJK_OR_FULLWIDTH_PUNCT_BLOCK =
+  /(?:[\u3000-\u303F\uFF00-\uFFEF])/u;
 
 function isAutolinkPunctuationBoundary(ch: string): boolean {
   const code = ch.codePointAt(0);
@@ -357,9 +361,8 @@ function isAutolinkPunctuationBoundary(ch: string): boolean {
   if (ch === '"' || ch === '`') return true;
   if (code >= 0x2018 && code <= 0x201f) return true;
   if (code === 0x2026) return true;
-  if (code >= 0x3000 && code <= 0x303f) return true;
-  if (code >= 0xff00 && code <= 0xffef) return true;
-  return false;
+  if (!CJK_OR_FULLWIDTH_PUNCT_BLOCK.test(ch)) return false;
+  return /^\p{P}$/u.test(ch) || /^\p{Z}$/u.test(ch);
 }
 
 /**


### PR DESCRIPTION
## 这次改了什么

### 摘要

聊天里点裸 `http(s)` 链接时，后面粘着的全角括号、中文说明会被吃进 href，点开 404。桌面和手机原先各写一套切边，口径还对不齐。现在 href 从哪一刀结束只问 `@cindy/maker-shared` 的 `clipBareHttpAutolink`：用户消息、GFM 后处理、手机 markdown 共用这一份。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：内部反馈，裸 URL 点开带上 `（）` 等尾巴导致 404
- 本 PR 包含：把 URL 切边收到 `@cindy/maker-shared/url-text-boundary`；桌面用户消息、桌面 GFM autolink 后处理、手机 markdown 都调用 `clipBareHttpAutolink`
- 明确不包含：`file://` / 本地路径 span、显式 `[text](url)` destination、深链 chip、输入框粘贴、系统长按 data detector、重写 GFM 解析器
- 用户可见变化：`https://example.com/x（无 @）` 只点开到 `/x`；维基 `/Foo_(bar)` 仍保留配对括号；`(https://example.com/x)` 外层括号不进链接
- 是否存在 breaking change：无

### 远程连接与手机版适配

- SSH 远程工作区：不涉及。本 PR 只改聊天正文里裸 http(s) 的 href 切边，不读 workdir、不启 agent、不走远程文件通道。
- 设备互联 / IPC：不涉及。无新增或修改 IPC channel / 推送事件。
- 手机版：已一并适配。手机 `messageMarkdown` 与桌面用户消息 / GFM 后处理共用同一套切边。

### UI 变化

- 引用的设计规范：不涉及：只改裸 http(s) 的 href 切点，无视觉、交互或文案变化。renderer / mobile 路径被命中，是因为聊天渲染调用了共享切边。

## 怎么验证的

### 自动验证

```text
pnpm --filter @cindy/maker-shared exec vitest run src/__tests__/urlTextBoundary.test.ts
结果：6 passed

pnpm --filter mobile exec vitest run src/__tests__/messageMarkdown.test.ts
结果：104 passed

pnpm --filter desktop exec vitest run \
  src/renderer/__tests__/remarkTruncateCjkUrls.test.ts \
  src/renderer/__tests__/userMessageLinkify.test.ts
结果：89 passed

pnpm --filter mobile run typecheck
pnpm --filter desktop run typecheck
结果：通过

pnpm test:unit:related
结果：desktop / mobile / maker-shared 通过。因改了 maker-shared/package.json 扩成全量；maker-core 有一条依赖 worktree 内 bundled ripgrep 的用例，补 `pnpm install:ripgrep` 后该条通过，与本 PR 逻辑无关。
```

### 手工验证

不涉及。未起 dev 实例、未真机点开跨行长 GitHub 链接。

### 未执行的验证

真机 / 桌面实机点开「URL 跨行折断 + 后面跟 `（无 @）`」的原反馈形态。单测已锁同形字符串；上线后可用任意带全角说明的裸 GitHub 链接目检一次。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：桌面用户消息、桌面 assistant GFM 裸链接、手机聊天 markdown 的裸 http(s) href。不改 IPC、不改原生、不改指纹。
- 回滚 / 降级方式：整 PR revert。无 migration、无协议变更。

手机相对旧实现有一处有意对齐：以前半角 `()` 一律当正文（维基 `/Foo_(bar)` 点不全），现在与桌面一样保留配对括号、剥掉包裹括号。这是修 404 的同一套规则，不是额外产品变更。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
