### PR TITLE
fix(device-link): 用文件锁替代持有权心跳续期

### DIFF
--- a/apps/desktop/src/main/device-link/__tests__/ownership.test.ts
+++ b/apps/desktop/src/main/device-link/__tests__/ownership.test.ts
@@ -1,695 +1,256 @@
 /**
  * device-link 单持有者仲裁测试:
- *  - DeviceLinkOwnershipArbiter 状态机(注入内存 store + 手动 tick / 假时钟)
- *  - createDbClientOwnershipStore 的 CAS 语义(真 better-sqlite3 :memory:,
- *    经 OwnershipDbAccess 适配器模拟 DbClient 的 async 接口)
- *  - 双实例竞争的端到端不变量:任意时刻至多一个持有者
+ *  - DeviceLinkOwnershipArbiter 状态机(注入内存锁)
+ *  - createSqliteExclusiveFileLock 的跨连接互斥(真 better-sqlite3 文件)
  */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import Database from 'better-sqlite3';
 import {
   DeviceLinkOwnershipArbiter,
-  createDbClientOwnershipStore,
-  type OwnershipDbAccess,
-  type OwnershipIdentity,
-  type OwnershipRow,
-  type OwnershipStore,
+  createSqliteExclusiveFileLock,
+  type OwnershipLock,
 } from '../ownership';
 
 vi.mock('../../logger', () => ({
   createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
 }));
 
