### PR TITLE
fix(settings): 用量历史的任务名不再把看板横向撑开

### DIFF
--- a/apps/desktop/src/renderer/components/settings/usage/UsageTaskTable.tsx
+++ b/apps/desktop/src/renderer/components/settings/usage/UsageTaskTable.tsx
@@ -46,18 +46,23 @@ const UNKNOWN_VALUE = '—';
 
 /**
  * 列宽口径: 右侧五列 (模型/供应商/token/上下文/最后活跃) 都是短的定长内容, 让它们
- * 按各自内容取满宽 —— 这几列是要被读数的, 不能被挤窄或截断; pl-4 是列间距, 否则
+ * 按各自内容取满宽 —— 这几列是要被读数的, 不能被挤窄或截断; pl-3 是列间距, 否则
  * 相邻两列的数字会贴到一起。任务名是用户输入的自由文本, 长度没有上限, 只能反过来
  * 吃右侧列分完后剩下的空间。
+ *
+ * 列间距取 12px 而不是 16px: 侧栏可拉到 480 (useSidebarResize MAX_WIDTH), 主窗下限
+ * 800, 此时设置页卡片内的表格只剩约 230px。列间距落在 nowrap 单元格上是**不可收缩**
+ * 宽度, 五列就是 5 份 —— 12px 比 16px 省下 20px, 直接抬高开始溢出的窗口宽度。
+ * 12 与 16 同在 DESIGN.md §5 间距刻度上, 这个字号下的分隔效果没有可见差别。
  *
  * 实现上靠 `w-full + max-w-0` (任务列自身 pl-0): 自动布局的表格若不加这一对,
  * 会先按 nowrap 的最长任务名算出列宽、把整张卡片横向撑开, 内层的 truncate 因为
  * 没有可收缩的宽度而失效。max-w-0 让这一列先塌到 0, w-full 再让它领走余量。
  */
 const TH_CLASS =
-  'whitespace-nowrap border-b border-[var(--border-default)] pb-2 pl-4 text-right text-11 font-medium text-[var(--text-tertiary)]';
+  'whitespace-nowrap border-b border-[var(--border-default)] pb-2 pl-3 text-right text-11 font-medium text-[var(--text-tertiary)]';
 const TD_CLASS =
-  'whitespace-nowrap border-b border-[var(--border-default)] py-2 pl-4 text-right text-12 tabular-nums';
+  'whitespace-nowrap border-b border-[var(--border-default)] py-2 pl-3 text-right text-12 tabular-nums';
 const TASK_COL_CLASS = 'w-full max-w-0 pl-0';
 
 /** 与 SessionItem 一致: 取两者中较新的值, 兼容只写 userSendAt 的存量行。 */

--- a/apps/desktop/src/renderer/components/settings/usage/UsageTaskTable.tsx
+++ b/apps/desktop/src/renderer/components/settings/usage/UsageTaskTable.tsx
@@ -44,10 +44,21 @@ const TOP_TASKS = 8;
 const WINDOW_DAYS = 30;
 const UNKNOWN_VALUE = '—';
 
+/**
+ * 列宽口径: 右侧五列 (模型/供应商/token/上下文/最后活跃) 都是短的定长内容, 让它们
+ * 按各自内容取满宽 —— 这几列是要被读数的, 不能被挤窄或截断; pl-4 是列间距, 否则
+ * 相邻两列的数字会贴到一起。任务名是用户输入的自由文本, 长度没有上限, 只能反过来
+ * 吃右侧列分完后剩下的空间。
+ *
+ * 实现上靠 `w-full + max-w-0` (任务列自身 pl-0): 自动布局的表格若不加这一对,
+ * 会先按 nowrap 的最长任务名算出列宽、把整张卡片横向撑开, 内层的 truncate 因为
+ * 没有可收缩的宽度而失效。max-w-0 让这一列先塌到 0, w-full 再让它领走余量。
+ */
 const TH_CLASS =
-  'whitespace-nowrap border-b border-[var(--border-default)] pb-2 text-right text-11 font-medium text-[var(--text-tertiary)]';
+  'whitespace-nowrap border-b border-[var(--border-default)] pb-2 pl-4 text-right text-11 font-medium text-[var(--text-tertiary)]';
 const TD_CLASS =
