### PR TITLE
fix(mobile): 修复热更后整包版本回退

### DIFF
--- a/apps/mobile/src/__tests__/clientEndpointStartup.test.ts
+++ b/apps/mobile/src/__tests__/clientEndpointStartup.test.ts
@@ -97,10 +97,28 @@ describe('runStartupEndpointResolve(CDN 解析)', () => {
     ).resolves.toEqual({ ok: true, source: 'cdn' });
   });
 
+  it('二进制版本优先读原生 0.1.2，不被 OTA manifest 的 0.1.0 覆盖', async () => {
+    vi.resetModules();
+    vi.doMock('expo-application', () => ({
+      nativeApplicationVersion: '0.1.2',
+    }));
+    vi.doMock('expo-constants', () => ({
+      default: { expoConfig: { version: '0.1.0' } },
+    }));
+    try {
+      const env = await import('@/config/env');
+      expect(env.APP_BINARY_VERSION).toBe('0.1.2');
+    } finally {
+      vi.doUnmock('expo-application');
+      vi.doUnmock('expo-constants');
+      vi.resetModules();
+    }
+  });
+
   it('清单 review 命中二进制版本号且非 TestFlight → REVIEW_MODE=true', async () => {
     vi.resetModules();
     vi.doMock('expo-constants', () => ({
-      default: { expoConfig: { version: '9.9.9' }, nativeAppVersion: '9.9.9' },
+      default: { expoConfig: { version: '9.9.9' } },
     }));
     try {
       const env = await import('@/config/env');

--- a/apps/mobile/src/__tests__/expo-application.mock.ts
+++ b/apps/mobile/src/__tests__/expo-application.mock.ts
@@ -1,0 +1,1 @@
+export const nativeApplicationVersion: string | null = null;

--- a/apps/mobile/src/config/env.ts
+++ b/apps/mobile/src/config/env.ts
@@ -1,3 +1,4 @@
+import * as Application from 'expo-application';
 import Constants from 'expo-constants';
 
 import {
@@ -268,9 +269,10 @@ syncBuildTokenEndpointCache();
 
 // 二进制版本号:审核模式匹配基准。优先原生层版本(iOS CFBundleShortVersionString /
 // Android versionName,OTA 热更后不漂移),expoConfig.version 兜底(dev / 测试环境
-// 拿不到原生值)。与 mobileTapdb 的版本上报取值口径一致。
+// 拿不到原生值)。expo-application 已由现有 expo-auth-session / expo-notifications
+// 链进存量整包;这里只消费现成原生模块,不改 package.json / runtime fingerprint。
 export const APP_BINARY_VERSION = (
-  Constants.nativeAppVersion ??
+  Application.nativeApplicationVersion ??
   Constants.expoConfig?.version ??
   ''
 ).trim();

--- a/apps/mobile/vitest.config.ts
+++ b/apps/mobile/vitest.config.ts
@@ -29,6 +29,9 @@ export default defineConfig({
       // (checkout 路径含空格时 alias 指向不存在的 %20 路径,255 个测试文件整体
       // TEST_COLLECT_FAILED);无空格路径下两者逐字节一致,CI 行为零变化。
       '@': fileURLToPath(new URL('./src', import.meta.url)),
+      'expo-application': fileURLToPath(
+        new URL('./src/__tests__/expo-application.mock.ts', import.meta.url),
+      ),
       'expo-constants': fileURLToPath(new URL('./src/__tests__/expo-constants.mock.ts', import.meta.url)),
       // expo-localization 同款处理:真模块拖 react-native(Flow 语法)依赖链;
       // 需要控制语言的测试用 vi.mock 覆盖(优先于 alias)。


### PR DESCRIPTION
## 这次改了什么

### 摘要

设置页的“整包版本”原本在原生版本取不到时回退到 `Constants.expoConfig.version`。OTA 热更后，该值来自热更 manifest，可能从整包的 0.1.2 变成热更发布时的 0.1.0。

本 PR 改为优先读取 `expo-application` 的 `nativeApplicationVersion`（iOS `CFBundleShortVersionString` / Android `versionName`），并补充“原生 0.1.2 + OTA manifest 0.1.0”的回归测试。该模块已由现有依赖链进入整包，本次不新增原生依赖。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：自建线 iOS 整包 0.1.2 经一次热更后，设置页整包版本回退为 0.1.0
- 本 PR 包含：修正 Mobile 整包版本的数据源；补充 OTA 回退回归测试及测试 mock
- 明确不包含：原生配置、原生依赖、Expo/EAS 配置、lockfile、OTA 更新机制改动
- 用户可见变化：热更前后设置页整包版本均保持真实原生整包版本（例如 0.1.2）
- 是否存在 breaking change：无

### UI 变化

不涉及：仅修正已有设置字段的数据源，无视觉、交互或文案变化。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
PATH=/tmp/cindy-node-v22.23.2/node-v22.23.2-darwin-arm64/bin:$PATH TMPDIR=/private/tmp pnpm test:unit:related
结果：通过；所有 required workspace 均为 PASS（含 apps/desktop、apps/mobile、packages/maker-core、packages/maker-pi-manager）

pnpm --filter mobile run --if-present typecheck
结果：通过

node apps/mobile/scripts/ci-fingerprint.mjs compute --output <临时文件>
结果：改动前后指纹一致
- iOS: e546aeba6cd3caaeb1c2c747df05704bcfc0d913
- Android: e32303018a056a53a00839069914afef2ddc6135
```

Mobile 定向回归测试 43/43 通过；Mobile 完整单测通过。

### 手工验证

不涉及：未启动 Metro 或模拟器；回归测试直接覆盖“原生版本 0.1.2、OTA manifest 版本 0.1.0”的故障组合。

### 未执行的验证

未执行 iOS 真机/模拟器手工热更流程。分支为 `fix/mobile-native-binary-version`；本次未启动 Metro，无 `__DEV__` build label 证据。变更为纯 JS/TS 数据源切换，且 runtime fingerprint 已确认不变。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [x] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Mobile 设置页及审核模式使用的整包版本读取口径。iOS 与 Android 均读取各自原生版本字段。
- 冷更影响：无。本 PR 不修改 `package.json`、lockfile、Expo/EAS 配置、config plugin 或原生模块；iOS/Android fingerprint 均保持不变，不触发冷更。
- 回滚 / 降级方式：回滚本提交即可恢复旧取值逻辑；不涉及数据迁移或用户数据。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在「UI 变化」注明引用的设计规范（不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次无需新增文档）
- [x] 已确认测试结果或说明未执行原因
