### PR TITLE
fix(desktop): 修复自动化任务来源切换保存

### DIFF
--- a/apps/desktop/src/renderer/features/scheduler/lib/__tests__/scheduleFormLogic.test.ts
+++ b/apps/desktop/src/renderer/features/scheduler/lib/__tests__/scheduleFormLogic.test.ts
@@ -448,8 +448,11 @@ describe('buildScheduleInput — 非 heartbeat 分支(行为锁定,不动 create
     expect(hasKey(input, 'effort')).toBe(false);
   });
 
-  it('空 providerId 不带 key(= 原生默认来源,no-break);显式值才带', () => {
-    expect(hasKey(buildScheduleInput(makeForm()), 'providerId')).toBe(false);
+  it('空 providerId 恒带 key 且值为 undefined（编辑回原生默认来源 → patch 清列）', () => {
+    const unpinned = buildScheduleInput(makeForm());
+    expect(hasKey(unpinned, 'providerId')).toBe(true);
+    expect(unpinned.providerId).toBeUndefined();
+
     const pinned = buildScheduleInput(makeForm({ providerId: 'anthropic' }));
     expect(pinned.providerId).toBe('anthropic');
   });

--- a/apps/desktop/src/renderer/features/scheduler/lib/scheduleFormLogic.ts
+++ b/apps/desktop/src/renderer/features/scheduler/lib/scheduleFormLogic.ts
@@ -548,7 +548,9 @@ export function buildScheduleInput(form: ScheduleFormState): CreateScheduleInput
   if (form.workspaceKind === 'project') base.workingDir = form.workingDir.trim();
   else base.useWorktree = false;
   if (form.model.trim()) base.model = form.model.trim();
-  if (form.providerId.trim()) base.providerId = form.providerId.trim();
+  // providerId 是可清除的来源 override：表单选回原生默认来源时值为空，仍须保留 key，
+  // 让 update patch 按「key 在 + undefined」把旧 provider_id 清成 NULL。
+  base.providerId = form.providerId.trim() || undefined;
   if (form.effort && isEffortValue(form.effort)) base.effort = form.effort;
   // fastMode 对 Codex / Pi 都生效(runner.ts:665 明确 claude-code 忽略此字段);只序列化
   // codex 会让用户在 Pi 任务里开的 Fast 被静默丢弃(codex review)。表单侧 Fast 开关已按


### PR DESCRIPTION
## 这次改了什么

### 摘要

自动化任务从显式 Cindy/XD 来源切换到 OpenAI OAuth 时，表单会用空 `providerId` 表示原生默认来源，但更新 payload 省略了该字段，导致数据库继续保留旧的 `provider_id`。

本次让非 heartbeat 任务在 `providerId` 为空时仍保留 key，由 storage 的 patch 契约将旧来源清为 `NULL`，并补充对应回归测试。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：自动化任务表单的来源字段序列化，以及对应回归测试
- 明确不包含：运行时路由策略、数据库 schema 或 migration 调整
- 用户可见变化：编辑自动化任务并从 Cindy/XD 来源切回 OpenAI OAuth 后，重新打开会保持新选择
- 是否存在 breaking change：无

### UI 变化

不涉及：未修改界面视觉、布局、交互入口或 UI 文案，仅修复已有来源选择的保存结果。

- 引用的设计规范：不涉及：纯表单序列化逻辑修复，无视觉、交互或文案变化。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/renderer/features/scheduler/lib/__tests__/scheduleFormLogic.test.ts
结果：通过，77 个测试全部通过

pnpm test:unit:related
结果：通过，Desktop related 测试通过

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm check:dco
结果：通过，1 个 commit 已签名
```

### 手工验证

Windows Global 隔离沙盒中，先将自动化任务保存为 Cindy/XD 来源，再编辑为 OpenAI OAuth 并保存；重新打开后仍保持 OpenAI OAuth，验收通过。

### 未执行的验证

- 未在本地运行全仓 `pnpm test:unit`；按仓库流程由 GitHub CI 执行完整单测。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Desktop 自动化任务编辑时清除来源 override 的保存路径
- 回滚 / 降级方式：回滚本 PR 即恢复原行为；不涉及数据迁移
- 移动端冷更：不涉及 `apps/mobile`、原生配置、原生依赖或 runtime fingerprint，不会触发冷更

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次无需新增文档）
- [x] 已确认测试结果或说明未执行原因