### PR TITLE
fix(desktop): 修复 Codex 子代理 HTTP fallback 路由

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
@@ -2532,6 +2532,7 @@ describe('codex proxy host', () => {
     });
     await host.ensureCodexProxyReady();
     host.setCodexProxyAuthInjection('oauth-bearer');
+    host.setCodexProxyGatewayKeyReader(() => 'gateway-subagent-key');
     host.registerComposed(
       'session-ws-parent',
       'thread-ws-parent',
@@ -2580,6 +2581,20 @@ describe('codex proxy host', () => {
         'session-ws-child-2',
         'thread-ws-parent',
       ))).toBeNull();
+      // Codex's HTTP fallback may only carry the child thread id. The WS
+      // handshake must have bound the child route before returning 426, or this
+      // request falls through as a normal ChatGPT OAuth request.
+      await expect(Promise.resolve(host.createModelRoutingTransform()(
+        { model: 'gpt-5.6-sol', input: [] },
+        {
+          reqId: 1,
+          method: 'POST',
+          url: '/responses',
+          headers: { 'thread-id': 'thread-ws-child-2' },
+        },
+      ))).resolves.toEqual({
+        headerOverride: { authorization: 'Bearer gateway-subagent-key' },
+      });
       // 未配置独立 route 的 collab child 不应被全局降级。
       expect(proxyOpts.resolveWebSocketUpstream(ctxForCodex145ChildPrewarm(
         'thread-openai-child',
@@ -2590,6 +2605,7 @@ describe('codex proxy host', () => {
       );
     } finally {
       host.unregister('session-ws-parent');
+      host.setCodexProxyGatewayKeyReader(() => null);
       host.clearCodexProxyAuthInjection();
     }
   });

--- a/apps/desktop/src/main/maker-host/codex-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/codex-proxy-host.ts
@@ -322,8 +322,9 @@ function subagentRouteFromHeaders(
  * Resolve only the independent Subagent route carried by this WS upgrade.
  *
  * A registered child already owns a frozen route snapshot. Its first
- * collab_spawn upgrade can race thread/started, so fall back to the explicit
- * parent header without mutating thread ownership from the handshake path.
+ * collab_spawn upgrade can race thread/started; when the handshake already
+ * carries a real child thread id, bind it before returning 426 so Codex's HTTP
+ * fallback can still resolve the frozen route if it omits parent metadata.
  */
 function subagentRouteForWebSocketUpgrade(
   headers: Readonly<Record<string, string>>,
@@ -334,8 +335,16 @@ function subagentRouteForWebSocketUpgrade(
 
   const parentThreadId = headerValue(headers, 'x-codex-parent-thread-id');
   if (!parentThreadId) return undefined;
-  return subagentRouteByThread.get(parentThreadId)
+  const inheritedRoute = subagentRouteByThread.get(parentThreadId)
     ?? subagentRouteByParentThread.get(parentThreadId);
+  if (!inheritedRoute) return undefined;
+
+  const childThreadId = headerValue(headers, 'thread-id');
+  if (childThreadId) {
+    registerChildThread(parentThreadId, childThreadId);
+    return subagentRouteByThread.get(childThreadId) ?? inheritedRoute;
+  }
+  return inheritedRoute;
 }
 
 interface ProviderRequestContext {


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Codex subagent 在 WS 握手被 Cindy 回 426 后，HTTP fallback 只带 child thread-id 时会丢失冻结路由的问题。现在握手阶段会先把 child 线程绑定到父线程的 subagent 路由，避免后续 fallback 误落到 ChatGPT 默认上游并返回 non-SSE 错误。

### 变更类型

- [x] fix 缺陷修复
- [ ] feat 新功能
- [ ] refactor / perf 重构或性能优化
- [ ] docs / test / chore 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：X 上关于 @askmycindy 的 subagent 无法启动反馈
- 本 PR 包含：apps/desktop/src/main/maker-host/codex-proxy-host.ts、apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
- 明确不包含：UI 改动、mobile 改动、协议包改动
- 用户可见变化：subagent 不再因为 fallback 丢路由而反复重试并最终报 502
- 是否存在 breaking change：无

### UI 变化

不涉及

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

pnpm --filter desktop exec vitest run src/main/maker-host/__tests__/codexProxyHost.test.ts
结果：通过（177 tests passed）

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm test:unit:related
结果：通过（apps/desktop 相关单测通过）

git diff --check
结果：通过

### 手工验证

不涉及

### 未执行的验证

无

## 风险

### 风险分类

- [x] 协议兼容
- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Codex subagent 的 WS 426 后 HTTP fallback 路由绑定
- 回滚 / 降级方式：回退这个提交即可恢复旧路由行为

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（git commit -s，见 DCO）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
