### PR TITLE
fix(desktop): 支持 Kimi Code 编程计划包月 Codex 路线图片桥接

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
@@ -622,6 +622,14 @@ describe('chatBridgeCapabilitiesForRoute', () => {
   });
 
   it.each([
+    ['https://api.kimi.com/coding/v1', 'k3'],
+    ['https://api.kimi.com/coding/v1/', 'k3-256k'],
+  ])('enables image_url for Kimi Code coding-plan route: %s / %s (#2732)', async (upstream, model) => {
+    const { chatBridgeCapabilitiesForRoute } = await freshCodexProxyHost();
+    expect(chatBridgeCapabilitiesForRoute(upstream, model).imageInput).toBe('image_url');
+  });
+
+  it.each([
     ['https://ark.cn-beijing.volces.com/api/v3', 'doubao-seed-2-1-pro-260628'],
     ['https://ark.ap-southeast-1.volces.com/api/v3/', 'doubao-seed-1-6-vision-260615'],
   ])('enables image_url for Doubao Seed on official Volcengine Ark host: %s (#771)', async (upstream, model) => {
@@ -642,6 +650,12 @@ describe('chatBridgeCapabilitiesForRoute', () => {
 
   it.each([
     ['https://api.moonshot.cn/v1', 'kimi-k2.6'],
+    // Kimi Code: non-HTTPS, spoofed subdomain, and models without verified image support stay closed.
+    ['http://api.kimi.com/coding/v1', 'k3'],
+    ['https://api.kimi.com.evil.example/coding/v1', 'k3'],
+    ['https://api.kimi.com/coding/v1', 'kimi-k3'],
+    ['https://api.kimi.com/coding/v1', 'kimi-for-coding'],
+    ['https://api.moonshot.cn/v1', 'k3'],
     ['https://api.deepseek.com/v1', 'kimi-k3'],
     ['https://api.moonshot.cn.evil.example/v1', 'kimi-k3'],
     ['http://api.moonshot.cn/v1', 'kimi-k3'],

--- a/apps/desktop/src/main/maker-host/codex-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/codex-proxy-host.ts
@@ -745,6 +745,10 @@ function isGoogleGeminiChatUpstream(upstream: string): boolean {
 }
 
 const MOONSHOT_CHAT_HOSTS = new Set(['api.moonshot.cn', 'api.moonshot.ai']);
+/** Kimi Code (coding plan) official endpoint DNS boundary. */
+const KIMI_CODING_CHAT_HOST = 'api.kimi.com';
+/** Model ids on the Kimi Code Codex (openai-chat) route verified for image input. */
+const KIMI_CODING_IMAGE_CHAT_MODELS = new Set(['k3', 'k3-256k']);
 /** 火山方舟(豆包)官方 DNS 边界:ark.<region>.volces.com(如 ark.cn-beijing.volces.com)。 */
 const VOLCENGINE_ARK_CHAT_HOST_RE = /^ark\.[a-z0-9-]+\.volces\.com$/;
 /** 阿里云百炼 Coding Plan / Token Plan / 按量付费官方 DNS 边界。 */
@@ -789,6 +793,7 @@ function rewriteChatBridgeModel(model: string, stripPrefix: string | undefined):
  * 在模型级多模态能力元数据接入路由前,图片桥接先按已验证的上游能力显式开启。
  *
  * 当前覆盖:
+ * - Kimi Code（编程计划包月）K3
  * - Moonshot Kimi K3
  * - Volcengine Doubao Seed 系列
  * - Alibaba Cloud Bailian Coding Plan Qwen 3.7 Plus
@@ -819,6 +824,7 @@ function isVerifiedImageChatRoute(upstream: string, realModel: string): boolean 
   if (url.protocol !== 'https:') return false;
   const host = url.hostname.toLowerCase();
   if (realModel === 'kimi-k3') return MOONSHOT_CHAT_HOSTS.has(host);
+  if (KIMI_CODING_IMAGE_CHAT_MODELS.has(realModel)) return host === KIMI_CODING_CHAT_HOST;
   if (isDoubaoVisionModel(realModel)) return VOLCENGINE_ARK_CHAT_HOST_RE.test(host);
   if (isQwenImageChatModel(realModel)) return DASHSCOPE_CODING_CHAT_HOSTS.has(host);
   return false;


### PR DESCRIPTION
## 这次改了什么

### 摘要

在 Codex 会话中使用「Kimi Code（编程计划包月）」路线的 K3 模型时，发送图片会被本地 Responses→Chat bridge 拒绝（`unsupported_feature`），因为图片桥接能力只放行了 Moonshot 官方 `api.moonshot.cn` / `api.moonshot.ai` + `kimi-k3` 这条路由，Kimi Code 的 `api.kimi.com/coding/v1` + `k3` 不在白名单内。

Kimi K3 本身支持视觉（Moonshot 官方文档给出了 Chat Completions `image_url` 图片输入示例），且本仓 Pi 路线的 catalog 已为 `k3` 显式标注 `supportsImageInput: true`。本修复在 `isVerifiedImageChatRoute()` 中按 **HTTPS + 精确 hostname `api.kimi.com` + 精确模型 id（`k3`、`k3-256k`）** 放行 `imageInput: 'image_url'`，其余路由继续 fail-closed。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：#2732（Codex 会话中使用 Kimi K3 无法读取图片，直接报错）中「仅 Kimi Code 失败」的分支
- 本 PR 包含：`codex-proxy-host.ts` 中 Kimi Code 路线的图片能力放行 + 正/负向回归测试
- 明确不包含：不放开第三方/自建 openai-chat 中转（与 #2371 的产品缺口分开推进）；不修改 wire protocol；不支持 `file_id`
- 用户可见变化：Kimi Code 包月路线（`k3` / `k3-256k`）在 Codex 会话中可以发送图片
- 是否存在 breaking change：无

### UI 变化

不涉及。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/maker-host/__tests__/codexProxyHost.test.ts
结果：184 tests 全部通过（含新增 2 个正向 + 5 个负向用例）

pnpm --filter @cindy/responses-chat-bridge test
结果：159 tests 全部通过

pnpm test:unit:related
结果：desktop 工作区 4 个 codexAuthInvalidation 用例失败，已用 git stash 对照验证
在不带本次改动的 clean 代码上同样失败（Windows 临时目录 EPERM 环境性 flake），
与本次改动无关；其余全部通过。

pnpm --filter desktop run --if-present typecheck
结果：失败，但已用 git stash 对照验证在 clean 代码上同样失败——错误全部来自
@cindy/plugin-protocol 等 workspace 包构建产物缺失（同步 2000+ commits 后未 rebuild），
与本次改动无关。
```

### 手工验证

提交者（Kimi Code 包月订阅用户）已在本地构建上端到端自测通过：Codex 会话选 Kimi Code 的 K3 模型发送图片，模型可正常读取图片内容。

### 未执行的验证

- 全量 `pnpm test:unit`：遵循「related 优先」的提交前门禁；全量以 CI 为准。

## 风险

### 风险分类

- [x] 协议兼容

### 影响与回滚

- 影响范围：仅 Desktop 本地 Responses→Chat bridge 的图片能力判定。只对 HTTPS + 精确 `api.kimi.com` hostname + 精确 `k3`/`k3-256k` 模型放行；HTTP、伪造子域名、其他模型（含 `kimi-for-coding`、`kimi-k3` 在 Kimi Code host 上的错配）继续 fail-closed。已有 Moonshot/Doubao/Qwen 路线行为不变。
- 回滚 / 降级方式：revert 本 commit 即恢复 Kimi Code 路线拒绝图片；纯文本行为不受影响。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（代码注释覆盖清单已更新）
- [x] 已确认测试结果或说明未执行原因