### PR TITLE
fix(desktop): release isLoadingMore lock on invalidated initial history backfill

### DIFF
--- a/apps/desktop/src/renderer/__tests__/makerChatStoreActiveView.test.ts
+++ b/apps/desktop/src/renderer/__tests__/makerChatStoreActiveView.test.ts
@@ -1322,4 +1322,56 @@ describe('makerChatStore active view tracking', () => {
     expect(makerChatStore.getSnapshot(sessionId).messages).toHaveLength(0);
     expect(makerChatStore.getSnapshot(sessionId).historyLoaded).toBe(false);
   });
+
+  // Regression: when ensureInitialMessages backfill is invalidated by an epoch
+  // change (e.g. reloadMessages), isLoadingMore must be released so that
+  // loadOlderMessages is not permanently blocked.
+  it('releases isLoadingMore when initial backfill is invalidated by epoch change', async () => {
+    const sessionId = sid('initial-backfill-invalidation-lock');
+    const latestPage = Array.from({ length: 49 }, (_, i) =>
+      dbMessage(
+        sessionId,
+        `latest-${String(i).padStart(2, '0')}`,
+        `latest message ${i}`,
+        new Date(BASE_TIME.getTime() + (60 + i) * 1000).toISOString(),
+      ),
+    );
+    const latestPlan = dbToolUseMessage(
+      sessionId,
+      'latest-plan',
+      'TaskUpdate',
+      { taskId: 'abc', status: 'completed' },
+      new Date(BASE_TIME.getTime() + 120_000).toISOString(),
+    );
+    let resolveOlderPage!: (rows: Message[]) => void;
+    vi.mocked(messageService.list)
+      .mockResolvedValueOnce([...latestPage, latestPlan])
+      .mockReturnValueOnce(
+        new Promise<Message[]>((resolve) => {
+          resolveOlderPage = resolve;
+        }),
+      );
+
+    makerChatStore.ensureInitialMessages(sessionId);
+    await flushPromises(4);
+
+    // Backfill is in progress, lock held.
+    expect(makerChatStore.getSnapshot(sessionId).isLoadingMore).toBe(true);
+    expect(messageService.list).toHaveBeenCalledTimes(2);
+
+    // Epoch change invalidates the in-flight backfill.
+    makerChatStore.reloadMessages(sessionId);
+    await Promise.resolve();
+
+    // Resolve the pending backfill — it should detect invalidation and exit.
+    resolveOlderPage([
+      dbMessage(sessionId, 'older-visible', 'older visible message', BASE_TIME.toISOString()),
+    ]);
+    await flushPromises();
+
+    // isLoadingMore must have been released despite the invalidation path.
+    expect(makerChatStore.getSnapshot(sessionId).isLoadingMore).toBe(false);
+  });
+
+
 });

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -9930,6 +9930,10 @@ function retryInvalidatedInitialHistoryFetchIfNeeded(
   origin: string | undefined,
   epoch: number,
 ): void {
+  // Release the shared pagination lock so that loadOlderMessages is not
+  // permanently blocked when this invalidated request exits without retrying.
+  // If a retry does happen, ensureInitialMessages will re-acquire the lock.
+  setState(sessionId, (s) => (s.isLoadingMore ? { ...s, isLoadingMore: false } : s));
   const ownsFetch = _historyFetchToken.get(sessionId) === token;
   const epochChanged = (_messagesEpoch.get(sessionId) ?? 0) !== epoch;
   const originUnchanged = remoteProjectsStore.getSessionDeviceId(sessionId) === origin;
@@ -10490,7 +10494,7 @@ function ensureInitialMessages(sessionId: string): void {
       // rewind 之类的粘滞抑制(见 releaseCacheHydrationAfterFailure)。屏上已 hydrate 的
       // 缓存行**保持不动**:离线时它是用户唯一能看到的历史,清掉纯属倒退。
       releaseCacheHydrationAfterFailure(sessionId);
-      setState(sessionId, (s) => ({ ...s, historyLoaded: false }));
+      setState(sessionId, (s) => ({ ...s, historyLoaded: false, isLoadingMore: false }));
     });
 }
 

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -9930,11 +9930,13 @@ function retryInvalidatedInitialHistoryFetchIfNeeded(
   origin: string | undefined,
   epoch: number,
 ): void {
-  // Release the shared pagination lock so that loadOlderMessages is not
-  // permanently blocked when this invalidated request exits without retrying.
-  // If a retry does happen, ensureInitialMessages will re-acquire the lock.
-  setState(sessionId, (s) => (s.isLoadingMore ? { ...s, isLoadingMore: false } : s));
   const ownsFetch = _historyFetchToken.get(sessionId) === token;
+  // Release the shared pagination lock only when this fetch still owns the
+  // token.  A stale callback from a superseded fetch must not clear the lock
+  // that a newer replacement backfill is actively holding.
+  if (ownsFetch) {
+    setState(sessionId, (s) => (s.isLoadingMore ? { ...s, isLoadingMore: false } : s));
+  }
   const epochChanged = (_messagesEpoch.get(sessionId) ?? 0) !== epoch;
   const originUnchanged = remoteProjectsStore.getSessionDeviceId(sessionId) === origin;
   releaseHistoryFetchIfCurrent(sessionId, token);


### PR DESCRIPTION
## 这次改了什么

### 摘要

Fixes #3377.

`ensureInitialMessages` 取得共享分页锁 `isLoadingMore = true` 后开始异步 backfill。当 epoch 变化（reloadMessages / purge / rewind 等）导致旧请求被作废时，`retryInvalidatedInitialHistoryFetchIfNeeded` 和 `.catch()` 错误路径都没有释放 `isLoadingMore`，导致锁永久生效：spinner 永久显示、`loadOlderMessages` 被 gate、用户无法继续翻页。

修复：在 `retryInvalidatedInitialHistoryFetchIfNeeded` 开头释放分页锁（无论是否重试，`ensureInitialMessages` 会重新获取）；在 `.catch()` 错误路径也释放锁。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：#3377
- 本 PR 包含：`isLoadingMore` lock release in `retryInvalidatedInitialHistoryFetchIfNeeded` and `.catch()` error path
- 明确不包含：分页系统重构、UI 变更
- 用户可见变化：长任务历史补页 spinner 不再永久卡住
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：不涉及：仅修改异步 store 的分页锁释放逻辑，无视觉/交互/文案变化。

## 怎么验证的

- `cd apps/desktop && npx vitest run src/renderer/__tests__/makerChatStoreActiveView.test.ts` — 35/35 passed (含新增回归测试)
- `cd apps/desktop && npx vitest run src/renderer/__tests__/makerChatStoreJumpBackfill.test.ts` — 全部通过
- 新增回归测试：`releases isLoadingMore when initial backfill is invalidated by epoch change`

## 风险

修改 `retryInvalidatedInitialHistoryFetchIfNeeded` 的锁释放时机。已验证：释放后若发生重试，`ensureInitialMessages` 会重新获取锁；若不重试，锁正确释放。不会引入新的竞态。