### PR TITLE
build(mobile): add global Android AAB artifact

### DIFF
--- a/apps/mobile/scripts/build-android.mjs
+++ b/apps/mobile/scripts/build-android.mjs
@@ -1,12 +1,11 @@
 #!/usr/bin/env node
 // =============================================================================
-// build-android.mjs —— Android 纯构建(本机出自签 APK,不含任何上传 / 分发 / 发布)
+// build-android.mjs —— Android 纯构建(本机出自签 APK / AAB,不含上传 / 分发 / 发布)
 //
 // 流程(--execute):git 闸门 → expo prebuild(注入 versionCode)→ patch build.gradle 用自有
-//       keystore 自签 → gradlew assembleRelease → app-release.apk
-//       → 从 APK 回读内嵌 runtimeVersion(assets/fingerprint,仅报告)
-//       → aapt2 本地校验 package/versionCode(找不到 aapt2 时降级 warn)
-//       → 产物留在 gradle 输出目录并打印路径(--out 可另拷一份)。
+//       keystore 自签 → 按地区 / --artifacts 执行 assembleRelease / bundleRelease
+//       → 从 APK / AAB 回读内嵌 runtimeVersion并交叉核对
+//       → 本地校验 package/versionCode/签名 → 打印全部产物路径(--out 可另拷一份)。
 // dry-run 纯本地:校验配置 + 打印计划,git 闸门(含 origin/main 远端比对)只在
 // --execute 时执行,分支/离线环境也能直接看计划。
 //
@@ -15,8 +14,8 @@
 // (经 env 注入,不写盘)。
 //
 // 用法:
-//   node scripts/build-android.mjs --region cn                 # dry-run:校验 + 打印计划
-//   node scripts/build-android.mjs --region cn --execute       # 真正构建(需 Android SDK + JDK 17)
+//   node scripts/build-android.mjs --region cn                 # 默认 APK
+//   node scripts/build-android.mjs --region global --execute   # 默认 APK + AAB
 //
 // 参数:
 //   --region cn|global|dev     必填。从 scripts/self-host-regions.json 取应用身份
@@ -32,11 +31,13 @@
 //                              并把 cdnBaseUrl 换成实际的无凭据 HTTPS 基址
 //                              (example 里的 localhost 占位过不了加载校验)。
 //   --execute                  真正构建;缺省 dry-run 只打印计划。
+//   --artifacts <csv>          可选:apk / aab / apk,aab。缺省按 region 选择:
+//                              cn/dev=apk,global=apk,aab;AAB 仅允许 global。
 //   --version-code <n>         可选。覆盖 android-version.json 的 versionCode
-//                              (只影响本次构建,不写盘)。
+//                              (只影响本次构建,不写盘;APK/AAB 始终共用同一值)。
 //   --desktop-version x.y.z    可选。配对的桌面产品线版本号(设置页展示用),
 //                              不传则不注入、设置页不显示该行。
-//   --out <dir>                可选。构建完把 .apk 另拷到该目录。
+//   --out <dir>                可选。构建完把本次所有 .apk/.aab 另拷到该目录。
 //   --skip-git-gate            跳过 --execute 的 main/clean/HEAD 校验(仅本地迭代用;
 //                              dry-run 本就不校验)。
 //
@@ -60,13 +61,18 @@ import {
 } from './release-lib.mjs';
 import {
   readAndroidVersionCode,
+  resolveAndroidArtifactKinds,
+  androidGradleTasksForArtifacts,
   resolveAndroidSigningEnv,
   patchBuildGradleSigning,
   patchGradlePropertiesMemory,
 } from './lib/android-local.mjs';
 import { resolveJavaRuntimeEnv } from './java-runtime-env.mjs';
 import { clearBundlerCache } from './lib/bundler-cache.mjs';
-import { readEmbeddedRuntimeVersionFromApk } from './lib/embedded-runtime.mjs';
+import {
+  readEmbeddedRuntimeVersionFromAab,
+  readEmbeddedRuntimeVersionFromApk,
+} from './lib/embedded-runtime.mjs';
 import { mobileClientBundleEnv } from '../../../scripts/shared/client-endpoint-build-env.mjs';
 import { SELF_HOST_REGIONS, loadSelfHostRegions, missingSelfHostBakeFields, stripSelfHostRegionEnv } from './lib/self-host-region.mjs';
 
@@ -128,7 +134,17 @@ function patchGradleProps() {
   log('  ✓ 已 patch android/gradle.properties(bump heap/metaspace)');
 }
 
