### PR TITLE
feat(billing): 支持订单 ID 脱敏展示与复制

### DIFF
--- a/apps/desktop/src/renderer/features/billing/BillingPage.tsx
+++ b/apps/desktop/src/renderer/features/billing/BillingPage.tsx
@@ -144,8 +144,8 @@ function isAwaitingPaymentOrder(order: BillingPaymentOrder): boolean {
 
 /** 订单号展示保留首尾用于对单，中段固定脱敏；复制仍使用服务端返回的完整原值。 */
 function maskedOrderId(orderId: string): string {
-  const visibleEdgeLength = 8;
-  if (orderId.length <= visibleEdgeLength * 2) return orderId;
+  if (orderId.length <= 2) return '*'.repeat(orderId.length);
+  const visibleEdgeLength = Math.min(8, Math.floor((orderId.length - 1) / 2));
   return `${orderId.slice(0, visibleEdgeLength)}****${orderId.slice(-visibleEdgeLength)}`;
 }
 
@@ -1800,15 +1800,17 @@ function OrderHistoryCard({
               <button
                 type="button"
                 onClick={() => void copyOrderId(order.orderId)}
-                aria-label={t('billing.orders.copy.action')}
+                aria-label={t('billing.orders.copy.action', {
+                  id: maskedOrderId(order.orderId),
+                })}
                 className={cn(
-                  '-ml-1.5 mt-0.5 inline-flex cursor-pointer select-none items-center gap-1 rounded-full px-1.5 py-0.5 text-left',
+                  '-ml-1.5 mt-0.5 inline-flex max-w-full cursor-pointer select-none items-center gap-1 rounded-full px-1.5 py-0.5 text-left',
                   'font-mono text-10 text-[var(--text-tertiary)] transition-colors',
                   'hover:bg-[var(--surface-hover-soft)] hover:text-[var(--text-secondary)]',
                   'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring-soft)]',
                 )}
               >
-                <span className="whitespace-nowrap">
+                <span className="min-w-0 break-all">
                   {t('billing.orders.orderId', { id: maskedOrderId(order.orderId) })}
                 </span>
                 <Copy aria-hidden="true" size={11} className="shrink-0" />

--- a/apps/desktop/src/renderer/features/billing/BillingPage.tsx
+++ b/apps/desktop/src/renderer/features/billing/BillingPage.tsx
@@ -7,6 +7,7 @@ import {
   ChevronRight,
   ChevronUp,
   CircleDollarSign,
+  Copy,
   CreditCard,
   ExternalLink,
   PackageOpen,
@@ -141,12 +142,11 @@ function isAwaitingPaymentOrder(order: BillingPaymentOrder): boolean {
   return phaseForOrder(order) === 'AWAITING_PAYMENT';
 }
 
-/**
- * 订单号在界面上只做「认得出是哪一单」用,全长展示会把左列挤没 —— 截断展示、完整值
- * 挂 title。截断取头部:服务端订单号带随机前缀,头 8 位已足够区分。
- */
-function shortOrderId(orderId: string): string {
-  return orderId.length > 8 ? orderId.slice(0, 8) : orderId;
+/** 订单号展示保留首尾用于对单，中段固定脱敏；复制仍使用服务端返回的完整原值。 */
+function maskedOrderId(orderId: string): string {
+  const visibleEdgeLength = 8;
+  if (orderId.length <= visibleEdgeLength * 2) return orderId;
+  return `${orderId.slice(0, visibleEdgeLength)}****${orderId.slice(-visibleEdgeLength)}`;
 }
 
 function decimalParts(value: string): { value: bigint; scale: number } | null {
@@ -1752,6 +1752,14 @@ function OrderHistoryCard({
 }) {
   const { t, i18n } = useTranslation();
   const billingLocale = i18n.resolvedLanguage ?? i18n.language;
+  const copyOrderId = async (orderId: string) => {
+    try {
+      await navigator.clipboard.writeText(orderId);
+      toast.success(t('billing.orders.copy.success'));
+    } catch {
+      toast.error(t('billing.orders.copy.failed'));
+    }
+  };
   /**
    * 支付方式只有在服务端还带着本单的支付动作时才知道 —— 订单投影(shared/billing.ts 的
    * BillingPaymentOrder)里没有收单渠道字段,终态订单通常也不再带 paymentAction。整批都
@@ -1788,13 +1796,23 @@ function OrderHistoryCard({
               <p className="truncate text-12 font-medium tabular-nums text-[var(--text-primary)]">
                 {formatLedgerTimestamp(order.createdAt, billingLocale)}
               </p>
-              {/* 订单号只用来对单,截断展示、完整值挂 title(客服场景要能复制全长)。 */}
-              <p
-                title={order.orderId}
-                className="mt-1 truncate font-mono text-10 text-[var(--text-tertiary)]"
+              {/* 可见值只露首尾；整块按钮含 Copy 图标，点击任一位置都复制完整订单号。 */}
+              <button
+                type="button"
+                onClick={() => void copyOrderId(order.orderId)}
+                aria-label={t('billing.orders.copy.action')}
+                className={cn(
+                  '-ml-1.5 mt-0.5 inline-flex cursor-pointer select-none items-center gap-1 rounded-full px-1.5 py-0.5 text-left',
+                  'font-mono text-10 text-[var(--text-tertiary)] transition-colors',
+                  'hover:bg-[var(--surface-hover-soft)] hover:text-[var(--text-secondary)]',
+                  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring-soft)]',
+                )}
               >
-                {t('billing.orders.orderId', { id: shortOrderId(order.orderId) })}
-              </p>
+                <span className="whitespace-nowrap">
+                  {t('billing.orders.orderId', { id: maskedOrderId(order.orderId) })}
+                </span>
+                <Copy aria-hidden="true" size={11} className="shrink-0" />
+              </button>
             </div>
             <p className="min-w-0 truncate text-right text-12 font-medium tabular-nums text-[var(--text-primary)]">
               {formatMoney(order.amount, order.currency, billingLocale)}

--- a/apps/desktop/src/renderer/features/billing/__tests__/BillingPage.test.tsx
+++ b/apps/desktop/src/renderer/features/billing/__tests__/BillingPage.test.tsx
@@ -14,6 +14,7 @@ const i18n = {
 };
 
 const uiMocks = vi.hoisted(() => ({
+  clipboardWriteText: vi.fn(),
   confirm: vi.fn(),
   toastError: vi.fn(),
   toastSuccess: vi.fn(),
@@ -103,6 +104,11 @@ import { BillingPage } from '../BillingPage';
 import * as QRCode from 'qrcode';
 
 beforeEach(() => {
+  Object.defineProperty(navigator, 'clipboard', {
+    configurable: true,
+    value: { writeText: uiMocks.clipboardWriteText },
+  });
+  uiMocks.clipboardWriteText.mockReset().mockResolvedValue(undefined);
   uiMocks.confirm.mockReset().mockResolvedValue(false);
   uiMocks.toastError.mockReset();
   uiMocks.toastSuccess.mockReset();
@@ -2772,22 +2778,65 @@ describe('BillingPage order history', () => {
     return listOrders;
   };
 
-  it('lists the most recent orders with amount, id and status', async () => {
-    install([order()]);
+  it('lists the most recent orders with amount, masked id and status', async () => {
+    const fullOrderId = 'c2309a98-d776-4ad9-99b3-418951f13c7f';
+    install([order({ orderId: fullOrderId })]);
 
     render(<BillingPage />);
 
     expect(await screen.findByText('billing.orders.title')).toBeTruthy();
     expect(screen.getByText('billing.orders.count:{"count":1}')).toBeTruthy();
     expect(screen.getByText('billing.orders.description')).toBeTruthy();
-    // 订单号截断展示、完整值挂 title(客服场景要能复制全长)。
-    expect(screen.getByText('billing.orders.orderId:{"id":"ord_8f21"}').title).toBe(
-      'ord_8f21c4de9a',
-    );
+    // 展示首尾并固定脱敏中段，不把完整订单号写进可见文本或原生 title。
+    const orderIdButton = screen.getByRole('button', { name: 'billing.orders.copy.action' });
     expect(
-      screen.getByText(new Intl.NumberFormat('en', { style: 'currency', currency: 'CNY' }).format(33)),
+      within(orderIdButton).getByText('billing.orders.orderId:{"id":"c2309a98****51f13c7f"}'),
+    ).toBeTruthy();
+    expect(orderIdButton.getAttribute('title')).toBeNull();
+    expect(screen.queryByText(`billing.orders.orderId:{"id":"${fullOrderId}"}`)).toBeNull();
+    expect(orderIdButton.querySelector('svg')).toBeTruthy();
+    expect(
+      screen.getByText(
+        new Intl.NumberFormat('en', { style: 'currency', currency: 'CNY' }).format(33),
+      ),
     ).toBeTruthy();
     expect(screen.getByText('billing.orders.states.completed')).toBeTruthy();
+  });
+
+  it('copies the complete order id from both the id text and copy icon', async () => {
+    const fullOrderId = 'c2309a98-d776-4ad9-99b3-418951f13c7f';
+    install([order({ orderId: fullOrderId })]);
+
+    render(<BillingPage />);
+
+    const orderIdButton = await screen.findByRole('button', {
+      name: 'billing.orders.copy.action',
+    });
+    const maskedText = within(orderIdButton).getByText(
+      'billing.orders.orderId:{"id":"c2309a98****51f13c7f"}',
+    );
+    const copyIcon = orderIdButton.querySelector('svg');
+    expect(copyIcon).toBeTruthy();
+
+    fireEvent.click(maskedText);
+    await waitFor(() => expect(uiMocks.clipboardWriteText).toHaveBeenCalledWith(fullOrderId));
+    expect(uiMocks.toastSuccess).toHaveBeenCalledWith('billing.orders.copy.success');
+
+    uiMocks.clipboardWriteText.mockClear();
+    fireEvent.click(copyIcon!);
+    await waitFor(() => expect(uiMocks.clipboardWriteText).toHaveBeenCalledWith(fullOrderId));
+  });
+
+  it('explains how to recover when copying an order id fails', async () => {
+    uiMocks.clipboardWriteText.mockRejectedValueOnce(new Error('clipboard denied'));
+    install([order()]);
+
+    render(<BillingPage />);
+    fireEvent.click(await screen.findByRole('button', { name: 'billing.orders.copy.action' }));
+
+    await waitFor(() =>
+      expect(uiMocks.toastError).toHaveBeenCalledWith('billing.orders.copy.failed'),
+    );
   });
 
   it('asks the server for exactly the ten most recent orders', async () => {

--- a/apps/desktop/src/renderer/features/billing/__tests__/BillingPage.test.tsx
+++ b/apps/desktop/src/renderer/features/billing/__tests__/BillingPage.test.tsx
@@ -2788,7 +2788,9 @@ describe('BillingPage order history', () => {
     expect(screen.getByText('billing.orders.count:{"count":1}')).toBeTruthy();
     expect(screen.getByText('billing.orders.description')).toBeTruthy();
     // 展示首尾并固定脱敏中段，不把完整订单号写进可见文本或原生 title。
-    const orderIdButton = screen.getByRole('button', { name: 'billing.orders.copy.action' });
+    const orderIdButton = screen.getByRole('button', {
+      name: 'billing.orders.copy.action:{"id":"c2309a98****51f13c7f"}',
+    });
     expect(
       within(orderIdButton).getByText('billing.orders.orderId:{"id":"c2309a98****51f13c7f"}'),
     ).toBeTruthy();
@@ -2810,7 +2812,7 @@ describe('BillingPage order history', () => {
     render(<BillingPage />);
 
     const orderIdButton = await screen.findByRole('button', {
-      name: 'billing.orders.copy.action',
+      name: 'billing.orders.copy.action:{"id":"c2309a98****51f13c7f"}',
     });
     const maskedText = within(orderIdButton).getByText(
       'billing.orders.orderId:{"id":"c2309a98****51f13c7f"}',
@@ -2827,12 +2829,38 @@ describe('BillingPage order history', () => {
     await waitFor(() => expect(uiMocks.clipboardWriteText).toHaveBeenCalledWith(fullOrderId));
   });
 
+  it('masks short ids, distinguishes copy targets and keeps the control shrinkable', async () => {
+    const shortOrderId = 'ord_8f21c4de9a';
+    const otherOrderId = '1234567890abcdefghi';
+    install([order({ orderId: shortOrderId }), order({ orderId: otherOrderId })]);
+
+    render(<BillingPage />);
+
+    const shortOrderButton = await screen.findByRole('button', {
+      name: 'billing.orders.copy.action:{"id":"ord_8f****c4de9a"}',
+    });
+    expect(
+      within(shortOrderButton).getByText('billing.orders.orderId:{"id":"ord_8f****c4de9a"}'),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole('button', {
+        name: 'billing.orders.copy.action:{"id":"12345678****bcdefghi"}',
+      }),
+    ).toBeTruthy();
+    expect(shortOrderButton.className).toContain('max-w-full');
+    expect(shortOrderButton.querySelector('span')?.className).toContain('break-all');
+  });
+
   it('explains how to recover when copying an order id fails', async () => {
     uiMocks.clipboardWriteText.mockRejectedValueOnce(new Error('clipboard denied'));
     install([order()]);
 
     render(<BillingPage />);
-    fireEvent.click(await screen.findByRole('button', { name: 'billing.orders.copy.action' }));
+    fireEvent.click(
+      await screen.findByRole('button', {
+        name: 'billing.orders.copy.action:{"id":"ord_8f****c4de9a"}',
+      }),
+    );
 
     await waitFor(() =>
       expect(uiMocks.toastError).toHaveBeenCalledWith('billing.orders.copy.failed'),

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -10671,7 +10671,7 @@
       "incomplete": "There are many order records. Only the latest {{count}} are shown.",
       "orderId": "NO. {{id}}",
       "copy": {
-        "action": "Copy Order ID",
+        "action": "Copy Order ID {{id}}",
         "success": "Order ID copied",
         "failed": "Order ID wasn’t copied — try again"
       },

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -10670,6 +10670,11 @@
       "count": "{{count}} orders",
       "incomplete": "There are many order records. Only the latest {{count}} are shown.",
       "orderId": "NO. {{id}}",
+      "copy": {
+        "action": "Copy Order ID",
+        "success": "Order ID copied",
+        "failed": "Order ID wasn’t copied — try again"
+      },
       "states": {
         "completed": "Completed",
         "awaitingPayment": "Awaiting payment",

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -10656,6 +10656,11 @@
       "count": "{{count}}件",
       "incomplete": "注文履歴が多いため、最新の{{count}}件のみ表示しています。",
       "orderId": "NO. {{id}}",
+      "copy": {
+        "action": "注文 ID をコピー",
+        "success": "注文 ID をコピーしました",
+        "failed": "注文 ID をコピーできませんでした。もう一度お試しください。"
+      },
       "states": {
         "completed": "完了",
         "awaitingPayment": "支払い待ち",

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -10657,7 +10657,7 @@
       "incomplete": "注文履歴が多いため、最新の{{count}}件のみ表示しています。",
       "orderId": "NO. {{id}}",
       "copy": {
-        "action": "注文 ID をコピー",
+        "action": "注文 ID {{id}} をコピー",
         "success": "注文 ID をコピーしました",
         "failed": "注文 ID をコピーできませんでした。もう一度お試しください。"
       },

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -10656,6 +10656,11 @@
       "count": "{{count}}건",
       "incomplete": "주문 내역이 많아 최근 {{count}}건만 표시합니다.",
       "orderId": "NO. {{id}}",
+      "copy": {
+        "action": "주문 ID 복사",
+        "success": "주문 ID를 복사했습니다",
+        "failed": "주문 ID를 복사하지 못했습니다. 다시 시도해 주세요."
+      },
       "states": {
         "completed": "완료",
         "awaitingPayment": "결제 대기",

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -10657,7 +10657,7 @@
       "incomplete": "주문 내역이 많아 최근 {{count}}건만 표시합니다.",
       "orderId": "NO. {{id}}",
       "copy": {
-        "action": "주문 ID 복사",
+        "action": "주문 ID {{id}} 복사",
         "success": "주문 ID를 복사했습니다",
         "failed": "주문 ID를 복사하지 못했습니다. 다시 시도해 주세요."
       },

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -10649,7 +10649,7 @@
       "incomplete": "订单记录较多，当前仅显示最近的 {{count}} 笔。",
       "orderId": "NO. {{id}}",
       "copy": {
-        "action": "复制订单 ID",
+        "action": "复制订单 ID {{id}}",
         "success": "订单 ID 已复制",
         "failed": "复制订单 ID 失败，请重试"
       },

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -10648,6 +10648,11 @@
       "count": "{{count}} 笔",
       "incomplete": "订单记录较多，当前仅显示最近的 {{count}} 笔。",
       "orderId": "NO. {{id}}",
+      "copy": {
+        "action": "复制订单 ID",
+        "success": "订单 ID 已复制",
+        "failed": "复制订单 ID 失败，请重试"
+      },
       "states": {
         "completed": "已完成",
         "awaitingPayment": "待支付",

--- a/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
@@ -10649,7 +10649,7 @@
       "incomplete": "訂單記錄較多，當前僅顯示最近的 {{count}} 筆。",
       "orderId": "NO. {{id}}",
       "copy": {
-        "action": "複製訂單 ID",
+        "action": "複製訂單 ID {{id}}",
         "success": "訂單 ID 已複製",
         "failed": "複製訂單 ID 失敗，請再試一次"
       },

--- a/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
@@ -10648,6 +10648,11 @@
       "count": "{{count}} 筆",
       "incomplete": "訂單記錄較多，當前僅顯示最近的 {{count}} 筆。",
       "orderId": "NO. {{id}}",
+      "copy": {
+        "action": "複製訂單 ID",
+        "success": "訂單 ID 已複製",
+        "failed": "複製訂單 ID 失敗，請再試一次"
+      },
       "states": {
         "completed": "已完成",
         "awaitingPayment": "待支付",


### PR DESCRIPTION
## 这次改了什么

### 摘要

订单记录不再只显示订单号前 8 位。现在保留订单 ID 首尾各 8 位，并用 `****` 脱敏中段；末尾增加 Copy 图标。点击脱敏订单 ID 或 Copy 图标都会复制服务端返回的完整 `orderId`，并通过五语言 Toast 反馈复制结果。

### 变更类型

- [x] `feat` 新功能
- [ ] `fix` Bug 修复
- [ ] `refactor` 重构
- [ ] `docs` 文档
- [ ] `test` 测试
- [ ] `chore` 工程维护

### 范围

- 关联 Issue / 需求：当前产品需求（无关联 Issue）
- 本 PR 包含：
  - Desktop 设置页订单 ID 的首尾脱敏展示
  - 完整 `orderId` 的点击复制与成功/失败反馈
  - 五语言文案与回归测试
- 明确不包含：后端订单字段或接口变更、订单分页、Mobile UI
- 用户可见变化：订单 ID 从仅前 8 位改为“首 8 位 + `****` + 尾 8 位”，末尾新增 Copy 图标；点击整块订单 ID 区域可复制完整值
- Breaking change：无

### UI 变化
<img width="956" height="410" alt="image" src="https://github.com/user-attachments/assets/c7f3b554-a3ce-48d2-8d40-e9ecc580d445" />

- macOS 本地 Desktop 已从本分支 worktree 启动供走查；。
- 引用的设计规范：
  - `docs/design-rules/DESIGN.md §4 Buttons / §5 Border Radius Scale`：整块可复制区域使用 pill 交互热区
  - `§10 Light / Dark Dual-Mode Delivery Gate`：颜色及 hover/focus 状态全部使用语义 token
  - `§11 Voice & Content`：结果 Toast 明确命名对象，失败提示给出重试动作
  - `§14.1 / §14.6`：控制区不可选，并提供本地化 accessible name

## 怎么验证的

### 自动验证

- `pnpm test:unit:related`：通过
- `pnpm --filter desktop run --if-present typecheck`：通过
- `pnpm check:i18n`：通过（仅有仓库既有 warning）
- `pnpm check:i18n-glossary`：通过（仅有仓库既有 proposed warning）
- 任务相关 ESLint：通过
- `git diff --check origin/main...HEAD`：通过
- `pnpm check:dco`：通过

### 手工验证

- macOS：通过 `cindy-local-desktop` 从本分支 worktree 启动 Dev 本地实例，确认实例进程来源正确。
- 多端适配结论：
  - SSH 远程工作区：不涉及；未读取 workdir、Agent 或任务数据。
  - 设备互联：不涉及；未新增或修改 IPC channel / push 事件。
  - Mobile：不涉及；本次只修改现有 Desktop Settings 的 Billing 订单记录入口，Mobile 没有对应 Billing Settings 界面。

### 未执行

- Light / Dark 两种模式逐一实机目检未执行；实现复用现有语义 token。
- Windows 实机手工验证未执行；无平台分支或系统 API 差异，后续由 CI 全量门禁覆盖。
- 未附 UI 截图。

## 风险与回滚

- [x] 无已知高风险
- 影响范围：仅 Desktop 订单记录行的 `orderId` 展示和复制交互；完整值只在用户明确点击后进入系统剪贴板，不进入可见文本或原生 `title`。
- 回滚方式：回退本 PR commit 即可。

## 提交前检查

- [x] 变更范围与需求一致
- [x] 已补充任务相关测试
- [x] 已完成相关 typecheck / lint / i18n 检查
- [x] Commit 已包含 DCO Signed-off-by
- [x] 未引入新依赖、OAuth scope 或鉴权边界变化
- [x] 已说明设计规范依据和未执行的实机验证项
