### PR TITLE
fix(mobile): Android 改用系统照片选择器

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -43,7 +43,15 @@
         "monochromeImage": "./assets/android-icon-monochrome.png"
       },
       "predictiveBackGestureEnabled": false,
-      "permissions": ["android.permission.MODIFY_AUDIO_SETTINGS"]
+      "permissions": ["android.permission.MODIFY_AUDIO_SETTINGS"],
+      "blockedPermissions": [
+        "android.permission.READ_EXTERNAL_STORAGE",
+        "android.permission.WRITE_EXTERNAL_STORAGE",
+        "android.permission.READ_MEDIA_AUDIO",
+        "android.permission.READ_MEDIA_IMAGES",
+        "android.permission.READ_MEDIA_VIDEO",
+        "android.permission.READ_MEDIA_VISUAL_USER_SELECTED"
+      ]
     },
     "web": {
       "favicon": "./assets/favicon.png"
@@ -134,7 +142,8 @@
         {
           "photosPermission": "Cindy needs photo library access to show recent photos and screenshots for quick attaching.",
           "savePhotosPermission": false,
-          "isAccessMediaLocationEnabled": false
+          "isAccessMediaLocationEnabled": false,
+          "granularPermissions": []
         }
       ]
     ],

--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -224,6 +224,7 @@ import {
 } from '@/session/useComposerImageAnnotations';
 import { buildMediaPayload } from '@/session/messagePayload';
 import type { MobileMessageGalleryImage } from '@/session/messageGallery';