-  'whitespace-nowrap border-b border-[var(--border-default)] py-2 text-right text-12 tabular-nums';
+  'whitespace-nowrap border-b border-[var(--border-default)] py-2 pl-4 text-right text-12 tabular-nums';
+const TASK_COL_CLASS = 'w-full max-w-0 pl-0';
 
 /** 与 SessionItem 一致: 取两者中较新的值, 兼容只写 userSendAt 的存量行。 */
 function lastActiveIso(session: { updatedAt: string; userSendAt: string | null }): string {
@@ -92,7 +103,9 @@ export function UsageTaskTable({ rows }: { rows: Session[] }): React.JSX.Element
     <table className="w-full border-collapse">
       <thead>
         <tr>
-          <th className={cn(TH_CLASS, 'text-left')}>{t('usageHistory.tasks.col.task')}</th>
+          <th className={cn(TH_CLASS, TASK_COL_CLASS, 'text-left')}>
+            {t('usageHistory.tasks.col.task')}
+          </th>
           <th className={TH_CLASS}>{t('usageHistory.tasks.col.model')}</th>
           <th className={TH_CLASS} title={t('usageHistory.tasks.providerTooltip')}>
             {t('usageHistory.tasks.col.provider')}
@@ -113,13 +126,15 @@ export function UsageTaskTable({ rows }: { rows: Session[] }): React.JSX.Element
             session.contextWindow > 0 ? session.contextTokens / session.contextWindow : null;
           return (
             <tr key={session.id}>
-              <td className={cn(TD_CLASS, 'text-left')}>
+              <td className={cn(TD_CLASS, TASK_COL_CLASS, 'text-left')}>
                 <span className="flex min-w-0 items-center gap-2">
                   <span
                     className="size-2 shrink-0 rounded-[2px]"
                     style={{ backgroundColor: usageRankColor(index) }}
                   />
-                  <span className="truncate">{session.title}</span>
+                  <span className="truncate" title={session.title}>
+                    {session.title}
+                  </span>
                 </span>
               </td>
               <td className={cn(TD_CLASS, 'text-[var(--text-tertiary)]')}>


### PR DESCRIPTION
## 这次改了什么

### 摘要

设置 → 用量历史里「最耗 token 的任务」这张表，任务名一长就会把整张卡片横向撑开，右侧的模型 / 供应商 / 累计 token 等列被挤出内容区。

任务列内层本来就有 `truncate`，但单元格是 `whitespace-nowrap` 且没有宽度约束——自动布局的表格会先按最长任务名算出列宽，`truncate` 因为没有可收缩的宽度而失效。任务名取自用户输入，长度没有上限，这个撑开是必然会发生的。

改法是给任务列加 `w-full max-w-0`：让它先塌到 0，再领走其余列分完后剩下的空间，`truncate` 由此生效；标题补 `title` 属性，悬停可读全名。其余五列维持按各自内容取满宽，不参与截断。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#3252 合并后发现的显示缺陷
- 本 PR 包含：`UsageTaskTable` 任务列的宽度约束与截断、任务名 `title` 提示、单元格列间距
- 明确不包含：
  - 「按模型」表首列（`UsageBreakdownTables`）的同类问题——同一个病但另一张表，单独提；
  - 供应商列空值语义（`—` 兼表「未指定」与「无数据」）——属文案与产品语义改动，单独提；
  - `formatModelShort` 认不出 `claude-opus-5` 这类单段版本号——单独提。
- 用户可见变化：长任务名不再撑破卡片，改为省略号截断 + 悬停显示完整标题；六列的列间距从 0 增至 16px。
- 是否存在 breaking change：无

### UI 变化

修复前 / 修复后截图见下（macOS，浅色主题，同一窗口宽度、同一份数据）。

- 引用的设计规范：
  - **DESIGN.md §14.6 Icon-only Controls and Tooltips**——「Native `title` remains acceptable for truncated persistent text」。任务名是被截断的常驻文本，用 native `title` 而非 Radix `Tip` 正落在这条许可里。
  - **DESIGN.md §14.4 Motion & Transitions / Sidebar title reading exception**——悬停跑马灯被明文限定在 `SessionItem.tsx` 的 `SidebarTitleMarquee`，不得外溢。因此同为任务名，这里采用静态省略号 + native tooltip，不引入跑马灯。
  - **DESIGN.md §5 Layout Principles / Spacing System**——新增的列间距取 16px，落在 `4/6/8/10/12/14/16/20/24/32/40/48` 刻度上。
  - **DESIGN.md §8 Window & Adaptive Behavior**——主窗下限 800×600，布局随窗口收缩而重排；本改动让任务列成为唯一可收缩的列，其余列在任何窗口宽度下保持完整可读。
  - 截断口径：表头与格式化数值（`累计 token` / `上下文占用` / `最后活跃`）属产品可控文案，不参与截断；只有用户输入的任务名会出现省略号。

## 怎么验证的

### 自动验证

```text
pnpm ensure-deps
结果：依赖已同步，better-sqlite3 root Node ABI 已就绪

pnpm test:unit:related
结果：PASS apps/desktop unit (17.1s)

pnpm --filter desktop run --if-present typecheck
结果：通过，无输出

pnpm --dir apps/desktop exec vitest run src/renderer/__tests__/typographyDiscipline.test.ts src/renderer/__tests__/compactComposerTypography.test.ts
结果：Test Files 2 passed，Tests 6 passed
（test:unit:related 覆盖不到全量扫源码的排版守卫，UI 改动后单独跑一次）

pnpm check:i18n-glossary
结果：无新增违规（4 处 lead 为存量待裁决告警，不阻断）
```

### 手工验证

macOS，`pnpm dev:desktop:remote` 起 dev 后登录账号，进入 设置 → 用量历史 →「最耗 token 的任务」，与正式版同一份数据、同一窗口宽度对比：

- 修复前：最长的任务名把表格撑出卡片，右侧列被挤到可视区外；
<img width="1375" height="812" alt="Token History - Bug" src="https://github.com/user-attachments/assets/9f99fa96-d2a0-47c3-ad46-8fb8a5ecdd82" />

- 修复后：任务名以省略号截断在卡内，模型 / 供应商 / 累计 token / 上下文占用 / 最后活跃五列完整显示；悬停任务名可看到完整标题。
<img width="1475" height="836" alt="Token History - Fixed" src="https://github.com/user-attachments/assets/94f12faa-d221-436b-aaa0-ec87e3801e20" />


### 未执行的验证

- 未在 Windows / Linux 上实机走查：本改动是纯 CSS 布局约束（Tailwind `w-full` / `max-w-0` / `pl-4`），无平台相关分支。
- 未新增单元测试：改动为纯样式类名，现有测试体系里没有对应的样式断言层；实机截图为准。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 `apps/desktop/src/renderer/components/settings/usage/UsageTaskTable.tsx` 一个组件的样式类名，不涉及数据、协议与主进程。
- 回滚 / 降级方式：revert 本 PR 即可，无残留状态。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（改动口径写在组件文件头注释里）
- [x] 已确认测试结果或说明未执行原因