-function buildApk(env, region) {
+function findSingleArtifact(dir, extension, taskName) {
+  const matches = existsSync(dir)
+    ? readdirSync(dir).filter((file) => file.endsWith(extension)).sort()
+    : [];
+  if (matches.length !== 1) {
+    throw new Error(`${taskName} 期望唯一 ${extension} 产物,实际 ${matches.length} 个:${dir}`);
+  }
+  return join(dir, matches[0]);
+}
+
+function buildAndroidArtifacts(env, region, artifactKinds) {
   // 签名配置:路径/alias 来自 region JSON,口令来自 env;prebuild 前先强制解析
   // (fail-fast,缺配置不白跑数分钟 prebuild)。
   const signEnv = resolveAndroidSigningEnv(region, env);
@@ -141,20 +157,34 @@ function buildApk(env, region) {
   // Metro/Babel 缓存,确保 EXPO_PUBLIC_ 变更被重新内联,不吃旧缓存。
   clearBundlerCache({ mobileDir: MOBILE_DIR, log });
 
-  // gradlew assembleRelease:需 JDK 17 + keystore 签名 env。
+  // assembleRelease / bundleRelease 共用同一次 prebuild、同一个 release signingConfig
+  // 与同一份 env,保证 APK / AAB 的身份、versionCode、runtimeVersion 和签名源一致。
   const javaEnv = resolveJavaRuntimeEnv({ ...env, ...signEnv });
   // 不把 javaEnv 传进被日志的函数:它由 process.env + 签名口令(signEnv)派生,
   // CodeQL 会将「机密 env 流入日志」判为泄漏(即便 javaRuntimeDetail 只读版本 /
   // JAVA_HOME)。这里只报静态信息;JDK 由 resolveJavaRuntimeEnv 确定性选 17+。
-  log('  → gradle assembleRelease(已解析 JDK 17+ 运行时)');
+  const tasks = androidGradleTasksForArtifacts(artifactKinds);
+  log(`  → gradle ${tasks.join(' ')}(已解析 JDK 17+ 运行时)`);
   const androidDir = resolve(MOBILE_DIR, 'android');
   const gradlew = process.platform === 'win32' ? 'gradlew.bat' : './gradlew';
-  run(gradlew, ['assembleRelease'], { cwd: androidDir, env: javaEnv });
+  run(gradlew, tasks, { cwd: androidDir, env: javaEnv });
 
-  const apkDir = join(androidDir, 'app/build/outputs/apk/release');
-  const apk = existsSync(apkDir) ? readdirSync(apkDir).find((f) => f.endsWith('.apk')) : null;
-  if (!apk) throw new Error(`assembleRelease 未产出 .apk:${apkDir}`);
-  return join(apkDir, apk);
+  const artifacts = {};
+  if (artifactKinds.includes('apk')) {
+    artifacts.apk = findSingleArtifact(
+      join(androidDir, 'app/build/outputs/apk/release'),
+      '.apk',
+      'assembleRelease',
+    );
+  }
+  if (artifactKinds.includes('aab')) {
+    artifacts.aab = findSingleArtifact(
+      join(androidDir, 'app/build/outputs/bundle/release'),
+      '.aab',
+      'bundleRelease',
+    );
+  }
+  return { androidDir, artifacts, javaEnv };
 }
 
 // 定位 aapt2(Android SDK build-tools)。优先 ANDROID_HOME / ANDROID_SDK_ROOT 下最高
@@ -195,6 +225,74 @@ function validateApkMetadata(apkPath, expectPackage, expectVersionCode) {
   log(`  ✓ APK manifest 校验通过(package=${expectPackage}, versionCode=${expectVersionCode})`);
 }
 
+function readJsonFile(filePath, label) {
+  try {
+    return JSON.parse(readFileSync(filePath, 'utf8'));
+  } catch (err) {
+    throw new Error(`${label}读取/解析失败(${filePath}):${err?.message ?? err}`);
+  }
+}
+
+// AAB 的 manifest 是 protobuf,不能用 aapt2 dump badging。这里读取同一 bundleRelease
+// 构建产生的 AGP metadata:bundle model 钉 applicationId / 输出文件,merged manifest metadata
+// 钉 versionCode / versionName。任一文件缺失或结构漂移都 fail closed,不把未核验包交给上传侧。
+function validateAabMetadata(aabPath, androidDir, expectPackage, expectVersionCode, expectVersionName) {
+  const bundleMetadataPath = join(
+    androidDir,
+    'app/build/intermediates/bundle_ide_model/release/produceReleaseBundleIdeListingFile/output-metadata.json',
+  );
+  const manifestMetadataPath = join(
+    androidDir,
+    'app/build/intermediates/merged_manifests/release/processReleaseManifest/output-metadata.json',
+  );
+  const bundle = readJsonFile(bundleMetadataPath, 'AAB bundle metadata');
+  const manifest = readJsonFile(manifestMetadataPath, 'AAB manifest metadata');
+  const bundleElement = Array.isArray(bundle?.elements) && bundle.elements.length === 1
+    ? bundle.elements[0]
+    : null;
+  const manifestElement = Array.isArray(manifest?.elements) && manifest.elements.length === 1
+    ? manifest.elements[0]
+    : null;
+  if (bundle?.artifactType?.type !== 'BUNDLE' || !bundleElement) {
+    throw new Error('AAB bundle metadata 结构无效(期望 artifactType=BUNDLE 且唯一 element)');
+  }
+  if (!manifestElement) {
+    throw new Error('AAB manifest metadata 结构无效(期望唯一 element)');
+  }
+  if (bundle.applicationId !== expectPackage || manifest.applicationId !== expectPackage) {
+    throw new Error(
+      `AAB package 不符:期望 ${expectPackage},bundle=${bundle.applicationId ?? '(空)'},manifest=${manifest.applicationId ?? '(空)'}`,
+    );
+  }
+  if (basename(String(bundleElement.outputFile ?? '')) !== basename(aabPath)) {
+    throw new Error(
+      `AAB metadata 输出文件不符:期望 ${basename(aabPath)},实际 ${String(bundleElement.outputFile ?? '(空)')}`,
+    );
+  }
+  if (String(manifestElement.versionCode) !== String(expectVersionCode)) {
+    throw new Error(
+      `AAB versionCode 不符:期望 ${expectVersionCode},实际 ${String(manifestElement.versionCode ?? '(空)')}`,
+    );
+  }
+  if (String(manifestElement.versionName ?? '') !== String(expectVersionName ?? '')) {
+    throw new Error(
+      `AAB versionName 不符:期望 ${expectVersionName},实际 ${String(manifestElement.versionName ?? '(空)')}`,
+    );
+  }
+  log(`  ✓ AAB metadata 校验通过(package=${expectPackage}, version=${expectVersionName}, versionCode=${expectVersionCode})`);
+}
+
+function validateAabSignature(aabPath, javaEnv) {
+  const r = spawnSync('jarsigner', ['-verify', aabPath], { encoding: 'utf8', env: javaEnv });
+  if (r.error?.code === 'ENOENT') {
+    throw new Error('未找到 jarsigner(JDK 17+ 应自带),无法确认 AAB 已使用 release keystore 签名');
+  }
+  if (r.status !== 0) {
+    throw new Error(`AAB jarsigner 校验失败:${r.stderr || r.stdout || `exit ${r.status}`}`);
+  }
+  log('  ✓ AAB jarsigner 校验通过(已签名)');
+}
+
 async function main() {
   const args = parseArgs(process.argv.slice(2));
   // --region 必填(cn|global|dev):选出本次出包身份 + 签名配置(见 lib/self-host-region.mjs)。
@@ -213,6 +311,7 @@ async function main() {
   if (!region.androidPackage?.trim()) {
     throw new Error(`self-host-regions.json 的 ${region.authRegion}.androidPackage 未填(构建必需)`);
   }
+  const artifactKinds = resolveAndroidArtifactKinds(region.authRegion, args.artifacts);
   const appJson = readAppJson();
   const version = appJson?.expo?.version ?? '';
   // --version-code 覆盖须是正整数且不超 Android 平台上限 2100000000:app.config.js
@@ -250,12 +349,14 @@ async function main() {
   // 计划打印
   console.log('');
   console.log(`target: Android 纯构建(region=${region.authRegion}, ${region.androidPackage})`);
+  console.log(`artifacts: ${artifactKinds.join(' + ')}${args.artifacts == null ? ' (按 region 默认)' : ' (--artifacts 覆盖)'}`);
   console.log(`version / versionCode: ${version} / ${versionCode}${args.versionCode != null ? ' (--version-code 覆盖)' : ' (取 android-version.json 现值)'}`);
   const suffix = String(region.authRegion).toUpperCase();
   const aSign = region.androidSigning ?? {};
   const pwPreview = (base) => (process.env[`${base}_${suffix}`]?.trim() || (suffix === 'CN' ? process.env[base]?.trim() : '')) ? 'set' : '未设';
   console.log(`sign: 自有 keystore 自签,path=${aSign.keystorePath || '(JSON 未填)'} alias=${aSign.keyAlias || '(JSON 未填)'} storePw(env ${suffix})=${pwPreview('XDT_ANDROID_KEYSTORE_PASSWORD')} keyPw(env ${suffix})=${pwPreview('XDT_ANDROID_KEY_PASSWORD')}`);
-  console.log('steps: prebuild → patch build.gradle 签名 → gradlew assembleRelease → 从 APK 回读 runtimeVersion → aapt2 本地校验(仅构建,无上传/发布)');
+  const gradleTasks = androidGradleTasksForArtifacts(artifactKinds);
+  console.log(`steps: prebuild → patch build.gradle 签名 → gradlew ${gradleTasks.join(' ')} → 回读/核对 runtimeVersion → metadata/签名校验(仅构建,无上传/发布)`);
   if (missingBake.length) {
     console.log(`selfhost 必填缺失: ${missingBake.join(', ')}(--execute 前须在 self-host-regions.json 补齐;prebuild 期 app.config.js 硬校验)`);
   }
@@ -274,29 +375,55 @@ async function main() {
   // region / endpoint manifest 自举基址必须齐全(读仓内 config/endpoint*.json,离线可用)。
   assertPublicEnv(env, { variant: 'production', requiredKeys: SELF_HOST_PUBLIC_ENV_KEYS });
 
-  const apkPath = buildApk(env, region);
-  log(`  ✓ apk: ${apkPath}`);
+  const built = buildAndroidArtifacts(env, region, artifactKinds);
+  for (const kind of artifactKinds) log(`  ✓ ${kind}: ${built.artifacts[kind]}`);
 
-  // 权威 runtimeVersion = 真正烤进 APK 的 assets/fingerprint(仅报告,供发布侧比对)。
-  const runtimeVersion = readEmbeddedRuntimeVersionFromApk(apkPath);
-  log(`  ✓ runtimeVersion(读自 APK 内嵌 assets/fingerprint): ${runtimeVersion}`);
+  // 权威 runtimeVersion 始终从真正烤进产物的 fingerprint 回读。双产物必须一致,
+  // 否则同一个 versionCode 会出现两条不兼容 OTA runtime,直接中止。
+  const runtimeVersions = {};
+  if (built.artifacts.apk) {
+    runtimeVersions.apk = readEmbeddedRuntimeVersionFromApk(built.artifacts.apk);
+    log(`  ✓ runtimeVersion(APK assets/fingerprint): ${runtimeVersions.apk}`);
+    validateApkMetadata(built.artifacts.apk, region.androidPackage, versionCode);
+  }
+  if (built.artifacts.aab) {
+    runtimeVersions.aab = readEmbeddedRuntimeVersionFromAab(built.artifacts.aab);
+    log(`  ✓ runtimeVersion(AAB base/assets/fingerprint): ${runtimeVersions.aab}`);
+    validateAabMetadata(
+      built.artifacts.aab,
+      built.androidDir,
+      region.androidPackage,
+      versionCode,
+      version,
+    );
+    validateAabSignature(built.artifacts.aab, built.javaEnv);
+  }
+  const uniqueRuntimeVersions = [...new Set(Object.values(runtimeVersions))];
+  if (uniqueRuntimeVersions.length !== 1) {
+    throw new Error(`APK/AAB runtimeVersion 不一致:${JSON.stringify(runtimeVersions)}`);
+  }
+  const runtimeVersion = uniqueRuntimeVersions[0];
 
-  validateApkMetadata(apkPath, region.androidPackage, versionCode);
-
-  let finalPath = apkPath;
+  const finalArtifacts = { ...built.artifacts };
   if (typeof args.out === 'string' && args.out) {
     const outDir = resolve(String(args.out));
     if (!existsSync(outDir)) mkdirSync(outDir, { recursive: true });
-    finalPath = join(outDir, basename(apkPath));
-    copyFileSync(apkPath, finalPath);
+    for (const kind of artifactKinds) {
+      const source = built.artifacts[kind];
+      const destination = join(outDir, basename(source));
+      copyFileSync(source, destination);
+      finalArtifacts[kind] = destination;
+    }
   }
 
   console.log('');
   console.log('==================== Android 构建完成 ====================');
-  console.log(`  apk            : ${finalPath}`);
+  for (const kind of artifactKinds) {
+    console.log(`  ${kind.padEnd(14)} : ${finalArtifacts[kind]}`);
+  }
   console.log(`  version        : ${version} (${versionCode})`);
   console.log(`  runtimeVersion : ${runtimeVersion}`);
-  console.log('  注意:本脚本只构建;APK 为本机 keystore 自签,分发/发布由发布方流程另行处理。');
+  console.log('  注意:本脚本只构建;APK/AAB 使用同一 release keystore,分发/商店上传由发布方流程另行处理。');
   console.log('==========================================================');
 }
 

--- a/apps/mobile/scripts/build-android.mjs
+++ b/apps/mobile/scripts/build-android.mjs
@@ -45,6 +45,9 @@
 //   self-host-regions.json 的 <region>.androidSigning:keystorePath / keyAlias
 //   口令走环境变量(按 region 大写后缀,cn 可省略后缀回落):
 //     XDT_ANDROID_KEYSTORE_PASSWORD_<REGION> / XDT_ANDROID_KEY_PASSWORD_<REGION>
+//   Global AAB 还必须独立 pin Play Console「上传密钥证书」的公开 SHA-256(不要填
+//   「应用签名密钥证书」;不得从当前 JKS 动态计算,否则配错 JKS 时无法拦截):
+//     XDT_ANDROID_UPLOAD_CERT_SHA256_GLOBAL
 //   keystore 本体在仓库外目录,不入仓。
 // =============================================================================
 
@@ -60,8 +63,11 @@ import {
   formatBakedEnvLines,
 } from './release-lib.mjs';
 import {
+  assertAndroidUploadCertificateSha256,
   readAndroidVersionCode,
+  readAndroidCertificateSha256FromPemOutput,
   resolveAndroidArtifactKinds,
+  resolveAndroidUploadCertificateSha256,
   androidGradleTasksForArtifacts,
   resolveAndroidSigningEnv,
   patchBuildGradleSigning,
@@ -282,7 +288,7 @@ function validateAabMetadata(aabPath, androidDir, expectPackage, expectVersionCo
   log(`  ✓ AAB metadata 校验通过(package=${expectPackage}, version=${expectVersionName}, versionCode=${expectVersionCode})`);
 }
 
-function validateAabSignature(aabPath, javaEnv) {
+function validateAabSignature(aabPath, javaEnv, expectedCertificateSha256) {
   const r = spawnSync('jarsigner', ['-verify', aabPath], { encoding: 'utf8', env: javaEnv });
   if (r.error?.code === 'ENOENT') {
     throw new Error('未找到 jarsigner(JDK 17+ 应自带),无法确认 AAB 已使用 release keystore 签名');
@@ -290,7 +296,26 @@ function validateAabSignature(aabPath, javaEnv) {
   if (r.status !== 0) {
     throw new Error(`AAB jarsigner 校验失败:${r.stderr || r.stdout || `exit ${r.status}`}`);
   }
-  log('  ✓ AAB jarsigner 校验通过(已签名)');
+
+  // jarsigner 对“未签名 JAR”也可能打印警告后退出 0,因此不能把上面的零退出码当作
+  // 已签名证据。keytool 的 RFC 输出必须包含实际 signer 证书,再与独立 Play upload cert
+  // pin 比对；这样既拒绝未签名 AAB,也拒绝由错误 JKS 产生的结构合法签名。
+  const cert = spawnSync('keytool', ['-printcert', '-jarfile', aabPath, '-rfc'], {
+    encoding: 'utf8',
+    env: javaEnv,
+  });
+  if (cert.error?.code === 'ENOENT') {
+    throw new Error('未找到 keytool(JDK 17+ 应自带),无法读取 AAB 签名证书');
+  }
+  if (cert.status !== 0) {
+    throw new Error(`AAB 签名证书读取失败:${cert.stderr || cert.stdout || `exit ${cert.status}`}`);
+  }
+  const actualCertificateSha256 = readAndroidCertificateSha256FromPemOutput(
+    cert.stdout,
+    'AAB 实际签名证书',
+  );
+  assertAndroidUploadCertificateSha256(actualCertificateSha256, expectedCertificateSha256);
+  log('  ✓ AAB 签名完整且与已 pin 的 Google Play 上传证书一致');
 }
 
 async function main() {
@@ -330,6 +355,7 @@ async function main() {
   const missingBake = missingSelfHostBakeFields(region);
 
   // git 闸门只管真构建:dry-run 纯本地(不做 origin/main 远端比对,分支/离线可跑)。
+  let expectedUploadCertificateSha256 = null;
   if (args.execute) {
     if (!args.skipGitGate) assertProductionGitGate();
     else log('  warn: --skip-git-gate,跳过 main/clean/HEAD 校验(仅本地迭代用)');
@@ -341,6 +367,12 @@ async function main() {
     }
     // 签名配置预检:缺配置尽早暴露,不白跑数分钟 prebuild(取用值在 buildApk 内再解析一次)。
     resolveAndroidSigningEnv(region, process.env);
+    if (artifactKinds.includes('aab')) {
+      expectedUploadCertificateSha256 = resolveAndroidUploadCertificateSha256(
+        region.authRegion,
+        process.env,
+      );
+    }
   }
 
   // env 必须在 versionCode 决定之后构建:经 XDT_ANDROID_VERSION_CODE 注入 prebuild。
@@ -354,7 +386,10 @@ async function main() {
   const suffix = String(region.authRegion).toUpperCase();
   const aSign = region.androidSigning ?? {};
   const pwPreview = (base) => (process.env[`${base}_${suffix}`]?.trim() || (suffix === 'CN' ? process.env[base]?.trim() : '')) ? 'set' : '未设';
-  console.log(`sign: 自有 keystore 自签,path=${aSign.keystorePath || '(JSON 未填)'} alias=${aSign.keyAlias || '(JSON 未填)'} storePw(env ${suffix})=${pwPreview('XDT_ANDROID_KEYSTORE_PASSWORD')} keyPw(env ${suffix})=${pwPreview('XDT_ANDROID_KEY_PASSWORD')}`);
+  const uploadCertPreview = artifactKinds.includes('aab')
+    ? pwPreview('XDT_ANDROID_UPLOAD_CERT_SHA256')
+    : '不适用';
+  console.log(`sign: 自有 keystore 自签,path=${aSign.keystorePath || '(JSON 未填)'} alias=${aSign.keyAlias || '(JSON 未填)'} storePw(env ${suffix})=${pwPreview('XDT_ANDROID_KEYSTORE_PASSWORD')} keyPw(env ${suffix})=${pwPreview('XDT_ANDROID_KEY_PASSWORD')} uploadCertSha256(env ${suffix})=${uploadCertPreview}`);
   const gradleTasks = androidGradleTasksForArtifacts(artifactKinds);
   console.log(`steps: prebuild → patch build.gradle 签名 → gradlew ${gradleTasks.join(' ')} → 回读/核对 runtimeVersion → metadata/签名校验(仅构建,无上传/发布)`);
   if (missingBake.length) {
@@ -396,7 +431,11 @@ async function main() {
       versionCode,
       version,
     );
-    validateAabSignature(built.artifacts.aab, built.javaEnv);
+    validateAabSignature(
+      built.artifacts.aab,
+      built.javaEnv,
+      expectedUploadCertificateSha256,
+    );
   }
   const uniqueRuntimeVersions = [...new Set(Object.values(runtimeVersions))];
   if (uniqueRuntimeVersions.length !== 1) {

--- a/apps/mobile/scripts/lib/android-local.mjs
+++ b/apps/mobile/scripts/lib/android-local.mjs
@@ -6,6 +6,48 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
+export const ANDROID_ARTIFACT_KINDS = Object.freeze(['apk', 'aab']);
+
+/**
+ * 解析 Android 构建产物集合。默认按地区选择:cn/dev 只出 APK,global 同时出 APK + AAB;
+ * --artifacts 可显式覆盖,但 AAB 仅允许 global 身份,避免误把国内包当成 Play 产物。
+ * 返回顺序固定为 apk → aab,让 Gradle task / 日志 / 复制顺序保持确定性。
+ * @param {string} authRegion
+ * @param {string|boolean|undefined} rawArtifacts
+ * @returns {Array<'apk'|'aab'>}
+ */
+export function resolveAndroidArtifactKinds(authRegion, rawArtifacts) {
+  const region = String(authRegion ?? '').trim();
+  const source = rawArtifacts == null
+    ? (region === 'global' ? 'apk,aab' : 'apk')
+    : String(rawArtifacts).trim();
+  if (!source || rawArtifacts === true) {
+    throw new Error('--artifacts 必须指定 apk、aab 或 apk,aab');
+  }
+
+  const requested = source.split(',').map((item) => item.trim()).filter(Boolean);
+  if (!requested.length) throw new Error('--artifacts 不能为空');
+  const duplicates = requested.filter((kind, index) => requested.indexOf(kind) !== index);
+  if (duplicates.length) {
+    throw new Error(`--artifacts 含重复产物:${[...new Set(duplicates)].join(', ')}`);
+  }
+  const unknown = requested.filter((kind) => !ANDROID_ARTIFACT_KINDS.includes(kind));
+  if (unknown.length) {
+    throw new Error(`--artifacts 仅支持 ${ANDROID_ARTIFACT_KINDS.join(',')},收到:${unknown.join(',')}`);
+  }
+  if (region !== 'global' && requested.includes('aab')) {
+    throw new Error(`AAB 仅用于 global Google Play 产物,当前 region=${region || '(空)'}`);
+  }
+  return ANDROID_ARTIFACT_KINDS.filter((kind) => requested.includes(kind));
+}
+
+/** @param {Array<'apk'|'aab'>} kinds */
+export function androidGradleTasksForArtifacts(kinds) {
+  const selected = Array.isArray(kinds) ? kinds : [];
+  if (!selected.length) throw new Error('Android 构建至少需要一种产物');
+  return selected.map((kind) => kind === 'apk' ? 'assembleRelease' : 'bundleRelease');
+}
+
 // 签名配置零代码默认值:keystore 路径 / alias / 两个口令全部由 XDT_ANDROID_* 环境变量提供,
 // 缺任一项即抛错(fail-closed)。签名套件本体(CindyMobileCer/Android/,含 signing-info.txt)
 // 在打包机的仓库外目录,口令**绝不**写进代码,只从 env 读。

--- a/apps/mobile/scripts/lib/android-local.mjs
+++ b/apps/mobile/scripts/lib/android-local.mjs
@@ -3,6 +3,7 @@
 // ./ios-local.mjs(不重复实现);本文件只放 Android 特有的:committed versionCode 读取、
 // 生成的 android/app/build.gradle 签名 patch、keystore 签名环境解析。
 
+import { X509Certificate } from 'node:crypto';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
@@ -46,6 +47,69 @@ export function androidGradleTasksForArtifacts(kinds) {
   const selected = Array.isArray(kinds) ? kinds : [];
   if (!selected.length) throw new Error('Android 构建至少需要一种产物');
   return selected.map((kind) => kind === 'apk' ? 'assembleRelease' : 'bundleRelease');
+}
+
+export const ANDROID_UPLOAD_CERT_SHA256_ENV = 'XDT_ANDROID_UPLOAD_CERT_SHA256';
+
+/**
+ * 归一化 Play Console / keytool 常见的 SHA-256 证书指纹格式。证书指纹是公开身份 pin,
+ * 不是 keystore 口令；允许裸 64 位 hex、冒号分隔和 SHA256: 前缀。
+ * @param {unknown} raw
+ * @param {string} [source]
+ */
+export function normalizeAndroidCertificateSha256(raw, source = 'Android 证书 SHA-256') {
+  const normalized = String(raw ?? '')
+    .trim()
+    .replace(/^sha-?256\s*:/i, '')
+    .replace(/[\s:]/g, '')
+    .toLowerCase();
+  if (!/^[0-9a-f]{64}$/.test(normalized)) {
+    throw new Error(`${source} 必须是 64 位十六进制 SHA-256 指纹`);
+  }
+  return normalized;
+}
+
+/**
+ * 从独立 env 读取 Google Play 上传证书 pin。它不能从本次选择的 JKS 动态计算，否则
+ * keystorePath / alias 本身配错时会把错误证书同时当作“期望值”，失去发布身份保护。
+ * @param {string} authRegion
+ * @param {NodeJS.ProcessEnv} [baseEnv]
+ */
+export function resolveAndroidUploadCertificateSha256(authRegion, baseEnv = process.env) {
+  const suffix = String(authRegion ?? '').trim().toUpperCase();
+  const envName = `${ANDROID_UPLOAD_CERT_SHA256_ENV}_${suffix}`;
+  const raw = String(baseEnv[envName] ?? '').trim();
+  if (!raw) {
+    throw new Error(`${envName} 未设置(AAB 构建必须独立 pin Google Play「上传密钥证书」SHA-256,不要填应用签名密钥证书)`);
+  }
+  return normalizeAndroidCertificateSha256(raw, envName);
+}
+
+/**
+ * 解析 `keytool -printcert -jarfile <aab> -rfc` 输出中的首张(签名者 leaf)证书。
+ * 未签名 JAR/AAB 的 keytool 也可能退出 0,但不会输出 PEM；这里必须 fail closed。
+ * @param {unknown} rawOutput
+ * @param {string} [source]
+ */
+export function readAndroidCertificateSha256FromPemOutput(rawOutput, source = 'AAB 签名证书') {
+  const pem = String(rawOutput ?? '').match(
+    /-----BEGIN CERTIFICATE-----[\s\S]+?-----END CERTIFICATE-----/,
+  )?.[0];
+  if (!pem) throw new Error(`${source} 未找到 PEM 证书(产物可能未签名)`);
+  try {
+    return normalizeAndroidCertificateSha256(new X509Certificate(pem).fingerprint256, source);
+  } catch (err) {
+    throw new Error(`${source} 解析失败:${err?.message ?? err}`);
+  }
+}
+
+export function assertAndroidUploadCertificateSha256(actual, expected) {
+  const actualSha256 = normalizeAndroidCertificateSha256(actual, 'AAB 实际签名证书 SHA-256');
+  const expectedSha256 = normalizeAndroidCertificateSha256(expected, '预期上传证书 SHA-256');
+  if (actualSha256 !== expectedSha256) {
+    throw new Error(`AAB 上传证书不符:期望 ${expectedSha256},实际 ${actualSha256}`);
+  }
+  return actualSha256;
 }
 
 // 签名配置零代码默认值:keystore 路径 / alias / 两个口令全部由 XDT_ANDROID_* 环境变量提供,

--- a/apps/mobile/scripts/lib/embedded-runtime.mjs
+++ b/apps/mobile/scripts/lib/embedded-runtime.mjs
@@ -87,6 +87,13 @@ export function readEmbeddedRuntimeVersionFromApk(apkPath) {
   return normalizeFingerprintHash(text, { source: `APK 内嵌 assets/fingerprint(${apkPath})` });
 }
 
+// Android App Bundle:base module 的 assets 位于 base/assets/。Google Play 最终拆包时
+// 会把该文件放回 base APK 的 assets/fingerprint,与直接构建 APK 的运行时读取位置一致。
+export function readEmbeddedRuntimeVersionFromAab(aabPath) {
+  const text = unzipEntryText(aabPath, 'base/assets/fingerprint');
+  return normalizeFingerprintHash(text, { source: `AAB 内嵌 base/assets/fingerprint(${aabPath})` });
+}
+
 // iOS:读 .ipa 内 Payload/<App>.app/fingerprint —— 客户端运行时实际使用的 runtimeVersion。
 // 用出包时的本地 ipa 读取即可:NPKG 企业重签只换签名、不改 bundle 内的 fingerprint 文件。
 export function readEmbeddedRuntimeVersionFromIpa(ipaPath) {

--- a/apps/mobile/src/__tests__/androidLocal.test.ts
+++ b/apps/mobile/src/__tests__/androidLocal.test.ts
@@ -1,14 +1,20 @@
 // @ts-nocheck —— 被测对象是 .mjs 发布工具模块,vitest 跑其纯函数。
 import { describe, expect, it } from 'vitest';
+import { X509Certificate } from 'node:crypto';
 import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { rootCertificates } from 'node:tls';
 import {
   androidGradleTasksForArtifacts,
+  assertAndroidUploadCertificateSha256,
+  normalizeAndroidCertificateSha256,
   readAndroidVersionCode,
+  readAndroidCertificateSha256FromPemOutput,
   nextSequentialVersionCode,
   replaceVersionCodeInAndroidVersionJson,
   resolveAndroidArtifactKinds,
+  resolveAndroidUploadCertificateSha256,
   resolveAndroidSigningEnv,
   patchBuildGradleSigning,
   patchGradlePropertiesMemory,
@@ -43,6 +49,43 @@ describe('androidGradleTasksForArtifacts', () => {
 
   it('空产物集合 fail closed', () => {
     expect(() => androidGradleTasksForArtifacts([])).toThrow(/至少需要一种/);
+  });
+});
+
+describe('Google Play upload certificate pin', () => {
+  const SHA256 = '0123456789abcdef'.repeat(4);
+  const COLON_SHA256 = SHA256.toUpperCase().match(/.{2}/g)?.join(':') ?? '';
+
+  it('归一化 Play Console / keytool 常见指纹格式', () => {
+    expect(normalizeAndroidCertificateSha256(SHA256)).toBe(SHA256);
+    expect(normalizeAndroidCertificateSha256(`SHA-256: ${COLON_SHA256}`)).toBe(SHA256);
+    expect(() => normalizeAndroidCertificateSha256('not-a-fingerprint')).toThrow(/64 位/);
+  });
+
+  it('按 region 从独立 env 读取 pin,缺失或非法时 fail closed', () => {
+    expect(resolveAndroidUploadCertificateSha256('global', {
+      XDT_ANDROID_UPLOAD_CERT_SHA256_GLOBAL: COLON_SHA256,
+    })).toBe(SHA256);
+    expect(() => resolveAndroidUploadCertificateSha256('global', {})).toThrow(
+      /XDT_ANDROID_UPLOAD_CERT_SHA256_GLOBAL/,
+    );
+    expect(() => resolveAndroidUploadCertificateSha256('global', {
+      XDT_ANDROID_UPLOAD_CERT_SHA256_GLOBAL: 'bad',
+    })).toThrow(/64 位/);
+  });
+
+  it('从 keytool RFC 输出读取 signer 证书;无 PEM 时拒绝未签名 AAB', () => {
+    const pem = rootCertificates[0];
+    const expected = new X509Certificate(pem).fingerprint256.replaceAll(':', '').toLowerCase();
+    expect(readAndroidCertificateSha256FromPemOutput(`Signer #1\n${pem}\n`)).toBe(expected);
+    expect(() => readAndroidCertificateSha256FromPemOutput('jar 未签名')).toThrow(/未找到 PEM/);
+  });
+
+  it('实际 signer 必须与独立 upload cert pin 一致', () => {
+    expect(assertAndroidUploadCertificateSha256(SHA256, COLON_SHA256)).toBe(SHA256);
+    expect(() => assertAndroidUploadCertificateSha256(SHA256, 'f'.repeat(64))).toThrow(
+      /上传证书不符/,
+    );
   });
 });
 

--- a/apps/mobile/src/__tests__/androidLocal.test.ts
+++ b/apps/mobile/src/__tests__/androidLocal.test.ts
@@ -4,13 +4,47 @@ import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
+  androidGradleTasksForArtifacts,
   readAndroidVersionCode,
   nextSequentialVersionCode,
   replaceVersionCodeInAndroidVersionJson,
+  resolveAndroidArtifactKinds,
   resolveAndroidSigningEnv,
   patchBuildGradleSigning,
   patchGradlePropertiesMemory,
 } from '../../scripts/lib/android-local.mjs';
+
+describe('resolveAndroidArtifactKinds', () => {
+  it('按地区默认:cn/dev 只出 APK,global 同时出 APK + AAB', () => {
+    expect(resolveAndroidArtifactKinds('cn')).toEqual(['apk']);
+    expect(resolveAndroidArtifactKinds('dev')).toEqual(['apk']);
+    expect(resolveAndroidArtifactKinds('global')).toEqual(['apk', 'aab']);
+  });
+
+  it('global 支持显式选择单产物或双产物,返回顺序确定', () => {
+    expect(resolveAndroidArtifactKinds('global', 'apk')).toEqual(['apk']);
+    expect(resolveAndroidArtifactKinds('global', 'aab')).toEqual(['aab']);
+    expect(resolveAndroidArtifactKinds('global', 'aab,apk')).toEqual(['apk', 'aab']);
+  });
+
+  it('拒绝未知/重复/空产物以及非 global AAB', () => {
+    expect(() => resolveAndroidArtifactKinds('global', 'ipa')).toThrow(/仅支持/);
+    expect(() => resolveAndroidArtifactKinds('global', 'apk,apk')).toThrow(/重复/);
+    expect(() => resolveAndroidArtifactKinds('global', true)).toThrow(/必须指定/);
+    expect(() => resolveAndroidArtifactKinds('cn', 'apk,aab')).toThrow(/仅用于 global/);
+  });
+});
+
+describe('androidGradleTasksForArtifacts', () => {
+  it('把产物确定性映射到 release tasks', () => {
+    expect(androidGradleTasksForArtifacts(['apk'])).toEqual(['assembleRelease']);
+    expect(androidGradleTasksForArtifacts(['apk', 'aab'])).toEqual(['assembleRelease', 'bundleRelease']);
+  });
+
+  it('空产物集合 fail closed', () => {
+    expect(() => androidGradleTasksForArtifacts([])).toThrow(/至少需要一种/);
+  });
+});
 
 function withMobileDir(json: unknown, fn: (dir: string) => void) {
   const dir = mkdtempSync(join(tmpdir(), 'xdt-android-ver-'));

--- a/apps/mobile/src/__tests__/embeddedRuntime.test.ts
+++ b/apps/mobile/src/__tests__/embeddedRuntime.test.ts
@@ -6,6 +6,7 @@ import { join } from 'node:path';
 import {
   normalizeFingerprintHash,
   pickIpaFingerprintEntry,
+  readEmbeddedRuntimeVersionFromAab,
   readEmbeddedRuntimeVersionFromApk,
   readEmbeddedRuntimeVersionFromIpa,
 } from '../../scripts/lib/embedded-runtime.mjs';
@@ -100,6 +101,31 @@ describe('readEmbeddedRuntimeVersionFromApk', () => {
     try {
       const apk = makeZip(root, { 'classes.dex': 'x' });
       expect(() => readEmbeddedRuntimeVersionFromApk(apk)).toThrow();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('readEmbeddedRuntimeVersionFromAab', () => {
+  itWithZip('从 AAB base module 的 assets/fingerprint 读出内嵌 runtimeVersion', () => {
+    const root = mkdtempSync(join(tmpdir(), 'xdt-aab-'));
+    try {
+      const aab = makeZip(root, {
+        'base/assets/fingerprint': `${HASH}\n`,
+        'base/manifest/AndroidManifest.xml': 'protobuf',
+      });
+      expect(readEmbeddedRuntimeVersionFromAab(aab)).toBe(HASH);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  itWithZip('AAB 缺 base/assets/fingerprint 时抛错', () => {
+    const root = mkdtempSync(join(tmpdir(), 'xdt-aab-'));
+    try {
+      const aab = makeZip(root, { 'base/manifest/AndroidManifest.xml': 'protobuf' });
+      expect(() => readEmbeddedRuntimeVersionFromAab(aab)).toThrow();
     } finally {
       rmSync(root, { recursive: true, force: true });
     }


### PR DESCRIPTION
## 这次改了什么

### 摘要

扩展 Android 本地构建脚本，让国内版和开发版默认继续生成 APK，国际版默认在同一次构建中生成 APK 与可上传 Google Play 的 AAB。两个产物共用版本号、runtimeVersion 和 release keystore，并在构建完成后执行元数据、签名完整性与独立上传证书 SHA-256 pin 校验。

### 变更类型

- [ ] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [x] `docs` / `test` / `chore` 文档、测试或工程维护
- [x] 其他：`build`

### 范围

- 关联 Issue / 需求：Android 国内版/国际版构建产物规划
- 本 PR 包含：
  - `cn` / `dev` 默认生成签名 APK
  - `global` 默认生成签名 APK + AAB
  - 支持 `--artifacts apk|aab|apk,aab` 显式选择产物
  - APK/AAB runtimeVersion、包身份、版本号与签名校验
  - Global AAB 强制使用独立配置的 Google Play 上传证书 SHA-256 pin，拒绝未签名或错误证书产物
  - AAB runtimeVersion 读取和相关单元测试
- 明确不包含：Google Play Developer API、service account 配置、上传或发布逻辑
- 用户可见变化：无应用内变化；发布方运行 Global Android 构建时会额外得到 AAB
- 是否存在 breaking change：无

### UI 变化

不涉及。

- 引用的设计规范：不涉及 UI

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：通过，apps/mobile related 5

pnpm --filter mobile run --if-present typecheck
结果：通过

pnpm --filter mobile exec vitest run src/__tests__/androidLocal.test.ts src/__tests__/embeddedRuntime.test.ts
结果：通过，2 个测试文件、43 项测试

git diff --check
结果：通过

Expo runtime fingerprint 修改前后对比
结果：iOS 与 Android 均未变化
```

### 手工验证

- 在当前分支运行 Global Android 真实签名联合构建：`assembleRelease bundleRelease`
- 构建结果：APK 与 AAB 均成功生成，package 为 `com.xd.cindy`，versionName 为 `0.1.0`，versionCode 为 `13`
- APK/AAB 内嵌 runtimeVersion 完全一致
- 使用 Android `apksigner`、AAB JAR 证书和外部 Cindy JKS 公共证书交叉核验，三者 SHA-256 证书一致
- 验证缺少 `XDT_ANDROID_UPLOAD_CERT_SHA256_GLOBAL` 时在 prebuild 前终止
- 验证未签名 ZIP 即使 `jarsigner` / `keytool` 返回零退出码，仍因缺少 signer PEM 证书被拒绝
- 冒烟构建使用临时公开商店配置，产物仅用于链路验证，未上传或分发

### 未执行的验证

- 未执行 Google Play 上传或发布：不在本 PR 范围内
- 未分别执行 cn/dev 真实构建：默认产物选择和 Gradle task 映射已由单元测试覆盖

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [x] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：Android 发布构建产物

### 影响与回滚

- 影响范围：仅 Android 本地 release 构建脚本及其测试；不修改应用原生配置、依赖或运行时代码。Global 默认多执行 `bundleRelease`，因此构建耗时和产物空间会增加。Global AAB 构建环境还需独立配置 Play Console「上传密钥证书」的公开 SHA-256 到 `XDT_ANDROID_UPLOAD_CERT_SHA256_GLOBAL`；不得使用应用签名密钥证书，也不得从当前 JKS 动态计算。
- fingerprint / OTA：修改前后 iOS 与 Android runtime fingerprint 均保持不变，不触发冷更。
- 凭证：keystore 路径仍来自地区配置，密码仍仅通过环境变量传入；未提交任何 JKS、密码、service account 或授权文件。
- 回滚 / 降级方式：调用方可临时传 `--artifacts apk` 只生成 APK；完整回滚可撤销本提交，恢复原 APK-only 行为。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
