### PR TITLE
fix(mobile): 修复远程消息文件在工作目录不可用时无法预览

### DIFF
--- a/apps/mobile/app/files/preview/[sessionId].tsx
+++ b/apps/mobile/app/files/preview/[sessionId].tsx
@@ -47,6 +47,7 @@ import { withTransientRemoteRetry } from '@/device-link/remoteRetry';
 import { useMobileMakerTransport } from '@/device-link/useMobileMakerTransport';
 import type { FileBrowserReadFileResult, MobileMakerTransport } from '@/device-link/mobileMakerTransport';
 import { isAbsolutePathShape, pathDisplayName } from '@/session/chatPathCandidate';
+import { chatFileDirectAbsFallback } from '@/session/chatFilePathContext';
 import { adaptTextFilePreviewResult, fetchRemoteAbsFileOnce, fetchRemoteAbsFileToUrl } from '@/session/remoteAbsFileFetch';
 import { formatByteSize, isHtmlFilePreviewCandidate } from '@/session/filePreview';
 import { joinRemotePath } from '@/session/htmlLocalResources';
@@ -54,6 +55,7 @@ import { decodeGzipBase64Text, mergePathIntoComposerDraft, shareMimeForFileName 
 import { appendQuote, truncateQuoteText } from '@/session/chatQuoteStore';
 import { getCachedPreviewText, storeCachedPreviewText } from '@/session/fileBrowserCache';
 import { exportRemoteFileToUrl } from '@/session/fileBrowserExport';
+import { isRemoteWorkdirUnavailableError } from '@/session/remoteWorkdirFallback';
 import type { RemoteMediaSshContext } from '@/session/fileBrowserGallery';
 import { HtmlFileReader } from '@/session/HtmlFileReader';
 import {
@@ -143,6 +145,7 @@ export default function RemoteFilePreviewScreen() {
     deviceName?: string;
     relPath?: string;
     absPath?: string;
+    directAbsPath?: string;
     sort?: string;
     line?: string;
   }>();
@@ -152,6 +155,9 @@ export default function RemoteFilePreviewScreen() {
   const initialRelPath = readRouteString(params.relPath) ?? '';
   // absPath 单文件模式:workdir 外文件,relPath 通道不可用(详见文件头注释)。
   const singleAbsPath = initialRelPath ? null : readRouteString(params.absPath);
+  // 本地设备任务的 workdir 内消息文件保留 relPath/pager，同时携带绝对路径作为
+  // REMOTE_WORKDIR_UNAVAILABLE 的单文件兜底。SSH 路由不会带这个参数。
+  const directAbsPath = initialRelPath ? readRouteString(params.directAbsPath) : null;
   const sortParam = readRouteString(params.sort);
   const sortMode: FileBrowserSortMode = sortParam === 'mtime' || sortParam === 'size' ? sortParam : 'name';
   // 内容搜索进入时的命中行(只作用于最初打开的那个文件)。
@@ -379,14 +385,29 @@ export default function RemoteFilePreviewScreen() {
       if (singleAbsPath) {
         return fetchRemoteAbsFileToUrl({ maker, deviceId, openLink, presignGet }, singleAbsPath);
       }
+      const fallbackAbsPath = chatFileDirectAbsFallback(initialRelPath, directAbsPath, relPath);
       return exportRemoteFileToUrl(
-        { maker, deviceId, openLink, presignGet, isCancelled: () => unmountedRef.current },
+        {
+          maker,
+          deviceId,
+          openLink,
+          presignGet,
+          isCancelled: () => unmountedRef.current,
+          ...(fallbackAbsPath
+            ? {
+                onRemoteWorkdirUnavailableAtStart: () => fetchRemoteAbsFileToUrl(
+                  { maker, deviceId, openLink, presignGet },
+                  fallbackAbsPath,
+                ),
+              }
+            : {}),
+        },
         workdir,
         relPath,
         mtimeMs,
       );
     },
-    [deviceId, maker, openLink, presignGet, singleAbsPath, workdir],
+    [deviceId, directAbsPath, initialRelPath, maker, openLink, presignGet, singleAbsPath, workdir],
   );
 
   /**
@@ -492,9 +513,16 @@ export default function RemoteFilePreviewScreen() {
           const res = await maker.fs.readTextFilePreview(singleAbsPath);
           return adaptTextFilePreviewResult(singleAbsPath, res);
         }
-        return maker.fileBrowser.readFile(workdir, relPath, { acceptGzip: true });
+        try {
+          return await maker.fileBrowser.readFile(workdir, relPath, { acceptGzip: true });
+        } catch (error) {
+          const fallbackAbsPath = chatFileDirectAbsFallback(initialRelPath, directAbsPath, relPath);
+          if (!fallbackAbsPath || !isRemoteWorkdirUnavailableError(error)) throw error;
+          const res = await maker.fs.readTextFilePreview(fallbackAbsPath);
+          return adaptTextFilePreviewResult(fallbackAbsPath, res);
+        }
       }),
-    [deviceId, maker, openLink, singleAbsPath, workdir],
+    [deviceId, directAbsPath, initialRelPath, maker, openLink, singleAbsPath, workdir],
   );
 
   const downloadAndShare = useCallback(async (item: FileBrowserGridItem) => {
@@ -817,7 +845,7 @@ function AvPreviewPage({
   const requestedRef = useRef(false);
 
   useEffect(() => {
-    if (!active || requestedRef.current || !workdir) return undefined;
+    if (!active || requestedRef.current || (!workdir && !isAbsolutePathShape(item.relPath))) return undefined;
     requestedRef.current = true;
     let cancelled = false;
     setFailure(null);
@@ -898,7 +926,7 @@ function PdfPreviewPage({
   }, [failure, recoveryEpoch]);
 
   useEffect(() => {
-    if (!active || requestedRef.current || !workdir) return undefined;
+    if (!active || requestedRef.current || (!workdir && !isAbsolutePathShape(item.relPath))) return undefined;
     requestedRef.current = true;
     requestedAtRecoveryEpochRef.current = latestRecoveryEpochRef.current;
     let cancelled = false;
@@ -1000,7 +1028,7 @@ function TextPreviewPage({
   const scrolledToTargetRef = useRef(false);
 
   useEffect(() => {
-    if (!active || loadedRef.current || !workdir) return;
+    if (!active || loadedRef.current || (!workdir && !isAbsolutePathShape(item.relPath))) return;
     loadedRef.current = true;
     let cancelled = false;
     void readTextFile(item.relPath)
@@ -1220,7 +1248,7 @@ function ImagePreviewPage({
   const requestedRef = useRef(false);
 
   useEffect(() => {
-    if (!active || requestedRef.current || !workdir) return undefined;
+    if (!active || requestedRef.current || (!workdir && !isAbsolutePathShape(item.relPath))) return undefined;
     requestedRef.current = true;
     let cancelled = false;
     setFailure(null);

--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -538,7 +538,13 @@ import {
   type RemoteMediaRequestOptions,
   type RemoteMediaResolveHooks,
 } from '@/session/remoteMediaResolveQueue';
-import { ChatFilePathContext, type ChatFilePathContextValue, type ChatFilePathTarget } from '@/session/chatFilePathContext';
+import {
+  chatFilePreviewPathParams,
+  ChatFilePathContext,
+  shouldFetchChatFileByAbsolutePath,
+  type ChatFilePathContextValue,
+  type ChatFilePathTarget,
+} from '@/session/chatFilePathContext';
 import { pathDisplayName } from '@/session/chatPathCandidate';
 import { fetchRemoteAbsFileToUrl } from '@/session/remoteAbsFileFetch';
 import { ChatFileChipMenuSheet } from '@/session/ChatFileChipMenuSheet';
@@ -8228,9 +8234,9 @@ export default function SessionScreen() {
 
   // chip「打开」:文件 → Quick Look 预览页(带行号),目录 → 文件浏览器定位。
   // 点击与长按菜单的「快速预览 / 打开文件浏览器」共用这一条。
-  // workdir 外文件(relPath 为 null)预览页走 absPath 单文件模式(被控端
-  // absPath 取件通道,无同目录翻页);workdir 外目录在 chip 层就不点亮,
-  // 不会走到这里(canOpenChatPathChip)。
+  // 本地设备任务里的消息文件额外携带 directAbsPath；正常仍用 relPath 保留同目录翻页，
+  // workdir 探测明确失败时才与 Desktop 控制端复用 media:fetch 取件。SSH 只走 workdir
+  // 内 relPath；workdir 外目标 fail-closed，避免把 SSH 路径误交给 Desktop 本机取件。
   const openChatPathTarget = useCallback((target: ChatFilePathTarget) => {
     if (target.kind === 'directory') {
       if (target.relPath === null) return;
@@ -8240,19 +8246,19 @@ export default function SessionScreen() {
       });
       return;
     }
+    const pathParams = chatFilePreviewPathParams(target, currentSession?.remoteHostId);
+    if (!pathParams) return;
     router.push({
       pathname: '/files/preview/[sessionId]',
       params: {
         sessionId,
         deviceId,
         deviceName,
-        ...(target.relPath !== null
-          ? { relPath: target.relPath }
-          : { absPath: target.absPath }),
+        ...pathParams,
         ...(target.line !== undefined ? { line: String(target.line) } : {}),
       },
     });
-  }, [deviceId, deviceName, router, sessionId]);
+  }, [currentSession?.remoteHostId, deviceId, deviceName, router, sessionId]);
 
   // chip 长按菜单(浮动面板,ContextSheet/模型选择面板同款):target 即开关。
   const [chipMenuTarget, setChipMenuTarget] = useState<ChatFilePathTarget | null>(null);
@@ -8324,11 +8330,14 @@ export default function SessionScreen() {
   /** chip 菜单「导出 / 分享」:两段式导出 → 系统分享单(与文件浏览器同链路);
    *  mtime 先列一拍父目录拿真实值(导出 URL 缓存 key 依赖),拿不到用当前时间
    *  兜底——宁可多导出一次也不复用同路径被覆写前的旧文件。
-   *  workdir 外文件(relPath 为 null)改走被控端 media:fetch 绝对路径取件
-   *  (xdt-file://open?path=…,与文件浏览器 gallery / 预览页 absPath 模式同一通道)。 */
+   *  本地设备任务的 workdir 外文件(relPath 为 null)直接走被控端 media:fetch 绝对路径取件；
+   *  workdir 内文件只在导出启动前的目录探测明确不可用时回退该通道。SSH workdir 外阻断。 */
   const shareChipFile = useCallback(async (target: ChatFilePathTarget) => {
     const workdir = currentSession?.workingDir?.trim();
     if (!deviceId || !workdir || chipShareBusy) return;
+    // 防御纵深：正常 UI 已不点亮 SSH workdir 外路径；即使旧状态残留菜单也不允许
+    // 把 SSH 绝对路径交给 Desktop 本机 media:fetch。
+    if (target.relPath === null && currentSession?.remoteHostId?.trim()) return;
     setChipShareBusy(true);
     try {
       const name = pathDisplayName(target.relPath ?? target.absPath);
@@ -8343,21 +8352,35 @@ export default function SessionScreen() {
           target.absPath,
         );
       } else {
+        const relPath = target.relPath;
         let mtimeMs = Date.now();
         try {
           const raw = await withTransientRemoteRetry(async () => {
             await openLink(deviceId);
-            return maker.fileBrowser.listDir(workdir, parentRelPath(target.relPath ?? '') ?? '');
+            return maker.fileBrowser.listDir(workdir, parentRelPath(relPath) ?? '');
           });
-          const entry = normalizeRemoteOpDirEntries(raw).find((item) => item.relPath === target.relPath);
+          const entry = normalizeRemoteOpDirEntries(raw).find((item) => item.relPath === relPath);
           if (entry) mtimeMs = entry.mtimeMs;
         } catch {
           /* 列目录失败不阻断分享,退当前时间 key */
         }
         url = await exportRemoteFileToUrl(
-          { maker, deviceId, openLink, presignGet },
+          {
+            maker,
+            deviceId,
+            openLink,
+            presignGet,
+            ...(shouldFetchChatFileByAbsolutePath(target, currentSession?.remoteHostId)
+              ? {
+                  onRemoteWorkdirUnavailableAtStart: () => fetchRemoteAbsFileToUrl(
+                    { maker, deviceId, openLink, presignGet },
+                    target.absPath,
+                  ),
+                }
+              : {}),
+          },
           workdir,
-          target.relPath,
+          relPath,
           mtimeMs,
         );
       }
@@ -8373,7 +8396,7 @@ export default function SessionScreen() {
     } finally {
       setChipShareBusy(false);
     }
-  }, [auth, chipShareBusy, currentSession?.workingDir, deviceId, maker, openLink]);
+  }, [auth, chipShareBusy, currentSession?.remoteHostId, currentSession?.workingDir, deviceId, maker, openLink]);
 
   /** chip 长按菜单动作分发。除「分享」(异步、行内 busy)外均即时执行并关面板。 */
   const handleChipMenuAction = useCallback((key: ChatFileChipMenuActionKey, target: ChatFilePathTarget) => {

--- a/apps/mobile/src/__tests__/chatFilePathContext.test.ts
+++ b/apps/mobile/src/__tests__/chatFilePathContext.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  chatFileDirectAbsFallback,
+  chatFilePreviewPathParams,
+  shouldFetchChatFileByAbsolutePath,
+  type ChatFilePathTarget,
+} from '@/session/chatFilePathContext';
+
+function fileTarget(relPath: string | null): ChatFilePathTarget {
+  return {
+    kind: 'file',
+    relPath,
+    absPath: 'D:\\repo\\tmp\\preview.png',
+  };
+}
+
+describe('shouldFetchChatFileByAbsolutePath', () => {
+  it('本地设备任务允许用绝对路径作为单文件取件兜底', () => {
+    expect(shouldFetchChatFileByAbsolutePath(fileTarget('tmp/preview.png'))).toBe(true);
+    expect(shouldFetchChatFileByAbsolutePath(fileTarget(null), '  ')).toBe(true);
+  });
+
+  it('SSH 任务不把远端绝对路径交给 Desktop 本机取件', () => {
+    expect(shouldFetchChatFileByAbsolutePath(fileTarget('tmp/preview.png'), 'host-1')).toBe(false);
+    expect(shouldFetchChatFileByAbsolutePath(fileTarget(null), 'host-1')).toBe(false);
+  });
+
+  it('目录不进入单文件绝对路径取件', () => {
+    expect(shouldFetchChatFileByAbsolutePath({
+      kind: 'directory',
+      relPath: 'tmp',
+      absPath: 'D:\\repo\\tmp',
+    })).toBe(false);
+  });
+});
+
+describe('chatFileDirectAbsFallback', () => {
+  it('只有消息最初点名的文件使用绝对路径兜底，同目录翻页文件不继承', () => {
+    expect(chatFileDirectAbsFallback(
+      'tmp/preview.png',
+      'D:\\repo\\tmp\\preview.png',
+      'tmp/preview.png',
+    )).toBe('D:\\repo\\tmp\\preview.png');
+    expect(chatFileDirectAbsFallback(
+      'tmp/preview.png',
+      'D:\\repo\\tmp\\preview.png',
+      'tmp/sibling.png',
+    )).toBeNull();
+  });
+});
+
+describe('chatFilePreviewPathParams', () => {
+  it('本地设备任务保留 relPath 翻页并携带 directAbsPath 兜底', () => {
+    expect(chatFilePreviewPathParams(fileTarget('tmp/preview.png'))).toEqual({
+      relPath: 'tmp/preview.png',
+      directAbsPath: 'D:\\repo\\tmp\\preview.png',
+    });
+  });
+
+  it('SSH workdir 内文件只携带相对路径', () => {
+    expect(chatFilePreviewPathParams(fileTarget('tmp/preview.png'), 'host-1')).toEqual({
+      relPath: 'tmp/preview.png',
+    });
+  });
+
+  it('既有 workdir 外文件继续进入 absPath 单文件模式', () => {
+    expect(chatFilePreviewPathParams(fileTarget(null))).toEqual({
+      absPath: 'D:\\repo\\tmp\\preview.png',
+    });
+  });
+
+  it('SSH workdir 外文件 fail-closed，不回落到 Desktop 本机绝对路径', () => {
+    expect(chatFilePreviewPathParams(fileTarget(null), 'host-1')).toBeNull();
+  });
+});

--- a/apps/mobile/src/__tests__/chatFileRemoteFallbackWiring.test.ts
+++ b/apps/mobile/src/__tests__/chatFileRemoteFallbackWiring.test.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+function readSource(relPath: string): string {
+  return readFileSync(resolve(process.cwd(), relPath), 'utf8').replace(/\r\n/g, '\n');
+}
+
+const sessionSource = readSource('app/sessions/[sessionId].tsx');
+const previewSource = readSource('app/files/preview/[sessionId].tsx');
+
+describe('chat file remote workdir fallback wiring', () => {
+  it('打开消息文件时同时传相对路径与受控绝对路径兜底', () => {
+    expect(sessionSource).toContain('const pathParams = chatFilePreviewPathParams(target, currentSession?.remoteHostId)');
+    expect(sessionSource).toContain('if (!pathParams) return;');
+    expect(sessionSource).toContain('...pathParams,');
+    expect(previewSource).toContain('directAbsPath?: string;');
+    expect(previewSource).toContain('readRouteString(params.directAbsPath)');
+  });
+
+  it('图片、PDF、音视频和下载只在导出启动前的 workdir 错误上回退', () => {
+    expect(previewSource).toContain('onRemoteWorkdirUnavailableAtStart: () => fetchRemoteAbsFileToUrl(');
+    expect(previewSource).toContain('chatFileDirectAbsFallback(initialRelPath, directAbsPath, relPath)');
+  });
+
+  it('文本预览只在同一错误码下改走绝对路径读取', () => {
+    expect(previewSource).toContain('!isRemoteWorkdirUnavailableError(error)');
+    expect(previewSource).toContain('maker.fs.readTextFilePreview(fallbackAbsPath)');
+  });
+
+  it('消息文件分享复用同一导出启动兜底，SSH 不启用本机绝对路径兜底', () => {
+    expect(sessionSource).toContain('shouldFetchChatFileByAbsolutePath(target, currentSession?.remoteHostId)');
+    expect(sessionSource).toContain('onRemoteWorkdirUnavailableAtStart: () => fetchRemoteAbsFileToUrl(');
+  });
+});

--- a/apps/mobile/src/__tests__/chatPathCandidate.test.ts
+++ b/apps/mobile/src/__tests__/chatPathCandidate.test.ts
@@ -226,9 +226,10 @@ describe('isAbsolutePathShape / pathDisplayName', () => {
 });
 
 describe('canOpenChatPathChip', () => {
-  it('文件始终可开(workdir 内 relPath / workdir 外 null 均可)', () => {
+  it('本地文件始终可开；SSH workdir 外文件 fail-closed', () => {
     expect(canOpenChatPathChip('file', 'src/a.ts')).toBe(true);
     expect(canOpenChatPathChip('file', null)).toBe(true);
+    expect(canOpenChatPathChip('file', null, 'ssh-host-1')).toBe(false);
   });
 
   it('目录仅 workdir 内可开(文件浏览器以 workdir 为根)', () => {

--- a/apps/mobile/src/__tests__/fileBrowserExportFallback.test.ts
+++ b/apps/mobile/src/__tests__/fileBrowserExportFallback.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { MobileMakerTransport } from '@/device-link/mobileMakerTransport';
+import {
+  exportRemoteFileToUrl,
+  type ExportRemoteFileDeps,
+} from '@/session/fileBrowserExport';
+
+function makeDeps() {
+  const exportFileStart = vi.fn<MobileMakerTransport['fileBrowser']['exportFileStart']>();
+  const exportFileStatus = vi.fn<MobileMakerTransport['fileBrowser']['exportFileStatus']>();
+  const fallback = vi.fn(async () => 'https://oss.example/direct');
+  const deps: ExportRemoteFileDeps = {
+    maker: {
+      fileBrowser: {
+        exportFileStart,
+        exportFileStatus,
+      },
+    },
+    deviceId: `dev-${Math.random().toString(36).slice(2)}`,
+    openLink: vi.fn(async () => undefined),
+    presignGet: vi.fn(async () => ({
+      getUrl: 'https://oss.example/export',
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+    })),
+    onRemoteWorkdirUnavailableAtStart: fallback,
+  };
+  return { deps, exportFileStart, exportFileStatus, fallback };
+}
+
+describe('exportRemoteFileToUrl workdir fallback', () => {
+  it('正常导出保留 start→status→presign 与 path+mtime 缓存，不调用兜底', async () => {
+    const { deps, exportFileStart, exportFileStatus, fallback } = makeDeps();
+    exportFileStart.mockResolvedValueOnce({ ok: true, transferId: 'transfer-ok', size: 2, mtimeMs: 9 });
+    exportFileStatus.mockResolvedValueOnce({
+      ok: true,
+      state: 'done',
+      key: 'exports/file-ok',
+      size: 2,
+      uploaded: 2,
+    });
+
+    await expect(exportRemoteFileToUrl(deps, 'D:\\repo', 'tmp/ok.png', 9))
+      .resolves.toBe('https://oss.example/export');
+    await expect(exportRemoteFileToUrl(deps, 'D:\\repo', 'tmp/ok.png', 9))
+      .resolves.toBe('https://oss.example/export');
+    expect(exportFileStart).toHaveBeenCalledTimes(1);
+    expect(exportFileStatus).toHaveBeenCalledTimes(1);
+    expect(fallback).not.toHaveBeenCalled();
+  });
+
+  it('只在导出任务创建前的 workdir 不可用错误上回退', async () => {
+    const { deps, exportFileStart, exportFileStatus, fallback } = makeDeps();
+    exportFileStart.mockRejectedValueOnce(Object.assign(new Error('probe timed out'), {
+      code: 'REMOTE_WORKDIR_UNAVAILABLE',
+    }));
+
+    await expect(exportRemoteFileToUrl(deps, 'D:\\repo', 'tmp/a.png', 1))
+      .resolves.toBe('https://oss.example/direct');
+    expect(fallback).toHaveBeenCalledTimes(1);
+    expect(exportFileStatus).not.toHaveBeenCalled();
+  });
+
+  it('导出状态阶段失败不回退，避免遗留后台任务', async () => {
+    const { deps, exportFileStart, exportFileStatus, fallback } = makeDeps();
+    exportFileStart.mockResolvedValueOnce({ ok: true, transferId: 'transfer-1', size: 1, mtimeMs: 1 });
+    exportFileStatus.mockRejectedValueOnce(Object.assign(new Error('probe timed out'), {
+      code: 'REMOTE_WORKDIR_UNAVAILABLE',
+    }));
+
+    await expect(exportRemoteFileToUrl(deps, 'D:\\repo', 'tmp/b.png', 2))
+      .rejects.toThrow('probe timed out');
+    expect(fallback).not.toHaveBeenCalled();
+  });
+
+  it('其它导出启动错误原样抛出', async () => {
+    const { deps, exportFileStart, fallback } = makeDeps();
+    exportFileStart.mockRejectedValueOnce(Object.assign(new Error('remote disabled'), {
+      code: 'REMOTE_DISABLED',
+    }));
+
+    await expect(exportRemoteFileToUrl(deps, 'D:\\repo', 'tmp/c.png', 3))
+      .rejects.toThrow('remote disabled');
+    expect(fallback).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mobile/src/__tests__/remoteWorkdirFallback.test.ts
+++ b/apps/mobile/src/__tests__/remoteWorkdirFallback.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+
+import { isRemoteWorkdirUnavailableError } from '@/session/remoteWorkdirFallback';
+
+describe('isRemoteWorkdirUnavailableError', () => {
+  it('识别结构化错误码', () => {
+    expect(isRemoteWorkdirUnavailableError(
+      Object.assign(new Error('Remote working directory check timed out.'), {
+        code: 'REMOTE_WORKDIR_UNAVAILABLE',
+      }),
+    )).toBe(true);
+  });
+
+  it('兼容隧道展平后的错误文本', () => {
+    expect(isRemoteWorkdirUnavailableError(
+      '[REMOTE_WORKDIR_UNAVAILABLE] Remote working directory check timed out.',
+    )).toBe(true);
+  });
+
+  it('不把普通超时或其它远程错误误判成路径兜底条件', () => {
+    expect(isRemoteWorkdirUnavailableError(new Error('request timed out'))).toBe(false);
+    expect(isRemoteWorkdirUnavailableError('[NOT_REMOTE_WORKDIR_UNAVAILABLE] wrong marker')).toBe(false);
+    expect(isRemoteWorkdirUnavailableError(
+      Object.assign(new Error('offline'), { code: 'DEVICE_OFFLINE' }),
+    )).toBe(false);
+  });
+});

--- a/apps/mobile/src/session/MessageRenderer.tsx
+++ b/apps/mobile/src/session/MessageRenderer.tsx
@@ -4385,7 +4385,7 @@ function ChatPathChipSpan({
   }
   const kind: 'file' | 'directory' =
     verdict === 'directory' || (verdict === 'unknown' && candidate.directoryShape) ? 'directory' : 'file';
-  if (!canOpenChatPathChip(kind, target.relPath)) {
+  if (!canOpenChatPathChip(kind, target.relPath, ctx.remoteHostId)) {
     return <SpanText style={plainStyle}>{display}</SpanText>;
   }
   const chipTarget: ChatFilePathTarget = {

--- a/apps/mobile/src/session/chatFilePathContext.ts
+++ b/apps/mobile/src/session/chatFilePathContext.ts
@@ -26,6 +26,51 @@ export interface ChatFilePathTarget {
   line?: number;
 }
 
+/**
+ * 聊天消息里已经明确点名的单个文件，在设备互联会话中可以安全地使用 Desktop 控制端
+ * 已有的绝对路径取件作为兜底。正常情况下仍先走 workdir 相对路径，以保留同目录翻页、
+ * 大文件两段式导出与 mtime 缓存；只有 workdir 探测明确不可用时才回退。
+ *
+ * SSH 会话仍保留 workdir 相对路径通道：它需要可信 session/host/workdir 上下文决定
+ * 实际执行端，不能把 SSH 绝对路径当成被控 Desktop 的本机路径。
+ */
+export function shouldFetchChatFileByAbsolutePath(
+  target: ChatFilePathTarget,
+  remoteHostId?: string | null,
+): boolean {
+  return target.kind === 'file' && !remoteHostId?.trim();
+}
+
+export type ChatFilePreviewPathParams =
+  | { absPath: string }
+  | { relPath: string; directAbsPath?: string };
+
+/**
+ * workdir 内文件仍携带 relPath 以保留同目录翻页；设备互联会话额外带上
+ * directAbsPath，让当前消息明确引用的文件在 workdir 探测失败时回退取件。
+ */
+export function chatFilePreviewPathParams(
+  target: ChatFilePathTarget,
+  remoteHostId?: string | null,
+): ChatFilePreviewPathParams | null {
+  if (target.relPath === null) {
+    return remoteHostId?.trim() ? null : { absPath: target.absPath };
+  }
+  if (shouldFetchChatFileByAbsolutePath(target, remoteHostId)) {
+    return { relPath: target.relPath, directAbsPath: target.absPath };
+  }
+  return { relPath: target.relPath };
+}
+
+/** 同目录翻页时只有消息最初点名的文件可以使用 route 携带的绝对路径兜底。 */
+export function chatFileDirectAbsFallback(
+  initialRelPath: string,
+  directAbsPath: string | null,
+  itemRelPath: string,
+): string | null {
+  return directAbsPath && itemRelPath === initialRelPath ? directAbsPath : null;
+}
+
 export interface ChatFilePathContextValue {
   deviceId: string;
   /** 当前会话 id；SSH 媒体取件由被控端据此反查可信 host/workdir。 */

--- a/apps/mobile/src/session/chatPathCandidate.ts
+++ b/apps/mobile/src/session/chatPathCandidate.ts
@@ -353,13 +353,19 @@ export function pathDisplayName(p: string): string {
 }
 
 /**
- * chip 是否可打开(点亮的后置条件):workdir 外(relPath 为 null)只有文件可开
- * ——文件走被控端绝对路径取件通道(fs:stat-path 已验存在);目录只能靠
+ * chip 是否可打开(点亮的后置条件):本地设备任务的 workdir 外(relPath 为 null)
+ * 只有文件可开——文件走被控端绝对路径取件通道(fs:stat-path 已验存在);目录只能靠
  * 文件浏览器定位,而文件浏览器以 workdir 为根,workdir 外目录保持纯文本。
- * 与桌面对齐:桌面对 workdir 外目录同样只报「不在工作目录内」,无可用动作。
+ * SSH workdir 外文件同样保持纯文本：不能把 SSH 绝对路径误交给 Desktop 本机取件。
+ * 与桌面对齐:桌面对 SSH workdir 外目标同样按 OUTSIDE_WORKDIR 阻断。
  */
-export function canOpenChatPathChip(kind: 'file' | 'directory', relPath: string | null): boolean {
-  return kind === 'file' || relPath !== null;
+export function canOpenChatPathChip(
+  kind: 'file' | 'directory',
+  relPath: string | null,
+  remoteHostId?: string | null,
+): boolean {
+  if (relPath !== null) return true;
+  return kind === 'file' && !remoteHostId?.trim();
 }
 
 /**

--- a/apps/mobile/src/session/fileBrowserExport.ts
+++ b/apps/mobile/src/session/fileBrowserExport.ts
@@ -8,17 +8,28 @@ import { withTransientRemoteRetry } from '@/device-link/remoteRetry';
 import type { MobileMakerTransport } from '@/device-link/mobileMakerTransport';
 import { getCachedExportUrl, storeCachedExportUrl } from '@/session/fileBrowserCache';
 import type { MobileRemoteMediaPresignResult } from '@/session/remoteMedia';
+import { isRemoteWorkdirUnavailableError } from '@/session/remoteWorkdirFallback';
 
 const EXPORT_POLL_INTERVAL_MS = 700;
 const EXPORT_TIMEOUT_MS = 120_000;
 
 export interface ExportRemoteFileDeps {
-  maker: Pick<MobileMakerTransport, 'fileBrowser'>;
+  maker: {
+    fileBrowser: Pick<
+      MobileMakerTransport['fileBrowser'],
+      'exportFileStart' | 'exportFileStatus'
+    >;
+  };
   deviceId: string;
   openLink: (deviceId: string) => Promise<unknown>;
   presignGet: (ossKey: string) => Promise<MobileRemoteMediaPresignResult>;
   /** 取消信号(如页面卸载):轮询每轮检查,true 即中止,不再空转最长 2 分钟。 */
   isCancelled?: () => boolean;
+  /**
+   * 仅在 exportFileStart 尚未创建导出任务、且 workdir 前置探测明确不可用时调用。
+   * status 阶段不回退，避免遗留已启动的后台导出任务或 OSS 对象。
+   */
+  onRemoteWorkdirUnavailableAtStart?: () => Promise<string>;
 }
 
 export async function exportRemoteFileToUrl(
@@ -29,10 +40,18 @@ export async function exportRemoteFileToUrl(
 ): Promise<string> {
   const cached = getCachedExportUrl(deps.deviceId, workdir, relPath, mtimeMs);
   if (cached) return cached;
-  const start = await withTransientRemoteRetry(async () => {
-    await deps.openLink(deps.deviceId);
-    return deps.maker.fileBrowser.exportFileStart(workdir, relPath);
-  });
+  let start: Awaited<ReturnType<MobileMakerTransport['fileBrowser']['exportFileStart']>>;
+  try {
+    start = await withTransientRemoteRetry(async () => {
+      await deps.openLink(deps.deviceId);
+      return deps.maker.fileBrowser.exportFileStart(workdir, relPath);
+    });
+  } catch (error) {
+    if (deps.onRemoteWorkdirUnavailableAtStart && isRemoteWorkdirUnavailableError(error)) {
+      return deps.onRemoteWorkdirUnavailableAtStart();
+    }
+    throw error;
+  }
   if (!start.ok) throw new Error(start.message ?? i18n.t('files.export.exportFailed'));
   const deadline = Date.now() + EXPORT_TIMEOUT_MS;
   for (;;) {

--- a/apps/mobile/src/session/remoteWorkdirFallback.ts
+++ b/apps/mobile/src/session/remoteWorkdirFallback.ts
@@ -1,0 +1,14 @@
+/**
+ * 只识别 Desktop 明确返回的远程工作目录不可用错误。
+ *
+ * 不能把任意超时、断链或导出失败都回退到绝对路径：调用方只有在确认失败发生于
+ * workdir 前置探测时，才可以复用已经通过消息路径验证的单文件取件能力。
+ */
+export function isRemoteWorkdirUnavailableError(error: unknown): boolean {
+  const code = typeof error === 'object' && error !== null
+    ? (error as { code?: unknown }).code
+    : undefined;
+  if (code === 'REMOTE_WORKDIR_UNAVAILABLE') return true;
+  const message = error instanceof Error ? error.message : typeof error === 'string' ? error : '';
+  return /(?:^|[^A-Z0-9_])REMOTE_WORKDIR_UNAVAILABLE(?:[^A-Z0-9_]|$)/.test(message);
+}


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复手机端查看 PC B 消息文件时，远程工作目录探测超时会在读取目标文件前直接失败的问题。

- 图片、PDF、音视频、文本和普通文档仍优先使用现有 workdir 相对路径能力，保留同目录翻页、120 秒两段式导出和 mtime 缓存。
- 仅当导出任务创建前明确返回 `REMOTE_WORKDIR_UNAVAILABLE` 时，对消息最初点名的本地设备文件回退到既有受控绝对路径取件；分享复用相同规则。
- 文本预览在同一错误码下回退既有 `text-file:read-preview` 能力。
- SSH workdir 外路径在展示、预览、打开和分享各层 fail-closed，避免把 SSH 路径误交给 Desktop 本机读取。
- 不新增 device-link channel、wire protocol、原生依赖或媒体持久化规则。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：PC A 与手机远程访问 PC B 时，消息内图片和文档应具备一致的受控查看能力。
- 本 PR 包含：Mobile 消息文件打开、预览、分享的 workdir 故障回退；SSH workdir 外路径安全收口；相关单测。
- 明确不包含：不自动持久化 Agent 工具输出；不把 PDF、docx、zip 等文档写入 `cindy-media`；不修改 Desktop、服务端或跨端协议。
- 用户可见变化：工作目录探测不可用时，手机仍可取回消息明确引用的普通图片和文档；SSH workdir 外路径不再显示为可操作文件。
- 是否存在 breaking change：无。

### UI 变化

涉及交互行为，不涉及视觉、布局或文案：保留现有文件 chip、Quick Look 与系统分享界面，只修正取件来源选择和 SSH 不安全路径的点亮门禁。

- 引用的设计规范：`docs/design-rules/DESIGN.md` §14.5 文件路径 chip 的可信点亮与交互边界；本 PR 继续要求路径经远端 stat 判定，并对不可安全取回的 SSH workdir 外目标保持纯文本。

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：通过（apps/mobile related unit tests）

pnpm --filter mobile run --if-present typecheck
结果：通过

pnpm check:dco
结果：通过（1 个 commit 已签名）
```

另执行回退、路径分流、文件预览接线相关定向测试，共 120 项通过。

### 手工验证

未执行 Mobile 实机复测。

### 未执行的验证

未启动本 worktree 的 Metro，也没有可核验的 `__DEV__` build label，因此未声明 Mobile 实机验证；完整单测由 GitHub CI 执行。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [x] 其他：workdir 故障态的大文件回退仍受既有单文件取件 30 秒上限约束。

### 影响与回滚

- 影响范围：仅 Mobile 远程任务中的消息文件预览与分享分流；正常 workdir 路径继续使用原两段式导出。Windows / POSIX 绝对路径沿用既有编码；SSH workdir 内继续走可信相对路径。
- 回滚 / 降级方式：可直接回滚本 commit；无 schema、migration、wire protocol、原生 fingerprint 或持久化数据变化。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因