### PR TITLE
fix(desktop): 优化子 Agent token 消耗显示

### DIFF
--- a/apps/desktop/src/renderer/components/chat/AgentTaskCard.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentTaskCard.tsx
@@ -33,6 +33,7 @@ import {
 import { useSidebarPanelReachable } from '@/features/cc-agent/embeddedSessionNavigation';
 import { cn } from '@/lib/utils';
 import { formatModelShortLabel } from '@/lib/modelShortLabel';
+import { formatCompactTokens } from '@/lib/usageFormat';
 import { CODEX_SUBAGENT_EFFORTS } from '../../../shared/subagentModelSettings';
 import {
   PI_SUBAGENT_TOOL_NAME,
@@ -393,7 +394,10 @@ export function AgentTaskCard({
       { key: 'status', text: t(`chat.agentTask.status.${status}`) },
     ];
     if (typeof update?.usage?.totalTokens === 'number') {
-      parts.push({ key: 'tokens', text: t('chat.agentTask.tokens', { count: update.usage.totalTokens }) });
+      parts.push({
+        key: 'tokens',
+        text: t('chat.agentTask.tokens', { count: formatCompactTokens(update.usage.totalTokens) }),
+      });
     }
     if (typeof update?.usage?.toolUses === 'number') {
       parts.push({ key: 'toolUses', text: t('chat.agentTask.toolUses', { count: update.usage.toolUses }) });

--- a/apps/desktop/src/renderer/components/chat/__tests__/AgentTaskCardSubagentLive.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/__tests__/AgentTaskCardSubagentLive.test.tsx
@@ -83,7 +83,7 @@ describe('AgentTaskCard codex subagent live state', () => {
     expect(text).toContain('chat.agentTask.provider.codex');
     expect(text).toContain('chat.agentTask.status.running');
     // tokens / 工具调用数 / 耗时三项都由 update.usage 驱动,与 Claude 卡同一渲染路径。
-    expect(text).toContain('chat.agentTask.tokens');
+    expect(text).toContain('chat.agentTask.tokens:{"count":"143.6k"}');
     expect(text).toContain('chat.agentTask.toolUses');
     expect(text).toContain('2m 50s');
   });


### PR DESCRIPTION
## 这次改了什么

### 摘要

将子 Agent 状态卡中的原始 token 整数改为统一的紧凑格式，提升高消耗数值的可读性。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：用户反馈
- 本 PR 包含：AgentTaskCard 的 token 紧凑格式化，以及对应的渲染回归测试
- 明确不包含：共享格式规则、布局、样式和交互调整
- 用户可见变化：例如 `195271 tokens` 显示为 `195.3k tokens`，百万级显示为 `M`
- 是否存在 breaking change：无

### UI 变化

仅改变子 Agent 状态卡中的数值格式，不改变布局、颜色、字号或交互；未附截图。

- 引用的设计规范：`docs/design-rules/DESIGN.md` §11.2 Numbers / units，继续使用阿拉伯数字和半角单位；§10 Light / Dark 双模式交付门槛，本次未增加或修改样式与颜色，两种模式沿用同一现有渲染路径。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/renderer/components/chat/__tests__/AgentTaskCardSubagentLive.test.tsx src/renderer/__tests__/AgentTaskCard.test.ts
结果：通过，2 个测试文件、36 项测试全部成功

pnpm test:unit:related
结果：通过，apps/desktop 相关单测成功

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm check:dco
结果：通过，1 个提交已签名
```

### 手工验证

不涉及：由组件渲染测试确认 `143615` 显示为 `143.6k`。

### 未执行的验证

未执行 Light / Dark 实机目检：本次不修改任何视觉样式或颜色，仅替换数值格式，并由渲染测试覆盖。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop 聊天区子 Agent 状态卡的 token 数值显示
- 回滚 / 降级方式：回退本提交即可恢复原始整数显示
- 移动端冷更：不涉及；未修改 `apps/mobile`、原生配置、原生依赖或 runtime fingerprint 输入

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次无需新增文档）
- [x] 已确认测试结果或说明未执行原因