### PR TITLE
fix(plugin): decouple manifest schema from client version

### DIFF
--- a/apps/desktop/src/main/cindy-brain/__tests__/forge.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/forge.test.ts
@@ -98,10 +98,15 @@ async function testScaffoldWriter(request: ForgeScaffoldWriteRequest) {
 }
 
 function scaffoldGhostDir(
-  input: Parameters<typeof scaffoldGhostDirRaw>[0],
+  input: Omit<Parameters<typeof scaffoldGhostDirRaw>[0], 'minCindyVersion'> & {
+    minCindyVersion?: string;
+  },
   options: Omit<NonNullable<Parameters<typeof scaffoldGhostDirRaw>[1]>, 'writeScaffold'> = {},
 ) {
-  return scaffoldGhostDirRaw(input, { ...options, writeScaffold: testScaffoldWriter });
+  return scaffoldGhostDirRaw(
+    { minCindyVersion: '1.2.3', ...input },
+    { ...options, writeScaffold: testScaffoldWriter },
+  );
 }
 
 function packGhostDir(
@@ -1267,6 +1272,7 @@ describe('scaffoldGhostDir', () => {
         template: 'plain',
         id: 'bigint-parent',
         name: 'BigInt parent',
+        minCindyVersion: '1.2.3',
       },
       {
         sessionWorkdir: workDir,
@@ -1314,7 +1320,7 @@ describe('scaffoldGhostDir', () => {
       ) as Record<string, unknown>;
       expect(manifestJson.icon).toBe('assets/icon.png');
       expect(manifestJson.schemaVersion).toBe(3);
-      expect(manifestJson.minCindyVersion).toBe('0.1.61');
+      expect(manifestJson.minCindyVersion).toBe('1.2.3');
       expect(manifestJson).not.toHaveProperty('slots');
       const iconBytes = await fs.promises.readFile(path.join(dir, 'assets/icon.png'));
       expect(iconBytes.subarray(0, 8)).toEqual(

--- a/apps/desktop/src/main/cindy-brain/forge.ts
+++ b/apps/desktop/src/main/cindy-brain/forge.ts
@@ -33,7 +33,6 @@ import {
   GHOST_MANUAL_ENTRY_FILE,
   GHOST_MANUAL_MD_MAX_BYTES,
   GHOST_MANIFEST_FILE,
-  GHOST_MANIFEST_V3_MIN_CINDY_VERSION,
   GHOST_MANIFEST_SUMMARY_MAX_CHARS,
   GHOST_SKILL_MD_MAX_BYTES,
   validateGhostManifest,
@@ -210,6 +209,7 @@ interface ForgeScaffoldInput {
   id: string;
   name: string;
   description?: string;
+  minCindyVersion: string;
 }
 
 /**
@@ -238,7 +238,7 @@ export type ForgeScaffoldWriter = (
 function scaffoldManifest(input: ForgeScaffoldInput): Record<string, unknown> {
   const common = {
     schemaVersion: 3,
-    minCindyVersion: GHOST_MANIFEST_V3_MIN_CINDY_VERSION,
+    minCindyVersion: input.minCindyVersion,
     id: input.id,
     name: input.name,
     description: input.description?.trim() || `${input.name} 插件`,
@@ -1480,7 +1480,9 @@ Cindy 校验真实包后直接安装并启用，不再追加整张能力确认�
 
 从零开始时优先调用 \`ghost_forge_scaffold\` 生成一份不会覆盖现有文件的骨架，再在
 骨架上修改。可选模板:\`plain\`(普通沙箱工具)、\`agent-action\`(卡片点击后让 Agent
-继续工作)、\`node-json-rpc\`(普通随包 Node 服务)、\`node-mcp\`(随包 stdio MCP)。
+继续工作)、\`node-json-rpc\`(普通随包 Node 服务)、\`node-mcp\`(随包 stdio MCP)。正式版
+Cindy 会默认把自身版本写进这份具体插件的 \`minCindyVersion\`；在开发版或预发布版中制作时，
+调用 scaffold 必须明确传入插件实际依赖的首个 Cindy 正式版本。
 
 ## 0. 设计对齐:动手前用提问卡片确认关键决策
 
@@ -1568,7 +1570,7 @@ my-ghost/
     "ko": "locales/ko.json"
   },
   "version": "1.0.0",
-  "minCindyVersion": "0.1.61", // v3 必填:首个支持本清单的 Cindy 正式版本(SemVer)
+  "minCindyVersion": "1.2.3", // 示例；v3 必填:本插件实际依赖的首个 Cindy 正式版本(SemVer)
   "entry": "main.js",          // 电子脑入口(kind 字段已无需填写:意识只有芯片一种形态,缺省即 chip;写了也只认 "chip")
   "launch": "on-demand",       // 可选:电子脑启动模式。on-demand(缺省)=被需要才拉起;resident=唤醒即常驻(详情页会如实标注"常驻运行",绝大多数意识不需要,仅订阅型/需秒响应的场景用)
   "command": "画图",            // 推荐:用户 $画图 显式点名(与已装意识查重,冲突拒装)。
@@ -1603,8 +1605,8 @@ my-ghost/
 }
 \`\`\`
 
-\`schemaVersion: 3\` 必须填写 \`minCindyVersion\`。它写首个能解析该清单的 Cindy
-正式版本；当前 v3 起点是 \`0.1.61\`。不要为了使用某项既有能力随意抬高版本。
+\`schemaVersion: 3\` 必须填写 \`minCindyVersion\`。它写本插件实际依赖的首个 Cindy
+正式版本；Manifest schema 本身没有统一的 Cindy 版本下限。不要为了使用某项既有能力随意抬高版本。
 官方市场会优先向旧客户端投影最近的兼容历史版本，没有兼容版本时不展示该插件。
 Desktop 信任来源已经完成的版本选择，不再按 \`minCindyVersion\` 追加筛选或确认弹窗；
 用户主动导入的本地包、以及用户添加的自定义市场也遵循同一安装策略。这个字段仍必须
@@ -4217,7 +4219,7 @@ const opened = await cindy.iosSimulator.request({
 \`\`\`json
 {
   "schemaVersion": 3,
-  "minCindyVersion": "0.1.61",
+  "minCindyVersion": "1.2.3",
   "mainView": {
     "title": "工作台",
     "icon": "puzzle",

--- a/apps/desktop/src/main/maker-host/index.ts
+++ b/apps/desktop/src/main/maker-host/index.ts
@@ -781,6 +781,7 @@ export function getMaker(): Maker {
     };
 
     const makerMemoryProviderDeps = {
+      getAppVersion: () => app.getVersion(),
       getMakerMemoryManager: () => makerMemoryManager,
       lspPool: getLspPool(),
       pluginRegistry,

--- a/apps/desktop/src/main/mcp-integrations/__tests__/ghostWorkdirGate.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/__tests__/ghostWorkdirGate.test.ts
@@ -29,8 +29,9 @@ const outsideDir = path.join(tmpUserData, 'outside');
 const logWarnMock = vi.fn();
 const logInfoMock = vi.fn();
 const grantAttachmentsMock = vi.fn();
-const { packGhostDirMock, forgeInstallPackageMock } = vi.hoisted(() => ({
+const { packGhostDirMock, scaffoldGhostDirMock, forgeInstallPackageMock } = vi.hoisted(() => ({
   packGhostDirMock: vi.fn(),
+  scaffoldGhostDirMock: vi.fn(),
   forgeInstallPackageMock: vi.fn(),
 }));
 const { completeForgePackStagingMock } = vi.hoisted(() => ({
@@ -60,6 +61,7 @@ const {
 }));
 const releaseMutationMock = vi.fn();
 const appSessionBoundaryPendingMock = vi.fn(() => false);
+const appVersionMock = vi.fn(() => '2.3.4');
 const captureMutationOwnerMock = vi.fn(() => ({
   mode: 'local' as const,
   dataOwnerId: 'test',
@@ -205,7 +207,7 @@ vi.mock('../../cindy-brain/cardService.js', () => ({ withCardToken: (r: unknown)
 vi.mock('../../cindy-brain/forge.js', () => ({
   FORGE_GUIDE: 'guide',
   packGhostDir: packGhostDirMock,
-  scaffoldGhostDir: vi.fn(),
+  scaffoldGhostDir: scaffoldGhostDirMock,
 }));
 vi.mock('../../cindy-brain/forgePackStaging.js', () => ({
   completeForgePackStaging: completeForgePackStagingMock,
@@ -281,6 +283,7 @@ function makeDeps(
   // 在 tool-call 时从 ALS 恢复真实 ctx。
   alsSessionContextMock.mockReturnValue(agentKind === 'claude-code' ? undefined : ctx);
   return getCindyGhostsMcpDeps(agentKind === 'claude-code' ? ctx : undefined, {
+    getAppVersion: appVersionMock,
     getLiveSessionGrantState: liveGrantStateMock,
   });
 }
@@ -410,6 +413,14 @@ beforeEach(() => {
     errorCode: 'MANIFEST_INVALID',
     message: 'stop after gate assertion',
   });
+  scaffoldGhostDirMock.mockReset();
+  scaffoldGhostDirMock.mockResolvedValue({
+    ok: true,
+    dir: path.join(WORKDIR, 'new-plugin'),
+    template: 'plain',
+    files: ['ghost.json', 'main.js'],
+    nextSteps: [],
+  });
   forgeInstallPackageMock.mockReset();
   forgeInstallPackageMock.mockResolvedValue({
     action: 'installed',
@@ -438,6 +449,8 @@ beforeEach(() => {
   });
   appSessionBoundaryPendingMock.mockReset();
   appSessionBoundaryPendingMock.mockReturnValue(false);
+  appVersionMock.mockReset();
+  appVersionMock.mockReturnValue('2.3.4');
   clearAllPrefs();
 });
 
@@ -629,6 +642,73 @@ describe('Forge session workdir gate', () => {
     await expect(
       deps.forgeScaffold({ dir: path.join(WORKDIR, 'new-plugin'), template: 'plain', id: 'x', name: 'X' }),
     ).resolves.toMatchObject({ ok: false, errorCode: 'WORKDIR_READ_ONLY' });
+  });
+
+  it('uses the current stable Cindy version only as scaffold metadata for the concrete package', async () => {
+    const deps = makeDeps();
+    await expect(
+      deps.forgeScaffold({
+        dir: path.join(WORKDIR, 'new-plugin'),
+        template: 'plain',
+        id: 'new-plugin',
+        name: 'New plugin',
+      }),
+    ).resolves.toMatchObject({ ok: true });
+    expect(scaffoldGhostDirMock).toHaveBeenCalledWith(
+      expect.objectContaining({ minCindyVersion: '2.3.4' }),
+      expect.any(Object),
+    );
+  });
+
+  it('requires explicit package metadata when scaffold runs in an unpublished Cindy build', async () => {
+    appVersionMock.mockReturnValue('0.0.0');
+    const deps = makeDeps();
+    await expect(
+      deps.forgeScaffold({
+        dir: path.join(WORKDIR, 'new-plugin'),
+        template: 'plain',
+        id: 'new-plugin',
+        name: 'New plugin',
+      }),
+    ).resolves.toMatchObject({ ok: false, errorCode: 'INVALID_INPUT' });
+    expect(scaffoldGhostDirMock).not.toHaveBeenCalled();
+
+    await expect(
+      deps.forgeScaffold({
+        dir: path.join(WORKDIR, 'new-plugin'),
+        template: 'plain',
+        id: 'new-plugin',
+        name: 'New plugin',
+        minCindyVersion: '1.4.0',
+      }),
+    ).resolves.toMatchObject({ ok: true });
+    expect(scaffoldGhostDirMock).toHaveBeenCalledWith(
+      expect.objectContaining({ minCindyVersion: '1.4.0' }),
+      expect.any(Object),
+    );
+
+    scaffoldGhostDirMock.mockClear();
+    await expect(
+      deps.forgeScaffold({
+        dir: path.join(WORKDIR, 'new-plugin'),
+        template: 'plain',
+        id: 'new-plugin',
+        name: 'New plugin',
+        minCindyVersion: '1.4.0-beta.1',
+      }),
+    ).resolves.toMatchObject({ ok: false, errorCode: 'INVALID_INPUT' });
+    expect(scaffoldGhostDirMock).not.toHaveBeenCalled();
+
+    await expect(
+      deps.forgeScaffold({
+        dir: path.join(WORKDIR, 'new-plugin'),
+        template: 'plain',
+        id: 'new-plugin',
+        name: 'New plugin',
+        minCindyVersion: '0.0.0',
+      }),
+    ).resolves.toMatchObject({ ok: false, errorCode: 'INVALID_INPUT' });
+    expect(scaffoldGhostDirMock).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/desktop/src/main/mcp-integrations/ghost.ts
+++ b/apps/desktop/src/main/mcp-integrations/ghost.ts
@@ -188,6 +188,8 @@ export interface ToolResultImageDescription {
 }
 
 export interface CindyGhostsHostDeps {
+  /** 当前 Desktop 版本；Forge scaffold 用它生成具体插件包的默认最低版本。 */
+  getAppVersion?: () => string;
   /**
    * 现读活跃 Maker Session 的运行时状态。不得回退 DB:权限热切换先作用于
    * runtime、后持久化,DB 在合法窗口内会滞后;缺失/异常必须 fail closed。
@@ -1758,7 +1760,37 @@ export function getCindyGhostsMcpDeps(
       return withForgeOwnerLease(async () => {
         const gate = await getForgeSessionFsGate(resolveSessionContext());
         if (!gate.ok) return gate;
-        const result = await scaffoldGhostDir(request, {
+        const declaredMinCindyVersion = request.minCindyVersion?.trim();
+        const stableCindyVersionPattern =
+          /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+        if (
+          declaredMinCindyVersion &&
+          (declaredMinCindyVersion === '0.0.0' ||
+            !stableCindyVersionPattern.test(declaredMinCindyVersion))
+        ) {
+          return {
+            ok: false,
+            errorCode: 'INVALID_INPUT',
+            message: 'minCindyVersion 必须是插件实际依赖的首个 Cindy 正式版本（major.minor.patch）',
+          };
+        }
+        const currentCindyVersion = hostDeps.getAppVersion?.().trim();
+        const stableCurrentCindyVersion =
+          currentCindyVersion &&
+          currentCindyVersion !== '0.0.0' &&
+          stableCindyVersionPattern.test(currentCindyVersion)
+            ? currentCindyVersion
+            : null;
+        const minCindyVersion = declaredMinCindyVersion || stableCurrentCindyVersion;
+        if (!minCindyVersion) {
+          return {
+            ok: false,
+            errorCode: 'INVALID_INPUT',
+            message:
+              '当前是未发布或预发布 Cindy 构建，请明确填写 minCindyVersion（插件实际依赖的首个 Cindy 正式版本）',
+          };
+        }
+        const result = await scaffoldGhostDir({ ...request, minCindyVersion }, {
           sessionWorkdir: gate.workingDir,
           forbiddenRootDirs: ghostForgeForbiddenRootDirs(),
           writeScaffold: writeForgeScaffoldWithStableParent,

--- a/apps/desktop/src/main/mcp-integrations/mcp-providers.ts
+++ b/apps/desktop/src/main/mcp-integrations/mcp-providers.ts
@@ -62,6 +62,8 @@ import {
 } from './remoteChatHistory.js';
 
 export interface DesktopMcpProvidersDeps {
+  /** 当前 Desktop 版本，供 Forge 为具体插件包生成默认 minCindyVersion。 */
+  getAppVersion?: () => string;
   getMakerMemoryManager: () => MakerMemoryManager;
   lspPool: LspServerPool;
   /** 按会话控制启用状态的 plugin registry。 */
@@ -546,6 +548,7 @@ export function createDesktopMcpProviders(deps: DesktopMcpProvidersDeps): LiziMc
       name: 'cindy',
       instance: createCindyGhostsMcpServer(
         getCindyGhostsMcpDeps(ctx, {
+          getAppVersion: deps.getAppVersion,
           getLiveSessionGrantState: deps.getLiveSessionGrantState,
           describeToolResultImage: deps.describeToolResultImage,
           onToolResultImagesFailed: deps.onToolResultImagesFailed,

--- a/apps/desktop/src/shared/__tests__/ghost.test.ts
+++ b/apps/desktop/src/shared/__tests__/ghost.test.ts
@@ -1022,7 +1022,7 @@ describe('ghost · Manifest v3 直接能力声明', () => {
     );
   });
 
-  it('拒绝 v3 slots、缺 minCindyVersion 和 false 布尔能力', () => {
+  it('拒绝 v3 slots、缺 minCindyVersion 和 false 布尔能力，但不设置统一版本下限', () => {
     const base = {
       schemaVersion: 3,
       minCindyVersion: '0.1.61',
@@ -1033,7 +1033,7 @@ describe('ghost · Manifest v3 直接能力声明', () => {
     };
     expect(validateGhostManifest({ ...base, slots: [] }).ok).toBe(false);
     expect(validateGhostManifest({ ...base, minCindyVersion: undefined }).ok).toBe(false);
-    expect(validateGhostManifest({ ...base, minCindyVersion: '0.1.60' }).ok).toBe(false);
+    expect(validateGhostManifest({ ...base, minCindyVersion: '0.1.60' }).ok).toBe(true);
     expect(validateGhostManifest({ ...base, notify: false }).ok).toBe(false);
   });
 

--- a/apps/desktop/src/shared/ghost.ts
+++ b/apps/desktop/src/shared/ghost.ts
@@ -1,9 +1,7 @@
 import {
   GHOST_LOCALES,
-  GHOST_MANIFEST_V3_MIN_CINDY_VERSION,
   GHOST_MANIFEST_SUMMARY_MAX_CHARS,
   GHOST_OAUTH_SCOPES_MAX,
-  compareCindyVersions,
   isValidCindyVersion,
   type GhostLocale,
   type GhostManifestLocales,
@@ -43,7 +41,7 @@ export const GHOST_MANIFEST_MAX_BYTES = 256 * 1024;
 export const GHOST_INSTALL_MANIFEST_MAX_BYTES = 256 * 1024;
 
 /** ghost.json 的 description / whenToUse 字符上限，正本在 plugin-protocol。 */
-export { GHOST_MANIFEST_SUMMARY_MAX_CHARS, GHOST_MANIFEST_V3_MIN_CINDY_VERSION };
+export { GHOST_MANIFEST_SUMMARY_MAX_CHARS };
 
 /** 意识文件扩展名。 */
 export const CINDY_FILE_EXT = '.cindy';
@@ -3729,15 +3727,6 @@ export function validateGhostManifest(value: unknown): ManifestValidation {
   }
   if (raw.minCindyVersion !== undefined && !isValidCindyVersion(raw.minCindyVersion)) {
     return { ok: false, reason: 'minCindyVersion 必须是合法的 SemVer 字符串' };
-  }
-  if (
-    prepared.schemaVersion === 3 &&
-    compareCindyVersions(raw.minCindyVersion as string, GHOST_MANIFEST_V3_MIN_CINDY_VERSION) === -1
-  ) {
-    return {
-      ok: false,
-      reason: `schemaVersion 3 的 minCindyVersion 不能低于 ${GHOST_MANIFEST_V3_MIN_CINDY_VERSION}`,
-    };
   }
   // kind 可省略(2026-07-12 晚定案:单形态后字段纯冗余,缺省即 chip);
   // 写了就必须是 chip——写错值仍拒,不静默纠正(规则 9)。

--- a/docs/dev-rules/plugin-security-and-authoring.md
+++ b/docs/dev-rules/plugin-security-and-authoring.md
@@ -50,7 +50,8 @@
 
 ### 1.1 Manifest v3 直接能力声明
 
-- 新插件统一使用 `schemaVersion: 3`，并填写不低于 `0.1.61` 的 `minCindyVersion`。
+- 新插件统一使用 `schemaVersion: 3`，并填写插件实际依赖的首个 Cindy 正式版本作为
+  `minCindyVersion`。Manifest schema 不设置统一的 Cindy 版本下限；具体版本只属于插件包元数据。
   v3 **没有** `slots`；
   `tools`、`card`、`panel`、`mainView`、`subscribe`、`skill`、`cindy`、`agent`、`node`、`network`、
   `preview` 等顶层字段本身就是插件贡献项或自主 Host 能力的直接声明。

--- a/packages/cindy-tools/src/ghost/mcpServer.ts
+++ b/packages/cindy-tools/src/ghost/mcpServer.ts
@@ -1025,6 +1025,7 @@ export async function handleForgeScaffold(
     id: string;
     name: string;
     description?: string;
+    minCindyVersion?: string;
   },
 ): Promise<McpTextResult> {
   try {
@@ -1322,6 +1323,10 @@ export function createCindyGhostsMcpServer(
         .string()
         .optional()
         .describe("一句话说明插件用途；省略时会生成占位说明"),
+      minCindyVersion: z
+        .string()
+        .optional()
+        .describe("插件实际依赖的首个 Cindy 正式版本；省略时使用当前正式版，开发构建必须明确填写"),
     },
     async (input) => handleForgeScaffold(deps, input),
   );

--- a/packages/cindy-tools/src/types.ts
+++ b/packages/cindy-tools/src/types.ts
@@ -446,6 +446,8 @@ export interface CindyGhostsMcpDeps {
     id: string;
     name: string;
     description?: string;
+    /** 省略时由正式版 Host 使用自身版本；开发构建必须明确填写。 */
+    minCindyVersion?: string;
   }): Promise<CindyForgeScaffoldResult>;
   /**
    * 把一个源码目录校验并打包成 .cindy。只生成产物，不安装或更新插件；

--- a/packages/plugin-protocol/src/__tests__/manifest.test.ts
+++ b/packages/plugin-protocol/src/__tests__/manifest.test.ts
@@ -90,12 +90,12 @@ describe('Ghost manifest contract', () => {
       validateGhostManifest({
         schemaVersion: 3,
         minCindyVersion: '0.1.60',
-        id: 'too-old-v3',
-        name: 'Too Old v3',
+        id: 'older-compatible-v3',
+        name: 'Older Compatible v3',
         version: '1.0.0',
         entry: 'index.js',
       }).ok,
-    ).toBe(false);
+    ).toBe(true);
   });
 
   it('validates and normalizes setup at the shared protocol boundary', () => {

--- a/packages/plugin-protocol/src/manifest.ts
+++ b/packages/plugin-protocol/src/manifest.ts
@@ -6,8 +6,6 @@ export const CINDY_FILE_EXT = '.cindy';
 
 /** 新建 ghost.json 使用的格式版本；与 Plugin HTTP API envelope 版本独立演进。 */
 export const GHOST_MANIFEST_SCHEMA_VERSION = 3 as const;
-/** 首个支持 Manifest v3 的 Cindy 正式版本；v3 清单不得声明更低的兼容下限。 */
-export const GHOST_MANIFEST_V3_MIN_CINDY_VERSION = '0.1.61';
 
 /** ghost.json 的 description / whenToUse 字符上限。 */
 export const GHOST_MANIFEST_SUMMARY_MAX_CHARS = 300;
@@ -1341,15 +1339,6 @@ export function validateGhostManifest(value: unknown): ManifestValidation {
     (typeof raw.minCindyVersion !== 'string' || !isValidCindyVersion(raw.minCindyVersion))
   ) {
     return { ok: false, reason: 'minCindyVersion 必须是合法的 SemVer 字符串' };
-  }
-  if (
-    prepared.schemaVersion === 3 &&
-    compareCindyVersions(raw.minCindyVersion as string, GHOST_MANIFEST_V3_MIN_CINDY_VERSION) === -1
-  ) {
-    return {
-      ok: false,
-      reason: `schemaVersion 3 的 minCindyVersion 不能低于 ${GHOST_MANIFEST_V3_MIN_CINDY_VERSION}`,
-    };
   }
   // kind 可省略(2026-07-12 晚定案:单形态后字段纯冗余,缺省即 chip);
   // 写了就必须是 chip——写错值仍拒,不静默纠正(规则 9)。


### PR DESCRIPTION
## 这次改了什么

### 摘要

移除 Manifest v3 与具体 Cindy 版本 `0.1.61` 的平台级耦合。`schemaVersion` 只描述清单结构，`minCindyVersion` 继续由每个插件包声明其实际依赖的首个 Cindy 正式版本。

Forge scaffold 不再引用全局版本常量：正式版 Cindy 默认把当前正式版本写入新插件包；开发版、预发布版或作者需要声明更早兼容版本时，可以显式传入稳定的 `major.minor.patch`。`0.0.0` 与预发布版本不会被 Forge 当成可发布插件的最低版本。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：插件模型重构中的 Manifest 版本职责修正
- 本 PR 包含：客户端与 `@cindy/plugin-protocol` 的 Manifest-v3 校验、Forge scaffold 包级版本元数据、对应文档与测试
- 明确不包含：Plugin Server 下发逻辑；插件安装、自动更新或运行时授权策略；任何具体官方插件包改动
- 用户可见变化：准确声明较早 `minCindyVersion` 的合法 v3 插件不再因平台固定下限被客户端拒绝；Forge 生成的包携带具体包自己的最低版本
- 是否存在 breaking change：无。校验只放宽固定下限，v3 仍必须声明合法 SemVer

### UI 变化

不涉及。

- 引用的设计规范：不涉及 UI

## 怎么验证的

### 自动验证

```text
pnpm --filter @cindy/plugin-protocol build
结果：通过

pnpm --filter cindy-tools build
结果：通过

pnpm --dir apps/desktop exec vitest run src/main/cindy-brain/__tests__/forge.test.ts src/main/mcp-integrations/__tests__/ghostWorkdirGate.test.ts src/shared/__tests__/ghost.test.ts --pool=threads --maxWorkers=1
结果：3 个文件、345 项测试通过

pnpm test:unit:related
结果：runner、cindy-tools、plugin-protocol 通过；Desktop 全量中本轮三个相关测试文件均通过，但整仓仍被当前 main 上与本改动无关的环境/时序用例失败阻断
```

### 手工验证

不涉及 UI；本轮行为由 Manifest 校验与 Forge scaffold 定向测试覆盖。

### 未执行的验证

`pnpm --filter desktop typecheck` 未能全绿：当前 worktree 缺少 `docx`、`pptxgenjs`、`exceljs` 模块，复跑结果中已无本 PR 引入的类型错误。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [x] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [x] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Manifest v3 的最低客户端版本校验与 Forge 新插件骨架元数据。Server 仍只按插件包声明做通用 SemVer 兼容选择。
- 存量插件影响：无。已有合法包、安装布局、批准状态和权限不变，不需要迁移、重装或重新确认。
- 回滚 / 降级方式：回滚本提交即可恢复旧的固定版本下限；不会涉及数据迁移。
- 合并要求：这是插件基座与 Manifest 契约变更，合并前需要仓库指定维护者明确批准；官方插件仓的固定校验器会在配套 PR 中同步。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范（不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