-const DDL = `CREATE TABLE device_link_ownership (
-  id integer PRIMARY KEY NOT NULL,
-  owner_id text NOT NULL,
-  owner_pid integer NOT NULL,
-  owner_label text,
-  heartbeat_at integer NOT NULL
-);`;
-
-function identity(id: string, pid = 100): OwnershipIdentity {
-  return { ownerId: id, ownerPid: pid, ownerLabel: 'test' };
-}
-
-/** 与 SQLite 实现同语义的内存 store(单进程测试用) */
-function memoryStore(): OwnershipStore & {
-  row: () => OwnershipRow | null;
-  set(r: OwnershipRow | null): void;
-} {
-  let row: (OwnershipRow & { ownerLabel: string | null }) | null = null;
+function memoryLock(): OwnershipLock {
+  let held = false;
   return {
-    row: () => row,
-    set(r) {
-      row = r ? { ...r, ownerLabel: null } : null;
-    },
-    read: async () =>
-      row ? { ownerId: row.ownerId, ownerPid: row.ownerPid, heartbeatAt: row.heartbeatAt } : null,
-    async tryInsert(id, now) {
-      if (row) return false;
-      row = {
-        ownerId: id.ownerId,
-        ownerPid: id.ownerPid,
-        ownerLabel: id.ownerLabel,
-        heartbeatAt: now,
-      };
+    tryAcquire() {
+      if (held) return false;
+      held = true;
       return true;
     },
-    async tryTakeover(expected, id, now) {
-      if (!row || row.ownerId !== expected.ownerId || row.heartbeatAt !== expected.heartbeatAt) {
-        return false;
-      }
-      row = {
-        ownerId: id.ownerId,
-        ownerPid: id.ownerPid,
-        ownerLabel: id.ownerLabel,
-        heartbeatAt: now,
-      };
-      return true;
+    release() {
+      held = false;
     },
-    async renew(ownerId, now) {
-      if (!row || row.ownerId !== ownerId) return false;
-      row = { ...row, heartbeatAt: now };
-      return true;
-    },
-    async release(ownerId) {
-      if (row?.ownerId === ownerId) row = null;
+    isHeld() {
+      return held;
     },
   };
 }
 
-function makeArbiter(opts: { store: OwnershipStore | null; id?: string; now: () => number }) {
+function makeArbiter(opts: { lock: OwnershipLock | null; retryMs?: number }) {
   const onAcquire = vi.fn();
   const onDemote = vi.fn();
   const onStandbyChanged = vi.fn();
   const arbiter = new DeviceLinkOwnershipArbiter({
-    getStore: () => opts.store,
-    instance: { ownerPid: 100, ownerLabel: 'test' },
-    newOwnerId: () => opts.id ?? 'self',
+    getLock: () => opts.lock,
     onAcquire,
     onDemote,
     onStandbyChanged,
-    heartbeatMs: 5_000,
-    staleMs: 15_000,
-    now: opts.now,
+    retryMs: opts.retryMs ?? 500,
   });
-  // 测试直接手动驱动 tick,不调 start()(避免 start 的后台首 tick 与手动 tick 竞争防重入锁)
   return { arbiter, onAcquire, onDemote, onStandbyChanged };
 }
 
 describe('DeviceLinkOwnershipArbiter', () => {
-  let clock: number;
-  const now = () => clock;
-
-  beforeEach(() => {
-    clock = 1_000_000;
-  });
-
-  it('空表 → 认领成功并回调 onAcquire', async () => {
-    const store = memoryStore();
-    const { arbiter, onAcquire } = makeArbiter({ store, now });
-    await arbiter.tick();
+  it('空锁 → 认领成功并回调 onAcquire', () => {
+    const lock = memoryLock();
+    const { arbiter, onAcquire } = makeArbiter({ lock });
+    arbiter.tick();
     expect(arbiter.isOwner()).toBe(true);
     expect(onAcquire).toHaveBeenCalledTimes(1);
-    expect(store.row()?.ownerId).toBe('self');
+    expect(lock.isHeld()).toBe(true);
   });
 
-  it('外部持有者心跳新鲜 → 保持被动不抢', async () => {
-    const store = memoryStore();
-    store.set({ ownerId: 'other', ownerPid: 200, heartbeatAt: clock - 5_000 });
-    const { arbiter, onAcquire } = makeArbiter({ store, now });
-    await arbiter.tick();
+  it('锁已被他人持有 → 保持被动不抢', () => {
+    const lock = memoryLock();
+    expect(lock.tryAcquire()).toBe(true);
+    const { arbiter, onAcquire } = makeArbiter({ lock });
+    arbiter.tick();
     expect(arbiter.isOwner()).toBe(false);
+    expect(arbiter.isStandby()).toBe(true);
     expect(onAcquire).not.toHaveBeenCalled();
-    expect(store.row()?.ownerId).toBe('other');
   });
 
-  it('外部持有者心跳过期 → CAS 接管', async () => {
-    const store = memoryStore();
-    store.set({ ownerId: 'other', ownerPid: 200, heartbeatAt: clock - 16_000 });
-    const { arbiter, onAcquire } = makeArbiter({ store, now });
-    await arbiter.tick();
+  it('他人释放后下一轮立刻接管', () => {
+    const lock = memoryLock();
+    expect(lock.tryAcquire()).toBe(true);
+    const { arbiter, onAcquire } = makeArbiter({ lock });
+    arbiter.tick();
+    expect(arbiter.isOwner()).toBe(false);
+    lock.release();
+    arbiter.tick();
     expect(arbiter.isOwner()).toBe(true);
     expect(onAcquire).toHaveBeenCalledTimes(1);
-    expect(store.row()?.ownerId).toBe('self');
   });
 
-  it('持有者续期正常 → 心跳被刷新且不重复回调', async () => {
-    const store = memoryStore();
-    const { arbiter, onAcquire } = makeArbiter({ store, now });
-    await arbiter.tick();
+  it('持有者不再续期;锁仍在则不重复回调', () => {
+    const lock = memoryLock();
+    const { arbiter, onAcquire } = makeArbiter({ lock });
+    arbiter.tick();
+    arbiter.tick();
+    arbiter.tick();
     expect(onAcquire).toHaveBeenCalledTimes(1);
-    clock += 5_000;
-    await arbiter.tick();
-    expect(store.row()?.heartbeatAt).toBe(clock);
-    expect(onAcquire).toHaveBeenCalledTimes(1);
+    expect(arbiter.isOwner()).toBe(true);
   });
 
-  it('续期失败(行被接管)→ onDemote 且不抢回', async () => {
-    const store = memoryStore();
-    const { arbiter, onDemote } = makeArbiter({ store, now });
-    await arbiter.tick();
-    // 模拟睡眠期间被另一实例接管
-    store.set({ ownerId: 'usurper', ownerPid: 300, heartbeatAt: clock });
-    clock += 5_000;
-    await arbiter.tick();
+  it('锁丢失 → onDemote 且不抢回(直到锁再次可拿)', () => {
+    const lock = memoryLock();
+    const { arbiter, onDemote } = makeArbiter({ lock });
+    arbiter.tick();
+    lock.release();
+    arbiter.tick();
     expect(arbiter.isOwner()).toBe(false);
     expect(onDemote).toHaveBeenCalledTimes(1);
-    // 对方心跳新鲜,后续 tick 保持被动
-    await arbiter.tick();
-    expect(arbiter.isOwner()).toBe(false);
-    expect(store.row()?.ownerId).toBe('usurper');
   });
 
-  it('stop() → 释放行 + onDemote;幸存实例可立即接管', async () => {
-    const store = memoryStore();
-    const a = makeArbiter({ store, id: 'a', now });
-    await a.arbiter.tick();
-    a.arbiter.stop();
+  it('stop() → 释放锁 + onDemote;幸存实例可立即接管', () => {
+    const lock = memoryLock();
+    const a = makeArbiter({ lock });
+    a.arbiter.tick();
+    void a.arbiter.stop();
     expect(a.onDemote).toHaveBeenCalledTimes(1);
-    await vi.waitFor(() => expect(store.row()).toBeNull()); // release 是 fire-and-forget
+    expect(lock.isHeld()).toBe(false);
 
-    const b = makeArbiter({ store, id: 'b', now });
-    await b.arbiter.tick();
+    const b = makeArbiter({ lock });
+    b.arbiter.tick();
     expect(b.arbiter.isOwner()).toBe(true);
   });
 
-  it('store 未就绪(null / getStore 抛错)→ 跳过不崩;就绪后下一轮认领', async () => {
-    let store: OwnershipStore | null = null;
+  it('getLock 未就绪(null / 抛错)→ 跳过不崩;就绪后下一轮认领', () => {
+    let lock: OwnershipLock | null = null;
     const onAcquire = vi.fn();
     const arbiter = new DeviceLinkOwnershipArbiter({
-      getStore: () => {
-        if (!store) throw new Error('DbClient not ready');
-        return store;
+      getLock: () => {
+        if (!lock) throw new Error('userData not ready');
+        return lock;
       },
-      instance: { ownerPid: 100, ownerLabel: 'test' },
-      newOwnerId: () => 'self',
       onAcquire,
       onDemote: vi.fn(),
-      heartbeatMs: 5_000,
-      staleMs: 15_000,
-      now,
     });
-    await arbiter.tick();
+    arbiter.tick();
     expect(onAcquire).not.toHaveBeenCalled();
-    store = memoryStore();
-    await arbiter.tick();
+    lock = memoryLock();
+    arbiter.tick();
     expect(onAcquire).toHaveBeenCalledTimes(1);
   });
 
-  it('store 操作抛错 → 本轮吞掉,下一轮自愈', async () => {
-    const store = memoryStore();
-    const broken: OwnershipStore = {
-      ...store,
-      read: async () => {
-        throw new Error('no such table: device_link_ownership');
-      },
-    };
-    let current: OwnershipStore = broken;
-    const onAcquire = vi.fn();
+  it('持有者期间 getLock 变 null → 自我降级停 client', () => {
+    let lock: OwnershipLock | null = memoryLock();
+    const onDemote = vi.fn();
     const arbiter = new DeviceLinkOwnershipArbiter({
-      getStore: () => current,
-      instance: { ownerPid: 100, ownerLabel: 'test' },
-      newOwnerId: () => 'self',
-      onAcquire,
-      onDemote: vi.fn(),
-      heartbeatMs: 5_000,
-      staleMs: 15_000,
-      now,
+      getLock: () => lock,
+      onAcquire: vi.fn(),
+      onDemote,
     });
-    await expect(arbiter.tick()).resolves.toBeUndefined();
-    current = store;
-    await arbiter.tick();
-    expect(onAcquire).toHaveBeenCalledTimes(1);
+    arbiter.tick();
+    expect(arbiter.isOwner()).toBe(true);
+    lock = null;
+    arbiter.tick();
+    expect(arbiter.isOwner()).toBe(false);
+    expect(onDemote).toHaveBeenCalledTimes(1);
   });
 
-  it('store 未就绪时亚秒级快速重试,就绪后立即认领(不等下一整拍)', async () => {
+  it('store 未就绪时亚秒级快速重试,就绪后立即认领', async () => {
     vi.useFakeTimers();
     try {
-      let store: OwnershipStore | null = null;
+      let lock: OwnershipLock | null = null;
       const onAcquire = vi.fn();
       const arbiter = new DeviceLinkOwnershipArbiter({
-        getStore: () => store,
-        instance: { ownerPid: 100, ownerLabel: 'test' },
-        newOwnerId: () => 'self',
+        getLock: () => lock,
         onAcquire,
         onDemote: vi.fn(),
-        heartbeatMs: 5_000,
-        staleMs: 15_000,
-        storeRetryMs: 500,
-        now,
+        retryMs: 500,
       });
       arbiter.start();
       expect(onAcquire).not.toHaveBeenCalled();
-      // DbClient 就绪(冷启动 auth 先到、DB takeover 后完成的时序)
-      store = memoryStore();
+      lock = memoryLock();
       await vi.advanceTimersByTimeAsync(500);
       expect(onAcquire).toHaveBeenCalledTimes(1);
-      arbiter.stop();
+      void arbiter.stop();
     } finally {
       vi.useRealTimers();
     }
   });
 
-  it('认领窗口内被 stop() → 刚写入的行被补释放,不留新鲜孤儿行', async () => {
-    const store = memoryStore();
-    let unblockInsert!: () => void;
-    const gate = new Promise<void>((r) => {
-      unblockInsert = r;
-    });
-    const slow: OwnershipStore = {
-      ...store,
-      async tryInsert(id, at) {
-        const ok = await store.tryInsert(id, at);
-        await gate; // 模拟慢 RPC:写入已落库,但结果尚未返回
-        return ok;
-      },
-    };
-    const { arbiter, onAcquire } = makeArbiter({ store: slow, now });
-    const inflight = arbiter.tick();
-    await new Promise((r) => setImmediate(r)); // 推进到 tryInsert 挂起点(行已写入)
-    expect(store.row()?.ownerId).toBe('self');
-    arbiter.stop(); // 此刻 owner 仍为 false,stop() 不会释放这条行
-    unblockInsert();
-    await inflight;
-    expect(onAcquire).not.toHaveBeenCalled();
-    // 取消的认领必须被补释放,否则幸存实例只能等 staleMs 过期
-    await vi.waitFor(() => expect(store.row()).toBeNull());
-  });
-
-  it('stop() 的 release 迟到时不会误删重启后新认领的行(ownerId 每次 start 轮换)', async () => {
-    const store = memoryStore();
-    let seq = 0;
-    const pendingReleases: Array<() => Promise<void>> = [];
-    const slowRelease: OwnershipStore = {
-      ...store,
-      release: (ownerId) =>
-        new Promise<void>((resolve) => {
-          pendingReleases.push(async () => {
-            await store.release(ownerId);
-            resolve();
-          });
-        }),
-    };
-    const arbiter = new DeviceLinkOwnershipArbiter({
-      getStore: () => slowRelease,
-      instance: { ownerPid: 100, ownerLabel: 'test' },
-      newOwnerId: () => `id-${++seq}`,
-      onAcquire: vi.fn(),
-      onDemote: vi.fn(),
-      heartbeatMs: 5_000,
-      staleMs: 15_000,
-      now,
-    });
-    await arbiter.tick(); // id-1 认领
-    expect(store.row()?.ownerId).toBe('id-1');
-    arbiter.stop(); // release(id-1) 被挂起(模拟登出时 RPC 迟迟未落盘)
-    arbiter.start(); // 轮换为 id-2
-    await new Promise((r) => setImmediate(r)); // 后台首 tick:旧行仍在且心跳新鲜 → 被动
-    expect(arbiter.isOwner()).toBe(false);
-    clock += 16_000; // 旧行心跳过期
-    await arbiter.tick(); // id-2 接管
+  it('失去持有权、接管和 stop 都会翻转待命状态', () => {
+    const lock = memoryLock();
+    const { arbiter, onStandbyChanged } = makeArbiter({ lock });
+    arbiter.tick();
+    expect(arbiter.isStandby()).toBe(false);
+    expect(onStandbyChanged).not.toHaveBeenCalled();
+    lock.release();
+    arbiter.tick();
+    expect(arbiter.isStandby()).toBe(true);
+    expect(onStandbyChanged).toHaveBeenLastCalledWith(true);
+    arbiter.tick();
     expect(arbiter.isOwner()).toBe(true);
-    expect(store.row()?.ownerId).toBe('id-2');
-    // 迟到的 stale release 此刻才落盘:按旧 ownerId(id-1)删,不得误删 id-2 的行
-    // (若 ownerId 不轮换,这里 DELETE WHERE owner_id=self 会把新认领的行删掉)
-    await pendingReleases[0]();
-    expect(store.row()?.ownerId).toBe('id-2');
-    arbiter.stop();
-  });
-
-  it('持有者续期持续不可达(store 长期 null)→ 在同伴判过期前自我降级停 client', async () => {
-    let store: OwnershipStore | null = memoryStore();
-    const onDemote = vi.fn();
-    const arbiter = new DeviceLinkOwnershipArbiter({
-      getStore: () => store,
-      instance: { ownerPid: 100, ownerLabel: 'test' },
-      newOwnerId: () => 'self',
-      onAcquire: vi.fn(),
-      onDemote,
-      heartbeatMs: 5_000,
-      staleMs: 15_000,
-      now,
-    });
-    await arbiter.tick();
-    expect(arbiter.isOwner()).toBe(true);
-    // DbClient 崩溃:store 不可用,续期停摆
-    store = null;
-    clock += 5_000;
-    await arbiter.tick(); // 距上次续期成功 5s,未过自我降级期限(10s),保持持有
-    expect(arbiter.isOwner()).toBe(true);
-    clock += 6_000; // 距上次续期成功 11s > staleMs - heartbeatMs = 10s
-    await arbiter.tick();
-    expect(arbiter.isOwner()).toBe(false);
-    expect(onDemote).toHaveBeenCalledTimes(1);
-  });
-
-  it('renew RPC 挂起(传输层超时 30s > staleMs)→ 独立降级检查仍按期停 client', async () => {
-    vi.useFakeTimers();
-    try {
-      const base = memoryStore();
-      const hung: OwnershipStore = {
-        ...base,
-        renew: () => new Promise<boolean>(() => {}), // 永不返回,模拟 worker 挂起
-      };
-      const onDemote = vi.fn();
-      const arbiter = new DeviceLinkOwnershipArbiter({
-        getStore: () => hung,
-        instance: { ownerPid: 100, ownerLabel: 'test' },
-        newOwnerId: () => 'self',
-        onAcquire: vi.fn(),
-        onDemote,
-        heartbeatMs: 5_000,
-        staleMs: 15_000,
-        now, // 与假时钟同步推进
-      });
-      arbiter.start();
-      await vi.advanceTimersByTimeAsync(0); // 首 tick:tryInsert 即时成功 → 持有
-      expect(arbiter.isOwner()).toBe(true);
-      // 三拍内 renew 全部挂起:第 5s / 10s 的独立检查未越限保持,15s 检查越限(>10s)降级
-      for (const step of [5_000, 5_000, 5_000]) {
-        clock += step;
-        await vi.advanceTimersByTimeAsync(step);
-      }
-      expect(arbiter.isOwner()).toBe(false);
-      expect(onDemote).toHaveBeenCalledTimes(1);
-      arbiter.stop();
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  it('stop() 在认领 CAS 已提交但 tick 未返回时,返回值涵盖取消认领的补释放', async () => {
-    const store = memoryStore();
-    let resolveInsert: (ok: boolean) => void = () => {};
-    const gated: OwnershipStore = {
-      ...store,
-      tryInsert: (id, at) =>
-        new Promise<boolean>((resolve) => {
-          resolveInsert = (ok) => {
-            // 模拟 CAS 已在 DB 落盘、RPC 返回慢:先真实写入,再放行返回值
-            void store.tryInsert(id, at).then(() => resolve(ok));
-          };
-        }),
-    };
-    const arbiter = new DeviceLinkOwnershipArbiter({
-      getStore: () => gated,
-      instance: { ownerPid: 100, ownerLabel: 'test' },
-      newOwnerId: () => 'self',
-      onAcquire: vi.fn(),
-      onDemote: vi.fn(),
-      heartbeatMs: 5_000,
-      staleMs: 15_000,
-      now,
-    });
-    const tickPromise = arbiter.tick(); // 停在 tryInsert await
-    await Promise.resolve(); // 让 tick 推进到 tryInsert
-    const stopPromise = arbiter.stop(); // 此刻 owner 仍为 false,常规 release 不触发
-    resolveInsert(true); // CAS 提交完成,tick 恢复后发现已取消 → 补释放
-    await stopPromise; // stop 的返回值必须等到补释放落盘
-    await tickPromise;
-    expect(store.row()).toBeNull();
-  });
-
-  it('认领 CAS 本地超时后晚落盘,stop() 仍能补释放该行(不滞留到 staleMs)', async () => {
-    vi.useFakeTimers();
-    try {
-      const base = memoryStore();
-      let resolveInsert: (ok: boolean) => void = () => {};
-      const gated: OwnershipStore = {
-        ...base,
-        tryInsert: (id, at) =>
-          new Promise<boolean>((resolve) => {
-            resolveInsert = (ok) => void base.tryInsert(id, at).then(() => resolve(ok));
-          }),
-      };
-      const arbiter = new DeviceLinkOwnershipArbiter({
-        getStore: () => gated,
-        instance: { ownerPid: 100, ownerLabel: 'test' },
-        newOwnerId: () => 'self',
-        onAcquire: vi.fn(),
-        onDemote: vi.fn(),
-        heartbeatMs: 5_000,
-        staleMs: 15_000,
-        now,
-      });
-      const tickPromise = arbiter.tick();
-      await vi.advanceTimersByTimeAsync(5_000); // tryInsert 本地超时 → trackLateClaim 登记
-      await tickPromise;
-      expect(arbiter.isOwner()).toBe(false);
-      const stopPromise = arbiter.stop();
-      resolveInsert(true); // CAS 在 stop 之后才落盘
-      await stopPromise; // stop 返回值等 late-claim settle 并补释放
-      expect(base.row()).toBeNull();
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  it('staleMs 配置过小直接拒绝', () => {
-    expect(
-      () =>
-        new DeviceLinkOwnershipArbiter({
-          getStore: () => null,
-          instance: { ownerPid: 100, ownerLabel: 'test' },
-          onAcquire: () => {},
-          onDemote: () => {},
-          heartbeatMs: 5_000,
-          staleMs: 10_000,
-          now,
-        }),
-    ).toThrow(/staleMs/);
-  });
-
-  describe('待命状态通知(onStandbyChanged)', () => {
-    it('外部持有者心跳新鲜 → 通知待命并去重', async () => {
-      const store = memoryStore();
-      store.set({ ownerId: 'other', ownerPid: 200, heartbeatAt: clock - 5_000 });
-      const { arbiter, onStandbyChanged } = makeArbiter({ store, now });
-      await arbiter.tick();
-      expect(arbiter.isStandby()).toBe(true);
-      expect(onStandbyChanged).toHaveBeenCalledWith(true);
-      store.set({ ownerId: 'other', ownerPid: 200, heartbeatAt: clock });
-      await arbiter.tick();
-      expect(onStandbyChanged).toHaveBeenCalledTimes(1);
-    });
-
-    it('过期持有者直接接管,不先闪一次待命', async () => {
-      const store = memoryStore();
-      store.set({ ownerId: 'other', ownerPid: 200, heartbeatAt: clock - 16_000 });
-      const { arbiter, onStandbyChanged } = makeArbiter({ store, now });
-      await arbiter.tick();
-      expect(arbiter.isOwner()).toBe(true);
-      expect(arbiter.isStandby()).toBe(false);
-      expect(onStandbyChanged).not.toHaveBeenCalled();
-    });
-
-    it('失去持有权、接管和 stop 都会翻转待命状态', async () => {
-      const store = memoryStore();
-      const { arbiter, onStandbyChanged } = makeArbiter({ store, now });
-      await arbiter.tick();
-      store.set({ ownerId: 'usurper', ownerPid: 300, heartbeatAt: clock });
-      clock += 5_000;
-      await arbiter.tick();
-      expect(arbiter.isStandby()).toBe(true);
-      expect(onStandbyChanged).toHaveBeenLastCalledWith(true);
-      clock += 16_000;
-      await arbiter.tick();
-      expect(arbiter.isOwner()).toBe(true);
-      expect(onStandbyChanged).toHaveBeenLastCalledWith(false);
-      await arbiter.stop();
-      expect(arbiter.isStandby()).toBe(false);
-    });
-
-    it('ownership store 短暂不可用时保留最近一次已确认的待命状态', async () => {
-      const base = memoryStore();
-      base.set({ ownerId: 'other', ownerPid: 200, heartbeatAt: clock - 5_000 });
-      let store: OwnershipStore | null = base;
-      const onStandbyChanged = vi.fn();
-      const arbiter = new DeviceLinkOwnershipArbiter({
-        getStore: () => store,
-        instance: { ownerPid: 100, ownerLabel: 'test' },
-        newOwnerId: () => 'self',
-        onAcquire: vi.fn(),
-        onDemote: vi.fn(),
-        onStandbyChanged,
-        heartbeatMs: 5_000,
-        staleMs: 15_000,
-        now,
-      });
-
-      await arbiter.tick();
-      expect(arbiter.isStandby()).toBe(true);
-
-      store = {
-        ...base,
-        read: async () => {
-          throw new Error('temporary ownership store failure');
-        },
-      };
-      await arbiter.tick();
-      expect(arbiter.isStandby()).toBe(true);
-
-      store = null;
-      await arbiter.tick();
-      expect(arbiter.isStandby()).toBe(true);
-      expect(onStandbyChanged).toHaveBeenCalledTimes(1);
-    });
-
-    it('ownership read 本地超时时保留待命,直到明确结果推进状态', async () => {
-      vi.useFakeTimers();
-      try {
-        const base = memoryStore();
-        base.set({ ownerId: 'other', ownerPid: 200, heartbeatAt: clock - 5_000 });
-        let readHangs = false;
-        const store: OwnershipStore = {
-          ...base,
-          read: () => (readHangs ? new Promise<never>(() => {}) : base.read()),
-        };
-        const onStandbyChanged = vi.fn();
-        const arbiter = new DeviceLinkOwnershipArbiter({
-          getStore: () => store,
-          instance: { ownerPid: 100, ownerLabel: 'test' },
-          newOwnerId: () => 'self',
-          onAcquire: vi.fn(),
-          onDemote: vi.fn(),
-          onStandbyChanged,
-          heartbeatMs: 5_000,
-          staleMs: 15_000,
-          opTimeoutMs: 100,
-          now,
-        });
-
-        await arbiter.tick();
-        expect(arbiter.isStandby()).toBe(true);
-
-        readHangs = true;
-        const timedOutTick = arbiter.tick();
-        await vi.advanceTimersByTimeAsync(100);
-        await timedOutTick;
-        expect(arbiter.isStandby()).toBe(true);
-        expect(onStandbyChanged).toHaveBeenCalledTimes(1);
-
-        readHangs = false;
-        base.set(null);
-        await arbiter.tick();
-        expect(arbiter.isOwner()).toBe(true);
-        expect(arbiter.isStandby()).toBe(false);
-        expect(onStandbyChanged).toHaveBeenLastCalledWith(false);
-      } finally {
-        vi.useRealTimers();
-      }
-    });
+    expect(onStandbyChanged).toHaveBeenLastCalledWith(false);
+    void arbiter.stop();
+    expect(arbiter.isStandby()).toBe(false);
   });
 });
 
-describe('createDbClientOwnershipStore(真 SQLite CAS 语义,DbClient 接口适配)', () => {
-  /** 用 better-sqlite3 :memory: 模拟 DbClient 的 queryOne/exec 异步接口 */
-  function dbAccess(db: InstanceType<typeof Database>): OwnershipDbAccess {
-    return {
-      queryOne: async <T>(sql: string, params: unknown[] = []) =>
-        db.prepare(sql).get(...params) as T | undefined,
-      exec: async (sql: string, params: unknown[] = []) => db.prepare(sql).run(...params),
-    };
+describe('createSqliteExclusiveFileLock', () => {
+  function openTempLock(): { dir: string; lockPath: string } {
+    const dir = mkdtempSync(join(tmpdir(), 'cindy-ownership-lock-'));
+    return { dir, lockPath: join(dir, 'device-link.lock.db') };
   }
 
-  function freshStore(): OwnershipStore {
-    const db = new Database(':memory:');
-    db.exec(DDL);
-    return createDbClientOwnershipStore(dbAccess(db));
+  function openLock(lockPath: string) {
+    return createSqliteExclusiveFileLock(lockPath, (file) => new Database(file, { timeout: 0 }));
   }
 
-  it('tryInsert:空表成功,已有行失败(ON CONFLICT DO NOTHING)', async () => {
-    const store = freshStore();
-    expect(await store.tryInsert(identity('a'), 1000)).toBe(true);
-    expect(await store.tryInsert(identity('b'), 2000)).toBe(false);
-    expect((await store.read())?.ownerId).toBe('a');
-  });
-
-  it('tryTakeover:期望值匹配才成功;心跳已被续期则失败', async () => {
-    const store = freshStore();
-    await store.tryInsert(identity('a'), 1000);
-    expect(await store.renew('a', 1500)).toBe(true);
-    // 期望的 heartbeatAt 不匹配(a 刚续期)→ 失败
-    expect(await store.tryTakeover({ ownerId: 'a', heartbeatAt: 1000 }, identity('b'), 2000)).toBe(
-      false,
-    );
-    // 匹配当前值 → 成功
-    expect(await store.tryTakeover({ ownerId: 'a', heartbeatAt: 1500 }, identity('b'), 2000)).toBe(
-      true,
-    );
-    expect(await store.read()).toMatchObject({ ownerId: 'b', heartbeatAt: 2000 });
-  });
-
-  it('renew:非持有者续期失败', async () => {
-    const store = freshStore();
-    await store.tryInsert(identity('a'), 1000);
-    expect(await store.renew('b', 2000)).toBe(false);
-    expect((await store.read())?.heartbeatAt).toBe(1000);
-  });
-
-  it('release:只删自己的行,不误删他人', async () => {
-    const store = freshStore();
-    await store.tryInsert(identity('a'), 1000);
-    await store.release('b');
-    expect((await store.read())?.ownerId).toBe('a');
-    await store.release('a');
-    expect(await store.read()).toBeNull();
-  });
-
-  it('双仲裁器共享同一 DB:任意时刻至多一个持有者,持有者死后另一个接管', async () => {
-    const db = new Database(':memory:');
-    db.exec(DDL);
-    const access = dbAccess(db);
-    let clock = 1_000_000;
-    const now = () => clock;
-    const mk = (id: string) => {
-      const onAcquire = vi.fn();
-      const onDemote = vi.fn();
-      const arbiter = new DeviceLinkOwnershipArbiter({
-        getStore: () => createDbClientOwnershipStore(access),
-        instance: { ownerPid: 100, ownerLabel: 'test' },
-        newOwnerId: () => id,
-        onAcquire,
-        onDemote,
-        heartbeatMs: 5_000,
-        staleMs: 15_000,
-        now,
-      });
-      return { arbiter, onAcquire, onDemote };
-    };
-    const a = mk('a');
-    const b = mk('b');
-
-    // a 先启动 → 持有;b 后启动 → 被动
-    await a.arbiter.tick();
-    await b.arbiter.tick();
-    expect(a.arbiter.isOwner()).toBe(true);
-    expect(b.arbiter.isOwner()).toBe(false);
-
-    // 双方按节奏 tick 两轮:持有权稳定,不互抢
-    for (let i = 0; i < 2; i++) {
-      clock += 5_000;
-      await a.arbiter.tick();
-      await b.arbiter.tick();
+  it('同一文件上至多一把锁;释放后同伴立刻能拿', () => {
+    const { dir, lockPath } = openTempLock();
+    const a = openLock(lockPath);
+    const b = openLock(lockPath);
+    try {
+      expect(a.tryAcquire()).toBe(true);
+      expect(b.tryAcquire()).toBe(false);
+      expect(a.tryAcquire()).toBe(true);
+      a.release();
+      expect(b.tryAcquire()).toBe(true);
+      expect(a.tryAcquire()).toBe(false);
+    } finally {
+      a.release();
+      b.release();
+      rmSync(dir, { recursive: true, force: true });
     }
-    expect(a.arbiter.isOwner()).toBe(true);
-    expect(b.arbiter.isOwner()).toBe(false);
+  });
 
-    // a 卡死(不再 tick),时间推进超过 staleMs → b 接管
-    clock += 16_000;
-    await b.arbiter.tick();
-    expect(b.arbiter.isOwner()).toBe(true);
+  it('持有者关连接(模拟崩溃收尾)后同伴可接手', () => {
+    const { dir, lockPath } = openTempLock();
+    const a = openLock(lockPath);
+    const b = openLock(lockPath);
+    try {
+      expect(a.tryAcquire()).toBe(true);
+      a.release();
+      expect(b.tryAcquire()).toBe(true);
+    } finally {
+      a.release();
+      b.release();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 
-    // a 苏醒后续期失败 → 降级,且不会抢回
-    clock += 1_000;
-    await a.arbiter.tick();
-    expect(a.arbiter.isOwner()).toBe(false);
-    expect(a.onDemote).toHaveBeenCalledTimes(1);
-    clock += 5_000;
-    await a.arbiter.tick();
-    await b.arbiter.tick();
-    expect(a.arbiter.isOwner()).toBe(false);
-    expect(b.arbiter.isOwner()).toBe(true);
+  it('双仲裁器共享同一文件锁:任意时刻至多一个持有者', () => {
+    const { dir, lockPath } = openTempLock();
+    const lockA = openLock(lockPath);
+    const lockB = openLock(lockPath);
+    const a = makeArbiter({ lock: lockA });
+    const b = makeArbiter({ lock: lockB });
+    try {
+      a.arbiter.tick();
+      b.arbiter.tick();
+      expect(a.arbiter.isOwner()).toBe(true);
+      expect(b.arbiter.isOwner()).toBe(false);
+      void a.arbiter.stop();
+      b.arbiter.tick();
+      expect(b.arbiter.isOwner()).toBe(true);
+    } finally {
+      void a.arbiter.stop();
+      void b.arbiter.stop();
+      lockA.release();
+      lockB.release();
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/apps/desktop/src/main/device-link/__tests__/ownership.test.ts
+++ b/apps/desktop/src/main/device-link/__tests__/ownership.test.ts
@@ -11,6 +11,7 @@ import Database from 'better-sqlite3';
 import {
   DeviceLinkOwnershipArbiter,
   createSqliteExclusiveFileLock,
+  isSqliteLockContention,
   type OwnershipLock,
 } from '../ownership';
 
@@ -170,6 +171,24 @@ describe('DeviceLinkOwnershipArbiter', () => {
     }
   });
 
+  it('锁初始化失败(非竞争)→ 不假装他人持有,下一轮再试', () => {
+    const lock: OwnershipLock = {
+      tryAcquire() {
+        throw Object.assign(new Error('disk I/O error'), { code: 'SQLITE_IOERR' });
+      },
+      release() {},
+      isHeld() {
+        return false;
+      },
+    };
+    const { arbiter, onAcquire, onStandbyChanged } = makeArbiter({ lock });
+    arbiter.tick();
+    expect(arbiter.isOwner()).toBe(false);
+    expect(arbiter.isStandby()).toBe(false);
+    expect(onAcquire).not.toHaveBeenCalled();
+    expect(onStandbyChanged).not.toHaveBeenCalled();
+  });
+
   it('失去持有权、接管和 stop 都会翻转待命状态', () => {
     const lock = memoryLock();
     const { arbiter, onStandbyChanged } = makeArbiter({ lock });
@@ -229,6 +248,35 @@ describe('createSqliteExclusiveFileLock', () => {
       b.release();
       rmSync(dir, { recursive: true, force: true });
     }
+  });
+
+  it('SQLITE_BUSY 视为竞争;其它 sqlite 错误向上抛', () => {
+    const { dir, lockPath } = openTempLock();
+    try {
+      const busy = createSqliteExclusiveFileLock(lockPath, () => {
+        throw Object.assign(new Error('database is locked'), { code: 'SQLITE_BUSY' });
+      });
+      expect(busy.tryAcquire()).toBe(false);
+
+      const io = createSqliteExclusiveFileLock(lockPath, () => {
+        throw Object.assign(new Error('disk I/O error'), { code: 'SQLITE_IOERR' });
+      });
+      expect(() => io.tryAcquire()).toThrow(/disk I\/O error/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('isSqliteLockContention 只认忙/锁,不把 IO 错误当占用', () => {
+    expect(
+      isSqliteLockContention(
+        Object.assign(new Error('database is locked'), { code: 'SQLITE_BUSY' }),
+      ),
+    ).toBe(true);
+    expect(
+      isSqliteLockContention(Object.assign(new Error('disk I/O error'), { code: 'SQLITE_IOERR' })),
+    ).toBe(false);
+    expect(isSqliteLockContention(new Error('database is locked'))).toBe(true);
   });
 
   it('双仲裁器共享同一文件锁:任意时刻至多一个持有者', () => {

--- a/apps/desktop/src/main/device-link/index.ts
+++ b/apps/desktop/src/main/device-link/index.ts
@@ -11,6 +11,7 @@
  */
 
 import os from 'node:os';
+import path from 'node:path';
 import { app, BrowserWindow } from 'electron';
 import WebSocket from 'ws';
 import {
@@ -42,13 +43,13 @@ import * as authManager from '../authManager';
 import { getActiveDataOwnerPushStamp } from '../appSessionState.js';
 import { createLogger } from '../logger';
 import { onQuit } from '../lifecycle';
-import { tryGetDbClient } from '../localDb/client/current';
+import { getCurrentUserId } from '../localDb';
 import { createOutboundHttpAgent } from '../maker-host/outbound-fetch';
 import { serverApiFetch } from '../serverApiClient';
 import {
   DeviceLinkOwnershipArbiter,
-  createDbClientOwnershipStore,
-  type OwnershipStore,
+  createSqliteExclusiveFileLock,
+  type OwnershipLock,
 } from './ownership';
 import { DEVICE_LINK_PUSH } from '../../shared/deviceLinkIpc';
 import {
@@ -140,10 +141,7 @@ import {
   pollContactsDeviceSyncSettingChange,
   setContactsDeviceLinkOwnerActive,
 } from '../contacts-sync/driver';
-import {
-  invokeWithClosedLinkRecovery,
-  requiresSessionLink,
-} from './linkRecovery';
+import { invokeWithClosedLinkRecovery, requiresSessionLink } from './linkRecovery';
 import {
   createResponsivenessTracker,
   isDeviceResponsivenessProbeEligible,
@@ -192,10 +190,7 @@ export function beginControllerDisplayNameDirectoryRefresh(): number {
 }
 
 export function isLatestControllerDisplayNameDirectoryRefresh(sequence: number): boolean {
-  return isLatestControllerDisplayNameDirectoryRequest(
-    controllerDisplayNameFreshness,
-    sequence,
-  );
+  return isLatestControllerDisplayNameDirectoryRequest(controllerDisplayNameFreshness, sequence);
 }
 
 export async function waitForNewerControllerDisplayNameDirectoryRefresh(
@@ -302,10 +297,10 @@ async function runControllerDisplayNamesFromDirectory(
       timeoutMs: 10_000,
     });
     if (
-      generation !== controllerDisplayNameRefreshGeneration
-      || !isLatestControllerDisplayNameDirectoryRefresh(directoryRequestSequence)
-      || linkTornDown
-      || client?.getStatus() !== 'online'
+      generation !== controllerDisplayNameRefreshGeneration ||
+      !isLatestControllerDisplayNameDirectoryRefresh(directoryRequestSequence) ||
+      linkTornDown ||
+      client?.getStatus() !== 'online'
     ) {
       return;
     }
@@ -368,16 +363,17 @@ const transportTimeoutReopen = createTransportTimeoutReopenLoop({
   // revokedControllers——那是「对方不再允许控制本机」,与本机主动控制对方
   // 无关;互控且仅反向撤权时重建必须照常。目标侧撤销本机控制权由入站
   // link-close('revoked') 经 routeLinkCloseForReopen 的永久关闭分支终止循环。
-  shouldAbort: (deviceId) => shouldAbortTransportTimeoutReopen({
-    clientOnline: client !== null && client.getStatus() === 'online',
-    isOwner: arbiter === null || arbiter.isOwner(),
-    // 与 openRemoteLink 的 fail-closed 门同源(#1408):本机已对该设备关闭控制
-    // 时不重建,避免把被禁用的链路反复拉起又失败空转。
-    controlDisabledLocally: readDeviceLinkSettings().disabledControlDeviceIds.includes(deviceId),
-    // 方向证据每次尝试前复查:退避等待期间用户可能退掉最后一个订阅 / 关掉窗口
-    // (review P1)。
-    hasOutboundControlIntent: hasOutboundControlIntent(deviceId),
-  }),
+  shouldAbort: (deviceId) =>
+    shouldAbortTransportTimeoutReopen({
+      clientOnline: client !== null && client.getStatus() === 'online',
+      isOwner: arbiter === null || arbiter.isOwner(),
+      // 与 openRemoteLink 的 fail-closed 门同源(#1408):本机已对该设备关闭控制
+      // 时不重建,避免把被禁用的链路反复拉起又失败空转。
+      controlDisabledLocally: readDeviceLinkSettings().disabledControlDeviceIds.includes(deviceId),
+      // 方向证据每次尝试前复查:退避等待期间用户可能退掉最后一个订阅 / 关掉窗口
+      // (review P1)。
+      hasOutboundControlIntent: hasOutboundControlIntent(deviceId),
+    }),
   log: {
     info: (msg) => log.info(msg),
     warn: (msg) => log.warn(msg),
@@ -387,8 +383,32 @@ let arbiter: DeviceLinkOwnershipArbiter | null = null;
 let observedAuthRealm: ReturnType<typeof authManager.getActiveAuthRealm> | null = null;
 let authRealmReconnectGeneration = 0;
 let unsubscribeAuthState: (() => void) | null = null;
-/** ownership store 按 DbClient 实例缓存(避免每 tick 建对象);换库(换账号)自动重建 */
-let ownershipStoreCache: { db: unknown; store: OwnershipStore } | null = null;
+/** 按 userId 缓存文件锁;换账号或登出时释放 */
+let ownershipFileLock: { lockPath: string; lock: OwnershipLock } | null = null;
+
+function closeOwnershipFileLock(): void {
+  if (!ownershipFileLock) return;
+  try {
+    ownershipFileLock.lock.release();
+  } catch (err) {
+    log.warn('ownership file lock release failed', err);
+  }
+  ownershipFileLock = null;
+}
+
+function getOwnershipLock(): OwnershipLock | null {
+  const userId = getCurrentUserId();
+  if (!userId) {
+    closeOwnershipFileLock();
+    return null;
+  }
+  const lockPath = path.join(app.getPath('userData'), `device-link-ownership-${userId}.lock.db`);
+  if (ownershipFileLock?.lockPath !== lockPath) {
+    closeOwnershipFileLock();
+    ownershipFileLock = { lockPath, lock: createSqliteExclusiveFileLock(lockPath) };
+  }
+  return ownershipFileLock.lock;
+}
 /**
  * 本机是否仍在控制该设备 —— 重开链路的**方向判据**(trigger 与每次重试共用)。
  *
@@ -659,7 +679,8 @@ export function initDeviceLinkService(options: DeviceLinkServiceOptions = {}): v
     // 探测直接走 client.invoke(guardInvoke 已在 tracker 内持有探测席位,不能再套
     // remoteInvoke 的外层门禁,否则自旋)。sessions:list 属 UNLINKED legacy 通道,无需 link。
     probeInvoke: (deviceId, channel, args) => {
-      if (!client) throw new Error('[DEVICE_LINK_NOT_CONNECTED] device-link client not initialized');
+      if (!client)
+        throw new Error('[DEVICE_LINK_NOT_CONNECTED] device-link client not initialized');
       return client.invoke(deviceId, { channel, args }, INVOKE_TIMEOUT_OVERRIDES_MS[channel]);
     },
     onUnresponsiveChanged: (deviceId, unresponsive) => {
@@ -674,13 +695,14 @@ export function initDeviceLinkService(options: DeviceLinkServiceOptions = {}): v
     // 探测只在熔断器已经放行 half-open 单飞席位后到达这里；presence 的未知态
     // 必须允许这一个探测穿过，否则 relay 重连清空 presence 后熔断会永久自锁。
     // 只有当代 presence 明确为 false 才阻止，且仍叠加 relay/owner/撤权/本机禁用门。
-    isProbeEligible: (deviceId) => isDeviceResponsivenessProbeEligible({
-      relayOnline: client?.getStatus() === 'online',
-      ownsRelay: arbiter?.isOwner() === true,
-      presenceAvailable: presenceAvailableByDevice.get(deviceId),
-      revoked: revokedByRemote.has(deviceId),
-      locallyDisabled: readDeviceLinkSettings().disabledControlDeviceIds.includes(deviceId),
-    }),
+    isProbeEligible: (deviceId) =>
+      isDeviceResponsivenessProbeEligible({
+        relayOnline: client?.getStatus() === 'online',
+        ownsRelay: arbiter?.isOwner() === true,
+        presenceAvailable: presenceAvailableByDevice.get(deviceId),
+        revoked: revokedByRemote.has(deviceId),
+        locallyDisabled: readDeviceLinkSettings().disabledControlDeviceIds.includes(deviceId),
+      }),
     // observed:false 且是唯一豁免熔断快速拒绝的建链入口:recoverLink 是探测
     // 周期的延伸(业务/探测超时已由 tracker 记账,不重复观测),且 open 期间
     // 必须真正上线重建 link——否则「探测超时→重开 link→下次探测走新链路」的
@@ -690,7 +712,9 @@ export function initDeviceLinkService(options: DeviceLinkServiceOptions = {}): v
     // 下一次触发生效),恢复统一由探测循环驱动。
     recoverLink: (deviceId) => {
       if (revokedByRemote.has(deviceId)) {
-        return Promise.reject(new DeviceLinkError('ACCESS_REVOKED', 'access revoked by target device'));
+        return Promise.reject(
+          new DeviceLinkError('ACCESS_REVOKED', 'access revoked by target device'),
+        );
       }
       return openRemoteLink(deviceId, { observed: false });
     },
@@ -781,7 +805,9 @@ export function initDeviceLinkService(options: DeviceLinkServiceOptions = {}): v
   client.onReliableFrameBeforeLink((deviceId) => {
     if (!hasOutboundControlIntent(deviceId)) return;
     if (readDeviceLinkSettings().disabledControlDeviceIds.includes(deviceId)) return;
-    log.info(`re-opening control link for ${deviceId.slice(0, 8)} after before-link reliable frame`);
+    log.info(
+      `re-opening control link for ${deviceId.slice(0, 8)} after before-link reliable frame`,
+    );
     transportTimeoutReopen.trigger(deviceId);
   });
   client.onPresenceChanged((snap: PresenceSnapshot) => {
@@ -976,10 +1002,11 @@ export function initDeviceLinkService(options: DeviceLinkServiceOptions = {}): v
     },
     listOnlineMobileDevices: () =>
       [...presenceOnlineByDevice.entries()]
-        .filter(([deviceId, online]) =>
-          online &&
-          isMobilePlatform(getControllerPlatform(deviceId)) &&
-          !isDeviceRevoked(deviceId),
+        .filter(
+          ([deviceId, online]) =>
+            online &&
+            isMobilePlatform(getControllerPlatform(deviceId)) &&
+            !isDeviceRevoked(deviceId),
         )
         .map(([deviceId]) => deviceId),
   });
@@ -1021,23 +1048,8 @@ export function initDeviceLinkService(options: DeviceLinkServiceOptions = {}): v
   // 成功的持有者才连 relay,其余被动待命 —— 否则 relay 的 last-wins 顶号语义会
   // 让双活实例无限互踢(4409 循环),手机端远程连接在实例间漂移。见 ./ownership.ts。
   arbiter = new DeviceLinkOwnershipArbiter({
-    // DB 访问必须走 DbClient:worker 接管后 main 侧 raw _db 已被释放(bootstrap
-    // Phase 1.1),getRawDb() 在稳态永久抛错;DbClient 同时覆盖 worker 与 inproc
-    // fallback 两种模式。未就绪(登录初期 / takeover 进行中 / 关库竞态)返回 null →
-    // 仲裁器亚秒级快速重试。store 按 DbClient 实例缓存,换账号换库时自动重建。
-    getStore: () => {
-      const dbClient = tryGetDbClient();
-      if (!dbClient) return null;
-      if (ownershipStoreCache?.db !== dbClient) {
-        ownershipStoreCache = { db: dbClient, store: createDbClientOwnershipStore(dbClient) };
-      }
-      return ownershipStoreCache.store;
-    },
-    // ownerId 由仲裁器生成并按 start() 轮换(防 stale release 误删新行),这里只给诊断字段
-    instance: {
-      ownerPid: process.pid,
-      ownerLabel: `${app.getVersion()}${app.isPackaged ? '' : '-dev'}`,
-    },
+    // 操作系统文件锁:崩溃即释放,不走聊天库,也不再 5s 续期。
+    getLock: getOwnershipLock,
     onAcquire: () => {
       // 认领成功但期间已登出:不连(登出路径已 stop 仲裁,这里是 tick 竞态兜底)
       if (!authManager.getAuthState().isAuthenticated) return;
@@ -1106,6 +1118,7 @@ export function initDeviceLinkService(options: DeviceLinkServiceOptions = {}): v
     'device-link-ownership-release',
     async () => {
       if (pendingQuitOwnershipRelease) await pendingQuitOwnershipRelease;
+      closeOwnershipFileLock();
     },
     'async',
   );
@@ -1602,9 +1615,10 @@ export async function openRemoteLink(
   // 后续 guard 见标不定论):observed 发起、unobserved 发起被多个业务加入者
   // 复用等全部形态都收敛到同一判据,这里不再自行打标。
   const observed = opts?.observed !== false;
-  const request = observed && responsivenessTracker
-    ? responsivenessTracker.guardInvoke(deviceId, OPEN_LINK_OBSERVATION_CHANNEL, doOpen)
-    : doOpen();
+  const request =
+    observed && responsivenessTracker
+      ? responsivenessTracker.guardInvoke(deviceId, OPEN_LINK_OBSERVATION_CHANNEL, doOpen)
+      : doOpen();
   openLinkInFlight.set(deviceId, request);
   const cleanup = (): void => {
     if (openLinkInFlight.get(deviceId) === request) openLinkInFlight.delete(deviceId);

--- a/apps/desktop/src/main/device-link/ownership.ts
+++ b/apps/desktop/src/main/device-link/ownership.ts
@@ -5,174 +5,71 @@
  * (userId, deviceId) 是 last-wins 顶号语义 —— 双活实例会无限互踢(4409 循环),
  * 手机端远程连接在实例间漂移("会话壳建在 A、消息发到 B、回传流丢失")。
  *
- * 方案:以共享 SQLite 的单行表 device_link_ownership 为互斥凭据,first-wins:
- *  - 最早认领成功的实例持有连接权(onAcquire → client.start())。
- *  - 其余实例保持被动:不发起 relay 连接,只按心跳节奏轮询持有者心跳。
- *  - 持有者每 heartbeatMs 用 CAS 续期;续期失败(被接管)立即降级(onDemote)。
- *  - 持有者心跳超过 staleMs 未续(卡死 / 崩溃 / 断电)→ 被动实例 CAS 接管。
- *  - 正常退出 / 登出走 stop() 释放行,幸存实例在下一轮 tick 内接管。
- *  - 单纯网络断线**不**让出持有权:同机的其它实例同样连不上,抢过去只会造成
- *    持有权无谓震荡;持有者保留权利,靠 client 自身的重连自愈。
+ * 方案:对一份很小的锁文件持有操作系统文件锁(SQLite EXCLUSIVE,底层是
+ * fcntl / LockFileEx)。first-wins:
+ *  - 抢到锁的实例持有连接权(onAcquire → client.start())。
+ *  - 其余实例保持被动:不发起 relay 连接,只按 retryMs 再试。
+ *  - 进程崩溃 / 被杀 / 断电 → OS 释放锁,同伴下一轮即可接手,不用等心跳过期。
+ *  - 正常退出 / 登出走 stop() 关连接,锁立刻掉。
+ *  - 单纯网络断线**不**让出持有权:锁在本机,与 relay 无关。
  *
- * 有效性判定只依赖两条硬信号:心跳新鲜度(覆盖卡死 / 死机)与行是否存在
- * (覆盖正常退出 / 登出)。不用 PID 探活(Windows PID 复用不可靠),不做
- * 功能级健康探测(误判成本高于收益)。
+ * 不用心跳租约,也不用 PID 探活。进程冻死但未退出时锁不会掉,同伴不会误抢;
+ * 这是文件锁相对 15s 过期窗口的取舍。
  *
- * DB 访问走 DbClient(async):worker 接管后 main 侧 raw _db 会被释放
- * (bootstrap Phase 1.1),getRawDb() 在稳态不可用,因此 store 基于
- * DbClient.queryOne/exec 的异步接口,同时天然兼容 inproc fallback。
+ * 锁文件按 userId 隔离,不打开聊天库。历史表 device_link_ownership 不再读写。
  *
- * 分层:本模块是纯 main 侧业务逻辑,store 依赖注入(可用内存实现单测),
+ * 分层:本模块是纯 main 侧业务逻辑,锁依赖注入(可用内存实现单测),
  * packages/device-link 保持纯传输层不感知仲裁。
  */
 
-import { randomUUID } from 'node:crypto';
+import type Database from 'better-sqlite3';
+
+import { createBetterSqliteDatabase } from '../localDb/betterSqliteFactory';
 
 import { createLogger } from '../logger';
 
 const log = createLogger('device-link-ownership');
 
-/** device_link_ownership 单行的读取投影 */
-export interface OwnershipRow {
-  ownerId: string;
-  ownerPid: number;
-  heartbeatAt: number;
-}
+/** 被动实例重试抢锁的间隔。崩溃后接管延迟由这一拍决定,不是过期窗口。 */
+export const DEFAULT_LOCK_RETRY_MS = 500;
 
-/** 认领者自述(写入行的内容) */
-export interface OwnershipIdentity {
-  ownerId: string;
-  ownerPid: number;
-  ownerLabel: string | null;
-}
-
-/**
- * 仲裁凭据存取层。所有写操作都是原子 CAS(以 changes 计数判成败),
- * 由 SQLite 单文件写锁保证跨进程互斥。接口 async 以适配 DbClient(worker RPC)。
- */
-export interface OwnershipStore {
-  read(): Promise<OwnershipRow | null>;
-  /** 行不存在时插入(INSERT OR IGNORE);返回是否成功成为持有者 */
-  tryInsert(identity: OwnershipIdentity, now: number): Promise<boolean>;
-  /** CAS 接管:仅当行仍是 expected 的 (ownerId, heartbeatAt) 时改写为自己 */
-  tryTakeover(
-    expected: { ownerId: string; heartbeatAt: number },
-    identity: OwnershipIdentity,
-    now: number,
-  ): Promise<boolean>;
-  /** 续期:仅当行仍属于 ownerId 时刷新心跳;失败即已被接管 */
-  renew(ownerId: string, now: number): Promise<boolean>;
-  /** 释放:仅删除仍属于 ownerId 的行(不许误删他人的持有权) */
-  release(ownerId: string): Promise<void>;
+export interface OwnershipLock {
+  /** 非阻塞:拿到返回 true,已被他人持有返回 false */
+  tryAcquire(): boolean;
+  /** 幂等释放;未持有时是 no-op */
+  release(): void;
+  isHeld(): boolean;
 }
 
 export interface OwnershipArbiterOptions {
   /**
-   * 取当前可用的 store;localDb / DbClient 未就绪(登录初期 / 登出关库竞态)
-   * 返回 null 或 throw,该轮 tick 跳过,靠快速重试 / 下一轮自愈。
+   * 取当前账号对应的锁。登录初期 / 登出关库返回 null,该轮跳过,
+   * 靠 retryMs 自愈。换账号时应返回另一把锁(旧锁由调用方先 release)。
    */
-  getStore: () => OwnershipStore | null;
-  /** 实例描述(诊断字段);ownerId 由仲裁器生成并在每次 start() 轮换,不在此传入 */
-  instance: { ownerPid: number; ownerLabel: string | null };
-  /** 测试注入 ownerId 生成器,默认 randomUUID */
-  newOwnerId?: () => string;
-  /** 成为持有者(首次认领或接管成功)→ 宿主启动 relay 连接 */
+  getLock: () => OwnershipLock | null;
   onAcquire: () => void;
-  /** 失去持有权(续期 CAS 失败,行被他人接管)→ 宿主停止 relay 连接 */
   onDemote: () => void;
-  /** 本机另一个实例持有连接时通知宿主；仅在状态变化时调用。 */
   onStandbyChanged?: (standby: boolean) => void;
-  /** 持有者续期间隔,默认 5s */
-  heartbeatMs?: number;
-  /** 心跳超过该时长未续视为持有者失效,默认 15s(须 > 2×heartbeatMs 留余量) */
-  staleMs?: number;
-  /**
-   * store 不可用(DbClient 未就绪 / 表未迁移)时的快速重试间隔,默认 500ms。
-   * 冷启动时 auth-authenticated 与 DbClient takeover 的到达顺序不固定,若只靠
-   * heartbeatMs 节奏重试,首连最多被推迟一整拍(~5s);快速重试把这个窗口收敛到亚秒级。
-   */
-  storeRetryMs?: number;
-  /**
-   * 单次 store RPC 的超时,默认 = heartbeatMs。DbClient 传输层自身超时(30s)
-   * 远大于 staleMs(15s):不设本地超时的话,一次挂起的 renew 会占住 tick 循环
-   * 直到同伴接管后本实例还在线。超时只中止本轮判定(晚到的 CAS 结果由
-   * reclaimed-own-row 分支自愈),持有者的安全兜底靠独立降级检查。
-   */
-  opTimeoutMs?: number;
-  /** 测试注入时钟 */
-  now?: () => number;
+  retryMs?: number;
 }
-
-export const DEFAULT_HEARTBEAT_MS = 5_000;
-export const DEFAULT_STALE_MS = 15_000;
-export const DEFAULT_STORE_RETRY_MS = 500;
-
-/** store RPC 超时的哨兵值(raceOpTimeout 返回) */
-const OP_TIMEOUT = Symbol('op-timeout');
 
 /**
  * 单持有者仲裁器。生命周期由宿主驱动:
  *  - start():登录后调用,开始参与仲裁(幂等)。
  *  - stop():登出 / 退出时调用,若持有则释放并回调 onDemote。
- * 内部单一定时器按 heartbeatMs 节奏 tick,持有者与被动实例共用同一节奏
- * (被动轮询更密没有收益,staleMs 才是接管延迟的主导项)。
- * tick 为 async(store 是 worker RPC):有 in-flight 防重入,慢 RPC 不会堆积。
+ * 只有被动实例需要定时重试;持有者只在锁丢失或账号切换时降级。
  */
 export class DeviceLinkOwnershipArbiter {
-  private readonly opts: Required<
-    Pick<OwnershipArbiterOptions, 'heartbeatMs' | 'staleMs' | 'storeRetryMs' | 'opTimeoutMs'>
-  > &
-    OwnershipArbiterOptions;
+  private readonly retryMs: number;
+  private readonly opts: OwnershipArbiterOptions;
   private timer: ReturnType<typeof setInterval> | null = null;
-  /**
-   * 当前生命周期的认领身份。每次 start() 轮换 ownerId:上一段生命周期
-   * fire-and-forget 的 release 若在本段重新认领后才落盘,DELETE 按旧 ownerId
-   * 匹配不到新行,不会误删刚认领的持有权。
-   */
-  private identity: OwnershipIdentity;
-  /** start() 递增;in-flight tick 恢复后 epoch 不匹配视为已取消 */
-  private epoch = 0;
-  /** store 不可用时的一次性快速重试(见 storeRetryMs);store 恢复或 stop 时清除 */
-  private storeRetryTimer: ReturnType<typeof setTimeout> | null = null;
   private owner = false;
-  /** stop() 后置位:拦截 in-flight tick 在 await 之后继续改状态。初始未停(tick 只由 start() 的定时器或测试驱动)。 */
   private stopped = false;
-  /** async tick 防重入:上一轮 RPC 未返回时跳过本轮 */
-  private ticking = false;
-  /** 当前 in-flight tick 的完成信号(stop() 需等它,才能收齐取消认领的补释放) */
-  private inFlightTick: Promise<void> | null = null;
-  /** 取消认领的补释放 promise 集合:stop() 返回值必须涵盖(见 stop 注释) */
-  private pendingCancelReleases: Promise<void>[] = [];
-  /**
-   * 最近一次续期成功(或 promote)的时间。持有者若持续无法续期(store 不可用 /
-   * renew 抛错)超过 staleMs - heartbeatMs,必须在同伴按 staleMs 判行过期**之前**
-   * 自我降级停 client —— 否则同伴接管后本实例 client 还活着,4409 互踢卷土重来。
-   */
-  private lastRenewOkAt = 0;
-  /** 已记录过日志的外部持有者,变化才再记(避免被动态每 5s 刷一行) */
-  private loggedForeignOwnerId: string | null = null;
-  /** 是否确知本机另一个实例正持有 device-link。 */
   private standby = false;
 
   constructor(options: OwnershipArbiterOptions) {
-    const heartbeatMs = options.heartbeatMs ?? DEFAULT_HEARTBEAT_MS;
-    const staleMs = options.staleMs ?? DEFAULT_STALE_MS;
-    const storeRetryMs = options.storeRetryMs ?? DEFAULT_STORE_RETRY_MS;
-    const opTimeoutMs = options.opTimeoutMs ?? heartbeatMs;
-    if (staleMs <= heartbeatMs * 2) {
-      // 心跳两拍以内就判失效会把 GC 停顿 / IO 抖动误判成死亡,直接拒绝错误配置
-      throw new Error(`staleMs (${staleMs}) must be > 2 * heartbeatMs (${heartbeatMs})`);
-    }
-    this.opts = { ...options, heartbeatMs, staleMs, storeRetryMs, opTimeoutMs };
-    this.identity = this.buildIdentity();
-  }
-
-  private buildIdentity(): OwnershipIdentity {
-    return {
-      ownerId: (this.opts.newOwnerId ?? randomUUID)(),
-      ownerPid: this.opts.instance.ownerPid,
-      ownerLabel: this.opts.instance.ownerLabel,
-    };
+    this.opts = options;
+    this.retryMs = options.retryMs ?? DEFAULT_LOCK_RETRY_MS;
   }
 
   isOwner(): boolean {
@@ -185,25 +82,14 @@ export class DeviceLinkOwnershipArbiter {
 
   start(): void {
     if (this.timer) return;
-    this.identity = this.buildIdentity(); // 轮换 ownerId,见字段注释
-    this.epoch++;
     this.stopped = false;
-    // 先建定时器再首 tick:首 tick 遇到 store 未就绪时,scheduleStoreRetry 以
-    // this.timer 判断"已启动",顺序反了会漏掉冷启动的快速重试。
     this.timer = setInterval(() => {
-      // 独立降级检查:不依赖 tick 推进(挂起的 RPC 会让 ticking 停留 true),
-      // 用新鲜时钟保证持有者在同伴按 staleMs 判过期之前必然停 client。
-      this.maybeSelfDemoteForRenewFailure((this.opts.now ?? Date.now)());
-      void this.tick();
-    }, this.opts.heartbeatMs);
+      this.tick();
+    }, this.retryMs);
     this.timer.unref?.();
-    void this.tick();
+    this.tick();
   }
 
-  /**
-   * 停止参与仲裁;若当前持有则释放行(fire-and-forget:release 是 RPC,登出 /
-   * 退出路径不宜阻塞;丢失时退化为等 staleMs 过期)并触发 onDemote(宿主据此停 client)。
-   */
   stop(): Promise<void> {
     this.stopped = true;
     if (this.timer) {
@@ -211,268 +97,50 @@ export class DeviceLinkOwnershipArbiter {
       this.timer = null;
     }
     this.setStandby(false);
-    this.clearStoreRetry();
-    let released: Promise<void> = Promise.resolve();
-    {
-      // 无条件按当前 ownerId 释放(而非仅持有时):CAS 可能已落盘但本地尚未
-      // promote(op 超时 / in-flight tick),owner 标志为 false 行却已是我们的。
-      // DELETE WHERE owner_id = self 天然幂等,行不属于我们时是 no-op;且与
-      // 在途 CAS 走同一 DbClient 传输队列(FIFO),晚到的认领会先于本条落盘。
-      const store = this.safeGetStore();
-      if (store) {
-        released = store.release(this.identity.ownerId).catch((err) => {
-          // 退出路径上 DbClient 可能已 dispose;释放失败退化为等心跳过期,不阻断退出
-          log.warn('ownership release failed (fallback to stale expiry)', err);
-        });
-      } else if (this.owner) {
-        log.warn('ownership release skipped: store unavailable (fallback to stale expiry)');
-      }
-    }
+    const lock = this.safeGetLock();
+    lock?.release();
     if (this.owner) this.demote('stopped');
-    // 返回 release 完成信号:登出路径需要在 dispose DbClient 前确保 DELETE 已落盘
-    // (fire-and-forget 会跟 DbClient dispose 竞速);退出等尽力而为路径可不 await。
-    // 必须先等 in-flight tick 收尾:它可能已经 CAS 认领成功但尚未返回,取消后的
-    // 补释放(releaseCanceledClaim)要等它执行完才会出现在 pendingCancelReleases。
-    const inFlight = this.inFlightTick ?? Promise.resolve();
-    const cancelTail = inFlight
-      .catch(() => undefined)
-      .then(() => Promise.all(this.pendingCancelReleases))
-      .then(() => undefined);
-    return Promise.all([released, cancelTail]).then(() => undefined);
+    return Promise.resolve();
   }
 
-  /** 单轮仲裁。异常一律吞掉留给下一轮,绝不让 DB 抖动打断定时器。 */
-  async tick(): Promise<void> {
-    if (this.stopped || this.ticking) return;
-    const store = this.safeGetStore();
-    if (!store) {
-      if (this.owner) {
-        // 持有者拿不到 store(DbClient 崩溃 / 长时间不可用):不能一直揣着 relay
-        // 连接不放 —— 同伴会在 staleMs 后按过期接管,若本实例 client 还活着就
-        // 回到 4409 互踢。超过自我降级期限(< staleMs)先停 client 保安全。
-        this.maybeSelfDemoteForRenewFailure((this.opts.now ?? Date.now)());
-      } else {
-        // DB 未就绪时保留最近一次已确认的 standby 事实,避免短暂故障把“另一实例占用”
-        // 错误地洗成普通离线;DB 恢复后的明确 ownership 结果再推进状态。
-        // 同时排一次快速重试,把冷启动首连延迟从一整拍收敛到亚秒级。
-        this.scheduleStoreRetry();
-      }
+  /** 单轮仲裁。异常一律吞掉留给下一轮。 */
+  tick(): void {
+    if (this.stopped) return;
+    const lock = this.safeGetLock();
+    if (!lock) {
+      if (this.owner) this.demote('lock-unavailable');
       return;
     }
-    this.clearStoreRetry();
-
-    this.ticking = true;
-    const run = this.runTick(store);
-    this.inFlightTick = run;
-    try {
-      await run;
-    } finally {
-      if (this.inFlightTick === run) this.inFlightTick = null;
+    if (this.owner) {
+      if (!lock.isHeld()) this.demote('lock-lost');
+      return;
     }
-  }
-
-  private async runTick(store: OwnershipStore): Promise<void> {
-    // 捕获本轮的身份与 epoch:await 期间可能发生 stop()+start()(身份已轮换),
-    // 恢复后必须用捕获值判断取消并释放,不能用 this.identity(可能已是新身份)。
-    const id = this.identity;
-    const epoch = this.epoch;
-    const canceled = (): boolean => this.stopped || this.epoch !== epoch;
-    const now = (this.opts.now ?? Date.now)();
+    let acquired = false;
     try {
-      if (this.owner) {
-        const renewed = await this.raceOpTimeout(store.renew(id.ownerId, now));
-        if (canceled()) return; // await 期间被 stop:行由 stop() 的 release 收口
-        if (renewed === OP_TIMEOUT) {
-          // 传输层挂起(其自身超时 30s > staleMs):中止本轮,安全性由定时器里的
-          // 独立降级检查兜底(距上次续期成功超限即停 client)
-          log.warn('ownership renew timed out locally, aborting round');
-          return;
-        }
-        if (!renewed) {
-          // 行被他人接管(如睡眠唤醒期间心跳过期被抢):安静让位,绝不抢回
-          log.warn('ownership lost (heartbeat superseded), demoting');
-          this.demote('superseded');
-          return;
-        }
-        this.lastRenewOkAt = now;
-        return;
-      }
-
-      const row = await this.raceOpTimeout(store.read());
-      if (canceled()) return;
-      if (row === OP_TIMEOUT) {
-        log.warn('ownership read timed out locally, aborting round');
-        return;
-      }
-      if (!row) {
-        this.setStandby(false);
-        const insertPromise = store.tryInsert(id, now);
-        const inserted = await this.raceOpTimeout(insertPromise);
-        if (inserted === OP_TIMEOUT) {
-          // CAS 可能晚落盘:活着则下一轮 read 走 reclaimed-own-row 自愈;
-          // 若在那之前 stop,晚到的成功认领必须有人补释放,否则行滞留到 staleMs
-          this.trackLateClaim(insertPromise, store, id.ownerId);
-          log.warn('ownership tryInsert timed out locally, aborting round');
-          return;
-        }
-        if (inserted) {
-          // 认领窗口内被 stop:此时 this.owner 仍为 false,stop() 不会释放这条
-          // 刚写入的行;不补释放的话它会以新鲜心跳滞留,幸存实例只能等 staleMs
-          // 过期,抵消 onBeforeLogout 争取的秒级接管。
-          if (canceled()) {
-            this.releaseCanceledClaim(store, id.ownerId);
-            return;
-          }
-          this.promote('claimed-empty');
-        }
-        return;
-      }
-      if (row.ownerId === id.ownerId) {
-        // 自己的行但本地状态是被动(本 start 周期内 promote 前的重入窗口):续上并恢复持有
-        const reclaimed = await this.raceOpTimeout(store.renew(id.ownerId, now));
-        if (reclaimed === OP_TIMEOUT) {
-          log.warn('ownership reclaim renew timed out locally, aborting round');
-          return;
-        }
-        if (reclaimed) {
-          if (canceled()) {
-            this.releaseCanceledClaim(store, id.ownerId);
-            return;
-          }
-          this.promote('reclaimed-own-row');
-        }
-        return;
-      }
-      if (this.loggedForeignOwnerId !== row.ownerId) {
-        this.loggedForeignOwnerId = row.ownerId;
-        log.info(
-          `device-link owned by another instance (pid=${row.ownerPid}), standing by — this instance will not connect to relay`,
-        );
-      }
-      if (now - row.heartbeatAt > this.opts.staleMs) {
-        // 持有者失效(卡死 / 崩溃 / 断电);CAS 保证多个被动实例只有一个接管成功
-        const takeoverPromise = store.tryTakeover(
-          { ownerId: row.ownerId, heartbeatAt: row.heartbeatAt },
-          id,
-          now,
-        );
-        const takenRaw = await this.raceOpTimeout(takeoverPromise);
-        if (takenRaw === OP_TIMEOUT) {
-          // 晚落盘的接管:活着由下一轮 reclaimed-own-row 自愈;stop 前需登记补释放
-          this.trackLateClaim(takeoverPromise, store, id.ownerId);
-          log.warn('ownership takeover timed out locally, aborting round');
-          return;
-        }
-        const taken = takenRaw;
-        if (canceled()) {
-          if (taken) this.releaseCanceledClaim(store, id.ownerId);
-          return;
-        }
-        if (taken) this.promote(`takeover-stale(prev pid=${row.ownerPid})`);
-        return;
-      }
-      // 持有者心跳新鲜 → 保持被动,不抢。过期行会直接尝试接管，不先闪一次待命提示。
-      this.setStandby(true);
+      acquired = lock.tryAcquire();
     } catch (err) {
-      log.warn('ownership tick failed (will retry next tick)', err);
-      // 持有者续期持续抛错(如 DbClient worker 崩溃):与 store 不可用同栏,
-      // 超过自我降级期限先停 client,避免同伴按 staleMs 接管后回到互踢。
-      // 用新鲜时钟 —— 本轮的 now 是 await 之前捕获的,RPC 拖延后已经过时。
-      this.maybeSelfDemoteForRenewFailure((this.opts.now ?? Date.now)());
-    } finally {
-      this.ticking = false;
+      log.warn('ownership lock acquire failed (will retry)', err);
+      return;
     }
+    if (acquired) {
+      this.promote();
+      return;
+    }
+    this.setStandby(true);
   }
 
-  /**
-   * 持有者续期失败链的自我降级期限:staleMs - heartbeatMs,严格早于同伴判定
-   * 行过期的 staleMs(构造器保证 staleMs > 2×heartbeatMs,余量 ≥ 一拍),
-   * 确保同伴接管上线时本实例 client 已停,不产生双连接互踢。
-   */
-  private maybeSelfDemoteForRenewFailure(now: number): void {
-    if (!this.owner) return;
-    if (now - this.lastRenewOkAt <= this.opts.staleMs - this.opts.heartbeatMs) return;
-    log.warn(
-      'ownership renew unreachable beyond safety margin, self-demoting before peers treat row as stale',
-    );
-    this.demote('renew-unreachable');
-  }
-
-  /** 认领窗口内被 stop()/重启:刚写成功的行立刻补一次释放,避免遗留新鲜心跳的孤儿行 */
-  private releaseCanceledClaim(store: OwnershipStore, ownerId: string): void {
-    // 记入 pendingCancelReleases:stop() 的返回值必须涵盖这条 DELETE,否则登出 /
-    // 退出路径可能在它落盘前就 dispose DbClient,新鲜行滞留到 staleMs 才被接管
-    const released = store.release(ownerId).catch((err) => {
-      log.warn('ownership release of canceled claim failed (fallback to stale expiry)', err);
-    });
-    this.pendingCancelReleases.push(released);
-  }
-
-  /**
-   * store RPC 加本地超时:超时返回 OP_TIMEOUT 哨兵,本轮判定中止。
-   * 晚到的结果无需善后 —— Promise.race 已订阅原 promise(rejection 不会变成
-   * unhandled),晚落盘的 CAS 由下一轮 reclaimed-own-row 分支自愈。
-   */
-  private raceOpTimeout<T>(p: Promise<T>): Promise<T | typeof OP_TIMEOUT> {
-    let timer: ReturnType<typeof setTimeout> | undefined;
-    const timeout = new Promise<typeof OP_TIMEOUT>((resolve) => {
-      timer = setTimeout(() => resolve(OP_TIMEOUT), this.opts.opTimeoutMs);
-      timer.unref?.();
-    });
-    return Promise.race([p, timeout]).finally(() => clearTimeout(timer));
-  }
-
-  /**
-   * 登记一条本地超时后仍在途的 CAS 认领:settle 后若实例已停止 / 身份已轮换,
-   * 晚到的成功认领要补释放(否则行以本轮 ownerId 滞留到 staleMs);实例仍活着且
-   * 身份未变则不动,留给下一轮 reclaimed-own-row 正常接管。整条链记入
-   * pendingCancelReleases,stop() 的返回值会等它 settle。
-   */
-  private trackLateClaim(claim: Promise<boolean>, store: OwnershipStore, ownerId: string): void {
-    const settled = claim
-      .then((ok) => {
-        if (!ok) return undefined;
-        if (this.stopped || this.identity.ownerId !== ownerId) {
-          return store.release(ownerId).catch((err) => {
-            log.warn('late claim release failed (fallback to stale expiry)', err);
-          });
-        }
-        return undefined;
-      })
-      .catch(() => undefined)
-      .then(() => undefined);
-    this.pendingCancelReleases.push(settled);
-  }
-
-  private safeGetStore(): OwnershipStore | null {
+  private safeGetLock(): OwnershipLock | null {
     try {
-      return this.opts.getStore();
+      return this.opts.getLock();
     } catch {
       return null;
     }
   }
 
-  private scheduleStoreRetry(): void {
-    if (this.storeRetryTimer || !this.timer) return; // 已排队 / 未 start
-    this.storeRetryTimer = setTimeout(() => {
-      this.storeRetryTimer = null;
-      void this.tick();
-    }, this.opts.storeRetryMs);
-    this.storeRetryTimer.unref?.();
-  }
-
-  private clearStoreRetry(): void {
-    if (this.storeRetryTimer) {
-      clearTimeout(this.storeRetryTimer);
-      this.storeRetryTimer = null;
-    }
-  }
-
-  private promote(reason: string): void {
+  private promote(): void {
     this.owner = true;
-    this.lastRenewOkAt = (this.opts.now ?? Date.now)();
     this.setStandby(false);
-    log.info(`became device-link owner (${reason})`);
+    log.info('became device-link owner (file-lock)');
     try {
       this.opts.onAcquire();
     } catch (err) {
@@ -482,7 +150,7 @@ export class DeviceLinkOwnershipArbiter {
 
   private demote(reason: string): void {
     this.owner = false;
-    this.setStandby(reason === 'superseded');
+    this.setStandby(reason !== 'stopped' && reason !== 'lock-unavailable');
     log.info(`no longer device-link owner (${reason})`);
     try {
       this.opts.onDemote();
@@ -502,62 +170,59 @@ export class DeviceLinkOwnershipArbiter {
   }
 }
 
-// ─── DbClient store 实现 ──────────────────────────────────────────────────────
-
 /**
- * store 需要的最小 DB 访问面(DbClient 的结构子集):worker 接管后 main 侧
- * raw _db 已释放,必须走 DbClient 的 async RPC;inproc fallback 模式下
- * DbClient 内部仍用 main 侧连接,两种模式同一接口。
+ * 用独立小库持有 SQLite EXCLUSIVE 锁。聊天库完全不参与。
+ * busy_timeout=0:抢不到立刻失败,由仲裁器下一拍再试。
  */
-export interface OwnershipDbAccess {
-  queryOne<T = unknown>(sql: string, params?: unknown[]): Promise<T | undefined>;
-  exec(sql: string, params?: unknown[]): Promise<{ changes: number }>;
-}
+export function createSqliteExclusiveFileLock(
+  lockPath: string,
+  openDatabase?: (lockPath: string) => Database.Database,
+): OwnershipLock {
+  const open =
+    openDatabase ??
+    ((file) =>
+      createBetterSqliteDatabase(file, {
+        timeout: 0,
+      }));
+  let db: Database.Database | null = null;
 
-/**
- * 基于 DbClient 的 store。全部走原子单语句,依赖 SQLite 单文件写锁做跨进程
- * 互斥;不开显式事务(单语句已原子)。语句编译缓存由 worker 端负责,这里
- * 无 per-store 状态,但调用方仍应按 DbClient 实例缓存复用,避免每 tick 建对象。
- */
-export function createDbClientOwnershipStore(db: OwnershipDbAccess): OwnershipStore {
+  const closeQuietly = (handle: Database.Database): void => {
+    try {
+      handle.exec('ROLLBACK');
+    } catch {
+      // 没有事务
+    }
+    try {
+      handle.close();
+    } catch {
+      // 已关
+    }
+  };
+
   return {
-    async read(): Promise<OwnershipRow | null> {
-      const row = await db.queryOne<{ owner_id: string; owner_pid: number; heartbeat_at: number }>(
-        'SELECT owner_id, owner_pid, heartbeat_at FROM device_link_ownership WHERE id = 1',
-      );
-      if (!row) return null;
-      return { ownerId: row.owner_id, ownerPid: row.owner_pid, heartbeatAt: row.heartbeat_at };
+    tryAcquire() {
+      if (db) return true;
+      let handle: Database.Database | null = null;
+      try {
+        handle = open(lockPath);
+        handle.pragma('journal_mode = DELETE');
+        handle.pragma('busy_timeout = 0');
+        handle.exec('BEGIN EXCLUSIVE');
+        handle.exec('CREATE TABLE IF NOT EXISTS ownership_lock (id INTEGER PRIMARY KEY NOT NULL)');
+        db = handle;
+        return true;
+      } catch {
+        if (handle) closeQuietly(handle);
+        return false;
+      }
     },
-    async tryInsert(identity, now): Promise<boolean> {
-      const r = await db.exec(
-        'INSERT INTO device_link_ownership (id, owner_id, owner_pid, owner_label, heartbeat_at) VALUES (1, ?, ?, ?, ?) ON CONFLICT(id) DO NOTHING',
-        [identity.ownerId, identity.ownerPid, identity.ownerLabel, now],
-      );
-      return r.changes > 0;
+    release() {
+      if (!db) return;
+      closeQuietly(db);
+      db = null;
     },
-    async tryTakeover(expected, identity, now): Promise<boolean> {
-      const r = await db.exec(
-        'UPDATE device_link_ownership SET owner_id = ?, owner_pid = ?, owner_label = ?, heartbeat_at = ? WHERE id = 1 AND owner_id = ? AND heartbeat_at = ?',
-        [
-          identity.ownerId,
-          identity.ownerPid,
-          identity.ownerLabel,
-          now,
-          expected.ownerId,
-          expected.heartbeatAt,
-        ],
-      );
-      return r.changes > 0;
-    },
-    async renew(ownerId, now): Promise<boolean> {
-      const r = await db.exec(
-        'UPDATE device_link_ownership SET heartbeat_at = ? WHERE id = 1 AND owner_id = ?',
-        [now, ownerId],
-      );
-      return r.changes > 0;
-    },
-    async release(ownerId): Promise<void> {
-      await db.exec('DELETE FROM device_link_ownership WHERE id = 1 AND owner_id = ?', [ownerId]);
+    isHeld() {
+      return db !== null;
     },
   };
 }

--- a/apps/desktop/src/main/device-link/ownership.ts
+++ b/apps/desktop/src/main/device-link/ownership.ts
@@ -18,6 +18,11 @@
  *
  * 锁文件按 userId 隔离,不打开聊天库。历史表 device_link_ownership 不再读写。
  *
+ * 混版本不回写旧租约:旧进程只认那张表,新进程只认文件锁,两边互相看不见。
+ * 同 userData 的 official+dev 若一个仍走心跳、一个已换文件锁,会双连 relay
+ * (4409)。同版本之间由文件锁仲裁;跨版本请用 --isolated,或先退出旧进程。
+ * 不双写旧表 —— 那会重新绑上聊天库,并让「谁是持有者」出现两套判据。
+ *
  * 分层:本模块是纯 main 侧业务逻辑,锁依赖注入(可用内存实现单测),
  * packages/device-link 保持纯传输层不感知仲裁。
  */
@@ -32,6 +37,29 @@ const log = createLogger('device-link-ownership');
 
 /** 被动实例重试抢锁的间隔。崩溃后接管延迟由这一拍决定,不是过期窗口。 */
 export const DEFAULT_LOCK_RETRY_MS = 500;
+
+function sqliteErrorCode(err: unknown): string {
+  if (!err || typeof err !== 'object' || !('code' in err)) return '';
+  return String((err as { code: unknown }).code);
+}
+
+/** SQLITE_BUSY / LOCKED 是同伴持锁;其它错误不能当成「有人占用」。 */
+export function isSqliteLockContention(err: unknown): boolean {
+  const code = sqliteErrorCode(err);
+  if (
+    code === 'SQLITE_BUSY' ||
+    code === 'SQLITE_LOCKED' ||
+    code === 'SQLITE_BUSY_SNAPSHOT' ||
+    code === 'SQLITE_BUSY_RECOVERY' ||
+    code === 'SQLITE_BUSY_TIMEOUT' ||
+    code === '5' ||
+    code === '6'
+  ) {
+    return true;
+  }
+  const message = err instanceof Error ? err.message : String(err);
+  return /database is locked|SQLITE_BUSY|SQLITE_LOCKED/i.test(message);
+}
 
 export interface OwnershipLock {
   /** 非阻塞:拿到返回 true,已被他人持有返回 false */
@@ -211,9 +239,11 @@ export function createSqliteExclusiveFileLock(
         handle.exec('CREATE TABLE IF NOT EXISTS ownership_lock (id INTEGER PRIMARY KEY NOT NULL)');
         db = handle;
         return true;
-      } catch {
+      } catch (err) {
         if (handle) closeQuietly(handle);
-        return false;
+        if (isSqliteLockContention(err)) return false;
+        log.warn('ownership lock initialize failed', err);
+        throw err;
       }
     },
     release() {


### PR DESCRIPTION
## 这次改了什么

### 摘要

本机多开 Cindy 时，device-link 持有权不再每 5 秒去聊天库续期。改为对一份按账号隔离的小锁文件持有操作系统文件锁：谁先锁上谁连远程，进程一死锁自动掉。这样侧栏刷任务再慢，也不会误判成「续期失败」把整条远程连接拆掉。

现场：7GB 消息库上 `sessions.list` 经常 4–8 秒，挡住同一条 DB worker 里的 5 秒续期，正式版大约每 15 秒自我降权，本机到 Mac mini 的请求发不出去。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：本机连 Mac mini 时 device-link 持有权被 `sessions.list` 挤超时
- 本 PR 包含：用 SQLite EXCLUSIVE（底层 `fcntl` / `LockFileEx`）替代 `device_link_ownership` 心跳租约；被动实例每 500ms 重试抢锁；锁初始化失败与同伴占用分开处理
- 明确不包含：缩小聊天库、优化 `sessions.list`、修改 relay / wire 协议、回写旧心跳表做混版本兼容（见风险）
- 用户可见变化：同机多开时远程连接应更稳；崩溃后另一实例接手更快（不必等 15 秒过期）
- 是否存在 breaking change：无。历史表 `device_link_ownership` 仍在 schema 里，只是不再读写

### UI 变化

- 引用的设计规范：不涉及：只改 main 进程持有权仲裁，无界面、文案、交互变化

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：PASS apps/desktop unit（related 3 个文件，ownership 16 tests）

pnpm --filter desktop run typecheck
结果：通过

pnpm check:dco
结果：2 commits signed off
```

`run-unit-gate.sh` 退回了更大范围的 unit，其中 `apps/mobile` 的 `startupSplashOverlay.test.ts` 超时失败。该测试与本 diff 无关；干净 main 上此前也出现过同类超时。未把它混进本 PR 修复。

### 手工验证

未在正式版 / 双机实机验证。需要装到本机与 Mac mini 后看：侧栏狂刷时本机不再每 15 秒 `renew-unreachable` / `device-link stopped`，对 Mac mini 的 `sessions:list` 能发出去。

### 未执行的验证

- 未起隔离开发版连真实 Mac mini
- 未在 Windows 上实机验证文件锁（单测覆盖了同文件两把锁互斥）
- 未验证进程冻死但未退出时同伴无法接手（文件锁的已知取舍）
- 未验证「正式版仍走旧心跳 + 本分支共库」的混版本双开（明确不支持，见下）

## 风险

### 风险分类

- [x] SQLite / migration
- [x] 跨平台差异
- [x] 其他：device-link 同机持有权恢复路径

### 远程与手机（故障半径）

1. **触发哪一层：** 本机持有权误判（DB worker 被 `sessions.list` 堵住），不是单 peer、也不是 relay 背压。
2. **恢复动作在哪一层：** 更小。不再因本地续期超时拆整条 relay；崩溃改由 OS 放锁，同伴 500ms 内可接手。
3. **多 peer：** 本 PR 不改 per-peer 传输 / ACK / 拆连接。同机双实例抢锁由新单测覆盖；未再加「两台手机共享被控端」传输用例，因为传输半径没变。

### 影响与回滚

- 影响范围：Desktop 同机多实例谁连 relay；锁文件在 userData 下 `device-link-ownership-<userId>.lock.db`。不改协议、不改 migration、不改手机包指纹。
- 回滚 / 降级方式：回退本 commit 即回到心跳租约。旧表仍在，无需 migration 回滚。
- 存量插件影响：无
- 跨平台：锁经 better-sqlite3，macOS/Linux 走 POSIX 锁，Windows 走 LockFileEx。进程冻死未退出时锁不掉，同伴不会误抢。
- 混版本：旧进程只认 `device_link_ownership`，新进程只认文件锁。正式版之间仍是单实例；dev+release 共库在两边都升到本改动后走同一把文件锁。跨版本请用 `--isolated` 或先退出旧进程，不双写旧表。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