+import { canBrowsePhotoLibraryDirectly } from '@/session/photoLibraryPolicy';
 import {
   prefetchContextSheetMediaAssets,
   resolveContextSheetMediaAssetForUpload,
@@ -1102,6 +1103,7 @@ export default function SessionScreen() {
   // Context 面板(+ 号弹出的可拖动 sheet):open + 面板内子视图(主视图 / 截图列表 / 目标模式)。
   const [contextSheetOpen, setContextSheetOpen] = useState(false);
   const [contextSheetView, setContextSheetView] = useState<'main' | 'screenshots' | 'goal'>('main');
+  const contextSheetMediaLibraryEnabled = canBrowsePhotoLibraryDirectly(Platform.OS);
   // 模型 + 权限浮窗(ContextSheet 同款 Modal,含二级「模型选项 / 权限」叠层)。
   const [modelSheetOpen, setModelSheetOpen] = useState(false);
   // 权限模式独立浮窗(composer 左侧图标钮点开,与模型浮窗同属 composer 激活态)。
@@ -7850,10 +7852,12 @@ export default function SessionScreen() {
   useEffect(() => {
     if (!contextSheetOpen) setPendingMediaAssets([]);
   }, [contextSheetOpen]);
-  // 进页面就静默预取最近照片(仅已授权时),打开 + 面板即刻出图。
+  // iOS 进页面就静默预取最近照片(仅已授权时),打开 + 面板即刻出图;Android 统一走系统选择器。
   useEffect(() => {
-    void prefetchContextSheetMediaAssets('recent');
-  }, []);
+    if (contextSheetMediaLibraryEnabled) {
+      void prefetchContextSheetMediaAssets('recent');
+    }
+  }, [contextSheetMediaLibraryEnabled]);
 
   // 目标模式:面板打开时拉一次快照(push 只送变更);动作后再拉一次收敛,避免依赖单一 push。
   const goalStatus = useSessionGoalStatus(sessionId);
@@ -8986,15 +8990,17 @@ export default function SessionScreen() {
         >
           {contextSheetView === 'main' ? (
             <>
-              <RecentPhotosStrip
-                busyAssetIds={uploadingMediaAssetIds}
-                disabled={!canUseComposer}
-                enabled={contextSheetOpen}
-                onToggleAsset={toggleMediaAssetAttachment}
-                pendingOrder={pendingMediaOrder}
-                selectedAssetIds={selectedMediaAssetIds}
-                testID="session.contextSheetPhotos"
-              />
+              {contextSheetMediaLibraryEnabled ? (
+                <RecentPhotosStrip
+                  busyAssetIds={uploadingMediaAssetIds}
+                  disabled={!canUseComposer}
+                  enabled={contextSheetOpen}
+                  onToggleAsset={toggleMediaAssetAttachment}
+                  pendingOrder={pendingMediaOrder}
+                  selectedAssetIds={selectedMediaAssetIds}
+                  testID="session.contextSheetPhotos"
+                />
+              ) : null}
               <ContextSheetGroup label={t('session.common.groupMode')}>
                 {planModeSupported ? (
                   // 点击即切换计划模式并关面板(产品决策,不做开关);已开启时显示 ✓,再点退出。
@@ -9035,14 +9041,16 @@ export default function SessionScreen() {
                   onPress={() => void addLocalImageAttachments('library')}
                   testID="session.contextSheetPhotoRow"
                 />
-                <ContextSheetRow
-                  disabled={!canUseComposer}
-                  icon={<Scan color={colors.textPrimary} size={iconSize.lg} strokeWidth={iconStroke.regular} />}
-                  label={t('session.common.screenshot')}
-                  onPress={() => setContextSheetView('screenshots')}
-                  testID="session.contextSheetScreenshotsRow"
-                  trailing="chevron"
-                />
+                {contextSheetMediaLibraryEnabled ? (
+                  <ContextSheetRow
+                    disabled={!canUseComposer}
+                    icon={<Scan color={colors.textPrimary} size={iconSize.lg} strokeWidth={iconStroke.regular} />}
+                    label={t('session.common.screenshot')}
+                    onPress={() => setContextSheetView('screenshots')}
+                    testID="session.contextSheetScreenshotsRow"
+                    trailing="chevron"
+                  />
+                ) : null}
                 <ContextSheetRow
                   accessibilityHint={composerSendUnavailableReason ?? undefined}
                   disabled={!canUseComposer}
@@ -9066,7 +9074,7 @@ export default function SessionScreen() {
                 </Text>
               ) : null}
             </>
-          ) : contextSheetView === 'screenshots' ? (
+          ) : contextSheetView === 'screenshots' && contextSheetMediaLibraryEnabled ? (
             <ScreenshotsGrid
               busyAssetIds={uploadingMediaAssetIds}
               contentWidth={Math.min(windowDimensions.width, nativeShellLayout.contentMaxWidth) - 40}

--- a/apps/mobile/app/sessions/new.tsx
+++ b/apps/mobile/app/sessions/new.tsx
@@ -130,6 +130,7 @@ import {
   resolveContextSheetMediaAssetForUpload,
   type ContextSheetMediaAsset,
 } from '@/session/useContextSheetMediaAssets';
+import { canBrowsePhotoLibraryDirectly } from '@/session/photoLibraryPolicy';
 import {
   detectComposerTrigger,
   filterAtResources,
@@ -497,6 +498,7 @@ export default function NewRemoteSessionScreen() {
   // Context 面板(+ 号弹出的可拖动 sheet):open + 子视图(主视图 / 截图列表 / 目标草稿)。
   const [contextSheetOpen, setContextSheetOpen] = useState(false);
   const [contextSheetView, setContextSheetView] = useState<'main' | 'screenshots' | 'goal'>('main');
+  const contextSheetMediaLibraryEnabled = canBrowsePhotoLibraryDirectly(Platform.OS);
   // 目标模式(对齐桌面 NewMakerDraftRoute.handleCreateGoal):填完表单直接建会话 + setGoal,
   // 被控端落目标消息并自动开跑第一轮,成功后跳转会话页。
   const [goalBusy, setGoalBusy] = useState(false);
@@ -3830,10 +3832,12 @@ export default function NewRemoteSessionScreen() {
   useEffect(() => {
     if (!contextSheetOpen) setPendingMediaAssets([]);
   }, [contextSheetOpen]);
-  // 进页面就静默预取最近照片(仅已授权时),打开 + 面板即刻出图。
+  // iOS 进页面就静默预取最近照片(仅已授权时),打开 + 面板即刻出图;Android 统一走系统选择器。
   useEffect(() => {
-    void prefetchContextSheetMediaAssets('recent');
-  }, []);
+    if (contextSheetMediaLibraryEnabled) {
+      void prefetchContextSheetMediaAssets('recent');
+    }
+  }, [contextSheetMediaLibraryEnabled]);
 
   // Context 面板「计划模式」入口,双路径(#494 迁移):
   //  - 新协议(capabilities.planMode.supported):本地布尔草稿态,创建会话后经
@@ -5755,15 +5759,17 @@ export default function NewRemoteSessionScreen() {
       >
         {contextSheetView === 'main' ? (
           <>
-            <RecentPhotosStrip
-              busyAssetIds={uploadingMediaAssetIds}
-              disabled={creating}
-              enabled={contextSheetOpen}
-              onToggleAsset={toggleMediaAssetAttachment}
-              pendingOrder={pendingMediaOrder}
-              selectedAssetIds={selectedMediaAssetIds}
-              testID="newSession.contextSheetPhotos"
-            />
+            {contextSheetMediaLibraryEnabled ? (
+              <RecentPhotosStrip
+                busyAssetIds={uploadingMediaAssetIds}
+                disabled={creating}
+                enabled={contextSheetOpen}
+                onToggleAsset={toggleMediaAssetAttachment}
+                pendingOrder={pendingMediaOrder}
+                selectedAssetIds={selectedMediaAssetIds}
+                testID="newSession.contextSheetPhotos"
+              />
+            ) : null}
             <ContextSheetGroup label={t('session.common.groupMode')}>
               {planModeSupported ? (
                 // 点击即切换计划模式并关面板(产品决策,不做开关);已开启时显示 ✓,再点退出。
@@ -5796,14 +5802,16 @@ export default function NewRemoteSessionScreen() {
                 onPress={() => void addLocalImageAttachments('library')}
                 testID="newSession.contextSheetPhotoRow"
               />
-              <ContextSheetRow
-                disabled={creating}
-                icon={<Scan color={colors.textPrimary} size={iconSize.lg} strokeWidth={iconStroke.regular} />}
-                label={t('session.common.screenshot')}
-                onPress={() => setContextSheetView('screenshots')}
-                testID="newSession.contextSheetScreenshotsRow"
-                trailing="chevron"
-              />
+              {contextSheetMediaLibraryEnabled ? (
+                <ContextSheetRow
+                  disabled={creating}
+                  icon={<Scan color={colors.textPrimary} size={iconSize.lg} strokeWidth={iconStroke.regular} />}
+                  label={t('session.common.screenshot')}
+                  onPress={() => setContextSheetView('screenshots')}
+                  testID="newSession.contextSheetScreenshotsRow"
+                  trailing="chevron"
+                />
+              ) : null}
               <ContextSheetRow
                 disabled={creating}
                 icon={<Camera color={colors.textPrimary} size={iconSize.lg} strokeWidth={iconStroke.regular} />}
@@ -5825,7 +5833,7 @@ export default function NewRemoteSessionScreen() {
               </Text>
             ) : null}
           </>
-        ) : contextSheetView === 'screenshots' ? (
+        ) : contextSheetView === 'screenshots' && contextSheetMediaLibraryEnabled ? (
           <ScreenshotsGrid
             busyAssetIds={uploadingMediaAssetIds}
             contentWidth={windowDimensions.width - 40}

--- a/apps/mobile/src/__tests__/contextSheetMediaAssets.test.ts
+++ b/apps/mobile/src/__tests__/contextSheetMediaAssets.test.ts
@@ -58,6 +58,15 @@ beforeEach(() => {
 });
 
 describe('prefetchContextSheetMediaAssets', () => {
+  it('Android 不读取媒体库,由系统照片选择器承担图片选择', async () => {
+    platform.os = 'android';
+
+    await prefetchContextSheetMediaAssets('recent');
+
+    expect(mediaLibrary.getPermissionsAsync).not.toHaveBeenCalled();
+    expect(mediaLibrary.getAssetsAsync).not.toHaveBeenCalled();
+  });
+
   it('iOS 受限照片权限不在页面预取时读取资产,避免每次冷启动弹系统提醒', async () => {
     platform.os = 'ios';
     mediaLibrary.getPermissionsAsync.mockResolvedValue({

--- a/apps/mobile/src/__tests__/nativeAppConfig.test.ts
+++ b/apps/mobile/src/__tests__/nativeAppConfig.test.ts
@@ -477,6 +477,31 @@ describe('mobile native app config', () => {
     expect(appJson.expo.ios.infoPlist.UIBackgroundModes ?? []).not.toContain('audio');
   });
 
+  it('uses the Android system photo picker without broad media permissions', () => {
+    const appJson = JSON.parse(
+      readFileSync(resolve(process.cwd(), 'app.json'), 'utf8'),
+    );
+    const mediaLibraryPlugin = appJson.expo.plugins.find(
+      (plugin: unknown) =>
+        Array.isArray(plugin) && plugin[0] === 'expo-media-library',
+    );
+
+    expect(mediaLibraryPlugin).toEqual([
+      'expo-media-library',
+      expect.objectContaining({ granularPermissions: [] }),
+    ]);
+    expect(appJson.expo.android.blockedPermissions).toEqual(
+      expect.arrayContaining([
+        'android.permission.READ_EXTERNAL_STORAGE',
+        'android.permission.WRITE_EXTERNAL_STORAGE',
+        'android.permission.READ_MEDIA_AUDIO',
+        'android.permission.READ_MEDIA_IMAGES',
+        'android.permission.READ_MEDIA_VIDEO',
+        'android.permission.READ_MEDIA_VISUAL_USER_SELECTED',
+      ]),
+    );
+  });
+
   it('keeps Metro React resolution on the mobile app dependency', () => {
     const metroConfig = readFileSync(
       resolve(process.cwd(), 'metro.config.js'),

--- a/apps/mobile/src/__tests__/photoLibraryPolicy.test.ts
+++ b/apps/mobile/src/__tests__/photoLibraryPolicy.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { canBrowsePhotoLibraryDirectly } from '@/session/photoLibraryPolicy';
+
+describe('photo library policy', () => {
+  it('keeps direct photo-library browsing on iOS', () => {
+    expect(canBrowsePhotoLibraryDirectly('ios')).toBe(true);
+  });
+
+  it('requires Android and web to use system pickers instead', () => {
+    expect(canBrowsePhotoLibraryDirectly('android')).toBe(false);
+    expect(canBrowsePhotoLibraryDirectly('web')).toBe(false);
+  });
+});

--- a/apps/mobile/src/session/photoLibraryPolicy.ts
+++ b/apps/mobile/src/session/photoLibraryPolicy.ts
@@ -1,0 +1,11 @@
+/**
+ * Google Play only permits broad Android photo-library access when it is
+ * essential to the app's primary purpose. Cindy only attaches user-selected
+ * images, so Android must use the system photo picker instead.
+ *
+ * iOS keeps the existing recent-photo and screenshot surfaces, whose asset
+ * resolution still depends on expo-media-library.
+ */
+export function canBrowsePhotoLibraryDirectly(platform: string): boolean {
+  return platform === 'ios';
+}

--- a/apps/mobile/src/session/useContextSheetMediaAssets.ts
+++ b/apps/mobile/src/session/useContextSheetMediaAssets.ts
@@ -6,14 +6,15 @@ import * as MediaLibrary from 'expo-media-library/legacy';
 import { ImageManipulator, SaveFormat } from 'expo-image-manipulator';
 import { i18n } from '@/i18n';
 import { MOBILE_IMAGE_UPLOAD_MAX_LONG_EDGE } from '@/session/mobileImagePreprocess';
+import { canBrowsePhotoLibraryDirectly } from '@/session/photoLibraryPolicy';
 
 /** Context 面板媒体列表的单个资产(展示 + 附加所需的最小字段)。 */
 export interface ContextSheetMediaAsset {
   id: string;
   filename: string;
-  /** 展示用 URI(iOS ph:// / Android content://);渲染走 expo-image,RN Image 在新架构下不支持 ph://。 */
+  /** 展示用 URI(iOS 通常为 ph://);渲染走 expo-image,RN Image 在新架构下不支持 ph://。 */
   uri: string;
-  /** 列表查询已返回的尺寸;Android full info 权限失败时供上传预处理继续使用。 */
+  /** 列表查询已返回的尺寸;解析完整资产信息失败时供上传预处理继续使用。 */
   width?: number;
   height?: number;
 }
@@ -44,19 +45,13 @@ const DEFAULT_FIRST: Record<ContextSheetMediaKind, number> = { recent: 24, scree
 
 /** 按 kind 拉一页资产(权限已就绪的前提下)。 */
 async function fetchAssets(kind: ContextSheetMediaKind, first: number): Promise<ContextSheetMediaAsset[] | null> {
-  let album: MediaLibrary.Album | null = null;
-  if (kind === 'screenshots' && Platform.OS === 'android') {
-    album = await MediaLibrary.getAlbumAsync('Screenshots');
-    if (!album) return [];
-  }
   const page = await MediaLibrary.getAssetsAsync({
     first,
     mediaType: [MediaLibrary.MediaType.photo],
     sortBy: [[MediaLibrary.SortBy.creationTime, false]],
-    ...(kind === 'screenshots' && Platform.OS === 'ios'
+    ...(kind === 'screenshots'
       ? { mediaSubtypes: ['screenshot' as MediaLibrary.MediaSubtype] }
       : {}),
-    ...(album ? { album } : {}),
   });
   return page.assets.map((asset) => ({
     id: asset.id,
@@ -68,12 +63,12 @@ async function fetchAssets(kind: ContextSheetMediaKind, first: number): Promise<
 }
 
 /**
- * 页面挂载时静默预取(打开面板即刻出图)。只在照片权限已授予、且 iOS 不是受限访问时拉取——
+ * iOS 页面挂载时静默预取(打开面板即刻出图)。只在照片权限已授予、且不是受限访问时拉取——
  * iOS 受限访问虽然 granted=true,首次读取资产仍可能触发系统自动提醒;预取绝不能打断用户。
  * 首次授权和受限资产读取仍由用户打开面板后触发;失败静默,面板打开时照常加载。
  */
 export async function prefetchContextSheetMediaAssets(kind: ContextSheetMediaKind = 'recent'): Promise<void> {
-  if (Platform.OS === 'web' || assetsCache.has(kind)) return;
+  if (!canBrowsePhotoLibraryDirectly(Platform.OS) || assetsCache.has(kind)) return;
   try {
     const permission = await MediaLibrary.getPermissionsAsync(false, ['photo']);
     if (!permission.granted) return;
@@ -86,12 +81,11 @@ export async function prefetchContextSheetMediaAssets(kind: ContextSheetMediaKin
 }
 
 /**
- * Context 面板的相册资产加载 hook(最近照片条 / 截图列表共用)。
+ * Context 面板的 iOS 相册资产加载 hook(最近照片条 / 截图列表共用)。
  *
  * enabled 变 true(面板打开)时才请求权限并加载,面板关闭不清缓存——再次打开先显示
  * 旧列表再后台刷新,遵守规则 7(先有内容再刷新,不闪空白帧)。
- * 截图过滤:iOS 用 mediaSubtypes=['screenshot'];Android 找 Screenshots 相册,
- * 找不到则退化为空列表(UI 显示「没有找到截图」)。
+ * 截图过滤使用 mediaSubtypes=['screenshot'];Android 不挂载此界面,统一走系统照片选择器。
  */
 export function useContextSheetMediaAssets(input: {
   enabled: boolean;
@@ -107,7 +101,7 @@ export function useContextSheetMediaAssets(input: {
 
   const load = useCallback(async (requestIfNeeded: boolean) => {
     const seq = ++loadSeqRef.current;
-    if (Platform.OS === 'web') {
+    if (!canBrowsePhotoLibraryDirectly(Platform.OS)) {
       setStatus('unavailable');
       return;
     }

--- a/apps/mobile/src/session/useMobileLocalAttachments.ts
+++ b/apps/mobile/src/session/useMobileLocalAttachments.ts
@@ -20,6 +20,7 @@ import * as DocumentPicker from 'expo-document-picker';
 import * as FileSystem from 'expo-file-system/legacy';
 import * as ImagePicker from 'expo-image-picker';
 import { formatRemoteError } from '@/device-link/remoteStatus';
+import { canBrowsePhotoLibraryDirectly } from '@/session/photoLibraryPolicy';
 import {
   MOBILE_MAX_ATTACHMENTS,
   assertMobileDocumentSize,
@@ -414,15 +415,17 @@ export function useMobileLocalAttachments(
         optionsRef.current.onError(t('composer.upload.simulatorNoCamera'));
         return;
       }
-      const permission = source === 'camera'
-        ? await ImagePicker.requestCameraPermissionsAsync()
-        : await ImagePicker.requestMediaLibraryPermissionsAsync(false);
-      if (!isAttachmentScopeActive()) return;
-      if (!permission.granted) {
-        optionsRef.current.onError(source === 'camera'
-          ? t('composer.upload.cameraPermission')
-          : t('composer.upload.photoPermission'));
-        return;
+      if (source === 'camera' || canBrowsePhotoLibraryDirectly(Platform.OS)) {
+        const permission = source === 'camera'
+          ? await ImagePicker.requestCameraPermissionsAsync()
+          : await ImagePicker.requestMediaLibraryPermissionsAsync(false);
+        if (!isAttachmentScopeActive()) return;
+        if (!permission.granted) {
+          optionsRef.current.onError(source === 'camera'
+            ? t('composer.upload.cameraPermission')
+            : t('composer.upload.photoPermission'));
+          return;
+        }
       }
 
       const picked = source === 'camera'


### PR DESCRIPTION
## 这次改了什么

### 摘要

Google Play 因 Cindy Android 声明广泛照片/视频权限而拒绝版本 11。本 PR 将 Android 图片附件改为系统 Photo Picker，仅授予用户明确选中的图片；同时移除依赖直接相册访问的“最近照片”和“截图”快捷入口。iOS 保持原有相册体验。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Google Play“照片和视频权限”政策拒审整改（versionCode 11）
- 本 PR 包含：屏蔽 Android 广泛媒体/存储权限；Android 图片附件使用系统 Photo Picker；新建会话和已有会话统一隐藏直接相册浏览入口；补充权限策略与原生配置测试
- 明确不包含：发布工作流、签名配置、AAB 打包/上传、Google Play 后台操作、iOS 相册行为调整
- 用户可见变化：Android 附件面板不再显示最近照片条和单独的“截图”入口；点击“Photos”进入 Android 系统选择器
- 是否存在 breaking change：无

### UI 变化

- Android：附件面板从“最近照片 + Photos + Screenshot + Take Photo + File”收敛为“Photos + Take Photo + File”；系统 Photo Picker 明确提示 Cindy 仅能访问所选照片
- iOS：无变化
- 本地已在 Pixel 8 Pro API 36 模拟器目检 Light 模式并留存截图，截图未写入仓库；Dark 模式未单独目检。没有新增样式、颜色或文案，继续复用既有 themed `ContextSheet` / `ContextSheetRow`
- 引用的设计规范：`docs/design-rules/DESIGN.md` §4 Component Stylings、§10 Theme System & Token Reference；`apps/mobile/docs/mobile-design-guide.md` §4 组件约定、§5 间距 / 圆角 / 触控 / 安全区

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：PASS（apps/mobile related 9）

pnpm --filter mobile run --if-present typecheck
结果：PASS

pnpm --filter mobile test:scope
结果：PASS

node scripts/hardcoded-color-audit.mjs
结果：PASS（unexpected=0）

pnpm check:dco
结果：PASS（1 commit signed off）

EXPO_PUBLIC_CINDY_AUTH_REGION=global pnpm --filter mobile exec expo prebuild --platform android --clean
env JAVA_HOME='/Applications/Android Studio.app/Contents/jbr/Contents/Home' EXPO_PUBLIC_CINDY_AUTH_REGION=global pnpm --filter mobile android
结果：Android Debug 原生构建、安装和启动成功

adb shell dumpsys package com.xd.cindy
结果：实际安装包 requested permissions 不含 READ_MEDIA_*、READ_EXTERNAL_STORAGE、WRITE_EXTERNAL_STORAGE
```

Fingerprint guard（以最新 `origin/main` 为 base）：

```text
ios:     13e5870a625bd90eedff264f3a79cbc28a40bf6d -> 946cc24854176bd4e798955ef1066b9c30b019d1
android: e1a41d64940890cfd57a42f02efa21f425761694 -> a9425578abf8f9d13abbbc4845ff08d68f66c273
结果：CHANGED，必须冷更
```

### 手工验证

- 分支/提交：`fix/android-system-photo-picker@593fd76b`
- Worktree：`/Users/caojianbo/Source/xdtmaker/cindy`
- 环境：Global 开发包 `com.xd.cindy`，Pixel 8 Pro / Android API 36
- Metro：本 worktree 直接执行 `expo run:android` 后启动的 `8081`（PID 27774）；仓库 `mobile:sim:*` 当前只识别 iOS，因此没有 `mobile:sim:whoami` / `__DEV__` build label 证据
- 已验证已有会话附件面板只显示 Photos / Take Photo / File
- 点击 Photos 后实际进入 `com.google.android.photopicker`，页面提示 Cindy 只能访问所选照片
- 选择图片并点击 Done 后成功回到 Cindy，composer 显示 1 个图片附件
- Debug 包覆盖安装后原有登录态和会话数据仍存在

### 未执行的验证

- iOS 模拟器/真机：本 PR 不改变 iOS 行为，但 resolved Expo config 指纹仍会变化
- Android Dark 模式独立目检：没有新增样式，复用现有主题组件，但未把复用等同于实机验证
- 相机实际拍摄、文件选择和最终发送：入口保留；本轮重点完成系统 Photo Picker 的选择到附件回填
- 正式 JKS 签名 AAB、同签名覆盖升级与 Google Play 上传：不在本 PR 范围，发布前必须补做

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [x] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 为什么冷更不可避免：Google Play 拒绝广泛照片/视频权限，必须修改 Android Manifest 来源配置；`app.json` 是 runtime fingerprint 输入
- 存量装机影响：现有安装无法收到该 fingerprint 下的后续 OTA，必须安装下一版商店冷更包后恢复到新 runtime；iOS 虽无行为变化，resolved config 指纹也发生变化
- 发版节奏建议：冷更把关人明确确认后合并；Android 将 `versionCode` 提升到至少 12，使用既有 JKS 签名打 AAB，先走内测再重新提交正式审核；iOS 与下一次计划内冷更合并安排，避免额外发版
- 影响范围：Android 图片附件入口和原生权限；iOS 仅 fingerprint 变化，交互保持不变
- 回滚 / 降级方式：revert 本提交并重新冷更可恢复旧 UI，但会重新引入 Google Play 权限拒审风险；线上降级应优先保留系统 Photo Picker，仅修复具体附件回归

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（不需要额外产品文档；权限策略和测试内含原因说明）
- [x] 已确认测试结果或说明未执行原因

> 冷更把关：本 PR 暂以 Draft 创建。需要仓库指定把关人对本次 fingerprint / 冷更影响明确确认后，才能转 Ready 并进入合并流程。
